### PR TITLE
feat(tui): add lerd tui terminal dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you're a PHP developer on Linux and want frictionless local development — a
 - 🐘 **Per-project PHP version** (8.1–8.5), switch with one click
 - 📦 **Node.js isolation** per project (Node 22, 24)
 - 🖥️ **Built-in Web UI** - 3-pane dashboard to manage sites, services, and logs from a browser
+- 🖥️ **Terminal dashboard** (`lerd tui`) - btop-style TUI with live status, site detail pane, inline domain and version editing, shell drop-in, log tailing, and filter/sort — the same operations surface as the web UI, for tmux and SSH workflows
 - 🗄️ **One-click services**: MySQL, PostgreSQL, Redis, Meilisearch, RustFS, Mailpit, Stripe Mock, Reverb and more
 - 📋 **Live logs** for PHP-FPM, Queue, Schedule, Reverb, per site
 - 🔒 **Rootless & daemonless** - Podman-native, no Docker required
@@ -63,6 +64,7 @@ AI:  → site_link()
 | Podman-native      | ✅   | ❌   | ❌    | ❌           |
 | Rootless           | ✅   | ❌   | ❌    | ✅           |
 | Web UI             | ✅   | ❌   | ❌    | ✅           |
+| Terminal dashboard | ✅   | ❌   | ❌    | ❌           |
 | Linux              | ✅   | ✅   | ✅    | ❌           |
 | macOS              | ✅   | ✅   | ✅    | ✅           |
 | MCP server         | ✅   | ❌   | ❌    | ❌           |

