### PR TITLE
chore(release): v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,20 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [1.2.3] — 2026-03-31
 
 ### Added
 
-- **Horizon appears in the Services panel** — when Laravel Horizon is running for a site it now shows up as its own entry in the Services panel (grouped under "Horizon"), with a stop button and a subtitle showing the site domain. Previously Horizon was only visible in the site detail view.
+- **Horizon appears in the Services panel** — when Laravel Horizon is running for a site it now shows up as its own entry in the Services panel (grouped under "Horizon"), with a stop button, live log stream, and a subtitle showing the site domain. Previously Horizon was only visible in the site detail view.
 - **Starting Horizon stops the queue worker** — `horizon:start` (CLI, UI, MCP) now automatically stops any running queue worker for the same site before starting Horizon, since the two must not run simultaneously.
+- **`lerd unlink` stops all workers for the site** — queue workers, Horizon, schedule workers, Reverb, Stripe listeners, and custom framework workers are all stopped before the site is unlinked.
 
 ### Fixed
 
 - **Tray no longer shows per-site workers** — Reverb, Horizon, queue workers, schedule workers, Stripe listeners, and custom framework workers are filtered out of the tray menu. Only real infrastructure services (MySQL, Redis, Mailpit, etc.) are listed there.
 - **`lerd php` can now run scripts outside `$HOME`** — IDEs like PhpStorm write their validation scripts to `/tmp` and call `php -d... /tmp/ide-phpinfo.php`. The container only mounts `$HOME`, so those scripts were unreachable and produced an empty output ("Failed to parse validation script output"). `runPhp` now detects any argument that is an absolute path to a host file outside `$HOME`, reads it, and streams it to the container via `stdin` / `/dev/stdin`.
+- **Horizon logs in the Services panel now stream the correct site** — the logs URL for a Horizon service entry now routes to `/api/horizon/{site}/logs` (systemd journal) instead of the generic `/api/logs/lerd-horizon-{site}` endpoint that tried to use `podman logs` on a non-existent container.
+- **Horizon log tab on the Sites panel no longer shows stale logs from a previous site** — switching sites now properly closes and clears the Horizon log stream; clicking the Horizon tab reconnects to the correct site's stream.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,23 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.2.3] — 2026-03-31
+
+### Added
+
+- **Horizon appears in the Services panel** — when Laravel Horizon is running for a site it now shows up as its own entry in the Services panel (grouped under "Horizon"), with a stop button, live log stream, and a subtitle showing the site domain. Previously Horizon was only visible in the site detail view.
+- **Starting Horizon stops the queue worker** — `horizon:start` (CLI, UI, MCP) now automatically stops any running queue worker for the same site before starting Horizon, since the two must not run simultaneously.
+- **`lerd unlink` stops all workers for the site** — queue workers, Horizon, schedule workers, Reverb, Stripe listeners, and custom framework workers are all stopped before the site is unlinked.
+
+### Fixed
+
+- **Tray no longer shows per-site workers** — Reverb, Horizon, queue workers, schedule workers, Stripe listeners, and custom framework workers are filtered out of the tray menu. Only real infrastructure services (MySQL, Redis, Mailpit, etc.) are listed there.
+- **`lerd php` can now run scripts outside `$HOME`** — IDEs like PhpStorm write their validation scripts to `/tmp` and call `php -d... /tmp/ide-phpinfo.php`. The container only mounts `$HOME`, so those scripts were unreachable and produced an empty output ("Failed to parse validation script output"). `runPhp` now detects any argument that is an absolute path to a host file outside `$HOME`, reads it, and streams it to the container via `stdin` / `/dev/stdin`.
+- **Horizon logs in the Services panel now stream the correct site** — the logs URL for a Horizon service entry now routes to `/api/horizon/{site}/logs` (systemd journal) instead of the generic `/api/logs/lerd-horizon-{site}` endpoint that tried to use `podman logs` on a non-existent container.
+- **Horizon log tab on the Sites panel no longer shows stale logs from a previous site** — switching sites now properly closes and clears the Horizon log stream; clicking the Horizon tab reconnects to the correct site's stream.
+
+---
+
 ## [1.2.2] — 2026-03-31
 
 ### Added

--- a/internal/cli/unlink.go
+++ b/internal/cli/unlink.go
@@ -45,6 +45,10 @@ func UnlinkSite(name string) error {
 		return fmt.Errorf("site %q not found", name)
 	}
 
+	for _, w := range collectRunningWorkers(site) {
+		stopWorkerByName(site, w)
+	}
+
 	if err := nginx.RemoveVhost(site.Domain); err != nil {
 		fmt.Printf("[WARN] removing vhost: %v\n", err)
 	}

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -2194,6 +2194,7 @@ function lerdApp() {
     closeSiteHorizonLogs() {
       if (this.siteHorizonLogs._source) { this.siteHorizonLogs._source.close(); this.siteHorizonLogs._source = null; }
       this.siteHorizonLogs.connected = false;
+      this.siteHorizonLogs.lines = [];
     },
 
     openSiteQueueLogs(site) {
@@ -2424,11 +2425,13 @@ function lerdApp() {
       this.siteLogsTab = tab;
       const s = this.selectedSite;
       this.closeSiteQueueLogs();
+      this.closeSiteHorizonLogs();
       this.closeSiteStripeLogs();
       this.closeSiteScheduleLogs();
       this.closeSiteReverbLogs();
       this.closeSiteWorkerLogs();
       if (tab === 'queue' && s) this.openSiteQueueLogs(s);
+      else if (tab === 'horizon' && s) this.openSiteHorizonLogs(s);
       else if (tab === 'stripe' && s) this.openSiteStripeLogs(s);
       else if (tab === 'schedule' && s) this.openSiteScheduleLogs(s);
       else if (tab === 'reverb' && s) this.openSiteReverbLogs(s);
@@ -2464,7 +2467,9 @@ function lerdApp() {
       if (svc.status !== 'active') return;
       const url = svc.queue_site
         ? `/api/queue/${svc.queue_site}/logs`
-        : svc.stripe_listener_site
+        : svc.horizon_site
+          ? `/api/horizon/${svc.horizon_site}/logs`
+          : svc.stripe_listener_site
           ? `/api/stripe/${svc.stripe_listener_site}/logs`
           : svc.schedule_worker_site
             ? `/api/schedule/${svc.schedule_worker_site}/logs`

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.2.2"
+	Version = "1.2.3"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## 1.2.3

### Added

- Horizon appears in the Services panel with stop button, live logs, and site subtitle
- `horizon:start` stops any running queue worker for the same site first
- `lerd unlink` now stops all workers (queue, horizon, schedule, reverb, stripe, custom) before unlinking

### Fixed

- Tray no longer shows per-site workers, only infrastructure services
- `lerd php` streams host-only scripts via stdin so PhpStorm interpreter validation works
- Horizon logs in the Services panel route to the correct systemd journal endpoint
- Horizon log tab on the Sites panel no longer shows stale logs from a previously selected site