### PR TITLE
feat: show site favicons in UI

### DIFF
--- a/internal/ui/favicon_test.go
+++ b/internal/ui/favicon_test.go
@@ -1,0 +1,80 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectFavicon(t *testing.T) {
+	t.Run("finds favicon.ico in public dir", func(t *testing.T) {
+		dir := t.TempDir()
+		pub := filepath.Join(dir, "public")
+		os.MkdirAll(pub, 0755)
+		os.WriteFile(filepath.Join(pub, "index.php"), []byte("<?php"), 0644)
+		os.WriteFile(filepath.Join(pub, "favicon.ico"), []byte("icon"), 0644)
+
+		got := detectFavicon(dir, "public")
+		if got != filepath.Join(pub, "favicon.ico") {
+			t.Errorf("got %q, want %q", got, filepath.Join(pub, "favicon.ico"))
+		}
+	})
+
+	t.Run("finds favicon.svg over ico when ico missing", func(t *testing.T) {
+		dir := t.TempDir()
+		pub := filepath.Join(dir, "public")
+		os.MkdirAll(pub, 0755)
+		os.WriteFile(filepath.Join(pub, "favicon.svg"), []byte("<svg/>"), 0644)
+
+		got := detectFavicon(dir, "public")
+		if got != filepath.Join(pub, "favicon.svg") {
+			t.Errorf("got %q, want %q", got, filepath.Join(pub, "favicon.svg"))
+		}
+	})
+
+	t.Run("prefers ico over svg", func(t *testing.T) {
+		dir := t.TempDir()
+		pub := filepath.Join(dir, "public")
+		os.MkdirAll(pub, 0755)
+		os.WriteFile(filepath.Join(pub, "favicon.ico"), []byte("icon"), 0644)
+		os.WriteFile(filepath.Join(pub, "favicon.svg"), []byte("<svg/>"), 0644)
+
+		got := detectFavicon(dir, "public")
+		if got != filepath.Join(pub, "favicon.ico") {
+			t.Errorf("got %q, want %q", got, filepath.Join(pub, "favicon.ico"))
+		}
+	})
+
+	t.Run("returns empty when no favicon exists", func(t *testing.T) {
+		dir := t.TempDir()
+		os.MkdirAll(filepath.Join(dir, "public"), 0755)
+
+		got := detectFavicon(dir, "public")
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("uses project root when publicDir is dot", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "favicon.png"), []byte("png"), 0644)
+
+		got := detectFavicon(dir, ".")
+		if got != filepath.Join(dir, "favicon.png") {
+			t.Errorf("got %q, want %q", got, filepath.Join(dir, "favicon.png"))
+		}
+	})
+
+	t.Run("auto-detects public dir when empty", func(t *testing.T) {
+		dir := t.TempDir()
+		pub := filepath.Join(dir, "public")
+		os.MkdirAll(pub, 0755)
+		os.WriteFile(filepath.Join(pub, "index.php"), []byte("<?php"), 0644)
+		os.WriteFile(filepath.Join(pub, "favicon.ico"), []byte("icon"), 0644)
+
+		got := detectFavicon(dir, "")
+		if got != filepath.Join(pub, "favicon.ico") {
+			t.Errorf("got %q, want %q", got, filepath.Join(pub, "favicon.ico"))
+		}
+	})
+}

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -149,7 +149,14 @@
           <button @click="selectSite(site)"
             class="w-full flex items-center gap-2 px-3 py-2.5 text-left transition-colors border-b border-gray-50 dark:border-lerd-border/50 last:border-0"
             :class="selectedSiteDomain===site.domain ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
-            <span class="w-2 h-2 rounded-full shrink-0" :class="site.fpm_running ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+            <span class="relative shrink-0 w-4 h-4 flex items-center justify-center">
+              <template x-if="site.has_favicon">
+                <img :src="'/api/sites/' + site.domain + '/favicon'" class="w-4 h-4 rounded-sm object-contain" loading="lazy" @error="site.has_favicon = false">
+              </template>
+              <template x-if="!site.has_favicon">
+                <span class="w-2 h-2 rounded-full" :class="site.fpm_running ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+              </template>
+            </span>
             <span class="flex-1 text-sm truncate" x-text="site.domain"></span>
             <svg x-show="site.tls" class="w-3 h-3 shrink-0 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
             <svg x-show="site.worktrees && site.worktrees.length > 0" class="w-3 h-3 shrink-0 text-violet-400" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M6 3v12M15 6a3 3 0 1 0 6 0a3 3 0 1 0-6 0M3 18a3 3 0 1 0 6 0a3 3 0 1 0-6 0M18 9a9 9 0 0 1-9 9"/></svg>
@@ -502,6 +509,9 @@
                 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4">
                   <div>
                     <div class="flex items-center gap-2 flex-wrap">
+                      <template x-if="selectedSite.has_favicon">
+                        <img :src="'/api/sites/' + selectedSite.domain + '/favicon'" class="w-5 h-5 rounded-sm object-contain" loading="lazy" @error="selectedSite.has_favicon = false">
+                      </template>
                       <a
                         :href="(selectedSite.tls ? 'https://' : 'http://') + selectedSite.domain"
                         @click.prevent="openSite(selectedSite)"
@@ -599,28 +609,38 @@
 
                 <!-- Version selects + toggles row -->
                 <div class="flex items-center gap-4 overflow-x-auto">
