### PR TITLE
fix: auto-mount project paths outside $HOME into containers

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -2,6 +2,7 @@
 
 - **Linux** — Arch, Debian/Ubuntu, Fedora-based, or omarchy
 - **[Podman](https://podman.io/)** — rootless, with systemd user session active
+- **[crun](https://github.com/containers/crun)** — recommended OCI runtime for rootless Podman
 - **DNS resolver** — [NetworkManager](https://networkmanager.dev/) or [systemd-resolved](https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html) (at least one is required for `.test` DNS)
 - **`systemctl --user` functional** — run `loginctl enable-linger $USER` if needed
 
@@ -11,6 +12,21 @@ If `systemctl --user` units do not survive logout, run:
 loginctl enable-linger $USER
 ```
 This is required for Podman Quadlet containers to start automatically and persist across sessions.
+:::
+
+::: tip crun is the recommended OCI runtime
+Most distributions ship `crun` as the default rootless Podman runtime. On Arch-based systems, `runc` is the default and `crun` must be installed separately. While both runtimes work, `crun` is lighter and purpose-built for rootless containers. `lerd doctor` will warn if `crun` is not installed.
+
+```bash
+# Arch / omarchy
+sudo pacman -S crun
+
+# Debian / Ubuntu
+sudo apt install crun
+
+# Fedora
+sudo dnf install crun
+```
 :::
 
 - **`unzip`** — used during install to extract fnm

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -30,7 +30,7 @@ All containers join the rootless Podman network `lerd`. Communication between Ng
                               reads (bind mount)
                                   │
                                   ▼
-                          ~/Lerd/my-app
+                       ~/Lerd/my-app (or any path)
 ```
 
 ## Components
@@ -56,3 +56,5 @@ All containers join the rootless Podman network `lerd`. Communication between Ng
 **Shared nginx** — a single nginx container serves all sites via virtual hosts. nginx uses a Podman-network-aware resolver to route `fastcgi_pass` to the correct PHP-FPM container by hostname.
 
 **Per-version PHP-FPM** — each PHP version gets its own container built from a local `Containerfile`. The image includes all extensions needed for Laravel out of the box: `pdo_mysql`, `pdo_pgsql`, `bcmath`, `mbstring`, `xml`, `zip`, `gd`, `intl`, `opcache`, `pcntl`, `exif`, `sockets`, `redis`, `imagick`.
+
+**Automatic volume mounts** — the PHP-FPM and nginx containers bind-mount `$HOME` by default. When a project lives outside the home directory (e.g. `/var/www`, `/opt/projects`), lerd automatically adds the extra volume mount to both containers and restarts them. This happens transparently during `lerd link`, `lerd park`, or the first `lerd php` / `composer` / `laravel new` invocation from the outside path.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -65,6 +65,28 @@ lerd php:rebuild
 ```
 :::
 
+::: details `podman exec` fails with "chdir: No such file or directory"
+This happens when your project is outside your home directory (e.g. `/var/www/`, `/opt/projects/`). The PHP-FPM and nginx containers only mount `$HOME` by default.
+
+Lerd handles this automatically — when you `lerd link`, `lerd park`, or run any exec command (`lerd php`, `composer`, `laravel new`) from an outside path, lerd adds the volume mount and restarts the affected containers.
+
+If you see this error on an older lerd version, update to the latest and re-link the site:
+
+```bash
+lerd update
+lerd unlink && lerd link
+```
+
+To verify the mounts are in place:
+
+```bash
+grep Volume ~/.config/containers/systemd/lerd-nginx.container
+grep Volume ~/.config/containers/systemd/lerd-php*-fpm.container
+```
+
+You should see your project path listed alongside the `%h:%h` mount.
+:::
+
 ::: details Permission denied on port 80/443
 Rootless Podman cannot bind to ports below 1024 by default. Allow it:
 

--- a/docs/usage/sites.md
+++ b/docs/usage/sites.md
@@ -85,6 +85,19 @@ lerd init --fresh
 
 ---
 
+## Projects outside the home directory
+
+By default, the PHP-FPM and nginx containers only have access to files under `$HOME`. If your project lives elsewhere (e.g. `/var/www`, `/opt/projects`, `/var/local`), lerd automatically detects this and adds the required volume mount to both containers.
+
+This happens transparently when you:
+
+- **`lerd link`** or **`lerd park`** a directory outside `$HOME`
+- Run **`lerd php`**, **`composer`**, **`laravel new`**, or any exec command from an outside path
+
+The containers are restarted once to pick up the new mount. Subsequent commands from the same path run without delay. When you unlink or unpark, stale mounts are cleaned up automatically.
+
+---
+
 ## Domain naming
 
 Directories with real TLDs are automatically normalised — dots are replaced with dashes and the TLD is stripped before appending `.test`.

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -54,6 +54,7 @@ func runConsole(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("PHP %s FPM container is not running — start it with: systemctl --user start %s", version, container)
 	}
 
+	podman.EnsurePathMounted(cwd, version)
 	ensureServicesForCwd(cwd)
 
 	execFlags := []string{"exec", "-i"}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -56,6 +56,12 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		ok("podman")
 	}
 
+	if _, err := exec.LookPath("crun"); err != nil {
+		warn("OCI runtime", "crun not found — recommended for rootless podman (install: sudo pacman -S crun / sudo apt install crun / sudo dnf install crun)")
+	} else {
+		ok("OCI runtime (crun)")
+	}
+
 	if out, err := exec.Command("systemctl", "--user", "is-system-running").Output(); err != nil {
 		// exit non-zero but "degraded" is acceptable
 		state := strings.TrimSpace(string(out))

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -231,6 +231,9 @@ func runLink(args []string) error {
 		fmt.Printf("[WARN] FPM quadlet for PHP %s: %v\n", phpVersion, err)
 	}
 
+	// Rewrite FPM quadlets so volume mounts cover the linked site path.
+	_ = podman.RewriteFPMQuadlets()
+
 	if err := podman.WriteContainerHosts(); err != nil {
 		fmt.Printf("[WARN] updating container hosts file: %v\n", err)
 	}

--- a/internal/cli/park.go
+++ b/internal/cli/park.go
@@ -131,6 +131,9 @@ func runPark(_ *cobra.Command, args []string) error {
 		fmt.Println("No PHP projects found in directory.")
 	}
 
+	// Rewrite FPM quadlets so volume mounts cover the new parked directory.
+	_ = podman.RewriteFPMQuadlets()
+
 	return nil
 }
 

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -68,6 +68,7 @@ func RunPHP(cwd string, args []string) error {
 		return fmt.Errorf("PHP %s FPM container is not running — start it with: systemctl --user start %s", version, container)
 	}
 
+	podman.EnsurePathMounted(cwd, version)
 	ensureServicesForCwd(cwd)
 
 	// If any positional arg is an absolute path to a file that exists on the

--- a/internal/cli/php_shell.go
+++ b/internal/cli/php_shell.go
@@ -49,6 +49,7 @@ func runPhpShell(_ *cobra.Command, _ []string) error {
 	// otherwise fall back to cwd.
 	workDir := siteRootFor(cwd)
 
+	podman.EnsurePathMounted(workDir, version)
 	ensureServicesForCwd(workDir)
 
 	cmd := exec.Command("podman", "exec", "-it", "-w", workDir, container, "sh")

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
 	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
 
@@ -470,6 +471,8 @@ func composerInContainer(dir string, args ...string) error {
 	short := strings.ReplaceAll(version, ".", "")
 	container := "lerd-php" + short + "-fpm"
 
+	podman.EnsurePathMounted(dir, version)
+
 	home := os.Getenv("HOME")
 	composerPhar := filepath.Join(config.BinDir(), "composer.phar")
 
@@ -495,6 +498,7 @@ func execInContainer(dir, command string) error {
 	}
 	short := strings.ReplaceAll(version, ".", "")
 	container := "lerd-php" + short + "-fpm"
+	podman.EnsurePathMounted(dir, version)
 	parts := strings.Fields(command)
 	if len(parts) == 0 {
 		return fmt.Errorf("empty setup command")

--- a/internal/cli/unlink.go
+++ b/internal/cli/unlink.go
@@ -93,5 +93,8 @@ func UnlinkSite(name string) error {
 	autoStopUnusedServices()
 	autoStopUnusedFPMs()
 
+	// Rewrite FPM quadlets to remove volume mounts that are no longer needed.
+	_ = podman.RewriteFPMQuadlets()
+
 	return nil
 }

--- a/internal/cli/unpark.go
+++ b/internal/cli/unpark.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/nginx"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
 
@@ -90,6 +91,9 @@ func runUnpark(_ *cobra.Command, args []string) error {
 			fmt.Printf("  [WARN] nginx reload: %v\n", err)
 		}
 	}
+
+	// Rewrite FPM quadlets to remove volume mounts that are no longer needed.
+	_ = podman.RewriteFPMQuadlets()
 
 	return nil
 }

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -12,6 +12,82 @@ import (
 	"github.com/geodro/lerd/internal/config"
 )
 
+// ExtraVolumePaths returns absolute paths that need to be bind-mounted into the
+// PHP-FPM container because they are outside the user's home directory. It
+// collects parked directories and linked site paths, deduplicates them, and
+// returns only the top-level ancestors (so /var/www covers /var/www/app).
+func ExtraVolumePaths() []string {
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		return nil
+	}
+	// Ensure home has a trailing slash for prefix matching.
+	homePrefix := home
+	if !strings.HasSuffix(homePrefix, "/") {
+		homePrefix += "/"
+	}
+
+	seen := map[string]bool{}
+	add := func(p string) {
+		if p == "" || p == home || strings.HasPrefix(p, homePrefix) {
+			return
+		}
+		seen[p] = true
+	}
+
+	if cfg, err := config.LoadGlobal(); err == nil {
+		for _, dir := range cfg.ParkedDirectories {
+			add(dir)
+		}
+	}
+	if reg, err := config.LoadSites(); err == nil {
+		for _, site := range reg.Sites {
+			add(site.Path)
+		}
+	}
+
+	if len(seen) == 0 {
+		return nil
+	}
+
+	// Collect unique paths and reduce to top-level ancestors.
+	paths := make([]string, 0, len(seen))
+	for p := range seen {
+		paths = append(paths, p)
+	}
+	// Sort so shorter paths come first, then filter out children.
+	sortPaths(paths)
+	var result []string
+	for _, p := range paths {
+		covered := false
+		for _, r := range result {
+			rPrefix := r
+			if !strings.HasSuffix(rPrefix, "/") {
+				rPrefix += "/"
+			}
+			if strings.HasPrefix(p, rPrefix) || p == r {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// sortPaths sorts paths by length then lexicographically.
+func sortPaths(paths []string) {
+	for i := 1; i < len(paths); i++ {
+		for j := i; j > 0; j-- {
+			if len(paths[j]) < len(paths[j-1]) || (len(paths[j]) == len(paths[j-1]) && paths[j] < paths[j-1]) {
+				paths[j], paths[j-1] = paths[j-1], paths[j]
+			}
+		}
+	}
+}
+
 // mkcertPath returns the path to the mkcert binary managed by lerd.
 func mkcertPath() string {
 	return filepath.Join(config.BinDir(), "mkcert")
@@ -297,6 +373,7 @@ func WriteFPMQuadlet(version string) error {
 	content = strings.ReplaceAll(content, "{{.VersionShort}}", short)
 	content = strings.ReplaceAll(content, "{{.XdebugIniPath}}", config.PHPConfFile(version))
 	content = strings.ReplaceAll(content, "{{.UserIniPath}}", config.PHPUserIniFile(version))
+	content = InjectExtraVolumes(content, ExtraVolumePaths())
 
 	// Skip the write and daemon-reload if the quadlet is already up to date.
 	// Unnecessary daemon-reloads cause Podman's quadlet generator to regenerate
@@ -310,7 +387,150 @@ func WriteFPMQuadlet(version string) error {
 	if err := WriteQuadlet(unitName, content); err != nil {
 		return err
 	}
-	return DaemonReload()
+	if err := DaemonReload(); err != nil {
+		return err
+	}
+	// Restart the container so new volume mounts take effect.
+	// Ignore errors — the container may not be running yet (first install).
+	_ = RestartUnit(unitName)
+	return nil
+}
+
+// RewriteFPMQuadlets regenerates the quadlet files for all installed PHP-FPM
+// versions and the nginx quadlet. Call this when parked directories or site
+// paths change so that extra volume mounts stay in sync.
+func RewriteFPMQuadlets() error {
+	extraPaths := ExtraVolumePaths()
+	versions, _ := listInstalledPHPVersions()
+
+	var changedUnits []string
+
+	for _, v := range versions {
+		short := strings.ReplaceAll(v, ".", "")
+		unitName := "lerd-php" + short + "-fpm"
+
+		tmplContent, tmplErr := GetQuadletTemplate("lerd-php-fpm.container.tmpl")
+		if tmplErr != nil {
+			continue
+		}
+		content := strings.ReplaceAll(tmplContent, "{{.Version}}", v)
+		content = strings.ReplaceAll(content, "{{.VersionShort}}", short)
+		content = strings.ReplaceAll(content, "{{.XdebugIniPath}}", config.PHPConfFile(v))
+		content = strings.ReplaceAll(content, "{{.UserIniPath}}", config.PHPUserIniFile(v))
+		content = InjectExtraVolumes(content, extraPaths)
+
+		changed, writeErr := WriteQuadletDiff(unitName, content)
+		if writeErr != nil {
+			continue
+		}
+		if changed {
+			changedUnits = append(changedUnits, unitName)
+		}
+	}
+
+	// Also rewrite nginx quadlet with the same extra volumes.
+	if nginxContent, err := GetQuadletTemplate("lerd-nginx.container"); err == nil {
+		nginxContent = InjectExtraVolumes(nginxContent, extraPaths)
+		if changed, err := WriteQuadletDiff("lerd-nginx", nginxContent); err == nil && changed {
+			changedUnits = append(changedUnits, "lerd-nginx")
+		}
+	}
+
+	if len(changedUnits) > 0 {
+		_ = DaemonReload()
+		for _, unit := range changedUnits {
+			_ = RestartUnit(unit)
+		}
+	}
+	return nil
+}
+
+// listInstalledPHPVersions returns PHP versions that have a quadlet installed.
+func listInstalledPHPVersions() ([]string, error) {
+	dir := config.QuadletDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var versions []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "lerd-php") || !strings.HasSuffix(name, "-fpm.container") {
+			continue
+		}
+		// Extract version short from lerd-php84-fpm.container → "84"
+		short := strings.TrimPrefix(name, "lerd-php")
+		short = strings.TrimSuffix(short, "-fpm.container")
+		if len(short) < 2 {
+			continue
+		}
+		// Convert "84" → "8.4"
+		version := string(short[0]) + "." + short[1:]
+		versions = append(versions, version)
+	}
+	return versions, nil
+}
+
+// EnsurePathMounted checks whether the given path is accessible inside the
+// PHP-FPM and nginx containers. If the path is outside $HOME and not already
+// volume-mounted, the quadlets are updated and containers restarted
+// transparently before returning.
+func EnsurePathMounted(path, phpVersion string) {
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		return
+	}
+	homePrefix := home
+	if !strings.HasSuffix(homePrefix, "/") {
+		homePrefix += "/"
+	}
+	if path == home || strings.HasPrefix(path, homePrefix) {
+		return
+	}
+
+	versions, _ := listInstalledPHPVersions()
+
+	// Collect all quadlet files to check: FPM containers + nginx.
+	type quadletInfo struct {
+		unitName string
+		path     string
+	}
+	var quadlets []quadletInfo
+	for _, v := range versions {
+		short := strings.ReplaceAll(v, ".", "")
+		unitName := "lerd-php" + short + "-fpm"
+		quadlets = append(quadlets, quadletInfo{unitName, filepath.Join(config.QuadletDir(), unitName+".container")})
+	}
+	quadlets = append(quadlets, quadletInfo{"lerd-nginx", filepath.Join(config.QuadletDir(), "lerd-nginx.container")})
+
+	var changedUnits []string
+	for _, q := range quadlets {
+		existing, readErr := os.ReadFile(q.path)
+		if readErr != nil {
+			continue
+		}
+
+		volumePrefix := fmt.Sprintf("Volume=%s:%s:", path, path)
+		if strings.Contains(string(existing), volumePrefix) {
+			continue
+		}
+
+		updated := InjectExtraVolumes(string(existing), []string{path})
+		if updated == string(existing) {
+			continue
+		}
+		if writeErr := os.WriteFile(q.path, []byte(updated), 0644); writeErr != nil {
+			continue
+		}
+		changedUnits = append(changedUnits, q.unitName)
+	}
+
+	if len(changedUnits) > 0 {
+		_ = DaemonReload()
+		for _, unit := range changedUnits {
+			_ = RestartUnit(unit)
+		}
+	}
 }
 
 // EnsureUserIni creates the per-version user php.ini with defaults if it doesn't exist.

--- a/internal/podman/quadlet_embed.go
+++ b/internal/podman/quadlet_embed.go
@@ -3,6 +3,7 @@ package podman
 import (
 	"embed"
 	"fmt"
+	"os/exec"
 	"strings"
 )
 
@@ -68,6 +69,49 @@ func StripInstallSection(content string, autostartDisabled bool) string {
 	}
 	out = append(out, "")
 	return strings.Join(out, "\n")
+}
+
+// InjectExtraVolumes adds Volume= lines for paths that are not already covered
+// by the %h:%h mount. Each path is bind-mounted read-write at the same location
+// inside the container. Existing Volume= lines for the same host path are not
+// duplicated.
+func InjectExtraVolumes(content string, paths []string) string {
+	if len(paths) == 0 {
+		return content
+	}
+	var extra []string
+	for _, p := range paths {
+		// Check if this path is already mounted (with any flags).
+		prefix := fmt.Sprintf("Volume=%s:%s:", p, p)
+		if strings.Contains(content, prefix) {
+			continue
+		}
+		extra = append(extra, fmt.Sprintf("Volume=%s:%s:rw", p, p))
+	}
+	if len(extra) == 0 {
+		return content
+	}
+	// Insert after the Volume=%h:%h line (matches both :rw and :ro).
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		if strings.Contains(line, "Volume=%h:%h:") {
+			out := make([]string, 0, len(lines)+len(extra))
+			out = append(out, lines[:i+1]...)
+			out = append(out, extra...)
+			out = append(out, lines[i+1:]...)
+			return strings.Join(out, "\n")
+		}
+	}
+	return content
+}
+
+// OCIRuntime returns the name of the OCI runtime podman is currently configured to use.
+func OCIRuntime() string {
+	out, err := exec.Command("podman", "info", "--format", "{{.Host.OCIRuntime.Name}}").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // BindForLAN rewrites every PublishPort= line in a quadlet so the host-side

--- a/internal/podman/quadlet_embed_test.go
+++ b/internal/podman/quadlet_embed_test.go
@@ -146,3 +146,54 @@ func TestBindForLANHandlesProtocolSuffixes(t *testing.T) {
 		t.Errorf("protocol suffix should be preserved when prefixing, got:\n%s", out)
 	}
 }
+
+func TestInjectExtraVolumesAfterHomeMount(t *testing.T) {
+	in := strings.Join([]string{
+		"[Container]",
+		"Image=foo",
+		"Volume=%h:%h:rw",
+		"PodmanArgs=--security-opt=label=disable",
+	}, "\n")
+
+	out := InjectExtraVolumes(in, []string{"/var/www", "/opt/projects"})
+	if !strings.Contains(out, "Volume=/var/www:/var/www:rw") {
+		t.Errorf("expected /var/www volume, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Volume=/opt/projects:/opt/projects:rw") {
+		t.Errorf("expected /opt/projects volume, got:\n%s", out)
+	}
+	// Extra volumes should appear after %h:%h:rw.
+	homeIdx := strings.Index(out, "Volume=%h:%h:rw")
+	varIdx := strings.Index(out, "Volume=/var/www:/var/www:rw")
+	podmanIdx := strings.Index(out, "PodmanArgs=")
+	if varIdx < homeIdx {
+		t.Errorf("extra volume should appear after home mount, got:\n%s", out)
+	}
+	if varIdx > podmanIdx {
+		t.Errorf("extra volume should appear before PodmanArgs, got:\n%s", out)
+	}
+}
+
+func TestInjectExtraVolumesNoPaths(t *testing.T) {
+	in := "Volume=%h:%h:rw\n"
+	out := InjectExtraVolumes(in, nil)
+	if out != in {
+		t.Errorf("expected unchanged content with no paths, got:\n%s", out)
+	}
+}
+
+func TestInjectExtraVolumesNoDuplicates(t *testing.T) {
+	in := "Volume=%h:%h:rw\nVolume=/var/www:/var/www:rw\n"
+	out := InjectExtraVolumes(in, []string{"/var/www"})
+	if strings.Count(out, "/var/www:/var/www:rw") != 1 {
+		t.Errorf("should not duplicate existing volume, got:\n%s", out)
+	}
+}
+
+func TestSortPaths(t *testing.T) {
+	paths := []string{"/var/www/app", "/opt", "/var/www"}
+	sortPaths(paths)
+	if paths[0] != "/opt" || paths[1] != "/var/www" || paths[2] != "/var/www/app" {
+		t.Errorf("expected sorted by length then lex, got: %v", paths)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #120, projects outside `$HOME` (e.g. `/var/www`, `/opt/projects`) failed with `chdir: No such file or directory` because the PHP-FPM and nginx containers only bind-mount `$HOME`.

- The PHP-FPM and nginx containers now get extra volume mounts injected into their quadlets automatically when a project lives outside the home directory
- Mounts are added transparently during `lerd link`, `lerd park`, or the first exec command (`lerd php`, `composer`, `laravel new`) from an outside path
- Stale mounts are cleaned up on `lerd unlink` and `lerd unpark`
- Adds a soft `lerd doctor` warning when `crun` is not installed

Closes #120