### PR TITLE
docs: improve SEO targeting for PHP/Laravel developers on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Lerd
 
-> The open-source Laravel Herd alternative for Linux —
-> Podman-native, rootless, with a built-in web UI.
+> Open-source Herd-like local PHP development environment for Linux.
+> Podman-native, rootless, with a built-in Web UI.
 
 [![CI](https://github.com/geodro/lerd/actions/workflows/ci.yml/badge.svg)](https://github.com/geodro/lerd/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/geodro/lerd)](https://github.com/geodro/lerd/releases)
@@ -11,9 +11,14 @@
 
 ![Lerd Web UI](screenshots/app-3.png)
 
-Lerd runs Nginx, PHP-FPM, and your services as rootless Podman containers.
+Lerd runs Nginx, PHP-FPM, and your services as rootless Podman containers,
+designed for PHP and Laravel developers on Linux (Ubuntu, Fedora, Arch, Debian).
 No Docker. No sudo. No system pollution. Just `lerd link` and your project
 is live at `project.test` with HTTPS.
+
+## Built for Linux PHP developers
+
+If you're a PHP or Laravel developer on Linux and want frictionless local development — automatic `.test` domains, per-project PHP versions, one-click HTTPS, zero Docker — Lerd is built for you.
 
 ## Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,20 @@
-# Lerd
+---
+title: Lerd — Herd-like Local PHP Development for Linux
+description: Lerd is an open-source, Herd-like local PHP development environment for Linux. Run Laravel, Symfony, and WordPress with automatic .test domains, PHP 8.2–8.4, and rootless Podman on Ubuntu, Fedora, Arch, or Debian. No Docker required.
+---
 
-**A Herd-like local PHP development environment for Linux** — Podman-native, rootless, zero system dependencies.
+# Lerd: Herd-like Local PHP Development for Linux
 
-Lerd bundles Nginx, PHP-FPM, and optional services (MySQL, Redis, PostgreSQL, Meilisearch, RustFS) as rootless Podman containers, giving you automatic `.test` domain routing, per-project PHP/Node version isolation, and one-command TLS — all without touching your system's PHP or web server. Laravel-first, with built-in support for Symfony, WordPress, and any PHP framework via YAML definitions.
+Lerd is an open-source local PHP development environment built for PHP and Laravel developers on Linux (Ubuntu, Fedora, Arch, Debian) who want automatic `.test` domain routing, per-project PHP and Node version switching, and one-command HTTPS without touching their system PHP or running Docker.
+
+Lerd bundles Nginx, PHP-FPM, and optional services (MySQL, Redis, PostgreSQL, Meilisearch, RustFS) as rootless Podman containers, giving you per-project PHP/Node version isolation and one-command TLS — all without modifying your existing projects. Laravel-first, with built-in support for Symfony, WordPress, and any PHP framework via YAML definitions.
+
+## Who is this for?
+
+- PHP and Laravel developers on Linux who want **automatic `.test` domains** without editing `/etc/hosts`
+- Developers on Ubuntu, Fedora, Arch, or Debian running multiple PHP projects at once
+- Teams who don't want a separate Docker Compose stack per repository
+- Anyone who wants rootless, no-`sudo` local PHP development on Linux
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Lerd
-site_description: A Herd-like local PHP development environment for Linux — Podman-native, rootless
+site_description: Lerd is an open-source, Herd-like local PHP development environment for Linux. Automatic .test domains, PHP 8.2–8.4, rootless Podman. Works on Ubuntu, Fedora, Arch, and Debian. No Docker required.
 site_url: https://geodro.github.io/lerd/
 repo_url: https://github.com/geodro/lerd
 repo_name: geodro/lerd


### PR DESCRIPTION
Adds distro names (Ubuntu, Fedora, Arch, Debian) and stronger keyword phrases across README, docs landing page, and site meta description to improve discoverability for PHP/Laravel developers searching for local dev tooling on Linux.

Changes: README tagline and description paragraph, new "Built for Linux PHP developers" section, docs/index.md frontmatter + h1 + "Who is this for?" section, mkdocs.yml site_description.