--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -97,6 +97,7 @@ func main() {
 	root.AddCommand(cli.NewNpxCmd())
 	root.AddCommand(cli.NewServiceCmd())
 	root.AddCommand(cli.NewStatusCmd())
+	root.AddCommand(cli.NewTuiCmd())
 	root.AddCommand(cli.NewWhichCmd())
 	root.AddCommand(cli.NewCheckCmd())
 	root.AddCommand(cli.NewAboutCmd())

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -105,6 +105,7 @@ export default defineConfig({
           text: 'Features',
           items: [
             { text: 'Web UI', link: '/features/web-ui' },
+            { text: 'Terminal Dashboard', link: '/features/tui' },
             { text: 'System Tray', link: '/features/system-tray' },
             { text: 'HTTPS / TLS', link: '/features/https' },
             { text: 'Git Worktrees', link: '/features/git-worktrees' },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,21 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`lerd tui` — terminal dashboard**. A btop-style, full-screen dashboard for sites, services, and workers, with near parity to the [Web UI](/features/web-ui) and [System Tray](/features/system-tray). Built on the same bubbletea / lipgloss stack already used for `lerd man` and the same `siteinfo` / `podman.Cache` / eventbus plumbing that drives `lerd-ui`, so both surfaces see identical live state.
+  - **Layout**: Sites + Services stacked in the left column, a full-height Site detail pane on the right, and a toggleable log tail below (`l`). Header shows DNS / nginx / FPM status plus an `update: vX.Y.Z` banner when a newer release is cached.
+  - **Site detail**: primary domain header, internal name, disk path, full domains list (add with `a`, rename with `e`, remove with `x`), services-used with live state, workers (toggle with `space`), git worktrees, HTTPS toggle, LAN share toggle (shows `http://<lan-ip>:<port>` when on), PHP and Node version pickers (open with `space`, commit with `enter`, backed by `lerd isolate` / `lerd isolate:node`).
+  - **Services pane** includes site-owned workers (`queue-<site>`, `schedule-<site>`, `horizon-<site>`, `reverb-<site>`, custom framework workers), routed through `lerd queue start/stop`, `lerd worker start/stop <name>`, etc. `t` opens an interactive shell in the focused container (FPM or custom for sites, the service container for services, the owning site's FPM for workers).
+  - **Filter + sort**: `/` to filter sites / services by name (sites also match domains and framework label), `o` to cycle sort (sites: name · status · framework; services: name · status · usage). `v` hides the services pane.
+  - **Log sources**: `[` / `]` cycle through FPM / custom container, every worker journal (`journalctl --user -u lerd-<kind>-<site>`), and every file matched by the framework's `fw.Logs` globs (Laravel: `storage/logs/*.log`). Logs pane takes at least half the window and has a right-edge scrollbar.
+  - **In-pane overlays**: `S` swaps the detail pane for global Settings (LAN expose, autostart on login, Xdebug per PHP version) and moves focus into it; `?` swaps it for a scrollable Keybindings reference. `esc` returns to Site detail.
+  - Updates live by subscribing to the in-process eventbus and re-querying every 2 s so changes made from another terminal surface within a couple of seconds.
+
+---
+
 ## [1.15.1] — 2026-04-16
 
 ### Fixed

--- a/docs/features/tui.md
+++ b/docs/features/tui.md
@@ -1,0 +1,138 @@
+# Terminal Dashboard (TUI)
+
+`lerd tui` opens a btop-inspired full-screen dashboard in your terminal. It shows sites, services, workers, and logs in one glance, updates live, and lets you drive most of the same operations the web UI exposes without ever leaving the terminal.
+
+```bash
+lerd tui
+```
+
+This is the terminal-native counterpart to the [Web UI](/features/web-ui) and the [System Tray](/features/system-tray). Use it when you prefer to keep everything in a tmux or terminal pane, or when you're on a remote machine over SSH.
+
+## Layout
+
+- **Header** shows the lerd version, DNS / nginx / FPM status, watcher state, the wall clock, and an `update: vX.Y.Z` banner when a newer release is available (populated from the same 24-hour cache `lerd status` and `lerd doctor` use, so no extra network on startup).
+- **Sites pane (left column, top)** lists every linked site by its primary domain, with an FPM running dot, PHP version, and worker glyphs (`q` queue, `s` schedule, `v` reverb, `h` horizon, plus a dot per custom framework worker). Paused sites are dimmed and marked. Columns line up across rows regardless of how many workers each site runs.
+- **Services pane (left column, bottom)** is a compact list of built-in services (mysql, redis, postgres, meilisearch, rustfs, mailpit), custom services, and every site-owned worker (`queue-<site>`, `schedule-<site>`, `horizon-<site>`, `reverb-<site>`, and custom framework workers). Each row shows a running dot, how many sites use it, and `pinned` / `custom` tags where applicable.
+- **Site detail (right column, full height)** always mirrors the focused site and shows primary domain, internal name, disk path, all domains, services used (with live state), workers, git worktrees, HTTPS / LAN share toggles, and PHP / Node version pickers. `S` swaps it for global Settings, `?` swaps it for the Keybindings reference.
+- **Logs pane** (toggle with `l`) tails the container, worker-journal, or app log file behind the focused item. Takes at least half the window and renders a right-edge scrollbar showing position in the buffer.
+- **Status bar** briefly shows the most recent action (e.g. `✓ lerd service stop redis` or `✖ …exit 1`).
+- **Footer** summarises active keybindings for the current mode.
+
+Dots follow the same convention everywhere: green `●` running, grey `○` stopped, amber `◐` paused, red `✖` failing.
+
+## Keybindings
+
+### Navigation
+
+| Key | Action |
+| --- | --- |
+| `tab` / `shift+tab` | Cycle focus through Sites · Services · Detail |
+| `↑` `↓` / `j` `k` | Move selection in the focused pane |
+| `pgup` `pgdn` | Jump by 10 rows |
+| `home` `g` | Jump to first row |
+| `end` `G` | Jump to last row |
+
+### Filter and sort
+
+| Key | Action |
+| --- | --- |
+| `/` | Type to filter the focused list (matches name, domains, framework label) |
+| `enter` | Commit filter and leave input mode |
+| `esc` | Clear filter and leave input mode |
+| `o` | Cycle sort order · **sites**: name → status → framework · **services**: name → status → usage (site count) |
+
+### Actions
+
+| Key | Action |
+| --- | --- |
+| `space` / `enter` | Toggle the focused detail row (worker, HTTPS, LAN share, PHP, Node) |
+| `s` | Start / resume the focused site or start the focused service / worker |
+| `x` | Stop / pause the focused site or stop the focused service / worker · on a domain row, remove that domain |
+| `r` | Restart the focused site / service / worker |
+| `p` | Pause / unpause toggle for a site |
+| `t` | Open an interactive shell inside the focused container (FPM or custom for sites, the service container for services, the owning site's FPM for worker rows) |
+
+### Logs
+
+| Key | Action |
+| --- | --- |
+| `l` | Toggle the logs pane for the focused item |
+| `[` / `]` | Cycle the log pane target through the site's log sources |
+
+### Domains
+
+Available when focus is on the Detail pane with the cursor on a domain row.
+
+| Key | Action |
+| --- | --- |
+| `a` | Add a new domain to the focused site (opens inline input) |
+| `e` | Edit / rename the focused domain (opens inline input prefilled with the short name; commit runs `lerd domain add <new>` then `lerd domain remove <old>` as a sequence) |
+| `x` | Remove the focused domain |
+
+### Panes and overlays
+
+| Key | Action |
+| --- | --- |
+| `v` | Show / hide the Services pane |
+| `S` | Swap the Detail pane for global Settings (LAN expose, autostart, Xdebug) and focus it |
+| `?` | Swap the Detail pane for this Keybindings reference |
+| `esc` | Close picker, return to Site detail |
+
+### General
+
+| Key | Action |
+| --- | --- |
+| `R` | Force a state refresh |
+| `q` / `ctrl+c` | Quit |
+
+## Log sources
+
+When the log pane is open, `[` and `]` cycle through every tail-able source for whatever's focused:
+
+- **FPM / custom container** — `podman logs -f lerd-php<ver>-fpm` for PHP sites, or `lerd-custom-<name>` for custom container sites.
+- **Workers** — `journalctl --user -u lerd-queue-<site>` (and the same for schedule, reverb, horizon, custom framework workers). Workers are systemd user units, not containers, so their output lives in the user journal.
+- **App logs** — any file matching the framework's declared log globs (Laravel: `storage/logs/*.log`). Tailed with `tail -F` so rotated Laravel-style logs keep following.
+
+The pane title shows which source is active and the index, e.g. `Logs · astrolov · laravel.log [3/5 · [ ] to switch]`.
+
+## Site detail
+
+The detail pane is the main control surface for a site. With focus on the Sites pane, moving the cursor updates the detail live. Press `tab` until focus lands on the Detail pane to navigate its rows and toggle them with `space`.
+
+Sections, top to bottom:
+
+- **Header** — primary domain (the URL users visit), internal name, disk path.
+- **Domains** — every domain on one row, each tagged `primary · e edit · x remove` or `alias · e edit · x remove`. Ends with `+ add domain (space or a)` to insert new ones.
+- **PHP / Node / framework / git branch** — one-line summary.
+- **Services used** — every service referenced in `.lerd.yaml` with its live state, so you can see at a glance whether redis / mysql / etc. are up for this site.
+- **Workers** — queue, schedule, horizon, reverb, and any custom framework workers, each with a running / failing indicator. `space` on a worker row toggles it (calls `lerd queue start/stop`, etc.).
+- **Worktrees** — every git worktree with its branch, domain, and path when the site uses them.
+- **Toggles** — HTTPS (runs `lerd secure` / `lerd unsecure`), LAN share (runs `lerd lan share` / `unshare` — shows the full `http://<lan-ip>:<port>` URL when enabled), PHP version (opens an inline picker from installed versions → `lerd isolate <ver>`), Node version (picker backed by `fnm list` → `lerd isolate:node <ver>`).
+
+## Settings view
+
+Press `S` to swap the detail pane for global settings. Navigate with `↑` `↓`, toggle with `space`:
+
+- **LAN expose** — flip every container to 0.0.0.0 binds (`lerd lan expose on/off`).
+- **Autostart on login** — `lerd autostart enable/disable`.
+- **Xdebug** — one toggle per installed PHP version; rebuilds the FPM container.
+
+`S` again (or `esc`) returns to Site detail.
+
+## Keybindings reference
+
+Press `?` to swap the detail pane for the full keybinding reference, scrollable with `↑` `↓`. `?` again (or `esc`) returns to Site detail.
+
+## Live updates
+
+The TUI draws state from the same sources `lerd-ui` uses, in-process:
+
+- Subscribes to the shared eventbus so any mutation the TUI itself triggers shows up immediately (150 ms debounce).
+- Re-queries every 2 seconds as a safety net, so changes made from another terminal (`lerd service stop redis` in a different shell) surface within a couple of seconds.
+- Services and site state are built from the same `siteinfo` + `podman.Cache` path the web UI uses, so the two surfaces can't disagree.
+
+## Troubleshooting
+
+- **Terminal too small** — if the window is under 60 columns by 12 rows the dashboard refuses to render and asks you to resize. It picks up the new size on the next frame.
+- **Non-interactive shells** — `lerd tui` exits with an error when stdout isn't a TTY (piped output, CI). Run it inside a real terminal.
+- **Worker log says nothing** — check the worker is actually running (`lerd status` or the Workers section of the detail pane). Journal logs only exist while the unit has run at least once.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,5 +36,5 @@ features:
     details: MySQL, Redis, PostgreSQL, Meilisearch, RustFS, and Mailpit. One command to start, shared across all your projects.
   - icon: 🖥️
     title: Web UI, terminal dashboard & tray
-    details: Browser dashboard with live logs and one-click toggles, a btop-style terminal dashboard (`lerd tui`) for tmux / SSH workflows, and a system tray applet for at-a-glance status.
+    details: Browser dashboard, btop-style terminal dashboard (`lerd tui`), and a system tray applet. Pick whichever fits your workflow.
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,6 @@ features:
     title: Built-in services
     details: MySQL, Redis, PostgreSQL, Meilisearch, RustFS, and Mailpit. One command to start, shared across all your projects.
   - icon: 🖥️
-    title: Web UI & system tray
-    details: Browser dashboard with live logs, per-site controls, and one-click toggles. Plus a system tray applet for at-a-glance status.
+    title: Web UI, terminal dashboard & tray
+    details: Browser dashboard with live logs and one-click toggles, a btop-style terminal dashboard (`lerd tui`) for tmux / SSH workflows, and a system tray applet for at-a-glance status.
 ---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -22,6 +22,7 @@
 | `lerd which` | Show resolved PHP version, Node version, document root, and nginx config for the current site |
 | `lerd about` | Show version, build info, and project URL |
 | `lerd man [page]` | Browse the built-in documentation in the terminal; pass a page name to jump directly (e.g. `lerd man sites`) |
+| `lerd tui` | Open a btop-style terminal dashboard with live site / service / worker status, per-site detail pane, inline domain and version editing, shell drop-in, log tailing, filter + sort, and global settings |
 | `lerd check` | Validate `.lerd.yaml` syntax, services, and PHP version before setup |
 | `lerd doctor` | Full environment diagnostic — podman, systemd, DNS, ports, PHP images, config validity |
 | `lerd logs [-f] [target]` | Show logs for the current project's FPM container, `nginx`, a service name, or a PHP version |

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,11 @@ require (
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/ansi v0.10.2
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/getlantern/systray v1.2.2
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/crypto v0.49.0
@@ -25,7 +27,6 @@ require (
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/x/ansi v0.10.2 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
@@ -60,7 +61,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
-	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -535,6 +535,7 @@ func runInstall(_ *cobra.Command, _ []string) error {
 
 	fmt.Println("\nLerd installation complete!")
 	fmt.Println("\n  Dashboard: \033[96mhttp://lerd.localhost\033[0m")
+	fmt.Println("  Terminal:  \033[96mlerd tui\033[0m")
 	return nil
 }
 

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/geodro/lerd/internal/tui"
+	"github.com/geodro/lerd/internal/version"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// NewTuiCmd returns the `lerd tui` command. Opens a btop-style dashboard in
+// the terminal with live site / service / worker status and keybindings for
+// common start / stop / restart actions.
+func NewTuiCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "tui",
+		Short: "Open a terminal dashboard for sites, services, and workers",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if !term.IsTerminal(int(os.Stdout.Fd())) {
+				return fmt.Errorf("lerd tui requires an interactive terminal")
+			}
+			return tui.Run(version.String())
+		},
+	}
+}

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -1,0 +1,86 @@
+package tui
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// ActionResult is emitted when an async action (start/stop/restart) finishes.
+// The status bar renders Err/Detail so the user sees failures without
+// dropping out of the TUI.
+type ActionResult struct {
+	Summary string
+	Err     error
+	Detail  string
+}
+
+// runShellIn suspends bubbletea, opens an interactive shell inside the
+// chosen container (FPM for PHP sites, the custom container for Node/Go/etc.
+// sites, and the service's own container for services), then resumes. Uses
+// `sh -c 'command -v bash && exec bash || exec sh'` so bash is used when
+// available and sh is the fallback (matters for minimal service images like
+// alpine where bash isn't installed).
+func runShellIn(container, workDir string) tea.Cmd {
+	args := []string{"exec", "-it"}
+	if workDir != "" {
+		args = append(args, "-w", workDir)
+	}
+	args = append(args, container, "sh", "-c",
+		"command -v bash >/dev/null 2>&1 && exec bash || exec sh")
+	cmd := exec.Command(podman.PodmanBin(), args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		if err != nil {
+			return ActionResult{Summary: "shell " + container, Err: err, Detail: err.Error()}
+		}
+		return ActionResult{Summary: "shell " + container + " exited"}
+	})
+}
+
+// containerForSite picks the right container to exec into for a site: the
+// custom container if the site is a non-PHP project, otherwise the shared
+// FPM image for that site's PHP version. Returns "" if neither exists yet
+// (e.g. PHP version hasn't been detected).
+func containerForSite(s *siteinfo.EnrichedSite) string {
+	if s.ContainerPort > 0 {
+		return podman.CustomContainerName(s.Name)
+	}
+	if s.PHPVersion == "" {
+		return ""
+	}
+	return "lerd-php" + strings.ReplaceAll(s.PHPVersion, ".", "") + "-fpm"
+}
+
+// runLerd executes `lerd` as a subprocess with the given args, in the given
+// working directory. We go through the public CLI rather than poking internal
+// helpers so the TUI goes down the same code paths users would run manually.
+// This avoids drifting when ensureQuadlet / dependency logic moves around.
+func runLerd(dir string, args ...string) tea.Cmd {
+	return func() tea.Msg {
+		self, err := os.Executable()
+		if err != nil {
+			self = "lerd"
+		}
+		cmd := exec.Command(self, args...)
+		if dir != "" {
+			cmd.Dir = dir
+		}
+		var buf bytes.Buffer
+		cmd.Stdout = &buf
+		cmd.Stderr = &buf
+		runErr := cmd.Run()
+		return ActionResult{
+			Summary: "lerd " + strings.Join(args, " "),
+			Err:     runErr,
+			Detail:  strings.TrimSpace(buf.String()),
+		}
+	}
+}

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -1,0 +1,623 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// detailRow is one line in the detail overlay that reacts to input.
+// Informational rows use kindInfo and are skipped by cursor navigation.
+type detailRow struct {
+	kind detailKind
+	// Worker kind: logical name used for `lerd queue/schedule/worker start`.
+	workerName string
+	// Domain kind: the full domain (including the TLD) this row represents.
+	domain string
+}
+
+type detailKind int
+
+const (
+	kindInfo detailKind = iota
+	kindWorker
+	kindHTTPS
+	kindLANShare
+	kindPHP
+	kindNode
+	kindDomain
+	kindDomainAdd
+)
+
+// detailRows returns the ordered rows the detail view draws. Built on each
+// render so worker lists stay in sync with live state.
+func detailRows(s *siteinfo.EnrichedSite) []detailRow {
+	var rows []detailRow
+	rows = append(rows, detailRow{kind: kindInfo}) // header placeholder drawn separately
+	for _, d := range s.Domains {
+		rows = append(rows, detailRow{kind: kindDomain, domain: d})
+	}
+	rows = append(rows, detailRow{kind: kindDomainAdd})
+	if s.HasQueueWorker {
+		rows = append(rows, detailRow{kind: kindWorker, workerName: "queue"})
+	}
+	if s.HasScheduleWorker {
+		rows = append(rows, detailRow{kind: kindWorker, workerName: "schedule"})
+	}
+	if s.HasHorizon {
+		rows = append(rows, detailRow{kind: kindWorker, workerName: "horizon"})
+	}
+	if s.HasReverb {
+		rows = append(rows, detailRow{kind: kindWorker, workerName: "reverb"})
+	}
+	for _, fw := range s.FrameworkWorkers {
+		switch fw.Name {
+		case "queue", "schedule", "horizon", "reverb":
+			continue
+		}
+		rows = append(rows, detailRow{kind: kindWorker, workerName: fw.Name})
+	}
+	if s.ContainerPort == 0 && s.PHPVersion != "" {
+		rows = append(rows, detailRow{kind: kindPHP})
+	}
+	if s.NodeVersion != "" {
+		rows = append(rows, detailRow{kind: kindNode})
+	}
+	rows = append(rows, detailRow{kind: kindHTTPS})
+	rows = append(rows, detailRow{kind: kindLANShare})
+	return rows
+}
+
+// navigableRows filters out info rows so cursor moves skip them.
+func navigableRows(rows []detailRow) []int {
+	var idx []int
+	for i, r := range rows {
+		if r.kind != kindInfo {
+			idx = append(idx, i)
+		}
+	}
+	return idx
+}
+
+func (m *Model) detailToggleSelected(s *siteinfo.EnrichedSite, rows []detailRow, nav []int) tea.Cmd {
+	if s == nil || len(nav) == 0 {
+		return nil
+	}
+	if m.detailCursor >= len(nav) {
+		m.detailCursor = len(nav) - 1
+	}
+	row := rows[nav[m.detailCursor]]
+	switch row.kind {
+	case kindWorker:
+		return m.toggleWorker(s, row.workerName)
+	case kindHTTPS:
+		if s.Secured {
+			m.setStatus("disabling HTTPS for "+s.Name+"…", 5*time.Second)
+			return runLerd(s.Path, "unsecure", s.Name)
+		}
+		m.setStatus("enabling HTTPS for "+s.Name+"…", 5*time.Second)
+		return runLerd(s.Path, "secure", s.Name)
+	case kindLANShare:
+		if s.LANPort > 0 {
+			m.setStatus("stopping LAN share for "+s.Name+"…", 5*time.Second)
+			return runLerd(s.Path, "lan", "unshare")
+		}
+		m.setStatus("starting LAN share for "+s.Name+"…", 5*time.Second)
+		return runLerd(s.Path, "lan", "share")
+	case kindPHP:
+		m.openPHPPicker(s)
+		return nil
+	case kindNode:
+		m.openNodePicker(s)
+		return nil
+	case kindDomain:
+		// Selecting a domain does nothing on its own; removal is `x`.
+		return nil
+	case kindDomainAdd:
+		m.openDomainInput()
+		return nil
+	}
+	return nil
+}
+
+// removeFocusedDomain runs `lerd domain remove <name>` for the domain the
+// cursor is on. Does nothing when focus is elsewhere or a different kind of
+// row is selected — meaning `x` on workers or services still does stop.
+func (m *Model) removeFocusedDomain() (handled bool, cmd tea.Cmd) {
+	if m.focus != paneDetail || m.detailMode != detailSite {
+		return false, nil
+	}
+	s := m.currentSite()
+	if s == nil {
+		return false, nil
+	}
+	rows := detailRows(s)
+	nav := navigableRows(rows)
+	if m.detailCursor >= len(nav) {
+		return false, nil
+	}
+	row := rows[nav[m.detailCursor]]
+	if row.kind != kindDomain {
+		return false, nil
+	}
+	short := trimTLD(row.domain)
+	m.setStatus("removing domain "+row.domain+"…", 5*time.Second)
+	return true, runLerd(s.Path, "domain", "remove", short)
+}
+
+// trimTLD strips the configured TLD suffix from a full domain so the short
+// form is what `lerd domain add/remove` expects. Falls back to stripping
+// the last dotted component if the config can't be read.
+func trimTLD(full string) string {
+	cfg, _ := config.LoadGlobal()
+	if cfg != nil && cfg.DNS.TLD != "" {
+		if trimmed := strings.TrimSuffix(full, "."+cfg.DNS.TLD); trimmed != full {
+			return trimmed
+		}
+	}
+	if i := strings.LastIndexByte(full, '.'); i >= 0 {
+		return full[:i]
+	}
+	return full
+}
+
+// currentTLD returns the configured TLD, defaulting to "test" when global
+// config can't be read. Centralised so the handful of call sites don't
+// each have to inline the fallback.
+func currentTLD() string {
+	cfg, _ := config.LoadGlobal()
+	if cfg != nil && cfg.DNS.TLD != "" {
+		return cfg.DNS.TLD
+	}
+	return "test"
+}
+
+func (m *Model) toggleWorker(s *siteinfo.EnrichedSite, name string) tea.Cmd {
+	running := workerRunning(s, name)
+	verb := "start"
+	if running {
+		verb = "stop"
+	}
+	m.setStatus(verb+"ing "+name+" worker for "+s.Name+"…", 5*time.Second)
+	switch name {
+	case "queue":
+		return runLerd(s.Path, "queue", verb)
+	case "schedule":
+		return runLerd(s.Path, "schedule", verb)
+	case "horizon":
+		return runLerd(s.Path, "horizon", verb)
+	case "reverb":
+		return runLerd(s.Path, "reverb", verb)
+	default:
+		return runLerd(s.Path, "worker", verb, name)
+	}
+}
+
+func workerRunning(s *siteinfo.EnrichedSite, name string) bool {
+	switch name {
+	case "queue":
+		return s.QueueRunning
+	case "schedule":
+		return s.ScheduleRunning
+	case "horizon":
+		return s.HorizonRunning
+	case "reverb":
+		return s.ReverbRunning
+	}
+	for _, fw := range s.FrameworkWorkers {
+		if fw.Name == name {
+			return fw.Running
+		}
+	}
+	return false
+}
+
+func workerFailing(s *siteinfo.EnrichedSite, name string) bool {
+	switch name {
+	case "queue":
+		return s.QueueFailing
+	case "schedule":
+		return s.ScheduleFailing
+	case "horizon":
+		return s.HorizonFailing
+	case "reverb":
+		return s.ReverbFailing
+	}
+	for _, fw := range s.FrameworkWorkers {
+		if fw.Name == name {
+			return fw.Failing
+		}
+	}
+	return false
+}
+
+func workerLabel(s *siteinfo.EnrichedSite, name string) string {
+	for _, fw := range s.FrameworkWorkers {
+		if fw.Name == name && fw.Label != "" {
+			return fw.Label
+		}
+	}
+	return name
+}
+
+// renderDetailInline builds the right-column pane: full-height site detail
+// by default, or the global settings rows when detailMode == detailSettings.
+// Both live in the same pane so `S` is a toggle, not a separate screen.
+func (m *Model) renderDetailInline(w, h int, focused bool) string {
+	style := paneStyle(focused)
+	innerW, innerH := innerSize(style, w, h)
+
+	var content []string
+	switch m.detailMode {
+	case detailSettings:
+		content = settingsContentLines(m, focused, innerW)
+	case detailHelp:
+		all := helpContentLines(m, innerW)
+		if m.helpScroll > len(all)-1 {
+			m.helpScroll = max(0, len(all)-1)
+		}
+		content = all[m.helpScroll:]
+	default:
+		site := m.currentSite()
+		if site == nil {
+			content = []string{
+				padToWidth(sectionStyle.Render("Site detail"), innerW),
+				padToWidth(dimStyle.Render("no site selected"), innerW),
+			}
+		} else {
+			content = detailContentLines(m, site, focused, innerW)
+		}
+	}
+
+	for len(content) < innerH {
+		content = append(content, spaces(innerW))
+	}
+	if len(content) > innerH {
+		content = content[:innerH]
+	}
+
+	return style.Render(strings.Join(content, "\n"))
+}
+
+// settingsContentLines builds the settings rows for the right-hand pane when
+// detailMode == detailSettings. Mirrors the detail pane's look so S feels
+// like a pane swap, not a modal.
+func settingsContentLines(m *Model, focused bool, innerW int) []string {
+	rows := m.settingsRows()
+	out := make([]string, 0, len(rows)+4)
+	add := func(s string) { out = append(out, padToWidth(clipLine(s, innerW), innerW)) }
+
+	add(sectionStyle.Render("Settings"))
+	add(dimStyle.Render("  press S again to return to site detail"))
+	add("")
+
+	if len(rows) == 0 {
+		add(dimStyle.Render("  no settings available"))
+		return out
+	}
+
+	for i, row := range rows {
+		selected := focused && i == m.settingsRow
+		add(renderDetailRow(selected, onOffGlyph(row.on), row.label, onOffText(row.on)))
+	}
+	return out
+}
+
+func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, innerW int) []string {
+	rows := detailRows(site)
+	nav := navigableRows(rows)
+	navPos := func(i int) int {
+		for pos, rowIdx := range nav {
+			if rowIdx == i {
+				return pos
+			}
+		}
+		return -1
+	}
+
+	var out []string
+	add := func(s string) { out = append(out, padToWidth(clipLine(s, innerW), innerW)) }
+
+	// Lead with the primary domain (what users see in the browser). The
+	// internal registry name is still surfaced as the "name:" line below,
+	// since commands and filters still accept it.
+	header := site.PrimaryDomain()
+	if header == "" {
+		header = site.Name
+	}
+	add(sectionStyle.Render(header))
+	if site.Name != header {
+		add(dimStyle.Render("  name: ") + site.Name)
+	}
+	if site.Path != "" {
+		add(dimStyle.Render("  path: ") + site.Path)
+	}
+
+	scheme := "http"
+	if site.Secured {
+		scheme = "https"
+	}
+
+	add("")
+	add(sectionStyle.Render("Domains"))
+	if len(site.Domains) == 0 {
+		add(dimStyle.Render("  (no domain)"))
+	}
+	for i, row := range rows {
+		if row.kind != kindDomain {
+			continue
+		}
+		selected := focused && navPos(i) == m.detailCursor
+		domain := row.domain
+		label := scheme + "://" + domain
+		add(renderDetailRow(selected, accentStyle.Render("⊙"), label, dimStyle.Render(domainRole(site, domain))))
+	}
+	for i, row := range rows {
+		if row.kind != kindDomainAdd {
+			continue
+		}
+		selected := focused && navPos(i) == m.detailCursor
+		prefix := "  "
+		if selected {
+			prefix = " " + accentStyle.Render("▸")
+		}
+		if m.domainInputActive {
+			label := "add domain: "
+			if m.domainInputEditing != "" {
+				label = "rename " + m.domainInputEditing + " → "
+			}
+			add(prefix + " " + accentStyle.Render("+") + " " + selectedStyle.Render(label) + m.domainInput + "▌")
+		} else {
+			add(prefix + " " + accentStyle.Render("+") + " " + dimStyle.Render("add domain (space or a)"))
+		}
+	}
+	add("")
+
+	php := site.PHPVersion
+	if php == "" && site.ContainerPort > 0 {
+		php = "custom"
+	}
+	info := dimStyle.Render("  php: ") + php
+	if site.NodeVersion != "" {
+		info += dimStyle.Render("  node: ") + site.NodeVersion
+	}
+	if site.FrameworkLabel != "" {
+		info += dimStyle.Render("  fw: ") + site.FrameworkLabel
+	}
+	if site.Branch != "" {
+		info += dimStyle.Render("  git: ") + site.Branch
+	}
+	add(info)
+	add("")
+	if len(site.Services) > 0 {
+		add(sectionStyle.Render("Services used"))
+		states := m.serviceStatesByName()
+		for _, svc := range site.Services {
+			add(renderSiteServiceRow(svc, states[svc]))
+		}
+		add("")
+	}
+
+	hasWorkers := false
+	for _, row := range rows {
+		if row.kind == kindWorker {
+			hasWorkers = true
+			break
+		}
+	}
+	if hasWorkers {
+		add(sectionStyle.Render("Workers"))
+		for i, row := range rows {
+			if row.kind != kindWorker {
+				continue
+			}
+			selected := focused && navPos(i) == m.detailCursor
+			add(renderDetailRow(selected,
+				workerGlyphFor(site, row.workerName),
+				workerLabel(site, row.workerName),
+				workerStateText(site, row.workerName)))
+		}
+		add("")
+	}
+
+	if len(site.Worktrees) > 0 {
+		add(sectionStyle.Render("Worktrees"))
+		for _, wt := range site.Worktrees {
+			line := "  " + accentStyle.Render(wt.Branch)
+			if wt.Domain != "" {
+				line += "  " + dimStyle.Render(scheme+"://"+wt.Domain)
+			}
+			if wt.Path != "" {
+				line += "  " + dimStyle.Render(wt.Path)
+			}
+			add(line)
+		}
+		add("")
+	}
+
+	add(sectionStyle.Render("Toggles"))
+	for i, row := range rows {
+		selected := focused && navPos(i) == m.detailCursor
+		switch row.kind {
+		case kindPHP:
+			add(renderDetailRow(selected,
+				accentStyle.Render("λ"), "PHP", dimStyle.Render(site.PHPVersion)))
+			if selected && m.pickerKind == kindPHP {
+				for _, pl := range m.renderPickerRows(site.PHPVersion) {
+					add(pl)
+				}
+			}
+		case kindNode:
+			add(renderDetailRow(selected,
+				accentStyle.Render("⬢"), "Node", dimStyle.Render(site.NodeVersion)))
+			if selected && m.pickerKind == kindNode {
+				for _, pl := range m.renderPickerRows(site.NodeVersion) {
+					add(pl)
+				}
+			}
+		case kindHTTPS:
+			add(renderDetailRow(selected,
+				onOffGlyph(site.Secured), "HTTPS", onOffText(site.Secured)))
+		case kindLANShare:
+			add(renderDetailRow(selected,
+				onOffGlyph(site.LANPort > 0), "LAN share", lanShareText(site.LANPort)))
+		}
+	}
+	return out
+}
+
+// renderPickerRows draws the inline version picker below a PHP or Node row.
+// Each option shows a cursor, the version, and a dim "current" marker when
+// it matches the site's active version.
+func (m *Model) renderPickerRows(current string) []string {
+	if len(m.pickerOptions) == 0 {
+		return []string{dimStyle.Render("      (no versions available)")}
+	}
+	out := make([]string, 0, len(m.pickerOptions)+1)
+	for i, v := range m.pickerOptions {
+		marker := "  "
+		if i == m.pickerCursor {
+			marker = accentStyle.Render("▸ ")
+		}
+		label := v
+		if i == m.pickerCursor {
+			label = selectedStyle.Render(v)
+		}
+		suffix := ""
+		if v == current {
+			suffix = "  " + dimStyle.Render("(current)")
+		}
+		out = append(out, "      "+marker+label+suffix)
+	}
+	out = append(out, dimStyle.Render("      enter apply · esc cancel"))
+	return out
+}
+
+func renderDetailRow(selected bool, glyph, label, state string) string {
+	prefix := "  "
+	if selected {
+		prefix = " " + accentStyle.Render("▸")
+	}
+	// Pad short labels to a minimum of 18 cells so state columns across
+	// rows line up, but do NOT truncate long labels — long values like a
+	// full https URL need the whole pane width. The outer clipLine call
+	// handles final truncation at innerW, so overflow is bounded.
+	padded := label
+	if w := len([]rune(label)); w < 18 {
+		padded = label + spaces(18-w)
+	}
+	if selected {
+		padded = selectedStyle.Render(padded)
+	}
+	return fmt.Sprintf("%s %s %s %s", prefix, glyph, padded, state)
+}
+
+// serviceStatesByName maps service name → live state from the current
+// snapshot. Used by the detail pane's "Services used" section so each
+// service the site references shows its actual running/stopped/paused
+// state instead of the raw name list.
+func (m *Model) serviceStatesByName() map[string]ServiceState {
+	out := make(map[string]ServiceState, len(m.snap.Services))
+	for _, s := range m.snap.Services {
+		out[s.Name] = s.State
+	}
+	return out
+}
+
+// renderSiteServiceRow draws one row in the detail pane's "Services used"
+// section: glyph, service name, and live state text. Missing entries (a
+// service referenced by the site but not present in the snapshot, e.g. a
+// removed custom service) render as dim "not configured".
+func renderSiteServiceRow(name string, state ServiceState) string {
+	var glyph, text string
+	switch state {
+	case stateRunning:
+		glyph = runningStyle.Render(glyphRunning)
+		text = runningStyle.Render("running")
+	case statePaused:
+		glyph = pausedStyle.Render(glyphPaused)
+		text = pausedStyle.Render("paused")
+	default:
+		glyph = stoppedStyle.Render(glyphStopped)
+		text = dimStyle.Render("stopped")
+	}
+	padded := name
+	if w := len([]rune(name)); w < 18 {
+		padded = name + spaces(18-w)
+	}
+	return "  " + glyph + " " + padded + " " + text
+}
+
+// domainRole labels a domain's position in the list. Exactly one domain is
+// the primary (the first in site.Domains); the others are aliases. The web
+// UI renders the same distinction, so the TUI shouldn't invent new terms.
+func domainRole(s *siteinfo.EnrichedSite, domain string) string {
+	role := "alias"
+	if len(s.Domains) > 0 && s.Domains[0] == domain {
+		role = "primary"
+	}
+	return role + " · e edit · x remove"
+}
+
+func workerGlyphFor(s *siteinfo.EnrichedSite, name string) string {
+	switch {
+	case workerFailing(s, name):
+		return failingStyle.Render(glyphFailing)
+	case workerRunning(s, name):
+		return runningStyle.Render(glyphRunning)
+	}
+	return stoppedStyle.Render(glyphStopped)
+}
+
+func workerStateText(s *siteinfo.EnrichedSite, name string) string {
+	switch {
+	case workerFailing(s, name):
+		return failingStyle.Render("failing")
+	case workerRunning(s, name):
+		return runningStyle.Render("running")
+	}
+	return dimStyle.Render("stopped")
+}
+
+func onOffGlyph(on bool) string {
+	if on {
+		return runningStyle.Render(glyphRunning)
+	}
+	return stoppedStyle.Render(glyphStopped)
+}
+
+func onOffText(on bool) string {
+	if on {
+		return runningStyle.Render("on")
+	}
+	return dimStyle.Render("off")
+}
+
+func lanShareText(port int) string {
+	if port <= 0 {
+		return dimStyle.Render("off")
+	}
+	ip := primaryLANIP()
+	if ip == "" {
+		return runningStyle.Render(fmt.Sprintf("sharing on port %d", port))
+	}
+	return runningStyle.Render(fmt.Sprintf("http://%s:%d", ip, port))
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -1,0 +1,176 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func TestDetailRows_IncludesDomainsWorkersAndToggles(t *testing.T) {
+	s := &siteinfo.EnrichedSite{
+		Name:           "alpha",
+		Domains:        []string{"alpha.test", "alpha-admin.test"},
+		PHPVersion:     "8.3",
+		NodeVersion:    "20",
+		HasQueueWorker: true,
+		HasHorizon:     true,
+	}
+	rows := detailRows(s)
+	kinds := rowKinds(rows)
+
+	// First kindInfo is a header placeholder, then 2 domain rows, then
+	// the add-domain row, then workers, PHP, Node, HTTPS, LAN share.
+	assertKindCount(t, kinds, kindDomain, 2)
+	assertKindCount(t, kinds, kindDomainAdd, 1)
+	assertKindCount(t, kinds, kindWorker, 2)
+	assertKindCount(t, kinds, kindPHP, 1)
+	assertKindCount(t, kinds, kindNode, 1)
+	assertKindCount(t, kinds, kindHTTPS, 1)
+	assertKindCount(t, kinds, kindLANShare, 1)
+}
+
+func TestDetailRows_CustomContainerSkipsPHP(t *testing.T) {
+	s := &siteinfo.EnrichedSite{
+		Name:          "nodeapp",
+		Domains:       []string{"nodeapp.test"},
+		ContainerPort: 3000,
+	}
+	rows := detailRows(s)
+	kinds := rowKinds(rows)
+	assertKindCount(t, kinds, kindPHP, 0)
+	assertKindCount(t, kinds, kindNode, 0) // NodeVersion empty
+	assertKindCount(t, kinds, kindHTTPS, 1)
+	assertKindCount(t, kinds, kindLANShare, 1)
+}
+
+func TestNavigableRows_SkipsInfo(t *testing.T) {
+	rows := []detailRow{
+		{kind: kindInfo},
+		{kind: kindWorker, workerName: "queue"},
+		{kind: kindInfo},
+		{kind: kindHTTPS},
+	}
+	nav := navigableRows(rows)
+	if len(nav) != 2 {
+		t.Fatalf("expected 2 navigable rows, got %d", len(nav))
+	}
+	if rows[nav[0]].kind != kindWorker || rows[nav[1]].kind != kindHTTPS {
+		t.Fatalf("nav picked wrong rows: %+v", nav)
+	}
+}
+
+func TestTrimTLD_StripsConfiguredTLD(t *testing.T) {
+	// Relies on the installed config; if the TLD isn't "test", the
+	// fallback path still trims the last dotted component. Both outcomes
+	// strip the suffix from "name.test".
+	if got := trimTLD("name.test"); got != "name" {
+		t.Errorf("trimTLD(name.test) = %q, want name", got)
+	}
+	if got := trimTLD("sub.name.test"); got != "sub.name" {
+		t.Errorf("trimTLD(sub.name.test) = %q, want sub.name", got)
+	}
+	if got := trimTLD("plain"); got != "plain" {
+		t.Errorf("trimTLD(plain) = %q, want plain (no dot, no change)", got)
+	}
+}
+
+func TestDomainRole_MarksPrimary(t *testing.T) {
+	s := &siteinfo.EnrichedSite{Domains: []string{"first.test", "second.test"}}
+	if got := domainRole(s, "first.test"); !strings.Contains(got, "primary") {
+		t.Errorf("first domain should be primary, got %q", got)
+	}
+	if got := domainRole(s, "second.test"); !strings.Contains(got, "alias") {
+		t.Errorf("second domain should be alias, got %q", got)
+	}
+}
+
+func TestLogTargetsForSite_IncludesFPMAndWorkers(t *testing.T) {
+	s := &siteinfo.EnrichedSite{
+		Name:           "alpha",
+		Path:           "/tmp/missing-so-no-app-logs",
+		PHPVersion:     "8.3",
+		HasQueueWorker: true,
+		HasHorizon:     true,
+	}
+	targets := logTargetsForSite(s)
+	if len(targets) < 3 {
+		t.Fatalf("expected at least 3 targets (fpm+queue+horizon), got %d", len(targets))
+	}
+	if targets[0].Kind != kindPodman || !strings.Contains(targets[0].ID, "lerd-php83-fpm") {
+		t.Errorf("first target should be fpm container, got %+v", targets[0])
+	}
+	// Every worker target should be a journal tail, not a podman one.
+	for _, t2 := range targets[1:] {
+		if t2.Kind != kindJournal && t2.Kind != kindFile {
+			t.Errorf("non-fpm target %s should be journal or file, got %v", t2.ID, t2.Kind)
+		}
+	}
+}
+
+func TestLogTargetsForSite_CustomContainer(t *testing.T) {
+	s := &siteinfo.EnrichedSite{
+		Name:          "nodeapp",
+		ContainerPort: 3000,
+	}
+	targets := logTargetsForSite(s)
+	if len(targets) != 1 || targets[0].Kind != kindPodman {
+		t.Fatalf("custom container should get exactly one podman target, got %+v", targets)
+	}
+	if !strings.Contains(targets[0].ID, "lerd-custom-nodeapp") {
+		t.Errorf("expected lerd-custom-nodeapp, got %s", targets[0].ID)
+	}
+}
+
+func TestContainerForSite(t *testing.T) {
+	if got := containerForSite(&siteinfo.EnrichedSite{ContainerPort: 3000, Name: "x"}); !strings.Contains(got, "lerd-custom-x") {
+		t.Errorf("custom container, got %s", got)
+	}
+	if got := containerForSite(&siteinfo.EnrichedSite{PHPVersion: "8.3"}); got != "lerd-php83-fpm" {
+		t.Errorf("php site, got %s", got)
+	}
+	if got := containerForSite(&siteinfo.EnrichedSite{}); got != "" {
+		t.Errorf("empty site should return empty, got %s", got)
+	}
+}
+
+func TestServiceStatesByName(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{
+		Services: []ServiceRow{
+			{Name: "mysql", State: stateRunning},
+			{Name: "redis", State: stateStopped},
+		},
+	}
+	states := m.serviceStatesByName()
+	if states["mysql"] != stateRunning {
+		t.Errorf("mysql state wrong")
+	}
+	if states["redis"] != stateStopped {
+		t.Errorf("redis state wrong")
+	}
+	if _, ok := states["nope"]; ok {
+		t.Errorf("unknown service shouldn't be in map")
+	}
+}
+
+func rowKinds(rows []detailRow) []detailKind {
+	out := make([]detailKind, len(rows))
+	for i, r := range rows {
+		out[i] = r.kind
+	}
+	return out
+}
+
+func assertKindCount(t *testing.T, kinds []detailKind, want detailKind, count int) {
+	t.Helper()
+	n := 0
+	for _, k := range kinds {
+		if k == want {
+			n++
+		}
+	}
+	if n != count {
+		t.Errorf("kind %d: got %d occurrences, want %d (kinds=%v)", want, n, count, kinds)
+	}
+}

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -1,0 +1,44 @@
+package tui
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/eventbus"
+)
+
+// refreshMsg arrives on every tick and on every eventbus publish. Update's
+// handler reloads the snapshot off the main loop.
+type refreshMsg struct{}
+
+// snapshotMsg carries a freshly-loaded Snapshot from a background goroutine
+// back into the tea program.
+type snapshotMsg struct{ snap Snapshot }
+
+// tickCmd schedules the next refreshMsg. Called from Update after each
+// snapshot lands so the model polls at a steady cadence even when no
+// eventbus traffic arrives (cross-process changes show up within the
+// interval).
+func tickCmd(d time.Duration) tea.Cmd {
+	return tea.Tick(d, func(time.Time) tea.Msg { return refreshMsg{} })
+}
+
+// loadCmd runs loadSnapshot off the main loop. siteinfo.LoadAll and podman
+// calls can block for 100s of ms on slow systems; running them in the Update
+// handler would freeze input.
+func loadCmd() tea.Cmd {
+	return func() tea.Msg { return snapshotMsg{snap: loadSnapshot()} }
+}
+
+// busCmd subscribes to the in-process eventbus and emits a refreshMsg the
+// first time a publish lands. The caller chains busCmd to itself from Update
+// so the subscription is long-lived.
+func busCmd(sub *eventbus.Subscriber) tea.Cmd {
+	return func() tea.Msg {
+		_, ok := <-sub.C
+		if !ok {
+			return nil
+		}
+		return refreshMsg{}
+	}
+}

--- a/internal/tui/filter.go
+++ b/internal/tui/filter.go
@@ -1,0 +1,143 @@
+package tui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// siteSortMode picks the ordering for the sites pane.
+type siteSortMode int
+
+const (
+	siteSortName siteSortMode = iota
+	siteSortStatus
+	siteSortFramework
+)
+
+func (m siteSortMode) label() string {
+	switch m {
+	case siteSortStatus:
+		return "status"
+	case siteSortFramework:
+		return "framework"
+	}
+	return "name"
+}
+
+// svcSortMode picks the ordering for the services pane.
+type svcSortMode int
+
+const (
+	svcSortName svcSortMode = iota
+	svcSortStatus
+	svcSortUsage
+)
+
+func (m svcSortMode) label() string {
+	switch m {
+	case svcSortStatus:
+		return "status"
+	case svcSortUsage:
+		return "usage"
+	}
+	return "name"
+}
+
+// filteredSortedSites returns the sites list after applying the active
+// filter and sort. Always returns a new slice so the caller can safely
+// mutate ordering without affecting m.snap.
+func filteredSortedSites(list []siteinfo.EnrichedSite, filter string, mode siteSortMode) []siteinfo.EnrichedSite {
+	out := make([]siteinfo.EnrichedSite, 0, len(list))
+	needle := strings.ToLower(strings.TrimSpace(filter))
+	for _, s := range list {
+		if needle != "" && !siteMatchesFilter(s, needle) {
+			continue
+		}
+		out = append(out, s)
+	}
+	switch mode {
+	case siteSortStatus:
+		sort.SliceStable(out, func(i, j int) bool {
+			return siteStatusRank(out[i]) < siteStatusRank(out[j])
+		})
+	case siteSortFramework:
+		sort.SliceStable(out, func(i, j int) bool {
+			if out[i].FrameworkLabel != out[j].FrameworkLabel {
+				return out[i].FrameworkLabel < out[j].FrameworkLabel
+			}
+			return out[i].Name < out[j].Name
+		})
+	default:
+		sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	}
+	return out
+}
+
+func siteMatchesFilter(s siteinfo.EnrichedSite, needle string) bool {
+	if strings.Contains(strings.ToLower(s.Name), needle) {
+		return true
+	}
+	for _, d := range s.Domains {
+		if strings.Contains(strings.ToLower(d), needle) {
+			return true
+		}
+	}
+	if strings.Contains(strings.ToLower(s.FrameworkLabel), needle) {
+		return true
+	}
+	return false
+}
+
+// siteStatusRank sorts running sites first, then stopped, then paused.
+// Within a bucket the sort is stable, so the caller's upstream ordering
+// (alphabetical) determines ties.
+func siteStatusRank(s siteinfo.EnrichedSite) int {
+	switch {
+	case s.Paused:
+		return 2
+	case s.FPMRunning:
+		return 0
+	}
+	return 1
+}
+
+// filteredSortedServices applies the active filter/sort to the services row
+// slice. Same policy as sites: new slice, stable ordering.
+func filteredSortedServices(list []ServiceRow, filter string, mode svcSortMode) []ServiceRow {
+	out := make([]ServiceRow, 0, len(list))
+	needle := strings.ToLower(strings.TrimSpace(filter))
+	for _, s := range list {
+		if needle != "" && !strings.Contains(strings.ToLower(s.Name), needle) {
+			continue
+		}
+		out = append(out, s)
+	}
+	switch mode {
+	case svcSortStatus:
+		sort.SliceStable(out, func(i, j int) bool {
+			return svcStatusRank(out[i]) < svcStatusRank(out[j])
+		})
+	case svcSortUsage:
+		sort.SliceStable(out, func(i, j int) bool {
+			if out[i].SiteCount != out[j].SiteCount {
+				return out[i].SiteCount > out[j].SiteCount
+			}
+			return out[i].Name < out[j].Name
+		})
+	default:
+		sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	}
+	return out
+}
+
+func svcStatusRank(s ServiceRow) int {
+	switch s.State {
+	case stateRunning:
+		return 0
+	case statePaused:
+		return 2
+	}
+	return 1
+}

--- a/internal/tui/filter_test.go
+++ b/internal/tui/filter_test.go
@@ -1,0 +1,124 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func sitesFixture() []siteinfo.EnrichedSite {
+	return []siteinfo.EnrichedSite{
+		{Name: "alpha", Domains: []string{"alpha.test"}, FrameworkLabel: "Laravel 11", FPMRunning: true},
+		{Name: "beta", Domains: []string{"beta.test", "beta-admin.test"}, FrameworkLabel: "Symfony 7", Paused: true},
+		{Name: "gamma", Domains: []string{"gamma.test"}, FrameworkLabel: "Laravel 11", FPMRunning: false},
+	}
+}
+
+func TestFilterSites_ByDomain(t *testing.T) {
+	got := filteredSortedSites(sitesFixture(), "admin", siteSortName)
+	if len(got) != 1 || got[0].Name != "beta" {
+		t.Fatalf("expected beta (matches beta-admin.test), got %+v", names(got))
+	}
+}
+
+func TestFilterSites_ByFrameworkLabel(t *testing.T) {
+	got := filteredSortedSites(sitesFixture(), "symfony", siteSortName)
+	if len(got) != 1 || got[0].Name != "beta" {
+		t.Fatalf("expected beta, got %+v", names(got))
+	}
+}
+
+func TestFilterSites_CaseInsensitive(t *testing.T) {
+	got := filteredSortedSites(sitesFixture(), "ALPHA", siteSortName)
+	if len(got) != 1 || got[0].Name != "alpha" {
+		t.Fatalf("filter should be case-insensitive, got %+v", names(got))
+	}
+}
+
+func TestSortSites_Framework(t *testing.T) {
+	got := filteredSortedSites(sitesFixture(), "", siteSortFramework)
+	// Laravel entries come before Symfony alphabetically.
+	if got[0].FrameworkLabel != "Laravel 11" || got[len(got)-1].FrameworkLabel != "Symfony 7" {
+		t.Fatalf("framework sort wrong: %+v", frameworkLabels(got))
+	}
+}
+
+func TestSortSites_StatusBuckets(t *testing.T) {
+	got := filteredSortedSites(sitesFixture(), "", siteSortStatus)
+	if got[0].Name != "alpha" {
+		t.Fatalf("running site should come first, got %s", got[0].Name)
+	}
+	if got[len(got)-1].Name != "beta" {
+		t.Fatalf("paused site should come last, got %s", got[len(got)-1].Name)
+	}
+}
+
+func servicesFixture() []ServiceRow {
+	return []ServiceRow{
+		{Name: "mysql", State: stateRunning, SiteCount: 3},
+		{Name: "redis", State: stateStopped, SiteCount: 1},
+		{Name: "mailpit", State: statePaused, SiteCount: 2},
+		{Name: "custom-x", State: stateRunning, SiteCount: 0, Custom: true},
+	}
+}
+
+func TestFilterServices_ByName(t *testing.T) {
+	got := filteredSortedServices(servicesFixture(), "redis", svcSortName)
+	if len(got) != 1 || got[0].Name != "redis" {
+		t.Fatalf("expected redis, got %+v", svcNames(got))
+	}
+}
+
+func TestSortServices_Usage(t *testing.T) {
+	got := filteredSortedServices(servicesFixture(), "", svcSortUsage)
+	// Highest site count first (mysql=3, mailpit=2, redis=1, custom-x=0).
+	if got[0].Name != "mysql" || got[3].Name != "custom-x" {
+		t.Fatalf("usage sort wrong: %+v", svcNames(got))
+	}
+}
+
+func TestSortServices_Status(t *testing.T) {
+	got := filteredSortedServices(servicesFixture(), "", svcSortStatus)
+	// Running bucket first, paused last.
+	if got[0].State != stateRunning {
+		t.Fatalf("running should sort first, got %v", got[0].State)
+	}
+	if got[len(got)-1].State != statePaused {
+		t.Fatalf("paused should sort last, got %v", got[len(got)-1].State)
+	}
+}
+
+func TestSortLabels(t *testing.T) {
+	cases := []struct {
+		mode  siteSortMode
+		label string
+	}{
+		{siteSortName, "name"},
+		{siteSortStatus, "status"},
+		{siteSortFramework, "framework"},
+	}
+	for _, c := range cases {
+		if got := c.mode.label(); got != c.label {
+			t.Errorf("site %d label=%q want %q", c.mode, got, c.label)
+		}
+	}
+	if svcSortUsage.label() != "usage" {
+		t.Error("usage label")
+	}
+}
+
+func frameworkLabels(ss []siteinfo.EnrichedSite) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = s.FrameworkLabel
+	}
+	return out
+}
+
+func svcNames(ss []ServiceRow) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = s.Name
+	}
+	return out
+}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -1,0 +1,97 @@
+package tui
+
+// helpSection groups related keybindings under a heading.
+type helpSection struct {
+	title string
+	rows  [][2]string // {key, description}
+}
+
+// helpReference is the canonical list of every keybinding in the TUI. It
+// lives here rather than inline in panes.go so a future keymap overhaul
+// (remappable keys, user-defined shortcuts) has one place to edit.
+var helpReference = []helpSection{
+	{
+		title: "Navigation",
+		rows: [][2]string{
+			{"tab / shift+tab", "cycle focus through Sites · Services · Detail"},
+			{"↑ ↓  j k", "move selection within the focused pane"},
+			{"pgup / pgdn", "jump by 10 rows"},
+			{"home / end · g G", "jump to first / last row"},
+		},
+	},
+	{
+		title: "Filter & sort",
+		rows: [][2]string{
+			{"/", "type to filter the focused list by name"},
+			{"  enter", "apply filter and leave input mode"},
+			{"  esc", "clear filter and leave input mode"},
+			{"o", "cycle sort order (name · status · …)"},
+		},
+	},
+	{
+		title: "Actions",
+		rows: [][2]string{
+			{"space / enter", "toggle the focused detail row (worker, HTTPS, LAN share, PHP, Node)"},
+			{"s", "start / unpause the focused site or start the focused service"},
+			{"x", "stop / pause the focused site or stop / remove the focused domain"},
+			{"r", "restart the focused site or service"},
+			{"p", "pause / unpause toggle for a site"},
+			{"t", "open an interactive shell inside the focused container"},
+		},
+	},
+	{
+		title: "Domains",
+		rows: [][2]string{
+			{"a", "add a new domain to the focused site (inline input)"},
+			{"e", "edit / rename the focused domain row (add new + remove old)"},
+			{"x", "remove the focused domain"},
+		},
+	},
+	{
+		title: "Logs",
+		rows: [][2]string{
+			{"l", "toggle the logs pane for the focused item"},
+			{"[ / ]", "cycle through the site's log sources (FPM, workers, app logs)"},
+		},
+	},
+	{
+		title: "Panes & overlays",
+		rows: [][2]string{
+			{"v", "show / hide the services pane"},
+			{"S", "swap the detail pane for global Settings (LAN expose, autostart, Xdebug)"},
+			{"?", "swap the detail pane for this help reference"},
+			{"esc", "close picker or return to site detail"},
+		},
+	},
+	{
+		title: "General",
+		rows: [][2]string{
+			{"R", "force a manual refresh"},
+			{"q / ctrl+c", "quit"},
+		},
+	},
+}
+
+// helpContentLines builds the lines drawn inside the detail pane when
+// detailMode == detailHelp. Same padding / clipping convention as the other
+// detail renderers so the border wraps cleanly.
+func helpContentLines(m *Model, innerW int) []string {
+	out := make([]string, 0, 64)
+	add := func(s string) { out = append(out, padToWidth(clipLine(s, innerW), innerW)) }
+
+	add(sectionStyle.Render("Keybindings"))
+	add(dimStyle.Render("  press ? or esc to return to site detail"))
+	add("")
+
+	for i, sec := range helpReference {
+		if i > 0 {
+			add("")
+		}
+		add(sectionStyle.Render(sec.title))
+		for _, row := range sec.rows {
+			key := padRight(truncatePlain(row[0], 18), 18)
+			add("  " + accentStyle.Render(key) + "  " + row[1])
+		}
+	}
+	return out
+}

