### PR TITLE
fix(workers): wait for backing service via systemd deps; restore preset service quadlets

### DIFF
--- a/docs/getting-started/services.md
+++ b/docs/getting-started/services.md
@@ -1,6 +1,6 @@
 # Services walkthrough
 
-Lerd ships with **MySQL, PostgreSQL, Redis, Meilisearch, RustFS, and Mailpit** built in. Anything else — MongoDB, phpMyAdmin, pgAdmin, Elasticsearch, MinIO, RabbitMQ — runs as a **custom service**: a YAML file dropped into `~/.config/lerd/services/`, registered with one command, and managed by `lerd service start/stop/list` exactly like the built-ins.
+Lerd ships with **MySQL, PostgreSQL, Redis, Meilisearch, RustFS, and Mailpit** built in. For a curated set of common extras (**MongoDB, phpMyAdmin, pgAdmin, Mongo Express, stripe-mock, MariaDB, alternative MySQL versions**) lerd ships **bundled presets** you can install with one command. Anything not on either list runs as a **custom service**: a YAML file dropped into `~/.config/lerd/services/`, registered with one command, and managed by `lerd service start/stop/list` exactly like the built-ins.
 
 ::: info Prerequisites
 You've already run `lerd install` once on this machine. If not, see [Installation](installation.md).
@@ -14,7 +14,20 @@ After running `lerd mcp:enable-global`, your AI assistant can call `service_add`
 
 ## How it works (30 seconds)
 
-Three steps for any custom service:
+For a bundled preset:
+
+```bash
+# Browse the catalogue
+lerd service preset
+
+# Install one (becomes a normal custom service)
+lerd service preset phpmyadmin
+
+# Start it
+lerd service start phpmyadmin
+```
+
+For everything else, three steps:
 
 ```bash
 # 1. Save the YAML somewhere
@@ -27,105 +40,57 @@ lerd service add ~/.config/lerd/services/<name>.yaml
 lerd service start <name>
 ```
 
