### PR TITLE
fix: resolve dynamic_env when generating custom service quadlets

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,14 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.10.1] — 2026-04-10
+
+### Fixed
+
+- **phpMyAdmin (and other `dynamic_env` presets) connected to wrong host** — the Web UI and MCP `service_start`/`service_add` code paths generated custom service quadlets without resolving `dynamic_env` directives, so `PMA_HOSTS` was never set and phpMyAdmin fell back to its default host `db`. All three paths now delegate to `serviceops.EnsureCustomServiceQuadlet` which handles `dynamic_env` resolution and file materialisation.
+
+---
+
 ## [1.10.0] — 2026-04-10
 
 ### Added

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1753,8 +1753,7 @@ func execServiceStart(args map[string]any) (any, *rpcError) {
 		if err != nil {
 			return toolErr("unknown service: " + name + ". Use service_add to register a custom service first."), nil
 		}
-		content := podman.GenerateCustomQuadlet(svc)
-		if err := podman.WriteQuadlet(unitName, content); err != nil {
+		if err := serviceops.EnsureCustomServiceQuadlet(svc); err != nil {
 			return toolErr("writing quadlet: " + err.Error()), nil
 		}
 	}
@@ -2832,19 +2831,8 @@ func execServiceAdd(args map[string]any) (any, *rpcError) {
 		return toolErr("saving service config: " + err.Error()), nil
 	}
 
-	if svc.DataDir != "" {
-		if err := os.MkdirAll(config.DataSubDir(svc.Name), 0755); err != nil {
-			return toolErr("creating data directory: " + err.Error()), nil
-		}
-	}
-
-	content := podman.GenerateCustomQuadlet(svc)
-	unitName := "lerd-" + name
-	if err := podman.WriteQuadlet(unitName, content); err != nil {
+	if err := serviceops.EnsureCustomServiceQuadlet(svc); err != nil {
 		return toolErr("writing quadlet: " + err.Error()), nil
-	}
-	if err := podman.DaemonReload(); err != nil {
-		return toolErr("daemon-reload: " + err.Error()), nil
 	}
 
 	return toolOK(fmt.Sprintf("Custom service %q added. Start it with service_start(name: %q).", name, name)), nil

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -27,6 +27,7 @@ import (
 	nodePkg "github.com/geodro/lerd/internal/node"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/serviceops"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	lerdUpdate "github.com/geodro/lerd/internal/update"
 )
@@ -1324,17 +1325,7 @@ func ensureServiceQuadlet(name string) error {
 
 // ensureCustomServiceQuadlet writes the quadlet for a custom service and reloads systemd.
 func ensureCustomServiceQuadlet(svc *config.CustomService) error {
-	if svc.DataDir != "" {
-		if err := os.MkdirAll(config.DataSubDir(svc.Name), 0755); err != nil {
-			return fmt.Errorf("creating data directory for %s: %w", svc.Name, err)
-		}
-	}
-	content := podman.GenerateCustomQuadlet(svc)
-	quadletName := "lerd-" + svc.Name
-	if err := podman.WriteQuadlet(quadletName, content); err != nil {
-		return fmt.Errorf("writing quadlet for %s: %w", svc.Name, err)
-	}
-	return podman.DaemonReload()
+	return serviceops.EnsureCustomServiceQuadlet(svc)
 }
 
 // countSitesUsingService counts how many active site .env files reference lerd-{name}.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.10.0"
+	Version = "1.10.1"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary
- Web UI and MCP service_start/service_add generated custom service quadlets without resolving dynamic_env directives, so presets like phpMyAdmin never got PMA_HOSTS set and fell back to the default host "db"
- All three paths now delegate to serviceops.EnsureCustomServiceQuadlet which handles dynamic_env resolution and file materialisation