### PR TITLE
feat(mcp): optimise tool responses for AI agents

### DIFF
--- a/docs/features/env-setup.md
+++ b/docs/features/env-setup.md
@@ -72,4 +72,15 @@ When everything is in sync:
 
 The command automatically discovers all `.env*` files in the project directory (`.env`, `.env.testing`, `.env.local`, etc.) and checks each one against `.env.example`. Only keys that differ in at least one file are shown.
 
-The command exits with a non-zero status when any `.env` file is missing a key defined in `.env.example` (✓ in `.env.example`, ✗ in an env file). Extra keys (present in an env file but not in `.env.example`) are reported but don't cause a failure.
+When called via the MCP server (AI assistants), `env_check` returns structured JSON instead of the formatted table:
+
+```json
+{
+  "in_sync": false,
+  "keys": [
+    {"key": "STRIPE_KEY", "in_example": true, "files": {".env": false, ".env.testing": false}},
+    {"key": "LEGACY_TOKEN", "in_example": false, "files": {".env": true, ".env.testing": false}}
+  ],
+  "out_of_sync_count": 3
+}
+```

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -79,7 +79,7 @@ Once the MCP server is connected, your AI assistant has access to:
 | `node_install` | Install a Node.js version via fnm (e.g. `"20"`, `"lts"`) |
 | `node_uninstall` | Uninstall a Node.js version via fnm |
 | `env_setup` | Configure `.env` for lerd: detects services, starts them, creates DB, sets APP_KEY and APP_URL |
-| `env_check` | Compare all `.env` files against `.env.example` and flag missing or extra keys |
+| `env_check` | Compare all `.env` files against `.env.example` and flag missing or extra keys (returns structured JSON) |
 | `site_link` | Register a directory as a lerd site — generates nginx vhost and `.test` domain |
 | `site_unlink` | Unregister a site and remove its nginx vhost (all domains) |
 | `site_domain_add` | Add an additional domain to a site (without TLD) |
@@ -124,9 +124,9 @@ Once the MCP server is connected, your AI assistant has access to:
 | `stripe_listen_stop` | Stop the Stripe webhook listener |
 | `logs` | Fetch container logs — defaults to current site's FPM; optionally specify nginx, service name, PHP version, or site name |
 | `status` | Health snapshot of DNS, nginx, PHP-FPM containers, and the watcher — use when a site isn't loading |
-| `doctor` | Full diagnostic: podman, systemd, DNS, ports, PHP images, config, updates — use when the user reports setup issues |
+| `doctor` | Full diagnostic as structured JSON: podman, systemd, DNS, ports, PHP images, config, updates — use when the user reports setup issues |
 | `which` | Show the resolved PHP version, Node version, document root, and nginx config for the current site |
-| `check` | Validate `.lerd.yaml` syntax, PHP version, services, and framework — reports OK/WARN/FAIL per field |
+| `check` | Validate `.lerd.yaml` as structured JSON: PHP version, services, framework — returns valid/errors/warnings with per-field status |
 
 ---
 

--- a/internal/cli/env_check.go
+++ b/internal/cli/env_check.go
@@ -14,9 +14,10 @@ import (
 // NewEnvCheckCmd returns the env:check command.
 func NewEnvCheckCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "env:check",
-		Short: "Compare all .env files against .env.example and flag missing keys",
-		RunE:  runEnvCheck,
+		Use:          "env:check",
+		Short:        "Compare all .env files against .env.example and flag missing keys",
+		SilenceUsage: true,
+		RunE:         runEnvCheck,
 	}
 }
 
@@ -217,9 +218,6 @@ func runEnvCheck(_ *cobra.Command, _ []string) error {
 	fmt.Println()
 	fmt.Printf("  %d key(s) out of sync\n", len(sortedKeys))
 
-	if totalMissing > 0 {
-		return fmt.Errorf("env check failed")
-	}
 	return nil
 }
 

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -559,7 +559,9 @@ app_url: http://myapp.test/api
 If the configured ` + bt + `app_url` + bt + ` happens to point at a domain that the conflict filter dropped, lerd silently falls through to the next precedence level so ` + bt + `.env` + bt + ` doesn't end up writing a hostname owned by another site.
 
 ### ` + bt + `env_check` + bt + `
-Compare all ` + bt + `.env` + bt + ` files (` + bt + `.env` + bt + `, ` + bt + `.env.testing` + bt + `, ` + bt + `.env.local` + bt + `, …) against ` + bt + `.env.example` + bt + ` and show a table of missing or extra keys. Useful for catching "works on my machine" bugs caused by env drift after pulling new code.
+Compare all ` + bt + `.env` + bt + ` files (` + bt + `.env` + bt + `, ` + bt + `.env.testing` + bt + `, ` + bt + `.env.local` + bt + `, …) against ` + bt + `.env.example` + bt + ` and return structured JSON with missing or extra keys. Useful for catching "works on my machine" bugs caused by env drift after pulling new code.
+
+Returns: ` + bt + `{"in_sync": bool, "keys": [{key, in_example, files: {filename: bool}}], "out_of_sync_count": N}` + bt + `
 
 Arguments:
 - ` + bt + `path` + bt + ` (optional): absolute path to the project root — defaults to the current working directory (or ` + bt + `LERD_SITE_PATH` + bt + ` if set by ` + bt + `mcp:inject` + bt + `)
