### PR TITLE
fix: pull pre-built PHP base images anonymously

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -103,6 +103,11 @@ lerd status   # quick health snapshot of all running services
 
     After installing the package, run `lerd install` again to register the CA.
 
+??? bug "PHP image build is slow on first run"
+    lerd normally pulls a pre-built base image from ghcr.io and finishes in ~30 seconds. If you see it fall back to a local build instead, the most common cause is being logged into ghcr.io with expired or unrelated credentials — the registry rejects the authenticated request even though the image is public.
+
+    lerd handles this automatically since v1.3.4 by always pulling anonymously. If you are on an older version, running `podman logout ghcr.io` before the build will fix it.
+
 ??? bug "Error: NetworkUpdate is not supported for backend CNI: invalid argument"
     Your system is likely configured to use the older CNI backend, which lacks support for the requested network operation. Edit or create the Podman configuration file at `/etc/containers/containers.conf` and add or modify the `network_backend` setting to `netavark`:
 

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -85,6 +85,8 @@ lerd ships pre-built PHP-FPM base images on ghcr.io for all supported versions (
 
 The base image tag is derived from the embedded Containerfile, so lerd always pulls the exact image that matches the version of lerd you have installed. If the pull fails (no internet, image not yet published) lerd falls back to a full local build transparently.
 
+The images are public, so no ghcr.io login is required. lerd pulls them anonymously even if you are already logged into ghcr.io, to avoid authentication errors from expired or unrelated credentials.
+
 To build entirely from source instead:
 
 ```bash

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -138,7 +138,25 @@ func tryPullBaseImage(version string, w io.Writer) string {
 	short := strings.ReplaceAll(version, ".", "")
 	ref := fmt.Sprintf("ghcr.io/geodro/lerd-php%s-fpm-base:%s", short, hash)
 	fmt.Fprintf(w, "  Pulling pre-built PHP %s base image...\n", version)
-	cmd := exec.Command("podman", "pull", ref)
+
+	// Use an empty auth file so the pull is always anonymous, regardless of
+	// whether the user is logged into ghcr.io. A logged-in account with
+	// expired or mismatched credentials would otherwise cause a 401 for this
+	// public image and force a slow local build.
+	tmpAuth, err := os.CreateTemp("", "lerd-auth-*.json")
+	if err == nil {
+		tmpAuth.WriteString("{}")
+		tmpAuth.Close()
+		defer os.Remove(tmpAuth.Name())
+	}
+
+	args := []string{"pull"}
+	if tmpAuth != nil {
+		args = append(args, "--authfile="+tmpAuth.Name())
+	}
+	args = append(args, ref)
+
+	cmd := exec.Command("podman", args...)
 	cmd.Stdout = w
 	cmd.Stderr = io.Discard
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
When a user is logged into ghcr.io with expired or unrelated credentials, podman sends those credentials on the pull request and the registry returns a 401, even though the lerd base images are public. This causes lerd to fall back to a full local build, which takes ~5 minutes instead of ~30 seconds.

The fix writes a temporary empty auth file and passes it via `--authfile` on the specific podman pull for lerd images, forcing an anonymous pull without affecting the user's existing login state for other registries.

Reported in geodro/lerd#1.