### PR TITLE
fix(watcher): publish sites event + auto-clean non-parked deleted sites

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -321,6 +321,10 @@ func newWatchCmd() *cobra.Command {
 						if err := nginx.Reload(); err != nil {
 							fmt.Printf("[WARN] nginx reload: %v\n", err)
 						}
+						// Tell the UI and anyone else subscribed that the
+						// sites list changed. Without this the browser keeps
+						// showing the deleted site until a manual refresh.
+						eventbus.Default.Publish(eventbus.KindSites)
 					}
 				}
 			}()
@@ -578,9 +582,13 @@ func cleanupWorktreeVhosts(site *config.Site) bool {
 	return changed
 }
 
-// removeStale removes registered sites under parked directories whose paths no
-// longer exist on disk. Returns true if any sites were removed.
-func removeStale(cfg *config.GlobalConfig) bool {
+// removeStale removes registered sites whose paths no longer exist on disk.
+// Covers both parked-dir projects (caught by the fast fsnotify path when it
+// fires) and manually site_link'd projects outside any park. Returns true if
+// any sites were removed so the caller can reload nginx and publish events.
+//
+//nolint:unparam // cfg reserved for future per-park gating
+func removeStale(_ *config.GlobalConfig) bool {
 	reg, err := config.LoadSites()
 	if err != nil {
 		return false
@@ -589,16 +597,6 @@ func removeStale(cfg *config.GlobalConfig) bool {
 	removed := false
 	for _, site := range reg.Sites {
 		if site.Ignored {
-			continue
-		}
-		underParked := false
-		for _, dir := range cfg.ParkedDirectories {
-			if filepath.Dir(site.Path) == dir {
-				underParked = true
-				break
-			}
-		}
-		if !underParked {
 			continue
 		}
 		if _, statErr := os.Stat(site.Path); os.IsNotExist(statErr) {

--- a/cmd/lerd/main_test.go
+++ b/cmd/lerd/main_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func isolateConfig(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, ".local", "share"))
+	for _, d := range []string{
+		config.ConfigDir(),
+		config.DataDir(),
+		config.NginxConfD(),
+	} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+}
+
+func TestRemoveStale_removesDeletedNonParkedSite(t *testing.T) {
+	isolateConfig(t)
+
+	liveDir := t.TempDir()
+	deletedDir := filepath.Join(t.TempDir(), "ghost")
+
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "live", Domains: []string{"live.test"}, Path: liveDir},
+		{Name: "ghost", Domains: []string{"ghost.test"}, Path: deletedDir},
+	}}
+	if err := config.SaveSites(reg); err != nil {
+		t.Fatal(err)
+	}
+
+	if !removeStale(&config.GlobalConfig{}) {
+		t.Fatal("expected removeStale to report a removal")
+	}
+
+	after, err := config.LoadSites()
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make([]string, 0, len(after.Sites))
+	for _, s := range after.Sites {
+		names = append(names, s.Name)
+	}
+	if len(names) != 1 || names[0] != "live" {
+		t.Errorf("expected only [live] after sweep, got %v", names)
+	}
+}
+
+func TestRemoveStale_keepsLiveSite(t *testing.T) {
+	isolateConfig(t)
+
+	liveDir := t.TempDir()
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "live", Domains: []string{"live.test"}, Path: liveDir},
+	}}
+	if err := config.SaveSites(reg); err != nil {
+		t.Fatal(err)
+	}
+
+	if removeStale(&config.GlobalConfig{}) {
+		t.Errorf("expected no removals when all site dirs exist")
+	}
+	after, _ := config.LoadSites()
+	if len(after.Sites) != 1 {
+		t.Errorf("expected live site preserved, got %d sites", len(after.Sites))
+	}
+}
+
+func TestRemoveStale_skipsIgnoredSites(t *testing.T) {
+	isolateConfig(t)
+
+	// Ignored site with a deleted path should NOT be touched — the user has
+	// intentionally parked it in the "ignored" state and the sweep shouldn't
+	// reap it out from under them.
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "archived", Domains: []string{"archived.test"}, Path: "/var/empty/does-not-exist", Ignored: true},
+	}}
+	if err := config.SaveSites(reg); err != nil {
+		t.Fatal(err)
+	}
+
+	if removeStale(&config.GlobalConfig{}) {
+		t.Errorf("removeStale should not touch ignored sites")
+	}
+	after, _ := config.LoadSites()
+	if len(after.Sites) != 1 {
+		t.Errorf("ignored site should be preserved, got %d sites", len(after.Sites))
+	}
+}


### PR DESCRIPTION
Two gaps observed after `rm -rf ~/Lerd/neil` on a registered site, reported as "neil still shows in the UI":

**1. The fast fsnotify `onRemoved` path didn't fire.** The park watcher's `onRemoved` callback at `cmd/lerd/main.go:483` would have published `eventbus.KindSites` immediately, but the journal shows no `Project deleted: neil` line — only the `Removing stale site: neil` from the 30s periodic sweep 30 seconds later. Likely a Go fsnotify race with inotify's `IN_DELETE_SELF` / `IN_IGNORED` ordering on `rm -rf`; hard to reproduce deterministically. The slow path caught the deletion and updated `sites.yaml` + nginx — but **never published `eventbus.KindSites`**, so the dashboard kept showing `neil` until a manual refresh.

**2. `removeStale` was gated on parked directories.** The check `if !underParked { continue }` meant manually `site_link`'d sites outside any park never got cleaned when their directory was deleted. They'd sit in `sites.yaml` indefinitely, nginx 502'ing on every request.

## Fixes

- **30s ticker now publishes `eventbus.KindSites`** when `removeStale` reports changes, mirroring the `onRemoved` fast path. UI gets notified within one sweep interval regardless of which cleanup code path fired.
- **`removeStale` drops the `underParked` gate.** Every registered non-`Ignored` site is checked; if its path doesn't exist on disk, it gets the same vhost-remove + `sites.yaml`-remove treatment. `Ignored` sites are still preserved — the user explicitly parked them in that state and the sweep must not reap them.

## Deliberately unchanged

Interval stays at 30 seconds. Not shortened per user preference ("no shorten of periodicy"). The eventbus push + wider sweep scope are what make the slow path feel responsive; tightening the tick frequency isn't necessary.

## Tests

New `cmd/lerd/main_test.go` covers three cases:
- deleted non-parked site **is removed** from sites.yaml;
- live site **is preserved**;
- `Ignored: true` site with a dead path **is NOT reaped**.

Isolated via `HOME` / `XDG_CONFIG_HOME` / `XDG_DATA_HOME` temp-dir overrides so the tests don't touch the user's real `sites.yaml`.