### PR TITLE
feat(cli): add bug-report command for GitHub issue triage

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -105,6 +105,7 @@ func main() {
 	root.AddCommand(cli.NewWhatsnewCmd())
 	root.AddCommand(cli.NewManCmd())
 	root.AddCommand(cli.NewDoctorCmd())
+	root.AddCommand(cli.NewBugReportCmd())
 	root.AddCommand(cli.NewLogsCmd())
 	root.AddCommand(cli.NewOpenCmd())
 	root.AddCommand(cli.NewDashboardCmd())

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -25,6 +25,7 @@
 | `lerd tui` | Open a btop-style terminal dashboard with live site / service / worker status, per-site detail pane, inline domain and version editing, shell drop-in, log tailing, filter + sort, and global settings |
 | `lerd check` | Validate `.lerd.yaml` syntax, services, and PHP version before setup |
 | `lerd doctor` | Full environment diagnostic: podman, systemd, DNS, ports, PHP images, config validity |
+| `lerd bug-report [-o file] [--log-lines n]` | Dump doctor output, config files, unit state, recent logs, network state and env vars to a plain-text file you can attach to a GitHub issue |
 | `lerd logs [-f] [target]` | Show logs for the current project's FPM container, `nginx`, a service name, or a PHP version |
 
 ## Project creation

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,6 +9,24 @@ lerd status   # quick health snapshot of all running services
 
 `lerd doctor` reports OK/FAIL/WARN for each check with a hint for every failure.
 
+## Filing a bug report
+
+If you need help on the [issue tracker](https://github.com/geodro/lerd/issues), run:
+
+```bash
+lerd bug-report
+```
+
+This writes a single plain-text file (default: `./lerd-bug-report-<timestamp>.txt`) containing the full `lerd doctor` output, your `config.yaml` and `sites.yaml`, the state of every `lerd-*` systemd unit, recent journal and container logs, listening sockets on the lerd ports, and a curated set of environment variables. Site `.env` files are intentionally excluded; home paths are replaced with `$HOME`.
+
+Skim the file before posting (it's plain text — open it in any editor) and attach it to your GitHub issue.
+
+Override the destination with `--output`, or change how many log lines per service to include with `--log-lines`:
+
+```bash
+lerd bug-report --output /tmp/report.txt --log-lines 500
+```
+
 ---
 
 ::: details `.test` domains not resolving

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,10 @@ require (
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.10.2
+	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/getlantern/systray v1.2.2
+	github.com/godbus/dbus/v5 v5.2.2
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/cobra v1.8.0
@@ -31,7 +33,6 @@ require (
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
-	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -42,7 +43,6 @@ require (
 	github.com/getlantern/hidden v0.0.0-20190325191715-f02dbb02be55 // indirect
 	github.com/getlantern/ops v0.0.0-20190325191751-d70cb0d6f85f // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/getlantern/systray v1.2.2 h1:dCEHtfmvkJG7HZ8lS/sLklTH4RKUcIsKrAD9sTho
 github.com/getlantern/systray v1.2.2/go.mod h1:pXFOI1wwqwYXEhLPm9ZGjS2u/vVELeIgNMY5HvhHhcE=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
-github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=

--- a/internal/cli/bug_report.go
+++ b/internal/cli/bug_report.go
@@ -1,0 +1,357 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/services"
+	"github.com/geodro/lerd/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// NewBugReportCmd returns the bug-report command. It writes a single
+// plain-text file aggregating the diagnostics a maintainer needs to triage a
+// GitHub issue: doctor output, config files, systemd/podman state, recent
+// logs, network state, and a curated set of environment variables.
+func NewBugReportCmd() *cobra.Command {
+	var outputPath string
+	var logLines int
+	cmd := &cobra.Command{
+		Use:   "bug-report",
+		Short: "Collect diagnostics into a single file for GitHub bug reports",
+		Long: "Generates a plain-text report containing the lerd doctor output, " +
+			"config files, systemd unit state, recent service logs, network " +
+			"state and the relevant environment variables. Attach the file to " +
+			"your GitHub issue.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			path, err := writeBugReport(outputPath, logLines)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Bug report written to: %s\n", path)
+			fmt.Println("Skim it for anything sensitive before posting, then attach it to your GitHub issue.")
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "output file path (default: ./lerd-bug-report-<timestamp>.txt)")
+	cmd.Flags().IntVar(&logLines, "log-lines", 200, "number of recent log lines to include per service/container")
+	return cmd
+}
+
+func writeBugReport(outputPath string, logLines int) (string, error) {
+	if logLines <= 0 {
+		logLines = 200
+	}
+	if outputPath == "" {
+		ts := time.Now().Format("20060102-150405")
+		outputPath = fmt.Sprintf("lerd-bug-report-%s.txt", ts)
+	}
+	abs, err := filepath.Abs(outputPath)
+	if err != nil {
+		return "", fmt.Errorf("resolving output path: %w", err)
+	}
+	f, err := os.Create(abs)
+	if err != nil {
+		return "", fmt.Errorf("creating output file: %w", err)
+	}
+	defer f.Close()
+
+	var buf bytes.Buffer
+	collectBugReport(&buf, logLines)
+
+	scrubbed := scrubHomePath(buf.String())
+	if _, err := io.WriteString(f, scrubbed); err != nil {
+		return "", fmt.Errorf("writing report: %w", err)
+	}
+	return abs, nil
+}
+
+func collectBugReport(w io.Writer, logLines int) {
+	writeBugReportHeader(w)
+
+	section(w, "Doctor")
+	if _, _, err := RunDoctorTo(w, false); err != nil {
+		fmt.Fprintf(w, "doctor failed: %v\n", err)
+	}
+
+	section(w, "Config files")
+	dumpConfigFiles(w)
+
+	section(w, "Installed runtimes")
+	dumpRuntimes(w)
+
+	section(w, "Systemd / launchd unit state")
+	dumpUnitState(w)
+
+	section(w, "Containers")
+	dumpContainers(w)
+
+	section(w, fmt.Sprintf("Recent service logs (last %d lines)", logLines))
+	dumpServiceLogs(w, logLines)
+
+	section(w, fmt.Sprintf("Recent container logs (last %d lines)", logLines))
+	dumpContainerLogs(w, logLines)
+
+	section(w, "Network")
+	dumpNetwork(w)
+
+	section(w, "Environment")
+	dumpEnvironment(w)
+}
+
+func writeBugReportHeader(w io.Writer) {
+	fmt.Fprintln(w, "Lerd bug report")
+	fmt.Fprintln(w, "════════════════════════════════════════════════════════")
+	fmt.Fprintln(w, "Review this file before posting publicly. It contains")
+	fmt.Fprintln(w, "your config and recent service logs but no .env contents.")
+	fmt.Fprintln(w, "Home paths have been replaced with $HOME.")
+	fmt.Fprintln(w, "════════════════════════════════════════════════════════")
+	fmt.Fprintf(w, "Generated:  %s\n", time.Now().Format(time.RFC3339))
+	fmt.Fprintf(w, "lerd:       %s\n", version.String())
+	fmt.Fprintf(w, "OS:         %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(w, "Go runtime: %s\n", runtime.Version())
+	if runtime.GOOS == "linux" {
+		if name := readOSRelease(); name != "" {
+			fmt.Fprintf(w, "Distro:     %s\n", name)
+		}
+		if out, err := exec.Command("uname", "-r").Output(); err == nil {
+			fmt.Fprintf(w, "Kernel:     %s\n", strings.TrimSpace(string(out)))
+		}
+	}
+	if runtime.GOOS == "darwin" {
+		if out, err := exec.Command("sw_vers", "-productVersion").Output(); err == nil {
+			fmt.Fprintf(w, "macOS:      %s\n", strings.TrimSpace(string(out)))
+		}
+	}
+}
+
+func section(w io.Writer, title string) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "════════════════════════════════════════════════════════")
+	fmt.Fprintf(w, "  %s\n", title)
+	fmt.Fprintln(w, "════════════════════════════════════════════════════════")
+}
+
+func dumpConfigFiles(w io.Writer) {
+	for _, p := range []string{config.GlobalConfigFile(), config.SitesFile()} {
+		fmt.Fprintf(w, "── %s\n", p)
+		data, err := os.ReadFile(p)
+		if err != nil {
+			fmt.Fprintf(w, "(unreadable: %v)\n\n", err)
+			continue
+		}
+		fmt.Fprintln(w, string(data))
+		if !bytes.HasSuffix(data, []byte("\n")) {
+			fmt.Fprintln(w)
+		}
+	}
+}
+
+func dumpRuntimes(w io.Writer) {
+	if out, err := exec.Command("podman", "--version").Output(); err == nil {
+		fmt.Fprintf(w, "podman:    %s", string(out))
+	} else {
+		fmt.Fprintln(w, "podman:    (not found)")
+	}
+	if out, err := exec.Command("podman", "info", "--format", "{{.Host.OCIRuntime.Name}} {{.Host.OCIRuntime.Version}}").Output(); err == nil {
+		fmt.Fprintf(w, "OCI:       %s", string(out))
+	}
+	if cfg, err := config.LoadGlobal(); err == nil {
+		fmt.Fprintf(w, "PHP default: %s\n", cfg.PHP.DefaultVersion)
+		fmt.Fprintf(w, "Node default: %s\n", cfg.Node.DefaultVersion)
+	}
+}
+
+func dumpUnitState(w io.Writer) {
+	units := lerdUnits()
+	if len(units) == 0 {
+		fmt.Fprintln(w, "(no lerd units found)")
+		return
+	}
+	for _, name := range units {
+		state, err := services.Mgr.UnitStatus(name)
+		if err != nil {
+			state = fmt.Sprintf("error: %v", err)
+		}
+		enabled := "no"
+		if services.Mgr.IsEnabled(name) {
+			enabled = "yes"
+		}
+		fmt.Fprintf(w, "%-30s  state=%s  enabled=%s\n", name, state, enabled)
+	}
+}
+
+// lerdUnits returns the union of installed container units and service units
+// matching the lerd-* prefix, deduplicated and sorted.
+func lerdUnits() []string {
+	seen := map[string]struct{}{}
+	for _, n := range services.Mgr.ListContainerUnits("lerd-*") {
+		seen[n] = struct{}{}
+	}
+	for _, n := range services.Mgr.ListServiceUnits("lerd-*") {
+		seen[n] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func dumpContainers(w io.Writer) {
+	out, err := podman.Run("ps", "-a", "--filter", "name=lerd-", "--format",
+		"{{.Names}}\t{{.Status}}\t{{.Image}}")
+	if err != nil {
+		fmt.Fprintf(w, "(podman ps failed: %v)\n", err)
+		return
+	}
+	if strings.TrimSpace(out) == "" {
+		fmt.Fprintln(w, "(no lerd containers)")
+		return
+	}
+	fmt.Fprintln(w, out)
+}
+
+func dumpServiceLogs(w io.Writer, n int) {
+	if runtime.GOOS != "linux" {
+		fmt.Fprintln(w, "(skipped: journalctl is Linux-only)")
+		return
+	}
+	for _, unit := range lerdUnits() {
+		fmt.Fprintf(w, "── journalctl --user -u %s --no-pager -n %d\n", unit, n)
+		out, err := exec.Command("journalctl", "--user", "-u", unit,
+			"--no-pager", "-n", fmt.Sprintf("%d", n)).CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(w, "(failed: %v)\n", err)
+		}
+		fmt.Fprintln(w, strings.TrimRight(string(out), "\n"))
+		fmt.Fprintln(w)
+	}
+}
+
+func dumpContainerLogs(w io.Writer, n int) {
+	out, err := podman.Run("ps", "-a", "--filter", "name=lerd-", "--format", "{{.Names}}")
+	if err != nil {
+		fmt.Fprintf(w, "(podman ps failed: %v)\n", err)
+		return
+	}
+	names := strings.Fields(out)
+	if len(names) == 0 {
+		fmt.Fprintln(w, "(no lerd containers)")
+		return
+	}
+	for _, name := range names {
+		fmt.Fprintf(w, "── podman logs --tail %d %s\n", n, name)
+		logs, err := podman.Run("logs", "--tail", fmt.Sprintf("%d", n), name)
+		if err != nil {
+			fmt.Fprintf(w, "(failed: %v)\n\n", err)
+			continue
+		}
+		fmt.Fprintln(w, logs)
+		fmt.Fprintln(w)
+	}
+}
+
+func dumpNetwork(w io.Writer) {
+	fmt.Fprintln(w, "── listening sockets (lerd-relevant ports)")
+	listing := portListOutput()
+	for _, port := range []string{"53", "80", "443", "5300", "7073"} {
+		for _, line := range strings.Split(listing, "\n") {
+			if strings.Contains(line, ":"+port+" ") {
+				fmt.Fprintf(w, "  port %-4s  %s\n", port, strings.TrimSpace(line))
+			}
+		}
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "── /etc/resolv.conf")
+	if data, err := os.ReadFile("/etc/resolv.conf"); err == nil {
+		fmt.Fprintln(w, strings.TrimRight(string(data), "\n"))
+	} else {
+		fmt.Fprintf(w, "(unreadable: %v)\n", err)
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "── host gateway probe (host.containers.internal)")
+	if !services.Mgr.IsActive("lerd-nginx") || !services.Mgr.IsActive("lerd-ui") {
+		fmt.Fprintln(w, "skipped: lerd-nginx and/or lerd-ui not running")
+	} else if ip := podman.DetectHostGatewayIPProbeOnly(); ip != "" {
+		fmt.Fprintf(w, "reachable via %s\n", ip)
+	} else {
+		fmt.Fprintln(w, "no candidate routed back to host (Xdebug + container→host calls will fail)")
+	}
+}
+
+// envAllowlist is the curated set of environment variables included in the
+// bug report. We intentionally avoid dumping the full environment because
+// CI/CD or shell setups frequently contain secrets in unrelated variables.
+var envAllowlist = []string{
+	"PATH",
+	"SHELL",
+	"USER",
+	"LOGNAME",
+	"LANG",
+	"LC_ALL",
+	"TERM",
+	"XDG_CONFIG_HOME",
+	"XDG_DATA_HOME",
+	"XDG_RUNTIME_DIR",
+	"XDG_SESSION_TYPE",
+	"DBUS_SESSION_BUS_ADDRESS",
+	"DOCKER_HOST",
+	"CONTAINER_HOST",
+}
+
+func dumpEnvironment(w io.Writer) {
+	for _, key := range envAllowlist {
+		val := os.Getenv(key)
+		if val == "" {
+			continue
+		}
+		fmt.Fprintf(w, "%s=%s\n", key, val)
+	}
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "LERD_") {
+			fmt.Fprintln(w, kv)
+		}
+	}
+}
+
+// scrubHomePath replaces occurrences of the user's home directory with the
+// literal string "$HOME". Pure cosmetic privacy: it does not constitute a
+// security boundary, just a courtesy so the report is shorter and doesn't
+// expose the username repeatedly.
+func scrubHomePath(s string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" || home == "/" {
+		return s
+	}
+	return strings.ReplaceAll(s, home, "$HOME")
+}
+
+// readOSRelease reads /etc/os-release and returns the PRETTY_NAME value.
+// Returns empty string on any error.
+func readOSRelease() string {
+	data, err := os.ReadFile("/etc/os-release")
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "PRETTY_NAME=") {
+			val := strings.TrimPrefix(line, "PRETTY_NAME=")
+			return strings.Trim(val, `"`)
+		}
+	}
+	return ""
+}

