### PR TITLE
release: v1.6.2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,8 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - **MissingAppKeyException on fresh project** — `lerd env` now generates `APP_KEY` directly in `.env` when `vendor/` does not exist yet, instead of failing silently on `artisan key:generate`. This prevents Laravel's `MissingAppKeyException` during `composer install` post-install scripts in the `lerd new` → `lerd link` → `lerd setup` flow.
+- **`composer install` using wrong PHP version in setup** — `lerd setup` now runs `composer install` inside the project's PHP-FPM container, matching the `composer.json` PHP constraint. Previously it used the host composer shim which could resolve to the global default PHP version.
+- **PHP version detection from `composer.json` ignores installed versions** — the constraint resolver now picks the highest installed PHP version satisfying the `composer.json` `require.php` constraint (e.g. `^8.3` with 8.3 and 8.4 installed → 8.4). Supports `^`, `~`, `>=`, `<`, `||`, `*`, and AND constraints. Falls back to the literal minimum when no installed version matches.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,14 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.6.2] — 2026-04-06
+
+### Fixed
+
+- **MissingAppKeyException on fresh project** — `lerd env` now generates `APP_KEY` directly in `.env` when `vendor/` does not exist yet, instead of failing silently on `artisan key:generate`. This prevents Laravel's `MissingAppKeyException` during `composer install` post-install scripts in the `lerd new` → `lerd link` → `lerd setup` flow.
+
+---
+
 ## [1.6.1] — 2026-04-06
 
 ### Fixed

--- a/docs/features/env-setup.md
+++ b/docs/features/env-setup.md
@@ -17,7 +17,7 @@ lerd env
 4. **Creates the project database** (and a `<name>_testing` database) inside the running service container; reports if they already exist
 5. **Starts any referenced service** that is not already running
 6. **Sets the app URL** (`APP_URL` for Laravel; the `url_key` defined in the framework for others) to the project's registered `.test` domain
-7. **Generates `APP_KEY`** via `php artisan key:generate` if the key is missing or empty (Laravel only)
+7. **Generates `APP_KEY`** if the key is missing or empty (Laravel only). Uses `php artisan key:generate` when `vendor/` is installed; on a fresh project before `composer install`, writes a random base64 key directly so post-install scripts can boot without a `MissingAppKeyException`
 8. **Generates `REVERB_*` values** — if `BROADCAST_CONNECTION=reverb` is detected, generates `REVERB_APP_ID`, `REVERB_APP_KEY`, `REVERB_APP_SECRET` using random secure values for secrets. Also assigns a unique `REVERB_SERVER_PORT` so multiple Reverb-enabled sites can run simultaneously without port collisions (starts at `8080`, increments per site). `REVERB_HOST`, `REVERB_PORT`, and `REVERB_SCHEME` are set to `localhost`, the assigned server port, and `http` respectively — the queue worker runs inside the PHP-FPM container alongside Reverb and connects directly. `VITE_REVERB_HOST`, `VITE_REVERB_PORT`, and `VITE_REVERB_SCHEME` are set to the site's domain and external port so the browser connects through the nginx WebSocket proxy
 
 ---

--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -66,7 +66,7 @@ No hooks or per-project setup needed — it works for every linked site out of t
 
 | Step | Default | Condition |
 |---|---|---|
-| `composer install` | - [x] on | only if `vendor/` is missing |
+| `composer install` | - [x] on | only if `vendor/` is missing; runs inside the project's PHP-FPM container to match the `composer.json` PHP constraint |
 | `npm ci` | - [x] on | only if `node_modules/` is missing and `package.json` exists |
 | `lerd env` | - [x] on | always |
 | `lerd mcp:inject` | - [ ] off | opt-in |

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -38,7 +38,7 @@ When serving a request, Lerd picks the PHP version for a project in this order:
 
 1. `.lerd.yaml` in the project root — `php_version` field (explicit lerd override)
 2. `.php-version` file in the project root (plain text, e.g. `8.2`)
