### PR TITLE
feat: dual-stack IPv4 + IPv6 across the lerd stack

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -51,6 +51,8 @@ All containers join the rootless Podman network `lerd`. Communication between Ng
 
 **Rootless Podman**: all containers run without root privileges. The only operations requiring `sudo` are DNS setup (configures NetworkManager or systemd-resolved to route `.test` queries) and the initial `net.ipv4.ip_unprivileged_port_start=80` sysctl.
 
+**Dual-stack networking**: the lerd podman bridge is created with both an IPv4 and an IPv6 ULA subnet (`fd00:1e7d::/64`), so containers receive both v4 and v6 addresses. nginx vhosts listen on `0.0.0.0` and `[::]`, lerd-dns answers AAAA records for `*.test` (`::1` locally, the host's primary global v6 when `lerd lan:expose on`), and every managed `PublishPort` in service quadlets is paired (a `127.0.0.1:5432` bind also gets a `[::1]:5432`). Existing v4-only installs are migrated to dual-stack on the next `lerd install`: attached containers stop, the network is recreated, the previous `network_dns_servers` list is restored, and the containers restart. To opt out, set an explicit subnet via `podman network create` before `lerd install` runs, or override the `lerd-*` quadlets to remove the `[::]` / `[::1]` lines before they're written.
+
 **Podman Quadlets**: containers are defined as systemd unit files (`.container` files) managed by the Quadlet generator. This means `systemctl --user start lerd-nginx` works like any other systemd service, and containers restart on failure and at login.
 
 **Shared nginx**: a single nginx container serves all sites via virtual hosts. nginx uses a Podman-network-aware resolver to route `fastcgi_pass` to the correct PHP-FPM container by hostname.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -224,3 +224,26 @@ To ensure a clean switch and recreate the networks with the new backend, reset t
 podman system reset
 ```
 :::
+
+::: details Error: unable to parse ip fe80::...%18 specified in AddDNSServer: invalid argument
+Your host's DNS configuration includes a zoned link-local IPv6 nameserver, typically advertised by your router via SLAAC + RDNSS. The zone identifier (`%18` is a kernel interface index) is meaningless inside a container's network namespace, and netavark refuses to accept it.
+
+Lerd 1.18+ filters these addresses automatically before handing them to podman. If you're still on 1.17 or older, upgrade with `lerd update` and rerun `lerd install`. The filter is conservative: only zoned link-local (`fe80::...%iface`) addresses are dropped; globally routable IPv6 nameservers (e.g. `2606:4700:4700::1111`) are preserved.
+
+When filtering empties the entire DNS list, lerd falls back to pasta's standard forwarder (`169.254.1.1`), which bridges into the host's resolver and preserves `.test` routing.
+:::
+
+::: details Containers can resolve `.test` over IPv4 but not over IPv6
+Lerd 1.18+ creates the lerd podman network as dual-stack (v4 + v6) and writes both A and AAAA records for `.test` domains. If you upgraded from an older version, the existing v4-only `lerd` network is migrated automatically the next time you run `lerd install`: attached containers stop, the network is recreated with the `fd00:1e7d::/64` ULA prefix, the previous DNS server list is restored, and the containers restart. Quick check:
+
+```bash
+podman network inspect lerd --format '{{.Subnets}}'
+# expect both an IPv4 subnet and one starting with fd00:1e7d::
+```
+
+If the v6 subnet is missing, run `lerd install` once to migrate. To verify resolution from inside a container:
+
+```bash
+podman run --rm --network lerd alpine sh -c 'nslookup laravel.test; nslookup -type=AAAA laravel.test'
+```
+:::

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -173,7 +173,8 @@ func runInstall(_ *cobra.Command, _ []string) error {
 			if site.Paused || site.Ignored {
 				continue
 			}
-			if site.IsCustomContainer() {
+			switch {
+			case site.IsCustomContainer():
 				if site.Secured {
 					if err := nginx.GenerateCustomSSLVhost(site); err != nil {
 						fmt.Printf("\n    WARN %s: %v", site.PrimaryDomain(), err)
@@ -188,7 +189,22 @@ func runInstall(_ *cobra.Command, _ []string) error {
 						fmt.Printf("\n    WARN %s: %v", site.PrimaryDomain(), err)
 					}
 				}
-			} else {
+			case site.IsFrankenPHP():
+				if site.Secured {
+					if err := nginx.GenerateFrankenPHPSSLVhost(site); err != nil {
+						fmt.Printf("\n    WARN %s: %v", site.PrimaryDomain(), err)
+						continue
+					}
+					sslConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
+					mainConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
+					os.Remove(mainConf)          //nolint:errcheck
+					os.Rename(sslConf, mainConf) //nolint:errcheck
+				} else {
+					if err := nginx.GenerateFrankenPHPVhost(site); err != nil {
+						fmt.Printf("\n    WARN %s: %v", site.PrimaryDomain(), err)
+					}
+				}
+			default:
 				phpVer := site.PHPVersion
 				if phpVer == "" && cfg != nil {
 					phpVer = cfg.PHP.DefaultVersion
@@ -597,8 +613,9 @@ func runInstall(_ *cobra.Command, _ []string) error {
 }
 
 // refreshUnreferencedCustomQuadlets rewrites quadlets for globally installed
-// custom services and per-site custom containers that the per-site walk would
-// otherwise skip, so the v4→v6 migration reaches every managed container.
+// custom services, per-site custom containers, and per-site FrankenPHP
+// containers that the earlier per-site walk would otherwise skip, so the v4→v6
+// migration and other quadlet-schema changes reach every managed container.
 func refreshUnreferencedCustomQuadlets(seenSvc map[string]bool, reg *config.SiteRegistry) {
 	if customs, err := config.ListCustomServices(); err == nil {
 		for _, svc := range customs {
@@ -613,11 +630,21 @@ func refreshUnreferencedCustomQuadlets(seenSvc map[string]bool, reg *config.Site
 		return
 	}
 	for _, s := range reg.Sites {
-		if s.Paused || s.Ignored || !s.IsCustomContainer() {
+		if s.Paused || s.Ignored {
 			continue
 		}
-		if err := podman.WriteCustomContainerQuadlet(s.Name, s.Path, s.ContainerPort); err != nil {
-			fmt.Printf("  WARN: refreshing %s quadlet: %v\n", podman.CustomContainerName(s.Name), err)
+		switch {
+		case s.IsCustomContainer():
+			if err := podman.WriteCustomContainerQuadlet(s.Name, s.Path, s.ContainerPort); err != nil {
+				fmt.Printf("  WARN: refreshing %s quadlet: %v\n", podman.CustomContainerName(s.Name), err)
+			}
+		case s.IsFrankenPHP():
+			fw, _ := config.GetFrameworkForDir(s.Framework, s.Path)
+			entrypoint := fw.FrankenPHPEntrypoint(s.RuntimeWorker)
+			env := fw.FrankenPHPEnv(s.RuntimeWorker)
+			if err := podman.WriteFrankenPHPQuadlet(s.Name, s.Path, s.PHPVersion, entrypoint, env); err != nil {
+				fmt.Printf("  WARN: refreshing %s quadlet: %v\n", podman.FrankenPHPContainerName(s.Name), err)
+			}
 		}
 	}
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -77,6 +77,10 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	}
 
 	// 2. Podman network
+	// Containers removed by the v4→v6 migration are restarted AFTER the
+	// quadlet refresh phase below — restarting inline here would bring them
+	// back on the stale pre-PairIPv6Binds quadlets.
+	var migrated []string
 	step("Creating lerd podman network")
 	if err := podman.EnsureNetwork("lerd"); err != nil {
 		if errors.Is(err, podman.ErrNetworkNeedsMigration) {
@@ -87,13 +91,7 @@ func runInstall(_ *cobra.Command, _ []string) error {
 			if mErr != nil {
 				return fmt.Errorf("migrating lerd network: %w", mErr)
 			}
-			// StartUnit recreates each container from its quadlet (systemd or launchd);
-			// `podman start` would reuse the stale pre-migration network spec.
-			for _, c := range restored {
-				if err := podman.StartUnit(c); err != nil {
-					fmt.Printf("    WARN: failed to restart %s: %v\n", c, err)
-				}
-			}
+			migrated = restored
 			step("Creating lerd podman network")
 		} else {
 			return err
@@ -335,6 +333,8 @@ func runInstall(_ *cobra.Command, _ []string) error {
 				}
 			}
 		}
+
+		refreshUnreferencedCustomQuadlets(seenSvc, reg)
 	}
 
 	// 7. Pull images before touching DNS so registry lookups use the system
@@ -398,15 +398,25 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	}
 	ok()
 
+	// Start containers removed by the v4→v6 network migration. Runs after
+	// the quadlet refresh phase + DaemonReload so they come up on the
+	// freshly written dual-stack quadlets.
+	migratedSet := make(map[string]bool, len(migrated))
+	for _, c := range migrated {
+		migratedSet[c] = true
+		fmt.Printf("  --> Starting %s (network migration) ", c)
+		if err := podman.StartUnit(c); err != nil {
+			fmt.Printf("WARN: %v\n", err)
+		} else {
+			ok()
+		}
+	}
+
 	// Migration safety net: restart any container whose quadlet content
-	// actually changed during this install run, EXCEPT lerd-nginx and
-	// lerd-dns which are already restarted unconditionally below. The
-	// scenario this catches: a user updating from a release where every
-	// container was bound to 0.0.0.0 by default. Without this restart
-	// the running services would silently keep their old LAN-exposed
-	// bind even though the new quadlet on disk says 127.0.0.1.
+	// actually changed during this install run, EXCEPT lerd-nginx /
+	// lerd-dns (handled separately) and anything we just started above.
 	for _, name := range changedQuadlets {
-		if name == "lerd-nginx" || name == "lerd-dns" {
+		if name == "lerd-nginx" || name == "lerd-dns" || migratedSet[name] {
 			continue
 		}
 		if running, _ := podman.ContainerRunning(name); !running {
@@ -584,6 +594,32 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	fmt.Println("\n  Dashboard: \033[96mhttp://lerd.localhost\033[0m")
 	fmt.Println("  Terminal:  \033[96mlerd tui\033[0m")
 	return nil
+}
+
+// refreshUnreferencedCustomQuadlets rewrites quadlets for globally installed
+// custom services and per-site custom containers that the per-site walk would
+// otherwise skip, so the v4→v6 migration reaches every managed container.
+func refreshUnreferencedCustomQuadlets(seenSvc map[string]bool, reg *config.SiteRegistry) {
+	if customs, err := config.ListCustomServices(); err == nil {
+		for _, svc := range customs {
+			if seenSvc[svc.Name] {
+				continue
+			}
+			seenSvc[svc.Name] = true
+			ensureCustomServiceQuadlet(svc) //nolint:errcheck
+		}
+	}
+	if reg == nil {
+		return
+	}
+	for _, s := range reg.Sites {
+		if s.Paused || s.Ignored || !s.IsCustomContainer() {
+			continue
+		}
+		if err := podman.WriteCustomContainerQuadlet(s.Name, s.Path, s.ContainerPort); err != nil {
+			fmt.Printf("  WARN: refreshing %s quadlet: %v\n", podman.CustomContainerName(s.Name), err)
+		}
+	}
 }
 
 // ensureSystemdLinger checks whether systemd user linger is enabled for the

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -78,7 +79,25 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	// 2. Podman network
 	step("Creating lerd podman network")
 	if err := podman.EnsureNetwork("lerd"); err != nil {
-		return err
+		if errors.Is(err, podman.ErrNetworkNeedsMigration) {
+			fmt.Println()
+			fmt.Println("    Migrating lerd network to dual-stack v4+v6.")
+			fmt.Println("    Existing containers on this network will be recreated.")
+			restored, mErr := podman.MigrateNetworkToIPv6("lerd")
+			if mErr != nil {
+				return fmt.Errorf("migrating lerd network: %w", mErr)
+			}
+			// StartUnit recreates each container from its quadlet (systemd or launchd);
+			// `podman start` would reuse the stale pre-migration network spec.
+			for _, c := range restored {
+				if err := podman.StartUnit(c); err != nil {
+					fmt.Printf("    WARN: failed to restart %s: %v\n", c, err)
+				}
+			}
+			step("Creating lerd podman network")
+		} else {
+			return err
+		}
 	}
 	if err := podman.EnsureNetworkDNS("lerd", dns.ReadContainerDNS()); err != nil {
 		return err

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -6,6 +6,9 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
 )
 
 func TestIsShell_fish(t *testing.T) {
@@ -114,6 +117,138 @@ func TestAddShellShims_LaravelShim(t *testing.T) {
 	expectedPath := expectedComposerHome + "/vendor/bin/laravel"
 	if !strings.Contains(shim, expectedPath) {
 		t.Errorf("laravel shim does not reference %q, got:\n%s", expectedPath, shim)
+	}
+}
+
+func TestRefreshUnreferencedCustomQuadlets_globalCustomServiceGetsV6Pair(t *testing.T) {
+	// Simulates a preset like mongo-express installed globally via
+	// `lerd service preset install`: a yaml in CustomServicesDir() with
+	// loopback publish ports, but no site .lerd.yaml references it.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	origReload := podman.DaemonReloadFn
+	t.Cleanup(func() { podman.DaemonReloadFn = origReload })
+	podman.DaemonReloadFn = func() error { return nil }
+
+	svc := &config.CustomService{
+		Name:  "mongo-express",
+		Image: "docker.io/library/mongo-express:latest",
+		Ports: []string{"127.0.0.1:8082:8081"},
+	}
+	if err := config.SaveCustomService(svc); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+
+	refreshUnreferencedCustomQuadlets(map[string]bool{}, nil)
+
+	path := filepath.Join(config.QuadletDir(), "lerd-mongo-express.container")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("quadlet not written at %s: %v", path, err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "PublishPort=127.0.0.1:8082:8081") {
+		t.Errorf("v4 bind missing from rewritten quadlet:\n%s", got)
+	}
+	if !strings.Contains(got, "PublishPort=[::1]:8082:8081") {
+		t.Errorf("v6 pair missing — PairIPv6Binds did not apply during refresh:\n%s", got)
+	}
+}
+
+func TestRefreshUnreferencedCustomQuadlets_skipsSeenServices(t *testing.T) {
+	// If the per-site loop already handled a service, the second pass must
+	// not overwrite its quadlet, so an overridden image or extra port is
+	// preserved.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	origReload := podman.DaemonReloadFn
+	t.Cleanup(func() { podman.DaemonReloadFn = origReload })
+	podman.DaemonReloadFn = func() error { return nil }
+
+	svc := &config.CustomService{
+		Name:  "mongo-express",
+		Image: "docker.io/library/mongo-express:latest",
+		Ports: []string{"127.0.0.1:8082:8081"},
+	}
+	if err := config.SaveCustomService(svc); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+
+	seen := map[string]bool{"mongo-express": true}
+	refreshUnreferencedCustomQuadlets(seen, nil)
+
+	path := filepath.Join(config.QuadletDir(), "lerd-mongo-express.container")
+	if _, err := os.Stat(path); err == nil {
+		t.Errorf("quadlet at %s should not be written when service is already in seenSvc", path)
+	}
+}
+
+func TestRefreshUnreferencedCustomQuadlets_rewritesCustomContainerSite(t *testing.T) {
+	// Custom-container sites (ContainerPort > 0) don't publish ports, so
+	// PairIPv6Binds is a no-op. The refresh must still write a fresh
+	// quadlet on disk so a migrated container restarts from current state.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	projectDir := filepath.Join(tmp, "my-app")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := &config.SiteRegistry{
+		Sites: []config.Site{
+			{
+				Name:          "my-app",
+				Domains:       []string{"my-app.test"},
+				Path:          projectDir,
+				ContainerPort: 3000,
+			},
+		},
+	}
+
+	refreshUnreferencedCustomQuadlets(map[string]bool{}, reg)
+
+	path := filepath.Join(config.QuadletDir(), "lerd-custom-my-app.container")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("custom-container quadlet not written at %s: %v", path, err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "Network=lerd") {
+		t.Errorf("expected Network=lerd in custom-container quadlet:\n%s", got)
+	}
+	if !strings.Contains(got, "ContainerName=lerd-custom-my-app") {
+		t.Errorf("expected ContainerName=lerd-custom-my-app:\n%s", got)
+	}
+}
+
+func TestRefreshUnreferencedCustomQuadlets_skipsPausedAndIgnoredSites(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	reg := &config.SiteRegistry{
+		Sites: []config.Site{
+			{Name: "paused-app", Path: tmp, ContainerPort: 3001, Paused: true},
+			{Name: "ignored-app", Path: tmp, ContainerPort: 3002, Ignored: true},
+		},
+	}
+	refreshUnreferencedCustomQuadlets(map[string]bool{}, reg)
+
+	for _, name := range []string{"lerd-custom-paused-app", "lerd-custom-ignored-app"} {
+		path := filepath.Join(config.QuadletDir(), name+".container")
+		if _, err := os.Stat(path); err == nil {
+			t.Errorf("quadlet %s should not be written for paused/ignored site", path)
+		}
 	}
 }
 

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -230,6 +230,55 @@ func TestRefreshUnreferencedCustomQuadlets_rewritesCustomContainerSite(t *testin
 	}
 }
 
+func TestRefreshUnreferencedCustomQuadlets_rewritesFrankenPHPSite(t *testing.T) {
+	// FrankenPHP sites (Runtime=="frankenphp") don't publish ports either, but
+	// the per-site loop that generates vhosts does not rewrite their quadlets.
+	// The refresh pass must emit a fresh lerd-fp-<name>.container on disk so
+	// the v4→v6 network migration (and any other quadlet-schema change) lands
+	// on the FrankenPHP container when install restarts it.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	projectDir := filepath.Join(tmp, "my-app")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := &config.SiteRegistry{
+		Sites: []config.Site{
+			{
+				Name:       "my-app",
+				Domains:    []string{"my-app.test"},
+				Path:       projectDir,
+				PHPVersion: "8.4",
+				Runtime:    "frankenphp",
+			},
+		},
+	}
+
+	refreshUnreferencedCustomQuadlets(map[string]bool{}, reg)
+
+	path := filepath.Join(config.QuadletDir(), "lerd-fp-my-app.container")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("frankenphp quadlet not written at %s: %v", path, err)
+	}
+	got := string(data)
+	wantFragments := []string{
+		"ContainerName=lerd-fp-my-app",
+		"Image=docker.io/dunglas/frankenphp:php8.4-alpine",
+		"Network=lerd",
+		"Volume=" + projectDir + ":" + projectDir + ":rw",
+	}
+	for _, s := range wantFragments {
+		if !strings.Contains(got, s) {
+			t.Errorf("quadlet missing %q:\n%s", s, got)
+		}
+	}
+}
+
 func TestRefreshUnreferencedCustomQuadlets_skipsPausedAndIgnoredSites(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -397,7 +398,11 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// init or if it was pruned. All service containers use --network lerd so
 	// this must succeed before any container is started.
 	if err := podman.EnsureNetwork("lerd"); err != nil {
-		fmt.Printf("  WARN: ensure lerd network: %v\n", err)
+		if errors.Is(err, podman.ErrNetworkNeedsMigration) {
+			fmt.Println("  WARN: lerd network is missing IPv6 support; run 'lerd install' to migrate")
+		} else {
+			fmt.Printf("  WARN: ensure lerd network: %v\n", err)
+		}
 	}
 
 	// Restore quadlets and worker units that may be missing after an

--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -198,7 +198,16 @@ func ReadContainerDNS() []string {
 	if err := json.Unmarshal(data, &info); err != nil || len(info.DnsForwardIps) == 0 {
 		return readUpstreamDNS()
 	}
-	return info.DnsForwardIps
+	var out []string
+	for _, ip := range info.DnsForwardIps {
+		if clean := sanitizeDNSIP(ip); clean != "" {
+			out = append(out, clean)
+		}
+	}
+	if len(out) == 0 {
+		return readUpstreamDNS()
+	}
+	return out
 }
 
 // ReadUpstreamDNS returns upstream DNS server IPs from the running system.
@@ -234,13 +243,13 @@ func parseNmcliLines(output string) []string {
 	for _, line := range strings.Split(output, "\n") {
 		// nmcli may separate multiple values with |
 		for _, ip := range strings.Split(line, "|") {
-			ip = strings.TrimSpace(ip)
-			if ip == "" || ip == "--" || ip == "127.0.0.1" || ip == "127.0.0.53" || ip == "::1" {
+			clean := sanitizeDNSIP(ip)
+			if clean == "" {
 				continue
 			}
-			if !seen[ip] {
-				seen[ip] = true
-				servers = append(servers, ip)
+			if !seen[clean] {
+				seen[clean] = true
+				servers = append(servers, clean)
 			}
 		}
 	}

--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -181,22 +181,27 @@ var nmcliDNSFunc = func() []string {
 	return parseNmcliLines(string(out))
 }
 
-// ReadContainerDNS returns the DNS servers to configure as aardvark-dns upstreams
-// for the lerd Podman bridge network. It reads DnsForwardIps from the pasta rootless-netns
-// info.json (typically 169.254.1.1), which chains through systemd-resolved and therefore
-// resolves both .test domains (via lerd-dns) and internet domains. Falls back to
-// ReadUpstreamDNS if the file is unavailable (e.g. before Podman initialises the netns).
+// defaultUpstreamFallback returns the last-resort dnsmasq upstream when no
+// system-detected nameservers are usable. On Linux, pasta's 169.254.1.1
+// bridges into the host resolver and preserves .test routing.
+func defaultUpstreamFallback() []string {
+	return []string{pastaDefaultForwarder}
+}
+
+// ReadContainerDNS returns DNS servers for aardvark-dns on the lerd network,
+// preferring pasta's info.json (typically 169.254.1.1) and falling back to
+// host upstreams then pastaDefaultForwarder so the list is never empty.
 func ReadContainerDNS() []string {
 	path := fmt.Sprintf("/run/user/%d/containers/networks/rootless-netns/info.json", os.Getuid())
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return readUpstreamDNS()
+		return upstreamOrPasta()
 	}
 	var info struct {
 		DnsForwardIps []string `json:"DnsForwardIps"`
 	}
 	if err := json.Unmarshal(data, &info); err != nil || len(info.DnsForwardIps) == 0 {
-		return readUpstreamDNS()
+		return upstreamOrPasta()
 	}
 	var out []string
 	for _, ip := range info.DnsForwardIps {
@@ -205,9 +210,18 @@ func ReadContainerDNS() []string {
 		}
 	}
 	if len(out) == 0 {
-		return readUpstreamDNS()
+		return upstreamOrPasta()
 	}
 	return out
+}
+
+// upstreamOrPasta returns host upstreams when readable, else pasta's default
+// forwarder, so the lerd network never ends up with an empty DNS list.
+func upstreamOrPasta() []string {
+	if servers := readUpstreamDNS(); len(servers) > 0 {
+		return servers
+	}
+	return []string{pastaDefaultForwarder}
 }
 
 // ReadUpstreamDNS returns upstream DNS server IPs from the running system.

--- a/internal/dns/setup_common.go
+++ b/internal/dns/setup_common.go
@@ -22,7 +22,7 @@ func isFileContent(path string, content []byte) bool {
 }
 
 // parseNameservers parses nameserver entries from a resolv.conf-style file.
-// Skips loopback and stub resolver addresses.
+// Skips loopback, stub resolver, and zoned link-local addresses.
 func parseNameservers(path string) []string {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -35,13 +35,30 @@ func parseNameservers(path string) []string {
 			continue
 		}
 		ip := strings.TrimSpace(strings.TrimPrefix(line, "nameserver "))
-		// Skip loopback / stub resolver addresses
-		if ip == "" || ip == "127.0.0.1" || ip == "127.0.0.53" || ip == "::1" {
-			continue
+		if ip := sanitizeDNSIP(ip); ip != "" {
+			servers = append(servers, ip)
 		}
-		servers = append(servers, ip)
 	}
 	return servers
+}
+
+// sanitizeDNSIP returns ip if it is usable as an upstream DNS target inside the
+// lerd container netns, or "" if it should be filtered. Loopback, unspecified
+// and zoned addresses (e.g. fe80::...%18) are rejected — podman/netavark cannot
+// consume scoped addresses, and link-local zones are interface-bound anyway.
+func sanitizeDNSIP(ip string) string {
+	ip = strings.TrimSpace(ip)
+	if ip == "" || ip == "--" {
+		return ""
+	}
+	if strings.ContainsRune(ip, '%') {
+		return ""
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil || parsed.IsLoopback() || parsed.IsUnspecified() {
+		return ""
+	}
+	return ip
 }
 
 // WaitReady blocks until lerd-dns is accepting TCP connections on port 5300

--- a/internal/dns/setup_common.go
+++ b/internal/dns/setup_common.go
@@ -12,6 +12,11 @@ import (
 	"github.com/geodro/lerd/internal/config"
 )
 
+// pastaDefaultForwarder is pasta's rootless-netns DNS forwarder IP, which
+// bridges into the host resolver and preserves .test routing. Last-resort
+// fallback when no other upstream is usable.
+const pastaDefaultForwarder = "169.254.1.1"
+
 // isFileContent returns true if the file at path already contains exactly content.
 func isFileContent(path string, content []byte) bool {
 	existing, err := os.ReadFile(path)
@@ -123,9 +128,10 @@ func sudoWriteFile(path string, content []byte, mode os.FileMode) error {
 // auto-detecting the right target based on whether `lerd lan:expose` is on.
 //
 // When cfg.LAN.Exposed is false the config answers .test queries with
-// 127.0.0.1, suitable for local-only use. When it's true the config
-// answers with the host's primary LAN IP so remote clients reach the
-// actual nginx instance through the lerd-dns-forwarder service.
+// 127.0.0.1 / ::1, suitable for local-only use. When it's true the config
+// answers with the host's primary LAN IP (v4 + v6 when available) so remote
+// clients reach the actual nginx instance through the lerd-dns-forwarder
+// service.
 func WriteDnsmasqConfig(dir string) error {
 	target := "127.0.0.1"
 	if cfg, err := config.LoadGlobal(); err == nil && cfg != nil && cfg.LAN.Exposed {
@@ -164,25 +170,78 @@ func primaryLANIP() string {
 	return ""
 }
 
+// primaryLANIPv6 returns the host's primary global-unicast IPv6, or "" if
+// none. Link-local and ULA are skipped: LAN-exposed mode publishes
+// reachable endpoints, and those scopes don't qualify.
+func primaryLANIPv6() string {
+	conn, err := net.Dial("udp6", "[2001:4860:4860::8888]:80")
+	if err == nil {
+		defer conn.Close()
+		ip := conn.LocalAddr().(*net.UDPAddr).IP
+		if ip.IsGlobalUnicast() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast() {
+			return ip.String()
+		}
+	}
+	ifaces, ifErr := net.Interfaces()
+	if ifErr != nil {
+		return ""
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			ipnet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			ip := ipnet.IP
+			if ip.To4() != nil {
+				continue
+			}
+			if ip.IsGlobalUnicast() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast() {
+				return ip.String()
+			}
+		}
+	}
+	return ""
+}
+
+// deriveV6Target picks the AAAA target for .test mirroring v4's reach:
+// loopback or empty → ::1; LAN-exposed → host's primary global v6, else ::1.
+func deriveV6Target(v4 string) string {
+	if v4 == "" || v4 == "127.0.0.1" {
+		return "::1"
+	}
+	if v6 := primaryLANIPv6(); v6 != "" {
+		return v6
+	}
+	return "::1"
+}
+
 // WriteDnsmasqConfigFor writes the lerd dnsmasq config with `target` as the
-// IP returned for any `*.test` query. The default `127.0.0.1` is correct when
-// the only client is the local machine — nginx is reachable on loopback. When
-// remote devices need to resolve the same hostnames, pass the server's LAN IP
-// instead.
-//
-// Upstream DNS servers are detected from the running system (DHCP /
-// systemd-resolved on Linux, /etc/resolv.conf on macOS). If no upstreams are
-// detected, no-resolv is omitted so dnsmasq falls back to the container's
-// /etc/resolv.conf.
+// IPv4 answer for `*.test`. An AAAA pair is derived (::1 locally, host's
+// global v6 when LAN-exposed). Upstreams come from the system; if none are
+// usable, the pasta default forwarder is used so .test routing keeps working.
 func WriteDnsmasqConfigFor(dir, target string) error {
+	return WriteDnsmasqConfigDual(dir, target, deriveV6Target(target))
+}
+
+// WriteDnsmasqConfigDual is the v4+v6 form of WriteDnsmasqConfigFor. Pass
+// v6Target = "" to skip the AAAA record entirely.
+func WriteDnsmasqConfigDual(dir, v4Target, v6Target string) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
-	if target == "" {
-		target = "127.0.0.1"
+	if v4Target == "" {
+		v4Target = "127.0.0.1"
 	}
 
 	upstreams := readUpstreamDNS()
+	if len(upstreams) == 0 {
+		upstreams = defaultUpstreamFallback()
+	}
 
 	var sb strings.Builder
 	sb.WriteString("# Lerd DNS configuration\n")
@@ -193,7 +252,10 @@ func WriteDnsmasqConfigFor(dir, target string) error {
 			fmt.Fprintf(&sb, "server=%s\n", ip)
 		}
 	}
-	fmt.Fprintf(&sb, "address=/.test/%s\n", target)
+	fmt.Fprintf(&sb, "address=/.test/%s\n", v4Target)
+	if v6Target != "" {
+		fmt.Fprintf(&sb, "address=/.test/%s\n", v6Target)
+	}
 
 	return os.WriteFile(filepath.Join(dir, "lerd.conf"), []byte(sb.String()), 0644)
 }

--- a/internal/dns/setup_common_test.go
+++ b/internal/dns/setup_common_test.go
@@ -46,6 +46,42 @@ func TestParseNameservers_missingFile(t *testing.T) {
 	}
 }
 
+func TestParseNameservers_skipsZonedLinkLocal(t *testing.T) {
+	f := writeTempFile(t, `
+nameserver fe80::46d4:53ff:fe3f:a9a7%18
+nameserver fe80::1%eth0
+nameserver 8.8.8.8
+`)
+	got := parseNameservers(f)
+	want := []string{"8.8.8.8"}
+	assertSliceEqual(t, got, want)
+}
+
+func TestSanitizeDNSIP(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"8.8.8.8", "8.8.8.8"},
+		{"  1.1.1.1  ", "1.1.1.1"},
+		{"169.254.1.1", "169.254.1.1"},
+		{"2606:4700:4700::1111", "2606:4700:4700::1111"},
+		{"127.0.0.1", ""},
+		{"127.0.0.53", ""},
+		{"::1", ""},
+		{"0.0.0.0", ""},
+		{"", ""},
+		{"--", ""},
+		{"not-an-ip", ""},
+		{"fe80::46d4:53ff:fe3f:a9a7%18", ""},
+		{"fe80::1%eth0", ""},
+	}
+	for _, c := range cases {
+		if got := sanitizeDNSIP(c.in); got != c.want {
+			t.Errorf("sanitizeDNSIP(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestParseNameservers_commentsIgnored(t *testing.T) {
 	f := writeTempFile(t, `
 # This is a comment

--- a/internal/dns/setup_darwin.go
+++ b/internal/dns/setup_darwin.go
@@ -18,6 +18,12 @@ func readUpstreamDNS() []string {
 	return parseNameservers("/etc/resolv.conf")
 }
 
+// defaultUpstreamFallback returns nil on macOS: pasta's 169.254.1.1 isn't
+// routable from inside Podman Machine. With no fallback dnsmasq omits
+// no-resolv and uses the container's /etc/resolv.conf, which podman seeds
+// from the host.
+func defaultUpstreamFallback() []string { return nil }
+
 // ConfigureResolver writes /etc/resolver/<tld> so macOS routes .<tld> queries to
 // the lerd-dns dnsmasq container on port 5300. macOS checks /etc/resolver/<tld>
 // automatically for per-TLD DNS overrides — no daemon restart required.

--- a/internal/dns/setup_test.go
+++ b/internal/dns/setup_test.go
@@ -39,6 +39,13 @@ func TestParseNmcliOutput_deduplicates(t *testing.T) {
 	assertSliceEqual(t, got, want)
 }
 
+func TestParseNmcliOutput_skipsZonedLinkLocal(t *testing.T) {
+	input := "fe80::46d4:53ff:fe3f:a9a7%18|8.8.8.8\nfe80::1%eth0\n"
+	got := parseNmcliLines(input)
+	want := []string{"8.8.8.8"}
+	assertSliceEqual(t, got, want)
+}
+
 func TestParseNmcliOutput_empty(t *testing.T) {
 	got := parseNmcliLines("")
 	if len(got) != 0 {

--- a/internal/dns/setup_test.go
+++ b/internal/dns/setup_test.go
@@ -53,6 +53,30 @@ func TestParseNmcliOutput_empty(t *testing.T) {
 	}
 }
 
+// --- upstreamOrPasta ---
+
+func TestUpstreamOrPasta_usesUpstreamsWhenPresent(t *testing.T) {
+	fakeResolv := writeTempFile(t, "nameserver 8.8.8.8\n")
+	origPaths := resolvPaths
+	resolvPaths = []string{fakeResolv}
+	defer func() { resolvPaths = origPaths }()
+
+	got := upstreamOrPasta()
+	assertSliceEqual(t, got, []string{"8.8.8.8"})
+}
+
+func TestUpstreamOrPasta_fallsBackToPastaForwarder(t *testing.T) {
+	emptyResolv := writeTempFile(t, "# empty\n")
+	origPaths := resolvPaths
+	origNmcli := nmcliDNSFunc
+	resolvPaths = []string{emptyResolv}
+	nmcliDNSFunc = func() []string { return nil }
+	defer func() { resolvPaths = origPaths; nmcliDNSFunc = origNmcli }()
+
+	got := upstreamOrPasta()
+	assertSliceEqual(t, got, []string{pastaDefaultForwarder})
+}
+
 // --- parseDefaultInterface ---
 
 func TestParseDefaultInterface_typical(t *testing.T) {
@@ -109,7 +133,7 @@ func TestWriteDnsmasqConfig_withUpstreams(t *testing.T) {
 	assertContains(t, content, "address=/.test/127.0.0.1")
 }
 
-func TestWriteDnsmasqConfig_noUpstreams(t *testing.T) {
+func TestWriteDnsmasqConfig_noUpstreamsFallsBackToPasta(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	dir := t.TempDir()
@@ -130,8 +154,11 @@ func TestWriteDnsmasqConfig_noUpstreams(t *testing.T) {
 
 	assertContains(t, content, "port=5300")
 	assertContains(t, content, "address=/.test/127.0.0.1")
-	if strings.Contains(content, "no-resolv") {
-		t.Error("expected no-resolv to be absent when no upstreams detected")
+	assertContains(t, content, "address=/.test/::1")
+	assertContains(t, content, "no-resolv")
+	assertContains(t, content, "server="+pastaDefaultForwarder)
+	if strings.Contains(content, "listen-address") {
+		t.Errorf("dnsmasq must not restrict listen-address (rootlessport forwards via container netif, not loopback), got:\n%s", content)
 	}
 }
 
@@ -152,9 +179,8 @@ func TestWriteDnsmasqConfigFor_customTarget(t *testing.T) {
 	}
 	content := readFile(t, filepath.Join(dir, "lerd.conf"))
 	assertContains(t, content, "address=/.test/10.0.0.5")
-	if strings.Contains(content, "no-resolv") {
-		t.Error("expected no-resolv absent when no upstreams")
-	}
+	assertContains(t, content, "no-resolv")
+	assertContains(t, content, "server="+pastaDefaultForwarder)
 }
 
 func TestWriteDnsmasqConfigFor_emptyTargetDefaults(t *testing.T) {
@@ -172,6 +198,62 @@ func TestWriteDnsmasqConfigFor_emptyTargetDefaults(t *testing.T) {
 	}
 	content := readFile(t, filepath.Join(dir, "lerd.conf"))
 	assertContains(t, content, "address=/.test/127.0.0.1")
+}
+
+// --- v6 dnsmasq output ---
+
+func TestWriteDnsmasqConfig_emitsV6Listen(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir := t.TempDir()
+	fakeResolv := writeTempFile(t, "nameserver 8.8.8.8\n")
+	origPaths := resolvPaths
+	resolvPaths = []string{fakeResolv}
+	defer func() { resolvPaths = origPaths }()
+
+	if err := WriteDnsmasqConfig(dir); err != nil {
+		t.Fatalf("WriteDnsmasqConfig: %v", err)
+	}
+	content := readFile(t, filepath.Join(dir, "lerd.conf"))
+	assertContains(t, content, "address=/.test/127.0.0.1")
+	assertContains(t, content, "address=/.test/::1")
+}
+
+func TestWriteDnsmasqConfigDual_skipsV6WhenEmpty(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir := t.TempDir()
+	fakeResolv := writeTempFile(t, "nameserver 8.8.8.8\n")
+	origPaths := resolvPaths
+	resolvPaths = []string{fakeResolv}
+	defer func() { resolvPaths = origPaths }()
+
+	if err := WriteDnsmasqConfigDual(dir, "10.0.0.5", ""); err != nil {
+		t.Fatalf("WriteDnsmasqConfigDual: %v", err)
+	}
+	content := readFile(t, filepath.Join(dir, "lerd.conf"))
+	assertContains(t, content, "address=/.test/10.0.0.5")
+	if strings.Contains(content, "address=/.test/::") {
+		t.Errorf("expected no v6 address record when v6Target empty, got:\n%s", content)
+	}
+}
+
+func TestDeriveV6Target(t *testing.T) {
+	cases := []struct {
+		v4   string
+		want string
+	}{
+		{"", "::1"},
+		{"127.0.0.1", "::1"},
+	}
+	for _, c := range cases {
+		if got := deriveV6Target(c.v4); got != c.want {
+			t.Errorf("deriveV6Target(%q) = %q, want %q", c.v4, got, c.want)
+		}
+	}
+	// LAN target derives to either a global v6 (if host has one) or ::1
+	// fallback. Both are acceptable; assert it never returns empty.
+	if got := deriveV6Target("10.0.0.5"); got == "" {
+		t.Error("deriveV6Target(LAN) returned empty, expected global v6 or ::1")
+	}
 }
 
 // --- lerdDNSInterfaces parsing ---

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -324,12 +324,14 @@ func GeneratePausedVhost(site config.Site) error {
 	if site.Secured {
 		conf = fmt.Sprintf(`server {
     listen 80;
+    listen [::]:80;
     server_name %s;
     return 302 https://$host$request_uri;
 }
 
 server {
     listen 443 ssl;
+    listen [::]:443 ssl;
     server_name %s;
     ssl_certificate /etc/nginx/certs/%s.crt;
     ssl_certificate_key /etc/nginx/certs/%s.key;
@@ -343,6 +345,7 @@ server {
 	} else {
 		conf = fmt.Sprintf(`server {
     listen 80;
+    listen [::]:80;
     server_name %s;
     root %s;
     location / {
@@ -376,12 +379,14 @@ func GeneratePausedWorktreeVhost(domain, certDomain, pausedDir string, secured b
 	if secured {
 		conf = fmt.Sprintf(`server {
     listen 80;
+    listen [::]:80;
     server_name %s;
     return 302 https://$host$request_uri;
 }
 
 server {
     listen 443 ssl;
+    listen [::]:443 ssl;
     server_name %s;
     ssl_certificate /etc/nginx/certs/%s.crt;
     ssl_certificate_key /etc/nginx/certs/%s.key;
@@ -395,6 +400,7 @@ server {
 	} else {
 		conf = fmt.Sprintf(`server {
     listen 80;
+    listen [::]:80;
     server_name %s;
     root %s;
     location / {
@@ -592,6 +598,7 @@ func EnsureDefaultVhost() error {
 	errorDir := config.ErrorPagesDir()
 	content := fmt.Sprintf(`server {
     listen 80 default_server;
+    listen [::]:80 default_server;
     root %s;
     location / {
         try_files /404.html =404;
@@ -600,6 +607,7 @@ func EnsureDefaultVhost() error {
 }
 server {
     listen 443 default_server ssl;
+    listen [::]:443 default_server ssl;
     ssl_reject_handshake on;
 }
 `, errorDir)
@@ -762,6 +770,7 @@ func EnsureLerdVhost() error {
 		}
 		content = fmt.Sprintf(`server {
     listen 80;
+    listen [::]:80;
     server_name lerd.localhost;
 
     proxy_http_version 1.1;
@@ -791,6 +800,7 @@ func EnsureLerdVhost() error {
 	} else {
 		content = fmt.Sprintf(`server {
     listen 80;
+    listen [::]:80;
     server_name lerd.localhost;
 
     proxy_http_version 1.1;

--- a/internal/nginx/templates/vhost-custom-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-custom-ssl.conf.tmpl
@@ -1,11 +1,13 @@
 server {
     listen 80;
+    listen [::]:80;
     server_name {{.ServerNames}};
     return 302 https://$host$request_uri;
 }
 
 server {
     listen 443 ssl;
+    listen [::]:443 ssl;
     server_name {{.ServerNames}};
 
     ssl_certificate /etc/nginx/certs/{{.CertDomain}}.crt;

--- a/internal/nginx/templates/vhost-custom.conf.tmpl
+++ b/internal/nginx/templates/vhost-custom.conf.tmpl
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    listen [::]:80;
     server_name {{.ServerNames}};
 
     location / {

--- a/internal/nginx/templates/vhost-proxy.conf.tmpl
+++ b/internal/nginx/templates/vhost-proxy.conf.tmpl
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    listen [::]:80;
     server_name {{.Domain}};
 
     location / {

--- a/internal/nginx/templates/vhost-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-ssl.conf.tmpl
@@ -1,11 +1,13 @@
 server {
     listen 80;
+    listen [::]:80;
     server_name {{.ServerNames}};
     return 302 https://$host$request_uri;
 }
 
 server {
     listen 443 ssl;
+    listen [::]:443 ssl;
     server_name {{.ServerNames}};
     root {{.Path}}/{{.PublicDir}};
     index index.php index.html;

--- a/internal/nginx/templates/vhost.conf.tmpl
+++ b/internal/nginx/templates/vhost.conf.tmpl
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    listen [::]:80;
     server_name {{.ServerNames}};
     root {{.Path}}/{{.PublicDir}};
     index index.php index.html;

--- a/internal/podman/network.go
+++ b/internal/podman/network.go
@@ -1,22 +1,65 @@
 package podman
 
 import (
+	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 )
 
+// LerdULAv6Subnet is the deterministic IPv6 ULA prefix for the lerd network.
+// The `1e7d` body is "lerd" in leetspeak, picked to avoid colliding with
+// common defaults (fd00::, fd00:beef::, etc.).
+const LerdULAv6Subnet = "fd00:1e7d::/64"
+
+// ErrNetworkNeedsMigration is returned by EnsureNetwork when an existing lerd
+// network is missing the IPv6 subnet and must be recreated. Callers should
+// run MigrateNetworkToIPv6 (or equivalent) and then retry EnsureNetwork.
+var ErrNetworkNeedsMigration = errors.New("lerd network exists without IPv6, migration required")
+
 // NetworkGateway returns the gateway IP of the named Podman network.
-// Falls back to "127.0.0.1" if it cannot be determined.
+// Falls back to "127.0.0.1" if it cannot be determined. When the network has
+// both v4 and v6 subnets, returns the v4 gateway (which most callers expect
+// for backwards compatibility).
 func NetworkGateway(name string) string {
 	out, err := exec.Command(PodmanBin(), "network", "inspect", name,
-		"--format", "{{range .Subnets}}{{.Gateway}}{{end}}").Output()
+		"--format", "{{range .Subnets}}{{if (.Gateway).To4}}{{.Gateway}}{{end}}{{end}}").Output()
 	if err != nil || strings.TrimSpace(string(out)) == "" {
+		// Fallback for older podman that doesn't expose .To4 in the template.
+		out, err = exec.Command(PodmanBin(), "network", "inspect", name,
+			"--format", "{{range .Subnets}}{{.Gateway}} {{end}}").Output()
+		if err != nil {
+			return "127.0.0.1"
+		}
+		for _, gw := range strings.Fields(string(out)) {
+			if !strings.Contains(gw, ":") {
+				return gw
+			}
+		}
 		return "127.0.0.1"
 	}
 	return strings.TrimSpace(string(out))
 }
 
-// EnsureNetwork creates the named Podman network if it does not already exist.
+// NetworkHasIPv6 reports whether the named podman network has at least one
+// IPv6 subnet configured.
+func NetworkHasIPv6(name string) bool {
+	out, err := exec.Command(PodmanBin(), "network", "inspect", name,
+		"--format", "{{range .Subnets}}{{.Subnet}} {{end}}").Output()
+	if err != nil {
+		return false
+	}
+	for _, subnet := range strings.Fields(string(out)) {
+		if strings.Contains(subnet, ":") {
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureNetwork creates the named podman network dual-stack if it doesn't
+// exist. Returns ErrNetworkNeedsMigration if it exists v4-only; the caller
+// should run MigrateNetworkToIPv6 and retry.
 func EnsureNetwork(name string) error {
 	out, err := Run("network", "ls", "--format={{.Name}}")
 	if err != nil {
@@ -25,11 +68,67 @@ func EnsureNetwork(name string) error {
 
 	for _, line := range strings.Split(out, "\n") {
 		if strings.TrimSpace(line) == name {
-			return nil // already exists
+			if NetworkHasIPv6(name) {
+				return nil
+			}
+			return ErrNetworkNeedsMigration
 		}
 	}
 
-	return RunSilent("network", "create", "--driver", "bridge", name)
+	return RunSilent("network", "create",
+		"--driver", "bridge",
+		"--ipv6",
+		"--subnet", LerdULAv6Subnet,
+		name)
+}
+
+// MigrateNetworkToIPv6 stops and removes containers attached to the named
+// network, removes the network, and recreates it dual-stack with v4+v6.
+// Returns the removed container names so the caller can recreate them via
+// StartUnit; `podman start` would reuse the stale pre-migration network spec.
+func MigrateNetworkToIPv6(name string) ([]string, error) {
+	dnsOut, err := Run("network", "inspect", name,
+		"--format", "{{range .NetworkDNSServers}}{{.}} {{end}}")
+	if err != nil {
+		return nil, fmt.Errorf("inspect %s: %w", name, err)
+	}
+	prevDNS := strings.Fields(strings.TrimSpace(dnsOut))
+
+	containersOut, err := Run("ps", "-a",
+		"--filter", "network="+name,
+		"--format", "{{.Names}}")
+	if err != nil {
+		return nil, fmt.Errorf("listing containers on %s: %w", name, err)
+	}
+	var attached []string
+	for _, c := range strings.Split(containersOut, "\n") {
+		if c = strings.TrimSpace(c); c != "" {
+			attached = append(attached, c)
+		}
+	}
+
+	for _, c := range attached {
+		_ = RunSilent("stop", "--time", "10", c)
+		_ = RunSilent("rm", "--force", c)
+	}
+
+	if err := RunSilent("network", "rm", "--force", name); err != nil {
+		return attached, fmt.Errorf("removing %s: %w", name, err)
+	}
+
+	if err := RunSilent("network", "create",
+		"--driver", "bridge",
+		"--ipv6",
+		"--subnet", LerdULAv6Subnet,
+		name); err != nil {
+		return attached, fmt.Errorf("recreating %s: %w", name, err)
+	}
+
+	for _, dns := range prevDNS {
+		_ = RunSilent("network", "update", "--dns-add", dns, name)
+	}
+
+	return attached, nil
 }
 
 // EnsureNetworkDNS syncs the DNS servers on the named network to the provided list.

--- a/internal/podman/network_test.go
+++ b/internal/podman/network_test.go
@@ -1,0 +1,32 @@
+package podman
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestLerdULAv6Subnet_isValidIPv6CIDR(t *testing.T) {
+	ip, ipnet, err := net.ParseCIDR(LerdULAv6Subnet)
+	if err != nil {
+		t.Fatalf("LerdULAv6Subnet not parseable: %v", err)
+	}
+	if ip.To4() != nil {
+		t.Errorf("LerdULAv6Subnet must be v6, got v4 %v", ip)
+	}
+	if ones, bits := ipnet.Mask.Size(); ones != 64 || bits != 128 {
+		t.Errorf("expected /64 mask, got /%d (bits=%d)", ones, bits)
+	}
+	if !strings.HasPrefix(ip.String(), "fd") {
+		t.Errorf("expected ULA prefix (fc00::/7), got %v", ip)
+	}
+}
+
+func TestErrNetworkNeedsMigration_isComparable(t *testing.T) {
+	if ErrNetworkNeedsMigration == nil {
+		t.Fatal("ErrNetworkNeedsMigration is nil")
+	}
+	if ErrNetworkNeedsMigration.Error() == "" {
+		t.Error("ErrNetworkNeedsMigration has empty message")
+	}
+}

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -40,6 +40,7 @@ func WriteQuadletDiff(name, content string) (changed bool, err error) {
 		autostartDisabled = cfg.Autostart.Disabled
 	}
 	content = BindForLAN(content, lanExposed)
+	content = PairIPv6Binds(content)
 	content = StripInstallSection(content, autostartDisabled)
 	path := filepath.Join(dir, name+".container")
 	fileChanged := true

--- a/internal/podman/quadlet_embed.go
+++ b/internal/podman/quadlet_embed.go
@@ -186,11 +186,12 @@ func BindForLAN(content string, lanExposed bool) string {
 			continue
 		}
 		value := strings.TrimPrefix(trimmed, "PublishPort=")
-		// Skip lines that already have an explicit IP prefix (any host
-		// IP, not just 127.0.0.1 — be conservative and leave operator
-		// overrides alone). Detect by checking if the first segment
-		// contains a dot (e.g. 127.0.0.1, 192.168.x.y) rather than being
-		// a bare port number.
+		// Skip lines that already have an explicit IPv4 or IPv6 prefix
+		// (operator override). Detect IPv4 by a dot in the first segment;
+		// IPv6 binds are bracketed, e.g. PublishPort=[::1]:5300:5300.
+		if strings.HasPrefix(value, "[") {
+			continue
+		}
 		firstSeg := strings.SplitN(value, ":", 2)[0]
 		if strings.ContainsRune(firstSeg, '.') {
 			continue
@@ -198,4 +199,76 @@ func BindForLAN(content string, lanExposed bool) string {
 		lines[i] = "PublishPort=127.0.0.1:" + value
 	}
 	return strings.Join(lines, "\n")
+}
+
+// PairIPv6Binds adds an IPv6 PublishPort next to each managed IPv4 line:
+// bare/0.0.0.0 → [::], 127.0.0.1 → [::1]. Idempotent; operator overrides
+// (other v4 IPs, existing v6 lines) are preserved as-is. Skipped entirely
+// when the quadlet has no Network= directive: those containers use pasta
+// (the rootless default), and pasta can't bind v6 ports.
+func PairIPv6Binds(content string) string {
+	hasNetwork := false
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "Network=") {
+			hasNetwork = true
+			break
+		}
+	}
+	if !hasNetwork {
+		return content
+	}
+	lines := strings.Split(content, "\n")
+
+	v6PortSpecs := map[string]bool{}
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "PublishPort=") {
+			continue
+		}
+		value := strings.TrimPrefix(trimmed, "PublishPort=")
+		if !strings.HasPrefix(value, "[") {
+			continue
+		}
+		end := strings.Index(value, "]")
+		if end < 0 || end+1 >= len(value) || value[end+1] != ':' {
+			continue
+		}
+		v6PortSpecs[value[end+2:]] = true
+	}
+
+	out := make([]string, 0, len(lines)*2)
+	for _, line := range lines {
+		out = append(out, line)
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "PublishPort=") {
+			continue
+		}
+		value := strings.TrimPrefix(trimmed, "PublishPort=")
+		if strings.HasPrefix(value, "[") {
+			continue
+		}
+
+		var v6Prefix, portSpec string
+		firstSeg := strings.SplitN(value, ":", 2)[0]
+		switch {
+		case !strings.ContainsRune(firstSeg, '.'):
+			v6Prefix = "[::]:"
+			portSpec = value
+		case firstSeg == "0.0.0.0":
+			v6Prefix = "[::]:"
+			portSpec = strings.TrimPrefix(value, "0.0.0.0:")
+		case firstSeg == "127.0.0.1":
+			v6Prefix = "[::1]:"
+			portSpec = strings.TrimPrefix(value, "127.0.0.1:")
+		default:
+			continue
+		}
+
+		if v6PortSpecs[portSpec] {
+			continue
+		}
+		v6PortSpecs[portSpec] = true
+		out = append(out, "PublishPort="+v6Prefix+portSpec)
+	}
+	return strings.Join(out, "\n")
 }

--- a/internal/podman/quadlet_embed_test.go
+++ b/internal/podman/quadlet_embed_test.go
@@ -251,3 +251,65 @@ func TestSortPaths(t *testing.T) {
 		t.Errorf("expected sorted by length then lex, got: %v", paths)
 	}
 }
+
+// --- PairIPv6Binds ---
+
+func TestPairIPv6Binds_pairsBarePublishPort(t *testing.T) {
+	in := "[Container]\nNetwork=lerd\nPublishPort=80:80\nPublishPort=443:443\n"
+	out := PairIPv6Binds(in)
+	if !strings.Contains(out, "PublishPort=[::]:80:80") {
+		t.Errorf("expected v6 pair for :80:80, got:\n%s", out)
+	}
+	if !strings.Contains(out, "PublishPort=[::]:443:443") {
+		t.Errorf("expected v6 pair for :443:443, got:\n%s", out)
+	}
+}
+
+func TestPairIPv6Binds_pairsLoopbackWithLinkLocal(t *testing.T) {
+	in := "Network=lerd\nPublishPort=127.0.0.1:5300:5300/udp\nPublishPort=127.0.0.1:5300:5300/tcp\n"
+	out := PairIPv6Binds(in)
+	if !strings.Contains(out, "PublishPort=[::1]:5300:5300/udp") {
+		t.Errorf("expected v6 pair [::1]:5300:5300/udp, got:\n%s", out)
+	}
+	if !strings.Contains(out, "PublishPort=[::1]:5300:5300/tcp") {
+		t.Errorf("expected v6 pair [::1]:5300:5300/tcp, got:\n%s", out)
+	}
+}
+
+func TestPairIPv6Binds_idempotent(t *testing.T) {
+	in := "Network=lerd\nPublishPort=80:80\n"
+	once := PairIPv6Binds(in)
+	twice := PairIPv6Binds(once)
+	if once != twice {
+		t.Errorf("PairIPv6Binds is not idempotent:\nonce:\n%s\ntwice:\n%s", once, twice)
+	}
+	if strings.Count(twice, "PublishPort=[::]:80:80") != 1 {
+		t.Errorf("expected exactly one v6 pair, got:\n%s", twice)
+	}
+}
+
+func TestPairIPv6Binds_preservesOperatorOverrides(t *testing.T) {
+	in := "Network=lerd\nPublishPort=192.168.1.10:80:80\nPublishPort=[fe80::1%eth0]:80:80\n"
+	out := PairIPv6Binds(in)
+	if out != in {
+		t.Errorf("operator overrides should be preserved verbatim:\nin:\n%s\nout:\n%s", in, out)
+	}
+}
+
+func TestPairIPv6Binds_handles0000(t *testing.T) {
+	in := "Network=lerd\nPublishPort=0.0.0.0:80:80\n"
+	out := PairIPv6Binds(in)
+	if !strings.Contains(out, "PublishPort=[::]:80:80") {
+		t.Errorf("expected v6 :: pair for 0.0.0.0, got:\n%s", out)
+	}
+}
+
+func TestPairIPv6Binds_skipsWhenNoNetworkDirective(t *testing.T) {
+	// pasta (the rootless default when no Network= is set) cannot bind v6
+	// ports. Adding [::1] pairs would crash the container at startup.
+	in := "[Container]\nPublishPort=127.0.0.1:5300:5300/udp\nPublishPort=127.0.0.1:5300:5300/tcp\n"
+	out := PairIPv6Binds(in)
+	if out != in {
+		t.Errorf("expected no v6 pairs when Network= absent (pasta path); got:\n%s", out)
+	}
+}

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -243,26 +243,36 @@ func stripSELinuxVolOpts(vol string) string {
 }
 
 // stripPrivilegedIPBind removes the host-IP prefix from a PublishPort value
-// (e.g. "127.0.0.1:80:80" → "80:80") when the host port is privileged (< 1024).
-// On macOS, gvproxy handles port forwarding via podman-mac-helper and does not
-// support explicit IP binds for privileged ports — trying them causes
-// "bind: permission denied". Non-privileged ports (3306, 6379, etc.) do support
-// IP binding and are left untouched so LAN restriction still works for them.
+// when the host port is privileged (< 1024). gvproxy on macOS rejects
+// explicit IP binds for privileged ports with "bind: permission denied".
+// Handles both v4 ("127.0.0.1:80:80" → "80:80") and bracketed v6
+// ("[::1]:443:443" → "443:443"). Non-privileged ports keep their bind so
+// LAN restriction is preserved.
 func stripPrivilegedIPBind(port string) string {
-	parts := strings.SplitN(port, ":", 3)
-	if len(parts) != 3 {
-		return port // bare "containerPort" or "hostPort:containerPort" — no IP prefix
+	var rest string
+	if strings.HasPrefix(port, "[") {
+		end := strings.Index(port, "]")
+		if end < 0 || end+1 >= len(port) || port[end+1] != ':' {
+			return port
+		}
+		rest = port[end+2:]
+	} else {
+		parts := strings.SplitN(port, ":", 3)
+		if len(parts) != 3 {
+			return port
+		}
+		rest = parts[1] + ":" + parts[2]
 	}
-	hostPortStr := strings.SplitN(parts[1], "/", 2)[0] // strip "/tcp" etc.
+	hostPortStr := strings.SplitN(strings.SplitN(rest, ":", 2)[0], "/", 2)[0]
 	n := 0
 	for _, c := range hostPortStr {
 		if c < '0' || c > '9' {
-			return port // non-numeric, leave as-is
+			return port
 		}
 		n = n*10 + int(c-'0')
 	}
 	if n > 0 && n < 1024 {
-		return parts[1] + ":" + parts[2] // drop the IP prefix
+		return rest
 	}
 	return port
 }
@@ -443,6 +453,7 @@ func (m *darwinServiceManager) WriteContainerUnit(name, content string) error {
 		lanExposed = cfg.LAN.Exposed
 	}
 	content = podman.BindForLAN(content, lanExposed)
+	content = podman.PairIPv6Binds(content)
 
 	c := parseSection(content, "Container")
 	args, err := containerToPodmanArgs(c)

--- a/internal/services/launchd_test.go
+++ b/internal/services/launchd_test.go
@@ -310,3 +310,36 @@ func TestIsEnabledBasedOnPlistExistence(t *testing.T) {
 		t.Error("should be enabled when plist exists")
 	}
 }
+
+func TestStripPrivilegedIPBind_v4(t *testing.T) {
+	cases := map[string]string{
+		"127.0.0.1:80:80":     "80:80",
+		"127.0.0.1:443:443":   "443:443",
+		"127.0.0.1:5300:5300": "127.0.0.1:5300:5300",
+		"0.0.0.0:80:80":       "80:80",
+		"3306:3306":           "3306:3306",
+		"127.0.0.1:80:80/tcp": "80:80/tcp",
+		"192.168.1.1:8080:80": "192.168.1.1:8080:80",
+	}
+	for in, want := range cases {
+		if got := stripPrivilegedIPBind(in); got != want {
+			t.Errorf("stripPrivilegedIPBind(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestStripPrivilegedIPBind_v6(t *testing.T) {
+	cases := map[string]string{
+		"[::1]:80:80":         "80:80",
+		"[::1]:443:443":       "443:443",
+		"[::1]:5300:5300":     "[::1]:5300:5300",
+		"[::1]:5300:5300/udp": "[::1]:5300:5300/udp",
+		"[::]:80:80":          "80:80",
+		"[::1]:443:443/tcp":   "443:443/tcp",
+	}
+	for in, want := range cases {
+		if got := stripPrivilegedIPBind(in); got != want {
+			t.Errorf("stripPrivilegedIPBind(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes the install crash when pasta hands lerd a zoned link-local IPv6 nameserver like `fe80::...%18`. podman rejects scoped addresses so install dies. New `sanitizeDNSIP` helper filters those out at every source, and if filtering empties the upstream list we fall back to pasta's standard forwarder so .test routing keeps working.

On top of that, makes lerd dual-stack across nginx, dnsmasq, and the podman network. Vhosts get `listen [::]:80/443` next to the v4 ones. Service quadlets pair every managed PublishPort with a v6 equivalent (skipped for the lerd-dns case where pasta can't bind v6). The lerd network is created with an IPv6 ULA subnet `fd00:1e7d::/64`; existing v4-only networks get migrated on the next `lerd install`. dnsmasq emits an `::1` AAAA alongside the v4 record so containers querying over v6 resolve. launchd's bind-stripper learned to parse bracketed v6 too.

Docs updated for the new dual-stack behavior and the troubleshooting entry for the zoned link-local symptom.