### PR TITLE
fix: xdebug host gateway detection, inter-site HTTP via lerd-nginx bridge (#186)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,14 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.13.1] — 2026-04-14
+
+### Fixed
+
+- **Xdebug and inter-site HTTP inside PHP-FPM containers** (closes #186). The shared `/etc/hosts` bind-mounted into every PHP-FPM container used to hardcode `169.254.1.2` both for `host.containers.internal` and for every linked `.test` domain. That address is only a valid host gateway on rootless podman with pasta/netavark/slirp4netns, so Xdebug timed out connecting back to the IDE on other podman configurations. It also routed inter-site HTTP through a fragile `FPM → pasta host-loopback → host 127.0.0.1:80 (rootlessport) → lerd-nginx` chain that failed on some podman versions and surfaced as 504s during debugging. `WriteContainerHosts` now probes the real host gateway by exec-ing `getent hosts host.containers.internal` inside `lerd-nginx`, with a throwaway alpine container on the lerd network as fallback, and the old constant as a final fallback. Two distinct IPs are written: `host.containers.internal` points at the detected host gateway for Xdebug and any host-side tooling, while every `.test` domain resolves straight to `lerd-nginx`'s bridge IP so inter-site HTTP travels container-to-container over the lerd network without any pasta hop. Rendering was extracted into a pure `renderContainerHosts` helper with table-driven unit tests covering empty registries, nginx IP wiring, IP separation regressions, and loopback preservation.
+
+---
+
 ## [1.13.0] — 2026-04-14
 
 ### Added

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -124,6 +124,8 @@ Xdebug is configured with:
 - `xdebug.client_port=9003`
 
 Set your IDE to listen on port `9003`. In VS Code, the default PHP Debug configuration works without changes. In PhpStorm, set **Settings → PHP → Debug → Debug port** to `9003`.
+
+`host.containers.internal` is resolved dynamically: when lerd writes the shared hosts file it probes the running `lerd-nginx` container for the IP that podman uses for the host gateway, so Xdebug reaches your IDE on any podman networking stack (rootless or rootful, pasta, netavark, slirp4netns).
 :::
 
 ---

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -375,10 +375,11 @@ func WriteFPMQuadlet(version string) error {
 		if err := WriteContainerHosts(); err != nil {
 			// Non-fatal: write the static header so the mount succeeds and
 			// host.containers.internal resolves correctly even before lerd link runs.
+			hostIP := DetectHostGatewayIP()
 			_ = os.WriteFile(hostsPath, []byte(
 				"127.0.0.1 localhost\n"+
 					"::1 localhost\n"+
-					"169.254.1.2 host.containers.internal host.docker.internal\n",
+					hostIP+" host.containers.internal host.docker.internal\n",
 			), 0644)
 		}
 	}

--- a/internal/podman/hosts.go
+++ b/internal/podman/hosts.go
@@ -9,29 +9,23 @@ import (
 	"github.com/geodro/lerd/internal/config"
 )
 
-// WriteContainerHosts writes the shared hosts file that is bind-mounted into every
-// PHP-FPM container at /etc/hosts. It contains the standard loopback entries,
-// host.containers.internal, and one entry per linked site pointing to
-// host.containers.internal (169.254.1.2) so that .test domains resolve correctly
-// inside containers without requiring a container restart when sites are added or removed.
+// Fallback for podman rootless + pasta/netavark/slirp4netns.
+const fallbackHostGatewayIP = "169.254.1.2"
+
+// WriteContainerHosts writes the shared /etc/hosts bind-mounted into every
+// PHP-FPM container. host.containers.internal uses the probed host gateway;
+// .test domains point at lerd-nginx directly on the lerd bridge network.
 func WriteContainerHosts() error {
 	reg, err := config.LoadSites()
 	if err != nil {
 		return fmt.Errorf("loading sites: %w", err)
 	}
 
-	var sb strings.Builder
-	sb.WriteString("127.0.0.1 localhost\n")
-	sb.WriteString("::1 localhost\n")
-	sb.WriteString("169.254.1.2 host.containers.internal host.docker.internal\n")
+	hostIP := DetectHostGatewayIP()
+	nginxIP := nginxContainerIP()
 
-	for _, site := range reg.Sites {
-		for _, domain := range site.Domains {
-			fmt.Fprintf(&sb, "169.254.1.2 %s\n", domain)
-		}
-	}
-
-	if err := os.WriteFile(config.ContainerHostsFile(), []byte(sb.String()), 0644); err != nil {
+	content := renderContainerHosts(reg, hostIP, nginxIP)
+	if err := os.WriteFile(config.ContainerHostsFile(), []byte(content), 0644); err != nil {
 		return err
 	}
 
@@ -39,6 +33,23 @@ func WriteContainerHosts() error {
 	// lerd-nginx's IP on the Podman network so Chromium inside Selenium
 	// (or similar containers) can reach sites via HTTP/HTTPS.
 	return writeBrowserHosts(reg)
+}
+
+// renderContainerHosts builds the /etc/hosts contents for PHP-FPM containers.
+// .test domains go to nginxIP (direct bridge), host.containers.internal to
+// hostIP (host gateway for Xdebug and other host-side services).
+func renderContainerHosts(reg *config.SiteRegistry, hostIP, nginxIP string) string {
+	var sb strings.Builder
+	sb.WriteString("127.0.0.1 localhost\n")
+	sb.WriteString("::1 localhost\n")
+	fmt.Fprintf(&sb, "%s host.containers.internal host.docker.internal\n", hostIP)
+
+	for _, site := range reg.Sites {
+		for _, domain := range site.Domains {
+			fmt.Fprintf(&sb, "%s %s\n", nginxIP, domain)
+		}
+	}
+	return sb.String()
 }
 
 // writeBrowserHosts writes the browser-testing hosts file. It resolves
@@ -59,6 +70,47 @@ func writeBrowserHosts(reg *config.SiteRegistry) error {
 	}
 
 	return os.WriteFile(config.BrowserHostsFile(), []byte(sb.String()), 0644)
+}
+
+// DetectHostGatewayIP returns the IP podman uses for host.containers.internal
+// on the lerd network. Tries an exec into lerd-nginx, then a throwaway alpine
+// probe, and finally falls back to fallbackHostGatewayIP.
+func DetectHostGatewayIP() string {
+	if ip := parseHostGatewayFromExec("lerd-nginx"); ip != "" {
+		return ip
+	}
+	if ip := parseHostGatewayFromProbe(); ip != "" {
+		return ip
+	}
+	return fallbackHostGatewayIP
+}
+
+func parseHostGatewayFromExec(container string) string {
+	out, err := exec.Command(PodmanBin(), "exec", container,
+		"getent", "hosts", "host.containers.internal").Output()
+	if err != nil {
+		return ""
+	}
+	return firstField(string(out))
+}
+
+func parseHostGatewayFromProbe() string {
+	out, err := exec.Command(PodmanBin(), "run", "--rm", "--network", "lerd",
+		"docker.io/library/alpine", "getent", "hosts", "host.containers.internal").Output()
+	if err != nil {
+		return ""
+	}
+	return firstField(string(out))
+}
+
+func firstField(s string) string {
+	for _, line := range strings.Split(strings.TrimSpace(s), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) > 0 {
+			return fields[0]
+		}
+	}
+	return ""
 }
 
 // nginxContainerIP returns the IP address of lerd-nginx on the lerd Podman

--- a/internal/podman/hosts_test.go
+++ b/internal/podman/hosts_test.go
@@ -1,0 +1,79 @@
+package podman
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestFirstField(t *testing.T) {
+	cases := map[string]string{
+		"169.254.1.2     host.containers.internal host.docker.internal\n": "169.254.1.2",
+		"  10.0.2.2 host.containers.internal\n":                           "10.0.2.2",
+		"":                                                                "",
+		"\n\n":                                                            "",
+		"only-one-tok":                                                    "only-one-tok",
+	}
+	for in, want := range cases {
+		if got := firstField(in); got != want {
+			t.Errorf("firstField(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRenderContainerHosts_EmptyRegistry(t *testing.T) {
+	got := renderContainerHosts(&config.SiteRegistry{}, "169.254.1.2", "10.89.0.2")
+	want := "127.0.0.1 localhost\n" +
+		"::1 localhost\n" +
+		"169.254.1.2 host.containers.internal host.docker.internal\n"
+	if got != want {
+		t.Errorf("renderContainerHosts empty = %q, want %q", got, want)
+	}
+}
+
+func TestRenderContainerHosts_SitesPointAtNginx(t *testing.T) {
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "foo", Domains: []string{"foo.test"}},
+		{Name: "bar", Domains: []string{"bar.test", "admin-bar.test"}},
+	}}
+
+	got := renderContainerHosts(reg, "169.254.1.2", "10.89.0.2")
+
+	// host.containers.internal must use the host gateway, never nginx.
+	if !strings.Contains(got, "169.254.1.2 host.containers.internal host.docker.internal\n") {
+		t.Errorf("missing host.containers.internal line:\n%s", got)
+	}
+	// .test domains must use the nginx container IP, never the host gateway.
+	for _, d := range []string{"foo.test", "bar.test", "admin-bar.test"} {
+		wantLine := "10.89.0.2 " + d + "\n"
+		if !strings.Contains(got, wantLine) {
+			t.Errorf("missing %q in output:\n%s", wantLine, got)
+		}
+		if strings.Contains(got, "169.254.1.2 "+d) {
+			t.Errorf("site %q incorrectly points at host gateway:\n%s", d, got)
+		}
+	}
+}
+
+func TestRenderContainerHosts_DistinctIPs(t *testing.T) {
+	// Regression: host-gateway (Xdebug) and nginx IP (.test) must stay separate.
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "x", Domains: []string{"x.test"}},
+	}}
+	got := renderContainerHosts(reg, "169.254.1.2", "10.89.0.2")
+
+	if strings.Contains(got, "169.254.1.2 x.test") {
+		t.Errorf("x.test must not resolve to host gateway:\n%s", got)
+	}
+	if strings.Contains(got, "10.89.0.2 host.containers.internal") {
+		t.Errorf("host.containers.internal must not resolve to nginx IP:\n%s", got)
+	}
+}
+
+func TestRenderContainerHosts_PreservesLoopback(t *testing.T) {
+	got := renderContainerHosts(&config.SiteRegistry{}, "1.2.3.4", "5.6.7.8")
+	if !strings.HasPrefix(got, "127.0.0.1 localhost\n::1 localhost\n") {
+		t.Errorf("loopback entries missing or out of order:\n%s", got)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.13.0"
+	Version = "1.13.1"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary
- Detect `host.containers.internal` dynamically by probing `lerd-nginx` (with an alpine fallback and the old `169.254.1.2` constant as a final fallback), instead of hardcoding. Xdebug now reaches the IDE on rootless and rootful podman across pasta, netavark, and slirp4netns.
- Point every `.test` domain in the FPM `/etc/hosts` straight at `lerd-nginx`'s bridge IP, so inter-site HTTP stays container-to-container on the lerd network instead of hopping through pasta's host-loopback mapping to rootlessport, which was fragile and surfaced as 504s on some podman versions.
- Extract rendering into a pure `renderContainerHosts(reg, hostIP, nginxIP)` helper and add table-driven unit tests for empty registries, nginx IP wiring, IP separation regressions, and loopback preservation.

Closes #186.