### PR TITLE
ci: skip docs deploy and brew tap upload on pre-release tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,6 +50,7 @@ jobs:
           path: docs/.vitepress/dist
 
   deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -142,7 +142,7 @@ brews:
     homepage: "https://github.com/geodro/lerd"
     description: "Local Laravel development environment for Linux and macOS"
     license: "MIT"
-    skip_upload: false
+    skip_upload: auto
     dependencies:
       - name: podman
     install: |


### PR DESCRIPTION
## Summary

- Docs workflow skips build/deploy when the tag ref contains a hyphen
  (beta, rc, alpha). Stable tags still deploy as before.
- Homebrew tap upload switches to `skip_upload: auto` so the `lerd.rb`
  formula is only overwritten on stable releases. GitHub Release
  tarballs still ship for every tag, so beta testers can still
  download.

Together these changes let pre-releases like `v1.18.0-beta.1` be
tagged without overwriting the production docs site or pushing
unreleased code to every `brew upgrade lerd` user.