--- a/internal/tui/lan.go
+++ b/internal/tui/lan.go
@@ -1,0 +1,79 @@
+package tui
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// The LAN IP lookup fires on every render when a site has LAN share on, so
+// we cache it for a few seconds. The underlying net.Dial trick is cheap but
+// re-running it every 100 ms of key input is wasteful when the routing
+// table almost never changes between frames.
+var lanIPCache struct {
+	sync.Mutex
+	value string
+	at    time.Time
+}
+
+const lanIPTTL = 5 * time.Second
+
+// primaryLANIP returns the host's primary outbound IPv4 address, or "" when
+// detection fails. Mirrors cli.detectPrimaryLANIP so the TUI and the web UI
+// agree on what URL the user should share — but kept local to avoid an
+// import cycle between internal/tui and internal/cli.
+func primaryLANIP() string {
+	lanIPCache.Lock()
+	defer lanIPCache.Unlock()
+	if lanIPCache.value != "" && time.Since(lanIPCache.at) < lanIPTTL {
+		return lanIPCache.value
+	}
+
+	if ip := dialProbeIP(); ip != "" {
+		lanIPCache.value = ip
+		lanIPCache.at = time.Now()
+		return ip
+	}
+	if ip := ifaceProbeIP(); ip != "" {
+		lanIPCache.value = ip
+		lanIPCache.at = time.Now()
+		return ip
+	}
+	return ""
+}
+
+func dialProbeIP() string {
+	conn, err := net.Dial("udp4", "1.1.1.1:80")
+	if err != nil {
+		return ""
+	}
+	defer conn.Close()
+	addr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok || addr == nil {
+		return ""
+	}
+	return addr.IP.String()
+}
+
+func ifaceProbeIP() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			ipnet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			if v4 := ipnet.IP.To4(); v4 != nil && !v4.IsLoopback() {
+				return v4.String()
+			}
+		}
+	}
+	return ""
+}

