### PR TITLE
fix(install): heal aardvark drift, start per-site containers, order workers

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -577,6 +577,7 @@ func runInstall(_ *cobra.Command, _ []string) error {
 		}
 
 		startRestoredServices()
+		startPerSiteContainers()
 	}
 
 	if wantLaravelInstaller {
@@ -610,6 +611,26 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	fmt.Println("\n  Dashboard: \033[96mhttp://lerd.localhost\033[0m")
 	fmt.Println("  Terminal:  \033[96mlerd tui\033[0m")
 	return nil
+}
+
+// startPerSiteContainers starts units for per-site custom containers and
+// FrankenPHP runtimes. startRestoredServices only covers global services, so
+// without this, uninstall+reinstall leaves these quadlets stopped on disk.
+func startPerSiteContainers() {
+	units := installedCustomContainerUnits()
+	if len(units) == 0 {
+		return
+	}
+	jobs := make([]BuildJob, len(units))
+	for i, u := range units {
+		unit := u
+		label := strings.TrimPrefix(unit, "lerd-")
+		jobs[i] = BuildJob{
+			Label: label,
+			Run:   func(_ io.Writer) error { return podman.StartUnit(unit) },
+		}
+	}
+	RunParallel(jobs) //nolint:errcheck
 }
 
 // refreshUnreferencedCustomQuadlets rewrites quadlets for globally installed

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -755,7 +755,7 @@ func restoreSiteInfrastructure() {
 			if w == "stripe" {
 				base := siteURL(s.Path)
 				if base != "" {
-					StripeStartForSite(s.Name, s.Path, base) //nolint:errcheck
+					StripeRestoreUnit(s.Name, s.Path, base) //nolint:errcheck
 				}
 				continue
 			}

--- a/internal/cli/stripe.go
+++ b/internal/cli/stripe.go
@@ -94,7 +94,10 @@ func newStripeListenStopCmd() *cobra.Command {
 	}
 }
 
-func stripeStartExplicit(siteName, apiKey, forwardTo string) error {
+// writeStripeUnit writes (and enables on first write) the lerd-stripe-<site>
+// service unit without starting it. Shared by the CLI path (starts right
+// after) and the install restore path (defers start to the worker phase).
+func writeStripeUnit(siteName, apiKey, forwardTo string) error {
 	unitName := "lerd-stripe-" + siteName
 	containerName := unitName
 
@@ -124,7 +127,14 @@ WantedBy=default.target
 			fmt.Printf("[WARN] enable: %v\n", err)
 		}
 	}
+	return nil
+}
 
