### PR TITLE
feat(mcp): add db_import, db_create, php_list, php_ext, park, unpark tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ AI:  → site_link()
      ✓  myapp → https://myapp.test ready
 ```
 
-50+ tools available: run migrations, manage services, toggle workers, tail logs, enable Xdebug, export databases, and more, all from your AI assistant.
+60+ tools available: run migrations, manage services, toggle workers, tail logs, enable Xdebug, manage databases, manage PHP extensions, park directories, and more, all from your AI assistant.
 
 📖 [MCP documentation](https://geodro.github.io/lerd/features/mcp/)
 

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -53,7 +53,7 @@ lerd mcp:inject --path ~/Lerd/another-app
 
 ### Path resolution
 
-Tools like `artisan`, `composer`, `env_setup`, and `db_export` accept an optional `path` argument. When omitted, the server resolves the path in this order:
+Tools like `artisan`, `composer`, `env_setup`, `db_export`, `db_import`, and `db_create` accept an optional `path` argument. When omitted, the server resolves the path in this order:
 
 1. Explicit `path` argument (highest priority)
 2. `LERD_SITE_PATH` env var (set by `mcp:inject`)
@@ -69,6 +69,10 @@ Once the MCP server is connected, your AI assistant has access to:
 |---|---|
 | `sites` | List all registered lerd sites (name, domain, path, PHP/Node version, framework, worker status) |
 | `runtime_versions` | List installed PHP and Node.js versions with configured defaults |
+| `php_list` | List all PHP versions installed by lerd, marking the global default |
+| `php_ext_list` | List custom PHP extensions configured for a PHP version |
+| `php_ext_add` | Add a custom PHP extension — rebuilds the FPM image and restarts the container |
+| `php_ext_remove` | Remove a custom PHP extension — rebuilds the FPM image and restarts the container |
 | `artisan` | Run `php artisan` in the PHP-FPM container — migrations, generators, seeders, cache, tinker (Laravel only) |
 | `console` | Run the framework's console command (e.g. `php bin/console` for Symfony) — shown for non-Laravel frameworks that define a `console` field |
 | `composer` | Run `composer` in the PHP-FPM container — install, require, dump-autoload, etc. |
@@ -77,6 +81,8 @@ Once the MCP server is connected, your AI assistant has access to:
 | `env_setup` | Configure `.env` for lerd: detects services, starts them, creates DB, sets APP_KEY and APP_URL |
 | `site_link` | Register a directory as a lerd site — generates nginx vhost and `.test` domain |
 | `site_unlink` | Unregister a site and remove its nginx vhost |
+| `park` | Register a parent directory — scans subdirectories and auto-registers any PHP projects as sites |
+| `unpark` | Remove a parked directory from lerd and unlink all its sites |
 | `secure` | Enable HTTPS for a site using a locally-trusted mkcert certificate |
 | `unsecure` | Disable HTTPS for a site |
 | `xdebug_on` | Enable Xdebug for a PHP version and restart the FPM container |
@@ -89,6 +95,8 @@ Once the MCP server is connected, your AI assistant has access to:
 | `service_expose` | Add or remove an extra published port on a built-in service (persisted, auto-restarts if running) |
 | `service_env` | Return the recommended `.env` connection variables for a built-in or custom service |
 | `db_export` | Export a database to a SQL dump file (defaults to site DB from `.env`) |
+| `db_import` | Import a SQL dump file into the project database (reads connection from `.env`) |
+| `db_create` | Create a database and `_testing` variant for the project (infers name from `.env` or project dir) |
 | `queue_start` | Start the queue worker for a site (any framework with a `queue` worker) |
 | `queue_stop` | Stop the queue worker |
 | `horizon_start` | Start Laravel Horizon for a site (use instead of `queue_start` when `laravel/horizon` is installed) |

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -284,7 +284,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment fo
 
 ## Path resolution
 
-Tools that accept a ` + bt + `path` + bt + ` argument (` + bt + `artisan` + bt + `, ` + bt + `composer` + bt + `, ` + bt + `env_setup` + bt + `, ` + bt + `site_link` + bt + `, ` + bt + `db_export` + bt + `, etc.) resolve it in this order:
+Tools that accept a ` + bt + `path` + bt + ` argument (` + bt + `artisan` + bt + `, ` + bt + `composer` + bt + `, ` + bt + `env_setup` + bt + `, ` + bt + `site_link` + bt + `, ` + bt + `db_export` + bt + `, ` + bt + `db_import` + bt + `, ` + bt + `db_create` + bt + `, etc.) resolve it in this order:
 1. Explicit ` + bt + `path` + bt + ` argument
 2. ` + bt + `LERD_SITE_PATH` + bt + ` env var (set when using project-scoped ` + bt + `mcp:inject` + bt + `)
 3. **Current working directory** — the directory Claude was opened in
@@ -311,6 +311,25 @@ List all registered lerd sites with domains, paths, PHP versions, Node versions,
 
 ### ` + bt + `runtime_versions` + bt + `
 List all installed PHP and Node.js versions and the configured defaults. Call this to check what runtimes are available before running commands.
+
+### ` + bt + `php_list` + bt + `
+List all PHP versions installed by lerd as JSON, with each version's ` + bt + `default` + bt + ` flag. Use this to confirm which versions are available before calling ` + bt + `site_php` + bt + `, ` + bt + `php_ext_add` + bt + `, or ` + bt + `xdebug_on` + bt + `.
+
+### ` + bt + `php_ext_list` + bt + ` / ` + bt + `php_ext_add` + bt + ` / ` + bt + `php_ext_remove` + bt + `
+Manage custom PHP extensions for a PHP version. Extensions are added on top of the bundled lerd FPM image. Adding or removing an extension rebuilds the image and restarts the FPM container (may take a minute).
+
+Optional ` + bt + `version` + bt + ` argument on all three — defaults to the project or global PHP version.
+
+` + bt + `php_ext_add` + bt + ` and ` + bt + `php_ext_remove` + bt + ` take ` + bt + `extension` + bt + ` (required).
+
+Examples:
+` + "```" + `
+php_ext_list()                              // list extensions for current project's PHP version
+php_ext_list(version: "8.4")               // list extensions for 8.4
+php_ext_add(extension: "imagick")          // add imagick to current project's PHP version
+php_ext_add(extension: "redis", version: "8.3")
+php_ext_remove(extension: "imagick")
+` + "```" + `
 
 ### ` + bt + `artisan` + bt + ` (Laravel only)
 Run ` + bt + `php artisan` + bt + ` inside the PHP-FPM container for the project. Only available when the site is detected as Laravel. Arguments:
@@ -464,6 +483,13 @@ Register or unregister a directory as a lerd site. Arguments for ` + bt + `site_
 
 ` + bt + `site_unlink` + bt + ` takes ` + bt + `site` + bt + ` (site name from ` + bt + `sites` + bt + ` tool). Project files are NOT deleted.
 
+### ` + bt + `park` + bt + ` / ` + bt + `unpark` + bt + `
+` + bt + `park` + bt + ` registers a parent directory: it scans every immediate subdirectory and auto-registers any PHP projects found as lerd sites. Use this when you keep many projects under one folder.
+
+` + bt + `unpark` + bt + ` removes the registration and unlinks all sites whose paths are under that directory. Project files are NOT deleted.
+
+Both take ` + bt + `path` + bt + ` (optional, defaults to LERD_SITE_PATH or cwd).
+
 ### ` + bt + `secure` + bt + ` / ` + bt + `unsecure` + bt + `
 Enable or disable HTTPS for a site using a locally-trusted mkcert certificate. Both take ` + bt + `site` + bt + ` (site name). ` + bt + `APP_URL` + bt + ` in ` + bt + `.env` + bt + ` is updated automatically.
 
@@ -604,6 +630,17 @@ Export a database to a SQL dump file. Arguments:
 - ` + bt + `database` + bt + ` (optional): database name to export (defaults to ` + bt + `DB_DATABASE` + bt + ` from ` + bt + `.env` + bt + `)
 - ` + bt + `output` + bt + ` (optional): output file path (defaults to ` + bt + `<database>.sql` + bt + ` in the project root)
 
+### ` + bt + `db_import` + bt + `
+Import a SQL dump file into the project database. Reads connection details from ` + bt + `.env` + bt + `. The database service must already be running. Arguments:
+- ` + bt + `file` + bt + ` (required): absolute path to the SQL file to import
+- ` + bt + `path` + bt + ` (optional): absolute path to the project root — defaults to the current working directory
+- ` + bt + `database` + bt + ` (optional): database name to import into (defaults to ` + bt + `DB_DATABASE` + bt + ` from ` + bt + `.env` + bt + `)
+
+### ` + bt + `db_create` + bt + `
+Create a database and a ` + bt + `<name>_testing` + bt + ` variant for the project. Infers the database name and engine from ` + bt + `.env` + bt + `, falling back to the project directory name. The service must be running. Arguments:
+- ` + bt + `path` + bt + ` (optional): absolute path to the project root
+- ` + bt + `name` + bt + ` (optional): database name (defaults to ` + bt + `DB_DATABASE` + bt + ` from ` + bt + `.env` + bt + `)
+
 ### ` + bt + `logs` + bt + `
 Fetch recent container logs. ` + bt + `target` + bt + ` is optional — when omitted, returns logs for the current site's PHP-FPM container (resolved from ` + bt + `LERD_SITE_PATH` + bt + `). Specify ` + bt + `target` + bt + ` only when you want a different container:
 - ` + bt + `"nginx"` + bt + ` — nginx proxy logs
@@ -694,6 +731,28 @@ db_export(output: "/tmp/myapp-backup.sql")
 artisan(args: ["migrate"])
 ` + "```" + `
 
+**Restore a database from a dump:**
+` + "```" + `
+db_import(file: "/tmp/myapp-backup.sql")
+` + "```" + `
+
+**Create databases for a new project manually:**
+` + "```" + `
+db_create()   // creates myapp + myapp_testing based on .env DB_DATABASE
+` + "```" + `
+
+**Check and manage PHP extensions:**
+` + "```" + `
+php_list()                           // see installed PHP versions
+php_ext_list()                       // see custom extensions for current project's PHP version
+php_ext_add(extension: "imagick")    // install imagick (rebuilds FPM image)
+` + "```" + `
+
+**Park a directory of projects:**
+` + "```" + `
+park(path: "/home/user/code")   // registers all PHP projects under ~/code as sites
+` + "```" + `
+
 **Diagnose PHP errors:**
 ` + "```" + `
 logs()                  // current site's PHP-FPM errors (no target needed)
@@ -775,6 +834,10 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 |------|-------------|
 | ` + bt + `sites` + bt + ` | List all registered sites with framework and worker status — call this first |
 | ` + bt + `runtime_versions` + bt + ` | List installed PHP and Node.js versions with defaults |
+| ` + bt + `php_list` + bt + ` | List installed PHP versions, marking the global default |
+| ` + bt + `php_ext_list` + bt + ` | List custom PHP extensions for a PHP version |
+| ` + bt + `php_ext_add` + bt + ` | Add a custom PHP extension — rebuilds FPM image and restarts container |
+| ` + bt + `php_ext_remove` + bt + ` | Remove a custom PHP extension — rebuilds FPM image and restarts container |
 | ` + bt + `artisan` + bt + ` | Run ` + bt + `php artisan` + bt + ` inside the PHP-FPM container (Laravel only) |
 | ` + bt + `console` + bt + ` | Run the framework's console command (e.g. ` + bt + `php bin/console` + bt + ` for Symfony) — non-Laravel frameworks with a ` + bt + `console` + bt + ` field |
 | ` + bt + `composer` + bt + ` | Run ` + bt + `composer` + bt + ` inside the PHP-FPM container |
@@ -783,6 +846,8 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `env_setup` + bt + ` | Configure ` + bt + `.env` + bt + ` for lerd: detects services, starts them, creates DB, generates APP_KEY |
 | ` + bt + `site_link` + bt + ` | Register a directory as a lerd site (creates nginx vhost + ` + bt + `.test` + bt + ` domain) |
 | ` + bt + `site_unlink` + bt + ` | Unregister a site and remove its nginx vhost |
