### PR TITLE
feat(mcp)!: slim manifest, merge action pairs, auto-refresh skills

### DIFF
--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -61,6 +61,8 @@ To target a different directory:
 lerd mcp:inject --path ~/Lerd/another-app
 ```
 
+> **During `lerd update`:** Projects that previously ran `mcp:inject` are detected automatically (by the presence of `.claude/skills/lerd/SKILL.md`, `.cursor/rules/lerd.mdc`, or the lerd marker in `.junie/guidelines.md`) and their per-project artefacts are refreshed in place. Directories whose content already matches the new binary stay untouched, so git status stays clean. Projects that never opted in are skipped.
+
 ### Path resolution
 
 Tools like `artisan`, `composer`, `env_setup`, `env_check`, `db_export`, `db_import`, and `db_create` accept an optional `path` argument. When omitted, the server resolves the path in this order:
@@ -80,29 +82,21 @@ Once the MCP server is connected, your AI assistant has access to:
 | `sites` | List all registered lerd sites (name, domain, path, PHP/Node version, framework, worker status) |
 | `runtime_versions` | List installed PHP and Node.js versions with configured defaults |
 | `php_list` | List all PHP versions installed by lerd, marking the global default |
-| `php_ext_list` | List custom PHP extensions configured for a PHP version |
-| `php_ext_add` | Add a custom PHP extension (rebuilds the FPM image and restarts the container) |
-| `php_ext_remove` | Remove a custom PHP extension (rebuilds the FPM image and restarts the container) |
+| `php_ext` | Manage custom PHP extensions for a PHP version — `action`: `list` / `add` / `remove` (`add` and `remove` rebuild the FPM image and restart the container) |
 | `artisan` | Run `php artisan` in the PHP-FPM container: migrations, generators, seeders, cache, tinker (Laravel only) |
 | `console` | Run the framework's console command (e.g. `php bin/console` for Symfony); shown for non-Laravel frameworks that define a `console` field |
 | `composer` | Run `composer` in the PHP-FPM container: install, require, dump-autoload, etc. |
-| `node_install` | Install a Node.js version via fnm (e.g. `"20"`, `"lts"`) |
-| `node_uninstall` | Uninstall a Node.js version via fnm |
+| `node` | Install or uninstall a Node.js version via fnm — `action`: `install` / `uninstall` (e.g. `"20"`, `"lts"`) |
 | `env_setup` | Configure `.env` for lerd: detects services, starts them, creates DB, sets APP_KEY and APP_URL |
 | `env_check` | Compare all `.env` files against `.env.example` and flag missing or extra keys (returns structured JSON) |
 | `site_link` | Register a directory as a lerd site; generates nginx vhost and `.test` domain |
 | `site_unlink` | Unregister a site and remove its nginx vhost (all domains) |
-| `site_domain_add` | Add an additional domain to a site (without TLD) |
-| `site_domain_remove` | Remove a domain from a site (cannot remove last) |
+| `site_domain` | Add or remove a site domain (without TLD) — `action`: `add` / `remove`; cannot remove last |
 | `park` | Register a parent directory; scans subdirectories and auto-registers any PHP projects as sites |
 | `unpark` | Remove a parked directory from lerd and unlink all its sites |
-| `secure` | Enable HTTPS for a site using a locally-trusted mkcert certificate |
-| `unsecure` | Disable HTTPS for a site |
-| `xdebug_on` | Enable Xdebug for a PHP version and restart the FPM container. Optional `mode` (default `debug`; accepts `coverage`, `develop`, `profile`, `trace`, `gcstats`, or comma combos like `debug,coverage`) |
-| `xdebug_off` | Disable Xdebug for a PHP version |
-| `xdebug_status` | Show Xdebug enabled/disabled state and active `mode` for all PHP versions |
-| `service_start` | Start a built-in or custom service; if the service has `depends_on`, dependencies start first and dependent services start after |
-| `service_stop` | Stop a built-in or custom service; cascade-stops any custom services that depend on it first |
+| `site_tls` | Enable or disable HTTPS for a site using a locally-trusted mkcert certificate — `action`: `enable` / `disable` |
+| `xdebug` | Manage Xdebug for a PHP version — `action`: `on` / `off` / `status`. `on` accepts optional `mode` (default `debug`; accepts `coverage`, `develop`, `profile`, `trace`, `gcstats`, or comma combos like `debug,coverage`); `status` reports state and active mode for all PHP versions |
+| `service_control` | Start, stop, pin, or unpin a built-in or custom service — `action`: `start` / `stop` / `pin` / `unpin`. Starting/stopping respects `depends_on` cascades; `pin` keeps a service running regardless of site activity |
 | `service_add` | Register a new custom OCI-based service (MongoDB, RabbitMQ, etc.); supports `depends_on` for service dependencies |
 | `service_remove` | Stop and deregister a custom service |
 | `service_expose` | Add or remove an extra published port on a built-in service (persisted, auto-restarts if running) |
@@ -110,29 +104,19 @@ Once the MCP server is connected, your AI assistant has access to:
 | `db_export` | Export a database to a SQL dump file (defaults to site DB from `.env`) |
 | `db_import` | Import a SQL dump file into the project database (reads connection from `.env`) |
 | `db_create` | Create a database and `_testing` variant for the project (infers name from `.env` or project dir) |
-| `queue_start` | Start the queue worker for a site (any framework with a `queue` worker) |
-| `queue_stop` | Stop the queue worker |
-| `horizon_start` | Start Laravel Horizon for a site (use instead of `queue_start` when `laravel/horizon` is installed) |
-| `horizon_stop` | Stop Laravel Horizon |
-| `reverb_start` | Start the Reverb WebSocket server for a site |
-| `reverb_stop` | Stop the Reverb server |
-| `schedule_start` | Start the task scheduler for a site |
-| `schedule_stop` | Stop the task scheduler |
-| `worker_start` | Start any named framework worker (e.g. `messenger`, `pulse`) |
-| `worker_stop` | Stop a named framework worker |
+| `queue` | Start or stop the queue worker for a site — `action`: `start` / `stop` (any framework with a `queue` worker) |
+| `horizon` | Start or stop Laravel Horizon for a site — `action`: `start` / `stop` (use instead of `queue` when `laravel/horizon` is installed) |
+| `reverb` | Start or stop the Reverb WebSocket server for a site — `action`: `start` / `stop` |
+| `schedule` | Start or stop the task scheduler for a site — `action`: `start` / `stop` |
+| `worker` | Start or stop any named framework worker (e.g. `messenger`, `pulse`) — `action`: `start` / `stop` |
 | `worker_list` | List all workers defined for a site's framework with running status |
 | `framework_list` | List all framework definitions including their workers |
 | `framework_add` | Add or update a framework definition; use `name: "laravel"` to add custom workers to Laravel |
 | `framework_remove` | Remove a user-defined framework; for `laravel` removes only custom worker additions |
 | `site_php` | Change the PHP version for a registered site: writes `.php-version`, updates registry, regenerates nginx vhost |
 | `site_node` | Change the Node.js version for a registered site: writes `.node-version`, installs via fnm if needed |
-| `site_pause` | Pause a site: stop workers and custom container, replace vhost with landing page |
-| `site_unpause` | Resume a paused site: start container, restore vhost, restart workers |
-| `site_restart` | Restart a site's container (custom container or PHP-FPM) |
-| `service_pin` | Pin a service so it is never auto-stopped even when no sites reference it |
-| `service_unpin` | Unpin a service so it can be auto-stopped when unused |
-| `stripe_listen` | Start a Stripe webhook listener for a site (reads `STRIPE_SECRET` from `.env`) |
-| `stripe_listen_stop` | Stop the Stripe webhook listener |
+| `site_control` | Pause, unpause, restart, or rebuild a site — `action`: `pause` / `unpause` / `restart` / `rebuild` (pause replaces vhost with landing page; rebuild only for custom containers) |
+| `stripe` | Start or stop a Stripe webhook listener for a site — `action`: `start` / `stop` (reads `STRIPE_SECRET` from `.env` on start) |
 | `logs` | Fetch container logs; defaults to current site's FPM; optionally specify nginx, service name, PHP version, or site name |
 | `status` | Health snapshot of DNS, nginx, PHP-FPM containers, and the watcher; use when a site isn't loading |
 | `doctor` | Full diagnostic as structured JSON: podman, systemd, DNS, ports, PHP images, config, updates; use when the user reports setup issues |
@@ -165,12 +149,12 @@ AI:  → composer(args: ["require", "laravel/sanctum"])
 
 You: add a MongoDB service
 AI:  → service_add(name: "mongodb", image: "docker.io/library/mongo:7", ports: ["27017:27017"], data_dir: "/data/db")
-     → service_start(name: "mongodb")
+     → service_control(action: "start", name: "mongodb")
      ✓  mongodb started
 
 You: add phpMyAdmin, it needs MySQL to be running
 AI:  → service_add(name: "phpmyadmin", image: "docker.io/phpmyadmin:latest", ports: ["8080:80"], depends_on: ["mysql"], dashboard: "http://localhost:8080")
-     → service_start(name: "phpmyadmin")
+     → service_control(action: "start", name: "phpmyadmin")
        # starts mysql first (dependency), then phpmyadmin
      ✓  mysql started
      ✓  phpmyadmin started
@@ -189,12 +173,12 @@ AI:  → site_link()
      ✓  whitewaters -> whitewaters.test ready
 
 You: enable xdebug so I can step through a failing job
-AI:  → xdebug_status()
-     → xdebug_on(version: "8.5")
+AI:  → xdebug(action: "status")
+     → xdebug(action: "on", version: "8.5")
      ✓  Xdebug enabled for PHP 8.5 (mode=debug, port 9003)
 
 You: turn on xdebug coverage so I can run phpunit --coverage
-AI:  → xdebug_on(version: "8.5", mode: "coverage")
+AI:  → xdebug(action: "on", version: "8.5", mode: "coverage")
      ✓  Xdebug enabled for PHP 8.5 (mode=coverage, port 9003)
 
 You: the app is throwing 500s, check the logs

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -66,22 +66,35 @@ func runMCPInject(targetPath string) error {
 		return err
 	}
 
+	fmt.Printf("Injecting lerd MCP config into: %s\n\n", abs)
+	if err := WriteProjectAISkills(abs, true); err != nil {
+		return err
+	}
+	fmt.Println("\nDone! Restart your AI assistant to load the lerd MCP server.")
+	return nil
+}
+
+// WriteProjectAISkills writes the per-project AI artefacts for abs. MCP config
+// JSONs and .junie/guidelines.md preserve non-lerd entries; SKILL.md and
+// lerd.mdc are overwritten. verbose=true prints each written path.
+func WriteProjectAISkills(abs string, verbose bool) error {
 	lerdEntry := map[string]any{
 		"command": "lerd",
 		"args":    []string{"mcp"},
 		"env":     map[string]string{"LERD_SITE_PATH": abs},
 	}
 
-	fmt.Printf("Injecting lerd MCP config into: %s\n\n", abs)
+	log := func(msg string) {
+		if verbose {
+			fmt.Println(msg)
+		}
+	}
 
-	// .mcp.json — merge lerd into mcpServers
 	if err := mergeMCPServersJSON(filepath.Join(abs, ".mcp.json"), lerdEntry); err != nil {
 		return err
 	}
-	rel1 := ".mcp.json"
-	fmt.Printf("  updated %s\n", rel1)
+	log("  updated .mcp.json")
 
-	// .cursor/mcp.json — Cursor
 	cursorPath := filepath.Join(abs, ".cursor", "mcp.json")
 	if err := os.MkdirAll(filepath.Dir(cursorPath), 0755); err != nil {
 		return fmt.Errorf("creating .cursor: %w", err)
@@ -89,9 +102,8 @@ func runMCPInject(targetPath string) error {
 	if err := mergeMCPServersJSON(cursorPath, lerdEntry); err != nil {
 		return err
 	}
-	fmt.Printf("  updated .cursor/mcp.json\n")
+	log("  updated .cursor/mcp.json")
 
-	// .ai/mcp/mcp.json — same mcpServers format (Windsurf and others)
 	aiPath := filepath.Join(abs, ".ai", "mcp", "mcp.json")
 	if err := os.MkdirAll(filepath.Dir(aiPath), 0755); err != nil {
 		return fmt.Errorf("creating .ai/mcp: %w", err)
@@ -99,9 +111,8 @@ func runMCPInject(targetPath string) error {
 	if err := mergeMCPServersJSON(aiPath, lerdEntry); err != nil {
 		return err
 	}
-	fmt.Printf("  updated .ai/mcp/mcp.json\n")
+	log("  updated .ai/mcp/mcp.json")
 
-	// .junie/mcp/mcp.json — same mcpServers format
 	juniePath := filepath.Join(abs, ".junie", "mcp", "mcp.json")
 	if err := os.MkdirAll(filepath.Dir(juniePath), 0755); err != nil {
 		return fmt.Errorf("creating .junie/mcp: %w", err)
@@ -109,37 +120,62 @@ func runMCPInject(targetPath string) error {
 	if err := mergeMCPServersJSON(juniePath, lerdEntry); err != nil {
 		return err
 	}
-	fmt.Printf("  updated .junie/mcp/mcp.json\n")
+	log("  updated .junie/mcp/mcp.json")
 
-	// .claude/skills/lerd/SKILL.md — always overwrite (we own this file)
 	skillPath := filepath.Join(abs, ".claude", "skills", "lerd", "SKILL.md")
 	if err := os.MkdirAll(filepath.Dir(skillPath), 0755); err != nil {
 		return fmt.Errorf("creating .claude/skills/lerd: %w", err)
 	}
-	if err := os.WriteFile(skillPath, []byte(claudeSkillContent), 0644); err != nil {
+	if err := writeIfChanged(skillPath, []byte(claudeSkillContent)); err != nil {
 		return fmt.Errorf("writing SKILL.md: %w", err)
 	}
-	fmt.Printf("  wrote   .claude/skills/lerd/SKILL.md\n")
+	log("  wrote   .claude/skills/lerd/SKILL.md")
 
-	// .cursor/rules/lerd.mdc — Cursor rules file (always overwrite, we own it)
 	cursorRulesPath := filepath.Join(abs, ".cursor", "rules", "lerd.mdc")
 	if err := os.MkdirAll(filepath.Dir(cursorRulesPath), 0755); err != nil {
 		return fmt.Errorf("creating .cursor/rules: %w", err)
 	}
-	if err := os.WriteFile(cursorRulesPath, []byte(cursorRulesContent), 0644); err != nil {
+	if err := writeIfChanged(cursorRulesPath, []byte(cursorRulesContent)); err != nil {
 		return fmt.Errorf("writing lerd.mdc: %w", err)
 	}
-	fmt.Printf("  wrote   .cursor/rules/lerd.mdc\n")
+	log("  wrote   .cursor/rules/lerd.mdc")
 
-	// .junie/guidelines.md — merge our section (Junie's equivalent of Claude skills)
 	guidelinesPath := filepath.Join(abs, ".junie", "guidelines.md")
 	if err := mergeJunieGuidelines(guidelinesPath, junieGuidelinesSection); err != nil {
 		return fmt.Errorf("writing .junie/guidelines.md: %w", err)
 	}
-	fmt.Printf("  updated .junie/guidelines.md\n")
+	log("  updated .junie/guidelines.md")
 
-	fmt.Println("\nDone! Restart your AI assistant to load the lerd MCP server.")
 	return nil
+}
+
+// ProjectHasLerdSkills is the opt-in signal for project-scoped refresh: true
+// iff at least one lerd-owned marker file exists. Shared JSON configs are not
+// checked because they may contain unrelated MCP servers.
+func ProjectHasLerdSkills(abs string) bool {
+	if _, err := os.Stat(filepath.Join(abs, ".claude", "skills", "lerd", "SKILL.md")); err == nil {
+		return true
+	}
+	if _, err := os.Stat(filepath.Join(abs, ".cursor", "rules", "lerd.mdc")); err == nil {
+		return true
+	}
+	if data, err := os.ReadFile(filepath.Join(abs, ".junie", "guidelines.md")); err == nil {
+		if strings.Contains(string(data), "<!-- lerd:begin -->") {
+			return true
+		}
+	}
+	return false
+}
+
+// writeIfChanged only writes when content differs, so projects already current
+// stay untouched (clean git status across upgrades).
+func writeIfChanged(path string, content []byte) error {
+	if existing, err := os.ReadFile(path); err == nil {
+		if len(existing) == len(content) && string(existing) == string(content) {
+			return nil
+		}
+	}
+	return os.WriteFile(path, content, 0644)
 }
 
 // NewMCPEnableGlobalCmd returns the mcp:enable-global command.
@@ -362,7 +398,7 @@ This project runs on **lerd**, a Podman-based Laravel development environment fo
 
 ## Path resolution
 
-Tools that accept a ` + bt + `path` + bt + ` argument (` + bt + `artisan` + bt + `, ` + bt + `composer` + bt + `, ` + bt + `env_setup` + bt + `, ` + bt + `env_check` + bt + `, ` + bt + `db_set` + bt + `, ` + bt + `site_link` + bt + `, ` + bt + `site_unlink` + bt + `, ` + bt + `site_domain_add` + bt + `, ` + bt + `site_domain_remove` + bt + `, ` + bt + `db_export` + bt + `, ` + bt + `db_import` + bt + `, ` + bt + `db_create` + bt + `, etc.) resolve it in this order:
+Tools that accept a ` + bt + `path` + bt + ` argument (` + bt + `artisan` + bt + `, ` + bt + `composer` + bt + `, ` + bt + `env_setup` + bt + `, ` + bt + `env_check` + bt + `, ` + bt + `db_set` + bt + `, ` + bt + `site_link` + bt + `, ` + bt + `site_unlink` + bt + `, ` + bt + `site_domain` + bt + `, ` + bt + `db_export` + bt + `, ` + bt + `db_import` + bt + `, ` + bt + `db_create` + bt + `, etc.) resolve it in this order:
 1. Explicit ` + bt + `path` + bt + ` argument
 2. ` + bt + `LERD_SITE_PATH` + bt + ` env var (set when using project-scoped ` + bt + `mcp:inject` + bt + `)
 3. **Current working directory** — the directory Claude was opened in
@@ -393,22 +429,23 @@ List all registered lerd sites with domains, paths, PHP versions, Node versions,
 List all installed PHP and Node.js versions and the configured defaults. Call this to check what runtimes are available before running commands.
 
 ### ` + bt + `php_list` + bt + `
-List all PHP versions installed by lerd as JSON, with each version's ` + bt + `default` + bt + ` flag. Use this to confirm which versions are available before calling ` + bt + `site_php` + bt + `, ` + bt + `php_ext_add` + bt + `, or ` + bt + `xdebug_on` + bt + `.
+List all PHP versions installed by lerd as JSON, with each version's ` + bt + `default` + bt + ` flag. Use this to confirm which versions are available before calling ` + bt + `site_php` + bt + `, ` + bt + `php_ext` + bt + `, or ` + bt + `xdebug` + bt + `.
 
-### ` + bt + `php_ext_list` + bt + ` / ` + bt + `php_ext_add` + bt + ` / ` + bt + `php_ext_remove` + bt + `
+### ` + bt + `php_ext` + bt + `
 Manage custom PHP extensions for a PHP version. Extensions are added on top of the bundled lerd FPM image. Adding or removing an extension rebuilds the image and restarts the FPM container (may take a minute).
 
-Optional ` + bt + `version` + bt + ` argument on all three — defaults to the project or global PHP version.
-
-` + bt + `php_ext_add` + bt + ` and ` + bt + `php_ext_remove` + bt + ` take ` + bt + `extension` + bt + ` (required).
+Arguments:
+- ` + bt + `action` + bt + ` (required): ` + bt + `"list"` + bt + `, ` + bt + `"add"` + bt + `, or ` + bt + `"remove"` + bt + `
+- ` + bt + `version` + bt + ` (optional): defaults to the project or global PHP version
+- ` + bt + `extension` + bt + ` (required for ` + bt + `add` + bt + ` and ` + bt + `remove` + bt + `)
 
 Examples:
 ` + "```" + `
-php_ext_list()                              // list extensions for current project's PHP version
-php_ext_list(version: "8.4")               // list extensions for 8.4
-php_ext_add(extension: "imagick")          // add imagick to current project's PHP version
-php_ext_add(extension: "redis", version: "8.3")
-php_ext_remove(extension: "imagick")
+php_ext(action: "list")                                        // list extensions for current project's PHP version
+php_ext(action: "list", version: "8.4")                        // list extensions for 8.4
+php_ext(action: "add", extension: "imagick")                   // add imagick to current project's PHP version
+php_ext(action: "add", extension: "redis", version: "8.3")
+php_ext(action: "remove", extension: "imagick")
 ` + "```" + `
 
 ### ` + bt + `artisan` + bt + ` (Laravel only)
@@ -472,19 +509,32 @@ vendor_run(bin: "rector", args: ["process", "--dry-run"])
 
 Prefer ` + bt + `vendor_run` + bt + ` over ` + bt + `composer(args: ["exec", ...])` + bt + ` — it's faster, doesn't go through composer's plugin pipeline, and the same shortcut is available on the CLI as ` + bt + `lerd <bin>` + bt + ` (e.g. ` + bt + `lerd pest` + bt + `, ` + bt + `lerd pint` + bt + `).
 
-### ` + bt + `node_install` + bt + ` / ` + bt + `node_uninstall` + bt + `
-Install or uninstall a Node.js version via fnm. Accepts a version number or alias:
+### ` + bt + `node` + bt + `
+Install or uninstall a Node.js version via fnm. Accepts a version number or alias.
+
+Arguments:
+- ` + bt + `action` + bt + ` (required): ` + bt + `"install"` + bt + ` or ` + bt + `"uninstall"` + bt + `
+- ` + bt + `version` + bt + ` (required)
+
 ` + "```" + `
-node_install(version: "20")
-node_install(version: "20.11.0")
-node_install(version: "lts")
-node_uninstall(version: "18.20.0")
+node(action: "install", version: "20")
+node(action: "install", version: "20.11.0")
+node(action: "install", version: "lts")
+node(action: "uninstall", version: "18.20.0")
 ` + "```" + `
 
 After installing a version you can pin it to a project by writing a ` + bt + `.node-version` + bt + ` file in the project root (or run ` + bt + `lerd isolate:node <version>` + bt + ` from a terminal).
 
-### ` + bt + `service_start` + bt + ` / ` + bt + `service_stop` + bt + `
-Start or stop any service — built-in or custom. ` + bt + `service_stop` + bt + ` marks the service as **paused** — ` + bt + `lerd start` + bt + ` and autostart on login will skip it until you explicitly start it again.
+### ` + bt + `service_control` + bt + `
+Start, stop, pin, or unpin any service — built-in or custom.
+
+Arguments:
+- ` + bt + `action` + bt + ` (required): ` + bt + `"start"` + bt + `, ` + bt + `"stop"` + bt + `, ` + bt + `"pin"` + bt + `, or ` + bt + `"unpin"` + bt + `
+- ` + bt + `name` + bt + ` (required): service name
+
+` + bt + `service_control(action: "stop", ...)` + bt + ` marks the service as **paused** — ` + bt + `lerd start` + bt + ` and autostart on login will skip it until you explicitly start it again.
+
+` + bt + `service_control(action: "pin", ...)` + bt + ` marks a service so it is **never auto-stopped**, even when no active sites reference it in their ` + bt + `.env` + bt + `. Starts the service if it isn't already running. Use this for services you want always available regardless of which site is active (e.g. a shared Redis or MySQL). ` + bt + `service_control(action: "unpin", ...)` + bt + ` removes the pin so the service can be auto-stopped when no sites use it.
 
 **Dependency cascade:** if a custom service has ` + bt + `depends_on` + bt + ` set, starting its dependency also starts it; stopping the dependency stops it first. Starting the custom service directly ensures its dependencies start first.
 
@@ -541,7 +591,7 @@ service_add(
   data_dir: "/data/db",
   env_vars: ["MONGODB_URL=mongodb://lerd-mongodb:27017"]
 )
-service_start(name: "mongodb")
+service_control(action: "start", name: "mongodb")
 ` + "```" + `
 
 Example — add phpMyAdmin depending on MySQL:
@@ -553,7 +603,7 @@ service_add(
   depends_on: ["mysql"],
   dashboard: "http://localhost:8080"
 )
-service_start(name: "phpmyadmin")   // starts mysql first, then phpmyadmin
+service_control(action: "start", name: "phpmyadmin")   // starts mysql first, then phpmyadmin
 ` + "```" + `
 
 ` + bt + `service_remove` + bt + ` stops and deregisters a custom service. Persistent data is NOT deleted.
@@ -574,12 +624,12 @@ service_preset_install(name: "phpmyadmin")           // adds phpmyadmin, mysql i
 service_preset_install(name: "mongo")                // install mongo first…
 service_preset_install(name: "mongo-express")        // …then mongo-express (gated otherwise)
 service_preset_install(name: "mysql", version: "8.4")
-service_start(name: "phpmyadmin")                    // mysql is started automatically
+service_control(action: "start", name: "phpmyadmin") // mysql is started automatically
 ` + "```" + `
 
 **Dependency gating:** installing a preset whose dependency is another *custom* service (e.g. ` + bt + `mongo-express` + bt + ` on ` + bt + `mongo` + bt + `) is rejected with a clear error until the dependency is installed first. Built-in deps (mysql, postgres) are auto-satisfied.
 
-Once installed, presets are normal custom services — manage them with ` + bt + `service_start` + bt + `, ` + bt + `service_stop` + bt + `, ` + bt + `service_remove` + bt + `, ` + bt + `service_expose` + bt + `, ` + bt + `service_pin` + bt + `.
+Once installed, presets are normal custom services — manage them with ` + bt + `service_control` + bt + `, ` + bt + `service_remove` + bt + `, and ` + bt + `service_expose` + bt + `.
 
 ### ` + bt + `service_env` + bt + `
 Return the recommended Laravel ` + bt + `.env` + bt + ` connection variables for a service — built-in or custom — as a key/value map. Use this when you need to inspect or manually apply connection settings without running ` + bt + `env_setup` + bt + `.
@@ -654,8 +704,9 @@ Register or unregister a directory as a lerd site. Arguments for ` + bt + `site_
 
 ` + bt + `site_unlink` + bt + ` takes ` + bt + `path` + bt + ` (optional, same resolution as ` + bt + `site_link` + bt + `). Removes the site and all its domains. Project files are NOT deleted.
 
-### ` + bt + `site_domain_add` + bt + ` / ` + bt + `site_domain_remove` + bt + `
+### ` + bt + `site_domain` + bt + `
 Add or remove additional domains for a site. Each site can have multiple domains (all served by the same nginx vhost).
+- ` + bt + `action` + bt + ` (required): ` + bt + `"add"` + bt + ` or ` + bt + `"remove"` + bt + `
 - ` + bt + `path` + bt + ` (optional): project directory
 - ` + bt + `domain` + bt + ` (required): domain name without TLD (e.g. ` + bt + `"api"` + bt + ` becomes ` + bt + `api.test` + bt + `)
 
@@ -668,53 +719,76 @@ Cannot remove the last domain. When a site is secured, the TLS certificate is au
 
 Both take ` + bt + `path` + bt + ` (optional, defaults to LERD_SITE_PATH or cwd).
 
-### ` + bt + `secure` + bt + ` / ` + bt + `unsecure` + bt + `
-Enable or disable HTTPS for a site using a locally-trusted mkcert certificate. Both take ` + bt + `site` + bt + ` (site name). ` + bt + `APP_URL` + bt + ` in ` + bt + `.env` + bt + ` is updated automatically.
-
-### ` + bt + `xdebug_on` + bt + ` / ` + bt + `xdebug_off` + bt + ` / ` + bt + `xdebug_status` + bt + `
-Toggle Xdebug for a PHP version (restarts the FPM container). Optional ` + bt + `version` + bt + ` argument — defaults to the project or global PHP version. Xdebug listens on port ` + bt + `9003` + bt + ` at ` + bt + `host.containers.internal` + bt + `.
-
-` + bt + `xdebug_on` + bt + ` accepts an optional ` + bt + `mode` + bt + ` argument (default ` + bt + `debug` + bt + `). Valid values: ` + bt + `debug` + bt + `, ` + bt + `coverage` + bt + `, ` + bt + `develop` + bt + `, ` + bt + `profile` + bt + `, ` + bt + `trace` + bt + `, ` + bt + `gcstats` + bt + `, or a comma-separated combo such as ` + bt + `debug,coverage` + bt + `. Use ` + bt + `coverage` + bt + ` for ` + bt + `phpunit --coverage` + bt + ` / ` + bt + `pest --coverage` + bt + ` when PCOV isn't available or is disabled. Calling ` + bt + `xdebug_on` + bt + ` with a different mode on an already-enabled version swaps modes without needing ` + bt + `xdebug_off` + bt + ` first.
-
-` + bt + `xdebug_status` + bt + ` returns the enabled/disabled state and the active ` + bt + `mode` + bt + ` for all installed PHP versions.
-
-### ` + bt + `queue_start` + bt + ` / ` + bt + `queue_stop` + bt + `
-Start or stop a queue worker for a site. Available for any framework that defines a ` + bt + `queue` + bt + ` worker (Laravel has it built-in). Runs the framework-defined command in the FPM container as a systemd service.
-
-> **Redis queues:** if the project's ` + bt + `.env` + bt + ` has ` + bt + `QUEUE_CONNECTION=redis` + bt + `, lerd will refuse to start the worker unless ` + bt + `lerd-redis` + bt + ` is running. Call ` + bt + `service_start(name: "redis")` + bt + ` first.
-
-Arguments for ` + bt + `queue_start` + bt + `:
-- ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
-- ` + bt + `queue` + bt + ` (optional): queue name, default ` + bt + `"default"` + bt + `
-- ` + bt + `tries` + bt + ` (optional): max job attempts, default ` + bt + `3` + bt + `
-- ` + bt + `timeout` + bt + ` (optional): job timeout in seconds, default ` + bt + `60` + bt + `
-
-### ` + bt + `horizon_start` + bt + ` / ` + bt + `horizon_stop` + bt + `
-Start or stop Laravel Horizon for a site. Horizon is a queue manager that replaces ` + bt + `queue:work` + bt + ` — use ` + bt + `horizon_start` + bt + ` instead of ` + bt + `queue_start` + bt + ` for projects that have ` + bt + `laravel/horizon` + bt + ` in ` + bt + `composer.json` + bt + `. Takes ` + bt + `site` + bt + ` (required, site name from ` + bt + `sites` + bt + ` tool). Returns an error if ` + bt + `laravel/horizon` + bt + ` is not installed.
-
-> **Horizon vs queue worker:** The ` + bt + `sites` + bt + ` tool returns ` + bt + `has_horizon: true` + bt + ` when a site has Horizon installed. In that case prefer ` + bt + `horizon_start` + bt + ` over ` + bt + `queue_start` + bt + `.
-
-### ` + bt + `reverb_start` + bt + ` / ` + bt + `reverb_stop` + bt + `
-Start or stop the Reverb WebSocket server for a site. Available for any framework that defines a ` + bt + `reverb` + bt + ` worker. Takes ` + bt + `site` + bt + ` (required, site name from ` + bt + `sites` + bt + ` tool).
-
-### ` + bt + `schedule_start` + bt + ` / ` + bt + `schedule_stop` + bt + `
-Start or stop the task scheduler for a site. Available for any framework that defines a ` + bt + `schedule` + bt + ` worker. Takes ` + bt + `site` + bt + ` (required, site name from ` + bt + `sites` + bt + ` tool).
-
-### ` + bt + `worker_start` + bt + ` / ` + bt + `worker_stop` + bt + `
-Start or stop any named framework worker for a site. Use this for workers that don't have a dedicated shortcut (e.g. ` + bt + `messenger` + bt + ` for Symfony, ` + bt + `horizon` + bt + ` or ` + bt + `pulse` + bt + ` for Laravel). The worker command is taken from the framework definition.
+### ` + bt + `site_tls` + bt + `
+Enable or disable HTTPS for a site using a locally-trusted mkcert certificate. ` + bt + `APP_URL` + bt + ` in ` + bt + `.env` + bt + ` is updated automatically.
 
 Arguments:
+- ` + bt + `action` + bt + ` (required): ` + bt + `"enable"` + bt + ` or ` + bt + `"disable"` + bt + `
+- ` + bt + `site` + bt + ` (required): site name
+
+### ` + bt + `xdebug` + bt + `
+Toggle Xdebug for a PHP version (restarts the FPM container) or report its state. Xdebug listens on port ` + bt + `9003` + bt + ` at ` + bt + `host.containers.internal` + bt + `.
+
+Arguments:
+- ` + bt + `action` + bt + ` (required): ` + bt + `"on"` + bt + `, ` + bt + `"off"` + bt + `, or ` + bt + `"status"` + bt + `
+- ` + bt + `version` + bt + ` (optional): defaults to the project or global PHP version
+- ` + bt + `mode` + bt + ` (optional, only for ` + bt + `on` + bt + `): default ` + bt + `debug` + bt + `. Valid values: ` + bt + `debug` + bt + `, ` + bt + `coverage` + bt + `, ` + bt + `develop` + bt + `, ` + bt + `profile` + bt + `, ` + bt + `trace` + bt + `, ` + bt + `gcstats` + bt + `, or a comma-separated combo such as ` + bt + `debug,coverage` + bt + `
+
+Use ` + bt + `coverage` + bt + ` for ` + bt + `phpunit --coverage` + bt + ` / ` + bt + `pest --coverage` + bt + ` when PCOV isn't available or is disabled. Calling ` + bt + `xdebug(action: "on", ...)` + bt + ` with a different mode on an already-enabled version swaps modes without needing ` + bt + `action: "off"` + bt + ` first.
+
+` + bt + `xdebug(action: "status")` + bt + ` returns the enabled/disabled state and the active ` + bt + `mode` + bt + ` for all installed PHP versions.
+
+### ` + bt + `queue` + bt + `
+Start or stop a queue worker for a site. Available for any framework that defines a ` + bt + `queue` + bt + ` worker (Laravel has it built-in). Runs the framework-defined command in the FPM container as a systemd service.
+
+> **Redis queues:** if the project's ` + bt + `.env` + bt + ` has ` + bt + `QUEUE_CONNECTION=redis` + bt + `, lerd will refuse to start the worker unless ` + bt + `lerd-redis` + bt + ` is running. Call ` + bt + `service_control(action: "start", name: "redis")` + bt + ` first.
+
+Arguments:
+- ` + bt + `action` + bt + ` (required): ` + bt + `"start"` + bt + ` or ` + bt + `"stop"` + bt + `
+- ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
+- ` + bt + `queue` + bt + ` (optional, ` + bt + `start` + bt + ` only): queue name, default ` + bt + `"default"` + bt + `
+- ` + bt + `tries` + bt + ` (optional, ` + bt + `start` + bt + ` only): max job attempts, default ` + bt + `3` + bt + `
+- ` + bt + `timeout` + bt + ` (optional, ` + bt + `start` + bt + ` only): job timeout in seconds, default ` + bt + `60` + bt + `
+
+### ` + bt + `horizon` + bt + `
+Start or stop Laravel Horizon for a site. Horizon is a queue manager that replaces ` + bt + `queue:work` + bt + ` — use ` + bt + `horizon` + bt + ` instead of ` + bt + `queue` + bt + ` for projects that have ` + bt + `laravel/horizon` + bt + ` in ` + bt + `composer.json` + bt + `. Returns an error on ` + bt + `action: "start"` + bt + ` if ` + bt + `laravel/horizon` + bt + ` is not installed.
+
+Arguments:
+- ` + bt + `action` + bt + ` (required): ` + bt + `"start"` + bt + ` or ` + bt + `"stop"` + bt + `
+- ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
+
+> **Horizon vs queue worker:** The ` + bt + `sites` + bt + ` tool returns ` + bt + `has_horizon: true` + bt + ` when a site has Horizon installed. In that case prefer ` + bt + `horizon` + bt + ` over ` + bt + `queue` + bt + `.
+
+### ` + bt + `reverb` + bt + `
+Start or stop the Reverb WebSocket server for a site. Available for any framework that defines a ` + bt + `reverb` + bt + ` worker.
+
+Arguments:
+- ` + bt + `action` + bt + ` (required): ` + bt + `"start"` + bt + ` or ` + bt + `"stop"` + bt + `
+- ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
+
+### ` + bt + `schedule` + bt + `
+Start or stop the task scheduler for a site. Available for any framework that defines a ` + bt + `schedule` + bt + ` worker.
+
+Arguments:
+- ` + bt + `action` + bt + ` (required): ` + bt + `"start"` + bt + ` or ` + bt + `"stop"` + bt + `
+- ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
+
+### ` + bt + `worker` + bt + `
+Start or stop any named framework worker for a site. Use this for workers that don't have a dedicated shortcut (e.g. ` + bt + `messenger` + bt + ` for Symfony, ` + bt + `pulse` + bt + ` for Laravel). The worker command is taken from the framework definition.
+
+Arguments:
+- ` + bt + `action` + bt + ` (required): ` + bt + `"start"` + bt + ` or ` + bt + `"stop"` + bt + `
 - ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
 - ` + bt + `worker` + bt + ` (required): worker name as defined in the framework (e.g. ` + bt + `"messenger"` + bt + `, ` + bt + `"horizon"` + bt + `)
 
 ### ` + bt + `worker_list` + bt + `
-List all workers defined for a site's framework, with their running status, command, unit name, and restart policy. Use this to discover available workers before calling ` + bt + `worker_start` + bt + `.
+List all workers defined for a site's framework, with their running status, command, unit name, and restart policy. Use this to discover available workers before calling ` + bt + `worker` + bt + `.
 
 Arguments:
 - ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
 
 ### ` + bt + `worker_add` + bt + `
-Add or update a custom worker for a project. Saves to ` + bt + `.lerd.yaml` + bt + ` ` + bt + `custom_workers` + bt + ` by default, or to the global framework overlay (` + bt + `~/.config/lerd/frameworks/` + bt + `) with ` + bt + `global: true` + bt + `. Does not auto-start — use ` + bt + `worker_start` + bt + ` afterwards.
+Add or update a custom worker for a project. Saves to ` + bt + `.lerd.yaml` + bt + ` ` + bt + `custom_workers` + bt + ` by default, or to the global framework overlay (` + bt + `~/.config/lerd/frameworks/` + bt + `) with ` + bt + `global: true` + bt + `. Does not auto-start — use ` + bt + `worker(action: "start", ...)` + bt + ` afterwards.
 
 Arguments:
 - ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
@@ -799,39 +873,32 @@ Delete a user-defined framework YAML. For ` + bt + `laravel` + bt + `, removes o
 ### ` + bt + `site_php` + bt + ` / ` + bt + `site_node` + bt + `
 Change the PHP or Node.js version for a registered site. Both take ` + bt + `site` + bt + ` (required) and ` + bt + `version` + bt + ` (required).
 
-` + bt + `site_php` + bt + ` writes a ` + bt + `.php-version` + bt + ` pin file to the project root, updates the site registry, and regenerates the nginx vhost. The FPM container for the target PHP version must be running — start it with ` + bt + `service_start(name: "php<version>")` + bt + ` if needed.
+` + bt + `site_php` + bt + ` writes a ` + bt + `.php-version` + bt + ` pin file to the project root, updates the site registry, and regenerates the nginx vhost. The FPM container for the target PHP version must be running — start it with ` + bt + `service_control(action: "start", name: "php<version>")` + bt + ` if needed.
 
 ` + bt + `site_node` + bt + ` writes a ` + bt + `.node-version` + bt + ` pin file and installs the version via fnm if it isn't already installed. Run ` + bt + `npm install` + bt + ` inside the project if dependencies need rebuilding against the new version.
 
-### ` + bt + `site_pause` + bt + ` / ` + bt + `site_unpause` + bt + `
-Pause or resume a site. Both take ` + bt + `site` + bt + ` (required, site name from ` + bt + `sites` + bt + ` tool).
+### ` + bt + `site_control` + bt + `
+Pause, unpause, restart, or rebuild a site.
 
-` + bt + `site_pause` + bt + ` stops all running workers for the site, stops the custom container (for custom container sites), and replaces its nginx vhost with a landing page that includes a **Resume** button. Services no longer needed by any active site are auto-stopped. The paused state is persisted.
-
-` + bt + `site_unpause` + bt + ` starts the custom container (if applicable), restores the nginx vhost, ensures required services are running, and restarts any workers that were running when the site was paused.
-
-Use this to free up resources for sites you're not actively working on without fully unlinking them.
-
-### ` + bt + `site_restart` + bt + `
-Restart the container for a site without rebuilding the image. Takes ` + bt + `site` + bt + ` (required). For custom container sites this restarts the dedicated container; for PHP sites it restarts the shared FPM container.
-
-### ` + bt + `site_rebuild` + bt + `
-Rebuild the custom container image from the Containerfile and restart the container. Takes ` + bt + `site` + bt + ` (required). Use after changing the Containerfile. ` + bt + `site_link` + bt + ` reuses the cached image; ` + bt + `site_rebuild` + bt + ` forces a fresh build. Only works for custom container sites.
-
-### ` + bt + `service_pin` + bt + ` / ` + bt + `service_unpin` + bt + `
-Pin or unpin a service. Both take ` + bt + `name` + bt + ` (required).
-
-` + bt + `service_pin` + bt + ` marks a service so it is **never auto-stopped**, even when no active sites reference it in their ` + bt + `.env` + bt + `. Starts the service if it isn't already running. Use this for services you want always available regardless of which site is active (e.g. a shared Redis or MySQL).
-
-` + bt + `service_unpin` + bt + ` removes the pin so the service can be auto-stopped when no sites use it.
-
-### ` + bt + `stripe_listen` + bt + ` / ` + bt + `stripe_listen_stop` + bt + `
-Start or stop a Stripe webhook listener for a site using the Stripe CLI container. Reads ` + bt + `STRIPE_SECRET` + bt + ` from the site's ` + bt + `.env` + bt + ` and forwards webhooks to ` + bt + `/stripe/webhook` + bt + ` by default.
-
-Arguments for ` + bt + `stripe_listen` + bt + `:
+Arguments:
+- ` + bt + `action` + bt + ` (required): ` + bt + `"pause"` + bt + `, ` + bt + `"unpause"` + bt + `, ` + bt + `"restart"` + bt + `, or ` + bt + `"rebuild"` + bt + `
 - ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
-- ` + bt + `api_key` + bt + ` (optional): Stripe secret key (defaults to ` + bt + `STRIPE_SECRET` + bt + ` in the site's ` + bt + `.env` + bt + `)
-- ` + bt + `webhook_path` + bt + ` (optional): webhook route path (default: ` + bt + `"/stripe/webhook"` + bt + `)
+
+- ` + bt + `pause` + bt + `: stops all running workers for the site, stops the custom container (for custom container sites), and replaces its nginx vhost with a landing page that includes a **Resume** button. Services no longer needed by any active site are auto-stopped. The paused state is persisted.
+- ` + bt + `unpause` + bt + `: starts the custom container (if applicable), restores the nginx vhost, ensures required services are running, and restarts any workers that were running when the site was paused.
+- ` + bt + `restart` + bt + `: restarts the container for a site without rebuilding the image. For custom container sites this restarts the dedicated container; for PHP sites it restarts the shared FPM container.
+- ` + bt + `rebuild` + bt + `: rebuilds the custom container image from the Containerfile and restarts the container. Use after changing the Containerfile. ` + bt + `site_link` + bt + ` reuses the cached image; ` + bt + `rebuild` + bt + ` forces a fresh build. Only works for custom container sites.
+
+Use ` + bt + `pause` + bt + ` / ` + bt + `unpause` + bt + ` to free up resources for sites you're not actively working on without fully unlinking them.
+
+### ` + bt + `stripe` + bt + `
+Start or stop a Stripe webhook listener for a site using the Stripe CLI container. On ` + bt + `start` + bt + ` it reads ` + bt + `STRIPE_SECRET` + bt + ` from the site's ` + bt + `.env` + bt + ` and forwards webhooks to ` + bt + `/stripe/webhook` + bt + ` by default.
+
+Arguments:
+- ` + bt + `action` + bt + ` (required): ` + bt + `"start"` + bt + ` or ` + bt + `"stop"` + bt + `
+- ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
+- ` + bt + `api_key` + bt + ` (optional, ` + bt + `start` + bt + ` only): Stripe secret key (defaults to ` + bt + `STRIPE_SECRET` + bt + ` in the site's ` + bt + `.env` + bt + `)
+- ` + bt + `webhook_path` + bt + ` (optional, ` + bt + `start` + bt + ` only): webhook route path (default: ` + bt + `"/stripe/webhook"` + bt + `)
 
 ### ` + bt + `db_export` + bt + `
 Export a database to a SQL dump file. Works with any project type — service and database are auto-detected. Arguments:
@@ -913,22 +980,22 @@ artisan(args: ["migrate", "--seed"])
 
 **Enable HTTPS for a site:**
 ` + "```" + `
-secure(site: "myapp")
+site_tls(action: "enable", site: "myapp")
 ` + "```" + `
 
 **Enable Xdebug for a debugging session:**
 ` + "```" + `
-xdebug_status()                                 // check current state and mode
-xdebug_on(version: "8.4")                       // default mode=debug, restarts FPM
+xdebug(action: "status")                                      // check current state and mode
+xdebug(action: "on", version: "8.4")                          // default mode=debug, restarts FPM
 // ... debug ...
-xdebug_off(version: "8.4")                      // disable when done (Xdebug adds overhead)
+xdebug(action: "off", version: "8.4")                         // disable when done (Xdebug adds overhead)
 ` + "```" + `
 
 **Enable Xdebug coverage mode for phpunit/pest:**
 ` + "```" + `
-xdebug_on(version: "8.4", mode: "coverage")     // swap mode without xdebug_off first
+xdebug(action: "on", version: "8.4", mode: "coverage")        // swap mode without action: "off" first
 vendor_run(name: "pest", args: ["--coverage"])
-xdebug_off(version: "8.4")
+xdebug(action: "off", version: "8.4")
 ` + "```" + `
 
 **Run migrations after schema changes:**
@@ -938,8 +1005,8 @@ artisan(args: ["migrate"])
 
 **Install and configure a service:**
 ` + "```" + `
-service_start(name: "mysql")
-service_start(name: "redis")   // if needed
+service_control(action: "start", name: "mysql")
+service_control(action: "start", name: "redis")   // if needed
 composer(args: ["install"])
 artisan(args: ["key:generate"])
 artisan(args: ["migrate", "--seed"])
@@ -954,14 +1021,14 @@ artisan(args: ["migrate"])
 
 **Install a Node.js version and pin it to the project:**
 ` + "```" + `
-node_install(version: "20")
+node(action: "install", version: "20")
 // Then in a terminal: lerd isolate:node 20
 ` + "```" + `
 
 **Add a custom service (e.g. MongoDB):**
 ` + "```" + `
 service_add(name: "mongodb", image: "docker.io/library/mongo:7", ports: ["27017:27017"], data_dir: "/data/db")
-service_start(name: "mongodb")
+service_control(action: "start", name: "mongodb")
 ` + "```" + `
 
 **Back up the database before a risky migration:**
@@ -982,9 +1049,9 @@ db_create()   // creates myapp + myapp_testing based on .env DB_DATABASE
 
 **Check and manage PHP extensions:**
 ` + "```" + `
-php_list()                           // see installed PHP versions
-php_ext_list()                       // see custom extensions for current project's PHP version
-php_ext_add(extension: "imagick")    // install imagick (rebuilds FPM image)
+php_list()                                           // see installed PHP versions
+php_ext(action: "list")                              // see custom extensions for current project's PHP version
+php_ext(action: "add", extension: "imagick")         // install imagick (rebuilds FPM image)
 ` + "```" + `
 
 **Park a directory of projects:**
@@ -1005,22 +1072,22 @@ status()    // see which of DNS / nginx / PHP-FPM / watcher is down
 
 **Free up resources — pause sites you're not using:**
 ` + "```" + `
-sites()                          // see all sites
-site_pause(site: "old-project")  // stop workers + replace vhost with landing page
+sites()                                                  // see all sites
+site_control(action: "pause", site: "old-project")       // stop workers + replace vhost with landing page
 // ... later ...
-site_unpause(site: "old-project")  // restore and restart
+site_control(action: "unpause", site: "old-project")     // restore and restart
 ` + "```" + `
 
 **Restart a site's container (e.g. after changing Containerfile):**
 ` + "```" + `
-site_restart(site: "nestjs-app")  // restarts container (no rebuild)
-site_rebuild(site: "nestjs-app")  // rebuilds image from Containerfile + restarts
+site_control(action: "restart", site: "nestjs-app")      // restarts container (no rebuild)
+site_control(action: "rebuild", site: "nestjs-app")      // rebuilds image from Containerfile + restarts
 ` + "```" + `
 
 **Keep a service always running regardless of active site:**
 ` + "```" + `
-service_pin(name: "mysql")    // never auto-stopped
-service_pin(name: "redis")
+service_control(action: "pin", name: "mysql")    // never auto-stopped
+service_control(action: "pin", name: "redis")
 ` + "```" + `
 
 **User reports setup issues or something unexpected:**
@@ -1030,9 +1097,9 @@ doctor()    // full diagnostic: podman, systemd, DNS, ports, images, config
 
 **Start a framework worker (Symfony Messenger, Laravel Horizon, etc.):**
 ` + "```" + `
-worker_list(site: "myapp")            // see what workers are available and their status
-worker_start(site: "myapp", worker: "messenger")  // start by name
-worker_stop(site: "myapp", worker: "messenger")
+worker_list(site: "myapp")                                      // see what workers are available and their status
+worker(action: "start", site: "myapp", worker: "messenger")     // start by name
+worker(action: "stop", site: "myapp", worker: "messenger")
 ` + "```" + `
 
 **Add a custom worker to Laravel (e.g. Horizon):**
@@ -1040,7 +1107,7 @@ worker_stop(site: "myapp", worker: "messenger")
 framework_add(name: "laravel", workers: {
   "horizon": {"label": "Horizon", "command": "php artisan horizon", "restart": "always"}
 })
-worker_start(site: "myapp", worker: "horizon")
+worker(action: "start", site: "myapp", worker: "horizon")
 ` + "```" + `
 
 **Work with failed queue jobs:**
@@ -1104,8 +1171,8 @@ REDIS_PORT=6379
 ` + "```" + `
    Start the services first if they're not running:
 ` + "```" + `
-service_start(name: "mysql")
-service_start(name: "redis")
+service_control(action: "start", name: "mysql")
+service_control(action: "start", name: "redis")
 ` + "```" + `
 
 4. Link and verify:
@@ -1199,32 +1266,24 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `sites` + bt + ` | List all registered sites with framework and worker status — call this first |
 | ` + bt + `runtime_versions` + bt + ` | List installed PHP and Node.js versions with defaults |
 | ` + bt + `php_list` + bt + ` | List installed PHP versions, marking the global default |
