### PR TITLE
feat(ui): offline landing page for the installed PWA

### DIFF
--- a/docs/features/web-ui.md
+++ b/docs/features/web-ui.md
@@ -22,7 +22,7 @@ The dashboard is a Progressive Web App (PWA). You can install it as a standalone
 
 Once installed, Lerd opens in its own window without browser chrome, just like a native app.
 
-A service worker ships with the dashboard, so when lerd-ui is stopped (or restarting) the installed PWA shows a small offline landing page instead of the usual browser "this site can't be reached" error. The page surfaces the command to start lerd-ui again and auto-reloads the dashboard as soon as the backend comes back up.
+A service worker ships with the dashboard, so when lerd is stopped (including via `lerd quit`) or restarting, the installed PWA shows a small offline landing page instead of the usual browser "this site can't be reached" error. The page surfaces `lerd start` as the restart command and auto-reloads the dashboard as soon as the backend comes back up.
 
 ---
 

--- a/docs/features/web-ui.md
+++ b/docs/features/web-ui.md
@@ -22,6 +22,8 @@ The dashboard is a Progressive Web App (PWA). You can install it as a standalone
 
 Once installed, Lerd opens in its own window without browser chrome, just like a native app.
 
+A service worker ships with the dashboard, so when lerd-ui is stopped (or restarting) the installed PWA shows a small offline landing page instead of the usual browser "this site can't be reached" error. The page surfaces the command to start lerd-ui again and auto-reloads the dashboard as soon as the backend comes back up.
+
 ---
 
 ## Layout

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -856,6 +856,14 @@ func EnsureLerdVhost() error {
         proxy_pass http://host.containers.internal:7073;
     }
 
+    location = /sw.js {
+        proxy_pass http://host.containers.internal:7073;
+    }
+
+    location = /offline.html {
+        proxy_pass http://host.containers.internal:7073;
+    }
+
     location / {
         return 444;
     }
@@ -882,6 +890,14 @@ func EnsureLerdVhost() error {
     }
 
     location = /manifest.webmanifest {
+        proxy_pass http://unix:%[1]s:$request_uri;
+    }
+
+    location = /sw.js {
+        proxy_pass http://unix:%[1]s:$request_uri;
+    }
+
+    location = /offline.html {
         proxy_pass http://unix:%[1]s:$request_uri;
     }
 

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -4708,8 +4708,14 @@ function lerdApp() {
 <script>
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', function () {
-      navigator.serviceWorker.register('/sw.js').catch(function () { /* ignore */ });
+      navigator.serviceWorker.register('/sw.js').then(function (reg) {
+        console.info('[lerd] SW registered, scope=', reg.scope);
+      }).catch(function (err) {
+        console.warn('[lerd] SW registration failed:', err);
+      });
     });
+  } else {
+    console.warn('[lerd] serviceWorker unavailable (insecure context? private mode?)');
   }
 </script>
 

--- a/internal/ui/index.html
+++ b/internal/ui/index.html
@@ -4705,5 +4705,13 @@ function lerdApp() {
   </div>
 </template>
 
+<script>
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', function () {
+      navigator.serviceWorker.register('/sw.js').catch(function () { /* ignore */ });
+    });
+  }
+</script>
+
 </body>
 </html>

--- a/internal/ui/offline.html
+++ b/internal/ui/offline.html
@@ -28,6 +28,7 @@
       padding: 28px 28px 24px;
       box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
     }
+    .logo { width: 56px; height: 56px; margin: 0 0 16px; display: block; }
     .title {
       display: flex;
       align-items: center;
@@ -56,7 +57,24 @@
       color: #d1d5db;
       white-space: pre-wrap;
       word-break: break-word;
+      margin: 0;
+      flex: 1;
     }
