### PR TITLE
fix(ui): flush SSE headers and close sibling log streams on tab switch

### DIFF
--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -3008,6 +3008,18 @@ function lerdApp() {
       this.siteLogsTab = tab;
       const site = this.selectedSite;
       if (!site) return;
+
+      // Close every other worker log stream before opening the new one.
+      // Browsers cap HTTP/1.1 at 6 concurrent connections per origin;
+      // leaving previous tabs' EventSources open makes new ones queue in
+      // CONNECTING state and the UI sticks on "connecting...".
+      if (tab !== 'queue') this.closeSiteQueueLogs();
+      if (tab !== 'horizon') this.closeSiteHorizonLogs();
+      if (tab !== 'stripe') this.closeSiteStripeLogs();
+      if (tab !== 'schedule') this.closeSiteScheduleLogs();
+      if (tab !== 'reverb') this.closeSiteReverbLogs();
+      if (!tab.startsWith('worker:')) this.closeSiteWorkerLogs();
+
       if (tab === 'queue') this.openSiteQueueLogs(site);
       if (tab === 'horizon') this.openSiteHorizonLogs(site);
       if (tab === 'stripe') this.openSiteStripeLogs(site);

--- a/internal/ui/logs_darwin.go
+++ b/internal/ui/logs_darwin.go
@@ -72,6 +72,13 @@ func streamUnitLogs(w http.ResponseWriter, r *http.Request, unit string) {
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 
+	// Flush an SSE comment so the response headers go out immediately and
+	// the browser's EventSource fires onopen. Without this a silent unit
+	// (schedule between cron ticks, reverb before any WebSocket client
+	// connects) leaves the UI stuck on "connecting...".
+	fmt.Fprint(w, ": connected\n\n")
+	flusher.Flush()
+
 	if isContainerUnit(unit) {
 		// Wait up to 10s for the container to exist (e.g. right after start).
 		bin := podman.PodmanBin()

--- a/internal/ui/logs_linux.go
+++ b/internal/ui/logs_linux.go
@@ -38,6 +38,13 @@ func streamUnitLogs(w http.ResponseWriter, r *http.Request, unit string) {
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 
+	// Flush an SSE comment so the response headers go out immediately and
+	// the browser's EventSource fires onopen. Without this a silent unit
+	// (schedule between cron ticks, reverb before any WebSocket client
+	// connects) leaves the UI stuck on "connecting...".
+	fmt.Fprint(w, ": connected\n\n")
+	flusher.Flush()
+
 	cursor := r.Header.Get("Last-Event-ID")
 	args := []string{"--user", "-u", unit, "-f", "--no-pager", "--output=json"}
 	if cursor != "" {

--- a/internal/ui/logs_test.go
+++ b/internal/ui/logs_test.go
@@ -1,8 +1,12 @@
 package ui
 
 import (
+	"context"
+	"net/http/httptest"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestServiceRecentLogs_unknownUnit(t *testing.T) {
@@ -30,5 +34,36 @@ func TestIsContainerUnit_dns(t *testing.T) {
 		if !isContainerUnit("lerd-dns") {
 			t.Error("expected isContainerUnit to return true for lerd-dns on linux")
 		}
+	}
+}
+
+// streamUnitLogs must send the response headers and an initial SSE comment
+// before running the log-following subprocess; otherwise silent units leave
+// the browser's EventSource stuck in CONNECTING and the UI sticks on
+// "connecting...".
+func TestStreamUnitLogs_flushesHeadersBeforeStreaming(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req := httptest.NewRequest("GET", "/api/schedule/nonexistent/logs", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		streamUnitLogs(rec, req, "lerd-nonexistent-unit-xyz")
+		close(done)
+	}()
+	<-done
+
+	if ct := rec.Result().Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+	body := rec.Body.String()
+	if !strings.HasPrefix(body, ": connected") {
+		n := len(body)
+		if n > 40 {
+			n = 40
+		}
+		t.Errorf("body should start with initial SSE comment, got: %q", body[:n])
 	}
 }


### PR DESCRIPTION
## Summary
Worker log tabs (Schedule, Reverb, Horizon, Queue, Stripe, custom workers) were getting stuck on `connecting...` for two distinct reasons.

**Silent units never flush headers.** `journalctl -f` and `podman logs -f` produce zero output until something happens. Go's `http.ResponseWriter` doesn't actually send the response headers until the first body write, so the browser's `EventSource` never saw `HTTP 200` + `text/event-stream` and stayed in CONNECTING forever. Schedule between cron ticks and Reverb before any WebSocket client connects both hit this. Fix: write a `: connected\n\n` SSE comment and flush right after setting the headers in both `logs_linux.go` and `logs_darwin.go`, so the response starts immediately.

**Tab switches leaked EventSources.** `setSiteLogsTab` opened the new tab's `EventSource` without closing the previous tab's. Every click added a long-lived streaming connection. Browsers cap HTTP/1.1 at six connections per origin, so after a few tab clicks subsequent `EventSource`s queued indefinitely in CONNECTING, waiting for a slot. Fix: close every non-active worker log stream before opening the clicked one, mirroring the teardown already in place on site selection and unlink.

Tested manually on Linux: rapid tabbing through Queue → Horizon → Schedule → Reverb now lands on `live` within a second for every tab, and the Network panel shows a single active worker EventSource at any time.