### PR TITLE
fix(ui): show workers as toggled on macOS when running

### DIFF
--- a/internal/siteinfo/unitcache_darwin.go
+++ b/internal/siteinfo/unitcache_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package siteinfo
+
+import "github.com/geodro/lerd/internal/podman"
+
+func init() {
+	// On macOS, workers are managed by launchd + podman containers — there is
+	// no systemd. Override the default unitStatusFn (which calls systemctl) so
+	// that worker status is queried through the darwinServiceManager instead,
+	// which checks launchd state and the running podman container directly.
+	unitStatusFn = podman.UnitStatus
+}


### PR DESCRIPTION
On macOS, `unitStatusFn` in the `siteinfo` package defaulted to `unitStatusCached`, which calls `systemctl --user list-units`. systemd is not available on macOS, so all worker status lookups returned `"unknown"` — causing the UI to show every worker as off even when they were running.

`lerd status` used `podman.UnitStatus` which correctly routes through `darwinServiceManager.UnitStatus()` (checks launchd state + podman container directly), so there was a discrepancy between the CLI and the UI.

**Fix:** Add `internal/siteinfo/unitcache_darwin.go` with an `init()` that overrides `unitStatusFn` to use `podman.UnitStatus` on darwin.