### PR TITLE
feat: Docker compatibility detection and database migration

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -107,6 +107,7 @@ func main() {
 	root.AddCommand(cli.NewNewCmd())
 	root.AddCommand(cli.NewSetupCmd())
 	root.AddCommand(cli.NewMinioMigrateCmd())
+	root.AddCommand(cli.NewDockerImportCmd())
 	root.AddCommand(cli.NewPauseCmd())
 	root.AddCommand(cli.NewUnpauseCmd())
 	root.AddCommand(cli.NewTrayCmd())

--- a/docs/usage/docker-migration.md
+++ b/docs/usage/docker-migration.md
@@ -1,0 +1,120 @@
+# Docker Migration
+
+If you are switching from a Docker-based setup (Laravel Sail, Laradock, DDEV, or a custom `docker-compose.yml`), Lerd can detect potential conflicts and help you migrate your database data.
+
+## Detecting conflicts
+
+Run `lerd doctor` to see if Docker is interfering with Lerd. When real Docker is installed, a **Docker Compatibility** section appears automatically and checks for:
+
+- Whether the Docker daemon is running (port and iptables conflicts)
+- Running Docker containers that hold ports Lerd needs (80, 443, 3306, 5432, etc.)
+- Docker iptables rules that may break rootless Podman networking
+- Docker volumes that look like database data
+
+If Docker is not installed (or only the harmless `podman-docker` shim is present), the section is hidden entirely.
+
+## Common issues
+
+### Port conflicts
+
+Docker containers may bind the same host ports as Lerd services. The fix is simple — stop the Docker containers:
+
+```bash
+docker compose down          # in your project directory
+# or
+sudo systemctl stop docker   # stop the daemon entirely
+```
+
+`lerd install` will warn you if the Docker daemon is running and offer to continue anyway.
+
+### iptables interference
+
+The Docker daemon inserts iptables rules that can break rootless Podman networking. Stopping the Docker daemon clears these rules on reboot, or you can flush them immediately:
+
+```bash
+sudo systemctl stop docker
+sudo iptables -F DOCKER
+sudo iptables -X DOCKER
+```
+
+### Separate image stores
+
+Docker and Podman use separate image storage. Images pulled via `docker pull` are not visible to Podman and vice versa. Lerd pulls its own images automatically — no action needed.
+
+## Migrating databases
+
+The `lerd docker:import` command exports databases from running Docker containers and imports them into Lerd's Podman-managed services.
+
+### List available databases
+
+```bash
+lerd docker:import --list
+```
+
+Shows running Docker database containers and database volumes.
+
+### Interactive migration
+
+```bash
+lerd docker:import
+```
+
+Walks you through selecting a Docker container, picking databases, and importing them. Credentials are auto-detected from the container's environment variables.
+
+### Direct migration
+
+```bash
+lerd docker:import --source sail-mysql-1 --database laravel
+lerd docker:import --source sail-mysql-1 --all-databases
+```
+
+### How it works
+
+1. Reads the Docker container's environment to discover the root password
+2. Runs `mysqldump` or `pg_dump` inside the Docker container via `docker exec`
+3. Creates the database in the Lerd service if it doesn't exist
+4. Pipes the dump into the Lerd service via `podman exec`
+
+The export and import use `docker exec` and `podman exec` respectively, so there are no host-port conflicts even if both Docker and Lerd bind the same ports.
+
+### Supported databases
+
+| Docker image | Lerd service | Notes |
+|---|---|---|
+| `mysql:*` | `lerd-mysql` | Auto-detected |
+| `mariadb:*` | `lerd-mysql` | Treated as MySQL-compatible |
+| `postgres:*` | `lerd-postgres` | Auto-detected |
+
+### After migration
+
+Update your project's `.env` to point to Lerd services:
+
+```bash
+lerd env
+```
+
+Or set the values manually:
+
+**MySQL:**
+```
+DB_HOST=lerd-mysql
+DB_PORT=3306
+DB_USERNAME=root
+DB_PASSWORD=lerd
+```
+
+**PostgreSQL:**
+```
+DB_HOST=lerd-postgres
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=lerd
+```
+
+## Recommended workflow
+
+1. Run `lerd doctor` to see the current state
+2. Run `lerd docker:import` to migrate databases
+3. Stop Docker: `sudo systemctl stop docker && sudo systemctl disable docker`
+4. Run `lerd start`
+5. Run `lerd env` in each project to reconfigure `.env` files

--- a/internal/cli/docker_import.go
+++ b/internal/cli/docker_import.go
@@ -1,0 +1,452 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	dockerDet "github.com/geodro/lerd/internal/docker"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/spf13/cobra"
+)
+
+// NewDockerImportCmd returns the docker:import command.
+func NewDockerImportCmd() *cobra.Command {
+	var (
+		list         bool
+		source       string
+		database     string
+		dbType       string
+		allDatabases bool
+	)
+	cmd := &cobra.Command{
+		Use:   "docker:import",
+		Short: "Import databases from Docker containers into Lerd services",
+		Long: `Migrate MySQL/MariaDB or PostgreSQL databases from running Docker containers
+into Lerd's Podman-managed services.
+
+The export uses "docker exec" and the import uses "podman exec", so there are
+no host-port conflicts even when both Docker and Lerd bind the same ports.
+
+Examples:
+  lerd docker:import --list
+  lerd docker:import
+  lerd docker:import --source sail-mysql-1 --database laravel
+  lerd docker:import --source sail-mysql-1 --all-databases`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runDockerImport(list, source, database, dbType, allDatabases)
+		},
+	}
+	cmd.Flags().BoolVar(&list, "list", false, "List Docker database containers and volumes without importing")
+	cmd.Flags().StringVar(&source, "source", "", "Docker container name to export from")
+	cmd.Flags().StringVar(&database, "database", "", "Database name to import")
+	cmd.Flags().StringVar(&dbType, "type", "", "Database type: mysql or postgres (auto-detected from image)")
+	cmd.Flags().BoolVar(&allDatabases, "all-databases", false, "Import all user databases")
+	return cmd
+}
+
+func runDockerImport(list bool, source, database, dbType string, allDatabases bool) error {
+	// Verify Docker is available.
+	dockerPath, _ := dockerDet.IsDockerInstalled()
+	if dockerPath == "" {
+		return fmt.Errorf("docker CLI not found in PATH — install Docker to use this command")
+	}
+	if !dockerDet.IsDaemonRunning() {
+		return fmt.Errorf("Docker daemon is not running — start it with: sudo systemctl start docker")
+	}
+
+	containers, err := dockerDet.ListRunningContainers()
+	if err != nil {
+		return fmt.Errorf("listing Docker containers: %w", err)
+	}
+
+	dbContainers := dockerDet.FindDatabaseContainers(containers)
+
+	// --list mode: print what's available and exit.
+	if list {
+		return runDockerImportList(dbContainers)
+	}
+
+	// Resolve the source container.
+	var selected dockerDet.DatabaseContainer
+	switch {
+	case source != "":
+		found := false
+		for _, c := range dbContainers {
+			if c.Name == source {
+				selected = c
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("no running database container named %q — run: lerd docker:import --list", source)
+		}
+	case len(dbContainers) == 0:
+		fmt.Println("No running Docker database containers found.")
+		if vols, err := dockerDet.ListVolumes(); err == nil {
+			if dbVols := dockerDet.FindDatabaseVolumes(vols); len(dbVols) > 0 {
+				fmt.Println("\nDatabase volumes exist — start the Docker containers first:")
+				for _, v := range dbVols {
+					fmt.Printf("  %s (%s)\n", v.Name, v.DBType)
+				}
+			}
+		}
+		return fmt.Errorf("start your Docker database containers and try again")
+	case len(dbContainers) == 1:
+		selected = dbContainers[0]
+		fmt.Printf("Found Docker container: %s (%s)\n\n", selected.Name, selected.Image)
+	default:
+		fmt.Println("Multiple Docker database containers found:")
+		for i, c := range dbContainers {
+			fmt.Printf("  [%d] %s (%s)\n", i+1, c.Name, c.Image)
+		}
+		fmt.Print("\nSelect container [1]: ")
+		reader := bufio.NewReader(os.Stdin)
+		answer, _ := reader.ReadString('\n')
+		answer = strings.TrimSpace(answer)
+		idx := 0
+		if answer != "" {
+			fmt.Sscanf(answer, "%d", &idx)
+			idx--
+		}
+		if idx < 0 || idx >= len(dbContainers) {
+			return fmt.Errorf("invalid selection")
+		}
+		selected = dbContainers[idx]
+	}
+
+	// Override type if specified.
+	if dbType != "" {
+		switch strings.ToLower(dbType) {
+		case "mysql", "mariadb":
+			selected.DBType = "mysql"
+		case "postgres", "pgsql":
+			selected.DBType = "postgres"
+		default:
+			return fmt.Errorf("unsupported --type %q (use mysql or postgres)", dbType)
+		}
+	}
+
+	// Discover credentials from the container environment.
+	password := discoverDockerDBPassword(selected)
+
+	// List databases in the Docker container.
+	databases, err := listDockerDatabases(selected, password)
+	if err != nil {
+		return fmt.Errorf("listing databases in %s: %w", selected.Name, err)
+	}
+	if len(databases) == 0 {
+		return fmt.Errorf("no user databases found in %s", selected.Name)
+	}
+
+	// Select which databases to import.
+	var toImport []string
+	switch {
+	case database != "":
+		toImport = []string{database}
+	case allDatabases:
+		toImport = databases
+	default:
+		fmt.Println("Available databases:")
+		for i, db := range databases {
+			fmt.Printf("  [%d] %s\n", i+1, db)
+		}
+		fmt.Print("\nSelect database(s) (comma-separated, or 'all') [1]: ")
+		reader := bufio.NewReader(os.Stdin)
+		answer, _ := reader.ReadString('\n')
+		answer = strings.TrimSpace(answer)
+		if answer == "" {
+			answer = "1"
+		}
+		if strings.ToLower(answer) == "all" {
+			toImport = databases
+		} else {
+			for _, part := range strings.Split(answer, ",") {
+				part = strings.TrimSpace(part)
+				var idx int
+				if _, err := fmt.Sscanf(part, "%d", &idx); err == nil && idx >= 1 && idx <= len(databases) {
+					toImport = append(toImport, databases[idx-1])
+				} else {
+					toImport = append(toImport, part)
+				}
+			}
+		}
+	}
+
+	if len(toImport) == 0 {
+		return fmt.Errorf("no databases selected")
+	}
+
+	// Determine the lerd service name.
+	lerdService := selected.DBType
+	if lerdService == "" {
+		lerdService = "mysql"
+	}
+
+	fmt.Printf("\nEnsuring lerd-%s is running...\n", lerdService)
+	if err := ensureServiceRunning(lerdService); err != nil {
+		return fmt.Errorf("could not start lerd-%s: %w\n\nIf the port is held by Docker, the export/import still works via\n\"docker exec\" and \"podman exec\" — no host port needed.\nTry stopping the Docker container's port mapping and retry.", lerdService, err)
+	}
+
+	// Import each database.
+	imported := 0
+	for _, dbName := range toImport {
+		fmt.Printf("\n── %s ──\n", dbName)
+
+		// Export from Docker.
+		fmt.Printf("  Exporting from Docker container %s...\n", selected.Name)
+		tmpFile, err := os.CreateTemp("", "lerd-docker-import-*.sql")
+		if err != nil {
+			return fmt.Errorf("creating temp file: %w", err)
+		}
+		tmpPath := tmpFile.Name()
+
+		exportCmd := dockerExportCmd(selected, password, dbName)
+		exportCmd.Stdout = tmpFile
+		exportCmd.Stderr = os.Stderr
+		if err := exportCmd.Run(); err != nil {
+			tmpFile.Close()
+			os.Remove(tmpPath)
+			fmt.Printf("  WARN: export of %q failed: %v — skipping\n", dbName, err)
+			continue
+		}
+		tmpFile.Close()
+
+		// Check the dump is not empty.
+		info, _ := os.Stat(tmpPath)
+		if info == nil || info.Size() == 0 {
+			os.Remove(tmpPath)
+			fmt.Printf("  WARN: export of %q produced empty dump — skipping\n", dbName)
+			continue
+		}
+		fmt.Printf("  Exported %d bytes\n", info.Size())
+
+		// Create database in lerd.
+		created, err := createDatabase(lerdService, dbName)
+		if err != nil {
+			os.Remove(tmpPath)
+			fmt.Printf("  WARN: creating database %q: %v — skipping\n", dbName, err)
+			continue
+		}
+		if created {
+			fmt.Printf("  Created database %q\n", dbName)
+		} else {
+			fmt.Printf("  Database %q already exists\n", dbName)
+		}
+
+		// Import into lerd.
+		fmt.Printf("  Importing into lerd-%s...\n", lerdService)
+		importCmd := lerdImportCmd(lerdService, dbName)
+		f, err := os.Open(tmpPath)
+		if err != nil {
+			os.Remove(tmpPath)
+			return fmt.Errorf("opening temp file: %w", err)
+		}
+		importCmd.Stdin = f
+		importCmd.Stderr = os.Stderr
+		err = importCmd.Run()
+		f.Close()
+		os.Remove(tmpPath)
+		if err != nil {
+			fmt.Printf("  WARN: import of %q failed: %v — skipping\n", dbName, err)
+			continue
+		}
+
+		fmt.Printf("  Done\n")
+		imported++
+	}
+
+	// Summary.
+	fmt.Printf("\nImported %d/%d database(s).\n", imported, len(toImport))
+	if imported > 0 {
+		fmt.Println("\nUpdate your .env to point to lerd services:")
+		switch lerdService {
+		case "mysql":
+			fmt.Println("  DB_CONNECTION=mysql")
+			fmt.Println("  DB_HOST=lerd-mysql")
+			fmt.Println("  DB_PORT=3306")
+			fmt.Println("  DB_USERNAME=root")
+			fmt.Println("  DB_PASSWORD=lerd")
+		case "postgres":
+			fmt.Println("  DB_CONNECTION=pgsql")
+			fmt.Println("  DB_HOST=lerd-postgres")
+			fmt.Println("  DB_PORT=5432")
+			fmt.Println("  DB_USERNAME=postgres")
+			fmt.Println("  DB_PASSWORD=lerd")
+		}
+		fmt.Println("\nOr run: lerd env")
+	}
+	return nil
+}
+
+func runDockerImportList(dbContainers []dockerDet.DatabaseContainer) error {
+	if len(dbContainers) > 0 {
+		fmt.Println("Running Docker database containers:")
+		for _, c := range dbContainers {
+			fmt.Printf("  %-30s %-30s %s\n", c.Name, c.Image, c.DBType)
+		}
+	} else {
+		fmt.Println("No running Docker database containers found.")
+	}
+
+	vols, err := dockerDet.ListVolumes()
+	if err != nil {
+		return nil
+	}
+	dbVols := dockerDet.FindDatabaseVolumes(vols)
+	if len(dbVols) > 0 {
+		fmt.Println("\nDocker database volumes:")
+		for _, v := range dbVols {
+			fmt.Printf("  %-40s %s\n", v.Name, v.DBType)
+		}
+	}
+	return nil
+}
+
+// discoverDockerDBPassword reads the container environment to find the root
+// database password. Falls back to common defaults.
+func discoverDockerDBPassword(c dockerDet.DatabaseContainer) string {
+	env := dockerDet.ContainerEnv(c.Name)
+
+	switch c.DBType {
+	case "mysql":
+		if v := env["MYSQL_ROOT_PASSWORD"]; v != "" {
+			return v
+		}
+		if env["MYSQL_ALLOW_EMPTY_PASSWORD"] == "yes" || env["MYSQL_ALLOW_EMPTY_PASSWORD"] == "1" || env["MYSQL_ALLOW_EMPTY_PASSWORD"] == "true" {
+			return ""
+		}
+		if v := env["MARIADB_ROOT_PASSWORD"]; v != "" {
+			return v
+		}
+		if env["MARIADB_ALLOW_EMPTY_ROOT_PASSWORD"] == "yes" || env["MARIADB_ALLOW_EMPTY_ROOT_PASSWORD"] == "1" {
+			return ""
+		}
+	case "postgres":
+		if v := env["POSTGRES_PASSWORD"]; v != "" {
+			return v
+		}
+	}
+
+	// Common defaults from Laravel Sail, Laradock, etc.
+	return "password"
+}
+
+// mysqlSystemDBs are databases to skip when listing user databases.
+var mysqlSystemDBs = map[string]bool{
+	"mysql": true, "information_schema": true, "performance_schema": true, "sys": true,
+}
+
+var postgresSystemDBs = map[string]bool{
+	"postgres": true, "template0": true, "template1": true,
+}
+
+func listDockerDatabases(c dockerDet.DatabaseContainer, password string) ([]string, error) {
+	switch c.DBType {
+	case "mysql":
+		return listDockerMySQLDatabases(c.Name, password)
+	case "postgres":
+		return listDockerPostgresDatabases(c.Name, password)
+	default:
+		return nil, fmt.Errorf("unsupported database type: %s", c.DBType)
+	}
+}
+
+func listDockerMySQLDatabases(container, password string) ([]string, error) {
+	args := []string{"exec", container}
+	// Try mariadb client first, fall back to mysql.
+	for _, bin := range []string{"mariadb", "mysql"} {
+		cmdArgs := append(args, bin, "-uroot")
+		if password != "" {
+			cmdArgs = append(cmdArgs, "-p"+password)
+		}
+		cmdArgs = append(cmdArgs, "-sNe", "SHOW DATABASES")
+		cmd := exec.Command("docker", cmdArgs...)
+		out, err := cmd.Output()
+		if err != nil {
+			continue
+		}
+		var dbs []string
+		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			db := strings.TrimSpace(line)
+			if db != "" && !mysqlSystemDBs[db] {
+				dbs = append(dbs, db)
+			}
+		}
+		return dbs, nil
+	}
+	return nil, fmt.Errorf("could not connect to MySQL in container %s — check credentials", container)
+}
+
+func listDockerPostgresDatabases(container, password string) ([]string, error) {
+	cmd := exec.Command("docker", "exec", "-e", "PGPASSWORD="+password,
+		container, "psql", "-U", "postgres", "-lqt")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to PostgreSQL in container %s: %w", container, err)
+	}
+	var dbs []string
+	for _, line := range strings.Split(string(out), "\n") {
+		parts := strings.SplitN(line, "|", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		db := strings.TrimSpace(parts[0])
+		if db != "" && !postgresSystemDBs[db] {
+			dbs = append(dbs, db)
+		}
+	}
+	return dbs, nil
+}
+
+func dockerExportCmd(c dockerDet.DatabaseContainer, password, database string) *exec.Cmd {
+	switch c.DBType {
+	case "mysql":
+		args := []string{"exec", c.Name}
+		// Try mysqldump first (works for both mysql and mariadb images).
+		args = append(args, "mysqldump", "-uroot")
+		if password != "" {
+			args = append(args, "-p"+password)
+		}
+		args = append(args, "--single-transaction", database)
+		return exec.Command("docker", args...)
+	case "postgres":
+		return exec.Command("docker", "exec", "-e", "PGPASSWORD="+password,
+			c.Name, "pg_dump", "-U", "postgres", database)
+	default:
+		return exec.Command("false")
+	}
+}
+
+func lerdImportCmd(service, database string) *exec.Cmd {
+	switch service {
+	case "mysql":
+		container := "lerd-mysql"
+		// MariaDB 11 removed the `mysql` symlink. Use `mariadb` if available.
+		if checkOut, err := exec.Command("podman", "exec", container, "which", "mariadb").Output(); err == nil && strings.TrimSpace(string(checkOut)) != "" {
+			return exec.Command("podman", "exec", "-i", container,
+				"mariadb", "-uroot", "-plerd", database)
+		}
+		return exec.Command("podman", "exec", "-i", container,
+			"mysql", "-uroot", "-plerd", database)
+	case "postgres":
+		return exec.Command("podman", "exec", "-i", "-e", "PGPASSWORD=lerd",
+			"lerd-postgres", "psql", "-U", "postgres", database)
+	default:
+		return exec.Command("false")
+	}
+}
+
+// ensureServicesForDockerImport starts the lerd service if not already running.
+// This is a thin wrapper around ensureServiceRunning for clarity.
+func ensureServicesForDockerImport(service string) error {
+	if !podman.QuadletInstalled("lerd-" + service) {
+		if err := ensureServiceQuadlet(service); err != nil {
+			return err
+		}
+	}
+	return ensureServiceRunning(service)
+}