-| ` + bt + `php_ext_list` + bt + ` | List custom PHP extensions for a PHP version |
-| ` + bt + `php_ext_add` + bt + ` | Add a custom PHP extension — rebuilds FPM image and restarts container |
-| ` + bt + `php_ext_remove` + bt + ` | Remove a custom PHP extension — rebuilds FPM image and restarts container |
+| ` + bt + `php_ext` + bt + ` | Manage custom PHP extensions — ` + bt + `action` + bt + `: ` + bt + `list` + bt + ` / ` + bt + `add` + bt + ` / ` + bt + `remove` + bt + `; ` + bt + `add` + bt + ` and ` + bt + `remove` + bt + ` rebuild FPM image and restart container |
 | ` + bt + `artisan` + bt + ` | Run ` + bt + `php artisan` + bt + ` inside the PHP-FPM container (Laravel only) |
 | ` + bt + `console` + bt + ` | Run the framework's console command (e.g. ` + bt + `php bin/console` + bt + ` for Symfony) — non-Laravel frameworks with a ` + bt + `console` + bt + ` field |
 | ` + bt + `composer` + bt + ` | Run ` + bt + `composer` + bt + ` inside the PHP-FPM container |
 | ` + bt + `vendor_bins` + bt + ` | List composer-installed binaries available in the project's ` + bt + `vendor/bin` + bt + ` directory |
 | ` + bt + `vendor_run` + bt + ` | Run a binary from ` + bt + `vendor/bin` + bt + ` (pest, phpunit, pint, phpstan, rector, …) inside the PHP-FPM container |