@@ -756,7 +758,9 @@ Arguments:
 - ` + bt + `path` + bt + ` (optional): absolute path to the project root — defaults to the current working directory (or ` + bt + `LERD_SITE_PATH` + bt + ` if set by ` + bt + `mcp:inject` + bt + `)
 
 ### ` + bt + `check` + bt + `
-Validate a project's ` + bt + `.lerd.yaml` + bt + ` file. Checks YAML syntax, PHP version format and installation status, service definitions (built-in, custom, and inline), and framework references. Reports OK/WARN/FAIL per field with a summary.
+Validate a project's ` + bt + `.lerd.yaml` + bt + ` file. Returns structured JSON with per-field status (ok/warn/fail). Checks PHP version format and installation, service definitions (built-in, custom, inline), framework references, and worker configuration.
+
+Returns: ` + bt + `{"valid": bool, "errors": N, "warnings": N, "items": [{name, status, detail}]}` + bt + `
 
 Arguments:
 - ` + bt + `path` + bt + ` (optional): absolute path to the project root containing ` + bt + `.lerd.yaml` + bt + ` — defaults to the current working directory (or ` + bt + `LERD_SITE_PATH` + bt + ` if set by ` + bt + `mcp:inject` + bt + `)
@@ -764,7 +768,11 @@ Arguments:
 > **Use this before** ` + bt + `env_setup` + bt + ` or ` + bt + `site_link` + bt + ` to catch configuration errors early.
 
 ### ` + bt + `doctor` + bt + `
-Run a full environment diagnostic. Checks podman availability, systemd user session, linger, quadlet/data dir writability, config validity, DNS resolution, port 80/443 conflicts, PHP image presence, and available updates. Returns a text report with OK/FAIL/WARN per check and hints for each failure. **Use this when the user reports setup issues or unexpected behaviour.**
+Run a full environment diagnostic. Returns structured JSON with per-check status (ok/warn/fail): podman, systemd, linger, dir writability, config validity, DNS resolution, nginx, PHP images, and update availability.
+
+Returns: ` + bt + `{"version": "...", "checks": [{name, status, detail}], "failures": N, "warnings": N, "php_installed": [...], "php_default": "...", "node_default": "..."}` + bt + `
+
+**Use this when the user reports setup issues or unexpected behaviour.**
 
 ## Common Workflows
 
@@ -969,7 +977,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `node_uninstall` + bt + ` | Uninstall a Node.js version via fnm |
 | ` + bt + `env_setup` + bt + ` | Configure ` + bt + `.env` + bt + ` for lerd: detects services, starts them, creates DB, generates APP_KEY (leaves ` + bt + `DB_CONNECTION=sqlite` + bt + ` alone — call ` + bt + `db_set` + bt + ` first); ` + bt + `APP_URL` + bt + ` follows ` + bt + `.lerd.yaml app_url` + bt + ` → ` + bt + `sites.yaml app_url` + bt + ` → default chain |
 | ` + bt + `db_set` + bt + ` | Pick the database for a Laravel project: ` + bt + `sqlite` + bt + ` / ` + bt + `mysql` + bt + ` / ` + bt + `postgres` + bt + `; persists to ` + bt + `.lerd.yaml` + bt + `, rewrites ` + bt + `DB_` + bt + ` keys in ` + bt + `.env` + bt + `, starts the service, creates the database |
-| ` + bt + `env_check` + bt + ` | Compare all ` + bt + `.env` + bt + ` files against ` + bt + `.env.example` + bt + ` and flag missing or extra keys |
+| ` + bt + `env_check` + bt + ` | Compare all ` + bt + `.env` + bt + ` files against ` + bt + `.env.example` + bt + ` — returns structured JSON with per-key sync status |
 | ` + bt + `site_link` + bt + ` | Register a directory as a lerd site (creates nginx vhost + ` + bt + `.test` + bt + ` domain) |
 | ` + bt + `site_unlink` + bt + ` | Unregister a site and remove its nginx vhost (all domains) |
 | ` + bt + `site_domain_add` + bt + ` | Add an additional domain to a site (without TLD) |
@@ -1017,9 +1025,9 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `stripe_listen_stop` + bt + ` | Stop the Stripe webhook listener |
 | ` + bt + `logs` + bt + ` | Fetch container logs — defaults to current site's FPM; optionally specify nginx, service name, PHP version, or site name |
 | ` + bt + `status` + bt + ` | Health snapshot of DNS, nginx, PHP-FPM containers, and the file watcher |
-| ` + bt + `doctor` + bt + ` | Full diagnostic: podman, systemd, DNS, ports, PHP images, config, updates |
+| ` + bt + `doctor` + bt + ` | Full diagnostic as structured JSON: podman, systemd, DNS, ports, PHP images, config, updates |
 | ` + bt + `which` + bt + ` | Show resolved PHP version, Node version, document root, and nginx config for the current site |