--- a/internal/cli/docker_import_test.go
+++ b/internal/cli/docker_import_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"testing"
+
+	dockerDet "github.com/geodro/lerd/internal/docker"
+)
+
+func TestDiscoverDockerDBPassword_MySQL(t *testing.T) {
+	// discoverDockerDBPassword calls ContainerEnv which runs docker inspect.
+	// For unit testing, we test the fallback path directly.
+	c := dockerDet.DatabaseContainer{Name: "test", Image: "mysql:8.0", DBType: "mysql"}
+	got := discoverDockerDBPassword(c)
+	// Without a running container, ContainerEnv returns nil, so it falls back
+	// to "password".
+	if got != "password" {
+		t.Errorf("got %q, want \"password\"", got)
+	}
+}
+
+func TestDiscoverDockerDBPassword_Postgres(t *testing.T) {
+	c := dockerDet.DatabaseContainer{Name: "test", Image: "postgres:16", DBType: "postgres"}
+	got := discoverDockerDBPassword(c)
+	if got != "password" {
+		t.Errorf("got %q, want \"password\"", got)
+	}
+}
+
+func TestMysqlSystemDBs(t *testing.T) {
+	for _, db := range []string{"mysql", "information_schema", "performance_schema", "sys"} {
+		if !mysqlSystemDBs[db] {
+			t.Errorf("%q should be a system DB", db)
+		}
+	}
+	if mysqlSystemDBs["laravel"] {
+		t.Error("laravel should not be a system DB")
+	}
+}
+
+func TestPostgresSystemDBs(t *testing.T) {
+	for _, db := range []string{"postgres", "template0", "template1"} {
+		if !postgresSystemDBs[db] {
+			t.Errorf("%q should be a system DB", db)
+		}
+	}
+	if postgresSystemDBs["myapp"] {
+		t.Error("myapp should not be a system DB")
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
+	dockerDet "github.com/geodro/lerd/internal/docker"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	lerdUpdate "github.com/geodro/lerd/internal/update"
@@ -179,6 +180,38 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 			fail("port 443", "in use by another process", "find the process: ss -tlnp sport = :443")
 		} else {
 			ok("port 443 (free)")
+		}
+	}
+
+	// ── Docker Compatibility ─────────────────────────────────────────────────
+	if dockerPath, isReal := dockerDet.IsDockerInstalled(); dockerPath != "" && isReal {
+		fmt.Println("\n[Docker Compatibility]")
+		warn("Docker CLI installed", "real Docker Engine detected at "+dockerPath)
+
+		if dockerDet.IsDaemonRunning() {
+			warn("Docker daemon active", "may cause port conflicts and iptables interference — stop with: sudo systemctl stop docker")
+
+			if containers, err := dockerDet.ListRunningContainers(); err == nil && len(containers) > 0 {
+				for port, name := range dockerDet.ConflictingPorts(containers) {
+					warn(fmt.Sprintf("port %s", port), fmt.Sprintf("held by Docker container %q", name))
+				}
+			}
+
+			if dockerDet.HasIPTablesDockerChain() {
+				warn("Docker iptables rules", "may interfere with rootless Podman networking")
+			}
+
+			if vols, err := dockerDet.ListVolumes(); err == nil {
+				if dbVols := dockerDet.FindDatabaseVolumes(vols); len(dbVols) > 0 {
+					names := make([]string, len(dbVols))
+					for i, v := range dbVols {
+						names[i] = v.Name
+					}
+					info("Docker DB volumes", strings.Join(names, ", ")+" — run: lerd docker:import --list")
+				}
+			}
+		} else {
+			ok("Docker daemon not running")
 		}
 	}
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -15,6 +15,7 @@ import (
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
+	dockerDet "github.com/geodro/lerd/internal/docker"
 	"github.com/geodro/lerd/internal/nginx"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
@@ -39,6 +40,21 @@ func runInstall(_ *cobra.Command, _ []string) error {
 
 	if err := ensureUnprivilegedPorts(); err != nil {
 		return err
+	}
+
+	if dockerPath, isReal := dockerDet.IsDockerInstalled(); dockerPath != "" && isReal {
+		if dockerDet.IsDaemonRunning() {
+			fmt.Println()
+			fmt.Printf("  \033[33m! Docker daemon is running\033[0m\n")
+			fmt.Println("    The Docker daemon can cause port conflicts (80, 443) and iptables")
+			fmt.Println("    rules that interfere with rootless Podman networking.")
+			fmt.Println()
+			fmt.Println("    Recommended: sudo systemctl stop docker && sudo systemctl disable docker")
+			fmt.Println()
+			if !confirmInstallPrompt("Continue anyway?") {
+				return fmt.Errorf("installation cancelled — stop Docker and try again")
+			}
+		}
 	}
 
 	// 1. Directories

--- a/internal/docker/detect.go
+++ b/internal/docker/detect.go
@@ -1,0 +1,239 @@
+package docker
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Container represents a running Docker container.
+type Container struct {
+	ID    string
+	Name  string
+	Ports string
+	Image string
+}
+
+// Volume represents a Docker volume.
+type Volume struct {
+	Name string
+}
+
+// DatabaseVolume is a Docker volume that likely contains database data.
+type DatabaseVolume struct {
+	Name   string
+	DBType string // "mysql" or "postgres"
+}
+
+// DatabaseContainer is a running Docker container that runs a database engine.
+type DatabaseContainer struct {
+	Name   string
+	Image  string
+	DBType string // "mysql" or "postgres"
+}
+
+// IsDockerInstalled checks whether the docker binary is in PATH and whether it
+// is real Docker or the podman-docker compatibility shim. Returns the binary
+// path and true when it is genuine Docker Engine / Docker Desktop.
+func IsDockerInstalled() (path string, isReal bool) {
+	p, err := exec.LookPath("docker")
+	if err != nil {
+		return "", false
+	}
+	out, err := exec.Command(p, "--version").CombinedOutput()
+	if err != nil {
+		return p, false
+	}
+	ver := string(out)
+	if strings.Contains(strings.ToLower(ver), "podman") {
+		return p, false
+	}
+	return p, true
+}
+
+// IsDaemonRunning returns true when the Docker daemon appears to be active.
+func IsDaemonRunning() bool {
+	// Check well-known sockets.
+	for _, sock := range dockerSockets() {
+		if fi, err := os.Stat(sock); err == nil && fi.Mode()&os.ModeSocket != 0 {
+			return true
+		}
+	}
+	// Fall back to systemctl.
+	out, err := exec.Command("systemctl", "is-active", "docker.service").Output()
+	if err == nil && strings.TrimSpace(string(out)) == "active" {
+		return true
+	}
+	return false
+}
+
+func dockerSockets() []string {
+	socks := []string{"/var/run/docker.sock"}
+	if home, err := os.UserHomeDir(); err == nil {
+		socks = append(socks, filepath.Join(home, ".docker", "desktop", "docker.sock"))
+	}
+	return socks
+}
+
+// ListRunningContainers returns all running Docker containers. If the docker
+// CLI is inaccessible (e.g. user not in docker group) it returns nil, nil.
+func ListRunningContainers() ([]Container, error) {
+	out, err := exec.Command("docker", "ps", "--format", "{{.ID}}\t{{.Names}}\t{{.Ports}}\t{{.Image}}").CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(out), "permission denied") || strings.Contains(string(out), "connect") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("docker ps: %s", strings.TrimSpace(string(out)))
+	}
+	return ParseContainers(string(out)), nil
+}
+
+// ParseContainers parses the tab-separated output of docker ps --format.
+func ParseContainers(output string) []Container {
+	var containers []Container
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 4)
+		if len(parts) < 4 {
+			continue
+		}
+		containers = append(containers, Container{
+			ID:    parts[0],
+			Name:  parts[1],
+			Ports: parts[2],
+			Image: parts[3],
+		})
+	}
+	return containers
+}
+
+// lerdPorts lists host ports that lerd may need.
+var lerdPorts = map[string]bool{
+	"80": true, "443": true, "5300": true,
+	"3306": true, "5432": true, "6379": true,
+	"7700": true, "9000": true, "8025": true,
+}
+
+// portRe matches a host port in Docker's Ports field, e.g. "0.0.0.0:3306->3306/tcp".
+var portRe = regexp.MustCompile(`(?:[\d.]+:)?(\d+)->`)
+
+// ConflictingPorts returns a map of host-port -> container-name for ports that
+// conflict with lerd services.
+func ConflictingPorts(containers []Container) map[string]string {
+	conflicts := map[string]string{}
+	for _, c := range containers {
+		for _, m := range portRe.FindAllStringSubmatch(c.Ports, -1) {
+			if lerdPorts[m[1]] {
+				conflicts[m[1]] = c.Name
+			}
+		}
+	}
+	return conflicts
+}
+
+// ListVolumes returns all Docker volumes.
+func ListVolumes() ([]Volume, error) {
+	out, err := exec.Command("docker", "volume", "ls", "--format", "{{.Name}}").CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(out), "permission denied") || strings.Contains(string(out), "connect") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("docker volume ls: %s", strings.TrimSpace(string(out)))
+	}
+	return ParseVolumes(string(out)), nil
+}
+
+// ParseVolumes parses the output of docker volume ls --format.
+func ParseVolumes(output string) []Volume {
+	var vols []Volume
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+		vols = append(vols, Volume{Name: strings.TrimSpace(line)})
+	}
+	return vols
+}
+
+// dbVolumePatterns maps substrings to database types for volume name detection.
+var dbVolumePatterns = []struct {
+	substr string
+	dbType string
+}{
+	{"mysql", "mysql"},
+	{"mariadb", "mysql"},
+	{"postgres", "postgres"},
+	{"pgsql", "postgres"},
+}
+
+// FindDatabaseVolumes filters volumes whose names suggest database data.
+func FindDatabaseVolumes(volumes []Volume) []DatabaseVolume {
+	var out []DatabaseVolume
+	for _, v := range volumes {
+		lower := strings.ToLower(v.Name)
+		for _, p := range dbVolumePatterns {
+			if strings.Contains(lower, p.substr) {
+				out = append(out, DatabaseVolume{Name: v.Name, DBType: p.dbType})
+				break
+			}
+		}
+	}
+	return out
+}
+
+// dbImagePatterns maps image name substrings to database types.
+var dbImagePatterns = []struct {
+	substr string
+	dbType string
+}{
+	{"mysql", "mysql"},
+	{"mariadb", "mysql"},
+	{"postgres", "postgres"},
+}
+
+// FindDatabaseContainers returns running containers that appear to be database engines.
+func FindDatabaseContainers(containers []Container) []DatabaseContainer {
+	var out []DatabaseContainer
+	for _, c := range containers {
+		lower := strings.ToLower(c.Image)
+		for _, p := range dbImagePatterns {
+			if strings.Contains(lower, p.substr) {
+				out = append(out, DatabaseContainer{
+					Name:   c.Name,
+					Image:  c.Image,
+					DBType: p.dbType,
+				})
+				break
+			}
+		}
+	}
+	return out
+}
+
+// ContainerEnv returns the environment variables of a Docker container as a map.
+func ContainerEnv(name string) map[string]string {
+	out, err := exec.Command("docker", "inspect",
+		"--format", "{{range .Config.Env}}{{println .}}{{end}}", name).CombinedOutput()
+	if err != nil {
+		return nil
+	}
+	env := map[string]string{}
+	for _, line := range strings.Split(string(out), "\n") {
+		k, v, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if ok {
+			env[k] = v
+		}
+	}
+	return env
+}
+
+// HasIPTablesDockerChain returns true when Docker's DOCKER iptables chain exists.
+func HasIPTablesDockerChain() bool {
+	err := exec.Command("iptables", "-L", "DOCKER").Run()
+	return err == nil
+}

