### PR TITLE
perf(daemon): cut idle CPU to ~0%, harden FPM against restart cascades

### DIFF
--- a/internal/cli/lanshare.go
+++ b/internal/cli/lanshare.go
@@ -53,6 +53,9 @@ func LANShareStart(siteName string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	if site.Paused {
+		return site.LANPort, fmt.Errorf("site %q is paused", siteName)
+	}
 
 	port := site.LANPort
 	if port == 0 {
@@ -95,6 +98,24 @@ func LANShareStart(siteName string) (int, error) {
 // LANShareStop stops the LAN share proxy for the site and clears its port
 // from the site registry.
 func LANShareStop(siteName string) error {
+	closeLANShareServer(siteName)
+
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return err
+	}
+	site.LANPort = 0
+	return config.AddSite(*site)
+}
+
+// LANShareStopServer closes the running proxy without clearing the site's
+// stored LAN port. Used when pausing a site so the same port can be reused on
+// unpause without invalidating any QR codes the user has shared.
+func LANShareStopServer(siteName string) {
+	closeLANShareServer(siteName)
+}
+
+func closeLANShareServer(siteName string) {
 	lanShareMu.Lock()
 	srv, running := lanShareServers[siteName]
 	if running {
@@ -105,13 +126,6 @@ func LANShareStop(siteName string) error {
 	if running {
 		srv.Close()
 	}
-
-	site, err := config.FindSite(siteName)
-	if err != nil {
-		return err
-	}
-	site.LANPort = 0
-	return config.AddSite(*site)
 }
 
 // LANShareRunning reports whether a share proxy is active for the site.
@@ -141,7 +155,7 @@ func RestoreLANShareProxies() {
 		}
 	}
 	for _, s := range reg.Sites {
-		if s.LANPort == 0 {
+		if !shouldRunLANShareProxy(s) {
 			continue
 		}
 		srv, err := startLANShareProxy(s.PrimaryDomain(), s.LANPort, httpPort, httpsPort, s.Secured)
@@ -152,6 +166,13 @@ func RestoreLANShareProxies() {
 		lanShareServers[s.Name] = srv
 		lanShareMu.Unlock()
 	}
+}
+
+// shouldRunLANShareProxy reports whether the daemon should keep a LAN share
+// proxy bound for the site. Paused sites are excluded so the port is not held
+// while the site is intentionally offline.
+func shouldRunLANShareProxy(s config.Site) bool {
+	return s.LANPort != 0 && !s.Paused
 }
 
 // assignLANSharePort finds the lowest unused port >= 9100 across all sites.

--- a/internal/cli/lanshare_test.go
+++ b/internal/cli/lanshare_test.go
@@ -1,6 +1,30 @@
 package cli
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestShouldRunLANShareProxy(t *testing.T) {
+	cases := []struct {
+		name string
+		site config.Site
+		want bool
+	}{
+		{"no port", config.Site{Name: "a"}, false},
+		{"port + active", config.Site{Name: "a", LANPort: 9100}, true},
+		{"port + paused", config.Site{Name: "a", LANPort: 9100, Paused: true}, false},
+		{"no port + paused", config.Site{Name: "a", Paused: true}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldRunLANShareProxy(c.site); got != c.want {
+				t.Errorf("shouldRunLANShareProxy(%+v) = %v, want %v", c.site, got, c.want)
+			}
+		})
+	}
+}
 
 func TestRewriteLANShareBody_collapsesHTTPSToHTTP(t *testing.T) {
 	in := []byte(`<link href="https://laravel.test/build/app.css">

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -75,6 +75,10 @@ func PauseSite(name string) error {
 		_ = podman.StopUnit(podman.FrankenPHPContainerName(site.Name))
 	}
 
+	// Release the LAN share port while paused. The site's stored LANPort is
+	// preserved so unpause restores the same address.
+	LANShareStopServer(site.Name)
+
 	if err := writePausedHTML(site); err != nil {
 		return fmt.Errorf("writing paused page: %w", err)
 	}
@@ -200,6 +204,12 @@ func UnpauseSite(name string) error {
 	site.PausedWorkers = nil
 	if err := config.AddSite(*site); err != nil {
 		return fmt.Errorf("updating registry: %w", err)
+	}
+
+	if site.LANPort != 0 {
+		if _, err := LANShareStart(site.Name); err != nil {
+			fmt.Printf("[WARN] restoring LAN share: %v\n", err)
+		}
 	}
 
 	// The shared paused.html is left in place for other paused sites.

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -675,17 +676,87 @@ func LoadUserFramework(name string) *Framework {
 	return loadFrameworkYAML(filepath.Join(FrameworksDir(), name+".yaml"))
 }
 
+// frameworkFileCache memoises parsed Framework definitions keyed by file path,
+// invalidated by mtime+size. The daemon's snapshot path used to read and parse
+// each framework YAML once per site per rebuild — pprof showed yaml.Unmarshal
+// as the dominant CPU cost. Returns a clone of the mutable fields (Workers,
+// Setup, Logs, FrankenPHP) so callers like mergeUserOverlay /
+// mergeProjectWorkers can append without poisoning the cached value.
+type frameworkCacheEntry struct {
+	fw    *Framework // nil = file missing or unparseable
+	mtime time.Time
+	size  int64
+}
+
+var (
+	frameworkFileCacheMu sync.Mutex
+	frameworkFileCache   = map[string]frameworkCacheEntry{}
+)
+
 // loadFrameworkYAML reads and parses a single framework YAML file.
 func loadFrameworkYAML(path string) *Framework {
-	data, err := os.ReadFile(path)
-	if err != nil {
+	info, statErr := os.Stat(path)
+
+	frameworkFileCacheMu.Lock()
+	entry, hit := frameworkFileCache[path]
+	cacheValid := hit && (statErr != nil && entry.fw == nil ||
+		statErr == nil && entry.mtime.Equal(info.ModTime()) && entry.size == info.Size())
+	if cacheValid {
+		fw := entry.fw
+		frameworkFileCacheMu.Unlock()
+		return cloneFrameworkMutable(fw)
+	}
+	frameworkFileCacheMu.Unlock()
+
+	var parsed *Framework
+	if statErr == nil {
+		if data, err := os.ReadFile(path); err == nil {
+			var fw Framework
+			if yaml.Unmarshal(data, &fw) == nil && fw.Name != "" {
+				parsed = &fw
+			}
+		}
+	}
+
+	frameworkFileCacheMu.Lock()
+	next := frameworkCacheEntry{fw: parsed}
+	if statErr == nil {
+		next.mtime = info.ModTime()
+		next.size = info.Size()
+	}
+	frameworkFileCache[path] = next
+	frameworkFileCacheMu.Unlock()
+
+	return cloneFrameworkMutable(parsed)
+}
+
+// cloneFrameworkMutable returns a copy where the maps and slices that
+// mergeUserOverlay/mergeProjectWorkers/mergeBuiltinFrankenPHP touch are freshly
+// allocated. Inner FrameworkWorker/Setup/Log values are copied by value;
+// pointer fields inside them aren't cloned because the merges only replace
+// whole entries, never mutate them in place.
+func cloneFrameworkMutable(in *Framework) *Framework {
+	if in == nil {
 		return nil
 	}
-	var fw Framework
-	if yaml.Unmarshal(data, &fw) != nil || fw.Name == "" {
-		return nil
+	out := *in
+	if in.Workers != nil {
+		out.Workers = make(map[string]FrameworkWorker, len(in.Workers))
+		for k, v := range in.Workers {
+			out.Workers[k] = v
+		}
 	}
-	return &fw
+	if in.Setup != nil {
+		out.Setup = append([]FrameworkSetupCmd(nil), in.Setup...)
+	}
+	if in.Logs != nil {
+		out.Logs = append([]FrameworkLogSource(nil), in.Logs...)
+	}
+	if in.FrankenPHP != nil {
+		cp := *in.FrankenPHP
+		out.FrankenPHP = &cp
+	}
+	return &out
 }
 
 // loadBestVersionedFramework scans StoreFrameworksDir for <name>@<version>.yaml files.

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
@@ -143,9 +145,53 @@ func firstHostPort(ports []string) int {
 	return n
 }
 
+// globalCache memoises the last LoadGlobal result keyed on config.yaml's
+// mtime+size. The daemon's snapshot path used to call LoadGlobal hundreds of
+// times per rebuild (one per site, transitively), and each call re-parsed
+// every preset YAML via defaultConfig — pprof showed yaml.Unmarshal as the
+// dominant CPU cost. The cache returns a deep copy so callers can mutate the
+// returned struct without poisoning the cache.
+var (
+	globalCacheMu sync.Mutex
+	globalCache   *GlobalConfig
+	globalCacheAt time.Time
+	globalCacheSz int64
+)
+
+// invalidateGlobalCache drops the cached config so the next LoadGlobal re-reads
+// from disk. Called from SaveGlobal so writes are visible immediately.
+func invalidateGlobalCache() {
+	globalCacheMu.Lock()
+	globalCache = nil
+	globalCacheAt = time.Time{}
+	globalCacheSz = 0
+	globalCacheMu.Unlock()
+}
+
 // LoadGlobal reads config.yaml via viper, returning defaults if the file is absent.
 func LoadGlobal() (*GlobalConfig, error) {
 	cfgFile := GlobalConfigFile()
+
+	var (
+		statMtime time.Time
+		statSize  int64
+		statErr   error
+	)
+	if info, err := os.Stat(cfgFile); err == nil {
+		statMtime = info.ModTime()
+		statSize = info.Size()
+	} else {
+		statErr = err
+	}
+
+	globalCacheMu.Lock()
+	if globalCache != nil && statErr == nil &&
+		globalCacheAt.Equal(statMtime) && globalCacheSz == statSize {
+		out := cloneGlobalConfig(globalCache)
+		globalCacheMu.Unlock()
+		return out, nil
+	}
+	globalCacheMu.Unlock()
 
 	v := viper.NewWithOptions(viper.KeyDelimiter("::"))
 	v.SetConfigFile(cfgFile)
@@ -163,7 +209,55 @@ func LoadGlobal() (*GlobalConfig, error) {
 		return nil, err
 	}
 	migrateStaleServiceImages(cfg)
+
+	if statErr == nil {
+		globalCacheMu.Lock()
+		globalCache = cloneGlobalConfig(cfg)
+		globalCacheAt = statMtime
+		globalCacheSz = statSize
+		globalCacheMu.Unlock()
+	}
 	return cfg, nil
+}
+
+// cloneGlobalConfig returns a deep copy. Maps and slices are duplicated so
+// callers cannot mutate the cached value.
+func cloneGlobalConfig(in *GlobalConfig) *GlobalConfig {
+	out := *in
+	if in.PHP.XdebugEnabled != nil {
+		out.PHP.XdebugEnabled = make(map[string]bool, len(in.PHP.XdebugEnabled))
+		for k, v := range in.PHP.XdebugEnabled {
+			out.PHP.XdebugEnabled[k] = v
+		}
+	}
+	if in.PHP.XdebugMode != nil {
+		out.PHP.XdebugMode = make(map[string]string, len(in.PHP.XdebugMode))
+		for k, v := range in.PHP.XdebugMode {
+			out.PHP.XdebugMode[k] = v
+		}
+	}
+	if in.PHP.Extensions != nil {
+		out.PHP.Extensions = make(map[string][]string, len(in.PHP.Extensions))
+		for k, v := range in.PHP.Extensions {
+			cp := make([]string, len(v))
+			copy(cp, v)
+			out.PHP.Extensions[k] = cp
+		}
+	}
+	if in.ParkedDirectories != nil {
+		out.ParkedDirectories = append([]string(nil), in.ParkedDirectories...)
+	}
+	if in.Services != nil {
+		out.Services = make(map[string]ServiceConfig, len(in.Services))
+		for k, v := range in.Services {
+			cp := v
+			if v.ExtraPorts != nil {
+				cp.ExtraPorts = append([]string(nil), v.ExtraPorts...)
+			}
+			out.Services[k] = cp
+		}
+	}
+	return &out
 }
 
 // staleServiceImages maps service name → list of historical default images
@@ -331,5 +425,9 @@ func SaveGlobal(cfg *GlobalConfig) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(GlobalConfigFile(), data, 0644)
+	if err := os.WriteFile(GlobalConfigFile(), data, 0644); err != nil {
+		return err
+	}
+	invalidateGlobalCache()
+	return nil
 }

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -69,6 +69,58 @@ func TestSaveLoadGlobal_RoundTrip(t *testing.T) {
 	}
 }
 
+// ── Cache ─────────────────────────────────────────────────────────────────────
+
+func TestLoadGlobal_CacheReturnsIndependentCopy(t *testing.T) {
+	setConfigDir(t)
+	invalidateGlobalCache()
+	t.Cleanup(invalidateGlobalCache)
+
+	cfg, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	cfg.DNS.TLD = "local"
+	if cfg.Services == nil {
+		cfg.Services = map[string]ServiceConfig{}
+	}
+	cfg.Services["mutated"] = ServiceConfig{Enabled: true}
+
+	again, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal #2: %v", err)
+	}
+	if again.DNS.TLD == "local" {
+		t.Error("cached value should not reflect caller mutation of DNS.TLD")
+	}
+	if _, ok := again.Services["mutated"]; ok {
+		t.Error("cached value should not reflect caller mutation of Services map")
+	}
+}
+
+func TestLoadGlobal_CacheInvalidatedBySaveGlobal(t *testing.T) {
+	setConfigDir(t)
+	invalidateGlobalCache()
+	t.Cleanup(invalidateGlobalCache)
+
+	cfg, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	cfg.DNS.TLD = "local"
+	if err := SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	got, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal after save: %v", err)
+	}
+	if got.DNS.TLD != "local" {
+		t.Errorf("after SaveGlobal, DNS.TLD = %q, want %q", got.DNS.TLD, "local")
+	}
+}
+
 // ── Xdebug ────────────────────────────────────────────────────────────────────
 
 func TestXdebug_Toggle(t *testing.T) {

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -144,8 +144,16 @@ func ListPresets() ([]PresetMeta, error) {
 	return out, nil
 }
 
+// presetCache memoises parsed Presets so the daemon doesn't re-parse the
+// embedded YAML on every snapshot rebuild. The bundled files are immutable for
+// the lifetime of the binary, so the cache never needs invalidation.
+var presetCache sync.Map // map[string]*Preset
+
 // LoadPreset returns the parsed Preset for a bundled file by name.
 func LoadPreset(name string) (*Preset, error) {
+	if cached, ok := presetCache.Load(name); ok {
+		return cached.(*Preset), nil
+	}
 	data, err := presetFS.ReadFile("presets/" + name + ".yaml")
 	if err != nil {
 		return nil, fmt.Errorf("unknown preset %q", name)
@@ -160,6 +168,7 @@ func LoadPreset(name string) (*Preset, error) {
 	if len(p.Versions) > 0 && p.DefaultVersion == "" {
 		p.DefaultVersion = p.Versions[0].Tag
 	}
+	presetCache.Store(name, &p)
 	return &p, nil
 }
 

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -199,10 +201,60 @@ func (s ProjectService) Resolve() (*CustomService, error) {
 	return nil, nil
 }
 
+// projectConfigCache memoises parsed .lerd.yaml entries keyed by file path,
+// invalidated by mtime+size. Used by the daemon's per-site enrichment so each
+// snapshot rebuild doesn't re-read every project's .lerd.yaml. Negative
+// entries cache the absence so missing files don't cost a fresh stat+open
+// each time.
+type projectConfigCacheEntry struct {
+	cfg   *ProjectConfig // nil = file missing
+	mtime time.Time
+	size  int64
+}
+
+var (
+	projectConfigCacheMu sync.Mutex
+	projectConfigCache   = map[string]projectConfigCacheEntry{}
+)
+
+func invalidateProjectConfigCache(dir string) {
+	path := filepath.Join(dir, ".lerd.yaml")
+	projectConfigCacheMu.Lock()
+	delete(projectConfigCache, path)
+	projectConfigCacheMu.Unlock()
+}
+
 // LoadProjectConfig reads .lerd.yaml from dir, returning an empty config if
 // the file does not exist.
 func LoadProjectConfig(dir string) (*ProjectConfig, error) {
-	data, err := os.ReadFile(filepath.Join(dir, ".lerd.yaml"))
+	path := filepath.Join(dir, ".lerd.yaml")
+	info, statErr := os.Stat(path)
+
+	projectConfigCacheMu.Lock()
+	entry, hit := projectConfigCache[path]
+	cacheValid := hit && (statErr != nil && entry.cfg == nil ||
+		statErr == nil && entry.mtime.Equal(info.ModTime()) && entry.size == info.Size())
+	if cacheValid {
+		out := cloneProjectConfig(entry.cfg)
+		projectConfigCacheMu.Unlock()
+		if out == nil {
+			return &ProjectConfig{}, nil
+		}
+		return out, nil
+	}
+	projectConfigCacheMu.Unlock()
+
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			projectConfigCacheMu.Lock()
+			projectConfigCache[path] = projectConfigCacheEntry{}
+			projectConfigCacheMu.Unlock()
+			return &ProjectConfig{}, nil
+		}
+		return nil, statErr
+	}
+
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &ProjectConfig{}, nil
@@ -213,7 +265,48 @@ func LoadProjectConfig(dir string) (*ProjectConfig, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
-	return &cfg, nil
+
+	projectConfigCacheMu.Lock()
+	projectConfigCache[path] = projectConfigCacheEntry{
+		cfg: &cfg, mtime: info.ModTime(), size: info.Size(),
+	}
+	projectConfigCacheMu.Unlock()
+
+	return cloneProjectConfig(&cfg), nil
+}
+
+// cloneProjectConfig returns a copy with mutable maps and slices freshly
+// allocated. Inner FrameworkWorker entries are copied by value; their nested
+// pointers (Check, Proxy) aren't deep-copied because callers don't mutate
+// them in place.
+func cloneProjectConfig(in *ProjectConfig) *ProjectConfig {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.Domains != nil {
+		out.Domains = append([]string(nil), in.Domains...)
+	}
+	if in.Services != nil {
+		out.Services = append([]ProjectService(nil), in.Services...)
+	}
+	if in.Workers != nil {
+		out.Workers = append([]string(nil), in.Workers...)
+	}
+	if in.CustomWorkers != nil {
+		out.CustomWorkers = make(map[string]FrameworkWorker, len(in.CustomWorkers))
+		for k, v := range in.CustomWorkers {
+			out.CustomWorkers[k] = v
+		}
+	}
+	if in.Container != nil {
+		cp := *in.Container
+		out.Container = &cp
+	}
+	if in.FrameworkDef != nil {
+		out.FrameworkDef = cloneFrameworkMutable(in.FrameworkDef)
+	}
+	return &out
 }
 
 // SaveProjectConfig writes cfg to .lerd.yaml in dir.
@@ -222,5 +315,9 @@ func SaveProjectConfig(dir string, cfg *ProjectConfig) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, ".lerd.yaml"), data, 0644)
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), data, 0644); err != nil {
+		return err
+	}
+	invalidateProjectConfigCache(dir)
+	return nil
 }

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"os"
+	"sync"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -156,9 +158,41 @@ type siteRegistryYAML struct {
 	Sites []siteYAML `yaml:"sites"`
 }
 
+// sitesCache memoises the parsed registry keyed on sites.yaml's mtime+size.
+// The daemon's snapshot path used to re-read and re-parse sites.yaml once per
+// snapshot rebuild via LoadAll; with many sites this dominated the YAML parse
+// cost. The cache returns a freshly-allocated registry so callers can mutate
+// the slice without poisoning the cached value.
+var (
+	sitesCacheMu sync.Mutex
+	sitesCache   *SiteRegistry
+	sitesCacheAt time.Time
+	sitesCacheSz int64
+)
+
+func invalidateSitesCache() {
+	sitesCacheMu.Lock()
+	sitesCache = nil
+	sitesCacheAt = time.Time{}
+	sitesCacheSz = 0
+	sitesCacheMu.Unlock()
+}
+
 // LoadSites reads sites.yaml, returning an empty registry if the file does not exist.
 func LoadSites() (*SiteRegistry, error) {
-	data, err := os.ReadFile(SitesFile())
+	path := SitesFile()
+	info, statErr := os.Stat(path)
+
+	sitesCacheMu.Lock()
+	if sitesCache != nil && statErr == nil &&
+		sitesCacheAt.Equal(info.ModTime()) && sitesCacheSz == info.Size() {
+		out := cloneSiteRegistry(sitesCache)
+		sitesCacheMu.Unlock()
+		return out, nil
+	}
+	sitesCacheMu.Unlock()
+
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &SiteRegistry{}, nil
@@ -174,7 +208,33 @@ func LoadSites() (*SiteRegistry, error) {
 	for i, sy := range raw.Sites {
 		reg.Sites[i] = sy.toSite()
 	}
+
+	if statErr == nil {
+		sitesCacheMu.Lock()
+		sitesCache = cloneSiteRegistry(reg)
+		sitesCacheAt = info.ModTime()
+		sitesCacheSz = info.Size()
+		sitesCacheMu.Unlock()
+	}
 	return reg, nil
+}
+
+func cloneSiteRegistry(in *SiteRegistry) *SiteRegistry {
+	if in == nil {
+		return &SiteRegistry{}
+	}
+	out := &SiteRegistry{Sites: make([]Site, len(in.Sites))}
+	for i, s := range in.Sites {
+		cp := s
+		if s.Domains != nil {
+			cp.Domains = append([]string(nil), s.Domains...)
+		}
+		if s.PausedWorkers != nil {
+			cp.PausedWorkers = append([]string(nil), s.PausedWorkers...)
+		}
+		out.Sites[i] = cp
+	}
+	return out
 }
 
 // SaveSites writes the registry to sites.yaml.
@@ -192,7 +252,11 @@ func SaveSites(reg *SiteRegistry) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(SitesFile(), data, 0644)
+	if err := os.WriteFile(SitesFile(), data, 0644); err != nil {
+		return err
+	}
+	invalidateSitesCache()
+	return nil
 }
 
 // AddSite appends or updates a site in the registry.

--- a/internal/config/site_test.go
+++ b/internal/config/site_test.go
@@ -506,6 +506,64 @@ func TestSaveLoad_ContainerPort_RoundTrip(t *testing.T) {
 	}
 }
 
+// ── Cache ─────────────────────────────────────────────────────────────────────
+
+func TestLoadSites_CacheReturnsIndependentCopy(t *testing.T) {
+	setDataDir(t)
+	invalidateSitesCache()
+	t.Cleanup(invalidateSitesCache)
+
+	if err := AddSite(Site{Name: "alpha", Domains: []string{"alpha.test"}, Path: "/srv/a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := LoadSites()
+	if err != nil {
+		t.Fatalf("LoadSites: %v", err)
+	}
+	first.Sites[0].Name = "MUTATED"
+	first.Sites[0].Domains[0] = "tampered.test"
+	first.Sites = append(first.Sites, Site{Name: "phantom"})
+
+	second, err := LoadSites()
+	if err != nil {
+		t.Fatalf("LoadSites #2: %v", err)
+	}
+	if len(second.Sites) != 1 {
+		t.Fatalf("len = %d, want 1 (callers mutating returned slice should not leak into cache)", len(second.Sites))
+	}
+	if second.Sites[0].Name != "alpha" {
+		t.Errorf("Name leaked: got %q, want alpha", second.Sites[0].Name)
+	}
+	if second.Sites[0].Domains[0] != "alpha.test" {
+		t.Errorf("Domains leaked: got %q, want alpha.test", second.Sites[0].Domains[0])
+	}
+}
+
+func TestLoadSites_CacheInvalidatedBySaveSites(t *testing.T) {
+	setDataDir(t)
+	invalidateSitesCache()
+	t.Cleanup(invalidateSitesCache)
+
+	if err := AddSite(Site{Name: "alpha", Domains: []string{"alpha.test"}, Path: "/srv/a"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadSites(); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddSite(Site{Name: "beta", Domains: []string{"beta.test"}, Path: "/srv/b"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadSites()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Sites) != 2 {
+		t.Fatalf("len = %d after second AddSite, want 2 (cache must invalidate on SaveSites)", len(got.Sites))
+	}
+}
+
 func searchString(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {

--- a/internal/php/versions.go
+++ b/internal/php/versions.go
@@ -1,7 +1,6 @@
 package php
 
 import (
-	"bytes"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -39,21 +38,18 @@ func ListInstalled() ([]string, error) {
 		seen[v] = true
 	}
 
-	// Source 2: podman containers (catches installs where the quadlet is missing)
-	if out, err := podman.Cmd("ps", "-a",
-		"--filter", "name=lerd-php",
-		"--format", "{{.Names}}").Output(); err == nil {
-		for _, name := range bytes.Fields(out) {
-			sub := fpmContainerRe.FindSubmatch(name)
-			if len(sub) != 3 {
-				continue
-			}
-			v := string(sub[1]) + "." + string(sub[2])
-			seen[v] = true
-			// Restore the missing quadlet so systemd can manage the container.
-			if !quadletExists(v) {
-				_ = restoreQuadlet(v)
-			}
+	// Source 2: podman containers (catches installs where the quadlet is missing).
+	// Reads from the daemon's container cache when available; falls back to a
+	// real podman ps in CLI contexts where the cache has not been started.
+	for name := range podman.Cache.Snapshot() {
+		sub := fpmContainerRe.FindStringSubmatch(name)
+		if len(sub) != 3 {
+			continue
+		}
+		v := sub[1] + "." + sub[2]
+		seen[v] = true
+		if !quadletExists(v) {
+			_ = restoreQuadlet(v)
 		}
 	}
 

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
 )
@@ -589,6 +591,27 @@ func listInstalledPHPVersions() ([]string, error) {
 	return versions, nil
 }
 
+// ephemeralPathPrefixes lists filesystem trees that are system-managed and
+// short-lived — there is no reason to bind-mount them into FPM/nginx, and
+// IDEs (PhpStorm, VSCode) drop temp .php files into /tmp with random names
+// that, mounted blindly, cascade FPM restarts every time the IDE invokes
+// `php` on a fresh path.
+var ephemeralPathPrefixes = []string{
+	"/tmp/", "/var/tmp/",
+	"/run/", "/proc/", "/sys/", "/dev/",
+}
+
+// pathMountAttempts memoises recent EnsurePathMounted calls so a runaway
+// caller (IDE running `php` repeatedly with rotating temp paths, broken
+// shell loop) cannot keep rewriting the FPM quadlet and re-triggering
+// RestartUnit at the cadence required to hit systemd's start rate-limit.
+var (
+	pathMountAttemptsMu sync.Mutex
+	pathMountAttempts   = map[string]time.Time{}
+)
+
+const pathMountDebounce = 60 * time.Second
+
 // EnsurePathMounted checks whether the given path is accessible inside the
 // PHP-FPM and nginx containers. If the path is outside $HOME and not already
 // volume-mounted, the quadlets are updated and containers restarted
@@ -605,6 +628,19 @@ func EnsurePathMounted(path, phpVersion string) {
 	if path == home || strings.HasPrefix(path, homePrefix) {
 		return
 	}
+	for _, p := range ephemeralPathPrefixes {
+		if strings.HasPrefix(path, p) {
+			return // ephemeral system dir, never bind-mount
+		}
+	}
+
+	pathMountAttemptsMu.Lock()
+	if last, ok := pathMountAttempts[path]; ok && time.Since(last) < pathMountDebounce {
+		pathMountAttemptsMu.Unlock()
+		return // already attempted recently; refuse to cascade restart again
+	}
+	pathMountAttempts[path] = time.Now()
+	pathMountAttemptsMu.Unlock()
 
 	versions, _ := listInstalledPHPVersions()
 

--- a/internal/podman/cache.go
+++ b/internal/podman/cache.go
@@ -26,6 +26,21 @@ type ContainerCache struct {
 	// pollFn fetches container states; defaults to the real podman ps call.
 	// Swappable in tests.
 	pollFn func() (string, error)
+
+	// onChangeMu guards onChange; readers load it under the read side of mu.
+	onChangeMu sync.Mutex
+	onChange   func()
+}
+
+// SetOnChange installs a callback that fires after a poll detects a change
+// in the running map. Used by the daemon to trigger a snapshot publish on
+// external state changes (container crash, systemctl outside of lerd-ui)
+// without paying for a DBus PropertiesChanged subscription. Pass nil to
+// remove the callback.
+func (c *ContainerCache) SetOnChange(fn func()) {
+	c.onChangeMu.Lock()
+	c.onChange = fn
+	c.onChangeMu.Unlock()
 }
 
 func defaultPollFn() (string, error) {
@@ -67,6 +82,44 @@ func (c *ContainerCache) Running(name string) bool {
 		return running
 	}
 	return v
+}
+
+// Snapshot returns a copy of the cached container map. When the cache has not
+// been started (CLI context), it falls back to a synchronous podman ps so
+// one-off commands still see current state. Used by callers that need to
+// enumerate containers by name pattern without spawning their own subprocess
+// on the daemon's hot path.
+func (c *ContainerCache) Snapshot() map[string]bool {
+	c.mu.RLock()
+	if c.started {
+		out := make(map[string]bool, len(c.running))
+		for k, v := range c.running {
+			out[k] = v
+		}
+		c.mu.RUnlock()
+		return out
+	}
+	c.mu.RUnlock()
+
+	out, err := c.pollFn()
+	fresh := make(map[string]bool)
+	if err != nil {
+		return fresh
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		state := strings.ToLower(strings.TrimSpace(parts[1]))
+		fresh[name] = strings.HasPrefix(state, "running")
+	}
+	return fresh
 }
 
 // Refresh schedules an immediate re-poll on the background goroutine.
@@ -134,6 +187,30 @@ func (c *ContainerCache) poll() {
 	// as not running, which is the correct observed state.
 
 	c.mu.Lock()
+	changed := !runningMapsEqual(c.running, fresh)
 	c.running = fresh
 	c.mu.Unlock()
+
+	if !changed {
+		return
+	}
+	c.onChangeMu.Lock()
+	cb := c.onChange
+	c.onChangeMu.Unlock()
+	if cb != nil {
+		cb()
+	}
+}
+
+// runningMapsEqual compares two name→running maps without allocating.
+func runningMapsEqual(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/podman/cache_test.go
+++ b/internal/podman/cache_test.go
@@ -101,6 +101,48 @@ func TestRunningUsesMapWhenStarted(t *testing.T) {
 	}
 }
 
+func TestSnapshotStartedReturnsCachedMap(t *testing.T) {
+	c := newTestCache(func() (string, error) {
+		return "lerd-nginx\trunning\nlerd-mysql\texited", nil
+	})
+	c.started = true
+	c.poll()
+
+	snap := c.Snapshot()
+	if !snap["lerd-nginx"] {
+		t.Error("expected lerd-nginx running in snapshot")
+	}
+	if snap["lerd-mysql"] {
+		t.Error("expected lerd-mysql not running in snapshot")
+	}
+
+	// Mutating the returned map must not affect the cache.
+	snap["lerd-nginx"] = false
+	if !c.Running("lerd-nginx") {
+		t.Error("snapshot mutation leaked into cache")
+	}
+}
+
+func TestSnapshotUnstartedFallsBackToPodman(t *testing.T) {
+	calls := 0
+	c := newTestCache(func() (string, error) {
+		calls++
+		return "lerd-nginx\trunning\nlerd-redis\texited", nil
+	})
+	// Note: c.started left false to exercise the CLI fallback path.
+
+	snap := c.Snapshot()
+	if calls != 1 {
+		t.Fatalf("expected 1 fallback poll, got %d", calls)
+	}
+	if !snap["lerd-nginx"] {
+		t.Error("expected lerd-nginx in fallback snapshot")
+	}
+	if snap["lerd-redis"] {
+		t.Error("expected lerd-redis not running in fallback snapshot")
+	}
+}
+
 func TestRefreshTriggersImmediatePoll(t *testing.T) {
 	polled := make(chan struct{}, 10)
 	c := newTestCache(func() (string, error) {

--- a/internal/podman/path_mount_test.go
+++ b/internal/podman/path_mount_test.go
@@ -1,0 +1,75 @@
+package podman
+
+import (
+	"testing"
+	"time"
+)
+
+// resetPathMountAttempts clears the debounce cache so tests can drive the
+// guards in isolation.
+func resetPathMountAttempts() {
+	pathMountAttemptsMu.Lock()
+	pathMountAttempts = map[string]time.Time{}
+	pathMountAttemptsMu.Unlock()
+}
+
+func TestEphemeralPathsAreSkipped(t *testing.T) {
+	cases := []string{
+		"/tmp/ide-phpinfo.php",
+		"/var/tmp/foo",
+		"/run/whatever",
+		"/proc/self",
+		"/sys/something",
+		"/dev/null",
+	}
+	for _, p := range cases {
+		matched := false
+		for _, prefix := range ephemeralPathPrefixes {
+			if len(p) >= len(prefix) && p[:len(prefix)] == prefix {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Errorf("%s should be classified as ephemeral", p)
+		}
+	}
+}
+
+func TestPathMountDebounce_BlocksRecentRetries(t *testing.T) {
+	resetPathMountAttempts()
+	t.Cleanup(resetPathMountAttempts)
+
+	const path = "/srv/myapp"
+	// First record: simulate an attempt happening now.
+	pathMountAttemptsMu.Lock()
+	pathMountAttempts[path] = time.Now()
+	pathMountAttemptsMu.Unlock()
+
+	pathMountAttemptsMu.Lock()
+	last, ok := pathMountAttempts[path]
+	pathMountAttemptsMu.Unlock()
+	if !ok || time.Since(last) >= pathMountDebounce {
+		t.Errorf("expected fresh entry to be within debounce window")
+	}
+}
+
+func TestPathMountDebounce_ExpiresAfterWindow(t *testing.T) {
+	resetPathMountAttempts()
+	t.Cleanup(resetPathMountAttempts)
+
+	const path = "/srv/myapp"
+	pathMountAttemptsMu.Lock()
+	pathMountAttempts[path] = time.Now().Add(-2 * pathMountDebounce)
+	pathMountAttemptsMu.Unlock()
+
+	pathMountAttemptsMu.Lock()
+	last, ok := pathMountAttempts[path]
+	pathMountAttemptsMu.Unlock()
+	if !ok {
+		t.Fatal("entry should still be present in the map until next access")
+	}
+	if time.Since(last) < pathMountDebounce {
+		t.Errorf("entry should be older than the debounce window; got age=%v", time.Since(last))
+	}
+}

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -155,13 +158,48 @@ func DaemonReload() error {
 // that don't run the UI don't pay the cost.
 var AfterUnitChange func(name string)
 
+// UnitOpDebug controls whether unit-lifecycle calls log a one-line caller
+// trace. Defaults to on; set LERD_UNIT_OP_DEBUG=0 to disable. Cheap when
+// off — runtime.Caller is only invoked when the flag is set. The log line
+// is one line per unit op, so volume is low in normal operation but jumps
+// out immediately during a "who keeps stopping FPM?" cascade.
+var UnitOpDebug = os.Getenv("LERD_UNIT_OP_DEBUG") != "0"
+
 func notifyUnitChange(name string) {
+	InvalidateUnitStatusCache(name)
 	if AfterUnitChange != nil {
 		AfterUnitChange(name)
 	}
 }
 
+func logUnitOp(action, unit string) {
+	if !UnitOpDebug {
+		return
+	}
+	caller := unitOpCaller()
+	fmt.Fprintf(os.Stderr, "[lerd] unit-op action=%s unit=%s caller=%s\n", action, unit, caller)
+}
+
+// unitOpCaller returns the closest frame outside the podman package — that's
+// the lerd-internal site that asked for the unit op. Falls back to "?" if
+// the stack walk fails.
+func unitOpCaller() string {
+	pc := make([]uintptr, 16)
+	n := runtime.Callers(3, pc)
+	frames := runtime.CallersFrames(pc[:n])
+	for {
+		frame, more := frames.Next()
+		if !strings.Contains(frame.Function, "geodro/lerd/internal/podman") {
+			return fmt.Sprintf("%s (%s:%d)", frame.Function, filepath.Base(frame.File), frame.Line)
+		}
+		if !more {
+			return frame.Function
+		}
+	}
+}
+
 func StartUnit(name string) error {
+	logUnitOp("start", name)
 	if UnitLifecycle != nil {
 		err := UnitLifecycle.Start(name)
 		if err == nil {
@@ -178,6 +216,7 @@ func StartUnit(name string) error {
 
 // StopUnit stops a service unit.
 func StopUnit(name string) error {
+	logUnitOp("stop", name)
 	if UnitLifecycle != nil {
 		err := UnitLifecycle.Stop(name)
 		if err == nil {
@@ -194,6 +233,7 @@ func StopUnit(name string) error {
 
 // RestartUnit restarts a service unit.
 func RestartUnit(name string) error {
+	logUnitOp("restart", name)
 	if UnitLifecycle != nil {
 		err := UnitLifecycle.Restart(name)
 		if err == nil {
@@ -255,14 +295,54 @@ func WaitReady(service string, timeout time.Duration) error {
 	return fmt.Errorf("%s did not become ready within %s", service, timeout)
 }
 
+// unitStatusCache memoises DBusActiveState calls for a short window so
+// dashboard snapshot rebuilds don't issue 100+ DBus round-trips per refresh.
+// 2 seconds is short enough that a unit toggle in lerd-ui (which runs the
+// AfterUnitChange hook anyway) is reflected promptly, while long enough to
+// absorb burst rebuilds during systemd state-change storms.
+const unitStatusCacheTTL = 2 * time.Second
+
+type unitStatusEntry struct {
+	state string
+	at    time.Time
+}
+
+var (
+	unitStatusCacheMu sync.Mutex
+	unitStatusCache   = map[string]unitStatusEntry{}
+)
+
+// InvalidateUnitStatusCache drops the cached DBus state for name. Called from
+// AfterUnitChange so explicit mutations are visible to the next snapshot
+// rebuild without waiting for the TTL.
+func InvalidateUnitStatusCache(name string) {
+	unitStatusCacheMu.Lock()
+	delete(unitStatusCache, name)
+	unitStatusCacheMu.Unlock()
+}
+
 // UnitStatus returns the active state of a service unit.
 func UnitStatus(name string) (string, error) {
 	if UnitLifecycle != nil {
 		return UnitLifecycle.UnitStatus(name)
 	}
+
+	unitStatusCacheMu.Lock()
+	if entry, ok := unitStatusCache[name]; ok && time.Since(entry.at) < unitStatusCacheTTL {
+		state := entry.state
+		unitStatusCacheMu.Unlock()
+		return state, nil
+	}
+	unitStatusCacheMu.Unlock()
+
 	state := systemd.DBusActiveState(name)
 	if state == "" {
-		return "unknown", nil
+		state = "unknown"
 	}
+
+	unitStatusCacheMu.Lock()
+	unitStatusCache[name] = unitStatusEntry{state: state, at: time.Now()}
+	unitStatusCacheMu.Unlock()
+
 	return state, nil
 }

--- a/internal/podman/quadlet_unit_status_test.go
+++ b/internal/podman/quadlet_unit_status_test.go
@@ -1,0 +1,72 @@
+package podman
+
+import (
+	"testing"
+	"time"
+)
+
+func TestUnitStatus_CacheReturnsCachedValueWithinTTL(t *testing.T) {
+	t.Cleanup(func() {
+		InvalidateUnitStatusCache("lerd-test")
+		UnitLifecycle = nil
+	})
+
+	UnitLifecycle = nil
+	InvalidateUnitStatusCache("lerd-test")
+
+	// Seed the cache with a known value, then assert UnitStatus reads it
+	// without falling through to the DBus path.
+	unitStatusCacheMu.Lock()
+	unitStatusCache["lerd-test"] = unitStatusEntry{state: "active", at: time.Now()}
+	unitStatusCacheMu.Unlock()
+
+	for i := 0; i < 5; i++ {
+		got, err := UnitStatus("lerd-test")
+		if err != nil {
+			t.Fatalf("UnitStatus: %v", err)
+		}
+		if got != "active" {
+			t.Errorf("call #%d: got %q, want active (cached value should be returned)", i, got)
+		}
+	}
+}
+
+func TestUnitStatus_StaleEntryIsReplaced(t *testing.T) {
+	t.Cleanup(func() { InvalidateUnitStatusCache("lerd-expire") })
+
+	UnitLifecycle = nil
+	InvalidateUnitStatusCache("lerd-expire")
+
+	unitStatusCacheMu.Lock()
+	unitStatusCache["lerd-expire"] = unitStatusEntry{
+		state: "active", at: time.Now().Add(-2 * unitStatusCacheTTL),
+	}
+	unitStatusCacheMu.Unlock()
+
+	_, _ = UnitStatus("lerd-expire")
+
+	unitStatusCacheMu.Lock()
+	entry := unitStatusCache["lerd-expire"]
+	unitStatusCacheMu.Unlock()
+	if time.Since(entry.at) > unitStatusCacheTTL {
+		t.Error("expected stale entry to be replaced after TTL expiry")
+	}
+}
+
+func TestInvalidateUnitStatusCache_DropsEntry(t *testing.T) {
+	UnitLifecycle = nil
+	t.Cleanup(func() { InvalidateUnitStatusCache("lerd-invalidate") })
+
+	unitStatusCacheMu.Lock()
+	unitStatusCache["lerd-invalidate"] = unitStatusEntry{state: "active", at: time.Now()}
+	unitStatusCacheMu.Unlock()
+
+	InvalidateUnitStatusCache("lerd-invalidate")
+
+	unitStatusCacheMu.Lock()
+	_, exists := unitStatusCache["lerd-invalidate"]
+	unitStatusCacheMu.Unlock()
+	if exists {
+		t.Error("expected entry to be removed after InvalidateUnitStatusCache")
+	}
+}

--- a/internal/podman/quadlets/lerd-php-fpm.container.tmpl
+++ b/internal/podman/quadlets/lerd-php-fpm.container.tmpl
@@ -1,6 +1,14 @@
 [Unit]
 Description=Lerd PHP {{.Version}} FPM
 After=network.target
+# Tolerate transient restart cascades (e.g. EnsurePathMounted called rapidly
+# with rotating paths) without permanently killing FPM and the worker units
+# that BindsTo it. systemd's default 5-restarts-in-10s is way too tight; this
+# allows up to 20 restarts in a 5-minute window, which absorbs realistic
+# cascades but still gives up on a genuinely broken FPM (corrupt image,
+# bad ini) instead of looping forever and burning CPU.
+StartLimitIntervalSec=300
+StartLimitBurst=20
 
 [Container]
 Image=lerd-php{{.VersionShort}}-fpm:local
@@ -15,6 +23,8 @@ Exec=php-fpm -F -R
 
 [Service]
 Restart=always
+# 2-second backoff between restarts so a tight crash loop can't burn CPU.
+RestartSec=2
 
 [Install]
 WantedBy=default.target

--- a/internal/serviceops/rollback_test.go
+++ b/internal/serviceops/rollback_test.go
@@ -129,6 +129,9 @@ func TestCheckUpdateAvailable_CanRollback(t *testing.T) {
 		LastOp:        "migrate",
 	}
 	_ = config.SaveGlobal(cfg)
+	// Mirror what the apply paths do: out-of-band config mutations must drop
+	// the cached result so the next read recomputes against fresh state.
+	invalidateUpdateAvailability("redis")
 
 	avail, err = CheckUpdateAvailable("redis")
 	if err != nil {

--- a/internal/serviceops/update.go
+++ b/internal/serviceops/update.go
@@ -31,7 +31,20 @@ type UpdateAvailability struct {
 // CheckUpdateAvailable queries the registry for a newer tag matching the
 // preset's update_strategy. Network and unsupported-registry errors are
 // swallowed so the UI stays quiet on offline / custom-registry installs.
+// Successful results are cached for updateAvailabilityTTL so snapshot
+// rebuilds don't fork a `podman image inspect` per service per rebuild.
 func CheckUpdateAvailable(name string) (*UpdateAvailability, error) {
+	if cached := cachedUpdateAvailability(name); cached != nil {
+		return cached, nil
+	}
+	out, err := computeUpdateAvailable(name)
+	if err == nil && out != nil {
+		storeUpdateAvailability(name, out)
+	}
+	return out, err
+}
+
+func computeUpdateAvailable(name string) (*UpdateAvailability, error) {
 	svc, strategy, allowMajor, err := resolveServiceForUpdate(name)
 	if err != nil {
 		return nil, err
@@ -265,6 +278,10 @@ func resolveServiceForUpdate(name string) (*config.CustomService, registry.Strat
 // Atomic: if the quadlet write fails the config write is rolled back so the
 // on-disk pair (config + quadlet) stays consistent.
 func persistImageChoice(name, newImage, op string) error {
+	// Drop the cached availability so the next CheckUpdateAvailable reflects
+	// the new image instead of the pre-mutation snapshot.
+	defer invalidateUpdateAvailability(name)
+
 	if config.IsDefaultPreset(name) {
 		cfg, err := config.LoadGlobal()
 		if err != nil {

--- a/internal/serviceops/update_cache.go
+++ b/internal/serviceops/update_cache.go
@@ -1,0 +1,53 @@
+package serviceops
+
+import (
+	"sync"
+	"time"
+)
+
+// updateAvailabilityTTL bounds how long a CheckUpdateAvailable result is
+// reused. Snapshot rebuilds in lerd-ui can fire many times per second during
+// systemd burst transitions; without a cache, each rebuild forks one
+// `podman image inspect` per service. 30 seconds balances freshness against
+// fork pressure. Mutating ops (update, rollback, migrate) call
+// invalidateUpdateAvailability(name) to drop their entry on completion.
+const updateAvailabilityTTL = 30 * time.Second
+
+type updateAvailabilityEntry struct {
+	value *UpdateAvailability
+	at    time.Time
+}
+
+var (
+	updateAvailMu    sync.Mutex
+	updateAvailCache = map[string]updateAvailabilityEntry{}
+)
+
+// cachedUpdateAvailability returns a recent CheckUpdateAvailable result for
+// name, or nil if no fresh entry exists.
+func cachedUpdateAvailability(name string) *UpdateAvailability {
+	updateAvailMu.Lock()
+	defer updateAvailMu.Unlock()
+	entry, ok := updateAvailCache[name]
+	if !ok || time.Since(entry.at) > updateAvailabilityTTL {
+		return nil
+	}
+	return entry.value
+}
+
+func storeUpdateAvailability(name string, v *UpdateAvailability) {
+	if v == nil {
+		return
+	}
+	updateAvailMu.Lock()
+	updateAvailCache[name] = updateAvailabilityEntry{value: v, at: time.Now()}
+	updateAvailMu.Unlock()
+}
+
+// invalidateUpdateAvailability drops the cached entry for name. Called from
+// the apply paths so the next read reflects the new image immediately.
+func invalidateUpdateAvailability(name string) {
+	updateAvailMu.Lock()
+	delete(updateAvailCache, name)
+	updateAvailMu.Unlock()
+}

--- a/internal/serviceops/update_cache_test.go
+++ b/internal/serviceops/update_cache_test.go
@@ -1,0 +1,55 @@
+package serviceops
+
+import (
+	"testing"
+	"time"
+)
+
+func TestUpdateAvailabilityCache_storeAndRetrieve(t *testing.T) {
+	t.Cleanup(func() { invalidateUpdateAvailability("svc") })
+
+	if got := cachedUpdateAvailability("svc"); got != nil {
+		t.Fatalf("expected nil before store, got %+v", got)
+	}
+
+	want := &UpdateAvailability{Service: "svc", LatestTag: "1.2.3"}
+	storeUpdateAvailability("svc", want)
+
+	got := cachedUpdateAvailability("svc")
+	if got == nil || got.LatestTag != "1.2.3" {
+		t.Fatalf("expected cached entry with tag 1.2.3, got %+v", got)
+	}
+}
+
+func TestUpdateAvailabilityCache_invalidate(t *testing.T) {
+	storeUpdateAvailability("svc", &UpdateAvailability{Service: "svc", LatestTag: "9.9"})
+	invalidateUpdateAvailability("svc")
+
+	if got := cachedUpdateAvailability("svc"); got != nil {
+		t.Fatalf("expected nil after invalidate, got %+v", got)
+	}
+}
+
+func TestUpdateAvailabilityCache_expiresAfterTTL(t *testing.T) {
+	t.Cleanup(func() { invalidateUpdateAvailability("svc") })
+
+	updateAvailMu.Lock()
+	updateAvailCache["svc"] = updateAvailabilityEntry{
+		value: &UpdateAvailability{Service: "svc"},
+		at:    time.Now().Add(-2 * updateAvailabilityTTL),
+	}
+	updateAvailMu.Unlock()
+
+	if got := cachedUpdateAvailability("svc"); got != nil {
+		t.Fatalf("expected nil after TTL expiry, got %+v", got)
+	}
+}
+
+func TestUpdateAvailabilityCache_storeNilIsNoop(t *testing.T) {
+	t.Cleanup(func() { invalidateUpdateAvailability("svc") })
+
+	storeUpdateAvailability("svc", nil)
+	if got := cachedUpdateAvailability("svc"); got != nil {
+		t.Fatalf("storing nil should be no-op, got %+v", got)
+	}
+}

--- a/internal/systemd/subscribe_linux.go
+++ b/internal/systemd/subscribe_linux.go
@@ -5,32 +5,62 @@ package systemd
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/coreos/go-systemd/v22/dbus"
 )
 
-// SubscribeLerdUnitStateChanges wires a push-based notification for every
-// systemd unit whose name matches "lerd-*". onChange fires with the bare
-// unit name (no .service suffix) whenever the unit's SubState changes,
-// which covers start, stop, restart, activating, and failed transitions.
-// Cancel ctx to tear down the subscription.
+// UnitStateWatcher manages the DBus SubState subscription. The subscription
+// is expensive at idle: go-systemd's dispatch goroutine receives a
+// PropertiesChanged signal for every property of every active unit and calls
+// GetUnitProperties on each, which on a host with many lerd-* units burns a
+// noticeable chunk of CPU even when nobody is watching the dashboard.
 //
-// The handler goroutine keeps running until ctx is cancelled; callers pass
-// a long-lived context (server lifetime) because state changes need to be
-// delivered continuously. Calling this more than once per process is safe
-// but wasteful: each call starts its own fanout goroutine.
-func SubscribeLerdUnitStateChanges(ctx context.Context, onChange func(unitName string)) error {
-	conn, err := userConn()
+// To pay that cost only when it produces value, the daemon starts the
+// watcher when a UI tab connects and stops it when the last one disconnects.
+// Stop closes a dedicated DBus connection so the underlying signal traffic
+// stops at the systemd side rather than just being dropped on our side.
+type UnitStateWatcher struct {
+	mu       sync.Mutex
+	conn     *dbus.Conn
+	cancel   context.CancelFunc
+	onChange func(unitName string)
+}
+
+// NewUnitStateWatcher returns a watcher that calls onChange on every SubState
+// transition of a lerd-* unit while running. The watcher starts in the
+// stopped state; call Start to begin receiving notifications.
+func NewUnitStateWatcher(onChange func(unitName string)) *UnitStateWatcher {
+	return &UnitStateWatcher{onChange: onChange}
+}
+
+// Start begins receiving SubState notifications. Calling Start while already
+// running is a no-op. Each Start opens its own DBus connection so a paired
+// Stop can close it cleanly.
+func (w *UnitStateWatcher) Start() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.conn != nil {
+		return nil
+	}
+
+	conn, err := dbus.NewUserConnectionContext(context.Background())
 	if err != nil {
 		return err
 	}
 	if err := conn.Subscribe(); err != nil {
+		conn.Close()
 		return err
 	}
 
 	updateCh := make(chan *dbus.SubStateUpdate, 64)
 	errCh := make(chan error, 8)
 	conn.SetSubStateSubscriber(updateCh, errCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	w.conn = conn
+	w.cancel = cancel
 
 	go func() {
 		for {
@@ -45,12 +75,48 @@ func SubscribeLerdUnitStateChanges(ctx context.Context, onChange func(unitName s
 				if !strings.HasPrefix(name, "lerd-") {
 					continue
 				}
-				onChange(name)
+				w.onChange(name)
 			case <-errCh:
-				// Drop subscription errors rather than spamming; the UI
-				// poll fallback keeps state current even if we lose pushes.
+				// Drop subscription errors; the periodic podman cache poll
+				// keeps state current even when pushes are missed.
 			}
 		}
+	}()
+	return nil
+}
+
+// Stop tears down the DBus subscription so go-systemd's dispatch goroutine
+// stops fetching unit properties. Safe to call when already stopped.
+func (w *UnitStateWatcher) Stop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.conn == nil {
+		return
+	}
+	if w.cancel != nil {
+		w.cancel()
+		w.cancel = nil
+	}
+	// Tell systemd to stop emitting unit signals on this connection, then
+	// close the connection so the dispatch goroutine inside go-systemd
+	// returns instead of looping on a now-quiet but still-allocated socket.
+	_ = w.conn.Unsubscribe()
+	w.conn.Close()
+	w.conn = nil
+}
+
+// SubscribeLerdUnitStateChanges keeps the previous one-shot subscription
+// helper for non-UI callers (e.g. tests). New code should prefer the
+// stoppable UnitStateWatcher.
+func SubscribeLerdUnitStateChanges(ctx context.Context, onChange func(unitName string)) error {
+	w := NewUnitStateWatcher(onChange)
+	if err := w.Start(); err != nil {
+		return err
+	}
+	go func() {
+		<-ctx.Done()
+		w.Stop()
 	}()
 	return nil
 }

--- a/internal/systemd/subscribe_stub.go
+++ b/internal/systemd/subscribe_stub.go
@@ -4,9 +4,18 @@ package systemd
 
 import "context"
 
-// SubscribeLerdUnitStateChanges is a no-op on non-Linux platforms: macOS
-// has no equivalent subscription model via launchctl. Callers continue to
-// rely on periodic polling for state updates on that platform.
+// UnitStateWatcher is a no-op stub on non-Linux platforms: macOS has no
+// equivalent subscription model via launchctl. Callers continue to rely on
+// periodic polling for state updates on that platform.
+type UnitStateWatcher struct{}
+
+func NewUnitStateWatcher(_ func(string)) *UnitStateWatcher { return &UnitStateWatcher{} }
+
+func (w *UnitStateWatcher) Start() error { return nil }
+func (w *UnitStateWatcher) Stop()        {}
+
+// SubscribeLerdUnitStateChanges keeps the previous one-shot subscription
+// helper for non-UI callers; on non-Linux it's a no-op.
 func SubscribeLerdUnitStateChanges(_ context.Context, _ func(string)) error {
 	return nil
 }

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -15,10 +15,11 @@ type refreshMsg struct{}
 // back into the tea program.
 type snapshotMsg struct{ snap Snapshot }
 
-// tickCmd schedules the next refreshMsg. Called from Update after each
-// snapshot lands so the model polls at a steady cadence even when no
-// eventbus traffic arrives (cross-process changes show up within the
-// interval).
+// tickCmd schedules the next refreshMsg. The TUI is push-driven via the
+// podman cache OnChange callback (wired in Run) plus the eventbus
+// subscription, so this passive tick is a safety net only — bumping the
+// interval up to 10s avoids waking siteinfo.LoadAll and the snapshot
+// rebuild every 2 seconds when nothing has changed.
 func tickCmd(d time.Duration) tea.Cmd {
 	return tea.Tick(d, func(time.Time) tea.Msg { return refreshMsg{} })
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -121,7 +121,7 @@ func NewModel(version string) *Model {
 func (m *Model) Init() tea.Cmd {
 	return tea.Batch(
 		loadCmd(),
-		tickCmd(2*time.Second),
+		tickCmd(10*time.Second),
 		busCmd(m.sub),
 		updateCheckCmd(m.version),
 	)
@@ -160,7 +160,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case snapshotMsg:
 		m.snap = msg.snap
 		m.clampCursors()
-		return m, tickCmd(2 * time.Second)
+		return m, tickCmd(10 * time.Second)
 
 	case ActionResult:
 		m.setStatus(formatAction(msg), 5*time.Second)
@@ -1000,6 +1000,17 @@ func Run(version string) error {
 	podman.Cache.Start(context.Background())
 	m := NewModel(version)
 	p := tea.NewProgram(m, tea.WithAltScreen())
+
+	// Wire the cache's change callback into the program so an external
+	// state change (CLI mutation in another process, container crash,
+	// systemctl outside lerd) shows up at the next 15s cache poll instead
+	// of waiting up to 2s+15s. Cleared on exit so the package-level Cache
+	// doesn't keep holding a reference to a dead program.
+	podman.Cache.SetOnChange(func() {
+		p.Send(refreshMsg{})
+	})
+	defer podman.Cache.SetOnChange(nil)
+
 	_, err := p.Run()
 	return err
 }

--- a/internal/ui/coalescer.go
+++ b/internal/ui/coalescer.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"sync"
+	"time"
+)
+
+// pollPublisher coalesces a burst of trigger() calls into a single delayed
+// invocation of action. Every trigger restarts the quiet-period timer so the
+// action runs once, ~delay after the last trigger in a burst.
+//
+// A burst of 30 systemd SubState transitions used to spawn 30 concurrent
+// `podman ps` subprocesses; this collapses them to one.
+type pollPublisher struct {
+	mu     sync.Mutex
+	timer  *time.Timer
+	delay  time.Duration
+	action func()
+}
+
+func newPollPublisher(delay time.Duration, action func()) *pollPublisher {
+	return &pollPublisher{delay: delay, action: action}
+}
+
+func (p *pollPublisher) trigger() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.timer == nil {
+		p.timer = time.AfterFunc(p.delay, p.action)
+		return
+	}
+	p.timer.Reset(p.delay)
+}

--- a/internal/ui/coalescer_test.go
+++ b/internal/ui/coalescer_test.go
@@ -1,0 +1,54 @@
+package ui
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPollPublisher_burstCoalescesToOne(t *testing.T) {
+	var calls atomic.Int32
+	p := newPollPublisher(40*time.Millisecond, func() { calls.Add(1) })
+
+	for i := 0; i < 100; i++ {
+		p.trigger()
+	}
+
+	time.Sleep(150 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Errorf("calls = %d, want 1 (a burst should collapse)", got)
+	}
+}
+
+func TestPollPublisher_triggersAfterFireRescheduleSeparately(t *testing.T) {
+	var calls atomic.Int32
+	p := newPollPublisher(20*time.Millisecond, func() { calls.Add(1) })
+
+	p.trigger()
+	time.Sleep(80 * time.Millisecond)
+
+	p.trigger()
+	time.Sleep(80 * time.Millisecond)
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("calls = %d, want 2 (two separated triggers should both fire)", got)
+	}
+}
+
+func TestPollPublisher_triggerWithinWindowExtendsDelay(t *testing.T) {
+	var firedAt atomic.Int64
+	start := time.Now()
+	p := newPollPublisher(50*time.Millisecond, func() {
+		firedAt.Store(time.Since(start).Milliseconds())
+	})
+
+	p.trigger()
+	time.Sleep(30 * time.Millisecond) // within the 50ms window
+	p.trigger()                       // resets timer; fire at ~80ms
+	time.Sleep(150 * time.Millisecond)
+
+	got := firedAt.Load()
+	if got < 70 {
+		t.Errorf("fired at %dms, expected >= 70ms (timer should reset on second trigger)", got)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -100,42 +100,44 @@ func Start(currentVersion string) error {
 	// Restart any LAN share proxies that were active before this process started.
 	go cli.RestoreLANShareProxies()
 
-	podman.AfterUnitChange = func(name string) {
-		// Run the poll and snapshot publish in a goroutine so the HTTP
-		// handler (and the unit start/stop call that triggered this) returns
-		// immediately. PollNow blocks until podman ps completes, ensuring
-		// the snapshot broadcast carries current container states rather than
-		// a stale pre-mutation value — which would cause the UI toggle to
-		// appear to revert.
-		go func() {
+	// Single coalescer for the three event sources that need to refresh the
+	// container cache and broadcast a snapshot: in-process mutations
+	// (AfterUnitChange), DBus push notifications (SubscribeLerdUnitStateChanges),
+	// and CLI/MCP notifications (/api/internal/notify). A burst of state
+	// transitions (e.g. a unit cycling activating→active during start) used to
+	// spawn one podman ps subprocess per transition; the coalescer collapses
+	// them into one poll + one publish per ~250ms quiet period.
+	//
+	// When no UI tab is open we don't fork podman ps — runSnapshotInvalidator
+	// also skips the rebuild for the same reason, and the periodic cache poll
+	// (60s while idle) catches container state on its own. An incoming WS
+	// connection forces a fresh PollNow before sending the initial snapshot.
+	publisher := newPollPublisher(250*time.Millisecond, func() {
+		if visibleClients.Load() > 0 {
 			podman.Cache.PollNow()
-			siteinfo.InvalidateUnitCache()
-			eventbus.Default.Publish(eventbus.KindSites)
-			eventbus.Default.Publish(eventbus.KindServices)
-			eventbus.Default.Publish(eventbus.KindStatus)
-		}()
-	}
+		}
+		siteinfo.InvalidateUnitCache()
+		eventbus.Default.Publish(eventbus.KindSites)
+		eventbus.Default.Publish(eventbus.KindServices)
+		eventbus.Default.Publish(eventbus.KindStatus)
+	})
+
+	podman.AfterUnitChange = func(string) { publisher.trigger() }
+
+	// External state changes (container crash, systemctl outside lerd-ui,
+	// timer firings) are caught by the periodic podman cache poll instead
+	// of a DBus PropertiesChanged subscription. The subscription used to
+	// burn ~50% of one core because go-systemd's dispatch goroutine fetches
+	// unit properties on every signal, and active containers emit a steady
+	// stream of property updates (CPU accounting, exec status, restart
+	// counters). Polling at 15s when a UI tab is focused / 60s otherwise
+	// trades off-up-to-15s latency for an order-of-magnitude CPU saving.
+	podman.Cache.SetOnChange(publisher.trigger)
 
 	// Drop the cache to idle cadence whenever the desktop session is idle
 	// or locked, so a focused tab on an unattended laptop still saves
 	// battery. Recomputes on every transition.
 	startIdleWatcher(context.Background())
-
-	// Event-driven push from systemd covers mutations that didn't go through
-	// lerd-ui's AfterUnitChange path: external systemctl calls, container
-	// crashes, external podman restart, unit timeouts. Mirrors the same
-	// invalidate-and-broadcast flow so the dashboard stays current without
-	// waiting for the 15s cache poll. AfterUnitChange stays as a fast path
-	// for in-process mutations; the DBus push catches everything else.
-	_ = lerdSystemd.SubscribeLerdUnitStateChanges(context.Background(), func(string) {
-		go func() {
-			podman.Cache.PollNow()
-			siteinfo.InvalidateUnitCache()
-			eventbus.Default.Publish(eventbus.KindSites)
-			eventbus.Default.Publish(eventbus.KindServices)
-			eventbus.Default.Publish(eventbus.KindStatus)
-		}()
-	})
 
 	// A single goroutine subscribes to the eventbus and invalidates the
 	// relevant snapshot on every mutation. The /api/ws handler broadcasts
@@ -158,13 +160,7 @@ func Start(currentVersion string) error {
 			http.Error(w, "forbidden", http.StatusForbidden)
 			return
 		}
-		go func() {
-			podman.Cache.PollNow()
-			siteinfo.InvalidateUnitCache()
-			eventbus.Default.Publish(eventbus.KindSites)
-			eventbus.Default.Publish(eventbus.KindServices)
-			eventbus.Default.Publish(eventbus.KindStatus)
-		}()
+		publisher.trigger()
 		w.WriteHeader(http.StatusNoContent)
 	})
 

--- a/internal/ui/snapshot.go
+++ b/internal/ui/snapshot.go
@@ -11,7 +11,23 @@ import (
 // request triggers a rebuild. Mutations that change state call
 // eventbus.Default.Publish, which invalidates the relevant kind so the next
 // read recomputes immediately.
-const snapshotTTL = 15 * time.Second
+//
+// Two cadences: the short one when a real UI tab is open (the dashboard
+// expects near-realtime data), the long one when only the tray is polling.
+// The tray shows slow-changing state (nginx running, dns ok, php list); five
+// minutes of staleness there is fine because explicit mutations invalidate
+// via AfterUnitChange and are reflected on the next tray poll regardless.
+const (
+	snapshotTTLActive = 15 * time.Second
+	snapshotTTLIdle   = 5 * time.Minute
+)
+
+func currentSnapshotTTL() time.Duration {
+	if visibleClients.Load() > 0 {
+		return snapshotTTLActive
+	}
+	return snapshotTTLIdle
+}
 
 // snapshotCache holds cached JSON bytes of the last /api/sites, /api/services,
 // and /api/status responses. Handlers read from here instead of rebuilding
@@ -36,7 +52,7 @@ var snapshots = &snapshotCache{}
 // rather than queuing behind the in-flight build.
 func (c *snapshotCache) Sites() []byte {
 	c.mu.Lock()
-	if c.sites != nil && time.Since(c.sitesAt) < snapshotTTL {
+	if c.sites != nil && time.Since(c.sitesAt) < currentSnapshotTTL() {
 		b := c.sites
 		c.mu.Unlock()
 		return b
@@ -50,7 +66,7 @@ func (c *snapshotCache) Sites() []byte {
 	defer c.sitesBuild.Unlock()
 
 	c.mu.Lock()
-	if c.sites != nil && time.Since(c.sitesAt) < snapshotTTL {
+	if c.sites != nil && time.Since(c.sitesAt) < currentSnapshotTTL() {
 		b := c.sites
 		c.mu.Unlock()
 		return b
@@ -70,7 +86,7 @@ func (c *snapshotCache) Sites() []byte {
 // rather than queuing behind the in-flight build.
 func (c *snapshotCache) Services() []byte {
 	c.mu.Lock()
-	if c.services != nil && time.Since(c.servicesAt) < snapshotTTL {
+	if c.services != nil && time.Since(c.servicesAt) < currentSnapshotTTL() {
 		b := c.services
 		c.mu.Unlock()
 		return b
@@ -84,7 +100,7 @@ func (c *snapshotCache) Services() []byte {
 	defer c.servicesBuild.Unlock()
 
 	c.mu.Lock()
-	if c.services != nil && time.Since(c.servicesAt) < snapshotTTL {
+	if c.services != nil && time.Since(c.servicesAt) < currentSnapshotTTL() {
 		b := c.services
 		c.mu.Unlock()
 		return b
@@ -104,7 +120,7 @@ func (c *snapshotCache) Services() []byte {
 // rather than queuing behind the in-flight build.
 func (c *snapshotCache) Status() []byte {
 	c.mu.Lock()
-	if c.status != nil && time.Since(c.statusAt) < snapshotTTL {
+	if c.status != nil && time.Since(c.statusAt) < currentSnapshotTTL() {
 		b := c.status
 		c.mu.Unlock()
 		return b
@@ -118,7 +134,7 @@ func (c *snapshotCache) Status() []byte {
 	defer c.statusBuild.Unlock()
 
 	c.mu.Lock()
-	if c.status != nil && time.Since(c.statusAt) < snapshotTTL {
+	if c.status != nil && time.Since(c.statusAt) < currentSnapshotTTL() {
 		b := c.status
 		c.mu.Unlock()
 		return b

--- a/internal/ui/snapshot_ttl_test.go
+++ b/internal/ui/snapshot_ttl_test.go
@@ -1,0 +1,51 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCurrentSnapshotTTL_TracksVisibility(t *testing.T) {
+	visibleClients.Store(0)
+	t.Cleanup(func() { visibleClients.Store(0) })
+
+	if got, want := currentSnapshotTTL(), snapshotTTLIdle; got != want {
+		t.Errorf("with no visible clients, TTL = %v, want %v", got, want)
+	}
+
+	visibleClients.Store(1)
+	if got, want := currentSnapshotTTL(), snapshotTTLActive; got != want {
+		t.Errorf("with 1 visible client, TTL = %v, want %v", got, want)
+	}
+
+	visibleClients.Store(0)
+	if got, want := currentSnapshotTTL(), snapshotTTLIdle; got != want {
+		t.Errorf("after returning to no visible, TTL = %v, want %v", got, want)
+	}
+}
+
+func TestSnapshotIdleTTLIsAtLeastFiveMinutes(t *testing.T) {
+	if snapshotTTLIdle < 5*time.Minute {
+		t.Errorf("idle TTL should keep tray polls off the rebuild path; got %v, want >= 5m", snapshotTTLIdle)
+	}
+	if snapshotTTLActive >= snapshotTTLIdle {
+		t.Errorf("active TTL must be shorter than idle TTL; active=%v idle=%v", snapshotTTLActive, snapshotTTLIdle)
+	}
+}
+
+func TestBrokerHasPeers(t *testing.T) {
+	b := &wsBroker{peers: map[chan wsMessage]struct{}{}}
+	if b.hasPeers() {
+		t.Error("empty broker should report no peers")
+	}
+
+	ch := b.add()
+	if !b.hasPeers() {
+		t.Error("broker with one peer should report hasPeers")
+	}
+
+	b.remove(ch)
+	if b.hasPeers() {
+		t.Error("broker after remove should report no peers")
+	}
+}

--- a/internal/ui/web/src/App.svelte
+++ b/internal/ui/web/src/App.svelte
@@ -28,6 +28,10 @@
   import SystemDetail from '$tabs/SystemDetail.svelte';
   import AppsPage from '$tabs/AppsPage.svelte';
 
+  function handlePageHide() {
+    disconnectWs();
+  }
+
   onMount(() => {
     loadVersion();
     loadAccessMode();
@@ -39,9 +43,11 @@
     loadServices();
     connectWs();
     initDashboardRoute();
+    window.addEventListener('pagehide', handlePageHide);
   });
 
   onDestroy(() => {
+    window.removeEventListener('pagehide', handlePageHide);
     disconnectWs();
   });
 

--- a/internal/ui/ws.go
+++ b/internal/ui/ws.go
@@ -22,6 +22,15 @@ const (
 	intervalFocused      = 15 * time.Second
 	intervalIdle         = 60 * time.Second
 	idleWatcherCheckTick = 30 * time.Second
+
+	// wsPingInterval is how often the server probes a connected client with
+	// a ping frame. Browsers reply within milliseconds; if no pong (or any
+	// frame) arrives within wsReadTimeout, the read deadline trips and the
+	// reader goroutine exits, releasing the connection. This is the only
+	// reliable mechanism for cleaning up half-open sockets after a tab
+	// suspend, kernel TCP timeout, or browser-side connection orphan.
+	wsPingInterval = 30 * time.Second
+	wsReadTimeout  = 75 * time.Second
 )
 
 // chooseInterval returns the cache poll cadence implied by the current
@@ -113,13 +122,17 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	// Reader goroutine: handle ping/close/visibility frames.
-	// Visibility frames carry {"type":"visibility","visible":bool} and let
-	// the server tune the container cache polling interval.
+	// Reader goroutine: handle ping/pong/close/visibility frames. The read
+	// deadline is reset before every frame; if the client falls silent
+	// (suspended tab, half-open TCP), ReadFrame returns a timeout error and
+	// the goroutine exits, which triggers the deferred cleanup below.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		for {
+			if err := ws.SetReadDeadline(time.Now().Add(wsReadTimeout)); err != nil {
+				return
+			}
 			op, payload, err := ws.ReadFrame()
 			if err != nil {
 				return
@@ -129,6 +142,8 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 				if err := ws.WritePong(payload); err != nil {
 					return
 				}
+			case wsOpPong:
+				// Client responded to our ping; loop body resets the deadline.
 			case wsOpClose:
 				_ = ws.WriteClose()
 				return
@@ -145,6 +160,9 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
+	pingTicker := time.NewTicker(wsPingInterval)
+	defer pingTicker.Stop()
+
 	for {
 		select {
 		case msg, ok := <-ch:
@@ -153,6 +171,10 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 			}
 			frame := assembleSnapshot(msg.Sites, msg.Services, msg.Status, msg.Kinds)
 			if err := ws.WriteText(frame); err != nil {
+				return
+			}
+		case <-pingTicker.C:
+			if err := ws.WritePing(nil); err != nil {
 				return
 			}
 		case <-done:

--- a/internal/ui/ws_broker.go
+++ b/internal/ui/ws_broker.go
@@ -68,6 +68,15 @@ func (b *wsBroker) remove(ch chan wsMessage) {
 	b.mu.Unlock()
 }
 
+// hasPeers reports whether at least one websocket client is currently
+// subscribed. Used to skip snapshot rebuild work when the broadcast would go
+// to nobody.
+func (b *wsBroker) hasPeers() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.peers) > 0
+}
+
 func (b *wsBroker) broadcast(msg wsMessage) {
 	b.mu.Lock()
 	var drop []chan wsMessage
@@ -86,13 +95,24 @@ func (b *wsBroker) broadcast(msg wsMessage) {
 }
 
 // runSnapshotInvalidator subscribes to the eventbus, invalidates the matching
-// snapshot kinds, and ships the rebuilt bytes to the websocket broker.
+// snapshot kinds, and ships the rebuilt bytes to the websocket broker. When
+// no UI tab is open (visibleClients == 0) the rebuild is skipped — the next
+// HTTP poll from the tray will rebuild lazily, which avoids burning CPU on
+// snapshot work nobody is going to receive over the websocket.
 func runSnapshotInvalidator() {
 	sub := eventbus.Default.Subscribe()
 	for evt := range sub.C {
-		msg := wsMessage{Kinds: evt.Kinds}
+		// Always invalidate so the next read sees fresh data; only rebuild
+		// proactively when at least one websocket client will actually
+		// receive the broadcast.
 		for _, k := range evt.Kinds {
 			snapshots.Invalidate(k)
+		}
+		if !broker.hasPeers() {
+			continue
+		}
+		msg := wsMessage{Kinds: evt.Kinds}
+		for _, k := range evt.Kinds {
 			switch k {
 			case eventbus.KindSites:
 				msg.Sites = snapshots.Sites()

--- a/internal/ui/wsframe.go
+++ b/internal/ui/wsframe.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // Hand-rolled RFC6455 WebSocket helpers. Scope: lerd-ui only ever sends JSON
@@ -80,9 +81,22 @@ func (c *wsConn) WriteText(payload []byte) error {
 	return c.writeFrame(wsOpText, payload)
 }
 
+// WritePing sends a ping frame so the server can probe whether a silent client
+// is still reachable. Browsers reply with a pong, which arrives on the read
+// path and refreshes the read deadline.
+func (c *wsConn) WritePing(payload []byte) error {
+	return c.writeFrame(wsOpPing, payload)
+}
+
 // WritePong sends a pong frame in reply to a ping, echoing the payload.
 func (c *wsConn) WritePong(payload []byte) error {
 	return c.writeFrame(wsOpPong, payload)
+}
+
+// SetReadDeadline forwards to the underlying connection so callers can bound
+// how long ReadFrame blocks waiting for the next frame.
+func (c *wsConn) SetReadDeadline(t time.Time) error {
+	return c.conn.SetReadDeadline(t)
 }
 
 // WriteClose sends a close frame with no payload.


### PR DESCRIPTION
## Summary

The lerd-ui daemon was burning 19-65% CPU at idle on hosts with many sites/services. Multiple unrelated hot paths fed each other; pprof traced the bulk of it to YAML re-parsing in the snapshot rebuild path, the go-systemd DBus dispatcher decoding PropertiesChanged signals from every active container, and per-rebuild forks of `podman ps` / `podman image inspect` per service.

Same investigation surfaced a related bug: a transient FPM restart loop (e.g. an IDE running `php` rapidly with rotating `/tmp/*.php` paths through `EnsurePathMounted`) hit systemd's default 5-restarts-in-10s rate limit and left FPM permanently `failed`, which cascaded to every `BindsTo=lerd-php<v>-fpm.service` worker.

## Idle CPU
- New `pollPublisher` coalesces three event sources into one publish per ~250ms quiet window (`internal/ui/coalescer.go`).
- Snapshot TTL is adaptive: 15s when a UI tab is open, 5min when only the tray is HTTP-polling.
- `runSnapshotInvalidator` skips rebuild when the broker has no peers — invalidation still happens; bytes are rebuilt lazily.
- DBus `SubState` subscription replaced with a `Cache.SetOnChange` hook driven by the existing podman cache poll. External state changes show up within 15-60s instead of <250ms, fine for a dashboard.

## Hot-path caches
- `config.LoadGlobal`, `LoadSites`, `LoadProjectConfig`: mtime+size keyed, deep-copy on read, write paths invalidate.
- `config.LoadPreset`: `sync.Map` (embedded YAML is immutable).
- `config.loadFrameworkYAML`: parsed-Framework cache with mutable-fields clone so merge functions stay safe.
- `podman.Cache.Snapshot()`: copy of the running map; `php/versions.go` no longer forks its own `podman ps` per snapshot.
- `podman.UnitStatus`: 2s TTL cache invalidated by `AfterUnitChange` + the cache OnChange hook.
- `serviceops.CheckUpdateAvailable`: 30s TTL cache invalidated on `persistImageChoice`.

## WebSocket lifecycle
- Server pings clients every 30s and drops connections silent for >75s. Closes the half-open-socket leak that fanned every broadcast 4× instead of 1×.
- Client closes WS on `pagehide` so the server rarely has to wait for the timeout.

## FPM cascade hardening
- `EnsurePathMounted` skips ephemeral system dirs (`/tmp/`, `/var/tmp/`, `/run/`, `/proc/`, `/sys/`, `/dev/`) and per-path 60s debounce. Random temp `.php` files from an IDE can no longer trigger the cascade.
- FPM template: `StartLimitIntervalSec=300`, `StartLimitBurst=20`, `RestartSec=2`. Transient cascade no longer leaves FPM permanently dead; tight crash loops are throttled.
- `UnitOpDebug` (toggle with `LERD_UNIT_OP_DEBUG=0`) logs the in-process caller of every Start/Stop/Restart on a unit, so the next "who keeps stopping FPM?" is one journal grep.

## LAN share
- Skip the proxy bind for paused sites. Stop on pause, restart on unpause, preserve the stable port. (Closes a separate leak where dmc-connect held port 9100 indefinitely.)

## Existing installs
The new FPM `StartLimit*` settings apply automatically on the next `lerd install` (or `lerd php install <v>`) — `WriteFPMQuadlet` diffs against the rendered template.

## Result
Steady-state with no UI tab open: 0.00% CPU, ~0 reads/s, ~0 writes/s. Down from 19-25% sustained.