### PR TITLE
feat: add ghostscript to PHP-FPM base image

### DIFF
--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -6,6 +6,7 @@ RUN apk update && apk add --no-cache \
         make \
         g++ \
         git \
+        ghostscript \
         curl-dev \
         libzip-dev \
         libpng-dev \


### PR DESCRIPTION
adds ghostscript to the base apk install in the PHP-FPM Containerfile so packages like spatie/pdf-to-image that need Imagick + Ghostscript work out of the box

Closes #135