### PR TITLE
release: v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.0] — 2026-04-04
+
+### Added
+
+- **Multi-domain support** — sites can now respond to multiple `.test` domains. Use `lerd domain add`, `lerd domain remove`, and `lerd domain list` to manage them. Domains are stored in `.lerd.yaml` and the certificate is reissued automatically when a domain is added to a secured site.
+- **`lerd env:check` command** — compare all `.env` files against `.env.example` and flag missing or extra keys. Exits non-zero when required keys are missing.
+- **`lerd check` command** — validate `.lerd.yaml` syntax, PHP version, Node version, services, frameworks, and workers before running setup. Reports OK/WARN/FAIL per field.
+- **`lerd which` command** — show the resolved PHP version, Node version, document root, and nginx config paths for the current site.
+- **Port conflict detection** — `lerd start` checks for port conflicts before starting containers and warns if another process is already using a required port.
+- **`lerd update --beta`** — update to the latest pre-release build from GitHub.
+- **`lerd update --rollback`** — revert to the previously installed version using the automatic backup.
+- **Automatic PHP/Node version switching** — the watcher monitors `.lerd.yaml`, `.php-version`, `.node-version`, and `.nvmrc` and automatically re-links the site when versions change.
+- **Workers in `lerd init`** — the wizard includes a workers step that pre-selects workers based on the framework and installed packages. Horizon is auto-detected from `composer.json`.
+- **Setup prompt on link** — when linking a site with workers configured in `.lerd.yaml`, lerd prompts to run `lerd setup` to install dependencies and start workers.
+- **Branded error pages** — requests to unlinked `.test` domains show a styled "Site Not Found" page with links to the dashboard instead of a generic browser error.
+- **Failing worker visibility** — `lerd status` shows failing and restarting workers across all sites. The web UI shows a pulsing red toggle and a "!" indicator on the log tab for failing workers.
+
+### Fixed
+
+- **Crash-looping workers left running after unlink** — `lerd unlink` now detects and stops crash-looping workers for the site.
+- **Paused sites counted in status workers section** — paused sites are now excluded from the workers list in `lerd status`.
+- **Paused sites counted in TLS check** — `lerd status` no longer flags TLS issues for paused or ignored sites.
+- **Service container left behind on remove** — `lerd service remove` now properly cleans up the Podman container.
+
+---
+
 ## [1.4.2] — 2026-04-03
 
 ### Fixed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,32 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.0] — 2026-04-04
+
+### Added
+
+- **Multi-domain support** — sites can now respond to multiple `.test` domains. Use `lerd domain add`, `lerd domain remove`, and `lerd domain list` to manage them. Domains are stored in `.lerd.yaml` and the certificate is reissued automatically when a domain is added to a secured site.
+- **`lerd env:check` command** — compare all `.env` files against `.env.example` and flag missing or extra keys. Exits non-zero when required keys are missing.
+- **`lerd check` command** — validate `.lerd.yaml` syntax, PHP version, Node version, services, frameworks, and workers before running setup. Reports OK/WARN/FAIL per field.
+- **`lerd which` command** — show the resolved PHP version, Node version, document root, and nginx config paths for the current site.
+- **Port conflict detection** — `lerd start` checks for port conflicts before starting containers and warns if another process is already using a required port.
+- **`lerd update --beta`** — update to the latest pre-release build from GitHub.
+- **`lerd update --rollback`** — revert to the previously installed version using the automatic backup.
+- **Automatic PHP/Node version switching** — the watcher monitors `.lerd.yaml`, `.php-version`, `.node-version`, and `.nvmrc` and automatically re-links the site when versions change.
+- **Workers in `lerd init`** — the wizard includes a workers step that pre-selects workers based on the framework and installed packages. Horizon is auto-detected from `composer.json`.
+- **Setup prompt on link** — when linking a site with workers configured in `.lerd.yaml`, lerd prompts to run `lerd setup` to install dependencies and start workers.
+- **Branded error pages** — requests to unlinked `.test` domains show a styled "Site Not Found" page with links to the dashboard instead of a generic browser error.
+- **Failing worker visibility** — `lerd status` shows failing and restarting workers across all sites. The web UI shows a pulsing red toggle and a "!" indicator on the log tab for failing workers.
+
+### Fixed
+
+- **Crash-looping workers left running after unlink** — `lerd unlink` now detects and stops crash-looping workers for the site.
+- **Paused sites counted in status workers section** — paused sites are now excluded from the workers list in `lerd status`.
+- **Paused sites counted in TLS check** — `lerd status` no longer flags TLS issues for paused or ignored sites.
+- **Service container left behind on remove** — `lerd service remove` now properly cleans up the Podman container.
+
+---
+
 ## [1.4.2] — 2026-04-03
 
 ### Fixed

--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -21,7 +21,9 @@ Linked: my-app -> my-app.test (PHP 8.4, Node 22, Framework: laravel)
 
 The services list includes both built-in services and any custom services already registered with `lerd service add`.
 