+| ` + bt + `park` + bt + ` | Register a parent directory — auto-registers all PHP projects as sites |
+| ` + bt + `unpark` + bt + ` | Remove a parked directory and unlink all its sites |
 | ` + bt + `secure` + bt + ` | Enable HTTPS for a site (mkcert) — updates APP_URL automatically |
 | ` + bt + `unsecure` + bt + ` | Disable HTTPS for a site |
 | ` + bt + `xdebug_on` + bt + ` | Enable Xdebug for a PHP version (port 9003) |
@@ -795,6 +860,8 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `service_expose` + bt + ` | Add or remove an extra published port on a built-in service (persisted) |
 | ` + bt + `service_env` + bt + ` | Return the recommended ` + bt + `.env` + bt + ` connection variables for a service |
 | ` + bt + `db_export` + bt + ` | Export a database to a SQL dump file (defaults to site DB from ` + bt + `.env` + bt + `) |
+| ` + bt + `db_import` + bt + ` | Import a SQL dump file into the project database (reads connection from ` + bt + `.env` + bt + `) |
+| ` + bt + `db_create` + bt + ` | Create a database and ` + bt + `_testing` + bt + ` variant (infers name from ` + bt + `.env` + bt + ` or project dir) |
 | ` + bt + `queue_start` + bt + ` | Start the queue worker for a site (any framework with a queue worker) |
 | ` + bt + `queue_stop` + bt + ` | Stop the queue worker |
 | ` + bt + `horizon_start` + bt + ` | Start Laravel Horizon for a site (use instead of queue_start when laravel/horizon is installed) |
@@ -839,4 +906,8 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - ` + bt + `service_pin` + bt + ` keeps a service always running regardless of which sites are active; use for shared services like MySQL or Redis
 - ` + bt + `service_add` + bt + ` supports ` + bt + `depends_on` + bt + ` (array of service names): starting a dependency auto-starts the dependent service; stopping a dependency cascade-stops the dependent first; starting the dependent ensures dependencies start first
 - ` + bt + `project_new` + bt + ` requires an absolute ` + bt + `path` + bt + ` and runs the framework's ` + bt + `create` + bt + ` command; follow it with ` + bt + `site_link` + bt + ` + ` + bt + `env_setup` + bt + ` to register and configure the new project
+- ` + bt + `php_ext_add` + bt + ` / ` + bt + `php_ext_remove` + bt + ` rebuild the FPM image and restart the container — may take a minute; ` + bt + `version` + bt + ` defaults to the project or global PHP version
+- ` + bt + `db_import` + bt + ` requires the database service to be running; pipe the file by absolute path — it reads connection info from ` + bt + `.env` + bt + `
+- ` + bt + `db_create` + bt + ` always creates both ` + bt + `<name>` + bt + ` and ` + bt + `<name>_testing` + bt + ` databases; safe to call if they already exist
+- ` + bt + `park` + bt + ` auto-registers all PHP subdirectories as sites in one call; ` + bt + `unpark` + bt + ` removes them all — project files are NOT deleted
 `

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -584,6 +584,129 @@ func toolList() []mcpTool {
 				},
 			},
 		},
