### PR TITLE
fix(presets): correct gotenberg auth wiring + match preset library style

### DIFF
--- a/internal/config/presets/gotenberg.yaml
+++ b/internal/config/presets/gotenberg.yaml
@@ -1,13 +1,10 @@
 name: gotenberg
 image: docker.io/gotenberg/gotenberg:8
-ports:
-  - 3000:3000
-environment:
-  API_ENABLE_BASIC_AUTH: "true"
-  GOTENBERG_API_BASIC_AUTH_USERNAME: lerd
-  GOTENBERG_API_BASIC_AUTH_PASSWORD: secret
+update_strategy: rolling
 description: "Gotenberg API for PDF generation and document conversion"
+ports:
+  - "3000:3000"
 env_vars:
   - GOTENBERG_URL=http://lerd-gotenberg:3000
-  - GOTENBERG_USERNAME=lerd
-  - GOTENBERG_PASSWORD=secret
+env_detect:
+  composer: spatie/laravel-pdf


### PR DESCRIPTION
## Summary

Follow-up to #268. Three issues with the merged gotenberg preset:

- **Auth wiring was broken.** The preset set `GOTENBERG_API_BASIC_AUTH_USERNAME` / `GOTENBERG_API_BASIC_AUTH_PASSWORD`, but gotenberg v8 reads `API_BASIC_AUTH_USERNAME` / `API_BASIC_AUTH_PASSWORD` (no `GOTENBERG_` prefix). With `API_ENABLE_BASIC_AUTH=true` and the credentials being silently ignored, the container would have started in an auth-required-but-no-credentials state.
- **Default credentials in source.** `lerd / secret` was hardcoded in the preset and exported via `env_vars` into every consumer's `.env`, where it leaks into `.env.example` copies, screenshots, repos. With `lerd lan:expose on` the port is reachable from the LAN with credentials anyone can read out of our source.
- **Style/consistency.** Unquoted port literal (rest of the library quotes), no `update_strategy`, no `env_detect`.

## Changes

- Drop the basic-auth setup entirely. This matches mailpit, mongo-express, mailhog, phpmyadmin — all dev-tool presets that trust the `--network lerd` + 127.0.0.1 binding for isolation. Gotenberg's own docs recommend a reverse proxy for environments where auth is needed; lerd-on-localhost isn't one of those.
- Quote the port (`"3000:3000"`).
- `update_strategy: rolling` so the dashboard surfaces v8.x updates.
- `env_detect: composer: spatie/laravel-pdf` so lerd auto-suggests gotenberg for Laravel projects that pull that package in.