### PR TITLE
feat(db): decouple db commands from site/PHP coupling

### DIFF
--- a/docs/usage/database.md
+++ b/docs/usage/database.md
@@ -1,19 +1,65 @@
 # Database
 
-Database shortcuts read `DB_CONNECTION`, `DB_DATABASE`, `DB_USERNAME`, and `DB_PASSWORD` from the project's `.env` and run the appropriate command inside the service container.
+Database commands work with any project type — Laravel, Symfony, NestJS, Next.js, or any other framework. lerd automatically detects which database service to use through a resolution chain described below.
 
 ## Commands
 
 | Command | Description |
 |---|---|
-| `lerd db:create [name]` | Create a database and a `<name>_testing` database for the current project |
-| `lerd db:import [-d name] <file.sql>` | Import a SQL dump (defaults to site DB from `.env`) |
-| `lerd db:export [-d name] [-o file.sql]` | Export a database to a SQL dump (defaults to site DB from `.env`) |
-| `lerd db:shell` | Open an interactive MySQL or PostgreSQL shell for the current project |
+| `lerd db:create [name]` | Create a database and a `<name>_testing` database |
+| `lerd db:import [-s service] [-d name] <file.sql>` | Import a SQL dump |
+| `lerd db:export [-s service] [-d name] [-o file.sql]` | Export a database to a SQL dump |
+| `lerd db:shell [-s service] [-d name]` | Open an interactive MySQL or PostgreSQL shell |
 | `lerd db create [name]` | Same as `db:create` (subcommand form) |
