### PR TITLE
docs: framework + services walkthroughs and lifecycle reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ lerd link
 # → https://my-laravel-project.test
 ```
 
+`lerd install` already starts everything for you on first run, so you can `lerd link` immediately. Day-to-day:
+
+```bash
+lerd start          # boot DNS, nginx, PHP-FPM, services, workers, UI
+lerd stop           # stop containers and workers (UI and watcher stay up)
+lerd quit           # full shutdown including UI, watcher, and tray
+lerd autostart enable   # boot lerd on every login
+lerd status         # health snapshot
+```
+
+See [Start, Stop & Autostart](https://geodro.github.io/lerd/usage/lifecycle/) for the full lifecycle reference.
+
 ## Documentation
 
 📖 **[geodro.github.io/lerd](https://geodro.github.io/lerd/)**
@@ -107,6 +119,7 @@ lerd link
 - [Requirements](https://geodro.github.io/lerd/getting-started/requirements/)
 - [Installation](https://geodro.github.io/lerd/getting-started/installation/)
 - [Quick Start](https://geodro.github.io/lerd/getting-started/quick-start/)
+- [Start, Stop & Autostart](https://geodro.github.io/lerd/usage/lifecycle/)
 - [Services](https://geodro.github.io/lerd/usage/services/)
 - [Command Reference](https://geodro.github.io/lerd/reference/commands/)
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -66,11 +66,26 @@ export default defineConfig({
             { text: 'Comparison', link: '/getting-started/comparison' },
           ],
         },
+        {
+          text: 'Framework walkthroughs',
+          items: [
+            { text: 'Laravel', link: '/getting-started/laravel' },
+            { text: 'Symfony', link: '/getting-started/symfony' },
+            { text: 'WordPress', link: '/getting-started/wordpress' },
+          ],
+        },
+        {
+          text: 'Add-ons',
+          items: [
+            { text: 'Services (MongoDB, phpMyAdmin, …)', link: '/getting-started/services' },
+          ],
+        },
       ],
       '/usage/': [
         {
           text: 'Usage',
           items: [
+            { text: 'Start, Stop & Autostart', link: '/usage/lifecycle' },
             { text: 'Site Management', link: '/usage/sites' },
             { text: 'PHP', link: '/usage/php' },
             { text: 'Node', link: '/usage/node' },

--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -1,27 +1,59 @@
 # Project Setup
 
-`lerd setup` automates the standard steps for getting a fresh PHP project running locally. Run it from the project root:
+Two commands cover project bootstrap:
+
+| Command | What it does |
+|---|---|
+| `lerd init` | Runs the interactive wizard, writes `.lerd.yaml`, applies it (link, HTTPS, database, services) |
+| `lerd setup` | Runs `lerd init` first, then a checkbox list of install/migrate/build steps |
+
+Use `lerd init` when you only want to configure the site (PHP version, services, HTTPS). Use `lerd setup` when you also want to install dependencies, run migrations, and start workers in one go.
+
+---
+
+## `lerd init`
+
+`lerd init` is the entry point for `.lerd.yaml`. Run it from the project root:
 
 ```bash
 cd ~/Projects/my-app
-lerd setup
+lerd init
 ```
-
-Before the step selector, `lerd setup` runs the **lerd init wizard** — you choose the PHP version, Node version, HTTPS, and required services. The answers are saved to `.lerd.yaml` in the project root. Commit this file so on any future machine `lerd setup` (or even `lerd link`) reads it and skips the wizard entirely.
 
 ```
 → Configuring site...
 ? PHP version: 8.4
 ? Node version (leave blank to skip): 22
 ? Enable HTTPS? No
+? Database: mysql
 ? Services: [mysql, redis]
