### PR TITLE
release: v1.9.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,34 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.9.0] — 2026-04-09
+
+### Added
+
+- **Service presets** — opt-in bundled service definitions surfaced via `lerd service preset` (list / install) and a `+` picker on the Web UI's Services tab. First batch ships `phpmyadmin`, `pgadmin`, `mongo`, `mongo-express`, and `stripe-mock` as embedded YAML that becomes a normal custom service once installed, so every existing `lerd service` subcommand (start/stop/remove/expose/pin) keeps working unchanged. Installed presets are filtered out of the picker; after install the user lands on the new service detail panel and the service auto-starts.
+- **Multi-version preset families** — presets can declare multiple versions in a single YAML (e.g. `mysql` 8.0/8.4/9.0, `mariadb` 10.11/11.4) and `lerd service preset` shows version pills on `list`, prompts for a version on install, and persists the chosen tag in `.lerd.yaml`. Family discovery groups versions by base name in both the CLI list and the Web UI picker.
+- **Preset MCP tools** — `service_preset_list` and `service_preset_install` expose the preset catalog and install flow to AI assistants, sharing the install path with the CLI through `serviceops.InstallPresetByName`. Re-run `lerd mcp:inject` in existing projects to pick up the new tool descriptions.
+- **Custom service `files:` field** — declare inline-rendered config files materialised on the host and bind-mounted into the container, with optional `mode` (octal perms) and `chown: true` (adds `:U` so podman re-chowns to the container's non-root uid). Used by the `pgadmin` preset to ship a `servers.json` + `pgpass` that autoconnects to `lerd-postgres`. Files re-render on every `lerd service start` so editing the YAML and restarting picks up changes.
+- **Custom service `connection_url:` field** — non-built-in databases now get the same "Open connection URL" link surface as the built-in mysql/postgres services. The detail panel renders a real `<a>` element pointing at `mysql://`, `postgresql://`, or `mongodb://` so right-click "Copy link" works and left-click hands the URL to the user's registered DB client (DBeaver, TablePlus, Compass, etc.).
+- **Recursive `service start`** — `lerd service start <svc>` now ensures every entry in `depends_on` is up first, recursively, in both the CLI and the Web UI. Pairs with the existing recursive stop that takes dependents down before the parent. Starting any preset that depends on a built-in (`phpmyadmin`, `pgadmin`) auto-starts the database.
+- **Preset dependency gating at install time** — installing a preset whose dependency is another *custom* service (e.g. `mongo-express` on `mongo`) is rejected with a clear error until the dependency is installed first. Built-in deps (mysql, postgres) are auto-satisfied. The Web UI's Add button is disabled with a matching amber "install mongo first" hint.
+- **Database service quality-of-life suggestions** — the detail panel of every database service (mysql, postgres, and an installed `mongo`) now shows a sky-blue suggestion banner offering to install its paired admin UI when missing. The banner is dismissable per-preset and the dismissal persists in `localStorage`. When the admin UI is installed, the header gains an Open phpMyAdmin / pgAdmin / Mongo Express button that auto-starts the admin service if needed.
+- **Lerd health dot in the Web UI** — the Lerd entry in the System list now reflects overall core health (green when DNS / nginx / watcher are all running, red when any is down, yellow when an update is available) instead of only the update flag. The lerd logo in the left rail gains a small yellow badge when an update is available and is clickable, jumping straight to the Lerd entry.
+- **One-click update terminal** — when an update is available, the Lerd entry exposes an "Open terminal & update" button that POSTs to the new loopback-only `/api/lerd/update-terminal` endpoint, which spawns the user's preferred terminal emulator (kitty / foot / alacritty / wezterm / ghostty / konsole / gnome-terminal / xfce4-terminal / tilix / terminator / xterm) running `lerd update` so the host can prompt for sudo and stream download progress.
+- **Getting-started walkthroughs** — new `docs/getting-started/laravel.md`, `symfony.md`, `wordpress.md`, and `services.md` pages plus a `docs/usage/lifecycle.md` reference covering how Lerd's units come up at boot and how `start` / `stop` / `autostart` interact.
+
+### Changed
+
+- **`autostart` is now a single coherent switch** — `cfg.Autostart.Disabled` is the canonical source of truth for whether lerd comes up at login. Toggling it enables/disables every `lerd-*.container` quadlet (by adding/stripping the `[Install]` section so the podman generator stops emitting the `default.target.wants` symlink) and every `lerd-*.service` unit (UI, watcher, per-site worker/queue/schedule/horizon/reverb/stripe) together. Toggling does not stop or start anything currently running — the user is in the middle of working and a session-level switch should not yank infrastructure out from under them. Use `lerd start` / `lerd stop` for live state.
+- **`lerd autostart tray` removed** — the tray is now governed by the same single autostart switch as everything else. The standalone `autostart tray` subcommand and the `lerd-autostart.service` unit file are gone.
+- **Service display labels** — the Web UI now shows phpMyAdmin, pgAdmin, MySQL, PostgreSQL, Meilisearch, Mailpit, RustFS, MongoDB, Mongo Express, and Stripe Mock with their proper casing.
+
+### Fixed
+
+- **Tray autostart was broken** — the tray autostart path went through the now-removed `lerd-autostart.service` shim and stopped enabling on fresh installs. The unified autostart toggle now covers the tray too, the per-unit autostart toggle is wired up correctly, and `lerd install` honours the persisted autostart state.
+
+---
+
 ## [1.8.0] — 2026-04-09
 
 ### Added

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -479,6 +479,29 @@ service_start(name: "phpmyadmin")   // starts mysql first, then phpmyadmin
 
 ` + bt + `service_remove` + bt + ` stops and deregisters a custom service. Persistent data is NOT deleted.
 
+### ` + bt + `service_preset_list` + bt + ` / ` + bt + `service_preset_install` + bt + `
+Lerd ships a small catalogue of opt-in **service presets** — bundled YAML definitions for common dev services that become normal custom services once installed. Use ` + bt + `service_preset_list` + bt + ` to see what's available and ` + bt + `service_preset_install` + bt + ` to install one. Prefer this over hand-rolling ` + bt + `service_add` + bt + ` for anything in the catalogue: presets ship sane defaults, dependency wiring, dashboard URLs, and (where relevant) rendered config files.
+
+Current catalogue: ` + bt + `phpmyadmin` + bt + ` (depends on built-in mysql), ` + bt + `pgadmin` + bt + ` (depends on built-in postgres, ships a pre-loaded servers.json + pgpass), ` + bt + `mongo` + bt + `, ` + bt + `mongo-express` + bt + ` (depends on the ` + bt + `mongo` + bt + ` preset), ` + bt + `stripe-mock` + bt + `. Some presets (e.g. ` + bt + `mysql` + bt + `, ` + bt + `mariadb` + bt + `) declare multiple versions in a single family — pass ` + bt + `version` + bt + ` to pick one, otherwise lerd installs the family default.
+
+Arguments:
+- ` + bt + `service_preset_list()` + bt + ` — returns each preset with its image, declared versions, dependencies, dashboard URL, and an ` + bt + `installed` + bt + ` flag
+- ` + bt + `service_preset_install(name, version?)` + bt + ` — installs a preset by name; ` + bt + `version` + bt + ` is required only for multi-version families when you want a specific tag
+
+Examples:
+` + "```" + `
+service_preset_list()
+service_preset_install(name: "phpmyadmin")           // adds phpmyadmin, mysql is built-in
+service_preset_install(name: "mongo")                // install mongo first…
+service_preset_install(name: "mongo-express")        // …then mongo-express (gated otherwise)
+service_preset_install(name: "mysql", version: "8.4")
+service_start(name: "phpmyadmin")                    // mysql is started automatically
+` + "```" + `
+
+**Dependency gating:** installing a preset whose dependency is another *custom* service (e.g. ` + bt + `mongo-express` + bt + ` on ` + bt + `mongo` + bt + `) is rejected with a clear error until the dependency is installed first. Built-in deps (mysql, postgres) are auto-satisfied.
+
+Once installed, presets are normal custom services — manage them with ` + bt + `service_start` + bt + `, ` + bt + `service_stop` + bt + `, ` + bt + `service_remove` + bt + `, ` + bt + `service_expose` + bt + `, ` + bt + `service_pin` + bt + `.
+
 ### ` + bt + `service_env` + bt + `
 Return the recommended Laravel ` + bt + `.env` + bt + ` connection variables for a service — built-in or custom — as a key/value map. Use this when you need to inspect or manually apply connection settings without running ` + bt + `env_setup` + bt + `.
 
@@ -961,6 +984,8 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `service_start` + bt + ` | Start a built-in or custom service |
 | ` + bt + `service_stop` + bt + ` | Stop a service |
 | ` + bt + `service_add` + bt + ` | Register a new custom OCI service (MongoDB, RabbitMQ, …); supports ` + bt + `depends_on` + bt + ` for service dependencies |
+| ` + bt + `service_preset_list` + bt + ` | List bundled service presets (phpmyadmin, pgadmin, mongo, mongo-express, stripe-mock, …) with versions and install state |
+| ` + bt + `service_preset_install` + bt + ` | Install a bundled preset by name (` + bt + `version` + bt + ` for multi-version families); becomes a normal custom service |
 | ` + bt + `service_remove` + bt + ` | Stop and deregister a custom service |
 | ` + bt + `service_expose` + bt + ` | Add or remove an extra published port on a built-in service (persisted) |
 | ` + bt + `service_env` + bt + ` | Return the recommended ` + bt + `.env` + bt + ` connection variables for a service |
@@ -1016,6 +1041,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - ` + bt + `site_pause` + bt + ` / ` + bt + `site_unpause` + bt + ` free up resources for sites not in active use without unlinking them; paused state persists across restarts
 - ` + bt + `service_pin` + bt + ` keeps a service always running regardless of which sites are active; use for shared services like MySQL or Redis
 - ` + bt + `service_add` + bt + ` supports ` + bt + `depends_on` + bt + ` (array of service names): starting a dependency auto-starts the dependent service; stopping a dependency cascade-stops the dependent first; starting the dependent ensures dependencies start first
+- Prefer ` + bt + `service_preset_install` + bt + ` over hand-rolling ` + bt + `service_add` + bt + ` for anything in the bundled catalogue (` + bt + `phpmyadmin` + bt + `, ` + bt + `pgadmin` + bt + `, ` + bt + `mongo` + bt + `, ` + bt + `mongo-express` + bt + `, ` + bt + `stripe-mock` + bt + `, ` + bt + `mysql` + bt + `, ` + bt + `mariadb` + bt + `, …) — presets ship sane defaults, dependency wiring, dashboards, and rendered config files; call ` + bt + `service_preset_list` + bt + ` first to see what's available; multi-version families take a ` + bt + `version` + bt + ` argument; presets whose dependency is another custom service (e.g. ` + bt + `mongo-express` + bt + ` on ` + bt + `mongo` + bt + `) require the dep installed first
 - ` + bt + `project_new` + bt + ` requires an absolute ` + bt + `path` + bt + ` and runs the framework's ` + bt + `create` + bt + ` command; follow it with ` + bt + `site_link` + bt + ` + ` + bt + `env_setup` + bt + ` to register and configure the new project
 - ` + bt + `framework_add` + bt + ` accepts ` + bt + `workers` + bt + ` (map) and ` + bt + `setup` + bt + ` (array) — both support an optional ` + bt + `check` + bt + ` field (` + bt + `{file}` + bt + ` or ` + bt + `{composer}` + bt + `) to conditionally show based on project deps; for Laravel, custom setup commands replace built-in storage:link/migrate/db:seed
 - Framework env vars support service version placeholders: ` + bt + `{{mysql_version}}` + bt + `, ` + bt + `{{postgres_version}}` + bt + `, ` + bt + `{{redis_version}}` + bt + `, ` + bt + `{{meilisearch_version}}` + bt + ` — resolved from the running service image tag

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.8.0"
+	Version = "1.9.0"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

- Service presets — bundled phpmyadmin/pgadmin/mongo/mongo-express/stripe-mock plus multi-version families (mysql, mariadb), surfaced in the CLI, the Web UI Services tab, and via new `service_preset_list` / `service_preset_install` MCP tools. Custom services gain `files:` (rendered config files with mode/chown) and `connection_url:` (DB client deep-links). `service start` now recursively starts dependencies, and dependency-gated installs reject non-built-in deps with a clear error.
- Web UI lerd health dot, update badge, and one-click "Open terminal & update" button (loopback-only `/api/lerd/update-terminal` spawns the user's terminal emulator).
- `autostart` consolidated into a single coherent switch (`cfg.Autostart.Disabled`) covering all `lerd-*` quadlets, services, and the tray together. The standalone `lerd autostart tray` subcommand and `lerd-autostart.service` unit are gone. Fixes the broken tray autostart shim.
- Getting-started walkthroughs for Laravel / Symfony / WordPress / services and a new `docs/usage/lifecycle.md` reference.
- MCP skill content (`claudeSkillContent` + `junieGuidelinesSection`) updated to describe the new preset tools — re-run `lerd mcp:inject` in existing projects to pick up the new descriptions.