### PR TITLE
feat(framework): don't install dependencies while creating new project

### DIFF
--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -30,7 +30,7 @@ lerd new myapp -- --no-interaction      # pass extra flags to the scaffold comma
 
 For Laravel, this runs:
 ```bash
-composer create-project laravel/laravel /abs/path/to/myapp
+composer create-project --no-install --no-plugins --no-scripts laravel/laravel /abs/path/to/myapp
 ```
 
 After creation, register the site and bootstrap it:

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -508,7 +508,7 @@ Arguments:
 - ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
 
 ### ` + bt + `project_new` + bt + `
-Scaffold a new PHP project using a framework's create command. For Laravel, runs ` + bt + `composer create-project laravel/laravel <path>` + bt + `. Other frameworks must have a ` + bt + `create` + bt + ` field in their YAML definition.
+Scaffold a new PHP project using a framework's create command. For Laravel, runs ` + bt + `composer create-project --no-install --no-plugins --no-scripts laravel/laravel <path>` + bt + `. Other frameworks must have a ` + bt + `create` + bt + ` field in their YAML definition.
 
 Arguments:
 - ` + bt + `path` + bt + ` (required): absolute path for the new project directory (e.g. ` + bt + `/home/user/code/myapp` + bt + `)

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -26,7 +26,7 @@ func NewNewCmd() *cobra.Command {
   lerd new myapp -- --no-interaction      # pass extra args to the scaffold command
 
 For Laravel this runs:
-  composer create-project laravel/laravel <target> [extra args]
+  composer create-project --no-install --no-plugins --no-scripts laravel/laravel <target> [extra args]
 
 Other frameworks must define a 'create' field in their YAML definition:
   create: composer create-project myvendor/myframework

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -23,7 +23,7 @@ type Framework struct {
 	// Example: "artisan", "bin/console"
 	Console string `yaml:"console,omitempty"`
 	// Create is the scaffold command used by "lerd new". The target directory is appended automatically.
-	// Example: "composer create-project laravel/laravel"
+	// Example: "composer create-project --no-install --no-plugins --no-scripts laravel/laravel"
 	Create string `yaml:"create,omitempty"`
 }
 
@@ -114,7 +114,7 @@ var laravelFramework = &Framework{
 	Name:      "laravel",
 	Label:     "Laravel",
 	PublicDir: "public",
-	Create:    "composer create-project laravel/laravel",
+	Create:    "composer create-project --no-install --no-plugins --no-scripts laravel/laravel",
 	Detect: []FrameworkRule{
 		{File: "artisan"},
 		{Composer: "laravel/framework"},

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -912,7 +912,7 @@ func toolList() []mcpTool {
 		},
 		mcpTool{
 			Name:        "project_new",
-			Description: "Scaffold a new PHP project using a framework's create command. For Laravel this runs `composer create-project laravel/laravel <path>`. Other frameworks must have a `create` field in their YAML definition. After creation, use site_link to register the site.",
+			Description: "Scaffold a new PHP project using a framework's create command. For Laravel this runs `composer create-project --no-install --no-plugins --no-scripts laravel/laravel <path>`. Other frameworks must have a `create` field in their YAML definition. After creation, use site_link to register the site.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{


### PR DESCRIPTION
This PR adds `--no-install --no-plugins --no-scripts` flags to the `composer create-project` command used during Laravel project scaffolding. This skips dependency installation and plugin/script execution at creation time. All dependencies should be installed in the next step, `lerd setup`, after selecting the PHP version.
