### PR TITLE
docs: fix missing pages, template escaping, and CLI error messages

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
       { text: 'Usage', link: '/usage/sites' },
       { text: 'Features', link: '/features/web-ui' },
       { text: 'Reference', link: '/reference/commands' },
+      { text: 'Contributing', link: '/contributing/building' },
       { text: 'Changelog', link: '/changelog' },
     ],
 
@@ -77,6 +78,7 @@ export default defineConfig({
             { text: 'Database', link: '/usage/database' },
             { text: 'Frameworks & Workers', link: '/usage/frameworks' },
             { text: 'Queue Workers', link: '/usage/queue-workers' },
+            { text: 'Stripe', link: '/usage/stripe' },
           ],
         },
       ],
@@ -102,6 +104,19 @@ export default defineConfig({
             { text: 'Configuration', link: '/reference/configuration' },
             { text: 'Directory Layout', link: '/reference/directory-layout' },
             { text: 'Architecture', link: '/reference/architecture' },
+            { text: 'Troubleshooting', link: '/troubleshooting' },
+          ],
+        },
+      ],
+      '/troubleshooting': [
+        {
+          text: 'Reference',
+          items: [
+            { text: 'Command Reference', link: '/reference/commands' },
+            { text: 'Configuration', link: '/reference/configuration' },
+            { text: 'Directory Layout', link: '/reference/directory-layout' },
+            { text: 'Architecture', link: '/reference/architecture' },
+            { text: 'Troubleshooting', link: '/troubleshooting' },
           ],
         },
       ],

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -590,7 +590,7 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `lerd status` — includes custom services in the `[Services]` section
   - Web UI services tab — shows custom services with start/stop and dashboard link
   - System tray — shows custom services (slot pool expanded from 7 to 20)
-- **`{{site}}` / `{{site_testing}}` placeholders** in `env_vars` and `site_init.exec` — substituted with the project site handle at `lerd env` time
+- <strong><code v-pre>{{site}}</code> / <code v-pre>{{site_testing}}</code> placeholders</strong> in `env_vars` and `site_init.exec` — substituted with the project site handle at `lerd env` time
 - **`site_init`** YAML block — runs a `sh -c` command inside the service container once per project when `lerd env` detects the service (for DB/collection creation, user setup, etc.)
 - **`dashboard`** field — shows an "Open" button in the web UI when the service is active; dashboard URLs for built-ins (Mailpit, MinIO, Meilisearch) moved from hardcoded JS to the API response
 - **README simplified** — now a slim landing page pointing to the docs site

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -4,17 +4,32 @@ All containers join the rootless Podman network `lerd`. Communication between Ng
 
 ## Request flow
 
-```mermaid
-graph TD
-    Browser["Browser"] -->|port 80/443| Nginx["lerd-nginx<br/>(nginx:alpine)"]
-    Nginx -->|fastcgi_pass :9000| FPM["lerd-php84-fpm<br/>(locally built image)"]
-    FPM -->|reads| Files["~/Lerd/my-app<br/>(bind-mounted read-only)"]
-
-    DNS["*.test DNS"] -->|resolves to| Loopback["127.0.0.1"]
-    Loopback --> Nginx
-
-    NM["NetworkManager"] -->|forwards .test queries| DNSMASQ["lerd-dns<br/>(dnsmasq, port 5300)"]
-    DNSMASQ -->|returns| Loopback
+```
+                          *.test DNS
+                              │
+                   ┌──────────┴──────────┐
+                   │    NetworkManager    │
+                   └──────────┬──────────┘
+                              │ forwards .test queries
+                   ┌──────────┴──────────┐
+                   │      lerd-dns       │
+                   │  (dnsmasq, :5300)   │
+                   └──────────┬──────────┘
+                              │ resolves to 127.0.0.1
+                              ▼
+  Browser ──── port 80/443 ──▶ lerd-nginx
+                              (nginx:alpine)
+                                  │
+                      fastcgi_pass :9000
+                                  │
+                                  ▼
+                            lerd-php84-fpm
+                          (locally built image)
+                                  │
+                              reads (bind mount)
+                                  │
+                                  ▼
+                          ~/Lerd/my-app
 ```
 
 ## Components

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -138,6 +138,8 @@ For projects that use `laravel/horizon` — lerd detects it automatically from `
 
 ## Reverb
 
