### PR TITLE
release: v1.17.1 — fresh-install fixes for macOS services, FPM images, certs, shims

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,24 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.17.1] — 2026-04-20
+
+### Fixed
+
+- **Services not started after fresh macOS install**. `ensureServiceQuadlet` on macOS called `WriteContainerUnitFn` which only writes the launchd plist, not a `.container` file in `QuadletDir`. `startRestoredServices` later reads that directory via `quadletImage()` to decide what to pre-pull; with no file it returns empty and skips the pull, leaving `podman run` to auto-pull mysql/postgres/etc. on a brand-new Podman Machine where those pulls often fail or time out. Switched to `WriteQuadletDiff`, which writes both the `.container` file and the launchd plist via `AfterQuadletWriteFn`, so pre-pull works on first install.
+- **PHP FPM images silently missed on first install**. `ensureFPMQuadletTo` wrote the launchd plist only after a successful image build; a failed build left the PHP version unregistered, invisible to `ensureImages()`, and never retried. The plist is now written before the build so the version shows up in `lerd status` (as `image missing`) and `lerd start` rebuilds it on the next run. `lerd install`'s autostart block also re-runs `ensureImages()` before starting FPM containers so transient build failures heal automatically.
+- **Image pulls routed through lerd-dns on macOS install**. `ensureImages()` ran after `ConfigureResolver()`, so every registry pull (nginx, DNS, services, FPM) went through the `.test` override. Moved the call before the DNS block so pulls use the clean system resolver.
+- **`.container` file missing for service and custom-container units on macOS**. All call sites (FPM, custom services, custom containers, UI server, MCP server) used `WriteContainerUnitFn`, which on macOS writes only the launchd plist. `quadletImage()` then had no file to read, so the pre-pull step was skipped and containers failed on first start. Every site now calls `WriteQuadletDiff`, which writes both artifacts.
+- **Certificates reissued on every `lerd setup`**. `IssueCert` re-ran mkcert even when the cert and key were already present. Now skips when both files exist.
+- **Shims broken under Homebrew installs**. php/composer/laravel shims hardcoded `~/.local/bin/lerd` as the target binary, so they failed for Homebrew installs at `/opt/homebrew/bin/lerd`. Shims now resolve the running binary with `os.Executable()` and use whichever path ran `lerd install`.
+- **PHP commands failing on fresh installs because `.env` services weren't running**. `ensureServicesForCwd` only acted on paused sites, so mysql/postgres/etc. referenced in a site's `.env` stayed down and migrations failed with connection errors. It now starts any referenced service that isn't running, silently, regardless of pause state.
+- **Dashboard preset install left services stopped**. `InstallPresetByName` only wrote the quadlet without starting the container, so services added from the Web UI (mongodb and others) sat idle after install. The UI now starts dependencies and then the service itself, matching the dashboard's Start button.
+- **`lerd share` URL unreachable while a VPN is active**. `detectPrimaryLANIP` returned the VPN tunnel address (`utun*`/`tun*`) instead of the physical LAN interface, so the shared URL worked on the host but nothing else on the LAN could reach it. The detector now validates which interface the routing-table probe selected and falls back to scanning physical interfaces, skipping `utun`, `tun`, `tap`, `wg`, and container bridges.
+- **fnm install fails on ARM Linux**. The installer only fetched `fnm-linux.zip`, which is x86_64-only; arm64 machines need `fnm-arm64.zip`. Arch detection now picks the correct archive, matching the existing logic used for mkcert.
+- **Go test runs hang for the full timeout**. `installCompletion` called `os.Executable()` during tests; the resulting path pointed at the test binary, which then re-invoked itself with `completion bash` and hung until CI's 10-minute timeout. The installer now skips when the executable name ends in `.test`.
+
+---
+
 ## [1.17.0] — 2026-04-20
 
 ### Added

