### PR TITLE
fix(ci): grant actions:write to PHP upstream watcher

### DIFF
--- a/.github/workflows/check-upstream-php.yml
+++ b/.github/workflows/check-upstream-php.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.compare.outputs.changed }}
+    permissions:
+      actions: write
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -44,19 +44,9 @@ jobs:
           done
           echo "changed=${CHANGED}" >> "$GITHUB_OUTPUT"
 
-      - name: Save updated digests
-        if: steps.compare.outputs.changed != ''
-        uses: actions/cache/save@v4
-        with:
-          path: /tmp/php-digests
-          key: php-upstream-digests-${{ github.run_id }}
-
-  trigger:
-    needs: check
-    if: needs.check.outputs.changed != ''
-    runs-on: ubuntu-latest
-    steps:
       - name: Trigger base image rebuild
+        id: trigger
+        if: steps.compare.outputs.changed != ''
         uses: actions/github-script@v7
         with:
           script: |
@@ -69,3 +59,10 @@ jobs:
                 force_rebuild: 'true'
               }
             });
+
+      - name: Save updated digests
+        if: steps.trigger.outcome == 'success'
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/php-digests
+          key: php-upstream-digests-${{ github.run_id }}


### PR DESCRIPTION
## Summary

The scheduled `check-upstream-php.yml` workflow has never actually triggered a base image rebuild since it was added in #123. Two compounding bugs:

**1. 403 on `createWorkflowDispatch`** — the `trigger` job used the default `GITHUB_TOKEN`, which only has `contents: read`. `createWorkflowDispatch` needs `actions: write`. Every scheduled run that detected an upstream change hit `RequestError [HttpError]: Resource not accessible by integration`.

**2. Cache poisoning on failed dispatch** — the `check` job saved the updated digest cache *before* the `trigger` job ran. So after a failed dispatch, the cache had already advanced past the change. Subsequent runs read back "no change" and stayed silent, even though `base-images.yml` had never actually been rebuilt.

Most recent real detection was 2026-04-17, which correctly saw PHP 8.2 and 8.3 move but failed to trigger. Every run since has reported "no change" across all versions — not because upstream was stable, but because the detector was self-silencing.

## Changes

- Merge `check` and `trigger` into a single job.
- Declare `permissions: actions: write` on the job.
- Gate the `actions/cache/save` step on `steps.trigger.outcome == 'success'` so a failed dispatch preserves the prior cache and the next cron retries.

Out-of-band, I've already kicked off a manual `base-images.yml` run with `force_rebuild: true` to recover the PHP 8.2/8.3 drift that went unbuilt since 2026-04-17.