### PR TITLE
feat: add whatsnew command

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -60,6 +60,7 @@ func main() {
 	root.AddCommand(cli.NewServiceCmd())
 	root.AddCommand(cli.NewStatusCmd())
 	root.AddCommand(cli.NewAboutCmd())
+	root.AddCommand(cli.NewWhatsnewCmd())
 	root.AddCommand(cli.NewManCmd())
 	root.AddCommand(cli.NewDoctorCmd())
 	root.AddCommand(cli.NewLogsCmd())

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -8,7 +8,8 @@
 | `lerd start` | Start DNS, nginx, PHP-FPM containers, and all installed services |
 | `lerd stop` | Stop DNS, nginx, PHP-FPM containers, and all running services |
 | `lerd quit` | Stop all Lerd processes and containers including the UI, watcher, and tray |
-| `lerd update` | Check for updates, show changelog, and update after confirmation |
+| `lerd update` | Check for updates and update after confirmation |
+| `lerd whatsnew` | Show what changed between the installed version and the latest release |
 | `lerd uninstall` | Stop all containers and remove Lerd |
 | `lerd uninstall --force` | Same, skipping all confirmation prompts |
 | `lerd autostart enable` | Start Lerd automatically on every login |
@@ -17,7 +18,7 @@
 | `lerd autostart tray enable` | Start the tray applet automatically on graphical login |
 | `lerd autostart tray disable` | Disable tray autostart |
 | `lerd dns:check` | Verify that `*.test` resolves to `127.0.0.1` |
-| `lerd status` | Health summary: DNS, nginx, PHP-FPM containers, watcher, services, cert expiry |
+| `lerd status` | Health summary: DNS, nginx, PHP-FPM containers, watcher, services, cert expiry; shows a notice if an update is available |
 | `lerd about` | Show version, build info, and project URL |
 | `lerd man [page]` | Browse the built-in documentation in the terminal; pass a page name to jump directly (e.g. `lerd man sites`) |
 | `lerd doctor` | Full environment diagnostic — podman, systemd, DNS, ports, PHP images, config validity |

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -222,15 +222,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	}
 
 	if updateInfo, _ := lerdUpdate.CachedUpdateCheck(version.Version); updateInfo != nil {
-		warn("lerd update available", updateInfo.LatestVersion+" — run: lerd update")
-		if updateInfo.Changelog != "" {
-			fmt.Println()
-			fmt.Println("  What's new:")
-			for _, line := range strings.Split(updateInfo.Changelog, "\n") {
-				fmt.Println("  " + line)
-			}
-			fmt.Println()
-		}
+		warn("lerd update available", updateInfo.LatestVersion+" — run: lerd update, lerd whatsnew to see changes")
 	} else {
 		ok("lerd up to date")
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
@@ -206,14 +205,8 @@ func printUpdateNotice(info *lerdUpdate.UpdateInfo) {
 	fmt.Println()
 	fmt.Printf("%s%s%s\n", colorYellow, bar, colorReset)
 	fmt.Printf("%s  Update available: %s  →  run: lerd update%s\n", colorYellow, info.LatestVersion, colorReset)
+	fmt.Printf("%s  Run lerd whatsnew to see what changed.%s\n", colorYellow, colorReset)
 	fmt.Printf("%s%s%s\n", colorYellow, bar, colorReset)
-	if info.Changelog != "" {
-		fmt.Println()
-		fmt.Println("  What's new:")
-		for _, line := range strings.Split(info.Changelog, "\n") {
-			fmt.Println("  " + line)
-		}
-	}
 }
 
 // certExpiry reads the expiry date from a PEM certificate file.

--- a/internal/cli/whatsnew.go
+++ b/internal/cli/whatsnew.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	lerdUpdate "github.com/geodro/lerd/internal/update"
+	"github.com/geodro/lerd/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// NewWhatsnewCmd returns the whatsnew command.
+func NewWhatsnewCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "whatsnew",
+		Short: "Show what changed in the latest release",
+		RunE:  runWhatsnew,
+	}
+}
+
+func runWhatsnew(_ *cobra.Command, _ []string) error {
+	latest, err := lerdUpdate.FetchLatestVersion()
+	if err != nil {
+		return fmt.Errorf("could not fetch latest version: %w", err)
+	}
+
+	current := lerdUpdate.StripV(version.Version)
+	latestStripped := lerdUpdate.StripV(latest)
+
+	if !lerdUpdate.VersionGreaterThan(latestStripped, current) {
+		fmt.Printf("You are on the latest version (%s).\n", version.Version)
+		return nil
+	}
+
+	changelog, err := lerdUpdate.FetchChangelog(current, latestStripped)
+	if err != nil {
+		return fmt.Errorf("could not fetch changelog: %w", err)
+	}
+
+	fmt.Printf("What's new in %s (you have %s):\n\n", latest, version.Version)
+	if changelog == "" {
+		fmt.Println("No changelog entries found.")
+		return nil
+	}
+	for _, line := range strings.Split(changelog, "\n") {
+		fmt.Println(line)
+	}
+	return nil
+}


### PR DESCRIPTION
Adds `lerd whatsnew` — fetches and displays the changelog between the installed version and the latest release.

`lerd status` and `lerd doctor` no longer show the full changelog inline, they now just show a one-liner hint to run `lerd whatsnew` when an update is available.

Docs updated in `docs/reference/commands.md`.