+Requires [Laravel Broadcasting](https://laravel.com/docs/13.x/broadcasting) with the `laravel/reverb` package — lerd detects it automatically from `composer.json`.
+
 | Command | Description |
 |---|---|
 | `lerd reverb:start` | Start the Reverb WebSocket server for the current project as a persistent background service |

--- a/docs/usage/services.md
+++ b/docs/usage/services.md
@@ -216,6 +216,9 @@ site_init:
 
 `env_vars` values and `site_init.exec` support two placeholders that are substituted per-project when `lerd env` runs:
 
+<!-- markdownlint-disable-next-line -->
+<div v-pre>
+
 | Placeholder | Expands to |
 |---|---|
 | `{{site}}` | Project site handle (derived from the registered site name or directory name, hyphens converted to underscores) |
@@ -223,11 +226,13 @@ site_init:
 
 These are not limited to database names — use them anywhere a per-project identifier is needed (a bucket name, a queue prefix, a namespace, etc.).
 
+</div>
+
 ### How `lerd env` uses custom services
 
 When `lerd env` runs in a project directory, it checks each custom service's `env_detect` rule against the project's `.env`. If a match is found:
 
-1. `env_vars` are written into `.env`, with `{{site}}` and `{{site_testing}}` substituted
+1. `env_vars` are written into `.env`, with <code v-pre>{{site}}</code> and <code v-pre>{{site_testing}}</code> substituted
 2. The service is started if not already running
 3. `site_init.exec` is run inside the container (if defined)
 
@@ -407,11 +412,11 @@ Point the Stripe PHP SDK at the mock in your `AppServiceProvider` or test bootst
 | `--image` | OCI image reference (required) |
 | `--port` | Port mapping `host:container` — repeatable |
 | `--env` | Container environment variable `KEY=VALUE` — repeatable |
-| `--env-var` | `.env` variable injected by `lerd env`, supports `{{site}}` — repeatable |
+| `--env-var` | `.env` variable injected by `lerd env`, supports <code v-pre>{{site}}</code> — repeatable |
 | `--data-dir` | Mount path inside the container for persistent data |
 | `--detect-key` | `.env` key that triggers auto-detection in `lerd env` |
 | `--detect-prefix` | Optional value prefix filter for auto-detection |
-| `--init-exec` | Shell command run inside the container once per site (supports `{{site}}` and `{{site_testing}}`) |
+| `--init-exec` | Shell command run inside the container once per site (supports <code v-pre>{{site}}</code> and <code v-pre>{{site_testing}}</code>) |
 | `--init-container` | Container to run `--init-exec` in (default: `lerd-<name>`) |
 | `--dashboard` | URL to open when clicking the dashboard button in the web UI |
 | `--description` | Description shown in `lerd service list` |

--- a/internal/cli/horizon.go
+++ b/internal/cli/horizon.go
@@ -40,7 +40,7 @@ func newHorizonStartCmd(use string) *cobra.Command {
 				return err
 			}
 			if !SiteHasHorizon(cwd) {
-				return fmt.Errorf("laravel/horizon is not installed in this project")
+				return fmt.Errorf("laravel/horizon is not installed in this project\nInstall it with: composer require laravel/horizon\nSee https://laravel.com/docs/13.x/horizon")
 			}
 			siteName, err := queueSiteName(cwd)
 			if err != nil {
@@ -72,7 +72,7 @@ func newHorizonStopCmd(use string) *cobra.Command {
 				return err
 			}
 			if !SiteHasHorizon(cwd) {
-				return fmt.Errorf("laravel/horizon is not installed in this project")
+				return fmt.Errorf("laravel/horizon is not installed in this project\nInstall it with: composer require laravel/horizon\nSee https://laravel.com/docs/13.x/horizon")
 			}
 			siteName, err := queueSiteName(cwd)
 			if err != nil {

--- a/internal/cli/reverb.go
+++ b/internal/cli/reverb.go
@@ -42,6 +42,9 @@ func newReverbStartCmd(use string) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if !SiteHasReverb(cwd) {
+				return fmt.Errorf("laravel/reverb is not installed in this project\nInstall it with: composer require laravel/reverb\nSee https://laravel.com/docs/13.x/broadcasting")
+			}
 			if err := requireFrameworkWorker(cwd, "reverb"); err != nil {
 				return err
 			}
@@ -73,6 +76,9 @@ func newReverbStopCmd(use string) *cobra.Command {
 			cwd, err := os.Getwd()
 			if err != nil {
 				return err
+			}
+			if !SiteHasReverb(cwd) {
+				return fmt.Errorf("laravel/reverb is not installed in this project\nInstall it with: composer require laravel/reverb\nSee https://laravel.com/docs/13.x/broadcasting")
 			}
 			if err := requireFrameworkWorker(cwd, "reverb"); err != nil {
 				return err


### PR DESCRIPTION
## Summary

- Added contributing nav link, stripe sidebar entry, and troubleshooting sidebar entry so all doc pages are reachable
- Escaped `{{site}}` and `{{site_testing}}` placeholders with v-pre so VitePress stops treating them as Vue template expressions
- Replaced mermaid code block on architecture page with ASCII diagram since no mermaid plugin is installed
- Added laravel/reverb package check to reverb commands, improved horizon and reverb error messages with install instructions and docs links
- Added reverb prerequisite note to commands reference page

Closes #83