### PR TITLE
chore: switch tray to libayatana-appindicator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,19 +21,19 @@ jobs:
       - name: Install tray build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --fix-missing libappindicator3-dev
+          sudo apt-get install -y --fix-missing libayatana-appindicator3-dev
 
       - name: Download dependencies
         run: go mod download
 
       - name: Build
-        run: CGO_ENABLED=1 go build -tags legacy_appindicator -o /dev/null ./cmd/lerd
+        run: CGO_ENABLED=1 go build -o /dev/null ./cmd/lerd
 
       - name: Test
-        run: CGO_ENABLED=1 go test -tags legacy_appindicator ./...
+        run: CGO_ENABLED=1 go test ./...
 
       - name: Vet
-        run: CGO_ENABLED=1 go vet -tags legacy_appindicator ./...
+        run: CGO_ENABLED=1 go vet ./...
 
       - name: Format
         run: test -z "$(gofmt -l .)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,19 +20,19 @@ jobs:
       - name: Install tray build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --fix-missing libappindicator3-dev
+          sudo apt-get install -y --fix-missing libayatana-appindicator3-dev
 
       - name: Download dependencies
         run: go mod download
 
       - name: Build
-        run: CGO_ENABLED=1 go build -tags legacy_appindicator -o /dev/null ./cmd/lerd
+        run: CGO_ENABLED=1 go build -o /dev/null ./cmd/lerd
 
       - name: Test
-        run: CGO_ENABLED=1 go test -tags legacy_appindicator ./...
+        run: CGO_ENABLED=1 go test ./...
 
       - name: Vet
-        run: CGO_ENABLED=1 go vet -tags legacy_appindicator ./...
+        run: CGO_ENABLED=1 go vet ./...
 
       - name: Format
         run: test -z "$(gofmt -l .)"
@@ -56,7 +56,7 @@ jobs:
       - name: Install tray build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --fix-missing libappindicator3-dev
+          sudo apt-get install -y --fix-missing libayatana-appindicator3-dev
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,7 +41,7 @@ builds:
       - -X github.com/geodro/lerd/internal/version.Commit={{.Commit}}
       - -X github.com/geodro/lerd/internal/version.Date={{.Date}}
 
-  # lerd-tray is a separate CGO binary that links libappindicator3.
+  # lerd-tray is a separate CGO binary that links libayatana-appindicator.
   # lerd (nogui) execs it at runtime; if the library is missing the tray
   # is silently skipped and everything else continues to work.
   - id: lerd-tray-amd64
@@ -49,8 +49,6 @@ builds:
     binary: lerd-tray
     env:
       - CGO_ENABLED=1
-    flags:
-      - -tags=legacy_appindicator
     goos:
       - linux
     goarch:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 	CGO_ENABLED=0 go build -tags nogui -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/lerd
 
 build-tray:
-	CGO_ENABLED=1 go build -tags legacy_appindicator -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/lerd-tray ./cmd/lerd-tray
+	CGO_ENABLED=1 go build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/lerd-tray ./cmd/lerd-tray
 
 install: build build-tray
 	install -Dm755 $(BUILD_DIR)/$(BINARY) $(INSTALL_DIR)/$(BINARY)

--- a/docs/contributing/building.md
+++ b/docs/contributing/building.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-The default build requires CGO and `libappindicator3` for the system tray. See [System Tray — Build requirements](../features/system-tray.md#build-requirements) for per-distro package names.
+The tray binary requires CGO and `libayatana-appindicator`. See [System Tray — Build requirements](../features/system-tray.md#build-requirements) for per-distro package names.
 
 Go is required to build from source. The released binary has no runtime dependencies.
 

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -26,7 +26,7 @@ make test
 ### Vet
 
 ```bash
-CGO_ENABLED=1 go vet -tags legacy_appindicator ./...
+CGO_ENABLED=1 go vet ./...
 ```
 
 ## CI checks

--- a/docs/features/system-tray.md
+++ b/docs/features/system-tray.md
@@ -71,25 +71,25 @@ The tray uses the **StatusNotifierItem (SNI) / AppIndicator** protocol (DBus-bas
 
 ## Build requirements
 
-The tray uses CGO and requires `libappindicator3` at build time:
+The tray uses CGO and requires `libayatana-appindicator` at build time:
 
 ::: code-group
 
-```bash [Arch]
-sudo pacman -S libappindicator-gtk3
+```bash [Arch / CachyOS / omarchy]
+sudo pacman -S libayatana-appindicator
 ```
 
 ```bash [Debian / Ubuntu]
-sudo apt install libappindicator3-dev
+sudo apt install libayatana-appindicator3-dev
 ```
 
 ```bash [Fedora]
-sudo dnf install libappindicator-gtk3-devel
+sudo dnf install libayatana-appindicator-gtk3
 ```
 
 :::
 
-For headless / CI builds without AppIndicator:
+For headless / CI builds without the tray:
 
 ```bash
 make build-nogui   # produces ./build/lerd-nogui — lerd tray returns an error

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -86,11 +86,11 @@ func runUpdate(currentVersion string, beta bool) error {
 	}
 
 	// Ask for confirmation.
-	fmt.Printf("\nUpdate to v%s? [y/N] ", lat)
+	fmt.Printf("\nUpdate to v%s? [Y/n] ", lat)
 	reader := bufio.NewReader(os.Stdin)
 	answer, _ := reader.ReadString('\n')
 	answer = strings.TrimSpace(strings.ToLower(answer))
-	if answer != "y" && answer != "yes" {
+	if answer == "n" || answer == "no" {
 		fmt.Println("Update cancelled.")
 		return nil
 	}


### PR DESCRIPTION
## Summary

- switch tray backend from legacy libappindicator3 to libayatana-appindicator (the actively maintained fork, default in getlantern/systray)
- remove legacy_appindicator build tag from Makefile, CI workflows, goreleaser
- update build requirement docs with per-distro ayatana package names (Arch, Debian/Ubuntu, Fedora)
- lerd update prompt now defaults to Y (press Enter to confirm)