--- a/internal/certs/manager.go
+++ b/internal/certs/manager.go
@@ -27,6 +27,7 @@ func InstallCA() error {
 
 // IssueCert issues a TLS certificate covering all the given domains using mkcert.
 // The cert files are named after primaryDomain. Each domain also gets a wildcard entry.
+// If the cert and key files already exist they are reused without re-running mkcert.
 func IssueCert(primaryDomain string, allDomains []string, certsDir string) error {
 	if err := os.MkdirAll(certsDir, 0755); err != nil {
 		return err
@@ -34,6 +35,13 @@ func IssueCert(primaryDomain string, allDomains []string, certsDir string) error
 
 	certFile := filepath.Join(certsDir, primaryDomain+".crt")
 	keyFile := filepath.Join(certsDir, primaryDomain+".key")
+
+	// Skip re-issuing if both files already exist.
+	if _, certErr := os.Stat(certFile); certErr == nil {
+		if _, keyErr := os.Stat(keyFile); keyErr == nil {
+			return nil
+		}
+	}
 
 	// Build the list of SANs: each domain + its wildcard.
 	var sans []string

--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
@@ -263,32 +264,121 @@ func reloadAndRestartUnit(unit string) error {
 	return nil
 }
 
-// detectPrimaryLANIP returns the local IPv4 address that the kernel would use
-// to reach a public destination, without actually sending a packet. Falls back
-// to scanning interfaces when the dial trick fails (e.g. no default route).
+// detectPrimaryLANIP returns the host's primary LAN IPv4 address.
+// The UDP-dial trick is tried first; if the result comes from a VPN tunnel
+// (utun/tun/tap) we fall back to scanning physical interfaces.
 func detectPrimaryLANIP() (string, error) {
 	conn, err := net.Dial("udp4", "1.1.1.1:80")
 	if err == nil {
-		defer conn.Close()
-		return conn.LocalAddr().(*net.UDPAddr).IP.String(), nil
+		ip := conn.LocalAddr().(*net.UDPAddr).IP
+		conn.Close()
+		if name, ok := interfaceNameForIP(ip); ok && !isTunnelInterface(name) {
+			return ip.String(), nil
+		}
+		// Fell through: the route goes through a VPN tunnel — keep scanning below.
 	}
 
 	ifaces, ifErr := net.Interfaces()
 	if ifErr != nil {
 		return "", fmt.Errorf("listing interfaces: %w", ifErr)
 	}
+	// First pass: physical interfaces only (en*, eth*, wlan*).
 	for _, iface := range ifaces {
 		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
 			continue
 		}
-		addrs, _ := iface.Addrs()
-		for _, addr := range addrs {
-			if ipnet, ok := addr.(*net.IPNet); ok {
-				if v4 := ipnet.IP.To4(); v4 != nil && !v4.IsLoopback() {
-					return v4.String(), nil
-				}
-			}
+		if isTunnelInterface(iface.Name) || isContainerInterface(iface.Name) {
+			continue
+		}
+		if ip := firstPrivateV4(iface); ip != "" {
+			return ip, nil
+		}
+	}
+	// Second pass: any non-tunnel interface as a last resort.
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if isTunnelInterface(iface.Name) {
+			continue
+		}
+		if ip := firstPrivateV4(iface); ip != "" {
+			return ip, nil
 		}
 	}
 	return "", fmt.Errorf("no usable IPv4 address found")
+}
+
+// interfaceNameForIP returns the interface name that owns ip.
+func interfaceNameForIP(ip net.IP) (string, bool) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", false
+	}
+	for _, iface := range ifaces {
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			if ipnet, ok := addr.(*net.IPNet); ok && ipnet.IP.Equal(ip) {
+				return iface.Name, true
+			}
+		}
+	}
+	return "", false
+}
+
+// isTunnelInterface reports whether the interface looks like a VPN tunnel
+// (macOS utun*, Linux tun*/tap*, WireGuard wg*, etc.).
+func isTunnelInterface(name string) bool {
+	for _, prefix := range []string{"utun", "tun", "tap", "wg", "ipsec", "ppp"} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// isContainerInterface reports whether the interface belongs to a container network.
+func isContainerInterface(name string) bool {
+	for _, prefix := range []string{"docker", "podman", "veth", "bridge", "br-", "vf-", "vz-"} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// firstPrivateV4 returns the first RFC-1918 IPv4 address on iface, or "".
+func firstPrivateV4(iface net.Interface) string {
+	addrs, _ := iface.Addrs()
+	for _, addr := range addrs {
+		if ipnet, ok := addr.(*net.IPNet); ok {
+			v4 := ipnet.IP.To4()
+			if v4 != nil && !v4.IsLoopback() && isPrivateV4(v4) {
+				return v4.String()
+			}
+		}
+	}
+	return ""
+}
+
+// isPrivateV4 reports whether ip is in an RFC-1918 private range.
+func isPrivateV4(ip net.IP) bool {
+	private := []struct{ net, mask [4]byte }{
+		{[4]byte{10, 0, 0, 0}, [4]byte{255, 0, 0, 0}},
+		{[4]byte{172, 16, 0, 0}, [4]byte{255, 240, 0, 0}},
+		{[4]byte{192, 168, 0, 0}, [4]byte{255, 255, 0, 0}},
+	}
+	for _, p := range private {
+		match := true
+		for i := range 4 {
+			if ip[i]&p.mask[i] != p.net[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -318,31 +318,10 @@ func runInstall(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	// On macOS, DNS runs natively (no container image needed) and DaemonReload
-	// is a no-op, so we can start lerd-dns and configure the resolver here —
-	// before RunParallel — keeping all sudo prompts before the image-pull spinner.
-	if !isDNSContainerUnit() {
-		step("Starting lerd-dns")
-		if err := services.Mgr.Restart("lerd-dns"); err != nil {
-			fmt.Printf("    WARN: %v\n", err)
-		}
-		ok()
-
-		step("Waiting for lerd-dns to be ready")
-		if err := dns.WaitReady(15 * time.Second); err != nil {
-			fmt.Printf("    WARN: %v\n", err)
-		}
-		ok()
-
-		fmt.Println("  --> Configuring DNS resolver")
-		if err := dns.ConfigureResolver(); err != nil {
-			fmt.Printf("    WARN: %v\n", err)
-		}
-	}
-
-	// 7. Pull images sequentially, then build dnsmasq. Sequential output
-	// keeps any sudo password prompt from later steps visible instead of
-	// being clobbered by a live-updating spinner.
+	// 7. Pull images before touching DNS so registry lookups use the system
+	// resolver. On macOS ConfigureResolver() redirects .test queries through
+	// lerd-dns; doing pulls first ensures the system DNS is intact for all
+	// registry traffic (docker.io, ghcr.io, etc.).
 	pullJobs := []BuildJob{
 		{
 			Label: "Pulling nginx:alpine",
@@ -362,6 +341,27 @@ func runInstall(_ *cobra.Command, _ []string) error {
 			continue
 		}
 		ok()
+	}
+
+	// On macOS, DNS runs natively (no container image needed) and DaemonReload
+	// is a no-op, so we can start lerd-dns and configure the resolver here.
+	if !isDNSContainerUnit() {
+		step("Starting lerd-dns")
+		if err := services.Mgr.Restart("lerd-dns"); err != nil {
+			fmt.Printf("    WARN: %v\n", err)
+		}
+		ok()
+
+		step("Waiting for lerd-dns to be ready")
+		if err := dns.WaitReady(15 * time.Second); err != nil {
+			fmt.Printf("    WARN: %v\n", err)
+		}
+		ok()
+
+		fmt.Println("  --> Configuring DNS resolver")
+		if err := dns.ConfigureResolver(); err != nil {
+			fmt.Printf("    WARN: %v\n", err)
+		}
 	}
 
 	// 8. Systemd / services

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -343,6 +343,14 @@ func runInstall(_ *cobra.Command, _ []string) error {
 		ok()
 	}
 
+	// Pull/build all service and FPM images before touching DNS. On macOS,
+	// ConfigureResolver() redirects .test DNS through lerd-dns; any registry
+	// pull after that point uses the overridden resolver which may not yet
+	// forward non-.test queries correctly on a fresh install.
+	if lerdSystemd.IsAutostartEnabled() {
+		ensureImages()
+	}
+
 	// On macOS, DNS runs natively (no container image needed) and DaemonReload
 	// is a no-op, so we can start lerd-dns and configure the resolver here.
 	if !isDNSContainerUnit() {
@@ -503,11 +511,6 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	// stopped — `lerd update` running install via re-exec must not flip
 	// disabled units back on.
 	if autostartOn {
-		// Build/pull any images that are still missing — catches PHP FPM builds
-		// that failed earlier (e.g. transient network error) and ensures service
-		// images are available before containers are started.
-		ensureImages()
-
 		// Start installed PHP FPM containers whose images are now available.
 		if fpmVersions, _ := phpDet.ListInstalled(); len(fpmVersions) > 0 {
 			var fpmJobs []BuildJob

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -503,6 +503,31 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	// stopped — `lerd update` running install via re-exec must not flip
 	// disabled units back on.
 	if autostartOn {
+		// Build/pull any images that are still missing — catches PHP FPM builds
+		// that failed earlier (e.g. transient network error) and ensures service
+		// images are available before containers are started.
+		ensureImages()
+
+		// Start installed PHP FPM containers whose images are now available.
+		if fpmVersions, _ := phpDet.ListInstalled(); len(fpmVersions) > 0 {
+			var fpmJobs []BuildJob
+			for _, v := range fpmVersions {
+				ver := v
+				short := strings.ReplaceAll(ver, ".", "")
+				if podman.RunSilent("image", "exists", "lerd-php"+short+"-fpm:local") != nil {
+					continue // image still missing, skip
+				}
+				unit := "lerd-php" + short + "-fpm"
+				fpmJobs = append(fpmJobs, BuildJob{
+					Label: "php" + short + "-fpm",
+					Run:   func(_ io.Writer) error { return podman.StartUnit(unit) },
+				})
+			}
+			if len(fpmJobs) > 0 {
+				RunParallel(fpmJobs) //nolint:errcheck
+			}
+		}
+
 		startRestoredServices()
 	}
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -825,7 +825,12 @@ func (p *progressReader) Read(b []byte) (int, error) {
 func addShellShims(manageNode bool) error {
 	home, _ := os.UserHomeDir()
 	binDir := config.BinDir()
-	lerdBin := filepath.Join(home, ".local", "bin", "lerd")
+	// Use the running binary so shims work regardless of install method
+	// (Homebrew at /opt/homebrew/bin/lerd, manual at ~/.local/bin/lerd, etc.).
+	lerdBin, _ := os.Executable()
+	if lerdBin == "" {
+		lerdBin = filepath.Join(home, ".local", "bin", "lerd")
+	}
 	fnmBin := filepath.Join(binDir, "fnm")
 
 	// Write php shim

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -953,6 +953,10 @@ func installCompletion(lerdBin, shell, dir, filename string) {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return
 	}
+	// Skip if lerdBin looks like a test binary to avoid re-entering test code.
+	if strings.HasSuffix(lerdBin, ".test") || strings.Contains(lerdBin, "/tmp/") {
+		return
+	}
 	out, err := exec.Command(lerdBin, "completion", shell).Output()
 	if err != nil {
 		return

--- a/internal/cli/install_linux.go
+++ b/internal/cli/install_linux.go
@@ -29,9 +29,13 @@ func downloadBinaries(w io.Writer) error {
 	// fnm
 	fnmPath := filepath.Join(binDir, "fnm")
 	if _, err := os.Stat(fnmPath); os.IsNotExist(err) {
-		fnmZip := filepath.Join(binDir, "fnm-linux.zip")
+		fnmAsset := "fnm-linux.zip"
+		if arch == "arm64" {
+			fnmAsset = "fnm-arm64.zip"
+		}
+		fnmZip := filepath.Join(binDir, fnmAsset)
 		if err := downloadFile(
-			"https://github.com/Schniz/fnm/releases/latest/download/fnm-linux.zip",
+			"https://github.com/Schniz/fnm/releases/latest/download/"+fnmAsset,
 			fnmZip, 0644, w,
 		); err != nil {
 			return fmt.Errorf("fnm download: %w", err)

--- a/internal/cli/park.go
+++ b/internal/cli/park.go
@@ -292,16 +292,18 @@ func ensureFPMQuadletTo(phpVersion string, w io.Writer) error {
 	versionShort := strings.ReplaceAll(phpVersion, ".", "")
 	unitName := "lerd-php" + versionShort + "-fpm"
 
+	// Write the unit file first so the version is registered in lerd status even
+	// if the image build fails — lerd start will rebuild the image on the next run.
+	if err := podman.WriteFPMQuadlet(phpVersion); err != nil {
+		return err
+	}
+
 	if err := podman.BuildFPMImageTo(phpVersion, false, w); err != nil {
 		return fmt.Errorf("building FPM image for PHP %s: %w", phpVersion, err)
 	}
 	_ = podman.StoreFPMHash()
 
 	_ = podman.EnsureXdebugIni(phpVersion)
-
-	if err := podman.WriteFPMQuadlet(phpVersion); err != nil {
-		return err
-	}
 
 	return podman.StartUnit(unitName)
 }

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -190,15 +190,19 @@ func UnpauseSite(name string) error {
 	return nil
 }
 
-// ensureServicesForCwd checks whether the site at cwd is paused and, if so,
-// starts any services its .env references that are not already running. Only
-// prints a notice when at least one service actually needs to be started.
+// ensureServicesForCwd starts any services referenced in the site's .env that
+// are not already running. When the site is paused it prints a notice; when it
+// is active it starts any missing services silently.
 func ensureServicesForCwd(cwd string) {
 	site, err := config.FindSiteByPath(cwd)
-	if err != nil || !site.Paused {
+	if err != nil {
 		return
 	}
-	startServicesForSiteNoticed(cwd, site.Name)
+	siteName := ""
+	if site.Paused {
+		siteName = site.Name
+	}
+	startServicesForSiteNoticed(cwd, siteName)
 }
 
 // startServicesForSite reads the site's .env file and ensures every lerd service

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -645,7 +645,10 @@ func ensureServiceQuadlet(name string) error {
 			content = podman.ApplyImage(content, override)
 		}
 	}
-	if err := podman.WriteContainerUnitFn(quadletName, content); err != nil {
+	// WriteQuadletDiff writes the .container file to QuadletDir (needed on macOS
+	// so quadletImage() can resolve the image for pre-pull in startRestoredServices)
+	// and calls AfterQuadletWriteFn (writes the launchd plist on macOS).
+	if _, err := podman.WriteQuadletDiff(quadletName, content); err != nil {
 		return fmt.Errorf("writing unit for %s: %w", name, err)
 	}
 	return podman.DaemonReloadFn()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1811,7 +1811,7 @@ func execServiceStart(args map[string]any) (any, *rpcError) {
 				}
 			}
 		}
-		if err := podman.WriteContainerUnitFn(unitName, content); err != nil {
+		if _, err := podman.WriteQuadletDiff(unitName, content); err != nil {
 			return toolErr("writing quadlet: " + err.Error()), nil
 		}
 	} else {
@@ -3131,7 +3131,7 @@ func execServiceExpose(args map[string]any) (any, *rpcError) {
 	if len(svcCfg.ExtraPorts) > 0 {
 		content = podman.ApplyExtraPorts(content, svcCfg.ExtraPorts)
 	}
-	if err := podman.WriteContainerUnitFn(unitName, content); err != nil {
+	if _, err := podman.WriteQuadletDiff(unitName, content); err != nil {
 		return toolErr("writing quadlet: " + err.Error()), nil
 	}
 	if err := podman.DaemonReloadFn(); err != nil {

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -504,7 +504,7 @@ func WriteFPMQuadlet(version string) error {
 		}
 	}
 
-	if err := WriteContainerUnitFn(unitName, content); err != nil {
+	if _, err := WriteQuadletDiff(unitName, content); err != nil {
 		return err
 	}
 	return DaemonReloadFn()

--- a/internal/podman/custom_quadlet.go
+++ b/internal/podman/custom_quadlet.go
@@ -41,7 +41,8 @@ func GenerateCustomContainerQuadlet(siteName, projectPath string, port int) stri
 // WriteCustomContainerQuadlet writes the quadlet for a custom container site.
 func WriteCustomContainerQuadlet(siteName, projectPath string, port int) error {
 	content := GenerateCustomContainerQuadlet(siteName, projectPath, port)
-	return WriteContainerUnitFn(CustomContainerName(siteName), content)
+	_, err := WriteQuadletDiff(CustomContainerName(siteName), content)
+	return err
 }
 
 // RemoveCustomContainerQuadlet removes the unit file for a custom container.

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -98,7 +98,7 @@ func EnsureCustomServiceQuadlet(svc *config.CustomService) error {
 	}
 	content := podman.GenerateCustomQuadlet(svc)
 	quadletName := "lerd-" + svc.Name
-	if err := podman.WriteContainerUnitFn(quadletName, content); err != nil {
+	if _, err := podman.WriteQuadletDiff(quadletName, content); err != nil {
 		return fmt.Errorf("writing unit for %s: %w", svc.Name, err)
 	}
 	return podman.DaemonReloadFn()

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1378,7 +1378,7 @@ func ensureServiceQuadlet(name string) error {
 	if err != nil {
 		return fmt.Errorf("unknown service %q", name)
 	}
-	if err := podman.WriteContainerUnitFn(quadletName, content); err != nil {
+	if _, err := podman.WriteQuadletDiff(quadletName, content); err != nil {
 		return fmt.Errorf("writing unit for %s: %w", name, err)
 	}
 	return podman.DaemonReloadFn()

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1047,11 +1047,37 @@ func handleServicePresetInstall(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
+
+	// Auto-start the service after installation, just like clicking Start
+	// from the dashboard. Start dependencies first so the service can connect.
+	unit := "lerd-" + svc.Name
+	var startErr string
+	if depErr := cli.StartServiceDependencies(svc); depErr != nil {
+		startErr = depErr.Error()
+	} else {
+		var opErr error
+		for attempt := range 5 {
+			opErr = podman.StartUnit(unit)
+			if opErr == nil || !strings.Contains(opErr.Error(), "not found") {
+				break
+			}
+			time.Sleep(time.Duration(attempt+1) * 300 * time.Millisecond)
+		}
+		if opErr == nil {
+			_ = config.SetServicePaused(svc.Name, false)
+			_ = config.SetServiceManuallyStarted(svc.Name, true)
+			cli.RegenerateFamilyConsumersForService(svc.Name)
+		} else {
+			startErr = opErr.Error()
+		}
+	}
+
 	writeJSON(w, map[string]any{
 		"ok":         true,
 		"name":       svc.Name,
 		"dashboard":  svc.Dashboard,
 		"depends_on": svc.DependsOn,
+		"startError": startErr,
 	})
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.17.0"
+	Version = "1.17.1"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

Patch release bundling 12 fixes, mostly around fresh-install reliability on macOS and ARM Linux.

- Fresh macOS installs now start services and PHP FPM containers correctly: `.container` files are written for all unit types so pre-pull can find the image, FPM plists register even when builds fail, and image pulls run before the DNS resolver override so registry traffic uses clean system DNS.
- `.env`-referenced services auto-start before `php`/composer/laravel commands, dashboard preset installs auto-start the new container, and certificates are no longer reissued when they already exist.
- Shims use `os.Executable()` instead of a hardcoded `~/.local/bin/lerd` path so Homebrew installs work; `lerd share` skips VPN/tunnel interfaces when picking the LAN IP; fnm download picks the arm64 archive on ARM Linux; test runs no longer hang because the completion installer now skips when invoked from a `.test` binary.

See CHANGELOG.md for per-fix detail.