### PR TITLE
fix: v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.1] — 2026-04-04
+
+### Fixed
+
+- **Nginx fails to start when TLS certificates are missing** — `lerd start` now detects SSL vhosts referencing missing cert files before starting nginx, switches affected sites back to HTTP, and removes orphan SSL configs. Previously a single missing certificate would prevent all sites from loading.
+- **Paused sites bypass landing page after update** — `lerd install` (called by `lerd update`) was regenerating vhosts for all sites, overwriting paused landing pages with the full site config. Paused and ignored sites are now skipped during vhost regeneration.
+- **Paused landing page redesigned** — the paused page now matches the branded "Site Not Found" page with the Lerd logo, red accent, and Resume + Dashboard buttons. Uses a single shared HTML file instead of generating one per site.
+
+---
+
 ## [1.5.0] — 2026-04-04
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,16 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.1] — 2026-04-04
+
+### Fixed
+
+- **Nginx fails to start when TLS certificates are missing** — `lerd start` now detects SSL vhosts referencing missing cert files before starting nginx, switches affected sites back to HTTP, and removes orphan SSL configs. Previously a single missing certificate would prevent all sites from loading.
+- **Paused sites bypass landing page after update** — `lerd install` (called by `lerd update`) was regenerating vhosts for all sites, overwriting paused landing pages with the full site config. Paused and ignored sites are now skipped during vhost regeneration.
+- **Paused landing page redesigned** — the paused page now matches the branded "Site Not Found" page with the Lerd logo, red accent, and Resume + Dashboard buttons. Uses a single shared HTML file instead of generating one per site.
+
+---
+
 ## [1.5.0] — 2026-04-04
 
 ### Added

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -115,6 +115,27 @@ lerd normally pulls a pre-built base image from ghcr.io and finishes in ~30 seco
 lerd handles this automatically since v1.3.4 by always pulling anonymously. If you are on an older version, running `podman logout ghcr.io` before the build will fix it.
 :::
 
