### PR TITLE
fix(install,uninstall): refresh MCP skills on install, add teardown prompts

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -607,6 +607,9 @@ func runInstall(_ *cobra.Command, _ []string) error {
 	}
 	ok()
 
+	refreshGlobalMCPSkills()
+	refreshProjectMCPSkills()
+
 	fmt.Println("\nLerd installation complete!")
 	fmt.Println("\n  Dashboard: \033[96mhttp://lerd.localhost\033[0m")
 	fmt.Println("  Terminal:  \033[96mlerd tui\033[0m")

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -385,6 +385,181 @@ func mergeMCPServersJSON(path string, lerdEntry map[string]any) error {
 	return os.WriteFile(path, append(data, '\n'), 0644)
 }
 
+// removeMCPServerEntry drops the named server from a shared mcp.json file.
+// Returns (changed, err). Missing file or missing entry is a no-op. When the
+// resulting config is empty the file is removed entirely.
+func removeMCPServerEntry(path, name string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	cfg := map[string]any{}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return false, fmt.Errorf("parsing %s: %w", path, err)
+		}
+	}
+	servers, _ := cfg["mcpServers"].(map[string]any)
+	if _, exists := servers[name]; !exists {
+		return false, nil
+	}
+	delete(servers, name)
+	if len(servers) == 0 {
+		delete(cfg, "mcpServers")
+	} else {
+		cfg["mcpServers"] = servers
+	}
+	if len(cfg) == 0 {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return true, err
+		}
+		return true, nil
+	}
+	out, err := json.MarshalIndent(cfg, "", "    ")
+	if err != nil {
+		return false, err
+	}
+	return true, os.WriteFile(path, append(out, '\n'), 0644)
+}
+
+// stripJunieLerdSection removes the lerd-delimited block from a guidelines.md
+// file. Returns (changed, err). When the file is empty after the block is
+// stripped it is removed.
+func stripJunieLerdSection(path string) (bool, error) {
+	const begin = "<!-- lerd:begin -->"
+	const end = "<!-- lerd:end -->"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	s := string(data)
+	startIdx := strings.Index(s, begin)
+	if startIdx == -1 {
+		return false, nil
+	}
+	endIdx := strings.Index(s, end)
+	if endIdx == -1 {
+		s = s[:startIdx]
+	} else {
+		s = s[:startIdx] + s[endIdx+len(end):]
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return true, err
+		}
+		return true, nil
+	}
+	return true, os.WriteFile(path, []byte(s+"\n"), 0644)
+}
+
+// RemoveGlobalAISkills tears down every user-scope artefact written by the
+// Write/RunMCPEnableGlobal path: skill + rules files, shared mcp.json entries,
+// Claude Code user-scope MCP registration, and the Junie guidelines block.
+func RemoveGlobalAISkills(home string, verbose bool) error {
+	log := func(msg string) {
+		if verbose {
+			fmt.Println(msg)
+		}
+	}
+
+	if err := exec.Command("claude", "mcp", "remove", "--scope", "user", "lerd").Run(); err == nil {
+		log("  removed Claude Code user-scope MCP registration")
+	}
+
+	for _, rel := range []string{
+		filepath.Join(".claude", "skills", "lerd", "SKILL.md"),
+		filepath.Join(".cursor", "rules", "lerd.mdc"),
+	} {
+		full := filepath.Join(home, rel)
+		if err := os.Remove(full); err == nil {
+			log("  removed " + full)
+			_ = os.Remove(filepath.Dir(full))
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	for _, rel := range []string{
+		filepath.Join(".cursor", "mcp.json"),
+		filepath.Join(".ai", "mcp", "mcp.json"),
+		filepath.Join(".junie", "mcp", "mcp.json"),
+	} {
+		full := filepath.Join(home, rel)
+		changed, err := removeMCPServerEntry(full, "lerd")
+		if err != nil {
+			fmt.Printf("  warn: %s: %v\n", full, err)
+			continue
+		}
+		if changed {
+			log("  cleaned " + full)
+		}
+	}
+
+	guidelinesPath := filepath.Join(home, ".junie", "guidelines.md")
+	if changed, err := stripJunieLerdSection(guidelinesPath); err != nil {
+		return err
+	} else if changed {
+		log("  cleaned " + guidelinesPath)
+	}
+	return nil
+}
+
+// RemoveProjectAISkills removes every lerd-owned artefact under abs: skill +
+// rules files, MCP entries in the project's shared mcp.json files, and the
+// lerd section of .junie/guidelines.md. Opt-out counterpart of Write.
+func RemoveProjectAISkills(abs string, verbose bool) error {
+	log := func(msg string) {
+		if verbose {
+			fmt.Println(msg)
+		}
+	}
+
+	for _, rel := range []string{
+		filepath.Join(".claude", "skills", "lerd", "SKILL.md"),
+		filepath.Join(".cursor", "rules", "lerd.mdc"),
+	} {
+		full := filepath.Join(abs, rel)
+		if err := os.Remove(full); err == nil {
+			log("  removed " + full)
+			_ = os.Remove(filepath.Dir(full))
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	for _, rel := range []string{
+		".mcp.json",
+		filepath.Join(".cursor", "mcp.json"),
+		filepath.Join(".ai", "mcp", "mcp.json"),
+		filepath.Join(".junie", "mcp", "mcp.json"),
+	} {
+		full := filepath.Join(abs, rel)
+		changed, err := removeMCPServerEntry(full, "lerd")
+		if err != nil {
+			fmt.Printf("  warn: %s: %v\n", full, err)
+			continue
+		}
+		if changed {
+			log("  cleaned " + full)
+		}
+	}
+
+	guidelinesPath := filepath.Join(abs, ".junie", "guidelines.md")
+	if changed, err := stripJunieLerdSection(guidelinesPath); err != nil {
+		return err
+	} else if changed {
+		log("  cleaned " + guidelinesPath)
+	}
+	return nil
+}
+
 // bt is a backtick character for use inside raw string literals.
 const bt = "`"
 

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -295,3 +295,208 @@ func mtimeOrFail(t *testing.T, path string) time.Time {
 	}
 	return info.ModTime()
 }
+
+func TestRemoveMCPServerEntry_missingFileIsNoop(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.json")
+	changed, err := removeMCPServerEntry(path, "lerd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Errorf("missing file should not report changed=true")
+	}
+}
+
+func TestRemoveMCPServerEntry_missingEntryIsNoop(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	_ = os.WriteFile(path, []byte(`{"mcpServers":{"other":{"command":"x"}}}`), 0644)
+
+	changed, err := removeMCPServerEntry(path, "lerd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Errorf("missing entry should not report changed=true")
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), `"other"`) {
+		t.Errorf("other entry was lost: %s", data)
+	}
+}
+
+func TestRemoveMCPServerEntry_preservesOtherEntries(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	_ = os.WriteFile(path, []byte(`{"mcpServers":{"lerd":{"command":"lerd"},"other":{"command":"x"}}}`), 0644)
+
+	changed, err := removeMCPServerEntry(path, "lerd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	data, _ := os.ReadFile(path)
+	if strings.Contains(string(data), `"lerd"`) {
+		t.Errorf("lerd entry should be gone: %s", data)
+	}
+	if !strings.Contains(string(data), `"other"`) {
+		t.Errorf("other entry was dropped: %s", data)
+	}
+}
+
+func TestRemoveMCPServerEntry_deletesFileWhenEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	_ = os.WriteFile(path, []byte(`{"mcpServers":{"lerd":{"command":"lerd"}}}`), 0644)
+
+	changed, err := removeMCPServerEntry(path, "lerd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file should be removed when empty, got err=%v", err)
+	}
+}
+
+func TestStripJunieLerdSection_removesDelimitedBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "guidelines.md")
+	content := "# Project guidelines\n\nsomething custom\n\n<!-- lerd:begin -->\nlerd stuff\n<!-- lerd:end -->\n"
+	_ = os.WriteFile(path, []byte(content), 0644)
+
+	changed, err := stripJunieLerdSection(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	got, _ := os.ReadFile(path)
+	if strings.Contains(string(got), "lerd:begin") || strings.Contains(string(got), "lerd stuff") {
+		t.Errorf("lerd block should be gone:\n%s", got)
+	}
+	if !strings.Contains(string(got), "something custom") {
+		t.Errorf("user content was lost:\n%s", got)
+	}
+}
+
+func TestStripJunieLerdSection_deletesFileWhenOnlyLerdBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "guidelines.md")
+	content := "<!-- lerd:begin -->\nlerd stuff\n<!-- lerd:end -->\n"
+	_ = os.WriteFile(path, []byte(content), 0644)
+
+	changed, err := stripJunieLerdSection(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file should be removed when only lerd block present, got err=%v", err)
+	}
+}
+
+func TestStripJunieLerdSection_missingFileIsNoop(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "guidelines.md")
+	changed, err := stripJunieLerdSection(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Errorf("missing file should not report changed=true")
+	}
+}
+
+func TestRemoveGlobalAISkills_roundTripWithWrite(t *testing.T) {
+	home := t.TempDir()
+	if err := WriteGlobalAISkills(home, false); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := RemoveGlobalAISkills(home, false); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	for _, rel := range []string{
+		".claude/skills/lerd/SKILL.md",
+		".cursor/rules/lerd.mdc",
+		".junie/guidelines.md",
+	} {
+		if _, err := os.Stat(filepath.Join(home, rel)); !os.IsNotExist(err) {
+			t.Errorf("%s should be removed, err=%v", rel, err)
+		}
+	}
+}
+
+func TestRemoveProjectAISkills_roundTripWithWrite(t *testing.T) {
+	abs := t.TempDir()
+	if err := WriteProjectAISkills(abs, false); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if ProjectHasLerdSkills(abs) == false {
+		t.Fatal("precondition: write should have produced markers")
+	}
+	if err := RemoveProjectAISkills(abs, false); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if ProjectHasLerdSkills(abs) {
+		t.Errorf("ProjectHasLerdSkills should be false after remove")
+	}
+	for _, rel := range []string{
+		".claude/skills/lerd/SKILL.md",
+		".cursor/rules/lerd.mdc",
+		".mcp.json",
+		".cursor/mcp.json",
+		".ai/mcp/mcp.json",
+		".junie/mcp/mcp.json",
+		".junie/guidelines.md",
+	} {
+		if _, err := os.Stat(filepath.Join(abs, rel)); !os.IsNotExist(err) {
+			t.Errorf("%s should be removed, err=%v", rel, err)
+		}
+	}
+}
+
+func TestRemoveProjectAISkills_preservesUnrelatedMCPEntries(t *testing.T) {
+	abs := t.TempDir()
+	_ = os.WriteFile(filepath.Join(abs, ".mcp.json"),
+		[]byte(`{"mcpServers":{"lerd":{"command":"lerd"},"other":{"command":"x"}}}`), 0644)
+
+	if err := RemoveProjectAISkills(abs, false); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(abs, ".mcp.json"))
+	if err != nil {
+		t.Fatalf("file should be preserved when other entries remain: %v", err)
+	}
+	if strings.Contains(string(data), `"lerd"`) {
+		t.Errorf("lerd should be gone: %s", data)
+	}
+	if !strings.Contains(string(data), `"other"`) {
+		t.Errorf("other should be preserved: %s", data)
+	}
+}
+
+func TestIsLerdBuiltImage_matchers(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"lerd-php84-fpm:local", true},
+		{"lerd-php83-fpm:local", true},
+		{"lerd-custom-my-app:local", true},
+		{"lerd-dnsmasq:local", true},
+		{"docker.io/library/mysql:8.0", false},
+		{"docker.io/dunglas/frankenphp:php8.4-alpine", false},
+		{"lerd-nginx:alpine", false},
+		{"some-other:tag", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			if got := isLerdBuiltImage(tt.ref); got != tt.want {
+				t.Errorf("isLerdBuiltImage(%q) = %v, want %v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -4,9 +4,11 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
 	"github.com/geodro/lerd/internal/podman"
@@ -42,6 +44,9 @@ func runUninstall(force bool) error {
 	// Ask about data removal up front — the StepRunner puts stdin into raw
 	// mode and its reader goroutine would consume bytes meant for this prompt.
 	removeData := force || confirmRemoveData()
+	removeMCP := force || confirmRemoveMCPIntegration()
+	removeMkcertCA := force || confirmRemoveMkcertCA()
+	purgeImages := force || confirmPurgeLerdImages()
 
 	// DNS teardown runs outside the step runner because it may prompt for sudo.
 	fmt.Println("  --> Removing DNS configuration")
@@ -108,6 +113,35 @@ func runUninstall(force bool) error {
 	_ = podman.RemoveNetwork("lerd")
 	ok()
 
+	if purgeImages {
+		fmt.Println("  --> Purging lerd-built container images")
+		removeLerdImages()
+	}
+
+	if removeMkcertCA {
+		fmt.Println("  --> Uninstalling mkcert CA from system trust stores")
+		cmd := exec.Command(certs.MkcertPath(), "-uninstall")
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		_ = cmd.Run()
+	}
+
+	if removeMCP {
+		fmt.Println("  --> Removing MCP integration (global)")
+		if home, err := os.UserHomeDir(); err == nil {
+			_ = RemoveGlobalAISkills(home, true)
+		}
+		fmt.Println("  --> Removing MCP integration (registered sites)")
+		if reg, err := config.LoadSites(); err == nil {
+			for _, s := range reg.Sites {
+				if err := RemoveProjectAISkills(s.Path, false); err == nil {
+					fmt.Printf("    cleaned %s\n", s.Path)
+				}
+			}
+		}
+	}
+
 	step("Removing shell PATH entry")
 	removeShellEntry()
 	ok()
@@ -131,6 +165,59 @@ func runUninstall(force bool) error {
 
 	fmt.Println("\nLerd uninstalled.")
 	return nil
+}
+
+func confirmRemoveMCPIntegration() bool {
+	fmt.Print("  Remove MCP integration (global skills + per-site .mcp/.claude/.cursor/.junie files)? [y/N] ")
+	return readYes()
+}
+
+func confirmRemoveMkcertCA() bool {
+	fmt.Print("  Uninstall mkcert CA from system trust stores? [y/N] ")
+	return readYes()
+}
+
+func confirmPurgeLerdImages() bool {
+	fmt.Print("  Purge lerd-built container images (lerd-php*-fpm, lerd-custom-*, lerd-dnsmasq)? Databases and app files are unaffected. [y/N] ")
+	return readYes()
+}
+
+// removeLerdImages removes locally-built lerd images. Upstream pulls
+// (mysql/redis/postgres/etc.) are left alone since they're expensive to
+// re-pull and not lerd-owned.
+func removeLerdImages() {
+	out, err := exec.Command(podman.PodmanBin(), "images", "--format", "{{.Repository}}:{{.Tag}}").Output()
+	if err != nil {
+		fmt.Printf("    WARN: listing images: %v\n", err)
+		return
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !isLerdBuiltImage(line) {
+			continue
+		}
+		if err := exec.Command(podman.PodmanBin(), "image", "rm", "-f", line).Run(); err != nil {
+			fmt.Printf("    WARN: removing %s: %v\n", line, err)
+			continue
+		}
+		fmt.Printf("    removed %s\n", line)
+	}
+}
+
+// isLerdBuiltImage matches the locally-built tags lerd owns.
+func isLerdBuiltImage(ref string) bool {
+	switch {
+	case strings.HasPrefix(ref, "lerd-php") && strings.HasSuffix(ref, "-fpm:local"):
+		return true
+	case strings.HasPrefix(ref, "lerd-custom-") && strings.HasSuffix(ref, ":local"):
+		return true
+	case ref == "lerd-dnsmasq:local":
+		return true
+	}
+	return false
 }
 
 func confirmRemoveData() bool {


### PR DESCRIPTION
Two install-time/uninstall-time asymmetries surfaced while looking at the state of a machine after `lerd uninstall && lerd install`.

Install never wrote MCP skills. Those were only refreshed by `lerd update` (which calls `refreshGlobalMCPSkills` / `refreshProjectMCPSkills` at its tail). After a reinstall, `~/.claude/skills/lerd/SKILL.md`, `~/.cursor/rules/lerd.mdc`, `~/.junie/guidelines.md`, and each registered site's equivalent files stayed pinned to whatever version the binary was when `lerd update` last ran — which could be days or weeks stale relative to the currently-installed binary. The same two function calls now run at the end of `runInstall`, using the existing opt-in semantics (global refreshed only if Claude Code user-scope MCP is registered; per-project only for directories that already have lerd markers).

Uninstall was the mirror of that problem: it stopped and removed containers, the podman network, and the binary itself, but intentionally left user artefacts behind. That's the right default for config/data/site files, but there's a class of artefacts the user may legitimately want cleaned up — they're lerd-specific, easy to lose track of, and regenerate on next install. Three opt-in prompts added (all default no; `--force` implies yes to all for parity with the existing `removeData` prompt):

- "Remove MCP integration" — new `RemoveGlobalAISkills` + `RemoveProjectAISkills` run across every registered site. Drops Claude Code user-scope MCP registration, deletes `SKILL.md` / `lerd.mdc`, removes the `"lerd"` entry from shared `mcp.json` files while preserving other servers, and strips the `<!-- lerd:begin -->`…`<!-- lerd:end -->` block from `.junie/guidelines.md` while preserving surrounding user content.
- "Uninstall mkcert CA from system trust stores" — runs `mkcert -uninstall` so browsers and OS trust stores stop trusting the lerd CA that `install` originally added via `mkcert -install`.
- "Purge lerd-built container images" — removes `lerd-php*-fpm:local`, `lerd-custom-*:local`, and `lerd-dnsmasq:local`. Upstream pulled images (mysql/redis/postgres/meilisearch/rustfs/mailpit/frankenphp/stripe-cli/…) are deliberately left alone because they're expensive to re-pull and user data lives in host bind mounts under `~/.local/share/lerd/data/`, not inside the images.

New shared helpers (`removeMCPServerEntry`, `stripJunieLerdSection`, `isLerdBuiltImage`) are pure enough to test without podman or a real filesystem. Round-trip tests confirm `Write`/`Remove` symmetry for both global and project scopes, and that preserving unrelated MCP servers + user content in guidelines.md works correctly. On macOS everything routes through the same `services.Mgr` / filesystem paths; `mkcert -uninstall` and `claude mcp remove` are platform-agnostic CLIs.