+? Workers to auto-start: [queue, schedule]
 Saved .lerd.yaml
 Linked: my-app -> my-app.test (PHP 8.4, Node 22, Framework: laravel)
 ```
 
-The services list includes both built-in services and any custom services already registered with `lerd service add`.
+The answers are saved to `.lerd.yaml` in the project root and applied immediately — the site is linked, HTTPS is enabled if requested, the database is created, and the chosen services are started.
 
-The init wizard also includes a workers step that lets you select which workers to auto-start. Available workers depend on the framework — Horizon is shown automatically when `laravel/horizon` is detected in `composer.json`, replacing the generic queue option.
+The services list includes both built-in services and any custom services already registered with `lerd service add`. The workers step pre-selects workers based on the framework and detected packages — Horizon is shown automatically when `laravel/horizon` is in `composer.json`, replacing the generic queue option.
+
+**Commit `.lerd.yaml` to your repo.** On any future machine, running `lerd link` (or `lerd init` again) reads the saved file and restores the full configuration non-interactively — no prompts.
+
+| Flag | Description |
+|---|---|
+| `--fresh` | Re-run the wizard with existing `.lerd.yaml` values as defaults instead of applying them silently |
+
+Use `--fresh` when you want to change the database engine, swap PHP versions, add or remove services, or otherwise re-answer the wizard.
+
+---
+
+## `lerd setup`
+
+`lerd setup` is the one-shot bootstrap command for a fresh PHP project. It runs `lerd init` first (so the wizard described above appears), then shows a checkbox list of install/migrate/build steps:
+
+```bash
+cd ~/Projects/my-app
+lerd setup
+```
 
 After the wizard, a checkbox list appears with all available steps pre-selected based on the current project state. Worker steps are pre-selected based on the `.lerd.yaml` workers list:
 

--- a/docs/getting-started/laravel.md
+++ b/docs/getting-started/laravel.md
@@ -1,0 +1,152 @@
+# Laravel walkthrough
+
+End-to-end: from `lerd install` to a Laravel app running on `https://myapp.test` with a database, queue worker, and scheduler.
+
+::: info Prerequisites
+You've already run `lerd install` once on this machine. If not, see [Installation](installation.md).
+:::
+
+::: tip Drive it from your AI assistant
+Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Junie, Windsurf) can call every command below as an MCP tool — `project_new`, `site_link`, `env_setup`, `db_create`, `secure`, `worker_start`, etc. See [AI Integration](../features/mcp.md).
+:::
+
+---
+
+## 1. Create the project
+
+Lerd ships with the official Laravel installer, available in your shell after `lerd install`:
+
+::: code-group
+
+```bash [laravel new]
+cd ~/Lerd
+laravel new myapp
+```
+
+```bash [lerd new]
+cd ~/Lerd
+lerd new myapp
+# runs: composer create-project laravel/laravel ./myapp
+```
+
+```bash [existing repo]
+cd ~/Lerd
+git clone git@github.com:you/myapp.git
+```
+
+:::
+
+The `laravel new` installer walks you through starter kit, auth, and database choices interactively. `lerd new` is the framework-agnostic alternative — it runs the bare `composer create-project` so you skip the installer's prompts.
+
+---
+
+## 2. Register the site
+
+```bash
+cd myapp
+lerd link
+```
+
+`lerd link` registers `myapp` and assigns it `http://myapp.test` automatically. No `/etc/hosts` edits — DNS is handled by the lerd dnsmasq container.
+
+::: info Already parked?
+If `~/Lerd` was registered with `lerd park ~/Lerd` earlier, every subdirectory under it is auto-linked. You can skip `lerd link` entirely.
+:::
+
+---
+
+## 3. Configure PHP, Node, database, services
+
+Run the init wizard from inside the project:
+
+```bash
+lerd init
+```
+
+```
+? PHP version: 8.4
+? Node version (leave blank to skip): 22
+? Enable HTTPS? Yes
+? Database: mysql
+? Services: [redis, mailpit]
+? Workers to auto-start: [queue, schedule]
+Saved .lerd.yaml
+```
+
+The wizard writes everything to `.lerd.yaml` in the project root. Commit that file — on any other machine, `lerd link` reads it and restores the same setup without re-running the wizard.
+
+See [Project Setup](../features/project-setup.md) for the full wizard reference.
+
+---
+
+## 4. Bootstrap the project
+
+```bash
+lerd setup
+```
+
+`lerd setup` reads `.lerd.yaml` and shows a checkbox list, pre-selecting every step that's actually needed:
+
+```
+? Select setup steps to run:
+  ◉ composer install
+  ◉ npm ci
+  ◉ lerd env                     # writes DB_*, REDIS_*, MAIL_* into .env
+  ◉ php artisan migrate
+  ◯ php artisan db:seed
+  ◉ php artisan storage:link
+  ◉ npm run build
+  ◉ lerd secure                  # issues mkcert TLS for myapp.test
+  ◉ queue:start
+  ◉ schedule:start
+  ◉ lerd open
+```
+
+Press enter and watch them run. When it's done, the browser opens at `https://myapp.test` and the queue + scheduler are running as systemd user services.
+
+::: info One-shot
+`lerd setup --all` skips the prompt and runs every selected step. Useful in scripts or after a fresh clone on CI.
+:::
+
+---
+
+## 5. Verify
+
+```bash
+lerd status
+```
+
+You should see `myapp` listed as `active`, the configured services running, and the queue/schedule workers as `running`. Live logs are in the [Web UI](../features/web-ui.md) at `http://127.0.0.1:7073` under the **App Logs** tab for `myapp`.
+
+---
+
+## What just happened
+
+| Command | What it did |
+|---|---|
+| `lerd link` | Registered `myapp.test` with nginx + dnsmasq |
+| `lerd init` | Wrote `.lerd.yaml` with PHP 8.4, Node 22, MySQL, Redis, Mailpit, queue, schedule |
+| `lerd env` (via setup) | Injected `DB_HOST=lerd-mysql`, `REDIS_HOST=lerd-redis`, `MAIL_HOST=lerd-mailpit` into `.env` |
+| `lerd db:create` (via env) | Created `myapp` and `myapp_testing` databases |
+| `lerd secure` (via setup) | Issued an mkcert cert, switched the vhost to HTTPS, set `APP_URL=https://myapp.test` |
+| `lerd worker start queue/schedule` (via setup) | Launched `lerd-queue-myapp` and `lerd-schedule-myapp` systemd units |
+
+---
+
+## Reverb (optional)
+
+If your project uses Laravel Reverb (`composer require laravel/reverb`), a third worker toggle appears automatically in the UI and `lerd setup` step list. Each Reverb-enabled site gets its own `REVERB_SERVER_PORT` starting at `8080`, written to `.env` on first run so multiple Reverb sites can coexist.
+
+```bash
+lerd worker start reverb
+```
+
+---
+
+## Next steps
+
+- [Frameworks & Workers](../usage/frameworks.md) — add Horizon, Pulse, or other custom workers
+- [Database](../usage/database.md) — `lerd db:import`, `lerd db:shell`, switching engines
+- [Services](../usage/services.md) — start Meilisearch, RustFS (S3), Postgres, custom services
+- [HTTPS](../features/https.md) — wildcard certs for git worktrees
+- [AI Integration (MCP)](../features/mcp.md) — drive lerd from Claude Code, Cursor, etc.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,40 +1,45 @@
 # Quick Start
 
