### PR TITLE
docs: update macOS Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ curl -fsSL https://raw.githubusercontent.com/geodro/lerd/main/install.sh | bash
 macOS support is in beta. Install via Homebrew:
 
 ```bash
-brew tap geodro/lerd
-brew install lerd
+brew install geodro/lerd/lerd
 lerd install
 ```
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -115,8 +115,7 @@ Binaries are published to the Homebrew tap as pre-releases.
 ### macOS
 
 ```bash
-brew tap geodro/lerd
-brew install lerd
+brew install geodro/lerd/lerd
 lerd install
 ```
 


### PR DESCRIPTION
Update macOS beta install instructions to use `brew tap` + `brew install` instead of the formula path, and add upgrade instructions with `lerd install`.