### PR TITLE
fix(install): move zsh completions to XDG directory

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -321,7 +321,6 @@ func ensureUnprivilegedPorts() error {
 	return nil
 }
 
-
 func downloadBinaries(w io.Writer) error {
 	arch := runtime.GOARCH
 	binDir := config.BinDir()
@@ -448,7 +447,6 @@ func (p *progressReader) Read(b []byte) (int, error) {
 	return n, err
 }
 
-
 func addShellShims() error {
 	home, _ := os.UserHomeDir()
 	binDir := config.BinDir()
@@ -508,11 +506,11 @@ fi
 		if err := appendShellRC(filepath.Join(home, ".zshrc"), binDir); err != nil {
 			return err
 		}
-		zfuncDir := filepath.Join(home, ".zfunc")
-		if err := os.MkdirAll(zfuncDir, 0755); err == nil {
-			installCompletion(lerdBin, "zsh", zfuncDir, "_lerd")
+		zshFunctionsDir := filepath.Join(home, ".local", "share", "zsh", "site-functions")
+		if err := os.MkdirAll(zshFunctionsDir, 0755); err == nil {
+			installCompletion(lerdBin, "zsh", zshFunctionsDir, "_lerd")
 			appendShellRC(filepath.Join(home, ".zshrc"), "") // ensure fpath line exists
-			ensureZshFpath(filepath.Join(home, ".zshrc"), zfuncDir)
+			ensureZshFpath(filepath.Join(home, ".zshrc"), zshFunctionsDir)
 		}
 		return nil
 	default:


### PR DESCRIPTION
This PR changes ZSH completions installation path from `~/.zfunc` to `~/.local/share/zsh/site-functions`.

There is no standard path for user-defined ZSH completions, but ~/.local/share/zsh/site-functions looks much better than ~/.zfunc. I don't understand why it's named `site-functions` instead of just `functions`, but ZSH uses this name:

- /usr/local/share/zsh/site-functions
- /home/linuxbrew/.linuxbrew/share/zsh/site-functions