### PR TITLE
feat: framework definition store

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@
 ![Lerd Web UI](screenshots/app-1.png)
 
 Lerd runs Nginx, PHP-FPM, and your services as rootless Podman containers,
-designed for PHP and Laravel developers on Linux (Ubuntu, Fedora, Arch, Debian).
+designed for PHP developers on Linux (Ubuntu, Fedora, Arch, Debian).
 No Docker. No sudo. No system pollution. Just `lerd link` and your project
 is live at `project.test` with HTTPS.
 
 ## Built for Linux PHP developers
 
-If you're a PHP or Laravel developer on Linux and want frictionless local development — automatic `.test` domains, per-project PHP versions, one-click HTTPS, zero Docker — Lerd is built for you.
+If you're a PHP developer on Linux and want frictionless local development — automatic `.test` domains, per-project PHP versions, one-click HTTPS, zero Docker — Lerd is built for you. Works with Laravel, Symfony, WordPress, Drupal, CakePHP, Statamic, and any custom PHP framework.
 
 ## Features
 
@@ -30,7 +30,8 @@ If you're a PHP or Laravel developer on Linux and want frictionless local develo
 - 📋 **Live logs** for PHP-FPM, Queue, Schedule, Reverb, per site
 - 🔒 **Rootless & daemonless** - Podman-native, no Docker required
 - 🤖 **MCP server** - let AI assistants (Claude Code, Windsurf, Junie) manage your environment directly
-- ⚡ **Laravel-first**, with Symfony, WordPress, and custom framework support
+- 🧩 **Framework store** - community definitions for Laravel, Symfony, WordPress, Drupal, CakePHP, Statamic with versioned auto-detection
+- ⚡ **Framework-agnostic** workers, env setup, and nginx proxy — driven by YAML definitions, not hardcoded
 
 ## AI Integration (MCP)
 
