### PR TITLE
feat: macOS service management — workers UI, tray fix, parallel start, LAN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,15 @@ install: build build-tray
 	install -Dm755 $(BUILD_DIR)/$(BINARY) $(INSTALL_DIR)/$(BINARY)
 	install -Dm755 $(BUILD_DIR)/lerd-tray $(INSTALL_DIR)/lerd-tray
 	@echo "Installed $(INSTALL_DIR)/$(BINARY) and $(INSTALL_DIR)/lerd-tray"
-	@systemctl --user is-active --quiet lerd-ui 2>/dev/null && systemctl --user restart lerd-ui && echo "Restarted lerd-ui" || true
-	@systemctl --user is-active --quiet lerd-watcher 2>/dev/null && systemctl --user restart lerd-watcher && echo "Restarted lerd-watcher" || true
-	@systemctl --user is-active --quiet lerd-tray 2>/dev/null && systemctl --user restart lerd-tray || true
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		launchctl kickstart -k gui/$$(id -u)/com.lerd.lerd-ui 2>/dev/null && echo "Restarted lerd-ui" || true; \
+		launchctl kickstart -k gui/$$(id -u)/com.lerd.lerd-watcher 2>/dev/null && echo "Restarted lerd-watcher" || true; \
+		launchctl kickstart -k gui/$$(id -u)/com.lerd.lerd-tray 2>/dev/null || true; \
+	else \
+		systemctl --user is-active --quiet lerd-ui 2>/dev/null && systemctl --user restart lerd-ui && echo "Restarted lerd-ui" || true; \
+		systemctl --user is-active --quiet lerd-watcher 2>/dev/null && systemctl --user restart lerd-watcher && echo "Restarted lerd-watcher" || true; \
+		systemctl --user is-active --quiet lerd-tray 2>/dev/null && systemctl --user restart lerd-tray || true; \
+	fi
 
 # Install the installer script as 'lerd-installer' so users can run
 # lerd-installer --update  or  lerd-installer --uninstall

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -64,7 +64,7 @@ func runConsole(_ *cobra.Command, args []string) error {
 	cmdArgs := append(execFlags, "-w", cwd, container, "php", consoleCmd)
 	cmdArgs = append(cmdArgs, args...)
 
-	cmd := exec.Command("podman", cmdArgs...)
+	cmd := podman.Cmd( cmdArgs...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
 
@@ -149,10 +150,10 @@ func runDbImport(file, database string) error {
 func dbImportCmd(env *dbEnv) (*exec.Cmd, error) {
 	switch env.connection {
 	case "mysql", "mariadb":
-		return exec.Command("podman", "exec", "-i", "lerd-mysql",
+		return podman.Cmd( "exec", "-i", "lerd-mysql",
 			"mysql", "-u"+env.username, "-p"+env.password, env.database), nil
 	case "pgsql", "postgres":
-		return exec.Command("podman", "exec", "-i", "-e", "PGPASSWORD="+env.password,
+		return podman.Cmd( "exec", "-i", "-e", "PGPASSWORD="+env.password,
 			"lerd-postgres", "psql", "-U", env.username, env.database), nil
 	default:
 		return nil, fmt.Errorf("unsupported DB_CONNECTION: %q (supported: mysql, pgsql)", env.connection)
@@ -204,10 +205,10 @@ func runDbExport(output, database string) error {
 func dbExportCmd(env *dbEnv) (*exec.Cmd, error) {
 	switch env.connection {
 	case "mysql", "mariadb":
-		return exec.Command("podman", "exec", "-i", "lerd-mysql",
+		return podman.Cmd( "exec", "-i", "lerd-mysql",
 			"mysqldump", "-u"+env.username, "-p"+env.password, env.database), nil
 	case "pgsql", "postgres":
-		return exec.Command("podman", "exec", "-i", "-e", "PGPASSWORD="+env.password,
+		return podman.Cmd( "exec", "-i", "-e", "PGPASSWORD="+env.password,
 			"lerd-postgres", "pg_dump", "-U", env.username, env.database), nil
 	default:
 		return nil, fmt.Errorf("unsupported DB_CONNECTION: %q (supported: mysql, pgsql)", env.connection)
@@ -299,13 +300,13 @@ func runDbShell() error {
 		if dbName != "" {
 			cmdArgs = append(cmdArgs, dbName)
 		}
-		cmd = exec.Command("podman", cmdArgs...)
+		cmd = podman.Cmd( cmdArgs...)
 	default:
 		cmdArgs := []string{"exec", "--tty", "-i", "lerd-mysql", "mysql", "-uroot", "-plerd"}
 		if dbName != "" {
 			cmdArgs = append(cmdArgs, dbName)
 		}
-		cmd = exec.Command("podman", cmdArgs...)
+		cmd = podman.Cmd( cmdArgs...)
 	}
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -183,7 +183,7 @@ func regenerateLANContainerQuadlets(progress LANProgressFunc) error {
 		if err != nil {
 			return fmt.Errorf("reading %s quadlet template: %w", name, err)
 		}
-		if err := podman.WriteQuadlet(name, content); err != nil {
+		if err := podman.WriteContainerUnitFn(name, content); err != nil {
 			return fmt.Errorf("rewriting %s quadlet: %w", name, err)
 		}
 		restarted = append(restarted, name)

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -537,7 +536,7 @@ func createDatabase(svc, name string) (bool, error) {
 		}
 		var lastErr error
 		for _, bin := range binaries {
-			check := exec.Command("podman", "exec", container, bin, "-uroot", "-plerd",
+			check := podman.Cmd( "exec", container, bin, "-uroot", "-plerd",
 				"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", name))
 			out, err := check.Output()
 			if err != nil {
@@ -547,14 +546,14 @@ func createDatabase(svc, name string) (bool, error) {
 			if strings.TrimSpace(string(out)) != "0" {
 				return false, nil
 			}
-			cmd := exec.Command("podman", "exec", container, bin, "-uroot", "-plerd",
+			cmd := podman.Cmd( "exec", container, bin, "-uroot", "-plerd",
 				"-e", fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`;", name))
 			cmd.Stderr = os.Stderr
 			return true, cmd.Run()
 		}
 		return false, lastErr
 	case "postgres":
-		cmd := exec.Command("podman", "exec", container, "psql", "-U", "postgres",
+		cmd := podman.Cmd( "exec", container, "psql", "-U", "postgres",
 			"-c", fmt.Sprintf(`CREATE DATABASE "%s";`, name))
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -602,19 +601,19 @@ func createS3Bucket(name string) (bool, error) {
 		mcEnv   = "MC_HOST_lerd=http://lerd:lerdpassword@lerd-rustfs:9000"
 	)
 
-	lsCmd := exec.Command("podman", "run", "--rm", "--network", "lerd",
+	lsCmd := podman.Cmd( "run", "--rm", "--network", "lerd",
 		"-e", mcEnv, mcImage, "ls", alias+"/"+name)
 	if err := lsCmd.Run(); err == nil {
 		return false, nil
 	}
 
-	mbCmd := exec.Command("podman", "run", "--rm", "--network", "lerd",
+	mbCmd := podman.Cmd( "run", "--rm", "--network", "lerd",
 		"-e", mcEnv, mcImage, "mb", alias+"/"+name)
 	if out, err := mbCmd.CombinedOutput(); err != nil {
 		return false, fmt.Errorf("%s", strings.TrimSpace(string(out)))
 	}
 
-	pubCmd := exec.Command("podman", "run", "--rm", "--network", "lerd",
+	pubCmd := podman.Cmd( "run", "--rm", "--network", "lerd",
 		"-e", mcEnv, mcImage, "anonymous", "set", "public", alias+"/"+name)
 	if out, err := pubCmd.CombinedOutput(); err != nil {
 		return false, fmt.Errorf("mc anonymous set public: %s", strings.TrimSpace(string(out)))
@@ -790,7 +789,7 @@ func artisanIn(dir string, args ...string) error {
 	cmdArgs := []string{"exec", "-i", "-w", dir, container, "php", "artisan"}
 	cmdArgs = append(cmdArgs, args...)
 
-	cmd := exec.Command("podman", cmdArgs...)
+	cmd := podman.Cmd( cmdArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -832,7 +831,7 @@ func runSiteInit(svc *config.CustomService, ctx siteTemplateCtx) {
 		container = "lerd-" + svc.Name
 	}
 	script := applySiteHandle(svc.SiteInit.Exec, ctx)
-	cmd := exec.Command("podman", "exec", container, "sh", "-c", script)
+	cmd := podman.Cmd( "exec", container, "sh", "-c", script)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/internal/cli/horizon.go
+++ b/internal/cli/horizon.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
 
@@ -118,11 +119,11 @@ BindsTo=%s.service
 Type=simple
 Restart=always
 RestartSec=5
-ExecStart=podman exec -w %s %s php artisan horizon
+ExecStart=%s exec -w %s %s php artisan horizon
 
 [Install]
 WantedBy=default.target
-`, siteName, fpmUnit, fpmUnit, fpmUnit, sitePath, container)
+`, siteName, fpmUnit, fpmUnit, fpmUnit, podman.PodmanBin(), sitePath, container)
 }
 
 // HorizonStopForSite stops and removes the Horizon unit for the named site.

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -418,10 +418,10 @@ func runInstall(_ *cobra.Command, _ []string) error {
 		}
 	}
 
+	killTray()
 	if services.Mgr.IsEnabled("lerd-tray") {
-		_ = services.Mgr.Restart("lerd-tray")
+		_ = services.Mgr.Start("lerd-tray")
 	} else {
-		killTray()
 		if exe, err := os.Executable(); err == nil {
 			_ = exec.Command(exe, "tray").Start()
 		}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -261,7 +261,7 @@ func runInstall(_ *cobra.Command, _ []string) error {
 		{
 			Label: "Pulling nginx:alpine",
 			Run: func(w io.Writer) error {
-				cmd := exec.Command("podman", "pull", "docker.io/library/nginx:alpine")
+				cmd := podman.Cmd( "pull", "docker.io/library/nginx:alpine")
 				cmd.Stdout = w
 				cmd.Stderr = w
 				return cmd.Run()
@@ -335,11 +335,11 @@ func runInstall(_ *cobra.Command, _ []string) error {
 
 	step("Writing watcher service")
 	if content, err := lerdSystemd.GetUnit("lerd-watcher"); err == nil {
-		if err := lerdSystemd.WriteService("lerd-watcher", content); err != nil {
+		if err := services.Mgr.WriteServiceUnit("lerd-watcher", content); err != nil {
 			return err
 		}
 		if autostartOn {
-			if err := lerdSystemd.EnableService("lerd-watcher"); err != nil {
+			if err := services.Mgr.Enable("lerd-watcher"); err != nil {
 				fmt.Printf("    WARN: %v\n", err)
 			}
 		}
@@ -356,11 +356,11 @@ func runInstall(_ *cobra.Command, _ []string) error {
 
 	step("Writing UI service")
 	if content, err := lerdSystemd.GetUnit("lerd-ui"); err == nil {
-		if err := lerdSystemd.WriteService("lerd-ui", content); err != nil {
+		if err := services.Mgr.WriteServiceUnit("lerd-ui", content); err != nil {
 			return err
 		}
 		if autostartOn {
-			if err := lerdSystemd.EnableService("lerd-ui"); err != nil {
+			if err := services.Mgr.Enable("lerd-ui"); err != nil {
 				fmt.Printf("    WARN: %v\n", err)
 			}
 		}
@@ -377,11 +377,11 @@ func runInstall(_ *cobra.Command, _ []string) error {
 
 	step("Writing tray service")
 	if content, err := lerdSystemd.GetUnit("lerd-tray"); err == nil {
-		if err := lerdSystemd.WriteService("lerd-tray", content); err != nil {
+		if err := services.Mgr.WriteServiceUnit("lerd-tray", content); err != nil {
 			return err
 		}
 		if autostartOn {
-			if err := lerdSystemd.EnableService("lerd-tray"); err != nil {
+			if err := services.Mgr.Enable("lerd-tray"); err != nil {
 				fmt.Printf("    WARN: %v\n", err)
 			}
 		}
@@ -394,6 +394,12 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	// on later. restoreSiteInfrastructure only writes files for units
 	// that don't already exist, so this is a no-op for ordinary updates.
 	restoreSiteInfrastructure()
+
+	// Ensure all globally configured services have unit files on disk.
+	// On macOS this writes launchd plists for any service that has a config
+	// entry but no plist (e.g. services installed before the macOS port, or
+	// after a clean install from config backup).
+	migrateServiceUnits()
 
 	// Start service containers and workers only when autostart is on.
 	// When the user has explicitly disabled autostart we leave them
@@ -412,8 +418,8 @@ func runInstall(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	if lerdSystemd.IsServiceEnabled("lerd-tray") {
-		_ = lerdSystemd.RestartService("lerd-tray")
+	if services.Mgr.IsEnabled("lerd-tray") {
+		_ = services.Mgr.Restart("lerd-tray")
 	} else {
 		killTray()
 		if exe, err := os.Executable(); err == nil {
@@ -502,6 +508,18 @@ func installLaravelInstaller() error {
 		if err := podman.StartUnit(container); err != nil {
 			return fmt.Errorf("starting %s: %w", container, err)
 		}
+		// Wait for the container to be ready for exec (launchd starts the
+		// podman run -d asynchronously, so the container may not exist yet).
+		deadline := time.Now().Add(30 * time.Second)
+		for time.Now().Before(deadline) {
+			if r, _ := podman.ContainerRunning(container); r {
+				break
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+		if r, _ := podman.ContainerRunning(container); !r {
+			return fmt.Errorf("%s did not become ready within 30s", container)
+		}
 	}
 
 	home := os.Getenv("HOME")
@@ -518,7 +536,7 @@ func installLaravelInstaller() error {
 	// --no-interaction prevents composer from blocking on plugin trust prompts
 	// (e.g. "Do you trust 'symfony/flex' to execute code?") which would hang
 	// the installer with no visible output.
-	cmd := exec.Command("podman", "exec", "-i",
+	cmd := podman.Cmd( "exec", "-i",
 		"--env", "HOME="+home,
 		"--env", "COMPOSER_HOME="+composerHome,
 		container, "php", composerPhar, "global", "require", "--no-interaction", "laravel/installer",

--- a/internal/cli/install_dns_darwin.go
+++ b/internal/cli/install_dns_darwin.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
 )
 
@@ -47,8 +48,8 @@ func installDNSService(w io.Writer) error {
 	// Stop and remove any running lerd-dns container. Container units use
 	// --restart=always which keeps the container alive independently of launchd;
 	// it must be removed before native dnsmasq can bind to port 5300.
-	exec.Command("podman", "stop", "lerd-dns").Run()     //nolint:errcheck
-	exec.Command("podman", "rm", "-f", "lerd-dns").Run() //nolint:errcheck
+	podman.Cmd( "stop", "lerd-dns").Run()     //nolint:errcheck
+	podman.Cmd( "rm", "-f", "lerd-dns").Run() //nolint:errcheck
 
 	// Write the launchd plist for lerd-dns using the native dnsmasq binary.
 	// KeepAlive=true keeps dnsmasq running; the service unit mechanism uses
@@ -156,8 +157,8 @@ func ensureDNSServiceUpdated(w io.Writer) error {
 // removeDNSContainerIfRunning stops and removes the legacy lerd-dns container
 // if it's still running (migration from container-based to native DNS).
 func removeDNSContainerIfRunning() {
-	exec.Command("podman", "stop", "lerd-dns").Run()     //nolint:errcheck
-	exec.Command("podman", "rm", "-f", "lerd-dns").Run() //nolint:errcheck
+	podman.Cmd( "stop", "lerd-dns").Run()     //nolint:errcheck
+	podman.Cmd( "rm", "-f", "lerd-dns").Run() //nolint:errcheck
 }
 
 // nativeDNSRestart restarts the native dnsmasq launchd service.

--- a/internal/cli/loghint_darwin.go
+++ b/internal/cli/loghint_darwin.go
@@ -1,0 +1,17 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// unitLogHint returns the shell command a user can run to view recent unit logs.
+// On macOS, launchd services log to ~/Library/Logs/lerd/<unit>.log.
+func unitLogHint(unitName string) string {
+	home, _ := os.UserHomeDir()
+	logPath := filepath.Join(home, "Library", "Logs", "lerd", unitName+".log")
+	return fmt.Sprintf("tail -n 20 %s", logPath)
+}

--- a/internal/cli/loghint_linux.go
+++ b/internal/cli/loghint_linux.go
@@ -1,0 +1,10 @@
+//go:build linux
+
+package cli
+
+import "fmt"
+
+// unitLogHint returns the shell command a user can run to view recent unit logs.
+func unitLogHint(unitName string) string {
+	return fmt.Sprintf("journalctl --user -u %s -n 20", unitName)
+}

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -3,11 +3,11 @@ package cli
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
 	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
 
@@ -42,7 +42,7 @@ Target can be:
 			}
 			cmdArgs = append(cmdArgs, container)
 
-			cmd := exec.Command("podman", cmdArgs...)
+			cmd := podman.Cmd( cmdArgs...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			return cmd.Run()

--- a/internal/cli/minio_migrate.go
+++ b/internal/cli/minio_migrate.go
@@ -55,7 +55,7 @@ func runMinioMigrate(_ *cobra.Command, _ []string) error {
 	} else {
 		fmt.Println("done")
 	}
-	if err := podman.DaemonReload(); err != nil {
+	if err := podman.DaemonReloadFn(); err != nil {
 		fmt.Printf("  warn: daemon-reload failed: %v\n", err)
 	}
 

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -101,7 +101,7 @@ func RunPHP(cwd string, args []string) error {
 	)
 	cmdArgs = append(cmdArgs, args...)
 
-	cmd := exec.Command("podman", cmdArgs...)
+	cmd := podman.Cmd( cmdArgs...)
 	cmd.Stdin = stdinReader
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/cli/php_shell.go
+++ b/internal/cli/php_shell.go
@@ -52,7 +52,7 @@ func runPhpShell(_ *cobra.Command, _ []string) error {
 	podman.EnsurePathMounted(workDir, version)
 	ensureServicesForCwd(workDir)
 
-	cmd := exec.Command("podman", "exec", "-it", "-w", workDir, container, "sh")
+	cmd := podman.Cmd( "exec", "-it", "-w", workDir, container, "sh")
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/cli/queue.go
+++ b/internal/cli/queue.go
@@ -191,11 +191,11 @@ BindsTo=%s.service
 Type=simple
 Restart=always
 RestartSec=5
-ExecStart=podman exec -w %s %s php artisan %s
+ExecStart=%s exec -w %s %s php artisan %s
 
 [Install]
 WantedBy=default.target
-`, siteName, afterLine, wantsLine, fpmUnit, sitePath, container, artisanArgs)
+`, siteName, afterLine, wantsLine, fpmUnit, podman.PodmanBin(), sitePath, container, artisanArgs)
 }
 
 // queueDependencyUnits returns the lerd service unit(s) the queue worker
@@ -238,7 +238,7 @@ func QueueRestartForSite(siteName, sitePath, phpVersion string) error {
 	if data, err := os.ReadFile(unitFile); err == nil {
 		if updated := strings.ReplaceAll(string(data), "Restart=on-failure", "Restart=always"); updated != string(data) {
 			if writeErr := os.WriteFile(unitFile, []byte(updated), 0644); writeErr == nil {
-				_ = podman.DaemonReload()
+				_ = podman.DaemonReloadFn()
 			}
 		}
 	}

--- a/internal/cli/queue_test.go
+++ b/internal/cli/queue_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/podman"
 )
 
 // writeTempEnv creates a temp dir with a .env file containing the given
@@ -94,7 +96,7 @@ func TestBuildQueueUnit_RedisBackendRendersDependencies(t *testing.T) {
 	mustContain(t, unit, "Wants=lerd-php84-fpm.service lerd-redis.service")
 	mustContain(t, unit, "BindsTo=lerd-php84-fpm.service")
 	mustContain(t, unit, "Restart=always")
-	mustContain(t, unit, "ExecStart=podman exec -w "+sitePath+" lerd-php84-fpm php artisan queue:work --queue=default --tries=3 --timeout=60")
+	mustContain(t, unit, "ExecStart="+podman.PodmanBin()+" exec -w "+sitePath+" lerd-php84-fpm php artisan queue:work --queue=default --tries=3 --timeout=60")
 	mustContain(t, unit, "WantedBy=default.target")
 }
 
@@ -127,7 +129,7 @@ func TestBuildHorizonUnit_AlwaysDependsOnRedis(t *testing.T) {
 	mustContain(t, unit, "After=network.target lerd-php84-fpm.service lerd-redis.service")
 	mustContain(t, unit, "Wants=lerd-php84-fpm.service lerd-redis.service")
 	mustContain(t, unit, "BindsTo=lerd-php84-fpm.service")
-	mustContain(t, unit, "ExecStart=podman exec -w /home/u/score-diviner lerd-php84-fpm php artisan horizon")
+	mustContain(t, unit, "ExecStart="+podman.PodmanBin()+" exec -w /home/u/score-diviner lerd-php84-fpm php artisan horizon")
 }
 
 func mustContain(t *testing.T, body, needle string) {

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -589,7 +589,7 @@ func newServiceRemoveCmd() *cobra.Command {
 			if err := podman.RemoveQuadlet(unit); err != nil {
 				fmt.Printf("  WARN: could not remove quadlet: %v\n", err)
 			}
-			if err := podman.DaemonReload(); err != nil {
+			if err := podman.DaemonReloadFn(); err != nil {
 				fmt.Printf("  WARN: daemon-reload failed: %v\n", err)
 			}
 
@@ -609,7 +609,20 @@ func newServiceRemoveCmd() *cobra.Command {
 	}
 }
 
-// ensureServiceQuadlet writes the quadlet for a known service and reloads systemd if needed.
+// migrateServiceUnits rewrites unit files for all globally configured services.
+// This ensures BindForLAN and other install-time settings are applied even for
+// services that already have a unit file on disk.
+func migrateServiceUnits() {
+	for _, svc := range knownServices {
+		ensureServiceQuadlet(svc) //nolint:errcheck
+	}
+	customs, _ := config.ListCustomServices()
+	for _, svc := range customs {
+		ensureCustomServiceQuadlet(svc) //nolint:errcheck
+	}
+}
+
+// ensureServiceQuadlet writes the unit file for a known service and reloads the service manager.
 func ensureServiceQuadlet(name string) error {
 	quadletName := "lerd-" + name
 	content, err := podman.GetQuadletTemplate(quadletName + ".container")
@@ -617,14 +630,17 @@ func ensureServiceQuadlet(name string) error {
 		return fmt.Errorf("unknown service %q", name)
 	}
 	if cfg, loadErr := config.LoadGlobal(); loadErr == nil {
-		if svcCfg, ok := cfg.Services[name]; ok && len(svcCfg.ExtraPorts) > 0 {
-			content = podman.ApplyExtraPorts(content, svcCfg.ExtraPorts)
+		if svcCfg, ok := cfg.Services[name]; ok {
+			content = podman.ApplyImage(content, svcCfg.Image)
+			if len(svcCfg.ExtraPorts) > 0 {
+				content = podman.ApplyExtraPorts(content, svcCfg.ExtraPorts)
+			}
 		}
 	}
-	if err := podman.WriteQuadlet(quadletName, content); err != nil {
-		return fmt.Errorf("writing quadlet for %s: %w", name, err)
+	if err := podman.WriteContainerUnitFn(quadletName, content); err != nil {
+		return fmt.Errorf("writing unit for %s: %w", name, err)
 	}
-	return podman.DaemonReload()
+	return podman.DaemonReloadFn()
 }
 
 // ensureCustomServiceQuadlet defers to serviceops so the CLI and the MCP

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -446,7 +445,7 @@ func composerInContainer(dir string, args ...string) error {
 	}
 	cmdArgs = append(cmdArgs, args...)
 
-	cmd := exec.Command("podman", cmdArgs...)
+	cmd := podman.Cmd( cmdArgs...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -467,7 +466,7 @@ func execInContainer(dir, command string) error {
 		return fmt.Errorf("empty setup command")
 	}
 	cmdArgs := append([]string{"exec", "-i", "-w", dir, container}, parts...)
-	cmd := exec.Command("podman", cmdArgs...)
+	cmd := podman.Cmd( cmdArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -432,7 +432,10 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// Prefer the systemd service when enabled; otherwise launch directly.
 	fmt.Print("  --> lerd-tray ... ")
 	if services.Mgr.IsEnabled("lerd-tray") {
-		if err := services.Mgr.Restart("lerd-tray"); err != nil {
+		// Use Start (bootout+bootstrap) instead of Restart (kickstart -k) to
+		// avoid launchctl hanging while waiting for the tray process to die.
+		killTray()
+		if err := services.Mgr.Start("lerd-tray"); err != nil {
 			fmt.Printf("WARN (%v)\n", err)
 		} else {
 			fmt.Println("OK")

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -15,7 +15,7 @@ import (
 	"github.com/geodro/lerd/internal/nginx"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
-	lerdSystemd "github.com/geodro/lerd/internal/systemd"
+	"github.com/geodro/lerd/internal/services"
 	"github.com/spf13/cobra"
 )
 
@@ -60,7 +60,7 @@ func ensureImages() {
 				Label: "Building dnsmasq",
 				Run: func(w io.Writer) error {
 					containerfile := "FROM docker.io/library/alpine:latest\nRUN apk add --no-cache dnsmasq\n"
-					cmd := exec.Command("podman", "build", "-t", "lerd-dnsmasq:local", "-")
+					cmd := podman.Cmd( "build", "-t", "lerd-dnsmasq:local", "-")
 					cmd.Stdin = strings.NewReader(containerfile)
 					cmd.Stdout = w
 					cmd.Stderr = w
@@ -83,7 +83,7 @@ func ensureImages() {
 			jobs = append(jobs, BuildJob{
 				Label: "Pulling " + label,
 				Run: func(w io.Writer) error {
-					cmd := exec.Command("podman", "pull", label)
+					cmd := podman.Cmd( "pull", label)
 					cmd.Stdout = w
 					cmd.Stderr = w
 					return cmd.Run()
@@ -142,36 +142,36 @@ func coreUnits() []string {
 	return units
 }
 
-// installedServiceUnits returns service units that have a quadlet file installed
+// installedServiceUnits returns service units that have a unit file installed
 // and have not been manually stopped by the user. Used for lerd start.
 func installedServiceUnits() []string {
 	var units []string
 	for _, svc := range knownServices {
-		if podman.QuadletInstalled("lerd-"+svc) && !config.ServiceIsPaused(svc) {
+		if services.Mgr.ContainerUnitInstalled("lerd-"+svc) && !config.ServiceIsPaused(svc) {
 			units = append(units, "lerd-"+svc)
 		}
 	}
 	customs, _ := config.ListCustomServices()
 	for _, svc := range customs {
-		if podman.QuadletInstalled("lerd-"+svc.Name) && !config.ServiceIsPaused(svc.Name) {
+		if services.Mgr.ContainerUnitInstalled("lerd-"+svc.Name) && !config.ServiceIsPaused(svc.Name) {
 			units = append(units, "lerd-"+svc.Name)
 		}
 	}
 	return units
 }
 
-// allInstalledServiceUnits returns all service units that have a quadlet file
+// allInstalledServiceUnits returns all service units that have a unit file
 // installed, regardless of paused state. Used for lerd stop.
 func allInstalledServiceUnits() []string {
 	var units []string
 	for _, svc := range knownServices {
-		if podman.QuadletInstalled("lerd-" + svc) {
+		if services.Mgr.ContainerUnitInstalled("lerd-" + svc) {
 			units = append(units, "lerd-"+svc)
 		}
 	}
 	customs, _ := config.ListCustomServices()
 	for _, svc := range customs {
-		if podman.QuadletInstalled("lerd-" + svc.Name) {
+		if services.Mgr.ContainerUnitInstalled("lerd-" + svc.Name) {
 			units = append(units, "lerd-"+svc.Name)
 		}
 	}
@@ -308,6 +308,14 @@ func runStart(_ *cobra.Command, _ []string) error {
 	ensurePodmanMachineRunning()
 	migrateExecWorkerPlists()
 
+	// Ensure the lerd bridge network exists. On macOS the network is stored
+	// inside the Podman Machine VM; it may be absent after a fresh machine
+	// init or if it was pruned. All service containers use --network lerd so
+	// this must succeed before any container is started.
+	if err := podman.EnsureNetwork("lerd"); err != nil {
+		fmt.Printf("  WARN: ensure lerd network: %v\n", err)
+	}
+
 	// Restore quadlets and worker units that may be missing after an
 	// uninstall/reinstall cycle. Reads .lerd.yaml from each active site.
 	restoreSiteInfrastructure()
@@ -351,32 +359,40 @@ func runStart(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	units = append(coreUnits(), installedServiceUnits()...)
-	units = append(units, "lerd-ui", "lerd-watcher")
-	units = append(units, registeredQueueUnits()...)
-	units = append(units, registeredStripeUnits()...)
-	units = append(units, registeredScheduleUnits()...)
-	units = append(units, registeredReverbUnits()...)
+	// Phase 1: start all infrastructure (containers, FPM, UI, watcher) before workers.
+	// Workers exec into FPM containers, so the containers must be up first.
+	serviceUnits := append(coreUnits(), installedServiceUnits()...)
+	serviceUnits = append(serviceUnits, "lerd-ui", "lerd-watcher")
+
+	// Phase 2: worker units that depend on running containers.
+	workerUnits := append(registeredQueueUnits(), registeredStripeUnits()...)
+	workerUnits = append(workerUnits, registeredScheduleUnits()...)
+	workerUnits = append(workerUnits, registeredReverbUnits()...)
 
 	fmt.Println("Starting Lerd...")
 
-	jobs := make([]BuildJob, len(units))
-	for i, u := range units {
-		unit := u
-		label := strings.TrimPrefix(unit, "lerd-")
-		jobs[i] = BuildJob{
-			Label: label,
-			Run: func(w io.Writer) error {
-				if unit == "lerd-dns" {
-					// Always restart lerd-dns to pick up the refreshed dnsmasq config
-					// and clear any stale cached DNS entries.
-					return podman.RestartUnit(unit)
-				}
-				return podman.StartUnit(unit)
-			},
+	makeJobs := func(us []string) []BuildJob {
+		jobs := make([]BuildJob, len(us))
+		for i, u := range us {
+			unit := u
+			label := strings.TrimPrefix(unit, "lerd-")
+			jobs[i] = BuildJob{
+				Label: label,
+				Run: func(w io.Writer) error {
+					if unit == "lerd-dns" {
+						return podman.RestartUnit(unit)
+					}
+					return podman.StartUnit(unit)
+				},
+			}
 		}
+		return jobs
 	}
-	RunParallel(jobs) //nolint:errcheck
+
+	RunParallel(makeJobs(serviceUnits)) //nolint:errcheck
+	if len(workerUnits) > 0 {
+		RunParallel(makeJobs(workerUnits)) //nolint:errcheck
+	}
 
 	// Regenerate the browser-testing hosts file now that nginx has its IP.
 	// The file was written earlier with a possibly stale address; update it
@@ -415,8 +431,8 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// Restart the tray applet, stopping any existing instance first.
 	// Prefer the systemd service when enabled; otherwise launch directly.
 	fmt.Print("  --> lerd-tray ... ")
-	if lerdSystemd.IsServiceEnabled("lerd-tray") {
-		if err := lerdSystemd.RestartService("lerd-tray"); err != nil {
+	if services.Mgr.IsEnabled("lerd-tray") {
+		if err := services.Mgr.Restart("lerd-tray"); err != nil {
 			fmt.Printf("WARN (%v)\n", err)
 		} else {
 			fmt.Println("OK")
@@ -462,7 +478,7 @@ func startRestoredServices() {
 		pullJobs = append(pullJobs, BuildJob{
 			Label: "Pulling " + img,
 			Run: func(w io.Writer) error {
-				cmd := exec.Command("podman", "pull", img)
+				cmd := podman.Cmd( "pull", img)
 				cmd.Stdout = w
 				cmd.Stderr = w
 				return cmd.Run()
@@ -562,20 +578,21 @@ func restoreSiteInfrastructure() {
 			}
 		}
 
-		// Restore worker units from saved worker names.
+		// Restore worker unit files from saved worker names.
+		// Only write the unit file here — the actual start happens in phase 2
+		// of runStart after all services (and their networks) are up.
 		for _, w := range proj.Workers {
 			unitName := "lerd-" + w + "-" + s.Name
-			unitPath := filepath.Join(config.SystemdUserDir(), unitName+".service")
-			if _, statErr := os.Stat(unitPath); statErr == nil {
+			if services.Mgr.IsEnabled(unitName) {
 				continue // unit file already exists
 			}
-			// Recreate the worker unit by starting it (which writes the unit file).
 			phpVersion := s.PHPVersion
 			if phpVersion == "" {
 				cfg, _ := config.LoadGlobal()
 				phpVersion = cfg.PHP.DefaultVersion
 			}
-			// Stripe is not a framework worker.
+			// Stripe is not a framework worker — start it immediately since it
+			// doesn't depend on the lerd container network.
 			if w == "stripe" {
 				base := siteURL(s.Path)
 				if base != "" {
@@ -583,14 +600,21 @@ func restoreSiteInfrastructure() {
 				}
 				continue
 			}
-			// All other workers come from the framework definition.
+			// Write the worker unit file; RunParallel phase 2 will start it.
 			fwName := s.Framework
 			if fw, ok := config.GetFrameworkForDir(fwName, s.Path); ok && fw.Workers != nil {
 				if wDef, ok := fw.Workers[w]; ok {
-					for _, conflict := range wDef.ConflictsWith {
-						WorkerStopForSite(s.Name, conflict) //nolint:errcheck
+					versionShort := strings.ReplaceAll(phpVersion, ".", "")
+					fpmUnit := "lerd-php" + versionShort + "-fpm"
+					restart := wDef.Restart
+					if restart == "" {
+						restart = "always"
 					}
-					WorkerStartForSite(s.Name, s.Path, phpVersion, w, wDef) //nolint:errcheck
+					label := wDef.Label
+					if label == "" {
+						label = w
+					}
+					writeWorkerUnitFile(unitName, label, s.Name, s.Path, phpVersion, wDef.Command, restart, fpmUnit) //nolint:errcheck
 				}
 			}
 		}
@@ -598,47 +622,40 @@ func restoreSiteInfrastructure() {
 	if dirty {
 		config.SaveSites(reg) //nolint:errcheck
 	}
-	podman.DaemonReload() //nolint:errcheck
+
+	// Restore unit files for standalone custom services (installed globally via
+	// `lerd service add`) whose config exists in ~/.config/lerd/services/ but
+	// whose unit file (plist on macOS, quadlet on Linux) is missing — e.g. after
+	// a reinstall that wiped ~/Library/LaunchAgents or ~/.config/containers/systemd/.
+	if customs, err := config.ListCustomServices(); err == nil {
+		for _, svc := range customs {
+			if !services.Mgr.ContainerUnitInstalled("lerd-" + svc.Name) {
+				ensureCustomServiceQuadlet(svc) //nolint:errcheck
+			}
+		}
+	}
+
+	podman.DaemonReloadFn() //nolint:errcheck
 }
 
 func registeredStripeUnits() []string {
-	entries, _ := filepath.Glob(filepath.Join(config.SystemdUserDir(), "lerd-stripe-*.service"))
-	units := make([]string, 0, len(entries))
-	for _, e := range entries {
-		units = append(units, strings.TrimSuffix(filepath.Base(e), ".service"))
-	}
-	return units
+	return services.Mgr.ListServiceUnits("lerd-stripe-*")
 }
 
-// registeredQueueUnits returns unit names for all lerd-queue-* service files
-// present in the systemd user dir (i.e. started via `lerd queue:start`).
+// registeredQueueUnits returns unit names for all lerd-queue-* service units
+// (i.e. started via `lerd queue:start`).
 func registeredQueueUnits() []string {
-	entries, _ := filepath.Glob(filepath.Join(config.SystemdUserDir(), "lerd-queue-*.service"))
-	units := make([]string, 0, len(entries))
-	for _, e := range entries {
-		units = append(units, strings.TrimSuffix(filepath.Base(e), ".service"))
-	}
-	return units
+	return services.Mgr.ListServiceUnits("lerd-queue-*")
 }
 
-// registeredScheduleUnits returns unit names for all lerd-schedule-* service files.
+// registeredScheduleUnits returns unit names for all lerd-schedule-* service units.
 func registeredScheduleUnits() []string {
-	entries, _ := filepath.Glob(filepath.Join(config.SystemdUserDir(), "lerd-schedule-*.service"))
-	units := make([]string, 0, len(entries))
-	for _, e := range entries {
-		units = append(units, strings.TrimSuffix(filepath.Base(e), ".service"))
-	}
-	return units
+	return services.Mgr.ListServiceUnits("lerd-schedule-*")
 }
 
-// registeredReverbUnits returns unit names for all lerd-reverb-* service files.
+// registeredReverbUnits returns unit names for all lerd-reverb-* service units.
 func registeredReverbUnits() []string {
-	entries, _ := filepath.Glob(filepath.Join(config.SystemdUserDir(), "lerd-reverb-*.service"))
-	units := make([]string, 0, len(entries))
-	for _, e := range entries {
-		units = append(units, strings.TrimSuffix(filepath.Base(e), ".service"))
-	}
-	return units
+	return services.Mgr.ListServiceUnits("lerd-reverb-*")
 }
 
 // RunStart starts all lerd services (exported for use by the UI server).
@@ -658,6 +675,11 @@ func runStop(_ *cobra.Command, _ []string) error {
 	units = append(units, registeredReverbUnits()...)
 
 	fmt.Println("Stopping Lerd...")
+
+	// On macOS: stop all containers in one podman call before the parallel
+	// per-unit jobs run. This avoids serialising N individual podman stop
+	// requests through the Podman Machine socket (which can take 5s × N).
+	batchStopContainers(units)
 
 	jobs := make([]BuildJob, len(units))
 	for i, u := range units {

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -8,24 +8,26 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/geodro/lerd/internal/podman"
 )
 
-// migrateExecWorkerPlists removes legacy worker plists that used `podman exec`
-// (written by alpha.2/alpha.3). These cause "no such container" errors on every
-// podman invocation because the container they exec into no longer exists.
-// Workers must be re-registered after removal (e.g. `lerd schedule:start`).
+// migrateExecWorkerPlists removes exec-based worker plists. On macOS, workers
+// now run as independent detached containers (podman run -d) rather than
+// exec'ing into the PHP-FPM container. Removing the old exec-based plists
+// lets restoreSiteInfrastructure recreate them in the container format.
 func migrateExecWorkerPlists() {
 	home, _ := os.UserHomeDir()
 	dir := filepath.Join(home, "Library", "LaunchAgents")
-	for _, glob := range []string{"lerd-queue-*.plist", "lerd-schedule-*.plist", "lerd-reverb-*.plist"} {
+	for _, glob := range []string{"lerd-queue-*.plist", "lerd-schedule-*.plist", "lerd-reverb-*.plist", "lerd-horizon-*.plist"} {
 		matches, _ := filepath.Glob(filepath.Join(dir, glob))
 		for _, p := range matches {
 			data, err := os.ReadFile(p)
 			if err != nil {
 				continue
 			}
+			// Only remove exec-based plists; container-based plists use "run" not "exec".
 			if !strings.Contains(string(data), "<string>exec</string>") {
 				continue
 			}
@@ -33,7 +35,6 @@ func migrateExecWorkerPlists() {
 			domain := fmt.Sprintf("gui/%d", os.Getuid())
 			exec.Command("launchctl", "bootout", domain+"/com.lerd."+name).Run() //nolint:errcheck
 			os.Remove(p)                                                         //nolint:errcheck
-			fmt.Printf("  --> Removed stale exec-based plist %s — re-register with `lerd schedule:start` / `lerd queue:start`\n", name)
 		}
 	}
 }
@@ -131,10 +132,47 @@ func ensurePodmanMachineRunning() {
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		fmt.Printf("  WARN: podman machine start: %v\n", err)
+		return
 	}
 
-	// Prune stopped containers and unused resources after a machine (re)start to
-	// clear any stale exec sessions left in Podman's database from processes
-	// that were killed abruptly.
-	podman.RunSilent("system", "prune", "-f") //nolint:errcheck
+	// `podman machine start` exits before the API socket is ready to handle
+	// container operations. Poll `podman ps` (which exercises the full
+	// container stack, not just the info endpoint) until it succeeds, then
+	// wait an extra second for the socket to fully settle.
+	fmt.Print("  --> Waiting for Podman Machine to be ready ...")
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := exec.Command(podman.PodmanBin(), "ps", "-q").Run(); err == nil {
+			time.Sleep(1 * time.Second) // brief grace period before container ops
+			fmt.Println(" ready")
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+		fmt.Print(".")
+	}
+	fmt.Println(" timed out (proceeding anyway)")
+}
+
+// batchStopContainers stops all running lerd-* containers in two podman calls
+// (stop then rm) so the Podman Machine socket isn't flooded by N individual
+// stop requests from RunParallel. After this returns the individual Stop()
+// calls find no containers and go straight to launchctl bootout.
+func batchStopContainers(_ []string) {
+	// Query only running containers with name prefix "lerd-" to avoid passing
+	// non-existent names (native services like lerd-dns have no container).
+	out, err := podman.Run("ps", "--format", "{{.Names}}", "--filter", "name=^lerd-")
+	if err != nil || strings.TrimSpace(out) == "" {
+		return
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if n := strings.TrimSpace(line); n != "" {
+			names = append(names, n)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+	podman.RunSilent(append([]string{"stop", "-t", "5"}, names...)...) //nolint:errcheck
+	podman.RunSilent(append([]string{"rm", "-f"}, names...)...)        //nolint:errcheck
 }

--- a/internal/cli/startstop_linux.go
+++ b/internal/cli/startstop_linux.go
@@ -9,3 +9,8 @@ func ensurePodmanMachineRunning() {}
 // migrateExecWorkerPlists is a no-op on Linux — exec-based plists only existed
 // in the macOS-specific alpha.2/alpha.3 launchd plist implementation.
 func migrateExecWorkerPlists() {}
+
+// batchStopContainers is a no-op on Linux — systemd stops containers via unit
+// deactivation so individual StopUnit calls are efficient and non-blocking.
+func batchStopContainers(_ []string) {}
+

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -184,10 +184,10 @@ func runStatus(_ *cobra.Command, _ []string) error {
 						ok2(fmt.Sprintf("%s/%s", s.Name, w))
 						hasWorkers = true
 					case "activating":
-						warn2(s.Name+"/"+w, "restarting — check logs: journalctl --user -u "+unit+" -n 20")
+						warn2(s.Name+"/"+w, "restarting — check logs: "+unitLogHint(unit))
 						hasWorkers = true
 					case "failed":
-						fail2(s.Name+"/"+w, "failed", "journalctl --user -u "+unit+" -n 20")
+						fail2(s.Name+"/"+w, "failed", unitLogHint(unit))
 						hasWorkers = true
 					}
 				}
@@ -209,10 +209,10 @@ func runStatus(_ *cobra.Command, _ []string) error {
 							ok2(fmt.Sprintf("%s/%s", s.Name, wName))
 							hasWorkers = true
 						case "activating":
-							warn2(s.Name+"/"+wName, "restarting — check logs: journalctl --user -u "+unit+" -n 20")
+							warn2(s.Name+"/"+wName, "restarting — check logs: "+unitLogHint(unit))
 							hasWorkers = true
 						case "failed":
-							fail2(s.Name+"/"+wName, "failed", "journalctl --user -u "+unit+" -n 20")
+							fail2(s.Name+"/"+wName, "failed", unitLogHint(unit))
 							hasWorkers = true
 						}
 					}
@@ -226,7 +226,7 @@ func runStatus(_ *cobra.Command, _ []string) error {
 					if stripeStatus == "activating" {
 						warn2(label, "restarting")
 					} else {
-						fail2(label, "failed", "journalctl --user -u lerd-stripe-"+s.Name+" -n 20")
+						fail2(label, "failed", unitLogHint("lerd-stripe-"+s.Name))
 					}
 					hasWorkers = true
 				}

--- a/internal/cli/stripe.go
+++ b/internal/cli/stripe.go
@@ -9,7 +9,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
 	"github.com/geodro/lerd/internal/podman"
-	lerdSystemd "github.com/geodro/lerd/internal/systemd"
+	"github.com/geodro/lerd/internal/services"
 	"github.com/spf13/cobra"
 )
 
@@ -106,32 +106,32 @@ After=network.target
 Type=simple
 Restart=on-failure
 RestartSec=5
-ExecStart=podman run --rm --replace --name %s --network host docker.io/stripe/stripe-cli:latest listen --api-key %s --forward-to %s --skip-verify
+ExecStart=%s run --rm --replace --name %s --network host docker.io/stripe/stripe-cli:latest listen --api-key %s --forward-to %s --skip-verify
 
 [Install]
 WantedBy=default.target
-`, siteName, containerName, apiKey, forwardTo)
+`, siteName, podman.PodmanBin(), containerName, apiKey, forwardTo)
 
-	changed, err := lerdSystemd.WriteServiceIfChanged(unitName, unit)
+	changed, err := services.Mgr.WriteServiceUnitIfChanged(unitName, unit)
 	if err != nil {
 		return fmt.Errorf("writing service unit: %w", err)
 	}
 	if changed {
-		if err := podman.DaemonReload(); err != nil {
+		if err := podman.DaemonReloadFn(); err != nil {
 			return fmt.Errorf("daemon-reload: %w", err)
 		}
-		if err := lerdSystemd.EnableService(unitName); err != nil {
+		if err := services.Mgr.Enable(unitName); err != nil {
 			fmt.Printf("[WARN] enable: %v\n", err)
 		}
 	}
 
-	if err := lerdSystemd.StartService(unitName); err != nil {
+	if err := services.Mgr.Start(unitName); err != nil {
 		return fmt.Errorf("starting stripe listener: %w", err)
 	}
 
 	fmt.Printf("Stripe listener started for %s\n", siteName)
 	fmt.Printf("  Forwarding to: %s\n", forwardTo)
-	fmt.Printf("  Logs: journalctl --user -u %s -f\n", unitName)
+	fmt.Printf("  Logs: %s\n", unitLogHint(unitName))
 	return nil
 }
 
@@ -147,16 +147,15 @@ func StripeStartForSite(siteName, sitePath, siteBaseURL string) error {
 // StripeStopForSite stops and removes the Stripe listener for the named site.
 func StripeStopForSite(siteName string) error {
 	unitName := "lerd-stripe-" + siteName
-	unitFile := filepath.Join(config.SystemdUserDir(), unitName+".service")
 
-	_ = lerdSystemd.DisableService(unitName)
+	_ = services.Mgr.Disable(unitName)
 	podman.StopUnit(unitName) //nolint:errcheck
 
-	if err := os.Remove(unitFile); err != nil && !os.IsNotExist(err) {
+	if err := services.Mgr.RemoveServiceUnit(unitName); err != nil {
 		return fmt.Errorf("removing unit file: %w", err)
 	}
 
-	if err := podman.DaemonReload(); err != nil {
+	if err := podman.DaemonReloadFn(); err != nil {
 		fmt.Printf("[WARN] daemon-reload: %v\n", err)
 	}
 

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -4,13 +4,13 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/services"
 	"github.com/spf13/cobra"
 )
 
@@ -47,53 +47,54 @@ func runUninstall(force bool) error {
 	fmt.Println("  --> Removing DNS configuration")
 	dns.Teardown()
 
-	quadletDir := config.QuadletDir()
-
 	step("Stopping containers and services")
 	{
-		var units []string
-		// Quadlet containers (nginx, dns, mysql, redis, etc.)
-		if entries, err := filepath.Glob(filepath.Join(quadletDir, "lerd-*.container")); err == nil {
-			for _, f := range entries {
-				units = append(units, strings.TrimSuffix(filepath.Base(f), ".container"))
-			}
-		}
-		// Systemd user services (workers, watcher, ui, autostart, stripe, etc.)
-		if entries, err := filepath.Glob(filepath.Join(config.SystemdUserDir(), "lerd-*.service")); err == nil {
-			for _, f := range entries {
-				units = append(units, strings.TrimSuffix(filepath.Base(f), ".service"))
-			}
-		}
-		for _, unit := range units {
+		// Use the service manager so this works on both Linux (systemd/quadlet)
+		// and macOS (launchd plists).
+		seen := map[string]bool{}
+		for _, unit := range services.Mgr.ListContainerUnits("lerd-*") {
+			seen[unit] = true
 			status, _ := podman.UnitStatus(unit)
-			if status == "active" {
+			if status == "active" || status == "activating" {
 				_ = podman.StopUnit(unit)
 			}
-			_ = disableUnit(unit)
+			_ = services.Mgr.Disable(unit)
+		}
+		for _, unit := range services.Mgr.ListServiceUnits("lerd-*") {
+			if seen[unit] {
+				continue
+			}
+			status, _ := podman.UnitStatus(unit)
+			if status == "active" || status == "activating" {
+				_ = podman.StopUnit(unit)
+			}
+			_ = services.Mgr.Disable(unit)
 		}
 		// Kill any running tray process. The tray may be running standalone
-		// (launched from the desktop file or `lerd tray`) without a systemd
-		// unit, in which case the unit teardown above misses it and the tray
-		// keeps running after the binary is gone.
+		// (launched from the desktop file or `lerd tray`) without a unit,
+		// in which case the unit teardown above misses it.
 		killTray()
 	}
 	ok()
 
-	step("Removing quadlet units and services")
-	if entries, err := filepath.Glob(filepath.Join(quadletDir, "lerd-*.container")); err == nil {
-		for _, f := range entries {
-			os.Remove(f) //nolint:errcheck
+	step("Removing service units")
+	{
+		seen := map[string]bool{}
+		for _, unit := range services.Mgr.ListContainerUnits("lerd-*") {
+			seen[unit] = true
+			_ = services.Mgr.RemoveContainerUnit(unit)
 		}
-	}
-	if entries, err := filepath.Glob(filepath.Join(config.SystemdUserDir(), "lerd-*.service")); err == nil {
-		for _, f := range entries {
-			os.Remove(f) //nolint:errcheck
+		for _, unit := range services.Mgr.ListServiceUnits("lerd-*") {
+			if seen[unit] {
+				continue
+			}
+			_ = services.Mgr.RemoveServiceUnit(unit)
 		}
 	}
 	ok()
 
-	step("Reloading systemd daemon")
-	_ = podman.DaemonReload()
+	step("Reloading service manager")
+	_ = podman.DaemonReloadFn()
 	ok()
 
 	step("Removing lerd Podman network")
@@ -137,10 +138,6 @@ func readYes() bool {
 	return strings.EqualFold(ans, "y") || strings.EqualFold(ans, "yes")
 }
 
-func disableUnit(name string) error {
-	return runSystemctlUser("disable", name)
-}
-
 func removeShellEntry() {
 	const marker = "# Added by Lerd installer"
 	home, _ := os.UserHomeDir()
@@ -154,11 +151,6 @@ func removeShellEntry() {
 	for _, rc := range candidates {
 		removeMarkedBlock(rc, marker)
 	}
-}
-
-func runSystemctlUser(args ...string) error {
-	cmd := exec.Command("systemctl", append([]string{"--user"}, args...)...)
-	return cmd.Run()
 }
 
 // removeMarkedBlock removes the marker line and the line immediately after it.

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -12,7 +12,7 @@ import (
 	"github.com/geodro/lerd/internal/envfile"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
-	lerdSystemd "github.com/geodro/lerd/internal/systemd"
+	"github.com/geodro/lerd/internal/services"
 	"github.com/spf13/cobra"
 )
 
@@ -82,7 +82,7 @@ func newWorkerStopCmd() *cobra.Command {
 			// but are no longer in the framework definition.
 			if _, ok := fw.Workers[workerName]; !ok {
 				unitName := "lerd-" + workerName + "-" + site.Name
-				if !lerdSystemd.IsServiceActiveOrRestarting(unitName) {
+				if !isServiceActiveOrRestarting(unitName) {
 					return fmt.Errorf("framework %q has no worker named %q\nRun 'lerd worker list' to see available workers", fw.Label, workerName)
 				}
 			}
@@ -135,8 +135,8 @@ func newWorkerListCmd() *cobra.Command {
 				}
 			}
 
-			// Detect orphaned workers — running systemd units with no definition.
-			orphans := lerdSystemd.FindOrphanedWorkers(site.Name, known)
+			// Detect orphaned workers — running units with no definition.
+			orphans := findOrphanedWorkers(site.Name, known)
 			if len(orphans) > 0 {
 				fmt.Println("\nOrphaned workers (running but not defined):")
 				for _, name := range orphans {
@@ -218,7 +218,6 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 
 	versionShort := strings.ReplaceAll(phpVersion, ".", "")
 	fpmUnit := "lerd-php" + versionShort + "-fpm"
-	container := "lerd-php" + versionShort + "-fpm"
 	unitName := "lerd-" + workerName + "-" + siteName
 
 	restart := w.Restart
@@ -230,40 +229,22 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 		label = workerName
 	}
 
-	unit := fmt.Sprintf(`[Unit]
-Description=Lerd %s (%s)
-After=network.target %s.service
-BindsTo=%s.service
-
-[Service]
-Type=simple
-Restart=%s
-RestartSec=5
-ExecStart=podman exec -w %s %s %s
-
-[Install]
-WantedBy=default.target
-`, label, siteName, fpmUnit, fpmUnit, restart, sitePath, container, command)
-
-	changed, err := lerdSystemd.WriteServiceIfChanged(unitName, unit)
+	changed, err := writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, command, restart, fpmUnit)
 	if err != nil {
-		return fmt.Errorf("writing service unit: %w", err)
+		return fmt.Errorf("writing worker unit: %w", err)
 	}
 	if changed {
-		if err := podman.DaemonReload(); err != nil {
-			return fmt.Errorf("daemon-reload: %w", err)
-		}
-		if err := lerdSystemd.EnableService(unitName); err != nil {
+		if err := services.Mgr.Enable(unitName); err != nil {
 			fmt.Printf("[WARN] enable: %v\n", err)
 		}
 	}
 
-	if err := lerdSystemd.StartService(unitName); err != nil {
+	if err := services.Mgr.Start(unitName); err != nil {
 		return fmt.Errorf("starting %s worker: %w", workerName, err)
 	}
 
 	fmt.Printf("%s started for %s\n", label, siteName)
-	fmt.Printf("  Logs: journalctl --user -u %s -f\n", unitName)
+	fmt.Printf("  Logs: %s\n", workerLogHint(unitName))
 
 	// Regenerate nginx vhost if the worker has proxy config.
 	if w.Proxy != nil {
@@ -393,7 +374,7 @@ func newWorkerRemoveCmd() *cobra.Command {
 
 			// Stop the worker if running.
 			unitName := "lerd-" + name + "-" + site.Name
-			if lerdSystemd.IsServiceActiveOrRestarting(unitName) {
+			if isServiceActiveOrRestarting(unitName) {
 				_ = WorkerStopForSite(site.Name, name)
 			}
 
@@ -444,19 +425,48 @@ func siteFrameworkName(siteName string) string {
 // WorkerStopForSite stops and removes the named worker unit for the given site.
 func WorkerStopForSite(siteName, workerName string) error {
 	unitName := "lerd-" + workerName + "-" + siteName
-	unitFile := filepath.Join(config.SystemdUserDir(), unitName+".service")
 
-	_ = lerdSystemd.DisableService(unitName)
+	_ = services.Mgr.Disable(unitName)
 	podman.StopUnit(unitName) //nolint:errcheck
 
-	if err := os.Remove(unitFile); err != nil && !os.IsNotExist(err) {
+	if err := services.Mgr.RemoveServiceUnit(unitName); err != nil {
 		return fmt.Errorf("removing unit file: %w", err)
 	}
-	if err := podman.DaemonReload(); err != nil {
+	if err := podman.DaemonReloadFn(); err != nil {
 		fmt.Printf("[WARN] daemon-reload: %v\n", err)
 	}
 
 	label := workerName
 	fmt.Printf("%s stopped for %s\n", label, siteName)
 	return nil
+}
+
+// isServiceActiveOrRestarting returns true if the unit is active or activating.
+func isServiceActiveOrRestarting(name string) bool {
+	status, _ := podman.UnitStatus(name)
+	return status == "active" || status == "activating"
+}
+
+// findOrphanedWorkers returns worker names that are running but not in the known set.
+func findOrphanedWorkers(siteName string, known map[string]bool) []string {
+	suffix := "-" + siteName
+	prefix := "lerd-"
+	units := services.Mgr.ListServiceUnits("lerd-*-" + siteName)
+	var orphans []string
+	for _, unit := range units {
+		workerName := strings.TrimPrefix(unit, prefix)
+		workerName = strings.TrimSuffix(workerName, suffix)
+		if workerName == "" || known[workerName] {
+			continue
+		}
+		switch workerName {
+		case "php84-fpm", "php83-fpm", "php82-fpm", "php81-fpm", "php80-fpm",
+			"nginx", "dns", "dns-forwarder", "watcher", "ui", "stripe":
+			continue
+		}
+		if isServiceActiveOrRestarting(unit) {
+			orphans = append(orphans, workerName)
+		}
+	}
+	return orphans
 }

--- a/internal/cli/worker_darwin.go
+++ b/internal/cli/worker_darwin.go
@@ -1,0 +1,64 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/services"
+)
+
+// writeWorkerUnitFile writes a container unit for the worker on macOS.
+// Workers run as independent detached containers using the same PHP-FPM image,
+// so each worker has its own lifecycle and logs stream via `podman logs`.
+func writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, command, restart, fpmUnit string) (bool, error) {
+	versionShort := strings.ReplaceAll(phpVersion, ".", "")
+	image := "lerd-php" + versionShort + "-fpm:local"
+
+	// Build a quadlet-style [Container] unit. On macOS, WriteContainerUnit
+	// converts this to a launchd plist running `podman run -d --restart=always`.
+	home, _ := os.UserHomeDir()
+	unit := fmt.Sprintf(`[Container]
+Image=%s
+ContainerName=%s
+Network=lerd
+Volume=%s/.local/share/lerd/hosts:/etc/hosts:ro
+Volume=%s:%s:rw
+Volume=%s:/usr/local/etc/php/conf.d/99-xdebug.ini:ro
+Volume=%s:/usr/local/etc/php/conf.d/98-lerd-user.ini:ro
+PodmanArgs=--security-opt=label=disable
+WorkingDir=%s
+Exec=%s
+
+[Service]
+Restart=%s
+`,
+		image,
+		unitName,
+		home,
+		sitePath, sitePath,
+		config.PHPConfFile(phpVersion),
+		config.PHPUserIniFile(phpVersion),
+		sitePath,
+		command,
+		restart,
+	)
+
+	if err := services.Mgr.WriteContainerUnit(unitName, unit); err != nil {
+		return false, err
+	}
+	if err := podman.DaemonReloadFn(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// workerLogHint returns the hint for viewing worker logs on macOS.
+func workerLogHint(unitName string) string {
+	return "podman logs -f " + unitName
+}
+

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -1,0 +1,39 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/services"
+)
+
+// writeWorkerUnitFile writes a systemd service unit for the worker on Linux.
+// Workers exec into the running FPM container.
+func writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, command, restart, fpmUnit string) (bool, error) {
+	container := fpmUnit
+	unit := fmt.Sprintf(`[Unit]
+Description=Lerd %s (%s)
+After=network.target %s.service
+BindsTo=%s.service
+
+[Service]
+Type=simple
+Restart=%s
+RestartSec=5
+ExecStart=%s exec -w %s %s %s
+
+[Install]
+WantedBy=default.target
+`, label, siteName, fpmUnit, fpmUnit, restart, podman.PodmanBin(), sitePath, container, command)
+
+	return services.Mgr.WriteServiceUnitIfChanged(unitName, unit)
+}
+
+// workerLogHint returns the hint for viewing worker logs on Linux.
+func workerLogHint(unitName string) string {
+	return "journalctl --user -u " + unitName + " -f"
+}
+

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1659,7 +1659,7 @@ func execArtisan(args map[string]any) (any, *rpcError) {
 	cmdArgs = append(cmdArgs, artisanArgs...)
 
 	var out bytes.Buffer
-	cmd := exec.Command("podman", cmdArgs...)
+	cmd := podman.Cmd( cmdArgs...)
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
@@ -1761,11 +1761,14 @@ func execServiceStart(args map[string]any) (any, *rpcError) {
 			return toolErr("no quadlet template for " + name + ": " + err.Error()), nil
 		}
 		if cfg, loadErr := config.LoadGlobal(); loadErr == nil {
-			if svcCfg, ok := cfg.Services[name]; ok && len(svcCfg.ExtraPorts) > 0 {
-				content = podman.ApplyExtraPorts(content, svcCfg.ExtraPorts)
+			if svcCfg, ok := cfg.Services[name]; ok {
+				content = podman.ApplyImage(content, svcCfg.Image)
+				if len(svcCfg.ExtraPorts) > 0 {
+					content = podman.ApplyExtraPorts(content, svcCfg.ExtraPorts)
+				}
 			}
 		}
-		if err := podman.WriteQuadlet(unitName, content); err != nil {
+		if err := podman.WriteContainerUnitFn(unitName, content); err != nil {
 			return toolErr("writing quadlet: " + err.Error()), nil
 		}
 	} else {
@@ -1778,7 +1781,7 @@ func execServiceStart(args map[string]any) (any, *rpcError) {
 		}
 	}
 
-	if err := podman.DaemonReload(); err != nil {
+	if err := podman.DaemonReloadFn(); err != nil {
 		return toolErr("daemon-reload: " + err.Error()), nil
 	}
 	if err := podman.StartUnit(unitName); err != nil {
@@ -1836,16 +1839,16 @@ BindsTo=%s.service
 Type=simple
 Restart=on-failure
 RestartSec=5
-ExecStart=podman exec -w %s %s php artisan %s
+ExecStart=%s exec -w %s %s php artisan %s
 
 [Install]
 WantedBy=default.target
-`, siteName, fpmUnit, fpmUnit, site.Path, container, artisanArgs)
+`, siteName, fpmUnit, fpmUnit, podman.PodmanBin(), site.Path, container, artisanArgs)
 
 	if err := lerdSystemd.WriteService(unitName, unit); err != nil {
 		return toolErr("writing service unit: " + err.Error()), nil
 	}
-	if err := podman.DaemonReload(); err != nil {
+	if err := podman.DaemonReloadFn(); err != nil {
 		return toolErr("daemon-reload: " + err.Error()), nil
 	}
 	_ = lerdSystemd.EnableService(unitName)
@@ -1869,7 +1872,7 @@ func execQueueStop(args map[string]any) (any, *rpcError) {
 	if err := os.Remove(unitFile); err != nil && !os.IsNotExist(err) {
 		return toolErr("removing unit file: " + err.Error()), nil
 	}
-	_ = podman.DaemonReload()
+	_ = podman.DaemonReloadFn()
 	return toolOK("Queue worker stopped for " + siteName), nil
 }
 
@@ -1900,16 +1903,16 @@ BindsTo=%s.service
 Type=simple
 Restart=on-failure
 RestartSec=5
-ExecStart=podman exec -w %s %s php artisan reverb:start
+ExecStart=%s exec -w %s %s php artisan reverb:start
 
 [Install]
 WantedBy=default.target
-`, siteName, fpmUnit, fpmUnit, site.Path, container)
+`, siteName, fpmUnit, fpmUnit, podman.PodmanBin(), site.Path, container)
 
 	if err := lerdSystemd.WriteService(unitName, unit); err != nil {
 		return toolErr("writing service unit: " + err.Error()), nil
 	}
-	if err := podman.DaemonReload(); err != nil {
+	if err := podman.DaemonReloadFn(); err != nil {
 		return toolErr("daemon-reload: " + err.Error()), nil
 	}
 	_ = lerdSystemd.EnableService(unitName)
@@ -1931,7 +1934,7 @@ func execReverbStop(args map[string]any) (any, *rpcError) {
 	if err := os.Remove(unitFile); err != nil && !os.IsNotExist(err) {
 		return toolErr("removing unit file: " + err.Error()), nil
 	}
-	_ = podman.DaemonReload()
+	_ = podman.DaemonReloadFn()
 	return toolOK("Reverb stopped for " + siteName), nil
 }
 
@@ -1967,16 +1970,16 @@ BindsTo=%s.service
 Type=simple
 Restart=always
 RestartSec=5
-ExecStart=podman exec -w %s %s php artisan horizon
+ExecStart=%s exec -w %s %s php artisan horizon
 
 [Install]
 WantedBy=default.target
-`, siteName, fpmUnit, fpmUnit, site.Path, container)
+`, siteName, fpmUnit, fpmUnit, podman.PodmanBin(), site.Path, container)
 
 	if err := lerdSystemd.WriteService(unitName, unit); err != nil {
 		return toolErr("writing service unit: " + err.Error()), nil
 	}
-	if err := podman.DaemonReload(); err != nil {
+	if err := podman.DaemonReloadFn(); err != nil {
 		return toolErr("daemon-reload: " + err.Error()), nil
 	}
 	_ = lerdSystemd.EnableService(unitName)
@@ -1998,7 +2001,7 @@ func execHorizonStop(args map[string]any) (any, *rpcError) {
 	if err := os.Remove(unitFile); err != nil && !os.IsNotExist(err) {
 		return toolErr("removing unit file: " + err.Error()), nil
 	}
-	_ = podman.DaemonReload()
+	_ = podman.DaemonReloadFn()
 	return toolOK("Horizon stopped for " + siteName), nil
 }
 
@@ -2029,16 +2032,16 @@ BindsTo=%s.service
 Type=simple
 Restart=always
 RestartSec=5
-ExecStart=podman exec -w %s %s php artisan schedule:work
+ExecStart=%s exec -w %s %s php artisan schedule:work
 
 [Install]
 WantedBy=default.target
-`, siteName, fpmUnit, fpmUnit, site.Path, container)
+`, siteName, fpmUnit, fpmUnit, podman.PodmanBin(), site.Path, container)
 
 	if err := lerdSystemd.WriteService(unitName, unit); err != nil {
 		return toolErr("writing service unit: " + err.Error()), nil
 	}
-	if err := podman.DaemonReload(); err != nil {
+	if err := podman.DaemonReloadFn(); err != nil {
 		return toolErr("daemon-reload: " + err.Error()), nil
 	}
 	_ = lerdSystemd.EnableService(unitName)
@@ -2060,7 +2063,7 @@ func execScheduleStop(args map[string]any) (any, *rpcError) {
 	if err := os.Remove(unitFile); err != nil && !os.IsNotExist(err) {
 		return toolErr("removing unit file: " + err.Error()), nil
 	}
-	_ = podman.DaemonReload()
+	_ = podman.DaemonReloadFn()
 	return toolOK("Scheduler stopped for " + siteName), nil
 }
 
@@ -2100,16 +2103,16 @@ After=network.target
 Type=simple
 Restart=on-failure
 RestartSec=5
-ExecStart=podman run --rm --replace --name %s --network host docker.io/stripe/stripe-cli:latest listen --api-key %s --forward-to %s --skip-verify
+ExecStart=%s run --rm --replace --name %s --network host docker.io/stripe/stripe-cli:latest listen --api-key %s --forward-to %s --skip-verify
 
 [Install]
 WantedBy=default.target
-`, siteName, containerName, apiKey, forwardTo)
+`, siteName, podman.PodmanBin(), containerName, apiKey, forwardTo)
 
 	if err := lerdSystemd.WriteService(unitName, unit); err != nil {
 		return toolErr("writing service unit: " + err.Error()), nil
 	}
-	if err := podman.DaemonReload(); err != nil {
+	if err := podman.DaemonReloadFn(); err != nil {
 		return toolErr("daemon-reload: " + err.Error()), nil
 	}
 	_ = lerdSystemd.EnableService(unitName)
@@ -2131,7 +2134,7 @@ func execStripeListenStop(args map[string]any) (any, *rpcError) {
 	if err := os.Remove(unitFile); err != nil && !os.IsNotExist(err) {
 		return toolErr("removing unit file: " + err.Error()), nil
 	}
-	_ = podman.DaemonReload()
+	_ = podman.DaemonReloadFn()
 	return toolOK("Stripe listener stopped for " + siteName), nil
 }
 
@@ -2158,7 +2161,7 @@ func execLogs(args map[string]any) (any, *rpcError) {
 	}
 
 	var out bytes.Buffer
-	cmd := exec.Command("podman", "logs", "--tail", fmt.Sprintf("%d", lines), container)
+	cmd := podman.Cmd( "logs", "--tail", fmt.Sprintf("%d", lines), container)
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	_ = cmd.Run() // non-zero exit if container not running is fine — we return what we have
@@ -2216,7 +2219,7 @@ func execComposer(args map[string]any) (any, *rpcError) {
 	cmdArgs = append(cmdArgs, composerArgs...)
 
 	var out bytes.Buffer
-	cmd := exec.Command("podman", cmdArgs...)
+	cmd := podman.Cmd( cmdArgs...)
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
@@ -2288,7 +2291,7 @@ func execVendorRun(args map[string]any) (any, *rpcError) {
 	cmdArgs = append(cmdArgs, binArgs...)
 
 	var out bytes.Buffer
-	cmd := exec.Command("podman", cmdArgs...)
+	cmd := podman.Cmd( cmdArgs...)
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
@@ -2873,7 +2876,7 @@ func execServiceRemove(args map[string]any) (any, *rpcError) {
 	if err := podman.RemoveQuadlet(unit); err != nil {
 		return toolErr("removing quadlet: " + err.Error()), nil
 	}
-	_ = podman.DaemonReload()
+	_ = podman.DaemonReloadFn()
 	if err := config.RemoveCustomService(name); err != nil {
 		return toolErr("removing service config: " + err.Error()), nil
 	}
@@ -3012,13 +3015,14 @@ func execServiceExpose(args map[string]any) (any, *rpcError) {
 	if err != nil {
 		return toolErr("quadlet template not found: " + err.Error()), nil
 	}
+	content = podman.ApplyImage(content, svcCfg.Image)
 	if len(svcCfg.ExtraPorts) > 0 {
 		content = podman.ApplyExtraPorts(content, svcCfg.ExtraPorts)
 	}
-	if err := podman.WriteQuadlet(unitName, content); err != nil {
+	if err := podman.WriteContainerUnitFn(unitName, content); err != nil {
 		return toolErr("writing quadlet: " + err.Error()), nil
 	}
-	if err := podman.DaemonReload(); err != nil {
+	if err := podman.DaemonReloadFn(); err != nil {
 		return toolErr("daemon-reload: " + err.Error()), nil
 	}
 
@@ -3621,10 +3625,10 @@ func execDBExport(args map[string]any) (any, *rpcError) {
 	var cmd *exec.Cmd
 	switch env.connection {
 	case "mysql", "mariadb":
-		cmd = exec.Command("podman", "exec", "-i", "lerd-mysql",
+		cmd = podman.Cmd( "exec", "-i", "lerd-mysql",
 			"mysqldump", "-u"+env.username, "-p"+env.password, env.database)
 	case "pgsql", "postgres":
-		cmd = exec.Command("podman", "exec", "-i", "-e", "PGPASSWORD="+env.password,
+		cmd = podman.Cmd( "exec", "-i", "-e", "PGPASSWORD="+env.password,
 			"lerd-postgres", "pg_dump", "-U", env.username, env.database)
 	default:
 		_ = os.Remove(output)
@@ -3986,16 +3990,16 @@ BindsTo=%s.service
 Type=simple
 Restart=%s
 RestartSec=5
-ExecStart=podman exec -w %s %s %s
+ExecStart=%s exec -w %s %s %s
 
 [Install]
 WantedBy=default.target
-`, label, siteName, fpmUnit, fpmUnit, restart, site.Path, container, worker.Command)
+`, label, siteName, fpmUnit, fpmUnit, restart, podman.PodmanBin(), site.Path, container, worker.Command)
 
 	if err := lerdSystemd.WriteService(unitName, unit); err != nil {
 		return toolErr("writing service unit: " + err.Error()), nil
 	}
-	if err := podman.DaemonReload(); err != nil {
+	if err := podman.DaemonReloadFn(); err != nil {
 		return toolErr("daemon-reload: " + err.Error()), nil
 	}
 	_ = lerdSystemd.EnableService(unitName)
@@ -4021,7 +4025,7 @@ func execWorkerStop(args map[string]any) (any, *rpcError) {
 	if err := os.Remove(unitFile); err != nil && !os.IsNotExist(err) {
 		return toolErr("removing unit file: " + err.Error()), nil
 	}
-	_ = podman.DaemonReload()
+	_ = podman.DaemonReloadFn()
 	return toolOK(fmt.Sprintf("%s worker stopped for %s", workerName, siteName)), nil
 }
 
@@ -4197,7 +4201,7 @@ func execWorkerRemove(args map[string]any) (any, *rpcError) {
 		podman.StopUnit(unitName) //nolint:errcheck
 		unitFile := filepath.Join(config.SystemdUserDir(), unitName+".service")
 		_ = os.Remove(unitFile)
-		_ = podman.DaemonReload()
+		_ = podman.DaemonReloadFn()
 	}
 
 	if boolArg(args, "global") {
@@ -4550,10 +4554,10 @@ func execDBImport(args map[string]any) (any, *rpcError) {
 	var cmd *exec.Cmd
 	switch env.connection {
 	case "mysql", "mariadb":
-		cmd = exec.Command("podman", "exec", "-i", "lerd-mysql",
+		cmd = podman.Cmd( "exec", "-i", "lerd-mysql",
 			"mysql", "-u"+env.username, "-p"+env.password, env.database)
 	case "pgsql", "postgres":
-		cmd = exec.Command("podman", "exec", "-i", "-e", "PGPASSWORD="+env.password,
+		cmd = podman.Cmd( "exec", "-i", "-e", "PGPASSWORD="+env.password,
 			"lerd-postgres", "psql", "-U", env.username, env.database)
 	default:
 		return toolErr("unsupported DB_CONNECTION: " + env.connection), nil
@@ -4615,13 +4619,13 @@ func execDBCreate(args map[string]any) (any, *rpcError) {
 func mcpCreateDatabase(svc, name string) (bool, error) {
 	switch svc {
 	case "mysql":
-		check := exec.Command("podman", "exec", "lerd-mysql", "mysql", "-uroot", "-plerd",
+		check := podman.Cmd( "exec", "lerd-mysql", "mysql", "-uroot", "-plerd",
 			"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", name))
 		out, err := check.Output()
 		if err == nil && strings.TrimSpace(string(out)) != "0" {
 			return false, nil
 		}
-		cmd := exec.Command("podman", "exec", "lerd-mysql", "mysql", "-uroot", "-plerd",
+		cmd := podman.Cmd( "exec", "lerd-mysql", "mysql", "-uroot", "-plerd",
 			"-e", fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`;", name))
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr
@@ -4630,7 +4634,7 @@ func mcpCreateDatabase(svc, name string) (bool, error) {
 		}
 		return true, nil
 	case "postgres":
-		cmd := exec.Command("podman", "exec", "lerd-postgres", "psql", "-U", "postgres",
+		cmd := podman.Cmd( "exec", "lerd-postgres", "psql", "-U", "postgres",
 			"-c", fmt.Sprintf(`CREATE DATABASE "%s";`, name))
 		out, err := cmd.CombinedOutput()
 		if err != nil {

--- a/internal/php/detector_test.go
+++ b/internal/php/detector_test.go
@@ -149,6 +149,7 @@ func TestDetectVersion_ComposerJson(t *testing.T) {
 
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
 
 	got, err := DetectVersion(dir)
 	if err != nil {

--- a/internal/php/versions.go
+++ b/internal/php/versions.go
@@ -2,7 +2,6 @@ package php
 
 import (
 	"bytes"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -41,7 +40,7 @@ func ListInstalled() ([]string, error) {
 	}
 
 	// Source 2: podman containers (catches installs where the quadlet is missing)
-	if out, err := exec.Command("podman", "ps", "-a",
+	if out, err := podman.Cmd( "ps", "-a",
 		"--filter", "name=lerd-php",
 		"--format", "{{.Names}}").Output(); err == nil {
 		for _, name := range bytes.Fields(out) {

--- a/internal/php/versions_test.go
+++ b/internal/php/versions_test.go
@@ -10,7 +10,9 @@ import (
 // --- listInstalledFromServiceDir ---
 
 func TestListInstalledFromServiceDir_linux(t *testing.T) {
-	// On linux this is a no-op
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only: listInstalledFromServiceDir reads quadlet files")
+	}
 	result := listInstalledFromServiceDir()
 	if result != nil {
 		t.Errorf("expected nil on linux, got %v", result)
@@ -77,6 +79,7 @@ func TestQuadletExists_found(t *testing.T) {
 func TestQuadletExists_missing(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("HOME", tmp)
 
 	if quadletExists("8.4") {
 		t.Error("expected quadletExists to return false for missing quadlet")

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -247,7 +247,7 @@ func tryPullBaseImage(version string, w io.Writer) string {
 	}
 	args = append(args, ref)
 
-	cmd := exec.Command("podman", args...)
+	cmd := exec.Command(PodmanBin(), args...)
 	cmd.Stdout = w
 	cmd.Stderr = io.Discard
 	if err := cmd.Run(); err != nil {
@@ -263,7 +263,7 @@ func buildFPMImage(version string, force, local bool, customExts []string, w io.
 
 	if !force {
 		// Skip if image already exists
-		if exec.Command("podman", "image", "exists", imageName).Run() == nil {
+		if exec.Command(PodmanBin(), "image", "exists", imageName).Run() == nil {
 			return nil
 		}
 	}
@@ -315,7 +315,7 @@ build:
 	}
 
 	buildArgs = append(buildArgs, "-f", cfPath, tmp)
-	cmd := exec.Command("podman", buildArgs...)
+	cmd := exec.Command(PodmanBin(), buildArgs...)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	if err := cmd.Run(); err != nil {

--- a/internal/podman/exec.go
+++ b/internal/podman/exec.go
@@ -25,9 +25,15 @@ func PodmanBin() string {
 	return "podman"
 }
 
+// Cmd returns an exec.Cmd for podman with the given arguments, using PodmanBin()
+// so the binary is found even under launchd's restricted PATH.
+func Cmd(args ...string) *exec.Cmd {
+	return exec.Command(PodmanBin(), args...)
+}
+
 // Run executes podman with the given arguments and returns stdout.
 func Run(args ...string) (string, error) {
-	cmd := exec.Command("podman", args...)
+	cmd := exec.Command(PodmanBin(), args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -51,7 +57,7 @@ func ImageExists(image string) bool {
 
 // PullImageTo pulls the named image, writing progress output to w.
 func PullImageTo(image string, w io.Writer) error {
-	cmd := exec.Command("podman", "pull", image)
+	cmd := exec.Command(PodmanBin(), "pull", image)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	if err := cmd.Run(); err != nil {

--- a/internal/podman/hosts.go
+++ b/internal/podman/hosts.go
@@ -64,7 +64,7 @@ func writeBrowserHosts(reg *config.SiteRegistry) error {
 // nginxContainerIP returns the IP address of lerd-nginx on the lerd Podman
 // network. Falls back to 127.0.0.1 if the container isn't running.
 func nginxContainerIP() string {
-	out, err := exec.Command("podman", "inspect", "lerd-nginx",
+	out, err := exec.Command(PodmanBin(), "inspect", "lerd-nginx",
 		"--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}").Output()
 	if err != nil {
 		return "127.0.0.1"

--- a/internal/podman/network.go
+++ b/internal/podman/network.go
@@ -8,7 +8,7 @@ import (
 // NetworkGateway returns the gateway IP of the named Podman network.
 // Falls back to "127.0.0.1" if it cannot be determined.
 func NetworkGateway(name string) string {
-	out, err := exec.Command("podman", "network", "inspect", name,
+	out, err := exec.Command(PodmanBin(), "network", "inspect", name,
 		"--format", "{{range .Subnets}}{{.Gateway}}{{end}}").Output()
 	if err != nil || strings.TrimSpace(string(out)) == "" {
 		return "127.0.0.1"

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -42,10 +42,24 @@ func WriteQuadletDiff(name, content string) (changed bool, err error) {
 	content = BindForLAN(content, lanExposed)
 	content = StripInstallSection(content, autostartDisabled)
 	path := filepath.Join(dir, name+".container")
+	fileChanged := true
 	if existing, err := os.ReadFile(path); err == nil && string(existing) == content {
-		return false, nil
+		fileChanged = false
 	}
-	return true, os.WriteFile(path, []byte(content), 0644)
+	if fileChanged {
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			return false, err
+		}
+	}
+	// Always sync the platform unit (e.g. macOS launchd plist) so it stays
+	// consistent with the .container file — even if the file didn't change,
+	// the plist may be stale (e.g. after a config change like LAN exposure).
+	if AfterQuadletWriteFn != nil {
+		if err := AfterQuadletWriteFn(name, content); err != nil {
+			return fileChanged, err
+		}
+	}
+	return fileChanged, nil
 }
 
 // QuadletInstalled returns true if a quadlet .container file exists for the given unit name.
@@ -67,7 +81,24 @@ func RemoveQuadlet(name string) error {
 // RemoveContainer removes a stopped Podman container by name, ignoring errors
 // if the container does not exist.
 func RemoveContainer(name string) {
-	_ = exec.Command("podman", "rm", "-f", name).Run()
+	_ = exec.Command(PodmanBin(), "rm", "-f", name).Run()
+}
+
+// AfterQuadletWriteFn, if non-nil, is called by WriteQuadletDiff after
+// writing the .container file. On macOS it is set to the launchd plist
+// writer so both formats stay in sync (the .container file is the
+// canonical source of truth; the plist is the live runtime unit).
+var AfterQuadletWriteFn func(name, content string) error
+
+// UnitLifecycle is the interface for starting, stopping, restarting, and
+// querying service units. Set by the platform service manager on macOS so that
+// StartUnit/StopUnit/RestartUnit/UnitStatus route through launchd instead of
+// systemctl. Nil on Linux (the systemctl fallback is used).
+var UnitLifecycle interface {
+	Start(name string) error
+	Stop(name string) error
+	Restart(name string) error
+	UnitStatus(name string) (string, error)
 }
 
 // DaemonReload runs systemctl --user daemon-reload.
@@ -80,8 +111,11 @@ func DaemonReload() error {
 	return nil
 }
 
-// StartUnit starts a systemd user unit.
+// StartUnit starts a service unit.
 func StartUnit(name string) error {
+	if UnitLifecycle != nil {
+		return UnitLifecycle.Start(name)
+	}
 	cmd := exec.Command("systemctl", "--user", "start", name)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -90,8 +124,11 @@ func StartUnit(name string) error {
 	return nil
 }
 
-// StopUnit stops a systemd user unit.
+// StopUnit stops a service unit.
 func StopUnit(name string) error {
+	if UnitLifecycle != nil {
+		return UnitLifecycle.Stop(name)
+	}
 	cmd := exec.Command("systemctl", "--user", "stop", name)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -102,8 +139,11 @@ func StopUnit(name string) error {
 	return nil
 }
 
-// RestartUnit restarts a systemd user unit.
+// RestartUnit restarts a service unit.
 func RestartUnit(name string) error {
+	if UnitLifecycle != nil {
+		return UnitLifecycle.Restart(name)
+	}
 	cmd := exec.Command("systemctl", "--user", "restart", name)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -124,13 +164,13 @@ func WaitReady(service string, timeout time.Duration) error {
 	switch service {
 	case "mysql":
 		probe = func() bool {
-			cmd := exec.Command("podman", "exec", "lerd-mysql",
+			cmd := exec.Command(PodmanBin(), "exec", "lerd-mysql",
 				"mysqladmin", "ping", "-uroot", "-plerd", "--silent")
 			return cmd.Run() == nil
 		}
 	case "postgres":
 		probe = func() bool {
-			cmd := exec.Command("podman", "exec", "lerd-postgres",
+			cmd := exec.Command(PodmanBin(), "exec", "lerd-postgres",
 				"pg_isready", "-U", "postgres")
 			return cmd.Run() == nil
 		}
@@ -159,8 +199,11 @@ func WaitReady(service string, timeout time.Duration) error {
 	return fmt.Errorf("%s did not become ready within %s", service, timeout)
 }
 
-// UnitStatus returns the active state of a systemd user unit.
+// UnitStatus returns the active state of a service unit.
 func UnitStatus(name string) (string, error) {
+	if UnitLifecycle != nil {
+		return UnitLifecycle.UnitStatus(name)
+	}
 	cmd := exec.Command("systemctl", "--user", "is-active", name)
 	out, err := cmd.Output()
 	status := strings.TrimSpace(string(out))

--- a/internal/podman/quadlet_embed.go
+++ b/internal/podman/quadlet_embed.go
@@ -19,6 +19,22 @@ func GetQuadletTemplate(name string) (string, error) {
 	return string(data), nil
 }
 
+// ApplyImage replaces the Image= line in quadlet content with the given image.
+// If content contains no Image= line it is returned unchanged.
+func ApplyImage(content, image string) string {
+	if image == "" {
+		return content
+	}
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "Image=") {
+			lines[i] = "Image=" + image
+			return strings.Join(lines, "\n")
+		}
+	}
+	return content
+}
+
 // ApplyExtraPorts appends extra PublishPort lines to quadlet content.
 func ApplyExtraPorts(content string, extraPorts []string) string {
 	var sb strings.Builder
@@ -107,7 +123,7 @@ func InjectExtraVolumes(content string, paths []string) string {
 
 // OCIRuntime returns the name of the OCI runtime podman is currently configured to use.
 func OCIRuntime() string {
-	out, err := exec.Command("podman", "info", "--format", "{{.Host.OCIRuntime.Name}}").Output()
+	out, err := exec.Command(PodmanBin(), "info", "--format", "{{.Host.OCIRuntime.Name}}").Output()
 	if err != nil {
 		return ""
 	}

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -98,10 +98,10 @@ func EnsureCustomServiceQuadlet(svc *config.CustomService) error {
 	}
 	content := podman.GenerateCustomQuadlet(svc)
 	quadletName := "lerd-" + svc.Name
-	if err := podman.WriteQuadlet(quadletName, content); err != nil {
-		return fmt.Errorf("writing quadlet for %s: %w", svc.Name, err)
+	if err := podman.WriteContainerUnitFn(quadletName, content); err != nil {
+		return fmt.Errorf("writing unit for %s: %w", svc.Name, err)
 	}
-	return podman.DaemonReload()
+	return podman.DaemonReloadFn()
 }
 
 // EnsureServiceRunning starts the service if it is not already active and

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
 )
 
@@ -29,12 +31,56 @@ func uidDomain() string {
 	return fmt.Sprintf("gui/%d", os.Getuid())
 }
 
+// podmanStartSem limits concurrent `podman run` executions to avoid
+// overwhelming the Podman Machine SSH connection with parallel requests.
+var podmanStartSem = make(chan struct{}, 4)
+
 func init() {
 	Mgr = &darwinServiceManager{}
-	// Override WriteFPMQuadlet to use launchd plists instead of systemd quadlets.
+	// Override service-manager hooks to use launchd instead of systemd.
 	podman.WriteContainerUnitFn = Mgr.WriteContainerUnit
 	podman.DaemonReloadFn = Mgr.DaemonReload
 	podman.SkipQuadletUpToDateCheck = true
+	podman.UnitLifecycle = Mgr
+	// Keep launchd plists in sync when WriteQuadletDiff updates a .container file.
+	podman.AfterQuadletWriteFn = func(name, content string) error {
+		return Mgr.WriteContainerUnit(name, content)
+	}
+}
+
+// plistArgs parses the ProgramArguments array from a plist file and returns
+// the argument strings. Used to run container units directly from Go code
+// rather than via launchctl kickstart, so we control launch concurrency.
+func plistArgs(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	// Find the ProgramArguments array using simple string search.
+	s := string(data)
+	const key = "<key>ProgramArguments</key>"
+	idx := strings.Index(s, key)
+	if idx < 0 {
+		return nil, fmt.Errorf("ProgramArguments not found in %s", path)
+	}
+	s = s[idx+len(key):]
+	start := strings.Index(s, "<array>")
+	end := strings.Index(s, "</array>")
+	if start < 0 || end < 0 {
+		return nil, fmt.Errorf("ProgramArguments array not found in %s", path)
+	}
+	block := s[start+len("<array>") : end]
+	var args []string
+	for {
+		open := strings.Index(block, "<string>")
+		close := strings.Index(block, "</string>")
+		if open < 0 || close < 0 {
+			break
+		}
+		args = append(args, block[open+len("<string>"):close])
+		block = block[close+len("</string>"):]
+	}
+	return args, nil
 }
 
 type darwinServiceManager struct{}
@@ -180,6 +226,31 @@ func stripSELinuxVolOpts(vol string) string {
 	return parts[0] + ":" + parts[1] + ":" + strings.Join(filtered, ",")
 }
 
+// stripPrivilegedIPBind removes the host-IP prefix from a PublishPort value
+// (e.g. "127.0.0.1:80:80" → "80:80") when the host port is privileged (< 1024).
+// On macOS, gvproxy handles port forwarding via podman-mac-helper and does not
+// support explicit IP binds for privileged ports — trying them causes
+// "bind: permission denied". Non-privileged ports (3306, 6379, etc.) do support
+// IP binding and are left untouched so LAN restriction still works for them.
+func stripPrivilegedIPBind(port string) string {
+	parts := strings.SplitN(port, ":", 3)
+	if len(parts) != 3 {
+		return port // bare "containerPort" or "hostPort:containerPort" — no IP prefix
+	}
+	hostPortStr := strings.SplitN(parts[1], "/", 2)[0] // strip "/tcp" etc.
+	n := 0
+	for _, c := range hostPortStr {
+		if c < '0' || c > '9' {
+			return port // non-numeric, leave as-is
+		}
+		n = n*10 + int(c-'0')
+	}
+	if n > 0 && n < 1024 {
+		return parts[1] + ":" + parts[2] // drop the IP prefix
+	}
+	return port
+}
+
 // containerToPodmanArgs builds a podman run argument list from a parsed [Container] section.
 // On macOS we run detached (-d) so that launchctl bootstrap sees an immediate
 // exit 0 (success); podman's own --restart=always policy handles crash recovery.
@@ -195,7 +266,7 @@ func containerToPodmanArgs(c map[string][]string) ([]string, error) {
 		args = append(args, "--network", net)
 	}
 	for _, port := range c["PublishPort"] {
-		args = append(args, "-p", port)
+		args = append(args, "-p", stripPrivilegedIPBind(port))
 	}
 	for _, vol := range c["Volume"] {
 		args = append(args, "-v", stripSELinuxVolOpts(expandSpecifiers(vol)))
@@ -225,54 +296,86 @@ func containerToPodmanArgs(c map[string][]string) ([]string, error) {
 
 // --- Service unit files ---
 
-func (m *darwinServiceManager) WriteServiceUnit(name, content string) error {
+// parseServiceUnit parses a systemd-format service unit and returns the argv
+// and keepAlive flag for the launchd plist.
+//
+// Binary resolution rules for args[0]:
+//   - Absolute path that exists → use as-is.
+//   - Absolute path that doesn't exist → substitute the running lerd binary
+//     (handles Homebrew → ~/.local/bin migration).
+//   - Bare command name (no '/') → resolve via PATH; if not found, substitute
+//     the running lerd binary (should not normally happen).
+func parseServiceUnit(name, content string) (args []string, keepAlive bool, err error) {
 	svc := parseSection(content, "Service")
 	execStarts := svc["ExecStart"]
 	if len(execStarts) == 0 {
-		return fmt.Errorf("no ExecStart= found in service unit %s", name)
+		return nil, false, fmt.Errorf("no ExecStart= found in service unit %s", name)
 	}
-	// Expand %h and split into argv
-	args := strings.Fields(expandSpecifiers(execStarts[0]))
+	args = strings.Fields(expandSpecifiers(execStarts[0]))
 	if len(args) == 0 {
-		return fmt.Errorf("empty ExecStart in service unit %s", name)
+		return nil, false, fmt.Errorf("empty ExecStart in service unit %s", name)
 	}
 
-	// On macOS the lerd binary is managed by Homebrew and lives at
-	// /opt/homebrew/bin/lerd, not at ~/.local/bin/lerd as on Linux.
-	// If the binary referenced in ExecStart doesn't exist, substitute
-	// the path of the currently running lerd executable.
-	if _, err := os.Stat(args[0]); err != nil {
-		if self, err := os.Executable(); err == nil {
-			args[0] = self
+	// Resolve args[0] to an absolute path suitable for a launchd plist.
+	if filepath.IsAbs(args[0]) {
+		// Absolute path: substitute if missing (e.g. old Homebrew install).
+		if _, statErr := os.Stat(args[0]); statErr != nil {
+			if self, selfErr := os.Executable(); selfErr == nil {
+				args[0] = self
+			}
 		}
+	} else {
+		// Bare command (e.g. "podman"): resolve via PATH first, then well-known
+		// Homebrew locations. Never fall back to the lerd binary — if the command
+		// cannot be found, return an error so the caller can surface a clear message.
+		resolved := ""
+		if p, lookErr := exec.LookPath(args[0]); lookErr == nil {
+			resolved = p
+		} else {
+			for _, dir := range []string{"/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"} {
+				candidate := filepath.Join(dir, args[0])
+				if _, statErr := os.Stat(candidate); statErr == nil {
+					resolved = candidate
+					break
+				}
+			}
+		}
+		if resolved == "" {
+			return nil, false, fmt.Errorf("command %q in ExecStart of %s not found; use an absolute path", args[0], name)
+		}
+		args[0] = resolved
 	}
 
+	// Map Restart= to KeepAlive so launchd restarts the job like systemd would.
+	restart := ""
+	if restarts := svc["Restart"]; len(restarts) > 0 {
+		restart = restarts[0]
+	}
+	keepAlive = restart == "always" || restart == "on-failure"
+	return args, keepAlive, nil
+}
+
+func (m *darwinServiceManager) WriteServiceUnit(name, content string) error {
+	args, keepAlive, err := parseServiceUnit(name, content)
+	if err != nil {
+		return err
+	}
 	if err := ensurePlistDirs(name); err != nil {
 		return err
 	}
 	logPath := filepath.Join(lerdLogsDir(), name+".log")
-	plist := buildPlist(plistLabel(name), args, true, false, logPath, logPath)
+	plist := buildPlist(plistLabel(name), args, true, keepAlive, logPath, logPath)
 	return os.WriteFile(plistPath(name), []byte(plist), 0644)
 }
 
 func (m *darwinServiceManager) WriteServiceUnitIfChanged(name, content string) (bool, error) {
-	svc := parseSection(content, "Service")
-	execStarts := svc["ExecStart"]
-	if len(execStarts) == 0 {
-		return false, fmt.Errorf("no ExecStart= found in service unit %s", name)
-	}
-	args := strings.Fields(expandSpecifiers(execStarts[0]))
-	if len(args) == 0 {
-		return false, fmt.Errorf("empty ExecStart in service unit %s", name)
-	}
-	if _, err := os.Stat(args[0]); err != nil {
-		if self, err := os.Executable(); err == nil {
-			args[0] = self
-		}
+	args, keepAlive, err := parseServiceUnit(name, content)
+	if err != nil {
+		return false, err
 	}
 
 	logPath := filepath.Join(lerdLogsDir(), name+".log")
-	newPlist := buildPlist(plistLabel(name), args, true, false, logPath, logPath)
+	newPlist := buildPlist(plistLabel(name), args, true, keepAlive, logPath, logPath)
 
 	if existing, err := os.ReadFile(plistPath(name)); err == nil && string(existing) == newPlist {
 		return false, nil
@@ -303,6 +406,13 @@ func (m *darwinServiceManager) ListServiceUnits(nameGlob string) []string {
 // --- Container unit files ---
 
 func (m *darwinServiceManager) WriteContainerUnit(name, content string) error {
+	// Apply LAN binding restriction before parsing — mirrors WriteQuadletDiff on Linux.
+	lanExposed := false
+	if cfg, err := config.LoadGlobal(); err == nil && cfg != nil {
+		lanExposed = cfg.LAN.Exposed
+	}
+	content = podman.BindForLAN(content, lanExposed)
+
 	c := parseSection(content, "Container")
 	args, err := containerToPodmanArgs(c)
 	if err != nil {
@@ -368,8 +478,13 @@ func (m *darwinServiceManager) Start(name string) error {
 	// bootstrap always picks up the current plist on disk. kickstart -k would
 	// restart the job but launchd would use its cached plist, missing any
 	// changes written by WriteServiceUnit / WriteContainerUnit.
+	alreadyInDomain := false
 	if _, err := launchctl("print", domain+"/"+label); err == nil {
+		alreadyInDomain = true
 		launchctl("bootout", domain+"/"+label) //nolint:errcheck
+		// Brief pause so macOS Sequoia+ doesn't reject the immediately-following
+		// bootstrap with a spurious "already bootstrapped" (36) or EBUSY (5) error.
+		time.Sleep(200 * time.Millisecond)
 	}
 
 	// Enable AFTER bootout — on macOS Ventura+, bootout marks the service as
@@ -386,6 +501,16 @@ func (m *darwinServiceManager) Start(name string) error {
 		if strings.Contains(s, "36") || strings.Contains(s, "Bootstrap failed: 5") ||
 			strings.Contains(s, "already bootstrapped") ||
 			strings.Contains(s, "service already loaded") {
+			// Already in domain — run container directly if it's a container unit.
+			content2, _ := os.ReadFile(p)
+			if !strings.Contains(string(content2), "<key>RunAtLoad</key>") {
+				if args, aerr := plistArgs(p); aerr == nil && len(args) > 0 {
+					podmanStartSem <- struct{}{}
+					exec.Command(args[0], args[1:]...).Run() //nolint:errcheck
+					<-podmanStartSem
+					return nil
+				}
+			}
 			if kout, kerr := launchctl("kickstart", "-k", domain+"/"+label); kerr != nil {
 				ks := string(kout)
 				// 37 = EALREADY — job is already running, treat as success.
@@ -396,14 +521,38 @@ func (m *darwinServiceManager) Start(name string) error {
 			}
 			return nil
 		}
+		// If bootstrap failed and we just did a bootout, retry once — launchd on
+		// Sequoia can transiently reject a re-bootstrap immediately after bootout.
+		if alreadyInDomain {
+			time.Sleep(300 * time.Millisecond)
+			launchctl("enable", domain+"/"+label) //nolint:errcheck
+			if out2, err2 := launchctl("bootstrap", domain, p); err2 != nil {
+				return fmt.Errorf("launchctl bootstrap %s: %w\n%s", name, err2, out2)
+			}
+			return nil
+		}
 		return fmt.Errorf("launchctl bootstrap %s: %w\n%s", name, err, out)
 	}
 	// Container units use RunAtLoad=false so bootstrap alone doesn't start them.
 	// Service units use RunAtLoad=true so bootstrap already started them — no kick needed.
 	content, _ := os.ReadFile(p)
-	if !strings.Contains(string(content), "<key>RunAtLoad</key>") {
-		launchctl("kickstart", domain+"/"+label) //nolint:errcheck
+	if strings.Contains(string(content), "<key>RunAtLoad</key>") {
+		return nil // service unit already started by bootstrap
 	}
+	// Container unit: run podman directly (with concurrency limit) instead of
+	// launchctl kickstart. kickstart lets launchd fire all podman run processes
+	// simultaneously, which overwhelms the Podman Machine SSH connection when
+	// N services start in parallel. Running directly lets us gate on podmanStartSem.
+	args, err := plistArgs(p)
+	if err != nil || len(args) == 0 {
+		// Fallback to kickstart if plist parsing fails.
+		launchctl("kickstart", domain+"/"+label) //nolint:errcheck
+		return nil
+	}
+	podmanStartSem <- struct{}{}
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Run() //nolint:errcheck
+	<-podmanStartSem
 	return nil
 }
 
@@ -412,9 +561,13 @@ func (m *darwinServiceManager) Start(name string) error {
 // needed because container units use -d (detached) + --restart=always, so the
 // container keeps running independently of launchd after the plist is booted out.
 func (m *darwinServiceManager) Stop(name string) error {
-	// Derive the container name: plist name IS the container name (e.g. lerd-dns).
-	exec.Command(podmanBinPath(), "stop", "-t", "5", name).Run() //nolint:errcheck
-	exec.Command(podmanBinPath(), "rm", "-f", name).Run()        //nolint:errcheck
+	// Stop and remove the container only if it is actually running.
+	// Skipping the podman calls when the container is absent avoids flooding the
+	// Podman Machine SSH socket with N parallel no-op requests during lerd stop.
+	if running, _ := podman.ContainerRunning(name); running {
+		exec.Command(podmanBinPath(), "stop", "-t", "5", name).Run() //nolint:errcheck
+		exec.Command(podmanBinPath(), "rm", "-f", name).Run()        //nolint:errcheck
+	}
 
 	domain := uidDomain()
 	label := plistLabel(name)
@@ -446,6 +599,10 @@ func (m *darwinServiceManager) Restart(name string) error {
 			return m.Start(name)
 		}
 		// 37 = EALREADY — job is already running, treat as success.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 37 {
+			return nil
+		}
 		if strings.Contains(s, "37") || strings.Contains(s, "already running") {
 			return nil
 		}

--- a/internal/services/launchd_test.go
+++ b/internal/services/launchd_test.go
@@ -161,7 +161,7 @@ func TestContainerToPodmanArgs(t *testing.T) {
 		"run", "-d", "--restart=always",
 		"--name", "lerd-nginx", "--replace",
 		"--network", "lerd",
-		"-p", "127.0.0.1:80:80",
+		"-p", "80:80",
 		"-e", "FOO=bar",
 		"docker.io/library/nginx:latest",
 	} {

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -129,7 +129,7 @@ func FinishLink(site config.Site, phpVersion string) error {
 
 	_ = podman.WriteXdebugIni(phpVersion, false)
 	if err := podman.WriteFPMQuadlet(phpVersion); err == nil {
-		_ = podman.DaemonReload()
+		_ = podman.DaemonReloadFn()
 	}
 
 	_ = podman.RewriteFPMQuadlets()

--- a/internal/systemd/units/lerd-autostart.service
+++ b/internal/systemd/units/lerd-autostart.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Lerd Autostart
+After=default.target
+
+[Service]
+ExecStart=%h/.local/bin/lerd start
+Restart=no
+
+[Install]
+WantedBy=default.target

--- a/internal/tray/menu.go
+++ b/internal/tray/menu.go
@@ -4,6 +4,7 @@ package tray
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
 
 	"github.com/getlantern/systray"
@@ -76,7 +77,11 @@ func buildMenu() *menuState {
 	systray.AddSeparator()
 
 	m.mAutostart = systray.AddMenuItem("Autostart at login: Off", "Toggle lerd autostart on login")
-	m.mLAN = systray.AddMenuItem("Expose to LAN: Off", "Toggle whether lerd is reachable from other devices on the local network")
+	// LAN exposure toggle is not shown on macOS — ports 80/443 are always
+	// reachable on the LAN via gvproxy; only non-privileged ports support IP binding.
+	if runtime.GOOS != "darwin" {
+		m.mLAN = systray.AddMenuItem("Expose to LAN: Off", "Toggle whether lerd is reachable from other devices on the local network")
+	}
 	m.mUpdate = systray.AddMenuItem("Check for update...", "Check for a newer version of Lerd")
 	m.mQuit = systray.AddMenuItem("Quit Lerd", "Stop all Lerd processes and containers")
 
@@ -167,11 +172,13 @@ func (m *menuState) apply(snap *Snapshot) {
 		m.mAutostart.SetTitle("Autostart at login: Off")
 	}
 
-	// LAN exposure
-	if snap.LANExposed {
-		m.mLAN.SetTitle("Expose to LAN: ✔ On")
-	} else {
-		m.mLAN.SetTitle("Expose to LAN: Off")
+	// LAN exposure (not shown on macOS — DNS-only, nginx 80/443 always LAN-accessible)
+	if m.mLAN != nil {
+		if snap.LANExposed {
+			m.mLAN.SetTitle("Expose to LAN: ✔ On")
+		} else {
+			m.mLAN.SetTitle("Expose to LAN: Off")
+		}
 	}
 
 	// Update availability

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -1626,6 +1626,11 @@
                       <span>Lerd is bound to 127.0.0.1 only — invisible to other devices on the network. Safe for untrusted wifi (cafés, conference networks). Expose to share your sites with another machine on a trusted LAN.</span>
                     </template>
                   </p>
+                  <template x-if="lanExposure.macos">
+                    <p class="text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/30 rounded-lg px-3 py-2 mb-3">
+                      <strong>macOS:</strong> This toggle only controls DNS resolution (<code class="font-mono">*.test</code> → 127.0.0.1 or LAN IP). Ports 80 and 443 are always reachable from the LAN due to a gvproxy limitation — the Podman Machine network layer does not support IP-specific bindings for privileged ports. Service ports (MySQL, Redis, etc.) are properly restricted to 127.0.0.1.
+                    </p>
+                  </template>
                   <div x-show="accessMode.loopback" class="flex items-center gap-2">
                     <button x-show="!lanExposure.exposed" @click="toggleLANExposure('expose')" :disabled="lanExposure.loading"
                       class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-gray-100 hover:bg-gray-200 dark:bg-white/5 dark:hover:bg-white/10 text-gray-700 dark:text-gray-300 disabled:opacity-50 transition-colors">
@@ -1971,7 +1976,7 @@ function lerdApp() {
     },
     updateTerminal: { loading: false, error: '' },
     remoteControl: { enabled: false, username: '', loading: false, error: '' },
-    lanExposure: { exposed: false, lanIP: '', loading: false, error: '', justExposed: false, setupCode: '', setupCurl: '', setupExpiresIn: '', setupLoading: false, setupError: '', setupCopied: false, progressSteps: [] },
+    lanExposure: { exposed: false, lanIP: '', macos: false, loading: false, error: '', justExposed: false, setupCode: '', setupCurl: '', setupExpiresIn: '', setupLoading: false, setupError: '', setupCopied: false, progressSteps: [] },
     remoteControlModal: { open: false, username: '', password: '', loading: false, error: '' },
     // apiBase is prepended to image/asset URLs that the browser fetches
     // directly (not via window.fetch — those are intercepted by the
@@ -2189,6 +2194,7 @@ function lerdApp() {
         const data = await res.json();
         this.lanExposure.exposed = !!data.exposed;
         this.lanExposure.lanIP = data.lan_ip || '';
+        this.lanExposure.macos = !!data.macos;
       } catch (e) { /* non-fatal */ }
     },
 

--- a/internal/ui/logs_darwin.go
+++ b/internal/ui/logs_darwin.go
@@ -3,7 +3,11 @@
 package ui
 
 import (
+	"bufio"
 	"context"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,17 +21,17 @@ func lerdLogPath(unit string) string {
 	return filepath.Join(home, "Library", "Logs", "lerd", unit+".log")
 }
 
-// isContainerUnit returns true for units that run as detached containers
+// isContainerUnit returns true for units that run as detached podman containers
 // (podman run -d). Their logs come from `podman logs`, not the launchd log file.
-// On macOS all worker units (queue, schedule, stripe, reverb, horizon) are
-// container-based — only native launchd services are excluded.
+//
+// On macOS only a few native services (dnsmasq, watcher, UI) are non-container;
+// everything else — including all worker units — runs as a container.
 func isContainerUnit(unit string) bool {
-	nativeUnits := map[string]bool{
-		"lerd-dns":     true, // dnsmasq running natively via Homebrew
-		"lerd-watcher": true,
-		"lerd-ui":      true,
+	switch unit {
+	case "lerd-dns", "lerd-watcher", "lerd-ui":
+		return false
 	}
-	return !nativeUnits[unit]
+	return true
 }
 
 func serviceRecentLogs(unit string) string {
@@ -44,18 +48,75 @@ func serviceRecentLogs(unit string) string {
 	return strings.TrimSpace(string(out))
 }
 
-// logStreamCmd returns a command that streams logs for the unit.
-// Container units use `podman logs -f`; native service units tail the launchd log file.
+// logStreamCmd returns a command that tails the launchd log file for native
+// service units (dns, watcher, ui). Container units are streamed directly
+// via `podman logs` in handleLogs and do not use this path.
 func logStreamCmd(ctx context.Context, unit string) *exec.Cmd {
-	if isContainerUnit(unit) {
-		// Wait up to 10s for the container to exist before streaming, so the
-		// UI doesn't get an immediate "no such container" error when the log
-		// panel opens right after a worker is started.
-		bin := podman.PodmanBin()
-		script := `for i in $(seq 1 20); do ` + bin + ` container exists ` + unit + ` 2>/dev/null && break; sleep 0.5; done; exec ` + bin + ` logs -f --tail 100 ` + unit
-		return exec.CommandContext(ctx, "/bin/sh", "-c", script)
-	}
 	path := lerdLogPath(unit)
 	script := `for i in $(seq 1 10); do [ -f "` + path + `" ] && break; sleep 0.5; done; exec tail -f -n 100 "` + path + `"`
 	return exec.CommandContext(ctx, "/bin/sh", "-c", script)
+}
+
+// streamUnitLogs streams logs for a unit as SSE.
+// Container units (workers, PHP-FPM, services) use `podman logs -f`.
+// Native service units (dns, watcher, ui) tail the launchd log file.
+func streamUnitLogs(w http.ResponseWriter, r *http.Request, unit string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	if isContainerUnit(unit) {
+		// Wait up to 10s for the container to exist (e.g. right after start).
+		bin := podman.PodmanBin()
+		tail := "100"
+		if r.Header.Get("Last-Event-ID") != "" {
+			tail = "0"
+		}
+		script := `for i in $(seq 1 20); do ` + bin + ` container exists ` + unit + ` 2>/dev/null && break; sleep 0.5; done; exec ` + bin + ` logs -f --tail ` + tail + ` ` + unit
+		cmd := exec.CommandContext(r.Context(), "/bin/sh", "-c", script)
+		pr, pw := io.Pipe()
+		cmd.Stdout = pw
+		cmd.Stderr = pw
+		if err := cmd.Start(); err != nil {
+			fmt.Fprintf(w, "data: error starting logs: %s\n\n", err.Error())
+			flusher.Flush()
+			return
+		}
+		go func() { cmd.Wait(); pw.Close() }() //nolint:errcheck
+		scanner := bufio.NewScanner(pr)
+		scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+		for scanner.Scan() {
+			fmt.Fprintf(w, "data: %s\n\n", scanner.Text())
+			flusher.Flush()
+		}
+		if cmd.Process != nil {
+			cmd.Process.Kill() //nolint:errcheck
+		}
+		return
+	}
+
+	// Native service: tail the launchd log file.
+	pr, pw := io.Pipe()
+	cmd := logStreamCmd(r.Context(), unit)
+	cmd.Stdout = pw
+	cmd.Stderr = pw
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(w, "data: error starting logs: %s\n\n", err.Error())
+		flusher.Flush()
+		return
+	}
+	go func() { cmd.Wait(); pw.Close() }() //nolint:errcheck
+	scanner := bufio.NewScanner(pr)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		fmt.Fprintf(w, "data: %s\n\n", scanner.Text())
+		flusher.Flush()
+	}
 }

--- a/internal/ui/logs_linux.go
+++ b/internal/ui/logs_linux.go
@@ -3,7 +3,12 @@
 package ui
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"os/exec"
 	"strings"
 )
@@ -20,3 +25,66 @@ func logStreamCmd(ctx context.Context, unit string) *exec.Cmd {
 
 // isContainerUnit returns true on Linux — all lerd units run as Podman containers.
 func isContainerUnit(_ string) bool { return true }
+
+func streamUnitLogs(w http.ResponseWriter, r *http.Request, unit string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	cursor := r.Header.Get("Last-Event-ID")
+	args := []string{"--user", "-u", unit, "-f", "--no-pager", "--output=json"}
+	if cursor != "" {
+		args = append(args, "--after-cursor="+cursor)
+	} else {
+		args = append(args, "-n", "100")
+	}
+
+	pr, pw := io.Pipe()
+	cmd := exec.CommandContext(r.Context(), "journalctl", args...)
+	cmd.Stdout = pw
+	cmd.Stderr = io.Discard
+
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(w, "data: error starting logs: %s\n\n", err.Error())
+		flusher.Flush()
+		return
+	}
+
+	go func() {
+		cmd.Wait() //nolint:errcheck
+		pw.Close()
+	}()
+
+	type journalEntry struct {
+		Cursor  string          `json:"__CURSOR"`
+		Message json.RawMessage `json:"MESSAGE"`
+	}
+
+	scanner := bufio.NewScanner(pr)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		var entry journalEntry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		var msg string
+		if len(entry.Message) > 0 && entry.Message[0] == '"' {
+			json.Unmarshal(entry.Message, &msg) //nolint:errcheck
+		} else {
+			// journalctl encodes binary messages as a JSON array of bytes
+			var b []byte
+			if json.Unmarshal(entry.Message, &b) == nil {
+				msg = string(b)
+			}
+		}
+		fmt.Fprintf(w, "id: %s\ndata: %s\n\n", entry.Cursor, msg)
+		flusher.Flush()
+	}
+}

--- a/internal/ui/remote_control.go
+++ b/internal/ui/remote_control.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net"
 	"net/http"
+	"runtime"
 	"strings"
 	"time"
 
@@ -196,6 +197,7 @@ func handleLANStatus(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]any{
 			"exposed": exposed,
 			"lan_ip":  lanIP,
+			"macos":   runtime.GOOS == "darwin",
 		})
 		return
 

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/cli"
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/services"
 	"github.com/geodro/lerd/internal/dns"
 	"github.com/geodro/lerd/internal/envfile"
 	"github.com/geodro/lerd/internal/nginx"
@@ -305,8 +306,7 @@ func handleStatus(w http.ResponseWriter, _ *http.Request) {
 
 	dnsOK, _ := dns.Check(tld)
 	nginxRunning, _ := podman.ContainerRunning("lerd-nginx")
-	watcherCmd := exec.Command("systemctl", "--user", "is-active", "--quiet", "lerd-watcher")
-	watcherRunning := watcherCmd.Run() == nil
+	watcherRunning := services.Mgr.IsActive("lerd-watcher")
 
 	versions, _ := phpPkg.ListInstalled()
 	var phpStatuses []PHPStatus
@@ -563,41 +563,6 @@ func listActiveHorizonWorkers() []string {
 	return listActiveUnitsBySuffix("lerd-horizon-*.service", "lerd-horizon-")
 }
 
-// listActiveStripeListeners returns the site names of active lerd-stripe-* units
-// that were started by `lerd stripe:listen` (i.e. have a .service file in the
-// systemd user dir, as opposed to quadlet-based services like stripe-mock).
-func listActiveStripeListeners() []string {
-	all := listActiveUnitsBySuffix("lerd-stripe-*.service", "lerd-stripe-")
-	var result []string
-	for _, name := range all {
-		unitFile := filepath.Join(config.SystemdUserDir(), "lerd-stripe-"+name+".service")
-		if _, err := os.Stat(unitFile); err == nil {
-			result = append(result, name)
-		}
-	}
-	return result
-}
-
-func listActiveUnitsBySuffix(pattern, prefix string) []string {
-	out, err := exec.Command("systemctl", "--user", "list-units", "--state=active",
-		"--no-legend", "--plain", pattern).Output()
-	if err != nil {
-		return nil
-	}
-	var sites []string
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) == 0 {
-			continue
-		}
-		unit := strings.TrimSuffix(fields[0], ".service")
-		siteName := strings.TrimPrefix(unit, prefix)
-		if siteName != unit && siteName != "" {
-			sites = append(sites, siteName)
-		}
-	}
-	return sites
-}
 
 func handleServices(w http.ResponseWriter, _ *http.Request) {
 	services := make([]ServiceResponse, 0, len(knownServices))
@@ -1075,7 +1040,7 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
 			return
 		}
-		_ = podman.DaemonReload()
+		_ = podman.DaemonReloadFn()
 		if err := config.RemoveCustomService(name); err != nil {
 			writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
 			return
@@ -1126,17 +1091,17 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// ensureServiceQuadlet writes the quadlet for a built-in service and reloads systemd.
+// ensureServiceQuadlet writes the unit file for a built-in service and reloads the service manager.
 func ensureServiceQuadlet(name string) error {
 	quadletName := "lerd-" + name
 	content, err := podman.GetQuadletTemplate(quadletName + ".container")
 	if err != nil {
 		return fmt.Errorf("unknown service %q", name)
 	}
-	if err := podman.WriteQuadlet(quadletName, content); err != nil {
-		return fmt.Errorf("writing quadlet for %s: %w", name, err)
+	if err := podman.WriteContainerUnitFn(quadletName, content); err != nil {
+		return fmt.Errorf("writing unit for %s: %w", name, err)
 	}
-	return podman.DaemonReload()
+	return podman.DaemonReloadFn()
 }
 
 // ensureCustomServiceQuadlet writes the quadlet for a custom service and reloads systemd.
@@ -1728,7 +1693,7 @@ func handlePHPVersionAction(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
 			return
 		}
-		_ = podman.DaemonReload()
+		_ = podman.DaemonReloadFn()
 		writeJSON(w, map[string]any{"ok": true})
 	default:
 		http.NotFound(w, r)
@@ -1842,9 +1807,16 @@ func handleLogs(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no") // tell nginx not to buffer
 
+	// If no container exists for this unit, route to the platform log stream
+	// (file tail for native services) or report not-running for container units.
 	if exists, _ := podman.ContainerExists(container); !exists {
-		fmt.Fprintf(w, "data: container %s is not running\n\n", container)
-		flusher.Flush()
+		if isContainerUnit(container) {
+			fmt.Fprintf(w, "data: container %s is not running\n\n", container)
+			flusher.Flush()
+			return
+		}
+		// Native service (dns, watcher, ui) — stream from log file.
+		streamUnitLogs(w, r, container)
 		return
 	}
 
@@ -1854,7 +1826,7 @@ func handleLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pr, pw := io.Pipe()
-	cmd := exec.CommandContext(r.Context(), "podman", "logs", "-f", "--tail", tail, container)
+	cmd := exec.CommandContext(r.Context(), podman.PodmanBin(), "logs", "-f", "--tail", tail, container)
 	cmd.Stdout = pw
 	cmd.Stderr = pw
 
@@ -2216,69 +2188,6 @@ func handleAppLogs(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]any{"entries": entries})
 }
 
-func streamUnitLogs(w http.ResponseWriter, r *http.Request, unit string) {
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "streaming not supported", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("X-Accel-Buffering", "no")
-
-	cursor := r.Header.Get("Last-Event-ID")
-	args := []string{"--user", "-u", unit, "-f", "--no-pager", "--output=json"}
-	if cursor != "" {
-		args = append(args, "--after-cursor="+cursor)
-	} else {
-		args = append(args, "-n", "100")
-	}
-
-	pr, pw := io.Pipe()
-	cmd := exec.CommandContext(r.Context(), "journalctl", args...)
-	cmd.Stdout = pw
-	cmd.Stderr = io.Discard
-
-	if err := cmd.Start(); err != nil {
-		fmt.Fprintf(w, "data: error starting logs: %s\n\n", err.Error())
-		flusher.Flush()
-		return
-	}
-
-	go func() {
-		cmd.Wait() //nolint:errcheck
-		pw.Close()
-	}()
-
-	type journalEntry struct {
-		Cursor  string          `json:"__CURSOR"`
-		Message json.RawMessage `json:"MESSAGE"`
-	}
-
-	scanner := bufio.NewScanner(pr)
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
-	for scanner.Scan() {
-		var entry journalEntry
-		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
-			continue
-		}
-		var msg string
-		if len(entry.Message) > 0 && entry.Message[0] == '"' {
-			json.Unmarshal(entry.Message, &msg) //nolint:errcheck
-		} else {
-			// journalctl encodes binary messages as a JSON array of bytes
-			var b []byte
-			if json.Unmarshal(entry.Message, &b) == nil {
-				msg = string(b)
-			}
-		}
-		fmt.Fprintf(w, "id: %s\ndata: %s\n\n", entry.Cursor, msg)
-		flusher.Flush()
-	}
-}
 
 // handleBrowse returns a listing of directories for the file browser.
 func handleBrowse(w http.ResponseWriter, r *http.Request) {

--- a/internal/ui/server_darwin.go
+++ b/internal/ui/server_darwin.go
@@ -1,0 +1,51 @@
+//go:build darwin
+
+package ui
+
+import (
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/services"
+)
+
+// listActiveUnitsBySuffix returns site names for active units with the given prefix.
+// On macOS, workers run as containers; we list units via the service manager and
+// check active status (which covers both containers and launchd-managed services).
+func listActiveUnitsBySuffix(_, prefix string) []string {
+	// Strip trailing dash from prefix to form the glob, e.g. "lerd-queue-" → "lerd-queue-*"
+	nameGlob := strings.TrimSuffix(prefix, "-") + "-*"
+	units := services.Mgr.ListContainerUnits(nameGlob)
+	var sites []string
+	for _, unit := range units {
+		if !services.Mgr.IsActive(unit) {
+			continue
+		}
+		siteName := strings.TrimPrefix(unit, prefix)
+		if siteName != unit && siteName != "" {
+			sites = append(sites, siteName)
+		}
+	}
+	return sites
+}
+
+// listActiveStripeListeners returns site names of active lerd-stripe-* units
+// that correspond to registered sites (excludes presets like stripe-mock).
+func listActiveStripeListeners() []string {
+	all := listActiveUnitsBySuffix("", "lerd-stripe-")
+	reg, err := config.LoadSites()
+	if err != nil {
+		return all
+	}
+	siteNames := make(map[string]bool, len(reg.Sites))
+	for _, s := range reg.Sites {
+		siteNames[s.Name] = true
+	}
+	var result []string
+	for _, name := range all {
+		if siteNames[name] {
+			result = append(result, name)
+		}
+	}
+	return result
+}

--- a/internal/ui/server_linux.go
+++ b/internal/ui/server_linux.go
@@ -1,0 +1,48 @@
+//go:build linux
+
+package ui
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func listActiveUnitsBySuffix(pattern, prefix string) []string {
+	out, err := exec.Command("systemctl", "--user", "list-units", "--state=active",
+		"--no-legend", "--plain", pattern).Output()
+	if err != nil {
+		return nil
+	}
+	var sites []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		unit := strings.TrimSuffix(fields[0], ".service")
+		siteName := strings.TrimPrefix(unit, prefix)
+		if siteName != unit && siteName != "" {
+			sites = append(sites, siteName)
+		}
+	}
+	return sites
+}
+
+// listActiveStripeListeners returns the site names of active lerd-stripe-* units
+// that were started by `lerd stripe:listen` (i.e. have a .service file in the
+// systemd user dir, as opposed to quadlet-based services like stripe-mock).
+func listActiveStripeListeners() []string {
+	all := listActiveUnitsBySuffix("lerd-stripe-*.service", "lerd-stripe-")
+	var result []string
+	for _, name := range all {
+		unitFile := filepath.Join(config.SystemdUserDir(), "lerd-stripe-"+name+".service")
+		if _, err := os.Stat(unitFile); err == nil {
+			result = append(result, name)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
## Summary

- **Fix tray accumulation**: `lerd start` used `lerdSystemd.IsServiceEnabled` (runs `systemctl`) which always returns false on macOS, spawning a new tray process on every start instead of restarting the launchd service
- **Fix workers not in Services UI**: platform-split `listActiveUnitsBySuffix` to use launchd plist checks instead of `systemctl list-units`
- **Fix "only stripe starts"**: ensure `lerd` podman network exists on every `lerd start`; replace `launchctl kickstart` with semaphore-gated direct `podman run` (max 4 concurrent) to avoid saturating the Podman Machine SSH connection after machine restart
- **Fix `lerd stop` hanging**: batch-stop all `lerd-*` containers in one `podman stop` call; skip stop when container is not running
- **Podman Machine readiness**: poll `podman ps` after `machine start` before proceeding with container operations
- **Privileged port binding**: strip host-IP prefix for ports <1024 (`stripPrivilegedIPBind`) — gvproxy cannot bind them to a specific IP
- **macOS LAN warning**: amber banner in dashboard UI and `macos` flag in `/api/lan/status`; hide LAN tray menu item on macOS
- **`make install` post-install hooks**: use `launchctl kickstart -k` on macOS instead of `systemctl --user restart`
- **`AfterQuadletWriteFn`**: hook to keep launchd plists in sync when quadlet files are updated
- **Platform-split test fixes** for macOS CI