### PR TITLE
release: v1.14.1 — restore node version dropdown on site rows

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,14 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.14.1] — 2026-04-16
+
+### Fixed
+
+- **Node version dropdown missing from site rows in the dashboard**. The 1.14.0 `node_managed_by_lerd` gate was implemented as an outer `<template x-if>` wrapping two inner templates (empty-list placeholder and populated `<select>`). Alpine.js's `x-if` directive only renders a single child element, so the outer template silently rendered nothing and the Node dropdown disappeared for every site, even on machines where lerd manages Node. Flattened into two sibling templates that each include the `node_managed_by_lerd` condition inline, matching the existing PHP dropdown pattern.
+
+---
+
 ## [1.14.0] — 2026-04-16
 
 ### Added

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -702,23 +702,21 @@
                       </template>
                     </select>
                   </template>
-                  <template x-if="systemStatus && systemStatus.node_managed_by_lerd">
-                    <template x-if="nodeVersions.length === 0">
-                      <span class="text-xs text-gray-400 border border-gray-200 dark:border-lerd-border rounded px-2 py-1 opacity-50">Node ...</span>
-                    </template>
-                    <template x-if="nodeVersions.length > 0">
-                      <select
-                        x-model="selectedSite.node_version"
-                        @change="setSiteVersion(selectedSite, 'node', selectedSite.node_version)"
-                        class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors [&>option]:bg-white [&>option]:dark:bg-lerd-card [&>option]:text-gray-900 [&>option]:dark:text-gray-200"
-                        :disabled="selectedSite.versionLoading"
-                      >
-                        <option value="">Node default</option>
-                        <template x-for="v in nodeVersions" :key="v">
-                          <option :value="v" x-text="'Node ' + v"></option>
-                        </template>
-                      </select>
-                    </template>
+                  <template x-if="systemStatus && systemStatus.node_managed_by_lerd && nodeVersions.length === 0">
+                    <span class="text-xs text-gray-400 border border-gray-200 dark:border-lerd-border rounded px-2 py-1 opacity-50">Node ...</span>
+                  </template>
+                  <template x-if="systemStatus && systemStatus.node_managed_by_lerd && nodeVersions.length > 0">
+                    <select
+                      x-model="selectedSite.node_version"
+                      @change="setSiteVersion(selectedSite, 'node', selectedSite.node_version)"
+                      class="text-xs bg-transparent border border-gray-200 dark:border-lerd-border rounded px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-none focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors [&>option]:bg-white [&>option]:dark:bg-lerd-card [&>option]:text-gray-900 [&>option]:dark:text-gray-200"
+                      :disabled="selectedSite.versionLoading"
+                    >
+                      <option value="">Node default</option>
+                      <template x-for="v in nodeVersions" :key="v">
+                        <option :value="v" x-text="'Node ' + v"></option>
+                      </template>
+                    </select>
                   </template>
 
                   <!-- HTTPS -->

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.14.0"
+	Version = "1.14.1"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

- Fix Alpine `x-if` nesting bug that hid the per-site Node version dropdown in the dashboard after 1.14.0. The `node_managed_by_lerd` gate was wrapping two inner templates in an outer `<template x-if>`, which Alpine does not support (x-if renders a single child), so the dropdown rendered nothing on every machine, even ones where lerd manages Node. Flattened into two sibling templates that each include the managed-by-lerd condition inline, matching the PHP dropdown pattern.

Version bump to 1.14.1 and CHANGELOG entry.