### PR TITLE
feat(lan): LAN sharing — per-site reverse proxy with QR code

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -147,6 +147,8 @@ func main() {
 	root.AddCommand(cli.NewLANExposeCmd())
 	root.AddCommand(cli.NewLANUnexposeCmd())
 	root.AddCommand(cli.NewLANStatusCmd())
+	root.AddCommand(cli.NewLANShareCmd())
+	root.AddCommand(cli.NewLANUnshareCmd())
 	root.AddCommand(cli.NewRemoteSetupCmd())
 	root.AddCommand(cli.NewRemoteControlCmd())
 	root.AddCommand(cli.NewRemoteControlOnCmd())

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -65,6 +65,29 @@ Setup steps include common tasks (composer install, npm install, lerd env) plus 
 | `lerd env` | Configure `.env` for the current project with lerd service connection settings |
 | `lerd env:check` | Compare all `.env` files against `.env.example` and flag missing or extra keys |
 
+## LAN
+
+### LAN sharing (per-site, no DNS setup required on clients)
+
+| Command | Description |
+|---|---|
+| `lerd lan:share` | Start a LAN reverse proxy for the current site on a stable port; prints the URL and a QR code |
+| `lerd lan:unshare` | Stop LAN sharing for the current site and release its port |
+
+The proxy runs inside the lerd daemon (`lerd-ui`) — no external tool needed and no internet access required. Any device on the same network can reach the site at `http://<your-LAN-IP>:<port>` without configuring DNS. The assigned port is stored in `sites.yaml` and reused across restarts. The proxy rewrites the Host header so nginx routes correctly, and rewrites absolute URLs in HTML/CSS/JS responses so asset and redirect URLs point to the LAN address instead of the `.test` domain. See [LAN sharing](/usage/remote-development#lan-sharing-per-site) for details.
+
+`lerd share` (without `lan:`) is different — it wraps an external tunnel tool (ngrok/cloudflared/Expose/SSH) to expose the site to the **public internet**.
+
+### Full LAN exposure (all sites, DNS-based)
+
+| Command | Description |
+|---|---|
+| `lerd lan:expose` | Expose all lerd services to the LAN — binds nginx to `0.0.0.0`, starts the DNS forwarder |
+| `lerd lan:unexpose` | Restrict everything back to `127.0.0.1` |
+| `lerd lan:status` | Show whether lerd is currently exposed to the local network |
+
+See [Remote / LAN Development](/usage/remote-development) for the full walkthrough.
+
 ## PHP
 
 | Command | Description |

--- a/docs/usage/remote-development.md
+++ b/docs/usage/remote-development.md
@@ -1,5 +1,51 @@
 # Remote / LAN Development
 
+## LAN sharing (per-site) {#lan-sharing-per-site}
+
+The quickest way to let another device on the same network reach one of your sites — no DNS setup, no external tools, no internet access required:
+
+```bash
+cd ~/Projects/myapp
+lerd lan:share
+```
+
+```
+Sharing myapp at http://192.168.1.42:9100
+Other devices on the network can use that URL directly — no DNS setup needed.
+
+█████████████████████████████████
+█ ▄▄▄▄▄ █▀▄ █▄█ ▀▀ ▄█ ▄▄▄▄▄ █
+...
+Run 'lerd lan:unshare' to stop.
+```
+
+What it does:
+
+- Assigns a stable port to the site (starting at 9100, incremented to avoid conflicts) and saves it in `sites.yaml`.
+- Starts a host-level reverse proxy inside the lerd daemon (`lerd-ui`) listening on `0.0.0.0:<port>`.
+- Rewrites the `Host` header on every request so nginx routes to the correct vhost.
+- Rewrites absolute URLs (`https://myapp.test/...` → `http://192.168.1.42:9100/...`) in HTML, CSS, and JS response bodies so assets and redirects work from the client device without a `.test` DNS resolver.
+- Prints a QR code you can scan to open the site on a phone.
+
+The port is reused across restarts. Stop sharing with `lerd lan:unshare`.
+
+The dashboard shows the LAN URL next to the HTTPS toggle for each site. Hovering the URL shows a QR code inline.
+
+### When to use LAN sharing vs full LAN exposure
+
+| | `lerd lan:share` | `lerd lan:expose` |
+|---|---|---|
+| Scope | One site at a time | All sites at once |
+| Client DNS setup | Not required — plain `IP:port` | Required (forward `.test` to lerd dnsmasq) |
+| Client cert trust | Not required | Required for HTTPS sites |
+| External tools | None | None |
+| Persists across restarts | Yes (port saved in `sites.yaml`) | Yes (`lan.exposed` in `config.yaml`) |
+| Use case | Quick demo to someone on the same wifi | Full remote dev setup (laptop + server) |
+
+---
+
+## Full LAN exposure (all sites, DNS-based)
+
 Lerd is designed to run on the machine you're developing from — install it, link a project, browse `myapp.test`, done. But there's a common variant of that workflow worth documenting: **the lerd server is a different machine from the one you're typing on**. Typical case: you have a beefier Linux box (desktop, NAS, mini PC) running the containers, and a laptop you carry around for editing.
 
 This page walks through the full setup so the laptop can browse `https://myapp.test` against a remote server with no per-site `/etc/hosts` maintenance and no certificate warnings.

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=

--- a/internal/certs/manager.go
+++ b/internal/certs/manager.go
@@ -59,3 +59,4 @@ func CertExists(domain string) bool {
 	_, err := os.Stat(certFile)
 	return err == nil
 }
+

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -246,6 +246,27 @@ func runEnv(_ *cobra.Command, _ []string) error {
 				}
 				continue
 			}
+			if svc == "rustfs" {
+				// Honour existing AWS_BUCKET from .env; fall back to project slug.
+				bucketName := strings.TrimSpace(envMap["AWS_BUCKET"])
+				if bucketName == "" || bucketName == "lerd" {
+					bucketName = s3BucketName(dbName)
+				}
+				updates["AWS_BUCKET"] = bucketName
+				updates["AWS_URL"] = "http://localhost:9000/" + bucketName
+				if err := ensureServiceRunning(svc); err != nil {
+					fmt.Printf("  [WARN] could not start %s: %v\n", svc, err)
+				}
+				created, err := createS3Bucket(bucketName)
+				if err != nil {
+					fmt.Printf("  [WARN] could not create bucket %q: %v\n", bucketName, err)
+				} else if created {
+					fmt.Printf("  Created bucket %q\n", bucketName)
+				} else {
+					fmt.Printf("  Bucket %q already exists\n", bucketName)
+				}
+				continue
+			}
 			if err := ensureServiceRunning(svc); err != nil {
 				fmt.Printf("  [WARN] could not start %s: %v\n", svc, err)
 			}
@@ -314,20 +335,28 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			}
 
 			if svc == "rustfs" {
-				bucketName := s3BucketName(dbName)
+				// Honour an existing AWS_BUCKET in .env (set manually or by a
+				// previous lerd env run) so we create/target the right bucket.
+				// Fall back to deriving the name from the project slug.
+				bucketName := strings.TrimSpace(envMap["AWS_BUCKET"])
+				if bucketName == "" || bucketName == "lerd" {
+					bucketName = s3BucketName(dbName)
+				}
 				updates["AWS_BUCKET"] = bucketName
 				updates["AWS_URL"] = "http://localhost:9000/" + bucketName
 				if err := ensureServiceRunning(svc); err != nil {
 					fmt.Printf("  [WARN] could not start %s: %v\n", svc, err)
+				}
+				// Always attempt bucket creation — ensureServiceRunning may have
+				// timed out on the host probe while the container network is already
+				// up, or rustfs was already running before lerd env ran.
+				created, err := createS3Bucket(bucketName)
+				if err != nil {
+					fmt.Printf("  [WARN] could not create bucket %q: %v\n", bucketName, err)
+				} else if created {
+					fmt.Printf("  Created bucket %q\n", bucketName)
 				} else {
-					created, err := createS3Bucket(bucketName)
-					if err != nil {
-						fmt.Printf("  [WARN] could not create bucket %q: %v\n", bucketName, err)
-					} else if created {
-						fmt.Printf("  Created bucket %q\n", bucketName)
-					} else {
-						fmt.Printf("  Bucket %q already exists\n", bucketName)
-					}
+					fmt.Printf("  Bucket %q already exists\n", bucketName)
 				}
 				continue
 			}
@@ -594,6 +623,8 @@ func s3BucketName(name string) string {
 
 // createS3Bucket creates a bucket for the given name in lerd-rustfs using an ephemeral mc container.
 // Returns (true, nil) if created, (false, nil) if it already existed, or (false, err) on failure.
+// Retries up to 3 times (2 s apart) to bridge the window between the host TCP port becoming
+// reachable and the container network being fully ready for mc operations.
 func createS3Bucket(name string) (bool, error) {
 	const (
 		alias   = "lerd"
@@ -601,24 +632,35 @@ func createS3Bucket(name string) (bool, error) {
 		mcEnv   = "MC_HOST_lerd=http://lerd:lerdpassword@lerd-rustfs:9000"
 	)
 
-	lsCmd := podman.Cmd("run", "--rm", "--network", "lerd",
-		"-e", mcEnv, mcImage, "ls", alias+"/"+name)
-	if err := lsCmd.Run(); err == nil {
-		return false, nil
-	}
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			time.Sleep(2 * time.Second)
+		}
 
-	mbCmd := podman.Cmd("run", "--rm", "--network", "lerd",
-		"-e", mcEnv, mcImage, "mb", alias+"/"+name)
-	if out, err := mbCmd.CombinedOutput(); err != nil {
-		return false, fmt.Errorf("%s", strings.TrimSpace(string(out)))
-	}
+		// Bucket already exists?
+		lsCmd := podman.Cmd("run", "--rm", "--network", "lerd",
+			"-e", mcEnv, mcImage, "ls", alias+"/"+name)
+		if lsCmd.Run() == nil {
+			return false, nil
+		}
 
-	pubCmd := podman.Cmd("run", "--rm", "--network", "lerd",
-		"-e", mcEnv, mcImage, "anonymous", "set", "public", alias+"/"+name)
-	if out, err := pubCmd.CombinedOutput(); err != nil {
-		return false, fmt.Errorf("mc anonymous set public: %s", strings.TrimSpace(string(out)))
+		mbCmd := podman.Cmd("run", "--rm", "--network", "lerd",
+			"-e", mcEnv, mcImage, "mb", alias+"/"+name)
+		out, err := mbCmd.CombinedOutput()
+		if err != nil {
+			lastErr = fmt.Errorf("%s", strings.TrimSpace(string(out)))
+			continue
+		}
+
+		pubCmd := podman.Cmd("run", "--rm", "--network", "lerd",
+			"-e", mcEnv, mcImage, "anonymous", "set", "public", alias+"/"+name)
+		if out, err := pubCmd.CombinedOutput(); err != nil {
+			return false, fmt.Errorf("mc anonymous set public: %s", strings.TrimSpace(string(out)))
+		}
+		return true, nil
 	}
-	return true, nil
+	return false, lastErr
 }
 
 // ensureServiceRunning starts the service if it is not already active, then

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -286,6 +286,12 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		sort.Strings(workerOptions)
 	}
 