-                  <select
-                    x-model="selectedSite.php_version"
-                    @change="setSiteVersion(selectedSite, 'php', selectedSite.php_version)"
-                    class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors"
-                    :disabled="selectedSite.versionLoading"
-                  >
-                    <option value="" disabled>— PHP —</option>
-                    <template x-for="v in phpVersions" :key="v">
-                      <option :value="v" x-text="'PHP ' + v"></option>
-                    </template>
-                  </select>
-                  <select
-                    x-model="selectedSite.node_version"
-                    @change="setSiteVersion(selectedSite, 'node', selectedSite.node_version)"
-                    class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors"
-                    :disabled="selectedSite.versionLoading"
-                  >
-                    <option value="">Node default</option>
-                    <template x-for="v in nodeVersions" :key="v">
-                      <option :value="v" x-text="'Node ' + v"></option>
-                    </template>
-                  </select>
+                  <template x-if="phpVersions.length === 0">
+                    <span class="text-xs text-gray-400 border border-gray-200 dark:border-lerd-border rounded px-2 py-1 opacity-50">PHP ...</span>
+                  </template>
+                  <template x-if="phpVersions.length > 0">
+                    <select
+                      x-model="selectedSite.php_version"
+                      @change="setSiteVersion(selectedSite, 'php', selectedSite.php_version)"
+                      class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors"
+                      :disabled="selectedSite.versionLoading"
+                    >
+                      <option value="" disabled>— PHP —</option>
+                      <template x-for="v in phpVersions" :key="v">
+                        <option :value="v" x-text="'PHP ' + v"></option>
+                      </template>
+                    </select>
+                  </template>
+                  <template x-if="nodeVersions.length === 0">
+                    <span class="text-xs text-gray-400 border border-gray-200 dark:border-lerd-border rounded px-2 py-1 opacity-50">Node ...</span>
+                  </template>
+                  <template x-if="nodeVersions.length > 0">
+                    <select
+                      x-model="selectedSite.node_version"
+                      @change="setSiteVersion(selectedSite, 'node', selectedSite.node_version)"
+                      class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors"
+                      :disabled="selectedSite.versionLoading"
+                    >
+                      <option value="">Node default</option>
+                      <template x-for="v in nodeVersions" :key="v">
+                        <option :value="v" x-text="'Node ' + v"></option>
+                      </template>
+                    </select>
+                  </template>
 
                   <!-- HTTPS -->
                   <div class="flex items-center gap-1.5">

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -351,6 +351,7 @@ type SiteResponse struct {
 	HasQueueWorker    bool               `json:"has_queue_worker"`
 	HasScheduleWorker bool               `json:"has_schedule_worker"`
 	FrameworkWorkers  []WorkerStatus     `json:"framework_workers,omitempty"`
+	HasFavicon        bool               `json:"has_favicon"`
 	Paused            bool               `json:"paused"`
 	Branch            string             `json:"branch"`
 	Worktrees         []WorktreeResponse `json:"worktrees"`
@@ -520,6 +521,7 @@ func handleSites(w http.ResponseWriter, _ *http.Request) {
 			HasQueueWorker:    hasQueueWorker,
 			HasScheduleWorker: hasScheduleWorker,
 			FrameworkWorkers:  fwWorkers,
+			HasFavicon:        detectFavicon(s.Path, s.PublicDir) != "",
 			Paused:            s.Paused,
 			Branch:            mainBranch,
 			Worktrees:         worktreeResponses,
@@ -1183,6 +1185,53 @@ func handleNodeVersions(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, versions)
 }
 
+// faviconCandidates lists file names to probe when looking for a site's favicon.
+var faviconCandidates = []string{
+	"favicon.ico",
+	"favicon.svg",
+	"favicon.png",
+}
+
+// detectFavicon returns the absolute path of the first favicon file found in
+// the site's public directory (or project root when publicDir is "." or empty).
+// Returns "" when no favicon is found.
+func detectFavicon(sitePath, publicDir string) string {
+	if publicDir == "" {
+		publicDir = config.DetectPublicDir(sitePath)
+	}
+	base := sitePath
+	if publicDir != "." {
+		base = filepath.Join(sitePath, publicDir)
+	}
+	for _, name := range faviconCandidates {
+		p := filepath.Join(base, name)
+		if info, err := os.Stat(p); err == nil && !info.IsDir() {
+			return p
+		}
+	}
+	return ""
+}
+
+func handleSiteFavicon(w http.ResponseWriter, r *http.Request) {
+	// path: /api/sites/{domain}/favicon
+	domain := strings.TrimPrefix(r.URL.Path, "/api/sites/")
+	domain = strings.TrimSuffix(domain, "/favicon")
+
+	site, err := config.FindSiteByDomain(domain)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	path := detectFavicon(site.Path, site.PublicDir)
+	if path == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	http.ServeFile(w, r, path)
+}
+
 // SiteActionResponse is returned by POST /api/sites/{domain}/secure|unsecure.
 type SiteActionResponse struct {
 	OK    bool   `json:"ok"`
@@ -1192,11 +1241,22 @@ type SiteActionResponse struct {
 func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 	// path: /api/sites/{domain}/secure or /api/sites/{domain}/unsecure
 	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/sites/"), "/")
-	if len(parts) != 2 || r.Method != http.MethodPost {
+	if len(parts) != 2 {
 		http.NotFound(w, r)
 		return
 	}
 	domain, action := parts[0], parts[1]
+
+	// Favicon is a GET endpoint served separately.
+	if action == "favicon" {
+		handleSiteFavicon(w, r)
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		http.NotFound(w, r)
+		return
+	}
 
 	site, err := config.FindSiteByDomain(domain)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Detect favicon.ico/svg/png in each site's public directory and serve them via GET /api/sites/{domain}/favicon
- Sites list and detail header display the favicon when available, falling back to the status dot
- PHP and Node version selects are now deferred with static placeholders until version lists finish loading, preventing the browser from resetting the model value to an empty string