### PR TITLE
feat(mcp): end-to-end agent-driven site bootstrap (project_new → setup)

### DIFF
--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -87,7 +87,8 @@ Once the MCP server is connected, your AI assistant has access to:
 | `console` | Run the framework's console command (e.g. `php bin/console` for Symfony); shown for non-Laravel frameworks that define a `console` field |
 | `composer` | Run `composer` in the PHP-FPM container: install, require, dump-autoload, etc. |
 | `node` | Install or uninstall a Node.js version via fnm — `action`: `install` / `uninstall` (e.g. `"20"`, `"lts"`) |
-| `env_setup` | Configure `.env` for lerd: detects services, starts them, creates DB, sets APP_KEY and APP_URL |
+| `env_setup` | Configure `.env` for lerd: detects services, starts them, creates DB (sqlite auto-created when `DB_CONNECTION=sqlite`), sets APP_KEY and APP_URL. Always follow with `setup` to run migrations. |
+| `setup` | Run the framework's post-install bootstrap steps (Laravel: `storage:link` + `migrate`; Symfony: `doctrine:migrations:migrate` when `doctrine-migrations-bundle` is installed). Mandatory after `env_setup` on new or cloned projects; idempotent. |
 | `env_check` | Compare all `.env` files against `.env.example` and flag missing or extra keys (returns structured JSON) |
 | `site_link` | Register a directory as a lerd site; generates nginx vhost and `.test` domain |
 | `site_unlink` | Unregister a site and remove its nginx vhost (all domains) |
