### PR TITLE
release: v1.18.0-beta.6 — IPv6 probe timeout and --no-ipv6 opt-out

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,18 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.18.0-beta.6] — 2026-04-24
+
+### Added
+
+- **`--no-ipv6` flag (and `LERD_DISABLE_IPV6=1`) on `lerd install`** so users on dual-stack-capable hosts can force a v4-only `lerd` network without touching the host. Reuses the existing `~/.local/share/lerd/ipv6-probe-failed-lerd` marker, so `EnsureNetwork` honors the opt-out on every path (initial create, host-gained-v6 migration, `RecreateNetwork`). Re-enable by deleting the marker and rerunning `lerd install`. New `MarkIPv6Disabled` / `IPv6DisabledMarkerPath` helpers expose this from `internal/podman` so the install command and the timeout-fallback warning point at the same path.
+
+### Fixed
+
+- **`lerd install` could hang forever on the IPv6 probe** if podman or the netns setup stalled. `probeNetworkIPv6` now runs under a 30s `context.WithTimeout`; on deadline it falls back to v4-only the same way an aardvark bind failure does, writes the marker, and prints a stderr warning telling the user exactly which file to delete to retry dual-stack later. The 5-line WARN block is the only user-visible change on healthy hosts (the probe itself stays well under one second on every distro tested).
+
+---
+
 ## [1.18.0-beta.5] — 2026-04-23
 
 ### Fixed

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -268,6 +268,16 @@ lerd install
 ```
 
 If the host later gains v6 connectivity, the next `lerd install` will recreate the network as dual-stack again.
+
+If you'd rather skip the dual-stack code path entirely, even on a v6-capable host, opt out:
+
+```bash
+lerd install --no-ipv6
+# or persistently via shell rc:
+export LERD_DISABLE_IPV6=1
+```
+
+Either path writes `~/.local/share/lerd/ipv6-probe-failed-lerd`, which `EnsureNetwork` honors on every code path (initial create, migration, recreate). To re-enable dual-stack, delete that marker file and re-run `lerd install`.
 :::
 
 ::: details Every DNS lookup inside a lerd container stalls ~5 seconds

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -25,18 +25,32 @@ import (
 
 // NewInstallCmd returns the install command.
 func NewInstallCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Run one-time Lerd setup",
 		RunE:  runInstall,
 	}
+	cmd.Flags().Bool("no-ipv6", false,
+		"Force the lerd network to v4-only even if the host supports IPv6 (also: LERD_DISABLE_IPV6=1)")
+	return cmd
 }
 
 func step(label string) { fmt.Printf("  --> %s ... ", label) }
 func ok()               { fmt.Println("OK") }
 
-func runInstall(_ *cobra.Command, _ []string) error {
+func runInstall(cmd *cobra.Command, _ []string) error {
 	fmt.Println("==> Installing Lerd")
+
+	noIPv6, _ := cmd.Flags().GetBool("no-ipv6")
+	if !noIPv6 && os.Getenv("LERD_DISABLE_IPV6") == "1" {
+		noIPv6 = true
+	}
+	if noIPv6 {
+		podman.MarkIPv6Disabled("lerd")
+		fmt.Println("  IPv6 disabled by user; lerd network will be v4-only.")
+		fmt.Printf("  Delete %s and re-run `lerd install` to re-enable.\n",
+			podman.IPv6DisabledMarkerPath("lerd"))
+	}
 
 	// On macOS, Podman Machine must be running before any podman commands.
 	ensurePodmanMachineRunning()
@@ -130,13 +144,13 @@ func runInstall(_ *cobra.Command, _ []string) error {
 		wantLerdNode = confirmInstallPrompt("Let lerd manage Node.js versions (installs fnm shims, may override system node)?")
 	}
 
-	// 4. mkcert CA — interactive (may prompt for sudo)
+	// 4. mkcert CA, interactive (may prompt for sudo)
 	fmt.Println("  --> Installing mkcert CA")
-	cmd := exec.Command(certs.MkcertPath(), "-install")
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Run() //nolint:errcheck
+	mkcertCmd := exec.Command(certs.MkcertPath(), "-install")
+	mkcertCmd.Stdin = os.Stdin
+	mkcertCmd.Stdout = os.Stdout
+	mkcertCmd.Stderr = os.Stderr
+	mkcertCmd.Run() //nolint:errcheck
 
 	// 5. DNS config + sudoers
 	step("Writing DNS configuration")

--- a/internal/podman/network.go
+++ b/internal/podman/network.go
@@ -112,16 +112,21 @@ func EnsureNetwork(name string) error {
 		return err
 	}
 
-	hostV6 := HostHasUsableIPv6()
+	// The probe-failed marker doubles as the user opt-out: install --no-ipv6
+	// (or LERD_DISABLE_IPV6=1) writes it before calling EnsureNetwork, so
+	// dual-stack is suppressed on every code path below without a second flag.
+	hostV6 := HostHasUsableIPv6() && !ipv6ProbeFailed(name)
 	for _, line := range strings.Split(out, "\n") {
 		if strings.TrimSpace(line) == name {
 			netV6 := NetworkHasIPv6(name)
 			if netV6 && !hostV6 {
-				// Network has IPv6 but host no longer does — strip it.
+				// Network has IPv6 but host no longer does, or user
+				// opted out: strip it.
 				return ErrNetworkNeedsMigration
 			}
-			if hostV6 && !netV6 && !ipv6ProbeFailed(name) {
-				// Host gained IPv6 and no previous probe failure — try upgrading.
+			if hostV6 && !netV6 {
+				// Host gained IPv6 and no previous probe failure or
+				// opt-out: try upgrading.
 				return ErrNetworkNeedsMigration
 			}
 			if hostV6 && netV6 && AardvarkNetworkDrifted(name) {
@@ -165,6 +170,21 @@ func clearIPv6ProbeFailed(name string) {
 	_ = os.Remove(ipv6ProbeFailedPath(name))
 }
 
+// MarkIPv6Disabled persists the user's opt-out (--no-ipv6 /
+// LERD_DISABLE_IPV6=1) using the same marker file as a probe failure.
+// EnsureNetwork honors it on every code path so dual-stack stays off
+// across installs until the user removes the marker.
+func MarkIPv6Disabled(name string) {
+	markIPv6ProbeFailed(name)
+}
+
+// IPv6DisabledMarkerPath returns the on-disk path of the opt-out marker
+// so callers (and the timeout-fallback warning) can show users exactly
+// what to delete to retry dual-stack.
+func IPv6DisabledMarkerPath(name string) string {
+	return ipv6ProbeFailedPath(name)
+}
+
 // createNetworkWithProbe creates the podman network. When dualStack is true it
 // first tries a dual-stack network and runs a throw-away container to verify
 // aardvark-dns can bind the IPv6 gateway. If the probe fails, the network is
@@ -187,7 +207,7 @@ func createNetworkWithProbe(name string, dualStack bool) (bool, error) {
 				fmt.Fprintf(os.Stderr,
 					"    [WARN] IPv6 probe timed out after %s; falling back to v4-only.\n"+
 						"    To retry dual-stack later, delete %s and re-run `lerd install`.\n",
-					probeNetworkIPv6Timeout, ipv6ProbeFailedPath(name))
+					probeNetworkIPv6Timeout, IPv6DisabledMarkerPath(name))
 			}
 			// Systemd may have auto-restarted containers on this network
 			// between RecreateNetwork and the probe. Stop and remove them
@@ -324,7 +344,7 @@ func RecreateNetwork(name string) ([]string, bool, error) {
 		return attached, false, fmt.Errorf("removing %s: %w", name, err)
 	}
 
-	hostV6 := HostHasUsableIPv6()
+	hostV6 := HostHasUsableIPv6() && !ipv6ProbeFailed(name)
 	actualV6, err := createNetworkWithProbe(name, hostV6)
 	if err != nil {
 		return attached, actualV6, fmt.Errorf("recreating %s: %w", name, err)

--- a/internal/podman/network.go
+++ b/internal/podman/network.go
@@ -1,6 +1,7 @@
 package podman
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // LerdULAv6Subnet is the deterministic IPv6 ULA prefix for the lerd network.
@@ -177,43 +179,62 @@ func createNetworkWithProbe(name string, dualStack bool) (bool, error) {
 		return dualStack, err
 	}
 
-	if dualStack && !probeNetworkIPv6(name) {
-		markIPv6ProbeFailed(name)
-		// Systemd may have auto-restarted containers on this network
-		// between RecreateNetwork and the probe. Stop and remove them
-		// before tearing down the network.
-		if out, err := Run("ps", "-a", "--filter", "network="+name, "--format", "{{.Names}}"); err == nil {
-			for _, c := range strings.Split(out, "\n") {
-				if c = strings.TrimSpace(c); c != "" {
-					_ = StopUnit(c)
-					_ = RunSilent("rm", "--force", c)
+	if dualStack {
+		ok, timedOut := probeNetworkIPv6(name)
+		if !ok {
+			markIPv6ProbeFailed(name)
+			if timedOut {
+				fmt.Fprintf(os.Stderr,
+					"    [WARN] IPv6 probe timed out after %s; falling back to v4-only.\n"+
+						"    To retry dual-stack later, delete %s and re-run `lerd install`.\n",
+					probeNetworkIPv6Timeout, ipv6ProbeFailedPath(name))
+			}
+			// Systemd may have auto-restarted containers on this network
+			// between RecreateNetwork and the probe. Stop and remove them
+			// before tearing down the network.
+			if out, err := Run("ps", "-a", "--filter", "network="+name, "--format", "{{.Names}}"); err == nil {
+				for _, c := range strings.Split(out, "\n") {
+					if c = strings.TrimSpace(c); c != "" {
+						_ = StopUnit(c)
+						_ = RunSilent("rm", "--force", c)
+					}
 				}
 			}
+			_ = RemoveNetwork(name)
+			return createNetworkWithProbe(name, false)
 		}
-		_ = RemoveNetwork(name)
-		return createNetworkWithProbe(name, false)
-	}
-
-	if dualStack {
 		clearIPv6ProbeFailed(name)
 	}
 	return dualStack, nil
 }
 
+// probeNetworkIPv6Timeout caps how long the throw-away container is allowed
+// to run before we treat the probe as inconclusive. A hung podman or netns
+// setup must not block install/recreate forever.
+const probeNetworkIPv6Timeout = 30 * time.Second
+
 // probeNetworkIPv6 starts a throw-away container on the named network to
-// verify aardvark-dns can bind the IPv6 gateway. Returns true when the
-// container starts (or when the probe is inconclusive, e.g. missing image),
-// false only for aardvark-dns bind failures.
-func probeNetworkIPv6(name string) bool {
-	cmd := exec.Command(PodmanBin(), "run", "--rm", "--network", name,
+// verify aardvark-dns can bind the IPv6 gateway. Returns ok=true when the
+// container starts (or when the probe is inconclusive, e.g. missing image).
+// Returns ok=false on aardvark-dns bind failures or when the probe times
+// out, so the caller falls back to v4-only in both cases. timedOut is set
+// when the deadline elapsed, so the caller can surface a recovery hint.
+func probeNetworkIPv6(name string) (ok, timedOut bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), probeNetworkIPv6Timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, PodmanBin(), "run", "--rm", "--network", name,
 		"--pull", "never", "alpine:latest", "true")
 	out, err := cmd.CombinedOutput()
 	if err == nil {
-		return true
+		return true, false
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return false, true
 	}
 	s := string(out)
-	return !strings.Contains(s, "aardvark-dns") &&
-		!strings.Contains(s, "Cannot assign requested address")
+	bindFailure := strings.Contains(s, "aardvark-dns") ||
+		strings.Contains(s, "Cannot assign requested address")
+	return !bindFailure, false
 }
 
 // aardvarkConfigPath returns the on-disk path to aardvark-dns's config file

--- a/internal/podman/network_test.go
+++ b/internal/podman/network_test.go
@@ -194,6 +194,21 @@ func TestIPv6ProbeFailedMarker(t *testing.T) {
 	}
 }
 
+func TestMarkIPv6Disabled_sharesProbeFailedMarker(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	MarkIPv6Disabled("lerd")
+	if !ipv6ProbeFailed("lerd") {
+		t.Fatal("MarkIPv6Disabled must set the same marker that EnsureNetwork checks")
+	}
+
+	want := ipv6ProbeFailedPath("lerd")
+	if got := IPv6DisabledMarkerPath("lerd"); got != want {
+		t.Errorf("IPv6DisabledMarkerPath = %q, want %q", got, want)
+	}
+}
+
 func TestProbeNetworkIPv6_detectsAardvarkFailure(t *testing.T) {
 	// probeNetworkIPv6 shells out to podman, so we only unit-test the output
 	// parsing logic by inlining it. Integration coverage comes from the

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.18.0-beta.5"
+	Version = "1.18.0-beta.6"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

- Bound the IPv6 probe with a 30s context deadline and treat timeout as a probe failure (fall back to v4-only, write the marker, print a stderr WARN telling the user which file to delete to retry). Closes the install-hang failure mode on stalled podman/netns setups.
- New `--no-ipv6` flag on `lerd install` (also `LERD_DISABLE_IPV6=1`) for users on dual-stack-capable hosts who want a v4-only `lerd` network without disabling IPv6 on the host. Reuses the existing probe-failed marker so a single mechanism covers both opt-out and probe failure across initial create, host-gained-v6 migration, and `RecreateNetwork`.
- Round-trip tested on CachyOS: `--no-ipv6` produces a v4-only network (only `10.89.7.0/24`); deleting `~/.local/share/lerd/ipv6-probe-failed-lerd` and rerunning `lerd install` restores `fd00:1e7d::/64` + `10.89.7.0/24` dual-stack.

Docs: troubleshooting page now documents the opt-out and the marker path.