### PR TITLE
fix(worktree): copy vendor and node_modules instead of symlinking

### DIFF
--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -36,11 +36,17 @@ When a worktree vhost is first created, Lerd sets up three things in the checkou
 
 | Resource | Behaviour |
 |---|---|
-| `vendor/` | Symlinked from the main repo (shares Composer packages) |
-| `node_modules/` | Symlinked from the main repo (shares npm packages) |
+| `vendor/` | Copied from the main repo using reflinks where the filesystem supports them (btrfs, xfs-reflink, APFS), then reconciled against the worktree's own `composer.lock` via `composer install` |
+| `node_modules/` | Copied from the main repo (reflink where supported), then reconciled against the worktree's own `package-lock.json` via `npm ci` |
 | `.env` | Copied from the main repo with `APP_URL` rewritten to `http://<branch>.<site>.test` |
 
-If any of these already exist in the worktree they are left untouched.
+If `vendor/` or `node_modules/` already exist as real directories they are left untouched. Legacy symlinks left by earlier lerd versions are replaced with real copies.
+
+On reflink-capable filesystems the initial copy is near-instant and consumes no extra disk until a file is modified. On ext4 it falls back to a plain copy, which typically takes a few seconds per vendor tree. The subsequent `composer install` / `npm ci` is a quick verification pass when the worktree branch shares the same lockfile as main, and installs only the differences when the branch has changed dependencies.
+
+::: info Why not symlink?
+Earlier versions of lerd symlinked `vendor/` to save disk. PHP resolves `__DIR__` through symlinks to the real filesystem path, so Composer's `ClassLoader` would initialise against the main repo directory and silently load stale classes from there. Real copies avoid the problem while still being cheap on modern filesystems.
+:::
 
 ---
 

--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -37,12 +37,12 @@ When a worktree vhost is first created, Lerd sets up three things in the checkou
 | Resource | Behaviour |
 |---|---|
 | `vendor/` | Copied from the main repo using reflinks where the filesystem supports them (btrfs, xfs-reflink, APFS), then reconciled against the worktree's own `composer.lock` via `composer install` |
-| `node_modules/` | Copied from the main repo (reflink where supported), then reconciled against the worktree's own `package-lock.json` via `npm ci` |
+| `node_modules/` | Copied from the main repo (reflink where supported), then reconciled against the worktree's own lockfile via the matching package manager (pnpm / yarn / bun / npm, auto-detected from `pnpm-lock.yaml`, `yarn.lock`, `bun.lock*`, or `package-lock.json`) |
 | `.env` | Copied from the main repo with `APP_URL` rewritten to `http://<branch>.<site>.test` |
 
 If `vendor/` or `node_modules/` already exist as real directories they are left untouched. Legacy symlinks left by earlier lerd versions are replaced with real copies.
 
-On reflink-capable filesystems the initial copy is near-instant and consumes no extra disk until a file is modified. On ext4 it falls back to a plain copy, which typically takes a few seconds per vendor tree. The subsequent `composer install` / `npm ci` is a quick verification pass when the worktree branch shares the same lockfile as main, and installs only the differences when the branch has changed dependencies.
+On reflink-capable filesystems the initial copy is near-instant and consumes no extra disk until a file is modified. On ext4 it falls back to a plain copy, which typically takes a few seconds per vendor tree. The subsequent `composer install` plus the JS install is a quick verification pass when the worktree branch shares the same lockfile as main, and installs only the differences when the branch has changed dependencies. If the detected package manager isn't on `PATH` (e.g. `pnpm-lock.yaml` but no pnpm installed) the JS step is skipped with a warning so the rest of the worktree is still usable.
 
 ::: info Why not symlink?
 Earlier versions of lerd symlinked `vendor/` to save disk. PHP resolves `__DIR__` through symlinks to the real filesystem path, so Composer's `ClassLoader` would initialise against the main repo directory and silently load stale classes from there. Real copies avoid the problem while still being cheap on modern filesystems.

--- a/internal/git/copy.go
+++ b/internal/git/copy.go
@@ -83,10 +83,14 @@ func copyFileWithMode(src, dst string, mode os.FileMode) error {
 	return nil
 }
 