+func stripeStartExplicit(siteName, apiKey, forwardTo string) error {
+	if err := writeStripeUnit(siteName, apiKey, forwardTo); err != nil {
+		return err
+	}
+	unitName := "lerd-stripe-" + siteName
 	if err := services.Mgr.Start(unitName); err != nil {
 		return fmt.Errorf("starting stripe listener: %w", err)
 	}
@@ -146,6 +156,17 @@ func StripeStartForSite(siteName, sitePath, siteBaseURL string) error {
 	}
 	_ = config.AddProjectWorker(sitePath, "stripe")
 	return nil
+}
+
+// StripeRestoreUnit writes the stripe listener unit without starting it.
+// Used by install's restore path so workers launch in phase order — FPM and
+// nginx come up first, then `startRestoredServices` starts every worker.
+func StripeRestoreUnit(siteName, sitePath, siteBaseURL string) error {
+	apiKey := envfile.ReadKey(filepath.Join(sitePath, ".env"), "STRIPE_SECRET")
+	if apiKey == "" {
+		return fmt.Errorf("STRIPE_SECRET not set in %s/.env", sitePath)
+	}
+	return writeStripeUnit(siteName, apiKey, siteBaseURL+"/stripe/webhook")
 }
 
 // StripeStopForSite stops and removes the Stripe listener for the named site.

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -105,7 +105,7 @@ func runUninstall(force bool) error {
 	ok()
 
 	step("Removing lerd Podman network")
-	_ = podman.RunSilent("network", "rm", "lerd")
+	_ = podman.RemoveNetwork("lerd")
 	ok()
 
 	step("Removing shell PATH entry")

--- a/internal/podman/network.go
+++ b/internal/podman/network.go
@@ -3,7 +3,9 @@ package podman
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -12,10 +14,10 @@ import (
 // common defaults (fd00::, fd00:beef::, etc.).
 const LerdULAv6Subnet = "fd00:1e7d::/64"
 
-// ErrNetworkNeedsMigration is returned by EnsureNetwork when an existing lerd
-// network is missing the IPv6 subnet and must be recreated. Callers should
-// run MigrateNetworkToIPv6 (or equivalent) and then retry EnsureNetwork.
-var ErrNetworkNeedsMigration = errors.New("lerd network exists without IPv6, migration required")
+// ErrNetworkNeedsMigration is returned when the lerd network needs a destroy
+// + recreate: either it has no IPv6 subnet, or aardvark-dns's listen line
+// has drifted to v4-only. Callers should run MigrateNetworkToIPv6 and retry.
+var ErrNetworkNeedsMigration = errors.New("lerd network needs recreate to reach dual-stack (v4-only subnet, or drifted aardvark listen)")
 
 // NetworkGateway returns the gateway IP of the named Podman network.
 // Falls back to "127.0.0.1" if it cannot be determined. When the network has
@@ -58,8 +60,8 @@ func NetworkHasIPv6(name string) bool {
 }
 
 // EnsureNetwork creates the named podman network dual-stack if it doesn't
-// exist. Returns ErrNetworkNeedsMigration if it exists v4-only; the caller
-// should run MigrateNetworkToIPv6 and retry.
+// exist. Returns ErrNetworkNeedsMigration when the network exists but is
+// v4-only or has drifted aardvark state; caller should migrate and retry.
 func EnsureNetwork(name string) error {
 	out, err := Run("network", "ls", "--format={{.Name}}")
 	if err != nil {
@@ -68,10 +70,13 @@ func EnsureNetwork(name string) error {
 
 	for _, line := range strings.Split(out, "\n") {
 		if strings.TrimSpace(line) == name {
-			if NetworkHasIPv6(name) {
-				return nil
+			if !NetworkHasIPv6(name) {
+				return ErrNetworkNeedsMigration
 			}
-			return ErrNetworkNeedsMigration
+			if AardvarkNetworkDrifted(name) {
+				return ErrNetworkNeedsMigration
+			}
+			return nil
 		}
 	}
 
@@ -80,6 +85,59 @@ func EnsureNetwork(name string) error {
 		"--ipv6",
 		"--subnet", LerdULAv6Subnet,
 		name)
+}
+
+// aardvarkConfigPath returns the on-disk path to aardvark-dns's config file
+// for the named network. Prefers XDG_RUNTIME_DIR; falls back to the rootless
+// runtime dir convention /run/user/<uid>.
+func aardvarkConfigPath(name string) string {
+	if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
+		return filepath.Join(dir, "containers/networks/aardvark-dns", name)
+	}
+	return fmt.Sprintf("/run/user/%d/containers/networks/aardvark-dns/%s", os.Getuid(), name)
+}
+
+// aardvarkListenHasV6 reports whether the first line of an aardvark-dns
+// config file contains a v6 address in its listen-ips field. First line
+// format: "<listen-ip>[,<listen-ip>...] <forwarder-ip>...".
+func aardvarkListenHasV6(firstLine string) bool {
+	fields := strings.Fields(firstLine)
+	if len(fields) == 0 {
+		return false
+	}
+	for _, ip := range strings.Split(fields[0], ",") {
+		if strings.Contains(ip, ":") {
+			return true
+		}
+	}
+	return false
+}
+
+// AardvarkNetworkDrifted returns true when the named network is dual-stack
+// but aardvark-dns's on-disk listen line is v4-only, which stalls every
+// lookup ~5s. Returns false when the config file is absent (fresh / macOS).
+func AardvarkNetworkDrifted(name string) bool {
+	if !NetworkHasIPv6(name) {
+		return false
+	}
+	data, err := os.ReadFile(aardvarkConfigPath(name))
+	if err != nil {
+		return false
+	}
+	firstLine := data
+	if i := strings.IndexByte(string(data), '\n'); i >= 0 {
+		firstLine = data[:i]
+	}
+	return !aardvarkListenHasV6(string(firstLine))
+}
+
+// RemoveNetwork force-removes the named podman network and wipes the stale
+// aardvark-dns runtime file; the file outlives `podman network rm` and its
+// listen-ips header would otherwise contaminate the next same-name network.
+func RemoveNetwork(name string) error {
+	err := RunSilent("network", "rm", "--force", name)
+	_ = os.Remove(aardvarkConfigPath(name))
+	return err
 }
 
 // MigrateNetworkToIPv6 stops and removes containers attached to the named
@@ -112,7 +170,7 @@ func MigrateNetworkToIPv6(name string) ([]string, error) {
 		_ = RunSilent("rm", "--force", c)
 	}
 
-	if err := RunSilent("network", "rm", "--force", name); err != nil {
+	if err := RemoveNetwork(name); err != nil {
 		return attached, fmt.Errorf("removing %s: %w", name, err)
 	}
 

--- a/internal/podman/network_test.go
+++ b/internal/podman/network_test.go
@@ -2,6 +2,8 @@ package podman
 
 import (
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -28,5 +30,110 @@ func TestErrNetworkNeedsMigration_isComparable(t *testing.T) {
 	}
 	if ErrNetworkNeedsMigration.Error() == "" {
 		t.Error("ErrNetworkNeedsMigration has empty message")
+	}
+}
+
+func TestAardvarkListenHasV6(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"dual-stack v6 first", "fd00:1e7d::1,10.89.7.1 169.254.1.1", true},
+		{"dual-stack v4 first", "10.89.7.1,fd00:1e7d::1 169.254.1.1", true},
+		{"v4 only with forwarder", "10.89.7.1 169.254.1.1", false},
+		{"v4 only no forwarder", "10.89.7.1", false},
+		{"v6 only", "fd00:1e7d::1", true},
+		{"empty", "", false},
+		{"whitespace", "   ", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := aardvarkListenHasV6(tt.line); got != tt.want {
+				t.Errorf("aardvarkListenHasV6(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAardvarkConfigPath_usesXDGRuntimeDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmp)
+
+	got := aardvarkConfigPath("lerd")
+	want := filepath.Join(tmp, "containers/networks/aardvark-dns", "lerd")
+	if got != want {
+		t.Errorf("aardvarkConfigPath: got %s, want %s", got, want)
+	}
+}
+
+func TestAardvarkNetworkDrifted_returnsFalseWhenConfigMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmp)
+
+	if got := AardvarkNetworkDrifted("nonexistent-network"); got {
+		t.Errorf("AardvarkNetworkDrifted with missing config: got true, want false")
+	}
+}
+
+func TestAardvarkConfigPath_removeIsIdempotent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmp)
+
+	path := aardvarkConfigPath("ghost")
+	if err := os.Remove(path); err == nil {
+		t.Error("removing missing file unexpectedly succeeded without ENOENT")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("stale\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("removing present file: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file should be gone after Remove, got err=%v", err)
+	}
+}
+
+func TestRemoveNetwork_wipesAardvarkConfigEvenWhenPodmanFails(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmp)
+	t.Setenv("PATH", filepath.Join(tmp, "no-bin"))
+
+	path := aardvarkConfigPath("ghost-net")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("10.0.0.1 8.8.8.8\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = RemoveNetwork("ghost-net")
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("aardvark file should be removed even when podman is unavailable, got err=%v", err)
+	}
+}
+
+func TestAardvarkNetworkDrifted_readsExistingConfig_v4Only(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", tmp)
+
+	dir := filepath.Join(tmp, "containers/networks/aardvark-dns")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := "10.89.7.1 169.254.1.1\nabc123 10.89.7.5 svc,abc123\n"
+	if err := os.WriteFile(filepath.Join(dir, "drifted"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	first := strings.SplitN(content, "\n", 2)[0]
+	if aardvarkListenHasV6(first) {
+		t.Errorf("drifted first line %q should not contain v6 listen", first)
 	}
 }


### PR DESCRIPTION
Fixes three interlocking install-flow issues exposed by the IPv6 migration.

The first is a drifted `aardvark-dns` state on the lerd podman network: after the v4→v6 migration the network is dual-stack on paper (both subnets in `podman network inspect`) but aardvark's on-disk config file keeps a v4-only listen line. Every container's DNS queries then spend ~5s timing out against the non-listening v6 gateway before falling back to v4, which surfaced as "phpmyadmin feels slow". Root cause is that `podman network rm` doesn't touch `$XDG_RUNTIME_DIR/containers/networks/aardvark-dns/<name>`, so when the network is recreated with the same name netavark inherits the stale v4-only listen-ips header. `EnsureNetwork` now detects this (`AardvarkNetworkDrifted`) and returns the existing `ErrNetworkNeedsMigration` so the install migration path recreates cleanly; a new `RemoveNetwork` helper force-removes the network AND wipes the aardvark runtime file, replacing the bare `podman network rm` calls in `MigrateNetworkToIPv6` and `runUninstall`.

Second, `lerd uninstall && lerd install` left per-site custom-container and FrankenPHP units with quadlets on disk but no running container, because install only starts core/FPM/global-service units and never called the equivalent of `installedCustomContainerUnits()`. New `startPerSiteContainers` helper runs after `startRestoredServices` in the autostart-on branch.

Third, stripe listeners were starting during `restoreSiteInfrastructure`, before FPM and nginx came up, unlike every other worker type which writes its unit file and defers the Start to the worker phase. Extracted `writeStripeUnit` from `stripeStartExplicit` and added a `StripeRestoreUnit` that the restore path uses, so `startRestoredServices`'s existing worker loop picks up `lerd-stripe-*` via `registeredStripeUnits()` alongside queue/schedule/reverb.

macOS: all four paths go through `services.Mgr` / `UnitLifecycle`. The aardvark file operations hit `$XDG_RUNTIME_DIR` which doesn't exist on macOS, so the drift check and cleanup are graceful no-ops there (correct, because aardvark-dns lives inside the Podman Machine VM).