### PR TITLE
feat: per-project custom container support

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -70,6 +70,7 @@ func main() {
 	root.AddCommand(cli.NewInitCmd())
 	root.AddCommand(cli.NewLinkCmd())
 	root.AddCommand(cli.NewUnlinkCmd())
+	root.AddCommand(cli.NewRestartCmd())
 	root.AddCommand(cli.NewUnparkCmd())
 	root.AddCommand(cli.NewSitesCmd())
 	root.AddCommand(cli.NewSecureCmd())
@@ -405,37 +406,42 @@ func newWatchCmd() *cobra.Command {
 						}
 						siteChanged := false
 
-						// Re-detect PHP version in case .lerd.yaml or .php-version changed.
-						{
-							phpMin, phpMax := "", ""
-							if site.Framework != "" {
-								if fw, fwOk := config.GetFrameworkForDir(site.Framework, sitePath); fwOk {
-									phpMin, phpMax = fw.PHP.Min, fw.PHP.Max
-								}
-							}
-							detected := phpDet.DetectVersionClamped(sitePath, phpMin, phpMax, site.PHPVersion)
-							if detected != site.PHPVersion {
-								fmt.Printf("PHP version changed for %s: %s -> %s\n", site.Name, site.PHPVersion, detected)
-								site.PHPVersion = detected
-								siteChanged = true
-								if !site.Paused {
-									if site.Secured {
-										_ = nginx.GenerateSSLVhost(*site, detected)
-									} else {
-										_ = nginx.GenerateVhost(*site, detected)
-									}
-									if err := nginx.Reload(); err != nil {
-										fmt.Printf("[WARN] nginx reload after php version change for %s: %v\n", site.Name, err)
+						// Custom container sites don't use PHP/Node version
+						// detection — skip re-detection to avoid overwriting
+						// the empty values with defaults.
+						if !site.IsCustomContainer() {
+							// Re-detect PHP version in case .lerd.yaml or .php-version changed.
+							{
+								phpMin, phpMax := "", ""
+								if site.Framework != "" {
+									if fw, fwOk := config.GetFrameworkForDir(site.Framework, sitePath); fwOk {
+										phpMin, phpMax = fw.PHP.Min, fw.PHP.Max
 									}
 								}
+								detected := phpDet.DetectVersionClamped(sitePath, phpMin, phpMax, site.PHPVersion)
+								if detected != site.PHPVersion {
+									fmt.Printf("PHP version changed for %s: %s -> %s\n", site.Name, site.PHPVersion, detected)
+									site.PHPVersion = detected
+									siteChanged = true
+									if !site.Paused {
+										if site.Secured {
+											_ = nginx.GenerateSSLVhost(*site, detected)
+										} else {
+											_ = nginx.GenerateVhost(*site, detected)
+										}
+										if err := nginx.Reload(); err != nil {
+											fmt.Printf("[WARN] nginx reload after php version change for %s: %v\n", site.Name, err)
+										}
+									}
+								}
 							}
-						}
 
-						// Re-detect Node version in case .lerd.yaml, .node-version, or .nvmrc changed.
-						if detected, detErr := nodeDet.DetectVersion(sitePath); detErr == nil && detected != site.NodeVersion {
-							fmt.Printf("Node version changed for %s: %s -> %s\n", site.Name, site.NodeVersion, detected)
-							site.NodeVersion = detected
-							siteChanged = true
+							// Re-detect Node version in case .lerd.yaml, .node-version, or .nvmrc changed.
+							if detected, detErr := nodeDet.DetectVersion(sitePath); detErr == nil && detected != site.NodeVersion {
+								fmt.Printf("Node version changed for %s: %s -> %s\n", site.Name, site.NodeVersion, detected)
+								site.NodeVersion = detected
+								siteChanged = true
+							}
 						}
 
 						if siteChanged {

--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -71,6 +71,7 @@ func main() {
 	root.AddCommand(cli.NewLinkCmd())
 	root.AddCommand(cli.NewUnlinkCmd())
 	root.AddCommand(cli.NewRestartCmd())
+	root.AddCommand(cli.NewRebuildCmd())
 	root.AddCommand(cli.NewUnparkCmd())
 	root.AddCommand(cli.NewSitesCmd())
 	root.AddCommand(cli.NewSecureCmd())

--- a/docs/features/custom-containers.md
+++ b/docs/features/custom-containers.md
@@ -168,7 +168,13 @@ LAN sharing works transparently since it proxies through nginx.
 
 ## Rebuilding
 
-To rebuild the image after changing your Containerfile, re-run `lerd link`. The image is rebuilt from scratch.
+`lerd rebuild` removes the old image, rebuilds from the Containerfile, and restarts the container:
+
+```bash
+lerd rebuild
+```
+
+`lerd link` reuses the cached image if it already exists. Use `lerd rebuild` when you change the Containerfile.
 
 ## CLI commands
 
@@ -179,6 +185,7 @@ To rebuild the image after changing your Containerfile, re-run `lerd link`. The 
 | `lerd secure` / `lerd unsecure` | Toggle HTTPS |
 | `lerd pause` / `lerd unpause` | Pause/resume the site and container |
 | `lerd restart` | Restart the container |
+| `lerd rebuild` | Rebuild image from Containerfile and restart |
 | `lerd worker start <name>` | Start a custom worker |
 | `lerd worker stop <name>` | Stop a custom worker |
 | `lerd worker list` | List available workers and status |

--- a/docs/features/custom-containers.md
+++ b/docs/features/custom-containers.md
@@ -13,9 +13,11 @@ Lerd can serve sites that use their own container instead of the shared PHP-FPM 
 
 ```dockerfile
 FROM node:20-alpine
-WORKDIR /app
+RUN npm install -g nodemon
 CMD ["npm", "run", "start:dev"]
 ```
+
+> The project directory is bind-mounted at runtime, so no `WORKDIR` or `COPY` is needed. Install any global CLI tools (nodemon, ts-node, etc.) in the image itself.
 
 2. Run `lerd init`:
 
@@ -57,6 +59,7 @@ The `container` section in `.lerd.yaml` accepts these fields:
 | `port` | yes | | Port the app listens on inside the container |
 | `containerfile` | no | `Containerfile.lerd` | Path to the Containerfile (relative to project root) |
 | `build_context` | no | `.` | Build context directory (relative to project root) |
+| `ssl` | no | `false` | Set to `true` if the app serves HTTPS on its port (nginx will `proxy_pass https://` with `proxy_ssl_verify off`) |
 
 ## How it works
 
@@ -79,6 +82,16 @@ Services work exactly the same as for PHP sites. Containers on the `lerd` networ
 ## HTTPS
 
 `lerd secure` and `lerd unsecure` work with custom container sites. The nginx vhost is regenerated with SSL termination, and your app continues to receive plain HTTP from nginx.
+
+If your app itself serves HTTPS on its port (e.g. it has its own TLS cert), set `ssl: true` under `container:` so nginx proxies via HTTPS:
+
+```yaml
+container:
+  port: 3000
+  ssl: true
+```
+
+Nginx will use `proxy_pass https://` and skip certificate verification (`proxy_ssl_verify off`) since the container cert is self-signed. Run `lerd check` to confirm the setting is recognised.
 
 ## Hot reload
 

--- a/docs/features/custom-containers.md
+++ b/docs/features/custom-containers.md
@@ -46,6 +46,8 @@ lerd link
 
 Lerd builds the image, creates a dedicated container, and configures nginx to reverse-proxy to it.
 
+> **Important:** `lerd link` must be called **after** both files exist. Calling it without the `container:` section in `.lerd.yaml` registers the project as a PHP-FPM site instead. If that happened, run `lerd unlink` first, then set up the files and link again. If you haven't written `.lerd.yaml` yet, run `lerd init` instead of writing it by hand — it detects the `Containerfile.lerd` and runs the custom container wizard for you.
+
 ## Configuration
 
 The `container` section in `.lerd.yaml` accepts these fields:
@@ -77,6 +79,31 @@ Services work exactly the same as for PHP sites. Containers on the `lerd` networ
 ## HTTPS
 
 `lerd secure` and `lerd unsecure` work with custom container sites. The nginx vhost is regenerated with SSL termination, and your app continues to receive plain HTTP from nginx.
+
+## Hot reload
+
+The project directory is bind-mounted into the container at the same absolute path, so file edits on the host are immediately visible inside the container. However, **filesystem watch events (inotify) do not fire** across the virtiofs mount boundary that Podman Machine uses on macOS. File watchers that rely on inotify (nodemon's default, Vite, webpack, etc.) will not detect changes.
+
+Use polling instead:
+
+| Tool | Polling flag |
+|------|-------------|
+| nodemon | `--legacy-watch` |
+| Vite | `--watch` (already polls) or set `server.watch.usePolling: true` in `vite.config` |
+| NestJS | `nest start --watch` uses nodemon — add `--legacy-watch` via `nodemon.json`: `{"legacyWatch": true}` |
+| webpack | `watchOptions: { poll: 1000 }` in webpack config |
+
+Example `package.json`:
+
+```json
+{
+  "scripts": {
+    "start:dev": "nodemon --legacy-watch src/main.js"
+  }
+}
+```
+
+The polling interval is typically 1–2 seconds, which is fine for dev.
 
 ## Workers
 

--- a/docs/features/custom-containers.md
+++ b/docs/features/custom-containers.md
@@ -1,0 +1,144 @@
+---
+title: Custom Containers
+description: Run non-PHP sites with per-project Containerfiles
+---
+
+# Custom Containers
+
+Lerd can serve sites that use their own container instead of the shared PHP-FPM image. This lets you run Node.js, Python, Ruby, Go, or any other runtime alongside your PHP sites, with full access to services, HTTPS, LAN sharing, and workers.
+
+## Quick start
+
+1. Create a `Containerfile.lerd` in your project root:
+
+```dockerfile
+FROM node:20-alpine
+WORKDIR /app
+CMD ["npm", "run", "start:dev"]
+```
+
+2. Run `lerd init`:
+
+```bash
+cd ~/projects/nestapp
+lerd init
+```
+
+When no PHP project is detected and a `Containerfile.lerd` exists, the wizard switches to custom container mode and asks for the container port, containerfile path, HTTPS, and services. The answers are saved to `.lerd.yaml`.
+
+Alternatively, write `.lerd.yaml` manually:
+
+```yaml
+domains:
+  - nestapp
+container:
+  port: 3000
+services:
+  - mysql
+  - redis
+```
+
+3. Link the site:
+
+```bash
+lerd link
+```
+
+Lerd builds the image, creates a dedicated container, and configures nginx to reverse-proxy to it.
+
+## Configuration
+
+The `container` section in `.lerd.yaml` accepts these fields:
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `port` | yes | | Port the app listens on inside the container |
+| `containerfile` | no | `Containerfile.lerd` | Path to the Containerfile (relative to project root) |
+| `build_context` | no | `.` | Build context directory (relative to project root) |
+
+## How it works
+
+When you `lerd link` a project with a `container` section:
+
+1. The image is built from your Containerfile and tagged `lerd-custom-{sitename}:local`
+2. A systemd quadlet is written so the container starts automatically
+3. The container joins the `lerd` network (same as PHP-FPM and services)
+4. Nginx is configured to `proxy_pass` to the container instead of `fastcgi_pass`
+5. Your project directory is bind-mounted into the container
+
+## Services
+
+Services work exactly the same as for PHP sites. Containers on the `lerd` network can reach services by name:
+
+- MySQL: `lerd-mysql:3306`
+- Redis: `lerd-redis:6379`
+- PostgreSQL: `lerd-postgres:5432`
+
+## HTTPS
+
+`lerd secure` and `lerd unsecure` work with custom container sites. The nginx vhost is regenerated with SSL termination, and your app continues to receive plain HTTP from nginx.
+
+## Workers
+
+Define workers in `.lerd.yaml` using `custom_workers`:
+
+```yaml
+container:
+  port: 3000
+custom_workers:
+  dev-server:
+    label: Dev Server
+    command: npm run start:dev
+    restart: always
+  queue:
+    label: Queue Worker
+    command: node dist/queue.js
+    restart: on-failure
+```
+
+Workers exec into the custom container, so they have access to the same filesystem and environment.
+
+Worker config fields:
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `label` | no | worker name | Display name in the dashboard |
+| `command` | yes | | Shell command to run inside the container |
+| `restart` | no | `always` | `always` or `on-failure` |
+| `schedule` | no | | systemd OnCalendar expression for timer-based workers |
+| `conflicts_with` | no | | Worker names to stop before starting this one |
+
+Worker definitions stay in `custom_workers` permanently. The `workers` list tracks which are active and is synced by start/stop commands.
+
+## LAN sharing
+
+LAN sharing works transparently since it proxies through nginx.
+
+## Pausing
+
+`lerd pause` stops the custom container and all workers, replacing the nginx vhost with a landing page. `lerd unpause` starts the container back up and restores workers.
+
+## Restarting
+
+`lerd restart` restarts the custom container without rebuilding the image. Useful after config changes inside the container.
+
+## Unlinking
+
+`lerd unlink` stops the custom container, removes the quadlet, and cleans up the image.
+
+## Rebuilding
+
+To rebuild the image after changing your Containerfile, re-run `lerd link`. The image is rebuilt from scratch.
+
+## CLI commands
+
+| Command | Description |
+|---------|-------------|
+| `lerd link` | Build image, create container, generate nginx vhost |
+| `lerd unlink` | Stop container, remove image, quadlet, and vhost |
+| `lerd secure` / `lerd unsecure` | Toggle HTTPS |
+| `lerd pause` / `lerd unpause` | Pause/resume the site and container |
+| `lerd restart` | Restart the container |
+| `lerd worker start <name>` | Start a custom worker |
+| `lerd worker stop <name>` | Stop a custom worker |
+| `lerd worker list` | List available workers and status |

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -118,8 +118,9 @@ Once the MCP server is connected, your AI assistant has access to:
 | `framework_remove` | Remove a user-defined framework; for `laravel` removes only custom worker additions |
 | `site_php` | Change the PHP version for a registered site — writes `.php-version`, updates registry, regenerates nginx vhost |
 | `site_node` | Change the Node.js version for a registered site — writes `.node-version`, installs via fnm if needed |
-| `site_pause` | Pause a site: stop all its workers and replace its vhost with a landing page |
-| `site_unpause` | Resume a paused site: restore its vhost and restart previously running workers |
+| `site_pause` | Pause a site: stop workers and custom container, replace vhost with landing page |
+| `site_unpause` | Resume a paused site: start container, restore vhost, restart workers |
+| `site_restart` | Restart a site's container (custom container or PHP-FPM) |
 | `service_pin` | Pin a service so it is never auto-stopped even when no sites reference it |
 | `service_unpin` | Unpin a service so it can be auto-stopped when unused |
 | `stripe_listen` | Start a Stripe webhook listener for a site (reads `STRIPE_SECRET` from `.env`) |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -63,6 +63,7 @@ Setup steps include common tasks (composer install, npm install, lerd env) plus 
 | `lerd pause [name]` | Pause a site: stop workers (and custom container if applicable), replace vhost with landing page |
 | `lerd unpause [name]` | Resume a paused site: start container, restore vhost, restart workers |
 | `lerd restart [name]` | Restart the container for the current or named site (custom container or PHP-FPM) |
+| `lerd rebuild [name]` | Rebuild the custom container image from Containerfile and restart |
 | `lerd env` | Configure `.env` for the current project with lerd service connection settings; backs up the original as `.env.before_lerd` on first run (skipped if lerd has already written to the file) |
 | `lerd env:restore` | Restore `.env` from the pre-lerd backup (`.env.before_lerd`) |
 | `lerd env:check` | Compare all `.env` files against `.env.example` and flag missing or extra keys |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -60,8 +60,9 @@ Setup steps include common tasks (composer install, npm install, lerd env) plus 
 | `lerd share [name]` | Expose the site publicly via ngrok, cloudflared, or Expose (auto-detected) |
 | `lerd secure [name]` | Issue a mkcert TLS cert and enable HTTPS — updates `APP_URL` in `.env` |
 | `lerd unsecure [name]` | Remove TLS and switch back to HTTP — updates `APP_URL` in `.env` |
-| `lerd pause [name]` | Pause a site: stop its workers and replace the vhost with a landing page |
-| `lerd unpause [name]` | Resume a paused site: restore its vhost and restart previously running workers |
+| `lerd pause [name]` | Pause a site: stop workers (and custom container if applicable), replace vhost with landing page |
+| `lerd unpause [name]` | Resume a paused site: start container, restore vhost, restart workers |
+| `lerd restart [name]` | Restart the container for the current or named site (custom container or PHP-FPM) |
 | `lerd env` | Configure `.env` for the current project with lerd service connection settings; backs up the original as `.env.before_lerd` on first run (skipped if lerd has already written to the file) |
 | `lerd env:restore` | Restore `.env` from the pre-lerd backup (`.env.before_lerd`) |
 | `lerd env:check` | Compare all `.env` files against `.env.example` and flag missing or extra keys |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -52,7 +52,7 @@ Setup steps include common tasks (composer install, npm install, lerd env) plus 
 |---|---|
 | `lerd park [dir]` | Register all Laravel projects inside `dir` (defaults to cwd) |
 | `lerd unpark [dir]` | Remove a parked directory and unlink all its sites |
-| `lerd link [name]` | Register the current directory as a site; prompts to import data when `laravel/sail` is detected in `composer.json` |
+| `lerd link [name]` | Register the current directory as a site; prompts to import data when `laravel/sail` is detected in `composer.json`. **Non-PHP projects** (Node.js, Python, Go, etc.) must have `Containerfile.lerd` and `.lerd.yaml` with `container: {port: N}` already written before calling this — see [Custom Containers](../features/custom-containers.md) |
 | `lerd link [name] --domain foo.test` | Register with a custom domain |
 | `lerd unlink [name]` | Stop serving the site |
 | `lerd sites` | Table view of all registered sites |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -44,6 +44,9 @@ A portable, self-contained description of a project's local environment. Created
 | `app_url` | Override for `APP_URL` (or the framework's URL key) written to `.env`. Highest priority — beats the per-machine `sites.yaml` override and the default `<scheme>://<primary-domain>` generator. Use for custom path prefixes, ports, or unrelated hostnames you want shared across machines |
 | `services` | Services to start on apply. Accepts built-in names, custom service names, or full inline definitions |
 | `workers` | Active worker names for the site (e.g. `queue`, `horizon`, `schedule`, `reverb`, `stripe`). Automatically kept in sync by start/stop commands. Used by `lerd start` to restore workers after reinstall |
+| `container` | Custom container config for non-PHP sites. When present, lerd builds a dedicated container from the project's Containerfile and nginx reverse-proxies to it. See below and [Custom Containers](../features/custom-containers.md) |
+| `custom_workers` | Custom worker definitions (name to config map). Works for both PHP and custom container sites. See below |
+| `db` | Database targeting for non-PHP projects: `service` (e.g. `mysql`, `postgres`) and `database` name |
 
 ### Basic example
 
@@ -56,6 +59,67 @@ services:
   - mysql
   - redis
 ```
+
+### Custom container example
+
+For non-PHP sites (Node.js, Python, Go, etc.), define a `container` section instead of `php_version` and `framework`:
+
+```yaml
+domains:
+  - nestapp
+container:
+  port: 3000
+  containerfile: Containerfile.lerd
+services:
+  - mysql
+  - redis
+custom_workers:
+  dev-server:
+    label: Dev Server
+    command: npm run start:dev
+    restart: always
+```
+
+When `container` is present, `php_version`, `framework`, and `node_version` are ignored.
+
+#### `container` fields
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `port` | yes | | Port the app listens on inside the container |
+| `containerfile` | no | `Containerfile.lerd` | Path to the Containerfile (relative to project root) |
+| `build_context` | no | `.` | Build context directory (relative to project root) |
+
+See [Custom Containers](../features/custom-containers.md) for the full guide.
+
+### Custom workers
+
+Custom workers can be defined for any site type (PHP or custom container). Each entry in `custom_workers` maps a name to a worker config:
+
+```yaml
+custom_workers:
+  queue:
+    label: Queue Worker
+    command: node dist/queue.js
+    restart: always
+  cron:
+    label: Cron Job
+    command: node dist/cron.js
+    restart: on-failure
+    schedule: minutely
+```
+
+#### Worker config fields
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `label` | no | worker name | Display name in the dashboard |
+| `command` | yes | | Shell command to run inside the container |
+| `restart` | no | `always` | `always` or `on-failure` |
+| `schedule` | no | | systemd OnCalendar expression for timer-based workers (e.g. `minutely`, `*-*-* *:00:00`) |
+| `conflicts_with` | no | | List of worker names to stop before starting this one |
+
+Worker definitions stay in `custom_workers` permanently. The `workers` field (a separate list of names) tracks which are currently active and is synced automatically by start/stop commands.
 
 ### Inline custom service definitions
 

--- a/docs/usage/sites.md
+++ b/docs/usage/sites.md
@@ -85,6 +85,20 @@ lerd init --fresh
 
 ---
 
+## Non-PHP / custom container sites
+
+For Node.js, Python, Go, or any other non-PHP runtime, lerd builds a dedicated container image per project and has nginx reverse-proxy to it. The workflow differs from PHP sites:
+
+1. Create a `Containerfile.lerd` in the project root that defines the runtime and start command.
+2. Run `lerd init` — it detects the non-PHP project (no `composer.json`) and switches to custom container mode, asking for the port, HTTPS, and services. It writes `.lerd.yaml` for you. Alternatively write `.lerd.yaml` manually with a `container: {port: N}` section.
+3. Run `lerd link` — it builds the image, starts the container as `lerd-custom-<sitename>`, and generates the nginx vhost.
+
+> **Important:** calling `lerd link` without the container config registers the project as a PHP-FPM site (wrong). If that happened, run `lerd unlink` first, set up the files, then `lerd link` again.
+
+See [Custom Containers](../features/custom-containers.md) for the full configuration reference.
+
+---
+
 ## Projects outside the home directory
 
 By default, the PHP-FPM and nginx containers only have access to files under `$HOME`. If your project lives elsewhere (e.g. `/var/www`, `/opt/projects`, `/var/local`), lerd automatically detects this and adds the required volume mount to both containers.

--- a/internal/certs/secure.go
+++ b/internal/certs/secure.go
@@ -18,7 +18,11 @@ func SecureSite(site config.Site) error {
 		return fmt.Errorf("issuing certificate: %w", err)
 	}
 
-	if err := nginx.GenerateSSLVhost(site, site.PHPVersion); err != nil {
+	if site.IsCustomContainer() {
+		if err := nginx.GenerateCustomSSLVhost(site); err != nil {
+			return fmt.Errorf("generating custom SSL vhost: %w", err)
+		}
+	} else if err := nginx.GenerateSSLVhost(site, site.PHPVersion); err != nil {
 		return fmt.Errorf("generating SSL vhost: %w", err)
 	}
 
@@ -49,7 +53,11 @@ func UnsecureSite(site config.Site) error {
 		return fmt.Errorf("removing SSL vhost: %w", err)
 	}
 
-	if err := nginx.GenerateVhost(site, site.PHPVersion); err != nil {
+	if site.IsCustomContainer() {
+		if err := nginx.GenerateCustomVhost(site); err != nil {
+			return fmt.Errorf("generating custom HTTP vhost: %w", err)
+		}
+	} else if err := nginx.GenerateVhost(site, site.PHPVersion); err != nil {
 		return fmt.Errorf("generating HTTP vhost: %w", err)
 	}
 

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -14,7 +14,7 @@ import (
 func NewCheckCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "check",
-		Short: "Validate .lerd.yaml syntax, services, and PHP version",
+		Short: "Validate .lerd.yaml — PHP version, services, workers, container config, custom_workers, and db",
 		RunE:  runCheck,
 	}
 }
@@ -82,52 +82,62 @@ func runCheck(_ *cobra.Command, _ []string) error {
 
 	// Workers
 	if len(cfg.Workers) > 0 {
-		fwName := cfg.Framework
-		fw, hasFw := config.GetFrameworkForDir(fwName, cwd)
-
-		hasQueue := false
-		hasHorizon := false
-		for _, w := range cfg.Workers {
-			if w == "queue" {
-				hasQueue = true
+		if cfg.Container != nil {
+			// Custom container site: workers must be defined in custom_workers.
+			for _, w := range cfg.Workers {
+				if _, ok := cfg.CustomWorkers[w]; ok {
+					fmt.Printf("  OK    worker: %s\n", w)
+				} else {
+					fmt.Printf("  FAIL  worker: %q is not defined in custom_workers\n", w)
+					errors++
+				}
 			}
-			if w == "horizon" {
-				hasHorizon = true
-			}
+		} else {
+			fwName := cfg.Framework
+			fw, hasFw := config.GetFrameworkForDir(fwName, cwd)
 
-			if !hasFw || fw.Workers == nil {
-				if fwName != "" {
-					fmt.Printf("  WARN  worker: %q — framework %s has no worker definitions\n", w, fwName)
+			hasQueue := false
+			hasHorizon := false
+			for _, w := range cfg.Workers {
+				if w == "queue" {
+					hasQueue = true
+				}
+				if w == "horizon" {
+					hasHorizon = true
+				}
+
+				if !hasFw || fw.Workers == nil {
+					if fwName != "" {
+						fmt.Printf("  WARN  worker: %q — framework %s has no worker definitions\n", w, fwName)
+						warnings++
+					} else {
+						fmt.Printf("  WARN  worker: %q — no framework detected\n", w)
+						warnings++
+					}
+					continue
+				}
+				wDef, ok := fw.Workers[w]
+				if !ok {
+					fmt.Printf("  FAIL  worker: %q is not defined for framework %s\n", w, fwName)
+					errors++
+					continue
+				}
+				if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
+					fmt.Printf("  WARN  worker: %s — prerequisite not met (check rule failed)\n", w)
 					warnings++
 				} else {
-					fmt.Printf("  WARN  worker: %q — no framework detected\n", w)
-					warnings++
+					fmt.Printf("  OK    worker: %s\n", w)
 				}
-				continue
 			}
-			wDef, ok := fw.Workers[w]
-			if !ok {
-				fmt.Printf("  FAIL  worker: %q is not defined for framework %s\n", w, fwName)
-				errors++
-				continue
-			}
-			// Check if the worker's prerequisite (Check rule) is satisfied.
-			if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
-				fmt.Printf("  WARN  worker: %s — prerequisite not met (check rule failed)\n", w)
+
+			if hasQueue && hasHorizon {
+				fmt.Printf("  WARN  workers: both queue and horizon are listed — horizon manages queues, queue worker will be skipped\n")
 				warnings++
-			} else {
-				fmt.Printf("  OK    worker: %s\n", w)
 			}
-		}
-
-		if hasQueue && hasHorizon {
-			fmt.Printf("  WARN  workers: both queue and horizon are listed — horizon manages queues, queue worker will be skipped\n")
-			warnings++
-		}
-
-		if hasQueue && SiteHasHorizon(cwd) {
-			fmt.Printf("  WARN  workers: queue is listed but laravel/horizon is installed — horizon will be started instead\n")
-			warnings++
+			if hasQueue && SiteHasHorizon(cwd) {
+				fmt.Printf("  WARN  workers: queue is listed but laravel/horizon is installed — horizon will be started instead\n")
+				warnings++
+			}
 		}
 	}
 
@@ -144,6 +154,21 @@ func runCheck(_ *cobra.Command, _ []string) error {
 			continue
 		}
 
+		if svc.Preset != "" {
+			// Preset reference — verify the preset exists in the catalog, then
+			// check whether it has been installed on this machine.
+			if _, err := config.LoadPreset(svc.Preset); err != nil {
+				fmt.Printf("  FAIL  service %q: unknown preset %q\n", svc.Name, svc.Preset)
+				errors++
+			} else if _, err := config.LoadCustomService(svc.Name); err != nil {
+				fmt.Printf("  WARN  service %s: preset %q not installed — run: lerd service preset install %s\n", svc.Name, svc.Preset, svc.Preset)
+				warnings++
+			} else {
+				fmt.Printf("  OK    service: %s (preset: %s)\n", svc.Name, svc.Preset)
+			}
+			continue
+		}
+
 		if isKnownService(svc.Name) {
 			fmt.Printf("  OK    service: %s\n", svc.Name)
 			continue
@@ -155,6 +180,56 @@ func runCheck(_ *cobra.Command, _ []string) error {
 		} else {
 			fmt.Printf("  FAIL  service %q: not a built-in service and no definition found at %s\n",
 				svc.Name, filepath.Join(config.CustomServicesDir(), svc.Name+".yaml"))
+			errors++
+		}
+	}
+
+	// Container
+	if cfg.Container != nil {
+		if cfg.Container.Port <= 0 || cfg.Container.Port > 65535 {
+			fmt.Printf("  FAIL  container.port: required and must be 1–65535\n")
+			errors++
+		} else {
+			fmt.Printf("  OK    container.port: %d\n", cfg.Container.Port)
+		}
+		cfPath := cfg.Container.Containerfile
+		if cfPath == "" {
+			cfPath = "Containerfile.lerd"
+		}
+		if _, err := os.Stat(filepath.Join(cwd, cfPath)); os.IsNotExist(err) {
+			fmt.Printf("  WARN  container.containerfile: %s not found — lerd link will fail\n", cfPath)
+			warnings++
+		} else {
+			fmt.Printf("  OK    container.containerfile: %s\n", cfPath)
+		}
+		if cfg.Container.BuildContext != "" {
+			if _, err := os.Stat(filepath.Join(cwd, cfg.Container.BuildContext)); os.IsNotExist(err) {
+				fmt.Printf("  WARN  container.build_context: %s not found\n", cfg.Container.BuildContext)
+				warnings++
+			} else {
+				fmt.Printf("  OK    container.build_context: %s\n", cfg.Container.BuildContext)
+			}
+		}
+	}
+
+	// custom_workers
+	for name, w := range cfg.CustomWorkers {
+		if w.Command == "" {
+			fmt.Printf("  FAIL  custom_worker.%s: command is required\n", name)
+			errors++
+		} else {
+			fmt.Printf("  OK    custom_worker.%s\n", name)
+		}
+	}
+
+	// db
+	if cfg.DB.Service != "" {
+		if isKnownService(cfg.DB.Service) {
+			fmt.Printf("  OK    db.service: %s\n", cfg.DB.Service)
+		} else if _, err := config.LoadCustomService(cfg.DB.Service); err == nil {
+			fmt.Printf("  OK    db.service: %s (custom)\n", cfg.DB.Service)
+		} else {
+			fmt.Printf("  FAIL  db.service: %q is not a known service\n", cfg.DB.Service)
 			errors++
 		}
 	}

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -210,6 +210,9 @@ func runCheck(_ *cobra.Command, _ []string) error {
 				fmt.Printf("  OK    container.build_context: %s\n", cfg.Container.BuildContext)
 			}
 		}
+		if cfg.Container.SSL {
+			fmt.Printf("  OK    container.ssl: true (nginx will proxy_pass via HTTPS with ssl_verify off)\n")
+		}
 	}
 
 	// custom_workers

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
 	phpPkg "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
 
@@ -84,6 +85,36 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		return nil, err
 	}
 
+	// Decide whether to offer the custom container wizard.
+	// If the existing config already has a container section (re-running
+	// --fresh), go straight to it. Otherwise check the project: no
+	// composer.json + no detected framework suggests a non-PHP project.
+	framework, hasFramework := resolveFramework(cwd)
+	hasComposer := fileExists(filepath.Join(cwd, "composer.json"))
+	hasContainerfile := podman.HasContainerfile(cwd)
+	alreadyCustom := defaults.Container != nil
+
+	if alreadyCustom {
+		return runCustomContainerWizard(cwd, defaults, gcfg)
+	}
+	if !hasFramework && !hasComposer && hasContainerfile {
+		return runCustomContainerWizard(cwd, defaults, gcfg)
+	}
+	if !hasFramework && !hasComposer {
+		useCustom := false
+		if err := huh.NewForm(huh.NewGroup(
+			huh.NewConfirm().
+				Title("No PHP project detected. Set up a custom container?").
+				Description("A Containerfile.lerd in the project root defines the container image").
+				Value(&useCustom),
+		)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
+			return nil, err
+		}
+		if useCustom {
+			return runCustomContainerWizard(cwd, defaults, gcfg)
+		}
+	}
+
 	// Seed defaults from the site registry when no saved config exists yet,
 	// so already-set PHP version and HTTPS state are reflected on first run.
 	if defaults.PHPVersion == "" && !defaults.Secured {
@@ -105,8 +136,6 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 			phpDefault = gcfg.PHP.DefaultVersion
 		}
 	}
-
-	framework, _ := resolveFramework(cwd)
 	phpMin, phpMax := "", ""
 	if framework != "" {
 		if fw, fwOk := config.GetFrameworkForDir(framework, cwd); fwOk {
@@ -417,6 +446,176 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		CustomWorkers:    filteredCustomWorkers,
 		AppURL:           defaults.AppURL,
 		Domains:          defaults.Domains,
+	}, nil
+}
+
+// runCustomContainerWizard runs the init wizard for custom container projects.
+// It collects the container port, containerfile path, HTTPS, services, and
+// custom workers, then returns a ProjectConfig with the container section.
+func runCustomContainerWizard(cwd string, defaults *config.ProjectConfig, gcfg *config.GlobalConfig) (*config.ProjectConfig, error) {
+	portStr := "3000"
+	containerfile := "Containerfile.lerd"
+	secured := defaults.Secured
+
+	if defaults.Container != nil {
+		if defaults.Container.Port > 0 {
+			portStr = fmt.Sprintf("%d", defaults.Container.Port)
+		}
+		if defaults.Container.Containerfile != "" {
+			containerfile = defaults.Container.Containerfile
+		}
+	}
+
+	// Seed secured from site registry if available.
+	if !defaults.Secured {
+		if site, err := config.FindSiteByPath(cwd); err == nil && site.Secured {
+			secured = true
+		}
+	}
+
+	if err := huh.NewForm(huh.NewGroup(
+		huh.NewInput().
+			Title("Container port").
+			Description("Port the app listens on inside the container").
+			Value(&portStr).
+			Validate(func(s string) error {
+				if s == "" {
+					return fmt.Errorf("port is required")
+				}
+				for _, c := range s {
+					if c < '0' || c > '9' {
+						return fmt.Errorf("port must be a number")
+					}
+				}
+				return nil
+			}),
+		huh.NewInput().
+			Title("Containerfile").
+			Description("Path relative to project root").
+			Value(&containerfile),
+		huh.NewConfirm().
+			Title("Enable HTTPS?").
+			Value(&secured),
+	)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
+		return nil, err
+	}
+
+	port := 0
+	fmt.Sscanf(portStr, "%d", &port)
+
+	// Services: same flow as the PHP wizard but without the database select
+	// since custom containers manage their own database connections.
+	serviceOptions := make([]string, 0, len(knownServices))
+	for _, svc := range knownServices {
+		serviceOptions = append(serviceOptions, svc)
+	}
+	if customs, err := config.ListCustomServices(); err == nil {
+		for _, svc := range customs {
+			if len(svc.EnvVars) == 0 && svc.EnvDetect == nil {
+				continue
+			}
+			serviceOptions = append(serviceOptions, svc.Name)
+		}
+	}
+
+	serviceDefaults := defaults.ServiceNames()
+	var selectedServices []string
+	copy(selectedServices, serviceDefaults)
+	selectedServices = serviceDefaults
+
+	if len(serviceOptions) > 0 {
+		if err := huh.NewForm(huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title("Services").
+				Options(huh.NewOptions(serviceOptions...)...).
+				Value(&selectedServices),
+		)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Custom workers from existing config.
+	var customWorkerNames []string
+	var keepCustomWorkers []string
+	if len(defaults.CustomWorkers) > 0 {
+		for name := range defaults.CustomWorkers {
+			customWorkerNames = append(customWorkerNames, name)
+		}
+		sort.Strings(customWorkerNames)
+		keepCustomWorkers = make([]string, len(customWorkerNames))
+		copy(keepCustomWorkers, customWorkerNames)
+
+		if err := huh.NewForm(huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title("Custom workers").
+				Description("Deselect to remove from .lerd.yaml").
+				Options(huh.NewOptions(customWorkerNames...)...).
+				Value(&keepCustomWorkers),
+		)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Build services list.
+	builtIn := make(map[string]bool, len(knownServices))
+	for _, s := range knownServices {
+		builtIn[s] = true
+	}
+	inlineByName := map[string]*config.CustomService{}
+	for _, svc := range defaults.Services {
+		if svc.Custom != nil {
+			inlineByName[svc.Name] = svc.Custom
+		}
+	}
+
+	services := make([]config.ProjectService, len(selectedServices))
+	for i, name := range selectedServices {
+		if builtIn[name] {
+			services[i] = config.ProjectService{Name: name}
+			continue
+		}
+		var loaded *config.CustomService
+		if svc, err := config.LoadCustomService(name); err == nil {
+			loaded = svc
+		} else if existing := inlineByName[name]; existing != nil {
+			loaded = existing
+		}
+		if loaded != nil && loaded.Preset != "" {
+			services[i] = config.ProjectService{
+				Name:          name,
+				Preset:        loaded.Preset,
+				PresetVersion: loaded.PresetVersion,
+			}
+			continue
+		}
+		services[i] = config.ProjectService{Name: name, Custom: loaded}
+	}
+
+	// Filter custom workers.
+	var filteredCustomWorkers map[string]config.FrameworkWorker
+	if len(keepCustomWorkers) > 0 {
+		filteredCustomWorkers = make(map[string]config.FrameworkWorker, len(keepCustomWorkers))
+		for _, name := range keepCustomWorkers {
+			if w, ok := defaults.CustomWorkers[name]; ok {
+				filteredCustomWorkers[name] = w
+			}
+		}
+	}
+
+	containerCfg := &config.ContainerConfig{
+		Port: port,
+	}
+	if containerfile != "Containerfile.lerd" && containerfile != "" {
+		containerCfg.Containerfile = containerfile
+	}
+
+	return &config.ProjectConfig{
+		Secured:       secured,
+		Services:      services,
+		CustomWorkers: filteredCustomWorkers,
+		Container:     containerCfg,
+		AppURL:        defaults.AppURL,
+		Domains:       defaults.Domains,
 	}, nil
 }
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -151,22 +151,39 @@ func runInstall(_ *cobra.Command, _ []string) error {
 			if site.Paused || site.Ignored {
 				continue
 			}
-			phpVer := site.PHPVersion
-			if phpVer == "" && cfg != nil {
-				phpVer = cfg.PHP.DefaultVersion
-			}
-			if site.Secured {
-				if err := nginx.GenerateSSLVhost(site, phpVer); err != nil {
-					fmt.Printf("\n    WARN %s: %v", site.PrimaryDomain(), err)
-					continue
+			if site.IsCustomContainer() {
+				if site.Secured {
+					if err := nginx.GenerateCustomSSLVhost(site); err != nil {
+						fmt.Printf("\n    WARN %s: %v", site.PrimaryDomain(), err)
+						continue
+					}
+					sslConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
+					mainConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
+					os.Remove(mainConf)          //nolint:errcheck
+					os.Rename(sslConf, mainConf) //nolint:errcheck
+				} else {
+					if err := nginx.GenerateCustomVhost(site); err != nil {
+						fmt.Printf("\n    WARN %s: %v", site.PrimaryDomain(), err)
+					}
 				}
-				sslConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
-				mainConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
-				os.Remove(mainConf)          //nolint:errcheck
-				os.Rename(sslConf, mainConf) //nolint:errcheck
 			} else {
-				if err := nginx.GenerateVhost(site, phpVer); err != nil {
-					fmt.Printf("\n    WARN %s: %v", site.PrimaryDomain(), err)
+				phpVer := site.PHPVersion
+				if phpVer == "" && cfg != nil {
+					phpVer = cfg.PHP.DefaultVersion
+				}
+				if site.Secured {
+					if err := nginx.GenerateSSLVhost(site, phpVer); err != nil {
+						fmt.Printf("\n    WARN %s: %v", site.PrimaryDomain(), err)
+						continue
+					}
+					sslConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
+					mainConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
+					os.Remove(mainConf)          //nolint:errcheck
+					os.Rename(sslConf, mainConf) //nolint:errcheck
+				} else {
+					if err := nginx.GenerateVhost(site, phpVer); err != nil {
+						fmt.Printf("\n    WARN %s: %v", site.PrimaryDomain(), err)
+					}
 				}
 			}
 		}

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -132,13 +132,14 @@ func runLink(args []string) error {
 	// Custom container path: the project defines its own Containerfile and
 	// nginx reverse-proxies to it. Skip PHP/framework detection entirely.
 	if proj != nil && proj.Container != nil && proj.Container.Port > 0 {
-		secured := siteops.CleanupRelink(cwd, name)
+		secured := siteops.CleanupRelink(cwd, name) || (proj != nil && proj.Secured)
 		site := config.Site{
 			Name:          name,
 			Domains:       domains,
 			Path:          cwd,
 			Secured:       secured,
 			ContainerPort: proj.Container.Port,
+			ContainerSSL:  proj.Container.SSL,
 		}
 		if err := config.AddSite(site); err != nil {
 			return fmt.Errorf("registering site: %w", err)
@@ -185,7 +186,7 @@ func runLink(args []string) error {
 		}
 	}
 
-	secured := siteops.CleanupRelink(cwd, name)
+	secured := siteops.CleanupRelink(cwd, name) || (proj != nil && proj.Secured)
 
 	site := config.Site{
 		Name:        name,

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -129,6 +129,28 @@ func runLink(args []string) error {
 	warnFilteredDomains(removed)
 	domains = kept
 
+	// Custom container path: the project defines its own Containerfile and
+	// nginx reverse-proxies to it. Skip PHP/framework detection entirely.
+	if proj != nil && proj.Container != nil && proj.Container.Port > 0 {
+		secured := siteops.CleanupRelink(cwd, name)
+		site := config.Site{
+			Name:          name,
+			Domains:       domains,
+			Path:          cwd,
+			Secured:       secured,
+			ContainerPort: proj.Container.Port,
+		}
+		if err := config.AddSite(site); err != nil {
+			return fmt.Errorf("registering site: %w", err)
+		}
+		_ = config.SyncProjectDomains(cwd, site.Domains, cfg.DNS.TLD)
+		if err := siteops.FinishCustomLink(site, proj.Container); err != nil {
+			return err
+		}
+		fmt.Printf("Linked: %s -> %s (custom container, port %d)\n", name, strings.Join(domains, ", "), proj.Container.Port)
+		return linkApplyServices(cwd, proj)
+	}
+
 	framework, ok := resolveFramework(cwd)
 	detectedPublicDir := ""
 	if !ok {
@@ -246,61 +268,68 @@ func runLink(args []string) error {
 			}
 		}
 
-		for _, svc := range proj.Services {
-			// Preset reference: install the bundled preset locally if the
-			// teammate's machine does not have it yet, so the project is
-			// portable across machines without inlining the definition.
-			if svc.Preset != "" {
-				if _, err := config.LoadCustomService(svc.Name); err != nil {
-					fmt.Printf("  Installing preset %s%s\n", svc.Preset, presetVersionSuffix(svc.PresetVersion))
-					if _, err := InstallPresetByName(svc.Preset, svc.PresetVersion); err != nil {
-						fmt.Printf("[WARN] installing preset %s: %v\n", svc.Preset, err)
-						continue
-					}
-				}
-			} else if svc.Custom != nil {
-				svc.Custom.Name = svc.Name
-				existing, loadErr := config.LoadCustomService(svc.Name)
-				shouldSave := true
-				if loadErr == nil {
-					action, err := confirmReplace("service", svc.Name, existing, svc.Custom)
-					if err != nil {
-						return err
-					}
-					switch action {
-					case replaceFromProject:
-						shouldSave = true
-					case replaceFromDisk:
-						svc.Custom = existing
-						shouldSave = false
-						// Update .lerd.yaml so the diff doesn't recur on next link.
-						if p, _ := config.LoadProjectConfig(cwd); p != nil {
-							for i, s := range p.Services {
-								if s.Name == svc.Name {
-									p.Services[i].Custom = existing
-									_ = config.SaveProjectConfig(cwd, p)
-									break
-								}
-							}
-						}
-					default:
-						shouldSave = false
-					}
-				}
-				if shouldSave {
-					if err := config.SaveCustomService(svc.Custom); err != nil {
-						fmt.Printf("[WARN] registering service %s: %v\n", svc.Name, err)
-						continue
-					}
-				}
-			}
-			if err := ensureServiceRunning(svc.Name); err != nil {
-				fmt.Printf("[WARN] service %s: %v\n", svc.Name, err)
-			}
+		if err := linkApplyServices(cwd, proj); err != nil {
+			return err
 		}
-
 	}
 
+	return nil
+}
+
+// linkApplyServices installs and starts services declared in .lerd.yaml.
+// Shared by both the standard PHP link path and the custom container path.
+func linkApplyServices(cwd string, proj *config.ProjectConfig) error {
+	if proj == nil {
+		return nil
+	}
+	for _, svc := range proj.Services {
+		if svc.Preset != "" {
+			if _, err := config.LoadCustomService(svc.Name); err != nil {
+				fmt.Printf("  Installing preset %s%s\n", svc.Preset, presetVersionSuffix(svc.PresetVersion))
+				if _, err := InstallPresetByName(svc.Preset, svc.PresetVersion); err != nil {
+					fmt.Printf("[WARN] installing preset %s: %v\n", svc.Preset, err)
+					continue
+				}
+			}
+		} else if svc.Custom != nil {
+			svc.Custom.Name = svc.Name
+			existing, loadErr := config.LoadCustomService(svc.Name)
+			shouldSave := true
+			if loadErr == nil {
+				action, err := confirmReplace("service", svc.Name, existing, svc.Custom)
+				if err != nil {
+					return err
+				}
+				switch action {
+				case replaceFromProject:
+					shouldSave = true
+				case replaceFromDisk:
+					svc.Custom = existing
+					shouldSave = false
+					if p, _ := config.LoadProjectConfig(cwd); p != nil {
+						for i, s := range p.Services {
+							if s.Name == svc.Name {
+								p.Services[i].Custom = existing
+								_ = config.SaveProjectConfig(cwd, p)
+								break
+							}
+						}
+					}
+				default:
+					shouldSave = false
+				}
+			}
+			if shouldSave {
+				if err := config.SaveCustomService(svc.Custom); err != nil {
+					fmt.Printf("[WARN] registering service %s: %v\n", svc.Name, err)
+					continue
+				}
+			}
+		}
+		if err := ensureServiceRunning(svc.Name); err != nil {
+			fmt.Printf("[WARN] service %s: %v\n", svc.Name, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -766,7 +766,10 @@ Pause or resume a site. Both take ` + bt + `site` + bt + ` (required, site name 
 Use this to free up resources for sites you're not actively working on without fully unlinking them.
 
 ### ` + bt + `site_restart` + bt + `
-Restart the container for a site. Takes ` + bt + `site` + bt + ` (required, site name from ` + bt + `sites` + bt + ` tool). For custom container sites this restarts the dedicated per-project container; for PHP sites it restarts the shared PHP-FPM container for that site's PHP version.
+Restart the container for a site without rebuilding the image. Takes ` + bt + `site` + bt + ` (required). For custom container sites this restarts the dedicated container; for PHP sites it restarts the shared FPM container.
+
+### ` + bt + `site_rebuild` + bt + `
+Rebuild the custom container image from the Containerfile and restart the container. Takes ` + bt + `site` + bt + ` (required). Use after changing the Containerfile. ` + bt + `site_link` + bt + ` reuses the cached image; ` + bt + `site_rebuild` + bt + ` forces a fresh build. Only works for custom container sites.
 
 ### ` + bt + `service_pin` + bt + ` / ` + bt + `service_unpin` + bt + `
 Pin or unpin a service. Both take ` + bt + `name` + bt + ` (required).
@@ -956,8 +959,8 @@ site_unpause(site: "old-project")  // restore and restart
 
 **Restart a site's container (e.g. after changing Containerfile):**
 ` + "```" + `
-site_restart(site: "nestjs-app")  // restarts lerd-custom-nestjs-app
-site_restart(site: "myapp")       // restarts lerd-php84-fpm (shared FPM)
+site_restart(site: "nestjs-app")  // restarts container (no rebuild)
+site_rebuild(site: "nestjs-app")  // rebuilds image from Containerfile + restarts
 ` + "```" + `
 
 **Keep a service always running regardless of active site:**
@@ -1199,6 +1202,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `site_pause` + bt + ` | Pause a site: stop workers and custom container, replace vhost with landing page |
 | ` + bt + `site_unpause` + bt + ` | Resume a paused site: start container, restore vhost, restart workers |
 | ` + bt + `site_restart` + bt + ` | Restart a site's container (custom container or PHP-FPM) |
+| ` + bt + `site_rebuild` + bt + ` | Rebuild custom container image from Containerfile and restart |
 | ` + bt + `service_pin` + bt + ` | Pin a service so it is never auto-stopped even when no sites reference it |
 | ` + bt + `service_unpin` + bt + ` | Unpin a service so it can be auto-stopped when unused |
 | ` + bt + `stripe_listen` + bt + ` | Start a Stripe webhook listener for a site |

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -605,6 +605,8 @@ Register or unregister a directory as a lerd site. Arguments for ` + bt + `site_
 - ` + bt + `path` + bt + ` (optional): absolute path to the project directory — defaults to ` + bt + `LERD_SITE_PATH` + bt + ` set by ` + bt + `mcp:inject` + bt + `
 - ` + bt + `name` + bt + ` (optional): domain name without TLD (e.g. ` + bt + `"myapp"` + bt + ` becomes ` + bt + `myapp.test` + bt + `; defaults to directory name, cleaned up)
 
+> **Non-PHP projects (Node.js, Python, Go, etc.):** a Containerfile and ` + bt + `.lerd.yaml` + bt + ` with a ` + bt + `container: {port: <N>}` + bt + ` section must exist **before** calling ` + bt + `site_link` + bt + `. The Containerfile can be named anything (` + bt + `Containerfile.lerd` + bt + ` is the default; set ` + bt + `container.containerfile` + bt + ` to point at a different name like ` + bt + `Dockerfile` + bt + `). Write ` + bt + `.lerd.yaml` + bt + ` directly (there is no MCP tool for this — see the custom container setup workflow in the Workflows section below), or ask the user to run ` + bt + `lerd init` + bt + ` which runs an interactive wizard and writes the file. Calling ` + bt + `site_link` + bt + ` without this config registers the site as a PHP-FPM site, which is wrong. If that happened, call ` + bt + `site_unlink` + bt + ` first, set up the files, then ` + bt + `site_link` + bt + ` again.
+
 ` + bt + `site_unlink` + bt + ` takes ` + bt + `path` + bt + ` (optional, same resolution as ` + bt + `site_link` + bt + `). Removes the site and all its domains. Project files are NOT deleted.
 
 ### ` + bt + `site_domain_add` + bt + ` / ` + bt + `site_domain_remove` + bt + `
@@ -1009,14 +1011,16 @@ check()   // validates .lerd.yaml syntax, services, PHP version
 
 **Set up a custom container site (Node.js, Python, Go, etc.):**
 
-1. Create a ` + bt + `Containerfile.lerd` + bt + ` in the project root:
+1. Create a ` + bt + `Containerfile.lerd` + bt + ` in the project root (do NOT add WORKDIR or COPY — lerd volume-mounts the project directory at its host path and sets --workdir automatically):
 ` + "```dockerfile" + `
 FROM node:20-alpine
-WORKDIR /app
+RUN npm install -g nodemon
 CMD ["npm", "run", "start:dev"]
 ` + "```" + `
 
-2. Create or update ` + bt + `.lerd.yaml` + bt + ` with the container section:
+   > **Hot-reload on macOS**: inotify events do not fire across Podman Machine's virtiofs mount. Use polling: nodemon needs ` + bt + `--legacy-watch` + bt + `, Vite needs ` + bt + `server.watch.usePolling: true` + bt + `, webpack needs ` + bt + `watchOptions: { poll: 1000 }` + bt + `. Example ` + bt + `package.json` + bt + `: ` + "`" + `"start:dev": "nodemon --legacy-watch src/main.js"` + "`" + `.
+
+2. Write ` + bt + `.lerd.yaml` + bt + ` with the container section (there is no MCP tool for this — write the file directly, or ask the user to run ` + bt + `lerd init` + bt + ` which runs an interactive wizard and writes it):
 ` + "```yaml" + `
 domains:
   - myapp
@@ -1113,7 +1117,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - Custom workers can be added per-project (` + bt + `.lerd.yaml` + bt + ` ` + bt + `custom_workers` + bt + `) or globally (` + bt + `~/.config/lerd/frameworks/<name>.yaml` + bt + `); use ` + bt + `worker_add` + bt + ` / ` + bt + `worker_remove` + bt + ` — both survive framework store updates
 - Framework setup commands (one-off bootstrap steps like migrations, storage links) are defined in the framework YAML and shown in ` + bt + `lerd setup` + bt + `; Laravel has built-in storage:link/migrate/db:seed; custom frameworks can define their own
 - Service version placeholders (` + bt + `{{mysql_version}}` + bt + `, ` + bt + `{{postgres_version}}` + bt + `, ` + bt + `{{redis_version}}` + bt + `, ` + bt + `{{meilisearch_version}}` + bt + `) are available in framework env vars and are resolved from the service image tag at ` + bt + `lerd env` + bt + ` time
-- **Custom containers**: non-PHP sites (Node.js, Python, Go, etc.) can define a ` + bt + `Containerfile.lerd` + bt + ` and a ` + bt + `container:` + bt + ` section in ` + bt + `.lerd.yaml` + bt + ` with a port; lerd builds a per-project image, runs it as ` + bt + `lerd-custom-<sitename>` + bt + `, and nginx reverse-proxies to it; workers exec into the custom container; services are accessible by name on the shared ` + bt + `lerd` + bt + ` Podman network
+- **Custom containers**: non-PHP sites (Node.js, Python, Go, etc.) can define a ` + bt + `Containerfile.lerd` + bt + ` and a ` + bt + `container:` + bt + ` section in ` + bt + `.lerd.yaml` + bt + ` with a port; lerd builds a per-project image, runs it as ` + bt + `lerd-custom-<sitename>` + bt + `, and nginx reverse-proxies to it; the project directory is volume-mounted at its host path with ` + bt + `--workdir` + bt + ` set automatically — do NOT add ` + bt + `WORKDIR` + bt + ` or ` + bt + `COPY` + bt + ` to the Containerfile; workers exec into the custom container; services are accessible by name on the shared ` + bt + `lerd` + bt + ` Podman network; **hot-reload file watchers must use polling on macOS** (inotify does not fire across Podman Machine's virtiofs mount) — nodemon: ` + bt + `--legacy-watch` + bt + `, Vite: ` + bt + `server.watch.usePolling: true` + bt + `, webpack: ` + bt + `watchOptions: { poll: 1000 }` + bt + `
 - Git worktrees automatically get a ` + bt + `<branch>.<site>.test` + bt + ` subdomain; ` + bt + `vendor/` + bt + `, ` + bt + `node_modules/` + bt + `, and ` + bt + `.env` + bt + ` are symlinked/copied from the main checkout
 
 ### Available MCP tools
@@ -1136,7 +1140,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `env_setup` + bt + ` | Configure ` + bt + `.env` + bt + ` for lerd: detects services, starts them, creates DB, generates APP_KEY (leaves ` + bt + `DB_CONNECTION=sqlite` + bt + ` alone — call ` + bt + `db_set` + bt + ` first); ` + bt + `APP_URL` + bt + ` follows ` + bt + `.lerd.yaml app_url` + bt + ` → ` + bt + `sites.yaml app_url` + bt + ` → default chain |
 | ` + bt + `db_set` + bt + ` | Pick the database for a Laravel project: ` + bt + `sqlite` + bt + ` / ` + bt + `mysql` + bt + ` / ` + bt + `postgres` + bt + `; persists to ` + bt + `.lerd.yaml` + bt + `, rewrites ` + bt + `DB_` + bt + ` keys in ` + bt + `.env` + bt + `, starts the service, creates the database |
 | ` + bt + `env_check` + bt + ` | Compare all ` + bt + `.env` + bt + ` files against ` + bt + `.env.example` + bt + ` — returns structured JSON with per-key sync status |
-| ` + bt + `site_link` + bt + ` | Register a directory as a lerd site (creates nginx vhost + ` + bt + `.test` + bt + ` domain) |
+| ` + bt + `site_link` + bt + ` | Register a directory as a lerd site — **non-PHP projects** must have a Containerfile (default name ` + bt + `Containerfile.lerd` + bt + `; set ` + bt + `container.containerfile` + bt + ` for a different path, e.g. ` + bt + `Dockerfile` + bt + `) + ` + bt + `.lerd.yaml` + bt + ` with ` + bt + `container: {port: N}` + bt + ` written first, otherwise the site registers as PHP (wrong) |
 | ` + bt + `site_unlink` + bt + ` | Unregister a site and remove its nginx vhost (all domains) |
 | ` + bt + `site_domain_add` + bt + ` | Add an additional domain to a site (without TLD) |
 | ` + bt + `site_domain_remove` + bt + ` | Remove a domain from a site (cannot remove last) |
@@ -1211,7 +1215,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - Worker unit names follow the pattern ` + bt + `lerd-<worker>-<site>` + bt + ` (e.g. ` + bt + `lerd-messenger-myapp` + bt + `, ` + bt + `lerd-horizon-myapp` + bt + `)
 - ` + bt + `site_php` + bt + ` / ` + bt + `site_node` + bt + ` change the PHP/Node version for a site; the FPM container for the new PHP version must be running after calling ` + bt + `site_php` + bt + `
 - ` + bt + `site_pause` + bt + ` / ` + bt + `site_unpause` + bt + ` free up resources for sites not in active use without unlinking them; paused state persists across restarts
-- **Custom container sites**: for non-PHP projects (Node.js, Python, Go, etc.), create a ` + bt + `Containerfile.lerd` + bt + ` in the project root and add ` + bt + `container: {port: <N>}` + bt + ` to ` + bt + `.lerd.yaml` + bt + `. ` + bt + `site_link` + bt + ` builds the image, starts the container, and nginx reverse-proxies to it. Workers defined in ` + bt + `custom_workers` + bt + ` exec into the container. ` + bt + `site_restart` + bt + ` restarts the container (e.g. after Containerfile changes). When ` + bt + `container` + bt + ` is set, ` + bt + `php_version` + bt + ` and ` + bt + `framework` + bt + ` are ignored.
+- **Custom container sites** (Node.js, Python, Go, etc.) — mandatory sequence: **(1)** write a Containerfile in the project root (default name ` + bt + `Containerfile.lerd` + bt + `; any name works — point ` + bt + `container.containerfile` + bt + ` at it if using a different name like ` + bt + `Dockerfile` + bt + `); **(2)** write ` + bt + `.lerd.yaml` + bt + ` with ` + bt + `container: {port: <N>}` + bt + ` (plus optional ` + bt + `domains` + bt + `, ` + bt + `services` + bt + `, ` + bt + `secured` + bt + `) — there is no MCP tool for this; write the file directly or ask the user to run ` + bt + `lerd init` + bt + ` (CLI wizard that generates the file interactively); **(3)** call ` + bt + `site_link` + bt + ` — it builds the image, starts the container, and configures nginx to reverse-proxy to it. **Never call ` + bt + `site_link` + bt + ` before steps 1–2**: without ` + bt + `container:` + bt + ` config the site registers as a PHP-FPM site (wrong); if that happened, call ` + bt + `site_unlink` + bt + ` first, write the files, then link again. Workers in ` + bt + `custom_workers` + bt + ` exec into the container. ` + bt + `site_restart` + bt + ` restarts the container without rebuilding. When ` + bt + `container` + bt + ` is set, ` + bt + `php_version` + bt + ` and ` + bt + `framework` + bt + ` are ignored.
 - ` + bt + `service_pin` + bt + ` keeps a service always running regardless of which sites are active; use for shared services like MySQL or Redis
 - ` + bt + `service_add` + bt + ` supports ` + bt + `depends_on` + bt + ` (array of service names): starting a dependency auto-starts the dependent service; stopping a dependency cascade-stops the dependent first; starting the dependent ensures dependencies start first
 - Prefer ` + bt + `service_preset_install` + bt + ` over hand-rolling ` + bt + `service_add` + bt + ` for anything in the bundled catalogue (` + bt + `phpmyadmin` + bt + `, ` + bt + `pgadmin` + bt + `, ` + bt + `mongo` + bt + `, ` + bt + `mongo-express` + bt + `, ` + bt + `selenium` + bt + `, ` + bt + `stripe-mock` + bt + `, ` + bt + `mysql` + bt + `, ` + bt + `mariadb` + bt + `, …) — presets ship sane defaults, dependency wiring, dashboards, and rendered config files; call ` + bt + `service_preset_list` + bt + ` first to see what's available; multi-version families take a ` + bt + `version` + bt + ` argument; presets whose dependency is another custom service (e.g. ` + bt + `mongo-express` + bt + ` on ` + bt + `mongo` + bt + `) require the dep installed first

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -1036,13 +1036,28 @@ custom_workers:
     restart: always
 ` + "```" + `
 
-3. Link and verify:
+3. **Configure environment variables BEFORE linking.** The container starts immediately on ` + bt + `site_link` + bt + `, so the app's ` + bt + `.env` + bt + ` (or equivalent config) must already have the correct service connection strings. Lerd services are reachable by container name on the ` + bt + `lerd` + bt + ` network:
+` + "```" + `
+DB_HOST=lerd-mysql          # or lerd-postgres
+DB_PORT=3306                # 5432 for postgres
+DB_USERNAME=root            # postgres for postgres
+DB_PASSWORD=lerd
+REDIS_HOST=lerd-redis
+REDIS_PORT=6379
+` + "```" + `
+   Start the services first if they're not running:
+` + "```" + `
+service_start(name: "mysql")
+service_start(name: "redis")
+` + "```" + `
+
+4. Link and verify:
 ` + "```" + `
 site_link()            // builds image, creates container, generates nginx vhost
 sites()                // verify the site is listed with custom_container: true
 ` + "```" + `
 
-The ` + bt + `container.port` + bt + ` field is required — it's the port the app listens on inside the container. ` + bt + `container.containerfile` + bt + ` defaults to ` + bt + `Containerfile.lerd` + bt + `. Workers defined in ` + bt + `custom_workers` + bt + ` exec into the custom container. Services are reachable by name (` + bt + `lerd-mysql` + bt + `, ` + bt + `lerd-redis` + bt + `, etc.) from inside the container.
+The ` + bt + `container.port` + bt + ` field is required — it's the port the app listens on inside the container. ` + bt + `container.containerfile` + bt + ` defaults to ` + bt + `Containerfile.lerd` + bt + `. Workers defined in ` + bt + `custom_workers` + bt + ` exec into the custom container.
 
 ## .lerd.yaml Reference
 
@@ -1215,7 +1230,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - Worker unit names follow the pattern ` + bt + `lerd-<worker>-<site>` + bt + ` (e.g. ` + bt + `lerd-messenger-myapp` + bt + `, ` + bt + `lerd-horizon-myapp` + bt + `)
 - ` + bt + `site_php` + bt + ` / ` + bt + `site_node` + bt + ` change the PHP/Node version for a site; the FPM container for the new PHP version must be running after calling ` + bt + `site_php` + bt + `
 - ` + bt + `site_pause` + bt + ` / ` + bt + `site_unpause` + bt + ` free up resources for sites not in active use without unlinking them; paused state persists across restarts
-- **Custom container sites** (Node.js, Python, Go, etc.) — mandatory sequence: **(1)** write a Containerfile in the project root (default name ` + bt + `Containerfile.lerd` + bt + `; any name works — point ` + bt + `container.containerfile` + bt + ` at it if using a different name like ` + bt + `Dockerfile` + bt + `); **(2)** write ` + bt + `.lerd.yaml` + bt + ` with ` + bt + `container: {port: <N>}` + bt + ` (plus optional ` + bt + `domains` + bt + `, ` + bt + `services` + bt + `, ` + bt + `secured` + bt + `) — there is no MCP tool for this; write the file directly or ask the user to run ` + bt + `lerd init` + bt + ` (CLI wizard that generates the file interactively); **(3)** call ` + bt + `site_link` + bt + ` — it builds the image, starts the container, and configures nginx to reverse-proxy to it. **Never call ` + bt + `site_link` + bt + ` before steps 1–2**: without ` + bt + `container:` + bt + ` config the site registers as a PHP-FPM site (wrong); if that happened, call ` + bt + `site_unlink` + bt + ` first, write the files, then link again. Workers in ` + bt + `custom_workers` + bt + ` exec into the container. ` + bt + `site_restart` + bt + ` restarts the container without rebuilding. When ` + bt + `container` + bt + ` is set, ` + bt + `php_version` + bt + ` and ` + bt + `framework` + bt + ` are ignored.
+- **Custom container sites** (Node.js, Python, Go, etc.) — mandatory sequence: **(1)** write a Containerfile in the project root (default name ` + bt + `Containerfile.lerd` + bt + `; any name works if you set ` + bt + `container.containerfile` + bt + `); **(2)** write ` + bt + `.lerd.yaml` + bt + ` with ` + bt + `container: {port: <N>}` + bt + ` (plus optional ` + bt + `domains` + bt + `, ` + bt + `services` + bt + `, ` + bt + `secured` + bt + `) — there is no MCP tool for this; write the file directly or ask the user to run ` + bt + `lerd init` + bt + `; **(3)** configure the project's ` + bt + `.env` + bt + ` (or equivalent config) with service connection strings BEFORE linking — use ` + bt + `lerd-mysql` + bt + `, ` + bt + `lerd-redis` + bt + `, ` + bt + `lerd-postgres` + bt + ` as hostnames and start needed services with ` + bt + `service_start` + bt + `; **(4)** call ` + bt + `site_link` + bt + ` — the container starts immediately, so the env must already be correct. **Never call ` + bt + `site_link` + bt + ` before steps 1–3**: without ` + bt + `container:` + bt + ` config the site registers as PHP-FPM (wrong); if that happened, ` + bt + `site_unlink` + bt + ` first, write the files, then link again. Workers in ` + bt + `custom_workers` + bt + ` exec into the container. ` + bt + `site_restart` + bt + ` restarts without rebuilding. When ` + bt + `container` + bt + ` is set, ` + bt + `php_version` + bt + ` and ` + bt + `framework` + bt + ` are ignored.
 - ` + bt + `service_pin` + bt + ` keeps a service always running regardless of which sites are active; use for shared services like MySQL or Redis
 - ` + bt + `service_add` + bt + ` supports ` + bt + `depends_on` + bt + ` (array of service names): starting a dependency auto-starts the dependent service; stopping a dependency cascade-stops the dependent first; starting the dependent ensures dependencies start first
 - Prefer ` + bt + `service_preset_install` + bt + ` over hand-rolling ` + bt + `service_add` + bt + ` for anything in the bundled catalogue (` + bt + `phpmyadmin` + bt + `, ` + bt + `pgadmin` + bt + `, ` + bt + `mongo` + bt + `, ` + bt + `mongo-express` + bt + `, ` + bt + `selenium` + bt + `, ` + bt + `stripe-mock` + bt + `, ` + bt + `mysql` + bt + `, ` + bt + `mariadb` + bt + `, …) — presets ship sane defaults, dependency wiring, dashboards, and rendered config files; call ` + bt + `service_preset_list` + bt + ` first to see what's available; multi-version families take a ` + bt + `version` + bt + ` argument; presets whose dependency is another custom service (e.g. ` + bt + `mongo-express` + bt + ` on ` + bt + `mongo` + bt + `) require the dep installed first

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -335,6 +335,7 @@ In practice, you can almost always omit ` + bt + `path` + bt + ` — just open C
 - Framework workers (queue, schedule, reverb, messenger, etc.) run as systemd user services named ` + bt + `lerd-<worker>-<sitename>` + bt + ` (e.g. ` + bt + `lerd-queue-myapp` + bt + `, ` + bt + `lerd-messenger-myapp` + bt + `)
 - Worker commands are defined per-framework in YAML definitions; Laravel has built-in queue/schedule/reverb workers; custom frameworks can add any workers; both workers and setup commands support an optional ` + bt + `check` + bt + ` field (` + bt + `file` + bt + ` or ` + bt + `composer` + bt + `) to conditionally show them based on project dependencies
 - Framework definitions can include ` + bt + `setup` + bt + ` commands (one-off bootstrap steps like migrations, storage links) shown in ` + bt + `lerd setup` + bt + `; Laravel has built-in storage:link/migrate/db:seed
+- **Custom containers**: non-PHP sites (Node.js, Python, Go, etc.) can define a ` + bt + `Containerfile.lerd` + bt + ` and a ` + bt + `container:` + bt + ` section in ` + bt + `.lerd.yaml` + bt + ` with a port. Lerd builds a per-project image (` + bt + `lerd-custom-<sitename>:local` + bt + `), runs it as ` + bt + `lerd-custom-<sitename>` + bt + `, and nginx reverse-proxies to it. Workers exec into the custom container. Services are accessible by name (` + bt + `lerd-mysql` + bt + `, ` + bt + `lerd-redis` + bt + `, etc.) on the shared ` + bt + `lerd` + bt + ` Podman network.
 - Git worktrees automatically get a ` + bt + `<branch>.<site>.test` + bt + ` subdomain; ` + bt + `vendor/` + bt + `, ` + bt + `node_modules/` + bt + `, and ` + bt + `.env` + bt + ` are symlinked/copied from the main checkout
 - DNS resolves ` + bt + `*.test` + bt + ` to ` + bt + `127.0.0.1` + bt + `
 
@@ -756,11 +757,14 @@ Change the PHP or Node.js version for a registered site. Both take ` + bt + `sit
 ### ` + bt + `site_pause` + bt + ` / ` + bt + `site_unpause` + bt + `
 Pause or resume a site. Both take ` + bt + `site` + bt + ` (required, site name from ` + bt + `sites` + bt + ` tool).
 
-` + bt + `site_pause` + bt + ` stops all running workers for the site (queue, schedule, reverb, stripe, custom) and replaces its nginx vhost with a landing page that includes a **Resume** button. Services no longer needed by any active site are auto-stopped. The paused state is persisted — the site stays paused across lerd restarts.
+` + bt + `site_pause` + bt + ` stops all running workers for the site, stops the custom container (for custom container sites), and replaces its nginx vhost with a landing page that includes a **Resume** button. Services no longer needed by any active site are auto-stopped. The paused state is persisted.
 
-` + bt + `site_unpause` + bt + ` restores the nginx vhost, ensures any services referenced in the site's ` + bt + `.env` + bt + ` are running, and restarts any workers that were running when the site was paused.
+` + bt + `site_unpause` + bt + ` starts the custom container (if applicable), restores the nginx vhost, ensures required services are running, and restarts any workers that were running when the site was paused.
 
 Use this to free up resources for sites you're not actively working on without fully unlinking them.
+
+### ` + bt + `site_restart` + bt + `
+Restart the container for a site. Takes ` + bt + `site` + bt + ` (required, site name from ` + bt + `sites` + bt + ` tool). For custom container sites this restarts the dedicated per-project container; for PHP sites it restarts the shared PHP-FPM container for that site's PHP version.
 
 ### ` + bt + `service_pin` + bt + ` / ` + bt + `service_unpin` + bt + `
 Pin or unpin a service. Both take ` + bt + `name` + bt + ` (required).
@@ -948,6 +952,12 @@ site_pause(site: "old-project")  // stop workers + replace vhost with landing pa
 site_unpause(site: "old-project")  // restore and restart
 ` + "```" + `
 
+**Restart a site's container (e.g. after changing Containerfile):**
+` + "```" + `
+site_restart(site: "nestjs-app")  // restarts lerd-custom-nestjs-app
+site_restart(site: "myapp")       // restarts lerd-php84-fpm (shared FPM)
+` + "```" + `
+
 **Keep a service always running regardless of active site:**
 ` + "```" + `
 service_pin(name: "mysql")    // never auto-stopped
@@ -996,6 +1006,94 @@ which()   // shows resolved PHP, Node, document root, nginx config
 ` + "```" + `
 check()   // validates .lerd.yaml syntax, services, PHP version
 ` + "```" + `
+
+**Set up a custom container site (Node.js, Python, Go, etc.):**
+
+1. Create a ` + bt + `Containerfile.lerd` + bt + ` in the project root:
+` + "```dockerfile" + `
+FROM node:20-alpine
+WORKDIR /app
+CMD ["npm", "run", "start:dev"]
+` + "```" + `
+
+2. Create or update ` + bt + `.lerd.yaml` + bt + ` with the container section:
+` + "```yaml" + `
+domains:
+  - myapp
+container:
+  port: 3000
+services:
+  - mysql
+  - redis
+custom_workers:
+  queue:
+    label: Queue Worker
+    command: node dist/queue.js
+    restart: always
+` + "```" + `
+
+3. Link and verify:
+` + "```" + `
+site_link()            // builds image, creates container, generates nginx vhost
+sites()                // verify the site is listed with custom_container: true
+` + "```" + `
+
+The ` + bt + `container.port` + bt + ` field is required — it's the port the app listens on inside the container. ` + bt + `container.containerfile` + bt + ` defaults to ` + bt + `Containerfile.lerd` + bt + `. Workers defined in ` + bt + `custom_workers` + bt + ` exec into the custom container. Services are reachable by name (` + bt + `lerd-mysql` + bt + `, ` + bt + `lerd-redis` + bt + `, etc.) from inside the container.
+
+## .lerd.yaml Reference
+
+` + bt + `.lerd.yaml` + bt + ` is the per-project config file, committed to the repo. ` + bt + `lerd link` + bt + ` and ` + bt + `lerd init` + bt + ` apply it automatically.
+
+### PHP site fields
+
+| Field | Description |
+|-------|-------------|
+| ` + bt + `domains` + bt + ` | Site hostnames without TLD (e.g. ` + bt + `[myapp, api]` + bt + `). First is primary. |
+| ` + bt + `php_version` + bt + ` | PHP version for this project (e.g. ` + bt + `"8.4"` + bt + `) |
+| ` + bt + `node_version` + bt + ` | Node version (e.g. ` + bt + `"22"` + bt + `) |
+| ` + bt + `framework` + bt + ` | Framework name (e.g. ` + bt + `laravel` + bt + `, ` + bt + `symfony` + bt + `, ` + bt + `wordpress` + bt + `) |
+| ` + bt + `secured` + bt + ` | ` + bt + `true` + bt + ` to enable HTTPS |
+| ` + bt + `services` + bt + ` | Services to start (e.g. ` + bt + `[mysql, redis]` + bt + `) |
+| ` + bt + `workers` + bt + ` | Active worker names (e.g. ` + bt + `[queue, schedule]` + bt + `) — auto-synced by start/stop |
+| ` + bt + `app_url` + bt + ` | Override for APP_URL in ` + bt + `.env` + bt + ` |
+
+### Custom container fields
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| ` + bt + `container.port` + bt + ` | yes | | Port the app listens on inside the container |
+| ` + bt + `container.containerfile` + bt + ` | no | ` + bt + `Containerfile.lerd` + bt + ` | Path to the Containerfile (relative to project root) |
+| ` + bt + `container.build_context` + bt + ` | no | ` + bt + `.` + bt + ` | Build context directory |
+| ` + bt + `custom_workers` + bt + ` | no | | Worker definitions — see below |
+| ` + bt + `domains` + bt + ` | no | | Same as PHP sites |
+| ` + bt + `secured` + bt + ` | no | | Same as PHP sites |
+| ` + bt + `services` + bt + ` | no | | Same as PHP sites |
+
+When ` + bt + `container` + bt + ` is present, ` + bt + `php_version` + bt + `, ` + bt + `framework` + bt + `, and ` + bt + `node_version` + bt + ` are ignored — the container defines its own runtime.
+
+### custom_workers fields
+
+Each entry under ` + bt + `custom_workers` + bt + ` is a name-to-config map. Works for both PHP and custom container sites.
+
+` + "```yaml" + `
+custom_workers:
+  queue:
+    label: Queue Worker
+    command: node dist/queue.js
+    restart: always
+  cron:
+    label: Cron
+    command: node dist/cron.js
+    restart: on-failure
+` + "```" + `
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| ` + bt + `label` + bt + ` | no | Display name in the UI |
+| ` + bt + `command` + bt + ` | yes | Shell command to run inside the container |
+| ` + bt + `restart` + bt + ` | no | ` + bt + `always` + bt + ` (default) or ` + bt + `on-failure` + bt + ` |
+| ` + bt + `schedule` + bt + ` | no | systemd OnCalendar expression for cron-style workers (e.g. ` + bt + `minutely` + bt + `) |
+| ` + bt + `conflicts_with` + bt + ` | no | List of worker names to stop before starting this one |
 `
 
 // junieGuidelinesSection is the lerd block written into .junie/guidelines.md.
@@ -1015,6 +1113,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - Custom workers can be added per-project (` + bt + `.lerd.yaml` + bt + ` ` + bt + `custom_workers` + bt + `) or globally (` + bt + `~/.config/lerd/frameworks/<name>.yaml` + bt + `); use ` + bt + `worker_add` + bt + ` / ` + bt + `worker_remove` + bt + ` — both survive framework store updates
 - Framework setup commands (one-off bootstrap steps like migrations, storage links) are defined in the framework YAML and shown in ` + bt + `lerd setup` + bt + `; Laravel has built-in storage:link/migrate/db:seed; custom frameworks can define their own
 - Service version placeholders (` + bt + `{{mysql_version}}` + bt + `, ` + bt + `{{postgres_version}}` + bt + `, ` + bt + `{{redis_version}}` + bt + `, ` + bt + `{{meilisearch_version}}` + bt + `) are available in framework env vars and are resolved from the service image tag at ` + bt + `lerd env` + bt + ` time
+- **Custom containers**: non-PHP sites (Node.js, Python, Go, etc.) can define a ` + bt + `Containerfile.lerd` + bt + ` and a ` + bt + `container:` + bt + ` section in ` + bt + `.lerd.yaml` + bt + ` with a port; lerd builds a per-project image, runs it as ` + bt + `lerd-custom-<sitename>` + bt + `, and nginx reverse-proxies to it; workers exec into the custom container; services are accessible by name on the shared ` + bt + `lerd` + bt + ` Podman network
 - Git worktrees automatically get a ` + bt + `<branch>.<site>.test` + bt + ` subdomain; ` + bt + `vendor/` + bt + `, ` + bt + `node_modules/` + bt + `, and ` + bt + `.env` + bt + ` are symlinked/copied from the main checkout
 
 ### Available MCP tools
@@ -1078,8 +1177,9 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `framework_remove` + bt + ` | Remove a user-defined framework; for laravel removes only custom worker and setup additions |
 | ` + bt + `site_php` + bt + ` | Change PHP version for a site — writes ` + bt + `.php-version` + bt + `, updates registry, regenerates nginx vhost |
 | ` + bt + `site_node` + bt + ` | Change Node.js version for a site — writes ` + bt + `.node-version` + bt + `, installs via fnm if needed |
-| ` + bt + `site_pause` + bt + ` | Pause a site: stop all its workers and replace its vhost with a landing page |
-| ` + bt + `site_unpause` + bt + ` | Resume a paused site: restore its vhost and restart previously running workers |
+| ` + bt + `site_pause` + bt + ` | Pause a site: stop workers and custom container, replace vhost with landing page |
+| ` + bt + `site_unpause` + bt + ` | Resume a paused site: start container, restore vhost, restart workers |
+| ` + bt + `site_restart` + bt + ` | Restart a site's container (custom container or PHP-FPM) |
 | ` + bt + `service_pin` + bt + ` | Pin a service so it is never auto-stopped even when no sites reference it |
 | ` + bt + `service_unpin` + bt + ` | Unpin a service so it can be auto-stopped when unused |
 | ` + bt + `stripe_listen` + bt + ` | Start a Stripe webhook listener for a site |
@@ -1111,6 +1211,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - Worker unit names follow the pattern ` + bt + `lerd-<worker>-<site>` + bt + ` (e.g. ` + bt + `lerd-messenger-myapp` + bt + `, ` + bt + `lerd-horizon-myapp` + bt + `)
 - ` + bt + `site_php` + bt + ` / ` + bt + `site_node` + bt + ` change the PHP/Node version for a site; the FPM container for the new PHP version must be running after calling ` + bt + `site_php` + bt + `
 - ` + bt + `site_pause` + bt + ` / ` + bt + `site_unpause` + bt + ` free up resources for sites not in active use without unlinking them; paused state persists across restarts
+- **Custom container sites**: for non-PHP projects (Node.js, Python, Go, etc.), create a ` + bt + `Containerfile.lerd` + bt + ` in the project root and add ` + bt + `container: {port: <N>}` + bt + ` to ` + bt + `.lerd.yaml` + bt + `. ` + bt + `site_link` + bt + ` builds the image, starts the container, and nginx reverse-proxies to it. Workers defined in ` + bt + `custom_workers` + bt + ` exec into the container. ` + bt + `site_restart` + bt + ` restarts the container (e.g. after Containerfile changes). When ` + bt + `container` + bt + ` is set, ` + bt + `php_version` + bt + ` and ` + bt + `framework` + bt + ` are ignored.
 - ` + bt + `service_pin` + bt + ` keeps a service always running regardless of which sites are active; use for shared services like MySQL or Redis
 - ` + bt + `service_add` + bt + ` supports ` + bt + `depends_on` + bt + ` (array of service names): starting a dependency auto-starts the dependent service; stopping a dependency cascade-stops the dependent first; starting the dependent ensures dependencies start first
 - Prefer ` + bt + `service_preset_install` + bt + ` over hand-rolling ` + bt + `service_add` + bt + ` for anything in the bundled catalogue (` + bt + `phpmyadmin` + bt + `, ` + bt + `pgadmin` + bt + `, ` + bt + `mongo` + bt + `, ` + bt + `mongo-express` + bt + `, ` + bt + `selenium` + bt + `, ` + bt + `stripe-mock` + bt + `, ` + bt + `mysql` + bt + `, ` + bt + `mariadb` + bt + `, …) — presets ship sane defaults, dependency wiring, dashboards, and rendered config files; call ` + bt + `service_preset_list` + bt + ` first to see what's available; multi-version families take a ` + bt + `version` + bt + ` argument; presets whose dependency is another custom service (e.g. ` + bt + `mongo-express` + bt + ` on ` + bt + `mongo` + bt + `) require the dep installed first

--- a/internal/cli/park.go
+++ b/internal/cli/park.go
@@ -225,8 +225,15 @@ func RegisterProject(projectDir string, cfg *config.GlobalConfig) (bool, error) 
 
 	warnMissingExtensions(projectDir, name, phpVersion, cfg)
 
-	// Skip if already registered at this path.
-	if existing, err := config.FindSite(name); err == nil && existing != nil && existing.Path == projectDir {
+	// Skip if already registered at this path. Also skip if the site is a
+	// custom container — the user linked it explicitly with their own
+	// Containerfile and the parked watcher should not overwrite it.
+	if existing, err := config.FindSite(name); err == nil && existing != nil {
+		if existing.Path == projectDir {
+			return false, nil
+		}
+	}
+	if existing, err := config.FindSiteByPath(projectDir); err == nil && existing != nil && existing.IsCustomContainer() {
 		return false, nil
 	}
 

--- a/internal/cli/park_test.go
+++ b/internal/cli/park_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/siteops"
 )
 
@@ -128,5 +129,37 @@ func TestFreeSiteName_legacyDomainField(t *testing.T) {
 	got := freeSiteName("myapp", "/projects/new")
 	if got != "myapp-2" {
 		t.Errorf("got %q, want %q", got, "myapp-2")
+	}
+}
+
+// ── RegisterProject skips custom containers ─────────────────────────────────
+
+func TestRegisterProject_SkipsCustomContainer(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	// Create a project directory with a composer.json so it looks like a PHP project.
+	projectDir := filepath.Join(t.TempDir(), "nestapp")
+	os.MkdirAll(projectDir, 0755)
+	os.WriteFile(filepath.Join(projectDir, "composer.json"), []byte(`{}`), 0644)
+
+	// Pre-register the site as a custom container.
+	config.AddSite(config.Site{
+		Name:          "nestapp",
+		Domains:       []string{"nestapp.test"},
+		Path:          projectDir,
+		ContainerPort: 3000,
+	})
+
+	cfg := &config.GlobalConfig{}
+	cfg.DNS.TLD = "test"
+	cfg.PHP.DefaultVersion = "8.4"
+
+	registered, err := RegisterProject(projectDir, cfg)
+	if err != nil {
+		t.Fatalf("RegisterProject: %v", err)
+	}
+	if registered {
+		t.Error("RegisterProject should return false for a custom container site")
 	}
 }

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -11,6 +11,7 @@ import (
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/nginx"
 	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/spf13/cobra"
 )
@@ -66,6 +67,11 @@ func PauseSite(name string) error {
 		stopWorkerByName(site, w)
 	}
 
+	// Stop the custom container when pausing a custom container site.
+	if site.IsCustomContainer() {
+		_ = podman.StopUnit(podman.CustomContainerName(site.Name))
+	}
+
 	if err := writePausedHTML(site); err != nil {
 		return fmt.Errorf("writing paused page: %w", err)
 	}
@@ -109,33 +115,54 @@ func UnpauseSite(name string) error {
 	}
 
 	phpVersion := site.PHPVersion
-	if detected, err := phpDet.DetectVersion(site.Path); err == nil && detected != "" {
-		phpVersion = detected
-	}
 
-	if phpVersion != "" {
-		if err := ensureFPMQuadlet(phpVersion); err != nil {
-			fmt.Printf("[WARN] ensuring FPM for PHP %s: %v\n", phpVersion, err)
-		}
-	}
-
-	if site.Secured {
-		if err := nginx.GenerateSSLVhost(*site, phpVersion); err != nil {
-			return fmt.Errorf("generating SSL vhost: %w", err)
-		}
-		sslConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
-		mainConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
-		_ = os.Remove(mainConf)
-		if err := os.Rename(sslConf, mainConf); err != nil {
-			return fmt.Errorf("installing SSL vhost: %w", err)
+	if site.IsCustomContainer() {
+		// Start the custom container and restore the proxy vhost.
+		_ = podman.StartUnit(podman.CustomContainerName(site.Name))
+		if site.Secured {
+			if err := nginx.GenerateCustomSSLVhost(*site); err != nil {
+				return fmt.Errorf("generating custom SSL vhost: %w", err)
+			}
+			sslConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
+			mainConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
+			_ = os.Remove(mainConf)
+			if err := os.Rename(sslConf, mainConf); err != nil {
+				return fmt.Errorf("installing SSL vhost: %w", err)
+			}
+		} else {
+			if err := nginx.GenerateCustomVhost(*site); err != nil {
+				return fmt.Errorf("generating custom vhost: %w", err)
+			}
 		}
 	} else {
-		if err := nginx.GenerateVhost(*site, phpVersion); err != nil {
-			return fmt.Errorf("generating vhost: %w", err)
+		if detected, err := phpDet.DetectVersion(site.Path); err == nil && detected != "" {
+			phpVersion = detected
 		}
-	}
 
-	unpauseWorktrees(site, phpVersion)
+		if phpVersion != "" {
+			if err := ensureFPMQuadlet(phpVersion); err != nil {
+				fmt.Printf("[WARN] ensuring FPM for PHP %s: %v\n", phpVersion, err)
+			}
+		}
+
+		if site.Secured {
+			if err := nginx.GenerateSSLVhost(*site, phpVersion); err != nil {
+				return fmt.Errorf("generating SSL vhost: %w", err)
+			}
+			sslConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
+			mainConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
+			_ = os.Remove(mainConf)
+			if err := os.Rename(sslConf, mainConf); err != nil {
+				return fmt.Errorf("installing SSL vhost: %w", err)
+			}
+		} else {
+			if err := nginx.GenerateVhost(*site, phpVersion); err != nil {
+				return fmt.Errorf("generating vhost: %w", err)
+			}
+		}
+
+		unpauseWorktrees(site, phpVersion)
+	}
 
 	if err := nginx.Reload(); err != nil {
 		fmt.Printf("[WARN] nginx reload: %v\n", err)

--- a/internal/cli/rebuild.go
+++ b/internal/cli/rebuild.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/spf13/cobra"
+)
+
+// NewRebuildCmd returns the rebuild command.
+func NewRebuildCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rebuild [site]",
+		Short: "Rebuild the custom container image and restart the container",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			name, err := resolveSiteName(args)
+			if err != nil {
+				return err
+			}
+			return RebuildSite(name)
+		},
+	}
+}
+
+// RebuildSite rebuilds the custom container image from the Containerfile and
+// restarts the container. For PHP sites this is a no-op (use php:rebuild).
+func RebuildSite(name string) error {
+	site, err := config.FindSite(name)
+	if err != nil {
+		return fmt.Errorf("site %q not found", name)
+	}
+	if !site.IsCustomContainer() {
+		return fmt.Errorf("site %q is not a custom container site — use 'lerd php:rebuild' for PHP sites", name)
+	}
+
+	proj, err := config.LoadProjectConfig(site.Path)
+	if err != nil {
+		return fmt.Errorf("loading .lerd.yaml: %w", err)
+	}
+
+	// Remove old image so build starts fresh.
+	_ = podman.RemoveCustomImage(name)
+
+	fmt.Printf("Building %s...\n", podman.CustomImageName(name))
+	if err := podman.BuildCustomImage(name, site.Path, proj.Container); err != nil {
+		return err
+	}
+
+	// Restart the container to pick up the new image.
+	unit := podman.CustomContainerName(name)
+	running, _ := podman.ContainerRunning(unit)
+	if running {
+		if err := podman.RestartUnit(unit); err != nil {
+			return fmt.Errorf("restarting container: %w", err)
+		}
+	}
+
+	fmt.Printf("Rebuilt and restarted: %s\n", name)
+	return nil
+}

--- a/internal/cli/rebuild.go
+++ b/internal/cli/rebuild.go
@@ -47,6 +47,7 @@ func RebuildSite(name string) error {
 	if err := podman.BuildCustomImage(name, site.Path, proj.Container); err != nil {
 		return err
 	}
+	podman.StoreContainerfileHash(name, site.Path, proj.Container)
 
 	// Restart the container to pick up the new image.
 	unit := podman.CustomContainerName(name)

--- a/internal/cli/restart.go
+++ b/internal/cli/restart.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/spf13/cobra"
+)
+
+// NewRestartCmd returns the restart command.
+func NewRestartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "restart [site]",
+		Short: "Restart the container for the current or named site",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			name, err := resolveSiteName(args)
+			if err != nil {
+				return err
+			}
+			return RestartSite(name)
+		},
+	}
+}
+
+// RestartSite restarts the custom container for a site. For PHP sites
+// it restarts the shared FPM container for that site's PHP version.
+func RestartSite(name string) error {
+	site, err := config.FindSite(name)
+	if err != nil {
+		return fmt.Errorf("site %q not found", name)
+	}
+
+	if site.IsCustomContainer() {
+		unit := podman.CustomContainerName(site.Name)
+		if err := podman.RestartUnit(unit); err != nil {
+			return fmt.Errorf("restarting container: %w", err)
+		}
+		fmt.Printf("Restarted: %s (%s)\n", name, unit)
+		return nil
+	}
+
+	if site.PHPVersion == "" {
+		return fmt.Errorf("site %q has no PHP version set", name)
+	}
+	short := strings.ReplaceAll(site.PHPVersion, ".", "")
+	unit := "lerd-php" + short + "-fpm"
+	if err := podman.RestartUnit(unit); err != nil {
+		return fmt.Errorf("restarting %s: %w", unit, err)
+	}
+	fmt.Printf("Restarted: %s (%s)\n", name, unit)
+	return nil
+}

--- a/internal/cli/restart_test.go
+++ b/internal/cli/restart_test.go
@@ -14,9 +14,9 @@ type fakeUnitLifecycle struct {
 	restartedUnit string
 }
 
-func (f *fakeUnitLifecycle) Start(name string) error          { return nil }
-func (f *fakeUnitLifecycle) Stop(name string) error           { return nil }
-func (f *fakeUnitLifecycle) Restart(name string) error        { f.restartedUnit = name; return nil }
+func (f *fakeUnitLifecycle) Start(name string) error                { return nil }
+func (f *fakeUnitLifecycle) Stop(name string) error                 { return nil }
+func (f *fakeUnitLifecycle) Restart(name string) error              { f.restartedUnit = name; return nil }
 func (f *fakeUnitLifecycle) UnitStatus(name string) (string, error) { return "active", nil }
 
 func TestRestartSite_CustomContainer(t *testing.T) {

--- a/internal/cli/restart_test.go
+++ b/internal/cli/restart_test.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// fakeUnitLifecycle records which unit was restarted.
+type fakeUnitLifecycle struct {
+	restartedUnit string
+}
+
+func (f *fakeUnitLifecycle) Start(name string) error          { return nil }
+func (f *fakeUnitLifecycle) Stop(name string) error           { return nil }
+func (f *fakeUnitLifecycle) Restart(name string) error        { f.restartedUnit = name; return nil }
+func (f *fakeUnitLifecycle) UnitStatus(name string) (string, error) { return "active", nil }
+
+func TestRestartSite_CustomContainer(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	siteDir := t.TempDir()
+	config.AddSite(config.Site{
+		Name:          "nestapp",
+		Domains:       []string{"nestapp.test"},
+		Path:          siteDir,
+		ContainerPort: 3000,
+	})
+
+	fake := &fakeUnitLifecycle{}
+	podman.UnitLifecycle = fake
+	defer func() { podman.UnitLifecycle = nil }()
+
+	if err := RestartSite("nestapp"); err != nil {
+		t.Fatalf("RestartSite: %v", err)
+	}
+	if fake.restartedUnit != "lerd-custom-nestapp" {
+		t.Errorf("restarted unit = %q, want lerd-custom-nestapp", fake.restartedUnit)
+	}
+}
+
+func TestRestartSite_PHPSite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	siteDir := t.TempDir()
+	config.AddSite(config.Site{
+		Name:       "phpapp",
+		Domains:    []string{"phpapp.test"},
+		Path:       siteDir,
+		PHPVersion: "8.4",
+	})
+
+	fake := &fakeUnitLifecycle{}
+	podman.UnitLifecycle = fake
+	defer func() { podman.UnitLifecycle = nil }()
+
+	if err := RestartSite("phpapp"); err != nil {
+		t.Fatalf("RestartSite: %v", err)
+	}
+	if fake.restartedUnit != "lerd-php84-fpm" {
+		t.Errorf("restarted unit = %q, want lerd-php84-fpm", fake.restartedUnit)
+	}
+}
+
+func TestRestartSite_NotFound(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	// Write an empty sites.yaml so FindSite returns not found.
+	dir := filepath.Join(tmp, "lerd")
+	os.MkdirAll(dir, 0755)
+	os.WriteFile(filepath.Join(dir, "sites.yaml"), []byte("sites: []\n"), 0644)
+
+	err := RestartSite("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent site")
+	}
+}

--- a/internal/cli/reverb.go
+++ b/internal/cli/reverb.go
@@ -122,6 +122,13 @@ func regenNginxVhost(siteName, sitePath string) {
 	if err != nil {
 		return
 	}
+
+	// Custom container sites handle proxying through the main container
+	// template, so the PHP-specific vhost regeneration is not needed.
+	if site.IsCustomContainer() {
+		return
+	}
+
 	phpVer := site.PHPVersion
 	if detected, detErr := phpDet.DetectVersion(sitePath); detErr == nil && detected != "" {
 		phpVer = detected

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -822,6 +822,9 @@ func registeredFrameworkWorkerUnits() []string {
 	}
 	out := make([]string, 0)
 	for _, s := range reg.Sites {
+		if s.Ignored || s.Paused {
+			continue
+		}
 		proj, err := config.LoadProjectConfig(s.Path)
 		if err != nil || proj == nil {
 			continue

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -203,7 +203,8 @@ func coreUnits() []string {
 }
 
 // installedCustomContainerUnits returns units for per-project custom containers
-// that have a quadlet installed. These are started alongside FPM and services.
+// that have a unit file installed (plist on macOS, quadlet on Linux).
+// These are started alongside FPM and services.
 func installedCustomContainerUnits() []string {
 	var units []string
 	reg, err := config.LoadSites()
@@ -215,7 +216,10 @@ func installedCustomContainerUnits() []string {
 			continue
 		}
 		unitName := podman.CustomContainerName(site.Name)
-		if podman.QuadletInstalled(unitName) {
+		// Use the platform-aware check (plist on macOS, .container quadlet on Linux)
+		// rather than podman.QuadletInstalled which only checks for .container files
+		// and always returns false on macOS where plists are used instead.
+		if services.Mgr.ContainerUnitInstalled(unitName) {
 			units = append(units, unitName)
 		}
 	}
@@ -661,15 +665,33 @@ func restoreSiteInfrastructure() {
 			continue
 		}
 
-		// Restore FPM quadlet for this site's PHP version.
-		phpVer := s.PHPVersion
-		if phpVer == "" {
-			cfg, _ := config.LoadGlobal()
-			phpVer = cfg.PHP.DefaultVersion
+		// Restore custom container plist/quadlet for custom container sites.
+		// On macOS the plist lives in ~/Library/LaunchAgents; on Linux it is a
+		// systemd quadlet. After a reinstall the unit file may be gone even though
+		// the site is still registered in sites.yaml and .lerd.yaml is on disk.
+		if s.IsCustomContainer() {
+			unitName := podman.CustomContainerName(s.Name)
+			if !services.Mgr.ContainerUnitInstalled(unitName) {
+				proj, _ := config.LoadProjectConfig(s.Path)
+				if proj != nil && proj.Container != nil {
+					if err := podman.WriteCustomContainerQuadlet(s.Name, s.Path, s.ContainerPort); err != nil {
+						fmt.Printf("[WARN] restoring custom container unit for %s: %v\n", s.Name, err)
+					}
+				}
+			}
 		}
-		if phpVer != "" && !seenPHP[phpVer] {
-			seenPHP[phpVer] = true
-			ensureFPMQuadlet(phpVer) //nolint:errcheck
+
+		// Restore FPM quadlet for this site's PHP version (PHP sites only).
+		if !s.IsCustomContainer() {
+			phpVer := s.PHPVersion
+			if phpVer == "" {
+				cfg, _ := config.LoadGlobal()
+				phpVer = cfg.PHP.DefaultVersion
+			}
+			if phpVer != "" && !seenPHP[phpVer] {
+				seenPHP[phpVer] = true
+				ensureFPMQuadlet(phpVer) //nolint:errcheck
+			}
 		}
 
 		// Read .lerd.yaml for service and worker info.

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -39,6 +39,7 @@ func quadletImage(unit string) string {
 // builds or pulls any that are missing, using the parallel spinner UI.
 func ensureImages() {
 	units := append(coreUnits(), installedServiceUnits()...)
+	units = append(units, installedCustomContainerUnits()...)
 	var jobs []BuildJob
 	seen := map[string]bool{}
 
@@ -85,6 +86,25 @@ func ensureImages() {
 			jobs = append(jobs, BuildJob{
 				Label: "PHP " + v,
 				Run:   func(w io.Writer) error { return podman.BuildFPMImageTo(v, false, w) },
+			})
+
+		case strings.HasPrefix(img, "lerd-custom-") && strings.HasSuffix(img, ":local"):
+			// Rebuild custom container from the site's Containerfile.
+			siteName := strings.TrimSuffix(strings.TrimPrefix(img, "lerd-custom-"), ":local")
+			sn := siteName
+			jobs = append(jobs, BuildJob{
+				Label: "Custom: " + sn,
+				Run: func(w io.Writer) error {
+					site, err := config.FindSite(sn)
+					if err != nil {
+						return err
+					}
+					proj, err := config.LoadProjectConfig(site.Path)
+					if err != nil {
+						return err
+					}
+					return podman.BuildCustomImageTo(sn, site.Path, proj.Container, w)
+				},
 			})
 
 		default:
@@ -178,6 +198,26 @@ func coreUnits() []string {
 		}
 		short := strings.ReplaceAll(v, ".", "")
 		units = append(units, "lerd-php"+short+"-fpm")
+	}
+	return units
+}
+
+// installedCustomContainerUnits returns units for per-project custom containers
+// that have a quadlet installed. These are started alongside FPM and services.
+func installedCustomContainerUnits() []string {
+	var units []string
+	reg, err := config.LoadSites()
+	if err != nil {
+		return nil
+	}
+	for _, site := range reg.Sites {
+		if !site.IsCustomContainer() || site.Paused {
+			continue
+		}
+		unitName := podman.CustomContainerName(site.Name)
+		if podman.QuadletInstalled(unitName) {
+			units = append(units, unitName)
+		}
 	}
 	return units
 }
@@ -403,9 +443,11 @@ func runStart(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	// Phase 1: start all infrastructure (containers, FPM, UI, watcher) before workers.
-	// Workers exec into FPM containers, so the containers must be up first.
+	// Phase 1: start all infrastructure (containers, FPM, custom containers,
+	// UI, watcher) before workers. Workers exec into containers, so they must
+	// be up first.
 	serviceUnits := append(coreUnits(), installedServiceUnits()...)
+	serviceUnits = append(serviceUnits, installedCustomContainerUnits()...)
 	serviceUnits = append(serviceUnits, "lerd-ui", "lerd-watcher")
 
 	// Phase 2: worker units that depend on running containers.
@@ -816,6 +858,7 @@ func RunQuit() error { return runQuit(nil, nil) }
 
 func runStop(_ *cobra.Command, _ []string) error {
 	units := append(coreUnits(), allInstalledServiceUnits()...)
+	units = append(units, installedCustomContainerUnits()...)
 	units = append(units, registeredQueueUnits()...)
 	units = append(units, registeredStripeUnits()...)
 	units = append(units, registeredScheduleUnits()...)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -104,6 +104,19 @@ func runStatus(_ *cobra.Command, _ []string) error {
 		}
 	}
 
+	// Custom Containers
+	if customUnits := installedCustomContainerUnits(); len(customUnits) > 0 {
+		fmt.Println("\n[Custom Containers]")
+		for _, unit := range customUnits {
+			running, _ := podman.ContainerRunning(unit)
+			if running {
+				ok2(unit)
+			} else {
+				fail2(unit, "not running", serviceStartHint(unit))
+			}
+		}
+	}
+
 	// Watcher
 	fmt.Println("\n[Watcher]")
 	if services.Mgr.IsActive("lerd-watcher") {

--- a/internal/cli/unlink.go
+++ b/internal/cli/unlink.go
@@ -65,6 +65,7 @@ func UnlinkSite(name string) error {
 			fmt.Scanln(&answer) //nolint:errcheck
 			if answer != "" && (answer[0] == 'y' || answer[0] == 'Y') {
 				_ = podman.RemoveCustomImage(site.Name)
+				podman.RemoveContainerfileHash(site.Name)
 				fmt.Println("Image removed.")
 			}
 		}

--- a/internal/cli/unlink.go
+++ b/internal/cli/unlink.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteops"
 	"github.com/spf13/cobra"
 )
@@ -55,6 +56,19 @@ func UnlinkSite(name string) error {
 	}
 
 	fmt.Printf("Unlinked: %s (%s)\n", name, site.PrimaryDomain())
+
+	// Offer to remove the cached custom container image.
+	if site.IsCustomContainer() && podman.CustomImageExists(site.Name) {
+		if isInteractive() {
+			fmt.Print("Remove the container image? [y/N] ")
+			var answer string
+			fmt.Scanln(&answer) //nolint:errcheck
+			if answer != "" && (answer[0] == 'y' || answer[0] == 'Y') {
+				_ = podman.RemoveCustomImage(site.Name)
+				fmt.Println("Image removed.")
+			}
+		}
+	}
 
 	autoStopUnusedServices()
 	autoStopUnusedFPMs()

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -150,10 +150,22 @@ func newWorkerListCmd() *cobra.Command {
 
 // resolveSiteAndFramework finds the registered site and its framework for cwd.
 // Falls back to framework detection if the site has no Framework set.
+// For custom container sites without a framework, a synthetic framework is
+// returned that contains only the custom_workers from .lerd.yaml.
 func resolveSiteAndFramework(cwd string) (*config.Site, *config.Framework, string, error) {
 	site, err := config.FindSiteByPath(cwd)
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("not a registered site — run 'lerd link' first")
+	}
+
+	// Custom container sites may not have a framework. Build a synthetic
+	// framework from .lerd.yaml custom_workers so the worker commands work.
+	if site.IsCustomContainer() && site.Framework == "" {
+		fw := &config.Framework{Name: "custom", Label: "custom container"}
+		if proj, _ := config.LoadProjectConfig(cwd); proj != nil && len(proj.CustomWorkers) > 0 {
+			fw.Workers = proj.CustomWorkers
+		}
+		return site, fw, "", nil
 	}
 
 	fwName := site.Framework
@@ -216,8 +228,14 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 		command = command + " --port=" + port
 	}
 
-	versionShort := strings.ReplaceAll(phpVersion, ".", "")
-	fpmUnit := "lerd-php" + versionShort + "-fpm"
+	// For custom container sites, exec into the custom container instead of FPM.
+	var fpmUnit string
+	if site, _ := config.FindSite(siteName); site != nil && site.IsCustomContainer() {
+		fpmUnit = podman.CustomContainerName(siteName)
+	} else {
+		versionShort := strings.ReplaceAll(phpVersion, ".", "")
+		fpmUnit = "lerd-php" + versionShort + "-fpm"
+	}
 	unitName := "lerd-" + workerName + "-" + siteName
 
 	restart := w.Restart

--- a/internal/cli/worker_darwin.go
+++ b/internal/cli/worker_darwin.go
@@ -24,13 +24,38 @@ func writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, comman
 		fmt.Printf("[WARN] worker %s has schedule=%q which is not yet supported on macOS — skipping\n", unitName, schedule)
 		return false, nil
 	}
-	versionShort := strings.ReplaceAll(phpVersion, ".", "")
-	image := "lerd-php" + versionShort + "-fpm:local"
 
-	// Build a quadlet-style [Container] unit. On macOS, WriteContainerUnit
-	// converts this to a launchd plist running `podman run -d --restart=always`.
-	home, _ := os.UserHomeDir()
-	unit := fmt.Sprintf(`[Container]
+	// Custom container sites exec into their own container.
+	var unit string
+	if site, _ := config.FindSite(siteName); site != nil && site.IsCustomContainer() {
+		image := podman.CustomImageName(siteName)
+		home, _ := os.UserHomeDir()
+		unit = fmt.Sprintf(`[Container]
+Image=%s
+ContainerName=%s
+Network=lerd
+Volume=%s/.local/share/lerd/hosts:/etc/hosts:ro
+Volume=%s:%s:rw
+PodmanArgs=--security-opt=label=disable
+WorkingDir=%s
+Exec=%s
+
+[Service]
+Restart=%s
+`,
+			image,
+			unitName,
+			home,
+			sitePath, sitePath,
+			sitePath,
+			command,
+			restart,
+		)
+	} else {
+		versionShort := strings.ReplaceAll(phpVersion, ".", "")
+		image := "lerd-php" + versionShort + "-fpm:local"
+		home, _ := os.UserHomeDir()
+		unit = fmt.Sprintf(`[Container]
 Image=%s
 ContainerName=%s
 Network=lerd
@@ -45,16 +70,17 @@ Exec=%s
 [Service]
 Restart=%s
 `,
-		image,
-		unitName,
-		home,
-		sitePath, sitePath,
-		config.PHPConfFile(phpVersion),
-		config.PHPUserIniFile(phpVersion),
-		sitePath,
-		command,
-		restart,
-	)
+			image,
+			unitName,
+			home,
+			sitePath, sitePath,
+			config.PHPConfFile(phpVersion),
+			config.PHPUserIniFile(phpVersion),
+			sitePath,
+			command,
+			restart,
+		)
+	}
 
 	if err := services.Mgr.WriteContainerUnit(unitName, unit); err != nil {
 		return false, err
@@ -75,8 +101,13 @@ func workerLogHint(unitName string) string {
 // phase 2 of runStart so we don't saturate the Podman Machine SSH connection
 // before containers are ready.
 func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.FrameworkWorker) {
-	versionShort := strings.ReplaceAll(phpVersion, ".", "")
-	fpmUnit := "lerd-php" + versionShort + "-fpm"
+	var fpmUnit string
+	if site, _ := config.FindSite(siteName); site != nil && site.IsCustomContainer() {
+		fpmUnit = podman.CustomContainerName(siteName)
+	} else {
+		versionShort := strings.ReplaceAll(phpVersion, ".", "")
+		fpmUnit = "lerd-php" + versionShort + "-fpm"
+	}
 	unitName := "lerd-" + workerName + "-" + siteName
 	restart := w.Restart
 	if restart == "" {

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -104,8 +104,13 @@ func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.F
 		command = command + " --port=" + port
 	}
 
-	versionShort := strings.ReplaceAll(phpVersion, ".", "")
-	fpmUnit := "lerd-php" + versionShort + "-fpm"
+	var fpmUnit string
+	if site, _ := config.FindSite(siteName); site != nil && site.IsCustomContainer() {
+		fpmUnit = podman.CustomContainerName(siteName)
+	} else {
+		versionShort := strings.ReplaceAll(phpVersion, ".", "")
+		fpmUnit = "lerd-php" + versionShort + "-fpm"
+	}
 	unitName := "lerd-" + workerName + "-" + siteName
 
 	restart := w.Restart

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -24,6 +24,7 @@ type ContainerConfig struct {
 	Port          int    `yaml:"port"`                    // port the app listens on inside the container (required)
 	Containerfile string `yaml:"containerfile,omitempty"` // path to Containerfile, default "Containerfile.lerd"
 	BuildContext  string `yaml:"build_context,omitempty"` // build context directory, default "."
+	SSL           bool   `yaml:"ssl,omitempty"`           // proxy to the container via HTTPS (app serves TLS on its port)
 }
 
 // ProjectConfig holds per-project configuration stored in .lerd.yaml.

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -16,6 +16,16 @@ type ProjectDB struct {
 	Database string `yaml:"database,omitempty"`
 }
 
+// ContainerConfig holds per-project custom container settings. When present
+// in .lerd.yaml the site gets its own dedicated container built from the
+// user's Containerfile, and nginx reverse-proxies to it instead of using
+// the shared PHP-FPM image.
+type ContainerConfig struct {
+	Port          int    `yaml:"port"`                    // port the app listens on inside the container (required)
+	Containerfile string `yaml:"containerfile,omitempty"` // path to Containerfile, default "Containerfile.lerd"
+	BuildContext  string `yaml:"build_context,omitempty"` // build context directory, default "."
+}
+
 // ProjectConfig holds per-project configuration stored in .lerd.yaml.
 type ProjectConfig struct {
 	Domains          []string                   `yaml:"domains,omitempty"`
@@ -32,8 +42,9 @@ type ProjectConfig struct {
 	// the framework-configured URL key) on every `lerd env` run. Committed to
 	// the repo so the choice is shared across machines. Takes precedence over
 	// the per-machine override in sites.yaml.
-	AppURL string    `yaml:"app_url,omitempty"`
-	DB     ProjectDB `yaml:"db,omitempty"`
+	AppURL    string           `yaml:"app_url,omitempty"`
+	DB        ProjectDB        `yaml:"db,omitempty"`
+	Container *ContainerConfig `yaml:"container,omitempty"`
 }
 
 // IsEmpty returns true when the config has no meaningful content, which
@@ -42,7 +53,7 @@ func (c *ProjectConfig) IsEmpty() bool {
 	return len(c.Domains) == 0 && c.PHPVersion == "" && c.NodeVersion == "" &&
 		c.Framework == "" && len(c.Services) == 0 && len(c.Workers) == 0 &&
 		len(c.CustomWorkers) == 0 && !c.Secured && c.AppURL == "" &&
-		c.DB.Service == "" && c.DB.Database == ""
+		c.DB.Service == "" && c.DB.Database == "" && c.Container == nil
 }
 
 // ServiceNames returns the name of every service in the config, for callers

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -241,6 +241,104 @@ func TestProjectConfig_DomainsAndWorkers(t *testing.T) {
 	}
 }
 
+func TestProjectConfig_Container(t *testing.T) {
+	input := `domains:
+  - nestapp
+container:
+  port: 3000
+  containerfile: Containerfile
+  build_context: .
+`
+	var cfg ProjectConfig
+	if err := yaml.Unmarshal([]byte(input), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.Container == nil {
+		t.Fatal("Container is nil")
+	}
+	if cfg.Container.Port != 3000 {
+		t.Errorf("Port = %d, want 3000", cfg.Container.Port)
+	}
+	if cfg.Container.Containerfile != "Containerfile" {
+		t.Errorf("Containerfile = %q, want Containerfile", cfg.Container.Containerfile)
+	}
+	if cfg.Container.BuildContext != "." {
+		t.Errorf("BuildContext = %q, want .", cfg.Container.BuildContext)
+	}
+}
+
+func TestProjectConfig_Container_PortOnly(t *testing.T) {
+	input := `container:
+  port: 8080
+`
+	var cfg ProjectConfig
+	if err := yaml.Unmarshal([]byte(input), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.Container == nil {
+		t.Fatal("Container is nil")
+	}
+	if cfg.Container.Port != 8080 {
+		t.Errorf("Port = %d, want 8080", cfg.Container.Port)
+	}
+	if cfg.Container.Containerfile != "" {
+		t.Errorf("Containerfile = %q, want empty", cfg.Container.Containerfile)
+	}
+	if cfg.Container.BuildContext != "" {
+		t.Errorf("BuildContext = %q, want empty", cfg.Container.BuildContext)
+	}
+}
+
+func TestProjectConfig_Container_RoundTrip(t *testing.T) {
+	cfg := ProjectConfig{
+		Domains: []string{"nestapp"},
+		Container: &ContainerConfig{
+			Port:          3000,
+			Containerfile: "Containerfile.custom",
+		},
+	}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restored ProjectConfig
+	if err := yaml.Unmarshal(data, &restored); err != nil {
+		t.Fatal(err)
+	}
+	if restored.Container == nil {
+		t.Fatal("Container is nil after round-trip")
+	}
+	if restored.Container.Port != 3000 {
+		t.Errorf("Port = %d, want 3000", restored.Container.Port)
+	}
+	if restored.Container.Containerfile != "Containerfile.custom" {
+		t.Errorf("Containerfile = %q", restored.Container.Containerfile)
+	}
+}
+
+func TestProjectConfig_Container_IsEmpty(t *testing.T) {
+	cfg := &ProjectConfig{}
+	if !cfg.IsEmpty() {
+		t.Error("empty config should be empty")
+	}
+	cfg.Container = &ContainerConfig{Port: 3000}
+	if cfg.IsEmpty() {
+		t.Error("config with container should not be empty")
+	}
+}
+
+func TestProjectConfig_NoContainer(t *testing.T) {
+	input := `php_version: "8.4"
+`
+	var cfg ProjectConfig
+	if err := yaml.Unmarshal([]byte(input), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Container != nil {
+		t.Errorf("expected nil container, got %+v", cfg.Container)
+	}
+}
+
 func TestProjectConfig_OldFormatCompat(t *testing.T) {
 	// Old .lerd.yaml used services: [mysql, redis] — must still parse.
 	input := `php_version: "8.3"

--- a/internal/config/service_manual.go
+++ b/internal/config/service_manual.go
@@ -166,13 +166,23 @@ func CountSitesUsingService(name string) int {
 		if s.Ignored || s.Paused {
 			continue
 		}
-		data, err := os.ReadFile(filepath.Join(s.Path, ".env"))
-		if err != nil {
-			continue
+		// Check .lerd.yaml services list (covers custom container sites
+		// that may not have a .env with lerd-{name} references).
+		if proj, pErr := LoadProjectConfig(s.Path); pErr == nil {
+			for _, svc := range proj.Services {
+				if svc.Name == name {
+					count++
+					goto next
+				}
+			}
 		}
-		if strings.Contains(string(data), needle) {
-			count++
+		// Fall back to .env scanning for PHP sites.
+		if data, err := os.ReadFile(filepath.Join(s.Path, ".env")); err == nil {
+			if strings.Contains(string(data), needle) {
+				count++
+			}
 		}
+	next:
 	}
 	return count
 }

--- a/internal/config/service_manual_test.go
+++ b/internal/config/service_manual_test.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCountSitesUsingService_LerdYAML(t *testing.T) {
+	setDataDir(t)
+
+	siteDir := t.TempDir()
+	lerdYAML := `services:
+  - postgres
+`
+	os.WriteFile(filepath.Join(siteDir, ".lerd.yaml"), []byte(lerdYAML), 0644)
+
+	if err := AddSite(Site{
+		Name:    "goapp",
+		Domains: []string{"goapp.test"},
+		Path:    siteDir,
+	}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	count := CountSitesUsingService("postgres")
+	if count != 1 {
+		t.Errorf("CountSitesUsingService(postgres) = %d, want 1", count)
+	}
+
+	count = CountSitesUsingService("mysql")
+	if count != 0 {
+		t.Errorf("CountSitesUsingService(mysql) = %d, want 0", count)
+	}
+}
+
+func TestCountSitesUsingService_NoEnvNoYAML(t *testing.T) {
+	setDataDir(t)
+
+	siteDir := t.TempDir()
+	if err := AddSite(Site{
+		Name:    "bare",
+		Domains: []string{"bare.test"},
+		Path:    siteDir,
+	}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	count := CountSitesUsingService("postgres")
+	if count != 0 {
+		t.Errorf("CountSitesUsingService(postgres) = %d, want 0", count)
+	}
+}
+
+func TestCountSitesUsingService_EnvFallback(t *testing.T) {
+	setDataDir(t)
+
+	siteDir := t.TempDir()
+	os.WriteFile(filepath.Join(siteDir, ".env"), []byte("DB_HOST=lerd-mysql\n"), 0644)
+
+	if err := AddSite(Site{
+		Name:    "phpapp",
+		Domains: []string{"phpapp.test"},
+		Path:    siteDir,
+	}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	count := CountSitesUsingService("mysql")
+	if count != 1 {
+		t.Errorf("CountSitesUsingService(mysql) = %d, want 1", count)
+	}
+}
+
+func TestCountSitesUsingService_LerdYAMLTakesPriority(t *testing.T) {
+	setDataDir(t)
+
+	siteDir := t.TempDir()
+	// .lerd.yaml declares postgres, .env also references lerd-mysql.
+	// The function should count the site for postgres via .lerd.yaml and
+	// NOT double-count it (goto next after .lerd.yaml match).
+	lerdYAML := `services:
+  - postgres
+`
+	os.WriteFile(filepath.Join(siteDir, ".lerd.yaml"), []byte(lerdYAML), 0644)
+	os.WriteFile(filepath.Join(siteDir, ".env"), []byte("DB_HOST=lerd-postgres\n"), 0644)
+
+	if err := AddSite(Site{
+		Name:    "dualapp",
+		Domains: []string{"dualapp.test"},
+		Path:    siteDir,
+	}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	count := CountSitesUsingService("postgres")
+	if count != 1 {
+		t.Errorf("CountSitesUsingService(postgres) = %d, want 1 (not double-counted)", count)
+	}
+}
+
+func TestCountSitesUsingService_IgnoredSiteSkipped(t *testing.T) {
+	setDataDir(t)
+
+	siteDir := t.TempDir()
+	lerdYAML := `services:
+  - redis
+`
+	os.WriteFile(filepath.Join(siteDir, ".lerd.yaml"), []byte(lerdYAML), 0644)
+
+	if err := AddSite(Site{
+		Name:    "ignored",
+		Domains: []string{"ignored.test"},
+		Path:    siteDir,
+		Ignored: true,
+	}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	count := CountSitesUsingService("redis")
+	if count != 0 {
+		t.Errorf("CountSitesUsingService(redis) = %d, want 0 for ignored site", count)
+	}
+}
+
+func TestCountSitesUsingService_PausedSiteSkipped(t *testing.T) {
+	setDataDir(t)
+
+	siteDir := t.TempDir()
+	lerdYAML := `services:
+  - redis
+`
+	os.WriteFile(filepath.Join(siteDir, ".lerd.yaml"), []byte(lerdYAML), 0644)
+
+	if err := AddSite(Site{
+		Name:    "paused",
+		Domains: []string{"paused.test"},
+		Path:    siteDir,
+		Paused:  true,
+	}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	count := CountSitesUsingService("redis")
+	if count != 0 {
+		t.Errorf("CountSitesUsingService(redis) = %d, want 0 for paused site", count)
+	}
+}

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -31,6 +31,16 @@ type Site struct {
 	// header rewritten. LAN devices can reach the site at <lanIP>:LANPort
 	// without any DNS configuration.
 	LANPort int `yaml:"lan_port,omitempty"`
+	// ContainerPort, when non-zero, means this site uses a per-project custom
+	// container instead of the shared PHP-FPM image. The value is the port the
+	// app listens on inside the container; nginx reverse-proxies to it.
+	ContainerPort int `yaml:"container_port,omitempty"`
+}
+
+// IsCustomContainer returns true when the site uses a per-project custom
+// container instead of the shared PHP-FPM image.
+func (s *Site) IsCustomContainer() bool {
+	return s.ContainerPort > 0
 }
 
 // PrimaryDomain returns the first (primary) domain for the site.
@@ -68,6 +78,7 @@ type siteYAML struct {
 	PublicDir     string   `yaml:"public_dir,omitempty"`
 	AppURL        string   `yaml:"app_url,omitempty"`
 	LANPort       int      `yaml:"lan_port,omitempty"`
+	ContainerPort int      `yaml:"container_port,omitempty"`
 }
 
 func (s Site) toYAML() siteYAML {
@@ -85,6 +96,7 @@ func (s Site) toYAML() siteYAML {
 		PublicDir:     s.PublicDir,
 		AppURL:        s.AppURL,
 		LANPort:       s.LANPort,
+		ContainerPort: s.ContainerPort,
 	}
 }
 
@@ -107,6 +119,7 @@ func (sy siteYAML) toSite() Site {
 		PublicDir:     sy.PublicDir,
 		AppURL:        sy.AppURL,
 		LANPort:       sy.LANPort,
+		ContainerPort: sy.ContainerPort,
 	}
 }
 

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -35,6 +35,9 @@ type Site struct {
 	// container instead of the shared PHP-FPM image. The value is the port the
 	// app listens on inside the container; nginx reverse-proxies to it.
 	ContainerPort int `yaml:"container_port,omitempty"`
+	// ContainerSSL, when true, means the app inside the custom container serves
+	// TLS on its port; nginx will proxy_pass via HTTPS with ssl_verify off.
+	ContainerSSL bool `yaml:"container_ssl,omitempty"`
 }
 
 // IsCustomContainer returns true when the site uses a per-project custom
@@ -79,6 +82,7 @@ type siteYAML struct {
 	AppURL        string   `yaml:"app_url,omitempty"`
 	LANPort       int      `yaml:"lan_port,omitempty"`
 	ContainerPort int      `yaml:"container_port,omitempty"`
+	ContainerSSL  bool     `yaml:"container_ssl,omitempty"`
 }
 
 func (s Site) toYAML() siteYAML {
@@ -97,6 +101,7 @@ func (s Site) toYAML() siteYAML {
 		AppURL:        s.AppURL,
 		LANPort:       s.LANPort,
 		ContainerPort: s.ContainerPort,
+		ContainerSSL:  s.ContainerSSL,
 	}
 }
 
@@ -120,6 +125,7 @@ func (sy siteYAML) toSite() Site {
 		AppURL:        sy.AppURL,
 		LANPort:       sy.LANPort,
 		ContainerPort: sy.ContainerPort,
+		ContainerSSL:  sy.ContainerSSL,
 	}
 }
 

--- a/internal/config/site_test.go
+++ b/internal/config/site_test.go
@@ -454,6 +454,58 @@ func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }
 
+// ── IsCustomContainer ───────────────────────────────────────────────────────
+
+func TestIsCustomContainer(t *testing.T) {
+	s := &Site{ContainerPort: 3000}
+	if !s.IsCustomContainer() {
+		t.Error("expected IsCustomContainer() = true for port 3000")
+	}
+}
+
+func TestIsCustomContainer_False(t *testing.T) {
+	s := &Site{}
+	if s.IsCustomContainer() {
+		t.Error("expected IsCustomContainer() = false for zero port")
+	}
+}
+
+// ── ContainerPort round-trip ────────────────────────────────────────────────
+
+func TestSaveLoad_ContainerPort_RoundTrip(t *testing.T) {
+	setDataDir(t)
+
+	reg := &SiteRegistry{
+		Sites: []Site{
+			{Name: "nestapp", Domains: []string{"nestapp.test"}, Path: "/srv/nestapp", ContainerPort: 3000},
+			{Name: "phpapp", Domains: []string{"phpapp.test"}, Path: "/srv/phpapp", PHPVersion: "8.4"},
+		},
+	}
+	if err := SaveSites(reg); err != nil {
+		t.Fatalf("SaveSites: %v", err)
+	}
+
+	got, err := LoadSites()
+	if err != nil {
+		t.Fatalf("LoadSites: %v", err)
+	}
+	if len(got.Sites) != 2 {
+		t.Fatalf("expected 2 sites, got %d", len(got.Sites))
+	}
+	if got.Sites[0].ContainerPort != 3000 {
+		t.Errorf("nestapp ContainerPort = %d, want 3000", got.Sites[0].ContainerPort)
+	}
+	if !got.Sites[0].IsCustomContainer() {
+		t.Error("nestapp should be custom container")
+	}
+	if got.Sites[1].ContainerPort != 0 {
+		t.Errorf("phpapp ContainerPort = %d, want 0", got.Sites[1].ContainerPort)
+	}
+	if got.Sites[1].IsCustomContainer() {
+		t.Error("phpapp should not be custom container")
+	}
+}
+
 func searchString(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4517,6 +4517,9 @@ func execSitePHP(args map[string]any) (any, *rpcError) {
 	if err != nil {
 		return toolErr(fmt.Sprintf("site %q not found — run sites to list registered sites", siteName)), nil
 	}
+	if site.IsCustomContainer() {
+		return toolErr("custom container sites do not use PHP versions — the container defines its own runtime"), nil
+	}
 
 	// Write .php-version pin file (keeps CLI php and other tools in sync).
 	phpVersionFile := filepath.Join(site.Path, ".php-version")

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1705,6 +1705,7 @@ func execSites() (any, *rpcError) {
 		Framework       string         `json:"framework,omitempty"`
 		CustomContainer bool           `json:"custom_container,omitempty"`
 		ContainerPort   int            `json:"container_port,omitempty"`
+		ContainerSSL    bool           `json:"container_ssl,omitempty"`
 		Workers         []workerStatus `json:"workers,omitempty"`
 	}
 
@@ -1757,6 +1758,7 @@ func execSites() (any, *rpcError) {
 			Framework:       e.FrameworkName,
 			CustomContainer: e.ContainerPort > 0,
 			ContainerPort:   e.ContainerPort,
+			ContainerSSL:    e.ContainerSSL,
 			Workers:         workers,
 		})
 	}
@@ -2838,6 +2840,9 @@ func execCheck(args map[string]any) (any, *rpcError) {
 				add("container.build_context", "ok", cfg.Container.BuildContext)
 			}
 		}
+		if cfg.Container.SSL {
+			add("container.ssl", "ok", "nginx will proxy_pass via HTTPS with ssl_verify off")
+		}
 	}
 
 	// custom_workers
@@ -3377,13 +3382,14 @@ func execSiteLink(args map[string]any) (any, *rpcError) {
 
 	// Custom container path: .lerd.yaml has a container section with a port.
 	if proj != nil && proj.Container != nil && proj.Container.Port > 0 {
-		secured := siteops.CleanupRelink(projectPath, name)
+		secured := siteops.CleanupRelink(projectPath, name) || (proj != nil && proj.Secured)
 		site := config.Site{
 			Name:          name,
 			Domains:       domains,
 			Path:          projectPath,
 			Secured:       secured,
 			ContainerPort: proj.Container.Port,
+			ContainerSSL:  proj.Container.SSL,
 		}
 		if err := config.AddSite(site); err != nil {
 			return toolErr("registering site: " + err.Error()), nil
@@ -3406,7 +3412,7 @@ func execSiteLink(args map[string]any) (any, *rpcError) {
 		phpVersion = proj.PHPVersion
 	}
 
-	secured := siteops.CleanupRelink(projectPath, name)
+	secured := siteops.CleanupRelink(projectPath, name) || (proj != nil && proj.Secured)
 	site := config.Site{
 		Name:        name,
 		Domains:     domains,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1368,6 +1368,20 @@ func toolList() []mcpTool {
 			},
 		},
 		mcpTool{
+			Name:        "site_rebuild",
+			Description: "Rebuild the custom container image from the Containerfile and restart the container. Use after changing the Containerfile. For PHP sites use php_ext_add/php_ext_remove instead.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"site": {
+						Type:        "string",
+						Description: "Site name as shown by the sites tool",
+					},
+				},
+				Required: []string{"site"},
+			},
+		},
+		mcpTool{
 			Name:        "service_pin",
 			Description: "Pin a service so it is never auto-stopped, even when no sites reference it. Starts the service if it is not already running.",
 			InputSchema: mcpSchema{
@@ -1544,6 +1558,8 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execSiteUnpause(args)
 	case "site_restart":
 		return execSiteRestart(args)
+	case "site_rebuild":
+		return execSiteRebuild(args)
 	case "service_pin":
 		return execServicePin(args)
 	case "service_unpin":
@@ -4626,6 +4642,14 @@ func execSiteRestart(args map[string]any) (any, *rpcError) {
 		return toolErr("site is required"), nil
 	}
 	return runLerdCmd("restart", siteName)
+}
+
+func execSiteRebuild(args map[string]any) (any, *rpcError) {
+	siteName := strArg(args, "site")
+	if siteName == "" {
+		return toolErr("site is required"), nil
+	}
+	return runLerdCmd("rebuild", siteName)
 }
 
 func execServicePin(args map[string]any) (any, *rpcError) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1327,7 +1327,7 @@ func toolList() []mcpTool {
 		},
 		mcpTool{
 			Name:        "site_pause",
-			Description: "Pause a site: stop all its running workers (queue, schedule, reverb, stripe, custom) and replace its nginx vhost with a landing page. Auto-stops services no longer needed by any active site.",
+			Description: "Pause a site: stop all its running workers and its custom container (if applicable), and replace its nginx vhost with a landing page. Auto-stops services no longer needed by any active site.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
@@ -1341,7 +1341,21 @@ func toolList() []mcpTool {
 		},
 		mcpTool{
 			Name:        "site_unpause",
-			Description: "Resume a paused site: restore its nginx vhost, restart any workers that were running when it was paused, and ensure required services are running.",
+			Description: "Resume a paused site: start its custom container (if applicable), restore its nginx vhost, restart any workers that were running when it was paused, and ensure required services are running.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"site": {
+						Type:        "string",
+						Description: "Site name as shown by the sites tool",
+					},
+				},
+				Required: []string{"site"},
+			},
+		},
+		mcpTool{
+			Name:        "site_restart",
+			Description: "Restart the container for a site. For custom container sites this restarts the dedicated per-project container; for PHP sites it restarts the shared PHP-FPM container for that site's PHP version.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
@@ -1528,6 +1542,8 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execSitePause(args)
 	case "site_unpause":
 		return execSiteUnpause(args)
+	case "site_restart":
+		return execSiteRestart(args)
 	case "service_pin":
 		return execServicePin(args)
 	case "service_unpin":
@@ -4489,6 +4505,14 @@ func execSiteUnpause(args map[string]any) (any, *rpcError) {
 		return toolErr("site is required"), nil
 	}
 	return runLerdCmd("unpause", siteName)
+}
+
+func execSiteRestart(args map[string]any) (any, *rpcError) {
+	siteName := strArg(args, "site")
+	if siteName == "" {
+		return toolErr("site is required"), nil
+	}
+	return runLerdCmd("restart", siteName)
 }
 
 func execServicePin(args map[string]any) (any, *rpcError) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -240,7 +240,7 @@ func toolList() []mcpTool {
 	tools := []mcpTool{
 		{
 			Name:        "sites",
-			Description: "List all sites registered with lerd, including domain, path, PHP version, Node version, TLS status, and queue worker status. Call this first to find site names for other tools.",
+			Description: "List all sites registered with lerd, including domain, path, PHP version, Node version, TLS status, worker status, and custom_container/container_port for non-PHP sites. Call this first to find site names for other tools.",
 			InputSchema: mcpSchema{
 				Type:       "object",
 				Properties: map[string]mcpProp{},
@@ -566,7 +566,7 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "site_link",
-			Description: "Register a directory as a lerd site, generating an nginx vhost and a <name>.test domain. Use this to set up a new project.",
+			Description: "Register a directory as a lerd site, generating an nginx vhost and a <name>.test domain. Reads .lerd.yaml automatically: if a container:{port:N} section is present, builds the custom container image and proxies nginx to it; otherwise registers as a PHP/framework site. For non-PHP projects (Node.js, Python, Go, etc.): write .lerd.yaml with container:{port:N} and a Containerfile (default name Containerfile.lerd; set container.containerfile for a different name like Dockerfile) BEFORE calling this.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
@@ -851,7 +851,7 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "check",
-			Description: "Validate a project's .lerd.yaml file — checks YAML syntax, PHP version format, service definitions, and framework references. Reports OK/WARN/FAIL per field.",
+			Description: "Validate a project's .lerd.yaml file — checks YAML syntax, PHP version, framework references, service definitions (including preset catalog), worker definitions, container config (port required; containerfile path, default Containerfile.lerd — any filename works, set container.containerfile to point at e.g. Dockerfile), custom_workers (command required), and db.service. Reports OK/WARN/FAIL per field.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
@@ -1695,15 +1695,17 @@ func execSites() (any, *rpcError) {
 		Running bool   `json:"running"`
 	}
 	type siteInfoResp struct {
-		Name        string         `json:"name"`
-		Domain      string         `json:"domain"`
-		Domains     []string       `json:"domains"`
-		Path        string         `json:"path"`
-		PHPVersion  string         `json:"php_version"`
-		NodeVersion string         `json:"node_version"`
-		TLS         bool           `json:"tls"`
-		Framework   string         `json:"framework,omitempty"`
-		Workers     []workerStatus `json:"workers,omitempty"`
+		Name            string         `json:"name"`
+		Domain          string         `json:"domain"`
+		Domains         []string       `json:"domains"`
+		Path            string         `json:"path"`
+		PHPVersion      string         `json:"php_version"`
+		NodeVersion     string         `json:"node_version"`
+		TLS             bool           `json:"tls"`
+		Framework       string         `json:"framework,omitempty"`
+		CustomContainer bool           `json:"custom_container,omitempty"`
+		ContainerPort   int            `json:"container_port,omitempty"`
+		Workers         []workerStatus `json:"workers,omitempty"`
 	}
 
 	var out []siteInfoResp
@@ -1745,15 +1747,17 @@ func execSites() (any, *rpcError) {
 		}
 
 		out = append(out, siteInfoResp{
-			Name:        e.Name,
-			Domain:      e.PrimaryDomain(),
-			Domains:     e.Domains,
-			Path:        e.Path,
-			PHPVersion:  e.PHPVersion,
-			NodeVersion: e.NodeVersion,
-			TLS:         e.Secured,
-			Framework:   e.FrameworkName,
-			Workers:     workers,
+			Name:            e.Name,
+			Domain:          e.PrimaryDomain(),
+			Domains:         e.Domains,
+			Path:            e.Path,
+			PHPVersion:      e.PHPVersion,
+			NodeVersion:     e.NodeVersion,
+			TLS:             e.Secured,
+			Framework:       e.FrameworkName,
+			CustomContainer: e.ContainerPort > 0,
+			ContainerPort:   e.ContainerPort,
+			Workers:         workers,
 		})
 	}
 	if out == nil {
@@ -2712,60 +2716,71 @@ func execCheck(args map[string]any) (any, *rpcError) {
 
 	// Workers
 	if len(cfg.Workers) > 0 {
-		fwName := cfg.Framework
-		if fwName == "" {
-			fwName, _ = config.DetectFrameworkForDir(projectPath)
-		}
-		fw, hasFw := config.GetFramework(fwName)
+		if cfg.Container != nil {
+			// Custom container site: workers must be defined in custom_workers.
+			for _, w := range cfg.Workers {
+				if _, ok := cfg.CustomWorkers[w]; ok {
+					add("worker_"+w, "ok", "")
+				} else {
+					add("worker_"+w, "fail", "not defined in custom_workers")
+				}
+			}
+		} else {
+			fwName := cfg.Framework
+			if fwName == "" {
+				fwName, _ = config.DetectFrameworkForDir(projectPath)
+			}
+			fw, hasFw := config.GetFramework(fwName)
 
-		hasQueue, hasHorizon := false, false
-		for _, w := range cfg.Workers {
-			if w == "queue" {
-				hasQueue = true
-			}
-			if w == "horizon" {
-				hasHorizon = true
-			}
-			switch w {
-			case "horizon":
-				if !siteHasComposerPkg(projectPath, `"laravel/horizon"`) {
-					add("worker_"+w, "warn", "laravel/horizon not installed")
-				} else {
-					add("worker_"+w, "ok", "")
+			hasQueue, hasHorizon := false, false
+			for _, w := range cfg.Workers {
+				if w == "queue" {
+					hasQueue = true
 				}
-			case "reverb":
-				if !siteUsesReverb(projectPath) {
-					add("worker_"+w, "warn", "reverb not configured")
-				} else {
-					add("worker_"+w, "ok", "")
+				if w == "horizon" {
+					hasHorizon = true
 				}
-			case "queue", "schedule":
-				if hasFw && fw.Workers != nil {
-					if _, ok := fw.Workers[w]; ok {
-						add("worker_"+w, "ok", "")
+				switch w {
+				case "horizon":
+					if !siteHasComposerPkg(projectPath, `"laravel/horizon"`) {
+						add("worker_"+w, "warn", "laravel/horizon not installed")
 					} else {
-						add("worker_"+w, "warn", "not defined for framework "+fwName)
-					}
-				} else {
-					add("worker_"+w, "warn", "no framework detected")
-				}
-			default:
-				if hasFw && fw.Workers != nil {
-					if _, ok := fw.Workers[w]; ok {
 						add("worker_"+w, "ok", "")
-					} else {
-						add("worker_"+w, "fail", "not defined for framework "+fwName)
 					}
-				} else {
-					add("worker_"+w, "fail", "no framework worker definition found")
+				case "reverb":
+					if !siteUsesReverb(projectPath) {
+						add("worker_"+w, "warn", "reverb not configured")
+					} else {
+						add("worker_"+w, "ok", "")
+					}
+				case "queue", "schedule":
+					if hasFw && fw.Workers != nil {
+						if _, ok := fw.Workers[w]; ok {
+							add("worker_"+w, "ok", "")
+						} else {
+							add("worker_"+w, "warn", "not defined for framework "+fwName)
+						}
+					} else {
+						add("worker_"+w, "warn", "no framework detected")
+					}
+				default:
+					if hasFw && fw.Workers != nil {
+						if _, ok := fw.Workers[w]; ok {
+							add("worker_"+w, "ok", "")
+						} else {
+							add("worker_"+w, "fail", "not defined for framework "+fwName)
+						}
+					} else {
+						add("worker_"+w, "fail", "no framework worker definition found")
+					}
 				}
 			}
-		}
-		if hasQueue && hasHorizon {
-			add("workers_conflict", "warn", "both queue and horizon listed — horizon manages queues")
-		}
-		if hasQueue && siteHasComposerPkg(projectPath, `"laravel/horizon"`) {
-			add("workers_conflict", "warn", "queue listed but horizon installed — horizon will be started instead")
+			if hasQueue && hasHorizon {
+				add("workers_conflict", "warn", "both queue and horizon listed — horizon manages queues")
+			}
+			if hasQueue && siteHasComposerPkg(projectPath, `"laravel/horizon"`) {
+				add("workers_conflict", "warn", "queue listed but horizon installed — horizon will be started instead")
+			}
 		}
 	}
 
@@ -2779,6 +2794,16 @@ func execCheck(args map[string]any) (any, *rpcError) {
 			}
 			continue
 		}
+		if svc.Preset != "" {
+			if _, err := config.LoadPreset(svc.Preset); err != nil {
+				add("service_"+svc.Name, "fail", fmt.Sprintf("unknown preset %q", svc.Preset))
+			} else if _, err := config.LoadCustomService(svc.Name); err != nil {
+				add("service_"+svc.Name, "warn", fmt.Sprintf("preset %q not installed — run: lerd service preset install %s", svc.Preset, svc.Preset))
+			} else {
+				add("service_"+svc.Name, "ok", "preset: "+svc.Preset)
+			}
+			continue
+		}
 		if isKnownService(svc.Name) {
 			add("service_"+svc.Name, "ok", "")
 			continue
@@ -2787,6 +2812,51 @@ func execCheck(args map[string]any) (any, *rpcError) {
 			add("service_"+svc.Name, "ok", "custom")
 		} else {
 			add("service_"+svc.Name, "fail", "not a built-in and no definition found")
+		}
+	}
+
+	// Container
+	if cfg.Container != nil {
+		if cfg.Container.Port <= 0 || cfg.Container.Port > 65535 {
+			add("container.port", "fail", "required and must be 1–65535")
+		} else {
+			add("container.port", "ok", fmt.Sprintf("%d", cfg.Container.Port))
+		}
+		cfPath := cfg.Container.Containerfile
+		if cfPath == "" {
+			cfPath = "Containerfile.lerd"
+		}
+		if _, err := os.Stat(filepath.Join(projectPath, cfPath)); os.IsNotExist(err) {
+			add("container.containerfile", "warn", cfPath+" not found — lerd link will fail")
+		} else {
+			add("container.containerfile", "ok", cfPath)
+		}
+		if cfg.Container.BuildContext != "" {
+			if _, err := os.Stat(filepath.Join(projectPath, cfg.Container.BuildContext)); os.IsNotExist(err) {
+				add("container.build_context", "warn", cfg.Container.BuildContext+" not found")
+			} else {
+				add("container.build_context", "ok", cfg.Container.BuildContext)
+			}
+		}
+	}
+
+	// custom_workers
+	for name, w := range cfg.CustomWorkers {
+		if w.Command == "" {
+			add("custom_worker."+name, "fail", "command is required")
+		} else {
+			add("custom_worker."+name, "ok", "")
+		}
+	}
+
+	// db
+	if cfg.DB.Service != "" {
+		if isKnownService(cfg.DB.Service) {
+			add("db.service", "ok", cfg.DB.Service)
+		} else if _, err := config.LoadCustomService(cfg.DB.Service); err == nil {
+			add("db.service", "ok", cfg.DB.Service+" (custom)")
+		} else {
+			add("db.service", "fail", cfg.DB.Service+" is not a known service")
 		}
 	}
 
@@ -3279,12 +3349,24 @@ func execSiteLink(args map[string]any) (any, *rpcError) {
 		return toolErr("loading config: " + err.Error()), nil
 	}
 
+	proj, _ := config.LoadProjectConfig(projectPath)
+
 	rawName := strArg(args, "name")
 	if rawName == "" {
 		rawName = filepath.Base(projectPath)
 	}
-	name, domain := siteops.SiteNameAndDomain(rawName, cfg.DNS.TLD)
-	domains := []string{domain}
+	name, _ := siteops.SiteNameAndDomain(rawName, cfg.DNS.TLD)
+
+	// Build domains: prefer .lerd.yaml domains, fall back to auto-generated.
+	var domains []string
+	if proj != nil && len(proj.Domains) > 0 {
+		for _, d := range proj.Domains {
+			domains = append(domains, strings.ToLower(d)+"."+cfg.DNS.TLD)
+		}
+	} else {
+		_, domain := siteops.SiteNameAndDomain(rawName, cfg.DNS.TLD)
+		domains = []string{domain}
+	}
 
 	// Validate domains are not used by other sites.
 	for _, d := range domains {
@@ -3293,17 +3375,38 @@ func execSiteLink(args map[string]any) (any, *rpcError) {
 		}
 	}
 
-	// Detect framework so the correct public_dir and workers are used.
-	framework := ""
-	if name, ok := config.DetectFrameworkForDir(projectPath); ok {
-		framework = name
+	// Custom container path: .lerd.yaml has a container section with a port.
+	if proj != nil && proj.Container != nil && proj.Container.Port > 0 {
+		secured := siteops.CleanupRelink(projectPath, name)
+		site := config.Site{
+			Name:          name,
+			Domains:       domains,
+			Path:          projectPath,
+			Secured:       secured,
+			ContainerPort: proj.Container.Port,
+		}
+		if err := config.AddSite(site); err != nil {
+			return toolErr("registering site: " + err.Error()), nil
+		}
+		_ = config.SyncProjectDomains(projectPath, site.Domains, cfg.DNS.TLD)
+		if err := siteops.FinishCustomLink(site, proj.Container); err != nil {
+			return toolErr(err.Error()), nil
+		}
+		return toolOK(fmt.Sprintf("Linked %s -> %s (custom container, port %d)", name, strings.Join(domains, ", "), proj.Container.Port)), nil
 	}
 
+	// PHP / framework path.
+	framework := ""
+	if fname, ok := config.DetectFrameworkForDir(projectPath); ok {
+		framework = fname
+	}
 	versions := siteops.DetectSiteVersions(projectPath, framework, cfg.PHP.DefaultVersion, cfg.Node.DefaultVersion)
 	phpVersion, nodeVersion := versions.PHP, versions.Node
+	if proj != nil && proj.PHPVersion != "" {
+		phpVersion = proj.PHPVersion
+	}
 
 	secured := siteops.CleanupRelink(projectPath, name)
-
 	site := config.Site{
 		Name:        name,
 		Domains:     domains,
@@ -3317,6 +3420,7 @@ func execSiteLink(args map[string]any) (any, *rpcError) {
 	if err := config.AddSite(site); err != nil {
 		return toolErr("registering site: " + err.Error()), nil
 	}
+	_ = config.SyncProjectDomains(projectPath, site.Domains, cfg.DNS.TLD)
 
 	if err := siteops.FinishLink(site, phpVersion); err != nil {
 		return toolErr(err.Error()), nil

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -57,6 +57,7 @@ type VhostData struct {
 	ProxyPort       int    // port the worker listens on inside the PHP-FPM container
 	CustomContainer string // container name for custom container sites (e.g. "lerd-custom-nestapp")
 	CustomPort      int    // port the app listens on inside the custom container
+	BackendSSL      bool   // proxy to the container via HTTPS (app serves TLS on its own port)
 }
 
 // phpShort converts "8.4" → "84".
@@ -189,6 +190,7 @@ func GenerateCustomVhost(site config.Site) error {
 		ServerNames:     serverNamesWithWildcards(site.Domains),
 		CustomContainer: podman.CustomContainerName(site.Name),
 		CustomPort:      site.ContainerPort,
+		BackendSSL:      site.ContainerSSL,
 	}
 
 	var buf bytes.Buffer
@@ -222,6 +224,7 @@ func GenerateCustomSSLVhost(site config.Site) error {
 		CertDomain:      site.PrimaryDomain(),
 		CustomContainer: podman.CustomContainerName(site.Name),
 		CustomPort:      site.ContainerPort,
+		BackendSSL:      site.ContainerSSL,
 	}
 
 	var buf bytes.Buffer

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -55,6 +55,8 @@ type VhostData struct {
 	Proxy           bool   // true when the site has a worker with WebSocket/HTTP proxy config
 	ProxyPath       string // URL path for the proxy (e.g. "/app")
 	ProxyPort       int    // port the worker listens on inside the PHP-FPM container
+	CustomContainer string // container name for custom container sites (e.g. "lerd-custom-nestapp")
+	CustomPort      int    // port the app listens on inside the custom container
 }
 
 // phpShort converts "8.4" → "84".
@@ -154,6 +156,72 @@ func GenerateSSLVhost(site config.Site, phpVersion string) error {
 		Proxy:           hasProxy,
 		ProxyPath:       proxyPath,
 		ProxyPort:       proxyPort,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
+		return err
+	}
+	confPath := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
+	return os.WriteFile(confPath, buf.Bytes(), 0644)
+}
+
+// GenerateCustomVhost renders the HTTP vhost template for a custom container
+// site and writes it to conf.d. Nginx reverse-proxies to the container instead
+// of using fastcgi_pass.
+func GenerateCustomVhost(site config.Site) error {
+	tmplData, err := GetTemplate("vhost-custom.conf.tmpl")
+	if err != nil {
+		return err
+	}
+
+	tmpl, err := template.New("vhost-custom").Parse(string(tmplData))
+	if err != nil {
+		return err
+	}
+
+	data := VhostData{
+		Domain:          site.PrimaryDomain(),
+		ServerNames:     serverNamesWithWildcards(site.Domains),
+		CustomContainer: podman.CustomContainerName(site.Name),
+		CustomPort:      site.ContainerPort,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
+		return err
+	}
+	confPath := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
+	return os.WriteFile(confPath, buf.Bytes(), 0644)
+}
+
+// GenerateCustomSSLVhost renders the SSL vhost template for a custom container
+// site and writes it to conf.d.
+func GenerateCustomSSLVhost(site config.Site) error {
+	tmplData, err := GetTemplate("vhost-custom-ssl.conf.tmpl")
+	if err != nil {
+		return err
+	}
+
+	tmpl, err := template.New("vhost-custom-ssl").Parse(string(tmplData))
+	if err != nil {
+		return err
+	}
+
+	data := VhostData{
+		Domain:          site.PrimaryDomain(),
+		ServerNames:     serverNamesWithWildcards(site.Domains),
+		CertDomain:      site.PrimaryDomain(),
+		CustomContainer: podman.CustomContainerName(site.Name),
+		CustomPort:      site.ContainerPort,
 	}
 
 	var buf bytes.Buffer

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -519,7 +519,13 @@ func RepairVhosts() []VhostRepair {
 				continue
 			}
 			// Regenerate as plain HTTP vhost.
-			if err := GenerateVhost(site, site.PHPVersion); err != nil {
+			var regenErr error
+			if site.IsCustomContainer() {
+				regenErr = GenerateCustomVhost(site)
+			} else {
+				regenErr = GenerateVhost(site, site.PHPVersion)
+			}
+			if regenErr != nil {
 				continue
 			}
 			reg.Sites[i].Secured = false

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -444,6 +444,86 @@ func TestRepairVhosts_preservesIgnoredSiteVhost(t *testing.T) {
 
 // ── EnsureDefaultVhost ────────────────────────────────────────────────────────
 
+// ── GenerateCustomVhost ──────────────────────────────────────────────────────
+
+func TestGenerateCustomVhost_createsConfFile(t *testing.T) {
+	confD := setupConfD(t)
+	site := config.Site{Name: "nestapp", Domains: []string{"nestapp.test"}, ContainerPort: 3000}
+	if err := GenerateCustomVhost(site); err != nil {
+		t.Fatalf("GenerateCustomVhost: %v", err)
+	}
+	content := readConf(t, filepath.Join(confD, "nestapp.test.conf"))
+	if !strings.Contains(content, "server_name nestapp.test") {
+		t.Errorf("expected server_name in:\n%s", content)
+	}
+	if !strings.Contains(content, "proxy_pass http://$backend:3000") {
+		t.Errorf("expected proxy_pass with port 3000 in:\n%s", content)
+	}
+	if !strings.Contains(content, "lerd-custom-nestapp") {
+		t.Errorf("expected custom container name in:\n%s", content)
+	}
+	if strings.Contains(content, "fastcgi_pass") {
+		t.Error("custom vhost should not contain fastcgi_pass")
+	}
+}
+
+func TestGenerateCustomVhost_multiDomain(t *testing.T) {
+	confD := setupConfD(t)
+	site := config.Site{Name: "nestapp", Domains: []string{"nestapp.test", "api.test"}, ContainerPort: 3000}
+	if err := GenerateCustomVhost(site); err != nil {
+		t.Fatal(err)
+	}
+	content := readConf(t, filepath.Join(confD, "nestapp.test.conf"))
+	if !strings.Contains(content, "server_name nestapp.test *.nestapp.test api.test *.api.test") {
+		t.Errorf("expected all domains with wildcards in:\n%s", content)
+	}
+}
+
+func TestGenerateCustomVhost_websocketHeaders(t *testing.T) {
+	setupConfD(t)
+	site := config.Site{Name: "app", Domains: []string{"app.test"}, ContainerPort: 8080}
+	if err := GenerateCustomVhost(site); err != nil {
+		t.Fatal(err)
+	}
+	confD := filepath.Join(os.Getenv("XDG_DATA_HOME"), "lerd", "nginx", "conf.d")
+	content := readConf(t, filepath.Join(confD, "app.test.conf"))
+	if !strings.Contains(content, "proxy_set_header Upgrade") {
+		t.Error("expected WebSocket upgrade header")
+	}
+	if !strings.Contains(content, "proxy_http_version 1.1") {
+		t.Error("expected HTTP/1.1 for WebSocket support")
+	}
+}
+
+// ── GenerateCustomSSLVhost ───────────────────────────────────────────────────
+
+func TestGenerateCustomSSLVhost_createsSSLConfFile(t *testing.T) {
+	confD := setupConfD(t)
+	site := config.Site{Name: "nestapp", Domains: []string{"nestapp.test"}, ContainerPort: 3000}
+	if err := GenerateCustomSSLVhost(site); err != nil {
+		t.Fatalf("GenerateCustomSSLVhost: %v", err)
+	}
+	content := readConf(t, filepath.Join(confD, "nestapp.test-ssl.conf"))
+	if !strings.Contains(content, "listen 443 ssl") {
+		t.Errorf("expected 443 ssl in:\n%s", content)
+	}
+	if !strings.Contains(content, "ssl_certificate /etc/nginx/certs/nestapp.test.crt") {
+		t.Errorf("expected ssl_certificate in:\n%s", content)
+	}
+	if !strings.Contains(content, "proxy_pass http://$backend:3000") {
+		t.Errorf("expected proxy_pass in:\n%s", content)
+	}
+	if !strings.Contains(content, "lerd-custom-nestapp") {
+		t.Errorf("expected custom container name in:\n%s", content)
+	}
+	if !strings.Contains(content, "return 302 https://") {
+		t.Errorf("expected HTTP redirect in:\n%s", content)
+	}
+	if strings.Contains(content, "fastcgi_pass") {
+		t.Error("custom SSL vhost should not contain fastcgi_pass")
+	}
+}
+
 func TestEnsureDefaultVhost_writesDefaultConf(t *testing.T) {
 	confD := setupConfD(t)
 	if err := EnsureDefaultVhost(); err != nil {

--- a/internal/nginx/templates/vhost-custom-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-custom-ssl.conf.tmpl
@@ -13,7 +13,7 @@ server {
 
     location / {
         set $backend "{{.CustomContainer}}";
-        proxy_pass http://$backend:{{.CustomPort}};
+        proxy_pass {{if .BackendSSL}}https{{else}}http{{end}}://$backend:{{.CustomPort}};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -23,5 +23,8 @@ server {
         proxy_set_header X-Forwarded-Proto https;
         proxy_read_timeout 60s;
         proxy_send_timeout 60s;
+        {{- if .BackendSSL}}
+        proxy_ssl_verify off;
+        {{- end}}
     }
 }

--- a/internal/nginx/templates/vhost-custom-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-custom-ssl.conf.tmpl
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name {{.ServerNames}};
+    return 302 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name {{.ServerNames}};
+
+    ssl_certificate /etc/nginx/certs/{{.CertDomain}}.crt;
+    ssl_certificate_key /etc/nginx/certs/{{.CertDomain}}.key;
+
+    location / {
+        set $backend "{{.CustomContainer}}";
+        proxy_pass http://$backend:{{.CustomPort}};
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+    }
+}

--- a/internal/nginx/templates/vhost-custom.conf.tmpl
+++ b/internal/nginx/templates/vhost-custom.conf.tmpl
@@ -4,7 +4,7 @@ server {
 
     location / {
         set $backend "{{.CustomContainer}}";
-        proxy_pass http://$backend:{{.CustomPort}};
+        proxy_pass {{if .BackendSSL}}https{{else}}http{{end}}://$backend:{{.CustomPort}};
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -14,5 +14,8 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 60s;
         proxy_send_timeout 60s;
+        {{- if .BackendSSL}}
+        proxy_ssl_verify off;
+        {{- end}}
     }
 }

--- a/internal/nginx/templates/vhost-custom.conf.tmpl
+++ b/internal/nginx/templates/vhost-custom.conf.tmpl
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name {{.ServerNames}};
+
+    location / {
+        set $backend "{{.CustomContainer}}";
+        proxy_pass http://$backend:{{.CustomPort}};
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+    }
+}

--- a/internal/podman/custom_container.go
+++ b/internal/podman/custom_container.go
@@ -2,6 +2,7 @@ package podman
 
 import (
 	"bufio"
+	"crypto/md5"
 	"fmt"
 	"os"
 	"os/exec"
@@ -54,6 +55,58 @@ func HasContainerfile(projectPath string) bool {
 // container is present in the podman store.
 func CustomImageExists(siteName string) bool {
 	return ImageExists(CustomImageName(siteName))
+}
+
+// CustomImageUpToDate returns true when the image exists and the stored
+// Containerfile hash matches the current file on disk. Returns false when
+// the image is missing, the hash file is missing, or the Containerfile
+// has changed since the last build.
+func CustomImageUpToDate(siteName, projectPath string, cfg *config.ContainerConfig) bool {
+	if !CustomImageExists(siteName) {
+		return false
+	}
+	stored := readContainerfileHash(siteName)
+	if stored == "" {
+		return false
+	}
+	current := hashContainerfile(projectPath, cfg)
+	return current != "" && current == stored
+}
+
+// StoreContainerfileHash persists the MD5 hash of the current Containerfile
+// so subsequent link calls can skip the build when the file hasn't changed.
+func StoreContainerfileHash(siteName, projectPath string, cfg *config.ContainerConfig) {
+	hash := hashContainerfile(projectPath, cfg)
+	if hash == "" {
+		return
+	}
+	dir := filepath.Join(config.DataDir(), "container-hashes")
+	os.MkdirAll(dir, 0755)                                         //nolint:errcheck
+	os.WriteFile(filepath.Join(dir, siteName), []byte(hash), 0644) //nolint:errcheck
+}
+
+// RemoveContainerfileHash removes the stored hash for a site.
+func RemoveContainerfileHash(siteName string) {
+	path := filepath.Join(config.DataDir(), "container-hashes", siteName)
+	os.Remove(path) //nolint:errcheck
+}
+
+func hashContainerfile(projectPath string, cfg *config.ContainerConfig) string {
+	path := ResolveContainerfile(projectPath, cfg)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%x", md5.Sum(data))
+}
+
+func readContainerfileHash(siteName string) string {
+	path := filepath.Join(config.DataDir(), "container-hashes", siteName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }
 
 // BuildCustomImage builds the OCI image for a site's custom container from

--- a/internal/podman/custom_container.go
+++ b/internal/podman/custom_container.go
@@ -50,6 +50,12 @@ func HasContainerfile(projectPath string) bool {
 	return err == nil
 }
 
+// CustomImageExists returns true when the local image for a site's custom
+// container is present in the podman store.
+func CustomImageExists(siteName string) bool {
+	return ImageExists(CustomImageName(siteName))
+}
+
 // BuildCustomImage builds the OCI image for a site's custom container from
 // the user's Containerfile. The image is tagged as lerd-custom-{siteName}:local.
 func BuildCustomImage(siteName, projectPath string, cfg *config.ContainerConfig) error {

--- a/internal/podman/custom_container.go
+++ b/internal/podman/custom_container.go
@@ -1,10 +1,12 @@
 package podman
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/geodro/lerd/internal/config"
 )
@@ -92,6 +94,34 @@ func RemoveCustomImage(siteName string) error {
 	imageName := CustomImageName(siteName)
 	_ = exec.Command(PodmanBin(), "rmi", "-f", imageName).Run()
 	return nil
+}
+
+// ContainerBaseImage reads the Containerfile for a project and returns the
+// base image from the first FROM instruction, e.g. "node:20-alpine".
+// Returns "" if the file cannot be read or has no FROM line.
+func ContainerBaseImage(projectPath string, cfg *config.ContainerConfig) string {
+	path := ResolveContainerfile(projectPath, cfg)
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		upper := strings.ToUpper(line)
+		if strings.HasPrefix(upper, "FROM ") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				// Strip the registry prefix for cleaner display.
+				image := parts[1]
+				image = strings.TrimPrefix(image, "docker.io/library/")
+				image = strings.TrimPrefix(image, "docker.io/")
+				return image
+			}
+		}
+	}
+	return ""
 }
 
 // RemoveCustomContainer removes the stopped container for a site's custom

--- a/internal/podman/custom_container.go
+++ b/internal/podman/custom_container.go
@@ -1,0 +1,102 @@
+package podman
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// CustomContainerName returns the Podman container name for a site's custom
+// container, e.g. "lerd-custom-nestapp".
+func CustomContainerName(siteName string) string {
+	return "lerd-custom-" + siteName
+}
+
+// CustomImageName returns the local image tag for a site's custom container,
+// e.g. "lerd-custom-nestapp:local".
+func CustomImageName(siteName string) string {
+	return CustomContainerName(siteName) + ":local"
+}
+
+// ResolveContainerfile returns the absolute path to the Containerfile for a
+// project. If cfg specifies a Containerfile it is resolved relative to
+// projectPath; otherwise the default "Containerfile.lerd" is used.
+func ResolveContainerfile(projectPath string, cfg *config.ContainerConfig) string {
+	name := "Containerfile.lerd"
+	if cfg != nil && cfg.Containerfile != "" {
+		name = cfg.Containerfile
+	}
+	return filepath.Join(projectPath, name)
+}
+
+// ResolveBuildContext returns the build context directory for a custom
+// container build. Defaults to the project root.
+func ResolveBuildContext(projectPath string, cfg *config.ContainerConfig) string {
+	if cfg != nil && cfg.BuildContext != "" && cfg.BuildContext != "." {
+		return filepath.Join(projectPath, cfg.BuildContext)
+	}
+	return projectPath
+}
+
+// HasContainerfile returns true when the project directory contains a
+// Containerfile.lerd (the default custom container definition).
+func HasContainerfile(projectPath string) bool {
+	_, err := os.Stat(filepath.Join(projectPath, "Containerfile.lerd"))
+	return err == nil
+}
+
+// BuildCustomImage builds the OCI image for a site's custom container from
+// the user's Containerfile. The image is tagged as lerd-custom-{siteName}:local.
+func BuildCustomImage(siteName, projectPath string, cfg *config.ContainerConfig) error {
+	containerfile := ResolveContainerfile(projectPath, cfg)
+	if _, err := os.Stat(containerfile); err != nil {
+		return fmt.Errorf("containerfile not found: %s", containerfile)
+	}
+
+	buildCtx := ResolveBuildContext(projectPath, cfg)
+	imageName := CustomImageName(siteName)
+
+	cmd := exec.Command(PodmanBin(), "build", "-t", imageName, "-f", containerfile, buildCtx)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("building custom image %s: %w", imageName, err)
+	}
+	return nil
+}
+
+// BuildCustomImageTo builds the custom image, writing progress to w.
+func BuildCustomImageTo(siteName, projectPath string, cfg *config.ContainerConfig, w interface{ Write([]byte) (int, error) }) error {
+	containerfile := ResolveContainerfile(projectPath, cfg)
+	if _, err := os.Stat(containerfile); err != nil {
+		return fmt.Errorf("containerfile not found: %s", containerfile)
+	}
+
+	buildCtx := ResolveBuildContext(projectPath, cfg)
+	imageName := CustomImageName(siteName)
+
+	cmd := exec.Command(PodmanBin(), "build", "-t", imageName, "-f", containerfile, buildCtx)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("building custom image %s: %w", imageName, err)
+	}
+	return nil
+}
+
+// RemoveCustomImage removes the local image for a site's custom container.
+func RemoveCustomImage(siteName string) error {
+	imageName := CustomImageName(siteName)
+	_ = exec.Command(PodmanBin(), "rmi", "-f", imageName).Run()
+	return nil
+}
+
+// RemoveCustomContainer removes the stopped container for a site's custom
+// container (force-remove to handle edge cases).
+func RemoveCustomContainer(siteName string) {
+	name := CustomContainerName(siteName)
+	_ = exec.Command(PodmanBin(), "rm", "-f", name).Run()
+}

--- a/internal/podman/custom_container_test.go
+++ b/internal/podman/custom_container_test.go
@@ -1,0 +1,86 @@
+package podman
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestCustomContainerName(t *testing.T) {
+	if got := CustomContainerName("nestapp"); got != "lerd-custom-nestapp" {
+		t.Errorf("CustomContainerName = %q, want lerd-custom-nestapp", got)
+	}
+}
+
+func TestCustomImageName(t *testing.T) {
+	if got := CustomImageName("nestapp"); got != "lerd-custom-nestapp:local" {
+		t.Errorf("CustomImageName = %q, want lerd-custom-nestapp:local", got)
+	}
+}
+
+func TestResolveContainerfile_Default(t *testing.T) {
+	got := ResolveContainerfile("/srv/myapp", nil)
+	want := "/srv/myapp/Containerfile.lerd"
+	if got != want {
+		t.Errorf("ResolveContainerfile(nil) = %q, want %q", got, want)
+	}
+}
+
+func TestResolveContainerfile_EmptyConfig(t *testing.T) {
+	cfg := &config.ContainerConfig{Port: 3000}
+	got := ResolveContainerfile("/srv/myapp", cfg)
+	want := "/srv/myapp/Containerfile.lerd"
+	if got != want {
+		t.Errorf("ResolveContainerfile(empty) = %q, want %q", got, want)
+	}
+}
+
+func TestResolveContainerfile_Custom(t *testing.T) {
+	cfg := &config.ContainerConfig{Port: 3000, Containerfile: "Containerfile"}
+	got := ResolveContainerfile("/srv/myapp", cfg)
+	want := "/srv/myapp/Containerfile"
+	if got != want {
+		t.Errorf("ResolveContainerfile(custom) = %q, want %q", got, want)
+	}
+}
+
+func TestResolveBuildContext_Default(t *testing.T) {
+	got := ResolveBuildContext("/srv/myapp", nil)
+	if got != "/srv/myapp" {
+		t.Errorf("ResolveBuildContext(nil) = %q, want /srv/myapp", got)
+	}
+}
+
+func TestResolveBuildContext_Dot(t *testing.T) {
+	cfg := &config.ContainerConfig{Port: 3000, BuildContext: "."}
+	got := ResolveBuildContext("/srv/myapp", cfg)
+	if got != "/srv/myapp" {
+		t.Errorf("ResolveBuildContext(.) = %q, want /srv/myapp", got)
+	}
+}
+
+func TestResolveBuildContext_Subdir(t *testing.T) {
+	cfg := &config.ContainerConfig{Port: 3000, BuildContext: "docker"}
+	got := ResolveBuildContext("/srv/myapp", cfg)
+	want := "/srv/myapp/docker"
+	if got != want {
+		t.Errorf("ResolveBuildContext(docker) = %q, want %q", got, want)
+	}
+}
+
+func TestHasContainerfile_Present(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "Containerfile.lerd"), []byte("FROM alpine\n"), 0644)
+	if !HasContainerfile(dir) {
+		t.Error("expected HasContainerfile = true")
+	}
+}
+
+func TestHasContainerfile_Absent(t *testing.T) {
+	dir := t.TempDir()
+	if HasContainerfile(dir) {
+		t.Error("expected HasContainerfile = false")
+	}
+}

--- a/internal/podman/custom_container_test.go
+++ b/internal/podman/custom_container_test.go
@@ -114,6 +114,56 @@ func TestContainerBaseImage_CustomPath(t *testing.T) {
 	}
 }
 
+func TestHashContainerfile(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "Containerfile.lerd"), []byte("FROM node:20-alpine\n"), 0644)
+	h1 := hashContainerfile(dir, nil)
+	if h1 == "" {
+		t.Fatal("expected non-empty hash")
+	}
+
+	// Same content, same hash.
+	h2 := hashContainerfile(dir, nil)
+	if h1 != h2 {
+		t.Errorf("same file should produce same hash: %q vs %q", h1, h2)
+	}
+
+	// Change content, different hash.
+	os.WriteFile(filepath.Join(dir, "Containerfile.lerd"), []byte("FROM python:3.12\n"), 0644)
+	h3 := hashContainerfile(dir, nil)
+	if h3 == h1 {
+		t.Error("different content should produce different hash")
+	}
+}
+
+func TestHashContainerfile_Missing(t *testing.T) {
+	dir := t.TempDir()
+	h := hashContainerfile(dir, nil)
+	if h != "" {
+		t.Errorf("missing file should return empty hash, got %q", h)
+	}
+}
+
+func TestStoreAndReadContainerfileHash(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "Containerfile.lerd"), []byte("FROM node:20\n"), 0644)
+
+	StoreContainerfileHash("mysite", dir, nil)
+	stored := readContainerfileHash("mysite")
+	expected := hashContainerfile(dir, nil)
+	if stored != expected {
+		t.Errorf("stored hash %q != expected %q", stored, expected)
+	}
+
+	RemoveContainerfileHash("mysite")
+	if got := readContainerfileHash("mysite"); got != "" {
+		t.Errorf("hash should be empty after removal, got %q", got)
+	}
+}
+
 func TestHasContainerfile_Absent(t *testing.T) {
 	dir := t.TempDir()
 	if HasContainerfile(dir) {

--- a/internal/podman/custom_container_test.go
+++ b/internal/podman/custom_container_test.go
@@ -78,6 +78,42 @@ func TestHasContainerfile_Present(t *testing.T) {
 	}
 }
 
+func TestContainerBaseImage(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "Containerfile.lerd"), []byte("FROM node:20-alpine\nWORKDIR /app\n"), 0644)
+	got := ContainerBaseImage(dir, nil)
+	if got != "node:20-alpine" {
+		t.Errorf("ContainerBaseImage = %q, want node:20-alpine", got)
+	}
+}
+
+func TestContainerBaseImage_StripsDockerIO(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "Containerfile.lerd"), []byte("FROM docker.io/library/python:3.12-slim\n"), 0644)
+	got := ContainerBaseImage(dir, nil)
+	if got != "python:3.12-slim" {
+		t.Errorf("ContainerBaseImage = %q, want python:3.12-slim", got)
+	}
+}
+
+func TestContainerBaseImage_Missing(t *testing.T) {
+	dir := t.TempDir()
+	got := ContainerBaseImage(dir, nil)
+	if got != "" {
+		t.Errorf("ContainerBaseImage = %q, want empty", got)
+	}
+}
+
+func TestContainerBaseImage_CustomPath(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM golang:1.23-alpine\n"), 0644)
+	cfg := &config.ContainerConfig{Port: 8080, Containerfile: "Dockerfile"}
+	got := ContainerBaseImage(dir, cfg)
+	if got != "golang:1.23-alpine" {
+		t.Errorf("ContainerBaseImage = %q, want golang:1.23-alpine", got)
+	}
+}
+
 func TestHasContainerfile_Absent(t *testing.T) {
 	dir := t.TempDir()
 	if HasContainerfile(dir) {

--- a/internal/podman/custom_quadlet.go
+++ b/internal/podman/custom_quadlet.go
@@ -1,0 +1,64 @@
+package podman
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// GenerateCustomContainerQuadlet builds a quadlet .container file for a
+// per-project custom container. The container joins the lerd network so it
+// can reach services (lerd-mysql, lerd-redis, etc.) and is reachable by
+// nginx via its container name.
+func GenerateCustomContainerQuadlet(siteName, projectPath string, port int) string {
+	containerName := CustomContainerName(siteName)
+	imageName := CustomImageName(siteName)
+
+	var b strings.Builder
+
+	b.WriteString("[Unit]\n")
+	fmt.Fprintf(&b, "Description=Lerd custom container (%s)\n", siteName)
+	b.WriteString("After=network.target\n")
+
+	b.WriteString("\n[Container]\n")
+	fmt.Fprintf(&b, "Image=%s\n", imageName)
+	fmt.Fprintf(&b, "ContainerName=%s\n", containerName)
+	b.WriteString("Network=lerd\n")
+	fmt.Fprintf(&b, "Volume=%s:/etc/hosts:ro,z\n", config.ContainerHostsFile())
+	fmt.Fprintf(&b, "Volume=%s:%s:rw\n", projectPath, projectPath)
+	fmt.Fprintf(&b, "PodmanArgs=--security-opt=label=disable --workdir=%s\n", projectPath)
+
+	b.WriteString("\n[Service]\n")
+	b.WriteString("Restart=always\n")
+
+	b.WriteString("\n[Install]\n")
+	b.WriteString("WantedBy=default.target\n")
+
+	return b.String()
+}
+
+// WriteCustomContainerQuadlet writes the quadlet for a custom container site.
+func WriteCustomContainerQuadlet(siteName, projectPath string, port int) error {
+	content := GenerateCustomContainerQuadlet(siteName, projectPath, port)
+	return WriteContainerUnitFn(CustomContainerName(siteName), content)
+}
+
+// RemoveCustomContainerQuadlet removes the unit file for a custom container.
+// On Linux this removes the systemd quadlet; on macOS the launchd plist.
+func RemoveCustomContainerQuadlet(siteName string) error {
+	name := CustomContainerName(siteName)
+	// Remove the quadlet file (Linux).
+	_ = RemoveQuadlet(name)
+	// Also remove the platform-specific unit (macOS plist) via the service
+	// manager, which is a no-op on Linux where the quadlet IS the unit.
+	if RemoveContainerUnitFn != nil {
+		return RemoveContainerUnitFn(name)
+	}
+	return nil
+}
+
+// RemoveContainerUnitFn removes the platform-specific container unit file.
+// On macOS this is set to services.Mgr.RemoveContainerUnit to remove the
+// launchd plist. Nil on Linux (quadlet removal is sufficient).
+var RemoveContainerUnitFn func(name string) error

--- a/internal/podman/custom_quadlet_test.go
+++ b/internal/podman/custom_quadlet_test.go
@@ -1,0 +1,49 @@
+package podman
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateCustomContainerQuadlet(t *testing.T) {
+	content := GenerateCustomContainerQuadlet("nestapp", "/home/user/projects/nestapp", 3000)
+
+	checks := []struct {
+		label    string
+		contains string
+	}{
+		{"image", "Image=lerd-custom-nestapp:local"},
+		{"container name", "ContainerName=lerd-custom-nestapp"},
+		{"network", "Network=lerd"},
+		{"project volume", "Volume=/home/user/projects/nestapp:/home/user/projects/nestapp:rw"},
+		{"hosts volume", "/etc/hosts:ro,z"},
+		{"security opt", "--security-opt=label=disable"},
+		{"workdir", "--workdir=/home/user/projects/nestapp"},
+		{"restart", "Restart=always"},
+		{"description", "Description=Lerd custom container (nestapp)"},
+		{"install", "WantedBy=default.target"},
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(content, check.contains) {
+			t.Errorf("%s: quadlet missing %q\n\nFull content:\n%s", check.label, check.contains, content)
+		}
+	}
+}
+
+func TestGenerateCustomContainerQuadlet_DifferentSite(t *testing.T) {
+	content := GenerateCustomContainerQuadlet("goapp", "/var/www/goapp", 8080)
+
+	if !strings.Contains(content, "Image=lerd-custom-goapp:local") {
+		t.Error("wrong image name")
+	}
+	if !strings.Contains(content, "ContainerName=lerd-custom-goapp") {
+		t.Error("wrong container name")
+	}
+	if !strings.Contains(content, "Volume=/var/www/goapp:/var/www/goapp:rw") {
+		t.Error("wrong project volume")
+	}
+	if !strings.Contains(content, "--workdir=/var/www/goapp") {
+		t.Error("wrong workdir")
+	}
+}

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -40,6 +40,7 @@ func init() {
 	podman.DaemonReloadFn = Mgr.DaemonReload
 	podman.SkipQuadletUpToDateCheck = true
 	podman.UnitLifecycle = Mgr
+	podman.RemoveContainerUnitFn = Mgr.RemoveContainerUnit
 	// Keep launchd plists in sync when WriteQuadletDiff updates a .container file.
 	podman.AfterQuadletWriteFn = func(name, content string) error {
 		return Mgr.WriteContainerUnit(name, content)

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -113,7 +113,8 @@ type EnrichedSite struct {
 	Services []string
 
 	// Custom container
-	ContainerPort int
+	ContainerPort  int
+	ContainerImage string
 
 	// LAN sharing
 	LANPort int
@@ -214,6 +215,7 @@ func Enrich(s config.Site, flags EnrichFlag) EnrichedSite {
 		AppURL:              s.AppURL,
 		LANPort:             s.LANPort,
 		ContainerPort:       s.ContainerPort,
+		ContainerImage:      containerImage(s),
 		FrameworkName:       s.Framework,
 		OriginalPHPVersion:  s.PHPVersion,
 		OriginalNodeVersion: s.NodeVersion,
@@ -293,6 +295,19 @@ func PersistVersionChanges(sites []EnrichedSite) error {
 		}
 	}
 	return nil
+}
+
+// containerImage returns the base image from the Containerfile for custom
+// container sites (e.g. "node:20-alpine"). Returns "" for PHP sites.
+func containerImage(s config.Site) string {
+	if s.ContainerPort == 0 {
+		return ""
+	}
+	proj, err := config.LoadProjectConfig(s.Path)
+	if err != nil {
+		return ""
+	}
+	return podman.ContainerBaseImage(s.Path, proj.Container)
 }
 
 func (e *EnrichedSite) enrichVersions(s config.Site, fw *config.Framework, hasFw bool) {

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -114,6 +114,7 @@ type EnrichedSite struct {
 
 	// Custom container
 	ContainerPort  int
+	ContainerSSL   bool
 	ContainerImage string
 
 	// LAN sharing
@@ -215,6 +216,7 @@ func Enrich(s config.Site, flags EnrichFlag) EnrichedSite {
 		AppURL:              s.AppURL,
 		LANPort:             s.LANPort,
 		ContainerPort:       s.ContainerPort,
+		ContainerSSL:        s.ContainerSSL,
 		ContainerImage:      containerImage(s),
 		FrameworkName:       s.Framework,
 		OriginalPHPVersion:  s.PHPVersion,

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -112,6 +112,9 @@ type EnrichedSite struct {
 	// Services
 	Services []string
 
+	// Custom container
+	ContainerPort int
+
 	// LAN sharing
 	LANPort int
 
@@ -210,6 +213,7 @@ func Enrich(s config.Site, flags EnrichFlag) EnrichedSite {
 		PublicDir:           s.PublicDir,
 		AppURL:              s.AppURL,
 		LANPort:             s.LANPort,
+		ContainerPort:       s.ContainerPort,
 		FrameworkName:       s.Framework,
 		OriginalPHPVersion:  s.PHPVersion,
 		OriginalNodeVersion: s.NodeVersion,
@@ -292,6 +296,11 @@ func PersistVersionChanges(sites []EnrichedSite) error {
 }
 
 func (e *EnrichedSite) enrichVersions(s config.Site, fw *config.Framework, hasFw bool) {
+	// Custom container sites don't use PHP/Node version detection.
+	if s.IsCustomContainer() {
+		return
+	}
+
 	phpMin, phpMax := "", ""
 	if hasFw {
 		phpMin, phpMax = fw.PHP.Min, fw.PHP.Max
@@ -314,6 +323,10 @@ func (e *EnrichedSite) enrichVersions(s config.Site, fw *config.Framework, hasFw
 }
 
 func (e *EnrichedSite) enrichFPM() {
+	if e.ContainerPort > 0 {
+		e.FPMRunning, _ = containerRunningFn("lerd-custom-" + e.Name)
+		return
+	}
 	if e.PHPVersion != "" {
 		short := strings.ReplaceAll(e.PHPVersion, ".", "")
 		e.FPMRunning, _ = containerRunningFn("lerd-php" + short + "-fpm")
@@ -329,6 +342,16 @@ func (e *EnrichedSite) enrichStripe() {
 }
 
 func (e *EnrichedSite) enrichWorkers(fw *config.Framework, hasFw bool) {
+	// Custom container sites without a framework get their workers from
+	// .lerd.yaml custom_workers. Build a synthetic framework so the rest
+	// of the function works uniformly.
+	if !hasFw && e.ContainerPort > 0 {
+		if proj, err := config.LoadProjectConfig(e.Path); err == nil && len(proj.CustomWorkers) > 0 {
+			fw = &config.Framework{Workers: proj.CustomWorkers}
+			hasFw = true
+		}
+	}
+
 	if !hasFw || fw.Workers == nil {
 		return
 	}

--- a/internal/siteinfo/siteinfo_test.go
+++ b/internal/siteinfo/siteinfo_test.go
@@ -27,6 +27,150 @@ func stubPodman(t *testing.T) {
 	})
 }
 
+// ── enrichVersions: custom container skipping ──────────────────────────────
+
+func TestEnrichVersions_CustomContainerSkipped(t *testing.T) {
+	stubPodman(t)
+
+	t.Run("custom container site skips version detection", func(t *testing.T) {
+		e := &EnrichedSite{Name: "nestapp", Path: t.TempDir(), ContainerPort: 3000}
+		s := config.Site{Name: "nestapp", Path: e.Path, ContainerPort: 3000}
+		e.enrichVersions(s, nil, false)
+
+		if e.PHPVersion != "" {
+			t.Errorf("PHPVersion = %q, want empty for custom container", e.PHPVersion)
+		}
+		if e.NodeVersion != "" {
+			t.Errorf("NodeVersion = %q, want empty for custom container", e.NodeVersion)
+		}
+		if e.PHPVersionChanged {
+			t.Error("PHPVersionChanged should be false for custom container")
+		}
+		if e.NodeVersionChanged {
+			t.Error("NodeVersionChanged should be false for custom container")
+		}
+	})
+
+	t.Run("custom container preserves pre-set versions", func(t *testing.T) {
+		e := &EnrichedSite{
+			Name:          "nestapp",
+			Path:          t.TempDir(),
+			ContainerPort: 3000,
+			PHPVersion:    "8.4",
+			NodeVersion:   "22",
+		}
+		s := config.Site{Name: "nestapp", Path: e.Path, ContainerPort: 3000, PHPVersion: "8.4", NodeVersion: "22"}
+		e.enrichVersions(s, nil, false)
+
+		if e.PHPVersion != "8.4" {
+			t.Errorf("PHPVersion = %q, want 8.4 (should be untouched)", e.PHPVersion)
+		}
+		if e.NodeVersion != "22" {
+			t.Errorf("NodeVersion = %q, want 22 (should be untouched)", e.NodeVersion)
+		}
+		if e.PHPVersionChanged {
+			t.Error("PHPVersionChanged should be false")
+		}
+	})
+
+	t.Run("non-container site runs version detection", func(t *testing.T) {
+		dir := t.TempDir()
+		e := &EnrichedSite{Name: "phpapp", Path: dir, PHPVersion: "8.3"}
+		s := config.Site{Name: "phpapp", Path: dir, PHPVersion: "8.3"}
+		e.enrichVersions(s, nil, false)
+		// The function ran detection (did not return early). Detection may
+		// change the version based on what PHP versions are installed, so
+		// we only assert that PHPVersion is non-empty, proving the early
+		// return for custom containers was NOT taken.
+		if e.PHPVersion == "" {
+			t.Error("PHPVersion should not be empty for a non-container site")
+		}
+	})
+}
+
+// ── enrichWorkers: custom container workers from .lerd.yaml ────────────────
+
+func TestEnrichWorkers_CustomContainerFromLerdYAML(t *testing.T) {
+	t.Run("custom_workers loaded for container site without framework", func(t *testing.T) {
+		origUnit := unitStatusFn
+		unitStatusFn = func(name string) (string, error) {
+			if name == "lerd-queue-mycontainer" {
+				return "active", nil
+			}
+			return "", nil
+		}
+		defer func() { unitStatusFn = origUnit }()
+
+		dir := t.TempDir()
+		lerdYAML := `custom_workers:
+  queue:
+    command: "node worker.js"
+  emailer:
+    command: "node emailer.js"
+    label: "Email Sender"
+`
+		os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte(lerdYAML), 0644)
+
+		e := &EnrichedSite{Name: "mycontainer", Path: dir, ContainerPort: 3000}
+		e.enrichWorkers(nil, false)
+
+		if !e.HasQueueWorker {
+			t.Error("expected HasQueueWorker = true from custom_workers")
+		}
+		if !e.QueueRunning {
+			t.Error("expected QueueRunning = true")
+		}
+
+		// "emailer" is a non-standard worker, should appear in FrameworkWorkers
+		if len(e.FrameworkWorkers) != 1 {
+			t.Fatalf("expected 1 framework worker, got %d", len(e.FrameworkWorkers))
+		}
+		if e.FrameworkWorkers[0].Name != "emailer" {
+			t.Errorf("FrameworkWorkers[0].Name = %q, want emailer", e.FrameworkWorkers[0].Name)
+		}
+		if e.FrameworkWorkers[0].Label != "Email Sender" {
+			t.Errorf("FrameworkWorkers[0].Label = %q, want 'Email Sender'", e.FrameworkWorkers[0].Label)
+		}
+	})
+
+	t.Run("no custom_workers for container site without .lerd.yaml", func(t *testing.T) {
+		origUnit := unitStatusFn
+		unitStatusFn = func(string) (string, error) { return "", nil }
+		defer func() { unitStatusFn = origUnit }()
+
+		e := &EnrichedSite{Name: "bare", Path: t.TempDir(), ContainerPort: 3000}
+		e.enrichWorkers(nil, false)
+
+		if e.HasQueueWorker {
+			t.Error("expected no queue worker without .lerd.yaml")
+		}
+		if len(e.FrameworkWorkers) != 0 {
+			t.Errorf("expected no framework workers, got %d", len(e.FrameworkWorkers))
+		}
+	})
+
+	t.Run("non-container site without framework gets no workers", func(t *testing.T) {
+		origUnit := unitStatusFn
+		unitStatusFn = func(string) (string, error) { return "", nil }
+		defer func() { unitStatusFn = origUnit }()
+
+		dir := t.TempDir()
+		lerdYAML := `custom_workers:
+  queue:
+    command: "php artisan queue:work"
+`
+		os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte(lerdYAML), 0644)
+
+		e := &EnrichedSite{Name: "phpapp", Path: dir}
+		e.enrichWorkers(nil, false)
+
+		// ContainerPort is 0, so the custom_workers path is not taken
+		if e.HasQueueWorker {
+			t.Error("non-container site without framework should not load custom_workers")
+		}
+	})
+}
+
 // ── DetectFavicon ───────────────────────────────────────────────────────────
 
 func TestDetectFavicon(t *testing.T) {
@@ -657,6 +801,39 @@ func TestEnrichFPM(t *testing.T) {
 		e.enrichFPM()
 		if !e.FPMRunning {
 			t.Error("expected FPMRunning = true")
+		}
+	})
+
+	t.Run("custom container checks lerd-custom container", func(t *testing.T) {
+		var checkedName string
+		origContainer := containerRunningFn
+		containerRunningFn = func(name string) (bool, error) {
+			checkedName = name
+			return true, nil
+		}
+		defer func() { containerRunningFn = origContainer }()
+
+		e := &EnrichedSite{Name: "nestapp", ContainerPort: 3000}
+		e.enrichFPM()
+		if checkedName != "lerd-custom-nestapp" {
+			t.Errorf("checked container %q, want lerd-custom-nestapp", checkedName)
+		}
+		if !e.FPMRunning {
+			t.Error("expected FPMRunning = true for running custom container")
+		}
+	})
+
+	t.Run("custom container not running", func(t *testing.T) {
+		origContainer := containerRunningFn
+		containerRunningFn = func(name string) (bool, error) {
+			return false, nil
+		}
+		defer func() { containerRunningFn = origContainer }()
+
+		e := &EnrichedSite{Name: "nestapp", ContainerPort: 3000}
+		e.enrichFPM()
+		if e.FPMRunning {
+			t.Error("expected FPMRunning = false for stopped custom container")
 		}
 	})
 }

--- a/internal/siteops/custom_container_test.go
+++ b/internal/siteops/custom_container_test.go
@@ -347,7 +347,7 @@ func TestCustomContainer_NestJS_IsNotPHPSite(t *testing.T) {
 // noopLifecycle is a stub for podman.UnitLifecycle that does nothing.
 type noopLifecycle struct{}
 
-func (n *noopLifecycle) Start(name string) error              { return nil }
-func (n *noopLifecycle) Stop(name string) error               { return nil }
-func (n *noopLifecycle) Restart(name string) error            { return nil }
+func (n *noopLifecycle) Start(name string) error                { return nil }
+func (n *noopLifecycle) Stop(name string) error                 { return nil }
+func (n *noopLifecycle) Restart(name string) error              { return nil }
 func (n *noopLifecycle) UnitStatus(name string) (string, error) { return "inactive", nil }

--- a/internal/siteops/custom_container_test.go
+++ b/internal/siteops/custom_container_test.go
@@ -1,0 +1,353 @@
+package siteops
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/nginx"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// setupCustomContainerEnv creates a temp environment with XDG overrides and
+// stubs for podman functions that would require a running system.
+func setupCustomContainerEnv(t *testing.T) (projectDir, confD string) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	// Stub out functions that call podman/systemd.
+	origWriteUnit := podman.WriteContainerUnitFn
+	origDaemonReload := podman.DaemonReloadFn
+	origAfterUnitChange := podman.AfterUnitChange
+	t.Cleanup(func() {
+		podman.WriteContainerUnitFn = origWriteUnit
+		podman.DaemonReloadFn = origDaemonReload
+		podman.AfterUnitChange = origAfterUnitChange
+	})
+
+	// Write quadlets to a temp dir instead of the real quadlet dir.
+	quadletDir := filepath.Join(tmp, "config", "containers", "systemd")
+	os.MkdirAll(quadletDir, 0755)
+	podman.WriteContainerUnitFn = func(name, content string) error {
+		return os.WriteFile(filepath.Join(quadletDir, name+".container"), []byte(content), 0644)
+	}
+	podman.DaemonReloadFn = func() error { return nil }
+	podman.AfterUnitChange = nil
+
+	// Create the NestJS project directory with Containerfile.lerd and .lerd.yaml.
+	projectDir = filepath.Join(tmp, "nestjs-app")
+	os.MkdirAll(projectDir, 0755)
+
+	os.WriteFile(filepath.Join(projectDir, "Containerfile.lerd"), []byte(`FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+CMD ["npm", "run", "start:dev"]
+`), 0644)
+
+	os.WriteFile(filepath.Join(projectDir, ".lerd.yaml"), []byte(`domains:
+  - nestapp
+container:
+  port: 3000
+services:
+  - redis
+custom_workers:
+  dev-server:
+    label: Dev Server
+    command: npm run start:dev
+    restart: always
+`), 0644)
+
+	os.WriteFile(filepath.Join(projectDir, "package.json"), []byte(`{
+  "name": "nestjs-app",
+  "version": "1.0.0",
+  "scripts": {
+    "start:dev": "nest start --watch"
+  }
+}
+`), 0644)
+
+	confD = filepath.Join(tmp, "lerd", "nginx", "conf.d")
+	return projectDir, confD
+}
+
+func TestCustomContainer_NestJS_ProjectConfigParsing(t *testing.T) {
+	projectDir, _ := setupCustomContainerEnv(t)
+
+	proj, err := config.LoadProjectConfig(projectDir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig: %v", err)
+	}
+
+	if proj.Container == nil {
+		t.Fatal("expected container config, got nil")
+	}
+	if proj.Container.Port != 3000 {
+		t.Errorf("Container.Port = %d, want 3000", proj.Container.Port)
+	}
+	if len(proj.Domains) != 1 || proj.Domains[0] != "nestapp" {
+		t.Errorf("Domains = %v, want [nestapp]", proj.Domains)
+	}
+	if len(proj.CustomWorkers) != 1 {
+		t.Fatalf("CustomWorkers count = %d, want 1", len(proj.CustomWorkers))
+	}
+	w, ok := proj.CustomWorkers["dev-server"]
+	if !ok {
+		t.Fatal("expected custom worker dev-server")
+	}
+	if w.Command != "npm run start:dev" {
+		t.Errorf("worker command = %q", w.Command)
+	}
+}
+
+func TestCustomContainer_NestJS_SiteRegistration(t *testing.T) {
+	projectDir, _ := setupCustomContainerEnv(t)
+
+	proj, _ := config.LoadProjectConfig(projectDir)
+
+	site := config.Site{
+		Name:          "nestjs-app",
+		Domains:       []string{"nestapp.test"},
+		Path:          projectDir,
+		ContainerPort: proj.Container.Port,
+	}
+
+	if err := config.AddSite(site); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	// Verify the site is registered and marked as custom container.
+	got, err := config.FindSite("nestjs-app")
+	if err != nil {
+		t.Fatalf("FindSite: %v", err)
+	}
+	if !got.IsCustomContainer() {
+		t.Error("expected IsCustomContainer() = true")
+	}
+	if got.ContainerPort != 3000 {
+		t.Errorf("ContainerPort = %d, want 3000", got.ContainerPort)
+	}
+	if got.PHPVersion != "" {
+		t.Errorf("PHPVersion should be empty for custom container site, got %q", got.PHPVersion)
+	}
+}
+
+func TestCustomContainer_NestJS_ContainerfileDetection(t *testing.T) {
+	projectDir, _ := setupCustomContainerEnv(t)
+
+	if !podman.HasContainerfile(projectDir) {
+		t.Error("expected HasContainerfile = true for NestJS project")
+	}
+
+	proj, _ := config.LoadProjectConfig(projectDir)
+	cf := podman.ResolveContainerfile(projectDir, proj.Container)
+	if !strings.HasSuffix(cf, "Containerfile.lerd") {
+		t.Errorf("ResolveContainerfile = %q, expected Containerfile.lerd suffix", cf)
+	}
+	if _, err := os.Stat(cf); err != nil {
+		t.Errorf("Containerfile should exist at %s", cf)
+	}
+}
+
+func TestCustomContainer_NestJS_NamingConventions(t *testing.T) {
+	if got := podman.CustomContainerName("nestjs-app"); got != "lerd-custom-nestjs-app" {
+		t.Errorf("CustomContainerName = %q", got)
+	}
+	if got := podman.CustomImageName("nestjs-app"); got != "lerd-custom-nestjs-app:local" {
+		t.Errorf("CustomImageName = %q", got)
+	}
+}
+
+func TestCustomContainer_NestJS_QuadletGeneration(t *testing.T) {
+	projectDir, _ := setupCustomContainerEnv(t)
+
+	content := podman.GenerateCustomContainerQuadlet("nestjs-app", projectDir, 3000)
+
+	checks := []struct {
+		label, substr string
+	}{
+		{"image", "Image=lerd-custom-nestjs-app:local"},
+		{"container name", "ContainerName=lerd-custom-nestjs-app"},
+		{"network", "Network=lerd"},
+		{"project mount", "Volume=" + projectDir + ":" + projectDir + ":rw"},
+		{"hosts mount", "/etc/hosts:ro,z"},
+		{"description", "Lerd custom container (nestjs-app)"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(content, c.substr) {
+			t.Errorf("%s: missing %q in quadlet", c.label, c.substr)
+		}
+	}
+
+	// Must NOT contain PHP-specific things.
+	if strings.Contains(content, "xdebug") || strings.Contains(content, "php-fpm") {
+		t.Error("custom container quadlet should not reference PHP/xdebug")
+	}
+}
+
+func TestCustomContainer_NestJS_VhostGeneration_HTTP(t *testing.T) {
+	_, confD := setupCustomContainerEnv(t)
+
+	site := config.Site{
+		Name:          "nestjs-app",
+		Domains:       []string{"nestapp.test"},
+		ContainerPort: 3000,
+	}
+
+	if err := nginx.GenerateCustomVhost(site); err != nil {
+		t.Fatalf("GenerateCustomVhost: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(confD, "nestapp.test.conf"))
+	if err != nil {
+		t.Fatalf("reading vhost: %v", err)
+	}
+	s := string(content)
+
+	if !strings.Contains(s, "server_name nestapp.test *.nestapp.test") {
+		t.Error("missing server_name with wildcard")
+	}
+	if !strings.Contains(s, "proxy_pass http://$backend:3000") {
+		t.Error("missing proxy_pass to port 3000")
+	}
+	if !strings.Contains(s, `"lerd-custom-nestjs-app"`) {
+		t.Error("missing custom container name in proxy backend")
+	}
+	if strings.Contains(s, "fastcgi_pass") {
+		t.Error("HTTP custom vhost should not have fastcgi_pass")
+	}
+	if strings.Contains(s, "index.php") {
+		t.Error("custom vhost should not reference PHP")
+	}
+	// WebSocket support
+	if !strings.Contains(s, "proxy_set_header Upgrade") {
+		t.Error("missing WebSocket Upgrade header")
+	}
+}
+
+func TestCustomContainer_NestJS_VhostGeneration_HTTPS(t *testing.T) {
+	_, confD := setupCustomContainerEnv(t)
+
+	site := config.Site{
+		Name:          "nestjs-app",
+		Domains:       []string{"nestapp.test"},
+		ContainerPort: 3000,
+	}
+
+	if err := nginx.GenerateCustomSSLVhost(site); err != nil {
+		t.Fatalf("GenerateCustomSSLVhost: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(confD, "nestapp.test-ssl.conf"))
+	if err != nil {
+		t.Fatalf("reading SSL vhost: %v", err)
+	}
+	s := string(content)
+
+	if !strings.Contains(s, "listen 443 ssl") {
+		t.Error("missing SSL listener")
+	}
+	if !strings.Contains(s, "ssl_certificate /etc/nginx/certs/nestapp.test.crt") {
+		t.Error("missing ssl_certificate")
+	}
+	if !strings.Contains(s, "return 302 https://") {
+		t.Error("missing HTTP-to-HTTPS redirect")
+	}
+	if !strings.Contains(s, "proxy_pass http://$backend:3000") {
+		t.Error("missing proxy_pass in SSL vhost")
+	}
+	if strings.Contains(s, "fastcgi_pass") {
+		t.Error("SSL custom vhost should not have fastcgi_pass")
+	}
+}
+
+func TestCustomContainer_NestJS_UnlinkCleanup(t *testing.T) {
+	projectDir, confD := setupCustomContainerEnv(t)
+
+	site := config.Site{
+		Name:          "nestjs-app",
+		Domains:       []string{"nestapp.test"},
+		Path:          projectDir,
+		ContainerPort: 3000,
+	}
+
+	// Register the site.
+	if err := config.AddSite(site); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write the vhost so RemoveVhost has something to delete.
+	if err := nginx.GenerateCustomVhost(site); err != nil {
+		t.Fatal(err)
+	}
+	vhostPath := filepath.Join(confD, "nestapp.test.conf")
+	if _, err := os.Stat(vhostPath); err != nil {
+		t.Fatal("vhost should exist before unlink")
+	}
+
+	// Write the quadlet so removal can clean it up.
+	if err := podman.WriteCustomContainerQuadlet("nestjs-app", projectDir, 3000); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stub out functions called during unlink that need podman.
+	origStopUnit := podman.UnitLifecycle
+	podman.UnitLifecycle = &noopLifecycle{}
+	t.Cleanup(func() { podman.UnitLifecycle = origStopUnit })
+
+	// We can't call the full UnlinkSiteCore because it calls nginx.Reload,
+	// podman.WriteContainerHosts, etc. But we can verify the pieces.
+
+	// Verify the site is removed from registry.
+	if err := config.RemoveSite("nestjs-app"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := config.FindSite("nestjs-app")
+	if err == nil {
+		t.Error("site should not be found after removal")
+	}
+
+	// Verify vhost removal.
+	if err := nginx.RemoveVhost("nestapp.test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(vhostPath); !os.IsNotExist(err) {
+		t.Error("vhost should be removed after unlink")
+	}
+
+	// Verify quadlet removal.
+	if err := podman.RemoveCustomContainerQuadlet("nestjs-app"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCustomContainer_NestJS_IsNotPHPSite(t *testing.T) {
+	site := config.Site{
+		Name:          "nestjs-app",
+		Domains:       []string{"nestapp.test"},
+		ContainerPort: 3000,
+	}
+
+	if !site.IsCustomContainer() {
+		t.Error("NestJS site should be a custom container")
+	}
+	if site.PHPVersion != "" {
+		t.Error("NestJS site should not have a PHP version")
+	}
+	if site.Framework != "" {
+		t.Error("NestJS site should not have a framework")
+	}
+}
+
+// noopLifecycle is a stub for podman.UnitLifecycle that does nothing.
+type noopLifecycle struct{}
+
+func (n *noopLifecycle) Start(name string) error              { return nil }
+func (n *noopLifecycle) Stop(name string) error               { return nil }
+func (n *noopLifecycle) Restart(name string) error            { return nil }
+func (n *noopLifecycle) UnitStatus(name string) (string, error) { return "inactive", nil }

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -155,8 +155,10 @@ func FinishLink(site config.Site, phpVersion string) error {
 // site: build the image, write a dedicated quadlet, generate a proxy vhost,
 // update container hosts, and reload nginx.
 func FinishCustomLink(site config.Site, containerCfg *config.ContainerConfig) error {
-	if err := podman.BuildCustomImage(site.Name, site.Path, containerCfg); err != nil {
-		return fmt.Errorf("building custom image: %w", err)
+	if !podman.CustomImageExists(site.Name) {
+		if err := podman.BuildCustomImage(site.Name, site.Path, containerCfg); err != nil {
+			return fmt.Errorf("building custom image: %w", err)
+		}
 	}
 
 	// Pre-create the shared hosts file before writing the unit so that the

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -159,6 +159,12 @@ func FinishCustomLink(site config.Site, containerCfg *config.ContainerConfig) er
 		return fmt.Errorf("building custom image: %w", err)
 	}
 
+	// Pre-create the shared hosts file before writing the unit so that the
+	// macOS WriteContainerUnit helper (which calls os.MkdirAll on every volume
+	// source path) does not create a directory at the hosts-file path if the
+	// file doesn't exist yet.  WriteFPMQuadlet does the same pre-creation step.
+	_ = podman.WriteContainerHosts()
+
 	if err := podman.WriteCustomContainerQuadlet(site.Name, site.Path, site.ContainerPort); err != nil {
 		return fmt.Errorf("writing custom quadlet: %w", err)
 	}

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -155,10 +155,13 @@ func FinishLink(site config.Site, phpVersion string) error {
 // site: build the image, write a dedicated quadlet, generate a proxy vhost,
 // update container hosts, and reload nginx.
 func FinishCustomLink(site config.Site, containerCfg *config.ContainerConfig) error {
-	if !podman.CustomImageExists(site.Name) {
+	if podman.CustomImageUpToDate(site.Name, site.Path, containerCfg) {
+		fmt.Println("Container image up to date, skipping build.")
+	} else {
 		if err := podman.BuildCustomImage(site.Name, site.Path, containerCfg); err != nil {
 			return fmt.Errorf("building custom image: %w", err)
 		}
+		podman.StoreContainerfileHash(site.Name, site.Path, containerCfg)
 	}
 
 	// Pre-create the shared hosts file before writing the unit so that the

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -150,3 +150,44 @@ func FinishLink(site config.Site, phpVersion string) error {
 
 	return nil
 }
+
+// FinishCustomLink performs the post-registration steps for a custom container
+// site: build the image, write a dedicated quadlet, generate a proxy vhost,
+// update container hosts, and reload nginx.
+func FinishCustomLink(site config.Site, containerCfg *config.ContainerConfig) error {
+	if err := podman.BuildCustomImage(site.Name, site.Path, containerCfg); err != nil {
+		return fmt.Errorf("building custom image: %w", err)
+	}
+
+	if err := podman.WriteCustomContainerQuadlet(site.Name, site.Path, site.ContainerPort); err != nil {
+		return fmt.Errorf("writing custom quadlet: %w", err)
+	}
+	_ = podman.DaemonReloadFn()
+
+	// Start the custom container so the site is immediately reachable.
+	if err := podman.StartUnit(podman.CustomContainerName(site.Name)); err != nil {
+		fmt.Printf("[WARN] starting custom container: %v\n", err)
+	}
+
+	if site.Secured {
+		if err := certs.SecureSite(site); err != nil {
+			return fmt.Errorf("securing site: %w", err)
+		}
+	} else {
+		if err := nginx.GenerateCustomVhost(site); err != nil {
+			return fmt.Errorf("generating custom vhost: %w", err)
+		}
+	}
+
+	_ = podman.WriteContainerHosts()
+
+	if err := nginx.Reload(); err != nil {
+		return fmt.Errorf("nginx reload: %w", err)
+	}
+
+	if podman.AfterUnitChange != nil {
+		podman.AfterUnitChange("site:" + site.Name)
+	}
+
+	return nil
+}

--- a/internal/siteops/unlink.go
+++ b/internal/siteops/unlink.go
@@ -40,6 +40,14 @@ func UnlinkSiteCore(site *config.Site, parkedDirs []string) error {
 		os.Remove(filepath.Join(certsDir, domain+".key")) //nolint:errcheck
 	}
 
+	// Clean up the per-project custom container if this site uses one.
+	if site.IsCustomContainer() {
+		_ = podman.StopUnit(podman.CustomContainerName(site.Name))
+		podman.RemoveCustomContainer(site.Name)
+		_ = podman.RemoveCustomContainerQuadlet(site.Name)
+		_ = podman.RemoveCustomImage(site.Name)
+	}
+
 	if IsParkedSite(site.Path, parkedDirs) {
 		_ = config.IgnoreSite(site.Name)
 	} else {

--- a/internal/siteops/unlink.go
+++ b/internal/siteops/unlink.go
@@ -41,11 +41,12 @@ func UnlinkSiteCore(site *config.Site, parkedDirs []string) error {
 	}
 
 	// Clean up the per-project custom container if this site uses one.
+	// The image is kept so relinking is fast; use `lerd rebuild` to
+	// force a fresh build.
 	if site.IsCustomContainer() {
 		_ = podman.StopUnit(podman.CustomContainerName(site.Name))
 		podman.RemoveCustomContainer(site.Name)
 		_ = podman.RemoveCustomContainerQuadlet(site.Name)
-		_ = podman.RemoveCustomImage(site.Name)
 	}
 
 	if IsParkedSite(site.Path, parkedDirs) {

--- a/internal/siteops/vhost.go
+++ b/internal/siteops/vhost.go
@@ -20,7 +20,23 @@ func RegenerateSiteVhost(site *config.Site, oldPrimary string) error {
 		_ = nginx.RemoveVhost(oldPrimary)
 	}
 
-	if site.Secured {
+	if site.IsCustomContainer() {
+		if site.Secured {
+			if err := nginx.GenerateCustomSSLVhost(*site); err != nil {
+				return fmt.Errorf("generating custom SSL vhost: %w", err)
+			}
+			sslConf := filepath.Join(config.NginxConfD(), newPrimary+"-ssl.conf")
+			mainConf := filepath.Join(config.NginxConfD(), newPrimary+".conf")
+			_ = os.Remove(mainConf)
+			if err := os.Rename(sslConf, mainConf); err != nil {
+				return fmt.Errorf("installing custom SSL vhost: %w", err)
+			}
+		} else {
+			if err := nginx.GenerateCustomVhost(*site); err != nil {
+				return fmt.Errorf("generating custom vhost: %w", err)
+			}
+		}
+	} else if site.Secured {
 		if err := nginx.GenerateSSLVhost(*site, site.PHPVersion); err != nil {
 			return fmt.Errorf("generating SSL vhost: %w", err)
 		}

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -175,10 +175,13 @@
             class="w-full flex items-center gap-2 px-3 py-2.5 text-left transition-colors border-b border-gray-50 dark:border-lerd-border/50 last:border-0"
             :class="selectedSiteDomain===site.domain ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
             <span class="relative shrink-0 w-4 h-4 flex items-center justify-center">
-              <template x-if="site.has_favicon">
+              <template x-if="site.custom_container">
+                <svg class="w-4 h-4" :class="site.fpm_running ? 'text-violet-500' : 'text-gray-300 dark:text-gray-600'" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
+              </template>
+              <template x-if="!site.custom_container && site.has_favicon">
                 <img :src="apiBase + '/api/sites/' + site.domain + '/favicon'" class="w-4 h-4 rounded-sm object-contain" loading="lazy" @error="site.has_favicon = false">
               </template>
-              <template x-if="!site.has_favicon">
+              <template x-if="!site.custom_container && !site.has_favicon">
                 <span class="w-2 h-2 rounded-full" :class="site.fpm_running ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
               </template>
             </span>
@@ -374,7 +377,12 @@
             <button @click="selectSite(site)"
               class="w-full flex items-center gap-2.5 px-4 py-3.5 text-left transition-colors border-b border-gray-100 dark:border-lerd-border"
               :class="selectedSiteDomain===site.domain ? 'bg-lerd-red/5' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
-              <span class="w-2 h-2 rounded-full shrink-0" :class="site.fpm_running ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+              <template x-if="site.custom_container">
+                <svg class="w-4 h-4 shrink-0" :class="site.fpm_running ? 'text-violet-500' : 'text-gray-300 dark:text-gray-600'" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
+              </template>
+              <template x-if="!site.custom_container">
+                <span class="w-2 h-2 rounded-full shrink-0" :class="site.fpm_running ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
+              </template>
               <span class="flex-1 text-sm font-medium truncate" :class="selectedSiteDomain===site.domain ? 'text-lerd-red' : ''" x-text="site.domain"></span>
               <span x-show="site.queue_running || site.horizon_running" class="w-2 h-2 rounded-full shrink-0 bg-amber-400"></span>
               <span x-show="site.stripe_running" class="w-2 h-2 rounded-full shrink-0 bg-violet-400"></span>
@@ -607,6 +615,15 @@
                           <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>stopped
                         </span>
                       </template>
+                      <template x-if="!selectedSite.paused && !selectedSite.restartLoading">
+                        <button @click="restartSite(selectedSite)" title="Restart container"
+                          class="text-gray-400 hover:text-lerd-red transition-colors">
+                          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
+                        </button>
+                      </template>
+                      <template x-if="selectedSite.restartLoading">
+                        <svg class="animate-spin w-3.5 h-3.5 text-gray-400" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                      </template>
                       <template x-if="selectedSite.framework_label">
                         <span class="inline-flex items-center text-xs font-medium text-lerd-red bg-red-50 dark:bg-red-900/20 px-2 py-0.5 rounded-full" x-text="selectedSite.framework_label"></span>
                       </template>
@@ -686,10 +703,13 @@
 
                 <!-- Version selects + toggles row -->
                 <div class="flex items-center gap-4 overflow-x-auto">
-                  <template x-if="phpVersions.length === 0">
+                  <template x-if="selectedSite.custom_container">
+                    <span class="text-xs text-violet-500 dark:text-violet-400 border border-violet-200 dark:border-violet-500/30 rounded px-2 py-1" x-text="'Container :' + selectedSite.container_port"></span>
+                  </template>
+                  <template x-if="!selectedSite.custom_container && phpVersions.length === 0">
                     <span class="text-xs text-gray-400 border border-gray-200 dark:border-lerd-border rounded px-2 py-1 opacity-50">PHP ...</span>
                   </template>
-                  <template x-if="phpVersions.length > 0">
+                  <template x-if="!selectedSite.custom_container && phpVersions.length > 0">
                     <select
                       x-model="selectedSite.php_version"
                       @change="setSiteVersion(selectedSite, 'php', selectedSite.php_version)"
@@ -880,7 +900,7 @@
                   <template x-if="selectedSite && selectedSite.has_app_logs">
                     <button @click="setSiteLogsTab('app')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='app' ? 'border-orange-500 text-orange-600 dark:text-orange-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'">App Logs</button>
                   </template>
-                  <button @click="setSiteLogsTab('fpm')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='fpm' ? 'border-lerd-red text-lerd-red' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'">PHP-FPM</button>
+                  <button @click="setSiteLogsTab('fpm')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='fpm' ? 'border-lerd-red text-lerd-red' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'" x-text="selectedSite.custom_container ? 'Container' : 'PHP-FPM'"></button>
                   <template x-if="selectedSite && (selectedSite.queue_running || selectedSite.queue_failing)">
                     <button @click="setSiteLogsTab('queue')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='queue' ? 'border-amber-500 text-amber-600 dark:text-amber-400' : selectedSite.queue_failing ? 'border-transparent text-red-500' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'" x-text="selectedSite.queue_failing ? 'Queue !' : 'Queue'"></button>
                   </template>
@@ -2695,6 +2715,8 @@ function lerdApp() {
           e.conflicting_domains = s.conflicting_domains;
           e.php_version = s.php_version;
           e.node_version = s.node_version;
+          e.custom_container = s.custom_container;
+          e.container_port = s.container_port;
           e.tls = s.tls;
           e.fpm_running = s.fpm_running;
           e.queue_running = s.queue_running;
@@ -3712,6 +3734,21 @@ function lerdApp() {
       window.open(url, '_blank', 'noopener');
     },
 
+    async restartSite(site) {
+      site.restartLoading = true;
+      try {
+        const res = await fetch(`/api/sites/${site.domain}/restart`, { method: 'POST' });
+        const data = await res.json();
+        if (!data.ok) {
+          alert('Restart failed: ' + (data.error || 'Unknown error'));
+        }
+      } catch (e) {
+        alert('Restart failed: ' + (e.message || 'Request failed'));
+      } finally {
+        site.restartLoading = false;
+      }
+    },
+
     async toggleTLS(site) {
       site.tlsLoading = true;
       site.tlsError = '';
@@ -3978,6 +4015,7 @@ function lerdApp() {
     },
 
     fpmContainer(site) {
+      if (site.custom_container) return 'lerd-custom-' + site.name;
       if (!site.php_version) return '';
       return 'lerd-php' + site.php_version.replace('.', '') + '-fpm';
     },

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -704,7 +704,7 @@
                 <!-- Version selects + toggles row -->
                 <div class="flex items-center gap-4 overflow-x-auto">
                   <template x-if="selectedSite.custom_container">
-                    <span class="text-xs text-violet-500 dark:text-violet-400 border border-violet-200 dark:border-violet-500/30 rounded px-2 py-1" x-text="'Container :' + selectedSite.container_port"></span>
+                    <span class="text-xs text-violet-500 dark:text-violet-400 border border-violet-200 dark:border-violet-500/30 rounded px-2 py-1" x-text="(selectedSite.container_image || 'container') + ' :' + selectedSite.container_port"></span>
                   </template>
                   <template x-if="!selectedSite.custom_container && phpVersions.length === 0">
                     <span class="text-xs text-gray-400 border border-gray-200 dark:border-lerd-border rounded px-2 py-1 opacity-50">PHP ...</span>
@@ -2717,6 +2717,7 @@ function lerdApp() {
           e.node_version = s.node_version;
           e.custom_container = s.custom_container;
           e.container_port = s.container_port;
+          e.container_image = s.container_image;
           e.tls = s.tls;
           e.fpm_running = s.fpm_running;
           e.queue_running = s.queue_running;

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1554,6 +1554,10 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, SiteActionResponse{Error: "writing .php-version: " + err.Error()})
 			return
 		}
+		if site.IsCustomContainer() {
+			writeJSON(w, SiteActionResponse{Error: "custom container sites do not use PHP versions"})
+			return
+		}
 		_ = config.SetProjectPHPVersion(site.Path, version)
 		site.PHPVersion = version
 		// Regenerate vhost with new PHP version

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -597,9 +597,11 @@ type SiteResponse struct {
 	// Services lists the service names this site uses, sourced from the
 	// project's .lerd.yaml. Used by the dashboard to render service badges
 	// on the site detail panel.
-	Services    []string `json:"services,omitempty"`
-	LANPort     int      `json:"lan_port,omitempty"`
-	LANShareURL string   `json:"lan_share_url,omitempty"`
+	Services        []string `json:"services,omitempty"`
+	LANPort         int      `json:"lan_port,omitempty"`
+	LANShareURL     string   `json:"lan_share_url,omitempty"`
+	CustomContainer bool     `json:"custom_container,omitempty"`
+	ContainerPort   int      `json:"container_port,omitempty"`
 }
 
 func handleSites(w http.ResponseWriter, _ *http.Request) {
@@ -685,6 +687,8 @@ func buildSites() []SiteResponse {
 			Services:           e.Services,
 			LANPort:            e.LANPort,
 			LANShareURL:        cli.LANShareURL(e.LANPort),
+			CustomContainer:    e.ContainerPort > 0,
+			ContainerPort:      e.ContainerPort,
 		})
 	}
 	return sites
@@ -1344,7 +1348,8 @@ func countSitesUsingService(name string) int {
 	return config.CountSitesUsingService(name)
 }
 
-// sitesUsingService returns the domains of active sites whose .env references lerd-{name}.
+// sitesUsingService returns the domains of active sites that use the named service.
+// Checks both .lerd.yaml services list and .env file references.
 func sitesUsingService(name string) []string {
 	reg, err := config.LoadSites()
 	if err != nil {
@@ -1356,6 +1361,21 @@ func sitesUsingService(name string) []string {
 		if s.Ignored || s.Paused {
 			continue
 		}
+		// Check .lerd.yaml services list first.
+		if proj, pErr := config.LoadProjectConfig(s.Path); pErr == nil {
+			found := false
+			for _, svc := range proj.Services {
+				if svc.Name == name {
+					found = true
+					break
+				}
+			}
+			if found {
+				domains = append(domains, s.PrimaryDomain())
+				continue
+			}
+		}
+		// Fall back to .env scanning.
 		data, err := os.ReadFile(filepath.Join(s.Path, ".env"))
 		if err != nil {
 			continue
@@ -1576,6 +1596,13 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		return
 	case "unpause":
 		if err := cli.UnpauseSite(site.Name); err != nil {
+			writeJSON(w, SiteActionResponse{Error: err.Error()})
+			return
+		}
+		writeJSON(w, SiteActionResponse{OK: true})
+		return
+	case "restart":
+		if err := cli.RestartSite(site.Name); err != nil {
 			writeJSON(w, SiteActionResponse{Error: err.Error()})
 			return
 		}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -602,6 +602,7 @@ type SiteResponse struct {
 	LANShareURL     string   `json:"lan_share_url,omitempty"`
 	CustomContainer bool     `json:"custom_container,omitempty"`
 	ContainerPort   int      `json:"container_port,omitempty"`
+	ContainerImage  string   `json:"container_image,omitempty"`
 }
 
 func handleSites(w http.ResponseWriter, _ *http.Request) {
@@ -689,6 +690,7 @@ func buildSites() []SiteResponse {
 			LANShareURL:        cli.LANShareURL(e.LANPort),
 			CustomContainer:    e.ContainerPort > 0,
 			ContainerPort:      e.ContainerPort,
+			ContainerImage:     e.ContainerImage,
 		})
 	}
 	return sites

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1614,6 +1614,13 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
+	case "rebuild":
+		if err := cli.RebuildSite(site.Name); err != nil {
+			writeJSON(w, SiteActionResponse{Error: err.Error()})
+			return
+		}
+		writeJSON(w, SiteActionResponse{OK: true})
+		return
 	case "horizon:start":
 		phpVersion := site.PHPVersion
 		if detected, err := phpPkg.DetectVersion(site.Path); err == nil && detected != "" {


### PR DESCRIPTION
## Summary

Adds per-project custom container support so lerd can serve non-PHP sites (Node.js, Python, Go, etc.) alongside PHP sites. Users define a `Containerfile.lerd` and a `container:` section in `.lerd.yaml`, and lerd builds a dedicated image, runs it as a named container, and has nginx reverse-proxy to it.

Resolves #198

## What changed

- `.lerd.yaml` gains a `container:` section (port, containerfile, build_context) and `custom_workers:` for defining workers that exec into the container
- `lerd link` builds the image, starts the container, generates a proxy vhost
- `lerd unlink` stops and removes the container, image, quadlet, and vhost
- `lerd init` wizard detects non-PHP projects and offers the custom container setup path
- `lerd pause`/`lerd unpause` stop and start the custom container
- `lerd restart` (new command) restarts the container for any site type
- `lerd start`/`lerd stop` include custom container units
- `lerd secure`/`lerd unsecure` work with custom container proxy vhosts
- workers exec into the custom container instead of PHP-FPM
- dashboard shows container icon, port badge, container logs tab, restart button, and worker toggles
- `CountSitesUsingService` checks `.lerd.yaml` services list so services used by custom container sites are not auto-stopped
- watcher skips PHP/Node version re-detection for custom container sites
- MCP `site_restart` tool, updated skill content with custom container docs and `.lerd.yaml` reference
- macOS launchd compatibility for all custom container operations
- 49 new tests covering config, quadlet generation, vhost generation, NestJS integration lifecycle, version enrichment, service counting, restart, and park skip logic