### PR TITLE
feat: framework setup commands, service version placeholders, checks

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -46,6 +46,8 @@
 | `lerd setup --all` | Run init (or apply saved `.lerd.yaml`) and all steps without prompting (useful in CI) |
 | `lerd setup --skip-open` | Same as above but don't open the browser at the end |
 
+Setup steps include common tasks (composer install, npm install, lerd env) plus framework-specific commands defined in the framework's `setup` field (e.g. migrations, storage links). See [Frameworks & Workers](/usage/frameworks) for how to define custom setup commands.
+
 ## Site management
 
 | Command | Description |

--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -210,7 +210,7 @@ env:
         - key: DATABASE_URL
           value_prefix: "mysql://"
       vars:
-        - "DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/{{site}}"
+        - "DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/{{site}}?serverVersion={{mysql_version}}"
     redis:
       detect:
         - key: REDIS_URL
@@ -234,6 +234,20 @@ workers:
     label: Messenger               # display name (optional)
     command: php bin/console messenger:consume async --time-limit=3600
     restart: always               # always | on-failure (default: always)
+    check:                         # only shown when check passes (optional)
+      composer: symfony/messenger
+
+# One-off setup commands shown in `lerd setup` wizard
+setup:
+  - label: "Run migrations"                     # display name and identifier
+    command: "php bin/console doctrine:migrations:migrate --no-interaction"
+    default: true                               # pre-selected in the wizard
+    check:                                      # only shown when check passes (optional)
+      composer: doctrine/doctrine-migrations-bundle
+  - label: "Load fixtures"
+    command: "php bin/console doctrine:fixtures:load --no-interaction"
+    check:
+      composer: doctrine/doctrine-fixtures-bundle  # skipped if package not installed
 ```
 
 ---
@@ -288,7 +302,7 @@ env:
         - key: DATABASE_URL
           value_prefix: "mariadb://"
       vars:
-        - "DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/{{site}}"
+        - "DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/{{site}}?serverVersion={{mysql_version}}"
     postgres:
       detect:
         - key: DATABASE_URL
@@ -296,7 +310,7 @@ env:
         - key: DATABASE_URL
           value_prefix: "postgres://"
       vars:
-        - "DATABASE_URL=postgresql://postgres:lerd@lerd-postgres:5432/{{site}}"
+        - "DATABASE_URL=postgresql://postgres:lerd@lerd-postgres:5432/{{site}}?serverVersion={{postgres_version}}"
     redis:
       detect:
         - key: REDIS_URL
@@ -321,11 +335,27 @@ workers:
     label: Messenger
     command: php bin/console messenger:consume async --time-limit=3600
     restart: always
+    check:
+      composer: symfony/messenger
+setup:
+  - label: "Run migrations"
+    command: "php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration"
+    default: true
+    check:
+      composer: doctrine/doctrine-migrations-bundle
+  - label: "Load fixtures"
+    command: "php bin/console doctrine:fixtures:load --no-interaction"
+    check:
+      composer: doctrine/doctrine-fixtures-bundle
+  - label: "Clear cache"
+    command: "php bin/console cache:clear"
+    default: true
 ```
 
 ```bash
 lerd framework add symfony --from-file ~/.config/lerd/frameworks/symfony.yaml
 lerd link                          # auto-detected as Symfony
+lerd setup                         # shows migrations, fixtures, and other steps
 lerd worker start messenger        # starts lerd-messenger-<sitename>
 ```
 

--- a/docs/usage/services.md
+++ b/docs/usage/services.md
@@ -223,6 +223,10 @@ site_init:
 |---|---|
 | `{{site}}` | Project site handle (derived from the registered site name or directory name, hyphens converted to underscores) |
 | `{{site_testing}}` | Same as `{{site}}` with `_testing` appended |
+| `{{mysql_version}}` | Major version of the MySQL service image (e.g. `8.0`) |
+| `{{postgres_version}}` | Major version of the PostgreSQL service image (e.g. `16`) |
+| `{{redis_version}}` | Major version of the Redis service image (e.g. `7`) |
+| `{{meilisearch_version}}` | Version of the Meilisearch service image (e.g. `1.7`) |
 
 These are not limited to database names — use them anywhere a per-project identifier is needed (a bucket name, a queue prefix, a namespace, etc.).
 

--- a/internal/cli/confirm_replace.go
+++ b/internal/cli/confirm_replace.go
@@ -16,22 +16,31 @@ var (
 	metaStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("4")) // blue
 )
 
