### PR TITLE
release: v1.12.5 — postgres platform image override

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,14 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.12.5] — 2026-04-13
+
+### Fixed
+
+- **macOS ARM64 postgres pulled an image with no ARM64 manifest** — `platformImageOverride` was applied before `svcCfg.Image` from global config, so the macOS substitute (`imresamu/postgis`) was silently overwritten by `postgis/postgis:16-3.5-alpine` on every `ensureServiceQuadlet` and `lerd install` run. The override now runs last and only when the resolved image is the known-bad upstream `postgis/postgis` + `alpine` suffix, leaving user-pinned custom images untouched. The embedded quadlet fallback also moves from `postgis:16-3.5-alpine` to `postgis:16-3.5` so fresh Linux installs get an image with an ARM64 manifest. (#175)
+
+---
+
 ## [1.12.4] — 2026-04-13
 
 ### Fixed

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -186,9 +186,6 @@ func runInstall(_ *cobra.Command, _ []string) error {
 		}
 		content = podman.InjectExtraVolumes(content, extraVolumes)
 		svcName := strings.TrimPrefix(name, "lerd-")
-		if override := platformImageOverride(svcName); override != "" {
-			content = podman.ApplyImage(content, override)
-		}
 		// Match ensureServiceQuadlet so install and the runtime service
 		// path produce byte-identical files. Without this, a user who has
 		// pinned an image (e.g. `mysql:8.0` instead of the embed's
@@ -200,6 +197,12 @@ func runInstall(_ *cobra.Command, _ []string) error {
 				if len(svcCfg.ExtraPorts) > 0 {
 					content = podman.ApplyExtraPorts(content, svcCfg.ExtraPorts)
 				}
+			}
+		}
+		// Platform override applied last so it wins over the global config image.
+		if currentImage := podman.CurrentImage(content); currentImage != "" {
+			if override := platformImageOverride(svcName, currentImage); override != "" {
+				content = podman.ApplyImage(content, override)
 			}
 		}
 		changed, err := podman.WriteQuadletDiff(name, content)

--- a/internal/cli/service_image_darwin.go
+++ b/internal/cli/service_image_darwin.go
@@ -2,14 +2,25 @@
 
 package cli
 
+import "strings"
+
 // platformImageOverride substitutes images that don't work on macOS Podman
 // Machine. The official postgis/postgis image is amd64-only and was deprecated
 // upstream; imresamu/postgis is the actively maintained multi-arch fork that
 // runs natively on Apple Silicon under Podman Machine.
-func platformImageOverride(name string) string {
+//
+// currentImage is the image that would otherwise be used (from global config or
+// the embedded quadlet). The override is only applied when currentImage is one
+// of the known-bad images so that user-pinned custom images are left untouched.
+func platformImageOverride(name, currentImage string) string {
 	switch name {
 	case "postgres":
-		return "docker.io/imresamu/postgis:16-3.5-alpine"
+		// postgis/postgis alpine tags have no ARM64 manifest; imresamu/postgis
+		// is the maintained multi-arch fork. Only override when the resolved
+		// image is from the upstream repo with the alpine suffix.
+		if strings.Contains(currentImage, "postgis/postgis") && strings.Contains(currentImage, "alpine") {
+			return "docker.io/imresamu/postgis:16-3.5-alpine"
+		}
 	}
 	return ""
 }

--- a/internal/cli/service_image_linux.go
+++ b/internal/cli/service_image_linux.go
@@ -4,6 +4,6 @@ package cli
 
 // platformImageOverride returns "" on Linux: the embedded quadlet image is
 // already correct for Linux (postgis/postgis works fine on libpod with crun).
-func platformImageOverride(_ string) string {
+func platformImageOverride(_, _ string) string {
 	return ""
 }

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -629,15 +629,20 @@ func ensureServiceQuadlet(name string) error {
 	if err != nil {
 		return fmt.Errorf("unknown service %q", name)
 	}
-	if override := platformImageOverride(name); override != "" {
-		content = podman.ApplyImage(content, override)
-	}
 	if cfg, loadErr := config.LoadGlobal(); loadErr == nil {
 		if svcCfg, ok := cfg.Services[name]; ok {
 			content = podman.ApplyImage(content, svcCfg.Image)
 			if len(svcCfg.ExtraPorts) > 0 {
 				content = podman.ApplyExtraPorts(content, svcCfg.ExtraPorts)
 			}
+		}
+	}
+	// Platform override applied last so it wins over the global config image.
+	// The override only fires when the resolved image is a known-bad one for
+	// this platform (e.g. postgis/postgis alpine has no ARM64 manifest on macOS).
+	if currentImage := podman.CurrentImage(content); currentImage != "" {
+		if override := platformImageOverride(name, currentImage); override != "" {
+			content = podman.ApplyImage(content, override)
 		}
 	}
 	if err := podman.WriteContainerUnitFn(quadletName, content); err != nil {

--- a/internal/podman/quadlet_embed.go
+++ b/internal/podman/quadlet_embed.go
@@ -35,6 +35,18 @@ func ApplyImage(content, image string) string {
 	return content
 }
 
+// CurrentImage returns the value of the Image= line in quadlet content,
+// or "" if no such line exists.
+func CurrentImage(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "Image=") {
+			return strings.TrimPrefix(trimmed, "Image=")
+		}
+	}
+	return ""
+}
+
 // ApplyExtraPorts appends extra PublishPort lines to quadlet content.
 func ApplyExtraPorts(content string, extraPorts []string) string {
 	var sb strings.Builder

--- a/internal/podman/quadlets/lerd-postgres.container
+++ b/internal/podman/quadlets/lerd-postgres.container
@@ -3,7 +3,7 @@ Description=Lerd PostgreSQL
 After=network.target
 
 [Container]
-Image=docker.io/postgis/postgis:16-3.5-alpine
+Image=docker.io/postgis/postgis:16-3.5
 ContainerName=lerd-postgres
 Network=lerd
 PublishPort=5432:5432

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.12.4"
+	Version = "1.12.5"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

- `platformImageOverride` was applied before `svcCfg.Image` from global config, so the macOS ARM64 substitute (`imresamu/postgis`) was silently overwritten on every `ensureServiceQuadlet` / `lerd install` run.
- Fix: apply the override **after** global config, and only when the resolved image is the known-bad upstream one (`postgis/postgis` + `alpine` suffix) — user-pinned custom images are left untouched.
- Linux stub updated to match the new two-argument signature (still always returns `""`, no behaviour change).
- Embedded quadlet fallback changed from `postgis:16-3.5-alpine` to `postgis:16-3.5` so fresh Linux installs also get an image with an ARM64 manifest.
- Bumps version to v1.12.5 and adds changelog entry.