### PR TITLE
feat(macos): stop podman machine on lerd quit

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -7,7 +7,7 @@
 | `lerd install` | One-time setup: directories, network, binaries, DNS, nginx, watcher |
 | `lerd start` | Start DNS, nginx, PHP-FPM containers, and all installed services; warns about port conflicts and builds or pulls any missing images first |
 | `lerd stop` | Stop DNS, nginx, PHP-FPM containers, and all running services |
-| `lerd quit` | Stop all Lerd processes and containers including the UI, watcher, and tray |
+| `lerd quit` | Stop all Lerd processes and containers including the UI, watcher, and tray; on macOS also stops the Podman Machine VM |
 | `lerd update` | Check for updates and update after confirmation |
 | `lerd update --beta` | Update to the latest pre-release build |
 | `lerd update --rollback` | Revert to the previously installed version |

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -72,8 +72,9 @@ The full off-switch:
 2. Stops `lerd-ui` (Web UI).
 3. Stops `lerd-watcher`.
 4. Kills the system tray process.
+5. **macOS only:** stops the Podman Machine VM.
 
-After `lerd quit` there are no lerd processes left running. This is the right command before a reinstall, a system reboot, or before pulling a major update.
+After `lerd quit` there are no lerd processes left running. On macOS the Podman Machine VM is also shut down, so `lerd start` will bring it back up on the next run. This is the right command before a reinstall, a system reboot, or before pulling a major update.
 
 The system tray's **Quit Lerd** menu item calls `lerd quit`.
 

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -938,5 +938,7 @@ func runQuit(_ *cobra.Command, _ []string) error {
 	// Also kill any directly-launched tray instance not managed by launchd/systemd.
 	killTray()
 
+	stopPodmanMachine()
+
 	return nil
 }

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -210,6 +210,32 @@ func ensurePodmanMachineRunning() {
 	fmt.Println(" timed out (proceeding anyway)")
 }
 
+// stopPodmanMachine stops the running Podman Machine VM. Called by runQuit so
+// the VM is cleanly shut down when the user quits Lerd entirely.
+func stopPodmanMachine() {
+	out, err := exec.Command(podman.PodmanBin(), "machine", "list", "--format", "{{.Name}}\t{{.Running}}").Output()
+	if err != nil {
+		return
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[1] != "true" {
+			continue
+		}
+		name := strings.TrimSuffix(fields[0], "*")
+		fmt.Printf("  --> Stopping Podman Machine (%s) ...\n", name)
+		cmd := exec.Command(podman.PodmanBin(), "machine", "stop", name)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("  WARN: podman machine stop: %v\n", err)
+		}
+	}
+}
+
 // batchStopContainers stops all running lerd-* containers in two podman calls
 // (stop then rm) so the Podman Machine socket isn't flooded by N individual
 // stop requests from RunParallel. After this returns the individual Stop()

--- a/internal/cli/startstop_linux.go
+++ b/internal/cli/startstop_linux.go
@@ -13,3 +13,6 @@ func migrateExecWorkerPlists() {}
 // batchStopContainers is a no-op on Linux — systemd stops containers via unit
 // deactivation so individual StopUnit calls are efficient and non-blocking.
 func batchStopContainers(_ []string) {}
+
+// stopPodmanMachine is a no-op on Linux — Podman runs natively without a VM.
+func stopPodmanMachine() {}


### PR DESCRIPTION
`lerd quit` on macOS now stops the Podman Machine VM after all containers and process units are shut down. `lerd start` already starts the machine, so this makes quit/start symmetric.

- Added `stopPodmanMachine()` in `startstop_darwin.go` — finds any running machine via `podman machine list` and calls `podman machine stop`
- Added no-op stub in `startstop_linux.go`
- Called from `runQuit` after `killTray()`
- Updated `docs/usage/lifecycle.md` and `docs/reference/commands.md`