### PR TITLE
feat(tui): responsive layout, scrollbars, color refresh, log scroll

### DIFF
--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -251,12 +251,15 @@ func (m *Model) renderDetailInline(w, h int, focused bool) string {
 	style := paneStyle(focused)
 	innerW, innerH := innerSize(style, w, h)
 
+	contentW := innerW - 1 // reserve 1 cell for scrollbar
+
 	var content []string
+	cursorLine := 0
 	switch m.detailMode {
 	case detailSettings:
-		content = settingsContentLines(m, focused, innerW)
+		content = settingsContentLines(m, focused, contentW)
 	case detailHelp:
-		all := helpContentLines(m, innerW)
+		all := helpContentLines(m, contentW)
 		if m.helpScroll > len(all)-1 {
 			m.helpScroll = max(0, len(all)-1)
 		}
@@ -265,22 +268,27 @@ func (m *Model) renderDetailInline(w, h int, focused bool) string {
 		site := m.currentSite()
 		if site == nil {
 			content = []string{
-				padToWidth(sectionStyle.Render("Site detail"), innerW),
-				padToWidth(dimStyle.Render("no site selected"), innerW),
+				padToWidth(sectionStyle.Render("Site detail"), contentW),
+				padToWidth(dimStyle.Render("no site selected"), contentW),
 			}
 		} else {
-			content = detailContentLines(m, site, focused, innerW)
+			content, cursorLine = detailContentLines(m, site, focused, contentW)
 		}
 	}
 
-	for len(content) < innerH {
-		content = append(content, spaces(innerW))
-	}
-	if len(content) > innerH {
-		content = content[:innerH]
+	visible := viewport(content, cursorLine, innerH, &m.detailScroll)
+	bar := renderScrollbar(innerH, len(content), m.detailScroll, len(visible))
+
+	lines := make([]string, 0, innerH)
+	for i := 0; i < innerH; i++ {
+		row := spaces(contentW)
+		if i < len(visible) {
+			row = visible[i]
+		}
+		lines = append(lines, padToWidth(row, contentW)+bar[i])
 	}
 
-	return style.Render(strings.Join(content, "\n"))
+	return style.Render(strings.Join(lines, "\n"))
 }
 
 // settingsContentLines builds the settings rows for the right-hand pane when
@@ -307,7 +315,9 @@ func settingsContentLines(m *Model, focused bool, innerW int) []string {
 	return out
 }
 
-func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, innerW int) []string {
+// detailContentLines returns the rendered lines for the site detail pane and
+// the line index of the currently selected row (for viewport scrolling).
+func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, innerW int) ([]string, int) {
 	rows := detailRows(site)
 	nav := navigableRows(rows)
 	navPos := func(i int) int {
@@ -320,7 +330,14 @@ func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, inn
 	}
 
 	var out []string
-	add := func(s string) { out = append(out, padToWidth(clipLine(s, innerW), innerW)) }
+	cursorLine := 0
+	add := func(s string, selected bool) {
+		if selected && len(out) > 0 {
+			cursorLine = len(out)
+		}
+		out = append(out, padToWidth(clipLine(s, innerW), innerW))
+	}
+	addPlain := func(s string) { add(s, false) }
 
 	// Lead with the primary domain (what users see in the browser). The
 	// internal registry name is still surfaced as the "name:" line below,
@@ -329,12 +346,12 @@ func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, inn
 	if header == "" {
 		header = site.Name
 	}
-	add(sectionStyle.Render(header))
+	addPlain(sectionStyle.Render(header))
 	if site.Name != header {
-		add(dimStyle.Render("  name: ") + site.Name)
+		addPlain(dimStyle.Render("  name: ") + site.Name)
 	}
 	if site.Path != "" {
-		add(dimStyle.Render("  path: ") + site.Path)
+		addPlain(dimStyle.Render("  path: ") + site.Path)
 	}
 
 	scheme := "http"
@@ -342,10 +359,10 @@ func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, inn
 		scheme = "https"
 	}
 
-	add("")
-	add(sectionStyle.Render("Domains"))
+	addPlain("")
+	addPlain(sectionStyle.Render("Domains"))
 	if len(site.Domains) == 0 {
-		add(dimStyle.Render("  (no domain)"))
+		addPlain(dimStyle.Render("  (no domain)"))
 	}
 	for i, row := range rows {
 		if row.kind != kindDomain {
@@ -354,7 +371,7 @@ func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, inn
 		selected := focused && navPos(i) == m.detailCursor
 		domain := row.domain
 		label := scheme + "://" + domain
-		add(renderDetailRow(selected, accentStyle.Render("⊙"), label, dimStyle.Render(domainRole(site, domain))))
+		add(renderDetailRow(selected, accentStyle.Render("⊙"), label, dimStyle.Render(domainRole(site, domain))), selected)
 	}
 	for i, row := range rows {
 		if row.kind != kindDomainAdd {
@@ -370,12 +387,12 @@ func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, inn
 			if m.domainInputEditing != "" {
 				label = "rename " + m.domainInputEditing + " → "
 			}
-			add(prefix + " " + accentStyle.Render("+") + " " + selectedStyle.Render(label) + m.domainInput + "▌")
+			add(prefix+" "+accentStyle.Render("+")+" "+selectedStyle.Render(label)+m.domainInput+"▌", selected)
 		} else {
-			add(prefix + " " + accentStyle.Render("+") + " " + dimStyle.Render("add domain (space or a)"))
+			add(prefix+" "+accentStyle.Render("+")+" "+dimStyle.Render("add domain (space or a)"), selected)
 		}
 	}
-	add("")
+	addPlain("")
 
 	php := site.PHPVersion
 	if php == "" && site.ContainerPort > 0 {
@@ -391,15 +408,15 @@ func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, inn
 	if site.Branch != "" {
 		info += dimStyle.Render("  git: ") + site.Branch
 	}
-	add(info)
-	add("")
+	addPlain(info)
+	addPlain("")
 	if len(site.Services) > 0 {
-		add(sectionStyle.Render("Services used"))
+		addPlain(sectionStyle.Render("Services used"))
 		states := m.serviceStatesByName()
 		for _, svc := range site.Services {
-			add(renderSiteServiceRow(svc, states[svc]))
+			addPlain(renderSiteServiceRow(svc, states[svc]))
 		}
-		add("")
+		addPlain("")
 	}
 
 	hasWorkers := false
@@ -410,7 +427,7 @@ func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, inn
 		}
 	}
 	if hasWorkers {
-		add(sectionStyle.Render("Workers"))
+		addPlain(sectionStyle.Render("Workers"))
 		for i, row := range rows {
 			if row.kind != kindWorker {
 				continue
@@ -419,13 +436,13 @@ func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, inn
 			add(renderDetailRow(selected,
 				workerGlyphFor(site, row.workerName),
 				workerLabel(site, row.workerName),
-				workerStateText(site, row.workerName)))
+				workerStateText(site, row.workerName)), selected)
 		}
-		add("")
+		addPlain("")
 	}
 
 	if len(site.Worktrees) > 0 {
-		add(sectionStyle.Render("Worktrees"))
+		addPlain(sectionStyle.Render("Worktrees"))
 		for _, wt := range site.Worktrees {
 			line := "  " + accentStyle.Render(wt.Branch)
 			if wt.Domain != "" {
@@ -434,40 +451,40 @@ func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, inn
 			if wt.Path != "" {
 				line += "  " + dimStyle.Render(wt.Path)
 			}
-			add(line)
+			addPlain(line)
 		}
-		add("")
+		addPlain("")
 	}
 
-	add(sectionStyle.Render("Toggles"))
+	addPlain(sectionStyle.Render("Toggles"))
 	for i, row := range rows {
 		selected := focused && navPos(i) == m.detailCursor
 		switch row.kind {
 		case kindPHP:
 			add(renderDetailRow(selected,
-				accentStyle.Render("λ"), "PHP", dimStyle.Render(site.PHPVersion)))
+				accentStyle.Render("λ"), "PHP", dimStyle.Render(site.PHPVersion)), selected)
 			if selected && m.pickerKind == kindPHP {
 				for _, pl := range m.renderPickerRows(site.PHPVersion) {
-					add(pl)
+					addPlain(pl)
 				}
 			}
 		case kindNode:
 			add(renderDetailRow(selected,
-				accentStyle.Render("⬢"), "Node", dimStyle.Render(site.NodeVersion)))
+				accentStyle.Render("⬢"), "Node", dimStyle.Render(site.NodeVersion)), selected)
 			if selected && m.pickerKind == kindNode {
 				for _, pl := range m.renderPickerRows(site.NodeVersion) {
-					add(pl)
+					addPlain(pl)
 				}
 			}
 		case kindHTTPS:
 			add(renderDetailRow(selected,
-				onOffGlyph(site.Secured), "HTTPS", onOffText(site.Secured)))
+				onOffGlyph(site.Secured), "HTTPS", onOffText(site.Secured)), selected)
 		case kindLANShare:
 			add(renderDetailRow(selected,
-				onOffGlyph(site.LANPort > 0), "LAN share", lanShareText(site.LANPort)))
+				onOffGlyph(site.LANPort > 0), "LAN share", lanShareText(site.LANPort)), selected)
 		}
 	}