--- a/internal/cli/bug_report_test.go
+++ b/internal/cli/bug_report_test.go
@@ -85,7 +85,11 @@ func TestWriteBugReport_defaultPath(t *testing.T) {
 	if !strings.HasPrefix(filepath.Base(got), "lerd-bug-report-") {
 		t.Errorf("default filename doesn't start with lerd-bug-report-: %s", got)
 	}
-	if filepath.Dir(got) != dir {
+	// EvalSymlinks both sides because macOS resolves /var → /private/var,
+	// so t.TempDir() and os.Getwd()-after-chdir return different forms.
+	gotDir, _ := filepath.EvalSymlinks(filepath.Dir(got))
+	wantDir, _ := filepath.EvalSymlinks(dir)
+	if gotDir != wantDir {
 		t.Errorf("default file not in cwd: %s (cwd=%s)", got, dir)
 	}
 }

--- a/internal/cli/bug_report_test.go
+++ b/internal/cli/bug_report_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestScrubHomePath_replacesHome(t *testing.T) {
+	t.Setenv("HOME", "/home/testuser")
+	in := "log line referencing /home/testuser/.config/lerd/config.yaml here"
+	out := scrubHomePath(in)
+	if strings.Contains(out, "/home/testuser") {
+		t.Fatalf("home path not scrubbed: %q", out)
+	}
+	if !strings.Contains(out, "$HOME/.config/lerd/config.yaml") {
+		t.Fatalf("expected $HOME placeholder, got: %q", out)
+	}
+}
+
+func TestScrubHomePath_emptyHome(t *testing.T) {
+	t.Setenv("HOME", "")
+	in := "no home set"
+	if got := scrubHomePath(in); got != in {
+		t.Fatalf("expected unchanged, got %q", got)
+	}
+}
+
+func TestScrubHomePath_rootHome(t *testing.T) {
+	t.Setenv("HOME", "/")
+	in := "/etc/foo and / and /home/x"
+	if got := scrubHomePath(in); got != in {
+		t.Fatalf("expected unchanged when HOME=/, got %q", got)
+	}
+}
+
+func TestWriteBugReportHeader_includesVersionAndOS(t *testing.T) {
+	var buf bytes.Buffer
+	writeBugReportHeader(&buf)
+	out := buf.String()
+	for _, want := range []string{"Lerd bug report", "lerd:", "OS:", "Generated:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("header missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestWriteBugReport_createsFile(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "report.txt")
+	got, err := writeBugReport(target, 5)
+	if err != nil {
+		t.Fatalf("writeBugReport: %v", err)
+	}
+	if got != target {
+		t.Errorf("path mismatch: got %s want %s", got, target)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	for _, want := range []string{"Lerd bug report", "Doctor", "Config files", "Environment"} {
+		if !bytes.Contains(data, []byte(want)) {
+			t.Errorf("report missing %q", want)
+		}
+	}
+}
+
+func TestWriteBugReport_defaultPath(t *testing.T) {
+	dir := t.TempDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	got, err := writeBugReport("", 5)
+	if err != nil {
+		t.Fatalf("writeBugReport: %v", err)
+	}
+	if !strings.HasPrefix(filepath.Base(got), "lerd-bug-report-") {
+		t.Errorf("default filename doesn't start with lerd-bug-report-: %s", got)
+	}
+	if filepath.Dir(got) != dir {
+		t.Errorf("default file not in cwd: %s (cwd=%s)", got, dir)
+	}
+}
+
+func TestEnvAllowlist_excludesSecrets(t *testing.T) {
+	for _, key := range envAllowlist {
+		switch strings.ToUpper(key) {
+		case "AWS_SECRET_ACCESS_KEY", "GITHUB_TOKEN", "ANTHROPIC_API_KEY":
+			t.Errorf("envAllowlist must not contain %q", key)
+		}
+		if strings.Contains(strings.ToUpper(key), "TOKEN") ||
+			strings.Contains(strings.ToUpper(key), "SECRET") ||
+			strings.Contains(strings.ToUpper(key), "PASSWORD") ||
+			strings.Contains(strings.ToUpper(key), "KEY") {
+			t.Errorf("envAllowlist contains suspicious key: %q", key)
+		}
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
@@ -27,45 +28,57 @@ func NewDoctorCmd() *cobra.Command {
 }
 
 func runDoctor(_ *cobra.Command, _ []string) error {
-	var fails, warns int
+	_, _, err := RunDoctorTo(os.Stdout, true)
+	return err
+}
+
+// RunDoctorTo runs the full doctor diagnostic, writing human-readable output
+// to w. When useColor is false ANSI escapes are stripped so the output is
+// safe to embed in a plain-text file (used by `lerd bug-report`). Returns
+// the failure and warning counts for callers that want to summarise.
+func RunDoctorTo(w io.Writer, useColor bool) (fails, warns int, err error) {
+	cR, cG, cY, cReset := colorRed, colorGreen, colorYellow, colorReset
+	if !useColor {
+		cR, cG, cY, cReset = "", "", "", ""
+	}
 
 	ok := func(label string) {
-		fmt.Printf("  %s%-34s%s OK\n", colorGreen, label, colorReset)
+		fmt.Fprintf(w, "  %s%-34s%s OK\n", cG, label, cReset)
 	}
 	fail := func(label, msg, hint string) {
 		fails++
-		fmt.Printf("  %s%-34s%s FAIL  %s\n    hint: %s\n", colorRed, label, colorReset, msg, hint)
+		fmt.Fprintf(w, "  %s%-34s%s FAIL  %s\n    hint: %s\n", cR, label, cReset, msg, hint)
 	}
 	warn := func(label, msg string) {
 		warns++
-		fmt.Printf("  %s%-34s%s WARN  %s\n", colorYellow, label, colorReset, msg)
+		fmt.Fprintf(w, "  %s%-34s%s WARN  %s\n", cY, label, cReset, msg)
 	}
 	info := func(label, val string) {
-		fmt.Printf("  %-34s %s\n", label, val)
+		fmt.Fprintf(w, "  %-34s %s\n", label, val)
 	}
 
-	fmt.Printf("Lerd Doctor  (version %s)\n", version.String())
-	fmt.Println("══════════════════════════════════════════════")
+	fmt.Fprintf(w, "Lerd Doctor  (version %s)\n", version.String())
+	fmt.Fprintln(w, "══════════════════════════════════════════════")
 
 	// ── Prerequisites ───────────────────────────────────────────────────────
-	fmt.Println("\n[Prerequisites]")
+	fmt.Fprintln(w, "\n[Prerequisites]")
 
-	if _, err := exec.LookPath("podman"); err != nil {
+	if _, lookErr := exec.LookPath("podman"); lookErr != nil {
 		fail("podman binary", "not found in PATH", "install podman: https://podman.io/docs/installation")
-	} else if err := podman.RunSilent("info"); err != nil {
+	} else if runErr := podman.RunSilent("info"); runErr != nil {
 		fail("podman", "podman info failed — daemon not running?", podmanDaemonHint())
 	} else {
 		ok("podman")
 	}
 
 	if runtime.GOOS == "linux" {
-		if _, err := exec.LookPath("crun"); err != nil {
+		if _, lookErr := exec.LookPath("crun"); lookErr != nil {
 			warn("OCI runtime", "crun not found — recommended for rootless podman (install: sudo pacman -S crun / sudo apt install crun / sudo dnf install crun)")
 		} else {
 			ok("OCI runtime (crun)")
 		}
 
-		if out, err := exec.Command("systemctl", "--user", "is-system-running").Output(); err != nil {
+		if out, runErr := exec.Command("systemctl", "--user", "is-system-running").Output(); runErr != nil {
 			state := strings.TrimSpace(string(out))
 			if state == "degraded" {
 				warn("systemd user session", "degraded — some units have failed")
@@ -81,8 +94,8 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 			currentUser = os.Getenv("LOGNAME")
 		}
 		if currentUser != "" {
-			out, err := exec.Command("loginctl", "show-user", currentUser).Output()
-			if err != nil || !strings.Contains(string(out), "Linger=yes") {
+			out, runErr := exec.Command("loginctl", "show-user", currentUser).Output()
+			if runErr != nil || !strings.Contains(string(out), "Linger=yes") {
 				warn("linger enabled", "services won't survive logout — fix: loginctl enable-linger "+currentUser)
 			} else {
 				ok("linger enabled")
@@ -91,24 +104,24 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	}
 
 	quadletDir := config.QuadletDir()
-	if err := checkDirWritable(quadletDir); err != nil {
-		fail("service config dir writable", err.Error(), "mkdir -p "+quadletDir)
+	if dirErr := checkDirWritable(quadletDir); dirErr != nil {
+		fail("service config dir writable", dirErr.Error(), "mkdir -p "+quadletDir)
 	} else {
 		ok("service config dir writable")
 	}
 
 	dataDir := config.DataDir()
-	if err := checkDirWritable(dataDir); err != nil {
-		fail("data dir writable", err.Error(), "mkdir -p "+dataDir)
+	if dirErr := checkDirWritable(dataDir); dirErr != nil {
+		fail("data dir writable", dirErr.Error(), "mkdir -p "+dataDir)
 	} else {
 		ok("data dir writable")
 	}
 
 	// ── Configuration ────────────────────────────────────────────────────────
-	fmt.Println("\n[Configuration]")
+	fmt.Fprintln(w, "\n[Configuration]")
 
 	cfgFile := config.GlobalConfigFile()
-	if _, err := os.Stat(cfgFile); os.IsNotExist(err) {
+	if _, statErr := os.Stat(cfgFile); os.IsNotExist(statErr) {
 		warn("config file", "not found — defaults will be used ("+cfgFile+")")
 	} else {
 		ok("config file exists")
@@ -117,7 +130,6 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	cfg, cfgErr := config.LoadGlobal()
 	if cfgErr != nil {
 		fail("config loads", cfgErr.Error(), "check "+cfgFile+" for YAML syntax errors")
-		// Can't proceed with config-dependent checks
 		cfg = nil
 	} else {
 		ok("config valid")
@@ -137,7 +149,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		}
 
 		for _, dir := range cfg.ParkedDirectories {
-			if _, err := os.Stat(dir); os.IsNotExist(err) {
+			if _, statErr := os.Stat(dir); os.IsNotExist(statErr) {
 				warn(fmt.Sprintf("parked dir: %s", truncate(dir, 26)), "directory does not exist — run: mkdir -p "+dir)
 			} else {
 				ok(fmt.Sprintf("parked dir: %s", truncate(dir, 26)))
@@ -146,7 +158,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	}
 
 	// ── DNS ──────────────────────────────────────────────────────────────────
-	fmt.Println("\n[DNS]")
+	fmt.Fprintln(w, "\n[DNS]")
 
 	tld := "test"
 	if cfg != nil && cfg.DNS.TLD != "" {
@@ -165,7 +177,6 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	// Port 5300 conflict (only warn when lerd-dns is not actively managing port 5300)
 	dnsRunning := services.Mgr.IsActive("lerd-dns")
 	if !dnsRunning {
 		if cr, _ := podman.ContainerRunning("lerd-dns"); cr {
@@ -177,7 +188,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	}
 
 	// ── Ports ────────────────────────────────────────────────────────────────
-	fmt.Println("\n[Ports]")
+	fmt.Fprintln(w, "\n[Ports]")
 
 	nginxRunning, _ := podman.ContainerRunning("lerd-nginx")
 	if nginxRunning {
@@ -197,7 +208,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	}
 
 	// ── Containers & Images ──────────────────────────────────────────────────
-	fmt.Println("\n[Containers & Images]")
+	fmt.Fprintln(w, "\n[Containers & Images]")
 
 	if !services.Mgr.ContainerUnitInstalled("lerd-nginx") {
 		fail("lerd-nginx service", "not installed", "run: lerd install")
@@ -227,7 +238,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	// Xdebug times out silently with no error in the FPM logs other than
 	// "Time-out connecting to debugging client" (issue #186 redux). This
 	// check surfaces the failure so the user gets a real diagnosis.
-	fmt.Println("\n[Container → Host connectivity]")
+	fmt.Fprintln(w, "\n[Container → Host connectivity]")
 	if !services.Mgr.IsActive("lerd-nginx") {
 		warn("host reachability probe", "skipped — lerd-nginx not running (start lerd first)")
 	} else if !services.Mgr.IsActive("lerd-ui") {
@@ -240,8 +251,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 			"check rootless podman / netavark / pasta routing; run: podman unshare --rootless-netns ip addr (expected: 169.254.1.2 on podman bridge or DNAT for it)")
 	}
 
-	// FrankenPHP suggestions: sites with signals but no runtime set get a one-line nudge.
-	if reg, err := config.LoadSites(); err == nil {
+	if reg, regErr := config.LoadSites(); regErr == nil {
 		for _, site := range reg.Sites {
 			if site.Ignored || site.IsCustomContainer() || site.IsFrankenPHP() {
 				continue
@@ -256,7 +266,7 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	}
 
 	// ── Version Info ─────────────────────────────────────────────────────────
-	fmt.Println("\n[Version Info]")
+	fmt.Fprintln(w, "\n[Version Info]")
 
 	info("lerd", version.String())
 
@@ -278,19 +288,19 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 	}
 
 	// ── Summary ──────────────────────────────────────────────────────────────
-	fmt.Println("\n══════════════════════════════════════════════")
+	fmt.Fprintln(w, "\n══════════════════════════════════════════════")
 	switch {
 	case fails > 0 && warns > 0:
-		fmt.Printf("%s%d failure(s), %d warning(s) found.%s\n", colorRed, fails, warns, colorReset)
+		fmt.Fprintf(w, "%s%d failure(s), %d warning(s) found.%s\n", cR, fails, warns, cReset)
 	case fails > 0:
-		fmt.Printf("%s%d failure(s) found.%s\n", colorRed, fails, colorReset)
+		fmt.Fprintf(w, "%s%d failure(s) found.%s\n", cR, fails, cReset)
 	case warns > 0:
-		fmt.Printf("%s%d warning(s) found.%s  All critical checks passed.\n", colorYellow, warns, colorReset)
+		fmt.Fprintf(w, "%s%d warning(s) found.%s  All critical checks passed.\n", cY, warns, cReset)
 	default:
-		fmt.Printf("%sAll checks passed.%s\n", colorGreen, colorReset)
+		fmt.Fprintf(w, "%sAll checks passed.%s\n", cG, cReset)
 	}
 
-	return nil
+	return fails, warns, nil
 }
 
 // checkDirWritable returns an error if the directory doesn't exist or isn't writable.


### PR DESCRIPTION
## Summary
- New `lerd bug-report` command that writes a single plain-text file aggregating doctor output, config files, every `lerd-*` unit's state, recent journal + container logs, listening sockets on the lerd ports, and a curated environment-variable allowlist. Users attach the file to their GitHub issue instead of being asked round-by-round for the same diagnostics.
- Refactored `runDoctor` into `RunDoctorTo(io.Writer, useColor bool)` so the report embeds the diagnostic with ANSI escapes stripped.
- Site `.env` files are never read; home paths are scrubbed to `$HOME` before the file is written. Flags: `--output <path>` (default `./lerd-bug-report-<timestamp>.txt`) and `--log-lines <n>` (default 200).
- Documented in `docs/troubleshooting.md` and `docs/reference/commands.md`.