### PR TITLE
fix: support omarchy and other systemd-resolved-only systems

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -1,8 +1,8 @@
 # Requirements
 
-- **Linux** — Arch, Debian/Ubuntu, or Fedora-based
+- **Linux** — Arch, Debian/Ubuntu, Fedora-based, or omarchy
 - **[Podman](https://podman.io/)** — rootless, with systemd user session active
-- **[NetworkManager](https://networkmanager.dev/)** — for `.test` DNS
+- **DNS resolver** — [NetworkManager](https://networkmanager.dev/) or [systemd-resolved](https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html) (at least one is required for `.test` DNS)
 - **`systemctl --user` functional** — run `loginctl enable-linger $USER` if needed
 
 ::: warning Linger must be enabled

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -8,7 +8,8 @@ All containers join the rootless Podman network `lerd`. Communication between Ng
                           *.test DNS
                               │
                    ┌──────────┴──────────┐
-                   │    NetworkManager    │
+                   │   DNS resolver      │
+                   │ (NM or resolved)    │
                    └──────────┬──────────┘
                               │ forwards .test queries
                    ┌──────────┴──────────┐
@@ -43,12 +44,12 @@ All containers join the rootless Podman network `lerd`. Communication between Ng
 | Composer | `composer.phar` via bundled PHP CLI |
 | Node | [fnm](https://github.com/Schniz/fnm) binary, version per project |
 | Services | Podman Quadlet containers |
-| DNS | dnsmasq container + NetworkManager integration |
+| DNS | dnsmasq container + NetworkManager or systemd-resolved integration |
 | TLS | [mkcert](https://github.com/FiloSottile/mkcert) — locally trusted CA |
 
 ## Key design decisions
 
-**Rootless Podman** — all containers run without root privileges. The only operations requiring `sudo` are DNS setup (writes to `/etc/NetworkManager/`) and the initial `net.ipv4.ip_unprivileged_port_start=80` sysctl.
+**Rootless Podman** — all containers run without root privileges. The only operations requiring `sudo` are DNS setup (configures NetworkManager or systemd-resolved to route `.test` queries) and the initial `net.ipv4.ip_unprivileged_port_start=80` sysctl.
 
 **Podman Quadlets** — containers are defined as systemd unit files (`.container` files) managed by the Quadlet generator. This means `systemctl --user start lerd-nginx` works like any other systemd service, and containers restart on failure and at login.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,14 +18,19 @@ Run the DNS check first:
 lerd dns:check
 ```
 
-If it fails, restart NetworkManager and check again:
+If it fails, restart your DNS resolver and check again:
 
 ```bash
+# NetworkManager systems:
 sudo systemctl restart NetworkManager
+
+# systemd-resolved only (e.g. omarchy):
+sudo systemctl restart systemd-resolved
+
 lerd dns:check
 ```
 
-On systems using systemd-resolved (Ubuntu), check that the per-interface DNS configuration was applied:
+On systems using systemd-resolved, check that the DNS configuration was applied:
 
 ```bash
 resolvectl status

--- a/install.sh
+++ b/install.sh
@@ -86,11 +86,13 @@ check_systemd_user() {
   fi
 }
 
-check_nm() {
+check_dns_resolver() {
   if systemctl is-active --quiet NetworkManager 2>/dev/null; then
     success "NetworkManager running"
+  elif systemctl is-active --quiet systemd-resolved 2>/dev/null; then
+    success "systemd-resolved running"
   else
-    warn "NetworkManager not running — required for .test DNS"
+    warn "No supported DNS resolver running (need NetworkManager or systemd-resolved)"
     MISSING_PKGS+=("networkmanager")
   fi
 }
@@ -129,7 +131,7 @@ check_prerequisites() {
 
   check_cmd podman podman "container runtime"
   check_cmd unzip unzip "needed to extract fnm"
-  check_nm
+  check_dns_resolver
   check_systemd_user
   check_podman_rootless
   check_certutil

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -152,7 +152,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 			ok(fmt.Sprintf(".%s resolves to 127.0.0.1", tld))
 		} else {
 			fail(fmt.Sprintf(".%s resolution", tld), "not resolving to 127.0.0.1",
-				"run 'lerd install' or: sudo systemctl restart NetworkManager")
+				"run 'lerd install' or: "+dns.ResolverHint())
 		}
 	}
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -59,7 +59,7 @@ func runStatus(_ *cobra.Command, _ []string) error {
 	} else {
 		fail2(fmt.Sprintf(".%s resolution", cfg.DNS.TLD),
 			"not resolving",
-			"run 'lerd install' to reconfigure, or: sudo systemctl restart NetworkManager")
+			"run 'lerd install' to reconfigure, or: "+dns.ResolverHint())
 	}
 
 	// Nginx

--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -90,7 +90,7 @@ func isFileContent(path string, content []byte) bool {
 }
 
 // isSystemdResolvedActive returns true if systemd-resolved is the active DNS resolver.
-func isSystemdResolvedActive() bool {
+var isSystemdResolvedActive = func() bool {
 	cmd := exec.Command("systemctl", "is-active", "--quiet", "systemd-resolved")
 	if err := cmd.Run(); err != nil {
 		return false
@@ -104,9 +104,20 @@ func isSystemdResolvedActive() bool {
 }
 
 // isNetworkManagerActive returns true if NetworkManager is running.
-func isNetworkManagerActive() bool {
+var isNetworkManagerActive = func() bool {
 	cmd := exec.Command("systemctl", "is-active", "--quiet", "NetworkManager")
 	return cmd.Run() == nil
+}
+
+// ResolverHint returns a user-facing hint for restarting the active DNS resolver.
+func ResolverHint() string {
+	if isNetworkManagerActive() {
+		return "sudo systemctl restart NetworkManager"
+	}
+	if isSystemdResolvedActive() {
+		return "sudo systemctl restart systemd-resolved"
+	}
+	return "restart your DNS resolver"
 }
 
 // defaultInterface returns the name of the default network interface (e.g. "enp1s0").

--- a/internal/dns/setup_test.go
+++ b/internal/dns/setup_test.go
@@ -184,6 +184,50 @@ func TestWriteDnsmasqConfig_noUpstreams(t *testing.T) {
 	}
 }
 
+// --- ResolverHint ---
+
+func TestResolverHint_NetworkManager(t *testing.T) {
+	origNM := isNetworkManagerActive
+	origResolved := isSystemdResolvedActive
+	defer func() { isNetworkManagerActive = origNM; isSystemdResolvedActive = origResolved }()
+
+	isNetworkManagerActive = func() bool { return true }
+	isSystemdResolvedActive = func() bool { return true }
+
+	got := ResolverHint()
+	if got != "sudo systemctl restart NetworkManager" {
+		t.Errorf("expected NM hint, got %q", got)
+	}
+}
+
+func TestResolverHint_SystemdResolvedOnly(t *testing.T) {
+	origNM := isNetworkManagerActive
+	origResolved := isSystemdResolvedActive
+	defer func() { isNetworkManagerActive = origNM; isSystemdResolvedActive = origResolved }()
+
+	isNetworkManagerActive = func() bool { return false }
+	isSystemdResolvedActive = func() bool { return true }
+
+	got := ResolverHint()
+	if got != "sudo systemctl restart systemd-resolved" {
+		t.Errorf("expected systemd-resolved hint, got %q", got)
+	}
+}
+
+func TestResolverHint_NoResolver(t *testing.T) {
+	origNM := isNetworkManagerActive
+	origResolved := isSystemdResolvedActive
+	defer func() { isNetworkManagerActive = origNM; isSystemdResolvedActive = origResolved }()
+
+	isNetworkManagerActive = func() bool { return false }
+	isSystemdResolvedActive = func() bool { return false }
+
+	got := ResolverHint()
+	if got != "restart your DNS resolver" {
+		t.Errorf("expected generic hint, got %q", got)
+	}
+}
+
 // --- helpers ---
 
 func writeTempFile(t *testing.T, content string) string {


### PR DESCRIPTION
## Summary

- Installer (`install.sh`) no longer requires NetworkManager — accepts systemd-resolved as an alternative DNS resolver, fixing installation on omarchy OS
- Added `dns.ResolverHint()` that detects the active resolver and returns the correct restart command
- `lerd doctor` and `lerd status` now show resolver-appropriate hints instead of always suggesting "restart NetworkManager"
- Added tests for all three ResolverHint paths (NM, systemd-resolved, neither)
- Updated docs: requirements page lists both resolvers, architecture diagram and troubleshooting reflect both backends