### PR TITLE
ci: build and release macOS binaries and Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,46 @@ jobs:
       - name: Format
         run: test -z "$(gofmt -l .)"
 
+  build-darwin-tray:
+    name: Build macOS tray (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: macos-latest
+            arch: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build lerd-tray
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          COMMIT=$(git rev-parse --short HEAD)
+          DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          mkdir -p dist/lerd-tray_darwin_${{ matrix.arch }}
+          CGO_ENABLED=1 go build \
+            -ldflags="-s -w \
+              -X github.com/geodro/lerd/internal/version.Version=${VERSION} \
+              -X github.com/geodro/lerd/internal/version.Commit=${COMMIT} \
+              -X github.com/geodro/lerd/internal/version.Date=${DATE}" \
+            -o dist/lerd-tray_darwin_${{ matrix.arch }}/lerd-tray \
+            ./cmd/lerd-tray
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lerd-tray-darwin-${{ matrix.arch }}
+          path: dist/lerd-tray_darwin_${{ matrix.arch }}/lerd-tray
+          retention-days: 1
+
   release:
     name: GoReleaser
-    needs: ci
+    needs: [ci, build-darwin-tray]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -58,6 +95,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --fix-missing libayatana-appindicator3-dev
 
+      - name: Download macOS tray binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: lerd-tray-darwin-*
+          path: dist-tray
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -66,3 +109,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,40 @@ builds:
       - -X github.com/geodro/lerd/internal/version.Commit={{.Commit}}
       - -X github.com/geodro/lerd/internal/version.Date={{.Date}}
 
+  - id: lerd-darwin-amd64
+    main: ./cmd/lerd
+    binary: lerd
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -tags=nogui
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    ldflags:
+      - -s -w
+      - -X github.com/geodro/lerd/internal/version.Version={{.Version}}
+      - -X github.com/geodro/lerd/internal/version.Commit={{.Commit}}
+      - -X github.com/geodro/lerd/internal/version.Date={{.Date}}
+
+  - id: lerd-darwin-arm64
+    main: ./cmd/lerd
+    binary: lerd
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -tags=nogui
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/geodro/lerd/internal/version.Version={{.Version}}
+      - -X github.com/geodro/lerd/internal/version.Commit={{.Commit}}
+      - -X github.com/geodro/lerd/internal/version.Date={{.Date}}
+
   # lerd-tray is a separate CGO binary that links libayatana-appindicator.
   # lerd (nogui) execs it at runtime; if the library is missing the tray
   # is silently skipped and everything else continues to work.
@@ -76,6 +110,56 @@ archives:
       - README.md
       - install.sh
 
+  - id: lerd-darwin-amd64
+    ids: [lerd-darwin-amd64]
+    name_template: "lerd_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format: tar.gz
+    files:
+      - README.md
+      - install.sh
+
+  - id: lerd-darwin-arm64
+    ids: [lerd-darwin-arm64]
+    name_template: "lerd_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format: tar.gz
+    files:
+      - README.md
+      - install.sh
+      - src: dist-tray/lerd-tray-darwin-arm64/lerd-tray
+        dst: lerd-tray
+        info:
+          mode: 0755
+
+brews:
+  - name: lerd
+    ids:
+      - lerd-darwin-amd64
+      - lerd-darwin-arm64
+    repository:
+      owner: geodro
+      name: homebrew-lerd
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: "https://github.com/geodro/lerd"
+    description: "Local Laravel development environment for Linux and macOS"
+    license: "MIT"
+    skip_upload: false
+    dependencies:
+      - name: podman
+    install: |
+      bin.install "lerd"
+      bin.install "lerd-tray" if File.exist?("lerd-tray")
+    caveats: |
+      To finish setting up Lerd, run:
+        lerd install
+
+      To uninstall cleanly, run in order:
+        lerd uninstall
+        brew uninstall lerd
+
+      If you already removed the binary before running `lerd uninstall`, run:
+        ~/.local/bin/lerd-cleanup
+        brew uninstall lerd
+
 checksum:
   name_template: "checksums.txt"
 
@@ -109,9 +193,9 @@ release:
   header: |
     ## Lerd {{ .Version }}
 
-    Lerd — Podman-powered local PHP dev environment for Linux.
+    Lerd — Podman-powered local PHP dev environment for Linux & macOS.
 
-    ### Install / Upgrade
+    ### Install on Linux
 
     ```bash
     curl -fsSL https://raw.githubusercontent.com/geodro/lerd/main/install.sh | bash
@@ -121,6 +205,21 @@ release:
 
     ```bash
     lerd update
+    ```
+
+    ### Install on macOS
+
+    ```bash
+    brew tap geodro/lerd
+    brew install lerd
+    lerd install
+    ```
+
+    Or if already installed:
+
+    ```bash
+    brew upgrade lerd
+    lerd install
     ```
   footer: |
     **Full Changelog**: https://github.com/geodro/lerd/compare/{{ .PreviousTag }}...{{ .Tag }}


### PR DESCRIPTION
Ports the macOS release pipeline from the macos-compat branch onto main so tagged releases ship darwin artifacts and publish to the geodro/homebrew-lerd tap.

## Changes

- **.goreleaser.yml**: adds darwin amd64/arm64 builds of lerd (nogui), darwin archives, and a `brews:` block targeting geodro/homebrew-lerd using the existing HOMEBREW_TAP_TOKEN secret. Release header updated with macOS install instructions. The darwin-arm64 archive bundles lerd-tray from the new CI artifact.
- **.github/workflows/release.yml**: new `build-darwin-tray` job on macos-latest that builds lerd-tray with CGO and uploads it as an artifact. The release job depends on it, downloads the artifact into dist-tray/, and runs goreleaser with HOMEBREW_TAP_TOKEN exposed.

## Notes

Effective on the next tag push after merge. v1.12.0 was already tagged and released without macOS artifacts; if you want darwin binaries and the brew formula for that version, retag after merge or cut a v1.12.1.