### PR TITLE
test: add unit tests ahead of macos-compat merge

### DIFF
--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -1,0 +1,166 @@
+package config
+
+import (
+	"testing"
+)
+
+// setConfigDir points ConfigDir() and DataDir() at a temp directory.
+func setConfigDir(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+}
+
+// ── LoadGlobal ────────────────────────────────────────────────────────────────
+
+func TestLoadGlobal_Defaults(t *testing.T) {
+	setConfigDir(t)
+	cfg, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.PHP.DefaultVersion == "" {
+		t.Error("expected a default PHP version")
+	}
+	if cfg.DNS.TLD == "" {
+		t.Error("expected a default DNS TLD")
+	}
+	if cfg.Nginx.HTTPPort == 0 {
+		t.Error("expected a non-zero HTTP port")
+	}
+	if cfg.Nginx.HTTPSPort == 0 {
+		t.Error("expected a non-zero HTTPS port")
+	}
+}
+
+func TestSaveLoadGlobal_RoundTrip(t *testing.T) {
+	setConfigDir(t)
+
+	cfg, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+
+	cfg.PHP.DefaultVersion = "8.2"
+	cfg.Node.DefaultVersion = "20"
+	cfg.DNS.TLD = "local"
+	cfg.Nginx.HTTPPort = 8080
+
+	if err := SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	got, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal after save: %v", err)
+	}
+	if got.PHP.DefaultVersion != "8.2" {
+		t.Errorf("PHP.DefaultVersion = %q, want %q", got.PHP.DefaultVersion, "8.2")
+	}
+	if got.Node.DefaultVersion != "20" {
+		t.Errorf("Node.DefaultVersion = %q, want %q", got.Node.DefaultVersion, "20")
+	}
+	if got.DNS.TLD != "local" {
+		t.Errorf("DNS.TLD = %q, want %q", got.DNS.TLD, "local")
+	}
+	if got.Nginx.HTTPPort != 8080 {
+		t.Errorf("Nginx.HTTPPort = %d, want 8080", got.Nginx.HTTPPort)
+	}
+}
+
+// ── Xdebug ────────────────────────────────────────────────────────────────────
+
+func TestXdebug_Toggle(t *testing.T) {
+	cfg := &GlobalConfig{}
+
+	if cfg.IsXdebugEnabled("8.3") {
+		t.Error("expected xdebug disabled by default")
+	}
+
+	cfg.SetXdebug("8.3", true)
+	if !cfg.IsXdebugEnabled("8.3") {
+		t.Error("expected xdebug enabled after SetXdebug(true)")
+	}
+
+	cfg.SetXdebug("8.3", false)
+	if cfg.IsXdebugEnabled("8.3") {
+		t.Error("expected xdebug disabled after SetXdebug(false)")
+	}
+}
+
+func TestXdebug_IndependentVersions(t *testing.T) {
+	cfg := &GlobalConfig{}
+	cfg.SetXdebug("8.3", true)
+	cfg.SetXdebug("8.4", false)
+
+	if !cfg.IsXdebugEnabled("8.3") {
+		t.Error("8.3 should still be enabled")
+	}
+	if cfg.IsXdebugEnabled("8.4") {
+		t.Error("8.4 should remain disabled")
+	}
+}
+
+// ── Extensions ────────────────────────────────────────────────────────────────
+
+func TestExtensions_AddRemoveGet(t *testing.T) {
+	cfg := &GlobalConfig{}
+
+	if exts := cfg.GetExtensions("8.3"); exts != nil {
+		t.Errorf("expected nil extensions, got %v", exts)
+	}
+
+	cfg.AddExtension("8.3", "redis")
+	cfg.AddExtension("8.3", "imagick")
+
+	exts := cfg.GetExtensions("8.3")
+	if len(exts) != 2 {
+		t.Fatalf("expected 2 extensions, got %d: %v", len(exts), exts)
+	}
+
+	cfg.RemoveExtension("8.3", "redis")
+	exts = cfg.GetExtensions("8.3")
+	if len(exts) != 1 || exts[0] != "imagick" {
+		t.Errorf("expected [imagick] after remove, got %v", exts)
+	}
+}
+
+func TestExtensions_AddIdempotent(t *testing.T) {
+	cfg := &GlobalConfig{}
+	cfg.AddExtension("8.3", "redis")
+	cfg.AddExtension("8.3", "redis")
+
+	if len(cfg.GetExtensions("8.3")) != 1 {
+		t.Error("duplicate add should be a no-op")
+	}
+}
+
+func TestExtensions_RemoveLastCleansMap(t *testing.T) {
+	cfg := &GlobalConfig{}
+	cfg.AddExtension("8.3", "redis")
+	cfg.RemoveExtension("8.3", "redis")
+
+	if exts := cfg.GetExtensions("8.3"); len(exts) != 0 {
+		t.Errorf("expected empty after removing last ext, got %v", exts)
+	}
+}
+
+func TestExtensions_RemoveNonExistent(t *testing.T) {
+	cfg := &GlobalConfig{}
+	// Should not panic
+	cfg.RemoveExtension("8.3", "nonexistent")
+}
+
+func TestExtensions_IndependentVersions(t *testing.T) {
+	cfg := &GlobalConfig{}
+	cfg.AddExtension("8.3", "redis")
+	cfg.AddExtension("8.4", "imagick")
+
+	if exts := cfg.GetExtensions("8.3"); len(exts) != 1 || exts[0] != "redis" {
+		t.Errorf("8.3 extensions wrong: %v", exts)
+	}
+	if exts := cfg.GetExtensions("8.4"); len(exts) != 1 || exts[0] != "imagick" {
+		t.Errorf("8.4 extensions wrong: %v", exts)
+	}
+}

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ── XDG overrides ─────────────────────────────────────────────────────────────
+
+func TestConfigDir_UsesXDGConfigHome(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	got := ConfigDir()
+	want := filepath.Join(tmp, "lerd")
+	if got != want {
+		t.Errorf("ConfigDir() = %q, want %q", got, want)
+	}
+}
+
+func TestDataDir_UsesXDGDataHome(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	got := DataDir()
+	want := filepath.Join(tmp, "lerd")
+	if got != want {
+		t.Errorf("DataDir() = %q, want %q", got, want)
+	}
+}
+
+// ── Path suffix correctness ───────────────────────────────────────────────────
+
+func TestPathFunctions_ContainExpectedSuffixes(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cases := []struct {
+		name   string
+		got    string
+		suffix string
+	}{
+		{"BinDir", BinDir(), "lerd/bin"},
+		{"NginxDir", NginxDir(), "lerd/nginx"},
+		{"NginxConfD", NginxConfD(), filepath.Join("nginx", "conf.d")},
+		{"CertsDir", CertsDir(), "lerd/certs"},
+		{"DnsmasqDir", DnsmasqDir(), "lerd/dnsmasq"},
+		{"SitesFile", SitesFile(), "sites.yaml"},
+		{"GlobalConfigFile", GlobalConfigFile(), "config.yaml"},
+		{"QuadletDir", QuadletDir(), filepath.Join("containers", "systemd")},
+		{"SystemdUserDir", SystemdUserDir(), filepath.Join("systemd", "user")},
+		{"CustomServicesDir", CustomServicesDir(), filepath.Join("lerd", "services")},
+		{"FrameworksDir", FrameworksDir(), filepath.Join("lerd", "frameworks")},
+		{"UpdateCheckFile", UpdateCheckFile(), "update-check.json"},
+		{"PausedDir", PausedDir(), "lerd/paused"},
+	}
+
+	for _, c := range cases {
+		if !strings.HasSuffix(c.got, c.suffix) {
+			t.Errorf("%s() = %q, expected suffix %q", c.name, c.got, c.suffix)
+		}
+	}
+}
+
+func TestPHPConfFile_ContainsVersionAndXdebug(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	got := PHPConfFile("8.3")
+	if !strings.Contains(got, "8.3") {
+		t.Errorf("PHPConfFile(8.3) = %q, expected to contain version", got)
+	}
+	if !strings.HasSuffix(got, "99-xdebug.ini") {
+		t.Errorf("PHPConfFile(8.3) = %q, expected suffix 99-xdebug.ini", got)
+	}
+}
+
+func TestPHPUserIniFile_ContainsVersion(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	got := PHPUserIniFile("8.4")
+	if !strings.Contains(got, "8.4") {
+		t.Errorf("PHPUserIniFile(8.4) = %q, expected to contain version", got)
+	}
+	if !strings.HasSuffix(got, "98-user.ini") {
+		t.Errorf("PHPUserIniFile(8.4) = %q, expected suffix 98-user.ini", got)
+	}
+}
+
+func TestDataSubDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	got := DataSubDir("mysql")
+	if !strings.Contains(got, "mysql") {
+		t.Errorf("DataSubDir(mysql) = %q, expected to contain mysql", got)
+	}
+}

