### PR TITLE
fix: MCP prompt Enter key registers as default Y

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/term"
+
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
@@ -285,11 +287,16 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	if _, err := exec.LookPath("claude"); err == nil {
 		if !IsMCPGloballyRegistered() {
 			fmt.Print("\n  --> Claude Code detected. Register lerd MCP globally? [Y/n] ")
+			var reader *bufio.Reader
+			if term.IsTerminal(int(os.Stdin.Fd())) {
+				reader = bufio.NewReader(os.Stdin)
+			} else if tty, err := os.Open("/dev/tty"); err == nil {
+				defer tty.Close()
+				reader = bufio.NewReader(tty)
+			}
 			answer := ""
-			if tty, err := os.Open("/dev/tty"); err == nil {
-				reader := bufio.NewReader(tty)
+			if reader != nil {
 				line, _ := reader.ReadString('\n')
-				tty.Close()
 				answer = strings.TrimSpace(line)
 			}
 			if answer == "" || strings.EqualFold(answer, "y") || strings.EqualFold(answer, "yes") {


### PR DESCRIPTION
## Summary
- When running interactively (stdin is a terminal), read directly from `os.Stdin` — Enter works correctly as the default Y
- When piped (`curl ... | sh`), fall back to `/dev/tty` to reach the actual terminal

## Root cause
Opening `/dev/tty` as a second fd to the same terminal device while stdin is already that terminal causes line discipline issues, making Enter not register. Using `term.IsTerminal` to pick the right reader fixes both cases.