### PR TITLE
feat(ui): show service version label and add restart action

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,15 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Service version label across every surface**. `lerd service list`, `lerd status`, the Web UI service list and detail header, and the TUI services pane now show the version alongside each built-in, preset, and custom service (e.g. `mysql v8.0`, `redis v7`, `postgres v16`, `meilisearch v1.7`). The label is derived from the installed quadlet's `Image=` tag via a new `podman.ServiceVersionLabel` helper that strips distro/variant suffixes (`-alpine`, `-slim`, `-3.5`), keeps leading `v`, and passes rolling tags (`latest`, `main`) through verbatim. Works for any service the user has overridden via `config.yaml` because the label reads the installed file, not the embedded template.
+- **Restart button in the Web UI service detail**. Built-in and custom services now expose a Restart action alongside Start/Stop, matching the site container row. Hits a new `POST /api/services/{name}/restart` handler which wraps `podman.RestartUnit` and clears the paused flag on success. Workers (queue, schedule, horizon, reverb, stripe, site-scoped custom workers) are intentionally excluded since their stop-only flow is unchanged.
+
+---
+
 ## [1.18.0-beta.3] — 2026-04-23
 
 ### Fixed

--- a/docs/usage/services.md
+++ b/docs/usage/services.md
@@ -16,6 +16,8 @@
 
 Available services: `mysql`, `redis`, `postgres`, `meilisearch`, `rustfs`, `mailpit`.
 
