### PR TITLE
fix(bootstrap): make project_new + env_setup reach a working site without agent hand-holding

### DIFF
--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -198,26 +198,31 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	// hasn't yet picked a DB service for this project, offer to swap sqlite for
 	// a lerd-managed mysql/postgres. Skipped for frameworks with explicit env
 	// service rules (e.g. wordpress, symfony) — they don't use DB_CONNECTION.
-	// "Keep SQLite" is persisted by adding "sqlite" to the project's services
-	// list so we don't re-ask on every subsequent `lerd env` run.
-	if len(fw.Env.Services) == 0 && isInteractive() &&
+	// Non-interactive callers (MCP, scripts) fall through to sqlite by default
+	// so they don't hit a 500 from the missing .sqlite file; the user can
+	// still switch later with `lerd db set mysql` or the db_set MCP tool.
+	if len(fw.Env.Services) == 0 &&
 		!lerdYAMLServices["mysql"] && !lerdYAMLServices["postgres"] && !lerdYAMLServices["sqlite"] &&
 		strings.EqualFold(strings.TrimSpace(envMap["DB_CONNECTION"]), "sqlite") {
 
 		dbChoice := "sqlite"
-		dbForm := huh.NewForm(huh.NewGroup(
-			huh.NewSelect[string]().
-				Title("Database").
-				Description(envRelPath+" uses SQLite. Use a lerd-managed database service instead?").
-				Options(
-					huh.NewOption("Keep SQLite", "sqlite"),
-					huh.NewOption("MySQL (lerd-mysql)", "mysql"),
-					huh.NewOption("PostgreSQL (lerd-postgres)", "postgres"),
-				).
-				Value(&dbChoice),
-		)).WithTheme(huh.ThemeCatppuccin())
-		if err := dbForm.Run(); err != nil {
-			return fmt.Errorf("database prompt: %w", err)
+		if isInteractive() {
+			dbForm := huh.NewForm(huh.NewGroup(
+				huh.NewSelect[string]().
+					Title("Database").
+					Description(envRelPath+" uses SQLite. Use a lerd-managed database service instead?").
+					Options(
+						huh.NewOption("Keep SQLite", "sqlite"),
+						huh.NewOption("MySQL (lerd-mysql)", "mysql"),
+						huh.NewOption("PostgreSQL (lerd-postgres)", "postgres"),
+					).
+					Value(&dbChoice),
+			)).WithTheme(huh.ThemeCatppuccin())
+			if err := dbForm.Run(); err != nil {
+				return fmt.Errorf("database prompt: %w", err)
+			}
+		} else {
+			fmt.Println("  Defaulting to SQLite (non-interactive). Run `lerd db set <mysql|postgres>` or call db_set to switch.")
 		}
 
 		// Persist the choice to .lerd.yaml so future runs don't re-ask, and

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -1142,20 +1142,46 @@ Returns: ` + bt + `{"version": "...", "checks": [{name, status, detail}], "failu
 
 Single-tool tasks are covered by the tool definitions above (e.g. ` + bt + `site_tls` + bt + ` enables HTTPS, ` + bt + `doctor` + bt + ` runs a full diagnostic, ` + bt + `logs` + bt + ` tails FPM/nginx). These flows only cover multi-step compositions where ordering or non-obvious glue matters.
 
-**New Laravel project from scratch:**
+**Bootstrap a new project from scratch** (any framework lerd knows, e.g. laravel, symfony):
 ` + "```" + `
-composer(args: ["create-project", "laravel/laravel", "."])
-site_link()           // registers the cwd as a lerd site
-env_setup()           // configures .env, starts services, creates DB, generates APP_KEY
-artisan(args: ["migrate"])
+project_new(path: "/abs/path/myapp", framework: "laravel")
+// project_new now runs composer install after scaffold, so vendor/ is ready
+site_link(path: "/abs/path/myapp")
+env_setup(path: "/abs/path/myapp")    // configures .env, starts services, creates/touches DB
+// Run migrations with the framework's own tool:
+artisan(args: ["migrate"])            // Laravel
+// console(args: ["doctrine:migrations:migrate"])  // Symfony
+// (skip for frameworks that don't use migrations)
+site_tls(action: "enable", site: "myapp")   // optional HTTPS
 ` + "```" + `
 
-**Cloned project setup:**
+**Set up a cloned project** (framework-agnostic):
 ` + "```" + `
-site_link()
-env_setup()                          // auto-configures .env, starts services, creates DB
+site_link()                           // registers cwd as a lerd site
+composer(args: ["install"])           // BEFORE env_setup — APP_KEY generation needs vendor/
+env_setup()                           // fills .env, starts services, creates/touches DB, APP_KEY
+// Run migrations with the framework's tool:
+artisan(args: ["migrate", "--seed"])  // Laravel
+// console(args: ["doctrine:migrations:migrate"])  // Symfony
+// vendor_run(bin: "<migrator>", ...) // any other project that needs migrations
+` + "```" + `
+
+**Debugging a 500 on a lerd site** (ordered, stop at the first signal):
+` + "```" + `
+logs()                                 // current site's FPM + recent errors
+logs(target: "nginx")                  // if FPM logs are clean
+env_check()                            // missing .env keys vs .env.example
+which()                                // confirm PHP version, docroot, vhost
+// If the error mentions vendor/, autoload, or class-not-found:
 composer(args: ["install"])
-artisan(args: ["migrate", "--seed"])
+// If the error mentions APP_KEY:
+artisan(args: ["key:generate"])        // or framework's equivalent
+// If the error mentions the database file / connection:
+//   sqlite: env_setup() now auto-creates database/database.sqlite
+//   mysql/postgres: service_control(action: "start", name: "<service>")
+artisan(args: ["migrate"])             // run pending migrations (or framework equivalent)
+status()                               // DNS / nginx / FPM container health at a glance
+doctor()                               // full diagnostic if nothing above explains it
 ` + "```" + `
 
 **Install a package that needs publish + migration:**

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -506,7 +506,10 @@ func TestIsLerdBuiltImage_matchers(t *testing.T) {
 // and globally; drift upward gets expensive fast. Raise the ceiling only
 // when adding content that justifies the bytes.
 func TestClaudeSkillContent_underSizeCeiling(t *testing.T) {
-	const ceiling = 41000
+	// Raised from 41000 → 42000 to fit the bootstrap / clone / debug
+	// workflows added so agents can stand up a site end-to-end without
+	// trial-and-error. Any further growth needs a justified bump here.
+	const ceiling = 42000
 	if got := len(claudeSkillContent); got > ceiling {
 		t.Errorf("claudeSkillContent is %d bytes, ceiling is %d — trim before raising", got, ceiling)
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4126,8 +4126,45 @@ func execProjectNew(args map[string]any) (any, *rpcError) {
 	if err := cmd.Run(); err != nil {
 		return toolErr(fmt.Sprintf("scaffold command failed (%v):\n%s", err, stripANSI(out.String()))), nil
 	}
+
+	// Framework create commands use --no-install --no-plugins --no-scripts so
+	// the scaffolder doesn't race with lerd's post-link setup. Chase with
+	// `composer install` in the FPM container so project_new returns a
+	// ready-to-work vendor/ directory and any post-install scripts fire.
+	if composerErr := runComposerInstallIfNeeded(projectPath, &out); composerErr != nil {
+		return toolErr(fmt.Sprintf("scaffold succeeded but composer install failed: %v\n%s", composerErr, stripANSI(out.String()))), nil
+	}
+
 	return toolOK(fmt.Sprintf("Project created at %s\n\nNext steps:\n  site_link(path: %q)\n  env_setup(path: %q)\n\n%s",
 		projectPath, projectPath, projectPath, stripANSI(strings.TrimSpace(out.String())))), nil
+}
+
+// runComposerInstallIfNeeded runs `composer install` inside the FPM container
+// matching projectPath's PHP version when composer.json exists but vendor/
+// does not. Output is appended to the provided buffer.
+func runComposerInstallIfNeeded(projectPath string, out *bytes.Buffer) error {
+	if _, err := os.Stat(filepath.Join(projectPath, "composer.json")); err != nil {
+		return nil
+	}
+	if _, err := os.Stat(filepath.Join(projectPath, "vendor")); err == nil {
+		return nil
+	}
+
+	phpVersion, err := phpDet.DetectVersion(projectPath)
+	if err != nil || phpVersion == "" {
+		cfg, cfgErr := config.LoadGlobal()
+		if cfgErr != nil || cfg == nil {
+			return fmt.Errorf("could not determine PHP version: %w", err)
+		}
+		phpVersion = cfg.PHP.DefaultVersion
+	}
+	container := "lerd-php" + strings.ReplaceAll(phpVersion, ".", "") + "-fpm"
+
+	out.WriteString("\n\n--- composer install ---\n")
+	cmd := podman.Cmd("exec", "-w", projectPath, container, "composer", "install", "--no-interaction")
+	cmd.Stdout = out
+	cmd.Stderr = out
+	return cmd.Run()
 }
 
 func execSitePHP(args map[string]any) (any, *rpcError) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -174,5 +175,39 @@ func TestToolList_underSizeCeiling(t *testing.T) {
 	}
 	if len(got) > ceiling {
 		t.Errorf("toolList JSON is %d bytes, ceiling is %d — trim before raising", len(got), ceiling)
+	}
+}
+
+// TestRunComposerInstallIfNeeded_noComposerJsonIsNoop confirms the helper
+// silently returns when composer.json doesn't exist (non-PHP scaffolds,
+// accidental calls from other framework paths).
+func TestRunComposerInstallIfNeeded_noComposerJsonIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	if err := runComposerInstallIfNeeded(dir, &buf); err != nil {
+		t.Errorf("expected nil for missing composer.json, got %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty buffer, got %q", buf.String())
+	}
+}
+
+// TestRunComposerInstallIfNeeded_vendorExistsIsNoop confirms the helper
+// skips the install when vendor/ is already populated (re-running the tool
+// on an existing project should not re-download dependencies).
+func TestRunComposerInstallIfNeeded_vendorExistsIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "vendor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := runComposerInstallIfNeeded(dir, &buf); err != nil {
+		t.Errorf("expected nil when vendor/ exists, got %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty buffer when vendor/ exists, got %q", buf.String())
 	}
 }


### PR DESCRIPTION
Observed in a real Claude Code session: the agent scaffolded a Laravel project via `project_new`, called `site_link` + `env_setup`, and the site returned **500** on every request. It took three extra back-and-forth turns (`composer install` → `key:generate` → `touch database/database.sqlite` → `artisan migrate`) to get to "Laravel welcome page loads". Every step that failed is something lerd already knew about; the failures were all because the tools stopped short of the obvious next action.

## Root causes

**1. `project_new` left `vendor/` empty.** Framework `create` commands use `--no-install --no-plugins --no-scripts` (deliberate — keeps scaffold deterministic), so `project_new` returned "success" with no dependencies installed. Agents have no reason to know this.

**2. `env_setup` skipped the sqlite-file-creation block.** `env_setup` runs `lerd env`. For Laravel's default `DB_CONNECTION=sqlite`, the DB-swap prompt in `env.go` is gated behind `isInteractive()`. Via MCP there is no TTY, the prompt is skipped, and the sqlite-file-creation block below (itself gated behind `lerdYAMLServices["sqlite"]`) never fires. Result: no `database/database.sqlite`, Laravel 500s immediately.

**3. SKILL.md workflows didn't cover end-to-end bootstrap, cloned project setup, or 500-debugging,** so agents had to improvise.

## Fixes

- `internal/cli/env.go`: non-interactive callers (MCP, scripts) default the sqlite choice to "keep sqlite" instead of skipping entirely. The choice is persisted to `.lerd.yaml` and the existing sqlite-file-creation block runs, so `database/database.sqlite` is touched and the site can respond. Agents can still call `db_set` / `lerd db set` to switch to mysql/postgres afterwards — nothing locks in sqlite beyond the default.
- `internal/mcp/server.go`: `execProjectNew` now runs `composer install --no-interaction` in the appropriate FPM container when `composer.json` is present but `vendor/` is missing. New `runComposerInstallIfNeeded` helper is unit-tested against both no-composer.json and vendor-already-present cases so happy paths don't regress into re-pulling on re-runs.
- `internal/cli/mcp.go` (SKILL.md): replaced the two Laravel-specific workflows with three framework-agnostic end-to-end flows:
  - **Bootstrap a new project from scratch** — uses `project_new`, shows the `artisan` vs `console` fork for the migrate step, notes the new composer-install-after-scaffold and DB-auto-create behaviour.
  - **Set up a cloned project** — `composer install` **before** `env_setup` so APP_KEY generation has a valid `vendor/`, then migrate.
  - **Debugging a 500** — ordered checklist starting at `logs()`, then `env_check` / `which` / composer install / APP_KEY / migrate / service start / `doctor` as last resort.

Bumped `claudeSkillContent` ceiling 41000 → 42000 to fit the new workflows; any further growth still requires an explicit ceiling bump so accretion stays visible in diffs.

## Net effect

Agents running `project_new` → `site_link` → `env_setup` now get a working site in the same four tool calls that previously failed. The clone workflow is symmetric. The debug flow turns "I'm stuck on a 500" into a deterministic sequence that any model (including weaker local LLMs) can follow.