-Get a Laravel project running locally in three commands.
+After `lerd install`, two commands cover every project type:
 
 ```bash
-# 1. Park your projects directory
-#    Any Laravel project inside is auto-registered
+# Park a directory — every PHP project inside gets a .test domain automatically
 lerd park ~/Lerd
 
-# 2. Visit your project in a browser
-#    ~/Lerd/my-app  →  http://my-app.test
-
-# 3. Check everything is running
+# Confirm DNS, nginx, services, and certs are healthy
 lerd status
 ```
 { .annotate }
 
-1. `lerd park` registers the directory with the watcher service. Every subdirectory that looks like a Laravel project gets a `.test` domain automatically.
-2. No `/etc/hosts` edits needed — DNS is handled by dnsmasq running in a Podman container.
-3. `lerd status` shows a health summary: DNS, nginx, PHP-FPM containers, services, and cert expiry.
+1. `lerd park` registers the directory with the watcher service. Every subdirectory that looks like a PHP project gets a `.test` domain — no `/etc/hosts` edits, DNS is handled by dnsmasq running in a Podman container.
+2. `lerd status` shows a health summary: DNS, nginx, PHP-FPM containers, services, and cert expiry.
 
-That's it. Nginx is serving your project through PHP-FPM, all inside Podman containers on the `lerd` network.
+If you only want to register a single project, `cd` into it and run `lerd link` instead of `lerd park`.
 
 ---
 
-## First project bootstrap
+## Pick your framework
 
-For a freshly cloned project, use `lerd setup` to run all the standard setup steps in one go:
+The next steps depend on what you're building. Each walkthrough is end-to-end — from an empty directory to an HTTPS site with a database, dependencies installed, and workers running:
 
-```bash
-cd ~/Lerd/my-app
-lerd setup
-```
+- [**Laravel**](laravel.md) — built-in framework, queue + scheduler + Reverb workers
+- [**Symfony**](symfony.md) — Doctrine migrations, Messenger worker, MySQL or Postgres
+- [**WordPress**](wordpress.md) — manual `wp-config.php` setup, MySQL
 
-A checkbox list appears with all available steps pre-selected. Toggle steps with space, confirm with enter, and watch them run sequentially.
+Already cloning an existing repo with a committed `.lerd.yaml`? `cd` in and run `lerd setup` — it reads the config and runs every install/migrate/build step automatically. See [Project Setup](../features/project-setup.md).
 
-See [Project Setup](../features/project-setup.md) for the full details.
+---
+
+## Add extra services
+
+Lerd ships with **MySQL, PostgreSQL, Redis, Meilisearch, RustFS, and Mailpit** built in. Need anything else? The [**Services walkthrough**](services.md) has copy-paste recipes for the most common ones:
+
+- **MongoDB** — document store with per-site database auto-provisioning
+- **phpMyAdmin / pgAdmin / Adminer** — web UIs for MySQL and PostgreSQL
+- **Elasticsearch** — full-text search
+- **RabbitMQ** — message broker with management UI
+
+Each recipe is a single YAML file plus `lerd service add` and `lerd service start` — that's it.
 
 ---
 