+`lerd service list` shows the version (derived from the image tag) alongside each service, e.g. `mysql v8.0`, `redis v7`, `postgres v16`, `meilisearch v1.7`. The Web UI, the TUI, and `lerd status` display the same label. Services pinned to rolling tags (`latest`, `main`) show the tag verbatim.
+
 ### Exposing extra ports on built-in services
 
 Built-in services publish a fixed set of ports by default. Use `lerd service expose` to bind additional host ports without recompiling or replacing the service:

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -244,15 +244,16 @@ func newServiceListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List all services and their status",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			fmt.Printf("%-20s %s\n", "Service", "Status")
-			fmt.Printf("%s\n", strings.Repeat("─", 32))
+			fmt.Printf("%-20s %-10s %s\n", "Service", "Version", "Status")
+			fmt.Printf("%s\n", strings.Repeat("─", 44))
 			for _, svc := range knownServices {
 				unit := "lerd-" + svc
 				status, err := podman.UnitStatus(unit)
 				if err != nil {
 					status = "unknown"
 				}
-				fmt.Printf("%-20s %s\n", svc, colorStatus(status))
+				ver := podman.ServiceVersionLabel(podman.InstalledImage(unit))
+				fmt.Printf("%-20s %-10s %s\n", svc, ver, colorStatus(status))
 				if status == "inactive" {
 					if reason := serviceInactiveReason(svc); reason != "" {
 						fmt.Printf("  %s\n", strings.TrimSpace(reason))
@@ -266,7 +267,8 @@ func newServiceListCmd() *cobra.Command {
 				if err != nil {
 					status = "unknown"
 				}
-				fmt.Printf("%-20s %s  [custom]\n", svc.Name, colorStatus(status))
+				ver := podman.ServiceVersionLabel(svc.Image)
+				fmt.Printf("%-20s %-10s %s  [custom]\n", svc.Name, ver, colorStatus(status))
 				if status == "inactive" {
 					if reason := serviceInactiveReason(svc.Name); reason != "" {
 						fmt.Printf("  %s\n", strings.TrimSpace(reason))

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -135,17 +135,21 @@ func runStatus(_ *cobra.Command, _ []string) error {
 		}
 		installedCount++
 		status, _ := services.Mgr.UnitStatus(unit)
+		label := svc
+		if ver := podman.ServiceVersionLabel(podman.InstalledImage(unit)); ver != "" {
+			label = svc + " " + ver
+		}
 		switch status {
 		case "active":
-			ok2(svc)
+			ok2(label)
 		case "inactive":
 			if config.CountSitesUsingService(svc) == 0 {
-				warn2(svc, "no sites using this service")
+				warn2(label, "no sites using this service")
 			} else {
-				warn2(svc, "inactive — start with: lerd service start "+svc)
+				warn2(label, "inactive — start with: lerd service start "+svc)
 			}
 		default:
-			fail2(svc, status, serviceStatusHint(unit))
+			fail2(label, status, serviceStatusHint(unit))
 		}
 	}
 	customs, _ := config.ListCustomServices()
@@ -160,7 +164,11 @@ func runStatus(_ *cobra.Command, _ []string) error {
 		if svc.Preset != "" {
 			tag = "[preset]"
 		}
-		label := svc.Name + " " + tag
+		label := svc.Name
+		if ver := podman.ServiceVersionLabel(svc.Image); ver != "" {
+			label = svc.Name + " " + ver
+		}
+		label = label + " " + tag
 		switch status {
 		case "active":
 			ok2(label)

--- a/internal/podman/exec.go
+++ b/internal/podman/exec.go
@@ -6,7 +6,10 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 // PodmanBin returns the full path to the podman binary. On macOS it searches
@@ -127,6 +130,49 @@ func ServiceVersion(quadletName string) string {
 		return tag
 	}
 	return ""
+}
+
+// InstalledImage returns the Image= from the installed quadlet on disk,
+// or falls back to the embedded template's Image=. Returns "" when neither
+// exists. The installed file reflects user image overrides (global config,
+// platform overrides) so display surfaces use this instead of ServiceImage.
+func InstalledImage(unit string) string {
+	path := filepath.Join(config.QuadletDir(), unit+".container")
+	if data, err := os.ReadFile(path); err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			if after, ok := strings.CutPrefix(line, "Image="); ok {
+				return strings.TrimSpace(after)
+			}
+		}
+	}
+	return ServiceImage(unit)
+}
+
+// ServiceVersionLabel returns a human-readable version label from an OCI
+// image reference. Rolling tags like "latest" pass through unchanged; numeric
+// tags are prefixed with "v" and stripped of distro/variant suffixes
+// (mysql:8.0 → v8.0, redis:7-alpine → v7, postgis:16-3.5 → v16).
+func ServiceVersionLabel(image string) string {
+	if image == "" {
+		return ""
+	}
+	idx := strings.LastIndex(image, ":")
+	if idx < 0 {
+		return ""
+	}
+	tag := image[idx+1:]
+	switch tag {
+	case "latest", "main", "master", "edge", "stable", "nightly":
+		return tag
+	}
+	core := strings.TrimPrefix(tag, "v")
+	if dash := strings.Index(core, "-"); dash > 0 {
+		core = core[:dash]
+	}
+	if core == "" || core[0] < '0' || core[0] > '9' {
+		return tag
+	}
+	return "v" + core
 }
 
 // ContainerRunning returns true if the named container is running.

--- a/internal/podman/exec_test.go
+++ b/internal/podman/exec_test.go
@@ -1,0 +1,29 @@
+package podman
+
+import "testing"
+
+func TestServiceVersionLabel(t *testing.T) {
+	tests := []struct {
+		image string
+		want  string
+	}{
+		{"docker.io/library/mysql:8.0", "v8.0"},
+		{"docker.io/library/redis:7-alpine", "v7"},
+		{"docker.io/postgis/postgis:16-3.5", "v16"},
+		{"docker.io/postgis/postgis:16-3.5-alpine", "v16"},
+		{"docker.io/getmeili/meilisearch:v1.7", "v1.7"},
+		{"docker.io/axllent/mailpit:latest", "latest"},
+		{"docker.io/rustfs/rustfs:latest", "latest"},
+		{"docker.io/library/redis:main", "main"},
+		{"nginx:alpine", "alpine"},
+		{"nginx", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.image, func(t *testing.T) {
+			if got := ServiceVersionLabel(tt.image); got != tt.want {
+				t.Errorf("ServiceVersionLabel(%q) = %q, want %q", tt.image, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tui/panes.go
+++ b/internal/tui/panes.go
@@ -421,10 +421,10 @@ func filterBar(text string, active bool) string {
 }
 
 // serviceMetaColWidth is the fixed budget for the trailing meta column
-// (site count + pinned/custom tags). Reserved identically on every row so
-// the meta column starts at the same column regardless of which tags are
-// present, mirroring the aligned layout in the sites pane.
-const serviceMetaColWidth = 22
+// (version + site count + pinned/custom tags). Reserved identically on
+// every row so the meta column starts at the same column regardless of
+// which tags are present, mirroring the aligned layout in the sites pane.
+const serviceMetaColWidth = 32
 
 func renderServiceRow(selected bool, s ServiceRow, paneW int) string {
 	var glyph string
@@ -438,6 +438,9 @@ func renderServiceRow(selected bool, s ServiceRow, paneW int) string {
 	}
 
 	meta := fmt.Sprintf("(%d site%s)", s.SiteCount, plural(s.SiteCount))
+	if s.Version != "" {
+		meta = dimStyle.Render(s.Version) + "  " + meta
+	}
 	if s.Pinned {
 		meta += "  " + accentStyle.Render("pinned")
 	}

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -27,6 +27,7 @@ type Snapshot struct {
 // per-site command instead of `lerd service start/stop` which would fail.
 type ServiceRow struct {
 	Name      string
+	Version   string
 	State     ServiceState
 	Custom    bool
 	Pinned    bool
@@ -152,8 +153,15 @@ func buildServiceRow(name string, custom bool) ServiceRow {
 	if config.ServiceIsPaused(name) {
 		state = statePaused
 	}
+	version := podman.ServiceVersionLabel(podman.InstalledImage(unit))
+	if custom && version == "" {
+		if svc, err := config.LoadCustomService(name); err == nil {
+			version = podman.ServiceVersionLabel(svc.Image)
+		}
+	}
 	return ServiceRow{
 		Name:      name,
+		Version:   version,
 		State:     state,
 		Custom:    custom,
 		Pinned:    config.ServiceIsPinned(name),

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -223,7 +223,10 @@
             class="w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left transition-colors border-b border-gray-50 dark:border-lerd-border/50"
             :class="selectedSvc===svc.name ? 'bg-lerd-red/10 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
             <span class="w-2 h-2 rounded-full shrink-0" :class="svc.status==='active' ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
-            <span class="font-medium truncate flex-1" x-text="serviceLabel(svc)"></span>
+            <span class="font-medium truncate flex-1">
+              <span x-text="serviceLabel(svc)"></span>
+              <template x-if="svc.version"><span class="ml-1 text-[10px] font-normal tabular-nums text-gray-400 dark:text-gray-500" x-text="svc.version"></span></template>
+            </span>
             <template x-if="svc.depends_on && svc.depends_on.length > 0">
               <span class="shrink-0 text-gray-300 dark:text-gray-600" title="has dependencies">
                 <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.59 13.51l6.83 3.98M15.41 6.51l-6.82 3.98"/></svg>
@@ -417,7 +420,10 @@
               class="w-full flex items-center gap-2.5 px-4 py-3.5 text-left transition-colors border-b border-gray-100 dark:border-lerd-border"
               :class="selectedSvc===svc.name ? 'bg-lerd-red/5 text-lerd-red' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/[0.03]'">
               <span class="w-2 h-2 rounded-full shrink-0" :class="svc.status==='active' ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'"></span>
-              <span class="font-medium flex-1" x-text="serviceLabel(svc)"></span>
+              <span class="font-medium flex-1">
+                <span x-text="serviceLabel(svc)"></span>
+                <template x-if="svc.version"><span class="ml-1 text-[10px] font-normal tabular-nums text-gray-400 dark:text-gray-500" x-text="svc.version"></span></template>
+              </span>
               <svg class="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
             </button>
           </template>
@@ -1119,6 +1125,9 @@
                     <div class="flex items-center gap-2">
                       <span class="font-semibold text-gray-900 dark:text-white text-base"
                         x-text="selectedService.queue_site ? 'Queue worker' : selectedService.horizon_site ? 'Horizon' : selectedService.stripe_listener_site ? 'Stripe listener' : serviceLabel(selectedService)"></span>
+                      <template x-if="selectedService.version && !selectedService.queue_site && !selectedService.horizon_site && !selectedService.stripe_listener_site && !selectedService.schedule_worker_site && !selectedService.reverb_site && !selectedService.worker_site">
+                        <span class="text-xs font-normal tabular-nums text-gray-500 dark:text-gray-400" x-text="selectedService.version"></span>
+                      </template>
                       <span class="inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-full"
                         :class="selectedService.status === 'active' ? 'bg-emerald-100 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-500' : 'bg-gray-100 dark:bg-white/5 text-gray-500'">
                         <span class="w-1.5 h-1.5 rounded-full" :class="selectedService.status === 'active' ? 'bg-emerald-500' : 'bg-gray-400 dark:bg-gray-600'"></span>
@@ -1204,6 +1213,15 @@
                       class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50">
                       <svg x-show="selectedService.loading" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
                       <span x-show="!selectedService.loading">Stop</span>
+                    </button>
+                  </template>
+                  <template x-if="selectedService.status === 'active' && !selectedService.queue_site && !selectedService.horizon_site && !selectedService.stripe_listener_site && !selectedService.schedule_worker_site && !selectedService.reverb_site && !selectedService.worker_site">
+                    <button @click="toggleService(selectedService, 'restart')" :disabled="selectedService.loading"
+                      title="Restart container"
+                      class="flex items-center gap-1.5 text-xs font-medium bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50">
+                      <svg x-show="selectedService.loading" class="animate-spin w-3 h-3" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"></path></svg>
+                      <svg x-show="!selectedService.loading" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
+                      <span x-show="!selectedService.loading">Restart</span>
                     </button>
                   </template>
                   <template x-if="!selectedService.queue_site && !selectedService.horizon_site && !selectedService.stripe_listener_site && !selectedService.schedule_worker_site && !selectedService.reverb_site && !selectedService.worker_site">
@@ -2392,13 +2410,12 @@ function lerdApp() {
       if (this.serviceDisplayLabels[svc.name]) return this.serviceDisplayLabels[svc.name];
       // Versioned alternates: name is "<family>-<sanitized-tag>" where the tag
       // starts with a digit (mysql-5-7, mongo-6, postgres-14-2, mariadb-11).
-      // Display as "<Family Label> <tag-with-dots>".
+      // The tag is rendered separately via the version badge, so return only
+      // the family label here to avoid duplicating the version in the row.
       const m = svc.name.match(/^([a-z][a-z0-9]*?)-(\d[\w-]*)$/);
       if (m) {
         const family = m[1];
-        const tag = m[2].replace(/-/g, '.');
-        const familyLabel = this.serviceDisplayLabels[family] || this.capitalize(family);
-        return familyLabel + ' ' + tag;
+        return this.serviceDisplayLabels[family] || this.capitalize(family);
       }
       return this.capitalize(svc.name);
     },
@@ -4129,17 +4146,17 @@ function lerdApp() {
         const res = await fetch(`/api/services/${svc.name}/${action}`, { method: 'POST', signal: ctrl.signal });
         const data = await res.json();
         if (data.ok) {
-          svc.status = data.status || (action === 'start' ? 'active' : 'inactive');
-          svc.flash = action === 'start' ? 'Service started' : 'Service stopped';
+          svc.status = data.status || (action === 'stop' ? 'inactive' : 'active');
+          svc.flash = action === 'start' ? 'Service started' : action === 'restart' ? 'Service restarted' : 'Service stopped';
           setTimeout(() => { svc.flash = ''; }, 3000);
-          if (action === 'start') this.openServiceLogs(svc);
+          if (action === 'start' || action === 'restart') this.openServiceLogs(svc);
         } else {
           svc.error = data.error || 'Action failed';
         }
         await this.loadServices();
       } catch (e) {
         if (e.name === 'AbortError') {
-          svc.flash = action === 'start' ? 'Starting in background…' : 'Stopping in background…';
+          svc.flash = action === 'start' ? 'Starting in background…' : action === 'restart' ? 'Restarting in background…' : 'Stopping in background…';
           setTimeout(() => { svc.flash = ''; }, 4000);
         } else {
           svc.error = e.message || 'Request failed';

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -748,6 +748,7 @@ func buildSites() []SiteResponse {
 type ServiceResponse struct {
 	Name               string            `json:"name"`
 	Status             string            `json:"status"`
+	Version            string            `json:"version,omitempty"`
 	EnvVars            map[string]string `json:"env_vars"`
 	Dashboard          string            `json:"dashboard,omitempty"`
 	ConnectionURL      string            `json:"connection_url,omitempty"`
@@ -799,6 +800,7 @@ func buildServiceResponse(name string) ServiceResponse {
 	return ServiceResponse{
 		Name:          name,
 		Status:        status,
+		Version:       podman.ServiceVersionLabel(podman.InstalledImage(unit)),
 		EnvVars:       envMap,
 		Dashboard:     builtinDashboards[name],
 		ConnectionURL: builtinConnectionURLs[name],
@@ -872,6 +874,7 @@ func buildServicesList() []ServiceResponse {
 		services = append(services, ServiceResponse{
 			Name:          svc.Name,
 			Status:        status,
+			Version:       podman.ServiceVersionLabel(svc.Image),
 			EnvVars:       envMap,
 			Dashboard:     svc.Dashboard,
 			ConnectionURL: svc.ConnectionURL,
@@ -1336,6 +1339,13 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 		if opErr == nil {
 			_ = config.SetServicePaused(name, true)
 			_ = config.SetServiceManuallyStarted(name, false)
+			cli.RegenerateFamilyConsumersForService(name)
+		}
+	case "restart":
+		opErr = podman.RestartUnit(unit)
+		if opErr == nil {
+			_ = config.SetServicePaused(name, false)
+			_ = config.SetServiceManuallyStarted(name, true)
 			cli.RegenerateFamilyConsumersForService(name)
 		}
 	case "remove":


### PR DESCRIPTION
Adds a version label next to every service in lerd service list, lerd status, the Web UI list and detail header, and the TUI services pane. The label comes from the installed quadlet's Image tag and renders as v8.0 for mysql, v7 for redis, v16 for postgres, v1.7 for meilisearch, and so on. Rolling tags like latest or main pass through as is. Reading the installed file on disk means the label reflects user image overrides from config.yaml rather than the embedded default.

Versioned presets (installed via lerd service preset mysql --version 5.7 and friends) keep their raw service name in the CLI and TUI so mysql-5-7 shows next to v5.7. The Web UI's serviceLabel transform previously rendered mysql-5-7 as "MySQL 5.7", so now it returns just the family label and the version badge appears as a separate chip, matching how built-in rows read.

The service detail page in the Web UI also gains a Restart button next to Start and Stop, matching the site container row. It posts to a new /api/services/name/restart handler which wraps podman.RestartUnit and clears the paused flag on success. Workers like queue, schedule, horizon, reverb and stripe are excluded since their flow is stop only.