-After step 2, the service appears in `lerd service list`, the Web UI Services panel, and `lerd start` / `lerd stop` cycles.
+Either way, the service appears in `lerd service list`, the Web UI Services panel, and `lerd start` / `lerd stop` cycles.
 
 For the full YAML schema (env vars, `depends_on`, `site_init`, `{{site}}` placeholders, etc.) see [Services reference](../usage/services.md#yaml-schema).
 
 ---
 
-## Recipe: MongoDB
-
-```yaml
-# ~/.config/lerd/services/mongodb.yaml
-name: mongodb
-image: docker.io/library/mongo:7
-description: "MongoDB document store"
-ports:
-  - 27017:27017
-environment:
-  MONGO_INITDB_ROOT_USERNAME: root
-  MONGO_INITDB_ROOT_PASSWORD: lerd
-data_dir: /data/db
-env_vars:
-  - "MONGO_DATABASE={{site}}"
-  - "MONGO_URI=mongodb://root:lerd@lerd-mongodb:27017/{{site}}?authSource=admin"
-env_detect:
-  key: MONGO_URI
-  value_prefix: "mongodb://"
-site_init:
-  exec: >
-    mongosh admin -u root -p lerd --eval
-    "db.getSiblingDB('{{site}}').createCollection('_init');
-     db.getSiblingDB('{{site_testing}}').createCollection('_init')"
-```
+## Recipe: MongoDB (preset)
 
 ```bash
-lerd service add ~/.config/lerd/services/mongodb.yaml
-lerd service start mongodb
+lerd service preset mongo
+lerd service start mongo
 ```
 
 | From | Host |
 |---|---|
-| Your app (PHP-FPM) | `lerd-mongodb:27017` |
+| Your app (PHP-FPM) | `lerd-mongo:27017` |
 | Host tools (Compass, mongosh) | `127.0.0.1:27017` |
 | User / password | `root` / `lerd` |
 
-When `lerd env` runs in a project that has `MONGO_URI=mongodb://...` in its `.env`, the connection string is rewritten to point at `lerd-mongodb` and a per-site database is created automatically.
+The preset ships with `env_detect` and `site_init` already wired up, so when `lerd env` runs in a project that has `MONGO_DSN=mongodb://...` in its `.env`, the connection string is rewritten to point at `lerd-mongo` and a per-site database is created automatically.
+
+For a Mongo web UI, install the paired preset:
+
+```bash
+lerd service preset mongo-express
+lerd service start mongo-express
+```
+
+It depends on `mongo`, so the database is started first automatically. Open `http://localhost:8082`.
 
 ---
 
-## Recipe: phpMyAdmin
-
-```yaml
-# ~/.config/lerd/services/phpmyadmin.yaml
-name: phpmyadmin
-image: docker.io/phpmyadmin:latest
-description: "phpMyAdmin web interface for MySQL"
-ports:
-  - 8080:80
-environment:
-  PMA_HOST: lerd-mysql
-  PMA_USER: root
-  PMA_PASSWORD: lerd
-depends_on:
-  - mysql
-dashboard: http://localhost:8080
-```
+## Recipe: phpMyAdmin (preset)
 
 ```bash
-lerd service add ~/.config/lerd/services/phpmyadmin.yaml
+lerd service preset phpmyadmin
 lerd service start phpmyadmin
 ```
 
-Open `http://localhost:8080`. Because of `depends_on: mysql`, `lerd service start phpmyadmin` boots MySQL first if it isn't already running, and `lerd service stop mysql` cascades down to phpMyAdmin.
+Open `http://localhost:8080`. The preset declares `depends_on: mysql`, so `lerd service start phpmyadmin` boots MySQL first if it isn't already running, and `lerd service stop mysql` cascades down to phpMyAdmin. Sign-in is auto-handled against `lerd-mysql` as `root` / `lerd`.
 
 ---
 
-## Recipe: pgAdmin
-
-```yaml
-# ~/.config/lerd/services/pgadmin.yaml
-name: pgadmin
-image: docker.io/dpage/pgadmin4:latest
-description: "pgAdmin 4 web interface for PostgreSQL"
-ports:
-  - 8081:80
-environment:
-  PGADMIN_DEFAULT_EMAIL: admin@lerd.test
-  PGADMIN_DEFAULT_PASSWORD: lerd
-  PGADMIN_CONFIG_SERVER_MODE: "False"
-data_dir: /var/lib/pgadmin
-depends_on:
-  - postgres
-dashboard: http://localhost:8081
-```
+## Recipe: pgAdmin (preset)
 
 ```bash
-lerd service add ~/.config/lerd/services/pgadmin.yaml
+lerd service preset pgadmin
 lerd service start pgadmin
 ```
 
-Open `http://localhost:8081`, log in with `admin@lerd.test` / `lerd`, then add a server with host `lerd-postgres`, port `5432`, user `postgres`, password `lerd`.
+Open `http://localhost:8081`, log in with `admin@pgadmin.org` / `lerd`. The preset ships with a pre-loaded `Lerd Postgres` connection (via a bundled `servers.json` + `pgpass`) so you don't need to add a server manually. Server mode is disabled and there is no master password. The preset declares `depends_on: postgres`, so PostgreSQL starts first automatically.
 
 ---
 
@@ -139,10 +104,10 @@ name: adminer
 image: docker.io/library/adminer:latest
 description: "Universal database web client (MySQL + PostgreSQL + more)"
 ports:
-  - 8082:8080
+  - 8083:8080
 depends_on:
   - mysql
-dashboard: http://localhost:8082
+dashboard: http://localhost:8083
 ```
 
 ```bash
@@ -150,7 +115,7 @@ lerd service add ~/.config/lerd/services/adminer.yaml
 lerd service start adminer
 ```
 
-Open `http://localhost:8082`. Choose the system (MySQL → host `lerd-mysql`, or PostgreSQL → host `lerd-postgres`), then user `root` / `postgres` and password `lerd`.
+Open `http://localhost:8083`. Choose the system (MySQL → host `lerd-mysql`, or PostgreSQL → host `lerd-postgres`), then user `root` / `postgres` and password `lerd`.
 
 ---
 
@@ -225,7 +190,7 @@ Management UI at `http://localhost:15672` (`lerd` / `lerd`).
 lerd service list
 ```
 
-Each registered custom service shows up with a `[custom]` marker. `[pinned]` means it stays running across `lerd start`/`lerd stop` cycles. Indented sub-lines show dependency or auto-stop reasons.
+Each registered service shows up with a `[preset]` marker if it came from a bundled preset, or `[custom]` if it was added from a YAML file. `[pinned]` means it stays running across `lerd start`/`lerd stop` cycles. Indented sub-lines show dependency or auto-stop reasons.
 
 ```bash
 lerd service status mongodb     # systemd unit status
@@ -239,14 +204,14 @@ The data directory at `~/.local/share/lerd/data/<name>/` is **not** deleted by `
 
 ## Per-site auto-injection
 
-Three of the recipes above (`mongodb`, `elasticsearch`, `rabbitmq`) include `env_detect` and `env_vars`. When you run `lerd env` in a project that already references one of those services in its `.env` (e.g. `MONGO_URI=` is set), lerd:
+Three of the recipes above (`mongo` preset, `elasticsearch`, `rabbitmq`) declare `env_detect` and `env_vars`. When you run `lerd env` in a project that already references one of those services in its `.env` (e.g. `MONGO_DSN=` is set), lerd:
 
 1. Starts the service if it isn't already running
 2. Substitutes <code v-pre>{{site}}</code> in the env vars with the project's site handle
 3. Writes the resulting variables into the project's `.env`
-4. Runs `site_init.exec` inside the container (MongoDB recipe) to create per-site databases
+4. Runs `site_init.exec` inside the container (mongo preset) to create per-site databases
 
-This means dropping the YAML once is enough — every project that needs the service gets wired up automatically on `lerd env` (which `lerd init` and `lerd setup` both call).
+This means installing the preset (or dropping the YAML) once is enough — every project that needs the service gets wired up automatically on `lerd env` (which `lerd init` and `lerd setup` both call).
 
 ---
 

--- a/internal/cli/horizon.go
+++ b/internal/cli/horizon.go
@@ -98,25 +98,8 @@ func HorizonStartForSite(siteName, sitePath, phpVersion string) error {
 			fmt.Printf("[WARN] stopping queue worker before horizon: %v\n", err)
 		}
 	}
-	versionShort := strings.ReplaceAll(phpVersion, ".", "")
-	fpmUnit := "lerd-php" + versionShort + "-fpm"
-	container := "lerd-php" + versionShort + "-fpm"
 	unitName := "lerd-horizon-" + siteName
-
-	unit := fmt.Sprintf(`[Unit]
-Description=Lerd Horizon (%s)
-After=network.target %s.service
-BindsTo=%s.service
-
-[Service]
-Type=simple
-Restart=always
-RestartSec=5
-ExecStart=podman exec -w %s %s php artisan horizon
-
-[Install]
-WantedBy=default.target
-`, siteName, fpmUnit, fpmUnit, sitePath, container)
+	unit := buildHorizonUnit(siteName, sitePath, phpVersion)
 
 	changed, err := lerdSystemd.WriteServiceIfChanged(unitName, unit)
 	if err != nil {
@@ -136,6 +119,30 @@ WantedBy=default.target
 	fmt.Printf("Horizon started for %s\n", siteName)
 	fmt.Printf("  Logs: journalctl --user -u %s -f\n", unitName)
 	return nil
+}
+
+// buildHorizonUnit renders the Horizon systemd unit body. Horizon always
+// uses Redis so lerd-redis is in After=/Wants= alongside the FPM container.
+func buildHorizonUnit(siteName, sitePath, phpVersion string) string {
+	versionShort := strings.ReplaceAll(phpVersion, ".", "")
+	fpmUnit := "lerd-php" + versionShort + "-fpm"
+	container := "lerd-php" + versionShort + "-fpm"
+
+	return fmt.Sprintf(`[Unit]
+Description=Lerd Horizon (%s)
+After=network.target %s.service lerd-redis.service
+Wants=%s.service lerd-redis.service
+BindsTo=%s.service
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5
+ExecStart=podman exec -w %s %s php artisan horizon
+
+[Install]
+WantedBy=default.target
+`, siteName, fpmUnit, fpmUnit, fpmUnit, sitePath, container)
 }
 
 // HorizonStopForSite stops and removes the Horizon unit for the named site.

--- a/internal/cli/queue.go
+++ b/internal/cli/queue.go
@@ -127,37 +127,8 @@ func runQueueStop() error {
 }
 
 func queueStartExplicit(siteName, sitePath, phpVersion, queue string, tries, timeout int) error {
-	// Pre-flight: if the site uses Redis as its queue connection, make sure
-	// lerd-redis is actually running. Without it the queue worker fails immediately
-	// with a cryptic PHP "getaddrinfo for lerd-redis failed" DNS error.
-	envPath := filepath.Join(sitePath, ".env")
-	if envfile.ReadKey(envPath, "QUEUE_CONNECTION") == "redis" {
-		if running, _ := podman.ContainerRunning("lerd-redis"); !running {
-			return fmt.Errorf("queue worker requires Redis (QUEUE_CONNECTION=redis in .env) but lerd-redis is not running\nStart it first: lerd services start redis")
-		}
-	}
-
-	versionShort := strings.ReplaceAll(phpVersion, ".", "")
-	fpmUnit := "lerd-php" + versionShort + "-fpm"
-	container := "lerd-php" + versionShort + "-fpm"
 	unitName := "lerd-queue-" + siteName
-
-	artisanArgs := fmt.Sprintf("queue:work --queue=%s --tries=%d --timeout=%d", queue, tries, timeout)
-
-	unit := fmt.Sprintf(`[Unit]
-Description=Lerd Queue Worker (%s)
-After=network.target %s.service
-BindsTo=%s.service
-
-[Service]
-Type=simple
-Restart=always
-RestartSec=5
-ExecStart=podman exec -w %s %s php artisan %s
-
-[Install]
-WantedBy=default.target
-`, siteName, fpmUnit, fpmUnit, sitePath, container, artisanArgs)
+	unit := buildQueueUnit(siteName, sitePath, phpVersion, queue, tries, timeout)
 
 	changed, err := lerdSystemd.WriteServiceIfChanged(unitName, unit)
 	if err != nil {
@@ -184,6 +155,56 @@ WantedBy=default.target
 // QueueStartForSite starts a queue worker for the given site with default settings.
 func QueueStartForSite(siteName, sitePath, phpVersion string) error {
 	return queueStartExplicit(siteName, sitePath, phpVersion, "default", 3, 60)
+}
+
+// buildQueueUnit renders the systemd unit body for a queue worker. Pure
+// function so the dep wiring can be exercised in tests.
+func buildQueueUnit(siteName, sitePath, phpVersion, queue string, tries, timeout int) string {
+	versionShort := strings.ReplaceAll(phpVersion, ".", "")
+	fpmUnit := "lerd-php" + versionShort + "-fpm"
+	container := "lerd-php" + versionShort + "-fpm"
+	artisanArgs := fmt.Sprintf("queue:work --queue=%s --tries=%d --timeout=%d", queue, tries, timeout)
+
+	// Wants= the backing service so systemd pulls it in; Restart=always covers
+	// the ready-window between activation and the container accepting connections.
+	depUnits := append([]string{fpmUnit + ".service"}, queueDependencyUnits(sitePath)...)
+	afterLine := "After=network.target " + strings.Join(depUnits, " ")
+	wantsLine := "Wants=" + strings.Join(depUnits, " ")
+
+	return fmt.Sprintf(`[Unit]
+Description=Lerd Queue Worker (%s)
+%s
+%s
+BindsTo=%s.service
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5
+ExecStart=podman exec -w %s %s php artisan %s
+
+[Install]
+WantedBy=default.target
+`, siteName, afterLine, wantsLine, fpmUnit, sitePath, container, artisanArgs)
+}
+
+// queueDependencyUnits returns the lerd service unit(s) the queue worker
+// needs based on QUEUE_CONNECTION (and DB_CONNECTION). FPM is added by the
+// caller. Returns nil for sync / sqs / sqlite / unreadable .env.
+func queueDependencyUnits(sitePath string) []string {
+	envPath := filepath.Join(sitePath, ".env")
+	switch envfile.ReadKey(envPath, "QUEUE_CONNECTION") {
+	case "redis":
+		return []string{"lerd-redis.service"}
+	case "database":
+		switch envfile.ReadKey(envPath, "DB_CONNECTION") {
+		case "mysql", "mariadb":
+			return []string{"lerd-mysql.service"}
+		case "pgsql", "pgsql_pdo", "postgres":
+			return []string{"lerd-postgres.service"}
+		}
+	}
+	return nil
 }
 
 // QueueRestartForSite signals the Laravel queue worker to gracefully restart by

--- a/internal/cli/queue_test.go
+++ b/internal/cli/queue_test.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTempEnv creates a temp dir with a .env file containing the given
+// key/value pairs and returns its path.
+func writeTempEnv(t *testing.T, kv map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	var b strings.Builder
+	for k, v := range kv {
+		b.WriteString(k)
+		b.WriteString("=")
+		b.WriteString(v)
+		b.WriteString("\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(b.String()), 0644); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	return dir
+}
+
+func TestQueueDependencyUnits(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want []string
+	}{
+		{
+			name: "redis backend",
+			env:  map[string]string{"QUEUE_CONNECTION": "redis"},
+			want: []string{"lerd-redis.service"},
+		},
+		{
+			name: "database backend with mysql",
+			env:  map[string]string{"QUEUE_CONNECTION": "database", "DB_CONNECTION": "mysql"},
+			want: []string{"lerd-mysql.service"},
+		},
+		{
+			name: "database backend with postgres",
+			env:  map[string]string{"QUEUE_CONNECTION": "database", "DB_CONNECTION": "pgsql"},
+			want: []string{"lerd-postgres.service"},
+		},
+		{
+			name: "database backend with sqlite has no lerd service dep",
+			env:  map[string]string{"QUEUE_CONNECTION": "database", "DB_CONNECTION": "sqlite"},
+			want: nil,
+		},
+		{
+			name: "sync backend has no service dep",
+			env:  map[string]string{"QUEUE_CONNECTION": "sync"},
+			want: nil,
+		},
+		{
+			name: "external backend has no local service dep",
+			env:  map[string]string{"QUEUE_CONNECTION": "sqs"},
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sitePath := writeTempEnv(t, tc.env)
+			got := queueDependencyUnits(sitePath)
+			if !equalStringSlices(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Missing .env happens during install-time restore on a freshly-linked
+// project before env_setup has run.
+func TestQueueDependencyUnits_NoEnv(t *testing.T) {
+	dir := t.TempDir() // no .env at all
+	if got := queueDependencyUnits(dir); got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+}
+
+// Regression for the bug where install-time restore couldn't recreate the
+// queue unit for QUEUE_CONNECTION=redis sites because the old preflight
+// rejected the write before lerd-redis was up.
+func TestBuildQueueUnit_RedisBackendRendersDependencies(t *testing.T) {
+	sitePath := writeTempEnv(t, map[string]string{"QUEUE_CONNECTION": "redis"})
+	unit := buildQueueUnit("whitewaters", sitePath, "8.4", "default", 3, 60)
+
+	mustContain(t, unit, "Description=Lerd Queue Worker (whitewaters)")
+	mustContain(t, unit, "After=network.target lerd-php84-fpm.service lerd-redis.service")
+	mustContain(t, unit, "Wants=lerd-php84-fpm.service lerd-redis.service")
+	mustContain(t, unit, "BindsTo=lerd-php84-fpm.service")
+	mustContain(t, unit, "Restart=always")
+	mustContain(t, unit, "ExecStart=podman exec -w "+sitePath+" lerd-php84-fpm php artisan queue:work --queue=default --tries=3 --timeout=60")
+	mustContain(t, unit, "WantedBy=default.target")
+}
+
+func TestBuildQueueUnit_SyncBackendOmitsServiceDep(t *testing.T) {
+	sitePath := writeTempEnv(t, map[string]string{"QUEUE_CONNECTION": "sync"})
+	unit := buildQueueUnit("astrolov", sitePath, "8.4", "default", 3, 60)
+
+	mustContain(t, unit, "After=network.target lerd-php84-fpm.service")
+	mustContain(t, unit, "Wants=lerd-php84-fpm.service")
+	if strings.Contains(unit, "lerd-redis.service") {
+		t.Errorf("sync backend should not depend on redis, unit:\n%s", unit)
+	}
+}
+
+func TestBuildQueueUnit_DatabaseBackendUsesDBConnection(t *testing.T) {
+	sitePath := writeTempEnv(t, map[string]string{
+		"QUEUE_CONNECTION": "database",
+		"DB_CONNECTION":    "pgsql",
+	})
+	unit := buildQueueUnit("admin-astrolov", sitePath, "8.3", "default", 3, 60)
+
+	mustContain(t, unit, "After=network.target lerd-php83-fpm.service lerd-postgres.service")
+	mustContain(t, unit, "Wants=lerd-php83-fpm.service lerd-postgres.service")
+}
+
+func TestBuildHorizonUnit_AlwaysDependsOnRedis(t *testing.T) {
+	unit := buildHorizonUnit("score-diviner", "/home/u/score-diviner", "8.4")
+
+	mustContain(t, unit, "Description=Lerd Horizon (score-diviner)")
+	mustContain(t, unit, "After=network.target lerd-php84-fpm.service lerd-redis.service")
+	mustContain(t, unit, "Wants=lerd-php84-fpm.service lerd-redis.service")
+	mustContain(t, unit, "BindsTo=lerd-php84-fpm.service")
+	mustContain(t, unit, "ExecStart=podman exec -w /home/u/score-diviner lerd-php84-fpm php artisan horizon")
+}
+
+func mustContain(t *testing.T, body, needle string) {
+	t.Helper()
+	if !strings.Contains(body, needle) {
+		t.Errorf("expected unit body to contain %q\n--- unit ---\n%s", needle, body)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -517,14 +517,21 @@ func restoreSiteInfrastructure() {
 			continue
 		}
 
-		// Restore service quadlets.
+		// Resolve() returns the rendered CustomService for inline + preset
+		// references (e.g. mariadb-11) and (nil, nil) for built-ins. Without
+		// it, preset references slipped through to the built-in template path.
 		for _, svc := range proj.Services {
 			if seenSvc[svc.Name] {
 				continue
 			}
 			seenSvc[svc.Name] = true
-			if svc.Custom != nil {
-				ensureCustomServiceQuadlet(svc.Custom) //nolint:errcheck
+			cs, err := svc.Resolve()
+			if err != nil {
+				fmt.Printf("[WARN] resolving service %q for %s: %v\n", svc.Name, s.Name, err)
+				continue
+			}
+			if cs != nil {
+				ensureCustomServiceQuadlet(cs) //nolint:errcheck
 			} else {
 				ensureServiceQuadlet(svc.Name) //nolint:errcheck
 			}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -146,7 +146,11 @@ func runStatus(_ *cobra.Command, _ []string) error {
 		}
 		installedCount++
 		status, _ := podman.UnitStatus(unit)
-		label := svc.Name + " [custom]"
+		tag := "[custom]"
+		if svc.Preset != "" {
+			tag = "[preset]"
+		}
+		label := svc.Name + " " + tag
 		switch status {
 		case "active":
 			ok2(label)


### PR DESCRIPTION
queue workers now wait for their backing service via systemd After and Wants instead of the old redis preflight, so queue and horizon declare lerd redis when the queue is redis, lerd mysql or lerd postgres when it's database, always lerd redis for horizon, all on top of the fpm container, with Restart=always covering the small ready window

restoreSiteInfrastructure now goes through ProjectService.Resolve so preset installed services like mariadb-11 get their quadlet regenerated on reinstall the same way inline custom services do

lerd status shows [preset] instead of [custom] for services that came from a bundled preset

extracted the queue and horizon unit body builders into pure functions and added tests for the dependency wiring