### PR TITLE
fix(tray): open dashboard, update prompt, quit stops everything

### DIFF
--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -820,6 +820,7 @@ func runStop(_ *cobra.Command, _ []string) error {
 	units = append(units, registeredStripeUnits()...)
 	units = append(units, registeredScheduleUnits()...)
 	units = append(units, registeredReverbUnits()...)
+	units = append(units, registeredFrameworkWorkerUnits()...)
 	// Stop scheduled-worker timers explicitly. Stopping the sibling
 	// oneshot .service is a no-op (it isn't running between firings),
 	// so without this the timer keeps dispatching after `lerd stop`.
@@ -852,7 +853,7 @@ func runQuit(_ *cobra.Command, _ []string) error {
 	}
 
 	// Stop process units.
-	for _, unit := range []string{"lerd-ui", "lerd-watcher"} {
+	for _, unit := range []string{"lerd-ui", "lerd-watcher", "lerd-tray"} {
 		fmt.Printf("  --> %s ... ", unit)
 		if err := podman.StopUnit(unit); err != nil {
 			fmt.Printf("WARN (%v)\n", err)
@@ -860,10 +861,8 @@ func runQuit(_ *cobra.Command, _ []string) error {
 			fmt.Println("OK")
 		}
 	}
-
-	// Kill the tray.
+	// Also kill any directly-launched tray instance not managed by launchd/systemd.
 	killTray()
-	fmt.Println("  --> lerd-tray ... OK")
 
 	return nil
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -66,7 +66,7 @@ func runUpdate(currentVersion string, beta bool) error {
 	// Strip "v" prefix and any git-describe suffix (e.g. "-dirty", "-5-gabcdef")
 	// so local dev builds compare cleanly against release tags. Preserve semver
 	// pre-release suffixes like "-beta.1".
-	cur := stripGitDescribe(lerdUpdate.StripV(currentVersion))
+	cur := lerdUpdate.StripGitDescribe(lerdUpdate.StripV(currentVersion))
 	lat := lerdUpdate.StripV(latest)
 
 	if !lerdUpdate.VersionGreaterThan(lat, cur) {
@@ -264,53 +264,6 @@ func copyFile(src, dest string, mode os.FileMode) error {
 }
 
 func stripV(v string) string { return lerdUpdate.StripV(v) }
-
-// stripGitDescribe removes git-describe suffixes like "-dirty" or "-5-gabcdef"
-// while preserving semver pre-release tags like "-beta.1" or "-rc.1".
-// Git-describe suffixes contain a commit hash segment starting with "g".
-func stripGitDescribe(v string) string {
-	for {
-		i := strings.LastIndexByte(v, '-')
-		if i < 0 {
-			break
-		}
-		suffix := v[i+1:]
-		if suffix == "dirty" {
-			v = v[:i]
-			continue
-		}
-		// Git describe hash segment: g followed by hex chars.
-		// Also strip the preceding commit-count segment (e.g. "-5-gabcdef").
-		if len(suffix) > 1 && suffix[0] == 'g' && isHex(suffix[1:]) {
-			v = v[:i]
-			// Now check if the new last segment is a numeric commit count.
-			if j := strings.LastIndexByte(v, '-'); j >= 0 && isNumeric(v[j+1:]) {
-				v = v[:j]
-			}
-			continue
-		}
-		break
-	}
-	return v
-}
-
-func isHex(s string) bool {
-	for _, c := range s {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
-			return false
-		}
-	}
-	return len(s) > 0
-}
-
-func isNumeric(s string) bool {
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return false
-		}
-	}
-	return len(s) > 0
-}
 
 // backupBinary copies the current binary and version to backup locations for rollback.
 func backupBinary(self, currentVersion string) {

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -293,9 +293,9 @@ func TestStripGitDescribe(t *testing.T) {
 		{"1.5.0-beta.1-3-g1a2b3c4", "1.5.0-beta.1"},
 	}
 	for _, c := range cases {
-		got := stripGitDescribe(c.in)
+		got := lerdUpdate.StripGitDescribe(c.in)
 		if got != c.want {
-			t.Errorf("stripGitDescribe(%q) = %q, want %q", c.in, got, c.want)
+			t.Errorf("StripGitDescribe(%q) = %q, want %q", c.in, got, c.want)
 		}
 	}
 }

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -414,5 +415,9 @@ func handleQuit(item *systray.MenuItem, cancel context.CancelFunc) {
 }
 
 func openURL(url string) {
-	_ = exec.Command("xdg-open", url).Start()
+	cmd := "open"
+	if runtime.GOOS == "linux" {
+		cmd = "xdg-open"
+	}
+	_ = exec.Command(cmd, url).Start()
 }

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -37,11 +37,13 @@ func CachedUpdateCheck(currentVersion string) (*UpdateInfo, error) {
 		return nil, nil
 	}
 
-	if !VersionGreaterThan(StripV(latest), StripV(currentVersion)) {
+	cur := StripGitDescribe(StripV(currentVersion))
+	lat := StripV(latest)
+	if !VersionGreaterThan(lat, cur) {
 		return nil, nil
 	}
 
-	changelog, _ := FetchChangelog(StripV(currentVersion), StripV(latest))
+	changelog, _ := FetchChangelog(cur, lat)
 	return &UpdateInfo{
 		LatestVersion: latest,
 		Changelog:     changelog,

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -106,3 +106,50 @@ func StripV(v string) string {
 	}
 	return v
 }
+
+// StripGitDescribe removes git-describe suffixes like "-dirty" or "-5-gabcdef"
+// while preserving semver pre-release tags like "-beta.1" or "-rc.1".
+// Git-describe suffixes contain a commit hash segment starting with "g".
+func StripGitDescribe(v string) string {
+	for {
+		i := strings.LastIndexByte(v, '-')
+		if i < 0 {
+			break
+		}
+		suffix := v[i+1:]
+		if suffix == "dirty" {
+			v = v[:i]
+			continue
+		}
+		// Git describe hash segment: g followed by hex chars.
+		// Also strip the preceding commit-count segment (e.g. "-5-gabcdef").
+		if len(suffix) > 1 && suffix[0] == 'g' && isHex(suffix[1:]) {
+			v = v[:i]
+			// Now check if the new last segment is a numeric commit count.
+			if j := strings.LastIndexByte(v, '-'); j >= 0 && isNumeric(v[j+1:]) {
+				v = v[:j]
+			}
+			continue
+		}
+		break
+	}
+	return v
+}
+
+func isHex(s string) bool {
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
+func isNumeric(s string) bool {
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
+}


### PR DESCRIPTION
## What

Four tray bugs fixed in one pass:

**Open Dashboard does nothing**
`openURL` was hardcoded to `xdg-open` (Linux-only). Now uses `open` on macOS, `xdg-open` on Linux via `runtime.GOOS`.

**Update prompt shown even when already on latest version**
`CachedUpdateCheck` compared the raw binary version (`v1.13.1-2-gabcdef`) against the GitHub release tag (`v1.13.1`). The semver logic treated `-2-gabcdef` as a pre-release suffix, making the release appear newer than the dev build. Fix: strip git-describe suffixes before comparing. `StripGitDescribe` is moved into the `update` package so both `CachedUpdateCheck` and the CLI share the same implementation.

**Quit Lerd restarts the tray instead of stopping it**
`lerd-tray.service` has `Restart=on-failure` → `KeepAlive=true` in the launchd plist. `killTray()` (plain `pkill`) triggers an unexpected exit, so launchd revives the tray. Fix: stop `lerd-tray` via `podman.StopUnit` first (`launchctl bootout` on macOS, `systemctl --user stop` on Linux), then `killTray()` as a fallback for directly-launched instances.

**Quit/stop leaves horizon and other framework workers running**
`runStop` included queue/stripe/schedule/reverb/timer units but was missing `registeredFrameworkWorkerUnits()` (horizon, vite-dev, etc.). These are started in `runStart` phase 2 but were never stopped.