### PR TITLE
fix(ui): label FrankenPHP log tab and stream from the right container

### DIFF
--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -352,6 +352,10 @@ func (e *EnrichedSite) enrichFPM() {
 		e.FPMRunning, _ = containerRunningFn("lerd-custom-" + e.Name)
 		return
 	}
+	if e.Runtime == "frankenphp" {
+		e.FPMRunning, _ = containerRunningFn("lerd-fp-" + e.Name)
+		return
+	}
 	if e.PHPVersion != "" {
 		short := strings.ReplaceAll(e.PHPVersion, ".", "")
 		e.FPMRunning, _ = containerRunningFn("lerd-php" + short + "-fpm")

--- a/internal/tui/detail_test.go
+++ b/internal/tui/detail_test.go
@@ -108,6 +108,28 @@ func TestLogTargetsForSite_IncludesFPMAndWorkers(t *testing.T) {
 	}
 }
 
+func TestLogTargetsForSite_FrankenPHP(t *testing.T) {
+	s := &siteinfo.EnrichedSite{
+		Name:       "beta",
+		Path:       "/tmp/missing-so-no-app-logs",
+		PHPVersion: "8.3",
+		Runtime:    "frankenphp",
+	}
+	targets := logTargetsForSite(s)
+	if len(targets) < 1 {
+		t.Fatalf("expected at least 1 target, got %d", len(targets))
+	}
+	if targets[0].Kind != kindPodman || targets[0].ID != "lerd-fp-beta" {
+		t.Errorf("first target should be frankenphp container, got %+v", targets[0])
+	}
+	if !strings.Contains(targets[0].Label, "frankenphp") {
+		t.Errorf("label should mention frankenphp, got %q", targets[0].Label)
+	}
+	if strings.Contains(targets[0].Label, "fpm 8.3") {
+		t.Errorf("label should not say 'fpm' for frankenphp runtime, got %q", targets[0].Label)
+	}
+}
+
 func TestLogTargetsForSite_CustomContainer(t *testing.T) {
 	s := &siteinfo.EnrichedSite{
 		Name:          "nodeapp",

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -714,6 +714,12 @@ func logTargetsForSite(s *siteinfo.EnrichedSite) []LogTarget {
 			ID:    podman.CustomContainerName(s.Name),
 			Label: s.Name + " · container",
 		})
+	} else if s.Runtime == "frankenphp" {
+		out = append(out, LogTarget{
+			Kind:  kindPodman,
+			ID:    podman.FrankenPHPContainerName(s.Name),
+			Label: s.Name + " · frankenphp " + s.PHPVersion,
+		})
 	} else if s.PHPVersion != "" {
 		out = append(out, LogTarget{
 			Kind:  kindPodman,

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -924,7 +924,7 @@
                   <template x-if="selectedSite && selectedSite.has_app_logs">
                     <button @click="setSiteLogsTab('app')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='app' ? 'border-orange-500 text-orange-600 dark:text-orange-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'">App Logs</button>
                   </template>
-                  <button @click="setSiteLogsTab('fpm')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='fpm' ? 'border-lerd-red text-lerd-red' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'" x-text="selectedSite.custom_container ? 'Container' : 'PHP-FPM'"></button>
+                  <button @click="setSiteLogsTab('fpm')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='fpm' ? 'border-lerd-red text-lerd-red' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'" x-text="selectedSite.custom_container ? 'Container' : (selectedSite.runtime === 'frankenphp' ? 'FrankenPHP' : 'PHP-FPM')"></button>
                   <template x-if="selectedSite && (selectedSite.queue_running || selectedSite.queue_failing)">
                     <button @click="setSiteLogsTab('queue')" class="pb-2 mr-5 text-xs font-medium transition-colors border-b-2" :class="siteLogsTab==='queue' ? 'border-amber-500 text-amber-600 dark:text-amber-400' : selectedSite.queue_failing ? 'border-transparent text-red-500' : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'" x-text="selectedSite.queue_failing ? 'Queue !' : 'Queue'"></button>
                   </template>
@@ -4067,6 +4067,7 @@ function lerdApp() {
 
     fpmContainer(site) {
       if (site.custom_container) return 'lerd-custom-' + site.name;
+      if (site.runtime === 'frankenphp') return 'lerd-fp-' + site.name;
       if (!site.php_version) return '';
       return 'lerd-php' + site.php_version.replace('.', '') + '-fpm';
     },


### PR DESCRIPTION
## Summary
- FrankenPHP sites previously showed a "PHP-FPM" log tab pointing at the shared `lerd-php*-fpm` container, which does not exist for per-site FrankenPHP deployments. The tab now reads "FrankenPHP" and streams from `lerd-fp-<site>`.
- `enrichFPM` now checks the frankenphp container when a site's runtime is `frankenphp`, so `fpm_running` reflects reality and the site detail panel actually opens the log stream.
- Same fix applied to the TUI log targets, plus a new test case covering the frankenphp branch.