### PR TITLE
feat: vendor/bin shortcuts and lerd test/lerd a aliases

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -54,6 +54,8 @@ func main() {
 	root.AddCommand(cli.NewPhpCmd())
 	root.AddCommand(cli.NewPhpShellCmd())
 	root.AddCommand(cli.NewConsoleCmd())
+	root.AddCommand(cli.NewTestCmd())
+	root.AddCommand(cli.NewVendorBinCmd())
 	root.AddCommand(cli.NewEnvCmd())
 	root.AddCommand(cli.NewEnvCheckCmd())
 	root.AddCommand(cli.NewNodeCmd())
@@ -112,9 +114,54 @@ func main() {
 	root.AddCommand(newWatchCmd())
 	root.AddCommand(newServeUICmd())
 
+	maybeDispatchVendorBin(root)
+
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+// maybeDispatchVendorBin rewrites os.Args to invoke the hidden `vendor-bin`
+// subcommand when the first positional arg doesn't match any registered cobra
+// command but does match an executable in the project's `vendor/bin` directory.
+// Real lerd commands always win — this only kicks in for unknown names.
+func maybeDispatchVendorBin(root *cobra.Command) {
+	if len(os.Args) < 2 {
+		return
+	}
+	first := os.Args[1]
+	if first == "" || strings.HasPrefix(first, "-") {
+		return
+	}
+	if isKnownCommand(root, first) {
+		return
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	if !cli.VendorBinExists(cwd, first) {
+		return
+	}
+	rest := os.Args[2:]
+	newArgs := make([]string, 0, len(rest)+3)
+	newArgs = append(newArgs, os.Args[0], "vendor-bin", first)
+	newArgs = append(newArgs, rest...)
+	os.Args = newArgs
+}
+
+func isKnownCommand(root *cobra.Command, name string) bool {
+	for _, c := range root.Commands() {
+		if c.Name() == name {
+			return true
+		}
+		for _, a := range c.Aliases {
+			if a == name {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // newServeUICmd returns the serve-ui command.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -183,6 +183,9 @@ Requires [Laravel Broadcasting](https://laravel.com/docs/13.x/broadcasting) with
 |---|---|
 | `lerd console [args...]` | Run the framework's console command (e.g., `php artisan` for Laravel, `php bin/console` for Symfony) inside the project's PHP-FPM container |
 | `lerd artisan [args...]` | Alias for `lerd console` (Laravel-specific, kept for backward compatibility) |
+| `lerd a [args...]` | Short alias for `lerd console` / `lerd artisan` |
+| `lerd test [args...]` | Shortcut for `lerd artisan test` |
+| `lerd <vendor-bin> [args...]` | Run any composer-installed binary from the project's `vendor/bin` directory (e.g. `lerd pest`, `lerd pint`, `lerd phpstan`). Real lerd commands always win over vendor binaries with the same name. |
 | `lerd shell` | Open an interactive shell inside the project's PHP-FPM container |
 
 ## AI integration

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -30,6 +30,26 @@ php artisan migrate
 composer install
 ```
 
+### Shortcuts and `vendor/bin` fallback
+
+For common workflows there are a few built-in shortcuts:
+
+- `lerd a [args...]` — short alias for `lerd artisan` (also `lerd console`)
+- `lerd test [args...]` — runs `lerd artisan test`
+
+In addition, any composer-installed binary in the project's `vendor/bin` directory is callable directly as `lerd <name>`. For example, with the usual Laravel dev tooling installed:
+
+```bash
+lerd pest
+lerd pint
+lerd phpstan analyse
+lerd rector process
+```
+
+These run inside the project's PHP-FPM container with the project's working directory mounted, so configuration files (`pest.xml`, `pint.json`, `phpstan.neon`, etc.) are picked up automatically. Real lerd commands always take precedence — if you have a `vendor/bin/composer`, `lerd composer` still resolves to the built-in command.
+
+The MCP integration exposes the same surface through two tools, `vendor_bins` (list available binaries) and `vendor_run` (execute one), so AI assistants can discover and run project tooling without per-project configuration.
+
 ---
 
 ## Version resolution

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -17,7 +17,7 @@ import (
 func NewConsoleCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:                "console [args...]",
-		Aliases:            []string{"artisan"},
+		Aliases:            []string{"artisan", "a"},
 		Short:              "Run framework console command in the project's container",
 		Example:            "  lerd console cache:clear\n  lerd console make:controller User",
 		DisableFlagParsing: true,

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -32,7 +32,13 @@ func runPhp(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	return RunPHP(cwd, args)
+}
 
+// RunPHP execs `php <args...>` inside the project's PHP-FPM container, with
+// stdio wired to the current terminal. Used by `lerd php`, the vendor/bin
+// fallback, and other passthrough commands that need a PHP runtime.
+func RunPHP(cwd string, args []string) error {
 	version, err := phpDet.DetectVersion(cwd)
 	if err != nil {
 		cfg, cfgErr := config.LoadGlobal()
@@ -56,6 +62,7 @@ func runPhp(_ *cobra.Command, args []string) error {
 		composerHome = filepath.Join(xdgConfig, "composer")
 	}
 	composerBin := filepath.Join(composerHome, "vendor", "bin")
+	projectVendorBin := filepath.Join(cwd, "vendor", "bin")
 
 	if running, _ := podman.ContainerRunning(container); !running {
 		return fmt.Errorf("PHP %s FPM container is not running — start it with: systemctl --user start %s", version, container)
@@ -88,7 +95,7 @@ func runPhp(_ *cobra.Command, args []string) error {
 	cmdArgs := append(execFlags, "-w", cwd,
 		"--env", "HOME="+home,
 		"--env", "COMPOSER_HOME="+composerHome,
-		"--env", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:"+composerBin,
+		"--env", "PATH="+projectVendorBin+":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:"+composerBin,
 		container, "php",
 	)
 	cmdArgs = append(cmdArgs, args...)

--- a/internal/cli/vendor_bin.go
+++ b/internal/cli/vendor_bin.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/spf13/cobra"
+)
+
+// NewTestCmd returns the `lerd test` command — shortcut for `lerd artisan test`.
+func NewTestCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:                "test [args...]",
+		Short:              "Run framework tests (shortcut for `lerd artisan test`)",
+		DisableFlagParsing: true,
+		SilenceUsage:       true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runConsole(nil, append([]string{"test"}, args...))
+		},
+	}
+}
+
+// NewVendorBinCmd returns the hidden `lerd vendor-bin <name> [args...]` command
+// used by the top-level fallback in main.go to dispatch composer-installed
+// binaries discovered in the project's vendor/bin directory.
+func NewVendorBinCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:                "vendor-bin <name> [args...]",
+		Short:              "Run a binary from the project's vendor/bin directory",
+		Hidden:             true,
+		DisableFlagParsing: true,
+		SilenceUsage:       true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cobra.MinimumNArgs(1)(nil, args)
+			}
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			name := args[0]
+			rest := args[1:]
+			return RunPHP(cwd, append([]string{"vendor/bin/" + name}, rest...))
+		},
+	}
+}
+
+// VendorBinExists reports whether the project rooted at cwd has an executable
+// vendor/bin/<name> on disk. Used by the top-level command-not-found fallback
+// to decide whether to dispatch unknown subcommands to a composer binary.
+func VendorBinExists(cwd, name string) bool {
+	if name == "" || cwd == "" {
+		return false
+	}
+	// Reject path separators — composer bins are flat filenames.
+	for _, r := range name {
+		if r == '/' || r == os.PathSeparator {
+			return false
+		}
+	}
+	info, err := os.Stat(filepath.Join(cwd, "vendor", "bin", name))
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return true
+}
+
+// ListVendorBins returns the names of executable files in <cwd>/vendor/bin,
+// sorted alphabetically. Returns an empty slice if the directory doesn't exist.
+func ListVendorBins(cwd string) []string {
+	dir := filepath.Join(cwd, "vendor", "bin")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var bins []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		bins = append(bins, e.Name())
+	}
+	sort.Strings(bins)
+	return bins
+}

--- a/internal/cli/vendor_bin_test.go
+++ b/internal/cli/vendor_bin_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestVendorBinExists(t *testing.T) {
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "vendor", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "pest"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(binDir, "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		bin  string
+		want bool
+	}{
+		{"existing executable", "pest", true},
+		{"missing", "phpunit", false},
+		{"directory not bin", "subdir", false},
+		{"empty name", "", false},
+		{"path traversal rejected", "../bin/pest", false},
+		{"nested name rejected", "foo/bar", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := VendorBinExists(dir, c.bin); got != c.want {
+				t.Errorf("VendorBinExists(%q) = %v, want %v", c.bin, got, c.want)
+			}
+		})
+	}
+
+	// Empty cwd is rejected.
+	if VendorBinExists("", "pest") {
+		t.Error("VendorBinExists with empty cwd should return false")
+	}
+
+	// Project without vendor/bin returns false.
+	empty := t.TempDir()
+	if VendorBinExists(empty, "pest") {
+		t.Error("VendorBinExists on project without vendor/bin should return false")
+	}
+}
+
+func TestListVendorBins(t *testing.T) {
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "vendor", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"pest", "phpunit", "pint"} {
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Subdirectories must be ignored.
+	if err := os.MkdirAll(filepath.Join(binDir, "stubs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := ListVendorBins(dir)
+	want := []string{"pest", "phpunit", "pint"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ListVendorBins() = %v, want %v", got, want)
+	}
+
+	// Missing vendor/bin returns nil.
+	if got := ListVendorBins(t.TempDir()); got != nil {
+		t.Errorf("ListVendorBins on empty project = %v, want nil", got)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -306,6 +306,41 @@ func toolList() []mcpTool {
 			},
 		},
 		{
+			Name:        "vendor_bins",
+			Description: "List composer-installed binaries available in the project's vendor/bin directory. Use this to discover tools like pest, phpunit, pint, phpstan, rector, etc. before invoking vendor_run.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"path": {
+						Type:        "string",
+						Description: "Absolute path to the project root. Defaults to LERD_SITE_PATH when omitted.",
+					},
+				},
+			},
+		},
+		{
+			Name:        "vendor_run",
+			Description: "Run a composer-installed binary from the project's vendor/bin directory inside the lerd PHP-FPM container. Use vendor_bins first to see what's available.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"path": {
+						Type:        "string",
+						Description: "Absolute path to the project root. Defaults to LERD_SITE_PATH when omitted.",
+					},
+					"bin": {
+						Type:        "string",
+						Description: `Name of the binary in vendor/bin, e.g. "pest", "phpunit", "pint"`,
+					},
+					"args": {
+						Type:        "array",
+						Description: `Arguments to pass to the binary, e.g. ["--filter", "UserTest"]`,
+					},
+				},
+				Required: []string{"bin"},
+			},
+		},
+		{
 			Name:        "node_install",
 			Description: "Install a Node.js version via fnm so it can be used by lerd sites. Accepts a version number (e.g. \"20\", \"20.11.0\") or alias (e.g. \"lts\").",
 			InputSchema: mcpSchema{
@@ -1301,6 +1336,10 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execLogs(args)
 	case "composer":
 		return execComposer(args)
+	case "vendor_bins":
+		return execVendorBins(args)
+	case "vendor_run":
+		return execVendorRun(args)
 	case "node_install":
 		return execNodeInstall(args)
 	case "node_uninstall":
@@ -2037,6 +2076,78 @@ func execComposer(args map[string]any) (any, *rpcError) {
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
 		return toolErr(fmt.Sprintf("composer failed (%v):\n%s", err, out.String())), nil
+	}
+	return toolOK(strings.TrimSpace(out.String())), nil
+}
+
+func execVendorBins(args map[string]any) (any, *rpcError) {
+	projectPath := resolvedPath(args)
+	if projectPath == "" {
+		return toolErr("path is required — pass a path argument or open Claude in the project directory"), nil
+	}
+	dir := filepath.Join(projectPath, "vendor", "bin")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return toolErr("no vendor/bin directory — run composer install first"), nil
+		}
+		return toolErr("failed to read vendor/bin: " + err.Error()), nil
+	}
+	var bins []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		bins = append(bins, e.Name())
+	}
+	sort.Strings(bins)
+	if len(bins) == 0 {
+		return toolOK("vendor/bin is empty"), nil
+	}
+	return toolOK(strings.Join(bins, "\n")), nil
+}
+
+func execVendorRun(args map[string]any) (any, *rpcError) {
+	projectPath := resolvedPath(args)
+	if projectPath == "" {
+		return toolErr("path is required — pass a path argument or open Claude in the project directory"), nil
+	}
+	bin := strArg(args, "bin")
+	if bin == "" {
+		return toolErr("bin is required"), nil
+	}
+	// Reject path separators — composer bins are flat filenames.
+	if strings.ContainsAny(bin, "/\\") {
+		return toolErr("bin must be a plain filename, not a path"), nil
+	}
+	binPath := filepath.Join(projectPath, "vendor", "bin", bin)
+	info, statErr := os.Stat(binPath)
+	if statErr != nil || info.IsDir() {
+		return toolErr(fmt.Sprintf("vendor/bin/%s not found in %s", bin, projectPath)), nil
+	}
+	binArgs := strSliceArg(args, "args")
+
+	phpVersion, err := phpDet.DetectVersion(projectPath)
+	if err != nil {
+		cfg, cfgErr := config.LoadGlobal()
+		if cfgErr != nil {
+			return toolErr("failed to detect PHP version: " + err.Error()), nil
+		}
+		phpVersion = cfg.PHP.DefaultVersion
+	}
+
+	short := strings.ReplaceAll(phpVersion, ".", "")
+	container := "lerd-php" + short + "-fpm"
+
+	cmdArgs := []string{"exec", "-w", projectPath, container, "php", "vendor/bin/" + bin}
+	cmdArgs = append(cmdArgs, binArgs...)
+
+	var out bytes.Buffer
+	cmd := exec.Command("podman", cmdArgs...)
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return toolErr(fmt.Sprintf("vendor/bin/%s failed (%v):\n%s", bin, err, out.String())), nil
 	}
 	return toolOK(strings.TrimSpace(out.String())), nil
 }


### PR DESCRIPTION
## Summary

- Adds `lerd a` (alias for `artisan`) and `lerd test` (shortcut for `artisan test`).
- Adds a top-level fallback so any composer-installed binary in the project's `vendor/bin` is callable as `lerd <name>` (e.g. `lerd pest`, `lerd pint`, `lerd phpstan`). Built-in lerd commands always win when names collide.
- Prepends the project's `vendor/bin` to the in-container `PATH` so tools spawned by these binaries can find each other without absolute paths.
- Exposes the same surface to MCP clients via two new tools, `vendor_bins` (list) and `vendor_run` (execute), so AI assistants can discover and run project tooling without per-project configuration.

## Implementation notes

- `internal/cli/php_exec.go` factored to expose `RunPHP(cwd, args)`, reused by the new vendor-bin dispatcher.
- New hidden `lerd vendor-bin <name> [args...]` cobra command does the actual exec; `cmd/lerd/main.go` rewrites `os.Args` before `Execute()` when the first positional arg is unknown to cobra and resolves under `<cwd>/vendor/bin`.
- MCP `vendor_run` rejects path separators in `bin` and stats the file before executing.
- Docs updated in `docs/reference/commands.md` and `docs/usage/php.md`.

Closes #101