### PR TITLE
feat: support scheduled (timer-driven) framework workers

### DIFF
--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -475,6 +475,15 @@ workers:
     label: Messenger
     command: php bin/console messenger:consume async --time-limit=3600
     restart: always               # always | on-failure (default: always)
+    schedule: ""                  # systemd OnCalendar expression (optional). When set, the
+                                  # worker is run as a Type=oneshot service triggered by a
+                                  # sibling .timer instead of a long-running daemon. Use this
+                                  # for cron-style commands like Laravel <=10's
+                                  # `php artisan schedule:run`, which exits immediately and
+                                  # would otherwise restart-loop under restart=always. Any
+                                  # systemd OnCalendar value is accepted (e.g. `minutely`,
+                                  # `*:0/5`, `Mon..Fri *-*-* 02:00:00`). Linux only — on
+                                  # macOS scheduled workers currently log a warning and skip.
     check:                        # only shown when check passes (optional)
       composer: symfony/messenger
     conflicts_with:               # workers to stop before starting (optional)

--- a/internal/cli/horizon.go
+++ b/internal/cli/horizon.go
@@ -91,7 +91,7 @@ func newHorizonStopCmd(use string) *cobra.Command {
 // HorizonStartForSite starts Horizon for the named site. Conflicting workers
 // (defined via ConflictsWith in the framework definition) are stopped first.
 func HorizonStartForSite(siteName, sitePath, phpVersion string) error {
-	fw, ok := config.GetFramework(siteFrameworkName(siteName))
+	fw, ok := config.GetFrameworkForDir(siteFrameworkName(siteName), sitePath)
 	if !ok {
 		return fmt.Errorf("no framework found for site %q", siteName)
 	}

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -233,7 +233,10 @@ func collectRunningWorkers(site *config.Site) []string {
 		}
 		sort.Strings(names)
 		for _, wName := range names {
-			if lerdSystemd.IsServiceActiveOrRestarting("lerd-" + wName + "-" + site.Name) {
+			unit := "lerd-" + wName + "-" + site.Name
+			// Scheduled workers' .service sits at inactive between timer firings.
+			if lerdSystemd.IsServiceActiveOrRestarting(unit) ||
+				lerdSystemd.IsTimerActive(unit) {
 				active = append(active, wName)
 			}
 		}

--- a/internal/cli/queue.go
+++ b/internal/cli/queue.go
@@ -137,7 +137,7 @@ func queueStartExplicit(siteName, sitePath, phpVersion, queue string, tries, tim
 		}
 	}
 
-	fw, ok := config.GetFramework(siteFrameworkName(siteName))
+	fw, ok := config.GetFrameworkForDir(siteFrameworkName(siteName), sitePath)
 	if !ok {
 		return fmt.Errorf("no framework found for site %q", siteName)
 	}
@@ -156,7 +156,7 @@ func queueStartExplicit(siteName, sitePath, phpVersion, queue string, tries, tim
 // QueueStartForSite starts a queue worker for the given site using the command
 // from the framework definition.
 func QueueStartForSite(siteName, sitePath, phpVersion string) error {
-	fw, ok := config.GetFramework(siteFrameworkName(siteName))
+	fw, ok := config.GetFrameworkForDir(siteFrameworkName(siteName), sitePath)
 	if !ok {
 		return fmt.Errorf("no framework found for site %q", siteName)
 	}

--- a/internal/cli/reverb.go
+++ b/internal/cli/reverb.go
@@ -100,7 +100,7 @@ func newReverbStopCmd(use string) *cobra.Command {
 // definition and delegates to the generic WorkerStartForSite, which handles
 // proxy port assignment and nginx regeneration automatically.
 func ReverbStartForSite(siteName, sitePath, phpVersion string) error {
-	fw, ok := config.GetFramework(siteFrameworkName(siteName))
+	fw, ok := config.GetFrameworkForDir(siteFrameworkName(siteName), sitePath)
 	if !ok {
 		return fmt.Errorf("no framework found for site %q", siteName)
 	}

--- a/internal/cli/schedule.go
+++ b/internal/cli/schedule.go
@@ -86,9 +86,12 @@ func newScheduleStopCmd(use string) *cobra.Command {
 }
 
 // ScheduleStartForSite starts the task scheduler for the named site using
-// the "schedule" worker from the framework definition.
+// the "schedule" worker from the framework definition. The version-aware
+// loader (GetFrameworkForDir) is used so per-version overrides — like
+// Laravel 10's `schedule: minutely` cron entry — actually take effect
+// instead of falling back to the version-less built-in defaults.
 func ScheduleStartForSite(siteName, sitePath, phpVersion string) error {
-	fw, ok := config.GetFramework(siteFrameworkName(siteName))
+	fw, ok := config.GetFrameworkForDir(siteFrameworkName(siteName), sitePath)
 	if !ok {
 		return fmt.Errorf("no framework found for site %q", siteName)
 	}

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -666,7 +666,23 @@ func restoreSiteInfrastructure() {
 		}
 	}
 
+	cleanOrphanTimerUnits()
+
 	podman.DaemonReloadFn() //nolint:errcheck
+}
+
+// cleanOrphanTimerUnits removes lerd-*.timer files whose sibling .service
+// is missing — they can't fire and break parallel start with exit 1.
+func cleanOrphanTimerUnits() {
+	dir := config.SystemdUserDir()
+	entries, _ := filepath.Glob(filepath.Join(dir, "lerd-*.timer"))
+	for _, e := range entries {
+		base := strings.TrimSuffix(filepath.Base(e), ".timer")
+		if _, err := os.Stat(filepath.Join(dir, base+".service")); err == nil {
+			continue
+		}
+		_ = services.Mgr.RemoveTimerUnit(base)
+	}
 }
 
 func registeredStripeUnits() []string {

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -377,6 +377,12 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// declared in the site registry, so restored unit files get started here
 	// rather than waiting for the next session.
 	workerUnits = append(workerUnits, registeredFrameworkWorkerUnits()...)
+	// Scheduled workers ship a sibling .timer that drives the oneshot
+	// .service. The .service alone is harmless to start (it runs once and
+	// exits 0), but the timer is what kicks the cron-like cadence — without
+	// adding it explicitly, `lerd start` would leave the timer dead until
+	// the next login.
+	workerUnits = append(workerUnits, registeredTimerUnits()...)
 	workerUnits = dedupeStrings(workerUnits)
 
 	fmt.Println("Starting Lerd...")
@@ -523,6 +529,7 @@ func startRestoredServices() {
 	workerUnits = append(workerUnits, registeredScheduleUnits()...)
 	workerUnits = append(workerUnits, registeredReverbUnits()...)
 	workerUnits = append(workerUnits, registeredFrameworkWorkerUnits()...)
+	workerUnits = append(workerUnits, registeredTimerUnits()...)
 	workerUnits = dedupeStrings(workerUnits)
 	if len(workerUnits) == 0 {
 		return
@@ -682,6 +689,14 @@ func registeredReverbUnits() []string {
 	return services.Mgr.ListServiceUnits("lerd-reverb-*")
 }
 
+// registeredTimerUnits returns names for every lerd-* timer unit on disk,
+// each with the explicit `.timer` suffix so callers pass them straight to
+// systemctl. These drive scheduled (cron-style) framework workers like
+// Laravel <=10's `php artisan schedule:run`.
+func registeredTimerUnits() []string {
+	return services.Mgr.ListTimerUnits("lerd-*")
+}
+
 // registeredFrameworkWorkerUnits returns lerd-{worker}-{site} unit names for
 // every site/worker pair declared in the site registry. Used to make sure
 // non-standard workers (horizon, vite-dev, etc.) get started in phase 2 of
@@ -735,6 +750,10 @@ func runStop(_ *cobra.Command, _ []string) error {
 	units = append(units, registeredStripeUnits()...)
 	units = append(units, registeredScheduleUnits()...)
 	units = append(units, registeredReverbUnits()...)
+	// Stop scheduled-worker timers explicitly. Stopping the sibling
+	// oneshot .service is a no-op (it isn't running between firings),
+	// so without this the timer keeps dispatching after `lerd stop`.
+	units = append(units, registeredTimerUnits()...)
 
 	fmt.Println("Stopping Lerd...")
 

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -377,13 +377,8 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// declared in the site registry, so restored unit files get started here
 	// rather than waiting for the next session.
 	workerUnits = append(workerUnits, registeredFrameworkWorkerUnits()...)
-	// Scheduled workers ship a sibling .timer that drives the oneshot
-	// .service. The .service alone is harmless to start (it runs once and
-	// exits 0), but the timer is what kicks the cron-like cadence — without
-	// adding it explicitly, `lerd start` would leave the timer dead until
-	// the next login.
 	workerUnits = append(workerUnits, registeredTimerUnits()...)
-	workerUnits = dedupeStrings(workerUnits)
+	workerUnits = collapseTimerSiblings(dedupeStrings(workerUnits))
 
 	fmt.Println("Starting Lerd...")
 
@@ -391,7 +386,7 @@ func runStart(_ *cobra.Command, _ []string) error {
 		jobs := make([]BuildJob, len(us))
 		for i, u := range us {
 			unit := u
-			label := strings.TrimPrefix(unit, "lerd-")
+			label := strings.TrimSuffix(strings.TrimPrefix(unit, "lerd-"), ".timer")
 			jobs[i] = BuildJob{
 				Label: label,
 				Run: func(w io.Writer) error {
@@ -512,7 +507,7 @@ func startRestoredServices() {
 	var startJobs []BuildJob
 	for _, u := range units {
 		unit := u
-		label := strings.TrimPrefix(unit, "lerd-")
+		label := strings.TrimSuffix(strings.TrimPrefix(unit, "lerd-"), ".timer")
 		startJobs = append(startJobs, BuildJob{
 			Label: label,
 			Run:   func(_ io.Writer) error { return podman.StartUnit(unit) },
@@ -530,14 +525,14 @@ func startRestoredServices() {
 	workerUnits = append(workerUnits, registeredReverbUnits()...)
 	workerUnits = append(workerUnits, registeredFrameworkWorkerUnits()...)
 	workerUnits = append(workerUnits, registeredTimerUnits()...)
-	workerUnits = dedupeStrings(workerUnits)
+	workerUnits = collapseTimerSiblings(dedupeStrings(workerUnits))
 	if len(workerUnits) == 0 {
 		return
 	}
 	var workerJobs []BuildJob
 	for _, u := range workerUnits {
 		unit := u
-		label := strings.TrimPrefix(unit, "lerd-")
+		label := strings.TrimSuffix(strings.TrimPrefix(unit, "lerd-"), ".timer")
 		workerJobs = append(workerJobs, BuildJob{
 			Label: label,
 			Run:   func(_ io.Writer) error { return podman.StartUnit(unit) },
@@ -738,6 +733,26 @@ func registeredFrameworkWorkerUnits() []string {
 	return out
 }
 
+// collapseTimerSiblings drops a worker's bare .service entry when its
+// .timer sibling is also in the list — the timer is what drives the
+// oneshot, the bare .service would just fire schedule:run a second time.
+func collapseTimerSiblings(in []string) []string {
+	hasTimer := map[string]bool{}
+	for _, u := range in {
+		if strings.HasSuffix(u, ".timer") {
+			hasTimer[strings.TrimSuffix(u, ".timer")] = true
+		}
+	}
+	out := make([]string, 0, len(in))
+	for _, u := range in {
+		if !strings.HasSuffix(u, ".timer") && hasTimer[u] {
+			continue
+		}
+		out = append(out, u)
+	}
+	return out
+}
+
 func dedupeStrings(in []string) []string {
 	seen := make(map[string]struct{}, len(in))
 	out := make([]string, 0, len(in))
@@ -781,7 +796,7 @@ func runStop(_ *cobra.Command, _ []string) error {
 	jobs := make([]BuildJob, len(units))
 	for i, u := range units {
 		unit := u
-		label := strings.TrimPrefix(unit, "lerd-")
+		label := strings.TrimSuffix(strings.TrimPrefix(unit, "lerd-"), ".timer")
 		jobs[i] = BuildJob{
 			Label: label,
 			Run:   func(w io.Writer) error { return podman.StopUnit(unit) },

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -70,6 +70,10 @@ func runUninstall(force bool) error {
 			}
 			_ = services.Mgr.Disable(unit)
 		}
+		for _, unit := range services.Mgr.ListTimerUnits("lerd-*") {
+			_ = podman.StopUnit(unit)
+			_ = services.Mgr.Disable(unit)
+		}
 		// Kill any running tray process. The tray may be running standalone
 		// (launched from the desktop file or `lerd tray`) without a unit,
 		// in which case the unit teardown above misses it.
@@ -89,6 +93,9 @@ func runUninstall(force bool) error {
 				continue
 			}
 			_ = services.Mgr.RemoveServiceUnit(unit)
+		}
+		for _, unit := range services.Mgr.ListTimerUnits("lerd-*") {
+			_ = services.Mgr.RemoveTimerUnit(strings.TrimSuffix(unit, ".timer"))
 		}
 	}
 	ok()

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -229,17 +229,28 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 		label = workerName
 	}
 
-	changed, err := writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, command, restart, fpmUnit)
+	changed, err := writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, command, restart, w.Schedule, fpmUnit)
 	if err != nil {
 		return fmt.Errorf("writing worker unit: %w", err)
 	}
+
+	// Scheduled workers run via a sibling .timer that systemd starts on
+	// the configured cadence; the .service is a Type=oneshot triggered by
+	// the timer, so we enable and start the .timer rather than the
+	// .service. The non-scheduled (daemon) path keeps the original
+	// .service-based lifecycle.
+	lifecycleTarget := unitName
+	if w.Schedule != "" {
+		lifecycleTarget = unitName + ".timer"
+	}
+
 	if changed {
-		if err := services.Mgr.Enable(unitName); err != nil {
+		if err := services.Mgr.Enable(lifecycleTarget); err != nil {
 			fmt.Printf("[WARN] enable: %v\n", err)
 		}
 	}
 
-	if err := services.Mgr.Start(unitName); err != nil {
+	if err := services.Mgr.Start(lifecycleTarget); err != nil {
 		return fmt.Errorf("starting %s worker: %w", workerName, err)
 	}
 
@@ -426,9 +437,20 @@ func siteFrameworkName(siteName string) string {
 func WorkerStopForSite(siteName, workerName string) error {
 	unitName := "lerd-" + workerName + "-" + siteName
 
+	// Stop and disable both possible shapes (daemon .service and
+	// scheduled .timer + oneshot .service). We don't know up-front
+	// whether the worker was scheduled, and the framework yaml may
+	// have flipped between the two shapes since the unit was written,
+	// so we tear down both unconditionally — missing units are no-ops
+	// at this layer.
+	_ = services.Mgr.Disable(unitName + ".timer")
+	podman.StopUnit(unitName + ".timer") //nolint:errcheck
 	_ = services.Mgr.Disable(unitName)
 	podman.StopUnit(unitName) //nolint:errcheck
 
+	if err := services.Mgr.RemoveTimerUnit(unitName); err != nil {
+		return fmt.Errorf("removing timer unit file: %w", err)
+	}
 	if err := services.Mgr.RemoveServiceUnit(unitName); err != nil {
 		return fmt.Errorf("removing unit file: %w", err)
 	}

--- a/internal/cli/worker_darwin.go
+++ b/internal/cli/worker_darwin.go
@@ -15,7 +15,15 @@ import (
 // writeWorkerUnitFile writes a container unit for the worker on macOS.
 // Workers run as independent detached containers using the same PHP-FPM image,
 // so each worker has its own lifecycle and logs stream via `podman logs`.
-func writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, command, restart, fpmUnit string) (bool, error) {
+//
+// Scheduled workers (Schedule != "") are not yet supported on macOS — the
+// launchd StartCalendarInterval path needs its own plist generator. We log
+// a warning and skip rather than restart-loop a one-shot command.
+func writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, command, restart, schedule, fpmUnit string) (bool, error) {
+	if schedule != "" {
+		fmt.Printf("[WARN] worker %s has schedule=%q which is not yet supported on macOS — skipping\n", unitName, schedule)
+		return false, nil
+	}
 	versionShort := strings.ReplaceAll(phpVersion, ".", "")
 	image := "lerd-php" + versionShort + "-fpm:local"
 
@@ -78,5 +86,5 @@ func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.F
 	if label == "" {
 		label = workerName
 	}
-	writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, w.Command, restart, fpmUnit) //nolint:errcheck
+	writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, w.Command, restart, w.Schedule, fpmUnit) //nolint:errcheck
 }

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -16,8 +16,49 @@ import (
 
 // writeWorkerUnitFile writes a systemd service unit for the worker on Linux.
 // Workers exec into the running FPM container.
-func writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, command, restart, fpmUnit string) (bool, error) {
+//
+// When schedule is non-empty the worker is modelled as a Type=oneshot
+// service triggered by a sibling .timer with the given OnCalendar
+// expression — the right shape for one-shot commands like Laravel 10's
+// `php artisan schedule:run`, which exit immediately and would otherwise
+// restart-loop every 5s under Restart=always.
+func writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, command, restart, schedule, fpmUnit string) (bool, error) {
 	container := fpmUnit
+
+	if schedule != "" {
+		serviceUnit := fmt.Sprintf(`[Unit]
+Description=Lerd %s (%s)
+After=network.target %s.service
+BindsTo=%s.service
+
+[Service]
+Type=oneshot
+ExecStart=%s exec -w %s %s %s
+`, label, siteName, fpmUnit, fpmUnit, podman.PodmanBin(), sitePath, container, command)
+
+		timerUnit := fmt.Sprintf(`[Unit]
+Description=Lerd %s timer (%s)
+
+[Timer]
+OnCalendar=%s
+Persistent=true
+AccuracySec=1s
+
+[Install]
+WantedBy=timers.target
+`, label, siteName, schedule)
+
+		serviceChanged, err := services.Mgr.WriteServiceUnitIfChanged(unitName, serviceUnit)
+		if err != nil {
+			return false, err
+		}
+		timerChanged, err := services.Mgr.WriteTimerUnitIfChanged(unitName, timerUnit)
+		if err != nil {
+			return serviceChanged, err
+		}
+		return serviceChanged || timerChanged, nil
+	}
+
 	unit := fmt.Sprintf(`[Unit]
 Description=Lerd %s (%s)
 After=network.target %s.service
@@ -32,6 +73,11 @@ ExecStart=%s exec -w %s %s %s
 [Install]
 WantedBy=default.target
 `, label, siteName, fpmUnit, fpmUnit, restart, podman.PodmanBin(), sitePath, container, command)
+
+	// A previous run may have written a sibling .timer for this unit
+	// (e.g. before the framework yaml dropped its `schedule:` field).
+	// Clean it up so the daemon model takes over cleanly.
+	_ = services.Mgr.RemoveTimerUnit(unitName)
 
 	return services.Mgr.WriteServiceUnitIfChanged(unitName, unit)
 }
@@ -71,14 +117,18 @@ func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.F
 		label = workerName
 	}
 
-	changed, err := writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, command, restart, fpmUnit)
+	changed, err := writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, command, restart, w.Schedule, fpmUnit)
 	if err != nil {
 		fmt.Printf("[WARN] writing worker unit %s: %v\n", unitName, err)
 		return
 	}
 	if changed {
-		if err := services.Mgr.Enable(unitName); err != nil {
-			fmt.Printf("[WARN] enable %s: %v\n", unitName, err)
+		enableTarget := unitName
+		if w.Schedule != "" {
+			enableTarget = unitName + ".timer"
+		}
+		if err := services.Mgr.Enable(enableTarget); err != nil {
+			fmt.Printf("[WARN] enable %s: %v\n", enableTarget, err)
 		}
 	}
 }

--- a/internal/cli/worker_schedule_linux_test.go
+++ b/internal/cli/worker_schedule_linux_test.go
@@ -1,0 +1,96 @@
+//go:build linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestWriteWorkerUnitFile_ScheduleEmitsTimer asserts that providing a
+// non-empty schedule produces both a Type=oneshot service and a sibling
+// .timer with the right OnCalendar expression — the shape Laravel <=10
+// scheduler needs to avoid the Restart=always loop bug.
+func TestWriteWorkerUnitFile_ScheduleEmitsTimer(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	changed, err := writeWorkerUnitFile(
+		"lerd-schedule-mysite", "Task Scheduler", "mysite",
+		"/srv/mysite", "8.3", "php artisan schedule:run",
+		"always", "minutely", "lerd-php83-fpm",
+	)
+	if err != nil {
+		t.Fatalf("writeWorkerUnitFile: %v", err)
+	}
+	if !changed {
+		t.Errorf("first write reported changed=false, want true")
+	}
+
+	systemdDir := filepath.Join(tmp, "systemd", "user")
+	svc, err := os.ReadFile(filepath.Join(systemdDir, "lerd-schedule-mysite.service"))
+	if err != nil {
+		t.Fatalf("read service: %v", err)
+	}
+	if !strings.Contains(string(svc), "Type=oneshot") {
+		t.Errorf("scheduled worker service missing Type=oneshot:\n%s", svc)
+	}
+	if strings.Contains(string(svc), "Restart=") {
+		t.Errorf("scheduled worker service must not declare Restart=:\n%s", svc)
+	}
+
+	timer, err := os.ReadFile(filepath.Join(systemdDir, "lerd-schedule-mysite.timer"))
+	if err != nil {
+		t.Fatalf("read timer: %v", err)
+	}
+	if !strings.Contains(string(timer), "OnCalendar=minutely") {
+		t.Errorf("timer missing OnCalendar=minutely:\n%s", timer)
+	}
+	if !strings.Contains(string(timer), "WantedBy=timers.target") {
+		t.Errorf("timer missing WantedBy=timers.target:\n%s", timer)
+	}
+}
+
+// TestWriteWorkerUnitFile_DaemonRemovesStaleTimer asserts that switching
+// a worker from scheduled back to daemon shape (e.g. user removes the
+// schedule field from the framework yaml) cleans up the lingering
+// .timer file so systemd doesn't keep firing the old oneshot.
+func TestWriteWorkerUnitFile_DaemonRemovesStaleTimer(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	if _, err := writeWorkerUnitFile(
+		"lerd-queue-mysite", "Queue Worker", "mysite",
+		"/srv/mysite", "8.3", "php artisan queue:work",
+		"always", "minutely", "lerd-php83-fpm",
+	); err != nil {
+		t.Fatalf("seed scheduled: %v", err)
+	}
+
+	timerPath := filepath.Join(tmp, "systemd", "user", "lerd-queue-mysite.timer")
+	if _, err := os.Stat(timerPath); err != nil {
+		t.Fatalf("stale timer not seeded: %v", err)
+	}
+
+	if _, err := writeWorkerUnitFile(
+		"lerd-queue-mysite", "Queue Worker", "mysite",
+		"/srv/mysite", "8.3", "php artisan queue:work",
+		"always", "", "lerd-php83-fpm",
+	); err != nil {
+		t.Fatalf("rewrite as daemon: %v", err)
+	}
+
+	if _, err := os.Stat(timerPath); !os.IsNotExist(err) {
+		t.Errorf("stale .timer still present after switching to daemon shape: %v", err)
+	}
+
+	svc, err := os.ReadFile(filepath.Join(tmp, "systemd", "user", "lerd-queue-mysite.service"))
+	if err != nil {
+		t.Fatalf("read service: %v", err)
+	}
+	if !strings.Contains(string(svc), "Restart=always") {
+		t.Errorf("daemon worker service missing Restart=always:\n%s", svc)
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -63,6 +63,7 @@ type FrameworkWorker struct {
 	Label         string         `yaml:"label,omitempty"`
 	Command       string         `yaml:"command"`
 	Restart       string         `yaml:"restart,omitempty"`        // always | on-failure (default: always)
+	Schedule      string         `yaml:"schedule,omitempty"`       // systemd OnCalendar expression (e.g. "minutely"); when set, the worker is run as a Type=oneshot service triggered by a .timer rather than a long-running daemon. Use this for Laravel <=10 schedule:run, cron-style cleanup tasks, etc.
 	Check         *FrameworkRule `yaml:"check,omitempty"`          // only show when check passes (file exists or composer package installed)
 	ConflictsWith []string       `yaml:"conflicts_with,omitempty"` // workers to stop before starting this one (e.g. horizon conflicts_with queue)
 	Proxy         *WorkerProxy   `yaml:"proxy,omitempty"`          // WebSocket/HTTP proxy config for nginx

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -397,6 +397,10 @@ func (m *darwinServiceManager) WriteTimerUnitIfChanged(_, _ string) (bool, error
 // RemoveTimerUnit is a no-op on macOS — see WriteTimerUnitIfChanged.
 func (m *darwinServiceManager) RemoveTimerUnit(_ string) error { return nil }
 
+// ListTimerUnits returns no entries on macOS until launchd
+// StartCalendarInterval support lands.
+func (m *darwinServiceManager) ListTimerUnits(_ string) []string { return nil }
+
 func (m *darwinServiceManager) RemoveServiceUnit(name string) error {
 	if err := os.Remove(plistPath(name)); err != nil && !os.IsNotExist(err) {
 		return err

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -386,6 +386,17 @@ func (m *darwinServiceManager) WriteServiceUnitIfChanged(name, content string) (
 	return true, os.WriteFile(plistPath(name), []byte(newPlist), 0644)
 }
 
+// WriteTimerUnitIfChanged is a no-op on macOS until launchd
+// StartCalendarInterval support is added. Scheduled framework workers
+// (like Laravel 10's `schedule:run`) currently log a warning and skip
+// on macOS rather than restart-loop as long-running daemons.
+func (m *darwinServiceManager) WriteTimerUnitIfChanged(_, _ string) (bool, error) {
+	return false, nil
+}
+
+// RemoveTimerUnit is a no-op on macOS — see WriteTimerUnitIfChanged.
+func (m *darwinServiceManager) RemoveTimerUnit(_ string) error { return nil }
+
 func (m *darwinServiceManager) RemoveServiceUnit(name string) error {
 	if err := os.Remove(plistPath(name)); err != nil && !os.IsNotExist(err) {
 		return err

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -35,6 +35,12 @@ type ServiceManager interface {
 	// May be a no-op on platforms without timer support.
 	RemoveTimerUnit(name string) error
 
+	// ListTimerUnits returns timer unit names whose files match nameGlob,
+	// each suffixed with `.timer` (so callers can pass them straight to
+	// systemctl without ambiguity against the sibling .service unit).
+	// Platforms without native timer support return an empty slice.
+	ListTimerUnits(nameGlob string) []string
+
 	// ListServiceUnits returns unit names whose files match nameGlob.
 	// e.g. nameGlob="lerd-queue-*" → ["lerd-queue-myapp", …]
 	ListServiceUnits(nameGlob string) []string

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -22,6 +22,19 @@ type ServiceManager interface {
 	// RemoveServiceUnit removes the unit file for the named service.
 	RemoveServiceUnit(name string) error
 
+	// WriteTimerUnitIfChanged writes a timer unit file (paired with a
+	// matching oneshot service) only when the content has changed. Used
+	// for scheduled framework workers like Laravel 10's `schedule:run`,
+	// which is a one-shot cron-style command rather than a daemon and
+	// would otherwise restart-loop under the always-on worker model.
+	// On platforms that lack a native timer concept the implementation
+	// may be a no-op that returns (false, nil).
+	WriteTimerUnitIfChanged(name, content string) (bool, error)
+
+	// RemoveTimerUnit removes the timer unit file for the named worker.
+	// May be a no-op on platforms without timer support.
+	RemoveTimerUnit(name string) error
+
 	// ListServiceUnits returns unit names whose files match nameGlob.
 	// e.g. nameGlob="lerd-queue-*" → ["lerd-queue-myapp", …]
 	ListServiceUnits(nameGlob string) []string

--- a/internal/services/systemd_linux.go
+++ b/internal/services/systemd_linux.go
@@ -41,9 +41,13 @@ func (m *linuxServiceManager) ListTimerUnits(nameGlob string) []string {
 	entries, _ := filepath.Glob(pattern)
 	names := make([]string, 0, len(entries))
 	for _, e := range entries {
-		// Keep the .timer suffix so callers can distinguish from
-		// the sibling .service unit when starting/stopping.
-		names = append(names, strings.TrimSuffix(filepath.Base(e), ".timer")+".timer")
+		// Skip orphan timers — without a sibling .service systemctl
+		// can't fire them and start jobs fail with exit 1.
+		base := strings.TrimSuffix(filepath.Base(e), ".timer")
+		if _, err := os.Stat(filepath.Join(config.SystemdUserDir(), base+".service")); err != nil {
+			continue
+		}
+		names = append(names, base+".timer")
 	}
 	return names
 }

--- a/internal/services/systemd_linux.go
+++ b/internal/services/systemd_linux.go
@@ -36,6 +36,18 @@ func (m *linuxServiceManager) RemoveTimerUnit(name string) error {
 	return lerdSystemd.RemoveTimer(name)
 }
 
+func (m *linuxServiceManager) ListTimerUnits(nameGlob string) []string {
+	pattern := filepath.Join(config.SystemdUserDir(), nameGlob+".timer")
+	entries, _ := filepath.Glob(pattern)
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		// Keep the .timer suffix so callers can distinguish from
+		// the sibling .service unit when starting/stopping.
+		names = append(names, strings.TrimSuffix(filepath.Base(e), ".timer")+".timer")
+	}
+	return names
+}
+
 func (m *linuxServiceManager) RemoveServiceUnit(name string) error {
 	path := filepath.Join(config.SystemdUserDir(), name+".service")
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {

--- a/internal/services/systemd_linux.go
+++ b/internal/services/systemd_linux.go
@@ -28,6 +28,14 @@ func (m *linuxServiceManager) WriteServiceUnitIfChanged(name, content string) (b
 	return lerdSystemd.WriteServiceIfChanged(name, content)
 }
 
+func (m *linuxServiceManager) WriteTimerUnitIfChanged(name, content string) (bool, error) {
+	return lerdSystemd.WriteTimerIfChanged(name, content)
+}
+
+func (m *linuxServiceManager) RemoveTimerUnit(name string) error {
+	return lerdSystemd.RemoveTimer(name)
+}
+
 func (m *linuxServiceManager) RemoveServiceUnit(name string) error {
 	path := filepath.Join(config.SystemdUserDir(), name+".service")
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -348,6 +348,12 @@ func (e *EnrichedSite) enrichWorkers(fw *config.Framework, hasFw bool) {
 	if fw.HasWorker("schedule", e.Path) && !suppressed["schedule"] {
 		e.HasScheduleWorker = true
 		status, _ := unitStatusFn("lerd-schedule-" + e.Name)
+		// Timer-driven scheduler: .service is static between firings.
+		if status != "active" {
+			if t, _ := unitStatusFn("lerd-schedule-" + e.Name + ".timer"); t == "active" {
+				status = "active"
+			}
+		}
 		e.ScheduleRunning = status == "active"
 		e.ScheduleFailing = status == "activating" || status == "failed"
 	}

--- a/internal/systemd/timer_test.go
+++ b/internal/systemd/timer_test.go
@@ -1,0 +1,62 @@
+package systemd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteTimerIfChanged(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	const content = "[Unit]\nDescription=Test\n\n[Timer]\nOnCalendar=minutely\n"
+
+	changed, err := WriteTimerIfChanged("lerd-test", content)
+	if err != nil {
+		t.Fatalf("WriteTimerIfChanged: %v", err)
+	}
+	if !changed {
+		t.Errorf("first write reported changed=false, want true")
+	}
+
+	path := filepath.Join(tmp, "systemd", "user", "lerd-test.timer")
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("on-disk content = %q, want %q", got, content)
+	}
+
+	// Second write with identical content must report unchanged.
+	changed, err = WriteTimerIfChanged("lerd-test", content)
+	if err != nil {
+		t.Fatalf("second WriteTimerIfChanged: %v", err)
+	}
+	if changed {
+		t.Errorf("idempotent write reported changed=true, want false")
+	}
+}
+
+func TestRemoveTimer(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	if _, err := WriteTimerIfChanged("lerd-test", "[Timer]\n"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := RemoveTimer("lerd-test"); err != nil {
+		t.Fatalf("RemoveTimer: %v", err)
+	}
+	path := filepath.Join(tmp, "systemd", "user", "lerd-test.timer")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file still present after RemoveTimer: %v", err)
+	}
+
+	// Removing a missing file must not error.
+	if err := RemoveTimer("lerd-nonexistent"); err != nil {
+		t.Errorf("RemoveTimer of missing file: %v", err)
+	}
+}

--- a/internal/systemd/user.go
+++ b/internal/systemd/user.go
@@ -123,6 +123,13 @@ func IsServiceActiveOrRestarting(name string) bool {
 	return state == "active" || state == "activating"
 }
 
+// IsTimerActive returns true if the worker's sibling .timer is active.
+func IsTimerActive(name string) bool {
+	cmd := exec.Command("systemctl", "--user", "is-active", name+".timer")
+	out, _ := cmd.Output()
+	return strings.TrimSpace(string(out)) == "active"
+}
+
 // FindOrphanedWorkers scans systemd unit files for worker units belonging to
 // the given site that are running but not present in the known workers set.
 func FindOrphanedWorkers(siteName string, known map[string]bool) []string {

--- a/internal/systemd/user.go
+++ b/internal/systemd/user.go
@@ -36,6 +36,30 @@ func WriteServiceIfChanged(name, content string) (bool, error) {
 	return true, os.WriteFile(path, []byte(content), 0644)
 }
 
+// WriteTimerIfChanged writes a systemd user timer unit file when its
+// content differs from what is already on disk. Returns true when the
+// file was written so the caller knows to run daemon-reload.
+func WriteTimerIfChanged(name, content string) (bool, error) {
+	dir := config.SystemdUserDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return false, err
+	}
+	path := filepath.Join(dir, name+".timer")
+	if existing, err := os.ReadFile(path); err == nil && string(existing) == content {
+		return false, nil
+	}
+	return true, os.WriteFile(path, []byte(content), 0644)
+}
+
+// RemoveTimer removes a systemd user timer unit file.
+func RemoveTimer(name string) error {
+	path := filepath.Join(config.SystemdUserDir(), name+".timer")
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 // EnableService enables a systemd user service.
 func EnableService(name string) error {
 	cmd := exec.Command("systemctl", "--user", "enable", name)

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -575,8 +575,19 @@ func listActiveQueueWorkers() []string {
 }
 
 // listActiveScheduleWorkers returns site names of active lerd-schedule-* units.
+// Includes timer-driven schedulers whose .service is static between firings.
 func listActiveScheduleWorkers() []string {
-	return listActiveUnitsBySuffix("lerd-schedule-*.service", "lerd-schedule-")
+	svc := listActiveUnitsBySuffix("lerd-schedule-*.service", "lerd-schedule-")
+	timer := listActiveUnitsBySuffix("lerd-schedule-*.timer", "lerd-schedule-")
+	seen := map[string]bool{}
+	out := make([]string, 0, len(svc)+len(timer))
+	for _, n := range append(svc, timer...) {
+		if !seen[n] {
+			seen[n] = true
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 // listActiveReverbServers returns site names of active lerd-reverb-* units.

--- a/internal/ui/server_linux.go
+++ b/internal/ui/server_linux.go
@@ -23,7 +23,7 @@ func listActiveUnitsBySuffix(pattern, prefix string) []string {
 		if len(fields) == 0 {
 			continue
 		}
-		unit := strings.TrimSuffix(fields[0], ".service")
+		unit := strings.TrimSuffix(strings.TrimSuffix(fields[0], ".service"), ".timer")
 		siteName := strings.TrimPrefix(unit, prefix)
 		if siteName != unit && siteName != "" {
 			sites = append(sites, siteName)


### PR DESCRIPTION
## Summary
- Adds a new `schedule` field to `FrameworkWorker`. When set, the worker is rendered on Linux as a `Type=oneshot` systemd service triggered by a sibling `.timer` with the given `OnCalendar=` expression, instead of the default `Restart=always` daemon.
- This is the right shape for one-shot cron-style commands like Laravel <=10's `php artisan schedule:run`, which exits immediately and was otherwise restart-looping every 5 seconds under the daemon model.
- Switching a worker between scheduled and daemon shape cleans up the stale sibling unit so systemd doesn't keep firing the previous shape.
- macOS currently logs a warning and skips scheduled workers until a launchd `StartCalendarInterval` generator is added.

## Companion change
The Laravel 10 framework definition (in geodro/lerd-frameworks) needs `schedule: minutely` added to its `schedule` worker so users on Laravel 10 stop seeing the restart loop. I'll open that PR separately.