### PR TITLE
release: v1.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release/**"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release/**"]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you're a PHP developer on Linux and want frictionless local development — a
 - 🐘 **Per-project PHP version** (8.1–8.5), switch with one click
 - 📦 **Node.js isolation** per project (Node 22, 24)
 - 🖥️ **Built-in Web UI** - 3-pane dashboard to manage sites, services, and logs from a browser
+- 🖥️ **Terminal dashboard** (`lerd tui`) - btop-style TUI with live status, site detail pane, inline domain and version editing, shell drop-in, log tailing, and filter/sort — the same operations surface as the web UI, for tmux and SSH workflows
 - 🗄️ **One-click services**: MySQL, PostgreSQL, Redis, Meilisearch, RustFS, Mailpit, Stripe Mock, Reverb and more
 - 📋 **Live logs** for PHP-FPM, Queue, Schedule, Reverb, per site
 - 🔒 **Rootless & daemonless** - Podman-native, no Docker required
@@ -63,6 +64,7 @@ AI:  → site_link()
 | Podman-native      | ✅   | ❌   | ❌    | ❌           |
 | Rootless           | ✅   | ❌   | ❌    | ✅           |
 | Web UI             | ✅   | ❌   | ❌    | ✅           |
+| Terminal dashboard | ✅   | ❌   | ❌    | ❌           |
 | Linux              | ✅   | ✅   | ✅    | ❌           |
 | macOS              | ✅   | ✅   | ✅    | ✅           |
 | MCP server         | ✅   | ❌   | ❌    | ❌           |

--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -97,6 +97,7 @@ func main() {
 	root.AddCommand(cli.NewNpxCmd())
 	root.AddCommand(cli.NewServiceCmd())
 	root.AddCommand(cli.NewStatusCmd())
+	root.AddCommand(cli.NewTuiCmd())
 	root.AddCommand(cli.NewWhichCmd())
 	root.AddCommand(cli.NewCheckCmd())
 	root.AddCommand(cli.NewAboutCmd())

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -135,6 +135,7 @@ export default defineConfig({
           text: 'UI & AI',
           items: [
             { text: 'Web UI', link: '/features/web-ui' },
+            { text: 'Terminal Dashboard', link: '/features/tui' },
             { text: 'System Tray', link: '/features/system-tray' },
             { text: 'AI Integration (MCP)', link: '/features/mcp' },
           ],

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,8 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`lerd quit` stops the Podman Machine VM on macOS**. After all containers, workers, the Web UI, watcher, and tray are shut down, `lerd quit` now calls `podman machine stop` on any running machine. `lerd start` already starts the machine, so quit and start are now fully symmetric. No change on Linux where Podman runs natively without a VM.
+
 - **`lerd tui` — terminal dashboard**. A btop-style, full-screen dashboard for sites, services, and workers, with near parity to the [Web UI](/features/web-ui) and [System Tray](/features/system-tray). Built on the same bubbletea / lipgloss stack already used for `lerd man` and the same `siteinfo` / `podman.Cache` / eventbus plumbing that drives `lerd-ui`, so both surfaces see identical live state.
   - **Layout**: Sites + Services stacked in the left column, a full-height Site detail pane on the right, and a toggleable log tail below (`l`). Header shows DNS / nginx / FPM status plus an `update: vX.Y.Z` banner when a newer release is cached.
   - **Site detail**: primary domain header, internal name, disk path, full domains list (add with `a`, rename with `e`, remove with `x`), services-used with live state, workers (toggle with `space`), git worktrees, HTTPS toggle, LAN share toggle (shows `http://<lan-ip>:<port>` when on), PHP and Node version pickers (open with `space`, commit with `enter`, backed by `lerd isolate` / `lerd isolate:node`).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,11 +11,9 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [1.16.0] — 2026-04-17
 
 ### Added
-
-- **`lerd quit` stops the Podman Machine VM on macOS**. After all containers, workers, the Web UI, watcher, and tray are shut down, `lerd quit` now calls `podman machine stop` on any running machine. `lerd start` already starts the machine, so quit and start are now fully symmetric. No change on Linux where Podman runs natively without a VM.
 
 - **`lerd tui` — terminal dashboard**. A btop-style, full-screen dashboard for sites, services, and workers, with near parity to the [Web UI](/features/web-ui) and [System Tray](/features/system-tray). Built on the same bubbletea / lipgloss stack already used for `lerd man` and the same `siteinfo` / `podman.Cache` / eventbus plumbing that drives `lerd-ui`, so both surfaces see identical live state.
   - **Layout**: Sites + Services stacked in the left column, a full-height Site detail pane on the right, and a toggleable log tail below (`l`). Header shows DNS / nginx / FPM status plus an `update: vX.Y.Z` banner when a newer release is cached.
@@ -25,6 +23,18 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - **Log sources**: `[` / `]` cycle through FPM / custom container, every worker journal (`journalctl --user -u lerd-<kind>-<site>`), and every file matched by the framework's `fw.Logs` globs (Laravel: `storage/logs/*.log`). Logs pane takes at least half the window and has a right-edge scrollbar.
   - **In-pane overlays**: `S` swaps the detail pane for global Settings (LAN expose, autostart on login, Xdebug per PHP version) and moves focus into it; `?` swaps it for a scrollable Keybindings reference. `esc` returns to Site detail.
   - Updates live by subscribing to the in-process eventbus and re-querying every 2 s so changes made from another terminal surface within a couple of seconds.
+
+- **Selectable Xdebug mode per PHP version** (#205). `lerd xdebug on` now accepts `--mode` (`debug`, `coverage`, `profile`, `trace`, `develop`, `gcstats`, or comma combos like `debug,coverage`); previously mode was hardcoded to `debug`. The dashboard gains a mode dropdown next to the Xdebug toggle and a clickable Xdebug chip on each site row. The MCP `xdebug_on` tool accepts a `mode` argument. Toggle orchestration (validate → persist → write ini → restart FPM) is extracted into a new `xdebugops` package; the three surfaces (CLI, UI, MCP) are now thin wrappers. Legacy configs with no saved mode resolve to `debug` so existing setups are unaffected.
+
+- **Adaptive Podman Machine memory on macOS** (#206). The VM memory target now scales with host RAM instead of a fixed 4 GB floor: 3 GB on machines with ≤8 GB, 4 GB on 9–31 GB, 6 GB on 32 GB+. Detection uses `sysctl hw.memsize`; falls back to 4 GB when detection fails. On 8 GB MacBooks lerd prints a note with the manual override command (`podman machine set --memory 4096`) so the tradeoff is visible.
+
+- **`lerd quit` stops the Podman Machine VM on macOS**. After all containers, workers, the Web UI, watcher, and tray are shut down, `lerd quit` calls `podman machine stop` on any running machine. `lerd start` already starts the machine, so quit and start are now fully symmetric. No change on Linux where Podman runs natively without a VM.
+
+### Fixed
+
+- **Worker log tabs stuck on "connecting..." in the dashboard** (#210). Two separate bugs combined. First, silent units (no output until an event fires) never triggered the first body write, so Go's `http.ResponseWriter` never sent the HTTP 200 + `text/event-stream` headers and the browser's `EventSource` stayed in `CONNECTING`. Fixed by flushing a `: connected` SSE comment immediately after writing headers. Second, switching tabs opened a new `EventSource` without closing the previous one; after a few clicks all six browser HTTP/1.1 connections were consumed and new streams queued indefinitely. Fixed by closing every non-active worker log stream before opening the new one.
+
+- **Git worktrees running stale code from the main checkout** (#209). `vendor/` and `node_modules/` in a new worktree were symlinks back to the main repo. PHP resolves `__DIR__` through symlinks, so `vendor/autoload.php` reported the main repo path and Composer's `ClassLoader` loaded every class from `main`'s source tree, silently ignoring any diverged `app/` or `src/` files in the worktree. The symlinks are now replaced with real copies seeded from the main repo using reflink-aware helpers (`cp -a --reflink=auto` on Linux btrfs/xfs, `cp -Rc` on macOS APFS, plain Go walk elsewhere), followed by `composer install` and `npm ci` to reconcile against the worktree's own lockfiles.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,21 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`lerd tui` — terminal dashboard**. A btop-style, full-screen dashboard for sites, services, and workers, with near parity to the [Web UI](/features/web-ui) and [System Tray](/features/system-tray). Built on the same bubbletea / lipgloss stack already used for `lerd man` and the same `siteinfo` / `podman.Cache` / eventbus plumbing that drives `lerd-ui`, so both surfaces see identical live state.
+  - **Layout**: Sites + Services stacked in the left column, a full-height Site detail pane on the right, and a toggleable log tail below (`l`). Header shows DNS / nginx / FPM status plus an `update: vX.Y.Z` banner when a newer release is cached.
+  - **Site detail**: primary domain header, internal name, disk path, full domains list (add with `a`, rename with `e`, remove with `x`), services-used with live state, workers (toggle with `space`), git worktrees, HTTPS toggle, LAN share toggle (shows `http://<lan-ip>:<port>` when on), PHP and Node version pickers (open with `space`, commit with `enter`, backed by `lerd isolate` / `lerd isolate:node`).
+  - **Services pane** includes site-owned workers (`queue-<site>`, `schedule-<site>`, `horizon-<site>`, `reverb-<site>`, custom framework workers), routed through `lerd queue start/stop`, `lerd worker start/stop <name>`, etc. `t` opens an interactive shell in the focused container (FPM or custom for sites, the service container for services, the owning site's FPM for workers).
+  - **Filter + sort**: `/` to filter sites / services by name (sites also match domains and framework label), `o` to cycle sort (sites: name · status · framework; services: name · status · usage). `v` hides the services pane.
+  - **Log sources**: `[` / `]` cycle through FPM / custom container, every worker journal (`journalctl --user -u lerd-<kind>-<site>`), and every file matched by the framework's `fw.Logs` globs (Laravel: `storage/logs/*.log`). Logs pane takes at least half the window and has a right-edge scrollbar.
+  - **In-pane overlays**: `S` swaps the detail pane for global Settings (LAN expose, autostart on login, Xdebug per PHP version) and moves focus into it; `?` swaps it for a scrollable Keybindings reference. `esc` returns to Site detail.
+  - Updates live by subscribing to the in-process eventbus and re-querying every 2 s so changes made from another terminal surface within a couple of seconds.
+
+---
+
 ## [1.15.1] — 2026-04-16
 
 ### Fixed

--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -36,11 +36,17 @@ When a worktree vhost is first created, Lerd sets up three things in the checkou
 
 | Resource | Behaviour |
 |---|---|
-| `vendor/` | Symlinked from the main repo (shares Composer packages) |
-| `node_modules/` | Symlinked from the main repo (shares npm packages) |
+| `vendor/` | Copied from the main repo using reflinks where the filesystem supports them (btrfs, xfs-reflink, APFS), then reconciled against the worktree's own `composer.lock` via `composer install` |
+| `node_modules/` | Copied from the main repo (reflink where supported), then reconciled against the worktree's own lockfile via the matching package manager (pnpm / yarn / bun / npm, auto-detected from `pnpm-lock.yaml`, `yarn.lock`, `bun.lock*`, or `package-lock.json`) |
 | `.env` | Copied from the main repo with `APP_URL` rewritten to `http://<branch>.<site>.test` |
 
-If any of these already exist in the worktree they are left untouched.
+If `vendor/` or `node_modules/` already exist as real directories they are left untouched. Legacy symlinks left by earlier lerd versions are replaced with real copies.
+
+On reflink-capable filesystems the initial copy is near-instant and consumes no extra disk until a file is modified. On ext4 it falls back to a plain copy, which typically takes a few seconds per vendor tree. The subsequent `composer install` plus the JS install is a quick verification pass when the worktree branch shares the same lockfile as main, and installs only the differences when the branch has changed dependencies. If the detected package manager isn't on `PATH` (e.g. `pnpm-lock.yaml` but no pnpm installed) the JS step is skipped with a warning so the rest of the worktree is still usable.
+
+::: info Why not symlink?
+Earlier versions of lerd symlinked `vendor/` to save disk. PHP resolves `__DIR__` through symlinks to the real filesystem path, so Composer's `ClassLoader` would initialise against the main repo directory and silently load stale classes from there. Real copies avoid the problem while still being cheap on modern filesystems.
+:::
 
 ---
 

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -90,9 +90,9 @@ Once the MCP server is connected, your AI assistant has access to:
 | `unpark` | Remove a parked directory from lerd and unlink all its sites |
 | `secure` | Enable HTTPS for a site using a locally-trusted mkcert certificate |
 | `unsecure` | Disable HTTPS for a site |
-| `xdebug_on` | Enable Xdebug for a PHP version and restart the FPM container |
+| `xdebug_on` | Enable Xdebug for a PHP version and restart the FPM container. Optional `mode` (default `debug`; accepts `coverage`, `develop`, `profile`, `trace`, `gcstats`, or comma combos like `debug,coverage`) |
 | `xdebug_off` | Disable Xdebug for a PHP version |
-| `xdebug_status` | Show Xdebug enabled/disabled state for all PHP versions |
+| `xdebug_status` | Show Xdebug enabled/disabled state and active `mode` for all PHP versions |
 | `service_start` | Start a built-in or custom service; if the service has `depends_on`, dependencies start first and dependent services start after |
 | `service_stop` | Stop a built-in or custom service; cascade-stops any custom services that depend on it first |
 | `service_add` | Register a new custom OCI-based service (MongoDB, RabbitMQ, etc.); supports `depends_on` for service dependencies |
@@ -183,7 +183,11 @@ AI:  → site_link()
 You: enable xdebug so I can step through a failing job
 AI:  → xdebug_status()
      → xdebug_on(version: "8.5")
-     ✓  Xdebug enabled for PHP 8.5 (port 9003)
+     ✓  Xdebug enabled for PHP 8.5 (mode=debug, port 9003)
+
+You: turn on xdebug coverage so I can run phpunit --coverage
+AI:  → xdebug_on(version: "8.5", mode: "coverage")
+     ✓  Xdebug enabled for PHP 8.5 (mode=coverage, port 9003)
 
 You: the app is throwing 500s, check the logs
 AI:  → logs(target: "8.5", lines: 50)

--- a/docs/features/tui.md
+++ b/docs/features/tui.md
@@ -1,0 +1,138 @@
+# Terminal Dashboard (TUI)
+
+`lerd tui` opens a btop-inspired full-screen dashboard in your terminal. It shows sites, services, workers, and logs in one glance, updates live, and lets you drive most of the same operations the web UI exposes without ever leaving the terminal.
+
+```bash
+lerd tui
+```
+
+This is the terminal-native counterpart to the [Web UI](/features/web-ui) and the [System Tray](/features/system-tray). Use it when you prefer to keep everything in a tmux or terminal pane, or when you're on a remote machine over SSH.
+
+## Layout
+
+- **Header** shows the lerd version, DNS / nginx / FPM status, watcher state, the wall clock, and an `update: vX.Y.Z` banner when a newer release is available (populated from the same 24-hour cache `lerd status` and `lerd doctor` use, so no extra network on startup).
+- **Sites pane (left column, top)** lists every linked site by its primary domain, with an FPM running dot, PHP version, and worker glyphs (`q` queue, `s` schedule, `v` reverb, `h` horizon, plus a dot per custom framework worker). Paused sites are dimmed and marked. Columns line up across rows regardless of how many workers each site runs.
+- **Services pane (left column, bottom)** is a compact list of built-in services (mysql, redis, postgres, meilisearch, rustfs, mailpit), custom services, and every site-owned worker (`queue-<site>`, `schedule-<site>`, `horizon-<site>`, `reverb-<site>`, and custom framework workers). Each row shows a running dot, how many sites use it, and `pinned` / `custom` tags where applicable.
+- **Site detail (right column, full height)** always mirrors the focused site and shows primary domain, internal name, disk path, all domains, services used (with live state), workers, git worktrees, HTTPS / LAN share toggles, and PHP / Node version pickers. `S` swaps it for global Settings, `?` swaps it for the Keybindings reference.
+- **Logs pane** (toggle with `l`) tails the container, worker-journal, or app log file behind the focused item. Takes at least half the window and renders a right-edge scrollbar showing position in the buffer.
+- **Status bar** briefly shows the most recent action (e.g. `✓ lerd service stop redis` or `✖ …exit 1`).
+- **Footer** summarises active keybindings for the current mode.
+
+Dots follow the same convention everywhere: green `●` running, grey `○` stopped, amber `◐` paused, red `✖` failing.
+
+## Keybindings
+
+### Navigation
+
+| Key | Action |
+| --- | --- |
+| `tab` / `shift+tab` | Cycle focus through Sites · Services · Detail |
+| `↑` `↓` / `j` `k` | Move selection in the focused pane |
+| `pgup` `pgdn` | Jump by 10 rows |
+| `home` `g` | Jump to first row |
+| `end` `G` | Jump to last row |
+
+### Filter and sort
+
+| Key | Action |
+| --- | --- |
+| `/` | Type to filter the focused list (matches name, domains, framework label) |
+| `enter` | Commit filter and leave input mode |
+| `esc` | Clear filter and leave input mode |
+| `o` | Cycle sort order · **sites**: name → status → framework · **services**: name → status → usage (site count) |
+
+### Actions
+
+| Key | Action |
+| --- | --- |
+| `space` / `enter` | Toggle the focused detail row (worker, HTTPS, LAN share, PHP, Node) |
+| `s` | Start / resume the focused site or start the focused service / worker |
+| `x` | Stop / pause the focused site or stop the focused service / worker · on a domain row, remove that domain |
+| `r` | Restart the focused site / service / worker |
+| `p` | Pause / unpause toggle for a site |
+| `t` | Open an interactive shell inside the focused container (FPM or custom for sites, the service container for services, the owning site's FPM for worker rows) |
+
+### Logs
+
+| Key | Action |
+| --- | --- |
+| `l` | Toggle the logs pane for the focused item |
+| `[` / `]` | Cycle the log pane target through the site's log sources |
+
+### Domains
+
+Available when focus is on the Detail pane with the cursor on a domain row.
+
+| Key | Action |
+| --- | --- |
+| `a` | Add a new domain to the focused site (opens inline input) |
+| `e` | Edit / rename the focused domain (opens inline input prefilled with the short name; commit runs `lerd domain add <new>` then `lerd domain remove <old>` as a sequence) |
+| `x` | Remove the focused domain |
+
+### Panes and overlays
+
+| Key | Action |
+| --- | --- |
+| `v` | Show / hide the Services pane |
+| `S` | Swap the Detail pane for global Settings (LAN expose, autostart, Xdebug) and focus it |
+| `?` | Swap the Detail pane for this Keybindings reference |
+| `esc` | Close picker, return to Site detail |
+
+### General
+
+| Key | Action |
+| --- | --- |
+| `R` | Force a state refresh |
+| `q` / `ctrl+c` | Quit |
+
+## Log sources
+
+When the log pane is open, `[` and `]` cycle through every tail-able source for whatever's focused:
+
+- **FPM / custom container** — `podman logs -f lerd-php<ver>-fpm` for PHP sites, or `lerd-custom-<name>` for custom container sites.
+- **Workers** — `journalctl --user -u lerd-queue-<site>` (and the same for schedule, reverb, horizon, custom framework workers). Workers are systemd user units, not containers, so their output lives in the user journal.
+- **App logs** — any file matching the framework's declared log globs (Laravel: `storage/logs/*.log`). Tailed with `tail -F` so rotated Laravel-style logs keep following.
+
+The pane title shows which source is active and the index, e.g. `Logs · astrolov · laravel.log [3/5 · [ ] to switch]`.
+
+## Site detail
+
+The detail pane is the main control surface for a site. With focus on the Sites pane, moving the cursor updates the detail live. Press `tab` until focus lands on the Detail pane to navigate its rows and toggle them with `space`.
+
+Sections, top to bottom:
+
+- **Header** — primary domain (the URL users visit), internal name, disk path.
+- **Domains** — every domain on one row, each tagged `primary · e edit · x remove` or `alias · e edit · x remove`. Ends with `+ add domain (space or a)` to insert new ones.
+- **PHP / Node / framework / git branch** — one-line summary.
+- **Services used** — every service referenced in `.lerd.yaml` with its live state, so you can see at a glance whether redis / mysql / etc. are up for this site.
+- **Workers** — queue, schedule, horizon, reverb, and any custom framework workers, each with a running / failing indicator. `space` on a worker row toggles it (calls `lerd queue start/stop`, etc.).
+- **Worktrees** — every git worktree with its branch, domain, and path when the site uses them.
+- **Toggles** — HTTPS (runs `lerd secure` / `lerd unsecure`), LAN share (runs `lerd lan share` / `unshare` — shows the full `http://<lan-ip>:<port>` URL when enabled), PHP version (opens an inline picker from installed versions → `lerd isolate <ver>`), Node version (picker backed by `fnm list` → `lerd isolate:node <ver>`).
+
+## Settings view
+
+Press `S` to swap the detail pane for global settings. Navigate with `↑` `↓`, toggle with `space`:
+
+- **LAN expose** — flip every container to 0.0.0.0 binds (`lerd lan expose on/off`).
+- **Autostart on login** — `lerd autostart enable/disable`.
+- **Xdebug** — one toggle per installed PHP version; rebuilds the FPM container.
+
+`S` again (or `esc`) returns to Site detail.
+
+## Keybindings reference
+
+Press `?` to swap the detail pane for the full keybinding reference, scrollable with `↑` `↓`. `?` again (or `esc`) returns to Site detail.
+
+## Live updates
+
+The TUI draws state from the same sources `lerd-ui` uses, in-process:
+
+- Subscribes to the shared eventbus so any mutation the TUI itself triggers shows up immediately (150 ms debounce).
+- Re-queries every 2 seconds as a safety net, so changes made from another terminal (`lerd service stop redis` in a different shell) surface within a couple of seconds.
+- Services and site state are built from the same `siteinfo` + `podman.Cache` path the web UI uses, so the two surfaces can't disagree.
+
+## Troubleshooting
+
+- **Terminal too small** — if the window is under 60 columns by 12 rows the dashboard refuses to render and asks you to resize. It picks up the new size on the next frame.
+- **Non-interactive shells** — `lerd tui` exits with an error when stdout isn't a TTY (piped output, CI). Run it inside a real terminal.
+- **Worker log says nothing** — check the worker is actually running (`lerd status` or the Workers section of the detail pane). Journal logs only exist while the unit has run at least once.

--- a/docs/features/web-ui.md
+++ b/docs/features/web-ui.md
@@ -79,7 +79,8 @@ The middle panel lists individual system components: DNS, Nginx, Watcher, each i
 
 Selecting an item opens its detail panel:
 
-- **PHP-FPM cards**: show which sites use the version, Xdebug toggle, custom extension list, and a live FPM log stream. For versions with no active sites, a manual Start/Stop button is shown.
+- **PHP-FPM cards**: show which sites use the version, Xdebug toggle with an inline mode selector (debug, coverage, debug-plus-coverage, develop, profile, trace, gcstats, visible when Xdebug is on), custom extension list, and a live FPM log stream. For versions with no active sites, a manual Start/Stop button is shown.
+- **Site Xdebug chip**: every site detail shows a small Xdebug chip in the services row, purple with the active mode when on, gray with `off` when disabled. Clicking the chip jumps to that PHP version's FPM card so you can flip the state without leaving the site.
 - **Node.js cards**: show which sites use the version, with a remove button. The **Install Node.js version** entry has an inline form; enter a version number (e.g. `22`) and click **Install**, equivalent to `lerd node:install <version>`.
 - **Watcher card**: shows whether `lerd-watcher` is running; a Start button appears when stopped. Streams live watcher logs (DNS repair events, fsnotify errors, worktree timeouts).
 - **Autostart card**: enable or disable automatic start of all services at login.

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -50,3 +50,21 @@ The released binary is fully static with no runtime dependencies. You do not nee
 - **Xcode Command Line Tools**: required by Homebrew (`xcode-select --install` if missing)
 
 DNS, the local CA (mkcert), and nginx are all set up by `lerd install`. No system-level resolver configuration is needed; macOS picks up `.test` lookups from `/etc/resolver/test` which lerd writes for you.
+
+### Podman Machine memory
+
+On first start `lerd` sizes the Podman Machine VM based on your host RAM so 8 GB MacBooks aren't squeezed while larger machines get headroom for heavier workloads.
+
+| Host RAM | Podman Machine memory |
+|----------|-----------------------|
+| ≤ 8 GB   | 3 GB                  |
+| 9-31 GB  | 4 GB                  |
+| ≥ 32 GB  | 6 GB                  |
+
+The memory value is a ceiling, not a reservation: the VM only uses what your containers actually request. If sites slow down under load on an 8 GB host, bump the VM manually:
+
+```bash
+podman machine stop
+podman machine set --memory 4096
+podman machine start
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,6 @@ features:
     title: Built-in services
     details: MySQL, Redis, PostgreSQL, Meilisearch, RustFS, and Mailpit. One command to start, shared across all your projects.
   - icon: 🖥️
-    title: Web UI & system tray
-    details: Browser dashboard with live logs, per-site controls, and one-click toggles. Plus a system tray applet for at-a-glance status.
+    title: Web UI, terminal dashboard & tray
+    details: Browser dashboard, btop-style terminal dashboard (`lerd tui`), and a system tray applet. Pick whichever fits your workflow.
 ---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -7,7 +7,7 @@
 | `lerd install` | One-time setup: directories, network, binaries, DNS, nginx, watcher |
 | `lerd start` | Start DNS, nginx, PHP-FPM containers, and all installed services; warns about port conflicts and builds or pulls any missing images first |
 | `lerd stop` | Stop DNS, nginx, PHP-FPM containers, and all running services |
-| `lerd quit` | Stop all Lerd processes and containers including the UI, watcher, and tray |
+| `lerd quit` | Stop all Lerd processes and containers including the UI, watcher, and tray; on macOS also stops the Podman Machine VM |
 | `lerd update` | Check for updates and update after confirmation |
 | `lerd update --beta` | Update to the latest pre-release build |
 | `lerd update --rollback` | Revert to the previously installed version |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -22,6 +22,7 @@
 | `lerd which` | Show resolved PHP version, Node version, document root, and nginx config for the current site |
 | `lerd about` | Show version, build info, and project URL |
 | `lerd man [page]` | Browse the built-in documentation in the terminal; pass a page name to jump directly (e.g. `lerd man sites`) |
+| `lerd tui` | Open a btop-style terminal dashboard with live site / service / worker status, per-site detail pane, inline domain and version editing, shell drop-in, log tailing, filter + sort, and global settings |
 | `lerd check` | Validate `.lerd.yaml` syntax, services, and PHP version before setup |
 | `lerd doctor` | Full environment diagnostic: podman, systemd, DNS, ports, PHP images, config validity |
 | `lerd logs [-f] [target]` | Show logs for the current project's FPM container, `nginx`, a service name, or a PHP version |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -101,9 +101,9 @@ See [Remote / LAN Development](/usage/remote-development) for the full walkthrou
 | `lerd php:list` | List all installed PHP-FPM versions |
 | `lerd php:rebuild [--local]` | Force-rebuild all installed PHP-FPM images (pulls pre-built base by default; `--local` builds from source) |
 | `lerd fetch [version...] [--local]` | Pull pre-built PHP FPM base images from ghcr.io for the given (or all supported) versions; `--local` builds from source instead |
-| `lerd xdebug on [version]` | Enable Xdebug for a PHP version |
+| `lerd xdebug on [version] [--mode MODE]` | Enable Xdebug for a PHP version. `--mode` defaults to `debug`; accepts `coverage`, `develop`, `profile`, `trace`, `gcstats`, or comma combos like `debug,coverage` |
 | `lerd xdebug off [version]` | Disable Xdebug |
-| `lerd xdebug status` | Show Xdebug enabled/disabled for all installed PHP versions |
+| `lerd xdebug status` | Show Xdebug enabled/disabled state and active mode for all installed PHP versions |
 | `lerd php:ext add <ext> [version]` | Add a custom PHP extension and rebuild the FPM image |
 | `lerd php:ext remove <ext> [version]` | Remove a custom PHP extension and rebuild |
 | `lerd php:ext list [version]` | List custom extensions for a PHP version |

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -72,8 +72,9 @@ The full off-switch:
 2. Stops `lerd-ui` (Web UI).
 3. Stops `lerd-watcher`.
 4. Kills the system tray process.
+5. **macOS only:** stops the Podman Machine VM.
 
-After `lerd quit` there are no lerd processes left running. This is the right command before a reinstall, a system reboot, or before pulling a major update.
+After `lerd quit` there are no lerd processes left running. On macOS the Podman Machine VM is also shut down, so `lerd start` will bring it back up on the next run. This is the right command before a reinstall, a system reboot, or before pulling a major update.
 
 The system tray's **Quit Lerd** menu item calls `lerd quit`.
 

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -14,7 +14,7 @@ Day-to-day lifecycle commands for the entire lerd stack: DNS, nginx, PHP-FPM con
 |---|---|---|
 | `lerd start` | nothing | DNS, nginx, watcher, tray, all PHP-FPM containers in use, services that were running before stop, queue / schedule / reverb / messenger workers, stripe listeners, Web UI |
 | `lerd stop` | All containers and workers above. Leaves the watcher and Web UI alone. | nothing |
-| `lerd quit` | Everything `lerd stop` does, **plus** the Web UI, watcher, and tray. | nothing |
+| `lerd quit` | Everything `lerd stop` does, **plus** the Web UI, watcher, and tray. macOS: also stops the Podman Machine VM. | nothing |
 
 `lerd stop` is the everyday "give my laptop back its CPU" command. `lerd quit` is a full shutdown: use it before a reinstall, a system reboot without autostart, or when you really want lerd out of the way.
 

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -9,9 +9,9 @@
 | `lerd php:list` | List all installed PHP-FPM versions |
 | `lerd php:rebuild [--local]` | Force-rebuild all installed PHP-FPM images; `--local` builds from source instead of pulling a base |
 | `lerd fetch [version...] [--local]` | Pull pre-built PHP FPM base images from ghcr.io; `--local` builds from source instead |
-| `lerd xdebug on [version]` | Enable Xdebug for a PHP version (rebuilds the FPM image and restarts the container) |
-| `lerd xdebug off [version]` | Disable Xdebug (rebuilds without Xdebug and restarts) |
-| `lerd xdebug status` | Show Xdebug enabled/disabled for all installed PHP versions |
+| `lerd xdebug on [version] [--mode MODE]` | Enable Xdebug for a PHP version with the given mode (default `debug`) and restart the FPM container |
+| `lerd xdebug off [version]` | Disable Xdebug and restart the FPM container |
+| `lerd xdebug status` | Show Xdebug enabled/disabled state and active mode for all installed PHP versions |
 | `lerd php:ext add <ext> [version]` | Add a custom PHP extension to the FPM image and rebuild |
 | `lerd php:ext remove <ext> [version]` | Remove a custom PHP extension and rebuild |
 | `lerd php:ext list [version]` | List custom extensions configured for a PHP version |
@@ -118,7 +118,7 @@ systemctl --user stop   lerd-php84-fpm
 ::: details Xdebug configuration values
 Xdebug is configured with:
 
-- `xdebug.mode=debug`
+- `xdebug.mode=<mode>` (defaults to `debug`, configurable per PHP version)
 - `xdebug.start_with_request=yes`
 - `xdebug.client_host=host.containers.internal` (reaches your host IDE from the container)
 - `xdebug.client_port=9003`
@@ -127,6 +127,20 @@ Set your IDE to listen on port `9003`. In VS Code, the default PHP Debug configu
 
 `host.containers.internal` is resolved via a real reachability probe: when lerd writes the shared hosts file it tries each candidate IP (netavark's `host.containers.internal` entry, the host's primary LAN IP, slirp4netns's `10.0.2.2`) by opening a TCP connection to lerd-ui on port 7073 from inside lerd-nginx, and writes the first one that succeeds. If none succeed, `lerd doctor` reports the failure so you get a real diagnosis instead of Xdebug silently timing out with `Time-out connecting to debugging client`.
 :::
+
+### Picking a mode
+
+Xdebug supports several modes: `debug` (step debugging, the default), `coverage` (code coverage collection), `develop`, `profile`, `trace`, `gcstats`, and `off`. Pick one with `--mode`:
+
+```bash
+lerd xdebug on --mode coverage        # code coverage for phpunit / pest
+lerd xdebug on --mode debug,coverage  # both at once
+lerd xdebug on 8.4 --mode trace       # explicit version
+```
+
+When combined with PCOV this matters in one direction: if your test runner's `phpunit.xml` prefers PCOV it still wins for coverage, but once you enable Xdebug in `coverage` mode your runner can fall back to Xdebug when PCOV isn't available or is disabled (`pcov.enabled = 0` in `lerd php:ini`). Running Xdebug in `coverage` mode carries the usual runtime cost, so only switch while you actually need coverage.
+
+Re-run `lerd xdebug on --mode <new>` at any time to swap modes without going through `off` first.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,11 @@ require (
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/ansi v0.10.2
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/getlantern/systray v1.2.2
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2
 	golang.org/x/crypto v0.49.0
@@ -25,7 +27,6 @@ require (
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/x/ansi v0.10.2 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
@@ -60,7 +61,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
-	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -535,6 +535,7 @@ func runInstall(_ *cobra.Command, _ []string) error {
 
 	fmt.Println("\nLerd installation complete!")
 	fmt.Println("\n  Dashboard: \033[96mhttp://lerd.localhost\033[0m")
+	fmt.Println("  Terminal:  \033[96mlerd tui\033[0m")
 	return nil
 }
 

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -629,7 +629,9 @@ Enable or disable HTTPS for a site using a locally-trusted mkcert certificate. B
 ### ` + bt + `xdebug_on` + bt + ` / ` + bt + `xdebug_off` + bt + ` / ` + bt + `xdebug_status` + bt + `
 Toggle Xdebug for a PHP version (restarts the FPM container). Optional ` + bt + `version` + bt + ` argument — defaults to the project or global PHP version. Xdebug listens on port ` + bt + `9003` + bt + ` at ` + bt + `host.containers.internal` + bt + `.
 
-` + bt + `xdebug_status` + bt + ` returns the enabled/disabled state for all installed PHP versions.
+` + bt + `xdebug_on` + bt + ` accepts an optional ` + bt + `mode` + bt + ` argument (default ` + bt + `debug` + bt + `). Valid values: ` + bt + `debug` + bt + `, ` + bt + `coverage` + bt + `, ` + bt + `develop` + bt + `, ` + bt + `profile` + bt + `, ` + bt + `trace` + bt + `, ` + bt + `gcstats` + bt + `, or a comma-separated combo such as ` + bt + `debug,coverage` + bt + `. Use ` + bt + `coverage` + bt + ` for ` + bt + `phpunit --coverage` + bt + ` / ` + bt + `pest --coverage` + bt + ` when PCOV isn't available or is disabled. Calling ` + bt + `xdebug_on` + bt + ` with a different mode on an already-enabled version swaps modes without needing ` + bt + `xdebug_off` + bt + ` first.
+
+` + bt + `xdebug_status` + bt + ` returns the enabled/disabled state and the active ` + bt + `mode` + bt + ` for all installed PHP versions.
 
 ### ` + bt + `queue_start` + bt + ` / ` + bt + `queue_stop` + bt + `
 Start or stop a queue worker for a site. Available for any framework that defines a ` + bt + `queue` + bt + ` worker (Laravel has it built-in). Runs the framework-defined command in the FPM container as a systemd service.
@@ -871,10 +873,17 @@ secure(site: "myapp")
 
 **Enable Xdebug for a debugging session:**
 ` + "```" + `
-xdebug_status()              // check current state
-xdebug_on(version: "8.4")   // enable and restart FPM
+xdebug_status()                                 // check current state and mode
+xdebug_on(version: "8.4")                       // default mode=debug, restarts FPM
 // ... debug ...
-xdebug_off(version: "8.4")  // disable when done (Xdebug adds overhead)
+xdebug_off(version: "8.4")                      // disable when done (Xdebug adds overhead)
+` + "```" + `
+
+**Enable Xdebug coverage mode for phpunit/pest:**
+` + "```" + `
+xdebug_on(version: "8.4", mode: "coverage")     // swap mode without xdebug_off first
+vendor_run(name: "pest", args: ["--coverage"])
+xdebug_off(version: "8.4")
 ` + "```" + `
 
 **Run migrations after schema changes:**
@@ -1166,9 +1175,9 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `unpark` + bt + ` | Remove a parked directory and unlink all its sites |
 | ` + bt + `secure` + bt + ` | Enable HTTPS for a site (mkcert) — updates APP_URL automatically |
 | ` + bt + `unsecure` + bt + ` | Disable HTTPS for a site |
-| ` + bt + `xdebug_on` + bt + ` | Enable Xdebug for a PHP version (port 9003) |
+| ` + bt + `xdebug_on` + bt + ` | Enable Xdebug for a PHP version (port 9003); optional ` + bt + `mode` + bt + ` (default ` + bt + `debug` + bt + `; also ` + bt + `coverage` + bt + `, ` + bt + `develop` + bt + `, ` + bt + `profile` + bt + `, ` + bt + `trace` + bt + `, ` + bt + `gcstats` + bt + `, or comma combos) |
 | ` + bt + `xdebug_off` + bt + ` | Disable Xdebug for a PHP version |
-| ` + bt + `xdebug_status` + bt + ` | Show Xdebug state for all PHP versions |
+| ` + bt + `xdebug_status` + bt + ` | Show Xdebug state and active mode for all PHP versions |
 | ` + bt + `service_start` + bt + ` | Start a built-in or custom service |
 | ` + bt + `service_stop` + bt + ` | Stop a service |
 | ` + bt + `service_add` + bt + ` | Register a new custom OCI service (MongoDB, RabbitMQ, …); supports ` + bt + `depends_on` + bt + ` for service dependencies |

--- a/internal/cli/park.go
+++ b/internal/cli/park.go
@@ -297,10 +297,7 @@ func ensureFPMQuadletTo(phpVersion string, w io.Writer) error {
 	}
 	_ = podman.StoreFPMHash()
 
-	// Ensure the xdebug ini exists (mode=off by default).
-	if _, err := os.Stat(config.PHPConfFile(phpVersion)); os.IsNotExist(err) {
-		_ = podman.WriteXdebugIni(phpVersion, false)
-	}
+	_ = podman.EnsureXdebugIni(phpVersion)
 
 	if err := podman.WriteFPMQuadlet(phpVersion); err != nil {
 		return err

--- a/internal/cli/podman_memory.go
+++ b/internal/cli/podman_memory.go
@@ -1,0 +1,18 @@
+package cli
+
+// recommendedVMMemoryMiB picks Podman Machine memory based on host RAM.
+// Returns 4096 (safe default) when detection fails so we never go below
+// the floor that fixes the v1.12.6 MySQL+PHP-FPM+Horizon swap thrash.
+// int64 matches strconv.ParseInt at the comparison site.
+func recommendedVMMemoryMiB(hostMemoryGiB int) int64 {
+	switch {
+	case hostMemoryGiB <= 0:
+		return 4096
+	case hostMemoryGiB <= 8:
+		return 3072
+	case hostMemoryGiB < 32:
+		return 4096
+	default:
+		return 6144
+	}
+}

--- a/internal/cli/podman_memory_test.go
+++ b/internal/cli/podman_memory_test.go
@@ -1,0 +1,28 @@
+package cli
+
+import "testing"
+
+func TestRecommendedVMMemoryMiB(t *testing.T) {
+	cases := []struct {
+		name string
+		host int
+		want int64
+	}{
+		{"detection failed", 0, 4096},
+		{"negative invalid", -1, 4096},
+		{"low-end 4GB", 4, 3072},
+		{"8GB MacBook", 8, 3072},
+		{"9GB edge", 9, 4096},
+		{"16GB laptop", 16, 4096},
+		{"31GB upper mid", 31, 4096},
+		{"32GB workstation", 32, 6144},
+		{"64GB power user", 64, 6144},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := recommendedVMMemoryMiB(c.host); got != c.want {
+				t.Errorf("recommendedVMMemoryMiB(%d) = %d, want %d", c.host, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -938,5 +938,7 @@ func runQuit(_ *cobra.Command, _ []string) error {
 	// Also kill any directly-launched tray instance not managed by launchd/systemd.
 	killTray()
 
+	stopPodmanMachine()
+
 	return nil
 }

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -40,6 +40,20 @@ func migrateExecWorkerPlists() {
 	}
 }
 
+// hostMemoryGiB reads host RAM in GiB via sysctl. Returns 0 on failure so
+// the caller falls back to the safe 4 GB default.
+func hostMemoryGiB() int {
+	out, err := exec.Command("sysctl", "-n", "hw.memsize").Output()
+	if err != nil {
+		return 0
+	}
+	bytes, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
+	if err != nil || bytes <= 0 {
+		return 0
+	}
+	return int(bytes / (1024 * 1024 * 1024))
+}
+
 // ensurePodmanMachineRunning ensures a Podman Machine VM exists, is rootful,
 // and is running. If no machine exists it initialises one with --rootful.
 // If an existing machine is rootless it is stopped, switched, and restarted.
@@ -110,15 +124,14 @@ func ensurePodmanMachineRunning() {
 		needsRootful := !m.rootful
 		needsMemory := false
 
-		// Check whether the machine has at least 4 GB RAM. MySQL + PHP-FPM +
-		// Horizon together need it; machines initialised with the default 2 GB
-		// run out of memory and thrash swap, causing 800%+ host CPU usage.
+		// Target memory scales with host RAM so 8 GB MacBooks aren't squeezed.
 		// {{.Resources.Memory}} returns MiB directly (not bytes).
-		const minMemoryMiB = 4096
+		hostGiB := hostMemoryGiB()
+		targetMemoryMiB := recommendedVMMemoryMiB(hostGiB)
 		if inspectMem, err := exec.Command(podman.PodmanBin(), "machine", "inspect",
 			"--format", "{{.Resources.Memory}}", m.name).Output(); err == nil {
 			if memMiB, parseErr := strconv.ParseInt(strings.TrimSpace(string(inspectMem)), 10, 64); parseErr == nil && memMiB > 0 {
-				if memMiB < minMemoryMiB {
+				if memMiB < targetMemoryMiB {
 					needsMemory = true
 				}
 			}
@@ -129,11 +142,11 @@ func ensurePodmanMachineRunning() {
 				var reason string
 				switch {
 				case needsRootful && needsMemory:
-					reason = "enable rootful mode and increase memory to 4 GB"
+					reason = fmt.Sprintf("enable rootful mode and increase memory to %d MB", targetMemoryMiB)
 				case needsRootful:
 					reason = "enable rootful mode"
 				default:
-					reason = "increase memory to 4 GB"
+					reason = fmt.Sprintf("increase memory to %d MB", targetMemoryMiB)
 				}
 				fmt.Printf("  --> Stopping Podman Machine to %s ...\n", reason)
 				stopCmd := exec.Command(podman.PodmanBin(), "machine", "stop", m.name)
@@ -151,9 +164,14 @@ func ensurePodmanMachineRunning() {
 				}
 			}
 			if needsMemory {
-				fmt.Printf("  --> Setting Podman Machine memory to %d MB (recommended minimum) ...\n", minMemoryMiB)
+				if hostGiB > 0 && hostGiB <= 8 {
+					fmt.Printf("  --> Host has %d GB RAM; setting Podman Machine to %d MB (tight but workable) ...\n", hostGiB, targetMemoryMiB)
+					fmt.Println("       If sites slow down under load, run: podman machine set --memory 4096")
+				} else {
+					fmt.Printf("  --> Setting Podman Machine memory to %d MB ...\n", targetMemoryMiB)
+				}
 				setCmd := exec.Command(podman.PodmanBin(), "machine", "set",
-					"--memory", strconv.Itoa(minMemoryMiB), m.name)
+					"--memory", strconv.FormatInt(targetMemoryMiB, 10), m.name)
 				setCmd.Stdout = os.Stdout
 				setCmd.Stderr = os.Stderr
 				if err := setCmd.Run(); err != nil {

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -210,6 +210,32 @@ func ensurePodmanMachineRunning() {
 	fmt.Println(" timed out (proceeding anyway)")
 }
 
+// stopPodmanMachine stops the running Podman Machine VM. Called by runQuit so
+// the VM is cleanly shut down when the user quits Lerd entirely.
+func stopPodmanMachine() {
+	out, err := exec.Command(podman.PodmanBin(), "machine", "list", "--format", "{{.Name}}\t{{.Running}}").Output()
+	if err != nil {
+		return
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[1] != "true" {
+			continue
+		}
+		name := strings.TrimSuffix(fields[0], "*")
+		fmt.Printf("  --> Stopping Podman Machine (%s) ...\n", name)
+		cmd := exec.Command(podman.PodmanBin(), "machine", "stop", name)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("  WARN: podman machine stop: %v\n", err)
+		}
+	}
+}
+
 // batchStopContainers stops all running lerd-* containers in two podman calls
 // (stop then rm) so the Podman Machine socket isn't flooded by N individual
 // stop requests from RunParallel. After this returns the individual Stop()

--- a/internal/cli/startstop_linux.go
+++ b/internal/cli/startstop_linux.go
@@ -13,3 +13,6 @@ func migrateExecWorkerPlists() {}
 // batchStopContainers is a no-op on Linux — systemd stops containers via unit
 // deactivation so individual StopUnit calls are efficient and non-blocking.
 func batchStopContainers(_ []string) {}
+
+// stopPodmanMachine is a no-op on Linux — Podman runs natively without a VM.
+func stopPodmanMachine() {}

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/geodro/lerd/internal/tui"
+	"github.com/geodro/lerd/internal/version"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// NewTuiCmd returns the `lerd tui` command. Opens a btop-style dashboard in
+// the terminal with live site / service / worker status and keybindings for
+// common start / stop / restart actions.
+func NewTuiCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "tui",
+		Short: "Open a terminal dashboard for sites, services, and workers",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if !term.IsTerminal(int(os.Stdout.Fd())) {
+				return fmt.Errorf("lerd tui requires an interactive terminal")
+			}
+			return tui.Run(version.String())
+		},
+	}
+}

--- a/internal/cli/xdebug.go
+++ b/internal/cli/xdebug.go
@@ -3,11 +3,11 @@ package cli
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/geodro/lerd/internal/config"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/xdebugops"
 	"github.com/spf13/cobra"
 )
 
@@ -24,14 +24,22 @@ func NewXdebugCmd() *cobra.Command {
 }
 
 func newXdebugOnCmd() *cobra.Command {
-	return &cobra.Command{
+	var mode string
+	cmd := &cobra.Command{
 		Use:   "on [version]",
 		Short: "Enable Xdebug for a PHP version (rebuilds the FPM image)",
+		Long:  "Enable Xdebug for a PHP version. Use --mode to pick a non-default mode, e.g. --mode coverage for code coverage, or --mode debug,coverage to combine.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runXdebugToggle(args, true)
+			normalised, err := podman.NormaliseXdebugMode(mode)
+			if err != nil {
+				return err
+			}
+			return runXdebugToggle(args, true, normalised)
 		},
 	}
+	cmd.Flags().StringVar(&mode, "mode", "debug", "xdebug.mode value (debug, coverage, develop, profile, trace, gcstats, or a comma-separated combo)")
+	return cmd
 }
 
 func newXdebugOffCmd() *cobra.Command {
@@ -40,7 +48,7 @@ func newXdebugOffCmd() *cobra.Command {
 		Short: "Disable Xdebug for a PHP version (rebuilds the FPM image)",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runXdebugToggle(args, false)
+			return runXdebugToggle(args, false, "")
 		},
 	}
 }
@@ -72,55 +80,44 @@ func xdebugVersion(args []string) (string, error) {
 	return v, nil
 }
 
-func runXdebugToggle(args []string, enable bool) error {
+func runXdebugToggle(args []string, enable bool, mode string) error {
 	version, err := xdebugVersion(args)
 	if err != nil {
 		return err
 	}
 
-	cfg, err := config.LoadGlobal()
+	applyMode := ""
+	if enable {
+		applyMode = mode
+	}
+
+	res, err := xdebugops.Apply(version, applyMode)
 	if err != nil {
 		return err
 	}
 
-	// No-op if already in the desired state.
-	if cfg.IsXdebugEnabled(version) == enable {
+	if res.NoChange {
 		state := "disabled"
-		if enable {
-			state = "enabled"
+		if res.Enabled {
+			state = fmt.Sprintf("enabled (mode=%s)", res.Mode)
 		}
 		fmt.Printf("Xdebug is already %s for PHP %s\n", state, version)
 		return nil
 	}
 
-	cfg.SetXdebug(version, enable)
-	if err := config.SaveGlobal(cfg); err != nil {
-		return fmt.Errorf("saving config: %w", err)
-	}
-
-	if err := podman.WriteXdebugIni(version, enable); err != nil {
-		return fmt.Errorf("writing xdebug ini: %w", err)
-	}
-
-	// Update quadlet (adds volume mount if not already present) + restart.
-	if err := podman.WriteFPMQuadlet(version); err != nil {
-		fmt.Printf("[WARN] updating quadlet: %v\n", err)
-	}
-
-	short := strings.ReplaceAll(version, ".", "")
-	unit := "lerd-php" + short + "-fpm"
-	if err := podman.RestartUnit(unit); err != nil {
-		fmt.Printf("[WARN] restart %s: %v\n", unit, err)
+	if res.RestartErr != nil {
+		unit := xdebugops.FPMUnit(version)
+		fmt.Printf("[WARN] restart %s: %v\n", unit, res.RestartErr)
 		fmt.Printf("Run: systemctl --user restart %s\n", unit)
-	} else {
+	} else if res.Restarted {
 		fmt.Printf("FPM container restarted.\n")
 	}
 
-	state := "disabled"
-	if enable {
-		state = "enabled"
+	if res.Enabled {
+		fmt.Printf("Xdebug enabled for PHP %s (mode=%s, port 9003, host.containers.internal)\n", version, res.Mode)
+	} else {
+		fmt.Printf("Xdebug disabled for PHP %s\n", version)
 	}
-	fmt.Printf("Xdebug %s for PHP %s (port 9003, host.containers.internal)\n", state, version)
 	return nil
 }
 
@@ -140,14 +137,17 @@ func runXdebugStatus(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	fmt.Printf("%-10s %s\n", "Version", "Xdebug")
-	fmt.Printf("%-10s %s\n", "─────────", "──────")
+	fmt.Printf("%-10s %-10s %s\n", "Version", "Xdebug", "Mode")
+	fmt.Printf("%-10s %-10s %s\n", "─────────", "──────────", "────")
 	for _, v := range versions {
-		status := "\033[33mdisabled\033[0m"
-		if cfg.IsXdebugEnabled(v) {
-			status = "\033[32menabled\033[0m"
+		state := "disabled"
+		color := "\033[33m"
+		mode := cfg.GetXdebugMode(v)
+		if mode != "" {
+			state = "enabled"
+			color = "\033[32m"
 		}
-		fmt.Printf("%-10s %s\n", v, status)
+		fmt.Printf("%-10s %s%-10s\033[0m %s\n", v, color, state, mode)
 	}
 	return nil
 }

--- a/internal/cli/xdebug_test.go
+++ b/internal/cli/xdebug_test.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"testing"
+)
+
+// TestXdebugOnCmd_ModeFlag guards the --mode flag wiring against accidental
+// removal during future refactors. Without the flag users can't reach any
+// mode other than the default "debug", which defeats the purpose of the
+// per-mode support.
+func TestXdebugOnCmd_ModeFlag(t *testing.T) {
+	cmd := newXdebugOnCmd()
+	flag := cmd.Flags().Lookup("mode")
+	if flag == nil {
+		t.Fatal("--mode flag not registered on `lerd xdebug on`")
+	}
+	if flag.DefValue != "debug" {
+		t.Errorf("--mode default = %q, want %q", flag.DefValue, "debug")
+	}
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -20,6 +20,7 @@ type GlobalConfig struct {
 	PHP struct {
 		DefaultVersion string              `yaml:"default_version" mapstructure:"default_version"`
 		XdebugEnabled  map[string]bool     `yaml:"xdebug_enabled"  mapstructure:"xdebug_enabled"`
+		XdebugMode     map[string]string   `yaml:"xdebug_mode,omitempty" mapstructure:"xdebug_mode"`
 		Extensions     map[string][]string `yaml:"extensions"      mapstructure:"extensions"`
 	} `yaml:"php" mapstructure:"php"`
 	Node struct {
@@ -211,19 +212,50 @@ func migrateStaleServiceImages(cfg *GlobalConfig) {
 
 // IsXdebugEnabled returns true if Xdebug is enabled for the given PHP version.
 func (c *GlobalConfig) IsXdebugEnabled(version string) bool {
-	return c.PHP.XdebugEnabled[version]
+	return c.GetXdebugMode(version) != ""
 }
 
-// SetXdebug enables or disables Xdebug for the given PHP version.
+// GetXdebugMode returns the configured Xdebug mode for version, or "" when
+// disabled. Entries in the legacy xdebug_enabled map (no explicit mode) are
+// treated as mode "debug" so configs written by older lerd builds keep the
+// same behaviour they had before per-mode support existed.
+func (c *GlobalConfig) GetXdebugMode(version string) string {
+	if m, ok := c.PHP.XdebugMode[version]; ok && m != "" {
+		return m
+	}
+	if c.PHP.XdebugEnabled[version] {
+		return "debug"
+	}
+	return ""
+}
+
+// SetXdebug enables (mode "debug") or disables Xdebug for version. Use
+// SetXdebugMode directly when a non-default mode is wanted.
 func (c *GlobalConfig) SetXdebug(version string, enabled bool) {
+	if !enabled {
+		c.SetXdebugMode(version, "")
+		return
+	}
+	c.SetXdebugMode(version, "debug")
+}
+
+// SetXdebugMode sets the Xdebug mode for version. Empty mode disables Xdebug.
+// Both the modern xdebug_mode map and the legacy xdebug_enabled map are kept
+// in sync so downgrades don't silently flip state.
+func (c *GlobalConfig) SetXdebugMode(version, mode string) {
 	if c.PHP.XdebugEnabled == nil {
 		c.PHP.XdebugEnabled = map[string]bool{}
 	}
-	if !enabled {
+	if c.PHP.XdebugMode == nil {
+		c.PHP.XdebugMode = map[string]string{}
+	}
+	if mode == "" {
 		delete(c.PHP.XdebugEnabled, version)
+		delete(c.PHP.XdebugMode, version)
 		return
 	}
 	c.PHP.XdebugEnabled[version] = true
+	c.PHP.XdebugMode[version] = mode
 }
 
 // GetExtensions returns the custom extensions configured for the given PHP version.

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -102,6 +102,50 @@ func TestXdebug_IndependentVersions(t *testing.T) {
 	}
 }
 
+func TestXdebug_ModeRoundtrip(t *testing.T) {
+	cfg := &GlobalConfig{}
+
+	cfg.SetXdebugMode("8.3", "coverage")
+	if cfg.GetXdebugMode("8.3") != "coverage" {
+		t.Errorf("GetXdebugMode = %q, want %q", cfg.GetXdebugMode("8.3"), "coverage")
+	}
+	if !cfg.IsXdebugEnabled("8.3") {
+		t.Error("IsXdebugEnabled should be true when a mode is set")
+	}
+
+	cfg.SetXdebugMode("8.3", "debug,coverage")
+	if cfg.GetXdebugMode("8.3") != "debug,coverage" {
+		t.Errorf("GetXdebugMode = %q, want combo", cfg.GetXdebugMode("8.3"))
+	}
+
+	cfg.SetXdebugMode("8.3", "")
+	if cfg.IsXdebugEnabled("8.3") {
+		t.Error("empty mode should disable xdebug")
+	}
+}
+
+// Legacy configs (lerd <= 1.15.1) only wrote xdebug_enabled. GetXdebugMode
+// must fall back to "debug" for those entries so upgrade keeps working.
+func TestXdebug_LegacyEnabledFallsBackToDebug(t *testing.T) {
+	cfg := &GlobalConfig{}
+	cfg.PHP.XdebugEnabled = map[string]bool{"8.3": true}
+
+	if got := cfg.GetXdebugMode("8.3"); got != "debug" {
+		t.Errorf("legacy xdebug_enabled → GetXdebugMode = %q, want %q", got, "debug")
+	}
+	if !cfg.IsXdebugEnabled("8.3") {
+		t.Error("IsXdebugEnabled should honour legacy flag")
+	}
+}
+
+func TestXdebug_SetXdebugDefaultsToDebugMode(t *testing.T) {
+	cfg := &GlobalConfig{}
+	cfg.SetXdebug("8.3", true)
+	if got := cfg.GetXdebugMode("8.3"); got != "debug" {
+		t.Errorf("SetXdebug(true) → mode = %q, want %q", got, "debug")
+	}
+}
+
 // ── Extensions ────────────────────────────────────────────────────────────────
 
 func TestExtensions_AddRemoveGet(t *testing.T) {

--- a/internal/git/copy.go
+++ b/internal/git/copy.go
@@ -1,0 +1,172 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// CopyTree copies src to dst recursively. It first tries a reflink-aware
+// fast path via cp, which is near-instant on btrfs, XFS with reflink=1,
+// and APFS. Falls back to a plain recursive Go copy elsewhere. dst must
+// not already exist.
+func CopyTree(src, dst string) error {
+	if err := copyTreeCP(src, dst); err == nil {
+		return nil
+	}
+	_ = os.RemoveAll(dst)
+	return copyTreeNative(src, dst)
+}
+
+func copyTreeCP(src, dst string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("cp", "-a", "--reflink=auto", src, dst)
+	case "darwin":
+		cmd = exec.Command("cp", "-Rc", src, dst)
+	default:
+		return errors.New("reflink path unsupported on " + runtime.GOOS)
+	}
+	return cmd.Run()
+}
+
+func copyTreeNative(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return os.MkdirAll(target, info.Mode())
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			link, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			return os.Symlink(link, target)
+		}
+		return copyFileWithMode(path, target, info.Mode())
+	})
+}
+
+func copyFileWithMode(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return nil
+}
+
+// InstallDependencies runs composer install and the JS package manager
+// matching whatever lockfile the project ships so vendor/ and node_modules/
+// match that checkout's own lockfiles. composer goes through the lerd
+// shim (which routes into the project's PHP-FPM container); JS tooling
+// goes through whichever of pnpm/yarn/bun/npm is on PATH, preferring the
+// npm shim from BinDir when the project uses npm so the fnm Node version
+// is picked up.
+//
+// Errors are aggregated and returned; callers should log them rather than
+// treat them as fatal since the worktree is still usable with the copied
+// trees from main.
+func InstallDependencies(projectPath string) error {
+	var errs []error
+
+	if hasFile(projectPath, "composer.json") {
+		composer := filepath.Join(config.BinDir(), "composer")
+		if err := runIn(projectPath, composer, "install", "--no-interaction", "--no-progress"); err != nil {
+			errs = append(errs, fmt.Errorf("composer install: %w", err))
+		}
+	}
+
+	if hasFile(projectPath, "package.json") {
+		if err := runJSInstall(projectPath); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// jsPackageManager returns the name and install args for the package
+// manager a project uses, picked from the presence of lockfiles.
+// Preference order mirrors each manager's lockfile being definitive:
+// pnpm-lock.yaml ▸ yarn.lock ▸ bun.lock(b) ▸ npm lockfile ▸ npm as fallback.
+func jsPackageManager(projectPath string) (name string, args []string) {
+	switch {
+	case hasFile(projectPath, "pnpm-lock.yaml"):
+		return "pnpm", []string{"install", "--frozen-lockfile"}
+	case hasFile(projectPath, "yarn.lock"):
+		// --immutable covers both yarn classic (v1) and berry (v2+); v1
+		// doesn't understand it but falls back to default install, which
+		// is what we want if the lockfile is already present.
+		return "yarn", []string{"install", "--immutable"}
+	case hasFile(projectPath, "bun.lockb"), hasFile(projectPath, "bun.lock"):
+		return "bun", []string{"install", "--frozen-lockfile"}
+	case hasFile(projectPath, "package-lock.json"), hasFile(projectPath, "npm-shrinkwrap.json"):
+		return "npm", []string{"ci", "--no-progress"}
+	default:
+		return "npm", []string{"install", "--no-progress"}
+	}
+}
+
+// runJSInstall resolves the chosen package manager's binary and runs the
+// install. For npm we use the lerd shim from BinDir so fnm's current Node
+// version wins; other managers go through PATH since lerd doesn't shim
+// them. Missing binary is logged and returned so the caller aggregates it
+// with other setup errors.
+func runJSInstall(projectPath string) error {
+	name, args := jsPackageManager(projectPath)
+
+	var bin string
+	if name == "npm" {
+		bin = filepath.Join(config.BinDir(), "npm")
+	} else if p, err := exec.LookPath(name); err == nil {
+		bin = p
+	} else {
+		return fmt.Errorf("%s (lockfile present) not found on PATH — install it to hydrate node_modules", name)
+	}
+
+	if err := runIn(projectPath, bin, args...); err != nil {
+		return fmt.Errorf("%s %s: %w", name, args[0], err)
+	}
+	return nil
+}
+
+func hasFile(dir, name string) bool {
+	_, err := os.Stat(filepath.Join(dir, name))
+	return err == nil
+}
+
+func runIn(dir, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/git/copy_test.go
+++ b/internal/git/copy_test.go
@@ -1,0 +1,160 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyTreeNative_RegularFilesAndDirs(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+
+	if err := os.MkdirAll(filepath.Join(src, "sub/nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "top.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "sub/nested/inner.txt"), []byte("world"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyTreeNative(src, dst); err != nil {
+		t.Fatalf("copyTreeNative: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, "top.txt"))
+	if err != nil || string(got) != "hello" {
+		t.Fatalf("top.txt: got %q err %v, want %q nil", got, err, "hello")
+	}
+
+	got, err = os.ReadFile(filepath.Join(dst, "sub/nested/inner.txt"))
+	if err != nil || string(got) != "world" {
+		t.Fatalf("inner.txt: got %q err %v, want %q nil", got, err, "world")
+	}
+
+	info, err := os.Stat(filepath.Join(dst, "sub/nested/inner.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("inner.txt perm: got %o want 600", perm)
+	}
+}
+
+func TestCopyTreeNative_PreservesInnerSymlinks(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+
+	if err := os.WriteFile(filepath.Join(src, "real.txt"), []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real.txt", filepath.Join(src, "link.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyTreeNative(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Lstat(filepath.Join(dst, "link.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("link.txt is not a symlink in dst")
+	}
+	target, err := os.Readlink(filepath.Join(dst, "link.txt"))
+	if err != nil || target != "real.txt" {
+		t.Errorf("link target: got %q err %v, want %q", target, err, "real.txt")
+	}
+}
+
+func TestJSPackageManager_DetectsLockfile(t *testing.T) {
+	cases := []struct {
+		name     string
+		lockfile string
+		wantBin  string
+		wantArg0 string
+	}{
+		{"pnpm", "pnpm-lock.yaml", "pnpm", "install"},
+		{"yarn", "yarn.lock", "yarn", "install"},
+		{"bun-binary", "bun.lockb", "bun", "install"},
+		{"bun-text", "bun.lock", "bun", "install"},
+		{"npm-lockfile", "package-lock.json", "npm", "ci"},
+		{"npm-shrinkwrap", "npm-shrinkwrap.json", "npm", "ci"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, c.lockfile), []byte(""), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			gotBin, gotArgs := jsPackageManager(dir)
+			if gotBin != c.wantBin {
+				t.Errorf("binary: got %q want %q", gotBin, c.wantBin)
+			}
+			if len(gotArgs) == 0 || gotArgs[0] != c.wantArg0 {
+				t.Errorf("first arg: got %v want %q", gotArgs, c.wantArg0)
+			}
+		})
+	}
+}
+
+func TestJSPackageManager_DefaultsToNpmInstallWithoutLockfile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bin, args := jsPackageManager(dir)
+	if bin != "npm" {
+		t.Errorf("binary: got %q want npm", bin)
+	}
+	if len(args) == 0 || args[0] != "install" {
+		t.Errorf("first arg: got %v want install", args)
+	}
+}
+
+func TestJSPackageManager_PnpmBeatsOtherLockfiles(t *testing.T) {
+	// Defensive: if a repo somehow has both pnpm-lock.yaml and
+	// package-lock.json, the pnpm lockfile is the modern one — prefer it.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, lf := range []string{"pnpm-lock.yaml", "package-lock.json"} {
+		if err := os.WriteFile(filepath.Join(dir, lf), []byte(""), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	bin, _ := jsPackageManager(dir)
+	if bin != "pnpm" {
+		t.Errorf("expected pnpm to win over npm lockfile, got %q", bin)
+	}
+}
+
+func TestCopyTree_CP(t *testing.T) {
+	// Covers the cp fast path end-to-end when the host supports it.
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "sub/file"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyTree(src, dst); err != nil {
+		t.Fatalf("CopyTree: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, "sub/file"))
+	if err != nil || string(got) != "x" {
+		t.Fatalf("copied file: got %q err %v", got, err)
+	}
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -117,19 +117,36 @@ func readCheckoutPath(wtDir string) string {
 }
 
 // EnsureWorktreeDeps sets up a worktree checkout with the dependencies it needs:
-//   - vendor/ and node_modules/ are symlinked from the main repo
+//   - vendor/ and node_modules/ are seeded from the main repo via a reflink
+//     copy (near-instant on btrfs, xfs-reflink, APFS; plain copy on ext4),
+//     then reconciled against the worktree's own lockfiles via
+//     composer install / npm ci.
 //   - .env is copied from the main repo with APP_URL rewritten to http(s)://<worktreeDomain>
+//
+// Copying (rather than symlinking) is required because PHP resolves __DIR__
+// through symlinks, which would make Composer's ClassLoader initialise
+// against the main repo directory and silently load stale classes from
+// there.
 func EnsureWorktreeDeps(mainRepoPath, worktreePath, worktreeDomain string, secured bool) {
 	for _, dir := range []string{"vendor", "node_modules"} {
 		dst := filepath.Join(worktreePath, dir)
-		if _, err := os.Lstat(dst); err == nil {
-			continue // already exists or is already a symlink
+		if info, err := os.Lstat(dst); err == nil {
+			if info.Mode()&os.ModeSymlink == 0 {
+				continue // real dir already exists, leave it
+			}
+			_ = os.Remove(dst) // legacy symlink from older lerd, replace it
 		}
 		src := filepath.Join(mainRepoPath, dir)
 		if _, err := os.Stat(src); err != nil {
-			continue // main repo doesn't have it either
+			continue
 		}
-		_ = os.Symlink(src, dst)
+		if err := CopyTree(src, dst); err != nil {
+			_, _ = os.Stderr.WriteString("[WARN] copy " + dir + " into worktree: " + err.Error() + "\n")
+		}
+	}
+
+	if err := InstallDependencies(worktreePath); err != nil {
+		_, _ = os.Stderr.WriteString("[WARN] worktree dependency install: " + err.Error() + "\n")
 	}
 
 	// .env: copy from main repo and set APP_URL to the worktree domain.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -242,3 +242,103 @@ func TestRewriteAppURL_missingFile(t *testing.T) {
 		t.Error("expected error for missing file")
 	}
 }
+
+// EnsureWorktreeDeps copies vendor/ and node_modules/ from the main repo
+// rather than symlinking, because PHP resolves __DIR__ through symlinks
+// and Composer's ClassLoader otherwise initialises against the main
+// checkout instead of the worktree.
+func TestEnsureWorktreeDeps_copiesInsteadOfSymlinking(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local/share"))
+
+	main := filepath.Join(home, "main")
+	wt := filepath.Join(home, "wt")
+	for _, d := range []string{main, wt} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(main, "vendor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(main, "vendor", "autoload.php"), []byte("<?php"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(main, ".env"), []byte("APP_URL=http://main.test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureWorktreeDeps(main, wt, "branch.main.test", false)
+
+	info, err := os.Lstat(filepath.Join(wt, "vendor"))
+	if err != nil {
+		t.Fatalf("vendor missing in worktree: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("vendor should be a real directory, not a symlink")
+	}
+	if !info.IsDir() {
+		t.Fatal("vendor should be a directory")
+	}
+	if _, err := os.Stat(filepath.Join(wt, "vendor", "autoload.php")); err != nil {
+		t.Errorf("vendor/autoload.php not copied: %v", err)
+	}
+}
+
+// EnsureWorktreeDeps replaces a legacy symlink left by an older lerd
+// version with a real copy.
+func TestEnsureWorktreeDeps_migratesLegacySymlink(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local/share"))
+
+	main := filepath.Join(home, "main")
+	wt := filepath.Join(home, "wt")
+	if err := os.MkdirAll(filepath.Join(main, "vendor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(main, "vendor", "autoload.php"), []byte("<?php"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(main, "vendor"), filepath.Join(wt, "vendor")); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureWorktreeDeps(main, wt, "branch.main.test", false)
+
+	info, err := os.Lstat(filepath.Join(wt, "vendor"))
+	if err != nil {
+		t.Fatalf("vendor missing: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("legacy symlink should have been replaced with a real copy")
+	}
+}
+
+// When main has no vendor/ yet, EnsureWorktreeDeps must not create an
+// empty directory in the worktree; it should simply do nothing for that
+// tree.
+func TestEnsureWorktreeDeps_mainMissingVendor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local/share"))
+
+	main := filepath.Join(home, "main")
+	wt := filepath.Join(home, "wt")
+	for _, d := range []string{main, wt} {
+		_ = os.MkdirAll(d, 0o755)
+	}
+
+	EnsureWorktreeDeps(main, wt, "branch.main.test", false)
+
+	if _, err := os.Lstat(filepath.Join(wt, "vendor")); err == nil {
+		t.Error("vendor should not be created when main has none")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -26,6 +26,7 @@ import (
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	lerdUpdate "github.com/geodro/lerd/internal/update"
 	"github.com/geodro/lerd/internal/version"
+	"github.com/geodro/lerd/internal/xdebugops"
 )
 
 const protocolVersion = "2024-11-05"
@@ -667,6 +668,10 @@ func toolList() []mcpTool {
 					"version": {
 						Type:        "string",
 						Description: "PHP version (e.g. \"8.4\"). Defaults to the project or global default.",
+					},
+					"mode": {
+						Type:        "string",
+						Description: "xdebug.mode value. Defaults to \"debug\". Accepts debug, coverage, develop, profile, trace, gcstats, or a comma-separated combo like \"debug,coverage\".",
 					},
 				},
 			},
@@ -3676,40 +3681,35 @@ func execXdebugToggle(args map[string]any, enable bool) (any, *rpcError) {
 		version = cfg.PHP.DefaultVersion
 	}
 
-	cfg, err := config.LoadGlobal()
-	if err != nil {
-		return toolErr("loading config: " + err.Error()), nil
-	}
-
-	state := "disabled"
+	applyMode := ""
 	if enable {
-		state = "enabled"
+		applyMode = strArg(args, "mode")
+		if applyMode == "" {
+			applyMode = "debug"
+		}
 	}
 
-	if cfg.IsXdebugEnabled(version) == enable {
-		return toolOK(fmt.Sprintf("Xdebug is already %s for PHP %s", state, version)), nil
+	res, err := xdebugops.Apply(version, applyMode)
+	if err != nil {
+		return toolErr(err.Error()), nil
 	}
 
-	cfg.SetXdebug(version, enable)
-	if err := config.SaveGlobal(cfg); err != nil {
-		return toolErr("saving config: " + err.Error()), nil
+	if res.NoChange {
+		if res.Enabled {
+			return toolOK(fmt.Sprintf("Xdebug is already enabled (mode=%s) for PHP %s", res.Mode, version)), nil
+		}
+		return toolOK(fmt.Sprintf("Xdebug is already disabled for PHP %s", version)), nil
 	}
 
-	if err := podman.WriteXdebugIni(version, enable); err != nil {
-		return toolErr("writing xdebug ini: " + err.Error()), nil
+	summary := fmt.Sprintf("Xdebug disabled for PHP %s", version)
+	if res.Enabled {
+		summary = fmt.Sprintf("Xdebug enabled for PHP %s (mode=%s, port 9003, host.containers.internal)", version, res.Mode)
 	}
-
-	if err := podman.WriteFPMQuadlet(version); err != nil {
-		return toolErr("updating FPM quadlet: " + err.Error()), nil
+	if res.RestartErr != nil {
+		unit := xdebugops.FPMUnit(version)
+		return toolOK(fmt.Sprintf("%s\n[WARN] FPM restart failed: %v\nRun: systemctl --user restart %s", summary, res.RestartErr, unit)), nil
 	}
-
-	short := strings.ReplaceAll(version, ".", "")
-	unit := "lerd-php" + short + "-fpm"
-	if err := podman.RestartUnit(unit); err != nil {
-		return toolOK(fmt.Sprintf("Xdebug %s for PHP %s\n[WARN] FPM restart failed: %v\nRun: systemctl --user restart %s", state, version, err, unit)), nil
-	}
-
-	return toolOK(fmt.Sprintf("Xdebug %s for PHP %s (port 9003, host.containers.internal)", state, version)), nil
+	return toolOK(summary), nil
 }
 
 func execXdebugStatus() (any, *rpcError) {
@@ -3729,10 +3729,12 @@ func execXdebugStatus() (any, *rpcError) {
 	type entry struct {
 		Version string `json:"version"`
 		Enabled bool   `json:"enabled"`
+		Mode    string `json:"mode,omitempty"`
 	}
 	result := make([]entry, 0, len(versions))
 	for _, v := range versions {
-		result = append(result, entry{Version: v, Enabled: cfg.IsXdebugEnabled(v)})
+		mode := cfg.GetXdebugMode(v)
+		result = append(result, entry{Version: v, Enabled: mode != "", Mode: mode})
 	}
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return toolOK(string(data)), nil
@@ -4554,7 +4556,7 @@ func execSitePHP(args map[string]any) (any, *rpcError) {
 	if err := podman.WriteFPMQuadlet(version); err != nil {
 		return toolErr("writing FPM quadlet: " + err.Error()), nil
 	}
-	_ = podman.WriteXdebugIni(version, false) // non-fatal if version not yet built
+	_ = podman.EnsureXdebugIni(version) // non-fatal if version not yet built
 
 	// Update the site registry.
 	site.PHPVersion = version

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -342,23 +342,71 @@ func buildCustomExtBlock(exts []string) string {
 	return sb.String()
 }
 
+// validXdebugModes lists the xdebug.mode tokens accepted by NormaliseXdebugMode.
+// Comma-separated combinations of these are allowed (e.g. "debug,coverage");
+// "off" is only valid on its own.
+var validXdebugModes = map[string]bool{
+	"off":      true,
+	"develop":  true,
+	"coverage": true,
+	"debug":    true,
+	"gcstats":  true,
+	"profile":  true,
+	"trace":    true,
+}
+
+// NormaliseXdebugMode validates and canonicalises a user-supplied xdebug.mode
+// value. Whitespace is trimmed, duplicates are dropped, and the result is a
+// comma-separated string ready to be written into the ini file. An empty input
+// returns "debug" so callers can use it as the default when enabling xdebug
+// without an explicit mode.
+func NormaliseXdebugMode(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "debug", nil
+	}
+	parts := strings.Split(raw, ",")
+	seen := map[string]bool{}
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if !validXdebugModes[p] {
+			return "", fmt.Errorf("invalid xdebug mode %q (accepted: debug, coverage, develop, profile, trace, gcstats, off)", p)
+		}
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	if len(out) == 0 {
+		return "debug", nil
+	}
+	if len(out) > 1 && seen["off"] {
+		return "", fmt.Errorf("xdebug mode %q cannot combine 'off' with other modes", raw)
+	}
+	return strings.Join(out, ","), nil
+}
+
 // WriteXdebugIni writes the per-version xdebug ini to the host config dir.
 // The file is volume-mounted into the FPM container at /usr/local/etc/php/conf.d/99-xdebug.ini.
-func WriteXdebugIni(version string, enabled bool) error {
+// An empty mode writes xdebug.mode=off (extension loaded but inactive); any other value
+// is emitted as-is, so callers can pass "debug", "coverage", "debug,coverage", etc.
+func WriteXdebugIni(version, mode string) error {
 	path := config.PHPConfFile(version)
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	// Podman auto-creates a directory at the bind-mount source when the file is missing
-	// at container start time. Remove it so os.WriteFile can create the real file.
 	if info, err := os.Stat(path); err == nil && info.IsDir() {
 		if err := os.Remove(path); err != nil {
 			return fmt.Errorf("removing stale xdebug ini directory: %w", err)
 		}
 	}
-	mode := "off"
-	if enabled {
-		mode = "debug"
+	if mode == "" {
+		mode = "off"
 	}
 	content := fmt.Sprintf("[xdebug]\nxdebug.mode=%s\nxdebug.start_with_request=yes\nxdebug.client_host=host.containers.internal\nxdebug.client_port=9003\n", mode)
 	return os.WriteFile(path, []byte(content), 0644)
@@ -414,7 +462,7 @@ func EnsureXdebugIni(version string) error {
 	if cfgErr != nil {
 		return cfgErr
 	}
-	return WriteXdebugIni(version, cfg.IsXdebugEnabled(version))
+	return WriteXdebugIni(version, cfg.GetXdebugMode(version))
 }
 
 // WriteFPMQuadlet writes the systemd quadlet for a PHP-FPM version and reloads the

--- a/internal/podman/ini_race_test.go
+++ b/internal/podman/ini_race_test.go
@@ -140,7 +140,7 @@ func TestWriteXdebugIni_healsStaleDirectoryDirectly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := WriteXdebugIni("8.4", true); err != nil {
+	if err := WriteXdebugIni("8.4", "debug"); err != nil {
 		t.Fatalf("WriteXdebugIni: %v", err)
 	}
 	info, err := os.Stat(path)
@@ -153,6 +153,66 @@ func TestWriteXdebugIni_healsStaleDirectoryDirectly(t *testing.T) {
 	body, _ := os.ReadFile(path)
 	if !strings.Contains(string(body), "xdebug.mode=debug") {
 		t.Errorf("expected xdebug.mode=debug, got:\n%s", body)
+	}
+}
+
+func TestWriteXdebugIni_writesRequestedMode(t *testing.T) {
+	// Users enabling coverage or a combo mode need the ini to reflect
+	// exactly what they asked for, not the hardcoded "debug" that the
+	// legacy bool signature produced.
+	setupConfigHome(t)
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"coverage", "xdebug.mode=coverage"},
+		{"debug,coverage", "xdebug.mode=debug,coverage"},
+		{"", "xdebug.mode=off"},
+	}
+	for _, c := range cases {
+		if err := WriteXdebugIni("8.4", c.in); err != nil {
+			t.Fatalf("WriteXdebugIni(%q): %v", c.in, err)
+		}
+		body, _ := os.ReadFile(config.PHPConfFile("8.4"))
+		if !strings.Contains(string(body), c.want) {
+			t.Errorf("WriteXdebugIni(%q): missing %q in:\n%s", c.in, c.want, body)
+		}
+	}
+}
+
+// ── NormaliseXdebugMode ──────────────────────────────────────────────────────
+
+func TestNormaliseXdebugMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", "debug", false},
+		{"debug", "debug", false},
+		{"coverage", "coverage", false},
+		{"  debug , coverage ", "debug,coverage", false},
+		{"debug,debug", "debug", false},
+		{"off", "off", false},
+		{"nonsense", "", true},
+		{"debug,off", "", true},
+	}
+	for _, c := range cases {
+		got, err := NormaliseXdebugMode(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("NormaliseXdebugMode(%q): expected error, got %q", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("NormaliseXdebugMode(%q): unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("NormaliseXdebugMode(%q) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }
 

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -127,7 +127,7 @@ func FinishLink(site config.Site, phpVersion string) error {
 		}
 	}
 
-	_ = podman.WriteXdebugIni(phpVersion, false)
+	_ = podman.EnsureXdebugIni(phpVersion)
 	if err := podman.WriteFPMQuadlet(phpVersion); err == nil {
 		_ = podman.DaemonReloadFn()
 	}

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -1,0 +1,86 @@
+package tui
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// ActionResult is emitted when an async action (start/stop/restart) finishes.
+// The status bar renders Err/Detail so the user sees failures without
+// dropping out of the TUI.
+type ActionResult struct {
+	Summary string
+	Err     error
+	Detail  string
+}
+
+// runShellIn suspends bubbletea, opens an interactive shell inside the
+// chosen container (FPM for PHP sites, the custom container for Node/Go/etc.
+// sites, and the service's own container for services), then resumes. Uses
+// `sh -c 'command -v bash && exec bash || exec sh'` so bash is used when
+// available and sh is the fallback (matters for minimal service images like
+// alpine where bash isn't installed).
+func runShellIn(container, workDir string) tea.Cmd {
+	args := []string{"exec", "-it"}
+	if workDir != "" {
+		args = append(args, "-w", workDir)
+	}
+	args = append(args, container, "sh", "-c",
+		"command -v bash >/dev/null 2>&1 && exec bash || exec sh")
+	cmd := exec.Command(podman.PodmanBin(), args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		if err != nil {
+			return ActionResult{Summary: "shell " + container, Err: err, Detail: err.Error()}
+		}
+		return ActionResult{Summary: "shell " + container + " exited"}
+	})
+}
+
+// containerForSite picks the right container to exec into for a site: the
+// custom container if the site is a non-PHP project, otherwise the shared
+// FPM image for that site's PHP version. Returns "" if neither exists yet
+// (e.g. PHP version hasn't been detected).
+func containerForSite(s *siteinfo.EnrichedSite) string {
+	if s.ContainerPort > 0 {
+		return podman.CustomContainerName(s.Name)
+	}
+	if s.PHPVersion == "" {
+		return ""
+	}
+	return "lerd-php" + strings.ReplaceAll(s.PHPVersion, ".", "") + "-fpm"
+}
+
+// runLerd executes `lerd` as a subprocess with the given args, in the given
+// working directory. We go through the public CLI rather than poking internal
+// helpers so the TUI goes down the same code paths users would run manually.
+// This avoids drifting when ensureQuadlet / dependency logic moves around.
+func runLerd(dir string, args ...string) tea.Cmd {
+	return func() tea.Msg {
+		self, err := os.Executable()
+		if err != nil {
+			self = "lerd"
+		}
+		cmd := exec.Command(self, args...)
+		if dir != "" {
+			cmd.Dir = dir
+		}
+		var buf bytes.Buffer
+		cmd.Stdout = &buf
+		cmd.Stderr = &buf
+		runErr := cmd.Run()
+		return ActionResult{
+			Summary: "lerd " + strings.Join(args, " "),
+			Err:     runErr,
+			Detail:  strings.TrimSpace(buf.String()),
+		}
+	}
+}

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -1,0 +1,623 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// detailRow is one line in the detail overlay that reacts to input.
+// Informational rows use kindInfo and are skipped by cursor navigation.
+type detailRow struct {
+	kind detailKind
+	// Worker kind: logical name used for `lerd queue/schedule/worker start`.
+	workerName string
+	// Domain kind: the full domain (including the TLD) this row represents.
+	domain string
+}
+
+type detailKind int
+
+const (
+	kindInfo detailKind = iota
+	kindWorker
+	kindHTTPS
+	kindLANShare
+	kindPHP
+	kindNode
+	kindDomain
+	kindDomainAdd
+)
+
+// detailRows returns the ordered rows the detail view draws. Built on each
+// render so worker lists stay in sync with live state.
+func detailRows(s *siteinfo.EnrichedSite) []detailRow {
+	var rows []detailRow
+	rows = append(rows, detailRow{kind: kindInfo}) // header placeholder drawn separately
+	for _, d := range s.Domains {
+		rows = append(rows, detailRow{kind: kindDomain, domain: d})
+	}
+	rows = append(rows, detailRow{kind: kindDomainAdd})
+	if s.HasQueueWorker {
+		rows = append(rows, detailRow{kind: kindWorker, workerName: "queue"})
+	}
+	if s.HasScheduleWorker {
+		rows = append(rows, detailRow{kind: kindWorker, workerName: "schedule"})
+	}
+	if s.HasHorizon {
+		rows = append(rows, detailRow{kind: kindWorker, workerName: "horizon"})
+	}
+	if s.HasReverb {
+		rows = append(rows, detailRow{kind: kindWorker, workerName: "reverb"})
+	}
+	for _, fw := range s.FrameworkWorkers {
+		switch fw.Name {
+		case "queue", "schedule", "horizon", "reverb":
+			continue
+		}
+		rows = append(rows, detailRow{kind: kindWorker, workerName: fw.Name})
+	}
+	if s.ContainerPort == 0 && s.PHPVersion != "" {
+		rows = append(rows, detailRow{kind: kindPHP})
+	}
+	if s.NodeVersion != "" {
+		rows = append(rows, detailRow{kind: kindNode})
+	}
+	rows = append(rows, detailRow{kind: kindHTTPS})
+	rows = append(rows, detailRow{kind: kindLANShare})
+	return rows
+}
+
+// navigableRows filters out info rows so cursor moves skip them.
+func navigableRows(rows []detailRow) []int {
+	var idx []int
+	for i, r := range rows {
+		if r.kind != kindInfo {
+			idx = append(idx, i)
+		}
+	}
+	return idx
+}
+
+func (m *Model) detailToggleSelected(s *siteinfo.EnrichedSite, rows []detailRow, nav []int) tea.Cmd {
+	if s == nil || len(nav) == 0 {
+		return nil
+	}
+	if m.detailCursor >= len(nav) {
+		m.detailCursor = len(nav) - 1
+	}
+	row := rows[nav[m.detailCursor]]
+	switch row.kind {
+	case kindWorker:
+		return m.toggleWorker(s, row.workerName)
+	case kindHTTPS:
+		if s.Secured {
+			m.setStatus("disabling HTTPS for "+s.Name+"…", 5*time.Second)
+			return runLerd(s.Path, "unsecure", s.Name)
+		}
+		m.setStatus("enabling HTTPS for "+s.Name+"…", 5*time.Second)
+		return runLerd(s.Path, "secure", s.Name)
+	case kindLANShare:
+		if s.LANPort > 0 {
+			m.setStatus("stopping LAN share for "+s.Name+"…", 5*time.Second)
+			return runLerd(s.Path, "lan", "unshare")
+		}
+		m.setStatus("starting LAN share for "+s.Name+"…", 5*time.Second)
+		return runLerd(s.Path, "lan", "share")
+	case kindPHP:
+		m.openPHPPicker(s)
+		return nil
+	case kindNode:
+		m.openNodePicker(s)
+		return nil
+	case kindDomain:
+		// Selecting a domain does nothing on its own; removal is `x`.
+		return nil
+	case kindDomainAdd:
+		m.openDomainInput()
+		return nil
+	}
+	return nil
+}
+
+// removeFocusedDomain runs `lerd domain remove <name>` for the domain the
+// cursor is on. Does nothing when focus is elsewhere or a different kind of
+// row is selected — meaning `x` on workers or services still does stop.
+func (m *Model) removeFocusedDomain() (handled bool, cmd tea.Cmd) {
+	if m.focus != paneDetail || m.detailMode != detailSite {
+		return false, nil
+	}
+	s := m.currentSite()
+	if s == nil {
+		return false, nil
+	}
+	rows := detailRows(s)
+	nav := navigableRows(rows)
+	if m.detailCursor >= len(nav) {
+		return false, nil
+	}
+	row := rows[nav[m.detailCursor]]
+	if row.kind != kindDomain {
+		return false, nil
+	}
+	short := trimTLD(row.domain)
+	m.setStatus("removing domain "+row.domain+"…", 5*time.Second)
+	return true, runLerd(s.Path, "domain", "remove", short)
+}
+
+// trimTLD strips the configured TLD suffix from a full domain so the short
+// form is what `lerd domain add/remove` expects. Falls back to stripping
+// the last dotted component if the config can't be read.
+func trimTLD(full string) string {
+	cfg, _ := config.LoadGlobal()
+	if cfg != nil && cfg.DNS.TLD != "" {
+		if trimmed := strings.TrimSuffix(full, "."+cfg.DNS.TLD); trimmed != full {
+			return trimmed
+		}
+	}
+	if i := strings.LastIndexByte(full, '.'); i >= 0 {
+		return full[:i]
+	}
+	return full
+}
+
+// currentTLD returns the configured TLD, defaulting to "test" when global
+// config can't be read. Centralised so the handful of call sites don't
+// each have to inline the fallback.
+func currentTLD() string {
+	cfg, _ := config.LoadGlobal()
+	if cfg != nil && cfg.DNS.TLD != "" {
+		return cfg.DNS.TLD
+	}
+	return "test"
+}
+
+func (m *Model) toggleWorker(s *siteinfo.EnrichedSite, name string) tea.Cmd {
+	running := workerRunning(s, name)
+	verb := "start"
+	if running {
+		verb = "stop"
+	}
+	m.setStatus(verb+"ing "+name+" worker for "+s.Name+"…", 5*time.Second)
+	switch name {
+	case "queue":
+		return runLerd(s.Path, "queue", verb)
+	case "schedule":
+		return runLerd(s.Path, "schedule", verb)
+	case "horizon":
+		return runLerd(s.Path, "horizon", verb)
+	case "reverb":
+		return runLerd(s.Path, "reverb", verb)
+	default:
+		return runLerd(s.Path, "worker", verb, name)
+	}
+}
+
+func workerRunning(s *siteinfo.EnrichedSite, name string) bool {
+	switch name {
+	case "queue":
+		return s.QueueRunning
+	case "schedule":
+		return s.ScheduleRunning
+	case "horizon":
+		return s.HorizonRunning
+	case "reverb":
+		return s.ReverbRunning
+	}
+	for _, fw := range s.FrameworkWorkers {
+		if fw.Name == name {
+			return fw.Running
+		}
+	}
+	return false
+}
+
+func workerFailing(s *siteinfo.EnrichedSite, name string) bool {
+	switch name {
+	case "queue":
+		return s.QueueFailing
+	case "schedule":
+		return s.ScheduleFailing
+	case "horizon":
+		return s.HorizonFailing
+	case "reverb":
+		return s.ReverbFailing
+	}
+	for _, fw := range s.FrameworkWorkers {
+		if fw.Name == name {
+			return fw.Failing
+		}
+	}
+	return false
+}
+
+func workerLabel(s *siteinfo.EnrichedSite, name string) string {
+	for _, fw := range s.FrameworkWorkers {
+		if fw.Name == name && fw.Label != "" {
+			return fw.Label
+		}
+	}
+	return name
+}
+
+// renderDetailInline builds the right-column pane: full-height site detail
+// by default, or the global settings rows when detailMode == detailSettings.
+// Both live in the same pane so `S` is a toggle, not a separate screen.
+func (m *Model) renderDetailInline(w, h int, focused bool) string {
+	style := paneStyle(focused)
+	innerW, innerH := innerSize(style, w, h)
+
+	var content []string
+	switch m.detailMode {
+	case detailSettings:
+		content = settingsContentLines(m, focused, innerW)
+	case detailHelp:
+		all := helpContentLines(m, innerW)
+		if m.helpScroll > len(all)-1 {
+			m.helpScroll = max(0, len(all)-1)
+		}
+		content = all[m.helpScroll:]
+	default:
+		site := m.currentSite()
+		if site == nil {
+			content = []string{
+				padToWidth(sectionStyle.Render("Site detail"), innerW),
+				padToWidth(dimStyle.Render("no site selected"), innerW),
+			}
+		} else {
+			content = detailContentLines(m, site, focused, innerW)
+		}
+	}
+
+	for len(content) < innerH {
+		content = append(content, spaces(innerW))
+	}
+	if len(content) > innerH {
+		content = content[:innerH]
+	}
+
+	return style.Render(strings.Join(content, "\n"))
+}
+
+// settingsContentLines builds the settings rows for the right-hand pane when
+// detailMode == detailSettings. Mirrors the detail pane's look so S feels
+// like a pane swap, not a modal.
+func settingsContentLines(m *Model, focused bool, innerW int) []string {
+	rows := m.settingsRows()
+	out := make([]string, 0, len(rows)+4)
+	add := func(s string) { out = append(out, padToWidth(clipLine(s, innerW), innerW)) }
+
+	add(sectionStyle.Render("Settings"))
+	add(dimStyle.Render("  press S again to return to site detail"))
+	add("")
+
+	if len(rows) == 0 {
+		add(dimStyle.Render("  no settings available"))
+		return out
+	}
+
+	for i, row := range rows {
+		selected := focused && i == m.settingsRow
+		add(renderDetailRow(selected, onOffGlyph(row.on), row.label, onOffText(row.on)))
+	}
+	return out
+}
+
+func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, innerW int) []string {
+	rows := detailRows(site)
+	nav := navigableRows(rows)
+	navPos := func(i int) int {
+		for pos, rowIdx := range nav {
+			if rowIdx == i {
+				return pos
+			}
+		}
+		return -1
+	}
+
+	var out []string
+	add := func(s string) { out = append(out, padToWidth(clipLine(s, innerW), innerW)) }
+
+	// Lead with the primary domain (what users see in the browser). The
+	// internal registry name is still surfaced as the "name:" line below,
+	// since commands and filters still accept it.
+	header := site.PrimaryDomain()
+	if header == "" {
+		header = site.Name
+	}
+	add(sectionStyle.Render(header))
+	if site.Name != header {
+		add(dimStyle.Render("  name: ") + site.Name)
+	}
+	if site.Path != "" {
+		add(dimStyle.Render("  path: ") + site.Path)
+	}
+
+	scheme := "http"
+	if site.Secured {
+		scheme = "https"
+	}
+
+	add("")
+	add(sectionStyle.Render("Domains"))
+	if len(site.Domains) == 0 {
+		add(dimStyle.Render("  (no domain)"))
+	}
+	for i, row := range rows {
+		if row.kind != kindDomain {
+			continue
+		}
+		selected := focused && navPos(i) == m.detailCursor
+		domain := row.domain
+		label := scheme + "://" + domain
+		add(renderDetailRow(selected, accentStyle.Render("⊙"), label, dimStyle.Render(domainRole(site, domain))))
+	}
+	for i, row := range rows {
+		if row.kind != kindDomainAdd {
+			continue
+		}
+		selected := focused && navPos(i) == m.detailCursor
+		prefix := "  "
+		if selected {
+			prefix = " " + accentStyle.Render("▸")
+		}
+		if m.domainInputActive {
+			label := "add domain: "
+			if m.domainInputEditing != "" {
+				label = "rename " + m.domainInputEditing + " → "
+			}
+			add(prefix + " " + accentStyle.Render("+") + " " + selectedStyle.Render(label) + m.domainInput + "▌")
+		} else {
+			add(prefix + " " + accentStyle.Render("+") + " " + dimStyle.Render("add domain (space or a)"))
+		}
+	}
+	add("")
+
+	php := site.PHPVersion
+	if php == "" && site.ContainerPort > 0 {
+		php = "custom"
+	}
+	info := dimStyle.Render("  php: ") + php
+	if site.NodeVersion != "" {
+		info += dimStyle.Render("  node: ") + site.NodeVersion
+	}
+	if site.FrameworkLabel != "" {
+		info += dimStyle.Render("  fw: ") + site.FrameworkLabel
+	}
+	if site.Branch != "" {
+		info += dimStyle.Render("  git: ") + site.Branch
+	}
+	add(info)
+	add("")
+	if len(site.Services) > 0 {
+		add(sectionStyle.Render("Services used"))
+		states := m.serviceStatesByName()
+		for _, svc := range site.Services {
+			add(renderSiteServiceRow(svc, states[svc]))
+		}
+		add("")
+	}
+
+	hasWorkers := false
+	for _, row := range rows {
+		if row.kind == kindWorker {
+			hasWorkers = true
+			break
+		}
+	}
+	if hasWorkers {
+		add(sectionStyle.Render("Workers"))
+		for i, row := range rows {
+			if row.kind != kindWorker {
+				continue
+			}
+			selected := focused && navPos(i) == m.detailCursor
+			add(renderDetailRow(selected,
+				workerGlyphFor(site, row.workerName),
+				workerLabel(site, row.workerName),
+				workerStateText(site, row.workerName)))
+		}
+		add("")
+	}
+
+	if len(site.Worktrees) > 0 {
+		add(sectionStyle.Render("Worktrees"))
+		for _, wt := range site.Worktrees {
+			line := "  " + accentStyle.Render(wt.Branch)
+			if wt.Domain != "" {
+				line += "  " + dimStyle.Render(scheme+"://"+wt.Domain)
+			}
+			if wt.Path != "" {
+				line += "  " + dimStyle.Render(wt.Path)
+			}
+			add(line)
+		}
+		add("")
+	}
+
+	add(sectionStyle.Render("Toggles"))
+	for i, row := range rows {
+		selected := focused && navPos(i) == m.detailCursor
+		switch row.kind {
+		case kindPHP:
+			add(renderDetailRow(selected,
+				accentStyle.Render("λ"), "PHP", dimStyle.Render(site.PHPVersion)))
+			if selected && m.pickerKind == kindPHP {
+				for _, pl := range m.renderPickerRows(site.PHPVersion) {
+					add(pl)
+				}
+			}
+		case kindNode:
+			add(renderDetailRow(selected,
+				accentStyle.Render("⬢"), "Node", dimStyle.Render(site.NodeVersion)))
+			if selected && m.pickerKind == kindNode {
+				for _, pl := range m.renderPickerRows(site.NodeVersion) {
+					add(pl)
+				}
+			}
+		case kindHTTPS:
+			add(renderDetailRow(selected,
+				onOffGlyph(site.Secured), "HTTPS", onOffText(site.Secured)))
+		case kindLANShare:
+			add(renderDetailRow(selected,
+				onOffGlyph(site.LANPort > 0), "LAN share", lanShareText(site.LANPort)))
+		}
+	}
+	return out
+}
+
+// renderPickerRows draws the inline version picker below a PHP or Node row.
+// Each option shows a cursor, the version, and a dim "current" marker when
+// it matches the site's active version.
+func (m *Model) renderPickerRows(current string) []string {
+	if len(m.pickerOptions) == 0 {
+		return []string{dimStyle.Render("      (no versions available)")}
+	}
+	out := make([]string, 0, len(m.pickerOptions)+1)
+	for i, v := range m.pickerOptions {
+		marker := "  "
+		if i == m.pickerCursor {
+			marker = accentStyle.Render("▸ ")
+		}
+		label := v
+		if i == m.pickerCursor {
+			label = selectedStyle.Render(v)
+		}
+		suffix := ""
+		if v == current {
+			suffix = "  " + dimStyle.Render("(current)")
+		}
+		out = append(out, "      "+marker+label+suffix)
+	}
+	out = append(out, dimStyle.Render("      enter apply · esc cancel"))
+	return out
+}
+
+func renderDetailRow(selected bool, glyph, label, state string) string {
+	prefix := "  "
+	if selected {
+		prefix = " " + accentStyle.Render("▸")
+	}
+	// Pad short labels to a minimum of 18 cells so state columns across
+	// rows line up, but do NOT truncate long labels — long values like a
+	// full https URL need the whole pane width. The outer clipLine call
+	// handles final truncation at innerW, so overflow is bounded.
+	padded := label
+	if w := len([]rune(label)); w < 18 {
+		padded = label + spaces(18-w)
+	}
+	if selected {
+		padded = selectedStyle.Render(padded)
+	}
+	return fmt.Sprintf("%s %s %s %s", prefix, glyph, padded, state)
+}
+
+// serviceStatesByName maps service name → live state from the current
+// snapshot. Used by the detail pane's "Services used" section so each
+// service the site references shows its actual running/stopped/paused
+// state instead of the raw name list.
+func (m *Model) serviceStatesByName() map[string]ServiceState {
+	out := make(map[string]ServiceState, len(m.snap.Services))
+	for _, s := range m.snap.Services {
+		out[s.Name] = s.State
+	}
+	return out
+}
+
+// renderSiteServiceRow draws one row in the detail pane's "Services used"
+// section: glyph, service name, and live state text. Missing entries (a
+// service referenced by the site but not present in the snapshot, e.g. a
+// removed custom service) render as dim "not configured".
+func renderSiteServiceRow(name string, state ServiceState) string {
+	var glyph, text string
+	switch state {
+	case stateRunning:
+		glyph = runningStyle.Render(glyphRunning)
+		text = runningStyle.Render("running")
+	case statePaused:
+		glyph = pausedStyle.Render(glyphPaused)
+		text = pausedStyle.Render("paused")
+	default:
+		glyph = stoppedStyle.Render(glyphStopped)
+		text = dimStyle.Render("stopped")
+	}
+	padded := name
+	if w := len([]rune(name)); w < 18 {
+		padded = name + spaces(18-w)
+	}
+	return "  " + glyph + " " + padded + " " + text
+}
+
+// domainRole labels a domain's position in the list. Exactly one domain is
+// the primary (the first in site.Domains); the others are aliases. The web
+// UI renders the same distinction, so the TUI shouldn't invent new terms.
+func domainRole(s *siteinfo.EnrichedSite, domain string) string {
+	role := "alias"
+	if len(s.Domains) > 0 && s.Domains[0] == domain {
+		role = "primary"
+	}
+	return role + " · e edit · x remove"
+}
+
+func workerGlyphFor(s *siteinfo.EnrichedSite, name string) string {
+	switch {
+	case workerFailing(s, name):
+		return failingStyle.Render(glyphFailing)
+	case workerRunning(s, name):
+		return runningStyle.Render(glyphRunning)
+	}
+	return stoppedStyle.Render(glyphStopped)
+}
+
+func workerStateText(s *siteinfo.EnrichedSite, name string) string {
+	switch {
+	case workerFailing(s, name):
+		return failingStyle.Render("failing")
+	case workerRunning(s, name):
+		return runningStyle.Render("running")
+	}
+	return dimStyle.Render("stopped")
+}
+
+func onOffGlyph(on bool) string {
+	if on {
+		return runningStyle.Render(glyphRunning)
+	}
+	return stoppedStyle.Render(glyphStopped)
+}
+
+func onOffText(on bool) string {
+	if on {
+		return runningStyle.Render("on")
+	}
+	return dimStyle.Render("off")
+}
+
+func lanShareText(port int) string {
+	if port <= 0 {
+		return dimStyle.Render("off")
+	}
+	ip := primaryLANIP()
+	if ip == "" {
+		return runningStyle.Render(fmt.Sprintf("sharing on port %d", port))
+	}
+	return runningStyle.Render(fmt.Sprintf("http://%s:%d", ip, port))
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -1,0 +1,176 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func TestDetailRows_IncludesDomainsWorkersAndToggles(t *testing.T) {
+	s := &siteinfo.EnrichedSite{
+		Name:           "alpha",
+		Domains:        []string{"alpha.test", "alpha-admin.test"},
+		PHPVersion:     "8.3",
+		NodeVersion:    "20",
+		HasQueueWorker: true,
+		HasHorizon:     true,
+	}
+	rows := detailRows(s)
+	kinds := rowKinds(rows)
+
+	// First kindInfo is a header placeholder, then 2 domain rows, then
+	// the add-domain row, then workers, PHP, Node, HTTPS, LAN share.
+	assertKindCount(t, kinds, kindDomain, 2)
+	assertKindCount(t, kinds, kindDomainAdd, 1)
+	assertKindCount(t, kinds, kindWorker, 2)
+	assertKindCount(t, kinds, kindPHP, 1)
+	assertKindCount(t, kinds, kindNode, 1)
+	assertKindCount(t, kinds, kindHTTPS, 1)
+	assertKindCount(t, kinds, kindLANShare, 1)
+}
+
+func TestDetailRows_CustomContainerSkipsPHP(t *testing.T) {
+	s := &siteinfo.EnrichedSite{
+		Name:          "nodeapp",
+		Domains:       []string{"nodeapp.test"},
+		ContainerPort: 3000,
+	}
+	rows := detailRows(s)
+	kinds := rowKinds(rows)
+	assertKindCount(t, kinds, kindPHP, 0)
+	assertKindCount(t, kinds, kindNode, 0) // NodeVersion empty
+	assertKindCount(t, kinds, kindHTTPS, 1)
+	assertKindCount(t, kinds, kindLANShare, 1)
+}
+
+func TestNavigableRows_SkipsInfo(t *testing.T) {
+	rows := []detailRow{
+		{kind: kindInfo},
+		{kind: kindWorker, workerName: "queue"},
+		{kind: kindInfo},
+		{kind: kindHTTPS},
+	}
+	nav := navigableRows(rows)
+	if len(nav) != 2 {
+		t.Fatalf("expected 2 navigable rows, got %d", len(nav))
+	}
+	if rows[nav[0]].kind != kindWorker || rows[nav[1]].kind != kindHTTPS {
+		t.Fatalf("nav picked wrong rows: %+v", nav)
+	}
+}
+
+func TestTrimTLD_StripsConfiguredTLD(t *testing.T) {
+	// Relies on the installed config; if the TLD isn't "test", the
+	// fallback path still trims the last dotted component. Both outcomes
+	// strip the suffix from "name.test".
+	if got := trimTLD("name.test"); got != "name" {
+		t.Errorf("trimTLD(name.test) = %q, want name", got)
+	}
+	if got := trimTLD("sub.name.test"); got != "sub.name" {
+		t.Errorf("trimTLD(sub.name.test) = %q, want sub.name", got)
+	}
+	if got := trimTLD("plain"); got != "plain" {
+		t.Errorf("trimTLD(plain) = %q, want plain (no dot, no change)", got)
+	}
+}
+
+func TestDomainRole_MarksPrimary(t *testing.T) {
+	s := &siteinfo.EnrichedSite{Domains: []string{"first.test", "second.test"}}
+	if got := domainRole(s, "first.test"); !strings.Contains(got, "primary") {
+		t.Errorf("first domain should be primary, got %q", got)
+	}
+	if got := domainRole(s, "second.test"); !strings.Contains(got, "alias") {
+		t.Errorf("second domain should be alias, got %q", got)
+	}
+}
+
+func TestLogTargetsForSite_IncludesFPMAndWorkers(t *testing.T) {
+	s := &siteinfo.EnrichedSite{
+		Name:           "alpha",
+		Path:           "/tmp/missing-so-no-app-logs",
+		PHPVersion:     "8.3",
+		HasQueueWorker: true,
+		HasHorizon:     true,
+	}
+	targets := logTargetsForSite(s)
+	if len(targets) < 3 {
+		t.Fatalf("expected at least 3 targets (fpm+queue+horizon), got %d", len(targets))
+	}
+	if targets[0].Kind != kindPodman || !strings.Contains(targets[0].ID, "lerd-php83-fpm") {
+		t.Errorf("first target should be fpm container, got %+v", targets[0])
+	}
+	// Every worker target should be a journal tail, not a podman one.
+	for _, t2 := range targets[1:] {
+		if t2.Kind != kindJournal && t2.Kind != kindFile {
+			t.Errorf("non-fpm target %s should be journal or file, got %v", t2.ID, t2.Kind)
+		}
+	}
+}
+
+func TestLogTargetsForSite_CustomContainer(t *testing.T) {
+	s := &siteinfo.EnrichedSite{
+		Name:          "nodeapp",
+		ContainerPort: 3000,
+	}
+	targets := logTargetsForSite(s)
+	if len(targets) != 1 || targets[0].Kind != kindPodman {
+		t.Fatalf("custom container should get exactly one podman target, got %+v", targets)
+	}
+	if !strings.Contains(targets[0].ID, "lerd-custom-nodeapp") {
+		t.Errorf("expected lerd-custom-nodeapp, got %s", targets[0].ID)
+	}
+}
+
+func TestContainerForSite(t *testing.T) {
+	if got := containerForSite(&siteinfo.EnrichedSite{ContainerPort: 3000, Name: "x"}); !strings.Contains(got, "lerd-custom-x") {
+		t.Errorf("custom container, got %s", got)
+	}
+	if got := containerForSite(&siteinfo.EnrichedSite{PHPVersion: "8.3"}); got != "lerd-php83-fpm" {
+		t.Errorf("php site, got %s", got)
+	}
+	if got := containerForSite(&siteinfo.EnrichedSite{}); got != "" {
+		t.Errorf("empty site should return empty, got %s", got)
+	}
+}
+
+func TestServiceStatesByName(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{
+		Services: []ServiceRow{
+			{Name: "mysql", State: stateRunning},
+			{Name: "redis", State: stateStopped},
+		},
+	}
+	states := m.serviceStatesByName()
+	if states["mysql"] != stateRunning {
+		t.Errorf("mysql state wrong")
+	}
+	if states["redis"] != stateStopped {
+		t.Errorf("redis state wrong")
+	}
+	if _, ok := states["nope"]; ok {
+		t.Errorf("unknown service shouldn't be in map")
+	}
+}
+
+func rowKinds(rows []detailRow) []detailKind {
+	out := make([]detailKind, len(rows))
+	for i, r := range rows {
+		out[i] = r.kind
+	}
+	return out
+}
+
+func assertKindCount(t *testing.T, kinds []detailKind, want detailKind, count int) {
+	t.Helper()
+	n := 0
+	for _, k := range kinds {
+		if k == want {
+			n++
+		}
+	}
+	if n != count {
+		t.Errorf("kind %d: got %d occurrences, want %d (kinds=%v)", want, n, count, kinds)
+	}
+}

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -1,0 +1,44 @@
+package tui
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/eventbus"
+)
+
+// refreshMsg arrives on every tick and on every eventbus publish. Update's
+// handler reloads the snapshot off the main loop.
+type refreshMsg struct{}
+
+// snapshotMsg carries a freshly-loaded Snapshot from a background goroutine
+// back into the tea program.
+type snapshotMsg struct{ snap Snapshot }
+
+// tickCmd schedules the next refreshMsg. Called from Update after each
+// snapshot lands so the model polls at a steady cadence even when no
+// eventbus traffic arrives (cross-process changes show up within the
+// interval).
+func tickCmd(d time.Duration) tea.Cmd {
+	return tea.Tick(d, func(time.Time) tea.Msg { return refreshMsg{} })
+}
+
+// loadCmd runs loadSnapshot off the main loop. siteinfo.LoadAll and podman
+// calls can block for 100s of ms on slow systems; running them in the Update
+// handler would freeze input.
+func loadCmd() tea.Cmd {
+	return func() tea.Msg { return snapshotMsg{snap: loadSnapshot()} }
+}
+
+// busCmd subscribes to the in-process eventbus and emits a refreshMsg the
+// first time a publish lands. The caller chains busCmd to itself from Update
+// so the subscription is long-lived.
+func busCmd(sub *eventbus.Subscriber) tea.Cmd {
+	return func() tea.Msg {
+		_, ok := <-sub.C
+		if !ok {
+			return nil
+		}
+		return refreshMsg{}
+	}
+}

--- a/internal/tui/filter.go
+++ b/internal/tui/filter.go
@@ -1,0 +1,143 @@
+package tui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// siteSortMode picks the ordering for the sites pane.
+type siteSortMode int
+
+const (
+	siteSortName siteSortMode = iota
+	siteSortStatus
+	siteSortFramework
+)
+
+func (m siteSortMode) label() string {
+	switch m {
+	case siteSortStatus:
+		return "status"
+	case siteSortFramework:
+		return "framework"
+	}
+	return "name"
+}
+
+// svcSortMode picks the ordering for the services pane.
+type svcSortMode int
+
+const (
+	svcSortName svcSortMode = iota
+	svcSortStatus
+	svcSortUsage
+)
+
+func (m svcSortMode) label() string {
+	switch m {
+	case svcSortStatus:
+		return "status"
+	case svcSortUsage:
+		return "usage"
+	}
+	return "name"
+}
+
+// filteredSortedSites returns the sites list after applying the active
+// filter and sort. Always returns a new slice so the caller can safely
+// mutate ordering without affecting m.snap.
+func filteredSortedSites(list []siteinfo.EnrichedSite, filter string, mode siteSortMode) []siteinfo.EnrichedSite {
+	out := make([]siteinfo.EnrichedSite, 0, len(list))
+	needle := strings.ToLower(strings.TrimSpace(filter))
+	for _, s := range list {
+		if needle != "" && !siteMatchesFilter(s, needle) {
+			continue
+		}
+		out = append(out, s)
+	}
+	switch mode {
+	case siteSortStatus:
+		sort.SliceStable(out, func(i, j int) bool {
+			return siteStatusRank(out[i]) < siteStatusRank(out[j])
+		})
+	case siteSortFramework:
+		sort.SliceStable(out, func(i, j int) bool {
+			if out[i].FrameworkLabel != out[j].FrameworkLabel {
+				return out[i].FrameworkLabel < out[j].FrameworkLabel
+			}
+			return out[i].Name < out[j].Name
+		})
+	default:
+		sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	}
+	return out
+}
+
+func siteMatchesFilter(s siteinfo.EnrichedSite, needle string) bool {
+	if strings.Contains(strings.ToLower(s.Name), needle) {
+		return true
+	}
+	for _, d := range s.Domains {
+		if strings.Contains(strings.ToLower(d), needle) {
+			return true
+		}
+	}
+	if strings.Contains(strings.ToLower(s.FrameworkLabel), needle) {
+		return true
+	}
+	return false
+}
+
+// siteStatusRank sorts running sites first, then stopped, then paused.
+// Within a bucket the sort is stable, so the caller's upstream ordering
+// (alphabetical) determines ties.
+func siteStatusRank(s siteinfo.EnrichedSite) int {
+	switch {
+	case s.Paused:
+		return 2
+	case s.FPMRunning:
+		return 0
+	}
+	return 1
+}
+
+// filteredSortedServices applies the active filter/sort to the services row
+// slice. Same policy as sites: new slice, stable ordering.
+func filteredSortedServices(list []ServiceRow, filter string, mode svcSortMode) []ServiceRow {
+	out := make([]ServiceRow, 0, len(list))
+	needle := strings.ToLower(strings.TrimSpace(filter))
+	for _, s := range list {
+		if needle != "" && !strings.Contains(strings.ToLower(s.Name), needle) {
+			continue
+		}
+		out = append(out, s)
+	}
+	switch mode {
+	case svcSortStatus:
+		sort.SliceStable(out, func(i, j int) bool {
+			return svcStatusRank(out[i]) < svcStatusRank(out[j])
+		})
+	case svcSortUsage:
+		sort.SliceStable(out, func(i, j int) bool {
+			if out[i].SiteCount != out[j].SiteCount {
+				return out[i].SiteCount > out[j].SiteCount
+			}
+			return out[i].Name < out[j].Name
+		})
+	default:
+		sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	}
+	return out
+}
+
+func svcStatusRank(s ServiceRow) int {
+	switch s.State {
+	case stateRunning:
+		return 0
+	case statePaused:
+		return 2
+	}
+	return 1
+}

--- a/internal/tui/filter_test.go
+++ b/internal/tui/filter_test.go
@@ -1,0 +1,124 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func sitesFixture() []siteinfo.EnrichedSite {
+	return []siteinfo.EnrichedSite{
+		{Name: "alpha", Domains: []string{"alpha.test"}, FrameworkLabel: "Laravel 11", FPMRunning: true},
+		{Name: "beta", Domains: []string{"beta.test", "beta-admin.test"}, FrameworkLabel: "Symfony 7", Paused: true},
+		{Name: "gamma", Domains: []string{"gamma.test"}, FrameworkLabel: "Laravel 11", FPMRunning: false},
+	}
+}
+
+func TestFilterSites_ByDomain(t *testing.T) {
+	got := filteredSortedSites(sitesFixture(), "admin", siteSortName)
+	if len(got) != 1 || got[0].Name != "beta" {
+		t.Fatalf("expected beta (matches beta-admin.test), got %+v", names(got))
+	}
+}
+
+func TestFilterSites_ByFrameworkLabel(t *testing.T) {
+	got := filteredSortedSites(sitesFixture(), "symfony", siteSortName)
+	if len(got) != 1 || got[0].Name != "beta" {
+		t.Fatalf("expected beta, got %+v", names(got))
+	}
+}
+
+func TestFilterSites_CaseInsensitive(t *testing.T) {
+	got := filteredSortedSites(sitesFixture(), "ALPHA", siteSortName)
+	if len(got) != 1 || got[0].Name != "alpha" {
+		t.Fatalf("filter should be case-insensitive, got %+v", names(got))
+	}
+}
+
+func TestSortSites_Framework(t *testing.T) {
+	got := filteredSortedSites(sitesFixture(), "", siteSortFramework)
+	// Laravel entries come before Symfony alphabetically.
+	if got[0].FrameworkLabel != "Laravel 11" || got[len(got)-1].FrameworkLabel != "Symfony 7" {
+		t.Fatalf("framework sort wrong: %+v", frameworkLabels(got))
+	}
+}
+
+func TestSortSites_StatusBuckets(t *testing.T) {
+	got := filteredSortedSites(sitesFixture(), "", siteSortStatus)
+	if got[0].Name != "alpha" {
+		t.Fatalf("running site should come first, got %s", got[0].Name)
+	}
+	if got[len(got)-1].Name != "beta" {
+		t.Fatalf("paused site should come last, got %s", got[len(got)-1].Name)
+	}
+}
+
+func servicesFixture() []ServiceRow {
+	return []ServiceRow{
+		{Name: "mysql", State: stateRunning, SiteCount: 3},
+		{Name: "redis", State: stateStopped, SiteCount: 1},
+		{Name: "mailpit", State: statePaused, SiteCount: 2},
+		{Name: "custom-x", State: stateRunning, SiteCount: 0, Custom: true},
+	}
+}
+
+func TestFilterServices_ByName(t *testing.T) {
+	got := filteredSortedServices(servicesFixture(), "redis", svcSortName)
+	if len(got) != 1 || got[0].Name != "redis" {
+		t.Fatalf("expected redis, got %+v", svcNames(got))
+	}
+}
+
+func TestSortServices_Usage(t *testing.T) {
+	got := filteredSortedServices(servicesFixture(), "", svcSortUsage)
+	// Highest site count first (mysql=3, mailpit=2, redis=1, custom-x=0).
+	if got[0].Name != "mysql" || got[3].Name != "custom-x" {
+		t.Fatalf("usage sort wrong: %+v", svcNames(got))
+	}
+}
+
+func TestSortServices_Status(t *testing.T) {
+	got := filteredSortedServices(servicesFixture(), "", svcSortStatus)
+	// Running bucket first, paused last.
+	if got[0].State != stateRunning {
+		t.Fatalf("running should sort first, got %v", got[0].State)
+	}
+	if got[len(got)-1].State != statePaused {
+		t.Fatalf("paused should sort last, got %v", got[len(got)-1].State)
+	}
+}
+
+func TestSortLabels(t *testing.T) {
+	cases := []struct {
+		mode  siteSortMode
+		label string
+	}{
+		{siteSortName, "name"},
+		{siteSortStatus, "status"},
+		{siteSortFramework, "framework"},
+	}
+	for _, c := range cases {
+		if got := c.mode.label(); got != c.label {
+			t.Errorf("site %d label=%q want %q", c.mode, got, c.label)
+		}
+	}
+	if svcSortUsage.label() != "usage" {
+		t.Error("usage label")
+	}
+}
+
+func frameworkLabels(ss []siteinfo.EnrichedSite) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = s.FrameworkLabel
+	}
+	return out
+}
+
+func svcNames(ss []ServiceRow) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = s.Name
+	}
+	return out
+}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -1,0 +1,97 @@
+package tui
+
+// helpSection groups related keybindings under a heading.
+type helpSection struct {
+	title string
+	rows  [][2]string // {key, description}
+}
+
+// helpReference is the canonical list of every keybinding in the TUI. It
+// lives here rather than inline in panes.go so a future keymap overhaul
+// (remappable keys, user-defined shortcuts) has one place to edit.
+var helpReference = []helpSection{
+	{
+		title: "Navigation",
+		rows: [][2]string{
+			{"tab / shift+tab", "cycle focus through Sites · Services · Detail"},
+			{"↑ ↓  j k", "move selection within the focused pane"},
+			{"pgup / pgdn", "jump by 10 rows"},
+			{"home / end · g G", "jump to first / last row"},
+		},
+	},
+	{
+		title: "Filter & sort",
+		rows: [][2]string{
+			{"/", "type to filter the focused list by name"},
+			{"  enter", "apply filter and leave input mode"},
+			{"  esc", "clear filter and leave input mode"},
+			{"o", "cycle sort order (name · status · …)"},
+		},
+	},
+	{
+		title: "Actions",
+		rows: [][2]string{
+			{"space / enter", "toggle the focused detail row (worker, HTTPS, LAN share, PHP, Node)"},
+			{"s", "start / unpause the focused site or start the focused service"},
+			{"x", "stop / pause the focused site or stop / remove the focused domain"},
+			{"r", "restart the focused site or service"},
+			{"p", "pause / unpause toggle for a site"},
+			{"t", "open an interactive shell inside the focused container"},
+		},
+	},
+	{
+		title: "Domains",
+		rows: [][2]string{
+			{"a", "add a new domain to the focused site (inline input)"},
+			{"e", "edit / rename the focused domain row (add new + remove old)"},
+			{"x", "remove the focused domain"},
+		},
+	},
+	{
+		title: "Logs",
+		rows: [][2]string{
+			{"l", "toggle the logs pane for the focused item"},
+			{"[ / ]", "cycle through the site's log sources (FPM, workers, app logs)"},
+		},
+	},
+	{
+		title: "Panes & overlays",
+		rows: [][2]string{
+			{"v", "show / hide the services pane"},
+			{"S", "swap the detail pane for global Settings (LAN expose, autostart, Xdebug)"},
+			{"?", "swap the detail pane for this help reference"},
+			{"esc", "close picker or return to site detail"},
+		},
+	},
+	{
+		title: "General",
+		rows: [][2]string{
+			{"R", "force a manual refresh"},
+			{"q / ctrl+c", "quit"},
+		},
+	},
+}
+
+// helpContentLines builds the lines drawn inside the detail pane when
+// detailMode == detailHelp. Same padding / clipping convention as the other
+// detail renderers so the border wraps cleanly.
+func helpContentLines(m *Model, innerW int) []string {
+	out := make([]string, 0, 64)
+	add := func(s string) { out = append(out, padToWidth(clipLine(s, innerW), innerW)) }
+
+	add(sectionStyle.Render("Keybindings"))
+	add(dimStyle.Render("  press ? or esc to return to site detail"))
+	add("")
+
+	for i, sec := range helpReference {
+		if i > 0 {
+			add("")
+		}
+		add(sectionStyle.Render(sec.title))
+		for _, row := range sec.rows {
+			key := padRight(truncatePlain(row[0], 18), 18)
+			add("  " + accentStyle.Render(key) + "  " + row[1])
+		}
+	}
+	return out
+}

--- a/internal/tui/lan.go
+++ b/internal/tui/lan.go
@@ -1,0 +1,79 @@
+package tui
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// The LAN IP lookup fires on every render when a site has LAN share on, so
+// we cache it for a few seconds. The underlying net.Dial trick is cheap but
+// re-running it every 100 ms of key input is wasteful when the routing
+// table almost never changes between frames.
+var lanIPCache struct {
+	sync.Mutex
+	value string
+	at    time.Time
+}
+
+const lanIPTTL = 5 * time.Second
+
+// primaryLANIP returns the host's primary outbound IPv4 address, or "" when
+// detection fails. Mirrors cli.detectPrimaryLANIP so the TUI and the web UI
+// agree on what URL the user should share — but kept local to avoid an
+// import cycle between internal/tui and internal/cli.
+func primaryLANIP() string {
+	lanIPCache.Lock()
+	defer lanIPCache.Unlock()
+	if lanIPCache.value != "" && time.Since(lanIPCache.at) < lanIPTTL {
+		return lanIPCache.value
+	}
+
+	if ip := dialProbeIP(); ip != "" {
+		lanIPCache.value = ip
+		lanIPCache.at = time.Now()
+		return ip
+	}
+	if ip := ifaceProbeIP(); ip != "" {
+		lanIPCache.value = ip
+		lanIPCache.at = time.Now()
+		return ip
+	}
+	return ""
+}
+
+func dialProbeIP() string {
+	conn, err := net.Dial("udp4", "1.1.1.1:80")
+	if err != nil {
+		return ""
+	}
+	defer conn.Close()
+	addr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok || addr == nil {
+		return ""
+	}
+	return addr.IP.String()
+}
+
+func ifaceProbeIP() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			ipnet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			if v4 := ipnet.IP.To4(); v4 != nil && !v4.IsLoopback() {
+				return v4.String()
+			}
+		}
+	}
+	return ""
+}

--- a/internal/tui/log_tail.go
+++ b/internal/tui/log_tail.go
@@ -1,0 +1,180 @@
+package tui
+
+import (
+	"bufio"
+	"context"
+	"os/exec"
+	"sync"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// LogKind picks between `podman logs` (containers), `journalctl --user`
+// (worker systemd units), and `tail -F` (framework app log files).
+// Workers don't run as containers so their output lives in the user
+// journal; sites and services do, and their history is richer when pulled
+// from podman; framework app logs (laravel.log, etc.) live on disk
+// because the framework writes them directly.
+type LogKind int
+
+const (
+	kindPodman LogKind = iota
+	kindJournal
+	kindFile
+)
+
+// LogTarget fully describes one tail-able source: what to tail, how to tail
+// it, and how to label it in the pane header.
+type LogTarget struct {
+	Kind  LogKind
+	ID    string
+	Label string
+}
+
+type logLineMsg struct {
+	source string
+	line   string
+}
+
+type logClosedMsg struct{ source string }
+
+// logTail runs at most one `podman logs -f` subprocess at a time. Switching
+// targets cancels the previous one and opens a fresh tail. A bounded ring
+// caps memory on chatty containers.
+type logTail struct {
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	target LogTarget
+	ch     chan string
+	lines  []string
+	max    int
+}
+
+func newLogTail() *logTail { return &logTail{max: 500} }
+
+// Start cancels any prior tail and spawns a fresh one for `target`.
+// The returned Cmd waits on the first line so Update can chain Follow().
+func (t *logTail) Start(target LogTarget) tea.Cmd {
+	t.mu.Lock()
+	if t.cancel != nil {
+		t.cancel()
+	}
+	t.lines = nil
+	t.target = target
+	ctx, cancel := context.WithCancel(context.Background())
+	t.cancel = cancel
+	ch := make(chan string, 64)
+	t.ch = ch
+	go t.run(ctx, target, ch)
+	t.mu.Unlock()
+	return t.readOne(target.ID, ch)
+}
+
+func (t *logTail) Stop() {
+	t.mu.Lock()
+	if t.cancel != nil {
+		t.cancel()
+		t.cancel = nil
+	}
+	t.target = LogTarget{}
+	t.ch = nil
+	t.mu.Unlock()
+}
+
+func (t *logTail) Lines() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]string, len(t.lines))
+	copy(out, t.lines)
+	return out
+}
+
+// Source returns the raw identifier of the active tail (container or unit
+// name). Used by Update to match incoming logLineMsgs against the current
+// target so stale reads from a just-cancelled tail are dropped on the floor.
+func (t *logTail) Source() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.target.ID
+}
+
+// Target returns the full active target for rendering the pane title.
+func (t *logTail) Target() LogTarget {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.target
+}
+
+func (t *logTail) append(line string) {
+	t.mu.Lock()
+	t.lines = append(t.lines, line)
+	if len(t.lines) > t.max {
+		t.lines = t.lines[len(t.lines)-t.max:]
+	}
+	t.mu.Unlock()
+}
+
+func (t *logTail) run(ctx context.Context, target LogTarget, ch chan<- string) {
+	defer close(ch)
+	var cmd *exec.Cmd
+	switch target.Kind {
+	case kindJournal:
+		// Worker log tail — platform-specific because workers are systemd
+		// user units on Linux (journalctl) but podman containers on macOS
+		// (podman logs). The ID is the same on both platforms (lerd-<kind>-<site>).
+		cmd = workerLogCmd(ctx, target.ID)
+	case kindFile:
+		// -F follows by name, re-opening if the file is rotated, which is
+		// what Laravel-style loggers do when they roll daily. -n 200 gives
+		// the same scrollback as the podman/journal variants.
+		cmd = exec.CommandContext(ctx, "tail", "-n", "200", "-F", target.ID)
+	default:
+		cmd = exec.CommandContext(ctx, podman.PodmanBin(), "logs", "-f", "--tail", "200", target.ID)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return
+	}
+	cmd.Stderr = cmd.Stdout
+	if err := cmd.Start(); err != nil {
+		return
+	}
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			return
+		case ch <- scanner.Text():
+		}
+	}
+	_ = cmd.Wait()
+}
+
+func (t *logTail) readOne(source string, ch <-chan string) tea.Cmd {
+	return func() tea.Msg {
+		line, ok := <-ch
+		if !ok {
+			return logClosedMsg{source: source}
+		}
+		t.append(line)
+		return logLineMsg{source: source, line: line}
+	}
+}
+
+// Follow returns a Cmd that reads the next line from the currently-active
+// tail. Returns nil when no tail is running.
+func (t *logTail) Follow() tea.Cmd {
+	t.mu.Lock()
+	source := t.target.ID
+	ch := t.ch
+	t.mu.Unlock()
+	if source == "" || ch == nil {
+		return nil
+	}
+	return t.readOne(source, ch)
+}

--- a/internal/tui/log_tail_darwin.go
+++ b/internal/tui/log_tail_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package tui
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// workerLogCmd returns the command that tails a worker's output on macOS.
+// Workers on macOS run as detached podman containers (not systemd units),
+// so their logs come from `podman logs -f`, matching what lerd-ui's
+// logs_darwin.go does. The short-retry wrapper exists because workers
+// started from the TUI may not have fully materialised yet when `l` fires.
+func workerLogCmd(ctx context.Context, container string) *exec.Cmd {
+	bin := podman.PodmanBin()
+	script := `for i in $(seq 1 20); do ` + bin + ` container exists ` + container +
+		` 2>/dev/null && break; sleep 0.25; done; exec ` + bin + ` logs -f --tail 200 ` + container
+	return exec.CommandContext(ctx, "/bin/sh", "-c", script)
+}

--- a/internal/tui/log_tail_linux.go
+++ b/internal/tui/log_tail_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package tui
+
+import (
+	"context"
+	"os/exec"
+)
+
+// workerLogCmd returns the command that tails a worker's output on Linux.
+// Workers run as systemd user units, so their stdout/stderr are in the
+// user journal — `journalctl --user` is the right source, matching what
+// lerd-ui's logs_linux.go does.
+func workerLogCmd(ctx context.Context, unit string) *exec.Cmd {
+	return exec.CommandContext(ctx, "journalctl", "--user", "-u", unit,
+		"-f", "--no-pager", "-n", "200", "--output=cat")
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,0 +1,995 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/eventbus"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/siteinfo"
+	lerdUpdate "github.com/geodro/lerd/internal/update"
+)
+
+// focusPane identifies which pane currently owns keyboard focus. Detail sits
+// permanently in the right column below the services list, so it's always
+// reachable via tab cycling.
+type focusPane int
+
+const (
+	paneSites focusPane = iota
+	paneServices
+	paneDetail
+)
+
+// detailMode picks what the right-hand pane renders. Site detail is the
+// default; pressing S swaps it for settings and ? swaps it for the full
+// keybinding reference. Kept as a single pane, not a separate overlay,
+// so the user never leaves the main dashboard.
+type detailMode int
+
+const (
+	detailSite detailMode = iota
+	detailSettings
+	detailHelp
+)
+
+// Model is the bubbletea root. Panes are all projections of snap plus small
+// per-pane cursor/scroll state, so every refresh cycle rebuilds from a single
+// source of truth without stale data.
+type Model struct {
+	width, height int
+
+	snap Snapshot
+
+	detailMode detailMode
+	focus      focusPane
+
+	siteCursor int
+	siteScroll int
+	siteFilter string
+	siteSort   siteSortMode
+
+	svcCursor int
+	svcScroll int
+	svcFilter string
+	svcSort   svcSortMode
+
+	// Filter-input mode: when active, key runes go into the active filter
+	// instead of firing actions. Which pane is being filtered is determined
+	// by focus. Exited by esc or enter.
+	filterActive bool
+
+	detailCursor int // index into detail rows (workers + toggles)
+	settingsRow  int // index into settings rows
+	helpScroll   int // vertical scroll offset for the help view
+
+	// Picker state (PHP/Node version). When active, up/down navigates
+	// pickerOptions instead of detail rows and enter applies the pick.
+	pickerKind    detailKind
+	pickerOptions []string
+	pickerCursor  int
+
+	// Domain-input state: when active, typing adds characters to the
+	// pending domain name; enter runs `lerd domain add`, esc cancels.
+	// When domainInputEditing is non-empty, the input is editing that
+	// existing full domain — commit chains an add-new + remove-old.
+	domainInputActive  bool
+	domainInput        string
+	domainInputEditing string
+
+	showLogs     bool
+	hideServices bool
+	logTail      *logTail
+	logCursor    int // index into currentLogTargets() for the focused item
+
+	status       string
+	statusExpiry time.Time
+
+	sub     *eventbus.Subscriber
+	version string
+
+	// Latest version reported by the 24h-cached update check. Non-empty
+	// when a newer release is available; rendered as a banner in the
+	// header so users see it without running lerd status.
+	updateAvailable string
+}
+
+// NewModel builds an initial model. The caller is expected to call
+// podman.Cache.Start before running; NewModel itself is pure.
+func NewModel(version string) *Model {
+	return &Model{
+		width:   100,
+		height:  30,
+		logTail: newLogTail(),
+		sub:     eventbus.Default.Subscribe(),
+		version: version,
+	}
+}
+
+// Init implements tea.Model. Kicks off the first snapshot load, the refresh
+// ticker, the eventbus subscription, and a one-shot update check.
+func (m *Model) Init() tea.Cmd {
+	return tea.Batch(
+		loadCmd(),
+		tickCmd(2*time.Second),
+		busCmd(m.sub),
+		updateCheckCmd(m.version),
+	)
+}
+
+// updateCheckMsg carries the result of the cached update lookup back into
+// the model. Empty Latest means "on the latest version or check failed".
+type updateCheckMsg struct{ Latest string }
+
+// updateCheckCmd reads the 24h update cache (populated by lerd status /
+// lerd doctor). We don't fire a live GitHub request ourselves — if no
+// other command has run lately, the banner just stays hidden.
+func updateCheckCmd(current string) tea.Cmd {
+	return func() tea.Msg {
+		info, _ := lerdUpdate.CachedUpdateCheck(current)
+		if info == nil {
+			return updateCheckMsg{}
+		}
+		return updateCheckMsg{Latest: info.LatestVersion}
+	}
+}
+
+// Update implements tea.Model.
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+
+	case refreshMsg:
+		return m, loadCmd()
+
+	case snapshotMsg:
+		m.snap = msg.snap
+		m.clampCursors()
+		return m, tickCmd(2 * time.Second)
+
+	case ActionResult:
+		m.setStatus(formatAction(msg), 5*time.Second)
+		return m, loadCmd()
+
+	case logLineMsg:
+		if msg.source == m.logTail.Source() {
+			return m, m.logTail.Follow()
+		}
+		return m, nil
+
+	case logClosedMsg:
+		return m, nil
+
+	case updateCheckMsg:
+		m.updateAvailable = msg.Latest
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	return m.handleMainKey(msg)
+}
+
+func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.filterActive {
+		return m.handleFilterKey(msg)
+	}
+	if m.domainInputActive {
+		return m.handleDomainInputKey(msg)
+	}
+	switch msg.String() {
+	case "ctrl+c", "q":
+		m.logTail.Stop()
+		eventbus.Default.Unsubscribe(m.sub)
+		return m, tea.Quit
+
+	case "enter", " ":
+		if m.focus == paneDetail {
+			if m.pickerKind != kindInfo {
+				return m, m.applyPicker()
+			}
+			if m.detailMode == detailSettings {
+				return m, m.settingsToggle(m.settingsRows())
+			}
+			return m, m.detailToggleSelected(m.currentSite(), detailRows(m.currentSite()), navigableRows(detailRows(m.currentSite())))
+		}
+		return m, nil
+
+	case "esc":
+		if m.pickerKind != kindInfo {
+			m.closePicker()
+			return m, nil
+		}
+		if m.detailMode != detailSite {
+			m.detailMode = detailSite
+		}
+		return m, nil
+
+	case "S":
+		if m.detailMode == detailSettings {
+			m.detailMode = detailSite
+		} else {
+			m.detailMode = detailSettings
+			m.settingsRow = 0
+			// Jump focus into the detail pane so the user can move through
+			// settings immediately without a separate tab press. No-op when
+			// already focused there.
+			m.focus = paneDetail
+		}
+		return m, nil
+
+	case "?":
+		if m.detailMode == detailHelp {
+			m.detailMode = detailSite
+		} else {
+			m.detailMode = detailHelp
+			m.focus = paneDetail
+		}
+		return m, nil
+
+	case "tab":
+		m.focus = m.nextFocus(+1)
+		return m, m.syncLogs()
+
+	case "shift+tab":
+		m.focus = m.nextFocus(-1)
+		return m, m.syncLogs()
+
+	case "up", "k":
+		m.moveCursor(-1)
+		return m, m.syncLogs()
+
+	case "down", "j":
+		m.moveCursor(1)
+		return m, m.syncLogs()
+
+	case "pgup":
+		m.moveCursor(-10)
+		return m, m.syncLogs()
+
+	case "pgdown":
+		m.moveCursor(10)
+		return m, m.syncLogs()
+
+	case "home", "g":
+		m.setCursor(0)
+		return m, m.syncLogs()
+
+	case "end", "G":
+		m.setCursor(1 << 30)
+		return m, m.syncLogs()
+
+	case "l":
+		return m, m.toggleLogs()
+
+	case "t":
+		return m, m.actionShell()
+
+	case "v":
+		m.hideServices = !m.hideServices
+		if m.hideServices && m.focus == paneServices {
+			m.focus = paneSites
+		}
+		return m, nil
+
+	case "/":
+		if m.focus == paneSites || m.focus == paneServices {
+			m.filterActive = true
+		}
+		return m, nil
+
+	case "o":
+		switch m.focus {
+		case paneSites:
+			m.siteSort = (m.siteSort + 1) % 3
+			m.siteCursor = 0
+		case paneServices:
+			m.svcSort = (m.svcSort + 1) % 3
+			m.svcCursor = 0
+		}
+		return m, nil
+
+	case "[":
+		return m, m.cycleLogTarget(-1)
+
+	case "]":
+		return m, m.cycleLogTarget(1)
+
+	case "s":
+		return m, m.actionStart()
+
+	case "x":
+		if handled, cmd := m.removeFocusedDomain(); handled {
+			return m, cmd
+		}
+		return m, m.actionStop()
+
+	case "a":
+		if m.focus == paneDetail && m.detailMode == detailSite && m.currentSite() != nil {
+			m.openDomainInput()
+			return m, nil
+		}
+		return m, nil
+
+	case "e":
+		if m.editFocusedDomain() {
+			return m, nil
+		}
+		return m, nil
+
+	case "r":
+		return m, m.actionRestart()
+
+	case "p":
+		return m, m.actionPauseToggle()
+
+	case "R":
+		return m, loadCmd()
+	}
+	return m, nil
+}
+
+// openDomainInput switches into domain-input mode for adding a new domain.
+// Focus is pinned to paneDetail so the user sees the input next to the
+// domains list they were just looking at.
+func (m *Model) openDomainInput() {
+	m.domainInputActive = true
+	m.domainInput = ""
+	m.domainInputEditing = ""
+	m.focus = paneDetail
+}
+
+// openDomainEdit enters domain-input mode pre-filled with the short form
+// of `full`. On commit the handler runs add-new + remove-old as a sequence,
+// which gives rename semantics without a dedicated `lerd domain rename`
+// command.
+func (m *Model) openDomainEdit(full string) {
+	m.domainInputActive = true
+	m.domainInput = trimTLD(full)
+	m.domainInputEditing = full
+	m.focus = paneDetail
+}
+
+// editFocusedDomain is called from handleMainKey when `e` is pressed with
+// the detail cursor on a domain row. Returns false when the focus/row
+// doesn't match so other bindings keep working.
+func (m *Model) editFocusedDomain() (handled bool) {
+	if m.focus != paneDetail || m.detailMode != detailSite {
+		return false
+	}
+	s := m.currentSite()
+	if s == nil {
+		return false
+	}
+	rows := detailRows(s)
+	nav := navigableRows(rows)
+	if m.detailCursor >= len(nav) {
+		return false
+	}
+	row := rows[nav[m.detailCursor]]
+	if row.kind != kindDomain {
+		return false
+	}
+	m.openDomainEdit(row.domain)
+	return true
+}
+
+// handleDomainInputKey collects characters for the new domain, commits on
+// enter (running `lerd domain add <short>` from the site dir), cancels on
+// esc. Unlike filter input we're not narrowing a list in real time, so no
+// refresh is needed until the subprocess exits.
+func (m *Model) handleDomainInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.domainInputActive = false
+		m.domainInput = ""
+		m.domainInputEditing = ""
+		return m, nil
+	case "enter":
+		s := m.currentSite()
+		value := strings.TrimSpace(m.domainInput)
+		editing := m.domainInputEditing
+		m.domainInputActive = false
+		m.domainInput = ""
+		m.domainInputEditing = ""
+		if s == nil || value == "" {
+			return m, nil
+		}
+		value = strings.ToLower(strings.TrimSuffix(value, "."+currentTLD()))
+		if editing != "" {
+			// No-op if the user pressed enter without changing anything.
+			if value == trimTLD(editing) {
+				return m, nil
+			}
+			oldShort := trimTLD(editing)
+			m.setStatus("renaming "+editing+" → "+value+"…", 5*time.Second)
+			return m, tea.Sequence(
+				runLerd(s.Path, "domain", "add", value),
+				runLerd(s.Path, "domain", "remove", oldShort),
+			)
+		}
+		m.setStatus("adding domain "+value+"…", 5*time.Second)
+		return m, runLerd(s.Path, "domain", "add", value)
+	case "ctrl+c":
+		m.logTail.Stop()
+		return m, tea.Quit
+	case "backspace":
+		if len(m.domainInput) > 0 {
+			r := []rune(m.domainInput)
+			m.domainInput = string(r[:len(r)-1])
+		}
+	default:
+		if len(msg.Runes) > 0 {
+			m.domainInput += string(msg.Runes)
+		}
+	}
+	return m, nil
+}
+
+// handleFilterKey runs while the filter input is active. Typed runes are
+// appended to the filter for the currently focused pane; backspace removes
+// the last rune; enter and esc exit input mode (esc also clears the
+// filter). Actions, tab, navigation are all suppressed while filter mode
+// is active so the user can type freely.
+func (m *Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	target := m.filterTarget()
+	switch msg.String() {
+	case "esc":
+		*target = ""
+		m.filterActive = false
+		m.resetFilteredCursor()
+	case "enter":
+		m.filterActive = false
+	case "ctrl+c":
+		m.logTail.Stop()
+		return m, tea.Quit
+	case "backspace":
+		if len(*target) > 0 {
+			r := []rune(*target)
+			*target = string(r[:len(r)-1])
+			m.resetFilteredCursor()
+		}
+	default:
+		if len(msg.Runes) > 0 {
+			*target += string(msg.Runes)
+			m.resetFilteredCursor()
+		}
+	}
+	return m, nil
+}
+
+// filterTarget returns the pointer to the filter string for whichever list
+// is currently focused, so handleFilterKey doesn't have to branch on pane.
+func (m *Model) filterTarget() *string {
+	if m.focus == paneServices {
+		return &m.svcFilter
+	}
+	return &m.siteFilter
+}
+
+func (m *Model) resetFilteredCursor() {
+	if m.focus == paneServices {
+		m.svcCursor = 0
+		m.svcScroll = 0
+		return
+	}
+	m.siteCursor = 0
+	m.siteScroll = 0
+}
+
+// syncLogs retargets the log tail to match the currently-focused item
+// whenever the log pane is open. Called after every navigation or focus
+// change. Resets to the first target of the new selection; previous logCursor
+// doesn't transfer since target lists differ per item.
+func (m *Model) syncLogs() tea.Cmd {
+	if !m.showLogs {
+		return nil
+	}
+	targets := m.currentLogTargets()
+	if len(targets) == 0 {
+		m.logTail.Stop()
+		return nil
+	}
+	if m.logCursor >= len(targets) {
+		m.logCursor = 0
+	}
+	next := targets[m.logCursor]
+	if next.ID == m.logTail.Source() {
+		return nil
+	}
+	m.logCursor = 0
+	return m.logTail.Start(targets[0])
+}
+
+// nextFocus returns the focus after moving `dir` steps (±1) through the
+// list of panes that are currently visible and usable. Skips services when
+// hidden and skips detail when no site is selected.
+func (m *Model) nextFocus(dir int) focusPane {
+	panes := []focusPane{paneSites}
+	if !m.hideServices {
+		panes = append(panes, paneServices)
+	}
+	if m.currentSite() != nil {
+		panes = append(panes, paneDetail)
+	}
+	n := len(panes)
+	if n == 0 {
+		return m.focus
+	}
+	idx := 0
+	for i, p := range panes {
+		if p == m.focus {
+			idx = i
+			break
+		}
+	}
+	idx = ((idx+dir)%n + n) % n
+	return panes[idx]
+}
+
+func (m *Model) moveCursor(delta int) {
+	switch m.focus {
+	case paneSites:
+		m.siteCursor = clamp(m.siteCursor+delta, 0, max(0, len(m.visibleSites())-1))
+		m.closePicker()
+	case paneServices:
+		m.svcCursor = clamp(m.svcCursor+delta, 0, max(0, len(m.visibleServices())-1))
+	case paneDetail:
+		if m.pickerKind != kindInfo {
+			n := len(m.pickerOptions)
+			if n == 0 {
+				return
+			}
+			m.pickerCursor = clamp(m.pickerCursor+delta, 0, n-1)
+			return
+		}
+		switch m.detailMode {
+		case detailSettings:
+			rows := m.settingsRows()
+			m.settingsRow = clamp(m.settingsRow+delta, 0, max(0, len(rows)-1))
+		case detailHelp:
+			m.helpScroll += delta
+			if m.helpScroll < 0 {
+				m.helpScroll = 0
+			}
+		default:
+			if s := m.currentSite(); s != nil {
+				nav := navigableRows(detailRows(s))
+				m.detailCursor = clamp(m.detailCursor+delta, 0, max(0, len(nav)-1))
+			}
+		}
+	}
+}
+
+func (m *Model) setCursor(pos int) {
+	switch m.focus {
+	case paneSites:
+		m.siteCursor = clamp(pos, 0, max(0, len(m.visibleSites())-1))
+	case paneServices:
+		m.svcCursor = clamp(pos, 0, max(0, len(m.visibleServices())-1))
+	}
+}
+
+func (m *Model) clampCursors() {
+	m.siteCursor = clamp(m.siteCursor, 0, max(0, len(m.visibleSites())-1))
+	m.svcCursor = clamp(m.svcCursor, 0, max(0, len(m.visibleServices())-1))
+}
+
+// visibleSites is the view-ready sites list: m.snap.Sites with the active
+// filter and sort applied. Every renderer and cursor lookup goes through
+// this so filtered-out rows are invisible to navigation, not just hidden
+// visually.
+func (m *Model) visibleSites() []siteinfo.EnrichedSite {
+	return filteredSortedSites(m.snap.Sites, m.siteFilter, m.siteSort)
+}
+
+func (m *Model) visibleServices() []ServiceRow {
+	return filteredSortedServices(m.snap.Services, m.svcFilter, m.svcSort)
+}
+
+func (m *Model) setStatus(s string, d time.Duration) {
+	m.status = s
+	m.statusExpiry = time.Now().Add(d)
+}
+
+func (m *Model) toggleLogs() tea.Cmd {
+	if m.showLogs {
+		m.logTail.Stop()
+		m.showLogs = false
+		return nil
+	}
+	targets := m.currentLogTargets()
+	if len(targets) == 0 {
+		m.setStatus("no log source for selected item", 3*time.Second)
+		return nil
+	}
+	m.showLogs = true
+	m.logCursor = 0
+	return m.logTail.Start(targets[0])
+}
+
+// cycleLogTarget steps through the available log sources for the currently
+// focused item (FPM → queue → schedule → …). No-op when the log pane is
+// closed or the item has only one source.
+func (m *Model) cycleLogTarget(delta int) tea.Cmd {
+	if !m.showLogs {
+		return nil
+	}
+	targets := m.currentLogTargets()
+	if len(targets) <= 1 {
+		return nil
+	}
+	n := len(targets)
+	m.logCursor = ((m.logCursor+delta)%n + n) % n
+	return m.logTail.Start(targets[m.logCursor])
+}
+
+// currentLogTargets returns every log source the user can switch between for
+// the focused item. Sites expose their FPM/custom container plus a target
+// per running-or-defined worker (each worker is a systemd user unit tailed
+// via journalctl --user). Services have just the one container.
+func (m *Model) currentLogTargets() []LogTarget {
+	switch m.focus {
+	case paneSites, paneDetail:
+		s := m.currentSite()
+		if s == nil {
+			return nil
+		}
+		return logTargetsForSite(s)
+	case paneServices:
+		svc := m.currentService()
+		if svc == nil {
+			return nil
+		}
+		if svc.WorkerKind != "" {
+			// Worker-backed services run as systemd user units; tail the
+			// journal, matching lerd-ui's handleQueueLogs / handleHorizonLogs.
+			return []LogTarget{{
+				Kind:  kindJournal,
+				ID:    "lerd-" + svc.WorkerKind + "-" + svc.WorkerSite,
+				Label: svc.WorkerKind + " · " + svc.WorkerSite,
+			}}
+		}
+		return []LogTarget{{Kind: kindPodman, ID: "lerd-" + svc.Name, Label: svc.Name}}
+	}
+	return nil
+}
+
+func logTargetsForSite(s *siteinfo.EnrichedSite) []LogTarget {
+	var out []LogTarget
+	if s.ContainerPort > 0 {
+		out = append(out, LogTarget{
+			Kind:  kindPodman,
+			ID:    podman.CustomContainerName(s.Name),
+			Label: s.Name + " · container",
+		})
+	} else if s.PHPVersion != "" {
+		out = append(out, LogTarget{
+			Kind:  kindPodman,
+			ID:    "lerd-php" + strings.ReplaceAll(s.PHPVersion, ".", "") + "-fpm",
+			Label: s.Name + " · fpm " + s.PHPVersion,
+		})
+	}
+
+	addUnit := func(present bool, unitSuffix, label string) {
+		if !present {
+			return
+		}
+		out = append(out, LogTarget{
+			Kind:  kindJournal,
+			ID:    "lerd-" + unitSuffix + "-" + s.Name,
+			Label: s.Name + " · " + label,
+		})
+	}
+	addUnit(s.HasQueueWorker, "queue", "queue")
+	addUnit(s.HasScheduleWorker, "schedule", "schedule")
+	addUnit(s.HasReverb, "reverb", "reverb")
+	addUnit(s.HasHorizon, "horizon", "horizon")
+	for _, fw := range s.FrameworkWorkers {
+		label := fw.Label
+		if label == "" {
+			label = fw.Name
+		}
+		out = append(out, LogTarget{
+			Kind:  kindJournal,
+			ID:    "lerd-" + fw.Name + "-" + s.Name,
+			Label: s.Name + " · " + label,
+		})
+	}
+	for _, path := range appLogPathsForSite(s) {
+		out = append(out, LogTarget{
+			Kind:  kindFile,
+			ID:    path,
+			Label: s.Name + " · " + filepath.Base(path),
+		})
+	}
+	return out
+}
+
+// appLogPathsForSite expands the framework's log-source globs against the
+// site's project directory, returning absolute paths. Mirrors the web UI's
+// app-logs endpoint: for Laravel that's storage/logs/*.log, other
+// frameworks get whatever they declare in their definition.
+func appLogPathsForSite(s *siteinfo.EnrichedSite) []string {
+	fw, ok := config.GetFrameworkForDir(s.FrameworkName, s.Path)
+	if !ok || fw == nil || len(fw.Logs) == 0 {
+		return nil
+	}
+	absProject, err := filepath.Abs(s.Path)
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var paths []string
+	for _, src := range fw.Logs {
+		matches, err := filepath.Glob(filepath.Join(absProject, src.Path))
+		if err != nil {
+			continue
+		}
+		for _, m := range matches {
+			abs, err := filepath.Abs(m)
+			if err != nil || !strings.HasPrefix(abs, absProject+string(filepath.Separator)) {
+				continue
+			}
+			if seen[abs] {
+				continue
+			}
+			if info, err := os.Stat(abs); err != nil || info.IsDir() {
+				continue
+			}
+			seen[abs] = true
+			paths = append(paths, abs)
+		}
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func (m *Model) currentSite() *siteinfo.EnrichedSite {
+	sites := m.visibleSites()
+	if m.siteCursor >= 0 && m.siteCursor < len(sites) {
+		return &sites[m.siteCursor]
+	}
+	return nil
+}
+
+func (m *Model) currentService() *ServiceRow {
+	svcs := m.visibleServices()
+	if m.svcCursor >= 0 && m.svcCursor < len(svcs) {
+		return &svcs[m.svcCursor]
+	}
+	return nil
+}
+
+func (m *Model) actionStart() tea.Cmd {
+	switch m.focus {
+	case paneSites, paneDetail:
+		if s := m.currentSite(); s != nil {
+			m.setStatus("starting "+s.Name+"…", 5*time.Second)
+			return runLerd(s.Path, "unpause", s.Name)
+		}
+	case paneServices:
+		if svc := m.currentService(); svc != nil {
+			if cmd := m.workerActionCmd(svc, "start"); cmd != nil {
+				return cmd
+			}
+			m.setStatus("starting "+svc.Name+"…", 5*time.Second)
+			return runLerd("", "service", "start", svc.Name)
+		}
+	}
+	return nil
+}
+
+// workerActionCmd returns a tea.Cmd for start/stop/restart on a worker-
+// backed service row. Returns nil for regular service rows so the caller
+// can fall through to `lerd service <verb>`.
+func (m *Model) workerActionCmd(svc *ServiceRow, verb string) tea.Cmd {
+	if svc.WorkerKind == "" || svc.WorkerPath == "" {
+		return nil
+	}
+	m.setStatus(verb+"ing "+svc.WorkerKind+" worker for "+svc.WorkerSite+"…", 5*time.Second)
+	switch svc.WorkerKind {
+	case "queue", "schedule", "horizon", "reverb":
+		if verb == "restart" {
+			// Worker restart = stop + start via systemd; we use the unit
+			// directly because `lerd queue restart` doesn't exist as a
+			// CLI verb on every worker. Two sequenced lerd invocations
+			// keep us inside the public CLI.
+			return tea.Sequence(
+				runLerd(svc.WorkerPath, svc.WorkerKind, "stop"),
+				runLerd(svc.WorkerPath, svc.WorkerKind, "start"),
+			)
+		}
+		return runLerd(svc.WorkerPath, svc.WorkerKind, verb)
+	default:
+		if verb == "restart" {
+			return tea.Sequence(
+				runLerd(svc.WorkerPath, "worker", "stop", svc.WorkerKind),
+				runLerd(svc.WorkerPath, "worker", "start", svc.WorkerKind),
+			)
+		}
+		return runLerd(svc.WorkerPath, "worker", verb, svc.WorkerKind)
+	}
+}
+
+func (m *Model) actionStop() tea.Cmd {
+	switch m.focus {
+	case paneSites, paneDetail:
+		if s := m.currentSite(); s != nil {
+			m.setStatus("pausing "+s.Name+"…", 5*time.Second)
+			return runLerd(s.Path, "pause", s.Name)
+		}
+	case paneServices:
+		if svc := m.currentService(); svc != nil {
+			if cmd := m.workerActionCmd(svc, "stop"); cmd != nil {
+				return cmd
+			}
+			m.setStatus("stopping "+svc.Name+"…", 5*time.Second)
+			return runLerd("", "service", "stop", svc.Name)
+		}
+	}
+	return nil
+}
+
+func (m *Model) actionRestart() tea.Cmd {
+	switch m.focus {
+	case paneSites, paneDetail:
+		if s := m.currentSite(); s != nil {
+			m.setStatus("restarting "+s.Name+"…", 5*time.Second)
+			return runLerd(s.Path, "restart", s.Name)
+		}
+	case paneServices:
+		if svc := m.currentService(); svc != nil {
+			if cmd := m.workerActionCmd(svc, "restart"); cmd != nil {
+				return cmd
+			}
+			m.setStatus("restarting "+svc.Name+"…", 5*time.Second)
+			return runLerd("", "service", "restart", svc.Name)
+		}
+	}
+	return nil
+}
+
+// actionShell opens an interactive shell inside the container that backs
+// whatever's currently focused: FPM / custom container for a site, the
+// service's own container for a service. Setting the working dir to the
+// site's project path means PHP tools (composer, artisan) run as if the
+// user had cd'd into the project first.
+func (m *Model) actionShell() tea.Cmd {
+	switch m.focus {
+	case paneSites, paneDetail:
+		s := m.currentSite()
+		if s == nil {
+			return nil
+		}
+		container := containerForSite(s)
+		if container == "" {
+			m.setStatus("no container to shell into for "+s.Name, 3*time.Second)
+			return nil
+		}
+		if running, _ := podman.ContainerRunning(container); !running {
+			m.setStatus(container+" is not running — start the site first", 4*time.Second)
+			return nil
+		}
+		return runShellIn(container, s.Path)
+	case paneServices:
+		svc := m.currentService()
+		if svc == nil {
+			return nil
+		}
+		if svc.WorkerKind != "" {
+			// Worker rows have no container of their own — they run inside
+			// the owning site's FPM container. Find that site and shell in
+			// there, which is what the user wants when they hit t on e.g.
+			// queue-astrolov.
+			site := m.siteByName(svc.WorkerSite)
+			if site == nil {
+				m.setStatus("owner site "+svc.WorkerSite+" not loaded", 3*time.Second)
+				return nil
+			}
+			container := containerForSite(site)
+			if container == "" {
+				m.setStatus("no container for "+svc.WorkerSite, 3*time.Second)
+				return nil
+			}
+			if running, _ := podman.ContainerRunning(container); !running {
+				m.setStatus(container+" is not running", 4*time.Second)
+				return nil
+			}
+			return runShellIn(container, site.Path)
+		}
+		container := "lerd-" + svc.Name
+		if running, _ := podman.ContainerRunning(container); !running {
+			m.setStatus(container+" is not running", 4*time.Second)
+			return nil
+		}
+		return runShellIn(container, "")
+	}
+	return nil
+}
+
+// siteByName returns the enriched site in the current snapshot with the
+// given name, or nil. Used by worker-service rows that need to reach back
+// to their owning site's container and path.
+func (m *Model) siteByName(name string) *siteinfo.EnrichedSite {
+	for i := range m.snap.Sites {
+		if m.snap.Sites[i].Name == name {
+			return &m.snap.Sites[i]
+		}
+	}
+	return nil
+}
+
+func (m *Model) actionPauseToggle() tea.Cmd {
+	if m.focus != paneSites && m.focus != paneDetail {
+		return nil
+	}
+	s := m.currentSite()
+	if s == nil {
+		return nil
+	}
+	if s.Paused {
+		m.setStatus("resuming "+s.Name+"…", 5*time.Second)
+		return runLerd(s.Path, "unpause", s.Name)
+	}
+	m.setStatus("pausing "+s.Name+"…", 5*time.Second)
+	return runLerd(s.Path, "pause", s.Name)
+}
+
+// Run starts the bubbletea program with the shared podman cache warmed up.
+// Called from cli.NewTuiCmd so the wiring lives next to the rest of the
+// command registry.
+func Run(version string) error {
+	podman.Cache.Start(context.Background())
+	m := NewModel(version)
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	_, err := p.Run()
+	return err
+}
+
+func formatAction(r ActionResult) string {
+	if r.Err != nil {
+		detail := r.Detail
+		if detail == "" {
+			detail = r.Err.Error()
+		}
+		detail = firstLine(detail)
+		return fmt.Sprintf("✖ %s: %s", r.Summary, detail)
+	}
+	return "✓ " + r.Summary
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+func clamp(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// ensure lipgloss is referenced so keeping it as a named import above doesn't
+// trip the linter if the render code moves around.
+var _ = lipgloss.NewStyle

--- a/internal/tui/model_extra_test.go
+++ b/internal/tui/model_extra_test.go
@@ -1,0 +1,232 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func TestNextFocus_SkipsServicesWhenHidden(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.hideServices = true
+	m.focus = paneSites
+
+	got := m.nextFocus(+1)
+	if got != paneDetail {
+		t.Fatalf("hideServices + tab should skip to detail, got %d", got)
+	}
+}
+
+func TestNextFocus_NoSitesSkipsDetail(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{
+		Services: []ServiceRow{{Name: "mysql", State: stateRunning}},
+	}
+	m.focus = paneServices
+	got := m.nextFocus(+1)
+	if got != paneSites {
+		t.Fatalf("without sites, tab from services should wrap to sites (skipping detail), got %d", got)
+	}
+}
+
+func TestClampCursors_ClampsToVisibleCount(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.siteCursor = 5
+	m.svcCursor = 9
+	m.clampCursors()
+	if m.siteCursor >= len(m.visibleSites()) {
+		t.Fatalf("siteCursor %d out of bounds (len=%d)", m.siteCursor, len(m.visibleSites()))
+	}
+	if m.svcCursor >= len(m.visibleServices()) {
+		t.Fatalf("svcCursor %d out of bounds (len=%d)", m.svcCursor, len(m.visibleServices()))
+	}
+}
+
+func TestFilterInput_CollectsRunes(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.focus = paneSites
+	m.filterActive = true
+
+	for _, r := range "be" {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = next.(*Model)
+	}
+	if m.siteFilter != "be" {
+		t.Fatalf("expected filter 'be', got %q", m.siteFilter)
+	}
+	// Backspace drops one rune.
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = next.(*Model)
+	if m.siteFilter != "b" {
+		t.Fatalf("expected filter 'b' after backspace, got %q", m.siteFilter)
+	}
+	// Esc clears and exits input mode.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	m = next.(*Model)
+	if m.siteFilter != "" || m.filterActive {
+		t.Fatalf("esc should clear filter and leave input, got filter=%q active=%v", m.siteFilter, m.filterActive)
+	}
+}
+
+func TestDetailMode_SToggleSetsFocus(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.focus = paneSites
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'S'}})
+	m = next.(*Model)
+	if m.detailMode != detailSettings {
+		t.Fatalf("S should enter settings mode, got %d", m.detailMode)
+	}
+	if m.focus != paneDetail {
+		t.Fatalf("S should move focus to detail, got %d", m.focus)
+	}
+	// S again → back to site
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'S'}})
+	m = next.(*Model)
+	if m.detailMode != detailSite {
+		t.Fatalf("second S should return to site detail, got %d", m.detailMode)
+	}
+}
+
+func TestDetailMode_HelpToggle(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	m = next.(*Model)
+	if m.detailMode != detailHelp {
+		t.Fatalf("? should enter help mode, got %d", m.detailMode)
+	}
+	// Esc returns to site detail.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	m = next.(*Model)
+	if m.detailMode != detailSite {
+		t.Fatalf("esc should return to site detail, got %d", m.detailMode)
+	}
+}
+
+func TestHideServicesToggle(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.focus = paneServices
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+	m = next.(*Model)
+	if !m.hideServices {
+		t.Fatalf("v should hide services")
+	}
+	if m.focus == paneServices {
+		t.Fatalf("focus should move off hidden pane, got %d", m.focus)
+	}
+}
+
+func TestViewRendersUnderSettingsMode(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.width, m.height = 150, 40
+	m.detailMode = detailSettings
+	out := m.View()
+	if !strings.Contains(out, "Settings") {
+		t.Fatalf("settings view should include 'Settings' header, got:\n%s", out)
+	}
+}
+
+func TestViewRendersUnderHelpMode(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.width, m.height = 150, 50
+	m.detailMode = detailHelp
+	out := m.View()
+	if !strings.Contains(out, "Keybindings") {
+		t.Fatalf("help view should include 'Keybindings' header")
+	}
+}
+
+func TestDomainInput_CommitRunsLerdAdd(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{
+		Sites: []siteinfo.EnrichedSite{{Name: "alpha", Path: "/x", Domains: []string{"alpha.test"}}},
+	}
+	m.focus = paneDetail
+	m.openDomainInput()
+	for _, r := range "newdomain" {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = next.(*Model)
+	}
+	if m.domainInput != "newdomain" {
+		t.Fatalf("expected pending domain 'newdomain', got %q", m.domainInput)
+	}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(*Model)
+	if cmd == nil {
+		t.Fatalf("enter should return a Cmd")
+	}
+	if m.domainInputActive {
+		t.Fatalf("input should be closed after commit")
+	}
+}
+
+func TestDomainInput_EscCancels(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{
+		Sites: []siteinfo.EnrichedSite{{Name: "alpha", Path: "/x", Domains: []string{"alpha.test"}}},
+	}
+	m.openDomainInput()
+	m.domainInput = "partial"
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	m = next.(*Model)
+	if m.domainInputActive || m.domainInput != "" {
+		t.Fatalf("esc should clear input, got active=%v value=%q", m.domainInputActive, m.domainInput)
+	}
+}
+
+func TestOpenDomainEdit_PrefillsShortName(t *testing.T) {
+	m := NewModel("test")
+	m.openDomainEdit("staging.alpha.test")
+	if !strings.Contains(m.domainInput, "staging.alpha") && m.domainInput != "staging.alpha" {
+		t.Fatalf("edit should prefill short form, got %q", m.domainInput)
+	}
+	if m.domainInputEditing != "staging.alpha.test" {
+		t.Fatalf("editing target not stored, got %q", m.domainInputEditing)
+	}
+}
+
+func TestClosePicker(t *testing.T) {
+	m := NewModel("test")
+	m.pickerKind = kindPHP
+	m.pickerOptions = []string{"8.3", "8.4"}
+	m.pickerCursor = 1
+	m.closePicker()
+	if m.pickerKind != kindInfo || m.pickerOptions != nil || m.pickerCursor != 0 {
+		t.Fatalf("closePicker should reset state, got %+v", m)
+	}
+}
+
+func TestWorkerActionCmd_BuiltinWorker(t *testing.T) {
+	m := NewModel("test")
+	svc := &ServiceRow{
+		Name: "queue-alpha", WorkerKind: "queue", WorkerSite: "alpha", WorkerPath: "/x",
+	}
+	if cmd := m.workerActionCmd(svc, "start"); cmd == nil {
+		t.Fatalf("should return a Cmd for a worker row")
+	}
+	// Non-worker service rows get nil so callers fall through.
+	plain := &ServiceRow{Name: "mysql"}
+	if cmd := m.workerActionCmd(plain, "start"); cmd != nil {
+		t.Fatalf("plain services should return nil (fallthrough)")
+	}
+}
+
+func TestSiteByName(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	if s := m.siteByName("alpha"); s == nil || s.Name != "alpha" {
+		t.Fatalf("siteByName(alpha) failed: %+v", s)
+	}
+	if s := m.siteByName("missing"); s != nil {
+		t.Fatalf("siteByName(missing) should be nil")
+	}
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,0 +1,217 @@
+package tui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func fakeSnap() Snapshot {
+	return Snapshot{
+		Sites: []siteinfo.EnrichedSite{
+			{Name: "alpha", PHPVersion: "8.3", FPMRunning: true, HasQueueWorker: true, QueueRunning: true},
+			{Name: "beta", PHPVersion: "8.2", FPMRunning: false, Paused: true},
+		},
+		Services: []ServiceRow{
+			{Name: "mysql", State: stateRunning, SiteCount: 2},
+			{Name: "redis", State: stateStopped, SiteCount: 1},
+			{Name: "mailpit", State: statePaused, SiteCount: 0},
+		},
+		Status: StatusRow{
+			TLD: "test", NginxRunning: true, DNSOk: true,
+			PHPRunning: []string{"8.3"},
+		},
+	}
+}
+
+func TestMoveCursor_Sites_Bounds(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.focus = paneSites
+
+	m.moveCursor(1)
+	if m.siteCursor != 1 {
+		t.Fatalf("expected cursor 1, got %d", m.siteCursor)
+	}
+	m.moveCursor(5)
+	if m.siteCursor != 1 {
+		t.Fatalf("cursor should clamp at last site (1), got %d", m.siteCursor)
+	}
+	m.moveCursor(-99)
+	if m.siteCursor != 0 {
+		t.Fatalf("cursor should clamp at 0, got %d", m.siteCursor)
+	}
+}
+
+func TestMoveCursor_Services_Bounds(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.focus = paneServices
+
+	m.moveCursor(2)
+	if m.svcCursor != 2 {
+		t.Fatalf("expected cursor 2, got %d", m.svcCursor)
+	}
+	m.moveCursor(99)
+	if m.svcCursor != 2 {
+		t.Fatalf("cursor should clamp at 2, got %d", m.svcCursor)
+	}
+}
+
+func TestTabCyclesFocus(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	if m.focus != paneSites {
+		t.Fatalf("initial focus should be sites, got %d", m.focus)
+	}
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(*Model)
+	if m.focus != paneServices {
+		t.Fatalf("tab should move focus to services, got %d", m.focus)
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(*Model)
+	if m.focus != paneDetail {
+		t.Fatalf("second tab should move focus to detail, got %d", m.focus)
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(*Model)
+	if m.focus != paneSites {
+		t.Fatalf("third tab should return focus to sites, got %d", m.focus)
+	}
+}
+
+func TestTabSkipsDetailWhenNoSite(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{
+		Services: []ServiceRow{{Name: "mysql", State: stateRunning}},
+	}
+	m.focus = paneServices
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(*Model)
+	if m.focus != paneSites {
+		t.Fatalf("tab with no sites should skip detail and wrap to sites, got %d", m.focus)
+	}
+}
+
+func TestSnapshotMsgClampsCursor(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.focus = paneSites
+	m.siteCursor = 1
+
+	shrunk := fakeSnap()
+	shrunk.Sites = shrunk.Sites[:1]
+
+	next, _ := m.Update(snapshotMsg{snap: shrunk})
+	m = next.(*Model)
+	if m.siteCursor != 0 {
+		t.Fatalf("cursor should clamp when snapshot shrinks, got %d", m.siteCursor)
+	}
+}
+
+func TestViewRendersCoreContent(t *testing.T) {
+	m := NewModel("v1.0.0")
+	m.snap = fakeSnap()
+	m.width, m.height = 120, 30
+
+	out := m.View()
+	for _, want := range []string{"Sites", "Services", "alpha", "beta", "mysql", "redis"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("view missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestViewTooSmall(t *testing.T) {
+	m := NewModel("v1.0.0")
+	m.snap = fakeSnap()
+	m.width, m.height = 40, 10
+	out := m.View()
+	if !strings.Contains(out, "too small") {
+		t.Fatalf("expected too-small banner, got: %s", out)
+	}
+}
+
+func TestCurrentSiteAndService(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+
+	if m.currentSite().Name != "alpha" {
+		t.Fatal("expected alpha at cursor 0")
+	}
+	m.siteCursor = 1
+	if m.currentSite().Name != "beta" {
+		t.Fatal("expected beta at cursor 1")
+	}
+
+	// Services render sorted by name by default, so the first row is mailpit,
+	// not mysql (the snapshot insertion order).
+	if m.currentService().Name != "mailpit" {
+		t.Fatalf("expected mailpit at cursor 0 (name sort), got %s", m.currentService().Name)
+	}
+}
+
+func TestFilterNarrowsSitesList(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.siteFilter = "bet"
+	visible := m.visibleSites()
+	if len(visible) != 1 || visible[0].Name != "beta" {
+		t.Fatalf("expected filter 'bet' to keep only beta, got %+v", names(visible))
+	}
+}
+
+func TestSortSitesByStatusRunningFirst(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.siteSort = siteSortStatus
+	got := m.visibleSites()
+	if got[0].Name != "alpha" {
+		t.Fatalf("expected running site (alpha) first under status sort, got %s", got[0].Name)
+	}
+}
+
+func names(ss []siteinfo.EnrichedSite) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = s.Name
+	}
+	return out
+}
+
+func TestFormatActionOK(t *testing.T) {
+	got := formatAction(ActionResult{Summary: "lerd service start redis"})
+	if !strings.HasPrefix(got, "✓") {
+		t.Fatalf("expected ok prefix, got %q", got)
+	}
+}
+
+func TestFormatActionError(t *testing.T) {
+	got := formatAction(ActionResult{
+		Summary: "lerd service start redis",
+		Err:     errors.New("exit 1"),
+		Detail:  "boom\ntrace",
+	})
+	if !strings.Contains(got, "boom") || strings.Contains(got, "trace") {
+		t.Fatalf("expected first-line error only, got %q", got)
+	}
+}
+
+func TestViewportScrollsToKeepCursorVisible(t *testing.T) {
+	rows := make([]string, 20)
+	for i := range rows {
+		rows[i] = "row"
+	}
+	scroll := 0
+	visible := viewport(rows, 15, 5, &scroll)
+	if len(visible) != 5 {
+		t.Fatalf("expected 5 visible rows, got %d", len(visible))
+	}
+	if scroll != 11 {
+		t.Fatalf("expected scroll=11 to keep cursor visible, got %d", scroll)
+	}
+}

--- a/internal/tui/panes.go
+++ b/internal/tui/panes.go
@@ -1,0 +1,610 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// View implements tea.Model.
+func (m *Model) View() string {
+	if m.width < 60 || m.height < 12 {
+		return "terminal too small (need at least 60×12)\n"
+	}
+
+	header := m.renderHeader()
+	footer := m.renderFooter()
+	statusBar := m.renderStatus()
+
+	reserved := lipgloss.Height(header) + lipgloss.Height(footer)
+	if statusBar != "" {
+		reserved += lipgloss.Height(statusBar)
+	}
+	bodyH := m.height - reserved
+	if bodyH < 6 {
+		bodyH = 6
+	}
+
+	// Logs pane gets at least half the full window when open. Clamp so the
+	// top lists always keep at least 6 rows to stay useful.
+	logH := 0
+	if m.showLogs {
+		logH = m.height / 2
+		if half := bodyH / 2; logH < half {
+			logH = half
+		}
+		if logH < 10 {
+			logH = 10
+		}
+		if logH > bodyH-6 {
+			logH = bodyH - 6
+		}
+	}
+	topH := bodyH - logH
+	if topH < 6 {
+		topH = 6
+	}
+
+	// Left column stacks sites on top of services; right column is the
+	// site detail (full topH). When services is hidden, sites takes the
+	// whole left column.
+	leftW := m.width * 2 / 5
+	if leftW < 36 {
+		leftW = 36
+	}
+	if leftW > m.width-30 {
+		leftW = m.width - 30
+	}
+	rightW := m.width - leftW
+
+	var left string
+	if m.hideServices {
+		left = m.renderSites(leftW, topH)
+	} else {
+		svcNeeded := len(m.snap.Services) + 3
+		if svcNeeded < 6 {
+			svcNeeded = 6
+		}
+		svcH := svcNeeded
+		if lim := topH / 2; svcH > lim {
+			svcH = lim
+		}
+		if svcH > topH-6 {
+			svcH = topH - 6
+		}
+		if svcH < 4 {
+			svcH = 4
+		}
+		siteH := topH - svcH
+		sites := m.renderSites(leftW, siteH)
+		services := m.renderServices(leftW, svcH)
+		left = lipgloss.JoinVertical(lipgloss.Left, sites, services)
+	}
+	detail := m.renderDetailInline(rightW, topH, m.focus == paneDetail)
+	top := lipgloss.JoinHorizontal(lipgloss.Top, left, detail)
+
+	sections := []string{header, top}
+	if m.showLogs {
+		sections = append(sections, m.renderLogs(m.width, logH))
+	}
+	if statusBar != "" {
+		sections = append(sections, statusBar)
+	}
+	sections = append(sections, footer)
+
+	return lipgloss.JoinVertical(lipgloss.Left, sections...)
+}
+
+func (m *Model) renderHeader() string {
+	parts := []string{titleStyle.Render("lerd " + m.version)}
+
+	if m.updateAvailable != "" {
+		parts = append(parts, accentStyle.Render("update: "+m.updateAvailable+" (run `lerd update`)"))
+	}
+
+	if m.snap.Status.DNSOk {
+		parts = append(parts, runningStyle.Render("DNS ok"))
+	} else {
+		parts = append(parts, failingStyle.Render("DNS down"))
+	}
+
+	if m.snap.Status.NginxRunning {
+		parts = append(parts, runningStyle.Render("nginx up"))
+	} else {
+		parts = append(parts, stoppedStyle.Render("nginx down"))
+	}
+
+	if len(m.snap.Status.PHPRunning) > 0 {
+		parts = append(parts, accentStyle.Render("FPM "+strings.Join(m.snap.Status.PHPRunning, ",")))
+	}
+
+	if m.snap.Status.WatcherRunning {
+		parts = append(parts, dimStyle.Render("watcher"))
+	}
+
+	parts = append(parts, dimStyle.Render(time.Now().Format("15:04:05")))
+
+	return strings.Join(parts, "  ·  ")
+}
+
+func (m *Model) renderFooter() string {
+	if m.filterActive {
+		return helpStyle.Render("  filter: type to match · enter apply · esc clear")
+	}
+	keys := []string{
+		"tab panes",
+		"↑↓ nav",
+		"space toggle",
+		"/ filter",
+		"o sort",
+		"s start",
+		"x stop",
+		"r restart",
+		"l logs",
+		"t shell",
+		"v services",
+		"S settings",
+		"? help",
+		"q quit",
+	}
+	return helpStyle.Render("  " + strings.Join(keys, "   "))
+}
+
+func (m *Model) renderStatus() string {
+	if m.status == "" {
+		return ""
+	}
+	if !m.statusExpiry.IsZero() && time.Now().After(m.statusExpiry) {
+		m.status = ""
+		return ""
+	}
+	return helpStyle.Render("  " + m.status)
+}
+
+func (m *Model) renderSites(w, h int) string {
+	style := paneStyle(m.focus == paneSites)
+	innerW, innerH := innerSize(style, w, h)
+
+	sites := m.visibleSites()
+	total := len(m.snap.Sites)
+	title := fmt.Sprintf("Sites (%d/%d · sort: %s)", len(sites), total, m.siteSort.label())
+	lines := []string{padToWidth(clipLine(sectionStyle.Render(title), innerW), innerW)}
+
+	// Filter bar appears as a second header row whenever the user has
+	// entered any filter text or is currently typing. Keeps the active
+	// filter visible at a glance and distinguishes "empty list because no
+	// matches" from "empty list because nothing was linked yet".
+	activeFilter := m.focus == paneSites && m.filterActive
+	if activeFilter || m.siteFilter != "" {
+		lines = append(lines, padToWidth(filterBar(m.siteFilter, activeFilter), innerW))
+	}
+
+	availRows := innerH - len(lines)
+	if availRows < 1 {
+		availRows = 1
+	}
+
+	switch {
+	case total == 0:
+		lines = append(lines, padToWidth(dimStyle.Render("no linked sites"), innerW))
+	case len(sites) == 0:
+		lines = append(lines, padToWidth(dimStyle.Render("no sites match filter"), innerW))
+	default:
+		rows := make([]string, 0, len(sites))
+		for i, s := range sites {
+			row := renderSiteRow(i == m.siteCursor && m.focus == paneSites, s, innerW)
+			rows = append(rows, padToWidth(clipLine(row, innerW), innerW))
+		}
+		visible := viewport(rows, m.siteCursor, availRows, &m.siteScroll)
+		lines = append(lines, visible...)
+	}
+	for len(lines) < innerH {
+		lines = append(lines, spaces(innerW))
+	}
+
+	return style.Render(strings.Join(lines, "\n"))
+}
+
+// siteWorkerColWidth is the fixed display-width reservation for the worker
+// glyphs column in the sites list. Needs to be consistent across rows for
+// the PHP column (which sits to the left of it) to align cleanly.
+// 12 cells fits the typical worst case: q·s·v·h·m·m (6 glyphs + 5 spaces).
+const siteWorkerColWidth = 12
+
+func renderSiteRow(selected bool, s siteinfo.EnrichedSite, paneW int) string {
+	glyph := fpmGlyph(s)
+	workers := workerGlyphs(s)
+
+	// Display the primary domain (the URL users actually visit) rather than
+	// the internal site registry name — the name is still used for command
+	// dispatch and filtering, it just isn't what shows up in the list.
+	name := s.PrimaryDomain()
+	if name == "" {
+		name = s.Name
+	}
+	if s.Paused {
+		name += " (paused)"
+	}
+
+	php := s.PHPVersion
+	if php == "" && s.ContainerPort > 0 {
+		php = "custom"
+	}
+
+	// Reserve the SAME budget on every row so PHP and worker columns line
+	// up vertically, regardless of which workers a site happens to run.
+	// The previous version subtracted workersW per row, which left empty-
+	// worker rows with a wider name column and shifted PHP leftward.
+	reserved := 4 /* prefix + glyph + spaces */ + 7 /* php %-7s */ + 1 + siteWorkerColWidth
+	nameW := paneW - reserved
+	if nameW < 16 {
+		nameW = 16
+	}
+	name = padRight(truncatePlain(name, nameW), nameW)
+
+	prefix := " "
+	if selected {
+		prefix = accentStyle.Render("▸")
+	}
+
+	styled := name
+	switch {
+	case s.Paused:
+		styled = pausedStyle.Render(name)
+	case selected:
+		styled = selectedStyle.Render(name)
+	}
+
+	return fmt.Sprintf("%s %s %s %-7s %s", prefix, glyph, styled, php, padToWidth(workers, siteWorkerColWidth))
+}
+
+func fpmGlyph(s siteinfo.EnrichedSite) string {
+	if s.Paused {
+		return pausedStyle.Render(glyphPaused)
+	}
+	if s.FPMRunning {
+		return runningStyle.Render(glyphRunning)
+	}
+	return stoppedStyle.Render(glyphStopped)
+}
+
+func workerGlyphs(s siteinfo.EnrichedSite) string {
+	var out []string
+	add := func(has, running, failing bool, label string) {
+		if !has {
+			return
+		}
+		switch {
+		case failing:
+			out = append(out, failingStyle.Render(label))
+		case running:
+			out = append(out, runningStyle.Render(label))
+		default:
+			out = append(out, stoppedStyle.Render(label))
+		}
+	}
+	add(s.HasQueueWorker, s.QueueRunning, s.QueueFailing, "q")
+	add(s.HasScheduleWorker, s.ScheduleRunning, s.ScheduleFailing, "s")
+	add(s.HasReverb, s.ReverbRunning, s.ReverbFailing, "v")
+	add(s.HasHorizon, s.HorizonRunning, s.HorizonFailing, "h")
+	for _, fw := range s.FrameworkWorkers {
+		add(true, fw.Running, fw.Failing, "•")
+	}
+	return strings.Join(out, " ")
+}
+
+func (m *Model) renderServices(w, h int) string {
+	style := paneStyle(m.focus == paneServices)
+	innerW, innerH := innerSize(style, w, h)
+
+	services := m.visibleServices()
+	total := len(m.snap.Services)
+	title := fmt.Sprintf("Services (%d/%d · sort: %s)", len(services), total, m.svcSort.label())
+	lines := []string{padToWidth(clipLine(sectionStyle.Render(title), innerW), innerW)}
+
+	activeFilter := m.focus == paneServices && m.filterActive
+	if activeFilter || m.svcFilter != "" {
+		lines = append(lines, padToWidth(filterBar(m.svcFilter, activeFilter), innerW))
+	}
+
+	availRows := innerH - len(lines)
+	if availRows < 1 {
+		availRows = 1
+	}
+
+	switch {
+	case total == 0:
+		lines = append(lines, padToWidth(dimStyle.Render("no services configured"), innerW))
+	case len(services) == 0:
+		lines = append(lines, padToWidth(dimStyle.Render("no services match filter"), innerW))
+	default:
+		rows := make([]string, 0, len(services))
+		for i, s := range services {
+			row := renderServiceRow(i == m.svcCursor && m.focus == paneServices, s, innerW)
+			rows = append(rows, padToWidth(clipLine(row, innerW), innerW))
+		}
+		visible := viewport(rows, m.svcCursor, availRows, &m.svcScroll)
+		lines = append(lines, visible...)
+	}
+	for len(lines) < innerH {
+		lines = append(lines, spaces(innerW))
+	}
+
+	return style.Render(strings.Join(lines, "\n"))
+}
+
+// filterBar renders the single-line filter chrome shown above the list:
+// "filter: <text>▌" while typing, "filter: <text>" otherwise. Kept
+// unstyled-plain so the caller can pad it reliably to the pane width.
+func filterBar(text string, active bool) string {
+	label := dimStyle.Render("  filter: ")
+	if active {
+		return label + text + "▌"
+	}
+	if text == "" {
+		return ""
+	}
+	return label + text
+}
+
+// serviceMetaColWidth is the fixed budget for the trailing meta column
+// (site count + pinned/custom tags). Reserved identically on every row so
+// the meta column starts at the same column regardless of which tags are
+// present, mirroring the aligned layout in the sites pane.
+const serviceMetaColWidth = 22
+
+func renderServiceRow(selected bool, s ServiceRow, paneW int) string {
+	var glyph string
+	switch s.State {
+	case stateRunning:
+		glyph = runningStyle.Render(glyphRunning)
+	case statePaused:
+		glyph = pausedStyle.Render(glyphPaused)
+	default:
+		glyph = stoppedStyle.Render(glyphStopped)
+	}
+
+	meta := fmt.Sprintf("(%d site%s)", s.SiteCount, plural(s.SiteCount))
+	if s.Pinned {
+		meta += "  " + accentStyle.Render("pinned")
+	}
+	if s.Custom {
+		meta += "  " + dimStyle.Render("custom")
+	}
+
+	reserved := 5 /* two prefix spaces + glyph + spaces */ + serviceMetaColWidth + 1
+	nameW := paneW - reserved
+	if nameW < 14 {
+		nameW = 14
+	}
+	name := padRight(truncatePlain(s.Name, nameW), nameW)
+	styledName := name
+	if selected {
+		styledName = selectedStyle.Render(name)
+	}
+
+	prefix := " "
+	if selected {
+		prefix = accentStyle.Render("▸")
+	}
+	return fmt.Sprintf(" %s %s %s %s", prefix, glyph, styledName, padToWidth(meta, serviceMetaColWidth))
+}
+
+func (m *Model) renderLogs(w, h int) string {
+	style := unfocusedPane
+	innerW, innerH := innerSize(style, w, h)
+
+	target := m.logTail.Target()
+	label := target.Label
+	if label == "" {
+		label = target.ID
+	}
+	title := fmt.Sprintf("Logs · %s", label)
+	if n := len(m.currentLogTargets()); n > 1 {
+		title += fmt.Sprintf("   [%d/%d · [ ] to switch]", m.logCursor+1, n)
+	}
+
+	availRows := innerH - 1
+	if availRows < 1 {
+		availRows = 1
+	}
+
+	all := m.logTail.Lines()
+	total := len(all)
+
+	// Reserve the rightmost column for the scrollbar. Log lines go in
+	// contentW; scrollbar gets 1 cell. lipgloss.Width() is skipped here
+	// because it treats horizontal padding as part of the width budget,
+	// which makes our already-innerW-wide lines wrap to an extra row.
+	contentW := innerW - 1
+	if contentW < 10 {
+		contentW = innerW
+	}
+
+	var visible []string
+	start := 0
+	if total > 0 {
+		if total > availRows {
+			start = total - availRows
+		}
+		visible = all[start:]
+	}
+
+	body := make([]string, 0, availRows)
+	for _, ln := range visible {
+		body = append(body, clipLine(ln, contentW))
+	}
+	if total == 0 {
+		body = append(body, clipLine(dimStyle.Render("waiting for output…"), contentW))
+	}
+	for len(body) < availRows {
+		body = append(body, "")
+	}
+
+	bar := renderScrollbar(availRows, total, start, len(visible))
+
+	lines := make([]string, 0, availRows+1)
+	lines = append(lines, padToWidth(clipLine(sectionStyle.Render(title), innerW), innerW))
+	for i := 0; i < availRows; i++ {
+		lines = append(lines, padToWidth(body[i], contentW)+bar[i])
+	}
+
+	return style.Render(strings.Join(lines, "\n"))
+}
+
+// padToWidth right-pads an ANSI-aware string with spaces to `w` display
+// cells. Used instead of Go's `%-*s` (which counts bytes) or
+// lipgloss.Style.Width (which treats padding as part of the block width
+// and causes lines to wrap when we want them to sit flush with the border).
+func padToWidth(s string, w int) string {
+	n := ansi.StringWidth(s)
+	if n >= w {
+		return s
+	}
+	return s + spaces(w-n)
+}
+
+// clipLine truncates s to display width w without slicing through an ANSI
+// escape or a multi-byte rune. Uses ansi.Truncate so styled log output is
+// preserved even when the line is too wide for the pane.
+func clipLine(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	if ansi.StringWidth(s) <= w {
+		return s
+	}
+	return ansi.Truncate(s, w, "…")
+}
+
+// renderScrollbar returns a slice of height strings (one per content row)
+// drawing a vertical scrollbar for a virtual list of `total` items where
+// `visible` items starting at `start` are on-screen. Each entry is a
+// single-cell string so the caller appends it to the rightmost column.
+func renderScrollbar(height, total, start, visible int) []string {
+	out := make([]string, height)
+	if height <= 0 {
+		return out
+	}
+	if total <= visible || total == 0 {
+		for i := range out {
+			out[i] = dimStyle.Render("│")
+		}
+		return out
+	}
+	thumbSize := height * visible / total
+	if thumbSize < 1 {
+		thumbSize = 1
+	}
+	if thumbSize > height {
+		thumbSize = height
+	}
+	// Track position proportionally: thumbStart ∈ [0, height-thumbSize].
+	maxStart := total - visible
+	thumbStart := 0
+	if maxStart > 0 {
+		thumbStart = start * (height - thumbSize) / maxStart
+	}
+	for i := 0; i < height; i++ {
+		if i >= thumbStart && i < thumbStart+thumbSize {
+			out[i] = accentStyle.Render("█")
+		} else {
+			out[i] = dimStyle.Render("│")
+		}
+	}
+	return out
+}
+
+func paneStyle(focused bool) lipgloss.Style {
+	if focused {
+		return focusedPane
+	}
+	return unfocusedPane
+}
+
+func innerSize(style lipgloss.Style, w, h int) (int, int) {
+	hf := style.GetHorizontalFrameSize()
+	vf := style.GetVerticalFrameSize()
+	return max(1, w-hf), max(1, h-vf)
+}
+
+// viewport returns the slice of rows that fit in `height`, scrolled so the
+// cursor stays visible. scroll is updated in place so the pane remembers
+// where it was between frames.
+func viewport(rows []string, cursor, height int, scroll *int) []string {
+	if height <= 0 || len(rows) == 0 {
+		return nil
+	}
+	if cursor < *scroll {
+		*scroll = cursor
+	}
+	if cursor >= *scroll+height {
+		*scroll = cursor - height + 1
+	}
+	if *scroll < 0 {
+		*scroll = 0
+	}
+	end := *scroll + height
+	if end > len(rows) {
+		end = len(rows)
+	}
+	return rows[*scroll:end]
+}
+
+func truncate(s string, w int) string {
+	if w <= 0 || len(s) <= w {
+		return s
+	}
+	if w <= 1 {
+		return "…"
+	}
+	return s[:w-1] + "…"
+}
+
+// truncatePlain truncates a rune string by display length without slicing
+// through a multi-byte rune. Only safe on unstyled text; never pass ANSI-
+// wrapped strings here since escape bytes would count against the budget.
+func truncatePlain(s string, w int) string {
+	if w <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= w {
+		return s
+	}
+	if w == 1 {
+		return "…"
+	}
+	return string(r[:w-1]) + "…"
+}
+
+// padRight right-pads s with spaces to display width w (rune-counted, unstyled).
+func padRight(s string, w int) string {
+	n := len([]rune(s))
+	if n >= w {
+		return s
+	}
+	return s + spaces(w-n)
+}
+
+func spaces(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = ' '
+	}
+	return string(b)
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/internal/tui/panes_test.go
+++ b/internal/tui/panes_test.go
@@ -1,0 +1,116 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func TestPadToWidth_PadsShort(t *testing.T) {
+	got := padToWidth("hi", 6)
+	if ansi.StringWidth(got) != 6 {
+		t.Fatalf("expected width 6, got %d (%q)", ansi.StringWidth(got), got)
+	}
+}
+
+func TestPadToWidth_NoOpWhenLongEnough(t *testing.T) {
+	got := padToWidth("already long", 4)
+	if got != "already long" {
+		t.Fatalf("expected unchanged, got %q", got)
+	}
+}
+
+func TestClipLine_TruncatesByDisplayWidth(t *testing.T) {
+	got := clipLine("hello world", 5)
+	if w := ansi.StringWidth(got); w > 5 {
+		t.Fatalf("clip exceeded width %d: %q", w, got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("truncated string should end with …: %q", got)
+	}
+}
+
+func TestClipLine_NoOpWhenShort(t *testing.T) {
+	got := clipLine("hi", 20)
+	if got != "hi" {
+		t.Fatalf("expected unchanged, got %q", got)
+	}
+}
+
+func TestTruncatePlain_RuneAware(t *testing.T) {
+	// ü and é are multi-byte UTF-8 runes; must not slice mid-byte.
+	got := truncatePlain("résümé-extra", 6)
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("expected truncation marker, got %q", got)
+	}
+	if len([]rune(got)) != 6 {
+		t.Fatalf("expected 6 runes, got %d (%q)", len([]rune(got)), got)
+	}
+}
+
+func TestPadRight_UsesRuneCount(t *testing.T) {
+	got := padRight("é", 3)
+	if len([]rune(got)) != 3 {
+		t.Fatalf("expected 3 runes, got %d (%q)", len([]rune(got)), got)
+	}
+}
+
+func TestRenderSiteRow_AlignsPHPColumn(t *testing.T) {
+	// Two sites with different worker load should produce rows where the
+	// PHP column starts at the same visual column — the bug that prompted
+	// siteWorkerColWidth. We can't easily measure visual column directly,
+	// but we can assert that the two rows have the same display width.
+	s1 := siteinfo.EnrichedSite{Name: "a", PHPVersion: "8.3", HasQueueWorker: true, QueueRunning: true}
+	s2 := siteinfo.EnrichedSite{Name: "b", PHPVersion: "8.3"}
+	r1 := renderSiteRow(false, s1, 60)
+	r2 := renderSiteRow(false, s2, 60)
+	if w1, w2 := ansi.StringWidth(r1), ansi.StringWidth(r2); w1 != w2 {
+		t.Fatalf("rows of equal pane width should have equal display width, got %d vs %d", w1, w2)
+	}
+}
+
+func TestRenderServiceRow_AlignsMetaColumn(t *testing.T) {
+	s1 := ServiceRow{Name: "mysql", State: stateRunning, SiteCount: 2, Pinned: true}
+	s2 := ServiceRow{Name: "redis", State: stateStopped, SiteCount: 1}
+	r1 := renderServiceRow(false, s1, 60)
+	r2 := renderServiceRow(false, s2, 60)
+	if w1, w2 := ansi.StringWidth(r1), ansi.StringWidth(r2); w1 != w2 {
+		t.Fatalf("service rows of equal pane width should have equal display width, got %d vs %d", w1, w2)
+	}
+}
+
+func TestFilterBar_ActiveShowsCursor(t *testing.T) {
+	got := filterBar("beta", true)
+	if !strings.HasSuffix(got, "▌") {
+		t.Fatalf("active filter bar should end with cursor, got %q", got)
+	}
+}
+
+func TestFilterBar_InactiveEmpty(t *testing.T) {
+	if got := filterBar("", false); got != "" {
+		t.Fatalf("empty inactive filter bar should render nothing, got %q", got)
+	}
+}
+
+func TestViewport_ShowsWindowedRows(t *testing.T) {
+	rows := []string{"a", "b", "c", "d", "e", "f"}
+	scroll := 0
+	got := viewport(rows, 2, 3, &scroll)
+	want := []string{"a", "b", "c"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("row %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestViewport_ScrollsDownAsCursorAdvances(t *testing.T) {
+	rows := []string{"a", "b", "c", "d", "e"}
+	scroll := 0
+	viewport(rows, 4, 2, &scroll)
+	if scroll != 3 {
+		t.Fatalf("scroll should advance to keep cursor visible, got %d", scroll)
+	}
+}

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -1,0 +1,118 @@
+package tui
+
+import (
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/config"
+	phpPkg "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// openPHPPicker loads installed PHP versions and enters picker mode on the
+// detail pane. A no-op when no versions are installed.
+func (m *Model) openPHPPicker(s *siteinfo.EnrichedSite) {
+	versions, err := phpPkg.ListInstalled()
+	if err != nil || len(versions) == 0 {
+		m.setStatus("no PHP versions installed", 3*time.Second)
+		return
+	}
+	m.pickerKind = kindPHP
+	m.pickerOptions = versions
+	m.pickerCursor = indexOf(versions, s.PHPVersion)
+}
+
+// openNodePicker shells out to fnm (same path lerd-ui uses) because node
+// version management is fnm's job; lerd doesn't keep its own registry.
+// A no-op when fnm reports nothing.
+func (m *Model) openNodePicker(s *siteinfo.EnrichedSite) {
+	versions := listNodeMajors()
+	if len(versions) == 0 {
+		m.setStatus("no Node versions installed (run 'lerd node install 20')", 3*time.Second)
+		return
+	}
+	m.pickerKind = kindNode
+	m.pickerOptions = versions
+	m.pickerCursor = indexOf(versions, s.NodeVersion)
+}
+
+// closePicker exits picker mode without applying a choice.
+func (m *Model) closePicker() {
+	m.pickerKind = kindInfo
+	m.pickerOptions = nil
+	m.pickerCursor = 0
+}
+
+// applyPicker runs `lerd isolate` or `lerd isolate:node` for the selected
+// version, then closes the picker. Refresh will land shortly via the regular
+// ActionResult → loadCmd path.
+func (m *Model) applyPicker() tea.Cmd {
+	if m.pickerKind == kindInfo || len(m.pickerOptions) == 0 {
+		return nil
+	}
+	s := m.currentSite()
+	if s == nil {
+		m.closePicker()
+		return nil
+	}
+	if m.pickerCursor >= len(m.pickerOptions) {
+		m.pickerCursor = len(m.pickerOptions) - 1
+	}
+	ver := m.pickerOptions[m.pickerCursor]
+	kind := m.pickerKind
+	m.closePicker()
+
+	switch kind {
+	case kindPHP:
+		m.setStatus("switching "+s.Name+" to PHP "+ver+"…", 5*time.Second)
+		return runLerd(s.Path, "isolate", ver)
+	case kindNode:
+		m.setStatus("switching "+s.Name+" to Node "+ver+"…", 5*time.Second)
+		return runLerd(s.Path, "isolate:node", ver)
+	}
+	return nil
+}
+
+// listNodeMajors returns the installed Node major versions as reported by
+// fnm. Mirrors ui.handleNodeVersions so the picker sees the same list the
+// web UI dropdown shows.
+func listNodeMajors() []string {
+	fnm := config.BinDir() + "/fnm"
+	out, err := exec.Command(fnm, "list").Output()
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var versions []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "* "))
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		v := strings.TrimPrefix(fields[0], "v")
+		if v == "" {
+			continue
+		}
+		major := strings.SplitN(v, ".", 2)[0]
+		if seen[major] || strings.Trim(major, "0123456789") != "" {
+			continue
+		}
+		seen[major] = true
+		versions = append(versions, major)
+	}
+	sort.Strings(versions)
+	return versions
+}
+
+func indexOf(ss []string, target string) int {
+	for i, s := range ss {
+		if s == target {
+			return i
+		}
+	}
+	return 0
+}

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -1,0 +1,89 @@
+package tui
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/config"
+	phpPkg "github.com/geodro/lerd/internal/php"
+	lerdSystemd "github.com/geodro/lerd/internal/systemd"
+)
+
+// settingsRow describes one focusable line in the settings view.
+type settingsRow struct {
+	kind       settingsKind
+	label      string
+	on         bool
+	phpVersion string // PHP version, for xdebug rows
+}
+
+type settingsKind int
+
+const (
+	settingsLANExpose settingsKind = iota
+	settingsAutostart
+	settingsXdebug
+)
+
+func (m *Model) settingsRows() []settingsRow {
+	cfg, _ := config.LoadGlobal()
+	var rows []settingsRow
+
+	lanExposed := cfg != nil && cfg.LAN.Exposed
+	rows = append(rows, settingsRow{
+		kind:  settingsLANExpose,
+		label: "LAN expose (open every service to the local network)",
+		on:    lanExposed,
+	})
+	rows = append(rows, settingsRow{
+		kind:  settingsAutostart,
+		label: "Autostart lerd on login",
+		on:    lerdSystemd.IsAutostartEnabled(),
+	})
+
+	if versions, err := phpPkg.ListInstalled(); err == nil {
+		for _, v := range versions {
+			rows = append(rows, settingsRow{
+				kind:       settingsXdebug,
+				label:      "Xdebug · PHP " + v,
+				on:         cfg != nil && cfg.IsXdebugEnabled(v),
+				phpVersion: v,
+			})
+		}
+	}
+	return rows
+}
+
+func (m *Model) settingsToggle(rows []settingsRow) tea.Cmd {
+	if len(rows) == 0 {
+		return nil
+	}
+	if m.settingsRow >= len(rows) {
+		m.settingsRow = len(rows) - 1
+	}
+	row := rows[m.settingsRow]
+	switch row.kind {
+	case settingsLANExpose:
+		verb := "on"
+		if row.on {
+			verb = "off"
+		}
+		m.setStatus("toggling LAN expose "+verb+"…", 5*time.Second)
+		return runLerd("", "lan", "expose", verb)
+	case settingsAutostart:
+		sub := "enable"
+		if row.on {
+			sub = "disable"
+		}
+		m.setStatus("autostart "+sub+"…", 5*time.Second)
+		return runLerd("", "autostart", sub)
+	case settingsXdebug:
+		verb := "on"
+		if row.on {
+			verb = "off"
+		}
+		m.setStatus("xdebug "+verb+" PHP "+row.phpVersion+"…", 5*time.Second)
+		return runLerd("", "xdebug", verb, row.phpVersion)
+	}
+	return nil
+}

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -1,0 +1,190 @@
+package tui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/dns"
+	phpPkg "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// Snapshot is the full view-model the TUI renders from. Produced by
+// loadSnapshot from the same sources lerd-ui uses, so every pane reflects the
+// same point-in-time state.
+type Snapshot struct {
+	Sites    []siteinfo.EnrichedSite
+	Services []ServiceRow
+	Status   StatusRow
+}
+
+// ServiceRow is a flat row for the services pane. Sourced from podman unit
+// status and service config so the TUI doesn't need to reach into ui/server.go.
+// For site-owned workers (queue, schedule, horizon, reverb, custom framework
+// workers) WorkerSite / WorkerKind are set so actions can run the right
+// per-site command instead of `lerd service start/stop` which would fail.
+type ServiceRow struct {
+	Name      string
+	State     ServiceState
+	Custom    bool
+	Pinned    bool
+	SiteCount int
+	Dashboard string
+	DependsOn []string
+
+	WorkerSite string
+	WorkerKind string
+	WorkerPath string
+}
+
+// ServiceState is a tri-state the TUI uses to pick a glyph and colour.
+type ServiceState int
+
+const (
+	stateStopped ServiceState = iota
+	stateRunning
+	statePaused
+)
+
+// StatusRow drives the top header bar.
+type StatusRow struct {
+	DNSOk          bool
+	TLD            string
+	NginxRunning   bool
+	WatcherRunning bool
+	PHPRunning     []string
+	Version        string
+}
+
+// loadSnapshot collects everything the TUI needs in one shot. Called on every
+// refresh tick and on every eventbus publish.
+func loadSnapshot() Snapshot {
+	snap := Snapshot{}
+
+	enriched, err := siteinfo.LoadAll(siteinfo.EnrichUI)
+	if err == nil {
+		_ = siteinfo.PersistVersionChanges(enriched)
+		sort.Slice(enriched, func(i, j int) bool { return enriched[i].Name < enriched[j].Name })
+		snap.Sites = enriched
+	}
+
+	snap.Services = loadServices()
+	// Workers live on sites but belong in the services pane too — same
+	// operational surface lerd-ui surfaces as "active" rows for queue,
+	// schedule, etc. Append them after the shared services so the user
+	// sees the full running-units picture in one list.
+	snap.Services = append(snap.Services, workerRows(snap.Sites)...)
+	snap.Status = loadStatus()
+	return snap
+}
+
+// workerRows synthesises one ServiceRow per active / defined worker across
+// every enriched site. Naming matches the web UI (`queue-<site>`, etc.) so
+// users moving between surfaces see familiar identifiers.
+func workerRows(sites []siteinfo.EnrichedSite) []ServiceRow {
+	var out []ServiceRow
+	add := func(site siteinfo.EnrichedSite, kind string, running, failing bool) {
+		state := stateStopped
+		if failing {
+			state = stateStopped
+		} else if running {
+			state = stateRunning
+		}
+		out = append(out, ServiceRow{
+			Name:       kind + "-" + site.Name,
+			State:      state,
+			WorkerSite: site.Name,
+			WorkerKind: kind,
+			WorkerPath: site.Path,
+			SiteCount:  1,
+		})
+	}
+	for _, s := range sites {
+		if s.HasQueueWorker {
+			add(s, "queue", s.QueueRunning, s.QueueFailing)
+		}
+		if s.HasScheduleWorker {
+			add(s, "schedule", s.ScheduleRunning, s.ScheduleFailing)
+		}
+		if s.HasHorizon {
+			add(s, "horizon", s.HorizonRunning, s.HorizonFailing)
+		}
+		if s.HasReverb {
+			add(s, "reverb", s.ReverbRunning, s.ReverbFailing)
+		}
+		for _, fw := range s.FrameworkWorkers {
+			switch fw.Name {
+			case "queue", "schedule", "horizon", "reverb":
+				continue
+			}
+			add(s, fw.Name, fw.Running, fw.Failing)
+		}
+	}
+	return out
+}
+
+func loadServices() []ServiceRow {
+	rows := make([]ServiceRow, 0, 16)
+	for _, name := range siteinfo.KnownServices {
+		rows = append(rows, buildServiceRow(name, false))
+	}
+	customs, _ := config.ListCustomServices()
+	for _, svc := range customs {
+		r := buildServiceRow(svc.Name, true)
+		r.DependsOn = svc.DependsOn
+		r.Dashboard = svc.Dashboard
+		rows = append(rows, r)
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Name < rows[j].Name })
+	return rows
+}
+
+func buildServiceRow(name string, custom bool) ServiceRow {
+	unit := "lerd-" + name
+	status, _ := podman.UnitStatus(unit)
+	state := stateStopped
+	switch status {
+	case "active", "activating":
+		state = stateRunning
+	}
+	if config.ServiceIsPaused(name) {
+		state = statePaused
+	}
+	return ServiceRow{
+		Name:      name,
+		State:     state,
+		Custom:    custom,
+		Pinned:    config.ServiceIsPinned(name),
+		SiteCount: config.CountSitesUsingService(name),
+	}
+}
+
+func loadStatus() StatusRow {
+	cfg, _ := config.LoadGlobal()
+	tld := "test"
+	if cfg != nil {
+		tld = cfg.DNS.TLD
+	}
+	dnsOK, _ := dns.Check(tld)
+	row := StatusRow{
+		TLD:          tld,
+		DNSOk:        dnsOK,
+		NginxRunning: podman.Cache.Running("lerd-nginx"),
+	}
+
+	if versions, err := phpPkg.ListInstalled(); err == nil {
+		for _, v := range versions {
+			short := strings.ReplaceAll(v, ".", "")
+			if podman.Cache.Running("lerd-php" + short + "-fpm") {
+				row.PHPRunning = append(row.PHPRunning, v)
+			}
+		}
+	}
+
+	st, _ := podman.UnitStatus("lerd-watcher")
+	row.WatcherRunning = st == "active" || st == "activating"
+
+	return row
+}

