### PR TITLE
fix: restore 3-pane UI lost during merge conflict resolution

### DIFF
--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -45,1819 +45,1404 @@
     .dark ::-webkit-scrollbar-thumb { background: #333; }
     ::-webkit-scrollbar-thumb:hover { background: #aaa; }
     .dark ::-webkit-scrollbar-thumb:hover { background: #444; }
+    /* Keep detail area always visible on desktop regardless of Alpine x-show state */
+    @media (min-width: 768px) { .detail-area { display: flex !important; } }
   </style>
 </head>
-<body class="bg-gray-50 dark:bg-lerd-bg text-gray-900 dark:text-gray-100 min-h-screen font-sans antialiased" x-data="lerdApp()" x-init="init()" x-cloak>
+<body class="bg-gray-50 dark:bg-lerd-bg text-gray-900 dark:text-gray-100 h-screen overflow-hidden flex font-sans antialiased" x-data="lerdApp()" x-init="init()" x-cloak>
 
-  <!-- Top Navbar -->
-  <nav class="border-b border-gray-200 dark:border-lerd-border bg-white/95 dark:bg-lerd-bg/95 backdrop-blur sticky top-0 z-40">
-    <div class="max-w-7xl mx-auto px-3 sm:px-6">
-      <div class="flex flex-wrap items-center justify-between gap-y-1 py-2 sm:flex-nowrap sm:h-14 sm:py-0">
+  <!-- ════════════════════════════════════════════
+       LEFT ICON RAIL  (desktop only)
+  ════════════════════════════════════════════ -->
+  <aside class="hidden md:flex flex-col items-center w-14 shrink-0 bg-white dark:bg-lerd-card border-r border-gray-200 dark:border-lerd-border py-3 z-20">
+    <!-- Logo -->
+    <div class="mb-4 flex items-center justify-center">
+      <img src="/icons/icon.svg" class="w-7 h-7 rounded-lg" alt="Lerd">
+    </div>
 
-        <!-- Logo + version -->
-        <div class="flex items-center gap-2.5 order-1">
-          <img src="/icons/icon.svg" class="w-7 h-7 rounded-lg" alt="Lerd">
-          <span class="font-bold text-gray-900 dark:text-white tracking-tight text-lg">Lerd</span>
-          <span class="text-xs text-gray-400 dark:text-gray-600 font-mono" x-text="'v' + version.current"></span>
-        </div>
+    <!-- Nav icons -->
+    <div class="flex flex-col gap-1">
+      <button @click="setTab('sites')" title="Sites"
+        class="w-10 h-10 rounded-xl flex items-center justify-center transition-colors"
+        :class="tab==='sites' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-white/5 hover:text-gray-700 dark:hover:text-gray-300'">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg>
+      </button>
+      <button @click="setTab('services')" title="Services"
+        class="w-10 h-10 rounded-xl flex items-center justify-center transition-colors"
+        :class="tab==='services' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-white/5 hover:text-gray-700 dark:hover:text-gray-300'">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/></svg>
+      </button>
+      <button @click="setTab('system')" title="System"
+        class="w-10 h-10 rounded-xl flex items-center justify-center transition-colors"
+        :class="tab==='system' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-white/5 hover:text-gray-700 dark:hover:text-gray-300'">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+      </button>
+    </div>
 
-        <!-- Nav tabs -->
-        <div class="flex items-center order-3 w-full sm:w-auto sm:order-2 border-t border-gray-100 dark:border-lerd-border sm:border-0 pt-1 sm:pt-0">
-          <button
-            @click="setTab('sites')"
-            :class="tab === 'sites' ? 'text-gray-900 dark:text-white bg-gray-100 dark:bg-white/10' : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5'"
-            class="flex-1 sm:flex-none text-center sm:text-left px-3 py-1.5 rounded-md text-sm font-medium transition-colors"
-          >Sites</button>
-          <button
-            @click="setTab('services')"
-            :class="tab === 'services' ? 'text-gray-900 dark:text-white bg-gray-100 dark:bg-white/10' : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5'"
-            class="flex-1 sm:flex-none text-center sm:text-left px-3 py-1.5 rounded-md text-sm font-medium transition-colors"
-          >Services</button>
-          <button
-            @click="setTab('system')"
-            :class="tab === 'system' ? 'text-gray-900 dark:text-white bg-gray-100 dark:bg-white/10' : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5'"
-            class="flex-1 sm:flex-none text-center sm:text-left px-3 py-1.5 rounded-md text-sm font-medium transition-colors"
-          >System</button>
-        </div>
+    <!-- Bottom: theme + docs + version -->
+    <div class="mt-auto flex flex-col items-center gap-2">
+      <a href="https://geodro.github.io/lerd/" target="_blank" rel="noopener" title="Documentation"
+        class="w-10 h-10 rounded-xl flex items-center justify-center text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-white/5 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/></svg>
+      </a>
+      <div class="flex flex-col rounded-md border border-gray-200 dark:border-lerd-border overflow-hidden">
+        <template x-for="m in ['light','auto','dark']" :key="'rail-t-'+m">
+          <button @click="setTheme(m)" :title="m"
+            :class="theme===m ? 'bg-gray-200 dark:bg-white/10 text-gray-900 dark:text-white' : 'text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-white/5'"
+            class="px-2 py-1.5 text-[10px] font-medium transition-colors"
+            x-text="m[0].toUpperCase()"></button>
+        </template>
+      </div>
+      <span class="text-[10px] text-gray-400 dark:text-gray-600 font-mono pb-1" x-text="'v'+version.current"></span>
+    </div>
+  </aside>
 
-        <!-- Right side -->
-        <div class="flex items-center gap-3 order-2 sm:order-3">
-          <!-- Docs link -->
-          <a href="https://geodro.github.io/lerd/" target="_blank" rel="noopener" class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors">Docs</a>
-          <!-- Theme toggle -->
-          <div class="flex items-center rounded-md border border-gray-200 dark:border-lerd-border overflow-hidden text-xs">
-            <template x-for="m in ['light','auto','dark']" :key="m">
-              <button
-                @click="setTheme(m)"
-                :class="theme === m ? 'bg-gray-200 dark:bg-white/10 text-gray-900 dark:text-white' : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
-                class="px-2 sm:px-2.5 py-1 capitalize transition-colors"
-              ><span class="hidden sm:inline" x-text="m"></span><span class="sm:hidden" x-text="m[0].toUpperCase()"></span></button>
-            </template>
-          </div>
+  <!-- ════════════════════════════════════════════
+       MIDDLE LIST PANEL  (desktop only)
+  ════════════════════════════════════════════ -->
+  <div class="hidden md:flex flex-col w-56 lg:w-64 shrink-0 border-r border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card overflow-hidden">
+
+    <!-- Panel header -->
+    <div class="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-lerd-border shrink-0 min-h-[48px]">
+      <div x-show="tab==='sites'" class="flex items-center justify-between w-full">
+        <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Sites</span>
+        <button @click="loadSites()" class="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">Refresh</button>
+      </div>
+      <div x-show="tab==='services'" class="flex items-center w-full">
+        <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Services</span>
+      </div>
+      <div x-show="tab==='system'" class="flex items-center justify-between w-full">
+        <span class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">System</span>
+        <div class="flex items-center gap-0.5">
+          <button x-show="!allCoreRunning" @click="lerdStart()" :disabled="lerdStarting||lerdStopping" title="Start Lerd"
+            class="w-7 h-7 flex items-center justify-center rounded-lg text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 transition-colors disabled:opacity-40">
+            <svg x-show="lerdStarting" class="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
+            <svg x-show="!lerdStarting" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3l14 9-14 9V3z"/></svg>
+          </button>
+          <button @click="lerdStop()" :disabled="lerdStarting||lerdStopping" title="Stop Lerd"
+            class="w-7 h-7 flex items-center justify-center rounded-lg text-gray-500 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors disabled:opacity-40">
+            <svg x-show="lerdStopping" class="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
+            <svg x-show="!lerdStopping" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12" rx="1" stroke-width="2"/></svg>
+          </button>
         </div>
       </div>
     </div>
-  </nav>
 
-  <!-- Page content -->
-  <main class="max-w-7xl mx-auto px-3 sm:px-6 py-6 sm:py-8">
+    <!-- ── Sites list ── -->
+    <div x-show="tab==='sites'" class="flex-1 overflow-y-auto">
+      <div x-show="sitesLoading" class="px-4 py-3 text-xs text-gray-400">Loading...</div>
+      <div x-show="!sitesLoading && sites.length === 0" class="px-4 py-8 text-center space-y-1">
+        <p class="text-xs text-gray-400">No sites yet</p>
+        <p class="text-[11px] text-gray-300 dark:text-gray-600">Run <code class="bg-gray-100 dark:bg-white/5 px-1 rounded">lerd park</code></p>
+      </div>
+      <div x-show="!sitesLoading && sites.length > 0">
+        <template x-for="site in sites.filter(s => !s.paused)" :key="site.domain">
+          <button @click="selectSite(site)"
+            class="w-full flex items-center gap-2 px-3 py-2.5 text-left transition-colors border-b border-gray-50 dark:border-lerd-border/50 last:border-0"
+            :class="selectedSiteDomain===site.domain ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+            <span class="w-2 h-2 rounded-full shrink-0" :class="site.fpm_running ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+            <span class="flex-1 text-sm truncate" x-text="site.domain"></span>
+            <svg x-show="site.tls" class="w-3 h-3 shrink-0 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
+            <svg x-show="site.worktrees && site.worktrees.length > 0" class="w-3 h-3 shrink-0 text-violet-400" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M6 3v12M15 6a3 3 0 1 0 6 0a3 3 0 1 0-6 0M3 18a3 3 0 1 0 6 0a3 3 0 1 0-6 0M18 9a9 9 0 0 1-9 9"/></svg>
+            <span x-show="site.queue_running || site.horizon_running" class="w-1.5 h-1.5 rounded-full shrink-0 bg-amber-400"></span>
+            <span x-show="site.stripe_running" class="w-1.5 h-1.5 rounded-full shrink-0 bg-violet-400"></span>
+            <span x-show="site.schedule_running" class="w-1.5 h-1.5 rounded-full shrink-0 bg-emerald-400"></span>
+            <span x-show="site.reverb_running" class="w-1.5 h-1.5 rounded-full shrink-0 bg-sky-400"></span>
+            <template x-for="w in (site.framework_workers||[]).filter(w=>w.running)" :key="'dot-'+w.name">
+              <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-indigo-400"></span>
+            </template>
+          </button>
+        </template>
+        <template x-if="sites.some(s => s.paused)">
+          <div class="border-t border-gray-100 dark:border-lerd-border">
+            <div class="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">Paused</div>
+            <template x-for="site in sites.filter(s => s.paused)" :key="'paused-'+site.domain">
+              <button @click="selectSite(site)"
+                class="w-full flex items-center gap-2 px-3 py-2 text-left transition-colors border-t border-gray-50 dark:border-lerd-border/50"
+                :class="selectedSiteDomain===site.domain ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-400 dark:text-gray-500 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+                <svg class="w-3 h-3 shrink-0 opacity-60" fill="currentColor" viewBox="0 0 24 24"><path d="M6 5h4v14H6zM14 5h4v14h-4z"/></svg>
+                <span class="flex-1 text-sm truncate" x-text="site.domain"></span>
+              </button>
+            </template>
+          </div>
+        </template>
+      </div>
+    </div>
 
-    <!-- ===== SITES TAB ===== -->
-    <div x-show="tab === 'sites'">
-      <div class="flex items-center justify-between mb-6">
-        <div>
-          <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Sites</h2>
-          <p class="text-sm text-gray-500 mt-0.5">Manage your registered sites</p>
+    <!-- ── Services list ── -->
+    <div x-show="tab==='services'" class="flex-1 overflow-y-auto">
+      <div x-show="servicesLoading" class="px-4 py-3 text-xs text-gray-400">Loading...</div>
+      <div x-show="!servicesLoading">
+        <template x-for="svc in coreServices()" :key="svc.name">
+          <button @click="selectService(svc)"
+            class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-50 dark:border-lerd-border/50"
+            :class="selectedSvc===svc.name ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+            <span class="w-2 h-2 rounded-full shrink-0" :class="svc.status==='active' ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+            <span class="font-medium truncate flex-1" x-text="capitalize(svc.name)"></span>
+            <template x-if="svc.depends_on && svc.depends_on.length > 0">
+              <span class="shrink-0 text-gray-300 dark:text-gray-600" title="has dependencies">
+                <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.59 13.51l6.83 3.98M15.41 6.51l-6.82 3.98"/></svg>
+              </span>
+            </template>
+            <template x-if="svc.site_count > 0">
+              <span class="text-[10px] font-medium tabular-nums shrink-0" :class="selectedSvc===svc.name ? 'text-lerd-red/70' : 'text-gray-400 dark:text-gray-600'" x-text="svc.site_count"></span>
+            </template>
+          </button>
+        </template>
+        <template x-for="group in workerGroups()" :key="'grp-'+group.key">
+          <div class="border-t border-gray-100 dark:border-lerd-border">
+            <div class="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500" x-text="group.label"></div>
+            <template x-for="svc in group.items" :key="'grp-item-'+svc.name">
+              <button @click="selectService(svc)"
+                class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left transition-colors border-t border-gray-50 dark:border-lerd-border/50"
+                :class="selectedSvc===svc.name ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+                <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="svc.status==='active' ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+                <span class="font-medium truncate flex-1" x-text="workerSiteName(svc)"></span>
+              </button>
+            </template>
+          </div>
+        </template>
+      </div>
+    </div>
+
+    <!-- ── System list ── -->
+    <div x-show="tab==='system'" class="flex-1 overflow-y-auto">
+      <div x-show="statusLoading" class="px-4 py-3 text-xs text-gray-400">Loading...</div>
+      <div x-show="!statusLoading">
+        <button @click="selectSystem('dns')"
+          class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-50 dark:border-lerd-border/50"
+          :class="selectedSystem==='dns' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+          <span class="w-2 h-2 rounded-full shrink-0" :class="systemStatus.dns && systemStatus.dns.ok ? 'bg-emerald-500' : 'bg-red-500'"></span>
+          <span class="font-medium">DNS</span>
+        </button>
+        <button @click="selectSystem('nginx')"
+          class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-50 dark:border-lerd-border/50"
+          :class="selectedSystem==='nginx' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+          <span class="w-2 h-2 rounded-full shrink-0" :class="systemStatus.nginx && systemStatus.nginx.running ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+          <span class="font-medium">Nginx</span>
+        </button>
+        <button @click="selectSystem('watcher')"
+          class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-50 dark:border-lerd-border/50"
+          :class="selectedSystem==='watcher' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+          <span class="w-2 h-2 rounded-full shrink-0" :class="systemStatus.watcher_running ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+          <span class="font-medium">Watcher</span>
+        </button>
+        <template x-if="phpVersions.length > 0">
+          <div class="px-3 pt-2.5 pb-1 border-t border-gray-100 dark:border-lerd-border">
+            <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">PHP-FPM</span>
+          </div>
+        </template>
+        <template x-for="v in phpVersions" :key="'php-'+v">
+          <button @click="selectSystem('php-'+v)"
+            class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-50 dark:border-lerd-border/50"
+            :class="selectedSystem==='php-'+v ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+            <span class="w-2 h-2 rounded-full shrink-0" :class="fpmRunning(v) ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+            <span class="font-medium flex-1" x-text="'PHP '+v"></span>
+            <template x-if="systemStatus.php_default === v">
+              <span class="text-[10px] font-medium shrink-0" :class="selectedSystem==='php-'+v ? 'text-lerd-red/60' : 'text-gray-400 dark:text-gray-600'">default</span>
+            </template>
+            <template x-if="phpSiteCount(v) > 0">
+              <span class="text-[10px] font-medium tabular-nums shrink-0 ml-1" :class="selectedSystem==='php-'+v ? 'text-lerd-red/70' : 'text-gray-400 dark:text-gray-600'" x-text="phpSiteCount(v)"></span>
+            </template>
+          </button>
+        </template>
+        <div class="px-3 pt-2.5 pb-1 border-t border-gray-100 dark:border-lerd-border">
+          <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Node.js</span>
         </div>
-        <button
-          @click="loadSites()"
-          class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 border border-gray-200 dark:border-lerd-border hover:border-gray-300 dark:hover:border-lerd-muted rounded-md px-3 py-1.5 transition-colors"
-        >Refresh</button>
+        <template x-for="v in nodeVersions" :key="'node-'+v">
+          <button @click="selectSystem('node-'+v)"
+            class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-50 dark:border-lerd-border/50"
+            :class="selectedSystem==='node-'+v ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+            <span class="w-2 h-2 rounded-full shrink-0 bg-gray-300 dark:bg-gray-600"></span>
+            <span class="font-medium flex-1" x-text="'Node '+v"></span>
+            <template x-if="systemStatus.node_default === v">
+              <span class="text-[10px] font-medium shrink-0" :class="selectedSystem==='node-'+v ? 'text-lerd-red/60' : 'text-gray-400 dark:text-gray-600'">default</span>
+            </template>
+            <template x-if="nodeSiteCount(v) > 0">
+              <span class="text-[10px] font-medium tabular-nums shrink-0 ml-1" :class="selectedSystem==='node-'+v ? 'text-lerd-red/70' : 'text-gray-400 dark:text-gray-600'" x-text="nodeSiteCount(v)"></span>
+            </template>
+          </button>
+        </template>
+        <button @click="selectSystem('node-install')"
+          class="w-full flex items-center gap-2 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-50 dark:border-lerd-border/50"
+          :class="selectedSystem==='node-install' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-400 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+          <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4"/></svg>
+          <span class="font-medium">Install version</span>
+        </button>
+        <button @click="selectSystem('autostart')"
+          class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-t border-gray-100 dark:border-lerd-border"
+          :class="selectedSystem==='autostart' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+          <span class="w-2 h-2 rounded-full shrink-0" :class="autostartEnabled ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+          <span class="font-medium">Autostart</span>
+        </button>
+        <button @click="selectSystem('lerd')"
+          class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-t border-gray-100 dark:border-lerd-border"
+          :class="selectedSystem==='lerd' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+          <span class="w-2 h-2 rounded-full shrink-0" :class="version.hasUpdate ? 'bg-yellow-400' : 'bg-gray-300 dark:bg-gray-600'"></span>
+          <span class="font-medium flex-1">Lerd</span>
+          <span x-show="version.hasUpdate" class="ml-auto text-xs font-medium text-yellow-600 dark:text-yellow-400">update</span>
+        </button>
+      </div>
+    </div>
+
+  </div><!-- end middle list panel -->
+
+  <!-- ════════════════════════════════════════════
+       MAIN CONTENT AREA
+  ════════════════════════════════════════════ -->
+  <main class="flex-1 min-w-0 flex flex-col overflow-hidden bg-gray-50 dark:bg-lerd-bg">
+
+    <!-- ── Mobile list (hidden on desktop, visible on mobile when !mobileShowDetail) ── -->
+    <div class="md:hidden flex-1 overflow-y-auto bg-white dark:bg-lerd-card pb-16" x-show="!mobileShowDetail">
+
+      <!-- Mobile header -->
+      <div class="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-lerd-border sticky top-0 bg-white dark:bg-lerd-card z-10">
+        <div class="flex items-center gap-2">
+          <img src="/icons/icon.svg" class="w-6 h-6 rounded-md" alt="Lerd">
+          <span class="font-semibold text-sm text-gray-900 dark:text-white">Lerd</span>
+          <span class="text-xs text-gray-400 dark:text-gray-600 font-mono" x-text="'v'+version.current"></span>
+        </div>
+        <div class="flex items-center rounded-md border border-gray-200 dark:border-lerd-border overflow-hidden text-xs">
+          <template x-for="m in ['light','auto','dark']" :key="'mob-t-'+m">
+            <button @click="setTheme(m)"
+              :class="theme===m ? 'bg-gray-200 dark:bg-white/10 text-gray-900 dark:text-white' : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
+              class="px-2 py-1 capitalize transition-colors"
+              x-text="m[0].toUpperCase()"></button>
+          </template>
+        </div>
       </div>
 
-      <template x-if="sitesLoading">
-        <div class="text-sm text-gray-400">Loading sites...</div>
-      </template>
-
-      <template x-if="!sitesLoading && sites.length === 0">
-        <div class="border border-gray-200 dark:border-lerd-border rounded-xl p-8 sm:p-12 text-center">
-          <div class="w-12 h-12 rounded-full bg-gray-100 dark:bg-lerd-card border border-gray-200 dark:border-lerd-border flex items-center justify-center mx-auto mb-4">
-            <svg class="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064"/></svg>
-          </div>
+      <!-- Mobile sites list -->
+      <div x-show="tab==='sites'">
+        <div x-show="sitesLoading" class="px-4 py-4 text-sm text-gray-400">Loading...</div>
+        <div x-show="!sitesLoading && sites.length === 0" class="px-4 py-10 text-center">
           <p class="text-sm text-gray-500 mb-1">No sites registered yet</p>
-          <p class="text-xs text-gray-400">Run <code class="bg-gray-100 dark:bg-lerd-card border border-gray-200 dark:border-lerd-border px-1.5 py-0.5 rounded text-gray-600 dark:text-gray-400">lerd park</code> or <code class="bg-gray-100 dark:bg-lerd-card border border-gray-200 dark:border-lerd-border px-1.5 py-0.5 rounded text-gray-600 dark:text-gray-400">lerd link</code> to add sites</p>
+          <p class="text-xs text-gray-400">Run <code class="bg-gray-100 dark:bg-lerd-card border border-gray-200 dark:border-lerd-border px-1.5 py-0.5 rounded">lerd park</code> or <code class="bg-gray-100 dark:bg-lerd-card border border-gray-200 dark:border-lerd-border px-1.5 py-0.5 rounded">lerd link</code></p>
         </div>
-      </template>
-
-      <template x-if="!sitesLoading && sites.length > 0">
-        <div class="flex flex-col sm:flex-row gap-4 sm:items-start">
-
-          <!-- Mobile: horizontal site picker -->
-          <div class="sm:hidden w-full flex overflow-x-auto gap-2 pb-2 -mx-3 px-3">
-            <template x-for="site in sites" :key="'pill-'+site.domain">
-              <button
-                @click="selectSite(site)"
-                class="flex-none flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium whitespace-nowrap transition-colors"
-                :class="selectedSiteDomain === site.domain
-                  ? 'bg-lerd-red/10 border-lerd-red/30 text-lerd-red'
-                  : site.paused
-                    ? 'bg-white dark:bg-lerd-card border-amber-200 dark:border-amber-900/50 text-amber-500 dark:text-amber-400'
-                    : 'bg-white dark:bg-lerd-card border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400'"
-              >
-                <template x-if="site.paused">
-                  <svg class="w-2.5 h-2.5 shrink-0" fill="currentColor" viewBox="0 0 24 24"><path d="M6 5h4v14H6zM14 5h4v14h-4z"/></svg>
-                </template>
-                <template x-if="!site.paused">
-                  <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="site.fpm_running ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                </template>
-                <span x-text="site.domain"></span>
-              </button>
-            </template>
-          </div>
-
-          <!-- Left: site list (desktop only) -->
-          <div class="hidden sm:block sm:w-64 sm:shrink-0 bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border overflow-hidden">
-            <!-- Active sites -->
-            <template x-for="site in sites.filter(s => !s.paused)" :key="site.domain">
-              <button
-                @click="selectSite(site)"
-                class="w-full flex items-center gap-2.5 px-4 py-3 text-left transition-colors border-b border-gray-100 dark:border-lerd-border last:border-0"
-                :class="selectedSiteDomain === site.domain
-                  ? 'bg-lerd-red/10 text-lerd-red'
-                  : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'"
-              >
-                <span class="w-2 h-2 rounded-full shrink-0"
-                  :class="site.fpm_running ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                <span class="flex-1 text-sm font-medium truncate" x-text="site.domain"></span>
-                <svg x-show="site.tls" class="w-3.5 h-3.5 shrink-0 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
-                </svg>
-                <svg x-show="site.worktrees && site.worktrees.length > 0" class="w-3.5 h-3.5 shrink-0 text-violet-400" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
-                  <path d="M6 3v12M15 6a3 3 0 1 0 6 0a3 3 0 1 0-6 0M3 18a3 3 0 1 0 6 0a3 3 0 1 0-6 0M18 9a9 9 0 0 1-9 9"/>
-                </svg>
-                <span x-show="site.queue_running || site.horizon_running" class="w-2 h-2 rounded-full shrink-0 bg-amber-400" :title="site.horizon_running ? 'Horizon running' : 'Queue running'"></span>
-                <span x-show="site.stripe_running" class="w-2 h-2 rounded-full shrink-0 bg-violet-400" title="Stripe listener running"></span>
-                <span x-show="site.schedule_running" class="w-2 h-2 rounded-full shrink-0 bg-emerald-400" title="Scheduler running"></span>
-                <span x-show="site.reverb_running" class="w-2 h-2 rounded-full shrink-0 bg-sky-400" title="Reverb running"></span>
-                <template x-for="w in (site.framework_workers || []).filter(w => w.running)" :key="'dot-' + w.name">
-                  <span class="w-2 h-2 rounded-full shrink-0 bg-indigo-400" :title="w.label + ' running'"></span>
-                </template>
-              </button>
-            </template>
-            <!-- Paused sites collapsible section -->
-            <template x-if="sites.some(s => s.paused)">
-              <div class="border-t border-gray-100 dark:border-lerd-border">
-                <button
-                  @click="pausedSectionOpen = !pausedSectionOpen"
-                  class="w-full flex items-center gap-2 px-4 py-2.5 text-left text-xs font-medium text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                >
-                  <svg class="w-3 h-3 shrink-0 transition-transform" :class="pausedSectionOpen ? 'rotate-90' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
-                  <span>Paused</span>
-                  <span class="ml-auto bg-gray-100 dark:bg-lerd-border text-gray-500 dark:text-gray-400 rounded-full px-1.5 py-0.5 text-[10px] font-medium" x-text="sites.filter(s => s.paused).length"></span>
-                </button>
-                <template x-if="pausedSectionOpen">
-                  <div>
-                    <template x-for="site in sites.filter(s => s.paused)" :key="'paused-'+site.domain">
-                      <button
-                        @click="selectSite(site)"
-                        class="w-full flex items-center gap-2.5 px-4 py-2.5 text-left transition-colors border-t border-gray-100 dark:border-lerd-border"
-                        :class="selectedSiteDomain === site.domain
-                          ? 'bg-lerd-red/10 text-lerd-red'
-                          : 'text-gray-400 dark:text-gray-500 hover:bg-gray-50 dark:hover:bg-white/[0.03]'"
-                      >
-                        <svg class="w-3 h-3 shrink-0 opacity-60" fill="currentColor" viewBox="0 0 24 24"><path d="M6 5h4v14H6zM14 5h4v14h-4z"/></svg>
-                        <span class="flex-1 text-sm truncate" x-text="site.domain"></span>
-                      </button>
-                    </template>
-                  </div>
-                </template>
-              </div>
-            </template>
-          </div>
-
-          <!-- Right: detail panel -->
-          <div class="flex-1 min-w-0">
-            <template x-if="!selectedSite">
-              <div class="border border-gray-200 dark:border-lerd-border rounded-xl p-10 text-center text-sm text-gray-400">
-                Select a site to view details
-              </div>
-            </template>
-
-            <template x-if="selectedSite">
-              <div class="bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border overflow-hidden">
-
-                <!-- Header -->
-                <div class="px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
-                  <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4">
-                    <div>
-                      <div class="flex items-center gap-2 flex-wrap">
-                        <a
-                          :href="(selectedSite.tls ? 'https://' : 'http://') + selectedSite.domain"
-                          @click.prevent="openSite(selectedSite)"
-                          class="font-semibold text-lerd-red hover:text-lerd-redhov transition-colors"
-                          x-text="selectedSite.domain"
-                        ></a>
-                        <template x-if="!selectedSite.paused && selectedSite.fpm_running">
-                          <span class="inline-flex items-center gap-1 text-xs font-medium text-emerald-600 dark:text-emerald-500 bg-emerald-50 dark:bg-emerald-900/20 px-2 py-0.5 rounded-full">
-                            <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>running
-                          </span>
-                        </template>
-                        <template x-if="!selectedSite.paused && !selectedSite.fpm_running">
-                          <span class="inline-flex items-center gap-1 text-xs font-medium text-red-500 bg-red-50 dark:bg-red-900/20 px-2 py-0.5 rounded-full">
-                            <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>stopped
-                          </span>
-                        </template>
-                        <template x-if="selectedSite.framework_label">
-                          <span class="inline-flex items-center text-xs font-medium text-lerd-red bg-red-50 dark:bg-red-900/20 px-2 py-0.5 rounded-full" x-text="selectedSite.framework_label"></span>
-                        </template>
-                        <template x-if="selectedSite.paused">
-                          <span class="inline-flex items-center gap-1 text-xs font-medium text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 px-2 py-0.5 rounded-full">
-                            <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M6 5h4v14H6zM14 5h4v14h-4z"/></svg>
-                            paused
-                          </span>
-                        </template>
-                      </div>
-                      <div class="text-xs text-gray-400 font-mono mt-1 flex items-center gap-2">
-                        <span x-text="selectedSite.path"></span>
-                        <template x-if="selectedSite.branch">
-                          <span class="text-violet-500 dark:text-violet-400 shrink-0">git:(<span x-text="selectedSite.branch"></span>)</span>
-                        </template>
-                      </div>
-                    </div>
-                    <div class="flex items-center gap-2 shrink-0">
-                      <button
-                        @click="selectedSite.paused ? resumeSite(selectedSite) : pauseSite(selectedSite)"
-                        :disabled="selectedSite.pauseLoading"
-                        class="text-xs border rounded px-2 py-1 transition-colors disabled:opacity-50"
-                        :class="selectedSite.paused
-                          ? 'border-emerald-300 dark:border-emerald-700 text-emerald-600 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20'
-                          : 'border-amber-300 dark:border-amber-700 text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20'"
-                      >
-                        <span x-show="!selectedSite.pauseLoading" x-text="selectedSite.paused ? 'Resume' : 'Pause'"></span>
-                        <span x-show="selectedSite.pauseLoading">...</span>
-                      </button>
-                      <button
-                        @click="unlinkSite(selectedSite)"
-                        :disabled="selectedSite.unlinkLoading"
-                        class="text-xs border border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded px-2 py-1 transition-colors disabled:opacity-50"
-                      >
-                        <span x-show="!selectedSite.unlinkLoading">Unlink</span>
-                        <span x-show="selectedSite.unlinkLoading">...</span>
-                      </button>
-                      <button
-                        @click="openSite(selectedSite)"
-                        class="flex items-center gap-1.5 text-xs border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-white/5 rounded px-2 py-1 transition-colors"
-                        title="Open in browser"
-                      >
-                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
-                        Open
-                      </button>
-                      <button
-                        @click="openTerminal(selectedSite)"
-                        class="flex items-center gap-1.5 text-xs border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-white/5 rounded px-2 py-1 transition-colors"
-                        title="Open in terminal"
-                      >
-                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
-                        Terminal
-                      </button>
-                    </div>
-                  </div>
-                </div>
-
-                <!-- Controls -->
-                <div class="px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border flex flex-wrap gap-x-6 gap-y-4">
-
-                  <!-- PHP version -->
-                  <div>
-                    <div class="text-[10px] font-medium text-gray-400 uppercase tracking-wider mb-1.5">PHP</div>
-                    <select
-                      x-model="selectedSite.php_version"
-                      @change="setSiteVersion(selectedSite, 'php', selectedSite.php_version)"
-                      class="w-full text-xs bg-white dark:bg-lerd-card border border-gray-200 dark:border-lerd-border rounded px-2 py-1.5 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors"
-                      :disabled="selectedSite.versionLoading"
-                    >
-                      <option value="" disabled>—</option>
-                      <template x-for="v in phpVersions" :key="v">
-                        <option :value="v" x-text="'PHP ' + v"></option>
-                      </template>
-                    </select>
-                  </div>
-
-                  <!-- Node version -->
-                  <div>
-                    <div class="text-[10px] font-medium text-gray-400 uppercase tracking-wider mb-1.5">Node</div>
-                    <select
-                      x-model="selectedSite.node_version"
-                      @change="setSiteVersion(selectedSite, 'node', selectedSite.node_version)"
-                      class="w-full text-xs bg-white dark:bg-lerd-card border border-gray-200 dark:border-lerd-border rounded px-2 py-1.5 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors"
-                      :disabled="selectedSite.versionLoading"
-                    >
-                      <option value="">Default</option>
-                      <template x-for="v in nodeVersions" :key="v">
-                        <option :value="v" x-text="'Node ' + v"></option>
-                      </template>
-                    </select>
-                  </div>
-
-                  <!-- HTTPS -->
-                  <div>
-                    <div class="text-[10px] font-medium text-gray-400 uppercase tracking-wider mb-1.5">HTTPS</div>
-                    <div class="flex flex-col items-start gap-1">
-                      <button
-                        @click="toggleTLS(selectedSite)"
-                        :disabled="selectedSite.tlsLoading"
-                        :title="selectedSite.tls ? 'Disable HTTPS' : 'Enable HTTPS'"
-                        class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
-                        :class="selectedSite.tls ? 'bg-lerd-red' : 'bg-gray-300 dark:bg-lerd-muted'"
-                      >
-                        <span
-                          class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform duration-200"
-                          :class="selectedSite.tls ? 'translate-x-4' : 'translate-x-1'"
-                        ></span>
-                        <svg x-show="selectedSite.tlsLoading" class="animate-spin absolute right-[-18px] w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24">
-                          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
-                        </svg>
-                      </button>
-                      <div x-show="selectedSite.tlsError" class="text-[10px] text-red-500" x-text="selectedSite.tlsError"></div>
-                    </div>
-                  </div>
-
-                  <!-- Queue -->
-                  <div x-show="selectedSite.has_queue_worker">
-                    <div class="text-[10px] font-medium text-gray-400 uppercase tracking-wider mb-1.5">Queue</div>
-                    <div class="flex flex-col items-start gap-1">
-                      <div class="flex items-center gap-2">
-                        <button
-                          @click="toggleQueue(selectedSite)"
-                          :disabled="selectedSite.queueLoading"
-                          :title="selectedSite.queue_running ? 'Stop queue worker' : 'Start queue worker'"
-                          class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
-                          :class="selectedSite.queue_running ? 'bg-amber-500' : 'bg-gray-300 dark:bg-lerd-muted'"
-                        >
-                          <span
-                            class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform duration-200"
-                            :class="selectedSite.queue_running ? 'translate-x-4' : 'translate-x-1'"
-                          ></span>
-                          <svg x-show="selectedSite.queueLoading" class="animate-spin absolute right-[-18px] w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
-                          </svg>
-                        </button>
-                      </div>
-                      <div x-show="selectedSite.queueError" class="text-[10px] text-red-500" x-text="selectedSite.queueError"></div>
-                    </div>
-                  </div>
-
-                  <!-- Horizon (replaces Queue when laravel/horizon is installed) -->
-                  <div x-show="selectedSite.has_horizon">
-                    <div class="text-[10px] font-medium text-gray-400 uppercase tracking-wider mb-1.5">Horizon</div>
-                    <div class="flex flex-col items-start gap-1">
-                      <div class="flex items-center gap-2">
-                        <button
-                          @click="toggleHorizon(selectedSite)"
-                          :disabled="selectedSite.horizonLoading"
-                          :title="selectedSite.horizon_running ? 'Stop Horizon' : 'Start Horizon'"
-                          class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
-                          :class="selectedSite.horizon_running ? 'bg-amber-500' : 'bg-gray-300 dark:bg-lerd-muted'"
-                        >
-                          <span
-                            class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform duration-200"
-                            :class="selectedSite.horizon_running ? 'translate-x-4' : 'translate-x-1'"
-                          ></span>
-                          <svg x-show="selectedSite.horizonLoading" class="animate-spin absolute right-[-18px] w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
-                          </svg>
-                        </button>
-                      </div>
-                      <div x-show="selectedSite.horizonError" class="text-[10px] text-red-500" x-text="selectedSite.horizonError"></div>
-                    </div>
-                  </div>
-
-                  <!-- Stripe -->
-                  <div x-show="selectedSite.stripe_secret_set">
-                    <div class="text-[10px] font-medium text-gray-400 uppercase tracking-wider mb-1.5">Stripe</div>
-                    <div class="flex flex-col items-start gap-1">
-                      <div class="flex items-center gap-2">
-                        <button
-                          @click="toggleStripe(selectedSite)"
-                          :disabled="selectedSite.stripeLoading"
-                          :title="selectedSite.stripe_running ? 'Stop Stripe listener' : 'Start Stripe webhook listener'"
-                          class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
-                          :class="selectedSite.stripe_running ? 'bg-violet-500' : 'bg-gray-300 dark:bg-lerd-muted'"
-                        >
-                          <span
-                            class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform duration-200"
-                            :class="selectedSite.stripe_running ? 'translate-x-4' : 'translate-x-1'"
-                          ></span>
-                          <svg x-show="selectedSite.stripeLoading" class="animate-spin absolute right-[-18px] w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
-                          </svg>
-                        </button>
-                      </div>
-                      <div x-show="selectedSite.stripeError" class="text-[10px] text-red-500" x-text="selectedSite.stripeError"></div>
-                    </div>
-                  </div>
-
-                  <!-- Schedule -->
-                  <div x-show="selectedSite.has_schedule_worker">
-                    <div class="text-[10px] font-medium text-gray-400 uppercase tracking-wider mb-1.5">Schedule</div>
-                    <div class="flex flex-col items-start gap-1">
-                      <div class="flex items-center gap-2">
-                        <button
-                          @click="toggleSchedule(selectedSite)"
-                          :disabled="selectedSite.scheduleLoading"
-                          :title="selectedSite.schedule_running ? 'Stop scheduler' : 'Start scheduler'"
-                          class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
-                          :class="selectedSite.schedule_running ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-lerd-muted'"
-                        >
-                          <span
-                            class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform duration-200"
-                            :class="selectedSite.schedule_running ? 'translate-x-4' : 'translate-x-1'"
-                          ></span>
-                          <svg x-show="selectedSite.scheduleLoading" class="animate-spin absolute right-[-18px] w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
-                          </svg>
-                        </button>
-                      </div>
-                      <div x-show="selectedSite.scheduleError" class="text-[10px] text-red-500" x-text="selectedSite.scheduleError"></div>
-                    </div>
-                  </div>
-
-                  <!-- Reverb -->
-                  <div x-show="selectedSite.has_reverb">
-                    <div class="text-[10px] font-medium text-gray-400 uppercase tracking-wider mb-1.5">Reverb</div>
-                    <div class="flex flex-col items-start gap-1">
-                      <div class="flex items-center gap-2">
-                        <button
-                          @click="toggleReverb(selectedSite)"
-                          :disabled="selectedSite.reverbLoading"
-                          :title="selectedSite.reverb_running ? 'Stop Reverb' : 'Start Reverb WebSocket server'"
-                          class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
-                          :class="selectedSite.reverb_running ? 'bg-sky-500' : 'bg-gray-300 dark:bg-lerd-muted'"
-                        >
-                          <span
-                            class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform duration-200"
-                            :class="selectedSite.reverb_running ? 'translate-x-4' : 'translate-x-1'"
-                          ></span>
-                          <svg x-show="selectedSite.reverbLoading" class="animate-spin absolute right-[-18px] w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
-                          </svg>
-                        </button>
-                      </div>
-                      <div x-show="selectedSite.reverbError" class="text-[10px] text-red-500" x-text="selectedSite.reverbError"></div>
-                    </div>
-                  </div>
-
-                  <!-- Custom framework workers -->
-                  <template x-for="worker in (selectedSite.framework_workers || [])" :key="'toggle-' + worker.name">
-                    <div>
-                      <div class="text-[10px] font-medium text-gray-400 uppercase tracking-wider mb-1.5" x-text="worker.label"></div>
-                      <div class="flex flex-col items-start gap-1">
-                        <div class="flex items-center gap-2">
-                          <button
-                            @click="toggleWorker(selectedSite, worker)"
-                            :disabled="worker.loading"
-                            :title="worker.running ? 'Stop ' + worker.label : 'Start ' + worker.label"
-                            class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
-                            :class="worker.running ? 'bg-indigo-500' : 'bg-gray-300 dark:bg-lerd-muted'"
-                          >
-                            <span
-                              class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform duration-200"
-                              :class="worker.running ? 'translate-x-4' : 'translate-x-1'"
-                            ></span>
-                            <svg x-show="worker.loading" class="animate-spin absolute right-[-18px] w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24">
-                              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
-                            </svg>
-                          </button>
-                        </div>
-                        <div x-show="worker.error" class="text-[10px] text-red-500" x-text="worker.error"></div>
-                      </div>
-                    </div>
-                  </template>
-
-                </div>
-
-                <!-- Git Worktrees -->
-                <template x-if="selectedSite.worktrees && selectedSite.worktrees.length > 0">
-                  <div class="px-3 sm:px-5 py-4 border-t border-gray-100 dark:border-lerd-border">
-                    <div class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">Git Worktrees</div>
-                    <div class="flex flex-col">
-                      <!-- Main repo branch (root of tree) -->
-                      <div class="flex items-center gap-1.5 py-1">
-                        <div class="flex items-center shrink-0 text-gray-300 dark:text-gray-600">
-                          <svg class="w-3.5 h-4" viewBox="0 0 14 16" fill="none">
-                            <path d="M2 8 L2 16" stroke="currentColor" stroke-width="1.5"/>
-                          </svg>
-                        </div>
-                        <svg class="w-3.5 h-3.5 shrink-0 text-violet-400" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
-                          <path d="M6 3v12M15 6a3 3 0 1 0 6 0a3 3 0 1 0-6 0M3 18a3 3 0 1 0 6 0a3 3 0 1 0-6 0M18 9a9 9 0 0 1-9 9"/>
-                        </svg>
-                        <span class="text-xs font-mono text-gray-600 dark:text-gray-400 truncate flex-1" x-text="selectedSite.branch || 'main'"></span>
-                        <button
-                          @click="openSite(selectedSite)"
-                          class="shrink-0 flex items-center gap-1 text-[11px] font-medium text-gray-500 dark:text-gray-400 hover:text-lerd-red dark:hover:text-lerd-red border border-gray-200 dark:border-lerd-border hover:border-lerd-red/40 rounded px-1.5 py-0.5 transition-colors"
-                          :title="selectedSite.domain"
-                        >
-                          <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
-                          <span class="font-mono" x-text="selectedSite.domain"></span>
-                        </button>
-                      </div>
-                      <!-- Worktree branches -->
-                      <template x-for="(wt, i) in selectedSite.worktrees" :key="wt.domain">
-                        <div class="flex items-center gap-1.5 py-1">
-                          <!-- tree lines -->
-                          <div class="flex items-center shrink-0 text-gray-300 dark:text-gray-600">
-                            <svg class="w-3.5 h-4" viewBox="0 0 14 16" fill="none">
-                              <path :d="i < selectedSite.worktrees.length - 1 ? 'M2 0 L2 16' : 'M2 0 L2 10'" stroke="currentColor" stroke-width="1.5"/>
-                              <path d="M2 10 L10 10" stroke="currentColor" stroke-width="1.5"/>
-                            </svg>
-                          </div>
-                          <!-- branch icon + name -->
-                          <svg class="w-3.5 h-3.5 shrink-0 text-violet-400" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
-                            <path d="M6 3v12M15 6a3 3 0 1 0 6 0a3 3 0 1 0-6 0M3 18a3 3 0 1 0 6 0a3 3 0 1 0-6 0M18 9a9 9 0 0 1-9 9"/>
-                          </svg>
-                          <span class="text-xs font-mono text-gray-600 dark:text-gray-400 truncate flex-1" x-text="wt.branch"></span>
-                          <!-- open button -->
-                          <button
-                            @click="openWorktree(wt)"
-                            class="shrink-0 flex items-center gap-1 text-[11px] font-medium text-gray-500 dark:text-gray-400 hover:text-lerd-red dark:hover:text-lerd-red border border-gray-200 dark:border-lerd-border hover:border-lerd-red/40 rounded px-1.5 py-0.5 transition-colors"
-                            :title="wt.domain"
-                          >
-                            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
-                            <span class="font-mono" x-text="wt.domain"></span>
-                          </button>
-                        </div>
-                      </template>
-                    </div>
-                  </div>
-                </template>
-
-                <!-- Logs (PHP-FPM + Queue tabs) -->
-                <div class="px-3 sm:px-5 py-4">
-                  <!-- Tab bar -->
-                  <div class="flex items-center gap-0 border-b border-gray-100 dark:border-lerd-border mb-3">
-                    <button
-                      @click="setSiteLogsTab('fpm')"
-                      class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2"
-                      :class="siteLogsTab === 'fpm' ? 'border-lerd-red text-lerd-red' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
-                    >PHP-FPM</button>
-                    <template x-if="selectedSite && selectedSite.queue_running">
-                      <button
-                        @click="setSiteLogsTab('queue')"
-                        class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2"
-                        :class="siteLogsTab === 'queue' ? 'border-amber-500 text-amber-600 dark:text-amber-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
-                      >Queue</button>
-                    </template>
-                    <template x-if="selectedSite && selectedSite.horizon_running">
-                      <button
-                        @click="setSiteLogsTab('horizon')"
-                        class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2"
-                        :class="siteLogsTab === 'horizon' ? 'border-amber-500 text-amber-600 dark:text-amber-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
-                      >Horizon</button>
-                    </template>
-                    <template x-if="selectedSite && selectedSite.stripe_running">
-                      <button
-                        @click="setSiteLogsTab('stripe')"
-                        class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2"
-                        :class="siteLogsTab === 'stripe' ? 'border-violet-500 text-violet-600 dark:text-violet-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
-                      >Stripe</button>
-                    </template>
-                    <template x-if="selectedSite && selectedSite.schedule_running">
-                      <button
-                        @click="setSiteLogsTab('schedule')"
-                        class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2"
-                        :class="siteLogsTab === 'schedule' ? 'border-emerald-500 text-emerald-600 dark:text-emerald-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
-                      >Schedule</button>
-                    </template>
-                    <template x-if="selectedSite && selectedSite.reverb_running">
-                      <button
-                        @click="setSiteLogsTab('reverb')"
-                        class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2"
-                        :class="siteLogsTab === 'reverb' ? 'border-sky-500 text-sky-600 dark:text-sky-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
-                      >Reverb</button>
-                    </template>
-                    <template x-for="worker in (selectedSite && selectedSite.framework_workers || []).filter(w => w.running)" :key="'tab-' + worker.name">
-                      <button
-                        @click="setSiteLogsTab('worker:' + worker.name)"
-                        class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2"
-                        :class="siteLogsTab === 'worker:' + worker.name ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
-                        x-text="worker.label"
-                      ></button>
-                    </template>
-                  </div>
-
-                  <!-- PHP-FPM log content -->
-                  <div x-show="siteLogsTab === 'fpm'">
-                    <div class="flex items-center gap-1 text-[10px] mb-2"
-                      :class="siteLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
-                      <span class="w-1.5 h-1.5 rounded-full"
-                        :class="siteLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                      <span x-text="siteLogs.connected ? 'live' : 'connecting...'"></span>
-                    </div>
-                    <div
-                      x-ref="siteLogScroll"
-                      class="max-h-80 overflow-y-auto rounded-lg bg-gray-50 dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5"
-                    >
-                      <template x-if="siteLogs.lines.length === 0">
-                        <div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div>
-                      </template>
-                      <template x-for="(line, i) in siteLogs.lines" :key="i">
-                        <div
-                          class="whitespace-pre-wrap break-all"
-                          :class="{
-                            'text-red-500':    line.includes('ERROR') || line.includes('Error') || line.includes('PHP Fatal') || line.includes('PHP Warning'),
-                            'text-yellow-600 dark:text-yellow-400': line.includes('WARNING') || line.includes('Warning') || line.includes('PHP Notice'),
-                            'text-gray-600 dark:text-gray-400':   !line.includes('ERROR') && !line.includes('Error') && !line.includes('WARNING') && !line.includes('Warning')
-                          }"
-                          x-text="line"
-                        ></div>
-                      </template>
-                    </div>
-                  </div>
-
-                  <!-- Queue log content -->
-                  <div x-show="siteLogsTab === 'queue'">
-                    <div class="flex items-center gap-1 text-[10px] mb-2"
-                      :class="siteQueueLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
-                      <span class="w-1.5 h-1.5 rounded-full"
-                        :class="siteQueueLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                      <span x-text="siteQueueLogs.connected ? 'live' : 'connecting...'"></span>
-                    </div>
-                    <div
-                      x-ref="siteQueueLogScroll"
-                      class="max-h-80 overflow-y-auto rounded-lg bg-gray-50 dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5"
-                    >
-                      <template x-if="siteQueueLogs.lines.length === 0">
-                        <div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div>
-                      </template>
-                      <template x-for="(line, i) in siteQueueLogs.lines" :key="i">
-                        <div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div>
-                      </template>
-                    </div>
-                  </div>
-
-                  <!-- Horizon log content -->
-                  <div x-show="siteLogsTab === 'horizon'">
-                    <div class="flex items-center gap-1 text-[10px] mb-2"
-                      :class="siteHorizonLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
-                      <span class="w-1.5 h-1.5 rounded-full"
-                        :class="siteHorizonLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                      <span x-text="siteHorizonLogs.connected ? 'live' : 'connecting...'"></span>
-                    </div>
-                    <div
-                      x-ref="siteHorizonLogScroll"
-                      class="max-h-80 overflow-y-auto rounded-lg bg-gray-50 dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5"
-                    >
-                      <template x-if="siteHorizonLogs.lines.length === 0">
-                        <div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div>
-                      </template>
-                      <template x-for="(line, i) in siteHorizonLogs.lines" :key="i">
-                        <div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div>
-                      </template>
-                    </div>
-                  </div>
-
-                  <!-- Stripe log content -->
-                  <div x-show="siteLogsTab === 'stripe'">
-                    <div class="flex items-center gap-1 text-[10px] mb-2"
-                      :class="siteStripeLogs.connected ? 'text-violet-600 dark:text-violet-500' : 'text-gray-400 dark:text-gray-600'">
-                      <span class="w-1.5 h-1.5 rounded-full"
-                        :class="siteStripeLogs.connected ? 'bg-violet-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                      <span x-text="siteStripeLogs.connected ? 'live' : 'connecting...'"></span>
-                    </div>
-                    <div
-                      x-ref="siteStripeLogScroll"
-                      class="max-h-80 overflow-y-auto rounded-lg bg-gray-50 dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5"
-                    >
-                      <template x-if="siteStripeLogs.lines.length === 0">
-                        <div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div>
-                      </template>
-                      <template x-for="(line, i) in siteStripeLogs.lines" :key="i">
-                        <div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div>
-                      </template>
-                    </div>
-                  </div>
-
-                  <!-- Schedule log content -->
-                  <div x-show="siteLogsTab === 'schedule'">
-                    <div class="flex items-center gap-1 text-[10px] mb-2"
-                      :class="siteScheduleLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
-                      <span class="w-1.5 h-1.5 rounded-full"
-                        :class="siteScheduleLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                      <span x-text="siteScheduleLogs.connected ? 'live' : 'connecting...'"></span>
-                    </div>
-                    <div
-                      x-ref="siteScheduleLogScroll"
-                      class="max-h-80 overflow-y-auto rounded-lg bg-gray-50 dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5"
-                    >
-                      <template x-if="siteScheduleLogs.lines.length === 0">
-                        <div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div>
-                      </template>
-                      <template x-for="(line, i) in siteScheduleLogs.lines" :key="i">
-                        <div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div>
-                      </template>
-                    </div>
-                  </div>
-
-                  <!-- Reverb log content -->
-                  <div x-show="siteLogsTab === 'reverb'">
-                    <div class="flex items-center gap-1 text-[10px] mb-2"
-                      :class="siteReverbLogs.connected ? 'text-sky-600 dark:text-sky-500' : 'text-gray-400 dark:text-gray-600'">
-                      <span class="w-1.5 h-1.5 rounded-full"
-                        :class="siteReverbLogs.connected ? 'bg-sky-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                      <span x-text="siteReverbLogs.connected ? 'live' : 'connecting...'"></span>
-                    </div>
-                    <div
-                      x-ref="siteReverbLogScroll"
-                      class="max-h-80 overflow-y-auto rounded-lg bg-gray-50 dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5"
-                    >
-                      <template x-if="siteReverbLogs.lines.length === 0">
-                        <div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div>
-                      </template>
-                      <template x-for="(line, i) in siteReverbLogs.lines" :key="i">
-                        <div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div>
-                      </template>
-                    </div>
-                  </div>
-
-                  <!-- Custom worker log content (shared panel, driven by siteLogsTab) -->
-                  <div x-show="siteLogsTab.startsWith('worker:')">
-                    <div class="flex items-center gap-1 text-[10px] mb-2"
-                      :class="siteWorkerLogs.connected ? 'text-indigo-600 dark:text-indigo-500' : 'text-gray-400 dark:text-gray-600'">
-                      <span class="w-1.5 h-1.5 rounded-full"
-                        :class="siteWorkerLogs.connected ? 'bg-indigo-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                      <span x-text="siteWorkerLogs.connected ? 'live' : 'connecting...'"></span>
-                    </div>
-                    <div
-                      x-ref="siteWorkerLogScroll"
-                      class="max-h-80 overflow-y-auto rounded-lg bg-gray-50 dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5"
-                    >
-                      <template x-if="siteWorkerLogs.lines.length === 0">
-                        <div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div>
-                      </template>
-                      <template x-for="(line, i) in siteWorkerLogs.lines" :key="i">
-                        <div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div>
-                      </template>
-                    </div>
-                  </div>
-                </div>
-
-              </div>
-            </template>
-          </div>
-
-        </div>
-      </template>
-    </div>
-
-    <!-- ===== SERVICES TAB ===== -->
-    <div x-show="tab === 'services'">
-      <div class="flex items-center justify-between mb-6">
-        <div>
-          <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Services</h2>
-          <p class="text-sm text-gray-500 mt-0.5">Databases, caches and other infrastructure</p>
-        </div>
-      </div>
-
-      <template x-if="servicesLoading">
-        <div class="text-sm text-gray-400">Loading services...</div>
-      </template>
-
-      <template x-if="!servicesLoading">
-        <div class="flex flex-col sm:flex-row gap-4 sm:items-start">
-
-          <!-- Mobile: horizontal service picker -->
-          <div class="sm:hidden w-full space-y-1">
-            <!-- Core services pills -->
-            <div class="flex overflow-x-auto gap-2 pb-1 -mx-3 px-3">
-              <template x-for="svc in coreServices()" :key="'pill-'+svc.name">
-                <button
-                  @click="selectService(svc)"
-                  class="flex-none flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium whitespace-nowrap transition-colors"
-                  :class="selectedSvc === svc.name ? 'bg-lerd-red/10 border-lerd-red/30 text-lerd-red' : 'bg-white dark:bg-lerd-card border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400'"
-                >
-                  <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="svc.status === 'active' ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                  <span x-text="capitalize(svc.name)"></span>
-                </button>
-              </template>
-              <!-- Worker group toggle pills -->
-              <template x-for="group in workerGroups()" :key="'grp-pill-'+group.key">
-                <button
-                  @click="toggleWorkerGroup(group.key)"
-                  class="flex-none flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium whitespace-nowrap transition-colors"
-                  :class="openWorkerGroup === group.key ? 'bg-lerd-red/10 border-lerd-red/30 text-lerd-red' : 'bg-white dark:bg-lerd-card border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400'"
-                >
-                  <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="group.items.some(s => s.status === 'active') ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                  <span x-text="group.label"></span>
-                  <span class="tabular-nums" x-text="group.items.length"></span>
-                  <svg class="w-3 h-3 transition-transform" :class="openWorkerGroup === group.key ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7"/></svg>
+        <div x-show="!sitesLoading && sites.length > 0">
+          <template x-for="site in sites.filter(s => !s.paused)" :key="'m-'+site.domain">
+            <button @click="selectSite(site)"
+              class="w-full flex items-center gap-2.5 px-4 py-3.5 text-left transition-colors border-b border-gray-100 dark:border-lerd-border"
+              :class="selectedSiteDomain===site.domain ? 'bg-lerd-red/5' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+              <span class="w-2 h-2 rounded-full shrink-0" :class="site.fpm_running ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+              <span class="flex-1 text-sm font-medium truncate" :class="selectedSiteDomain===site.domain ? 'text-lerd-red' : ''" x-text="site.domain"></span>
+              <span x-show="site.queue_running || site.horizon_running" class="w-2 h-2 rounded-full shrink-0 bg-amber-400"></span>
+              <span x-show="site.stripe_running" class="w-2 h-2 rounded-full shrink-0 bg-violet-400"></span>
+              <span x-show="site.schedule_running" class="w-2 h-2 rounded-full shrink-0 bg-emerald-400"></span>
+              <span x-show="site.reverb_running" class="w-2 h-2 rounded-full shrink-0 bg-sky-400"></span>
+              <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+            </button>
+          </template>
+          <template x-if="sites.some(s => s.paused)">
+            <div class="border-t border-gray-100 dark:border-lerd-border">
+              <div class="px-4 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">Paused</div>
+              <template x-for="site in sites.filter(s => s.paused)" :key="'mp-'+site.domain">
+                <button @click="selectSite(site)"
+                  class="w-full flex items-center gap-2.5 px-4 py-3 text-left transition-colors border-t border-gray-100 dark:border-lerd-border"
+                  :class="selectedSiteDomain===site.domain ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-400 dark:text-gray-500 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+                  <svg class="w-3 h-3 shrink-0 opacity-60" fill="currentColor" viewBox="0 0 24 24"><path d="M6 5h4v14H6zM14 5h4v14h-4z"/></svg>
+                  <span class="flex-1 text-sm truncate" x-text="site.domain"></span>
+                  <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                 </button>
               </template>
             </div>
-            <!-- Expanded worker group sub-pills -->
-            <template x-for="group in workerGroups()" :key="'grp-sub-'+group.key">
-              <div x-show="openWorkerGroup === group.key" class="flex overflow-x-auto gap-2 pb-1 -mx-3 px-3">
-                <template x-for="svc in group.items" :key="'subpill-'+svc.name">
-                  <button
-                    @click="selectService(svc)"
-                    class="flex-none flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium whitespace-nowrap transition-colors"
-                    :class="selectedSvc === svc.name ? 'bg-lerd-red/10 border-lerd-red/30 text-lerd-red' : 'bg-white dark:bg-lerd-card border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400'"
-                  >
-                    <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="svc.status === 'active' ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                    <span x-text="workerSiteName(svc)"></span>
-                  </button>
-                </template>
-              </div>
-            </template>
-          </div>
+          </template>
+        </div>
+      </div>
 
-          <!-- Service list (desktop only) -->
-          <div class="hidden sm:block sm:w-56 sm:shrink-0 bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border overflow-hidden">
-            <!-- Core services -->
-            <template x-for="svc in coreServices()" :key="svc.name">
-              <button
-                @click="selectService(svc)"
-                class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border"
-                :class="selectedSvc === svc.name ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'"
-              >
-                <span class="w-2 h-2 rounded-full shrink-0" :class="svc.status === 'active' ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                <span class="font-medium truncate flex-1" x-text="capitalize(svc.name)"></span>
-                <template x-if="svc.depends_on && svc.depends_on.length > 0">
-                  <span class="shrink-0 text-gray-300 dark:text-gray-600" title="has dependencies">
-                    <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.59 13.51l6.83 3.98M15.41 6.51l-6.82 3.98"/></svg>
-                  </span>
-                </template>
-                <template x-if="svc.site_count > 0">
-                  <span class="text-[10px] font-medium tabular-nums shrink-0"
-                    :class="selectedSvc === svc.name ? 'text-lerd-red/70' : 'text-gray-400 dark:text-gray-600'"
-                    x-text="svc.site_count"></span>
-                </template>
-              </button>
-            </template>
-
-            <!-- Worker group accordions -->
-            <template x-for="group in workerGroups()" :key="'grp-'+group.key">
-              <div class="border-t border-gray-100 dark:border-lerd-border">
-                <!-- Accordion header -->
-                <button
-                  @click="toggleWorkerGroup(group.key)"
-                  class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors"
-                  :class="openWorkerGroup === group.key ? 'bg-gray-50 dark:bg-white/[0.03] text-gray-900 dark:text-white' : 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-white/[0.03]'"
-                >
-                  <span class="w-2 h-2 rounded-full shrink-0" :class="group.items.some(s => s.status === 'active') ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                  <span class="font-medium flex-1" x-text="group.label"></span>
-                  <span class="text-[10px] font-medium tabular-nums text-gray-400 dark:text-gray-600" x-text="group.items.length"></span>
-                  <svg class="w-3.5 h-3.5 shrink-0 transition-transform duration-150" :class="openWorkerGroup === group.key ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7"/></svg>
+      <!-- Mobile services list -->
+      <div x-show="tab==='services'">
+        <div x-show="servicesLoading" class="px-4 py-4 text-sm text-gray-400">Loading...</div>
+        <div x-show="!servicesLoading">
+          <template x-for="svc in coreServices()" :key="'ms-'+svc.name">
+            <button @click="selectService(svc)"
+              class="w-full flex items-center gap-2.5 px-4 py-3.5 text-left transition-colors border-b border-gray-100 dark:border-lerd-border"
+              :class="selectedSvc===svc.name ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+              <span class="w-2 h-2 rounded-full shrink-0" :class="svc.status==='active' ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+              <span class="font-medium flex-1" x-text="capitalize(svc.name)"></span>
+              <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+            </button>
+          </template>
+          <template x-for="group in workerGroups()" :key="'mgrp-'+group.key">
+            <div class="border-t border-gray-100 dark:border-lerd-border">
+              <div class="px-4 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500" x-text="group.label"></div>
+              <template x-for="svc in group.items" :key="'mgi-'+svc.name">
+                <button @click="selectService(svc)"
+                  class="w-full flex items-center gap-2.5 px-4 py-3 text-sm text-left transition-colors border-t border-gray-100 dark:border-lerd-border"
+                  :class="selectedSvc===svc.name ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+                  <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="svc.status==='active' ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+                  <span class="font-medium flex-1 truncate" x-text="workerSiteName(svc)"></span>
+                  <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                 </button>
-                <!-- Accordion items -->
-                <div x-show="openWorkerGroup === group.key">
-                  <template x-for="svc in group.items" :key="'grp-item-'+svc.name">
-                    <button
-                      @click="selectService(svc)"
-                      class="w-full flex items-center gap-2.5 pl-7 pr-3 py-2 text-sm text-left transition-colors border-t border-gray-100 dark:border-lerd-border"
-                      :class="selectedSvc === svc.name ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'"
-                    >
-                      <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="svc.status === 'active' ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                      <span class="font-medium truncate flex-1" x-text="workerSiteName(svc)"></span>
-                    </button>
-                  </template>
-                </div>
-              </div>
-            </template>
-          </div>
-
-          <!-- Detail panel -->
-          <div class="flex-1 min-w-0">
-
-            <!-- Empty state -->
-            <template x-if="!selectedService">
-              <div class="bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border p-10 text-center">
-                <p class="text-sm text-gray-400">Select a service to view details</p>
-              </div>
-            </template>
-
-            <!-- Detail content -->
-            <template x-if="selectedService">
-              <div class="bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border overflow-hidden">
-
-                <!-- Header -->
-                <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
-                  <div class="flex items-center gap-3">
-                    <div>
-                      <div class="flex items-center gap-2">
-                        <span class="font-semibold text-gray-900 dark:text-white text-base"
-                          x-text="selectedService.queue_site ? 'Queue worker' : selectedService.horizon_site ? 'Horizon' : selectedService.stripe_listener_site ? 'Stripe listener' : capitalize(selectedService.name)"></span>
-                        <span
-                          class="inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-full"
-                          :class="selectedService.status === 'active'
-                            ? 'bg-emerald-100 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-500'
-                            : 'bg-gray-100 dark:bg-white/5 text-gray-500'"
-                        >
-                          <span class="w-1.5 h-1.5 rounded-full" :class="selectedService.status === 'active' ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                          <span x-text="selectedService.status"></span>
-                        </span>
-                      </div>
-                      <template x-if="selectedService.queue_site">
-                        <div class="text-xs text-gray-400 mt-0.5" x-text="selectedService.queue_site + '.test'"></div>
-                      </template>
-                      <template x-if="selectedService.horizon_site">
-                        <div class="text-xs text-gray-400 mt-0.5" x-text="selectedService.horizon_site + '.test'"></div>
-                      </template>
-                      <template x-if="selectedService.stripe_listener_site">
-                        <div class="text-xs text-gray-400 mt-0.5" x-text="selectedService.stripe_listener_site + '.test'"></div>
-                      </template>
-                      <template x-if="!selectedService.queue_site && !selectedService.stripe_listener_site && selectedService.site_count > 0">
-                        <div class="text-xs text-gray-400 mt-0.5" x-text="selectedService.site_count + (selectedService.site_count === 1 ? ' site' : ' sites')"></div>
-                      </template>
-                      <template x-if="selectedService.depends_on && selectedService.depends_on.length > 0">
-                        <div class="flex items-center gap-1 flex-wrap mt-1">
-                          <span class="text-xs text-gray-400">depends on:</span>
-                          <template x-for="dep in selectedService.depends_on" :key="dep">
-                            <span class="inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded bg-gray-100 dark:bg-white/5 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border">
-                              <span class="w-1.5 h-1.5 rounded-full shrink-0"
-                                :class="services.find(s => s.name === dep)?.status === 'active' ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                              <span x-text="dep"></span>
-                            </span>
-                          </template>
-                        </div>
-                      </template>
-                    </div>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <!-- Start button (not for queue/stripe/horizon workers) -->
-                    <template x-if="!selectedService.queue_site && !selectedService.horizon_site && !selectedService.stripe_listener_site && selectedService.status !== 'active'">
-                      <button
-                        @click="toggleService(selectedService, 'start')"
-                        :disabled="selectedService.loading"
-                        class="flex items-center gap-1.5 text-xs font-medium bg-lerd-red hover:bg-lerd-redhov text-white rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-                      >
-                        <svg x-show="selectedService.loading" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24">
-                          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
-                        </svg>
-                        <span x-show="!selectedService.loading">Start</span>
-                      </button>
-                    </template>
-                    <template x-if="selectedService.status === 'active'">
-                      <button
-                        @click="toggleService(selectedService, 'stop')"
-                        :disabled="selectedService.loading"
-                        class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-                      >
-                        <svg x-show="selectedService.loading" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24">
-                          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
-                        </svg>
-                        <span x-show="!selectedService.loading">Stop</span>
-                      </button>
-                    </template>
-
-                    <!-- Pin toggle (core + custom services only, not queue/stripe/horizon/schedule/reverb workers) -->
-                    <template x-if="!selectedService.queue_site && !selectedService.horizon_site && !selectedService.stripe_listener_site && !selectedService.schedule_worker_site && !selectedService.reverb_site && !selectedService.worker_site">
-                      <button
-                        @click="toggleServicePin(selectedService)"
-                        :disabled="selectedService.loading"
-                        :title="selectedService.pinned ? 'Unpin — allow auto-stop when unused' : 'Pin — prevent auto-stop when unused'"
-                        class="flex items-center gap-1 text-xs font-medium border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-                        :class="selectedService.pinned
-                          ? 'bg-amber-50 dark:bg-amber-500/10 border-amber-300 dark:border-amber-500/40 text-amber-600 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-500/20'
-                          : 'bg-gray-100 dark:bg-white/5 border-gray-200 dark:border-lerd-border text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-white/10'"
-                      >
-                        <svg x-show="selectedService.pinned" class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 17v5M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1v4.76z"/></svg>
-                        <svg x-show="!selectedService.pinned" class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="17" x2="12" y2="22"/><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1v4.76z"/></svg>
-                        <span x-text="selectedService.pinned ? 'Pinned' : 'Pin'"></span>
-                      </button>
-                    </template>
-
-                    <!-- Delete (custom + inactive only, not queue workers) -->
-                    <template x-if="!selectedService.queue_site && selectedService.custom && selectedService.status !== 'active'">
-                      <button
-                        @click="removeService(selectedService)"
-                        :disabled="selectedService.loading"
-                        class="flex items-center gap-1 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-red-50 dark:hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 hover:border-red-200 dark:hover:border-red-500/30 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-                        title="Remove this custom service"
-                      >
-                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
-                      </button>
-                    </template>
-
-                    <!-- Dashboard link (active only) -->
-                    <template x-if="selectedService.status === 'active' && selectedService.dashboard">
-                      <a
-                        :href="selectedService.dashboard"
-                        target="_blank"
-                        class="flex items-center gap-1 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors"
-                        title="Open dashboard"
-                      >
-                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
-                        Dashboard
-                      </a>
-                    </template>
-                  </div>
-                </div>
-
-                <!-- Flash / error messages -->
-                <div x-show="selectedService.flash" class="mx-5 mt-4 text-xs text-center text-emerald-700 dark:text-emerald-500 bg-emerald-50 dark:bg-emerald-500/10 rounded-lg px-2 py-1.5" x-text="selectedService.flash"></div>
-                <template x-if="selectedService.error">
-                  <div class="mx-5 mt-4 text-xs font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10 rounded-lg px-3 py-1.5" x-text="selectedService.error"></div>
-                </template>
-
-                <!-- Tab bar -->
-                <div class="flex gap-0 border-b border-gray-100 dark:border-lerd-border mt-4 px-3 sm:px-5">
-                  <button
-                    @click="svcDetailTab = 'logs'"
-                    class="pb-2 mr-5 text-sm font-medium transition-colors border-b-2"
-                    :class="svcDetailTab === 'logs'
-                      ? 'border-lerd-red text-lerd-red'
-                      : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
-                  >Logs</button>
-                  <template x-if="selectedService.env_vars && Object.keys(selectedService.env_vars).length > 0">
-                    <button
-                      @click="svcDetailTab = 'env'"
-                      class="pb-2 text-sm font-medium transition-colors border-b-2"
-                      :class="svcDetailTab === 'env'
-                        ? 'border-lerd-red text-lerd-red'
-                        : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'"
-                    >.env</button>
-                  </template>
-                </div>
-
-                <!-- Logs tab -->
-                <div x-show="svcDetailTab === 'logs'" class="p-3 sm:p-5">
-                  <div class="flex items-center justify-between mb-3">
-                    <div class="flex items-center gap-2.5">
-                      <span class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Logs</span>
-                      <span class="flex items-center gap-1.5 text-[10px]" :class="svcLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
-                        <span class="w-1.5 h-1.5 rounded-full" :class="svcLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                        <span x-text="svcLogs.connected ? 'live' : 'disconnected'"></span>
-                      </span>
-                    </div>
-                    <div class="flex items-center gap-2">
-                      <button
-                        @click="svcLogs.lines = []"
-                        class="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-400 transition-colors"
-                      >Clear</button>
-                      <button
-                        @click="openServiceLogs(selectedService)"
-                        class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 border border-gray-200 dark:border-lerd-border hover:border-gray-300 dark:hover:border-lerd-muted rounded px-2 py-1 transition-colors"
-                      >Reconnect</button>
-                    </div>
-                  </div>
-                  <div class="bg-gray-50 dark:bg-black/40 rounded-lg max-h-80 overflow-y-auto px-3 py-2.5 font-mono text-[11px] leading-relaxed space-y-0.5" x-ref="svcLogScroll">
-                    <template x-if="svcLogs.lines.length === 0">
-                      <div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div>
-                    </template>
-                    <template x-for="(line, i) in svcLogs.lines" :key="i">
-                      <div
-                        class="whitespace-pre-wrap break-all"
-                        :class="{
-                          'text-red-500':    line.includes('ERROR') || line.includes('Error'),
-                          'text-yellow-600 dark:text-yellow-400': !line.includes('ERROR') && !line.includes('Error') && (line.includes('WARNING') || line.includes('Warning')),
-                          'text-gray-600 dark:text-gray-400':   !line.includes('ERROR') && !line.includes('Error') && !line.includes('WARNING') && !line.includes('Warning')
-                        }"
-                        x-text="line"
-                      ></div>
-                    </template>
-                  </div>
-                </div>
-
-                <!-- .env tab -->
-                <div x-show="svcDetailTab === 'env'" class="p-3 sm:p-5 space-y-3">
-                  <!-- Connection URL -->
-                  <template x-if="selectedService.connection_url">
-                    <div class="rounded-lg border border-gray-200 dark:border-lerd-border overflow-hidden">
-                      <div class="flex items-center justify-between bg-gray-50 dark:bg-white/[0.03] px-3 py-1.5 border-b border-gray-200 dark:border-lerd-border">
-                        <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Connect</span>
-                      </div>
-                      <div class="bg-gray-50 dark:bg-black/40 px-3 py-2.5">
-                        <a
-                          :href="selectedService.connection_url"
-                          class="font-mono text-[10px] text-sky-600 dark:text-sky-400 hover:underline break-all"
-                          x-text="selectedService.connection_url"
-                        ></a>
-                        <p class="text-[10px] text-gray-400 dark:text-gray-600 mt-1.5">Use <code class="text-gray-500 dark:text-gray-400">127.0.0.1</code> or <code class="text-gray-500 dark:text-gray-400">localhost</code> from your host machine or DB client. Inside your app containers use the hostname shown in <code class="text-gray-500 dark:text-gray-400">DB_HOST</code> below.</p>
-                      </div>
-                    </div>
-                  </template>
-                  <!-- .env vars -->
-                  <div class="rounded-lg border border-gray-200 dark:border-lerd-border overflow-hidden">
-                    <div class="flex items-center justify-between bg-gray-50 dark:bg-white/[0.03] px-3 py-1.5 border-b border-gray-200 dark:border-lerd-border">
-                      <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">.env</span>
-                      <button
-                        @click="copyEnvVars(selectedService)"
-                        class="text-[10px] font-medium text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
-                      >
-                        <span x-show="!selectedService.copied">Copy</span>
-                        <span x-show="selectedService.copied" class="text-emerald-600 dark:text-emerald-500">Copied!</span>
-                      </button>
-                    </div>
-                    <pre class="bg-gray-50 dark:bg-black/40 text-gray-600 dark:text-gray-400 px-3 py-2.5 text-[10px] leading-relaxed overflow-x-auto whitespace-pre" x-text="envPreview(selectedService)"></pre>
-                  </div>
-                </div>
-
-              </div>
-            </template>
-
-          </div>
+              </template>
+            </div>
+          </template>
         </div>
-      </template>
+      </div>
 
-    </div>
-
-    <!-- ===== SYSTEM TAB ===== -->
-    <div x-show="tab === 'system'">
-      <div class="flex items-center justify-between mb-6">
-        <div>
-          <h2 class="text-xl font-semibold text-gray-900 dark:text-white">System</h2>
-          <p class="text-sm text-gray-500 mt-0.5">Infrastructure health — auto-refreshes every 10 seconds</p>
-        </div>
-        <div class="flex items-center gap-2">
-          <button
-            x-show="!allCoreRunning"
-            @click="lerdStart()"
-            :disabled="lerdStarting || lerdStopping"
-            class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors"
-          >
+      <!-- Mobile system list -->
+      <div x-show="tab==='system'">
+        <div class="px-4 py-3 border-b border-gray-100 dark:border-lerd-border flex items-center gap-2">
+          <button x-show="!allCoreRunning" @click="lerdStart()" :disabled="lerdStarting||lerdStopping"
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 text-white transition-colors">
             <svg x-show="lerdStarting" class="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
             <svg x-show="!lerdStarting" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3l14 9-14 9V3z"/></svg>
             <span x-text="lerdStarting ? 'Starting…' : 'Start'"></span>
           </button>
-          <button
-            @click="lerdStop()"
-            :disabled="lerdStarting || lerdStopping"
-            class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-gray-200 hover:bg-gray-300 dark:bg-white/10 dark:hover:bg-white/15 disabled:opacity-50 disabled:cursor-not-allowed text-gray-700 dark:text-gray-200 transition-colors"
-          >
+          <button @click="lerdStop()" :disabled="lerdStarting||lerdStopping"
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-gray-200 hover:bg-gray-300 dark:bg-white/10 dark:hover:bg-white/15 disabled:opacity-50 text-gray-700 dark:text-gray-200 transition-colors">
             <svg x-show="lerdStopping" class="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
             <svg x-show="!lerdStopping" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12" rx="1" stroke-width="2"/></svg>
             <span x-text="lerdStopping ? 'Stopping…' : 'Stop'"></span>
           </button>
         </div>
+        <div x-show="statusLoading" class="px-4 py-4 text-sm text-gray-400">Loading...</div>
+        <div x-show="!statusLoading">
+          <button @click="selectSystem('dns')" class="w-full flex items-center gap-2.5 px-4 py-3.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border" :class="selectedSystem==='dns' ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+            <span class="w-2 h-2 rounded-full shrink-0" :class="systemStatus.dns && systemStatus.dns.ok ? 'bg-emerald-500' : 'bg-red-500'"></span>
+            <span class="font-medium flex-1">DNS</span>
+            <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+          </button>
+          <button @click="selectSystem('nginx')" class="w-full flex items-center gap-2.5 px-4 py-3.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border" :class="selectedSystem==='nginx' ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+            <span class="w-2 h-2 rounded-full shrink-0" :class="systemStatus.nginx && systemStatus.nginx.running ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+            <span class="font-medium flex-1">Nginx</span>
+            <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+          </button>
+          <button @click="selectSystem('watcher')" class="w-full flex items-center gap-2.5 px-4 py-3.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border" :class="selectedSystem==='watcher' ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+            <span class="w-2 h-2 rounded-full shrink-0" :class="systemStatus.watcher_running ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+            <span class="font-medium flex-1">Watcher</span>
+            <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+          </button>
+          <template x-if="phpVersions.length > 0">
+            <div class="px-4 pt-2.5 pb-1 border-t border-gray-100 dark:border-lerd-border">
+              <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">PHP-FPM</span>
+            </div>
+          </template>
+          <template x-for="v in phpVersions" :key="'mphp-'+v">
+            <button @click="selectSystem('php-'+v)" class="w-full flex items-center gap-2.5 px-4 py-3.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border" :class="selectedSystem==='php-'+v ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+              <span class="w-2 h-2 rounded-full shrink-0" :class="fpmRunning(v) ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+              <span class="font-medium flex-1" x-text="'PHP '+v"></span>
+              <template x-if="systemStatus.php_default === v"><span class="text-[10px] text-gray-400 mr-1">default</span></template>
+              <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+            </button>
+          </template>
+          <div class="px-4 pt-2.5 pb-1 border-t border-gray-100 dark:border-lerd-border">
+            <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Node.js</span>
+          </div>
+          <template x-for="v in nodeVersions" :key="'mnode-'+v">
+            <button @click="selectSystem('node-'+v)" class="w-full flex items-center gap-2.5 px-4 py-3.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border" :class="selectedSystem==='node-'+v ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+              <span class="w-2 h-2 rounded-full shrink-0 bg-gray-300 dark:bg-gray-600"></span>
+              <span class="font-medium flex-1" x-text="'Node '+v"></span>
+              <template x-if="systemStatus.node_default === v"><span class="text-[10px] text-gray-400 mr-1">default</span></template>
+              <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+            </button>
+          </template>
+          <button @click="selectSystem('node-install')" class="w-full flex items-center gap-2.5 px-4 py-3.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border" :class="selectedSystem==='node-install' ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4"/></svg>
+            <span class="font-medium flex-1">Install version</span>
+            <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+          </button>
+          <button @click="selectSystem('autostart')" class="w-full flex items-center gap-2.5 px-4 py-3.5 text-sm text-left transition-colors border-t border-gray-100 dark:border-lerd-border" :class="selectedSystem==='autostart' ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+            <span class="w-2 h-2 rounded-full shrink-0" :class="autostartEnabled ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+            <span class="font-medium flex-1">Autostart</span>
+            <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+          </button>
+          <button @click="selectSystem('lerd')" class="w-full flex items-center gap-2.5 px-4 py-3.5 text-sm text-left transition-colors border-t border-gray-100 dark:border-lerd-border" :class="selectedSystem==='lerd' ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
+            <span class="w-2 h-2 rounded-full shrink-0" :class="version.hasUpdate ? 'bg-yellow-400' : 'bg-gray-300 dark:bg-gray-600'"></span>
+            <span class="font-medium flex-1">Lerd</span>
+            <span x-show="version.hasUpdate" class="text-xs font-medium text-yellow-600 dark:text-yellow-400 mr-1">update</span>
+            <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+          </button>
+        </div>
       </div>
 
-      <template x-if="statusLoading">
-        <div class="text-sm text-gray-400">Loading system status...</div>
-      </template>
+    </div><!-- end mobile list -->
 
-      <template x-if="!statusLoading">
-        <div class="flex flex-col sm:flex-row gap-4 sm:items-start">
+    <!-- ── Detail area (CSS forces display on desktop; Alpine controls on mobile) ── -->
+    <div class="detail-area flex-1 flex flex-col overflow-hidden" x-show="mobileShowDetail" style="display:none">
 
-          <!-- Mobile: horizontal system picker -->
-          <div class="sm:hidden w-full flex overflow-x-auto gap-2 pb-2 -mx-3 px-3">
-            <button @click="selectSystem('dns')" class="flex-none flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium whitespace-nowrap transition-colors" :class="selectedSystem === 'dns' ? 'bg-lerd-red/10 border-lerd-red/30 text-lerd-red' : 'bg-white dark:bg-lerd-card border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400'">
-              <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="systemStatus.dns && systemStatus.dns.ok ? 'bg-emerald-500' : 'bg-red-500'"></span>DNS
-            </button>
-            <button @click="selectSystem('nginx')" class="flex-none flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium whitespace-nowrap transition-colors" :class="selectedSystem === 'nginx' ? 'bg-lerd-red/10 border-lerd-red/30 text-lerd-red' : 'bg-white dark:bg-lerd-card border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400'">
-              <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="systemStatus.nginx && systemStatus.nginx.running ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>Nginx
-            </button>
-            <button @click="selectSystem('watcher')" class="flex-none flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium whitespace-nowrap transition-colors" :class="selectedSystem === 'watcher' ? 'bg-lerd-red/10 border-lerd-red/30 text-lerd-red' : 'bg-white dark:bg-lerd-card border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400'">
-              <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="systemStatus.watcher_running ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>Watcher
-            </button>
-            <template x-for="v in phpVersions" :key="'php-pill-'+v">
-              <button @click="selectSystem('php-' + v)" class="flex-none flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium whitespace-nowrap transition-colors" :class="selectedSystem === 'php-' + v ? 'bg-lerd-red/10 border-lerd-red/30 text-lerd-red' : 'bg-white dark:bg-lerd-card border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400'">
-                <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="fpmRunning(v) ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                <span x-text="'PHP ' + v"></span>
-              </button>
-            </template>
-            <template x-for="v in nodeVersions" :key="'node-pill-'+v">
-              <button @click="selectSystem('node-' + v)" class="flex-none flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium whitespace-nowrap transition-colors" :class="selectedSystem === 'node-' + v ? 'bg-lerd-red/10 border-lerd-red/30 text-lerd-red' : 'bg-white dark:bg-lerd-card border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400'">
-                <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-gray-400 dark:bg-gray-600"></span>
-                <span x-text="'Node ' + v"></span>
-              </button>
-            </template>
-            <button @click="selectSystem('node-install')" class="flex-none flex items-center gap-1 px-2.5 py-1 rounded-full border text-xs font-medium whitespace-nowrap transition-colors" :class="selectedSystem === 'node-install' ? 'bg-lerd-red/10 border-lerd-red/30 text-lerd-red' : 'bg-white dark:bg-lerd-card border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400'">
-              <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4"/></svg>Node
-            </button>
-            <button @click="selectSystem('autostart')" class="flex-none flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium whitespace-nowrap transition-colors" :class="selectedSystem === 'autostart' ? 'bg-lerd-red/10 border-lerd-red/30 text-lerd-red' : 'bg-white dark:bg-lerd-card border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400'">
-              <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="autostartEnabled ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>Autostart
-            </button>
-            <button @click="selectSystem('lerd')" class="flex-none flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium whitespace-nowrap transition-colors" :class="selectedSystem === 'lerd' ? 'bg-lerd-red/10 border-lerd-red/30 text-lerd-red' : 'bg-white dark:bg-lerd-card border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400'">
-              <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="version.hasUpdate ? 'bg-yellow-400' : 'bg-gray-400 dark:bg-gray-600'"></span>Lerd
-            </button>
-          </div>
+      <!-- Mobile back header -->
+      <div class="md:hidden flex items-center gap-3 px-4 py-3 border-b border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card shrink-0 sticky top-0 z-10">
+        <button @click="mobileShowDetail = false"
+          class="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors -ml-1">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        </button>
+        <span class="text-sm font-medium text-gray-900 dark:text-white truncate"
+          x-text="tab==='sites' ? (selectedSite ? selectedSite.domain : 'Sites') : tab==='services' ? (selectedService ? capitalize(selectedService.name) : 'Services') : (selectedSystem || 'System')">
+        </span>
+      </div>
 
-          <!-- System items list (desktop only) -->
-          <div class="hidden sm:block sm:w-56 sm:shrink-0 bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border overflow-hidden">
+      <!-- Detail content -->
+      <div class="flex-1 flex flex-col overflow-hidden">
 
-            <!-- DNS -->
-            <button
-              @click="selectSystem('dns')"
-              class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border"
-              :class="selectedSystem === 'dns' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'"
-            >
-              <span class="w-2 h-2 rounded-full shrink-0" :class="systemStatus.dns && systemStatus.dns.ok ? 'bg-emerald-500' : 'bg-red-500'"></span>
-              <span class="font-medium">DNS</span>
-            </button>
+        <!-- ══════════════ SITES DETAIL ══════════════ -->
+        <div x-show="tab === 'sites'" class="flex-1 flex flex-col overflow-hidden min-h-0">
 
-            <!-- Nginx -->
-            <button
-              @click="selectSystem('nginx')"
-              class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border"
-              :class="selectedSystem === 'nginx' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'"
-            >
-              <span class="w-2 h-2 rounded-full shrink-0" :class="systemStatus.nginx && systemStatus.nginx.running ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-              <span class="font-medium">Nginx</span>
-            </button>
-
-            <!-- Watcher -->
-            <button
-              @click="selectSystem('watcher')"
-              class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border"
-              :class="selectedSystem === 'watcher' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'"
-            >
-              <span class="w-2 h-2 rounded-full shrink-0" :class="systemStatus.watcher_running ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-              <span class="font-medium">Watcher</span>
-            </button>
-
-            <!-- PHP section -->
-            <template x-if="phpVersions.length > 0">
-              <div class="px-3 pt-2.5 pb-1 border-t border-gray-100 dark:border-lerd-border">
-                <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">PHP-FPM</span>
-              </div>
-            </template>
-            <template x-for="v in phpVersions" :key="'php-'+v">
-              <button
-                @click="selectSystem('php-' + v)"
-                class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border"
-                :class="selectedSystem === 'php-' + v ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'"
-              >
-                <span class="w-2 h-2 rounded-full shrink-0" :class="fpmRunning(v) ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                <span class="font-medium flex-1" x-text="'PHP ' + v"></span>
-                <template x-if="systemStatus.php_default === v">
-                  <span class="text-[10px] font-medium shrink-0"
-                    :class="selectedSystem === 'php-' + v ? 'text-lerd-red/60' : 'text-gray-400 dark:text-gray-600'"
-                  >default</span>
-                </template>
-                <template x-if="phpSiteCount(v) > 0">
-                  <span class="text-[10px] font-medium tabular-nums shrink-0 ml-1"
-                    :class="selectedSystem === 'php-' + v ? 'text-lerd-red/70' : 'text-gray-400 dark:text-gray-600'"
-                    x-text="phpSiteCount(v)"></span>
-                </template>
-              </button>
-            </template>
-
-            <!-- Node section -->
-            <div class="px-3 pt-2.5 pb-1 border-t border-gray-100 dark:border-lerd-border">
-              <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Node.js</span>
+          <template x-if="!selectedSite">
+            <div class="p-10 text-center text-sm text-gray-400">
+              Select a site to view details
             </div>
-            <template x-for="v in nodeVersions" :key="'node-'+v">
-              <button
-                @click="selectSystem('node-' + v)"
-                class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border"
-                :class="selectedSystem === 'node-' + v ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'"
-              >
-                <span class="w-2 h-2 rounded-full shrink-0 bg-gray-400 dark:bg-gray-600"></span>
-                <span class="font-medium flex-1" x-text="'Node ' + v"></span>
-                <template x-if="systemStatus.node_default === v">
-                  <span class="text-[10px] font-medium shrink-0"
-                    :class="selectedSystem === 'node-' + v ? 'text-lerd-red/60' : 'text-gray-400 dark:text-gray-600'"
-                  >default</span>
-                </template>
-                <template x-if="nodeSiteCount(v) > 0">
-                  <span class="text-[10px] font-medium tabular-nums shrink-0 ml-1"
-                    :class="selectedSystem === 'node-' + v ? 'text-lerd-red/70' : 'text-gray-400 dark:text-gray-600'"
-                    x-text="nodeSiteCount(v)"></span>
-                </template>
-              </button>
-            </template>
-            <button
-              @click="selectSystem('node-install')"
-              class="w-full flex items-center gap-2 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border"
-              :class="selectedSystem === 'node-install' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-400 hover:bg-gray-50 dark:hover:bg-white/[0.03]'"
-            >
-              <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4"/></svg>
-              <span class="font-medium">Install version</span>
-            </button>
+          </template>
 
-            <!-- Autostart -->
-            <button
-              @click="selectSystem('autostart')"
-              class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-t border-gray-100 dark:border-lerd-border"
-              :class="selectedSystem === 'autostart' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'"
-            >
-              <span class="w-2 h-2 rounded-full shrink-0" :class="autostartEnabled ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-              <span class="font-medium">Autostart</span>
-            </button>
+          <template x-if="selectedSite">
+            <div class="flex-1 flex flex-col overflow-hidden min-h-0">
 
-            <!-- Lerd version -->
-            <button
-              @click="selectSystem('lerd')"
-              class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-t border-gray-100 dark:border-lerd-border"
-              :class="selectedSystem === 'lerd' ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'"
-            >
-              <span class="w-2 h-2 rounded-full shrink-0" :class="version.hasUpdate ? 'bg-yellow-400' : 'bg-gray-400 dark:bg-gray-600'"></span>
-              <span class="font-medium">Lerd</span>
-              <span x-show="version.hasUpdate" class="ml-auto text-xs font-medium text-yellow-600 dark:text-yellow-400">update</span>
-            </button>
-
-          </div>
-
-          <!-- Detail panel -->
-          <div class="flex-1 min-w-0">
-
-            <!-- Empty state -->
-            <template x-if="!selectedSystem">
-              <div class="bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border p-10 text-center">
-                <p class="text-sm text-gray-400">Select an item to view details</p>
-              </div>
-            </template>
-
-            <!-- DNS -->
-            <template x-if="selectedSystem === 'dns'">
-              <div class="bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border overflow-hidden">
-                <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
-                  <span class="font-semibold text-gray-900 dark:text-white text-base">DNS</span>
-                  <template x-if="systemStatus.dns && systemStatus.dns.ok">
-                    <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-500 px-2.5 py-1 rounded-full">
-                      <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>OK
-                    </span>
-                  </template>
-                  <template x-if="!systemStatus.dns || !systemStatus.dns.ok">
-                    <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-red-100 dark:bg-red-500/10 text-red-600 dark:text-red-400 px-2.5 py-1 rounded-full">
-                      <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>Failed
-                    </span>
-                  </template>
-                </div>
-                <div class="px-3 sm:px-5 py-4 space-y-4">
-                  <div class="flex items-center justify-between">
-                    <span class="text-sm text-gray-500">TLD</span>
-                    <code class="bg-gray-100 dark:bg-white/5 border border-gray-200 dark:border-lerd-border px-1.5 py-0.5 rounded text-gray-600 dark:text-gray-400 text-xs" x-text="'.' + (systemStatus.dns ? systemStatus.dns.tld : 'test')"></code>
-                  </div>
-                  <template x-if="!systemStatus.dns || !systemStatus.dns.ok">
-                    <p class="text-xs text-gray-400">Try clicking <strong class="text-gray-500">Start</strong> above, or run <code class="bg-gray-100 dark:bg-white/5 px-1 rounded text-gray-500">lerd install</code> to fix DNS.</p>
-                  </template>
-                  <!-- Live logs -->
+              <!-- Header -->
+              <div class="px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border shrink-0">
+                <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4">
                   <div>
-                    <div class="flex items-center justify-between mb-3">
-                      <div class="flex items-center gap-2.5">
-                        <span class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Logs</span>
-                        <span class="flex items-center gap-1.5 text-[10px]" :class="systemLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
-                          <span class="w-1.5 h-1.5 rounded-full" :class="systemLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                          <span x-text="systemLogs.connected ? 'live' : 'disconnected'"></span>
+                    <div class="flex items-center gap-2 flex-wrap">
+                      <a
+                        :href="(selectedSite.tls ? 'https://' : 'http://') + selectedSite.domain"
+                        @click.prevent="openSite(selectedSite)"
+                        class="font-semibold text-lerd-red hover:text-lerd-redhov transition-colors"
+                        x-text="selectedSite.domain"
+                      ></a>
+                      <template x-if="!selectedSite.paused && selectedSite.fpm_running">
+                        <span class="inline-flex items-center gap-1 text-xs font-medium text-emerald-600 dark:text-emerald-500 bg-emerald-50 dark:bg-emerald-900/20 px-2 py-0.5 rounded-full">
+                          <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>running
                         </span>
-                      </div>
-                      <div class="flex items-center gap-2">
-                        <button @click="systemLogs.lines = []" class="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-400 transition-colors">Clear</button>
-                        <button @click="openSystemLogs('lerd-dns')" class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 border border-gray-200 dark:border-lerd-border hover:border-gray-300 dark:hover:border-lerd-muted rounded px-2 py-1 transition-colors">Reconnect</button>
-                      </div>
-                    </div>
-                    <div class="bg-gray-50 dark:bg-black/40 rounded-lg max-h-80 overflow-y-auto px-3 py-2.5 font-mono text-[11px] leading-relaxed space-y-0.5" x-ref="nginxLogScroll">
-                      <template x-if="systemLogs.lines.length === 0">
-                        <div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div>
                       </template>
-                      <template x-for="(line, i) in systemLogs.lines" :key="i">
-                        <div
-                          class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400"
-                          x-text="line"
-                        ></div>
-                      </template>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </template>
-
-            <!-- Nginx -->
-            <template x-if="selectedSystem === 'nginx'">
-              <div class="bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border overflow-hidden">
-                <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
-                  <span class="font-semibold text-gray-900 dark:text-white text-base">Nginx</span>
-                  <template x-if="systemStatus.nginx && systemStatus.nginx.running">
-                    <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-500 px-2.5 py-1 rounded-full">
-                      <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>Running
-                    </span>
-                  </template>
-                  <template x-if="!systemStatus.nginx || !systemStatus.nginx.running">
-                    <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-red-100 dark:bg-red-500/10 text-red-600 dark:text-red-400 px-2.5 py-1 rounded-full">
-                      <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>Stopped
-                    </span>
-                  </template>
-                </div>
-                <div class="px-3 sm:px-5 py-4 space-y-4">
-                  <div class="flex items-center justify-between">
-                    <span class="text-sm text-gray-500">Container</span>
-                    <code class="bg-gray-100 dark:bg-white/5 border border-gray-200 dark:border-lerd-border px-1.5 py-0.5 rounded text-gray-600 dark:text-gray-400 text-xs">lerd-nginx</code>
-                  </div>
-                  <!-- Live logs -->
-                  <div>
-                    <div class="flex items-center justify-between mb-3">
-                      <div class="flex items-center gap-2.5">
-                        <span class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Logs</span>
-                        <span class="flex items-center gap-1.5 text-[10px]" :class="systemLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
-                          <span class="w-1.5 h-1.5 rounded-full" :class="systemLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                          <span x-text="systemLogs.connected ? 'live' : 'disconnected'"></span>
+                      <template x-if="!selectedSite.paused && !selectedSite.fpm_running">
+                        <span class="inline-flex items-center gap-1 text-xs font-medium text-red-500 bg-red-50 dark:bg-red-900/20 px-2 py-0.5 rounded-full">
+                          <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>stopped
                         </span>
-                      </div>
-                      <div class="flex items-center gap-2">
-                        <button @click="systemLogs.lines = []" class="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-400 transition-colors">Clear</button>
-                        <button @click="openSystemLogs('lerd-nginx')" class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 border border-gray-200 dark:border-lerd-border hover:border-gray-300 dark:hover:border-lerd-muted rounded px-2 py-1 transition-colors">Reconnect</button>
-                      </div>
-                    </div>
-                    <div class="bg-gray-50 dark:bg-black/40 rounded-lg max-h-80 overflow-y-auto px-3 py-2.5 font-mono text-[11px] leading-relaxed space-y-0.5" x-ref="nginxLogScroll">
-                      <template x-if="systemLogs.lines.length === 0">
-                        <div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div>
                       </template>
-                      <template x-for="(line, i) in systemLogs.lines" :key="i">
-                        <div
-                          class="whitespace-pre-wrap break-all"
-                          :class="{
-                            'text-red-500':    line.includes('error') || line.includes('Error') || line.includes('crit'),
-                            'text-yellow-600 dark:text-yellow-400': !line.includes('error') && !line.includes('Error') && !line.includes('crit') && line.includes('warn'),
-                            'text-gray-600 dark:text-gray-400':   !line.includes('error') && !line.includes('Error') && !line.includes('crit') && !line.includes('warn')
-                          }"
-                          x-text="line"
-                        ></div>
+                      <template x-if="selectedSite.framework_label">
+                        <span class="inline-flex items-center text-xs font-medium text-lerd-red bg-red-50 dark:bg-red-900/20 px-2 py-0.5 rounded-full" x-text="selectedSite.framework_label"></span>
                       </template>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </template>
