### PR TITLE
feat(ui,tray,horizon): show Horizon in services panel, stop queue on horizon start, fix tray worker filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Horizon appears in the Services panel** — when Laravel Horizon is running for a site it now shows up as its own entry in the Services panel (grouped under "Horizon"), with a stop button and a subtitle showing the site domain. Previously Horizon was only visible in the site detail view.
+- **Starting Horizon stops the queue worker** — `horizon:start` (CLI, UI, MCP) now automatically stops any running queue worker for the same site before starting Horizon, since the two must not run simultaneously.
+
+### Fixed
+
+- **Tray no longer shows per-site workers** — Reverb, Horizon, queue workers, schedule workers, Stripe listeners, and custom framework workers are filtered out of the tray menu. Only real infrastructure services (MySQL, Redis, Mailpit, etc.) are listed there.
+
+---
+
 ## [1.2.2] — 2026-03-31
 
 ### Added

--- a/internal/cli/horizon.go
+++ b/internal/cli/horizon.go
@@ -78,7 +78,14 @@ func newHorizonStopCmd(use string) *cobra.Command {
 }
 
 // HorizonStartForSite starts Laravel Horizon for the named site as a systemd service.
+// If a queue worker is running for the same site it is stopped first, since Horizon
+// manages queues and the two must not run simultaneously.
 func HorizonStartForSite(siteName, sitePath, phpVersion string) error {
+	if status, _ := podman.UnitStatus("lerd-queue-" + siteName); status == "active" {
+		if err := QueueStopForSite(siteName); err != nil {
+			fmt.Printf("[WARN] stopping queue worker before horizon: %v\n", err)
+		}
+	}
 	versionShort := strings.ReplaceAll(phpVersion, ".", "")
 	fpmUnit := "lerd-php" + versionShort + "-fpm"
 	container := "lerd-php" + versionShort + "-fpm"

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -39,8 +38,14 @@ type phpInfo struct {
 }
 
 type serviceInfo struct {
-	Name   string `json:"name"`
-	Status string `json:"status"`
+	Name               string `json:"name"`
+	Status             string `json:"status"`
+	QueueSite          string `json:"queue_site,omitempty"`
+	ScheduleWorkerSite string `json:"schedule_worker_site,omitempty"`
+	StripeListenerSite string `json:"stripe_listener_site,omitempty"`
+	ReverbSite         string `json:"reverb_site,omitempty"`
+	HorizonSite        string `json:"horizon_site,omitempty"`
+	WorkerSite         string `json:"worker_site,omitempty"`
 }
 
 const daemonEnv = "LERD_TRAY_DAEMON"
@@ -206,9 +211,9 @@ func fetchSnapshot() *Snapshot {
 		var all []serviceInfo
 		if json.NewDecoder(r.Body).Decode(&all) == nil {
 			for _, svc := range all {
-				if strings.HasPrefix(svc.Name, "queue-") ||
-					strings.HasPrefix(svc.Name, "schedule-") ||
-					strings.HasPrefix(svc.Name, "stripe-") {
+				if svc.QueueSite != "" || svc.ScheduleWorkerSite != "" ||
+					svc.StripeListenerSite != "" || svc.ReverbSite != "" ||
+					svc.HorizonSite != "" || svc.WorkerSite != "" {
 					continue
 				}
 				snap.Services = append(snap.Services, svc)

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -932,7 +932,7 @@
                     <div>
                       <div class="flex items-center gap-2">
                         <span class="font-semibold text-gray-900 dark:text-white text-base"
-                          x-text="selectedService.queue_site ? 'Queue worker' : selectedService.stripe_listener_site ? 'Stripe listener' : capitalize(selectedService.name)"></span>
+                          x-text="selectedService.queue_site ? 'Queue worker' : selectedService.horizon_site ? 'Horizon' : selectedService.stripe_listener_site ? 'Stripe listener' : capitalize(selectedService.name)"></span>
                         <span
                           class="inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-full"
                           :class="selectedService.status === 'active'
@@ -945,6 +945,9 @@
                       </div>
                       <template x-if="selectedService.queue_site">
                         <div class="text-xs text-gray-400 mt-0.5" x-text="selectedService.queue_site + '.test'"></div>
+                      </template>
+                      <template x-if="selectedService.horizon_site">
+                        <div class="text-xs text-gray-400 mt-0.5" x-text="selectedService.horizon_site + '.test'"></div>
                       </template>
                       <template x-if="selectedService.stripe_listener_site">
                         <div class="text-xs text-gray-400 mt-0.5" x-text="selectedService.stripe_listener_site + '.test'"></div>
@@ -967,8 +970,8 @@
                     </div>
                   </div>
                   <div class="flex items-center gap-2">
-                    <!-- Start button (not for queue/stripe workers) -->
-                    <template x-if="!selectedService.queue_site && !selectedService.stripe_listener_site && selectedService.status !== 'active'">
+                    <!-- Start button (not for queue/stripe/horizon workers) -->
+                    <template x-if="!selectedService.queue_site && !selectedService.horizon_site && !selectedService.stripe_listener_site && selectedService.status !== 'active'">
                       <button
                         @click="toggleService(selectedService, 'start')"
                         :disabled="selectedService.loading"
@@ -995,8 +998,8 @@
                       </button>
                     </template>
 
-                    <!-- Pin toggle (core + custom services only, not queue/stripe workers) -->
-                    <template x-if="!selectedService.queue_site && !selectedService.stripe_listener_site && !selectedService.schedule_worker_site && !selectedService.reverb_site && !selectedService.worker_site">
+                    <!-- Pin toggle (core + custom services only, not queue/stripe/horizon/schedule/reverb workers) -->
+                    <template x-if="!selectedService.queue_site && !selectedService.horizon_site && !selectedService.stripe_listener_site && !selectedService.schedule_worker_site && !selectedService.reverb_site && !selectedService.worker_site">
                       <button
                         @click="toggleServicePin(selectedService)"
                         :disabled="selectedService.loading"
@@ -2030,11 +2033,12 @@ function lerdApp() {
 
     capitalize(s) { return s.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' '); },
     coreServices() {
-      return this.services.filter(s => !s.queue_site && !s.schedule_worker_site && !s.stripe_listener_site && !s.reverb_site && !s.worker_site);
+      return this.services.filter(s => !s.queue_site && !s.schedule_worker_site && !s.stripe_listener_site && !s.reverb_site && !s.horizon_site && !s.worker_site);
     },
     workerGroups() {
       return [
         { key: 'queue',    label: 'Queues',    items: this.services.filter(s => s.queue_site) },
+        { key: 'horizon',  label: 'Horizon',   items: this.services.filter(s => s.horizon_site) },
         { key: 'schedule', label: 'Schedules', items: this.services.filter(s => s.schedule_worker_site) },
         { key: 'workers',  label: 'Workers',   items: this.services.filter(s => s.worker_site) },
         { key: 'stripe',   label: 'Stripe',    items: this.services.filter(s => s.stripe_listener_site) },
@@ -2042,7 +2046,7 @@ function lerdApp() {
       ].filter(g => g.items.length > 0);
     },
     workerSiteName(svc) {
-      return svc.queue_site || svc.schedule_worker_site || svc.stripe_listener_site || svc.reverb_site || svc.worker_site || svc.name;
+      return svc.queue_site || svc.horizon_site || svc.schedule_worker_site || svc.stripe_listener_site || svc.reverb_site || svc.worker_site || svc.name;
     },
     toggleWorkerGroup(key) {
       this.openWorkerGroup = this.openWorkerGroup === key ? null : key;

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -524,6 +524,7 @@ type ServiceResponse struct {
 	StripeListenerSite string            `json:"stripe_listener_site,omitempty"`
 	ScheduleWorkerSite string            `json:"schedule_worker_site,omitempty"`
 	ReverbSite         string            `json:"reverb_site,omitempty"`
+	HorizonSite        string            `json:"horizon_site,omitempty"`
 	WorkerSite         string            `json:"worker_site,omitempty"`
 	WorkerName         string            `json:"worker_name,omitempty"`
 }
@@ -594,6 +595,11 @@ func listActiveScheduleWorkers() []string {
 // listActiveReverbServers returns site names of active lerd-reverb-* units.
 func listActiveReverbServers() []string {
 	return listActiveUnitsBySuffix("lerd-reverb-*.service", "lerd-reverb-")
+}
+
+// listActiveHorizonWorkers returns site names of active lerd-horizon-* units.
+func listActiveHorizonWorkers() []string {
+	return listActiveUnitsBySuffix("lerd-horizon-*.service", "lerd-horizon-")
 }
 
 // listActiveStripeListeners returns the site names of active lerd-stripe-* units
@@ -695,6 +701,14 @@ func handleServices(w http.ResponseWriter, _ *http.Request) {
 			Status:     "active",
 			EnvVars:    map[string]string{},
 			ReverbSite: siteName,
+		})
+	}
+	for _, siteName := range listActiveHorizonWorkers() {
+		services = append(services, ServiceResponse{
+			Name:        "horizon-" + siteName,
+			Status:      "active",
+			EnvVars:     map[string]string{},
+			HorizonSite: siteName,
 		})
 	}
 	// Custom framework workers (non-builtin: not queue/schedule/reverb)
@@ -820,6 +834,26 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, resp)
 		} else {
 			writeJSON(w, ServiceActionResponse{OK: false, Error: "unsupported action for schedule worker"})
+		}
+		return
+	}
+
+	// Handle horizon worker services (horizon-{sitename})
+	if strings.HasPrefix(name, "horizon-") {
+		siteName := strings.TrimPrefix(name, "horizon-")
+		if action == "stop" {
+			opErr := cli.HorizonStopForSite(siteName)
+			resp := ServiceActionResponse{
+				ServiceResponse: ServiceResponse{Name: name, Status: "inactive", EnvVars: map[string]string{}, HorizonSite: siteName},
+				OK:              opErr == nil,
+			}
+			if opErr != nil {
+				resp.Error = opErr.Error()
+				resp.Status = "active"
+			}
+			writeJSON(w, resp)
+		} else {
+			writeJSON(w, ServiceActionResponse{OK: false, Error: "unsupported action for horizon worker"})
 		}
 		return
 	}


### PR DESCRIPTION
## Summary

- Horizon workers now appear in the Services panel grouped under "Horizon" (same UX as queues, schedules, reverb), with a stop button and site subtitle. Previously Horizon was only visible in the site detail toggle.
- `horizon:start` (CLI, UI, MCP) automatically stops any running queue worker for the same site before starting Horizon, since they must not run simultaneously.
- The tray menu no longer shows per-site workers (reverb, horizon, queue workers, schedule workers, Stripe listeners, custom framework workers). The filter now uses typed fields from `ServiceResponse` instead of name-prefix string matching, so new worker types are covered automatically.