### PR TITLE
feat(mcp): refresh global AI skills on lerd update

### DIFF
--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -16,11 +16,19 @@ Run once after installing lerd:
 lerd mcp:enable-global
 ```
 
-This registers the lerd MCP server at **user scope**, available in every Claude Code session, regardless of which directory you open. It also updates Cursor, Windsurf, and JetBrains Junie global configs.
+This registers the lerd MCP server at **user scope**, available in every Claude Code session, regardless of which directory you open. It also updates Cursor, Windsurf, and JetBrains Junie global configs, and writes user-scope skill, rules, and guidelines files so the assistant knows what lerd tools are available and how to use them:
+
+| File | Purpose |
+|---|---|
+| `~/.claude/skills/lerd/SKILL.md` | Claude Code user-scope skill |
+| `~/.cursor/rules/lerd.mdc` | Cursor user-scope rules |
+| `~/.junie/guidelines.md` | JetBrains Junie user-scope guidelines (merged, not overwritten) |
 
 When running globally, the server uses the **directory Claude is opened in** as the site context. No further configuration is needed: just open your AI assistant in a project directory and lerd tools work immediately.
 
 > **During `lerd install`:** If Claude Code is detected, you'll be prompted to run this automatically.
+
+> **During `lerd update`:** When MCP is globally registered, the skill, rules, and guidelines files are automatically rewritten from the newly installed binary so they stay in sync with any added or renamed tools.
 
 ### Project-scoped registration
 

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -154,10 +154,13 @@ The server uses the directory Claude is opened in as the site context —
 no LERD_SITE_PATH configuration needed.
 
 This command updates:
-  claude mcp add --scope user   Claude Code user-scope MCP registration
-  ~/.cursor/mcp.json            Cursor global MCP config
-  ~/.ai/mcp/mcp.json            Windsurf global MCP config
-  ~/.junie/mcp/mcp.json         JetBrains Junie global MCP config`,
+  claude mcp add --scope user      Claude Code user-scope MCP registration
+  ~/.cursor/mcp.json               Cursor global MCP config
+  ~/.ai/mcp/mcp.json               Windsurf global MCP config
+  ~/.junie/mcp/mcp.json            JetBrains Junie global MCP config
+  ~/.claude/skills/lerd/SKILL.md   Claude Code user-scope skill
+  ~/.cursor/rules/lerd.mdc         Cursor user-scope rules
+  ~/.junie/guidelines.md           JetBrains Junie user-scope guidelines`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return RunMCPEnableGlobal()
 		},
@@ -221,8 +224,50 @@ func RunMCPEnableGlobal() error {
 	}
 	fmt.Println("  updated ~/.junie/mcp/mcp.json")
 
+	if err := WriteGlobalAISkills(home, true); err != nil {
+		return err
+	}
+
 	fmt.Println("\nDone! Restart your AI assistant for changes to take effect.")
 	fmt.Println("lerd will use the directory you open Claude in as the site context.")
+	return nil
+}
+
+// WriteGlobalAISkills writes the user-scope skill, rules, and guidelines files
+// used by Claude Code, Cursor, and JetBrains Junie. It is called both from
+// mcp:enable-global and from lerd update so the docs the AI reads stay aligned
+// with the currently installed binary's tool set. When verbose is true each
+// written path is printed to stdout.
+func WriteGlobalAISkills(home string, verbose bool) error {
+	skillPath := filepath.Join(home, ".claude", "skills", "lerd", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0755); err != nil {
+		return fmt.Errorf("creating ~/.claude/skills/lerd: %w", err)
+	}
+	if err := os.WriteFile(skillPath, []byte(claudeSkillContent), 0644); err != nil {
+		return fmt.Errorf("writing %s: %w", skillPath, err)
+	}
+	if verbose {
+		fmt.Println("  wrote   ~/.claude/skills/lerd/SKILL.md")
+	}
+
+	cursorRulesPath := filepath.Join(home, ".cursor", "rules", "lerd.mdc")
+	if err := os.MkdirAll(filepath.Dir(cursorRulesPath), 0755); err != nil {
+		return fmt.Errorf("creating ~/.cursor/rules: %w", err)
+	}
+	if err := os.WriteFile(cursorRulesPath, []byte(cursorRulesContent), 0644); err != nil {
+		return fmt.Errorf("writing %s: %w", cursorRulesPath, err)
+	}
+	if verbose {
+		fmt.Println("  wrote   ~/.cursor/rules/lerd.mdc")
+	}
+
+	guidelinesPath := filepath.Join(home, ".junie", "guidelines.md")
+	if err := mergeJunieGuidelines(guidelinesPath, junieGuidelinesSection); err != nil {
+		return fmt.Errorf("writing %s: %w", guidelinesPath, err)
+	}
+	if verbose {
+		fmt.Println("  updated ~/.junie/guidelines.md")
+	}
 	return nil
 }
 

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteGlobalAISkills_writesAllThreeFiles(t *testing.T) {
+	home := t.TempDir()
+
+	if err := WriteGlobalAISkills(home, false); err != nil {
+		t.Fatalf("WriteGlobalAISkills: %v", err)
+	}
+
+	expect := []string{
+		filepath.Join(home, ".claude", "skills", "lerd", "SKILL.md"),
+		filepath.Join(home, ".cursor", "rules", "lerd.mdc"),
+		filepath.Join(home, ".junie", "guidelines.md"),
+	}
+	for _, path := range expect {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("expected %s to exist: %v", path, err)
+		}
+		if info.Size() == 0 {
+			t.Errorf("%s is empty", path)
+		}
+	}
+
+	skill, err := os.ReadFile(filepath.Join(home, ".claude", "skills", "lerd", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	if string(skill) != claudeSkillContent {
+		t.Errorf("SKILL.md content does not match embedded claudeSkillContent")
+	}
+
+	rules, err := os.ReadFile(filepath.Join(home, ".cursor", "rules", "lerd.mdc"))
+	if err != nil {
+		t.Fatalf("read lerd.mdc: %v", err)
+	}
+	if string(rules) != cursorRulesContent {
+		t.Errorf("lerd.mdc content does not match embedded cursorRulesContent")
+	}
+
+	guidelines, err := os.ReadFile(filepath.Join(home, ".junie", "guidelines.md"))
+	if err != nil {
+		t.Fatalf("read guidelines.md: %v", err)
+	}
+	if !strings.Contains(string(guidelines), "<!-- lerd:begin -->") {
+		t.Errorf("guidelines.md missing lerd block sentinel")
+	}
+	if !strings.Contains(string(guidelines), "<!-- lerd:end -->") {
+		t.Errorf("guidelines.md missing lerd end sentinel")
+	}
+}
+
+func TestWriteGlobalAISkills_idempotent(t *testing.T) {
+	home := t.TempDir()
+
+	if err := WriteGlobalAISkills(home, false); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := WriteGlobalAISkills(home, false); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	guidelines, err := os.ReadFile(filepath.Join(home, ".junie", "guidelines.md"))
+	if err != nil {
+		t.Fatalf("read guidelines: %v", err)
+	}
+	if got := strings.Count(string(guidelines), "<!-- lerd:begin -->"); got != 1 {
+		t.Errorf("expected 1 lerd:begin sentinel, got %d", got)
+	}
+	if got := strings.Count(string(guidelines), "<!-- lerd:end -->"); got != 1 {
+		t.Errorf("expected 1 lerd:end sentinel, got %d", got)
+	}
+}
+
+func TestWriteGlobalAISkills_preservesExistingGuidelines(t *testing.T) {
+	home := t.TempDir()
+
+	guidelinesPath := filepath.Join(home, ".junie", "guidelines.md")
+	if err := os.MkdirAll(filepath.Dir(guidelinesPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	existing := "# Project guidelines\n\nFollow house style.\n"
+	if err := os.WriteFile(guidelinesPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("seed guidelines: %v", err)
+	}
+
+	if err := WriteGlobalAISkills(home, false); err != nil {
+		t.Fatalf("WriteGlobalAISkills: %v", err)
+	}
+
+	got, err := os.ReadFile(guidelinesPath)
+	if err != nil {
+		t.Fatalf("read guidelines: %v", err)
+	}
+	if !strings.Contains(string(got), "Follow house style.") {
+		t.Errorf("existing guidelines content was dropped")
+	}
+	if !strings.Contains(string(got), "<!-- lerd:begin -->") {
+		t.Errorf("lerd block not appended")
+	}
+}
+
+func TestMcpEnabledGlobally_noMarkers(t *testing.T) {
+	home := t.TempDir()
+	if mcpEnabledGlobally(home) {
+		t.Errorf("expected false when no markers present")
+	}
+}
+
+func TestMcpEnabledGlobally_detectsClaudeSkill(t *testing.T) {
+	home := t.TempDir()
+	skill := filepath.Join(home, ".claude", "skills", "lerd", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skill), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(skill, []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !mcpEnabledGlobally(home) {
+		t.Errorf("expected true when SKILL.md marker exists")
+	}
+}
+
+func TestMcpEnabledGlobally_detectsCursorRules(t *testing.T) {
+	home := t.TempDir()
+	rules := filepath.Join(home, ".cursor", "rules", "lerd.mdc")
+	if err := os.MkdirAll(filepath.Dir(rules), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(rules, []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !mcpEnabledGlobally(home) {
+		t.Errorf("expected true when lerd.mdc marker exists")
+	}
+}
+
+func TestWriteGlobalAISkills_replacesExistingLerdBlock(t *testing.T) {
+	home := t.TempDir()
+
+	guidelinesPath := filepath.Join(home, ".junie", "guidelines.md")
+	if err := os.MkdirAll(filepath.Dir(guidelinesPath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	stale := "# guidelines\n\n<!-- lerd:begin -->\nstale lerd content\n<!-- lerd:end -->\n"
+	if err := os.WriteFile(guidelinesPath, []byte(stale), 0644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := WriteGlobalAISkills(home, false); err != nil {
+		t.Fatalf("WriteGlobalAISkills: %v", err)
+	}
+
+	got, err := os.ReadFile(guidelinesPath)
+	if err != nil {
+		t.Fatalf("read guidelines: %v", err)
+	}
+	if strings.Contains(string(got), "stale lerd content") {
+		t.Errorf("stale lerd block was not replaced")
+	}
+	if !strings.Contains(string(got), "Lerd — Laravel Local Dev Environment") {
+		t.Errorf("fresh lerd block not written")
+	}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -157,6 +157,8 @@ func runUpdate(currentVersion string, beta bool) error {
 		return err
 	}
 
+	refreshGlobalMCPSkills()
+
 	// Offer MinIO → RustFS migration if legacy data directory exists and the
 	// minio container is still running (skip if already migrated to RustFS).
 	minioRunning, _ := podman.ContainerRunning("lerd-minio")
@@ -199,6 +201,44 @@ func runUpdate(currentVersion string, beta bool) error {
 
 	restartLerdUserServices()
 	return nil
+}
+
+// refreshGlobalMCPSkills re-writes the user-scope skill, rules, and guidelines
+// files when lerd MCP is registered globally, so the AI's description of
+// available tools stays aligned with the newly installed binary.
+func refreshGlobalMCPSkills() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	if !mcpEnabledGlobally(home) {
+		return
+	}
+	fmt.Println("\n==> Refreshing global MCP skills and guidelines")
+	if err := WriteGlobalAISkills(home, true); err != nil {
+		fmt.Fprintf(os.Stderr, "  warn: could not refresh global AI skills: %v\n", err)
+	}
+}
+
+// mcpEnabledGlobally reports whether the user opted into global MCP at some
+// point. Checks (a) Claude Code user-scope registration and (b) the lerd-owned
+// marker files written by mcp:enable-global. The marker check lets us detect
+// users who enabled globally without Claude Code (Cursor-only, Junie-only) and
+// users whose `claude` CLI is temporarily unavailable.
+func mcpEnabledGlobally(home string) bool {
+	if IsMCPGloballyRegistered() {
+		return true
+	}
+	markers := []string{
+		filepath.Join(home, ".claude", "skills", "lerd", "SKILL.md"),
+		filepath.Join(home, ".cursor", "rules", "lerd.mdc"),
+	}
+	for _, p := range markers {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // restartLerdUserServices restarts the long-running lerd user units so they


### PR DESCRIPTION
## Summary

- `mcp:enable-global` now writes user-scope skill, rules, and guidelines files (`~/.claude/skills/lerd/SKILL.md`, `~/.cursor/rules/lerd.mdc`, `~/.junie/guidelines.md`) in addition to the MCP server registrations, so the assistants actually know which lerd tools exist.
- `lerd update` re-writes those three files from the newly installed binary when global MCP is enabled, so the skill content stays aligned with any added or renamed tools in the release.
- Gate runs only when MCP was enabled globally, detected via `claude mcp list --scope user` or the lerd-owned marker files, covering users without Claude Code installed.

## Changes

- `internal/cli/mcp.go`: new `WriteGlobalAISkills(home, verbose)` helper shared between `mcp:enable-global` and the update flow, updated help text.
- `internal/cli/update.go`: post-install `refreshGlobalMCPSkills` with `mcpEnabledGlobally` marker-aware gate.
- `internal/cli/mcp_test.go`: seven tests covering file writes, idempotence, preservation of existing Junie guidelines, replacement of a stale lerd block, and the gate.
- `docs/features/mcp.md`: documents the new user-scope files and the update-time refresh.