### PR TITLE
fix(network): probe IPv6 and fall back to v4-only on aardvark bind failure

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -91,7 +91,7 @@ func runInstall(_ *cobra.Command, _ []string) error {
 			if dualStack {
 				fmt.Println("    Recreated lerd network as dual-stack v4+v6.")
 			} else {
-				fmt.Println("    Recreated lerd network as v4-only (host has no usable IPv6).")
+				fmt.Println("    Recreated lerd network as v4-only (IPv6 not available for containers).")
 			}
 			fmt.Println("    Existing containers on this network were recreated.")
 			migrated = restored

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -496,10 +496,10 @@ func runRollback() error {
 	// Update the cache.
 	lerdUpdate.WriteUpdateCache(prevVersion)
 
-	// Recreate the podman network so the old binary's `lerd install`
-	// starts with a clean v4-only network. Without this, a dual-stack
-	// network left by a newer version stays broken because the old
-	// binary doesn't know about IPv6.
+	// Recreate the network cleanly so the rolled-back binary's
+	// `lerd install` starts from a known-good state. The current
+	// binary's probe logic decides v4-only vs dual-stack; the old
+	// binary's EnsureNetwork will accept whatever schema it finds.
 	fmt.Println("  --> Resetting lerd network for rollback")
 	if attached, _, err := podman.RecreateNetwork("lerd"); err == nil {
 		for _, c := range attached {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -496,6 +496,17 @@ func runRollback() error {
 	// Update the cache.
 	lerdUpdate.WriteUpdateCache(prevVersion)
 
+	// Recreate the podman network so the old binary's `lerd install`
+	// starts with a clean v4-only network. Without this, a dual-stack
+	// network left by a newer version stays broken because the old
+	// binary doesn't know about IPv6.
+	fmt.Println("  --> Resetting lerd network for rollback")
+	if attached, _, err := podman.RecreateNetwork("lerd"); err == nil {
+		for _, c := range attached {
+			_ = podman.StartUnit(c)
+		}
+	}
+
 	fmt.Printf("\nRolled back to v%s — applying infrastructure changes...\n\n", prevVersion)
 
 	// Re-exec the new binary with `install`, same as a normal update.

--- a/internal/podman/network.go
+++ b/internal/podman/network.go
@@ -114,22 +114,106 @@ func EnsureNetwork(name string) error {
 	for _, line := range strings.Split(out, "\n") {
 		if strings.TrimSpace(line) == name {
 			netV6 := NetworkHasIPv6(name)
-			if hostV6 != netV6 {
+			if netV6 && !hostV6 {
+				// Network has IPv6 but host no longer does — strip it.
 				return ErrNetworkNeedsMigration
 			}
-			if hostV6 && AardvarkNetworkDrifted(name) {
+			if hostV6 && !netV6 && !ipv6ProbeFailed(name) {
+				// Host gained IPv6 and no previous probe failure — try upgrading.
+				return ErrNetworkNeedsMigration
+			}
+			if hostV6 && netV6 && AardvarkNetworkDrifted(name) {
 				return ErrNetworkNeedsMigration
 			}
 			return nil
 		}
 	}
 
+	_, err = createNetworkWithProbe(name, hostV6)
+	return err
+}
+
+// ipv6ProbeFailedPath returns the marker file path that records a failed
+// IPv6 probe so we don't retry the dual-stack migration on every install.
+func ipv6ProbeFailedPath(networkName string) string {
+	if dir := os.Getenv("XDG_DATA_HOME"); dir != "" {
+		return filepath.Join(dir, "lerd", "ipv6-probe-failed-"+networkName)
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local/share/lerd", "ipv6-probe-failed-"+networkName)
+}
+
+// ipv6ProbeFailed reports whether a previous IPv6 probe failed for the
+// named network.
+func ipv6ProbeFailed(name string) bool {
+	_, err := os.Stat(ipv6ProbeFailedPath(name))
+	return err == nil
+}
+
+// markIPv6ProbeFailed writes a marker file to prevent retrying the
+// dual-stack migration on subsequent installs.
+func markIPv6ProbeFailed(name string) {
+	path := ipv6ProbeFailedPath(name)
+	_ = os.MkdirAll(filepath.Dir(path), 0755)
+	_ = os.WriteFile(path, []byte("probe failed\n"), 0644)
+}
+
+// clearIPv6ProbeFailed removes the marker so a future install retries.
+func clearIPv6ProbeFailed(name string) {
+	_ = os.Remove(ipv6ProbeFailedPath(name))
+}
+
+// createNetworkWithProbe creates the podman network. When dualStack is true it
+// first tries a dual-stack network and runs a throw-away container to verify
+// aardvark-dns can bind the IPv6 gateway. If the probe fails, the network is
+// torn down and recreated as v4-only. Returns the actual dual-stack state.
+func createNetworkWithProbe(name string, dualStack bool) (bool, error) {
 	args := []string{"network", "create", "--driver", "bridge"}
-	if hostV6 {
+	if dualStack {
 		args = append(args, "--ipv6", "--subnet", LerdULAv6Subnet)
 	}
 	args = append(args, "--opt", "mtu="+LerdNetworkMTU, name)
-	return RunSilent(args...)
+	if err := RunSilent(args...); err != nil {
+		return dualStack, err
+	}
+
+	if dualStack && !probeNetworkIPv6(name) {
+		markIPv6ProbeFailed(name)
+		// Systemd may have auto-restarted containers on this network
+		// between RecreateNetwork and the probe. Stop and remove them
+		// before tearing down the network.
+		if out, err := Run("ps", "-a", "--filter", "network="+name, "--format", "{{.Names}}"); err == nil {
+			for _, c := range strings.Split(out, "\n") {
+				if c = strings.TrimSpace(c); c != "" {
+					_ = StopUnit(c)
+					_ = RunSilent("rm", "--force", c)
+				}
+			}
+		}
+		_ = RemoveNetwork(name)
+		return createNetworkWithProbe(name, false)
+	}
+
+	if dualStack {
+		clearIPv6ProbeFailed(name)
+	}
+	return dualStack, nil
+}
+
+// probeNetworkIPv6 starts a throw-away container on the named network to
+// verify aardvark-dns can bind the IPv6 gateway. Returns true when the
+// container starts (or when the probe is inconclusive, e.g. missing image),
+// false only for aardvark-dns bind failures.
+func probeNetworkIPv6(name string) bool {
+	cmd := exec.Command(PodmanBin(), "run", "--rm", "--network", name,
+		"--pull", "never", "alpine:latest", "true")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return true
+	}
+	s := string(out)
+	return !strings.Contains(s, "aardvark-dns") &&
+		!strings.Contains(s, "Cannot assign requested address")
 }
 
 // aardvarkConfigPath returns the on-disk path to aardvark-dns's config file
@@ -211,7 +295,7 @@ func RecreateNetwork(name string) ([]string, bool, error) {
 	}
 
 	for _, c := range attached {
-		_ = RunSilent("stop", "--time", "10", c)
+		_ = StopUnit(c)
 		_ = RunSilent("rm", "--force", c)
 	}
 
@@ -220,20 +304,16 @@ func RecreateNetwork(name string) ([]string, bool, error) {
 	}
 
 	hostV6 := HostHasUsableIPv6()
-	args := []string{"network", "create", "--driver", "bridge"}
-	if hostV6 {
-		args = append(args, "--ipv6", "--subnet", LerdULAv6Subnet)
-	}
-	args = append(args, "--opt", "mtu="+LerdNetworkMTU, name)
-	if err := RunSilent(args...); err != nil {
-		return attached, hostV6, fmt.Errorf("recreating %s: %w", name, err)
+	actualV6, err := createNetworkWithProbe(name, hostV6)
+	if err != nil {
+		return attached, actualV6, fmt.Errorf("recreating %s: %w", name, err)
 	}
 
 	for _, dns := range prevDNS {
 		_ = RunSilent("network", "update", "--dns-add", dns, name)
 	}
 
-	return attached, hostV6, nil
+	return attached, actualV6, nil
 }
 
 // EnsureNetworkDNS syncs the DNS servers on the named network to the provided list.

--- a/internal/podman/network_test.go
+++ b/internal/podman/network_test.go
@@ -175,6 +175,53 @@ func TestHostHasUsableIPv6(t *testing.T) {
 	}
 }
 
+func TestIPv6ProbeFailedMarker(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if ipv6ProbeFailed("lerd") {
+		t.Fatal("should not be marked before any probe")
+	}
+
+	markIPv6ProbeFailed("lerd")
+	if !ipv6ProbeFailed("lerd") {
+		t.Fatal("should be marked after markIPv6ProbeFailed")
+	}
+
+	clearIPv6ProbeFailed("lerd")
+	if ipv6ProbeFailed("lerd") {
+		t.Fatal("should be cleared after clearIPv6ProbeFailed")
+	}
+}
+
+func TestProbeNetworkIPv6_detectsAardvarkFailure(t *testing.T) {
+	// probeNetworkIPv6 shells out to podman, so we only unit-test the output
+	// parsing logic by inlining it. Integration coverage comes from the
+	// full install test.
+	tests := []struct {
+		name   string
+		output string
+		want   bool // true = probe OK (IPv6 works or inconclusive)
+	}{
+		{"success (empty output)", "", true},
+		{"aardvark bind error", "Error: netavark: error while applying dns entries: aardvark-dns failed to start: Error from child process\nError starting server failed to bind udp listener on [fd00:1e7d::1]:53: IO error: Cannot assign requested address (os error 99)", false},
+		{"image not found", "Error: alpine:latest: image not known", true},
+		{"generic error", "Error: some unrelated failure", true},
+		{"cannot assign only", "Cannot assign requested address", false},
+		{"aardvark only", "aardvark-dns crashed", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.output
+			got := !strings.Contains(s, "aardvark-dns") &&
+				!strings.Contains(s, "Cannot assign requested address")
+			if got != tt.want {
+				t.Errorf("probe output %q: got %v, want %v", tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRemoveNetwork_wipesAardvarkConfigEvenWhenPodmanFails(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_RUNTIME_DIR", tmp)


### PR DESCRIPTION
## Summary
- After creating a dual-stack network, runs a probe container to verify aardvark-dns can bind the IPv6 gateway — falls back to v4-only if it can't
- Stops containers via `systemctl --user stop` (StopUnit) instead of `podman stop` during migration, preventing systemd auto-restart races that broke inter-container DNS
- Writes a marker file (`~/.local/share/lerd/ipv6-probe-failed-lerd`) on probe failure so subsequent `lerd install` runs don't re-trigger the migration

Fixes upgrade failures from v1.17.1 → v1.18.0-beta.3 where `HostHasUsableIPv6` returned true but rootless podman's aardvark-dns couldn't bind `[fd00:1e7d::1]:53`, causing php-fpm, mysql, and nginx to fail with "Cannot assign requested address".