-| ` + bt + `node_install` + bt + ` | Install a Node.js version via fnm (e.g. ` + bt + `"20"` + bt + `, ` + bt + `"lts"` + bt + `) |
-| ` + bt + `node_uninstall` + bt + ` | Uninstall a Node.js version via fnm |
+| ` + bt + `node` + bt + ` | Install or uninstall a Node.js version via fnm — ` + bt + `action` + bt + `: ` + bt + `install` + bt + ` / ` + bt + `uninstall` + bt + ` (e.g. ` + bt + `"20"` + bt + `, ` + bt + `"lts"` + bt + `) |
 | ` + bt + `env_setup` + bt + ` | Configure ` + bt + `.env` + bt + ` for lerd: detects services, starts them, creates DB, generates APP_KEY (leaves ` + bt + `DB_CONNECTION=sqlite` + bt + ` alone — call ` + bt + `db_set` + bt + ` first); ` + bt + `APP_URL` + bt + ` follows ` + bt + `.lerd.yaml app_url` + bt + ` → ` + bt + `sites.yaml app_url` + bt + ` → default chain |
 | ` + bt + `db_set` + bt + ` | Pick the database for a Laravel project: ` + bt + `sqlite` + bt + ` / ` + bt + `mysql` + bt + ` / ` + bt + `postgres` + bt + `; persists to ` + bt + `.lerd.yaml` + bt + `, rewrites ` + bt + `DB_` + bt + ` keys in ` + bt + `.env` + bt + `, starts the service, creates the database |
 | ` + bt + `env_check` + bt + ` | Compare all ` + bt + `.env` + bt + ` files against ` + bt + `.env.example` + bt + ` — returns structured JSON with per-key sync status |
 | ` + bt + `site_link` + bt + ` | Register a directory as a lerd site — **non-PHP projects** must have a Containerfile (default name ` + bt + `Containerfile.lerd` + bt + `; set ` + bt + `container.containerfile` + bt + ` for a different path, e.g. ` + bt + `Dockerfile` + bt + `) + ` + bt + `.lerd.yaml` + bt + ` with ` + bt + `container: {port: N}` + bt + ` written first, otherwise the site registers as PHP (wrong) |
 | ` + bt + `site_unlink` + bt + ` | Unregister a site and remove its nginx vhost (all domains) |