-
-            <!-- Watcher -->
-            <template x-if="selectedSystem === 'watcher'">
-              <div class="bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border overflow-hidden">
-                <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
-                  <span class="font-semibold text-gray-900 dark:text-white text-base">Watcher</span>
-                  <template x-if="systemStatus.watcher_running">
-                    <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-500 px-2.5 py-1 rounded-full">
-                      <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>Running
-                    </span>
-                  </template>
-                  <template x-if="!systemStatus.watcher_running">
-                    <div class="flex items-center gap-2">
-                      <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-red-100 dark:bg-red-500/10 text-red-600 dark:text-red-400 px-2.5 py-1 rounded-full">
-                        <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>Stopped
-                      </span>
-                      <button
-                        @click="startWatcher()"
-                        :disabled="watcherStarting"
-                        class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors"
-                      >
-                        <svg x-show="watcherStarting" class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
-                        <span x-text="watcherStarting ? 'Starting…' : 'Start'"></span>
-                      </button>
-                    </div>
-                  </template>
-                </div>
-                <div class="px-3 sm:px-5 py-4 space-y-4">
-                  <p class="text-xs text-gray-400">Monitors parked directories, site files, git worktrees, and DNS health. Logs WARN and ERROR events by default; set <code class="bg-gray-100 dark:bg-white/5 px-1 rounded">LERD_DEBUG=1</code> in the service environment for verbose output.</p>
-                  <!-- Live logs -->
-                  <div>
-                    <div class="flex items-center justify-between mb-3">
-                      <div class="flex items-center gap-2.5">
-                        <span class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Logs</span>
-                        <span class="flex items-center gap-1.5 text-[10px]" :class="systemLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
-                          <span class="w-1.5 h-1.5 rounded-full" :class="systemLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                          <span x-text="systemLogs.connected ? 'live' : 'disconnected'"></span>
+                      <template x-if="selectedSite.paused">
+                        <span class="inline-flex items-center gap-1 text-xs font-medium text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 px-2 py-0.5 rounded-full">
+                          <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M6 5h4v14H6zM14 5h4v14h-4z"/></svg>
+                          paused
                         </span>
