### PR TITLE
fix: add mysql-client to PHP-FPM image

### DIFF
--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -25,6 +25,7 @@ RUN apk update && apk add --no-cache \
         openldap-dev \
         sqlite-dev \
         libxslt-dev \
+        mysql-client \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j$(nproc) \
         curl \


### PR DESCRIPTION
Laravel commands like `php artisan schema:dump` shell out to mysqldump, which was missing from the Alpine-based PHP-FPM container. This PR adds mysql-client to the image.

Addresses #141 