+		{
+			Name:        "db_import",
+			Description: "Import a SQL dump file into the project database. Reads connection details from the project .env. The database service must be running.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"path": {
+						Type:        "string",
+						Description: "Absolute path to the project root. Defaults to LERD_SITE_PATH when omitted.",
+					},
+					"file": {
+						Type:        "string",
+						Description: "Absolute path to the SQL dump file to import",
+					},
+					"database": {
+						Type:        "string",
+						Description: "Database name to import into (defaults to DB_DATABASE from .env)",
+					},
+				},
+				Required: []string{"file"},
+			},
+		},
+		{
+			Name:        "db_create",
+			Description: "Create a database (and a _testing variant) for the project. Reads the connection type from .env and starts the service if needed. Defaults to the DB_DATABASE name from .env, falling back to the project directory name.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"path": {
+						Type:        "string",
+						Description: "Absolute path to the project root. Defaults to LERD_SITE_PATH when omitted.",
+					},
+					"name": {
+						Type:        "string",
+						Description: "Database name (defaults to DB_DATABASE from .env, then to the project directory name)",
+					},
+				},
+			},
+		},
+		{
+			Name:        "php_list",
+			Description: "List all PHP versions installed by lerd, marking the global default. Use this to check available versions before calling site_php or php_ext_add.",
+			InputSchema: mcpSchema{
+				Type:       "object",
+				Properties: map[string]mcpProp{},
+			},
+		},
+		{
+			Name:        "php_ext_list",
+			Description: "List custom PHP extensions configured for a PHP version. These are extensions added on top of the bundled lerd image.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"version": {
+						Type:        "string",
+						Description: "PHP version (e.g. \"8.4\"). Defaults to the project or global default.",
+					},
+				},
+			},
+		},
+		{
+			Name:        "php_ext_add",
+			Description: "Install a custom PHP extension for a PHP version. Rebuilds the FPM image and restarts the container. This may take a minute.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"extension": {
+						Type:        "string",
+						Description: "Extension name to install (e.g. \"imagick\", \"redis\", \"swoole\")",
+					},
+					"version": {
+						Type:        "string",
+						Description: "PHP version (e.g. \"8.4\"). Defaults to the project or global default.",
+					},
+				},
+				Required: []string{"extension"},
+			},
+		},
+		{
+			Name:        "php_ext_remove",
+			Description: "Remove a custom PHP extension from a PHP version. Rebuilds the FPM image and restarts the container.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"extension": {
+						Type:        "string",
+						Description: "Extension name to remove",
+					},
+					"version": {
+						Type:        "string",
+						Description: "PHP version (e.g. \"8.4\"). Defaults to the project or global default.",
+					},
+				},
+				Required: []string{"extension"},
+			},
+		},
+		{
+			Name:        "park",
+			Description: "Register a directory as a lerd park: scans all subdirectories and auto-registers any PHP projects as sites. Use this to manage many projects under a single parent directory.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"path": {
+						Type:        "string",
+						Description: "Absolute path to the directory to park. Defaults to LERD_SITE_PATH when omitted.",
+					},
+				},
+			},
+		},
+		{
+			Name:        "unpark",
+			Description: "Remove a parked directory from lerd and unlink all sites whose paths are under it. Project files are NOT deleted.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"path": {
+						Type:        "string",
+						Description: "Absolute path to the parked directory to remove",
+					},
+				},
+				Required: []string{"path"},
+			},
+		},
 	}
 
 	if siteIsLaravel() {
@@ -1160,6 +1283,22 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execServicePin(args)
 	case "service_unpin":
 		return execServiceUnpin(args)
+	case "db_import":
+		return execDBImport(args)
+	case "db_create":
+		return execDBCreate(args)
+	case "php_list":
+		return execPHPList()
+	case "php_ext_list":
+		return execPHPExtList(args)
+	case "php_ext_add":
+		return execPHPExtAdd(args)
+	case "php_ext_remove":
+		return execPHPExtRemove(args)
+	case "park":
+		return execPark(args)
+	case "unpark":
+		return execUnpark(args)
 	default:
 		return toolErr("unknown tool: " + p.Name), nil
 	}
