### PR TITLE
fix(macos): unquote Environment= values and honour UserNS= in launchd plist

### DIFF
--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -199,6 +199,17 @@ func parseSection(content, section string) map[string][]string {
 	return result
 }
 
+// unquoteSystemdValue strips the outer double-quotes that systemd / quadlet
+// uses for values that contain spaces or special chars (e.g. Environment=
+// "KEY=hello world"). The shell never processes these args, so the quotes
+// must be removed before passing to exec.Command.
+func unquoteSystemdValue(s string) string {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return strings.ReplaceAll(s[1:len(s)-1], `\"`, `"`)
+	}
+	return s
+}
+
 // expandSpecifiers replaces Quadlet path specifiers (%h → home dir).
 func expandSpecifiers(s string) string {
 	home, _ := os.UserHomeDir()
@@ -314,7 +325,10 @@ func containerToPodmanArgs(c map[string][]string) ([]string, error) {
 		args = append(args, "-v", stripSELinuxVolOpts(expandSpecifiers(vol)))
 	}
 	for _, env := range c["Environment"] {
-		args = append(args, "-e", env)
+		args = append(args, "-e", unquoteSystemdValue(env))
+	}
+	if userns := c["UserNS"]; len(userns) > 0 {
+		args = append(args, "--userns", userns[0])
 	}
 	if dirs := c["WorkingDir"]; len(dirs) > 0 {
 		args = append(args, "--workdir", expandSpecifiers(dirs[0]))

--- a/internal/services/launchd_test.go
+++ b/internal/services/launchd_test.go
@@ -311,6 +311,58 @@ func TestIsEnabledBasedOnPlistExistence(t *testing.T) {
 	}
 }
 
+func TestUnquoteSystemdValue(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`"FOO=bar"`, `FOO=bar`},
+		{`"ES_JAVA_OPTS=-Xms512m -Xmx512m"`, `ES_JAVA_OPTS=-Xms512m -Xmx512m`},
+		{`"http.cors.allow-origin=\"*\""`, `http.cors.allow-origin="*"`},
+		{`FOO=bar`, `FOO=bar`},
+		{`"unclosed`, `"unclosed`},
+		{``, ``},
+	}
+	for _, tt := range cases {
+		if got := unquoteSystemdValue(tt.in); got != tt.want {
+			t.Errorf("unquoteSystemdValue(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestContainerToPodmanArgsQuotedEnv(t *testing.T) {
+	c := map[string][]string{
+		"ContainerName": {"lerd-elasticsearch"},
+		"Image":         {"docker.elastic.co/elasticsearch/elasticsearch:8.13.4"},
+		"Network":       {"lerd"},
+		"Environment": {
+			`"ES_JAVA_OPTS=-Xms512m -Xmx512m"`,
+			`"http.cors.allow-origin=\"*\""`,
+			`"discovery.type=single-node"`,
+		},
+		"UserNS": {"keep-id:uid=1000,gid=0"},
+	}
+	args, err := containerToPodmanArgs(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	argStr := strings.Join(args, " ")
+
+	for _, want := range []string{
+		"-e ES_JAVA_OPTS=-Xms512m -Xmx512m",
+		`-e http.cors.allow-origin="*"`,
+		"-e discovery.type=single-node",
+		"--userns keep-id:uid=1000,gid=0",
+	} {
+		if !strings.Contains(argStr, want) {
+			t.Errorf("args missing %q in:\n%s", want, argStr)
+		}
+	}
+	// Confirm no literal quotes bleed through into env values
+	for _, bad := range []string{`-e "ES_JAVA_OPTS`, `"discovery.type`} {
+		if strings.Contains(argStr, bad) {
+			t.Errorf("args contain literal quote in env: %q found in:\n%s", bad, argStr)
+		}
+	}
+}
+
 func TestStripPrivilegedIPBind_v4(t *testing.T) {
 	cases := map[string]string{
 		"127.0.0.1:80:80":     "80:80",


### PR DESCRIPTION
Two bugs in `launchd_darwin.go` introduced when `quadlet_generate.go` started wrapping `Environment=` values in double-quotes.

## Environment= quoting

`parseSection` returned `"KEY=VALUE"` with literal double-quotes, so `podman run -e "KEY=VALUE"` received an env var whose name started with `"`. Added `unquoteSystemdValue` which strips surrounding quotes and unescapes `\"` → `"` before the value reaches `exec.Command`.

Affects elasticsearch (`ES_JAVA_OPTS`, `http.cors.*`), rabbitmq, and any custom service or FrankenPHP container with `environment:` entries.

## UserNS= silently dropped

The elasticsearch preset uses `userns: keep-id:uid=1000,gid=0` but `containerToPodmanArgs` had no handler for `UserNS=`. Without `--userns=keep-id`, the `:U` data-dir chown maps to the wrong UID and elasticsearch fails to start on macOS.