### PR TITLE
chore: release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.3.3] — 2026-04-02
+
+### Fixed
+
+- **Broadcasting jobs fail when `lerd env` was run on a Reverb site** — `REVERB_HOST` was set to the site domain (e.g. `score-diviner.test`), which resolves inside the PHP-FPM container to `host.containers.internal` (169.254.1.2). That address — the nginx proxy on the host — is not reachable from inside the container's network namespace, so every broadcast job failed with cURL error 7. `REVERB_HOST`, `REVERB_PORT`, and `REVERB_SCHEME` are now always written as `localhost`, `REVERB_SERVER_PORT`, and `http` so the queue worker connects to Reverb directly inside the same container. `VITE_REVERB_HOST/PORT/SCHEME` continue to use the site domain and external port for browser connections through nginx. Sites affected can be fixed by re-running `lerd env`.
+- **Log lines repeating on SSE reconnect** — when the browser reconnected to a log stream (network blip, tab restore) the entire history was replayed from the start. For systemd units the stream now emits the journalctl cursor as the SSE event id and resumes with `--after-cursor` on reconnect; for Podman containers a monotonic line counter is used and `--tail 0` skips history on reconnect.
+
+---
+
 ## [1.3.2] — 2026-04-01
 
 ### Fixed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,15 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.3.3] — 2026-04-02
+
+### Fixed
+
+- **Broadcasting jobs fail when `lerd env` was run on a Reverb site** — `REVERB_HOST` was set to the site domain (e.g. `score-diviner.test`), which resolves inside the PHP-FPM container to `host.containers.internal` (169.254.1.2). That address — the nginx proxy on the host — is not reachable from inside the container's network namespace, so every broadcast job failed with cURL error 7. `REVERB_HOST`, `REVERB_PORT`, and `REVERB_SCHEME` are now always written as `localhost`, `REVERB_SERVER_PORT`, and `http` so the queue worker connects to Reverb directly inside the same container. `VITE_REVERB_HOST/PORT/SCHEME` continue to use the site domain and external port for browser connections through nginx. Sites affected can be fixed by re-running `lerd env`.
+- **Log lines repeating on SSE reconnect** — when the browser reconnected to a log stream (network blip, tab restore) the entire history was replayed from the start. For systemd units the stream now emits the journalctl cursor as the SSE event id and resumes with `--after-cursor` on reconnect; for Podman containers a monotonic line counter is used and `--tail 0` skips history on reconnect.
+
+---
+
 ## [1.3.2] — 2026-04-01
 
 ### Fixed

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.3.2"
+	Version = "1.3.3"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## [1.3.3] — 2026-04-02

### Fixed

- **Broadcasting jobs fail when `lerd env` was run on a Reverb site** — `REVERB_HOST` was set to the site domain, which resolves inside the container to `host.containers.internal` — not reachable from inside the container's network namespace. Every broadcast job failed with cURL error 7. `REVERB_HOST/PORT/SCHEME` are now written as `localhost:REVERB_SERVER_PORT` over HTTP for direct in-container connection; `VITE_REVERB_*` continue to use the external domain/port for the browser. #56
- **Log lines repeating on SSE reconnect** — entire log history was replayed on every browser reconnect. Systemd streams now emit the journalctl cursor as the SSE event id and resume with `--after-cursor`; Podman streams use a monotonic counter and `--tail 0` on reconnect. #54