### PR TITLE
feat: APP_URL precedence chain and domain conflict soft-fallback

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -40,6 +40,8 @@ A portable, self-contained description of a project's local environment. Created
 | `framework` | Framework name — overrides auto-detection |
 | `framework_def` | Full framework definition — embedded automatically for custom (non-Laravel) frameworks so the project is portable across machines |
 | `secured` | When `true`, HTTPS is enabled on apply |
+| `domains` | Site hostnames without the TLD (e.g. `[myapp, api]`). The first entry is the primary; additional entries become aliases. Conflict-filtered domains stay in this list on disk but are not registered |
+| `app_url` | Override for `APP_URL` (or the framework's URL key) written to `.env`. Highest priority — beats the per-machine `sites.yaml` override and the default `<scheme>://<primary-domain>` generator. Use for custom path prefixes, ports, or unrelated hostnames you want shared across machines |
 | `services` | Services to start on apply. Accepts built-in names, custom service names, or full inline definitions |
 | `workers` | Active worker names for the site (e.g. `queue`, `horizon`, `schedule`, `reverb`, `stripe`). Automatically kept in sync by start/stop commands. Used by `lerd start` to restore workers after reinstall |
 

--- a/docs/usage/sites.md
+++ b/docs/usage/sites.md
@@ -89,7 +89,7 @@ lerd init --fresh
 
 Directories with real TLDs are automatically normalised — dots are replaced with dashes and the TLD is stripped before appending `.test`.
 
-For example: `admin.astrolov.com` → `admin-astrolov.test`
+For example: `admin.example.com` → `admin-example.test`
 
 ---
 
@@ -126,6 +126,46 @@ You can also manage domains from the web UI — click the pencil icon next to th
 When a site is secured with HTTPS, the certificate is automatically reissued to cover all domains.
 
 Subdomains (e.g. `anything.myapp.test`) are automatically routed to the same site. Git worktree subdomains take priority when they exist.
+
+---
+
+## Domain conflicts
+
+A domain may only be claimed by one site at a time. When `lerd link`, the watcher's auto-registration, or a `.lerd.yaml`-driven re-link tries to register a domain that another site already owns, the conflicting domain is **filtered out** (not the whole site) and a warning is printed:
+
+```
+$ lerd link
+  [WARN] domain "shared.test" already used by site "owner-app" — skipped
+Linked: clone-app -> clone-app.test (PHP 8.4, Node 22, Framework: laravel)
+```
+
+The site still gets registered with whatever domains survived the filter. If every requested domain is conflicted, lerd falls back to a freshly generated `<dirname>.<tld>` (with a numeric suffix to avoid name collisions).
+
+`.lerd.yaml` is **never modified** when this happens — the original `domains:` list stays on disk so the conflict is visible to the UI and the entry self-heals on the next link if you remove the owning site. The web UI surfaces filtered domains in two places:
+
+- The site detail header's domain pill shows an amber ⚠️ when one or more declared domains are filtered (`+N more` count includes them). Hovering reveals each conflicted entry with the owning site name.
+- The Manage Domains modal lists conflicted entries at the top with a warning icon, the domain struck-through, a `used by <site>` pill, and a small trash button. Clicking the trash removes the entry from `.lerd.yaml` only — the registry, vhost, and certs are untouched.
+
+The conflict check is **strict**: a domain is reserved regardless of TLS scheme. Two sites cannot share the same domain even if one runs HTTPS and the other HTTP — DNS and browser caches don't reliably disambiguate by scheme, and the resulting setup is fragile.
+
+---
+
+## Custom `APP_URL`
+
+By default `lerd env` writes `APP_URL=<scheme>://<primary-domain>` to the project's `.env` on every run. If you need to override that — for example to add a path prefix, point at a staging hostname, or pin a specific protocol — set `app_url` in `.lerd.yaml` (committed, shared across machines) or in the per-machine site entry in `~/.local/share/lerd/sites.yaml`. The precedence chain is:
+
+1. `.lerd.yaml` `app_url` — committed to the repo, takes effect on every machine.
+2. `sites.yaml` `app_url` — per-machine override, useful when only one developer needs a different URL.
+3. The default generator (`<scheme>://<primary-domain>`) — used when neither override is set.
+
+```yaml
+# .lerd.yaml
+domains:
+  - myapp
+app_url: http://myapp.test/api
+```
+
+`lerd env` reads the chain on every invocation, so editing the file and re-running `lerd setup` (or `lerd env` directly) is enough to apply the change. If the `.lerd.yaml` `app_url` happens to point at a domain that got filtered by the conflict check, lerd silently falls through to the next precedence level so you don't end up writing a `DB_HOST` of `lerd-mysql` next to an `APP_URL` that points at someone else's site.
 
 ---
 
@@ -176,7 +216,9 @@ You can link a new site directly from the dashboard by clicking the **+** button
 
 ## Unlinked domains
 
-When you visit a `.test` domain that isn't linked to any site, lerd shows a branded "Site Not Found" page with a link to the dashboard and a retry button. This replaces the browser's generic connection error.
+When you visit a `.test` domain that isn't linked to any site over **HTTP**, lerd shows a branded "Site Not Found" page with a link to the dashboard and a retry button. This replaces the browser's generic connection error.
+
+For **HTTPS** the catch-all uses `ssl_reject_handshake on;` — the browser sees a clean `ERR_SSL_UNRECOGNIZED_NAME_ALERT` connection error rather than a landing page. This is unavoidable: lerd cannot pre-issue a certificate covering arbitrary `*.test` hostnames because browsers (Chrome especially) reject TLD-level wildcard certificates with `ERR_CERT_COMMON_NAME_INVALID`. If you're hitting this on a domain you used to have linked, the fix is browser-side (clear site data / unregister the service worker), not server-side.
 
 ---
 

--- a/internal/cli/domain.go
+++ b/internal/cli/domain.go
@@ -87,7 +87,7 @@ func runDomainAdd(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("site %q already has domain %q", site.Name, fullDomain)
 	}
 
-	// Check if used by another site.
+	// Check if used by another site (strict — regardless of TLS scheme).
 	if existing, err := config.IsDomainUsed(fullDomain); err == nil && existing != nil {
 		return fmt.Errorf("domain %q is already used by site %q", fullDomain, existing.Name)
 	}
@@ -238,8 +238,15 @@ func RegenerateSiteVhost(site *config.Site, oldPrimary string) error {
 	return nil
 }
 
-// SyncLerdYAMLDomains updates the domains field in .lerd.yaml, stripping the TLD
-// so the file stores portable name-only values.
+// SyncLerdYAMLDomains updates the domains field in .lerd.yaml, stripping the
+// TLD so the file stores portable name-only values.
+//
+// Domains that were originally declared in .lerd.yaml but didn't survive the
+// conflict filter (because another site on this machine already owns them)
+// are preserved at the end of the list. The user's declared intent stays on
+// disk, the UI's conflict-warning surface continues to work, and the entry
+// will be re-evaluated on the next link — self-healing the moment the
+// conflicting site is removed.
 func SyncLerdYAMLDomains(projectPath string, fullDomains []string, tld string) {
 	lerdYAML := filepath.Join(projectPath, ".lerd.yaml")
 	if _, err := os.Stat(lerdYAML); err != nil {
@@ -247,9 +254,27 @@ func SyncLerdYAMLDomains(projectPath string, fullDomains []string, tld string) {
 	}
 	proj, _ := config.LoadProjectConfig(projectPath)
 	suffix := "." + tld
+	seen := make(map[string]bool)
 	var names []string
+	// First, the registered (post-filter) domains in their current order so
+	// the primary domain reflects the live registry state.
 	for _, d := range fullDomains {
-		names = append(names, strings.TrimSuffix(d, suffix))
+		name := strings.TrimSuffix(d, suffix)
+		low := strings.ToLower(name)
+		if !seen[low] {
+			names = append(names, name)
+			seen[low] = true
+		}
+	}
+	// Then, any pre-existing .lerd.yaml entries that aren't in the registered
+	// list — typically conflict-filtered domains. Appended at the end so they
+	// don't accidentally become the new primary.
+	for _, d := range proj.Domains {
+		low := strings.ToLower(d)
+		if !seen[low] {
+			names = append(names, d)
+			seen[low] = true
+		}
 	}
 	proj.Domains = names
 	if err := config.SaveProjectConfig(projectPath, proj); err != nil {

--- a/internal/cli/domain_conflict.go
+++ b/internal/cli/domain_conflict.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// filterConflictingDomains splits desired into the domains that ownPath is
+// allowed to claim and those already taken by a different site. The check is
+// strict: a domain is a conflict regardless of TLS scheme (HTTPS vs HTTP).
+// Two sites cannot share the same domain even on different ports — DNS and
+// browser caches don't disambiguate by scheme reliably. Order is preserved
+// so the user's preferred primary domain stays primary if it survives.
+//
+// Re-linking the same path is not a conflict — domains owned by ownPath stay
+// in the kept list. Reserved domains (e.g. lerd's own internal hosts) are
+// always filtered out.
+func filterConflictingDomains(desired []string, ownPath string, allSites []config.Site) (kept, removed []string) {
+	// Build a domain → owning path index from the registry.
+	owners := make(map[string]string, len(allSites)*2)
+	for _, s := range allSites {
+		for _, d := range s.Domains {
+			owners[d] = s.Path
+		}
+	}
+
+	for _, d := range desired {
+		if isReservedDomain(d) {
+			removed = append(removed, d)
+			continue
+		}
+		owner, taken := owners[d]
+		if taken && owner != ownPath {
+			removed = append(removed, d)
+			continue
+		}
+		kept = append(kept, d)
+	}
+	return kept, removed
+}
+
+// resolveSiteDomains takes the desired domain list (built from .lerd.yaml or
+// auto-generated), filters out conflicts using the live site registry, and
+// returns the final list to write into the site struct. Falls back to a
+// freshly generated `<baseName>.<tld>` (with numeric suffix to avoid both
+// name and domain collisions) when every desired domain is conflicted.
+//
+// Any filtered domains are reported to the caller via the removed slice so
+// the caller can print a warning. The .lerd.yaml file on disk is never
+// touched — the discrepancy lives only in memory and the site registry.
+func resolveSiteDomains(desired []string, baseName, ownPath, tld string) (kept, removed []string) {
+	reg, err := config.LoadSites()
+	var sites []config.Site
+	if err == nil {
+		sites = reg.Sites
+	}
+
+	kept, removed = filterConflictingDomains(desired, ownPath, sites)
+	if len(kept) > 0 {
+		return kept, removed
+	}
+
+	// Every desired domain was filtered. Fall back to a generated name+domain
+	// that's free in both axes. Loop with a numeric suffix until we find one.
+	for i := 0; ; i++ {
+		candidate := baseName
+		if i > 0 {
+			candidate = fmt.Sprintf("%s-%d", baseName, i+1)
+		}
+		domain := candidate + "." + tld
+		if isReservedDomain(domain) {
+			continue
+		}
+		if existing, _ := config.FindSite(candidate); existing != nil && existing.Path != ownPath {
+			continue
+		}
+		owners, _ := filterConflictingDomains([]string{domain}, ownPath, sites)
+		if len(owners) == 0 {
+			continue
+		}
+		return []string{domain}, removed
+	}
+}
+
+// warnFilteredDomains prints a single-line warning for each domain that
+// resolveSiteDomains had to drop because another site already owns it.
+// Includes the conflicting site name when known so the user can react.
+func warnFilteredDomains(removed []string) {
+	if len(removed) == 0 {
+		return
+	}
+	for _, d := range removed {
+		if existing, err := config.IsDomainUsed(d); err == nil && existing != nil {
+			fmt.Printf("  [WARN] domain %q already used by site %q — skipped\n", d, existing.Name)
+			continue
+		}
+		fmt.Printf("  [WARN] domain %q is reserved — skipped\n", d)
+	}
+}

--- a/internal/cli/domain_conflict_test.go
+++ b/internal/cli/domain_conflict_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestFilterConflictingDomains(t *testing.T) {
+	allSites := []config.Site{
+		{Name: "blog", Path: "/home/me/blog", Domains: []string{"blog.test"}},
+		{Name: "shop", Path: "/home/me/shop", Domains: []string{"shop.test", "store.test"}},
+	}
+
+	cases := []struct {
+		name        string
+		desired     []string
+		ownPath     string
+		wantKept    []string
+		wantRemoved []string
+	}{
+		{
+			name:     "no conflicts — everything kept in order",
+			desired:  []string{"newsite.test", "alias.test"},
+			ownPath:  "/home/me/newsite",
+			wantKept: []string{"newsite.test", "alias.test"},
+		},
+		{
+			name:        "primary conflicts — alias becomes primary",
+			desired:     []string{"shop.test", "alias.test"},
+			ownPath:     "/home/me/newshop",
+			wantKept:    []string{"alias.test"},
+			wantRemoved: []string{"shop.test"},
+		},
+		{
+			name:        "all desired conflict — empty kept list",
+			desired:     []string{"shop.test", "store.test"},
+			ownPath:     "/home/me/newshop",
+			wantRemoved: []string{"shop.test", "store.test"},
+		},
+		{
+			name:     "re-link of same path is not a conflict",
+			desired:  []string{"shop.test", "store.test"},
+			ownPath:  "/home/me/shop",
+			wantKept: []string{"shop.test", "store.test"},
+		},
+		{
+			name:     "mix of own + new",
+			desired:  []string{"shop.test", "newdomain.test"},
+			ownPath:  "/home/me/shop",
+			wantKept: []string{"shop.test", "newdomain.test"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			kept, removed := filterConflictingDomains(c.desired, c.ownPath, allSites)
+			if !sliceEq(kept, c.wantKept) {
+				t.Errorf("kept = %v, want %v", kept, c.wantKept)
+			}
+			if !sliceEq(removed, c.wantRemoved) {
+				t.Errorf("removed = %v, want %v", removed, c.wantRemoved)
+			}
+		})
+	}
+}
+
+// sliceEq compares two string slices treating nil and empty as equal.
+func sliceEq(a, b []string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
+}

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	neturl "net/url"
+
 	"github.com/charmbracelet/huh"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
@@ -365,12 +367,15 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	// 4. Set the URL key to the registered .test domain
+	// 4. Set the URL key. Precedence (matching other lerd settings):
+	//    1. .lerd.yaml `app_url` — committed, shared across machines
+	//    2. sites.yaml `app_url` — per-machine override
+	//    3. <scheme>://<primary-domain> default generator
 	urlKey := fw.Env.URLKey
 	if urlKey == "" {
 		urlKey = "APP_URL"
 	}
-	if url := siteURL(cwd); url != "" {
+	if url := resolveAppURL(cwd, site); url != "" {
 		updates[urlKey] = url
 		fmt.Printf("  Setting %s=%s\n", urlKey, url)
 	}
@@ -521,6 +526,75 @@ func ensureServiceRunning(name string) error {
 		return err
 	}
 	return podman.WaitReady(name, 60*time.Second)
+}
+
+// resolveAppURL returns the URL lerd should write to APP_URL for the project,
+// applying the standard lerd precedence chain:
+//
+//  1. .lerd.yaml `app_url` (committed, shared across machines)
+//  2. sites.yaml `app_url` (per-machine override)
+//  3. `<scheme>://<primary-domain>` default generator
+//
+// The .lerd.yaml `app_url` is suppressed when its host is one of the project's
+// declared domains that got filtered out at registration time (i.e. another
+// site already owns it on this machine). External hosts and unrelated values
+// pass through unchanged — only the conflict-filtered case is rejected.
+//
+// Returns an empty string only when the site is unregistered and no override
+// is set anywhere — callers should treat that as "leave APP_URL alone".
+func resolveAppURL(cwd string, site *config.Site) string {
+	proj, _ := config.LoadProjectConfig(cwd)
+	if proj != nil && strings.TrimSpace(proj.AppURL) != "" {
+		val := strings.TrimSpace(proj.AppURL)
+		if !appURLPointsToFilteredDomain(val, proj, site) {
+			return val
+		}
+	}
+	if site != nil && strings.TrimSpace(site.AppURL) != "" {
+		return strings.TrimSpace(site.AppURL)
+	}
+	return siteURL(cwd)
+}
+
+// appURLPointsToFilteredDomain reports whether the given URL's host matches
+// a domain that the project declared in .lerd.yaml but that did NOT survive
+// the conflict filter at registration time. When true, the caller should
+// fall through to the next precedence level instead of writing a value that
+// points at a domain owned by another site.
+func appURLPointsToFilteredDomain(rawURL string, proj *config.ProjectConfig, site *config.Site) bool {
+	if proj == nil || site == nil || len(proj.Domains) == 0 {
+		return false
+	}
+	parsed, err := neturl.Parse(rawURL)
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	host := parsed.Hostname()
+
+	cfg, cfgErr := config.LoadGlobal()
+	if cfgErr != nil {
+		return false
+	}
+	suffix := "." + cfg.DNS.TLD
+
+	// Was this host in the .lerd.yaml-declared list?
+	declared := false
+	for _, d := range proj.Domains {
+		if strings.ToLower(d)+suffix == host {
+			declared = true
+			break
+		}
+	}
+	if !declared {
+		return false
+	}
+	// Declared but did it survive into the registered site?
+	for _, d := range site.Domains {
+		if d == host {
+			return false
+		}
+	}
+	return true
 }
 
 // siteURL returns the APP_URL for the project registered at path, or "".

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// writeProject writes a minimal .lerd.yaml at dir with the given AppURL.
+func writeProject(t *testing.T, dir, appURL string) {
+	t.Helper()
+	body := ""
+	if appURL != "" {
+		body = "app_url: " + appURL + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolveAppURL(t *testing.T) {
+	t.Run(".lerd.yaml beats sites.yaml beats default", func(t *testing.T) {
+		dir := t.TempDir()
+		writeProject(t, dir, "https://from-project.test")
+		site := &config.Site{AppURL: "https://from-sites.test"}
+		got := resolveAppURL(dir, site)
+		if got != "https://from-project.test" {
+			t.Errorf("expected project value to win, got %q", got)
+		}
+	})
+
+	t.Run("sites.yaml used when .lerd.yaml has no app_url", func(t *testing.T) {
+		dir := t.TempDir()
+		writeProject(t, dir, "") // .lerd.yaml exists but no app_url
+		site := &config.Site{AppURL: "https://from-sites.test"}
+		got := resolveAppURL(dir, site)
+		if got != "https://from-sites.test" {
+			t.Errorf("expected sites.yaml value, got %q", got)
+		}
+	})
+
+	t.Run("sites.yaml used when no .lerd.yaml exists", func(t *testing.T) {
+		dir := t.TempDir() // no .lerd.yaml
+		site := &config.Site{AppURL: "https://from-sites.test"}
+		got := resolveAppURL(dir, site)
+		if got != "https://from-sites.test" {
+			t.Errorf("expected sites.yaml value, got %q", got)
+		}
+	})
+
+	t.Run("falls through to default generator when neither override is set", func(t *testing.T) {
+		dir := t.TempDir() // no .lerd.yaml
+		site := &config.Site{}
+		// siteURL() reads the global registry; for an unregistered tempdir
+		// it returns "", which is exactly the "leave APP_URL alone" signal.
+		if got := resolveAppURL(dir, site); got != "" {
+			t.Errorf("expected empty fallback for unregistered path, got %q", got)
+		}
+	})
+
+	t.Run("nil site falls through to project then default", func(t *testing.T) {
+		dir := t.TempDir()
+		writeProject(t, dir, "https://only-project.test")
+		got := resolveAppURL(dir, nil)
+		if got != "https://only-project.test" {
+			t.Errorf("expected project value with nil site, got %q", got)
+		}
+	})
+
+	t.Run("whitespace in stored value is trimmed", func(t *testing.T) {
+		dir := t.TempDir()
+		writeProject(t, dir, "  https://padded.test  ")
+		got := resolveAppURL(dir, nil)
+		if got != "https://padded.test" {
+			t.Errorf("expected trimmed value, got %q", got)
+		}
+	})
+}

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -110,18 +110,15 @@ func runLink(args []string) error {
 		domains = append([]string{explicit}, filtered...)
 	}
 
-	// Validate that none of the domains are already used by another site.
-	for _, d := range domains {
-		if isReservedDomain(d) {
-			return fmt.Errorf("domain %q is reserved for internal Lerd use", d)
-		}
-		if existing, err := config.IsDomainUsed(d); err == nil && existing != nil {
-			// Allow re-linking the same site (same path).
-			if existing.Path != cwd {
-				return fmt.Errorf("domain %q is already used by site %q", d, existing.Name)
-			}
-		}
-	}
+	// Filter out domains already owned by another site (and reserved domains).
+	// The check is strict — a domain may only belong to one site regardless of
+	// TLS scheme. We never touch .lerd.yaml on disk; the surviving in-memory
+	// list is what gets registered. If everything was conflicted, fall back to
+	// a freshly generated <baseName>.<tld>. Re-linking the same path is not a
+	// conflict.
+	kept, removed := resolveSiteDomains(domains, baseName, cwd, cfg.DNS.TLD)
+	warnFilteredDomains(removed)
+	domains = kept
 
 	phpVersion, err := phpDet.DetectVersion(cwd)
 	if err != nil {
@@ -173,13 +170,37 @@ func runLink(args []string) error {
 		return fmt.Errorf("registering site: %w", err)
 	}
 
-	// Write domains to .lerd.yaml (creates or updates).
+	// Write domains to .lerd.yaml (creates or updates). Preserve any domain
+	// that was originally declared but got filtered out by resolveSiteDomains
+	// (because another site already owns it) — the user's declared intent is
+	// the source of truth on disk, and surfacing the conflict in the UI
+	// requires the dropped entry to remain visible. The conflict will be
+	// re-evaluated on the next link, so the filtered domain self-heals when
+	// the conflicting site is removed.
 	{
 		proj, _ := config.LoadProjectConfig(cwd)
 		suffix := "." + cfg.DNS.TLD
+		seen := make(map[string]bool)
 		var names []string
+		// First, the registered (post-filter) domains in their current order —
+		// preserves the "explicit arg becomes primary" behavior of `lerd link`.
 		for _, d := range site.Domains {
-			names = append(names, strings.TrimSuffix(d, suffix))
+			name := strings.TrimSuffix(d, suffix)
+			low := strings.ToLower(name)
+			if !seen[low] {
+				names = append(names, name)
+				seen[low] = true
+			}
+		}
+		// Then, any pre-existing .lerd.yaml entries that didn't survive the
+		// conflict filter. They get appended at the end so they don't become
+		// primary, but they stay visible to the UI as conflict warnings.
+		for _, d := range proj.Domains {
+			low := strings.ToLower(d)
+			if !seen[low] {
+				names = append(names, d)
+				seen[low] = true
+			}
 		}
 		proj.Domains = names
 		if err := config.SaveProjectConfig(cwd, proj); err != nil {

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -489,7 +489,7 @@ Configure the project's ` + bt + `.env` + bt + ` for lerd in one call:
 - Starts any referenced services that aren't running
 - Creates the project database (and ` + bt + `<name>_testing` + bt + ` database)
 - Generates ` + bt + `APP_KEY` + bt + ` if missing
-- Sets ` + bt + `APP_URL` + bt + ` to the registered ` + bt + `.test` + bt + ` domain
+- Sets ` + bt + `APP_URL` + bt + ` (or the framework's URL key) using the precedence chain: ` + bt + `.lerd.yaml` + bt + ` ` + bt + `app_url` + bt + ` → ` + bt + `sites.yaml` + bt + ` ` + bt + `app_url` + bt + ` → default ` + bt + `<scheme>://<primary-domain>` + bt + ` — see "Custom APP_URL" below
 
 Arguments:
 - ` + bt + `path` + bt + ` (optional): absolute path to the Laravel project root — defaults to the current working directory (or ` + bt + `LERD_SITE_PATH` + bt + ` if set by ` + bt + `mcp:inject` + bt + `)
@@ -516,6 +516,24 @@ db_set(database: "sqlite")       // explicitly keep SQLite (and create the file)
 ` + "```" + `
 
 > Use this **before** ` + bt + `env_setup` + bt + ` on a fresh Laravel project so the database lands in ` + bt + `.env` + bt + ` deliberately. Switching databases later via ` + bt + `db_set` + bt + ` removes the previous database entry from ` + bt + `.lerd.yaml` + bt + ` automatically.
+
+### Custom ` + bt + `APP_URL` + bt + `
+By default ` + bt + `env_setup` + bt + ` writes ` + bt + `APP_URL=<scheme>://<primary-domain>` + bt + ` (e.g. ` + bt + `http://myapp.test` + bt + `) on every run. Three-tier override chain when you need a different value:
+
+1. ` + bt + `.lerd.yaml` + bt + ` ` + bt + `app_url` + bt + ` field — committed to the repo, applies to every machine. Use for path prefixes, ports, or unrelated hostnames the whole team should share.
+2. ` + bt + `~/.local/share/lerd/sites.yaml` + bt + ` ` + bt + `app_url` + bt + ` field on the site entry — per-machine override, not committed.
+3. The default ` + bt + `<scheme>://<primary-domain>` + bt + ` generator — used when neither override is set.
+
+There is no MCP tool to set ` + bt + `app_url` + bt + ` programmatically; the user (or you) edit ` + bt + `.lerd.yaml` + bt + ` directly and re-run ` + bt + `env_setup` + bt + ` (or any command that runs ` + bt + `lerd env` + bt + ` internally) to apply it.
+
+Example ` + bt + `.lerd.yaml` + bt + `:
+` + "```" + `yaml
+domains:
+  - myapp
+app_url: http://myapp.test/api
+` + "```" + `
+
+If the configured ` + bt + `app_url` + bt + ` happens to point at a domain that the conflict filter dropped, lerd silently falls through to the next precedence level so ` + bt + `.env` + bt + ` doesn't end up writing a hostname owned by another site.
 
 ### ` + bt + `env_check` + bt + `
 Compare all ` + bt + `.env` + bt + ` files (` + bt + `.env` + bt + `, ` + bt + `.env.testing` + bt + `, ` + bt + `.env.local` + bt + `, …) against ` + bt + `.env.example` + bt + ` and show a table of missing or extra keys. Useful for catching "works on my machine" bugs caused by env drift after pulling new code.
@@ -926,7 +944,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `vendor_run` + bt + ` | Run a binary from ` + bt + `vendor/bin` + bt + ` (pest, phpunit, pint, phpstan, rector, …) inside the PHP-FPM container |
 | ` + bt + `node_install` + bt + ` | Install a Node.js version via fnm (e.g. ` + bt + `"20"` + bt + `, ` + bt + `"lts"` + bt + `) |
 | ` + bt + `node_uninstall` + bt + ` | Uninstall a Node.js version via fnm |
-| ` + bt + `env_setup` + bt + ` | Configure ` + bt + `.env` + bt + ` for lerd: detects services, starts them, creates DB, generates APP_KEY (leaves ` + bt + `DB_CONNECTION=sqlite` + bt + ` alone — call ` + bt + `db_set` + bt + ` first) |
+| ` + bt + `env_setup` + bt + ` | Configure ` + bt + `.env` + bt + ` for lerd: detects services, starts them, creates DB, generates APP_KEY (leaves ` + bt + `DB_CONNECTION=sqlite` + bt + ` alone — call ` + bt + `db_set` + bt + ` first); ` + bt + `APP_URL` + bt + ` follows ` + bt + `.lerd.yaml app_url` + bt + ` → ` + bt + `sites.yaml app_url` + bt + ` → default chain |
 | ` + bt + `db_set` + bt + ` | Pick the database for a Laravel project: ` + bt + `sqlite` + bt + ` / ` + bt + `mysql` + bt + ` / ` + bt + `postgres` + bt + `; persists to ` + bt + `.lerd.yaml` + bt + `, rewrites ` + bt + `DB_` + bt + ` keys in ` + bt + `.env` + bt + `, starts the service, creates the database |
 | ` + bt + `env_check` + bt + ` | Compare all ` + bt + `.env` + bt + ` files against ` + bt + `.env.example` + bt + ` and flag missing or extra keys |
 | ` + bt + `site_link` + bt + ` | Register a directory as a lerd site (creates nginx vhost + ` + bt + `.test` + bt + ` domain) |
@@ -984,6 +1002,8 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - ` + bt + `artisan` + bt + ` is Laravel-only; ` + bt + `console` + bt + ` is the equivalent for non-Laravel frameworks — both take ` + bt + `path` + bt + ` (absolute project root) and ` + bt + `args` + bt + ` (array)
 - ` + bt + `vendor_run` + bt + ` is the right way to invoke project tooling like pest, phpunit, pint, phpstan, rector — call ` + bt + `vendor_bins` + bt + ` first to discover what's installed, then ` + bt + `vendor_run(bin: "<name>", args: [...])` + bt + `; prefer it over ` + bt + `composer(args: ["exec", ...])` + bt + `
 - On a **fresh Laravel clone** (DB_CONNECTION=sqlite in ` + bt + `.env` + bt + `), call ` + bt + `db_set(database: "mysql"|"postgres"|"sqlite")` + bt + ` before ` + bt + `env_setup` + bt + ` to pick a database deliberately. ` + bt + `env_setup` + bt + ` on its own won't switch the database away from sqlite.
+- **Domain conflicts on link**: when ` + bt + `lerd link` + bt + ` (or the parked-directory watcher) tries to register a ` + bt + `.lerd.yaml` + bt + ` domain that another site already owns, the conflicting domain is filtered out and a ` + bt + `[WARN] domain "X" already used by site "Y" — skipped` + bt + ` line is printed. The site still gets registered with surviving domains, falling back to ` + bt + `<dirname>.<tld>` + bt + ` if everything was filtered. ` + bt + `.lerd.yaml` + bt + ` is not modified on disk so the conflict is visible in the UI and self-heals on the next link if the owning site is removed. The ` + bt + `site_link` + bt + ` and ` + bt + `site_domain_add` + bt + ` MCP tools, by contrast, hard-error on conflicts so you can react explicitly — read the error message for the owning site name.
+- **Custom APP_URL**: ` + bt + `env_setup` + bt + ` writes ` + bt + `<scheme>://<primary-domain>` + bt + ` by default. Override by setting ` + bt + `app_url` + bt + ` in ` + bt + `.lerd.yaml` + bt + ` (committed) or in the per-machine ` + bt + `sites.yaml` + bt + ` site entry. No MCP tool sets it — edit the YAML and re-run ` + bt + `env_setup` + bt + `.
 - ` + bt + `tinker` + bt + ` must use ` + bt + `--execute=<code>` + bt + ` for non-interactive use
 - Built-in service hosts follow the pattern ` + bt + `lerd-<name>` + bt + ` (e.g. ` + bt + `lerd-mysql` + bt + `, ` + bt + `lerd-redis` + bt + `)
 - Default DB credentials: username ` + bt + `root` + bt + `, password ` + bt + `lerd` + bt + `

--- a/internal/cli/park.go
+++ b/internal/cli/park.go
@@ -231,6 +231,14 @@ func RegisterProject(projectDir string, cfg *config.GlobalConfig) (bool, error) 
 		domains = []string{domain}
 	}
 
+	// Filter out conflicting / reserved domains. Strict — a domain may only
+	// belong to one site regardless of TLS scheme. .lerd.yaml is never
+	// modified on disk; the surviving list is what we register. If everything
+	// was conflicted, fall back to a freshly generated <baseName>.<tld>.
+	kept, removed := resolveSiteDomains(domains, baseName, projectDir, cfg.DNS.TLD)
+	warnFilteredDomains(removed)
+	domains = kept
+
 	phpVersion, err := phpDet.DetectVersion(projectDir)
 	if err != nil {
 		phpVersion = cfg.PHP.DefaultVersion

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -18,6 +18,11 @@ type ProjectConfig struct {
 	Secured      bool             `yaml:"secured,omitempty"`
 	Services     []ProjectService `yaml:"services,omitempty"`
 	Workers      []string         `yaml:"workers,omitempty"`
+	// AppURL, when set, is the value lerd writes to the project's APP_URL (or
+	// the framework-configured URL key) on every `lerd env` run. Committed to
+	// the repo so the choice is shared across machines. Takes precedence over
+	// the per-machine override in sites.yaml.
+	AppURL string `yaml:"app_url,omitempty"`
 }
 
 // ServiceNames returns the name of every service in the config, for callers

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -20,6 +20,12 @@ type Site struct {
 	PausedWorkers []string `yaml:"paused_workers,omitempty"`
 	Framework     string   `yaml:"framework,omitempty"`
 	PublicDir     string   `yaml:"public_dir,omitempty"`
+	// AppURL, when set, is the per-machine override for APP_URL in the
+	// project's env file. Lower priority than ProjectConfig.AppURL (which is
+	// committed to the repo) and higher priority than the default generator
+	// (`<scheme>://<primary-domain>`). Use this for personal customizations
+	// you don't want to share via .lerd.yaml.
+	AppURL string `yaml:"app_url,omitempty"`
 }
 
 // PrimaryDomain returns the first (primary) domain for the site.
@@ -60,6 +66,7 @@ type siteYAML struct {
 	PausedWorkers []string `yaml:"paused_workers,omitempty"`
 	Framework     string   `yaml:"framework,omitempty"`
 	PublicDir     string   `yaml:"public_dir,omitempty"`
+	AppURL        string   `yaml:"app_url,omitempty"`
 }
 
 func (s Site) toYAML() siteYAML {
@@ -75,6 +82,7 @@ func (s Site) toYAML() siteYAML {
 		PausedWorkers: s.PausedWorkers,
 		Framework:     s.Framework,
 		PublicDir:     s.PublicDir,
+		AppURL:        s.AppURL,
 	}
 }
 
@@ -95,6 +103,7 @@ func (sy siteYAML) toSite() Site {
 		PausedWorkers: sy.PausedWorkers,
 		Framework:     sy.Framework,
 		PublicDir:     sy.PublicDir,
+		AppURL:        sy.AppURL,
 	}
 }
 
@@ -248,6 +257,11 @@ func FindSiteByDomain(domain string) (*Site, error) {
 
 // IsDomainUsed checks if any site already uses this domain.
 // Returns the site that uses it, or nil if the domain is free.
+//
+// The check is strict: a domain may only belong to one site, regardless of
+// TLS scheme. Two sites cannot share the same domain even if one runs on
+// HTTPS and the other on HTTP — DNS and browser caches don't reliably
+// disambiguate by scheme, and the resulting setup is fragile.
 func IsDomainUsed(domain string) (*Site, error) {
 	reg, err := LoadSites()
 	if err != nil {

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -501,7 +501,12 @@ func hasMissingCert(content, certsDir string) bool {
 }
 
 // EnsureDefaultVhost writes a catch-all default server that shows a branded
-// error page for any request that doesn't match a registered site.
+// error page for any HTTP request that doesn't match a registered site. For
+// HTTPS we cannot serve a real catch-all because browsers (Chrome especially)
+// reject TLD-level wildcard certificates like `*.test` with
+// ERR_CERT_COMMON_NAME_INVALID, and we can't issue per-domain certs ahead of
+// time. ssl_reject_handshake produces a clean connection error
+// (ERR_SSL_UNRECOGNIZED_NAME_ALERT) which is the best UX available.
 func EnsureDefaultVhost() error {
 	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
 		return err

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -518,9 +518,19 @@
                         class="font-semibold text-lerd-red hover:text-lerd-redhov transition-colors"
                         x-text="selectedSite.domain"
                       ></a>
-                      <template x-if="(selectedSite.domains || []).length > 1">
+                      <!-- "+N more" pill: covers both extra registered domains and any
+                           .lerd.yaml entries dropped due to a conflict. The latter render
+                           with a warning icon both on the pill (when present) and inside
+                           the tooltip (struck-through with the owning site name). -->
+                      <template x-if="((selectedSite.domains || []).length - 1 + (selectedSite.conflicting_domains || []).length) > 0">
                         <span class="relative cursor-default" x-data="{ show: false }" @mouseenter="show = true" @mouseleave="show = false">
-                          <span class="text-xs text-gray-400 dark:text-gray-500" x-text="'+' + (selectedSite.domains.length - 1) + ' more'"></span>
+                          <span class="inline-flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500"
+                            :class="(selectedSite.conflicting_domains || []).length > 0 ? 'text-amber-600 dark:text-amber-400' : ''">
+                            <svg x-show="(selectedSite.conflicting_domains || []).length > 0" class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M4.93 19h14.14a2 2 0 001.74-3l-7.07-12a2 2 0 00-3.48 0L3.19 16a2 2 0 001.74 3z"/>
+                            </svg>
+                            <span x-text="'+' + ((selectedSite.domains.length - 1) + (selectedSite.conflicting_domains || []).length) + ' more'"></span>
+                          </span>
                           <div x-show="show" x-transition.opacity class="absolute left-0 top-full mt-1 z-50 bg-gray-900 dark:bg-gray-800 text-white text-xs rounded-lg px-3 py-2 shadow-lg whitespace-nowrap">
                             <template x-for="d in selectedSite.domains.slice(1)" :key="d">
                               <a :href="(selectedSite.tls ? 'https://' : 'http://') + d" @click.prevent="window.open((selectedSite.tls ? 'https://' : 'http://') + d, '_blank', 'noopener')"
@@ -528,6 +538,15 @@
                                 <span x-text="d"></span>
                                 <svg class="w-3 h-3 shrink-0 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
                               </a>
+                            </template>
+                            <template x-for="c in (selectedSite.conflicting_domains || [])" :key="c.domain">
+                              <div class="flex items-center gap-1.5 py-0.5 font-mono">
+                                <svg class="w-3 h-3 shrink-0 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M4.93 19h14.14a2 2 0 001.74-3l-7.07-12a2 2 0 00-3.48 0L3.19 16a2 2 0 001.74 3z"/>
+                                </svg>
+                                <span class="line-through text-gray-400" x-text="c.domain"></span>
+                                <span x-show="c.owned_by" class="text-amber-300" x-text="'→ ' + c.owned_by"></span>
+                              </div>
                             </template>
                           </div>
                         </span>
@@ -1802,6 +1821,7 @@ function lerdApp() {
             if (e) {
               e.domain = s.domain;
               e.domains = s.domains;
+              e.conflicting_domains = s.conflicting_domains;
               e.php_version = s.php_version;
               e.node_version = s.node_version;
               e.tls = s.tls;
@@ -2325,6 +2345,10 @@ function lerdApp() {
         open: true,
         site: site,
         domains: (site.domains || [site.domain]).map(d => d.endsWith(suffix) ? d.slice(0, -suffix.length) : d),
+        // Domains declared in .lerd.yaml that another site on this machine
+        // already owns — surfaced from the API as {domain, owned_by} so the
+        // modal can render them with a warning icon.
+        conflicting: site.conflicting_domains || [],
         newDomain: '',
         editIndex: -1,
         editValue: '',
@@ -2343,6 +2367,7 @@ function lerdApp() {
         this.selectedSiteDomain = updated.domain;
         const suffix = '.' + this.tld;
         m.domains = (updated.domains || [updated.domain]).map(d => d.endsWith(suffix) ? d.slice(0, -suffix.length) : d);
+        m.conflicting = updated.conflicting_domains || [];
       }
     },
 
@@ -2504,6 +2529,32 @@ function lerdApp() {
         this._refreshDomainModal(siteName);
         m.dirty = true;
         m.flash = 'Domain removed';
+        setTimeout(() => { m.flash = ''; }, 3000);
+      } catch (e) { m.error = e.message; }
+      m.loading = false;
+    },
+
+    async domainModalRemoveConflict(c) {
+      // Remove a conflict-filtered entry from .lerd.yaml only. The server's
+      // domain:remove handler detects the entry isn't in the registered list
+      // and routes it to a .lerd.yaml-only delete (no registry, vhost, or
+      // cert work). Strip the TLD before passing the name through, since the
+      // server re-appends it.
+      const m = this.domainModal;
+      const suffix = '.' + this.tld;
+      const fullDomain = c.domain;
+      const nameOnly = fullDomain.endsWith(suffix) ? fullDomain.slice(0, -suffix.length) : fullDomain;
+      const siteName = m.site.name;
+      m.loading = true;
+      m.error = '';
+      try {
+        const res = await fetch(`/api/sites/${m.site.domain}/domain:remove?name=${encodeURIComponent(nameOnly)}`, { method: 'POST' });
+        const data = await res.json();
+        if (!data.ok) { m.error = data.error; m.loading = false; return; }
+        await this.loadSites();
+        this._refreshDomainModal(siteName);
+        m.dirty = true;
+        m.flash = 'Removed from .lerd.yaml';
         setTimeout(() => { m.flash = ''; }, 3000);
       } catch (e) { m.error = e.message; }
       m.loading = false;
@@ -3162,6 +3213,25 @@ function lerdApp() {
 
       <!-- Domain List -->
       <div class="px-5 py-4 space-y-2 max-h-64 overflow-y-auto">
+        <!-- Conflicting domains: declared in .lerd.yaml but already used by another site on this machine. The trash button removes the entry from .lerd.yaml only — no registry change. -->
+        <template x-for="c in (domainModal.conflicting || [])" :key="c.domain">
+          <div class="flex items-center gap-2 group opacity-70">
+            <div class="flex items-center gap-2 flex-1 min-w-0">
+              <svg class="w-4 h-4 text-amber-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                :title="c.owned_by ? ('In .lerd.yaml but already used by site \u201c' + c.owned_by + '\u201d on this machine. Not registered.') : ('In .lerd.yaml but already used by another site on this machine. Not registered.')">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M4.93 19h14.14a2 2 0 001.74-3l-7.07-12a2 2 0 00-3.48 0L3.19 16a2 2 0 001.74 3z"/>
+              </svg>
+              <div class="flex-1 min-w-0 flex items-center gap-1.5">
+                <span class="text-sm font-mono text-gray-500 dark:text-gray-400 truncate line-through" x-text="c.domain"></span>
+                <span x-show="c.owned_by" class="text-[10px] font-medium text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 px-1.5 py-0.5 rounded shrink-0" x-text="'used by ' + c.owned_by"></span>
+              </div>
+              <button @click="domainModalRemoveConflict(c)" :disabled="domainModal.loading"
+                class="text-gray-400 hover:text-red-500 transition-colors shrink-0 disabled:opacity-50" title="Remove from .lerd.yaml">
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+              </button>
+            </div>
+          </div>
+        </template>
         <template x-for="(dom, i) in domainModal.domains" :key="i">
           <div class="flex items-center gap-2 group">
             <!-- View mode -->

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -325,40 +325,50 @@ type WorkerStatus struct {
 	Failing bool   `json:"failing,omitempty"`
 }
 
+// ConflictingDomain describes a domain declared in .lerd.yaml that wasn't
+// registered for the site because another site on this machine already owns
+// it. Surfaced to the UI so the domain modal can render a warning icon next
+// to the entry with the owning site name.
+type ConflictingDomain struct {
+	Domain  string `json:"domain"`
+	OwnedBy string `json:"owned_by"`
+}
+
 // SiteResponse is the response for GET /api/sites.
 type SiteResponse struct {
-	Name              string             `json:"name"`
-	Domain            string             `json:"domain"`
-	Domains           []string           `json:"domains"`
-	Path              string             `json:"path"`
-	PHPVersion        string             `json:"php_version"`
-	NodeVersion       string             `json:"node_version"`
-	TLS               bool               `json:"tls"`
-	Framework         string             `json:"framework"`
-	FPMRunning        bool               `json:"fpm_running"`
-	IsLaravel         bool               `json:"is_laravel"`
-	FrameworkLabel    string             `json:"framework_label"`
-	QueueRunning      bool               `json:"queue_running"`
-	QueueFailing      bool               `json:"queue_failing,omitempty"`
-	StripeRunning     bool               `json:"stripe_running"`
-	StripeSecretSet   bool               `json:"stripe_secret_set"`
-	ScheduleRunning   bool               `json:"schedule_running"`
-	ScheduleFailing   bool               `json:"schedule_failing,omitempty"`
-	ReverbRunning     bool               `json:"reverb_running"`
-	ReverbFailing     bool               `json:"reverb_failing,omitempty"`
-	HasReverb         bool               `json:"has_reverb"`
-	HasHorizon        bool               `json:"has_horizon"`
-	HorizonRunning    bool               `json:"horizon_running"`
-	HorizonFailing    bool               `json:"horizon_failing,omitempty"`
-	HasQueueWorker    bool               `json:"has_queue_worker"`
-	HasScheduleWorker bool               `json:"has_schedule_worker"`
-	FrameworkWorkers  []WorkerStatus     `json:"framework_workers,omitempty"`
-	HasAppLogs        bool               `json:"has_app_logs"`
-	LatestLogTime     string             `json:"latest_log_time,omitempty"`
-	HasFavicon        bool               `json:"has_favicon"`
-	Paused            bool               `json:"paused"`
-	Branch            string             `json:"branch"`
-	Worktrees         []WorktreeResponse `json:"worktrees"`
+	Name               string              `json:"name"`
+	Domain             string              `json:"domain"`
+	Domains            []string            `json:"domains"`
+	ConflictingDomains []ConflictingDomain `json:"conflicting_domains,omitempty"`
+	Path               string              `json:"path"`
+	PHPVersion         string              `json:"php_version"`
+	NodeVersion        string              `json:"node_version"`
+	TLS                bool                `json:"tls"`
+	Framework          string              `json:"framework"`
+	FPMRunning         bool                `json:"fpm_running"`
+	IsLaravel          bool                `json:"is_laravel"`
+	FrameworkLabel     string              `json:"framework_label"`
+	QueueRunning       bool                `json:"queue_running"`
+	QueueFailing       bool                `json:"queue_failing,omitempty"`
+	StripeRunning      bool                `json:"stripe_running"`
+	StripeSecretSet    bool                `json:"stripe_secret_set"`
+	ScheduleRunning    bool                `json:"schedule_running"`
+	ScheduleFailing    bool                `json:"schedule_failing,omitempty"`
+	ReverbRunning      bool                `json:"reverb_running"`
+	ReverbFailing      bool                `json:"reverb_failing,omitempty"`
+	HasReverb          bool                `json:"has_reverb"`
+	HasHorizon         bool                `json:"has_horizon"`
+	HorizonRunning     bool                `json:"horizon_running"`
+	HorizonFailing     bool                `json:"horizon_failing,omitempty"`
+	HasQueueWorker     bool                `json:"has_queue_worker"`
+	HasScheduleWorker  bool                `json:"has_schedule_worker"`
+	FrameworkWorkers   []WorkerStatus      `json:"framework_workers,omitempty"`
+	HasAppLogs         bool                `json:"has_app_logs"`
+	LatestLogTime      string              `json:"latest_log_time,omitempty"`
+	HasFavicon         bool                `json:"has_favicon"`
+	Paused             bool                `json:"paused"`
+	Branch             string              `json:"branch"`
+	Worktrees          []WorktreeResponse  `json:"worktrees"`
 }
 
 func handleSites(w http.ResponseWriter, _ *http.Request) {
@@ -486,6 +496,41 @@ func handleSites(w http.ResponseWriter, _ *http.Request) {
 			}
 		}
 
+		// Compute conflicting domains: ones declared in .lerd.yaml that weren't
+		// registered because another site on this machine already owns them.
+		// The check happens at link/auto-register time but the original list
+		// in .lerd.yaml is preserved on disk, so we surface the discrepancy
+		// here for the UI to render with a warning icon.
+		var conflicting []ConflictingDomain
+		if proj, projErr := config.LoadProjectConfig(s.Path); projErr == nil && proj != nil && len(proj.Domains) > 0 {
+			gcfg, _ := config.LoadGlobal()
+			tld := ""
+			if gcfg != nil {
+				tld = gcfg.DNS.TLD
+			}
+			registered := make(map[string]bool, len(s.Domains))
+			for _, d := range s.Domains {
+				registered[d] = true
+			}
+			for _, declared := range proj.Domains {
+				full := strings.ToLower(declared)
+				if tld != "" {
+					full = full + "." + tld
+				}
+				if registered[full] {
+					continue
+				}
+				owner := ""
+				if owning, _ := config.IsDomainUsed(full); owning != nil && owning.Path != s.Path {
+					owner = owning.Name
+				}
+				conflicting = append(conflicting, ConflictingDomain{
+					Domain:  full,
+					OwnedBy: owner,
+				})
+			}
+		}
+
 		worktreeResponses := []WorktreeResponse{}
 		mainBranch := gitpkg.MainBranch(s.Path)
 		if wts, err := gitpkg.DetectWorktrees(s.Path, s.PrimaryDomain()); err == nil {
@@ -499,38 +544,39 @@ func handleSites(w http.ResponseWriter, _ *http.Request) {
 		}
 
 		sites = append(sites, SiteResponse{
-			Name:              s.Name,
-			Domain:            s.PrimaryDomain(),
-			Domains:           s.Domains,
-			Path:              s.Path,
-			PHPVersion:        phpVersion,
-			NodeVersion:       nodeVersion,
-			TLS:               s.Secured,
-			Framework:         s.Framework,
-			IsLaravel:         isLaravel,
-			FrameworkLabel:    frameworkLabel(fwName),
-			FPMRunning:        fpmRunning,
-			QueueRunning:      queueStatus == "active",
-			QueueFailing:      queueStatus == "activating" || queueStatus == "failed",
-			StripeRunning:     stripeStatus == "active",
-			StripeSecretSet:   stripeSecretSet,
-			ScheduleRunning:   scheduleStatus == "active",
-			ScheduleFailing:   scheduleStatus == "activating" || scheduleStatus == "failed",
-			ReverbRunning:     reverbStatus == "active",
-			ReverbFailing:     reverbStatus == "activating" || reverbStatus == "failed",
-			HasReverb:         hasReverb,
-			HasHorizon:        hasHorizon,
-			HorizonRunning:    horizonStatus == "active",
-			HorizonFailing:    horizonStatus == "activating" || horizonStatus == "failed",
-			HasQueueWorker:    hasQueueWorker,
-			HasScheduleWorker: hasScheduleWorker,
-			FrameworkWorkers:  fwWorkers,
-			HasAppLogs:        hasFw && len(fw.Logs) > 0,
-			LatestLogTime:     latestLogTime(hasFw, fw, s.Path),
-			HasFavicon:        detectFavicon(s.Path, s.PublicDir) != "",
-			Paused:            s.Paused,
-			Branch:            mainBranch,
-			Worktrees:         worktreeResponses,
+			Name:               s.Name,
+			Domain:             s.PrimaryDomain(),
+			Domains:            s.Domains,
+			ConflictingDomains: conflicting,
+			Path:               s.Path,
+			PHPVersion:         phpVersion,
+			NodeVersion:        nodeVersion,
+			TLS:                s.Secured,
+			Framework:          s.Framework,
+			IsLaravel:          isLaravel,
+			FrameworkLabel:     frameworkLabel(fwName),
+			FPMRunning:         fpmRunning,
+			QueueRunning:       queueStatus == "active",
+			QueueFailing:       queueStatus == "activating" || queueStatus == "failed",
+			StripeRunning:      stripeStatus == "active",
+			StripeSecretSet:    stripeSecretSet,
+			ScheduleRunning:    scheduleStatus == "active",
+			ScheduleFailing:    scheduleStatus == "activating" || scheduleStatus == "failed",
+			ReverbRunning:      reverbStatus == "active",
+			ReverbFailing:      reverbStatus == "activating" || reverbStatus == "failed",
+			HasReverb:          hasReverb,
+			HasHorizon:         hasHorizon,
+			HorizonRunning:     horizonStatus == "active",
+			HorizonFailing:     horizonStatus == "activating" || horizonStatus == "failed",
+			HasQueueWorker:     hasQueueWorker,
+			HasScheduleWorker:  hasScheduleWorker,
+			FrameworkWorkers:   fwWorkers,
+			HasAppLogs:         hasFw && len(fw.Logs) > 0,
+			LatestLogTime:      latestLogTime(hasFw, fw, s.Path),
+			HasFavicon:         detectFavicon(s.Path, s.PublicDir) != "",
+			Paused:             s.Paused,
+			Branch:             mainBranch,
+			Worktrees:          worktreeResponses,
 		})
 	}
 	if sites == nil {
@@ -1545,10 +1591,40 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		fullDomain := strings.ToLower(domainName) + "." + cfg.DNS.TLD
+
+		// If the domain isn't in the registered list, it might still be in the
+		// project's .lerd.yaml as a conflict-filtered entry. Remove it from
+		// .lerd.yaml only — no registry, vhost, or cert work needed.
 		if !site.HasDomain(fullDomain) {
-			writeJSON(w, SiteActionResponse{Error: "site does not have domain " + fullDomain})
+			proj, projErr := config.LoadProjectConfig(site.Path)
+			if projErr != nil || proj == nil {
+				writeJSON(w, SiteActionResponse{Error: "site does not have domain " + fullDomain})
+				return
+			}
+			suffix := "." + cfg.DNS.TLD
+			declared := strings.TrimSuffix(fullDomain, suffix)
+			found := false
+			var kept []string
+			for _, d := range proj.Domains {
+				if strings.EqualFold(d, declared) {
+					found = true
+					continue
+				}
+				kept = append(kept, d)
+			}
+			if !found {
+				writeJSON(w, SiteActionResponse{Error: "site does not have domain " + fullDomain})
+				return
+			}
+			proj.Domains = kept
+			if err := config.SaveProjectConfig(site.Path, proj); err != nil {
+				writeJSON(w, SiteActionResponse{Error: "updating .lerd.yaml: " + err.Error()})
+				return
+			}
+			writeJSON(w, SiteActionResponse{OK: true})
 			return
 		}
+
 		if len(site.Domains) <= 1 {
 			writeJSON(w, SiteActionResponse{Error: "cannot remove the last domain"})
 			return


### PR DESCRIPTION
## Summary

Two related improvements to how lerd handles domains and the project URL:

### APP_URL precedence chain

`lerd setup` previously overwrote `APP_URL` on every run with `<scheme>://<primary-domain>`, wiping any custom value the user set. Now lerd respects an `app_url` field in `.lerd.yaml` (committed, shared across machines) or in the per-machine `sites.yaml` site entry, falling back to the default generator only when neither override is set. Use it for path prefixes, ports, or unrelated hostnames.

\`\`\`yaml
# .lerd.yaml
domains:
  - myapp
app_url: http://myapp.test/api
\`\`\`

### Domain conflict soft-fallback

`lerd link` and the parked-directory watcher previously hard-errored when a `.lerd.yaml` domain was already owned by another site, leaving the project unregistered or (in the watcher's case) silently colliding. Now the conflicting domain is filtered out, surviving domains still register, and a clear WARN line is printed naming the owning site:

\`\`\`
$ lerd link
  [WARN] domain \"shared.test\" already used by site \"owner-app\" — skipped
Linked: clone-app -> clone-app.test (PHP 8.4, Node 22, Framework: laravel)
\`\`\`

`.lerd.yaml` is never modified on disk so the dropped entries stay visible and self-heal on the next link if the owning site is removed. The Manage Domains modal in the dashboard surfaces dropped entries with a warning icon, the owning site name, and a trash button that removes the entry from `.lerd.yaml` only. The site detail header's `+N more` pill counts conflicts and turns amber when present.

### Other

- Skill content (`.claude/skills/lerd/SKILL.md`, `.junie/guidelines.md`) updated with the new `app_url` field and the conflict-filter behavior so AI assistants understand the WARN line.
- `docs/usage/sites.md` and `docs/reference/configuration.md` updated with the new sections and field reference.
- `nginx/manager.go:EnsureDefaultVhost` gets a longer comment explaining why HTTPS for unregistered `.test` domains can't serve a real landing page (Chrome rejects TLD-level wildcard certs with `ERR_CERT_COMMON_NAME_INVALID`).