### PR TITLE
fix(env): sanitise AWS_BUCKET through s3BucketName on every run

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -98,6 +98,7 @@ env:
   # Template variables available in vars values:
   #   {{site}}              : project database / handle name (e.g. myapp)
   #   {{site_testing}}      : testing database name (e.g. myapp_testing)
+  #   {{bucket}}            : S3-safe bucket name (lowercase, hyphens; e.g. my-app)
   #   {{domain}}            : site's primary domain (e.g. myapp.test)
   #   {{scheme}}            : http or https depending on TLS status
   #   {{mysql_version}}     : running MySQL server version

--- a/docs/usage/services.md
+++ b/docs/usage/services.md
@@ -72,7 +72,7 @@ Additional UIs:
 
 RustFS is an S3-compatible object storage service (a drop-in replacement for MinIO). When `lerd env` detects it is needed (via `FILESYSTEM_DISK=s3` or `AWS_ENDPOINT` in `.env`), it automatically:
 
-1. Creates a bucket named after the site handle (e.g. `my_project`)
+1. Creates a bucket named after the site handle, sanitised to match the S3 naming rules (lowercase, digits, hyphens, dots only, max 63 chars). Underscores in the handle are rewritten as hyphens, so `admin_astrolov` becomes bucket `admin-astrolov`.
 2. Sets the bucket to **public access** (suitable for local development)
 3. Writes the correct `.env` values:
 
@@ -81,11 +81,13 @@ FILESYSTEM_DISK=s3
 AWS_ACCESS_KEY_ID=lerd
 AWS_SECRET_ACCESS_KEY=lerdpassword
 AWS_DEFAULT_REGION=us-east-1
