### PR TITLE
feat(lan): LAN sharing — per-site reverse proxy with QR code

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -147,6 +147,8 @@ func main() {
 	root.AddCommand(cli.NewLANExposeCmd())
 	root.AddCommand(cli.NewLANUnexposeCmd())
 	root.AddCommand(cli.NewLANStatusCmd())
+	root.AddCommand(cli.NewLANShareCmd())
+	root.AddCommand(cli.NewLANUnshareCmd())
 	root.AddCommand(cli.NewRemoteSetupCmd())
 	root.AddCommand(cli.NewRemoteControlCmd())
 	root.AddCommand(cli.NewRemoteControlOnCmd())

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -65,6 +65,29 @@ Setup steps include common tasks (composer install, npm install, lerd env) plus 
 | `lerd env` | Configure `.env` for the current project with lerd service connection settings |
 | `lerd env:check` | Compare all `.env` files against `.env.example` and flag missing or extra keys |
 
+## LAN
+
+### LAN sharing (per-site, no DNS setup required on clients)
+
+| Command | Description |
+|---|---|
+| `lerd lan:share` | Start a LAN reverse proxy for the current site on a stable port; prints the URL and a QR code |
+| `lerd lan:unshare` | Stop LAN sharing for the current site and release its port |
+
+The proxy runs inside the lerd daemon (`lerd-ui`) — no external tool needed and no internet access required. Any device on the same network can reach the site at `http://<your-LAN-IP>:<port>` without configuring DNS. The assigned port is stored in `sites.yaml` and reused across restarts. The proxy rewrites the Host header so nginx routes correctly, and rewrites absolute URLs in HTML/CSS/JS responses so asset and redirect URLs point to the LAN address instead of the `.test` domain. See [LAN sharing](/usage/remote-development#lan-sharing-per-site) for details.
+
+`lerd share` (without `lan:`) is different — it wraps an external tunnel tool (ngrok/cloudflared/Expose/SSH) to expose the site to the **public internet**.
+
+### Full LAN exposure (all sites, DNS-based)
+
+| Command | Description |
+|---|---|
+| `lerd lan:expose` | Expose all lerd services to the LAN — binds nginx to `0.0.0.0`, starts the DNS forwarder |
+| `lerd lan:unexpose` | Restrict everything back to `127.0.0.1` |
+| `lerd lan:status` | Show whether lerd is currently exposed to the local network |
+
+See [Remote / LAN Development](/usage/remote-development) for the full walkthrough.
+
 ## PHP
 
 | Command | Description |

--- a/docs/usage/remote-development.md
+++ b/docs/usage/remote-development.md
@@ -1,5 +1,51 @@
 # Remote / LAN Development
 
+## LAN sharing (per-site) {#lan-sharing-per-site}
+
+The quickest way to let another device on the same network reach one of your sites — no DNS setup, no external tools, no internet access required:
+
+```bash
+cd ~/Projects/myapp
+lerd lan:share
+```
+
+```
+Sharing myapp at http://192.168.1.42:9100
+Other devices on the network can use that URL directly — no DNS setup needed.
+
+█████████████████████████████████
+█ ▄▄▄▄▄ █▀▄ █▄█ ▀▀ ▄█ ▄▄▄▄▄ █
+...
+Run 'lerd lan:unshare' to stop.
+```
+
+What it does:
+
+- Assigns a stable port to the site (starting at 9100, incremented to avoid conflicts) and saves it in `sites.yaml`.
+- Starts a host-level reverse proxy inside the lerd daemon (`lerd-ui`) listening on `0.0.0.0:<port>`.
+- Rewrites the `Host` header on every request so nginx routes to the correct vhost.
+- Rewrites absolute URLs (`https://myapp.test/...` → `http://192.168.1.42:9100/...`) in HTML, CSS, and JS response bodies so assets and redirects work from the client device without a `.test` DNS resolver.
+- Prints a QR code you can scan to open the site on a phone.
+
+The port is reused across restarts. Stop sharing with `lerd lan:unshare`.
+
+The dashboard shows the LAN URL next to the HTTPS toggle for each site. Hovering the URL shows a QR code inline.
+
+### When to use LAN sharing vs full LAN exposure
+
+| | `lerd lan:share` | `lerd lan:expose` |
+|---|---|---|
+| Scope | One site at a time | All sites at once |
+| Client DNS setup | Not required — plain `IP:port` | Required (forward `.test` to lerd dnsmasq) |
+| Client cert trust | Not required | Required for HTTPS sites |
+| External tools | None | None |
+| Persists across restarts | Yes (port saved in `sites.yaml`) | Yes (`lan.exposed` in `config.yaml`) |
+| Use case | Quick demo to someone on the same wifi | Full remote dev setup (laptop + server) |
+
+---
+
+## Full LAN exposure (all sites, DNS-based)
+
 Lerd is designed to run on the machine you're developing from — install it, link a project, browse `myapp.test`, done. But there's a common variant of that workflow worth documenting: **the lerd server is a different machine from the one you're typing on**. Typical case: you have a beefier Linux box (desktop, NAS, mini PC) running the containers, and a laptop you carry around for editing.
 
 This page walks through the full setup so the laptop can browse `https://myapp.test` against a remote server with no per-site `/etc/hosts` maintenance and no certificate warnings.

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=

--- a/internal/certs/manager.go
+++ b/internal/certs/manager.go
@@ -59,4 +59,3 @@ func CertExists(domain string) bool {
 	_, err := os.Stat(certFile)
 	return err == nil
 }
-

--- a/internal/certs/manager.go
+++ b/internal/certs/manager.go
@@ -59,3 +59,4 @@ func CertExists(domain string) bool {
 	_, err := os.Stat(certFile)
 	return err == nil
 }
+

--- a/internal/cli/lan.go
+++ b/internal/cli/lan.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"net/http"
+	"os"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/spf13/cobra"
@@ -34,6 +36,8 @@ sites. Run 'lerd lan:expose off' to revert.`,
 	cmd.AddCommand(newLANExposeCmd())
 	cmd.AddCommand(newLANUnexposeCmd())
 	cmd.AddCommand(newLANStatusCmd())
+	cmd.AddCommand(newLANShareCmd())
+	cmd.AddCommand(newLANUnshareCmd())
 	return cmd
 }
 
@@ -58,6 +62,20 @@ func NewLANStatusCmd() *cobra.Command {
 	cmd := newLANStatusCmd()
 	cmd.Use = "lan:status"
 	cmd.Hidden = true
+	return cmd
+}
+
+// NewLANShareCmd returns the `lerd lan:share` colon-style alias.
+func NewLANShareCmd() *cobra.Command {
+	cmd := newLANShareCmd()
+	cmd.Use = "lan:share"
+	return cmd
+}
+
+// NewLANUnshareCmd returns the `lerd lan:unshare` colon-style alias.
+func NewLANUnshareCmd() *cobra.Command {
+	cmd := newLANUnshareCmd()
+	cmd.Use = "lan:unshare"
 	return cmd
 }
 
@@ -126,6 +144,99 @@ func newLANUnexposeCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func newLANShareCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "share",
+		Short: "Share the current site on a stable LAN port (no DNS setup required on clients)",
+		Long: `Assigns a stable port to the current site and starts a host-level reverse
+proxy on 0.0.0.0:<port>. Any device on the same network can reach the site
+at http://<your-LAN-IP>:<port> without configuring DNS or a resolver.
+
+The proxy rewrites the Host header so nginx routes correctly, and rewrites
+absolute URLs in HTML/CSS/JS responses so asset and redirect URLs point to
+the LAN address instead of the .test domain.
+
+The assigned port is stored in sites.yaml and reused across restarts.
+Run 'lerd lan:unshare' to stop sharing and release the port.`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			siteName, err := queueSiteName(cwd)
+			if err != nil {
+				return err
+			}
+			// Persist the port assignment (daemon will start the proxy).
+			port, err := LANShareEnsurePort(siteName)
+			if err != nil {
+				return err
+			}
+			// Tell the running daemon to start the proxy now.
+			site, _ := config.FindSite(siteName)
+			if site != nil {
+				notifyDaemon(site.PrimaryDomain(), "lan:share") //nolint:errcheck
+			}
+			ip, _ := detectPrimaryLANIP()
+			if ip == "" {
+				ip = "<your-LAN-IP>"
+			}
+			shareURL := fmt.Sprintf("http://%s:%d", ip, port)
+			fmt.Printf("Sharing %s at %s\n", siteName, shareURL)
+			fmt.Println("Other devices on the network can use that URL directly — no DNS setup needed.")
+			fmt.Println()
+			PrintLANShareQR(shareURL)
+			fmt.Println()
+			fmt.Println("Run 'lerd lan:unshare' to stop.")
+			return nil
+		},
+	}
+}
+
+func newLANUnshareCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unshare",
+		Short: "Stop LAN sharing for the current site",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			siteName, err := queueSiteName(cwd)
+			if err != nil {
+				return err
+			}
+			site, err := config.FindSite(siteName)
+			if err != nil {
+				return err
+			}
+			// Tell the running daemon to stop the proxy and clear the port.
+			// If the daemon is not reachable, clear the port directly so the
+			// proxy is not restored on next daemon start.
+			if nErr := notifyDaemon(site.PrimaryDomain(), "lan:unshare"); nErr != nil {
+				site.LANPort = 0
+				_ = config.AddSite(*site)
+			}
+			fmt.Printf("LAN sharing stopped for %s.\n", siteName)
+			return nil
+		},
+	}
+}
+
+// notifyDaemon posts an action to the running lerd-ui daemon API. It is a
+// best-effort call; callers should handle errors gracefully.
+func notifyDaemon(domain, action string) error {
+	resp, err := http.Post(
+		fmt.Sprintf("http://127.0.0.1:7073/api/sites/%s/%s", domain, action),
+		"application/json", nil,
+	)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
 }
 
 func newLANStatusCmd() *cobra.Command {

--- a/internal/cli/lanshare.go
+++ b/internal/cli/lanshare.go
@@ -1,0 +1,327 @@
+package cli
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	qrcode "github.com/skip2/go-qrcode"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+var (
+	lanShareMu      sync.Mutex
+	lanShareServers = map[string]*http.Server{} // siteName → running proxy
+)
+
+// LANShareEnsurePort assigns a stable port to the site if not already set and
+// saves it to sites.yaml. It does NOT start the proxy — that is the daemon's job.
+// CLI commands use this to persist the port, then notify the daemon via its API.
+func LANShareEnsurePort(siteName string) (int, error) {
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return 0, err
+	}
+	if site.LANPort != 0 {
+		return site.LANPort, nil
+	}
+	port := assignLANSharePort(siteName)
+	site.LANPort = port
+	if err := config.AddSite(*site); err != nil {
+		return 0, fmt.Errorf("saving LAN port: %w", err)
+	}
+	return port, nil
+}
+
+// LANShareStart starts the in-process reverse proxy for the site. It is
+// intended to be called from the daemon (UI server) only — the proxy goroutine
+// lives in the daemon process. CLI commands should notify the daemon via its
+// HTTP API instead of calling this directly.
+func LANShareStart(siteName string) (int, error) {
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return 0, err
+	}
+
+	port := site.LANPort
+	if port == 0 {
+		port = assignLANSharePort(siteName)
+		site.LANPort = port
+		if err := config.AddSite(*site); err != nil {
+			return 0, fmt.Errorf("saving LAN port: %w", err)
+		}
+	}
+
+	lanShareMu.Lock()
+	if _, running := lanShareServers[siteName]; running {
+		lanShareMu.Unlock()
+		return port, nil
+	}
+	lanShareMu.Unlock()
+
+	cfg, _ := config.LoadGlobal()
+	httpPort := cfg.Nginx.HTTPPort
+	if httpPort == 0 {
+		httpPort = 80
+	}
+	httpsPort := cfg.Nginx.HTTPSPort
+	if httpsPort == 0 {
+		httpsPort = 443
+	}
+
+	srv, err := startLANShareProxy(site.PrimaryDomain(), port, httpPort, httpsPort, site.Secured)
+	if err != nil {
+		return 0, err
+	}
+
+	lanShareMu.Lock()
+	lanShareServers[siteName] = srv
+	lanShareMu.Unlock()
+
+	return port, nil
+}
+
+// LANShareStop stops the LAN share proxy for the site and clears its port
+// from the site registry.
+func LANShareStop(siteName string) error {
+	lanShareMu.Lock()
+	srv, running := lanShareServers[siteName]
+	if running {
+		delete(lanShareServers, siteName)
+	}
+	lanShareMu.Unlock()
+
+	if running {
+		srv.Close()
+	}
+
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return err
+	}
+	site.LANPort = 0
+	return config.AddSite(*site)
+}
+
+// LANShareRunning reports whether a share proxy is active for the site.
+func LANShareRunning(siteName string) bool {
+	lanShareMu.Lock()
+	defer lanShareMu.Unlock()
+	_, ok := lanShareServers[siteName]
+	return ok
+}
+
+// RestoreLANShareProxies restarts share proxies for every site that has a
+// LANPort stored in the registry. Called once when the UI server starts.
+func RestoreLANShareProxies() {
+	reg, err := config.LoadSites()
+	if err != nil {
+		return
+	}
+	cfg, _ := config.LoadGlobal()
+	httpPort := 80
+	httpsPort := 443
+	if cfg != nil {
+		if cfg.Nginx.HTTPPort != 0 {
+			httpPort = cfg.Nginx.HTTPPort
+		}
+		if cfg.Nginx.HTTPSPort != 0 {
+			httpsPort = cfg.Nginx.HTTPSPort
+		}
+	}
+	for _, s := range reg.Sites {
+		if s.LANPort == 0 {
+			continue
+		}
+		srv, err := startLANShareProxy(s.PrimaryDomain(), s.LANPort, httpPort, httpsPort, s.Secured)
+		if err != nil {
+			continue
+		}
+		lanShareMu.Lock()
+		lanShareServers[s.Name] = srv
+		lanShareMu.Unlock()
+	}
+}
+
+// assignLANSharePort finds the lowest unused port >= 9100 across all sites.
+func assignLANSharePort(excludeSiteName string) int {
+	const base = 9100
+	used := map[int]bool{}
+	reg, err := config.LoadSites()
+	if err != nil {
+		return base
+	}
+	for _, s := range reg.Sites {
+		if s.Name == excludeSiteName || s.LANPort == 0 {
+			continue
+		}
+		used[s.LANPort] = true
+	}
+	port := base
+	for used[port] {
+		port++
+	}
+	return port
+}
+
+// startLANShareProxy starts an HTTP reverse proxy listening on 0.0.0.0:<port>.
+// It rewrites the Host header to domain so nginx routes to the right vhost,
+// sets X-Forwarded-Host to the incoming address, and rewrites response bodies
+// and Location headers to replace domain URLs with the LAN address.
+func startLANShareProxy(domain string, port, httpPort, httpsPort int, secured bool) (*http.Server, error) {
+	var target *url.URL
+	if secured {
+		target = &url.URL{Scheme: "https", Host: fmt.Sprintf("localhost:%d", httpsPort)}
+	} else {
+		target = &url.URL{Scheme: "http", Host: fmt.Sprintf("localhost:%d", httpPort)}
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+
+	if secured {
+		t := http.DefaultTransport.(*http.Transport).Clone()
+		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true, ServerName: domain} //nolint:gosec
+		proxy.Transport = t
+	}
+
+	const scheme = "http"
+
+	orig := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		lanHost := req.Host // e.g. "192.168.1.5:9100"
+		orig(req)
+		req.Header.Set("X-Forwarded-Host", lanHost)
+		req.Header.Set("X-Forwarded-Proto", scheme)
+		req.Host = domain
+		// Tell upstream not to compress so we can rewrite bodies without
+		// having to decompress/recompress every response.
+		req.Header.Set("Accept-Encoding", "identity")
+	}
+
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		lanHost := resp.Request.Header.Get("X-Forwarded-Host")
+		if lanHost == "" {
+			return nil
+		}
+
+		// Rewrite Location headers: replace both http:// and https:// variants
+		// of the origin domain with the plain-HTTP LAN address.
+		if loc := resp.Header.Get("Location"); loc != "" {
+			loc = strings.ReplaceAll(loc, "https://"+domain, scheme+"://"+lanHost)
+			loc = strings.ReplaceAll(loc, "http://"+domain, scheme+"://"+lanHost)
+			resp.Header.Set("Location", loc)
+		}
+
+		ct := resp.Header.Get("Content-Type")
+		enc := resp.Header.Get("Content-Encoding")
+
+		if !isTextContent(ct) {
+			return nil
+		}
+
+		// Read the body, decompressing gzip if needed.
+		var body []byte
+		var err error
+		if enc == "gzip" {
+			gr, gErr := gzip.NewReader(resp.Body)
+			if gErr != nil {
+				return nil // leave untouched if we can't decompress
+			}
+			body, err = io.ReadAll(gr)
+			gr.Close()
+			resp.Body.Close()
+			if err != nil {
+				return err
+			}
+			resp.Header.Del("Content-Encoding")
+		} else if enc == "" || enc == "identity" {
+			body, err = io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				return err
+			}
+		} else {
+			return nil // unknown encoding, leave untouched
+		}
+
+		// Replace https://domain and http://domain with the LAN address.
+		body = bytes.ReplaceAll(body, []byte("https://"+domain), []byte(scheme+"://"+lanHost))
+		body = bytes.ReplaceAll(body, []byte("http://"+domain), []byte(scheme+"://"+lanHost))
+
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		resp.ContentLength = int64(len(body))
+		resp.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		return nil
+	}
+
+	ln, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
+	if err != nil {
+		return nil, fmt.Errorf("binding port %d: %w", port, err)
+	}
+
+	srv := &http.Server{Handler: proxy}
+	go srv.Serve(ln) //nolint:errcheck
+	return srv, nil
+}
+
+// PrintLANShareQR prints a compact QR code for the given URL to stdout using
+// half-block Unicode characters (two rows per terminal line).
+func PrintLANShareQR(rawURL string) {
+	qr, err := qrcode.New(rawURL, qrcode.Medium)
+	if err != nil {
+		return
+	}
+	qr.DisableBorder = false
+	bitmap := qr.Bitmap() // [][]bool, true = dark module
+
+	// Render two rows of modules per terminal line using half-block chars.
+	// Quiet zone is already included in Bitmap().
+	for y := 0; y < len(bitmap); y += 2 {
+		row1 := bitmap[y]
+		var row2 []bool
+		if y+1 < len(bitmap) {
+			row2 = bitmap[y+1]
+		} else {
+			row2 = make([]bool, len(row1))
+		}
+		for x := range row1 {
+			top := row1[x]
+			bot := row2[x]
+			switch {
+			case top && bot:
+				fmt.Fprint(os.Stdout, "█")
+			case top:
+				fmt.Fprint(os.Stdout, "▀")
+			case bot:
+				fmt.Fprint(os.Stdout, "▄")
+			default:
+				fmt.Fprint(os.Stdout, " ")
+			}
+		}
+		fmt.Fprintln(os.Stdout)
+	}
+}
+
+// LANShareURL returns the URL a LAN device would use to reach the site on the
+// given port, or an empty string if the port is 0 or the LAN IP cannot be detected.
+func LANShareURL(lanPort int) string {
+	if lanPort == 0 {
+		return ""
+	}
+	ip, err := detectPrimaryLANIP()
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("http://%s:%d", ip, lanPort)
+}

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -26,6 +26,11 @@ type Site struct {
 	// (`<scheme>://<primary-domain>`). Use this for personal customizations
 	// you don't want to share via .lerd.yaml.
 	AppURL string `yaml:"app_url,omitempty"`
+	// LANPort, when non-zero, means a host-level reverse proxy is (or should
+	// be) listening on 0.0.0.0:LANPort, forwarding to the site with the Host
+	// header rewritten. LAN devices can reach the site at <lanIP>:LANPort
+	// without any DNS configuration.
+	LANPort int `yaml:"lan_port,omitempty"`
 }
 
 // PrimaryDomain returns the first (primary) domain for the site.
@@ -62,6 +67,7 @@ type siteYAML struct {
 	Framework     string   `yaml:"framework,omitempty"`
 	PublicDir     string   `yaml:"public_dir,omitempty"`
 	AppURL        string   `yaml:"app_url,omitempty"`
+	LANPort       int      `yaml:"lan_port,omitempty"`
 }
 
 func (s Site) toYAML() siteYAML {
@@ -78,6 +84,7 @@ func (s Site) toYAML() siteYAML {
 		Framework:     s.Framework,
 		PublicDir:     s.PublicDir,
 		AppURL:        s.AppURL,
+		LANPort:       s.LANPort,
 	}
 }
 
@@ -99,6 +106,7 @@ func (sy siteYAML) toSite() Site {
 		Framework:     sy.Framework,
 		PublicDir:     sy.PublicDir,
 		AppURL:        sy.AppURL,
+		LANPort:       sy.LANPort,
 	}
 }
 

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -112,6 +112,9 @@ type EnrichedSite struct {
 	// Services
 	Services []string
 
+	// LAN sharing
+	LANPort int
+
 	// App metadata
 	HasAppLogs    bool
 	LatestLogTime string
@@ -206,6 +209,7 @@ func Enrich(s config.Site, flags EnrichFlag) EnrichedSite {
 		PausedWorkers:       s.PausedWorkers,
 		PublicDir:           s.PublicDir,
 		AppURL:              s.AppURL,
+		LANPort:             s.LANPort,
 		FrameworkName:       s.Framework,
 		OriginalPHPVersion:  s.PHPVersion,
 		OriginalNodeVersion: s.NodeVersion,

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -724,6 +724,31 @@
                     <span x-show="selectedSite.tlsError" class="text-[10px] text-red-500" x-text="selectedSite.tlsError"></span>
                   </div>
 
+                  <!-- LAN share -->
+                  <div class="flex items-center gap-1.5">
+                    <button @click="toggleLANShare(selectedSite)" :disabled="selectedSite.lanShareLoading" :title="selectedSite.lan_port ? 'Stop LAN sharing' : 'Share on LAN — other devices can reach this site at the shown IP:port without any DNS setup'"
+                      class="relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none disabled:opacity-50"
+                      :class="selectedSite.lan_port ? 'bg-teal-500' : 'bg-gray-300 dark:bg-lerd-muted'">
+                      <span class="inline-block h-3 w-3 rounded-full bg-white shadow transition-transform duration-200" :class="selectedSite.lan_port ? 'translate-x-3.5' : 'translate-x-0.5'"></span>
+                      <svg x-show="selectedSite.lanShareLoading" class="animate-spin absolute right-[-14px] w-2.5 h-2.5 text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                    </button>
+                    <span class="text-xs text-gray-500 dark:text-gray-400">LAN</span>
+                    <template x-if="selectedSite.lan_share_url">
+                      <div x-data="{ showQR: false, qrX: 0, qrY: 0 }"
+                           @mouseenter="let r = $el.getBoundingClientRect(); qrX = r.left; qrY = r.bottom + 4; showQR = true"
+                           @mouseleave="showQR = false">
+                        <a :href="selectedSite.lan_share_url" target="_blank" class="text-[10px] text-teal-600 dark:text-teal-400 font-mono hover:underline" x-text="selectedSite.lan_share_url"></a>
+                        <div x-show="showQR" :style="`position:fixed; left:${qrX}px; top:${qrY}px; z-index:9999`"
+                             class="p-1.5 bg-white dark:bg-lerd-card rounded shadow-lg border border-gray-200 dark:border-lerd-border">
+                          <img :src="apiBase + '/api/lan-qr/' + selectedSite.domain" width="160" height="160" alt="QR code">
+                        </div>
+                      </div>
+                    </template>
+                    <span x-show="selectedSite.lanShareError" class="text-[10px] text-red-500" x-text="selectedSite.lanShareError"></span>
+                  </div>
+
+                  <div class="w-px h-4 bg-gray-200 dark:bg-lerd-border mx-0.5"></div>
+
                   <!-- Queue -->
                   <div x-show="selectedSite.has_queue_worker" class="flex items-center gap-1.5">
                     <button @click="toggleQueue(selectedSite)" :disabled="selectedSite.queueLoading" :title="selectedSite.queue_failing ? 'Queue worker is failing — click to restart' : selectedSite.queue_running ? 'Stop queue worker' : 'Start queue worker'"
@@ -2575,6 +2600,7 @@ function lerdApp() {
         scheduleLoading: false, scheduleError: '',
         reverbLoading: false, reverbError: '',
         horizonLoading: false, horizonError: '',
+        lanShareLoading: false, lanShareError: '',
         unlinkLoading: false, pauseLoading: false,
         framework_workers: (s.framework_workers || []).map(w => ({ ...w, loading: false, error: '' })),
       });
@@ -2613,6 +2639,8 @@ function lerdApp() {
           e.latest_log_time = s.latest_log_time;
           e.branch = s.branch;
           e.paused = s.paused;
+          e.lan_port = s.lan_port;
+          e.lan_share_url = s.lan_share_url;
           if (s.framework_workers) {
             if (e.framework_workers) {
               s.framework_workers.forEach(sw => {
@@ -3662,6 +3690,23 @@ function lerdApp() {
         site.reverbError = e.message || 'Request failed';
       } finally {
         site.reverbLoading = false;
+      }
+    },
+
+    async toggleLANShare(site) {
+      site.lanShareLoading = true;
+      site.lanShareError = '';
+      try {
+        const action = site.lan_port ? 'lan:unshare' : 'lan:share';
+        const res = await fetch(`/api/sites/${site.domain}/${action}`, { method: 'POST' });
+        const data = await res.json();
+        if (!data.ok) {
+          site.lanShareError = data.error || 'Failed';
+        }
+      } catch (e) {
+        site.lanShareError = e.message || 'Request failed';
+      } finally {
+        site.lanShareLoading = false;
       }
     },
 

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -16,6 +17,8 @@ import (
 	"time"
 
 	_ "embed"
+
+	qrcode "github.com/skip2/go-qrcode"
 
 	"github.com/geodro/lerd/internal/applog"
 	"github.com/geodro/lerd/internal/certs"
@@ -138,6 +141,9 @@ func Start(currentVersion string) error {
 	// podman inspect subprocesses.
 	podman.Cache.Start(context.Background())
 
+	// Restart any LAN share proxies that were active before this process started.
+	go cli.RestoreLANShareProxies()
+
 	podman.AfterUnitChange = func(name string) {
 		// Run the poll and snapshot publish in a goroutine so the HTTP
 		// handler (and the unit start/stop call that triggered this) returns
@@ -165,6 +171,7 @@ func Start(currentVersion string) error {
 	mux.HandleFunc("/api/sites", withCORS(handleSites))
 	mux.HandleFunc("/api/services", withCORS(handleServices))
 	mux.HandleFunc("/api/ws", handleWS)
+	mux.HandleFunc("/api/lan-qr/", withCORS(handleLANQR))
 
 	// Cross-process notifier: the CLI and MCP processes run outside
 	// lerd-ui and can't publish to the in-process eventbus. They POST
@@ -487,7 +494,9 @@ type SiteResponse struct {
 	// Services lists the service names this site uses, sourced from the
 	// project's .lerd.yaml. Used by the dashboard to render service badges
 	// on the site detail panel.
-	Services []string `json:"services,omitempty"`
+	Services    []string `json:"services,omitempty"`
+	LANPort     int      `json:"lan_port,omitempty"`
+	LANShareURL string   `json:"lan_share_url,omitempty"`
 }
 
 func handleSites(w http.ResponseWriter, _ *http.Request) {
@@ -571,6 +580,8 @@ func buildSites() []SiteResponse {
 			Branch:             e.Branch,
 			Worktrees:          worktreeResponses,
 			Services:           e.Services,
+			LANPort:            e.LANPort,
+			LANShareURL:        cli.LANShareURL(e.LANPort),
 		})
 	}
 	return sites
@@ -1333,6 +1344,30 @@ func handleSiteFavicon(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, path)
 }
 
+// handleLANQR serves a QR code PNG for the LAN share URL of a site.
+// Path: /api/lan-qr/{domain}
+func handleLANQR(w http.ResponseWriter, r *http.Request) {
+	domain := strings.TrimPrefix(r.URL.Path, "/api/lan-qr/")
+	site, err := config.FindSiteByDomain(domain)
+	if err != nil || site.LANPort == 0 {
+		http.NotFound(w, r)
+		return
+	}
+	shareURL := cli.LANShareURL(site.LANPort)
+	if shareURL == "" {
+		http.NotFound(w, r)
+		return
+	}
+	png, err := qrcode.Encode(shareURL, qrcode.Medium, 160)
+	if err != nil {
+		http.Error(w, "qr encode: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "image/png")
+	w.Header().Set("Cache-Control", "no-cache")
+	http.ServeContent(w, r, "qr.png", time.Time{}, bytes.NewReader(png))
+}
+
 // SiteActionResponse is returned by POST /api/sites/{domain}/secure|unsecure.
 type SiteActionResponse struct {
 	OK    bool   `json:"ok"`
@@ -1535,6 +1570,20 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		}
 		if !site.Paused {
 			_ = config.SetProjectWorkers(site.Path, cli.CollectRunningWorkerNames(site))
+		}
+		writeJSON(w, SiteActionResponse{OK: true})
+		return
+	case "lan:share":
+		if _, err := cli.LANShareStart(site.Name); err != nil {
+			writeJSON(w, SiteActionResponse{Error: err.Error()})
+			return
+		}
+		writeJSON(w, SiteActionResponse{OK: true})
+		return
+	case "lan:unshare":
+		if err := cli.LANShareStop(site.Name); err != nil {
+			writeJSON(w, SiteActionResponse{Error: err.Error()})
+			return
 		}
 		writeJSON(w, SiteActionResponse{OK: true})
 		return


### PR DESCRIPTION
Closes #179

## What

Adds `lerd lan:share` / `lerd lan:unshare` to expose a single site to other devices on the local network via a stable `http://IP:PORT` URL — no DNS setup or client configuration required.

## How it works

- Assigns a stable port per site (starting at 9100, saved in `sites.yaml`, reused across restarts)
- Starts a host-level HTTP reverse proxy inside the lerd-ui daemon that:
  - Rewrites the `Host` header so nginx routes to the correct vhost
  - Rewrites absolute URLs (`https://myapp.test/...` → `http://192.168.x.x:9100/...`) in HTML, CSS, and JS response bodies so assets and redirects work without DNS
  - Sets `Accept-Encoding: identity` on upstream requests and handles gzip decompression to ensure body rewriting is reliable
  - Rewrites `Location` headers on redirects
- CLI commands update `sites.yaml` and notify the running daemon via its HTTP API; proxy goroutine lives entirely in the daemon
- `RestoreLANShareProxies()` called on daemon start to restore any proxies saved in `sites.yaml`

## UI

- LAN toggle next to the HTTPS toggle in the dashboard, lightly separated from the worker toggles
- LAN URL shown inline; hovering shows a QR code in a `fixed`-positioned tooltip (escapes `overflow-x-auto` clipping on parent containers)
- QR images served by the daemon at `/api/lan-qr/{domain}`

## Terminal

Prints a compact half-block Unicode QR code after `lerd lan:share`:

```
Sharing myapp at http://192.168.1.42:9100
Other devices on the network can use that URL directly — no DNS setup needed.

█████████████████████████████████
...

Run 'lerd lan:unshare' to stop.
```

## Docs

- `docs/reference/commands.md` — new LAN section with `lan:share` / `lan:unshare` and `lan:expose` / `lan:unexpose` / `lan:status`
- `docs/usage/remote-development.md` — new LAN sharing section with usage, how it works, and a comparison table (LAN sharing vs full LAN exposure)