-// InstallDependencies runs composer install and npm ci in projectPath so
-// vendor/ and node_modules/ match that checkout's own lockfiles. Uses the
-// lerd composer and npm shims from BinDir so the commands route through
-// the project's PHP-FPM container and the correct Node version.
+// InstallDependencies runs composer install and the JS package manager
+// matching whatever lockfile the project ships so vendor/ and node_modules/
+// match that checkout's own lockfiles. composer goes through the lerd
+// shim (which routes into the project's PHP-FPM container); JS tooling
+// goes through whichever of pnpm/yarn/bun/npm is on PATH, preferring the
+// npm shim from BinDir when the project uses npm so the fnm Node version
+// is picked up.
+//
 // Errors are aggregated and returned; callers should log them rather than
 // treat them as fatal since the worktree is still usable with the copied
 // trees from main.
@@ -101,17 +105,57 @@ func InstallDependencies(projectPath string) error {
 	}
 
 	if hasFile(projectPath, "package.json") {
-		npm := filepath.Join(config.BinDir(), "npm")
-		cmd := "install"
-		if hasFile(projectPath, "package-lock.json") || hasFile(projectPath, "npm-shrinkwrap.json") {
-			cmd = "ci"
-		}
-		if err := runIn(projectPath, npm, cmd, "--no-progress"); err != nil {
-			errs = append(errs, fmt.Errorf("npm %s: %w", cmd, err))
+		if err := runJSInstall(projectPath); err != nil {
+			errs = append(errs, err)
 		}
 	}
 
 	return errors.Join(errs...)
+}
+
+// jsPackageManager returns the name and install args for the package
+// manager a project uses, picked from the presence of lockfiles.
+// Preference order mirrors each manager's lockfile being definitive:
+// pnpm-lock.yaml ▸ yarn.lock ▸ bun.lock(b) ▸ npm lockfile ▸ npm as fallback.
+func jsPackageManager(projectPath string) (name string, args []string) {
+	switch {
+	case hasFile(projectPath, "pnpm-lock.yaml"):
+		return "pnpm", []string{"install", "--frozen-lockfile"}
+	case hasFile(projectPath, "yarn.lock"):
+		// --immutable covers both yarn classic (v1) and berry (v2+); v1
+		// doesn't understand it but falls back to default install, which
+		// is what we want if the lockfile is already present.
+		return "yarn", []string{"install", "--immutable"}
+	case hasFile(projectPath, "bun.lockb"), hasFile(projectPath, "bun.lock"):
+		return "bun", []string{"install", "--frozen-lockfile"}
+	case hasFile(projectPath, "package-lock.json"), hasFile(projectPath, "npm-shrinkwrap.json"):
+		return "npm", []string{"ci", "--no-progress"}
+	default:
+		return "npm", []string{"install", "--no-progress"}
+	}
+}
+
+// runJSInstall resolves the chosen package manager's binary and runs the
+// install. For npm we use the lerd shim from BinDir so fnm's current Node
+// version wins; other managers go through PATH since lerd doesn't shim
+// them. Missing binary is logged and returned so the caller aggregates it
+// with other setup errors.
+func runJSInstall(projectPath string) error {
+	name, args := jsPackageManager(projectPath)
+
+	var bin string
+	if name == "npm" {
+		bin = filepath.Join(config.BinDir(), "npm")
+	} else if p, err := exec.LookPath(name); err == nil {
+		bin = p
+	} else {
+		return fmt.Errorf("%s (lockfile present) not found on PATH — install it to hydrate node_modules", name)
+	}
+
+	if err := runIn(projectPath, bin, args...); err != nil {
+		return fmt.Errorf("%s %s: %w", name, args[0], err)
+	}
+	return nil
 }
 
 func hasFile(dir, name string) bool {

--- a/internal/git/copy.go
+++ b/internal/git/copy.go
@@ -1,0 +1,128 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// CopyTree copies src to dst recursively. It first tries a reflink-aware
+// fast path via cp, which is near-instant on btrfs, XFS with reflink=1,
+// and APFS. Falls back to a plain recursive Go copy elsewhere. dst must
+// not already exist.
+func CopyTree(src, dst string) error {
+	if err := copyTreeCP(src, dst); err == nil {
+		return nil
+	}
+	_ = os.RemoveAll(dst)
+	return copyTreeNative(src, dst)
+}
+
+func copyTreeCP(src, dst string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("cp", "-a", "--reflink=auto", src, dst)
+	case "darwin":
+		cmd = exec.Command("cp", "-Rc", src, dst)
+	default:
+		return errors.New("reflink path unsupported on " + runtime.GOOS)
+	}
+	return cmd.Run()
+}
+
+func copyTreeNative(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			link, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			return os.Symlink(link, target)
+		}
+		return copyFileWithMode(path, target, info.Mode())
+	})
+}
+
+func copyFileWithMode(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return nil
+}
+
+// InstallDependencies runs composer install and npm ci in projectPath so
+// vendor/ and node_modules/ match that checkout's own lockfiles. Uses the
+// lerd composer and npm shims from BinDir so the commands route through
+// the project's PHP-FPM container and the correct Node version.
+// Errors are aggregated and returned; callers should log them rather than
+// treat them as fatal since the worktree is still usable with the copied
+// trees from main.
+func InstallDependencies(projectPath string) error {
+	var errs []error
+
+	if hasFile(projectPath, "composer.json") {
+		composer := filepath.Join(config.BinDir(), "composer")
+		if err := runIn(projectPath, composer, "install", "--no-interaction", "--no-progress"); err != nil {
+			errs = append(errs, fmt.Errorf("composer install: %w", err))
+		}
+	}
+
+	if hasFile(projectPath, "package.json") {
+		npm := filepath.Join(config.BinDir(), "npm")
+		cmd := "install"
+		if hasFile(projectPath, "package-lock.json") || hasFile(projectPath, "npm-shrinkwrap.json") {
+			cmd = "ci"
+		}
+		if err := runIn(projectPath, npm, cmd, "--no-progress"); err != nil {
+			errs = append(errs, fmt.Errorf("npm %s: %w", cmd, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func hasFile(dir, name string) bool {
+	_, err := os.Stat(filepath.Join(dir, name))
+	return err == nil
+}
+
+func runIn(dir, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/git/copy_test.go
+++ b/internal/git/copy_test.go
@@ -71,6 +71,72 @@ func TestCopyTreeNative_PreservesInnerSymlinks(t *testing.T) {
 	}
 }
 
+func TestJSPackageManager_DetectsLockfile(t *testing.T) {
+	cases := []struct {
+		name     string
+		lockfile string
+		wantBin  string
+		wantArg0 string
+	}{
+		{"pnpm", "pnpm-lock.yaml", "pnpm", "install"},
+		{"yarn", "yarn.lock", "yarn", "install"},
+		{"bun-binary", "bun.lockb", "bun", "install"},
+		{"bun-text", "bun.lock", "bun", "install"},
+		{"npm-lockfile", "package-lock.json", "npm", "ci"},
+		{"npm-shrinkwrap", "npm-shrinkwrap.json", "npm", "ci"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, c.lockfile), []byte(""), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			gotBin, gotArgs := jsPackageManager(dir)
+			if gotBin != c.wantBin {
+				t.Errorf("binary: got %q want %q", gotBin, c.wantBin)
+			}
+			if len(gotArgs) == 0 || gotArgs[0] != c.wantArg0 {
+				t.Errorf("first arg: got %v want %q", gotArgs, c.wantArg0)
+			}
+		})
+	}
+}
+
+func TestJSPackageManager_DefaultsToNpmInstallWithoutLockfile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bin, args := jsPackageManager(dir)
+	if bin != "npm" {
+		t.Errorf("binary: got %q want npm", bin)
+	}
+	if len(args) == 0 || args[0] != "install" {
+		t.Errorf("first arg: got %v want install", args)
+	}
+}
+
+func TestJSPackageManager_PnpmBeatsOtherLockfiles(t *testing.T) {
+	// Defensive: if a repo somehow has both pnpm-lock.yaml and
+	// package-lock.json, the pnpm lockfile is the modern one — prefer it.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, lf := range []string{"pnpm-lock.yaml", "package-lock.json"} {
+		if err := os.WriteFile(filepath.Join(dir, lf), []byte(""), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	bin, _ := jsPackageManager(dir)
+	if bin != "pnpm" {
+		t.Errorf("expected pnpm to win over npm lockfile, got %q", bin)
+	}
+}
+
 func TestCopyTree_CP(t *testing.T) {
 	// Covers the cp fast path end-to-end when the host supports it.
 	src := t.TempDir()

--- a/internal/git/copy_test.go
+++ b/internal/git/copy_test.go
@@ -1,0 +1,94 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyTreeNative_RegularFilesAndDirs(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+
+	if err := os.MkdirAll(filepath.Join(src, "sub/nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "top.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "sub/nested/inner.txt"), []byte("world"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyTreeNative(src, dst); err != nil {
+		t.Fatalf("copyTreeNative: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, "top.txt"))
+	if err != nil || string(got) != "hello" {
+		t.Fatalf("top.txt: got %q err %v, want %q nil", got, err, "hello")
+	}
+
+	got, err = os.ReadFile(filepath.Join(dst, "sub/nested/inner.txt"))
+	if err != nil || string(got) != "world" {
+		t.Fatalf("inner.txt: got %q err %v, want %q nil", got, err, "world")
+	}
+
+	info, err := os.Stat(filepath.Join(dst, "sub/nested/inner.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("inner.txt perm: got %o want 600", perm)
+	}
+}
+
+func TestCopyTreeNative_PreservesInnerSymlinks(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+
+	if err := os.WriteFile(filepath.Join(src, "real.txt"), []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real.txt", filepath.Join(src, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyTreeNative(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Lstat(filepath.Join(dst, "link.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("link.txt is not a symlink in dst")
+	}
+	target, err := os.Readlink(filepath.Join(dst, "link.txt"))
+	if err != nil || target != "real.txt" {
+		t.Errorf("link target: got %q err %v, want %q", target, err, "real.txt")
+	}
+}
+
+func TestCopyTree_CP(t *testing.T) {
+	// Covers the cp fast path end-to-end when the host supports it.
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "sub/file"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyTree(src, dst); err != nil {
+		t.Fatalf("CopyTree: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, "sub/file"))
+	if err != nil || string(got) != "x" {
+		t.Fatalf("copied file: got %q err %v", got, err)
+	}
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -117,19 +117,36 @@ func readCheckoutPath(wtDir string) string {
 }
 
 // EnsureWorktreeDeps sets up a worktree checkout with the dependencies it needs:
-//   - vendor/ and node_modules/ are symlinked from the main repo
+//   - vendor/ and node_modules/ are seeded from the main repo via a reflink
+//     copy (near-instant on btrfs, xfs-reflink, APFS; plain copy on ext4),
+//     then reconciled against the worktree's own lockfiles via
+//     composer install / npm ci.
 //   - .env is copied from the main repo with APP_URL rewritten to http(s)://<worktreeDomain>
+//
+// Copying (rather than symlinking) is required because PHP resolves __DIR__
+// through symlinks, which would make Composer's ClassLoader initialise
+// against the main repo directory and silently load stale classes from
+// there.
 func EnsureWorktreeDeps(mainRepoPath, worktreePath, worktreeDomain string, secured bool) {
 	for _, dir := range []string{"vendor", "node_modules"} {
 		dst := filepath.Join(worktreePath, dir)
-		if _, err := os.Lstat(dst); err == nil {
-			continue // already exists or is already a symlink
+		if info, err := os.Lstat(dst); err == nil {
+			if info.Mode()&os.ModeSymlink == 0 {
+				continue // real dir already exists, leave it
+			}
+			_ = os.Remove(dst) // legacy symlink from older lerd, replace it
 		}
 		src := filepath.Join(mainRepoPath, dir)
 		if _, err := os.Stat(src); err != nil {
-			continue // main repo doesn't have it either
+			continue
 		}
-		_ = os.Symlink(src, dst)
+		if err := CopyTree(src, dst); err != nil {
+			_, _ = os.Stderr.WriteString("[WARN] copy " + dir + " into worktree: " + err.Error() + "\n")
+		}
+	}
+
+	if err := InstallDependencies(worktreePath); err != nil {
+		_, _ = os.Stderr.WriteString("[WARN] worktree dependency install: " + err.Error() + "\n")
 	}
 
 	// .env: copy from main repo and set APP_URL to the worktree domain.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -242,3 +242,103 @@ func TestRewriteAppURL_missingFile(t *testing.T) {
 		t.Error("expected error for missing file")
 	}
 }
+
+// EnsureWorktreeDeps copies vendor/ and node_modules/ from the main repo
+// rather than symlinking, because PHP resolves __DIR__ through symlinks
+// and Composer's ClassLoader otherwise initialises against the main
+// checkout instead of the worktree.
+func TestEnsureWorktreeDeps_copiesInsteadOfSymlinking(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local/share"))
+
+	main := filepath.Join(home, "main")
+	wt := filepath.Join(home, "wt")
+	for _, d := range []string{main, wt} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(main, "vendor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(main, "vendor", "autoload.php"), []byte("<?php"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(main, ".env"), []byte("APP_URL=http://main.test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureWorktreeDeps(main, wt, "branch.main.test", false)
+
+	info, err := os.Lstat(filepath.Join(wt, "vendor"))
+	if err != nil {
+		t.Fatalf("vendor missing in worktree: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("vendor should be a real directory, not a symlink")
+	}
+	if !info.IsDir() {
+		t.Fatal("vendor should be a directory")
+	}
+	if _, err := os.Stat(filepath.Join(wt, "vendor", "autoload.php")); err != nil {
+		t.Errorf("vendor/autoload.php not copied: %v", err)
+	}
+}
+
+// EnsureWorktreeDeps replaces a legacy symlink left by an older lerd
+// version with a real copy.
+func TestEnsureWorktreeDeps_migratesLegacySymlink(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local/share"))
+
+	main := filepath.Join(home, "main")
+	wt := filepath.Join(home, "wt")
+	if err := os.MkdirAll(filepath.Join(main, "vendor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(main, "vendor", "autoload.php"), []byte("<?php"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(main, "vendor"), filepath.Join(wt, "vendor")); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureWorktreeDeps(main, wt, "branch.main.test", false)
+
+	info, err := os.Lstat(filepath.Join(wt, "vendor"))
+	if err != nil {
+		t.Fatalf("vendor missing: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("legacy symlink should have been replaced with a real copy")
+	}
+}
+
+// When main has no vendor/ yet, EnsureWorktreeDeps must not create an
+// empty directory in the worktree; it should simply do nothing for that
+// tree.
+func TestEnsureWorktreeDeps_mainMissingVendor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local/share"))
+
+	main := filepath.Join(home, "main")
+	wt := filepath.Join(home, "wt")
+	for _, d := range []string{main, wt} {
+		_ = os.MkdirAll(d, 0o755)
+	}
+
+	EnsureWorktreeDeps(main, wt, "branch.main.test", false)
+
+	if _, err := os.Lstat(filepath.Join(wt, "vendor")); err == nil {
+		t.Error("vendor should not be created when main has none")
+	}
+}


### PR DESCRIPTION
## Summary
PHP resolves `__DIR__` through symlinks, so `vendor/autoload.php` inside a git worktree reports the main repo's real path. Composer's `ClassLoader` then initialises with the main repo as its base and every PSR-4 class resolves against main's source tree instead of the worktree's. Any worktree with diverged `app/`, `src/`, etc. silently runs stale code. Reported in #208.

Replace the symlinks with real copies seeded from the main repo, using `cp -a --reflink=auto` on Linux and `cp -Rc` on macOS (APFS clone_file) for near-instant, zero-disk copies on btrfs, xfs-reflink, and APFS. Falls back to a plain Go walk on ext4 and anywhere `cp` is unavailable.

After copying, the JS install is routed to the matching package manager based on the lockfile (pnpm-lock.yaml → pnpm, yarn.lock → yarn, bun.lock / bun.lockb → bun, package-lock.json / npm-shrinkwrap.json → npm ci, otherwise npm install). composer install goes through the lerd shim; the JS manager goes through the shim when it's npm and through PATH otherwise. Missing binaries aggregate into a warning rather than failing the worktree so the reflink copy is still usable.

Legacy symlinks from earlier lerd versions are detected on the next worktree detection event and replaced with real copies automatically.

Fixes #208.