### PR TITLE
fix: preserve extra volume mounts during install/update

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -158,11 +158,13 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	// would silently keep its old LAN-exposed bind even though the
 	// quadlet on disk now says 127.0.0.1.
 	changedQuadlets := []string{}
+	extraVolumes := podman.ExtraVolumePaths()
 	rewriteQuadlet := func(name string) error {
 		content, err := podman.GetQuadletTemplate(name + ".container")
 		if err != nil {
 			return nil //nolint:nilerr // missing template = nothing to write
 		}
+		content = podman.InjectExtraVolumes(content, extraVolumes)
 		changed, err := podman.WriteQuadletDiff(name, content)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

Follow-up to #127, rewriteQuadlet in install.go wrote quadlets from raw templates without injecting extra volumes, so projects outside $HOME lost their mounts after lerd install or lerd update.