-                      </div>
-                      <div class="flex items-center gap-2">
-                        <button @click="systemLogs.lines = []" class="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-400 transition-colors">Clear</button>
-                        <button @click="openWatcherLogs()" class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 border border-gray-200 dark:border-lerd-border hover:border-gray-300 dark:hover:border-lerd-muted rounded px-2 py-1 transition-colors">Reconnect</button>
-                      </div>
-                    </div>
-                    <div class="bg-gray-50 dark:bg-black/40 rounded-lg max-h-80 overflow-y-auto px-3 py-2.5 font-mono text-[11px] leading-relaxed space-y-0.5" x-ref="watcherLogScroll">
-                      <template x-if="systemLogs.lines.length === 0">
-                        <div class="text-gray-400 dark:text-gray-700 italic">No events yet — watcher is running quietly.</div>
                       </template>
-                      <template x-for="(line, i) in systemLogs.lines" :key="i">
-                        <div
-                          class="whitespace-pre-wrap break-all"
-                          :class="{
-                            'text-red-500':    line.includes('level=ERROR') || line.includes('error'),
-                            'text-yellow-600 dark:text-yellow-400': !line.includes('level=ERROR') && !line.includes('error') && line.includes('level=WARN'),
-                            'text-gray-600 dark:text-gray-400':   !line.includes('level=ERROR') && !line.includes('error') && !line.includes('level=WARN')
-                          }"
-                          x-text="line"
-                        ></div>
+                    </div>
+                    <div class="text-xs text-gray-400 font-mono mt-1 flex items-center gap-2">
+                      <span x-text="selectedSite.path"></span>
+                      <template x-if="selectedSite.branch">
+                        <span class="text-violet-500 dark:text-violet-400 shrink-0">git:(<span x-text="selectedSite.branch"></span>)</span>
                       </template>
                     </div>
                   </div>
