### PR TITLE
feat(ui): stream per-phase progress when installing a preset

### DIFF
--- a/docs/usage/service-presets.md
+++ b/docs/usage/service-presets.md
@@ -46,6 +46,13 @@ presets like `mysql` and `mariadb` show a version dropdown next to the **Add**
 button. Already-installed presets are filtered out; for multi-version
 families, only the still-uninstalled versions appear.
 
+The Add button streams per-phase progress while it works, so the spinner label
+tracks the real step: *Writing config…*, *Starting elasticsearch…* for each
+dependency, *Pulling image…* with live podman output underneath, *Starting
+service…*, then *Waiting for ready…*. Most of the perceived latency on a
+first install is the image pull; the progress line shows what layer is being
+copied so a slow registry is distinguishable from a stuck install.
+
 The detail panel of every database service (built-in `mysql` / `postgres`, any
 installed `mongo`, and any installed alternate like `mysql-5-7`) surfaces a
 sky-blue suggestion banner offering to install the paired admin UI when it

--- a/internal/podman/exec.go
+++ b/internal/podman/exec.go
@@ -70,6 +70,54 @@ func PullImageTo(image string, w io.Writer) error {
 	return nil
 }
 
+// PullImageWithProgress pulls the named image and invokes onLine for each
+// complete line of podman's output so callers can forward live progress.
+func PullImageWithProgress(image string, onLine func(string)) error {
+	if onLine == nil {
+		return PullImageIfMissing(image)
+	}
+	cmd := exec.Command(PodmanBin(), "pull", image)
+	w := &lineWriter{onLine: onLine}
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("pulling %s: %w", image, err)
+	}
+	w.flush()
+	return nil
+}
+
+// lineWriter invokes onLine per full line. Both \n and \r terminate, so
+// podman's TTY progress-bar rewrites still surface as discrete events.
+type lineWriter struct {
+	buf    []byte
+	onLine func(string)
+}
+
+func (w *lineWriter) Write(p []byte) (int, error) {
+	w.buf = append(w.buf, p...)
+	for {
+		i := bytes.IndexAny(w.buf, "\r\n")
+		if i < 0 {
+			break
+		}
+		line := strings.TrimRight(string(w.buf[:i]), "\r\n")
+		w.buf = w.buf[i+1:]
+		if line != "" {
+			w.onLine(line)
+		}
+	}
+	return len(p), nil
+}
+
+func (w *lineWriter) flush() {
+	line := strings.TrimRight(string(w.buf), "\r\n")
+	w.buf = w.buf[:0]
+	if line != "" {
+		w.onLine(line)
+	}
+}
+
 // PullImageIfMissing pulls the named image when it is not already in the
 // local store. No-op when the image exists.
 func PullImageIfMissing(image string) error {

--- a/internal/podman/pull_progress_test.go
+++ b/internal/podman/pull_progress_test.go
@@ -1,0 +1,69 @@
+package podman
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLineWriter_SplitsOnNewline(t *testing.T) {
+	var got []string
+	w := &lineWriter{onLine: func(s string) { got = append(got, s) }}
+	w.Write([]byte("Trying to pull foo...\nCopying blob sha256:abc done\n"))
+	want := []string{"Trying to pull foo...", "Copying blob sha256:abc done"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestLineWriter_SplitsOnCarriageReturn(t *testing.T) {
+	var got []string
+	w := &lineWriter{onLine: func(s string) { got = append(got, s) }}
+	w.Write([]byte("Copying blob [=>  ] 10MB / 40MB\rCopying blob [====>] 20MB / 40MB\rCopying blob done\n"))
+	want := []string{
+		"Copying blob [=>  ] 10MB / 40MB",
+		"Copying blob [====>] 20MB / 40MB",
+		"Copying blob done",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestLineWriter_BuffersPartialLine(t *testing.T) {
+	var got []string
+	w := &lineWriter{onLine: func(s string) { got = append(got, s) }}
+	w.Write([]byte("Copying blob"))
+	if len(got) != 0 {
+		t.Fatalf("expected no lines yet, got %v", got)
+	}
+	w.Write([]byte(" sha256:abc done\nWriting manifest"))
+	want := []string{"Copying blob sha256:abc done"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("after second write: got %v, want %v", got, want)
+	}
+	w.flush()
+	want = append(want, "Writing manifest")
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("after flush: got %v, want %v", got, want)
+	}
+}
+
+func TestLineWriter_SkipsEmptyLines(t *testing.T) {
+	var got []string
+	w := &lineWriter{onLine: func(s string) { got = append(got, s) }}
+	w.Write([]byte("\n\nTrying to pull\n\n"))
+	want := []string{"Trying to pull"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestLineWriter_MixedCRLF(t *testing.T) {
+	var got []string
+	w := &lineWriter{onLine: func(s string) { got = append(got, s) }}
+	w.Write([]byte("line one\r\nline two\r\n"))
+	want := []string{"line one", "line two"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}

--- a/internal/serviceops/install_streaming_test.go
+++ b/internal/serviceops/install_streaming_test.go
@@ -1,0 +1,21 @@
+package serviceops
+
+import (
+	"testing"
+)
+
+func TestInstallPresetStreaming_UnknownPresetEmitsConfigPhaseAndErrors(t *testing.T) {
+	var events []PhaseEvent
+	svc, err := InstallPresetStreaming("definitely-not-a-real-preset-xyz", "", func(e PhaseEvent) {
+		events = append(events, e)
+	})
+	if err == nil {
+		t.Fatalf("expected error for unknown preset, got svc=%+v", svc)
+	}
+	if svc != nil {
+		t.Fatalf("expected nil service on error, got %+v", svc)
+	}
+	if len(events) != 1 || events[0].Phase != "installing_config" {
+		t.Fatalf("expected single installing_config event before the error, got %+v", events)
+	}
+}

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -28,6 +28,67 @@ func IsBuiltin(name string) bool {
 	return false
 }
 
+// PhaseEvent is one step of the streaming preset-install flow.
+type PhaseEvent struct {
+	Phase   string `json:"phase"`
+	Image   string `json:"image,omitempty"`
+	Message string `json:"message,omitempty"`
+	Dep     string `json:"dep,omitempty"`
+	State   string `json:"state,omitempty"`
+	Unit    string `json:"unit,omitempty"`
+}
+
+// InstallPresetStreaming runs the full install flow and emits a PhaseEvent
+// at every step. The image is pulled before StartUnit so the hidden
+// on-demand pull latency becomes visible progress in the UI.
+func InstallPresetStreaming(name, version string, emit func(PhaseEvent)) (*config.CustomService, error) {
+	emit(PhaseEvent{Phase: "installing_config"})
+	svc, err := InstallPresetByName(name, version)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, dep := range svc.DependsOn {
+		emit(PhaseEvent{Phase: "starting_deps", Dep: dep, State: "starting"})
+		if err := EnsureServiceRunning(dep); err != nil {
+			return svc, fmt.Errorf("starting dependency %q: %w", dep, err)
+		}
+		emit(PhaseEvent{Phase: "starting_deps", Dep: dep, State: "ready"})
+	}
+
+	if svc.Image != "" && !podman.ImageExists(svc.Image) {
+		emit(PhaseEvent{Phase: "pulling_image", Image: svc.Image})
+		pullErr := podman.PullImageWithProgress(svc.Image, func(line string) {
+			emit(PhaseEvent{Phase: "pulling_image", Message: line})
+		})
+		if pullErr != nil {
+			return svc, pullErr
+		}
+	}
+
+	unit := "lerd-" + svc.Name
+	emit(PhaseEvent{Phase: "starting_unit", Unit: unit})
+	var startErr error
+	for attempt := range 5 {
+		startErr = podman.StartUnit(unit)
+		if startErr == nil || !strings.Contains(startErr.Error(), "not found") {
+			break
+		}
+		time.Sleep(time.Duration(attempt+1) * 300 * time.Millisecond)
+	}
+	if startErr != nil {
+		return svc, startErr
+	}
+	_ = config.SetServicePaused(svc.Name, false)
+	_ = config.SetServiceManuallyStarted(svc.Name, true)
+
+	emit(PhaseEvent{Phase: "waiting_ready", Unit: unit})
+	if err := podman.WaitReady(svc.Name, 60*time.Second); err != nil {
+		return svc, err
+	}
+	return svc, nil
+}
+
 // InstallPresetByName materialises a bundled preset as a custom service.
 // version selects a tag for multi-version presets; empty falls back to the
 // preset's DefaultVersion.

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -1283,9 +1283,10 @@
                       <p x-show="suggestedPresetFor(selectedService).error" class="text-[11px] text-red-500 mt-1" x-text="suggestedPresetFor(selectedService).error"></p>
                     </div>
                     <button @click="installPreset(suggestedPresetFor(selectedService))" :disabled="suggestedPresetFor(selectedService).installing"
+                      :title="suggestedPresetFor(selectedService).installingMessage || ''"
                       class="shrink-0 inline-flex items-center gap-1.5 text-xs font-medium bg-sky-600 hover:bg-sky-700 text-white rounded px-3 py-1.5 transition-colors disabled:opacity-50">
                       <svg x-show="suggestedPresetFor(selectedService).installing" class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
-                      <span x-text="suggestedPresetFor(selectedService).installing ? 'Adding…' : 'Add'"></span>
+                      <span x-text="presetPhaseLabel(suggestedPresetFor(selectedService))"></span>
                     </button>
                     <button @click="dismissPresetSuggestion(suggestedPresetFor(selectedService).name)"
                       title="Dismiss — you can still add this from the Services + button"
@@ -3597,36 +3598,83 @@ function lerdApp() {
         return;
       }
       p.installing = true;
+      p.installingPhase = '';
+      p.installingMessage = '';
+      p.installingDep = '';
       p.error = '';
       let installedSvcName = p.name;
+      let finalEvent = null;
       try {
         let url = '/api/services/presets/' + encodeURIComponent(p.name);
         if ((p.versions || []).length > 0 && p.selected_version) {
           url += '?version=' + encodeURIComponent(p.selected_version);
         }
         const res = await fetch(url, { method: 'POST' });
-        const data = await res.json();
-        if (!data.ok) {
-          p.error = data.error || 'install failed';
+        if (!res.ok) {
+          p.error = (await res.text()).trim() || 'install failed';
           return;
         }
-        installedSvcName = data.name || p.name;
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          let nl;
+          while ((nl = buffer.indexOf('\n')) !== -1) {
+            const line = buffer.slice(0, nl).trim();
+            buffer = buffer.slice(nl + 1);
+            if (!line) continue;
+            let evt;
+            try { evt = JSON.parse(line); } catch (_) { continue; }
+            if (evt.phase === 'done' || evt.phase === 'error') {
+              finalEvent = evt;
+              continue;
+            }
+            p.installingPhase = evt.phase || '';
+            if (evt.phase === 'starting_deps') {
+              p.installingDep = evt.dep || '';
+            } else if (evt.phase === 'pulling_image') {
+              p.installingMessage = evt.message || (evt.image ? 'pulling ' + evt.image : '');
+            } else {
+              p.installingMessage = '';
+            }
+          }
+        }
+        if (!finalEvent || finalEvent.phase === 'error') {
+          p.error = (finalEvent && finalEvent.error) || 'install failed without a final result';
+          return;
+        }
+        installedSvcName = finalEvent.name || p.name;
         await this.loadServices();
         const svc = this.services.find(s => s.name === installedSvcName);
         if (svc) {
           this.setTab('services');
           this.closePresetModal();
           this.selectService(svc);
-          if (svc.status !== 'active') {
-            this.toggleService(svc, 'start');
-          }
         }
       } catch (e) {
         p.error = e.message;
       } finally {
         p.installing = false;
+        p.installingPhase = '';
+        p.installingMessage = '';
+        p.installingDep = '';
       }
       this.loadPresets();
+    },
+
+    presetPhaseLabel(p) {
+      if (!p || !p.installing) return 'Add';
+      switch (p.installingPhase) {
+        case 'installing_config': return 'Writing config…';
+        case 'starting_deps':     return p.installingDep ? 'Starting ' + p.installingDep + '…' : 'Starting dependencies…';
+        case 'pulling_image':     return 'Pulling image…';
+        case 'starting_unit':     return 'Starting service…';
+        case 'waiting_ready':     return 'Waiting for ready…';
+        default:                  return 'Adding…';
+      }
     },
 
     closeLinkModal() {
@@ -4520,12 +4568,13 @@ function lerdApp() {
               </template>
               <button @click="installPreset(p)"
                 :disabled="!!(p.installing || (p.missing_deps || []).length > 0)"
-                :title="(p.missing_deps || []).length > 0 ? 'Install ' + p.missing_deps.join(', ') + ' first' : ''"
+                :title="(p.missing_deps || []).length > 0 ? 'Install ' + p.missing_deps.join(', ') + ' first' : (p.installingMessage || '')"
                 class="text-xs font-medium bg-lerd-red text-white rounded px-3 py-1.5 hover:bg-lerd-redhov transition-colors disabled:opacity-40 disabled:cursor-not-allowed shrink-0 flex items-center gap-1.5">
                 <svg x-show="p.installing" class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>
-                <span x-text="p.installing ? 'Adding…' : 'Add'"></span>
+                <span x-text="presetPhaseLabel(p)"></span>
               </button>
             </div>
+            <p x-show="p.installing && p.installingMessage" class="text-[11px] text-gray-400 dark:text-gray-500 mt-2 font-mono truncate" x-text="p.installingMessage"></p>
             <p x-show="p.error" class="text-[11px] text-red-500 mt-2" x-text="p.error"></p>
           </div>
         </template>

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1038,7 +1038,9 @@ func handleServicePresets(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, out)
 }
 
-// handleServicePresetInstall installs a bundled preset by name.
+// handleServicePresetInstall installs a bundled preset and streams per-phase
+// progress as NDJSON so the UI can show what step is active and surface the
+// podman pull output instead of one opaque spinner.
 func handleServicePresetInstall(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -1051,42 +1053,32 @@ func handleServicePresetInstall(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	version := r.URL.Query().Get("version")
-	svc, err := cli.InstallPresetByName(name, version)
+
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	flusher, _ := w.(http.Flusher)
+	writeLine := func(payload any) {
+		data, _ := json.Marshal(payload)
+		_, _ = w.Write(append(data, '\n'))
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+
+	svc, err := serviceops.InstallPresetStreaming(name, version, func(ev serviceops.PhaseEvent) {
+		writeLine(ev)
+	})
 	if err != nil {
-		writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
+		writeLine(map[string]any{"phase": "error", "error": err.Error()})
 		return
 	}
-
-	// Auto-start the service after installation, just like clicking Start
-	// from the dashboard. Start dependencies first so the service can connect.
-	unit := "lerd-" + svc.Name
-	var startErr string
-	if depErr := cli.StartServiceDependencies(svc); depErr != nil {
-		startErr = depErr.Error()
-	} else {
-		var opErr error
-		for attempt := range 5 {
-			opErr = podman.StartUnit(unit)
-			if opErr == nil || !strings.Contains(opErr.Error(), "not found") {
-				break
-			}
-			time.Sleep(time.Duration(attempt+1) * 300 * time.Millisecond)
-		}
-		if opErr == nil {
-			_ = config.SetServicePaused(svc.Name, false)
-			_ = config.SetServiceManuallyStarted(svc.Name, true)
-			cli.RegenerateFamilyConsumersForService(svc.Name)
-		} else {
-			startErr = opErr.Error()
-		}
-	}
-
-	writeJSON(w, map[string]any{
-		"ok":         true,
+	cli.RegenerateFamilyConsumersForService(svc.Name)
+	writeLine(map[string]any{
+		"phase":      "done",
 		"name":       svc.Name,
 		"dashboard":  svc.Dashboard,
 		"depends_on": svc.DependsOn,
-		"startError": startErr,
 	})
 }
 


### PR DESCRIPTION
## Summary

Clicking **Add** on a preset (elasticvue, phpMyAdmin, mongo, etc.) used to show a single opaque spinner for up to a minute. The biggest contributor to that latency is the first-time image pull, which happened silently inside podman when `systemctl --user start lerd-<preset>` ran, with no output reaching the UI.

This rewrites the install flow to stream per-phase progress.

## Changes

**Backend** — `POST /api/services/presets/{name}` now returns `application/x-ndjson`. A new `serviceops.InstallPresetStreaming` orchestrator emits a `PhaseEvent` at every step:

```
{"phase":"installing_config"}
{"phase":"starting_deps","dep":"elasticsearch","state":"starting"}
{"phase":"starting_deps","dep":"elasticsearch","state":"ready"}
{"phase":"pulling_image","image":"docker.io/cars10/elasticvue:latest"}
{"phase":"pulling_image","message":"Copying blob sha256:... done"}
{"phase":"starting_unit","unit":"lerd-elasticvue"}
{"phase":"waiting_ready","unit":"lerd-elasticvue"}
{"phase":"done","name":"elasticvue","dashboard":"http://localhost:8083"}
```

The image pull is now explicit and happens **before** `StartUnit`, using a new `podman.PullImageWithProgress(image, onLine)` helper. A small `lineWriter` splits podman output on both `\n` and `\r` so TTY progress-bar rewrites still surface as discrete events.

**Frontend** — `installPreset()` consumes the NDJSON stream via `ReadableStream`, tracks `installingPhase / installingMessage / installingDep`, and a new `presetPhaseLabel(p)` helper maps phase → button text ("Pulling image...", "Starting elasticsearch...", "Waiting for ready..."). The modal card shows the live `Copying blob ...` line underneath the button so a slow registry is distinguishable from a stuck install. Both install entry points (preset modal, service-detail suggestion banner) use the same labels.

**Compatibility** — CLI (`lerd service preset <name>`) and MCP (`service_preset_install`) still call `serviceops.InstallPresetByName` unchanged; only the HTTP UI response shape is new. macOS is fine: `podman.StartUnit` already abstracts launchd vs systemctl via `UnitLifecycle`, and the pull helper just shells out to `podman pull`.

## Notes

`publishAfter` still wraps the handler, so the eventbus services/status broadcast fires after the stream closes and the WS snapshot refreshes as before.