### PR TITLE
feat(presets): add memcached, rabbitmq, elasticsearch service presets

### DIFF
--- a/docs/usage/custom-services.md
+++ b/docs/usage/custom-services.md
@@ -57,6 +57,19 @@ data_dir: /data/db                     # mount target inside container
                                        # host path: ~/.local/share/lerd/data/<name>/
                                        # omit to disable persistent storage
 
+chown_data: false                      # add :U to the data_dir mount so podman re-chowns
+                                       # the host dir to the container's expected UID at
+                                       # mount time. Pair with userns when the in-container
+                                       # process runs as a non-root user (e.g. elasticsearch
+                                       # UID 1000) and would otherwise hit EACCES.
+
+userns: ""                             # written verbatim to UserNS= in the quadlet, e.g.
+                                       # "keep-id:uid=1000,gid=0" maps the host user 1:1
+                                       # to container UID 1000 so bind-mounted volumes are
+                                       # writable in rootless podman. Leave empty for
+                                       # images that run as root or drop privileges via
+                                       # their entrypoint.
+
 exec: ""                               # container command override
 
 dashboard: http://localhost:8081       # URL shown as an "Open" button in the web UI

--- a/docs/usage/custom-services.md
+++ b/docs/usage/custom-services.md
@@ -75,6 +75,12 @@ exec: ""                               # container command override
 dashboard: http://localhost:8081       # URL shown as an "Open" button in the web UI
                                        # when the service is active
 
+dashboard_external: false              # open the dashboard in a new browser tab instead of
+                                       # the embedded iframe. Use for admin UIs whose login
+                                       # cookie is dropped on cross-origin iframe POSTs and
+                                       # has no SameSite override (e.g. RabbitMQ Cowboy).
+                                       # External dashboards also skip the sidebar shortcut.
+
 connection_url: mongodb://root:secret@127.0.0.1:27017/?authSource=admin
                                        # host-side scheme URL (mysql://, postgresql://, mongodb://, etc.)
                                        # Surfaced as an "Open connection URL" link on the service detail

--- a/docs/usage/service-presets.md
+++ b/docs/usage/service-presets.md
@@ -20,6 +20,7 @@ plays nicely with every `lerd service` subcommand (start/stop/remove/expose/pin)
 | `memcached` | `docker.io/library/memcached:1.6-alpine` | - | `127.0.0.1:11211` |
 | `rabbitmq` | `docker.io/library/rabbitmq:3-management-alpine` | - | `http://localhost:15672` (mgmt UI) |
 | `elasticsearch` | `docker.elastic.co/elasticsearch/elasticsearch:8.13.4` | - | `127.0.0.1:9200` |
+| `elasticvue` | `docker.io/cars10/elasticvue:latest` | `elasticsearch` (preset) | `http://localhost:8083` |
 
 ```bash
 # List the bundled presets and their install state
@@ -146,6 +147,7 @@ A preset's `depends_on` is enforced two ways:
 | `memcached` | no auth (Memcached has no native authentication) |
 | `rabbitmq` | management UI: `root` / `lerd` (also the default AMQP user) |
 | `elasticsearch` | no auth (`xpack.security.enabled=false` for local dev) |
+| `elasticvue` | no auth, opens straight to the pre-configured `Lerd Elasticsearch` cluster at `http://localhost:9200` |
 
 ## Database service quality-of-life
 

--- a/docs/usage/service-presets.md
+++ b/docs/usage/service-presets.md
@@ -1,6 +1,6 @@
 # Service presets
 
-The built-in services (MySQL, Postgres, Redis, etc.) live in [Services](services.md). This page covers the opt-in **service presets** Lerd ships: one-command installers for phpMyAdmin, pgAdmin, MongoDB, alternate MySQL / MariaDB versions, Selenium, and Stripe Mock.
+The built-in services (MySQL, Postgres, Redis, etc.) live in [Services](services.md). This page covers the opt-in **service presets** Lerd ships: one-command installers for phpMyAdmin, pgAdmin, MongoDB, alternate MySQL / MariaDB versions, Selenium, Stripe Mock, Memcached, RabbitMQ, and Elasticsearch.
 
 Lerd ships a small set of opt-in service presets that you can install in one
 command without cluttering the built-in service list. Each preset is just a