-| ` + bt + `check` + bt + ` | Validate ` + bt + `.lerd.yaml` + bt + ` syntax, PHP version, services, and framework references — reports OK/WARN/FAIL per field |
+| ` + bt + `check` + bt + ` | Validate ` + bt + `.lerd.yaml` + bt + ` as structured JSON — PHP version, services, framework references with per-field ok/warn/fail |
 
 ### Key conventions
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -22,6 +22,8 @@ import (
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/serviceops"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
+	lerdUpdate "github.com/geodro/lerd/internal/update"
+	"github.com/geodro/lerd/internal/version"
 )
 
 const protocolVersion = "2024-11-05"
@@ -81,6 +83,7 @@ var builtinServiceEnv = map[string][]string{
 
 // phpVersionRe matches PHP version strings like "8.4" or "8.3" — digits only, no domain names.
 var phpVersionRe = regexp.MustCompile(`^\d+\.\d+$`)
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 
 // defaultSitePath is resolved at startup: LERD_SITE_PATH takes precedence (injected by
 // mcp:inject for project-scoped use); if not set, the working directory is used so that
@@ -1498,6 +1501,10 @@ func toolErr(text string) map[string]any {
 	}
 }
 
+func stripANSI(s string) string {
+	return ansiRe.ReplaceAllString(s, "")
+}
+
 func strArg(args map[string]any, key string) string {
 	if v, ok := args[key]; ok {
 		if s, ok := v.(string); ok {
@@ -1589,9 +1596,9 @@ func execArtisan(args map[string]any) (any, *rpcError) {
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
-		return toolErr(fmt.Sprintf("artisan failed (%v):\n%s", err, out.String())), nil
+		return toolErr(fmt.Sprintf("artisan failed (%v):\n%s", err, stripANSI(out.String()))), nil
 	}
-	return toolOK(strings.TrimSpace(out.String())), nil
+	return toolOK(stripANSI(strings.TrimSpace(out.String()))), nil
 }
 
 func execSites() (any, *rpcError) {
@@ -2074,7 +2081,7 @@ func execLogs(args map[string]any) (any, *rpcError) {
 	cmd.Stderr = &out
 	_ = cmd.Run() // non-zero exit if container not running is fine — we return what we have
 
-	return toolOK(strings.TrimSpace(out.String())), nil
+	return toolOK(stripANSI(strings.TrimSpace(out.String()))), nil
 }
 
 func resolveLogsContainer(target string) (string, error) {
@@ -2131,9 +2138,9 @@ func execComposer(args map[string]any) (any, *rpcError) {
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
-		return toolErr(fmt.Sprintf("composer failed (%v):\n%s", err, out.String())), nil
+		return toolErr(fmt.Sprintf("composer failed (%v):\n%s", err, stripANSI(out.String()))), nil
 	}
-	return toolOK(strings.TrimSpace(out.String())), nil
+	return toolOK(stripANSI(strings.TrimSpace(out.String()))), nil
 }
 
 func execVendorBins(args map[string]any) (any, *rpcError) {
@@ -2203,9 +2210,9 @@ func execVendorRun(args map[string]any) (any, *rpcError) {
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
-		return toolErr(fmt.Sprintf("vendor/bin/%s failed (%v):\n%s", bin, err, out.String())), nil
+		return toolErr(fmt.Sprintf("vendor/bin/%s failed (%v):\n%s", bin, err, stripANSI(out.String()))), nil
 	}
-	return toolOK(strings.TrimSpace(out.String())), nil
+	return toolOK(stripANSI(strings.TrimSpace(out.String()))), nil
 }
 
 func execNodeInstall(args map[string]any) (any, *rpcError) {
@@ -2224,9 +2231,9 @@ func execNodeInstall(args map[string]any) (any, *rpcError) {
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
-		return toolErr(fmt.Sprintf("fnm install %s failed (%v):\n%s", version, err, out.String())), nil
+		return toolErr(fmt.Sprintf("fnm install %s failed (%v):\n%s", version, err, stripANSI(out.String()))), nil
 	}
-	return toolOK(strings.TrimSpace(out.String())), nil
+	return toolOK(stripANSI(strings.TrimSpace(out.String()))), nil
 }
 
 func execNodeUninstall(args map[string]any) (any, *rpcError) {
@@ -2245,9 +2252,9 @@ func execNodeUninstall(args map[string]any) (any, *rpcError) {
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
-		return toolErr(fmt.Sprintf("fnm uninstall %s failed (%v):\n%s", version, err, out.String())), nil
+		return toolErr(fmt.Sprintf("fnm uninstall %s failed (%v):\n%s", version, err, stripANSI(out.String()))), nil
 	}
-	return toolOK(strings.TrimSpace(out.String())), nil
+	return toolOK(stripANSI(strings.TrimSpace(out.String()))), nil
 }
 
 func execRuntimeVersions() (any, *rpcError) {
@@ -2351,12 +2358,167 @@ func execStatus() (any, *rpcError) {
 }
 
 func execDoctor() (any, *rpcError) {
-	cmd := exec.Command("lerd", "doctor")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	cmd.Run() //nolint:errcheck
-	return toolOK(out.String()), nil
+	type checkResult struct {
+		Name   string `json:"name"`
+		Status string `json:"status"`
+		Detail string `json:"detail,omitempty"`
+	}
+	type doctorResult struct {
+		Version      string        `json:"version"`
+		Checks       []checkResult `json:"checks"`
+		Failures     int           `json:"failures"`
+		Warnings     int           `json:"warnings"`
+		UpdateAvail  string        `json:"update_available,omitempty"`
+		PHPInstalled []string      `json:"php_installed"`
+		PHPDefault   string        `json:"php_default,omitempty"`
+		NodeDefault  string        `json:"node_default,omitempty"`
+	}
+
+	var r doctorResult
+	r.Version = version.String()
+	var checks []checkResult
+
+	add := func(name, status, detail string) {
+		checks = append(checks, checkResult{Name: name, Status: status, Detail: detail})
+	}
+
+	// Prerequisites
+	if _, err := exec.LookPath("podman"); err != nil {
+		add("podman", "fail", "not found in PATH")
+	} else if err := podman.RunSilent("info"); err != nil {
+		add("podman", "fail", "podman info failed — daemon not running?")
+	} else {
+		add("podman", "ok", "")
+	}
+
+	if out, err := exec.Command("systemctl", "--user", "is-system-running").Output(); err != nil {
+		state := strings.TrimSpace(string(out))
+		if state == "degraded" {
+			add("systemd_user_session", "warn", "degraded — some units have failed")
+		} else {
+			add("systemd_user_session", "fail", "state="+state)
+		}
+	} else {
+		add("systemd_user_session", "ok", "")
+	}
+
+	currentUser := os.Getenv("USER")
+	if currentUser == "" {
+		currentUser = os.Getenv("LOGNAME")
+	}
+	if currentUser != "" {
+		out, err := exec.Command("loginctl", "show-user", currentUser).Output()
+		if err != nil || !strings.Contains(string(out), "Linger=yes") {
+			add("systemd_linger", "warn", "services won't survive logout")
+		} else {
+			add("systemd_linger", "ok", "")
+		}
+	}
+
+	quadletDir := config.QuadletDir()
+	if err := dirWritable(quadletDir); err != nil {
+		add("quadlet_dir", "fail", err.Error())
+	} else {
+		add("quadlet_dir", "ok", "")
+	}
+
+	dataDir := config.DataDir()
+	if err := dirWritable(dataDir); err != nil {
+		add("data_dir", "fail", err.Error())
+	} else {
+		add("data_dir", "ok", "")
+	}
+
+	// Configuration
+	cfg, cfgErr := config.LoadGlobal()
+	if cfgErr != nil {
+		add("config", "fail", cfgErr.Error())
+		cfg = nil
+	} else {
+		add("config", "ok", "")
+	}
+
+	if cfg != nil {
+		if cfg.PHP.DefaultVersion == "" {
+			add("php_default_version", "warn", "not set")
+		} else {
+			add("php_default_version", "ok", cfg.PHP.DefaultVersion)
+			r.PHPDefault = cfg.PHP.DefaultVersion
+		}
+		r.NodeDefault = cfg.Node.DefaultVersion
+
+		if cfg.Nginx.HTTPPort <= 0 || cfg.Nginx.HTTPSPort <= 0 {
+			add("nginx_ports", "fail", fmt.Sprintf("http=%d https=%d", cfg.Nginx.HTTPPort, cfg.Nginx.HTTPSPort))
+		} else {
+			add("nginx_ports", "ok", fmt.Sprintf("%d/%d", cfg.Nginx.HTTPPort, cfg.Nginx.HTTPSPort))
+		}
+	}
+
+	// DNS
+	tld := "test"
+	if cfg != nil && cfg.DNS.TLD != "" {
+		tld = cfg.DNS.TLD
+	}
+	if resolved, _ := dns.Check(tld); resolved {
+		add("dns_resolution", "ok", "."+tld)
+	} else {
+		add("dns_resolution", "fail", "."+tld+" not resolving")
+	}
+
+	// Ports
+	nginxRunning, _ := podman.ContainerRunning("lerd-nginx")
+	if nginxRunning {
+		add("nginx", "ok", "running")
+	} else {
+		add("nginx", "warn", "not running")
+	}
+
+	// PHP images
+	phpVersions, _ := phpDet.ListInstalled()
+	r.PHPInstalled = phpVersions
+	if r.PHPInstalled == nil {
+		r.PHPInstalled = []string{}
+	}
+	for _, v := range phpVersions {
+		short := strings.ReplaceAll(v, ".", "")
+		image := "lerd-php" + short + "-fpm:local"
+		if !podman.ImageExists(image) {
+			add("php_"+v+"_image", "fail", "missing")
+		} else {
+			add("php_"+v+"_image", "ok", "")
+		}
+	}
+
+	// Update check
+	if updateInfo, _ := lerdUpdate.CachedUpdateCheck(version.Version); updateInfo != nil {
+		r.UpdateAvail = updateInfo.LatestVersion
+	}
+
+	r.Checks = checks
+	for _, c := range checks {
+		switch c.Status {
+		case "fail":
+			r.Failures++
+		case "warn":
+			r.Warnings++
+		}
+	}
+
+	data, _ := json.MarshalIndent(r, "", "  ")
+	return toolOK(string(data)), nil
+}
+
+func dirWritable(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("cannot create: %v", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".lerd-mcp-*")
+	if err != nil {
+		return fmt.Errorf("not writable: %v", err)
+	}
+	tmp.Close()
+	os.Remove(tmp.Name())
+	return nil
 }
 
 func execWhich(args map[string]any) (any, *rpcError) {
@@ -2376,9 +2538,9 @@ func execWhich(args map[string]any) (any, *rpcError) {
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
-		return toolErr(fmt.Sprintf("which failed (%v):\n%s", err, out.String())), nil
+		return toolErr(fmt.Sprintf("which failed (%v):\n%s", err, stripANSI(out.String()))), nil
 	}
-	return toolOK(strings.TrimSpace(out.String())), nil
+	return toolOK(stripANSI(strings.TrimSpace(out.String()))), nil
 }
 
 func execCheck(args map[string]any) (any, *rpcError) {
@@ -2387,18 +2549,184 @@ func execCheck(args map[string]any) (any, *rpcError) {
 		return toolErr("path is required — pass a path argument or open Claude in the project directory"), nil
 	}
 
-	self, err := os.Executable()
-	if err != nil {
-		return toolErr("could not resolve lerd executable: " + err.Error()), nil
+	path := filepath.Join(projectPath, ".lerd.yaml")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return toolErr("no .lerd.yaml found in " + projectPath), nil
 	}
 
-	var out bytes.Buffer
-	cmd := exec.Command(self, "check")
-	cmd.Dir = projectPath
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	cmd.Run() //nolint:errcheck
-	return toolOK(out.String()), nil
+	cfg, err := config.LoadProjectConfig(projectPath)
+	if err != nil {
+		return toolErr("invalid .lerd.yaml: " + err.Error()), nil
+	}
+
+	type checkItem struct {
+		Name   string `json:"name"`
+		Status string `json:"status"`
+		Detail string `json:"detail,omitempty"`
+	}
+	type checkResult struct {
+		Valid    bool        `json:"valid"`
+		Errors   int         `json:"errors"`
+		Warnings int         `json:"warnings"`
+		Items    []checkItem `json:"items"`
+	}
+
+	var r checkResult
+	add := func(name, status, detail string) {
+		r.Items = append(r.Items, checkItem{Name: name, Status: status, Detail: detail})
+		switch status {
+		case "fail":
+			r.Errors++
+		case "warn":
+			r.Warnings++
+		}
+	}
+
+	// PHP version
+	if cfg.PHPVersion != "" {
+		if err := validatePHPVersionMCP(cfg.PHPVersion); err != nil {
+			add("php_version", "fail", cfg.PHPVersion+" — "+err.Error())
+		} else if !phpDet.IsInstalled(cfg.PHPVersion) {
+			add("php_version", "warn", cfg.PHPVersion+" not installed")
+		} else {
+			add("php_version", "ok", cfg.PHPVersion)
+		}
+	}
+
+	// Node version
+	if cfg.NodeVersion != "" {
+		add("node_version", "ok", cfg.NodeVersion)
+	}
+
+	// Framework
+	if cfg.Framework != "" {
+		if cfg.FrameworkDef != nil {
+			add("framework", "ok", cfg.Framework+" (inline)")
+		} else if _, ok := config.GetFramework(cfg.Framework); ok {
+			add("framework", "ok", cfg.Framework)
+		} else {
+			add("framework", "warn", cfg.Framework+" is not a known framework")
+		}
+	}
+
+	// Workers
+	if len(cfg.Workers) > 0 {
+		fwName := cfg.Framework
+		if fwName == "" {
+			fwName, _ = config.DetectFramework(projectPath)
+		}
+		fw, hasFw := config.GetFramework(fwName)
+
+		hasQueue, hasHorizon := false, false
+		for _, w := range cfg.Workers {
+			if w == "queue" {
+				hasQueue = true
+			}
+			if w == "horizon" {
+				hasHorizon = true
+			}
+			switch w {
+			case "horizon":
+				if !siteHasComposerPkg(projectPath, `"laravel/horizon"`) {
+					add("worker_"+w, "warn", "laravel/horizon not installed")
+				} else {
+					add("worker_"+w, "ok", "")
+				}
+			case "reverb":
+				if !siteUsesReverb(projectPath) {
+					add("worker_"+w, "warn", "reverb not configured")
+				} else {
+					add("worker_"+w, "ok", "")
+				}
+			case "queue", "schedule":
+				if hasFw && fw.Workers != nil {
+					if _, ok := fw.Workers[w]; ok {
+						add("worker_"+w, "ok", "")
+					} else {
+						add("worker_"+w, "warn", "not defined for framework "+fwName)
+					}
+				} else {
+					add("worker_"+w, "warn", "no framework detected")
+				}
+			default:
+				if hasFw && fw.Workers != nil {
+					if _, ok := fw.Workers[w]; ok {
+						add("worker_"+w, "ok", "")
+					} else {
+						add("worker_"+w, "fail", "not defined for framework "+fwName)
+					}
+				} else {
+					add("worker_"+w, "fail", "no framework worker definition found")
+				}
+			}
+		}
+		if hasQueue && hasHorizon {
+			add("workers_conflict", "warn", "both queue and horizon listed — horizon manages queues")
+		}
+		if hasQueue && siteHasComposerPkg(projectPath, `"laravel/horizon"`) {
+			add("workers_conflict", "warn", "queue listed but horizon installed — horizon will be started instead")
+		}
+	}
+
+	// Services
+	for _, svc := range cfg.Services {
+		if svc.Custom != nil {
+			if svc.Custom.Image == "" {
+				add("service_"+svc.Name, "fail", "inline definition missing image")
+			} else {
+				add("service_"+svc.Name, "ok", "inline, image: "+svc.Custom.Image)
+			}
+			continue
+		}
+		if isKnownService(svc.Name) {
+			add("service_"+svc.Name, "ok", "")
+			continue
+		}
+		if _, err := config.LoadCustomService(svc.Name); err == nil {
+			add("service_"+svc.Name, "ok", "custom")
+		} else {
+			add("service_"+svc.Name, "fail", "not a built-in and no definition found")
+		}
+	}
+
+	r.Valid = r.Errors == 0
+	data, _ := json.MarshalIndent(r, "", "  ")
+	return toolOK(string(data)), nil
+}
+
+func validatePHPVersionMCP(s string) error {
+	parts := strings.SplitN(s, ".", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("must be MAJOR.MINOR format")
+	}
+	for _, p := range parts {
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				return fmt.Errorf("must be MAJOR.MINOR format")
+			}
+		}
+	}
+	return nil
+}
+
+func siteHasComposerPkg(sitePath, pkg string) bool {
+	data, err := os.ReadFile(filepath.Join(sitePath, "composer.json"))
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), pkg)
+}
+
+func siteUsesReverb(sitePath string) bool {
+	if siteHasComposerPkg(sitePath, `"laravel/reverb"`) {
+		return true
+	}
+	for _, name := range []string{".env", ".env.example"} {
+		if envfile.ReadKey(filepath.Join(sitePath, name), "BROADCAST_CONNECTION") == "reverb" {
+			return true
+		}
+	}
+	return false
 }
 
 func execServiceAdd(args map[string]any) (any, *rpcError) {
@@ -2681,9 +3009,9 @@ func execEnvSetup(args map[string]any) (any, *rpcError) {
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
-		return toolErr(fmt.Sprintf("env setup failed (%v):\n%s", err, out.String())), nil
+		return toolErr(fmt.Sprintf("env setup failed (%v):\n%s", err, stripANSI(out.String()))), nil
 	}
-	return toolOK(strings.TrimSpace(out.String())), nil
+	return toolOK(stripANSI(strings.TrimSpace(out.String()))), nil
 }
 
 // execDbSet sets the database for a Laravel project: persists the choice to
