### PR TITLE
ci: auto-rebuild PHP images on upstream security updates

### DIFF
--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -7,6 +7,11 @@ on:
       - 'internal/podman/quadlets/lerd-php-fpm.Containerfile'
       - '.github/workflows/base-images.yml'
   workflow_dispatch:
+    inputs:
+      force_rebuild:
+        description: 'Force rebuild for upstream updates'
+        required: false
+        default: 'false'
 
 jobs:
   build:
@@ -67,12 +72,17 @@ jobs:
       - name: Check if image already exists
         id: check
         run: |
-          IMG="ghcr.io/geodro/lerd-php${{ steps.tag.outputs.php_short }}-fpm-base:${{ steps.tag.outputs.tag }}-${{ matrix.arch.name }}"
-          if docker manifest inspect "$IMG" > /dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Image already exists, skipping build."
-          else
+          if [ "${{ inputs.force_rebuild }}" = "true" ]; then
             echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Force rebuild requested, skipping existence check."
+          else
+            IMG="ghcr.io/geodro/lerd-php${{ steps.tag.outputs.php_short }}-fpm-base:${{ steps.tag.outputs.tag }}-${{ matrix.arch.name }}"
+            if docker manifest inspect "$IMG" > /dev/null 2>&1; then
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              echo "Image already exists, skipping build."
+            else
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Set up Docker Buildx
@@ -86,6 +96,7 @@ jobs:
           context: .
           file: /tmp/Containerfile
           push: true
+          pull: ${{ inputs.force_rebuild == 'true' }}
           platforms: linux/${{ matrix.arch.name }}
           tags: ghcr.io/geodro/lerd-php${{ steps.tag.outputs.php_short }}-fpm-base:${{ steps.tag.outputs.tag }}-${{ matrix.arch.name }}
           cache-from: type=gha,scope=php-${{ matrix.php }}-${{ matrix.arch.name }}
@@ -132,12 +143,17 @@ jobs:
       - name: Check if manifest already exists
         id: check
         run: |
-          IMG="ghcr.io/geodro/lerd-php${{ steps.tag.outputs.php_short }}-fpm-base:${{ steps.tag.outputs.tag }}"
-          if docker manifest inspect "$IMG" > /dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Manifest already exists, skipping."
-          else
+          if [ "${{ inputs.force_rebuild }}" = "true" ]; then
             echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Force rebuild requested, recreating manifest."
+          else
+            IMG="ghcr.io/geodro/lerd-php${{ steps.tag.outputs.php_short }}-fpm-base:${{ steps.tag.outputs.tag }}"
+            if docker manifest inspect "$IMG" > /dev/null 2>&1; then
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              echo "Manifest already exists, skipping."
+            else
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Create and push multi-arch manifest

--- a/.github/workflows/check-upstream-php.yml
+++ b/.github/workflows/check-upstream-php.yml
@@ -1,0 +1,71 @@
+name: Check Upstream PHP Updates
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.compare.outputs.changed }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore cached digests
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/php-digests
+          key: php-upstream-digests-dummy
+          restore-keys: php-upstream-digests-
+
+      - name: Check upstream digests
+        id: compare
+        run: |
+          mkdir -p /tmp/php-digests
+          CHANGED=""
+          for V in 8.1 8.2 8.3 8.4 8.5; do
+            CURRENT=$(docker buildx imagetools inspect \
+              "docker.io/library/php:${V}-fpm-alpine" \
+              --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"')
+
+            PREVIOUS=""
+            [ -f "/tmp/php-digests/${V}" ] && PREVIOUS=$(cat "/tmp/php-digests/${V}")
+
+            if [ -n "$CURRENT" ] && [ "$CURRENT" != "$PREVIOUS" ]; then
+              echo "PHP ${V}: upstream changed (${PREVIOUS:-none} -> ${CURRENT})"
+              CHANGED="${CHANGED}${V},"
+              echo "$CURRENT" > "/tmp/php-digests/${V}"
+            else
+              echo "PHP ${V}: no change"
+            fi
+          done
+          echo "changed=${CHANGED}" >> "$GITHUB_OUTPUT"
+
+      - name: Save updated digests
+        if: steps.compare.outputs.changed != ''
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/php-digests
+          key: php-upstream-digests-${{ github.run_id }}
+
+  trigger:
+    needs: check
+    if: needs.check.outputs.changed != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger base image rebuild
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'base-images.yml',
+              ref: 'main',
+              inputs: {
+                force_rebuild: 'true'
+              }
+            });


### PR DESCRIPTION
## Summary

Adds a daily scheduled workflow that checks if upstream php:X.Y-fpm-alpine images have been updated on Docker Hub. When a new PHP patch version is released (e.g. 8.4.19 to 8.4.20), it triggers a force rebuild of all base images on GHCR so security patches are picked up automatically.

The build workflow gains a force_rebuild input that skips image existence checks and pulls fresh base images.