### PR TITLE
fix: fully qualify built-in service images for Ubuntu podman

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -17,12 +17,12 @@ dns:
 parked_directories:
   - ~/Lerd
 services:
-  mysql:       { enabled: true,  image: "mysql:8.0",                    port: 3306 }
-  redis:       { enabled: true,  image: "redis:7-alpine",               port: 6379 }
-  postgres:    { enabled: false, image: "postgres:16-alpine",           port: 5432 }
-  meilisearch: { enabled: false, image: "getmeili/meilisearch:v1.7",    port: 7700 }
-  rustfs:      { enabled: false, image: "rustfs/rustfs:latest",         port: 9000 }
-  mailpit:     { enabled: false, image: "axllent/mailpit:latest",       port: 1025 }
+  mysql:       { enabled: true,  image: "docker.io/library/mysql:8.0",             port: 3306 }
+  redis:       { enabled: true,  image: "docker.io/library/redis:7-alpine",        port: 6379 }
+  postgres:    { enabled: false, image: "docker.io/postgis/postgis:16-3.5-alpine", port: 5432 }
+  meilisearch: { enabled: false, image: "docker.io/getmeili/meilisearch:v1.7",     port: 7700 }
+  rustfs:      { enabled: false, image: "docker.io/rustfs/rustfs:latest",          port: 9000 }
+  mailpit:     { enabled: false, image: "docker.io/axllent/mailpit:latest",        port: 1025 }
 ```
 
 ---

--- a/internal/cli/minio_migrate.go
+++ b/internal/cli/minio_migrate.go
@@ -83,7 +83,7 @@ func runMinioMigrate(_ *cobra.Command, _ []string) error {
 	if _, hasRustfs := cfg.Services["rustfs"]; !hasRustfs {
 		cfg.Services["rustfs"] = config.ServiceConfig{
 			Enabled: minioWasEnabled,
-			Image:   "rustfs/rustfs:latest",
+			Image:   "docker.io/rustfs/rustfs:latest",
 			Port:    9000,
 		}
 	}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -95,32 +95,32 @@ func defaultConfig() *GlobalConfig {
 	cfg.Services = map[string]ServiceConfig{
 		"mysql": {
 			Enabled: true,
-			Image:   "mysql:8.0",
+			Image:   "docker.io/library/mysql:8.0",
 			Port:    3306,
 		},
 		"redis": {
 			Enabled: true,
-			Image:   "redis:7-alpine",
+			Image:   "docker.io/library/redis:7-alpine",
 			Port:    6379,
 		},
 		"postgres": {
 			Enabled: false,
-			Image:   "postgis/postgis:16-3.5-alpine",
+			Image:   "docker.io/postgis/postgis:16-3.5-alpine",
 			Port:    5432,
 		},
 		"meilisearch": {
 			Enabled: false,
-			Image:   "getmeili/meilisearch:v1.7",
+			Image:   "docker.io/getmeili/meilisearch:v1.7",
 			Port:    7700,
 		},
 		"rustfs": {
 			Enabled: false,
-			Image:   "rustfs/rustfs:latest",
+			Image:   "docker.io/rustfs/rustfs:latest",
 			Port:    9000,
 		},
 		"mailpit": {
 			Enabled: false,
-			Image:   "axllent/mailpit:latest",
+			Image:   "docker.io/axllent/mailpit:latest",
 			Port:    1025,
 		},
 	}
@@ -157,10 +157,26 @@ func LoadGlobal() (*GlobalConfig, error) {
 // move onto the new image (e.g. postgres → postgis/postgis for PostGIS
 // support) without having to hand-edit ~/.config/lerd/config.yaml.
 var staleServiceImages = map[string][]string{
+	"mysql": {
+		"mysql:8.0",
+	},
+	"redis": {
+		"redis:7-alpine",
+	},
 	"postgres": {
 		"postgres:16-alpine",
 		"docker.io/library/postgres:16-alpine",
 		"docker.io/postgres:16-alpine",
+		"postgis/postgis:16-3.5-alpine",
+	},
+	"meilisearch": {
+		"getmeili/meilisearch:v1.7",
+	},
+	"rustfs": {
+		"rustfs/rustfs:latest",
+	},
+	"mailpit": {
+		"axllent/mailpit:latest",
 	},
 }
 

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -173,7 +173,7 @@ func TestMigrateStaleServiceImages_Postgres(t *testing.T) {
 		Port:    5432,
 	}
 	migrateStaleServiceImages(cfg)
-	if got := cfg.Services["postgres"].Image; got != "postgis/postgis:16-3.5-alpine" {
+	if got := cfg.Services["postgres"].Image; got != "docker.io/postgis/postgis:16-3.5-alpine" {
 		t.Errorf("postgres image not migrated: got %q", got)
 	}
 }


### PR DESCRIPTION
On Ubuntu, podman's /etc/containers/registries.conf has no unqualified-search registries configured by default, so short image names like postgis/postgis:16-3.5-alpine fail to pull with "short-name did not resolve to an alias". Arch and Fedora ship a default search registry list, which is why this went unnoticed.

## Changes

- internal/config/global.go: fully qualify the six built-in service defaults (mysql, redis, postgres/postgis, meilisearch, rustfs, mailpit) with their docker.io/ prefixes.
- internal/config/global.go: extend the existing migrateStaleServiceImages table so users upgrading from 1.11.x with the old short names on disk auto-upgrade on next LoadGlobal.
- internal/cli/minio_migrate.go: qualify the rustfs image used by the minio→rustfs migration path.
- docs/reference/configuration.md: update the example config block to match.

Preset YAML files under internal/config/presets/ were already fully qualified and need no changes. Quadlet templates under internal/podman/quadlets/ and embed/quadlet/ were also already qualified.