-| ` + bt + `site_domain_add` + bt + ` | Add an additional domain to a site (without TLD) |
-| ` + bt + `site_domain_remove` + bt + ` | Remove a domain from a site (cannot remove last) |
+| ` + bt + `site_domain` + bt + ` | Add or remove a site domain (without TLD) — ` + bt + `action` + bt + `: ` + bt + `add` + bt + ` / ` + bt + `remove` + bt + `; cannot remove last |
 | ` + bt + `park` + bt + ` | Register a parent directory — auto-registers all PHP projects as sites |
 | ` + bt + `unpark` + bt + ` | Remove a parked directory and unlink all its sites |
-| ` + bt + `secure` + bt + ` | Enable HTTPS for a site (mkcert) — updates APP_URL automatically |
-| ` + bt + `unsecure` + bt + ` | Disable HTTPS for a site |
-| ` + bt + `xdebug_on` + bt + ` | Enable Xdebug for a PHP version (port 9003); optional ` + bt + `mode` + bt + ` (default ` + bt + `debug` + bt + `; also ` + bt + `coverage` + bt + `, ` + bt + `develop` + bt + `, ` + bt + `profile` + bt + `, ` + bt + `trace` + bt + `, ` + bt + `gcstats` + bt + `, or comma combos) |
-| ` + bt + `xdebug_off` + bt + ` | Disable Xdebug for a PHP version |
-| ` + bt + `xdebug_status` + bt + ` | Show Xdebug state and active mode for all PHP versions |
-| ` + bt + `service_start` + bt + ` | Start a built-in or custom service |
-| ` + bt + `service_stop` + bt + ` | Stop a service |
+| ` + bt + `site_tls` + bt + ` | Enable or disable HTTPS for a site (mkcert) — ` + bt + `action` + bt + `: ` + bt + `enable` + bt + ` / ` + bt + `disable` + bt + `; updates APP_URL automatically |
+| ` + bt + `xdebug` + bt + ` | Manage Xdebug for a PHP version (port 9003) — ` + bt + `action` + bt + `: ` + bt + `on` + bt + ` / ` + bt + `off` + bt + ` / ` + bt + `status` + bt + `; optional ` + bt + `mode` + bt + ` on ` + bt + `on` + bt + ` (default ` + bt + `debug` + bt + `; also ` + bt + `coverage` + bt + `, ` + bt + `develop` + bt + `, ` + bt + `profile` + bt + `, ` + bt + `trace` + bt + `, ` + bt + `gcstats` + bt + `, or comma combos) |
+| ` + bt + `service_control` + bt + ` | Start, stop, pin, or unpin a built-in or custom service — ` + bt + `action` + bt + `: ` + bt + `start` + bt + ` / ` + bt + `stop` + bt + ` / ` + bt + `pin` + bt + ` / ` + bt + `unpin` + bt + ` |
 | ` + bt + `service_add` + bt + ` | Register a new custom OCI service (MongoDB, RabbitMQ, …); supports ` + bt + `depends_on` + bt + ` for service dependencies |
 | ` + bt + `service_preset_list` + bt + ` | List bundled service presets (phpmyadmin, pgadmin, mongo, mongo-express, selenium, stripe-mock, …) with versions and install state |
 | ` + bt + `service_preset_install` + bt + ` | Install a bundled preset by name (` + bt + `version` + bt + ` for multi-version families); becomes a normal custom service |
@@ -1234,16 +1293,11 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `db_export` + bt + ` | Export a database to a SQL dump file — auto-detects service and database; accepts optional ` + bt + `service` + bt + ` override |
 | ` + bt + `db_import` + bt + ` | Import a SQL dump file into the project database — auto-detects service and database; starts the service if needed |
 | ` + bt + `db_create` + bt + ` | Create a database and ` + bt + `_testing` + bt + ` variant — auto-detects service and name; starts the service if needed |
-| ` + bt + `queue_start` + bt + ` | Start the queue worker for a site (any framework with a queue worker) |
-| ` + bt + `queue_stop` + bt + ` | Stop the queue worker |
-| ` + bt + `horizon_start` + bt + ` | Start Laravel Horizon for a site (use instead of queue_start when laravel/horizon is installed) |
-| ` + bt + `horizon_stop` + bt + ` | Stop Laravel Horizon |
-| ` + bt + `reverb_start` + bt + ` | Start the Reverb WebSocket server for a site |
-| ` + bt + `reverb_stop` + bt + ` | Stop the Reverb server |
-| ` + bt + `schedule_start` + bt + ` | Start the task scheduler for a site |
-| ` + bt + `schedule_stop` + bt + ` | Stop the task scheduler |
-| ` + bt + `worker_start` + bt + ` | Start any named framework worker (e.g. messenger, pulse) |
-| ` + bt + `worker_stop` + bt + ` | Stop a named framework worker |
+| ` + bt + `queue` + bt + ` | Start or stop the queue worker for a site — ` + bt + `action` + bt + `: ` + bt + `start` + bt + ` / ` + bt + `stop` + bt + ` (any framework with a queue worker) |
+| ` + bt + `horizon` + bt + ` | Start or stop Laravel Horizon for a site — ` + bt + `action` + bt + `: ` + bt + `start` + bt + ` / ` + bt + `stop` + bt + ` (use instead of ` + bt + `queue` + bt + ` when laravel/horizon is installed) |
+| ` + bt + `reverb` + bt + ` | Start or stop the Reverb WebSocket server for a site — ` + bt + `action` + bt + `: ` + bt + `start` + bt + ` / ` + bt + `stop` + bt + ` |
+| ` + bt + `schedule` + bt + ` | Start or stop the task scheduler for a site — ` + bt + `action` + bt + `: ` + bt + `start` + bt + ` / ` + bt + `stop` + bt + ` |
+| ` + bt + `worker` + bt + ` | Start or stop any named framework worker (e.g. messenger, pulse) — ` + bt + `action` + bt + `: ` + bt + `start` + bt + ` / ` + bt + `stop` + bt + ` |
 | ` + bt + `worker_list` + bt + ` | List all workers defined for a site's framework with running status |
 | ` + bt + `worker_add` + bt + ` | Add a custom worker to a project or global framework overlay |
 | ` + bt + `worker_remove` + bt + ` | Remove a custom worker; stops it if running |
@@ -1253,14 +1307,8 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 | ` + bt + `framework_remove` + bt + ` | Remove a user-defined framework; for laravel removes only custom worker and setup additions |
 | ` + bt + `site_php` + bt + ` | Change PHP version for a site — writes ` + bt + `.php-version` + bt + `, updates registry, regenerates nginx vhost |
 | ` + bt + `site_node` + bt + ` | Change Node.js version for a site — writes ` + bt + `.node-version` + bt + `, installs via fnm if needed |
-| ` + bt + `site_pause` + bt + ` | Pause a site: stop workers and custom container, replace vhost with landing page |
-| ` + bt + `site_unpause` + bt + ` | Resume a paused site: start container, restore vhost, restart workers |
-| ` + bt + `site_restart` + bt + ` | Restart a site's container (custom container or PHP-FPM) |
-| ` + bt + `site_rebuild` + bt + ` | Rebuild custom container image from Containerfile and restart |
-| ` + bt + `service_pin` + bt + ` | Pin a service so it is never auto-stopped even when no sites reference it |
-| ` + bt + `service_unpin` + bt + ` | Unpin a service so it can be auto-stopped when unused |
-| ` + bt + `stripe_listen` + bt + ` | Start a Stripe webhook listener for a site |
-| ` + bt + `stripe_listen_stop` + bt + ` | Stop the Stripe webhook listener |
+| ` + bt + `site_control` + bt + ` | Pause, unpause, restart, or rebuild a site — ` + bt + `action` + bt + `: ` + bt + `pause` + bt + ` / ` + bt + `unpause` + bt + ` / ` + bt + `restart` + bt + ` / ` + bt + `rebuild` + bt + ` (pause replaces vhost with landing page; rebuild only for custom containers) |
+| ` + bt + `stripe` + bt + ` | Start or stop a Stripe webhook listener for a site — ` + bt + `action` + bt + `: ` + bt + `start` + bt + ` / ` + bt + `stop` + bt + ` |
 | ` + bt + `logs` + bt + ` | Fetch container logs — defaults to current site's FPM; optionally specify nginx, service name, PHP version, or site name |
 | ` + bt + `status` + bt + ` | Health snapshot of DNS, nginx, PHP-FPM containers, and the file watcher |
 | ` + bt + `doctor` + bt + ` | Full diagnostic as structured JSON: podman, systemd, DNS, ports, PHP images, config, updates |
@@ -1273,29 +1321,29 @@ This project runs on **lerd**, a Podman-based Laravel development environment. T
 - ` + bt + `artisan` + bt + ` is Laravel-only; ` + bt + `console` + bt + ` is the equivalent for non-Laravel frameworks — both take ` + bt + `path` + bt + ` (absolute project root) and ` + bt + `args` + bt + ` (array)
 - ` + bt + `vendor_run` + bt + ` is the right way to invoke project tooling like pest, phpunit, pint, phpstan, rector — call ` + bt + `vendor_bins` + bt + ` first to discover what's installed, then ` + bt + `vendor_run(bin: "<name>", args: [...])` + bt + `; prefer it over ` + bt + `composer(args: ["exec", ...])` + bt + `
 - On a **fresh Laravel clone** (DB_CONNECTION=sqlite in ` + bt + `.env` + bt + `), call ` + bt + `db_set(database: "mysql"|"postgres"|"sqlite")` + bt + ` before ` + bt + `env_setup` + bt + ` to pick a database deliberately. ` + bt + `env_setup` + bt + ` on its own won't switch the database away from sqlite.
-- **Domain conflicts on link**: when ` + bt + `lerd link` + bt + ` (or the parked-directory watcher) tries to register a ` + bt + `.lerd.yaml` + bt + ` domain that another site already owns, the conflicting domain is filtered out and a ` + bt + `[WARN] domain "X" already used by site "Y" — skipped` + bt + ` line is printed. The site still gets registered with surviving domains, falling back to ` + bt + `<dirname>.<tld>` + bt + ` if everything was filtered. ` + bt + `.lerd.yaml` + bt + ` is not modified on disk so the conflict is visible in the UI and self-heals on the next link if the owning site is removed. The ` + bt + `site_link` + bt + ` and ` + bt + `site_domain_add` + bt + ` MCP tools, by contrast, hard-error on conflicts so you can react explicitly — read the error message for the owning site name.
+- **Domain conflicts on link**: when ` + bt + `lerd link` + bt + ` (or the parked-directory watcher) tries to register a ` + bt + `.lerd.yaml` + bt + ` domain that another site already owns, the conflicting domain is filtered out and a ` + bt + `[WARN] domain "X" already used by site "Y" — skipped` + bt + ` line is printed. The site still gets registered with surviving domains, falling back to ` + bt + `<dirname>.<tld>` + bt + ` if everything was filtered. ` + bt + `.lerd.yaml` + bt + ` is not modified on disk so the conflict is visible in the UI and self-heals on the next link if the owning site is removed. The ` + bt + `site_link` + bt + ` and ` + bt + `site_domain(action: "add", ...)` + bt + ` MCP tools, by contrast, hard-error on conflicts so you can react explicitly — read the error message for the owning site name.
 - **Custom APP_URL**: ` + bt + `env_setup` + bt + ` writes ` + bt + `<scheme>://<primary-domain>` + bt + ` by default. Override by setting ` + bt + `app_url` + bt + ` in ` + bt + `.lerd.yaml` + bt + ` (committed) or in the per-machine ` + bt + `sites.yaml` + bt + ` site entry. No MCP tool sets it — edit the YAML and re-run ` + bt + `env_setup` + bt + `.
 - ` + bt + `tinker` + bt + ` must use ` + bt + `--execute=<code>` + bt + ` for non-interactive use
 - Built-in service hosts follow the pattern ` + bt + `lerd-<name>` + bt + ` (e.g. ` + bt + `lerd-mysql` + bt + `, ` + bt + `lerd-redis` + bt + `)
 - Default DB credentials: username ` + bt + `root` + bt + `, password ` + bt + `lerd` + bt + `
-- ` + bt + `service_stop` + bt + ` marks the service paused — ` + bt + `lerd start` + bt + ` skips it until explicitly started again
-- ` + bt + `queue_start` + bt + ` requires Redis to be running when ` + bt + `QUEUE_CONNECTION=redis` + bt + `; call ` + bt + `service_start(name: "redis")` + bt + ` first
-- If ` + bt + `sites` + bt + ` returns ` + bt + `has_horizon: true` + bt + ` for a site, use ` + bt + `horizon_start` + bt + ` / ` + bt + `horizon_stop` + bt + ` instead of ` + bt + `queue_start` + bt + ` / ` + bt + `queue_stop` + bt + ` — Horizon manages queues and they are mutually exclusive
-- Use ` + bt + `worker_list` + bt + ` first to discover what workers are available for a site before calling ` + bt + `worker_start` + bt + `
-- ` + bt + `worker_add` + bt + ` saves custom workers to ` + bt + `.lerd.yaml` + bt + ` by default (project-level, committed to git); use ` + bt + `global: true` + bt + ` to save to the user framework overlay (` + bt + `~/.config/lerd/frameworks/` + bt + `) for all projects of that framework; does not auto-start — call ` + bt + `worker_start` + bt + ` afterwards
+- ` + bt + `service_control(action: "stop", ...)` + bt + ` marks the service paused — ` + bt + `lerd start` + bt + ` skips it until explicitly started again
+- ` + bt + `queue(action: "start", ...)` + bt + ` requires Redis to be running when ` + bt + `QUEUE_CONNECTION=redis` + bt + `; call ` + bt + `service_control(action: "start", name: "redis")` + bt + ` first
+- If ` + bt + `sites` + bt + ` returns ` + bt + `has_horizon: true` + bt + ` for a site, use ` + bt + `horizon` + bt + ` instead of ` + bt + `queue` + bt + ` — Horizon manages queues and they are mutually exclusive
+- Use ` + bt + `worker_list` + bt + ` first to discover what workers are available for a site before calling ` + bt + `worker(action: "start", ...)` + bt + `
+- ` + bt + `worker_add` + bt + ` saves custom workers to ` + bt + `.lerd.yaml` + bt + ` by default (project-level, committed to git); use ` + bt + `global: true` + bt + ` to save to the user framework overlay (` + bt + `~/.config/lerd/frameworks/` + bt + `) for all projects of that framework; does not auto-start — call ` + bt + `worker(action: "start", ...)` + bt + ` afterwards
 - ` + bt + `worker_remove` + bt + ` stops a running worker before removing it from config; use ` + bt + `global: true` + bt + ` to target the framework overlay
 - Workers with ` + bt + `conflicts_with` + bt + ` automatically stop conflicting workers when started (e.g. a custom queue processor that conflicts with the default queue worker); conflicted workers are hidden from the UI while the conflicting worker runs
 - Worker unit names follow the pattern ` + bt + `lerd-<worker>-<site>` + bt + ` (e.g. ` + bt + `lerd-messenger-myapp` + bt + `, ` + bt + `lerd-horizon-myapp` + bt + `)
 - ` + bt + `site_php` + bt + ` / ` + bt + `site_node` + bt + ` change the PHP/Node version for a site; the FPM container for the new PHP version must be running after calling ` + bt + `site_php` + bt + `
-- ` + bt + `site_pause` + bt + ` / ` + bt + `site_unpause` + bt + ` free up resources for sites not in active use without unlinking them; paused state persists across restarts
-- **Custom container sites** (Node.js, Python, Go, etc.) — mandatory sequence: **(1)** write a Containerfile in the project root (default name ` + bt + `Containerfile.lerd` + bt + `; any name works if you set ` + bt + `container.containerfile` + bt + `); **(2)** write ` + bt + `.lerd.yaml` + bt + ` with ` + bt + `container: {port: <N>}` + bt + ` (plus optional ` + bt + `domains` + bt + `, ` + bt + `services` + bt + `, ` + bt + `secured` + bt + `) — there is no MCP tool for this; write the file directly or ask the user to run ` + bt + `lerd init` + bt + `; **(3)** configure the project's ` + bt + `.env` + bt + ` (or equivalent config) with service connection strings BEFORE linking — use ` + bt + `lerd-mysql` + bt + `, ` + bt + `lerd-redis` + bt + `, ` + bt + `lerd-postgres` + bt + ` as hostnames and start needed services with ` + bt + `service_start` + bt + `; **(4)** call ` + bt + `site_link` + bt + ` — the container starts immediately, so the env must already be correct. **Never call ` + bt + `site_link` + bt + ` before steps 1–3**: without ` + bt + `container:` + bt + ` config the site registers as PHP-FPM (wrong); if that happened, ` + bt + `site_unlink` + bt + ` first, write the files, then link again. Workers in ` + bt + `custom_workers` + bt + ` exec into the container. ` + bt + `site_restart` + bt + ` restarts without rebuilding. When ` + bt + `container` + bt + ` is set, ` + bt + `php_version` + bt + ` and ` + bt + `framework` + bt + ` are ignored.
-- ` + bt + `service_pin` + bt + ` keeps a service always running regardless of which sites are active; use for shared services like MySQL or Redis
+- ` + bt + `site_control(action: "pause")` + bt + ` / ` + bt + `site_control(action: "unpause")` + bt + ` free up resources for sites not in active use without unlinking them; paused state persists across restarts
+- **Custom container sites** (Node.js, Python, Go, etc.) — mandatory sequence: **(1)** write a Containerfile in the project root (default name ` + bt + `Containerfile.lerd` + bt + `; any name works if you set ` + bt + `container.containerfile` + bt + `); **(2)** write ` + bt + `.lerd.yaml` + bt + ` with ` + bt + `container: {port: <N>}` + bt + ` (plus optional ` + bt + `domains` + bt + `, ` + bt + `services` + bt + `, ` + bt + `secured` + bt + `) — there is no MCP tool for this; write the file directly or ask the user to run ` + bt + `lerd init` + bt + `; **(3)** configure the project's ` + bt + `.env` + bt + ` (or equivalent config) with service connection strings BEFORE linking — use ` + bt + `lerd-mysql` + bt + `, ` + bt + `lerd-redis` + bt + `, ` + bt + `lerd-postgres` + bt + ` as hostnames and start needed services with ` + bt + `service_control(action: "start", ...)` + bt + `; **(4)** call ` + bt + `site_link` + bt + ` — the container starts immediately, so the env must already be correct. **Never call ` + bt + `site_link` + bt + ` before steps 1–3**: without ` + bt + `container:` + bt + ` config the site registers as PHP-FPM (wrong); if that happened, ` + bt + `site_unlink` + bt + ` first, write the files, then link again. Workers in ` + bt + `custom_workers` + bt + ` exec into the container. ` + bt + `site_control(action: "restart", ...)` + bt + ` restarts without rebuilding. When ` + bt + `container` + bt + ` is set, ` + bt + `php_version` + bt + ` and ` + bt + `framework` + bt + ` are ignored.
+- ` + bt + `service_control(action: "pin", ...)` + bt + ` keeps a service always running regardless of which sites are active; use for shared services like MySQL or Redis
 - ` + bt + `service_add` + bt + ` supports ` + bt + `depends_on` + bt + ` (array of service names): starting a dependency auto-starts the dependent service; stopping a dependency cascade-stops the dependent first; starting the dependent ensures dependencies start first
 - Prefer ` + bt + `service_preset_install` + bt + ` over hand-rolling ` + bt + `service_add` + bt + ` for anything in the bundled catalogue (` + bt + `phpmyadmin` + bt + `, ` + bt + `pgadmin` + bt + `, ` + bt + `mongo` + bt + `, ` + bt + `mongo-express` + bt + `, ` + bt + `selenium` + bt + `, ` + bt + `stripe-mock` + bt + `, ` + bt + `mysql` + bt + `, ` + bt + `mariadb` + bt + `, …) — presets ship sane defaults, dependency wiring, dashboards, and rendered config files; call ` + bt + `service_preset_list` + bt + ` first to see what's available; multi-version families take a ` + bt + `version` + bt + ` argument; presets whose dependency is another custom service (e.g. ` + bt + `mongo-express` + bt + ` on ` + bt + `mongo` + bt + `) require the dep installed first
 - ` + bt + `project_new` + bt + ` requires an absolute ` + bt + `path` + bt + ` and runs the framework's ` + bt + `create` + bt + ` command; follow it with ` + bt + `site_link` + bt + ` + ` + bt + `env_setup` + bt + ` to register and configure the new project
 - ` + bt + `framework_add` + bt + ` accepts ` + bt + `workers` + bt + ` (map) and ` + bt + `setup` + bt + ` (array) — both support an optional ` + bt + `check` + bt + ` field (` + bt + `{file}` + bt + ` or ` + bt + `{composer}` + bt + `) to conditionally show based on project deps; for Laravel, custom setup commands replace built-in storage:link/migrate/db:seed
 - Framework env vars support service version placeholders: ` + bt + `{{mysql_version}}` + bt + `, ` + bt + `{{postgres_version}}` + bt + `, ` + bt + `{{redis_version}}` + bt + `, ` + bt + `{{meilisearch_version}}` + bt + ` — resolved from the running service image tag
-- ` + bt + `php_ext_add` + bt + ` / ` + bt + `php_ext_remove` + bt + ` rebuild the FPM image and restart the container — may take a minute; ` + bt + `version` + bt + ` defaults to the project or global PHP version
+- ` + bt + `php_ext(action: "add", ...)` + bt + ` / ` + bt + `php_ext(action: "remove", ...)` + bt + ` rebuild the FPM image and restart the container — may take a minute; ` + bt + `version` + bt + ` defaults to the project or global PHP version
 - ` + bt + `db_import` + bt + ` / ` + bt + `db_export` + bt + ` / ` + bt + `db_create` + bt + ` auto-detect service and database via: ` + bt + `service` + bt + ` arg → framework definition detect rules → ` + bt + `DB_CONNECTION` + bt + ` / ` + bt + `DB_TYPE` + bt + ` / ` + bt + `TYPEORM_CONNECTION` + bt + ` / ` + bt + `DATABASE_URL` + bt + ` / ` + bt + `DB_PORT` + bt + `; pass ` + bt + `service` + bt + ` explicitly for projects with no env config
 - ` + bt + `db_create` + bt + ` always creates both ` + bt + `<name>` + bt + ` and ` + bt + `<name>_testing` + bt + ` databases; safe to call if they already exist; starts the service automatically if not running
 - ` + bt + `park` + bt + ` auto-registers all PHP subdirectories as sites in one call; ` + bt + `unpark` + bt + ` removes them all — project files are NOT deleted

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestWriteGlobalAISkills_writesAllThreeFiles(t *testing.T) {
@@ -168,4 +169,129 @@ func TestWriteGlobalAISkills_replacesExistingLerdBlock(t *testing.T) {
 	if !strings.Contains(string(got), "Lerd — Laravel Local Dev Environment") {
 		t.Errorf("fresh lerd block not written")
 	}
+}
+
+func TestProjectHasLerdSkills(t *testing.T) {
+	dir := t.TempDir()
+	if ProjectHasLerdSkills(dir) {
+		t.Fatalf("empty dir should not be opted in")
+	}
+
+	skill := filepath.Join(dir, ".claude", "skills", "lerd", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skill), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(skill, []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !ProjectHasLerdSkills(dir) {
+		t.Errorf("SKILL.md presence should signal opt-in")
+	}
+
+	dir2 := t.TempDir()
+	guidelines := filepath.Join(dir2, ".junie", "guidelines.md")
+	if err := os.MkdirAll(filepath.Dir(guidelines), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(guidelines, []byte("header only, no lerd markers\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if ProjectHasLerdSkills(dir2) {
+		t.Errorf("guidelines without lerd marker should not signal opt-in")
+	}
+
+	if err := os.WriteFile(guidelines, []byte("junk\n<!-- lerd:begin -->\nstuff\n<!-- lerd:end -->\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !ProjectHasLerdSkills(dir2) {
+		t.Errorf("guidelines with lerd marker should signal opt-in")
+	}
+}
+
+func TestWriteProjectAISkills_writesAllArtefacts(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteProjectAISkills(dir, false); err != nil {
+		t.Fatalf("WriteProjectAISkills: %v", err)
+	}
+
+	want := []string{
+		".mcp.json",
+		".cursor/mcp.json",
+		".ai/mcp/mcp.json",
+		".junie/mcp/mcp.json",
+		".claude/skills/lerd/SKILL.md",
+		".cursor/rules/lerd.mdc",
+		".junie/guidelines.md",
+	}
+	for _, rel := range want {
+		info, err := os.Stat(filepath.Join(dir, rel))
+		if err != nil {
+			t.Errorf("missing %s: %v", rel, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("%s is empty", rel)
+		}
+	}
+	if !ProjectHasLerdSkills(dir) {
+		t.Errorf("ProjectHasLerdSkills should return true after WriteProjectAISkills")
+	}
+}
+
+func TestWriteProjectAISkills_skipsUnchangedFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteProjectAISkills(dir, false); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	skill := filepath.Join(dir, ".claude", "skills", "lerd", "SKILL.md")
+	rules := filepath.Join(dir, ".cursor", "rules", "lerd.mdc")
+
+	oldSkillMtime := mtimeOrFail(t, skill)
+	oldRulesMtime := mtimeOrFail(t, rules)
+
+	time.Sleep(10 * time.Millisecond)
+
+	if err := WriteProjectAISkills(dir, false); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	if got := mtimeOrFail(t, skill); !got.Equal(oldSkillMtime) {
+		t.Errorf("SKILL.md was rewritten despite unchanged content (mtime changed from %v to %v)", oldSkillMtime, got)
+	}
+	if got := mtimeOrFail(t, rules); !got.Equal(oldRulesMtime) {
+		t.Errorf("lerd.mdc was rewritten despite unchanged content (mtime changed from %v to %v)", oldRulesMtime, got)
+	}
+}
+
+func TestWriteProjectAISkills_rewritesWhenContentChanges(t *testing.T) {
+	dir := t.TempDir()
+	skill := filepath.Join(dir, ".claude", "skills", "lerd", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skill), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(skill, []byte("stale content, older schema"), 0644); err != nil {
+		t.Fatalf("write stale: %v", err)
+	}
+
+	if err := WriteProjectAISkills(dir, false); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	got, err := os.ReadFile(skill)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != claudeSkillContent {
+		t.Errorf("stale SKILL.md was not refreshed")
+	}
+}
+
+func mtimeOrFail(t *testing.T, path string) time.Time {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info.ModTime()
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -158,6 +158,7 @@ func runUpdate(currentVersion string, beta bool) error {
 	}
 
 	refreshGlobalMCPSkills()
+	refreshProjectMCPSkills()
 
 	// Offer MinIO → RustFS migration if legacy data directory exists and the
 	// minio container is still running (skip if already migrated to RustFS).
@@ -218,6 +219,93 @@ func refreshGlobalMCPSkills() {
 	if err := WriteGlobalAISkills(home, true); err != nil {
 		fmt.Fprintf(os.Stderr, "  warn: could not refresh global AI skills: %v\n", err)
 	}
+}
+
+// refreshProjectMCPSkills re-writes per-project AI artefacts for every opted-in
+// project (registered site or park subdir with a lerd marker). Projects whose
+// content already matches stay untouched.
+func refreshProjectMCPSkills() {
+	paths := gatherProjectPaths()
+	if len(paths) == 0 {
+		return
+	}
+
+	opted := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if ProjectHasLerdSkills(p) {
+			opted = append(opted, p)
+		}
+	}
+	if len(opted) == 0 {
+		return
+	}
+
+	fmt.Printf("\n==> Refreshing project MCP skills (%d project%s)\n", len(opted), pluralS(len(opted)))
+	for _, p := range opted {
+		if err := WriteProjectAISkills(p, false); err != nil {
+			fmt.Fprintf(os.Stderr, "  warn: %s: %v\n", p, err)
+			continue
+		}
+		fmt.Printf("  refreshed %s\n", p)
+	}
+}
+
+// gatherProjectPaths lists registered sites plus immediate subdirs of parks.
+// The park scan covers projects that were injected but never registered as
+// lerd sites (e.g. non-PHP projects the user added by hand).
+func gatherProjectPaths() []string {
+	seen := make(map[string]struct{})
+	add := func(p string) {
+		if p == "" {
+			return
+		}
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return
+		}
+		seen[abs] = struct{}{}
+	}
+
+	if reg, err := config.LoadSites(); err == nil {
+		for _, s := range reg.Sites {
+			add(s.Path)
+		}
+	}
+
+	if cfg, err := config.LoadGlobal(); err == nil {
+		for _, park := range cfg.ParkedDirectories {
+			if park == "" {
+				continue
+			}
+			parkAbs, err := filepath.Abs(park)
+			if err != nil {
+				continue
+			}
+			entries, err := os.ReadDir(parkAbs)
+			if err != nil {
+				continue
+			}
+			for _, e := range entries {
+				if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+					continue
+				}
+				add(filepath.Join(parkAbs, e.Name()))
+			}
+		}
+	}
+
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	return out
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }
 
 // mcpEnabledGlobally reports whether the user opted into global MCP at some

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -241,53 +241,44 @@ func toolList() []mcpTool {
 	tools := []mcpTool{
 		{
 			Name:        "sites",
-			Description: "List all sites registered with lerd, including domain, path, PHP version, Node version, TLS status, worker status, and custom_container/container_port for non-PHP sites. Call this first to find site names for other tools.",
+			Description: "List registered sites (domain, path, PHP/Node version, TLS, workers). Call first to discover site names.",
 			InputSchema: mcpSchema{
 				Type:       "object",
 				Properties: map[string]mcpProp{},
 			},
 		},
 		{
-			Name:        "service_start",
-			Description: "Start a lerd infrastructure service (built-in or custom). Ensures the quadlet is written and the systemd unit is running.",
+			Name:        "service_control",
+			Description: "Control a lerd service: start, stop, pin (never auto-stop), unpin.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
+					"action": {
+						Type:        "string",
+						Description: "start, stop, pin, or unpin.",
+						Enum:        []string{"start", "stop", "pin", "unpin"},
+					},
 					"name": {
 						Type:        "string",
-						Description: "Service to start (built-in: mysql, redis, postgres, meilisearch, rustfs, mailpit — or any custom service name registered with service_add)",
+						Description: "Service name (mysql, redis, postgres, meilisearch, rustfs, mailpit, or custom).",
 					},
 				},
-				Required: []string{"name"},
-			},
-		},
-		{
-			Name:        "service_stop",
-			Description: "Stop a running lerd infrastructure service (built-in or custom).",
-			InputSchema: mcpSchema{
-				Type: "object",
-				Properties: map[string]mcpProp{
-					"name": {
-						Type:        "string",
-						Description: "Service to stop (built-in: mysql, redis, postgres, meilisearch, rustfs, mailpit — or any custom service name registered with service_add)",
-					},
-				},
-				Required: []string{"name"},
+				Required: []string{"action", "name"},
 			},
 		},
 		{
 			Name:        "logs",
-			Description: `Fetch recent container logs for a lerd service or PHP-FPM container. When target is omitted, logs for the current site's FPM container are returned. Valid targets: "nginx", a service name (mysql, redis, etc.), a PHP version (8.4, 8.5), or a site name.`,
+			Description: "Fetch recent container logs. target: nginx, service, PHP version (8.4), or site name. Defaults to current site's FPM.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"target": {
 						Type:        "string",