-| `lerd db import [-d name] <file.sql>` | Same as `db:import` (subcommand form) |
-| `lerd db export [-d name]` | Same as `db:export` (subcommand form) |
-| `lerd db shell` | Same as `db:shell` (subcommand form) |
+| `lerd db import [-s service] [-d name] <file.sql>` | Same as `db:import` (subcommand form) |
+| `lerd db export [-s service] [-d name]` | Same as `db:export` (subcommand form) |
+| `lerd db shell [-s service] [-d name]` | Same as `db:shell` (subcommand form) |
+
+### Flags
+
+| Flag | Short | Description |
+|---|---|---|
+| `--service <name>` | `-s` | Target a specific lerd service (e.g. `mysql`, `postgres`, `mysql-5-7`) |
+| `--database <name>` | `-d` | Override the database name |
+| `--output <file>` | `-o` | Output file for `db:export` (default: `<database>.sql`) |
+
+---
+
+## Service and database resolution
+
+Every db command resolves which service to target and which database to use through the following chain (first match wins):
+
+1. **`--service` flag** — explicit override, e.g. `lerd db:shell --service postgres`
+2. **`.lerd.yaml` `db:` block** — declared in the project root, works even on unlinked sites
+3. **Framework definition** — lerd detects the framework and uses its service detection rules against the framework's env file (e.g. `.env.local` for Symfony)
+4. **`.env` key inference** — reads `DB_CONNECTION`, `DB_TYPE`, `TYPEORM_CONNECTION`, `DATABASE_URL`, or `DB_PORT` from `.env`
+5. **Error** — with instructions listing all options above
+
+The `--database` flag overrides the database name at any resolution level.
+
+### `.lerd.yaml` `db:` block
+
+Add a `db:` block to `.lerd.yaml` to set a persistent default for the project. Useful for non-PHP projects that don't have a lerd framework definition.
+
+```yaml
+db:
+  service: postgres
+  database: myapp
+```
+
+### Supported `.env` keys
+
+When falling back to `.env` inference, lerd checks the following keys in order to determine the database type:
+
+| Key | Frameworks |
+|---|---|
+| `DB_CONNECTION` | Laravel (`mysql`, `pgsql`, …) |
+| `DB_TYPE` | TypeORM / NestJS (`postgres`, `mysql`, …) |
+| `TYPEORM_CONNECTION` | TypeORM CLI |
+| `DATABASE_URL` | Prisma, Drizzle, Symfony, Next.js (`postgresql://…`, `mysql://…`) |
+| `DB_PORT` | Last resort — `5432` → postgres, `3306`/`3307` → mysql |
+
+The database name is resolved from `DB_DATABASE`, `TYPEORM_DATABASE`, or the path component of `DATABASE_URL` (Prisma's `?schema=public` suffix is stripped automatically).
 
 ---
 
@@ -22,16 +68,14 @@ Database shortcuts read `DB_CONNECTION`, `DB_DATABASE`, `DB_USERNAME`, and `DB_P
 Name is resolved in this order (first match wins):
 
 1. Explicit `[name]` argument
-2. `DB_DATABASE` from the project's `.env`
+2. Database name from the resolution chain above
 3. Project name derived from the registered site name (or directory name)
 
 A `<name>_testing` database is always created alongside the main one. If a database already exists the command reports it instead of failing.
 
-Supports `DB_CONNECTION=mysql` / `mariadb` (via `lerd-mysql`) and `pgsql` / `postgres` (via `lerd-postgres`).
-
 ---
 
-## Picking a database for a project
+## Picking a database for a Laravel project
 
 The database for a Laravel project is configured through `.lerd.yaml` and applied to `.env` when `lerd env` runs (which the `lerd init` wizard calls automatically). The supported choices are:
 
@@ -41,10 +85,31 @@ The database for a Laravel project is configured through `.lerd.yaml` and applie
 | `mysql` | `lerd-mysql` (Podman) | `DB_CONNECTION=mysql`, `DB_HOST=lerd-mysql`, `DB_PORT=3306`, `DB_DATABASE=<project>`, `DB_USERNAME=root`, `DB_PASSWORD=lerd` |
 | `postgres` | `lerd-postgres` (Podman) | `DB_CONNECTION=pgsql`, `DB_HOST=lerd-postgres`, `DB_PORT=5432`, `DB_DATABASE=<project>`, `DB_USERNAME=postgres`, `DB_PASSWORD=lerd` |
 
-Picking a database is exclusive — `.lerd.yaml` only ever lists one of `sqlite`, `mysql`, or `postgres`. Switching between them in the wizard immediately rewrites the relevant `.env` keys; the previous database's settings are not preserved.
+For SQLite, the `database/database.sqlite` file is created automatically if it doesn't exist. No service is started.
 
-For SQLite, the `database/database.sqlite` file is created automatically if it doesn't exist, and the `database/` directory is created alongside it. No service is started.
+For MySQL or PostgreSQL, the matching `lerd-<engine>` service is started if it isn't already, and the project database (plus a `_testing` variant) is created via `lerd db:create`.
 
-For MySQL or PostgreSQL, the matching `lerd-<engine>` service is started if it isn't already, and the project database (plus a `_testing` variant) is created via `lerd db:create`. The database name is inferred from the registered site name, or from `DB_DATABASE` in `.env` if it was set explicitly.
+You can change the choice at any time by editing the `services:` list in `.lerd.yaml` and re-running `lerd env`, or by running `lerd init --fresh` and picking a different database in the wizard.
 
-You can change the choice at any time by editing the `services:` list in `.lerd.yaml` (replace the current database entry with the desired one) and re-running `lerd env`, or by running `lerd init --fresh` and picking a different database in the wizard.
+---
+
+## Non-PHP projects
+
+For projects without a lerd framework definition (NestJS, Next.js, Go, etc.), db commands work without any lerd-specific configuration if the project's `.env` uses a recognised key:
+
+```bash
+# NestJS / TypeORM — DB_TYPE is sufficient
+lerd db:shell
+
+# Next.js / Prisma — DATABASE_URL is sufficient
+lerd db:shell
+
+# No .env at all — use --service
+lerd db:shell --service postgres --database myapp
+
+# Or declare it once in .lerd.yaml
+# db:
+#   service: postgres
+#   database: myapp
+lerd db:shell
+```

--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -251,25 +251,16 @@ func loadDBEnv(cwd string) (*dbEnv, error) {
 		return nil, fmt.Errorf("DB_DATABASE not set in .env")
 	}
 
-	// Credentials: use individual vars when present; fall back to lerd service defaults.
-	// We do not use credentials from DATABASE_URL — lerd connects via podman exec
-	// using the container's fixed root/lerd credentials.
+	// Always use container admin credentials. Ignoring app-level DB_USERNAME /
+	// DB_PASSWORD avoids authenticating as a role that doesn't exist in the
+	// container (e.g. DB_USERNAME=root against pgsql).
 	svcDefaults := serviceToDBEnv(connToService(conn))
-	username := vals["DB_USERNAME"]
-	if username == "" {
-		username = svcDefaults.username
-	}
-	password := vals["DB_PASSWORD"]
-	if password == "" {
-		password = svcDefaults.password
-	}
-
 	return &dbEnv{
 		service:    connToService(conn),
 		connection: conn,
 		database:   db,
-		username:   username,
-		password:   password,
+		username:   svcDefaults.username,
+		password:   svcDefaults.password,
 	}, nil
 }
 
@@ -464,6 +455,28 @@ func runDbShell(flagService, flagDatabase string) error {
 		return fmt.Errorf("could not start %s: %w", env.service, err)
 	}
 
+	if env.database != "" {
+		exists, err := databaseExists(env.service, env.database)
+		if err != nil {
+			return fmt.Errorf("checking database %q: %w", env.database, err)
+		}
+		if !exists {
+			if !isInteractive() {
+				return fmt.Errorf("database %q does not exist in %s — run 'lerd db:create %s'", env.database, env.service, env.database)
+			}
+			fmt.Printf("Database %q does not exist in %s. Create it? [Y/n] ", env.database, env.service)
+			var answer string
+			fmt.Scanln(&answer) //nolint:errcheck
+			if answer != "" && answer[0] != 'Y' && answer[0] != 'y' {
+				return fmt.Errorf("database %q does not exist", env.database)
+			}
+			if _, err := createDatabase(env.service, env.database); err != nil {
+				return fmt.Errorf("creating database %q: %w", env.database, err)
+			}
+			fmt.Printf("Created database %q\n", env.database)
+		}
+	}
+
 	container := "lerd-" + env.service
 	var cmd *exec.Cmd
 	switch env.connection {
@@ -484,6 +497,44 @@ func runDbShell(flagService, flagDatabase string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+// databaseExists returns whether the named database exists in the given lerd
+// DB service's container. Uses the same admin credentials createDatabase uses.
+func databaseExists(svc, name string) (bool, error) {
+	container := "lerd-" + svc
+	family := svc
+	if inferred := config.InferFamily(svc); inferred != "" {
+		family = inferred
+	}
+	switch family {
+	case "mysql", "mariadb":
+		binaries := []string{"mysql", "mariadb"}
+		if family == "mariadb" {
+			binaries = []string{"mariadb", "mysql"}
+		}
+		var lastErr error
+		for _, bin := range binaries {
+			check := podman.Cmd("exec", container, bin, "-uroot", "-plerd",
+				"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", name))
+			out, err := check.Output()
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			return strings.TrimSpace(string(out)) != "0", nil
+		}
+		return false, lastErr
+	case "postgres":
+		cmd := podman.Cmd("exec", container, "psql", "-U", "postgres", "-tAc",
+			fmt.Sprintf("SELECT 1 FROM pg_database WHERE datname='%s';", name))
+		out, err := cmd.Output()
+		if err != nil {
+			return false, err
+		}
+		return strings.TrimSpace(string(out)) == "1", nil
+	}
+	return true, nil
 }
 
 // connToService maps a DB_CONNECTION value to the lerd service name.
@@ -585,20 +636,11 @@ func loadDBEnvLenient(cwd string) (*dbEnv, error) {
 	}
 
 	svcDefaults := serviceToDBEnv(connToService(conn))
-	username := vals["DB_USERNAME"]
-	if username == "" {
-		username = svcDefaults.username
-	}
-	password := vals["DB_PASSWORD"]
-	if password == "" {
-		password = svcDefaults.password
-	}
-
 	return &dbEnv{
 		service:    connToService(conn),
 		connection: conn,
 		database:   db,
-		username:   username,
-		password:   password,
+		username:   svcDefaults.username,
+		password:   svcDefaults.password,
 	}, nil
 }

--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -3,11 +3,13 @@ package cli
 import (
 	"bufio"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
@@ -38,38 +40,175 @@ func NewDbCreateCmd() *cobra.Command { return newDbCreateCmd("db:create") }
 func NewDbShellCmd() *cobra.Command { return newDbShellCmd("db:shell") }
 
 func newDbImportCmd(use string) *cobra.Command {
-	var database string
+	var database, service string
 	cmd := &cobra.Command{
 		Use:   use + " <file.sql>",
 		Short: "Import a SQL dump into a database (default: site DB from .env)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runDbImport(args[0], database)
+			return runDbImport(args[0], service, database)
 		},
 	}
-	cmd.Flags().StringVarP(&database, "database", "d", "", "Database name (default: DB_DATABASE from .env)")
+	cmd.Flags().StringVarP(&database, "database", "d", "", "Database name (default: from .env or .lerd.yaml)")
+	cmd.Flags().StringVarP(&service, "service", "s", "", "Lerd DB service to target (e.g. mysql, postgres)")
 	return cmd
 }
 
 func newDbExportCmd(use string) *cobra.Command {
-	var output, database string
+	var output, database, service string
 	cmd := &cobra.Command{
 		Use:   use,
 		Short: "Export a database to a SQL dump (default: site DB from .env)",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return runDbExport(output, database)
+			return runDbExport(output, service, database)
 		},
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "", "Output file (default: <database>.sql)")
-	cmd.Flags().StringVarP(&database, "database", "d", "", "Database name (default: DB_DATABASE from .env)")
+	cmd.Flags().StringVarP(&database, "database", "d", "", "Database name (default: from .env or .lerd.yaml)")
+	cmd.Flags().StringVarP(&service, "service", "s", "", "Lerd DB service to target (e.g. mysql, postgres)")
 	return cmd
 }
 
 type dbEnv struct {
-	connection string
+	service    string // lerd service name → container "lerd-<service>"
+	connection string // dialect: "mysql"/"mariadb"/"pgsql"/"postgres"
 	database   string
 	username   string
 	password   string
+}
+
+// serviceToDBEnv returns dialect and default credentials for a given lerd service name.
+// The family is inferred from the service name prefix.
+func serviceToDBEnv(name string) *dbEnv {
+	lower := strings.ToLower(name)
+	if strings.HasPrefix(lower, "postgres") || lower == "pgsql" {
+		return &dbEnv{service: name, connection: "pgsql", username: "postgres", password: "lerd"}
+	}
+	// mysql, mariadb, mysql-5-7, etc.
+	return &dbEnv{service: name, connection: "mysql", username: "root", password: "lerd"}
+}
+
+// resolveDB resolves database connection config using the following priority:
+//  1. --service flag (flagService)
+//  2. .lerd.yaml db: block (present even on unlinked sites)
+//  3. Framework definition service detection (uses framework-specific env file + detect rules)
+//  4. .env file with generic key inference (DB_CONNECTION, DB_TYPE, DATABASE_URL, DB_PORT…)
+//  5. Error with instructions
+//
+// flagDatabase overrides the database name at any level.
+func resolveDB(cwd, flagService, flagDatabase string) (*dbEnv, error) {
+	var env *dbEnv
+
+	switch {
+	case flagService != "":
+		env = serviceToDBEnv(flagService)
+
+	default:
+		// Try .lerd.yaml db: block
+		if pc, err := config.LoadProjectConfig(cwd); err == nil && pc.DB.Service != "" {
+			env = serviceToDBEnv(pc.DB.Service)
+			if pc.DB.Database != "" {
+				env.database = pc.DB.Database
+			}
+			break
+		}
+		// Try framework definition (reads the framework's own env file with its detect rules)
+		if env = resolveDBFromFramework(cwd); env != nil {
+			break
+		}
+		// Fall back to .env with generic key inference
+		loaded, err := loadDBEnv(cwd)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"no DB config found — use --service <name>, add a db: block to .lerd.yaml, or create a .env file with DB_CONNECTION and DB_DATABASE",
+			)
+		}
+		env = loaded
+	}
+
+	if flagDatabase != "" {
+		env.database = flagDatabase
+	}
+	return env, nil
+}
+
+// resolveDBFromFramework detects the framework for cwd and uses its service
+// detection rules to identify which DB service is in use and what database name
+// to connect to. Returns nil when no framework is detected or no DB service matches.
+func resolveDBFromFramework(cwd string) *dbEnv {
+	fwName, ok := config.DetectFrameworkForDir(cwd)
+	if !ok {
+		return nil
+	}
+	fw, ok := config.GetFramework(fwName)
+	if !ok || len(fw.Env.Services) == 0 {
+		return nil
+	}
+
+	envRelPath, envFormat := fw.Env.Resolve(cwd)
+	readKey := makeEnvReader(filepath.Join(cwd, envRelPath), envFormat)
+
+	// Build a map of only the keys referenced in detect rules (avoid reading the whole file).
+	detectKeys := map[string]string{}
+	for _, def := range fw.Env.Services {
+		for _, rule := range def.Detect {
+			if _, seen := detectKeys[rule.Key]; !seen {
+				detectKeys[rule.Key] = readKey(rule.Key)
+			}
+		}
+	}
+
+	// Check known DB services in priority order.
+	for _, svc := range []string{"mysql", "postgres"} {
+		def, ok := fw.Env.Services[svc]
+		if !ok || !frameworkServiceDetected(def, detectKeys) {
+			continue
+		}
+		env := serviceToDBEnv(svc)
+		// Resolve database name from the framework's env file.
+		env.database = readKey("DB_DATABASE")
+		if env.database == "" {
+			if urlEnv := parseDBURL(readKey("DATABASE_URL")); urlEnv != nil {
+				env.database = urlEnv.database
+			}
+		}
+		return env
+	}
+	return nil
+}
+
+// resolveDBLenient is like resolveDB but does not require a database name to be
+// present (used by db:shell and db:create where it is optional).
+func resolveDBLenient(cwd, flagService, flagDatabase string) (*dbEnv, error) {
+	var env *dbEnv
+
+	switch {
+	case flagService != "":
+		env = serviceToDBEnv(flagService)
+
+	default:
+		if pc, err := config.LoadProjectConfig(cwd); err == nil && pc.DB.Service != "" {
+			env = serviceToDBEnv(pc.DB.Service)
+			if pc.DB.Database != "" {
+				env.database = pc.DB.Database
+			}
+			break
+		}
+		if env = resolveDBFromFramework(cwd); env != nil {
+			break
+		}
+		loaded, _ := loadDBEnvLenient(cwd)
+		if loaded != nil {
+			env = loaded
+		} else {
+			env = serviceToDBEnv("mysql") // default to mysql when nothing is configured
+		}
+	}
+
+	if flagDatabase != "" {
+		env.database = flagDatabase
+	}
+	return env, nil
 }
 
 func loadDBEnv(cwd string) (*dbEnv, error) {
@@ -94,36 +233,59 @@ func loadDBEnv(cwd string) (*dbEnv, error) {
 		return nil, err
 	}
 
-	conn := vals["DB_CONNECTION"]
+	urlEnv := parseDBURL(vals["DATABASE_URL"])
+
+	conn := inferDBConnection(vals)
 	if conn == "" {
-		return nil, fmt.Errorf("DB_CONNECTION not set in .env")
+		return nil, fmt.Errorf("cannot determine DB type from .env — set DB_CONNECTION, DB_TYPE, TYPEORM_CONNECTION, DATABASE_URL, or DB_PORT")
 	}
+
 	db := vals["DB_DATABASE"]
+	if db == "" {
+		db = vals["TYPEORM_DATABASE"]
+	}
+	if db == "" && urlEnv != nil {
+		db = urlEnv.database
+	}
 	if db == "" {
 		return nil, fmt.Errorf("DB_DATABASE not set in .env")
 	}
+
+	// Credentials: use individual vars when present; fall back to lerd service defaults.
+	// We do not use credentials from DATABASE_URL — lerd connects via podman exec
+	// using the container's fixed root/lerd credentials.
+	svcDefaults := serviceToDBEnv(connToService(conn))
+	username := vals["DB_USERNAME"]
+	if username == "" {
+		username = svcDefaults.username
+	}
+	password := vals["DB_PASSWORD"]
+	if password == "" {
+		password = svcDefaults.password
+	}
+
 	return &dbEnv{
+		service:    connToService(conn),
 		connection: conn,
 		database:   db,
-		username:   vals["DB_USERNAME"],
-		password:   vals["DB_PASSWORD"],
+		username:   username,
+		password:   password,
 	}, nil
 }
 
-func runDbImport(file, database string) error {
+func runDbImport(file, service, database string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
-	env, err := loadDBEnv(cwd)
+	env, err := resolveDB(cwd, service, database)
 	if err != nil {
 		return err
 	}
-	if database != "" {
-		env.database = database
-	}
 
-	ensureServicesForCwd(cwd)
+	if err := ensureServiceRunning(env.service); err != nil {
+		return fmt.Errorf("could not start %s: %w", env.service, err)
+	}
 
 	f, err := os.Open(file)
 	if err != nil {
@@ -148,34 +310,34 @@ func runDbImport(file, database string) error {
 }
 
 func dbImportCmd(env *dbEnv) (*exec.Cmd, error) {
+	container := "lerd-" + env.service
 	switch env.connection {
 	case "mysql", "mariadb":
 		return podman.Cmd("exec", "-i",
 			"-e", "MYSQL_PWD="+env.password,
-			"lerd-mysql",
+			container,
 			"mysql", "-u"+env.username, env.database), nil
 	case "pgsql", "postgres":
 		return podman.Cmd("exec", "-i", "-e", "PGPASSWORD="+env.password,
-			"lerd-postgres", "psql", "-U", env.username, env.database), nil
+			container, "psql", "-U", env.username, env.database), nil
 	default:
 		return nil, fmt.Errorf("unsupported DB_CONNECTION: %q (supported: mysql, pgsql)", env.connection)
 	}
 }
 
-func runDbExport(output, database string) error {
+func runDbExport(output, service, database string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
-	env, err := loadDBEnv(cwd)
+	env, err := resolveDB(cwd, service, database)
 	if err != nil {
 		return err
 	}
-	if database != "" {
-		env.database = database
-	}
 
-	ensureServicesForCwd(cwd)
+	if err := ensureServiceRunning(env.service); err != nil {
+		return fmt.Errorf("could not start %s: %w", env.service, err)
+	}
 
 	if output == "" {
 		output = env.database + ".sql"
@@ -205,61 +367,62 @@ func runDbExport(output, database string) error {
 }
 
 func dbExportCmd(env *dbEnv) (*exec.Cmd, error) {
+	container := "lerd-" + env.service
 	switch env.connection {
 	case "mysql", "mariadb":
 		return podman.Cmd("exec", "-i",
 			"-e", "MYSQL_PWD="+env.password,
-			"lerd-mysql",
+			container,
 			"mysqldump", "-u"+env.username, env.database), nil
 	case "pgsql", "postgres":
 		return podman.Cmd("exec", "-i", "-e", "PGPASSWORD="+env.password,
-			"lerd-postgres", "pg_dump", "-U", env.username, env.database), nil
+			container, "pg_dump", "-U", env.username, env.database), nil
 	default:
 		return nil, fmt.Errorf("unsupported DB_CONNECTION: %q (supported: mysql, pgsql)", env.connection)
 	}
 }
 
 func newDbCreateCmd(use string) *cobra.Command {
-	return &cobra.Command{
+	var service string
+	cmd := &cobra.Command{
 		Use:   use + " [name]",
 		Short: "Create a database (and testing database) for the current project",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runDbCreate(args)
+			return runDbCreate(service, args)
 		},
 	}
+	cmd.Flags().StringVarP(&service, "service", "s", "", "Lerd DB service to target (e.g. mysql, postgres)")
+	return cmd
 }
 
-func runDbCreate(args []string) error {
+func runDbCreate(flagService string, args []string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
 
-	env, _ := loadDBEnvLenient(cwd)
+	env, err := resolveDBLenient(cwd, flagService, "")
+	if err != nil {
+		return err
+	}
 
 	var dbName string
 	switch {
 	case len(args) > 0:
 		dbName = args[0]
-	case env != nil && env.database != "":
+	case env.database != "":
 		dbName = env.database
 	default:
 		dbName = projectDBName(cwd)
 	}
 
-	conn := "mysql"
-	if env != nil && env.connection != "" {
-		conn = env.connection
-	}
-	svc := connToService(conn)
-
-	if err := ensureServiceRunning(svc); err != nil {
-		return fmt.Errorf("could not start %s: %w", svc, err)
+	if err := ensureServiceRunning(env.service); err != nil {
+		return fmt.Errorf("could not start %s: %w", env.service, err)
 	}
 
 	for _, name := range []string{dbName, dbName + "_testing"} {
-		created, err := createDatabase(svc, name)
+		created, err := createDatabase(env.service, name)
 		if err != nil {
 			return fmt.Errorf("creating %q: %w", name, err)
 		}
@@ -273,42 +436,47 @@ func runDbCreate(args []string) error {
 }
 
 func newDbShellCmd(use string) *cobra.Command {
-	return &cobra.Command{
+	var service, database string
+	cmd := &cobra.Command{
 		Use:   use,
 		Short: "Open an interactive database shell for the current project",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return runDbShell()
+			return runDbShell(service, database)
 		},
 	}
+	cmd.Flags().StringVarP(&service, "service", "s", "", "Lerd DB service to target (e.g. mysql, postgres)")
+	cmd.Flags().StringVarP(&database, "database", "d", "", "Database to connect to")
+	return cmd
 }
 
-func runDbShell() error {
+func runDbShell(flagService, flagDatabase string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
 
-	conn := "mysql"
-	var dbName string
-	if env, _ := loadDBEnvLenient(cwd); env != nil {
-		conn = env.connection
-		dbName = env.database
+	env, err := resolveDBLenient(cwd, flagService, flagDatabase)
+	if err != nil {
+		return err
 	}
 
-	ensureServicesForCwd(cwd)
+	if err := ensureServiceRunning(env.service); err != nil {
+		return fmt.Errorf("could not start %s: %w", env.service, err)
+	}
 
+	container := "lerd-" + env.service
 	var cmd *exec.Cmd
-	switch conn {
+	switch env.connection {
 	case "pgsql", "postgres":
-		cmdArgs := []string{"exec", "--tty", "-i", "lerd-postgres", "psql", "-U", "postgres"}
-		if dbName != "" {
-			cmdArgs = append(cmdArgs, dbName)
+		cmdArgs := []string{"exec", "--tty", "-i", container, "psql", "-U", env.username}
+		if env.database != "" {
+			cmdArgs = append(cmdArgs, env.database)
 		}
 		cmd = podman.Cmd(cmdArgs...)
 	default:
-		cmdArgs := []string{"exec", "--tty", "-i", "lerd-mysql", "mysql", "-uroot", "-plerd"}
-		if dbName != "" {
-			cmdArgs = append(cmdArgs, dbName)
+		cmdArgs := []string{"exec", "--tty", "-i", container, "mysql", "-u" + env.username, "-p" + env.password}
+		if env.database != "" {
+			cmdArgs = append(cmdArgs, env.database)
 		}
 		cmd = podman.Cmd(cmdArgs...)
 	}
@@ -325,6 +493,59 @@ func connToService(conn string) string {
 		return "postgres"
 	default:
 		return "mysql"
+	}
+}
+
+// inferDBConnection resolves the database dialect from a parsed .env map.
+// Checks in priority order: DB_CONNECTION → DB_TYPE → TYPEORM_CONNECTION → DATABASE_URL → DB_PORT.
+func inferDBConnection(vals map[string]string) string {
+	for _, key := range []string{"DB_CONNECTION", "DB_TYPE", "TYPEORM_CONNECTION"} {
+		if v := vals[key]; v != "" {
+			return v
+		}
+	}
+	if u := parseDBURL(vals["DATABASE_URL"]); u != nil {
+		return u.connection
+	}
+	switch vals["DB_PORT"] {
+	case "5432":
+		return "pgsql"
+	case "3306", "3307":
+		return "mysql"
+	}
+	return ""
+}
+
+// parseDBURL parses a DATABASE_URL connection string and returns the dialect and
+// database name. Supports postgresql://, postgres://, mysql://, mysql2://, mariadb://.
+// Credentials from the URL are intentionally ignored — lerd always connects via
+// podman exec using the container's fixed credentials.
+func parseDBURL(rawURL string) *dbEnv {
+	if rawURL == "" {
+		return nil
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return nil
+	}
+	var conn string
+	switch strings.ToLower(u.Scheme) {
+	case "postgresql", "postgres":
+		conn = "pgsql"
+	case "mysql", "mysql2", "mariadb":
+		conn = "mysql"
+	default:
+		return nil
+	}
+	db := strings.TrimPrefix(u.Path, "/")
+	// Strip Prisma-style query params (e.g. ?schema=public)
+	if i := strings.IndexByte(db, '?'); i >= 0 {
+		db = db[:i]
+	}
+	return &dbEnv{
+		service:    connToService(conn),
+		connection: conn,
+		database:   db,
 	}
 }
 
@@ -351,10 +572,33 @@ func loadDBEnvLenient(cwd string) (*dbEnv, error) {
 		return nil, err
 	}
 
+	urlEnv := parseDBURL(vals["DATABASE_URL"])
+
+	conn := inferDBConnection(vals)
+
+	db := vals["DB_DATABASE"]
+	if db == "" {
+		db = vals["TYPEORM_DATABASE"]
+	}
+	if db == "" && urlEnv != nil {
+		db = urlEnv.database
+	}
+
+	svcDefaults := serviceToDBEnv(connToService(conn))
+	username := vals["DB_USERNAME"]
+	if username == "" {
+		username = svcDefaults.username
+	}
+	password := vals["DB_PASSWORD"]
+	if password == "" {
+		password = svcDefaults.password
+	}
+
 	return &dbEnv{
-		connection: vals["DB_CONNECTION"],
-		database:   vals["DB_DATABASE"],
-		username:   vals["DB_USERNAME"],
-		password:   vals["DB_PASSWORD"],
+		service:    connToService(conn),
+		connection: conn,
+		database:   db,
+		username:   username,
+		password:   password,
 	}, nil
 }

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -778,21 +778,24 @@ Arguments for ` + bt + `stripe_listen` + bt + `:
 - ` + bt + `webhook_path` + bt + ` (optional): webhook route path (default: ` + bt + `"/stripe/webhook"` + bt + `)
 
 ### ` + bt + `db_export` + bt + `
-Export a database to a SQL dump file. Arguments:
-- ` + bt + `path` + bt + ` (optional): absolute path to the Laravel project root — defaults to the current working directory (or ` + bt + `LERD_SITE_PATH` + bt + ` if set by ` + bt + `mcp:inject` + bt + `)
-- ` + bt + `database` + bt + ` (optional): database name to export (defaults to ` + bt + `DB_DATABASE` + bt + ` from ` + bt + `.env` + bt + `)
+Export a database to a SQL dump file. Works with any project type — service and database are auto-detected. Arguments:
+- ` + bt + `path` + bt + ` (optional): absolute path to the project root — defaults to the current working directory (or ` + bt + `LERD_SITE_PATH` + bt + ` if set by ` + bt + `mcp:inject` + bt + `)
+- ` + bt + `service` + bt + ` (optional): lerd service name to target (e.g. ` + bt + `mysql` + bt + `, ` + bt + `postgres` + bt + `) — overrides auto-detection
+- ` + bt + `database` + bt + ` (optional): database name to export — overrides auto-detection
 - ` + bt + `output` + bt + ` (optional): output file path (defaults to ` + bt + `<database>.sql` + bt + ` in the project root)
 
 ### ` + bt + `db_import` + bt + `
-Import a SQL dump file into the project database. Reads connection details from ` + bt + `.env` + bt + `. The database service must already be running. Arguments:
+Import a SQL dump file into the project database. Service and database are auto-detected; the service is started if not already running. Arguments:
 - ` + bt + `file` + bt + ` (required): absolute path to the SQL file to import
 - ` + bt + `path` + bt + ` (optional): absolute path to the project root — defaults to the current working directory
-- ` + bt + `database` + bt + ` (optional): database name to import into (defaults to ` + bt + `DB_DATABASE` + bt + ` from ` + bt + `.env` + bt + `)
+- ` + bt + `service` + bt + ` (optional): lerd service name to target — overrides auto-detection
+- ` + bt + `database` + bt + ` (optional): database name to import into — overrides auto-detection
 
 ### ` + bt + `db_create` + bt + `
-Create a database and a ` + bt + `<name>_testing` + bt + ` variant for the project. Infers the database name and engine from ` + bt + `.env` + bt + `, falling back to the project directory name. The service must be running. Arguments:
+Create a database and a ` + bt + `<name>_testing` + bt + ` variant for the project. Service and database name are auto-detected; the service is started if not already running. Arguments:
 - ` + bt + `path` + bt + ` (optional): absolute path to the project root
-- ` + bt + `name` + bt + ` (optional): database name (defaults to ` + bt + `DB_DATABASE` + bt + ` from ` + bt + `.env` + bt + `)
+- ` + bt + `service` + bt + ` (optional): lerd service name to target — overrides auto-detection
+- ` + bt + `name` + bt + ` (optional): database name — overrides auto-detection
 
 ### ` + bt + `logs` + bt + `
 Fetch recent container logs. ` + bt + `target` + bt + ` is optional — when omitted, returns logs for the current site's PHP-FPM container (resolved from ` + bt + `LERD_SITE_PATH` + bt + `). Specify ` + bt + `target` + bt + ` only when you want a different container:
@@ -1053,9 +1056,9 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `service_remove` + bt + ` | Stop and deregister a custom service |
 | ` + bt + `service_expose` + bt + ` | Add or remove an extra published port on a built-in service (persisted) |
 | ` + bt + `service_env` + bt + ` | Return the recommended ` + bt + `.env` + bt + ` connection variables for a service |
-| ` + bt + `db_export` + bt + ` | Export a database to a SQL dump file (defaults to site DB from ` + bt + `.env` + bt + `) |
-| ` + bt + `db_import` + bt + ` | Import a SQL dump file into the project database (reads connection from ` + bt + `.env` + bt + `) |
-| ` + bt + `db_create` + bt + ` | Create a database and ` + bt + `_testing` + bt + ` variant (infers name from ` + bt + `.env` + bt + ` or project dir) |
+| ` + bt + `db_export` + bt + ` | Export a database to a SQL dump file — auto-detects service and database; accepts optional ` + bt + `service` + bt + ` override |
+| ` + bt + `db_import` + bt + ` | Import a SQL dump file into the project database — auto-detects service and database; starts the service if needed |
+| ` + bt + `db_create` + bt + ` | Create a database and ` + bt + `_testing` + bt + ` variant — auto-detects service and name; starts the service if needed |
 | ` + bt + `queue_start` + bt + ` | Start the queue worker for a site (any framework with a queue worker) |
 | ` + bt + `queue_stop` + bt + ` | Stop the queue worker |
 | ` + bt + `horizon_start` + bt + ` | Start Laravel Horizon for a site (use instead of queue_start when laravel/horizon is installed) |
@@ -1115,8 +1118,8 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - ` + bt + `framework_add` + bt + ` accepts ` + bt + `workers` + bt + ` (map) and ` + bt + `setup` + bt + ` (array) — both support an optional ` + bt + `check` + bt + ` field (` + bt + `{file}` + bt + ` or ` + bt + `{composer}` + bt + `) to conditionally show based on project deps; for Laravel, custom setup commands replace built-in storage:link/migrate/db:seed
 - Framework env vars support service version placeholders: ` + bt + `{{mysql_version}}` + bt + `, ` + bt + `{{postgres_version}}` + bt + `, ` + bt + `{{redis_version}}` + bt + `, ` + bt + `{{meilisearch_version}}` + bt + ` — resolved from the running service image tag
 - ` + bt + `php_ext_add` + bt + ` / ` + bt + `php_ext_remove` + bt + ` rebuild the FPM image and restart the container — may take a minute; ` + bt + `version` + bt + ` defaults to the project or global PHP version
-- ` + bt + `db_import` + bt + ` requires the database service to be running; pipe the file by absolute path — it reads connection info from ` + bt + `.env` + bt + `
-- ` + bt + `db_create` + bt + ` always creates both ` + bt + `<name>` + bt + ` and ` + bt + `<name>_testing` + bt + ` databases; safe to call if they already exist
+- ` + bt + `db_import` + bt + ` / ` + bt + `db_export` + bt + ` / ` + bt + `db_create` + bt + ` auto-detect service and database via: ` + bt + `service` + bt + ` arg → framework definition detect rules → ` + bt + `DB_CONNECTION` + bt + ` / ` + bt + `DB_TYPE` + bt + ` / ` + bt + `TYPEORM_CONNECTION` + bt + ` / ` + bt + `DATABASE_URL` + bt + ` / ` + bt + `DB_PORT` + bt + `; pass ` + bt + `service` + bt + ` explicitly for projects with no env config
+- ` + bt + `db_create` + bt + ` always creates both ` + bt + `<name>` + bt + ` and ` + bt + `<name>_testing` + bt + ` databases; safe to call if they already exist; starts the service automatically if not running
 - ` + bt + `park` + bt + ` auto-registers all PHP subdirectories as sites in one call; ` + bt + `unpark` + bt + ` removes them all — project files are NOT deleted
 `
 

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -8,6 +8,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// ProjectDB holds optional database targeting info for the project.
+// Setting these in .lerd.yaml lets db commands work without a .env file,
+// which is useful for non-PHP projects (NestJS, Go, etc.).
+type ProjectDB struct {
+	Service  string `yaml:"service,omitempty"`
+	Database string `yaml:"database,omitempty"`
+}
+
 // ProjectConfig holds per-project configuration stored in .lerd.yaml.
 type ProjectConfig struct {
 	Domains          []string                   `yaml:"domains,omitempty"`
@@ -24,7 +32,8 @@ type ProjectConfig struct {
 	// the framework-configured URL key) on every `lerd env` run. Committed to
 	// the repo so the choice is shared across machines. Takes precedence over
 	// the per-machine override in sites.yaml.
-	AppURL string `yaml:"app_url,omitempty"`
+	AppURL string    `yaml:"app_url,omitempty"`
+	DB     ProjectDB `yaml:"db,omitempty"`
 }
 
 // IsEmpty returns true when the config has no meaningful content, which
@@ -32,7 +41,8 @@ type ProjectConfig struct {
 func (c *ProjectConfig) IsEmpty() bool {
 	return len(c.Domains) == 0 && c.PHPVersion == "" && c.NodeVersion == "" &&
 		c.Framework == "" && len(c.Services) == 0 && len(c.Workers) == 0 &&
-		len(c.CustomWorkers) == 0 && !c.Secured && c.AppURL == ""
+		len(c.CustomWorkers) == 0 && !c.Secured && c.AppURL == "" &&
+		c.DB.Service == "" && c.DB.Database == ""
 }
 
 // ServiceNames returns the name of every service in the config, for callers


### PR DESCRIPTION
## Summary

- DB commands (`db:import`, `db:export`, `db:create`, `db:shell`) now work with any project type — NestJS, Next.js, Go, etc. — without requiring a linked site or PHP-style `.env`
- All four commands gain a `--service` / `-s` flag to target any lerd service by name
- Adds a `db:` block to `.lerd.yaml` for persistent per-project defaults on unlinked sites
- Container name is derived from the service name rather than hardcoded to `lerd-mysql` / `lerd-postgres`

**Resolution chain (first match wins):**
1. `--service` flag
2. `.lerd.yaml` `db:` block
3. Framework definition detect rules (uses framework-specific env file — correct for Symfony's `.env.local`, etc.)
4. `.env` key inference: `DB_CONNECTION` → `DB_TYPE` → `TYPEORM_CONNECTION` → `DATABASE_URL` (Prisma/Drizzle/Symfony) → `DB_PORT`

Fully backward compatible — PHP/Laravel projects are unaffected.