-	return out
+	return out, cursorLine
 }
 
 // renderPickerRows draws the inline version picker below a PHP or Node row.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -68,6 +68,7 @@ type Model struct {
 	filterActive bool
 
 	detailCursor int // index into detail rows (workers + toggles)
+	detailScroll int // vertical scroll offset for the site detail view
 	settingsRow  int // index into settings rows
 	helpScroll   int // vertical scroll offset for the help view
 
@@ -86,6 +87,7 @@ type Model struct {
 	domainInputEditing string
 
 	showLogs     bool
+	logScroll    int // lines scrolled back from tail (0 = live tail)
 	hideServices bool
 	logTail      *logTail
 	logCursor    int // index into currentLogTargets() for the focused item
@@ -280,9 +282,18 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.actionShell()
 
 	case "v":
-		m.hideServices = !m.hideServices
-		if m.hideServices && m.focus == paneServices {
-			m.focus = paneSites
+		if m.width < narrowWidth {
+			// Narrow: v switches the top list between sites and services.
+			if m.focus == paneServices {
+				m.focus = paneSites
+			} else {
+				m.focus = paneServices
+			}
+		} else {
+			m.hideServices = !m.hideServices
+			if m.hideServices && m.focus == paneServices {
+				m.focus = paneSites
+			}
 		}
 		return m, nil
 
@@ -308,6 +319,21 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "]":
 		return m, m.cycleLogTarget(1)
+
+	case "{":
+		if m.showLogs {
+			m.logScroll += 10
+		}
+		return m, nil
+
+	case "}":
+		if m.showLogs {
+			m.logScroll -= 10
+			if m.logScroll < 0 {
+				m.logScroll = 0
+			}
+		}
+		return m, nil
 
 	case "s":
 		return m, m.actionStart()
@@ -516,12 +542,22 @@ func (m *Model) syncLogs() tea.Cmd {
 }
 
 // nextFocus returns the focus after moving `dir` steps (±1) through the
-// list of panes that are currently visible and usable. Skips services when
-// hidden and skips detail when no site is selected.
+// list of panes that are currently visible and usable. In narrow mode tab
+// cycles only between the active list pane and detail; use v to reach services.
 func (m *Model) nextFocus(dir int) focusPane {
-	panes := []focusPane{paneSites}
-	if !m.hideServices {
-		panes = append(panes, paneServices)
+	var panes []focusPane
+	if m.width < narrowWidth {
+		// In narrow mode, tab only moves between the current list pane and detail.
+		listPane := paneSites
+		if m.focus == paneServices {
+			listPane = paneServices
+		}
+		panes = []focusPane{listPane}
+	} else {
+		panes = []focusPane{paneSites}
+		if !m.hideServices {
+			panes = append(panes, paneServices)
+		}
 	}
 	if m.currentSite() != nil {
 		panes = append(panes, paneDetail)
@@ -610,6 +646,7 @@ func (m *Model) toggleLogs() tea.Cmd {
 	if m.showLogs {
 		m.logTail.Stop()
 		m.showLogs = false
+		m.logScroll = 0
 		return nil
 	}
 	targets := m.currentLogTargets()

--- a/internal/tui/panes.go
+++ b/internal/tui/panes.go
@@ -10,6 +10,11 @@ import (
 	"github.com/geodro/lerd/internal/siteinfo"
 )
 
+// narrowWidth is the terminal width below which the TUI switches from the
+// two-column layout (sites+services | detail) to a single-column layout
+// where only the focused pane fills the full width.
+const narrowWidth = 100
+
 // View implements tea.Model.
 func (m *Model) View() string {
 	if m.width < 60 || m.height < 12 {
@@ -49,43 +54,70 @@ func (m *Model) View() string {
 		topH = 6
 	}
 
-	// Left column stacks sites on top of services; right column is the
-	// site detail (full topH). When services is hidden, sites takes the
-	// whole left column.
-	leftW := m.width * 2 / 5
-	if leftW < 36 {
-		leftW = 36
-	}
-	if leftW > m.width-30 {
-		leftW = m.width - 30
-	}
-	rightW := m.width - leftW
+	var top string
+	if m.width < narrowWidth {
+		// Narrow: stack list on top, detail below — both always visible.
+		// Give the list 40% of the body height, detail gets the rest.
+		listH := topH * 2 / 5
+		if listH < 6 {
+			listH = 6
+		}
+		if listH > topH-6 {
+			listH = topH - 6
+		}
+		detailH := topH - listH
 
-	var left string
-	if m.hideServices {
-		left = m.renderSites(leftW, topH)
+		switch {
+		case m.focus == paneServices:
+			// Services focused: take the full height, hide detail.
+			top = m.renderServices(m.width, topH)
+		case m.detailMode == detailHelp || m.detailMode == detailSettings:
+			// Help / settings: take full height so content isn't cramped.
+			top = m.renderDetailInline(m.width, topH, true)
+		default:
+			list := m.renderSites(m.width, listH)
+			detail := m.renderDetailInline(m.width, detailH, m.focus == paneDetail)
+			top = lipgloss.JoinVertical(lipgloss.Left, list, detail)
+		}
 	} else {
-		svcNeeded := len(m.snap.Services) + 3
-		if svcNeeded < 6 {
-			svcNeeded = 6
+		// Wide: left column stacks sites on top of services; right column is
+		// the site detail (full topH). When services is hidden, sites takes
+		// the whole left column.
+		leftW := m.width * 2 / 5
+		if leftW < 36 {
+			leftW = 36
 		}
-		svcH := svcNeeded
-		if lim := topH / 2; svcH > lim {
-			svcH = lim
+		if leftW > m.width-30 {
+			leftW = m.width - 30
 		}
-		if svcH > topH-6 {
-			svcH = topH - 6
+		rightW := m.width - leftW
+
+		var left string
+		if m.hideServices {
+			left = m.renderSites(leftW, topH)
+		} else {
+			svcNeeded := len(m.snap.Services) + 3
+			if svcNeeded < 6 {
+				svcNeeded = 6
+			}
+			svcH := svcNeeded
+			if lim := topH / 2; svcH > lim {
+				svcH = lim
+			}
+			if svcH > topH-6 {
+				svcH = topH - 6
+			}
+			if svcH < 4 {
+				svcH = 4
+			}
+			siteH := topH - svcH
+			sites := m.renderSites(leftW, siteH)
+			services := m.renderServices(leftW, svcH)
+			left = lipgloss.JoinVertical(lipgloss.Left, sites, services)
 		}
-		if svcH < 4 {
-			svcH = 4
-		}
-		siteH := topH - svcH
-		sites := m.renderSites(leftW, siteH)
-		services := m.renderServices(leftW, svcH)
-		left = lipgloss.JoinVertical(lipgloss.Left, sites, services)
+		detail := m.renderDetailInline(rightW, topH, m.focus == paneDetail)
+		top = lipgloss.JoinHorizontal(lipgloss.Top, left, detail)
 	}
-	detail := m.renderDetailInline(rightW, topH, m.focus == paneDetail)
-	top := lipgloss.JoinHorizontal(lipgloss.Top, left, detail)
 
 	sections := []string{header, top}
 	if m.showLogs {
@@ -134,6 +166,17 @@ func (m *Model) renderHeader() string {
 func (m *Model) renderFooter() string {
 	if m.filterActive {
 		return helpStyle.Render("  filter: type to match · enter apply · esc clear")
+	}
+	if m.width < narrowWidth {
+		keys := []string{
+			"tab panes",
+			"↑↓ nav",
+			"space toggle",
+			"l logs",
+			"v services",
+			"q quit",
+		}
+		return helpStyle.Render("  " + strings.Join(keys, "   "))
 	}
 	keys := []string{
 		"tab panes",
@@ -188,19 +231,32 @@ func (m *Model) renderSites(w, h int) string {
 		availRows = 1
 	}
 
+	contentW := innerW - 1
+	if contentW < 10 {
+		contentW = innerW
+	}
+
+	var rowData []string
 	switch {
 	case total == 0:
-		lines = append(lines, padToWidth(dimStyle.Render("no linked sites"), innerW))
+		rowData = []string{padToWidth(dimStyle.Render("no linked sites"), contentW)}
 	case len(sites) == 0:
-		lines = append(lines, padToWidth(dimStyle.Render("no sites match filter"), innerW))
+		rowData = []string{padToWidth(dimStyle.Render("no sites match filter"), contentW)}
 	default:
-		rows := make([]string, 0, len(sites))
 		for i, s := range sites {
-			row := renderSiteRow(i == m.siteCursor && m.focus == paneSites, s, innerW)
-			rows = append(rows, padToWidth(clipLine(row, innerW), innerW))
+			row := renderSiteRow(i == m.siteCursor && m.focus == paneSites, s, contentW)
+			rowData = append(rowData, padToWidth(clipLine(row, contentW), contentW))
 		}
-		visible := viewport(rows, m.siteCursor, availRows, &m.siteScroll)
-		lines = append(lines, visible...)
+	}
+
+	visible := viewport(rowData, m.siteCursor, availRows, &m.siteScroll)
+	bar := renderScrollbar(availRows, len(rowData), m.siteScroll, len(visible))
+	for i := 0; i < availRows; i++ {
+		row := ""
+		if i < len(visible) {
+			row = visible[i]
+		}
+		lines = append(lines, padToWidth(row, contentW)+bar[i])
 	}
 	for len(lines) < innerH {
 		lines = append(lines, spaces(innerW))
@@ -316,19 +372,32 @@ func (m *Model) renderServices(w, h int) string {
 		availRows = 1
 	}
 
+	contentW := innerW - 1
+	if contentW < 10 {
+		contentW = innerW
+	}
+
+	var rowData []string
 	switch {
 	case total == 0:
-		lines = append(lines, padToWidth(dimStyle.Render("no services configured"), innerW))
+		rowData = []string{padToWidth(dimStyle.Render("no services configured"), contentW)}
 	case len(services) == 0:
-		lines = append(lines, padToWidth(dimStyle.Render("no services match filter"), innerW))
+		rowData = []string{padToWidth(dimStyle.Render("no services match filter"), contentW)}
 	default:
-		rows := make([]string, 0, len(services))
 		for i, s := range services {
-			row := renderServiceRow(i == m.svcCursor && m.focus == paneServices, s, innerW)
-			rows = append(rows, padToWidth(clipLine(row, innerW), innerW))
+			row := renderServiceRow(i == m.svcCursor && m.focus == paneServices, s, contentW)
+			rowData = append(rowData, padToWidth(clipLine(row, contentW), contentW))
 		}
-		visible := viewport(rows, m.svcCursor, availRows, &m.svcScroll)
-		lines = append(lines, visible...)
+	}
+
+	visible := viewport(rowData, m.svcCursor, availRows, &m.svcScroll)
+	bar := renderScrollbar(availRows, len(rowData), m.svcScroll, len(visible))
+	for i := 0; i < availRows; i++ {
+		row := ""
+		if i < len(visible) {
+			row = visible[i]
+		}
+		lines = append(lines, padToWidth(row, contentW)+bar[i])
 	}
 	for len(lines) < innerH {
 		lines = append(lines, spaces(innerW))
@@ -407,6 +476,9 @@ func (m *Model) renderLogs(w, h int) string {
 	if n := len(m.currentLogTargets()); n > 1 {
 		title += fmt.Sprintf("   [%d/%d · [ ] to switch]", m.logCursor+1, n)
 	}
+	if m.logScroll > 0 {
+		title += dimStyle.Render(fmt.Sprintf("   ↑%d  } to tail", m.logScroll))
+	}
 
 	availRows := innerH - 1
 	if availRows < 1 {
@@ -425,13 +497,26 @@ func (m *Model) renderLogs(w, h int) string {
 		contentW = innerW
 	}
 
+	// Clamp logScroll so it can't scroll past the beginning.
+	if m.logScroll > total-availRows {
+		m.logScroll = max(0, total-availRows)
+	}
+
 	var visible []string
 	start := 0
 	if total > 0 {
-		if total > availRows {
-			start = total - availRows
+		end := total - m.logScroll
+		if end < availRows {
+			end = availRows
 		}
-		visible = all[start:]
+		if end > total {
+			end = total
+		}
+		start = end - availRows
+		if start < 0 {
+			start = 0
+		}
+		visible = all[start:end]
 	}
 
 	body := make([]string, 0, availRows)

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -3,15 +3,15 @@ package tui
 import "github.com/charmbracelet/lipgloss"
 
 var (
-	colTitle    = lipgloss.Color("205")
-	colDim      = lipgloss.Color("243")
-	colDivider  = lipgloss.Color("237")
-	colRunning  = lipgloss.Color("42")
-	colStopped  = lipgloss.Color("243")
-	colFailing  = lipgloss.Color("203")
-	colPaused   = lipgloss.Color("214")
-	colAccent   = lipgloss.Color("147")
-	colSelected = lipgloss.Color("205")
+	colTitle    = lipgloss.Color("#FF2D20") // lerd red
+	colDim      = lipgloss.Color("#6b7280") // gray-500
+	colDivider  = lipgloss.Color("#374151") // gray-700
+	colRunning  = lipgloss.Color("#10b981") // emerald-500
+	colStopped  = lipgloss.Color("#6b7280") // gray-500
+	colFailing  = lipgloss.Color("#ef4444") // red-500
+	colPaused   = lipgloss.Color("#f59e0b") // amber-400
+	colAccent   = lipgloss.Color("#a78bfa") // violet-400
+	colSelected = lipgloss.Color("#FF2D20") // lerd red
 )
 
 var (


### PR DESCRIPTION
## Summary

- **Responsive narrow layout** (<100 cols): list pane stacks above detail (40/60 split); `v` toggles between sites and services; `tab` only cycles between the active list and detail
- **Full-height overlays** in narrow mode: services, help (`?`), and settings (`S`) each take the full height when active
- **Scrollbars** on sites, services, and site detail panes; detail viewport follows cursor
- **Log scrolling**: `{` scrolls back, `}` returns to tail; header shows current offset
- **Color refresh**: palette updated to match web UI (emerald running, violet accent, amber paused)