-						Description: `Optional. "nginx", service name like "mysql", PHP version like "8.4", or site name. Defaults to the current site's FPM container.`,
+						Description: "nginx, service, PHP version (8.4), or site name. Defaults to current site's FPM.",
 					},
 					"lines": {
 						Type:        "integer",
-						Description: "Number of lines to return from the tail (default: 50)",
+						Description: "Tail line count (default 50).",
 					},
 				},
 				Required: []string{},
@@ -295,17 +286,17 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "composer",
-			Description: "Run a Composer command inside the lerd PHP-FPM container for the project. Use this to install dependencies, require packages, run scripts, or any other composer command.",
+			Description: "Run a Composer command in the project's PHP-FPM container.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the Laravel project root (e.g. /home/user/code/myapp). Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project root (defaults to LERD_SITE_PATH or cwd).",
 					},
 					"args": {
 						Type:        "array",
-						Description: `Composer arguments as an array, e.g. ["install"] or ["require", "laravel/sanctum"] or ["dump-autoload"]`,
+						Description: `Composer arguments, e.g. ["install"], ["require", "laravel/sanctum"].`,
 					},
 				},
 				Required: []string{"args"},
@@ -313,70 +304,61 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "vendor_bins",
-			Description: "List composer-installed binaries available in the project's vendor/bin directory. Use this to discover tools like pest, phpunit, pint, phpstan, rector, etc. before invoking vendor_run.",
+			Description: "List composer-installed binaries in vendor/bin (pest, phpunit, pint, etc.). Call before vendor_run.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the project root. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project root (defaults to LERD_SITE_PATH or cwd).",
 					},
 				},
 			},
 		},
 		{
 			Name:        "vendor_run",
-			Description: "Run a composer-installed binary from the project's vendor/bin directory inside the lerd PHP-FPM container. Use vendor_bins first to see what's available.",
+			Description: "Run a vendor/bin binary in the PHP-FPM container. Use vendor_bins first.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the project root. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project root (defaults to LERD_SITE_PATH or cwd).",
 					},
 					"bin": {
 						Type:        "string",
-						Description: `Name of the binary in vendor/bin, e.g. "pest", "phpunit", "pint"`,
+						Description: "Binary name (pest, phpunit, pint, etc.).",
 					},
 					"args": {
 						Type:        "array",
-						Description: `Arguments to pass to the binary, e.g. ["--filter", "UserTest"]`,
+						Description: `Arguments to pass, e.g. ["--filter", "UserTest"].`,
 					},
 				},
 				Required: []string{"bin"},
 			},
 		},
 		{
-			Name:        "node_install",
-			Description: "Install a Node.js version via fnm so it can be used by lerd sites. Accepts a version number (e.g. \"20\", \"20.11.0\") or alias (e.g. \"lts\").",
+			Name:        "node",
+			Description: "Install or uninstall a Node.js version via fnm.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
+					"action": {
+						Type:        "string",
+						Description: "install or uninstall.",
+						Enum:        []string{"install", "uninstall"},
+					},
 					"version": {
 						Type:        "string",
-						Description: `Node.js version or alias to install, e.g. "20", "20.11.0", "lts"`,
+						Description: "Node.js version or alias (e.g. 20, 20.11.0, lts).",
 					},
 				},