@@ -17,6 +17,9 @@ plays nicely with every `lerd service` subcommand (start/stop/remove/expose/pin)
 | `mongo-express` | `docker.io/library/mongo-express:latest` | `mongo` (preset) | `http://localhost:8082` |
 | `selenium` | `docker.io/selenium/standalone-chromium:latest` | - | `http://localhost:7900` (noVNC) |
 | `stripe-mock` | `docker.io/stripemock/stripe-mock:latest` | - | `127.0.0.1:12111` |
+| `memcached` | `docker.io/library/memcached:1.6-alpine` | - | `127.0.0.1:11211` |
+| `rabbitmq` | `docker.io/library/rabbitmq:3-management-alpine` | - | `http://localhost:15672` (mgmt UI) |
+| `elasticsearch` | `docker.elastic.co/elasticsearch/elasticsearch:8.13.4` | - | `127.0.0.1:9200` |
 
 ```bash
 # List the bundled presets and their install state
@@ -140,6 +143,9 @@ A preset's `depends_on` is enforced two ways:
 | `mongo` | root user `root` / `lerd` |
 | `mongo-express` | basic auth disabled, open `http://localhost:8082` directly |
 | `stripe-mock` | no auth (Stripe test mock) |
+| `memcached` | no auth (Memcached has no native authentication) |
+| `rabbitmq` | management UI: `root` / `lerd` (also the default AMQP user) |
+| `elasticsearch` | no auth (`xpack.security.enabled=false` for local dev) |
 
 ## Database service quality-of-life
 

--- a/docs/usage/service-presets.md
+++ b/docs/usage/service-presets.md
@@ -18,7 +18,7 @@ plays nicely with every `lerd service` subcommand (start/stop/remove/expose/pin)
 | `selenium` | `docker.io/selenium/standalone-chromium:latest` | - | `http://localhost:7900` (noVNC) |
 | `stripe-mock` | `docker.io/stripemock/stripe-mock:latest` | - | `127.0.0.1:12111` |
 | `memcached` | `docker.io/library/memcached:1.6-alpine` | - | `127.0.0.1:11211` |
-| `rabbitmq` | `docker.io/library/rabbitmq:3-management-alpine` | - | `http://localhost:15672` (mgmt UI) |
+| `rabbitmq` | `docker.io/library/rabbitmq:3-management-alpine` | - | `http://localhost:15672` (mgmt UI, opens in new tab) |
 | `elasticsearch` | `docker.elastic.co/elasticsearch/elasticsearch:8.13.4` | - | `127.0.0.1:9200` |
 | `elasticvue` | `docker.io/cars10/elasticvue:latest` | `elasticsearch` (preset) | `http://localhost:8083` |
 

--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -105,6 +105,10 @@ type CustomService struct {
 	// directory to the container's expected UID at mount time. Pair with
 	// Userns to keep bind-mounted data writable to non-root container users.
 	ChownData bool `yaml:"chown_data,omitempty"`
+	// DashboardExternal opens the dashboard URL in a new browser tab instead
+	// of embedding it as an iframe. Use for admin UIs that set session
+	// cookies the iframe can't carry across origins (e.g. RabbitMQ Cowboy).
+	DashboardExternal bool `yaml:"dashboard_external,omitempty" json:"dashboard_external,omitempty"`
 }
 
 // ServiceFilePath returns the deterministic host path for a single FileMount