@@ -3034,6 +3173,314 @@ func runLerdCmd(cmdArgs ...string) (any, *rpcError) {
 		return toolErr(fmt.Sprintf("command failed (%v):\n%s", err, out.String())), nil
 	}
 	return toolOK(strings.TrimSpace(out.String())), nil
+}
+
+// ---- DB import / create ----
+
+func execDBImport(args map[string]any) (any, *rpcError) {
+	projectPath := resolvedPath(args)
+	if projectPath == "" {
+		return toolErr("path is required — pass a path argument or open Claude in the project directory"), nil
+	}
+
+	file := strArg(args, "file")
+	if file == "" {
+		return toolErr("file is required"), nil
+	}
+
+	env, err := readDBEnv(projectPath)
+	if err != nil {
+		return toolErr(err.Error()), nil
+	}
+	if db := strArg(args, "database"); db != "" {
+		env.database = db
+	}
+
+	f, err := os.Open(file)
+	if err != nil {
+		return toolErr(fmt.Sprintf("opening %s: %v", file, err)), nil
+	}
+	defer f.Close()
+
+	var cmd *exec.Cmd
+	switch env.connection {
+	case "mysql", "mariadb":
+		cmd = exec.Command("podman", "exec", "-i", "lerd-mysql",
+			"mysql", "-u"+env.username, "-p"+env.password, env.database)
+	case "pgsql", "postgres":
+		cmd = exec.Command("podman", "exec", "-i", "-e", "PGPASSWORD="+env.password,
+			"lerd-postgres", "psql", "-U", env.username, env.database)
+	default:
+		return toolErr("unsupported DB_CONNECTION: " + env.connection), nil
+	}
+
+	var stderr bytes.Buffer
+	cmd.Stdin = f
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return toolErr(fmt.Sprintf("import failed (%v):\n%s", err, stderr.String())), nil
+	}
+	return toolOK(fmt.Sprintf("Imported %s into %s (%s)", file, env.database, env.connection)), nil
+}
+
+func execDBCreate(args map[string]any) (any, *rpcError) {
+	projectPath := resolvedPath(args)
+	if projectPath == "" {
+		return toolErr("path is required — pass a path argument or open Claude in the project directory"), nil
+	}
+
+	env, _ := readDBEnvLenient(projectPath)
+
+	dbName := strArg(args, "name")
+	if dbName == "" {
+		if env != nil && env.database != "" {
+			dbName = env.database
+		} else {
+			base := filepath.Base(projectPath)
+			dbName = strings.ToLower(strings.ReplaceAll(base, "-", "_"))
+		}
+	}
+
+	conn := "mysql"
+	if env != nil && env.connection != "" {
+		conn = env.connection
+	}
+
+	svc := "mysql"
+	switch strings.ToLower(conn) {
+	case "pgsql", "postgres":
+		svc = "postgres"
+	}
+
+	var results []string
+	for _, name := range []string{dbName, dbName + "_testing"} {
+		created, err := mcpCreateDatabase(svc, name)
+		if err != nil {
+			return toolErr(fmt.Sprintf("creating %q: %v", name, err)), nil
+		}
+		if created {
+			results = append(results, fmt.Sprintf("Created database %q", name))
+		} else {
+			results = append(results, fmt.Sprintf("Database %q already exists", name))
+		}
+	}
+	return toolOK(strings.Join(results, "\n")), nil
+}
+
+func mcpCreateDatabase(svc, name string) (bool, error) {
+	switch svc {
+	case "mysql":
+		check := exec.Command("podman", "exec", "lerd-mysql", "mysql", "-uroot", "-plerd",
+			"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", name))
+		out, err := check.Output()
+		if err == nil && strings.TrimSpace(string(out)) != "0" {
+			return false, nil
+		}
+		cmd := exec.Command("podman", "exec", "lerd-mysql", "mysql", "-uroot", "-plerd",
+			"-e", fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`;", name))
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return false, fmt.Errorf("%v: %s", err, stderr.String())
+		}
+		return true, nil
+	case "postgres":
+		cmd := exec.Command("podman", "exec", "lerd-postgres", "psql", "-U", "postgres",
+			"-c", fmt.Sprintf(`CREATE DATABASE "%s";`, name))
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			if strings.Contains(string(out), "already exists") {
+				return false, nil
+			}
+			return false, fmt.Errorf("%s", strings.TrimSpace(string(out)))
+		}
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+// readDBEnvLenient reads DB connection info from .env without requiring DB_DATABASE.
+func readDBEnvLenient(projectPath string) (*mcpDBEnv, error) {
+	envPath := filepath.Join(projectPath, ".env")
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		return nil, fmt.Errorf("no .env found in %s", projectPath)
+	}
+	vals := map[string]string{}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") || !strings.Contains(line, "=") {
+			continue
+		}
+		k, v, _ := strings.Cut(line, "=")
+		vals[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `"'`)
+	}
+	return &mcpDBEnv{
+		connection: vals["DB_CONNECTION"],
+		database:   vals["DB_DATABASE"],
+		username:   vals["DB_USERNAME"],
+		password:   vals["DB_PASSWORD"],
+	}, nil
+}
+
+// ---- PHP list / extensions ----
+
+func execPHPList() (any, *rpcError) {
+	versions, err := phpDet.ListInstalled()
+	if err != nil {
+		return toolErr("listing PHP versions: " + err.Error()), nil
+	}
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return toolErr("loading config: " + err.Error()), nil
+	}
+
+	if len(versions) == 0 {
+		return toolOK("No PHP versions installed. Run 'lerd install' to set up PHP."), nil
+	}
+
+	type entry struct {
+		Version string `json:"version"`
+		Default bool   `json:"default"`
+	}
+	result := make([]entry, 0, len(versions))
+	for _, v := range versions {
+		result = append(result, entry{Version: v, Default: v == cfg.PHP.DefaultVersion})
+	}
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return toolOK(string(data)), nil
+}
+
+func execPHPExtList(args map[string]any) (any, *rpcError) {
+	version, err := resolvePHPVersion(args)
+	if err != nil {
+		return toolErr(err.Error()), nil
+	}
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return toolErr("loading config: " + err.Error()), nil
+	}
+
+	exts := cfg.GetExtensions(version)
+	if len(exts) == 0 {
+		return toolOK(fmt.Sprintf("No custom extensions configured for PHP %s.", version)), nil
+	}
+
+	data, _ := json.MarshalIndent(map[string]any{
+		"version":    version,
+		"extensions": exts,
+	}, "", "  ")
+	return toolOK(string(data)), nil
+}
+
+func execPHPExtAdd(args map[string]any) (any, *rpcError) {
+	ext := strArg(args, "extension")
+	if ext == "" {
+		return toolErr("extension is required"), nil
+	}
+
+	version, err := resolvePHPVersion(args)
+	if err != nil {
+		return toolErr(err.Error()), nil
+	}
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return toolErr("loading config: " + err.Error()), nil
+	}
+
+	cfg.AddExtension(version, ext)
+	if err := config.SaveGlobal(cfg); err != nil {
+		return toolErr("saving config: " + err.Error()), nil
+	}
+
+	var out bytes.Buffer
+	if err := podman.RebuildFPMImageTo(version, false, &out); err != nil {
+		return toolErr(fmt.Sprintf("rebuilding PHP %s image (%v):\n%s", version, err, out.String())), nil
+	}
+
+	short := strings.ReplaceAll(version, ".", "")
+	unit := "lerd-php" + short + "-fpm"
+	if err := podman.RestartUnit(unit); err != nil {
+		return toolOK(fmt.Sprintf("Extension %q added to PHP %s.\n[WARN] FPM restart failed: %v\nRun: systemctl --user restart %s", ext, version, err, unit)), nil
+	}
+	return toolOK(fmt.Sprintf("Extension %q added to PHP %s. FPM container restarted.", ext, version)), nil
+}
+
+func execPHPExtRemove(args map[string]any) (any, *rpcError) {
+	ext := strArg(args, "extension")
+	if ext == "" {
+		return toolErr("extension is required"), nil
+	}
+
+	version, err := resolvePHPVersion(args)
+	if err != nil {
+		return toolErr(err.Error()), nil
+	}
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return toolErr("loading config: " + err.Error()), nil
+	}
+
+	cfg.RemoveExtension(version, ext)
+	if err := config.SaveGlobal(cfg); err != nil {
+		return toolErr("saving config: " + err.Error()), nil
+	}
+
+	var out bytes.Buffer
+	if err := podman.RebuildFPMImageTo(version, false, &out); err != nil {
+		return toolErr(fmt.Sprintf("rebuilding PHP %s image (%v):\n%s", version, err, out.String())), nil
+	}
+
+	short := strings.ReplaceAll(version, ".", "")
+	unit := "lerd-php" + short + "-fpm"
+	if err := podman.RestartUnit(unit); err != nil {
+		return toolOK(fmt.Sprintf("Extension %q removed from PHP %s.\n[WARN] FPM restart failed: %v\nRun: systemctl --user restart %s", ext, version, err, unit)), nil
+	}
+	return toolOK(fmt.Sprintf("Extension %q removed from PHP %s. FPM container restarted.", ext, version)), nil
+}
+
+// resolvePHPVersion picks the PHP version from args["version"], the site .php-version file, or the global default.
+func resolvePHPVersion(args map[string]any) (string, error) {
+	if v := strArg(args, "version"); v != "" {
+		if !phpVersionRe.MatchString(v) {
+			return "", fmt.Errorf("invalid PHP version %q — expected format like \"8.4\"", v)
+		}
+		return v, nil
+	}
+	if defaultSitePath != "" {
+		if v, err := phpDet.DetectVersion(defaultSitePath); err == nil {
+			return v, nil
+		}
+	}
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return "", fmt.Errorf("loading config: %w", err)
+	}
+	return cfg.PHP.DefaultVersion, nil
+}
+
+// ---- Park / Unpark ----
+
+func execPark(args map[string]any) (any, *rpcError) {
+	path := resolvedPath(args)
+	if path == "" {
+		return toolErr("path is required — pass a path argument or open Claude in the project directory"), nil
+	}
+	return runLerdCmd("park", path)
+}
+
+func execUnpark(args map[string]any) (any, *rpcError) {
+	path := strArg(args, "path")
+	if path == "" {
+		return toolErr("path is required"), nil
+	}
+	return runLerdCmd("unpark", path)
 }
 
 // syncMCPLerdYAMLSecured updates the secured field in .lerd.yaml when the file


### PR DESCRIPTION
Adds 8 new MCP tools identified as gaps between the CLI and the MCP server.

## New tools

**Database**
- `db_import` — import a SQL dump into the project database (symmetric with `db_export`)
- `db_create` — create `<name>` and `<name>_testing` databases, infers name from `.env` or project dir

**PHP**
- `php_list` — list installed PHP versions with default marker
- `php_ext_list` — list custom extensions for a PHP version
- `php_ext_add` — install a custom extension, rebuilds FPM image, restarts container
- `php_ext_remove` — remove a custom extension, rebuilds FPM image, restarts container

**Directory management**
- `park` — register a parent directory, auto-registers all PHP subdirectories as sites
- `unpark` — remove a parked directory and unlink all its sites

## Docs updated
- `docs/features/mcp.md` — new rows in the tools table, updated path resolution mention
- `README.md` — updated tool count (50+ → 60+)
- `internal/cli/mcp.go` — new tool sections, workflow examples, and conventions in both `claudeSkillContent` (SKILL.md) and `junieGuidelinesSection` (guidelines.md)