-3. `composer.json` — `require.php` constraint (e.g. `^8.4` → `8.4`)
+3. `composer.json` — `require.php` constraint, resolved to the best installed version (e.g. `^8.3` with PHP 8.3 and 8.4 installed → `8.4`)
 4. Global default in `~/.config/lerd/config.yaml`
 
 When `.php-version` changes on disk, the lerd watcher automatically updates the site registry and regenerates the nginx vhost — no manual reload needed.
@@ -54,8 +54,10 @@ This writes `.php-version: 8.4` (so CLI `php`, asdf, and other tools see the rig
 
 The UI PHP version selector and the MCP `site_php` tool follow the same rules — they always write both files when applicable.
 
+The composer constraint is matched against all installed PHP versions using full semver rules (`^`, `~`, `>=`, `<`, `||`, `*`). The highest installed version that satisfies the constraint wins. If no installed version matches, the literal minimum from the constraint is used (and the FPM will be built on first use).
+
 ::: tip Overriding a `composer.json` constraint
-If `composer.json` requires `^8.3` but you need to run the project on PHP 8.4, `lerd isolate 8.4` is the right tool. It writes `.php-version` which takes priority over the composer constraint. Running `lerd use 8.4` alone won't help — that only sets the global fallback, which loses to the composer constraint.
+If `composer.json` requires `^8.3` but you need to run the project on a specific version, `lerd isolate 8.4` is the right tool. It writes `.php-version` which takes priority over the composer constraint. Running `lerd use 8.4` alone won't help — that only sets the global fallback, which loses to the composer constraint.
 :::
 
 To change the global default (applies to all projects that don't have a per-project pin):

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bufio"
 	crand "crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
@@ -315,11 +316,21 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	// 6. Generate APP_KEY if missing or empty (Laravel only)
+	// 6. Generate APP_KEY if missing or empty (Laravel only).
+	// Prefer artisan key:generate when vendor/ exists; otherwise write a
+	// random base64 key directly so composer post-install scripts can boot.
 	if isLaravel && strings.TrimSpace(envMap["APP_KEY"]) == "" {
-		fmt.Println("  Generating APP_KEY...")
-		if err := artisanIn(cwd, "key:generate"); err != nil {
-			fmt.Printf("  [WARN] key:generate failed: %v\n", err)
+		if _, statErr := os.Stat(filepath.Join(cwd, "vendor")); statErr == nil {
+			fmt.Println("  Generating APP_KEY...")
+			if err := artisanIn(cwd, "key:generate"); err != nil {
+				fmt.Printf("  [WARN] key:generate failed: %v\n", err)
+			}
+		} else {
+			fmt.Println("  Generating APP_KEY (vendor not installed yet)...")
+			key := generateLaravelAppKey()
+			if err := envfile.ApplyUpdates(envPath, map[string]string{"APP_KEY": key}); err != nil {
+				fmt.Printf("  [WARN] writing APP_KEY: %v\n", err)
+			}
 		}
 	}
 
@@ -481,6 +492,15 @@ func parseEnvMap(path string) (map[string]string, error) {
 }
 
 // artisanIn runs php artisan <args> in the given directory using the project's PHP container.
+// generateLaravelAppKey generates a base64-encoded 32-byte random key in the
+// format Laravel expects (base64:...). Used when vendor/ is not installed yet
+// and artisan key:generate cannot run.
+func generateLaravelAppKey() string {
+	key := make([]byte, 32)
+	crand.Read(key) //nolint:errcheck
+	return "base64:" + base64.StdEncoding.EncodeToString(key)
+}
+
 func artisanIn(dir string, args ...string) error {
 	version, err := phpDet.DetectVersion(dir)
 	if err != nil {

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -695,7 +695,7 @@ runtime_versions()   // see PHP and Node.js versions available
 ` + "```" + `
 composer(args: ["create-project", "laravel/laravel", "."])
 site_link()           // registers the cwd as a lerd site
-env_setup()           // configures .env, starts services, creates DB, generates APP_KEY
+env_setup()           // configures .env, starts services, creates DB, generates APP_KEY (even before composer install)
 artisan(args: ["migrate"])
 ` + "```" + `
 
@@ -859,7 +859,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 
 ### Architecture
 
-- PHP runs in Podman containers named ` + bt + `lerd-php<version>-fpm` + bt + ` (e.g. ` + bt + `lerd-php84-fpm` + bt + `); each container includes composer and node/npm
+- PHP runs in Podman containers named ` + bt + `lerd-php<version>-fpm` + bt + ` (e.g. ` + bt + `lerd-php84-fpm` + bt + `); each container includes composer and node/npm; the PHP version is resolved from ` + bt + `.lerd.yaml` + bt + ` → ` + bt + `.php-version` + bt + ` → ` + bt + `composer.json` + bt + ` ` + bt + `require.php` + bt + ` constraint (matched against installed versions) → global default
 - Nginx routes ` + bt + `*.test` + bt + ` domains to the correct PHP-FPM container
 - Services (MySQL, Redis, PostgreSQL, etc.) and custom services run as Podman containers via systemd quadlets
 - Node.js versions are managed by fnm; per-project version is set via a ` + bt + `.node-version` + bt + ` file

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -114,10 +114,7 @@ func runSetup(allSteps, skipOpen bool) error {
 			label:   "composer install",
 			enabled: os.IsNotExist(vendorMissing),
 			run: func() error {
-				cmd := exec.Command("composer", "install")
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-				return cmd.Run()
+				return composerInContainer(cwd, "install")
 			},
 		},
 		{
@@ -462,6 +459,34 @@ func siteHasStripeSecret(cwd string) bool {
 }
 
 // execInContainer runs an arbitrary command string inside the site's PHP-FPM container.
+// composerInContainer runs composer inside the project's PHP-FPM container,
+// ensuring the correct PHP version is used for dependency resolution.
+func composerInContainer(dir string, args ...string) error {
+	version, err := phpDet.DetectVersion(dir)
+	if err != nil {
+		cfg, _ := config.LoadGlobal()
+		version = cfg.PHP.DefaultVersion
+	}
+	short := strings.ReplaceAll(version, ".", "")
+	container := "lerd-php" + short + "-fpm"
+
+	home := os.Getenv("HOME")
+	composerPhar := filepath.Join(config.BinDir(), "composer.phar")
+
+	cmdArgs := []string{"exec", "-i", "-w", dir,
+		"--env", "HOME=" + home,
+		"--env", "COMPOSER_HOME=" + filepath.Join(home, ".config", "composer"),
+		container, "php", composerPhar,
+	}
+	cmdArgs = append(cmdArgs, args...)
+
+	cmd := exec.Command("podman", cmdArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
 func execInContainer(dir, command string) error {
 	version, err := phpDet.DetectVersion(dir)
 	if err != nil {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -455,7 +455,7 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "env_setup",
-			Description: "Configure the project's .env for lerd: creates .env from .env.example if missing, detects services (mysql, redis, etc.), starts them, creates databases, generates APP_KEY, and sets APP_URL. Run this once after cloning a project.",
+			Description: "Configure the project's .env for lerd: creates .env from .env.example if missing, detects services (mysql, redis, etc.), starts them, creates databases, generates APP_KEY (works even before composer install), and sets APP_URL. Run this once after cloning a project.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{

--- a/internal/php/detector.go
+++ b/internal/php/detector.go
@@ -2,6 +2,7 @@ package php
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -61,7 +62,10 @@ func DetectVersion(dir string) (string, error) {
 		}
 	}
 
-	// 3. composer.json require.php — project requirement
+	// 3. composer.json require.php — pick the best installed version that
+	//    satisfies the constraint (e.g. ^8.3 with 8.4 installed → 8.4).
+	//    Falls back to the literal minimum from the constraint when no
+	//    installed version matches.
 	composerFile := filepath.Join(dir, "composer.json")
 	if data, err := os.ReadFile(composerFile); err == nil {
 		var composer struct {
@@ -69,6 +73,9 @@ func DetectVersion(dir string) (string, error) {
 		}
 		if json.Unmarshal(data, &composer) == nil {
 			if phpConstraint, ok := composer.Require["php"]; ok {
+				if v := bestInstalledVersion(phpConstraint); v != "" {
+					return v, nil
+				}
 				if v := parseComposerPHP(phpConstraint); v != "" {
 					return v, nil
 				}
@@ -87,11 +94,142 @@ func DetectVersion(dir string) (string, error) {
 // parseComposerPHP extracts a simple major.minor version from a composer PHP constraint.
 // e.g. "^8.2" → "8.2", ">=8.1" → "8.1", "~8.3.0" → "8.3"
 func parseComposerPHP(constraint string) string {
-	// Strip operators and whitespace
 	re := regexp.MustCompile(`(\d+\.\d+)`)
 	matches := re.FindStringSubmatch(constraint)
 	if len(matches) > 1 {
 		return matches[1]
 	}
 	return ""
+}
+
+// bestInstalledVersion returns the highest installed PHP version that satisfies
+// the given composer constraint, or "" if none match.
+func bestInstalledVersion(constraint string) string {
+	installed, err := ListInstalled()
+	if err != nil || len(installed) == 0 {
+		return ""
+	}
+	// Iterate from highest to lowest.
+	for i := len(installed) - 1; i >= 0; i-- {
+		if satisfiesConstraint(installed[i], constraint) {
+			return installed[i]
+		}
+	}
+	return ""
+}
+
+// satisfiesConstraint checks if a major.minor version satisfies a composer PHP
+// constraint. Supports ^, ~, >=, >, <=, <, !=, exact, .*, and || (OR).
+func satisfiesConstraint(version, constraint string) bool {
+	major, minor := parseMajorMinor(version)
+	if major < 0 {
+		return false
+	}
+
+	// Handle OR constraints: "^8.1 || ^7.4"
+	for _, alt := range strings.Split(constraint, "||") {
+		alt = strings.TrimSpace(alt)
+		if alt == "" {
+			continue
+		}
+		if satisfiesSingle(major, minor, alt) {
+			return true
+		}
+	}
+	return false
+}
+
+func satisfiesSingle(major, minor int, constraint string) bool {
+	// Handle AND constraints: ">=8.1 <8.5", ">=8.1,<8.5"
+	parts := splitAND(constraint)
+	if len(parts) > 1 {
+		for _, p := range parts {
+			if !satisfiesSingle(major, minor, p) {
+				return false
+			}
+		}
+		return true
+	}
+
+	constraint = strings.TrimSpace(constraint)
+	if constraint == "" || constraint == "*" {
+		return true
+	}
+
+	// Wildcard: "8.*"
+	if strings.HasSuffix(constraint, ".*") {
+		wMajor, _ := parseMajorMinor(strings.TrimSuffix(constraint, ".*") + ".0")
+		return major == wMajor
+	}
+
+	// Operators
+	switch {
+	case strings.HasPrefix(constraint, "^"):
+		cMajor, cMinor := parseMajorMinor(stripOp(constraint, "^"))
+		if cMajor < 0 {
+			return false
+		}
+		return major == cMajor && minor >= cMinor
+	case strings.HasPrefix(constraint, "~"):
+		cMajor, cMinor := parseMajorMinor(stripOp(constraint, "~"))
+		if cMajor < 0 {
+			return false
+		}
+		// ~8.3 means >=8.3, <9.0; ~8.3.0 means >=8.3.0, <8.4.0
+		if strings.Count(stripOp(constraint, "~"), ".") >= 2 {
+			return major == cMajor && minor == cMinor
+		}
+		return major == cMajor && minor >= cMinor
+	case strings.HasPrefix(constraint, ">="):
+		cMajor, cMinor := parseMajorMinor(stripOp(constraint, ">="))
+		return major > cMajor || (major == cMajor && minor >= cMinor)
+	case strings.HasPrefix(constraint, ">"):
+		cMajor, cMinor := parseMajorMinor(stripOp(constraint, ">"))
+		return major > cMajor || (major == cMajor && minor > cMinor)
+	case strings.HasPrefix(constraint, "<="):
+		cMajor, cMinor := parseMajorMinor(stripOp(constraint, "<="))
+		return major < cMajor || (major == cMajor && minor <= cMinor)
+	case strings.HasPrefix(constraint, "<"):
+		cMajor, cMinor := parseMajorMinor(stripOp(constraint, "<"))
+		return major < cMajor || (major == cMajor && minor < cMinor)
+	case strings.HasPrefix(constraint, "!="):
+		cMajor, cMinor := parseMajorMinor(stripOp(constraint, "!="))
+		return major != cMajor || minor != cMinor
+	default:
+		// Exact match: "8.3" or "8.3.0"
+		cMajor, cMinor := parseMajorMinor(constraint)
+		return major == cMajor && minor == cMinor
+	}
+}
+
+// splitAND splits a constraint on space or comma boundaries, treating each
+// part as an AND condition. E.g. ">=8.1 <8.5" → [">=8.1", "<8.5"].
+func splitAND(s string) []string {
+	// Replace commas with spaces, then split on whitespace.
+	s = strings.ReplaceAll(s, ",", " ")
+	var parts []string
+	for _, p := range strings.Fields(s) {
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return parts
+}
+
+func stripOp(s, op string) string {
+	return strings.TrimSpace(strings.TrimPrefix(s, op))
+}
+
+func parseMajorMinor(s string) (int, int) {
+	s = strings.TrimSpace(s)
+	// Strip trailing .patch if present (e.g. "8.3.0" → "8.3")
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) < 2 {
+		return -1, -1
+	}
+	var major, minor int
+	if _, err := fmt.Sscanf(parts[0]+"."+parts[1], "%d.%d", &major, &minor); err != nil {
+		return -1, -1
+	}
+	return major, minor
 }

--- a/internal/php/detector_test.go
+++ b/internal/php/detector_test.go
@@ -37,6 +37,66 @@ func TestParseComposerPHP(t *testing.T) {
 	}
 }
 
+// ── satisfiesConstraint ───────────────────────────────────────────────────────
+
+func TestSatisfiesConstraint(t *testing.T) {
+	cases := []struct {
+		version    string
+		constraint string
+		want       bool
+	}{
+		// caret
+		{"8.3", "^8.3", true},
+		{"8.4", "^8.3", true},
+		{"8.2", "^8.3", false},
+		{"9.0", "^8.3", false},
+		// tilde
+		{"8.3", "~8.3", true},
+		{"8.4", "~8.3", true},
+		{"8.2", "~8.3", false},
+		{"8.3", "~8.3.0", true},
+		{"8.4", "~8.3.0", false}, // ~8.3.0 means <8.4
+		// comparison
+		{"8.4", ">=8.3", true},
+		{"8.3", ">=8.3", true},
+		{"8.2", ">=8.3", false},
+		{"8.4", ">8.3", true},
+		{"8.3", ">8.3", false},
+		{"8.2", "<8.3", true},
+		{"8.3", "<8.3", false},
+		{"8.3", "<=8.3", true},
+		{"8.4", "<=8.3", false},
+		{"8.4", "!=8.3", true},
+		{"8.3", "!=8.3", false},
+		// wildcard
+		{"8.3", "8.*", true},
+		{"8.4", "8.*", true},
+		{"9.0", "8.*", false},
+		// exact
+		{"8.3", "8.3", true},
+		{"8.4", "8.3", false},
+		{"8.3", "8.3.0", true},
+		// OR
+		{"7.4", "^7.4 || ^8.0", true},
+		{"8.3", "^7.4 || ^8.0", true},
+		{"7.3", "^7.4 || ^8.0", false},
+		// AND (space-separated)
+		{"8.3", ">=8.1 <8.5", true},
+		{"8.5", ">=8.1 <8.5", false},
+		{"8.0", ">=8.1 <8.5", false},
+		// AND (comma-separated)
+		{"8.3", ">=8.1,<8.5", true},
+		// star
+		{"8.4", "*", true},
+	}
+	for _, c := range cases {
+		got := satisfiesConstraint(c.version, c.constraint)
+		if got != c.want {
+			t.Errorf("satisfiesConstraint(%q, %q) = %v, want %v", c.version, c.constraint, got, c.want)
+		}
+	}
+}
+
 // ── DetectVersion ─────────────────────────────────────────────────────────────
 
 func TestDetectVersion_DotLerdYaml(t *testing.T) {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.6.1"
+	Version = "1.6.2"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

- lerd env now generates APP_KEY directly in .env when vendor/ doesn't exist yet, preventing MissingAppKeyException during composer install post-install scripts on fresh projects (lerd new → lerd link → lerd setup flow)