### PR TITLE
fix: check container state directly in autoStopUnusedServices

### DIFF
--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -805,8 +805,12 @@ func autoStopUnusedServices() {
 	for _, name := range candidates {
 		if config.CountSitesUsingService(name) == 0 && !config.ServiceIsManuallyStarted(name) && !config.ServiceIsPinned(name) {
 			unit := "lerd-" + name
-			status, _ := podman.UnitStatus(unit)
-			if status == "active" || status == "activating" {
+			running, _ := podman.ContainerRunning(unit)
+			if !running {
+				status, _ := podman.UnitStatus(unit)
+				running = status == "active" || status == "activating"
+			}
+			if running {
 				StopServiceAndDependents(name)
 			}
 		}


### PR DESCRIPTION
On macOS, services started via Podman's `--restart=always` policy have a launchd plist in `state = not running / last exit code = (never exited)` state — the container is running but launchd never launched it in the current session. `UnitStatus` falls through to `ContainerRunning`, but if that podman inspect call fails transiently (VM SSH socket busy with worker processes), it returns `"failed"` and `autoStopUnusedServices` silently skips the service.

Fix: check `ContainerRunning` first as the authoritative source on whether to stop. Only fall back to `UnitStatus` when the container isn't found (covers Linux/systemd and activating-but-not-yet-containerised units).

Symptom: postgres and meilisearch staying up after all sites are paused.