### PR TITLE
fix(services): harden update / migrate / rollback against races, partial failures, leaks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,27 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `internal/podman/quadlets/lerd-{mysql,redis,postgres,meilisearch,rustfs,mailpit}.container` deleted — quadlets are now generated from preset YAML on demand. `internal/cli/service_image_{darwin,linux}.go` deleted — platform image overrides moved into `Preset.PlatformOverrides` with optional `{{tag}}` template substitution so `track_latest`-resolved tags survive the platform swap.
 - `applyServices` in the Web UI now refreshes every server-supplied field on each WS push (was only `status` / `pinned` / `site_count`), so update / upgrade / version state propagates over the socket without a page reload. Client-only flags (`loading`, `error`, `flash`) still survive across pushes for in-flight UI state.
 
+### Fixed
+
+- **Concurrent update / migrate / rollback now serialised per service** (`internal/serviceops/locks.go`). Double-clicking the Update button, or a CLI run racing the dashboard, can no longer interleave config writes, image pulls and data-dir swaps.
+- **`persistImageChoice` and `swapImagePin` are now atomic with quadlet regeneration**. If the on-disk quadlet write fails after the config write, the config is rolled back so `~/.config/lerd/config.yaml` and the generated `.container` file can't disagree. Joined-error output if the rollback itself fails.
+- **Migrate failures now restore the pre-migrate data dir.** A new `abortMigrate` helper bubbles errors from `restoreDataDirFromBackup` (was `_ = restoreDataDirFromBackup(...)`) and restarts the old unit when appropriate.
+- **Rollback after a Migrate is refused.** New `LastOp` and `PreMigrateBackup` fields on `ServiceConfig` / `CustomService`. `RollbackService` errors out when the last op was a migrate (running the old binary against the upgraded data dir would corrupt it). The dashboard hides the Rollback button via the new `can_rollback` field on `/api/services`.
+- **SQL dump credentials no longer leak through argv.** `mysqldump` and `pg_dumpall` receive `MYSQL_PWD` / `PGPASSWORD` via `podman exec --env`, not on the command line. Dump files now open with mode `0600`; the backups directory is `0700`.
+- **30-minute timeout on every in-container migrate exec.** A wedged container can no longer block migrate forever; `containerExec` / `dumpToHost` / `restoreFromHost` use `exec.CommandContext` with a hard cap.
+- **`allow_major_upgrade` is enforced even when the CLI passes a tag explicitly.** A new `enforceMajorUpgradeGate` check refuses `lerd service update mysql 9.0` for presets where `allow_major_upgrade: false`. The registry-recommendation gate could previously be bypassed by direct tag invocation.
+- **Server-side NDJSON streams stop on client disconnect.** A new `startNDJSONStream` helper short-circuits writes once `r.Context()` is cancelled or `w.Write` returns an error, replacing four copies of the `_, _ = w.Write(...)` closure in update / migrate / rollback / preset-install handlers.
+- **Client surfaces stream errors instead of freezing the spinner.** `streamServiceAction` now calls `setProgress` with phase `error` before continuing, so a failed update shows the message in the UI instead of leaving the inline status stuck on the last visible phase.
+- **Update-button gate uses strict equality.** `migration_supported === false` / `=== true` and `can_rollback !== false` so a missing field doesn't accidentally show the wrong button. JSON tags lose `omitempty` on those bool fields so the false case is always wire-visible.
+- **`lerd service restart` warns instead of failing when quadlet regeneration trips.** A transient template error (e.g. a malformed env var) no longer strands a healthy unit; the restart proceeds against the existing on-disk quadlet.
+- **Registry: Docker Hub pagination followed.** `dockerHubResponse.Next` was previously read but never followed; long-tail repos (postgres, mysql) lost newer tags past page 1. Capped at 20 pages and 5000 tags so a pathological response can't drive unbounded traffic.
+- **Registry: distinct error classes.** New `*AuthRequiredErr` and `*NotFoundErr`. 401/403 → auth needed, 404 → repo doesn't exist, 429/5xx → unreachable. All four collapse to "no update info" via `isQuietRegistryErr` but stay distinguishable.
+- **Registry: token and tag-list calls have separate timeout budgets** (15 s each). A slow GHCR token endpoint can no longer starve the subsequent tag-list request.
+- **Registry: concurrent cache writes now safe.** In-process `cacheMu` plus an inline singleflight collapses concurrent `ListTags` calls; cache writes go to a temp file and `os.Rename` atomically. Cache write failures emit a rate-limited `log.Printf` instead of disappearing into `_ = os.WriteFile(...)`.
+- **Registry: response body capped at 5 MB and tag list at 5000 entries** so a malicious or misconfigured registry can't OOM the process.
+- **Digest comparisons normalised** (lowercase + trim) in the `alreadyOnDigest` helper so registries returning differently-cased digests don't cause a permanent "update available" badge.
+- New tests: `TestRollback_RefusesAfterMigrate`, `TestCheckUpdateAvailable_CanRollback`, `TestEnforceMajorUpgradeGate`, `TestLeadingMajor`, plus registry tests for 404, 429, 5xx, pagination, and concurrent-singleflight de-duplication.
+
 ---
 
 ## [1.18.0] — 2026-04-25

--- a/docs/usage/service-updates.md
+++ b/docs/usage/service-updates.md
@@ -72,13 +72,13 @@ lerd service start <svc>
 
 ## Rollback — undo the last update
 
-Every successful Update / Upgrade / Migrate records the previous image in `~/.config/lerd/config.yaml` (or the custom service YAML). The grey **Rollback → \<tag\>** button swaps back to it, pulling first if the image isn't local anymore. A second rollback returns to the post-update image — the swap is symmetric, so you can flip-flop while debugging.
+Every successful Update / Upgrade records the previous image in `~/.config/lerd/config.yaml` (or the custom service YAML). The grey **Rollback → \<tag\>** button swaps back to it, pulling first if the image isn't local anymore. A second rollback returns to the post-update image — the swap is symmetric, so you can flip-flop while debugging.
 
 ```bash
 lerd service rollback redis
 ```
 
-Rollback uses no dump-and-restore: it's a pure image swap. Cross-data-format rollbacks (mysql 8.4 → 8.0 after a minor migration) will fail at startup because the older binary refuses the upgraded data dir. The confirm dialog warns about this. Use the migration recovery procedure above for that case.
+Rollback uses no dump-and-restore: it's a pure image swap. Rollback is refused after a Migrate — running the previous binary against the freshly-migrated data dir would corrupt it. The Rollback button is hidden in that case (the API exposes `can_rollback: false`), and the CLI prints an error pointing at the pre-migrate backup directory for manual recovery.
 
 ## Configuration knobs
 

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -333,16 +334,17 @@ func newServiceRestartCmd() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			name := args[0]
 			unit := "lerd-" + name
-			// Refresh the quadlet first so config edits (image override,
-			// extra ports) and preset file mounts (mysql lerd.cnf) land
-			// on disk before the unit picks them up.
+			// Refresh the quadlet first so config edits and preset file
+			// mounts land before the unit picks them up. If regen fails,
+			// warn and restart the existing quadlet — failing here would
+			// strand a healthy unit on a transient render error.
 			if isKnownService(name) {
 				if err := ensureServiceQuadlet(name); err != nil {
-					return err
+					fmt.Fprintf(os.Stderr, "[WARN] regenerating quadlet for %s failed: %v; restarting with the existing one\n", name, err)
 				}
 			} else if svc, err := config.LoadCustomService(name); err == nil {
 				if err := ensureCustomServiceQuadlet(svc); err != nil {
-					return err
+					fmt.Fprintf(os.Stderr, "[WARN] regenerating quadlet for %s failed: %v; restarting with the existing one\n", name, err)
 				}
 			}
 			fmt.Printf("Restarting %s...\n", unit)