--- a/internal/config/site_test.go
+++ b/internal/config/site_test.go
@@ -1,0 +1,241 @@
+package config
+
+import (
+	"testing"
+)
+
+// setDataDir points DataDir() (and SitesFile()) at a temp directory.
+func setDataDir(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+}
+
+// ── AddSite / LoadSites ───────────────────────────────────────────────────────
+
+func TestAddSite_Basic(t *testing.T) {
+	setDataDir(t)
+
+	site := Site{Name: "myapp", Domain: "myapp.test", Path: "/srv/myapp"}
+	if err := AddSite(site); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	reg, err := LoadSites()
+	if err != nil {
+		t.Fatalf("LoadSites: %v", err)
+	}
+	if len(reg.Sites) != 1 {
+		t.Fatalf("expected 1 site, got %d", len(reg.Sites))
+	}
+	if reg.Sites[0].Name != "myapp" {
+		t.Errorf("Name = %q, want myapp", reg.Sites[0].Name)
+	}
+}
+
+func TestAddSite_UpdateExisting(t *testing.T) {
+	setDataDir(t)
+
+	if err := AddSite(Site{Name: "myapp", Domain: "myapp.test", Path: "/old"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddSite(Site{Name: "myapp", Domain: "myapp.test", Path: "/new"}); err != nil {
+		t.Fatal(err)
+	}
+
+	reg, err := LoadSites()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reg.Sites) != 1 {
+		t.Fatalf("expected 1 site after update, got %d", len(reg.Sites))
+	}
+	if reg.Sites[0].Path != "/new" {
+		t.Errorf("Path = %q, want /new", reg.Sites[0].Path)
+	}
+}
+
+// ── RemoveSite ────────────────────────────────────────────────────────────────
+
+func TestRemoveSite(t *testing.T) {
+	setDataDir(t)
+
+	AddSite(Site{Name: "alpha", Domain: "alpha.test", Path: "/alpha"})
+	AddSite(Site{Name: "beta", Domain: "beta.test", Path: "/beta"})
+
+	if err := RemoveSite("alpha"); err != nil {
+		t.Fatalf("RemoveSite: %v", err)
+	}
+
+	reg, err := LoadSites()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reg.Sites) != 1 || reg.Sites[0].Name != "beta" {
+		t.Errorf("expected only beta after remove, got %v", reg.Sites)
+	}
+}
+
+func TestRemoveSite_NotFound_NoError(t *testing.T) {
+	setDataDir(t)
+
+	if err := RemoveSite("ghost"); err != nil {
+		t.Errorf("expected no error removing non-existent site, got: %v", err)
+	}
+}
+
+// ── FindSite ─────────────────────────────────────────────────────────────────
+
+func TestFindSite_ByName(t *testing.T) {
+	setDataDir(t)
+	AddSite(Site{Name: "myapp", Domain: "myapp.test", Path: "/srv/myapp"})
+
+	s, err := FindSite("myapp")
+	if err != nil {
+		t.Fatalf("FindSite: %v", err)
+	}
+	if s.Domain != "myapp.test" {
+		t.Errorf("Domain = %q, want myapp.test", s.Domain)
+	}
+}
+
+func TestFindSite_NotFound(t *testing.T) {
+	setDataDir(t)
+
+	_, err := FindSite("ghost")
+	if err == nil {
+		t.Error("expected error for missing site")
+	}
+}
+
+func TestFindSiteByPath(t *testing.T) {
+	setDataDir(t)
+	AddSite(Site{Name: "myapp", Domain: "myapp.test", Path: "/srv/myapp"})
+
+	s, err := FindSiteByPath("/srv/myapp")
+	if err != nil {
+		t.Fatalf("FindSiteByPath: %v", err)
+	}
+	if s.Name != "myapp" {
+		t.Errorf("Name = %q, want myapp", s.Name)
+	}
+}
+
+func TestFindSiteByPath_NotFound(t *testing.T) {
+	setDataDir(t)
+
+	_, err := FindSiteByPath("/nonexistent")
+	if err == nil {
+		t.Error("expected error for missing path")
+	}
+}
+
+func TestFindSiteByDomain(t *testing.T) {
+	setDataDir(t)
+	AddSite(Site{Name: "myapp", Domain: "myapp.test", Path: "/srv/myapp"})
+
+	s, err := FindSiteByDomain("myapp.test")
+	if err != nil {
+		t.Fatalf("FindSiteByDomain: %v", err)
+	}
+	if s.Path != "/srv/myapp" {
+		t.Errorf("Path = %q, want /srv/myapp", s.Path)
+	}
+}
+
+func TestFindSiteByDomain_NotFound(t *testing.T) {
+	setDataDir(t)
+
+	_, err := FindSiteByDomain("ghost.test")
+	if err == nil {
+		t.Error("expected error for missing domain")
+	}
+}
+
+// ── IgnoreSite ────────────────────────────────────────────────────────────────
+
+func TestIgnoreSite(t *testing.T) {
+	setDataDir(t)
+	AddSite(Site{Name: "myapp", Domain: "myapp.test", Path: "/srv/myapp"})
+
+	if err := IgnoreSite("myapp"); err != nil {
+		t.Fatalf("IgnoreSite: %v", err)
+	}
+
+	s, err := FindSite("myapp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.Ignored {
+		t.Error("expected site to be marked Ignored")
+	}
+}
+
+func TestIgnoreSite_NotFound(t *testing.T) {
+	setDataDir(t)
+
+	err := IgnoreSite("ghost")
+	if err == nil {
+		t.Error("expected error when ignoring non-existent site")
+	}
+}
+
+// ── SaveSites / LoadSites round-trip ─────────────────────────────────────────
+
+func TestSaveLoad_RoundTrip(t *testing.T) {
+	setDataDir(t)
+
+	reg := &SiteRegistry{
+		Sites: []Site{
+			{Name: "alpha", Domain: "alpha.test", Path: "/alpha", PHPVersion: "8.3", Secured: true},
+			{Name: "beta", Domain: "beta.test", Path: "/beta", PHPVersion: "8.4"},
+		},
+	}
+	if err := SaveSites(reg); err != nil {
+		t.Fatalf("SaveSites: %v", err)
+	}
+
+	got, err := LoadSites()
+	if err != nil {
+		t.Fatalf("LoadSites: %v", err)
+	}
+	if len(got.Sites) != 2 {
+		t.Fatalf("expected 2 sites, got %d", len(got.Sites))
+	}
+	if got.Sites[0].PHPVersion != "8.3" || !got.Sites[0].Secured {
+		t.Errorf("alpha not persisted correctly: %+v", got.Sites[0])
+	}
+	if got.Sites[1].PHPVersion != "8.4" {
+		t.Errorf("beta not persisted correctly: %+v", got.Sites[1])
+	}
+}
+
+func TestLoadSites_EmptyWhenMissing(t *testing.T) {
+	setDataDir(t)
+
+	reg, err := LoadSites()
+	if err != nil {
+		t.Fatalf("LoadSites on missing file: %v", err)
+	}
+	if len(reg.Sites) != 0 {
+		t.Errorf("expected empty registry, got %v", reg.Sites)
+	}
+}
+
+// ── IsLaravel ─────────────────────────────────────────────────────────────────
+
+func TestIsLaravel(t *testing.T) {
+	cases := []struct {
+		framework string
+		want      bool
+	}{
+		{"laravel", true},
+		{"symfony", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		s := Site{Framework: c.framework}
+		if got := s.IsLaravel(); got != c.want {
+			t.Errorf("IsLaravel() for framework=%q = %v, want %v", c.framework, got, c.want)
+		}
+	}
+}

--- a/internal/envfile/phpconst_test.go
+++ b/internal/envfile/phpconst_test.go
@@ -1,0 +1,169 @@
+package envfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writePhpConfig(t *testing.T, content string) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "wp-config.php")
+	if err := os.WriteFile(f, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+// ── ReadPhpConst ──────────────────────────────────────────────────────────────
+
+func TestReadPhpConst_SingleQuotes(t *testing.T) {
+	f := writePhpConfig(t, `<?php
+define('DB_NAME', 'mydb');
+define('DB_USER', 'root');
+`)
+	got, err := ReadPhpConst(f)
+	if err != nil {
+		t.Fatalf("ReadPhpConst: %v", err)
+	}
+	if got["DB_NAME"] != "mydb" {
+		t.Errorf("DB_NAME = %q, want %q", got["DB_NAME"], "mydb")
+	}
+	if got["DB_USER"] != "root" {
+		t.Errorf("DB_USER = %q, want %q", got["DB_USER"], "root")
+	}
+}
+
+func TestReadPhpConst_DoubleQuotes(t *testing.T) {
+	f := writePhpConfig(t, `<?php
+define("DB_HOST", "localhost");
+define("DB_PASSWORD", "secret");
+`)
+	got, err := ReadPhpConst(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["DB_HOST"] != "localhost" {
+		t.Errorf("DB_HOST = %q, want localhost", got["DB_HOST"])
+	}
+	if got["DB_PASSWORD"] != "secret" {
+		t.Errorf("DB_PASSWORD = %q, want secret", got["DB_PASSWORD"])
+	}
+}
+
+func TestReadPhpConst_MixedQuotes(t *testing.T) {
+	f := writePhpConfig(t, `<?php
+define('DB_NAME', 'mydb');
+define("DB_HOST", "localhost");
+`)
+	got, err := ReadPhpConst(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["DB_NAME"] != "mydb" || got["DB_HOST"] != "localhost" {
+		t.Errorf("mixed quotes not parsed correctly: %v", got)
+	}
+}
+
+func TestReadPhpConst_WithWhitespace(t *testing.T) {
+	f := writePhpConfig(t, `<?php
+define( 'DB_NAME' , 'mydb' );
+`)
+	got, err := ReadPhpConst(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["DB_NAME"] != "mydb" {
+		t.Errorf("DB_NAME = %q, want mydb (whitespace inside define should be ok)", got["DB_NAME"])
+	}
+}
+
+func TestReadPhpConst_MissingKey(t *testing.T) {
+	f := writePhpConfig(t, `<?php
+define('DB_NAME', 'mydb');
+`)
+	got, err := ReadPhpConst(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val, ok := got["DB_HOST"]; ok {
+		t.Errorf("expected DB_HOST to be absent, got %q", val)
+	}
+}
+
+func TestReadPhpConst_MissingFile(t *testing.T) {
+	_, err := ReadPhpConst("/nonexistent/wp-config.php")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestReadPhpConst_EmptyFile(t *testing.T) {
+	f := writePhpConfig(t, "")
+	got, err := ReadPhpConst(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty map for empty file, got %v", got)
+	}
+}
+
+// ── ApplyPhpConstUpdates ──────────────────────────────────────────────────────
+
+func TestApplyPhpConstUpdates_UpdatesExisting(t *testing.T) {
+	f := writePhpConfig(t, `<?php
+define('DB_NAME', 'olddb');
+define('DB_HOST', 'localhost');
+`)
+	if err := ApplyPhpConstUpdates(f, map[string]string{"DB_NAME": "newdb"}); err != nil {
+		t.Fatalf("ApplyPhpConstUpdates: %v", err)
+	}
+	got, _ := ReadPhpConst(f)
+	if got["DB_NAME"] != "newdb" {
+		t.Errorf("DB_NAME = %q, want newdb", got["DB_NAME"])
+	}
+	if got["DB_HOST"] != "localhost" {
+		t.Error("DB_HOST should remain unchanged")
+	}
+}
+
+func TestApplyPhpConstUpdates_AppendsBeforeThatsAll(t *testing.T) {
+	content := `<?php
+define('DB_NAME', 'mydb');
+
+/* That's all, stop editing! Happy publishing. */
+`
+	f := writePhpConfig(t, content)
+	if err := ApplyPhpConstUpdates(f, map[string]string{"NEW_KEY": "newval"}); err != nil {
+		t.Fatalf("ApplyPhpConstUpdates: %v", err)
+	}
+
+	data, _ := os.ReadFile(f)
+	s := string(data)
+	// New key must appear before "That's all"
+	newKeyPos := indexOf(s, "NEW_KEY")
+	thatsAllPos := indexOf(s, "/* That's all")
+	if newKeyPos == -1 {
+		t.Error("NEW_KEY not found in file")
+	} else if thatsAllPos != -1 && newKeyPos > thatsAllPos {
+		t.Error("NEW_KEY should be inserted before \"/* That's all\"")
+	}
+}
+
+func TestApplyPhpConstUpdates_MissingFile(t *testing.T) {
+	err := ApplyPhpConstUpdates("/nonexistent/wp-config.php", map[string]string{"K": "v"})
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+// indexOf returns the byte index of substr in s, or -1.
+func indexOf(s, substr string) int {
+	for i := range s {
+		if i+len(substr) <= len(s) && s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/php/detector_test.go
+++ b/internal/php/detector_test.go
@@ -1,0 +1,190 @@
+package php
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFile is a test helper that writes content to filename inside dir.
+func writeFile(t *testing.T, dir, filename, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ── parseComposerPHP ──────────────────────────────────────────────────────────
+
+func TestParseComposerPHP(t *testing.T) {
+	cases := []struct{ constraint, want string }{
+		{"^8.1", "8.1"},
+		{"^8.2", "8.2"},
+		{">=8.1", "8.1"},
+		{">=8.3", "8.3"},
+		{"~8.3.0", "8.3"},
+		{"^8.4.0", "8.4"},
+		{"8.2.*", "8.2"},
+		{"*", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := parseComposerPHP(c.constraint)
+		if got != c.want {
+			t.Errorf("parseComposerPHP(%q) = %q, want %q", c.constraint, got, c.want)
+		}
+	}
+}
+
+// ── DetectVersion ─────────────────────────────────────────────────────────────
+
+func TestDetectVersion_DotLerdYaml(t *testing.T) {
+	dir := t.TempDir()
+	// All lower-priority files present too — .lerd.yaml must win
+	writeFile(t, dir, ".lerd.yaml", "php_version: \"8.1\"\n")
+	writeFile(t, dir, ".php-version", "8.2")
+	writeFile(t, dir, "composer.json", `{"require":{"php":"^8.3"}}`)
+
+	// Point XDG dirs away from real config
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	got, err := DetectVersion(dir)
+	if err != nil {
+		t.Fatalf("DetectVersion: %v", err)
+	}
+	if got != "8.1" {
+		t.Errorf("expected 8.1 from .lerd.yaml, got %q", got)
+	}
+}
+
+func TestDetectVersion_DotPhpVersion(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".php-version", "8.2\n")
+	writeFile(t, dir, "composer.json", `{"require":{"php":"^8.3"}}`)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	got, err := DetectVersion(dir)
+	if err != nil {
+		t.Fatalf("DetectVersion: %v", err)
+	}
+	if got != "8.2" {
+		t.Errorf("expected 8.2 from .php-version, got %q", got)
+	}
+}
+
+func TestDetectVersion_ComposerJson(t *testing.T) {
+	dir := t.TempDir()
+	composer := map[string]interface{}{
+		"require": map[string]string{
+			"php":           "^8.3",
+			"laravel/frame": "^11.0",
+		},
+	}
+	data, _ := json.Marshal(composer)
+	os.WriteFile(filepath.Join(dir, "composer.json"), data, 0644)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	got, err := DetectVersion(dir)
+	if err != nil {
+		t.Fatalf("DetectVersion: %v", err)
+	}
+	if got != "8.3" {
+		t.Errorf("expected 8.3 from composer.json, got %q", got)
+	}
+}
+
+func TestDetectVersion_GlobalFallback(t *testing.T) {
+	dir := t.TempDir() // no version files
+
+	cfgDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	// Write a global config with a known PHP version
+	cfgContent := "php:\n  default_version: \"8.4\"\n"
+	lerdCfgDir := filepath.Join(cfgDir, "lerd")
+	os.MkdirAll(lerdCfgDir, 0755)
+	os.WriteFile(filepath.Join(lerdCfgDir, "config.yaml"), []byte(cfgContent), 0644)
+
+	got, err := DetectVersion(dir)
+	if err != nil {
+		t.Fatalf("DetectVersion: %v", err)
+	}
+	if got != "8.4" {
+		t.Errorf("expected 8.4 from global config, got %q", got)
+	}
+}
+
+func TestDetectVersion_NoFiles_ReturnsDefault(t *testing.T) {
+	dir := t.TempDir()
+
+	// Empty config dir — LoadGlobal returns built-in defaults
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	got, err := DetectVersion(dir)
+	if err != nil {
+		t.Fatalf("DetectVersion: %v", err)
+	}
+	if got == "" {
+		t.Error("expected a non-empty default PHP version")
+	}
+}
+
+// ── DetectExtensions ──────────────────────────────────────────────────────────
+
+func TestDetectExtensions(t *testing.T) {
+	dir := t.TempDir()
+	composer := map[string]interface{}{
+		"require": map[string]string{
+			"php":          "^8.2",
+			"ext-redis":    "*",
+			"ext-imagick":  "*",
+			"ext-pdo":      "*",
+			"laravel/some": "^11",
+		},
+	}
+	data, _ := json.Marshal(composer)
+	os.WriteFile(filepath.Join(dir, "composer.json"), data, 0644)
+
+	exts := DetectExtensions(dir)
+	extSet := make(map[string]bool)
+	for _, e := range exts {
+		extSet[e] = true
+	}
+
+	for _, want := range []string{"redis", "imagick", "pdo"} {
+		if !extSet[want] {
+			t.Errorf("expected extension %q in %v", want, exts)
+		}
+	}
+	// Non-ext- keys must not appear
+	for _, notwant := range []string{"php", "laravel/some"} {
+		if extSet[notwant] {
+			t.Errorf("unexpected entry %q in extensions %v", notwant, exts)
+		}
+	}
+}
+
+func TestDetectExtensions_NoComposerJson(t *testing.T) {
+	dir := t.TempDir()
+	exts := DetectExtensions(dir)
+	if exts != nil {
+		t.Errorf("expected nil when no composer.json, got %v", exts)
+	}
+}
+
+func TestDetectExtensions_NoExtRequires(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "composer.json", `{"require":{"php":"^8.2","laravel/framework":"^11"}}`)
+	exts := DetectExtensions(dir)
+	if len(exts) != 0 {
+		t.Errorf("expected no extensions, got %v", exts)
+	}
+}

--- a/pkg/distro/detect.go
+++ b/pkg/distro/detect.go
@@ -15,7 +15,11 @@ type Distro struct {
 
 // Detect parses /etc/os-release and returns the distro information.
 func Detect() (*Distro, error) {
-	f, err := os.Open("/etc/os-release")
+	return detectFromPath("/etc/os-release")
+}
+
+func detectFromPath(path string) (*Distro, error) {
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/distro/detect_test.go
+++ b/pkg/distro/detect_test.go
@@ -1,0 +1,186 @@
+package distro
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeOsRelease(t *testing.T, content string) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "os-release")
+	if err := os.WriteFile(f, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+// ── detectFromPath ────────────────────────────────────────────────────────────
+
+func TestDetect_Debian(t *testing.T) {
+	f := writeOsRelease(t, `ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 24.04 LTS"
+`)
+	d, err := detectFromPath(f)
+	if err != nil {
+		t.Fatalf("detectFromPath: %v", err)
+	}
+	if !d.IsDebian() {
+		t.Errorf("expected IsDebian() for ubuntu, got ID=%q IDLike=%q", d.ID, d.IDLike)
+	}
+	if d.IsArch() {
+		t.Error("ubuntu should not be Arch")
+	}
+	if d.IsFedora() {
+		t.Error("ubuntu should not be Fedora")
+	}
+}
+
+func TestDetect_DebianByIDLike(t *testing.T) {
+	f := writeOsRelease(t, `ID=linuxmint
+ID_LIKE=ubuntu debian
+PRETTY_NAME="Linux Mint 22"
+`)
+	d, err := detectFromPath(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.IsDebian() {
+		t.Errorf("Linux Mint should be Debian-like, got ID=%q IDLike=%q", d.ID, d.IDLike)
+	}
+}
+
+func TestDetect_Fedora(t *testing.T) {
+	f := writeOsRelease(t, `ID=fedora
+PRETTY_NAME="Fedora Linux 40"
+`)
+	d, err := detectFromPath(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.IsFedora() {
+		t.Errorf("expected IsFedora() for ID=fedora")
+	}
+	if d.IsDebian() || d.IsArch() {
+		t.Error("fedora should not be Debian or Arch")
+	}
+}
+
+func TestDetect_FedoraByIDLike(t *testing.T) {
+	f := writeOsRelease(t, `ID=centos
+ID_LIKE="rhel fedora"
+PRETTY_NAME="CentOS Stream 9"
+`)
+	d, err := detectFromPath(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.IsFedora() {
+		t.Errorf("CentOS should be Fedora-like")
+	}
+}
+
+func TestDetect_Arch(t *testing.T) {
+	f := writeOsRelease(t, `ID=arch
+PRETTY_NAME="Arch Linux"
+`)
+	d, err := detectFromPath(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.IsArch() {
+		t.Errorf("expected IsArch() for ID=arch")
+	}
+	if d.IsDebian() || d.IsFedora() {
+		t.Error("arch should not be Debian or Fedora")
+	}
+}
+
+func TestDetect_ArchByIDLike(t *testing.T) {
+	f := writeOsRelease(t, `ID=endeavouros
+ID_LIKE=arch
+PRETTY_NAME="EndeavourOS"
+`)
+	d, err := detectFromPath(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.IsArch() {
+		t.Errorf("EndeavourOS should be Arch-like")
+	}
+}
+
+func TestDetect_Unknown(t *testing.T) {
+	f := writeOsRelease(t, `ID=slackware
+PRETTY_NAME="Slackware 15.0"
+`)
+	d, err := detectFromPath(f)
+	if err != nil {
+		t.Fatalf("detectFromPath: %v", err)
+	}
+	if d == nil {
+		t.Fatal("expected non-nil Distro for unknown distro")
+	}
+	if d.IsArch() || d.IsDebian() || d.IsFedora() {
+		t.Error("slackware should not match any known family")
+	}
+	if d.PrettyName != "Slackware 15.0" {
+		t.Errorf("PrettyName = %q, want %q", d.PrettyName, "Slackware 15.0")
+	}
+}
+
+func TestDetect_QuotedValues(t *testing.T) {
+	f := writeOsRelease(t, `ID="ubuntu"
+PRETTY_NAME="Ubuntu 22.04 LTS"
+`)
+	d, err := detectFromPath(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.ID != "ubuntu" {
+		t.Errorf("expected quotes stripped, ID = %q", d.ID)
+	}
+}
+
+func TestDetect_CommentsSkipped(t *testing.T) {
+	f := writeOsRelease(t, `# This is a comment
+ID=arch
+# Another comment
+PRETTY_NAME="Arch Linux"
+`)
+	d, err := detectFromPath(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.ID != "arch" {
+		t.Errorf("ID = %q, expected arch (comments should be skipped)", d.ID)
+	}
+}
+
+func TestDetect_MissingFile(t *testing.T) {
+	_, err := detectFromPath("/nonexistent/os-release")
+	if err == nil {
+		t.Error("expected error for missing os-release file")
+	}
+}
+
+// ── IsDebian edge cases ───────────────────────────────────────────────────────
+
+func TestIsDebian_ByID(t *testing.T) {
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{"debian", true},
+		{"ubuntu", true},
+		{"linuxmint", false},
+		{"arch", false},
+	}
+	for _, c := range cases {
+		d := &Distro{ID: c.id}
+		if got := d.IsDebian(); got != c.want {
+			t.Errorf("IsDebian() for ID=%q = %v, want %v", c.id, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add unit tests for `internal/config` (GlobalConfig, SiteRegistry, all path helpers)
- Add unit tests for `internal/php` (DetectVersion priority chain, DetectExtensions, parseComposerPHP)
- Add unit tests for `pkg/distro` (os-release parsing for Debian/Fedora/Arch families)
- Add unit tests for `internal/envfile` (ReadPhpConst, ApplyPhpConstUpdates)
- Extract `detectFromPath()` in `pkg/distro` to make Detect() testable without relying on the live `/etc/os-release`

## Why

The `macos-compat` branch is being merged soon. These tests protect the Linux side by catching regressions in core packages before and after the merge.