### PR TITLE
fix: gitignore dist-tray so goreleaser sees clean tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 dist/
+dist-tray/
 *.tmp
 .venv/
 site/


### PR DESCRIPTION
v1.12.1 release run failed at goreleaser's git-state validation: `?? dist-tray/` made the tree dirty. The build-darwin-tray job uploads the macOS tray binary as an artifact and the release job downloads it into dist-tray/, which wasn't gitignored. dist/ was already ignored for the same reason.