### PR TITLE
feat: add {{domain}} and {{scheme}} template vars, sync env on domain change

### DIFF
--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -219,6 +219,16 @@ env:
   url_key: DEFAULT_URI            # env key holding the app URL (default: APP_URL)
 
   # Per-service env detection and variable injection for `lerd env`
+  #
+  # Template variables available in vars values:
+  #   {{site}}              — project database / handle name (e.g. myapp)
+  #   {{site_testing}}      — testing database name (e.g. myapp_testing)
+  #   {{domain}}            — site's primary domain (e.g. myapp.test)
+  #   {{scheme}}            — http or https depending on TLS status
+  #   {{mysql_version}}     — running MySQL server version
+  #   {{postgres_version}}  — running PostgreSQL server version
+  #   {{redis_version}}     — running Redis server version
+  #   {{meilisearch_version}} — running Meilisearch server version
   services:
     mysql:
       detect:

--- a/internal/cli/domain.go
+++ b/internal/cli/domain.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/envfile"
 	"github.com/geodro/lerd/internal/nginx"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
@@ -125,6 +126,12 @@ func runDomainAdd(_ *cobra.Command, args []string) error {
 		fmt.Printf("[WARN] nginx reload: %v\n", err)
 	}
 
+	if site.PrimaryDomain() != oldPrimary {
+		if err := envfile.SyncPrimaryDomain(site.Path, site.PrimaryDomain(), site.Secured); err != nil {
+			fmt.Printf("[WARN] syncing .env to new primary domain: %v\n", err)
+		}
+	}
+
 	fmt.Printf("Added domain %s to site %s\n", fullDomain, site.Name)
 	return nil
 }
@@ -188,6 +195,12 @@ func runDomainRemove(_ *cobra.Command, args []string) error {
 
 	if err := nginx.Reload(); err != nil {
 		fmt.Printf("[WARN] nginx reload: %v\n", err)
+	}
+
+	if site.PrimaryDomain() != oldPrimary {
+		if err := envfile.SyncPrimaryDomain(site.Path, site.PrimaryDomain(), site.Secured); err != nil {
+			fmt.Printf("[WARN] syncing .env to new primary domain: %v\n", err)
+		}
 	}
 
 	fmt.Printf("Removed domain %s from site %s\n", fullDomain, site.Name)

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -151,6 +151,16 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	updates := map[string]string{}
 	dbName := projectDBName(cwd)
 
+	scheme := "http"
+	if site.Secured {
+		scheme = "https"
+	}
+	tplCtx := siteTemplateCtx{
+		site:   dbName,
+		domain: site.PrimaryDomain(),
+		scheme: scheme,
+	}
+
 	// Load .lerd.yaml service hints so we can apply env vars for services
 	// listed there even when they are not yet referenced in the env file.
 	lerdYAMLServices := map[string]bool{}
@@ -209,7 +219,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			isDB := svc == "mysql" || svc == "postgres"
 			for _, kv := range def.Vars {
 				k, v, _ := strings.Cut(kv, "=")
-				updates[k] = applySiteHandle(v, dbName)
+				updates[k] = applySiteHandle(v, tplCtx)
 			}
 			if isDB {
 				if err := ensureServiceRunning(svc); err != nil {
@@ -377,7 +387,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		}
 		for _, kv := range svc.EnvVars {
 			k, v, _ := strings.Cut(kv, "=")
-			updates[k] = applySiteHandle(v, dbName)
+			updates[k] = applySiteHandle(v, tplCtx)
 		}
 		family := config.InferFamily(svc.Name)
 		isDB := family == "mysql" || family == "mariadb" || family == "postgres"
@@ -401,7 +411,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			}
 		}
 		if svc.SiteInit != nil && svc.SiteInit.Exec != "" {
-			runSiteInit(svc, dbName)
+			runSiteInit(svc, tplCtx)
 		}
 	}
 
