### PR TITLE
docs: clarify that php artisan and lerd artisan are equivalent

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -180,7 +180,7 @@ Requires [Laravel Broadcasting](https://laravel.com/docs/13.x/broadcasting) with
 | Command | Description |
 |---|---|
 | `lerd console [args...]` | Run the framework's console command (e.g., `php artisan` for Laravel, `php bin/console` for Symfony) inside the project's PHP-FPM container |
-| `lerd artisan [args...]` | Alias for `lerd console` (Laravel-specific, kept for backward compatibility) |
+| `lerd artisan [args...]` | Alias for `lerd console` — equivalent to `php artisan` since the `php` shim also runs inside the FPM container |
 | `lerd a [args...]` | Short alias for `lerd console` / `lerd artisan` |
 | `lerd test [args...]` | Shortcut for `lerd artisan test` |
 | `lerd <vendor-bin> [args...]` | Run any composer-installed binary from the project's `vendor/bin` directory (e.g. `lerd pest`, `lerd pint`, `lerd phpstan`). Real lerd commands always win over vendor binaries with the same name. |

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -30,6 +30,8 @@ php artisan migrate
 composer install
 ```
 
+Because the `php` shim runs inside the PHP-FPM container, `php artisan`, `lerd artisan`, and the MCP `artisan` tool are all equivalent — they all execute inside the same container with the same PHP version and extensions. Use whichever form you prefer.
+
 ### Shortcuts and `vendor/bin` fallback
 
 For common workflows there are a few built-in shortcuts:


### PR DESCRIPTION
## Summary

- Added a note in the PHP usage guide explaining that `php artisan`, `lerd artisan`, and the MCP `artisan` tool all run inside the same PHP-FPM container and are equivalent
- Updated the command reference table to reflect this

Ref #132