@@ -2753,18 +3081,105 @@ func execEnvCheck(args map[string]any) (any, *rpcError) {
 		return toolErr("path is required — pass a path argument or open Claude in the project directory"), nil
 	}
 
-	self, err := os.Executable()
-	if err != nil {
-		return toolErr("could not resolve lerd executable: " + err.Error()), nil
+	examplePath := filepath.Join(projectPath, ".env.example")
+	if _, err := os.Stat(examplePath); os.IsNotExist(err) {
+		return toolErr("no .env.example found in " + projectPath), nil
 	}
 
-	var out bytes.Buffer
-	cmd := exec.Command(self, "env:check")
-	cmd.Dir = projectPath
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	_ = cmd.Run() // non-zero exit is expected when keys are missing
-	return toolOK(strings.TrimSpace(out.String())), nil
+	exampleKeys, err := envfile.ReadKeys(examplePath)
+	if err != nil {
+		return toolErr("reading .env.example: " + err.Error()), nil
+	}
+	exampleSet := make(map[string]bool, len(exampleKeys))
+	for _, k := range exampleKeys {
+		exampleSet[k] = true
+	}
+
+	// Find all .env* files (excluding .env.example).
+	entries, err := os.ReadDir(projectPath)
+	if err != nil {
+		return toolErr("reading directory: " + err.Error()), nil
+	}
+	type fileInfo struct {
+		name   string
+		keySet map[string]bool
+		keys   []string
+	}
+	var files []fileInfo
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, ".env") || e.IsDir() || name == ".env.example" {
+			continue
+		}
+		keys, err := envfile.ReadKeys(filepath.Join(projectPath, name))
+		if err != nil {
+			continue
+		}
+		set := make(map[string]bool, len(keys))
+		for _, k := range keys {
+			set[k] = true
+		}
+		files = append(files, fileInfo{name: name, keySet: set, keys: keys})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].name < files[j].name })
+
+	if len(files) == 0 {
+		return toolErr("no .env files found — run env_setup first"), nil
+	}
+
+	// Build per-key status across all files.
+	type keyStatus struct {
+		Key     string          `json:"key"`
+		Example bool            `json:"in_example"`
+		Files   map[string]bool `json:"files"`
+	}
+
+	// Collect keys with at least one mismatch.
+	mismatched := make(map[string]bool)
+	for _, k := range exampleKeys {
+		for _, f := range files {
+			if !f.keySet[k] {
+				mismatched[k] = true
+				break
+			}
+		}
+	}
+	for _, f := range files {
+		for _, k := range f.keys {
+			if !exampleSet[k] {
+				mismatched[k] = true
+			}
+		}
+	}
+
+	var keys []keyStatus
+	sortedKeys := make([]string, 0, len(mismatched))
+	for k := range mismatched {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+
+	for _, k := range sortedKeys {
+		fs := make(map[string]bool, len(files))
+		for _, f := range files {
+			fs[f.name] = f.keySet[k]
+		}
+		keys = append(keys, keyStatus{Key: k, Example: exampleSet[k], Files: fs})
+	}
+
+	type result struct {
+		InSync bool        `json:"in_sync"`
+		Keys   []keyStatus `json:"keys,omitempty"`
+		Count  int         `json:"out_of_sync_count"`
+	}
+	r := result{
+		InSync: len(keys) == 0,
+		Keys:   keys,
+		Count:  len(keys),
+	}
+
+	data, _ := json.MarshalIndent(r, "", "  ")
+	return toolOK(string(data)), nil
 }
 
 func execSiteLink(args map[string]any) (any, *rpcError) {
@@ -3232,7 +3647,7 @@ func execDBExport(args map[string]any) (any, *rpcError) {
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		_ = os.Remove(output)
-		return toolErr(fmt.Sprintf("export failed (%v):\n%s", err, stderr.String())), nil
+		return toolErr(fmt.Sprintf("export failed (%v):\n%s", err, stripANSI(stderr.String()))), nil
 	}
 	return toolOK(fmt.Sprintf("Exported %s (%s) to %s", env.database, env.connection, output)), nil
 }
