### PR TITLE
release: v1.7.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,25 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.7.0] — 2026-04-08
+
+### Added
+
+- **Application log viewer in the UI** — site detail view now has an App Logs tab that parses application log files into a structured table with level, date, and message columns, expandable to show full stacktraces. Frameworks declare log file locations and parser format via a new `logs` field in their YAML; Laravel defaults to `storage/logs/*.log` with Monolog parsing. Auto-selects the site with the most recent log activity on page load, refreshes every 5 seconds, and supports search filtering plus a Latest/All toggle. Entries display oldest-first (newest at the bottom), pinned to the bottom on every refresh, matching the streaming container/queue/worker log panes.
+- **`vendor/bin` shortcuts and `lerd test` / `lerd a` aliases** — any composer-installed binary in the project's `vendor/bin` is now callable directly as `lerd <name>` (e.g. `lerd pest`, `lerd pint`, `lerd phpstan`), routed through the project's PHP-FPM container with `vendor/bin` prepended to `PATH`. Built-in lerd commands always win on name collisions. Two new shortcuts: `lerd a` (alias for `artisan`) and `lerd test` (shortcut for `artisan test`). The same surface is exposed to MCP clients via `vendor_bins` (list) and `vendor_run` (execute). Closes #101.
+- **Laravel installer shipped globally** — `lerd install` now offers to install `laravel/installer` as a global composer package and creates a `laravel` shim in `BinDir` routed through `lerd php`, so the `laravel` command works directly in the terminal the way Herd ships it. The prompt defaults to yes and runs before the parallel TUI to avoid stdin conflicts. Closes #98.
+- **Site favicons in the UI** — the UI detects `favicon.ico`/`svg`/`png` in each site's public directory and serves them via `GET /api/sites/{domain}/favicon`. The sites list and detail header now display the favicon when available, falling back to the status dot.
+
+### Changed
+
+- **PHP and Node version selects deferred until loaded** — the version dropdowns in the site detail view now show static placeholders while the version lists are still loading, preventing the browser from resetting `selectedSite.php_version` / `node_version` to an empty string and causing spurious change events.
+
+### Fixed
+
+- **Dark mode dropdown readability** — the PHP and Node version selectors now apply explicit option background and text colors so the dropdown menu is readable in dark mode.
+
+---
+
 ## [1.6.3] — 2026-04-06
 
 ### Changed

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.6.3"
+	Version = "1.7.0"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

Bumps lerd to v1.7.0, bundling four new features merged since v1.6.3.

### Added

- Application log viewer in the UI (#100), with framework-declared log file locations and Monolog parsing for Laravel
- `vendor/bin` shortcuts and `lerd test` / `lerd a` aliases (#104, closes #101), exposed to MCP via `vendor_bins` and `vendor_run`
- `laravel` global installer shipped during `lerd install` (#99, closes #98)
- Site favicons in the UI sidebar and detail header (#102)

### Changed

- Version selects in the site detail view defer behind a placeholder until the version lists finish loading

### Fixed

- Dark mode readability of the PHP and Node version dropdowns