@@ -761,11 +771,25 @@ func artisanIn(dir string, args ...string) error {
 	return cmd.Run()
 }
 
-// applySiteHandle replaces {{site}}, {{site_testing}}, and service version
-// placeholders (e.g. {{mysql_version}}, {{postgres_version}}) in s.
-func applySiteHandle(s, site string) string {
-	s = strings.ReplaceAll(s, "{{site}}", site)
-	s = strings.ReplaceAll(s, "{{site_testing}}", site+"_testing")
+// siteTemplateCtx holds the values available to {{…}} placeholders in
+// framework env var templates.
+type siteTemplateCtx struct {
+	site   string // database / handle name
+	domain string // primary domain (e.g. myapp.test)
+	scheme string // "http" or "https"
+}
+
+// applySiteHandle replaces {{site}}, {{site_testing}}, {{domain}}, {{scheme}},
+// and service version placeholders (e.g. {{mysql_version}}, {{postgres_version}}) in s.
+func applySiteHandle(s string, ctx siteTemplateCtx) string {
+	s = strings.ReplaceAll(s, "{{site}}", ctx.site)
+	s = strings.ReplaceAll(s, "{{site_testing}}", ctx.site+"_testing")
+	if ctx.domain != "" {
+		s = strings.ReplaceAll(s, "{{domain}}", ctx.domain)
+	}
+	if ctx.scheme != "" {
+		s = strings.ReplaceAll(s, "{{scheme}}", ctx.scheme)
+	}
 	// Lazy-resolve service version placeholders only when present.
 	for _, svc := range []string{"mysql", "postgres", "redis", "meilisearch"} {
 		placeholder := "{{" + svc + "_version}}"
@@ -777,12 +801,12 @@ func applySiteHandle(s, site string) string {
 }
 
 // runSiteInit executes the site_init.exec command inside the service container.
-func runSiteInit(svc *config.CustomService, site string) {
+func runSiteInit(svc *config.CustomService, ctx siteTemplateCtx) {
 	container := svc.SiteInit.Container
 	if container == "" {
 		container = "lerd-" + svc.Name
 	}
-	script := applySiteHandle(svc.SiteInit.Exec, site)
+	script := applySiteHandle(svc.SiteInit.Exec, ctx)
 	cmd := exec.Command("podman", "exec", container, "sh", "-c", script)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -132,3 +132,49 @@ func UpdateAppURL(projectPath, scheme, domain string) error {
 		"APP_URL": scheme + "://" + domain,
 	})
 }
+
+// SyncPrimaryDomain updates APP_URL and VITE_REVERB_HOST/SCHEME/PORT in the
+// project's .env to reflect the current primary domain and TLS state.
+// Only keys that already exist in the .env are touched.
+// Silently does nothing if no .env exists.
+func SyncPrimaryDomain(projectPath, domain string, secured bool) error {
+	envPath := filepath.Join(projectPath, ".env")
+	if _, err := os.Stat(envPath); os.IsNotExist(err) {
+		return nil
+	}
+
+	keys, err := ReadKeys(envPath)
+	if err != nil {
+		return err
+	}
+	present := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		present[k] = true
+	}
+
+	scheme := "http"
+	port := "80"
+	if secured {
+		scheme = "https"
+		port = "443"
+	}
+
+	updates := map[string]string{}
+	if present["APP_URL"] {
+		updates["APP_URL"] = scheme + "://" + domain
+	}
+	if present["VITE_REVERB_HOST"] {
+		updates["VITE_REVERB_HOST"] = domain
+	}
+	if present["VITE_REVERB_SCHEME"] {
+		updates["VITE_REVERB_SCHEME"] = scheme
+	}
+	if present["VITE_REVERB_PORT"] {
+		updates["VITE_REVERB_PORT"] = port
+	}
+
+	if len(updates) == 0 {
+		return nil
+	}
+	return ApplyUpdates(envPath, updates)
+}

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -219,3 +219,60 @@ func TestUpdateAppURL_noEnvFile_silent(t *testing.T) {
 		t.Errorf("expected no error for missing .env, got: %v", err)
 	}
 }
+
+// ── SyncPrimaryDomain ────────────────────────────────────────────────────────
+
+func TestSyncPrimaryDomain_updatesAllReverbVars(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte(
+		"APP_URL=https://old.test\n"+
+			"VITE_REVERB_HOST=old.test\n"+
+			"VITE_REVERB_SCHEME=https\n"+
+			"VITE_REVERB_PORT=443\n",
+	), 0644)
+
+	if err := SyncPrimaryDomain(dir, "new.test", false); err != nil {
+		t.Fatal(err)
+	}
+	got := readEnv(t, filepath.Join(dir, ".env"))
+
+	if !strings.Contains(got, "APP_URL=http://new.test") {
+		t.Errorf("APP_URL not updated:\n%s", got)
+	}
+	if !strings.Contains(got, "VITE_REVERB_HOST=new.test") {
+		t.Errorf("VITE_REVERB_HOST not updated:\n%s", got)
+	}
+	if !strings.Contains(got, "VITE_REVERB_SCHEME=http") {
+		t.Errorf("VITE_REVERB_SCHEME not updated:\n%s", got)
+	}
+	if !strings.Contains(got, "VITE_REVERB_PORT=80") {
+		t.Errorf("VITE_REVERB_PORT not updated:\n%s", got)
+	}
+}
+
+func TestSyncPrimaryDomain_skipsAbsentKeys(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte(
+		"APP_URL=http://old.test\nAPP_NAME=MyApp\n",
+	), 0644)
+
+	if err := SyncPrimaryDomain(dir, "new.test", true); err != nil {
+		t.Fatal(err)
+	}
+	got := readEnv(t, filepath.Join(dir, ".env"))
+
+	if !strings.Contains(got, "APP_URL=https://new.test") {
+		t.Errorf("APP_URL not updated:\n%s", got)
+	}
+	// VITE_REVERB_HOST should NOT be added
+	if strings.Contains(got, "VITE_REVERB_HOST") {
+		t.Errorf("VITE_REVERB_HOST should not be added when absent:\n%s", got)
+	}
+}
+
+func TestSyncPrimaryDomain_noEnvFile_silent(t *testing.T) {
+	err := SyncPrimaryDomain(t.TempDir(), "new.test", true)
+	if err != nil {
+		t.Errorf("expected no error for missing .env, got: %v", err)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2949,6 +2949,10 @@ func execSiteDomainAdd(args map[string]any) (any, *rpcError) {
 	_ = podman.WriteContainerHosts()
 	_ = nginx.Reload()
 
+	if site.PrimaryDomain() != oldPrimary {
+		_ = envfile.SyncPrimaryDomain(site.Path, site.PrimaryDomain(), site.Secured)
+	}
+
 	return toolOK(fmt.Sprintf("Added domain %s to site %s", fullDomain, site.Name)), nil
 }
 
@@ -3007,6 +3011,10 @@ func execSiteDomainRemove(args map[string]any) (any, *rpcError) {
 
 	_ = podman.WriteContainerHosts()
 	_ = nginx.Reload()
+
+	if site.PrimaryDomain() != oldPrimary {
+		_ = envfile.SyncPrimaryDomain(site.Path, site.PrimaryDomain(), site.Secured)
+	}
 
 	return toolOK(fmt.Sprintf("Removed domain %s from site %s", fullDomain, site.Name)), nil
 }


### PR DESCRIPTION
## Summary

- adds {{domain}} and {{scheme}} template variables for framework env var definitions, so framework authors can write things like VITE_REVERB_HOST={{domain}} directly in service vars
- syncs APP_URL, VITE_REVERB_HOST, VITE_REVERB_SCHEME, and VITE_REVERB_PORT in .env automatically when the primary domain changes via domain add/remove, only touching keys that already exist
- documents all available template variables in docs/usage/frameworks.md