--- a/internal/tui/log_tail.go
+++ b/internal/tui/log_tail.go
@@ -1,0 +1,178 @@
+package tui
+
+import (
+	"bufio"
+	"context"
+	"os/exec"
+	"sync"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// LogKind picks between `podman logs` (containers), `journalctl --user`
+// (worker systemd units), and `tail -F` (framework app log files).
+// Workers don't run as containers so their output lives in the user
+// journal; sites and services do, and their history is richer when pulled
+// from podman; framework app logs (laravel.log, etc.) live on disk
+// because the framework writes them directly.
+type LogKind int
+
+const (
+	kindPodman LogKind = iota
+	kindJournal
+	kindFile
+)
+
+// LogTarget fully describes one tail-able source: what to tail, how to tail
+// it, and how to label it in the pane header.
+type LogTarget struct {
+	Kind  LogKind
+	ID    string
+	Label string
+}
+
+type logLineMsg struct {
+	source string
+	line   string
+}
+
+type logClosedMsg struct{ source string }
+
+// logTail runs at most one `podman logs -f` subprocess at a time. Switching
+// targets cancels the previous one and opens a fresh tail. A bounded ring
+// caps memory on chatty containers.
+type logTail struct {
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	target LogTarget
+	ch     chan string
+	lines  []string
+	max    int
+}
+
+func newLogTail() *logTail { return &logTail{max: 500} }
+
+// Start cancels any prior tail and spawns a fresh one for `target`.
+// The returned Cmd waits on the first line so Update can chain Follow().
+func (t *logTail) Start(target LogTarget) tea.Cmd {
+	t.mu.Lock()
+	if t.cancel != nil {
+		t.cancel()
+	}
+	t.lines = nil
+	t.target = target
+	ctx, cancel := context.WithCancel(context.Background())
+	t.cancel = cancel
+	ch := make(chan string, 64)
+	t.ch = ch
+	go t.run(ctx, target, ch)
+	t.mu.Unlock()
+	return t.readOne(target.ID, ch)
+}
+
+func (t *logTail) Stop() {
+	t.mu.Lock()
+	if t.cancel != nil {
+		t.cancel()
+		t.cancel = nil
+	}
+	t.target = LogTarget{}
+	t.ch = nil
+	t.mu.Unlock()
+}
+
+func (t *logTail) Lines() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]string, len(t.lines))
+	copy(out, t.lines)
+	return out
+}
+
+// Source returns the raw identifier of the active tail (container or unit
+// name). Used by Update to match incoming logLineMsgs against the current
+// target so stale reads from a just-cancelled tail are dropped on the floor.
+func (t *logTail) Source() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.target.ID
+}
+
+// Target returns the full active target for rendering the pane title.
+func (t *logTail) Target() LogTarget {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.target
+}
+
+func (t *logTail) append(line string) {
+	t.mu.Lock()
+	t.lines = append(t.lines, line)
+	if len(t.lines) > t.max {
+		t.lines = t.lines[len(t.lines)-t.max:]
+	}
+	t.mu.Unlock()
+}
+
+func (t *logTail) run(ctx context.Context, target LogTarget, ch chan<- string) {
+	defer close(ch)
+	var cmd *exec.Cmd
+	switch target.Kind {
+	case kindJournal:
+		cmd = exec.CommandContext(ctx, "journalctl", "--user", "-u", target.ID,
+			"-f", "--no-pager", "-n", "200", "--output=cat")
+	case kindFile:
+		// -F follows by name, re-opening if the file is rotated, which is
+		// what Laravel-style loggers do when they roll daily. -n 200 gives
+		// the same scrollback as the podman/journal variants.
+		cmd = exec.CommandContext(ctx, "tail", "-n", "200", "-F", target.ID)
+	default:
+		cmd = exec.CommandContext(ctx, podman.PodmanBin(), "logs", "-f", "--tail", "200", target.ID)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return
+	}
+	cmd.Stderr = cmd.Stdout
+	if err := cmd.Start(); err != nil {
+		return
+	}
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			return
+		case ch <- scanner.Text():
+		}
+	}
+	_ = cmd.Wait()
+}
+
+func (t *logTail) readOne(source string, ch <-chan string) tea.Cmd {
+	return func() tea.Msg {
+		line, ok := <-ch
+		if !ok {
+			return logClosedMsg{source: source}
+		}
+		t.append(line)
+		return logLineMsg{source: source, line: line}
+	}
+}
+
+// Follow returns a Cmd that reads the next line from the currently-active
+// tail. Returns nil when no tail is running.
+func (t *logTail) Follow() tea.Cmd {
+	t.mu.Lock()
+	source := t.target.ID
+	ch := t.ch
+	t.mu.Unlock()
+	if source == "" || ch == nil {
+		return nil
+	}
+	return t.readOne(source, ch)
+}

