### PR TITLE
feat: ship Laravel installer

### DIFF
--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -19,7 +19,22 @@ Laravel has a built-in definition. Any other PHP framework (Symfony, WordPress, 
 
 ## Creating new projects
 
-Use `lerd new` to scaffold a new PHP project from a framework's create command:
+### Laravel installer
+
+Lerd ships with the [Laravel installer](https://laravel.com/docs/installation#creating-a-laravel-application) — it's already available in your CLI after `lerd install`:
+
+```bash
+laravel new myapp
+cd myapp
+lerd link
+lerd setup
+```
+
+The installer walks you through starter kit selection, database setup, and other options interactively.
+
+### lerd new
+
+`lerd new` is a framework-agnostic shortcut that runs the framework's scaffold command:
 
 ```bash
 lerd new myapp                          # create ./myapp using Laravel (default)

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net/http"
@@ -73,6 +74,9 @@ func runInstall(_ *cobra.Command, _ []string) error {
 		return err
 	}
 	ok()
+
+	// Ask before RunParallel steals stdin.
+	wantLaravelInstaller := confirmInstallPrompt("Install Laravel installer (laravel new)?")
 
 	// 4. mkcert CA — interactive (may prompt for sudo)
 	fmt.Println("  --> Installing mkcert CA")
@@ -321,6 +325,15 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	startRestoredServices()
 	restoreSiteInfrastructure()
 
+	if wantLaravelInstaller {
+		fmt.Print("  --> Installing Laravel installer ... ")
+		if err := installLaravelInstaller(); err != nil {
+			fmt.Printf("WARN: %v\n", err)
+		} else {
+			ok()
+		}
+	}
+
 	// Restart tray if running.
 	if lerdSystemd.IsServiceEnabled("lerd-tray") {
 		_ = lerdSystemd.RestartService("lerd-tray")
@@ -429,6 +442,26 @@ func downloadBinaries(w io.Writer) error {
 	return nil
 }
 
+// installLaravelInstaller runs composer global require laravel/installer using
+// the composer shim so the `laravel` CLI is available for scaffolding new apps.
+func installLaravelInstaller() error {
+	composerBin := filepath.Join(config.BinDir(), "composer")
+	cmd := exec.Command(composerBin, "global", "require", "laravel/installer")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// confirmInstallPrompt asks a [Y/n] question. Must be called before any
+// RunParallel invocation, which leaves a goroutine reading from os.Stdin.
+func confirmInstallPrompt(question string) bool {
+	fmt.Printf("  --> %s [Y/n] ", question)
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer != "n" && answer != "no"
+}
+
 // downloadFile downloads a URL to a local file, printing a progress bar to w.
 func downloadFile(url, dest string, mode os.FileMode, w io.Writer) error {
 	fmt.Fprintf(w, "\n      Downloading %s\n      ", url)
@@ -499,6 +532,20 @@ func addShellShims() error {
 	composerShim := fmt.Sprintf("#!/bin/sh\nexec %s php %s/.local/share/lerd/bin/composer.phar \"$@\"\n", lerdBin, home)
 	if err := os.WriteFile(filepath.Join(binDir, "composer"), []byte(composerShim), 0755); err != nil {
 		return fmt.Errorf("writing composer shim: %w", err)
+	}
+
+	// Write laravel shim (laravel/installer global package)
+	composerHome := os.Getenv("COMPOSER_HOME")
+	if composerHome == "" {
+		xdgConfig := os.Getenv("XDG_CONFIG_HOME")
+		if xdgConfig == "" {
+			xdgConfig = filepath.Join(home, ".config")
+		}
+		composerHome = filepath.Join(xdgConfig, "composer")
+	}
+	laravelShim := fmt.Sprintf("#!/bin/sh\nexec %s php %s/vendor/bin/laravel \"$@\"\n", lerdBin, composerHome)
+	if err := os.WriteFile(filepath.Join(binDir, "laravel"), []byte(laravelShim), 0755); err != nil {
+		return fmt.Errorf("writing laravel shim: %w", err)
 	}
 
 	// Write node/npm/npx shims — use fnm directly so they work inside containers

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAddShellShims_LaravelShim(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("HOME", tmp)
+	// Clear COMPOSER_HOME so the default path is used.
+	t.Setenv("COMPOSER_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	binDir := filepath.Join(tmp, "lerd", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// addShellShims expects a shell env var for the PATH block.
+	t.Setenv("SHELL", "/bin/sh")
+
+	if err := addShellShims(); err != nil {
+		t.Fatalf("addShellShims: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(binDir, "laravel"))
+	if err != nil {
+		t.Fatalf("laravel shim not created: %v", err)
+	}
+
+	shim := string(data)
+	if !strings.HasPrefix(shim, "#!/bin/sh\n") {
+		t.Errorf("laravel shim missing shebang, got: %q", shim)
+	}
+	expectedComposerHome := filepath.Join(tmp, ".config", "composer")
+	expectedPath := expectedComposerHome + "/vendor/bin/laravel"
+	if !strings.Contains(shim, expectedPath) {
+		t.Errorf("laravel shim does not reference %q, got:\n%s", expectedPath, shim)
+	}
+}
+
+func TestAddShellShims_LaravelShimRespectsComposerHome(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("HOME", tmp)
+
+	customHome := filepath.Join(tmp, "custom-composer")
+	t.Setenv("COMPOSER_HOME", customHome)
+
+	binDir := filepath.Join(tmp, "lerd", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SHELL", "/bin/sh")
+
+	if err := addShellShims(); err != nil {
+		t.Fatalf("addShellShims: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(binDir, "laravel"))
+	if err != nil {
+		t.Fatalf("laravel shim not created: %v", err)
+	}
+
+	shim := string(data)
+	expectedPath := customHome + "/vendor/bin/laravel"
+	if !strings.Contains(shim, expectedPath) {
+		t.Errorf("laravel shim should use COMPOSER_HOME=%q, got:\n%s", customHome, shim)
+	}
+}


### PR DESCRIPTION
## Summary

- Installs laravel/installer as a global composer package during lerd install, so the laravel command is available directly in the terminal just like Herd ships it
- Creates a laravel shim in BinDir that routes through lerd php
- Prompts the user with [Y/n] before installing, defaults to yes
- Prompt runs before RunParallel to avoid stdin conflicts with the TUI goroutine

Closes #98