### PR TITLE
feat: add env:check command

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -55,6 +55,7 @@ func main() {
 	root.AddCommand(cli.NewPhpShellCmd())
 	root.AddCommand(cli.NewConsoleCmd())
 	root.AddCommand(cli.NewEnvCmd())
+	root.AddCommand(cli.NewEnvCheckCmd())
 	root.AddCommand(cli.NewNodeCmd())
 	root.AddCommand(cli.NewNpmCmd())
 	root.AddCommand(cli.NewNpxCmd())

--- a/docs/features/env-setup.md
+++ b/docs/features/env-setup.md
@@ -41,3 +41,35 @@ Services prefixed with `From .lerd.yaml` were not referenced in the env file but
 ## Safe to re-run
 
 Running `lerd env` on a project that already has a `.env` is safe — it only updates connection-related keys and leaves everything else untouched.
+
+---
+
+## Checking for drift
+
+`lerd env:check` compares all `.env` files in the project against `.env.example` and shows a single table of any keys that are out of sync:
+
+```bash
+lerd env:check
+```
+
+Example output when keys are out of sync:
+
+```
+  KEY              .env.example  .env  .env.testing
+  ---------------  ------------  ----  ------------
+  STRIPE_KEY            ✓         ✗         ✗
+  STRIPE_SECRET         ✓         ✗         ✗
+  LEGACY_TOKEN          ✗         ✓         ✗
+
+  3 key(s) out of sync
+```
+
+When everything is in sync:
+
+```
+  all .env files are in sync with .env.example
+```
+
+The command automatically discovers all `.env*` files in the project directory (`.env`, `.env.testing`, `.env.local`, etc.) and checks each one against `.env.example`. Only keys that differ in at least one file are shown.
+
+The command exits with a non-zero status when any `.env` file is missing a key defined in `.env.example` (✓ in `.env.example`, ✗ in an env file). Extra keys (present in an env file but not in `.env.example`) are reported but don't cause a failure.

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -53,7 +53,7 @@ lerd mcp:inject --path ~/Lerd/another-app
 
 ### Path resolution
 
-Tools like `artisan`, `composer`, `env_setup`, `db_export`, `db_import`, and `db_create` accept an optional `path` argument. When omitted, the server resolves the path in this order:
+Tools like `artisan`, `composer`, `env_setup`, `env_check`, `db_export`, `db_import`, and `db_create` accept an optional `path` argument. When omitted, the server resolves the path in this order:
 
 1. Explicit `path` argument (highest priority)
 2. `LERD_SITE_PATH` env var (set by `mcp:inject`)
@@ -79,6 +79,7 @@ Once the MCP server is connected, your AI assistant has access to:
 | `node_install` | Install a Node.js version via fnm (e.g. `"20"`, `"lts"`) |
 | `node_uninstall` | Uninstall a Node.js version via fnm |
 | `env_setup` | Configure `.env` for lerd: detects services, starts them, creates DB, sets APP_KEY and APP_URL |
+| `env_check` | Compare all `.env` files against `.env.example` and flag missing or extra keys |
 | `site_link` | Register a directory as a lerd site — generates nginx vhost and `.test` domain |
 | `site_unlink` | Unregister a site and remove its nginx vhost (all domains) |
 | `site_domain_add` | Add an additional domain to a site (without TLD) |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -63,6 +63,7 @@
 | `lerd pause [name]` | Pause a site: stop its workers and replace the vhost with a landing page |
 | `lerd unpause [name]` | Resume a paused site: restore its vhost and restart previously running workers |
 | `lerd env` | Configure `.env` for the current project with lerd service connection settings |
+| `lerd env:check` | Compare all `.env` files against `.env.example` and flag missing or extra keys |
 
 ## PHP
 

--- a/internal/cli/env_check.go
+++ b/internal/cli/env_check.go
@@ -1,0 +1,239 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/geodro/lerd/internal/envfile"
+	"github.com/spf13/cobra"
+)
+
+// NewEnvCheckCmd returns the env:check command.
+func NewEnvCheckCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "env:check",
+		Short: "Compare all .env files against .env.example and flag missing keys",
+		RunE:  runEnvCheck,
+	}
+}
+
+// diffEnvKeys compares envFile against exampleFile and returns
+// keys missing from envFile and keys extra in envFile.
+func diffEnvKeys(exampleFile, envFile string) (missing, extra []string) {
+	exampleKeys, err := envfile.ReadKeys(exampleFile)
+	if err != nil {
+		return nil, nil
+	}
+	envKeys, err := envfile.ReadKeys(envFile)
+	if err != nil {
+		return nil, nil
+	}
+
+	envSet := make(map[string]bool, len(envKeys))
+	for _, k := range envKeys {
+		envSet[k] = true
+	}
+	exampleSet := make(map[string]bool, len(exampleKeys))
+	for _, k := range exampleKeys {
+		exampleSet[k] = true
+	}
+
+	for _, k := range exampleKeys {
+		if !envSet[k] {
+			missing = append(missing, k)
+		}
+	}
+	for _, k := range envKeys {
+		if !exampleSet[k] {
+			extra = append(extra, k)
+		}
+	}
+	return missing, extra
+}
+
+// findEnvFiles returns all .env* files in dir except .env.example, sorted.
+func findEnvFiles(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, ".env") || e.IsDir() {
+			continue
+		}
+		if name == ".env.example" {
+			continue
+		}
+		files = append(files, filepath.Join(dir, name))
+	}
+	sort.Strings(files)
+	return files
+}
+
+func runEnvCheck(_ *cobra.Command, _ []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	examplePath := filepath.Join(cwd, ".env.example")
+	if _, err := os.Stat(examplePath); os.IsNotExist(err) {
+		return fmt.Errorf("no .env.example found in %s", cwd)
+	}
+
+	envFiles := findEnvFiles(cwd)
+	if len(envFiles) == 0 {
+		return fmt.Errorf("no .env files found in %s — run lerd env to create one", cwd)
+	}
+
+	exampleKeys, err := envfile.ReadKeys(examplePath)
+	if err != nil {
+		return fmt.Errorf("reading .env.example: %w", err)
+	}
+
+	// Build per-file key sets.
+	type fileInfo struct {
+		name   string
+		keySet map[string]bool
+		keys   []string
+	}
+	var files []fileInfo
+	for _, f := range envFiles {
+		keys, err := envfile.ReadKeys(f)
+		if err != nil {
+			continue
+		}
+		set := make(map[string]bool, len(keys))
+		for _, k := range keys {
+			set[k] = true
+		}
+		files = append(files, fileInfo{
+			name:   filepath.Base(f),
+			keySet: set,
+			keys:   keys,
+		})
+	}
+
+	// Collect all keys that have at least one mismatch.
+	allKeys := make(map[string]bool)
+	exampleSet := make(map[string]bool, len(exampleKeys))
+	for _, k := range exampleKeys {
+		exampleSet[k] = true
+	}
+
+	// Check for keys missing from any env file or extra in any env file.
+	for _, k := range exampleKeys {
+		for _, f := range files {
+			if !f.keySet[k] {
+				allKeys[k] = true
+				break
+			}
+		}
+	}
+	for _, f := range files {
+		for _, k := range f.keys {
+			if !exampleSet[k] {
+				allKeys[k] = true
+			}
+		}
+	}
+
+	if len(allKeys) == 0 {
+		if len(files) == 1 {
+			fmt.Printf("  %s is in sync with .env.example\n", files[0].name)
+		} else {
+			fmt.Println("  all .env files are in sync with .env.example")
+		}
+		return nil
+	}
+
+	// Sort keys for stable output.
+	var sortedKeys []string
+	for k := range allKeys {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+
+	// Compute column widths.
+	keyWidth := len("KEY")
+	for _, k := range sortedKeys {
+		if len(k) > keyWidth {
+			keyWidth = len(k)
+		}
+	}
+
+	colWidths := make([]int, len(files)+1)
+	colWidths[0] = len(".env.example")
+	for i, f := range files {
+		colWidths[i+1] = len(f.name)
+		if colWidths[i+1] < 4 {
+			colWidths[i+1] = 4
+		}
+	}
+
+	// Print header.
+	fmt.Printf("  %-*s", keyWidth, "KEY")
+	fmt.Printf("  %-*s", colWidths[0], ".env.example")
+	for i, f := range files {
+		fmt.Printf("  %-*s", colWidths[i+1], f.name)
+	}
+	fmt.Println()
+
+	// Print separator.
+	fmt.Printf("  %s", dashes(keyWidth))
+	fmt.Printf("  %s", dashes(colWidths[0]))
+	for i := range files {
+		fmt.Printf("  %s", dashes(colWidths[i+1]))
+	}
+	fmt.Println()
+
+	// Print rows.
+	totalMissing := 0
+	for _, k := range sortedKeys {
+		fmt.Printf("  %-*s", keyWidth, k)
+		if exampleSet[k] {
+			fmt.Printf("  %s", center("✓", colWidths[0]))
+		} else {
+			fmt.Printf("  %s", center("✗", colWidths[0]))
+		}
+		for i, f := range files {
+			if f.keySet[k] {
+				fmt.Printf("  %s", center("✓", colWidths[i+1]))
+			} else {
+				fmt.Printf("  %s", center("✗", colWidths[i+1]))
+				if exampleSet[k] {
+					totalMissing++
+				}
+			}
+		}
+		fmt.Println()
+	}
+
+	fmt.Println()
+	fmt.Printf("  %d key(s) out of sync\n", len(sortedKeys))
+
+	if totalMissing > 0 {
+		return fmt.Errorf("env check failed")
+	}
+	return nil
+}
+
+func dashes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = '-'
+	}
+	return string(b)
+}
+
+func center(s string, width int) string {
+	pad := width - 1
+	left := pad / 2
+	right := pad - left
+	return fmt.Sprintf("%*s%s%*s", left, "", s, right, "")
+}

