### PR TITLE
fix(network): pin bridge MTU to 1500 and respawn aardvark-dns on network recreate

### DIFF
--- a/internal/podman/network.go
+++ b/internal/podman/network.go
@@ -14,6 +14,11 @@ import (
 // common defaults (fd00::, fd00:beef::, etc.).
 const LerdULAv6Subnet = "fd00:1e7d::/64"
 
+// LerdNetworkMTU pins the lerd bridge to the universal safe MTU. Fedora's
+// rootless podman defaults eth0 to 65520 in the netns, which triggers
+// EMSGSIZE on UDP DNS writes and stalls every lookup ~5 seconds.
+const LerdNetworkMTU = "1500"
+
 // ErrNetworkNeedsMigration is returned when the lerd network needs a destroy
 // + recreate: either it has no IPv6 subnet, or aardvark-dns's listen line
 // has drifted to v4-only. Callers should run MigrateNetworkToIPv6 and retry.
@@ -84,6 +89,7 @@ func EnsureNetwork(name string) error {
 		"--driver", "bridge",
 		"--ipv6",
 		"--subnet", LerdULAv6Subnet,
+		"--opt", "mtu="+LerdNetworkMTU,
 		name)
 }
 
@@ -131,12 +137,13 @@ func AardvarkNetworkDrifted(name string) bool {
 	return !aardvarkListenHasV6(string(firstLine))
 }
 
-// RemoveNetwork force-removes the named podman network and wipes the stale
-// aardvark-dns runtime file; the file outlives `podman network rm` and its
-// listen-ips header would otherwise contaminate the next same-name network.
+// RemoveNetwork force-removes the podman network, wipes the aardvark-dns
+// runtime file, and kills aardvark-dns so it respawns fresh against the
+// new config when containers next join (fixes Fedora netavark's stale-inode).
 func RemoveNetwork(name string) error {
 	err := RunSilent("network", "rm", "--force", name)
 	_ = os.Remove(aardvarkConfigPath(name))
+	_ = exec.Command("pkill", "-f", "aardvark-dns").Run()
 	return err
 }
 
@@ -178,6 +185,7 @@ func MigrateNetworkToIPv6(name string) ([]string, error) {
 		"--driver", "bridge",
 		"--ipv6",
 		"--subnet", LerdULAv6Subnet,
+		"--opt", "mtu="+LerdNetworkMTU,
 		name); err != nil {
 		return attached, fmt.Errorf("recreating %s: %w", name, err)
 	}


### PR DESCRIPTION
Diagnosed on a Fedora 40 VM after `lerd update --beta` migrated the lerd podman network to dual-stack. Symptom: every phpmyadmin page took 5–10 seconds. Two separate rootless podman/netavark quirks combined:

**1. Container eth0 MTU was 65520 (jumbo).** Fedora's rootless podman defaults the netns interface MTU to pasta's huge value. glibc's resolver uses `IP_MTU_DISCOVER=DO` on its UDP socket and some kernel paths returned `EMSGSIZE` ("Message too large") on the `write()` of a trivially-sized DNS query. Containers fell back to TCP DNS, which worked but cost 5+ seconds per page. cachyos (my other VM) defaults to a saner MTU so the bug was invisible there.

**2. `RemoveNetwork` unlinked aardvark-dns's config file but didn't kill the running aardvark-dns process.** The daemon kept its file descriptor on the old inode. When containers joined the recreated network, netavark wrote a new config at the same path, but aardvark kept reading the stale inode. Half the migrated containers ended up missing from DNS — `lerd-mysql` returned `NXDOMAIN` even though the container was clearly running, making phpmyadmin time out on its connection attempt.

## Changes

- New `LerdNetworkMTU = "1500"` constant in `internal/podman/network.go`. Both `EnsureNetwork` and `MigrateNetworkToIPv6` now pass `--opt mtu=1500` to `podman network create`. 1500 is the universal bridge MTU; hosts that already worked (cachyos) are unaffected.
- `RemoveNetwork` now runs `pkill -f aardvark-dns` after unlinking the aardvark config file. Podman/netavark auto-respawns the daemon on the next container join, against the freshly-written config.

## Verified

On the Fedora 40 VM after applying the manual equivalent of these changes: curl to phpmyadmin dropped from 10 seconds to 220 ms, and aardvark-dns's registry contained all 10 lerd containers after the migration (before the kill, only 3 were registered).