### PR TITLE
fix(ui): inherit graphical session env when spawning terminals

### DIFF
--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -286,6 +286,101 @@ func withCORS(h http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// graphicalSessionKeys lists the env vars a GUI terminal needs to attach to
+// the user's compositor. Missing any of these (notably WAYLAND_DISPLAY /
+// DISPLAY) causes the spawned terminal to exit silently after fork.
+var graphicalSessionKeys = []string{
+	"WAYLAND_DISPLAY",
+	"DISPLAY",
+	"XAUTHORITY",
+	"XDG_SESSION_TYPE",
+	"XDG_CURRENT_DESKTOP",
+	"XDG_RUNTIME_DIR",
+	"XDG_DATA_DIRS",
+	"DBUS_SESSION_BUS_ADDRESS",
+}
+
+// graphicalEnv returns os.Environ() enriched with graphical-session vars
+// pulled from the systemd user manager and (as a last resort) probed from
+// $XDG_RUNTIME_DIR. When lerd-ui runs as a lingering user service started at
+// boot, its own env has no DISPLAY / WAYLAND_DISPLAY, so any GUI child it
+// spawns dies on startup. This helper patches that up at spawn time.
+//
+// Darwin doesn't need this (Terminal/iTerm are launched via `open` which
+// reattaches to the user's Aqua session), so the caller should skip it there.
+func graphicalEnv() []string {
+	env := os.Environ()
+	have := map[string]string{}
+	for _, kv := range env {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			have[kv[:i]] = kv[i+1:]
+		}
+	}
+
+	merged := map[string]string{}
+	for _, k := range graphicalSessionKeys {
+		if v := have[k]; v != "" {
+			merged[k] = v
+		}
+	}
+
+	if out, err := exec.Command("systemctl", "--user", "show-environment").Output(); err == nil {
+		sc := bufio.NewScanner(strings.NewReader(string(out)))
+		for sc.Scan() {
+			line := sc.Text()
+			i := strings.IndexByte(line, '=')
+			if i <= 0 {
+				continue
+			}
+			k, v := line[:i], line[i+1:]
+			for _, want := range graphicalSessionKeys {
+				if k == want && merged[k] == "" && v != "" {
+					merged[k] = v
+				}
+			}
+		}
+	}
+
+	if merged["WAYLAND_DISPLAY"] == "" {
+		runtimeDir := merged["XDG_RUNTIME_DIR"]
+		if runtimeDir == "" {
+			runtimeDir = have["XDG_RUNTIME_DIR"]
+		}
+		if runtimeDir == "" {
+			runtimeDir = fmt.Sprintf("/run/user/%d", os.Getuid())
+		}
+		if entries, err := os.ReadDir(runtimeDir); err == nil {
+			for _, e := range entries {
+				name := e.Name()
+				if strings.HasPrefix(name, "wayland-") && !strings.HasSuffix(name, ".lock") {
+					merged["WAYLAND_DISPLAY"] = name
+					if merged["XDG_RUNTIME_DIR"] == "" {
+						merged["XDG_RUNTIME_DIR"] = runtimeDir
+					}
+					break
+				}
+			}
+		}
+	}
+
+	out := make([]string, 0, len(env)+len(merged))
+	for _, kv := range env {
+		i := strings.IndexByte(kv, '=')
+		if i <= 0 {
+			out = append(out, kv)
+			continue
+		}
+		if _, overridden := merged[kv[:i]]; overridden {
+			continue
+		}
+		out = append(out, kv)
+	}
+	for k, v := range merged {
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
 // openTerminalAt opens the user's preferred terminal emulator in dir.
 // It checks $TERMINAL first, then falls back to a list of common emulators.
 func openTerminalAt(dir string) error {
@@ -337,6 +432,9 @@ func openTerminalAt(dir string) error {
 		}
 		cmd := exec.Command(bin, args...)
 		cmd.Dir = dir
+		if runtime.GOOS != "darwin" {
+			cmd.Env = graphicalEnv()
+		}
 		if err := cmd.Start(); err != nil {
 			return err
 		}
@@ -2120,6 +2218,9 @@ func openTerminalCommand(script string) error {
 			continue
 		}
 		cmd := exec.Command(bin, t.args...)
+		if runtime.GOOS != "darwin" {
+			cmd.Env = graphicalEnv()
+		}
 		if err := cmd.Start(); err != nil {
 			return err
 		}

--- a/internal/ui/terminal_env_test.go
+++ b/internal/ui/terminal_env_test.go
@@ -1,0 +1,62 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGraphicalEnvPreservesBaseEnvAndPatchesDisplay(t *testing.T) {
+	t.Setenv("LERD_TEST_SENTINEL", "abc123")
+	t.Setenv("WAYLAND_DISPLAY", "")
+	t.Setenv("DISPLAY", "")
+
+	runtimeDir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+	if err := os.WriteFile(runtimeDir+"/wayland-7", []byte{}, 0o600); err != nil {
+		t.Fatalf("seed wayland socket: %v", err)
+	}
+
+	env := graphicalEnv()
+
+	var sawSentinel, sawWayland, sawRuntimeDir bool
+	var waylandVal string
+	for _, kv := range env {
+		switch {
+		case kv == "LERD_TEST_SENTINEL=abc123":
+			sawSentinel = true
+		case strings.HasPrefix(kv, "WAYLAND_DISPLAY="):
+			sawWayland = true
+			waylandVal = strings.TrimPrefix(kv, "WAYLAND_DISPLAY=")
+		case kv == "XDG_RUNTIME_DIR="+runtimeDir:
+			sawRuntimeDir = true
+		}
+	}
+
+	if !sawSentinel {
+		t.Error("graphicalEnv dropped base environment entry")
+	}
+	if !sawRuntimeDir {
+		t.Error("graphicalEnv did not preserve XDG_RUNTIME_DIR")
+	}
+	if !sawWayland {
+		t.Error("graphicalEnv did not probe WAYLAND_DISPLAY from XDG_RUNTIME_DIR")
+	}
+	if sawWayland && waylandVal != "wayland-7" {
+		t.Errorf("WAYLAND_DISPLAY = %q, want wayland-7", waylandVal)
+	}
+}
+
+func TestGraphicalEnvDoesNotDuplicateKeys(t *testing.T) {
+	t.Setenv("XDG_SESSION_TYPE", "wayland")
+	env := graphicalEnv()
+	count := 0
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "XDG_SESSION_TYPE=") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("XDG_SESSION_TYPE appears %d times, want 1", count)
+	}
+}


### PR DESCRIPTION
## Summary

When `lerd-ui` runs as a lingering systemd user service, it starts at boot before the compositor exists and inherits an empty graphical environment (no `WAYLAND_DISPLAY` / `DISPLAY`). Any GUI terminal it forks then dies silently on startup, so clicking the site **Terminal** button or **Open terminal & update** did nothing, with no visible error (the fork succeeds, so the handler happily returns `ok:true`).

`graphicalEnv()` returns `os.Environ()` merged with graphical-session vars pulled from `systemctl --user show-environment`, with a `XDG_RUNTIME_DIR` wayland-socket probe as a last resort. Both `openTerminalAt` (site terminal) and `openTerminalCommand` (update-in-terminal) seed `cmd.Env` from it before `Start()`.

Darwin is skipped via `runtime.GOOS != "darwin"` — `open -a Terminal` / `open -a iTerm` reattach to the Aqua session on their own, so macOS behavior is unchanged.