-				Required: []string{"version"},
-			},
-		},
-		{
-			Name:        "node_uninstall",
-			Description: "Uninstall a Node.js version via fnm.",
-			InputSchema: mcpSchema{
-				Type: "object",
-				Properties: map[string]mcpProp{
-					"version": {
-						Type:        "string",
-						Description: `Node.js version to uninstall, e.g. "20.11.0"`,
-					},
-				},
-				Required: []string{"version"},
+				Required: []string{"action", "version"},
 			},
 		},
 		{
 			Name:        "runtime_versions",
-			Description: "List installed PHP and Node.js versions managed by lerd, plus default versions. Use this to check what runtimes are available before running commands.",
+			Description: "List installed PHP and Node.js versions (plus defaults).",
 			InputSchema: mcpSchema{
 				Type:       "object",
 				Properties: map[string]mcpProp{},
@@ -384,7 +366,7 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "status",
-			Description: "Return the health status of core lerd services: DNS resolution, nginx, PHP-FPM containers, and the file watcher. Use this to diagnose why a site isn't loading or before suggesting start/stop commands.",
+			Description: "Health status of DNS, nginx, PHP-FPM containers, and the file watcher. Call when a site is unreachable.",
 			InputSchema: mcpSchema{
 				Type:       "object",
 				Properties: map[string]mcpProp{},
@@ -392,7 +374,7 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "doctor",
-			Description: "Run a full lerd environment diagnostic: checks podman, systemd, DNS resolution, port conflicts, PHP images, config validity, and update availability. Use this when the user reports setup issues or unexpected behaviour.",
+			Description: "Full environment diagnostic (podman, systemd, DNS, ports, images, config). Call on setup issues.",
 			InputSchema: mcpSchema{
 				Type:       "object",
 				Properties: map[string]mcpProp{},
@@ -400,45 +382,45 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "service_add",
-			Description: "Register a new custom OCI-based service with lerd (e.g. RabbitMQ, Cassandra, a hand-rolled image). Writes a systemd quadlet so the service can be started/stopped like built-in services. For commonly-used services that ship as bundled presets (phpmyadmin, pgadmin, mongo, mongo-express, mysql alternates, mariadb, stripe-mock) prefer service_preset_install instead.",
+			Description: "Register a custom OCI service (writes systemd quadlet). For bundled presets (mongo, phpmyadmin, mariadb, etc.) use service_preset_install.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"name": {
 						Type:        "string",
-						Description: "Service slug, lowercase letters/digits/hyphens only (e.g. \"mongodb\")",
+						Description: "Service slug (lowercase, hyphens; e.g. mongodb).",
 					},
 					"image": {
 						Type:        "string",
-						Description: "OCI image reference (e.g. \"docker.io/library/mongo:7\")",
+						Description: "OCI image reference (e.g. docker.io/library/mongo:7).",
 					},
 					"ports": {
 						Type:        "array",
-						Description: `Port mappings as \"host:container\" strings, e.g. ["27017:27017"]`,
+						Description: `Port mappings host:container, e.g. ["27017:27017"].`,
 					},
 					"environment": {
 						Type:        "array",
-						Description: `Container environment variables as \"KEY=VALUE\" strings`,
+						Description: `Container env, ["KEY=VALUE", ...].`,
 					},
 					"env_vars": {
 						Type:        "array",
-						Description: `Project .env variables to inject (shown by lerd env), as \"KEY=VALUE\" strings`,
+						Description: `Project .env keys to inject, ["KEY=VALUE", ...].`,
 					},
 					"data_dir": {
 						Type:        "string",
-						Description: "Mount path inside the container for persistent data (host directory is auto-created)",
+						Description: "Container path for persistent data (host dir auto-created).",
 					},
 					"description": {
 						Type:        "string",
-						Description: "Human-readable description of the service",
+						Description: "Human-readable description.",
 					},
 					"dashboard": {
 						Type:        "string",
-						Description: "URL to open for this service's web dashboard (e.g. \"http://localhost:8080\")",
+						Description: "Web dashboard URL (optional).",
 					},
 					"depends_on": {
 						Type:        "array",
-						Description: `Services that must be running before this one starts, e.g. ["mysql"]. When this service starts its dependencies start first; when a dependency is stopped this service is stopped first.`,
+						Description: `Services that must start first, e.g. ["mysql"].`,
 					},
 				},
 				Required: []string{"name", "image"},
@@ -446,13 +428,13 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "service_remove",
-			Description: "Stop and remove a custom lerd service. Built-in services (mysql, redis, etc.) cannot be removed. Persistent data is NOT deleted.",
+			Description: "Stop and remove a custom service. Built-ins cannot be removed. Data is kept.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"name": {
 						Type:        "string",
-						Description: "Name of the custom service to remove",
+						Description: "Custom service name.",
 					},
 				},
 				Required: []string{"name"},
@@ -460,21 +442,21 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "service_expose",
-			Description: "Add or remove an extra published port on a built-in lerd service (mysql, redis, etc.). The port mapping is persisted in the global config. The service is restarted automatically if running.",
+			Description: "Add or remove a published port on a built-in service. Persists to config; restarts if running.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"name": {
 						Type:        "string",
-						Description: "Built-in service name (mysql, redis, postgres, meilisearch, rustfs, mailpit)",
+						Description: "Built-in service (mysql, redis, postgres, meilisearch, rustfs, mailpit).",
 					},
 					"port": {
 						Type:        "string",
-						Description: `Port mapping as "host:container", e.g. "13306:3306"`,
+						Description: `Port mapping "host:container", e.g. "13306:3306".`,
 					},
 					"remove": {
 						Type:        "boolean",
-						Description: "Set to true to remove the port mapping instead of adding it",
+						Description: "Set true to remove the mapping.",
 					},
 				},
 				Required: []string{"name", "port"},
@@ -482,13 +464,13 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "service_env",
-			Description: "Return the recommended Laravel .env connection variables for a lerd service (built-in or custom). Use this to see what keys a service needs before calling env_setup or editing .env manually.",
+			Description: "Recommended Laravel .env connection keys for a service.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"name": {
 						Type:        "string",
-						Description: "Service name (e.g. \"mysql\", \"redis\", \"mongodb\")",
+						Description: "Service name (e.g. mysql, redis, mongodb).",
 					},
 				},
 				Required: []string{"name"},
@@ -496,7 +478,7 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "service_preset_list",
-			Description: "List bundled service presets that ship with lerd. Each entry includes the preset name, description, dashboard URL, declared dependencies, available versions (for multi-version presets like mysql or mariadb), and which versions are already installed locally. Use this before service_preset_install to see what's available.",
+			Description: "List bundled service presets (name, description, versions, installed state). Call before service_preset_install.",
 			InputSchema: mcpSchema{
 				Type:       "object",
 				Properties: map[string]mcpProp{},
@@ -504,17 +486,17 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "service_preset_install",
-			Description: "Install a bundled service preset as a local custom service. Single-version presets (phpmyadmin, pgadmin, mongo, mongo-express, stripe-mock) are installed by name. Multi-version presets (mysql, mariadb) require a version argument; available versions come from service_preset_list. Dependencies that are themselves presets must be installed first — installing mongo-express without mongo errors out with a clear hint. After install the service can be started, stopped, removed, exposed, or pinned with the usual service_* tools.",
+			Description: "Install a bundled preset. Multi-version presets (mysql, mariadb) need version. Preset dependencies (e.g. mongo for mongo-express) must be installed first. Call service_preset_list first.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"name": {
 						Type:        "string",
-						Description: "Preset name (e.g. \"phpmyadmin\", \"pgadmin\", \"mongo\", \"mongo-express\", \"stripe-mock\", \"mysql\", \"mariadb\"). Run service_preset_list to see all bundled presets.",
+						Description: "Preset name (e.g. phpmyadmin, mongo, mysql, mariadb).",
 					},
 					"version": {
 						Type:        "string",
-						Description: "Version tag for multi-version presets (e.g. \"5.7\" for mysql, \"11\" for mariadb). Required when the preset declares versions. Empty for single-version presets.",
+						Description: "Version for multi-version presets (e.g. 5.7, 11). Required when the preset has versions.",
 					},
 				},
 				Required: []string{"name"},
@@ -522,30 +504,30 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "env_setup",
-			Description: "Configure the project's .env for lerd: creates .env from .env.example if missing, detects services (mysql, redis, etc.), starts them, creates databases, generates APP_KEY (works even before composer install), and sets APP_URL. Run this once after cloning a project. Note: when run on a fresh Laravel project where .env still says DB_CONNECTION=sqlite, env_setup leaves the database choice alone — call db_set first to pick a database explicitly.",
+			Description: "Configure .env: start services, create DBs, APP_KEY, APP_URL. Run once after clone. For fresh Laravel with DB_CONNECTION=sqlite, call db_set first.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the Laravel project root. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project root (defaults to LERD_SITE_PATH or cwd).",
 					},
 				},
 			},
 		},
 		{
 			Name:        "db_set",
-			Description: "Pick the database for a Laravel project: sqlite (local file, no service), mysql (lerd-mysql), or postgres (lerd-postgres). Persists the choice to .lerd.yaml, rewrites the relevant DB_ keys in .env, starts the service if needed, and creates the project database (and a _testing variant) for mysql/postgres. For sqlite, creates database/database.sqlite if missing. Picking a database is exclusive — switching from one to another removes the previous entry from .lerd.yaml. Use this on fresh Laravel clones before env_setup.",
+			Description: "Pick the project database (sqlite/mysql/postgres). Persists to .lerd.yaml, rewrites DB_ keys, starts service, creates DB + _testing. Exclusive. Call before env_setup on fresh clones.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the Laravel project root. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project root (defaults to LERD_SITE_PATH or cwd).",
 					},
 					"database": {
 						Type:        "string",
-						Description: `Database to use: "sqlite", "mysql", or "postgres"`,
+						Description: "Database choice.",
 						Enum:        []string{"sqlite", "mysql", "postgres"},
 					},
 				},
@@ -554,187 +536,150 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "env_check",
-			Description: "Compare .env against .env.example and flag missing or extra keys. Useful for catching 'works on my machine' bugs caused by env drift.",
+			Description: "Compare .env against .env.example; flag missing/extra keys.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the project root. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project root (defaults to LERD_SITE_PATH or cwd).",
 					},
 				},
 			},
 		},
 		{
 			Name:        "site_link",
-			Description: "Register a directory as a lerd site, generating an nginx vhost and a <name>.test domain. Reads .lerd.yaml automatically: if a container:{port:N} section is present, builds the custom container image and proxies nginx to it; otherwise registers as a PHP/framework site. For non-PHP projects (Node.js, Python, Go, etc.): write .lerd.yaml with container:{port:N} and a Containerfile (default name Containerfile.lerd; set container.containerfile for a different name like Dockerfile) BEFORE calling this.",
+			Description: "Register a directory as a lerd site (nginx vhost + <name>.test). Non-PHP sites need .lerd.yaml with container.port and a Containerfile first; see the lerd skill.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the project directory. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project directory (defaults to LERD_SITE_PATH or cwd).",
 					},
 					"name": {
 						Type:        "string",
-						Description: "Domain name without TLD (e.g. 'myapp' becomes myapp.test). Defaults to the directory name, cleaned up.",
+						Description: "Domain without .test TLD (defaults to cleaned dir name).",
 					},
 				},
 			},
 		},
 		{
 			Name:        "site_unlink",
-			Description: "Unregister a lerd site and remove its nginx vhost (all domains). The project files are NOT deleted.",
+			Description: "Unregister a site and remove its nginx vhost. Project files are kept.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the project directory. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project directory (defaults to LERD_SITE_PATH or cwd).",
 					},
 				},
 			},
 		},
 		{
-			Name:        "site_domain_add",
-			Description: "Add an additional domain to a lerd site. The domain name should not include the .test TLD.",
+			Name:        "site_domain",
+			Description: "Add or remove a domain on a site (without .test TLD). Cannot remove the last domain.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
+					"action": {
+						Type:        "string",
+						Description: "add or remove.",
+						Enum:        []string{"add", "remove"},
+					},
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the project directory. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project directory (defaults to LERD_SITE_PATH or cwd).",
 					},
 					"domain": {
 						Type:        "string",
-						Description: "Domain name to add (without .test TLD, e.g. 'api')",
+						Description: "Domain without .test TLD.",
 					},
 				},
-				Required: []string{"domain"},
+				Required: []string{"action", "domain"},
 			},
 		},
 		{
-			Name:        "site_domain_remove",
-			Description: "Remove a domain from a lerd site. Cannot remove the last domain.",
+			Name:        "site_tls",
+			Description: "Enable or disable HTTPS for a site (mkcert cert). Updates APP_URL in .env.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
-					"path": {
+					"action": {
 						Type:        "string",
-						Description: "Absolute path to the project directory. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "enable or disable.",
+						Enum:        []string{"enable", "disable"},
 					},
-					"domain": {
-						Type:        "string",
-						Description: "Domain name to remove (without .test TLD, e.g. 'api')",
-					},
-				},
-				Required: []string{"domain"},
-			},
-		},
-		{
-			Name:        "secure",
-			Description: "Enable HTTPS for a lerd site using a locally-trusted mkcert certificate. Updates APP_URL in .env automatically.",
-			InputSchema: mcpSchema{
-				Type: "object",
-				Properties: map[string]mcpProp{
 					"site": {
 						Type:        "string",
-						Description: "Site name as shown by the sites tool",
+						Description: "Site name (from sites).",
 					},
 				},
-				Required: []string{"site"},
+				Required: []string{"action", "site"},
 			},
 		},
 		{
-			Name:        "unsecure",
-			Description: "Disable HTTPS for a lerd site and revert APP_URL in .env to http://.",
+			Name:        "xdebug",
+			Description: "Xdebug control: on (enable + restart FPM, port 9003), off (disable + restart), status (all versions).",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
-					"site": {
+					"action": {
 						Type:        "string",
-						Description: "Site name as shown by the sites tool",
+						Description: "on, off, or status.",
+						Enum:        []string{"on", "off", "status"},
 					},
-				},
-				Required: []string{"site"},
-			},
-		},
-		{
-			Name:        "xdebug_on",
-			Description: "Enable Xdebug for a PHP version and restart the FPM container. Xdebug listens on port 9003 (host.containers.internal).",
-			InputSchema: mcpSchema{
-				Type: "object",
-				Properties: map[string]mcpProp{
 					"version": {
 						Type:        "string",
-						Description: "PHP version (e.g. \"8.4\"). Defaults to the project or global default.",
+						Description: "PHP version (defaults to project/global). Ignored for action=status.",
 					},
 					"mode": {
 						Type:        "string",
-						Description: "xdebug.mode value. Defaults to \"debug\". Accepts debug, coverage, develop, profile, trace, gcstats, or a comma-separated combo like \"debug,coverage\".",
+						Description: "xdebug.mode for action=on: debug, coverage, develop, profile, trace, gcstats (combinable). Default debug.",
 					},
 				},
-			},
-		},
-		{
-			Name:        "xdebug_off",
-			Description: "Disable Xdebug for a PHP version and restart the FPM container.",
-			InputSchema: mcpSchema{
-				Type: "object",
-				Properties: map[string]mcpProp{
-					"version": {
-						Type:        "string",
-						Description: "PHP version (e.g. \"8.4\"). Defaults to the project or global default.",
-					},
-				},
-			},
-		},
-		{
-			Name:        "xdebug_status",
-			Description: "Show Xdebug enabled/disabled status for all installed PHP versions.",
-			InputSchema: mcpSchema{
-				Type:       "object",
-				Properties: map[string]mcpProp{},
+				Required: []string{"action"},
 			},
 		},
 		{
 			Name:        "db_export",
-			Description: "Export a database to a SQL dump file. Reads connection details from the project .env.",
+			Description: "Export the project database to a SQL dump.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the Laravel project root. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project root (defaults to LERD_SITE_PATH or cwd).",
 					},
 					"database": {
 						Type:        "string",
-						Description: "Database name to export (defaults to DB_DATABASE from .env)",
+						Description: "Database name (defaults to DB_DATABASE).",
 					},
 					"output": {
 						Type:        "string",
-						Description: "Output file path (defaults to <database>.sql in the project root)",
+						Description: "Output path (defaults to <database>.sql in the project root).",
 					},
 				},
 			},
 		},
 		{
 			Name:        "db_import",
-			Description: "Import a SQL dump file into the project database. Reads connection details from the project .env. The database service must be running.",
+			Description: "Import a SQL dump into the project database.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the project root. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project root (defaults to LERD_SITE_PATH or cwd).",
 					},
 					"file": {
 						Type:        "string",
-						Description: "Absolute path to the SQL dump file to import",
+						Description: "SQL dump file path.",
 					},
 					"database": {
 						Type:        "string",
-						Description: "Database name to import into (defaults to DB_DATABASE from .env)",
+						Description: "Target database (defaults to DB_DATABASE).",
 					},
 				},
 				Required: []string{"file"},
@@ -742,100 +687,74 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "db_create",
-			Description: "Create a database (and a _testing variant) for the project. Reads the connection type from .env and starts the service if needed. Defaults to the DB_DATABASE name from .env, falling back to the project directory name.",
+			Description: "Create the project database (and a _testing variant). Starts service if needed.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the project root. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project root (defaults to LERD_SITE_PATH or cwd).",
 					},
 					"name": {
 						Type:        "string",
-						Description: "Database name (defaults to DB_DATABASE from .env, then to the project directory name)",
+						Description: "Database name (defaults to DB_DATABASE, then project dir name).",
 					},
 				},
 			},
 		},
 		{
 			Name:        "php_list",
-			Description: "List all PHP versions installed by lerd, marking the global default. Use this to check available versions before calling site_php or php_ext_add.",
+			Description: "List installed PHP versions (global default marked).",
 			InputSchema: mcpSchema{
 				Type:       "object",
 				Properties: map[string]mcpProp{},
 			},
 		},
 		{
-			Name:        "php_ext_list",
-			Description: "List custom PHP extensions configured for a PHP version. These are extensions added on top of the bundled lerd image.",
+			Name:        "php_ext",
+			Description: "Manage custom PHP extensions: list, add (rebuild FPM; slow), remove (rebuild FPM).",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
-					"version": {
+					"action": {
 						Type:        "string",
-						Description: "PHP version (e.g. \"8.4\"). Defaults to the project or global default.",
+						Description: "list, add, or remove.",
+						Enum:        []string{"list", "add", "remove"},
 					},
-				},
-			},
-		},
-		{
-			Name:        "php_ext_add",
-			Description: "Install a custom PHP extension for a PHP version. Rebuilds the FPM image and restarts the container. This may take a minute.",
-			InputSchema: mcpSchema{
-				Type: "object",
-				Properties: map[string]mcpProp{
 					"extension": {
 						Type:        "string",
-						Description: "Extension name to install (e.g. \"imagick\", \"redis\", \"swoole\")",
+						Description: "Extension name (required for add/remove; e.g. imagick, redis, swoole).",
 					},
 					"version": {
 						Type:        "string",
-						Description: "PHP version (e.g. \"8.4\"). Defaults to the project or global default.",
+						Description: "PHP version (defaults to project/global).",
 					},
 				},
-				Required: []string{"extension"},
-			},
-		},
-		{
-			Name:        "php_ext_remove",
-			Description: "Remove a custom PHP extension from a PHP version. Rebuilds the FPM image and restarts the container.",
-			InputSchema: mcpSchema{
-				Type: "object",
-				Properties: map[string]mcpProp{
-					"extension": {
-						Type:        "string",
-						Description: "Extension name to remove",
-					},
-					"version": {
-						Type:        "string",
-						Description: "PHP version (e.g. \"8.4\"). Defaults to the project or global default.",
-					},
-				},
-				Required: []string{"extension"},
+				Required: []string{"action"},
 			},
 		},
 		{
 			Name:        "park",
-			Description: "Register a directory as a lerd park: scans all subdirectories and auto-registers any PHP projects as sites. Use this to manage many projects under a single parent directory.",
+			Description: "Register a parent directory as a park: auto-registers all PHP projects under it as sites.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the directory to park. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Parent directory (defaults to LERD_SITE_PATH or cwd).",
 					},
 				},
 			},
 		},
 		{
 			Name:        "unpark",
-			Description: "Remove a parked directory from lerd and unlink all sites whose paths are under it. Project files are NOT deleted.",
+			Description: "Remove a parked directory and unlink sites under it. Project files are kept.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the parked directory to remove",
+						Description: "Parked directory path.",
 					},
 				},
 				Required: []string{"path"},