+	// Stripe is not a framework worker but can be auto-started when
+	// STRIPE_SECRET is present in the project's .env.
+	if StripeSecretSet(cwd) {
+		workerOptions = append(workerOptions, "stripe")
+	}
+
 	// Remove any selected workers that are no longer available.
 	filtered := selectedWorkers[:0]
 	availableSet := make(map[string]bool, len(workerOptions))

--- a/internal/cli/lan.go
+++ b/internal/cli/lan.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"net/http"
+	"os"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/spf13/cobra"
@@ -34,6 +36,8 @@ sites. Run 'lerd lan:expose off' to revert.`,
 	cmd.AddCommand(newLANExposeCmd())
 	cmd.AddCommand(newLANUnexposeCmd())
 	cmd.AddCommand(newLANStatusCmd())
+	cmd.AddCommand(newLANShareCmd())
+	cmd.AddCommand(newLANUnshareCmd())
 	return cmd
 }
 
@@ -58,6 +62,20 @@ func NewLANStatusCmd() *cobra.Command {
 	cmd := newLANStatusCmd()
 	cmd.Use = "lan:status"
 	cmd.Hidden = true
+	return cmd
+}
+
+// NewLANShareCmd returns the `lerd lan:share` colon-style alias.
+func NewLANShareCmd() *cobra.Command {
+	cmd := newLANShareCmd()
+	cmd.Use = "lan:share"
+	return cmd
+}
+
+// NewLANUnshareCmd returns the `lerd lan:unshare` colon-style alias.
+func NewLANUnshareCmd() *cobra.Command {
+	cmd := newLANUnshareCmd()
+	cmd.Use = "lan:unshare"
 	return cmd
 }
 
@@ -126,6 +144,99 @@ func newLANUnexposeCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func newLANShareCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "share",
+		Short: "Share the current site on a stable LAN port (no DNS setup required on clients)",
+		Long: `Assigns a stable port to the current site and starts a host-level reverse
+proxy on 0.0.0.0:<port>. Any device on the same network can reach the site
+at http://<your-LAN-IP>:<port> without configuring DNS or a resolver.
+
+The proxy rewrites the Host header so nginx routes correctly, and rewrites
+absolute URLs in HTML/CSS/JS responses so asset and redirect URLs point to
+the LAN address instead of the .test domain.
+
+The assigned port is stored in sites.yaml and reused across restarts.
+Run 'lerd lan:unshare' to stop sharing and release the port.`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			siteName, err := queueSiteName(cwd)
+			if err != nil {
+				return err
+			}
+			// Persist the port assignment (daemon will start the proxy).
+			port, err := LANShareEnsurePort(siteName)
+			if err != nil {
+				return err
+			}
+			// Tell the running daemon to start the proxy now.
+			site, _ := config.FindSite(siteName)
+			if site != nil {
+				notifyDaemon(site.PrimaryDomain(), "lan:share") //nolint:errcheck
+			}
+			ip, _ := detectPrimaryLANIP()
+			if ip == "" {
+				ip = "<your-LAN-IP>"
+			}
+			shareURL := fmt.Sprintf("http://%s:%d", ip, port)
+			fmt.Printf("Sharing %s at %s\n", siteName, shareURL)
+			fmt.Println("Other devices on the network can use that URL directly — no DNS setup needed.")
+			fmt.Println()
+			PrintLANShareQR(shareURL)
+			fmt.Println()
+			fmt.Println("Run 'lerd lan:unshare' to stop.")
+			return nil
+		},
+	}
+}
+
+func newLANUnshareCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unshare",
+		Short: "Stop LAN sharing for the current site",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			siteName, err := queueSiteName(cwd)
+			if err != nil {
+				return err
+			}
+			site, err := config.FindSite(siteName)
+			if err != nil {
+				return err
+			}
+			// Tell the running daemon to stop the proxy and clear the port.
+			// If the daemon is not reachable, clear the port directly so the
+			// proxy is not restored on next daemon start.
+			if nErr := notifyDaemon(site.PrimaryDomain(), "lan:unshare"); nErr != nil {
+				site.LANPort = 0
+				_ = config.AddSite(*site)
+			}
+			fmt.Printf("LAN sharing stopped for %s.\n", siteName)
+			return nil
+		},
+	}
+}
+
+// notifyDaemon posts an action to the running lerd-ui daemon API. It is a
+// best-effort call; callers should handle errors gracefully.
+func notifyDaemon(domain, action string) error {
+	resp, err := http.Post(
+		fmt.Sprintf("http://127.0.0.1:7073/api/sites/%s/%s", domain, action),
+		"application/json", nil,
+	)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
 }
 
 func newLANStatusCmd() *cobra.Command {

--- a/internal/cli/lanshare.go
+++ b/internal/cli/lanshare.go
@@ -1,0 +1,327 @@
+package cli
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	qrcode "github.com/skip2/go-qrcode"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+var (
+	lanShareMu      sync.Mutex
+	lanShareServers = map[string]*http.Server{} // siteName → running proxy
+)
+
+// LANShareEnsurePort assigns a stable port to the site if not already set and
+// saves it to sites.yaml. It does NOT start the proxy — that is the daemon's job.
+// CLI commands use this to persist the port, then notify the daemon via its API.
+func LANShareEnsurePort(siteName string) (int, error) {
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return 0, err
+	}
+	if site.LANPort != 0 {
+		return site.LANPort, nil
+	}
+	port := assignLANSharePort(siteName)
+	site.LANPort = port
+	if err := config.AddSite(*site); err != nil {
+		return 0, fmt.Errorf("saving LAN port: %w", err)
+	}
+	return port, nil
+}
+
+// LANShareStart starts the in-process reverse proxy for the site. It is
+// intended to be called from the daemon (UI server) only — the proxy goroutine
+// lives in the daemon process. CLI commands should notify the daemon via its
+// HTTP API instead of calling this directly.
+func LANShareStart(siteName string) (int, error) {
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return 0, err
+	}
+
+	port := site.LANPort
+	if port == 0 {
+		port = assignLANSharePort(siteName)
+		site.LANPort = port
+		if err := config.AddSite(*site); err != nil {
+			return 0, fmt.Errorf("saving LAN port: %w", err)
+		}
+	}
+
+	lanShareMu.Lock()
+	if _, running := lanShareServers[siteName]; running {
+		lanShareMu.Unlock()
+		return port, nil
+	}
+	lanShareMu.Unlock()
+
+	cfg, _ := config.LoadGlobal()
+	httpPort := cfg.Nginx.HTTPPort
+	if httpPort == 0 {
+		httpPort = 80
+	}
+	httpsPort := cfg.Nginx.HTTPSPort
+	if httpsPort == 0 {
+		httpsPort = 443
+	}
+
+	srv, err := startLANShareProxy(site.PrimaryDomain(), port, httpPort, httpsPort, site.Secured)
+	if err != nil {
+		return 0, err
+	}
+
+	lanShareMu.Lock()
+	lanShareServers[siteName] = srv
+	lanShareMu.Unlock()
+
+	return port, nil
+}
+
+// LANShareStop stops the LAN share proxy for the site and clears its port
+// from the site registry.
+func LANShareStop(siteName string) error {
+	lanShareMu.Lock()
+	srv, running := lanShareServers[siteName]
+	if running {
+		delete(lanShareServers, siteName)
+	}
+	lanShareMu.Unlock()
+
+	if running {
+		srv.Close()
+	}
+
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return err
+	}
+	site.LANPort = 0
+	return config.AddSite(*site)
+}
+
+// LANShareRunning reports whether a share proxy is active for the site.
+func LANShareRunning(siteName string) bool {
+	lanShareMu.Lock()
+	defer lanShareMu.Unlock()
+	_, ok := lanShareServers[siteName]
+	return ok
+}
+
+// RestoreLANShareProxies restarts share proxies for every site that has a
+// LANPort stored in the registry. Called once when the UI server starts.
+func RestoreLANShareProxies() {
+	reg, err := config.LoadSites()
+	if err != nil {
+		return
+	}
+	cfg, _ := config.LoadGlobal()
+	httpPort := 80
+	httpsPort := 443
+	if cfg != nil {
+		if cfg.Nginx.HTTPPort != 0 {
+			httpPort = cfg.Nginx.HTTPPort
+		}
+		if cfg.Nginx.HTTPSPort != 0 {
+			httpsPort = cfg.Nginx.HTTPSPort
+		}
+	}
+	for _, s := range reg.Sites {
+		if s.LANPort == 0 {
+			continue
+		}
+		srv, err := startLANShareProxy(s.PrimaryDomain(), s.LANPort, httpPort, httpsPort, s.Secured)
+		if err != nil {
+			continue
+		}
+		lanShareMu.Lock()
+		lanShareServers[s.Name] = srv
+		lanShareMu.Unlock()
+	}
+}
+
+// assignLANSharePort finds the lowest unused port >= 9100 across all sites.
+func assignLANSharePort(excludeSiteName string) int {
+	const base = 9100
+	used := map[int]bool{}
+	reg, err := config.LoadSites()
+	if err != nil {
+		return base
+	}
+	for _, s := range reg.Sites {
+		if s.Name == excludeSiteName || s.LANPort == 0 {
+			continue
+		}
+		used[s.LANPort] = true
+	}
+	port := base
+	for used[port] {
+		port++
+	}
+	return port
+}
+
+// startLANShareProxy starts an HTTP reverse proxy listening on 0.0.0.0:<port>.
+// It rewrites the Host header to domain so nginx routes to the right vhost,
+// sets X-Forwarded-Host to the incoming address, and rewrites response bodies
+// and Location headers to replace domain URLs with the LAN address.
+func startLANShareProxy(domain string, port, httpPort, httpsPort int, secured bool) (*http.Server, error) {
+	var target *url.URL
+	if secured {
+		target = &url.URL{Scheme: "https", Host: fmt.Sprintf("localhost:%d", httpsPort)}
+	} else {
+		target = &url.URL{Scheme: "http", Host: fmt.Sprintf("localhost:%d", httpPort)}
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+
+	if secured {
+		t := http.DefaultTransport.(*http.Transport).Clone()
+		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true, ServerName: domain} //nolint:gosec
+		proxy.Transport = t
+	}
+
+	const scheme = "http"
+
+	orig := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		lanHost := req.Host // e.g. "192.168.1.5:9100"
+		orig(req)
+		req.Header.Set("X-Forwarded-Host", lanHost)
+		req.Header.Set("X-Forwarded-Proto", scheme)
+		req.Host = domain
+		// Tell upstream not to compress so we can rewrite bodies without
+		// having to decompress/recompress every response.
+		req.Header.Set("Accept-Encoding", "identity")
+	}
+
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		lanHost := resp.Request.Header.Get("X-Forwarded-Host")
+		if lanHost == "" {
+			return nil
+		}
+
+		// Rewrite Location headers: replace both http:// and https:// variants
+		// of the origin domain with the plain-HTTP LAN address.
+		if loc := resp.Header.Get("Location"); loc != "" {
+			loc = strings.ReplaceAll(loc, "https://"+domain, scheme+"://"+lanHost)
+			loc = strings.ReplaceAll(loc, "http://"+domain, scheme+"://"+lanHost)
+			resp.Header.Set("Location", loc)
+		}
+
+		ct := resp.Header.Get("Content-Type")
+		enc := resp.Header.Get("Content-Encoding")
+
+		if !isTextContent(ct) {
+			return nil
+		}
+
+		// Read the body, decompressing gzip if needed.
+		var body []byte
+		var err error
+		if enc == "gzip" {
+			gr, gErr := gzip.NewReader(resp.Body)
+			if gErr != nil {
+				return nil // leave untouched if we can't decompress
+			}
+			body, err = io.ReadAll(gr)
+			gr.Close()
+			resp.Body.Close()
+			if err != nil {
+				return err
+			}
+			resp.Header.Del("Content-Encoding")
+		} else if enc == "" || enc == "identity" {
+			body, err = io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				return err
+			}
+		} else {
+			return nil // unknown encoding, leave untouched
+		}
+
+		// Replace https://domain and http://domain with the LAN address.
+		body = bytes.ReplaceAll(body, []byte("https://"+domain), []byte(scheme+"://"+lanHost))
+		body = bytes.ReplaceAll(body, []byte("http://"+domain), []byte(scheme+"://"+lanHost))
+
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		resp.ContentLength = int64(len(body))
+		resp.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		return nil
+	}
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
+	if err != nil {
+		return nil, fmt.Errorf("binding port %d: %w", port, err)
+	}
+
+	srv := &http.Server{Handler: proxy}
+	go srv.Serve(ln) //nolint:errcheck
+	return srv, nil
+}
+
+// PrintLANShareQR prints a compact QR code for the given URL to stdout using
+// half-block Unicode characters (two rows per terminal line).
+func PrintLANShareQR(rawURL string) {
+	qr, err := qrcode.New(rawURL, qrcode.Medium)
+	if err != nil {
+		return
+	}
+	qr.DisableBorder = false
+	bitmap := qr.Bitmap() // [][]bool, true = dark module
+
+	// Render two rows of modules per terminal line using half-block chars.
+	// Quiet zone is already included in Bitmap().
+	for y := 0; y < len(bitmap); y += 2 {
+		row1 := bitmap[y]
+		var row2 []bool
+		if y+1 < len(bitmap) {
+			row2 = bitmap[y+1]
+		} else {
+			row2 = make([]bool, len(row1))
+		}
+		for x := range row1 {
+			top := row1[x]
+			bot := row2[x]
+			switch {
+			case top && bot:
+				fmt.Fprint(os.Stdout, "█")
+			case top:
+				fmt.Fprint(os.Stdout, "▀")
+			case bot:
+				fmt.Fprint(os.Stdout, "▄")
+			default:
+				fmt.Fprint(os.Stdout, " ")
+			}
+		}
+		fmt.Fprintln(os.Stdout)
+	}
+}
+
+// LANShareURL returns the URL a LAN device would use to reach the site on the
+// given port, or an empty string if the port is 0 or the LAN IP cannot be detected.
+func LANShareURL(lanPort int) string {
+	if lanPort == 0 {
+		return ""
+	}
+	ip, err := detectPrimaryLANIP()
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("http://%s:%d", ip, lanPort)
+}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -848,6 +848,12 @@ func autoStopUnusedFPMs() {
 		return
 	}
 	active := activePHPVersions()
+	// Never stop the globally configured default PHP version — it must always be
+	// available for `php`, `composer`, and `laravel new` shims even when no site
+	// explicitly references it (same logic as coreUnits).
+	if cfg, cfgErr := config.LoadGlobal(); cfgErr == nil && cfg != nil {
+		active[cfg.PHP.DefaultVersion] = true
+	}
 	for _, v := range versions {
 		if active[v] {
 			continue

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -44,6 +44,15 @@ func ensureImages() {
 
 	for _, unit := range units {
 		image := quadletImage(unit)
+
+		// On macOS there are no quadlet files, so quadletImage returns "".
+		// Derive the image name from the unit name for PHP-FPM units so that
+		// images are rebuilt after a VM reset without requiring manual intervention.
+		if image == "" && strings.HasPrefix(unit, "lerd-php") && strings.HasSuffix(unit, "-fpm") {
+			short := strings.TrimSuffix(strings.TrimPrefix(unit, "lerd-php"), "-fpm")
+			image = "lerd-php" + short + "-fpm:local"
+		}
+
 		if image == "" || seen[image] {
 			continue
 		}
@@ -121,6 +130,32 @@ func NewQuitCmd() *cobra.Command {
 		Use:   "quit",
 		Short: "Stop all Lerd processes and containers (including UI, watcher, and tray)",
 		RunE:  runQuit,
+	}
+}
+
+// ensureDefaultPHPInstalled builds the FPM image and writes the unit file for
+// the configured default PHP version if it has never been installed. This
+// handles the case where the user sets a new default (e.g. 8.5) before running
+// `lerd php install`, so `lerd start` transparently installs it.
+func ensureDefaultPHPInstalled() {
+	cfg, err := config.LoadGlobal()
+	if err != nil || cfg == nil || cfg.PHP.DefaultVersion == "" {
+		return
+	}
+	defaultVer := cfg.PHP.DefaultVersion
+	installed, _ := phpPkg.ListInstalled()
+	for _, v := range installed {
+		if v == defaultVer {
+			return // already installed
+		}
+	}
+	fmt.Printf("  --> Installing PHP %s (configured default, not yet installed) ...\n", defaultVer)
+	if err := podman.BuildFPMImage(defaultVer, false); err != nil {
+		fmt.Printf("  WARN: build PHP %s image: %v\n", defaultVer, err)
+		return
+	}
+	if err := podman.WriteFPMQuadlet(defaultVer); err != nil {
+		fmt.Printf("  WARN: write PHP %s unit: %v\n", defaultVer, err)
 	}
 }
 
@@ -324,6 +359,10 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// Restore quadlets and worker units that may be missing after an
 	// uninstall/reinstall cycle. Reads .lerd.yaml from each active site.
 	restoreSiteInfrastructure()
+
+	// If the configured default PHP version has never been installed (no plist /
+	// quadlet / container), install it now so coreUnits() can include it.
+	ensureDefaultPHPInstalled()
 
 	// Pre-flight port conflict check.
 	units := append(coreUnits(), installedServiceUnits()...)

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -113,11 +113,12 @@ func ensurePodmanMachineRunning() {
 		// Check whether the machine has at least 4 GB RAM. MySQL + PHP-FPM +
 		// Horizon together need it; machines initialised with the default 2 GB
 		// run out of memory and thrash swap, causing 800%+ host CPU usage.
+		// {{.Resources.Memory}} returns MiB directly (not bytes).
 		const minMemoryMiB = 4096
 		if inspectMem, err := exec.Command(podman.PodmanBin(), "machine", "inspect",
 			"--format", "{{.Resources.Memory}}", m.name).Output(); err == nil {
-			if memBytes, parseErr := strconv.ParseInt(strings.TrimSpace(string(inspectMem)), 10, 64); parseErr == nil && memBytes > 0 {
-				if memBytes/(1024*1024) < minMemoryMiB {
+			if memMiB, parseErr := strconv.ParseInt(strings.TrimSpace(string(inspectMem)), 10, 64); parseErr == nil && memMiB > 0 {
+				if memMiB < minMemoryMiB {
 					needsMemory = true
 				}
 			}

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -105,24 +106,61 @@ func ensurePodmanMachineRunning() {
 		}
 	} else {
 		m := machines[0]
-		if !m.rootful {
-			// Switch to rootful — required for nginx to bind ports 80/443.
+
+		needsRootful := !m.rootful
+		needsMemory := false
+
+		// Check whether the machine has at least 4 GB RAM. MySQL + PHP-FPM +
+		// Horizon together need it; machines initialised with the default 2 GB
+		// run out of memory and thrash swap, causing 800%+ host CPU usage.
+		const minMemoryMiB = 4096
+		if inspectMem, err := exec.Command(podman.PodmanBin(), "machine", "inspect",
+			"--format", "{{.Resources.Memory}}", m.name).Output(); err == nil {
+			if memBytes, parseErr := strconv.ParseInt(strings.TrimSpace(string(inspectMem)), 10, 64); parseErr == nil && memBytes > 0 {
+				if memBytes/(1024*1024) < minMemoryMiB {
+					needsMemory = true
+				}
+			}
+		}
+
+		if needsRootful || needsMemory {
 			if m.running {
-				fmt.Println("  --> Stopping Podman Machine to enable rootful mode ...")
+				var reason string
+				switch {
+				case needsRootful && needsMemory:
+					reason = "enable rootful mode and increase memory to 4 GB"
+				case needsRootful:
+					reason = "enable rootful mode"
+				default:
+					reason = "increase memory to 4 GB"
+				}
+				fmt.Printf("  --> Stopping Podman Machine to %s ...\n", reason)
 				stopCmd := exec.Command(podman.PodmanBin(), "machine", "stop", m.name)
 				stopCmd.Stdout = os.Stdout
 				stopCmd.Stderr = os.Stderr
 				stopCmd.Run() //nolint:errcheck
 			}
-			fmt.Println("  --> Enabling rootful mode for Podman Machine (required for ports 80/443) ...")
-			setCmd := exec.Command(podman.PodmanBin(), "machine", "set", "--rootful", m.name)
-			setCmd.Stdout = os.Stdout
-			setCmd.Stderr = os.Stderr
-			if err := setCmd.Run(); err != nil {
-				fmt.Printf("  WARN: podman machine set --rootful: %v\n", err)
+			if needsRootful {
+				fmt.Println("  --> Enabling rootful mode for Podman Machine (required for ports 80/443) ...")
+				setCmd := exec.Command(podman.PodmanBin(), "machine", "set", "--rootful", m.name)
+				setCmd.Stdout = os.Stdout
+				setCmd.Stderr = os.Stderr
+				if err := setCmd.Run(); err != nil {
+					fmt.Printf("  WARN: podman machine set --rootful: %v\n", err)
+				}
+			}
+			if needsMemory {
+				fmt.Printf("  --> Setting Podman Machine memory to %d MB (recommended minimum) ...\n", minMemoryMiB)
+				setCmd := exec.Command(podman.PodmanBin(), "machine", "set",
+					"--memory", strconv.Itoa(minMemoryMiB), m.name)
+				setCmd.Stdout = os.Stdout
+				setCmd.Stderr = os.Stderr
+				if err := setCmd.Run(); err != nil {
+					fmt.Printf("  WARN: podman machine set --memory: %v\n", err)
+				}
 			}
 		} else if m.running {
-			return // already running and rootful
+			return // already running and correctly configured
 		}
 	}
 
@@ -138,12 +176,12 @@ func ensurePodmanMachineRunning() {
 	// `podman machine start` exits before the API socket is ready to handle
 	// container operations. Poll `podman ps` (which exercises the full
 	// container stack, not just the info endpoint) until it succeeds, then
-	// wait an extra second for the socket to fully settle.
+	// wait a few extra seconds for the socket to fully settle.
 	fmt.Print("  --> Waiting for Podman Machine to be ready ...")
-	deadline := time.Now().Add(90 * time.Second)
+	deadline := time.Now().Add(120 * time.Second)
 	for time.Now().Before(deadline) {
 		if err := exec.Command(podman.PodmanBin(), "ps", "-q").Run(); err == nil {
-			time.Sleep(1 * time.Second) // brief grace period before container ops
+			time.Sleep(3 * time.Second) // grace period before container ops
 			fmt.Println(" ready")
 			return
 		}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -196,7 +196,7 @@ func runStatus(_ *cobra.Command, _ []string) error {
 				if fw, ok := config.GetFrameworkForDir(fwName, s.Path); ok && fw.Workers != nil {
 					for wName, wDef := range fw.Workers {
 						switch wName {
-						case "queue", "schedule", "reverb":
+						case "queue", "schedule", "reverb", "horizon":
 							continue
 						}
 						if wDef.Check != nil && !config.MatchesRule(s.Path, *wDef.Check) {

--- a/internal/cli/stripe.go
+++ b/internal/cli/stripe.go
@@ -141,7 +141,11 @@ func StripeStartForSite(siteName, sitePath, siteBaseURL string) error {
 	if apiKey == "" {
 		return fmt.Errorf("STRIPE_SECRET not set in %s/.env", sitePath)
 	}
-	return stripeStartExplicit(siteName, apiKey, siteBaseURL+"/stripe/webhook")
+	if err := stripeStartExplicit(siteName, apiKey, siteBaseURL+"/stripe/webhook"); err != nil {
+		return err
+	}
+	_ = config.AddProjectWorker(sitePath, "stripe")
+	return nil
 }
 
 // StripeStopForSite stops and removes the Stripe listener for the named site.

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -262,6 +262,12 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 		regenNginxVhost(siteName, sitePath)
 	}
 
+	// Persist this worker to .lerd.yaml so lerd install can restore it.
+	// Additive: other workers already in the list are not removed. This covers
+	// callers like setup and pause that start workers sequentially and must not
+	// clobber each other's entries.
+	_ = config.AddProjectWorker(sitePath, workerName)
+
 	return nil
 }
 

--- a/internal/config/project_update.go
+++ b/internal/config/project_update.go
@@ -42,6 +42,19 @@ func SetProjectWorkers(dir string, workers []string) error {
 	})
 }
 
+// AddProjectWorker appends name to the workers list if not already present.
+// No-op if .lerd.yaml does not exist.
+func AddProjectWorker(dir, name string) error {
+	return updateProjectConfig(dir, func(cfg *ProjectConfig) {
+		for _, w := range cfg.Workers {
+			if w == name {
+				return
+			}
+		}
+		cfg.Workers = append(cfg.Workers, name)
+	})
+}
+
 // SetProjectDomains replaces the domains list. No-op if .lerd.yaml does not exist.
 func SetProjectDomains(dir string, domains []string) error {
 	return updateProjectConfig(dir, func(cfg *ProjectConfig) {

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -26,6 +26,11 @@ type Site struct {
 	// (`<scheme>://<primary-domain>`). Use this for personal customizations
 	// you don't want to share via .lerd.yaml.
 	AppURL string `yaml:"app_url,omitempty"`