--- a/internal/docker/detect_test.go
+++ b/internal/docker/detect_test.go
@@ -1,0 +1,119 @@
+package docker
+
+import (
+	"testing"
+)
+
+func TestParseContainers(t *testing.T) {
+	input := "abc123\tsail-mysql-1\t0.0.0.0:3306->3306/tcp\tmysql:8.0\n" +
+		"def456\tsail-redis-1\t0.0.0.0:6379->6379/tcp\tredis:alpine\n" +
+		"ghi789\tmy-app\t\tnginx:latest\n"
+
+	got := ParseContainers(input)
+	if len(got) != 3 {
+		t.Fatalf("got %d containers, want 3", len(got))
+	}
+	if got[0].Name != "sail-mysql-1" {
+		t.Errorf("got Name=%q, want sail-mysql-1", got[0].Name)
+	}
+	if got[0].Image != "mysql:8.0" {
+		t.Errorf("got Image=%q, want mysql:8.0", got[0].Image)
+	}
+	if got[2].Ports != "" {
+		t.Errorf("got Ports=%q, want empty", got[2].Ports)
+	}
+}
+
+func TestParseContainers_Empty(t *testing.T) {
+	got := ParseContainers("")
+	if len(got) != 0 {
+		t.Fatalf("got %d containers, want 0", len(got))
+	}
+}
+
+func TestConflictingPorts(t *testing.T) {
+	containers := []Container{
+		{Name: "sail-mysql-1", Ports: "0.0.0.0:3306->3306/tcp"},
+		{Name: "traefik", Ports: "0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp"},
+		{Name: "app", Ports: "0.0.0.0:8080->80/tcp"},
+	}
+	got := ConflictingPorts(containers)
+
+	if got["3306"] != "sail-mysql-1" {
+		t.Errorf("port 3306: got %q, want sail-mysql-1", got["3306"])
+	}
+	if got["80"] != "traefik" {
+		t.Errorf("port 80: got %q, want traefik", got["80"])
+	}
+	if got["443"] != "traefik" {
+		t.Errorf("port 443: got %q, want traefik", got["443"])
+	}
+	if _, ok := got["8080"]; ok {
+		t.Error("port 8080 should not be a conflict")
+	}
+}
+
+func TestParseVolumes(t *testing.T) {
+	input := "sail-mysql\nsail-redis\nmy-project_postgres-data\n"
+	got := ParseVolumes(input)
+	if len(got) != 3 {
+		t.Fatalf("got %d volumes, want 3", len(got))
+	}
+	if got[0].Name != "sail-mysql" {
+		t.Errorf("got %q, want sail-mysql", got[0].Name)
+	}
+}
+
+func TestFindDatabaseVolumes(t *testing.T) {
+	vols := []Volume{
+		{Name: "sail-mysql"},
+		{Name: "sail-redis"},
+		{Name: "my-project_postgres-data"},
+		{Name: "app-mariadb-vol"},
+		{Name: "something-else"},
+	}
+	got := FindDatabaseVolumes(vols)
+	if len(got) != 3 {
+		t.Fatalf("got %d, want 3", len(got))
+	}
+	types := map[string]string{}
+	for _, v := range got {
+		types[v.Name] = v.DBType
+	}
+	if types["sail-mysql"] != "mysql" {
+		t.Errorf("sail-mysql type=%q, want mysql", types["sail-mysql"])
+	}
+	if types["my-project_postgres-data"] != "postgres" {
+		t.Errorf("postgres volume type=%q, want postgres", types["my-project_postgres-data"])
+	}
+	if types["app-mariadb-vol"] != "mysql" {
+		t.Errorf("mariadb volume type=%q, want mysql", types["app-mariadb-vol"])
+	}
+}
+
+func TestFindDatabaseContainers(t *testing.T) {
+	containers := []Container{
+		{Name: "sail-mysql-1", Image: "mysql:8.0"},
+		{Name: "sail-redis-1", Image: "redis:alpine"},
+		{Name: "pg-1", Image: "postgres:16"},
+		{Name: "app", Image: "nginx:latest"},
+		{Name: "maria", Image: "mariadb:11"},
+	}
+	got := FindDatabaseContainers(containers)
+	if len(got) != 3 {
+		t.Fatalf("got %d, want 3", len(got))
+	}
+	names := map[string]string{}
+	for _, c := range got {
+		names[c.Name] = c.DBType
+	}
+	if names["sail-mysql-1"] != "mysql" {
+		t.Errorf("sail-mysql-1 type=%q, want mysql", names["sail-mysql-1"])
+	}
+	if names["pg-1"] != "postgres" {
+		t.Errorf("pg-1 type=%q, want postgres", names["pg-1"])
+	}
+	if names["maria"] != "mysql" {
+		t.Errorf("maria type=%q, want mysql", names["maria"])
+	}
+}


### PR DESCRIPTION
## Summary

- adds a Docker Compatibility section to `lerd doctor` that only appears when real Docker is installed, warns about the daemon running, port conflicts, iptables interference, and database volumes
- `lerd install` now warns when the Docker daemon is active and lets the user choose to continue or stop
- new `lerd docker:import` command that exports MySQL/MariaDB/PostgreSQL databases from running Docker containers and imports them into lerd services, auto-discovers credentials from the container environment, no port conflicts since it uses `docker exec` and `podman exec`

Closes #120