### PR TITLE
feat: add application log viewer to the UI

### DIFF
--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -248,6 +248,11 @@ setup:
     command: "php bin/console doctrine:fixtures:load --no-interaction"
     check:
       composer: doctrine/doctrine-fixtures-bundle  # skipped if package not installed
+
+# Application log files shown in the UI "App Logs" tab
+logs:
+  - path: "var/log/*.log"             # glob relative to project root
+    format: raw                       # monolog | raw (plain text, default)
 ```
 
 ---
@@ -268,6 +273,48 @@ The **first match wins**. Detection rules are OR-based — any single matching r
 If no framework matches and no `--public-dir` is specified, lerd tries these candidate directories in order, accepting the first that contains an `index.php`:
 
 `public` → `web` → `webroot` → `pub` → `www` → `htdocs` → `.` (project root)
+
+---
+
+## Log viewer
+
+Frameworks can define application log file locations so they appear in the UI's **App Logs** tab. Laravel has this built-in (`storage/logs/*.log` with Monolog parsing). Custom frameworks can add their own:
+
+```yaml
+logs:
+  - path: "var/log/*.log"
+    format: raw
+```
+
+The `path` is a glob relative to the project root. The `format` controls parsing:
+
+| Format | Description |
+|---|---|
+| `monolog` | Monolog format: `[date] channel.LEVEL: message {context}` with stacktrace grouping |
+| `raw` | Plain text, each line shown as a separate entry (default) |
+
+The App Logs tab is the first tab in the site detail view. When the UI opens it automatically selects the site with the most recent log activity, so you immediately see logs from the project you last visited in your browser.
+
+Features:
+
+- **File selector** — switch between available log files (e.g. `laravel.log`, `worker.log`), sorted by modification time with the newest file pre-selected
+- **Latest / All toggle** — "Latest" shows the last 100 entries (default), "All" reads the entire file
+- **Search** — filter entries by message, level, date, or stacktrace content
+- **Expandable entries** — click any entry to expand and see the full detail and stacktrace
+- **Auto-refresh** — polls every 5 seconds while the tab is active, keeping the expanded entry open
+- **Color-coded levels** — entries are color-coded by severity (red for ERROR/CRITICAL/EMERGENCY/ALERT, yellow for WARNING, blue for INFO/NOTICE, grey for DEBUG)
+
+To customise Laravel's log paths (e.g. add a custom channel log):
+
+```yaml
+# ~/.config/lerd/frameworks/laravel.yaml
+name: laravel
+logs:
+  - path: "storage/logs/*.log"
+    format: monolog
+  - path: "storage/logs/custom/*.log"
+    format: monolog
+```
 
 ---
 

--- a/internal/applog/parser.go
+++ b/internal/applog/parser.go
@@ -1,0 +1,302 @@
+package applog
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// LogEntry represents a single parsed log entry.
+type LogEntry struct {
+	Level   string `json:"level"`
+	Date    string `json:"date"`
+	Channel string `json:"channel"`
+	Message string `json:"message"`
+	Detail  string `json:"detail,omitempty"`
+}
+
+// LogFile represents an available log file on disk.
+type LogFile struct {
+	Name    string `json:"name"`
+	Size    int64  `json:"size"`
+	ModTime string `json:"mod_time"`
+}
+
+// maxReadBytes is the maximum number of bytes to read from the end of a file.
+const maxReadBytes = 512 * 1024
+
+// laravelRe matches the opening line of a Laravel/Monolog log entry:
+// [2024-01-09 13:13:49] local.ERROR: message text
+var laravelRe = regexp.MustCompile(`^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\] (\w+)\.(\w+): (.*)$`)
+
+// DiscoverLogFiles expands the configured log source globs for a project and
+// returns the matching files sorted by modification time (newest first).
+// Resolved paths are validated to stay within projectDir.
+func DiscoverLogFiles(projectDir string, sources []config.FrameworkLogSource) ([]LogFile, error) {
+	absProject, err := filepath.Abs(projectDir)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]bool{}
+	var files []LogFile
+
+	for _, src := range sources {
+		pattern := filepath.Join(absProject, src.Path)
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			continue
+		}
+		for _, m := range matches {
+			abs, err := filepath.Abs(m)
+			if err != nil || !strings.HasPrefix(abs, absProject+string(filepath.Separator)) {
+				continue // path traversal guard
+			}
+			if seen[abs] {
+				continue
+			}
+			seen[abs] = true
+
+			info, err := os.Stat(abs)
+			if err != nil || info.IsDir() {
+				continue
+			}
+			files = append(files, LogFile{
+				Name:    info.Name(),
+				Size:    info.Size(),
+				ModTime: info.ModTime().UTC().Format(time.RFC3339),
+			})
+		}
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].ModTime > files[j].ModTime
+	})
+	return files, nil
+}
+
+// LatestModTime returns the most recent modification time across all log files
+// matched by the given sources. Returns zero time if no files found.
+func LatestModTime(projectDir string, sources []config.FrameworkLogSource) time.Time {
+	absProject, err := filepath.Abs(projectDir)
+	if err != nil {
+		return time.Time{}
+	}
+
+	var latest time.Time
+	for _, src := range sources {
+		pattern := filepath.Join(absProject, src.Path)
+		matches, _ := filepath.Glob(pattern)
+		for _, m := range matches {
+			abs, err := filepath.Abs(m)
+			if err != nil || !strings.HasPrefix(abs, absProject+string(filepath.Separator)) {
+				continue
+			}
+			info, err := os.Stat(abs)
+			if err != nil || info.IsDir() {
+				continue
+			}
+			if info.ModTime().After(latest) {
+				latest = info.ModTime()
+			}
+		}
+	}
+	return latest
+}
+
+// ResolveLogFilePath finds the full path for a log file by name within the
+// configured sources. Returns empty string if not found or path traversal detected.
+func ResolveLogFilePath(projectDir string, sources []config.FrameworkLogSource, filename string) string {
+	if strings.ContainsAny(filename, "/\\") || strings.Contains(filename, "..") {
+		return ""
+	}
+
+	absProject, _ := filepath.Abs(projectDir)
+	for _, src := range sources {
+		pattern := filepath.Join(absProject, src.Path)
+		matches, _ := filepath.Glob(pattern)
+		for _, m := range matches {
+			abs, err := filepath.Abs(m)
+			if err != nil || !strings.HasPrefix(abs, absProject+string(filepath.Separator)) {
+				continue
+			}
+			if filepath.Base(abs) == filename {
+				return abs
+			}
+		}
+	}
+	return ""
+}
+
+// FormatForFile returns the log format string for the given filename based on
+// the framework's log sources. Falls back to "raw".
+func FormatForFile(sources []config.FrameworkLogSource, filename string) string {
+	for _, src := range sources {
+		// Check if the filename could match this source's glob pattern
+		_, base := filepath.Split(src.Path)
+		if matched, _ := filepath.Match(base, filename); matched {
+			if src.Format != "" {
+				return src.Format
+			}
+			return "raw"
+		}
+	}
+	return "raw"
+}
+
+// ParseFile reads the tail of a log file and parses up to maxEntries entries.
+// When maxEntries is 0, the entire file is read and all entries are returned.
+// Returns entries in reverse-chronological order (newest first).
+func ParseFile(path, format string, maxEntries int) ([]LogEntry, error) {
+	readLimit := maxReadBytes
+	if maxEntries == 0 {
+		readLimit = 0 // read entire file
+	}
+	data, err := readTail(path, int64(readLimit))
+	if err != nil {
+		return nil, err
+	}
+
+	switch format {
+	case "laravel", "monolog":
+		return parseLaravel(string(data), maxEntries), nil
+	default:
+		return parseRaw(string(data), maxEntries), nil
+	}
+}
+
+// readTail reads up to maxBytes from the end of the file. If the file is
+// smaller than maxBytes, the entire file is read. When truncated, the first
+// partial line is discarded. When maxBytes is 0, the entire file is read.
+func readTail(path string, maxBytes int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	size := info.Size()
+	if size == 0 {
+		return nil, nil
+	}
+
+	truncated := false
+	readSize := size
+	if maxBytes > 0 && size > maxBytes {
+		readSize = maxBytes
+		truncated = true
+		if _, err := f.Seek(size-maxBytes, 0); err != nil {
+			return nil, err
+		}
+	}
+
+	buf := make([]byte, readSize)
+	n, err := f.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	buf = buf[:n]
+
+	// Discard incomplete first line when truncated
+	if truncated {
+		if idx := indexByte(buf, '\n'); idx >= 0 {
+			buf = buf[idx+1:]
+		}
+	}
+
+	return buf, nil
+}
+
+func indexByte(b []byte, c byte) int {
+	for i, v := range b {
+		if v == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// parseLaravel splits Monolog-formatted log content into structured entries.
+func parseLaravel(content string, maxEntries int) []LogEntry {
+	lines := strings.Split(content, "\n")
+
+	// Group lines into blocks: each block starts with a line matching laravelRe
+	type block struct {
+		header string
+		extra  []string
+	}
+	var blocks []block
+
+	for _, line := range lines {
+		if laravelRe.MatchString(line) {
+			blocks = append(blocks, block{header: line})
+		} else if len(blocks) > 0 && strings.TrimSpace(line) != "" {
+			blocks[len(blocks)-1].extra = append(blocks[len(blocks)-1].extra, line)
+		}
+	}
+
+	// Take only the last maxEntries blocks (0 = unlimited)
+	if maxEntries > 0 && len(blocks) > maxEntries {
+		blocks = blocks[len(blocks)-maxEntries:]
+	}
+
+	// Parse blocks into entries, newest first
+	entries := make([]LogEntry, 0, len(blocks))
+	for i := len(blocks) - 1; i >= 0; i-- {
+		b := blocks[i]
+		m := laravelRe.FindStringSubmatch(b.header)
+		if m == nil {
+			continue
+		}
+
+		entry := LogEntry{
+			Date:    m[1],
+			Channel: m[2],
+			Level:   strings.ToUpper(m[3]),
+			Message: m[4],
+		}
+
+		if len(b.extra) > 0 {
+			entry.Detail = entry.Message + "\n" + strings.Join(b.extra, "\n")
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
+// parseRaw treats each non-empty line as a separate log entry.
+func parseRaw(content string, maxEntries int) []LogEntry {
+	lines := strings.Split(content, "\n")
+
+	// Collect non-empty lines
+	var nonEmpty []string
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			nonEmpty = append(nonEmpty, line)
+		}
+	}
+
+	if maxEntries > 0 && len(nonEmpty) > maxEntries {
+		nonEmpty = nonEmpty[len(nonEmpty)-maxEntries:]
+	}
+
+	entries := make([]LogEntry, 0, len(nonEmpty))
+	for i := len(nonEmpty) - 1; i >= 0; i-- {
+		entries = append(entries, LogEntry{
+			Message: nonEmpty[i],
+		})
+	}
+	return entries
+}

--- a/internal/applog/parser_test.go
+++ b/internal/applog/parser_test.go
@@ -1,0 +1,668 @@
+package applog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+const sampleLaravelLog = `[2024-01-08 14:05:08] local.ERROR: Database file at path [herd_templates] does not exist. Ensure this is an absolute path to the database. (Connection: sqlite, SQL: select * from "users") {"exception":"[object] (Illuminate\\Database\\QueryException(code: 0): Database file at path [herd_templates] does not exist.)"}
+[stacktrace]
+#0 /Users/seb/Code/herd-templates/vendor/laravel/framework/src/Illuminate/Database/Connection.php(801): Illuminate\Database\Connection->runQueryCallback()
+#1 /Users/seb/Code/herd-templates/vendor/laravel/framework/src/Illuminate/Database/Connection.php(756): Illuminate\Database\Connection->run()
+[2024-01-09 13:13:49] local.ERROR: syntax error, unexpected token "++", expecting variable or "{" or "$" {"exception":"[object] (ParseError(code: 0): syntax error)"}
+[stacktrace]
+#0 /Users/seb/Code/herd-templates/vendor/laravel/framework/src/Illuminate/Routing/Router.php(511): Illuminate\Routing\Router->loadRoutes()
+#1 /Users/seb/Code/herd-templates/vendor/laravel/framework/src/Illuminate/Routing/Router.php(465): Illuminate\Routing\Router->loadRoutes()
+[2024-01-09 13:14:00] local.ERROR: Maximum execution time of 30 seconds exceeded {"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError)"}
+[2024-01-11 14:58:09] local.ERROR: Connection could not be established with host "mailpit:1025": stream_socket_client(): php_network_getaddresses: getaddrinfo for mailpit failed {"exception":"[object] (Symfony\\Component\\Mailer\\Exception\\TransportException)"}
+`
+
+// ── parseLaravel ─────────────────────────────────────────────────────────────
+
+func TestParseLaravel(t *testing.T) {
+	entries := parseLaravel(sampleLaravelLog, 100)
+
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+
+	// Newest first
+	if entries[0].Date != "2024-01-11 14:58:09" {
+		t.Errorf("expected newest entry first, got date %s", entries[0].Date)
+	}
+	if entries[0].Level != "ERROR" {
+		t.Errorf("expected level ERROR, got %s", entries[0].Level)
+	}
+	if entries[0].Channel != "local" {
+		t.Errorf("expected channel local, got %s", entries[0].Channel)
+	}
+	if !strings.Contains(entries[0].Message, "mailpit:1025") {
+		t.Errorf("expected message to contain mailpit:1025, got %s", entries[0].Message)
+	}
+
+	// Entry with stacktrace should have detail
+	syntaxErr := entries[2] // 2024-01-09 13:13:49
+	if syntaxErr.Detail == "" {
+		t.Error("expected detail for entry with stacktrace")
+	}
+	if !strings.Contains(syntaxErr.Detail, "Router.php(511)") {
+		t.Error("expected stacktrace in detail")
+	}
+
+	// Entry without extra lines should have no detail
+	if entries[0].Detail != "" {
+		t.Errorf("expected no detail for single-line entry, got %q", entries[0].Detail)
+	}
+}
+
+func TestParseLaravelMaxEntries(t *testing.T) {
+	entries := parseLaravel(sampleLaravelLog, 2)
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries (limited), got %d", len(entries))
+	}
+
+	// Should be the 2 newest
+	if entries[0].Date != "2024-01-11 14:58:09" {
+		t.Errorf("expected newest entry, got %s", entries[0].Date)
+	}
+	if entries[1].Date != "2024-01-09 13:14:00" {
+		t.Errorf("expected second newest entry, got %s", entries[1].Date)
+	}
+}
+
+func TestParseLaravelEmpty(t *testing.T) {
+	entries := parseLaravel("", 100)
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 entries for empty input, got %d", len(entries))
+	}
+}
+
+func TestParseLaravelMultipleLevels(t *testing.T) {
+	content := `[2024-03-01 10:00:00] production.DEBUG: Debug message
+[2024-03-01 10:00:01] production.INFO: Info message
+[2024-03-01 10:00:02] production.WARNING: Warning message
+[2024-03-01 10:00:03] production.ERROR: Error message
+[2024-03-01 10:00:04] production.CRITICAL: Critical message
+[2024-03-01 10:00:05] production.ALERT: Alert message
+[2024-03-01 10:00:06] production.EMERGENCY: Emergency message
+`
+	entries := parseLaravel(content, 100)
+	if len(entries) != 7 {
+		t.Fatalf("expected 7 entries, got %d", len(entries))
+	}
+
+	expectedLevels := []string{"EMERGENCY", "ALERT", "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"}
+	for i, want := range expectedLevels {
+		if entries[i].Level != want {
+			t.Errorf("entry %d: level = %q, want %q", i, entries[i].Level, want)
+		}
+	}
+
+	for _, e := range entries {
+		if e.Channel != "production" {
+			t.Errorf("expected channel production, got %s", e.Channel)
+		}
+	}
+}
+
+func TestParseLaravelMultilineStacktrace(t *testing.T) {
+	content := `[2024-03-01 10:00:00] local.ERROR: Something broke {"exception":"[object] (RuntimeException)"}
+[stacktrace]
+#0 /app/Http/Controller.php(42): App\Service->doStuff()
+#1 /vendor/laravel/framework/Router.php(100): App\Http\Controller->handle()
+#2 {main}
+`
+	entries := parseLaravel(content, 100)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	e := entries[0]
+	if e.Detail == "" {
+		t.Fatal("expected detail with stacktrace")
+	}
+	if !strings.Contains(e.Detail, "#0") {
+		t.Error("detail should contain stacktrace frame #0")
+	}
+	if !strings.Contains(e.Detail, "#2 {main}") {
+		t.Error("detail should contain final stacktrace frame")
+	}
+	if !strings.Contains(e.Detail, "Something broke") {
+		t.Error("detail should include the original message")
+	}
+}
+
+func TestParseLaravelDetailIncludesMessage(t *testing.T) {
+	content := `[2024-03-01 10:00:00] local.ERROR: The message line {"ctx":"val"}
+extra context line
+`
+	entries := parseLaravel(content, 100)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if !strings.HasPrefix(entries[0].Detail, entries[0].Message) {
+		t.Error("detail should start with the message text")
+	}
+}
+
+func TestParseLaravelOnlyHeaders(t *testing.T) {
+	content := `[2024-03-01 10:00:00] local.INFO: first
+[2024-03-01 10:00:01] local.INFO: second
+[2024-03-01 10:00:02] local.INFO: third
+`
+	entries := parseLaravel(content, 100)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3, got %d", len(entries))
+	}
+	for _, e := range entries {
+		if e.Detail != "" {
+			t.Errorf("expected no detail for header-only entry, got %q", e.Detail)
+		}
+	}
+}
+
+func TestParseLaravelGarbageLinesBeforeFirstEntry(t *testing.T) {
+	content := `some garbage line
+another garbage
+[2024-03-01 10:00:00] local.INFO: real entry
+`
+	entries := parseLaravel(content, 100)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (garbage ignored), got %d", len(entries))
+	}
+	if entries[0].Message != "real entry" {
+		t.Errorf("unexpected message: %q", entries[0].Message)
+	}
+}
+
+func TestParseLaravelMaxEntriesOne(t *testing.T) {
+	entries := parseLaravel(sampleLaravelLog, 1)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1, got %d", len(entries))
+	}
+	if entries[0].Date != "2024-01-11 14:58:09" {
+		t.Errorf("expected the newest entry, got %s", entries[0].Date)
+	}
+}
+
+// ── parseRaw ─────────────────────────────────────────────────────────────────
+
+func TestParseRaw(t *testing.T) {
+	content := "line one\nline two\nline three\n"
+	entries := parseRaw(content, 100)
+
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	// Newest first (last line first)
+	if entries[0].Message != "line three" {
+		t.Errorf("expected 'line three', got %q", entries[0].Message)
+	}
+	if entries[2].Message != "line one" {
+		t.Errorf("expected 'line one', got %q", entries[2].Message)
+	}
+}
+
+func TestParseRawMaxEntries(t *testing.T) {
+	content := "a\nb\nc\nd\ne\n"
+	entries := parseRaw(content, 2)
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2, got %d", len(entries))
+	}
+	if entries[0].Message != "e" {
+		t.Errorf("expected 'e', got %q", entries[0].Message)
+	}
+	if entries[1].Message != "d" {
+		t.Errorf("expected 'd', got %q", entries[1].Message)
+	}
+}
+
+func TestParseRawEmpty(t *testing.T) {
+	entries := parseRaw("", 100)
+	if len(entries) != 0 {
+		t.Fatalf("expected 0, got %d", len(entries))
+	}
+}
+
+func TestParseRawBlankLines(t *testing.T) {
+	content := "line one\n\n\nline two\n   \nline three\n"
+	entries := parseRaw(content, 100)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 (blanks skipped), got %d", len(entries))
+	}
+}
+
+func TestParseRawNoTrailingNewline(t *testing.T) {
+	content := "alpha\nbeta"
+	entries := parseRaw(content, 100)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2, got %d", len(entries))
+	}
+	if entries[0].Message != "beta" {
+		t.Errorf("expected beta first (newest), got %q", entries[0].Message)
+	}
+}
+
+func TestParseRawFieldsEmpty(t *testing.T) {
+	entries := parseRaw("hello\n", 100)
+	if len(entries) != 1 {
+		t.Fatal("expected 1")
+	}
+	e := entries[0]
+	if e.Level != "" || e.Date != "" || e.Channel != "" || e.Detail != "" {
+		t.Error("raw entries should only have Message set")
+	}
+}
+
+// ── ParseFile ────────────────────────────────────────────────────────────────
+
+func TestParseFileMonolog(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "laravel.log")
+	os.WriteFile(path, []byte(sampleLaravelLog), 0644)
+
+	entries, err := ParseFile(path, "monolog", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+}
+
+func TestParseFileLaravelAlias(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "app.log")
+	os.WriteFile(path, []byte("[2024-01-01 00:00:00] local.INFO: test\n"), 0644)
+
+	entries, err := ParseFile(path, "laravel", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry with 'laravel' alias, got %d", len(entries))
+	}
+}
+
+func TestParseFileRaw(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "app.log")
+	os.WriteFile(path, []byte("line1\nline2\nline3\n"), 0644)
+
+	entries, err := ParseFile(path, "raw", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3, got %d", len(entries))
+	}
+}
+
+func TestParseFileUnknownFormatFallsBackToRaw(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "app.log")
+	os.WriteFile(path, []byte("some text\n"), 0644)
+
+	entries, err := ParseFile(path, "unknown_format", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 (raw fallback), got %d", len(entries))
+	}
+}
+
+func TestParseFileEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.log")
+	os.WriteFile(path, []byte(""), 0644)
+
+	entries, err := ParseFile(path, "monolog", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected 0, got %d", len(entries))
+	}
+}
+
+func TestParseFileNonExistent(t *testing.T) {
+	_, err := ParseFile("/nonexistent/path/file.log", "monolog", 100)
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+// ── readTail ─────────────────────────────────────────────────────────────────
+
+func TestReadTailSmallFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "small.log")
+	content := "line one\nline two\n"
+	os.WriteFile(path, []byte(content), 0644)
+
+	data, err := readTail(path, 1024*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != content {
+		t.Errorf("expected full content, got %q", string(data))
+	}
+}
+
+func TestReadTailTruncatesLargeFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.log")
+
+	var content strings.Builder
+	for i := 0; i < 1000; i++ {
+		fmt.Fprintf(&content, "[2024-01-01 00:00:00] local.INFO: line %d %s\n", i, strings.Repeat("x", 100))
+	}
+	os.WriteFile(path, []byte(content.String()), 0644)
+
+	data, err := readTail(path, 1024) // only read last 1KB
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if int64(len(data)) >= 1024 {
+		t.Errorf("expected data shorter than maxBytes after partial line discard, got %d", len(data))
+	}
+
+	// First line should be complete (partial line discarded)
+	lines := strings.SplitN(string(data), "\n", 2)
+	if len(lines) > 0 && lines[0] != "" {
+		if !strings.HasPrefix(lines[0], "[") {
+			t.Errorf("first line looks partial after truncation: %q", lines[0])
+		}
+	}
+}
+
+func TestReadTailEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.log")
+	os.WriteFile(path, []byte(""), 0644)
+
+	data, err := readTail(path, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data != nil {
+		t.Errorf("expected nil for empty file, got %q", string(data))
+	}
+}
+
+// ── DiscoverLogFiles ─────────────────────────────────────────────────────────
+
+func TestDiscoverLogFiles(t *testing.T) {
+	dir := t.TempDir()
+	logDir := filepath.Join(dir, "storage", "logs")
+	os.MkdirAll(logDir, 0755)
+
+	oldTime := time.Now().Add(-time.Hour)
+	os.WriteFile(filepath.Join(logDir, "laravel.log"), []byte("test"), 0644)
+	os.Chtimes(filepath.Join(logDir, "laravel.log"), oldTime, oldTime)
+	os.WriteFile(filepath.Join(logDir, "worker.log"), []byte("test2"), 0644)
+	// worker.log keeps the current time, laravel.log is 1 hour old
+
+	sources := []config.FrameworkLogSource{
+		{Path: "storage/logs/*.log", Format: "monolog"},
+	}
+
+	files, err := DiscoverLogFiles(dir, sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(files))
+	}
+	// Newest first
+	if files[0].Name != "worker.log" {
+		t.Errorf("expected worker.log first (newest), got %s", files[0].Name)
+	}
+}
+
+func TestDiscoverLogFilesMultipleSources(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "storage", "logs"), 0755)
+	os.MkdirAll(filepath.Join(dir, "var", "log"), 0755)
+	os.WriteFile(filepath.Join(dir, "storage", "logs", "app.log"), []byte("a"), 0644)
+	os.WriteFile(filepath.Join(dir, "var", "log", "debug.log"), []byte("b"), 0644)
+
+	sources := []config.FrameworkLogSource{
+		{Path: "storage/logs/*.log", Format: "monolog"},
+		{Path: "var/log/*.log", Format: "raw"},
+	}
+
+	files, err := DiscoverLogFiles(dir, sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files from 2 sources, got %d", len(files))
+	}
+}
+
+func TestDiscoverLogFilesDeduplicates(t *testing.T) {
+	dir := t.TempDir()
+	logDir := filepath.Join(dir, "logs")
+	os.MkdirAll(logDir, 0755)
+	os.WriteFile(filepath.Join(logDir, "app.log"), []byte("x"), 0644)
+
+	sources := []config.FrameworkLogSource{
+		{Path: "logs/*.log"},
+		{Path: "logs/app.log"}, // overlapping glob
+	}
+
+	files, err := DiscoverLogFiles(dir, sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file (deduplicated), got %d", len(files))
+	}
+}
+
+func TestDiscoverLogFilesPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	sources := []config.FrameworkLogSource{
+		{Path: "../../../etc/*.log"},
+	}
+
+	files, err := DiscoverLogFiles(dir, sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected 0 files for traversal attempt, got %d", len(files))
+	}
+}
+
+func TestDiscoverLogFilesNoMatches(t *testing.T) {
+	dir := t.TempDir()
+	sources := []config.FrameworkLogSource{
+		{Path: "nonexistent/*.log"},
+	}
+
+	files, err := DiscoverLogFiles(dir, sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected 0 files, got %d", len(files))
+	}
+}
+
+func TestDiscoverLogFilesSkipsDirectories(t *testing.T) {
+	dir := t.TempDir()
+	logDir := filepath.Join(dir, "logs")
+	os.MkdirAll(logDir, 0755)
+	os.WriteFile(filepath.Join(logDir, "app.log"), []byte("x"), 0644)
+	// Create a directory that matches the glob
+	os.MkdirAll(filepath.Join(logDir, "subdir.log"), 0755)
+
+	sources := []config.FrameworkLogSource{
+		{Path: "logs/*.log"},
+	}
+
+	files, err := DiscoverLogFiles(dir, sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file (directory skipped), got %d", len(files))
+	}
+}
+
+func TestDiscoverLogFilesReportsSize(t *testing.T) {
+	dir := t.TempDir()
+	logDir := filepath.Join(dir, "logs")
+	os.MkdirAll(logDir, 0755)
+	content := strings.Repeat("x", 42)
+	os.WriteFile(filepath.Join(logDir, "app.log"), []byte(content), 0644)
+
+	sources := []config.FrameworkLogSource{{Path: "logs/*.log"}}
+	files, err := DiscoverLogFiles(dir, sources)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatal("expected 1 file")
+	}
+	if files[0].Size != 42 {
+		t.Errorf("size = %d, want 42", files[0].Size)
+	}
+}
+
+func TestDiscoverLogFilesEmptySources(t *testing.T) {
+	dir := t.TempDir()
+	files, err := DiscoverLogFiles(dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected 0 for nil sources, got %d", len(files))
+	}
+}
+
+// ── ResolveLogFilePath ───────────────────────────────────────────────────────
+
+func TestResolveLogFilePath(t *testing.T) {
+	dir := t.TempDir()
+	logDir := filepath.Join(dir, "storage", "logs")
+	os.MkdirAll(logDir, 0755)
+	os.WriteFile(filepath.Join(logDir, "laravel.log"), []byte("test"), 0644)
+
+	sources := []config.FrameworkLogSource{
+		{Path: "storage/logs/*.log", Format: "monolog"},
+	}
+
+	path := ResolveLogFilePath(dir, sources, "laravel.log")
+	if path == "" {
+		t.Fatal("expected to resolve laravel.log")
+	}
+	if filepath.Base(path) != "laravel.log" {
+		t.Errorf("resolved to %q, expected laravel.log basename", path)
+	}
+}
+
+func TestResolveLogFilePathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	sources := []config.FrameworkLogSource{{Path: "logs/*.log"}}
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{"dotdot", "../etc/passwd"},
+		{"slash", "sub/file.log"},
+		{"backslash", "sub\\file.log"},
+		{"dotdot_only", ".."},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveLogFilePath(dir, sources, tc.filename); got != "" {
+				t.Errorf("expected empty for %q, got %q", tc.filename, got)
+			}
+		})
+	}
+}
+
+func TestResolveLogFilePathNotFound(t *testing.T) {
+	dir := t.TempDir()
+	logDir := filepath.Join(dir, "logs")
+	os.MkdirAll(logDir, 0755)
+	os.WriteFile(filepath.Join(logDir, "app.log"), []byte("x"), 0644)
+
+	sources := []config.FrameworkLogSource{{Path: "logs/*.log"}}
+
+	if got := ResolveLogFilePath(dir, sources, "nope.log"); got != "" {
+		t.Errorf("expected empty for nonexistent file, got %q", got)
+	}
+}
+
+func TestResolveLogFilePathMultipleSources(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "a"), 0755)
+	os.MkdirAll(filepath.Join(dir, "b"), 0755)
+	os.WriteFile(filepath.Join(dir, "b", "found.log"), []byte("x"), 0644)
+
+	sources := []config.FrameworkLogSource{
+		{Path: "a/*.log"},
+		{Path: "b/*.log"},
+	}
+
+	path := ResolveLogFilePath(dir, sources, "found.log")
+	if path == "" {
+		t.Fatal("expected to find file in second source")
+	}
+}
+
+// ── FormatForFile ────────────────────────────────────────────────────────────
+
+func TestFormatForFile(t *testing.T) {
+	sources := []config.FrameworkLogSource{
+		{Path: "storage/logs/*.log", Format: "monolog"},
+		{Path: "var/log/*.txt", Format: "raw"},
+	}
+
+	if f := FormatForFile(sources, "laravel.log"); f != "monolog" {
+		t.Errorf("expected monolog, got %s", f)
+	}
+	if f := FormatForFile(sources, "app.txt"); f != "raw" {
+		t.Errorf("expected raw, got %s", f)
+	}
+}
+
+func TestFormatForFileNoMatch(t *testing.T) {
+	sources := []config.FrameworkLogSource{
+		{Path: "logs/*.log", Format: "monolog"},
+	}
+	if f := FormatForFile(sources, "other.json"); f != "raw" {
+		t.Errorf("expected raw fallback for non-matching file, got %s", f)
+	}
+}
+
+func TestFormatForFileEmptyFormat(t *testing.T) {
+	sources := []config.FrameworkLogSource{
+		{Path: "logs/*.log"}, // no format set
+	}
+	if f := FormatForFile(sources, "app.log"); f != "raw" {
+		t.Errorf("expected raw when format is empty, got %s", f)
+	}
+}
+
+func TestFormatForFileEmptySources(t *testing.T) {
+	if f := FormatForFile(nil, "app.log"); f != "raw" {
+		t.Errorf("expected raw for nil sources, got %s", f)
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -26,6 +26,8 @@ type Framework struct {
 	// Create is the scaffold command used by "lerd new". The target directory is appended automatically.
 	// Example: "composer create-project --no-install --no-plugins --no-scripts laravel/laravel"
 	Create string `yaml:"create,omitempty"`
+	// Logs defines where application log files live for this framework.
+	Logs []FrameworkLogSource `yaml:"logs,omitempty"`
 }
 
 // FrameworkWorker describes a long-running process managed as a systemd service.
@@ -35,6 +37,12 @@ type FrameworkWorker struct {
 	Command string         `yaml:"command"`
 	Restart string         `yaml:"restart,omitempty"` // always | on-failure (default: always)
 	Check   *FrameworkRule `yaml:"check,omitempty"`   // only show when check passes (file exists or composer package installed)
+}
+
+// FrameworkLogSource describes where application log files live for a framework.
+type FrameworkLogSource struct {
+	Path   string `yaml:"path"`             // glob relative to project root, e.g. "storage/logs/*.log"
+	Format string `yaml:"format,omitempty"` // "monolog" | "raw" (default: "raw")
 }
 
 // FrameworkSetupCmd describes a one-off bootstrap command run during project setup.
@@ -159,6 +167,9 @@ var laravelFramework = &Framework{
 		{Label: "php artisan migrate", Command: "php artisan migrate", Default: true},
 		{Label: "php artisan db:seed", Command: "php artisan db:seed", Default: false},
 	},
+	Logs: []FrameworkLogSource{
+		{Path: "storage/logs/*.log", Format: "monolog"},
+	},
 }
 
 // GetFramework returns the framework definition for the given name.
@@ -188,6 +199,9 @@ func GetFramework(name string) (*Framework, bool) {
 				}
 				if userFw.Setup != nil {
 					merged.Setup = userFw.Setup
+				}
+				if userFw.Logs != nil {
+					merged.Logs = userFw.Logs
 				}
 			}
 		}
@@ -284,8 +298,8 @@ func SaveFramework(fw *Framework) error {
 	}
 	toSave := fw
 	if fw.Name == "laravel" {
-		// Only persist workers and setup — built-in handles everything else
-		toSave = &Framework{Name: fw.Name, Workers: fw.Workers, Setup: fw.Setup}
+		// Only persist workers, setup, and logs — built-in handles everything else
+		toSave = &Framework{Name: fw.Name, Workers: fw.Workers, Setup: fw.Setup, Logs: fw.Logs}
 	}
 	data, err := yaml.Marshal(toSave)
 	if err != nil {

--- a/internal/config/framework_test.go
+++ b/internal/config/framework_test.go
@@ -1,0 +1,267 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ── Logs field on built-in Laravel ───────────────────────────────────────────
+
+func TestLaravelBuiltinHasLogs(t *testing.T) {
+	if len(laravelFramework.Logs) == 0 {
+		t.Fatal("built-in Laravel should have Logs configured")
+	}
+	if laravelFramework.Logs[0].Path != "storage/logs/*.log" {
+		t.Errorf("expected storage/logs/*.log, got %s", laravelFramework.Logs[0].Path)
+	}
+	if laravelFramework.Logs[0].Format != "monolog" {
+		t.Errorf("expected monolog format, got %s", laravelFramework.Logs[0].Format)
+	}
+}
+
+func TestGetFrameworkLaravel_BuiltinLogs(t *testing.T) {
+	setConfigDir(t)
+
+	fw, ok := GetFramework("laravel")
+	if !ok {
+		t.Fatal("expected to find laravel framework")
+	}
+	if len(fw.Logs) == 0 {
+		t.Fatal("GetFramework(laravel) should include built-in Logs")
+	}
+	if fw.Logs[0].Format != "monolog" {
+		t.Errorf("expected monolog, got %s", fw.Logs[0].Format)
+	}
+}
+
+func TestGetFrameworkLaravel_UserOverridesLogs(t *testing.T) {
+	setConfigDir(t)
+
+	// Write a user laravel.yaml that overrides logs
+	dir := FrameworksDir()
+	os.MkdirAll(dir, 0755)
+
+	userFw := Framework{
+		Name: "laravel",
+		Logs: []FrameworkLogSource{
+			{Path: "storage/logs/*.log", Format: "monolog"},
+			{Path: "storage/logs/custom/*.log", Format: "monolog"},
+		},
+	}
+	data, _ := yaml.Marshal(userFw)
+	os.WriteFile(filepath.Join(dir, "laravel.yaml"), data, 0644)
+
+	fw, ok := GetFramework("laravel")
+	if !ok {
+		t.Fatal("expected to find laravel")
+	}
+	if len(fw.Logs) != 2 {
+		t.Fatalf("expected 2 log sources from user override, got %d", len(fw.Logs))
+	}
+	if fw.Logs[1].Path != "storage/logs/custom/*.log" {
+		t.Errorf("second log source path = %q", fw.Logs[1].Path)
+	}
+}
+
+func TestGetFrameworkLaravel_NoUserOverrideKeepsBuiltinLogs(t *testing.T) {
+	setConfigDir(t)
+
+	// Write a user laravel.yaml with only workers, no logs
+	dir := FrameworksDir()
+	os.MkdirAll(dir, 0755)
+
+	userFw := Framework{
+		Name: "laravel",
+		Workers: map[string]FrameworkWorker{
+			"horizon": {Label: "Horizon", Command: "php artisan horizon"},
+		},
+	}
+	data, _ := yaml.Marshal(userFw)
+	os.WriteFile(filepath.Join(dir, "laravel.yaml"), data, 0644)
+
+	fw, ok := GetFramework("laravel")
+	if !ok {
+		t.Fatal("expected to find laravel")
+	}
+	// Built-in logs should remain since user didn't override
+	if len(fw.Logs) != 1 {
+		t.Fatalf("expected 1 built-in log source, got %d", len(fw.Logs))
+	}
+	if fw.Logs[0].Path != "storage/logs/*.log" {
+		t.Errorf("expected built-in log path, got %s", fw.Logs[0].Path)
+	}
+}
+
+// ── Custom framework with Logs ───────────────────────────────────────────────
+
+func TestGetFrameworkCustom_WithLogs(t *testing.T) {
+	setConfigDir(t)
+
+	dir := FrameworksDir()
+	os.MkdirAll(dir, 0755)
+
+	fw := Framework{
+		Name:      "symfony",
+		Label:     "Symfony",
+		PublicDir: "public",
+		Detect:    []FrameworkRule{{File: "symfony.lock"}},
+		Logs: []FrameworkLogSource{
+			{Path: "var/log/*.log", Format: "raw"},
+		},
+	}
+	data, _ := yaml.Marshal(fw)
+	os.WriteFile(filepath.Join(dir, "symfony.yaml"), data, 0644)
+
+	got, ok := GetFramework("symfony")
+	if !ok {
+		t.Fatal("expected to find symfony")
+	}
+	if len(got.Logs) != 1 {
+		t.Fatalf("expected 1 log source, got %d", len(got.Logs))
+	}
+	if got.Logs[0].Path != "var/log/*.log" {
+		t.Errorf("log path = %q", got.Logs[0].Path)
+	}
+	if got.Logs[0].Format != "raw" {
+		t.Errorf("log format = %q", got.Logs[0].Format)
+	}
+}
+
+func TestGetFrameworkCustom_WithoutLogs(t *testing.T) {
+	setConfigDir(t)
+
+	dir := FrameworksDir()
+	os.MkdirAll(dir, 0755)
+
+	fw := Framework{
+		Name:      "wordpress",
+		Label:     "WordPress",
+		PublicDir: ".",
+		Detect:    []FrameworkRule{{File: "wp-login.php"}},
+	}
+	data, _ := yaml.Marshal(fw)
+	os.WriteFile(filepath.Join(dir, "wordpress.yaml"), data, 0644)
+
+	got, ok := GetFramework("wordpress")
+	if !ok {
+		t.Fatal("expected to find wordpress")
+	}
+	if len(got.Logs) != 0 {
+		t.Errorf("expected 0 log sources for wordpress, got %d", len(got.Logs))
+	}
+}
+
+// ── SaveFramework preserves Logs ─────────────────────────────────────────────
+
+func TestSaveFrameworkLaravel_PersistsLogs(t *testing.T) {
+	setConfigDir(t)
+
+	fw := &Framework{
+		Name: "laravel",
+		Workers: map[string]FrameworkWorker{
+			"horizon": {Label: "Horizon", Command: "php artisan horizon"},
+		},
+		Logs: []FrameworkLogSource{
+			{Path: "storage/logs/*.log", Format: "monolog"},
+			{Path: "storage/logs/jobs/*.log", Format: "monolog"},
+		},
+	}
+	if err := SaveFramework(fw); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read back raw YAML to verify logs are persisted
+	path := filepath.Join(FrameworksDir(), "laravel.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var saved Framework
+	if err := yaml.Unmarshal(data, &saved); err != nil {
+		t.Fatal(err)
+	}
+	if len(saved.Logs) != 2 {
+		t.Fatalf("expected 2 log sources saved, got %d", len(saved.Logs))
+	}
+}
+
+func TestSaveFrameworkCustom_PersistsLogs(t *testing.T) {
+	setConfigDir(t)
+
+	fw := &Framework{
+		Name:      "drupal",
+		Label:     "Drupal",
+		PublicDir: "web",
+		Logs: []FrameworkLogSource{
+			{Path: "sites/default/files/logs/*.log"},
+		},
+	}
+	if err := SaveFramework(fw); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := GetFramework("drupal")
+	if !ok {
+		t.Fatal("expected to find drupal after save")
+	}
+	if len(got.Logs) != 1 {
+		t.Fatalf("expected 1 log source, got %d", len(got.Logs))
+	}
+}
+
+// ── ListFrameworks includes Logs ─────────────────────────────────────────────
+
+func TestListFrameworks_IncludesLogs(t *testing.T) {
+	setConfigDir(t)
+
+	frameworks := ListFrameworks()
+	// At minimum the built-in Laravel
+	found := false
+	for _, fw := range frameworks {
+		if fw.Name == "laravel" {
+			found = true
+			if len(fw.Logs) == 0 {
+				t.Error("ListFrameworks: laravel should have Logs")
+			}
+		}
+	}
+	if !found {
+		t.Error("ListFrameworks should include laravel")
+	}
+}
+
+// ── FrameworkLogSource YAML round-trip ────────────────────────────────────────
+
+func TestFrameworkLogSource_YAMLRoundTrip(t *testing.T) {
+	original := []FrameworkLogSource{
+		{Path: "storage/logs/*.log", Format: "monolog"},
+		{Path: "var/log/*.log", Format: "raw"},
+		{Path: "logs/*.txt"}, // no format
+	}
+
+	data, err := yaml.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var loaded []FrameworkLogSource
+	if err := yaml.Unmarshal(data, &loaded); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(loaded) != 3 {
+		t.Fatalf("expected 3, got %d", len(loaded))
+	}
+	if loaded[0].Path != "storage/logs/*.log" || loaded[0].Format != "monolog" {
+		t.Errorf("entry 0: %+v", loaded[0])
+	}
+	if loaded[1].Format != "raw" {
+		t.Errorf("entry 1 format: %q", loaded[1].Format)
+	}
+	if loaded[2].Format != "" {
+		t.Errorf("entry 2 format should be empty, got %q", loaded[2].Format)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1089,6 +1089,10 @@ func toolList() []mcpTool {
 						Type:        "array",
 						Description: `List of one-off setup commands shown in "lerd setup" wizard. Each element is an object with "label" (string), "command" (string), optional "default" (boolean, pre-selected in wizard), and optional "check" (object with "file" or "composer" field — command is only shown when the check passes). e.g. [{"label": "Load fixtures", "command": "php bin/console doctrine:fixtures:load", "check": {"composer": "doctrine/doctrine-fixtures-bundle"}}]`,
 					},
+					"logs": {
+						Type:        "array",
+						Description: `List of log source definitions for the app log viewer. Each element is an object with "path" (glob relative to project root, e.g. "storage/logs/*.log") and optional "format" ("monolog" for Monolog format, "raw" for plain text; default: "raw"). e.g. [{"path": "storage/logs/*.log", "format": "monolog"}]`,
+					},
 				},
 				Required: []string{"name"},
 			},
@@ -3000,6 +3004,10 @@ func execFrameworkList() (any, *rpcError) {
 		Default bool       `json:"default,omitempty"`
 		Check   *checkInfo `json:"check,omitempty"`
 	}
+	type logSourceInfo struct {
+		Path   string `json:"path"`
+		Format string `json:"format,omitempty"`
+	}
 	type frameworkInfo struct {
 		Name      string                `json:"name"`
 		Label     string                `json:"label"`
@@ -3009,6 +3017,7 @@ func execFrameworkList() (any, *rpcError) {
 		BuiltIn   bool                  `json:"built_in"`
 		Workers   map[string]workerInfo `json:"workers,omitempty"`
 		Setup     []setupInfo           `json:"setup,omitempty"`
+		Logs      []logSourceInfo       `json:"logs,omitempty"`
 	}
 	var result []frameworkInfo
 	for _, fw := range frameworks {
@@ -3046,6 +3055,10 @@ func execFrameworkList() (any, *rpcError) {
 			}
 			setup = append(setup, si)
 		}
+		var logSources []logSourceInfo
+		for _, ls := range merged.Logs {
+			logSources = append(logSources, logSourceInfo{Path: ls.Path, Format: ls.Format})
+		}
 		result = append(result, frameworkInfo{
 			Name:      merged.Name,
 			Label:     merged.Label,
@@ -3055,6 +3068,7 @@ func execFrameworkList() (any, *rpcError) {
 			BuiltIn:   merged.Name == "laravel",
 			Workers:   workers,
 			Setup:     setup,
+			Logs:      logSources,
 		})
 	}
 	if result == nil {
@@ -3121,12 +3135,28 @@ func execFrameworkAdd(args map[string]any) (any, *rpcError) {
 		}
 	}
 
-	if name == "laravel" {
-		// For Laravel, only persist custom workers and setup (built-in handles everything else)
-		if len(workers) == 0 && len(setup) == 0 {
-			return toolErr("workers or setup is required when customising laravel"), nil
+	// Parse logs sources if provided
+	var logs []config.FrameworkLogSource
+	if raw, ok := args["logs"]; ok {
+		if arr, ok := raw.([]any); ok {
+			for _, item := range arr {
+				if obj, ok := item.(map[string]any); ok {
+					path, _ := obj["path"].(string)
+					format, _ := obj["format"].(string)
+					if path != "" {
+						logs = append(logs, config.FrameworkLogSource{Path: path, Format: format})
+					}
+				}
+			}
 		}
-		fw := &config.Framework{Name: "laravel", Workers: workers, Setup: setup}
+	}
+
+	if name == "laravel" {
+		// For Laravel, only persist custom workers, setup, and logs (built-in handles everything else)
+		if len(workers) == 0 && len(setup) == 0 && len(logs) == 0 {
+			return toolErr("workers, setup, or logs is required when customising laravel"), nil
+		}
+		fw := &config.Framework{Name: "laravel", Workers: workers, Setup: setup, Logs: logs}
 		if err := config.SaveFramework(fw); err != nil {
 			return toolErr(fmt.Sprintf("saving framework: %v", err)), nil
 		}
@@ -3161,6 +3191,7 @@ func execFrameworkAdd(args map[string]any) (any, *rpcError) {
 		NPM:       "auto",
 		Workers:   workers,
 		Setup:     setup,
+		Logs:      logs,
 	}
 	if fw.PublicDir == "" {
 		fw.PublicDir = "public"

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -602,7 +602,7 @@
                   <select
                     x-model="selectedSite.php_version"
                     @change="setSiteVersion(selectedSite, 'php', selectedSite.php_version)"
-                    class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors"
+                    class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors [&>option]:bg-white [&>option]:dark:bg-lerd-card [&>option]:text-gray-900 [&>option]:dark:text-gray-200"
                     :disabled="selectedSite.versionLoading"
                   >
                     <option value="" disabled>— PHP —</option>
@@ -613,7 +613,7 @@
                   <select
                     x-model="selectedSite.node_version"
                     @change="setSiteVersion(selectedSite, 'node', selectedSite.node_version)"
-                    class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors"
+                    class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors [&>option]:bg-white [&>option]:dark:bg-lerd-card [&>option]:text-gray-900 [&>option]:dark:text-gray-200"
                     :disabled="selectedSite.versionLoading"
                   >
                     <option value="">Node default</option>
@@ -755,6 +755,9 @@
               <!-- Logs -->
               <div class="flex-1 flex flex-col overflow-hidden min-h-0">
                 <div class="flex items-center gap-0 border-b border-gray-100 dark:border-lerd-border px-3 sm:px-5 pt-3 shrink-0">
+                  <template x-if="selectedSite && selectedSite.has_app_logs">
+                    <button @click="setSiteLogsTab('app')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='app' ? 'border-orange-500 text-orange-600 dark:text-orange-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'">App Logs</button>
+                  </template>
                   <button @click="setSiteLogsTab('fpm')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='fpm' ? 'border-lerd-red text-lerd-red' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'">PHP-FPM</button>
                   <template x-if="selectedSite && (selectedSite.queue_running || selectedSite.queue_failing)">
                     <button @click="setSiteLogsTab('queue')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='queue' ? 'border-amber-500 text-amber-600 dark:text-amber-400' : selectedSite.queue_failing ? 'border-transparent text-red-500' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'" x-text="selectedSite.queue_failing ? 'Queue !' : 'Queue'"></button>
@@ -859,6 +862,68 @@
                   <div x-ref="siteWorkerLogScroll" class="flex-1 overflow-y-auto bg-gray-50 dark:bg-lerd-bg px-4 py-3 font-mono text-[11px] leading-relaxed space-y-0.5">
                     <template x-if="siteWorkerLogs.lines.length === 0"><div class="text-gray-400 dark:text-gray-700 italic">Waiting for log output...</div></template>
                     <template x-for="(line, i) in siteWorkerLogs.lines" :key="i"><div class="whitespace-pre-wrap break-all text-gray-600 dark:text-gray-400" x-text="line"></div></template>
+                  </div>
+                </div>
+
+                <!-- App Logs (application log files) -->
+                <div x-show="siteLogsTab === 'app'" class="flex-1 flex flex-col overflow-hidden min-h-0">
+                  <div class="flex items-center gap-2 px-3 sm:px-5 py-2 shrink-0 border-b border-gray-100 dark:border-lerd-border">
+                    <select x-model="appLogs.selectedFile" @change="loadAppLogEntries()"
+                      class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-orange-500/50 cursor-pointer transition-colors [&>option]:bg-white [&>option]:dark:bg-lerd-card [&>option]:text-gray-900 [&>option]:dark:text-gray-200">
+                      <template x-for="f in appLogs.files" :key="f.name">
+                        <option :value="f.name" x-text="f.name"></option>
+                      </template>
+                    </select>
+                    <div class="flex items-center rounded border border-gray-200 dark:border-lerd-border overflow-hidden shrink-0">
+                      <button @click="appLogs.showAll = false; loadAppLogEntries()"
+                        class="text-[11px] px-2 py-1 transition-colors"
+                        :class="!appLogs.showAll ? 'bg-orange-500 text-white' : 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-white/5'">Latest</button>
+                      <button @click="appLogs.showAll = true; loadAppLogEntries()"
+                        class="text-[11px] px-2 py-1 transition-colors border-l border-gray-200 dark:border-lerd-border"
+                        :class="appLogs.showAll ? 'bg-orange-500 text-white' : 'text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-white/5'">All</button>
+                    </div>
+                    <div class="relative flex-1 max-w-xs">
+                      <svg class="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
+                      <input type="text" x-model="appLogs.search" placeholder="Search logs..."
+                        class="w-full text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded pl-7 pr-2 py-1 text-gray-700 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-600 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-orange-500/50 transition-colors">
+                    </div>
+                    <button @click="loadAppLogEntries()"
+                      class="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 border border-gray-200 dark:border-lerd-border hover:border-gray-300 dark:hover:border-lerd-muted rounded px-2 py-1 transition-colors">
+                      <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
+                      Refresh
+                    </button>
+                    <svg x-show="appLogs.loading" class="animate-spin w-3.5 h-3.5 text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                  </div>
+                  <div class="flex-1 overflow-y-auto">
+                    <template x-if="appLogs.entries.length === 0 && !appLogs.loading">
+                      <div class="text-gray-400 dark:text-gray-600 italic text-xs p-4">No log entries found.</div>
+                    </template>
+                    <template x-for="(entry, i) in appLogs.entries.filter(e => !appLogs.search || (e.message && e.message.toLowerCase().includes(appLogs.search.toLowerCase())) || (e.level && e.level.toLowerCase().includes(appLogs.search.toLowerCase())) || (e.detail && e.detail.toLowerCase().includes(appLogs.search.toLowerCase())) || (e.date && e.date.includes(appLogs.search)))" :key="i">
+                      <div class="border-b border-gray-100 dark:border-lerd-border/50">
+                        <button @click="appLogs.expandedIdx = appLogs.expandedIdx === i ? -1 : i"
+                          class="w-full flex items-center gap-3 px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-white/[0.03] transition-colors">
+                          <span class="shrink-0 text-[10px] font-bold uppercase px-1.5 py-0.5 rounded leading-tight"
+                            :class="{
+                              'bg-red-100 dark:bg-red-500/10 text-red-600 dark:text-red-400': ['ERROR','CRITICAL','EMERGENCY','ALERT'].includes(entry.level),
+                              'bg-yellow-100 dark:bg-yellow-500/10 text-yellow-700 dark:text-yellow-400': entry.level === 'WARNING',
+                              'bg-blue-100 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400': ['INFO','NOTICE'].includes(entry.level),
+                              'bg-gray-100 dark:bg-white/5 text-gray-500 dark:text-gray-400': !['ERROR','CRITICAL','EMERGENCY','ALERT','WARNING','INFO','NOTICE'].includes(entry.level)
+                            }"
+                            x-text="entry.level || 'LOG'"></span>
+                          <span class="shrink-0 text-[11px] text-gray-400 font-mono w-[135px]" x-text="entry.date"></span>
+                          <span class="text-xs text-gray-700 dark:text-gray-300 truncate flex-1" x-text="entry.message"></span>
+                          <svg class="w-3 h-3 shrink-0 ml-auto text-gray-400 transition-transform duration-150"
+                            :class="appLogs.expandedIdx === i ? 'rotate-180' : ''"
+                            fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+                          </svg>
+                        </button>
+                        <div x-show="appLogs.expandedIdx === i" x-collapse
+                          class="px-4 py-3 bg-gray-50 dark:bg-lerd-bg border-t border-gray-100 dark:border-lerd-border/30 font-mono text-[11px] text-gray-600 dark:text-gray-400 whitespace-pre-wrap break-all max-h-80 overflow-y-auto leading-relaxed"
+                          x-text="entry.detail || entry.message">
+                        </div>
+                      </div>
+                    </template>
                   </div>
                 </div>
 
@@ -1609,6 +1674,7 @@ function lerdApp() {
       _source: null,
     },
     siteLogsTab: 'fpm',
+    appLogs: { files: [], selectedFile: '', entries: [], loading: false, expandedIdx: -1, search: '', showAll: false },
 
     applyTheme(t) {
       const isDark = t === 'dark' || (t === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches);
@@ -1730,6 +1796,8 @@ function lerdApp() {
               e.has_horizon = s.has_horizon;
               e.has_queue_worker = s.has_queue_worker;
               e.has_schedule_worker = s.has_schedule_worker;
+              e.has_app_logs = s.has_app_logs;
+              e.latest_log_time = s.latest_log_time;
               e.branch = s.branch;
               e.paused = s.paused;
               if (s.framework_workers) {
@@ -1753,13 +1821,23 @@ function lerdApp() {
       } catch (_) {
         if (firstLoad) this.sites = [];
       } finally {
-        if (firstLoad) this.sitesLoading = false;
+        if (firstLoad) {
+          this.sitesLoading = false;
+          // Auto-select site with the most recent app log activity
+          if (!this.selectedSiteDomain) {
+            const withLogs = this.sites.filter(s => s.has_app_logs && s.latest_log_time);
+            if (withLogs.length > 0) {
+              withLogs.sort((a, b) => b.latest_log_time.localeCompare(a.latest_log_time));
+              this.selectSite(withLogs[0]);
+            }
+          }
+        }
       }
     },
 
     selectSite(site) {
       this.selectedSiteDomain = site.domain;
-      this.siteLogsTab = 'fpm';
+      this.siteLogsTab = site.has_app_logs ? 'app' : 'fpm';
       this.mobileShowDetail = true;
       this.closeSiteQueueLogs();
       this.closeSiteHorizonLogs();
@@ -1767,6 +1845,11 @@ function lerdApp() {
       this.closeSiteScheduleLogs();
       this.closeSiteReverbLogs();
       this.closeSiteWorkerLogs();
+      this.stopAppLogPolling();
+      this.appLogs = { files: [], selectedFile: '', entries: [], loading: false, expandedIdx: -1, search: '', showAll: false };
+      if (site.has_app_logs) {
+        this.loadAppLogFiles(site);
+      }
       this.openSiteLogs(site);
     },
 
@@ -1927,6 +2010,58 @@ function lerdApp() {
       this.siteWorkerLogs.connected = false;
     },
 
+    async loadAppLogFiles(site) {
+      if (!site) site = this.selectedSite;
+      if (!site) return;
+      this.appLogs.loading = true;
+      try {
+        const res = await fetch(`/api/app-logs/${site.domain}`);
+        const data = await res.json();
+        this.appLogs.files = data.files || [];
+        if (this.appLogs.files.length > 0) {
+          // Always select the most recently modified file
+          this.appLogs.selectedFile = this.appLogs.files[0].name;
+        }
+        if (this.appLogs.selectedFile) {
+          await this.loadAppLogEntries();
+        } else {
+          this.appLogs.loading = false;
+        }
+      } catch (e) {
+        this.appLogs.loading = false;
+      }
+      this.startAppLogPolling();
+    },
+
+    async loadAppLogEntries() {
+      const site = this.selectedSite;
+      if (!site || !this.appLogs.selectedFile) return;
+      this.appLogs.loading = true;
+      try {
+        const limit = this.appLogs.showAll ? 0 : 100;
+        const res = await fetch(`/api/app-logs/${site.domain}/${this.appLogs.selectedFile}?limit=${limit}`);
+        const data = await res.json();
+        this.appLogs.entries = data.entries || [];
+      } catch (e) {
+        this.appLogs.entries = [];
+      } finally {
+        this.appLogs.loading = false;
+      }
+    },
+
+    startAppLogPolling() {
+      this.stopAppLogPolling();
+      this._appLogInterval = setInterval(() => {
+        if (this.siteLogsTab === 'app' && this.selectedSite && this.appLogs.selectedFile && !this.appLogs.loading) {
+          this.loadAppLogEntries();
+        }
+      }, 5000);
+    },
+
+    stopAppLogPolling() {
+      if (this._appLogInterval) { clearInterval(this._appLogInterval); this._appLogInterval = null; }
+    },
+
     setSiteLogsTab(tab) {
       this.siteLogsTab = tab;
       const site = this.selectedSite;
@@ -1937,6 +2072,7 @@ function lerdApp() {
       if (tab === 'schedule') this.openSiteScheduleLogs(site);
       if (tab === 'reverb') this.openSiteReverbLogs(site);
       if (tab.startsWith('worker:')) this.openSiteWorkerLogs(site, tab.slice(7));
+      if (tab === 'app') this.loadAppLogFiles(site);
     },
 
     async loadPHPVersions() {

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -894,13 +894,13 @@
                     </button>
                     <svg x-show="appLogs.loading" class="animate-spin w-3.5 h-3.5 text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
                   </div>
-                  <div class="flex-1 overflow-y-auto">
+                  <div x-ref="appLogScroll" class="flex-1 overflow-y-auto">
                     <template x-if="appLogs.entries.length === 0 && !appLogs.loading">
                       <div class="text-gray-400 dark:text-gray-600 italic text-xs p-4">No log entries found.</div>
                     </template>
-                    <template x-for="(entry, i) in appLogs.entries.filter(e => !appLogs.search || (e.message && e.message.toLowerCase().includes(appLogs.search.toLowerCase())) || (e.level && e.level.toLowerCase().includes(appLogs.search.toLowerCase())) || (e.detail && e.detail.toLowerCase().includes(appLogs.search.toLowerCase())) || (e.date && e.date.includes(appLogs.search)))" :key="i">
+                    <template x-for="(entry, i) in appLogs.entries.filter(e => !appLogs.search || (e.message && e.message.toLowerCase().includes(appLogs.search.toLowerCase())) || (e.level && e.level.toLowerCase().includes(appLogs.search.toLowerCase())) || (e.detail && e.detail.toLowerCase().includes(appLogs.search.toLowerCase())) || (e.date && e.date.includes(appLogs.search))).slice().reverse()" :key="i">
                       <div class="border-b border-gray-100 dark:border-lerd-border/50">
-                        <button @click="appLogs.expandedIdx = appLogs.expandedIdx === i ? -1 : i"
+                        <button @click="toggleAppLogEntry(i, $event)"
                           class="w-full flex items-center gap-3 px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-white/[0.03] transition-colors">
                           <span class="shrink-0 text-[10px] font-bold uppercase px-1.5 py-0.5 rounded leading-tight"
                             :class="{
@@ -2047,6 +2047,27 @@ function lerdApp() {
       } finally {
         this.appLogs.loading = false;
       }
+      // Match container/queue/etc. log panes: oldest at top, newest at bottom,
+      // pinned to the bottom on every update.
+      this.$nextTick(() => {
+        const el = this.$refs.appLogScroll;
+        if (el) el.scrollTop = el.scrollHeight;
+      });
+    },
+
+    toggleAppLogEntry(i, ev) {
+      const wasExpanded = this.appLogs.expandedIdx === i;
+      this.appLogs.expandedIdx = wasExpanded ? -1 : i;
+      if (wasExpanded) return;
+      // Wait for x-collapse to finish animating, then scroll the row (header
+      // + expanded detail) fully into view. Without this, expanding the
+      // bottom-most entry leaves the detail panel below the viewport.
+      const row = ev && ev.currentTarget ? ev.currentTarget.parentElement : null;
+      if (!row) return;
+      setTimeout(() => {
+        if (this.appLogs.expandedIdx !== i) return;
+        row.scrollIntoView({ block: 'end', behavior: 'smooth' });
+      }, 220);
     },
 
     startAppLogPolling() {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -17,6 +17,7 @@ import (
 	_ "embed"
 
 	"github.com/geodro/lerd/internal/certs"
+	"github.com/geodro/lerd/internal/applog"
 	"github.com/geodro/lerd/internal/cli"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
@@ -132,6 +133,7 @@ func Start(currentVersion string) error {
 	mux.HandleFunc("/api/schedule/", withCORS(handleScheduleLogs))
 	mux.HandleFunc("/api/reverb/", withCORS(handleReverbLogs))
 	mux.HandleFunc("/api/worker/", withCORS(handleWorkerLogs))
+	mux.HandleFunc("/api/app-logs/", withCORS(handleAppLogs))
 	mux.HandleFunc("/api/watcher/logs", withCORS(handleWatcherLogs))
 	mux.HandleFunc("/api/watcher/start", withCORS(handleWatcherStart))
 	mux.HandleFunc("/api/settings", withCORS(handleSettings))
@@ -351,6 +353,8 @@ type SiteResponse struct {
 	HasQueueWorker    bool               `json:"has_queue_worker"`
 	HasScheduleWorker bool               `json:"has_schedule_worker"`
 	FrameworkWorkers  []WorkerStatus     `json:"framework_workers,omitempty"`
+	HasAppLogs        bool               `json:"has_app_logs"`
+	LatestLogTime     string             `json:"latest_log_time,omitempty"`
 	Paused            bool               `json:"paused"`
 	Branch            string             `json:"branch"`
 	Worktrees         []WorktreeResponse `json:"worktrees"`
@@ -520,6 +524,8 @@ func handleSites(w http.ResponseWriter, _ *http.Request) {
 			HasQueueWorker:    hasQueueWorker,
 			HasScheduleWorker: hasScheduleWorker,
 			FrameworkWorkers:  fwWorkers,
+			HasAppLogs:        hasFw && len(fw.Logs) > 0,
+			LatestLogTime:     latestLogTime(hasFw, fw, s.Path),
 			Paused:            s.Paused,
 			Branch:            mainBranch,
 			Worktrees:         worktreeResponses,
@@ -1986,6 +1992,95 @@ func handleWatcherStart(w http.ResponseWriter, r *http.Request) {
 
 func handleWatcherLogs(w http.ResponseWriter, r *http.Request) {
 	streamUnitLogs(w, r, "lerd-watcher")
+}
+
+// latestLogTime returns the ISO 8601 timestamp of the most recently modified
+// log file for a site, or empty string if no log files exist.
+func latestLogTime(hasFw bool, fw *config.Framework, projectPath string) string {
+	if !hasFw || len(fw.Logs) == 0 {
+		return ""
+	}
+	t := applog.LatestModTime(projectPath, fw.Logs)
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+// handleAppLogs serves application-level log files (e.g. Laravel's storage/logs/*.log).
+//
+//	GET /api/app-logs/{domain}            → list available log files
+//	GET /api/app-logs/{domain}/{filename} → parsed log entries
+func handleAppLogs(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/app-logs/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	domain := parts[0]
+	site, err := config.FindSiteByDomain(domain)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	fwName := site.Framework
+	if fwName == "" {
+		fwName, _ = config.DetectFramework(site.Path)
+	}
+	fw, hasFw := config.GetFramework(fwName)
+	if !hasFw || len(fw.Logs) == 0 {
+		writeJSON(w, map[string]any{"files": []any{}, "entries": []any{}})
+		return
+	}
+
+	if len(parts) == 1 {
+		// List available log files
+		files, _ := applog.DiscoverLogFiles(site.Path, fw.Logs)
+		if files == nil {
+			files = []applog.LogFile{}
+		}
+		writeJSON(w, map[string]any{"files": files})
+		return
+	}
+
+	// Parse entries for a specific file
+	filename := parts[1]
+	// Validate filename: only safe characters
+	for _, c := range filename {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-') {
+			http.NotFound(w, r)
+			return
+		}
+	}
+
+	fullPath := applog.ResolveLogFilePath(site.Path, fw.Logs, filename)
+	if fullPath == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	maxEntries := 100
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if n, err := fmt.Sscanf(limitStr, "%d", &maxEntries); err != nil || n != 1 {
+			maxEntries = 100
+		}
+		if maxEntries <= 0 {
+			maxEntries = 0 // 0 means unlimited
+		}
+	}
+
+	format := applog.FormatForFile(fw.Logs, filename)
+	entries, err := applog.ParseFile(fullPath, format, maxEntries)
+	if err != nil {
+		writeJSON(w, map[string]any{"entries": []any{}, "error": err.Error()})
+		return
+	}
+	if entries == nil {
+		entries = []applog.LogEntry{}
+	}
+	writeJSON(w, map[string]any{"entries": entries})
 }
 
 func streamUnitLogs(w http.ResponseWriter, r *http.Request, unit string) {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -16,8 +16,8 @@ import (
 
 	_ "embed"
 
-	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/applog"
+	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/cli"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"


### PR DESCRIPTION
## Summary

- Adds an App Logs tab to the site detail view that parses and displays application log files in a structured table with level, date, and message columns, expandable to show full stacktraces
- Adds a `logs` field to the Framework struct so any framework can define log file locations via YAML, Laravel defaults to `storage/logs/*.log` with Monolog parsing
- Auto-selects the site with the most recent log activity on page load, auto-refreshes every 5 seconds, includes search filtering and a Latest/All toggle
- Fixes dark mode dropdown readability for PHP and Node version selectors