### PR TITLE
feat: stream link logs in real-time in the link modal

### DIFF
--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -1518,7 +1518,7 @@ function lerdApp() {
     sitesLoading: false,
     selectedSiteDomain: null,
     domainModal: { open: false, site: null, domains: [], newDomain: '', editIndex: -1, editValue: '', error: '', flash: '', loading: false, dirty: false },
-    linkModal: { open: false, currentDir: '', dirs: [], loading: false, linking: false, error: '' },
+    linkModal: { open: false, currentDir: '', dirs: [], loading: false, linking: false, error: '', logs: [] },
     phpVersions: [],
     nodeVersions: [],
     services: [],
@@ -2170,7 +2170,7 @@ function lerdApp() {
     },
 
     async openLinkModal() {
-      this.linkModal = { open: true, currentDir: '', dirs: [], loading: true, linking: false, error: '' };
+      this.linkModal = { open: true, currentDir: '', dirs: [], loading: true, linking: false, error: '', logs: [] };
       await this.browseDir('');
     },
 
@@ -2196,14 +2196,49 @@ function lerdApp() {
       const m = this.linkModal;
       m.linking = true;
       m.error = '';
+      m.logs = [];
       try {
         const res = await fetch(`/api/sites/link?path=${encodeURIComponent(m.currentDir)}`, { method: 'POST' });
-        const data = await res.json();
-        if (!data.ok) { m.error = data.error; m.linking = false; return; }
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buf = '';
+        let result = null;
+        let eventType = '';
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const lines = buf.split('\n');
+          buf = lines.pop();
+          for (const line of lines) {
+            if (line.startsWith('event: ')) {
+              eventType = line.slice(7);
+            } else if (line.startsWith('data: ')) {
+              const payload = line.slice(6);
+              if (eventType === 'done') {
+                try { result = JSON.parse(payload); } catch (_) {}
+              } else {
+                m.logs.push(payload);
+                this.$nextTick(() => {
+                  const el = document.getElementById('link-log-area');
+                  if (el) el.scrollTop = el.scrollHeight;
+                });
+              }
+              eventType = '';
+            } else if (line === '') {
+              eventType = '';
+            }
+          }
+        }
+        if (!result || !result.ok) {
+          m.error = (result && result.error) || 'Link failed';
+          m.linking = false;
+          return;
+        }
         m.open = false;
         await this.loadSites();
-        if (data.domain) {
-          const site = this.sites.find(s => s.domain === data.domain);
+        if (result.domain) {
+          const site = this.sites.find(s => s.domain === result.domain);
           if (site) this.selectSite(site);
         }
       } catch (e) { m.error = e.message; }
@@ -2887,7 +2922,7 @@ function lerdApp() {
       </div>
 
       <!-- Directory browser -->
-      <div class="px-5 py-2 max-h-72 overflow-y-auto">
+      <div x-show="!linkModal.linking" class="px-5 py-2 max-h-72 overflow-y-auto">
         <div x-show="linkModal.loading" class="py-4 text-center text-xs text-gray-400">Loading...</div>
         <div x-show="!linkModal.loading">
           <template x-for="d in linkModal.dirs" :key="d.path">
@@ -2902,6 +2937,16 @@ function lerdApp() {
         </div>
       </div>
 
+      <!-- Linking logs -->
+      <div x-show="linkModal.linking" class="px-5 py-3">
+        <div id="link-log-area" class="bg-gray-50 dark:bg-black/30 rounded-lg p-3 max-h-56 overflow-y-auto font-mono text-xs text-gray-600 dark:text-gray-400 space-y-0.5">
+          <template x-for="(line, i) in linkModal.logs" :key="i">
+            <div x-text="line"></div>
+          </template>
+          <div x-show="linkModal.logs.length === 0" class="text-gray-400 dark:text-gray-500">Waiting for output...</div>
+        </div>
+      </div>
+
       <!-- Error -->
       <template x-if="linkModal.error">
         <div class="px-5 py-2">
@@ -2911,7 +2956,7 @@ function lerdApp() {
 
       <!-- Footer -->
       <div class="px-5 py-4 border-t border-gray-100 dark:border-lerd-border flex items-center justify-end gap-2">
-        <button @click="closeLinkModal()"
+        <button x-show="!linkModal.linking" @click="closeLinkModal()"
           class="text-xs border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-white/5 rounded px-3 py-1.5 transition-colors">
           Cancel
         </button>

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -241,6 +241,11 @@ func writeJSON(w http.ResponseWriter, v any) {
 	json.NewEncoder(w).Encode(v) //nolint:errcheck
 }
 
+func mustJSON(v any) string {
+	b, _ := json.Marshal(v) //nolint:errcheck
+	return string(b)
+}
+
 // StatusResponse is the response for GET /api/status.
 type StatusResponse struct {
 	DNS            DNSStatus    `json:"dns"`
@@ -2107,6 +2112,7 @@ func handleBrowse(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleSiteLink links a directory as a site via POST /api/sites/link.
+// It streams command output as SSE events and sends a final "done" event.
 func handleSiteLink(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.NotFound(w, r)
@@ -2126,34 +2132,82 @@ func handleSiteLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Run lerd link in the target directory.
 	self, err := os.Executable()
 	if err != nil {
 		writeJSON(w, SiteActionResponse{Error: "resolving executable: " + err.Error()})
 		return
 	}
-	cmd := exec.Command(self, "link")
-	cmd.Dir = path
-	var out strings.Builder
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	if err := cmd.Run(); err != nil {
-		writeJSON(w, SiteActionResponse{Error: "link failed: " + out.String()})
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
 
-	// Run env setup (non-fatal — may not be a Laravel project).
-	envCmd := exec.Command(self, "env")
-	envCmd.Dir = path
-	_ = envCmd.Run()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	// streamCmd runs a command and streams its output as SSE data events.
+	// Returns the combined output and whether the command failed.
+	streamCmd := func(name string, args ...string) (string, bool) {
+		cmd := exec.CommandContext(r.Context(), name, args...)
+		cmd.Dir = path
+
+		pr, pw := io.Pipe()
+		cmd.Stdout = pw
+		cmd.Stderr = pw
+
+		if startErr := cmd.Start(); startErr != nil {
+			msg := startErr.Error()
+			fmt.Fprintf(w, "data: %s\n\n", msg)
+			flusher.Flush()
+			return msg, true
+		}
+
+		go func() {
+			cmd.Wait() //nolint:errcheck
+			pw.Close()
+		}()
+
+		var out strings.Builder
+		scanner := bufio.NewScanner(pr)
+		for scanner.Scan() {
+			line := scanner.Text()
+			out.WriteString(line)
+			out.WriteByte('\n')
+			escaped := strings.ReplaceAll(line, "\\", "\\\\")
+			fmt.Fprintf(w, "data: %s\n\n", escaped)
+			flusher.Flush()
+		}
+		return out.String(), cmd.ProcessState != nil && cmd.ProcessState.ExitCode() != 0
+	}
+
+	// Run lerd link.
+	fmt.Fprintf(w, "data: → Linking site...\n\n")
+	flusher.Flush()
+	out, failed := streamCmd(self, "link")
+	if failed {
+		fmt.Fprintf(w, "event: done\ndata: %s\n\n", mustJSON(map[string]any{"ok": false, "error": "link failed: " + out}))
+		flusher.Flush()
+		return
+	}
+
+	// Run env setup (non-fatal).
+	fmt.Fprintf(w, "data: → Setting up environment...\n\n")
+	flusher.Flush()
+	streamCmd(self, "env") //nolint:errcheck
 
 	// Find the newly linked site to return its domain.
 	site, err := config.FindSiteByPath(path)
 	if err != nil {
-		writeJSON(w, SiteActionResponse{OK: true})
+		fmt.Fprintf(w, "event: done\ndata: %s\n\n", mustJSON(map[string]any{"ok": true}))
+		flusher.Flush()
 		return
 	}
-	writeJSON(w, map[string]any{"ok": true, "domain": site.PrimaryDomain()})
+	fmt.Fprintf(w, "event: done\ndata: %s\n\n", mustJSON(map[string]any{"ok": true, "domain": site.PrimaryDomain()}))
+	flusher.Flush()
 }
 
 // syncLerdYAMLWorkersDelayed waits briefly for the worker unit to start, then syncs.


### PR DESCRIPTION
## Summary

- Changed the link API from synchronous JSON to SSE streaming, so `lerd link` and `lerd env` output is sent line-by-line as it happens
- The link modal now shows a scrollable log area during linking instead of the directory browser, so you can see what's happening (php-fpm spin-up, nginx config, etc)
- Cancel button is hidden while linking is in progress since the operation can't be interrupted