### PR TITLE
Push dashboard updates over websocket instead of polling

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -8,13 +8,18 @@ import (
 	"strings"
 	"time"
 
+	"bytes"
+	"net/http"
+
 	"github.com/geodro/lerd/internal/cli"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
+	"github.com/geodro/lerd/internal/eventbus"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/nginx"
 	nodeDet "github.com/geodro/lerd/internal/node"
 	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteops"
 	"github.com/geodro/lerd/internal/ui"
 	"github.com/geodro/lerd/internal/version"
@@ -22,7 +27,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// notifyLerdUI posts to the lerd-ui loopback notifier so any unit lifecycle
+// change from a CLI process propagates to the dashboard in real time. It
+// runs synchronously with a tight timeout: the CLI process is about to
+// exit, so a background goroutine would be killed before the POST hits the
+// socket. 500ms is more than enough for a loopback round-trip and is barely
+// perceptible. If lerd-ui isn't running the POST fails fast and the CLI
+// command still succeeds.
+func notifyLerdUI(_ string) {
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	req, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:7073/api/internal/notify", bytes.NewReader(nil))
+	if err != nil {
+		return
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}
+
 func main() {
+	// Cross-process bridge from CLI unit mutations to the running lerd-ui.
+	// ui.Start reassigns this in its own process for a direct in-process
+	// publish; in the CLI/MCP processes we HTTP-POST to the dashboard.
+	podman.AfterUnitChange = notifyLerdUI
+
 	root := &cobra.Command{
 		Use:     "lerd",
 		Short:   "Lerd — Podman-powered local PHP dev environment for Linux and macOS",
@@ -409,6 +439,7 @@ func newWatchCmd() *cobra.Command {
 						if err := cli.QueueRestartForSite(site.Name, sitePath, site.PHPVersion); err != nil {
 							fmt.Printf("[WARN] queue restart for %s: %v\n", site.Name, err)
 						}
+						eventbus.Default.Publish(eventbus.KindSites)
 					},
 				)
 				if err != nil {
@@ -425,6 +456,7 @@ func newWatchCmd() *cobra.Command {
 					if err := nginx.Reload(); err != nil {
 						fmt.Printf("[WARN] nginx reload: %v\n", err)
 					}
+					eventbus.Default.Publish(eventbus.KindSites)
 				}
 			}, func(removedPath string) {
 				site, err := config.FindSiteByPath(removedPath)
@@ -433,6 +465,7 @@ func newWatchCmd() *cobra.Command {
 				}
 				fmt.Printf("Project deleted: %s (%s)\n", site.Name, removedPath)
 				_ = siteops.UnlinkSiteCore(site, nil)
+				eventbus.Default.Publish(eventbus.KindSites)
 			})
 		},
 	}

--- a/docs/features/web-ui.md
+++ b/docs/features/web-ui.md
@@ -8,6 +8,10 @@ lerd dashboard   # open in your default browser
 
 The `.localhost` TLD resolves to `127.0.0.1` natively on all modern systems — no DNS configuration needed. The dashboard is also reachable directly at `http://127.0.0.1:7073` if nginx is not running.
 
+## Real-time updates
+
+The dashboard opens a single WebSocket to `/api/ws` on load and receives state changes as they happen. No polling, no stale panels. Every surface that mutates lerd state — browser actions, `lerd` CLI commands, the MCP server, the file watcher — pushes a fresh snapshot to every connected tab within about 200 ms. If the WebSocket ever drops (e.g. `lerd-ui` restart), the dashboard falls back to a 5 s polling loop and reconnects in the background with exponential backoff, so a restart is transparent.
+
 ## Install as an app
 
 The dashboard is a Progressive Web App (PWA). You can install it as a standalone desktop app from any Chromium-based browser (Chrome, Brave, Edge):

--- a/internal/eventbus/eventbus.go
+++ b/internal/eventbus/eventbus.go
@@ -1,0 +1,132 @@
+// Package eventbus is an in-process pub/sub hub for UI state-change events.
+//
+// Mutations anywhere in the codebase (CLI commands, HTTP handlers, file
+// watchers) call Publish to announce that a kind of state has changed. The
+// hub debounces rapid publishes and broadcasts a single Event to every
+// Subscriber. The ui package subscribes from the /api/ws handler so the
+// browser can update without polling.
+package eventbus
+
+import (
+	"sync"
+	"time"
+)
+
+// Event kinds. Callers should use these constants rather than raw strings.
+const (
+	KindSites    = "sites"
+	KindServices = "services"
+	KindStatus   = "status"
+)
+
+// Event is broadcast to every Subscriber when a publish fires.
+type Event struct {
+	Kinds []string
+	At    time.Time
+}
+
+// Subscriber receives events via C. Slow subscribers whose buffer fills up
+// are dropped: the hub closes C and removes the subscriber.
+type Subscriber struct {
+	C      chan Event
+	closed bool
+}
+
+// Hub coalesces publishes and fans them out to subscribers.
+type Hub struct {
+	mu       sync.Mutex
+	subs     map[*Subscriber]struct{}
+	dirty    map[string]struct{}
+	timer    *time.Timer
+	debounce time.Duration
+	now      func() time.Time
+}
+
+// New returns a Hub with the default 150ms debounce window.
+func New() *Hub {
+	return &Hub{
+		subs:     make(map[*Subscriber]struct{}),
+		dirty:    make(map[string]struct{}),
+		debounce: 150 * time.Millisecond,
+		now:      time.Now,
+	}
+}
+
+// Default is the process-wide Hub used by publishers that don't carry their
+// own hub reference.
+var Default = New()
+
+// Subscribe registers a new subscriber with a buffered channel.
+func (h *Hub) Subscribe() *Subscriber {
+	s := &Subscriber{C: make(chan Event, 16)}
+	h.mu.Lock()
+	h.subs[s] = struct{}{}
+	h.mu.Unlock()
+	return s
+}
+
+// Unsubscribe removes s and closes its channel if not already closed.
+func (h *Hub) Unsubscribe(s *Subscriber) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.subs[s]; !ok {
+		return
+	}
+	delete(h.subs, s)
+	if !s.closed {
+		s.closed = true
+		close(s.C)
+	}
+}
+
+// Publish marks kind dirty and (re)arms the debounce timer. Multiple
+// publishes within the debounce window collapse into one broadcast.
+func (h *Hub) Publish(kind string) {
+	h.mu.Lock()
+	h.dirty[kind] = struct{}{}
+	if h.timer == nil {
+		h.timer = time.AfterFunc(h.debounce, h.flush)
+	} else {
+		h.timer.Reset(h.debounce)
+	}
+	h.mu.Unlock()
+}
+
+func (h *Hub) flush() {
+	h.mu.Lock()
+	kinds := make([]string, 0, len(h.dirty))
+	for k := range h.dirty {
+		kinds = append(kinds, k)
+	}
+	h.dirty = make(map[string]struct{})
+	h.timer = nil
+	evt := Event{Kinds: kinds, At: h.now()}
+
+	var drop []*Subscriber
+	for s := range h.subs {
+		if s.closed {
+			drop = append(drop, s)
+			continue
+		}
+		select {
+		case s.C <- evt:
+		default:
+			drop = append(drop, s)
+		}
+	}
+	for _, s := range drop {
+		delete(h.subs, s)
+		if !s.closed {
+			s.closed = true
+			close(s.C)
+		}
+	}
+	h.mu.Unlock()
+}
+
+// SetDebounce changes the debounce window. Intended for tests.
+func (h *Hub) SetDebounce(d time.Duration) {
+	h.mu.Lock()
+	h.debounce = d
+	h.mu.Unlock()
+}

