### PR TITLE
fix: remove MCP registration prompt from install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.1.2] — 2026-03-30
+
+### Fixed
+
+- **`lerd install` no longer hangs after "Adding shell PATH configuration"** — the interactive MCP registration prompt has been removed. Run `lerd mcp:enable-global` manually after install to register the MCP server.
+- **Dashboard URL in install completion message** — now shows `http://lerd.localhost` instead of the raw `http://127.0.0.1:7073` address.
+
+---
+
 ## [1.1.1] — 2026-03-30
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,15 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.1.2] — 2026-03-30
+
+### Fixed
+
+- **`lerd install` no longer hangs after "Adding shell PATH configuration"** — the interactive MCP registration prompt has been removed. Run `lerd mcp:enable-global` manually after install to register the MCP server.
+- **Dashboard URL in install completion message** — now shows `http://lerd.localhost` instead of the raw `http://127.0.0.1:7073` address.
+
+---
+
 ## [1.1.1] — 2026-03-30
 
 ### Added

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -280,7 +280,6 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	}
 	ok()
 
-
 	fmt.Println("\nLerd installation complete!")
 	fmt.Println("\n  Dashboard: \033[96mhttp://lerd.localhost\033[0m")
 	return nil


### PR DESCRIPTION
## Summary
- Removes the interactive "Register lerd MCP globally?" prompt from `lerd install`
- The prompt had unresolvable issues reading input reliably (typeahead from subprocesses, terminal state left by mkcert/sudo)
- Users can run `lerd mcp:enable-global` manually after install to register the MCP server