-                </div>
-              </div>
-            </template>
-
-            <!-- PHP version detail -->
-            <template x-if="selectedPHPVersion">
-              <div class="bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border overflow-hidden">
-                <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
-                  <div class="flex items-center gap-3">
-                    <span class="font-semibold text-gray-900 dark:text-white text-base" x-text="'PHP ' + selectedPHPVersion"></span>
-                    <template x-if="fpmRunning(selectedPHPVersion)">
-                      <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-500 px-2.5 py-1 rounded-full">
-                        <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>Running
-                      </span>
-                    </template>
-                    <template x-if="!fpmRunning(selectedPHPVersion)">
-                      <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 text-gray-500 px-2.5 py-1 rounded-full">
-                        <span class="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-gray-600"></span>Stopped
-                      </span>
-                    </template>
-                    <template x-if="phpSiteCount(selectedPHPVersion) > 0">
-                      <span class="text-xs text-gray-400 dark:text-gray-500" x-text="phpSiteCount(selectedPHPVersion) + (phpSiteCount(selectedPHPVersion) === 1 ? ' site' : ' sites')"></span>
-                    </template>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <template x-if="systemStatus.php_default !== selectedPHPVersion">
-                      <button
-                        @click="setPHPDefault(selectedPHPVersion)"
-                        :disabled="phpDefaultLoading"
-                        class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-                      >
-                        <svg x-show="phpDefaultLoading" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
-                        <span x-show="!phpDefaultLoading">Set as default</span>
-                      </button>
-                    </template>
-                    <template x-if="phpSiteCount(selectedPHPVersion) === 0">
-                      <button
-                        @click="toggleFPM(selectedPHPVersion)"
-                        :disabled="phpFPMLoading[selectedPHPVersion]"
-                        class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-                      >
-                        <svg x-show="phpFPMLoading[selectedPHPVersion]" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
-                        <span x-show="!phpFPMLoading[selectedPHPVersion]" x-text="fpmRunning(selectedPHPVersion) ? 'Stop' : 'Start'"></span>
-                      </button>
-                    </template>
-                    <template x-if="phpSiteCount(selectedPHPVersion) === 0">
-                      <button
-                        @click="removePHPVersion(selectedPHPVersion)"
-                        :disabled="phpRemoveLoading[selectedPHPVersion]"
-                        class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-red-50 dark:hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 hover:border-red-200 dark:hover:border-red-500/30 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-                      >
-                        <svg x-show="phpRemoveLoading[selectedPHPVersion]" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
-                        <span x-show="!phpRemoveLoading[selectedPHPVersion]">Remove</span>
-                      </button>
-                    </template>
-                  </div>
-                </div>
-                <div class="px-3 sm:px-5 py-4 space-y-5">
-                  <!-- Xdebug -->
-                  <div class="flex items-center justify-between">
-                    <div>
-                      <p class="text-sm font-medium text-gray-700 dark:text-gray-300">Xdebug</p>
-                      <p class="text-xs text-gray-400 mt-0.5">Restarts FPM on toggle</p>
-                    </div>
-                    <div class="flex items-center gap-2">
-                      <button
-                        type="button"
-                        @click.prevent="toggleXdebug(selectedPHPVersion)"
-                        class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200 focus:outline-none"
-                        :class="xdebugEnabled[selectedPHPVersion] ? 'bg-purple-500' : 'bg-gray-300 dark:bg-lerd-muted'"
-                        :title="xdebugEnabled[selectedPHPVersion] ? 'Disable Xdebug' : 'Enable Xdebug'"
-                      >
-                        <span
-                          class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform duration-200"
-                          :class="xdebugEnabled[selectedPHPVersion] ? 'translate-x-4' : 'translate-x-1'"
-                        ></span>
-                      </button>
-                      <svg x-show="xdebugLoading[selectedPHPVersion]" style="display:none" class="animate-spin w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24">
-                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
-                      </svg>
-                    </div>
-                  </div>
-                  <!-- Container -->
-                  <div class="flex items-center justify-between">
-                    <span class="text-sm text-gray-500">Container</span>
-                    <code class="bg-gray-100 dark:bg-white/5 border border-gray-200 dark:border-lerd-border px-1.5 py-0.5 rounded text-gray-600 dark:text-gray-400 text-xs" x-text="'lerd-php' + selectedPHPVersion.replace('.','') + '-fpm'"></code>
-                  </div>
-                  <!-- Sites using this PHP version -->
-                  <div>
-                    <p class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">Sites</p>
-                    <template x-if="phpSiteCount(selectedPHPVersion) === 0">
-                      <p class="text-sm text-gray-400">No sites are using PHP <span x-text="selectedPHPVersion"></span>.</p>
-                    </template>
-                    <div class="flex flex-wrap gap-2">
-                      <template x-for="site in sites.filter(s => s.php_version === selectedPHPVersion)" :key="site.domain">
-                        <a
-                          :href="(site.tls ? 'https://' : 'http://') + site.domain"
-                          @click.prevent="openSite(site)"
-                          class="inline-flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 border border-gray-200 dark:border-lerd-border text-gray-700 dark:text-gray-300 rounded-full px-2.5 py-1 transition-colors"
-                        >
-                          <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="site.fpm_running ? 'bg-emerald-500' : 'bg-gray-400'"></span>
-                          <span x-text="site.domain"></span>
-                        </a>
-                      </template>
-                    </div>
-                  </div>
-                  <!-- Live logs -->
-                  <div>
-                    <div class="flex items-center justify-between mb-3">
-                      <div class="flex items-center gap-2.5">
-                        <span class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Logs</span>
-                        <span class="flex items-center gap-1.5 text-[10px]" :class="systemLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
-                          <span class="w-1.5 h-1.5 rounded-full" :class="systemLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                          <span x-text="systemLogs.connected ? 'live' : 'disconnected'"></span>
-                        </span>
-                      </div>
-                      <div class="flex items-center gap-2">
-                        <button @click="systemLogs.lines = []" class="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-400 transition-colors">Clear</button>
-                        <button
-                          @click="openSystemLogs('lerd-php' + selectedPHPVersion.replace('.','') + '-fpm')"
-                          class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 border border-gray-200 dark:border-lerd-border hover:border-gray-300 dark:hover:border-lerd-muted rounded px-2 py-1 transition-colors"
-                        >Reconnect</button>
-                      </div>
-                    </div>
-                    <div class="bg-gray-50 dark:bg-black/40 rounded-lg max-h-80 overflow-y-auto px-3 py-2.5 font-mono text-[11px] leading-relaxed space-y-0.5" x-ref="nginxLogScroll">
-                      <template x-if="systemLogs.lines.length === 0">
-                        <div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div>
-                      </template>
-                      <template x-for="(line, i) in systemLogs.lines" :key="i">
-                        <div
-                          class="whitespace-pre-wrap break-all"
-                          :class="{
-                            'text-red-500':    line.includes('ERROR') || line.includes('Error') || line.includes('PHP Fatal') || line.includes('PHP Warning'),
-                            'text-yellow-600 dark:text-yellow-400': !line.includes('ERROR') && !line.includes('Error') && (line.includes('WARNING') || line.includes('Warning') || line.includes('PHP Notice')),
-                            'text-gray-600 dark:text-gray-400':   !line.includes('ERROR') && !line.includes('Error') && !line.includes('WARNING') && !line.includes('Warning')
-                          }"
-                          x-text="line"
-                        ></div>
-                      </template>
-                    </div>
-                  </div>
-
-                  <!-- Error -->
-                  <template x-if="phpRemoveError[selectedPHPVersion]">
-                    <div class="text-xs font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10 rounded-lg px-3 py-1.5" x-text="phpRemoveError[selectedPHPVersion]"></div>
-                  </template>
-                </div>
-              </div>
-            </template>
-
-            <!-- Node version detail -->
-            <template x-if="selectedNodeVersion">
-              <div class="bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border overflow-hidden">
-                <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
-                  <div class="flex items-center gap-3">
-                    <span class="font-semibold text-gray-900 dark:text-white text-base" x-text="'Node ' + selectedNodeVersion"></span>
-                    <template x-if="nodeSiteCount(selectedNodeVersion) > 0">
-                      <span class="text-xs text-gray-400 dark:text-gray-500" x-text="nodeSiteCount(selectedNodeVersion) + (nodeSiteCount(selectedNodeVersion) === 1 ? ' site' : ' sites')"></span>
-                    </template>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <template x-if="systemStatus.node_default !== selectedNodeVersion">
-                      <button
-                        @click="setNodeDefault(selectedNodeVersion)"
-                        :disabled="nodeDefaultLoading"
-                        class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-                      >
-                        <svg x-show="nodeDefaultLoading" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
-                        <span x-show="!nodeDefaultLoading">Set as default</span>
-                      </button>
-                    </template>
-                    <template x-if="nodeSiteCount(selectedNodeVersion) === 0">
-                      <button
-                        @click="removeNodeVersion(selectedNodeVersion)"
-                        :disabled="nodeRemoveLoading[selectedNodeVersion]"
-                        class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-red-50 dark:hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 hover:border-red-200 dark:hover:border-red-500/30 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-                      >
-                        <svg x-show="nodeRemoveLoading[selectedNodeVersion]" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
-                        <span x-show="!nodeRemoveLoading[selectedNodeVersion]">Remove</span>
-                      </button>
-                    </template>
-                  </div>
-                </div>
-                <div class="px-3 sm:px-5 py-4 space-y-4">
-                  <!-- Sites -->
-                  <div>
-                    <p class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">Sites</p>
-                    <template x-if="nodeSiteCount(selectedNodeVersion) === 0">
-                      <p class="text-sm text-gray-400">No sites are using Node <span x-text="selectedNodeVersion"></span>.</p>
-                    </template>
-                    <div class="flex flex-wrap gap-2">
-                      <template x-for="site in sites.filter(s => s.node_version === selectedNodeVersion || (!s.node_version && selectedNodeVersion === systemStatus.node_default))" :key="site.domain">
-                        <a
-                          :href="(site.tls ? 'https://' : 'http://') + site.domain"
-                          @click.prevent="openSite(site)"
-                          class="inline-flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 border border-gray-200 dark:border-lerd-border text-gray-700 dark:text-gray-300 rounded-full px-2.5 py-1 transition-colors"
-                        >
-                          <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-gray-400"></span>
-                          <span x-text="site.domain"></span>
-                        </a>
-                      </template>
-                    </div>
-                  </div>
-                  <!-- Error -->
-                  <template x-if="nodeRemoveError[selectedNodeVersion]">
-                    <div class="text-xs font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10 rounded-lg px-3 py-1.5" x-text="nodeRemoveError[selectedNodeVersion]"></div>
-                  </template>
-                </div>
-              </div>
-            </template>
-
-            <!-- Node install -->
-            <template x-if="selectedSystem === 'node-install'">
-              <div class="bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border overflow-hidden">
-                <div class="px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
-                  <span class="font-semibold text-gray-900 dark:text-white text-base">Install Node.js version</span>
-                </div>
-                <div class="px-3 sm:px-5 py-4 space-y-4">
-                  <p class="text-sm text-gray-500">Install a new Node.js version using fnm.</p>
-                  <div class="flex items-center gap-2">
-                    <input
-                      type="text"
-                      x-model="nodeInstall.version"
-                      @keydown.enter="installNodeVersion()"
-                      placeholder="e.g. 22"
-                      class="text-sm bg-white dark:bg-lerd-card border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 w-28 text-gray-700 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-600 focus:outline-none focus:border-lerd-red/50 transition-colors"
-                      :disabled="nodeInstall.installing"
-                    >
+                  <div class="flex items-center gap-2 shrink-0">
                     <button