+::: details Nginx fails to start (missing certificates)
+`lerd start` automatically detects SSL vhosts that reference missing certificate files and repairs them before starting nginx:
+
+- **Registered sites** — the site is switched back to HTTP and the vhost is regenerated. The registry is updated (`Secured = false`).
+- **Orphan SSL vhosts** — configs left behind by unlinked sites with missing certs are removed.
+
+Repaired items are printed as warnings during startup:
+
+```
+  WARN: missing TLS certificate for myapp.test — switched to HTTP
+```
+
+To re-enable HTTPS after the automatic repair, run `lerd secure <name>`.
+
+If nginx still fails to start, check the logs:
+
+```bash
+journalctl --user -u lerd-nginx -n 30 --no-pager
+```
+:::
+
 ::: details Port conflicts on `lerd start`
 `lerd start` checks for port conflicts before starting containers. If another process is already using a required port, you'll see a warning:
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -110,6 +110,11 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	if err == nil {
 		cfg, _ := config.LoadGlobal()
 		for _, site := range reg.Sites {
+			// Skip paused and ignored sites — they have their own vhosts
+			// (landing page or none) that should not be overwritten.
+			if site.Paused || site.Ignored {
+				continue
+			}
 			phpVer := site.PHPVersion
 			if phpVer == "" && cfg != nil {
 				phpVer = cfg.PHP.DefaultVersion

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -1,13 +1,11 @@
 package cli
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
-	"text/template"
 
 	"github.com/geodro/lerd/internal/config"
 	gitpkg "github.com/geodro/lerd/internal/git"
@@ -156,7 +154,7 @@ func UnpauseSite(name string) error {
 		return fmt.Errorf("updating registry: %w", err)
 	}
 
-	_ = os.Remove(filepath.Join(config.PausedDir(), site.PrimaryDomain()+".html"))
+	// The shared paused.html is left in place for other paused sites.
 
 	fmt.Printf("Resumed: %s (%s)\n", name, site.PrimaryDomain())
 	if len(resumed) > 0 {
@@ -323,13 +321,15 @@ func resumeWorkerByName(site *config.Site, workerName, phpVersion string) {
 	}
 }
 
-// pausedPageTmpl is the HTML template for the paused-site landing page.
-var pausedPageTmpl = template.Must(template.New("paused").Parse(`<!DOCTYPE html>
+// pausedPageHTML is the static HTML for the shared paused-site landing page.
+// A single file is served for all paused sites; JavaScript reads the hostname
+// and calls the correct unpause API endpoint.
+const pausedPageHTML = `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{.Domain}} — Paused</title>
+  <title>Site Paused — Lerd</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     body {
@@ -347,108 +347,102 @@ var pausedPageTmpl = template.Must(template.New("paused").Parse(`<!DOCTYPE html>
       border: 1px solid #2d3142;
       border-radius: 14px;
       padding: 2.5rem 3rem;
-      max-width: 400px;
+      max-width: 420px;
       width: calc(100% - 2rem);
       text-align: center;
     }
-    .icon { font-size: 2.5rem; margin-bottom: 1.25rem; }
-    h1 { font-size: 1.2rem; font-weight: 600; margin: 0 0 0.3rem; }
-    .domain {
-      font-size: 0.8rem;
-      color: #6b7280;
-      font-family: ui-monospace, 'Cascadia Code', monospace;
-      margin: 0 0 2rem;
-    }
-    button {
-      background: #4f46e5;
+    .logo {
+      width: 48px;
+      height: 48px;
+      margin: 0 auto 1.25rem;
+      background: #FF2D20;
+      border-radius: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 1.2rem;
       color: #fff;
-      border: none;
+    }
+    h1 { font-size: 1.2rem; font-weight: 600; margin: 0 0 0.5rem; }
+    .host {
+      font-size: 0.85rem;
+      color: #FF2D20;
+      font-family: ui-monospace, 'Cascadia Code', monospace;
+      margin: 0 0 1rem;
+      word-break: break-all;
+    }
+    p {
+      font-size: 0.85rem;
+      color: #9ca3af;
+      margin: 0 0 1.5rem;
+      line-height: 1.5;
+    }
+    .actions { display: flex; gap: 0.5rem; }
+    a, button {
+      flex: 1;
+      display: inline-block;
+      text-decoration: none;
+      text-align: center;
       border-radius: 8px;
-      padding: 0.7rem 0;
-      font-size: 0.95rem;
+      padding: 0.6rem 0;
+      font-size: 0.85rem;
       font-weight: 500;
       cursor: pointer;
-      width: 100%;
       transition: background 0.15s;
+      border: none;
     }
-    button:hover:not(:disabled) { background: #4338ca; }
-    button:disabled { background: #374151; cursor: not-allowed; }
-    .status {
-      margin-top: 1rem;
-      font-size: 0.78rem;
-      color: #9ca3af;
-      min-height: 1.1em;
-    }
-    .error { color: #ef4444; }
+    .btn-primary { background: #FF2D20; color: #fff; }
+    .btn-primary:hover:not(:disabled) { background: #e02419; }
+    .btn-primary:disabled { background: #374151; cursor: not-allowed; color: #9ca3af; }
+    .btn-secondary { background: #262a36; color: #e5e7eb; border: 1px solid #2d3142; }
+    .btn-secondary:hover { background: #2d3142; }
   </style>
 </head>
 <body>
   <div class="card">
-    <div class="icon">⏸</div>
-    <h1>{{.Name}}</h1>
-    <p class="domain">{{.Domain}}</p>
-    <button id="btn" onclick="resume()">Resume Site</button>
-    <p class="status" id="status"></p>
+    <div class="logo">L</div>
+    <h1>Site Paused</h1>
+    <p class="host" id="host"></p>
+    <p>This site has been paused. Resume it to restore the application and restart any workers.</p>
+    <div class="actions">
+      <button id="btn" class="btn-primary" onclick="resume()">Resume</button>
+      <a href="http://lerd.localhost" class="btn-secondary">Dashboard</a>
+    </div>
   </div>
   <script>
+    document.getElementById('host').textContent = location.hostname;
     async function resume() {
       const btn = document.getElementById('btn');
-      const status = document.getElementById('status');
       btn.disabled = true;
       btn.textContent = 'Resuming\u2026';
-      status.textContent = '';
-      status.className = 'status';
       try {
-        const r = await fetch('http://127.0.0.1:7073/api/sites/{{.ResumeDomain}}/unpause', { method: 'POST' });
+        const r = await fetch('http://127.0.0.1:7073/api/sites/' + location.hostname + '/unpause', { method: 'POST' });
         const data = await r.json();
         if (data.ok) {
-          status.textContent = 'Resumed! Redirecting\u2026';
-          setTimeout(() => { window.location.href = '{{.Scheme}}://{{.Domain}}'; }, 1200);
+          btn.textContent = 'Redirecting\u2026';
+          setTimeout(() => location.reload(), 1200);
         } else {
           throw new Error(data.error || 'unknown error');
         }
       } catch (e) {
         btn.disabled = false;
-        btn.textContent = 'Resume Site';
-        status.textContent = 'Error: ' + e.message;
-        status.className = 'status error';
+        btn.textContent = 'Resume';
+        alert('Error: ' + e.message);
       }
     }
   </script>
 </body>
 </html>
-`))
+`
 
-type pausedPageData struct {
-	Name         string
-	Domain       string
-	ResumeDomain string // domain used in the API unpause call (parent site for worktrees)
-	Scheme       string
-}
-
-// writePausedHTML renders and writes the landing page HTML for a paused site.
-func writePausedHTML(site *config.Site) error {
-	if err := os.MkdirAll(config.PausedDir(), 0755); err != nil {
+// writePausedHTML ensures the shared paused landing page exists.
+func writePausedHTML(_ *config.Site) error {
+	dir := config.PausedDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
-
-	scheme := "http"
-	if site.Secured {
-		scheme = "https"
-	}
-
-	var buf bytes.Buffer
-	if err := pausedPageTmpl.Execute(&buf, pausedPageData{
-		Name:         site.Name,
-		Domain:       site.PrimaryDomain(),
-		ResumeDomain: site.PrimaryDomain(),
-		Scheme:       scheme,
-	}); err != nil {
-		return err
-	}
-
-	htmlPath := filepath.Join(config.PausedDir(), site.PrimaryDomain()+".html")
-	return os.WriteFile(htmlPath, buf.Bytes(), 0644)
+	return os.WriteFile(filepath.Join(dir, "paused.html"), []byte(pausedPageHTML), 0644)
 }
 
 // pauseWorktrees generates paused HTML and nginx vhosts for every worktree of
@@ -487,33 +481,10 @@ func unpauseWorktrees(site *config.Site, phpVersion string) {
 		if vhostErr != nil {
 			fmt.Printf("  [WARN] restoring worktree vhost %s: %v\n", wt.Domain, vhostErr)
 		}
-		_ = os.Remove(filepath.Join(config.PausedDir(), wt.Domain+".html"))
 	}
 }
 
-// writePausedWorktreeHTML renders the paused landing page for a worktree checkout.
-// The resume button targets the parent site's domain so that unpausing restores
-// all worktree vhosts at once.
-func writePausedWorktreeHTML(wt gitpkg.Worktree, parent *config.Site) error {
-	if err := os.MkdirAll(config.PausedDir(), 0755); err != nil {
-		return err
-	}
-
-	scheme := "http"
-	if parent.Secured {
-		scheme = "https"
-	}
-
-	var buf bytes.Buffer
-	if err := pausedPageTmpl.Execute(&buf, pausedPageData{
-		Name:         wt.Branch,
-		Domain:       wt.Domain,
-		ResumeDomain: parent.PrimaryDomain(),
-		Scheme:       scheme,
-	}); err != nil {
-		return err
-	}
-
-	htmlPath := filepath.Join(config.PausedDir(), wt.Domain+".html")
-	return os.WriteFile(htmlPath, buf.Bytes(), 0644)
+// writePausedWorktreeHTML ensures the shared paused landing page exists (same file).
+func writePausedWorktreeHTML(_ gitpkg.Worktree, parent *config.Site) error {
+	return writePausedHTML(parent)
 }

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -331,6 +331,18 @@ func runStart(_ *cobra.Command, _ []string) error {
 		fmt.Printf("  WARN: container hosts file: %v\n", err)
 	}
 
+	// Pre-flight: repair SSL vhosts with missing cert files so nginx can start.
+	if repairs := nginx.RepairVhosts(); len(repairs) > 0 {
+		for _, r := range repairs {
+			switch r.Reason {
+			case "missing-cert":
+				fmt.Printf("  WARN: missing TLS certificate for %s — switched to HTTP\n", r.Domain)
+			case "orphan-ssl":
+				fmt.Printf("  WARN: removed orphan SSL vhost for %s\n", r.Domain)
+			}
+		}
+	}
+
 	units = append(coreUnits(), installedServiceUnits()...)
 	units = append(units, "lerd-ui", "lerd-watcher")
 	units = append(units, registeredQueueUnits()...)

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -252,7 +252,6 @@ func GeneratePausedVhost(site config.Site) error {
 	}
 
 	pausedDir := config.PausedDir()
-	htmlFile := "/" + site.PrimaryDomain() + ".html"
 	serverNames := serverNamesWithWildcards(site.Domains)
 
 	var conf string
@@ -270,22 +269,22 @@ server {
     ssl_certificate_key /etc/nginx/certs/%s.key;
     root %s;
     location / {
-        try_files %s =503;
+        try_files /paused.html =503;
         default_type text/html;
     }
 }
-`, serverNames, serverNames, site.PrimaryDomain(), site.PrimaryDomain(), pausedDir, htmlFile)
+`, serverNames, serverNames, site.PrimaryDomain(), site.PrimaryDomain(), pausedDir)
 	} else {
 		conf = fmt.Sprintf(`server {
     listen 80;
     server_name %s;
     root %s;
     location / {
-        try_files %s =503;
+        try_files /paused.html =503;
         default_type text/html;
     }
 }
-`, serverNames, pausedDir, htmlFile)
+`, serverNames, pausedDir)
 	}
 
 	confPath := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
@@ -307,8 +306,6 @@ func GeneratePausedWorktreeVhost(domain, certDomain, pausedDir string, secured b
 		return err
 	}
 
-	htmlFile := "/" + domain + ".html"
-
 	var conf string
 	if secured {
 		conf = fmt.Sprintf(`server {
@@ -324,22 +321,22 @@ server {
     ssl_certificate_key /etc/nginx/certs/%s.key;
     root %s;
     location / {
-        try_files %s =503;
+        try_files /paused.html =503;
         default_type text/html;
     }
 }
-`, domain, domain, certDomain, certDomain, pausedDir, htmlFile)
+`, domain, domain, certDomain, certDomain, pausedDir)
 	} else {
 		conf = fmt.Sprintf(`server {
     listen 80;
     server_name %s;
     root %s;
     location / {
-        try_files %s =503;
+        try_files /paused.html =503;
         default_type text/html;
     }
 }
-`, domain, pausedDir, htmlFile)
+`, domain, pausedDir)
 	}
 
 	confPath := filepath.Join(config.NginxConfD(), domain+".conf")
@@ -399,6 +396,108 @@ func GenerateProxyVhost(domain, upstreamHost string, upstreamPort int) error {
 func Reload() error {
 	_, err := podman.Run("exec", "lerd-nginx", "nginx", "-s", "reload")
 	return err
+}
+
+// VhostRepair describes a single vhost that was repaired during pre-flight.
+type VhostRepair struct {
+	Domain string
+	Reason string // "missing-cert" or "orphan-ssl"
+}
+
+// RepairVhosts performs pre-flight validation of nginx vhost configs before start.
+// It fixes SSL vhosts that reference cert files that don't exist on the host:
+//
+//   - If the domain belongs to a registered site, the vhost is regenerated as
+//     plain HTTP and the site registry is updated (Secured = false).
+//   - If no matching site exists (orphan SSL vhost), the config is removed.
+//
+// Plain HTTP vhosts are left untouched even if they don't match any site — they
+// are harmless and may belong to worktrees, parked sites, or ignored sites.
+func RepairVhosts() []VhostRepair {
+	certsDir := filepath.Join(config.CertsDir(), "sites")
+	confDir := config.NginxConfD()
+	entries, err := os.ReadDir(confDir)
+	if err != nil {
+		return nil
+	}
+
+	reg, err := config.LoadSites()
+	if err != nil {
+		return nil
+	}
+
+	var repairs []VhostRepair
+	dirty := false
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".conf") {
+			continue
+		}
+		// Skip internal configs (default catch-all and lerd dashboard proxy).
+		if entry.Name() == "_default.conf" || entry.Name() == "lerd.localhost.conf" {
+			continue
+		}
+
+		confPath := filepath.Join(confDir, entry.Name())
+		domain := strings.TrimSuffix(entry.Name(), ".conf")
+
+		data, err := os.ReadFile(confPath)
+		if err != nil {
+			continue
+		}
+
+		// Only act on vhosts with missing TLS certificates — those crash nginx.
+		if !hasMissingCert(string(data), certsDir) {
+			continue
+		}
+
+		repaired := false
+		for i, site := range reg.Sites {
+			if site.PrimaryDomain() != domain || !site.Secured {
+				continue
+			}
+			// Regenerate as plain HTTP vhost.
+			if err := GenerateVhost(site, site.PHPVersion); err != nil {
+				continue
+			}
+			reg.Sites[i].Secured = false
+			dirty = true
+			repaired = true
+			repairs = append(repairs, VhostRepair{Domain: domain, Reason: "missing-cert"})
+			os.Remove(filepath.Join(certsDir, domain+".crt")) //nolint:errcheck
+			os.Remove(filepath.Join(certsDir, domain+".key")) //nolint:errcheck
+			break
+		}
+		if !repaired {
+			// No matching site — orphan SSL vhost with missing cert, remove it.
+			os.Remove(confPath) //nolint:errcheck
+			repairs = append(repairs, VhostRepair{Domain: domain, Reason: "orphan-ssl"})
+		}
+	}
+
+	if dirty {
+		config.SaveSites(reg) //nolint:errcheck
+	}
+
+	return repairs
+}
+
+// hasMissingCert returns true if the vhost content contains an ssl_certificate
+// directive pointing to a cert file that doesn't exist on the host.
+func hasMissingCert(content, certsDir string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "ssl_certificate ") {
+			continue
+		}
+		certPath := strings.TrimSuffix(strings.TrimPrefix(line, "ssl_certificate "), ";")
+		certPath = strings.TrimSpace(certPath)
+		hostPath := filepath.Join(certsDir, filepath.Base(certPath))
+		if _, err := os.Stat(hostPath); os.IsNotExist(err) {
+			return true
+		}
+	}
+	return false
 }
 
 // EnsureDefaultVhost writes a catch-all default server that shows a branded

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -247,6 +247,203 @@ func TestRemoveVhost_noError_whenMissing(t *testing.T) {
 
 // ── EnsureDefaultVhost ────────────────────────────────────────────────────────
 
+// ── RepairVhosts ─────────────────────────────────────────────────────────────
+
+// setupRepairEnv creates a temp dir with XDG env vars, conf.d and certs dirs,
+// and writes sites.yaml. Returns confD and certsDir paths.
+func setupRepairEnv(t *testing.T, sitesYAML string) (confD, certsDir string) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	confD = filepath.Join(tmp, "lerd", "nginx", "conf.d")
+	certsDir = filepath.Join(tmp, "lerd", "certs", "sites")
+	os.MkdirAll(confD, 0755)
+	os.MkdirAll(certsDir, 0755)
+
+	sitesDir := filepath.Join(tmp, "lerd")
+	os.MkdirAll(sitesDir, 0755)
+	os.WriteFile(filepath.Join(sitesDir, "sites.yaml"), []byte(sitesYAML), 0644)
+	return confD, certsDir
+}
+
+func TestRepairVhosts_missingCertSwitchesToHTTP(t *testing.T) {
+	confD, _ := setupRepairEnv(t, `sites:
+- name: myapp
+  domains:
+    - myapp.test
+  path: /srv/myapp
+  php_version: "8.4"
+  secured: true
+`)
+
+	// Write an SSL vhost config that references a missing cert.
+	sslConf := `server {
+    listen 80;
+    server_name myapp.test *.myapp.test;
+    return 302 https://$host$request_uri;
+}
+server {
+    listen 443 ssl;
+    server_name myapp.test *.myapp.test;
+    root /srv/myapp/public;
+    ssl_certificate /etc/nginx/certs/myapp.test.crt;
+    ssl_certificate_key /etc/nginx/certs/myapp.test.key;
+}
+`
+	os.WriteFile(filepath.Join(confD, "myapp.test.conf"), []byte(sslConf), 0644)
+
+	repairs := RepairVhosts()
+
+	if len(repairs) != 1 || repairs[0].Domain != "myapp.test" || repairs[0].Reason != "missing-cert" {
+		t.Fatalf("expected [{myapp.test missing-cert}], got %v", repairs)
+	}
+
+	// Verify the vhost was regenerated as HTTP.
+	content := readConf(t, filepath.Join(confD, "myapp.test.conf"))
+	if strings.Contains(content, "ssl_certificate") {
+		t.Error("expected SSL directives to be removed after repair")
+	}
+	if !strings.Contains(content, "server_name myapp.test") {
+		t.Error("expected server_name to be preserved")
+	}
+
+	// Verify site registry was updated.
+	reg, err := config.LoadSites()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range reg.Sites {
+		if s.Name == "myapp" && s.Secured {
+			t.Error("expected site.Secured to be false after repair")
+		}
+	}
+}
+
+func TestRepairVhosts_noOpWhenCertExists(t *testing.T) {
+	confD, certsDir := setupRepairEnv(t, `sites:
+- name: good
+  domains:
+    - good.test
+  path: /srv/good
+  php_version: "8.4"
+  secured: true
+`)
+
+	sslConf := `server {
+    listen 443 ssl;
+    server_name good.test *.good.test;
+    ssl_certificate /etc/nginx/certs/good.test.crt;
+    ssl_certificate_key /etc/nginx/certs/good.test.key;
+}
+`
+	os.WriteFile(filepath.Join(confD, "good.test.conf"), []byte(sslConf), 0644)
+	os.WriteFile(filepath.Join(certsDir, "good.test.crt"), []byte("cert"), 0644)
+	os.WriteFile(filepath.Join(certsDir, "good.test.key"), []byte("key"), 0644)
+
+	repairs := RepairVhosts()
+
+	if len(repairs) != 0 {
+		t.Fatalf("expected no repairs, got %v", repairs)
+	}
+
+	content := readConf(t, filepath.Join(confD, "good.test.conf"))
+	if !strings.Contains(content, "ssl_certificate") {
+		t.Error("SSL vhost should not be modified when cert exists")
+	}
+}
+
+func TestRepairVhosts_removesOrphanSSLVhost(t *testing.T) {
+	confD, _ := setupRepairEnv(t, "sites: []\n")
+
+	sslConf := `server {
+    listen 443 ssl;
+    server_name orphan.test;
+    ssl_certificate /etc/nginx/certs/orphan.test.crt;
+}
+`
+	os.WriteFile(filepath.Join(confD, "orphan.test.conf"), []byte(sslConf), 0644)
+
+	repairs := RepairVhosts()
+
+	if len(repairs) != 1 || repairs[0].Domain != "orphan.test" || repairs[0].Reason != "orphan-ssl" {
+		t.Fatalf("expected [{orphan.test orphan-ssl}], got %v", repairs)
+	}
+
+	if _, err := os.Stat(filepath.Join(confD, "orphan.test.conf")); !os.IsNotExist(err) {
+		t.Error("expected orphan SSL vhost to be removed")
+	}
+}
+
+func TestRepairVhosts_preservesOrphanHTTPVhost(t *testing.T) {
+	confD, _ := setupRepairEnv(t, "sites: []\n")
+
+	// An HTTP vhost for an unregistered domain — harmless, should NOT be removed.
+	httpConf := `server {
+    listen 80;
+    server_name stale.test;
+    root /srv/stale/public;
+}
+`
+	os.WriteFile(filepath.Join(confD, "stale.test.conf"), []byte(httpConf), 0644)
+
+	repairs := RepairVhosts()
+
+	if len(repairs) != 0 {
+		t.Fatalf("expected no repairs for orphan HTTP vhost, got %v", repairs)
+	}
+
+	if _, err := os.Stat(filepath.Join(confD, "stale.test.conf")); err != nil {
+		t.Error("orphan HTTP vhost should be preserved")
+	}
+}
+
+func TestRepairVhosts_preservesInternalVhosts(t *testing.T) {
+	confD, _ := setupRepairEnv(t, "sites: []\n")
+
+	// Write internal vhosts that should never be removed.
+	os.WriteFile(filepath.Join(confD, "_default.conf"), []byte("server {}"), 0644)
+	os.WriteFile(filepath.Join(confD, "lerd.localhost.conf"), []byte("server { server_name lerd.localhost; }"), 0644)
+
+	repairs := RepairVhosts()
+
+	if len(repairs) != 0 {
+		t.Fatalf("expected no repairs for internal vhosts, got %v", repairs)
+	}
+	if _, err := os.Stat(filepath.Join(confD, "_default.conf")); err != nil {
+		t.Error("_default.conf should be preserved")
+	}
+	if _, err := os.Stat(filepath.Join(confD, "lerd.localhost.conf")); err != nil {
+		t.Error("lerd.localhost.conf should be preserved")
+	}
+}
+
+func TestRepairVhosts_preservesIgnoredSiteVhost(t *testing.T) {
+	confD, _ := setupRepairEnv(t, `sites:
+- name: ignored
+  domains:
+    - ignored.test
+  path: /srv/ignored
+  php_version: "8.4"
+  ignored: true
+`)
+
+	os.WriteFile(filepath.Join(confD, "ignored.test.conf"), []byte("server { server_name ignored.test; }"), 0644)
+
+	repairs := RepairVhosts()
+
+	if len(repairs) != 0 {
+		t.Fatalf("expected no repairs for ignored site HTTP vhost, got %v", repairs)
+	}
+
+	if _, err := os.Stat(filepath.Join(confD, "ignored.test.conf")); err != nil {
+		t.Error("ignored site HTTP vhost should be preserved")
+	}
+}
+
+// ── EnsureDefaultVhost ────────────────────────────────────────────────────────
+
 func TestEnsureDefaultVhost_writesDefaultConf(t *testing.T) {
 	confD := setupConfD(t)
 	if err := EnsureDefaultVhost(); err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.5.0"
+	Version = "1.5.1"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

Self-heal missing TLS certificates on lerd start so nginx doesn't refuse to start. Skip paused and ignored sites during vhost regeneration in lerd install so landing pages aren't overwritten. Redesign the paused landing page to match the branded error page, using a single shared HTML file with JS hostname detection instead of per-site templates.