### PR TITLE
fix: set SERVER_NAME to $host in PHP-FPM vhosts for correct subdomain detection

### DIFF
--- a/internal/nginx/templates/vhost-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-ssl.conf.tmpl
@@ -40,6 +40,7 @@ server {
         fastcgi_buffers 16 16k;
         fastcgi_buffer_size 32k;
         include fastcgi_params;
+        fastcgi_param SERVER_NAME $host;
     }
 
     location ~ /\.ht {

--- a/internal/nginx/templates/vhost.conf.tmpl
+++ b/internal/nginx/templates/vhost.conf.tmpl
@@ -30,6 +30,7 @@ server {
         fastcgi_buffers 16 16k;
         fastcgi_buffer_size 32k;
         include fastcgi_params;
+        fastcgi_param SERVER_NAME $host;
     }
 
     location ~ /\.ht {


### PR DESCRIPTION
## Summary

- Override `SERVER_NAME` with `$host` in the PHP-FPM FastCGI location block for both HTTP and SSL vhost templates
- nginx's default `fastcgi_params` sets `SERVER_NAME` to `$server_name`, which is the first name in the `server_name` directive — not the matched hostname. For wildcard vhosts (`*.myapp.test`), this meant PHP always received `SERVER_NAME=myapp.test` regardless of the actual subdomain requested
- Apps relying on `SERVER_NAME` for subdomain detection (including Laravel/Symfony via `Request::getHost()` fallback) now correctly see the requested subdomain