### PR TITLE
feat(systemd): integrate go-systemd for DBus calls, idle-aware watcher, notify readiness

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -21,6 +21,7 @@ import (
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteops"
+	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/geodro/lerd/internal/ui"
 	"github.com/geodro/lerd/internal/version"
 	"github.com/geodro/lerd/internal/watcher"
@@ -472,6 +473,11 @@ func newWatchCmd() *cobra.Command {
 					fmt.Printf("[WARN] site file watcher: %v\n", err)
 				}
 			}()
+
+			// Initial setup and goroutines are live; tell systemd we're
+			// ready so Type=notify unit starts unblock for any dependent
+			// startup sequence (lerd-ui, lerd-tray, test harnesses).
+			lerdSystemd.NotifyReady()
 
 			return watcher.Watch(cfg.ParkedDirectories, func(projectPath string) {
 				fmt.Printf("New project detected: %s\n", projectPath)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,10 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Web UI cache poll backs off when the desktop session is idle or locked** (#255). The `podman ps` cache that drives the dashboard already drops from 15 s to 60 s when no tab is visible. It now also drops to 60 s while at least one tab is visible but systemd-logind reports the session as idle or locked, so a focused tab on an unattended laptop stops paying the per-15 s subprocess cost. Recomputes on every transition via a 30 s logind poll. Linux only; macOS keeps the visibility-only behavior via the existing `SessionIsIdleOrLocked` stub.
+
 ---
 
 ## [1.18.0] — 2026-04-25

--- a/docs/features/web-ui.md
+++ b/docs/features/web-ui.md
@@ -12,6 +12,8 @@ The `.localhost` TLD resolves to `127.0.0.1` natively on all modern systems, no 
 
 The dashboard opens a single WebSocket to `/api/ws` on load and receives state changes as they happen. No polling, no stale panels. Every surface that mutates lerd state (browser actions, `lerd` CLI commands, the MCP server, the file watcher) pushes a fresh snapshot to every connected tab within about 200 ms. If the WebSocket ever drops (e.g. `lerd-ui` restart), the dashboard falls back to a 5 s polling loop and reconnects in the background with exponential backoff, so a restart is transparent.
 
+Behind the scenes a background container poll runs every 15 s when at least one tab is visible and the desktop session is active, and drops to 60 s otherwise (every tab hidden, or the session reported idle or locked by systemd-logind). Battery-aware: a focused tab on a locked laptop still falls back to the slow cadence.
+
 ## Install as an app
 
 The dashboard is a Progressive Web App (PWA). You can install it as a standalone desktop app from any Chromium-based browser (Chrome, Brave, Edge):

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -6,7 +6,7 @@
 
 |  | Lerd | Laravel Herd |
 |---|---|---|
-| Platforms | Linux, macOS | macOS, Windows (WSL2) |
+| Platforms | Linux (systemd), macOS | macOS, Windows (WSL2) |
 | License | Open source (MIT) | Proprietary, freemium (Herd Pro subscription) |
 | PHP runtime | Rootless Podman containers | Native binaries on macOS, WSL on Windows |
 | PHP versions | 8.1, 8.2, 8.3, 8.4, 8.5 (shared FPM containers) | 7.4 through 8.5 (native) |
@@ -46,7 +46,7 @@ You trade a sliver of native performance (Podman Machine on macOS adds overhead 
 
 |  | Lerd | Laravel Sail |
 |---|---|---|
-| Platforms | Linux, macOS | Linux, macOS, Windows |
+| Platforms | Linux (systemd), macOS | Linux, macOS, Windows |
 | License | Open source (MIT) | Open source (MIT) |
 | Container runtime | Rootless Podman | Docker Desktop / Orbstack / Colima |
 | Architecture | One shared nginx + PHP-FPM + services across every site | Per-project Docker Compose stack |
@@ -85,7 +85,7 @@ See [Importing from Laravel Sail](/usage/import-sail) for details.
 
 |  | Lerd | ddev |
 |---|---|---|
-| Platforms | Linux, macOS | Linux, macOS, Windows |
+| Platforms | Linux (systemd), macOS | Linux, macOS, Windows |
 | License | Open source (MIT) | Open source (Apache 2.0) |
 | Container runtime | Rootless Podman | Docker / Orbstack / Colima |
 | Architecture | Shared nginx + PHP-FPM across all projects | Per-project containers behind a shared reverse proxy |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,6 +2,12 @@
 
 ## Linux
 
+::: warning Requires systemd
+Lerd runs every container as a Podman Quadlet and every worker as a systemd user service, so a systemd-based distro is required. OpenRC (Gentoo, Artix-openrc, Alpine), runit (Void, Artix-runit), s6, and sysvinit-based distros (Devuan) are not supported.
+
+Tested and known-good: Ubuntu, Fedora, Arch, Debian, Mint, Pop!_OS, openSUSE, CachyOS, Omarchy. Any systemd distro should work.
+:::
+
 ### One-line installer (recommended)
 
 ::: code-group

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -2,6 +2,10 @@
 
 All containers join the rootless Podman network `lerd`. Communication between Nginx and PHP-FPM uses container names as hostnames.
 
+::: info Platform requirement
+On Linux, lerd requires systemd. Every container runs as a Podman Quadlet (systemd unit), every worker as a systemd user service, and the autostart flow uses systemd user linger. Non-systemd distros (OpenRC, runit, s6, sysvinit) are not supported. On macOS the same responsibilities are handled by launchd, which lerd manages automatically.
+:::
+
 ## Request flow
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
+	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -41,6 +42,7 @@ require (
 	github.com/getlantern/hidden v0.0.0-20190325191715-f02dbb02be55 // indirect
 	github.com/getlantern/ops v0.0.0-20190325191751-d70cb0d6f85f // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8
 github.com/charmbracelet/x/termios v0.1.1/go.mod h1:rB7fnv1TgOPOyyKRJ9o+AsTU/vK5WHJ2ivHeut/Pcwo=
 github.com/charmbracelet/x/xpty v0.1.2 h1:Pqmu4TEJ8KeA9uSkISKMU3f+C1F6OGBn8ABuGlqCbtI=
 github.com/charmbracelet/x/xpty v0.1.2/go.mod h1:XK2Z0id5rtLWcpeNiMYBccNNBrP2IJnzHI0Lq13Xzq4=
+github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
+github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -81,6 +83,8 @@ github.com/getlantern/systray v1.2.2 h1:dCEHtfmvkJG7HZ8lS/sLklTH4RKUcIsKrAD9sTho
 github.com/getlantern/systray v1.2.2/go.mod h1:pXFOI1wwqwYXEhLPm9ZGjS2u/vVELeIgNMY5HvhHhcE=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -501,7 +501,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 
 	step("Writing watcher service")
 	if content, err := lerdSystemd.GetUnit("lerd-watcher"); err == nil {
-		if err := services.Mgr.WriteServiceUnit("lerd-watcher", content); err != nil {
+		if err := writeUserServiceWithReload("lerd-watcher", content); err != nil {
 			return err
 		}
 		if autostartOn {
@@ -522,7 +522,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 
 	step("Writing UI service")
 	if content, err := lerdSystemd.GetUnit("lerd-ui"); err == nil {
-		if err := services.Mgr.WriteServiceUnit("lerd-ui", content); err != nil {
+		if err := writeUserServiceWithReload("lerd-ui", content); err != nil {
 			return err
 		}
 		if autostartOn {
@@ -543,7 +543,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 
 	step("Writing tray service")
 	if content, err := lerdSystemd.GetUnit("lerd-tray"); err == nil {
-		if err := services.Mgr.WriteServiceUnit("lerd-tray", content); err != nil {
+		if err := writeUserServiceWithReload("lerd-tray", content); err != nil {
 			return err
 		}
 		if autostartOn {
@@ -629,6 +629,23 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	fmt.Println("\nLerd installation complete!")
 	fmt.Println("\n  Dashboard: \033[96mhttp://lerd.localhost\033[0m")
 	fmt.Println("  Terminal:  \033[96mlerd tui\033[0m")
+	return nil
+}
+
+// writeUserServiceWithReload writes a user service unit file and reloads
+// systemd when the on-disk content changed, so the next Start/Restart
+// picks up the new directives instead of the cached pre-write copy.
+func writeUserServiceWithReload(name, content string) error {
+	changed, err := services.Mgr.WriteServiceUnitIfChanged(name, content)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	if err := services.Mgr.DaemonReload(); err != nil {
+		fmt.Printf("    WARN: daemon-reload after %s: %v\n", name, err)
+	}
 	return nil
 }
 

--- a/internal/cli/install_writeunit_test.go
+++ b/internal/cli/install_writeunit_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/geodro/lerd/internal/services"
+)
+
+type fakeServiceMgr struct {
+	calls        []string
+	writeChanged bool
+	writeErr     error
+	reloadErr    error
+}
+
+func (f *fakeServiceMgr) WriteServiceUnit(string, string) error { return nil }
+func (f *fakeServiceMgr) WriteServiceUnitIfChanged(name, _ string) (bool, error) {
+	f.calls = append(f.calls, "write:"+name)
+	return f.writeChanged, f.writeErr
+}
+func (f *fakeServiceMgr) RemoveServiceUnit(string) error                       { return nil }
+func (f *fakeServiceMgr) WriteTimerUnitIfChanged(string, string) (bool, error) { return false, nil }
+func (f *fakeServiceMgr) RemoveTimerUnit(string) error                         { return nil }
+func (f *fakeServiceMgr) ListTimerUnits(string) []string                       { return nil }
+func (f *fakeServiceMgr) ListServiceUnits(string) []string                     { return nil }
+func (f *fakeServiceMgr) WriteContainerUnit(string, string) error              { return nil }
+func (f *fakeServiceMgr) ContainerUnitInstalled(string) bool                   { return false }
+func (f *fakeServiceMgr) RemoveContainerUnit(string) error                     { return nil }
+func (f *fakeServiceMgr) ListContainerUnits(string) []string                   { return nil }
+func (f *fakeServiceMgr) DaemonReload() error {
+	f.calls = append(f.calls, "reload")
+	return f.reloadErr
+}
+func (f *fakeServiceMgr) Start(string) error                { return nil }
+func (f *fakeServiceMgr) Stop(string) error                 { return nil }
+func (f *fakeServiceMgr) Restart(string) error              { return nil }
+func (f *fakeServiceMgr) Enable(string) error               { return nil }
+func (f *fakeServiceMgr) Disable(string) error              { return nil }
+func (f *fakeServiceMgr) IsActive(string) bool              { return false }
+func (f *fakeServiceMgr) IsEnabled(string) bool             { return false }
+func (f *fakeServiceMgr) UnitStatus(string) (string, error) { return "", nil }
+
+func swapMgr(t *testing.T, fake services.ServiceManager) {
+	t.Helper()
+	prev := services.Mgr
+	services.Mgr = fake
+	t.Cleanup(func() { services.Mgr = prev })
+}
+
+func TestWriteUserServiceWithReload_reloadsWhenChanged(t *testing.T) {
+	fake := &fakeServiceMgr{writeChanged: true}
+	swapMgr(t, fake)
+
+	if err := writeUserServiceWithReload("lerd-ui", "x"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"write:lerd-ui", "reload"}
+	if !equalStrings(fake.calls, want) {
+		t.Fatalf("call order: got %v want %v", fake.calls, want)
+	}
+}
+
+func TestWriteUserServiceWithReload_skipsReloadWhenUnchanged(t *testing.T) {
+	fake := &fakeServiceMgr{writeChanged: false}
+	swapMgr(t, fake)
+
+	if err := writeUserServiceWithReload("lerd-ui", "x"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"write:lerd-ui"}
+	if !equalStrings(fake.calls, want) {
+		t.Fatalf("call order: got %v want %v", fake.calls, want)
+	}
+}
+
+func TestWriteUserServiceWithReload_returnsWriteError(t *testing.T) {
+	wantErr := errors.New("boom")
+	fake := &fakeServiceMgr{writeErr: wantErr}
+	swapMgr(t, fake)
+
+	if err := writeUserServiceWithReload("lerd-ui", "x"); !errors.Is(err, wantErr) {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+	if len(fake.calls) != 1 || fake.calls[0] != "write:lerd-ui" {
+		t.Fatalf("expected only the write call, got %v", fake.calls)
+	}
+}
+
+func TestWriteUserServiceWithReload_swallowsReloadError(t *testing.T) {
+	fake := &fakeServiceMgr{writeChanged: true, reloadErr: errors.New("dbus down")}
+	swapMgr(t, fake)
+
+	if err := writeUserServiceWithReload("lerd-ui", "x"); err != nil {
+		t.Fatalf("reload errors should not propagate, got %v", err)
+	}
+	want := []string{"write:lerd-ui", "reload"}
+	if !equalStrings(fake.calls, want) {
+		t.Fatalf("call order: got %v want %v", fake.calls, want)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -624,7 +624,9 @@ func migrateServiceUnits() {
 	}
 }
 
-// ensureServiceQuadlet writes the unit file for a known service and reloads the service manager.
+// ensureServiceQuadlet writes the unit file for a known service and reloads
+// the service manager only when the on-disk quadlet actually changed, so a
+// migrate-all pass over unchanged services skips redundant reloads entirely.
 func ensureServiceQuadlet(name string) error {
 	quadletName := "lerd-" + name
 	content, err := podman.GetQuadletTemplate(quadletName + ".container")
@@ -650,10 +652,11 @@ func ensureServiceQuadlet(name string) error {
 	// WriteQuadletDiff writes the .container file to QuadletDir (needed on macOS
 	// so quadletImage() can resolve the image for pre-pull in startRestoredServices)
 	// and calls AfterQuadletWriteFn (writes the launchd plist on macOS).
-	if _, err := podman.WriteQuadletDiff(quadletName, content); err != nil {
+	changed, err := podman.WriteQuadletDiff(quadletName, content)
+	if err != nil {
 		return fmt.Errorf("writing unit for %s: %w", name, err)
 	}
-	return podman.DaemonReloadFn()
+	return podman.DaemonReloadIfNeeded(changed)
 }
 
 // ensureCustomServiceQuadlet defers to serviceops so the CLI and the MCP

--- a/internal/cli/services_quadlet_test.go
+++ b/internal/cli/services_quadlet_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+func swapDaemonReload(t *testing.T) *int {
+	t.Helper()
+	count := new(int)
+	orig := podman.DaemonReloadFn
+	t.Cleanup(func() { podman.DaemonReloadFn = orig })
+	podman.DaemonReloadFn = func() error {
+		*count++
+		return nil
+	}
+	return count
+}
+
+func setIsolatedXDG(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+}
+
+func TestEnsureServiceQuadlet_reloadsOnlyWhenContentChanges(t *testing.T) {
+	setIsolatedXDG(t)
+	count := swapDaemonReload(t)
+
+	if err := ensureServiceQuadlet("mysql"); err != nil {
+		t.Fatalf("first ensureServiceQuadlet: %v", err)
+	}
+	if *count != 1 {
+		t.Errorf("first call should reload exactly once, got %d", *count)
+	}
+
+	if err := ensureServiceQuadlet("mysql"); err != nil {
+		t.Fatalf("second ensureServiceQuadlet: %v", err)
+	}
+	if *count != 1 {
+		t.Errorf("second call with unchanged content must not reload again, got %d total", *count)
+	}
+}
+
+func TestEnsureServiceQuadlet_retriesAfterFailedReload(t *testing.T) {
+	setIsolatedXDG(t)
+
+	failures := 0
+	orig := podman.DaemonReloadFn
+	t.Cleanup(func() { podman.DaemonReloadFn = orig })
+	podman.DaemonReloadFn = func() error {
+		failures++
+		return errors.New("dbus down")
+	}
+
+	if err := ensureServiceQuadlet("mysql"); err == nil {
+		t.Fatalf("expected reload error on first call")
+	}
+	if failures != 1 {
+		t.Fatalf("expected 1 reload attempt, got %d", failures)
+	}
+
+	successes := 0
+	podman.DaemonReloadFn = func() error {
+		successes++
+		return nil
+	}
+
+	if err := ensureServiceQuadlet("mysql"); err != nil {
+		t.Fatalf("retry should succeed, got %v", err)
+	}
+	if successes != 1 {
+		t.Errorf("retry must reload exactly once even though content is unchanged, got %d", successes)
+	}
+
+	if err := ensureServiceQuadlet("mysql"); err != nil {
+		t.Fatalf("third call: %v", err)
+	}
+	if successes != 1 {
+		t.Errorf("third call with unchanged content and pending cleared must not reload, got %d", successes)
+	}
+}
+
+func TestEnsureServiceQuadlet_reloadsAgainWhenImageOverrideChanges(t *testing.T) {
+	setIsolatedXDG(t)
+	count := swapDaemonReload(t)
+
+	if err := ensureServiceQuadlet("mysql"); err != nil {
+		t.Fatalf("first ensureServiceQuadlet: %v", err)
+	}
+	if *count != 1 {
+		t.Fatalf("first call should reload, got %d", *count)
+	}
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	svc := cfg.Services["mysql"]
+	svc.Image = "docker.io/library/mysql:8.4"
+	cfg.Services["mysql"] = svc
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	if err := ensureServiceQuadlet("mysql"); err != nil {
+		t.Fatalf("after image swap ensureServiceQuadlet: %v", err)
+	}
+	if *count != 2 {
+		t.Errorf("changed image should trigger a second reload, got %d total", *count)
+	}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -507,6 +507,12 @@ func runRollback() error {
 		}
 	}
 
+	// Old install daemon-reloads before WriteServiceUnit, so a leftover
+	// Type=notify on disk pins the cache and the post-write Restart blocks
+	// on sd_notify(READY=1) which the old binary never sends. Strip it so
+	// the cache picks up Type=simple immediately.
+	prepUserUnitsForRollback("lerd-ui.service", "lerd-watcher.service")
+
 	fmt.Printf("\nRolled back to v%s — applying infrastructure changes...\n\n", prevVersion)
 
 	// Re-exec the new binary with `install`, same as a normal update.
@@ -515,4 +521,37 @@ func runRollback() error {
 	installCmd.Stderr = os.Stderr
 	installCmd.Stdin = os.Stdin
 	return installCmd.Run()
+}
+
+// prepUserUnitsForRollback strips any "Type=notify" line from the named
+// systemd user unit files on disk so the rolled-back binary's install
+// flow does not restart them under a notify cache the old binary cannot
+// satisfy.
+func prepUserUnitsForRollback(units ...string) {
+	for _, name := range units {
+		path := filepath.Join(config.SystemdUserDir(), name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		stripped := stripTypeNotify(string(data))
+		if string(data) == stripped {
+			continue
+		}
+		_ = os.WriteFile(path, []byte(stripped), 0644)
+	}
+}
+
+// stripTypeNotify removes any line whose trimmed content is exactly
+// "Type=notify" from a systemd unit file body.
+func stripTypeNotify(content string) string {
+	lines := strings.Split(content, "\n")
+	out := lines[:0]
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "Type=notify" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
 }

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -426,3 +426,77 @@ func TestUpdateCmd_mutuallyExclusive(t *testing.T) {
 		t.Fatal("expected error when both --beta and --rollback are set, got nil")
 	}
 }
+
+// ── stripTypeNotify ────────────────────────────────────────────────────────
+
+func TestStripTypeNotify_removesLineWithSurroundingContext(t *testing.T) {
+	in := "[Service]\nType=notify\nExecStart=/bin/x\nRestart=on-failure\n"
+	want := "[Service]\nExecStart=/bin/x\nRestart=on-failure\n"
+	if got := stripTypeNotify(in); got != want {
+		t.Errorf("stripTypeNotify:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestStripTypeNotify_ignoresWhitespaceVariants(t *testing.T) {
+	in := "[Service]\n  Type=notify  \nExecStart=/bin/x\n"
+	want := "[Service]\nExecStart=/bin/x\n"
+	if got := stripTypeNotify(in); got != want {
+		t.Errorf("stripTypeNotify did not strip whitespace-padded line:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestStripTypeNotify_doesNotTouchOtherDirectives(t *testing.T) {
+	in := "[Service]\nType=simple\nExecStart=/bin/x\n# Type=notify in a comment\n"
+	if got := stripTypeNotify(in); got != in {
+		t.Errorf("stripTypeNotify changed unrelated content:\n got %q\nwant %q", got, in)
+	}
+}
+
+func TestStripTypeNotify_noOpWhenAbsent(t *testing.T) {
+	in := "[Service]\nExecStart=/bin/x\n"
+	if got := stripTypeNotify(in); got != in {
+		t.Errorf("stripTypeNotify changed input without Type=notify:\n got %q\nwant %q", got, in)
+	}
+}
+
+// ── prepUserUnitsForRollback ───────────────────────────────────────────────
+
+func TestPrepUserUnitsForRollback_rewritesOnlyChangedFiles(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	dir := filepath.Join(tmp, "systemd", "user")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	withNotify := "[Service]\nType=notify\nExecStart=/bin/x\n"
+	withoutNotify := "[Service]\nExecStart=/bin/y\n"
+
+	uiPath := filepath.Join(dir, "lerd-ui.service")
+	watcherPath := filepath.Join(dir, "lerd-watcher.service")
+	if err := os.WriteFile(uiPath, []byte(withNotify), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(watcherPath, []byte(withoutNotify), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	prepUserUnitsForRollback("lerd-ui.service", "lerd-watcher.service")
+
+	gotUI, _ := os.ReadFile(uiPath)
+	if string(gotUI) != "[Service]\nExecStart=/bin/x\n" {
+		t.Errorf("lerd-ui.service was not stripped: %q", gotUI)
+	}
+	gotWatcher, _ := os.ReadFile(watcherPath)
+	if string(gotWatcher) != withoutNotify {
+		t.Errorf("lerd-watcher.service must not be rewritten when unchanged: %q", gotWatcher)
+	}
+}
+
+func TestPrepUserUnitsForRollback_skipsMissingFiles(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	prepUserUnitsForRollback("lerd-ui.service")
+}

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -6,11 +6,34 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/systemd"
 )
+
+// quadletReloadPending records that a previous DaemonReloadIfNeeded call
+// failed without being retried. The next caller forces a reload even when
+// nothing else changed so a transient DBus failure does not leave
+// systemd's cache stale until an external trigger heals it.
+var quadletReloadPending atomic.Bool
+
+// DaemonReloadIfNeeded reloads systemd when the caller wrote new quadlet
+// content (changed=true) or when a previous reload failed and was never
+// retried. Failures set a sticky flag so the next caller forces the
+// retry; success clears it.
+func DaemonReloadIfNeeded(changed bool) error {
+	if !changed && !quadletReloadPending.Load() {
+		return nil
+	}
+	if err := DaemonReloadFn(); err != nil {
+		quadletReloadPending.Store(true)
+		return err
+	}
+	quadletReloadPending.Store(false)
+	return nil
+}
 
 // WriteQuadlet writes a Podman quadlet container unit file. Before writing
 // it applies BindForLAN to rewrite PublishPort= lines according to the

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/systemd"
 )
 
 // WriteQuadlet writes a Podman quadlet container unit file. Before writing
@@ -102,8 +102,14 @@ var UnitLifecycle interface {
 	UnitStatus(name string) (string, error)
 }
 
-// DaemonReload runs systemctl --user daemon-reload.
+// DaemonReload runs the equivalent of systemctl --user daemon-reload.
+// On Linux it goes through systemd DBus. On macOS the DBus stub returns
+// a sentinel and we fall through to the historical shell-out so launchd
+// users still get the legacy path (a no-op for non-systemd systems).
 func DaemonReload() error {
+	if err := systemd.DBusDaemonReload(); err == nil {
+		return nil
+	}
 	cmd := exec.Command("systemctl", "--user", "daemon-reload")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -140,11 +146,8 @@ func StartUnit(name string) error {
 		}
 		return err
 	}
-	_ = exec.Command("systemctl", "--user", "reset-failed", name).Run()
-	cmd := exec.Command("systemctl", "--user", "start", name)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("start %s failed: %w\n%s", name, err, out)
+	if err := systemd.DBusStartUnit(name); err != nil {
+		return err
 	}
 	notifyUnitChange(name)
 	return nil
@@ -159,13 +162,9 @@ func StopUnit(name string) error {
 		}
 		return err
 	}
-	cmd := exec.Command("systemctl", "--user", "stop", name)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("stop %s failed: %w\n%s", name, err, out)
+	if err := systemd.DBusStopUnit(name); err != nil {
+		return err
 	}
-	// Clear any failed state so the unit shows as inactive rather than failed.
-	_ = exec.Command("systemctl", "--user", "reset-failed", name).Run()
 	notifyUnitChange(name)
 	return nil
 }
@@ -179,10 +178,8 @@ func RestartUnit(name string) error {
 		}
 		return err
 	}
-	cmd := exec.Command("systemctl", "--user", "restart", name)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("restart %s failed: %w\n%s", name, err, out)
+	if err := systemd.DBusRestartUnit(name); err != nil {
+		return err
 	}
 	notifyUnitChange(name)
 	return nil
@@ -240,13 +237,9 @@ func UnitStatus(name string) (string, error) {
 	if UnitLifecycle != nil {
 		return UnitLifecycle.UnitStatus(name)
 	}
-	cmd := exec.Command("systemctl", "--user", "is-active", name)
-	out, err := cmd.Output()
-	status := strings.TrimSpace(string(out))
-	if status == "" {
-		if err != nil {
-			return "unknown", nil
-		}
+	state := systemd.DBusActiveState(name)
+	if state == "" {
+		return "unknown", nil
 	}
-	return status, nil
+	return state, nil
 }

--- a/internal/podman/quadlet_reload_test.go
+++ b/internal/podman/quadlet_reload_test.go
@@ -1,0 +1,101 @@
+package podman
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDaemonReloadIfNeeded_skipsWhenUnchangedAndNotPending(t *testing.T) {
+	resetReloadState(t)
+	count := installCountingReload(t, nil)
+
+	if err := DaemonReloadIfNeeded(false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *count != 0 {
+		t.Errorf("no reload expected, got %d", *count)
+	}
+}
+
+func TestDaemonReloadIfNeeded_reloadsWhenChanged(t *testing.T) {
+	resetReloadState(t)
+	count := installCountingReload(t, nil)
+
+	if err := DaemonReloadIfNeeded(true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if *count != 1 {
+		t.Errorf("expected 1 reload, got %d", *count)
+	}
+	if quadletReloadPending.Load() {
+		t.Errorf("pending flag must be cleared after a successful reload")
+	}
+}
+
+func TestDaemonReloadIfNeeded_setsPendingOnFailure(t *testing.T) {
+	resetReloadState(t)
+	wantErr := errors.New("dbus down")
+	count := installCountingReload(t, wantErr)
+
+	if err := DaemonReloadIfNeeded(true); !errors.Is(err, wantErr) {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+	if *count != 1 {
+		t.Errorf("expected 1 reload attempt, got %d", *count)
+	}
+	if !quadletReloadPending.Load() {
+		t.Errorf("pending flag must be set after a failed reload")
+	}
+}
+
+func TestDaemonReloadIfNeeded_retriesPendingEvenWhenUnchanged(t *testing.T) {
+	resetReloadState(t)
+	wantErr := errors.New("dbus down")
+
+	failCount := installCountingReload(t, wantErr)
+	if err := DaemonReloadIfNeeded(true); !errors.Is(err, wantErr) {
+		t.Fatalf("first call err: got %v want %v", err, wantErr)
+	}
+	if !quadletReloadPending.Load() {
+		t.Fatalf("pending must be set after the failure")
+	}
+	if *failCount != 1 {
+		t.Fatalf("first attempt count: got %d want 1", *failCount)
+	}
+
+	okCount := installCountingReload(t, nil)
+	if err := DaemonReloadIfNeeded(false); err != nil {
+		t.Fatalf("retry should succeed, got %v", err)
+	}
+	if *okCount != 1 {
+		t.Errorf("retry must reload even with changed=false, got %d", *okCount)
+	}
+	if quadletReloadPending.Load() {
+		t.Errorf("pending must clear after a successful retry")
+	}
+
+	if err := DaemonReloadIfNeeded(false); err != nil {
+		t.Fatalf("third call err: %v", err)
+	}
+	if *okCount != 1 {
+		t.Errorf("third call should be a no-op, got %d", *okCount)
+	}
+}
+
+func resetReloadState(t *testing.T) {
+	t.Helper()
+	prev := quadletReloadPending.Swap(false)
+	t.Cleanup(func() { quadletReloadPending.Store(prev) })
+}
+
+func installCountingReload(t *testing.T, returnErr error) *int {
+	t.Helper()
+	count := new(int)
+	prev := DaemonReloadFn
+	t.Cleanup(func() { DaemonReloadFn = prev })
+	DaemonReloadFn = func() error {
+		*count++
+		return returnErr
+	}
+	return count
+}

--- a/internal/serviceops/ensure_quadlet_test.go
+++ b/internal/serviceops/ensure_quadlet_test.go
@@ -1,0 +1,52 @@
+package serviceops
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+func TestEnsureCustomServiceQuadlet_reloadsOnlyWhenContentChanges(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	count := 0
+	orig := podman.DaemonReloadFn
+	t.Cleanup(func() { podman.DaemonReloadFn = orig })
+	podman.DaemonReloadFn = func() error {
+		count++
+		return nil
+	}
+
+	svc := &config.CustomService{
+		Name:  "mongo-express",
+		Image: "docker.io/library/mongo-express:latest",
+		Ports: []string{"127.0.0.1:8082:8081"},
+	}
+
+	if err := EnsureCustomServiceQuadlet(svc); err != nil {
+		t.Fatalf("first EnsureCustomServiceQuadlet: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("first call should reload once, got %d", count)
+	}
+
+	if err := EnsureCustomServiceQuadlet(svc); err != nil {
+		t.Fatalf("second EnsureCustomServiceQuadlet: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("second call with unchanged content must not reload, got %d total", count)
+	}
+
+	svc.Image = "docker.io/library/mongo-express:1.0.2"
+	if err := EnsureCustomServiceQuadlet(svc); err != nil {
+		t.Fatalf("third EnsureCustomServiceQuadlet: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("changed image should reload again, got %d total", count)
+	}
+}

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -143,8 +143,9 @@ func MissingPresetDependencies(svc *config.CustomService) []string {
 }
 
 // EnsureCustomServiceQuadlet writes the quadlet for a custom service and
-// reloads systemd. Materialises any declared file mounts and resolves
-// dynamic_env directives so the rendered quadlet has the computed values.
+// reloads systemd only when the file actually changed on disk. Materialises
+// any declared file mounts and resolves dynamic_env directives so the
+// rendered quadlet has the computed values.
 func EnsureCustomServiceQuadlet(svc *config.CustomService) error {
 	if svc.DataDir != "" {
 		if err := os.MkdirAll(config.DataSubDir(svc.Name), 0755); err != nil {
@@ -159,10 +160,11 @@ func EnsureCustomServiceQuadlet(svc *config.CustomService) error {
 	}
 	content := podman.GenerateCustomQuadlet(svc)
 	quadletName := "lerd-" + svc.Name
-	if _, err := podman.WriteQuadletDiff(quadletName, content); err != nil {
+	changed, err := podman.WriteQuadletDiff(quadletName, content)
+	if err != nil {
 		return fmt.Errorf("writing unit for %s: %w", svc.Name, err)
 	}
-	return podman.DaemonReloadFn()
+	return podman.DaemonReloadIfNeeded(changed)
 }
 
 // EnsureServiceRunning starts the service if it is not already active and

--- a/internal/systemd/dbus_linux.go
+++ b/internal/systemd/dbus_linux.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/coreos/go-systemd/v22/dbus"
 )
 
@@ -197,4 +198,19 @@ func withDefaultSuffix(name string) string {
 		return name
 	}
 	return name + ".service"
+}
+
+// NotifyReady tells systemd the current process has finished its startup
+// work and is ready to serve. Used by Type=notify units so systemctl start
+// blocks until the service is actually up, not just spawned. No-op outside
+// a systemd-managed process (returns false without error).
+func NotifyReady() {
+	_, _ = daemon.SdNotify(false, daemon.SdNotifyReady)
+}
+
+// NotifyStopping tells systemd the process is winding down, letting
+// dependent units start their own teardown early instead of waiting for
+// the process to actually exit.
+func NotifyStopping() {
+	_, _ = daemon.SdNotify(false, daemon.SdNotifyStopping)
 }

--- a/internal/systemd/dbus_linux.go
+++ b/internal/systemd/dbus_linux.go
@@ -1,0 +1,200 @@
+//go:build linux
+
+package systemd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+)
+
+// userBus holds the lazily-initialised systemd user bus connection. Long-lived:
+// the library handles reconnection internally and the process lifetime is the
+// natural owner. sync.Once guards the first-dial race.
+var (
+	userBusOnce sync.Once
+	userBusConn *dbus.Conn
+	userBusErr  error
+)
+
+func userConn() (*dbus.Conn, error) {
+	userBusOnce.Do(func() {
+		// Dial context must not be cancellable: go-systemd ties the
+		// conn lifetime to this ctx, so cancelling it invalidates the
+		// underlying socket for every subsequent op in this process.
+		userBusConn, userBusErr = dbus.NewUserConnectionContext(context.Background())
+	})
+	return userBusConn, userBusErr
+}
+
+// dbusUnitOp runs one of StartUnit / StopUnit / RestartUnit / ReloadUnit by
+// name and waits for systemd to report the result on the internal channel.
+// Returns an error whose message mirrors the old systemctl shell-out for
+// drop-in compatibility with existing error strings.
+func dbusUnitOp(op, verb, name string) error {
+	conn, err := userConn()
+	if err != nil {
+		return fmt.Errorf("%s %s: dbus connect: %w", verb, name, err)
+	}
+	ch := make(chan string, 1)
+	unit := withServiceSuffix(name)
+	var jobID int
+	var opErr error
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	switch op {
+	case "start":
+		jobID, opErr = conn.StartUnitContext(ctx, unit, "replace", ch)
+	case "stop":
+		jobID, opErr = conn.StopUnitContext(ctx, unit, "replace", ch)
+	case "restart":
+		jobID, opErr = conn.RestartUnitContext(ctx, unit, "replace", ch)
+	default:
+		return fmt.Errorf("unknown unit op %q", op)
+	}
+	_ = jobID
+	if opErr != nil {
+		return fmt.Errorf("%s %s failed: %w", verb, name, opErr)
+	}
+	select {
+	case result := <-ch:
+		if result != "done" {
+			return fmt.Errorf("%s %s failed: %s", verb, name, result)
+		}
+	case <-ctx.Done():
+		return fmt.Errorf("%s %s timed out after 30s", verb, name)
+	}
+	return nil
+}
+
+// DBusDaemonReload runs systemctl --user daemon-reload over DBus.
+func DBusDaemonReload() error {
+	conn, err := userConn()
+	if err != nil {
+		return fmt.Errorf("daemon-reload: dbus connect: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := conn.ReloadContext(ctx); err != nil {
+		return fmt.Errorf("daemon-reload failed: %w", err)
+	}
+	return nil
+}
+
+// DBusStartUnit starts a user unit via DBus and waits for the job to finish.
+func DBusStartUnit(name string) error {
+	_ = DBusResetFailed(name)
+	return dbusUnitOp("start", "start", name)
+}
+
+// DBusStopUnit stops a user unit via DBus.
+func DBusStopUnit(name string) error {
+	if err := dbusUnitOp("stop", "stop", name); err != nil {
+		return err
+	}
+	_ = DBusResetFailed(name)
+	return nil
+}
+
+// DBusRestartUnit restarts a user unit via DBus.
+func DBusRestartUnit(name string) error {
+	return dbusUnitOp("restart", "restart", name)
+}
+
+// DBusResetFailed clears any "failed" state for the named unit so the next
+// start is not blocked by Restart= rate-limits.
+func DBusResetFailed(name string) error {
+	conn, err := userConn()
+	if err != nil {
+		return err
+	}
+	return conn.ResetFailedUnitContext(context.Background(), withServiceSuffix(name))
+}
+
+// DBusEnableService marks a user service to start at login.
+func DBusEnableService(name string) error {
+	conn, err := userConn()
+	if err != nil {
+		return fmt.Errorf("enable %s: dbus connect: %w", name, err)
+	}
+	_, _, err = conn.EnableUnitFilesContext(
+		context.Background(),
+		[]string{withServiceSuffix(name)},
+		false, true,
+	)
+	if err != nil {
+		return fmt.Errorf("enable %s: %w", name, err)
+	}
+	return nil
+}
+
+// DBusDisableService removes a user service from the login start set.
+func DBusDisableService(name string) error {
+	conn, err := userConn()
+	if err != nil {
+		return fmt.Errorf("disable %s: dbus connect: %w", name, err)
+	}
+	if _, err := conn.DisableUnitFilesContext(
+		context.Background(),
+		[]string{withServiceSuffix(name)},
+		false,
+	); err != nil {
+		return fmt.Errorf("disable %s: %w", name, err)
+	}
+	return nil
+}
+
+// DBusActiveState returns the ActiveState property ("active", "inactive",
+// "failed", "activating", …) for the named unit, or "" when the unit is
+// unknown. Unit name may be bare (e.g. "lerd-foo") or fully-qualified
+// ("lerd-foo.service", "lerd-foo.timer").
+func DBusActiveState(name string) string {
+	conn, err := userConn()
+	if err != nil {
+		return ""
+	}
+	props, err := conn.GetUnitPropertiesContext(context.Background(), withDefaultSuffix(name))
+	if err != nil {
+		return ""
+	}
+	s, _ := props["ActiveState"].(string)
+	return s
+}
+
+// DBusIsEnabled returns true when the unit-file state resolves to "enabled".
+func DBusIsEnabled(name string) bool {
+	conn, err := userConn()
+	if err != nil {
+		return false
+	}
+	props, err := conn.GetUnitPropertiesContext(context.Background(), withServiceSuffix(name))
+	if err != nil {
+		return false
+	}
+	s, _ := props["UnitFileState"].(string)
+	return s == "enabled"
+}
+
+// withServiceSuffix ensures the unit name ends in ".service" which DBus
+// requires for enable/disable and for unit-property lookups. Bare names are
+// what callers pass today when they shell out to systemctl.
+func withServiceSuffix(name string) string {
+	if strings.Contains(name, ".") {
+		return name
+	}
+	return name + ".service"
+}
+
+// withDefaultSuffix keeps an explicit .timer / .service suffix when the
+// caller passed one, and otherwise assumes .service. Used by property
+// lookups where a bare name could legitimately refer to either unit type.
+func withDefaultSuffix(name string) string {
+	if strings.Contains(name, ".") {
+		return name
+	}
+	return name + ".service"
+}

--- a/internal/systemd/dbus_linux_test.go
+++ b/internal/systemd/dbus_linux_test.go
@@ -1,0 +1,69 @@
+//go:build linux
+
+package systemd
+
+import "testing"
+
+// withServiceSuffix is the gate every DBus unit op passes through. A bug here
+// breaks Start/Stop/Restart/Enable/Disable/IsEnabled for every caller, so the
+// table covers the inputs each callsite actually emits.
+func TestWithServiceSuffix(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"lerd-ui", "lerd-ui.service"},
+		{"lerd-watcher", "lerd-watcher.service"},
+		{"lerd-queue-myapp", "lerd-queue-myapp.service"},
+		{"lerd-ui.service", "lerd-ui.service"},
+		{"lerd-test.timer", "lerd-test.timer"},
+		{"lerd-stripe-my.app", "lerd-stripe-my.app"},
+		{"", ".service"},
+	}
+	for _, tc := range cases {
+		if got := withServiceSuffix(tc.in); got != tc.want {
+			t.Errorf("withServiceSuffix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// withDefaultSuffix is used by property lookups that may legitimately target
+// a .timer or a .service. Bare names default to .service; explicit suffixes
+// pass through verbatim so IsTimerActive's name+".timer" composition works.
+func TestWithDefaultSuffix(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"lerd-ui", "lerd-ui.service"},
+		{"lerd-test.timer", "lerd-test.timer"},
+		{"lerd-test.service", "lerd-test.service"},
+		{"lerd-queue-myapp.timer", "lerd-queue-myapp.timer"},
+		{"some.weird.name", "some.weird.name"},
+	}
+	for _, tc := range cases {
+		if got := withDefaultSuffix(tc.in); got != tc.want {
+			t.Errorf("withDefaultSuffix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// IsTimerActive composes name+".timer" and asks DBus. The suffix rule must
+// pass ".timer" through unchanged so IsTimerActive doesn't end up querying
+// "lerd-foo.timer.service".
+func TestTimerSuffixIsNotDoubleAppended(t *testing.T) {
+	if got := withServiceSuffix("lerd-foo.timer"); got != "lerd-foo.timer" {
+		t.Errorf("withServiceSuffix(%q) = %q, want passthrough — IsTimerActive would query the wrong unit", "lerd-foo.timer", got)
+	}
+	if got := withDefaultSuffix("lerd-foo.timer"); got != "lerd-foo.timer" {
+		t.Errorf("withDefaultSuffix(%q) = %q, want passthrough", "lerd-foo.timer", got)
+	}
+}
+
+// NotifyReady and NotifyStopping must be safe to call outside a systemd
+// notify-socket context: bare CLI runs (lerd serve-ui from a terminal,
+// go test) have no $NOTIFY_SOCKET and the underlying daemon.SdNotify
+// returns (false, nil) — no panic, no error surfaced.
+func TestNotifyReadyAndStoppingAreSafeWithoutSocket(t *testing.T) {
+	t.Setenv("NOTIFY_SOCKET", "")
+	NotifyReady()
+	NotifyStopping()
+}

--- a/internal/systemd/dbus_stub.go
+++ b/internal/systemd/dbus_stub.go
@@ -19,3 +19,9 @@ func DBusEnableService(string) error  { return errNoDBus }
 func DBusDisableService(string) error { return errNoDBus }
 func DBusActiveState(string) string   { return "" }
 func DBusIsEnabled(string) bool       { return false }
+
+// NotifyReady is a no-op on non-Linux platforms (no sd_notify).
+func NotifyReady() {}
+
+// NotifyStopping is a no-op on non-Linux platforms (no sd_notify).
+func NotifyStopping() {}

--- a/internal/systemd/dbus_stub.go
+++ b/internal/systemd/dbus_stub.go
@@ -1,0 +1,21 @@
+//go:build !linux
+
+package systemd
+
+import "errors"
+
+// errNoDBus is returned for every DBus-routed call on non-Linux platforms.
+// Callers that care (the Linux user service manager) never reach these stubs
+// because they are Linux-only; the stubs exist so the systemd package still
+// compiles on macOS where cross-platform CLI code imports it.
+var errNoDBus = errors.New("systemd DBus not available on this platform")
+
+func DBusDaemonReload() error         { return errNoDBus }
+func DBusStartUnit(string) error      { return errNoDBus }
+func DBusStopUnit(string) error       { return errNoDBus }
+func DBusRestartUnit(string) error    { return errNoDBus }
+func DBusResetFailed(string) error    { return errNoDBus }
+func DBusEnableService(string) error  { return errNoDBus }
+func DBusDisableService(string) error { return errNoDBus }
+func DBusActiveState(string) string   { return "" }
+func DBusIsEnabled(string) bool       { return false }

--- a/internal/systemd/login1_linux.go
+++ b/internal/systemd/login1_linux.go
@@ -1,0 +1,102 @@
+//go:build linux
+
+package systemd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/coreos/go-systemd/v22/login1"
+	"github.com/godbus/dbus/v5"
+)
+
+// login1Conn holds the lazily-initialised systemd-logind system-bus conn.
+// Read-only property polls don't need thread-local connections, so one
+// long-lived conn serves every watcher/UI caller in this process.
+var (
+	login1Once sync.Once
+	login1C    *login1.Conn
+	login1Err  error
+)
+
+func login1Connect() (*login1.Conn, error) {
+	login1Once.Do(func() {
+		login1C, login1Err = login1.New()
+	})
+	return login1C, login1Err
+}
+
+// SessionIsIdle returns true when systemd-logind reports the current user's
+// active session as idle (the compositor hasn't seen input for the
+// configured idle timeout). Returns false when logind is unreachable or
+// the session can't be identified, so callers behave as if the user is
+// active when the signal is unavailable.
+func SessionIsIdle() bool {
+	c, err := login1Connect()
+	if err != nil {
+		return false
+	}
+	path, err := resolveOwnSessionPath(c)
+	if err != nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	v, err := c.GetSessionPropertyContext(ctx, path, "IdleHint")
+	if err != nil || v == nil {
+		return false
+	}
+	b, ok := v.Value().(bool)
+	return ok && b
+}
+
+// SessionIsLocked returns true when the user's session is locked by the
+// screen locker. Returns false when the property is unreadable.
+func SessionIsLocked() bool {
+	c, err := login1Connect()
+	if err != nil {
+		return false
+	}
+	path, err := resolveOwnSessionPath(c)
+	if err != nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	v, err := c.GetSessionPropertyContext(ctx, path, "LockedHint")
+	if err != nil || v == nil {
+		return false
+	}
+	b, ok := v.Value().(bool)
+	return ok && b
+}
+
+// resolveOwnSessionPath prefers the session exposed in XDG_SESSION_ID and
+// falls back to the user's active session so headless systemd-user timers
+// without that env var still resolve to something useful.
+func resolveOwnSessionPath(c *login1.Conn) (dbus.ObjectPath, error) {
+	if id := os.Getenv("XDG_SESSION_ID"); id != "" {
+		if p, err := c.GetSession(id); err == nil {
+			return p, nil
+		}
+	}
+	uid := uint32(os.Getuid())
+	users, err := c.ListUsers()
+	if err != nil {
+		return "", err
+	}
+	for _, u := range users {
+		if u.UID == uid {
+			return c.GetActiveSession()
+		}
+	}
+	return "", errors.New("no active login1 session for current user")
+}
+
+// SessionIsIdleOrLocked is a convenience combining both states.
+func SessionIsIdleOrLocked() bool {
+	return SessionIsIdle() || SessionIsLocked()
+}

--- a/internal/systemd/login1_stub.go
+++ b/internal/systemd/login1_stub.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package systemd
+
+// SessionIsIdle always returns false on non-Linux platforms (no logind).
+// Callers default to "treat as active" so watchers never starve on macOS.
+func SessionIsIdle() bool { return false }
+
+// SessionIsLocked always returns false on non-Linux platforms.
+func SessionIsLocked() bool { return false }
+
+// SessionIsIdleOrLocked always returns false on non-Linux platforms.
+func SessionIsIdleOrLocked() bool { return false }
+
+// Keep stub and linux variants in sync if more helpers are added.

--- a/internal/systemd/subscribe_linux.go
+++ b/internal/systemd/subscribe_linux.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+package systemd
+
+import (
+	"context"
+	"strings"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+)
+
+// SubscribeLerdUnitStateChanges wires a push-based notification for every
+// systemd unit whose name matches "lerd-*". onChange fires with the bare
+// unit name (no .service suffix) whenever the unit's SubState changes,
+// which covers start, stop, restart, activating, and failed transitions.
+// Cancel ctx to tear down the subscription.
+//
+// The handler goroutine keeps running until ctx is cancelled; callers pass
+// a long-lived context (server lifetime) because state changes need to be
+// delivered continuously. Calling this more than once per process is safe
+// but wasteful: each call starts its own fanout goroutine.
+func SubscribeLerdUnitStateChanges(ctx context.Context, onChange func(unitName string)) error {
+	conn, err := userConn()
+	if err != nil {
+		return err
+	}
+	if err := conn.Subscribe(); err != nil {
+		return err
+	}
+
+	updateCh := make(chan *dbus.SubStateUpdate, 64)
+	errCh := make(chan error, 8)
+	conn.SetSubStateSubscriber(updateCh, errCh)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case upd := <-updateCh:
+				if upd == nil {
+					continue
+				}
+				name := strings.TrimSuffix(upd.UnitName, ".service")
+				if !strings.HasPrefix(name, "lerd-") {
+					continue
+				}
+				onChange(name)
+			case <-errCh:
+				// Drop subscription errors rather than spamming; the UI
+				// poll fallback keeps state current even if we lose pushes.
+			}
+		}
+	}()
+	return nil
+}

--- a/internal/systemd/subscribe_stub.go
+++ b/internal/systemd/subscribe_stub.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package systemd
+
+import "context"
+
+// SubscribeLerdUnitStateChanges is a no-op on non-Linux platforms: macOS
+// has no equivalent subscription model via launchctl. Callers continue to
+// rely on periodic polling for state updates on that platform.
+func SubscribeLerdUnitStateChanges(_ context.Context, _ func(string)) error {
+	return nil
+}

--- a/internal/systemd/units/lerd-ui.service
+++ b/internal/systemd/units/lerd-ui.service
@@ -3,6 +3,7 @@ Description=Lerd UI Dashboard
 After=default.target
 
 [Service]
+Type=notify
 ExecStart=%h/.local/bin/lerd serve-ui
 Restart=on-failure
 

--- a/internal/systemd/units/lerd-watcher.service
+++ b/internal/systemd/units/lerd-watcher.service
@@ -3,6 +3,7 @@ Description=Lerd Project Watcher
 After=default.target
 
 [Service]
+Type=notify
 ExecStart=%h/.local/bin/lerd watch
 Restart=on-failure
 

--- a/internal/systemd/units_test.go
+++ b/internal/systemd/units_test.go
@@ -1,0 +1,42 @@
+package systemd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// PR #255 switches lerd-ui and lerd-watcher to Type=notify so systemctl start
+// blocks until the process actually finishes setup (UI listener accepting,
+// watcher goroutines live). The two unit files in this package's units/
+// directory are the source of truth shipped by the installer; assert each
+// one declares the type so the change can't silently regress.
+func TestServiceUnitsDeclareTypeNotify(t *testing.T) {
+	cases := []struct {
+		file string
+	}{
+		{"lerd-ui.service"},
+		{"lerd-watcher.service"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.file, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join("units", tc.file))
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.file, err)
+			}
+			if !containsLine(string(data), "Type=notify") {
+				t.Errorf("%s: missing Type=notify directive\n--- file ---\n%s", tc.file, data)
+			}
+		})
+	}
+}
+
+func containsLine(content, line string) bool {
+	for _, l := range strings.Split(content, "\n") {
+		if strings.TrimSpace(l) == line {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/systemd/user.go
+++ b/internal/systemd/user.go
@@ -1,9 +1,7 @@
 package systemd
 
 import (
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -61,74 +59,32 @@ func RemoveTimer(name string) error {
 }
 
 // EnableService enables a systemd user service.
-func EnableService(name string) error {
-	cmd := exec.Command("systemctl", "--user", "enable", name)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("enable %s: %w\n%s", name, err, out)
-	}
-	return nil
-}
+func EnableService(name string) error { return DBusEnableService(name) }
 
 // StartService starts a systemd user service.
-func StartService(name string) error {
-	cmd := exec.Command("systemctl", "--user", "start", name)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("start %s: %w\n%s", name, err, out)
-	}
-	return nil
-}
+func StartService(name string) error { return DBusStartUnit(name) }
 
 // DisableService disables a systemd user service.
-func DisableService(name string) error {
-	cmd := exec.Command("systemctl", "--user", "disable", name)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("disable %s: %w\n%s", name, err, out)
-	}
-	return nil
-}
+func DisableService(name string) error { return DBusDisableService(name) }
 
 // RestartService restarts a systemd user service.
-func RestartService(name string) error {
-	cmd := exec.Command("systemctl", "--user", "restart", name)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("restart %s: %w\n%s", name, err, out)
-	}
-	return nil
-}
+func RestartService(name string) error { return DBusRestartUnit(name) }
 
 // IsServiceEnabled returns true if the systemd user service is enabled.
-func IsServiceEnabled(name string) bool {
-	cmd := exec.Command("systemctl", "--user", "is-enabled", name)
-	out, _ := cmd.Output()
-	return strings.TrimSpace(string(out)) == "enabled"
-}
+func IsServiceEnabled(name string) bool { return DBusIsEnabled(name) }
 
 // IsServiceActive returns true if the systemd user service is currently active.
-func IsServiceActive(name string) bool {
-	cmd := exec.Command("systemctl", "--user", "is-active", name)
-	out, _ := cmd.Output()
-	return strings.TrimSpace(string(out)) == "active"
-}
+func IsServiceActive(name string) bool { return DBusActiveState(name) == "active" }
 
 // IsServiceActiveOrRestarting returns true if the service is active or in a
 // restart loop (activating). Used to detect workers that should be stopped on unlink.
 func IsServiceActiveOrRestarting(name string) bool {
-	cmd := exec.Command("systemctl", "--user", "is-active", name)
-	out, _ := cmd.Output()
-	state := strings.TrimSpace(string(out))
+	state := DBusActiveState(name)
 	return state == "active" || state == "activating"
 }
 
 // IsTimerActive returns true if the worker's sibling .timer is active.
-func IsTimerActive(name string) bool {
-	cmd := exec.Command("systemctl", "--user", "is-active", name+".timer")
-	out, _ := cmd.Output()
-	return strings.TrimSpace(string(out)) == "active"
-}
+func IsTimerActive(name string) bool { return DBusActiveState(name+".timer") == "active" }
 
 // FindOrphanedWorkers scans systemd unit files for worker units belonging to
 // the given site that are running but not present in the known workers set.

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -170,6 +170,22 @@ func Start(currentVersion string) error {
 		}()
 	}
 
+	// Event-driven push from systemd covers mutations that didn't go through
+	// lerd-ui's AfterUnitChange path: external systemctl calls, container
+	// crashes, external podman restart, unit timeouts. Mirrors the same
+	// invalidate-and-broadcast flow so the dashboard stays current without
+	// waiting for the 15s cache poll. AfterUnitChange stays as a fast path
+	// for in-process mutations; the DBus push catches everything else.
+	_ = lerdSystemd.SubscribeLerdUnitStateChanges(context.Background(), func(string) {
+		go func() {
+			podman.Cache.PollNow()
+			siteinfo.InvalidateUnitCache()
+			eventbus.Default.Publish(eventbus.KindSites)
+			eventbus.Default.Publish(eventbus.KindServices)
+			eventbus.Default.Publish(eventbus.KindStatus)
+		}()
+	})
+
 	// A single goroutine subscribes to the eventbus and invalidates the
 	// relevant snapshot on every mutation. The /api/ws handler broadcasts
 	// the freshly rebuilt bytes to every connected browser.

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -170,6 +170,11 @@ func Start(currentVersion string) error {
 		}()
 	}
 
+	// Drop the cache to idle cadence whenever the desktop session is idle
+	// or locked, so a focused tab on an unattended laptop still saves
+	// battery. Recomputes on every transition.
+	startIdleWatcher(context.Background())
+
 	// Event-driven push from systemd covers mutations that didn't go through
 	// lerd-ui's AfterUnitChange path: external systemctl calls, container
 	// crashes, external podman restart, unit timeouts. Mirrors the same

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -325,8 +325,15 @@ func Start(currentVersion string) error {
 		}
 	}
 
+	ln, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", listenAddr, err)
+	}
 	fmt.Printf("Lerd UI listening on http://%s\n", listenAddr)
-	return http.ListenAndServe(listenAddr, handler)
+	// Notify systemd we're ready only after the listener is accepting, so
+	// Type=notify units make systemctl start block until the UI can serve.
+	lerdSystemd.NotifyReady()
+	return http.Serve(ln, handler)
 }
 
 var allowedCORSOrigins = map[string]bool{

--- a/internal/ui/ws.go
+++ b/internal/ui/ws.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"sync/atomic"
@@ -9,28 +10,64 @@ import (
 
 	"github.com/geodro/lerd/internal/eventbus"
 	"github.com/geodro/lerd/internal/podman"
+	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 )
 
-// visibleClients tracks how many browser tabs currently report as visible.
-// When at least one tab is focused the cache polls more aggressively.
-var visibleClients atomic.Int32
+var (
+	visibleClients atomic.Int32
+	sessionIdle    atomic.Bool
+)
 
 const (
-	intervalFocused = 15 * time.Second
-	intervalIdle    = 60 * time.Second
+	intervalFocused      = 15 * time.Second
+	intervalIdle         = 60 * time.Second
+	idleWatcherCheckTick = 30 * time.Second
 )
+
+// chooseInterval returns the cache poll cadence implied by the current
+// (visibility, session-idle) pair. Fast cadence requires both an engaged
+// browser tab and an active desktop session: a focused tab on a locked
+// laptop still drops to idle, matching the watcher's idle backoff.
+func chooseInterval(visible int32, idle bool) time.Duration {
+	if visible > 0 && !idle {
+		return intervalFocused
+	}
+	return intervalIdle
+}
+
+func recomputeInterval() {
+	podman.Cache.SetInterval(chooseInterval(visibleClients.Load(), sessionIdle.Load()))
+}
 
 func noteVisibility(visible bool) {
 	if visible {
-		if visibleClients.Add(1) == 1 {
-			podman.Cache.SetInterval(intervalFocused)
-		}
-	} else {
-		if visibleClients.Add(-1) <= 0 {
-			visibleClients.Store(0)
-			podman.Cache.SetInterval(intervalIdle)
-		}
+		visibleClients.Add(1)
+	} else if visibleClients.Add(-1) < 0 {
+		visibleClients.Store(0)
 	}
+	recomputeInterval()
+}
+
+// startIdleWatcher polls systemd-logind every 30s and recomputes the cache
+// interval when the session transitions between idle/locked and active.
+// On non-Linux SessionIsIdleOrLocked is a stub that always returns false,
+// so the interval stays driven by visibility alone.
+func startIdleWatcher(ctx context.Context) {
+	go func() {
+		t := time.NewTicker(idleWatcherCheckTick)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				idle := lerdSystemd.SessionIsIdleOrLocked()
+				if sessionIdle.Swap(idle) != idle {
+					recomputeInterval()
+				}
+			}
+		}
+	}()
 }
 
 // handleWS upgrades the HTTP connection to a websocket and streams snapshot

--- a/internal/ui/ws_idle_test.go
+++ b/internal/ui/ws_idle_test.go
@@ -1,0 +1,42 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+// chooseInterval is the only branching point that decides the cache poll
+// cadence. The full state space is 4 combinations of (visible>0, idle);
+// table covers them and a couple of edge values for the visible counter.
+func TestChooseInterval(t *testing.T) {
+	cases := []struct {
+		name    string
+		visible int32
+		idle    bool
+		want    time.Duration
+	}{
+		{"focused tab, active session", 1, false, intervalFocused},
+		{"focused tab, idle session", 1, true, intervalIdle},
+		{"no tabs, active session", 0, false, intervalIdle},
+		{"no tabs, idle session", 0, true, intervalIdle},
+		{"many tabs, active session", 7, false, intervalFocused},
+		{"many tabs, idle session", 7, true, intervalIdle},
+		{"negative counter, active session", -1, false, intervalIdle},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := chooseInterval(tc.visible, tc.idle); got != tc.want {
+				t.Errorf("chooseInterval(%d, %v) = %v, want %v", tc.visible, tc.idle, got, tc.want)
+			}
+		})
+	}
+}
+
+// intervalFocused must be strictly shorter than intervalIdle, otherwise the
+// "fast cadence on focused tabs" promise is meaningless. Pin the invariant
+// so a future tweak to the constants can't silently break it.
+func TestFocusedIntervalIsFasterThanIdle(t *testing.T) {
+	if intervalFocused >= intervalIdle {
+		t.Errorf("intervalFocused (%v) must be < intervalIdle (%v)", intervalFocused, intervalIdle)
+	}
+}

--- a/internal/watcher/dns.go
+++ b/internal/watcher/dns.go
@@ -4,16 +4,31 @@ import (
 	"time"
 
 	"github.com/geodro/lerd/internal/dns"
+	"github.com/geodro/lerd/internal/systemd"
 )
+
+// idleSkipEveryN controls how aggressively to back off polling when the
+// session is idle or locked. We still probe once every N ticks so a
+// returning user hits a healed DNS immediately instead of a 0.5-1s
+// resolver timeout. At interval=30s, N=10 means one probe per 5 min.
+const idleSkipEveryN = 10
 
 // WatchDNS polls DNS health for the given TLD every interval. When resolution
 // is broken it waits for lerd-dns to be ready and re-applies the resolver
-// configuration, replicating the DNS repair done by lerd start.
+// configuration, replicating the DNS repair done by lerd start. When the
+// user session is idle or locked it backs off to one probe every 10 ticks
+// so laptops don't pay the per-30s DNS lookup battery cost while away.
 func WatchDNS(interval time.Duration, tld string) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
+	tickCount := 0
 	for range ticker.C {
+		tickCount++
+		if systemd.SessionIsIdleOrLocked() && tickCount%idleSkipEveryN != 0 {
+			continue
+		}
+
 		ok, _ := dns.Check(tld)
 		if ok {
 			continue

--- a/internal/xdebugops/xdebugops_test.go
+++ b/internal/xdebugops/xdebugops_test.go
@@ -116,23 +116,25 @@ func TestApply_RejectsInvalidMode(t *testing.T) {
 }
 
 func TestApply_RestartErrIsNonFatal(t *testing.T) {
-	// PATH is empty so podman.RestartUnit will fail. Apply must still
-	// persist config and ini, returning RestartErr instead of aborting;
-	// otherwise a harmless restart hiccup loses the user's toggle.
+	// Use a bogus PHP version so the derived unit name (lerd-php99-fpm)
+	// can't exist on the host; RestartUnit must then fail, and Apply must
+	// still persist config and ini, surfacing RestartErr rather than
+	// aborting. A prior version of this test relied on PATH=empty to
+	// break the systemctl shell-out, which the DBus refactor bypasses.
 	setupConfigHome(t)
 
-	res, err := Apply("8.4", "debug")
+	res, err := Apply("9.9", "debug")
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 	if res.RestartErr == nil {
-		t.Fatal("expected RestartErr when podman is unavailable")
+		t.Fatal("expected RestartErr when the target FPM unit does not exist")
 	}
 	if !res.Enabled || res.Mode != "debug" {
 		t.Errorf("config/ini should still be applied: %+v", res)
 	}
 	cfg, _ := config.LoadGlobal()
-	if cfg.GetXdebugMode("8.4") != "debug" {
+	if cfg.GetXdebugMode("9.9") != "debug" {
 		t.Error("config not saved despite RestartErr")
 	}
 }


### PR DESCRIPTION
## Summary

Replaces every `systemctl --user` shell-out on Linux with go-systemd DBus calls, adds session-idle awareness to the watcher, flips lerd-ui and lerd-watcher to `Type=notify`, and pushes unit-state updates into the UI from DBus instead of relying solely on the 15s cache poll. Adds one dep, `github.com/coreos/go-systemd/v22` (pure Go + godbus, no cgo, active maintainer, used by Docker and Kubernetes).

Linux-scoped throughout. macOS launchd paths unchanged. A `!linux` stub for every new helper keeps cross-platform code compiling.

## What changes

**DBus replaces systemctl shell-outs.** `DaemonReload`, `StartUnit`, `StopUnit`, `RestartUnit`, `UnitStatus` in `internal/podman/quadlet.go` and the service-level helpers in `internal/systemd/user.go`. Each saves a process spawn (~20-40 ms on Linux) plus the is-active text parsing. `lerd install` fires 50+ of these, `lerd start` 15+. The shared `*dbus.Conn` is opened once with `context.Background()` — cancelling the dial context would tear down the whole connection for the lifetime of the process.

**Idle-aware DNS polling via logind.** New `SessionIsIdleOrLocked()` reads `IdleHint`/`LockedHint` from systemd-logind. `WatchDNS` skips 9 out of every 10 ticks while the session is idle, so a locked-and-away laptop does one DNS lookup per 5 min instead of 120 per hour. Snaps back to full cadence on activity.

**`Type=notify` for the long-running services.** `lerd-ui` calls `daemon.SdNotify(READY=1)` after the TCP listener is bound, so `systemctl start` returns only when the UI can serve. `lerd-watcher` calls it after initial parked-dir scan + goroutine launches. Unit files updated accordingly.

**DBus subscription pushes state updates into the UI.** `SubscribeLerdUnitStateChanges` wires `SetSubStateSubscriber` on the user bus; every transition on any `lerd-*` unit fires the same invalidate-and-broadcast flow that `AfterUnitChange` already used. External `systemctl restart` now reflects in the dashboard within milliseconds instead of up to 15 seconds.

**Docs.** Explicitly state the systemd requirement in `installation.md`, `architecture.md`, and `comparison.md`. Pre-existing constraint (every container is a Podman Quadlet, every worker a systemd user service), just never called out.