-                      @click="installNodeVersion()"
-                      :disabled="nodeInstall.installing || !nodeInstall.version.trim()"
-                      class="text-sm bg-lerd-red hover:bg-lerd-redhov text-white rounded-lg px-3 py-1.5 transition-colors disabled:opacity-40 flex items-center gap-1.5 font-medium"
+                      @click="selectedSite.paused ? resumeSite(selectedSite) : pauseSite(selectedSite)"
+                      :disabled="selectedSite.pauseLoading"
+                      class="text-xs border rounded px-2 py-1 transition-colors disabled:opacity-50"
+                      :class="selectedSite.paused
+                        ? 'border-emerald-300 dark:border-emerald-700 text-emerald-600 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20'
+                        : 'border-amber-300 dark:border-amber-700 text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20'"
                     >
-                      <svg x-show="nodeInstall.installing" class="animate-spin w-3.5 h-3.5" fill="none" viewBox="0 0 24 24">
-                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path>
-                      </svg>
-                      <span x-text="nodeInstall.installing ? 'Installing...' : 'Install'"></span>
+                      <span x-show="!selectedSite.pauseLoading" x-text="selectedSite.paused ? 'Resume' : 'Pause'"></span>
+                      <span x-show="selectedSite.pauseLoading">...</span>
                     </button>
-                    <span x-show="nodeInstall.done" class="text-xs text-emerald-600 dark:text-emerald-500">Installed!</span>
-                    <span x-show="nodeInstall.error" class="text-xs text-red-500" x-text="nodeInstall.error"></span>
+                    <button
+                      @click="unlinkSite(selectedSite)"
+                      :disabled="selectedSite.unlinkLoading"
+                      class="text-xs border border-red-300 dark:border-red-700 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded px-2 py-1 transition-colors disabled:opacity-50"
+                    >
+                      <span x-show="!selectedSite.unlinkLoading">Unlink</span>
+                      <span x-show="selectedSite.unlinkLoading">...</span>
+                    </button>
+                    <button
+                      @click="openSite(selectedSite)"
+                      class="flex items-center gap-1.5 text-xs border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-white/5 rounded px-2 py-1 transition-colors"
+                      title="Open in browser"
+                    >
+                      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                      Open
+                    </button>
+                    <button
+                      @click="openTerminal(selectedSite)"
+                      class="flex items-center gap-1.5 text-xs border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-white/5 rounded px-2 py-1 transition-colors"
+                      title="Open in terminal"
+                    >
+                      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
+                      Terminal
+                    </button>
                   </div>
                 </div>
               </div>
-            </template>
 
-            <!-- Lerd version & update -->
-            <template x-if="selectedSystem === 'lerd'">
-              <div class="bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border overflow-hidden">
-                <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
-                  <span class="font-semibold text-gray-900 dark:text-white text-base">Lerd</span>
-                  <span class="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full bg-gray-100 dark:bg-white/5 text-gray-600 dark:text-gray-400 font-mono" x-text="'v' + version.current"></span>
-                </div>
-                <div class="px-3 sm:px-5 py-4 space-y-4">
+              <!-- Controls -->
+              <div class="px-3 sm:px-5 py-3 border-b border-gray-100 dark:border-lerd-border shrink-0">
 
-                  <!-- Up to date -->
-                  <template x-if="version.checked && !version.hasUpdate">
-                    <div class="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-500">
-                      <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>
-                      You're on the latest version.
+                <!-- Version selects + toggles row -->
+                <div class="flex items-center gap-4 overflow-x-auto">
+                  <select
+                    x-model="selectedSite.php_version"
+                    @change="setSiteVersion(selectedSite, 'php', selectedSite.php_version)"
+                    class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors"
+                    :disabled="selectedSite.versionLoading"
+                  >
+                    <option value="" disabled>— PHP —</option>
+                    <template x-for="v in phpVersions" :key="v">
+                      <option :value="v" x-text="'PHP ' + v"></option>
+                    </template>
+                  </select>
+                  <select
+                    x-model="selectedSite.node_version"
+                    @change="setSiteVersion(selectedSite, 'node', selectedSite.node_version)"
+                    class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors"
+                    :disabled="selectedSite.versionLoading"
+                  >
+                    <option value="">Node default</option>
+                    <template x-for="v in nodeVersions" :key="v">
+                      <option :value="v" x-text="'Node ' + v"></option>
+                    </template>
+                  </select>
+
+                  <!-- HTTPS -->
+                  <div class="flex items-center gap-1.5">
+                    <button @click="toggleTLS(selectedSite)" :disabled="selectedSite.tlsLoading" :title="selectedSite.tls ? 'Disable HTTPS' : 'Enable HTTPS'"
+                      class="relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
+                      :class="selectedSite.tls ? 'bg-lerd-red' : 'bg-gray-300 dark:bg-lerd-muted'">
+                      <span class="inline-block h-3 w-3 rounded-full bg-white shadow transition-transform duration-200" :class="selectedSite.tls ? 'translate-x-3.5' : 'translate-x-0.5'"></span>
+                      <svg x-show="selectedSite.tlsLoading" class="animate-spin absolute right-[-14px] w-2.5 h-2.5 text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                    </button>
+                    <span class="text-xs text-gray-500 dark:text-gray-400">HTTPS</span>
+                    <span x-show="selectedSite.tlsError" class="text-[10px] text-red-500" x-text="selectedSite.tlsError"></span>
+                  </div>
+
+                  <!-- Queue -->
+                  <div x-show="selectedSite.has_queue_worker" class="flex items-center gap-1.5">
+                    <button @click="toggleQueue(selectedSite)" :disabled="selectedSite.queueLoading" :title="selectedSite.queue_running ? 'Stop queue worker' : 'Start queue worker'"
+                      class="relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
+                      :class="selectedSite.queue_running ? 'bg-amber-500' : 'bg-gray-300 dark:bg-lerd-muted'">
+                      <span class="inline-block h-3 w-3 rounded-full bg-white shadow transition-transform duration-200" :class="selectedSite.queue_running ? 'translate-x-3.5' : 'translate-x-0.5'"></span>
+                      <svg x-show="selectedSite.queueLoading" class="animate-spin absolute right-[-14px] w-2.5 h-2.5 text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                    </button>
+                    <span class="text-xs text-gray-500 dark:text-gray-400">Queue</span>
+                    <span x-show="selectedSite.queueError" class="text-[10px] text-red-500" x-text="selectedSite.queueError"></span>
+                  </div>
+
+                  <!-- Horizon -->
+                  <div x-show="selectedSite.has_horizon" class="flex items-center gap-1.5">
+                    <button @click="toggleHorizon(selectedSite)" :disabled="selectedSite.horizonLoading" :title="selectedSite.horizon_running ? 'Stop Horizon' : 'Start Horizon'"
+                      class="relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
+                      :class="selectedSite.horizon_running ? 'bg-amber-500' : 'bg-gray-300 dark:bg-lerd-muted'">
+                      <span class="inline-block h-3 w-3 rounded-full bg-white shadow transition-transform duration-200" :class="selectedSite.horizon_running ? 'translate-x-3.5' : 'translate-x-0.5'"></span>
+                      <svg x-show="selectedSite.horizonLoading" class="animate-spin absolute right-[-14px] w-2.5 h-2.5 text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                    </button>
+                    <span class="text-xs text-gray-500 dark:text-gray-400">Horizon</span>
+                    <span x-show="selectedSite.horizonError" class="text-[10px] text-red-500" x-text="selectedSite.horizonError"></span>
+                  </div>
+
+                  <!-- Stripe -->
+                  <div x-show="selectedSite.stripe_secret_set" class="flex items-center gap-1.5">
+                    <button @click="toggleStripe(selectedSite)" :disabled="selectedSite.stripeLoading" :title="selectedSite.stripe_running ? 'Stop Stripe listener' : 'Start Stripe webhook listener'"
+                      class="relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
+                      :class="selectedSite.stripe_running ? 'bg-violet-500' : 'bg-gray-300 dark:bg-lerd-muted'">
+                      <span class="inline-block h-3 w-3 rounded-full bg-white shadow transition-transform duration-200" :class="selectedSite.stripe_running ? 'translate-x-3.5' : 'translate-x-0.5'"></span>
+                      <svg x-show="selectedSite.stripeLoading" class="animate-spin absolute right-[-14px] w-2.5 h-2.5 text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                    </button>
+                    <span class="text-xs text-gray-500 dark:text-gray-400">Stripe</span>
+                    <span x-show="selectedSite.stripeError" class="text-[10px] text-red-500" x-text="selectedSite.stripeError"></span>
+                  </div>
+
+                  <!-- Schedule -->
+                  <div x-show="selectedSite.has_schedule_worker" class="flex items-center gap-1.5">
+                    <button @click="toggleSchedule(selectedSite)" :disabled="selectedSite.scheduleLoading" :title="selectedSite.schedule_running ? 'Stop scheduler' : 'Start scheduler'"
+                      class="relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
+                      :class="selectedSite.schedule_running ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-lerd-muted'">
+                      <span class="inline-block h-3 w-3 rounded-full bg-white shadow transition-transform duration-200" :class="selectedSite.schedule_running ? 'translate-x-3.5' : 'translate-x-0.5'"></span>
+                      <svg x-show="selectedSite.scheduleLoading" class="animate-spin absolute right-[-14px] w-2.5 h-2.5 text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                    </button>
+                    <span class="text-xs text-gray-500 dark:text-gray-400">Schedule</span>
+                    <span x-show="selectedSite.scheduleError" class="text-[10px] text-red-500" x-text="selectedSite.scheduleError"></span>
+                  </div>
+
+                  <!-- Reverb -->
+                  <div x-show="selectedSite.has_reverb" class="flex items-center gap-1.5">
+                    <button @click="toggleReverb(selectedSite)" :disabled="selectedSite.reverbLoading" :title="selectedSite.reverb_running ? 'Stop Reverb' : 'Start Reverb WebSocket server'"
+                      class="relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
+                      :class="selectedSite.reverb_running ? 'bg-sky-500' : 'bg-gray-300 dark:bg-lerd-muted'">
+                      <span class="inline-block h-3 w-3 rounded-full bg-white shadow transition-transform duration-200" :class="selectedSite.reverb_running ? 'translate-x-3.5' : 'translate-x-0.5'"></span>
+                      <svg x-show="selectedSite.reverbLoading" class="animate-spin absolute right-[-14px] w-2.5 h-2.5 text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                    </button>
+                    <span class="text-xs text-gray-500 dark:text-gray-400">Reverb</span>
+                    <span x-show="selectedSite.reverbError" class="text-[10px] text-red-500" x-text="selectedSite.reverbError"></span>
+                  </div>
+
+                  <!-- Custom framework workers -->
+                  <template x-for="worker in (selectedSite.framework_workers || [])" :key="'toggle-' + worker.name">
+                    <div class="flex items-center gap-1.5">
+                      <button @click="toggleWorker(selectedSite, worker)" :disabled="worker.loading" :title="worker.running ? 'Stop ' + worker.label : 'Start ' + worker.label"
+                        class="relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
+                        :class="worker.running ? 'bg-indigo-500' : 'bg-gray-300 dark:bg-lerd-muted'">
+                        <span class="inline-block h-3 w-3 rounded-full bg-white shadow transition-transform duration-200" :class="worker.running ? 'translate-x-3.5' : 'translate-x-0.5'"></span>
+                        <svg x-show="worker.loading" class="animate-spin absolute right-[-14px] w-2.5 h-2.5 text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                      </button>
+                      <span class="text-xs text-gray-500 dark:text-gray-400" x-text="worker.label"></span>
+                      <span x-show="worker.error" class="text-[10px] text-red-500" x-text="worker.error"></span>
                     </div>
                   </template>
 
-                  <!-- Update available -->
-                  <template x-if="version.hasUpdate">
-                    <div class="space-y-3">
-                      <div class="flex flex-wrap items-center gap-3">
-                        <span class="inline-flex items-center gap-1.5 text-sm font-medium text-yellow-700 dark:text-yellow-400">
-                          <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"/></svg>
-                          <span x-text="version.latest + ' available'"></span>
-                        </span>
-                        <code class="text-xs bg-gray-100 dark:bg-white/10 px-2 py-1 rounded font-mono text-gray-700 dark:text-gray-300">lerd update</code>
+                </div>
+
+              </div>
+
+              <!-- Git Worktrees -->
+              <template x-if="selectedSite.worktrees && selectedSite.worktrees.length > 0">
+                <div class="px-3 sm:px-5 py-4 border-t border-gray-100 dark:border-lerd-border shrink-0">
+                  <div class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-3">Git Worktrees</div>
+                  <div class="flex flex-col">
+                    <div class="flex items-center gap-1.5 py-1">
+                      <div class="flex items-center shrink-0 text-gray-300 dark:text-gray-600">
+                        <svg class="w-3.5 h-4" viewBox="0 0 14 16" fill="none"><path d="M2 8 L2 16" stroke="currentColor" stroke-width="1.5"/></svg>
                       </div>
-                      <template x-if="version.changelog">
-                        <div>
-                          <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">What's new</p>
-                          <pre class="text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-white/[0.03] rounded-lg p-3 overflow-x-auto whitespace-pre-wrap font-mono leading-relaxed border border-gray-100 dark:border-lerd-border" x-text="version.changelog"></pre>
+                      <svg class="w-3.5 h-3.5 shrink-0 text-violet-400" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M6 3v12M15 6a3 3 0 1 0 6 0a3 3 0 1 0-6 0M3 18a3 3 0 1 0 6 0a3 3 0 1 0-6 0M18 9a9 9 0 0 1-9 9"/></svg>
+                      <span class="text-xs font-mono text-gray-600 dark:text-gray-400 truncate flex-1" x-text="selectedSite.branch || 'main'"></span>
+                      <button @click="openSite(selectedSite)"
+                        class="shrink-0 flex items-center gap-1 text-[11px] font-medium text-gray-500 dark:text-gray-400 hover:text-lerd-red dark:hover:text-lerd-red border border-gray-200 dark:border-lerd-border hover:border-lerd-red/40 rounded px-1.5 py-0.5 transition-colors"
+                        :title="selectedSite.domain">
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                        <span class="font-mono" x-text="selectedSite.domain"></span>
+                      </button>
+                    </div>
+                    <template x-for="(wt, i) in selectedSite.worktrees" :key="wt.domain">
+                      <div class="flex items-center gap-1.5 py-1">
+                        <div class="flex items-center shrink-0 text-gray-300 dark:text-gray-600">
+                          <svg class="w-3.5 h-4" viewBox="0 0 14 16" fill="none">
+                            <path :d="i < selectedSite.worktrees.length - 1 ? 'M2 0 L2 16' : 'M2 0 L2 10'" stroke="currentColor" stroke-width="1.5"/>
+                            <path d="M2 10 L10 10" stroke="currentColor" stroke-width="1.5"/>
+                          </svg>
                         </div>
-                      </template>
-                    </div>
-                  </template>
-
-                  <!-- Check button -->
-                  <button
-                    @click="checkVersion()"
-                    :disabled="version.checking"
-                    class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-gray-100 hover:bg-gray-200 dark:bg-white/5 dark:hover:bg-white/10 disabled:opacity-40 text-gray-700 dark:text-gray-300 transition-colors"
-                  >
-                    <svg x-show="version.checking" class="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
-                    <svg x-show="!version.checking" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
-                    <span x-text="version.checking ? 'Checking…' : 'Check for updates'"></span>
-                  </button>
-
-                </div>
-              </div>
-            </template>
-
-            <!-- Autostart -->
-            <template x-if="selectedSystem === 'autostart'">
-              <div class="bg-white dark:bg-lerd-card rounded-xl border border-gray-200 dark:border-lerd-border overflow-hidden">
-                <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
-                  <span class="font-semibold text-gray-900 dark:text-white text-base">Autostart</span>
-                  <span class="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full"
-                    :class="autostartEnabled ? 'bg-emerald-100 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-500' : 'bg-gray-100 dark:bg-white/5 text-gray-500'"
-                  >
-                    <span class="w-1.5 h-1.5 rounded-full" :class="autostartEnabled ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
-                    <span x-text="autostartEnabled ? 'Enabled' : 'Disabled'"></span>
-                  </span>
-                </div>
-                <div class="px-3 sm:px-5 py-4">
-                  <div class="flex items-center justify-between gap-4">
-                    <div>
-                      <p class="text-sm font-medium text-gray-700 dark:text-gray-300">Start on login</p>
-                      <p class="text-xs text-gray-400 mt-0.5">When enabled, lerd starts automatically on every login.</p>
-                    </div>
-                    <button
-                      @click="toggleAutostart()"
-                      :disabled="autostartLoading"
-                      :title="autostartEnabled ? 'Disable autostart' : 'Enable autostart'"
-                      class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
-                      :class="autostartEnabled ? 'bg-lerd-red' : 'bg-gray-300 dark:bg-lerd-muted'"
-                    >
-                      <span
-                        class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform duration-200"
-                        :class="autostartEnabled ? 'translate-x-4' : 'translate-x-1'"
-                      ></span>
-                    </button>
+                        <svg class="w-3.5 h-3.5 shrink-0 text-violet-400" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M6 3v12M15 6a3 3 0 1 0 6 0a3 3 0 1 0-6 0M3 18a3 3 0 1 0 6 0a3 3 0 1 0-6 0M18 9a9 9 0 0 1-9 9"/></svg>
+                        <span class="text-xs font-mono text-gray-600 dark:text-gray-400 truncate flex-1" x-text="wt.branch"></span>
+                        <button @click="openWorktree(wt)"
+                          class="shrink-0 flex items-center gap-1 text-[11px] font-medium text-gray-500 dark:text-gray-400 hover:text-lerd-red dark:hover:text-lerd-red border border-gray-200 dark:border-lerd-border hover:border-lerd-red/40 rounded px-1.5 py-0.5 transition-colors"
+                          :title="wt.domain">
+                          <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                          <span class="font-mono" x-text="wt.domain"></span>
+                        </button>
+                      </div>
+                    </template>
                   </div>
                 </div>