-// confirmReplace compares existing and replacement by marshalling both to YAML.
-// If they are identical it returns true immediately (no prompt needed).
-// If they differ it prints a unified diff and asks the user whether to replace.
-// Returns true if the replacement should be applied, false to skip.
-func confirmReplace(kind, name string, existing, replacement interface{}) (bool, error) {
+// replaceAction represents the user's choice when a definition conflict is found.
+type replaceAction int
+
+const (
+	replaceSkip        replaceAction = iota // keep both as-is
+	replaceFromProject                      // apply .lerd.yaml → disk
+	replaceFromDisk                         // apply disk → .lerd.yaml
+)
+
+// confirmReplace compares existing (on disk) and replacement (from .lerd.yaml)
+// by marshalling both to YAML. If they are identical it returns replaceSkip
+// immediately. Otherwise it prints a unified diff and asks the user which
+// direction to sync, or to skip.
+func confirmReplace(kind, name string, existing, replacement interface{}) (replaceAction, error) {
 	oldYAML, err := yaml.Marshal(existing)
 	if err != nil {
-		return false, err
+		return replaceSkip, err
 	}
 	newYAML, err := yaml.Marshal(replacement)
 	if err != nil {
-		return false, err
+		return replaceSkip, err
 	}
 
 	if string(oldYAML) == string(newYAML) {
-		return true, nil // identical — nothing to do
+		return replaceSkip, nil // identical — nothing to do
 	}
 
 	diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
@@ -42,7 +51,7 @@ func confirmReplace(kind, name string, existing, replacement interface{}) (bool,
 		Context:  3,
 	})
 	if err != nil {
-		return false, err
+		return replaceSkip, err
 	}
 
 	fmt.Printf("\n%s %s/%s already exists and differs:\n\n", metaStyle.Render("~"), kind, name)
@@ -60,16 +69,21 @@ func confirmReplace(kind, name string, existing, replacement interface{}) (bool,
 	}
 	fmt.Println()
 
-	replace := false
+	choice := 0
 	if err := huh.NewForm(
 		huh.NewGroup(
-			huh.NewConfirm().
-				Title(fmt.Sprintf("Replace %s/%s with the version from .lerd.yaml?", kind, name)).
-				Value(&replace),
+			huh.NewSelect[int]().
+				Title(fmt.Sprintf("How to resolve %s/%s?", kind, name)).
+				Options(
+					huh.NewOption("Use version from .lerd.yaml (update local definition)", int(replaceFromProject)),
+					huh.NewOption("Use local definition (update .lerd.yaml)", int(replaceFromDisk)),
+					huh.NewOption("Skip (keep both as-is)", int(replaceSkip)),
+				).
+				Value(&choice),
 		),
 	).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
-		return false, err
+		return replaceSkip, err
 	}
 
-	return replace, nil
+	return replaceAction(choice), nil
 }

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -500,10 +500,18 @@ func artisanIn(dir string, args ...string) error {
 	return cmd.Run()
 }
 
-// applySiteHandle replaces {{site}} and {{site_testing}} placeholders in s.
+// applySiteHandle replaces {{site}}, {{site_testing}}, and service version
+// placeholders (e.g. {{mysql_version}}, {{postgres_version}}) in s.
 func applySiteHandle(s, site string) string {
 	s = strings.ReplaceAll(s, "{{site}}", site)
 	s = strings.ReplaceAll(s, "{{site_testing}}", site+"_testing")
+	// Lazy-resolve service version placeholders only when present.
+	for _, svc := range []string{"mysql", "postgres", "redis", "meilisearch"} {
+		placeholder := "{{" + svc + "_version}}"
+		if strings.Contains(s, placeholder) {
+			s = strings.ReplaceAll(s, placeholder, podman.ServiceVersion("lerd-"+svc))
+		}
+	}
 	return s
 }
 

--- a/internal/cli/framework.go
+++ b/internal/cli/framework.go
@@ -65,6 +65,7 @@ func newFrameworkAddCmd() *cobra.Command {
 		composer       string
 		npm            string
 		create         string
+		setupCmds      []string
 	)
 
 	cmd := &cobra.Command{
@@ -90,7 +91,15 @@ YAML file format:
     format: dotenv
   composer: auto
   npm: auto
-  create: composer create-project myvendor/myfw`,
+  create: composer create-project myvendor/myfw
+  setup:
+    - label: "Run migrations"
+      command: "php bin/console doctrine:migrations:migrate --no-interaction"
+      default: true
+    - label: "Load fixtures"
+      command: "php bin/console doctrine:fixtures:load --no-interaction"
+      check:
+        composer: doctrine/doctrine-fixtures-bundle`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			var fw config.Framework
@@ -131,6 +140,18 @@ YAML file format:
 						Format:      envFormat,
 					}
 				}