--- a/docs/getting-started/services.md
+++ b/docs/getting-started/services.md
@@ -1,0 +1,257 @@
+# Services walkthrough
+
+Lerd ships with **MySQL, PostgreSQL, Redis, Meilisearch, RustFS, and Mailpit** built in. Anything else — MongoDB, phpMyAdmin, pgAdmin, Elasticsearch, MinIO, RabbitMQ — runs as a **custom service**: a YAML file dropped into `~/.config/lerd/services/`, registered with one command, and managed by `lerd service start/stop/list` exactly like the built-ins.
+
+::: info Prerequisites
+You've already run `lerd install` once on this machine. If not, see [Installation](installation.md).
+:::
+
+::: tip Drive it from your AI assistant
+After running `lerd mcp:enable-global`, your AI assistant can call `service_add`, `service_start`, `service_stop`, and `service_remove` directly. See [AI Integration](../features/mcp.md).
+:::
+
+---
+
+## How it works (30 seconds)
+
+Three steps for any custom service:
+
+```bash
+# 1. Save the YAML somewhere
+$EDITOR ~/.config/lerd/services/<name>.yaml
+
+# 2. Register it with lerd
+lerd service add ~/.config/lerd/services/<name>.yaml
+
+# 3. Start it
+lerd service start <name>
+```
+
+After step 2, the service appears in `lerd service list`, the Web UI Services panel, and `lerd start` / `lerd stop` cycles.
+
+For the full YAML schema (env vars, `depends_on`, `site_init`, `{{site}}` placeholders, etc.) see [Services reference](../usage/services.md#yaml-schema).
+
+---
+
+## Recipe: MongoDB
+
+```yaml
+# ~/.config/lerd/services/mongodb.yaml
+name: mongodb
+image: docker.io/library/mongo:7
+description: "MongoDB document store"
+ports:
+  - 27017:27017
+environment:
+  MONGO_INITDB_ROOT_USERNAME: root
+  MONGO_INITDB_ROOT_PASSWORD: lerd
+data_dir: /data/db
+env_vars:
+  - "MONGO_DATABASE={{site}}"
+  - "MONGO_URI=mongodb://root:lerd@lerd-mongodb:27017/{{site}}?authSource=admin"
+env_detect:
+  key: MONGO_URI
+  value_prefix: "mongodb://"
+site_init:
+  exec: >
+    mongosh admin -u root -p lerd --eval
+    "db.getSiblingDB('{{site}}').createCollection('_init');
+     db.getSiblingDB('{{site_testing}}').createCollection('_init')"
+```
+
+```bash
+lerd service add ~/.config/lerd/services/mongodb.yaml
+lerd service start mongodb
+```
+
+| From | Host |
+|---|---|
+| Your app (PHP-FPM) | `lerd-mongodb:27017` |
+| Host tools (Compass, mongosh) | `127.0.0.1:27017` |
+| User / password | `root` / `lerd` |
+
+When `lerd env` runs in a project that has `MONGO_URI=mongodb://...` in its `.env`, the connection string is rewritten to point at `lerd-mongodb` and a per-site database is created automatically.
+
+---
+
+## Recipe: phpMyAdmin
+
+```yaml
+# ~/.config/lerd/services/phpmyadmin.yaml
+name: phpmyadmin
+image: docker.io/phpmyadmin:latest
+description: "phpMyAdmin web interface for MySQL"
+ports:
+  - 8080:80
+environment:
+  PMA_HOST: lerd-mysql
+  PMA_USER: root
+  PMA_PASSWORD: lerd
+depends_on:
+  - mysql
+dashboard: http://localhost:8080
+```
+
+```bash
+lerd service add ~/.config/lerd/services/phpmyadmin.yaml
+lerd service start phpmyadmin
+```
+
+Open `http://localhost:8080`. Because of `depends_on: mysql`, `lerd service start phpmyadmin` boots MySQL first if it isn't already running, and `lerd service stop mysql` cascades down to phpMyAdmin.
+
+---
+
+## Recipe: pgAdmin
+
+```yaml
+# ~/.config/lerd/services/pgadmin.yaml
+name: pgadmin
+image: docker.io/dpage/pgadmin4:latest
+description: "pgAdmin 4 web interface for PostgreSQL"
+ports:
+  - 8081:80
+environment:
+  PGADMIN_DEFAULT_EMAIL: admin@lerd.test
+  PGADMIN_DEFAULT_PASSWORD: lerd
+  PGADMIN_CONFIG_SERVER_MODE: "False"
+data_dir: /var/lib/pgadmin
+depends_on:
+  - postgres
+dashboard: http://localhost:8081
+```
+
+```bash
+lerd service add ~/.config/lerd/services/pgadmin.yaml
+lerd service start pgadmin
+```
+
+Open `http://localhost:8081`, log in with `admin@lerd.test` / `lerd`, then add a server with host `lerd-postgres`, port `5432`, user `postgres`, password `lerd`.
+
+---
+
+## Recipe: Adminer
+
+A lightweight, single-file alternative to phpMyAdmin/pgAdmin that supports both MySQL and PostgreSQL:
+
+```yaml
+# ~/.config/lerd/services/adminer.yaml
+name: adminer
+image: docker.io/library/adminer:latest
+description: "Universal database web client (MySQL + PostgreSQL + more)"
+ports:
+  - 8082:8080
+depends_on:
+  - mysql
+dashboard: http://localhost:8082
+```
+
+```bash
+lerd service add ~/.config/lerd/services/adminer.yaml
+lerd service start adminer
+```
+
+Open `http://localhost:8082`. Choose the system (MySQL → host `lerd-mysql`, or PostgreSQL → host `lerd-postgres`), then user `root` / `postgres` and password `lerd`.
+
+---
+
+## Recipe: Elasticsearch
+
+```yaml
+# ~/.config/lerd/services/elasticsearch.yaml
+name: elasticsearch
+image: docker.io/elasticsearch:8.13.4
+description: "Elasticsearch search engine"
+ports:
+  - 9200:9200
+environment:
+  discovery.type: single-node
+  xpack.security.enabled: "false"
+  ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+data_dir: /usr/share/elasticsearch/data
+env_vars:
+  - "ELASTICSEARCH_HOST=http://lerd-elasticsearch:9200"
+env_detect:
+  key: ELASTICSEARCH_HOST
+```
+
+```bash
+lerd service add ~/.config/lerd/services/elasticsearch.yaml
+lerd service start elasticsearch
+```
+
+| From | Host |
+|---|---|
+| Your app | `http://lerd-elasticsearch:9200` |
+| Host tools | `http://127.0.0.1:9200` |
+
+---
+
+## Recipe: RabbitMQ
+
+```yaml
+# ~/.config/lerd/services/rabbitmq.yaml
+name: rabbitmq
+image: docker.io/library/rabbitmq:3-management
+description: "RabbitMQ message broker with management UI"
+ports:
+  - 5672:5672
+  - 15672:15672
+environment:
+  RABBITMQ_DEFAULT_USER: lerd
+  RABBITMQ_DEFAULT_PASS: lerd
+data_dir: /var/lib/rabbitmq
+env_vars:
+  - "RABBITMQ_HOST=lerd-rabbitmq"
+  - "RABBITMQ_PORT=5672"
+  - "RABBITMQ_USER=lerd"
+  - "RABBITMQ_PASSWORD=lerd"
+env_detect:
+  key: RABBITMQ_HOST
+dashboard: http://localhost:15672
+```
+
+```bash
+lerd service add ~/.config/lerd/services/rabbitmq.yaml
+lerd service start rabbitmq
+```
+
+Management UI at `http://localhost:15672` (`lerd` / `lerd`).
+
+---
+
+## Verify
+
+```bash
+lerd service list
+```
+
+Each registered custom service shows up with a `[custom]` marker. `[pinned]` means it stays running across `lerd start`/`lerd stop` cycles. Indented sub-lines show dependency or auto-stop reasons.
+
+```bash
+lerd service status mongodb     # systemd unit status
+lerd service stop mongodb        # stop without removing
+lerd service remove mongodb      # stop + remove quadlet + delete YAML
+```
+
+The data directory at `~/.local/share/lerd/data/<name>/` is **not** deleted by `service remove` — wipe it manually if you want a clean slate.
+
+---
+
+## Per-site auto-injection
+
+Three of the recipes above (`mongodb`, `elasticsearch`, `rabbitmq`) include `env_detect` and `env_vars`. When you run `lerd env` in a project that already references one of those services in its `.env` (e.g. `MONGO_URI=` is set), lerd:
+
+1. Starts the service if it isn't already running
+2. Substitutes <code v-pre>{{site}}</code> in the env vars with the project's site handle
+3. Writes the resulting variables into the project's `.env`
+4. Runs `site_init.exec` inside the container (MongoDB recipe) to create per-site databases
+
+This means dropping the YAML once is enough — every project that needs the service gets wired up automatically on `lerd env` (which `lerd init` and `lerd setup` both call).
+
+---
+
+## Next steps
+
+- [Services reference](../usage/services.md) — full YAML schema, dependency rules, custom command flags, RustFS / Mailpit / Soketi / stripe-mock built-in details
+- [Configuration](../reference/configuration.md) — embedding services directly in `.lerd.yaml` so they ship with the repo
+- [AI Integration (MCP)](../features/mcp.md) — manage services from your AI assistant

--- a/docs/getting-started/symfony.md
+++ b/docs/getting-started/symfony.md
@@ -1,0 +1,213 @@
+# Symfony walkthrough
+
+End-to-end: from `lerd install` to a Symfony app running on `https://myapp.test` with Doctrine, MySQL, and a Messenger worker.
+
+::: info Prerequisites
+You've already run `lerd install` once on this machine. If not, see [Installation](installation.md).
+:::
+
+::: tip Drive it from your AI assistant
+Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Junie, Windsurf) can call every command below as an MCP tool — `project_new`, `site_link`, `env_setup`, `db_create`, `secure`, `worker_start`, etc. See [AI Integration](../features/mcp.md).
+:::
+
+---
+
+## 1. Register the Symfony framework definition (one-time)
+
+Lerd's built-in framework is Laravel. Other frameworks are user-defined YAML files dropped into `~/.config/lerd/frameworks/`. Save this as `~/.config/lerd/frameworks/symfony.yaml`:
+
+```yaml
+# ~/.config/lerd/frameworks/symfony.yaml
+name: symfony
+label: Symfony
+detect:
+  - file: symfony.lock
+  - composer: symfony/framework-bundle
+public_dir: public
+create: composer create-project symfony/skeleton
+console: bin/console
+env:
+  file: .env
+  example_file: .env.dist
+  format: dotenv
+  url_key: DEFAULT_URI
+  services:
+    mysql:
+      detect:
+        - key: DATABASE_URL
+          value_prefix: "mysql://"
+        - key: DATABASE_URL
+          value_prefix: "mariadb://"
+      vars:
+        - "DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/{{site}}?serverVersion={{mysql_version}}"
+    postgres:
+      detect:
+        - key: DATABASE_URL
+          value_prefix: "postgresql://"
+        - key: DATABASE_URL
+          value_prefix: "postgres://"
+      vars:
+        - "DATABASE_URL=postgresql://postgres:lerd@lerd-postgres:5432/{{site}}?serverVersion={{postgres_version}}"
+    redis:
+      detect:
+        - key: REDIS_URL
+        - key: REDIS_DSN
+      vars:
+        - "REDIS_URL=redis://lerd-redis:6379"
+    mailpit:
+      detect:
+        - key: MAILER_DSN
+      vars:
+        - "MAILER_DSN=smtp://lerd-mailpit:1025"
+composer: auto
+npm: auto
+workers:
+  messenger:
+    label: Messenger
+    command: php bin/console messenger:consume async --time-limit=3600
+    restart: always
+    check:
+      composer: symfony/messenger
+setup:
+  - label: "Run migrations"
+    command: "php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration"
+    default: true
+    check:
+      composer: doctrine/doctrine-migrations-bundle
+  - label: "Load fixtures"
+    command: "php bin/console doctrine:fixtures:load --no-interaction"
+    check:
+      composer: doctrine/doctrine-fixtures-bundle
+  - label: "Clear cache"
+    command: "php bin/console cache:clear"
+    default: true
+```
+
+Then register it with lerd:
+
+```bash
+lerd framework add symfony --from-file ~/.config/lerd/frameworks/symfony.yaml
+```
+
+You only do this once per machine. From now on, every Symfony project is auto-detected via `symfony.lock` or `symfony/framework-bundle`.
+
+See [Frameworks & Workers](../usage/frameworks.md) for the full schema reference.
+
+---
+
+## 2. Create the project
+
+::: code-group
+
+```bash [lerd new]
+cd ~/Lerd
+lerd new myapp --framework=symfony
+# runs: composer create-project symfony/skeleton ./myapp
+```
+
+```bash [composer]
+cd ~/Lerd
+composer create-project symfony/skeleton myapp
+```
+
+```bash [existing repo]
+cd ~/Lerd
+git clone git@github.com:you/myapp.git
+```
+
+:::
+
+---
+
+## 3. Register the site
+
+```bash
+cd myapp
+lerd link
+```
+
+`lerd link` detects Symfony (via `symfony.lock` or the composer package), assigns `http://myapp.test`, and sets the document root to `public/`.
+
+---
+
+## 4. Configure PHP, Node, database, services
+
+```bash
+lerd init
+```
+
+```
+? PHP version: 8.4
+? Node version (leave blank to skip): 22
+? Enable HTTPS? Yes
+? Database: mysql
+? Services: [mailpit]
+? Workers to auto-start: [messenger]
+Saved .lerd.yaml
+```
+
+The wizard discovers `messenger` as an available worker because the framework YAML declares it (and the `check: composer: symfony/messenger` rule matches your project).
+
+---
+
+## 5. Bootstrap the project
+
+```bash
+lerd setup
+```
+
+```
+? Select setup steps to run:
+  ◉ composer install
+  ◉ npm ci                       # only if package.json exists
+  ◉ lerd env                     # injects DATABASE_URL, MAILER_DSN, DEFAULT_URI
+  ◉ Run migrations               # from framework setup block
+  ◉ Clear cache                  # from framework setup block
+  ◯ Load fixtures
+  ◉ lerd secure                  # mkcert TLS for myapp.test
+  ◉ messenger:start
+  ◉ lerd open
+```
+
+The "Run migrations", "Clear cache", and "Load fixtures" steps come from the `setup:` block in your `symfony.yaml`. Lerd surfaces them automatically and respects the `check:` rules — fixtures only appears if `doctrine/doctrine-fixtures-bundle` is installed.
+
+When it finishes, `https://myapp.test` opens in your browser and `lerd-messenger-myapp` is running as a systemd user service.
+
+---
+
+## 6. Verify
+
+```bash
+lerd status
+```
+
+```bash
+# Tail messenger logs
+journalctl --user -u lerd-messenger-myapp -f
+```
+
+App logs (anything in `var/log/*.log`) show up in the [Web UI](../features/web-ui.md) **App Logs** tab — add a `logs:` block to `symfony.yaml` to customise paths or parsing.
+
+---
+
+## What just happened
+
+| Command | What it did |
+|---|---|
+| `lerd framework add symfony` | Registered the YAML so Symfony projects are auto-detected |
+| `lerd link` | Assigned `myapp.test`, set document root to `public/` |
+| `lerd init` | Wrote `.lerd.yaml` with PHP, Node, MySQL, Mailpit, messenger |
+| `lerd env` (via setup) | Wrote `DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/myapp?serverVersion=8.0` and `MAILER_DSN=smtp://lerd-mailpit:1025` into `.env` |
+| `lerd secure` (via setup) | Issued mkcert cert, set `DEFAULT_URI=https://myapp.test` |
+| Doctrine migrations + cache:clear | Ran via the framework's `setup:` block |
+| `lerd worker start messenger` (via setup) | Launched `lerd-messenger-myapp` |
+
+---
+
+## Next steps
+
+- [Frameworks & Workers](../usage/frameworks.md) — add custom workers, customise log paths, define more setup steps
+- [Database](../usage/database.md) — `lerd db:import`, `lerd db:shell`, switching to Postgres
+- [Services](../usage/services.md) — start Meilisearch, RustFS (S3), custom services
+- [HTTPS](../features/https.md) — how `lerd secure` works under the hood
+- [AI Integration (MCP)](../features/mcp.md) — drive lerd from Claude Code, Cursor, Junie, etc.