+              </template>
+
+              <!-- Logs -->
+              <div class="flex-1 flex flex-col overflow-hidden min-h-0">
+                <div class="flex items-center gap-0 border-b border-gray-100 dark:border-lerd-border px-3 sm:px-5 pt-3 shrink-0">
+                  <button @click="setSiteLogsTab('fpm')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='fpm' ? 'border-lerd-red text-lerd-red' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'">PHP-FPM</button>
+                  <template x-if="selectedSite && selectedSite.queue_running">
+                    <button @click="setSiteLogsTab('queue')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='queue' ? 'border-amber-500 text-amber-600 dark:text-amber-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'">Queue</button>
+                  </template>
+                  <template x-if="selectedSite && selectedSite.horizon_running">
+                    <button @click="setSiteLogsTab('horizon')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='horizon' ? 'border-amber-500 text-amber-600 dark:text-amber-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'">Horizon</button>
+                  </template>
+                  <template x-if="selectedSite && selectedSite.stripe_running">
+                    <button @click="setSiteLogsTab('stripe')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='stripe' ? 'border-violet-500 text-violet-600 dark:text-violet-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'">Stripe</button>
+                  </template>
+                  <template x-if="selectedSite && selectedSite.schedule_running">
+                    <button @click="setSiteLogsTab('schedule')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='schedule' ? 'border-emerald-500 text-emerald-600 dark:text-emerald-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'">Schedule</button>
+                  </template>
+                  <template x-if="selectedSite && selectedSite.reverb_running">
+                    <button @click="setSiteLogsTab('reverb')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='reverb' ? 'border-sky-500 text-sky-600 dark:text-sky-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'">Reverb</button>
+                  </template>
+                  <template x-for="worker in (selectedSite && selectedSite.framework_workers || []).filter(w => w.running)" :key="'tab-' + worker.name">
+                    <button @click="setSiteLogsTab('worker:' + worker.name)" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab === 'worker:' + worker.name ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'" x-text="worker.label"></button>
+                  </template>
+                </div>
+
+                <!-- PHP-FPM log -->
+                <div x-show="siteLogsTab === 'fpm'" class="flex-1 flex flex-col overflow-hidden min-h-0">
+                  <div class="flex items-center gap-1 text-[10px] px-3 sm:px-5 py-1.5 shrink-0" :class="siteLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
+                    <span class="w-1.5 h-1.5 rounded-full" :class="siteLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                    <span x-text="siteLogs.connected ? 'live' : 'connecting...'"></span>
+                  </div>
+                  <div x-ref="siteLogScroll" class="flex-1 overflow-y-auto bg-gray-50 dark:bg-lerd-bg px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5">
+                    <template x-if="siteLogs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div></template>
+                    <template x-for="(line, i) in siteLogs.lines" :key="i">
+                      <div class="whitespace-pre-wrap break-all" :class="{'text-red-500': line.includes('ERROR') || line.includes('Error') || line.includes('PHP Fatal') || line.includes('PHP Warning'), 'text-yellow-600 dark:text-yellow-400': line.includes('WARNING') || line.includes('Warning') || line.includes('PHP Notice'), 'text-gray-600 dark:text-gray-400': !line.includes('ERROR') && !line.includes('Error') && !line.includes('WARNING') && !line.includes('Warning')}" x-text="line"></div>
+                    </template>
+                  </div>
+                </div>
+
+                <!-- Queue log -->
+                <div x-show="siteLogsTab === 'queue'" class="flex-1 flex flex-col overflow-hidden min-h-0">
+                  <div class="flex items-center gap-1 text-[10px] px-3 sm:px-5 py-1.5 shrink-0" :class="siteQueueLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
+                    <span class="w-1.5 h-1.5 rounded-full" :class="siteQueueLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                    <span x-text="siteQueueLogs.connected ? 'live' : 'connecting...'"></span>
+                  </div>
+                  <div x-ref="siteQueueLogScroll" class="flex-1 overflow-y-auto bg-gray-50 dark:bg-lerd-bg px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5">
+                    <template x-if="siteQueueLogs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div></template>
+                    <template x-for="(line, i) in siteQueueLogs.lines" :key="i"><div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div></template>
+                  </div>
+                </div>
+
+                <!-- Horizon log -->
+                <div x-show="siteLogsTab === 'horizon'" class="flex-1 flex flex-col overflow-hidden min-h-0">
+                  <div class="flex items-center gap-1 text-[10px] px-3 sm:px-5 py-1.5 shrink-0" :class="siteHorizonLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
+                    <span class="w-1.5 h-1.5 rounded-full" :class="siteHorizonLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                    <span x-text="siteHorizonLogs.connected ? 'live' : 'connecting...'"></span>
+                  </div>
+                  <div x-ref="siteHorizonLogScroll" class="flex-1 overflow-y-auto bg-gray-50 dark:bg-lerd-bg px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5">
+                    <template x-if="siteHorizonLogs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div></template>
+                    <template x-for="(line, i) in siteHorizonLogs.lines" :key="i"><div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div></template>
+                  </div>
+                </div>
+
+                <!-- Stripe log -->
+                <div x-show="siteLogsTab === 'stripe'" class="flex-1 flex flex-col overflow-hidden min-h-0">
+                  <div class="flex items-center gap-1 text-[10px] px-3 sm:px-5 py-1.5 shrink-0" :class="siteStripeLogs.connected ? 'text-violet-600 dark:text-violet-500' : 'text-gray-400 dark:text-gray-600'">
+                    <span class="w-1.5 h-1.5 rounded-full" :class="siteStripeLogs.connected ? 'bg-violet-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                    <span x-text="siteStripeLogs.connected ? 'live' : 'connecting...'"></span>
+                  </div>
+                  <div x-ref="siteStripeLogScroll" class="flex-1 overflow-y-auto bg-gray-50 dark:bg-lerd-bg px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5">
+                    <template x-if="siteStripeLogs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div></template>
+                    <template x-for="(line, i) in siteStripeLogs.lines" :key="i"><div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div></template>
+                  </div>
+                </div>
+
+                <!-- Schedule log -->
+                <div x-show="siteLogsTab === 'schedule'" class="flex-1 flex flex-col overflow-hidden min-h-0">
+                  <div class="flex items-center gap-1 text-[10px] px-3 sm:px-5 py-1.5 shrink-0" :class="siteScheduleLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
+                    <span class="w-1.5 h-1.5 rounded-full" :class="siteScheduleLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                    <span x-text="siteScheduleLogs.connected ? 'live' : 'connecting...'"></span>
+                  </div>
+                  <div x-ref="siteScheduleLogScroll" class="flex-1 overflow-y-auto bg-gray-50 dark:bg-lerd-bg px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5">
+                    <template x-if="siteScheduleLogs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div></template>
+                    <template x-for="(line, i) in siteScheduleLogs.lines" :key="i"><div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div></template>
+                  </div>
+                </div>
+
+                <!-- Reverb log -->
+                <div x-show="siteLogsTab === 'reverb'" class="flex-1 flex flex-col overflow-hidden min-h-0">
+                  <div class="flex items-center gap-1 text-[10px] px-3 sm:px-5 py-1.5 shrink-0" :class="siteReverbLogs.connected ? 'text-sky-600 dark:text-sky-500' : 'text-gray-400 dark:text-gray-600'">
+                    <span class="w-1.5 h-1.5 rounded-full" :class="siteReverbLogs.connected ? 'bg-sky-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                    <span x-text="siteReverbLogs.connected ? 'live' : 'connecting...'"></span>
+                  </div>
+                  <div x-ref="siteReverbLogScroll" class="flex-1 overflow-y-auto bg-gray-50 dark:bg-lerd-bg px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5">
+                    <template x-if="siteReverbLogs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div></template>
+                    <template x-for="(line, i) in siteReverbLogs.lines" :key="i"><div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div></template>
+                  </div>
+                </div>
+
+                <!-- Custom worker log -->
+                <div x-show="siteLogsTab.startsWith('worker:')" class="flex-1 flex flex-col overflow-hidden min-h-0">
+                  <div class="flex items-center gap-1 text-[10px] px-3 sm:px-5 py-1.5 shrink-0" :class="siteWorkerLogs.connected ? 'text-indigo-600 dark:text-indigo-500' : 'text-gray-400 dark:text-gray-600'">
+                    <span class="w-1.5 h-1.5 rounded-full" :class="siteWorkerLogs.connected ? 'bg-indigo-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                    <span x-text="siteWorkerLogs.connected ? 'live' : 'connecting...'"></span>
+                  </div>
+                  <div x-ref="siteWorkerLogScroll" class="flex-1 overflow-y-auto bg-gray-50 dark:bg-lerd-bg px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5">
+                    <template x-if="siteWorkerLogs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div></template>
+                    <template x-for="(line, i) in siteWorkerLogs.lines" :key="i"><div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div></template>
+                  </div>
+                </div>
+
               </div>
-            </template>
 
-          </div>
-        </div>
-      </template>
-    </div>
+            </div>
+          </template>
 