+
+				for _, raw := range setupCmds {
+					cmdLabel, command, found := strings.Cut(raw, ":")
+					if !found {
+						return fmt.Errorf("invalid --setup %q: expected \"label:command\"", raw)
+					}
+					fw.Setup = append(fw.Setup, config.FrameworkSetupCmd{
+						Label:   strings.TrimSpace(cmdLabel),
+						Command: strings.TrimSpace(command),
+						Default: true,
+					})
+				}
 			}
 
 			if fw.PublicDir == "" && fw.Name != "laravel" {
@@ -162,6 +183,7 @@ YAML file format:
 	cmd.Flags().StringVar(&composer, "composer", "", "Run composer install: auto, true, or false")
 	cmd.Flags().StringVar(&npm, "npm", "", "Run npm install: auto, true, or false")
 	cmd.Flags().StringVar(&create, "create", "", "Scaffold command for 'lerd new' (target dir is appended automatically, e.g. \"composer create-project myvendor/myfw\")")
+	cmd.Flags().StringArrayVar(&setupCmds, "setup", nil, `Setup command as "label:command" (repeatable, e.g. --setup "Run migrations:php bin/console doctrine:migrations:migrate")`)
 
 	return cmd
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -117,7 +117,11 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 	hasReverb := SiteUsesReverb(cwd)
 	var workerOptions []string
 	if fw, ok := config.GetFramework(framework); ok && fw.Workers != nil {
-		for name := range fw.Workers {
+		for name, wDef := range fw.Workers {
+			// Skip workers whose check doesn't pass.
+			if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
+				continue
+			}
 			// Skip queue when horizon is installed — horizon manages queues.
 			if name == "queue" && hasHorizon {
 				continue

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -55,10 +55,16 @@ func runLink(args []string) error {
 			// Does not exist locally — save without prompting.
 			_ = config.SaveFramework(proj.FrameworkDef)
 		} else {
-			if ok, err := confirmReplace("framework", proj.Framework, existing, proj.FrameworkDef); err != nil {
+			action, err := confirmReplace("framework", proj.Framework, existing, proj.FrameworkDef)
+			if err != nil {
 				return err
-			} else if ok {
+			}
+			switch action {
+			case replaceFromProject:
 				_ = config.SaveFramework(proj.FrameworkDef)
+			case replaceFromDisk:
+				proj.FrameworkDef = existing
+				_ = config.SaveProjectConfig(cwd, proj)
 			}
 		}
 	}
@@ -226,15 +232,33 @@ func runLink(args []string) error {
 			if svc.Custom != nil {
 				svc.Custom.Name = svc.Name
 				existing, loadErr := config.LoadCustomService(svc.Name)
-				save := true
+				shouldSave := true
 				if loadErr == nil {
-					var err error
-					save, err = confirmReplace("service", svc.Name, existing, svc.Custom)
+					action, err := confirmReplace("service", svc.Name, existing, svc.Custom)
 					if err != nil {
 						return err
 					}
+					switch action {
+					case replaceFromProject:
+						shouldSave = true
+					case replaceFromDisk:
+						svc.Custom = existing
+						shouldSave = false
+						// Update .lerd.yaml so the diff doesn't recur on next link.
+						if p, _ := config.LoadProjectConfig(cwd); p != nil {
+							for i, s := range p.Services {
+								if s.Name == svc.Name {
+									p.Services[i].Custom = existing
+									_ = config.SaveProjectConfig(cwd, p)
+									break
+								}
+							}
+						}
+					default:
+						shouldSave = false
+					}
 				}
-				if save {
+				if shouldSave {
 					if err := config.SaveCustomService(svc.Custom); err != nil {
 						fmt.Printf("[WARN] registering service %s: %v\n", svc.Name, err)
 						continue

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -300,7 +300,8 @@ In practice, you can almost always omit ` + bt + `path` + bt + ` — just open C
 - Custom services (MongoDB, RabbitMQ, …) can be added with ` + bt + `service_add` + bt + ` and managed identically to built-in ones
 - Node.js versions are managed by **fnm** (Fast Node Manager); pin per-project with a ` + bt + `.node-version` + bt + ` file
 - Framework workers (queue, schedule, reverb, messenger, etc.) run as systemd user services named ` + bt + `lerd-<worker>-<sitename>` + bt + ` (e.g. ` + bt + `lerd-queue-myapp` + bt + `, ` + bt + `lerd-messenger-myapp` + bt + `)
-- Worker commands are defined per-framework in YAML definitions; Laravel has built-in queue/schedule/reverb workers; custom frameworks can add any workers
+- Worker commands are defined per-framework in YAML definitions; Laravel has built-in queue/schedule/reverb workers; custom frameworks can add any workers; both workers and setup commands support an optional ` + bt + `check` + bt + ` field (` + bt + `file` + bt + ` or ` + bt + `composer` + bt + `) to conditionally show them based on project dependencies
+- Framework definitions can include ` + bt + `setup` + bt + ` commands (one-off bootstrap steps like migrations, storage links) shown in ` + bt + `lerd setup` + bt + `; Laravel has built-in storage:link/migrate/db:seed
 - Git worktrees automatically get a ` + bt + `<branch>.<site>.test` + bt + ` subdomain; ` + bt + `vendor/` + bt + `, ` + bt + `node_modules/` + bt + `, and ` + bt + `.env` + bt + ` are symlinked/copied from the main checkout
 - DNS resolves ` + bt + `*.test` + bt + ` to ` + bt + `127.0.0.1` + bt + `
 
@@ -567,10 +568,10 @@ cd myapp && lerd link && lerd setup
 ` + "```" + `
 
 ### ` + bt + `framework_list` + bt + `
-List all available framework definitions (Laravel built-in plus any user-defined YAMLs at ` + bt + `~/.config/lerd/frameworks/` + bt + `), including their defined workers. Call this before ` + bt + `framework_add` + bt + ` to see what already exists.
+List all available framework definitions (Laravel built-in plus any user-defined YAMLs at ` + bt + `~/.config/lerd/frameworks/` + bt + `), including their defined workers and setup commands. Call this before ` + bt + `framework_add` + bt + ` to see what already exists.
 
 ### ` + bt + `framework_add` + bt + `
-Create or update a framework definition. For ` + bt + `laravel` + bt + `, only the ` + bt + `workers` + bt + ` field is accepted (built-in settings are always preserved). For other frameworks, creates a full definition.
+Create or update a framework definition. For ` + bt + `laravel` + bt + `, only the ` + bt + `workers` + bt + ` and ` + bt + `setup` + bt + ` fields are accepted (built-in settings are always preserved). For other frameworks, creates a full definition.
 
 Arguments:
 - ` + bt + `name` + bt + ` (required): framework slug (e.g. ` + bt + `"symfony"` + bt + `). Use ` + bt + `"laravel"` + bt + ` to add custom workers to the built-in Laravel definition (e.g. ` + bt + `horizon` + bt + `, ` + bt + `pulse` + bt + `)
@@ -580,7 +581,8 @@ Arguments:
 - ` + bt + `detect_packages` + bt + ` (optional): array of Composer packages that signal this framework
 - ` + bt + `env_file` + bt + ` (optional): primary env file path (default: ` + bt + `".env"` + bt + `)
 - ` + bt + `env_format` + bt + ` (optional): ` + bt + `"dotenv"` + bt + ` or ` + bt + `"php-const"` + bt + `
-- ` + bt + `workers` + bt + ` (optional): map of worker name → ` + bt + `{label, command, restart}` + bt + `
+- ` + bt + `workers` + bt + ` (optional): map of worker name → ` + bt + `{label, command, restart, check}` + bt + ` — ` + bt + `check` + bt + ` is optional (` + bt + `{file}` + bt + ` or ` + bt + `{composer}` + bt + `), worker only shown when check passes
+- ` + bt + `setup` + bt + ` (optional): array of one-off setup commands shown in ` + bt + `lerd setup` + bt + ` wizard, each with ` + bt + `{label, command, default, check}` + bt + ` — ` + bt + `check` + bt + ` is optional, same format as workers
 
 Example — add Horizon to Laravel:
 ` + "```" + `
@@ -603,7 +605,7 @@ framework_add(
 ` + "```" + `
 
 ### ` + bt + `framework_remove` + bt + `
-Delete a user-defined framework YAML. For ` + bt + `laravel` + bt + `, removes only the custom worker additions (built-in queue/schedule/reverb remain). Takes ` + bt + `name` + bt + ` (required).
+Delete a user-defined framework YAML. For ` + bt + `laravel` + bt + `, removes only custom worker and setup command additions (built-in queue/schedule/reverb workers and storage:link/migrate/db:seed setup remain). Takes ` + bt + `name` + bt + ` (required).
 
 ### ` + bt + `site_php` + bt + ` / ` + bt + `site_node` + bt + `
 Change the PHP or Node.js version for a registered site. Both take ` + bt + `site` + bt + ` (required) and ` + bt + `version` + bt + ` (required).
@@ -861,7 +863,9 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - Nginx routes ` + bt + `*.test` + bt + ` domains to the correct PHP-FPM container
 - Services (MySQL, Redis, PostgreSQL, etc.) and custom services run as Podman containers via systemd quadlets
 - Node.js versions are managed by fnm; per-project version is set via a ` + bt + `.node-version` + bt + ` file
-- Framework workers (queue, schedule, reverb, horizon, messenger, etc.) run as systemd user services named ` + bt + `lerd-<worker>-<sitename>` + bt + `; commands are defined per-framework in YAML definitions; Laravel Horizon is auto-detected from ` + bt + `composer.json` + bt + ` and replaces the queue toggle when installed
+- Framework workers (queue, schedule, reverb, horizon, messenger, etc.) run as systemd user services named ` + bt + `lerd-<worker>-<sitename>` + bt + `; commands are defined per-framework in YAML definitions; Laravel Horizon is auto-detected from ` + bt + `composer.json` + bt + ` and replaces the queue toggle when installed; both workers and setup commands support an optional ` + bt + `check` + bt + ` field (` + bt + `file` + bt + ` or ` + bt + `composer` + bt + `) to conditionally show them based on project dependencies
+- Framework setup commands (one-off bootstrap steps like migrations, storage links) are defined in the framework YAML and shown in ` + bt + `lerd setup` + bt + `; Laravel has built-in storage:link/migrate/db:seed; custom frameworks can define their own
+- Service version placeholders (` + bt + `{{mysql_version}}` + bt + `, ` + bt + `{{postgres_version}}` + bt + `, ` + bt + `{{redis_version}}` + bt + `, ` + bt + `{{meilisearch_version}}` + bt + `) are available in framework env vars and are resolved from the service image tag at ` + bt + `lerd env` + bt + ` time
 - Git worktrees automatically get a ` + bt + `<branch>.<site>.test` + bt + ` subdomain; ` + bt + `vendor/` + bt + `, ` + bt + `node_modules/` + bt + `, and ` + bt + `.env` + bt + ` are symlinked/copied from the main checkout
 
 ### Available MCP tools
@@ -913,9 +917,9 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `worker_stop` + bt + ` | Stop a named framework worker |
 | ` + bt + `worker_list` + bt + ` | List all workers defined for a site's framework with running status |
 | ` + bt + `project_new` + bt + ` | Scaffold a new PHP project (runs the framework's create command); follow with ` + bt + `site_link` + bt + ` + ` + bt + `env_setup` + bt + ` |
-| ` + bt + `framework_list` + bt + ` | List all framework definitions with their workers |
-| ` + bt + `framework_add` + bt + ` | Add or update a framework definition; use ` + bt + `name: "laravel"` + bt + ` to add custom workers to Laravel |
-| ` + bt + `framework_remove` + bt + ` | Remove a user-defined framework; for laravel removes only custom worker additions |
+| ` + bt + `framework_list` + bt + ` | List all framework definitions with their workers and setup commands |
+| ` + bt + `framework_add` + bt + ` | Add or update a framework definition; use ` + bt + `name: "laravel"` + bt + ` to add custom workers or setup commands to Laravel |
+| ` + bt + `framework_remove` + bt + ` | Remove a user-defined framework; for laravel removes only custom worker and setup additions |
 | ` + bt + `site_php` + bt + ` | Change PHP version for a site — writes ` + bt + `.php-version` + bt + `, updates registry, regenerates nginx vhost |
 | ` + bt + `site_node` + bt + ` | Change Node.js version for a site — writes ` + bt + `.node-version` + bt + `, installs via fnm if needed |
 | ` + bt + `site_pause` + bt + ` | Pause a site: stop all its workers and replace its vhost with a landing page |
@@ -947,6 +951,8 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - ` + bt + `service_pin` + bt + ` keeps a service always running regardless of which sites are active; use for shared services like MySQL or Redis
 - ` + bt + `service_add` + bt + ` supports ` + bt + `depends_on` + bt + ` (array of service names): starting a dependency auto-starts the dependent service; stopping a dependency cascade-stops the dependent first; starting the dependent ensures dependencies start first
 - ` + bt + `project_new` + bt + ` requires an absolute ` + bt + `path` + bt + ` and runs the framework's ` + bt + `create` + bt + ` command; follow it with ` + bt + `site_link` + bt + ` + ` + bt + `env_setup` + bt + ` to register and configure the new project
+- ` + bt + `framework_add` + bt + ` accepts ` + bt + `workers` + bt + ` (map) and ` + bt + `setup` + bt + ` (array) — both support an optional ` + bt + `check` + bt + ` field (` + bt + `{file}` + bt + ` or ` + bt + `{composer}` + bt + `) to conditionally show based on project deps; for Laravel, custom setup commands replace built-in storage:link/migrate/db:seed
+- Framework env vars support service version placeholders: ` + bt + `{{mysql_version}}` + bt + `, ` + bt + `{{postgres_version}}` + bt + `, ` + bt + `{{redis_version}}` + bt + `, ` + bt + `{{meilisearch_version}}` + bt + ` — resolved from the running service image tag
 - ` + bt + `php_ext_add` + bt + ` / ` + bt + `php_ext_remove` + bt + ` rebuild the FPM image and restart the container — may take a minute; ` + bt + `version` + bt + ` defaults to the project or global PHP version
 - ` + bt + `db_import` + bt + ` requires the database service to be running; pipe the file by absolute path — it reads connection info from ` + bt + `.env` + bt + `
 - ` + bt + `db_create` + bt + ` always creates both ` + bt + `<name>` + bt + ` and ` + bt + `<name>_testing` + bt + ` databases; safe to call if they already exist

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -102,6 +102,13 @@ func runSetup(allSteps, skipOpen bool) error {
 	hasLockFile := lockMissing == nil || shrinkMissing == nil
 	buildScript := detectBuildScript(cwd + "/package.json")
 
+	// Always run lerd env first — it configures .env, starts services, and
+	// creates databases before any other step that may depend on them.
+	fmt.Println("\n→ Running: lerd env")
+	if err := runEnv(nil, nil); err != nil {
+		fmt.Printf("  [WARN] lerd env: %v\n", err)
+	}
+
 	steps := []setupStep{
 		{
 			label:   "composer install",
@@ -124,13 +131,6 @@ func runSetup(allSteps, skipOpen bool) error {
 			},
 		},
 		{
-			label:   "lerd env",
-			enabled: true,
-			run: func() error {
-				return runEnv(nil, nil)
-			},
-		},
-		{
 			label:   "lerd mcp:inject",
 			enabled: false,
 			run: func() error {
@@ -146,28 +146,33 @@ func runSetup(allSteps, skipOpen bool) error {
 		},
 	}
 
-	if isLaravel {
-		steps = append(steps, setupStep{
-			label:   "php artisan storage:link",
-			enabled: siteNeedsStorageLink(cwd),
-			run: func() error {
-				return artisanIn(cwd, "storage:link")
-			},
-		})
-		steps = append(steps, setupStep{
-			label:   "php artisan migrate",
-			enabled: true,
-			run: func() error {
-				return artisanIn(cwd, "migrate")
-			},
-		})
-		steps = append(steps, setupStep{
-			label:   "php artisan db:seed",
-			enabled: false,
-			run: func() error {
-				return artisanIn(cwd, "db:seed")
-			},
-		})
+	// Framework setup commands (one-off bootstrap steps like migrations, storage:link, etc.)
+	if site != nil {
+		fwName := site.Framework
+		if fwName == "" {
+			fwName, _ = config.DetectFramework(cwd)
+		}
+		if fw, ok := config.GetFramework(fwName); ok {
+			for _, sc := range fw.Setup {
+				// Skip commands whose check doesn't pass.
+				if sc.Check != nil && !config.MatchesRule(cwd, *sc.Check) {
+					continue
+				}
+				setupCmd := sc
+				enabled := setupCmd.Default
+				// Laravel dynamic default: only enable storage:link when actually needed.
+				if fwName == "laravel" && strings.Contains(setupCmd.Command, "storage:link") {
+					enabled = siteNeedsStorageLink(cwd)
+				}
+				steps = append(steps, setupStep{
+					label:   setupCmd.Label,
+					enabled: enabled,
+					run: func() error {
+						return execInContainer(cwd, setupCmd.Command)
+					},
+				})
+			}
+		}
 	}
 
 	// Only offer the secure step when the site isn't already secured by lerd init.
@@ -295,6 +300,9 @@ func runSetup(allSteps, skipOpen bool) error {
 		}
 		if fw, ok := config.GetFramework(fwName); ok && fw.Workers != nil {
 			for wName, wDef := range fw.Workers {
+				if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
+					continue
+				}
 				if isLaravel {
 					switch wName {
 					case "queue", "schedule", "reverb":
@@ -451,6 +459,26 @@ func siteHasStripeSecret(cwd string) bool {
 		}
 	}
 	return false
+}
+
+// execInContainer runs an arbitrary command string inside the site's PHP-FPM container.
+func execInContainer(dir, command string) error {
+	version, err := phpDet.DetectVersion(dir)
+	if err != nil {
+		cfg, _ := config.LoadGlobal()
+		version = cfg.PHP.DefaultVersion
+	}
+	short := strings.ReplaceAll(version, ".", "")
+	container := "lerd-php" + short + "-fpm"
+	parts := strings.Fields(command)
+	if len(parts) == 0 {
+		return fmt.Errorf("empty setup command")
+	}
+	cmdArgs := append([]string{"exec", "-i", "-w", dir, container}, parts...)
+	cmd := exec.Command("podman", cmdArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 // promptContinue asks the user whether to continue after a step failure.

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -196,9 +196,12 @@ func runStatus(_ *cobra.Command, _ []string) error {
 					fwName, _ = config.DetectFramework(s.Path)
 				}
 				if fw, ok := config.GetFramework(fwName); ok && fw.Workers != nil {
-					for wName := range fw.Workers {
+					for wName, wDef := range fw.Workers {
 						switch wName {
 						case "queue", "schedule", "reverb":
+							continue
+						}
+						if wDef.Check != nil && !config.MatchesRule(s.Path, *wDef.Check) {
 							continue
 						}
 						unit := "lerd-" + wName + "-" + s.Name

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -91,7 +91,10 @@ func newWorkerListCmd() *cobra.Command {
 				return nil
 			}
 			names := make([]string, 0, len(fw.Workers))
-			for n := range fw.Workers {
+			for n, wDef := range fw.Workers {
+				if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
+					continue
+				}
 				names = append(names, n)
 			}
 			sort.Strings(names)

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -19,6 +19,7 @@ type Framework struct {
 	Composer  string                     `yaml:"composer,omitempty"` // auto | true | false
 	NPM       string                     `yaml:"npm,omitempty"`      // auto | true | false
 	Workers   map[string]FrameworkWorker `yaml:"workers,omitempty"`
+	Setup     []FrameworkSetupCmd        `yaml:"setup,omitempty"`
 	// Console is the console command to run (without 'php' prefix).
 	// Example: "artisan", "bin/console"
 	Console string `yaml:"console,omitempty"`
@@ -30,9 +31,18 @@ type Framework struct {
 // FrameworkWorker describes a long-running process managed as a systemd service.
 // The Command is executed inside the PHP-FPM container for the site.
 type FrameworkWorker struct {
-	Label   string `yaml:"label,omitempty"`
-	Command string `yaml:"command"`
-	Restart string `yaml:"restart,omitempty"` // always | on-failure (default: always)
+	Label   string         `yaml:"label,omitempty"`
+	Command string         `yaml:"command"`
+	Restart string         `yaml:"restart,omitempty"` // always | on-failure (default: always)
+	Check   *FrameworkRule `yaml:"check,omitempty"`   // only show when check passes (file exists or composer package installed)
+}
+
+// FrameworkSetupCmd describes a one-off bootstrap command run during project setup.
+type FrameworkSetupCmd struct {
+	Label   string         `yaml:"label"`
+	Command string         `yaml:"command"`
+	Default bool           `yaml:"default,omitempty"`
+	Check   *FrameworkRule `yaml:"check,omitempty"` // only show when check passes (file exists or composer package installed)
 }
 
 // FrameworkRule is a single detection rule for a framework.
@@ -144,6 +154,11 @@ var laravelFramework = &Framework{
 			Restart: "on-failure",
 		},
 	},
+	Setup: []FrameworkSetupCmd{
+		{Label: "php artisan storage:link", Command: "php artisan storage:link", Default: true},
+		{Label: "php artisan migrate", Command: "php artisan migrate", Default: true},
+		{Label: "php artisan db:seed", Command: "php artisan db:seed", Default: false},
+	},
 }
 
 // GetFramework returns the framework definition for the given name.
@@ -163,13 +178,16 @@ func GetFramework(name string) (*Framework, bool) {
 		for k, v := range laravelFramework.Workers {
 			mergedWorkers[k] = v
 		}
-		// Merge user-defined workers (user additions/overrides win)
+		// Merge user-defined workers and setup commands (user additions/overrides win)
 		path := filepath.Join(FrameworksDir(), "laravel.yaml")
 		if data, err := os.ReadFile(path); err == nil {
 			var userFw Framework
 			if yaml.Unmarshal(data, &userFw) == nil {
 				for k, v := range userFw.Workers {
 					mergedWorkers[k] = v
+				}
+				if userFw.Setup != nil {
+					merged.Setup = userFw.Setup
 				}
 			}
 		}
@@ -266,8 +284,8 @@ func SaveFramework(fw *Framework) error {
 	}
 	toSave := fw
 	if fw.Name == "laravel" {
-		// Only persist workers — built-in handles everything else
-		toSave = &Framework{Name: fw.Name, Workers: fw.Workers}
+		// Only persist workers and setup — built-in handles everything else
+		toSave = &Framework{Name: fw.Name, Workers: fw.Workers, Setup: fw.Setup}
 	}
 	data, err := yaml.Marshal(toSave)
 	if err != nil {
@@ -316,6 +334,21 @@ func GetConsoleCommand(projectDir string) (string, error) {
 // removes the user workers overlay (the built-in definition remains).
 func RemoveFramework(name string) error {
 	return os.Remove(filepath.Join(FrameworksDir(), name+".yaml"))
+}
+
+// MatchesRule returns true if the given rule matches the project directory.
+func MatchesRule(dir string, rule FrameworkRule) bool {
+	if rule.File != "" {
+		if _, err := os.Stat(filepath.Join(dir, rule.File)); err == nil {
+			return true
+		}
+	}
+	if rule.Composer != "" {
+		if composerHasPackage(dir, rule.Composer) {
+			return true
+		}
+	}
+	return false
 }
 
 func matchesFramework(dir string, fw *Framework) bool {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1036,12 +1036,12 @@ func toolList() []mcpTool {
 		},
 		mcpTool{
 			Name:        "framework_list",
-			Description: "List all available framework definitions (laravel built-in plus any user-defined YAMLs), including their defined workers. Use this before framework_add to see what is already defined.",
+			Description: "List all available framework definitions (laravel built-in plus any user-defined YAMLs), including their defined workers and setup commands. Use this before framework_add to see what is already defined.",
 			InputSchema: mcpSchema{Type: "object", Properties: map[string]mcpProp{}},
 		},
 		mcpTool{
 			Name:        "framework_add",
-			Description: "Create or update a framework definition. For laravel, only the workers field is used (built-in settings are always preserved). For other frameworks, creates a full definition at ~/.config/lerd/frameworks/<name>.yaml.",
+			Description: "Create or update a framework definition. For laravel, only the workers and setup fields are used (built-in settings are always preserved). For other frameworks, creates a full definition at ~/.config/lerd/frameworks/<name>.yaml.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
@@ -1083,7 +1083,11 @@ func toolList() []mcpTool {
 					},
 					"workers": {
 						Type:        "object",
-						Description: `Map of worker name → {label, command, restart} definitions, e.g. {"horizon": {"label": "Horizon", "command": "php artisan horizon", "restart": "always"}}`,
+						Description: `Map of worker name → {label, command, restart, check} definitions. "check" is optional — an object with "file" or "composer" field; the worker is only shown when the check passes. e.g. {"messenger": {"label": "Messenger", "command": "php bin/console messenger:consume async", "restart": "always", "check": {"composer": "symfony/messenger"}}}`,
+					},
+					"setup": {
+						Type:        "array",
+						Description: `List of one-off setup commands shown in "lerd setup" wizard. Each element is an object with "label" (string), "command" (string), optional "default" (boolean, pre-selected in wizard), and optional "check" (object with "file" or "composer" field — command is only shown when the check passes). e.g. [{"label": "Load fixtures", "command": "php bin/console doctrine:fixtures:load", "check": {"composer": "doctrine/doctrine-fixtures-bundle"}}]`,
 					},
 				},
 				Required: []string{"name"},
@@ -2980,10 +2984,21 @@ func siteLinkNameAndDomain(dirName, tld string) (string, string) {
 
 func execFrameworkList() (any, *rpcError) {
 	frameworks := config.ListFrameworks()
+	type checkInfo struct {
+		File     string `json:"file,omitempty"`
+		Composer string `json:"composer,omitempty"`
+	}
 	type workerInfo struct {
-		Label   string `json:"label,omitempty"`
-		Command string `json:"command"`
-		Restart string `json:"restart,omitempty"`
+		Label   string     `json:"label,omitempty"`
+		Command string     `json:"command"`
+		Restart string     `json:"restart,omitempty"`
+		Check   *checkInfo `json:"check,omitempty"`
+	}
+	type setupInfo struct {
+		Label   string     `json:"label"`
+		Command string     `json:"command"`
+		Default bool       `json:"default,omitempty"`
+		Check   *checkInfo `json:"check,omitempty"`
 	}
 	type frameworkInfo struct {
 		Name      string                `json:"name"`
@@ -2993,6 +3008,7 @@ func execFrameworkList() (any, *rpcError) {
 		EnvFormat string                `json:"env_format"`
 		BuiltIn   bool                  `json:"built_in"`
 		Workers   map[string]workerInfo `json:"workers,omitempty"`
+		Setup     []setupInfo           `json:"setup,omitempty"`
 	}
 	var result []frameworkInfo
 	for _, fw := range frameworks {
@@ -3015,8 +3031,20 @@ func execFrameworkList() (any, *rpcError) {
 		if len(merged.Workers) > 0 {
 			workers = make(map[string]workerInfo, len(merged.Workers))
 			for n, w := range merged.Workers {
-				workers[n] = workerInfo{Label: w.Label, Command: w.Command, Restart: w.Restart}
+				wi := workerInfo{Label: w.Label, Command: w.Command, Restart: w.Restart}
+				if w.Check != nil {
+					wi.Check = &checkInfo{File: w.Check.File, Composer: w.Check.Composer}
+				}
+				workers[n] = wi
 			}
+		}
+		var setup []setupInfo
+		for _, sc := range merged.Setup {
+			si := setupInfo{Label: sc.Label, Command: sc.Command, Default: sc.Default}
+			if sc.Check != nil {
+				si.Check = &checkInfo{File: sc.Check.File, Composer: sc.Check.Composer}
+			}
+			setup = append(setup, si)
 		}
 		result = append(result, frameworkInfo{
 			Name:      merged.Name,
@@ -3026,6 +3054,7 @@ func execFrameworkList() (any, *rpcError) {
 			EnvFormat: efmt,
 			BuiltIn:   merged.Name == "laravel",
 			Workers:   workers,
+			Setup:     setup,
 		})
 	}
 	if result == nil {
@@ -3051,26 +3080,72 @@ func execFrameworkAdd(args map[string]any) (any, *rpcError) {
 					label, _ := wobj["label"].(string)
 					command, _ := wobj["command"].(string)
 					restart, _ := wobj["restart"].(string)
-					workers[wname] = config.FrameworkWorker{Label: label, Command: command, Restart: restart}
+					w := config.FrameworkWorker{Label: label, Command: command, Restart: restart}
+					if chk, ok := wobj["check"].(map[string]any); ok {
+						rule := &config.FrameworkRule{}
+						rule.File, _ = chk["file"].(string)
+						rule.Composer, _ = chk["composer"].(string)
+						if rule.File != "" || rule.Composer != "" {
+							w.Check = rule
+						}
+					}
+					workers[wname] = w
+				}
+			}
+		}
+	}
+
+	// Parse setup commands if provided
+	var setup []config.FrameworkSetupCmd
+	if raw, ok := args["setup"]; ok {
+		if arr, ok := raw.([]any); ok {
+			for _, item := range arr {
+				if obj, ok := item.(map[string]any); ok {
+					label, _ := obj["label"].(string)
+					command, _ := obj["command"].(string)
+					dflt, _ := obj["default"].(bool)
+					if label != "" && command != "" {
+						sc := config.FrameworkSetupCmd{Label: label, Command: command, Default: dflt}
+						if chk, ok := obj["check"].(map[string]any); ok {
+							rule := &config.FrameworkRule{}
+							rule.File, _ = chk["file"].(string)
+							rule.Composer, _ = chk["composer"].(string)
+							if rule.File != "" || rule.Composer != "" {
+								sc.Check = rule
+							}
+						}
+						setup = append(setup, sc)
+					}
 				}
 			}
 		}
 	}
 
 	if name == "laravel" {
-		// For Laravel, only persist custom workers (built-in handles everything else)
-		if len(workers) == 0 {
-			return toolErr("workers is required when adding custom workers to laravel"), nil
+		// For Laravel, only persist custom workers and setup (built-in handles everything else)
+		if len(workers) == 0 && len(setup) == 0 {
+			return toolErr("workers or setup is required when customising laravel"), nil
 		}
-		fw := &config.Framework{Name: "laravel", Workers: workers}
+		fw := &config.Framework{Name: "laravel", Workers: workers, Setup: setup}
 		if err := config.SaveFramework(fw); err != nil {
 			return toolErr(fmt.Sprintf("saving framework: %v", err)), nil
 		}
-		names := make([]string, 0, len(workers))
-		for n := range workers {
-			names = append(names, n)
+		var parts []string
+		if len(workers) > 0 {
+			names := make([]string, 0, len(workers))
+			for n := range workers {
+				names = append(names, n)
+			}
+			parts = append(parts, "Workers: "+strings.Join(names, ", "))
 		}
-		return toolOK(fmt.Sprintf("Custom workers added to Laravel: %s\nThese are merged with the built-in queue/schedule/reverb workers.", strings.Join(names, ", "))), nil
+		if len(setup) > 0 {
+			names := make([]string, 0, len(setup))
+			for _, s := range setup {
+				names = append(names, s.Label)
+			}
+			parts = append(parts, "Setup commands: "+strings.Join(names, ", "))
+		}
+		return toolOK(fmt.Sprintf("Laravel customisations saved: %s\nWorkers are merged with built-in queue/schedule/reverb. Setup commands replace built-in storage:link/migrate/db:seed.", strings.Join(parts, ". "))), nil
 	}
 
 	label := strArg(args, "label")
@@ -3085,6 +3160,7 @@ func execFrameworkAdd(args map[string]any) (any, *rpcError) {
 		Composer:  "auto",
 		NPM:       "auto",
 		Workers:   workers,
+		Setup:     setup,
 	}
 	if fw.PublicDir == "" {
 		fw.PublicDir = "public"

--- a/internal/podman/exec.go
+++ b/internal/podman/exec.go
@@ -58,6 +58,38 @@ func ServiceImage(quadletName string) string {
 	return ""
 }
 
+// ServiceVersion extracts the major version from a built-in service's image tag.
+// For example: mysql:8.0 → "8.0", postgis/postgis:16-3.5-alpine → "16",
+// redis:7-alpine → "7", meilisearch:v1.7 → "1.7".
+// Returns "" if the version cannot be determined.
+func ServiceVersion(quadletName string) string {
+	image := ServiceImage(quadletName)
+	if image == "" {
+		return ""
+	}
+	// Extract tag after the last colon.
+	idx := strings.LastIndex(image, ":")
+	if idx < 0 {
+		return ""
+	}
+	tag := image[idx+1:]
+	// Strip leading "v" prefix.
+	tag = strings.TrimPrefix(tag, "v")
+	// Take only the version part (before any dash-separated suffix like "-alpine").
+	if dash := strings.Index(tag, "-"); dash > 0 {
+		// Keep if it looks like a version (e.g. "8.0"), drop suffix like "-alpine".
+		candidate := tag[:dash]
+		if len(candidate) > 0 && candidate[0] >= '0' && candidate[0] <= '9' {
+			return candidate
+		}
+	}
+	// Return as-is if it starts with a digit.
+	if len(tag) > 0 && tag[0] >= '0' && tag[0] <= '9' {
+		return tag
+	}
+	return ""
+}
+
 // ContainerRunning returns true if the named container is running.
 func ContainerRunning(name string) (bool, error) {
 	out, err := Run("inspect", "--format={{.State.Running}}", name)

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -454,9 +454,12 @@ func handleSites(w http.ResponseWriter, _ *http.Request) {
 		var fwWorkers []WorkerStatus
 		if hasFw && fw.Workers != nil {
 			names := make([]string, 0, len(fw.Workers))
-			for n := range fw.Workers {
+			for n, wDef := range fw.Workers {
 				switch n {
 				case "queue", "schedule", "reverb":
+					continue
+				}
+				if wDef.Check != nil && !config.MatchesRule(s.Path, *wDef.Check) {
 					continue
 				}
 				names = append(names, n)


### PR DESCRIPTION
## Summary

- Added `setup` field to framework definitions for one-off bootstrap commands (migrations, storage:link, fixtures) shown in `lerd setup`, replacing hardcoded Laravel steps with a generic framework-driven approach
- Added `check` field (file or composer package) on both workers and setup commands to conditionally show them based on project dependencies (e.g. messenger worker only shown when `symfony/messenger` is installed)
- Added service version placeholders (`{{mysql_version}}`, `{{postgres_version}}`, `{{redis_version}}`, `{{meilisearch_version}}`) resolved from the service image tag at `lerd env` time
- `lerd env` now runs automatically at the start of `lerd setup` instead of being a selectable step, ensuring `.env` is configured before composer post-install scripts run
- Replaced the binary yes/no definition conflict prompt with a three-way selector: use .lerd.yaml version, use local definition, or skip — both directions persist immediately
- Added `--setup` flag to `lerd framework add` CLI command
- Updated MCP tool definitions, Claude skill, and Junie guidelines
- Updated docs: YAML schema, Symfony example, commands reference, services placeholder table