-After the wizard, a checkbox list appears with all available steps pre-selected based on the current project state:
+The init wizard also includes a workers step that lets you select which workers to auto-start. Available workers depend on the framework — Horizon is shown automatically when `laravel/horizon` is detected in `composer.json`, replacing the generic queue option.
+
+After the wizard, a checkbox list appears with all available steps pre-selected based on the current project state. Worker steps are pre-selected based on the `.lerd.yaml` workers list:
 
 ```
 ? Select setup steps to run:
@@ -42,7 +44,9 @@ The `lerd secure` step is omitted entirely when HTTPS was already enabled in the
 
 On a machine where `.lerd.yaml` already exists the wizard is skipped and the saved configuration is applied silently before the step selector appears.
 
-`lerd link` also applies `.lerd.yaml` when the file is present, so cloning a repo and running `lerd link` is enough to restore the full environment without running `lerd setup` or `lerd init` first. See [Configuration](../reference/configuration.md#per-project-config-lerdyaml) for the full field reference including inline service definitions and custom frameworks.
+`lerd link` also applies `.lerd.yaml` when the file is present, so cloning a repo and running `lerd link` is enough to restore the full environment without running `lerd setup` or `lerd init` first. When workers are configured in `.lerd.yaml` but not yet running, `lerd link` prompts to run `lerd setup` so you can install dependencies, run migrations, and start workers in the right order.
+
+See [Configuration](../reference/configuration.md#per-project-config-lerdyaml) for the full field reference including inline service definitions and custom frameworks.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -115,6 +115,40 @@ lerd normally pulls a pre-built base image from ghcr.io and finishes in ~30 seco
 lerd handles this automatically since v1.3.4 by always pulling anonymously. If you are on an older version, running `podman logout ghcr.io` before the build will fix it.
 :::
 
+::: details Port conflicts on `lerd start`
+`lerd start` checks for port conflicts before starting containers. If another process is already using a required port, you'll see a warning:
+
+```
+Port conflicts detected:
+  WARN: port 80 (nginx HTTP) already in use — may fail to start (check: ss -tlnp sport = :80)
+```
+
+Common culprits are Apache, another nginx instance, or a previously running lerd that wasn't stopped cleanly. Find and stop the conflicting process:
+
+```bash
+ss -tlnp sport = :80    # show what's listening on port 80
+```
+
+`lerd doctor` also checks for port conflicts as part of its full diagnostic.
+:::
+
+::: details Workers failing or crash-looping
+Check `lerd status` — the Workers section lists all active, restarting, or failed workers. In the web UI, failing workers show a pulsing red toggle and a **!** on their log tab.
+
+To inspect the error:
+
+```bash
+journalctl --user -u lerd-queue-my-app -f    # or lerd-horizon-my-app, lerd-schedule-my-app
+```
+
+Common causes:
+- Missing Redis when `QUEUE_CONNECTION=redis` — start it with `lerd service start redis`
+- Missing dependencies after a fresh clone — run `lerd setup` to install them
+- Bad `.env` values — run `lerd env` to reset service connection settings
+
+When you unlink a site, crash-looping workers are automatically detected and stopped.
+:::
+
 ::: details Error: NetworkUpdate is not supported for backend CNI: invalid argument
 Your system is likely configured to use the older CNI backend, which lacks support for the requested network operation. Edit or create the Podman configuration file at `/etc/containers/containers.conf` and add or modify the `network_backend` setting to `netavark`:
 

--- a/docs/usage/queue-workers.md
+++ b/docs/usage/queue-workers.md
@@ -100,6 +100,16 @@ This ensures queue workers and nginx stay in sync after deploys or PHP version c
 
 ---
 
+## Failing and restarting workers
+
+`lerd status` includes a Workers section that lists all active, restarting, or failed workers across sites. Paused sites are excluded from this list.
+
+Workers that are crash-looping (repeatedly failing and restarting) are detected automatically. When you unlink a site, lerd stops any crash-looping workers for that site to prevent them from consuming resources after the site is gone.
+
+In the web UI, a failing worker shows a pulsing red toggle and its log tab appears with a **!** indicator so you can inspect the error output immediately.
+
+---
+
 ## Web UI control
 
 Queue workers and Horizon are controllable from the **Sites tab** in the web UI:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.4.2"
+	Version = "1.5.0"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

Multi-domain support, new commands (env:check, check, which), port conflict detection on start, update --beta and --rollback flags, automatic PHP/Node version switching when config files change, workers step in init wizard with Horizon auto-detection, setup prompt on link, branded error pages for unlinked domains, and failing worker visibility in status and the web UI. Also fixes crash-looping workers on unlink, paused sites leaking into status counts, and service container cleanup on remove.

Bumps version from 1.4.2 to 1.5.0, updates both changelogs and docs for queue workers, project setup, and troubleshooting.