--- a/internal/cli/env_check_test.go
+++ b/internal/cli/env_check_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func envPaths(dir string, names ...string) (string, []string) {
+	example := filepath.Join(dir, ".env.example")
+	envs := make([]string, len(names))
+	for i, n := range names {
+		envs[i] = filepath.Join(dir, n)
+	}
+	return example, envs
+}
+
+func TestEnvCheck_inSync(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".env.example", "APP_NAME=\nDB_HOST=\n")
+	writeFile(t, dir, ".env", "APP_NAME=MyApp\nDB_HOST=localhost\n")
+
+	ex, envs := envPaths(dir, ".env")
+	missing, extra := diffEnvKeys(ex, envs[0])
+	if len(missing) != 0 {
+		t.Errorf("expected no missing keys, got %v", missing)
+	}
+	if len(extra) != 0 {
+		t.Errorf("expected no extra keys, got %v", extra)
+	}
+}
+
+func TestEnvCheck_missingKeys(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".env.example", "APP_NAME=\nDB_HOST=\nMAIL_HOST=\n")
+	writeFile(t, dir, ".env", "APP_NAME=MyApp\n")
+
+	ex, envs := envPaths(dir, ".env")
+	missing, extra := diffEnvKeys(ex, envs[0])
+	if len(missing) != 2 {
+		t.Errorf("expected 2 missing keys, got %v", missing)
+	}
+	if len(extra) != 0 {
+		t.Errorf("expected no extra keys, got %v", extra)
+	}
+}
+
+func TestEnvCheck_extraKeys(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".env.example", "APP_NAME=\n")
+	writeFile(t, dir, ".env", "APP_NAME=MyApp\nCUSTOM_KEY=val\n")
+
+	ex, envs := envPaths(dir, ".env")
+	missing, extra := diffEnvKeys(ex, envs[0])
+	if len(missing) != 0 {
+		t.Errorf("expected no missing keys, got %v", missing)
+	}
+	if len(extra) != 1 || extra[0] != "CUSTOM_KEY" {
+		t.Errorf("expected [CUSTOM_KEY], got %v", extra)
+	}
+}
+
+func TestEnvCheck_commentsIgnored(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".env.example", "# comment\nAPP_NAME=\n")
+	writeFile(t, dir, ".env", "# different comment\nAPP_NAME=MyApp\n")
+
+	ex, envs := envPaths(dir, ".env")
+	missing, extra := diffEnvKeys(ex, envs[0])
+	if len(missing) != 0 {
+		t.Errorf("expected no missing keys, got %v", missing)
+	}
+	if len(extra) != 0 {
+		t.Errorf("expected no extra keys, got %v", extra)
+	}
+}
+
+func TestFindEnvFiles_findsVariants(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".env", "A=1\n")
+	writeFile(t, dir, ".env.testing", "A=1\n")
+	writeFile(t, dir, ".env.example", "A=\n")
+	writeFile(t, dir, ".env.local", "A=1\n")
+	writeFile(t, dir, "unrelated.txt", "x\n")
+
+	files := findEnvFiles(dir)
+	// Should include .env, .env.testing, .env.local but not .env.example
+	found := map[string]bool{}
+	for _, f := range files {
+		found[filepath.Base(f)] = true
+	}
+	if !found[".env"] {
+		t.Error("expected .env")
+	}
+	if !found[".env.testing"] {
+		t.Error("expected .env.testing")
+	}
+	if !found[".env.local"] {
+		t.Error("expected .env.local")
+	}
+	if found[".env.example"] {
+		t.Error("should not include .env.example")
+	}
+	if found["unrelated.txt"] {
+		t.Error("should not include unrelated.txt")
+	}
+}

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -284,7 +284,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment fo
 
 ## Path resolution
 
