### PR TITLE
Fix webp support for gd and imagick

### DIFF
--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -11,6 +11,7 @@ RUN apk update && apk add --no-cache \
         libpng-dev \
         libjpeg-turbo-dev \
         freetype-dev \
+        libwebp-dev \
         icu-dev \
         oniguruma-dev \
         libxml2-dev \
@@ -23,7 +24,7 @@ RUN apk update && apk add --no-cache \
         openldap-dev \
         sqlite-dev \
         libxslt-dev \
-    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j$(nproc) \
         curl \
         pdo_mysql \


### PR DESCRIPTION
The below adds support for saving images in WebP using either the `gd` or `imagick` libraries.

For example, the following errors would previously arise when asking InterventionImage to save as WebP:

> Error
> vendor/intervention/image/src/Drivers/Gd/Encoders/WebpEncoder.php:24
> 
> Call to undefined function Intervention\Image\Drivers\Gd\Encoders\imagewebp() 

> ImagickException
> vendor/intervention/image/src/Drivers/Imagick/Encoders/WebpEncoder.php:35
> 
> Unable to set format 

This PR solves this by adding the necessary `libwebp-dev` Alpine package, and adding the `--with-webp` flag when compiling the `gd` extension for PHP.

This also solves the issue for `imagick` because the package already supports the WebP, it just needs `libwebp-dev` to be present at build time.

I've confirmed these changes are working with `lerd php:rebuild` after my changes

This might be overly detailed for a simple change but I wanted to be thorough! Thank you for the lerd project, this is by far the best and easiest solution for local dev on Linux that I've come across and it has quickly become my daily driver :)