--- a/internal/tui/log_tail.go
+++ b/internal/tui/log_tail.go
@@ -120,8 +120,10 @@ func (t *logTail) run(ctx context.Context, target LogTarget, ch chan<- string) {
 	var cmd *exec.Cmd
 	switch target.Kind {
 	case kindJournal:
-		cmd = exec.CommandContext(ctx, "journalctl", "--user", "-u", target.ID,
-			"-f", "--no-pager", "-n", "200", "--output=cat")
+		// Worker log tail — platform-specific because workers are systemd
+		// user units on Linux (journalctl) but podman containers on macOS
+		// (podman logs). The ID is the same on both platforms (lerd-<kind>-<site>).
+		cmd = workerLogCmd(ctx, target.ID)
 	case kindFile:
 		// -F follows by name, re-opening if the file is rotated, which is
 		// what Laravel-style loggers do when they roll daily. -n 200 gives

--- a/internal/tui/log_tail_darwin.go
+++ b/internal/tui/log_tail_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package tui
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// workerLogCmd returns the command that tails a worker's output on macOS.
+// Workers on macOS run as detached podman containers (not systemd units),
+// so their logs come from `podman logs -f`, matching what lerd-ui's
+// logs_darwin.go does. The short-retry wrapper exists because workers
+// started from the TUI may not have fully materialised yet when `l` fires.
+func workerLogCmd(ctx context.Context, container string) *exec.Cmd {
+	bin := podman.PodmanBin()
+	script := `for i in $(seq 1 20); do ` + bin + ` container exists ` + container +
+		` 2>/dev/null && break; sleep 0.25; done; exec ` + bin + ` logs -f --tail 200 ` + container
+	return exec.CommandContext(ctx, "/bin/sh", "-c", script)
+}

--- a/internal/tui/log_tail_linux.go
+++ b/internal/tui/log_tail_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package tui
+
+import (
+	"context"
+	"os/exec"
+)
+
+// workerLogCmd returns the command that tails a worker's output on Linux.
+// Workers run as systemd user units, so their stdout/stderr are in the
+// user journal — `journalctl --user` is the right source, matching what
+// lerd-ui's logs_linux.go does.
+func workerLogCmd(ctx context.Context, unit string) *exec.Cmd {
+	return exec.CommandContext(ctx, "journalctl", "--user", "-u", unit,
+		"-f", "--no-pager", "-n", "200", "--output=cat")
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,0 +1,995 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/eventbus"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/siteinfo"
+	lerdUpdate "github.com/geodro/lerd/internal/update"
+)
+
+// focusPane identifies which pane currently owns keyboard focus. Detail sits
+// permanently in the right column below the services list, so it's always
+// reachable via tab cycling.
+type focusPane int
+
+const (
+	paneSites focusPane = iota
+	paneServices
+	paneDetail
+)
+
+// detailMode picks what the right-hand pane renders. Site detail is the
+// default; pressing S swaps it for settings and ? swaps it for the full
+// keybinding reference. Kept as a single pane, not a separate overlay,
+// so the user never leaves the main dashboard.
+type detailMode int
+
+const (
+	detailSite detailMode = iota
+	detailSettings
+	detailHelp
+)
+
+// Model is the bubbletea root. Panes are all projections of snap plus small
+// per-pane cursor/scroll state, so every refresh cycle rebuilds from a single
+// source of truth without stale data.
+type Model struct {
+	width, height int
+
+	snap Snapshot
+
+	detailMode detailMode
+	focus      focusPane
+
+	siteCursor int
+	siteScroll int
+	siteFilter string
+	siteSort   siteSortMode
+
+	svcCursor int
+	svcScroll int
+	svcFilter string
+	svcSort   svcSortMode
+
+	// Filter-input mode: when active, key runes go into the active filter
+	// instead of firing actions. Which pane is being filtered is determined
+	// by focus. Exited by esc or enter.
+	filterActive bool
+
+	detailCursor int // index into detail rows (workers + toggles)
+	settingsRow  int // index into settings rows
+	helpScroll   int // vertical scroll offset for the help view
+
+	// Picker state (PHP/Node version). When active, up/down navigates
+	// pickerOptions instead of detail rows and enter applies the pick.
+	pickerKind    detailKind
+	pickerOptions []string
+	pickerCursor  int
+
+	// Domain-input state: when active, typing adds characters to the
+	// pending domain name; enter runs `lerd domain add`, esc cancels.
+	// When domainInputEditing is non-empty, the input is editing that
+	// existing full domain — commit chains an add-new + remove-old.
+	domainInputActive  bool
+	domainInput        string
+	domainInputEditing string
+
+	showLogs     bool
+	hideServices bool
+	logTail      *logTail
+	logCursor    int // index into currentLogTargets() for the focused item
+
+	status       string
+	statusExpiry time.Time
+
+	sub     *eventbus.Subscriber
+	version string
+
+	// Latest version reported by the 24h-cached update check. Non-empty
+	// when a newer release is available; rendered as a banner in the
+	// header so users see it without running lerd status.
+	updateAvailable string
+}
+
+// NewModel builds an initial model. The caller is expected to call
+// podman.Cache.Start before running; NewModel itself is pure.
+func NewModel(version string) *Model {
+	return &Model{
+		width:   100,
+		height:  30,
+		logTail: newLogTail(),
+		sub:     eventbus.Default.Subscribe(),
+		version: version,
+	}
+}
+
+// Init implements tea.Model. Kicks off the first snapshot load, the refresh
+// ticker, the eventbus subscription, and a one-shot update check.
+func (m *Model) Init() tea.Cmd {
+	return tea.Batch(
+		loadCmd(),
+		tickCmd(2*time.Second),
+		busCmd(m.sub),
+		updateCheckCmd(m.version),
+	)
+}
+
+// updateCheckMsg carries the result of the cached update lookup back into
+// the model. Empty Latest means "on the latest version or check failed".
+type updateCheckMsg struct{ Latest string }
+
+// updateCheckCmd reads the 24h update cache (populated by lerd status /
+// lerd doctor). We don't fire a live GitHub request ourselves — if no
+// other command has run lately, the banner just stays hidden.
+func updateCheckCmd(current string) tea.Cmd {
+	return func() tea.Msg {
+		info, _ := lerdUpdate.CachedUpdateCheck(current)
+		if info == nil {
+			return updateCheckMsg{}
+		}
+		return updateCheckMsg{Latest: info.LatestVersion}
+	}
+}
+
+// Update implements tea.Model.
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+
+	case refreshMsg:
+		return m, loadCmd()
+
+	case snapshotMsg:
+		m.snap = msg.snap
+		m.clampCursors()
+		return m, tickCmd(2 * time.Second)
+
+	case ActionResult:
+		m.setStatus(formatAction(msg), 5*time.Second)
+		return m, loadCmd()
+
+	case logLineMsg:
+		if msg.source == m.logTail.Source() {
+			return m, m.logTail.Follow()
+		}
+		return m, nil
+
+	case logClosedMsg:
+		return m, nil
+
+	case updateCheckMsg:
+		m.updateAvailable = msg.Latest
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	return m.handleMainKey(msg)
+}
+
+func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.filterActive {
+		return m.handleFilterKey(msg)
+	}
+	if m.domainInputActive {
+		return m.handleDomainInputKey(msg)
+	}
+	switch msg.String() {
+	case "ctrl+c", "q":
+		m.logTail.Stop()
+		eventbus.Default.Unsubscribe(m.sub)
+		return m, tea.Quit
+
+	case "enter", " ":
+		if m.focus == paneDetail {
+			if m.pickerKind != kindInfo {
+				return m, m.applyPicker()
+			}
+			if m.detailMode == detailSettings {
+				return m, m.settingsToggle(m.settingsRows())
+			}
+			return m, m.detailToggleSelected(m.currentSite(), detailRows(m.currentSite()), navigableRows(detailRows(m.currentSite())))
+		}
+		return m, nil
+
+	case "esc":
+		if m.pickerKind != kindInfo {
+			m.closePicker()
+			return m, nil
+		}
+		if m.detailMode != detailSite {
+			m.detailMode = detailSite
+		}
+		return m, nil
+
+	case "S":
+		if m.detailMode == detailSettings {
+			m.detailMode = detailSite
+		} else {
+			m.detailMode = detailSettings
+			m.settingsRow = 0
+			// Jump focus into the detail pane so the user can move through
+			// settings immediately without a separate tab press. No-op when
+			// already focused there.
+			m.focus = paneDetail
+		}
+		return m, nil
+
+	case "?":
+		if m.detailMode == detailHelp {
+			m.detailMode = detailSite
+		} else {
+			m.detailMode = detailHelp
+			m.focus = paneDetail
+		}
+		return m, nil
+
+	case "tab":
+		m.focus = m.nextFocus(+1)
+		return m, m.syncLogs()
+
+	case "shift+tab":
+		m.focus = m.nextFocus(-1)
+		return m, m.syncLogs()
+
+	case "up", "k":
+		m.moveCursor(-1)
+		return m, m.syncLogs()
+
+	case "down", "j":
+		m.moveCursor(1)
+		return m, m.syncLogs()
+
+	case "pgup":
+		m.moveCursor(-10)
+		return m, m.syncLogs()
+
+	case "pgdown":
+		m.moveCursor(10)
+		return m, m.syncLogs()
+
+	case "home", "g":
+		m.setCursor(0)
+		return m, m.syncLogs()
+
+	case "end", "G":
+		m.setCursor(1 << 30)
+		return m, m.syncLogs()
+
+	case "l":
+		return m, m.toggleLogs()
+
+	case "t":
+		return m, m.actionShell()
+
+	case "v":
+		m.hideServices = !m.hideServices
+		if m.hideServices && m.focus == paneServices {
+			m.focus = paneSites
+		}
+		return m, nil
+
+	case "/":
+		if m.focus == paneSites || m.focus == paneServices {
+			m.filterActive = true
+		}
+		return m, nil
+
+	case "o":
+		switch m.focus {
+		case paneSites:
+			m.siteSort = (m.siteSort + 1) % 3
+			m.siteCursor = 0
+		case paneServices:
+			m.svcSort = (m.svcSort + 1) % 3
+			m.svcCursor = 0
+		}
+		return m, nil
+
+	case "[":
+		return m, m.cycleLogTarget(-1)
+
+	case "]":
+		return m, m.cycleLogTarget(1)
+
+	case "s":
+		return m, m.actionStart()
+
+	case "x":
+		if handled, cmd := m.removeFocusedDomain(); handled {
+			return m, cmd
+		}
+		return m, m.actionStop()
+
+	case "a":
+		if m.focus == paneDetail && m.detailMode == detailSite && m.currentSite() != nil {
+			m.openDomainInput()
+			return m, nil
+		}
+		return m, nil
+
+	case "e":
+		if m.editFocusedDomain() {
+			return m, nil
+		}
+		return m, nil
+
+	case "r":
+		return m, m.actionRestart()
+
+	case "p":
+		return m, m.actionPauseToggle()
+
+	case "R":
+		return m, loadCmd()
+	}
+	return m, nil
+}
+
+// openDomainInput switches into domain-input mode for adding a new domain.
+// Focus is pinned to paneDetail so the user sees the input next to the
+// domains list they were just looking at.
+func (m *Model) openDomainInput() {
+	m.domainInputActive = true
+	m.domainInput = ""
+	m.domainInputEditing = ""
+	m.focus = paneDetail
+}
+
+// openDomainEdit enters domain-input mode pre-filled with the short form
+// of `full`. On commit the handler runs add-new + remove-old as a sequence,
+// which gives rename semantics without a dedicated `lerd domain rename`
+// command.
+func (m *Model) openDomainEdit(full string) {
+	m.domainInputActive = true
+	m.domainInput = trimTLD(full)
+	m.domainInputEditing = full
+	m.focus = paneDetail
+}
+
+// editFocusedDomain is called from handleMainKey when `e` is pressed with
+// the detail cursor on a domain row. Returns false when the focus/row
+// doesn't match so other bindings keep working.
+func (m *Model) editFocusedDomain() (handled bool) {
+	if m.focus != paneDetail || m.detailMode != detailSite {
+		return false
+	}
+	s := m.currentSite()
+	if s == nil {
+		return false
+	}
+	rows := detailRows(s)
+	nav := navigableRows(rows)
+	if m.detailCursor >= len(nav) {
+		return false
+	}
+	row := rows[nav[m.detailCursor]]
+	if row.kind != kindDomain {
+		return false
+	}
+	m.openDomainEdit(row.domain)
+	return true
+}
+
+// handleDomainInputKey collects characters for the new domain, commits on
+// enter (running `lerd domain add <short>` from the site dir), cancels on
+// esc. Unlike filter input we're not narrowing a list in real time, so no
+// refresh is needed until the subprocess exits.
+func (m *Model) handleDomainInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.domainInputActive = false
+		m.domainInput = ""
+		m.domainInputEditing = ""
+		return m, nil
+	case "enter":
+		s := m.currentSite()
+		value := strings.TrimSpace(m.domainInput)
+		editing := m.domainInputEditing
+		m.domainInputActive = false
+		m.domainInput = ""
+		m.domainInputEditing = ""
+		if s == nil || value == "" {
+			return m, nil
+		}
+		value = strings.ToLower(strings.TrimSuffix(value, "."+currentTLD()))
+		if editing != "" {
+			// No-op if the user pressed enter without changing anything.
+			if value == trimTLD(editing) {
+				return m, nil
+			}
+			oldShort := trimTLD(editing)
+			m.setStatus("renaming "+editing+" → "+value+"…", 5*time.Second)
+			return m, tea.Sequence(
+				runLerd(s.Path, "domain", "add", value),
+				runLerd(s.Path, "domain", "remove", oldShort),
+			)
+		}
+		m.setStatus("adding domain "+value+"…", 5*time.Second)
+		return m, runLerd(s.Path, "domain", "add", value)
+	case "ctrl+c":
+		m.logTail.Stop()
+		return m, tea.Quit
+	case "backspace":
+		if len(m.domainInput) > 0 {
+			r := []rune(m.domainInput)
+			m.domainInput = string(r[:len(r)-1])
+		}
+	default:
+		if len(msg.Runes) > 0 {
+			m.domainInput += string(msg.Runes)
+		}
+	}
+	return m, nil
+}
+
+// handleFilterKey runs while the filter input is active. Typed runes are
+// appended to the filter for the currently focused pane; backspace removes
+// the last rune; enter and esc exit input mode (esc also clears the
+// filter). Actions, tab, navigation are all suppressed while filter mode
+// is active so the user can type freely.
+func (m *Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	target := m.filterTarget()
+	switch msg.String() {
+	case "esc":
+		*target = ""
+		m.filterActive = false
+		m.resetFilteredCursor()
+	case "enter":
+		m.filterActive = false
+	case "ctrl+c":
+		m.logTail.Stop()
+		return m, tea.Quit
+	case "backspace":
+		if len(*target) > 0 {
+			r := []rune(*target)
+			*target = string(r[:len(r)-1])
+			m.resetFilteredCursor()
+		}
+	default:
+		if len(msg.Runes) > 0 {
+			*target += string(msg.Runes)
+			m.resetFilteredCursor()
+		}
+	}
+	return m, nil
+}
+
+// filterTarget returns the pointer to the filter string for whichever list
+// is currently focused, so handleFilterKey doesn't have to branch on pane.
+func (m *Model) filterTarget() *string {
+	if m.focus == paneServices {
+		return &m.svcFilter
+	}
+	return &m.siteFilter
+}
+
+func (m *Model) resetFilteredCursor() {
+	if m.focus == paneServices {
+		m.svcCursor = 0
+		m.svcScroll = 0
+		return
+	}
+	m.siteCursor = 0
+	m.siteScroll = 0
+}
+
+// syncLogs retargets the log tail to match the currently-focused item
+// whenever the log pane is open. Called after every navigation or focus
+// change. Resets to the first target of the new selection; previous logCursor
+// doesn't transfer since target lists differ per item.
+func (m *Model) syncLogs() tea.Cmd {
+	if !m.showLogs {
+		return nil
+	}
+	targets := m.currentLogTargets()
+	if len(targets) == 0 {
+		m.logTail.Stop()
+		return nil
+	}
+	if m.logCursor >= len(targets) {
+		m.logCursor = 0
+	}
+	next := targets[m.logCursor]
+	if next.ID == m.logTail.Source() {
+		return nil
+	}
+	m.logCursor = 0
+	return m.logTail.Start(targets[0])
+}
+
+// nextFocus returns the focus after moving `dir` steps (±1) through the
+// list of panes that are currently visible and usable. Skips services when
+// hidden and skips detail when no site is selected.
+func (m *Model) nextFocus(dir int) focusPane {
+	panes := []focusPane{paneSites}
+	if !m.hideServices {
+		panes = append(panes, paneServices)
+	}
+	if m.currentSite() != nil {
+		panes = append(panes, paneDetail)
+	}
+	n := len(panes)
+	if n == 0 {
+		return m.focus
+	}
+	idx := 0
+	for i, p := range panes {
+		if p == m.focus {
+			idx = i
+			break
+		}
+	}
+	idx = ((idx+dir)%n + n) % n
+	return panes[idx]
+}
+
+func (m *Model) moveCursor(delta int) {
+	switch m.focus {
+	case paneSites:
+		m.siteCursor = clamp(m.siteCursor+delta, 0, max(0, len(m.visibleSites())-1))
+		m.closePicker()
+	case paneServices:
+		m.svcCursor = clamp(m.svcCursor+delta, 0, max(0, len(m.visibleServices())-1))
+	case paneDetail:
+		if m.pickerKind != kindInfo {
+			n := len(m.pickerOptions)
+			if n == 0 {
+				return
+			}
+			m.pickerCursor = clamp(m.pickerCursor+delta, 0, n-1)
+			return
+		}
+		switch m.detailMode {
+		case detailSettings:
+			rows := m.settingsRows()
+			m.settingsRow = clamp(m.settingsRow+delta, 0, max(0, len(rows)-1))
+		case detailHelp:
+			m.helpScroll += delta
+			if m.helpScroll < 0 {
+				m.helpScroll = 0
+			}
+		default:
+			if s := m.currentSite(); s != nil {
+				nav := navigableRows(detailRows(s))
+				m.detailCursor = clamp(m.detailCursor+delta, 0, max(0, len(nav)-1))
+			}
+		}
+	}
+}
+
+func (m *Model) setCursor(pos int) {
+	switch m.focus {
+	case paneSites:
+		m.siteCursor = clamp(pos, 0, max(0, len(m.visibleSites())-1))
+	case paneServices:
+		m.svcCursor = clamp(pos, 0, max(0, len(m.visibleServices())-1))
+	}
+}
+
+func (m *Model) clampCursors() {
+	m.siteCursor = clamp(m.siteCursor, 0, max(0, len(m.visibleSites())-1))
+	m.svcCursor = clamp(m.svcCursor, 0, max(0, len(m.visibleServices())-1))
+}
+
+// visibleSites is the view-ready sites list: m.snap.Sites with the active
+// filter and sort applied. Every renderer and cursor lookup goes through
+// this so filtered-out rows are invisible to navigation, not just hidden
+// visually.
+func (m *Model) visibleSites() []siteinfo.EnrichedSite {
+	return filteredSortedSites(m.snap.Sites, m.siteFilter, m.siteSort)
+}
+
+func (m *Model) visibleServices() []ServiceRow {
+	return filteredSortedServices(m.snap.Services, m.svcFilter, m.svcSort)
+}
+
+func (m *Model) setStatus(s string, d time.Duration) {
+	m.status = s
+	m.statusExpiry = time.Now().Add(d)
+}
+
+func (m *Model) toggleLogs() tea.Cmd {
+	if m.showLogs {
+		m.logTail.Stop()
+		m.showLogs = false
+		return nil
+	}
+	targets := m.currentLogTargets()
+	if len(targets) == 0 {
+		m.setStatus("no log source for selected item", 3*time.Second)
+		return nil
+	}
+	m.showLogs = true
+	m.logCursor = 0
+	return m.logTail.Start(targets[0])
+}
+
+// cycleLogTarget steps through the available log sources for the currently
+// focused item (FPM → queue → schedule → …). No-op when the log pane is
+// closed or the item has only one source.
+func (m *Model) cycleLogTarget(delta int) tea.Cmd {
+	if !m.showLogs {
+		return nil
+	}
+	targets := m.currentLogTargets()
+	if len(targets) <= 1 {
+		return nil
+	}
+	n := len(targets)
+	m.logCursor = ((m.logCursor+delta)%n + n) % n
+	return m.logTail.Start(targets[m.logCursor])
+}
+
+// currentLogTargets returns every log source the user can switch between for
+// the focused item. Sites expose their FPM/custom container plus a target
+// per running-or-defined worker (each worker is a systemd user unit tailed
+// via journalctl --user). Services have just the one container.
+func (m *Model) currentLogTargets() []LogTarget {
+	switch m.focus {
+	case paneSites, paneDetail:
+		s := m.currentSite()
+		if s == nil {
+			return nil
+		}
+		return logTargetsForSite(s)
+	case paneServices:
+		svc := m.currentService()
+		if svc == nil {
+			return nil
+		}
+		if svc.WorkerKind != "" {
+			// Worker-backed services run as systemd user units; tail the
+			// journal, matching lerd-ui's handleQueueLogs / handleHorizonLogs.
+			return []LogTarget{{
+				Kind:  kindJournal,
+				ID:    "lerd-" + svc.WorkerKind + "-" + svc.WorkerSite,
+				Label: svc.WorkerKind + " · " + svc.WorkerSite,
+			}}
+		}
+		return []LogTarget{{Kind: kindPodman, ID: "lerd-" + svc.Name, Label: svc.Name}}
+	}
+	return nil
+}
+
+func logTargetsForSite(s *siteinfo.EnrichedSite) []LogTarget {
+	var out []LogTarget
+	if s.ContainerPort > 0 {
+		out = append(out, LogTarget{
+			Kind:  kindPodman,
+			ID:    podman.CustomContainerName(s.Name),
+			Label: s.Name + " · container",
+		})
+	} else if s.PHPVersion != "" {
+		out = append(out, LogTarget{
+			Kind:  kindPodman,
+			ID:    "lerd-php" + strings.ReplaceAll(s.PHPVersion, ".", "") + "-fpm",
+			Label: s.Name + " · fpm " + s.PHPVersion,
+		})
+	}
+
+	addUnit := func(present bool, unitSuffix, label string) {
+		if !present {
+			return
+		}
+		out = append(out, LogTarget{
+			Kind:  kindJournal,
+			ID:    "lerd-" + unitSuffix + "-" + s.Name,
+			Label: s.Name + " · " + label,
+		})
+	}
+	addUnit(s.HasQueueWorker, "queue", "queue")
+	addUnit(s.HasScheduleWorker, "schedule", "schedule")
+	addUnit(s.HasReverb, "reverb", "reverb")
+	addUnit(s.HasHorizon, "horizon", "horizon")
+	for _, fw := range s.FrameworkWorkers {
+		label := fw.Label
+		if label == "" {
+			label = fw.Name
+		}
+		out = append(out, LogTarget{
+			Kind:  kindJournal,
+			ID:    "lerd-" + fw.Name + "-" + s.Name,
+			Label: s.Name + " · " + label,
+		})
+	}
+	for _, path := range appLogPathsForSite(s) {
+		out = append(out, LogTarget{
+			Kind:  kindFile,
+			ID:    path,
+			Label: s.Name + " · " + filepath.Base(path),
+		})
+	}
+	return out
+}
+
+// appLogPathsForSite expands the framework's log-source globs against the
+// site's project directory, returning absolute paths. Mirrors the web UI's
+// app-logs endpoint: for Laravel that's storage/logs/*.log, other
+// frameworks get whatever they declare in their definition.
+func appLogPathsForSite(s *siteinfo.EnrichedSite) []string {
+	fw, ok := config.GetFrameworkForDir(s.FrameworkName, s.Path)
+	if !ok || fw == nil || len(fw.Logs) == 0 {
+		return nil
+	}
+	absProject, err := filepath.Abs(s.Path)
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var paths []string
+	for _, src := range fw.Logs {
+		matches, err := filepath.Glob(filepath.Join(absProject, src.Path))
+		if err != nil {
+			continue
+		}
+		for _, m := range matches {
+			abs, err := filepath.Abs(m)
+			if err != nil || !strings.HasPrefix(abs, absProject+string(filepath.Separator)) {
+				continue
+			}
+			if seen[abs] {
+				continue
+			}
+			if info, err := os.Stat(abs); err != nil || info.IsDir() {
+				continue
+			}
+			seen[abs] = true
+			paths = append(paths, abs)
+		}
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func (m *Model) currentSite() *siteinfo.EnrichedSite {
+	sites := m.visibleSites()
+	if m.siteCursor >= 0 && m.siteCursor < len(sites) {
+		return &sites[m.siteCursor]
+	}
+	return nil
+}
+
+func (m *Model) currentService() *ServiceRow {
+	svcs := m.visibleServices()
+	if m.svcCursor >= 0 && m.svcCursor < len(svcs) {
+		return &svcs[m.svcCursor]
+	}
+	return nil
+}
+
+func (m *Model) actionStart() tea.Cmd {
+	switch m.focus {
+	case paneSites, paneDetail:
+		if s := m.currentSite(); s != nil {
+			m.setStatus("starting "+s.Name+"…", 5*time.Second)
+			return runLerd(s.Path, "unpause", s.Name)
+		}
+	case paneServices:
+		if svc := m.currentService(); svc != nil {
+			if cmd := m.workerActionCmd(svc, "start"); cmd != nil {
+				return cmd
+			}
+			m.setStatus("starting "+svc.Name+"…", 5*time.Second)
+			return runLerd("", "service", "start", svc.Name)
+		}
+	}
+	return nil
+}
+
+// workerActionCmd returns a tea.Cmd for start/stop/restart on a worker-
+// backed service row. Returns nil for regular service rows so the caller
+// can fall through to `lerd service <verb>`.
+func (m *Model) workerActionCmd(svc *ServiceRow, verb string) tea.Cmd {
+	if svc.WorkerKind == "" || svc.WorkerPath == "" {
+		return nil
+	}
+	m.setStatus(verb+"ing "+svc.WorkerKind+" worker for "+svc.WorkerSite+"…", 5*time.Second)
+	switch svc.WorkerKind {
+	case "queue", "schedule", "horizon", "reverb":
+		if verb == "restart" {
+			// Worker restart = stop + start via systemd; we use the unit
+			// directly because `lerd queue restart` doesn't exist as a
+			// CLI verb on every worker. Two sequenced lerd invocations
+			// keep us inside the public CLI.
+			return tea.Sequence(
+				runLerd(svc.WorkerPath, svc.WorkerKind, "stop"),
+				runLerd(svc.WorkerPath, svc.WorkerKind, "start"),
+			)
+		}
+		return runLerd(svc.WorkerPath, svc.WorkerKind, verb)
+	default:
+		if verb == "restart" {
+			return tea.Sequence(
+				runLerd(svc.WorkerPath, "worker", "stop", svc.WorkerKind),
+				runLerd(svc.WorkerPath, "worker", "start", svc.WorkerKind),
+			)
+		}
+		return runLerd(svc.WorkerPath, "worker", verb, svc.WorkerKind)
+	}
+}
+
+func (m *Model) actionStop() tea.Cmd {
+	switch m.focus {
+	case paneSites, paneDetail:
+		if s := m.currentSite(); s != nil {
+			m.setStatus("pausing "+s.Name+"…", 5*time.Second)
+			return runLerd(s.Path, "pause", s.Name)
+		}
+	case paneServices:
+		if svc := m.currentService(); svc != nil {
+			if cmd := m.workerActionCmd(svc, "stop"); cmd != nil {
+				return cmd
+			}
+			m.setStatus("stopping "+svc.Name+"…", 5*time.Second)
+			return runLerd("", "service", "stop", svc.Name)
+		}
+	}
+	return nil
+}
+
+func (m *Model) actionRestart() tea.Cmd {
+	switch m.focus {
+	case paneSites, paneDetail:
+		if s := m.currentSite(); s != nil {
+			m.setStatus("restarting "+s.Name+"…", 5*time.Second)
+			return runLerd(s.Path, "restart", s.Name)
+		}
+	case paneServices:
+		if svc := m.currentService(); svc != nil {
+			if cmd := m.workerActionCmd(svc, "restart"); cmd != nil {
+				return cmd
+			}
+			m.setStatus("restarting "+svc.Name+"…", 5*time.Second)
+			return runLerd("", "service", "restart", svc.Name)
+		}
+	}
+	return nil
+}
+
+// actionShell opens an interactive shell inside the container that backs
+// whatever's currently focused: FPM / custom container for a site, the
+// service's own container for a service. Setting the working dir to the
+// site's project path means PHP tools (composer, artisan) run as if the
+// user had cd'd into the project first.
+func (m *Model) actionShell() tea.Cmd {
+	switch m.focus {
+	case paneSites, paneDetail:
+		s := m.currentSite()
+		if s == nil {
+			return nil
+		}
+		container := containerForSite(s)
+		if container == "" {
+			m.setStatus("no container to shell into for "+s.Name, 3*time.Second)
+			return nil
+		}
+		if running, _ := podman.ContainerRunning(container); !running {
+			m.setStatus(container+" is not running — start the site first", 4*time.Second)
+			return nil
+		}
+		return runShellIn(container, s.Path)
+	case paneServices:
+		svc := m.currentService()
+		if svc == nil {
+			return nil
+		}
+		if svc.WorkerKind != "" {
+			// Worker rows have no container of their own — they run inside
+			// the owning site's FPM container. Find that site and shell in
+			// there, which is what the user wants when they hit t on e.g.
+			// queue-astrolov.
+			site := m.siteByName(svc.WorkerSite)
+			if site == nil {
+				m.setStatus("owner site "+svc.WorkerSite+" not loaded", 3*time.Second)
+				return nil
+			}
+			container := containerForSite(site)
+			if container == "" {
+				m.setStatus("no container for "+svc.WorkerSite, 3*time.Second)
+				return nil
+			}
+			if running, _ := podman.ContainerRunning(container); !running {
+				m.setStatus(container+" is not running", 4*time.Second)
+				return nil
+			}
+			return runShellIn(container, site.Path)
+		}
+		container := "lerd-" + svc.Name
+		if running, _ := podman.ContainerRunning(container); !running {
+			m.setStatus(container+" is not running", 4*time.Second)
+			return nil
+		}
+		return runShellIn(container, "")
+	}
+	return nil
+}
+
+// siteByName returns the enriched site in the current snapshot with the
+// given name, or nil. Used by worker-service rows that need to reach back
+// to their owning site's container and path.
+func (m *Model) siteByName(name string) *siteinfo.EnrichedSite {
+	for i := range m.snap.Sites {
+		if m.snap.Sites[i].Name == name {
+			return &m.snap.Sites[i]
+		}
+	}
+	return nil
+}
+
+func (m *Model) actionPauseToggle() tea.Cmd {
+	if m.focus != paneSites && m.focus != paneDetail {
+		return nil
+	}
+	s := m.currentSite()
+	if s == nil {
+		return nil
+	}
+	if s.Paused {
+		m.setStatus("resuming "+s.Name+"…", 5*time.Second)
+		return runLerd(s.Path, "unpause", s.Name)
+	}
+	m.setStatus("pausing "+s.Name+"…", 5*time.Second)
+	return runLerd(s.Path, "pause", s.Name)
+}
+
+// Run starts the bubbletea program with the shared podman cache warmed up.
+// Called from cli.NewTuiCmd so the wiring lives next to the rest of the
+// command registry.
+func Run(version string) error {
+	podman.Cache.Start(context.Background())
+	m := NewModel(version)
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	_, err := p.Run()
+	return err
+}
+
+func formatAction(r ActionResult) string {
+	if r.Err != nil {
+		detail := r.Detail
+		if detail == "" {
+			detail = r.Err.Error()
+		}
+		detail = firstLine(detail)
+		return fmt.Sprintf("✖ %s: %s", r.Summary, detail)
+	}
+	return "✓ " + r.Summary
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+func clamp(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// ensure lipgloss is referenced so keeping it as a named import above doesn't
+// trip the linter if the render code moves around.
+var _ = lipgloss.NewStyle

--- a/internal/tui/model_extra_test.go
+++ b/internal/tui/model_extra_test.go
@@ -1,0 +1,232 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func TestNextFocus_SkipsServicesWhenHidden(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.hideServices = true
+	m.focus = paneSites
+
+	got := m.nextFocus(+1)
+	if got != paneDetail {
+		t.Fatalf("hideServices + tab should skip to detail, got %d", got)
+	}
+}
+
+func TestNextFocus_NoSitesSkipsDetail(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{
+		Services: []ServiceRow{{Name: "mysql", State: stateRunning}},
+	}
+	m.focus = paneServices
+	got := m.nextFocus(+1)
+	if got != paneSites {
+		t.Fatalf("without sites, tab from services should wrap to sites (skipping detail), got %d", got)
+	}
+}
+
+func TestClampCursors_ClampsToVisibleCount(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.siteCursor = 5
+	m.svcCursor = 9
+	m.clampCursors()
+	if m.siteCursor >= len(m.visibleSites()) {
+		t.Fatalf("siteCursor %d out of bounds (len=%d)", m.siteCursor, len(m.visibleSites()))
+	}
+	if m.svcCursor >= len(m.visibleServices()) {
+		t.Fatalf("svcCursor %d out of bounds (len=%d)", m.svcCursor, len(m.visibleServices()))
+	}
+}
+
+func TestFilterInput_CollectsRunes(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.focus = paneSites
+	m.filterActive = true
+
+	for _, r := range "be" {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = next.(*Model)
+	}
+	if m.siteFilter != "be" {
+		t.Fatalf("expected filter 'be', got %q", m.siteFilter)
+	}
+	// Backspace drops one rune.
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = next.(*Model)
+	if m.siteFilter != "b" {
+		t.Fatalf("expected filter 'b' after backspace, got %q", m.siteFilter)
+	}
+	// Esc clears and exits input mode.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	m = next.(*Model)
+	if m.siteFilter != "" || m.filterActive {
+		t.Fatalf("esc should clear filter and leave input, got filter=%q active=%v", m.siteFilter, m.filterActive)
+	}
+}
+
+func TestDetailMode_SToggleSetsFocus(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.focus = paneSites
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'S'}})
+	m = next.(*Model)
+	if m.detailMode != detailSettings {
+		t.Fatalf("S should enter settings mode, got %d", m.detailMode)
+	}
+	if m.focus != paneDetail {
+		t.Fatalf("S should move focus to detail, got %d", m.focus)
+	}
+	// S again → back to site
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'S'}})
+	m = next.(*Model)
+	if m.detailMode != detailSite {
+		t.Fatalf("second S should return to site detail, got %d", m.detailMode)
+	}
+}
+
+func TestDetailMode_HelpToggle(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	m = next.(*Model)
+	if m.detailMode != detailHelp {
+		t.Fatalf("? should enter help mode, got %d", m.detailMode)
+	}
+	// Esc returns to site detail.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	m = next.(*Model)
+	if m.detailMode != detailSite {
+		t.Fatalf("esc should return to site detail, got %d", m.detailMode)
+	}
+}
+
+func TestHideServicesToggle(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.focus = paneServices
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+	m = next.(*Model)
+	if !m.hideServices {
+		t.Fatalf("v should hide services")
+	}
+	if m.focus == paneServices {
+		t.Fatalf("focus should move off hidden pane, got %d", m.focus)
+	}
+}
+
+func TestViewRendersUnderSettingsMode(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.width, m.height = 150, 40
+	m.detailMode = detailSettings
+	out := m.View()
+	if !strings.Contains(out, "Settings") {
+		t.Fatalf("settings view should include 'Settings' header, got:\n%s", out)
+	}
+}
+
+func TestViewRendersUnderHelpMode(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.width, m.height = 150, 50
+	m.detailMode = detailHelp
+	out := m.View()
+	if !strings.Contains(out, "Keybindings") {
+		t.Fatalf("help view should include 'Keybindings' header")
+	}
+}
+
+func TestDomainInput_CommitRunsLerdAdd(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{
+		Sites: []siteinfo.EnrichedSite{{Name: "alpha", Path: "/x", Domains: []string{"alpha.test"}}},
+	}
+	m.focus = paneDetail
+	m.openDomainInput()
+	for _, r := range "newdomain" {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = next.(*Model)
+	}
+	if m.domainInput != "newdomain" {
+		t.Fatalf("expected pending domain 'newdomain', got %q", m.domainInput)
+	}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(*Model)
+	if cmd == nil {
+		t.Fatalf("enter should return a Cmd")
+	}
+	if m.domainInputActive {
+		t.Fatalf("input should be closed after commit")
+	}
+}
+
+func TestDomainInput_EscCancels(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{
+		Sites: []siteinfo.EnrichedSite{{Name: "alpha", Path: "/x", Domains: []string{"alpha.test"}}},
+	}
+	m.openDomainInput()
+	m.domainInput = "partial"
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	m = next.(*Model)
+	if m.domainInputActive || m.domainInput != "" {
+		t.Fatalf("esc should clear input, got active=%v value=%q", m.domainInputActive, m.domainInput)
+	}
+}
+
+func TestOpenDomainEdit_PrefillsShortName(t *testing.T) {
+	m := NewModel("test")
+	m.openDomainEdit("staging.alpha.test")
+	if !strings.Contains(m.domainInput, "staging.alpha") && m.domainInput != "staging.alpha" {
+		t.Fatalf("edit should prefill short form, got %q", m.domainInput)
+	}
+	if m.domainInputEditing != "staging.alpha.test" {
+		t.Fatalf("editing target not stored, got %q", m.domainInputEditing)
+	}
+}
+
+func TestClosePicker(t *testing.T) {
+	m := NewModel("test")
+	m.pickerKind = kindPHP
+	m.pickerOptions = []string{"8.3", "8.4"}
+	m.pickerCursor = 1
+	m.closePicker()
+	if m.pickerKind != kindInfo || m.pickerOptions != nil || m.pickerCursor != 0 {
+		t.Fatalf("closePicker should reset state, got %+v", m)
+	}
+}
+
+func TestWorkerActionCmd_BuiltinWorker(t *testing.T) {
+	m := NewModel("test")
+	svc := &ServiceRow{
+		Name: "queue-alpha", WorkerKind: "queue", WorkerSite: "alpha", WorkerPath: "/x",
+	}
+	if cmd := m.workerActionCmd(svc, "start"); cmd == nil {
+		t.Fatalf("should return a Cmd for a worker row")
+	}
+	// Non-worker service rows get nil so callers fall through.
+	plain := &ServiceRow{Name: "mysql"}
+	if cmd := m.workerActionCmd(plain, "start"); cmd != nil {
+		t.Fatalf("plain services should return nil (fallthrough)")
+	}
+}
+
+func TestSiteByName(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	if s := m.siteByName("alpha"); s == nil || s.Name != "alpha" {
+		t.Fatalf("siteByName(alpha) failed: %+v", s)
+	}
+	if s := m.siteByName("missing"); s != nil {
+		t.Fatalf("siteByName(missing) should be nil")
+	}
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,0 +1,217 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func fakeSnap() Snapshot {
+	return Snapshot{
+		Sites: []siteinfo.EnrichedSite{
+			{Name: "alpha", PHPVersion: "8.3", FPMRunning: true, HasQueueWorker: true, QueueRunning: true},
+			{Name: "beta", PHPVersion: "8.2", FPMRunning: false, Paused: true},
+		},
+		Services: []ServiceRow{
+			{Name: "mysql", State: stateRunning, SiteCount: 2},
+			{Name: "redis", State: stateStopped, SiteCount: 1},
+			{Name: "mailpit", State: statePaused, SiteCount: 0},
+		},
+		Status: StatusRow{
+			TLD: "test", NginxRunning: true, DNSOk: true,
+			PHPRunning: []string{"8.3"},
+		},
+	}
+}
+
+func TestMoveCursor_Sites_Bounds(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.focus = paneSites
+
+	m.moveCursor(1)
+	if m.siteCursor != 1 {
+		t.Fatalf("expected cursor 1, got %d", m.siteCursor)
+	}
+	m.moveCursor(5)
+	if m.siteCursor != 1 {
+		t.Fatalf("cursor should clamp at last site (1), got %d", m.siteCursor)
+	}
+	m.moveCursor(-99)
+	if m.siteCursor != 0 {
+		t.Fatalf("cursor should clamp at 0, got %d", m.siteCursor)
+	}
+}
+
+func TestMoveCursor_Services_Bounds(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.focus = paneServices
+
+	m.moveCursor(2)
+	if m.svcCursor != 2 {
+		t.Fatalf("expected cursor 2, got %d", m.svcCursor)
+	}
+	m.moveCursor(99)
+	if m.svcCursor != 2 {
+		t.Fatalf("cursor should clamp at 2, got %d", m.svcCursor)
+	}
+}
+
+func TestTabCyclesFocus(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	if m.focus != paneSites {
+		t.Fatalf("initial focus should be sites, got %d", m.focus)
+	}
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(*Model)
+	if m.focus != paneServices {
+		t.Fatalf("tab should move focus to services, got %d", m.focus)
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(*Model)
+	if m.focus != paneDetail {
+		t.Fatalf("second tab should move focus to detail, got %d", m.focus)
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(*Model)
+	if m.focus != paneSites {
+		t.Fatalf("third tab should return focus to sites, got %d", m.focus)
+	}
+}
+
+func TestTabSkipsDetailWhenNoSite(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{
+		Services: []ServiceRow{{Name: "mysql", State: stateRunning}},
+	}
+	m.focus = paneServices
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(*Model)
+	if m.focus != paneSites {
+		t.Fatalf("tab with no sites should skip detail and wrap to sites, got %d", m.focus)
+	}
+}
+
+func TestSnapshotMsgClampsCursor(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.focus = paneSites
+	m.siteCursor = 1
+
+	shrunk := fakeSnap()
+	shrunk.Sites = shrunk.Sites[:1]
+
+	next, _ := m.Update(snapshotMsg{snap: shrunk})
+	m = next.(*Model)
+	if m.siteCursor != 0 {
+		t.Fatalf("cursor should clamp when snapshot shrinks, got %d", m.siteCursor)
+	}
+}
+
+func TestViewRendersCoreContent(t *testing.T) {
+	m := NewModel("v1.0.0")
+	m.snap = fakeSnap()
+	m.width, m.height = 120, 30
+
+	out := m.View()
+	for _, want := range []string{"Sites", "Services", "alpha", "beta", "mysql", "redis"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("view missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestViewTooSmall(t *testing.T) {
+	m := NewModel("v1.0.0")
+	m.snap = fakeSnap()
+	m.width, m.height = 40, 10
+	out := m.View()
+	if !strings.Contains(out, "too small") {
+		t.Fatalf("expected too-small banner, got: %s", out)
+	}
+}
+
+func TestCurrentSiteAndService(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+
+	if m.currentSite().Name != "alpha" {
+		t.Fatal("expected alpha at cursor 0")
+	}
+	m.siteCursor = 1
+	if m.currentSite().Name != "beta" {
+		t.Fatal("expected beta at cursor 1")
+	}
+
+	// Services render sorted by name by default, so the first row is mailpit,
+	// not mysql (the snapshot insertion order).
+	if m.currentService().Name != "mailpit" {
+		t.Fatalf("expected mailpit at cursor 0 (name sort), got %s", m.currentService().Name)
+	}
+}
+
+func TestFilterNarrowsSitesList(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.siteFilter = "bet"
+	visible := m.visibleSites()
+	if len(visible) != 1 || visible[0].Name != "beta" {
+		t.Fatalf("expected filter 'bet' to keep only beta, got %+v", names(visible))
+	}
+}
+
+func TestSortSitesByStatusRunningFirst(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.siteSort = siteSortStatus
+	got := m.visibleSites()
+	if got[0].Name != "alpha" {
+		t.Fatalf("expected running site (alpha) first under status sort, got %s", got[0].Name)
+	}
+}
+
+func names(ss []siteinfo.EnrichedSite) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = s.Name
+	}
+	return out
+}
+
+func TestFormatActionOK(t *testing.T) {
+	got := formatAction(ActionResult{Summary: "lerd service start redis"})
+	if !strings.HasPrefix(got, "✓") {
+		t.Fatalf("expected ok prefix, got %q", got)
+	}
+}
+
+func TestFormatActionError(t *testing.T) {
+	got := formatAction(ActionResult{
+		Summary: "lerd service start redis",
+		Err:     errors.New("exit 1"),
+		Detail:  "boom\ntrace",
+	})
+	if !strings.Contains(got, "boom") || strings.Contains(got, "trace") {
+		t.Fatalf("expected first-line error only, got %q", got)
+	}
+}
+
+func TestViewportScrollsToKeepCursorVisible(t *testing.T) {
+	rows := make([]string, 20)
+	for i := range rows {
+		rows[i] = "row"
+	}
+	scroll := 0
+	visible := viewport(rows, 15, 5, &scroll)
+	if len(visible) != 5 {
+		t.Fatalf("expected 5 visible rows, got %d", len(visible))
+	}
+	if scroll != 11 {
+		t.Fatalf("expected scroll=11 to keep cursor visible, got %d", scroll)
+	}
+}

--- a/internal/tui/panes.go
+++ b/internal/tui/panes.go
@@ -1,0 +1,610 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// View implements tea.Model.
+func (m *Model) View() string {
+	if m.width < 60 || m.height < 12 {
+		return "terminal too small (need at least 60×12)\n"
+	}
+
+	header := m.renderHeader()
+	footer := m.renderFooter()
+	statusBar := m.renderStatus()
+
+	reserved := lipgloss.Height(header) + lipgloss.Height(footer)
+	if statusBar != "" {
+		reserved += lipgloss.Height(statusBar)
+	}
+	bodyH := m.height - reserved
+	if bodyH < 6 {
+		bodyH = 6
+	}
+
+	// Logs pane gets at least half the full window when open. Clamp so the
+	// top lists always keep at least 6 rows to stay useful.
+	logH := 0
+	if m.showLogs {
+		logH = m.height / 2
+		if half := bodyH / 2; logH < half {
+			logH = half
+		}
+		if logH < 10 {
+			logH = 10
+		}
+		if logH > bodyH-6 {
+			logH = bodyH - 6
+		}
+	}
+	topH := bodyH - logH
+	if topH < 6 {
+		topH = 6
+	}
+
+	// Left column stacks sites on top of services; right column is the
+	// site detail (full topH). When services is hidden, sites takes the
+	// whole left column.
+	leftW := m.width * 2 / 5
+	if leftW < 36 {
+		leftW = 36
+	}
+	if leftW > m.width-30 {
+		leftW = m.width - 30
+	}
+	rightW := m.width - leftW
+
+	var left string
+	if m.hideServices {
+		left = m.renderSites(leftW, topH)
+	} else {
+		svcNeeded := len(m.snap.Services) + 3
+		if svcNeeded < 6 {
+			svcNeeded = 6
+		}
+		svcH := svcNeeded
+		if lim := topH / 2; svcH > lim {
+			svcH = lim
+		}
+		if svcH > topH-6 {
+			svcH = topH - 6
+		}
+		if svcH < 4 {
+			svcH = 4
+		}
+		siteH := topH - svcH
+		sites := m.renderSites(leftW, siteH)
+		services := m.renderServices(leftW, svcH)
+		left = lipgloss.JoinVertical(lipgloss.Left, sites, services)
+	}
+	detail := m.renderDetailInline(rightW, topH, m.focus == paneDetail)
+	top := lipgloss.JoinHorizontal(lipgloss.Top, left, detail)
+
+	sections := []string{header, top}
+	if m.showLogs {
+		sections = append(sections, m.renderLogs(m.width, logH))
+	}
+	if statusBar != "" {
+		sections = append(sections, statusBar)
+	}
+	sections = append(sections, footer)
+
+	return lipgloss.JoinVertical(lipgloss.Left, sections...)
+}
+
+func (m *Model) renderHeader() string {
+	parts := []string{titleStyle.Render("lerd " + m.version)}
+
+	if m.updateAvailable != "" {
+		parts = append(parts, accentStyle.Render("update: "+m.updateAvailable+" (run `lerd update`)"))
+	}
+
+	if m.snap.Status.DNSOk {
+		parts = append(parts, runningStyle.Render("DNS ok"))
+	} else {
+		parts = append(parts, failingStyle.Render("DNS down"))
+	}
+
+	if m.snap.Status.NginxRunning {
+		parts = append(parts, runningStyle.Render("nginx up"))
+	} else {
+		parts = append(parts, stoppedStyle.Render("nginx down"))
+	}
+
+	if len(m.snap.Status.PHPRunning) > 0 {
+		parts = append(parts, accentStyle.Render("FPM "+strings.Join(m.snap.Status.PHPRunning, ",")))
+	}
+
+	if m.snap.Status.WatcherRunning {
+		parts = append(parts, dimStyle.Render("watcher"))
+	}
+
+	parts = append(parts, dimStyle.Render(time.Now().Format("15:04:05")))
+
+	return strings.Join(parts, "  ·  ")
+}
+
+func (m *Model) renderFooter() string {
+	if m.filterActive {
+		return helpStyle.Render("  filter: type to match · enter apply · esc clear")
+	}
+	keys := []string{
+		"tab panes",
+		"↑↓ nav",
+		"space toggle",
+		"/ filter",
+		"o sort",
+		"s start",
+		"x stop",
+		"r restart",
+		"l logs",
+		"t shell",
+		"v services",
+		"S settings",
+		"? help",
+		"q quit",
+	}
+	return helpStyle.Render("  " + strings.Join(keys, "   "))
+}
+
+func (m *Model) renderStatus() string {
+	if m.status == "" {
+		return ""
+	}
+	if !m.statusExpiry.IsZero() && time.Now().After(m.statusExpiry) {
+		m.status = ""
+		return ""
+	}
+	return helpStyle.Render("  " + m.status)
+}
+
+func (m *Model) renderSites(w, h int) string {
+	style := paneStyle(m.focus == paneSites)
+	innerW, innerH := innerSize(style, w, h)
+
+	sites := m.visibleSites()
+	total := len(m.snap.Sites)
+	title := fmt.Sprintf("Sites (%d/%d · sort: %s)", len(sites), total, m.siteSort.label())
+	lines := []string{padToWidth(clipLine(sectionStyle.Render(title), innerW), innerW)}
+
+	// Filter bar appears as a second header row whenever the user has
+	// entered any filter text or is currently typing. Keeps the active
+	// filter visible at a glance and distinguishes "empty list because no
+	// matches" from "empty list because nothing was linked yet".
+	activeFilter := m.focus == paneSites && m.filterActive
+	if activeFilter || m.siteFilter != "" {
+		lines = append(lines, padToWidth(filterBar(m.siteFilter, activeFilter), innerW))
+	}
+
+	availRows := innerH - len(lines)
+	if availRows < 1 {
+		availRows = 1
+	}
+
+	switch {
+	case total == 0:
+		lines = append(lines, padToWidth(dimStyle.Render("no linked sites"), innerW))
+	case len(sites) == 0:
+		lines = append(lines, padToWidth(dimStyle.Render("no sites match filter"), innerW))
+	default:
+		rows := make([]string, 0, len(sites))
+		for i, s := range sites {
+			row := renderSiteRow(i == m.siteCursor && m.focus == paneSites, s, innerW)
+			rows = append(rows, padToWidth(clipLine(row, innerW), innerW))
+		}
+		visible := viewport(rows, m.siteCursor, availRows, &m.siteScroll)
+		lines = append(lines, visible...)
+	}
+	for len(lines) < innerH {
+		lines = append(lines, spaces(innerW))
+	}
+
+	return style.Render(strings.Join(lines, "\n"))
+}
+
+// siteWorkerColWidth is the fixed display-width reservation for the worker
+// glyphs column in the sites list. Needs to be consistent across rows for
+// the PHP column (which sits to the left of it) to align cleanly.
+// 12 cells fits the typical worst case: q·s·v·h·m·m (6 glyphs + 5 spaces).
+const siteWorkerColWidth = 12
+
+func renderSiteRow(selected bool, s siteinfo.EnrichedSite, paneW int) string {
+	glyph := fpmGlyph(s)
+	workers := workerGlyphs(s)
+
+	// Display the primary domain (the URL users actually visit) rather than
+	// the internal site registry name — the name is still used for command
+	// dispatch and filtering, it just isn't what shows up in the list.
+	name := s.PrimaryDomain()
+	if name == "" {
+		name = s.Name
+	}
+	if s.Paused {
+		name += " (paused)"
+	}
+
+	php := s.PHPVersion
+	if php == "" && s.ContainerPort > 0 {
+		php = "custom"
+	}
+
+	// Reserve the SAME budget on every row so PHP and worker columns line
+	// up vertically, regardless of which workers a site happens to run.
+	// The previous version subtracted workersW per row, which left empty-
+	// worker rows with a wider name column and shifted PHP leftward.
+	reserved := 4 /* prefix + glyph + spaces */ + 7 /* php %-7s */ + 1 + siteWorkerColWidth
+	nameW := paneW - reserved
+	if nameW < 16 {
+		nameW = 16
+	}
+	name = padRight(truncatePlain(name, nameW), nameW)
+
+	prefix := " "
+	if selected {
+		prefix = accentStyle.Render("▸")
+	}
+
+	styled := name
+	switch {
+	case s.Paused:
+		styled = pausedStyle.Render(name)
+	case selected:
+		styled = selectedStyle.Render(name)
+	}
+
+	return fmt.Sprintf("%s %s %s %-7s %s", prefix, glyph, styled, php, padToWidth(workers, siteWorkerColWidth))
+}
+
+func fpmGlyph(s siteinfo.EnrichedSite) string {
+	if s.Paused {
+		return pausedStyle.Render(glyphPaused)
+	}
+	if s.FPMRunning {
+		return runningStyle.Render(glyphRunning)
+	}
+	return stoppedStyle.Render(glyphStopped)
+}
+
+func workerGlyphs(s siteinfo.EnrichedSite) string {
+	var out []string
+	add := func(has, running, failing bool, label string) {
+		if !has {
+			return
+		}
+		switch {
+		case failing:
+			out = append(out, failingStyle.Render(label))
+		case running:
+			out = append(out, runningStyle.Render(label))
+		default:
+			out = append(out, stoppedStyle.Render(label))
+		}
+	}
+	add(s.HasQueueWorker, s.QueueRunning, s.QueueFailing, "q")
+	add(s.HasScheduleWorker, s.ScheduleRunning, s.ScheduleFailing, "s")
+	add(s.HasReverb, s.ReverbRunning, s.ReverbFailing, "v")
+	add(s.HasHorizon, s.HorizonRunning, s.HorizonFailing, "h")
+	for _, fw := range s.FrameworkWorkers {
+		add(true, fw.Running, fw.Failing, "•")
+	}
+	return strings.Join(out, " ")
+}
+
+func (m *Model) renderServices(w, h int) string {
+	style := paneStyle(m.focus == paneServices)
+	innerW, innerH := innerSize(style, w, h)
+
+	services := m.visibleServices()
+	total := len(m.snap.Services)
+	title := fmt.Sprintf("Services (%d/%d · sort: %s)", len(services), total, m.svcSort.label())
+	lines := []string{padToWidth(clipLine(sectionStyle.Render(title), innerW), innerW)}
+
+	activeFilter := m.focus == paneServices && m.filterActive
+	if activeFilter || m.svcFilter != "" {
+		lines = append(lines, padToWidth(filterBar(m.svcFilter, activeFilter), innerW))
+	}
+
+	availRows := innerH - len(lines)
+	if availRows < 1 {
+		availRows = 1
+	}
+
+	switch {
+	case total == 0:
+		lines = append(lines, padToWidth(dimStyle.Render("no services configured"), innerW))
+	case len(services) == 0:
+		lines = append(lines, padToWidth(dimStyle.Render("no services match filter"), innerW))
+	default:
+		rows := make([]string, 0, len(services))
+		for i, s := range services {
+			row := renderServiceRow(i == m.svcCursor && m.focus == paneServices, s, innerW)
+			rows = append(rows, padToWidth(clipLine(row, innerW), innerW))
+		}
+		visible := viewport(rows, m.svcCursor, availRows, &m.svcScroll)
+		lines = append(lines, visible...)
+	}
+	for len(lines) < innerH {
+		lines = append(lines, spaces(innerW))
+	}
+
+	return style.Render(strings.Join(lines, "\n"))
+}
+
+// filterBar renders the single-line filter chrome shown above the list:
+// "filter: <text>▌" while typing, "filter: <text>" otherwise. Kept
+// unstyled-plain so the caller can pad it reliably to the pane width.
+func filterBar(text string, active bool) string {
+	label := dimStyle.Render("  filter: ")
+	if active {
+		return label + text + "▌"
+	}
+	if text == "" {
+		return ""
+	}
+	return label + text
+}
+
+// serviceMetaColWidth is the fixed budget for the trailing meta column
+// (site count + pinned/custom tags). Reserved identically on every row so
+// the meta column starts at the same column regardless of which tags are
+// present, mirroring the aligned layout in the sites pane.
+const serviceMetaColWidth = 22
+
+func renderServiceRow(selected bool, s ServiceRow, paneW int) string {
+	var glyph string
+	switch s.State {
+	case stateRunning:
+		glyph = runningStyle.Render(glyphRunning)
+	case statePaused:
+		glyph = pausedStyle.Render(glyphPaused)
+	default:
+		glyph = stoppedStyle.Render(glyphStopped)
+	}
+
+	meta := fmt.Sprintf("(%d site%s)", s.SiteCount, plural(s.SiteCount))
+	if s.Pinned {
+		meta += "  " + accentStyle.Render("pinned")
+	}
+	if s.Custom {
+		meta += "  " + dimStyle.Render("custom")
+	}
+
+	reserved := 5 /* two prefix spaces + glyph + spaces */ + serviceMetaColWidth + 1
+	nameW := paneW - reserved
+	if nameW < 14 {
+		nameW = 14
+	}
+	name := padRight(truncatePlain(s.Name, nameW), nameW)
+	styledName := name
+	if selected {
+		styledName = selectedStyle.Render(name)
+	}
+
+	prefix := " "
+	if selected {
+		prefix = accentStyle.Render("▸")
+	}
+	return fmt.Sprintf(" %s %s %s %s", prefix, glyph, styledName, padToWidth(meta, serviceMetaColWidth))
+}
+
+func (m *Model) renderLogs(w, h int) string {
+	style := unfocusedPane
+	innerW, innerH := innerSize(style, w, h)
+
+	target := m.logTail.Target()
+	label := target.Label
+	if label == "" {
+		label = target.ID
+	}
+	title := fmt.Sprintf("Logs · %s", label)
+	if n := len(m.currentLogTargets()); n > 1 {
+		title += fmt.Sprintf("   [%d/%d · [ ] to switch]", m.logCursor+1, n)
+	}
+
+	availRows := innerH - 1
+	if availRows < 1 {
+		availRows = 1
+	}
+
+	all := m.logTail.Lines()
+	total := len(all)
+
+	// Reserve the rightmost column for the scrollbar. Log lines go in
+	// contentW; scrollbar gets 1 cell. lipgloss.Width() is skipped here
+	// because it treats horizontal padding as part of the width budget,
+	// which makes our already-innerW-wide lines wrap to an extra row.
+	contentW := innerW - 1
+	if contentW < 10 {
+		contentW = innerW
+	}
+
+	var visible []string
+	start := 0
+	if total > 0 {
+		if total > availRows {
+			start = total - availRows
+		}
+		visible = all[start:]
+	}
+
+	body := make([]string, 0, availRows)
+	for _, ln := range visible {
+		body = append(body, clipLine(ln, contentW))
+	}
+	if total == 0 {
+		body = append(body, clipLine(dimStyle.Render("waiting for output…"), contentW))
+	}
+	for len(body) < availRows {
+		body = append(body, "")
+	}
+
+	bar := renderScrollbar(availRows, total, start, len(visible))
+
+	lines := make([]string, 0, availRows+1)
+	lines = append(lines, padToWidth(clipLine(sectionStyle.Render(title), innerW), innerW))
+	for i := 0; i < availRows; i++ {
+		lines = append(lines, padToWidth(body[i], contentW)+bar[i])
+	}
+
+	return style.Render(strings.Join(lines, "\n"))
+}
+
+// padToWidth right-pads an ANSI-aware string with spaces to `w` display
+// cells. Used instead of Go's `%-*s` (which counts bytes) or
+// lipgloss.Style.Width (which treats padding as part of the block width
+// and causes lines to wrap when we want them to sit flush with the border).
+func padToWidth(s string, w int) string {
+	n := ansi.StringWidth(s)
+	if n >= w {
+		return s
+	}
+	return s + spaces(w-n)
+}
+
+// clipLine truncates s to display width w without slicing through an ANSI
+// escape or a multi-byte rune. Uses ansi.Truncate so styled log output is
+// preserved even when the line is too wide for the pane.
+func clipLine(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	if ansi.StringWidth(s) <= w {
+		return s
+	}
+	return ansi.Truncate(s, w, "…")
+}
+
+// renderScrollbar returns a slice of height strings (one per content row)
+// drawing a vertical scrollbar for a virtual list of `total` items where
+// `visible` items starting at `start` are on-screen. Each entry is a
+// single-cell string so the caller appends it to the rightmost column.
+func renderScrollbar(height, total, start, visible int) []string {
+	out := make([]string, height)
+	if height <= 0 {
+		return out
+	}
+	if total <= visible || total == 0 {
+		for i := range out {
+			out[i] = dimStyle.Render("│")
+		}
+		return out
+	}
+	thumbSize := height * visible / total
+	if thumbSize < 1 {
+		thumbSize = 1
+	}
+	if thumbSize > height {
+		thumbSize = height
+	}
+	// Track position proportionally: thumbStart ∈ [0, height-thumbSize].
+	maxStart := total - visible
+	thumbStart := 0
+	if maxStart > 0 {
+		thumbStart = start * (height - thumbSize) / maxStart
+	}
+	for i := 0; i < height; i++ {
+		if i >= thumbStart && i < thumbStart+thumbSize {
+			out[i] = accentStyle.Render("█")
+		} else {
+			out[i] = dimStyle.Render("│")
+		}
+	}
+	return out
+}
+
+func paneStyle(focused bool) lipgloss.Style {
+	if focused {
+		return focusedPane
+	}
+	return unfocusedPane
+}
+
+func innerSize(style lipgloss.Style, w, h int) (int, int) {
+	hf := style.GetHorizontalFrameSize()
+	vf := style.GetVerticalFrameSize()
+	return max(1, w-hf), max(1, h-vf)
+}
+
+// viewport returns the slice of rows that fit in `height`, scrolled so the
+// cursor stays visible. scroll is updated in place so the pane remembers
+// where it was between frames.
+func viewport(rows []string, cursor, height int, scroll *int) []string {
+	if height <= 0 || len(rows) == 0 {
+		return nil
+	}
+	if cursor < *scroll {
+		*scroll = cursor
+	}
+	if cursor >= *scroll+height {
+		*scroll = cursor - height + 1
+	}
+	if *scroll < 0 {
+		*scroll = 0
+	}
+	end := *scroll + height
+	if end > len(rows) {
+		end = len(rows)
+	}
+	return rows[*scroll:end]
+}
+
+func truncate(s string, w int) string {
+	if w <= 0 || len(s) <= w {
+		return s
+	}
+	if w <= 1 {
+		return "…"
+	}
+	return s[:w-1] + "…"
+}
+
+// truncatePlain truncates a rune string by display length without slicing
+// through a multi-byte rune. Only safe on unstyled text; never pass ANSI-
+// wrapped strings here since escape bytes would count against the budget.
+func truncatePlain(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= w {
+		return s
+	}
+	if w == 1 {
+		return "…"
+	}
+	return string(r[:w-1]) + "…"
+}
+
+// padRight right-pads s with spaces to display width w (rune-counted, unstyled).
+func padRight(s string, w int) string {
+	n := len([]rune(s))
+	if n >= w {
+		return s
+	}
+	return s + spaces(w-n)
+}
+
+func spaces(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = ' '
+	}
+	return string(b)
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/internal/tui/panes_test.go
+++ b/internal/tui/panes_test.go
@@ -1,0 +1,116 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func TestPadToWidth_PadsShort(t *testing.T) {
+	got := padToWidth("hi", 6)
+	if ansi.StringWidth(got) != 6 {
+		t.Fatalf("expected width 6, got %d (%q)", ansi.StringWidth(got), got)
+	}
+}
+
+func TestPadToWidth_NoOpWhenLongEnough(t *testing.T) {
+	got := padToWidth("already long", 4)
+	if got != "already long" {
+		t.Fatalf("expected unchanged, got %q", got)
+	}
+}
+
+func TestClipLine_TruncatesByDisplayWidth(t *testing.T) {
+	got := clipLine("hello world", 5)
+	if w := ansi.StringWidth(got); w > 5 {
+		t.Fatalf("clip exceeded width %d: %q", w, got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("truncated string should end with …: %q", got)
+	}
+}
+
+func TestClipLine_NoOpWhenShort(t *testing.T) {
+	got := clipLine("hi", 20)
+	if got != "hi" {
+		t.Fatalf("expected unchanged, got %q", got)
+	}
+}
+
+func TestTruncatePlain_RuneAware(t *testing.T) {
+	// ü and é are multi-byte UTF-8 runes; must not slice mid-byte.
+	got := truncatePlain("résümé-extra", 6)
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("expected truncation marker, got %q", got)
+	}
+	if len([]rune(got)) != 6 {
+		t.Fatalf("expected 6 runes, got %d (%q)", len([]rune(got)), got)
+	}
+}
+
+func TestPadRight_UsesRuneCount(t *testing.T) {
+	got := padRight("é", 3)
+	if len([]rune(got)) != 3 {
+		t.Fatalf("expected 3 runes, got %d (%q)", len([]rune(got)), got)
+	}
+}
+
+func TestRenderSiteRow_AlignsPHPColumn(t *testing.T) {
+	// Two sites with different worker load should produce rows where the
+	// PHP column starts at the same visual column — the bug that prompted
+	// siteWorkerColWidth. We can't easily measure visual column directly,
+	// but we can assert that the two rows have the same display width.
+	s1 := siteinfo.EnrichedSite{Name: "a", PHPVersion: "8.3", HasQueueWorker: true, QueueRunning: true}
+	s2 := siteinfo.EnrichedSite{Name: "b", PHPVersion: "8.3"}
+	r1 := renderSiteRow(false, s1, 60)
+	r2 := renderSiteRow(false, s2, 60)
+	if w1, w2 := ansi.StringWidth(r1), ansi.StringWidth(r2); w1 != w2 {
+		t.Fatalf("rows of equal pane width should have equal display width, got %d vs %d", w1, w2)
+	}
+}
+
+func TestRenderServiceRow_AlignsMetaColumn(t *testing.T) {
+	s1 := ServiceRow{Name: "mysql", State: stateRunning, SiteCount: 2, Pinned: true}
+	s2 := ServiceRow{Name: "redis", State: stateStopped, SiteCount: 1}
+	r1 := renderServiceRow(false, s1, 60)
+	r2 := renderServiceRow(false, s2, 60)
+	if w1, w2 := ansi.StringWidth(r1), ansi.StringWidth(r2); w1 != w2 {
+		t.Fatalf("service rows of equal pane width should have equal display width, got %d vs %d", w1, w2)
+	}
+}
+
+func TestFilterBar_ActiveShowsCursor(t *testing.T) {
+	got := filterBar("beta", true)
+	if !strings.HasSuffix(got, "▌") {
+		t.Fatalf("active filter bar should end with cursor, got %q", got)
+	}
+}
+
+func TestFilterBar_InactiveEmpty(t *testing.T) {
+	if got := filterBar("", false); got != "" {
+		t.Fatalf("empty inactive filter bar should render nothing, got %q", got)
+	}
+}
+
+func TestViewport_ShowsWindowedRows(t *testing.T) {
+	rows := []string{"a", "b", "c", "d", "e", "f"}
+	scroll := 0
+	got := viewport(rows, 2, 3, &scroll)
+	want := []string{"a", "b", "c"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("row %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestViewport_ScrollsDownAsCursorAdvances(t *testing.T) {
+	rows := []string{"a", "b", "c", "d", "e"}
+	scroll := 0
+	viewport(rows, 4, 2, &scroll)
+	if scroll != 3 {
+		t.Fatalf("scroll should advance to keep cursor visible, got %d", scroll)
+	}
+}

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -1,0 +1,118 @@
+package tui
+
+import (
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/config"
+	phpPkg "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// openPHPPicker loads installed PHP versions and enters picker mode on the
+// detail pane. A no-op when no versions are installed.
+func (m *Model) openPHPPicker(s *siteinfo.EnrichedSite) {
+	versions, err := phpPkg.ListInstalled()
+	if err != nil || len(versions) == 0 {
+		m.setStatus("no PHP versions installed", 3*time.Second)
+		return
+	}
+	m.pickerKind = kindPHP
+	m.pickerOptions = versions
+	m.pickerCursor = indexOf(versions, s.PHPVersion)
+}
+
+// openNodePicker shells out to fnm (same path lerd-ui uses) because node
+// version management is fnm's job; lerd doesn't keep its own registry.
+// A no-op when fnm reports nothing.
+func (m *Model) openNodePicker(s *siteinfo.EnrichedSite) {
+	versions := listNodeMajors()
+	if len(versions) == 0 {
+		m.setStatus("no Node versions installed (run 'lerd node install 20')", 3*time.Second)
+		return
+	}
+	m.pickerKind = kindNode
+	m.pickerOptions = versions
+	m.pickerCursor = indexOf(versions, s.NodeVersion)
+}
+
+// closePicker exits picker mode without applying a choice.
+func (m *Model) closePicker() {
+	m.pickerKind = kindInfo
+	m.pickerOptions = nil
+	m.pickerCursor = 0
+}
+
+// applyPicker runs `lerd isolate` or `lerd isolate:node` for the selected
+// version, then closes the picker. Refresh will land shortly via the regular
+// ActionResult → loadCmd path.
+func (m *Model) applyPicker() tea.Cmd {
+	if m.pickerKind == kindInfo || len(m.pickerOptions) == 0 {
+		return nil
+	}
+	s := m.currentSite()
+	if s == nil {
+		m.closePicker()
+		return nil
+	}
+	if m.pickerCursor >= len(m.pickerOptions) {
+		m.pickerCursor = len(m.pickerOptions) - 1
+	}
+	ver := m.pickerOptions[m.pickerCursor]
+	kind := m.pickerKind
+	m.closePicker()
+
+	switch kind {
+	case kindPHP:
+		m.setStatus("switching "+s.Name+" to PHP "+ver+"…", 5*time.Second)
+		return runLerd(s.Path, "isolate", ver)
+	case kindNode:
+		m.setStatus("switching "+s.Name+" to Node "+ver+"…", 5*time.Second)
+		return runLerd(s.Path, "isolate:node", ver)
+	}
+	return nil
+}
+
+// listNodeMajors returns the installed Node major versions as reported by
+// fnm. Mirrors ui.handleNodeVersions so the picker sees the same list the
+// web UI dropdown shows.
+func listNodeMajors() []string {
+	fnm := config.BinDir() + "/fnm"
+	out, err := exec.Command(fnm, "list").Output()
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var versions []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "* "))
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		v := strings.TrimPrefix(fields[0], "v")
+		if v == "" {
+			continue
+		}
+		major := strings.SplitN(v, ".", 2)[0]
+		if seen[major] || strings.Trim(major, "0123456789") != "" {
+			continue
+		}
+		seen[major] = true
+		versions = append(versions, major)
+	}
+	sort.Strings(versions)
+	return versions
+}
+
+func indexOf(ss []string, target string) int {
+	for i, s := range ss {
+		if s == target {
+			return i
+		}
+	}
+	return 0
+}

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -1,0 +1,89 @@
+package tui
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/config"
+	phpPkg "github.com/geodro/lerd/internal/php"
+	lerdSystemd "github.com/geodro/lerd/internal/systemd"
+)
+
+// settingsRow describes one focusable line in the settings view.
+type settingsRow struct {
+	kind       settingsKind
+	label      string
+	on         bool
+	phpVersion string // PHP version, for xdebug rows
+}
+
+type settingsKind int
+
+const (
+	settingsLANExpose settingsKind = iota
+	settingsAutostart
+	settingsXdebug
+)
+
+func (m *Model) settingsRows() []settingsRow {
+	cfg, _ := config.LoadGlobal()
+	var rows []settingsRow
+
+	lanExposed := cfg != nil && cfg.LAN.Exposed
+	rows = append(rows, settingsRow{
+		kind:  settingsLANExpose,
+		label: "LAN expose (open every service to the local network)",
+		on:    lanExposed,
+	})
+	rows = append(rows, settingsRow{
+		kind:  settingsAutostart,
+		label: "Autostart lerd on login",
+		on:    lerdSystemd.IsAutostartEnabled(),
+	})
+
+	if versions, err := phpPkg.ListInstalled(); err == nil {
+		for _, v := range versions {
+			rows = append(rows, settingsRow{
+				kind:       settingsXdebug,
+				label:      "Xdebug · PHP " + v,
+				on:         cfg != nil && cfg.IsXdebugEnabled(v),
+				phpVersion: v,
+			})
+		}
+	}
+	return rows
+}
+
+func (m *Model) settingsToggle(rows []settingsRow) tea.Cmd {
+	if len(rows) == 0 {
+		return nil
+	}
+	if m.settingsRow >= len(rows) {
+		m.settingsRow = len(rows) - 1
+	}
+	row := rows[m.settingsRow]
+	switch row.kind {
+	case settingsLANExpose:
+		verb := "on"
+		if row.on {
+			verb = "off"
+		}
+		m.setStatus("toggling LAN expose "+verb+"…", 5*time.Second)
+		return runLerd("", "lan", "expose", verb)
+	case settingsAutostart:
+		sub := "enable"
+		if row.on {
+			sub = "disable"
+		}
+		m.setStatus("autostart "+sub+"…", 5*time.Second)
+		return runLerd("", "autostart", sub)
+	case settingsXdebug:
+		verb := "on"
+		if row.on {
+			verb = "off"
+		}
+		m.setStatus("xdebug "+verb+" PHP "+row.phpVersion+"…", 5*time.Second)
+		return runLerd("", "xdebug", verb, row.phpVersion)
+	}
+	return nil
+}

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -1,0 +1,190 @@
+package tui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/dns"
+	phpPkg "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// Snapshot is the full view-model the TUI renders from. Produced by
+// loadSnapshot from the same sources lerd-ui uses, so every pane reflects the
+// same point-in-time state.
+type Snapshot struct {
+	Sites    []siteinfo.EnrichedSite
+	Services []ServiceRow
+	Status   StatusRow
+}
+
+// ServiceRow is a flat row for the services pane. Sourced from podman unit
+// status and service config so the TUI doesn't need to reach into ui/server.go.
+// For site-owned workers (queue, schedule, horizon, reverb, custom framework
+// workers) WorkerSite / WorkerKind are set so actions can run the right
+// per-site command instead of `lerd service start/stop` which would fail.
+type ServiceRow struct {
+	Name      string
+	State     ServiceState
+	Custom    bool
+	Pinned    bool
+	SiteCount int
+	Dashboard string
+	DependsOn []string
+
+	WorkerSite string
+	WorkerKind string
+	WorkerPath string
+}
+
+// ServiceState is a tri-state the TUI uses to pick a glyph and colour.
+type ServiceState int
+
+const (
+	stateStopped ServiceState = iota
+	stateRunning
+	statePaused
+)
+
+// StatusRow drives the top header bar.
+type StatusRow struct {
+	DNSOk          bool
+	TLD            string
+	NginxRunning   bool
+	WatcherRunning bool
+	PHPRunning     []string
+	Version        string
+}
+
+// loadSnapshot collects everything the TUI needs in one shot. Called on every
+// refresh tick and on every eventbus publish.
+func loadSnapshot() Snapshot {
+	snap := Snapshot{}
+
+	enriched, err := siteinfo.LoadAll(siteinfo.EnrichUI)
+	if err == nil {
+		_ = siteinfo.PersistVersionChanges(enriched)
+		sort.Slice(enriched, func(i, j int) bool { return enriched[i].Name < enriched[j].Name })
+		snap.Sites = enriched
+	}
+
+	snap.Services = loadServices()
+	// Workers live on sites but belong in the services pane too — same
+	// operational surface lerd-ui surfaces as "active" rows for queue,
+	// schedule, etc. Append them after the shared services so the user
+	// sees the full running-units picture in one list.
+	snap.Services = append(snap.Services, workerRows(snap.Sites)...)
+	snap.Status = loadStatus()
+	return snap
+}
+
+// workerRows synthesises one ServiceRow per active / defined worker across
+// every enriched site. Naming matches the web UI (`queue-<site>`, etc.) so
+// users moving between surfaces see familiar identifiers.
+func workerRows(sites []siteinfo.EnrichedSite) []ServiceRow {
+	var out []ServiceRow
+	add := func(site siteinfo.EnrichedSite, kind string, running, failing bool) {
+		state := stateStopped
+		if failing {
+			state = stateStopped
+		} else if running {
+			state = stateRunning
+		}
+		out = append(out, ServiceRow{
+			Name:       kind + "-" + site.Name,
+			State:      state,
+			WorkerSite: site.Name,
+			WorkerKind: kind,
+			WorkerPath: site.Path,
+			SiteCount:  1,
+		})
+	}
+	for _, s := range sites {
+		if s.HasQueueWorker {
+			add(s, "queue", s.QueueRunning, s.QueueFailing)
+		}
+		if s.HasScheduleWorker {
+			add(s, "schedule", s.ScheduleRunning, s.ScheduleFailing)
+		}
+		if s.HasHorizon {
+			add(s, "horizon", s.HorizonRunning, s.HorizonFailing)
+		}
+		if s.HasReverb {
+			add(s, "reverb", s.ReverbRunning, s.ReverbFailing)
+		}
+		for _, fw := range s.FrameworkWorkers {
+			switch fw.Name {
+			case "queue", "schedule", "horizon", "reverb":
+				continue
+			}
+			add(s, fw.Name, fw.Running, fw.Failing)
+		}
+	}
+	return out
+}
+
+func loadServices() []ServiceRow {
+	rows := make([]ServiceRow, 0, 16)
+	for _, name := range siteinfo.KnownServices {
+		rows = append(rows, buildServiceRow(name, false))
+	}
+	customs, _ := config.ListCustomServices()
+	for _, svc := range customs {
+		r := buildServiceRow(svc.Name, true)
+		r.DependsOn = svc.DependsOn
+		r.Dashboard = svc.Dashboard
+		rows = append(rows, r)
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Name < rows[j].Name })
+	return rows
+}
+
+func buildServiceRow(name string, custom bool) ServiceRow {
+	unit := "lerd-" + name
+	status, _ := podman.UnitStatus(unit)
+	state := stateStopped
+	switch status {
+	case "active", "activating":
+		state = stateRunning
+	}
+	if config.ServiceIsPaused(name) {
+		state = statePaused
+	}
+	return ServiceRow{
+		Name:      name,
+		State:     state,
+		Custom:    custom,
+		Pinned:    config.ServiceIsPinned(name),
+		SiteCount: config.CountSitesUsingService(name),
+	}
+}
+
+func loadStatus() StatusRow {
+	cfg, _ := config.LoadGlobal()
+	tld := "test"
+	if cfg != nil {
+		tld = cfg.DNS.TLD
+	}
+	dnsOK, _ := dns.Check(tld)
+	row := StatusRow{
+		TLD:          tld,
+		DNSOk:        dnsOK,
+		NginxRunning: podman.Cache.Running("lerd-nginx"),
+	}
+
+	if versions, err := phpPkg.ListInstalled(); err == nil {
+		for _, v := range versions {
+			short := strings.ReplaceAll(v, ".", "")
+			if podman.Cache.Running("lerd-php" + short + "-fpm") {
+				row.PHPRunning = append(row.PHPRunning, v)
+			}
+		}
+	}
+
+	st, _ := podman.UnitStatus("lerd-watcher")
+	row.WatcherRunning = st == "active" || st == "activating"
+
+	return row
+}

--- a/internal/tui/snapshot_test.go
+++ b/internal/tui/snapshot_test.go
@@ -1,0 +1,87 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func TestWorkerRows_SynthesizesFromSites(t *testing.T) {
+	sites := []siteinfo.EnrichedSite{
+		{
+			Name: "alpha", Path: "/sites/alpha",
+			HasQueueWorker: true, QueueRunning: true,
+			HasHorizon: true, HorizonRunning: false,
+		},
+		{
+			Name: "beta", Path: "/sites/beta",
+			HasScheduleWorker: true, ScheduleRunning: true,
+			FrameworkWorkers: []siteinfo.WorkerInfo{
+				{Name: "broadcaster", Running: true},
+			},
+		},
+	}
+	rows := workerRows(sites)
+
+	want := map[string]ServiceState{
+		"queue-alpha":      stateRunning,
+		"horizon-alpha":    stateStopped,
+		"schedule-beta":    stateRunning,
+		"broadcaster-beta": stateRunning,
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("expected %d worker rows, got %d: %+v", len(want), len(rows), rowsNames(rows))
+	}
+	for _, row := range rows {
+		wantState, ok := want[row.Name]
+		if !ok {
+			t.Errorf("unexpected worker row %q", row.Name)
+			continue
+		}
+		if row.State != wantState {
+			t.Errorf("%s: state %v, want %v", row.Name, row.State, wantState)
+		}
+		if row.WorkerSite == "" || row.WorkerKind == "" || row.WorkerPath == "" {
+			t.Errorf("%s: worker fields missing: %+v", row.Name, row)
+		}
+	}
+}
+
+func TestWorkerRows_FrameworkWorkerSkipsBuiltinNames(t *testing.T) {
+	// When a framework redeclares queue / schedule / horizon / reverb in
+	// FrameworkWorkers it's covered by the well-known branches already;
+	// don't synthesise a duplicate row.
+	sites := []siteinfo.EnrichedSite{{
+		Name: "alpha", Path: "/x",
+		FrameworkWorkers: []siteinfo.WorkerInfo{
+			{Name: "queue", Running: true},
+			{Name: "custom", Running: true},
+		},
+	}}
+	rows := workerRows(sites)
+	for _, r := range rows {
+		if r.Name == "queue-alpha" {
+			t.Errorf("framework-declared queue should be skipped, well-known branch handles it")
+		}
+	}
+	if !hasName(rows, "custom-alpha") {
+		t.Errorf("custom framework worker missing: %+v", rowsNames(rows))
+	}
+}
+
+func rowsNames(rows []ServiceRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.Name
+	}
+	return out
+}
+
+func hasName(rows []ServiceRow, name string) bool {
+	for _, r := range rows {
+		if r.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,0 +1,37 @@
+package tui
+
+import "github.com/charmbracelet/lipgloss"
+
+var (
+	colTitle    = lipgloss.Color("205")
+	colDim      = lipgloss.Color("243")
+	colDivider  = lipgloss.Color("237")
+	colRunning  = lipgloss.Color("42")
+	colStopped  = lipgloss.Color("243")
+	colFailing  = lipgloss.Color("203")
+	colPaused   = lipgloss.Color("214")
+	colAccent   = lipgloss.Color("147")
+	colSelected = lipgloss.Color("205")
+)
+
+var (
+	titleStyle    = lipgloss.NewStyle().Bold(true).Foreground(colTitle)
+	sectionStyle  = lipgloss.NewStyle().Bold(true).Foreground(colDim)
+	dimStyle      = lipgloss.NewStyle().Foreground(colDim)
+	selectedStyle = lipgloss.NewStyle().Bold(true).Foreground(colSelected)
+	focusedPane   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(colAccent).Padding(0, 1)
+	unfocusedPane = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(colDivider).Padding(0, 1)
+	runningStyle  = lipgloss.NewStyle().Foreground(colRunning)
+	stoppedStyle  = lipgloss.NewStyle().Foreground(colStopped)
+	failingStyle  = lipgloss.NewStyle().Foreground(colFailing).Bold(true)
+	pausedStyle   = lipgloss.NewStyle().Foreground(colPaused)
+	accentStyle   = lipgloss.NewStyle().Foreground(colAccent)
+	helpStyle     = lipgloss.NewStyle().Foreground(colDim)
+)
+
+const (
+	glyphRunning = "●"
+	glyphStopped = "○"
+	glyphFailing = "✖"
+	glyphPaused  = "◐"
+)


### PR DESCRIPTION
## Summary

Adds `lerd tui`, a btop-style terminal dashboard with near parity to the existing web UI and system tray. Built on the same bubbletea / lipgloss stack used for `lerd man` and the same `siteinfo` / `podman.Cache` / eventbus plumbing that drives `lerd-ui`, so both surfaces see identical live state.

- **Layout**: sites + services stacked left, full-height site detail right, toggleable log pane below with a right-edge scrollbar, header with DNS / nginx / FPM status and a cached `update: vX.Y.Z` banner.
- **Site detail**: primary domain header, internal name, disk path, full domains list (add with `a`, rename with `e`, remove with `x`), services used with live state, workers with toggles, git worktrees, HTTPS toggle, LAN share toggle with full `http://<lan-ip>:<port>` URL, inline PHP and Node version pickers backed by `lerd isolate` / `lerd isolate:node`.
- **Services pane** includes site-owned workers (`queue-<site>`, `schedule-<site>`, `horizon-<site>`, `reverb-<site>`, custom framework workers) routed to the right per-site commands.
- **Filter + sort** on both lists (`/` filter, `o` cycle sort). `v` hides services, `t` opens a shell in the focused container, `l` tails logs, `[` / `]` cycle log sources (FPM + custom container, worker journals via `journalctl --user` on Linux / `podman logs` on macOS, framework app log files tailed with `tail -F`).
- **In-pane overlays** for global Settings (`S`) and a Keybindings reference (`?`), both toggleable back with `esc`.
- **Cross-platform**: platform-split for worker log tailing so the TUI works on macOS (where workers are containers) and Linux (where they are systemd user units).
- Live updates via the in-process eventbus plus a 2s refresh tick so changes made from another terminal surface within a couple of seconds.
- Unit tests for filter / sort variants, `detailRows`, log targets, worker-row synthesis, `nextFocus` edges, domain input flow, picker lifecycle, and row alignment invariants.

Docs: new `/features/tui.md` page with a full keybindings reference, updated homepage feature tile, README feature bullet and comparison table row, changelog entry under Unreleased. Post-install banner now also points at `lerd tui` alongside the dashboard URL.