### PR TITLE
release: v1.12.4

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,14 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.12.4] — 2026-04-13
+
+### Fixed
+
+- **`pgpass` rewrite failed with permission denied** — file mounts declared with `chown: true` (e.g. pgAdmin's `/pgpass`) get re-owned to a userns-mapped uid by podman's `:U` flag. On the next materialize the host process could no longer open the file for writing and surfaced `open …/pgpass: permission denied`. `MaterializeServiceFiles` now unlinks the existing entry before writing, so a stale userns-owned file is replaced cleanly.
+
+---
+
 ## [1.12.3] — 2026-04-13
 
 ### Fixed

--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -252,6 +252,12 @@ func MaterializeServiceFiles(svc *CustomService) error {
 			mode = os.FileMode(parsed)
 		}
 		path := ServiceFilePath(svc.Name, f.Target)
+		// Unlink first: with chown:true podman's :U flag re-owns the file to a
+		// userns-mapped uid, so a plain rewrite would EACCES. Removing the dir
+		// entry succeeds because the parent dir is owned by us.
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing stale %s for service %s: %w", path, svc.Name, err)
+		}
 		if err := os.WriteFile(path, []byte(f.Content), mode); err != nil {
 			return fmt.Errorf("writing %s for service %s: %w", path, svc.Name, err)
 		}

--- a/internal/config/custom_service_test.go
+++ b/internal/config/custom_service_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMaterializeServiceFiles_OverwritesReadOnlyFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	svc := &CustomService{
+		Name:  "pgadmin",
+		Image: "docker.io/dpage/pgadmin4:latest",
+		Files: []FileMount{{
+			Target:  "/pgpass",
+			Mode:    "0600",
+			Chown:   true,
+			Content: "host:5432:*:postgres:secret\n",
+		}},
+	}
+
+	if err := MaterializeServiceFiles(svc); err != nil {
+		t.Fatalf("first materialize: %v", err)
+	}
+
+	path := ServiceFilePath(svc.Name, "/pgpass")
+	if err := os.Chmod(path, 0o400); err != nil {
+		t.Fatalf("chmod 0400: %v", err)
+	}
+
+	svc.Files[0].Content = "host:5432:*:postgres:rotated\n"
+	if err := MaterializeServiceFiles(svc); err != nil {
+		t.Fatalf("rewrite over read-only file: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "host:5432:*:postgres:rotated\n" {
+		t.Errorf("unexpected content: %q", string(got))
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %v, want 0600", info.Mode().Perm())
+	}
+
+	if got, want := filepath.Dir(path), ServiceFilesDir(svc.Name); got != want {
+		t.Errorf("dir = %q, want %q", got, want)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.12.3"
+	Version = "1.12.4"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

- Fix `permission denied` when re-materializing `chown: true` file mounts (e.g. pgAdmin's `/pgpass`). Podman's `:U` re-owns the file to a userns-mapped uid, so the next host-side rewrite hit EACCES. `MaterializeServiceFiles` now unlinks the existing entry first; the parent dir is owned by us, so unlink is always permitted, and `WriteFile` then creates a fresh file.