@@ -843,26 +762,26 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "which",
-			Description: "Show the resolved PHP version, Node version, document root, and nginx config path for a site. Useful for confirming which runtime versions a project will use.",
+			Description: "Show resolved PHP/Node versions, docroot, and nginx config path for a site.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the project root. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project root (defaults to LERD_SITE_PATH or cwd).",
 					},
 				},
 			},
 		},
 		{
 			Name:        "check",
-			Description: "Validate a project's .lerd.yaml file — checks YAML syntax, PHP version, framework references, service definitions (including preset catalog), worker definitions, container config (port required; containerfile path, default Containerfile.lerd — any filename works, set container.containerfile to point at e.g. Dockerfile), custom_workers (command required), and db.service. Reports OK/WARN/FAIL per field.",
+			Description: "Validate .lerd.yaml (syntax, PHP, framework, services, workers, container, db). Reports OK/WARN/FAIL per field.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the project root containing .lerd.yaml. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project root (defaults to LERD_SITE_PATH or cwd).",
 					},
 				},
 			},
@@ -873,180 +792,135 @@ func toolList() []mcpTool {
 		tools = append(tools,
 			mcpTool{
 				Name:        "artisan",
-				Description: "Run a php artisan command inside the lerd PHP-FPM container for the project. Use this to run migrations, generate files, seed databases, clear caches, or any other artisan command.",
+				Description: "Run `php artisan` in the project's PHP-FPM container.",
 				InputSchema: mcpSchema{
 					Type: "object",
 					Properties: map[string]mcpProp{
 						"path": {
 							Type:        "string",
-							Description: "Absolute path to the Laravel project root (e.g. /home/user/code/myapp). Defaults to LERD_SITE_PATH when omitted.",
+							Description: "Project root (defaults to LERD_SITE_PATH or cwd).",
 						},
 						"args": {
 							Type:        "array",
-							Description: `Artisan arguments as an array, e.g. ["migrate"] or ["make:model", "Post", "-m"] or ["tinker", "--execute=App\\Models\\User::count()"]`,
+							Description: `Artisan arguments, e.g. ["migrate"], ["make:model", "Post", "-m"].`,
 						},
 					},
 					Required: []string{"args"},
 				},
 			},
 			mcpTool{
-				Name:        "queue_start",
-				Description: "Start a Laravel queue worker for a registered site as a systemd user service. The worker runs php artisan queue:work inside the PHP-FPM container.",
+				Name:        "queue",
+				Description: "Start or stop a Laravel queue:work worker (systemd user service) for a site.",
 				InputSchema: mcpSchema{
 					Type: "object",
 					Properties: map[string]mcpProp{
+						"action": {
+							Type:        "string",
+							Description: "start or stop.",
+							Enum:        []string{"start", "stop"},
+						},
 						"site": {
 							Type:        "string",
-							Description: "Site name as shown by the sites tool",
+							Description: "Site name (from sites).",
 						},
 						"queue": {
 							Type:        "string",
-							Description: `Queue name to process (default: "default")`,
+							Description: `Queue name for action=start (default "default").`,
 						},
 						"tries": {
 							Type:        "integer",
-							Description: "Max job attempts before marking failed (default: 3)",
+							Description: "Max attempts for action=start (default 3).",
 						},
 						"timeout": {
 							Type:        "integer",
-							Description: "Seconds a job may run before timing out (default: 60)",
+							Description: "Job timeout seconds for action=start (default 60).",
 						},
 					},
-					Required: []string{"site"},
+					Required: []string{"action", "site"},
 				},
 			},
 			mcpTool{
-				Name:        "queue_stop",
-				Description: "Stop the Laravel queue worker systemd service for a registered site.",
+				Name:        "reverb",
+				Description: "Start or stop Laravel Reverb (WebSocket server) for a site.",
 				InputSchema: mcpSchema{
 					Type: "object",
 					Properties: map[string]mcpProp{
+						"action": {
+							Type:        "string",
+							Description: "start or stop.",
+							Enum:        []string{"start", "stop"},
+						},
 						"site": {
 							Type:        "string",
-							Description: "Site name as shown by the sites tool",
+							Description: "Site name (from sites).",
 						},
 					},
-					Required: []string{"site"},
+					Required: []string{"action", "site"},
 				},
 			},
 			mcpTool{
-				Name:        "reverb_start",
-				Description: "Start the Laravel Reverb WebSocket server for a registered site as a systemd user service. The server runs php artisan reverb:start inside the PHP-FPM container.",
+				Name:        "horizon",
+				Description: "Start or stop Laravel Horizon for a site (requires laravel/horizon; replaces queue:work).",
 				InputSchema: mcpSchema{
 					Type: "object",
 					Properties: map[string]mcpProp{
+						"action": {
+							Type:        "string",
+							Description: "start or stop.",
+							Enum:        []string{"start", "stop"},
+						},
 						"site": {
 							Type:        "string",
-							Description: "Site name as shown by the sites tool",
+							Description: "Site name (from sites).",
 						},
 					},
-					Required: []string{"site"},
+					Required: []string{"action", "site"},
 				},
 			},
 			mcpTool{
-				Name:        "reverb_stop",
-				Description: "Stop the Laravel Reverb WebSocket server for a registered site.",
+				Name:        "schedule",
+				Description: "Start or stop the Laravel scheduler (schedule:work) for a site.",
 				InputSchema: mcpSchema{
 					Type: "object",
 					Properties: map[string]mcpProp{
+						"action": {
+							Type:        "string",
+							Description: "start or stop.",
+							Enum:        []string{"start", "stop"},
+						},
 						"site": {
 							Type:        "string",
-							Description: "Site name as shown by the sites tool",
+							Description: "Site name (from sites).",
 						},
 					},
-					Required: []string{"site"},
+					Required: []string{"action", "site"},
 				},
 			},
 			mcpTool{
-				Name:        "horizon_start",
-				Description: "Start Laravel Horizon for a registered site as a systemd user service. Horizon runs php artisan horizon inside the PHP-FPM container and replaces the standard queue worker. Only available for sites that have laravel/horizon in composer.json.",
+				Name:        "stripe",
+				Description: "Start or stop a Stripe webhook listener for a site. Reads STRIPE_SECRET from .env.",
 				InputSchema: mcpSchema{
 					Type: "object",
 					Properties: map[string]mcpProp{
-						"site": {
+						"action": {
 							Type:        "string",
-							Description: "Site name as shown by the sites tool",
+							Description: "start or stop.",
+							Enum:        []string{"start", "stop"},
 						},
-					},
-					Required: []string{"site"},
-				},
-			},
-			mcpTool{
-				Name:        "horizon_stop",
-				Description: "Stop the Laravel Horizon service for a registered site.",
-				InputSchema: mcpSchema{
-					Type: "object",
-					Properties: map[string]mcpProp{
 						"site": {
 							Type:        "string",
-							Description: "Site name as shown by the sites tool",
-						},
-					},
-					Required: []string{"site"},
-				},
-			},
-			mcpTool{
-				Name:        "schedule_start",
-				Description: "Start the Laravel task scheduler (php artisan schedule:work) for a registered site as a systemd user service.",
-				InputSchema: mcpSchema{
-					Type: "object",
-					Properties: map[string]mcpProp{
-						"site": {
-							Type:        "string",
-							Description: "Site name as shown by the sites tool",
-						},
-					},
-					Required: []string{"site"},
-				},
-			},
-			mcpTool{
-				Name:        "schedule_stop",
-				Description: "Stop the Laravel task scheduler for a registered site.",
-				InputSchema: mcpSchema{
-					Type: "object",
-					Properties: map[string]mcpProp{
-						"site": {
-							Type:        "string",
-							Description: "Site name as shown by the sites tool",
-						},
-					},
-					Required: []string{"site"},
-				},
-			},
-			mcpTool{
-				Name:        "stripe_listen",
-				Description: "Start a Stripe webhook listener for a registered site using the Stripe CLI container. Reads STRIPE_SECRET from the site's .env. Forwards webhooks to the site's /stripe/webhook route by default.",
-				InputSchema: mcpSchema{
-					Type: "object",
-					Properties: map[string]mcpProp{
-						"site": {
-							Type:        "string",
-							Description: "Site name as shown by the sites tool",
+							Description: "Site name (from sites).",
 						},
 						"api_key": {
 							Type:        "string",
-							Description: "Stripe secret key (defaults to STRIPE_SECRET in the site's .env)",
+							Description: "Stripe secret key for action=start (defaults to STRIPE_SECRET in .env).",
 						},
 						"webhook_path": {
 							Type:        "string",
-							Description: `Webhook route path on the app (default: "/stripe/webhook")`,
+							Description: "Webhook path for action=start (default /stripe/webhook).",
 						},
 					},
-					Required: []string{"site"},
-				},
-			},
-			mcpTool{
-				Name:        "stripe_listen_stop",
-				Description: "Stop the Stripe webhook listener for a registered site.",
-				InputSchema: mcpSchema{
-					Type: "object",
-					Properties: map[string]mcpProp{
-						"site": {
-							Type:        "string",
-							Description: "Site name as shown by the sites tool",
-						},
-					},
-					Required: []string{"site"},
+					Required: []string{"action", "site"},
 				},
 			},
 		)
@@ -1055,17 +929,17 @@ func toolList() []mcpTool {
 	if fw, ok := siteFramework(); ok && fw.Console != "" && fw.Console != "artisan" {
 		tools = append(tools, mcpTool{
 			Name:        "console",
-			Description: fmt.Sprintf("Run a framework console command (php %s) inside the lerd PHP-FPM container for the project.", fw.Console),
+			Description: fmt.Sprintf("Run `php %s` in the project's PHP-FPM container.", fw.Console),
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path to the project root. Defaults to LERD_SITE_PATH when omitted.",
+						Description: "Project root (defaults to LERD_SITE_PATH or cwd).",
 					},
 					"args": {
 						Type:        "array",
-						Description: fmt.Sprintf(`Console arguments as an array, e.g. ["%s", "cache:clear"]`, fw.Console),
+						Description: fmt.Sprintf(`Console arguments, e.g. ["%s", "cache:clear"].`, fw.Console),
 					},
 				},
 				Required: []string{"args"},
@@ -1075,50 +949,37 @@ func toolList() []mcpTool {
 
 	tools = append(tools,
 		mcpTool{
-			Name:        "worker_start",
-			Description: "Start a framework-defined worker for a registered site as a systemd user service. The worker command is taken from the framework definition. Use worker_list to see available workers.",
+			Name:        "worker",
+			Description: "Start or stop a framework-defined worker for a site (systemd user service). Call worker_list first.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
+					"action": {
+						Type:        "string",
+						Description: "start or stop.",
+						Enum:        []string{"start", "stop"},
+					},
 					"site": {
 						Type:        "string",
-						Description: "Site name as shown by the sites tool",
+						Description: "Site name (from sites).",
 					},
 					"worker": {
 						Type:        "string",
-						Description: "Worker name as defined in the framework (e.g. messenger, horizon, pulse)",
+						Description: "Worker name (e.g. messenger, horizon, pulse).",
 					},
 				},
-				Required: []string{"site", "worker"},
-			},
-		},
-		mcpTool{
-			Name:        "worker_stop",
-			Description: "Stop a framework-defined worker for a registered site.",
-			InputSchema: mcpSchema{
-				Type: "object",
-				Properties: map[string]mcpProp{
-					"site": {
-						Type:        "string",
-						Description: "Site name as shown by the sites tool",
-					},
-					"worker": {
-						Type:        "string",
-						Description: "Worker name (e.g. messenger, horizon)",
-					},
-				},
-				Required: []string{"site", "worker"},
+				Required: []string{"action", "site", "worker"},
 			},
 		},
 		mcpTool{
 			Name:        "worker_list",
-			Description: "List all workers defined for a site's framework, including their running status.",
+			Description: "List workers defined for a site's framework, including running status.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"site": {
 						Type:        "string",
-						Description: "Site name as shown by the sites tool",
+						Description: "Site name (from sites).",
 					},
 				},
 				Required: []string{"site"},
@@ -1126,97 +987,97 @@ func toolList() []mcpTool {
 		},
 		mcpTool{
 			Name:        "worker_add",
-			Description: "Add or update a custom worker for a project. Saves to .lerd.yaml custom_workers by default, or to the global user framework overlay (~/.config/lerd/frameworks/) with global: true. Does not auto-start — use worker_start afterwards.",
+			Description: "Add or update a custom worker. Saves to .lerd.yaml (or global overlay with global=true). Use worker_start to run.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
-					"site":               {Type: "string", Description: "Site name as shown by the sites tool"},
-					"name":               {Type: "string", Description: "Worker name (slug, e.g. pdf-generator)"},
-					"command":            {Type: "string", Description: "Command to run inside the PHP-FPM container"},
-					"label":              {Type: "string", Description: "Human-readable label (optional)"},
-					"restart":            {Type: "string", Description: "Restart policy: always or on-failure (default: always)"},
-					"check_file":         {Type: "string", Description: "Only show worker when this file exists (optional)"},
-					"check_composer":     {Type: "string", Description: "Only show worker when this Composer package is installed (optional)"},
-					"conflicts_with":     {Type: "array", Description: "Workers to stop before starting this one (optional)"},
-					"proxy_path":         {Type: "string", Description: "URL path to proxy (optional, e.g. /app)"},
-					"proxy_port_env_key": {Type: "string", Description: "Env key holding the worker port (optional)"},
-					"proxy_default_port": {Type: "number", Description: "Default port if env key is missing (optional)"},
-					"global":             {Type: "boolean", Description: "Save to global framework overlay instead of project .lerd.yaml (default: false)"},
+					"site":               {Type: "string", Description: "Site name (from sites)."},
+					"name":               {Type: "string", Description: "Worker slug (e.g. pdf-generator)."},
+					"command":            {Type: "string", Description: "Command (runs in PHP-FPM container)."},
+					"label":              {Type: "string", Description: "Human-readable label."},
+					"restart":            {Type: "string", Description: "Restart policy: always | on-failure (default always)."},
+					"check_file":         {Type: "string", Description: "Show only when this file exists."},
+					"check_composer":     {Type: "string", Description: "Show only when this Composer package is installed."},
+					"conflicts_with":     {Type: "array", Description: "Workers to stop before starting this one."},
+					"proxy_path":         {Type: "string", Description: "URL path to proxy (e.g. /app)."},
+					"proxy_port_env_key": {Type: "string", Description: "Env key holding the worker port."},
+					"proxy_default_port": {Type: "number", Description: "Default port if env key is missing."},
+					"global":             {Type: "boolean", Description: "Save to global overlay instead of .lerd.yaml."},
 				},
 				Required: []string{"site", "name", "command"},
 			},
 		},
 		mcpTool{
 			Name:        "worker_remove",
-			Description: "Remove a custom worker from a project's .lerd.yaml or global framework overlay. Stops the worker if running.",
+			Description: "Remove a custom worker (from .lerd.yaml or global overlay). Stops if running.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
-					"site":   {Type: "string", Description: "Site name as shown by the sites tool"},
-					"name":   {Type: "string", Description: "Worker name to remove"},
-					"global": {Type: "boolean", Description: "Remove from global framework overlay instead of .lerd.yaml (default: false)"},
+					"site":   {Type: "string", Description: "Site name (from sites)."},
+					"name":   {Type: "string", Description: "Worker name."},
+					"global": {Type: "boolean", Description: "Remove from global overlay instead of .lerd.yaml."},
 				},
 				Required: []string{"site", "name"},
 			},
 		},
 		mcpTool{
 			Name:        "framework_list",
-			Description: "List all available framework definitions (laravel built-in plus any user-defined YAMLs), including their defined workers and setup commands. Use this before framework_add to see what is already defined.",
+			Description: "List framework definitions (built-in + user YAMLs), with their workers and setup commands.",
 			InputSchema: mcpSchema{Type: "object", Properties: map[string]mcpProp{}},
 		},
 		mcpTool{
 			Name:        "framework_add",
-			Description: "Create or update a framework definition. For laravel, only the workers and setup fields are used (built-in settings are always preserved). For other frameworks, creates a full definition at ~/.config/lerd/frameworks/<name>.yaml.",
+			Description: "Create or update a framework definition. For name=laravel, only workers/setup are merged into the built-in.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"name": {
 						Type:        "string",
-						Description: `Framework identifier (slug). Use "laravel" to add custom workers to Laravel (e.g. horizon, pulse). For new frameworks use e.g. symfony, wordpress, drupal.`,
+						Description: `Framework slug. "laravel" adds workers to Laravel; others: symfony, wordpress, drupal, etc.`,
 					},
 					"label": {
 						Type:        "string",
-						Description: "Human-readable name, e.g. Symfony (not required when name is laravel)",
+						Description: "Human-readable name (e.g. Symfony).",
 					},
 					"public_dir": {
 						Type:        "string",
-						Description: `Document root relative to project path (e.g. "public", "web", "."). Not required when name is laravel.`,
+						Description: `Document root (e.g. "public", "web", ".").`,
 					},
 					"detect_files": {
 						Type:        "array",
-						Description: `List of filenames whose presence signals this framework, e.g. ["wp-login.php"]`,
+						Description: `Filenames that signal this framework, e.g. ["wp-login.php"].`,
 					},
 					"detect_packages": {
 						Type:        "array",
-						Description: `List of Composer package names that signal this framework, e.g. ["symfony/framework-bundle"]`,
+						Description: `Composer packages that signal this framework, e.g. ["symfony/framework-bundle"].`,
 					},
 					"env_file": {
 						Type:        "string",
-						Description: `Primary env file path relative to project root (default: ".env")`,
+						Description: `Primary env file (default ".env").`,
 					},
 					"env_format": {
 						Type:        "string",
-						Description: `Env file format: "dotenv" (default) or "php-const" (for wp-config.php style)`,
+						Description: `Env format: "dotenv" (default) or "php-const".`,
 					},
 					"env_fallback_file": {
 						Type:        "string",
-						Description: `Fallback env file if primary doesn't exist (e.g. "wp-config.php")`,
+						Description: `Fallback env file (e.g. "wp-config.php").`,
 					},
 					"env_fallback_format": {
 						Type:        "string",
-						Description: `Format for fallback env file`,
+						Description: "Format for fallback env file.",
 					},
 					"workers": {
 						Type:        "object",
-						Description: `Map of worker name → {label, command, restart, check} definitions. "check" is optional — an object with "file" or "composer" field; the worker is only shown when the check passes. e.g. {"messenger": {"label": "Messenger", "command": "php bin/console messenger:consume async", "restart": "always", "check": {"composer": "symfony/messenger"}}}`,
+						Description: `Map of worker name → {label, command, restart, check?}. check: {file} or {composer}.`,
 					},
 					"setup": {
 						Type:        "array",
-						Description: `List of one-off setup commands shown in "lerd setup" wizard. Each element is an object with "label" (string), "command" (string), optional "default" (boolean, pre-selected in wizard), and optional "check" (object with "file" or "composer" field — command is only shown when the check passes). e.g. [{"label": "Load fixtures", "command": "php bin/console doctrine:fixtures:load", "check": {"composer": "doctrine/doctrine-fixtures-bundle"}}]`,
+						Description: `List of {label, command, default?, check?} shown in lerd setup.`,
 					},
 					"logs": {
 						Type:        "array",
-						Description: `List of log source definitions for the app log viewer. Each element is an object with "path" (glob relative to project root, e.g. "storage/logs/*.log") and optional "format" ("monolog" for Monolog format, "raw" for plain text; default: "raw"). e.g. [{"path": "storage/logs/*.log", "format": "monolog"}]`,
+						Description: `List of {path, format?} for the log viewer. format: "monolog" or "raw".`,
 					},
 				},
 				Required: []string{"name"},