@@ -132,11 +133,13 @@ The `path` argument is omitted from most calls; the server resolves it from the 
 
 ```
 You: create a new Laravel project and get it running
-AI:  → composer(args: ["create-project", "laravel/laravel", "."])
-     → site_link()
-     → env_setup()
-       # detects MySQL + Redis, starts them, creates database, generates APP_KEY
-     → artisan(args: ["migrate"])
+AI:  → project_new(path: "/home/me/Code/myapp", framework: "laravel")
+       # scaffolds + runs composer install, returns with vendor/ populated
+     → site_link(path: "/home/me/Code/myapp")
+     → env_setup(path: "/home/me/Code/myapp")
+       # detects MySQL + Redis (or keeps sqlite), starts services, creates/touches DB, generates APP_KEY
+     → setup(path: "/home/me/Code/myapp")
+       # runs storage:link + migrate
      ✓  myapp -> myapp.test ready
 
 You: run migrations
@@ -167,10 +170,12 @@ AI:  → runtime_versions()
 
 You: set up the project I just cloned
 AI:  → site_link()
+     → composer(args: ["install"])
+       # runs BEFORE env_setup so APP_KEY generation has vendor/
      → env_setup()
        # detects MySQL + Redis, starts them, creates database, generates APP_KEY
-     → composer(args: ["install"])
-     → artisan(args: ["migrate", "--seed"])
+     → setup()
+       # framework migrations + storage:link (or doctrine:migrations:migrate for Symfony)
      ✓  whitewaters -> whitewaters.test ready
 
 You: enable xdebug so I can step through a failing job

--- a/docs/getting-started/laravel.md
+++ b/docs/getting-started/laravel.md
@@ -7,7 +7,7 @@ You've already run `lerd install` once on this machine. If not, see [Installatio
 :::
 
 ::: tip Drive it from your AI assistant
-Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Junie, Windsurf) can call every command below as an MCP tool: `project_new`, `site_link`, `env_setup`, `db_create`, `secure`, `worker_start`, etc. See [AI Integration](../features/mcp.md).
+Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Junie, Windsurf) can call every command below as an MCP tool: `project_new`, `site_link`, `env_setup`, `setup`, `db_create`, `site_tls`, `worker`, etc. See [AI Integration](../features/mcp.md).
 :::
 
 ---

--- a/docs/getting-started/symfony.md
+++ b/docs/getting-started/symfony.md
@@ -7,7 +7,7 @@ You've already run `lerd install` once on this machine. If not, see [Installatio
 :::
 
 ::: tip Drive it from your AI assistant
-Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Junie, Windsurf) can call every command below as an MCP tool: `project_new`, `site_link`, `env_setup`, `db_create`, `secure`, `worker_start`, etc. See [AI Integration](../features/mcp.md).
+Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Junie, Windsurf) can call every command below as an MCP tool: `project_new`, `site_link`, `env_setup`, `setup`, `db_create`, `site_tls`, `worker`, etc. See [AI Integration](../features/mcp.md).
 :::
 
 ---

--- a/docs/getting-started/wordpress.md
+++ b/docs/getting-started/wordpress.md
@@ -7,7 +7,7 @@ You've already run `lerd install` once on this machine. If not, see [Installatio
 :::
 
 ::: tip Drive it from your AI assistant
-Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Junie, Windsurf) can call every command below as an MCP tool: `site_link`, `db_create`, `secure`, etc. See [AI Integration](../features/mcp.md).
+Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Junie, Windsurf) can call every command below as an MCP tool: `site_link`, `env_setup`, `setup`, `db_create`, `site_tls`, etc. See [AI Integration](../features/mcp.md).
 :::
 
 ---

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -198,26 +198,31 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	// hasn't yet picked a DB service for this project, offer to swap sqlite for
 	// a lerd-managed mysql/postgres. Skipped for frameworks with explicit env
 	// service rules (e.g. wordpress, symfony) — they don't use DB_CONNECTION.
-	// "Keep SQLite" is persisted by adding "sqlite" to the project's services
-	// list so we don't re-ask on every subsequent `lerd env` run.
-	if len(fw.Env.Services) == 0 && isInteractive() &&
+	// Non-interactive callers (MCP, scripts) fall through to sqlite by default
+	// so they don't hit a 500 from the missing .sqlite file; the user can
+	// still switch later with `lerd db set mysql` or the db_set MCP tool.
+	if len(fw.Env.Services) == 0 &&
 		!lerdYAMLServices["mysql"] && !lerdYAMLServices["postgres"] && !lerdYAMLServices["sqlite"] &&
 		strings.EqualFold(strings.TrimSpace(envMap["DB_CONNECTION"]), "sqlite") {
 
 		dbChoice := "sqlite"
-		dbForm := huh.NewForm(huh.NewGroup(
-			huh.NewSelect[string]().
-				Title("Database").
-				Description(envRelPath+" uses SQLite. Use a lerd-managed database service instead?").
-				Options(
-					huh.NewOption("Keep SQLite", "sqlite"),
-					huh.NewOption("MySQL (lerd-mysql)", "mysql"),
-					huh.NewOption("PostgreSQL (lerd-postgres)", "postgres"),
-				).
-				Value(&dbChoice),
-		)).WithTheme(huh.ThemeCatppuccin())
-		if err := dbForm.Run(); err != nil {
-			return fmt.Errorf("database prompt: %w", err)
+		if isInteractive() {
+			dbForm := huh.NewForm(huh.NewGroup(
+				huh.NewSelect[string]().
+					Title("Database").
+					Description(envRelPath+" uses SQLite. Use a lerd-managed database service instead?").
+					Options(
+						huh.NewOption("Keep SQLite", "sqlite"),
+						huh.NewOption("MySQL (lerd-mysql)", "mysql"),
+						huh.NewOption("PostgreSQL (lerd-postgres)", "postgres"),
+					).
+					Value(&dbChoice),
+			)).WithTheme(huh.ThemeCatppuccin())
+			if err := dbForm.Run(); err != nil {
+				return fmt.Errorf("database prompt: %w", err)
+			}
+		} else {
+			fmt.Println("  Defaulting to SQLite (non-interactive). Run `lerd db set <mysql|postgres>` or call db_set to switch.")
 		}
 
 		// Persist the choice to .lerd.yaml so future runs don't re-ask, and

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -318,14 +318,17 @@ func IsMCPGloballyRegistered() bool {
 	return exec.Command("claude", "mcp", "get", "lerd").Run() == nil
 }
 
-// ensureClaudeMCPRegistered (re)registers lerd with Claude Code at user scope
-// using the remove-then-add idempotent pattern. Safe to call on every install
-// or update: if Claude Code isn't installed, the LookPath guard returns early.
+// ensureClaudeMCPRegistered adds lerd to Claude Code at user scope only when
+// `claude mcp get lerd` reports it missing. Add-only (no remove-then-add) so
+// a failing add can't leave the user unregistered. No-op when claude isn't
+// installed or lerd is already registered.
 func ensureClaudeMCPRegistered() {
 	if _, err := exec.LookPath("claude"); err != nil {
 		return
 	}
-	_ = exec.Command("claude", "mcp", "remove", "-s", "user", "lerd").Run()
+	if exec.Command("claude", "mcp", "get", "lerd").Run() == nil {
+		return
+	}
 	if err := exec.Command("claude", "mcp", "add", "-s", "user", "lerd", "--", "lerd", "mcp").Run(); err != nil {
 		fmt.Printf("  [WARN] could not register lerd with Claude Code: %v\n", err)
 		fmt.Println("  Run manually: claude mcp add -s user lerd -- lerd mcp")
@@ -1157,28 +1160,25 @@ Returns: ` + bt + `{"version": "...", "checks": [{name, status, detail}], "failu
 
 Single-tool tasks are covered by the tool definitions above (e.g. ` + bt + `site_tls` + bt + ` enables HTTPS, ` + bt + `doctor` + bt + ` runs a full diagnostic, ` + bt + `logs` + bt + ` tails FPM/nginx). These flows only cover multi-step compositions where ordering or non-obvious glue matters.
 
-**Bootstrap a new project from scratch** (any framework lerd knows, e.g. laravel, symfony):
+**Bootstrap a new project from scratch, end-to-end** — works for any lerd-known framework (laravel, symfony, etc.). **Run every step, in order. Do not stop until ` + bt + `setup` + bt + ` returns.**
 ` + "```" + `
 project_new(path: "/abs/path/myapp", framework: "laravel")
-// project_new now runs composer install after scaffold, so vendor/ is ready
+// project_new scaffolds AND runs composer install — vendor/ is populated on return
 site_link(path: "/abs/path/myapp")
-env_setup(path: "/abs/path/myapp")    // configures .env, starts services, creates/touches DB
-// Run migrations with the framework's own tool:
-artisan(args: ["migrate"])            // Laravel
-// console(args: ["doctrine:migrations:migrate"])  // Symfony
-// (skip for frameworks that don't use migrations)
-site_tls(action: "enable", site: "myapp")   // optional HTTPS
+env_setup(path: "/abs/path/myapp")    // .env, services, DB (sqlite auto-created), APP_KEY
+setup(path: "/abs/path/myapp")        // framework Default:true steps — migrations, storage:link, etc.
+// Optional:
+site_tls(action: "enable", site: "myapp")   // HTTPS via mkcert
 ` + "```" + `
 
-**Set up a cloned project** (framework-agnostic):
+**Set up a cloned project, end-to-end** — framework-agnostic. **Run every step, in order.**
 ` + "```" + `
 site_link()                           // registers cwd as a lerd site
 composer(args: ["install"])           // BEFORE env_setup — APP_KEY generation needs vendor/
-env_setup()                           // fills .env, starts services, creates/touches DB, APP_KEY
-// Run migrations with the framework's tool:
-artisan(args: ["migrate", "--seed"])  // Laravel
-// console(args: ["doctrine:migrations:migrate"])  // Symfony
-// vendor_run(bin: "<migrator>", ...) // any other project that needs migrations
+env_setup()                           // .env, services, DB (sqlite auto-created), APP_KEY
+setup()                               // framework migrations + other Default:true setup steps
+// Optional:
+// vendor_run(bin: "pest")            // run tests to confirm everything works
 ` + "```" + `
 
 **Debugging a 500 on a lerd site** (ordered, stop at the first signal):
@@ -1192,9 +1192,9 @@ composer(args: ["install"])
 // If the error mentions APP_KEY:
 artisan(args: ["key:generate"])        // or framework's equivalent
 // If the error mentions the database file / connection:
-//   sqlite: env_setup() now auto-creates database/database.sqlite
+//   sqlite: env_setup() auto-creates database/database.sqlite
 //   mysql/postgres: service_control(action: "start", name: "<service>")
-artisan(args: ["migrate"])             // run pending migrations (or framework equivalent)
+setup()                                // re-runs pending migrations + setup steps
 status()                               // DNS / nginx / FPM container health at a glance
 doctor()                               // full diagnostic if nothing above explains it
 ` + "```" + `

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -1142,20 +1142,46 @@ Returns: ` + bt + `{"version": "...", "checks": [{name, status, detail}], "failu
 
 Single-tool tasks are covered by the tool definitions above (e.g. ` + bt + `site_tls` + bt + ` enables HTTPS, ` + bt + `doctor` + bt + ` runs a full diagnostic, ` + bt + `logs` + bt + ` tails FPM/nginx). These flows only cover multi-step compositions where ordering or non-obvious glue matters.
 
-**New Laravel project from scratch:**
+**Bootstrap a new project from scratch** (any framework lerd knows, e.g. laravel, symfony):
 ` + "```" + `
-composer(args: ["create-project", "laravel/laravel", "."])
-site_link()           // registers the cwd as a lerd site
-env_setup()           // configures .env, starts services, creates DB, generates APP_KEY
-artisan(args: ["migrate"])
+project_new(path: "/abs/path/myapp", framework: "laravel")
+// project_new now runs composer install after scaffold, so vendor/ is ready
+site_link(path: "/abs/path/myapp")
+env_setup(path: "/abs/path/myapp")    // configures .env, starts services, creates/touches DB
+// Run migrations with the framework's own tool:
+artisan(args: ["migrate"])            // Laravel
+// console(args: ["doctrine:migrations:migrate"])  // Symfony
+// (skip for frameworks that don't use migrations)
+site_tls(action: "enable", site: "myapp")   // optional HTTPS
 ` + "```" + `
 
-**Cloned project setup:**
+**Set up a cloned project** (framework-agnostic):
 ` + "```" + `
-site_link()
-env_setup()                          // auto-configures .env, starts services, creates DB
+site_link()                           // registers cwd as a lerd site
+composer(args: ["install"])           // BEFORE env_setup — APP_KEY generation needs vendor/
+env_setup()                           // fills .env, starts services, creates/touches DB, APP_KEY
+// Run migrations with the framework's tool:
+artisan(args: ["migrate", "--seed"])  // Laravel
+// console(args: ["doctrine:migrations:migrate"])  // Symfony
+// vendor_run(bin: "<migrator>", ...) // any other project that needs migrations
+` + "```" + `
+
+**Debugging a 500 on a lerd site** (ordered, stop at the first signal):
+` + "```" + `
+logs()                                 // current site's FPM + recent errors
+logs(target: "nginx")                  // if FPM logs are clean
+env_check()                            // missing .env keys vs .env.example
+which()                                // confirm PHP version, docroot, vhost
+// If the error mentions vendor/, autoload, or class-not-found:
 composer(args: ["install"])
-artisan(args: ["migrate", "--seed"])
+// If the error mentions APP_KEY:
+artisan(args: ["key:generate"])        // or framework's equivalent
+// If the error mentions the database file / connection:
+//   sqlite: env_setup() now auto-creates database/database.sqlite
+//   mysql/postgres: service_control(action: "start", name: "<service>")
+artisan(args: ["migrate"])             // run pending migrations (or framework equivalent)
+status()                               // DNS / nginx / FPM container health at a glance
+doctor()                               // full diagnostic if nothing above explains it
 ` + "```" + `
 
 **Install a package that needs publish + migration:**

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -307,14 +307,29 @@ func WriteGlobalAISkills(home string, verbose bool) error {
 	return nil
 }
 
-// IsMCPGloballyRegistered reports whether lerd is already registered at user scope
-// in Claude Code. Used by the install command to skip the prompt if already set up.
+// IsMCPGloballyRegistered reports whether lerd is registered with Claude Code.
+// Uses `claude mcp get lerd` which returns exit 0 when the server is known and
+// exit 1 otherwise. The older `claude mcp list --scope user` flag form breaks
+// on newer Claude CLI releases.
 func IsMCPGloballyRegistered() bool {
-	out, err := exec.Command("claude", "mcp", "list", "--scope", "user").CombinedOutput()
-	if err != nil {
+	if _, err := exec.LookPath("claude"); err != nil {
 		return false
 	}
-	return strings.Contains(string(out), "lerd")
+	return exec.Command("claude", "mcp", "get", "lerd").Run() == nil
+}
+
+// ensureClaudeMCPRegistered (re)registers lerd with Claude Code at user scope
+// using the remove-then-add idempotent pattern. Safe to call on every install
+// or update: if Claude Code isn't installed, the LookPath guard returns early.
+func ensureClaudeMCPRegistered() {
+	if _, err := exec.LookPath("claude"); err != nil {
+		return
+	}
+	_ = exec.Command("claude", "mcp", "remove", "-s", "user", "lerd").Run()
+	if err := exec.Command("claude", "mcp", "add", "-s", "user", "lerd", "--", "lerd", "mcp").Run(); err != nil {
+		fmt.Printf("  [WARN] could not register lerd with Claude Code: %v\n", err)
+		fmt.Println("  Run manually: claude mcp add -s user lerd -- lerd mcp")
+	}
 }
 
 // mergeJunieGuidelines upserts the lerd section inside .junie/guidelines.md.

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -506,7 +506,10 @@ func TestIsLerdBuiltImage_matchers(t *testing.T) {
 // and globally; drift upward gets expensive fast. Raise the ceiling only
 // when adding content that justifies the bytes.
 func TestClaudeSkillContent_underSizeCeiling(t *testing.T) {
-	const ceiling = 41000
+	// Raised from 41000 → 42000 to fit the bootstrap / clone / debug
+	// workflows added so agents can stand up a site end-to-end without
+	// trial-and-error. Any further growth needs a justified bump here.
+	const ceiling = 42000
 	if got := len(claudeSkillContent); got > ceiling {
 		t.Errorf("claudeSkillContent is %d bytes, ceiling is %d — trim before raising", got, ceiling)
 	}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -206,7 +206,10 @@ func runUpdate(currentVersion string, beta bool) error {
 
 // refreshGlobalMCPSkills re-writes the user-scope skill, rules, and guidelines
 // files when lerd MCP is registered globally, so the AI's description of
-// available tools stays aligned with the newly installed binary.
+// available tools stays aligned with the newly installed binary. Also heals
+// the Claude Code MCP registration: an install after an uninstall (or a
+// Claude config migration) can lose the `claude mcp add` entry while the
+// marker files remain; re-run the idempotent add so lerd shows up again.
 func refreshGlobalMCPSkills() {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -218,6 +221,10 @@ func refreshGlobalMCPSkills() {
 	fmt.Println("\n==> Refreshing global MCP skills and guidelines")
 	if err := WriteGlobalAISkills(home, true); err != nil {
 		fmt.Fprintf(os.Stderr, "  warn: could not refresh global AI skills: %v\n", err)
+	}
+	if !IsMCPGloballyRegistered() {
+		fmt.Println("  Re-registering lerd with Claude Code (was missing)")
+		ensureClaudeMCPRegistered()
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -423,7 +423,7 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "env_setup",
-			Description: "Configure .env: start services, create DBs, APP_KEY, APP_URL. Run once after clone. For fresh Laravel with DB_CONNECTION=sqlite, call db_set first.",
+			Description: "Configure .env (services, DBs, APP_KEY, APP_URL). Call after site_link, then ALWAYS follow with setup to run migrations. For sqlite DB_CONNECTION, pick db_set first if you want mysql/postgres instead.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
@@ -433,7 +433,7 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "setup",
-			Description: "Run the framework's post-install bootstrap steps (migrations, storage:link, etc.). Call after env_setup on a fresh project. Idempotent.",
+			Description: "Run the framework's post-install steps (migrations, storage:link, etc.). MANDATORY after env_setup on new or cloned projects — otherwise migrations never run. Idempotent.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4126,8 +4126,45 @@ func execProjectNew(args map[string]any) (any, *rpcError) {
 	if err := cmd.Run(); err != nil {
 		return toolErr(fmt.Sprintf("scaffold command failed (%v):\n%s", err, stripANSI(out.String()))), nil
 	}
+
+	// Framework create commands use --no-install --no-plugins --no-scripts so
+	// the scaffolder doesn't race with lerd's post-link setup. Chase with
+	// `composer install` in the FPM container so project_new returns a
+	// ready-to-work vendor/ directory and any post-install scripts fire.
+	if composerErr := runComposerInstallIfNeeded(projectPath, &out); composerErr != nil {
+		return toolErr(fmt.Sprintf("scaffold succeeded but composer install failed: %v\n%s", composerErr, stripANSI(out.String()))), nil
+	}
+
 	return toolOK(fmt.Sprintf("Project created at %s\n\nNext steps:\n  site_link(path: %q)\n  env_setup(path: %q)\n\n%s",
 		projectPath, projectPath, projectPath, stripANSI(strings.TrimSpace(out.String())))), nil
+}
+
+// runComposerInstallIfNeeded runs `composer install` inside the FPM container
+// matching projectPath's PHP version when composer.json exists but vendor/
+// does not. Output is appended to the provided buffer.
+func runComposerInstallIfNeeded(projectPath string, out *bytes.Buffer) error {
+	if _, err := os.Stat(filepath.Join(projectPath, "composer.json")); err != nil {
+		return nil
+	}
+	if _, err := os.Stat(filepath.Join(projectPath, "vendor")); err == nil {
+		return nil
+	}
+
+	phpVersion, err := phpDet.DetectVersion(projectPath)
+	if err != nil || phpVersion == "" {
+		cfg, cfgErr := config.LoadGlobal()
+		if cfgErr != nil || cfg == nil {
+			return fmt.Errorf("could not determine PHP version: %w", err)
+		}
+		phpVersion = cfg.PHP.DefaultVersion
+	}
+	container := "lerd-php" + strings.ReplaceAll(phpVersion, ".", "") + "-fpm"
+
+	out.WriteString("\n\n--- composer install ---\n")
+	cmd := podman.Cmd("exec", "-w", projectPath, container, "composer", "install", "--no-interaction")
+	cmd.Stdout = out
+	cmd.Stderr = out
+	return cmd.Run()
 }
 
 func execSitePHP(args map[string]any) (any, *rpcError) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -432,6 +432,16 @@ func toolList() []mcpTool {
 			},
 		},
 		{
+			Name:        "setup",
+			Description: "Run the framework's post-install bootstrap steps (migrations, storage:link, etc.). Call after env_setup on a fresh project. Idempotent.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"path": {Type: "string", Description: "Project root. Defaults to cwd."},
+				},
+			},
+		},
+		{
 			Name:        "db_set",
 			Description: "Pick the project database. Persists to .lerd.yaml, rewrites DB_ keys in .env, starts service, creates DB + _testing. Call before env_setup on fresh clones.",
 			InputSchema: mcpSchema{
@@ -1142,6 +1152,8 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execFrameworkInstall(args)
 	case "project_new":
 		return execProjectNew(args)
+	case "setup":
+		return execSetup(args)
 	case "site_php":
 		return execSitePHP(args)
 	case "site_node":
@@ -4165,6 +4177,77 @@ func runComposerInstallIfNeeded(projectPath string, out *bytes.Buffer) error {
 	cmd.Stdout = out
 	cmd.Stderr = out
 	return cmd.Run()
+}
+
+// execSetup runs every Default: true entry in the site framework's Setup list
+// whose Check rule passes, mirroring what the `lerd setup` CLI does when the
+// user keeps the default selections. Commands run in the site's PHP-FPM
+// container via `podman exec`. A single step failure is reported but doesn't
+// abort the rest — these commands are idempotent by convention.
+func execSetup(args map[string]any) (any, *rpcError) {
+	projectPath := resolvedPath(args)
+	if projectPath == "" {
+		return toolErr("path is required — pass a path argument or open Claude in the project directory"), nil
+	}
+	site, err := config.FindSiteByPath(projectPath)
+	if err != nil || site == nil {
+		return toolErr("no site registered at " + projectPath + " — run site_link first"), nil
+	}
+	fwName := site.Framework
+	if fwName == "" {
+		fwName, _ = config.DetectFrameworkForDir(projectPath)
+	}
+	if fwName == "" {
+		return toolErr("no framework detected — nothing to set up"), nil
+	}
+	fw, ok := config.GetFramework(fwName)
+	if !ok {
+		return toolErr(fmt.Sprintf("framework %q is not defined", fwName)), nil
+	}
+
+	phpVersion, phpErr := phpDet.DetectVersion(projectPath)
+	if phpErr != nil || phpVersion == "" {
+		cfg, cfgErr := config.LoadGlobal()
+		if cfgErr != nil || cfg == nil {
+			return toolErr("could not determine PHP version"), nil
+		}
+		phpVersion = cfg.PHP.DefaultVersion
+	}
+	container := "lerd-php" + strings.ReplaceAll(phpVersion, ".", "") + "-fpm"
+
+	var out bytes.Buffer
+	ran, skipped, failed := 0, 0, 0
+	for _, step := range fw.Setup {
+		if !step.Default {
+			skipped++
+			continue
+		}
+		if step.Check != nil && !config.MatchesRule(projectPath, *step.Check) {
+			skipped++
+			continue
+		}
+		parts := strings.Fields(step.Command)
+		if len(parts) == 0 {
+			continue
+		}
+		fmt.Fprintf(&out, "\n--- %s ---\n", step.Label)
+		cmdArgs := append([]string{"exec", "-i", "-w", projectPath, container}, parts...)
+		cmd := podman.Cmd(cmdArgs...)
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(&out, "[WARN] %s failed: %v\n", step.Label, err)
+			failed++
+			continue
+		}
+		ran++
+	}
+
+	if ran == 0 && failed == 0 {
+		return toolOK(fmt.Sprintf("No default setup steps to run for %s.", fw.Label)), nil
+	}
+	summary := fmt.Sprintf("%s setup: %d ran, %d skipped, %d failed.", fw.Label, ran, skipped, failed)
+	return toolOK(summary + "\n" + stripANSI(strings.TrimSpace(out.String()))), nil
 }
 
 func execSitePHP(args map[string]any) (any, *rpcError) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -174,5 +175,39 @@ func TestToolList_underSizeCeiling(t *testing.T) {
 	}
 	if len(got) > ceiling {
 		t.Errorf("toolList JSON is %d bytes, ceiling is %d — trim before raising", len(got), ceiling)
+	}
+}
+
+// TestRunComposerInstallIfNeeded_noComposerJsonIsNoop confirms the helper
+// silently returns when composer.json doesn't exist (non-PHP scaffolds,
+// accidental calls from other framework paths).
+func TestRunComposerInstallIfNeeded_noComposerJsonIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	var buf bytes.Buffer
+	if err := runComposerInstallIfNeeded(dir, &buf); err != nil {
+		t.Errorf("expected nil for missing composer.json, got %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty buffer, got %q", buf.String())
+	}
+}
+
+// TestRunComposerInstallIfNeeded_vendorExistsIsNoop confirms the helper
+// skips the install when vendor/ is already populated (re-running the tool
+// on an existing project should not re-download dependencies).
+func TestRunComposerInstallIfNeeded_vendorExistsIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "vendor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := runComposerInstallIfNeeded(dir, &buf); err != nil {
+		t.Errorf("expected nil when vendor/ exists, got %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty buffer when vendor/ exists, got %q", buf.String())
 	}
 }


### PR DESCRIPTION
Consolidates four commits that together make the MCP-driven "scaffold and run a new site" flow work without the agent (or the user) shuffling intermediate steps. Observed problem: agents ran `project_new → site_link → env_setup` and stopped there, leaving the site with empty `vendor/`, no migrations, and a broken sqlite path.

## What it does

**`env_setup` auto-creates the sqlite database when running non-interactively.** Laravel's default `.env` has `DB_CONNECTION=sqlite`; the CLI's interactive prompt to swap it for MySQL/Postgres was gated on `isInteractive()`, so MCP calls fell through without persisting the sqlite choice or creating `database/database.sqlite`. Non-interactive callers now default to sqlite, persist it to `.lerd.yaml`, and the existing file-creation block runs.

**`project_new` chases `composer create-project --no-install` with `composer install`** inside the FPM container. The scaffold command is deliberately `--no-install --no-plugins --no-scripts` for deterministic output; the tool now fills in `vendor/` before returning so the reported success is actual success.

**New `setup` MCP tool** exposes the framework's `Default: true` `Setup` entries (Laravel: `storage:link` + `migrate`; Symfony: `doctrine:migrations:migrate` gated on the `doctrine-migrations-bundle` Check). Runs via `podman exec -i -w <path>` in the site's FPM container, idempotent, non-fatal per step. No prompts; agents get the same underlying capability as the interactive `lerd setup` CLI without the `huh` form.

**Claude Code registration self-heal.** `IsMCPGloballyRegistered` switched from the broken `claude mcp list --scope user` (rejected by newer Claude CLI) to `claude mcp get lerd`. `refreshGlobalMCPSkills` (called from both `lerd install` and `lerd update`) now calls a new `ensureClaudeMCPRegistered` helper when markers say the user opted in globally but the Claude config doesn't know about lerd. The helper is add-only (skips the remove-then-add dance) so a transient `add` failure can't leave you unregistered.

**SKILL.md workflows** replace the per-framework `artisan migrate` / `console doctrine:migrations:migrate` fork with a framework-agnostic four-step sequence:
- New project: `project_new → site_link → env_setup → setup`
- Cloned project: `site_link → composer install → env_setup → setup`
- Debug a 500: ordered checklist ending in `setup()` to run pending migrations, then `status()`, then `doctor()`.

**Tool descriptions** on `env_setup` and `setup` are worded imperatively ("ALWAYS follow with setup", "MANDATORY after env_setup") so weaker local models (qwen, llama, mistral) sequence the bootstrap correctly.

## Docs

`docs/features/mcp.md` adds a `setup` row to the tool table, updates the `env_setup` row, and rewrites the "create a new Laravel project" and "set up the project I just cloned" example interactions to the four-step sequence. `docs/getting-started/{laravel,symfony,wordpress}.md` mention `setup` in the AI-assistant tip.