--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -92,6 +92,15 @@ type CustomService struct {
 	// before the last update, so a one-click rollback can swap back to it.
 	// Toggled on each rollback so consecutive rollbacks redo the update.
 	PreviousImage string `yaml:"previous_image,omitempty"`
+	// LastOp is "update" or "migrate" — set by serviceops to mark whether the
+	// most recent change is rollback-safe. Migrate is one-way: rolling back the
+	// image without restoring the pre-migrate data dir would run the old binary
+	// against the new schema, so the rollback path refuses unless this is empty
+	// or "update".
+	LastOp string `yaml:"last_op,omitempty"`
+	// PreMigrateBackup is the absolute host path to the data dir that was
+	// preserved when the most recent op was a migrate.
+	PreMigrateBackup string `yaml:"pre_migrate_backup,omitempty"`
 	// ShareHosts mounts the browser-testing hosts file
 	// (~/.local/share/lerd/browser-hosts) into the container at /etc/hosts,
 	// so the container can resolve .test domains to the nginx container's IP

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -16,6 +16,15 @@ type ServiceConfig struct {
 	Port          int      `yaml:"port"           mapstructure:"port"`
 	ExtraPorts    []string `yaml:"extra_ports"    mapstructure:"extra_ports"`
 	PreviousImage string   `yaml:"previous_image,omitempty" mapstructure:"previous_image"`
+	// LastOp records the most recent mutation kind ("update" or "migrate") so
+	// the rollback flow can refuse a swap that would race the new image
+	// against the post-migrate (fresh) data dir. Empty means no recent op or a
+	// state predating the field — treated as plain update for compatibility.
+	LastOp string `yaml:"last_op,omitempty" mapstructure:"last_op"`
+	// PreMigrateBackup is the absolute path to the data dir that was preserved
+	// when the most recent operation was a migrate. Used by rollback to refuse
+	// (or, in future, restore) when undoing the migrate would corrupt data.
+	PreMigrateBackup string `yaml:"pre_migrate_backup,omitempty" mapstructure:"pre_migrate_backup"`
 }
 
 // GlobalConfig is the top-level lerd configuration.

--- a/internal/registry/backends.go
+++ b/internal/registry/backends.go
@@ -5,13 +5,14 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -19,11 +20,20 @@ import (
 var httpClient = &http.Client{Timeout: 10 * time.Second}
 
 // cacheTTL is how long ListTags results stay valid on disk before re-fetching.
-// 6 hours balances freshness against polling Docker Hub on every page load.
 var cacheTTL = 6 * time.Hour
 
-// cacheDir returns the on-disk path for cached registry responses, defaulting
-// to ~/.cache/lerd/registry-tags. Override LERD_REGISTRY_CACHE_DIR for tests.
+// dockerHubMaxPages caps pagination for repos with thousands of tags so a
+// pathological registry response can't drive unbounded HTTP traffic.
+const dockerHubMaxPages = 20
+
+// dockerHubMaxTags caps tags retained in the cache so a malicious registry
+// response can't OOM the process.
+const dockerHubMaxTags = 5000
+
+// fetchTimeout is the budget for a single registry HTTP call. Token and tag
+// list each get their own context so a slow token doesn't starve the list.
+const fetchTimeout = 15 * time.Second
+
 func cacheDir() string {
 	if d := os.Getenv("LERD_REGISTRY_CACHE_DIR"); d != "" {
 		return d
@@ -35,9 +45,25 @@ func cacheDir() string {
 	return filepath.Join(home, ".cache", "lerd", "registry-tags")
 }
 
+// AuthRequiredErr is returned when the registry needs credentials we don't
+// have. Treated as "no update info" by NewestStable / MaybeNewerTag, but
+// distinguishable so future code can surface a "click to authenticate" hint.
+type AuthRequiredErr struct{ Registry string }
+
+func (e *AuthRequiredErr) Error() string {
+	return "registry " + e.Registry + " needs authentication"
+}
+
+// NotFoundErr signals the repo doesn't exist (404). Distinguished from
+// transient unreachability so the UI can show a typo hint instead of silently
+// hiding the error.
+type NotFoundErr struct{ Repo string }
+
+func (e *NotFoundErr) Error() string { return "repository not found: " + e.Repo }
+
 // ListTags fetches available tags for the named image, choosing the backend
-// by registry hostname. Returns *UnsupportedRegistryErr for unknown hosts and
-// *UnreachableErr for network failures so callers can swallow the latter.
+// by registry hostname. Errors classify as Auth/NotFound/Unreachable/
+// Unsupported so callers can decide whether to surface or swallow.
 func ListTags(image string) ([]TagInfo, error) {
 	ref, err := ParseImage(image)
 	if err != nil {
@@ -46,26 +72,37 @@ func ListTags(image string) ([]TagInfo, error) {
 	if cached, ok := readCache(ref); ok {
 		return cached, nil
 	}
-	var tags []TagInfo
-	switch ref.Registry {
-	case "docker.io":
-		tags, err = listTagsDockerHub(ref)
-	case "ghcr.io":
-		tags, err = listTagsGHCR(ref)
-	default:
-		return nil, &UnsupportedRegistryErr{Registry: ref.Registry}
-	}
+	tags, err, _ := listTagsGroup.Do(cacheKey(ref), func() (any, error) {
+		var t []TagInfo
+		var e error
+		switch ref.Registry {
+		case "docker.io":
+			t, e = listTagsDockerHub(ref)
+		case "ghcr.io":
+			t, e = listTagsGHCR(ref)
+		default:
+			return nil, &UnsupportedRegistryErr{Registry: ref.Registry}
+		}
+		if e != nil {
+			return nil, e
+		}
+		writeCache(ref, t)
+		return t, nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	writeCache(ref, tags)
-	return tags, nil
+	return tags.([]TagInfo), nil
 }
+
+// listTagsGroup deduplicates concurrent ListTags calls for the same image so
+// only one HTTP fetch runs at a time.
+var listTagsGroup = newSingleflight()
 
 // NewestStable returns the newest version-shaped tag in the registry,
 // ignoring update_strategy. Same variant suffix is required. When
 // allowMajorUpgrade is false the search stays within the current numeric
-// major; when true any newer version in any major qualifies.
+// major; when true any newer version qualifies.
 func NewestStable(image string, allowMajorUpgrade bool) (*TagInfo, error) {
 	ref, err := ParseImage(image)
 	if err != nil {
@@ -73,9 +110,7 @@ func NewestStable(image string, allowMajorUpgrade bool) (*TagInfo, error) {
 	}
 	tags, err := ListTags(image)
 	if err != nil {
-		var unreachable *UnreachableErr
-		var unsupported *UnsupportedRegistryErr
-		if errors.As(err, &unreachable) || errors.As(err, &unsupported) {
+		if isQuietRegistryErr(err) {
 			return nil, nil
 		}
 		return nil, err
@@ -109,10 +144,9 @@ func NewestStable(image string, allowMajorUpgrade bool) (*TagInfo, error) {
 	return best, nil
 }
 
-// MaybeNewerTag is the high-level entry point. It looks at the image's tag,
+// MaybeNewerTag is the high-level entry point. Looks at the image's tag,
 // queries the registry, applies the strategy, and returns either a newer tag
-// to recommend or nil. Network errors are converted to (nil, nil) so the UI
-// can stay quiet when the user is offline.
+// to recommend or nil. Quiet errors collapse to (nil, nil).
 func MaybeNewerTag(image string, strategy Strategy) (*TagInfo, error) {
 	if strategy == StrategyNone || strategy == "" {
 		return nil, nil
@@ -123,9 +157,7 @@ func MaybeNewerTag(image string, strategy Strategy) (*TagInfo, error) {
 	}
 	tags, err := ListTags(image)
 	if err != nil {
-		var unreachable *UnreachableErr
-		var unsupported *UnsupportedRegistryErr
-		if errors.As(err, &unreachable) || errors.As(err, &unsupported) {
+		if isQuietRegistryErr(err) {
 			return nil, nil
 		}
 		return nil, err
@@ -134,7 +166,7 @@ func MaybeNewerTag(image string, strategy Strategy) (*TagInfo, error) {
 	return pickNewer(current, tags, strategy), nil
 }
 
-// ---- Docker Hub backend -----------------------------------------------------
+// ---- Docker Hub backend ----------------------------------------------------
 
 type dockerHubResponse struct {
 	Next    string             `json:"next"`
@@ -154,7 +186,29 @@ type dockerHubImageVariant struct {
 
 func listTagsDockerHub(ref ImageRef) ([]TagInfo, error) {
 	url := fmt.Sprintf("https://hub.docker.com/v2/repositories/%s/tags/?page_size=100&ordering=last_updated", ref.Repo)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	out := make([]TagInfo, 0, 128)
+	for page := 0; page < dockerHubMaxPages && url != ""; page++ {
+		parsed, err := fetchDockerHubPage(url)
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range parsed.Results {
+			digest := t.Digest
+			if digest == "" && len(t.Images) > 0 {
+				digest = t.Images[0].Digest
+			}
+			out = append(out, TagInfo{Name: t.Name, Pushed: t.LastUpdated, Digest: digest})
+			if len(out) >= dockerHubMaxTags {
+				return out, nil
+			}
+		}
+		url = parsed.Next
+	}
+	return out, nil
+}
+
+func fetchDockerHubPage(url string) (*dockerHubResponse, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
@@ -165,39 +219,27 @@ func listTagsDockerHub(ref ImageRef) ([]TagInfo, error) {
 		return nil, &UnreachableErr{Cause: err}
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("repository not found: %s", ref.Repo)
-	}
-	if resp.StatusCode == http.StatusTooManyRequests {
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized, resp.StatusCode == http.StatusForbidden:
+		return nil, &AuthRequiredErr{Registry: "docker.io"}
+	case resp.StatusCode == http.StatusNotFound:
+		return nil, &NotFoundErr{Repo: strings.TrimPrefix(url, "https://hub.docker.com/v2/repositories/")}
+	case resp.StatusCode == http.StatusTooManyRequests:
 		return nil, &UnreachableErr{Cause: fmt.Errorf("docker hub rate-limited (429)")}
-	}
-	if resp.StatusCode >= 500 {
+	case resp.StatusCode >= 500:
 		return nil, &UnreachableErr{Cause: fmt.Errorf("docker hub %d", resp.StatusCode)}
-	}
-	if resp.StatusCode != http.StatusOK {
+	case resp.StatusCode != http.StatusOK:
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return nil, fmt.Errorf("docker hub %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	var parsed dockerHubResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 5<<20)).Decode(&parsed); err != nil {
 		return nil, &UnreachableErr{Cause: err}
 	}
-	out := make([]TagInfo, 0, len(parsed.Results))
-	for _, t := range parsed.Results {
-		digest := t.Digest
-		if digest == "" && len(t.Images) > 0 {
-			digest = t.Images[0].Digest
-		}
-		out = append(out, TagInfo{
-			Name:   t.Name,
-			Pushed: t.LastUpdated,
-			Digest: digest,
-		})
-	}
-	return out, nil
+	return &parsed, nil
 }
 
-// ---- GHCR backend -----------------------------------------------------------
+// ---- GHCR backend ----------------------------------------------------------
 
 type ghcrTagsResponse struct {
 	Tags []string `json:"tags"`
@@ -208,41 +250,37 @@ type ghcrTokenResponse struct {
 }
 
 func listTagsGHCR(ref ImageRef) ([]TagInfo, error) {
-	tokenURL := fmt.Sprintf("https://ghcr.io/token?scope=repository:%s:pull&service=ghcr.io", ref.Repo)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	tokenReq, err := http.NewRequestWithContext(ctx, "GET", tokenURL, nil)
+	tok, err := fetchGHCRToken(ref.Repo)
 	if err != nil {
 		return nil, err
 	}
-	tokenResp, err := httpClient.Do(tokenReq)
-	if err != nil {
-		return nil, &UnreachableErr{Cause: err}
-	}
-	defer tokenResp.Body.Close()
-	if tokenResp.StatusCode != http.StatusOK {
-		return nil, &UnreachableErr{Cause: fmt.Errorf("ghcr token %d", tokenResp.StatusCode)}
-	}
-	var tok ghcrTokenResponse
-	if err := json.NewDecoder(tokenResp.Body).Decode(&tok); err != nil {
-		return nil, &UnreachableErr{Cause: err}
-	}
 	listURL := fmt.Sprintf("https://ghcr.io/v2/%s/tags/list?n=100", ref.Repo)
+	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, "GET", listURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+tok.Token)
+	req.Header.Set("Authorization", "Bearer "+tok)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, &UnreachableErr{Cause: err}
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized, resp.StatusCode == http.StatusForbidden:
+		return nil, &AuthRequiredErr{Registry: "ghcr.io"}
+	case resp.StatusCode == http.StatusNotFound:
+		return nil, &NotFoundErr{Repo: ref.Repo}
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return nil, &UnreachableErr{Cause: fmt.Errorf("ghcr.io rate-limited (429)")}
+	case resp.StatusCode >= 500:
+		return nil, &UnreachableErr{Cause: fmt.Errorf("ghcr tags %d", resp.StatusCode)}
+	case resp.StatusCode != http.StatusOK:
 		return nil, &UnreachableErr{Cause: fmt.Errorf("ghcr tags %d", resp.StatusCode)}
 	}
 	var parsed ghcrTagsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 5<<20)).Decode(&parsed); err != nil {
 		return nil, &UnreachableErr{Cause: err}
 	}
 	out := make([]TagInfo, 0, len(parsed.Tags))
@@ -252,13 +290,44 @@ func listTagsGHCR(ref ImageRef) ([]TagInfo, error) {
 	return out, nil
 }
 
-// ---- Cache ------------------------------------------------------------------
+func fetchGHCRToken(repo string) (string, error) {
+	tokenURL := fmt.Sprintf("https://ghcr.io/token?scope=repository:%s:pull&service=ghcr.io", repo)
+	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, "GET", tokenURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", &UnreachableErr{Cause: err}
+	}
+	defer resp.Body.Close()
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized, resp.StatusCode == http.StatusForbidden:
+		return "", &AuthRequiredErr{Registry: "ghcr.io"}
+	case resp.StatusCode == http.StatusNotFound:
+		return "", &NotFoundErr{Repo: repo}
+	case resp.StatusCode != http.StatusOK:
+		return "", &UnreachableErr{Cause: fmt.Errorf("ghcr token %d", resp.StatusCode)}
+	}
+	var tok ghcrTokenResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&tok); err != nil {
+		return "", &UnreachableErr{Cause: err}
+	}
+	return tok.Token, nil
+}
+
+// ---- Cache -----------------------------------------------------------------
 
 type cachedEntry struct {
 	FetchedAt time.Time `json:"fetched_at"`
 	Tags      []TagInfo `json:"tags"`
 }
 
+// cacheKey hashes registry + repo. Architecture is not included because the
+// cached payload is just the tag list; per-arch digests are resolved against
+// the local image at the call site, not from cache.
 func cacheKey(ref ImageRef) string {
 	h := sha256.Sum256([]byte(ref.Registry + "/" + ref.Repo))
 	return hex.EncodeToString(h[:])
@@ -267,6 +336,11 @@ func cacheKey(ref ImageRef) string {
 func cachePath(ref ImageRef) string {
 	return filepath.Join(cacheDir(), cacheKey(ref)+".json")
 }
+
+// cacheMu serialises in-process cache writes so concurrent listTags calls
+// can't interleave bytes into the same file. Cross-process safety relies on
+// the atomic rename — readers either see the old file or the new one.
+var cacheMu sync.Mutex
 
 func readCache(ref ImageRef) ([]TagInfo, bool) {
 	data, err := os.ReadFile(cachePath(ref))
@@ -284,13 +358,97 @@ func readCache(ref ImageRef) ([]TagInfo, bool) {
 }
 
 func writeCache(ref ImageRef, tags []TagInfo) {
-	if err := os.MkdirAll(cacheDir(), 0755); err != nil {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	dir := cacheDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		warnCache("mkdir %s: %v", dir, err)
 		return
 	}
 	entry := cachedEntry{FetchedAt: time.Now(), Tags: tags}
 	data, err := json.Marshal(entry)
 	if err != nil {
+		warnCache("marshal: %v", err)
 		return
 	}
-	_ = os.WriteFile(cachePath(ref), data, 0644)
+	final := cachePath(ref)
+	tmp, err := os.CreateTemp(dir, ".cache-*.tmp")
+	if err != nil {
+		warnCache("tempfile in %s: %v", dir, err)
+		return
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		warnCache("write %s: %v", tmpPath, err)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		warnCache("close %s: %v", tmpPath, err)
+		return
+	}
+	if err := os.Rename(tmpPath, final); err != nil {
+		_ = os.Remove(tmpPath)
+		warnCache("rename %s → %s: %v", tmpPath, final, err)
+	}
+}
+
+// warnCache rate-limits write-failure logs so a read-only cache dir doesn't
+// flood the log on every check. Logs at most once per minute per process.
+var (
+	cacheWarnMu sync.Mutex
+	cacheWarnAt time.Time
+)
+
+func warnCache(format string, args ...any) {
+	cacheWarnMu.Lock()
+	defer cacheWarnMu.Unlock()
+	if time.Since(cacheWarnAt) < time.Minute {
+		return
+	}
+	cacheWarnAt = time.Now()
+	log.Printf("registry cache write failed: "+format, args...)
+}
+
+// ---- singleflight ----------------------------------------------------------
+
+// singleflight is a tiny stand-in for golang.org/x/sync/singleflight to avoid
+// adding a dependency. Concurrent Do calls with the same key share one
+// execution and result.
+type singleflight struct {
+	mu sync.Mutex
+	m  map[string]*sfCall
+}
+
+type sfCall struct {
+	wg  sync.WaitGroup
+	val any
+	err error
+}
+
+func newSingleflight() *singleflight {
+	return &singleflight{m: map[string]*sfCall{}}
+}
+
+func (g *singleflight) Do(key string, fn func() (any, error)) (any, error, bool) {
+	g.mu.Lock()
+	if c, ok := g.m[key]; ok {
+		g.mu.Unlock()
+		c.wg.Wait()
+		return c.val, c.err, true
+	}
+	c := &sfCall{}
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	c.val, c.err = fn()
+	c.wg.Done()
+
+	g.mu.Lock()
+	delete(g.m, key)
+	g.mu.Unlock()
+	return c.val, c.err, false
 }

--- a/internal/registry/backends_test.go
+++ b/internal/registry/backends_test.go
@@ -241,3 +241,126 @@ func TestListTags_CacheTTL(t *testing.T) {
 		t.Errorf("expected exactly one HTTP hit (cache should serve the second), got %d", hits)
 	}
 }
+
+// TestListTags_404 surfaces NotFoundErr so callers can show a typo hint
+// rather than swallowing into "no update info".
+func TestListTags_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"detail": "object not found"}`))
+	}))
+	defer srv.Close()
+	withStubHTTP(t, srv)
+	withTempCacheDir(t)
+
+	_, err := ListTags("docker.io/typo/typo:1")
+	var nf *NotFoundErr
+	if !errors.As(err, &nf) {
+		t.Fatalf("expected NotFoundErr, got %T %v", err, err)
+	}
+}
+
+// TestListTags_429 wraps as UnreachableErr so the UI silently retries later.
+func TestListTags_429(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+	withStubHTTP(t, srv)
+	withTempCacheDir(t)
+
+	_, err := ListTags("docker.io/library/redis:7")
+	var ur *UnreachableErr
+	if !errors.As(err, &ur) {
+		t.Fatalf("expected UnreachableErr, got %T %v", err, err)
+	}
+}
+
+// TestListTags_5xx wraps as UnreachableErr.
+func TestListTags_5xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+	withStubHTTP(t, srv)
+	withTempCacheDir(t)
+
+	_, err := ListTags("docker.io/library/redis:7")
+	var ur *UnreachableErr
+	if !errors.As(err, &ur) {
+		t.Fatalf("expected UnreachableErr for 502, got %T %v", err, err)
+	}
+}
+
+// TestListTags_Pagination follows the next link until the registry stops
+// returning one. Without it large repos lose newer tags.
+func TestListTags_Pagination(t *testing.T) {
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		switch hits {
+		case 1:
+			w.Write([]byte(`{
+				"next": "/page2",
+				"results": [{"name": "8.0", "last_updated": "2024-01-01T00:00:00Z"}]
+			}`))
+		case 2:
+			w.Write([]byte(`{
+				"next": null,
+				"results": [{"name": "8.4.3", "last_updated": "2026-04-15T00:00:00Z"}]
+			}`))
+		default:
+			t.Fatalf("unexpected page %d", hits)
+		}
+	}))
+	defer srv.Close()
+	withStubHTTP(t, srv)
+	withTempCacheDir(t)
+
+	tags, err := ListTags("docker.io/library/mysql:8.0")
+	if err != nil {
+		t.Fatalf("ListTags: %v", err)
+	}
+	if len(tags) != 2 {
+		t.Fatalf("expected 2 tags across pages, got %d: %+v", len(tags), tags)
+	}
+	if hits != 2 {
+		t.Errorf("expected 2 HTTP hits across pages, got %d", hits)
+	}
+}
+
+// TestListTags_ConcurrentSingleflight collapses concurrent fetches for the
+// same image into a single registry call.
+func TestListTags_ConcurrentSingleflight(t *testing.T) {
+	hits := 0
+	gate := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		<-gate
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"results": [{"name": "1.0"}]}`))
+	}))
+	defer srv.Close()
+	withStubHTTP(t, srv)
+	withTempCacheDir(t)
+
+	const N = 8
+	done := make(chan error, N)
+	for range N {
+		go func() {
+			_, err := ListTags("docker.io/library/redis:7")
+			done <- err
+		}()
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(gate)
+	for range N {
+		if err := <-done; err != nil {
+			t.Errorf("ListTags: %v", err)
+		}
+	}
+	if hits != 1 {
+		t.Errorf("expected singleflight to collapse %d concurrent calls into 1 hit, got %d", N, hits)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -9,7 +9,6 @@ package registry
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -67,6 +66,21 @@ type UnsupportedRegistryErr struct{ Registry string }
 
 func (e *UnsupportedRegistryErr) Error() string {
 	return "unsupported registry: " + e.Registry
+}
+
+// isQuietRegistryErr reports whether err is one of the registry conditions
+// the UI is happy to swallow into "no update info" (offline, unsupported
+// registry, repo doesn't exist, or auth needed). Distinct error types are
+// preserved so callers that want richer feedback still can.
+func isQuietRegistryErr(err error) bool {
+	var unreachable *UnreachableErr
+	var unsupported *UnsupportedRegistryErr
+	var notFound *NotFoundErr
+	var authReq *AuthRequiredErr
+	return errors.As(err, &unreachable) ||
+		errors.As(err, &unsupported) ||
+		errors.As(err, &notFound) ||
+		errors.As(err, &authReq)
 }
 
 // ParseImage splits an image reference into registry, repo and tag. Implicit
@@ -236,5 +250,3 @@ func numericGreater(a, b []int) bool {
 	}
 	return len(a) > len(b)
 }
-
-var _ = fmt.Sprintf // placate compiler if errors path is later removed

--- a/internal/serviceops/locks.go
+++ b/internal/serviceops/locks.go
@@ -1,0 +1,24 @@
+package serviceops
+
+import "sync"
+
+// serviceLocks serialises mutating operations (update / migrate / rollback)
+// per service so a double-click in the UI, or a CLI invocation racing the
+// dashboard, cannot leave the data dir, image config and quadlet pointing at
+// inconsistent versions. One mutex per name, lazily created.
+var (
+	serviceLocksMu sync.Mutex
+	serviceLocks   = map[string]*sync.Mutex{}
+)
+
+func lockService(name string) func() {
+	serviceLocksMu.Lock()
+	mu, ok := serviceLocks[name]
+	if !ok {
+		mu = &sync.Mutex{}
+		serviceLocks[name] = mu
+	}
+	serviceLocksMu.Unlock()
+	mu.Lock()
+	return mu.Unlock
+}

--- a/internal/serviceops/migrate.go
+++ b/internal/serviceops/migrate.go
@@ -1,6 +1,7 @@
 package serviceops
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,38 +14,37 @@ import (
 )
 
 // migratorFn drives a one-shot version migration for a single service family.
-// It receives the lerd service name, the target image to migrate to, and an
-// emit channel for streaming phase events. Implementations are expected to:
-//   - Dump current data while the running container is still on the old image.
-//   - Move the on-disk data dir aside (so the new container sees a fresh dir).
-//   - Persist the new image into the user config and regenerate the quadlet.
-//   - Restart the unit on the new image and wait for it ready.
-//   - Restore the dump into the new container.
-//
-// Backups land in config.BackupsDir() so manual recovery is always possible.
+// Implementations dump current data, swap the data dir aside, switch image,
+// restart, and restore the dump. Backups land in config.BackupsDir().
 type migratorFn func(name, targetImage string, emit func(PhaseEvent)) error
 
 // migrators is restricted to families with stable text-format dumps that load
-// cleanly across versions (SQL via mysqldump / pg_dumpall). Engines whose
-// dumps are version-specific binary blobs need manual upgrades.
+// cleanly across versions (mysqldump / pg_dumpall). Engines whose dumps are
+// version-specific binary blobs need manual upgrades.
 var migrators = map[string]migratorFn{
 	"mysql":    migrateMysql,
 	"mariadb":  migrateMysql,
 	"postgres": migratePostgres,
 }
 
+// dumpRestoreTimeout caps any single in-container dump or restore exec so a
+// wedged container can't block the migrate forever.
+const dumpRestoreTimeout = 30 * time.Minute
+
 // SupportsMigration reports whether a registered family migrator exists for
-// the named service. Used by the UI to decide whether to render the Migrate
-// button alongside (or instead of) Upgrade.
+// the named service.
 func SupportsMigration(name string) bool {
 	_, ok := migrators[familyOf(name)]
 	return ok
 }
 
 // MigrateService runs a per-family dump/restore migration so the service can
-// move across data-incompatible SQL versions (e.g. mysql 8.0 → 9.0, postgres
-// 16 → 17). Errors when no handler is registered for the service family.
+// move across data-incompatible SQL versions (e.g. mysql 8.0 → 9.0). Errors
+// when no handler is registered for the service family.
 func MigrateService(name, targetImage string, emit func(PhaseEvent)) error {
+	unlock := lockService(name)
+	defer unlock()
+
 	fam := familyOf(name)
 	fn, ok := migrators[fam]
 	if !ok {
@@ -53,14 +53,14 @@ func MigrateService(name, targetImage string, emit func(PhaseEvent)) error {
 	if targetImage == "" {
 		return fmt.Errorf("targetImage is required")
 	}
-	if err := os.MkdirAll(config.BackupsDir(), 0755); err != nil {
+	if err := os.MkdirAll(config.BackupsDir(), 0700); err != nil {
 		return fmt.Errorf("creating backups dir: %w", err)
 	}
 	return fn(name, targetImage, emit)
 }
 
-// familyOf returns the service family for a default preset or installed custom
-// service. Used to dispatch to the right migrator handler.
+// familyOf returns the service family for a default preset or installed
+// custom service.
 func familyOf(name string) string {
 	if config.IsDefaultPreset(name) {
 		if p, err := config.LoadPreset(name); err == nil {
@@ -76,28 +76,43 @@ func familyOf(name string) string {
 	return ""
 }
 
-// timestamped returns a UTC ISO-ish timestamp safe for filenames.
 func timestamped() string { return time.Now().UTC().Format("20060102-150405") }
 
-// containerExec runs a command inside a running container with stdin piped
-// from r and stdout/stderr captured. Used by every migrator's dump+restore
-// steps so we don't ship per-family copies of this plumbing.
-func containerExec(container, shellCmd string, stdin *os.File) ([]byte, error) {
-	cmd := exec.Command(podman.PodmanBin(), "exec", "-i", container, "sh", "-c", shellCmd)
+// containerExec runs shellCmd inside a running container with a hard timeout.
+// envPairs are passed via the exec env (not argv) so secrets don't leak into
+// /proc/<pid>/cmdline. Captured output includes stderr.
+func containerExec(container, shellCmd string, envPairs []string, stdin *os.File, timeout time.Duration) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	args := []string{"exec", "-i"}
+	for _, kv := range envPairs {
+		args = append(args, "--env", kv)
+	}
+	args = append(args, container, "sh", "-c", shellCmd)
+	cmd := exec.CommandContext(ctx, podman.PodmanBin(), args...)
 	if stdin != nil {
 		cmd.Stdin = stdin
 	}
 	return cmd.CombinedOutput()
 }
 
-// dumpToHost streams the output of a container command into a host file path.
-func dumpToHost(container, shellCmd, hostPath string) error {
-	out, err := os.Create(hostPath)
+// dumpToHost streams the output of a container command into a host file with
+// 0600 permissions. envPairs go through podman exec --env so secrets stay out
+// of argv.
+func dumpToHost(container, shellCmd string, envPairs []string, hostPath string, timeout time.Duration) error {
+	out, err := os.OpenFile(hostPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("creating dump file %s: %w", hostPath, err)
 	}
 	defer out.Close()
-	cmd := exec.Command(podman.PodmanBin(), "exec", container, "sh", "-c", shellCmd)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	args := []string{"exec"}
+	for _, kv := range envPairs {
+		args = append(args, "--env", kv)
+	}
+	args = append(args, container, "sh", "-c", shellCmd)
+	cmd := exec.CommandContext(ctx, podman.PodmanBin(), args...)
 	cmd.Stdout = out
 	stderr, err := cmd.CombinedOutput()
 	if err != nil {
@@ -107,13 +122,20 @@ func dumpToHost(container, shellCmd, hostPath string) error {
 }
 
 // restoreFromHost streams a host file into a container command's stdin.
-func restoreFromHost(container, shellCmd, hostPath string) error {
+func restoreFromHost(container, shellCmd string, envPairs []string, hostPath string, timeout time.Duration) error {
 	in, err := os.Open(hostPath)
 	if err != nil {
 		return fmt.Errorf("opening dump file %s: %w", hostPath, err)
 	}
 	defer in.Close()
-	cmd := exec.Command(podman.PodmanBin(), "exec", "-i", container, "sh", "-c", shellCmd)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	args := []string{"exec", "-i"}
+	for _, kv := range envPairs {
+		args = append(args, "--env", kv)
+	}
+	args = append(args, container, "sh", "-c", shellCmd)
+	cmd := exec.CommandContext(ctx, podman.PodmanBin(), args...)
 	cmd.Stdin = in
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -123,19 +145,18 @@ func restoreFromHost(container, shellCmd, hostPath string) error {
 }
 
 // swapDataDirAside moves the current data dir to a timestamped backup name so
-// the new container starts from an empty dir. Returns the backup path so the
-// caller can restore it on failure.
+// the new container starts empty. Returns the backup path on success; empty
+// string with no error means there was no data dir to swap.
 func swapDataDirAside(svcName string) (string, error) {
 	src := config.DataSubDir(svcName)
 	if _, err := os.Stat(src); err != nil {
-		return "", nil // no data to swap — fresh container or volume-managed
+		return "", nil
 	}
 	dst := src + ".pre-migrate-" + timestamped()
 	if err := os.Rename(src, dst); err != nil {
 		return "", fmt.Errorf("moving data dir aside: %w", err)
 	}
 	if err := os.MkdirAll(src, 0755); err != nil {
-		// Best-effort restore: put the original back if we can't make a new one.
 		_ = os.Rename(dst, src)
 		return "", fmt.Errorf("creating fresh data dir: %w", err)
 	}
@@ -143,43 +164,40 @@ func swapDataDirAside(svcName string) (string, error) {
 }
 
 // restoreDataDirFromBackup undoes swapDataDirAside, used when migration fails
-// before the new image is committed.
+// before the new image is committed. Errors are bubbled — silent failure here
+// would leave the data destroyed without operator awareness.
 func restoreDataDirFromBackup(svcName, backupPath string) error {
 	if backupPath == "" {
 		return nil
 	}
 	src := config.DataSubDir(svcName)
-	_ = os.RemoveAll(src)
-	return os.Rename(backupPath, src)
+	if err := os.RemoveAll(src); err != nil {
+		return fmt.Errorf("clearing fresh data dir: %w", err)
+	}
+	if err := os.Rename(backupPath, src); err != nil {
+		return fmt.Errorf("restoring data dir from %s: %w", backupPath, err)
+	}
+	return nil
 }
 
 // switchToTargetImage persists the new image, regenerates the quadlet, and
-// restarts the unit. Reuses the same path the streaming Update flow uses so
-// behavior is consistent across update/upgrade/migrate.
+// restarts the unit.
 func switchToTargetImage(name, targetImage string, emit func(PhaseEvent)) error {
 	emit(PhaseEvent{Phase: "writing_quadlet", Image: targetImage})
-	if err := persistImageChoice(name, targetImage); err != nil {
+	if err := persistImageChoice(name, targetImage, "migrate"); err != nil {
 		return err
 	}
 	unit := "lerd-" + name
 	emit(PhaseEvent{Phase: "restarting_unit", Unit: unit})
-	for attempt := range 5 {
-		if err := podman.RestartUnit(unit); err == nil {
-			return nil
-		} else if !strings.Contains(err.Error(), "not found") {
-			return err
-		}
-		time.Sleep(time.Duration(attempt+1) * 300 * time.Millisecond)
-	}
-	return fmt.Errorf("restarting %s timed out", unit)
+	return restartWithRetry(unit)
 }
 
-// waitContainerReady polls a service-specific readiness probe by exec'ing a
-// trivial command inside the container until it succeeds or timeout elapses.
-func waitContainerReady(container, probeCmd string, timeout time.Duration) error {
+// waitContainerReady polls a service-specific readiness probe until it
+// succeeds or timeout elapses.
+func waitContainerReady(container, probeCmd string, envPairs []string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if _, err := containerExec(container, probeCmd, nil); err == nil {
+		if _, err := containerExec(container, probeCmd, envPairs, nil, 5*time.Second); err == nil {
 			return nil
 		}
 		time.Sleep(500 * time.Millisecond)
@@ -187,15 +205,33 @@ func waitContainerReady(container, probeCmd string, timeout time.Duration) error
 	return fmt.Errorf("container %s never became ready within %s", container, timeout)
 }
 
-// ---- mysql / mariadb ---------------------------------------------------------
+// abortMigrate is the shared post-failure recovery: try to put the old data
+// dir back and restart the old unit, joining errors so neither fix is silent.
+func abortMigrate(unit, name, backup string, restartOldUnit bool, cause error) error {
+	parts := []string{cause.Error()}
+	if backup != "" {
+		if err := restoreDataDirFromBackup(name, backup); err != nil {
+			parts = append(parts, "data-dir restore failed: "+err.Error()+" (backup left at "+backup+")")
+		}
+	}
+	if restartOldUnit {
+		if err := podman.StartUnit(unit); err != nil {
+			parts = append(parts, "restarting old unit failed: "+err.Error())
+		}
+	}
+	return fmt.Errorf("%s", strings.Join(parts, "; "))
+}
+
+// ---- mysql / mariadb -------------------------------------------------------
 
 func migrateMysql(name, targetImage string, emit func(PhaseEvent)) error {
 	unit := "lerd-" + name
 	dump := filepath.Join(config.BackupsDir(), name+"-"+timestamped()+".sql")
+	rootEnv := []string{"MYSQL_PWD=lerd"}
 
 	emit(PhaseEvent{Phase: "dumping_data", Message: "mysqldump → " + dump})
-	dumpCmd := "mysqldump -uroot -plerd --all-databases --single-transaction --routines --triggers --events --quick"
-	if err := dumpToHost(unit, dumpCmd, dump); err != nil {
+	dumpCmd := "mysqldump -uroot --all-databases --single-transaction --routines --triggers --events --quick"
+	if err := dumpToHost(unit, dumpCmd, rootEnv, dump, dumpRestoreTimeout); err != nil {
 		return fmt.Errorf("mysqldump: %w", err)
 	}
 
@@ -207,49 +243,49 @@ func migrateMysql(name, targetImage string, emit func(PhaseEvent)) error {
 	emit(PhaseEvent{Phase: "swapping_data_dir", Message: "old data preserved alongside the dump"})
 	backup, err := swapDataDirAside(name)
 	if err != nil {
-		_ = podman.StartUnit(unit)
-		return err
+		return abortMigrate(unit, name, "", true, err)
 	}
 
 	emit(PhaseEvent{Phase: "pulling_image", Image: targetImage})
 	if err := podman.PullImageWithProgress(targetImage, func(line string) {
 		emit(PhaseEvent{Phase: "pulling_image", Message: line})
 	}); err != nil {
-		_ = restoreDataDirFromBackup(name, backup)
-		_ = podman.StartUnit(unit)
-		return fmt.Errorf("pulling target: %w", err)
+		return abortMigrate(unit, name, backup, true, fmt.Errorf("pulling target: %w", err))
 	}
 
 	if err := switchToTargetImage(name, targetImage, emit); err != nil {
-		_ = restoreDataDirFromBackup(name, backup)
-		return err
+		return abortMigrate(unit, name, backup, false, err)
 	}
 
 	emit(PhaseEvent{Phase: "waiting_ready", Unit: unit})
-	probe := "mysql -uroot -plerd -e 'SELECT 1' >/dev/null 2>&1 || mariadb -uroot -plerd -e 'SELECT 1' >/dev/null 2>&1"
-	if err := waitContainerReady(unit, probe, 90*time.Second); err != nil {
-		return fmt.Errorf("%w. Dump preserved at %s", err, dump)
+	probe := "mysql -uroot -e 'SELECT 1' >/dev/null 2>&1 || mariadb -uroot -e 'SELECT 1' >/dev/null 2>&1"
+	if err := waitContainerReady(unit, probe, rootEnv, 90*time.Second); err != nil {
+		return fmt.Errorf("%w. Dump preserved at %s; old data dir at %s", err, dump, backup)
 	}
 
 	emit(PhaseEvent{Phase: "restoring_data", Message: dump})
-	restoreCmd := "mysql -uroot -plerd 2>&1 || mariadb -uroot -plerd 2>&1"
-	if err := restoreFromHost(unit, restoreCmd, dump); err != nil {
+	restoreCmd := "mysql -uroot 2>&1 || mariadb -uroot 2>&1"
+	if err := restoreFromHost(unit, restoreCmd, rootEnv, dump, dumpRestoreTimeout); err != nil {
 		return fmt.Errorf("restore: %w. Dump preserved at %s; old data dir at %s", err, dump, backup)
 	}
 
+	if err := recordMigrateBackup(name, backup); err != nil {
+		return fmt.Errorf("recording migrate backup: %w. Old data dir kept at %s", err, backup)
+	}
 	emit(PhaseEvent{Phase: "done", Image: targetImage, Unit: unit, Message: "Migrated. Old data dir kept at " + backup + "; remove when verified."})
 	return nil
 }
 
-// ---- postgres ----------------------------------------------------------------
+// ---- postgres --------------------------------------------------------------
 
 func migratePostgres(name, targetImage string, emit func(PhaseEvent)) error {
 	unit := "lerd-" + name
 	dump := filepath.Join(config.BackupsDir(), name+"-"+timestamped()+".sql")
+	pgEnv := []string{"PGPASSWORD=lerd"}
 
 	emit(PhaseEvent{Phase: "dumping_data", Message: "pg_dumpall → " + dump})
-	dumpCmd := "PGPASSWORD=lerd pg_dumpall -h 127.0.0.1 -U postgres --clean --if-exists"
-	if err := dumpToHost(unit, dumpCmd, dump); err != nil {
+	dumpCmd := "pg_dumpall -h 127.0.0.1 -U postgres --clean --if-exists"
+	if err := dumpToHost(unit, dumpCmd, pgEnv, dump, dumpRestoreTimeout); err != nil {
 		return fmt.Errorf("pg_dumpall: %w", err)
 	}
 
@@ -261,36 +297,35 @@ func migratePostgres(name, targetImage string, emit func(PhaseEvent)) error {
 	emit(PhaseEvent{Phase: "swapping_data_dir"})
 	backup, err := swapDataDirAside(name)
 	if err != nil {
-		_ = podman.StartUnit(unit)
-		return err
+		return abortMigrate(unit, name, "", true, err)
 	}
 
 	emit(PhaseEvent{Phase: "pulling_image", Image: targetImage})
 	if err := podman.PullImageWithProgress(targetImage, func(line string) {
 		emit(PhaseEvent{Phase: "pulling_image", Message: line})
 	}); err != nil {
-		_ = restoreDataDirFromBackup(name, backup)
-		_ = podman.StartUnit(unit)
-		return fmt.Errorf("pulling target: %w", err)
+		return abortMigrate(unit, name, backup, true, fmt.Errorf("pulling target: %w", err))
 	}
 
 	if err := switchToTargetImage(name, targetImage, emit); err != nil {
-		_ = restoreDataDirFromBackup(name, backup)
-		return err
+		return abortMigrate(unit, name, backup, false, err)
 	}
 
 	emit(PhaseEvent{Phase: "waiting_ready", Unit: unit})
-	probe := "PGPASSWORD=lerd psql -h 127.0.0.1 -U postgres -c 'SELECT 1' >/dev/null 2>&1"
-	if err := waitContainerReady(unit, probe, 90*time.Second); err != nil {
-		return fmt.Errorf("%w. Dump preserved at %s", err, dump)
+	probe := "psql -h 127.0.0.1 -U postgres -c 'SELECT 1' >/dev/null 2>&1"
+	if err := waitContainerReady(unit, probe, pgEnv, 90*time.Second); err != nil {
+		return fmt.Errorf("%w. Dump preserved at %s; old data dir at %s", err, dump, backup)
 	}
 
 	emit(PhaseEvent{Phase: "restoring_data", Message: dump})
-	restoreCmd := "PGPASSWORD=lerd psql -h 127.0.0.1 -U postgres -d postgres 2>&1"
-	if err := restoreFromHost(unit, restoreCmd, dump); err != nil {
+	restoreCmd := "psql -h 127.0.0.1 -U postgres -d postgres 2>&1"
+	if err := restoreFromHost(unit, restoreCmd, pgEnv, dump, dumpRestoreTimeout); err != nil {
 		return fmt.Errorf("restore: %w. Dump preserved at %s; old data dir at %s", err, dump, backup)
 	}
 
+	if err := recordMigrateBackup(name, backup); err != nil {
+		return fmt.Errorf("recording migrate backup: %w. Old data dir kept at %s", err, backup)
+	}
 	emit(PhaseEvent{Phase: "done", Image: targetImage, Unit: unit, Message: "Migrated. Old data dir kept at " + backup + "; remove when verified."})
 	return nil
 }

--- a/internal/serviceops/rollback_test.go
+++ b/internal/serviceops/rollback_test.go
@@ -1,13 +1,14 @@
 package serviceops
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
 )
 
 // TestRollback_RequiresPreviousImage covers the contract that rollback fails
-// loudly when there's nothing to roll back to (vs. silently no-oping).
+// loudly when there's nothing to roll back to.
 func TestRollback_RequiresPreviousImage(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
@@ -19,8 +20,8 @@ func TestRollback_RequiresPreviousImage(t *testing.T) {
 	}
 }
 
-// TestPersistImageChoice_RecordsPrevious covers the recorder side: each update
-// must capture the old image so rollback has a target.
+// TestPersistImageChoice_RecordsPrevious covers the recorder side: each
+// update must capture the old image so rollback has a target.
 func TestPersistImageChoice_RecordsPrevious(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
@@ -39,7 +40,6 @@ func TestPersistImageChoice_RecordsPrevious(t *testing.T) {
 		t.Fatalf("SaveGlobal: %v", err)
 	}
 
-	// First "update" — the current 7-alpine should land in PreviousImage.
 	if err := persistRecordOnly("redis", "docker.io/library/redis:7.4.8-alpine"); err != nil {
 		t.Fatalf("persistRecordOnly: %v", err)
 	}
@@ -53,7 +53,6 @@ func TestPersistImageChoice_RecordsPrevious(t *testing.T) {
 		t.Errorf("PreviousImage = %q, want previous 7-alpine", got.PreviousImage)
 	}
 
-	// Second update — previous should advance to the post-first-update image.
 	if err := persistRecordOnly("redis", "docker.io/library/redis:7.4.9-alpine"); err != nil {
 		t.Fatalf("persistRecordOnly: %v", err)
 	}
@@ -64,9 +63,122 @@ func TestPersistImageChoice_RecordsPrevious(t *testing.T) {
 	}
 }
 
-// persistRecordOnly mimics persistImageChoice's record step without actually
-// regenerating quadlets (which would need podman). The test only asserts the
-// pin-swapping logic, not the side effects.
+// TestRollback_RefusesAfterMigrate guards against running the previous binary
+// against a fresh (post-migrate) data dir.
+func TestRollback_RefusesAfterMigrate(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	cfg.Services["mysql"] = config.ServiceConfig{
+		Enabled:          true,
+		Image:            "docker.io/library/mysql:8.4",
+		PreviousImage:    "docker.io/library/mysql:8.0",
+		LastOp:           "migrate",
+		PreMigrateBackup: "/tmp/mysql.pre-migrate-20260428-1200",
+		Port:             3306,
+	}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	err = RollbackService("mysql", func(PhaseEvent) {})
+	if err == nil {
+		t.Fatal("RollbackService must refuse when last op was a migrate")
+	}
+	if !strings.Contains(err.Error(), "migrate") {
+		t.Errorf("rollback error should mention migrate, got %q", err)
+	}
+}
+
+// TestCheckUpdateAvailable_CanRollback flips false when the last op was a
+// migrate so the UI can hide the rollback button.
+func TestCheckUpdateAvailable_CanRollback(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("LERD_REGISTRY_CACHE_DIR", tmp+"/cache")
+	// Empty cache + no network access in tests means the registry probe
+	// returns nothing useful, but CanRollback is computed before that.
+
+	cfg, _ := config.LoadGlobal()
+	cfg.Services["redis"] = config.ServiceConfig{
+		Enabled:       true,
+		Image:         "docker.io/library/redis:7.4.9-alpine",
+		PreviousImage: "docker.io/library/redis:7.4.8-alpine",
+		LastOp:        "update",
+	}
+	_ = config.SaveGlobal(cfg)
+
+	avail, err := CheckUpdateAvailable("redis")
+	if err != nil {
+		t.Fatalf("CheckUpdateAvailable: %v", err)
+	}
+	if !avail.CanRollback {
+		t.Errorf("CanRollback = false, want true after a plain update")
+	}
+
+	cfg.Services["redis"] = config.ServiceConfig{
+		Enabled:       true,
+		Image:         "docker.io/library/redis:7.4.9-alpine",
+		PreviousImage: "docker.io/library/redis:7.4.8-alpine",
+		LastOp:        "migrate",
+	}
+	_ = config.SaveGlobal(cfg)
+
+	avail, err = CheckUpdateAvailable("redis")
+	if err != nil {
+		t.Fatalf("CheckUpdateAvailable (migrate state): %v", err)
+	}
+	if avail.CanRollback {
+		t.Errorf("CanRollback = true after migrate, want false")
+	}
+}
+
+// TestEnforceMajorUpgradeGate refuses cross-major when the preset's
+// allow_major_upgrade is false. mysql is the canonical case.
+func TestEnforceMajorUpgradeGate(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cfg, _ := config.LoadGlobal()
+	cfg.Services["mysql"] = config.ServiceConfig{
+		Enabled: true,
+		Image:   "docker.io/library/mysql:8.4",
+	}
+	_ = config.SaveGlobal(cfg)
+
+	if err := enforceMajorUpgradeGate("mysql", "docker.io/library/mysql:9.0"); err == nil {
+		t.Fatal("enforceMajorUpgradeGate must refuse 8.4 → 9.0 when allow_major_upgrade=false")
+	}
+	if err := enforceMajorUpgradeGate("mysql", "docker.io/library/mysql:8.4.10"); err != nil {
+		t.Errorf("8.4 → 8.4.10 should be allowed, got %v", err)
+	}
+}
+
+// TestLeadingMajor parses the leading numeric prefix of common tag shapes.
+func TestLeadingMajor(t *testing.T) {
+	cases := map[string]int{
+		"8.4":             8,
+		"v8.4":            8,
+		"8.4.10":          8,
+		"7-alpine":        7,
+		"latest":          -1,
+		"":                -1,
+		"16-3.5-bookworm": 16,
+	}
+	for in, want := range cases {
+		if got := leadingMajor(in); got != want {
+			t.Errorf("leadingMajor(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
 func persistRecordOnly(name, newImage string) error {
 	cfg, err := config.LoadGlobal()
 	if err != nil {
@@ -77,6 +189,7 @@ func persistRecordOnly(name, newImage string) error {
 		svcCfg.PreviousImage = svcCfg.Image
 	}
 	svcCfg.Image = newImage
+	svcCfg.LastOp = "update"
 	cfg.Services[name] = svcCfg
 	return config.SaveGlobal(cfg)
 }

--- a/internal/serviceops/update.go
+++ b/internal/serviceops/update.go
@@ -11,68 +11,48 @@ import (
 )
 
 // UpdateAvailability is the metadata returned by CheckUpdateAvailable so the
-// UI can render an "update available → v8.4.3" badge without performing the
-// update yet. Latest* fields surface newer versions outside the safe-update
-// strategy (e.g. meilisearch v1.7.6 patch-update + v1.42.1 cross-minor) so
-// the UI can offer them as an explicit, manual-migration upgrade.
+// UI can render an "update available → v8.4.3" badge without applying it.
 type UpdateAvailability struct {
-	Service      string `json:"service"`
-	CurrentImage string `json:"current_image"`
-	CurrentTag   string `json:"current_tag"`
-	LatestTag    string `json:"latest_tag,omitempty"`
-	LatestImage  string `json:"latest_image,omitempty"`
-	Available    bool   `json:"available"`
-	Strategy     string `json:"strategy"`
-	// Upgrade* points at the newest version regardless of update_strategy.
-	// Set only when it differs from LatestTag, i.e. there's a cross-strategy
-	// upgrade the user could opt into manually.
-	UpgradeTag   string `json:"upgrade_tag,omitempty"`
-	UpgradeImage string `json:"upgrade_image,omitempty"`
-	// PreviousImage is the image running before the most recent update; set
-	// when the user can roll back to it without an extra registry roundtrip.
+	Service       string `json:"service"`
+	CurrentImage  string `json:"current_image"`
+	CurrentTag    string `json:"current_tag"`
+	LatestTag     string `json:"latest_tag,omitempty"`
+	LatestImage   string `json:"latest_image,omitempty"`
+	Available     bool   `json:"available"`
+	Strategy      string `json:"strategy"`
+	UpgradeTag    string `json:"upgrade_tag,omitempty"`
+	UpgradeImage  string `json:"upgrade_image,omitempty"`
 	PreviousImage string `json:"previous_image,omitempty"`
+	// CanRollback is false when the most recent op was a migrate (rolling the
+	// image back without restoring the pre-migrate data dir would corrupt it).
+	CanRollback bool `json:"can_rollback"`
 }
 
 // CheckUpdateAvailable queries the registry for a newer tag matching the
 // preset's update_strategy. Network and unsupported-registry errors are
-// swallowed (returning Available=false) so the UI stays quiet on offline /
-// custom-registry installs.
+// swallowed so the UI stays quiet on offline / custom-registry installs.
 func CheckUpdateAvailable(name string) (*UpdateAvailability, error) {
 	svc, strategy, allowMajor, err := resolveServiceForUpdate(name)
 	if err != nil {
 		return nil, err
 	}
-	prevImage, _, _ := previousImageFor(name)
+	prevImage, _, lastOp, _ := previousImageFor(name)
 	out := &UpdateAvailability{
 		Service:       name,
 		CurrentImage:  svc.Image,
 		Strategy:      string(strategy),
 		PreviousImage: prevImage,
+		CanRollback:   prevImage != "" && lastOp != "migrate",
 	}
 	ref, parseErr := registry.ParseImage(svc.Image)
 	if parseErr == nil {
 		out.CurrentTag = ref.Tag
 	}
-	// The safe in-strategy update suggestion (auto-applicable, no migration).
 	var newer *registry.TagInfo
 	if strategy != registry.StrategyNone && strategy != "" {
 		newer, _ = registry.MaybeNewerTag(svc.Image, strategy)
-		// If the locally-pulled image already has the same digest as the
-		// recommended candidate, the user is effectively already on it.
-		// Probe both the configured tag (svc.Image) and whatever's actually
-		// in the on-disk quadlet (which may have drifted, e.g. config says
-		// :8.4 but quadlet pinned :8.4.9 from a previous update).
-		if newer != nil && newer.Digest != "" {
-			candidates := podman.LocalImageDigest(svc.Image)
-			if installed := podman.InstalledImage("lerd-" + name); installed != "" && installed != svc.Image {
-				candidates = append(candidates, podman.LocalImageDigest(installed)...)
-			}
-			for _, local := range candidates {
-				if local == newer.Digest {
-					newer = nil
-					break
-				}
-			}
+		if newer != nil && newer.Digest != "" && alreadyOnDigest(name, svc.Image, newer.Digest) {
+			newer = nil
 		}
 	}
 	if newer != nil {
@@ -82,13 +62,8 @@ func CheckUpdateAvailable(name string) (*UpdateAvailability, error) {
 			out.LatestImage = ref.Registry + "/" + ref.Repo + ":" + newer.Name
 		}
 	}
-	// The absolute newest stable tag, regardless of strategy. Surfaced as an
-	// opt-in cross-strategy upgrade. Cross-major boundaries only when the
-	// preset opts in via allow_major_upgrade. Skipped for strategy=none so
-	// opted-out presets stay quiet, and skipped for patch-strategy presets
-	// without a registered migrator — for those (e.g. meilisearch) crossing
-	// the minor boundary corrupts data and an in-place Upgrade button would
-	// be a trap; the user must follow upstream's manual upgrade guide.
+	// Cross-strategy upgrade: skipped for strategy=none and for patch presets
+	// without a registered migrator (otherwise the in-place button is a trap).
 	if strategy == registry.StrategyNone || strategy == "" {
 		return out, nil
 	}
@@ -96,19 +71,7 @@ func CheckUpdateAvailable(name string) (*UpdateAvailability, error) {
 		return out, nil
 	}
 	if upgrade, _ := registry.NewestStable(svc.Image, allowMajor); upgrade != nil {
-		alreadyOn := false
-		if upgrade.Digest != "" {
-			candidates := podman.LocalImageDigest(svc.Image)
-			if installed := podman.InstalledImage("lerd-" + name); installed != "" && installed != svc.Image {
-				candidates = append(candidates, podman.LocalImageDigest(installed)...)
-			}
-			for _, local := range candidates {
-				if local == upgrade.Digest {
-					alreadyOn = true
-					break
-				}
-			}
-		}
+		alreadyOn := upgrade.Digest != "" && alreadyOnDigest(name, svc.Image, upgrade.Digest)
 		if !alreadyOn && (newer == nil || upgrade.Name != newer.Name) {
 			out.UpgradeTag = upgrade.Name
 			if parseErr == nil {
@@ -119,12 +82,39 @@ func CheckUpdateAvailable(name string) (*UpdateAvailability, error) {
 	return out, nil
 }
 
-// UpdateServiceStreaming pulls the recommended newer image (or the
-// caller-supplied targetImage when non-empty for explicit upgrades), persists
-// it (in cfg.Services for default presets, in the on-disk YAML for installed
-// custom services), rewrites the quadlet, and restarts the unit. Phase
-// events: checking_registry, pulling_image, writing_quadlet, restarting_unit, done.
+// alreadyOnDigest reports whether a local image already matches the candidate
+// digest. Both sides are lowercased so registry casing differences don't
+// register as a mismatch.
+func alreadyOnDigest(name, configuredImage, candidate string) bool {
+	if candidate == "" {
+		return false
+	}
+	want := strings.ToLower(strings.TrimSpace(candidate))
+	check := func(local string) bool {
+		return strings.ToLower(strings.TrimSpace(local)) == want
+	}
+	for _, local := range podman.LocalImageDigest(configuredImage) {
+		if check(local) {
+			return true
+		}
+	}
+	if installed := podman.InstalledImage("lerd-" + name); installed != "" && installed != configuredImage {
+		for _, local := range podman.LocalImageDigest(installed) {
+			if check(local) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// UpdateServiceStreaming pulls the chosen image, persists it, rewrites the
+// quadlet, and restarts the unit. Phases: checking_registry, pulling_image,
+// writing_quadlet, restarting_unit, done.
 func UpdateServiceStreaming(name, targetImage string, emit func(PhaseEvent)) error {
+	unlock := lockService(name)
+	defer unlock()
+
 	emit(PhaseEvent{Phase: "checking_registry"})
 	chosenImage := targetImage
 	if chosenImage == "" {
@@ -137,6 +127,8 @@ func UpdateServiceStreaming(name, targetImage string, emit func(PhaseEvent)) err
 			return nil
 		}
 		chosenImage = avail.LatestImage
+	} else if err := enforceMajorUpgradeGate(name, chosenImage); err != nil {
+		return err
 	}
 
 	emit(PhaseEvent{Phase: "pulling_image", Image: chosenImage})
@@ -147,33 +139,87 @@ func UpdateServiceStreaming(name, targetImage string, emit func(PhaseEvent)) err
 	}
 
 	emit(PhaseEvent{Phase: "writing_quadlet", Image: chosenImage})
-	if err := persistImageChoice(name, chosenImage); err != nil {
+	if err := persistImageChoice(name, chosenImage, "update"); err != nil {
 		return err
 	}
 
 	unit := "lerd-" + name
 	emit(PhaseEvent{Phase: "restarting_unit", Unit: unit})
-	var restartErr error
-	for attempt := range 5 {
-		restartErr = podman.RestartUnit(unit)
-		if restartErr == nil || !strings.Contains(restartErr.Error(), "not found") {
-			break
-		}
-		time.Sleep(time.Duration(attempt+1) * 300 * time.Millisecond)
-	}
-	if restartErr != nil {
-		return restartErr
+	if err := restartWithRetry(unit); err != nil {
+		return err
 	}
 	emit(PhaseEvent{Phase: "done", Image: chosenImage, Unit: unit})
 	return nil
 }
 
+// restartWithRetry handles the "unit not found" race after writing a fresh
+// quadlet. Other errors return immediately. Surfaces the last error rather
+// than swallowing it after retries.
+func restartWithRetry(unit string) error {
+	var lastErr error
+	for attempt := range 5 {
+		err := podman.RestartUnit(unit)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !strings.Contains(err.Error(), "not found") {
+			return err
+		}
+		time.Sleep(time.Duration(attempt+1) * 300 * time.Millisecond)
+	}
+	if lastErr == nil {
+		return fmt.Errorf("restarting %s: gave up after retries", unit)
+	}
+	return lastErr
+}
+
+// enforceMajorUpgradeGate refuses an explicit cross-major target when the
+// preset has not opted in via allow_major_upgrade — same gate as the registry
+// recommendation path, so a CLI tag arg can't bypass it.
+func enforceMajorUpgradeGate(name, target string) error {
+	svc, _, allowMajor, err := resolveServiceForUpdate(name)
+	if err != nil || svc == nil {
+		return err
+	}
+	if allowMajor {
+		return nil
+	}
+	currentRef, perr := registry.ParseImage(svc.Image)
+	if perr != nil {
+		return nil
+	}
+	targetRef, perr := registry.ParseImage(target)
+	if perr != nil {
+		return nil
+	}
+	cur := leadingMajor(currentRef.Tag)
+	tgt := leadingMajor(targetRef.Tag)
+	if cur < 0 || tgt < 0 || cur == tgt {
+		return nil
+	}
+	return fmt.Errorf("refusing major-version jump %s → %s for %s; preset has allow_major_upgrade=false (use the Migrate flow instead)", currentRef.Tag, targetRef.Tag, name)
+}
+
+func leadingMajor(tag string) int {
+	t := strings.TrimPrefix(tag, "v")
+	end := 0
+	for end < len(t) && t[end] >= '0' && t[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return -1
+	}
+	n := 0
+	for i := 0; i < end; i++ {
+		n = n*10 + int(t[i]-'0')
+	}
+	return n
+}
+
 // resolveServiceForUpdate returns the resolved CustomService, update strategy,
-// and major-upgrade policy for either a default preset or an installed
-// custom service. Alternates installed via service preset (e.g. mysql-8-0)
-// override the preset's broader strategy with patch, so a user who explicitly
-// pinned 8.0 doesn't get suggested 8.4.9 — that crosses a minor and (for
-// mysql) a documented LTS line. Use the alternates picker for cross-minor.
+// and major-upgrade policy. Alternates installed via service preset (e.g.
+// mysql-8-0) downgrade the preset's strategy to patch.
 func resolveServiceForUpdate(name string) (*config.CustomService, registry.Strategy, bool, error) {
 	if config.IsDefaultPreset(name) {
 		p, err := config.LoadPreset(name)
@@ -184,11 +230,8 @@ func resolveServiceForUpdate(name string) (*config.CustomService, registry.Strat
 		if err != nil {
 			return nil, "", false, err
 		}
-		// Prefer the on-disk quadlet's image — it reflects what's actually
-		// running. With track_latest, the freshly-resolved canonical can drift
-		// ahead of the installed image (e.g. data dir is v1.7.6 but track_latest
-		// would now resolve to v1.42), and the update-check must report the
-		// real current state, not the would-be-fresh-install state.
+		// Prefer the installed image — track_latest can drift the resolved
+		// canonical ahead of what's actually on disk.
 		if installed := podman.InstalledImage("lerd-" + name); installed != "" {
 			svc.Image = installed
 		}
@@ -218,54 +261,102 @@ func resolveServiceForUpdate(name string) (*config.CustomService, registry.Strat
 	return svc, strategy, allowMajor, nil
 }
 
-// persistImageChoice records the chosen image so a subsequent service start
-// picks it up. For default presets this means writing to global config's
-// Services[name].Image; for installed custom services it means rewriting the
-// on-disk YAML and regenerating the quadlet. The previous image is preserved
-// alongside so a subsequent rollback can swap back without re-querying the
-// registry.
-func persistImageChoice(name, newImage string) error {
+// persistImageChoice records the chosen image and regenerates the quadlet.
+// Atomic: if the quadlet write fails the config write is rolled back so the
+// on-disk pair (config + quadlet) stays consistent.
+func persistImageChoice(name, newImage, op string) error {
 	if config.IsDefaultPreset(name) {
 		cfg, err := config.LoadGlobal()
 		if err != nil {
 			return err
 		}
-		svcCfg := cfg.Services[name]
-		if svcCfg.Image != "" && svcCfg.Image != newImage {
-			svcCfg.PreviousImage = svcCfg.Image
+		prev := cfg.Services[name]
+		next := prev
+		if next.Image != "" && next.Image != newImage {
+			next.PreviousImage = next.Image
 		}
-		svcCfg.Image = newImage
-		cfg.Services[name] = svcCfg
+		next.Image = newImage
+		next.LastOp = op
+		if op != "migrate" {
+			next.PreMigrateBackup = ""
+		}
+		cfg.Services[name] = next
 		if err := config.SaveGlobal(cfg); err != nil {
 			return fmt.Errorf("saving global config: %w", err)
 		}
-		return EnsureDefaultPresetQuadlet(name)
+		if err := EnsureDefaultPresetQuadlet(name); err != nil {
+			cfg.Services[name] = prev
+			if rbErr := config.SaveGlobal(cfg); rbErr != nil {
+				return fmt.Errorf("writing quadlet failed: %w; AND rolling config back failed: %v", err, rbErr)
+			}
+			return fmt.Errorf("writing quadlet: %w", err)
+		}
+		return nil
 	}
 	svc, err := config.LoadCustomService(name)
 	if err != nil {
 		return err
 	}
+	prevSvc := *svc
 	if svc.Image != "" && svc.Image != newImage {
 		svc.PreviousImage = svc.Image
 	}
 	svc.Image = newImage
+	svc.LastOp = op
+	if op != "migrate" {
+		svc.PreMigrateBackup = ""
+	}
 	if err := config.SaveCustomService(svc); err != nil {
 		return fmt.Errorf("saving service config: %w", err)
 	}
-	return EnsureCustomServiceQuadlet(svc)
+	if err := EnsureCustomServiceQuadlet(svc); err != nil {
+		if rbErr := config.SaveCustomService(&prevSvc); rbErr != nil {
+			return fmt.Errorf("writing quadlet failed: %w; AND rolling config back failed: %v", err, rbErr)
+		}
+		return fmt.Errorf("writing quadlet: %w", err)
+	}
+	return nil
+}
+
+// recordMigrateBackup stamps the post-migrate state onto the service config
+// so a later rollback can detect and refuse the unsafe path.
+func recordMigrateBackup(name, backup string) error {
+	if config.IsDefaultPreset(name) {
+		cfg, err := config.LoadGlobal()
+		if err != nil {
+			return err
+		}
+		entry := cfg.Services[name]
+		entry.LastOp = "migrate"
+		entry.PreMigrateBackup = backup
+		cfg.Services[name] = entry
+		return config.SaveGlobal(cfg)
+	}
+	svc, err := config.LoadCustomService(name)
+	if err != nil {
+		return err
+	}
+	svc.LastOp = "migrate"
+	svc.PreMigrateBackup = backup
+	return config.SaveCustomService(svc)
 }
 
 // RollbackService swaps a service back to its previously-running image.
-// The previous image is recorded on every update via persistImageChoice; a
-// rollback toggles current/previous so the next rollback redoes the update.
-// Errors when no previous image is recorded (nothing to roll back to).
+// Refuses when no previous image is recorded or when the most recent op was
+// a migrate (binary/schema mismatch would corrupt the data dir).
 func RollbackService(name string, emit func(PhaseEvent)) error {
-	prev, current, err := previousImageFor(name)
+	unlock := lockService(name)
+	defer unlock()
+
+	prev, current, lastOp, err := previousImageFor(name)
 	if err != nil {
 		return err
 	}
 	if prev == "" {
 		return fmt.Errorf("no previous image recorded for %s — nothing to roll back to", name)
+	}
+	if lastOp == "migrate" {
+		return fmt.Errorf("refusing rollback for %s: last op was a migrate. Restoring %s would mismatch binary against schema. Restore the pre-migrate data dir manually if you really want to revert", name, prev)
 	}
 	emit(PhaseEvent{Phase: "pulling_image", Image: prev})
 	if err := podman.PullImageWithProgress(prev, func(line string) {
@@ -279,64 +370,76 @@ func RollbackService(name string, emit func(PhaseEvent)) error {
 	}
 	unit := "lerd-" + name
 	emit(PhaseEvent{Phase: "restarting_unit", Unit: unit})
-	var restartErr error
-	for attempt := range 5 {
-		restartErr = podman.RestartUnit(unit)
-		if restartErr == nil || !strings.Contains(restartErr.Error(), "not found") {
-			break
-		}
-		time.Sleep(time.Duration(attempt+1) * 300 * time.Millisecond)
-	}
-	if restartErr != nil {
-		return restartErr
+	if err := restartWithRetry(unit); err != nil {
+		return err
 	}
 	emit(PhaseEvent{Phase: "done", Image: prev, Unit: unit})
 	return nil
 }
 
-// previousImageFor returns the recorded previous image and the current pinned
-// image for a service. Either may be empty.
-func previousImageFor(name string) (prev, current string, err error) {
+// previousImageFor returns the recorded previous image, current pinned image,
+// and the kind of the most recent op for a service. Any field may be empty.
+func previousImageFor(name string) (prev, current, lastOp string, err error) {
 	if config.IsDefaultPreset(name) {
 		cfg, lErr := config.LoadGlobal()
 		if lErr != nil {
-			return "", "", lErr
+			return "", "", "", lErr
 		}
 		svcCfg := cfg.Services[name]
-		return svcCfg.PreviousImage, svcCfg.Image, nil
+		return svcCfg.PreviousImage, svcCfg.Image, svcCfg.LastOp, nil
 	}
 	svc, lErr := config.LoadCustomService(name)
 	if lErr != nil {
-		return "", "", fmt.Errorf("unknown service %q", name)
+		return "", "", "", fmt.Errorf("unknown service %q", name)
 	}
-	return svc.PreviousImage, svc.Image, nil
+	return svc.PreviousImage, svc.Image, svc.LastOp, nil
 }
 
-// swapImagePin moves PreviousImage→Image and the old Image→PreviousImage so
-// the rollback is reversible: clicking rollback again returns to the original.
+// swapImagePin moves PreviousImage→Image and old Image→PreviousImage so the
+// rollback is reversible. Atomic: rolls back the config write if the quadlet
+// regeneration fails.
 func swapImagePin(name, newImage, newPrev string) error {
 	if config.IsDefaultPreset(name) {
 		cfg, err := config.LoadGlobal()
 		if err != nil {
 			return err
 		}
-		svcCfg := cfg.Services[name]
-		svcCfg.Image = newImage
-		svcCfg.PreviousImage = newPrev
-		cfg.Services[name] = svcCfg
+		prev := cfg.Services[name]
+		next := prev
+		next.Image = newImage
+		next.PreviousImage = newPrev
+		next.LastOp = "update"
+		next.PreMigrateBackup = ""
+		cfg.Services[name] = next
 		if err := config.SaveGlobal(cfg); err != nil {
 			return fmt.Errorf("saving global config: %w", err)
 		}
-		return EnsureDefaultPresetQuadlet(name)
+		if err := EnsureDefaultPresetQuadlet(name); err != nil {
+			cfg.Services[name] = prev
+			if rbErr := config.SaveGlobal(cfg); rbErr != nil {
+				return fmt.Errorf("writing quadlet failed: %w; AND rolling config back failed: %v", err, rbErr)
+			}
+			return fmt.Errorf("writing quadlet: %w", err)
+		}
+		return nil
 	}
 	svc, err := config.LoadCustomService(name)
 	if err != nil {
 		return err
 	}
+	prevSvc := *svc
 	svc.Image = newImage
 	svc.PreviousImage = newPrev
+	svc.LastOp = "update"
+	svc.PreMigrateBackup = ""
 	if err := config.SaveCustomService(svc); err != nil {
 		return fmt.Errorf("saving service config: %w", err)
 	}
-	return EnsureCustomServiceQuadlet(svc)
+	if err := EnsureCustomServiceQuadlet(svc); err != nil {
+		if rbErr := config.SaveCustomService(&prevSvc); rbErr != nil {
+			return fmt.Errorf("writing quadlet failed: %w; AND rolling config back failed: %v", err, rbErr)
+		}
+		return fmt.Errorf("writing quadlet: %w", err)
+	}
+	return nil
 }

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -756,7 +756,11 @@ type ServiceResponse struct {
 	LatestVersion      string            `json:"latest_version,omitempty"`
 	UpgradeVersion     string            `json:"upgrade_version,omitempty"`
 	PreviousVersion    string            `json:"previous_version,omitempty"`
-	MigrationSupported bool              `json:"migration_supported,omitempty"`
+	// MigrationSupported and CanRollback intentionally drop omitempty so the
+	// false case still appears in the JSON. The UI uses === to distinguish
+	// "field missing" (no avail check ran) from "explicitly false".
+	MigrationSupported bool `json:"migration_supported"`
+	CanRollback        bool `json:"can_rollback"`
 }
 
 func buildServiceResponse(name string) ServiceResponse {
@@ -797,6 +801,7 @@ func buildServiceResponse(name string) ServiceResponse {
 		resp.UpgradeVersion = avail.UpgradeTag
 		resp.PreviousVersion = avail.PreviousImage
 		resp.MigrationSupported = serviceops.SupportsMigration(name)
+		resp.CanRollback = avail.CanRollback
 	}
 	return resp
 }
@@ -1044,17 +1049,7 @@ func handleServicePresetInstall(w http.ResponseWriter, r *http.Request) {
 	}
 	version := r.URL.Query().Get("version")
 
-	w.Header().Set("Content-Type", "application/x-ndjson")
-	w.Header().Set("Cache-Control", "no-store")
-	w.WriteHeader(http.StatusOK)
-	flusher, _ := w.(http.Flusher)
-	writeLine := func(payload any) {
-		data, _ := json.Marshal(payload)
-		_, _ = w.Write(append(data, '\n'))
-		if flusher != nil {
-			flusher.Flush()
-		}
-	}
+	writeLine, _ := startNDJSONStream(w, r)
 
 	svc, err := serviceops.InstallPresetStreaming(name, version, func(ev serviceops.PhaseEvent) {
 		writeLine(ev)
@@ -1070,6 +1065,42 @@ func handleServicePresetInstall(w http.ResponseWriter, r *http.Request) {
 		"dashboard":  svc.Dashboard,
 		"depends_on": svc.DependsOn,
 	})
+}
+
+// startNDJSONStream writes the streaming-response headers and returns a
+// writeLine that stops after the first failed write or when the client
+// disconnects, so a refreshed browser tab can't drive the server to keep
+// writing into a broken connection.
+func startNDJSONStream(w http.ResponseWriter, r *http.Request) (writeLine func(payload any), alive func() bool) {
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	flusher, _ := w.(http.Flusher)
+	dead := false
+	ctx := r.Context()
+	writeLine = func(payload any) {
+		if dead {
+			return
+		}
+		if ctx.Err() != nil {
+			dead = true
+			return
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			dead = true
+			return
+		}
+		if _, err := w.Write(append(data, '\n')); err != nil {
+			dead = true
+			return
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+	alive = func() bool { return !dead && ctx.Err() == nil }
+	return writeLine, alive
 }
 
 // ServiceActionResponse wraps the service state plus any error details.
@@ -1123,17 +1154,7 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 		if at := strings.LastIndex(targetImage, ":"); at > 0 {
 			targetImage = targetImage[:at] + ":" + targetTag
 		}
-		w.Header().Set("Content-Type", "application/x-ndjson")
-		w.Header().Set("Cache-Control", "no-store")
-		w.WriteHeader(http.StatusOK)
-		flusher, _ := w.(http.Flusher)
-		writeLine := func(payload any) {
-			data, _ := json.Marshal(payload)
-			_, _ = w.Write(append(data, '\n'))
-			if flusher != nil {
-				flusher.Flush()
-			}
-		}
+		writeLine, _ := startNDJSONStream(w, r)
 		if err := serviceops.MigrateService(name, targetImage, func(ev serviceops.PhaseEvent) { writeLine(ev) }); err != nil {
 			writeLine(map[string]any{"phase": "error", "error": err.Error()})
 		}
@@ -1142,17 +1163,7 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 
 	// Streaming rollback: pull the previously-running image and restart.
 	if action == "rollback" && r.Method == http.MethodPost {
-		w.Header().Set("Content-Type", "application/x-ndjson")
-		w.Header().Set("Cache-Control", "no-store")
-		w.WriteHeader(http.StatusOK)
-		flusher, _ := w.(http.Flusher)
-		writeLine := func(payload any) {
-			data, _ := json.Marshal(payload)
-			_, _ = w.Write(append(data, '\n'))
-			if flusher != nil {
-				flusher.Flush()
-			}
-		}
+		writeLine, _ := startNDJSONStream(w, r)
 		if err := serviceops.RollbackService(name, func(ev serviceops.PhaseEvent) { writeLine(ev) }); err != nil {
 			writeLine(map[string]any{"phase": "error", "error": err.Error()})
 		}
@@ -1173,17 +1184,7 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-		w.Header().Set("Content-Type", "application/x-ndjson")
-		w.Header().Set("Cache-Control", "no-store")
-		w.WriteHeader(http.StatusOK)
-		flusher, _ := w.(http.Flusher)
-		writeLine := func(payload any) {
-			data, _ := json.Marshal(payload)
-			_, _ = w.Write(append(data, '\n'))
-			if flusher != nil {
-				flusher.Flush()
-			}
-		}
+		writeLine, _ := startNDJSONStream(w, r)
 		err := serviceops.UpdateServiceStreaming(name, targetImage, func(ev serviceops.PhaseEvent) {
 			writeLine(ev)
 		})

--- a/internal/ui/web/src/stores/services.ts
+++ b/internal/ui/web/src/stores/services.ts
@@ -29,6 +29,7 @@ export interface Service {
   upgrade_version?: string;
   previous_version?: string;
   migration_supported?: boolean;
+  can_rollback?: boolean;
 }
 
 export interface PhaseEvent {
@@ -44,6 +45,7 @@ export interface PhaseEvent {
 export interface UpdateProgress {
   phase: string;
   message: string;
+  error?: boolean;
 }
 
 export const updateProgress = writable<Record<string, UpdateProgress>>({});
@@ -197,6 +199,7 @@ export async function streamServiceAction(
         }
         if (evt.phase === 'error') {
           finalError = evt.error || 'failed';
+          setProgress(name, { phase: 'error', message: finalError, error: true });
           continue;
         }
         if (evt.phase === 'done') continue;
@@ -207,7 +210,11 @@ export async function streamServiceAction(
         setProgress(name, { phase: evt.phase, message });
       }
     }
-    setProgress(name, null);
+    if (finalError) {
+      setTimeout(() => setProgress(name, null), 5000);
+    } else {
+      setProgress(name, null);
+    }
     await loadServices();
     return { ok: !finalError, error: finalError };
   } catch (e) {

--- a/internal/ui/web/src/tabs/services/ServiceHeader.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceHeader.svelte
@@ -149,7 +149,7 @@
       });
     }
 
-    if (svc.upgrade_version && !svc.migration_supported && !updating) {
+    if (svc.upgrade_version && svc.migration_supported === false && !updating) {
       const tag = svc.upgrade_version;
       list.push({
         id: 'upgrade',
@@ -161,7 +161,7 @@
       });
     }
 
-    if (svc.upgrade_version && svc.migration_supported && !updating) {
+    if (svc.upgrade_version && svc.migration_supported === true && !updating) {
       const tag = svc.upgrade_version;
       list.push({
         id: 'migrate',
@@ -173,7 +173,7 @@
       });
     }
 
-    if (svc.previous_version && !updating) {
+    if (svc.previous_version && svc.can_rollback !== false && !updating) {
       const tag = rollbackTagFromImage(svc.previous_version);
       list.push({
         id: 'rollback',


### PR DESCRIPTION
## Summary

Bug fixes and hardening for the Update / Upgrade / Migrate / Rollback flow added in #265. Nothing here has shipped to a tagged release.

## Critical

- Per-service mutex serialises `UpdateServiceStreaming` / `MigrateService` / `RollbackService`. Double-clicks in the dashboard, or a CLI run racing the UI, can no longer interleave config writes, image pulls and data-dir swaps (`internal/serviceops/locks.go`).
- `persistImageChoice` and `swapImagePin` now roll the config write back if quadlet regeneration fails, so `~/.config/lerd/config.yaml` and the on-disk `.container` file can never disagree. Joined-error reporting if rollback itself fails.
- Migrate: a new `abortMigrate` helper restores the pre-migrate data dir on failure and bubbles errors from `restoreDataDirFromBackup` (was `_ = ...`). Old unit is restarted when appropriate.
- Rollback after a Migrate is now refused. New `LastOp` and `PreMigrateBackup` fields on `ServiceConfig` / `CustomService`. Dashboard hides the Rollback button via the new `can_rollback` field.

## High

- `mysqldump` and `pg_dumpall` receive `MYSQL_PWD` / `PGPASSWORD` via `podman exec --env`, not on the command line — credentials no longer land in `/proc/<pid>/cmdline`. Dump files open with `0600`; backups dir is `0700`.
- 30-minute timeout on every in-container migrate exec. A wedged container can no longer block migrate forever.
- `allow_major_upgrade` enforced in the CLI tag path too — `lerd service update mysql 9.0` is now refused for presets where `allow_major_upgrade: false`.
- Server-side NDJSON streams stop on client disconnect. New `startNDJSONStream` helper short-circuits writes once `r.Context()` is cancelled or `w.Write` errors, replacing four copies of `_, _ = w.Write(...)` in update / migrate / rollback / preset-install handlers.
- Client surfaces stream errors. `streamServiceAction` now calls `setProgress(name, { phase: 'error', error: true })` before continuing, so a failed update shows the error instead of leaving the spinner stuck on the last visible phase.
- Strict-equality button gates: `migration_supported === false` / `=== true`, `can_rollback !== false`. JSON tags lose `omitempty` on the corresponding bools so the false case is always wire-visible.
- `lerd service restart` warns and continues if quadlet regeneration trips, instead of failing a healthy unit on a transient render error.

## Registry (`internal/registry`)

- Docker Hub pagination followed (was: `Next` field read but never used). Capped at 20 pages and 5000 tags.
- Distinct error classes: `*AuthRequiredErr`, `*NotFoundErr`. 401/403 → auth, 404 → not found, 429/5xx → unreachable. All collapse to "no update info" in the UI via a new `isQuietRegistryErr` but stay distinguishable for future hints.
- Token and tag-list calls have separate 15s timeout budgets.
- Concurrent cache writes now safe: in-process mutex + atomic rename, plus an inline singleflight collapses concurrent `ListTags`. Cache write failures emit a rate-limited `log.Printf`.
- Response body capped at 5 MB; tag list capped at 5000 entries.

## Misc

- Digest comparisons normalised (lowercase + trim) so registries returning differently-cased digests don't drive a permanent "update available" badge.
- New tests: `TestRollback_RefusesAfterMigrate`, `TestCheckUpdateAvailable_CanRollback`, `TestEnforceMajorUpgradeGate`, `TestLeadingMajor`, and registry tests for 404 / 429 / 5xx / pagination / concurrent-singleflight.
- `docs/usage/service-updates.md` updated to describe the post-migrate rollback refusal.