### PR TITLE
fix: refresh services list after installing preset from UI

### DIFF
--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -169,7 +169,7 @@ func Start(currentVersion string) error {
 	})
 
 	mux.HandleFunc("/api/services/presets", withCORS(handleServicePresets))
-	mux.HandleFunc("/api/services/presets/", withCORS(handleServicePresetInstall))
+	mux.HandleFunc("/api/services/presets/", withCORS(publishAfter(handleServicePresetInstall, eventbus.KindServices, eventbus.KindStatus)))
 	mux.HandleFunc("/api/services/", withCORS(publishAfter(handleServiceAction, eventbus.KindServices, eventbus.KindStatus, eventbus.KindSites)))
 	mux.HandleFunc("/api/version", withCORS(func(w http.ResponseWriter, r *http.Request) {
 		handleVersion(w, r, currentVersion)


### PR DESCRIPTION
Installing a preset from the UI (e.g. the phpMyAdmin suggestion on the MySQL card) did nothing visible: the new service never appeared in the list, the modal didn't close, and the dashboard didn't navigate to the new service.

## Cause

/api/services/presets/ was registered with only withCORS and not wrapped in publishAfter, so after a successful preset install no eventbus event was published. The snapshotCache holds /api/services responses for up to 2 seconds (snapshotTTL), so the frontend's immediate loadServices() call after POST came back with the stale pre-install list. The `find(s => s.name === installedSvcName)` check in installPreset then failed, short-circuiting the switch-tab / selectService / start flow.

## Fix

Wrap handleServicePresetInstall with publishAfter(KindServices, KindStatus). runSnapshotInvalidator picks up the event, drops the cached services bytes, rebuilds them, and broadcasts to every WS client — and the same event invalidates the cache for the frontend's immediate HTTP poll, so the new service is visible and the existing installPreset() flow (load → find → switch tab → start) works as written.