### PR TITLE
feat: FrankenPHP runtime for Laravel and Symfony sites

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -79,6 +79,7 @@ func main() {
 	root.AddCommand(cli.NewUseCmd())
 	root.AddCommand(cli.NewIsolateCmd())
 	root.AddCommand(cli.NewIsolateNodeCmd())
+	root.AddCommand(cli.NewRuntimeCmd())
 	root.AddCommand(cli.NewNodeInstallCmd())
 	root.AddCommand(cli.NewNodeUninstallCmd())
 	root.AddCommand(cli.NewNodeUseCmd())

--- a/docs/features/frankenphp.md
+++ b/docs/features/frankenphp.md
@@ -1,0 +1,140 @@
+# FrankenPHP Runtime
+
+Lerd can serve a PHP site through a per-site [FrankenPHP](https://frankenphp.dev/) container instead of the shared PHP-FPM container. FrankenPHP keeps PHP resident in memory, serves HTTP directly, and supports a worker mode that reuses a single PHP process across requests.
+
+The FrankenPHP runtime is opt-in, framework-agnostic, and coexists with the default FPM runtime on the same machine. Laravel sites (via Octane) and Symfony sites (via the native worker flag) are both supported out of the box; any other PHP framework with a `public/index.php` gets the generic `frankenphp php-server` entrypoint.
+
+---
+
+## Switching runtime
+
+Two equivalent ways to turn FrankenPHP on for a site.
+
+**From `.lerd.yaml`** (commits the choice to the repo, so everyone who links the project gets the same runtime):
+
+```yaml
+runtime: frankenphp
+runtime_worker: true
+```
+
+**From the CLI**:
+
+```bash
+cd ~/Code/my-app
+lerd runtime frankenphp --worker
+```
+
+Flip back to FPM with `lerd runtime fpm`. `lerd runtime` without an argument prints the current runtime. Both surfaces restart the container, regenerate the nginx vhost, and reload nginx automatically.
+
+---
+
+## What happens under the hood
+
+For a FrankenPHP site, lerd:
+
+1. Pulls `dunglas/frankenphp:php<version>-alpine` for the site's PHP version (defaults 8.2, 8.3, 8.4; unsupported versions fall back to 8.4).
+2. Writes a per-site quadlet `lerd-fp-<site>.container` that mounts the project at its host path and runs the framework's entrypoint.
+3. Generates an nginx vhost that reverse-proxies to `lerd-fp-<site>:8000`.
+4. Starts the container, reloads nginx.
+
+The container joins the shared `lerd` Podman network, so services like `lerd-mysql`, `lerd-redis`, and `lerd-meilisearch` are reachable by hostname.
+
+---
+
+## Framework adapters
+
+Each framework can declare how to launch FrankenPHP via a `frankenphp:` block in its definition. Both built-in adapters ship with one.
+
+**Laravel** has two modes:
+
+- **Non-worker (`runtime_worker: false`, default)**: lerd runs `frankenphp php-server -r public/`. Each request boots Laravel from scratch; code edits take effect on the next request, same as FPM. You still get FrankenPHP's HTTP/2, HTTP/3, and TLS, but not Octane's per-request speedup.
+- **Worker (`runtime_worker: true`)**: lerd runs `php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=8000 --workers=auto`. Octane keeps Laravel resident; requests skip the full bootstrap. Octane registers Symfony Console signal handlers which need the `pcntl` PHP extension — since the stock `dunglas/frankenphp` image doesn't ship `pcntl`, lerd installs it at container boot via the image's bundled `install-php-extensions` script. First boot takes ~10s longer; subsequent boots reuse the install.
+
+**Symfony** uses FrankenPHP's native worker flag:
+
+```
+frankenphp php-server -l :8000 -r public/ [--worker=public/index.php --watch]
+```
+
+In worker mode lerd also passes `--watch`, which reloads the resident worker on any `.php`, `.env`, `.yaml`, or `.twig` change, so file edits take effect without a manual restart. `runtime/frankenphp-symfony` (optional) plugs Symfony's Runtime into the same worker loop for slightly lower per-request overhead.
+
+**Any other framework** with a `public/index.php` falls back to:
+
+```
+frankenphp php-server -l :8000 -r <public_dir>
+```
+
+To override the defaults for a specific project, add a user framework overlay at `~/.config/lerd/frameworks/<name>.yaml` with a `frankenphp:` block, or commit a full framework definition alongside the project.
+
+---
+
+## Workers
+
+Queue workers, schedulers, Reverb, Horizon, and any framework-defined worker continue to work unchanged: lerd spawns each as its own systemd service and `podman exec`s into the FrankenPHP container for the site. Laravel `queue:work` and Symfony `messenger:consume` both run alongside the web worker without conflict.
+
+Start a worker the same way you would on an FPM site:
+
+```bash
+cd ~/Code/my-app
+lerd worker start queue       # Laravel
+lerd worker start messenger   # Symfony
+```
+
+---
+
+## Worker mode on vs off
+
+Both modes use the same FrankenPHP binary, so you always get HTTP/2, HTTP/3, and TLS for free. The difference is what happens *inside* the PHP process for each request.
+
+**Worker off** (default): each incoming request runs `public/index.php` from scratch. The framework boots (container, DI, config cache, routes, middleware stack, etc.) on every hit, same as classic PHP-FPM. Memory resets between requests; file edits take effect on the next request.
+
+**Worker on**: FrankenPHP keeps one resident PHP process alive and calls `frankenphp_handle_request()` in a loop. The framework boots **once**, then the warm worker handles every subsequent request by reusing the already-constructed DI container, cached routes, resolved config, etc. Requests are typically 10x to 50x faster because you skip the bootstrap each time.
+
+Tradeoffs of worker mode:
+
+- **State leaks across requests.** Anything you stored in a static property, a singleton service, or the global `$_SERVER` / `$_SESSION` arrays from request A is still there for request B. This is usually fine for well-written frameworks (Octane's "state resetters" and Symfony's Runtime handle the common cases), but custom code that assumes a fresh process per request can misbehave.
+- **File edits are not picked up automatically.** The worker holds PHP in memory, so editing a controller doesn't affect the next request until the worker reloads. Symfony worker mode passes `--watch` so edits reload the worker within a second or two; Laravel worker mode requires `lerd restart <site>` or `lerd runtime fpm`.
+- **Memory usage grows over time.** Leaks that would be invisible in FPM (where each request gets a fresh process) become visible over thousands of requests.
+
+Typical usage:
+
+- **Local dev, iterating on code**: worker off, or Symfony worker on (auto reload). Laravel dev is usually happier with worker off or the shared FPM runtime.
+- **Benchmarking, perf testing, staging**: worker on — this is the realistic production picture.
+- **CI / ephemeral environments**: worker off — simpler, no state-leak surprises.
+
+---
+
+## Dev iteration and hot reload
+
+Non-worker mode (the default) serves each request with a fresh PHP request lifecycle for both Laravel and Symfony, so file edits take effect on the next request, just like FPM. That's the right default for local iteration.
+
+Worker mode keeps PHP resident, so a source file change is **not** picked up on the next request unless the worker is told to reload:
+
+- **Symfony** worker mode passes `--watch` to `frankenphp php-server`, so edits under the project tree reload the worker within a second or two.
+- **Laravel** worker mode does not auto-reload. Octane's `--watch` flag needs `chokidar-cli` (npm) plus `pcntl`, and bundling npm+node into the stock image adds ~150MB to boot for a dev-only feature. Workarounds:
+  - `lerd restart <site>` rebuilds and restarts the container (~5s)
+  - `php artisan octane:reload` inside the project drops the warm workers so the next request rebuilds state; doesn't restart the container so it's noticeably faster
+  - `lerd runtime frankenphp --no-worker` if you'll be iterating for a while — non-worker hot reloads on every request like FPM
+
+---
+
+## Limitations
+
+- **Xdebug** is not wired up for FrankenPHP. `lerd xdebug on` still works, but it affects only the shared FPM container and is silently ignored by FrankenPHP sites. Switch back to FPM to debug.
+- **Per-site PHP extensions** (beyond those in the dunglas image) aren't installable from `lerd php:ext add` yet. To add an extension, either publish a custom `Containerfile.lerd` and use lerd's custom-container runtime instead, or wait for a follow-up that extends the FrankenPHP path.
+- **PHP version picker** (in the Web UI and `lerd isolate`) does re-pull the matching `dunglas/frankenphp:php<version>-alpine` image and restart the site. Versions without published dunglas images fall back to 8.4.
+- **macOS** works the same way as Linux because FrankenPHP runs inside the Podman Machine VM; no extra wiring required.
+
+---
+
+## Runtime badge
+
+The Web UI site detail panel shows an orange **FrankenPHP** badge next to the framework and services, with a `worker` suffix when worker mode is on. The same badge appears in `lerd tui` beside the PHP version line. The Xdebug toggle is hidden on FrankenPHP sites since the shared FPM Xdebug state doesn't apply.
+
+---
+
+## Related pages
+
+- [Per-project custom container](project-setup.md#custom-container) — for non-PHP apps or FrankenPHP setups that need extra extensions.
+- [Web UI](web-ui.md) and [TUI](tui.md) — where the runtime badge appears.
+- [Environment setup](env-setup.md) — `.env` wiring is identical under both runtimes.

--- a/internal/certs/secure.go
+++ b/internal/certs/secure.go
@@ -22,6 +22,10 @@ func SecureSite(site config.Site) error {
 		if err := nginx.GenerateCustomSSLVhost(site); err != nil {
 			return fmt.Errorf("generating custom SSL vhost: %w", err)
 		}
+	} else if site.IsFrankenPHP() {
+		if err := nginx.GenerateFrankenPHPSSLVhost(site); err != nil {
+			return fmt.Errorf("generating FrankenPHP SSL vhost: %w", err)
+		}
 	} else if err := nginx.GenerateSSLVhost(site, site.PHPVersion); err != nil {
 		return fmt.Errorf("generating SSL vhost: %w", err)
 	}
@@ -56,6 +60,10 @@ func UnsecureSite(site config.Site) error {
 	if site.IsCustomContainer() {
 		if err := nginx.GenerateCustomVhost(site); err != nil {
 			return fmt.Errorf("generating custom HTTP vhost: %w", err)
+		}
+	} else if site.IsFrankenPHP() {
+		if err := nginx.GenerateFrankenPHPVhost(site); err != nil {
+			return fmt.Errorf("generating FrankenPHP HTTP vhost: %w", err)
 		}
 	} else if err := nginx.GenerateVhost(site, site.PHPVersion); err != nil {
 		return fmt.Errorf("generating HTTP vhost: %w", err)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -240,6 +240,21 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 			"check rootless podman / netavark / pasta routing; run: podman unshare --rootless-netns ip addr (expected: 169.254.1.2 on podman bridge or DNAT for it)")
 	}
 
+	// FrankenPHP suggestions: sites with signals but no runtime set get a one-line nudge.
+	if reg, err := config.LoadSites(); err == nil {
+		for _, site := range reg.Sites {
+			if site.Ignored || site.IsCustomContainer() || site.IsFrankenPHP() {
+				continue
+			}
+			hints := config.DetectFrankenPHPHints(site.Path)
+			if len(hints) == 0 {
+				continue
+			}
+			warn(fmt.Sprintf("site %s", site.Name),
+				fmt.Sprintf("%s; switch with: lerd runtime frankenphp", hints[0].Reason))
+		}
+	}
+
 	// ── Version Info ─────────────────────────────────────────────────────────
 	fmt.Println("\n[Version Info]")
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -207,6 +207,12 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 	nodeVersion := defaults.NodeVersion
 	secured := defaults.Secured
 
+	// FrankenPHP detection. If the project has signals we offer it as a
+	// choice in the wizard; default to whatever the existing config says.
+	frankenHints := config.DetectFrankenPHPHints(cwd)
+	useFrankenPHP := defaults.Runtime == "frankenphp"
+	useFrankenPHPWorker := defaults.RuntimeWorker
+
 	selectedWorkers := defaults.Workers
 	if len(selectedWorkers) == 0 {
 		selectedWorkers = []string{}
@@ -259,6 +265,23 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 	)
 
 	formGroups := []*huh.Group{huh.NewGroup(firstGroupFields...)}
+
+	if len(frankenHints) > 0 || useFrankenPHP {
+		reason := "Detected FrankenPHP signals in this project"
+		if len(frankenHints) > 0 {
+			reason = frankenHints[0].Reason
+		}
+		formGroups = append(formGroups, huh.NewGroup(
+			huh.NewConfirm().
+				Title("Use FrankenPHP runtime?").
+				Description(reason).
+				Value(&useFrankenPHP),
+			huh.NewConfirm().
+				Title("Enable worker mode?").
+				Description("Keeps PHP resident, ~10-50x faster requests, trades some dev ergonomics").
+				Value(&useFrankenPHPWorker),
+		))
+	}
 
 	if len(customWorkerNames) > 0 {
 		formGroups = append(formGroups, huh.NewGroup(
@@ -434,6 +457,13 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		}
 	}
 
+	runtime := ""
+	runtimeWorker := false
+	if useFrankenPHP {
+		runtime = "frankenphp"
+		runtimeWorker = useFrankenPHPWorker
+	}
+
 	return &config.ProjectConfig{
 		PHPVersion:       phpVersion,
 		NodeVersion:      nodeVersion,
@@ -446,6 +476,8 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		CustomWorkers:    filteredCustomWorkers,
 		AppURL:           defaults.AppURL,
 		Domains:          defaults.Domains,
+		Runtime:          runtime,
+		RuntimeWorker:    runtimeWorker,
 	}, nil
 }
 

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -199,11 +199,27 @@ func runLink(args []string) error {
 		PublicDir:   detectedPublicDir,
 	}
 
+	// Honour .lerd.yaml runtime selection (e.g. "frankenphp") so a re-link
+	// rehydrates the site with the committed runtime rather than resetting
+	// to FPM.
+	if proj != nil && proj.Runtime != "" {
+		site.Runtime = proj.Runtime
+		site.RuntimeWorker = proj.RuntimeWorker
+	}
+
 	if err := config.AddSite(site); err != nil {
 		return fmt.Errorf("registering site: %w", err)
 	}
 
 	_ = config.SyncProjectDomains(cwd, site.Domains, cfg.DNS.TLD)
+
+	if site.IsFrankenPHP() {
+		if err := siteops.FinishFrankenPHPLink(site); err != nil {
+			return err
+		}
+		fmt.Printf("Linked: %s -> %s (FrankenPHP, PHP %s, Node %s, Framework: %s)\n", name, strings.Join(domains, ", "), phpVersion, nodeVersion, framework)
+		return linkApplyServices(cwd, proj)
+	}
 
 	if err := siteops.FinishLink(site, phpVersion); err != nil {
 		return err

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -818,6 +818,14 @@ Restart the container for a site without rebuilding the image. Takes ` + bt + `s
 ### ` + bt + `site_rebuild` + bt + `
 Rebuild the custom container image from the Containerfile and restart the container. Takes ` + bt + `site` + bt + ` (required). Use after changing the Containerfile. ` + bt + `site_link` + bt + ` reuses the cached image; ` + bt + `site_rebuild` + bt + ` forces a fresh build. Only works for custom container sites.
 
+### ` + bt + `site_runtime` + bt + `
+Switch the PHP runtime for a site between the shared PHP-FPM container (` + bt + `fpm` + bt + `, default) and a per-site FrankenPHP container (` + bt + `frankenphp` + bt + `). Arguments:
+- ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
+- ` + bt + `runtime` + bt + ` (required): ` + bt + `fpm` + bt + ` or ` + bt + `frankenphp` + bt + `
+- ` + bt + `worker` + bt + ` (optional, default false): when runtime=frankenphp, enable worker mode (keeps PHP resident for ~10-50x faster requests)
+
+FrankenPHP is framework-aware: Laravel uses ` + bt + `octane:start --server=frankenphp --workers=auto` + bt + ` (needs pcntl, installed at container start); Symfony uses ` + bt + `frankenphp php-server --worker=public/index.php --watch` + bt + ` for live reload; unknown frameworks fall back to ` + bt + `frankenphp php-server` + bt + ` rooted at the framework's public dir. Switching to ` + bt + `fpm` + bt + ` removes the runtime fields from ` + bt + `.lerd.yaml` + bt + ` and regenerates the FPM vhost. Not supported on custom-container sites (their runtime comes from their Containerfile). Xdebug is not wired up for FrankenPHP; switch back to ` + bt + `fpm` + bt + ` to debug.
+
 ### ` + bt + `service_pin` + bt + ` / ` + bt + `service_unpin` + bt + `
 Pin or unpin a service. Both take ` + bt + `name` + bt + ` (required).
 
@@ -1015,6 +1023,13 @@ site_unpause(site: "old-project")  // restore and restart
 ` + "```" + `
 site_restart(site: "nestjs-app")  // restarts container (no rebuild)
 site_rebuild(site: "nestjs-app")  // rebuilds image from Containerfile + restarts
+` + "```" + `
+
+**Switch a site to FrankenPHP (per-site container, optional worker mode):**
+` + "```" + `
+site_runtime(site: "myapp", runtime: "frankenphp")                  // non-worker
+site_runtime(site: "myapp", runtime: "frankenphp", worker: true)    // worker mode
+site_runtime(site: "myapp", runtime: "fpm")                         // back to shared FPM
 ` + "```" + `
 
 **Keep a service always running regardless of active site:**
@@ -1257,6 +1272,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `site_unpause` + bt + ` | Resume a paused site: start container, restore vhost, restart workers |
 | ` + bt + `site_restart` + bt + ` | Restart a site's container (custom container or PHP-FPM) |
 | ` + bt + `site_rebuild` + bt + ` | Rebuild custom container image from Containerfile and restart |
+| ` + bt + `site_runtime` + bt + ` | Switch between shared PHP-FPM and per-site FrankenPHP runtime (supports worker mode) |
 | ` + bt + `service_pin` + bt + ` | Pin a service so it is never auto-stopped even when no sites reference it |
 | ` + bt + `service_unpin` + bt + ` | Unpin a service so it can be auto-stopped when unused |
 | ` + bt + `stripe_listen` + bt + ` | Start a Stripe webhook listener for a site |

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -71,6 +71,9 @@ func PauseSite(name string) error {
 	if site.IsCustomContainer() {
 		_ = podman.StopUnit(podman.CustomContainerName(site.Name))
 	}
+	if site.IsFrankenPHP() {
+		_ = podman.StopUnit(podman.FrankenPHPContainerName(site.Name))
+	}
 
 	if err := writePausedHTML(site); err != nil {
 		return fmt.Errorf("writing paused page: %w", err)
@@ -116,7 +119,8 @@ func UnpauseSite(name string) error {
 
 	phpVersion := site.PHPVersion
 
-	if site.IsCustomContainer() {
+	switch {
+	case site.IsCustomContainer():
 		// Start the custom container and restore the proxy vhost.
 		_ = podman.StartUnit(podman.CustomContainerName(site.Name))
 		if site.Secured {
@@ -134,7 +138,24 @@ func UnpauseSite(name string) error {
 				return fmt.Errorf("generating custom vhost: %w", err)
 			}
 		}
-	} else {
+	case site.IsFrankenPHP():
+		_ = podman.StartUnit(podman.FrankenPHPContainerName(site.Name))
+		if site.Secured {
+			if err := nginx.GenerateFrankenPHPSSLVhost(*site); err != nil {
+				return fmt.Errorf("generating FrankenPHP SSL vhost: %w", err)
+			}
+			sslConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
+			mainConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
+			_ = os.Remove(mainConf)
+			if err := os.Rename(sslConf, mainConf); err != nil {
+				return fmt.Errorf("installing SSL vhost: %w", err)
+			}
+		} else {
+			if err := nginx.GenerateFrankenPHPVhost(*site); err != nil {
+				return fmt.Errorf("generating FrankenPHP vhost: %w", err)
+			}
+		}
+	default:
 		if detected, err := phpDet.DetectVersion(site.Path); err == nil && detected != "" {
 			phpVersion = detected
 		}

--- a/internal/cli/restart.go
+++ b/internal/cli/restart.go
@@ -42,6 +42,15 @@ func RestartSite(name string) error {
 		return nil
 	}
 
+	if site.IsFrankenPHP() {
+		unit := podman.FrankenPHPContainerName(site.Name)
+		if err := podman.RestartUnit(unit); err != nil {
+			return fmt.Errorf("restarting FrankenPHP container: %w", err)
+		}
+		fmt.Printf("Restarted: %s (%s)\n", name, unit)
+		return nil
+	}
+
 	if site.PHPVersion == "" {
 		return fmt.Errorf("site %q has no PHP version set", name)
 	}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/nginx"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/siteops"
+	"github.com/spf13/cobra"
+)
+
+// NewRuntimeCmd returns the `lerd runtime` parent command.
+func NewRuntimeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runtime [fpm|frankenphp]",
+		Short: "Switch the PHP runtime for the current site (fpm or frankenphp)",
+		Long: `Switch the PHP runtime for the current site. Writes to .lerd.yaml so the
+choice is committed with the project.
+
+  lerd runtime                     # print the current runtime
+  lerd runtime frankenphp          # enable FrankenPHP (non-worker)
+  lerd runtime frankenphp --worker # enable FrankenPHP worker mode
+  lerd runtime fpm                 # back to shared PHP-FPM (clears .lerd.yaml)`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runRuntime,
+	}
+	cmd.Flags().Bool("worker", false, "Enable FrankenPHP worker mode")
+	cmd.Flags().Bool("no-worker", false, "Disable FrankenPHP worker mode")
+	return cmd
+}
+
+func runRuntime(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	site, err := config.FindSiteByPath(cwd)
+	if err != nil {
+		return fmt.Errorf("not a registered site — run 'lerd link' first")
+	}
+	if site.IsCustomContainer() {
+		return fmt.Errorf("site uses a custom Containerfile; the runtime is defined by your Containerfile.lerd")
+	}
+
+	if len(args) == 0 {
+		fmt.Printf("Runtime: %s\n", runtimeLabel(site))
+		return nil
+	}
+
+	target := args[0]
+	worker, _ := cmd.Flags().GetBool("worker")
+	noWorker, _ := cmd.Flags().GetBool("no-worker")
+
+	switch target {
+	case "fpm":
+		if !site.IsFrankenPHP() {
+			fmt.Println("Already on FPM runtime.")
+			return nil
+		}
+		return switchToFPM(site)
+	case "frankenphp":
+		fw, ok := config.GetFrameworkForDir(site.Framework, site.Path)
+		if !ok {
+			return fmt.Errorf("site has no framework assigned — FrankenPHP needs a framework entrypoint or the generic public/ fallback")
+		}
+		if fw.FrankenPHP == nil && fw.PublicDir == "" {
+			fmt.Println("[INFO] framework has no FrankenPHP adapter, falling back to the generic `frankenphp php-server` entrypoint")
+		}
+		wantWorker := site.RuntimeWorker
+		if worker {
+			wantWorker = true
+		}
+		if noWorker {
+			wantWorker = false
+		}
+		return switchToFrankenPHP(site, wantWorker)
+	default:
+		return fmt.Errorf("unknown runtime %q — use 'fpm' or 'frankenphp'", target)
+	}
+}
+
+func runtimeLabel(site *config.Site) string {
+	if site.IsFrankenPHP() {
+		if site.RuntimeWorker {
+			return "frankenphp (worker mode)"
+		}
+		return "frankenphp"
+	}
+	return "fpm"
+}
+
+func switchToFPM(site *config.Site) error {
+	_ = podman.StopUnit(podman.FrankenPHPContainerName(site.Name))
+	_ = podman.RemoveFrankenPHPQuadlet(site.Name)
+	_ = podman.DaemonReloadFn()
+
+	site.Runtime = ""
+	site.RuntimeWorker = false
+	if err := config.AddSite(*site); err != nil {
+		return fmt.Errorf("updating site: %w", err)
+	}
+	_ = config.SetProjectRuntime(site.Path, "", false)
+
+	if site.Secured {
+		if err := nginx.GenerateSSLVhost(*site, site.PHPVersion); err != nil {
+			return fmt.Errorf("regenerating SSL vhost: %w", err)
+		}
+	} else {
+		if err := nginx.GenerateVhost(*site, site.PHPVersion); err != nil {
+			return fmt.Errorf("regenerating vhost: %w", err)
+		}
+	}
+	_ = nginx.Reload()
+	fmt.Printf("Runtime: fpm (switched from FrankenPHP)\n")
+	return nil
+}
+
+func switchToFrankenPHP(site *config.Site, worker bool) error {
+	site.Runtime = "frankenphp"
+	site.RuntimeWorker = worker
+	if err := config.AddSite(*site); err != nil {
+		return fmt.Errorf("updating site: %w", err)
+	}
+	_ = config.SetProjectRuntime(site.Path, "frankenphp", worker)
+
+	if err := siteops.FinishFrankenPHPLink(*site); err != nil {
+		return err
+	}
+	label := "frankenphp"
+	if worker {
+		label = "frankenphp (worker mode)"
+	}
+	fmt.Printf("Runtime: %s\n", label)
+	return nil
+}

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -203,8 +203,8 @@ func coreUnits() []string {
 }
 
 // installedCustomContainerUnits returns units for per-project custom containers
-// that have a unit file installed (plist on macOS, quadlet on Linux).
-// These are started alongside FPM and services.
+// and per-site FrankenPHP containers that have a unit file installed (plist on
+// macOS, quadlet on Linux). These are started alongside FPM and services.
 func installedCustomContainerUnits() []string {
 	var units []string
 	reg, err := config.LoadSites()
@@ -212,10 +212,18 @@ func installedCustomContainerUnits() []string {
 		return nil
 	}
 	for _, site := range reg.Sites {
-		if !site.IsCustomContainer() || site.Paused {
+		if site.Paused {
 			continue
 		}
-		unitName := podman.CustomContainerName(site.Name)
+		var unitName string
+		switch {
+		case site.IsCustomContainer():
+			unitName = podman.CustomContainerName(site.Name)
+		case site.IsFrankenPHP():
+			unitName = podman.FrankenPHPContainerName(site.Name)
+		default:
+			continue
+		}
 		// Use the platform-aware check (plist on macOS, .container quadlet on Linux)
 		// rather than podman.QuadletInstalled which only checks for .container files
 		// and always returns false on macOS where plists are used instead.

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -228,11 +228,17 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 		command = command + " --port=" + port
 	}
 
-	// For custom container sites, exec into the custom container instead of FPM.
+	// Workers exec into the container that hosts the site's runtime:
+	//   - custom container sites → lerd-custom-<site>
+	//   - FrankenPHP sites       → lerd-fp-<site>
+	//   - shared FPM sites       → lerd-php<version>-fpm
 	var fpmUnit string
-	if site, _ := config.FindSite(siteName); site != nil && site.IsCustomContainer() {
+	switch site, _ := config.FindSite(siteName); {
+	case site != nil && site.IsCustomContainer():
 		fpmUnit = podman.CustomContainerName(siteName)
-	} else {
+	case site != nil && site.IsFrankenPHP():
+		fpmUnit = podman.FrankenPHPContainerName(siteName)
+	default:
 		versionShort := strings.ReplaceAll(phpVersion, ".", "")
 		fpmUnit = "lerd-php" + versionShort + "-fpm"
 	}

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -68,6 +68,7 @@ BindsTo=%s.service
 Type=simple
 Restart=%s
 RestartSec=5
+SuccessExitStatus=1 130 143
 ExecStart=%s exec -w %s %s %s
 
 [Install]

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -55,6 +55,32 @@ type Framework struct {
 	// When set, detectFavicon checks this path in addition to the standard candidates.
 	// Example: "core/misc/favicon.ico" for Drupal.
 	Favicon string `yaml:"favicon,omitempty"`
+	// FrankenPHP, when set, tells lerd how to start a FrankenPHP container
+	// for this framework. When absent, lerd falls back to the generic
+	// `frankenphp php-server -r <public>/` entrypoint.
+	FrankenPHP *FrameworkFrankenPHP `yaml:"frankenphp,omitempty"`
+}
+
+// FrameworkFrankenPHP describes how to serve the framework via FrankenPHP.
+// Entrypoints are shell-quoted strings executed inside the container; the
+// working directory is the project root mounted at the same path as the host.
+type FrameworkFrankenPHP struct {
+	// Entrypoint is the command to run when the site is served in normal
+	// (non-worker) FrankenPHP mode. Example: ["php","artisan","octane:start",
+	// "--server=frankenphp","--host=0.0.0.0","--port=8000"].
+	Entrypoint []string `yaml:"entrypoint,omitempty"`
+	// WorkerEntrypoint, when set and the site opts into worker mode, is used
+	// instead of Entrypoint. When SupportsWorker is false the flag is ignored.
+	WorkerEntrypoint []string `yaml:"worker_entrypoint,omitempty"`
+	// SupportsWorker declares whether the framework ships a FrankenPHP worker
+	// script. If false, `--worker` is a no-op and the regular entrypoint is used.
+	SupportsWorker bool `yaml:"supports_worker,omitempty"`
+	// Env is the list of environment variables to set in the container in
+	// normal mode (appended to the defaults lerd always sets).
+	Env map[string]string `yaml:"env,omitempty"`
+	// WorkerEnv, when the site opts into worker mode, is merged on top of Env.
+	// Example for Symfony: {"FRANKENPHP_CONFIG": "worker ./public/index.php"}.
+	WorkerEnv map[string]string `yaml:"worker_env,omitempty"`
 }
 
 // FrameworkWorker describes a long-running process managed as a systemd service.
@@ -325,6 +351,89 @@ var laravelFramework = &Framework{
 	Logs: []FrameworkLogSource{
 		{Path: "storage/logs/*.log", Format: "monolog"},
 	},
+	FrankenPHP: &FrameworkFrankenPHP{
+		// Non-worker serves via plain frankenphp php-server so code edits take effect
+		// immediately (fresh request lifecycle), same UX as FPM.
+		Entrypoint: []string{"frankenphp", "php-server", "-l", ":8000", "-r", "public/"},
+		// Worker runs Octane; pcntl is installed at boot since dunglas/frankenphp
+		// doesn't ship it. Code edits need `lerd restart` until we add --watch.
+		WorkerEntrypoint: []string{"sh", "-c",
+			`install-php-extensions pcntl >/dev/null && ` +
+				`exec php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=8000 --workers=auto`},
+		SupportsWorker: true,
+	},
+}
+
+// symfonyFramework is a built-in Symfony adapter. It detects Symfony via
+// `symfony/runtime` or `symfony/framework-bundle` in composer.json and wires
+// `bin/console messenger:consume`/`schedule:run` as workers. FrankenPHP support
+// uses the `runtime/frankenphp` adapter; worker mode opts into the same entrypoint
+// (Symfony's runtime picks up FRANKENPHP_CONFIG=worker).
+var symfonyFramework = &Framework{
+	Name:      "symfony",
+	Label:     "Symfony",
+	PublicDir: "public",
+	Create:    "composer create-project --no-install --no-plugins --no-scripts symfony/skeleton",
+	Detect: []FrameworkRule{
+		{File: "symfony.lock"},
+		{Composer: "symfony/runtime"},
+		{Composer: "symfony/framework-bundle"},
+	},
+	Env: FrameworkEnvConf{
+		File:        ".env",
+		ExampleFile: ".env.example",
+		Format:      "dotenv",
+		Services: map[string]FrameworkServiceDef{
+			"mysql": {
+				Detect: []FrameworkServiceDetect{{Key: "DATABASE_URL", ValuePrefix: "mysql"}},
+				Vars:   []string{"DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/{{site}}?serverVersion=8.0"},
+			},
+			"postgres": {
+				Detect: []FrameworkServiceDetect{{Key: "DATABASE_URL", ValuePrefix: "postgres"}, {Key: "DATABASE_URL", ValuePrefix: "pgsql"}},
+				Vars:   []string{"DATABASE_URL=postgresql://postgres:lerd@lerd-postgres:5432/{{site}}?serverVersion=16"},
+			},
+			"redis": {
+				Detect: []FrameworkServiceDetect{{Key: "REDIS_URL"}, {Key: "MESSENGER_TRANSPORT_DSN", ValuePrefix: "redis"}},
+				Vars:   []string{"REDIS_URL=redis://lerd-redis:6379"},
+			},
+			"mailpit": {
+				Detect: []FrameworkServiceDetect{{Key: "MAILER_DSN"}},
+				Vars:   []string{"MAILER_DSN=smtp://lerd-mailpit:1025"},
+			},
+		},
+	},
+	Composer: "auto",
+	NPM:      "auto",
+	Console:  "bin/console",
+	Workers: map[string]FrameworkWorker{
+		"messenger": {
+			Label:   "Messenger Consumer",
+			Command: "php bin/console messenger:consume async --time-limit=3600",
+			Restart: "always",
+			Check:   &FrameworkRule{Composer: "symfony/messenger"},
+		},
+		"scheduler": {
+			Label:   "Scheduler",
+			Command: "php bin/console messenger:consume scheduler_default",
+			Restart: "always",
+			Check:   &FrameworkRule{Composer: "symfony/scheduler"},
+		},
+	},
+	Setup: []FrameworkSetupCmd{
+		{Label: "php bin/console doctrine:migrations:migrate --no-interaction", Command: "php bin/console doctrine:migrations:migrate --no-interaction", Default: true, Check: &FrameworkRule{Composer: "doctrine/doctrine-migrations-bundle"}},
+	},
+	Logs: []FrameworkLogSource{
+		{Path: "var/log/*.log", Format: "monolog"},
+	},
+	FrankenPHP: &FrameworkFrankenPHP{
+		Entrypoint: []string{"frankenphp", "php-server", "-l", ":8000", "-r", "public/"},
+		// --watch reloads the worker on PHP/env/yaml/twig changes, no restart needed.
+		WorkerEntrypoint: []string{
+			"frankenphp", "php-server", "-l", ":8000", "-r", "public/",
+			"--worker=public/index.php", "--watch",
+		},
+		SupportsWorker: true,
+	},
 }
 
 // GetFramework returns the framework definition for the given name.
@@ -348,21 +457,15 @@ func GetFramework(name string) (*Framework, bool) {
 	}
 
 	// Merge user overlay (if any) on top of the base.
-	return mergeUserOverlay(base), true
+	return mergeBuiltinFrankenPHP(mergeUserOverlay(base)), true
 }
 
 // loadBaseFramework returns the base definition for a framework:
-// built-in for "laravel", then store-installed (versioned > unversioned).
+// built-in for "laravel" and "symfony", then store-installed (versioned >
+// unversioned).
 func loadBaseFramework(name string) *Framework {
-	if name == "laravel" {
-		// Copy built-in so callers don't mutate the global.
-		fw := *laravelFramework
-		workers := make(map[string]FrameworkWorker, len(laravelFramework.Workers))
-		for k, v := range laravelFramework.Workers {
-			workers[k] = v
-		}
-		fw.Workers = workers
-		return &fw
+	if builtin := copyBuiltin(name); builtin != nil {
+		return builtin
 	}
 
 	// Store-installed: unversioned first (backwards compat), then versioned.
@@ -370,6 +473,51 @@ func loadBaseFramework(name string) *Framework {
 		return fw
 	}
 	return loadBestVersionedFramework(name, "")
+}
+
+// copyBuiltin returns a deep-enough copy of a built-in framework so callers
+// can safely merge overlays without mutating the package-level global.
+func copyBuiltin(name string) *Framework {
+	src := builtinFramework(name)
+	if src == nil {
+		return nil
+	}
+	fw := *src
+	workers := make(map[string]FrameworkWorker, len(src.Workers))
+	for k, v := range src.Workers {
+		workers[k] = v
+	}
+	fw.Workers = workers
+	return &fw
+}
+
+// builtinFramework returns the package-level Framework for a known built-in
+// name, or nil if the name is not built in.
+func builtinFramework(name string) *Framework {
+	switch name {
+	case "laravel":
+		return laravelFramework
+	case "symfony":
+		return symfonyFramework
+	}
+	return nil
+}
+
+// mergeBuiltinFrankenPHP backfills the FrankenPHP adapter from a built-in when
+// a store- or user-provided definition doesn't ship one. This keeps existing
+// store yamls for Laravel/Symfony working without needing a store update to
+// pick up FrankenPHP support.
+func mergeBuiltinFrankenPHP(fw *Framework) *Framework {
+	if fw == nil || fw.FrankenPHP != nil {
+		return fw
+	}
+	src := builtinFramework(fw.Name)
+	if src == nil || src.FrankenPHP == nil {
+		return fw
+	}
+	cp := *src.FrankenPHP
+	fw.FrankenPHP = &cp
+	return fw
 }
 
 // mergeUserOverlay checks for a user-defined overlay file in FrameworksDir()
@@ -461,11 +609,12 @@ func GetFrameworkForDir(name, projectDir string) (*Framework, bool) {
 
 	if base != nil {
 		base = mergeUserOverlay(base)
+		base = mergeBuiltinFrankenPHP(base)
 		return mergeProjectWorkers(base, projectDir), true
 	}
 
-	// 4. For Laravel, fall back to the built-in definition.
-	if name == "laravel" {
+	// 4. For built-ins (Laravel, Symfony), fall back to the built-in definition.
+	if builtinFramework(name) != nil {
 		fw, ok := GetFramework(name)
 		if ok {
 			return mergeProjectWorkers(fw, projectDir), true
@@ -503,7 +652,7 @@ func mergeProjectWorkers(fw *Framework, projectDir string) *Framework {
 // Returns SourceBuiltIn for "laravel", SourceUser if a user-defined file exists,
 // SourceStore if a store-installed file exists, or "" if not found.
 func GetFrameworkSource(name string) FrameworkSource {
-	if name == "laravel" {
+	if builtinFramework(name) != nil {
 		return SourceBuiltIn
 	}
 	if loadFrameworkYAML(filepath.Join(FrameworksDir(), name+".yaml")) != nil {
@@ -636,9 +785,11 @@ func DetectFramework(dir string) (string, bool) {
 		}
 	}
 
-	// Built-in Laravel as fallback.
-	if !seen["laravel"] && matchesFramework(dir, laravelFramework) {
-		matches = append(matches, "laravel")
+	// Built-in Laravel and Symfony as fallbacks.
+	for _, fw := range builtinFrameworks() {
+		if !seen[fw.Name] && matchesFramework(dir, fw) {
+			matches = append(matches, fw.Name)
+		}
 	}
 
 	if len(matches) == 0 {
@@ -657,11 +808,19 @@ func DetectFramework(dir string) (string, bool) {
 	return matches[0], true
 }
 
+// builtinFrameworks returns all built-in Framework pointers in a stable order.
+func builtinFrameworks() []*Framework {
+	return []*Framework{laravelFramework, symfonyFramework}
+}
+
 // ListFrameworks returns all available framework definitions:
-// the laravel built-in plus any user-defined YAMLs in FrameworksDir().
+// the built-in frameworks plus any user-defined YAMLs in FrameworksDir().
 func ListFrameworks() []*Framework {
-	result := []*Framework{laravelFramework}
-	seen := map[string]bool{"laravel": true}
+	result := builtinFrameworks()
+	seen := map[string]bool{}
+	for _, fw := range result {
+		seen[fw.Name] = true
+	}
 
 	// User-defined first (unversioned), then store-installed.
 	// For store, include both <name>.yaml and <name>@<version>.yaml.
@@ -736,9 +895,15 @@ func ListFrameworksDetailed() []FrameworkInfo {
 			result = append(result, FrameworkInfo{Framework: fw, Source: SourceBuiltIn})
 		}
 	}
+	// Built-in Symfony.
+	if !seenNameVersion[key("symfony", "")] {
+		if fw, ok := GetFramework("symfony"); ok {
+			result = append(result, FrameworkInfo{Framework: fw, Source: SourceBuiltIn})
+		}
+	}
 
 	// User-only (skip if a store version for the same name already listed).
-	seenName := map[string]bool{"laravel": true}
+	seenName := map[string]bool{"laravel": true, "symfony": true}
 	for _, info := range result {
 		seenName[info.Name] = true
 	}
@@ -882,6 +1047,44 @@ func RemoveFramework(name string) error {
 		os.Remove(f.Path) //nolint:errcheck
 	}
 	return nil
+}
+
+// FrankenPHPEntrypoint returns the argv to launch inside the FrankenPHP
+// container for this framework, preferring the worker entrypoint when worker
+// mode is requested and the framework declares support. A generic fallback
+// uses `frankenphp php-server` rooted at the framework's PublicDir.
+func (fw *Framework) FrankenPHPEntrypoint(worker bool) []string {
+	if fw != nil && fw.FrankenPHP != nil {
+		if worker && fw.FrankenPHP.SupportsWorker && len(fw.FrankenPHP.WorkerEntrypoint) > 0 {
+			return fw.FrankenPHP.WorkerEntrypoint
+		}
+		if len(fw.FrankenPHP.Entrypoint) > 0 {
+			return fw.FrankenPHP.Entrypoint
+		}
+	}
+	root := "public"
+	if fw != nil && fw.PublicDir != "" {
+		root = fw.PublicDir
+	}
+	return []string{"frankenphp", "php-server", "-l", ":8000", "-r", root}
+}
+
+// FrankenPHPEnv returns the environment variables to set in the FrankenPHP
+// container, merging WorkerEnv on top of Env when worker mode is requested.
+func (fw *Framework) FrankenPHPEnv(worker bool) map[string]string {
+	out := make(map[string]string)
+	if fw == nil || fw.FrankenPHP == nil {
+		return out
+	}
+	for k, v := range fw.FrankenPHP.Env {
+		out[k] = v
+	}
+	if worker && fw.FrankenPHP.SupportsWorker {
+		for k, v := range fw.FrankenPHP.WorkerEnv {
+			out[k] = v
+		}
+	}
+	return out
 }
 
 // HasWorker returns true if the framework defines a worker with the given name

--- a/internal/config/frankenphp_detect.go
+++ b/internal/config/frankenphp_detect.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FrankenPHPHint describes one reason a project looks like it's set up for
+// FrankenPHP. Multiple hints can be present at once.
+type FrankenPHPHint struct {
+	// Signal is a short machine-readable tag: "laravel-octane-franken",
+	// "symfony-runtime", "runtime-frankenphp", "containerfile", "caddyfile".
+	Signal string
+	// Reason is a one-line human-readable explanation.
+	Reason string
+}
+
+// DetectFrankenPHPHints inspects a project directory for signals that it is
+// intended to run under FrankenPHP. It never returns an error; an unreadable
+// composer.json or missing file simply produces no hints for that signal.
+// Hints are ordered by confidence (most specific first).
+func DetectFrankenPHPHints(dir string) []FrankenPHPHint {
+	if dir == "" {
+		return nil
+	}
+	var hints []FrankenPHPHint
+
+	hasOctane := ComposerHasPackage(dir, "laravel/octane")
+	hasSymfonyRuntime := ComposerHasPackage(dir, "runtime/frankenphp-symfony")
+	hasRuntimeFranken := ComposerHasPackage(dir, "runtime/frankenphp")
+
+	if hasOctane {
+		if server := envValue(dir, "OCTANE_SERVER"); strings.EqualFold(server, "frankenphp") {
+			hints = append(hints, FrankenPHPHint{
+				Signal: "laravel-octane-franken",
+				Reason: "laravel/octane is installed and OCTANE_SERVER=frankenphp in .env",
+			})
+		}
+	}
+	if hasSymfonyRuntime {
+		hints = append(hints, FrankenPHPHint{
+			Signal: "symfony-runtime",
+			Reason: "runtime/frankenphp-symfony is installed in composer.json",
+		})
+	}
+	if hasRuntimeFranken && !hasSymfonyRuntime {
+		hints = append(hints, FrankenPHPHint{
+			Signal: "runtime-frankenphp",
+			Reason: "runtime/frankenphp is installed in composer.json",
+		})
+	}
+	if fromsFrankenPHP(dir) {
+		hints = append(hints, FrankenPHPHint{
+			Signal: "containerfile",
+			Reason: "Containerfile.lerd FROMs dunglas/frankenphp",
+		})
+	}
+
+	return hints
+}
+
+// envValue reads a single KEY from the project's .env. Returns "" when the
+// file, the key, or the value is missing. No expansion, no quoting.
+func envValue(dir, key string) string {
+	data, err := os.ReadFile(filepath.Join(dir, ".env"))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq <= 0 {
+			continue
+		}
+		if strings.TrimSpace(line[:eq]) == key {
+			v := strings.TrimSpace(line[eq+1:])
+			v = strings.Trim(v, `"'`)
+			return v
+		}
+	}
+	return ""
+}
+
+// fromsFrankenPHP returns true when the project's Containerfile.lerd starts
+// from a dunglas/frankenphp image.
+func fromsFrankenPHP(dir string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "Containerfile.lerd"))
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(strings.ToUpper(line), "FROM ") {
+			continue
+		}
+		return strings.Contains(strings.ToLower(line), "dunglas/frankenphp")
+	}
+	return false
+}

--- a/internal/config/frankenphp_detect_test.go
+++ b/internal/config/frankenphp_detect_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectFrankenPHPHintsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if got := DetectFrankenPHPHints(dir); len(got) != 0 {
+		t.Fatalf("empty dir should yield no hints, got %v", got)
+	}
+}
+
+func TestDetectFrankenPHPHintsLaravelOctane(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "composer.json", `{"require":{"laravel/octane":"^2.0"}}`)
+	write(t, dir, ".env", "APP_ENV=local\nOCTANE_SERVER=frankenphp\n")
+	hints := DetectFrankenPHPHints(dir)
+	if len(hints) != 1 || hints[0].Signal != "laravel-octane-franken" {
+		t.Fatalf("want laravel-octane-franken, got %+v", hints)
+	}
+}
+
+func TestDetectFrankenPHPHintsLaravelOctaneSwapped(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "composer.json", `{"require":{"laravel/octane":"^2.0"}}`)
+	write(t, dir, ".env", "OCTANE_SERVER=swoole\n")
+	if got := DetectFrankenPHPHints(dir); len(got) != 0 {
+		t.Fatalf("octane with swoole should not flag frankenphp, got %+v", got)
+	}
+}
+
+func TestDetectFrankenPHPHintsSymfonyRuntime(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "composer.json", `{"require":{"runtime/frankenphp-symfony":"^1.0","runtime/frankenphp":"^1.0"}}`)
+	hints := DetectFrankenPHPHints(dir)
+	if len(hints) != 1 || hints[0].Signal != "symfony-runtime" {
+		t.Fatalf("symfony runtime should dedupe runtime-frankenphp, got %+v", hints)
+	}
+}
+
+func TestDetectFrankenPHPHintsContainerfile(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "Containerfile.lerd", "FROM dunglas/frankenphp:php8.4-alpine\n")
+	hints := DetectFrankenPHPHints(dir)
+	if len(hints) != 1 || hints[0].Signal != "containerfile" {
+		t.Fatalf("containerfile signal missing: %+v", hints)
+	}
+}
+
+func write(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/config/frankenphp_test.go
+++ b/internal/config/frankenphp_test.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFrameworkFrankenPHPEntrypoint(t *testing.T) {
+	// Framework with full declaration.
+	fw := &Framework{
+		PublicDir: "public",
+		FrankenPHP: &FrameworkFrankenPHP{
+			Entrypoint:       []string{"php", "artisan", "serve"},
+			WorkerEntrypoint: []string{"php", "artisan", "serve", "--worker"},
+			SupportsWorker:   true,
+		},
+	}
+	if got := fw.FrankenPHPEntrypoint(false); !reflect.DeepEqual(got, []string{"php", "artisan", "serve"}) {
+		t.Fatalf("regular entrypoint: got %v", got)
+	}
+	if got := fw.FrankenPHPEntrypoint(true); !reflect.DeepEqual(got, []string{"php", "artisan", "serve", "--worker"}) {
+		t.Fatalf("worker entrypoint: got %v", got)
+	}
+
+	// Framework without worker support: worker flag falls back to regular.
+	noWorker := &Framework{
+		FrankenPHP: &FrameworkFrankenPHP{
+			Entrypoint:     []string{"frankenphp", "php-server"},
+			SupportsWorker: false,
+		},
+	}
+	if got := noWorker.FrankenPHPEntrypoint(true); !reflect.DeepEqual(got, []string{"frankenphp", "php-server"}) {
+		t.Fatalf("no-worker fallback: got %v", got)
+	}
+
+	// Framework with no FrankenPHP declaration: generic fallback rooted at PublicDir.
+	generic := &Framework{PublicDir: "web"}
+	wantGeneric := []string{"frankenphp", "php-server", "-l", ":8000", "-r", "web"}
+	if got := generic.FrankenPHPEntrypoint(false); !reflect.DeepEqual(got, wantGeneric) {
+		t.Fatalf("generic fallback: want %v, got %v", wantGeneric, got)
+	}
+}
+
+func TestFrameworkFrankenPHPEnvMerging(t *testing.T) {
+	fw := &Framework{
+		FrankenPHP: &FrameworkFrankenPHP{
+			Env:            map[string]string{"APP_ENV": "prod"},
+			WorkerEnv:      map[string]string{"FRANKENPHP_CONFIG": "worker ./public/index.php", "APP_ENV": "worker"},
+			SupportsWorker: true,
+		},
+	}
+	regular := fw.FrankenPHPEnv(false)
+	if regular["APP_ENV"] != "prod" || len(regular) != 1 {
+		t.Fatalf("regular env: got %v", regular)
+	}
+	worker := fw.FrankenPHPEnv(true)
+	if worker["APP_ENV"] != "worker" {
+		t.Errorf("worker env APP_ENV: got %s", worker["APP_ENV"])
+	}
+	if worker["FRANKENPHP_CONFIG"] != "worker ./public/index.php" {
+		t.Errorf("worker env FRANKENPHP_CONFIG: got %s", worker["FRANKENPHP_CONFIG"])
+	}
+}
+
+func TestSymfonyFrameworkIsBuiltIn(t *testing.T) {
+	if GetFrameworkSource("symfony") != SourceBuiltIn {
+		t.Fatalf("symfony source: want built-in, got %s", GetFrameworkSource("symfony"))
+	}
+	fw, ok := GetFramework("symfony")
+	if !ok {
+		t.Fatal("GetFramework symfony: not found")
+	}
+	if fw.Name != "symfony" {
+		t.Fatalf("symfony name: got %s", fw.Name)
+	}
+	if fw.FrankenPHP == nil {
+		t.Fatal("symfony framework missing FrankenPHP adapter")
+	}
+}
+
+func TestSymfonyBuiltinMatchesRuntimePackage(t *testing.T) {
+	dir := t.TempDir()
+	composer := `{"require":{"symfony/runtime":"^7.0"}}`
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fw := copyBuiltin("symfony")
+	if fw == nil {
+		t.Fatal("copyBuiltin(symfony) nil")
+	}
+	if !matchesFramework(dir, fw) {
+		t.Fatal("symfony built-in should match composer.json with symfony/runtime")
+	}
+}
+
+func TestSymfonyBuiltinMatchesLockFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "symfony.lock"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fw := copyBuiltin("symfony")
+	if !matchesFramework(dir, fw) {
+		t.Fatal("symfony built-in should match symfony.lock")
+	}
+}
+
+func TestLaravelOctaneFrankenPHPAdapter(t *testing.T) {
+	fw, ok := GetFramework("laravel")
+	if !ok {
+		t.Fatal("GetFramework laravel: not found")
+	}
+	if fw.FrankenPHP == nil {
+		t.Fatal("laravel has no FrankenPHP adapter")
+	}
+	// Non-worker falls back to plain frankenphp php-server for dev ergonomics.
+	if e := fw.FrankenPHPEntrypoint(false); !strings.Contains(strings.Join(e, " "), "frankenphp php-server") {
+		t.Fatalf("laravel non-worker should use frankenphp php-server: %v", e)
+	}
+	// Worker mode runs Octane (wrapped in sh -c so pcntl is installed at boot).
+	worker := strings.Join(fw.FrankenPHPEntrypoint(true), " ")
+	if !strings.Contains(worker, "octane:start") || !strings.Contains(worker, "frankenphp") {
+		t.Fatalf("laravel worker should use Octane: %s", worker)
+	}
+}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -46,6 +46,14 @@ type ProjectConfig struct {
 	AppURL    string           `yaml:"app_url,omitempty"`
 	DB        ProjectDB        `yaml:"db,omitempty"`
 	Container *ContainerConfig `yaml:"container,omitempty"`
+	// Runtime selects how the site's PHP is served. "fpm" (default) uses the
+	// shared lerd-php{version}-fpm container; "frankenphp" spins up a
+	// per-site dunglas/frankenphp container that keeps PHP resident.
+	Runtime string `yaml:"runtime,omitempty"`
+	// RuntimeWorker, when true and Runtime is "frankenphp", starts the
+	// FrankenPHP container in worker mode. Framework-specific entrypoints
+	// decide whether this flag is honoured.
+	RuntimeWorker bool `yaml:"runtime_worker,omitempty"`
 }
 
 // IsEmpty returns true when the config has no meaningful content, which
@@ -54,7 +62,8 @@ func (c *ProjectConfig) IsEmpty() bool {
 	return len(c.Domains) == 0 && c.PHPVersion == "" && c.NodeVersion == "" &&
 		c.Framework == "" && len(c.Services) == 0 && len(c.Workers) == 0 &&
 		len(c.CustomWorkers) == 0 && !c.Secured && c.AppURL == "" &&
-		c.DB.Service == "" && c.DB.Database == "" && c.Container == nil
+		c.DB.Service == "" && c.DB.Database == "" && c.Container == nil &&
+		c.Runtime == "" && !c.RuntimeWorker
 }
 
 // ServiceNames returns the name of every service in the config, for callers

--- a/internal/config/project_update.go
+++ b/internal/config/project_update.go
@@ -105,6 +105,15 @@ func RemoveProjectDomain(dir string, domain string) error {
 	})
 }
 
+// SetProjectRuntime updates runtime and runtime_worker. No-op if .lerd.yaml
+// does not exist. Passing an empty runtime clears both fields.
+func SetProjectRuntime(dir, runtime string, worker bool) error {
+	return updateProjectConfig(dir, func(cfg *ProjectConfig) {
+		cfg.Runtime = runtime
+		cfg.RuntimeWorker = worker && runtime != ""
+	})
+}
+
 // SetProjectFrameworkVersion updates framework_version. No-op if .lerd.yaml
 // does not exist or the version hasn't changed.
 func SetProjectFrameworkVersion(dir string, version string) error {

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSetProjectRuntimeRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	yaml := "domains:\n  - myapp\n"
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetProjectRuntime(dir, "frankenphp", true); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Runtime != "frankenphp" {
+		t.Fatalf("Runtime: want frankenphp, got %s", cfg.Runtime)
+	}
+	if !cfg.RuntimeWorker {
+		t.Fatalf("RuntimeWorker: want true, got false")
+	}
+	// Clear runtime → worker flag should also go false.
+	if err := SetProjectRuntime(dir, "", true); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Runtime != "" || cfg.RuntimeWorker {
+		t.Fatalf("cleared runtime: got %+v", cfg)
+	}
+}
+
+func TestSiteIsFrankenPHP(t *testing.T) {
+	s := Site{Runtime: "frankenphp"}
+	if !s.IsFrankenPHP() {
+		t.Fatal("IsFrankenPHP: want true for runtime=frankenphp")
+	}
+	if s.IsCustomContainer() {
+		t.Fatal("IsCustomContainer: want false for FrankenPHP site")
+	}
+	plain := Site{}
+	if plain.IsFrankenPHP() {
+		t.Fatal("IsFrankenPHP: want false for empty site")
+	}
+}

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -38,12 +38,24 @@ type Site struct {
 	// ContainerSSL, when true, means the app inside the custom container serves
 	// TLS on its port; nginx will proxy_pass via HTTPS with ssl_verify off.
 	ContainerSSL bool `yaml:"container_ssl,omitempty"`
+	// Runtime is "fpm" (default) or "frankenphp". When "frankenphp" the site
+	// runs a per-site dunglas/frankenphp:php<version> container and nginx
+	// reverse-proxies to it on port 8000.
+	Runtime string `yaml:"runtime,omitempty"`
+	// RuntimeWorker toggles FrankenPHP worker mode when Runtime=="frankenphp".
+	RuntimeWorker bool `yaml:"runtime_worker,omitempty"`
 }
 
 // IsCustomContainer returns true when the site uses a per-project custom
 // container instead of the shared PHP-FPM image.
 func (s *Site) IsCustomContainer() bool {
 	return s.ContainerPort > 0
+}
+
+// IsFrankenPHP returns true when the site is served by a per-site
+// dunglas/frankenphp container instead of the shared PHP-FPM image.
+func (s *Site) IsFrankenPHP() bool {
+	return s.Runtime == "frankenphp"
 }
 
 // PrimaryDomain returns the first (primary) domain for the site.
@@ -83,6 +95,8 @@ type siteYAML struct {
 	LANPort       int      `yaml:"lan_port,omitempty"`
 	ContainerPort int      `yaml:"container_port,omitempty"`
 	ContainerSSL  bool     `yaml:"container_ssl,omitempty"`
+	Runtime       string   `yaml:"runtime,omitempty"`
+	RuntimeWorker bool     `yaml:"runtime_worker,omitempty"`
 }
 
 func (s Site) toYAML() siteYAML {
@@ -102,6 +116,8 @@ func (s Site) toYAML() siteYAML {
 		LANPort:       s.LANPort,
 		ContainerPort: s.ContainerPort,
 		ContainerSSL:  s.ContainerSSL,
+		Runtime:       s.Runtime,
+		RuntimeWorker: s.RuntimeWorker,
 	}
 }
 
@@ -126,6 +142,8 @@ func (sy siteYAML) toSite() Site {
 		LANPort:       sy.LANPort,
 		ContainerPort: sy.ContainerPort,
 		ContainerSSL:  sy.ContainerSSL,
+		Runtime:       sy.Runtime,
+		RuntimeWorker: sy.RuntimeWorker,
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1387,6 +1387,29 @@ func toolList() []mcpTool {
 			},
 		},
 		mcpTool{
+			Name:        "site_runtime",
+			Description: "Switch the PHP runtime for a site. `fpm` (default) uses the shared PHP-FPM container; `frankenphp` spins up a per-site dunglas/frankenphp container that keeps PHP resident. Worker mode is framework-aware: Laravel uses octane:start --workers=auto, Symfony uses frankenphp's --worker flag + --watch for live reload. Falls back to generic `frankenphp php-server` when the framework has no adapter.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"site": {
+						Type:        "string",
+						Description: "Site name as shown by the sites tool",
+					},
+					"runtime": {
+						Type:        "string",
+						Enum:        []string{"fpm", "frankenphp"},
+						Description: "Target runtime: 'fpm' or 'frankenphp'",
+					},
+					"worker": {
+						Type:        "boolean",
+						Description: "When runtime=frankenphp, enable worker mode (PHP stays resident, faster but needs file-watch for dev). Ignored for fpm.",
+					},
+				},
+				Required: []string{"site", "runtime"},
+			},
+		},
+		mcpTool{
 			Name:        "service_pin",
 			Description: "Pin a service so it is never auto-stopped, even when no sites reference it. Starts the service if it is not already running.",
 			InputSchema: mcpSchema{
@@ -1565,6 +1588,8 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execSiteRestart(args)
 	case "site_rebuild":
 		return execSiteRebuild(args)
+	case "site_runtime":
+		return execSiteRuntime(args)
 	case "service_pin":
 		return execServicePin(args)
 	case "service_unpin":
@@ -4552,17 +4577,27 @@ func execSitePHP(args map[string]any) (any, *rpcError) {
 	}
 	_ = config.SetProjectPHPVersion(site.Path, version)
 
+	// Update the site registry so later steps see the new version.
+	site.PHPVersion = version
+	if err := config.AddSite(*site); err != nil {
+		return toolErr("updating site registry: " + err.Error()), nil
+	}
+
+	// FrankenPHP sites get a different image per PHP version; rewrite the
+	// per-site quadlet (with restart-on-change) via the shared link helper
+	// instead of touching FPM state or the FPM vhost.
+	if site.IsFrankenPHP() {
+		if err := siteops.FinishFrankenPHPLink(*site); err != nil {
+			return toolErr("re-linking FrankenPHP site: " + err.Error()), nil
+		}
+		return toolOK(fmt.Sprintf("PHP version for %s set to %s (FrankenPHP image updated).", siteName, version)), nil
+	}
+
 	// Ensure the FPM quadlet and xdebug ini exist for this version.
 	if err := podman.WriteFPMQuadlet(version); err != nil {
 		return toolErr("writing FPM quadlet: " + err.Error()), nil
 	}
 	_ = podman.EnsureXdebugIni(version) // non-fatal if version not yet built
-
-	// Update the site registry.
-	site.PHPVersion = version
-	if err := config.AddSite(*site); err != nil {
-		return toolErr("updating site registry: " + err.Error()), nil
-	}
 
 	// Regenerate the nginx vhost (SSL or plain).
 	if site.Secured {
@@ -4652,6 +4687,65 @@ func execSiteRebuild(args map[string]any) (any, *rpcError) {
 		return toolErr("site is required"), nil
 	}
 	return runLerdCmd("rebuild", siteName)
+}
+
+func execSiteRuntime(args map[string]any) (any, *rpcError) {
+	siteName := strArg(args, "site")
+	if siteName == "" {
+		return toolErr("site is required"), nil
+	}
+	runtime := strArg(args, "runtime")
+	if runtime != "fpm" && runtime != "frankenphp" {
+		return toolErr("runtime must be 'fpm' or 'frankenphp'"), nil
+	}
+	worker := boolArg(args, "worker")
+
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return toolErr(fmt.Sprintf("site %q not found", siteName)), nil
+	}
+	if site.IsCustomContainer() {
+		return toolErr("site uses a custom Containerfile; runtime is defined by Containerfile.lerd"), nil
+	}
+
+	if runtime == "fpm" {
+		if !site.IsFrankenPHP() {
+			return toolOK(fmt.Sprintf("%s already on fpm runtime", siteName)), nil
+		}
+		_ = podman.StopUnit(podman.FrankenPHPContainerName(site.Name))
+		_ = podman.RemoveFrankenPHPQuadlet(site.Name)
+		_ = podman.DaemonReloadFn()
+		site.Runtime = ""
+		site.RuntimeWorker = false
+		if err := config.AddSite(*site); err != nil {
+			return toolErr("updating site: " + err.Error()), nil
+		}
+		_ = config.SetProjectRuntime(site.Path, "", false)
+		if site.Secured {
+			if err := nginx.GenerateSSLVhost(*site, site.PHPVersion); err != nil {
+				return toolErr("regenerating SSL vhost: " + err.Error()), nil
+			}
+		} else if err := nginx.GenerateVhost(*site, site.PHPVersion); err != nil {
+			return toolErr("regenerating vhost: " + err.Error()), nil
+		}
+		_ = nginx.Reload()
+		return toolOK(fmt.Sprintf("%s: runtime set to fpm", siteName)), nil
+	}
+
+	site.Runtime = "frankenphp"
+	site.RuntimeWorker = worker
+	if err := config.AddSite(*site); err != nil {
+		return toolErr("updating site: " + err.Error()), nil
+	}
+	_ = config.SetProjectRuntime(site.Path, "frankenphp", worker)
+	if err := siteops.FinishFrankenPHPLink(*site); err != nil {
+		return toolErr("linking FrankenPHP site: " + err.Error()), nil
+	}
+	label := "frankenphp"
+	if worker {
+		label = "frankenphp (worker mode)"
+	}
+	return toolOK(fmt.Sprintf("%s: runtime set to %s", siteName, label)), nil
 }
 
 func execServicePin(args map[string]any) (any, *rpcError) {

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -172,6 +172,67 @@ func GenerateSSLVhost(site config.Site, phpVersion string) error {
 	return os.WriteFile(confPath, buf.Bytes(), 0644)
 }
 
+// GenerateFrankenPHPVhost renders the HTTP vhost template for a FrankenPHP
+// site. Nginx reverse-proxies to the per-site lerd-fp-<name>:8000 container
+// using the shared custom-container template.
+func GenerateFrankenPHPVhost(site config.Site) error {
+	tmplData, err := GetTemplate("vhost-custom.conf.tmpl")
+	if err != nil {
+		return err
+	}
+	tmpl, err := template.New("vhost-custom").Parse(string(tmplData))
+	if err != nil {
+		return err
+	}
+
+	data := VhostData{
+		Domain:          site.PrimaryDomain(),
+		ServerNames:     serverNamesWithWildcards(site.Domains),
+		CustomContainer: podman.FrankenPHPContainerName(site.Name),
+		CustomPort:      podman.FrankenPHPPort,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
+		return err
+	}
+	confPath := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
+	return os.WriteFile(confPath, buf.Bytes(), 0644)
+}
+
+// GenerateFrankenPHPSSLVhost renders the HTTPS vhost template for a FrankenPHP site.
+func GenerateFrankenPHPSSLVhost(site config.Site) error {
+	tmplData, err := GetTemplate("vhost-custom-ssl.conf.tmpl")
+	if err != nil {
+		return err
+	}
+	tmpl, err := template.New("vhost-custom-ssl").Parse(string(tmplData))
+	if err != nil {
+		return err
+	}
+
+	data := VhostData{
+		Domain:          site.PrimaryDomain(),
+		ServerNames:     serverNamesWithWildcards(site.Domains),
+		CertDomain:      site.PrimaryDomain(),
+		CustomContainer: podman.FrankenPHPContainerName(site.Name),
+		CustomPort:      podman.FrankenPHPPort,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
+		return err
+	}
+	confPath := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
+	return os.WriteFile(confPath, buf.Bytes(), 0644)
+}
+
 // GenerateCustomVhost renders the HTTP vhost template for a custom container
 // site and writes it to conf.d. Nginx reverse-proxies to the container instead
 // of using fastcgi_pass.
@@ -524,9 +585,12 @@ func RepairVhosts() []VhostRepair {
 			}
 			// Regenerate as plain HTTP vhost.
 			var regenErr error
-			if site.IsCustomContainer() {
+			switch {
+			case site.IsCustomContainer():
 				regenErr = GenerateCustomVhost(site)
-			} else {
+			case site.IsFrankenPHP():
+				regenErr = GenerateFrankenPHPVhost(site)
+			default:
 				regenErr = GenerateVhost(site, site.PHPVersion)
 			}
 			if regenErr != nil {

--- a/internal/podman/exec.go
+++ b/internal/podman/exec.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -60,6 +61,21 @@ func PullImageTo(image string, w io.Writer) error {
 	cmd := exec.Command(PodmanBin(), "pull", image)
 	cmd.Stdout = w
 	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("pulling %s: %w", image, err)
+	}
+	return nil
+}
+
+// PullImageIfMissing pulls the named image when it is not already in the
+// local store. No-op when the image exists.
+func PullImageIfMissing(image string) error {
+	if ImageExists(image) {
+		return nil
+	}
+	cmd := exec.Command(PodmanBin(), "pull", image)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("pulling %s: %w", image, err)
 	}

--- a/internal/podman/frankenphp.go
+++ b/internal/podman/frankenphp.go
@@ -1,0 +1,117 @@
+package podman
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// FrankenPHPContainerName returns the Podman container name for a site's
+// FrankenPHP container, e.g. "lerd-fp-myapp".
+func FrankenPHPContainerName(siteName string) string {
+	return "lerd-fp-" + siteName
+}
+
+// FrankenPHPImage returns the official dunglas/frankenphp image tag for the
+// requested PHP version. Versions outside the published build set fall back
+// to the latest stable (php8.4).
+func FrankenPHPImage(phpVersion string) string {
+	supported := map[string]bool{"8.2": true, "8.3": true, "8.4": true}
+	if !supported[phpVersion] {
+		phpVersion = "8.4"
+	}
+	return "docker.io/dunglas/frankenphp:php" + phpVersion + "-alpine"
+}
+
+// FrankenPHPPort is the port FrankenPHP listens on inside the container. Kept
+// fixed so the nginx proxy target and framework entrypoints stay in sync.
+const FrankenPHPPort = 8000
+
+// GenerateFrankenPHPQuadlet builds a quadlet .container file for a per-site
+// FrankenPHP container. The container mounts the project at its host path,
+// joins the lerd network, and runs the framework's declared entrypoint. Any
+// env map entries are written as Environment= lines.
+func GenerateFrankenPHPQuadlet(siteName, projectPath, phpVersion string, entrypoint []string, env map[string]string) string {
+	containerName := FrankenPHPContainerName(siteName)
+	image := FrankenPHPImage(phpVersion)
+
+	var b strings.Builder
+	b.WriteString("[Unit]\n")
+	fmt.Fprintf(&b, "Description=Lerd FrankenPHP container (%s)\n", siteName)
+	b.WriteString("After=network.target\n")
+
+	b.WriteString("\n[Container]\n")
+	fmt.Fprintf(&b, "Image=%s\n", image)
+	fmt.Fprintf(&b, "ContainerName=%s\n", containerName)
+	b.WriteString("Network=lerd\n")
+	fmt.Fprintf(&b, "Volume=%s:/etc/hosts:ro,z\n", config.ContainerHostsFile())
+	fmt.Fprintf(&b, "Volume=%s:%s:rw\n", projectPath, projectPath)
+	fmt.Fprintf(&b, "PodmanArgs=--security-opt=label=disable --workdir=%s\n", projectPath)
+	for _, k := range sortedKeys(env) {
+		// systemd Environment= splits on whitespace unless the whole
+		// KEY=value pair is quoted, so always wrap in double quotes.
+		v := strings.ReplaceAll(env[k], `"`, `\"`)
+		fmt.Fprintf(&b, "Environment=\"%s=%s\"\n", k, v)
+	}
+	if len(entrypoint) > 0 {
+		fmt.Fprintf(&b, "Exec=%s\n", shellJoin(entrypoint))
+	}
+
+	b.WriteString("\n[Service]\n")
+	b.WriteString("Restart=always\n")
+
+	b.WriteString("\n[Install]\n")
+	b.WriteString("WantedBy=default.target\n")
+
+	return b.String()
+}
+
+// WriteFrankenPHPQuadlet writes the quadlet for a FrankenPHP site.
+func WriteFrankenPHPQuadlet(siteName, projectPath, phpVersion string, entrypoint []string, env map[string]string) error {
+	_, err := WriteFrankenPHPQuadletDiff(siteName, projectPath, phpVersion, entrypoint, env)
+	return err
+}
+
+// WriteFrankenPHPQuadletDiff writes the quadlet and returns whether the content
+// changed on disk so callers can decide whether to restart the running
+// container.
+func WriteFrankenPHPQuadletDiff(siteName, projectPath, phpVersion string, entrypoint []string, env map[string]string) (bool, error) {
+	content := GenerateFrankenPHPQuadlet(siteName, projectPath, phpVersion, entrypoint, env)
+	return WriteQuadletDiff(FrankenPHPContainerName(siteName), content)
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// RemoveFrankenPHPQuadlet removes the unit file for a FrankenPHP site.
+func RemoveFrankenPHPQuadlet(siteName string) error {
+	name := FrankenPHPContainerName(siteName)
+	_ = RemoveQuadlet(name)
+	if RemoveContainerUnitFn != nil {
+		return RemoveContainerUnitFn(name)
+	}
+	return nil
+}
+
+// shellJoin quotes each argument for embedding in a quadlet Exec= line.
+// Quadlet Exec values are passed through podman's argv parser which already
+// handles single-word args; anything with whitespace needs quoting.
+func shellJoin(args []string) string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		if strings.ContainsAny(a, " \t\"'\\") {
+			out[i] = `"` + strings.ReplaceAll(a, `"`, `\"`) + `"`
+		} else {
+			out[i] = a
+		}
+	}
+	return strings.Join(out, " ")
+}

--- a/internal/podman/frankenphp_test.go
+++ b/internal/podman/frankenphp_test.go
@@ -1,0 +1,60 @@
+package podman
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFrankenPHPContainerName(t *testing.T) {
+	got := FrankenPHPContainerName("myapp")
+	if got != "lerd-fp-myapp" {
+		t.Fatalf("FrankenPHPContainerName: want lerd-fp-myapp, got %s", got)
+	}
+}
+
+func TestFrankenPHPImage(t *testing.T) {
+	tests := []struct {
+		version, want string
+	}{
+		{"8.2", "docker.io/dunglas/frankenphp:php8.2-alpine"},
+		{"8.3", "docker.io/dunglas/frankenphp:php8.3-alpine"},
+		{"8.4", "docker.io/dunglas/frankenphp:php8.4-alpine"},
+		{"8.1", "docker.io/dunglas/frankenphp:php8.4-alpine"}, // unsupported → fallback
+		{"", "docker.io/dunglas/frankenphp:php8.4-alpine"},
+	}
+	for _, tt := range tests {
+		if got := FrankenPHPImage(tt.version); got != tt.want {
+			t.Errorf("FrankenPHPImage(%q): want %s, got %s", tt.version, tt.want, got)
+		}
+	}
+}
+
+func TestGenerateFrankenPHPQuadlet(t *testing.T) {
+	entry := []string{"php", "artisan", "octane:start", "--server=frankenphp"}
+	env := map[string]string{"FRANKENPHP_CONFIG": "worker ./public/index.php"}
+	content := GenerateFrankenPHPQuadlet("myapp", "/home/user/myapp", "8.4", entry, env)
+
+	mustContain := []string{
+		"ContainerName=lerd-fp-myapp",
+		"Image=docker.io/dunglas/frankenphp:php8.4-alpine",
+		"Network=lerd",
+		"Volume=/home/user/myapp:/home/user/myapp:rw",
+		"--workdir=/home/user/myapp",
+		`Environment="FRANKENPHP_CONFIG=worker ./public/index.php"`,
+		"Exec=php artisan octane:start --server=frankenphp",
+		"Restart=always",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(content, s) {
+			t.Errorf("generated quadlet missing %q\n%s", s, content)
+		}
+	}
+}
+
+func TestShellJoinQuotesWhitespace(t *testing.T) {
+	got := shellJoin([]string{"frankenphp", "run", "--with spaces", `has"quote`})
+	want := `frankenphp run "--with spaces" "has\"quote"`
+	if got != want {
+		t.Fatalf("shellJoin:\n  want %s\n  got  %s", want, got)
+	}
+}

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -117,6 +117,12 @@ type EnrichedSite struct {
 	ContainerSSL   bool
 	ContainerImage string
 
+	// Runtime — "" / "fpm" is the shared PHP-FPM image; "frankenphp" is the
+	// per-site dunglas/frankenphp container. RuntimeWorker toggles worker mode
+	// when running under frankenphp.
+	Runtime       string
+	RuntimeWorker bool
+
 	// LAN sharing
 	LANPort int
 
@@ -218,6 +224,8 @@ func Enrich(s config.Site, flags EnrichFlag) EnrichedSite {
 		ContainerPort:       s.ContainerPort,
 		ContainerSSL:        s.ContainerSSL,
 		ContainerImage:      containerImage(s),
+		Runtime:             s.Runtime,
+		RuntimeWorker:       s.RuntimeWorker,
 		FrameworkName:       s.Framework,
 		OriginalPHPVersion:  s.PHPVersion,
 		OriginalNodeVersion: s.NodeVersion,

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -151,6 +151,65 @@ func FinishLink(site config.Site, phpVersion string) error {
 	return nil
 }
 
+// FinishFrankenPHPLink performs the post-registration steps for a site whose
+// runtime is "frankenphp": ensure the image is pulled, write a per-site
+// quadlet that runs the framework's entrypoint, generate an nginx proxy
+// vhost, update container hosts, and reload nginx.
+func FinishFrankenPHPLink(site config.Site) error {
+	fw, _ := config.GetFrameworkForDir(site.Framework, site.Path)
+	entrypoint := fw.FrankenPHPEntrypoint(site.RuntimeWorker)
+	env := fw.FrankenPHPEnv(site.RuntimeWorker)
+
+	_ = podman.WriteContainerHosts()
+
+	image := podman.FrankenPHPImage(site.PHPVersion)
+	if err := podman.PullImageIfMissing(image); err != nil {
+		fmt.Printf("[WARN] pulling %s: %v\n", image, err)
+	}
+
+	unitName := podman.FrankenPHPContainerName(site.Name)
+	changed, err := podman.WriteFrankenPHPQuadletDiff(site.Name, site.Path, site.PHPVersion, entrypoint, env)
+	if err != nil {
+		return fmt.Errorf("writing FrankenPHP quadlet: %w", err)
+	}
+	_ = podman.DaemonReloadFn()
+
+	// Always Start (no-op if already running). If the quadlet content changed
+	// (new PHP version, worker flip, new entrypoint) we also need to restart
+	// so the running container picks up the change, otherwise the updated
+	// image/exec sits unused until the next manual restart.
+	if err := podman.StartUnit(unitName); err != nil {
+		fmt.Printf("[WARN] starting FrankenPHP container: %v\n", err)
+	}
+	if changed {
+		if err := podman.RestartUnit(unitName); err != nil {
+			fmt.Printf("[WARN] restarting FrankenPHP container after quadlet change: %v\n", err)
+		}
+	}
+
+	if site.Secured {
+		if err := certs.SecureSite(site); err != nil {
+			return fmt.Errorf("securing site: %w", err)
+		}
+	} else {
+		if err := nginx.GenerateFrankenPHPVhost(site); err != nil {
+			return fmt.Errorf("generating FrankenPHP vhost: %w", err)
+		}
+	}
+
+	_ = podman.WriteContainerHosts()
+
+	if err := nginx.Reload(); err != nil {
+		return fmt.Errorf("nginx reload: %w", err)
+	}
+
+	if podman.AfterUnitChange != nil {
+		podman.AfterUnitChange("site:" + site.Name)
+	}
+
+	return nil
+}
+
 // FinishCustomLink performs the post-registration steps for a custom container
 // site: build the image, write a dedicated quadlet, generate a proxy vhost,
 // update container hosts, and reload nginx.

--- a/internal/siteops/unlink.go
+++ b/internal/siteops/unlink.go
@@ -49,6 +49,14 @@ func UnlinkSiteCore(site *config.Site, parkedDirs []string) error {
 		_ = podman.RemoveCustomContainerQuadlet(site.Name)
 	}
 
+	// Same cleanup for FrankenPHP sites: stop and remove the per-site
+	// quadlet. The dunglas/frankenphp image is shared across all FrankenPHP
+	// sites on this PHP version, so it stays in the local store.
+	if site.IsFrankenPHP() {
+		_ = podman.StopUnit(podman.FrankenPHPContainerName(site.Name))
+		_ = podman.RemoveFrankenPHPQuadlet(site.Name)
+	}
+
 	if IsParkedSite(site.Path, parkedDirs) {
 		_ = config.IgnoreSite(site.Name)
 	} else {

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -405,6 +405,13 @@ func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, inn
 	if site.FrameworkLabel != "" {
 		info += dimStyle.Render("  fw: ") + site.FrameworkLabel
 	}
+	if site.Runtime == "frankenphp" {
+		rt := "frankenphp"
+		if site.RuntimeWorker {
+			rt = "frankenphp (worker)"
+		}
+		info += dimStyle.Render("  runtime: ") + accentStyle.Render(rt)
+	}
 	if site.Branch != "" {
 		info += dimStyle.Render("  git: ") + site.Branch
 	}

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -654,7 +654,7 @@
                             <span x-text="serviceByName(svcName) ? serviceLabel(serviceByName(svcName)) : svcName"></span>
                           </button>
                         </template>
-                        <template x-if="!selectedSite.custom_container && selectedSite.php_version">
+                        <template x-if="!selectedSite.custom_container && selectedSite.php_version && selectedSite.runtime !== 'frankenphp'">
                           <button
                             @click="setTab('system'); selectSystem('php-' + selectedSite.php_version)"
                             :title="(xdebugEnabled[selectedSite.php_version] ? 'Xdebug ' + (xdebugMode[selectedSite.php_version] || 'debug') : 'Xdebug off') + ' — click to manage'"
@@ -666,6 +666,17 @@
                             <span>Xdebug</span>
                             <span class="opacity-70" x-text="xdebugEnabled[selectedSite.php_version] ? (xdebugMode[selectedSite.php_version] || 'debug') : 'off'"></span>
                           </button>
+                        </template>
+                        <template x-if="!selectedSite.custom_container && selectedSite.runtime === 'frankenphp'">
+                          <span
+                            :title="selectedSite.runtime_worker ? 'FrankenPHP worker mode' : 'FrankenPHP'"
+                            class="inline-flex items-center gap-1.5 text-[11px] font-medium px-2 py-0.5 rounded-full border bg-orange-50 dark:bg-orange-500/10 border-orange-200 dark:border-orange-500/30 text-orange-700 dark:text-orange-300">
+                            <span class="w-1.5 h-1.5 rounded-full bg-orange-500"></span>
+                            <span>FrankenPHP</span>
+                            <template x-if="selectedSite.runtime_worker">
+                              <span class="opacity-70">worker</span>
+                            </template>
+                          </span>
                         </template>
                       </div>
                     </template>

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -647,6 +647,8 @@ type SiteResponse struct {
 	CustomContainer bool     `json:"custom_container,omitempty"`
 	ContainerPort   int      `json:"container_port,omitempty"`
 	ContainerImage  string   `json:"container_image,omitempty"`
+	Runtime         string   `json:"runtime,omitempty"`
+	RuntimeWorker   bool     `json:"runtime_worker,omitempty"`
 }
 
 func handleSites(w http.ResponseWriter, _ *http.Request) {
@@ -735,6 +737,8 @@ func buildSites() []SiteResponse {
 			CustomContainer:    e.ContainerPort > 0,
 			ContainerPort:      e.ContainerPort,
 			ContainerImage:     e.ContainerImage,
+			Runtime:            e.Runtime,
+			RuntimeWorker:      e.RuntimeWorker,
 		})
 	}
 	return sites
@@ -1632,7 +1636,17 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		}
 		_ = config.SetProjectPHPVersion(site.Path, version)
 		site.PHPVersion = version
-		// Regenerate vhost with new PHP version
+		if site.IsFrankenPHP() {
+			if err := config.AddSite(*site); err != nil {
+				writeJSON(w, SiteActionResponse{Error: "updating site registry: " + err.Error()})
+				return
+			}
+			if err := siteops.FinishFrankenPHPLink(*site); err != nil {
+				writeJSON(w, SiteActionResponse{Error: "re-linking FrankenPHP site: " + err.Error()})
+				return
+			}
+			break
+		}
 		if site.Secured {
 			if err := certs.SecureSite(*site); err != nil {
 				writeJSON(w, SiteActionResponse{Error: "regenerating SSL vhost: " + err.Error()})


### PR DESCRIPTION
## Summary

Adds an opt-in FrankenPHP runtime as an alternative to the shared PHP-FPM container. Sites declare `runtime: frankenphp` (optionally `runtime_worker: true`) in `.lerd.yaml`, or switch at runtime with `lerd runtime frankenphp [--worker]`. Each FrankenPHP site spins up its own `dunglas/frankenphp:php<version>-alpine` container; nginx reverse-proxies to it on port 8000 and workers `podman exec` into it.

## What's in

- `Site.Runtime` / `.lerd.yaml runtime:` schema plus `lerd runtime` CLI that writes both fields and cleans them up on switch to fpm.
- `Framework.FrankenPHP` adapter hook with `Entrypoint`, `WorkerEntrypoint`, `Env`, `WorkerEnv`, `SupportsWorker`. Built-in Laravel and Symfony adapters:
  - **Laravel non-worker** uses `frankenphp php-server -r public/` for fresh-per-request dev ergonomics (code edits take effect immediately).
  - **Laravel worker** runs `octane:start --server=frankenphp --workers=auto`, with pcntl installed at container boot via the image's bundled install-php-extensions helper.
  - **Symfony non-worker** uses `frankenphp php-server -r public/`.
  - **Symfony worker** uses `frankenphp php-server --worker=public/index.php --watch` so file edits hot-reload without `lerd restart`.
  - Unknown frameworks fall back to `frankenphp php-server` rooted at the framework's public dir. `mergeBuiltinFrankenPHP` backfills the hook onto store framework defs that predate this feature.
- Built-in Symfony framework detection (composer.json `symfony/runtime`, `symfony/framework-bundle`, or `symfony.lock`).
- Per-site quadlet writer with restart-on-change so `lerd isolate 8.3` and the dashboard's PHP picker actually pick up the new image tag.
- Nginx FrankenPHP vhost reuses the custom-container template. `secure`, `unsecure`, pause/unpause, restart, unlink, and `lerd start` all handle the FrankenPHP branch.
- Worker exec target branches three ways (FPM / custom container / FrankenPHP). `SuccessExitStatus=1 130 143` on generated worker units so Symfony `messenger:consume` and similar workers stop cleanly without spurious `Failed` journal entries.
- **Web UI**: orange `FrankenPHP` badge (with `worker` suffix in worker mode) next to the existing service badges; Xdebug toggle is hidden on FrankenPHP sites since shared FPM Xdebug state doesn't apply. API exposes `runtime` and `runtime_worker` on `/api/sites`. PHP version picker now routes FrankenPHP sites through the FrankenPHP link path instead of regenerating a broken FPM vhost.
- **TUI**: `runtime: frankenphp (worker)` on the site detail info line.
- `site_runtime` MCP tool plus updated SKILL / cursor / junie guidelines.
- `lerd init` offers a FrankenPHP prompt when it detects signals (`laravel/octane` with `OCTANE_SERVER=frankenphp`, `runtime/frankenphp`, `runtime/frankenphp-symfony`, or a `Containerfile.lerd` FROM `dunglas/frankenphp`). `lerd doctor` surfaces the same hint on registered sites still on FPM.
- `docs/features/frankenphp.md` covers runtime switching, worker vs non-worker tradeoffs, hot reload caveats per framework, and current limitations.

## Tested

Scaffolded Laravel 12 + Octane and Symfony 7.4 + Messenger projects at `~/Code/lerd-fp-tests/{laravel-fp,symfony-fp}`. Verified per request serving, worker-mode resident PHP, queue/messenger workers executing via `podman exec` into the FrankenPHP container, `lerd runtime` round-trips cleanly removing `.lerd.yaml` runtime fields, and hot reload works in non-worker mode for both frameworks plus Symfony worker mode.

## Out of scope (follow-ups)

- Xdebug support for FrankenPHP containers.
- Custom extension install (`lerd php:ext add`) on FrankenPHP sites.
- Laravel Octane `--watch` hot reload (needs chokidar-cli, ~150MB boot overhead). Workaround: non-worker mode for dev iteration, or `php artisan octane:reload` for quick worker refresh.