### PR TITLE
release: v1.18.0-beta.1 — FrankenPHP, IPv6 dual-stack, setup MCP tool, install/uninstall polish

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,53 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.18.0-beta.1] — 2026-04-22
+
+### Added
+
+- **FrankenPHP runtime** (#229). Per-site `dunglas/frankenphp` container as an alternative to the shared PHP-FPM image. Laravel and Symfony adapters; `lerd runtime frankenphp` CLI and `site_runtime` MCP tool to switch; optional worker mode (Laravel Octane, Symfony's FrankenPHP adapter with `--watch`). Runtime badge shown in both the Web UI and TUI. Paused sites stop/start their per-site container alongside FPM.
+- **Dual-stack IPv4 + IPv6 networking** (#230). The lerd podman bridge is now created with both subnets (`fd00:1e7d::/64` for v6). Nginx vhosts listen on `[::]`, dnsmasq answers AAAA for `.test`, and every managed `PublishPort` gets paired with a `[::1]` bind. Existing v4-only networks auto-migrate on the next `lerd install`: containers stop, the network is recreated, previous DNS servers are restored, and containers restart. See [architecture](reference/architecture.md) and [troubleshooting](troubleshooting.md).
+- **`setup` MCP tool** (#240). Runs the framework's `Default: true` bootstrap commands (Laravel: `storage:link` + `migrate`; Symfony: `doctrine:migrations:migrate` when `doctrine-migrations-bundle` is installed). Agents call it after `env_setup` on new or cloned projects; idempotent, no prompts. The interactive `lerd setup` CLI is unchanged.
+- **Uninstall teardown prompts** (#235). `lerd uninstall` now prompts independently for:
+  - Remove MCP integration (global skills + per-site `.claude`/`.cursor`/`.junie`/`.mcp.json` entries, preserves other MCP servers in shared files).
+  - Uninstall mkcert CA from system trust stores.
+  - Purge lerd-built container images (`lerd-php*-fpm:local`, `lerd-custom-*:local`, `lerd-dnsmasq:local`; upstream pulls like mysql/redis are deliberately kept — data lives in host bind mounts, not in the images).
+  `--force` answers yes to all.
+- **`lerd install` refreshes MCP skills and heals Claude Code registration** (#235, #240). Global skill files (`~/.claude/skills/lerd/`, `~/.cursor/rules/lerd.mdc`, `~/.junie/guidelines.md`) and every opted-in site's per-project copies are re-written on install to match the new binary; previously this only ran on `lerd update`. If Claude Code's user-scope MCP config has lost the lerd entry, install also re-adds it via `claude mcp add` (add-only, no remove-then-add race).
+- **Stale-site auto-cleanup covers non-parked sites** (#239). The 30 second watcher sweep now removes any registered site whose directory has been deleted, not only those under `parked_directories`. Publishes a `sites` eventbus event so the dashboard reflects the removal without a manual refresh.
+
+### Changed
+
+- **BREAKING — slimmer MCP tool manifest** (#232). The `tools/list` response merged action pairs (`queue_start` + `queue_stop` → `queue(action: ...)`, `service_start` + `service_stop` → `service_control(action: ...)`, and similar) and trimmed long descriptions. AI sessions started against the old tool names must be restarted. The new names are reflected in the injected SKILL.md and in `docs/features/mcp.md`.
+- **`project_new` runs `composer install` after scaffolding** (#240). The `create-project --no-install` scaffold is chased by `composer install` inside the FPM container, so the returned project has a populated `vendor/` ready for `env_setup` + `setup`.
+- **`env_setup` auto-creates `database/database.sqlite` non-interactively** (#240). Laravel's default `DB_CONNECTION=sqlite` triggered an interactive prompt in `lerd env` that MCP/script callers silently skipped, leaving the sqlite file uncreated and the first request 500'ing. Non-interactive callers now default to sqlite, persist the choice to `.lerd.yaml`, and run the existing file-creation block. Call `db_set` to switch to mysql/postgres afterwards.
+- **Per-session MCP token cost reduced** (#236, #237). `tools/list` trimmed ~14% (20 KB → 17 KB), injected `SKILL.md` trimmed from 44 KB → 40 KB by collapsing redundant single-tool workflow recipes. Descriptions are preserved where weaker local LLMs rely on them (`site` fields, `path` defaulting, enum-valued descriptions).
+- **SKILL.md bootstrap workflows rewritten** (#240). Replaced the per-framework `artisan migrate` / `console doctrine:migrations:migrate` fork with a framework-agnostic sequence: new project = `project_new → site_link → env_setup → setup`, cloned project = `site_link → composer install → env_setup → setup`. Debug-500 flow calls `setup()` for pending migrations.
+- **Install flow starts per-site containers and stripe workers in the correct phase** (#234). `lerd install` now starts per-site custom containers and FrankenPHP runtimes after service containers, and stripe listeners fire in the worker phase instead of during `restoreSiteInfrastructure` (no more "stripe starts before FPM" out-of-order).
+
+### Fixed
+
+- **Aardvark-dns drift after dual-stack migration** (#234, #240). When a network is rm'd and recreated with the same name, netavark can preserve the old v4-only listen-ips header in aardvark's runtime config, stalling every container DNS lookup ~5 seconds while glibc waits for the non-listening v6 gateway to time out. `EnsureNetwork` now detects the drift (via `AardvarkNetworkDrifted`) and triggers a recreate; `MigrateNetworkToIPv6` and `lerd uninstall`'s network teardown both wipe `$XDG_RUNTIME_DIR/containers/networks/aardvark-dns/<name>` between `rm` and `create` so the condition can't re-occur.
+- **Custom container and FrankenPHP sites not started after `lerd install`** (#234). `install.go` now calls `startPerSiteContainers` after `startRestoredServices`, so `lerd-custom-<site>` and `lerd-fp-<site>` units come up alongside FPM and global services. Previously they sat enabled-but-stopped until the user ran `lerd start`.
+- **FrankenPHP quadlets not refreshed on upgrade migrations** (#234). The v4→v6 network migration rewrote service and custom-container quadlets but skipped FrankenPHP sites. `refreshUnreferencedCustomQuadlets` now rewrites `lerd-fp-<site>.container` too.
+- **FrankenPHP vhosts overwritten with FPM template on every install** (#234). The vhost regeneration loop only branched on `IsCustomContainer`, so FrankenPHP sites fell through to `GenerateVhost` and had their proxy template replaced. Added an `IsFrankenPHP` branch that uses `GenerateFrankenPHPVhost`.
+- **Stripe listeners started before FPM and nginx were up** (#234). `restoreSiteInfrastructure` called `StripeStartForSite` synchronously, unlike other workers which write their unit file and defer `Start` to the worker phase. New `writeStripeUnit` / `StripeRestoreUnit` split so the start fires in `startRestoredServices`'s worker phase, matching queue/schedule/reverb ordering.
+- **`lerd share` collapsed https asset URLs on LAN** (#231). HTTPS sites sharing on LAN had asset URLs stripped back to HTTP by the nginx rewrite; the collapse now only fires for http assets on https pages.
+
+### Docs
+
+- New troubleshooting entry for the aardvark-dns drift case (symptoms, cause, manual verification via the aardvark config file).
+- Uninstall instructions now cover the three new teardown prompts and `--force` semantics.
+- Lifecycle reference documents the stale-site auto-cleanup (fsnotify fast path + 30s sweep + eventbus refresh).
+- `docs/features/mcp.md` tool table adds `setup` and updates example interactions to the four-step bootstrap sequence.
+- Getting-started guides (laravel / symfony / wordpress) mention `setup` in the AI-assistant tip.
+
+### CI
+
+- Skip docs deploy and brew tap upload on pre-release tags (#233). The docs site and the Homebrew tap now track stable tags only; beta and rc tags still build binaries but don't publish.
+
+---
+
 ## [1.17.1] — 2026-04-20
 
 ### Fixed

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -91,9 +91,16 @@ wget -qO- https://raw.githubusercontent.com/geodro/lerd/main/install.sh | bash -
 lerd uninstall
 ```
 
-Stops all containers, disables and removes Quadlet units, removes the watcher service, removes the binary, and cleans up the `PATH` entry from your shell config. Prompts before deleting config and data directories.
+Stops all containers, disables and removes Quadlet units, removes the watcher service, removes the binary, tears down the `lerd` podman network (including aardvark-dns runtime state), and cleans up the `PATH` entry from your shell config.
 
-To skip all prompts:
+Four opt-in prompts before finishing:
+
+1. **Remove all config and data** — deletes `~/.config/lerd` and `~/.local/share/lerd` (takes your `sites.yaml`, bundled binaries, TLS certs, and all service data with it).
+2. **Remove MCP integration** — unregisters lerd from Claude Code, Cursor, Windsurf, and Junie at user scope, removes `~/.claude/skills/lerd/`, `~/.cursor/rules/lerd.mdc`, and strips the lerd block from `~/.junie/guidelines.md`. Also runs across every registered site to clean the same files per-project.
+3. **Uninstall mkcert CA** — runs `mkcert -uninstall` so browsers and OS trust stores stop trusting the lerd CA that `install` originally added.
+4. **Purge lerd-built container images** — removes `lerd-php*-fpm:local`, `lerd-custom-*:local`, and `lerd-dnsmasq:local`. Upstream pulled images (mysql/redis/postgres/etc.) are deliberately left alone; they're expensive to re-pull and your database/app data lives in host bind mounts, not inside the images, so nothing is lost by keeping them.
+
+To answer yes to every prompt without interaction:
 
 ```bash
 lerd uninstall --force

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -247,3 +247,23 @@ If the v6 subnet is missing, run `lerd install` once to migrate. To verify resol
 podman run --rm --network lerd alpine sh -c 'nslookup laravel.test; nslookup -type=AAAA laravel.test'
 ```
 :::
+
+::: details Every DNS lookup inside a lerd container stalls ~5 seconds
+Symptom: pages that hit the database or any container-to-container hostname feel slow, and `time dig <anything> @<container>` takes roughly five seconds before returning an answer. The network looks fine in `podman network inspect lerd` (both IPv4 and IPv6 subnets present), but aardvark-dns's on-disk config has the v6 gateway absent from its listen-ips line.
+
+Cause: `podman network rm` doesn't clean up `$XDG_RUNTIME_DIR/containers/networks/aardvark-dns/<name>` between rm and recreate, so a network that was originally v4-only can leave aardvark with a v4-only listen header even after the network is recreated dual-stack. The container's `/etc/resolv.conf` still lists the v6 gateway as the primary nameserver, queries to it time out (~5s), then glibc falls back to the v4 gateway.
+
+Lerd 1.18+ detects this drift on `lerd install` (aardvark listen line is v4-only despite the network being dual-stack) and self-heals by recreating the network with the stale aardvark state wiped. If you're on an earlier 1.18 build or the heal didn't fire, force it:
+
+```bash
+lerd install
+```
+
+Manual verification:
+
+```bash
+cat "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/containers/networks/aardvark-dns/lerd" | head -1
+# expect both gateways, e.g.: fd00:1e7d::1,10.89.7.1 169.254.1.1
+# if only 10.89.7.1 is present, the drift fix didn't run — re-run lerd install
+```
+:::

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -42,6 +42,15 @@ A live spinner shows the per-unit progress. If a single SSL vhost references a m
 If you ran `lerd uninstall` and then reinstalled, worker units and service quadlets are recreated by `lerd start` from each site's `.lerd.yaml`. Sites with a committed `.lerd.yaml` come back fully wired up. Sites without one need their workers restarted manually.
 :::
 
+::: info Deleted project directories are auto-cleaned
+`lerd-watcher` removes sites from `sites.yaml` whenever their project directory disappears on disk. Two paths do this:
+
+- **Instant** — fsnotify on every parked directory (configured via `lerd park`). When a direct subdirectory gets deleted, the corresponding site is unlinked within milliseconds.
+- **Periodic** — every 30 seconds the watcher sweeps the full site registry (parked and non-parked) and removes any site whose path no longer exists. The UI refreshes via the sites eventbus so the dashboard reflects the removal without a manual page reload.
+
+Both paths skip `Ignored: true` sites — those are explicitly parked by the user (e.g. via `lerd unpark` leaving a tombstone) and must not be reaped.
+:::
+
 ---
 
 ## `lerd stop`

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.17.1"
+	Version = "1.18.0-beta.1"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
First beta of the 1.18 line. Consolidates 11 merged PRs since v1.17.1 into a single beta tag. No stable users are pinged (the docs-site deploy and brew tap upload skip pre-release tags per #233, and `FetchLatestVersion` ignores GitHub's pre-release flag).

See [`CHANGELOG.md`](CHANGELOG.md#1180-beta1--2026-04-22) for the full entry. Short list:

**Added** — FrankenPHP per-site runtime (#229), dual-stack IPv4+IPv6 networking (#230), `setup` MCP tool (#240), uninstall teardown prompts for MCP / mkcert CA / lerd-built images (#235), install-time MCP skill refresh + Claude Code registration self-heal (#235, #240), stale-site cleanup for non-parked sites (#239).

**Changed** — BREAKING: slimmer MCP tool manifest with merged action pairs (#232); `project_new` now runs `composer install`; `env_setup` auto-creates `database/database.sqlite` non-interactively; per-session MCP token cost ~14% lower; SKILL.md bootstrap workflows rewritten to the four-step `project_new → site_link → env_setup → setup` sequence; install-flow orderings fixed so stripe/workers start after FPM.

**Fixed** — aardvark-dns drift self-heal after dual-stack migration, custom container + FrankenPHP start during install, FrankenPHP quadlet + vhost refresh on upgrade, stripe worker phase ordering, https asset URL collapse on LAN share.

**Docs** — new aardvark drift troubleshooting entry, uninstall prompts documented, stale-site cleanup documented in lifecycle, `setup` tool added to `features/mcp.md` + getting-started tips.

**CI** — pre-release tags skip docs deploy and brew tap upload (#233).