--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -97,6 +97,14 @@ type CustomService struct {
 	//   discover_family:<name>  -> comma-joined hostnames of every installed
 	//   service in the named family (built-in or custom).
 	DynamicEnv map[string]string `yaml:"dynamic_env,omitempty"`
+	// Userns sets the quadlet UserNS= line verbatim, e.g. "keep-id:uid=1000,gid=0"
+	// for images whose process runs as a non-root UID and needs that UID
+	// mapped to the host user for bind-mounted volumes.
+	Userns string `yaml:"userns,omitempty"`
+	// ChownData adds :U to the data_dir mount so podman re-chowns the host
+	// directory to the container's expected UID at mount time. Pair with
+	// Userns to keep bind-mounted data writable to non-root container users.
+	ChownData bool `yaml:"chown_data,omitempty"`
 }
 
 // ServiceFilePath returns the deterministic host path for a single FileMount

--- a/internal/config/presets/elasticsearch.yaml
+++ b/internal/config/presets/elasticsearch.yaml
@@ -7,6 +7,12 @@ environment:
   discovery.type: single-node
   xpack.security.enabled: "false"
   ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+  http.cors.enabled: "true"
+  # ES parses env vars as YAML, so a bare '*' becomes an alias and crashes
+  # SnakeYAML on boot. Wrap in literal quotes to force a string.
+  http.cors.allow-origin: '"*"'
+  http.cors.allow-headers: X-Requested-With,Content-Type,Content-Length,Authorization
+  http.cors.allow-methods: OPTIONS,HEAD,GET,POST,PUT,DELETE
 data_dir: /usr/share/elasticsearch/data
 # Map host user 1:1 to container UID 1000 and chown the data dir to it
 # so node.lock + indices are writable in rootless podman.

--- a/internal/config/presets/elasticsearch.yaml
+++ b/internal/config/presets/elasticsearch.yaml
@@ -1,0 +1,17 @@
+name: elasticsearch
+image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+description: Elasticsearch single-node search and analytics engine
+ports:
+  - "9200:9200"
+environment:
+  discovery.type: single-node
+  xpack.security.enabled: "false"
+  ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+data_dir: /usr/share/elasticsearch/data
+env_vars:
+  - ELASTICSEARCH_HOST=lerd-elasticsearch
+  - ELASTICSEARCH_PORT=9200
+  - ELASTICSEARCH_URL=http://lerd-elasticsearch:9200
+env_detect:
+  composer: elasticsearch/elasticsearch
+connection_url: http://127.0.0.1:9200

--- a/internal/config/presets/elasticsearch.yaml
+++ b/internal/config/presets/elasticsearch.yaml
@@ -8,6 +8,10 @@ environment:
   xpack.security.enabled: "false"
   ES_JAVA_OPTS: "-Xms512m -Xmx512m"
 data_dir: /usr/share/elasticsearch/data
+# Map host user 1:1 to container UID 1000 and chown the data dir to it
+# so node.lock + indices are writable in rootless podman.
+userns: keep-id:uid=1000,gid=0
+chown_data: true
 env_vars:
   - ELASTICSEARCH_HOST=lerd-elasticsearch
   - ELASTICSEARCH_PORT=9200

--- a/internal/config/presets/elasticvue.yaml
+++ b/internal/config/presets/elasticvue.yaml
@@ -1,0 +1,10 @@
+name: elasticvue
+image: docker.io/cars10/elasticvue:latest
+description: Elasticvue web UI for the lerd Elasticsearch service
+ports:
+  - "8083:8080"
+environment:
+  ELASTICVUE_CLUSTERS: '[{"name":"Lerd Elasticsearch","uri":"http://localhost:9200"}]'
+depends_on:
+  - elasticsearch
+dashboard: http://localhost:8083

--- a/internal/config/presets/memcached.yaml
+++ b/internal/config/presets/memcached.yaml
@@ -1,0 +1,11 @@
+name: memcached
+image: docker.io/library/memcached:1.6-alpine
+description: Memcached in-memory key/value cache
+ports:
+  - "11211:11211"
+env_vars:
+  - MEMCACHED_HOST=lerd-memcached
+  - MEMCACHED_PORT=11211
+env_detect:
+  key: MEMCACHED_HOST
+connection_url: memcached://127.0.0.1:11211