@@ -3747,10 +4162,10 @@ func execProjectNew(args map[string]any) (any, *rpcError) {
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
-		return toolErr(fmt.Sprintf("scaffold command failed (%v):\n%s", err, out.String())), nil
+		return toolErr(fmt.Sprintf("scaffold command failed (%v):\n%s", err, stripANSI(out.String()))), nil
 	}
 	return toolOK(fmt.Sprintf("Project created at %s\n\nNext steps:\n  site_link(path: %q)\n  env_setup(path: %q)\n\n%s",
-		projectPath, projectPath, projectPath, strings.TrimSpace(out.String()))), nil
+		projectPath, projectPath, projectPath, stripANSI(strings.TrimSpace(out.String())))), nil
 }
 
 func execSitePHP(args map[string]any) (any, *rpcError) {
@@ -3895,9 +4310,9 @@ func runLerdCmd(cmdArgs ...string) (any, *rpcError) {
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
-		return toolErr(fmt.Sprintf("command failed (%v):\n%s", err, out.String())), nil
+		return toolErr(fmt.Sprintf("command failed (%v):\n%s", err, stripANSI(out.String()))), nil
 	}
-	return toolOK(strings.TrimSpace(out.String())), nil
+	return toolOK(stripANSI(strings.TrimSpace(out.String()))), nil
 }
 
 // ---- DB import / create ----
