### PR TITLE
fix(cli): fall back to artisan for laravel when console field is unset

### DIFF
--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -100,6 +100,9 @@ func getConsoleCommand(cwd string) (string, error) {
 	}
 
 	if frameworkConfig.Console == "" {
+		if framework == "laravel" {
+			return "artisan", nil
+		}
 		return "", fmt.Errorf(
 			"no console command defined for framework %q — add 'console' field to %s/%s.yaml",
 			frameworkConfig.Name,


### PR DESCRIPTION
If a user has a custom Laravel framework YAML that doesn't include a `console` field, `lerd console` now falls back to `artisan` instead of returning an error. All other frameworks still require the field to be set explicitly.