### PR TITLE
feat(env): skip .env backup when lerd has already written the file

### DIFF
--- a/docs/features/env-setup.md
+++ b/docs/features/env-setup.md
@@ -40,7 +40,7 @@ Services prefixed with `From .lerd.yaml` were not referenced in the env file but
 
 ## Automatic backup
 
-The first time `lerd env` modifies an existing `.env`, it saves a copy as `.env.before_lerd` in the project root. This backup is created once and never overwritten on subsequent runs.
+The first time `lerd env` modifies an existing `.env` that has not yet been touched by lerd, it saves a copy as `.env.before_lerd` in the project root and adds the file to `.gitignore` (if one exists). Once lerd has written its connection values to `.env`, subsequent runs skip the backup entirely — so deleting `.env.before_lerd` is safe and it will never be recreated.
 
 The backup lets you:
 - **See exactly what lerd changed** — diff `.env.before_lerd` against `.env`

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -62,7 +62,7 @@ Setup steps include common tasks (composer install, npm install, lerd env) plus 
 | `lerd unsecure [name]` | Remove TLS and switch back to HTTP — updates `APP_URL` in `.env` |
 | `lerd pause [name]` | Pause a site: stop its workers and replace the vhost with a landing page |
 | `lerd unpause [name]` | Resume a paused site: restore its vhost and restart previously running workers |
-| `lerd env` | Configure `.env` for the current project with lerd service connection settings; backs up the original as `.env.before_lerd` on first run |
+| `lerd env` | Configure `.env` for the current project with lerd service connection settings; backs up the original as `.env.before_lerd` on first run (skipped if lerd has already written to the file) |
 | `lerd env:restore` | Restore `.env` from the pre-lerd backup (`.env.before_lerd`) |
 | `lerd env:check` | Compare all `.env` files against `.env.example` and flag missing or extra keys |
 

--- a/docs/usage/import-sail.md
+++ b/docs/usage/import-sail.md
@@ -84,7 +84,7 @@ Use `--sail-db-*` flags only when your project uses non-default Sail credentials
 
 ### `.env.before_lerd`
 
-When `lerd env` first modifies a project's `.env`, it saves the original file as `.env.before_lerd`. The import command reads S3 detection keys (`FILESYSTEM_DISK`, `AWS_ENDPOINT`, `AWS_BUCKET`) from this backup when it exists, so the original Sail S3 configuration is used even after lerd has overwritten `.env`.
+When `lerd env` first modifies a project's `.env` (before lerd has written any values to it), it saves the original file as `.env.before_lerd`. The import command reads S3 detection keys (`FILESYSTEM_DISK`, `AWS_ENDPOINT`, `AWS_BUCKET`) from this backup when it exists, so the original Sail S3 configuration is used even after lerd has overwritten `.env`.
 
 ---
 

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -141,14 +141,19 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		}
 	} else {
 		fmt.Printf("Updating existing %s...\n", envRelPath)
-		// Back up the original .env the first time lerd modifies it, so the user
-		// can inspect what changed and restore it with `lerd env:restore`.
+		// Back up the original .env the first time lerd modifies it (so the user
+		// can inspect what changed and restore with `lerd env:restore`), but only
+		// if lerd hasn't already written to it — detected by presence of the word
+		// "lerd" in the file (e.g. DB_HOST=lerd-mysql).
 		backupPath := filepath.Join(cwd, ".env.before_lerd")
-		if _, err := os.Stat(backupPath); os.IsNotExist(err) {
-			if err := copyEnvFile(envPath, backupPath); err != nil {
-				fmt.Printf("  [WARN] could not back up %s: %v\n", envRelPath, err)
-			} else {
-				fmt.Printf("  Backed up original %s → .env.before_lerd\n", envRelPath)
+		if !envFileHasLerd(envPath) {
+			if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+				if err := copyEnvFile(envPath, backupPath); err != nil {
+					fmt.Printf("  [WARN] could not back up %s: %v\n", envRelPath, err)
+				} else {
+					fmt.Printf("  Backed up original %s → .env.before_lerd\n", envRelPath)
+					addToGitignore(cwd, ".env.before_lerd")
+				}
 			}
 		}
 	}
@@ -922,6 +927,38 @@ func runEnvRestore(_ *cobra.Command, _ []string) error {
 	fmt.Println("Restored .env from .env.before_lerd")
 	fmt.Println("Run 'lerd env' again to re-apply lerd connection settings.")
 	return nil
+}
+
+// addToGitignore appends entry to dir/.gitignore if the file exists and the
+// entry is not already present. Failures are silently ignored.
+func addToGitignore(dir, entry string) {
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	data, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		return // file doesn't exist or can't be read — skip
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == entry {
+			return // already present
+		}
+	}
+	content := string(data)
+	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += entry + "\n"
+	_ = os.WriteFile(gitignorePath, []byte(content), 0644)
+}
+
+// envFileHasLerd reports whether path already contains lerd-written values.
+// lerd always writes hostnames like "lerd-mysql", "lerd-redis", etc., so a
+// simple substring search is sufficient.
+func envFileHasLerd(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(data)), "lerd")
 }
 
 // copyEnvFile copies src to dst with 0644 permissions.


### PR DESCRIPTION
## What

- `lerd env` no longer recreates `.env.before_lerd` after the user deletes it
- When the backup is first created, `.env.before_lerd` is added to `.gitignore` (if one exists)

## How

Scan `.env` for the word `lerd` before deciding whether to backup. Since lerd always writes values like `DB_HOST=lerd-mysql`, any file lerd has touched will contain `lerd` — so the backup is only created for truly original, pre-lerd files.

Running `lerd env:restore` then `lerd env` still works correctly: the restored file has no `lerd` values, so a fresh backup is created.