--- a/internal/eventbus/eventbus_test.go
+++ b/internal/eventbus/eventbus_test.go
@@ -1,0 +1,97 @@
+package eventbus
+
+import (
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestPublishDebouncesIntoOneBroadcast(t *testing.T) {
+	h := New()
+	h.SetDebounce(20 * time.Millisecond)
+	sub := h.Subscribe()
+	defer h.Unsubscribe(sub)
+
+	h.Publish(KindSites)
+	h.Publish(KindServices)
+	h.Publish(KindSites)
+
+	select {
+	case evt := <-sub.C:
+		sort.Strings(evt.Kinds)
+		if len(evt.Kinds) != 2 || evt.Kinds[0] != KindServices || evt.Kinds[1] != KindSites {
+			t.Fatalf("unexpected kinds: %v", evt.Kinds)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected one coalesced event")
+	}
+
+	select {
+	case <-sub.C:
+		t.Fatal("did not expect a second event")
+	case <-time.After(60 * time.Millisecond):
+	}
+}
+
+func TestSlowSubscriberDropped(t *testing.T) {
+	h := New()
+	h.SetDebounce(5 * time.Millisecond)
+	sub := h.Subscribe()
+
+	// Fill the buffer without draining, then publish one more round.
+	for i := 0; i < 20; i++ {
+		h.Publish(KindSites)
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// The subscriber's channel must be closed eventually.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		h.mu.Lock()
+		_, stillThere := h.subs[sub]
+		h.mu.Unlock()
+		if !stillThere {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("slow subscriber was not dropped")
+}
+
+func TestUnsubscribeStopsDelivery(t *testing.T) {
+	h := New()
+	h.SetDebounce(5 * time.Millisecond)
+	sub := h.Subscribe()
+	h.Unsubscribe(sub)
+
+	h.Publish(KindSites)
+	select {
+	case _, ok := <-sub.C:
+		if ok {
+			t.Fatal("did not expect an event after unsubscribe")
+		}
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestMultipleSubscribersEachReceive(t *testing.T) {
+	h := New()
+	h.SetDebounce(5 * time.Millisecond)
+	a := h.Subscribe()
+	b := h.Subscribe()
+	defer h.Unsubscribe(a)
+	defer h.Unsubscribe(b)
+
+	h.Publish(KindStatus)
+
+	for i, sub := range []*Subscriber{a, b} {
+		select {
+		case evt := <-sub.C:
+			if len(evt.Kinds) != 1 || evt.Kinds[0] != KindStatus {
+				t.Fatalf("sub %d: unexpected kinds %v", i, evt.Kinds)
+			}
+		case <-time.After(200 * time.Millisecond):
+			t.Fatalf("sub %d: no event received", i)
+		}
+	}
+}

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -116,9 +116,28 @@ func DaemonReload() error {
 // rate-limit (e.g. workers that raced container readiness in a buggy
 // upgrade) recover automatically on the next `lerd start` instead of
 // staying stuck in `failed`.
+// AfterUnitChange is fired after every successful StartUnit / StopUnit /
+// RestartUnit call. lerd-ui wires this at startup to invalidate the
+// systemctl unit cache and publish "sites"/"services" events to the
+// eventbus so every browser tab updates in real time — regardless of
+// whether the mutation came from an HTTP handler, the CLI, the MCP
+// server, or the file watcher. Nil by default so unit tests and binaries
+// that don't run the UI don't pay the cost.
+var AfterUnitChange func(name string)
+
+func notifyUnitChange(name string) {
+	if AfterUnitChange != nil {
+		AfterUnitChange(name)
+	}
+}
+
 func StartUnit(name string) error {
 	if UnitLifecycle != nil {
-		return UnitLifecycle.Start(name)
+		err := UnitLifecycle.Start(name)
+		if err == nil {
+			notifyUnitChange(name)
+		}
+		return err
 	}
 	_ = exec.Command("systemctl", "--user", "reset-failed", name).Run()
 	cmd := exec.Command("systemctl", "--user", "start", name)
@@ -126,13 +145,18 @@ func StartUnit(name string) error {
 	if err != nil {
 		return fmt.Errorf("start %s failed: %w\n%s", name, err, out)
 	}
+	notifyUnitChange(name)
 	return nil
 }
 
 // StopUnit stops a service unit.
 func StopUnit(name string) error {
 	if UnitLifecycle != nil {
-		return UnitLifecycle.Stop(name)
+		err := UnitLifecycle.Stop(name)
+		if err == nil {
+			notifyUnitChange(name)
+		}
+		return err
 	}
 	cmd := exec.Command("systemctl", "--user", "stop", name)
 	out, err := cmd.CombinedOutput()
@@ -141,19 +165,25 @@ func StopUnit(name string) error {
 	}
 	// Clear any failed state so the unit shows as inactive rather than failed.
 	_ = exec.Command("systemctl", "--user", "reset-failed", name).Run()
+	notifyUnitChange(name)
 	return nil
 }
 
 // RestartUnit restarts a service unit.
 func RestartUnit(name string) error {
 	if UnitLifecycle != nil {
-		return UnitLifecycle.Restart(name)
+		err := UnitLifecycle.Restart(name)
+		if err == nil {
+			notifyUnitChange(name)
+		}
+		return err
 	}
 	cmd := exec.Command("systemctl", "--user", "restart", name)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("restart %s failed: %w\n%s", name, err, out)
 	}
+	notifyUnitChange(name)
 	return nil
 }
 

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -143,8 +143,10 @@ var faviconCandidates = []string{
 }
 
 // Swappable function variables for testing without podman/systemd.
+// unitStatusFn routes through a batched systemctl cache so loading 25 sites
+// no longer fans out into 125+ subprocesses per /api/sites request.
 var (
-	unitStatusFn       = podman.UnitStatus
+	unitStatusFn       = unitStatusCached
 	containerRunningFn = podman.ContainerRunning
 )
 

--- a/internal/siteinfo/unitcache.go
+++ b/internal/siteinfo/unitcache.go
@@ -1,0 +1,89 @@
+package siteinfo
+
+import (
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// unitCacheTTL bounds how long a batched systemctl snapshot is reused before
+// a refresh is triggered on the next lookup.
+const unitCacheTTL = 3 * time.Second
+
+type unitCache struct {
+	mu     sync.Mutex
+	states map[string]string
+	at     time.Time
+}
+
+var (
+	globalUnitCache unitCache
+
+	// unitCacheListFn is swappable for tests. It returns the raw output of
+	// `systemctl --user list-units --all --no-legend --plain 'lerd-*'`.
+	unitCacheListFn = defaultUnitCacheList
+)
+
+func defaultUnitCacheList() (string, error) {
+	out, err := exec.Command("systemctl", "--user", "list-units", "--all", "--no-legend", "--plain", "lerd-*").Output()
+	return string(out), err
+}
+
+// InvalidateUnitCache forces the next UnitStatus lookup to re-run systemctl.
+// Call this after any mutation that changes lerd-* unit state (start, stop,
+// enable, disable, etc.) so cached "active" values do not go stale.
+func InvalidateUnitCache() {
+	globalUnitCache.mu.Lock()
+	globalUnitCache.at = time.Time{}
+	globalUnitCache.mu.Unlock()
+}
+
+// unitStatusCached returns the active state of a lerd-* unit, consulting a
+// short-lived batched snapshot. One systemctl call populates ~all lerd units
+// instead of one subprocess per worker.
+func unitStatusCached(name string) (string, error) {
+	globalUnitCache.mu.Lock()
+	defer globalUnitCache.mu.Unlock()
+
+	if globalUnitCache.states == nil || time.Since(globalUnitCache.at) > unitCacheTTL {
+		if err := globalUnitCache.refreshLocked(); err != nil {
+			return "unknown", nil
+		}
+	}
+
+	if st, ok := globalUnitCache.states[name]; ok {
+		return st, nil
+	}
+	return "unknown", nil
+}
+
+func (c *unitCache) refreshLocked() error {
+	out, err := unitCacheListFn()
+	if err != nil {
+		return err
+	}
+	states := make(map[string]string, 64)
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Columns: UNIT LOAD ACTIVE SUB DESCRIPTION
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		unit, active := fields[0], fields[2]
+		// Strip the .service suffix so callers can pass either form.
+		// Timer and other suffixes are preserved since enrichWorkers
+		// explicitly looks up "lerd-schedule-<site>.timer".
+		states[unit] = active
+		if strings.HasSuffix(unit, ".service") {
+			states[strings.TrimSuffix(unit, ".service")] = active
+		}
+	}
+	c.states = states
+	c.at = time.Now()
+	return nil
+}

--- a/internal/siteinfo/unitcache_test.go
+++ b/internal/siteinfo/unitcache_test.go
@@ -1,0 +1,119 @@
+package siteinfo
+
+import (
+	"testing"
+	"time"
+)
+
+func withStubList(t *testing.T, out string, err error) {
+	t.Helper()
+	prev := unitCacheListFn
+	unitCacheListFn = func() (string, error) { return out, err }
+	InvalidateUnitCache()
+	t.Cleanup(func() {
+		unitCacheListFn = prev
+		InvalidateUnitCache()
+	})
+}
+
+func TestUnitStatusCachedParsesListUnits(t *testing.T) {
+	withStubList(t, `lerd-queue-astrolov.service     loaded active   running Lerd Queue Worker
+lerd-schedule-silvia.timer      loaded active   waiting Lerd Schedule Timer
+lerd-reverb-boom.service        loaded failed   failed  Lerd Reverb
+`, nil)
+
+	cases := map[string]string{
+		"lerd-queue-astrolov":         "active",
+		"lerd-queue-astrolov.service": "active",
+		"lerd-schedule-silvia.timer":  "active",
+		"lerd-reverb-boom":            "failed",
+		"lerd-ghost":                  "unknown",
+	}
+	for unit, want := range cases {
+		got, _ := unitStatusCached(unit)
+		if got != want {
+			t.Errorf("%s: got %q, want %q", unit, got, want)
+		}
+	}
+}
+
+func TestUnitStatusCachedBatchesCalls(t *testing.T) {
+	calls := 0
+	prev := unitCacheListFn
+	unitCacheListFn = func() (string, error) {
+		calls++
+		return "lerd-queue-a.service loaded active running x\n", nil
+	}
+	InvalidateUnitCache()
+	t.Cleanup(func() {
+		unitCacheListFn = prev
+		InvalidateUnitCache()
+	})
+
+	for i := 0; i < 50; i++ {
+		unitStatusCached("lerd-queue-a")
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 systemctl call for 50 lookups, got %d", calls)
+	}
+}
+
+func TestUnitStatusCachedRefreshesAfterInvalidate(t *testing.T) {
+	calls := 0
+	prev := unitCacheListFn
+	unitCacheListFn = func() (string, error) {
+		calls++
+		return "lerd-queue-a.service loaded active running x\n", nil
+	}
+	InvalidateUnitCache()
+	t.Cleanup(func() {
+		unitCacheListFn = prev
+		InvalidateUnitCache()
+	})
+
+	unitStatusCached("lerd-queue-a")
+	InvalidateUnitCache()
+	unitStatusCached("lerd-queue-a")
+	if calls != 2 {
+		t.Fatalf("expected 2 calls after invalidate, got %d", calls)
+	}
+}
+
+func TestUnitStatusCachedRefreshesAfterTTL(t *testing.T) {
+	calls := 0
+	prev := unitCacheListFn
+	unitCacheListFn = func() (string, error) {
+		calls++
+		return "lerd-queue-a.service loaded active running x\n", nil
+	}
+	InvalidateUnitCache()
+	t.Cleanup(func() {
+		unitCacheListFn = prev
+		InvalidateUnitCache()
+	})
+
+	unitStatusCached("lerd-queue-a")
+
+	// Backdate the cache so the next call triggers a refresh without
+	// sleeping for the full TTL.
+	globalUnitCache.mu.Lock()
+	globalUnitCache.at = time.Now().Add(-unitCacheTTL - time.Second)
+	globalUnitCache.mu.Unlock()
+
+	unitStatusCached("lerd-queue-a")
+	if calls != 2 {
+		t.Fatalf("expected 2 calls after TTL expiry, got %d", calls)
+	}
+}
+
+func TestUnitStatusCachedSystemctlFailure(t *testing.T) {
+	withStubList(t, "", errFakeSystemctl{})
+	got, _ := unitStatusCached("lerd-anything")
+	if got != "unknown" {
+		t.Fatalf("want unknown on systemctl failure, got %q", got)
+	}
+}
+
+type errFakeSystemctl struct{}
+
+func (errFakeSystemctl) Error() string { return "boom" }

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -139,5 +139,14 @@ func FinishLink(site config.Site, phpVersion string) error {
 		return fmt.Errorf("nginx reload: %w", err)
 	}
 
+	// Linking a site doesn't start a systemd unit, so the shared
+	// AfterUnitChange hook wouldn't otherwise fire. Notify the hook
+	// explicitly so the CLI/MCP processes ping lerd-ui (and lerd-ui's
+	// own in-process handler invalidates the snapshot cache) and the
+	// new site appears in every open dashboard tab.
+	if podman.AfterUnitChange != nil {
+		podman.AfterUnitChange("site:" + site.Name)
+	}
+
 	return nil
 }

--- a/internal/siteops/unlink.go
+++ b/internal/siteops/unlink.go
@@ -49,5 +49,14 @@ func UnlinkSiteCore(site *config.Site, parkedDirs []string) error {
 	_ = podman.WriteContainerHosts()
 	_ = podman.RewriteFPMQuadlets()
 
-	return nginx.Reload()
+	if err := nginx.Reload(); err != nil {
+		return err
+	}
+
+	// See FinishLink: unlinking doesn't start/stop a systemd unit, so
+	// the shared hook wouldn't otherwise fire. Notify explicitly.
+	if podman.AfterUnitChange != nil {
+		podman.AfterUnitChange("site:" + site.Name)
+	}
+	return nil
 }

--- a/internal/siteops/vhost.go
+++ b/internal/siteops/vhost.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/nginx"
+	"github.com/geodro/lerd/internal/podman"
 )
 
 // RegenerateSiteVhost regenerates the nginx vhost for a site after domain changes.
@@ -33,6 +34,9 @@ func RegenerateSiteVhost(site *config.Site, oldPrimary string) error {
 		if err := nginx.GenerateVhost(*site, site.PHPVersion); err != nil {
 			return fmt.Errorf("generating vhost: %w", err)
 		}
+	}
+	if podman.AfterUnitChange != nil {
+		podman.AfterUnitChange("site:" + site.Name)
 	}
 	return nil
 }

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -281,7 +281,7 @@
           <button @click="selectSystem('node-'+v)"
             class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-50 dark:border-lerd-border/50"
             :class="selectedSystem==='node-'+v ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
-            <span class="w-2 h-2 rounded-full shrink-0 bg-gray-300 dark:bg-gray-600"></span>
+            <span class="w-2 h-2 rounded-full shrink-0 bg-emerald-500"></span>
             <span class="font-medium flex-1" x-text="'Node '+v"></span>
             <template x-if="systemStatus.node_default === v">
               <span class="text-[10px] font-medium shrink-0" :class="selectedSystem==='node-'+v ? 'text-lerd-red/60' : 'text-gray-400 dark:text-gray-600'">default</span>
@@ -464,7 +464,7 @@
           </div>
           <template x-for="v in nodeVersions" :key="'mnode-'+v">
             <button @click="selectSystem('node-'+v)" class="w-full flex items-center gap-2.5 px-4 py-3.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border" :class="selectedSystem==='node-'+v ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
-              <span class="w-2 h-2 rounded-full shrink-0 bg-gray-300 dark:bg-gray-600"></span>
+              <span class="w-2 h-2 rounded-full shrink-0 bg-emerald-500"></span>
               <span class="font-medium flex-1" x-text="'Node '+v"></span>
               <template x-if="systemStatus.node_default === v"><span class="text-[10px] text-gray-400 mr-1">default</span></template>
               <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
@@ -1941,6 +1941,26 @@
     window.EventSource.OPEN = OrigES.OPEN;
     window.EventSource.CLOSED = OrigES.CLOSED;
   }
+  // WebSocket: the dashboard's /api/ws stream uses the same rewrite so
+  // browsers on lerd.localhost connect straight to ws://localhost:7073
+  // instead of going through the nginx vhost (which only proxies the HTML
+  // shell and returns 444 on everything else).
+  if (typeof window.WebSocket === 'function') {
+    const WS_BASE = API_BASE.replace(/^http/, 'ws');
+    const OrigWS = window.WebSocket;
+    const PatchedWS = function(url, protocols) {
+      if (typeof url === 'string' && url.startsWith('/')) {
+        url = WS_BASE + url;
+      }
+      return protocols === undefined ? new OrigWS(url) : new OrigWS(url, protocols);
+    };
+    PatchedWS.prototype = OrigWS.prototype;
+    PatchedWS.CONNECTING = OrigWS.CONNECTING;
+    PatchedWS.OPEN = OrigWS.OPEN;
+    PatchedWS.CLOSING = OrigWS.CLOSING;
+    PatchedWS.CLOSED = OrigWS.CLOSED;
+    window.WebSocket = PatchedWS;
+  }
 })();
 
 function lerdApp() {
@@ -2094,21 +2114,68 @@ function lerdApp() {
       this.loadServices();
       this.loadPresets();
       this.loadStatus();
-      this._statusInterval = setInterval(() => {
-        this.loadSites();
-        if (this.tab === 'services') {
-          this.loadServices();
+      this._startPollFallback = () => {
+        if (this._statusInterval) return;
+        this._statusInterval = setInterval(() => {
+          this.loadSites();
+          if (this.tab === 'services') { this.loadServices(); }
+          if (this.tab === 'system') {
+            this.loadStatus();
+            this.loadNodeVersions();
+            this.loadLANStatus();
+            this.loadRemoteControl();
+          }
+        }, 5000);
+      };
+      this._stopPollFallback = () => {
+        if (this._statusInterval) {
+          clearInterval(this._statusInterval);
+          this._statusInterval = null;
         }
-        if (this.tab === 'system') {
-          this.loadStatus();
-          this.loadNodeVersions();
-          // Refresh LAN/remote-control state on the system tab so the
-          // dashboard reflects toggles made via CLI (`lerd lan:expose`,
-          // `lerd remote-control on`) without a page reload.
-          this.loadLANStatus();
-          this.loadRemoteControl();
-        }
-      }, 5000);
+      };
+      this._connectWS();
+    },
+
+    // _connectWS opens a websocket to /api/ws so the dashboard receives
+    // state-change events instead of polling every 5 seconds. Each message
+    // lists which kinds changed; we trigger the matching loader, which now
+    // reads from the server-side snapshot cache and returns in a few ms.
+    // If the socket drops, we fall back to the legacy polling interval and
+    // retry with exponential backoff up to 30s so a restart of lerd-ui
+    // transparently reconnects.
+    _connectWS() {
+      try {
+        // Relative URL so the WebSocket wrapper at the top of this file
+        // rewrites it to ws://localhost:7073 when served from lerd.localhost.
+        const ws = new WebSocket('/api/ws');
+        this._ws = ws;
+        ws.onopen = () => {
+          this._wsBackoff = 1000;
+          this._stopPollFallback();
+        };
+        ws.onmessage = (e) => {
+          let msg;
+          try { msg = JSON.parse(e.data); } catch (_) { return; }
+          // The frame carries the actual data — apply it directly instead
+          // of re-fetching over REST. First frame after connect has all
+          // three kinds; subsequent frames have only the kind that changed.
+          if (msg.sites)    this.applySites(msg.sites);
+          if (msg.services) this.applyServices(msg.services);
+          if (msg.status)   this.applyStatus(msg.status);
+        };
+        ws.onclose = () => {
+          this._ws = null;
+          this._startPollFallback();
+          const delay = Math.min(30000, this._wsBackoff || 1000);
+          this._wsBackoff = delay * 2;
+          setTimeout(() => this._connectWS(), delay);
+        };
+        ws.onerror = () => {
+          // onclose will fire right after, which handles the fallback.
+        };
+      } catch (_) {
+        this._startPollFallback();
+      }
     },
 
     capitalize(s) { return s.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' '); },
@@ -2419,10 +2486,6 @@ function lerdApp() {
     },
 
     async loadSites() {
-      // Skip if a previous loadSites is still in flight. The 5s polling
-      // timer would otherwise stack requests on a slow backend and saturate
-      // the browser's per-host HTTP/1.1 connection limit alongside open
-      // SSE log streams, leaving requests pending or failing CONN_RESET.
       if (this._sitesInFlight) return;
       this._sitesInFlight = true;
       const firstLoad = !this._sitesLoaded;
@@ -2430,68 +2493,87 @@ function lerdApp() {
       try {
         const res = await fetch('/api/sites');
         const raw = await res.json();
-        this._sitesLoaded = true;
-        if (firstLoad) {
-          this.sites = raw.map(s => ({ ...s, tlsLoading: false, tlsError: '', versionLoading: false, queueLoading: false, queueError: '', stripeLoading: false, stripeError: '', scheduleLoading: false, scheduleError: '', reverbLoading: false, reverbError: '', horizonLoading: false, horizonError: '', unlinkLoading: false, pauseLoading: false, framework_workers: (s.framework_workers || []).map(w => ({ ...w, loading: false, error: '' })) }));
-        } else {
-          raw.forEach(s => {
-            const e = this.sites.find(x => x.name === s.name);
-            if (e) {
-              e.domain = s.domain;
-              e.domains = s.domains;
-              e.conflicting_domains = s.conflicting_domains;
-              e.php_version = s.php_version;
-              e.node_version = s.node_version;
-              e.tls = s.tls;
-              e.fpm_running = s.fpm_running;
-              e.queue_running = s.queue_running;
-              e.stripe_running = s.stripe_running;
-              e.stripe_secret_set = s.stripe_secret_set;
-              e.schedule_running = s.schedule_running;
-              e.reverb_running = s.reverb_running;
-              e.has_reverb = s.has_reverb;
-              e.horizon_running = s.horizon_running;
-              e.has_horizon = s.has_horizon;
-              e.has_queue_worker = s.has_queue_worker;
-              e.has_schedule_worker = s.has_schedule_worker;
-              e.has_app_logs = s.has_app_logs;
-              e.latest_log_time = s.latest_log_time;
-              e.branch = s.branch;
-              e.paused = s.paused;
-              if (s.framework_workers) {
-                if (e.framework_workers) {
-                  s.framework_workers.forEach(sw => {
-                    const ew = e.framework_workers.find(w => w.name === sw.name);
-                    if (ew) { ew.running = sw.running; }
-                    else { e.framework_workers.push({ ...sw, loading: false, error: '' }); }
-                  });
-                  e.framework_workers = e.framework_workers.filter(ew => s.framework_workers.some(sw => sw.name === ew.name));
-                } else {
-                  e.framework_workers = s.framework_workers.map(w => ({ ...w, loading: false, error: '' }));
-                }
-              }
-            } else {
-              this.sites.push({ ...s, tlsLoading: false, tlsError: '', versionLoading: false, queueLoading: false, queueError: '', stripeLoading: false, stripeError: '', scheduleLoading: false, scheduleError: '', reverbLoading: false, reverbError: '', horizonLoading: false, horizonError: '', unlinkLoading: false, pauseLoading: false, framework_workers: (s.framework_workers || []).map(w => ({ ...w, loading: false, error: '' })) });
-            }
-          });
-          this.sites = this.sites.filter(e => raw.some(s => s.name === e.name));
-        }
+        this.applySites(raw);
       } catch (_) {
         if (firstLoad) this.sites = [];
       } finally {
         this._sitesInFlight = false;
-        if (firstLoad) {
-          this.sitesLoading = false;
-          // Auto-select site with the most recent app log activity
-          if (!this.selectedSiteDomain) {
-            const withLogs = this.sites.filter(s => s.has_app_logs && s.latest_log_time);
-            if (withLogs.length > 0) {
-              withLogs.sort((a, b) => b.latest_log_time.localeCompare(a.latest_log_time));
-              this.selectSite(withLogs[0]);
-            }
+        if (firstLoad) this.sitesLoading = false;
+      }
+    },
+
+    // applySites merges server-pushed sites data into Alpine state. Shared
+    // between the initial REST loadSites() and the websocket onmessage
+    // handler, so WS-delivered updates go through the same field-diff code
+    // that polling used. Preserves per-row UI state (loading flags, errors).
+    applySites(raw) {
+      if (!Array.isArray(raw)) return;
+      const firstLoad = !this._sitesLoaded;
+      this._sitesLoaded = true;
+      const decorate = s => ({
+        ...s,
+        tlsLoading: false, tlsError: '',
+        versionLoading: false,
+        queueLoading: false, queueError: '',
+        stripeLoading: false, stripeError: '',
+        scheduleLoading: false, scheduleError: '',
+        reverbLoading: false, reverbError: '',
+        horizonLoading: false, horizonError: '',
+        unlinkLoading: false, pauseLoading: false,
+        framework_workers: (s.framework_workers || []).map(w => ({ ...w, loading: false, error: '' })),
+      });
+      if (firstLoad) {
+        this.sites = raw.map(decorate);
+        if (!this.selectedSiteDomain) {
+          const withLogs = this.sites.filter(s => s.has_app_logs && s.latest_log_time);
+          if (withLogs.length > 0) {
+            withLogs.sort((a, b) => b.latest_log_time.localeCompare(a.latest_log_time));
+            this.selectSite(withLogs[0]);
           }
         }
+        return;
       }
+      raw.forEach(s => {
+        const e = this.sites.find(x => x.name === s.name);
+        if (e) {
+          e.domain = s.domain;
+          e.domains = s.domains;
+          e.conflicting_domains = s.conflicting_domains;
+          e.php_version = s.php_version;
+          e.node_version = s.node_version;
+          e.tls = s.tls;
+          e.fpm_running = s.fpm_running;
+          e.queue_running = s.queue_running;
+          e.stripe_running = s.stripe_running;
+          e.stripe_secret_set = s.stripe_secret_set;
+          e.schedule_running = s.schedule_running;
+          e.reverb_running = s.reverb_running;
+          e.has_reverb = s.has_reverb;
+          e.horizon_running = s.horizon_running;
+          e.has_horizon = s.has_horizon;
+          e.has_queue_worker = s.has_queue_worker;
+          e.has_schedule_worker = s.has_schedule_worker;
+          e.has_app_logs = s.has_app_logs;
+          e.latest_log_time = s.latest_log_time;
+          e.branch = s.branch;
+          e.paused = s.paused;
+          if (s.framework_workers) {
+            if (e.framework_workers) {
+              s.framework_workers.forEach(sw => {
+                const ew = e.framework_workers.find(w => w.name === sw.name);
+                if (ew) { ew.running = sw.running; }
+                else { e.framework_workers.push({ ...sw, loading: false, error: '' }); }
+              });
+              e.framework_workers = e.framework_workers.filter(ew => s.framework_workers.some(sw => sw.name === ew.name));
+            } else {
+              e.framework_workers = s.framework_workers.map(w => ({ ...w, loading: false, error: '' }));
+            }
+          }
+        } else {
+          this.sites.push(decorate(s));
+        }
+      });
+      this.sites = this.sites.filter(e => raw.some(s => s.name === e.name));
     },
 
     selectSite(site) {
@@ -2777,26 +2859,32 @@ function lerdApp() {
       try {
         const res = await fetch('/api/services');
         const raw = await res.json();
-        if (firstLoad) {
-          this.services = raw.map(s => ({ ...s, loading: false, error: '', flash: '', copied: false }));
-        } else {
-          raw.forEach(s => {
-            const e = this.services.find(x => x.name === s.name);
-            if (e) {
-              e.status = s.status;
-              e.pinned = s.pinned;
-              e.site_count = s.site_count;
-            } else {
-              this.services.push({ ...s, loading: false, error: '', flash: '', copied: false });
-            }
-          });
-          this.services = this.services.filter(e => raw.some(s => s.name === e.name));
-        }
+        this.applyServices(raw);
       } catch (_) {
         if (firstLoad) this.services = [];
       } finally {
         if (firstLoad) this.servicesLoading = false;
       }
+    },
+
+    // applyServices: see applySites.
+    applyServices(raw) {
+      if (!Array.isArray(raw)) return;
+      if (this.services.length === 0) {
+        this.services = raw.map(s => ({ ...s, loading: false, error: '', flash: '', copied: false }));
+        return;
+      }
+      raw.forEach(s => {
+        const e = this.services.find(x => x.name === s.name);
+        if (e) {
+          e.status = s.status;
+          e.pinned = s.pinned;
+          e.site_count = s.site_count;
+        } else {
+          this.services.push({ ...s, loading: false, error: '', flash: '', copied: false });
+        }
+      });
+      this.services = this.services.filter(e => raw.some(s => s.name === e.name));
     },
 
     selectService(svc) {
@@ -3846,17 +3934,23 @@ function lerdApp() {
       try {
         const res = await fetch('/api/status');
         const data = await res.json();
-        this.systemStatus = data;
-        const next = { ...this.xdebugEnabled };
-        (data.php_fpms || []).forEach(fpm => {
-          if (!this.xdebugLoading[fpm.version]) {
-            next[fpm.version] = fpm.xdebug_enabled;
-          }
-        });
-        this.xdebugEnabled = next;
+        this.applyStatus(data);
       } catch (_) {} finally {
         this.statusLoading = false;
       }
+    },
+
+    // applyStatus: see applySites.
+    applyStatus(data) {
+      if (!data || typeof data !== 'object') return;
+      this.systemStatus = data;
+      const next = { ...this.xdebugEnabled };
+      (data.php_fpms || []).forEach(fpm => {
+        if (!this.xdebugLoading[fpm.version]) {
+          next[fpm.version] = fpm.xdebug_enabled;
+        }
+      });
+      this.xdebugEnabled = next;
     },
 
     async loadSettings() {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
 	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/eventbus"
 	"github.com/geodro/lerd/internal/nginx"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
@@ -123,27 +124,64 @@ var serviceEnvVars = map[string][]string{
 
 // Start starts the HTTP server on listenAddr.
 func Start(currentVersion string) error {
+	// Every unit lifecycle change (from CLI, MCP, HTTP handlers, or the
+	// file watcher) funnels through podman.StartUnit/StopUnit/RestartUnit.
+	// Hook into that choke point so any mutation — regardless of which
+	// surface triggered it — invalidates the systemctl unit cache and
+	// pushes a fresh snapshot to every connected browser. The bus debounces,
+	// so bursty mutations (e.g. restarting a set of workers) still collapse
+	// into one broadcast.
+	podman.AfterUnitChange = func(name string) {
+		siteinfo.InvalidateUnitCache()
+		eventbus.Default.Publish(eventbus.KindSites)
+		eventbus.Default.Publish(eventbus.KindServices)
+		eventbus.Default.Publish(eventbus.KindStatus)
+	}
+
+	// A single goroutine subscribes to the eventbus and invalidates the
+	// relevant snapshot on every mutation. The /api/ws handler broadcasts
+	// the freshly rebuilt bytes to every connected browser.
+	go runSnapshotInvalidator()
+
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/api/status", withCORS(handleStatus))
 	mux.HandleFunc("/api/sites", withCORS(handleSites))
 	mux.HandleFunc("/api/services", withCORS(handleServices))
+	mux.HandleFunc("/api/ws", handleWS)
+
+	// Cross-process notifier: the CLI and MCP processes run outside
+	// lerd-ui and can't publish to the in-process eventbus. They POST
+	// here after any unit lifecycle change so lerd-ui invalidates its
+	// snapshot cache and pushes a fresh broadcast to every browser.
+	// Loopback-only because anything that wouldn't go through the gate
+	// has no business triggering an invalidation.
+	mux.HandleFunc("/api/internal/notify", func(w http.ResponseWriter, r *http.Request) {
+		if !isLoopbackRequest(r) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		siteinfo.InvalidateUnitCache()
+		eventbus.Default.Publish(eventbus.KindSites)
+		eventbus.Default.Publish(eventbus.KindServices)
+		eventbus.Default.Publish(eventbus.KindStatus)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
 	mux.HandleFunc("/api/services/presets", withCORS(handleServicePresets))
 	mux.HandleFunc("/api/services/presets/", withCORS(handleServicePresetInstall))
-	mux.HandleFunc("/api/services/", withCORS(func(w http.ResponseWriter, r *http.Request) {
-		handleServiceAction(w, r)
-	}))
+	mux.HandleFunc("/api/services/", withCORS(publishAfter(handleServiceAction, eventbus.KindServices, eventbus.KindStatus, eventbus.KindSites)))
 	mux.HandleFunc("/api/version", withCORS(func(w http.ResponseWriter, r *http.Request) {
 		handleVersion(w, r, currentVersion)
 	}))
 	mux.HandleFunc("/api/php-versions", withCORS(handlePHPVersions))
-	mux.HandleFunc("/api/php-versions/", withCORS(handlePHPVersionAction))
+	mux.HandleFunc("/api/php-versions/", withCORS(publishAfter(handlePHPVersionAction, eventbus.KindStatus, eventbus.KindSites)))
 	mux.HandleFunc("/api/node-versions", withCORS(handleNodeVersions))
 	mux.HandleFunc("/api/node-versions/install", withCORS(handleInstallNodeVersion))
 	mux.HandleFunc("/api/node-versions/", withCORS(handleNodeVersionAction))
-	mux.HandleFunc("/api/sites/link", withCORS(handleSiteLink))
+	mux.HandleFunc("/api/sites/link", withCORS(publishAfter(handleSiteLink, eventbus.KindSites)))
 	mux.HandleFunc("/api/browse", withCORS(handleBrowse))
-	mux.HandleFunc("/api/sites/", withCORS(handleSiteAction))
+	mux.HandleFunc("/api/sites/", withCORS(publishAfter(handleSiteAction, eventbus.KindSites, eventbus.KindServices)))
 	mux.HandleFunc("/api/logs/", withCORS(handleLogs))
 	mux.HandleFunc("/api/queue/", withCORS(handleQueueLogs))
 	mux.HandleFunc("/api/horizon/", withCORS(handleHorizonLogs))
@@ -156,7 +194,7 @@ func Start(currentVersion string) error {
 	mux.HandleFunc("/api/watcher/start", withCORS(handleWatcherStart))
 	mux.HandleFunc("/api/settings", withCORS(handleSettings))
 	mux.HandleFunc("/api/settings/autostart", withCORS(handleSettingsAutostart))
-	mux.HandleFunc("/api/xdebug/", withCORS(handleXdebugAction))
+	mux.HandleFunc("/api/xdebug/", withCORS(publishAfter(handleXdebugAction, eventbus.KindStatus)))
 	mux.HandleFunc("/api/lerd/start", withCORS(handleLerdStart))
 	mux.HandleFunc("/api/lerd/stop", withCORS(handleLerdStop))
 	mux.HandleFunc("/api/lerd/quit", withCORS(handleLerdQuit))
@@ -197,6 +235,11 @@ func Start(currentVersion string) error {
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		// The shell embeds the entire JS/CSS inline and changes on
+		// every binary update. Without this, browsers cache the HTML
+		// indefinitely and keep running stale client code — which hid
+		// the WebSocket URL-rewrite fix during local testing.
+		w.Header().Set("Cache-Control", "no-store")
 		w.Write(indexHTML) //nolint:errcheck
 	})
 
@@ -324,6 +367,11 @@ type PHPStatus struct {
 }
 
 func handleStatus(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(snapshots.Status())
+}
+
+func buildStatus() StatusResponse {
 	cfg, _ := config.LoadGlobal()
 	tld := "test"
 	if cfg != nil {
@@ -349,15 +397,17 @@ func handleStatus(w http.ResponseWriter, _ *http.Request) {
 		phpDefault = cfg.PHP.DefaultVersion
 		nodeDefault = cfg.Node.DefaultVersion
 	}
-	writeJSON(w, StatusResponse{
+	return StatusResponse{
 		DNS:            DNSStatus{OK: dnsOK, TLD: tld},
 		Nginx:          ServiceCheck{Running: nginxRunning},
 		PHPFPMs:        phpStatuses,
 		PHPDefault:     phpDefault,
 		NodeDefault:    nodeDefault,
 		WatcherRunning: watcherRunning,
-	})
+	}
 }
+
+func buildStatusJSON() []byte { return []byte(mustJSON(buildStatus())) }
 
 // WorktreeResponse is embedded in SiteResponse for each git worktree.
 type WorktreeResponse struct {
@@ -425,10 +475,16 @@ type SiteResponse struct {
 }
 
 func handleSites(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(snapshots.Sites())
+}
+
+func buildSitesJSON() []byte { return []byte(mustJSON(buildSites())) }
+
+func buildSites() []SiteResponse {
 	enriched, err := siteinfo.LoadAll(siteinfo.EnrichUI)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return []SiteResponse{}
 	}
 	_ = siteinfo.PersistVersionChanges(enriched)
 
@@ -501,7 +557,7 @@ func handleSites(w http.ResponseWriter, _ *http.Request) {
 			Services:           e.Services,
 		})
 	}
-	writeJSON(w, sites)
+	return sites
 }
 
 // ServiceResponse is the response for GET /api/services.
@@ -601,6 +657,13 @@ func listActiveHorizonWorkers() []string {
 }
 
 func handleServices(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(snapshots.Services())
+}
+
+func buildServicesJSON() []byte { return []byte(mustJSON(buildServicesList())) }
+
+func buildServicesList() []ServiceResponse {
 	services := make([]ServiceResponse, 0, len(knownServices))
 	for _, name := range knownServices {
 		services = append(services, buildServiceResponse(name))
@@ -709,7 +772,7 @@ func handleServices(w http.ResponseWriter, _ *http.Request) {
 			}
 		}
 	}
-	writeJSON(w, services)
+	return services
 }
 
 // PresetResponse describes a bundled service preset for the web UI.

--- a/internal/ui/snapshot.go
+++ b/internal/ui/snapshot.go
@@ -1,0 +1,104 @@
+package ui
+
+import (
+	"sync"
+	"time"
+
+	"github.com/geodro/lerd/internal/eventbus"
+)
+
+// snapshotTTL bounds how long a cached snapshot is reused before the next
+// request triggers a rebuild. Mutations that change state call
+// eventbus.Default.Publish, which invalidates the relevant kind so the next
+// read recomputes immediately.
+const snapshotTTL = 2 * time.Second
+
+// snapshotCache holds cached JSON bytes of the last /api/sites, /api/services,
+// and /api/status responses. Handlers read from here instead of rebuilding
+// from scratch on every poll; /api/ws broadcasts the same bytes to every
+// connected browser.
+type snapshotCache struct {
+	mu sync.Mutex
+
+	sites, services, status       []byte
+	sitesAt, servicesAt, statusAt time.Time
+}
+
+var snapshots = &snapshotCache{}
+
+// Sites returns cached /api/sites JSON, rebuilding if stale.
+func (c *snapshotCache) Sites() []byte {
+	c.mu.Lock()
+	fresh := c.sites != nil && time.Since(c.sitesAt) < snapshotTTL
+	c.mu.Unlock()
+	if fresh {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.sites
+	}
+	b := buildSitesJSON()
+	c.mu.Lock()
+	c.sites = b
+	c.sitesAt = time.Now()
+	c.mu.Unlock()
+	return b
+}
+
+// Services returns cached /api/services JSON, rebuilding if stale.
+func (c *snapshotCache) Services() []byte {
+	c.mu.Lock()
+	fresh := c.services != nil && time.Since(c.servicesAt) < snapshotTTL
+	c.mu.Unlock()
+	if fresh {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.services
+	}
+	b := buildServicesJSON()
+	c.mu.Lock()
+	c.services = b
+	c.servicesAt = time.Now()
+	c.mu.Unlock()
+	return b
+}
+
+// Status returns cached /api/status JSON, rebuilding if stale.
+func (c *snapshotCache) Status() []byte {
+	c.mu.Lock()
+	fresh := c.status != nil && time.Since(c.statusAt) < snapshotTTL
+	c.mu.Unlock()
+	if fresh {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.status
+	}
+	b := buildStatusJSON()
+	c.mu.Lock()
+	c.status = b
+	c.statusAt = time.Now()
+	c.mu.Unlock()
+	return b
+}
+
+// Invalidate drops the cached bytes for one kind so the next read rebuilds.
+func (c *snapshotCache) Invalidate(kind string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	switch kind {
+	case eventbus.KindSites:
+		c.sitesAt = time.Time{}
+	case eventbus.KindServices:
+		c.servicesAt = time.Time{}
+	case eventbus.KindStatus:
+		c.statusAt = time.Time{}
+	}
+}
+
+// InvalidateAll drops all three cached snapshots.
+func (c *snapshotCache) InvalidateAll() {
+	c.mu.Lock()
+	c.sitesAt = time.Time{}
+	c.servicesAt = time.Time{}
+	c.statusAt = time.Time{}
+	c.mu.Unlock()
+}

--- a/internal/ui/ws.go
+++ b/internal/ui/ws.go
@@ -1,0 +1,95 @@
+package ui
+
+import (
+	"bytes"
+	"net/http"
+)
+
+// handleWS upgrades the HTTP connection to a websocket and streams snapshot
+// updates to the client. The initial frame carries a full snapshot of sites,
+// services, and status so the browser can render immediately. Subsequent
+// frames carry only the kinds that changed.
+func handleWS(w http.ResponseWriter, r *http.Request) {
+	ws, err := wsUpgrade(w, r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer ws.Close()
+
+	ch := broker.add()
+	defer broker.remove(ch)
+
+	// Initial snapshot: assemble one JSON object containing all three kinds.
+	initial := assembleSnapshot(snapshots.Sites(), snapshots.Services(), snapshots.Status(), []string{"snapshot"})
+	if err := ws.WriteText(initial); err != nil {
+		return
+	}
+
+	// Reader goroutine: handle ping/close frames, drop the channel on any
+	// error so the writer loop exits.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			op, payload, err := ws.ReadFrame()
+			if err != nil {
+				return
+			}
+			switch op {
+			case wsOpPing:
+				if err := ws.WritePong(payload); err != nil {
+					return
+				}
+			case wsOpClose:
+				_ = ws.WriteClose()
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			frame := assembleSnapshot(msg.Sites, msg.Services, msg.Status, msg.Kinds)
+			if err := ws.WriteText(frame); err != nil {
+				return
+			}
+		case <-done:
+			return
+		}
+	}
+}
+
+// assembleSnapshot builds a JSON object of the form:
+//
+//	{"type":"<type>","sites":<sites>,"services":<services>,"status":<status>}
+//
+// Any nil slice is omitted so clients can treat missing keys as "unchanged".
+func assembleSnapshot(sites, services, status []byte, kinds []string) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(`{"type":"`)
+	if len(kinds) == 1 {
+		buf.WriteString(kinds[0])
+	} else {
+		buf.WriteString("snapshot")
+	}
+	buf.WriteByte('"')
+	if len(sites) > 0 {
+		buf.WriteString(`,"sites":`)
+		buf.Write(sites)
+	}
+	if len(services) > 0 {
+		buf.WriteString(`,"services":`)
+		buf.Write(services)
+	}
+	if len(status) > 0 {
+		buf.WriteString(`,"status":`)
+		buf.Write(status)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes()
+}

--- a/internal/ui/ws_broker.go
+++ b/internal/ui/ws_broker.go
@@ -1,0 +1,107 @@
+package ui
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/geodro/lerd/internal/eventbus"
+)
+
+// publishAfter wraps a mutating HTTP handler so that every successful
+// invocation publishes the listed event kinds. The bus debounces bursty
+// calls into a single websocket broadcast, so passing multiple kinds is
+// cheap. Publish is called after the handler returns regardless of whether
+// the response status was 2xx — lerd-ui actions either succeed and change
+// state or fail and write an error body; in both cases the cached snapshot
+// needs to be re-read, so the broadcast is harmless on failure.
+func publishAfter(h http.HandlerFunc, kinds ...string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		h(w, r)
+		if r.Method == http.MethodGet || r.Method == http.MethodOptions {
+			return
+		}
+		for _, k := range kinds {
+			eventbus.Default.Publish(k)
+		}
+	}
+}
+
+// wsBroker is the in-process fan-out target for snapshot updates. It holds a
+// set of per-connection channels that handleWS drains. The eventbus
+// subscriber goroutine invalidates the snapshot cache, rebuilds the affected
+// kinds, and then pushes the fresh bytes onto each broker channel.
+//
+// A second layer on top of eventbus is necessary because eventbus only
+// carries "what kind changed"; the broker carries the rebuilt JSON bytes
+// that the websocket handler writes to the socket.
+type wsBroker struct {
+	mu    sync.Mutex
+	peers map[chan wsMessage]struct{}
+}
+
+// wsMessage is what the broker ships to each websocket writer goroutine.
+// Kinds names which snapshots changed; Sites/Services/Status hold the fresh
+// JSON bytes for only the kinds in Kinds.
+type wsMessage struct {
+	Kinds    []string
+	Sites    []byte
+	Services []byte
+	Status   []byte
+}
+
+var broker = &wsBroker{peers: make(map[chan wsMessage]struct{})}
+
+func (b *wsBroker) add() chan wsMessage {
+	ch := make(chan wsMessage, 8)
+	b.mu.Lock()
+	b.peers[ch] = struct{}{}
+	b.mu.Unlock()
+	return ch
+}
+
+func (b *wsBroker) remove(ch chan wsMessage) {
+	b.mu.Lock()
+	if _, ok := b.peers[ch]; ok {
+		delete(b.peers, ch)
+		close(ch)
+	}
+	b.mu.Unlock()
+}
+
+func (b *wsBroker) broadcast(msg wsMessage) {
+	b.mu.Lock()
+	var drop []chan wsMessage
+	for ch := range b.peers {
+		select {
+		case ch <- msg:
+		default:
+			drop = append(drop, ch)
+		}
+	}
+	for _, ch := range drop {
+		delete(b.peers, ch)
+		close(ch)
+	}
+	b.mu.Unlock()
+}
+
+// runSnapshotInvalidator subscribes to the eventbus, invalidates the matching
+// snapshot kinds, and ships the rebuilt bytes to the websocket broker.
+func runSnapshotInvalidator() {
+	sub := eventbus.Default.Subscribe()
+	for evt := range sub.C {
+		msg := wsMessage{Kinds: evt.Kinds}
+		for _, k := range evt.Kinds {
+			snapshots.Invalidate(k)
+			switch k {
+			case eventbus.KindSites:
+				msg.Sites = snapshots.Sites()
+			case eventbus.KindServices:
+				msg.Services = snapshots.Services()
+			case eventbus.KindStatus:
+				msg.Status = snapshots.Status()
+			}
+		}
+		broker.broadcast(msg)
+	}
+}

--- a/internal/ui/wsframe.go
+++ b/internal/ui/wsframe.go
@@ -1,0 +1,161 @@
+package ui
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// Hand-rolled RFC6455 WebSocket helpers. Scope: lerd-ui only ever sends JSON
+// text frames to browser clients, so this supports the subset we need —
+// server-side handshake, unmasked text frames out, masked frames in, close
+// and ping/pong control frames. No binary, no fragmentation, no compression.
+//
+// Keeping it in-tree avoids adding a websocket dependency for what is a
+// few dozen lines of straightforward protocol work.
+
+const wsGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+// Opcodes we care about.
+const (
+	wsOpText  = 0x1
+	wsOpClose = 0x8
+	wsOpPing  = 0x9
+	wsOpPong  = 0xA
+)
+
+// wsConn wraps a hijacked net.Conn with the buffered reader from the
+// handshake so WriteText and ReadFrame can share the same underlying stream.
+type wsConn struct {
+	conn net.Conn
+	br   *bufio.Reader
+}
+
+// wsUpgrade performs the RFC6455 handshake and returns a wsConn ready for
+// ReadFrame / WriteText. The http.ResponseWriter must support Hijack.
+func wsUpgrade(w http.ResponseWriter, r *http.Request) (*wsConn, error) {
+	if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+		return nil, errors.New("missing Upgrade: websocket header")
+	}
+	if !strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade") {
+		return nil, errors.New("missing Connection: upgrade header")
+	}
+	key := r.Header.Get("Sec-WebSocket-Key")
+	if key == "" {
+		return nil, errors.New("missing Sec-WebSocket-Key")
+	}
+	h, ok := w.(http.Hijacker)
+	if !ok {
+		return nil, errors.New("response writer does not support hijack")
+	}
+	conn, brw, err := h.Hijack()
+	if err != nil {
+		return nil, err
+	}
+	sum := sha1.Sum([]byte(key + wsGUID))
+	accept := base64.StdEncoding.EncodeToString(sum[:])
+	resp := "HTTP/1.1 101 Switching Protocols\r\n" +
+		"Upgrade: websocket\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Sec-WebSocket-Accept: " + accept + "\r\n\r\n"
+	if _, err := brw.Writer.WriteString(resp); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if err := brw.Writer.Flush(); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return &wsConn{conn: conn, br: brw.Reader}, nil
+}
+
+// WriteText sends a single unfragmented text frame.
+func (c *wsConn) WriteText(payload []byte) error {
+	return c.writeFrame(wsOpText, payload)
+}
+
+// WritePong sends a pong frame in reply to a ping, echoing the payload.
+func (c *wsConn) WritePong(payload []byte) error {
+	return c.writeFrame(wsOpPong, payload)
+}
+
+// WriteClose sends a close frame with no payload.
+func (c *wsConn) WriteClose() error {
+	return c.writeFrame(wsOpClose, nil)
+}
+
+func (c *wsConn) writeFrame(op byte, payload []byte) error {
+	header := make([]byte, 2, 10)
+	header[0] = 0x80 | op // FIN | opcode
+	n := len(payload)
+	switch {
+	case n < 126:
+		header[1] = byte(n)
+	case n <= 0xFFFF:
+		header[1] = 126
+		header = binary.BigEndian.AppendUint16(header, uint16(n))
+	default:
+		header[1] = 127
+		header = binary.BigEndian.AppendUint64(header, uint64(n))
+	}
+	if _, err := c.conn.Write(header); err != nil {
+		return err
+	}
+	if n > 0 {
+		if _, err := c.conn.Write(payload); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Close shuts down the underlying connection.
+func (c *wsConn) Close() error { return c.conn.Close() }
+
+// ReadFrame reads one frame and returns its opcode and payload. Client frames
+// are always masked per RFC6455; the mask is applied before return.
+func (c *wsConn) ReadFrame() (op byte, payload []byte, err error) {
+	var hdr [2]byte
+	if _, err = io.ReadFull(c.br, hdr[:]); err != nil {
+		return
+	}
+	op = hdr[0] & 0x0F
+	masked := hdr[1]&0x80 != 0
+	plen := int(hdr[1] & 0x7F)
+	switch plen {
+	case 126:
+		var ext [2]byte
+		if _, err = io.ReadFull(c.br, ext[:]); err != nil {
+			return
+		}
+		plen = int(binary.BigEndian.Uint16(ext[:]))
+	case 127:
+		var ext [8]byte
+		if _, err = io.ReadFull(c.br, ext[:]); err != nil {
+			return
+		}
+		plen = int(binary.BigEndian.Uint64(ext[:]))
+	}
+	var mask [4]byte
+	if masked {
+		if _, err = io.ReadFull(c.br, mask[:]); err != nil {
+			return
+		}
+	}
+	payload = make([]byte, plen)
+	if _, err = io.ReadFull(c.br, payload); err != nil {
+		return
+	}
+	if masked {
+		for i := range payload {
+			payload[i] ^= mask[i%4]
+		}
+	}
+	return
+}


### PR DESCRIPTION
## Summary

- Dashboard now opens a single WebSocket to `/api/ws` and receives state changes as they happen, replacing the 5 s polling loop that dominated `/api/sites` latency.
- One `systemctl list-units` call per ~3 s replaces the 125+ `is-active` subprocesses `siteinfo.LoadAll` used to fan out, so even REST reads drop from ~500 ms to under 5 ms on a cache hit.
- A new `internal/eventbus` debounced pub/sub hub fans every mutation out to every connected tab. `podman.AfterUnitChange` plus a loopback `/api/internal/notify` endpoint route CLI, MCP, HTTP, and watcher mutations through the same invalidate+publish path, so `lerd worker stop`, `lerd link`, or an out-of-band `.env` edit all flip the UI within ~250 ms.
- WebSocket framing is a hand-rolled RFC6455 text-only subset in `internal/ui/wsframe.go`, no new dependencies. Initial frame is a full snapshot; subsequent frames carry only the kinds that changed and the client applies them directly via `applySites`/`applyServices`/`applyStatus`, so no REST refetch happens after first paint.
- Client-side `WebSocket` wrapper mirrors the existing `fetch`/`EventSource` wrappers so browsers on `lerd.localhost` route `/api/ws` to `ws://localhost:7073` instead of hitting the nginx 444 fallback. HTML shell is served `no-store` so stale browser caches stop pinning old client code after a binary update.
- Fallback path is preserved: if the socket drops for any reason the dashboard falls back to 5 s polling and reconnects with exponential backoff in the background, so a `lerd-ui` restart is transparent.
- Minor: Node version rows in the System tab are now emerald rather than grey, since each listed row represents an installed toolchain.