@@ -3943,7 +4358,7 @@ func execDBImport(args map[string]any) (any, *rpcError) {
 	cmd.Stdin = f
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return toolErr(fmt.Sprintf("import failed (%v):\n%s", err, stderr.String())), nil
+		return toolErr(fmt.Sprintf("import failed (%v):\n%s", err, stripANSI(stderr.String()))), nil
 	}
 	return toolOK(fmt.Sprintf("Imported %s into %s (%s)", file, env.database, env.connection)), nil
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,163 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStripANSI_removesColorCodes(t *testing.T) {
+	input := "\x1b[32mOK\x1b[0m some text \x1b[31mFAIL\x1b[0m"
+	got := stripANSI(input)
+	want := "OK some text FAIL"
+	if got != want {
+		t.Errorf("stripANSI(%q) = %q, want %q", input, got, want)
+	}
+}
+
+func TestStripANSI_preservesPlainText(t *testing.T) {
+	input := "no ansi here"
+	got := stripANSI(input)
+	if got != input {
+		t.Errorf("stripANSI(%q) = %q, want %q", input, got, input)
+	}
+}
+
+func TestStripANSI_handlesBoldAndCursor(t *testing.T) {
+	input := "\x1b[1mBold\x1b[0m \x1b[2J\x1b[H"
+	got := stripANSI(input)
+	want := "Bold "
+	if got != want {
+		t.Errorf("stripANSI(%q) = %q, want %q", input, got, want)
+	}
+}
+
+func TestValidatePHPVersionMCP_valid(t *testing.T) {
+	for _, v := range []string{"8.3", "8.4", "7.4"} {
+		if err := validatePHPVersionMCP(v); err != nil {
+			t.Errorf("validatePHPVersionMCP(%q) = %v, want nil", v, err)
+		}
+	}
+}
+
+func TestValidatePHPVersionMCP_invalid(t *testing.T) {
+	for _, v := range []string{"8", "8.3.1", "abc", "", "8.", ".3"} {
+		if err := validatePHPVersionMCP(v); err == nil {
+			t.Errorf("validatePHPVersionMCP(%q) = nil, want error", v)
+		}
+	}
+}
+
+func TestSiteHasComposerPkg_found(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "composer.json"), []byte(`{"require":{"laravel/horizon":"^5.0"}}`), 0644)
+	if !siteHasComposerPkg(dir, `"laravel/horizon"`) {
+		t.Error("expected true for present package")
+	}
+}
+
+func TestSiteHasComposerPkg_notFound(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "composer.json"), []byte(`{"require":{"laravel/framework":"^11.0"}}`), 0644)
+	if siteHasComposerPkg(dir, `"laravel/horizon"`) {
+		t.Error("expected false for missing package")
+	}
+}
+
+func TestSiteHasComposerPkg_noFile(t *testing.T) {
+	if siteHasComposerPkg(t.TempDir(), `"laravel/horizon"`) {
+		t.Error("expected false when no composer.json")
+	}
+}
+
+func TestToolOK_structure(t *testing.T) {
+	result := toolOK("hello")
+	content, ok := result["content"].([]map[string]any)
+	if !ok || len(content) != 1 {
+		t.Fatal("expected content array with one element")
+	}
+	if content[0]["type"] != "text" || content[0]["text"] != "hello" {
+		t.Errorf("unexpected content: %v", content[0])
+	}
+	if _, has := result["isError"]; has {
+		t.Error("toolOK should not have isError")
+	}
+}
+
+func TestToolErr_structure(t *testing.T) {
+	result := toolErr("oops")
+	content, ok := result["content"].([]map[string]any)
+	if !ok || len(content) != 1 {
+		t.Fatal("expected content array with one element")
+	}
+	if content[0]["text"] != "oops" {
+		t.Errorf("unexpected text: %v", content[0]["text"])
+	}
+	if result["isError"] != true {
+		t.Error("toolErr should have isError=true")
+	}
+}
+
+func TestExecEnvCheck_inSync(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env.example"), []byte("APP_KEY=\nDB_HOST=\n"), 0644)
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_KEY=secret\nDB_HOST=localhost\n"), 0644)
+
+	result, rpcErr := execEnvCheck(map[string]any{"path": dir})
+	if rpcErr != nil {
+		t.Fatal("unexpected rpc error")
+	}
+	content := result.(map[string]any)["content"].([]map[string]any)
+	var parsed struct {
+		InSync bool `json:"in_sync"`
+		Count  int  `json:"out_of_sync_count"`
+	}
+	if err := json.Unmarshal([]byte(content[0]["text"].(string)), &parsed); err != nil {
+		t.Fatal("failed to parse JSON:", err)
+	}
+	if !parsed.InSync {
+		t.Error("expected in_sync=true")
+	}
+	if parsed.Count != 0 {
+		t.Errorf("expected count=0, got %d", parsed.Count)
+	}
+}
+
+func TestExecEnvCheck_missingKeys(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env.example"), []byte("APP_KEY=\nDB_HOST=\nMAIL_HOST=\n"), 0644)
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_KEY=secret\n"), 0644)
+
+	result, rpcErr := execEnvCheck(map[string]any{"path": dir})
+	if rpcErr != nil {
+		t.Fatal("unexpected rpc error")
+	}
+	content := result.(map[string]any)["content"].([]map[string]any)
+	var parsed struct {
+		InSync bool `json:"in_sync"`
+		Count  int  `json:"out_of_sync_count"`
+		Keys   []struct {
+			Key     string          `json:"key"`
+			Example bool            `json:"in_example"`
+			Files   map[string]bool `json:"files"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal([]byte(content[0]["text"].(string)), &parsed); err != nil {
+		t.Fatal("failed to parse JSON:", err)
+	}
+	if parsed.InSync {
+		t.Error("expected in_sync=false")
+	}
+	if parsed.Count != 2 {
+		t.Errorf("expected count=2, got %d", parsed.Count)
+	}
+	for _, k := range parsed.Keys {
+		if !k.Example {
+			t.Errorf("key %s should be in example", k.Key)
+		}
+		if k.Files[".env"] {
+			t.Errorf("key %s should be missing from .env", k.Key)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Strip ANSI escape codes from all MCP tool responses that shell out to CLI commands (artisan, composer, vendor_run, logs, which, env_setup, env_check, node_install/uninstall, project_new, db_import/export, runLerdCmd)
- Convert `doctor`, `check`, and `env_check` from raw CLI text to structured JSON so agents can parse results directly
- Remove non-zero exit from `env:check` since it's a diagnostic tool, not a gate
- Update docs, SKILL.md, and Junie guidelines to document the new structured response formats
- Add tests for ANSI stripping, PHP version validation, composer package detection, env_check JSON output, and toolOK/toolErr helpers