### PR TITLE
release: v1.9.4

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,14 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.9.4] — 2026-04-10
+
+### Fixed
+
+- **Extra volume mounts lost after install/update** — `lerd install` rewrote nginx and service quadlets from raw templates, dropping extra volume mounts for projects outside `$HOME`. Mounts now survive install and update cycles.
+
+---
+
 ## [1.9.3] — 2026-04-10
 
 ### Fixed

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.9.3"
+	Version = "1.9.4"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

- fix: extra volume mounts for projects outside $HOME preserved during install/update (#129)