### PR TITLE
fix(docs): add custom containers page to sidebar navigation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -110,6 +110,7 @@ export default defineConfig({
             { text: 'Git Worktrees', link: '/features/git-worktrees' },
             { text: 'Project Setup', link: '/features/project-setup' },
             { text: 'Environment Setup', link: '/features/env-setup' },
+            { text: 'Custom Containers', link: '/features/custom-containers' },
             { text: 'AI Integration (MCP)', link: '/features/mcp' },
           ],
         },


### PR DESCRIPTION
## Summary

- Add Custom Containers page to the Features sidebar in VitePress config
- All other doc pages verified present in sidebar