### PR TITLE
docs: add macOS beta install instructions, fix cleanUrls and canonical URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ AI:  → site_link()
 curl -fsSL https://raw.githubusercontent.com/geodro/lerd/main/install.sh | bash
 ```
 
+### macOS beta
+
+macOS support is in beta. Install via Homebrew:
+
+```bash
+brew install geodro/lerd/lerd
+lerd install
+```
+
+> [!NOTE]
+> See the [beta installation docs](https://geodro.github.io/lerd/getting-started/installation/#beta-macos-preview) for details.
+
 ## Quick Start
 
 ```bash

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   title: 'Lerd',
   description: 'Open-source Herd-like local PHP development environment for Linux. Automatic .test domains, PHP 8.2–8.4, rootless Podman. Works on Ubuntu, Fedora, Arch, and Debian.',
   base: '/lerd/',
+  cleanUrls: true,
 
   sitemap: {
     hostname: SITE_URL,
@@ -28,7 +29,7 @@ export default defineConfig({
   ],
 
   transformPageData(pageData, { siteConfig }) {
-    const canonicalUrl = `${SITE_URL}/${pageData.relativePath.replace(/\.md$/, '.html').replace(/index\.html$/, '')}`
+    const canonicalUrl = `${SITE_URL}/${pageData.relativePath.replace(/\.md$/, '').replace(/index$/, '')}`
     const description = pageData.frontmatter.description ?? pageData.description ?? siteConfig.site.description
     const title = pageData.frontmatter.title ?? pageData.title ?? siteConfig.site.title
     pageData.frontmatter.head ??= []

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -104,3 +104,48 @@ lerd uninstall --force
 ```bash
 bash install.sh --check
 ```
+
+---
+
+## Beta (macOS preview)
+
+macOS support is currently in beta on the [`macos-compat`](https://github.com/geodro/lerd/tree/macos-compat) branch.
+Binaries are published to the Homebrew tap as pre-releases.
+
+### macOS
+
+```bash
+brew install geodro/lerd/lerd
+lerd install
+```
+
+Podman is installed automatically as a Homebrew dependency. `lerd install` sets up
+Podman Machine, DNS, and nginx on first run.
+
+**Update:**
+
+```bash
+brew upgrade lerd
+```
+
+**Uninstall:**
+
+```bash
+lerd uninstall
+brew uninstall lerd
+```
+
+### Linux (beta)
+
+Build from source off the beta branch:
+
+```bash
+git clone -b macos-compat https://github.com/geodro/lerd
+cd lerd
+make build
+bash install.sh --local ./build/lerd
+```
+
+::: warning Beta software
+These builds may have rough edges. Please [open an issue](https://github.com/geodro/lerd/issues) if you encounter problems.
+:::


### PR DESCRIPTION
## Summary

- Adds `cleanUrls: true` to VitePress config — fixes blank page on direct navigation (e.g. from Google) by generating `page/index.html` instead of `page.html`, so GitHub Pages can serve pages without falling back to the SPA router
- Fixes canonical URL generation to emit clean URLs without `.html` extension
- Adds macOS beta install instructions to `docs/getting-started/installation.md` and `README.md`