### PR TITLE
fix(man): skip node_modules when walking docs FS

### DIFF
--- a/internal/man/registry.go
+++ b/internal/man/registry.go
@@ -46,7 +46,13 @@ func BuildRegistry() []Page {
 	bySection := make(map[string][]Page)
 
 	_ = fs.WalkDir(docsfs.FS, "docs", func(p string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(p, ".md") {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() && d.Name() == "node_modules" {
+			return fs.SkipDir
+		}
+		if d.IsDir() || !strings.HasSuffix(p, ".md") {
 			return nil
 		}
 


### PR DESCRIPTION
`BuildRegistry` walks `docs/` in the embedded FS and picks up every `.md` file — including all the `README.md` files inside `docs/node_modules/`. This floods `lerd man` with npm package readmes.

Fix: return `fs.SkipDir` when the walker enters a directory named `node_modules`, pruning the entire subtree from the walk.