### PR TITLE
release: v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.4.2] — 2026-04-03
+
+### Fixed
+
+- **Paused sites counted in service badges and auto-stop logic** — paused sites were included when counting how many sites use a service, so services stayed active and their site-count badges inflated even after all active sites were paused. Paused sites are now excluded from `CountSitesUsingService` and the badge tooltip list.
+
+---
+
 ## [1.4.1] — 2026-04-03
 
 ### Fixed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,14 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.4.2] — 2026-04-03
+
+### Fixed
+
+- **Paused sites counted in service badges and auto-stop logic** — paused sites were included when counting how many sites use a service, so services stayed active and their site-count badges inflated even after all active sites were paused. Paused sites are now excluded from `CountSitesUsingService` and the badge tooltip list.
+
+---
+
 ## [1.4.1] — 2026-04-03
 
 ### Fixed

--- a/internal/config/service_manual.go
+++ b/internal/config/service_manual.go
@@ -163,7 +163,7 @@ func CountSitesUsingService(name string) int {
 	needle := "lerd-" + name
 	count := 0
 	for _, s := range reg.Sites {
-		if s.Ignored {
+		if s.Ignored || s.Paused {
 			continue
 		}
 		data, err := os.ReadFile(filepath.Join(s.Path, ".env"))

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1080,7 +1080,7 @@ func sitesUsingService(name string) []string {
 	needle := "lerd-" + name
 	var domains []string
 	for _, s := range reg.Sites {
-		if s.Ignored {
+		if s.Ignored || s.Paused {
 			continue
 		}
 		data, err := os.ReadFile(filepath.Join(s.Path, ".env"))

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.4.1"
+	Version = "1.4.2"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
Paused sites were counted when determining how many sites use a service, causing services to stay running and badge counts to be inflated even when all active sites were paused. This fixes `CountSitesUsingService` and the `sitesUsingService` badge tooltip list to exclude paused sites.