### PR TITLE
chore: reword tagline to drop 'Laravel Herd for Linux'

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -109,7 +109,7 @@ release:
   header: |
     ## Lerd {{ .Version }}
 
-    Laravel Herd for Linux — Podman-native dev environment.
+    Lerd — Podman-powered local PHP dev environment for Linux.
 
     ### Install / Upgrade
 

--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -24,7 +24,7 @@ import (
 func main() {
 	root := &cobra.Command{
 		Use:     "lerd",
-		Short:   "Laravel Herd for Linux — Podman-powered local dev environment",
+		Short:   "Lerd — Podman-powered local PHP dev environment for Linux",
 		Version: version.String(),
 	}
 

--- a/install.sh
+++ b/install.sh
@@ -473,7 +473,7 @@ main() {
   echo "  ███████╗███████╗██║  ██║██████╔╝"
   echo "  ╚══════╝╚══════╝╚═╝  ╚═╝╚═════╝ "
   echo -e "${RESET}"
-  echo "  Laravel Herd for Linux — Podman-native dev environment"
+  echo "  Lerd — Podman-powered local PHP dev environment for Linux"
   echo "  https://github.com/${REPO}"
   echo ""
 


### PR DESCRIPTION
## Summary

- Replaces the `Laravel Herd for Linux — …` tagline with `Lerd — Podman-powered local PHP dev environment for Linux` in the three places where it surfaces directly to users: the `install.sh` banner, the `lerd --help` short description, and the goreleaser GitHub release notes header.
- Other Herd references (the comparison page, the README comparison table, the MCP skill's "similar to Laravel Herd" framing, historical changelog entries, applog test fixtures) are intentionally left alone — those are legitimate comparisons or fixed content, not tagline copy.