-  </main>
+        </div><!-- end sites detail -->
+
+        <!-- ══════════════ SERVICES DETAIL ══════════════ -->
+        <div x-show="tab === 'services'" class="flex-1 flex flex-col overflow-hidden">
+
+          <template x-if="!selectedService">
+            <div class="p-10 text-center">
+              <p class="text-sm text-gray-400">Select a service to view details</p>
+            </div>
+          </template>
+
+          <template x-if="selectedService">
+            <div class="flex-1 flex flex-col overflow-hidden min-h-0">
+
+              <!-- Header -->
+              <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border shrink-0">
+                <div class="flex items-center gap-3">
+                  <div>
+                    <div class="flex items-center gap-2">
+                      <span class="font-semibold text-gray-900 dark:text-white text-base"
+                        x-text="selectedService.queue_site ? 'Queue worker' : selectedService.horizon_site ? 'Horizon' : selectedService.stripe_listener_site ? 'Stripe listener' : capitalize(selectedService.name)"></span>
+                      <span class="inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-full"
+                        :class="selectedService.status === 'active' ? 'bg-emerald-100 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-500' : 'bg-gray-100 dark:bg-white/5 text-gray-500'">
+                        <span class="w-1.5 h-1.5 rounded-full" :class="selectedService.status === 'active' ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                        <span x-text="selectedService.status"></span>
+                      </span>
+                    </div>
+                    <template x-if="selectedService.queue_site">
+                      <button @click="setTab('sites'); selectSite(sites.find(s => s.domain === selectedService.queue_site + '.test'))"
+                        class="inline-flex items-center gap-1.5 mt-1 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 border border-gray-200 dark:border-lerd-border text-gray-700 dark:text-gray-300 rounded-full px-2 py-0.5 transition-colors">
+                        <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-gray-400"></span>
+                        <span x-text="selectedService.queue_site + '.test'"></span>
+                      </button>
+                    </template>
+                    <template x-if="selectedService.horizon_site">
+                      <button @click="setTab('sites'); selectSite(sites.find(s => s.domain === selectedService.horizon_site + '.test'))"
+                        class="inline-flex items-center gap-1.5 mt-1 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 border border-gray-200 dark:border-lerd-border text-gray-700 dark:text-gray-300 rounded-full px-2 py-0.5 transition-colors">
+                        <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-gray-400"></span>
+                        <span x-text="selectedService.horizon_site + '.test'"></span>
+                      </button>
+                    </template>
+                    <template x-if="selectedService.stripe_listener_site">
+                      <button @click="setTab('sites'); selectSite(sites.find(s => s.domain === selectedService.stripe_listener_site + '.test'))"
+                        class="inline-flex items-center gap-1.5 mt-1 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 border border-gray-200 dark:border-lerd-border text-gray-700 dark:text-gray-300 rounded-full px-2 py-0.5 transition-colors">
+                        <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-gray-400"></span>
+                        <span x-text="selectedService.stripe_listener_site + '.test'"></span>
+                      </button>
+                    </template>
+                    <template x-if="selectedService.schedule_worker_site">
+                      <button @click="setTab('sites'); selectSite(sites.find(s => s.domain === selectedService.schedule_worker_site + '.test'))"
+                        class="inline-flex items-center gap-1.5 mt-1 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 border border-gray-200 dark:border-lerd-border text-gray-700 dark:text-gray-300 rounded-full px-2 py-0.5 transition-colors">
+                        <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-gray-400"></span>
+                        <span x-text="selectedService.schedule_worker_site + '.test'"></span>
+                      </button>
+                    </template>
+                    <template x-if="selectedService.reverb_site">
+                      <button @click="setTab('sites'); selectSite(sites.find(s => s.domain === selectedService.reverb_site + '.test'))"
+                        class="inline-flex items-center gap-1.5 mt-1 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 border border-gray-200 dark:border-lerd-border text-gray-700 dark:text-gray-300 rounded-full px-2 py-0.5 transition-colors">
+                        <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-gray-400"></span>
+                        <span x-text="selectedService.reverb_site + '.test'"></span>
+                      </button>
+                    </template>
+                    <template x-if="selectedService.worker_site">
+                      <button @click="setTab('sites'); selectSite(sites.find(s => s.domain === selectedService.worker_site + '.test'))"
+                        class="inline-flex items-center gap-1.5 mt-1 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 border border-gray-200 dark:border-lerd-border text-gray-700 dark:text-gray-300 rounded-full px-2 py-0.5 transition-colors">
+                        <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-gray-400"></span>
+                        <span x-text="selectedService.worker_site + '.test'"></span>
+                      </button>
+                    </template>
+                    <template x-if="!selectedService.queue_site && !selectedService.stripe_listener_site && selectedService.site_domains && selectedService.site_domains.length > 0">
+                      <div class="flex flex-wrap gap-1 mt-1">
+                        <template x-for="domain in selectedService.site_domains" :key="domain">
+                          <button @click="setTab('sites'); selectSite(sites.find(s => s.domain === domain))"
+                            class="inline-flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 border border-gray-200 dark:border-lerd-border text-gray-700 dark:text-gray-300 rounded-full px-2 py-0.5 transition-colors">
+                            <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-gray-400"></span>
+                            <span x-text="domain"></span>
+                          </button>
+                        </template>
+                      </div>
+                    </template>
+                    <template x-if="selectedService.depends_on && selectedService.depends_on.length > 0">
+                      <div class="flex items-center gap-1 flex-wrap mt-1">
+                        <span class="text-xs text-gray-400">depends on:</span>
+                        <template x-for="dep in selectedService.depends_on" :key="dep">
+                          <span class="inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded bg-gray-100 dark:bg-white/5 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border">
+                            <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="services.find(s => s.name === dep)?.status === 'active' ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                            <span x-text="dep"></span>
+                          </span>
+                        </template>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+                <div class="flex items-center gap-2">
+                  <template x-if="!selectedService.queue_site && !selectedService.horizon_site && !selectedService.stripe_listener_site && selectedService.status !== 'active'">
+                    <button @click="toggleService(selectedService, 'start')" :disabled="selectedService.loading"
+                      class="flex items-center gap-1.5 text-xs font-medium bg-lerd-red hover:bg-lerd-redhov text-white rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50">
+                      <svg x-show="selectedService.loading" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                      <span x-show="!selectedService.loading">Start</span>
+                    </button>
+                  </template>
+                  <template x-if="selectedService.status === 'active'">
+                    <button @click="toggleService(selectedService, 'stop')" :disabled="selectedService.loading"
+                      class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50">
+                      <svg x-show="selectedService.loading" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                      <span x-show="!selectedService.loading">Stop</span>
+                    </button>
+                  </template>
+                  <template x-if="!selectedService.queue_site && !selectedService.horizon_site && !selectedService.stripe_listener_site && !selectedService.schedule_worker_site && !selectedService.reverb_site && !selectedService.worker_site">
+                    <button @click="toggleServicePin(selectedService)" :disabled="selectedService.loading"
+                      :title="selectedService.pinned ? 'Unpin — allow auto-stop when unused' : 'Pin — prevent auto-stop when unused'"
+                      class="flex items-center gap-1 text-xs font-medium border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
+                      :class="selectedService.pinned ? 'bg-amber-50 dark:bg-amber-500/10 border-amber-300 dark:border-amber-500/40 text-amber-600 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-500/20' : 'bg-gray-100 dark:bg-white/5 border-gray-200 dark:border-lerd-border text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-white/10'">
+                      <svg x-show="selectedService.pinned" class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 17v5M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1v4.76z"/></svg>
+                      <svg x-show="!selectedService.pinned" class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="17" x2="12" y2="22"/><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1v4.76z"/></svg>
+                      <span x-text="selectedService.pinned ? 'Pinned' : 'Pin'"></span>
+                    </button>
+                  </template>
+                  <template x-if="!selectedService.queue_site && selectedService.custom && selectedService.status !== 'active'">
+                    <button @click="removeService(selectedService)" :disabled="selectedService.loading"
+                      class="flex items-center gap-1 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-red-50 dark:hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 hover:border-red-200 dark:hover:border-red-500/30 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
+                      title="Remove this custom service">
+                      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+                    </button>
+                  </template>
+                  <template x-if="selectedService.status === 'active' && selectedService.dashboard">
+                    <a :href="selectedService.dashboard" target="_blank"
+                      class="flex items-center gap-1 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors"
+                      title="Open dashboard">
+                      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                      Dashboard
+                    </a>
+                  </template>
+                </div>
+              </div>
+
+              <div x-show="selectedService.flash" class="mx-5 mt-4 text-xs text-center text-emerald-700 dark:text-emerald-500 bg-emerald-50 dark:bg-emerald-500/10 rounded-lg px-2 py-1.5" x-text="selectedService.flash"></div>
+              <template x-if="selectedService.error">
+                <div class="mx-5 mt-4 text-xs font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10 rounded-lg px-3 py-1.5" x-text="selectedService.error"></div>
+              </template>
+
+              <!-- Tab bar -->
+              <div class="flex gap-0 border-b border-gray-100 dark:border-lerd-border pt-3 px-3 sm:px-5 shrink-0">
+                <button @click="svcDetailTab = 'logs'" class="pb-2 mr-5 text-sm font-medium transition-colors border-b-2" :class="svcDetailTab==='logs' ? 'border-lerd-red text-lerd-red' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'">Logs</button>
+                <template x-if="selectedService.env_vars && Object.keys(selectedService.env_vars).length > 0">
+                  <button @click="svcDetailTab = 'env'" class="pb-2 text-sm font-medium transition-colors border-b-2" :class="svcDetailTab==='env' ? 'border-lerd-red text-lerd-red' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'">.env</button>
+                </template>
+              </div>
+
+              <!-- Logs tab -->
+              <div x-show="svcDetailTab === 'logs'" class="flex-1 flex flex-col overflow-hidden min-h-0">
+                <div class="flex items-center justify-between px-3 sm:px-5 py-2 shrink-0">
+                  <div class="flex items-center gap-2.5">
+                    <span class="flex items-center gap-1.5 text-[10px]" :class="svcLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
+                      <span class="w-1.5 h-1.5 rounded-full" :class="svcLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                      <span x-text="svcLogs.connected ? 'live' : 'disconnected'"></span>
+                    </span>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <button @click="svcLogs.lines = []" class="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-400 transition-colors">Clear</button>
+                    <button @click="openServiceLogs(selectedService)" class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 border border-gray-200 dark:border-lerd-border hover:border-gray-300 dark:hover:border-lerd-muted rounded px-2 py-1 transition-colors">Reconnect</button>
+                  </div>
+                </div>
+                <div class="flex-1 overflow-y-auto bg-gray-50 dark:bg-lerd-bg px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5" x-ref="svcLogScroll">
+                  <template x-if="svcLogs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div></template>
+                  <template x-for="(line, i) in svcLogs.lines" :key="i">
+                    <div class="whitespace-pre-wrap break-all" :class="{'text-red-500': line.includes('ERROR') || line.includes('Error'), 'text-yellow-600 dark:text-yellow-400': !line.includes('ERROR') && !line.includes('Error') && (line.includes('WARNING') || line.includes('Warning')), 'text-gray-600 dark:text-gray-400': !line.includes('ERROR') && !line.includes('Error') && !line.includes('WARNING') && !line.includes('Warning')}" x-text="line"></div>
+                  </template>
+                </div>
+              </div>
+
+              <!-- .env tab -->
+              <div x-show="svcDetailTab === 'env'" class="p-3 sm:p-5 space-y-3">
+                <template x-if="selectedService.connection_url">
+                  <div class="rounded-lg border border-gray-200 dark:border-lerd-border overflow-hidden">
+                    <div class="flex items-center justify-between bg-gray-50 dark:bg-white/[0.03] px-3 py-1.5 border-b border-gray-200 dark:border-lerd-border">
+                      <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Connect</span>
+                    </div>
+                    <div class="bg-gray-50 dark:bg-black/40 px-3 py-2.5">
+                      <a :href="selectedService.connection_url" class="font-mono text-[10px] text-sky-600 dark:text-sky-400 hover:underline break-all" x-text="selectedService.connection_url"></a>
+                      <p class="text-[10px] text-gray-400 dark:text-gray-600 mt-1.5">Use <code class="text-gray-500 dark:text-gray-400">127.0.0.1</code> or <code class="text-gray-500 dark:text-gray-400">localhost</code> from your host machine or DB client. Inside your app containers use the hostname shown in <code class="text-gray-500 dark:text-gray-400">DB_HOST</code> below.</p>
+                    </div>
+                  </div>
+                </template>
+                <div class="rounded-lg border border-gray-200 dark:border-lerd-border overflow-hidden">
+                  <div class="flex items-center justify-between bg-gray-50 dark:bg-white/[0.03] px-3 py-1.5 border-b border-gray-200 dark:border-lerd-border">
+                    <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">.env</span>
+                    <button @click="copyEnvVars(selectedService)" class="text-[10px] font-medium text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors">
+                      <span x-show="!selectedService.copied">Copy</span>
+                      <span x-show="selectedService.copied" class="text-emerald-600 dark:text-emerald-500">Copied!</span>
+                    </button>
+                  </div>
+                  <pre class="bg-gray-50 dark:bg-black/40 text-gray-600 dark:text-gray-400 px-3 py-2.5 text-[10px] leading-relaxed overflow-x-auto whitespace-pre" x-text="envPreview(selectedService)"></pre>
+                </div>
+              </div>
+
+            </div>
+          </template>
+
+        </div><!-- end services detail -->
+
+        <!-- ══════════════ SYSTEM DETAIL ══════════════ -->
+        <div x-show="tab === 'system'" class="flex-1 flex flex-col overflow-hidden">
+
+          <template x-if="!selectedSystem">
+            <div class="p-10 text-center">
+              <p class="text-sm text-gray-400">Select an item to view details</p>
+            </div>
+          </template>
+
+          <!-- DNS -->
+          <template x-if="selectedSystem === 'dns'">
+            <div class="flex-1 flex flex-col overflow-hidden min-h-0">
+              <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border shrink-0">
+                <span class="font-semibold text-gray-900 dark:text-white text-base">DNS</span>
+                <template x-if="systemStatus.dns && systemStatus.dns.ok">
+                  <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-500 px-2.5 py-1 rounded-full"><span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>OK</span>
+                </template>
+                <template x-if="!systemStatus.dns || !systemStatus.dns.ok">
+                  <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-red-100 dark:bg-red-500/10 text-red-600 dark:text-red-400 px-2.5 py-1 rounded-full"><span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>Failed</span>
+                </template>
+              </div>
+              <div class="px-3 sm:px-5 py-3 space-y-2 shrink-0">
+                <div class="flex items-center justify-between">
+                  <span class="text-sm text-gray-500">TLD</span>
+                  <code class="bg-gray-100 dark:bg-white/5 border border-gray-200 dark:border-lerd-border px-1.5 py-0.5 rounded text-gray-600 dark:text-gray-400 text-xs" x-text="'.' + (systemStatus.dns ? systemStatus.dns.tld : 'test')"></code>
+                </div>
+                <template x-if="!systemStatus.dns || !systemStatus.dns.ok">
+                  <p class="text-xs text-gray-400">Try clicking <strong class="text-gray-500">Start</strong> above, or run <code class="bg-gray-100 dark:bg-white/5 px-1 rounded text-gray-500">lerd install</code> to fix DNS.</p>
+                </template>
+              </div>
+              <div class="flex-1 flex flex-col overflow-hidden min-h-0">
+                <div class="flex items-center justify-between px-3 sm:px-5 py-2 shrink-0">
+                  <span class="flex items-center gap-1.5 text-[10px]" :class="systemLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
+                    <span class="w-1.5 h-1.5 rounded-full" :class="systemLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                    <span x-text="systemLogs.connected ? 'live' : 'disconnected'"></span>
+                  </span>
+                  <div class="flex items-center gap-2">
+                    <button @click="systemLogs.lines = []" class="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-400 transition-colors">Clear</button>
+                    <button @click="openSystemLogs('lerd-dns')" class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 border border-gray-200 dark:border-lerd-border hover:border-gray-300 dark:hover:border-lerd-muted rounded px-2 py-1 transition-colors">Reconnect</button>
+                  </div>
+                </div>
+                <div class="flex-1 overflow-y-auto bg-gray-50 dark:bg-lerd-bg px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5" x-ref="dnsLogScroll">
+                  <template x-if="systemLogs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div></template>
+                  <template x-for="(line, i) in systemLogs.lines" :key="i"><div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div></template>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <!-- Nginx -->
+          <template x-if="selectedSystem === 'nginx'">
+            <div class="flex-1 flex flex-col overflow-hidden min-h-0">
+              <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border shrink-0">
+                <span class="font-semibold text-gray-900 dark:text-white text-base">Nginx</span>
+                <template x-if="systemStatus.nginx && systemStatus.nginx.running">
+                  <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-500 px-2.5 py-1 rounded-full"><span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>Running</span>
+                </template>
+                <template x-if="!systemStatus.nginx || !systemStatus.nginx.running">
+                  <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-red-100 dark:bg-red-500/10 text-red-600 dark:text-red-400 px-2.5 py-1 rounded-full"><span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>Stopped</span>
+                </template>
+              </div>
+              <div class="px-3 sm:px-5 py-3 shrink-0">
+                <div class="flex items-center justify-between">
+                  <span class="text-sm text-gray-500">Container</span>
+                  <code class="bg-gray-100 dark:bg-white/5 border border-gray-200 dark:border-lerd-border px-1.5 py-0.5 rounded text-gray-600 dark:text-gray-400 text-xs">lerd-nginx</code>
+                </div>
+              </div>
+              <div class="flex-1 flex flex-col overflow-hidden min-h-0">
+                <div class="flex items-center justify-between px-3 sm:px-5 py-2 shrink-0">
+                  <span class="flex items-center gap-1.5 text-[10px]" :class="systemLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
+                    <span class="w-1.5 h-1.5 rounded-full" :class="systemLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                    <span x-text="systemLogs.connected ? 'live' : 'disconnected'"></span>
+                  </span>
+                  <div class="flex items-center gap-2">
+                    <button @click="systemLogs.lines = []" class="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-400 transition-colors">Clear</button>
+                    <button @click="openSystemLogs('lerd-nginx')" class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 border border-gray-200 dark:border-lerd-border hover:border-gray-300 dark:hover:border-lerd-muted rounded px-2 py-1 transition-colors">Reconnect</button>
+                  </div>
+                </div>
+                <div class="flex-1 overflow-y-auto bg-gray-50 dark:bg-lerd-bg px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5" x-ref="nginxLogScroll">
+                  <template x-if="systemLogs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div></template>
+                  <template x-for="(line, i) in systemLogs.lines" :key="i">
+                    <div class="whitespace-pre-wrap break-all" :class="{'text-red-500': line.includes('error') || line.includes('Error') || line.includes('crit'), 'text-yellow-600 dark:text-yellow-400': !line.includes('error') && !line.includes('Error') && !line.includes('crit') && line.includes('warn'), 'text-gray-600 dark:text-gray-400': !line.includes('error') && !line.includes('Error') && !line.includes('crit') && !line.includes('warn')}" x-text="line"></div>
+                  </template>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <!-- Watcher -->
+          <template x-if="selectedSystem === 'watcher'">
+            <div class="flex-1 flex flex-col overflow-hidden min-h-0">
+              <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border shrink-0">
+                <span class="font-semibold text-gray-900 dark:text-white text-base">Watcher</span>
+                <template x-if="systemStatus.watcher_running">
+                  <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-500 px-2.5 py-1 rounded-full"><span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>Running</span>
+                </template>
+                <template x-if="!systemStatus.watcher_running">
+                  <div class="flex items-center gap-2">
+                    <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-red-100 dark:bg-red-500/10 text-red-600 dark:text-red-400 px-2.5 py-1 rounded-full"><span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>Stopped</span>
+                    <button @click="startWatcher()" :disabled="watcherStarting" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-emerald-600 hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors">
+                      <svg x-show="watcherStarting" class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
+                      <span x-text="watcherStarting ? 'Starting…' : 'Start'"></span>
+                    </button>
+                  </div>
+                </template>
+              </div>
+              <p class="px-3 sm:px-5 py-3 text-xs text-gray-400 shrink-0">Monitors parked directories, site files, git worktrees, and DNS health. Logs WARN and ERROR events by default; set <code class="bg-gray-100 dark:bg-white/5 px-1 rounded">LERD_DEBUG=1</code> in the service environment for verbose output.</p>
+              <div class="flex-1 flex flex-col overflow-hidden min-h-0">
+                <div class="flex items-center justify-between px-3 sm:px-5 py-2 shrink-0">
+                  <span class="flex items-center gap-1.5 text-[10px]" :class="systemLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
+                    <span class="w-1.5 h-1.5 rounded-full" :class="systemLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                    <span x-text="systemLogs.connected ? 'live' : 'disconnected'"></span>
+                  </span>
+                  <div class="flex items-center gap-2">
+                    <button @click="systemLogs.lines = []" class="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-400 transition-colors">Clear</button>
+                    <button @click="openWatcherLogs()" class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 border border-gray-200 dark:border-lerd-border hover:border-gray-300 dark:hover:border-lerd-muted rounded px-2 py-1 transition-colors">Reconnect</button>
+                  </div>
+                </div>
+                <div class="flex-1 overflow-y-auto bg-gray-50 dark:bg-lerd-bg px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5" x-ref="watcherLogScroll">
+                  <template x-if="systemLogs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">No events yet — watcher is running quietly.</div></template>
+                  <template x-for="(line, i) in systemLogs.lines" :key="i">
+                    <div class="whitespace-pre-wrap break-all" :class="{'text-red-500': line.includes('level=ERROR') || line.includes('error'), 'text-yellow-600 dark:text-yellow-400': !line.includes('level=ERROR') && !line.includes('error') && line.includes('level=WARN'), 'text-gray-600 dark:text-gray-400': !line.includes('level=ERROR') && !line.includes('error') && !line.includes('level=WARN')}" x-text="line"></div>
+                  </template>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <!-- PHP version detail -->
+          <template x-if="selectedPHPVersion">
+            <div class="flex-1 flex flex-col overflow-hidden min-h-0">
+              <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border shrink-0">
+                <div class="flex items-center gap-3">
+                  <span class="font-semibold text-gray-900 dark:text-white text-base" x-text="'PHP ' + selectedPHPVersion"></span>
+                  <template x-if="fpmRunning(selectedPHPVersion)">
+                    <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-500 px-2.5 py-1 rounded-full"><span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>Running</span>
+                  </template>
+                  <template x-if="!fpmRunning(selectedPHPVersion)">
+                    <span class="inline-flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 text-gray-500 px-2.5 py-1 rounded-full"><span class="w-1.5 h-1.5 rounded-full bg-gray-400 dark:bg-gray-600"></span>Stopped</span>
+                  </template>
+                  <template x-if="phpSiteCount(selectedPHPVersion) > 0">
+                    <span class="text-xs text-gray-400 dark:text-gray-500" x-text="phpSiteCount(selectedPHPVersion) + (phpSiteCount(selectedPHPVersion) === 1 ? ' site' : ' sites')"></span>
+                  </template>
+                </div>
+                <div class="flex items-center gap-2">
+                  <template x-if="systemStatus.php_default !== selectedPHPVersion">
+                    <button @click="setPHPDefault(selectedPHPVersion)" :disabled="phpDefaultLoading"
+                      class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50">
+                      <svg x-show="phpDefaultLoading" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                      <span x-show="!phpDefaultLoading">Set as default</span>
+                    </button>
+                  </template>
+                  <template x-if="phpSiteCount(selectedPHPVersion) === 0 && fpmRunning(selectedPHPVersion)">
+                    <button @click="toggleFPM(selectedPHPVersion)" :disabled="phpFPMLoading[selectedPHPVersion]"
+                      class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50">
+                      <svg x-show="phpFPMLoading[selectedPHPVersion]" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                      <span x-show="!phpFPMLoading[selectedPHPVersion]" x-text="fpmRunning(selectedPHPVersion) ? 'Stop' : 'Start'"></span>
+                    </button>
+                  </template>
+                  <template x-if="phpSiteCount(selectedPHPVersion) === 0">
+                    <button @click="removePHPVersion(selectedPHPVersion)" :disabled="phpRemoveLoading[selectedPHPVersion]"
+                      class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-red-50 dark:hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 hover:border-red-200 dark:hover:border-red-500/30 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50">
+                      <svg x-show="phpRemoveLoading[selectedPHPVersion]" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                      <span x-show="!phpRemoveLoading[selectedPHPVersion]">Remove</span>
+                    </button>
+                  </template>
+                </div>
+              </div>
+              <div class="px-3 sm:px-5 py-3 space-y-4 shrink-0">
+                <!-- Xdebug -->
+                <div class="flex items-center justify-between">
+                  <div>
+                    <p class="text-sm font-medium text-gray-700 dark:text-gray-300">Xdebug</p>
+                    <p class="text-xs text-gray-400 mt-0.5">Restarts FPM on toggle</p>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <button type="button" @click.prevent="toggleXdebug(selectedPHPVersion)"
+                      class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200 focus:outline-none"
+                      :class="xdebugEnabled[selectedPHPVersion] ? 'bg-purple-500' : 'bg-gray-300 dark:bg-lerd-muted'"
+                      :title="xdebugEnabled[selectedPHPVersion] ? 'Disable Xdebug' : 'Enable Xdebug'">
+                      <span class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform duration-200" :class="xdebugEnabled[selectedPHPVersion] ? 'translate-x-4' : 'translate-x-1'"></span>
+                    </button>
+                    <svg x-show="xdebugLoading[selectedPHPVersion]" style="display:none" class="animate-spin w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                  </div>
+                </div>
+                <!-- Container -->
+                <div class="flex items-center justify-between">
+                  <span class="text-sm text-gray-500">Container</span>
+                  <code class="bg-gray-100 dark:bg-white/5 border border-gray-200 dark:border-lerd-border px-1.5 py-0.5 rounded text-gray-600 dark:text-gray-400 text-xs" x-text="'lerd-php' + selectedPHPVersion.replace('.','') + '-fpm'"></code>
+                </div>
+                <!-- Sites -->
+                <div>
+                  <p class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">Sites</p>
+                  <template x-if="phpSiteCount(selectedPHPVersion) === 0">
+                    <p class="text-sm text-gray-400">No sites are using PHP <span x-text="selectedPHPVersion"></span>.</p>
+                  </template>
+                  <div class="flex flex-wrap gap-2">
+                    <template x-for="site in sites.filter(s => s.php_version === selectedPHPVersion)" :key="site.domain">
+                      <button @click="setTab('sites'); selectSite(site)"
+                        class="inline-flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 border border-gray-200 dark:border-lerd-border text-gray-700 dark:text-gray-300 rounded-full px-2.5 py-1 transition-colors">
+                        <span class="w-1.5 h-1.5 rounded-full shrink-0" :class="site.fpm_running ? 'bg-emerald-500' : 'bg-gray-400'"></span>
+                        <span x-text="site.domain"></span>
+                      </button>
+                    </template>
+                  </div>
+                </div>
+                <template x-if="phpRemoveError[selectedPHPVersion]">
+                  <div class="text-xs font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10 rounded-lg px-3 py-1.5" x-text="phpRemoveError[selectedPHPVersion]"></div>
+                </template>
+              </div>
+              <div class="flex-1 flex flex-col overflow-hidden min-h-0">
+                <div class="flex items-center justify-between px-3 sm:px-5 py-2 shrink-0">
+                  <span class="flex items-center gap-1.5 text-[10px]" :class="systemLogs.connected ? 'text-emerald-600 dark:text-emerald-500' : 'text-gray-400 dark:text-gray-600'">
+                    <span class="w-1.5 h-1.5 rounded-full" :class="systemLogs.connected ? 'bg-emerald-500 animate-pulse' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                    <span x-text="systemLogs.connected ? 'live' : 'disconnected'"></span>
+                  </span>
+                  <div class="flex items-center gap-2">
+                    <button @click="systemLogs.lines = []" class="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-400 transition-colors">Clear</button>
+                    <button @click="openSystemLogs('lerd-php' + selectedPHPVersion.replace('.','') + '-fpm')" class="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 border border-gray-200 dark:border-lerd-border hover:border-gray-300 dark:hover:border-lerd-muted rounded px-2 py-1 transition-colors">Reconnect</button>
+                  </div>
+                </div>
+                <div class="flex-1 overflow-y-auto bg-gray-50 dark:bg-lerd-bg px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5" x-ref="phpLogScroll">
+                  <template x-if="systemLogs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div></template>
+                  <template x-for="(line, i) in systemLogs.lines" :key="i">
+                    <div class="whitespace-pre-wrap break-all" :class="{'text-red-500': line.includes('ERROR') || line.includes('Error') || line.includes('PHP Fatal') || line.includes('PHP Warning'), 'text-yellow-600 dark:text-yellow-400': !line.includes('ERROR') && !line.includes('Error') && (line.includes('WARNING') || line.includes('Warning') || line.includes('PHP Notice')), 'text-gray-600 dark:text-gray-400': !line.includes('ERROR') && !line.includes('Error') && !line.includes('WARNING') && !line.includes('Warning')}" x-text="line"></div>
+                  </template>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <!-- Node version detail -->
+          <template x-if="selectedNodeVersion">
+            <div class="flex-1 overflow-y-auto">
+              <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
+                <div class="flex items-center gap-3">
+                  <span class="font-semibold text-gray-900 dark:text-white text-base" x-text="'Node ' + selectedNodeVersion"></span>
+                  <template x-if="nodeSiteCount(selectedNodeVersion) > 0">
+                    <span class="text-xs text-gray-400 dark:text-gray-500" x-text="nodeSiteCount(selectedNodeVersion) + (nodeSiteCount(selectedNodeVersion) === 1 ? ' site' : ' sites')"></span>
+                  </template>
+                </div>
+                <div class="flex items-center gap-2">
+                  <template x-if="systemStatus.node_default !== selectedNodeVersion">
+                    <button @click="setNodeDefault(selectedNodeVersion)" :disabled="nodeDefaultLoading"
+                      class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50">
+                      <svg x-show="nodeDefaultLoading" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                      <span x-show="!nodeDefaultLoading">Set as default</span>
+                    </button>
+                  </template>
+                  <template x-if="nodeSiteCount(selectedNodeVersion) === 0">
+                    <button @click="removeNodeVersion(selectedNodeVersion)" :disabled="nodeRemoveLoading[selectedNodeVersion]"
+                      class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-red-50 dark:hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 hover:border-red-200 dark:hover:border-red-500/30 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50">
+                      <svg x-show="nodeRemoveLoading[selectedNodeVersion]" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                      <span x-show="!nodeRemoveLoading[selectedNodeVersion]">Remove</span>
+                    </button>
+                  </template>
+                </div>
+              </div>
+              <div class="px-3 sm:px-5 py-4 space-y-4">
+                <div>
+                  <p class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">Sites</p>
+                  <template x-if="nodeSiteCount(selectedNodeVersion) === 0">
+                    <p class="text-sm text-gray-400">No sites are using Node <span x-text="selectedNodeVersion"></span>.</p>
+                  </template>
+                  <div class="flex flex-wrap gap-2">
+                    <template x-for="site in sites.filter(s => s.node_version === selectedNodeVersion || (!s.node_version && selectedNodeVersion === systemStatus.node_default))" :key="site.domain">
+                      <a :href="(site.tls ? 'https://' : 'http://') + site.domain" @click.prevent="openSite(site)"
+                        class="inline-flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 border border-gray-200 dark:border-lerd-border text-gray-700 dark:text-gray-300 rounded-full px-2.5 py-1 transition-colors">
+                        <span class="w-1.5 h-1.5 rounded-full shrink-0 bg-gray-400"></span>
+                        <span x-text="site.domain"></span>
+                      </a>
+                    </template>
+                  </div>
+                </div>
+                <template x-if="nodeRemoveError[selectedNodeVersion]">
+                  <div class="text-xs font-medium text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-500/10 rounded-lg px-3 py-1.5" x-text="nodeRemoveError[selectedNodeVersion]"></div>
+                </template>
+              </div>
+            </div>
+          </template>
+
+          <!-- Node install -->
+          <template x-if="selectedSystem === 'node-install'">
+            <div class="flex-1 overflow-y-auto">
+              <div class="px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
+                <span class="font-semibold text-gray-900 dark:text-white text-base">Install Node.js version</span>
+              </div>
+              <div class="px-3 sm:px-5 py-4 space-y-4">
+                <p class="text-sm text-gray-500">Install a new Node.js version using fnm.</p>
+                <div class="flex items-center gap-2">
+                  <input type="text" x-model="nodeInstall.version" @keydown.enter="installNodeVersion()" placeholder="e.g. 22"
+                    class="text-sm bg-white dark:bg-lerd-card border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 w-28 text-gray-700 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-600 focus:outline-none focus:border-lerd-red/50 transition-colors"
+                    :disabled="nodeInstall.installing">
+                  <button @click="installNodeVersion()" :disabled="nodeInstall.installing || !nodeInstall.version.trim()"
+                    class="text-sm bg-lerd-red hover:bg-lerd-redhov text-white rounded-lg px-3 py-1.5 transition-colors disabled:opacity-40 flex items-center gap-1.5 font-medium">
+                    <svg x-show="nodeInstall.installing" class="animate-spin w-3.5 h-3.5" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                    <span x-text="nodeInstall.installing ? 'Installing...' : 'Install'"></span>
+                  </button>
+                  <span x-show="nodeInstall.done" class="text-xs text-emerald-600 dark:text-emerald-500">Installed!</span>
+                  <span x-show="nodeInstall.error" class="text-xs text-red-500" x-text="nodeInstall.error"></span>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <!-- Lerd version -->
+          <template x-if="selectedSystem === 'lerd'">
+            <div class="flex-1 overflow-y-auto">
+              <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
+                <span class="font-semibold text-gray-900 dark:text-white text-base">Lerd</span>
+                <span class="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full bg-gray-100 dark:bg-white/5 text-gray-600 dark:text-gray-400 font-mono" x-text="'v' + version.current"></span>
+              </div>
+              <div class="px-3 sm:px-5 py-4 space-y-4">
+                <template x-if="version.checked && !version.hasUpdate">
+                  <div class="flex items-center gap-2 text-sm text-emerald-600 dark:text-emerald-500">
+                    <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>
+                    You're on the latest version.
+                  </div>
+                </template>
+                <template x-if="version.hasUpdate">
+                  <div class="space-y-3">
+                    <div class="flex flex-wrap items-center gap-3">
+                      <span class="inline-flex items-center gap-1.5 text-sm font-medium text-yellow-700 dark:text-yellow-400">
+                        <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"/></svg>
+                        <span x-text="version.latest + ' available'"></span>
+                      </span>
+                      <code class="text-xs bg-gray-100 dark:bg-white/10 px-2 py-1 rounded font-mono text-gray-700 dark:text-gray-300">lerd update</code>
+                    </div>
+                    <template x-if="version.changelog">
+                      <div>
+                        <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">What's new</p>
+                        <pre class="text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-white/[0.03] rounded-lg p-3 overflow-x-auto whitespace-pre-wrap font-mono leading-relaxed border border-gray-100 dark:border-lerd-border" x-text="version.changelog"></pre>
+                      </div>
+                    </template>
+                  </div>
+                </template>
+                <button @click="checkVersion()" :disabled="version.checking"
+                  class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-gray-100 hover:bg-gray-200 dark:bg-white/5 dark:hover:bg-white/10 disabled:opacity-40 text-gray-700 dark:text-gray-300 transition-colors">
+                  <svg x-show="version.checking" class="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
+                  <svg x-show="!version.checking" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
+                  <span x-text="version.checking ? 'Checking…' : 'Check for updates'"></span>
+                </button>
+              </div>
+            </div>
+          </template>
+
+          <!-- Autostart -->
+          <template x-if="selectedSystem === 'autostart'">
+            <div class="flex-1 overflow-y-auto">
+              <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
+                <span class="font-semibold text-gray-900 dark:text-white text-base">Autostart</span>
+                <span class="inline-flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-full"
+                  :class="autostartEnabled ? 'bg-emerald-100 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-500' : 'bg-gray-100 dark:bg-white/5 text-gray-500'">
+                  <span class="w-1.5 h-1.5 rounded-full" :class="autostartEnabled ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                  <span x-text="autostartEnabled ? 'Enabled' : 'Disabled'"></span>
+                </span>
+              </div>
+              <div class="px-3 sm:px-5 py-4">
+                <div class="flex items-center justify-between gap-4">
+                  <div>
+                    <p class="text-sm font-medium text-gray-700 dark:text-gray-300">Start on login</p>
+                    <p class="text-xs text-gray-400 mt-0.5">When enabled, lerd starts automatically on every login.</p>
+                  </div>
+                  <button @click="toggleAutostart()" :disabled="autostartLoading" :title="autostartEnabled ? 'Disable autostart' : 'Enable autostart'"
+                    class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
+                    :class="autostartEnabled ? 'bg-lerd-red' : 'bg-gray-300 dark:bg-lerd-muted'">
+                    <span class="inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform duration-200" :class="autostartEnabled ? 'translate-x-4' : 'translate-x-1'"></span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </template>
+
+        </div><!-- end system detail -->
+
+      </div><!-- end detail content -->
+
+    </div><!-- end detail area -->
+
+  </main><!-- end main content area -->
+
+  <!-- ════════════════════════════════════════════
+       MOBILE BOTTOM NAV
+  ════════════════════════════════════════════ -->
+  <nav class="md:hidden fixed bottom-0 left-0 right-0 z-30 flex border-t border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card">
+    <button @click="setTab('sites'); mobileShowDetail = false"
+      class="flex-1 flex flex-col items-center py-2 gap-0.5 transition-colors"
+      :class="tab==='sites' ? 'text-lerd-red' : 'text-gray-400 dark:text-gray-500'">
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg>
+      <span class="text-[10px] font-medium">Sites</span>
+    </button>
+    <button @click="setTab('services'); mobileShowDetail = false"
+      class="flex-1 flex flex-col items-center py-2 gap-0.5 transition-colors"
+      :class="tab==='services' ? 'text-lerd-red' : 'text-gray-400 dark:text-gray-500'">
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/></svg>
+      <span class="text-[10px] font-medium">Services</span>
+    </button>
+    <button @click="setTab('system'); mobileShowDetail = false"
+      class="flex-1 flex flex-col items-center py-2 gap-0.5 transition-colors"
+      :class="tab==='system' ? 'text-lerd-red' : 'text-gray-400 dark:text-gray-500'">
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+      <span class="text-[10px] font-medium">System</span>
+    </button>
+  </nav>
 
   <!-- Live logs drawer (fixed bottom) -->
   <div
@@ -1868,10 +1453,9 @@
     x-transition:leave="transition ease-in duration-150"
     x-transition:leave-start="translate-y-0 opacity-100"
     x-transition:leave-end="translate-y-full opacity-0"
-    class="fixed bottom-0 left-0 right-0 h-72 bg-white dark:bg-black border-t border-gray-200 dark:border-lerd-border flex flex-col z-50"
+    class="fixed left-0 right-0 h-72 bg-white dark:bg-black border-t border-gray-200 dark:border-lerd-border flex flex-col z-50 bottom-16 md:bottom-0"
     style="display:none"
   >
-    <!-- Drawer header -->
     <div class="flex items-center justify-between px-5 py-2.5 border-b border-gray-200 dark:border-lerd-border shrink-0 bg-gray-50 dark:bg-transparent">
       <div class="flex items-center gap-3">
         <span class="text-xs font-semibold text-gray-600 dark:text-gray-400 font-mono" x-text="logs.container"></span>
@@ -1883,27 +1467,14 @@
       <div class="flex items-center gap-4">
         <button @click="clearLogs()" class="text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-400 transition-colors">Clear</button>
         <button @click="closeLogs()" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-400 transition-colors" title="Close">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-          </svg>
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
         </button>
       </div>
     </div>
-    <!-- Log lines -->
     <div class="flex-1 overflow-y-auto px-5 py-3 font-mono text-[11px] leading-relaxed text-gray-500 space-y-0.5 bg-gray-50 dark:bg-transparent" x-ref="logScroll">
-      <template x-if="logs.lines.length === 0">
-        <div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div>
-      </template>
+      <template x-if="logs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div></template>
       <template x-for="(line, i) in logs.lines" :key="i">
-        <div
-          class="whitespace-pre-wrap break-all"
-          :class="{
-            'text-red-500':    line.includes('ERROR') || line.includes('Error') || line.includes('PHP Fatal') || line.includes('PHP Warning'),
-            'text-yellow-600 dark:text-yellow-400': line.includes('WARNING') || line.includes('Warning') || line.includes('PHP Notice'),
-            'text-gray-600 dark:text-gray-400':   !line.includes('ERROR') && !line.includes('Error') && !line.includes('WARNING') && !line.includes('Warning')
-          }"
-          x-text="line"
-        ></div>
+        <div class="whitespace-pre-wrap break-all" :class="{'text-red-500': line.includes('ERROR') || line.includes('Error') || line.includes('PHP Fatal') || line.includes('PHP Warning'), 'text-yellow-600 dark:text-yellow-400': line.includes('WARNING') || line.includes('Warning') || line.includes('PHP Notice'), 'text-gray-600 dark:text-gray-400': !line.includes('ERROR') && !line.includes('Error') && !line.includes('WARNING') && !line.includes('Warning')}" x-text="line"></div>
       </template>
     </div>
   </div>
