### PR TITLE
ci: gate releases on CI passing and add CI badge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,40 @@ on:
       - "v*"
 
 jobs:
+  ci:
+    name: CI Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install tray build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --fix-missing libappindicator3-dev
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Build
+        run: CGO_ENABLED=1 go build -tags legacy_appindicator -o /dev/null ./cmd/lerd
+
+      - name: Test
+        run: CGO_ENABLED=1 go test -tags legacy_appindicator ./...
+
+      - name: Vet
+        run: CGO_ENABLED=1 go vet -tags legacy_appindicator ./...
+
+      - name: Format
+        run: test -z "$(gofmt -l .)"
+
   release:
     name: GoReleaser
+    needs: ci
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > The open-source Laravel Herd alternative for Linux —
 > Podman-native, rootless, with a built-in web UI.
 
+[![CI](https://github.com/geodro/lerd/actions/workflows/ci.yml/badge.svg)](https://github.com/geodro/lerd/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/geodro/lerd)](https://github.com/geodro/lerd/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Linux-lightgrey)]()


### PR DESCRIPTION
## Summary
- Adds a `ci` job to `release.yml` that runs build, test, vet, and format checks before GoReleaser is allowed to run
- The `release` job now has `needs: ci`, so a tag push on broken code will fail before publishing anything
- Adds a CI status badge to the README