### PR TITLE
fix(install): avoid duplicate PATH entry when already present

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -290,7 +290,13 @@ add_to_path() {
   local shell; shell="$(basename "${SHELL:-bash}")"
   local rc; rc="$(detect_shell_rc)"
 
-  # Don't add if already present
+  # Check if already in current PATH
+  if [[ ":$PATH:" == *":$INSTALL_DIR:"* ]]; then
+    success "$INSTALL_DIR is already in PATH"
+    return
+  fi
+
+  # Don't add if already present in rc file
   if grep -q "$SHELL_MARKER" "$rc" 2>/dev/null; then
     success "PATH already configured in $rc"
     return


### PR DESCRIPTION
This change adds an early check against the live `PATH` variable. If `$INSTALL_DIR` is already present, the function reports success and returns immediately, avoiding unnecessary rc file modifications and duplicate entries.

In most cases `.local/bin` path is already configured by user, so we don't need to change user's rc file at all.