@@ -1913,6 +1484,7 @@ function lerdApp() {
   return {
     theme: localStorage.getItem('lerd-theme') || 'auto',
     tab: ['sites','services','system'].includes(location.hash.slice(1)) ? location.hash.slice(1) : 'sites',
+    mobileShowDetail: false,
     sites: [],
     sitesLoading: false,
     selectedSiteDomain: null,
@@ -2018,11 +1590,15 @@ function lerdApp() {
     },
     setTab(t) {
       this.tab = t;
+      this.mobileShowDetail = false;
       location.hash = t;
     },
 
     init() {
       this.applyTheme(this.theme);
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+        if (this.theme === 'auto') this.applyTheme('auto');
+      });
       this.loadVersion();
       this.loadSettings();
       this.loadSites();
@@ -2123,7 +1699,6 @@ function lerdApp() {
               e.has_schedule_worker = s.has_schedule_worker;
               e.branch = s.branch;
               e.paused = s.paused;
-              // Merge framework_workers running state, preserving UI state
               if (s.framework_workers) {
                 if (e.framework_workers) {
                   s.framework_workers.forEach(sw => {
@@ -2152,6 +1727,7 @@ function lerdApp() {
     selectSite(site) {
       this.selectedSiteDomain = site.domain;
       this.siteLogsTab = 'fpm';
+      this.mobileShowDetail = true;
       this.closeSiteQueueLogs();
       this.closeSiteHorizonLogs();
       this.closeSiteStripeLogs();
@@ -2318,153 +1894,66 @@ function lerdApp() {
       this.siteWorkerLogs.connected = false;
     },
 
-    async toggleWorker(site, worker) {
-      worker.loading = true;
-      worker.error = '';
-      const stopping = worker.running;
-      const action = stopping ? `worker:${worker.name}:stop` : `worker:${worker.name}:start`;
-      try {
-        const res = await fetch(`/api/sites/${site.domain}/${action}`, { method: 'POST' });
-        const data = await res.json();
-        if (data.ok) {
-          worker.running = !stopping;
-          if (stopping) {
-            if (this.siteLogsTab === 'worker:' + worker.name) {
-              this.closeSiteWorkerLogs();
-              this.siteLogsTab = 'fpm';
-            }
-          } else {
-            this.siteLogsTab = 'worker:' + worker.name;
-            this.openSiteWorkerLogs(site, worker.name);
-          }
-          await this.loadServices();
-        } else {
-          worker.error = data.error || 'Failed';
-        }
-      } catch (e) {
-        worker.error = e.message || 'Request failed';
-      } finally {
-        worker.loading = false;
-      }
-    },
-
-    async toggleStripe(site) {
-      site.stripeLoading = true;
-      site.stripeError = '';
-      const stopping = site.stripe_running;
-      const action = stopping ? 'stripe:stop' : 'stripe:start';
-      try {
-        const res = await fetch(`/api/sites/${site.domain}/${action}`, { method: 'POST' });
-        const data = await res.json();
-        if (data.ok) {
-          site.stripe_running = !stopping;
-          if (stopping) {
-            this.closeSiteStripeLogs();
-            if (this.siteLogsTab === 'stripe') this.siteLogsTab = 'fpm';
-          } else {
-            this.siteLogsTab = 'stripe';
-            this.openSiteStripeLogs(site);
-          }
-          await this.loadServices();
-        } else {
-          site.stripeError = data.error || 'Failed';
-        }
-      } catch (e) {
-        site.stripeError = e.message || 'Request failed';
-      } finally {
-        site.stripeLoading = false;
-      }
-    },
-
-    async toggleSchedule(site) {
-      site.scheduleLoading = true;
-      site.scheduleError = '';
-      const stopping = site.schedule_running;
-      const action = stopping ? 'schedule:stop' : 'schedule:start';
-      try {
-        const res = await fetch(`/api/sites/${site.domain}/${action}`, { method: 'POST' });
-        const data = await res.json();
-        if (data.ok) {
-          site.schedule_running = !stopping;
-          if (stopping) {
-            this.closeSiteScheduleLogs();
-            if (this.siteLogsTab === 'schedule') this.siteLogsTab = 'fpm';
-          } else {
-            this.siteLogsTab = 'schedule';
-            this.openSiteScheduleLogs(site);
-          }
-          await this.loadServices();
-        } else {
-          site.scheduleError = data.error || 'Failed';
-        }
-      } catch (e) {
-        site.scheduleError = e.message || 'Request failed';
-      } finally {
-        site.scheduleLoading = false;
-      }
-    },
-
-    async toggleReverb(site) {
-      site.reverbLoading = true;
-      site.reverbError = '';
-      const stopping = site.reverb_running;
-      const action = stopping ? 'reverb:stop' : 'reverb:start';
-      try {
-        const res = await fetch(`/api/sites/${site.domain}/${action}`, { method: 'POST' });
-        const data = await res.json();
-        if (data.ok) {
-          site.reverb_running = !stopping;
-          if (stopping) {
-            this.closeSiteReverbLogs();
-            if (this.siteLogsTab === 'reverb') this.siteLogsTab = 'fpm';
-          } else {
-            this.siteLogsTab = 'reverb';
-            this.openSiteReverbLogs(site);
-          }
-          await this.loadServices();
-        } else {
-          site.reverbError = data.error || 'Failed';
-        }
-      } catch (e) {
-        site.reverbError = e.message || 'Request failed';
-      } finally {
-        site.reverbLoading = false;
-      }
-    },
-
     setSiteLogsTab(tab) {
       this.siteLogsTab = tab;
-      const s = this.selectedSite;
-      this.closeSiteQueueLogs();
-      this.closeSiteHorizonLogs();
-      this.closeSiteStripeLogs();
-      this.closeSiteScheduleLogs();
-      this.closeSiteReverbLogs();
-      this.closeSiteWorkerLogs();
-      if (tab === 'queue' && s) this.openSiteQueueLogs(s);
-      else if (tab === 'horizon' && s) this.openSiteHorizonLogs(s);
-      else if (tab === 'stripe' && s) this.openSiteStripeLogs(s);
-      else if (tab === 'schedule' && s) this.openSiteScheduleLogs(s);
-      else if (tab === 'reverb' && s) this.openSiteReverbLogs(s);
-      else if (tab.startsWith('worker:') && s) this.openSiteWorkerLogs(s, tab.slice(7));
+      const site = this.selectedSite;
+      if (!site) return;
+      if (tab === 'queue') this.openSiteQueueLogs(site);
+      if (tab === 'horizon') this.openSiteHorizonLogs(site);
+      if (tab === 'stripe') this.openSiteStripeLogs(site);
+      if (tab === 'schedule') this.openSiteScheduleLogs(site);
+      if (tab === 'reverb') this.openSiteReverbLogs(site);
+      if (tab.startsWith('worker:')) this.openSiteWorkerLogs(site, tab.slice(7));
+    },
+
+    async loadPHPVersions() {
+      try {
+        const res = await fetch('/api/php-versions');
+        const data = await res.json();
+        this.phpVersions = data || [];
+      } catch (_) {}
+    },
+
+    async loadNodeVersions() {
+      try {
+        const res = await fetch('/api/node-versions');
+        const data = await res.json();
+        this.nodeVersions = data || [];
+      } catch (_) {}
     },
 
     async loadServices() {
-      if (this.services.length === 0) this.servicesLoading = true;
+      const firstLoad = this.services.length === 0;
+      if (firstLoad) this.servicesLoading = true;
       try {
         const res = await fetch('/api/services');
-        const data = await res.json();
-        this.services = data.map(s => ({ ...s, loading: false, copied: false, flash: '', error: '' }));
+        const raw = await res.json();
+        if (firstLoad) {
+          this.services = raw.map(s => ({ ...s, loading: false, error: '', flash: '', copied: false }));
+        } else {
+          raw.forEach(s => {
+            const e = this.services.find(x => x.name === s.name);
+            if (e) {
+              e.status = s.status;
+              e.pinned = s.pinned;
+              e.site_count = s.site_count;
+            } else {
+              this.services.push({ ...s, loading: false, error: '', flash: '', copied: false });
+            }
+          });
+          this.services = this.services.filter(e => raw.some(s => s.name === e.name));
+        }
       } catch (_) {
-        this.services = [];
+        if (firstLoad) this.services = [];
       } finally {
-        this.servicesLoading = false;
+        if (firstLoad) this.servicesLoading = false;
       }
     },
 
     selectService(svc) {
       this.selectedSvc = svc.name;
       this.svcDetailTab = 'logs';
+      this.mobileShowDetail = true;
       this.openServiceLogs(svc);
     },
 
@@ -2511,6 +2000,7 @@ function lerdApp() {
       this.systemLogs.lines = [];
       this.systemLogs.connected = false;
       this.selectedSystem = item;
+      this.mobileShowDetail = true;
       if (item === 'dns' && this.systemStatus.dns?.ok) this.openSystemLogs('lerd-dns');
       if (item === 'nginx' && this.systemStatus.nginx?.running) this.openSystemLogs('lerd-nginx');
       if (item === 'watcher') this.openWatcherLogs();
@@ -2562,78 +2052,6 @@ function lerdApp() {
       };
     },
 
-    async toggleService(svc, action) {
-      svc.loading = true;
-      svc.error = '';
-      svc.flash = '';
-      try {
-        const res = await fetch(`/api/services/${svc.name}/${action}`, { method: 'POST' });
-        const data = await res.json();
-        svc.status = data.status;
-        svc.env_vars = data.env_vars;
-        if (data.ok) {
-          // Queue/stripe/schedule/reverb workers disappear after stop — remove from list
-          if ((svc.queue_site || svc.stripe_listener_site || svc.schedule_worker_site || svc.reverb_site) && action === 'stop') {
-            if (this.svcLogs._source) { this.svcLogs._source.close(); this.svcLogs._source = null; }
-            this.svcLogs.lines = [];
-            this.svcLogs.connected = false;
-            this.selectedSvc = null;
-            this.services = this.services.filter(s => s.name !== svc.name);
-            return;
-          }
-          svc.flash = action === 'start' ? 'Started successfully' : 'Stopped';
-          setTimeout(() => { svc.flash = ''; }, 3000);
-        } else {
-          svc.error = data.error || 'Unknown error';
-        }
-      } catch (e) {
-        svc.error = e.message || 'Request failed';
-      } finally {
-        svc.loading = false;
-        if (this.selectedSvc === svc.name) this.openServiceLogs(svc);
-      }
-    },
-
-    async toggleServicePin(svc) {
-      const action = svc.pinned ? 'unpin' : 'pin';
-      svc.loading = true;
-      try {
-        const res = await fetch(`/api/services/${svc.name}/${action}`, { method: 'POST' });
-        const data = await res.json();
-        if (data.ok) {
-          svc.pinned = !svc.pinned;
-        }
-      } catch (e) {
-        svc.error = e.message || 'Request failed';
-      } finally {
-        svc.loading = false;
-      }
-    },
-
-    async removeService(svc) {
-      if (!confirm(`Remove custom service "${svc.name}"?`)) return;
-      svc.loading = true;
-      try {
-        const res = await fetch(`/api/services/${svc.name}/remove`, { method: 'POST' });
-        const data = await res.json();
-        if (data.ok) {
-          if (this.selectedSvc === svc.name) {
-            if (this.svcLogs._source) { this.svcLogs._source.close(); this.svcLogs._source = null; }
-            this.svcLogs.lines = [];
-            this.svcLogs.connected = false;
-            this.selectedSvc = null;
-          }
-          this.services = this.services.filter(s => s.name !== svc.name);
-        } else {
-          svc.error = data.error || 'Remove failed';
-        }
-      } catch (e) {
-        svc.error = e.message || 'Request failed';
-      } finally {
-        svc.loading = false;
-      }
-    },
-
     get selectedSite() {
       if (!this.selectedSiteDomain) return null;
       return this.sites.find(s => s.domain === this.selectedSiteDomain) || null;
@@ -2664,90 +2082,39 @@ function lerdApp() {
       const text = this.envPreview(svc);
       try {
         await navigator.clipboard.writeText(text);
-      } catch (_) {
-        const ta = document.createElement('textarea');
-        ta.value = text;
-        ta.style.position = 'fixed';
-        ta.style.opacity = '0';
-        document.body.appendChild(ta);
-        ta.focus();
-        ta.select();
-        document.execCommand('copy');
-        document.body.removeChild(ta);
-      }
-      svc.copied = true;
-      setTimeout(() => { svc.copied = false; }, 2000);
-    },
-
-    async loadPHPVersions() {
-      try {
-        const res = await fetch('/api/php-versions');
-        this.phpVersions = await res.json();
+        svc.copied = true;
+        setTimeout(() => { svc.copied = false; }, 2000);
       } catch (_) {}
-    },
-
-    async loadNodeVersions() {
-      try {
-        const res = await fetch('/api/node-versions');
-        this.nodeVersions = await res.json();
-      } catch (_) {}
-    },
-
-    async installNodeVersion() {
-      const v = this.nodeInstall.version.trim();
-      if (!v) return;
-      this.nodeInstall.installing = true;
-      this.nodeInstall.error = '';
-      this.nodeInstall.done = false;
-      try {
-        const res = await fetch(`/api/node-versions/install?version=${encodeURIComponent(v)}`, { method: 'POST' });
-        const data = await res.json();
-        if (data.ok) {
-          this.nodeInstall.done = true;
-          this.nodeInstall.version = '';
-          setTimeout(() => { this.nodeInstall.done = false; }, 3000);
-          await this.loadNodeVersions();
-        } else {
-          this.nodeInstall.error = data.error || 'Install failed';
-        }
-      } catch (e) {
-        this.nodeInstall.error = e.message || 'Request failed';
-      } finally {
-        this.nodeInstall.installing = false;
-      }
     },
 
     async setSiteVersion(site, type, version) {
-      if (!version) return;
       site.versionLoading = true;
       try {
         const res = await fetch(`/api/sites/${site.domain}/${type}?version=${encodeURIComponent(version)}`, { method: 'POST' });
         const data = await res.json();
-        if (!data.ok) await this.loadSites();
-      } catch (_) {
-        await this.loadSites();
+        if (!data.ok) alert('Version change failed: ' + (data.error || 'Unknown error'));
+      } catch (e) {
+        alert('Version change failed: ' + (e.message || 'Request failed'));
       } finally {
         site.versionLoading = false;
       }
     },
 
     openSite(site) {
-      const protocol = site.tls ? 'https' : 'http';
-      // Append a cache-buster for HTTP sites so the browser doesn't serve a
-      // previously cached 301 redirect to the HTTPS version.
-      const bust = site.tls ? '' : `?_=${Date.now()}`;
-      window.open(`${protocol}://${site.domain}${bust}`, '_blank', 'noopener');
+      const url = (site.tls ? 'https://' : 'http://') + site.domain;
+      window.open(url, '_blank', 'noopener');
     },
 
     openWorktree(wt) {
-      window.open('http://' + wt.domain, '_blank', 'noopener');
+      const url = 'http://' + wt.domain;
+      window.open(url, '_blank', 'noopener');
     },
 
     async toggleTLS(site) {
       site.tlsLoading = true;
       site.tlsError = '';
-      const action = site.tls ? 'unsecure' : 'secure';
       try {
+        const action = site.tls ? 'unsecure' : 'secure';
         const res = await fetch(`/api/sites/${site.domain}/${action}`, { method: 'POST' });
         const data = await res.json();
         if (data.ok) {
@@ -2765,27 +2132,19 @@ function lerdApp() {
     async toggleQueue(site) {
       site.queueLoading = true;
       site.queueError = '';
-      const stopping = site.queue_running;
-      const action = stopping ? 'queue:stop' : 'queue:start';
       try {
+        const action = site.queue_running ? 'queue:stop' : 'queue:start';
         const res = await fetch(`/api/sites/${site.domain}/${action}`, { method: 'POST' });
         const data = await res.json();
         if (data.ok) {
-          site.queue_running = !stopping;
-          if (stopping) {
-            // Close stale log drawer stream if open for this queue
-            if (this.logs.open && this.logs.container === `queue:${site.name}`) {
-              this.closeLogs();
-            }
-            // Close site queue logs panel and return to FPM tab
-            this.closeSiteQueueLogs();
-            this.siteLogsTab = 'fpm';
-          } else {
-            // Queue just started — switch to Queue tab and begin streaming
+          site.queue_running = !site.queue_running;
+          if (site.queue_running) {
             this.siteLogsTab = 'queue';
             this.openSiteQueueLogs(site);
+          } else {
+            this.closeSiteQueueLogs();
+            this.siteLogsTab = 'fpm';
           }
-          // Refresh services list so queue worker appears/disappears
           await this.loadServices();
         } else {
           site.queueError = data.error || 'Failed';
@@ -2797,17 +2156,124 @@ function lerdApp() {
       }
     },
 
-    async toggleHorizon(site) {
-      site.horizonLoading = true;
-      site.horizonError = '';
-      const stopping = site.horizon_running;
-      const action = stopping ? 'horizon:stop' : 'horizon:start';
+    async toggleStripe(site) {
+      site.stripeLoading = true;
+      site.stripeError = '';
       try {
+        const action = site.stripe_running ? 'stripe:stop' : 'stripe:start';
         const res = await fetch(`/api/sites/${site.domain}/${action}`, { method: 'POST' });
         const data = await res.json();
         if (data.ok) {
-          site.horizon_running = !stopping;
-          if (stopping) {
+          site.stripe_running = !site.stripe_running;
+          if (site.stripe_running) {
+            this.siteLogsTab = 'stripe';
+            this.openSiteStripeLogs(site);
+          } else {
+            this.closeSiteStripeLogs();
+            this.siteLogsTab = 'fpm';
+          }
+          await this.loadServices();
+        } else {
+          site.stripeError = data.error || 'Failed';
+        }
+      } catch (e) {
+        site.stripeError = e.message || 'Request failed';
+      } finally {
+        site.stripeLoading = false;
+      }
+    },
+
+    async toggleSchedule(site) {
+      site.scheduleLoading = true;
+      site.scheduleError = '';
+      try {
+        const action = site.schedule_running ? 'schedule:stop' : 'schedule:start';
+        const res = await fetch(`/api/sites/${site.domain}/${action}`, { method: 'POST' });
+        const data = await res.json();
+        if (data.ok) {
+          site.schedule_running = !site.schedule_running;
+          if (site.schedule_running) {
+            this.siteLogsTab = 'schedule';
+            this.openSiteScheduleLogs(site);
+          } else {
+            this.closeSiteScheduleLogs();
+            this.siteLogsTab = 'fpm';
+          }
+          await this.loadServices();
+        } else {
+          site.scheduleError = data.error || 'Failed';
+        }
+      } catch (e) {
+        site.scheduleError = e.message || 'Request failed';
+      } finally {
+        site.scheduleLoading = false;
+      }
+    },
+
+    async toggleReverb(site) {
+      site.reverbLoading = true;
+      site.reverbError = '';
+      try {
+        const action = site.reverb_running ? 'reverb:stop' : 'reverb:start';
+        const res = await fetch(`/api/sites/${site.domain}/${action}`, { method: 'POST' });
+        const data = await res.json();
+        if (data.ok) {
+          site.reverb_running = !site.reverb_running;
+          if (site.reverb_running) {
+            this.siteLogsTab = 'reverb';
+            this.openSiteReverbLogs(site);
+          } else {
+            this.closeSiteReverbLogs();
+            this.siteLogsTab = 'fpm';
+          }
+          await this.loadServices();
+        } else {
+          site.reverbError = data.error || 'Failed';
+        }
+      } catch (e) {
+        site.reverbError = e.message || 'Request failed';
+      } finally {
+        site.reverbLoading = false;
+      }
+    },
+
+    async toggleWorker(site, worker) {
+      worker.loading = true;
+      worker.error = '';
+      try {
+        const action = worker.running ? `worker:${worker.name}:stop` : `worker:${worker.name}:start`;
+        const res = await fetch(`/api/sites/${site.domain}/${action}`, { method: 'POST' });
+        const data = await res.json();
+        if (data.ok) {
+          worker.running = !worker.running;
+          if (worker.running) {
+            this.siteLogsTab = 'worker:' + worker.name;
+            this.openSiteWorkerLogs(site, worker.name);
+          } else {
+            this.closeSiteWorkerLogs();
+            this.siteLogsTab = 'fpm';
+          }
+          await this.loadServices();
+        } else {
+          worker.error = data.error || 'Failed';
+        }
+      } catch (e) {
+        worker.error = e.message || 'Request failed';
+      } finally {
+        worker.loading = false;
+      }
+    },
+
+    async toggleHorizon(site) {
+      site.horizonLoading = true;
+      site.horizonError = '';
+      try {
+        const action = site.horizon_running ? 'horizon:stop' : 'horizon:start';
+        const res = await fetch(`/api/sites/${site.domain}/${action}`, { method: 'POST' });
+        const data = await res.json();
+        if (data.ok) {
+          site.horizon_running = !site.horizon_running;
+          if (!site.horizon_running) {
             this.closeSiteHorizonLogs();
             this.siteLogsTab = 'fpm';
           } else {
@@ -2834,6 +2300,7 @@ function lerdApp() {
         if (data.ok) {
           if (this.selectedSiteDomain === site.domain) {
             this.selectedSiteDomain = null;
+            this.mobileShowDetail = false;
             if (this.siteLogs._source) { this.siteLogs._source.close(); this.siteLogs._source = null; }
             this.closeSiteQueueLogs();
             this.closeSiteHorizonLogs();
@@ -2858,11 +2325,8 @@ function lerdApp() {
       try {
         const res = await fetch(`/api/sites/${site.domain}/pause`, { method: 'POST' });
         const data = await res.json();
-        if (data.ok) {
-          site.paused = true;
-        } else {
-          alert('Pause failed: ' + (data.error || 'Unknown error'));
-        }
+        if (data.ok) { site.paused = true; }
+        else { alert('Pause failed: ' + (data.error || 'Unknown error')); }
       } catch (e) {
         alert('Pause failed: ' + (e.message || 'Request failed'));
       } finally {
@@ -2875,11 +2339,8 @@ function lerdApp() {
       try {
         const res = await fetch(`/api/sites/${site.domain}/unpause`, { method: 'POST' });
         const data = await res.json();
-        if (data.ok) {
-          site.paused = false;
-        } else {
-          alert('Resume failed: ' + (data.error || 'Unknown error'));
-        }
+        if (data.ok) { site.paused = false; }
+        else { alert('Resume failed: ' + (data.error || 'Unknown error')); }
       } catch (e) {
         alert('Resume failed: ' + (e.message || 'Request failed'));
       } finally {
@@ -2905,16 +2366,12 @@ function lerdApp() {
     openLogs(site) {
       const container = this.fpmContainer(site);
       if (!container) return;
-      if (this.logs.open && this.logs.container === container) {
-        this.closeLogs();
-        return;
-      }
+      if (this.logs.open && this.logs.container === container) { this.closeLogs(); return; }
       this.closeLogs();
       this.logs.container = container;
       this.logs.lines = [];
       this.logs.open = true;
       this.logs.connected = false;
-
       const src = new EventSource(`/api/logs/${container}`);
       this.logs._source = src;
       src.onopen = () => { this.logs.connected = true; };
@@ -2922,25 +2379,18 @@ function lerdApp() {
       src.onmessage = (e) => {
         this.logs.lines.push(e.data);
         if (this.logs.lines.length > 500) this.logs.lines.splice(0, this.logs.lines.length - 500);
-        this.$nextTick(() => {
-          const el = this.$refs.logScroll;
-          if (el) el.scrollTop = el.scrollHeight;
-        });
+        this.$nextTick(() => { const el = this.$refs.logScroll; if (el) el.scrollTop = el.scrollHeight; });
       };
     },
 
     openQueueLogs(site) {
       const label = `queue:${site.name}`;
-      if (this.logs.open && this.logs.container === label) {
-        this.closeLogs();
-        return;
-      }
+      if (this.logs.open && this.logs.container === label) { this.closeLogs(); return; }
       this.closeLogs();
       this.logs.container = label;
       this.logs.lines = [];
       this.logs.open = true;
       this.logs.connected = false;
-
       const src = new EventSource(`/api/queue/${site.name}/logs`);
       this.logs._source = src;
       src.onopen = () => { this.logs.connected = true; };
@@ -2948,10 +2398,7 @@ function lerdApp() {
       src.onmessage = (e) => {
         this.logs.lines.push(e.data);
         if (this.logs.lines.length > 500) this.logs.lines.splice(0, this.logs.lines.length - 500);
-        this.$nextTick(() => {
-          const el = this.$refs.logScroll;
-          if (el) el.scrollTop = el.scrollHeight;
-        });
+        this.$nextTick(() => { const el = this.$refs.logScroll; if (el) el.scrollTop = el.scrollHeight; });
       };
     },
 
@@ -2962,6 +2409,62 @@ function lerdApp() {
     },
 
     clearLogs() { this.logs.lines = []; },
+
+    async toggleService(svc, action) {
+      svc.loading = true;
+      svc.error = '';
+      svc.flash = '';
+      try {
+        const res = await fetch(`/api/services/${svc.name}/${action}`, { method: 'POST' });
+        const data = await res.json();
+        if (data.ok) {
+          svc.status = data.status || (action === 'start' ? 'active' : 'inactive');
+          svc.flash = action === 'start' ? 'Service started' : 'Service stopped';
+          setTimeout(() => { svc.flash = ''; }, 3000);
+          if (action === 'start') this.openServiceLogs(svc);
+        } else {
+          svc.error = data.error || 'Action failed';
+        }
+        await this.loadServices();
+      } catch (e) {
+        svc.error = e.message || 'Request failed';
+      } finally {
+        svc.loading = false;
+      }
+    },
+
+    async toggleServicePin(svc) {
+      svc.loading = true;
+      try {
+        const action = svc.pinned ? 'unpin' : 'pin';
+        const res = await fetch(`/api/services/${svc.name}/${action}`, { method: 'POST' });
+        const data = await res.json();
+        if (data.ok) svc.pinned = !svc.pinned;
+      } catch (_) {}
+      finally { svc.loading = false; }
+    },
+
+    async removeService(svc) {
+      if (!confirm(`Remove service ${svc.name}?`)) return;
+      svc.loading = true;
+      try {
+        const res = await fetch(`/api/services/${svc.name}/remove`, { method: 'POST' });
+        const data = await res.json();
+        if (data.ok) {
+          this.services = this.services.filter(s => s.name !== svc.name);
+          if (this.selectedSvc === svc.name) {
+            this.selectedSvc = null;
+            this.mobileShowDetail = false;
+          }
+        } else {
+          svc.error = data.error || 'Remove failed';
+        }
+      } catch (e) {
+        svc.error = e.message || 'Request failed';
+      } finally {
+        svc.loading = false;
+      }
+    },
 
     async setPHPDefault(version) {
       this.phpDefaultLoading = true;
@@ -3017,6 +2520,7 @@ function lerdApp() {
         if (data.ok) {
           this.phpVersions = this.phpVersions.filter(v => v !== version);
           this.selectedSystem = null;
+          this.mobileShowDetail = false;
           await this.loadStatus();
         } else {
           this.phpRemoveError = { ...this.phpRemoveError, [version]: data.error || 'Remove failed' };
@@ -3037,6 +2541,7 @@ function lerdApp() {
         if (data.ok) {
           this.nodeVersions = this.nodeVersions.filter(v => v !== version);
           this.selectedSystem = null;
+          this.mobileShowDetail = false;
         } else {
           this.nodeRemoveError = { ...this.nodeRemoveError, [version]: data.error || 'Remove failed' };
         }
@@ -3138,6 +2643,32 @@ function lerdApp() {
         if (data.ok) this.autostartEnabled = !this.autostartEnabled;
       } catch (_) {} finally {
         this.autostartLoading = false;
+      }
+    },
+
+    async installNodeVersion() {
+      if (!this.nodeInstall.version.trim()) return;
+      this.nodeInstall.installing = true;
+      this.nodeInstall.error = '';
+      this.nodeInstall.done = false;
+      try {
+        const res = await fetch('/api/node-versions/install', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ version: this.nodeInstall.version.trim() }),
+        });
+        const data = await res.json();
+        if (data.ok) {
+          this.nodeInstall.done = true;
+          this.nodeInstall.version = '';
+          await this.loadNodeVersions();
+        } else {
+          this.nodeInstall.error = data.error || 'Install failed';
+        }
+      } catch (e) {
+        this.nodeInstall.error = e.message || 'Request failed';
+      } finally {
+        this.nodeInstall.installing = false;
       }
     },
   };


### PR DESCRIPTION
The 3-pane dashboard layout was lost when resolving the merge conflict for feat/php-fpm-auto-lifecycle — the conflict resolution kept the old top-navbar layout instead of the new icon rail + list panel + detail panel layout.

This restores the correct index.html (3-pane UI from PR #61) and re-applies the FPM lifecycle UI additions on top: phpFPMLoading state, toggleFPM() function, Stop button for unused running PHP versions, and the allCoreRunning fix that excludes stopped unused FPMs from the health check.