### PR TITLE
fix(siteops): strip any 2-letter ccTLD from dir names

### DIFF
--- a/internal/siteops/naming.go
+++ b/internal/siteops/naming.go
@@ -1,24 +1,53 @@
 package siteops
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
-// KnownTLDs is the list of domain suffixes stripped from directory names
-// when deriving a site name.
-var KnownTLDs = []string{
-	".com", ".net", ".org", ".io", ".co", ".ltd", ".dev", ".app", ".me",
-	".info", ".biz", ".uk", ".us", ".eu", ".de", ".fr", ".ca", ".au",
+// gTLDs lists multi-letter gTLDs stripped from directory names when deriving
+// a site handle. All ccTLDs are 2 letters and are handled by ccTLDPattern, so
+// we don't need to enumerate them here.
+var gTLDs = []string{
+	".com", ".net", ".org", ".info", ".biz", ".dev", ".app",
+	".tech", ".site", ".online", ".store", ".shop", ".xyz",
+	".cloud", ".digital", ".studio", ".agency", ".host", ".ltd",
 }
 
+// ccTLDPattern matches any trailing .xx suffix where xx is two ASCII letters.
+// ISO 3166 country codes are all 2-letter, so this catches every ccTLD without
+// a maintenance list. Only the last segment is stripped; inputs like
+// example.co.uk lose only .uk, matching the historical single-pass behaviour.
+var ccTLDPattern = regexp.MustCompile(`\.[a-z]{2}$`)
+
 // SiteNameAndDomain derives a clean site name and domain from a directory name.
-// It strips known TLDs (e.g. "myapp.com" → "myapp") and replaces dots with dashes.
+// It strips one trailing TLD (either a gTLD from the curated list or any
+// 2-letter ccTLD), then replaces remaining dots with dashes so the result is
+// a valid DNS label. Examples:
+//
+//	"myapp"              -> "myapp",          "myapp.test"
+//	"myapp.com"          -> "myapp",          "myapp.test"
+//	"astrolov.ro"        -> "astrolov",       "astrolov.test"
+//	"admin.astrolov.com" -> "admin-astrolov", "admin-astrolov.test"
 func SiteNameAndDomain(dirName, tld string) (string, string) {
 	name := strings.ToLower(dirName)
-	for _, ext := range KnownTLDs {
-		if strings.HasSuffix(name, ext) {
-			name = name[:len(name)-len(ext)]
-			break
-		}
+	if stripped, ok := stripGTLD(name); ok {
+		name = stripped
+	} else if m := ccTLDPattern.FindStringIndex(name); m != nil {
+		name = name[:m[0]]
 	}
 	name = strings.ReplaceAll(name, ".", "-")
+	if name == "" {
+		name = "site"
+	}
 	return name, name + "." + tld
+}
+
+func stripGTLD(name string) (string, bool) {
+	for _, ext := range gTLDs {
+		if strings.HasSuffix(name, ext) {
+			return name[:len(name)-len(ext)], true
+		}
+	}
+	return name, false
 }

--- a/internal/siteops/naming_test.go
+++ b/internal/siteops/naming_test.go
@@ -17,6 +17,22 @@ func TestSiteNameAndDomain(t *testing.T) {
 		{"example.co.uk", "test", "example-co", "example-co.test"}, // .uk stripped first
 		{"plain", "local", "plain", "plain.local"},
 		{"dots.in.name", "test", "dots-in-name", "dots-in-name.test"},
+
+		// ccTLDs handled by the 2-letter regex, no enumeration needed.
+		{"astrolov.ro", "test", "astrolov", "astrolov.test"},
+		{"mysite.nl", "test", "mysite", "mysite.test"},
+		{"mysite.be", "test", "mysite", "mysite.test"},
+		{"project.pl", "test", "project", "project.test"},
+
+		// gTLDs from the curated list.
+		{"shop.online", "test", "shop", "shop.test"},
+		{"studio.digital", "test", "studio", "studio.test"},
+
+		// Digit suffix must not be stripped; preserves version-style dir names.
+		{"app.v2", "test", "app-v2", "app-v2.test"},
+
+		// Unknown longer suffix is left alone.
+		{"backup.old", "test", "backup-old", "backup-old.test"},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
SiteNameAndDomain only stripped a curated list of TLDs, so a dir named astrolov.ro produced astrolov-ro.test instead of astrolov.test. Most country codes were simply not in the list.

The fix replaces the hand-maintained ccTLD entries with a regex that matches any trailing .xx suffix where xx is two ASCII letters, covering every ISO 3166 country code without a list to maintain. A curated list is kept for multi letter gTLDs like .com, .net, .info, .dev, .app, .ltd and common new gTLDs, so single segment digit suffixes like app.v2 and unknown words like backup.old still survive unchanged.