--- a/internal/tui/snapshot_test.go
+++ b/internal/tui/snapshot_test.go
@@ -1,0 +1,87 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func TestWorkerRows_SynthesizesFromSites(t *testing.T) {
+	sites := []siteinfo.EnrichedSite{
+		{
+			Name: "alpha", Path: "/sites/alpha",
+			HasQueueWorker: true, QueueRunning: true,
+			HasHorizon: true, HorizonRunning: false,
+		},
+		{
+			Name: "beta", Path: "/sites/beta",
+			HasScheduleWorker: true, ScheduleRunning: true,
+			FrameworkWorkers: []siteinfo.WorkerInfo{
+				{Name: "broadcaster", Running: true},
+			},
+		},
+	}
+	rows := workerRows(sites)
+
+	want := map[string]ServiceState{
+		"queue-alpha":      stateRunning,
+		"horizon-alpha":    stateStopped,
+		"schedule-beta":    stateRunning,
+		"broadcaster-beta": stateRunning,
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("expected %d worker rows, got %d: %+v", len(want), len(rows), rowsNames(rows))
+	}
+	for _, row := range rows {
+		wantState, ok := want[row.Name]
+		if !ok {
+			t.Errorf("unexpected worker row %q", row.Name)
+			continue
+		}
+		if row.State != wantState {
+			t.Errorf("%s: state %v, want %v", row.Name, row.State, wantState)
+		}
+		if row.WorkerSite == "" || row.WorkerKind == "" || row.WorkerPath == "" {
+			t.Errorf("%s: worker fields missing: %+v", row.Name, row)
+		}
+	}
+}
+
+func TestWorkerRows_FrameworkWorkerSkipsBuiltinNames(t *testing.T) {
+	// When a framework redeclares queue / schedule / horizon / reverb in
+	// FrameworkWorkers it's covered by the well-known branches already;
+	// don't synthesise a duplicate row.
+	sites := []siteinfo.EnrichedSite{{
+		Name: "alpha", Path: "/x",
+		FrameworkWorkers: []siteinfo.WorkerInfo{
+			{Name: "queue", Running: true},
+			{Name: "custom", Running: true},
+		},
+	}}
+	rows := workerRows(sites)
+	for _, r := range rows {
+		if r.Name == "queue-alpha" {
+			t.Errorf("framework-declared queue should be skipped, well-known branch handles it")
+		}
+	}
+	if !hasName(rows, "custom-alpha") {
+		t.Errorf("custom framework worker missing: %+v", rowsNames(rows))
+	}
+}
+
+func rowsNames(rows []ServiceRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.Name
+	}
+	return out
+}
+
+func hasName(rows []ServiceRow, name string) bool {
+	for _, r := range rows {
+		if r.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,0 +1,37 @@
+package tui
+
+import "github.com/charmbracelet/lipgloss"
+
+var (
+	colTitle    = lipgloss.Color("205")
+	colDim      = lipgloss.Color("243")
+	colDivider  = lipgloss.Color("237")
+	colRunning  = lipgloss.Color("42")
+	colStopped  = lipgloss.Color("243")
+	colFailing  = lipgloss.Color("203")
+	colPaused   = lipgloss.Color("214")
+	colAccent   = lipgloss.Color("147")
+	colSelected = lipgloss.Color("205")
+)
+
+var (
+	titleStyle    = lipgloss.NewStyle().Bold(true).Foreground(colTitle)
+	sectionStyle  = lipgloss.NewStyle().Bold(true).Foreground(colDim)
+	dimStyle      = lipgloss.NewStyle().Foreground(colDim)
+	selectedStyle = lipgloss.NewStyle().Bold(true).Foreground(colSelected)
+	focusedPane   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(colAccent).Padding(0, 1)
+	unfocusedPane = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(colDivider).Padding(0, 1)
+	runningStyle  = lipgloss.NewStyle().Foreground(colRunning)
+	stoppedStyle  = lipgloss.NewStyle().Foreground(colStopped)
+	failingStyle  = lipgloss.NewStyle().Foreground(colFailing).Bold(true)
+	pausedStyle   = lipgloss.NewStyle().Foreground(colPaused)
+	accentStyle   = lipgloss.NewStyle().Foreground(colAccent)
+	helpStyle     = lipgloss.NewStyle().Foreground(colDim)
+)
+
+const (
+	glyphRunning = "●"
+	glyphStopped = "○"
+	glyphFailing = "✖"
+	glyphPaused  = "◐"
+)

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -640,9 +640,9 @@
                         <span class="text-violet-500 dark:text-violet-400 shrink-0">git:(<span x-text="selectedSite.branch"></span>)</span>
                       </template>
                     </div>
-                    <template x-if="(selectedSite.services || []).length > 0">
+                    <template x-if="(selectedSite.services || []).length > 0 || (!selectedSite.custom_container && selectedSite.php_version)">
                       <div class="flex items-center flex-wrap gap-1.5 mt-2">
-                        <template x-for="svcName in selectedSite.services" :key="'svcb-'+svcName">
+                        <template x-for="svcName in (selectedSite.services || [])" :key="'svcb-'+svcName">
                           <button @click="jumpToService(svcName)"
                             :title="'Open ' + svcName + ' service'"
                             class="inline-flex items-center gap-1.5 text-[11px] font-medium px-2 py-0.5 rounded-full border transition-colors"
@@ -652,6 +652,19 @@
                             <span class="w-1.5 h-1.5 rounded-full"
                               :class="serviceByName(svcName) && serviceByName(svcName).status === 'active' ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
                             <span x-text="serviceByName(svcName) ? serviceLabel(serviceByName(svcName)) : svcName"></span>
+                          </button>
+                        </template>
+                        <template x-if="!selectedSite.custom_container && selectedSite.php_version">
+                          <button
+                            @click="setTab('system'); selectSystem('php-' + selectedSite.php_version)"
+                            :title="(xdebugEnabled[selectedSite.php_version] ? 'Xdebug ' + (xdebugMode[selectedSite.php_version] || 'debug') : 'Xdebug off') + ' — click to manage'"
+                            class="inline-flex items-center gap-1.5 text-[11px] font-medium px-2 py-0.5 rounded-full border transition-colors"
+                            :class="xdebugEnabled[selectedSite.php_version]
+                              ? 'bg-purple-50 dark:bg-purple-900/20 border-purple-200 dark:border-purple-500/40 text-purple-700 dark:text-purple-300 hover:bg-purple-100 dark:hover:bg-purple-900/40'
+                              : 'bg-gray-50 dark:bg-white/5 border-gray-200 dark:border-lerd-border text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-white/10'">
+                            <span class="w-1.5 h-1.5 rounded-full" :class="xdebugEnabled[selectedSite.php_version] ? 'bg-purple-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
+                            <span>Xdebug</span>
+                            <span class="opacity-70" x-text="xdebugEnabled[selectedSite.php_version] ? (xdebugMode[selectedSite.php_version] || 'debug') : 'off'"></span>
                           </button>
                         </template>
                       </div>
@@ -1492,9 +1505,22 @@
                 <div class="flex items-center justify-between">
                   <div>
                     <p class="text-sm font-medium text-gray-700 dark:text-gray-300">Xdebug</p>
-                    <p class="text-xs text-gray-400 mt-0.5">Restarts FPM on toggle</p>
+                    <p class="text-xs text-gray-400 mt-0.5">Restarts FPM on change</p>
                   </div>
                   <div class="flex items-center gap-2">
+                    <select x-show="xdebugEnabled[selectedPHPVersion]"
+                      @change="setXdebugMode(selectedPHPVersion, $event.target.value)"
+                      :value="xdebugMode[selectedPHPVersion] || 'debug'"
+                      class="text-xs bg-white dark:bg-lerd-muted border border-gray-200 dark:border-lerd-border rounded px-1.5 py-0.5 text-gray-700 dark:text-gray-300 focus:outline-none focus:ring-1 focus:ring-purple-400"
+                      title="Xdebug mode">
+                      <option value="debug">debug</option>
+                      <option value="coverage">coverage</option>
+                      <option value="debug,coverage">debug,coverage</option>
+                      <option value="develop">develop</option>
+                      <option value="profile">profile</option>
+                      <option value="trace">trace</option>
+                      <option value="gcstats">gcstats</option>
+                    </select>
                     <button type="button" @click.prevent="toggleXdebug(selectedPHPVersion)"
                       class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200 focus:outline-none"
                       :class="xdebugEnabled[selectedPHPVersion] ? 'bg-purple-500' : 'bg-gray-300 dark:bg-lerd-muted'"
@@ -2132,6 +2158,7 @@ function lerdApp() {
     autostartEnabled: false,
     autostartLoading: false,
     xdebugEnabled: {},
+    xdebugMode: {},
     xdebugLoading: {},
     selectedSystem: null,
     phpRemoveLoading: {},
@@ -4298,12 +4325,15 @@ function lerdApp() {
       if (!data || typeof data !== 'object') return;
       this.systemStatus = data;
       const next = { ...this.xdebugEnabled };
+      const nextMode = { ...this.xdebugMode };
       (data.php_fpms || []).forEach(fpm => {
         if (!this.xdebugLoading[fpm.version]) {
           next[fpm.version] = fpm.xdebug_enabled;
+          nextMode[fpm.version] = fpm.xdebug_mode || '';
         }
       });
       this.xdebugEnabled = next;
+      this.xdebugMode = nextMode;
     },
 
     async loadSettings() {
@@ -4317,14 +4347,38 @@ function lerdApp() {
     async toggleXdebug(version) {
       const current = !!this.xdebugEnabled[version];
       const action = current ? 'off' : 'on';
+      const nextMode = current ? '' : (this.xdebugMode[version] || 'debug');
       this.xdebugEnabled = { ...this.xdebugEnabled, [version]: !current };
+      this.xdebugMode = { ...this.xdebugMode, [version]: nextMode };
       this.xdebugLoading = { ...this.xdebugLoading, [version]: true };
       try {
-        const res = await fetch(`/api/xdebug/${version}/${action}`, { method: 'POST' });
+        const url = action === 'on'
+          ? `/api/xdebug/${version}/on?mode=${encodeURIComponent(nextMode)}`
+          : `/api/xdebug/${version}/off`;
+        const res = await fetch(url, { method: 'POST' });
         const data = await res.json();
-        if (!data.ok) this.xdebugEnabled = { ...this.xdebugEnabled, [version]: current };
+        if (!data.ok) {
+          this.xdebugEnabled = { ...this.xdebugEnabled, [version]: current };
+          this.xdebugMode = { ...this.xdebugMode, [version]: current ? (this.xdebugMode[version] || '') : '' };
+        }
       } catch (_) {
         this.xdebugEnabled = { ...this.xdebugEnabled, [version]: current };
+      } finally {
+        this.xdebugLoading = { ...this.xdebugLoading, [version]: false };
+      }
+    },
+
+    async setXdebugMode(version, mode) {
+      const previous = this.xdebugMode[version] || 'debug';
+      if (mode === previous) return;
+      this.xdebugMode = { ...this.xdebugMode, [version]: mode };
+      this.xdebugLoading = { ...this.xdebugLoading, [version]: true };
+      try {
+        const res = await fetch(`/api/xdebug/${version}/on?mode=${encodeURIComponent(mode)}`, { method: 'POST' });
+        const data = await res.json();
+        if (!data.ok) this.xdebugMode = { ...this.xdebugMode, [version]: previous };
+      } catch (_) {
+        this.xdebugMode = { ...this.xdebugMode, [version]: previous };
       } finally {
         this.xdebugLoading = { ...this.xdebugLoading, [version]: false };
       }

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -3008,6 +3008,18 @@ function lerdApp() {
       this.siteLogsTab = tab;
       const site = this.selectedSite;
       if (!site) return;
+
+      // Close every other worker log stream before opening the new one.
+      // Browsers cap HTTP/1.1 at 6 concurrent connections per origin;
+      // leaving previous tabs' EventSources open makes new ones queue in
+      // CONNECTING state and the UI sticks on "connecting...".
+      if (tab !== 'queue') this.closeSiteQueueLogs();
+      if (tab !== 'horizon') this.closeSiteHorizonLogs();
+      if (tab !== 'stripe') this.closeSiteStripeLogs();
+      if (tab !== 'schedule') this.closeSiteScheduleLogs();
+      if (tab !== 'reverb') this.closeSiteReverbLogs();
+      if (!tab.startsWith('worker:')) this.closeSiteWorkerLogs();
+
       if (tab === 'queue') this.openSiteQueueLogs(site);
       if (tab === 'horizon') this.openSiteHorizonLogs(site);
       if (tab === 'stripe') this.openSiteStripeLogs(site);

--- a/internal/ui/logs_darwin.go
+++ b/internal/ui/logs_darwin.go
@@ -72,6 +72,13 @@ func streamUnitLogs(w http.ResponseWriter, r *http.Request, unit string) {
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 
+	// Flush an SSE comment so the response headers go out immediately and
+	// the browser's EventSource fires onopen. Without this a silent unit
+	// (schedule between cron ticks, reverb before any WebSocket client
+	// connects) leaves the UI stuck on "connecting...".
+	fmt.Fprint(w, ": connected\n\n")
+	flusher.Flush()
+
 	if isContainerUnit(unit) {
 		// Wait up to 10s for the container to exist (e.g. right after start).
 		bin := podman.PodmanBin()

--- a/internal/ui/logs_linux.go
+++ b/internal/ui/logs_linux.go
@@ -38,6 +38,13 @@ func streamUnitLogs(w http.ResponseWriter, r *http.Request, unit string) {
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 
+	// Flush an SSE comment so the response headers go out immediately and
+	// the browser's EventSource fires onopen. Without this a silent unit
+	// (schedule between cron ticks, reverb before any WebSocket client
+	// connects) leaves the UI stuck on "connecting...".
+	fmt.Fprint(w, ": connected\n\n")
+	flusher.Flush()
+
 	cursor := r.Header.Get("Last-Event-ID")
 	args := []string{"--user", "-u", unit, "-f", "--no-pager", "--output=json"}
 	if cursor != "" {

--- a/internal/ui/logs_test.go
+++ b/internal/ui/logs_test.go
@@ -1,8 +1,12 @@
 package ui
 
 import (
+	"context"
+	"net/http/httptest"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestServiceRecentLogs_unknownUnit(t *testing.T) {
@@ -30,5 +34,36 @@ func TestIsContainerUnit_dns(t *testing.T) {
 		if !isContainerUnit("lerd-dns") {
 			t.Error("expected isContainerUnit to return true for lerd-dns on linux")
 		}
+	}
+}
+
+// streamUnitLogs must send the response headers and an initial SSE comment
+// before running the log-following subprocess; otherwise silent units leave
+// the browser's EventSource stuck in CONNECTING and the UI sticks on
+// "connecting...".
+func TestStreamUnitLogs_flushesHeadersBeforeStreaming(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req := httptest.NewRequest("GET", "/api/schedule/nonexistent/logs", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		streamUnitLogs(rec, req, "lerd-nonexistent-unit-xyz")
+		close(done)
+	}()
+	<-done
+
+	if ct := rec.Result().Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+	body := rec.Body.String()
+	if !strings.HasPrefix(body, ": connected") {
+		n := len(body)
+		if n > 40 {
+			n = 40
+		}
+		t.Errorf("body should start with initial SSE comment, got: %q", body[:n])
 	}
 }

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/geodro/lerd/internal/siteops"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	lerdUpdate "github.com/geodro/lerd/internal/update"
+	"github.com/geodro/lerd/internal/xdebugops"
 )
 
 //go:embed index.html
@@ -525,6 +526,7 @@ type PHPStatus struct {
 	Version       string `json:"version"`
 	Running       bool   `json:"running"`
 	XdebugEnabled bool   `json:"xdebug_enabled"`
+	XdebugMode    string `json:"xdebug_mode,omitempty"`
 }
 
 func handleStatus(w http.ResponseWriter, _ *http.Request) {
@@ -548,8 +550,11 @@ func buildStatus() StatusResponse {
 	for _, v := range versions {
 		short := strings.ReplaceAll(v, ".", "")
 		running := podman.Cache.Running("lerd-php" + short + "-fpm")
-		xdebugEnabled := cfg != nil && cfg.IsXdebugEnabled(v)
-		phpStatuses = append(phpStatuses, PHPStatus{Version: v, Running: running, XdebugEnabled: xdebugEnabled})
+		xdebugMode := ""
+		if cfg != nil {
+			xdebugMode = cfg.GetXdebugMode(v)
+		}
+		phpStatuses = append(phpStatuses, PHPStatus{Version: v, Running: running, XdebugEnabled: xdebugMode != "", XdebugMode: xdebugMode})
 	}
 
 	phpDefault := ""
@@ -2384,7 +2389,7 @@ func appleScriptStr(s string) string {
 }
 
 func handleXdebugAction(w http.ResponseWriter, r *http.Request) {
-	// path: /api/xdebug/{version}/on or /api/xdebug/{version}/off
+	// path: /api/xdebug/{version}/on[?mode=MODE] or /api/xdebug/{version}/off
 	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/xdebug/"), "/")
 	if len(parts) != 2 || r.Method != http.MethodPost {
 		http.NotFound(w, r)
@@ -2395,42 +2400,24 @@ func handleXdebugAction(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	enable := action == "on"
 
-	cfg, err := config.LoadGlobal()
+	applyMode := ""
+	if action == "on" {
+		applyMode = r.URL.Query().Get("mode")
+		if applyMode == "" {
+			applyMode = "debug"
+		}
+	}
+
+	res, err := xdebugops.Apply(version, applyMode)
 	if err != nil {
 		writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
-
-	if cfg.IsXdebugEnabled(version) == enable {
-		writeJSON(w, map[string]any{"ok": true, "xdebug_enabled": enable})
-		return
+	if res.RestartErr != nil {
+		fmt.Printf("[WARN] restart %s: %v\n", xdebugops.FPMUnit(version), res.RestartErr)
 	}
-
-	cfg.SetXdebug(version, enable)
-	if err := config.SaveGlobal(cfg); err != nil {
-		writeJSON(w, map[string]any{"ok": false, "error": "saving config: " + err.Error()})
-		return
-	}
-
-	if err := podman.WriteXdebugIni(version, enable); err != nil {
-		writeJSON(w, map[string]any{"ok": false, "error": "writing xdebug ini: " + err.Error()})
-		return
-	}
-
-	// Update quadlet (adds volume mount if not already present).
-	if err := podman.WriteFPMQuadlet(version); err != nil {
-		fmt.Printf("[WARN] updating quadlet for PHP %s: %v\n", version, err)
-	}
-
-	short := strings.ReplaceAll(version, ".", "")
-	unit := "lerd-php" + short + "-fpm"
-	if err := podman.RestartUnit(unit); err != nil {
-		fmt.Printf("[WARN] restart %s: %v\n", unit, err)
-	}
-
-	writeJSON(w, map[string]any{"ok": true, "xdebug_enabled": enable})
+	writeJSON(w, map[string]any{"ok": true, "xdebug_enabled": res.Enabled, "xdebug_mode": res.Mode})
 }
 
 func handleScheduleLogs(w http.ResponseWriter, r *http.Request) {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.15.1"
+	Version = "1.16.0"
 	Commit  = "none"
 	Date    = "unknown"
 )

--- a/internal/xdebugops/xdebugops.go
+++ b/internal/xdebugops/xdebugops.go
@@ -1,0 +1,89 @@
+// Package xdebugops contains the shared business logic for toggling Xdebug
+// on a PHP version: mode validation, config persistence, ini write, FPM
+// quadlet update, and unit restart. The CLI, UI, and MCP all call into here
+// so the three surfaces stay in lockstep on state transitions and ordering.
+package xdebugops
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// Result describes the outcome of Apply so callers can render their own
+// user-facing message without inspecting the config again.
+type Result struct {
+	Version   string
+	Mode      string // canonical mode after Apply; "" means xdebug disabled
+	Enabled   bool   // convenience: Mode != ""
+	NoChange  bool   // true when the requested state already matched; no restart was attempted
+	Restarted bool   // true when the FPM unit restart succeeded
+	// RestartErr is set when the FPM unit restart failed. Non-fatal: config and
+	// ini are already persisted, the caller just needs to surface a hint so
+	// the user can restart the unit manually.
+	RestartErr error
+}
+
+// Apply toggles Xdebug for version. An empty mode disables xdebug; a non-empty
+// mode is validated via podman.NormaliseXdebugMode and enables xdebug with
+// that canonical value. Apply is idempotent: passing the current mode is a
+// no-op that returns NoChange=true without touching the FPM container.
+func Apply(version, rawMode string) (Result, error) {
+	targetMode := ""
+	if rawMode != "" {
+		m, err := podman.NormaliseXdebugMode(rawMode)
+		if err != nil {
+			return Result{Version: version}, err
+		}
+		targetMode = m
+	}
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return Result{Version: version}, fmt.Errorf("loading config: %w", err)
+	}
+
+	if cfg.GetXdebugMode(version) == targetMode {
+		return Result{
+			Version:  version,
+			Mode:     targetMode,
+			Enabled:  targetMode != "",
+			NoChange: true,
+		}, nil
+	}
+
+	cfg.SetXdebugMode(version, targetMode)
+	if err := config.SaveGlobal(cfg); err != nil {
+		return Result{Version: version}, fmt.Errorf("saving config: %w", err)
+	}
+
+	if err := podman.WriteXdebugIni(version, targetMode); err != nil {
+		return Result{Version: version}, fmt.Errorf("writing xdebug ini: %w", err)
+	}
+
+	if err := podman.WriteFPMQuadlet(version); err != nil {
+		return Result{Version: version}, fmt.Errorf("writing FPM quadlet: %w", err)
+	}
+
+	res := Result{
+		Version: version,
+		Mode:    targetMode,
+		Enabled: targetMode != "",
+	}
+	unit := "lerd-php" + strings.ReplaceAll(version, ".", "") + "-fpm"
+	if err := podman.RestartUnit(unit); err != nil {
+		res.RestartErr = err
+		return res, nil
+	}
+	res.Restarted = true
+	return res, nil
+}
+
+// FPMUnit returns the systemd unit name for a PHP version's FPM container.
+// Exposed so callers can print consistent "Run: systemctl --user restart ..."
+// hints when Apply's RestartErr is non-nil.
+func FPMUnit(version string) string {
+	return "lerd-php" + strings.ReplaceAll(version, ".", "") + "-fpm"
+}

--- a/internal/xdebugops/xdebugops_test.go
+++ b/internal/xdebugops/xdebugops_test.go
@@ -1,0 +1,147 @@
+package xdebugops
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// setupConfigHome points config.* path helpers at a temp tree and neutralises
+// PATH so podman.RestartUnit inside Apply fails fast instead of actually
+// restarting a unit on the dev machine running the tests.
+func setupConfigHome(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("PATH", filepath.Join(tmp, "no-bin"))
+
+	// WriteFPMQuadlet shells out through a hook; stub it so the test doesn't
+	// need the full container environment. DaemonReload is stubbed for the
+	// same reason.
+	prevWrite := podman.WriteContainerUnitFn
+	prevReload := podman.DaemonReloadFn
+	podman.WriteContainerUnitFn = func(name, content string) error { return nil }
+	podman.DaemonReloadFn = func() error { return nil }
+	t.Cleanup(func() {
+		podman.WriteContainerUnitFn = prevWrite
+		podman.DaemonReloadFn = prevReload
+	})
+}
+
+func TestApply_EnablesWithDefaultMode(t *testing.T) {
+	setupConfigHome(t)
+
+	res, err := Apply("8.4", "debug")
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !res.Enabled || res.Mode != "debug" {
+		t.Errorf("unexpected result: %+v", res)
+	}
+
+	cfg, _ := config.LoadGlobal()
+	if cfg.GetXdebugMode("8.4") != "debug" {
+		t.Errorf("config not persisted: mode=%q", cfg.GetXdebugMode("8.4"))
+	}
+
+	body, _ := os.ReadFile(config.PHPConfFile("8.4"))
+	if !strings.Contains(string(body), "xdebug.mode=debug") {
+		t.Errorf("ini missing xdebug.mode=debug:\n%s", body)
+	}
+}
+
+func TestApply_EnablesWithCoverageMode(t *testing.T) {
+	setupConfigHome(t)
+
+	res, err := Apply("8.4", "coverage")
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if res.Mode != "coverage" {
+		t.Errorf("Mode = %q, want %q", res.Mode, "coverage")
+	}
+	body, _ := os.ReadFile(config.PHPConfFile("8.4"))
+	if !strings.Contains(string(body), "xdebug.mode=coverage") {
+		t.Errorf("ini missing xdebug.mode=coverage:\n%s", body)
+	}
+}
+
+func TestApply_DisableWritesOff(t *testing.T) {
+	setupConfigHome(t)
+
+	if _, err := Apply("8.4", "debug"); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	res, err := Apply("8.4", "")
+	if err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	if res.Enabled || res.Mode != "" {
+		t.Errorf("expected disabled, got %+v", res)
+	}
+	body, _ := os.ReadFile(config.PHPConfFile("8.4"))
+	if !strings.Contains(string(body), "xdebug.mode=off") {
+		t.Errorf("ini missing xdebug.mode=off:\n%s", body)
+	}
+}
+
+func TestApply_NoChangeOnIdempotentCall(t *testing.T) {
+	setupConfigHome(t)
+
+	if _, err := Apply("8.4", "coverage"); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	res, err := Apply("8.4", "coverage")
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+	if !res.NoChange {
+		t.Errorf("second Apply should be a no-op, got %+v", res)
+	}
+	if res.Restarted {
+		t.Errorf("NoChange result must not claim a restart")
+	}
+}
+
+func TestApply_RejectsInvalidMode(t *testing.T) {
+	setupConfigHome(t)
+	if _, err := Apply("8.4", "nonsense"); err == nil {
+		t.Error("expected invalid-mode error, got nil")
+	}
+}
+
+func TestApply_RestartErrIsNonFatal(t *testing.T) {
+	// PATH is empty so podman.RestartUnit will fail. Apply must still
+	// persist config and ini, returning RestartErr instead of aborting;
+	// otherwise a harmless restart hiccup loses the user's toggle.
+	setupConfigHome(t)
+
+	res, err := Apply("8.4", "debug")
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if res.RestartErr == nil {
+		t.Fatal("expected RestartErr when podman is unavailable")
+	}
+	if !res.Enabled || res.Mode != "debug" {
+		t.Errorf("config/ini should still be applied: %+v", res)
+	}
+	cfg, _ := config.LoadGlobal()
+	if cfg.GetXdebugMode("8.4") != "debug" {
+		t.Error("config not saved despite RestartErr")
+	}
+}
+
+func TestFPMUnit(t *testing.T) {
+	if got := FPMUnit("8.4"); got != "lerd-php84-fpm" {
+		t.Errorf("FPMUnit(8.4) = %q, want lerd-php84-fpm", got)
+	}
+	if got := FPMUnit("8.10"); got != "lerd-php810-fpm" {
+		t.Errorf("FPMUnit(8.10) = %q, want lerd-php810-fpm", got)
+	}
+}


### PR DESCRIPTION
## What's in 1.16.0

### Added

- **`lerd tui`** — btop-style terminal dashboard with full site/service/worker management, log tailing, PHP/Node version pickers, settings overlay, and keybindings reference
- **Selectable Xdebug mode** — `lerd xdebug on --mode coverage|profile|trace|...`; dashboard mode dropdown; MCP `xdebug_on mode` arg
- **Adaptive Podman Machine memory on macOS** — VM memory scales with host RAM (3 GB / 4 GB / 6 GB tiers) instead of a fixed 4 GB floor
- **`lerd quit` stops the Podman Machine VM on macOS** — quit and start are now fully symmetric

### Fixed

- Worker log tabs stuck on "connecting…" in the dashboard (SSE header flush + sibling stream teardown on tab switch)
- Git worktrees running stale code from the main checkout (vendor/ and node_modules/ are now real copies, not symlinks)