+	// LANPort, when non-zero, means a host-level reverse proxy is (or should
+	// be) listening on 0.0.0.0:LANPort, forwarding to the site with the Host
+	// header rewritten. LAN devices can reach the site at <lanIP>:LANPort
+	// without any DNS configuration.
+	LANPort int `yaml:"lan_port,omitempty"`
 }
 
 // PrimaryDomain returns the first (primary) domain for the site.
@@ -62,6 +67,7 @@ type siteYAML struct {
 	Framework     string   `yaml:"framework,omitempty"`
 	PublicDir     string   `yaml:"public_dir,omitempty"`
 	AppURL        string   `yaml:"app_url,omitempty"`
+	LANPort       int      `yaml:"lan_port,omitempty"`
 }
 
 func (s Site) toYAML() siteYAML {
@@ -78,6 +84,7 @@ func (s Site) toYAML() siteYAML {
 		Framework:     s.Framework,
 		PublicDir:     s.PublicDir,
 		AppURL:        s.AppURL,
+		LANPort:       s.LANPort,
 	}
 }
 
@@ -99,6 +106,7 @@ func (sy siteYAML) toSite() Site {
 		Framework:     sy.Framework,
 		PublicDir:     sy.PublicDir,
 		AppURL:        sy.AppURL,
+		LANPort:       sy.LANPort,
 	}
 }
 

