### PR TITLE
feat: node version management - detect system node, fix UI install bug, surface managed state

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -196,34 +196,40 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		copy(keepCustomWorkers, customWorkerNames)
 	}
 
-	formGroups := []*huh.Group{
-		huh.NewGroup(
-			huh.NewInput().
-				Title("PHP version").
-				Value(&phpVersion).
-				Validate(func(s string) error {
-					if s == "" {
-						return nil
-					}
-					return validatePHPVersion(s)
-				}),
+	firstGroupFields := []huh.Field{
+		huh.NewInput().
+			Title("PHP version").
+			Value(&phpVersion).
+			Validate(func(s string) error {
+				if s == "" {
+					return nil
+				}
+				return validatePHPVersion(s)
+			}),
+	}
+	if lerdManagesNode() {
+		firstGroupFields = append(firstGroupFields,
 			huh.NewInput().
 				Title("Node version").
 				Description("Leave blank to skip").
 				Value(&nodeVersion),
-			huh.NewConfirm().
-				Title("Enable HTTPS?").
-				Value(&secured),
-			huh.NewSelect[string]().
-				Title("Database").
-				Options(dbOptions...).
-				Value(&dbChoice),
-			huh.NewMultiSelect[string]().
-				Title("Services").
-				Options(huh.NewOptions(nonDBServiceOptions...)...).
-				Value(&nonDBSelected),
-		),
+		)
 	}
+	firstGroupFields = append(firstGroupFields,
+		huh.NewConfirm().
+			Title("Enable HTTPS?").
+			Value(&secured),
+		huh.NewSelect[string]().
+			Title("Database").
+			Options(dbOptions...).
+			Value(&dbChoice),
+		huh.NewMultiSelect[string]().
+			Title("Services").
+			Options(huh.NewOptions(nonDBServiceOptions...)...).
+			Value(&nonDBSelected),
+	)
+
+	formGroups := []*huh.Group{huh.NewGroup(firstGroupFields...)}
 
 	if len(customWorkerNames) > 0 {
 		formGroups = append(formGroups, huh.NewGroup(

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -104,6 +104,12 @@ func runInstall(_ *cobra.Command, _ []string) error {
 		wantLaravelInstaller = confirmInstallPrompt("Install Laravel installer (laravel new)?")
 	}
 
+	wantLerdNode := true
+	if systemNode := detectSystemNode(); systemNode != "" {
+		fmt.Printf("  --> Node.js detected at %s\n", systemNode)
+		wantLerdNode = confirmInstallPrompt("Let lerd manage Node.js versions (installs fnm shims, may override system node)?")
+	}
+
 	// 4. mkcert CA — interactive (may prompt for sudo)
 	fmt.Println("  --> Installing mkcert CA")
 	cmd := exec.Command(certs.MkcertPath(), "-install")
@@ -500,7 +506,7 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	installCleanupScript()
 
 	step("Adding shell PATH configuration")
-	if err := addShellShims(); err != nil {
+	if err := addShellShims(wantLerdNode); err != nil {
 		fmt.Printf("    WARN: %v\n", err)
 	}
 	ok()
@@ -679,6 +685,31 @@ func installLaravelInstaller() error {
 	return cmd.Run()
 }
 
+// lerdManagesNode reports whether lerd's node shim is present in its bin dir,
+// meaning the user opted in to fnm-based node version management.
+func lerdManagesNode() bool {
+	shim := filepath.Join(config.BinDir(), "node")
+	_, err := os.Stat(shim)
+	return err == nil
+}
+
+// detectSystemNode returns the path to a node binary found in PATH outside of
+// lerd's own bin dir, or "" if none exists. Used during install to decide
+// whether to write fnm-backed node/npm/npx shims.
+func detectSystemNode() string {
+	lerdBin := config.BinDir()
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == lerdBin {
+			continue
+		}
+		candidate := filepath.Join(dir, "node")
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+	return ""
+}
+
 // confirmInstallPrompt asks a [Y/n] question. Must be called before any
 // RunParallel invocation, which leaves a goroutine reading from os.Stdin.
 func confirmInstallPrompt(question string) bool {
@@ -743,7 +774,7 @@ func (p *progressReader) Read(b []byte) (int, error) {
 	return n, err
 }
 
-func addShellShims() error {
+func addShellShims(manageNode bool) error {
 	home, _ := os.UserHomeDir()
 	binDir := config.BinDir()
 	lerdBin := filepath.Join(home, ".local", "bin", "lerd")
@@ -777,7 +808,10 @@ func addShellShims() error {
 
 	// Write node/npm/npx shims — use fnm directly so they work inside containers
 	// (lerd is glibc-linked and cannot run inside Alpine-based PHP containers).
-	nodeShimTmpl := `#!/bin/sh
+	// Only written when lerd is managing Node versions; skipped when the user
+	// declined the prompt because they already have their own node installed.
+	if manageNode {
+		nodeShimTmpl := `#!/bin/sh
 FNM="%s"
 VERSION=""
 for f in .node-version .nvmrc; do
@@ -787,13 +821,18 @@ if [ -n "$VERSION" ]; then
   "$FNM" install "$VERSION" >/dev/null 2>&1 || true
   exec "$FNM" exec --using="$VERSION" -- %s "$@"
 else
+  if [ -z "$("$FNM" list 2>/dev/null)" ]; then
+    printf 'No Node.js version installed. Run: lerd node:install 22\n' >&2
+    exit 1
+  fi
   exec "$FNM" exec --using=default -- %s "$@"
 fi
 `
-	for _, bin := range []string{"node", "npm", "npx"} {
-		shim := fmt.Sprintf(nodeShimTmpl, fnmBin, bin, bin)
-		if err := os.WriteFile(filepath.Join(binDir, bin), []byte(shim), 0755); err != nil {
-			return fmt.Errorf("writing %s shim: %w", bin, err)
+		for _, bin := range []string{"node", "npm", "npx"} {
+			shim := fmt.Sprintf(nodeShimTmpl, fnmBin, bin, bin)
+			if err := os.WriteFile(filepath.Join(binDir, bin), []byte(shim), 0755); err != nil {
+				return fmt.Errorf("writing %s shim: %w", bin, err)
+			}
 		}
 	}
 

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -97,7 +97,7 @@ func TestAddShellShims_LaravelShim(t *testing.T) {
 	// addShellShims expects a shell env var for the PATH block.
 	t.Setenv("SHELL", "/bin/sh")
 
-	if err := addShellShims(); err != nil {
+	if err := addShellShims(false); err != nil {
 		t.Fatalf("addShellShims: %v", err)
 	}
 
@@ -132,7 +132,7 @@ func TestAddShellShims_LaravelShimRespectsComposerHome(t *testing.T) {
 
 	t.Setenv("SHELL", "/bin/sh")
 
-	if err := addShellShims(); err != nil {
+	if err := addShellShims(false); err != nil {
 		t.Fatalf("addShellShims: %v", err)
 	}
 

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -288,8 +288,11 @@
             </template>
           </button>
         </template>
-        <div class="px-3 pt-2.5 pb-1 border-t border-gray-100 dark:border-lerd-border">
+        <div class="px-3 pt-2.5 pb-1 border-t border-gray-100 dark:border-lerd-border flex items-center gap-2">
           <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Node.js</span>
+          <template x-if="systemStatus && !systemStatus.node_managed_by_lerd">
+            <span class="text-[10px] font-medium text-blue-500 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10 rounded px-1.5 py-0.5">system</span>
+          </template>
         </div>
         <template x-for="v in nodeVersions" :key="'node-'+v">
           <button @click="selectSystem('node-'+v)"
@@ -473,8 +476,11 @@
               <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
             </button>
           </template>
-          <div class="px-4 pt-2.5 pb-1 border-t border-gray-100 dark:border-lerd-border">
+          <div class="px-4 pt-2.5 pb-1 border-t border-gray-100 dark:border-lerd-border flex items-center gap-2">
             <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Node.js</span>
+            <template x-if="systemStatus && !systemStatus.node_managed_by_lerd">
+              <span class="text-[10px] font-medium text-blue-500 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10 rounded px-1.5 py-0.5">system</span>
+            </template>
           </div>
           <template x-for="v in nodeVersions" :key="'mnode-'+v">
             <button @click="selectSystem('node-'+v)" class="w-full flex items-center gap-2.5 px-4 py-3.5 text-sm text-left transition-colors border-b border-gray-100 dark:border-lerd-border" :class="selectedSystem==='node-'+v ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
@@ -696,21 +702,23 @@
                       </template>
                     </select>
                   </template>
-                  <template x-if="nodeVersions.length === 0">
-                    <span class="text-xs text-gray-400 border border-gray-200 dark:border-lerd-border rounded px-2 py-1 opacity-50">Node ...</span>
-                  </template>
-                  <template x-if="nodeVersions.length > 0">
-                    <select
-                      x-model="selectedSite.node_version"
-                      @change="setSiteVersion(selectedSite, 'node', selectedSite.node_version)"
-                      class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors [&>option]:bg-white [&>option]:dark:bg-lerd-card [&>option]:text-gray-900 [&>option]:dark:text-gray-200"
-                      :disabled="selectedSite.versionLoading"
-                    >
-                      <option value="">Node default</option>
-                      <template x-for="v in nodeVersions" :key="v">
-                        <option :value="v" x-text="'Node ' + v"></option>
-                      </template>
-                    </select>
+                  <template x-if="systemStatus && systemStatus.node_managed_by_lerd">
+                    <template x-if="nodeVersions.length === 0">
+                      <span class="text-xs text-gray-400 border border-gray-200 dark:border-lerd-border rounded px-2 py-1 opacity-50">Node ...</span>
+                    </template>
+                    <template x-if="nodeVersions.length > 0">
+                      <select
+                        x-model="selectedSite.node_version"
+                        @change="setSiteVersion(selectedSite, 'node', selectedSite.node_version)"
+                        class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors [&>option]:bg-white [&>option]:dark:bg-lerd-card [&>option]:text-gray-900 [&>option]:dark:text-gray-200"
+                        :disabled="selectedSite.versionLoading"
+                      >
+                        <option value="">Node default</option>
+                        <template x-for="v in nodeVersions" :key="v">
+                          <option :value="v" x-text="'Node ' + v"></option>
+                        </template>
+                      </select>
+                    </template>
                   </template>
 
                   <!-- HTTPS -->
@@ -1581,6 +1589,11 @@
                 <span class="font-semibold text-gray-900 dark:text-white text-base">Install Node.js version</span>
               </div>
               <div class="px-3 sm:px-5 py-4 space-y-4">
+                <template x-if="systemStatus && !systemStatus.node_managed_by_lerd">
+                  <div class="text-sm text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-500/10 border border-blue-200 dark:border-blue-500/20 rounded-lg px-3 py-2.5">
+                    <span class="font-medium">Using system Node.js.</span> Installing a version here will switch to lerd-managed Node.js via fnm and override your system node.
+                  </div>
+                </template>
                 <p class="text-sm text-gray-500">Install a new Node.js version using fnm.</p>
                 <div class="flex items-center gap-2">
                   <input type="text" x-model="nodeInstall.version" @keydown.enter="installNodeVersion()" placeholder="e.g. 22"

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -464,12 +464,13 @@ func mustJSON(v any) string {
 
 // StatusResponse is the response for GET /api/status.
 type StatusResponse struct {
-	DNS            DNSStatus    `json:"dns"`
-	Nginx          ServiceCheck `json:"nginx"`
-	PHPFPMs        []PHPStatus  `json:"php_fpms"`
-	PHPDefault     string       `json:"php_default"`
-	NodeDefault    string       `json:"node_default"`
-	WatcherRunning bool         `json:"watcher_running"`
+	DNS               DNSStatus    `json:"dns"`
+	Nginx             ServiceCheck `json:"nginx"`
+	PHPFPMs           []PHPStatus  `json:"php_fpms"`
+	PHPDefault        string       `json:"php_default"`
+	NodeDefault       string       `json:"node_default"`
+	NodeManagedByLerd bool         `json:"node_managed_by_lerd"`
+	WatcherRunning    bool         `json:"watcher_running"`
 }
 
 type DNSStatus struct {
@@ -518,13 +519,17 @@ func buildStatus() StatusResponse {
 		phpDefault = cfg.PHP.DefaultVersion
 		nodeDefault = cfg.Node.DefaultVersion
 	}
+	nodeShim := filepath.Join(config.BinDir(), "node")
+	_, nodeShimErr := os.Stat(nodeShim)
+	nodeManagedByLerd := nodeShimErr == nil
 	return StatusResponse{
-		DNS:            DNSStatus{OK: dnsOK, TLD: tld},
-		Nginx:          ServiceCheck{Running: nginxRunning},
-		PHPFPMs:        phpStatuses,
-		PHPDefault:     phpDefault,
-		NodeDefault:    nodeDefault,
-		WatcherRunning: watcherRunning,
+		DNS:               DNSStatus{OK: dnsOK, TLD: tld},
+		Nginx:             ServiceCheck{Running: nginxRunning},
+		PHPFPMs:           phpStatuses,
+		PHPDefault:        phpDefault,
+		NodeDefault:       nodeDefault,
+		NodeManagedByLerd: nodeManagedByLerd,
+		WatcherRunning:    watcherRunning,
 	}
 }
 
@@ -2033,11 +2038,14 @@ func handleInstallNodeVersion(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	version := r.URL.Query().Get("version")
-	if version == "" || !validVersion.MatchString(version) {
+	var req struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Version == "" || !validVersion.MatchString(req.Version) {
 		writeJSON(w, map[string]any{"ok": false, "error": "invalid version"})
 		return
 	}
+	version := req.Version
 	major := strings.SplitN(version, ".", 2)[0]
 	fnmPath := config.BinDir() + "/fnm"
 	cmd := exec.Command(fnmPath, "install", major)


### PR DESCRIPTION
## Summary

- \`lerd install\` now detects an existing system Node.js and asks whether lerd should manage Node versions; if declined, \`node\`/\`npm\`/\`npx\` shims are not written so the user's own node is not shadowed
- Node shims now print a friendly message (\`No Node.js version installed. Run: lerd node:install 22\`) instead of a cryptic fnm error when no version is installed yet
- Fix \`handleInstallNodeVersion\`: handler was reading version from a query param but the UI posted a JSON body, causing "invalid version" error when installing from the dashboard
- \`StatusResponse\` gains \`node_managed_by_lerd\`; UI shows a \`system\` badge next to the Node.js sidebar section, hides the per-site node version dropdown, and shows an info banner in the install panel when lerd is not managing node
- \`lerd init\` wizard hides the Node version input on machines where lerd does not manage node; existing \`node_version\` in \`.lerd.yaml\` is preserved unchanged