-Tools that accept a ` + bt + `path` + bt + ` argument (` + bt + `artisan` + bt + `, ` + bt + `composer` + bt + `, ` + bt + `env_setup` + bt + `, ` + bt + `site_link` + bt + `, ` + bt + `site_unlink` + bt + `, ` + bt + `site_domain_add` + bt + `, ` + bt + `site_domain_remove` + bt + `, ` + bt + `db_export` + bt + `, ` + bt + `db_import` + bt + `, ` + bt + `db_create` + bt + `, etc.) resolve it in this order:
+Tools that accept a ` + bt + `path` + bt + ` argument (` + bt + `artisan` + bt + `, ` + bt + `composer` + bt + `, ` + bt + `env_setup` + bt + `, ` + bt + `env_check` + bt + `, ` + bt + `site_link` + bt + `, ` + bt + `site_unlink` + bt + `, ` + bt + `site_domain_add` + bt + `, ` + bt + `site_domain_remove` + bt + `, ` + bt + `db_export` + bt + `, ` + bt + `db_import` + bt + `, ` + bt + `db_create` + bt + `, etc.) resolve it in this order:
 1. Explicit ` + bt + `path` + bt + ` argument
 2. ` + bt + `LERD_SITE_PATH` + bt + ` env var (set when using project-scoped ` + bt + `mcp:inject` + bt + `)
 3. **Current working directory** — the directory Claude was opened in