--- a/internal/podman/cache.go
+++ b/internal/podman/cache.go
@@ -1,0 +1,132 @@
+package podman
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ContainerCache polls podman for container states on a configurable interval
+// and serves reads from an in-memory snapshot. One background goroutine does
+// all the work; every other caller reads from the map without spawning any
+// subprocesses.
+type ContainerCache struct {
+	mu      sync.RWMutex
+	running map[string]bool
+	started bool
+
+	intervalMu sync.Mutex
+	interval   time.Duration
+
+	// refresh is signalled to trigger an immediate out-of-cycle refresh
+	// (e.g. after a container start/stop mutation).
+	refresh chan struct{}
+
+	// pollFn fetches container states; defaults to the real podman ps call.
+	// Swappable in tests.
+	pollFn func() (string, error)
+}
+
+func defaultPollFn() (string, error) {
+	return Run("ps", "-a",
+		"--filter", "name=lerd-",
+		"--format", "{{.Names}}\t{{.State}}")
+}
+
+// Cache is the process-wide container state store. Start it once from serve-ui;
+// CLI commands that don't call Start fall back to direct podman inspect.
+var Cache = &ContainerCache{
+	running:  make(map[string]bool),
+	interval: 15 * time.Second,
+	refresh:  make(chan struct{}, 1),
+	pollFn:   defaultPollFn,
+}
+
+// Start launches the background refresh loop. Safe to call only once.
+func (c *ContainerCache) Start(ctx context.Context) {
+	c.mu.Lock()
+	c.started = true
+	c.mu.Unlock()
+
+	c.poll() // initial population before returning
+	go c.loop(ctx)
+}
+
+// Running returns true if the named container is currently running.
+// If the cache has not been started (CLI context), it falls back to a direct
+// podman inspect so one-off commands still work correctly.
+func (c *ContainerCache) Running(name string) bool {
+	c.mu.RLock()
+	started := c.started
+	v := c.running[name]
+	c.mu.RUnlock()
+
+	if !started {
+		running, _ := ContainerRunning(name)
+		return running
+	}
+	return v
+}
+
+// Refresh schedules an immediate re-poll. Safe to call from any goroutine.
+// Returns without blocking; at most one pending refresh is queued.
+func (c *ContainerCache) Refresh() {
+	select {
+	case c.refresh <- struct{}{}:
+	default:
+	}
+}
+
+// SetInterval changes the background polling interval. Safe to call from any goroutine.
+func (c *ContainerCache) SetInterval(d time.Duration) {
+	c.intervalMu.Lock()
+	c.interval = d
+	c.intervalMu.Unlock()
+}
+
+func (c *ContainerCache) loop(ctx context.Context) {
+	for {
+		c.intervalMu.Lock()
+		d := c.interval
+		c.intervalMu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(d):
+			c.poll()
+		case <-c.refresh:
+			c.poll()
+		}
+	}
+}
+
+// poll runs a single podman ps and updates the running map.
+// One subprocess per cycle instead of one per container.
+func (c *ContainerCache) poll() {
+	out, err := c.pollFn()
+
+	fresh := make(map[string]bool)
+	if err == nil {
+		for _, line := range strings.Split(out, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			parts := strings.SplitN(line, "\t", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			name := strings.TrimSpace(parts[0])
+			state := strings.ToLower(strings.TrimSpace(parts[1]))
+			fresh[name] = strings.HasPrefix(state, "running")
+		}
+	}
+	// On error (e.g. machine stopped) fresh is empty — all containers appear
+	// as not running, which is the correct observed state.
+
+	c.mu.Lock()
+	c.running = fresh
+	c.mu.Unlock()
+}

--- a/internal/podman/cache.go
+++ b/internal/podman/cache.go
@@ -69,13 +69,20 @@ func (c *ContainerCache) Running(name string) bool {
 	return v
 }
 
-// Refresh schedules an immediate re-poll. Safe to call from any goroutine.
+// Refresh schedules an immediate re-poll on the background goroutine.
 // Returns without blocking; at most one pending refresh is queued.
 func (c *ContainerCache) Refresh() {
 	select {
 	case c.refresh <- struct{}{}:
 	default:
 	}
+}
+
+// PollNow runs a synchronous poll and updates the in-memory state before
+// returning. Use this when the caller needs current data immediately (e.g.
+// the initial WebSocket snapshot). Unlike Refresh, it blocks until done.
+func (c *ContainerCache) PollNow() {
+	c.poll()
 }
 
 // SetInterval changes the background polling interval. Safe to call from any goroutine.

--- a/internal/podman/cache_test.go
+++ b/internal/podman/cache_test.go
@@ -1,0 +1,244 @@
+package podman
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestCache returns a fresh ContainerCache with a custom poll function.
+func newTestCache(pollFn func() (string, error)) *ContainerCache {
+	return &ContainerCache{
+		running:  make(map[string]bool),
+		interval: 10 * time.Second,
+		refresh:  make(chan struct{}, 1),
+		pollFn:   pollFn,
+	}
+}
+
+func TestPollParsesRunningContainers(t *testing.T) {
+	c := newTestCache(func() (string, error) {
+		return "lerd-nginx\trunning\nlerd-mysql\texited\nlerd-redis\tRunning Up 2h", nil
+	})
+	c.started = true
+	c.poll()
+
+	if !c.Running("lerd-nginx") {
+		t.Error("lerd-nginx should be running")
+	}
+	if c.Running("lerd-mysql") {
+		t.Error("lerd-mysql should not be running (exited)")
+	}
+	if !c.Running("lerd-redis") {
+		t.Error("lerd-redis should be running (Running prefix, mixed case)")
+	}
+	if c.Running("lerd-postgres") {
+		t.Error("lerd-postgres should not be running (not in output)")
+	}
+}
+
+func TestPollEmptyOutputClearsState(t *testing.T) {
+	c := newTestCache(func() (string, error) {
+		return "lerd-nginx\trunning", nil
+	})
+	c.started = true
+	c.poll()
+	if !c.Running("lerd-nginx") {
+		t.Fatal("expected running after first poll")
+	}
+
+	// Simulate podman machine stopped: empty output (but no error).
+	c.pollFn = func() (string, error) { return "", nil }
+	c.poll()
+	if c.Running("lerd-nginx") {
+		t.Error("should not be running after empty poll (machine stopped)")
+	}
+}
+
+func TestPollErrorKeepsLastState(t *testing.T) {
+	// On error (e.g. VM booting) the cache should go to all-false (safe default).
+	calls := 0
+	c := newTestCache(func() (string, error) {
+		calls++
+		if calls == 1 {
+			return "lerd-nginx\trunning", nil
+		}
+		return "", errors.New("podman machine unreachable")
+	})
+	c.started = true
+	c.poll() // first poll: nginx running
+	if !c.Running("lerd-nginx") {
+		t.Fatal("expected running after first poll")
+	}
+
+	c.poll() // second poll: error — fresh map is empty
+	if c.Running("lerd-nginx") {
+		t.Error("on error the cache should clear (all containers appear stopped)")
+	}
+}
+
+func TestRunningUsesMapWhenStarted(t *testing.T) {
+	// When started=true, Running() must read from the map, never calling
+	// ContainerRunning (which would spawn a real podman subprocess).
+	pollCalled := false
+	c := newTestCache(func() (string, error) {
+		pollCalled = true
+		return "lerd-nginx\trunning", nil
+	})
+	c.started = true
+	c.poll()
+
+	if !pollCalled {
+		t.Fatal("expected poll to be called")
+	}
+	if !c.Running("lerd-nginx") {
+		t.Error("lerd-nginx should be running from cache")
+	}
+	if c.Running("lerd-notexist") {
+		t.Error("unknown container should not be running")
+	}
+}
+
+func TestRefreshTriggersImmediatePoll(t *testing.T) {
+	polled := make(chan struct{}, 10)
+	c := newTestCache(func() (string, error) {
+		polled <- struct{}{}
+		return "lerd-nginx\trunning", nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c.mu.Lock()
+	c.started = true
+	c.mu.Unlock()
+
+	// Use a very long interval so the timer doesn't fire during the test.
+	c.interval = 10 * time.Minute
+	go c.loop(ctx)
+	// Drain the initial poll that loop() does not perform (we call poll directly).
+
+	// Signal a refresh.
+	c.Refresh()
+
+	select {
+	case <-polled:
+		// good — poll was triggered
+	case <-time.After(2 * time.Second):
+		t.Error("Refresh() did not trigger a poll within 2s")
+	}
+}
+
+func TestSetIntervalTakeEffect(t *testing.T) {
+	polled := 0
+	var mu sync.Mutex
+	c := newTestCache(func() (string, error) {
+		mu.Lock()
+		polled++
+		mu.Unlock()
+		return "", nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c.mu.Lock()
+	c.started = true
+	c.mu.Unlock()
+
+	c.interval = 50 * time.Millisecond
+	go c.loop(ctx)
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	mu.Lock()
+	count := polled
+	mu.Unlock()
+
+	// With 50ms interval over 200ms we expect ~3-4 polls (not 0, not hundreds).
+	if count < 2 || count > 10 {
+		t.Errorf("expected 2-10 polls in 200ms with 50ms interval, got %d", count)
+	}
+
+	// Now verify SetInterval slows things down.
+	polled = 0
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	c.SetInterval(10 * time.Second)
+	c.mu.Lock()
+	c.started = true
+	c.mu.Unlock()
+	go c.loop(ctx2)
+
+	time.Sleep(200 * time.Millisecond)
+	cancel2()
+
+	mu.Lock()
+	count2 := polled
+	mu.Unlock()
+	if count2 > 2 {
+		t.Errorf("expected ≤2 polls in 200ms with 10s interval, got %d", count2)
+	}
+}
+
+func TestConcurrentReads(t *testing.T) {
+	c := newTestCache(func() (string, error) {
+		return "lerd-nginx\trunning\nlerd-mysql\texited", nil
+	})
+	c.started = true
+	c.poll()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = c.Running("lerd-nginx")
+			_ = c.Running("lerd-mysql")
+			_ = c.Running("lerd-redis")
+		}()
+	}
+	wg.Wait()
+}
+
+func TestConcurrentPollAndRead(t *testing.T) {
+	// Ensure no data race between background poll and concurrent reads.
+	var callsMu sync.Mutex
+	calls := 0
+	c := newTestCache(func() (string, error) {
+		callsMu.Lock()
+		calls++
+		n := calls
+		callsMu.Unlock()
+		if n%2 == 0 {
+			return "lerd-nginx\trunning", nil
+		}
+		return "lerd-mysql\trunning", nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c.mu.Lock()
+	c.started = true
+	c.mu.Unlock()
+	c.interval = 10 * time.Millisecond
+	go c.loop(ctx)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				_ = c.Running("lerd-nginx")
+				_ = c.Running("lerd-mysql")
+			}
+		}()
+	}
+	wg.Wait()
+}
+

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -664,7 +664,7 @@ func (m *darwinServiceManager) Disable(name string) error {
 // IsActive returns true if the service is currently running.
 // For container units we also check the container directly.
 func (m *darwinServiceManager) IsActive(name string) bool {
-	if running, _ := podman.ContainerRunning(name); running {
+	if podman.Cache.Running(name) {
 		return true
 	}
 	domain := uidDomain()
@@ -693,7 +693,7 @@ func (m *darwinServiceManager) UnitStatus(name string) (string, error) {
 	out, err := launchctl("print", domain+"/"+label)
 	if err != nil {
 		// Not loaded at all — check container directly before giving up.
-		if running, _ := podman.ContainerRunning(name); running {
+		if podman.Cache.Running(name) {
 			return "active", nil
 		}
 		if _, statErr := os.Stat(plistPath(name)); statErr == nil {
@@ -707,7 +707,7 @@ func (m *darwinServiceManager) UnitStatus(name string) (string, error) {
 	}
 	// For exited-0 or waiting: the job may be a container launcher that
 	// succeeded (-d detach). Check the actual container state.
-	if running, _ := podman.ContainerRunning(name); running {
+	if podman.Cache.Running(name) {
 		return "active", nil
 	}
 	if strings.Contains(s, "state = waiting") || strings.Contains(s, "last exit code = 0") {

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -346,32 +346,32 @@ func (e *EnrichedSite) enrichWorkers(fw *config.Framework, hasFw bool) {
 	if fw.HasWorker("queue", e.Path) && !suppressed["queue"] {
 		e.HasQueueWorker = true
 		status, _ := unitStatusFn("lerd-queue-" + e.Name)
-		e.QueueRunning = status == "active"
-		e.QueueFailing = status == "activating" || status == "failed"
+		e.QueueRunning = status == "active" || status == "activating"
+		e.QueueFailing = status == "failed"
 	}
 	if fw.HasWorker("schedule", e.Path) && !suppressed["schedule"] {
 		e.HasScheduleWorker = true
 		status, _ := unitStatusFn("lerd-schedule-" + e.Name)
 		// Timer-driven scheduler: .service is static between firings.
-		if status != "active" {
+		if status != "active" && status != "activating" {
 			if t, _ := unitStatusFn("lerd-schedule-" + e.Name + ".timer"); t == "active" {
 				status = "active"
 			}
 		}
-		e.ScheduleRunning = status == "active"
-		e.ScheduleFailing = status == "activating" || status == "failed"
+		e.ScheduleRunning = status == "active" || status == "activating"
+		e.ScheduleFailing = status == "failed"
 	}
 	if fw.HasWorker("reverb", e.Path) && !suppressed["reverb"] {
 		e.HasReverb = true
 		status, _ := unitStatusFn("lerd-reverb-" + e.Name)
-		e.ReverbRunning = status == "active"
-		e.ReverbFailing = status == "activating" || status == "failed"
+		e.ReverbRunning = status == "active" || status == "activating"
+		e.ReverbFailing = status == "failed"
 	}
 	if fw.HasWorker("horizon", e.Path) && !suppressed["horizon"] {
 		e.HasHorizon = true
 		status, _ := unitStatusFn("lerd-horizon-" + e.Name)
-		e.HorizonRunning = status == "active"
-		e.HorizonFailing = status == "activating" || status == "failed"
+		e.HorizonRunning = status == "active" || status == "activating"
+		e.HorizonFailing = status == "failed"
 		e.HasQueueWorker = false // Horizon manages queues
 	}
 
@@ -401,8 +401,8 @@ func (e *EnrichedSite) enrichWorkers(fw *config.Framework, hasFw bool) {
 		e.FrameworkWorkers = append(e.FrameworkWorkers, WorkerInfo{
 			Name:    wname,
 			Label:   label,
-			Running: unitStatus == "active",
-			Failing: unitStatus == "activating" || unitStatus == "failed",
+			Running: unitStatus == "active" || unitStatus == "activating",
+			Failing: unitStatus == "failed",
 		})
 	}
 }

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -112,6 +112,9 @@ type EnrichedSite struct {
 	// Services
 	Services []string
 
+	// LAN sharing
+	LANPort int
+
 	// App metadata
 	HasAppLogs    bool
 	LatestLogTime string
@@ -206,6 +209,7 @@ func Enrich(s config.Site, flags EnrichFlag) EnrichedSite {
 		PausedWorkers:       s.PausedWorkers,
 		PublicDir:           s.PublicDir,
 		AppURL:              s.AppURL,
+		LANPort:             s.LANPort,
 		FrameworkName:       s.Framework,
 		OriginalPHPVersion:  s.PHPVersion,
 		OriginalNodeVersion: s.NodeVersion,

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -147,7 +147,9 @@ var faviconCandidates = []string{
 // no longer fans out into 125+ subprocesses per /api/sites request.
 var (
 	unitStatusFn       = unitStatusCached
-	containerRunningFn = podman.ContainerRunning
+	containerRunningFn = func(name string) (bool, error) {
+		return podman.Cache.Running(name), nil
+	}
 )
 
 // LoadAll loads all non-ignored sites and enriches them according to flags.

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -177,7 +177,7 @@ func runPoller(ctx context.Context, updateCh chan<- *Snapshot) {
 		}
 	}
 	send()
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 	for {
 		select {

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -2147,9 +2147,10 @@ function lerdApp() {
       this.loadServices();
       this.loadPresets();
       this.loadStatus();
+      this._pollInterval = () => document.hidden ? 60000 : 15000;
       this._startPollFallback = () => {
         if (this._statusInterval) return;
-        this._statusInterval = setInterval(() => {
+        const poll = () => {
           this.loadSites();
           if (this.tab === 'services') { this.loadServices(); }
           if (this.tab === 'system') {
@@ -2158,14 +2159,35 @@ function lerdApp() {
             this.loadLANStatus();
             this.loadRemoteControl();
           }
-        }, 5000);
+        };
+        const schedule = () => {
+          this._statusInterval = setTimeout(() => {
+            poll();
+            schedule();
+          }, this._pollInterval());
+        };
+        schedule();
       };
       this._stopPollFallback = () => {
         if (this._statusInterval) {
-          clearInterval(this._statusInterval);
+          clearTimeout(this._statusInterval);
           this._statusInterval = null;
         }
       };
+      document.addEventListener('visibilitychange', () => {
+        if (this._ws && this._ws.readyState === WebSocket.OPEN) {
+          this._ws.send(JSON.stringify({type: 'visibility', visible: !document.hidden}));
+          if (!document.hidden) {
+            // Refresh immediately when tab regains focus in case state changed.
+            this.loadSites();
+            this.loadStatus();
+          }
+        } else if (this._statusInterval != null) {
+          // In fallback mode: restart with the new interval rate.
+          this._stopPollFallback();
+          this._startPollFallback();
+        }
+      });
       this._connectWS();
     },
 
@@ -2185,6 +2207,7 @@ function lerdApp() {
         ws.onopen = () => {
           this._wsBackoff = 1000;
           this._stopPollFallback();
+          ws.send(JSON.stringify({type: 'visibility', visible: !document.hidden}));
         };
         ws.onmessage = (e) => {
           let msg;

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -724,6 +724,31 @@
                     <span x-show="selectedSite.tlsError" class="text-[10px] text-red-500" x-text="selectedSite.tlsError"></span>
                   </div>
 
+                  <!-- LAN share -->
+                  <div class="flex items-center gap-1.5">
+                    <button @click="toggleLANShare(selectedSite)" :disabled="selectedSite.lanShareLoading" :title="selectedSite.lan_port ? 'Stop LAN sharing' : 'Share on LAN — other devices can reach this site at the shown IP:port without any DNS setup'"
+                      class="relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
+                      :class="selectedSite.lan_port ? 'bg-teal-500' : 'bg-gray-300 dark:bg-lerd-muted'">
+                      <span class="inline-block h-3 w-3 rounded-full bg-white shadow transition-transform duration-200" :class="selectedSite.lan_port ? 'translate-x-3.5' : 'translate-x-0.5'"></span>
+                      <svg x-show="selectedSite.lanShareLoading" class="animate-spin absolute right-[-14px] w-2.5 h-2.5 text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                    </button>
+                    <span class="text-xs text-gray-500 dark:text-gray-400">LAN</span>
+                    <template x-if="selectedSite.lan_share_url">
+                      <div x-data="{ showQR: false, qrX: 0, qrY: 0 }"
+                           @mouseenter="let r = $el.getBoundingClientRect(); qrX = r.left; qrY = r.bottom + 4; showQR = true"
+                           @mouseleave="showQR = false">
+                        <a :href="selectedSite.lan_share_url" target="_blank" class="text-[10px] text-teal-600 dark:text-teal-400 font-mono hover:underline" x-text="selectedSite.lan_share_url"></a>
+                        <div x-show="showQR" :style="`position:fixed; left:${qrX}px; top:${qrY}px; z-index:9999`"
+                             class="p-1.5 bg-white dark:bg-lerd-card rounded shadow-lg border border-gray-200 dark:border-lerd-border">
+                          <img :src="apiBase + '/api/lan-qr/' + selectedSite.domain" width="160" height="160" alt="QR code">
+                        </div>
+                      </div>
+                    </template>
+                    <span x-show="selectedSite.lanShareError" class="text-[10px] text-red-500" x-text="selectedSite.lanShareError"></span>
+                  </div>
+
+                  <div class="w-px h-4 bg-gray-200 dark:bg-lerd-border mx-0.5"></div>
+
                   <!-- Queue -->
                   <div x-show="selectedSite.has_queue_worker" class="flex items-center gap-1.5">
                     <button @click="toggleQueue(selectedSite)" :disabled="selectedSite.queueLoading" :title="selectedSite.queue_failing ? 'Queue worker is failing — click to restart' : selectedSite.queue_running ? 'Stop queue worker' : 'Start queue worker'"
@@ -2575,6 +2600,7 @@ function lerdApp() {
         scheduleLoading: false, scheduleError: '',
         reverbLoading: false, reverbError: '',
         horizonLoading: false, horizonError: '',
+        lanShareLoading: false, lanShareError: '',
         unlinkLoading: false, pauseLoading: false,
         framework_workers: (s.framework_workers || []).map(w => ({ ...w, loading: false, error: '' })),
       });
@@ -2613,6 +2639,8 @@ function lerdApp() {
           e.latest_log_time = s.latest_log_time;
           e.branch = s.branch;
           e.paused = s.paused;
+          e.lan_port = s.lan_port;
+          e.lan_share_url = s.lan_share_url;
           if (s.framework_workers) {
             if (e.framework_workers) {
               s.framework_workers.forEach(sw => {
@@ -3662,6 +3690,23 @@ function lerdApp() {
         site.reverbError = e.message || 'Request failed';
       } finally {
         site.reverbLoading = false;
+      }
+    },
+
+    async toggleLANShare(site) {
+      site.lanShareLoading = true;
+      site.lanShareError = '';
+      try {
+        const action = site.lan_port ? 'lan:unshare' : 'lan:share';
+        const res = await fetch(`/api/sites/${site.domain}/${action}`, { method: 'POST' });
+        const data = await res.json();
+        if (!data.ok) {
+          site.lanShareError = data.error || 'Failed';
+        }
+      } catch (e) {
+        site.lanShareError = e.message || 'Request failed';
+      } finally {
+        site.lanShareLoading = false;
       }
     },
 

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -139,11 +139,19 @@ func Start(currentVersion string) error {
 	podman.Cache.Start(context.Background())
 
 	podman.AfterUnitChange = func(name string) {
-		podman.Cache.Refresh() // bring the cache up-to-date after any mutation
-		siteinfo.InvalidateUnitCache()
-		eventbus.Default.Publish(eventbus.KindSites)
-		eventbus.Default.Publish(eventbus.KindServices)
-		eventbus.Default.Publish(eventbus.KindStatus)
+		// Run the poll and snapshot publish in a goroutine so the HTTP
+		// handler (and the unit start/stop call that triggered this) returns
+		// immediately. PollNow blocks until podman ps completes, ensuring
+		// the snapshot broadcast carries current container states rather than
+		// a stale pre-mutation value — which would cause the UI toggle to
+		// appear to revert.
+		go func() {
+			podman.Cache.PollNow()
+			siteinfo.InvalidateUnitCache()
+			eventbus.Default.Publish(eventbus.KindSites)
+			eventbus.Default.Publish(eventbus.KindServices)
+			eventbus.Default.Publish(eventbus.KindStatus)
+		}()
 	}
 
 	// A single goroutine subscribes to the eventbus and invalidates the

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -131,7 +132,14 @@ func Start(currentVersion string) error {
 	// pushes a fresh snapshot to every connected browser. The bus debounces,
 	// so bursty mutations (e.g. restarting a set of workers) still collapse
 	// into one broadcast.
+	// Start the container state cache. One background goroutine polls
+	// podman ps every N seconds; all hot paths (buildStatus, siteinfo,
+	// IsActive) read from the cache instead of spawning per-container
+	// podman inspect subprocesses.
+	podman.Cache.Start(context.Background())
+
 	podman.AfterUnitChange = func(name string) {
+		podman.Cache.Refresh() // bring the cache up-to-date after any mutation
 		siteinfo.InvalidateUnitCache()
 		eventbus.Default.Publish(eventbus.KindSites)
 		eventbus.Default.Publish(eventbus.KindServices)
@@ -379,14 +387,14 @@ func buildStatus() StatusResponse {
 	}
 
 	dnsOK, _ := dns.Check(tld)
-	nginxRunning, _ := podman.ContainerRunning("lerd-nginx")
+	nginxRunning := podman.Cache.Running("lerd-nginx")
 	watcherRunning := services.Mgr.IsActive("lerd-watcher")
 
 	versions, _ := phpPkg.ListInstalled()
 	var phpStatuses []PHPStatus
 	for _, v := range versions {
 		short := strings.ReplaceAll(v, ".", "")
-		running, _ := podman.ContainerRunning("lerd-php" + short + "-fpm")
+		running := podman.Cache.Running("lerd-php" + short + "-fpm")
 		xdebugEnabled := cfg != nil && cfg.IsXdebugEnabled(v)
 		phpStatuses = append(phpStatuses, PHPStatus{Version: v, Running: running, XdebugEnabled: xdebugEnabled})
 	}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -16,6 +17,8 @@ import (
 	"time"
 
 	_ "embed"
+
+	qrcode "github.com/skip2/go-qrcode"
 
 	"github.com/geodro/lerd/internal/applog"
 	"github.com/geodro/lerd/internal/certs"
@@ -138,6 +141,9 @@ func Start(currentVersion string) error {
 	// podman inspect subprocesses.
 	podman.Cache.Start(context.Background())
 
+	// Restart any LAN share proxies that were active before this process started.
+	go cli.RestoreLANShareProxies()
+
 	podman.AfterUnitChange = func(name string) {
 		// Run the poll and snapshot publish in a goroutine so the HTTP
 		// handler (and the unit start/stop call that triggered this) returns
@@ -165,6 +171,7 @@ func Start(currentVersion string) error {
 	mux.HandleFunc("/api/sites", withCORS(handleSites))
 	mux.HandleFunc("/api/services", withCORS(handleServices))
 	mux.HandleFunc("/api/ws", handleWS)
+	mux.HandleFunc("/api/lan-qr/", withCORS(handleLANQR))
 
 	// Cross-process notifier: the CLI and MCP processes run outside
 	// lerd-ui and can't publish to the in-process eventbus. They POST
@@ -487,7 +494,9 @@ type SiteResponse struct {
 	// Services lists the service names this site uses, sourced from the
 	// project's .lerd.yaml. Used by the dashboard to render service badges
 	// on the site detail panel.
-	Services []string `json:"services,omitempty"`
+	Services    []string `json:"services,omitempty"`
+	LANPort     int      `json:"lan_port,omitempty"`
+	LANShareURL string   `json:"lan_share_url,omitempty"`
 }
 
 func handleSites(w http.ResponseWriter, _ *http.Request) {
@@ -571,6 +580,8 @@ func buildSites() []SiteResponse {
 			Branch:             e.Branch,
 			Worktrees:          worktreeResponses,
 			Services:           e.Services,
+			LANPort:            e.LANPort,
+			LANShareURL:        cli.LANShareURL(e.LANPort),
 		})
 	}
 	return sites
@@ -1333,6 +1344,30 @@ func handleSiteFavicon(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, path)
 }
 
+// handleLANQR serves a QR code PNG for the LAN share URL of a site.
+// Path: /api/lan-qr/{domain}
+func handleLANQR(w http.ResponseWriter, r *http.Request) {
+	domain := strings.TrimPrefix(r.URL.Path, "/api/lan-qr/")
+	site, err := config.FindSiteByDomain(domain)
+	if err != nil || site.LANPort == 0 {
+		http.NotFound(w, r)
+		return
+	}
+	shareURL := cli.LANShareURL(site.LANPort)
+	if shareURL == "" {
+		http.NotFound(w, r)
+		return
+	}
+	png, err := qrcode.Encode(shareURL, qrcode.Medium, 160)
+	if err != nil {
+		http.Error(w, "qr encode: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "image/png")
+	w.Header().Set("Cache-Control", "no-cache")
+	http.ServeContent(w, r, "qr.png", time.Time{}, bytes.NewReader(png))
+}
+
 // SiteActionResponse is returned by POST /api/sites/{domain}/secure|unsecure.
 type SiteActionResponse struct {
 	OK    bool   `json:"ok"`
@@ -1535,6 +1570,20 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		}
 		if !site.Paused {
 			_ = config.SetProjectWorkers(site.Path, cli.CollectRunningWorkerNames(site))
+		}
+		writeJSON(w, SiteActionResponse{OK: true})
+		return
+	case "lan:share":
+		if _, err := cli.LANShareStart(site.Name); err != nil {
+			writeJSON(w, SiteActionResponse{Error: err.Error()})
+			return
+		}
+		writeJSON(w, SiteActionResponse{OK: true})
+		return
+	case "lan:unshare":
+		if err := cli.LANShareStop(site.Name); err != nil {
+			writeJSON(w, SiteActionResponse{Error: err.Error()})
+			return
 		}
 		writeJSON(w, SiteActionResponse{OK: true})
 		return

--- a/internal/ui/snapshot.go
+++ b/internal/ui/snapshot.go
@@ -11,7 +11,7 @@ import (
 // request triggers a rebuild. Mutations that change state call
 // eventbus.Default.Publish, which invalidates the relevant kind so the next
 // read recomputes immediately.
-const snapshotTTL = 2 * time.Second
+const snapshotTTL = 15 * time.Second
 
 // snapshotCache holds cached JSON bytes of the last /api/sites, /api/services,
 // and /api/status responses. Handlers read from here instead of rebuilding
@@ -22,20 +22,41 @@ type snapshotCache struct {
 
 	sites, services, status       []byte
 	sitesAt, servicesAt, statusAt time.Time
+
+	// One build-mutex per kind serialises concurrent rebuilds so that when
+	// podman inspect is slow, goroutines queue behind one in-flight rebuild
+	// rather than each spawning their own batch of subprocesses.
+	sitesBuild, servicesBuild, statusBuild sync.Mutex
 }
 
 var snapshots = &snapshotCache{}
 
 // Sites returns cached /api/sites JSON, rebuilding if stale.
+// If a rebuild is already in progress, returns the stale value immediately
+// rather than queuing behind the in-flight build.
 func (c *snapshotCache) Sites() []byte {
 	c.mu.Lock()
-	fresh := c.sites != nil && time.Since(c.sitesAt) < snapshotTTL
-	c.mu.Unlock()
-	if fresh {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		return c.sites
+	if c.sites != nil && time.Since(c.sitesAt) < snapshotTTL {
+		b := c.sites
+		c.mu.Unlock()
+		return b
 	}
+	stale := c.sites
+	c.mu.Unlock()
+
+	if !c.sitesBuild.TryLock() {
+		return stale
+	}
+	defer c.sitesBuild.Unlock()
+
+	c.mu.Lock()
+	if c.sites != nil && time.Since(c.sitesAt) < snapshotTTL {
+		b := c.sites
+		c.mu.Unlock()
+		return b
+	}
+	c.mu.Unlock()
+
 	b := buildSitesJSON()
 	c.mu.Lock()
 	c.sites = b
@@ -45,15 +66,31 @@ func (c *snapshotCache) Sites() []byte {
 }
 
 // Services returns cached /api/services JSON, rebuilding if stale.
+// If a rebuild is already in progress, returns the stale value immediately
+// rather than queuing behind the in-flight build.
 func (c *snapshotCache) Services() []byte {
 	c.mu.Lock()
-	fresh := c.services != nil && time.Since(c.servicesAt) < snapshotTTL
-	c.mu.Unlock()
-	if fresh {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		return c.services
+	if c.services != nil && time.Since(c.servicesAt) < snapshotTTL {
+		b := c.services
+		c.mu.Unlock()
+		return b
 	}
+	stale := c.services
+	c.mu.Unlock()
+
+	if !c.servicesBuild.TryLock() {
+		return stale
+	}
+	defer c.servicesBuild.Unlock()
+
+	c.mu.Lock()
+	if c.services != nil && time.Since(c.servicesAt) < snapshotTTL {
+		b := c.services
+		c.mu.Unlock()
+		return b
+	}
+	c.mu.Unlock()
+
 	b := buildServicesJSON()
 	c.mu.Lock()
 	c.services = b
@@ -63,15 +100,31 @@ func (c *snapshotCache) Services() []byte {
 }
 
 // Status returns cached /api/status JSON, rebuilding if stale.
+// If a rebuild is already in progress, returns the stale value immediately
+// rather than queuing behind the in-flight build.
 func (c *snapshotCache) Status() []byte {
 	c.mu.Lock()
-	fresh := c.status != nil && time.Since(c.statusAt) < snapshotTTL
-	c.mu.Unlock()
-	if fresh {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		return c.status
+	if c.status != nil && time.Since(c.statusAt) < snapshotTTL {
+		b := c.status
+		c.mu.Unlock()
+		return b
 	}
+	stale := c.status
+	c.mu.Unlock()
+
+	if !c.statusBuild.TryLock() {
+		return stale
+	}
+	defer c.statusBuild.Unlock()
+
+	c.mu.Lock()
+	if c.status != nil && time.Since(c.statusAt) < snapshotTTL {
+		b := c.status
+		c.mu.Unlock()
+		return b
+	}
+	c.mu.Unlock()
+
 	b := buildStatusJSON()
 	c.mu.Lock()
 	c.status = b

--- a/internal/ui/visibility_test.go
+++ b/internal/ui/visibility_test.go
@@ -1,0 +1,64 @@
+package ui
+
+import (
+	"testing"
+)
+
+func TestNoteVisibilityCounter(t *testing.T) {
+	// Reset global state before and after test so other tests aren't affected.
+	visibleClients.Store(0)
+	t.Cleanup(func() { visibleClients.Store(0) })
+
+	noteVisibility(true) // 1
+	noteVisibility(true) // 2
+	if v := visibleClients.Load(); v != 2 {
+		t.Errorf("expected 2 visible clients, got %d", v)
+	}
+
+	noteVisibility(false) // 1 — should NOT change interval to idle yet
+	if v := visibleClients.Load(); v != 1 {
+		t.Errorf("expected 1 visible client after one decrement, got %d", v)
+	}
+
+	noteVisibility(false) // 0 — now idle
+	if v := visibleClients.Load(); v != 0 {
+		t.Errorf("expected 0 visible clients, got %d", v)
+	}
+
+	// Extra decrement (simulates the double-decrement bug we fixed: browser
+	// sends visible=false then connection closes) must not go negative.
+	noteVisibility(false)
+	if v := visibleClients.Load(); v != 0 {
+		t.Errorf("counter should not go below 0, got %d", v)
+	}
+}
+
+func TestNoteVisibilityMultipleConnections(t *testing.T) {
+	visibleClients.Store(0)
+	t.Cleanup(func() { visibleClients.Store(0) })
+
+	// Simulate two connections: A visible, B visible.
+	noteVisibility(true) // A connects (assumed visible) → 1
+	noteVisibility(true) // B connects → 2
+
+	// A hides.
+	noteVisibility(false) // → 1 (B still visible, should stay at focused interval)
+	if v := visibleClients.Load(); v != 1 {
+		t.Errorf("expected 1 after A hides, got %d", v)
+	}
+
+	// A disconnects — with the fix, since connVisible is false for A, no
+	// extra decrement. We simulate the correct behaviour: no call.
+	// (The fixed handleWS only calls noteVisibility(false) on disconnect
+	// if the connection was still visible.)
+	// Counter should still be 1.
+	if v := visibleClients.Load(); v != 1 {
+		t.Errorf("disconnect of already-hidden A should not change counter; got %d", v)
+	}
+
+	// B disconnects while still visible → 0.
+	noteVisibility(false) // → 0
+	if v := visibleClients.Load(); v != 0 {
+		t.Errorf("expected 0 after B disconnects, got %d", v)
+	}
+}

--- a/internal/ui/ws.go
+++ b/internal/ui/ws.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/geodro/lerd/internal/eventbus"
 	"github.com/geodro/lerd/internal/podman"
 )
 
@@ -46,6 +47,16 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 
 	ch := broker.add()
 	defer broker.remove(ch)
+
+	// Force-refresh the container cache and invalidate all snapshot kinds so
+	// the first frame always reflects current container state, not a cached
+	// value from before lerd start ran. PollNow blocks until the podman ps
+	// completes, so the snapshot below is guaranteed to use fresh data even
+	// when multiple connections arrive simultaneously.
+	podman.Cache.PollNow()
+	snapshots.Invalidate(eventbus.KindSites)
+	snapshots.Invalidate(eventbus.KindServices)
+	snapshots.Invalidate(eventbus.KindStatus)
 
 	// Initial snapshot: assemble one JSON object containing all three kinds.
 	initial := assembleSnapshot(snapshots.Sites(), snapshots.Services(), snapshots.Status(), []string{"snapshot"})

--- a/internal/ui/ws.go
+++ b/internal/ui/ws.go
@@ -2,8 +2,35 @@ package ui
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/geodro/lerd/internal/podman"
 )
+
+// visibleClients tracks how many browser tabs currently report as visible.
+// When at least one tab is focused the cache polls more aggressively.
+var visibleClients atomic.Int32
+
+const (
+	intervalFocused = 15 * time.Second
+	intervalIdle    = 60 * time.Second
+)
+
+func noteVisibility(visible bool) {
+	if visible {
+		if visibleClients.Add(1) == 1 {
+			podman.Cache.SetInterval(intervalFocused)
+		}
+	} else {
+		if visibleClients.Add(-1) <= 0 {
+			visibleClients.Store(0)
+			podman.Cache.SetInterval(intervalIdle)
+		}
+	}
+}
 
 // handleWS upgrades the HTTP connection to a websocket and streams snapshot
 // updates to the client. The initial frame carries a full snapshot of sites,
@@ -26,8 +53,21 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Reader goroutine: handle ping/close frames, drop the channel on any
-	// error so the writer loop exits.
+	// connVisible tracks whether THIS connection is currently counted as
+	// visible. Only the reader goroutine writes it; the deferred cleanup
+	// reads it after the reader has exited (close(done) happens-before the
+	// <-done branch), so there is no data race.
+	connVisible := true
+	noteVisibility(true)
+	defer func() {
+		if connVisible {
+			noteVisibility(false)
+		}
+	}()
+
+	// Reader goroutine: handle ping/close/visibility frames.
+	// Visibility frames carry {"type":"visibility","visible":bool} and let
+	// the server tune the container cache polling interval.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -44,6 +84,15 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 			case wsOpClose:
 				_ = ws.WriteClose()
 				return
+			case wsOpText:
+				var msg struct {
+					Type    string `json:"type"`
+					Visible bool   `json:"visible"`
+				}
+				if json.Unmarshal(payload, &msg) == nil && msg.Type == "visibility" && msg.Visible != connVisible {
+					noteVisibility(msg.Visible)
+					connVisible = msg.Visible
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
Closes #179

## What

Adds `lerd lan:share` / `lerd lan:unshare` to expose a single site to other devices on the local network via a stable `http://IP:PORT` URL — no DNS setup or client configuration required.

## How it works

- Assigns a stable port per site (starting at 9100, saved in `sites.yaml`, reused across restarts)
- Starts a host-level HTTP reverse proxy inside the lerd-ui daemon that:
  - Rewrites the `Host` header so nginx routes to the correct vhost
  - Rewrites absolute URLs (`https://myapp.test/...` → `http://192.168.x.x:9100/...`) in HTML, CSS, and JS response bodies so assets and redirects work without DNS
  - Sets `Accept-Encoding: identity` on upstream requests and handles gzip decompression to ensure body rewriting is reliable
  - Rewrites `Location` headers on redirects
- CLI commands update `sites.yaml` and notify the running daemon via its HTTP API; proxy goroutine lives entirely in the daemon
- `RestoreLANShareProxies()` called on daemon start to restore any proxies saved in `sites.yaml`

## UI

- LAN toggle next to the HTTPS toggle in the dashboard, lightly separated from the worker toggles
- LAN URL shown inline; hovering shows a QR code in a `fixed`-positioned tooltip (escapes `overflow-x-auto` clipping on parent containers)
- QR images served by the daemon at `/api/lan-qr/{domain}`

## Terminal

Prints a compact half-block Unicode QR code after `lerd lan:share`:

```
Sharing myapp at http://192.168.1.42:9100
Other devices on the network can use that URL directly — no DNS setup needed.

█████████████████████████████████
...

Run 'lerd lan:unshare' to stop.
```

## Docs

- `docs/reference/commands.md` — new LAN section with `lan:share` / `lan:unshare` and `lan:expose` / `lan:unexpose` / `lan:status`
- `docs/usage/remote-development.md` — new LAN sharing section with usage, how it works, and a comparison table (LAN sharing vs full LAN exposure)