### PR TITLE
chore: release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.4.1] — 2026-04-03
+
+### Fixed
+
+- **3-pane dashboard layout missing from v1.4.0** — the new icon rail, list panel, and full-height detail panel were lost during a merge conflict resolution. The correct UI is now restored.
+
+---
+
 ## [1.4.0] — 2026-04-03
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,14 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.4.1] — 2026-04-03
+
+### Fixed
+
+- **3-pane dashboard layout missing from v1.4.0** — the new icon rail, list panel, and full-height detail panel were lost during a merge conflict resolution. The correct UI is now restored.
+
+---
+
 ## [1.4.0] — 2026-04-03
 
 ### Added

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.4.0"
+	Version = "1.4.1"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## v1.4.1

### Fixed

- **3-pane dashboard layout missing from v1.4.0** — the new icon rail, list panel, and full-height detail panel were lost during a merge conflict resolution. The correct UI is now restored.