+    .cmd-row { display: flex; gap: 6px; align-items: stretch; }
+    .copy-btn {
+      background: #0d0d0d;
+      border: 1px solid #2a2a2a;
+      color: #9ca3af;
+      border-radius: 6px;
+      padding: 0 10px;
+      font-size: 11px;
+      font-weight: 500;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: color 0.15s, background 0.15s;
+    }
+    .copy-btn:hover { color: #e5e7eb; background: #141414; }
+    .copy-btn.copied { color: #10b981; border-color: rgba(16, 185, 129, 0.4); }
     .row { display: flex; gap: 10px; margin-top: 20px; align-items: center; }
     button {
       appearance: none;
@@ -76,14 +94,18 @@
 </head>
 <body>
   <div class="card">
-    <p class="title"><span class="dot" id="dot"></span> lerd-ui is not reachable</p>
-    <p class="subtitle">This page is being served by the installed app's offline cache. Your services are unaffected — only the dashboard backend is stopped or restarting.</p>
+    <img class="logo" src="/icons/icon.svg" alt="Lerd">
+    <p class="title"><span class="dot" id="dot"></span> Lerd is not running</p>
+    <p class="subtitle">This page is being served by the installed app's offline cache. Your containers and site files are untouched; only the lerd stack is stopped or restarting.</p>
 
     <h2>Start it</h2>
-    <pre id="cmd">systemctl --user start lerd-ui</pre>
+    <div class="cmd-row">
+      <pre id="cmd">lerd start</pre>
+      <button class="copy-btn" id="copy" type="button">Copy</button>
+    </div>
 
     <h2>Or use the tray</h2>
-    <p class="subtitle" style="margin-top: 0">Click the lerd tray icon and choose <strong>Start Lerd UI</strong>. On macOS, look in the menu bar.</p>
+    <p class="subtitle" style="margin-top: 0">Click the lerd tray icon and choose <strong>Start Lerd</strong>. On macOS, look in the menu bar.</p>
 
     <div class="row">
       <button id="retry">Retry now</button>
@@ -92,15 +114,31 @@
   </div>
   <script>
     (function () {
-      var cmd = document.getElementById('cmd');
-      var platform = (navigator.userAgentData && navigator.userAgentData.platform) || navigator.platform || '';
-      if (/mac/i.test(platform)) {
-        cmd.textContent = 'launchctl kickstart -k gui/$(id -u)/com.lerd.lerd-ui';
-      }
-
       var statusEl = document.getElementById('status');
       var dotEl = document.getElementById('dot');
       var retryBtn = document.getElementById('retry');
+      var copyBtn = document.getElementById('copy');
+      var cmdEl = document.getElementById('cmd');
+
+      copyBtn.addEventListener('click', async function () {
+        try {
+          await navigator.clipboard.writeText(cmdEl.textContent.trim());
+        } catch (_) {
+          var r = document.createRange();
+          r.selectNodeContents(cmdEl);
+          var s = window.getSelection();
+          s.removeAllRanges();
+          s.addRange(r);
+          try { document.execCommand('copy'); } catch (_) {}
+          s.removeAllRanges();
+        }
+        copyBtn.textContent = 'Copied';
+        copyBtn.classList.add('copied');
+        setTimeout(function () {
+          copyBtn.textContent = 'Copy';
+          copyBtn.classList.remove('copied');
+        }, 1500);
+      });
 
       async function probe() {
         try {

--- a/internal/ui/offline.html
+++ b/internal/ui/offline.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lerd — offline</title>
+  <link rel="manifest" href="/manifest.webmanifest">
+  <link rel="icon" href="/icons/icon.svg" type="image/svg+xml">
+  <style>
+    :root { color-scheme: dark; }
+    html, body { margin: 0; padding: 0; height: 100%; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      background: #0d0d0d;
+      color: #e5e7eb;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      box-sizing: border-box;
+    }
+    .card {
+      max-width: 520px;
+      width: 100%;
+      background: #1a1a1a;
+      border: 1px solid #2a2a2a;
+      border-radius: 12px;
+      padding: 28px 28px 24px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+    }
+    .title {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 18px;
+      font-weight: 600;
+      margin: 0 0 4px;
+    }
+    .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: #9ca3af;
+      box-shadow: 0 0 0 3px rgba(156, 163, 175, 0.15);
+    }
+    .subtitle { margin: 0 0 20px; color: #9ca3af; font-size: 13px; }
+    h2 { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: #9ca3af; margin: 18px 0 8px; }
+    code, pre {
+      font-family: "SF Mono", Menlo, Consolas, monospace;
+      font-size: 12px;
+      background: #0d0d0d;
+      border: 1px solid #2a2a2a;
+      border-radius: 6px;
+      padding: 8px 10px;
+      display: block;
+      color: #d1d5db;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .row { display: flex; gap: 10px; margin-top: 20px; align-items: center; }
+    button {
+      appearance: none;
+      background: #FF2D20;
+      color: white;
+      border: 0;
+      border-radius: 6px;
+      padding: 9px 14px;
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+    }
+    button:hover { background: #e8281c; }
+    .status { font-size: 12px; color: #6b7280; }
+    .status.online { color: #10b981; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <p class="title"><span class="dot" id="dot"></span> lerd-ui is not reachable</p>
+    <p class="subtitle">This page is being served by the installed app's offline cache. Your services are unaffected — only the dashboard backend is stopped or restarting.</p>
+
+    <h2>Start it</h2>
+    <pre id="cmd">systemctl --user start lerd-ui</pre>
+
+    <h2>Or use the tray</h2>
+    <p class="subtitle" style="margin-top: 0">Click the lerd tray icon and choose <strong>Start Lerd UI</strong>. On macOS, look in the menu bar.</p>
+
+    <div class="row">
+      <button id="retry">Retry now</button>
+      <span class="status" id="status">checking every 5s…</span>
+    </div>
+  </div>
+  <script>
+    (function () {
+      var cmd = document.getElementById('cmd');
+      var platform = (navigator.userAgentData && navigator.userAgentData.platform) || navigator.platform || '';
+      if (/mac/i.test(platform)) {
+        cmd.textContent = 'launchctl kickstart -k gui/$(id -u)/com.lerd.lerd-ui';
+      }
+
+      var statusEl = document.getElementById('status');
+      var dotEl = document.getElementById('dot');
+      var retryBtn = document.getElementById('retry');
+
+      async function probe() {
+        try {
+          var res = await fetch('/api/status', { cache: 'no-store' });
+          if (res.ok) {
+            statusEl.textContent = 'online — reloading';
+            statusEl.classList.add('online');
+            dotEl.style.background = '#10b981';
+            dotEl.style.boxShadow = '0 0 0 3px rgba(16, 185, 129, 0.2)';
+            setTimeout(function () { location.reload(); }, 400);
+            return;
+          }
+        } catch (_) { /* still offline */ }
+        statusEl.textContent = 'still offline — retrying in 5s';
+      }
+
+      retryBtn.addEventListener('click', function () { location.reload(); });
+      probe();
+      setInterval(probe, 5000);
+    })();
+  </script>
+</body>
+</html>

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/geodro/lerd/internal/siteops"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	lerdUpdate "github.com/geodro/lerd/internal/update"
+	"github.com/geodro/lerd/internal/version"
 	"github.com/geodro/lerd/internal/xdebugops"
 )
 
@@ -60,6 +61,12 @@ var iconMaskable192PNG []byte
 
 //go:embed icons/icon-maskable-512.png
 var iconMaskable512PNG []byte
+
+//go:embed sw.js
+var swJS []byte
+
+//go:embed offline.html
+var offlineHTML []byte
 
 // listenAddr is the TCP address lerd-ui binds to. It listens on 0.0.0.0:7073
 // so browsers can hit it directly and LAN clients (gated by the remote-control
@@ -258,6 +265,18 @@ func Start(currentVersion string) error {
 	mux.HandleFunc("/icons/icon-maskable-512.png", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/png")
 		w.Write(iconMaskable512PNG) //nolint:errcheck
+	})
+	swBody := bytes.ReplaceAll(swJS, []byte("{{LERD_VERSION}}"), []byte(version.Version+"-"+version.Commit))
+	mux.HandleFunc("/sw.js", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Service-Worker-Allowed", "/")
+		w.Write(swBody) //nolint:errcheck
+	})
+	mux.HandleFunc("/offline.html", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Write(offlineHTML) //nolint:errcheck
 	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/ui/sw.js
+++ b/internal/ui/sw.js
@@ -1,0 +1,61 @@
+const VERSION = '{{LERD_VERSION}}';
+const CACHE = 'lerd-shell-' + VERSION;
+
+const SHELL = [
+  '/offline.html',
+  '/manifest.webmanifest',
+  '/icons/icon-192.png',
+  '/icons/icon-512.png',
+  '/icons/icon.svg',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE)
+      .then((cache) => cache.addAll(SHELL))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(
+      keys.filter((k) => k.startsWith('lerd-shell-') && k !== CACHE).map((k) => caches.delete(k))
+    )).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  if (req.method !== 'GET') return;
+  const url = new URL(req.url);
+  if (url.origin !== self.location.origin) return;
+  if (url.pathname.startsWith('/api/')) return;
+
+  if (req.mode === 'navigate') {
+    event.respondWith((async () => {
+      try {
+        return await fetch(req);
+      } catch (_) {
+        const fallback = await caches.match('/offline.html');
+        return fallback || new Response('lerd-ui unreachable', { status: 503, headers: { 'Content-Type': 'text/plain' } });
+      }
+    })());
+    return;
+  }
+
+  event.respondWith((async () => {
+    const cached = await caches.match(req);
+    if (cached) return cached;
+    try {
+      const res = await fetch(req);
+      if (res && res.ok && res.type === 'basic') {
+        const copy = res.clone();
+        caches.open(CACHE).then((cache) => cache.put(req, copy)).catch(() => {});
+      }
+      return res;
+    } catch (_) {
+      return new Response('', { status: 503 });
+    }
+  })());
+});


### PR DESCRIPTION
## Summary

When lerd-ui is stopped or restarting, the installed dashboard (PWA) previously showed the browser's generic "this site can't be reached" error. This change ships a small service worker that swaps that in for a dedicated offline landing page, and the dashboard auto-recovers the moment the backend comes back.

## Changes

**`internal/ui/sw.js`** — new service worker:
- **Navigation requests**: network-first; on fetch failure, returns the cached `/offline.html`.
- **Static assets** (icons, manifest): cache-first, filled on first successful load.
- **`/api/*` requests are bypassed entirely** — the WebSocket and every mutating call keep their normal error semantics so a stopped backend surfaces honestly everywhere except on top-level navigation.
- Cache name is `lerd-shell-<version>-<commit>`; `install` pre-caches the offline page + icons + manifest, `activate` deletes any older `lerd-shell-*` caches. Each lerd update naturally invalidates the previous cache.

**`internal/ui/offline.html`** — dark-themed static page:
- States "lerd-ui is not reachable" and clarifies that services themselves are unaffected.
- Shows the restart command per-platform (systemctl on Linux, launchctl on macOS, detected via `navigator.userAgentData.platform`).
- Probes `/api/status` every 5 s; when the call succeeds it flips the status dot green and reloads automatically, so the user typically sees the offline page for less than one probe interval.
- Retry button for manual reload.

**`internal/ui/server.go`** — two new routes:
- `/sw.js` — served with `Content-Type: application/javascript; charset=utf-8`, `Cache-Control: no-cache`, and `Service-Worker-Allowed: /` for full-site scope. `{{LERD_VERSION}}` is substituted once at startup from `version.Version+"-"+version.Commit` so the SW bytes change on every release, triggering a real install cycle in the browser.
- `/offline.html` — static HTML.

**`internal/ui/index.html`** — SW registration under `'serviceWorker' in navigator`, fires on `load` so it doesn't race the main app boot.

## Activation

Existing browsers installing the PWA after this change ships will register the SW on the next page load. The SW takes control on the subsequent navigation (standard SW lifecycle — `clients.claim()` is called at activate but navigation requests already in-flight use the previous controller). No action required on the user side.