### PR TITLE
fix: always pull fresh base images on php:rebuild

### DIFF
--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -226,7 +226,7 @@ func tryPullBaseImage(version string, w io.Writer) string {
 		defer os.Remove(tmpAuth.Name())
 	}
 
-	args := []string{"pull"}
+	args := []string{"pull", "--policy=always"}
 	if tmpAuth != nil {
 		args = append(args, "--authfile="+tmpAuth.Name())
 	}
@@ -270,6 +270,9 @@ func buildFPMImage(version string, force, local bool, customExts []string, w io.
 			containerfile = "FROM " + baseRef + "\n" +
 				buildCustomExtBlock(customExts) +
 				mkcertCABlock(tmp)
+			if force {
+				buildArgs = append(buildArgs, "--no-cache")
+			}
 			goto build
 		}
 	}


### PR DESCRIPTION
podman pull was using locally cached images even when newer versions existed on GHCR. adds --policy=always so it always checks the registry, and --no-cache on the fast path build so the FROM layer isn't reused from a stale cache