@@ -112,6 +113,19 @@ lerd status         # health snapshot
 
 See [Start, Stop & Autostart](https://geodro.github.io/lerd/usage/lifecycle/) for the full lifecycle reference.
 
+## Framework Store
+
+Install community framework definitions from [geodro/lerd-frameworks](https://github.com/geodro/lerd-frameworks):
+
+```bash
+lerd framework search                   # list all available
+lerd framework install symfony          # auto-detects version from composer.lock
+lerd framework install drupal@11        # explicit version
+lerd framework list --check             # compare local vs store
+```
+
+Frameworks auto-detect when you `lerd link` a project. Workers, env setup, nginx proxy, and setup commands are all driven by the framework definition — no hardcoded behavior.
+
 ## Documentation
 
 📖 **[geodro.github.io/lerd](https://geodro.github.io/lerd/)**
@@ -120,6 +134,7 @@ See [Start, Stop & Autostart](https://geodro.github.io/lerd/usage/lifecycle/) fo
 - [Installation](https://geodro.github.io/lerd/getting-started/installation/)
 - [Quick Start](https://geodro.github.io/lerd/getting-started/quick-start/)
 - [Start, Stop & Autostart](https://geodro.github.io/lerd/usage/lifecycle/)
+- [Frameworks](https://geodro.github.io/lerd/usage/frameworks/)
 - [Services](https://geodro.github.io/lerd/usage/services/)
 - [Command Reference](https://geodro.github.io/lerd/reference/commands/)
 

--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -18,7 +18,8 @@ Laravel has a built-in definition. Other frameworks (Symfony, WordPress, Drupal,
 | `lerd framework update [name[@version]]` | Update installed definitions from the store |
 | `lerd framework update --diff` | Preview changes before applying updates |
 | `lerd framework add <name>` | Add or update a user-defined framework definition |
-| `lerd framework remove <name>` | Remove a user-defined framework definition |
+| `lerd framework remove <name>[@version]` | Remove a framework definition (prompts if multiple versions) |
+| `lerd framework remove <name> --all` | Remove all versions of a framework definition |
 
 ---
 
@@ -35,7 +36,7 @@ lerd framework search
 ```
 Name            Label           Latest       Versions
 ───────────────────────────────────────────────────────
-laravel         Laravel         13           13, 12
+laravel         Laravel         13           13, 12, 11, 10
 symfony         Symfony         8            8, 7
 wordpress       WordPress       6            6, 5
 drupal          Drupal          11           11, 10
@@ -79,14 +80,16 @@ lerd framework update                 # update all installed frameworks
 lerd framework update --diff          # show changes before applying
 ```
 
-### Auto-detection
+### Auto-detection and auto-fetch
 
-When `lerd link`, `lerd init`, or `lerd setup` detects a framework with no local definition, it checks the store:
+When any command needs a framework definition that isn't installed locally, lerd fetches it from the store automatically. The version is resolved from `composer.lock`, so a Laravel 11 project gets `laravel@11.yaml` and a Laravel 12 project gets `laravel@12.yaml`.
+
+Locally installed definitions are refreshed from the store every 24 hours to pick up upstream fixes (e.g. new log sources, corrected PHP ranges).
+
+During `lerd link`, `lerd init`, or `lerd setup`, if no framework is detected at all:
 
 - **Interactive mode**: prompts to install from the store
 - **Non-interactive mode**: fetches silently when `.lerd.yaml` specifies a framework name
-
-Framework detection only happens during `lerd link`, `lerd init`, `lerd env`, and `lerd setup`. All other commands read the saved framework from the site registry.
 
 ### Contributing to the store
 
@@ -100,10 +103,10 @@ Lerd resolves framework definitions from multiple sources. Higher priority wins:
 
 | Priority | Source | Location | Purpose |
 |----------|--------|----------|---------|
-| 1 | User-defined | `~/.config/lerd/frameworks/<name>.yaml` | Manual overrides and custom frameworks |
+| 1 | User overlay | `~/.config/lerd/frameworks/<name>.yaml` | Manual overrides (merged on top) |
 | 2 | Project embedded | `.lerd.yaml` `framework_def` | Portability for user-defined frameworks |
-| 3 | Store-installed | `~/.local/share/lerd/frameworks/<name>@<version>.yaml` | Community definitions |
-| 4 | Built-in | Compiled into lerd binary | Laravel only |
+| 3 | Store-installed | `~/.local/share/lerd/frameworks/<name>@<version>.yaml` | Community definitions (auto-fetched) |
+| 4 | Built-in | Compiled into lerd binary | Laravel fallback only |
 
 ### Worker merging
 
@@ -257,11 +260,11 @@ journalctl --user -u lerd-messenger-myapp -f
 
 ---
 
-## Built-in Laravel definition
+## Laravel definition
 
-Laravel is the only framework with a built-in definition compiled into the binary. It is always available without any YAML file or store install.
+Laravel has a built-in definition compiled into the binary as a fallback. When a project is linked, lerd auto-fetches the version-specific definition from the store (e.g. `laravel@11`, `laravel@12`), which includes the correct PHP version range and version-specific behaviour (e.g. Laravel 10 uses `schedule:run` instead of `schedule:work`, and doesn't include Reverb).
 
-Built-in workers:
+Default workers:
 
 | Worker | Label | Command | Check | Extra |
 |---|---|---|---|---|
@@ -292,6 +295,28 @@ To remove the overlay (built-in workers remain):
 ```bash
 lerd framework remove laravel
 ```
+
+### Removing framework definitions
+
+```bash
+lerd framework remove symfony          # prompts if multiple versions installed
+lerd framework remove symfony@7        # remove a specific version
+lerd framework remove symfony --all    # remove all versions
+```
+
+When multiple versions of a framework are installed, `lerd framework remove` prompts you to choose which version to remove.
+
+---
+
+## PHP version clamping
+
+When a framework definition includes `php.min` and `php.max`, `lerd link` and `lerd init` automatically clamp the detected PHP version to the supported range. For example, if you link a Laravel 10 project (max PHP 8.3) but your system defaults to PHP 8.4, lerd will select PHP 8.3 instead:
+
+```
+PHP 8.4 is outside Laravel's supported range (8.1–8.3), using PHP 8.3.
+```
+
+This prevents accidentally running a project on an unsupported PHP version.
 
 ---
 
@@ -341,6 +366,11 @@ public_dir: public                # document root relative to project
 
 # Version (required for store definitions)
 version: "8"                      # framework major version this definition targets
+
+# PHP version range (optional, used during lerd link/init to clamp PHP version)
+php:
+  min: "8.2"                      # minimum supported PHP version
+  max: "8.5"                      # maximum supported PHP version
 
 # Detection rules — any match is sufficient
 detect:
@@ -444,7 +474,7 @@ If no framework matches and no `--public-dir` is specified, lerd tries these can
 
 ## Log viewer
 
-Frameworks can define application log file locations so they appear in the UI's **App Logs** tab. Laravel has this built-in (`storage/logs/*.log` with Monolog parsing). Custom frameworks can add their own:
+Frameworks can define application log file locations so they appear in the UI's **App Logs** tab. The tab only appears when matching log files actually exist on disk — for example, WordPress defines `wp-content/debug.log` but the tab stays hidden until `WP_DEBUG_LOG` is enabled. Custom frameworks can add their own:
 
 ```yaml
 logs:

--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -2,7 +2,7 @@
 
 Lerd uses **framework definitions** to describe how a PHP project type behaves: where the document root is, how to detect it automatically, which env file to use, and which background workers it supports.
 
-Laravel has a built-in definition. Any other PHP framework (Symfony, WordPress, Drupal, etc.) can be added via a YAML file stored at `~/.config/lerd/frameworks/<name>.yaml`.
+Laravel has a built-in definition. Other frameworks (Symfony, WordPress, Drupal, CakePHP, Statamic, etc.) can be installed from the [community store](https://github.com/geodro/lerd-frameworks) or defined manually.
 
 ---
 
@@ -11,9 +11,123 @@ Laravel has a built-in definition. Any other PHP framework (Symfony, WordPress, 
 | Command | Description |
 |---|---|
 | `lerd new <name-or-path>` | Scaffold a new PHP project using a framework's create command |
-| `lerd framework list` | List all framework definitions including workers |
-| `lerd framework add <name>` | Add or update a framework definition (flags or `--from-file`) |
+| `lerd framework list` | List all framework definitions with source and workers |
+| `lerd framework list --check` | Compare local definitions against the store |
+| `lerd framework search [query]` | Search the community store for available definitions |
+| `lerd framework install <name>[@version]` | Install a framework definition from the store |
+| `lerd framework update [name[@version]]` | Update installed definitions from the store |
+| `lerd framework update --diff` | Preview changes before applying updates |
+| `lerd framework add <name>` | Add or update a user-defined framework definition |
 | `lerd framework remove <name>` | Remove a user-defined framework definition |
+
+---
+
+## Framework store
+
+Lerd has a community-driven framework store backed by [geodro/lerd-frameworks](https://github.com/geodro/lerd-frameworks). The store hosts definitions for popular PHP frameworks, versioned by major release.
+
+### Available frameworks
+
+```bash
+lerd framework search
+```
+
+```
+Name            Label           Latest       Versions
+───────────────────────────────────────────────────────
+laravel         Laravel         13           13, 12
+symfony         Symfony         8            8, 7
+wordpress       WordPress       6            6, 5
+drupal          Drupal          11           11, 10
+cakephp         CakePHP         5            5, 4
+statamic        Statamic        6            6, 5
+```
+
+### Installing from the store
+
+```bash
+lerd framework install symfony          # auto-detects version from composer.lock
+lerd framework install laravel@12       # explicit version
+lerd framework install wordpress        # latest version
+```
+
+When no version is specified, lerd reads `composer.lock` to detect the installed major version. If the version can't be determined, it falls back to the latest available.
+
+Store-installed definitions are saved to `~/.local/share/lerd/frameworks/<name>@<version>.yaml`, separate from user-defined frameworks.
+
+### Checking for updates
+
+```bash
+lerd framework list --check
+```
+
+```
+Name            Version  Source     Latest     Status
+───────────────────────────────────────────────────────
+laravel         —        built-in   13         built-in
+symfony         8        store      8          up to date
+wordpress       6        store      6          up to date
+magento         —        user       —          not in store
+```
+
+### Updating
+
+```bash
+lerd framework update symfony         # update a single framework
+lerd framework update symfony@7       # update to a specific version
+lerd framework update                 # update all installed frameworks
+lerd framework update --diff          # show changes before applying
+```
+
+### Auto-detection
+
+When `lerd link`, `lerd init`, or `lerd setup` detects a framework with no local definition, it checks the store:
+
+- **Interactive mode**: prompts to install from the store
+- **Non-interactive mode**: fetches silently when `.lerd.yaml` specifies a framework name
+
+Framework detection only happens during `lerd link`, `lerd init`, `lerd env`, and `lerd setup`. All other commands read the saved framework from the site registry.
+
+### Contributing to the store
+
+Submit a pull request to [geodro/lerd-frameworks](https://github.com/geodro/lerd-frameworks) with a YAML file under `frameworks/<name>/<version>.yaml` and update `frameworks/index.json`.
+
+---
+
+## Definition sources and priority
+
+Lerd resolves framework definitions from multiple sources. Higher priority wins:
+
+| Priority | Source | Location | Purpose |
+|----------|--------|----------|---------|
+| 1 | User-defined | `~/.config/lerd/frameworks/<name>.yaml` | Manual overrides and custom frameworks |
+| 2 | Project embedded | `.lerd.yaml` `framework_def` | Portability for user-defined frameworks |
+| 3 | Store-installed | `~/.local/share/lerd/frameworks/<name>@<version>.yaml` | Community definitions |
+| 4 | Built-in | Compiled into lerd binary | Laravel only |
+
+### Worker merging
+
+When a store or built-in definition is used, workers from the user-defined overlay (`~/.config/lerd/frameworks/<name>.yaml`) are merged on top. Project-specific custom workers from `.lerd.yaml` are also merged. This means you can add workers without replacing the base definition:
+
+```yaml
+# ~/.config/lerd/frameworks/laravel.yaml — adds Pulse to the built-in Laravel definition
+name: laravel
+workers:
+  pulse:
+    label: Pulse
+    command: php artisan pulse:work
+    restart: always
+```
+
+### Version resolution
+
+When loading a framework definition for a project, the version is resolved in order:
+
+1. `composer.lock` — the actual installed version (source of truth)
+2. `.lerd.yaml` `framework_version` — pinned version (fallback when no `composer.lock`)
+3. Latest available in store
+
+When `composer.lock` shows a different version than `.lerd.yaml`, the pinned version is auto-updated.
 
 ---
 
@@ -36,54 +150,26 @@ The installer walks you through starter kit selection, database setup, and other
 
 `lerd new` is a framework-agnostic shortcut that runs the framework's scaffold command:
 
+
 ```bash
-lerd new myapp                          # create ./myapp using Laravel (default)
+lerd new myapp                          # create using Laravel (default)
 lerd new myapp --framework=symfony      # create using Symfony's create command
 lerd new /path/to/myapp                 # create at an absolute path
 lerd new myapp -- --no-interaction      # pass extra flags to the scaffold command
 ```
 
-For Laravel, this runs:
-```bash
-composer create-project --no-install --no-plugins --no-scripts laravel/laravel /abs/path/to/myapp
-```
-
-After creation, register the site and bootstrap it:
+After creation:
 ```bash
 cd myapp
 lerd link
 lerd setup
 ```
 
-Or let your AI assistant do it via MCP:
-```
-project_new(path: "/home/user/code/myapp")
-site_link(path: "/home/user/code/myapp")
-env_setup(path: "/home/user/code/myapp")
-```
-
-### Defining a create command for custom frameworks
-
-Add a `create` field to a framework's YAML definition. The target directory is appended automatically when `lerd new` runs:
-
-```yaml
-# ~/.config/lerd/frameworks/symfony.yaml
-name: symfony
-create: composer create-project symfony/skeleton
-# ... rest of definition
-```
-
-Then:
-```bash
-lerd new myapp --framework=symfony
-# runs: composer create-project symfony/skeleton /abs/path/to/myapp
-```
-
 ---
 
 ## Framework workers
 
-Each framework can define one or more **workers** — long-running processes managed as systemd user services inside the PHP-FPM container. Laravel has three built-in: `queue`, `schedule`, and `reverb`.
+Each framework can define **workers** — long-running processes managed as systemd user services inside the PHP-FPM container.
 
 | Command | Description |
 |---|---|
@@ -91,9 +177,80 @@ Each framework can define one or more **workers** — long-running processes man
 | `lerd worker stop <name>` | Stop a named worker |
 | `lerd worker list` | List all workers defined for this project's framework |
 
-The shortcut commands `lerd queue:start`, `lerd schedule:start`, and `lerd reverb:start` are aliases for `lerd worker start queue/schedule/reverb` — they work for any framework that defines a worker with that name, not just Laravel.
+The shortcut commands `lerd queue:start`, `lerd schedule:start`, `lerd reverb:start`, and `lerd horizon:start` are aliases — they look up the worker from the framework definition and delegate to the generic handler. They work for any framework that defines a worker with that name.
 
-Worker systemd units follow the naming pattern `lerd-<worker>-<sitename>` (e.g. `lerd-messenger-myapp`). Logs:
+### Worker features
+
+**Conditional workers** — Workers with a `check` rule only appear when the condition passes (e.g. `laravel/horizon` is in `composer.json`):
+
+```yaml
+workers:
+  horizon:
+    command: php artisan horizon
+    check:
+      composer: laravel/horizon
+```
+
+**Conflict resolution** — Workers can declare conflicts. When a conflicting worker starts, the other is stopped automatically:
+
+```yaml
+workers:
+  horizon:
+    command: php artisan horizon
+    conflicts_with:
+      - queue      # stops queue before starting horizon
+```
+
+**WebSocket/HTTP proxy** — Workers that need an nginx proxy block define a `proxy` config. Lerd auto-assigns a collision-free port and regenerates the nginx vhost:
+
+```yaml
+workers:
+  reverb:
+    command: php artisan reverb:start
+    proxy:
+      path: /app                    # URL path for the proxy location block
+      port_env_key: REVERB_SERVER_PORT  # env key holding the port
+      default_port: 8080            # starting port for auto-assignment
+```
+
+Port assignment scans all proxy port env keys across all sites to prevent collisions between different workers and frameworks.
+
+### Project-specific custom workers
+
+Add workers to `.lerd.yaml` for project-specific needs that don't belong in the framework definition:
+
+```yaml
+# .lerd.yaml
+framework: symfony
+framework_version: "8"
+workers:
+  - messenger
+  - pdf-generator
+custom_workers:
+  pdf-generator:
+    label: PDF Generator
+    command: php bin/console app:generate-pdfs --daemon
+    restart: always
+```
+
+Custom workers with proxy support:
+
+```yaml
+custom_workers:
+  mercure:
+    label: Mercure Hub
+    command: php bin/console mercure:run
+    restart: always
+    proxy:
+      path: /.well-known/mercure
+      port_env_key: MERCURE_PORT
+      default_port: 3000
+```
+
+Custom workers are merged with the framework's workers at runtime. They are committed to git so teammates get the same setup.
+
+### Worker logs
+
 ```bash
 journalctl --user -u lerd-messenger-myapp -f
 ```
@@ -102,48 +259,25 @@ journalctl --user -u lerd-messenger-myapp -f
 
 ## Built-in Laravel definition
 
-Laravel is the only framework with a built-in definition. It is always available without any YAML file.
+Laravel is the only framework with a built-in definition compiled into the binary. It is always available without any YAML file or store install.
 
 Built-in workers:
 
-| Worker | Label | Command | Restart |
-|---|---|---|---|
-| `queue` | Queue Worker | `php artisan queue:work --queue=default --tries=3 --timeout=60` | on-failure |
-| `schedule` | Task Scheduler | `php artisan schedule:work` | always |
-| `reverb` | Reverb WebSocket | `php artisan reverb:start` | on-failure |
+| Worker | Label | Command | Check | Extra |
+|---|---|---|---|---|
+| `queue` | Queue Worker | `php artisan queue:work --queue=default --tries=3 --timeout=60` | — | — |
+| `schedule` | Task Scheduler | `php artisan schedule:work` | — | — |
+| `reverb` | Reverb WebSocket | `php artisan reverb:start` | `laravel/reverb` | proxy at `/app`, auto-assigned port |
+| `horizon` | Horizon | `php artisan horizon` | `laravel/horizon` | conflicts with `queue` |
 
-The `reverb` worker toggle only appears in the UI when the project actually uses Reverb (detected via `laravel/reverb` in `composer.json` or `BROADCAST_CONNECTION=reverb` in `.env`).
+### Adding workers to Laravel
 
-Each site that uses Reverb gets its own `REVERB_SERVER_PORT` assigned automatically — starting at `8080` and incrementing for each additional site — so multiple Reverb-enabled sites can run at the same time without port collisions. The port is written to the site's `.env` on first `lerd env` run or on the first `reverb:start`, and stays fixed after that.
-
----
-
-## Adding custom workers to Laravel
-
-You can add extra workers to Laravel (e.g. Horizon, Pulse) without overriding its built-in definition. Custom workers are merged on top:
-
-```bash
-lerd framework add laravel \
-  --from-file horizon.yaml
-```
-
-Or inline:
-
-```bash
-lerd framework add laravel \
-  # (no --public-dir needed for laravel)
-```
-
-Using a YAML file (recommended):
+User-defined workers are merged on top of the built-in. Use `lerd framework add` to create an overlay:
 
 ```yaml
 # horizon.yaml
 name: laravel
 workers:
-  horizon:
-    label: Horizon
-    command: php artisan horizon
-    restart: always
   pulse:
     label: Pulse
     command: php artisan pulse:work
@@ -152,46 +286,47 @@ workers:
 
 ```bash
 lerd framework add laravel --from-file horizon.yaml
-lerd worker start horizon    # starts lerd-horizon-<sitename>
 ```
 
-To remove your custom additions (the built-in queue/schedule/reverb remain):
+To remove the overlay (built-in workers remain):
 ```bash
 lerd framework remove laravel
 ```
 
 ---
 
-## User-defined frameworks
+## Environment setup
 
-### Adding a framework
+The `env` section in a framework definition controls how `lerd env` works:
 
-**With flags** (quick):
+```yaml
+env:
+  file: .env                        # primary env file
+  example_file: .env.example        # copied to file if missing
+  format: dotenv                    # dotenv | php-const
+  fallback_file: wp-config.php      # used when file doesn't exist
+  fallback_format: php-const        # format for fallback_file
+  url_key: APP_URL                  # env key holding the app URL
 
-```bash
-lerd framework add symfony \
-  --label "Symfony" \
-  --public-dir public \
-  --detect-file symfony.lock \
-  --detect-composer symfony/framework-bundle \
-  --env-file .env \
-  --env-format dotenv \
-  --composer auto \
-  --npm auto
-```
+  # Application key generation
+  key_generation:
+    env_key: APP_KEY                # env var to check/set
+    command: key:generate           # artisan command to run if vendor/ exists
+    fallback_prefix: "base64:"     # prefix for random key fallback
 
-**From a YAML file** (recommended for sharing):
-
-```bash
-lerd framework add symfony --from-file symfony.yaml
-```
-
-Framework YAML files are stored at `~/.config/lerd/frameworks/<name>.yaml`.
-
-### Removing a framework
-
-```bash
-lerd framework remove symfony
+  # Per-service detection and env variable injection
+  services:
+    mysql:
+      detect:
+        - key: DB_CONNECTION
+          value_prefix: mysql
+      vars:
+        - DB_CONNECTION=mysql
+        - DB_HOST=lerd-mysql
+        - DB_PORT=3306
+        - DB_DATABASE={{site}}
+        - DB_USERNAME=root
+        - DB_PASSWORD=lerd
 ```
 
 ---
@@ -202,21 +337,28 @@ lerd framework remove symfony
 # Required
 name: symfony                     # slug [a-z0-9-], must match filename stem
 label: Symfony                    # display name
-public_dir: public                # document root relative to project (e.g. public, web, .)
+public_dir: public                # document root relative to project
+
+# Version (required for store definitions)
+version: "8"                      # framework major version this definition targets
 
 # Detection rules — any match is sufficient
 detect:
-  - file: symfony.lock            # file must exist in project root
-  - composer: symfony/framework-bundle  # package in composer.json require/require-dev
+  - file: symfony.lock
+  - composer: symfony/framework-bundle
 
 # Env file configuration
 env:
-  file: .env                      # primary env file (default: .env)
-  example_file: .env.dist         # copied to file if missing (like .env.example for Laravel)
-  format: dotenv                  # dotenv (default) | php-const (for wp-config.php style)
-  fallback_file: wp-config.php    # used when file doesn't exist (optional)
-  fallback_format: php-const      # format for fallback_file (optional)
+  file: .env.local
+  example_file: .env
+  format: dotenv                  # dotenv | php-const
+  fallback_file: settings.php     # used when file doesn't exist (optional)
+  fallback_format: php-const
   url_key: DEFAULT_URI            # env key holding the app URL (default: APP_URL)
+  key_generation:                 # application key generation (optional)
+    env_key: APP_KEY
+    command: key:generate
+    fallback_prefix: "base64:"
 
   # Per-service env detection and variable injection for `lerd env`
   #
@@ -235,44 +377,40 @@ env:
         - key: DATABASE_URL
           value_prefix: "mysql://"
       vars:
-        - "DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/{{site}}?serverVersion={{mysql_version}}"
-    redis:
-      detect:
-        - key: REDIS_URL
-        - key: REDIS_DSN
-      vars:
-        - "REDIS_URL=redis://lerd-redis:6379"
+        - "DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/{{site}}"
 
-# Scaffold command for "lerd new" — target directory is appended automatically
-create: composer create-project myvendor/myframework
+# Scaffold command for "lerd new"
+create: composer create-project symfony/skeleton
 
 # Dependency installation
-composer: auto                    # auto | true | false (auto = run if vendor/ missing)
-npm: auto                         # auto | true | false (auto = run if node_modules/ missing)
+composer: auto                    # auto | true | false
+npm: auto
 
 # Console command (without 'php' prefix)
-console: artisan                  # artisan (Laravel), bin/console (Symfony), etc.
+console: bin/console
 
-# Background workers (systemd user services)
+# Background workers
 workers:
   messenger:
-    label: Messenger               # display name (optional)
+    label: Messenger
     command: php bin/console messenger:consume async --time-limit=3600
     restart: always               # always | on-failure (default: always)
-    check:                         # only shown when check passes (optional)
+    check:                        # only shown when check passes (optional)
       composer: symfony/messenger
+    conflicts_with:               # workers to stop before starting (optional)
+      - other-worker
+    proxy:                        # nginx proxy config (optional)
+      path: /ws
+      port_env_key: WS_PORT
+      default_port: 8080
 
-# One-off setup commands shown in `lerd setup` wizard
+# One-off setup commands
 setup:
-  - label: "Run migrations"                     # display name and identifier
+  - label: "Run migrations"
     command: "php bin/console doctrine:migrations:migrate --no-interaction"
-    default: true                               # pre-selected in the wizard
-    check:                                      # only shown when check passes (optional)
-      composer: doctrine/doctrine-migrations-bundle
-  - label: "Load fixtures"
-    command: "php bin/console doctrine:fixtures:load --no-interaction"
+    default: true
     check:
-      composer: doctrine/doctrine-fixtures-bundle  # skipped if package not installed
+      composer: doctrine/doctrine-migrations-bundle  # skipped if package not installed
 
 # Application log files shown in the UI "App Logs" tab
 logs:
@@ -284,12 +422,15 @@ logs:
 
 ## Framework detection
 
-When you run `lerd link` or `lerd park`, lerd inspects the project directory and tries to match it against framework definitions in this order:
+Framework detection only runs during `lerd link`, `lerd init`, `lerd env`, `lerd setup`, and `lerd park`. All other commands read the saved framework from the site registry.
+
+Detection order:
 
 1. **Laravel** (built-in): checks for `artisan` file or `laravel/framework` in `composer.json`
-2. **User-defined frameworks**: iterates `~/.config/lerd/frameworks/*.yaml` alphabetically, applying each detection rule
+2. **Local definitions**: iterates user-defined and store-installed YAML files, applying detection rules
+3. **Framework store** (interactive): checks the store index and prompts to install, or fetches silently when `.lerd.yaml` specifies the framework name
 
-The **first match wins**. Detection rules are OR-based — any single matching rule is enough to identify the framework.
+The first match wins. Detection rules are OR-based — any single matching rule is enough.
 
 ---
 
@@ -345,112 +486,6 @@ logs:
 
 ## Web UI
 
-Framework workers appear as toggles in the **Sites** panel alongside queue/schedule/reverb. Each running worker also gets a log tab in the site detail drawer and an indicator dot in the site list.
+Framework workers appear as toggles in the Sites panel. Workers with a `check` rule only appear when the condition passes. Workers with `conflicts_with` suppress each other (e.g. when Horizon is available, the queue toggle is hidden).
 
-Workers defined in the framework are shown regardless of framework type — Laravel gets its built-in queue/schedule/reverb workers; Symfony shows the `messenger` worker if defined; etc.
-
----
-
-## Example: Symfony
-
-```yaml
-# ~/.config/lerd/frameworks/symfony.yaml
-name: symfony
-label: Symfony
-detect:
-  - file: symfony.lock
-  - composer: symfony/framework-bundle
-public_dir: public
-env:
-  file: .env
-  example_file: .env.dist
-  format: dotenv
-  url_key: DEFAULT_URI
-  services:
-    mysql:
-      detect:
-        - key: DATABASE_URL
-          value_prefix: "mysql://"
-        - key: DATABASE_URL
-          value_prefix: "mariadb://"
-      vars:
-        - "DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/{{site}}?serverVersion={{mysql_version}}"
-    postgres:
-      detect:
-        - key: DATABASE_URL
-          value_prefix: "postgresql://"
-        - key: DATABASE_URL
-          value_prefix: "postgres://"
-      vars:
-        - "DATABASE_URL=postgresql://postgres:lerd@lerd-postgres:5432/{{site}}?serverVersion={{postgres_version}}"
-    redis:
-      detect:
-        - key: REDIS_URL
-        - key: REDIS_DSN
-      vars:
-        - "REDIS_URL=redis://lerd-redis:6379"
-    mailpit:
-      detect:
-        - key: MAILER_DSN
-      vars:
-        - "MAILER_DSN=smtp://lerd-mailpit:1025"
-    meilisearch:
-      detect:
-        - key: MEILISEARCH_HOST
-        - key: MEILISEARCH_DSN
-      vars:
-        - "MEILISEARCH_HOST=http://lerd-meilisearch:7700"
-composer: auto
-npm: auto
-workers:
-  messenger:
-    label: Messenger
-    command: php bin/console messenger:consume async --time-limit=3600
-    restart: always
-    check:
-      composer: symfony/messenger
-setup:
-  - label: "Run migrations"
-    command: "php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration"
-    default: true
-    check:
-      composer: doctrine/doctrine-migrations-bundle
-  - label: "Load fixtures"
-    command: "php bin/console doctrine:fixtures:load --no-interaction"
-    check:
-      composer: doctrine/doctrine-fixtures-bundle
-  - label: "Clear cache"
-    command: "php bin/console cache:clear"
-    default: true
-```
-
-```bash
-lerd framework add symfony --from-file ~/.config/lerd/frameworks/symfony.yaml
-lerd link                          # auto-detected as Symfony
-lerd setup                         # shows migrations, fixtures, and other steps
-lerd worker start messenger        # starts lerd-messenger-<sitename>
-```
-
----
-
-## Example: WordPress
-
-```yaml
-# ~/.config/lerd/frameworks/wordpress.yaml
-name: wordpress
-label: WordPress
-detect:
-  - file: wp-login.php
-  - file: wp-config.php
-public_dir: .
-env:
-  fallback_file: wp-config.php
-  fallback_format: php-const
-composer: false
-npm: false
-```
-
-```bash
-lerd framework add wordpress --from-file ~/.config/lerd/frameworks/wordpress.yaml
-lerd link                          # auto-detected as WordPress
-```
+Custom framework workers from `.lerd.yaml` also appear as toggles alongside the framework's standard workers.

--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -122,6 +122,56 @@ workers:
     restart: always
 ```
 
+### Managing custom workers
+
+Use `lerd worker add` to add project-specific or global custom workers without manually editing YAML:
+
+```bash
+# Add a project-specific worker (saved to .lerd.yaml)
+lerd worker add pulse --command "php artisan pulse:work" --label "Pulse" --check-composer laravel/pulse
+
+# Add a worker that conflicts with another (stops it on start, hides it in UI)
+lerd worker add custom-queue --command "php artisan queue:work --queue=emails" --conflicts-with queue
+
+# Add a global worker (saved to ~/.config/lerd/frameworks/<name>.yaml)
+lerd worker add pulse --command "php artisan pulse:work" --global
+
+# Remove a custom worker (stops it if running)
+lerd worker remove pulse
+lerd worker remove pulse --global
+```
+
+Project workers (`.lerd.yaml`) apply to a single project and are committed to git. Global workers (user overlay) apply to all projects using that framework. Both survive framework store updates.
+
+The resulting `.lerd.yaml` looks like:
+
+```yaml
+framework: laravel
+custom_workers:
+  pulse:
+    label: Pulse
+    command: php artisan pulse:work
+    check:
+      composer: laravel/pulse
+  custom-queue:
+    command: php artisan queue:work --queue=emails
+    conflicts_with:
+      - queue
+```
+
+After adding, start the worker with `lerd worker start pulse`.
+
+When running `lerd init --fresh`, existing custom workers are shown in a multi-select step before the workers step. Deselecting a custom worker removes it from `.lerd.yaml` and excludes it from the workers selection. If the removed worker had `conflicts_with`, those workers become available again.
+
+### Orphaned workers
+
+A worker becomes orphaned when its systemd unit is still running but its definition has been removed from `.lerd.yaml` (e.g. after a `git pull` or manual edit). Orphaned workers are detected and surfaced in several places:
+
+- **`lerd worker list`** — shows orphaned workers with a stop hint
+- **`lerd worker stop <name>`** — can stop orphaned workers even without a definition
+- **`lerd setup`** — offers orphaned workers as pre-selected stop steps before framework worker starts
+- **UI** — the stop button works for orphaned workers directly
+
 ### Version resolution
 
 When loading a framework definition for a project, the version is resolved in order:
@@ -194,14 +244,14 @@ workers:
       composer: laravel/horizon
 ```
 
-**Conflict resolution** — Workers can declare conflicts. When a conflicting worker starts, the other is stopped automatically:
+**Conflict resolution** — Workers can declare conflicts. When a conflicting worker starts, the other is stopped automatically and hidden from the UI:
 
 ```yaml
 workers:
   horizon:
     command: php artisan horizon
     conflicts_with:
-      - queue      # stops queue before starting horizon
+      - queue      # stops queue before starting horizon; hides queue toggle in UI
 ```
 
 **WebSocket/HTTP proxy** — Workers that need an nginx proxy block define a `proxy` config. Lerd auto-assigns a collision-free port and regenerates the nginx vhost:

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -83,10 +83,7 @@ func runCheck(_ *cobra.Command, _ []string) error {
 	// Workers
 	if len(cfg.Workers) > 0 {
 		fwName := cfg.Framework
-		if fwName == "" {
-			fwName, _ = config.DetectFramework(cwd)
-		}
-		fw, hasFw := config.GetFramework(fwName)
+		fw, hasFw := config.GetFrameworkForDir(fwName, cwd)
 
 		hasQueue := false
 		hasHorizon := false
@@ -98,48 +95,28 @@ func runCheck(_ *cobra.Command, _ []string) error {
 				hasHorizon = true
 			}
 
-			switch w {
-			case "horizon":
-				if !SiteHasHorizon(cwd) {
-					fmt.Printf("  WARN  worker: %s — laravel/horizon is not installed\n", w)
-					warnings++
-				} else {
-					fmt.Printf("  OK    worker: %s\n", w)
-				}
-			case "reverb":
-				if !SiteUsesReverb(cwd) {
-					fmt.Printf("  WARN  worker: %s — reverb is not configured (no laravel/reverb in composer.json and no BROADCAST_CONNECTION=reverb in .env)\n", w)
-					warnings++
-				} else {
-					fmt.Printf("  OK    worker: %s\n", w)
-				}
-			case "queue", "schedule":
-				if hasFw && fw.Workers != nil {
-					if _, ok := fw.Workers[w]; ok {
-						fmt.Printf("  OK    worker: %s\n", w)
-					} else {
-						fmt.Printf("  WARN  worker: %q is not defined for framework %s\n", w, fwName)
-						warnings++
-					}
-				} else if fwName != "" {
+			if !hasFw || fw.Workers == nil {
+				if fwName != "" {
 					fmt.Printf("  WARN  worker: %q — framework %s has no worker definitions\n", w, fwName)
 					warnings++
 				} else {
 					fmt.Printf("  WARN  worker: %q — no framework detected\n", w)
 					warnings++
 				}
-			default:
-				if hasFw && fw.Workers != nil {
-					if _, ok := fw.Workers[w]; ok {
-						fmt.Printf("  OK    worker: %s (custom)\n", w)
-					} else {
-						fmt.Printf("  FAIL  worker: %q is not defined for framework %s\n", w, fwName)
-						errors++
-					}
-				} else {
-					fmt.Printf("  FAIL  worker: %q — no framework worker definition found\n", w)
-					errors++
-				}
+				continue
+			}
+			wDef, ok := fw.Workers[w]
+			if !ok {
+				fmt.Printf("  FAIL  worker: %q is not defined for framework %s\n", w, fwName)
+				errors++
+				continue
+			}
+			// Check if the worker's prerequisite (Check rule) is satisfied.
+			if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
+				fmt.Printf("  WARN  worker: %s — prerequisite not met (check rule failed)\n", w)
+				warnings++
+			} else {
+				fmt.Printf("  OK    worker: %s\n", w)
 			}
 		}
 

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -907,7 +907,6 @@ func reverbEnvUpdates(envMap map[string]string, domain string, secured bool, sit
 	return updates
 }
 
-
 const alphanumChars = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 func randAlphanumeric(n int) string {

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -111,8 +111,6 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("'lerd env' is not supported for %s\nConfigure the env section in the framework YAML to enable it", fw.Label)
 	}
 
-	isLaravel := fwName == "laravel"
-
 	envRelPath, envFormat := fw.Env.Resolve(cwd)
 	envPath := filepath.Join(cwd, envRelPath)
 
@@ -425,8 +423,10 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		patchDuskTestCase(cwd)
 	}
 
-	// 3d. Generate REVERB_ env vars if BROADCAST_CONNECTION=reverb (Laravel only)
-	if isLaravel && strings.ToLower(strings.Trim(envMap["BROADCAST_CONNECTION"], `"'`)) == "reverb" {
+	// 3d. Generate REVERB_ env vars if a worker with proxy config is detected and
+	// BROADCAST_CONNECTION=reverb is set.
+	if fw.HasWorker("reverb", cwd) &&
+		strings.ToLower(strings.Trim(envMap["BROADCAST_CONNECTION"], `"'`)) == "reverb" {
 		fmt.Println("  Detected reverb     — configuring REVERB_ connection values")
 		for k, v := range reverbEnvUpdates(envMap, site.PrimaryDomain(), site.Secured, cwd) {
 			updates[k] = v
@@ -460,20 +460,26 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	// 6. Generate APP_KEY if missing or empty (Laravel only).
-	// Prefer artisan key:generate when vendor/ exists; otherwise write a
-	// random base64 key directly so composer post-install scripts can boot.
-	if isLaravel && strings.TrimSpace(envMap["APP_KEY"]) == "" {
-		if _, statErr := os.Stat(filepath.Join(cwd, "vendor")); statErr == nil {
-			fmt.Println("  Generating APP_KEY...")
-			if err := artisanIn(cwd, "key:generate"); err != nil {
-				fmt.Printf("  [WARN] key:generate failed: %v\n", err)
+	// 6. Generate application key if the framework defines key generation and the key is missing.
+	if kg := fw.Env.KeyGeneration; kg != nil && strings.TrimSpace(envMap[kg.EnvKey]) == "" {
+		if kg.Command != "" {
+			if _, statErr := os.Stat(filepath.Join(cwd, "vendor")); statErr == nil {
+				fmt.Printf("  Generating %s...\n", kg.EnvKey)
+				if err := artisanIn(cwd, kg.Command); err != nil {
+					fmt.Printf("  [WARN] %s failed: %v\n", kg.Command, err)
+				}
+			} else if kg.FallbackPrefix != "" {
+				fmt.Printf("  Generating %s (vendor not installed yet)...\n", kg.EnvKey)
+				key := generateRandomKey(kg.FallbackPrefix)
+				if err := envfile.ApplyUpdates(envPath, map[string]string{kg.EnvKey: key}); err != nil {
+					fmt.Printf("  [WARN] writing %s: %v\n", kg.EnvKey, err)
+				}
 			}
-		} else {
-			fmt.Println("  Generating APP_KEY (vendor not installed yet)...")
-			key := generateLaravelAppKey()
-			if err := envfile.ApplyUpdates(envPath, map[string]string{"APP_KEY": key}); err != nil {
-				fmt.Printf("  [WARN] writing APP_KEY: %v\n", err)
+		} else if kg.FallbackPrefix != "" {
+			fmt.Printf("  Generating %s...\n", kg.EnvKey)
+			key := generateRandomKey(kg.FallbackPrefix)
+			if err := envfile.ApplyUpdates(envPath, map[string]string{kg.EnvKey: key}); err != nil {
+				fmt.Printf("  [WARN] writing %s: %v\n", kg.EnvKey, err)
 			}
 		}
 	}
@@ -752,14 +758,12 @@ func parseEnvMap(path string) (map[string]string, error) {
 	return m, scanner.Err()
 }
 
-// artisanIn runs php artisan <args> in the given directory using the project's PHP container.
-// generateLaravelAppKey generates a base64-encoded 32-byte random key in the
-// format Laravel expects (base64:...). Used when vendor/ is not installed yet
-// and artisan key:generate cannot run.
-func generateLaravelAppKey() string {
+// generateRandomKey generates a random 32-byte key with the given prefix.
+// Example: generateRandomKey("base64:") returns "base64:<base64-encoded-32-bytes>".
+func generateRandomKey(prefix string) string {
 	key := make([]byte, 32)
 	crand.Read(key) //nolint:errcheck
-	return "base64:" + base64.StdEncoding.EncodeToString(key)
+	return prefix + base64.StdEncoding.EncodeToString(key)
 }
 
 func artisanIn(dir string, args ...string) error {
@@ -865,7 +869,7 @@ func reverbEnvUpdates(envMap map[string]string, domain string, secured bool, sit
 	// REVERB_SERVER_PORT is the port Reverb listens on inside the PHP-FPM container.
 	// Auto-assign a unique port per site to prevent collisions when multiple apps run Reverb.
 	if missing("REVERB_SERVER_PORT") {
-		updates["REVERB_SERVER_PORT"] = strconv.Itoa(assignReverbServerPort(sitePath))
+		updates["REVERB_SERVER_PORT"] = strconv.Itoa(assignWorkerProxyPort(sitePath, "REVERB_SERVER_PORT", 8080))
 	}
 	serverPort := envMap["REVERB_SERVER_PORT"]
 	if v, ok := updates["REVERB_SERVER_PORT"]; ok {
@@ -903,36 +907,6 @@ func reverbEnvUpdates(envMap map[string]string, domain string, secured bool, sit
 	return updates
 }
 
-// assignReverbServerPort returns the port Reverb should listen on for the site at sitePath.
-// It scans all other linked sites and picks the lowest port >= 8080 not already in use.
-// A site's port is read from REVERB_SERVER_PORT in its .env; if absent but the site's Reverb
-// unit is active, 8080 is assumed (pre-fix sites that started without an explicit port).
-func assignReverbServerPort(sitePath string) int {
-	used := map[int]bool{}
-	if reg, err := config.LoadSites(); err == nil {
-		for _, s := range reg.Sites {
-			if filepath.Clean(s.Path) == filepath.Clean(sitePath) {
-				continue
-			}
-			if v := envfile.ReadKey(filepath.Join(s.Path, ".env"), "REVERB_SERVER_PORT"); v != "" {
-				if p, err := strconv.Atoi(v); err == nil {
-					used[p] = true
-				}
-			} else {
-				// No REVERB_SERVER_PORT in .env — if Reverb is actively running for this site
-				// it must be on the default 8080.
-				if status, _ := podman.UnitStatus("lerd-reverb-" + s.Name); status == "active" {
-					used[8080] = true
-				}
-			}
-		}
-	}
-	port := 8080
-	for used[port] {
-		port++
-	}
-	return port
-}
 
 const alphanumChars = "abcdefghijklmnopqrstuvwxyz0123456789"
 

--- a/internal/cli/framework.go
+++ b/internal/cli/framework.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"sort"
@@ -47,6 +48,10 @@ Use --check to compare local definitions against the store and show update statu
 func runFrameworkList(check bool) error {
 	frameworks := config.ListFrameworksDetailed()
 
+	// Try to resolve versions from composer.lock in cwd for frameworks
+	// that don't have a static version (e.g. built-in laravel).
+	cwd, _ := os.Getwd()
+
 	// Fetch store index if --check is requested.
 	var storeIndex *store.Index
 	if check {
@@ -71,6 +76,9 @@ func runFrameworkList(check bool) error {
 
 	for _, info := range frameworks {
 		version := info.Version
+		if version == "" && cwd != "" {
+			version = config.ComposerLockMajorVersion(cwd, info.Name)
+		}
 		if version == "" {
 			version = "—"
 		}
@@ -273,25 +281,108 @@ YAML file format:
 }
 
 func newFrameworkRemoveCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "remove <name>",
-		Short: "Remove a user-defined framework definition",
-		Args:  cobra.ExactArgs(1),
+	var all bool
+	cmd := &cobra.Command{
+		Use:   "remove <name>[@version]",
+		Short: "Remove a framework definition (user-defined or store-installed)",
+		Long: `Remove a framework definition. If multiple versions are installed and no
+version is specified, you will be prompted to choose which to remove.
+
+Use --all to remove all versions without prompting.
+
+Examples:
+  lerd framework remove symfony          # prompt if multiple versions
+  lerd framework remove symfony@7        # remove specific version
+  lerd framework remove symfony --all    # remove all versions`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			name := args[0]
-			if err := config.RemoveFramework(name); err != nil {
-				if os.IsNotExist(err) {
-					if name == "laravel" {
+			name, version := parseNameVersion(args[0])
+
+			if name == "laravel" {
+				if err := config.RemoveFramework(name); err != nil {
+					if os.IsNotExist(err) {
 						return fmt.Errorf("no custom workers defined for laravel")
 					}
-					return fmt.Errorf("framework %q not found", name)
+					return err
 				}
+				fmt.Printf("Custom laravel overlay removed (built-in definition remains).\n")
+				return nil
+			}
+
+			files := config.ListFrameworkFiles(name)
+			if len(files) == 0 {
+				return fmt.Errorf("framework %q not found", name)
+			}
+
+			// Specific version requested.
+			if version != "" {
+				for _, f := range files {
+					if f.Version == version {
+						if err := config.RemoveFrameworkFile(f.Path); err != nil {
+							return err
+						}
+						fmt.Printf("Removed %s@%s.\n", name, version)
+						return nil
+					}
+				}
+				return fmt.Errorf("framework %q version %q not found", name, version)
+			}
+
+			// Single file or --all: remove everything.
+			if len(files) == 1 || all {
+				if err := config.RemoveFramework(name); err != nil {
+					return err
+				}
+				fmt.Printf("Framework %q removed.\n", name)
+				return nil
+			}
+
+			// Multiple files: prompt.
+			fmt.Printf("Multiple definitions found for %q:\n", name)
+			labels := make([]string, len(files))
+			for i, f := range files {
+				v := f.Version
+				if v == "" {
+					v = "unversioned"
+				}
+				labels[i] = fmt.Sprintf("%s (%s)", v, f.Source)
+				fmt.Printf("  %d) %s\n", i+1, labels[i])
+			}
+			fmt.Printf("  %d) all\n", len(files)+1)
+			fmt.Printf("Choose [1-%d]: ", len(files)+1)
+
+			reader := bufio.NewReader(os.Stdin)
+			line, _ := reader.ReadString('\n')
+			line = strings.TrimSpace(line)
+			choice := 0
+			fmt.Sscanf(line, "%d", &choice)
+
+			if choice == len(files)+1 {
+				if err := config.RemoveFramework(name); err != nil {
+					return err
+				}
+				fmt.Printf("Framework %q removed (all versions).\n", name)
+				return nil
+			}
+
+			if choice < 1 || choice > len(files) {
+				return fmt.Errorf("invalid choice")
+			}
+
+			f := files[choice-1]
+			if err := config.RemoveFrameworkFile(f.Path); err != nil {
 				return err
 			}
-			fmt.Printf("Framework %q removed.\n", name)
+			v := f.Version
+			if v == "" {
+				v = "unversioned"
+			}
+			fmt.Printf("Removed %s (%s).\n", name, v)
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&all, "all", false, "Remove all versions without prompting")
+	return cmd
 }
 
 func newFrameworkSearchCmd() *cobra.Command {

--- a/internal/cli/framework.go
+++ b/internal/cli/framework.go
@@ -3,9 +3,12 @@ package cli
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/store"
+	"github.com/pmezard/go-difflib/difflib"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -19,37 +22,118 @@ func NewFrameworkCmd() *cobra.Command {
 	cmd.AddCommand(newFrameworkListCmd())
 	cmd.AddCommand(newFrameworkAddCmd())
 	cmd.AddCommand(newFrameworkRemoveCmd())
+	cmd.AddCommand(newFrameworkSearchCmd())
+	cmd.AddCommand(newFrameworkInstallCmd())
+	cmd.AddCommand(newFrameworkUpdateCmd())
 	return cmd
 }
 
 func newFrameworkListCmd() *cobra.Command {
-	return &cobra.Command{
+	var check bool
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all available framework definitions",
+		Long: `List all framework definitions (built-in, user-defined, and store-installed).
+
+Use --check to compare local definitions against the store and show update status.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			frameworks := config.ListFrameworks()
-			fmt.Printf("%-15s %-15s %-10s %s\n", "Name", "Label", "PublicDir", "Detect")
-			fmt.Printf("%-15s %-15s %-10s %s\n",
-				"───────────────", "───────────────", "──────────", "──────────────────────")
-			for _, fw := range frameworks {
-				var rules []string
-				for _, r := range fw.Detect {
-					if r.File != "" {
-						rules = append(rules, "file:"+r.File)
-					}
-					if r.Composer != "" {
-						rules = append(rules, "composer:"+r.Composer)
-					}
-				}
-				detect := strings.Join(rules, ", ")
-				if detect == "" {
-					detect = "—"
-				}
-				fmt.Printf("%-15s %-15s %-10s %s\n", fw.Name, fw.Label, fw.PublicDir, detect)
-			}
-			return nil
+			return runFrameworkList(check)
 		},
 	}
+	cmd.Flags().BoolVar(&check, "check", false, "Compare against the store and show update status")
+	return cmd
+}
+
+func runFrameworkList(check bool) error {
+	frameworks := config.ListFrameworksDetailed()
+
+	// Fetch store index if --check is requested.
+	var storeIndex *store.Index
+	if check {
+		client := store.NewClient()
+		idx, err := client.FetchIndex()
+		if err != nil {
+			fmt.Printf("[WARN] could not fetch store index: %v\n", err)
+		} else {
+			storeIndex = idx
+		}
+	}
+
+	if check {
+		fmt.Printf("%-15s %-8s %-10s %-10s %s\n", "Name", "Version", "Source", "Latest", "Status")
+		fmt.Printf("%-15s %-8s %-10s %-10s %s\n",
+			"───────────────", "────────", "──────────", "──────────", "──────────────────────")
+	} else {
+		fmt.Printf("%-15s %-8s %-10s %-10s %s\n", "Name", "Version", "Source", "PublicDir", "Workers")
+		fmt.Printf("%-15s %-8s %-10s %-10s %s\n",
+			"───────────────", "────────", "──────────", "──────────", "──────────────────────")
+	}
+
+	for _, info := range frameworks {
+		version := info.Version
+		if version == "" {
+			version = "—"
+		}
+
+		if check {
+			latest, status := storeStatus(info, storeIndex)
+			fmt.Printf("%-15s %-8s %-10s %-10s %s\n",
+				info.Name, version, info.Source, latest, status)
+		} else {
+			var workerNames []string
+			for name := range info.Workers {
+				workerNames = append(workerNames, name)
+			}
+			sort.Strings(workerNames)
+			workers := strings.Join(workerNames, ", ")
+			if workers == "" {
+				workers = "—"
+			}
+			fmt.Printf("%-15s %-8s %-10s %-10s %s\n",
+				info.Name, version, info.Source, info.PublicDir, workers)
+		}
+	}
+	return nil
+}
+
+func storeStatus(info config.FrameworkInfo, idx *store.Index) (latest, status string) {
+	if idx == nil {
+		return "—", "offline"
+	}
+
+	for _, entry := range idx.Frameworks {
+		if entry.Name != info.Name {
+			continue
+		}
+		latest = entry.Latest
+
+		localVer := info.Version
+		if localVer == "" {
+			localVer = "0"
+		}
+
+		if info.Source == config.SourceBuiltIn {
+			return latest, "built-in"
+		}
+
+		// Check if a newer version exists in the store.
+		found := false
+		for _, v := range entry.Versions {
+			if v == localVer {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return latest, "not in store"
+		}
+		if localVer == latest {
+			return latest, "up to date"
+		}
+		return latest, "update available"
+	}
+
+	return "—", "not in store"
 }
 
 func newFrameworkAddCmd() *cobra.Command {
@@ -208,4 +292,322 @@ func newFrameworkRemoveCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func newFrameworkSearchCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "search [query]",
+		Short: "Search the framework store for available definitions",
+		Long: `Search the community framework store. Without a query, lists all available frameworks.
+
+Examples:
+  lerd framework search           # list all available
+  lerd framework search symfony   # search by name`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			query := ""
+			if len(args) > 0 {
+				query = args[0]
+			}
+			client := store.NewClient()
+			results, err := client.Search(query)
+			if err != nil {
+				return fmt.Errorf("searching store: %w", err)
+			}
+			if len(results) == 0 {
+				fmt.Println("No frameworks found.")
+				return nil
+			}
+
+			fmt.Printf("%-15s %-15s %-12s %s\n", "Name", "Label", "Latest", "Versions")
+			fmt.Printf("%-15s %-15s %-12s %s\n",
+				"───────────────", "───────────────", "────────────", "──────────────────────")
+			for _, entry := range results {
+				fmt.Printf("%-15s %-15s %-12s %s\n",
+					entry.Name, entry.Label, entry.Latest, strings.Join(entry.Versions, ", "))
+			}
+			return nil
+		},
+	}
+}
+
+func newFrameworkInstallCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "install <name>[@version]",
+		Short: "Install a framework definition from the store",
+		Long: `Download and install a framework definition from the community store.
+
+If no version is specified, the version is auto-detected from composer.lock
+in the current directory, falling back to the latest available version.
+
+Examples:
+  lerd framework install symfony
+  lerd framework install laravel@11
+  lerd framework install wordpress@6`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			name, version := parseNameVersion(args[0])
+
+			client := store.NewClient()
+
+			// Auto-detect version from cwd if not specified
+			if version == "" {
+				cwd, _ := os.Getwd()
+				if cwd != "" {
+					idx, err := client.FetchIndex()
+					if err == nil {
+						for _, entry := range idx.Frameworks {
+							if entry.Name == name {
+								for _, rule := range entry.Detect {
+									if rule.Composer != "" {
+										if v := store.DetectFrameworkVersion(cwd, rule.Composer); v != "" {
+											for _, ev := range entry.Versions {
+												if ev == v {
+													version = v
+													break
+												}
+											}
+										}
+									}
+									if version != "" {
+										break
+									}
+								}
+								break
+							}
+						}
+					}
+				}
+			}
+
+			fw, err := client.FetchFramework(name, version)
+			if err != nil {
+				return err
+			}
+
+			// Check if already exists locally
+			if _, ok := config.GetFramework(name); ok {
+				fmt.Printf("Framework %q already exists locally. Overwriting with store definition.\n", name)
+			}
+
+			if err := config.SaveStoreFramework(fw); err != nil {
+				return fmt.Errorf("saving framework: %w", err)
+			}
+			// Remove old user-defined file so the store version takes effect.
+			config.RemoveUserFramework(name)
+
+			versionStr := fw.Version
+			if versionStr == "" {
+				versionStr = "latest"
+			}
+			filename := fw.Name + ".yaml"
+			if fw.Version != "" {
+				filename = fw.Name + "@" + fw.Version + ".yaml"
+			}
+			fmt.Printf("Installed %s@%s (%s).\n", fw.Name, versionStr, fw.Label)
+			fmt.Printf("Saved to %s/%s\n", config.StoreFrameworksDir(), filename)
+			return nil
+		},
+	}
+}
+
+func newFrameworkUpdateCmd() *cobra.Command {
+	var diff bool
+	cmd := &cobra.Command{
+		Use:   "update [name[@version]]",
+		Short: "Update installed framework definitions from the store",
+		Long: `Re-fetch framework definitions from the store.
+
+If a name is given, only that framework is updated.
+If no name is given, all locally installed store frameworks are updated.
+Use --diff to preview changes before applying.
+
+Examples:
+  lerd framework update symfony       # update to latest
+  lerd framework update symfony@7     # update specific version
+  lerd framework update               # update all
+  lerd framework update --diff        # show what would change`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			client := store.NewClient()
+			client.InvalidateIndex()
+
+			if len(args) == 1 {
+				name, version := parseNameVersion(args[0])
+				return updateSingleFramework(client, name, version, diff)
+			}
+			return updateAllFrameworks(client, diff)
+		},
+	}
+	cmd.Flags().BoolVar(&diff, "diff", false, "Show changes before applying")
+	return cmd
+}
+
+func updateSingleFramework(client *store.Client, name, version string, showDiff bool) error {
+	if version == "" {
+		cwd, _ := os.Getwd()
+		version = autoDetectVersion(client, name, cwd)
+	}
+	remote, err := client.FetchFramework(name, version)
+	if err != nil {
+		return err
+	}
+
+	local, _ := config.GetFramework(name)
+	if showDiff && local != nil {
+		changed, err := showFrameworkDiff(name, local, remote)
+		if err != nil {
+			return err
+		}
+		if !changed {
+			fmt.Printf("%s@%s is already up to date.\n", name, versionOrLatest(remote))
+			return nil
+		}
+	}
+
+	if err := config.SaveStoreFramework(remote); err != nil {
+		return fmt.Errorf("saving framework: %w", err)
+	}
+	// Remove old user-defined file if it exists — the store version should take effect.
+	config.RemoveUserFramework(name)
+	fmt.Printf("Updated %s@%s (%s).\n", remote.Name, versionOrLatest(remote), remote.Label)
+	return nil
+}
+
+func updateAllFrameworks(client *store.Client, showDiff bool) error {
+	idx, err := client.FetchIndex()
+	if err != nil {
+		return err
+	}
+
+	local := config.ListFrameworksDetailed()
+	updated := 0
+	for _, info := range local {
+		if info.Source == config.SourceBuiltIn {
+			continue
+		}
+		for _, entry := range idx.Frameworks {
+			if entry.Name != info.Name {
+				continue
+			}
+			remote, fetchErr := client.FetchFramework(entry.Name, entry.Latest)
+			if fetchErr != nil {
+				fmt.Printf("  [WARN] %s: %v\n", entry.Name, fetchErr)
+				continue
+			}
+
+			if showDiff {
+				changed, diffErr := showFrameworkDiff(entry.Name, info.Framework, remote)
+				if diffErr != nil {
+					fmt.Printf("  [WARN] %s: %v\n", entry.Name, diffErr)
+					continue
+				}
+				if !changed {
+					fmt.Printf("  %s@%s — up to date\n", entry.Name, versionOrLatest(remote))
+					continue
+				}
+			}
+
+			if saveErr := config.SaveStoreFramework(remote); saveErr != nil {
+				fmt.Printf("  [WARN] %s: %v\n", entry.Name, saveErr)
+				continue
+			}
+			config.RemoveUserFramework(entry.Name)
+			fmt.Printf("  Updated %s@%s\n", remote.Name, versionOrLatest(remote))
+			updated++
+			break
+		}
+	}
+	if updated == 0 {
+		fmt.Println("No frameworks to update.")
+	} else {
+		fmt.Printf("Updated %d framework(s).\n", updated)
+	}
+	return nil
+}
+
+func versionOrLatest(fw *config.Framework) string {
+	if fw.Version != "" {
+		return fw.Version
+	}
+	return "latest"
+}
+
+// showFrameworkDiff prints a colored diff between local and remote framework
+// definitions. Returns true if they differ.
+func showFrameworkDiff(name string, local, remote *config.Framework) (bool, error) {
+	localYAML, err := yaml.Marshal(local)
+	if err != nil {
+		return false, err
+	}
+	remoteYAML, err := yaml.Marshal(remote)
+	if err != nil {
+		return false, err
+	}
+	if string(localYAML) == string(remoteYAML) {
+		return false, nil
+	}
+
+	diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(localYAML)),
+		B:        difflib.SplitLines(string(remoteYAML)),
+		FromFile: name + " (local)",
+		ToFile:   name + " (store)",
+		Context:  3,
+	})
+	if err != nil {
+		return true, err
+	}
+
+	fmt.Printf("\n%s:\n", name)
+	for _, line := range strings.Split(strings.TrimRight(diff, "\n"), "\n") {
+		switch {
+		case strings.HasPrefix(line, "+"):
+			fmt.Printf("\033[32m%s\033[0m\n", line)
+		case strings.HasPrefix(line, "-"):
+			fmt.Printf("\033[31m%s\033[0m\n", line)
+		case strings.HasPrefix(line, "@@") || strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++"):
+			fmt.Printf("\033[34m%s\033[0m\n", line)
+		default:
+			fmt.Println(line)
+		}
+	}
+	fmt.Println()
+	return true, nil
+}
+
+// autoDetectVersion tries to resolve a version from composer.lock in dir.
+func autoDetectVersion(client *store.Client, name, dir string) string {
+	if dir == "" {
+		return ""
+	}
+	idx, err := client.FetchIndex()
+	if err != nil {
+		return ""
+	}
+	for _, entry := range idx.Frameworks {
+		if entry.Name != name {
+			continue
+		}
+		for _, rule := range entry.Detect {
+			if rule.Composer != "" {
+				if v := store.DetectFrameworkVersion(dir, rule.Composer); v != "" {
+					for _, ev := range entry.Versions {
+						if ev == v {
+							return v
+						}
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// parseNameVersion splits "name@version" into (name, version).
+func parseNameVersion(s string) (string, string) {
+	if i := strings.IndexByte(s, '@'); i != -1 {
+		return s[:i], s[i+1:]
+	}
+	return s, ""
 }

--- a/internal/cli/horizon.go
+++ b/internal/cli/horizon.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	phpDet "github.com/geodro/lerd/internal/php"
-	"github.com/geodro/lerd/internal/podman"
-	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/spf13/cobra"
 )
 
@@ -89,36 +87,22 @@ func newHorizonStopCmd(use string) *cobra.Command {
 	}
 }
 
-// HorizonStartForSite starts Laravel Horizon for the named site as a systemd service.
-// If a queue worker is running for the same site it is stopped first, since Horizon
-// manages queues and the two must not run simultaneously.
+// HorizonStartForSite starts Horizon for the named site. Conflicting workers
+// (defined via ConflictsWith in the framework definition) are stopped first.
 func HorizonStartForSite(siteName, sitePath, phpVersion string) error {
-	if status, _ := podman.UnitStatus("lerd-queue-" + siteName); status == "active" {
-		if err := QueueStopForSite(siteName); err != nil {
-			fmt.Printf("[WARN] stopping queue worker before horizon: %v\n", err)
-		}
+	fw, ok := config.GetFramework(siteFrameworkName(siteName))
+	if !ok {
+		return fmt.Errorf("no framework found for site %q", siteName)
 	}
-	unitName := "lerd-horizon-" + siteName
-	unit := buildHorizonUnit(siteName, sitePath, phpVersion)
-
-	changed, err := lerdSystemd.WriteServiceIfChanged(unitName, unit)
-	if err != nil {
-		return fmt.Errorf("writing service unit: %w", err)
+	worker, ok := fw.Workers["horizon"]
+	if !ok {
+		return fmt.Errorf("framework %q has no worker named \"horizon\"", fw.Label)
 	}
-	if changed {
-		if err := podman.DaemonReload(); err != nil {
-			return fmt.Errorf("daemon-reload: %w", err)
-		}
-		if err := lerdSystemd.EnableService(unitName); err != nil {
-			fmt.Printf("[WARN] enable: %v\n", err)
-		}
+	// Stop conflicting workers (e.g. queue).
+	for _, conflict := range worker.ConflictsWith {
+		WorkerStopForSite(siteName, conflict) //nolint:errcheck
 	}
-	if err := lerdSystemd.StartService(unitName); err != nil {
-		return fmt.Errorf("starting horizon: %w", err)
-	}
-	fmt.Printf("Horizon started for %s\n", siteName)
-	fmt.Printf("  Logs: journalctl --user -u %s -f\n", unitName)
-	return nil
+	return WorkerStartForSite(siteName, sitePath, phpVersion, "horizon", worker)
 }
 
 // buildHorizonUnit renders the Horizon systemd unit body. Horizon always
@@ -147,20 +131,7 @@ WantedBy=default.target
 
 // HorizonStopForSite stops and removes the Horizon unit for the named site.
 func HorizonStopForSite(siteName string) error {
-	unitName := "lerd-horizon-" + siteName
-	unitFile := filepath.Join(config.SystemdUserDir(), unitName+".service")
-
-	_ = lerdSystemd.DisableService(unitName)
-	podman.StopUnit(unitName) //nolint:errcheck
-
-	if err := os.Remove(unitFile); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("removing unit file: %w", err)
-	}
-	if err := podman.DaemonReload(); err != nil {
-		fmt.Printf("[WARN] daemon-reload: %v\n", err)
-	}
-	fmt.Printf("Horizon stopped for %s\n", siteName)
-	return nil
+	return WorkerStopForSite(siteName, "horizon")
 }
 
 // SiteHasHorizon returns true if composer.json lists laravel/horizon as a dependency.

--- a/internal/cli/horizon.go
+++ b/internal/cli/horizon.go
@@ -98,10 +98,6 @@ func HorizonStartForSite(siteName, sitePath, phpVersion string) error {
 	if !ok {
 		return fmt.Errorf("framework %q has no worker named \"horizon\"", fw.Label)
 	}
-	// Stop conflicting workers (e.g. queue).
-	for _, conflict := range worker.ConflictsWith {
-		WorkerStopForSite(siteName, conflict) //nolint:errcheck
-	}
 	return WorkerStartForSite(siteName, sitePath, phpVersion, "horizon", worker)
 }
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -91,6 +91,17 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		}
 	}
 
+	// Clamp PHP version to the framework's supported range.
+	framework, _ := resolveFramework(cwd)
+	if framework != "" {
+		if fw, fwOk := config.GetFrameworkForDir(framework, cwd); fwOk && (fw.PHP.Min != "" || fw.PHP.Max != "") {
+			clamped := phpPkg.ClampToRange(phpDefault, fw.PHP.Min, fw.PHP.Max)
+			if clamped != phpDefault {
+				phpDefault = clamped
+			}
+		}
+	}
+
 	// Database is picked as a single choice (sqlite | mysql family member |
 	// postgres family member), while other services are a multi-select. This
 	// mirrors the runtime prompt in `lerd env` and prevents users from
@@ -156,7 +167,6 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 
 	// Detect available workers from the framework definition.
 	// Workers with ConflictsWith suppress conflicted workers (e.g. horizon suppresses queue).
-	framework, _ := resolveFramework(cwd)
 	var workerOptions []string
 	if fw, ok := config.GetFrameworkForDir(framework, cwd); ok && fw.Workers != nil {
 		// Build set of workers suppressed by conflict rules.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -165,34 +165,22 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 	nodeVersion := defaults.NodeVersion
 	secured := defaults.Secured
 
-	// Detect available workers from the framework definition.
-	// Workers with ConflictsWith suppress conflicted workers (e.g. horizon suppresses queue).
-	var workerOptions []string
-	if fw, ok := config.GetFrameworkForDir(framework, cwd); ok && fw.Workers != nil {
-		// Build set of workers suppressed by conflict rules.
-		suppressed := map[string]bool{}
-		for _, wDef := range fw.Workers {
-			if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
-				continue
-			}
-			for _, c := range wDef.ConflictsWith {
-				suppressed[c] = true
-			}
-		}
-		for name, wDef := range fw.Workers {
-			if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
-				continue
-			}
-			if suppressed[name] {
-				continue
-			}
-			workerOptions = append(workerOptions, name)
-		}
-		sort.Strings(workerOptions)
-	}
 	selectedWorkers := defaults.Workers
 	if len(selectedWorkers) == 0 {
 		selectedWorkers = []string{}
+	}
+
+	// If there are custom workers from the existing config, let the user
+	// choose which to keep before the workers step.
+	var customWorkerNames []string
+	var keepCustomWorkers []string
+	if len(defaults.CustomWorkers) > 0 {
+		for name := range defaults.CustomWorkers {
+			customWorkerNames = append(customWorkerNames, name)
+		}
+		sort.Strings(customWorkerNames)
+		keepCustomWorkers = make([]string, len(customWorkerNames))
+		copy(keepCustomWorkers, customWorkerNames)
 	}
 
 	formGroups := []*huh.Group{
@@ -224,18 +212,93 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		),
 	}
 
-	if len(workerOptions) > 0 {
+	if len(customWorkerNames) > 0 {
 		formGroups = append(formGroups, huh.NewGroup(
 			huh.NewMultiSelect[string]().
-				Title("Workers").
-				Description("Auto-start when linking").
-				Options(huh.NewOptions(workerOptions...)...).
-				Value(&selectedWorkers),
+				Title("Custom workers").
+				Description("Deselect to remove from .lerd.yaml").
+				Options(huh.NewOptions(customWorkerNames...)...).
+				Value(&keepCustomWorkers),
 		))
 	}
 
 	if err := huh.NewForm(formGroups...).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
 		return nil, err
+	}
+
+	// Build the set of kept custom workers.
+	keptSet := make(map[string]bool, len(keepCustomWorkers))
+	for _, name := range keepCustomWorkers {
+		keptSet[name] = true
+	}
+
+	// Detect available workers from the framework definition.
+	// Workers with ConflictsWith suppress conflicted workers (e.g. horizon suppresses queue).
+	// Custom workers that were removed are excluded, and their conflict rules
+	// no longer apply — so previously suppressed workers become available again.
+	var workerOptions []string
+	if fw, ok := config.GetFrameworkForDir(framework, cwd); ok && fw.Workers != nil {
+		// First pass: identify which workers are removed custom workers.
+		removedCustom := map[string]bool{}
+		for name := range fw.Workers {
+			if defaults.CustomWorkers[name].Command != "" && !keptSet[name] {
+				removedCustom[name] = true
+			}
+		}
+		// Build suppression set only from workers that are NOT removed.
+		suppressed := map[string]bool{}
+		for name, wDef := range fw.Workers {
+			if removedCustom[name] {
+				continue
+			}
+			if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
+				continue
+			}
+			for _, c := range wDef.ConflictsWith {
+				suppressed[c] = true
+			}
+		}
+		for name, wDef := range fw.Workers {
+			if removedCustom[name] {
+				continue
+			}
+			if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
+				continue
+			}
+			if suppressed[name] {
+				continue
+			}
+			workerOptions = append(workerOptions, name)
+		}
+		sort.Strings(workerOptions)
+	}
+
+	// Remove any selected workers that are no longer available.
+	filtered := selectedWorkers[:0]
+	availableSet := make(map[string]bool, len(workerOptions))
+	for _, w := range workerOptions {
+		availableSet[w] = true
+	}
+	for _, w := range selectedWorkers {
+		if availableSet[w] {
+			filtered = append(filtered, w)
+		}
+	}
+	selectedWorkers = filtered
+
+	if len(workerOptions) > 0 {
+		workerGroups := []*huh.Group{
+			huh.NewGroup(
+				huh.NewMultiSelect[string]().
+					Title("Workers").
+					Description("Auto-start when linking").
+					Options(huh.NewOptions(workerOptions...)...).
+					Value(&selectedWorkers),
+			),
+		}
+		if err := huh.NewForm(workerGroups...).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
+			return nil, err
+		}
 	}
 
 	// Recombine the database pick and the non-DB multi-select into a single
@@ -306,6 +369,17 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		frameworkVersion = fw.Version
 	}
 
+	// Filter custom workers to only those the user chose to keep.
+	var filteredCustomWorkers map[string]config.FrameworkWorker
+	if len(keepCustomWorkers) > 0 {
+		filteredCustomWorkers = make(map[string]config.FrameworkWorker, len(keepCustomWorkers))
+		for _, name := range keepCustomWorkers {
+			if w, ok := defaults.CustomWorkers[name]; ok {
+				filteredCustomWorkers[name] = w
+			}
+		}
+	}
+
 	return &config.ProjectConfig{
 		PHPVersion:       phpVersion,
 		NodeVersion:      nodeVersion,
@@ -315,6 +389,9 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		Secured:          secured,
 		Services:         services,
 		Workers:          selectedWorkers,
+		CustomWorkers:    filteredCustomWorkers,
+		AppURL:           defaults.AppURL,
+		Domains:          defaults.Domains,
 	}, nil
 }
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -155,31 +155,28 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 	secured := defaults.Secured
 
 	// Detect available workers from the framework definition.
-	// If horizon is installed, show it instead of queue (they're mutually exclusive).
+	// Workers with ConflictsWith suppress conflicted workers (e.g. horizon suppresses queue).
 	framework, _ := resolveFramework(cwd)
-	hasHorizon := SiteHasHorizon(cwd)
-	hasReverb := SiteUsesReverb(cwd)
 	var workerOptions []string
-	if fw, ok := config.GetFramework(framework); ok && fw.Workers != nil {
-		for name, wDef := range fw.Workers {
-			// Skip workers whose check doesn't pass.
+	if fw, ok := config.GetFrameworkForDir(framework, cwd); ok && fw.Workers != nil {
+		// Build set of workers suppressed by conflict rules.
+		suppressed := map[string]bool{}
+		for _, wDef := range fw.Workers {
 			if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
 				continue
 			}
-			// Skip queue when horizon is installed — horizon manages queues.
-			if name == "queue" && hasHorizon {
+			for _, c := range wDef.ConflictsWith {
+				suppressed[c] = true
+			}
+		}
+		for name, wDef := range fw.Workers {
+			if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
 				continue
 			}
-			// Skip reverb when not configured.
-			if name == "reverb" && !hasReverb {
+			if suppressed[name] {
 				continue
 			}
 			workerOptions = append(workerOptions, name)
-		}
-		// Horizon is not in the framework workers map — it's auto-detected from
-		// composer.json. Add it explicitly when installed.
-		if hasHorizon {
-			workerOptions = append(workerOptions, "horizon")
 		}
 		sort.Strings(workerOptions)
 	}
@@ -237,12 +234,16 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 	selectedServices = append(selectedServices, dbChoice)
 	selectedServices = append(selectedServices, nonDBSelected...)
 
-	// For custom (non-built-in) frameworks, embed the definition so the project
-	// is fully portable — another machine can restore it from .lerd.yaml alone.
+	// Only embed the framework definition in .lerd.yaml for user-defined
+	// frameworks that aren't available from the store. Built-in (laravel) and
+	// store-installed frameworks can be fetched on any machine.
 	var frameworkDef *config.Framework
-	if framework != "" && framework != "laravel" {
-		if fw, ok := config.GetFramework(framework); ok {
-			frameworkDef = fw
+	if framework != "" {
+		info := config.GetFrameworkSource(framework)
+		if info == config.SourceUser {
+			if fw, ok := config.GetFramework(framework); ok {
+				frameworkDef = fw
+			}
 		}
 	}
 
@@ -287,14 +288,23 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		services[i] = config.ProjectService{Name: name, Custom: loaded}
 	}
 
+	// Resolve framework version from the definition that was used.
+	frameworkVersion := ""
+	if frameworkDef != nil && frameworkDef.Version != "" {
+		frameworkVersion = frameworkDef.Version
+	} else if fw, ok := config.GetFrameworkForDir(framework, cwd); ok && fw.Version != "" {
+		frameworkVersion = fw.Version
+	}
+
 	return &config.ProjectConfig{
-		PHPVersion:   phpVersion,
-		NodeVersion:  nodeVersion,
-		Framework:    framework,
-		FrameworkDef: frameworkDef,
-		Secured:      secured,
-		Services:     services,
-		Workers:      selectedWorkers,
+		PHPVersion:       phpVersion,
+		NodeVersion:      nodeVersion,
+		Framework:        framework,
+		FrameworkVersion: frameworkVersion,
+		FrameworkDef:     frameworkDef,
+		Secured:          secured,
+		Services:         services,
+		Workers:          selectedWorkers,
 	}, nil
 }
 

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -152,6 +152,18 @@ func runLink(args []string) error {
 		detectedPublicDir = config.DetectPublicDir(cwd)
 	}
 
+	// Clamp PHP version to the framework's supported range.
+	if framework != "" {
+		if fw, fwOk := config.GetFrameworkForDir(framework, cwd); fwOk && (fw.PHP.Min != "" || fw.PHP.Max != "") {
+			clamped := phpDet.ClampToRange(phpVersion, fw.PHP.Min, fw.PHP.Max)
+			if clamped != phpVersion {
+				fmt.Printf("PHP %s is outside %s's supported range (%s–%s), using PHP %s.\n",
+					phpVersion, fw.Label, fw.PHP.Min, fw.PHP.Max, clamped)
+				phpVersion = clamped
+			}
+		}
+	}
+
 	// Check if this path already has registered sites (re-link scenario).
 	// Carry over secured state and clean up any old registrations at this path.
 	secured := false

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -12,6 +12,7 @@ import (
 	nodeDet "github.com/geodro/lerd/internal/node"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/store"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -56,12 +57,14 @@ func runLink(args []string) error {
 	proj, _ := config.LoadProjectConfig(cwd)
 
 	// Restore embedded custom framework definition before resolveFramework runs.
+	// The embedded def in .lerd.yaml is the project's known-good configuration.
+	// Compare against whichever definition is currently active (user-defined or store-installed).
 	if proj != nil && proj.Framework != "" && proj.FrameworkDef != nil {
 		proj.FrameworkDef.Name = proj.Framework
-		existing, exists := config.GetFramework(proj.Framework)
+		existing, exists := config.GetFrameworkForDir(proj.Framework, cwd)
 		if !exists {
-			// Does not exist locally — save without prompting.
-			_ = config.SaveFramework(proj.FrameworkDef)
+			// No definition anywhere — save the embedded one to the store dir.
+			_ = config.SaveStoreFramework(proj.FrameworkDef)
 		} else {
 			action, err := confirmReplace("framework", proj.Framework, existing, proj.FrameworkDef)
 			if err != nil {
@@ -69,8 +72,10 @@ func runLink(args []string) error {
 			}
 			switch action {
 			case replaceFromProject:
-				_ = config.SaveFramework(proj.FrameworkDef)
+				// User chose the .lerd.yaml version — save to store dir.
+				_ = config.SaveStoreFramework(proj.FrameworkDef)
 			case replaceFromDisk:
+				// User chose the local/store version — update .lerd.yaml.
 				proj.FrameworkDef = existing
 				_ = config.SaveProjectConfig(cwd, proj)
 			}
@@ -339,41 +344,55 @@ func runLink(args []string) error {
 }
 
 // startWorkersForSite starts the named workers for a site.
-// It applies the same detection as the init wizard: if horizon is installed,
-// "queue" is upgraded to "horizon"; if reverb is not configured, it is skipped.
+// Workers with a Check rule that doesn't pass are skipped. Workers that conflict
+// with another requested worker are resolved via ConflictsWith (e.g. horizon replaces queue).
 func startWorkersForSite(site *config.Site, workers []string, phpVersion string) {
-	hasHorizon := SiteHasHorizon(site.Path)
-	hasReverb := SiteUsesReverb(site.Path)
-	fw, hasFw := config.GetFramework(site.Framework)
+	fw, hasFw := config.GetFrameworkForDir(site.Framework, site.Path)
+	if !hasFw || fw.Workers == nil {
+		return
+	}
 
+	// Build a set of requested workers, applying conflict resolution.
+	// If a worker with ConflictsWith is requested AND its conflicts are also
+	// requested, the conflicting workers are removed (e.g. horizon removes queue).
+	requested := make(map[string]bool, len(workers))
 	for _, w := range workers {
-		// If horizon is installed, start horizon instead of queue.
-		if w == "queue" && hasHorizon {
-			w = "horizon"
-		}
-		// Skip reverb if not configured in the project.
-		if w == "reverb" && !hasReverb {
+		requested[w] = true
+	}
+
+	// Check if any worker with conflicts should replace others.
+	for _, w := range workers {
+		wDef, ok := fw.Workers[w]
+		if !ok {
 			continue
 		}
-
-		var err error
-		switch w {
-		case "queue":
-			err = QueueStartForSite(site.Name, site.Path, phpVersion)
-		case "schedule":
-			err = ScheduleStartForSite(site.Name, site.Path, phpVersion)
-		case "reverb":
-			err = ReverbStartForSite(site.Name, site.Path, phpVersion)
-		case "horizon":
-			err = HorizonStartForSite(site.Name, site.Path, phpVersion)
-		default:
-			if hasFw && fw.Workers != nil {
-				if worker, ok := fw.Workers[w]; ok {
-					err = WorkerStartForSite(site.Name, site.Path, phpVersion, w, worker)
-				}
-			}
+		// Skip workers whose check doesn't pass.
+		if wDef.Check != nil && !config.MatchesRule(site.Path, *wDef.Check) {
+			delete(requested, w)
+			continue
 		}
-		if err != nil {
+		for _, conflict := range wDef.ConflictsWith {
+			delete(requested, conflict)
+		}
+	}
+
+	for _, w := range workers {
+		if !requested[w] {
+			continue
+		}
+		worker, ok := fw.Workers[w]
+		if !ok {
+			continue
+		}
+		// Skip workers whose check doesn't pass.
+		if worker.Check != nil && !config.MatchesRule(site.Path, *worker.Check) {
+			continue
+		}
+		// Stop conflicting workers before starting.
+		for _, conflict := range worker.ConflictsWith {
+			WorkerStopForSite(site.Name, conflict) //nolint:errcheck
+		}
+		if err := WorkerStartForSite(site.Name, site.Path, phpVersion, w, worker); err != nil {
 			fmt.Printf("[WARN] starting worker %s: %v\n", w, err)
 		}
 	}
@@ -395,18 +414,73 @@ func isInteractive() bool {
 // framework definition is found.
 func resolveFramework(dir string) (string, bool) {
 	if proj, err := config.LoadProjectConfig(dir); err == nil && proj.Framework != "" {
-		if _, ok := config.GetFramework(proj.Framework); ok {
+		// Check user-defined first (local overrides always win).
+		if fw := config.LoadUserFramework(proj.Framework); fw != nil {
 			return proj.Framework, true
 		}
-		// Framework definition not found locally — restore from the embedded def
-		// in .lerd.yaml if present (enables portability across machines).
+		// Embedded definition in .lerd.yaml is the project's known-good config,
+		// committed to git. Restore it to the store dir so it takes effect.
 		if proj.FrameworkDef != nil {
 			proj.FrameworkDef.Name = proj.Framework
-			if saveErr := config.SaveFramework(proj.FrameworkDef); saveErr == nil {
+			if saveErr := config.SaveStoreFramework(proj.FrameworkDef); saveErr == nil {
 				return proj.Framework, true
 			}
 		}
+		// Fall back to store-installed.
+		if _, ok := config.GetFrameworkForDir(proj.Framework, dir); ok {
+			return proj.Framework, true
+		}
+		// Not installed anywhere — try to fetch from store.
+		if fetchFrameworkFromStore(proj.Framework, dir) {
+			return proj.Framework, true
+		}
 		return "", false
 	}
-	return config.DetectFramework(dir)
+	if name, ok := config.DetectFramework(dir); ok {
+		return name, true
+	}
+	return store.DetectFrameworkWithStore(dir)
+}
+
+// fetchFrameworkFromStore attempts to install a framework definition from the
+// store. Returns true if successful.
+func fetchFrameworkFromStore(name, dir string) bool {
+	client := store.NewClient()
+	version := ""
+	// Try to detect version from the store index + composer.lock.
+	if idx, err := client.FetchIndex(); err == nil {
+		for _, entry := range idx.Frameworks {
+			if entry.Name == name {
+				for _, rule := range entry.Detect {
+					if rule.Composer != "" {
+						if v := store.DetectFrameworkVersion(dir, rule.Composer); v != "" {
+							for _, ev := range entry.Versions {
+								if ev == v {
+									version = v
+									break
+								}
+							}
+						}
+					}
+					if version != "" {
+						break
+					}
+				}
+				break
+			}
+		}
+	}
+	fw, err := client.FetchFramework(name, version)
+	if err != nil {
+		return false
+	}
+	if err := config.SaveStoreFramework(fw); err != nil {
+		return false
+	}
+	v := fw.Version
+	if v == "" {
+		v = "latest"
+	}
+	fmt.Printf("  Installed %s@%s from store\n", name, v)
+	return true
 }

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -663,6 +663,28 @@ List all workers defined for a site's framework, with their running status, comm
 Arguments:
 - ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
 
+### ` + bt + `worker_add` + bt + `
+Add or update a custom worker for a project. Saves to ` + bt + `.lerd.yaml` + bt + ` ` + bt + `custom_workers` + bt + ` by default, or to the global framework overlay (` + bt + `~/.config/lerd/frameworks/` + bt + `) with ` + bt + `global: true` + bt + `. Does not auto-start — use ` + bt + `worker_start` + bt + ` afterwards.
+
+Arguments:
+- ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
+- ` + bt + `name` + bt + ` (required): worker name (slug, e.g. ` + bt + `"pdf-generator"` + bt + `)
+- ` + bt + `command` + bt + ` (required): command to run inside the PHP-FPM container
+- ` + bt + `label` + bt + `: human-readable label
+- ` + bt + `restart` + bt + `: ` + bt + `"always"` + bt + ` or ` + bt + `"on-failure"` + bt + ` (default: always)
+- ` + bt + `check_file` + bt + `: only show worker when this file exists
+- ` + bt + `check_composer` + bt + `: only show worker when this Composer package is installed
+- ` + bt + `conflicts_with` + bt + `: array of workers to stop before starting this one
+- ` + bt + `global` + bt + `: save to global framework overlay instead of ` + bt + `.lerd.yaml` + bt + `
+
+### ` + bt + `worker_remove` + bt + `
+Remove a custom worker from a project's ` + bt + `.lerd.yaml` + bt + ` or global framework overlay. Stops the worker if running.
+
+Arguments:
+- ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
+- ` + bt + `name` + bt + ` (required): worker name to remove
+- ` + bt + `global` + bt + `: remove from global framework overlay instead of ` + bt + `.lerd.yaml` + bt + `
+
 ### ` + bt + `project_new` + bt + `
 Scaffold a new PHP project using a framework's create command. For Laravel, runs ` + bt + `composer create-project --no-install --no-plugins --no-scripts laravel/laravel <path>` + bt + `. Other frameworks must have a ` + bt + `create` + bt + ` field in their YAML definition.
 
@@ -986,7 +1008,8 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - Nginx routes ` + bt + `*.test` + bt + ` domains to the correct PHP-FPM container
 - Services (MySQL, Redis, PostgreSQL, etc.) and custom services run as Podman containers via systemd quadlets
 - Node.js versions are managed by fnm; per-project version is set via a ` + bt + `.node-version` + bt + ` file
-- Framework workers (queue, schedule, reverb, horizon, messenger, etc.) run as systemd user services named ` + bt + `lerd-<worker>-<sitename>` + bt + `; commands are defined per-framework in YAML definitions; Laravel Horizon is auto-detected from ` + bt + `composer.json` + bt + ` and replaces the queue toggle when installed; both workers and setup commands support an optional ` + bt + `check` + bt + ` field (` + bt + `file` + bt + ` or ` + bt + `composer` + bt + `) to conditionally show them based on project dependencies
+- Framework workers (queue, schedule, reverb, horizon, messenger, etc.) run as systemd user services named ` + bt + `lerd-<worker>-<sitename>` + bt + `; commands are defined per-framework in YAML definitions; Laravel Horizon is auto-detected from ` + bt + `composer.json` + bt + ` and replaces the queue toggle when installed; both workers and setup commands support an optional ` + bt + `check` + bt + ` field (` + bt + `file` + bt + ` or ` + bt + `composer` + bt + `) to conditionally show them based on project dependencies; workers with ` + bt + `conflicts_with` + bt + ` auto-stop conflicting workers on start and hide them from the UI
+- Custom workers can be added per-project (` + bt + `.lerd.yaml` + bt + ` ` + bt + `custom_workers` + bt + `) or globally (` + bt + `~/.config/lerd/frameworks/<name>.yaml` + bt + `); use ` + bt + `worker_add` + bt + ` / ` + bt + `worker_remove` + bt + ` — both survive framework store updates
 - Framework setup commands (one-off bootstrap steps like migrations, storage links) are defined in the framework YAML and shown in ` + bt + `lerd setup` + bt + `; Laravel has built-in storage:link/migrate/db:seed; custom frameworks can define their own
 - Service version placeholders (` + bt + `{{mysql_version}}` + bt + `, ` + bt + `{{postgres_version}}` + bt + `, ` + bt + `{{redis_version}}` + bt + `, ` + bt + `{{meilisearch_version}}` + bt + `) are available in framework env vars and are resolved from the service image tag at ` + bt + `lerd env` + bt + ` time
 - Git worktrees automatically get a ` + bt + `<branch>.<site>.test` + bt + ` subdomain; ` + bt + `vendor/` + bt + `, ` + bt + `node_modules/` + bt + `, and ` + bt + `.env` + bt + ` are symlinked/copied from the main checkout
@@ -1044,6 +1067,8 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `worker_start` + bt + ` | Start any named framework worker (e.g. messenger, pulse) |
 | ` + bt + `worker_stop` + bt + ` | Stop a named framework worker |
 | ` + bt + `worker_list` + bt + ` | List all workers defined for a site's framework with running status |
+| ` + bt + `worker_add` + bt + ` | Add a custom worker to a project or global framework overlay |
+| ` + bt + `worker_remove` + bt + ` | Remove a custom worker; stops it if running |
 | ` + bt + `project_new` + bt + ` | Scaffold a new PHP project (runs the framework's create command); follow with ` + bt + `site_link` + bt + ` + ` + bt + `env_setup` + bt + ` |
 | ` + bt + `framework_list` + bt + ` | List all framework definitions with their workers and setup commands |
 | ` + bt + `framework_add` + bt + ` | Add or update a framework definition; use ` + bt + `name: "laravel"` + bt + ` to add custom workers or setup commands to Laravel |
@@ -1077,6 +1102,9 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - ` + bt + `queue_start` + bt + ` requires Redis to be running when ` + bt + `QUEUE_CONNECTION=redis` + bt + `; call ` + bt + `service_start(name: "redis")` + bt + ` first
 - If ` + bt + `sites` + bt + ` returns ` + bt + `has_horizon: true` + bt + ` for a site, use ` + bt + `horizon_start` + bt + ` / ` + bt + `horizon_stop` + bt + ` instead of ` + bt + `queue_start` + bt + ` / ` + bt + `queue_stop` + bt + ` — Horizon manages queues and they are mutually exclusive
 - Use ` + bt + `worker_list` + bt + ` first to discover what workers are available for a site before calling ` + bt + `worker_start` + bt + `
+- ` + bt + `worker_add` + bt + ` saves custom workers to ` + bt + `.lerd.yaml` + bt + ` by default (project-level, committed to git); use ` + bt + `global: true` + bt + ` to save to the user framework overlay (` + bt + `~/.config/lerd/frameworks/` + bt + `) for all projects of that framework; does not auto-start — call ` + bt + `worker_start` + bt + ` afterwards
+- ` + bt + `worker_remove` + bt + ` stops a running worker before removing it from config; use ` + bt + `global: true` + bt + ` to target the framework overlay
+- Workers with ` + bt + `conflicts_with` + bt + ` automatically stop conflicting workers when started (e.g. a custom queue processor that conflicts with the default queue worker); conflicted workers are hidden from the UI while the conflicting worker runs
 - Worker unit names follow the pattern ` + bt + `lerd-<worker>-<site>` + bt + ` (e.g. ` + bt + `lerd-messenger-myapp` + bt + `, ` + bt + `lerd-horizon-myapp` + bt + `)
 - ` + bt + `site_php` + bt + ` / ` + bt + `site_node` + bt + ` change the PHP/Node version for a site; the FPM container for the new PHP version must be running after calling ` + bt + `site_php` + bt + `
 - ` + bt + `site_pause` + bt + ` / ` + bt + `site_unpause` + bt + ` free up resources for sites not in active use without unlinking them; paused state persists across restarts

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -241,23 +241,10 @@ func CollectRunningWorkerNames(site *config.Site) []string {
 func collectRunningWorkers(site *config.Site) []string {
 	var active []string
 
-	for _, w := range []string{"queue", "schedule", "reverb", "horizon"} {
-		if lerdSystemd.IsServiceActiveOrRestarting("lerd-" + w + "-" + site.Name) {
-			active = append(active, w)
-		}
-	}
-	if lerdSystemd.IsServiceActiveOrRestarting("lerd-stripe-" + site.Name) {
-		active = append(active, "stripe")
-	}
-
-	// Framework-defined custom workers (skip built-ins already checked above).
-	if fw, ok := config.GetFramework(site.Framework); ok && fw.Workers != nil {
+	// Enumerate all workers from the framework definition.
+	if fw, ok := config.GetFrameworkForDir(site.Framework, site.Path); ok && fw.Workers != nil {
 		names := make([]string, 0, len(fw.Workers))
 		for wName := range fw.Workers {
-			switch wName {
-			case "queue", "schedule", "reverb":
-				continue
-			}
 			names = append(names, wName)
 		}
 		sort.Strings(names)
@@ -268,55 +255,42 @@ func collectRunningWorkers(site *config.Site) []string {
 		}
 	}
 
+	// Stripe is not a framework worker — check it separately.
+	if lerdSystemd.IsServiceActiveOrRestarting("lerd-stripe-" + site.Name) {
+		active = append(active, "stripe")
+	}
+
 	return active
 }
 
 // stopWorkerByName stops a single named worker for the site.
 func stopWorkerByName(site *config.Site, workerName string) {
-	switch workerName {
-	case "queue":
-		QueueStopForSite(site.Name) //nolint:errcheck
-	case "schedule":
-		ScheduleStopForSite(site.Name) //nolint:errcheck
-	case "reverb":
-		ReverbStopForSite(site.Name) //nolint:errcheck
-	case "horizon":
-		HorizonStopForSite(site.Name) //nolint:errcheck
-	case "stripe":
+	if workerName == "stripe" {
 		StripeStopForSite(site.Name) //nolint:errcheck
-	default:
-		WorkerStopForSite(site.Name, workerName) //nolint:errcheck
+		return
 	}
+	WorkerStopForSite(site.Name, workerName) //nolint:errcheck
 }
 
 // resumeWorkerByName restarts a single named worker for the site.
 func resumeWorkerByName(site *config.Site, workerName, phpVersion string) {
-	switch workerName {
-	case "queue":
-		QueueStartForSite(site.Name, site.Path, phpVersion) //nolint:errcheck
-	case "schedule":
-		ScheduleStartForSite(site.Name, site.Path, phpVersion) //nolint:errcheck
-	case "reverb":
-		ReverbStartForSite(site.Name, site.Path, phpVersion) //nolint:errcheck
-	case "horizon":
-		HorizonStartForSite(site.Name, site.Path, phpVersion) //nolint:errcheck
-	case "stripe":
+	if workerName == "stripe" {
 		scheme := "http"
 		if site.Secured {
 			scheme = "https"
 		}
 		StripeStartForSite(site.Name, site.Path, scheme+"://"+site.PrimaryDomain()) //nolint:errcheck
-	default:
-		fw, ok := config.GetFramework(site.Framework)
-		if !ok || fw.Workers == nil {
-			return
-		}
-		worker, ok := fw.Workers[workerName]
-		if !ok {
-			return
-		}
-		WorkerStartForSite(site.Name, site.Path, phpVersion, workerName, worker) //nolint:errcheck
+		return
 	}
+	fw, ok := config.GetFrameworkForDir(site.Framework, site.Path)
+	if !ok || fw.Workers == nil {
+		return
+	}
+	worker, ok := fw.Workers[workerName]
+	if !ok {
+		return
+	}
+	WorkerStartForSite(site.Name, site.Path, phpVersion, workerName, worker) //nolint:errcheck
 }
 
 // pausedPageHTML is the static HTML for the shared paused-site landing page.

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -260,6 +260,13 @@ func collectRunningWorkers(site *config.Site) []string {
 		active = append(active, "stripe")
 	}
 
+	// Detect orphaned workers — running units with no framework definition.
+	known := make(map[string]bool, len(active))
+	for _, a := range active {
+		known[a] = true
+	}
+	active = append(active, lerdSystemd.FindOrphanedWorkers(site.Name, known)...)
+
 	return active
 }
 

--- a/internal/cli/queue.go
+++ b/internal/cli/queue.go
@@ -10,7 +10,6 @@ import (
 	"github.com/geodro/lerd/internal/envfile"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
-	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/spf13/cobra"
 )
 
@@ -127,34 +126,44 @@ func runQueueStop() error {
 }
 
 func queueStartExplicit(siteName, sitePath, phpVersion, queue string, tries, timeout int) error {
-	unitName := "lerd-queue-" + siteName
-	unit := buildQueueUnit(siteName, sitePath, phpVersion, queue, tries, timeout)
-
-	changed, err := lerdSystemd.WriteServiceIfChanged(unitName, unit)
-	if err != nil {
-		return fmt.Errorf("writing service unit: %w", err)
-	}
-	if changed {
-		if err := podman.DaemonReload(); err != nil {
-			return fmt.Errorf("daemon-reload: %w", err)
-		}
-		if err := lerdSystemd.EnableService(unitName); err != nil {
-			fmt.Printf("[WARN] enable: %v\n", err)
+	// Pre-flight: if the site uses Redis as its queue connection, make sure
+	// lerd-redis is actually running. Without it the queue worker fails immediately
+	// with a cryptic PHP "getaddrinfo for lerd-redis failed" DNS error.
+	envPath := filepath.Join(sitePath, ".env")
+	if envfile.ReadKey(envPath, "QUEUE_CONNECTION") == "redis" {
+		if running, _ := podman.ContainerRunning("lerd-redis"); !running {
+			return fmt.Errorf("queue worker requires Redis (QUEUE_CONNECTION=redis in .env) but lerd-redis is not running\nStart it first: lerd services start redis")
 		}
 	}
 
-	if err := lerdSystemd.StartService(unitName); err != nil {
-		return fmt.Errorf("starting queue worker: %w", err)
+	fw, ok := config.GetFramework(siteFrameworkName(siteName))
+	if !ok {
+		return fmt.Errorf("no framework found for site %q", siteName)
+	}
+	worker, ok := fw.Workers["queue"]
+	if !ok {
+		return fmt.Errorf("framework %q has no worker named \"queue\"", fw.Label)
 	}
 
-	fmt.Printf("Queue worker started for %s (queue: %s)\n", siteName, queue)
-	fmt.Printf("  Logs: journalctl --user -u %s -f\n", unitName)
-	return nil
+	// Build the command with custom flags if they differ from defaults.
+	workerCopy := worker
+	workerCopy.Command = fmt.Sprintf("php artisan queue:work --queue=%s --tries=%d --timeout=%d", queue, tries, timeout)
+
+	return WorkerStartForSite(siteName, sitePath, phpVersion, "queue", workerCopy)
 }
 
-// QueueStartForSite starts a queue worker for the given site with default settings.
+// QueueStartForSite starts a queue worker for the given site using the command
+// from the framework definition.
 func QueueStartForSite(siteName, sitePath, phpVersion string) error {
-	return queueStartExplicit(siteName, sitePath, phpVersion, "default", 3, 60)
+	fw, ok := config.GetFramework(siteFrameworkName(siteName))
+	if !ok {
+		return fmt.Errorf("no framework found for site %q", siteName)
+	}
+	worker, ok := fw.Workers["queue"]
+	if !ok {
+		return fmt.Errorf("framework %q has no worker named \"queue\"", fw.Label)
+	}
+	return WorkerStartForSite(siteName, sitePath, phpVersion, "queue", worker)
 }
 
 // buildQueueUnit renders the systemd unit body for a queue worker. Pure
@@ -249,21 +258,5 @@ func QueueRestartForSite(siteName, sitePath, phpVersion string) error {
 
 // QueueStopForSite stops and removes the queue worker for the named site.
 func QueueStopForSite(siteName string) error {
-	unitName := "lerd-queue-" + siteName
-	unitFile := filepath.Join(config.SystemdUserDir(), unitName+".service")
-
-	// Stop and disable — ignore errors if already stopped.
-	_ = lerdSystemd.DisableService(unitName)
-	podman.StopUnit(unitName) //nolint:errcheck
-
-	if err := os.Remove(unitFile); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("removing unit file: %w", err)
-	}
-
-	if err := podman.DaemonReload(); err != nil {
-		fmt.Printf("[WARN] daemon-reload: %v\n", err)
-	}
-
-	fmt.Printf("Queue worker stopped for %s\n", siteName)
-	return nil
+	return WorkerStopForSite(siteName, "queue")
 }

--- a/internal/cli/reverb.go
+++ b/internal/cli/reverb.go
@@ -5,14 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
 	"github.com/geodro/lerd/internal/nginx"
 	phpDet "github.com/geodro/lerd/internal/php"
-	"github.com/geodro/lerd/internal/podman"
-	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/spf13/cobra"
 )
 
@@ -99,103 +96,69 @@ func newReverbStopCmd(use string) *cobra.Command {
 }
 
 // ReverbStartForSite starts the Reverb WebSocket server for the named site.
+// This is an alias that looks up the "reverb" worker from the framework
+// definition and delegates to the generic WorkerStartForSite, which handles
+// proxy port assignment and nginx regeneration automatically.
 func ReverbStartForSite(siteName, sitePath, phpVersion string) error {
-	versionShort := strings.ReplaceAll(phpVersion, ".", "")
-	fpmUnit := "lerd-php" + versionShort + "-fpm"
-	container := "lerd-php" + versionShort + "-fpm"
-	unitName := "lerd-reverb-" + siteName
-
-	// Read the port Reverb should listen on from the site's .env.
-	// If absent (e.g. UI toggle before lerd env was run), auto-assign a collision-free port
-	// and persist it so nginx and future starts use the same value.
-	envPath := filepath.Join(sitePath, ".env")
-	reverbPort := envfile.ReadKey(envPath, "REVERB_SERVER_PORT")
-	if reverbPort == "" {
-		reverbPort = strconv.Itoa(assignReverbServerPort(sitePath))
-		_ = envfile.ApplyUpdates(envPath, map[string]string{"REVERB_SERVER_PORT": reverbPort})
+	fw, ok := config.GetFramework(siteFrameworkName(siteName))
+	if !ok {
+		return fmt.Errorf("no framework found for site %q", siteName)
 	}
-
-	unit := fmt.Sprintf(`[Unit]
-Description=Lerd Reverb (%s)
-After=network.target %s.service
-BindsTo=%s.service
-
-[Service]
-Type=simple
-Restart=on-failure
-RestartSec=5
-ExecStart=podman exec -w %s %s php artisan reverb:start --port=%s
-
-[Install]
-WantedBy=default.target
-`, siteName, fpmUnit, fpmUnit, sitePath, container, reverbPort)
-
-	changed, err := lerdSystemd.WriteServiceIfChanged(unitName, unit)
-	if err != nil {
-		return fmt.Errorf("writing service unit: %w", err)
+	worker, ok := fw.Workers["reverb"]
+	if !ok {
+		return fmt.Errorf("framework %q has no worker named \"reverb\"", fw.Label)
 	}
-	if changed {
-		if err := podman.DaemonReload(); err != nil {
-			return fmt.Errorf("daemon-reload: %w", err)
-		}
-		if err := lerdSystemd.EnableService(unitName); err != nil {
-			fmt.Printf("[WARN] enable: %v\n", err)
-		}
-	}
-	if err := lerdSystemd.StartService(unitName); err != nil {
-		return fmt.Errorf("starting reverb: %w", err)
-	}
-	fmt.Printf("Reverb started for %s\n", siteName)
-	fmt.Printf("  Logs: journalctl --user -u %s -f\n", unitName)
-
-	// Regenerate the nginx vhost so the /app WebSocket proxy block is added.
-	if site, err := config.FindSite(siteName); err == nil {
-		phpVer := site.PHPVersion
-		if detected, detErr := phpDet.DetectVersion(sitePath); detErr == nil && detected != "" {
-			phpVer = detected
-		}
-		var vhostErr error
-		if site.Secured {
-			vhostErr = nginx.GenerateSSLVhost(*site, phpVer)
-		} else {
-			vhostErr = nginx.GenerateVhost(*site, phpVer)
-		}
-		if vhostErr == nil {
-			_ = nginx.Reload()
-		}
-	}
-	return nil
+	return WorkerStartForSite(siteName, sitePath, phpVersion, "reverb", worker)
 }
 
 // ReverbStopForSite stops and removes the Reverb unit for the named site.
 func ReverbStopForSite(siteName string) error {
-	unitName := "lerd-reverb-" + siteName
-	unitFile := filepath.Join(config.SystemdUserDir(), unitName+".service")
-
-	_ = lerdSystemd.DisableService(unitName)
-	podman.StopUnit(unitName) //nolint:errcheck
-
-	if err := os.Remove(unitFile); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("removing unit file: %w", err)
-	}
-	if err := podman.DaemonReload(); err != nil {
-		fmt.Printf("[WARN] daemon-reload: %v\n", err)
-	}
-	fmt.Printf("Reverb stopped for %s\n", siteName)
-	return nil
+	return WorkerStopForSite(siteName, "reverb")
 }
 
-// SiteHasReverb returns true if composer.json lists laravel/reverb as a dependency.
-func SiteHasReverb(sitePath string) bool {
-	data, err := os.ReadFile(filepath.Join(sitePath, "composer.json"))
+// regenNginxVhost regenerates the nginx vhost for the site so proxy blocks are updated.
+func regenNginxVhost(siteName, sitePath string) {
+	site, err := config.FindSite(siteName)
 	if err != nil {
+		return
+	}
+	phpVer := site.PHPVersion
+	if detected, detErr := phpDet.DetectVersion(sitePath); detErr == nil && detected != "" {
+		phpVer = detected
+	}
+	var vhostErr error
+	if site.Secured {
+		vhostErr = nginx.GenerateSSLVhost(*site, phpVer)
+	} else {
+		vhostErr = nginx.GenerateVhost(*site, phpVer)
+	}
+	if vhostErr == nil {
+		_ = nginx.Reload()
+	}
+}
+
+// SiteHasProxyWorker returns true if the site's framework defines a worker with
+// a proxy configuration and that worker's check rule passes.
+func SiteHasProxyWorker(sitePath, workerName string) bool {
+	site, err := config.FindSiteByPath(sitePath)
+	if err != nil || site.Framework == "" {
 		return false
 	}
-	return strings.Contains(string(data), `"laravel/reverb"`)
+	fw, ok := config.GetFrameworkForDir(site.Framework, sitePath)
+	if !ok {
+		return false
+	}
+	return fw.HasWorker(workerName, sitePath)
 }
 
-// SiteUsesReverb returns true if the site uses Laravel Reverb — either as a
-// composer dependency or with BROADCAST_CONNECTION=reverb in .env or .env.example.
+// SiteHasReverb returns true if the site's framework defines a "reverb" worker
+// and the worker's check rule passes (e.g. laravel/reverb is in composer.json).
+func SiteHasReverb(sitePath string) bool {
+	return SiteHasProxyWorker(sitePath, "reverb")
+}
+
+// SiteUsesReverb returns true if the site has a reverb worker configured and
+// optionally checks for BROADCAST_CONNECTION=reverb in the env file.
 func SiteUsesReverb(sitePath string) bool {
 	if SiteHasReverb(sitePath) {
 		return true
@@ -206,4 +169,57 @@ func SiteUsesReverb(sitePath string) bool {
 		}
 	}
 	return false
+}
+
+// assignWorkerProxyPort finds the lowest unused port >= defaultPort for the given
+// env key across all linked sites.
+// assignWorkerProxyPort finds the lowest unused port >= defaultPort.
+// It scans ALL proxy port env keys across ALL sites to prevent collisions
+// between different workers and different frameworks.
+func assignWorkerProxyPort(sitePath, envKey string, defaultPort int) int {
+	if defaultPort == 0 {
+		defaultPort = 8080
+	}
+	used := map[int]bool{}
+	reg, err := config.LoadSites()
+	if err != nil {
+		return defaultPort
+	}
+
+	// Collect all proxy port env key names from every framework definition.
+	proxyPortKeys := map[string]bool{envKey: true}
+	for _, s := range reg.Sites {
+		if s.Framework == "" {
+			continue
+		}
+		fw, ok := config.GetFramework(s.Framework)
+		if !ok {
+			continue
+		}
+		for _, w := range fw.Workers {
+			if w.Proxy != nil && w.Proxy.PortEnvKey != "" {
+				proxyPortKeys[w.Proxy.PortEnvKey] = true
+			}
+		}
+	}
+
+	// Scan all sites for all proxy port values to build the used set.
+	for _, s := range reg.Sites {
+		if filepath.Clean(s.Path) == filepath.Clean(sitePath) {
+			continue
+		}
+		for key := range proxyPortKeys {
+			if v := envfile.ReadKey(filepath.Join(s.Path, ".env"), key); v != "" {
+				if p, err := strconv.Atoi(v); err == nil {
+					used[p] = true
+				}
+			}
+		}
+	}
+
+	port := defaultPort
+	for used[port] {
+		port++
+	}
+	return port
 }

--- a/internal/cli/schedule.go
+++ b/internal/cli/schedule.go
@@ -3,13 +3,9 @@ package cli
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/geodro/lerd/internal/config"
 	phpDet "github.com/geodro/lerd/internal/php"
-	"github.com/geodro/lerd/internal/podman"
-	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/spf13/cobra"
 )
 
@@ -89,62 +85,21 @@ func newScheduleStopCmd(use string) *cobra.Command {
 	}
 }
 
-// ScheduleStartForSite starts the Laravel task scheduler for the named site.
+// ScheduleStartForSite starts the task scheduler for the named site using
+// the "schedule" worker from the framework definition.
 func ScheduleStartForSite(siteName, sitePath, phpVersion string) error {
-	versionShort := strings.ReplaceAll(phpVersion, ".", "")
-	fpmUnit := "lerd-php" + versionShort + "-fpm"
-	container := "lerd-php" + versionShort + "-fpm"
-	unitName := "lerd-schedule-" + siteName
-
-	unit := fmt.Sprintf(`[Unit]
-Description=Lerd Scheduler (%s)
-After=network.target %s.service
-BindsTo=%s.service
-
-[Service]
-Type=simple
-Restart=always
-RestartSec=5
-ExecStart=podman exec -w %s %s php artisan schedule:work
-
-[Install]
-WantedBy=default.target
-`, siteName, fpmUnit, fpmUnit, sitePath, container)
-
-	changed, err := lerdSystemd.WriteServiceIfChanged(unitName, unit)
-	if err != nil {
-		return fmt.Errorf("writing service unit: %w", err)
+	fw, ok := config.GetFramework(siteFrameworkName(siteName))
+	if !ok {
+		return fmt.Errorf("no framework found for site %q", siteName)
 	}
-	if changed {
-		if err := podman.DaemonReload(); err != nil {
-			return fmt.Errorf("daemon-reload: %w", err)
-		}
-		if err := lerdSystemd.EnableService(unitName); err != nil {
-			fmt.Printf("[WARN] enable: %v\n", err)
-		}
+	worker, ok := fw.Workers["schedule"]
+	if !ok {
+		return fmt.Errorf("framework %q has no worker named \"schedule\"", fw.Label)
 	}
-	if err := lerdSystemd.StartService(unitName); err != nil {
-		return fmt.Errorf("starting scheduler: %w", err)
-	}
-	fmt.Printf("Scheduler started for %s\n", siteName)
-	fmt.Printf("  Logs: journalctl --user -u %s -f\n", unitName)
-	return nil
+	return WorkerStartForSite(siteName, sitePath, phpVersion, "schedule", worker)
 }
 
 // ScheduleStopForSite stops and removes the scheduler unit for the named site.
 func ScheduleStopForSite(siteName string) error {
-	unitName := "lerd-schedule-" + siteName
-	unitFile := filepath.Join(config.SystemdUserDir(), unitName+".service")
-
-	_ = lerdSystemd.DisableService(unitName)
-	podman.StopUnit(unitName) //nolint:errcheck
-
-	if err := os.Remove(unitFile); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("removing unit file: %w", err)
-	}
-	if err := podman.DaemonReload(); err != nil {
-		fmt.Printf("[WARN] daemon-reload: %v\n", err)
-	}
-	fmt.Printf("Scheduler stopped for %s\n", siteName)
-	return nil
+	return WorkerStopForSite(siteName, "schedule")
 }

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -15,6 +15,7 @@ import (
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/store"
+	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/spf13/cobra"
 )
 
@@ -200,6 +201,28 @@ func runSetup(allSteps, skipOpen bool) error {
 		})
 	}
 
+	// Orphaned workers — running units with no framework definition.
+	// Shown before framework workers so they are stopped first.
+	if site != nil {
+		known := make(map[string]bool)
+		if fw, ok := config.GetFrameworkForDir(site.Framework, cwd); ok {
+			for wn := range fw.Workers {
+				known[wn] = true
+			}
+		}
+		orphans := lerdSystemd.FindOrphanedWorkers(site.Name, known)
+		for _, oName := range orphans {
+			on := oName
+			steps = append(steps, setupStep{
+				label:   on + ":stop (orphaned)",
+				enabled: true,
+				run: func() error {
+					return WorkerStopForSite(site.Name, on)
+				},
+			})
+		}
+	}
+
 	// Framework workers — driven entirely by the framework definition.
 	// Workers with ConflictsWith suppress the conflicted worker from the list
 	// (e.g. horizon replaces queue when horizon's check passes).
@@ -209,7 +232,6 @@ func runSetup(allSteps, skipOpen bool) error {
 			fwName, _ = store.DetectFrameworkWithStore(cwd)
 		}
 		if fw, ok := config.GetFramework(fwName); ok && fw.Workers != nil {
-			// Build a set of workers suppressed by conflict rules.
 			suppressed := map[string]bool{}
 			for _, wDef := range fw.Workers {
 				if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
@@ -246,7 +268,6 @@ func runSetup(allSteps, skipOpen bool) error {
 								phpVersion = cfg.PHP.DefaultVersion
 							}
 						}
-						// Stop conflicting workers before starting.
 						for _, conflict := range wd.ConflictsWith {
 							WorkerStopForSite(s.Name, conflict) //nolint:errcheck
 						}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/geodro/lerd/internal/envfile"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/store"
 	"github.com/spf13/cobra"
 )
 
@@ -83,7 +84,6 @@ func runSetup(allSteps, skipOpen bool) error {
 	}
 
 	site, _ := config.FindSiteByPath(cwd)
-	isLaravel := site != nil && site.IsLaravel()
 
 	// Load saved workers from .lerd.yaml to pre-select them in the step selector.
 	projCfg, _ := config.LoadProjectConfig(cwd)
@@ -168,7 +168,7 @@ func runSetup(allSteps, skipOpen bool) error {
 	if site != nil {
 		fwName := site.Framework
 		if fwName == "" {
-			fwName, _ = config.DetectFramework(cwd)
+			fwName, _ = store.DetectFrameworkWithStore(cwd)
 		}
 		if fw, ok := config.GetFramework(fwName); ok {
 			for _, sc := range fw.Setup {
@@ -178,10 +178,6 @@ func runSetup(allSteps, skipOpen bool) error {
 				}
 				setupCmd := sc
 				enabled := setupCmd.Default
-				// Laravel dynamic default: only enable storage:link when actually needed.
-				if fwName == "laravel" && strings.Contains(setupCmd.Command, "storage:link") {
-					enabled = siteNeedsStorageLink(cwd)
-				}
 				steps = append(steps, setupStep{
 					label:   setupCmd.Label,
 					enabled: enabled,
@@ -204,128 +200,32 @@ func runSetup(allSteps, skipOpen bool) error {
 		})
 	}
 
-	if isLaravel {
-		// Show horizon instead of queue when laravel/horizon is installed.
-		if SiteHasHorizon(cwd) {
-			steps = append(steps, setupStep{
-				label:   "horizon:start",
-				enabled: savedWorkers["horizon"],
-				run: func() error {
-					s, err := config.FindSiteByPath(cwd)
-					if err != nil {
-						return fmt.Errorf("site not registered: %w", err)
-					}
-					phpVersion := s.PHPVersion
-					if phpVersion == "" {
-						if detected, detErr := phpDet.DetectVersion(cwd); detErr == nil {
-							phpVersion = detected
-						} else {
-							cfg, _ := config.LoadGlobal()
-							phpVersion = cfg.PHP.DefaultVersion
-						}
-					}
-					return HorizonStartForSite(s.Name, cwd, phpVersion)
-				},
-			})
-		} else {
-			steps = append(steps, setupStep{
-				label:   "queue:start",
-				enabled: savedWorkers["queue"] || siteUsesRedisQueue(cwd),
-				run: func() error {
-					s, err := config.FindSiteByPath(cwd)
-					if err != nil {
-						return fmt.Errorf("site not registered: %w", err)
-					}
-					phpVersion := s.PHPVersion
-					if phpVersion == "" {
-						if detected, detErr := phpDet.DetectVersion(cwd); detErr == nil {
-							phpVersion = detected
-						} else {
-							cfg, _ := config.LoadGlobal()
-							phpVersion = cfg.PHP.DefaultVersion
-						}
-					}
-					return QueueStartForSite(s.Name, cwd, phpVersion)
-				},
-			})
-		}
-
-		steps = append(steps, setupStep{
-			label:   "stripe:listen",
-			enabled: siteHasStripeSecret(cwd),
-			run: func() error {
-				s, err := config.FindSiteByPath(cwd)
-				if err != nil {
-					return fmt.Errorf("site not registered: %w", err)
-				}
-				base := siteURL(cwd)
-				if base == "" {
-					return fmt.Errorf("could not resolve site URL — run 'lerd link' first")
-				}
-				return StripeStartForSite(s.Name, cwd, base)
-			},
-		})
-
-		steps = append(steps, setupStep{
-			label:   "schedule:start",
-			enabled: savedWorkers["schedule"],
-			run: func() error {
-				s, err := config.FindSiteByPath(cwd)
-				if err != nil {
-					return fmt.Errorf("site not registered: %w", err)
-				}
-				phpVersion := s.PHPVersion
-				if phpVersion == "" {
-					if detected, detErr := phpDet.DetectVersion(cwd); detErr == nil {
-						phpVersion = detected
-					} else {
-						cfg, _ := config.LoadGlobal()
-						phpVersion = cfg.PHP.DefaultVersion
-					}
-				}
-				return ScheduleStartForSite(s.Name, cwd, phpVersion)
-			},
-		})
-
-		steps = append(steps, setupStep{
-			label:   "reverb:start",
-			enabled: savedWorkers["reverb"] || SiteUsesReverb(cwd),
-			run: func() error {
-				s, err := config.FindSiteByPath(cwd)
-				if err != nil {
-					return fmt.Errorf("site not registered: %w", err)
-				}
-				phpVersion := s.PHPVersion
-				if phpVersion == "" {
-					if detected, detErr := phpDet.DetectVersion(cwd); detErr == nil {
-						phpVersion = detected
-					} else {
-						cfg, _ := config.LoadGlobal()
-						phpVersion = cfg.PHP.DefaultVersion
-					}
-				}
-				return ReverbStartForSite(s.Name, cwd, phpVersion)
-			},
-		})
-	}
-
-	// Custom framework workers (e.g. messenger for Symfony).
-	// For Laravel, skip built-in worker names already handled above.
+	// Framework workers — driven entirely by the framework definition.
+	// Workers with ConflictsWith suppress the conflicted worker from the list
+	// (e.g. horizon replaces queue when horizon's check passes).
 	if site != nil {
 		fwName := site.Framework
 		if fwName == "" {
-			fwName, _ = config.DetectFramework(cwd)
+			fwName, _ = store.DetectFrameworkWithStore(cwd)
 		}
 		if fw, ok := config.GetFramework(fwName); ok && fw.Workers != nil {
+			// Build a set of workers suppressed by conflict rules.
+			suppressed := map[string]bool{}
+			for _, wDef := range fw.Workers {
+				if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
+					continue
+				}
+				for _, c := range wDef.ConflictsWith {
+					suppressed[c] = true
+				}
+			}
+
 			for wName, wDef := range fw.Workers {
 				if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
 					continue
 				}
-				if isLaravel {
-					switch wName {
-					case "queue", "schedule", "reverb":
-						continue
-					}
+				if suppressed[wName] {
+					continue
 				}
 				wn := wName
 				wd := wDef
@@ -346,11 +246,34 @@ func runSetup(allSteps, skipOpen bool) error {
 								phpVersion = cfg.PHP.DefaultVersion
 							}
 						}
+						// Stop conflicting workers before starting.
+						for _, conflict := range wd.ConflictsWith {
+							WorkerStopForSite(s.Name, conflict) //nolint:errcheck
+						}
 						return WorkerStartForSite(s.Name, cwd, phpVersion, wn, wd)
 					},
 				})
 			}
 		}
+	}
+
+	// Stripe listener (not a framework worker — still special-cased).
+	if siteHasStripeSecret(cwd) {
+		steps = append(steps, setupStep{
+			label:   "stripe:listen",
+			enabled: siteHasStripeSecret(cwd),
+			run: func() error {
+				s, err := config.FindSiteByPath(cwd)
+				if err != nil {
+					return fmt.Errorf("site not registered: %w", err)
+				}
+				base := siteURL(cwd)
+				if base == "" {
+					return fmt.Errorf("could not resolve site URL — run 'lerd link' first")
+				}
+				return StripeStartForSite(s.Name, cwd, base)
+			},
+		})
 	}
 
 	if !skipOpen {

--- a/internal/cli/sites.go
+++ b/internal/cli/sites.go
@@ -47,8 +47,11 @@ func runSites(_ *cobra.Command, _ []string) error {
 		}
 		fwName := s.Framework
 		fwLabel := ""
-		if fw, ok := config.GetFramework(fwName); ok {
+		if fw, ok := config.GetFrameworkForDir(fwName, s.Path); ok {
 			fwLabel = fw.Label
+			if fw.Version != "" {
+				fwLabel += " " + fw.Version
+			}
 		}
 
 		var worktrees []gitpkg.Worktree

--- a/internal/cli/sites.go
+++ b/internal/cli/sites.go
@@ -46,9 +46,6 @@ func runSites(_ *cobra.Command, _ []string) error {
 			continue
 		}
 		fwName := s.Framework
-		if fwName == "" {
-			fwName, _ = config.DetectFramework(s.Path)
-		}
 		fwLabel := ""
 		if fw, ok := config.GetFramework(fwName); ok {
 			fwLabel = fw.Label

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -502,6 +502,19 @@ func restoreSiteInfrastructure() {
 
 	seenPHP := map[string]bool{}
 	seenSvc := map[string]bool{}
+	dirty := false
+
+	// Backfill framework for all sites (including paused) that were linked
+	// before detection was added.
+	for i, s := range reg.Sites {
+		if s.Ignored || s.Framework != "" {
+			continue
+		}
+		if name, ok := config.DetectFramework(s.Path); ok {
+			reg.Sites[i].Framework = name
+			dirty = true
+		}
+	}
 
 	for _, s := range reg.Sites {
 		if s.Paused || s.Ignored {
@@ -558,33 +571,28 @@ func restoreSiteInfrastructure() {
 				cfg, _ := config.LoadGlobal()
 				phpVersion = cfg.PHP.DefaultVersion
 			}
-			switch w {
-			case "queue":
-				QueueStartForSite(s.Name, s.Path, phpVersion) //nolint:errcheck
-			case "schedule":
-				ScheduleStartForSite(s.Name, s.Path, phpVersion) //nolint:errcheck
-			case "reverb":
-				ReverbStartForSite(s.Name, s.Path, phpVersion) //nolint:errcheck
-			case "horizon":
-				HorizonStartForSite(s.Name, s.Path, phpVersion) //nolint:errcheck
-			case "stripe":
+			// Stripe is not a framework worker.
+			if w == "stripe" {
 				base := siteURL(s.Path)
 				if base != "" {
 					StripeStartForSite(s.Name, s.Path, base) //nolint:errcheck
 				}
-			default:
-				// Custom framework worker — look up definition.
-				fwName := s.Framework
-				if fwName == "" {
-					fwName, _ = config.DetectFramework(s.Path)
-				}
-				if fw, ok := config.GetFramework(fwName); ok && fw.Workers != nil {
-					if wDef, ok := fw.Workers[w]; ok {
-						WorkerStartForSite(s.Name, s.Path, phpVersion, w, wDef) //nolint:errcheck
+				continue
+			}
+			// All other workers come from the framework definition.
+			fwName := s.Framework
+			if fw, ok := config.GetFrameworkForDir(fwName, s.Path); ok && fw.Workers != nil {
+				if wDef, ok := fw.Workers[w]; ok {
+					for _, conflict := range wDef.ConflictsWith {
+						WorkerStopForSite(s.Name, conflict) //nolint:errcheck
 					}
+					WorkerStartForSite(s.Name, s.Path, phpVersion, w, wDef) //nolint:errcheck
 				}
 			}
 		}
+	}
+	if dirty {
+		config.SaveSites(reg) //nolint:errcheck
 	}
 	podman.DaemonReload() //nolint:errcheck
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -196,10 +196,7 @@ func runStatus(_ *cobra.Command, _ []string) error {
 				}
 				// Check custom framework workers.
 				fwName := s.Framework
-				if fwName == "" {
-					fwName, _ = config.DetectFramework(s.Path)
-				}
-				if fw, ok := config.GetFramework(fwName); ok && fw.Workers != nil {
+				if fw, ok := config.GetFrameworkForDir(fwName, s.Path); ok && fw.Workers != nil {
 					for wName, wDef := range fw.Workers {
 						switch wName {
 						case "queue", "schedule", "reverb":

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/envfile"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
@@ -131,12 +133,10 @@ func resolveSiteAndFramework(cwd string) (*config.Site, *config.Framework, strin
 
 	fwName := site.Framework
 	if fwName == "" {
-		if detected, ok := config.DetectFramework(cwd); ok {
-			fwName = detected
-		}
+		return nil, nil, "", fmt.Errorf("site %q has no framework assigned — run 'lerd link' first", site.Name)
 	}
 
-	fw, ok := config.GetFramework(fwName)
+	fw, ok := config.GetFrameworkForDir(fwName, cwd)
 	if !ok {
 		return nil, nil, "", fmt.Errorf("site %q has no framework assigned — run 'lerd link' or 'lerd framework add'", site.Name)
 	}
@@ -170,7 +170,22 @@ func requireFrameworkWorker(cwd, workerName string) error {
 
 // WorkerStartForSite writes a systemd unit for the given framework worker and starts it.
 // The unit name is lerd-{workerName}-{siteName}.
+// If the worker has a Proxy config, the proxy port is auto-assigned and the
+// nginx vhost is regenerated to include the WebSocket/HTTP proxy block.
 func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w config.FrameworkWorker) error {
+	command := w.Command
+
+	// Handle proxy port assignment and command augmentation.
+	if w.Proxy != nil && w.Proxy.PortEnvKey != "" {
+		envPath := filepath.Join(sitePath, ".env")
+		port := envfile.ReadKey(envPath, w.Proxy.PortEnvKey)
+		if port == "" {
+			port = strconv.Itoa(assignWorkerProxyPort(sitePath, w.Proxy.PortEnvKey, w.Proxy.DefaultPort))
+			_ = envfile.ApplyUpdates(envPath, map[string]string{w.Proxy.PortEnvKey: port})
+		}
+		command = command + " --port=" + port
+	}
+
 	versionShort := strings.ReplaceAll(phpVersion, ".", "")
 	fpmUnit := "lerd-php" + versionShort + "-fpm"
 	container := "lerd-php" + versionShort + "-fpm"
@@ -198,7 +213,7 @@ ExecStart=podman exec -w %s %s %s
 
 [Install]
 WantedBy=default.target
-`, label, siteName, fpmUnit, fpmUnit, restart, sitePath, container, w.Command)
+`, label, siteName, fpmUnit, fpmUnit, restart, sitePath, container, command)
 
 	changed, err := lerdSystemd.WriteServiceIfChanged(unitName, unit)
 	if err != nil {
@@ -219,7 +234,23 @@ WantedBy=default.target
 
 	fmt.Printf("%s started for %s\n", label, siteName)
 	fmt.Printf("  Logs: journalctl --user -u %s -f\n", unitName)
+
+	// Regenerate nginx vhost if the worker has proxy config.
+	if w.Proxy != nil {
+		regenNginxVhost(siteName, sitePath)
+	}
+
 	return nil
+}
+
+// siteFrameworkName returns the saved framework name for the given site, or "".
+// Does not auto-detect — framework should already be set at link time.
+func siteFrameworkName(siteName string) string {
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return ""
+	}
+	return site.Framework
 }
 
 // WorkerStopForSite stops and removes the named worker unit for the given site.

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -25,6 +25,8 @@ func NewWorkerCmd() *cobra.Command {
 	cmd.AddCommand(newWorkerStartCmd())
 	cmd.AddCommand(newWorkerStopCmd())
 	cmd.AddCommand(newWorkerListCmd())
+	cmd.AddCommand(newWorkerAddCmd())
+	cmd.AddCommand(newWorkerRemoveCmd())
 	return cmd
 }
 
@@ -71,8 +73,13 @@ func newWorkerStopCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// Allow stopping orphaned workers that have a running unit
+			// but are no longer in the framework definition.
 			if _, ok := fw.Workers[workerName]; !ok {
-				return fmt.Errorf("framework %q has no worker named %q\nRun 'lerd worker list' to see available workers", fw.Label, workerName)
+				unitName := "lerd-" + workerName + "-" + site.Name
+				if !lerdSystemd.IsServiceActiveOrRestarting(unitName) {
+					return fmt.Errorf("framework %q has no worker named %q\nRun 'lerd worker list' to see available workers", fw.Label, workerName)
+				}
 			}
 			if err := WorkerStopForSite(site.Name, workerName); err != nil {
 				return err
@@ -92,31 +99,42 @@ func newWorkerListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			_, fw, _, err := resolveSiteAndFramework(cwd)
+			site, fw, _, err := resolveSiteAndFramework(cwd)
 			if err != nil {
 				return err
 			}
+			known := make(map[string]bool)
 			if len(fw.Workers) == 0 {
 				fmt.Printf("Framework %q has no workers defined.\n", fw.Label)
-				return nil
-			}
-			names := make([]string, 0, len(fw.Workers))
-			for n, wDef := range fw.Workers {
-				if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
-					continue
+			} else {
+				names := make([]string, 0, len(fw.Workers))
+				for n, wDef := range fw.Workers {
+					if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
+						continue
+					}
+					names = append(names, n)
 				}
-				names = append(names, n)
-			}
-			sort.Strings(names)
-			fmt.Printf("Workers for %s:\n", fw.Label)
-			for _, name := range names {
-				w := fw.Workers[name]
-				label := w.Label
-				if label == "" {
-					label = name
+				sort.Strings(names)
+				fmt.Printf("Workers for %s:\n", fw.Label)
+				for _, name := range names {
+					known[name] = true
+					w := fw.Workers[name]
+					label := w.Label
+					if label == "" {
+						label = name
+					}
+					fmt.Printf("  %-15s %s\n", name, label)
+					fmt.Printf("  %-15s command: %s\n", "", w.Command)
 				}
-				fmt.Printf("  %-15s %s\n", name, label)
-				fmt.Printf("  %-15s command: %s\n", "", w.Command)
+			}
+
+			// Detect orphaned workers — running systemd units with no definition.
+			orphans := lerdSystemd.FindOrphanedWorkers(site.Name, known)
+			if len(orphans) > 0 {
+				fmt.Println("\nOrphaned workers (running but not defined):")
+				for _, name := range orphans {
+					fmt.Printf("  %-15s (stop with: lerd worker stop %s)\n", name, name)
+				}
 			}
 			return nil
 		},
@@ -173,6 +191,11 @@ func requireFrameworkWorker(cwd, workerName string) error {
 // If the worker has a Proxy config, the proxy port is auto-assigned and the
 // nginx vhost is regenerated to include the WebSocket/HTTP proxy block.
 func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w config.FrameworkWorker) error {
+	// Stop conflicting workers before starting.
+	for _, conflict := range w.ConflictsWith {
+		WorkerStopForSite(siteName, conflict) //nolint:errcheck
+	}
+
 	command := w.Command
 
 	// Handle proxy port assignment and command augmentation.
@@ -243,6 +266,181 @@ WantedBy=default.target
 	return nil
 }
 
+func newWorkerAddCmd() *cobra.Command {
+	var (
+		command       string
+		label         string
+		restart       string
+		checkFile     string
+		checkComposer string
+		conflictsWith []string
+		proxyPath     string
+		proxyPortKey  string
+		proxyDefPort  int
+		global        bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Add a custom worker to this project or global framework overlay",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			name := args[0]
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+
+			site, err := config.FindSiteByPath(cwd)
+			if err != nil {
+				return fmt.Errorf("not a registered site — run 'lerd link' first")
+			}
+
+			w := config.FrameworkWorker{
+				Label:         label,
+				Command:       command,
+				Restart:       restart,
+				ConflictsWith: conflictsWith,
+			}
+			if checkFile != "" || checkComposer != "" {
+				w.Check = &config.FrameworkRule{File: checkFile, Composer: checkComposer}
+			}
+			if proxyPath != "" {
+				w.Proxy = &config.WorkerProxy{
+					Path:        proxyPath,
+					PortEnvKey:  proxyPortKey,
+					DefaultPort: proxyDefPort,
+				}
+			}
+
+			action := "added"
+			if global {
+				fwName := site.Framework
+				if fwName == "" {
+					return fmt.Errorf("site %q has no framework assigned", site.Name)
+				}
+				fw := config.LoadUserFramework(fwName)
+				if fw == nil {
+					fw = &config.Framework{Name: fwName}
+				}
+				if fw.Workers == nil {
+					fw.Workers = make(map[string]config.FrameworkWorker)
+				}
+				if _, exists := fw.Workers[name]; exists {
+					action = "updated"
+				}
+				fw.Workers[name] = w
+				if err := config.SaveFramework(fw); err != nil {
+					return fmt.Errorf("saving framework overlay: %w", err)
+				}
+				fmt.Printf("Custom worker %q %s in global %s overlay\n", name, action, fwName)
+			} else {
+				proj, err := config.LoadProjectConfig(cwd)
+				if err != nil {
+					return fmt.Errorf("loading .lerd.yaml: %w", err)
+				}
+				if proj.CustomWorkers == nil {
+					proj.CustomWorkers = make(map[string]config.FrameworkWorker)
+				}
+				if _, exists := proj.CustomWorkers[name]; exists {
+					action = "updated"
+				}
+				proj.CustomWorkers[name] = w
+				if err := config.SaveProjectConfig(cwd, proj); err != nil {
+					return fmt.Errorf("saving .lerd.yaml: %w", err)
+				}
+				fmt.Printf("Custom worker %q %s in .lerd.yaml\n", name, action)
+			}
+			fmt.Printf("Start it with: lerd worker start %s\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&command, "command", "", "Command to run (required)")
+	cmd.Flags().StringVar(&label, "label", "", "Human-readable label")
+	cmd.Flags().StringVar(&restart, "restart", "", "Restart policy: always or on-failure")
+	cmd.Flags().StringVar(&checkFile, "check-file", "", "Only show worker when this file exists")
+	cmd.Flags().StringVar(&checkComposer, "check-composer", "", "Only show worker when this Composer package is installed")
+	cmd.Flags().StringSliceVar(&conflictsWith, "conflicts-with", nil, "Workers to stop before starting this one")
+	cmd.Flags().StringVar(&proxyPath, "proxy-path", "", "URL path to proxy (e.g. /app)")
+	cmd.Flags().StringVar(&proxyPortKey, "proxy-port-env-key", "", "Env key holding the worker port")
+	cmd.Flags().IntVar(&proxyDefPort, "proxy-default-port", 0, "Default port if env key is missing")
+	cmd.Flags().BoolVar(&global, "global", false, "Save to global framework overlay instead of .lerd.yaml")
+	_ = cmd.MarkFlagRequired("command")
+
+	return cmd
+}
+
+func newWorkerRemoveCmd() *cobra.Command {
+	var global bool
+
+	cmd := &cobra.Command{
+		Use:   "remove <name>",
+		Short: "Remove a custom worker from .lerd.yaml or global framework overlay",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			name := args[0]
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+
+			site, err := config.FindSiteByPath(cwd)
+			if err != nil {
+				return fmt.Errorf("not a registered site — run 'lerd link' first")
+			}
+
+			// Stop the worker if running.
+			unitName := "lerd-" + name + "-" + site.Name
+			if lerdSystemd.IsServiceActiveOrRestarting(unitName) {
+				_ = WorkerStopForSite(site.Name, name)
+			}
+
+			if global {
+				fwName := site.Framework
+				if fwName == "" {
+					return fmt.Errorf("site %q has no framework assigned", site.Name)
+				}
+				fw := config.LoadUserFramework(fwName)
+				if fw == nil || fw.Workers == nil {
+					return fmt.Errorf("no global overlay for framework %q", fwName)
+				}
+				if _, exists := fw.Workers[name]; !exists {
+					return fmt.Errorf("worker %q not found in global %s overlay", name, fwName)
+				}
+				delete(fw.Workers, name)
+				if len(fw.Workers) == 0 {
+					fw.Workers = nil
+				}
+				if err := config.SaveFramework(fw); err != nil {
+					return fmt.Errorf("saving framework overlay: %w", err)
+				}
+				fmt.Printf("Custom worker %q removed from global %s overlay\n", name, fwName)
+			} else {
+				proj, err := config.LoadProjectConfig(cwd)
+				if err != nil {
+					return fmt.Errorf("loading .lerd.yaml: %w", err)
+				}
+				if _, exists := proj.CustomWorkers[name]; !exists {
+					return fmt.Errorf("custom worker %q not found in .lerd.yaml", name)
+				}
+				delete(proj.CustomWorkers, name)
+				if len(proj.CustomWorkers) == 0 {
+					proj.CustomWorkers = nil
+				}
+				if err := config.SaveProjectConfig(cwd, proj); err != nil {
+					return fmt.Errorf("saving .lerd.yaml: %w", err)
+				}
+				fmt.Printf("Custom worker %q removed from .lerd.yaml\n", name)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&global, "global", false, "Remove from global framework overlay instead of .lerd.yaml")
+	return cmd
+}
+
 // siteFrameworkName returns the saved framework name for the given site, or "".
 // Does not auto-detect — framework should already be set at link time.
 func siteFrameworkName(siteName string) string {
@@ -272,3 +470,4 @@ func WorkerStopForSite(siteName, workerName string) error {
 	fmt.Printf("%s stopped for %s\n", label, siteName)
 	return nil
 }
+

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -470,4 +470,3 @@ func WorkerStopForSite(siteName, workerName string) error {
 	fmt.Printf("%s stopped for %s\n", label, siteName)
 	return nil
 }
-

--- a/internal/cli/worker_test.go
+++ b/internal/cli/worker_test.go
@@ -1,0 +1,252 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestWorkerAdd_Project(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644)
+
+	proj, _ := config.LoadProjectConfig(dir)
+	if proj.CustomWorkers == nil {
+		proj.CustomWorkers = make(map[string]config.FrameworkWorker)
+	}
+	proj.CustomWorkers["pulse"] = config.FrameworkWorker{
+		Label:   "Pulse",
+		Command: "php artisan pulse:work",
+	}
+	if err := config.SaveProjectConfig(dir, proj); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := config.LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w, ok := got.CustomWorkers["pulse"]
+	if !ok {
+		t.Fatal("expected pulse in custom_workers")
+	}
+	if w.Command != "php artisan pulse:work" {
+		t.Errorf("command = %q, want %q", w.Command, "php artisan pulse:work")
+	}
+	if w.Label != "Pulse" {
+		t.Errorf("label = %q, want %q", w.Label, "Pulse")
+	}
+}
+
+func TestWorkerAdd_UpdateExisting(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644)
+
+	proj, _ := config.LoadProjectConfig(dir)
+	proj.CustomWorkers = map[string]config.FrameworkWorker{
+		"pulse": {Command: "php artisan pulse:work"},
+	}
+	config.SaveProjectConfig(dir, proj)
+
+	// Update the command.
+	proj, _ = config.LoadProjectConfig(dir)
+	proj.CustomWorkers["pulse"] = config.FrameworkWorker{
+		Command: "php artisan pulse:work --rest=1",
+		Label:   "Pulse Updated",
+	}
+	config.SaveProjectConfig(dir, proj)
+
+	got, _ := config.LoadProjectConfig(dir)
+	w := got.CustomWorkers["pulse"]
+	if w.Command != "php artisan pulse:work --rest=1" {
+		t.Errorf("command not updated: %q", w.Command)
+	}
+	if w.Label != "Pulse Updated" {
+		t.Errorf("label not updated: %q", w.Label)
+	}
+}
+
+func TestWorkerAdd_WithCheck(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644)
+
+	proj, _ := config.LoadProjectConfig(dir)
+	proj.CustomWorkers = map[string]config.FrameworkWorker{
+		"pulse": {
+			Command: "php artisan pulse:work",
+			Check:   &config.FrameworkRule{Composer: "laravel/pulse"},
+		},
+	}
+	config.SaveProjectConfig(dir, proj)
+
+	got, _ := config.LoadProjectConfig(dir)
+	w := got.CustomWorkers["pulse"]
+	if w.Check == nil {
+		t.Fatal("expected check to be set")
+	}
+	if w.Check.Composer != "laravel/pulse" {
+		t.Errorf("check.composer = %q, want %q", w.Check.Composer, "laravel/pulse")
+	}
+}
+
+func TestWorkerAdd_WithProxy(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644)
+
+	proj, _ := config.LoadProjectConfig(dir)
+	proj.CustomWorkers = map[string]config.FrameworkWorker{
+		"ws": {
+			Command: "php artisan ws:serve",
+			Proxy: &config.WorkerProxy{
+				Path:        "/ws",
+				PortEnvKey:  "WS_PORT",
+				DefaultPort: 6001,
+			},
+		},
+	}
+	config.SaveProjectConfig(dir, proj)
+
+	got, _ := config.LoadProjectConfig(dir)
+	w := got.CustomWorkers["ws"]
+	if w.Proxy == nil {
+		t.Fatal("expected proxy to be set")
+	}
+	if w.Proxy.Path != "/ws" {
+		t.Errorf("proxy.path = %q, want %q", w.Proxy.Path, "/ws")
+	}
+	if w.Proxy.PortEnvKey != "WS_PORT" {
+		t.Errorf("proxy.port_env_key = %q", w.Proxy.PortEnvKey)
+	}
+	if w.Proxy.DefaultPort != 6001 {
+		t.Errorf("proxy.default_port = %d, want 6001", w.Proxy.DefaultPort)
+	}
+}
+
+func TestWorkerRemove_Project(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644)
+
+	proj, _ := config.LoadProjectConfig(dir)
+	proj.CustomWorkers = map[string]config.FrameworkWorker{
+		"pulse": {Command: "php artisan pulse:work"},
+		"other": {Command: "php artisan other:work"},
+	}
+	config.SaveProjectConfig(dir, proj)
+
+	// Remove pulse.
+	proj, _ = config.LoadProjectConfig(dir)
+	delete(proj.CustomWorkers, "pulse")
+	config.SaveProjectConfig(dir, proj)
+
+	got, _ := config.LoadProjectConfig(dir)
+	if _, ok := got.CustomWorkers["pulse"]; ok {
+		t.Error("pulse should have been removed")
+	}
+	if _, ok := got.CustomWorkers["other"]; !ok {
+		t.Error("other should still be present")
+	}
+}
+
+func TestWorkerRemove_NilsEmptyMap(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644)
+
+	proj, _ := config.LoadProjectConfig(dir)
+	proj.CustomWorkers = map[string]config.FrameworkWorker{
+		"pulse": {Command: "php artisan pulse:work"},
+	}
+	config.SaveProjectConfig(dir, proj)
+
+	// Remove the last worker and nil out.
+	proj, _ = config.LoadProjectConfig(dir)
+	delete(proj.CustomWorkers, "pulse")
+	proj.CustomWorkers = nil
+	config.SaveProjectConfig(dir, proj)
+
+	// Verify custom_workers is absent from YAML.
+	data, _ := os.ReadFile(filepath.Join(dir, ".lerd.yaml"))
+	if strings.Contains(string(data), "custom_workers") {
+		t.Error("custom_workers should be omitted from YAML when nil")
+	}
+}
+
+func TestWorkerRemove_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644)
+
+	proj, _ := config.LoadProjectConfig(dir)
+	if _, exists := proj.CustomWorkers["nonexistent"]; exists {
+		t.Error("nonexistent worker should not be found")
+	}
+}
+
+func TestWorkerAdd_Global(t *testing.T) {
+	// Use a temp dir as the frameworks dir.
+	dir := t.TempDir()
+	origDir := config.FrameworksDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	fwDir := filepath.Join(dir, "lerd", "frameworks")
+	os.MkdirAll(fwDir, 0755)
+
+	fw := &config.Framework{
+		Name: "testfw",
+		Workers: map[string]config.FrameworkWorker{
+			"pulse": {Command: "php artisan pulse:work", Label: "Pulse"},
+		},
+	}
+	if err := config.SaveFramework(fw); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := config.LoadUserFramework("testfw")
+	if loaded == nil {
+		t.Fatal("expected to load saved framework")
+	}
+	w, ok := loaded.Workers["pulse"]
+	if !ok {
+		t.Fatal("expected pulse worker")
+	}
+	if w.Command != "php artisan pulse:work" {
+		t.Errorf("command = %q", w.Command)
+	}
+
+	// Verify frameworks dir changed.
+	_ = origDir
+}
+
+func TestWorkerRemove_Global(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	fwDir := filepath.Join(dir, "lerd", "frameworks")
+	os.MkdirAll(fwDir, 0755)
+
+	fw := &config.Framework{
+		Name: "testfw",
+		Workers: map[string]config.FrameworkWorker{
+			"pulse": {Command: "php artisan pulse:work"},
+			"other": {Command: "php artisan other:work"},
+		},
+	}
+	config.SaveFramework(fw)
+
+	// Remove pulse.
+	loaded := config.LoadUserFramework("testfw")
+	delete(loaded.Workers, "pulse")
+	if len(loaded.Workers) == 0 {
+		loaded.Workers = nil
+	}
+	config.SaveFramework(loaded)
+
+	reloaded := config.LoadUserFramework("testfw")
+	if _, ok := reloaded.Workers["pulse"]; ok {
+		t.Error("pulse should have been removed")
+	}
+	if _, ok := reloaded.Workers["other"]; !ok {
+		t.Error("other should still be present")
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -7,16 +7,34 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+// FrameworkFetchFunc is a callback that fetches a framework definition from the
+// store and saves it locally. It is called when GetFrameworkForDir cannot find a
+// local definition for the detected version. The store package registers this at
+// startup to avoid a circular import.
+type FrameworkFetchFunc func(name, version string) (*Framework, error)
+
+// frameworkFetchHook is set by the store package via RegisterFrameworkFetchHook.
+var frameworkFetchHook FrameworkFetchFunc
+
+// RegisterFrameworkFetchHook sets the callback used to auto-fetch missing
+// framework definitions from the store.
+func RegisterFrameworkFetchHook(fn FrameworkFetchFunc) {
+	frameworkFetchHook = fn
+}
 
 // Framework describes a PHP project framework type.
 type Framework struct {
 	Name  string `yaml:"name"`
 	Label string `yaml:"label"`
 	// Version is the framework major version this definition targets (e.g. "11", "7").
-	Version   string                     `yaml:"version,omitempty"`
+	Version string `yaml:"version,omitempty"`
+	// PHP defines the supported PHP version range for this framework version.
+	PHP       FrameworkPHP               `yaml:"php,omitempty"`
 	Detect    []FrameworkRule            `yaml:"detect,omitempty"`
 	PublicDir string                     `yaml:"public_dir"`
 	Env       FrameworkEnvConf           `yaml:"env,omitempty"`
@@ -66,6 +84,12 @@ type FrameworkSetupCmd struct {
 	Command string         `yaml:"command"`
 	Default bool           `yaml:"default,omitempty"`
 	Check   *FrameworkRule `yaml:"check,omitempty"` // only show when check passes (file exists or composer package installed)
+}
+
+// FrameworkPHP defines the supported PHP version range for a framework version.
+type FrameworkPHP struct {
+	Min string `yaml:"min,omitempty"` // minimum PHP version (e.g. "8.2")
+	Max string `yaml:"max,omitempty"` // maximum PHP version (e.g. "8.4")
 }
 
 // FrameworkRule is a single detection rule for a framework.
@@ -365,24 +389,26 @@ func mergeUserOverlay(base *Framework) *Framework {
 		base.Setup = append(base.Setup, overlay.Setup...)
 	}
 
+	// Merge logs (overlay replaces the full list if provided).
+	if overlay.Logs != nil {
+		base.Logs = overlay.Logs
+	}
+
 	return base
 }
 
 // GetFrameworkForDir is like GetFramework but auto-detects the framework version
 // from composer.lock in projectDir. If a version-specific store definition exists
 // it is preferred over an unversioned one. User overlay workers are always merged.
+// When a version is detected but no local definition exists, it attempts to fetch
+// the definition from the store automatically.
 func GetFrameworkForDir(name, projectDir string) (*Framework, bool) {
 	if name == "" {
 		return nil, false
 	}
 
-	// Laravel built-in handling is version-agnostic.
-	if name == "laravel" {
-		return GetFramework(name)
-	}
-
 	// 1. Resolve version from composer.lock (source of truth) or .lerd.yaml (fallback).
-	version := composerLockMajorVersion(projectDir, name)
+	version := ComposerLockMajorVersion(projectDir, name)
 	if proj, err := LoadProjectConfig(projectDir); err == nil {
 		if version == "" && proj.FrameworkVersion != "" {
 			version = proj.FrameworkVersion
@@ -392,11 +418,31 @@ func GetFrameworkForDir(name, projectDir string) (*Framework, bool) {
 		}
 	}
 
-	// 2. Find the base definition from the store.
+	// 2. Find the base definition from the store directory.
 	var base *Framework
+	versionedPath := ""
 	if version != "" {
-		base = loadFrameworkYAML(filepath.Join(StoreFrameworksDir(), name+"@"+version+".yaml"))
+		versionedPath = filepath.Join(StoreFrameworksDir(), name+"@"+version+".yaml")
+		base = loadFrameworkYAML(versionedPath)
 	}
+
+	// 3. Auto-fetch from the store: either the file is missing, or it's older
+	//    than 24 hours and may have been updated upstream.
+	if version != "" && frameworkFetchHook != nil {
+		shouldFetch := base == nil
+		if !shouldFetch && versionedPath != "" {
+			if info, err := os.Stat(versionedPath); err == nil {
+				shouldFetch = time.Since(info.ModTime()) > 24*time.Hour
+			}
+		}
+		if shouldFetch {
+			if fetched, err := frameworkFetchHook(name, version); err == nil && fetched != nil {
+				base = fetched
+			}
+		}
+	}
+
+	// 4. Fall back to any available local definition.
 	if base == nil {
 		base = loadFrameworkYAML(filepath.Join(StoreFrameworksDir(), name+".yaml"))
 	}
@@ -405,13 +451,19 @@ func GetFrameworkForDir(name, projectDir string) (*Framework, bool) {
 	}
 
 	if base != nil {
-		// Merge user overlay on top of the store base.
 		base = mergeUserOverlay(base)
-		// Merge project-specific custom workers from .lerd.yaml.
 		return mergeProjectWorkers(base, projectDir), true
 	}
 
-	// 3. No store definition — check user-only definition (custom framework).
+	// 4. For Laravel, fall back to the built-in definition.
+	if name == "laravel" {
+		fw, ok := GetFramework(name)
+		if ok {
+			return mergeProjectWorkers(fw, projectDir), true
+		}
+	}
+
+	// 5. No store definition — check user-only definition (custom framework).
 	if fw := loadFrameworkYAML(filepath.Join(FrameworksDir(), name+".yaml")); fw != nil {
 		return mergeProjectWorkers(fw, projectDir), true
 	}
@@ -597,37 +649,50 @@ type FrameworkInfo struct {
 // Frameworks with a store base + user overlay show as "store" with merged workers.
 func ListFrameworksDetailed() []FrameworkInfo {
 	var result []FrameworkInfo
-	seen := map[string]bool{}
+	seenNameVersion := map[string]bool{}
+	hasStoreLaravel := false
 
-	// Built-in Laravel (merged with user overlay).
-	if fw, ok := GetFramework("laravel"); ok {
-		result = append(result, FrameworkInfo{Framework: fw, Source: SourceBuiltIn})
-	}
-	seen["laravel"] = true
+	key := func(name, version string) string { return name + "@" + version }
 
-	// Store-installed (merged with user overlay).
+	// Store-installed: each versioned file is a separate entry.
 	storeEntries, _ := filepath.Glob(filepath.Join(StoreFrameworksDir(), "*.yaml"))
 	sort.Sort(sort.Reverse(sort.StringSlice(storeEntries)))
 	for _, yamlPath := range storeEntries {
 		fw := loadFrameworkYAML(yamlPath)
-		if fw == nil || seen[fw.Name] {
+		if fw == nil {
 			continue
 		}
-		seen[fw.Name] = true
-		// Use GetFramework to get the merged result (store base + user overlay).
-		if merged, ok := GetFramework(fw.Name); ok {
-			result = append(result, FrameworkInfo{Framework: merged, Source: SourceStore})
+		k := key(fw.Name, fw.Version)
+		if seenNameVersion[k] {
+			continue
+		}
+		seenNameVersion[k] = true
+		merged := mergeUserOverlay(fw)
+		result = append(result, FrameworkInfo{Framework: merged, Source: SourceStore})
+		if fw.Name == "laravel" {
+			hasStoreLaravel = true
 		}
 	}
 
-	// User-only (no store base).
+	// Built-in Laravel (only if no store-installed version exists).
+	if !hasStoreLaravel {
+		if fw, ok := GetFramework("laravel"); ok {
+			result = append(result, FrameworkInfo{Framework: fw, Source: SourceBuiltIn})
+		}
+	}
+
+	// User-only (skip if a store version for the same name already listed).
+	seenName := map[string]bool{"laravel": true}
+	for _, info := range result {
+		seenName[info.Name] = true
+	}
 	entries, _ := filepath.Glob(filepath.Join(FrameworksDir(), "*.yaml"))
 	for _, yamlPath := range entries {
 		fw := loadFrameworkYAML(yamlPath)
-		if fw == nil || seen[fw.Name] {
+		if fw == nil || seenName[fw.Name] {
 			continue
 		}
-		seen[fw.Name] = true
+		seenName[fw.Name] = true
 		result = append(result, FrameworkInfo{Framework: fw, Source: SourceUser})
 	}
 
@@ -704,10 +769,63 @@ func RemoveUserFramework(name string) {
 	os.Remove(filepath.Join(FrameworksDir(), name+".yaml")) //nolint:errcheck
 }
 
-// RemoveFramework deletes a user-defined framework YAML. For "laravel" it only
-// removes the user workers overlay (the built-in definition remains).
+// FrameworkFile describes a framework definition file on disk.
+type FrameworkFile struct {
+	Path    string
+	Version string // "" for unversioned
+	Source  FrameworkSource
+}
+
+// ListFrameworkFiles returns all definition files for a framework across user
+// and store directories.
+func ListFrameworkFiles(name string) []FrameworkFile {
+	var files []FrameworkFile
+	seen := make(map[string]bool)
+
+	add := func(path string, source FrameworkSource) {
+		if seen[path] {
+			return
+		}
+		if _, err := os.Stat(path); err != nil {
+			return
+		}
+		seen[path] = true
+		version := ""
+		base := filepath.Base(path)
+		if i := strings.IndexByte(base, '@'); i != -1 {
+			version = strings.TrimSuffix(base[i+1:], ".yaml")
+		}
+		files = append(files, FrameworkFile{Path: path, Version: version, Source: source})
+	}
+
+	add(filepath.Join(FrameworksDir(), name+".yaml"), SourceUser)
+
+	storeDir := StoreFrameworksDir()
+	add(filepath.Join(storeDir, name+".yaml"), SourceStore)
+	matches, _ := filepath.Glob(filepath.Join(storeDir, name+"@*.yaml"))
+	for _, m := range matches {
+		add(m, SourceStore)
+	}
+
+	return files
+}
+
+// RemoveFrameworkFile removes a single framework definition file.
+func RemoveFrameworkFile(path string) error {
+	return os.Remove(path)
+}
+
+// RemoveFramework deletes all framework definition files (user and store) for
+// the given name.
 func RemoveFramework(name string) error {
-	return os.Remove(filepath.Join(FrameworksDir(), name+".yaml"))
+	files := ListFrameworkFiles(name)
+	if len(files) == 0 {
+		return &os.PathError{Op: "remove", Path: name, Err: os.ErrNotExist}
+	}
+	for _, f := range files {
+		os.Remove(f.Path) //nolint:errcheck
+	}
+	return nil
 }
 
 // HasWorker returns true if the framework defines a worker with the given name
@@ -772,8 +890,10 @@ func matchesFramework(dir string, fw *Framework) bool {
 	return false
 }
 
-// composerLockMajorVersion detects the major version of a framework from composer.lock.
-func composerLockMajorVersion(projectDir, frameworkName string) string {
+// ComposerLockMajorVersion detects the major version of a framework from composer.lock.
+// It scans store-installed definitions to find the composer package name for the framework,
+// then looks up the version in composer.lock. Returns "" if not determinable.
+func ComposerLockMajorVersion(projectDir, frameworkName string) string {
 	if projectDir == "" {
 		return ""
 	}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -13,8 +13,8 @@ import (
 
 // Framework describes a PHP project framework type.
 type Framework struct {
-	Name      string                     `yaml:"name"`
-	Label     string                     `yaml:"label"`
+	Name  string `yaml:"name"`
+	Label string `yaml:"label"`
 	// Version is the framework major version this definition targets (e.g. "11", "7").
 	Version   string                     `yaml:"version,omitempty"`
 	Detect    []FrameworkRule            `yaml:"detect,omitempty"`
@@ -37,21 +37,21 @@ type Framework struct {
 // FrameworkWorker describes a long-running process managed as a systemd service.
 // The Command is executed inside the PHP-FPM container for the site.
 type FrameworkWorker struct {
-	Label         string            `yaml:"label,omitempty"`
-	Command       string            `yaml:"command"`
-	Restart       string            `yaml:"restart,omitempty"`        // always | on-failure (default: always)
-	Check         *FrameworkRule    `yaml:"check,omitempty"`          // only show when check passes (file exists or composer package installed)
-	ConflictsWith []string          `yaml:"conflicts_with,omitempty"` // workers to stop before starting this one (e.g. horizon conflicts_with queue)
-	Proxy         *WorkerProxy      `yaml:"proxy,omitempty"`          // WebSocket/HTTP proxy config for nginx
+	Label         string         `yaml:"label,omitempty"`
+	Command       string         `yaml:"command"`
+	Restart       string         `yaml:"restart,omitempty"`        // always | on-failure (default: always)
+	Check         *FrameworkRule `yaml:"check,omitempty"`          // only show when check passes (file exists or composer package installed)
+	ConflictsWith []string       `yaml:"conflicts_with,omitempty"` // workers to stop before starting this one (e.g. horizon conflicts_with queue)
+	Proxy         *WorkerProxy   `yaml:"proxy,omitempty"`          // WebSocket/HTTP proxy config for nginx
 }
 
 // WorkerProxy describes an HTTP/WebSocket proxy that nginx should configure
 // for this worker. When present, nginx adds a location block that proxies
 // requests to the worker inside the PHP-FPM container.
 type WorkerProxy struct {
-	Path       string `yaml:"path"`                  // URL path to proxy (e.g. "/app")
-	PortEnvKey string `yaml:"port_env_key,omitempty"` // env key holding the port (e.g. "REVERB_SERVER_PORT")
-	DefaultPort int   `yaml:"default_port,omitempty"` // fallback port if env key is missing (default: 8080)
+	Path        string `yaml:"path"`                   // URL path to proxy (e.g. "/app")
+	PortEnvKey  string `yaml:"port_env_key,omitempty"` // env key holding the port (e.g. "REVERB_SERVER_PORT")
+	DefaultPort int    `yaml:"default_port,omitempty"` // fallback port if env key is missing (default: 8080)
 }
 
 // FrameworkLogSource describes where application log files live for a framework.
@@ -96,8 +96,8 @@ type FrameworkEnvConf struct {
 
 // EnvKeyGeneration describes how to generate an application encryption key.
 type EnvKeyGeneration struct {
-	EnvKey        string `yaml:"env_key"`                   // env var to check/set (e.g. "APP_KEY")
-	Command       string `yaml:"command,omitempty"`          // artisan command to run if vendor/ exists (e.g. "key:generate")
+	EnvKey         string `yaml:"env_key"`                   // env var to check/set (e.g. "APP_KEY")
+	Command        string `yaml:"command,omitempty"`         // artisan command to run if vendor/ exists (e.g. "key:generate")
 	FallbackPrefix string `yaml:"fallback_prefix,omitempty"` // prefix for random key fallback (e.g. "base64:")
 }
 

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -13,6 +15,8 @@ import (
 type Framework struct {
 	Name      string                     `yaml:"name"`
 	Label     string                     `yaml:"label"`
+	// Version is the framework major version this definition targets (e.g. "11", "7").
+	Version   string                     `yaml:"version,omitempty"`
 	Detect    []FrameworkRule            `yaml:"detect,omitempty"`
 	PublicDir string                     `yaml:"public_dir"`
 	Env       FrameworkEnvConf           `yaml:"env,omitempty"`
@@ -33,10 +37,21 @@ type Framework struct {
 // FrameworkWorker describes a long-running process managed as a systemd service.
 // The Command is executed inside the PHP-FPM container for the site.
 type FrameworkWorker struct {
-	Label   string         `yaml:"label,omitempty"`
-	Command string         `yaml:"command"`
-	Restart string         `yaml:"restart,omitempty"` // always | on-failure (default: always)
-	Check   *FrameworkRule `yaml:"check,omitempty"`   // only show when check passes (file exists or composer package installed)
+	Label         string            `yaml:"label,omitempty"`
+	Command       string            `yaml:"command"`
+	Restart       string            `yaml:"restart,omitempty"`        // always | on-failure (default: always)
+	Check         *FrameworkRule    `yaml:"check,omitempty"`          // only show when check passes (file exists or composer package installed)
+	ConflictsWith []string          `yaml:"conflicts_with,omitempty"` // workers to stop before starting this one (e.g. horizon conflicts_with queue)
+	Proxy         *WorkerProxy      `yaml:"proxy,omitempty"`          // WebSocket/HTTP proxy config for nginx
+}
+
+// WorkerProxy describes an HTTP/WebSocket proxy that nginx should configure
+// for this worker. When present, nginx adds a location block that proxies
+// requests to the worker inside the PHP-FPM container.
+type WorkerProxy struct {
+	Path       string `yaml:"path"`                  // URL path to proxy (e.g. "/app")
+	PortEnvKey string `yaml:"port_env_key,omitempty"` // env key holding the port (e.g. "REVERB_SERVER_PORT")
+	DefaultPort int   `yaml:"default_port,omitempty"` // fallback port if env key is missing (default: 8080)
 }
 
 // FrameworkLogSource describes where application log files live for a framework.
@@ -74,6 +89,16 @@ type FrameworkEnvConf struct {
 	// Services defines per-service detection rules and env vars to apply.
 	// Keys match the built-in service names: mysql, postgres, redis, meilisearch, rustfs, mailpit.
 	Services map[string]FrameworkServiceDef `yaml:"services,omitempty"`
+
+	// KeyGeneration describes how to generate an application key if missing.
+	KeyGeneration *EnvKeyGeneration `yaml:"key_generation,omitempty"`
+}
+
+// EnvKeyGeneration describes how to generate an application encryption key.
+type EnvKeyGeneration struct {
+	EnvKey        string `yaml:"env_key"`                   // env var to check/set (e.g. "APP_KEY")
+	Command       string `yaml:"command,omitempty"`          // artisan command to run if vendor/ exists (e.g. "key:generate")
+	FallbackPrefix string `yaml:"fallback_prefix,omitempty"` // prefix for random key fallback (e.g. "base64:")
 }
 
 // FrameworkServiceDef describes how a service is detected and configured for a framework.
@@ -141,6 +166,89 @@ var laravelFramework = &Framework{
 		File:        ".env",
 		ExampleFile: ".env.example",
 		Format:      "dotenv",
+		KeyGeneration: &EnvKeyGeneration{
+			EnvKey:         "APP_KEY",
+			Command:        "key:generate",
+			FallbackPrefix: "base64:",
+		},
+		Services: map[string]FrameworkServiceDef{
+			"mysql": {
+				Detect: []FrameworkServiceDetect{
+					{Key: "DB_CONNECTION", ValuePrefix: "mysql"},
+					{Key: "DB_CONNECTION", ValuePrefix: "mariadb"},
+				},
+				Vars: []string{
+					"DB_CONNECTION=mysql",
+					"DB_HOST=lerd-mysql",
+					"DB_PORT=3306",
+					"DB_DATABASE={{site}}",
+					"DB_USERNAME=root",
+					"DB_PASSWORD=lerd",
+				},
+			},
+			"postgres": {
+				Detect: []FrameworkServiceDetect{
+					{Key: "DB_CONNECTION", ValuePrefix: "pgsql"},
+				},
+				Vars: []string{
+					"DB_CONNECTION=pgsql",
+					"DB_HOST=lerd-postgres",
+					"DB_PORT=5432",
+					"DB_DATABASE={{site}}",
+					"DB_USERNAME=postgres",
+					"DB_PASSWORD=lerd",
+				},
+			},
+			"redis": {
+				Detect: []FrameworkServiceDetect{
+					{Key: "REDIS_HOST"},
+					{Key: "CACHE_STORE", ValuePrefix: "redis"},
+					{Key: "SESSION_DRIVER", ValuePrefix: "redis"},
+					{Key: "QUEUE_CONNECTION", ValuePrefix: "redis"},
+				},
+				Vars: []string{
+					"REDIS_HOST=lerd-redis",
+					"REDIS_PORT=6379",
+					"REDIS_PASSWORD=",
+				},
+			},
+			"meilisearch": {
+				Detect: []FrameworkServiceDetect{
+					{Key: "SCOUT_DRIVER", ValuePrefix: "meilisearch"},
+				},
+				Vars: []string{
+					"MEILISEARCH_HOST=http://lerd-meilisearch:7700",
+					"MEILISEARCH_NO_ANALYTICS=true",
+				},
+			},
+			"rustfs": {
+				Detect: []FrameworkServiceDetect{
+					{Key: "FILESYSTEM_DISK", ValuePrefix: "s3"},
+					{Key: "AWS_ENDPOINT"},
+				},
+				Vars: []string{
+					"AWS_ACCESS_KEY_ID=lerd",
+					"AWS_SECRET_ACCESS_KEY=lerdpassword",
+					"AWS_BUCKET={{site}}",
+					"AWS_ENDPOINT=http://lerd-rustfs:9000",
+					"AWS_URL=http://localhost:9000/{{site}}",
+					"AWS_USE_PATH_STYLE_ENDPOINT=true",
+				},
+			},
+			"mailpit": {
+				Detect: []FrameworkServiceDetect{
+					{Key: "MAIL_HOST"},
+				},
+				Vars: []string{
+					"MAIL_MAILER=smtp",
+					"MAIL_HOST=lerd-mailpit",
+					"MAIL_PORT=1025",
+					"MAIL_USERNAME=null",
+					"MAIL_PASSWORD=null",
+					"MAIL_ENCRYPTION=null",
+				},
+			},
+		},
 	},
 	Composer: "auto",
 	NPM:      "auto",
@@ -160,6 +268,19 @@ var laravelFramework = &Framework{
 			Label:   "Reverb WebSocket",
 			Command: "php artisan reverb:start",
 			Restart: "on-failure",
+			Check:   &FrameworkRule{Composer: "laravel/reverb"},
+			Proxy: &WorkerProxy{
+				Path:        "/app",
+				PortEnvKey:  "REVERB_SERVER_PORT",
+				DefaultPort: 8080,
+			},
+		},
+		"horizon": {
+			Label:         "Horizon",
+			Command:       "php artisan horizon",
+			Restart:       "always",
+			Check:         &FrameworkRule{Composer: "laravel/horizon"},
+			ConflictsWith: []string{"queue"},
 		},
 	},
 	Setup: []FrameworkSetupCmd{
@@ -173,52 +294,212 @@ var laravelFramework = &Framework{
 }
 
 // GetFramework returns the framework definition for the given name.
-// For non-laravel frameworks it checks user-defined YAMLs in FrameworksDir().
-// For laravel it always starts from the built-in and merges any user-defined
-// workers on top, so queue/schedule/reverb are always available.
+// It loads the base definition from the built-in (laravel), store, or user dir,
+// then merges any user-defined overlay on top. The overlay can add/override
+// workers and setup commands without replacing the entire definition.
 // Returns (nil, false) if the framework is not found.
 func GetFramework(name string) (*Framework, bool) {
 	if name == "" {
 		return nil, false
 	}
 
-	if name == "laravel" {
-		// Start from a copy of the built-in
-		merged := *laravelFramework
-		mergedWorkers := make(map[string]FrameworkWorker, len(laravelFramework.Workers))
-		for k, v := range laravelFramework.Workers {
-			mergedWorkers[k] = v
+	// Find the base definition.
+	base := loadBaseFramework(name)
+	if base == nil {
+		// No base — check if a user-only definition exists (custom framework).
+		if fw := loadFrameworkYAML(filepath.Join(FrameworksDir(), name+".yaml")); fw != nil {
+			return fw, true
 		}
-		// Merge user-defined workers and setup commands (user additions/overrides win)
-		path := filepath.Join(FrameworksDir(), "laravel.yaml")
-		if data, err := os.ReadFile(path); err == nil {
-			var userFw Framework
-			if yaml.Unmarshal(data, &userFw) == nil {
-				for k, v := range userFw.Workers {
-					mergedWorkers[k] = v
-				}
-				if userFw.Setup != nil {
-					merged.Setup = userFw.Setup
-				}
-				if userFw.Logs != nil {
-					merged.Logs = userFw.Logs
-				}
-			}
-		}
-		merged.Workers = mergedWorkers
-		return &merged, true
+		return nil, false
 	}
 
-	// User-defined YAML for other frameworks
-	path := filepath.Join(FrameworksDir(), name+".yaml")
-	if data, err := os.ReadFile(path); err == nil {
-		var fw Framework
-		if yaml.Unmarshal(data, &fw) == nil && fw.Name != "" {
-			return &fw, true
+	// Merge user overlay (if any) on top of the base.
+	return mergeUserOverlay(base), true
+}
+
+// loadBaseFramework returns the base definition for a framework:
+// built-in for "laravel", then store-installed (versioned > unversioned).
+func loadBaseFramework(name string) *Framework {
+	if name == "laravel" {
+		// Copy built-in so callers don't mutate the global.
+		fw := *laravelFramework
+		workers := make(map[string]FrameworkWorker, len(laravelFramework.Workers))
+		for k, v := range laravelFramework.Workers {
+			workers[k] = v
 		}
+		fw.Workers = workers
+		return &fw
+	}
+
+	// Store-installed: unversioned first (backwards compat), then versioned.
+	if fw := loadFrameworkYAML(filepath.Join(StoreFrameworksDir(), name+".yaml")); fw != nil {
+		return fw
+	}
+	return loadBestVersionedFramework(name, "")
+}
+
+// mergeUserOverlay checks for a user-defined overlay file in FrameworksDir()
+// and merges its workers and setup commands on top of base.
+// User additions/overrides win. If no overlay exists, base is returned as-is.
+func mergeUserOverlay(base *Framework) *Framework {
+	path := filepath.Join(FrameworksDir(), base.Name+".yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return base
+	}
+	var overlay Framework
+	if yaml.Unmarshal(data, &overlay) != nil {
+		return base
+	}
+
+	// Merge workers.
+	if base.Workers == nil {
+		base.Workers = make(map[string]FrameworkWorker)
+	}
+	for k, v := range overlay.Workers {
+		base.Workers[k] = v
+	}
+
+	// Merge setup commands (overlay replaces the full list if provided).
+	if overlay.Setup != nil {
+		base.Setup = append(base.Setup, overlay.Setup...)
+	}
+
+	return base
+}
+
+// GetFrameworkForDir is like GetFramework but auto-detects the framework version
+// from composer.lock in projectDir. If a version-specific store definition exists
+// it is preferred over an unversioned one. User overlay workers are always merged.
+func GetFrameworkForDir(name, projectDir string) (*Framework, bool) {
+	if name == "" {
+		return nil, false
+	}
+
+	// Laravel built-in handling is version-agnostic.
+	if name == "laravel" {
+		return GetFramework(name)
+	}
+
+	// 1. Resolve version from composer.lock (source of truth) or .lerd.yaml (fallback).
+	version := composerLockMajorVersion(projectDir, name)
+	if proj, err := LoadProjectConfig(projectDir); err == nil {
+		if version == "" && proj.FrameworkVersion != "" {
+			version = proj.FrameworkVersion
+		} else if version != "" && proj.FrameworkVersion != "" && version != proj.FrameworkVersion {
+			proj.FrameworkVersion = version
+			_ = SaveProjectConfig(projectDir, proj)
+		}
+	}
+
+	// 2. Find the base definition from the store.
+	var base *Framework
+	if version != "" {
+		base = loadFrameworkYAML(filepath.Join(StoreFrameworksDir(), name+"@"+version+".yaml"))
+	}
+	if base == nil {
+		base = loadFrameworkYAML(filepath.Join(StoreFrameworksDir(), name+".yaml"))
+	}
+	if base == nil {
+		base = loadBestVersionedFramework(name, "")
+	}
+
+	if base != nil {
+		// Merge user overlay on top of the store base.
+		base = mergeUserOverlay(base)
+		// Merge project-specific custom workers from .lerd.yaml.
+		return mergeProjectWorkers(base, projectDir), true
+	}
+
+	// 3. No store definition — check user-only definition (custom framework).
+	if fw := loadFrameworkYAML(filepath.Join(FrameworksDir(), name+".yaml")); fw != nil {
+		return mergeProjectWorkers(fw, projectDir), true
 	}
 
 	return nil, false
+}
+
+// mergeProjectWorkers merges custom_workers from .lerd.yaml on top of the
+// framework definition. These are project-specific workers that live in git.
+func mergeProjectWorkers(fw *Framework, projectDir string) *Framework {
+	if projectDir == "" {
+		return fw
+	}
+	proj, err := LoadProjectConfig(projectDir)
+	if err != nil || len(proj.CustomWorkers) == 0 {
+		return fw
+	}
+	if fw.Workers == nil {
+		fw.Workers = make(map[string]FrameworkWorker)
+	}
+	for k, v := range proj.CustomWorkers {
+		fw.Workers[k] = v
+	}
+	return fw
+}
+
+// GetFrameworkSource returns the source of the active framework definition.
+// Returns SourceBuiltIn for "laravel", SourceUser if a user-defined file exists,
+// SourceStore if a store-installed file exists, or "" if not found.
+func GetFrameworkSource(name string) FrameworkSource {
+	if name == "laravel" {
+		return SourceBuiltIn
+	}
+	if loadFrameworkYAML(filepath.Join(FrameworksDir(), name+".yaml")) != nil {
+		return SourceUser
+	}
+	// Check store (unversioned and versioned).
+	if loadFrameworkYAML(filepath.Join(StoreFrameworksDir(), name+".yaml")) != nil {
+		return SourceStore
+	}
+	matches, _ := filepath.Glob(filepath.Join(StoreFrameworksDir(), name+"@*.yaml"))
+	if len(matches) > 0 {
+		return SourceStore
+	}
+	return ""
+}
+
+// LoadUserFramework loads a user-defined framework from FrameworksDir().
+// Returns nil if not found.
+func LoadUserFramework(name string) *Framework {
+	return loadFrameworkYAML(filepath.Join(FrameworksDir(), name+".yaml"))
+}
+
+// loadFrameworkYAML reads and parses a single framework YAML file.
+func loadFrameworkYAML(path string) *Framework {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var fw Framework
+	if yaml.Unmarshal(data, &fw) != nil || fw.Name == "" {
+		return nil
+	}
+	return &fw
+}
+
+// loadBestVersionedFramework scans StoreFrameworksDir for <name>@<version>.yaml files.
+// If preferVersion is set, it tries that first. Otherwise picks the first match
+// alphabetically (which for numeric versions gives the latest).
+func loadBestVersionedFramework(name, preferVersion string) *Framework {
+	if preferVersion != "" {
+		if fw := loadFrameworkYAML(filepath.Join(StoreFrameworksDir(), name+"@"+preferVersion+".yaml")); fw != nil {
+			return fw
+		}
+	}
+	pattern := filepath.Join(StoreFrameworksDir(), name+"@*.yaml")
+	matches, _ := filepath.Glob(pattern)
+	if len(matches) == 0 {
+		return nil
+	}
+	// Reverse sort so highest version comes first (e.g. @7 before @6).
+	sort.Sort(sort.Reverse(sort.StringSlice(matches)))
+	for _, path := range matches {
+		if fw := loadFrameworkYAML(path); fw != nil {
+			return fw
+		}
+	}
+	return nil
 }
 
 // DetectPublicDir inspects dir for a well-known PHP public directory and returns it.
@@ -249,19 +530,19 @@ func DetectFramework(dir string) (string, bool) {
 		return "laravel", true
 	}
 
-	// User-defined frameworks
-	entries, _ := filepath.Glob(filepath.Join(FrameworksDir(), "*.yaml"))
-	for _, yamlPath := range entries {
-		data, err := os.ReadFile(yamlPath)
-		if err != nil {
-			continue
-		}
-		var fw Framework
-		if yaml.Unmarshal(data, &fw) != nil || fw.Name == "" {
-			continue
-		}
-		if matchesFramework(dir, &fw) {
-			return fw.Name, true
+	// User-defined frameworks, then store-installed (including versioned files).
+	seen := map[string]bool{}
+	for _, fwDir := range []string{FrameworksDir(), StoreFrameworksDir()} {
+		entries, _ := filepath.Glob(filepath.Join(fwDir, "*.yaml"))
+		for _, yamlPath := range entries {
+			fw := loadFrameworkYAML(yamlPath)
+			if fw == nil || seen[fw.Name] {
+				continue
+			}
+			seen[fw.Name] = true
+			if matchesFramework(dir, fw) {
+				return fw.Name, true
+			}
 		}
 	}
 
@@ -272,18 +553,82 @@ func DetectFramework(dir string) (string, bool) {
 // the laravel built-in plus any user-defined YAMLs in FrameworksDir().
 func ListFrameworks() []*Framework {
 	result := []*Framework{laravelFramework}
+	seen := map[string]bool{"laravel": true}
 
+	// User-defined first (unversioned), then store-installed.
+	// For store, include both <name>.yaml and <name>@<version>.yaml.
+	// Deduplicate by name — user-defined wins, then first store version seen.
+	for _, fwDir := range []string{FrameworksDir(), StoreFrameworksDir()} {
+		entries, _ := filepath.Glob(filepath.Join(fwDir, "*.yaml"))
+		// Sort reverse so higher versions appear first.
+		sort.Sort(sort.Reverse(sort.StringSlice(entries)))
+		for _, yamlPath := range entries {
+			fw := loadFrameworkYAML(yamlPath)
+			if fw == nil {
+				continue
+			}
+			if seen[fw.Name] {
+				continue
+			}
+			seen[fw.Name] = true
+			result = append(result, fw)
+		}
+	}
+
+	return result
+}
+
+// FrameworkSource describes where a framework definition came from.
+type FrameworkSource string
+
+const (
+	SourceBuiltIn FrameworkSource = "built-in"
+	SourceUser    FrameworkSource = "user"
+	SourceStore   FrameworkSource = "store"
+)
+
+// FrameworkInfo holds a framework definition together with its source metadata.
+type FrameworkInfo struct {
+	*Framework
+	Source FrameworkSource
+}
+
+// ListFrameworksDetailed returns all available framework definitions with source info.
+// Frameworks with a store base + user overlay show as "store" with merged workers.
+func ListFrameworksDetailed() []FrameworkInfo {
+	var result []FrameworkInfo
+	seen := map[string]bool{}
+
+	// Built-in Laravel (merged with user overlay).
+	if fw, ok := GetFramework("laravel"); ok {
+		result = append(result, FrameworkInfo{Framework: fw, Source: SourceBuiltIn})
+	}
+	seen["laravel"] = true
+
+	// Store-installed (merged with user overlay).
+	storeEntries, _ := filepath.Glob(filepath.Join(StoreFrameworksDir(), "*.yaml"))
+	sort.Sort(sort.Reverse(sort.StringSlice(storeEntries)))
+	for _, yamlPath := range storeEntries {
+		fw := loadFrameworkYAML(yamlPath)
+		if fw == nil || seen[fw.Name] {
+			continue
+		}
+		seen[fw.Name] = true
+		// Use GetFramework to get the merged result (store base + user overlay).
+		if merged, ok := GetFramework(fw.Name); ok {
+			result = append(result, FrameworkInfo{Framework: merged, Source: SourceStore})
+		}
+	}
+
+	// User-only (no store base).
 	entries, _ := filepath.Glob(filepath.Join(FrameworksDir(), "*.yaml"))
 	for _, yamlPath := range entries {
-		data, err := os.ReadFile(yamlPath)
-		if err != nil {
+		fw := loadFrameworkYAML(yamlPath)
+		if fw == nil || seen[fw.Name] {
 			continue
 		}
-		var fw Framework
-		if yaml.Unmarshal(data, &fw) != nil || fw.Name == "" {
-			continue
-		}
-		result = append(result, &fw)
+		seen[fw.Name] = true
+		result = append(result, FrameworkInfo{Framework: fw, Source: SourceUser})
 	}
 
 	return result
@@ -312,27 +657,17 @@ func SaveFramework(fw *Framework) error {
 // the framework detected in projectDir. It checks the site registry first, then
 // falls back to auto-detection. For Laravel the default is "artisan".
 func GetConsoleCommand(projectDir string) (string, error) {
-	framework := ""
-
-	if site, err := FindSiteByPath(projectDir); err == nil && site.Framework != "" {
-		framework = site.Framework
-	} else {
-		detected, ok := DetectFramework(projectDir)
-		if !ok {
-			return "", fmt.Errorf("no framework detected — create framework config with 'lerd framework add'")
-		}
-		framework = detected
+	site, err := FindSiteByPath(projectDir)
+	if err != nil || site.Framework == "" {
+		return "", fmt.Errorf("no framework assigned — run 'lerd link' first")
 	}
 
-	fw, ok := GetFramework(framework)
+	fw, ok := GetFrameworkForDir(site.Framework, projectDir)
 	if !ok {
-		return "", fmt.Errorf("framework %q not found", framework)
+		return "", fmt.Errorf("framework %q not found", site.Framework)
 	}
 
 	if fw.Console == "" {
-		if framework == "laravel" {
-			return "artisan", nil
-		}
 		return "", fmt.Errorf(
 			"no console command defined for framework %q — add 'console' field to %s/%s.yaml",
 			fw.Name,
@@ -344,10 +679,63 @@ func GetConsoleCommand(projectDir string) (string, error) {
 	return fw.Console, nil
 }
 
+// SaveStoreFramework writes a store-installed framework definition to StoreFrameworksDir().
+// If the framework has a Version field, the file is named <name>@<version>.yaml.
+// Otherwise it is named <name>.yaml (backwards compatible).
+func SaveStoreFramework(fw *Framework) error {
+	dir := StoreFrameworksDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(fw)
+	if err != nil {
+		return err
+	}
+	filename := fw.Name + ".yaml"
+	if fw.Version != "" {
+		filename = fw.Name + "@" + fw.Version + ".yaml"
+	}
+	return os.WriteFile(filepath.Join(dir, filename), data, 0644)
+}
+
+// RemoveUserFramework silently removes a user-defined framework YAML if it exists.
+// Used when migrating from user-defined to store-installed.
+func RemoveUserFramework(name string) {
+	os.Remove(filepath.Join(FrameworksDir(), name+".yaml")) //nolint:errcheck
+}
+
 // RemoveFramework deletes a user-defined framework YAML. For "laravel" it only
 // removes the user workers overlay (the built-in definition remains).
 func RemoveFramework(name string) error {
 	return os.Remove(filepath.Join(FrameworksDir(), name+".yaml"))
+}
+
+// HasWorker returns true if the framework defines a worker with the given name
+// and (if the worker has a Check rule) the check passes for the project at dir.
+func (fw *Framework) HasWorker(name, dir string) bool {
+	w, ok := fw.Workers[name]
+	if !ok {
+		return false
+	}
+	if w.Check != nil && dir != "" {
+		return MatchesRule(dir, *w.Check)
+	}
+	return true
+}
+
+// WorkerProxy returns the proxy configuration for the first worker that has one
+// and whose check rule passes for the project at dir. Returns nil if no proxy is configured.
+func (fw *Framework) DetectProxy(dir string) (*WorkerProxy, string) {
+	for name, w := range fw.Workers {
+		if w.Proxy == nil {
+			continue
+		}
+		if w.Check != nil && !MatchesRule(dir, *w.Check) {
+			continue
+		}
+		return w.Proxy, name
+	}
+	return nil, ""
 }
 
 // MatchesRule returns true if the given rule matches the project directory.
@@ -382,6 +770,70 @@ func matchesFramework(dir string, fw *Framework) bool {
 		}
 	}
 	return false
+}
+
+// composerLockMajorVersion detects the major version of a framework from composer.lock.
+func composerLockMajorVersion(projectDir, frameworkName string) string {
+	if projectDir == "" {
+		return ""
+	}
+
+	var packages []string
+	if frameworkName == "laravel" {
+		packages = []string{"laravel/framework"}
+	} else {
+		pattern := filepath.Join(StoreFrameworksDir(), frameworkName+"@*.yaml")
+		matches, _ := filepath.Glob(pattern)
+		matches = append(matches, filepath.Join(StoreFrameworksDir(), frameworkName+".yaml"))
+		for _, path := range matches {
+			if fw := loadFrameworkYAML(path); fw != nil {
+				for _, rule := range fw.Detect {
+					if rule.Composer != "" {
+						packages = append(packages, rule.Composer)
+					}
+				}
+				break
+			}
+		}
+	}
+
+	if len(packages) == 0 {
+		return ""
+	}
+
+	data, err := os.ReadFile(filepath.Join(projectDir, "composer.lock"))
+	if err != nil {
+		return ""
+	}
+	var lock struct {
+		Packages    []struct{ Name, Version string } `json:"packages"`
+		PackagesDev []struct{ Name, Version string } `json:"packages-dev"`
+	}
+	if json.Unmarshal(data, &lock) != nil {
+		return ""
+	}
+
+	all := append(lock.Packages, lock.PackagesDev...)
+	for _, pkg := range packages {
+		for _, p := range all {
+			if p.Name == pkg {
+				return extractMajorVersion(p.Version)
+			}
+		}
+	}
+	return ""
+}
+
+func extractMajorVersion(version string) string {
+	v := strings.TrimPrefix(version, "v")
+	if i := strings.IndexByte(v, '-'); i != -1 {
+		v = v[:i]
+	}
+	parts := strings.SplitN(v, ".", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return ""
+	}
+	return parts[0]
 }
 
 // ComposerHasPackage reports whether the composer.json in dir lists pkg

--- a/internal/config/framework_test.go
+++ b/internal/config/framework_test.go
@@ -233,6 +233,51 @@ func TestListFrameworks_IncludesLogs(t *testing.T) {
 	}
 }
 
+// ── RemoveFramework ─────────────────────────────────────────────────────────
+
+func TestRemoveFramework_UserDefined(t *testing.T) {
+	setConfigDir(t)
+
+	dir := FrameworksDir()
+	os.MkdirAll(dir, 0755)
+	os.WriteFile(filepath.Join(dir, "myfw.yaml"), []byte("name: myfw\n"), 0644)
+
+	if err := RemoveFramework("myfw"); err != nil {
+		t.Fatalf("RemoveFramework(user): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "myfw.yaml")); !os.IsNotExist(err) {
+		t.Error("expected user file to be removed")
+	}
+}
+
+func TestRemoveFramework_StoreInstalled(t *testing.T) {
+	setConfigDir(t)
+
+	dir := StoreFrameworksDir()
+	os.MkdirAll(dir, 0755)
+	os.WriteFile(filepath.Join(dir, "symfony.yaml"), []byte("name: symfony\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "symfony@7.yaml"), []byte("name: symfony\nversion: \"7\"\n"), 0644)
+
+	if err := RemoveFramework("symfony"); err != nil {
+		t.Fatalf("RemoveFramework(store): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "symfony.yaml")); !os.IsNotExist(err) {
+		t.Error("expected unversioned store file to be removed")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "symfony@7.yaml")); !os.IsNotExist(err) {
+		t.Error("expected versioned store file to be removed")
+	}
+}
+
+func TestRemoveFramework_NotFound(t *testing.T) {
+	setConfigDir(t)
+
+	err := RemoveFramework("nonexistent")
+	if !os.IsNotExist(err) {
+		t.Errorf("expected os.IsNotExist error, got: %v", err)
+	}
+}
+
 // ── FrameworkLogSource YAML round-trip ────────────────────────────────────────
 
 func TestFrameworkLogSource_YAMLRoundTrip(t *testing.T) {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -13,6 +13,14 @@ func xdgConfigHome() string {
 	return filepath.Join(home, ".config")
 }
 
+func xdgCacheHome() string {
+	if v := os.Getenv("XDG_CACHE_HOME"); v != "" {
+		return v
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".cache")
+}
+
 func xdgDataHome() string {
 	if v := os.Getenv("XDG_DATA_HOME"); v != "" {
 		return v
@@ -111,6 +119,16 @@ func ServiceFilesDir(name string) string {
 // FrameworksDir returns the directory for user-defined framework YAML files.
 func FrameworksDir() string {
 	return filepath.Join(ConfigDir(), "frameworks")
+}
+
+// StoreFrameworksDir returns the directory for store-installed framework YAML files.
+func StoreFrameworksDir() string {
+	return filepath.Join(DataDir(), "frameworks")
+}
+
+// StoreCacheDir returns the directory for cached framework store data.
+func StoreCacheDir() string {
+	return filepath.Join(xdgCacheHome(), "lerd", "store")
 }
 
 // UpdateCheckFile returns the path to the cached update-check state file.

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -10,9 +10,9 @@ import (
 
 // ProjectConfig holds per-project configuration stored in .lerd.yaml.
 type ProjectConfig struct {
-	Domains      []string         `yaml:"domains,omitempty"`
-	PHPVersion   string           `yaml:"php_version,omitempty"`
-	NodeVersion  string           `yaml:"node_version,omitempty"`
+	Domains          []string                   `yaml:"domains,omitempty"`
+	PHPVersion       string                     `yaml:"php_version,omitempty"`
+	NodeVersion      string                     `yaml:"node_version,omitempty"`
 	Framework        string                     `yaml:"framework,omitempty"`
 	FrameworkVersion string                     `yaml:"framework_version,omitempty"`
 	FrameworkDef     *Framework                 `yaml:"framework_def,omitempty"`

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -13,11 +13,13 @@ type ProjectConfig struct {
 	Domains      []string         `yaml:"domains,omitempty"`
 	PHPVersion   string           `yaml:"php_version,omitempty"`
 	NodeVersion  string           `yaml:"node_version,omitempty"`
-	Framework    string           `yaml:"framework,omitempty"`
-	FrameworkDef *Framework       `yaml:"framework_def,omitempty"`
-	Secured      bool             `yaml:"secured,omitempty"`
-	Services     []ProjectService `yaml:"services,omitempty"`
-	Workers      []string         `yaml:"workers,omitempty"`
+	Framework        string                     `yaml:"framework,omitempty"`
+	FrameworkVersion string                     `yaml:"framework_version,omitempty"`
+	FrameworkDef     *Framework                 `yaml:"framework_def,omitempty"`
+	Secured          bool                       `yaml:"secured,omitempty"`
+	Services         []ProjectService           `yaml:"services,omitempty"`
+	Workers          []string                   `yaml:"workers,omitempty"`
+	CustomWorkers    map[string]FrameworkWorker `yaml:"custom_workers,omitempty"`
 	// AppURL, when set, is the value lerd writes to the project's APP_URL (or
 	// the framework-configured URL key) on every `lerd env` run. Committed to
 	// the repo so the choice is shared across machines. Takes precedence over

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -46,11 +46,6 @@ func (s *Site) HasDomain(domain string) bool {
 	return false
 }
 
-// IsLaravel returns true if this site uses the Laravel framework.
-func (s *Site) IsLaravel() bool {
-	return s.Framework == "laravel"
-}
-
 // siteYAML is the on-disk YAML representation of a Site, supporting both the
 // legacy single "domain" field and the new "domains" array.
 type siteYAML struct {

--- a/internal/config/site_test.go
+++ b/internal/config/site_test.go
@@ -462,4 +462,3 @@ func searchString(s, substr string) bool {
 	}
 	return false
 }
-

--- a/internal/config/site_test.go
+++ b/internal/config/site_test.go
@@ -463,21 +463,3 @@ func searchString(s, substr string) bool {
 	return false
 }
 
-// ── IsLaravel ─────────────────────────────────────────────────────────────────
-
-func TestIsLaravel(t *testing.T) {
-	cases := []struct {
-		framework string
-		want      bool
-	}{
-		{"laravel", true},
-		{"symfony", false},
-		{"", false},
-	}
-	for _, c := range cases {
-		s := Site{Framework: c.framework}
-		if got := s.IsLaravel(); got != c.want {
-			t.Errorf("IsLaravel() for framework=%q = %v, want %v", c.framework, got, c.want)
-		}
-	}
-}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1183,13 +1183,17 @@ func toolList() []mcpTool {
 		},
 		mcpTool{
 			Name:        "framework_remove",
-			Description: "Delete a user-defined framework YAML by name. For laravel, removes only custom worker additions (built-in definition remains).",
+			Description: "Delete a framework definition (user-defined or store-installed) by name. For laravel, removes only custom worker additions (built-in definition remains). Use version to remove a specific version, or omit to remove all.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"name": {
 						Type:        "string",
-						Description: "Framework name to remove",
+						Description: "Framework name to remove (e.g. 'symfony')",
+					},
+					"version": {
+						Type:        "string",
+						Description: "Specific version to remove (e.g. '7'). Omit to remove all versions.",
 					},
 				},
 				Required: []string{"name"},
@@ -4141,17 +4145,36 @@ func execFrameworkRemove(args map[string]any) (any, *rpcError) {
 	if name == "" {
 		return toolErr("name is required"), nil
 	}
-	if err := config.RemoveFramework(name); err != nil {
-		if os.IsNotExist(err) {
-			if name == "laravel" {
+	version := strArg(args, "version")
+
+	if name == "laravel" {
+		if err := config.RemoveFramework(name); err != nil {
+			if os.IsNotExist(err) {
 				return toolErr("no custom workers defined for laravel"), nil
 			}
+			return toolErr(fmt.Sprintf("removing framework: %v", err)), nil
+		}
+		return toolOK("Custom Laravel worker additions removed. Built-in queue/schedule/reverb workers remain."), nil
+	}
+
+	if version != "" {
+		files := config.ListFrameworkFiles(name)
+		for _, f := range files {
+			if f.Version == version {
+				if err := config.RemoveFrameworkFile(f.Path); err != nil {
+					return toolErr(fmt.Sprintf("removing framework: %v", err)), nil
+				}
+				return toolOK(fmt.Sprintf("Removed %s@%s.", name, version)), nil
+			}
+		}
+		return toolErr(fmt.Sprintf("framework %q version %q not found", name, version)), nil
+	}
+
+	if err := config.RemoveFramework(name); err != nil {
+		if os.IsNotExist(err) {
 			return toolErr(fmt.Sprintf("framework %q not found", name)), nil
 		}
 		return toolErr(fmt.Sprintf("removing framework: %v", err)), nil
-	}
-	if name == "laravel" {
-		return toolOK("Custom Laravel worker additions removed. Built-in queue/schedule/reverb workers remain."), nil
 	}
 	return toolOK(fmt.Sprintf("Framework %q removed.", name)), nil
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1119,6 +1119,41 @@ func toolList() []mcpTool {
 			},
 		},
 		mcpTool{
+			Name:        "worker_add",
+			Description: "Add or update a custom worker for a project. Saves to .lerd.yaml custom_workers by default, or to the global user framework overlay (~/.config/lerd/frameworks/) with global: true. Does not auto-start — use worker_start afterwards.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"site":               {Type: "string", Description: "Site name as shown by the sites tool"},
+					"name":               {Type: "string", Description: "Worker name (slug, e.g. pdf-generator)"},
+					"command":            {Type: "string", Description: "Command to run inside the PHP-FPM container"},
+					"label":              {Type: "string", Description: "Human-readable label (optional)"},
+					"restart":            {Type: "string", Description: "Restart policy: always or on-failure (default: always)"},
+					"check_file":         {Type: "string", Description: "Only show worker when this file exists (optional)"},
+					"check_composer":     {Type: "string", Description: "Only show worker when this Composer package is installed (optional)"},
+					"conflicts_with":     {Type: "array", Description: "Workers to stop before starting this one (optional)"},
+					"proxy_path":         {Type: "string", Description: "URL path to proxy (optional, e.g. /app)"},
+					"proxy_port_env_key": {Type: "string", Description: "Env key holding the worker port (optional)"},
+					"proxy_default_port": {Type: "number", Description: "Default port if env key is missing (optional)"},
+					"global":             {Type: "boolean", Description: "Save to global framework overlay instead of project .lerd.yaml (default: false)"},
+				},
+				Required: []string{"site", "name", "command"},
+			},
+		},
+		mcpTool{
+			Name:        "worker_remove",
+			Description: "Remove a custom worker from a project's .lerd.yaml or global framework overlay. Stops the worker if running.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"site":   {Type: "string", Description: "Site name as shown by the sites tool"},
+					"name":   {Type: "string", Description: "Worker name to remove"},
+					"global": {Type: "boolean", Description: "Remove from global framework overlay instead of .lerd.yaml (default: false)"},
+				},
+				Required: []string{"site", "name"},
+			},
+		},
+		mcpTool{
 			Name:        "framework_list",
 			Description: "List all available framework definitions (laravel built-in plus any user-defined YAMLs), including their defined workers and setup commands. Use this before framework_add to see what is already defined.",
 			InputSchema: mcpSchema{Type: "object", Properties: map[string]mcpProp{}},
@@ -1406,6 +1441,10 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execWorkerStart(args)
 	case "worker_stop":
 		return execWorkerStop(args)
+	case "worker_add":
+		return execWorkerAdd(args)
+	case "worker_remove":
+		return execWorkerRemove(args)
 	case "worker_list":
 		return execWorkerList(args)
 	case "logs":
@@ -4105,16 +4144,19 @@ func execWorkerList(args map[string]any) (any, *rpcError) {
 	}
 
 	type workerInfo struct {
-		Name    string `json:"name"`
-		Label   string `json:"label"`
-		Command string `json:"command"`
-		Restart string `json:"restart"`
-		Running bool   `json:"running"`
-		Unit    string `json:"unit"`
+		Name     string `json:"name"`
+		Label    string `json:"label"`
+		Command  string `json:"command"`
+		Restart  string `json:"restart"`
+		Running  bool   `json:"running"`
+		Unit     string `json:"unit"`
+		Orphaned bool   `json:"orphaned,omitempty"`
 	}
 
+	known := make(map[string]bool, len(fw.Workers))
 	var result []workerInfo
 	for wname, w := range fw.Workers {
+		known[wname] = true
 		unitName := "lerd-" + wname + "-" + siteName
 		status, _ := podman.UnitStatus(unitName)
 		label := w.Label
@@ -4134,10 +4176,169 @@ func execWorkerList(args map[string]any) (any, *rpcError) {
 			Unit:    unitName,
 		})
 	}
+
+	// Detect orphaned workers — running units with no framework definition.
+	orphans := lerdSystemd.FindOrphanedWorkers(siteName, known)
+	for _, wname := range orphans {
+		unitName := "lerd-" + wname + "-" + siteName
+		result = append(result, workerInfo{
+			Name:     wname,
+			Label:    wname + " (orphaned)",
+			Running:  true,
+			Unit:     unitName,
+			Orphaned: true,
+		})
+	}
+
 	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
 
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return toolOK(string(data)), nil
+}
+
+func execWorkerAdd(args map[string]any) (any, *rpcError) {
+	siteName := strArg(args, "site")
+	if siteName == "" {
+		return toolErr("site is required"), nil
+	}
+	name := strArg(args, "name")
+	if name == "" {
+		return toolErr("name is required"), nil
+	}
+	command := strArg(args, "command")
+	if command == "" {
+		return toolErr("command is required"), nil
+	}
+
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return toolErr("site not found: " + siteName), nil
+	}
+
+	w := config.FrameworkWorker{
+		Label:   strArg(args, "label"),
+		Command: command,
+		Restart: strArg(args, "restart"),
+	}
+	checkFile := strArg(args, "check_file")
+	checkComposer := strArg(args, "check_composer")
+	if checkFile != "" || checkComposer != "" {
+		w.Check = &config.FrameworkRule{File: checkFile, Composer: checkComposer}
+	}
+	if cw := strSliceArg(args, "conflicts_with"); len(cw) > 0 {
+		w.ConflictsWith = cw
+	}
+	proxyPath := strArg(args, "proxy_path")
+	if proxyPath != "" {
+		w.Proxy = &config.WorkerProxy{
+			Path:        proxyPath,
+			PortEnvKey:  strArg(args, "proxy_port_env_key"),
+			DefaultPort: intArg(args, "proxy_default_port", 0),
+		}
+	}
+
+	action := "added"
+	if boolArg(args, "global") {
+		fwName := site.Framework
+		if fwName == "" {
+			return toolErr("site has no framework assigned"), nil
+		}
+		fw := config.LoadUserFramework(fwName)
+		if fw == nil {
+			fw = &config.Framework{Name: fwName}
+		}
+		if fw.Workers == nil {
+			fw.Workers = make(map[string]config.FrameworkWorker)
+		}
+		if _, exists := fw.Workers[name]; exists {
+			action = "updated"
+		}
+		fw.Workers[name] = w
+		if err := config.SaveFramework(fw); err != nil {
+			return toolErr("saving framework overlay: " + err.Error()), nil
+		}
+		return toolOK(fmt.Sprintf("Custom worker %q %s in global %s overlay. Start it with worker_start(site: %q, worker: %q).", name, action, fwName, siteName, name)), nil
+	}
+
+	proj, err := config.LoadProjectConfig(site.Path)
+	if err != nil {
+		return toolErr("loading .lerd.yaml: " + err.Error()), nil
+	}
+	if proj.CustomWorkers == nil {
+		proj.CustomWorkers = make(map[string]config.FrameworkWorker)
+	}
+	if _, exists := proj.CustomWorkers[name]; exists {
+		action = "updated"
+	}
+	proj.CustomWorkers[name] = w
+	if err := config.SaveProjectConfig(site.Path, proj); err != nil {
+		return toolErr("saving .lerd.yaml: " + err.Error()), nil
+	}
+	return toolOK(fmt.Sprintf("Custom worker %q %s in .lerd.yaml. Start it with worker_start(site: %q, worker: %q).", name, action, siteName, name)), nil
+}
+
+func execWorkerRemove(args map[string]any) (any, *rpcError) {
+	siteName := strArg(args, "site")
+	if siteName == "" {
+		return toolErr("site is required"), nil
+	}
+	name := strArg(args, "name")
+	if name == "" {
+		return toolErr("name is required"), nil
+	}
+
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return toolErr("site not found: " + siteName), nil
+	}
+
+	// Stop the worker if running.
+	unitName := "lerd-" + name + "-" + siteName
+	if status, _ := podman.UnitStatus(unitName); status == "active" {
+		_ = lerdSystemd.DisableService(unitName)
+		podman.StopUnit(unitName) //nolint:errcheck
+		unitFile := filepath.Join(config.SystemdUserDir(), unitName+".service")
+		_ = os.Remove(unitFile)
+		_ = podman.DaemonReload()
+	}
+
+	if boolArg(args, "global") {
+		fwName := site.Framework
+		if fwName == "" {
+			return toolErr("site has no framework assigned"), nil
+		}
+		fw := config.LoadUserFramework(fwName)
+		if fw == nil || fw.Workers == nil {
+			return toolErr(fmt.Sprintf("no global overlay for framework %q", fwName)), nil
+		}
+		if _, exists := fw.Workers[name]; !exists {
+			return toolErr(fmt.Sprintf("worker %q not found in global %s overlay", name, fwName)), nil
+		}
+		delete(fw.Workers, name)
+		if len(fw.Workers) == 0 {
+			fw.Workers = nil
+		}
+		if err := config.SaveFramework(fw); err != nil {
+			return toolErr("saving framework overlay: " + err.Error()), nil
+		}
+		return toolOK(fmt.Sprintf("Custom worker %q removed from global %s overlay", name, fwName)), nil
+	}
+
+	proj, err := config.LoadProjectConfig(site.Path)
+	if err != nil {
+		return toolErr("loading .lerd.yaml: " + err.Error()), nil
+	}
+	if _, exists := proj.CustomWorkers[name]; !exists {
+		return toolErr(fmt.Sprintf("custom worker %q not found in .lerd.yaml for site %q", name, siteName)), nil
+	}
+	delete(proj.CustomWorkers, name)
+	if len(proj.CustomWorkers) == 0 {
+		proj.CustomWorkers = nil
+	}
+	if err := config.SaveProjectConfig(site.Path, proj); err != nil {
+		return toolErr("saving .lerd.yaml: " + err.Error()), nil
+	}
+	return toolOK(fmt.Sprintf("Custom worker %q removed from %s", name, siteName)), nil
 }
 
 func execFrameworkRemove(args map[string]any) (any, *rpcError) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -21,6 +21,7 @@ import (
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/serviceops"
+	"github.com/geodro/lerd/internal/store"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	lerdUpdate "github.com/geodro/lerd/internal/update"
 	"github.com/geodro/lerd/internal/version"
@@ -205,17 +206,20 @@ func dispatch(req *rpcRequest) (any, *rpcError) {
 
 // ---- Tool definitions ----
 
-// siteIsLaravel returns true when the default site path points to a registered
-// Laravel site, or when no path is configured (safe default: show all tools).
-func siteIsLaravel() bool {
-	if defaultSitePath == "" {
-		return true
+// siteHasConsole returns true when the site's framework defines a console command.
+func siteHasConsole() bool {
+	fw, ok := siteFramework()
+	return ok && fw.Console != ""
+}
+
+// siteHasWorker returns true when the site's framework defines the named worker
+// and its check rule passes.
+func siteHasWorker(name string) bool {
+	fw, ok := siteFramework()
+	if !ok {
+		return false
 	}
-	site, err := config.FindSiteByPath(defaultSitePath)
-	if err != nil {
-		return true // unknown site → show all tools
-	}
-	return site.IsLaravel()
+	return fw.HasWorker(name, defaultSitePath)
 }
 
 // siteFramework returns the framework definition for the configured site path.
@@ -228,11 +232,7 @@ func siteFramework() (*config.Framework, bool) {
 	if err != nil {
 		return nil, false
 	}
-	fwName := site.Framework
-	if fwName == "" {
-		fwName, _ = config.DetectFramework(defaultSitePath)
-	}
-	return config.GetFramework(fwName)
+	return config.GetFrameworkForDir(site.Framework, site.Path)
 }
 
 func toolList() []mcpTool {
@@ -863,7 +863,7 @@ func toolList() []mcpTool {
 		},
 	}
 
-	if siteIsLaravel() {
+	if siteHasConsole() {
 		tools = append(tools,
 			mcpTool{
 				Name:        "artisan",
@@ -1046,7 +1046,7 @@ func toolList() []mcpTool {
 		)
 	}
 
-	if fw, ok := siteFramework(); ok && !siteIsLaravel() && fw.Console != "" {
+	if fw, ok := siteFramework(); ok && fw.Console != "" && fw.Console != "artisan" {
 		tools = append(tools, mcpTool{
 			Name:        "console",
 			Description: fmt.Sprintf("Run a framework console command (php %s) inside the lerd PHP-FPM container for the project.", fw.Console),
@@ -1196,6 +1196,38 @@ func toolList() []mcpTool {
 			},
 		},
 		mcpTool{
+			Name:        "framework_search",
+			Description: "Search the community framework store for available definitions. Returns matching frameworks with their available versions.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"query": {
+						Type:        "string",
+						Description: "Search query (matches framework name or label, case-insensitive)",
+					},
+				},
+				Required: []string{"query"},
+			},
+		},
+		mcpTool{
+			Name:        "framework_install",
+			Description: "Install a framework definition from the community store. If no version is specified, auto-detects from composer.lock or uses the latest available version.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"name": {
+						Type:        "string",
+						Description: "Framework name to install (e.g. symfony, wordpress)",
+					},
+					"version": {
+						Type:        "string",
+						Description: "Framework major version (e.g. 11, 7). Omit to auto-detect or use latest.",
+					},
+				},
+				Required: []string{"name"},
+			},
+		},
+		mcpTool{
 			Name:        "project_new",
 			Description: "Scaffold a new PHP project using a framework's create command. For Laravel this runs `composer create-project --no-install --no-plugins --no-scripts laravel/laravel <path>`. Other frameworks must have a `create` field in their YAML definition. After creation, use site_link to register the site.",
 			InputSchema: mcpSchema{
@@ -1335,15 +1367,8 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		args = map[string]any{}
 	}
 
-	laravelOnly := func() (any, *rpcError) {
-		return toolErr(fmt.Sprintf("tool %q is only available for Laravel projects", p.Name)), nil
-	}
-
 	switch p.Name {
 	case "artisan":
-		if !siteIsLaravel() {
-			return laravelOnly()
-		}
 		return execArtisan(args)
 	case "console":
 		return execArtisan(args)
@@ -1370,14 +1395,8 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 	case "schedule_stop":
 		return execScheduleStop(args)
 	case "stripe_listen":
-		if !siteIsLaravel() {
-			return laravelOnly()
-		}
 		return execStripeListen(args)
 	case "stripe_listen_stop":
-		if !siteIsLaravel() {
-			return laravelOnly()
-		}
 		return execStripeListenStop(args)
 	case "worker_start":
 		return execWorkerStart(args)
@@ -1451,6 +1470,10 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execFrameworkAdd(args)
 	case "framework_remove":
 		return execFrameworkRemove(args)
+	case "framework_search":
+		return execFrameworkSearch(args)
+	case "framework_install":
+		return execFrameworkInstall(args)
 	case "project_new":
 		return execProjectNew(args)
 	case "site_php":
@@ -1630,12 +1653,9 @@ func execSites() (any, *rpcError) {
 		}
 
 		fwName := s.Framework
-		if fwName == "" {
-			fwName, _ = config.DetectFramework(s.Path)
-		}
 		var workers []workerStatus
 		if fwName != "" {
-			if fw, ok := config.GetFramework(fwName); ok {
+			if fw, ok := config.GetFrameworkForDir(fwName, s.Path); ok {
 				for wname := range fw.Workers {
 					unitName := "lerd-" + wname + "-" + s.Name
 					status, _ := podman.UnitStatus(unitName)
@@ -3981,12 +4001,9 @@ func execWorkerStart(args map[string]any) (any, *rpcError) {
 
 	fwName := site.Framework
 	if fwName == "" {
-		fwName, _ = config.DetectFramework(site.Path)
+		return toolErr("site has no framework assigned — run lerd link first"), nil
 	}
-	if fwName == "" {
-		return toolErr("no framework detected for site " + siteName), nil
-	}
-	fw, ok := config.GetFramework(fwName)
+	fw, ok := config.GetFrameworkForDir(fwName, site.Path)
 	if !ok {
 		return toolErr("framework not found: " + fwName), nil
 	}
@@ -4074,13 +4091,10 @@ func execWorkerList(args map[string]any) (any, *rpcError) {
 
 	fwName := site.Framework
 	if fwName == "" {
-		fwName, _ = config.DetectFramework(site.Path)
-	}
-	if fwName == "" {
 		data, _ := json.MarshalIndent([]struct{}{}, "", "  ")
 		return toolOK(string(data)), nil
 	}
-	fw, ok := config.GetFramework(fwName)
+	fw, ok := config.GetFrameworkForDir(fwName, site.Path)
 	if !ok || len(fw.Workers) == 0 {
 		data, _ := json.MarshalIndent([]struct{}{}, "", "  ")
 		return toolOK(string(data)), nil
@@ -4140,6 +4154,92 @@ func execFrameworkRemove(args map[string]any) (any, *rpcError) {
 		return toolOK("Custom Laravel worker additions removed. Built-in queue/schedule/reverb workers remain."), nil
 	}
 	return toolOK(fmt.Sprintf("Framework %q removed.", name)), nil
+}
+
+func execFrameworkSearch(args map[string]any) (any, *rpcError) {
+	query := strArg(args, "query")
+	if query == "" {
+		return toolErr("query is required"), nil
+	}
+
+	client := store.NewClient()
+	results, err := client.Search(query)
+	if err != nil {
+		return toolErr(fmt.Sprintf("searching store: %v", err)), nil
+	}
+
+	type searchResult struct {
+		Name     string   `json:"name"`
+		Label    string   `json:"label"`
+		Versions []string `json:"versions"`
+		Latest   string   `json:"latest"`
+	}
+	out := make([]searchResult, len(results))
+	for i, r := range results {
+		out[i] = searchResult{
+			Name:     r.Name,
+			Label:    r.Label,
+			Versions: r.Versions,
+			Latest:   r.Latest,
+		}
+	}
+	data, _ := json.Marshal(out)
+	return toolOK(string(data)), nil
+}
+
+func execFrameworkInstall(args map[string]any) (any, *rpcError) {
+	name := strArg(args, "name")
+	if name == "" {
+		return toolErr("name is required"), nil
+	}
+	version := strArg(args, "version")
+
+	client := store.NewClient()
+
+	// Auto-detect version from site path if not specified
+	if version == "" {
+		sitePath := defaultSitePath
+		if sitePath != "" {
+			idx, err := client.FetchIndex()
+			if err == nil {
+				for _, entry := range idx.Frameworks {
+					if entry.Name == name {
+						for _, rule := range entry.Detect {
+							if rule.Composer != "" {
+								if v := store.DetectFrameworkVersion(sitePath, rule.Composer); v != "" {
+									for _, ev := range entry.Versions {
+										if ev == v {
+											version = v
+											break
+										}
+									}
+								}
+							}
+							if version != "" {
+								break
+							}
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+
+	fw, err := client.FetchFramework(name, version)
+	if err != nil {
+		return toolErr(fmt.Sprintf("fetching framework: %v", err)), nil
+	}
+
+	if err := config.SaveStoreFramework(fw); err != nil {
+		return toolErr(fmt.Sprintf("saving framework: %v", err)), nil
+	}
+
+	versionStr := fw.Version
+	if versionStr == "" {
+		versionStr = "latest"
+	}
+	return toolOK(fmt.Sprintf("Installed %s@%s (%s). Saved to %s/%s.yaml", fw.Name, versionStr, fw.Label, config.StoreFrameworksDir(), fw.Name)), nil
 }
 
 func execProjectNew(args map[string]any) (any, *rpcError) {

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -14,30 +14,29 @@ import (
 	"github.com/geodro/lerd/internal/podman"
 )
 
-// detectSiteReverb returns true when the project at sitePath uses Laravel Reverb —
-// either as a composer dependency or with BROADCAST_CONNECTION=reverb in .env/.env.example.
-func detectSiteReverb(sitePath string) bool {
-	if data, err := os.ReadFile(filepath.Join(sitePath, "composer.json")); err == nil {
-		if strings.Contains(string(data), `"laravel/reverb"`) {
-			return true
-		}
+// detectSiteProxy checks the site's framework definition for a worker with a
+// proxy configuration. Returns the proxy path and port if found.
+func detectSiteProxy(site config.Site) (path string, port int, ok bool) {
+	fw, fwOK := config.GetFrameworkForDir(site.Framework, site.Path)
+	if !fwOK {
+		return "", 0, false
 	}
-	for _, name := range []string{".env", ".env.example"} {
-		if data, err := os.ReadFile(filepath.Join(sitePath, name)); err == nil {
-			for _, line := range strings.Split(string(data), "\n") {
-				line = strings.TrimSpace(line)
-				if strings.HasPrefix(line, "#") {
-					continue
-				}
-				if strings.EqualFold(line, "BROADCAST_CONNECTION=reverb") ||
-					strings.EqualFold(line, `BROADCAST_CONNECTION="reverb"`) ||
-					strings.EqualFold(line, `BROADCAST_CONNECTION='reverb'`) {
-					return true
-				}
+	proxy, _ := fw.DetectProxy(site.Path)
+	if proxy == nil {
+		return "", 0, false
+	}
+	proxyPort := proxy.DefaultPort
+	if proxyPort == 0 {
+		proxyPort = 8080
+	}
+	if proxy.PortEnvKey != "" {
+		if v := envfile.ReadKey(filepath.Join(site.Path, ".env"), proxy.PortEnvKey); v != "" {
+			if p, err := strconv.Atoi(v); err == nil && p > 0 {
+				proxyPort = p
 			}
 		}
 	}
-	return false
+	return proxy.Path, proxyPort, true
 }
 
 type nginxConfData struct {
@@ -53,18 +52,9 @@ type VhostData struct {
 	PHPVersionShort string
 	CertDomain      string // domain whose cert files to use (defaults to Domain)
 	PublicDir       string // document root subdirectory, e.g. "public", "web", "."
-	Reverb          bool   // true when the site uses Laravel Reverb (adds /app WebSocket proxy)
-	ReverbPort      int    // port Reverb listens on inside the PHP-FPM container (default 8080)
-}
-
-// detectSiteReverbPort reads REVERB_SERVER_PORT from the site's .env, falling back to 8080.
-func detectSiteReverbPort(sitePath string) int {
-	if v := envfile.ReadKey(filepath.Join(sitePath, ".env"), "REVERB_SERVER_PORT"); v != "" {
-		if port, err := strconv.Atoi(v); err == nil && port > 0 {
-			return port
-		}
-	}
-	return 8080
+	Proxy           bool   // true when the site has a worker with WebSocket/HTTP proxy config
+	ProxyPath       string // URL path for the proxy (e.g. "/app")
+	ProxyPort       int    // port the worker listens on inside the PHP-FPM container
 }
 
 // phpShort converts "8.4" → "84".
@@ -79,7 +69,7 @@ func resolvePublicDir(site config.Site) string {
 	if site.PublicDir != "" {
 		return site.PublicDir
 	}
-	if fw, ok := config.GetFramework(site.Framework); ok && fw.PublicDir != "" {
+	if fw, ok := config.GetFrameworkForDir(site.Framework, site.Path); ok && fw.PublicDir != "" {
 		return fw.PublicDir
 	}
 	return "public"
@@ -112,6 +102,7 @@ func GenerateVhost(site config.Site, phpVersion string) error {
 	publicDir := resolvePublicDir(site)
 	serverNames := serverNamesWithWildcards(site.Domains)
 
+	proxyPath, proxyPort, hasProxy := detectSiteProxy(site)
 	data := VhostData{
 		Domain:          site.PrimaryDomain(),
 		ServerNames:     serverNames,
@@ -119,8 +110,9 @@ func GenerateVhost(site config.Site, phpVersion string) error {
 		PHPVersion:      phpVersion,
 		PHPVersionShort: phpShort(phpVersion),
 		PublicDir:       publicDir,
-		Reverb:          detectSiteReverb(site.Path),
-		ReverbPort:      detectSiteReverbPort(site.Path),
+		Proxy:           hasProxy,
+		ProxyPath:       proxyPath,
+		ProxyPort:       proxyPort,
 	}
 
 	var buf bytes.Buffer
@@ -150,6 +142,7 @@ func GenerateSSLVhost(site config.Site, phpVersion string) error {
 	publicDir := resolvePublicDir(site)
 	serverNames := serverNamesWithWildcards(site.Domains)
 
+	proxyPath, proxyPort, hasProxy := detectSiteProxy(site)
 	data := VhostData{
 		Domain:          site.PrimaryDomain(),
 		ServerNames:     serverNames,
@@ -158,8 +151,9 @@ func GenerateSSLVhost(site config.Site, phpVersion string) error {
 		PHPVersionShort: phpShort(phpVersion),
 		CertDomain:      site.PrimaryDomain(),
 		PublicDir:       publicDir,
-		Reverb:          detectSiteReverb(site.Path),
-		ReverbPort:      detectSiteReverbPort(site.Path),
+		Proxy:           hasProxy,
+		ProxyPath:       proxyPath,
+		ProxyPort:       proxyPort,
 	}
 
 	var buf bytes.Buffer

--- a/internal/nginx/templates/vhost-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-ssl.conf.tmpl
@@ -12,10 +12,10 @@ server {
 
     ssl_certificate /etc/nginx/certs/{{.CertDomain}}.crt;
     ssl_certificate_key /etc/nginx/certs/{{.CertDomain}}.key;
-{{if .Reverb}}
-    location /app {
-        set $reverb "lerd-php{{.PHPVersionShort}}-fpm";
-        proxy_pass http://$reverb:{{.ReverbPort}};
+{{if .Proxy}}
+    location {{.ProxyPath}} {
+        set $proxybackend "lerd-php{{.PHPVersionShort}}-fpm";
+        proxy_pass http://$proxybackend:{{.ProxyPort}};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/internal/nginx/templates/vhost.conf.tmpl
+++ b/internal/nginx/templates/vhost.conf.tmpl
@@ -3,10 +3,10 @@ server {
     server_name {{.ServerNames}};
     root {{.Path}}/{{.PublicDir}};
     index index.php index.html;
-{{if .Reverb}}
-    location /app {
-        set $reverb "lerd-php{{.PHPVersionShort}}-fpm";
-        proxy_pass http://$reverb:{{.ReverbPort}};
+{{if .Proxy}}
+    location {{.ProxyPath}} {
+        set $proxybackend "lerd-php{{.PHPVersionShort}}-fpm";
+        proxy_pass http://$proxybackend:{{.ProxyPort}};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/internal/php/detector.go
+++ b/internal/php/detector.go
@@ -91,6 +91,58 @@ func DetectVersion(dir string) (string, error) {
 	return cfg.PHP.DefaultVersion, nil
 }
 
+// ClampToRange checks if version falls within [min, max] and returns the best
+// installed version within range if it doesn't. Returns the original version if
+// min/max are empty or the version is already in range. This is used to respect
+// framework PHP version constraints during site linking.
+func ClampToRange(version, min, max string) string {
+	if min == "" && max == "" {
+		return version
+	}
+
+	major, minor := parseMajorMinor(version)
+	if major < 0 {
+		return version
+	}
+
+	inRange := true
+	if min != "" {
+		mMajor, mMinor := parseMajorMinor(min)
+		if mMajor >= 0 && (major < mMajor || (major == mMajor && minor < mMinor)) {
+			inRange = false
+		}
+	}
+	if max != "" {
+		mMajor, mMinor := parseMajorMinor(max)
+		if mMajor >= 0 && (major > mMajor || (major == mMajor && minor > mMinor)) {
+			inRange = false
+		}
+	}
+
+	if inRange {
+		return version
+	}
+
+	// Build a composer-style constraint from min/max and find best installed.
+	var parts []string
+	if min != "" {
+		parts = append(parts, ">="+min)
+	}
+	if max != "" {
+		parts = append(parts, "<="+max)
+	}
+	constraint := strings.Join(parts, " ")
+	if best := bestInstalledVersion(constraint); best != "" {
+		return best
+	}
+
+	// No installed version in range; fall back to min if set.
+	if min != "" {
+		return min
+	}
+	return version
+}
+
 // parseComposerPHP extracts a simple major.minor version from a composer PHP constraint.
 // e.g. "^8.2" → "8.2", ">=8.1" → "8.1", "~8.3.0" → "8.3"
 func parseComposerPHP(constraint string) string {

--- a/internal/php/detector_test.go
+++ b/internal/php/detector_test.go
@@ -248,3 +248,45 @@ func TestDetectExtensions_NoExtRequires(t *testing.T) {
 		t.Errorf("expected no extensions, got %v", exts)
 	}
 }
+
+// ── ClampToRange ─────────────────────────────────────────────────────────────
+
+func TestClampToRange(t *testing.T) {
+	tests := []struct {
+		version, min, max, want string
+	}{
+		// In range — no change.
+		{"8.3", "8.2", "8.4", "8.3"},
+		{"8.2", "8.2", "8.4", "8.2"},
+		{"8.4", "8.2", "8.4", "8.4"},
+		// Empty range — no change.
+		{"8.3", "", "", "8.3"},
+		{"8.3", "", "8.4", "8.3"},
+		{"8.3", "8.2", "", "8.3"},
+		// Below min — clamps (falls back to min if no installed version).
+		{"8.1", "8.2", "8.4", "8.2"},
+		{"7.4", "8.2", "8.5", "8.2"},
+		// Above max — clamps.
+		{"8.5", "8.2", "8.4", "8.4"},
+	}
+	for _, tt := range tests {
+		got := ClampToRange(tt.version, tt.min, tt.max)
+		// ClampToRange may pick a different installed version within range,
+		// but when no installed version matches it falls back to min/max boundary.
+		// We check that the result is within the stated range.
+		if tt.min != "" {
+			gMaj, gMin := parseMajorMinor(got)
+			mMaj, mMin := parseMajorMinor(tt.min)
+			if gMaj < mMaj || (gMaj == mMaj && gMin < mMin) {
+				t.Errorf("ClampToRange(%q, %q, %q) = %q, below min", tt.version, tt.min, tt.max, got)
+			}
+		}
+		if tt.max != "" {
+			gMaj, gMin := parseMajorMinor(got)
+			mMaj, mMin := parseMajorMinor(tt.max)
+			if gMaj > mMaj || (gMaj == mMaj && gMin > mMin) {
+				t.Errorf("ClampToRange(%q, %q, %q) = %q, above max", tt.version, tt.min, tt.max, got)
+			}
+		}
+	}
+}

--- a/internal/store/detect.go
+++ b/internal/store/detect.go
@@ -1,0 +1,57 @@
+package store
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/geodro/lerd/internal/config"
+	"golang.org/x/term"
+)
+
+// DetectFrameworkWithStore wraps config.DetectFramework with a store fallback.
+// When no local framework matches and stdin is a terminal, it checks the store
+// index and prompts the user to install a matching definition.
+// Returns the framework name and true if resolved, ("", false) otherwise.
+func DetectFrameworkWithStore(dir string) (string, bool) {
+	// Try local detection first
+	if name, ok := config.DetectFramework(dir); ok {
+		return name, true
+	}
+
+	// Only prompt in interactive mode
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return "", false
+	}
+
+	client := NewClient()
+	entry, version, ok := client.DetectFromStore(dir)
+	if !ok {
+		return "", false
+	}
+
+	// Prompt user
+	fmt.Printf("Detected %s project. Install framework definition from the store? [Y/n] ", entry.Label)
+	var answer string
+	fmt.Scanln(&answer) //nolint:errcheck
+	if answer != "" && answer[0] != 'Y' && answer[0] != 'y' {
+		return "", false
+	}
+
+	fw, err := client.FetchFramework(entry.Name, version)
+	if err != nil {
+		fmt.Printf("  [WARN] Failed to fetch %s: %v\n", entry.Name, err)
+		return "", false
+	}
+
+	if err := config.SaveStoreFramework(fw); err != nil {
+		fmt.Printf("  [WARN] Failed to save %s: %v\n", entry.Name, err)
+		return "", false
+	}
+
+	versionStr := fw.Version
+	if versionStr == "" {
+		versionStr = "latest"
+	}
+	fmt.Printf("  Installed %s@%s\n", fw.Name, versionStr)
+	return fw.Name, true
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -33,10 +33,10 @@ type Index struct {
 
 // IndexEntry describes a single framework available in the store.
 type IndexEntry struct {
-	Name     string               `json:"name"`
-	Label    string               `json:"label"`
-	Versions []string             `json:"versions"`
-	Latest   string               `json:"latest"`
+	Name     string                 `json:"name"`
+	Label    string                 `json:"label"`
+	Versions []string               `json:"versions"`
+	Latest   string                 `json:"latest"`
 	Detect   []config.FrameworkRule `json:"detect"`
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -40,6 +40,25 @@ type IndexEntry struct {
 	Detect   []config.FrameworkRule `json:"detect"`
 }
 
+func init() {
+	config.RegisterFrameworkFetchHook(autoFetchFramework)
+}
+
+// autoFetchFramework downloads a framework definition from the store and saves
+// it to the local store directory. Called automatically by config.GetFrameworkForDir
+// when a version-specific definition is missing locally.
+func autoFetchFramework(name, version string) (*config.Framework, error) {
+	client := NewClient()
+	fw, err := client.FetchFramework(name, version)
+	if err != nil {
+		return nil, err
+	}
+	if err := config.SaveStoreFramework(fw); err != nil {
+		return nil, err
+	}
+	return fw, nil
+}
+
 // NewClient returns a store client with default settings.
 func NewClient() *Client {
 	return &Client{
@@ -82,7 +101,7 @@ func (c *Client) FetchIndex() (*Index, error) {
 }
 
 // FetchFramework downloads a framework definition from the store.
-// Versioned definitions are cached indefinitely (they are immutable).
+// Always fetches from remote to ensure definitions are up to date.
 func (c *Client) FetchFramework(name, version string) (*config.Framework, error) {
 	if version == "" {
 		// Resolve latest from index
@@ -97,17 +116,6 @@ func (c *Client) FetchFramework(name, version string) (*config.Framework, error)
 		version = entry.Latest
 	}
 
-	cacheFile := filepath.Join(c.CacheDir, name, version+".yaml")
-
-	// Versioned definitions are immutable — cache hit means done
-	if data, err := os.ReadFile(cacheFile); err == nil {
-		var fw config.Framework
-		if yaml.Unmarshal(data, &fw) == nil && fw.Name != "" {
-			return &fw, nil
-		}
-	}
-
-	// Fetch from remote
 	remotePath := name + "/" + version + ".yaml"
 	data, err := c.fetch(remotePath)
 	if err != nil {
@@ -120,11 +128,6 @@ func (c *Client) FetchFramework(name, version string) (*config.Framework, error)
 	}
 	if fw.Name == "" {
 		return nil, fmt.Errorf("invalid framework definition for %s@%s: missing name", name, version)
-	}
-
-	// Write to cache
-	if mkErr := os.MkdirAll(filepath.Dir(cacheFile), 0o755); mkErr == nil {
-		os.WriteFile(cacheFile, data, 0o644) //nolint:errcheck
 	}
 
 	return &fw, nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,0 +1,224 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	defaultBaseURL = "https://raw.githubusercontent.com/geodro/lerd-frameworks/main/frameworks"
+	indexTTL       = 24 * time.Hour
+	httpTimeout    = 10 * time.Second
+)
+
+// Client fetches framework definitions from the remote store.
+type Client struct {
+	BaseURL  string
+	CacheDir string
+}
+
+// Index is the top-level store index listing all available frameworks.
+type Index struct {
+	Frameworks []IndexEntry `json:"frameworks"`
+}
+
+// IndexEntry describes a single framework available in the store.
+type IndexEntry struct {
+	Name     string               `json:"name"`
+	Label    string               `json:"label"`
+	Versions []string             `json:"versions"`
+	Latest   string               `json:"latest"`
+	Detect   []config.FrameworkRule `json:"detect"`
+}
+
+// NewClient returns a store client with default settings.
+func NewClient() *Client {
+	return &Client{
+		BaseURL:  defaultBaseURL,
+		CacheDir: config.StoreCacheDir(),
+	}
+}
+
+// FetchIndex downloads the store index, using a 24-hour disk cache.
+func (c *Client) FetchIndex() (*Index, error) {
+	cacheFile := filepath.Join(c.CacheDir, "index.json")
+
+	// Check cache
+	if data, err := os.ReadFile(cacheFile); err == nil {
+		if info, statErr := os.Stat(cacheFile); statErr == nil && time.Since(info.ModTime()) < indexTTL {
+			var idx Index
+			if json.Unmarshal(data, &idx) == nil {
+				return &idx, nil
+			}
+		}
+	}
+
+	// Fetch from remote
+	data, err := c.fetch("index.json")
+	if err != nil {
+		return nil, fmt.Errorf("fetching store index: %w", err)
+	}
+
+	var idx Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, fmt.Errorf("parsing store index: %w", err)
+	}
+
+	// Write to cache
+	if mkErr := os.MkdirAll(filepath.Dir(cacheFile), 0o755); mkErr == nil {
+		os.WriteFile(cacheFile, data, 0o644) //nolint:errcheck
+	}
+
+	return &idx, nil
+}
+
+// FetchFramework downloads a framework definition from the store.
+// Versioned definitions are cached indefinitely (they are immutable).
+func (c *Client) FetchFramework(name, version string) (*config.Framework, error) {
+	if version == "" {
+		// Resolve latest from index
+		idx, err := c.FetchIndex()
+		if err != nil {
+			return nil, err
+		}
+		entry, ok := c.findEntry(idx, name)
+		if !ok {
+			return nil, fmt.Errorf("framework %q not found in store", name)
+		}
+		version = entry.Latest
+	}
+
+	cacheFile := filepath.Join(c.CacheDir, name, version+".yaml")
+
+	// Versioned definitions are immutable — cache hit means done
+	if data, err := os.ReadFile(cacheFile); err == nil {
+		var fw config.Framework
+		if yaml.Unmarshal(data, &fw) == nil && fw.Name != "" {
+			return &fw, nil
+		}
+	}
+
+	// Fetch from remote
+	remotePath := name + "/" + version + ".yaml"
+	data, err := c.fetch(remotePath)
+	if err != nil {
+		return nil, fmt.Errorf("fetching %s@%s: %w", name, version, err)
+	}
+
+	var fw config.Framework
+	if err := yaml.Unmarshal(data, &fw); err != nil {
+		return nil, fmt.Errorf("parsing %s@%s: %w", name, version, err)
+	}
+	if fw.Name == "" {
+		return nil, fmt.Errorf("invalid framework definition for %s@%s: missing name", name, version)
+	}
+
+	// Write to cache
+	if mkErr := os.MkdirAll(filepath.Dir(cacheFile), 0o755); mkErr == nil {
+		os.WriteFile(cacheFile, data, 0o644) //nolint:errcheck
+	}
+
+	return &fw, nil
+}
+
+// Search filters the store index by a case-insensitive substring match on name or label.
+func (c *Client) Search(query string) ([]IndexEntry, error) {
+	idx, err := c.FetchIndex()
+	if err != nil {
+		return nil, err
+	}
+
+	q := strings.ToLower(query)
+	var results []IndexEntry
+	for _, entry := range idx.Frameworks {
+		if strings.Contains(strings.ToLower(entry.Name), q) ||
+			strings.Contains(strings.ToLower(entry.Label), q) {
+			results = append(results, entry)
+		}
+	}
+	return results, nil
+}
+
+// DetectFromStore checks the store index for a framework matching the given
+// project directory. Returns the matching entry, the resolved version, and true
+// if found. The version is auto-detected from composer.lock when possible.
+func (c *Client) DetectFromStore(dir string) (*IndexEntry, string, bool) {
+	idx, err := c.FetchIndex()
+	if err != nil {
+		return nil, "", false
+	}
+
+	for i, entry := range idx.Frameworks {
+		for _, rule := range entry.Detect {
+			if config.MatchesRule(dir, rule) {
+				version := c.resolveVersion(dir, &entry)
+				return &idx.Frameworks[i], version, true
+			}
+		}
+	}
+	return nil, "", false
+}
+
+// InvalidateIndex removes the cached index so the next FetchIndex call hits the network.
+func (c *Client) InvalidateIndex() {
+	os.Remove(filepath.Join(c.CacheDir, "index.json")) //nolint:errcheck
+}
+
+// resolveVersion tries to detect the framework version from composer.lock,
+// falling back to the entry's Latest version.
+func (c *Client) resolveVersion(dir string, entry *IndexEntry) string {
+	// Find a composer package from the detect rules
+	for _, rule := range entry.Detect {
+		if rule.Composer != "" {
+			if ver := DetectFrameworkVersion(dir, rule.Composer); ver != "" {
+				// Check if this version exists in the store
+				for _, v := range entry.Versions {
+					if v == ver {
+						return ver
+					}
+				}
+			}
+		}
+	}
+	return entry.Latest
+}
+
+func (c *Client) findEntry(idx *Index, name string) (*IndexEntry, bool) {
+	for i, entry := range idx.Frameworks {
+		if entry.Name == name {
+			return &idx.Frameworks[i], true
+		}
+	}
+	return nil, false
+}
+
+func (c *Client) fetch(path string) ([]byte, error) {
+	url := c.BaseURL + "/" + path
+	client := &http.Client{Timeout: httpTimeout}
+	req, err := http.NewRequest(http.MethodGet, url, nil) //nolint:noctx
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "lerd-cli")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+	}
+
+	return io.ReadAll(resp.Body)
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -172,25 +172,25 @@ func TestFetchFramework_NotFound(t *testing.T) {
 	}
 }
 
-func TestFetchFramework_CacheHit(t *testing.T) {
+func TestFetchFramework_AlwaysFresh(t *testing.T) {
 	srv := testServer(t)
 	defer srv.Close()
 	c := testClient(t, srv)
 
-	// First fetch
-	_, err := c.FetchFramework("symfony", "7")
-	if err != nil {
-		t.Fatalf("first FetchFramework() error: %v", err)
-	}
-
-	// Stop server — second call should use cache
-	srv.Close()
+	// Fetch should always hit the server (no local cache).
 	fw, err := c.FetchFramework("symfony", "7")
 	if err != nil {
-		t.Fatalf("cached FetchFramework() error: %v", err)
+		t.Fatalf("FetchFramework() error: %v", err)
 	}
 	if fw.Name != "symfony" {
-		t.Errorf("expected name=symfony from cache, got %q", fw.Name)
+		t.Errorf("expected name=symfony, got %q", fw.Name)
+	}
+
+	// Stop server — second call should fail (no cache fallback).
+	srv.Close()
+	_, err = c.FetchFramework("symfony", "7")
+	if err == nil {
+		t.Error("expected error when server is down, got nil")
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,301 @@
+package store
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func testServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	index := Index{
+		Frameworks: []IndexEntry{
+			{
+				Name:     "laravel",
+				Label:    "Laravel",
+				Versions: []string{"11", "10"},
+				Latest:   "11",
+				Detect: []config.FrameworkRule{
+					{File: "artisan"},
+					{Composer: "laravel/framework"},
+				},
+			},
+			{
+				Name:     "symfony",
+				Label:    "Symfony",
+				Versions: []string{"7", "6"},
+				Latest:   "7",
+				Detect: []config.FrameworkRule{
+					{Composer: "symfony/framework-bundle"},
+				},
+			},
+		},
+	}
+
+	laravelYAML := `name: laravel
+label: Laravel
+version: "11"
+public_dir: public
+detect:
+  - file: artisan
+  - composer: laravel/framework
+console: artisan
+`
+
+	symfonyYAML := `name: symfony
+label: Symfony
+version: "7"
+public_dir: public
+detect:
+  - composer: symfony/framework-bundle
+console: bin/console
+`
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/index.json", func(w http.ResponseWriter, _ *http.Request) {
+		data, _ := json.Marshal(index)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data) //nolint:errcheck
+	})
+	mux.HandleFunc("/laravel/11.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(laravelYAML)) //nolint:errcheck
+	})
+	mux.HandleFunc("/symfony/7.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(symfonyYAML)) //nolint:errcheck
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func testClient(t *testing.T, srv *httptest.Server) *Client {
+	t.Helper()
+	return &Client{
+		BaseURL:  srv.URL,
+		CacheDir: filepath.Join(t.TempDir(), "store-cache"),
+	}
+}
+
+// ── FetchIndex ───────────────────────────────────────────────────────────────
+
+func TestFetchIndex(t *testing.T) {
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	idx, err := c.FetchIndex()
+	if err != nil {
+		t.Fatalf("FetchIndex() error: %v", err)
+	}
+	if len(idx.Frameworks) != 2 {
+		t.Fatalf("expected 2 frameworks, got %d", len(idx.Frameworks))
+	}
+	if idx.Frameworks[0].Name != "laravel" {
+		t.Errorf("expected first framework to be laravel, got %q", idx.Frameworks[0].Name)
+	}
+}
+
+func TestFetchIndex_CacheHit(t *testing.T) {
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	// First call populates cache
+	_, err := c.FetchIndex()
+	if err != nil {
+		t.Fatalf("first FetchIndex() error: %v", err)
+	}
+
+	// Stop server — second call should use cache
+	srv.Close()
+	idx, err := c.FetchIndex()
+	if err != nil {
+		t.Fatalf("cached FetchIndex() error: %v", err)
+	}
+	if len(idx.Frameworks) != 2 {
+		t.Errorf("expected 2 frameworks from cache, got %d", len(idx.Frameworks))
+	}
+}
+
+// ── FetchFramework ───────────────────────────────────────────────────────────
+
+func TestFetchFramework(t *testing.T) {
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	fw, err := c.FetchFramework("laravel", "11")
+	if err != nil {
+		t.Fatalf("FetchFramework() error: %v", err)
+	}
+	if fw.Name != "laravel" {
+		t.Errorf("expected name=laravel, got %q", fw.Name)
+	}
+	if fw.Version != "11" {
+		t.Errorf("expected version=11, got %q", fw.Version)
+	}
+	if fw.Console != "artisan" {
+		t.Errorf("expected console=artisan, got %q", fw.Console)
+	}
+}
+
+func TestFetchFramework_ResolvesLatest(t *testing.T) {
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	fw, err := c.FetchFramework("laravel", "")
+	if err != nil {
+		t.Fatalf("FetchFramework() error: %v", err)
+	}
+	if fw.Version != "11" {
+		t.Errorf("expected latest version=11, got %q", fw.Version)
+	}
+}
+
+func TestFetchFramework_NotFound(t *testing.T) {
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	_, err := c.FetchFramework("nonexistent", "1")
+	if err == nil {
+		t.Fatal("expected error for nonexistent framework")
+	}
+}
+
+func TestFetchFramework_CacheHit(t *testing.T) {
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	// First fetch
+	_, err := c.FetchFramework("symfony", "7")
+	if err != nil {
+		t.Fatalf("first FetchFramework() error: %v", err)
+	}
+
+	// Stop server — second call should use cache
+	srv.Close()
+	fw, err := c.FetchFramework("symfony", "7")
+	if err != nil {
+		t.Fatalf("cached FetchFramework() error: %v", err)
+	}
+	if fw.Name != "symfony" {
+		t.Errorf("expected name=symfony from cache, got %q", fw.Name)
+	}
+}
+
+// ── Search ───────────────────────────────────────────────────────────────────
+
+func TestSearch(t *testing.T) {
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	results, err := c.Search("sym")
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Name != "symfony" {
+		t.Errorf("expected symfony, got %q", results[0].Name)
+	}
+}
+
+func TestSearch_CaseInsensitive(t *testing.T) {
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	results, err := c.Search("LARAVEL")
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(results) != 1 || results[0].Name != "laravel" {
+		t.Errorf("expected laravel from case-insensitive search, got %v", results)
+	}
+}
+
+func TestSearch_NoMatch(t *testing.T) {
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	results, err := c.Search("django")
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+// ── DetectFromStore ──────────────────────────────────────────────────────────
+
+func TestDetectFromStore_FileRule(t *testing.T) {
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	dir := t.TempDir()
+	// Create artisan file to trigger Laravel detection
+	os.WriteFile(filepath.Join(dir, "artisan"), []byte("#!/usr/bin/env php"), 0o644) //nolint:errcheck
+
+	entry, version, ok := c.DetectFromStore(dir)
+	if !ok {
+		t.Fatal("expected detection to succeed")
+	}
+	if entry.Name != "laravel" {
+		t.Errorf("expected laravel, got %q", entry.Name)
+	}
+	if version != "11" {
+		t.Errorf("expected version=11 (latest), got %q", version)
+	}
+}
+
+func TestDetectFromStore_NoMatch(t *testing.T) {
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	dir := t.TempDir()
+	_, _, ok := c.DetectFromStore(dir)
+	if ok {
+		t.Fatal("expected no detection in empty dir")
+	}
+}
+
+// ── InvalidateIndex ──────────────────────────────────────────────────────────
+
+func TestInvalidateIndex(t *testing.T) {
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	// Populate cache
+	_, err := c.FetchIndex()
+	if err != nil {
+		t.Fatalf("FetchIndex() error: %v", err)
+	}
+
+	cacheFile := filepath.Join(c.CacheDir, "index.json")
+	if _, statErr := os.Stat(cacheFile); statErr != nil {
+		t.Fatal("expected cache file to exist")
+	}
+
+	c.InvalidateIndex()
+	if _, statErr := os.Stat(cacheFile); !os.IsNotExist(statErr) {
+		t.Fatal("expected cache file to be removed")
+	}
+}

--- a/internal/store/version.go
+++ b/internal/store/version.go
@@ -1,0 +1,56 @@
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// composerLock is a minimal representation of composer.lock for version extraction.
+type composerLock struct {
+	Packages    []composerPackage `json:"packages"`
+	PackagesDev []composerPackage `json:"packages-dev"`
+}
+
+type composerPackage struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// DetectFrameworkVersion reads composer.lock in dir and returns the major version
+// of the given composer package. Returns "" if the file is missing or the package
+// is not found.
+func DetectFrameworkVersion(dir string, composerPackageName string) string {
+	data, err := os.ReadFile(filepath.Join(dir, "composer.lock"))
+	if err != nil {
+		return ""
+	}
+
+	var lock composerLock
+	if json.Unmarshal(data, &lock) != nil {
+		return ""
+	}
+
+	for _, pkg := range append(lock.Packages, lock.PackagesDev...) {
+		if pkg.Name == composerPackageName {
+			return extractMajorVersion(pkg.Version)
+		}
+	}
+	return ""
+}
+
+// extractMajorVersion extracts the major version from a composer version string.
+// Examples: "v11.34.2" -> "11", "7.0.0" -> "7", "v2.3.0-beta.1" -> "2"
+func extractMajorVersion(version string) string {
+	v := strings.TrimPrefix(version, "v")
+	// Strip pre-release suffix
+	if i := strings.IndexByte(v, '-'); i != -1 {
+		v = v[:i]
+	}
+	parts := strings.SplitN(v, ".", 2)
+	if len(parts) == 0 || parts[0] == "" {
+		return ""
+	}
+	return parts[0]
+}

--- a/internal/store/version_test.go
+++ b/internal/store/version_test.go
@@ -1,0 +1,88 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ── extractMajorVersion ──────────────────────────────────────────────────────
+
+func TestExtractMajorVersion(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"v11.34.2", "11"},
+		{"11.34.2", "11"},
+		{"7.0.0", "7"},
+		{"v2.3.0-beta.1", "2"},
+		{"6.0.0-rc.1", "6"},
+		{"v1.0.0", "1"},
+		{"", ""},
+		{"v", ""},
+	}
+
+	for _, c := range cases {
+		got := extractMajorVersion(c.input)
+		if got != c.want {
+			t.Errorf("extractMajorVersion(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+// ── DetectFrameworkVersion ───────────────────────────────────────────────────
+
+func TestDetectFrameworkVersion(t *testing.T) {
+	dir := t.TempDir()
+	composerLock := `{
+		"packages": [
+			{"name": "laravel/framework", "version": "v11.34.2"},
+			{"name": "guzzlehttp/guzzle", "version": "7.8.1"}
+		],
+		"packages-dev": [
+			{"name": "phpunit/phpunit", "version": "10.5.0"}
+		]
+	}`
+	os.WriteFile(filepath.Join(dir, "composer.lock"), []byte(composerLock), 0o644) //nolint:errcheck
+
+	got := DetectFrameworkVersion(dir, "laravel/framework")
+	if got != "11" {
+		t.Errorf("DetectFrameworkVersion() = %q, want %q", got, "11")
+	}
+}
+
+func TestDetectFrameworkVersion_DevPackage(t *testing.T) {
+	dir := t.TempDir()
+	composerLock := `{
+		"packages": [],
+		"packages-dev": [
+			{"name": "symfony/framework-bundle", "version": "v7.1.0"}
+		]
+	}`
+	os.WriteFile(filepath.Join(dir, "composer.lock"), []byte(composerLock), 0o644) //nolint:errcheck
+
+	got := DetectFrameworkVersion(dir, "symfony/framework-bundle")
+	if got != "7" {
+		t.Errorf("DetectFrameworkVersion() = %q, want %q", got, "7")
+	}
+}
+
+func TestDetectFrameworkVersion_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	composerLock := `{"packages": [{"name": "foo/bar", "version": "1.0.0"}], "packages-dev": []}`
+	os.WriteFile(filepath.Join(dir, "composer.lock"), []byte(composerLock), 0o644) //nolint:errcheck
+
+	got := DetectFrameworkVersion(dir, "laravel/framework")
+	if got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestDetectFrameworkVersion_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	got := DetectFrameworkVersion(dir, "laravel/framework")
+	if got != "" {
+		t.Errorf("expected empty for missing file, got %q", got)
+	}
+}

--- a/internal/systemd/user.go
+++ b/internal/systemd/user.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
@@ -96,4 +97,42 @@ func IsServiceActiveOrRestarting(name string) bool {
 	out, _ := cmd.Output()
 	state := strings.TrimSpace(string(out))
 	return state == "active" || state == "activating"
+}
+
+// FindOrphanedWorkers scans systemd unit files for worker units belonging to
+// the given site that are running but not present in the known workers set.
+func FindOrphanedWorkers(siteName string, known map[string]bool) []string {
+	suffix := "-" + siteName + ".service"
+	prefix := "lerd-"
+	entries, err := os.ReadDir(config.SystemdUserDir())
+	if err != nil {
+		return nil
+	}
+	var orphans []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
+			continue
+		}
+		workerName := strings.TrimPrefix(name, prefix)
+		workerName = strings.TrimSuffix(workerName, suffix)
+		if workerName == "" {
+			continue
+		}
+		// Skip non-worker units.
+		switch workerName {
+		case "php84-fpm", "php83-fpm", "php82-fpm", "php81-fpm", "php80-fpm",
+			"nginx", "dns", "dns-forwarder", "watcher", "ui", "stripe":
+			continue
+		}
+		if known[workerName] {
+			continue
+		}
+		unitName := strings.TrimSuffix(name, ".service")
+		if IsServiceActiveOrRestarting(unitName) {
+			orphans = append(orphans, workerName)
+		}
+	}
+	sort.Strings(orphans)
+	return orphans
 }

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -595,7 +595,7 @@ func handleSites(w http.ResponseWriter, _ *http.Request) {
 			TLS:                s.Secured,
 			Framework:          s.Framework,
 			IsLaravel:          fwName == "laravel",
-			FrameworkLabel:     frameworkLabel(fwName),
+			FrameworkLabel:     frameworkLabel(fwName, s.Path),
 			FPMRunning:         fpmRunning,
 			QueueRunning:       queueStatus == "active",
 			QueueFailing:       queueStatus == "activating" || queueStatus == "failed",
@@ -612,7 +612,7 @@ func handleSites(w http.ResponseWriter, _ *http.Request) {
 			HasQueueWorker:     hasQueueWorker,
 			HasScheduleWorker:  hasScheduleWorker,
 			FrameworkWorkers:   fwWorkers,
-			HasAppLogs:         hasFw && len(fw.Logs) > 0,
+			HasAppLogs:         hasLogFiles(hasFw, fw, s.Path),
 			LatestLogTime:      latestLogTime(hasFw, fw, s.Path),
 			HasFavicon:         detectFavicon(s.Path, s.PublicDir) != "",
 			Paused:             s.Paused,
@@ -693,13 +693,16 @@ func buildServiceResponse(name string) ServiceResponse {
 }
 
 // listActiveQueueWorkers returns the site names of active lerd-queue-* systemd units.
-// frameworkLabel returns the display label for a framework name.
+// frameworkLabel returns the display label (with version) for a framework name.
 // Returns the Label field from the framework definition, or an empty string if not found.
-func frameworkLabel(name string) string {
+func frameworkLabel(name, path string) string {
 	if name == "" {
 		return ""
 	}
-	if fw, ok := config.GetFramework(name); ok {
+	if fw, ok := config.GetFrameworkForDir(name, path); ok {
+		if fw.Version != "" {
+			return fw.Label + " " + fw.Version
+		}
 		return fw.Label
 	}
 	return name
@@ -2339,6 +2342,21 @@ func handleWatcherLogs(w http.ResponseWriter, r *http.Request) {
 
 // latestLogTime returns the ISO 8601 timestamp of the most recently modified
 // log file for a site, or empty string if no log files exist.
+// hasLogFiles returns true if the framework defines log sources and at least one
+// matching log file exists on disk.
+func hasLogFiles(hasFw bool, fw *config.Framework, projectPath string) bool {
+	if !hasFw || len(fw.Logs) == 0 {
+		return false
+	}
+	for _, src := range fw.Logs {
+		matches, _ := filepath.Glob(filepath.Join(projectPath, src.Path))
+		if len(matches) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func latestLogTime(hasFw bool, fw *config.Framework, projectPath string) string {
 	if !hasFw || len(fw.Logs) == 0 {
 		return ""

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -449,23 +449,38 @@ func handleSites(w http.ResponseWriter, _ *http.Request) {
 			stripeSecretSet = true
 		}
 
+		// Build a set of workers suppressed by a running worker's ConflictsWith.
+		suppressed := make(map[string]bool)
+		if hasFw && fw.Workers != nil {
+			for wn, wDef := range fw.Workers {
+				if len(wDef.ConflictsWith) == 0 {
+					continue
+				}
+				if st, _ := podman.UnitStatus("lerd-" + wn + "-" + s.Name); st == "active" {
+					for _, c := range wDef.ConflictsWith {
+						suppressed[c] = true
+					}
+				}
+			}
+		}
+
 		// queue/schedule/reverb/horizon: driven by framework worker definitions
 		var horizonStatus string
 		var hasHorizon bool
 		if hasFw && fw.Workers != nil {
-			if fw.HasWorker("queue", s.Path) {
+			if fw.HasWorker("queue", s.Path) && !suppressed["queue"] {
 				hasQueueWorker = true
 				queueStatus, _ = podman.UnitStatus("lerd-queue-" + s.Name)
 			}
-			if fw.HasWorker("schedule", s.Path) {
+			if fw.HasWorker("schedule", s.Path) && !suppressed["schedule"] {
 				hasScheduleWorker = true
 				scheduleStatus, _ = podman.UnitStatus("lerd-schedule-" + s.Name)
 			}
-			if fw.HasWorker("reverb", s.Path) {
+			if fw.HasWorker("reverb", s.Path) && !suppressed["reverb"] {
 				hasReverb = true
 				reverbStatus, _ = podman.UnitStatus("lerd-reverb-" + s.Name)
 			}
-			if fw.HasWorker("horizon", s.Path) {
+			if fw.HasWorker("horizon", s.Path) && !suppressed["horizon"] {
 				hasHorizon = true
 				horizonStatus, _ = podman.UnitStatus("lerd-horizon-" + s.Name)
 				hasQueueWorker = false // Horizon manages queues; suppress the plain queue toggle
@@ -473,6 +488,7 @@ func handleSites(w http.ResponseWriter, _ *http.Request) {
 		}
 
 		// Collect framework workers that aren't the well-known ones handled above.
+
 		var fwWorkers []WorkerStatus
 		if hasFw && fw.Workers != nil {
 			names := make([]string, 0, len(fw.Workers))
@@ -482,6 +498,9 @@ func handleSites(w http.ResponseWriter, _ *http.Request) {
 					continue
 				}
 				if wDef.Check != nil && !config.MatchesRule(s.Path, *wDef.Check) {
+					continue
+				}
+				if suppressed[n] {
 					continue
 				}
 				names = append(names, n)
@@ -1834,30 +1853,31 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			parts := strings.SplitN(action, ":", 3)
 			if len(parts) == 3 && (parts[2] == "start" || parts[2] == "stop") {
 				workerName := parts[1]
-				fwN := site.Framework
-				fw, ok := config.GetFrameworkForDir(fwN, site.Path)
-				if !ok || fw.Workers == nil {
-					writeJSON(w, SiteActionResponse{Error: "framework has no workers defined"})
-					return
-				}
-				worker, ok := fw.Workers[workerName]
-				if !ok {
-					writeJSON(w, SiteActionResponse{Error: "worker " + workerName + " not defined for this framework"})
-					return
-				}
-				phpVersion := site.PHPVersion
-				if detected, err := phpPkg.DetectVersion(site.Path); err == nil && detected != "" {
-					phpVersion = detected
-				}
-				if parts[2] == "start" {
-					go cli.WorkerStartForSite(site.Name, site.Path, phpVersion, workerName, worker) //nolint:errcheck
-					go syncLerdYAMLWorkersDelayed(site)
-				} else {
+				if parts[2] == "stop" {
+					// Allow stopping orphaned workers that have no definition.
 					if err := cli.WorkerStopForSite(site.Name, workerName); err != nil {
 						writeJSON(w, SiteActionResponse{Error: err.Error()})
 						return
 					}
 					syncLerdYAMLWorkers(site)
+				} else {
+					fwN := site.Framework
+					fw, ok := config.GetFrameworkForDir(fwN, site.Path)
+					if !ok || fw.Workers == nil {
+						writeJSON(w, SiteActionResponse{Error: "framework has no workers defined"})
+						return
+					}
+					worker, ok := fw.Workers[workerName]
+					if !ok {
+						writeJSON(w, SiteActionResponse{Error: "worker " + workerName + " not defined for this framework"})
+						return
+					}
+					phpVersion := site.PHPVersion
+					if detected, err := phpPkg.DetectVersion(site.Path); err == nil && detected != "" {
+						phpVersion = detected
+					}
+					go cli.WorkerStartForSite(site.Name, site.Path, phpVersion, workerName, worker) //nolint:errcheck
+					go syncLerdYAMLWorkersDelayed(site)
 				}
 				writeJSON(w, SiteActionResponse{OK: true})
 				return

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -438,66 +438,47 @@ func handleSites(w http.ResponseWriter, _ *http.Request) {
 			fpmRunning, _ = podman.ContainerRunning("lerd-php" + short + "-fpm")
 		}
 		fwName := s.Framework
-		if fwName == "" {
-			fwName, _ = config.DetectFramework(s.Path)
-		}
-		isLaravel := fwName == "laravel"
-		fw, hasFw := config.GetFramework(fwName)
+		fw, hasFw := config.GetFrameworkForDir(fwName, s.Path)
 
 		var queueStatus, stripeStatus, scheduleStatus, reverbStatus string
 		var stripeSecretSet, hasReverb, hasQueueWorker, hasScheduleWorker bool
 
-		// Stripe is Laravel-only
-		if isLaravel {
+		// Stripe: check if the framework defines stripe support (currently Laravel only by convention)
+		if cli.StripeSecretSet(s.Path) {
 			stripeStatus, _ = podman.UnitStatus("lerd-stripe-" + s.Name)
-			stripeSecretSet = cli.StripeSecretSet(s.Path)
+			stripeSecretSet = true
 		}
 
-		// queue/schedule/reverb: driven by framework worker definitions
+		// queue/schedule/reverb/horizon: driven by framework worker definitions
+		var horizonStatus string
+		var hasHorizon bool
 		if hasFw && fw.Workers != nil {
-			if _, ok := fw.Workers["queue"]; ok {
+			if fw.HasWorker("queue", s.Path) {
 				hasQueueWorker = true
 				queueStatus, _ = podman.UnitStatus("lerd-queue-" + s.Name)
 			}
-			if _, ok := fw.Workers["schedule"]; ok {
+			if fw.HasWorker("schedule", s.Path) {
 				hasScheduleWorker = true
 				scheduleStatus, _ = podman.UnitStatus("lerd-schedule-" + s.Name)
 			}
-			if _, ok := fw.Workers["reverb"]; ok {
-				// For Laravel, reverb toggle still requires the package/env to be present.
-				// For other frameworks, defining the worker is enough to show the toggle.
-				if isLaravel {
-					hasReverb = cli.SiteUsesReverb(s.Path)
-				} else {
-					hasReverb = true
-				}
-				if hasReverb {
-					reverbStatus, _ = podman.UnitStatus("lerd-reverb-" + s.Name)
-				}
+			if fw.HasWorker("reverb", s.Path) {
+				hasReverb = true
+				reverbStatus, _ = podman.UnitStatus("lerd-reverb-" + s.Name)
+			}
+			if fw.HasWorker("horizon", s.Path) {
+				hasHorizon = true
+				horizonStatus, _ = podman.UnitStatus("lerd-horizon-" + s.Name)
+				hasQueueWorker = false // Horizon manages queues; suppress the plain queue toggle
 			}
 		}
-		// For Laravel without reverb in workers map (shouldn't happen with built-in, but guard anyway)
-		if isLaravel && !hasReverb {
-			reverbStatus, _ = podman.UnitStatus("lerd-reverb-" + s.Name)
-			hasReverb = cli.SiteUsesReverb(s.Path)
-		}
 
-		// Horizon: auto-detected from composer.json; replaces the queue toggle.
-		var horizonStatus string
-		var hasHorizon bool
-		if isLaravel && cli.SiteHasHorizon(s.Path) {
-			hasHorizon = true
-			horizonStatus, _ = podman.UnitStatus("lerd-horizon-" + s.Name)
-			hasQueueWorker = false // Horizon manages queues; suppress the plain queue toggle
-		}
-
-		// Collect custom framework workers (non-builtin names)
+		// Collect framework workers that aren't the well-known ones handled above.
 		var fwWorkers []WorkerStatus
 		if hasFw && fw.Workers != nil {
 			names := make([]string, 0, len(fw.Workers))
 			for n, wDef := range fw.Workers {
 				switch n {
-				case "queue", "schedule", "reverb":
+				case "queue", "schedule", "reverb", "horizon":
 					continue
 				}
 				if wDef.Check != nil && !config.MatchesRule(s.Path, *wDef.Check) {
@@ -613,7 +594,7 @@ func handleSites(w http.ResponseWriter, _ *http.Request) {
 			NodeVersion:        nodeVersion,
 			TLS:                s.Secured,
 			Framework:          s.Framework,
-			IsLaravel:          isLaravel,
+			IsLaravel:          fwName == "laravel",
 			FrameworkLabel:     frameworkLabel(fwName),
 			FPMRunning:         fpmRunning,
 			QueueRunning:       queueStatus == "active",
@@ -862,9 +843,6 @@ func handleServices(w http.ResponseWriter, _ *http.Request) {
 				continue
 			}
 			fwN := s.Framework
-			if fwN == "" {
-				fwN, _ = config.DetectFramework(s.Path)
-			}
 			fw2, ok2 := config.GetFramework(fwN)
 			if !ok2 || fw2.Workers == nil {
 				continue
@@ -1138,9 +1116,6 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				fwN3 := s.Framework
-				if fwN3 == "" {
-					fwN3, _ = config.DetectFramework(s.Path)
-				}
 				fw3, ok3 := config.GetFramework(fwN3)
 				if !ok3 || fw3.Workers == nil {
 					continue
@@ -1857,10 +1832,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			if len(parts) == 3 && (parts[2] == "start" || parts[2] == "stop") {
 				workerName := parts[1]
 				fwN := site.Framework
-				if fwN == "" {
-					fwN, _ = config.DetectFramework(site.Path)
-				}
-				fw, ok := config.GetFramework(fwN)
+				fw, ok := config.GetFrameworkForDir(fwN, site.Path)
 				if !ok || fw.Workers == nil {
 					writeJSON(w, SiteActionResponse{Error: "framework has no workers defined"})
 					return


### PR DESCRIPTION
## Summary

- Community framework store backed by geodro/lerd-frameworks with versioned definitions for Laravel, Symfony, WordPress, Drupal, CakePHP, Statamic
- All hardcoded Laravel worker logic replaced with a generic system driven by framework YAML definitions
- New commands: framework search, install, update with --check and --diff flags
- New MCP tools: framework_search, framework_install
- Workers support conflicts_with (horizon replaces queue), proxy config (auto port assignment + nginx regen), and check rules (conditional visibility)
- Dedicated commands (queue, schedule, reverb, horizon) are now aliases to the generic worker handler
- Framework definitions resolve from 4 layers: user overlay > project .lerd.yaml > store-installed > built-in
- Project-specific custom workers via .lerd.yaml custom_workers field
- Framework detection limited to link/init/env/setup only, all other commands read from site registry
- Existing sites backfilled with detected framework on lerd start/update