@@ -474,6 +474,12 @@ Arguments:
 - ` + bt + `path` + bt + ` (optional): absolute path to the Laravel project root — defaults to the current working directory (or ` + bt + `LERD_SITE_PATH` + bt + ` if set by ` + bt + `mcp:inject` + bt + `)
 
 > Run this right after ` + bt + `site_link` + bt + ` when setting up a fresh project.
+
+### ` + bt + `env_check` + bt + `
+Compare all ` + bt + `.env` + bt + ` files (` + bt + `.env` + bt + `, ` + bt + `.env.testing` + bt + `, ` + bt + `.env.local` + bt + `, …) against ` + bt + `.env.example` + bt + ` and show a table of missing or extra keys. Useful for catching "works on my machine" bugs caused by env drift after pulling new code.
+
+Arguments:
+- ` + bt + `path` + bt + ` (optional): absolute path to the project root — defaults to the current working directory (or ` + bt + `LERD_SITE_PATH` + bt + ` if set by ` + bt + `mcp:inject` + bt + `)
 
 ### ` + bt + `site_link` + bt + ` / ` + bt + `site_unlink` + bt + `
 Register or unregister a directory as a lerd site. Arguments for ` + bt + `site_link` + bt + `:
@@ -874,6 +880,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `node_install` + bt + ` | Install a Node.js version via fnm (e.g. ` + bt + `"20"` + bt + `, ` + bt + `"lts"` + bt + `) |
 | ` + bt + `node_uninstall` + bt + ` | Uninstall a Node.js version via fnm |
 | ` + bt + `env_setup` + bt + ` | Configure ` + bt + `.env` + bt + ` for lerd: detects services, starts them, creates DB, generates APP_KEY |
+| ` + bt + `env_check` + bt + ` | Compare all ` + bt + `.env` + bt + ` files against ` + bt + `.env.example` + bt + ` and flag missing or extra keys |
 | ` + bt + `site_link` + bt + ` | Register a directory as a lerd site (creates nginx vhost + ` + bt + `.test` + bt + ` domain) |
 | ` + bt + `site_unlink` + bt + ` | Unregister a site and remove its nginx vhost (all domains) |
 | ` + bt + `site_domain_add` + bt + ` | Add an additional domain to a site (without TLD) |

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -73,6 +73,34 @@ func ReadKey(path, key string) string {
 	return ""
 }
 
+// ReadKeys returns all non-comment key names from the .env file at path,
+// in the order they appear.
+func ReadKeys(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var keys []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") || !strings.Contains(line, "=") {
+			continue
+		}
+		k, _, _ := strings.Cut(line, "=")
+		k = strings.TrimSpace(k)
+		if k != "" {
+			keys = append(keys, k)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
 // UpdateAppURL sets APP_URL in the project's .env to scheme://domain.
 // Silently does nothing if no .env exists.
 func UpdateAppURL(projectPath, scheme, domain string) error {

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -144,6 +144,46 @@ func TestUpdateAppURL_setsHTTPS(t *testing.T) {
 	}
 }
 
+// ── ReadKeys ─────────────────────────────────────────────────────────────────
+
+func TestReadKeys_returnsAllKeys(t *testing.T) {
+	f := writeEnv(t, "APP_NAME=MyApp\nDB_HOST=localhost\nAPP_ENV=local\n")
+	keys, err := ReadKeys(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"APP_NAME", "DB_HOST", "APP_ENV"}
+	if len(keys) != len(want) {
+		t.Fatalf("got %d keys, want %d", len(keys), len(want))
+	}
+	for i, k := range keys {
+		if k != want[i] {
+			t.Errorf("key[%d] = %q, want %q", i, k, want[i])
+		}
+	}
+}
+
+func TestReadKeys_skipsCommentsAndBlanks(t *testing.T) {
+	f := writeEnv(t, "# a comment\nAPP_NAME=MyApp\n\n# another\nDB_HOST=localhost\n")
+	keys, err := ReadKeys(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("got %d keys, want 2: %v", len(keys), keys)
+	}
+	if keys[0] != "APP_NAME" || keys[1] != "DB_HOST" {
+		t.Errorf("unexpected keys: %v", keys)
+	}
+}
+
+func TestReadKeys_missingFile(t *testing.T) {
+	_, err := ReadKeys("/nonexistent/.env")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
 func TestUpdateAppURL_noEnvFile_silent(t *testing.T) {
 	// Should silently return nil when .env doesn't exist
 	err := UpdateAppURL(t.TempDir(), "https", "myapp.test")

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -467,6 +467,19 @@ func toolList() []mcpTool {
 			},
 		},
 		{
+			Name:        "env_check",
+			Description: "Compare .env against .env.example and flag missing or extra keys. Useful for catching 'works on my machine' bugs caused by env drift.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"path": {
+						Type:        "string",
+						Description: "Absolute path to the project root. Defaults to LERD_SITE_PATH when omitted.",
+					},
+				},
+			},
+		},
+		{
 			Name:        "site_link",
 			Description: "Register a directory as a lerd site, generating an nginx vhost and a <name>.test domain. Use this to set up a new project.",
 			InputSchema: mcpSchema{
@@ -1308,6 +1321,8 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execServiceExpose(args)
 	case "env_setup":
 		return execEnvSetup(args)
+	case "env_check":
+		return execEnvCheck(args)
 	case "site_link":
 		return execSiteLink(args)
 	case "site_unlink":
@@ -2415,6 +2430,26 @@ func execEnvSetup(args map[string]any) (any, *rpcError) {
 	if err := cmd.Run(); err != nil {
 		return toolErr(fmt.Sprintf("env setup failed (%v):\n%s", err, out.String())), nil
 	}
+	return toolOK(strings.TrimSpace(out.String())), nil
+}
+
+func execEnvCheck(args map[string]any) (any, *rpcError) {
+	projectPath := resolvedPath(args)
+	if projectPath == "" {
+		return toolErr("path is required — pass a path argument or open Claude in the project directory"), nil
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return toolErr("could not resolve lerd executable: " + err.Error()), nil
+	}
+
+	var out bytes.Buffer
+	cmd := exec.Command(self, "env:check")
+	cmd.Dir = projectPath
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	_ = cmd.Run() // non-zero exit is expected when keys are missing
 	return toolOK(strings.TrimSpace(out.String())), nil
 }
 


### PR DESCRIPTION
## Summary

- adds `lerd env:check` which auto-discovers all `.env` variants and compares them against `.env.example` in a single table with ✓/✗ per key per file
- exits non-zero when keys from `.env.example` are missing, so it works in CI or git hooks
- includes MCP tool (`env_check`), CLI registration, tests, Claude skill and Junie guidelines updates, and docs