--- a/docs/getting-started/wordpress.md
+++ b/docs/getting-started/wordpress.md
@@ -1,0 +1,196 @@
+# WordPress walkthrough
+
+End-to-end: from `lerd install` to a WordPress site running on `https://myblog.test` with MySQL.
+
+::: info Prerequisites
+You've already run `lerd install` once on this machine. If not, see [Installation](installation.md).
+:::
+
+::: tip Drive it from your AI assistant
+Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Junie, Windsurf) can call every command below as an MCP tool — `site_link`, `db_create`, `secure`, etc. See [AI Integration](../features/mcp.md).
+:::
+
+---
+
+## 1. Register the WordPress framework definition (one-time)
+
+Save this as `~/.config/lerd/frameworks/wordpress.yaml`:
+
+```yaml
+# ~/.config/lerd/frameworks/wordpress.yaml
+name: wordpress
+label: WordPress
+detect:
+  - file: wp-login.php
+  - file: wp-config.php
+public_dir: .
+env:
+  fallback_file: wp-config.php
+  fallback_format: php-const
+composer: false
+npm: false
+```
+
+Then register it:
+
+```bash
+lerd framework add wordpress --from-file ~/.config/lerd/frameworks/wordpress.yaml
+```
+
+::: info Why no `.env`?
+WordPress stores configuration in `wp-config.php` as PHP constants, not in a `.env` file. The `fallback_file` / `fallback_format` settings tell lerd to read constants like `DB_HOST`, `WP_HOME`, and `WP_SITEURL` directly from `wp-config.php`. This means `lerd env` doesn't auto-inject database credentials the way it does for Laravel or Symfony — you'll wire them up by hand in step 5.
+:::
+
+---
+
+## 2. Download WordPress
+
+::: code-group
+
+```bash [wp-cli]
+cd ~/Lerd
+wp core download --path=myblog
+```
+
+```bash [curl + tar]
+cd ~/Lerd
+mkdir myblog && cd myblog
+curl -O https://wordpress.org/latest.tar.gz
+tar -xzf latest.tar.gz --strip-components=1
+rm latest.tar.gz
+```
+
+:::
+
+---
+
+## 3. Register the site
+
+```bash
+cd ~/Lerd/myblog
+lerd link
+```
+
+`lerd link` detects WordPress (via `wp-login.php` or `wp-config.php`), assigns `http://myblog.test`, and serves from the project root.
+
+---
+
+## 4. Configure PHP and start MySQL
+
+```bash
+lerd init
+```
+
+```
+? PHP version: 8.3
+? Node version (leave blank to skip):
+? Enable HTTPS? Yes
+? Services: [mysql]
+Saved .lerd.yaml
+```
+
+Workers are not shown — the WordPress framework definition declares none.
+
+---
+
+## 5. Create the database
+
+```bash
+lerd db:create myblog
+```
+
+This creates `myblog` and `myblog_testing` inside the lerd-mysql container.
+
+::: info Database credentials
+| Setting | Value |
+|---|---|
+| Host | `lerd-mysql` |
+| Port | `3306` |
+| User | `root` |
+| Password | `lerd` |
+| Database | `myblog` |
+
+These come from the lerd built-in MySQL service. See [Services](../usage/services.md#service-credentials).
+:::
+
+---
+
+## 6. Configure `wp-config.php`
+
+Run the WordPress installer (browser at `http://myblog.test`) which will prompt for the values above, **or** copy `wp-config-sample.php` and edit it manually:
+
+```bash
+cp wp-config-sample.php wp-config.php
+```
+
+Then edit the `DB_*` constants:
+
+```php
+define( 'DB_NAME',     'myblog' );
+define( 'DB_USER',     'root' );
+define( 'DB_PASSWORD', 'lerd' );
+define( 'DB_HOST',     'lerd-mysql' );
+```
+
+Generate fresh authentication salts (the installer does this automatically; for the manual path, replace the placeholder block with output from <https://api.wordpress.org/secret-key/1.1/salt/>).
+
+---
+
+## 7. Enable HTTPS
+
+```bash
+lerd secure myblog
+```
+
+This issues a trusted local cert via mkcert and switches the vhost to HTTPS. WordPress also stores its canonical URL in two places, so update them too:
+
+```php
+// wp-config.php
+define( 'WP_HOME',    'https://myblog.test' );
+define( 'WP_SITEURL', 'https://myblog.test' );
+```
+
+(Or update the same values in **Settings → General** from the WordPress admin.)
+
+---
+
+## 8. Open it
+
+```bash
+lerd open
+```
+
+Walk through the five-minute install (admin user, site title, password). When you're done, `https://myblog.test/wp-admin` is your dashboard.
+
+---
+
+## 9. Verify
+
+```bash
+lerd status
+```
+
+`myblog` should be listed as `active` and `mysql` as `running`. Live nginx and PHP-FPM logs are in the [Web UI](../features/web-ui.md) at `http://127.0.0.1:7073`.
+
+---
+
+## What just happened
+
+| Command | What it did |
+|---|---|
+| `lerd framework add wordpress` | Registered the YAML so WordPress projects are auto-detected |
+| `lerd link` | Assigned `myblog.test`, set document root to project root |
+| `lerd init` | Wrote `.lerd.yaml` with PHP 8.3 and the MySQL service |
+| `lerd db:create myblog` | Created `myblog` and `myblog_testing` inside lerd-mysql |
+| (manual) `wp-config.php` edits | Pointed WordPress at `lerd-mysql` and the new database |
+| `lerd secure myblog` | Issued mkcert TLS, switched vhost to HTTPS |
+
+---
+
+## Next steps
+
+- [Frameworks & Workers](../usage/frameworks.md) — extend `wordpress.yaml` to add log paths or custom workers (e.g. `wp cron event run`)
+- [Database](../usage/database.md) — `lerd db:import` to load a production dump, `lerd db:shell` for quick queries
+- [Services](../usage/services.md) — add a Mailpit service to capture outgoing mail in dev
+- [HTTPS](../features/https.md) — wildcard certs for multi-site or git worktrees
+- [AI Integration (MCP)](../features/mcp.md) — drive lerd from Claude Code, Cursor, Junie, etc.

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -1,0 +1,136 @@
+# Start, Stop & Autostart
+
+Day-to-day lifecycle commands for the entire lerd stack — DNS, nginx, PHP-FPM containers, services, workers, the Web UI, the watcher, and the system tray.
+
+::: tip You don't need to run `lerd start` after installing
+`lerd install` already starts everything for you on first run: it boots `lerd-dns`, `lerd-nginx`, the `lerd-watcher`, and the system tray. Services like MySQL or Redis are started on demand the first time something needs them (`lerd service start`, `lerd init`, or `lerd env`). Reach for `lerd start` only after a `lerd stop`, a reboot without autostart enabled, or after you've manually killed containers.
+:::
+
+---
+
+## Commands at a glance
+
+| Command | Stops | Starts |
+|---|---|---|
+| `lerd start` | — | DNS, nginx, watcher, tray, all PHP-FPM containers in use, services that were running before stop, queue / schedule / reverb / messenger workers, stripe listeners, Web UI |
+| `lerd stop` | All containers and workers above. Leaves the watcher and Web UI alone. | — |
+| `lerd quit` | Everything `lerd stop` does, **plus** the Web UI, watcher, and tray. | — |
+
+`lerd stop` is the everyday "give my laptop back its CPU" command. `lerd quit` is a full shutdown — use it before a reinstall, a system reboot without autostart, or when you really want lerd out of the way.
+
+---
+
+## `lerd start`
+
+```bash
+lerd start
+```
+
+Walks the install in dependency order:
+
+1. Pre-flight: checks for **port conflicts** on 53, 80, and 443; refuses to start if another process is bound.
+2. Rebuilds or pulls any missing container images (e.g. after a `podman rmi` or a podman cleanup).
+3. Boots core: `lerd-dns`, `lerd-nginx`, `lerd-watcher`.
+4. Boots every PHP-FPM container that has at least one site referencing its version. Unused PHP versions stay stopped.
+5. Boots all installed services that are **not** marked as manually paused (see [Manually stopped services](services.md#manually-stopped-services) for the pause-state contract).
+6. Restores per-site workers (`lerd-queue-*`, `lerd-schedule-*`, `lerd-reverb-*`, `lerd-messenger-*`, custom workers) and stripe listeners (`lerd-stripe-*`) from the `workers` list saved in each site's `.lerd.yaml`.
+7. Starts the Web UI (`lerd-ui`) and the system tray.
+
+A live spinner shows the per-unit progress. If a single SSL vhost references a missing certificate file, lerd switches that site back to HTTP automatically and continues — one broken cert no longer blocks the whole nginx start.
+
+::: info After a reinstall
+If you ran `lerd uninstall` and then reinstalled, worker units and service quadlets are recreated by `lerd start` from each site's `.lerd.yaml`. Sites with a committed `.lerd.yaml` come back fully wired up. Sites without one need their workers restarted manually.
+:::
+
+---
+
+## `lerd stop`
+
+```bash
+lerd stop
+```
+
+Stops everything `lerd start` started **except** the Web UI, watcher, and tray — those keep running so the dashboard stays reachable to bring lerd back up.
+
+A few important details:
+
+- **Manually paused services are remembered.** If you stopped Mailpit earlier with `lerd service stop mailpit`, then `lerd stop` + `lerd start` will not bring Mailpit back. The pause flag survives the cycle.
+- **Pinned services start anyway.** A `lerd service pin <name>` overrides auto-stop logic — pinned services are always started by `lerd start` regardless of which sites are active.
+- **Worker state is preserved.** Workers running before `lerd stop` are restarted by the next `lerd start`; workers you manually stopped stay stopped.
+
+---
+
+## `lerd quit`
+
+```bash
+lerd quit
+```
+
+The full off-switch:
+
+1. Runs everything `lerd stop` does.
+2. Stops `lerd-ui` (Web UI).
+3. Stops `lerd-watcher`.
+4. Kills the system tray process.
+
+After `lerd quit` there are no lerd processes left running. This is the right command before a reinstall, a system reboot, or before pulling a major update.
+
+The system tray's **Quit Lerd** menu item calls `lerd quit`.
+
+---
+
+## Autostart on login
+
+Lerd can boot itself every time you log in via a user systemd unit (`lerd-autostart.service`).
+
+```bash
+lerd autostart enable      # boot lerd on every login
+lerd autostart disable     # stop booting on login
+```
+
+The autostart unit runs `lerd start` once your graphical session is ready, so DNS routing, the tray, and the Web UI are all live before you open your editor. Manually paused services are honored — they stay paused across the boot.
+
+The system tray has its own autostart toggle so you can have lerd running headless without the tray icon, or vice versa:
+
+```bash
+lerd autostart tray enable
+lerd autostart tray disable
+```
+
+Both toggles also appear in the **System Tray** menu under **Autostart** — see [System Tray](../features/system-tray.md).
+
+---
+
+## From the Web UI
+
+The dashboard at `http://127.0.0.1:7073` has **Start** and **Stop** buttons in the header:
+
+- **Start** appears only when one or more core services (DNS, nginx, PHP-FPM) are not running. Clicking it calls `lerd start` via the API.
+- **Stop** is always visible while lerd is running. Clicking it calls `lerd stop`.
+- The tray's **Quit Lerd** menu item calls `lerd quit` (full shutdown including the UI).
+
+These map one-to-one to the CLI commands above — no special UI-only behaviour.
+
+---
+
+## Status & verification
+
+```bash
+lerd status
+```
+
+Shows a live snapshot: DNS reachability, nginx, PHP-FPM containers, watcher, services, certificate expiry, and LAN exposure. Run it after every `lerd start` to confirm everything is healthy. See [Troubleshooting](../troubleshooting.md) if anything is reported as down.
+
+---
+
+## Cheat sheet
+
+| Situation | Command |
+|---|---|
+| Just installed lerd | Nothing — `lerd install` already started everything |
+| Coming back to your laptop after `lerd stop` | `lerd start` |
+| Reboot, autostart disabled | `lerd start` |
+| Reboot, autostart enabled | Nothing — happens automatically |
+| Free up CPU / RAM during a heavy build | `lerd stop` |
+| Full shutdown before a reinstall | `lerd quit` |
+| Verify everything's healthy | `lerd status` |


### PR DESCRIPTION
## Summary

The Quick Start used to drop new users at `lerd park` / `lerd status` with no narrative for taking a Laravel, Symfony, or WordPress project from zero to running. `lerd start`, `lerd stop`, and `lerd quit` were also only a one-line table entry, and the `lerd init` wizard was buried inside the `lerd setup` section. This PR turns the post-install experience into a coherent guided flow.

## What's new

- **Framework walkthroughs** in `docs/getting-started/` for **Laravel**, **Symfony**, and **WordPress**, each shaped identically (link → init → setup → secure → workers → verify) so they can be skimmed side by side.
- **Services walkthrough** with copy-paste recipes for **MongoDB**, **phpMyAdmin**, **pgAdmin**, **Adminer**, **Elasticsearch**, and **RabbitMQ** — each is a single YAML file plus `lerd service add` and `lerd service start`.
- **Start, Stop & Autostart** page documenting `lerd start` / `lerd stop` / `lerd quit`, the autostart unit, the relationship with `lerd install` (which already starts everything on first run), and a situation-to-command cheat sheet.
- **Project Setup** page now leads with `lerd init` as a first-class command separate from `lerd setup`, including the `--fresh` flag.
- **Quick Start** rewritten to point at the framework walkthroughs and services walkthrough instead of pretending three commands cover everything.
- **README** gains a lifecycle snippet under Quick Start and a lifecycle docs link.
- **Sidebar** adds *Framework walkthroughs* and *Add-ons* groups under Getting Started, and *Start, Stop & Autostart* at the top of Usage.

Each framework walkthrough also has an MCP tip callout in the intro and an AI Integration entry in Next steps so MCP-curious users have pointers without bloating the step-by-step flow.