### PR TITLE
ci(docs): deploy docs only on tag release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,8 @@ name: Docs
 
 on:
   push:
-    branches: [main]
+    tags:
+      - "v*"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

The Docs workflow triggered on every push to main, which republished the site whenever any non-docs change merged. Switch the trigger to tag pushes matching `v*` so the published docs track tagged releases of lerd instead of trunk.

`workflow_dispatch` is retained for manual redeploys between releases.