--- a/internal/config/presets/rabbitmq.yaml
+++ b/internal/config/presets/rabbitmq.yaml
@@ -1,0 +1,20 @@
+name: rabbitmq
+image: docker.io/library/rabbitmq:3-management-alpine
+description: RabbitMQ message broker with management UI
+ports:
+  - "5672:5672"
+  - "15672:15672"
+environment:
+  RABBITMQ_DEFAULT_USER: root
+  RABBITMQ_DEFAULT_PASS: lerd
+data_dir: /var/lib/rabbitmq
+env_vars:
+  - RABBITMQ_HOST=lerd-rabbitmq
+  - RABBITMQ_PORT=5672
+  - RABBITMQ_USER=root
+  - RABBITMQ_PASSWORD=lerd
+  - RABBITMQ_VHOST=/
+env_detect:
+  key: RABBITMQ_HOST
+dashboard: http://localhost:15672
+connection_url: amqp://root:lerd@127.0.0.1:5672/

--- a/internal/config/presets/rabbitmq.yaml
+++ b/internal/config/presets/rabbitmq.yaml
@@ -17,4 +17,7 @@ env_vars:
 env_detect:
   key: RABBITMQ_HOST
 dashboard: http://localhost:15672
+# Cowboy session cookie has no SameSite override, so iframe login fails.
+# Force the dashboard to open in a new tab to keep auth working.
+dashboard_external: true
 connection_url: amqp://root:lerd@127.0.0.1:5672/

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -18,6 +18,9 @@ func TestListPresets_IncludesShippedPresets(t *testing.T) {
 		"selenium":      false,
 		"stripe-mock":   false,
 		"mysql":         false,
+		"memcached":     false,
+		"rabbitmq":      false,
+		"elasticsearch": false,
 	}
 	for _, p := range presets {
 		if _, ok := want[p.Name]; ok {
@@ -83,6 +86,54 @@ func TestLoadPreset_PgAdmin(t *testing.T) {
 	}
 	if !foundFramingCfg {
 		t.Errorf("pgadmin preset must ship config_local.py clearing X_FRAME_OPTIONS for iframe embedding")
+	}
+}
+
+func TestLoadPreset_Memcached(t *testing.T) {
+	p, err := LoadPreset("memcached")
+	if err != nil {
+		t.Fatalf("LoadPreset(memcached) error = %v", err)
+	}
+	if p.Image == "" || len(p.Ports) != 1 || p.Ports[0] != "11211:11211" {
+		t.Errorf("memcached preset missing image or 11211:11211 port, got: %+v", p)
+	}
+	if p.DataDir != "" {
+		t.Errorf("memcached is in-memory and must not declare data_dir, got %q", p.DataDir)
+	}
+	if p.EnvDetect == nil || p.EnvDetect.Key != "MEMCACHED_HOST" {
+		t.Errorf("memcached env_detect should be key=MEMCACHED_HOST, got %+v", p.EnvDetect)
+	}
+}
+
+func TestLoadPreset_RabbitMQ(t *testing.T) {
+	p, err := LoadPreset("rabbitmq")
+	if err != nil {
+		t.Fatalf("LoadPreset(rabbitmq) error = %v", err)
+	}
+	if len(p.Ports) != 2 {
+		t.Errorf("rabbitmq should publish AMQP (5672) and management UI (15672), got %v", p.Ports)
+	}
+	if p.Dashboard == "" {
+		t.Errorf("rabbitmq should expose the management UI as dashboard")
+	}
+	if p.DataDir == "" {
+		t.Errorf("rabbitmq should persist /var/lib/rabbitmq for queue durability across restarts")
+	}
+}
+
+func TestLoadPreset_Elasticsearch(t *testing.T) {
+	p, err := LoadPreset("elasticsearch")
+	if err != nil {
+		t.Fatalf("LoadPreset(elasticsearch) error = %v", err)
+	}
+	if p.Environment["discovery.type"] != "single-node" {
+		t.Errorf("elasticsearch must run in single-node mode for local dev (skips production bootstrap checks), got %q", p.Environment["discovery.type"])
+	}
+	if p.Environment["xpack.security.enabled"] != "false" {
+		t.Errorf("elasticsearch must disable xpack security so apps can connect without TLS+auth in dev, got %q", p.Environment["xpack.security.enabled"])
+	}
+	if p.EnvDetect == nil || p.EnvDetect.Composer != "elasticsearch/elasticsearch" {
+		t.Errorf("elasticsearch env_detect should fire on composer elasticsearch/elasticsearch, got %+v", p.EnvDetect)
 	}
 }
 

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -21,6 +21,7 @@ func TestListPresets_IncludesShippedPresets(t *testing.T) {
 		"memcached":     false,
 		"rabbitmq":      false,
 		"elasticsearch": false,
+		"elasticvue":    false,
 	}
 	for _, p := range presets {
 		if _, ok := want[p.Name]; ok {
@@ -118,6 +119,38 @@ func TestLoadPreset_RabbitMQ(t *testing.T) {
 	}
 	if p.DataDir == "" {
 		t.Errorf("rabbitmq should persist /var/lib/rabbitmq for queue durability across restarts")
+	}
+}
+
+func TestLoadPreset_Elasticvue(t *testing.T) {
+	p, err := LoadPreset("elasticvue")
+	if err != nil {
+		t.Fatalf("LoadPreset(elasticvue) error = %v", err)
+	}
+	if len(p.DependsOn) != 1 || p.DependsOn[0] != "elasticsearch" {
+		t.Errorf("elasticvue should depend on elasticsearch, got %v", p.DependsOn)
+	}
+	if p.Dashboard == "" {
+		t.Errorf("elasticvue must expose its UI as dashboard")
+	}
+	if got := p.Environment["ELASTICVUE_CLUSTERS"]; got == "" {
+		t.Errorf("elasticvue must pre-configure the lerd ES cluster via ELASTICVUE_CLUSTERS")
+	}
+}
+
+func TestLoadPreset_ElasticsearchEnablesCors(t *testing.T) {
+	p, err := LoadPreset("elasticsearch")
+	if err != nil {
+		t.Fatalf("LoadPreset(elasticsearch) error = %v", err)
+	}
+	if p.Environment["http.cors.enabled"] != "true" {
+		t.Errorf("elasticsearch must enable CORS so the elasticvue browser SPA can reach it, got %q", p.Environment["http.cors.enabled"])
+	}
+	// The wildcard must be wrapped in literal quotes because ES parses env
+	// vars as YAML and a bare '*' becomes an alias token that crashes the
+	// SnakeYAML scanner on boot.
+	if p.Environment["http.cors.allow-origin"] != `"*"` {
+		t.Errorf(`elasticsearch must allow any origin for local dev (quoted to survive YAML parse), got %q`, p.Environment["http.cors.allow-origin"])
 	}
 }
 

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -120,6 +120,9 @@ func TestLoadPreset_RabbitMQ(t *testing.T) {
 	if p.DataDir == "" {
 		t.Errorf("rabbitmq should persist /var/lib/rabbitmq for queue durability across restarts")
 	}
+	if !p.DashboardExternal {
+		t.Errorf("rabbitmq must set dashboard_external because Cowboy's session cookie can't be carried by the iframe")
+	}
 }
 
 func TestLoadPreset_Elasticvue(t *testing.T) {
@@ -167,6 +170,12 @@ func TestLoadPreset_Elasticsearch(t *testing.T) {
 	}
 	if p.EnvDetect == nil || p.EnvDetect.Composer != "elasticsearch/elasticsearch" {
 		t.Errorf("elasticsearch env_detect should fire on composer elasticsearch/elasticsearch, got %+v", p.EnvDetect)
+	}
+	if p.Userns != "keep-id:uid=1000,gid=0" {
+		t.Errorf("elasticsearch must map host user to container UID 1000 via keep-id, got %q", p.Userns)
+	}
+	if !p.ChownData {
+		t.Errorf("elasticsearch must set chown_data so the host data dir is owned by the container UID at mount time")
 	}
 }
 

--- a/internal/podman/quadlet_embed_test.go
+++ b/internal/podman/quadlet_embed_test.go
@@ -270,6 +270,25 @@ func TestGenerateCustomQuadlet_DataDirDefaultsToZOnly(t *testing.T) {
 	}
 }
 
+func TestGenerateCustomQuadlet_EnvWithJSONPreservesQuotes(t *testing.T) {
+	svc := &config.CustomService{
+		Name:  "elasticvue",
+		Image: "docker.io/cars10/elasticvue:latest",
+		Environment: map[string]string{
+			"ELASTICVUE_CLUSTERS": `[{"name":"Lerd","uri":"http://localhost:9200"}]`,
+			"WILDCARD":            `"*"`,
+		},
+	}
+	out := GenerateCustomQuadlet(svc)
+	wantClusters := `Environment="ELASTICVUE_CLUSTERS=[{\"name\":\"Lerd\",\"uri\":\"http://localhost:9200\"}]"`
+	if !strings.Contains(out, wantClusters) {
+		t.Errorf("env value with JSON quotes must be wrapped + escaped (otherwise systemd strips inner quotes), got:\n%s", out)
+	}
+	if !strings.Contains(out, `Environment="WILDCARD=\"*\""`) {
+		t.Errorf("env value with quoted wildcard must round-trip, got:\n%s", out)
+	}
+}
+
 func TestGenerateCustomQuadlet_StopTimeout(t *testing.T) {
 	// Images like selenium/standalone-chromium hang for 30s+ on graceful
 	// shutdown. StopTimeout=5 bounds podman's SIGTERM-wait so systemctl stop

--- a/internal/podman/quadlet_embed_test.go
+++ b/internal/podman/quadlet_embed_test.go
@@ -238,6 +238,38 @@ func TestGenerateCustomQuadlet_NoShareHosts(t *testing.T) {
 	}
 }
 
+func TestGenerateCustomQuadlet_UsernsAndChownData(t *testing.T) {
+	svc := &config.CustomService{
+		Name:      "elasticsearch",
+		Image:     "docker.elastic.co/elasticsearch/elasticsearch:8.13.4",
+		DataDir:   "/usr/share/elasticsearch/data",
+		Userns:    "keep-id:uid=1000,gid=0",
+		ChownData: true,
+	}
+	out := GenerateCustomQuadlet(svc)
+	if !strings.Contains(out, "UserNS=keep-id:uid=1000,gid=0") {
+		t.Errorf("expected UserNS line when Userns set, got:\n%s", out)
+	}
+	if !strings.Contains(out, ":/usr/share/elasticsearch/data:z,U") {
+		t.Errorf("expected :z,U flags on data_dir mount when ChownData=true, got:\n%s", out)
+	}
+}
+
+func TestGenerateCustomQuadlet_DataDirDefaultsToZOnly(t *testing.T) {
+	svc := &config.CustomService{
+		Name:    "postgres-test",
+		Image:   "docker.io/library/postgres:16",
+		DataDir: "/var/lib/postgresql/data",
+	}
+	out := GenerateCustomQuadlet(svc)
+	if !strings.Contains(out, ":/var/lib/postgresql/data:z\n") {
+		t.Errorf("data_dir mount must default to :z (no ,U) when ChownData unset, got:\n%s", out)
+	}
+	if strings.Contains(out, "UserNS=") {
+		t.Errorf("must not emit UserNS line when Userns unset, got:\n%s", out)
+	}
+}
+
 func TestGenerateCustomQuadlet_StopTimeout(t *testing.T) {
 	// Images like selenium/standalone-chromium hang for 30s+ on graceful
 	// shutdown. StopTimeout=5 bounds podman's SIGTERM-wait so systemctl stop

--- a/internal/podman/quadlet_generate.go
+++ b/internal/podman/quadlet_generate.go
@@ -59,7 +59,11 @@ func GenerateCustomQuadlet(svc *config.CustomService) string {
 	}
 
 	for k, v := range svc.Environment {
-		fmt.Fprintf(&b, "Environment=%s=%s\n", k, v)
+		// systemd splits Environment= on whitespace and strips unescaped
+		// double quotes, so JSON / quoted-wildcard values get mangled.
+		// Wrap the whole pair and escape inner quotes to preserve them.
+		escaped := strings.ReplaceAll(v, `"`, `\"`)
+		fmt.Fprintf(&b, "Environment=\"%s=%s\"\n", k, escaped)
 	}
 
 	if svc.Exec != "" {

--- a/internal/podman/quadlet_generate.go
+++ b/internal/podman/quadlet_generate.go
@@ -38,7 +38,15 @@ func GenerateCustomQuadlet(svc *config.CustomService) string {
 
 	if svc.DataDir != "" {
 		hostDir := config.DataSubDir(svc.Name)
-		fmt.Fprintf(&b, "Volume=%s:%s:z\n", hostDir, svc.DataDir)
+		flags := "z"
+		if svc.ChownData {
+			flags += ",U"
+		}
+		fmt.Fprintf(&b, "Volume=%s:%s:%s\n", hostDir, svc.DataDir, flags)
+	}
+
+	if svc.Userns != "" {
+		fmt.Fprintf(&b, "UserNS=%s\n", svc.Userns)
 	}
 
 	for _, f := range config.PresetFiles(svc.Preset) {

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -2146,7 +2146,7 @@ function lerdApp() {
     linkModal: { open: false, currentDir: '', dirs: [], loading: false, linking: false, error: '', logs: [] },
     presets: [],
     presetModal: { open: false, loading: false },
-    presetSuggestions: { mysql: 'phpmyadmin', postgres: 'pgadmin', mongo: 'mongo-express' },
+    presetSuggestions: { mysql: 'phpmyadmin', postgres: 'pgadmin', mongo: 'mongo-express', elasticsearch: 'elasticvue' },
     dismissedPresetSuggestions: JSON.parse(localStorage.getItem('lerd-dismissed-preset-suggestions') || '[]'),
     phpVersions: [],
     nodeVersions: [],
@@ -2404,6 +2404,10 @@ function lerdApp() {
       mongo: 'MongoDB',
       'mongo-express': 'Mongo Express',
       'stripe-mock': 'Stripe Mock',
+      elasticsearch: 'Elasticsearch',
+      elasticvue: 'Elasticvue',
+      memcached: 'Memcached',
+      rabbitmq: 'RabbitMQ',
     },
     serviceLabel(svc) {
       if (!svc || !svc.name) return '';
@@ -3348,6 +3352,7 @@ function lerdApp() {
         mailhog: icons.mail,
         meilisearch: icons.search,
         elasticsearch: icons.search,
+        elasticvue: icons.search,
         typesense: icons.search,
         rustfs: icons.storage,
         minio: icons.storage,

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -3253,10 +3253,17 @@ function lerdApp() {
     },
 
     get dashboardServices() {
-      return this.services.filter(s => s.dashboard && s.status === 'active');
+      // External-dashboard services (rabbitmq) skip the sidebar icon since
+      // they open in a new tab anyway. The detail panel still surfaces the
+      // dashboard URL so they remain discoverable.
+      return this.services.filter(s => s.dashboard && s.status === 'active' && !s.dashboard_external);
     },
 
     openDashboardIframe(svc) {
+      if (svc && svc.dashboard_external && svc.dashboard) {
+        window.open(svc.dashboard, '_blank', 'noopener,noreferrer');
+        return;
+      }
       if (this.dashboardSvc && this.dashboardSvc.name === svc.name) {
         this.dashboardSvc = null;
         location.hash = this.tab;
@@ -3548,6 +3555,10 @@ function lerdApp() {
       if (!adminSvc) return;
       if (adminSvc.status !== 'active') {
         await this.toggleService(adminSvc, 'start');
+      }
+      if (adminSvc.dashboard_external) {
+        window.open(adminSvc.dashboard, '_blank', 'noopener,noreferrer');
+        return;
       }
       if (adminSvc.dashboard) {
         const fresh = this.services.find(s => s.name === adminSvc.name) || adminSvc;

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -751,6 +751,7 @@ type ServiceResponse struct {
 	Version            string            `json:"version,omitempty"`
 	EnvVars            map[string]string `json:"env_vars"`
 	Dashboard          string            `json:"dashboard,omitempty"`
+	DashboardExternal  bool              `json:"dashboard_external,omitempty"`
 	ConnectionURL      string            `json:"connection_url,omitempty"`
 	Custom             bool              `json:"custom,omitempty"`
 	SiteCount          int               `json:"site_count"`
@@ -872,18 +873,19 @@ func buildServicesList() []ServiceResponse {
 			}
 		}
 		services = append(services, ServiceResponse{
-			Name:          svc.Name,
-			Status:        status,
-			Version:       podman.ServiceVersionLabel(svc.Image),
-			EnvVars:       envMap,
-			Dashboard:     svc.Dashboard,
-			ConnectionURL: svc.ConnectionURL,
-			Custom:        true,
-			SiteCount:     countSitesUsingService(svc.Name),
-			SiteDomains:   sitesUsingService(svc.Name),
-			Pinned:        config.ServiceIsPinned(svc.Name),
-			Paused:        config.ServiceIsPaused(svc.Name),
-			DependsOn:     svc.DependsOn,
+			Name:              svc.Name,
+			Status:            status,
+			Version:           podman.ServiceVersionLabel(svc.Image),
+			EnvVars:           envMap,
+			Dashboard:         svc.Dashboard,
+			DashboardExternal: svc.DashboardExternal,
+			ConnectionURL:     svc.ConnectionURL,
+			Custom:            true,
+			SiteCount:         countSitesUsingService(svc.Name),
+			SiteDomains:       sitesUsingService(svc.Name),
+			Pinned:            config.ServiceIsPinned(svc.Name),
+			Paused:            config.ServiceIsPaused(svc.Name),
+			DependsOn:         svc.DependsOn,
 		})
 	}
 	for _, siteName := range listActiveQueueWorkers() {


### PR DESCRIPTION
## Summary

- New `memcached` preset (`memcached:1.6-alpine`, no auth, no persistent data, detected via `MEMCACHED_HOST` in `.env`). For older Laravel / Drupal / WordPress projects.
- New `rabbitmq` preset (`rabbitmq:3-management-alpine` with AMQP on 5672 and the management UI on 15672, default creds `root` / `lerd`, persistent `/var/lib/rabbitmq` so queues survive restarts, detected via `RABBITMQ_HOST`). Broadens worker support beyond Redis.
- New `elasticsearch` preset (`8.13.4` single-node with `xpack.security.enabled=false` so apps connect without TLS + auth in dev, 512m heap, persistent data dir, detected via composer `elasticsearch/elasticsearch`).

Tests extend `TestListPresets_IncludesShippedPresets` and add focused load tests for each: memcached must not declare `data_dir`, rabbitmq must persist `/var/lib/rabbitmq`, elasticsearch must run `single-node` with security off. Docs page gets the three new rows plus default credentials.