### PR TITLE
release: v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.6.1] — 2026-04-06
+
+### Fixed
+
+- **Fresh install missing default PHP-FPM** — `lerd install` now always builds and starts the default PHP version, even with no registered sites. Previously `lerd new` would fail on a fresh install because no PHP-FPM container existed.
+- **Install not restoring services** — `lerd install` now restores service quadlets (mysql, redis, custom services) from `.lerd.yaml`, pulls missing images, and starts them. Workers no longer fail on reinstall because their dependencies are running.
+- **Install not restoring workers** — `lerd install` now calls `restoreSiteInfrastructure` to recreate worker units from `.lerd.yaml` after services are started.
+- **FPM not restored for sites using default PHP** — both `lerd install` and `lerd start` now fall back to the configured default PHP version when a site has no explicit `PHPVersion`, instead of skipping it.
+- **UI stripe toggle not syncing `.lerd.yaml`** — toggling the Stripe listener from the web UI now writes the workers list to `.lerd.yaml`, matching the behaviour of all other worker toggles.
+- **Uninstall spinner with no expandable output** — replaced the StepRunner spinner (Ctrl+O did nothing) with the same `step()`/`ok()` output style used by install.
+
+---
+
 ## [1.6.0] — 2026-04-06
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,19 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.6.1] — 2026-04-06
+
+### Fixed
+
+- **Fresh install missing default PHP-FPM** — `lerd install` now always builds and starts the default PHP version, even with no registered sites. Previously `lerd new` would fail on a fresh install because no PHP-FPM container existed.
+- **Install not restoring services** — `lerd install` now restores service quadlets (mysql, redis, custom services) from `.lerd.yaml`, pulls missing images, and starts them. Workers no longer fail on reinstall because their dependencies are running.
+- **Install not restoring workers** — `lerd install` now calls `restoreSiteInfrastructure` to recreate worker units from `.lerd.yaml` after services are started.
+- **FPM not restored for sites using default PHP** — both `lerd install` and `lerd start` now fall back to the configured default PHP version when a site has no explicit `PHPVersion`, instead of skipping it.
+- **UI stripe toggle not syncing `.lerd.yaml`** — toggling the Stripe listener from the web UI now writes the workers list to `.lerd.yaml`, matching the behaviour of all other worker toggles.
+- **Uninstall spinner with no expandable output** — replaced the StepRunner spinner (Ctrl+O did nothing) with the same `step()`/`ok()` output style used by install.
+
+---
+
 ## [1.6.0] — 2026-04-06
 
 ### Added

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -164,20 +164,56 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	}
 	ok()
 
