### PR TITLE
fix(share): collapse https asset URLs on LAN share

### DIFF
--- a/internal/cli/lanshare.go
+++ b/internal/cli/lanshare.go
@@ -255,9 +255,7 @@ func startLANShareProxy(domain string, port, httpPort, httpsPort int, secured bo
 			return nil // unknown encoding, leave untouched
 		}
 
-		// Replace https://domain and http://domain with the LAN address.
-		body = bytes.ReplaceAll(body, []byte("https://"+domain), []byte(scheme+"://"+lanHost))
-		body = bytes.ReplaceAll(body, []byte("http://"+domain), []byte(scheme+"://"+lanHost))
+		body = rewriteLANShareBody(body, domain, lanHost)
 
 		resp.Body = io.NopCloser(bytes.NewReader(body))
 		resp.ContentLength = int64(len(body))
@@ -315,6 +313,16 @@ func PrintLANShareQR(rawURL string) {
 
 // LANShareURL returns the URL a LAN device would use to reach the site on the
 // given port, or an empty string if the port is 0 or the LAN IP cannot be detected.
+// rewriteLANShareBody collapses absolute URLs to http://<lanHost>. The third
+// pass catches https://<lanHost> URLs Laravel emitted itself (X-Forwarded-Host
+// honored, APP_URL forced https) so browsers don't TLS-handshake the proxy.
+func rewriteLANShareBody(body []byte, domain, lanHost string) []byte {
+	body = bytes.ReplaceAll(body, []byte("https://"+domain), []byte("http://"+lanHost))
+	body = bytes.ReplaceAll(body, []byte("http://"+domain), []byte("http://"+lanHost))
+	body = bytes.ReplaceAll(body, []byte("https://"+lanHost), []byte("http://"+lanHost))
+	return body
+}
+
 func LANShareURL(lanPort int) string {
 	if lanPort == 0 {
 		return ""

--- a/internal/cli/lanshare_test.go
+++ b/internal/cli/lanshare_test.go
@@ -1,0 +1,44 @@
+package cli
+
+import "testing"
+
+func TestRewriteLANShareBody_collapsesHTTPSToHTTP(t *testing.T) {
+	in := []byte(`<link href="https://laravel.test/build/app.css">
+<script src="https://laravel.test/build/app.js"></script>
+<a href="http://laravel.test/login">Login</a>`)
+
+	got := string(rewriteLANShareBody(in, "laravel.test", "192.168.1.42:9100"))
+
+	want := `<link href="http://192.168.1.42:9100/build/app.css">
+<script src="http://192.168.1.42:9100/build/app.js"></script>
+<a href="http://192.168.1.42:9100/login">Login</a>`
+
+	if got != want {
+		t.Errorf("rewriteLANShareBody:\nGOT:\n%s\nWANT:\n%s", got, want)
+	}
+}
+
+func TestRewriteLANShareBody_downgradesAlreadyRewrittenHTTPS(t *testing.T) {
+	// Laravel honors X-Forwarded-Host but forces https from APP_URL, so it
+	// already emits https://<lanHost>/asset directly. Must be downgraded.
+	in := []byte(`<link href="https://192.168.1.42:9100/build/app.css">
+<script src="https://192.168.1.42:9100/build/app.js"></script>`)
+
+	got := string(rewriteLANShareBody(in, "laravel.test", "192.168.1.42:9100"))
+
+	want := `<link href="http://192.168.1.42:9100/build/app.css">
+<script src="http://192.168.1.42:9100/build/app.js"></script>`
+
+	if got != want {
+		t.Errorf("rewriteLANShareBody downgrade:\nGOT:\n%s\nWANT:\n%s", got, want)
+	}
+}
+
+func TestRewriteLANShareBody_leavesUnrelatedURLsAlone(t *testing.T) {
+	in := []byte(`<img src="https://cdn.example.com/logo.png">
+<a href="https://other.test/foo">other</a>`)
+	got := rewriteLANShareBody(in, "laravel.test", "192.168.1.42:9100")
+	if string(got) != string(in) {
+		t.Errorf("expected URLs for other domains untouched:\nGOT:\n%s", got)
+	}
+}


### PR DESCRIPTION
LAN share serves over plain HTTP but Laravel emits asset URLs as `https://<lan-ip>:9100/build/app.css` (when APP_URL forces https and X-Forwarded-Host gets honored). The body rewriter only swapped the origin domain, so those https URLs slipped through, the browser opened TLS to the plain-HTTP proxy, and every asset failed with ERR_SSL_PROTOCOL_ERROR while the page itself loaded fine.

New `rewriteLANShareBody` helper does three passes (`https://domain` and `http://domain` to `http://lanHost`, plus `https://lanHost` to `http://lanHost`) so the asset URLs Laravel emits ahead of time get downgraded too. `lerd share` (cloudflared, ngrok, serveo, localhost.run) is left alone because those tunnels do serve over HTTPS.

Tests cover all three paths.