@@ -1224,17 +1085,17 @@ func toolList() []mcpTool {
 		},
 		mcpTool{
 			Name:        "framework_remove",
-			Description: "Delete a framework definition (user-defined or store-installed) by name. For laravel, removes only custom worker additions (built-in definition remains). Use version to remove a specific version, or omit to remove all.",
+			Description: "Delete a framework definition. For laravel, removes only custom additions. Omit version to remove all.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"name": {
 						Type:        "string",
-						Description: "Framework name to remove (e.g. 'symfony')",
+						Description: "Framework name (e.g. symfony).",
 					},
 					"version": {
 						Type:        "string",
-						Description: "Specific version to remove (e.g. '7'). Omit to remove all versions.",
+						Description: "Version to remove (e.g. 7). Omit for all.",
 					},
 				},
 				Required: []string{"name"},
@@ -1242,13 +1103,13 @@ func toolList() []mcpTool {
 		},
 		mcpTool{
 			Name:        "framework_search",
-			Description: "Search the community framework store for available definitions. Returns matching frameworks with their available versions.",
+			Description: "Search the community framework store.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"query": {
 						Type:        "string",
-						Description: "Search query (matches framework name or label, case-insensitive)",
+						Description: "Query (matches name or label, case-insensitive).",
 					},
 				},
 				Required: []string{"query"},
@@ -1256,17 +1117,17 @@ func toolList() []mcpTool {
 		},
 		mcpTool{
 			Name:        "framework_install",
-			Description: "Install a framework definition from the community store. If no version is specified, auto-detects from composer.lock or uses the latest available version.",
+			Description: "Install a framework from the community store. Auto-detects version from composer.lock if omitted.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"name": {
 						Type:        "string",
-						Description: "Framework name to install (e.g. symfony, wordpress)",
+						Description: "Framework name (e.g. symfony, wordpress).",
 					},
 					"version": {
 						Type:        "string",
-						Description: "Framework major version (e.g. 11, 7). Omit to auto-detect or use latest.",
+						Description: "Major version (e.g. 11, 7). Omit to auto-detect.",
 					},
 				},
 				Required: []string{"name"},
@@ -1274,21 +1135,21 @@ func toolList() []mcpTool {
 		},
 		mcpTool{
 			Name:        "project_new",
-			Description: "Scaffold a new PHP project using a framework's create command. For Laravel this runs `composer create-project --no-install --no-plugins --no-scripts laravel/laravel <path>`. Other frameworks must have a `create` field in their YAML definition. After creation, use site_link to register the site.",
+			Description: "Scaffold a new PHP project with a framework's create command (default laravel). Follow with site_link.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path": {
 						Type:        "string",
-						Description: "Absolute path for the new project directory (e.g. /home/user/code/myapp)",
+						Description: "New project directory path.",
 					},
 					"framework": {
 						Type:        "string",
-						Description: `Framework to use (default: "laravel"). Must have a 'create' field defined.`,
+						Description: `Framework (default "laravel"). Needs a 'create' field defined.`,
 					},
 					"args": {
 						Type:        "array",
-						Description: `Extra arguments to pass to the scaffold command, e.g. ["--no-interaction"]`,
+						Description: `Extra args for the scaffold command, e.g. ["--no-interaction"].`,
 					},
 				},
 				Required: []string{"path"},
@@ -1296,17 +1157,17 @@ func toolList() []mcpTool {
 		},
 		mcpTool{
 			Name:        "site_php",
-			Description: "Change the PHP version for a registered lerd site. Writes a .php-version file, updates the site registry, and regenerates the nginx vhost.",
+			Description: "Change a site's PHP version. Writes .php-version and regenerates the nginx vhost.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"site": {
 						Type:        "string",
-						Description: "Site name as shown by the sites tool",
+						Description: "Site name (from sites).",
 					},
 					"version": {
 						Type:        "string",
-						Description: "PHP version to use, e.g. \"8.4\", \"8.3\"",
+						Description: "PHP version (e.g. 8.4, 8.3).",
 					},
 				},
 				Required: []string{"site", "version"},
@@ -1314,104 +1175,39 @@ func toolList() []mcpTool {
 		},
 		mcpTool{
 			Name:        "site_node",
-			Description: "Change the Node.js version for a registered lerd site. Writes a .node-version file, installs the version via fnm if needed, and updates the site registry.",
+			Description: "Change a site's Node.js version. Writes .node-version; installs via fnm if needed.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"site": {
 						Type:        "string",
-						Description: "Site name as shown by the sites tool",
+						Description: "Site name (from sites).",
 					},
 					"version": {
 						Type:        "string",
-						Description: "Node.js version to use, e.g. \"22\", \"20\", \"lts\"",
+						Description: "Node.js version (e.g. 22, 20, lts).",
 					},
 				},
 				Required: []string{"site", "version"},
 			},
 		},
 		mcpTool{
-			Name:        "site_pause",
-			Description: "Pause a site: stop all its running workers and its custom container (if applicable), and replace its nginx vhost with a landing page. Auto-stops services no longer needed by any active site.",
+			Name:        "site_control",
+			Description: "Control a site's container: pause (stop workers + landing-page vhost), unpause (resume), restart (no rebuild), rebuild (rebuild image + restart; custom container only, PHP sites use php_ext).",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
+					"action": {
+						Type:        "string",
+						Description: "pause, unpause, restart, or rebuild.",
+						Enum:        []string{"pause", "unpause", "restart", "rebuild"},
+					},
 					"site": {
 						Type:        "string",
-						Description: "Site name as shown by the sites tool",
+						Description: "Site name (from sites).",
 					},
 				},
-				Required: []string{"site"},
-			},
-		},
-		mcpTool{
-			Name:        "site_unpause",
-			Description: "Resume a paused site: start its custom container (if applicable), restore its nginx vhost, restart any workers that were running when it was paused, and ensure required services are running.",
-			InputSchema: mcpSchema{
-				Type: "object",
-				Properties: map[string]mcpProp{
-					"site": {
-						Type:        "string",
-						Description: "Site name as shown by the sites tool",
-					},
-				},
-				Required: []string{"site"},
-			},
-		},
-		mcpTool{
-			Name:        "site_restart",
-			Description: "Restart the container for a site. For custom container sites this restarts the dedicated per-project container; for PHP sites it restarts the shared PHP-FPM container for that site's PHP version.",
-			InputSchema: mcpSchema{
-				Type: "object",
-				Properties: map[string]mcpProp{
-					"site": {
-						Type:        "string",
-						Description: "Site name as shown by the sites tool",
-					},
-				},
-				Required: []string{"site"},
-			},
-		},
-		mcpTool{
-			Name:        "site_rebuild",
-			Description: "Rebuild the custom container image from the Containerfile and restart the container. Use after changing the Containerfile. For PHP sites use php_ext_add/php_ext_remove instead.",
-			InputSchema: mcpSchema{
-				Type: "object",
-				Properties: map[string]mcpProp{
-					"site": {
-						Type:        "string",
-						Description: "Site name as shown by the sites tool",
-					},
-				},
-				Required: []string{"site"},
-			},
-		},
-		mcpTool{
-			Name:        "service_pin",
-			Description: "Pin a service so it is never auto-stopped, even when no sites reference it. Starts the service if it is not already running.",
-			InputSchema: mcpSchema{
-				Type: "object",
-				Properties: map[string]mcpProp{
-					"name": {
-						Type:        "string",
-						Description: "Service name to pin (built-in: mysql, redis, postgres, meilisearch, rustfs, mailpit — or any custom service name)",
-					},
-				},
-				Required: []string{"name"},
-			},
-		},
-		mcpTool{
-			Name:        "service_unpin",
-			Description: "Unpin a service so it can be auto-stopped when no active sites reference it.",
-			InputSchema: mcpSchema{
-				Type: "object",
-				Properties: map[string]mcpProp{
-					"name": {
-						Type:        "string",
-						Description: "Service name to unpin",
-					},
-				},
-				Required: []string{"name"},
+				Required: []string{"action", "site"},
 			},
 		},
 	)
@@ -1440,6 +1236,11 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		args = map[string]any{}
 	}
 
+	action := strArg(args, "action")
+	unknownAction := func(tool string) (any, *rpcError) {
+		return toolErr(fmt.Sprintf("unknown action %q for tool %q", action, tool)), nil
+	}
+
 	switch p.Name {
 	case "artisan":
 		return execArtisan(args)
@@ -1447,40 +1248,87 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execArtisan(args)
 	case "sites":
 		return execSites()
-	case "service_start":
-		return execServiceStart(args)
-	case "service_stop":
-		return execServiceStop(args)
-	case "queue_start":
-		return execQueueStart(args)
-	case "queue_stop":
-		return execQueueStop(args)
-	case "reverb_start":
-		return execReverbStart(args)
-	case "reverb_stop":
-		return execReverbStop(args)
-	case "horizon_start":
-		return execHorizonStart(args)
-	case "horizon_stop":
-		return execHorizonStop(args)
-	case "schedule_start":
-		return execScheduleStart(args)
-	case "schedule_stop":
-		return execScheduleStop(args)
-	case "stripe_listen":
-		return execStripeListen(args)
-	case "stripe_listen_stop":
-		return execStripeListenStop(args)
-	case "worker_start":
-		return execWorkerStart(args)
-	case "worker_stop":
-		return execWorkerStop(args)
+
+	case "service_control":
+		switch action {
+		case "start":
+			return execServiceStart(args)
+		case "stop":
+			return execServiceStop(args)
+		case "pin":
+			return execServicePin(args)
+		case "unpin":
+			return execServiceUnpin(args)
+		default:
+			return unknownAction("service_control")
+		}
+
+	case "queue":
+		switch action {
+		case "start":
+			return execQueueStart(args)
+		case "stop":
+			return execQueueStop(args)
+		default:
+			return unknownAction("queue")
+		}
+
+	case "reverb":
+		switch action {
+		case "start":
+			return execReverbStart(args)
+		case "stop":
+			return execReverbStop(args)
+		default:
+			return unknownAction("reverb")
+		}
+
+	case "horizon":
+		switch action {
+		case "start":
+			return execHorizonStart(args)
+		case "stop":
+			return execHorizonStop(args)
+		default:
+			return unknownAction("horizon")
+		}
+
+	case "schedule":
+		switch action {
+		case "start":
+			return execScheduleStart(args)
+		case "stop":
+			return execScheduleStop(args)
+		default:
+			return unknownAction("schedule")
+		}
+
+	case "stripe":
+		switch action {
+		case "start":
+			return execStripeListen(args)
+		case "stop":
+			return execStripeListenStop(args)
+		default:
+			return unknownAction("stripe")
+		}
+
+	case "worker":
+		switch action {
+		case "start":
+			return execWorkerStart(args)
+		case "stop":
+			return execWorkerStop(args)
+		default:
+			return unknownAction("worker")
+		}
 	case "worker_add":
 		return execWorkerAdd(args)
 	case "worker_remove":
 		return execWorkerRemove(args)
 	case "worker_list":
 		return execWorkerList(args)
+
 	case "logs":
 		return execLogs(args)
 	case "composer":
@@ -1489,10 +1337,17 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execVendorBins(args)
 	case "vendor_run":
 		return execVendorRun(args)
-	case "node_install":
-		return execNodeInstall(args)
-	case "node_uninstall":
-		return execNodeUninstall(args)
+
+	case "node":
+		switch action {
+		case "install":
+			return execNodeInstall(args)
+		case "uninstall":
+			return execNodeUninstall(args)
+		default:
+			return unknownAction("node")
+		}
+
 	case "runtime_versions":
 		return execRuntimeVersions()
 	case "status":
@@ -1525,20 +1380,39 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execSiteLink(args)
 	case "site_unlink":
 		return execSiteUnlink(args)
-	case "site_domain_add":
-		return execSiteDomainAdd(args)
-	case "site_domain_remove":
-		return execSiteDomainRemove(args)
-	case "secure":
-		return execSecure(args)
-	case "unsecure":
-		return execUnsecure(args)
-	case "xdebug_on":
-		return execXdebugToggle(args, true)
-	case "xdebug_off":
-		return execXdebugToggle(args, false)
-	case "xdebug_status":
-		return execXdebugStatus()
+
+	case "site_domain":
+		switch action {
+		case "add":
+			return execSiteDomainAdd(args)
+		case "remove":
+			return execSiteDomainRemove(args)
+		default:
+			return unknownAction("site_domain")
+		}
+
+	case "site_tls":
+		switch action {
+		case "enable":
+			return execSecure(args)
+		case "disable":
+			return execUnsecure(args)
+		default:
+			return unknownAction("site_tls")
+		}
+
+	case "xdebug":
+		switch action {
+		case "on":
+			return execXdebugToggle(args, true)
+		case "off":
+			return execXdebugToggle(args, false)
+		case "status":
+			return execXdebugStatus()
+		default:
+			return unknownAction("xdebug")
+		}
+
 	case "db_export":
 		return execDBExport(args)
 	case "framework_list":
@@ -1557,34 +1431,45 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execSitePHP(args)
 	case "site_node":
 		return execSiteNode(args)
-	case "site_pause":
-		return execSitePause(args)
-	case "site_unpause":
-		return execSiteUnpause(args)
-	case "site_restart":
-		return execSiteRestart(args)
-	case "site_rebuild":
-		return execSiteRebuild(args)
-	case "service_pin":
-		return execServicePin(args)
-	case "service_unpin":
-		return execServiceUnpin(args)
+
+	case "site_control":
+		switch action {
+		case "pause":
+			return execSitePause(args)
+		case "unpause":
+			return execSiteUnpause(args)
+		case "restart":
+			return execSiteRestart(args)
+		case "rebuild":
+			return execSiteRebuild(args)
+		default:
+			return unknownAction("site_control")
+		}
+
 	case "db_import":
 		return execDBImport(args)
 	case "db_create":
 		return execDBCreate(args)
 	case "php_list":
 		return execPHPList()
-	case "php_ext_list":
-		return execPHPExtList(args)
-	case "php_ext_add":
-		return execPHPExtAdd(args)
-	case "php_ext_remove":
-		return execPHPExtRemove(args)
+
+	case "php_ext":
+		switch action {
+		case "list":
+			return execPHPExtList(args)
+		case "add":
+			return execPHPExtAdd(args)
+		case "remove":
+			return execPHPExtRemove(args)
+		default:
+			return unknownAction("php_ext")
+		}
+
 	case "park":
 		return execPark(args)
 	case "unpark":
 		return execUnpark(args)
+
 	default:
 		return toolErr("unknown tool: " + p.Name), nil
 	}


### PR DESCRIPTION
## Summary

- Trim every MCP tool description and shared param description, pushing long-form guidance into the skill file rather than repeating it in each tool schema.
- Collapse 13 start/stop/pin/add/remove groups into action-dispatcher tools with an `action` enum. This is a **breaking** change to the MCP API.
- On `lerd update`, refresh per-project AI artefacts for every opted-in project so the skill/rules files stay aligned with the installed binary. Content-aware writes mean projects already current stay untouched (clean git status).

## Manifest size

Measured against the live MCP server (`lerd mcp` stdio):

| | tools | bytes | ~tokens |
|---|---:|---:|---:|
| Before (main at 02f2a99) | 60 | 30,432 | ~7,608 |
| After | 46 | 18,320 | ~4,580 |
| Saved | −14 | −12,112 | ~−3,028 (**−40%**) |

## Merged tool mapping

| New tool | Replaces | Action enum |
|---|---|---|
| `service_control` | `service_{start,stop,pin,unpin}` | start, stop, pin, unpin |
| `queue` | `queue_{start,stop}` | start, stop |
| `reverb` | `reverb_{start,stop}` | start, stop |
| `horizon` | `horizon_{start,stop}` | start, stop |
| `schedule` | `schedule_{start,stop}` | start, stop |
| `stripe` | `stripe_listen`, `stripe_listen_stop` | start, stop |
| `worker` | `worker_{start,stop}` | start, stop |
| `node` | `node_{install,uninstall}` | install, uninstall |
| `site_domain` | `site_domain_{add,remove}` | add, remove |
| `site_tls` | `secure`, `unsecure` | enable, disable |
| `xdebug` | `xdebug_{on,off,status}` | on, off, status |
| `site_control` | `site_{pause,unpause,restart,rebuild}` | pause, unpause, restart, rebuild |
| `php_ext` | `php_ext_{list,add,remove}` | list, add, remove |

Old names are removed entirely, no aliases. Anyone pinned to stale prompts will get a clear `unknown tool` error from the server. The skill, Cursor rules, and Junie guidelines embedded in the binary all reference the new names; `lerd update` re-emits them globally and across opted-in projects.

## Auto-refresh on `lerd update`

- Iterates registered sites (from `sites.yaml`) plus immediate subdirs of each parked directory (catches non-PHP projects that ran `mcp:inject` without being linked).
- Treats a project as opted-in iff at least one lerd-owned marker file exists: `.claude/skills/lerd/SKILL.md`, `.cursor/rules/lerd.mdc`, or the `<!-- lerd:begin -->` block in `.junie/guidelines.md`. Shared MCP config JSONs are not used as opt-in signals because they may contain unrelated servers.
- Rewrites via the same helper as `mcp:inject` (`WriteProjectAISkills`), so the two flows cannot drift.
- `writeIfChanged` skips the write when content matches, so unchanged projects keep their mtime and git status stays clean.