-	// Restore PHP-FPM quadlets for all PHP versions used by registered sites.
-	if reg, err := config.LoadSites(); err == nil {
-		seen := map[string]bool{}
-		for _, s := range reg.Sites {
-			v := s.PHPVersion
-			if v == "" {
-				continue
+	// Always ensure the default PHP-FPM is available (needed for lerd new on fresh installs).
+	// Then restore quadlets for any additional PHP versions and services from registered sites.
+	{
+		cfg, _ := config.LoadGlobal()
+		seenPHP := map[string]bool{}
+		seenSvc := map[string]bool{}
+
+		if cfg != nil && cfg.PHP.DefaultVersion != "" {
+			seenPHP[cfg.PHP.DefaultVersion] = true
+			if err := ensureFPMQuadlet(cfg.PHP.DefaultVersion); err != nil {
+				fmt.Printf("  WARN: default PHP %s FPM quadlet: %v\n", cfg.PHP.DefaultVersion, err)
 			}
-			if seen[v] {
-				continue
-			}
-			seen[v] = true
-			if err := ensureFPMQuadlet(v); err != nil {
-				fmt.Printf("  WARN: PHP %s FPM quadlet: %v\n", v, err)
+		}
+
+		reg, regErr := config.LoadSites()
+		if regErr == nil {
+
+			for _, s := range reg.Sites {
+				if s.Paused || s.Ignored {
+					continue
+				}
+
+				// Restore FPM quadlet.
+				v := s.PHPVersion
+				if v == "" && cfg != nil {
+					v = cfg.PHP.DefaultVersion
+				}
+				if v != "" && !seenPHP[v] {
+					seenPHP[v] = true
+					if err := ensureFPMQuadlet(v); err != nil {
+						fmt.Printf("  WARN: PHP %s FPM quadlet: %v\n", v, err)
+					}
+				}
+
+				// Restore service quadlets from .lerd.yaml.
+				proj, _ := config.LoadProjectConfig(s.Path)
+				if proj == nil {
+					continue
+				}
+				for _, svc := range proj.Services {
+					if seenSvc[svc.Name] {
+						continue
+					}
+					seenSvc[svc.Name] = true
+					if svc.Custom != nil {
+						ensureCustomServiceQuadlet(svc.Custom) //nolint:errcheck
+					} else {
+						ensureServiceQuadlet(svc.Name) //nolint:errcheck
+					}
+				}
 			}
 		}
 	}
@@ -278,6 +314,12 @@ func runInstall(_ *cobra.Command, _ []string) error {
 		fmt.Printf("    WARN: %v\n", err)
 	}
 	ok()
+
+	// Start restored services (mysql, redis, etc.) and workers.
+	// Service quadlets were written earlier; now pull images and start them.
+	// Then restore worker units from .lerd.yaml so everything comes back up.
+	startRestoredServices()
+	restoreSiteInfrastructure()
 
 	// Restart tray if running.
 	if lerdSystemd.IsServiceEnabled("lerd-tray") {

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -425,6 +425,55 @@ func runStart(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
+// startRestoredServices pulls images and starts service units that have a quadlet
+// installed but are not yet running. Called from lerd install to bring back services
+// (mysql, redis, etc.) that were restored from .lerd.yaml.
+func startRestoredServices() {
+	units := installedServiceUnits()
+	if len(units) == 0 {
+		return
+	}
+
+	// Pull missing images first.
+	var pullJobs []BuildJob
+	seen := map[string]bool{}
+	for _, unit := range units {
+		image := quadletImage(unit)
+		if image == "" || seen[image] {
+			continue
+		}
+		seen[image] = true
+		if podman.RunSilent("image", "exists", image) == nil {
+			continue
+		}
+		img := image
+		pullJobs = append(pullJobs, BuildJob{
+			Label: "Pulling " + img,
+			Run: func(w io.Writer) error {
+				cmd := exec.Command("podman", "pull", img)
+				cmd.Stdout = w
+				cmd.Stderr = w
+				return cmd.Run()
+			},
+		})
+	}
+	if len(pullJobs) > 0 {
+		RunParallel(pullJobs) //nolint:errcheck
+	}
+
+	// Start the services.
+	var startJobs []BuildJob
+	for _, u := range units {
+		unit := u
+		label := strings.TrimPrefix(unit, "lerd-")
+		startJobs = append(startJobs, BuildJob{
+			Label: label,
+			Run:   func(_ io.Writer) error { return podman.StartUnit(unit) },
+		})
+	}
+	RunParallel(startJobs) //nolint:errcheck
+}
+
 // killTray kills any running lerd tray process (launched directly or as lerd-tray binary).
 func killTray() {
 	exec.Command("pkill", "-f", "lerd tray").Run()
@@ -452,9 +501,14 @@ func restoreSiteInfrastructure() {
 		}
 
 		// Restore FPM quadlet for this site's PHP version.
-		if s.PHPVersion != "" && !seenPHP[s.PHPVersion] {
-			seenPHP[s.PHPVersion] = true
-			ensureFPMQuadlet(s.PHPVersion) //nolint:errcheck
+		phpVer := s.PHPVersion
+		if phpVer == "" {
+			cfg, _ := config.LoadGlobal()
+			phpVer = cfg.PHP.DefaultVersion
+		}
+		if phpVer != "" && !seenPHP[phpVer] {
+			seenPHP[phpVer] = true
+			ensureFPMQuadlet(phpVer) //nolint:errcheck
 		}
 
 		// Read .lerd.yaml for service and worker info.

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"bufio"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -48,11 +47,10 @@ func runUninstall(force bool) error {
 	fmt.Println("  --> Removing DNS configuration")
 	dns.Teardown()
 
-	r := NewStepRunner()
-
 	quadletDir := config.QuadletDir()
 
-	r.Run("Stopping containers and services", func(_ io.Writer) error { //nolint:errcheck
+	step("Stopping containers and services")
+	{
 		var units []string
 		// Quadlet containers (nginx, dns, mysql, redis, etc.)
 		if entries, err := filepath.Glob(filepath.Join(quadletDir, "lerd-*.container")); err == nil {
@@ -73,46 +71,39 @@ func runUninstall(force bool) error {
 			}
 			_ = disableUnit(unit)
 		}
-		return nil
-	})
+	}
+	ok()
 
-	r.Run("Removing quadlet units and services", func(_ io.Writer) error { //nolint:errcheck
-		if entries, err := filepath.Glob(filepath.Join(quadletDir, "lerd-*.container")); err == nil {
-			for _, f := range entries {
-				os.Remove(f) //nolint:errcheck
-			}
+	step("Removing quadlet units and services")
+	if entries, err := filepath.Glob(filepath.Join(quadletDir, "lerd-*.container")); err == nil {
+		for _, f := range entries {
+			os.Remove(f) //nolint:errcheck
 		}
-		if entries, err := filepath.Glob(filepath.Join(config.SystemdUserDir(), "lerd-*.service")); err == nil {
-			for _, f := range entries {
-				os.Remove(f) //nolint:errcheck
-			}
+	}
+	if entries, err := filepath.Glob(filepath.Join(config.SystemdUserDir(), "lerd-*.service")); err == nil {
+		for _, f := range entries {
+			os.Remove(f) //nolint:errcheck
 		}
-		return nil
-	})
+	}
+	ok()
 
-	r.Run("Reloading systemd daemon", func(_ io.Writer) error { //nolint:errcheck
-		_ = podman.DaemonReload()
-		return nil
-	})
+	step("Reloading systemd daemon")
+	_ = podman.DaemonReload()
+	ok()
 
-	r.Run("Removing lerd Podman network", func(_ io.Writer) error { //nolint:errcheck
-		_ = podman.RunSilent("network", "rm", "lerd")
-		return nil
-	})
+	step("Removing lerd Podman network")
+	_ = podman.RunSilent("network", "rm", "lerd")
+	ok()
 
-	r.Run("Removing shell PATH entry", func(_ io.Writer) error { //nolint:errcheck
-		removeShellEntry()
-		return nil
-	})
+	step("Removing shell PATH entry")
+	removeShellEntry()
+	ok()
 
-	r.Run("Removing lerd binary", func(_ io.Writer) error { //nolint:errcheck
-		if self, err := selfPath(); err == nil {
-			os.Remove(self) //nolint:errcheck
-		}
-		return nil
-	})
-
-	r.Close()
+	step("Removing lerd binary")
+	if self, err := selfPath(); err == nil {
+		os.Remove(self) //nolint:errcheck
+	}
+	ok()
 
 	fmt.Println()
 	if removeData {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1328,6 +1328,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			scheme = "https"
 		}
 		go cli.StripeStartForSite(site.Name, site.Path, scheme+"://"+site.PrimaryDomain()) //nolint:errcheck
+		go syncLerdYAMLWorkersDelayed(site)
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
 	case "stripe:stop":
@@ -1335,6 +1336,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, SiteActionResponse{Error: err.Error()})
 			return
 		}
+		syncLerdYAMLWorkers(site)
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
 	case "schedule:start":

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.6.0"
+	Version = "1.6.1"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

- install now always sets up default PHP-FPM, restores services and workers from .lerd.yaml, and pulls missing service images on reinstall
- lerd start restores site infrastructure (FPM, services, workers) after uninstall/reinstall with default PHP fallback
- all worker start/stop commands (CLI + UI) sync .lerd.yaml, including stripe and custom workers, skipping paused sites
- uninstall stops all lerd-* units, reverts DNS on all configured interfaces, pushes DHCP DNS after NM restart, uses step/ok output instead of spinner