### PR TITLE
fix(ui): regenerate family consumers after service remove

### DIFF
--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1144,6 +1144,7 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
 			return
 		}
+		cli.RegenerateFamilyConsumersForService(name)
 		writeJSON(w, map[string]any{"ok": true})
 		return
 	case "pin":


### PR DESCRIPTION
The web UI remove handler was missing the `RegenerateFamilyConsumers` call that `lerd service remove` (CLI) already performs.

Removing mariadb (or any family service) via the UI left phpMyAdmin's `PMA_HOSTS` unchanged — the container kept its old env var and tried to connect to the removed host, returning a DNS error.