-AWS_BUCKET=my_project
-AWS_URL=http://localhost:9000/my_project
+AWS_BUCKET=my-project
+AWS_URL=http://localhost:9000/my-project
 AWS_ENDPOINT=http://lerd-rustfs:9000
 AWS_USE_PATH_STYLE_ENDPOINT=true
 ```
+
+If a historical `AWS_BUCKET` value with underscores (or other S3-invalid characters) is present from an earlier lerd run or Sail import, `lerd env` will sanitise it in place on the next run.
 
 `AWS_URL` points to the public bucket URL (browser-reachable). `AWS_ENDPOINT` is the internal container address used by PHP.
 

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -180,6 +180,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	}
 	tplCtx := siteTemplateCtx{
 		site:   dbName,
+		bucket: s3BucketName(dbName),
 		domain: site.PrimaryDomain(),
 		scheme: scheme,
 	}
@@ -262,9 +263,11 @@ func runEnv(_ *cobra.Command, _ []string) error {
 				continue
 			}
 			if svc == "rustfs" {
-				// Honour existing AWS_BUCKET from .env; fall back to project slug.
-				bucketName := strings.TrimSpace(envMap["AWS_BUCKET"])
-				if bucketName == "" || bucketName == "lerd" {
+				// Always sanitise through s3BucketName: rustfs/S3 reject underscores,
+				// uppercase, etc. A historical invalid value in .env (from an older
+				// lerd, a Sail import, or manual edit) gets auto-healed on this run.
+				bucketName := s3BucketName(envMap["AWS_BUCKET"])
+				if bucketName == "lerd" {
 					bucketName = s3BucketName(dbName)
 				}
 				updates["AWS_BUCKET"] = bucketName
@@ -350,11 +353,11 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			}
 
 			if svc == "rustfs" {
-				// Honour an existing AWS_BUCKET in .env (set manually or by a
-				// previous lerd env run) so we create/target the right bucket.
-				// Fall back to deriving the name from the project slug.
-				bucketName := strings.TrimSpace(envMap["AWS_BUCKET"])
-				if bucketName == "" || bucketName == "lerd" {
+				// Always sanitise through s3BucketName: rustfs/S3 reject underscores,
+				// uppercase, etc. A historical invalid value in .env (from an older
+				// lerd, a Sail import, or manual edit) gets auto-healed on this run.
+				bucketName := s3BucketName(envMap["AWS_BUCKET"])
+				if bucketName == "lerd" {
 					bucketName = s3BucketName(dbName)
 				}
 				updates["AWS_BUCKET"] = bucketName
@@ -855,16 +858,20 @@ func artisanIn(dir string, args ...string) error {
 // siteTemplateCtx holds the values available to {{…}} placeholders in
 // framework env var templates.
 type siteTemplateCtx struct {
-	site   string // database / handle name
+	site   string // database / handle name (underscored)
+	bucket string // S3-safe bucket name (lowercase, hyphens)
 	domain string // primary domain (e.g. myapp.test)
 	scheme string // "http" or "https"
 }
 
-// applySiteHandle replaces {{site}}, {{site_testing}}, {{domain}}, {{scheme}},
-// and service version placeholders (e.g. {{mysql_version}}, {{postgres_version}}) in s.
+// applySiteHandle replaces {{site}}, {{site_testing}}, {{bucket}}, {{domain}},
+// {{scheme}}, and service version placeholders (e.g. {{mysql_version}}) in s.
 func applySiteHandle(s string, ctx siteTemplateCtx) string {
 	s = strings.ReplaceAll(s, "{{site}}", ctx.site)
 	s = strings.ReplaceAll(s, "{{site_testing}}", ctx.site+"_testing")
+	if ctx.bucket != "" {
+		s = strings.ReplaceAll(s, "{{bucket}}", ctx.bucket)
+	}
 	if ctx.domain != "" {
 		s = strings.ReplaceAll(s, "{{domain}}", ctx.domain)
 	}

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
@@ -77,4 +78,41 @@ func TestResolveAppURL(t *testing.T) {
 			t.Errorf("expected trimmed value, got %q", got)
 		}
 	})
+}
+
+func TestS3BucketName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"admin_astrolov", "admin-astrolov"},
+		{"Admin_Astrolov", "admin-astrolov"},
+		{"my-app", "my-app"},
+		{"MyApp 2", "myapp-2"},
+		{"my.bucket.v2", "my.bucket.v2"},
+		{"  ___  ", "lerd"},
+		{"", "lerd"},
+		{"--app--", "app"},
+	}
+	for _, tc := range cases {
+		if got := s3BucketName(tc.in); got != tc.want {
+			t.Errorf("s3BucketName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+
+	long := strings.Repeat("a", 80)
+	if got := s3BucketName(long); len(got) != 63 {
+		t.Errorf("long input should be clamped to 63, got %d", len(got))
+	}
+}
+
+func TestApplySiteHandleBucket(t *testing.T) {
+	ctx := siteTemplateCtx{site: "admin_astrolov", bucket: "admin-astrolov"}
+	got := applySiteHandle("AWS_BUCKET={{bucket}}", ctx)
+	if got != "AWS_BUCKET=admin-astrolov" {
+		t.Errorf("expected sanitised bucket, got %q", got)
+	}
+	gotSite := applySiteHandle("DB_DATABASE={{site}}", ctx)
+	if gotSite != "DB_DATABASE=admin_astrolov" {
+		t.Errorf("{{site}} should preserve underscores, got %q", gotSite)
+	}
 }

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -263,9 +263,9 @@ var laravelFramework = &Framework{
 				Vars: []string{
 					"AWS_ACCESS_KEY_ID=lerd",
 					"AWS_SECRET_ACCESS_KEY=lerdpassword",
-					"AWS_BUCKET={{site}}",
+					"AWS_BUCKET={{bucket}}",
 					"AWS_ENDPOINT=http://lerd-rustfs:9000",
-					"AWS_URL=http://localhost:9000/{{site}}",
+					"AWS_URL=http://localhost:9000/{{bucket}}",
 					"AWS_USE_PATH_STYLE_ENDPOINT=true",
 				},
 			},


### PR DESCRIPTION
The framework rustfs template wrote AWS_BUCKET={{site}} to .env, which expands to the underscored database handle like admin_astrolov. Rustfs and S3 reject underscores, so the bucket on disk got the sanitised name admin-astrolov via s3BucketName, while .env pointed at admin_astrolov, causing InvalidBucketName errors at runtime.

This pipes envMap[AWS_BUCKET] through s3BucketName in both rustfs paths in lerd env, so historical invalid values auto-heal on the next run. It also adds a {{bucket}} template placeholder resolving to the S3 safe form, and switches the framework rustfs defaults from {{site}} to {{bucket}}, so both code paths agree on the bucket name.