### PR TITLE
fix(worktree): skip APP_URL rewrite when unchanged, don't reinstall deps on cleanup

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -574,14 +574,13 @@ func syncWorktree(sitePath, worktreeName, action string, pruneStale bool) bool {
 	return false
 }
 
-// cleanupWorktreeVhosts removes all subdomain vhosts for the given site's domain,
-// then re-generates for worktrees still on disk. Returns true if any change was made.
+// cleanupWorktreeVhosts removes all subdomain vhosts for the given site's
+// domain, then re-generates for worktrees still on disk. Survivors keep their
+// .env; deps and APP_URL are handled by syncWorktree on add/rename, not here.
 func cleanupWorktreeVhosts(site *config.Site) bool {
 	changed := removeWorktreeVhosts(site)
-	// Re-generate for worktrees still present
 	worktrees, _ := gitpkg.DetectWorktrees(site.Path, site.PrimaryDomain())
 	for _, wt := range worktrees {
-		gitpkg.EnsureWorktreeDeps(site.Path, wt.Path, wt.Domain, site.Secured)
 		var vhostErr error
 		if site.Secured {
 			vhostErr = nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, site.PHPVersion, site.PrimaryDomain())

--- a/cmd/lerd/main_test.go
+++ b/cmd/lerd/main_test.go
@@ -97,3 +97,47 @@ func TestRemoveStale_skipsIgnoredSites(t *testing.T) {
 		t.Errorf("ignored site should be preserved, got %d sites", len(after.Sites))
 	}
 }
+
+// cleanupWorktreeVhosts runs after a worktree is removed and re-generates
+// vhosts for surviving worktrees. It must NOT touch the surviving worktree's
+// .env or kick off EnsureWorktreeDeps (which would trigger composer install
+// and the JS install on every survivor on every removal).
+func TestCleanupWorktreeVhosts_doesNotTouchSurvivorEnv(t *testing.T) {
+	isolateConfig(t)
+
+	mainSite := filepath.Join(t.TempDir(), "myapp")
+	survivor := filepath.Join(t.TempDir(), "myapp-feat")
+	for _, d := range []string{
+		filepath.Join(mainSite, ".git", "worktrees", "feat"),
+		survivor,
+	} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(mainSite, ".env"), []byte("APP_URL=http://myapp.test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wtMeta := filepath.Join(mainSite, ".git", "worktrees", "feat")
+	if err := os.WriteFile(filepath.Join(wtMeta, "HEAD"), []byte("ref: refs/heads/feat\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtMeta, "gitdir"), []byte(filepath.Join(survivor, ".git")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	site := &config.Site{
+		Name:       "myapp",
+		Domains:    []string{"myapp.test"},
+		Path:       mainSite,
+		PHPVersion: "8.3",
+	}
+
+	cleanupWorktreeVhosts(site)
+
+	if _, err := os.Stat(filepath.Join(survivor, ".env")); err == nil {
+		t.Fatal("cleanupWorktreeVhosts copied .env into survivor — EnsureWorktreeDeps must not run from cleanup path")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected stat error on survivor .env: %v", err)
+	}
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,8 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Migration safety guards**. Rolling-tag updates suppressed when local manifest digest matches remote (no phantom badges on `:latest`). Cross-major upgrades hidden from the Upgrade button by default; opt-in via per-preset `allow_major_upgrade`. Cross-strategy upgrade button suppressed for `update_strategy: patch` presets without a registered SQL migrator (Meilisearch — clicking would brick the data dir). Alternates installed via preset (e.g. `mysql-8-0`) internally promote to `patch` strategy so they don't get auto-suggested cross-LTS jumps.
 - **`internal/registry` package**. `ListTags`, `MaybeNewerTag`, `NewestStable` against Docker Hub and GHCR with a 6-hour disk cache. Typed `*UnreachableErr` and `*UnsupportedRegistryErr` are swallowed by the high-level helpers so offline / unsupported-registry installs stay quiet rather than spamming errors.
 - **`/api/services/<name>/{updates,update,rollback,migrate}`**. Read JSON + streaming NDJSON endpoints mirroring the existing preset-install streaming flow.
+- **Worktree branch renames are picked up automatically** (#264). The watcher now monitors each `.git/worktrees/<name>/HEAD` for writes, so a `git branch -m` or a `git checkout -b` inside a worktree re-syncs the nginx vhost and `.env` `APP_URL` to the renamed branch without a manual restart. Stale subdomain vhosts are removed surgically (only the now stale one), not by nuking and regenerating every vhost on the site. Thanks to @ropi-bc for the contribution.
+- **`APP_URL` realigns to the worktree domain on every scan** (#263). Previously `EnsureWorktreeDeps` only rewrote `APP_URL` when it first created the `.env`; renames and external workflows that relied on a manual `git branch -m` left it pointing at the stale subdomain. The worktree scan now updates `APP_URL` on existing `.env` files too, completing the rename flow added in #264. Thanks to @ropi-bc for the contribution.
 
 ### Changed
 
@@ -53,6 +55,8 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Registry: response body capped at 5 MB and tag list at 5000 entries** so a malicious or misconfigured registry can't OOM the process.
 - **Digest comparisons normalised** (lowercase + trim) in the `alreadyOnDigest` helper so registries returning differently-cased digests don't cause a permanent "update available" badge.
 - New tests: `TestRollback_RefusesAfterMigrate`, `TestCheckUpdateAvailable_CanRollback`, `TestEnforceMajorUpgradeGate`, `TestLeadingMajor`, plus registry tests for 404, 429, 5xx, pagination, and concurrent-singleflight de-duplication.
+- **`cleanupWorktreeVhosts` no longer triggers `composer install` and the JS install on every surviving worktree.** When one worktree was removed, the cleanup pass that re-generated vhosts for the survivors also called `EnsureWorktreeDeps` on each one, which kicked off a full `composer install` plus the JS package-manager install. The rename and add paths handle deps via `syncWorktree`; doing it from cleanup burned cycles for no benefit. Survivors keep their existing `.env` and the cleanup pass only touches nginx config now.
+- **`.env` `APP_URL` rewrite is skipped when the value is already correct.** `rewriteAppURL` now compares the new bytes against the file before writing, so a no-op worktree scan no longer bumps `.env`'s mtime. Dev-side watchers (vite, IDE indexers, opcache `file_update_protection`) used to react to every scan even when the URL hadn't changed.
 
 ---
 

--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -26,6 +26,8 @@ When the Lerd watcher daemon is running it watches each registered site's `.git/
 
 When `git worktree remove` is run the vhost is removed and nginx is reloaded.
 
+Renaming the branch inside a worktree (`git branch -m`, `git checkout -b`) is also picked up: Lerd watches each worktree's `HEAD` and re-syncs the vhost and `.env` to the new branch name without a manual restart.
+
 Existing worktrees are also picked up on watcher startup, so nothing is lost after a reboot.
 
 ---
@@ -38,7 +40,7 @@ When a worktree vhost is first created, Lerd sets up three things in the checkou
 |---|---|
 | `vendor/` | Copied from the main repo using reflinks where the filesystem supports them (btrfs, xfs-reflink, APFS), then reconciled against the worktree's own `composer.lock` via `composer install` |
 | `node_modules/` | Copied from the main repo (reflink where supported), then reconciled against the worktree's own lockfile via the matching package manager (pnpm / yarn / bun / npm, auto-detected from `pnpm-lock.yaml`, `yarn.lock`, `bun.lock*`, or `package-lock.json`) |
-| `.env` | Copied from the main repo with `APP_URL` rewritten to `http://<branch>.<site>.test` |
+| `.env` | Copied from the main repo with `APP_URL` rewritten to `http://<branch>.<site>.test`. On every subsequent worktree scan `APP_URL` is realigned with the current vhost domain, so a `git branch -m` or a manual rename keeps the `.env` in sync. The write is skipped when the value is already correct, so dev-side watchers don't see spurious mtime bumps. |
 
 If `vendor/` or `node_modules/` already exist as real directories they are left untouched. Legacy symlinks left by earlier lerd versions are replaced with real copies.
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -183,7 +184,9 @@ func copyFile(src, dst string) error {
 	return err
 }
 
-// rewriteAppURL replaces APP_URL in the given .env file.
+// rewriteAppURL replaces APP_URL in the given .env file. The write is skipped
+// when the new contents match the existing file so dev-side watchers (vite,
+// IDE indexers, opcache) don't see mtime churn on no-op scans.
 func rewriteAppURL(envPath, appURL string) error {
 	data, err := os.ReadFile(envPath)
 	if err != nil {
@@ -201,7 +204,11 @@ func rewriteAppURL(envPath, appURL string) error {
 	if !found {
 		lines = append(lines, "APP_URL="+appURL)
 	}
-	return os.WriteFile(envPath, []byte(strings.Join(lines, "\n")), 0644)
+	out := []byte(strings.Join(lines, "\n"))
+	if bytes.Equal(out, data) {
+		return nil
+	}
+	return os.WriteFile(envPath, out, 0644)
 }
 
 var nonSlugChars = regexp.MustCompile(`[^a-z0-9-]`)

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // ── SanitizeBranch ───────────────────────────────────────────────────────────
@@ -350,6 +351,74 @@ func TestEnsureWorktreeDeps_updatesExistingEnvAppURL(t *testing.T) {
 	}
 	if strings.Contains(content, "http://stale.test") {
 		t.Fatalf("stale APP_URL should have been replaced, got:\n%s", content)
+	}
+}
+
+// EnsureWorktreeDeps must not downgrade the .env file mode when rewriting
+// APP_URL. .env holds APP_KEY and DB credentials and users routinely chmod it
+// to 0600.
+func TestEnsureWorktreeDeps_preservesEnvMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local/share"))
+
+	main := filepath.Join(home, "main")
+	wt := filepath.Join(home, "wt")
+	for _, d := range []string{main, wt} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	envPath := filepath.Join(wt, ".env")
+	if err := os.WriteFile(envPath, []byte("APP_URL=http://stale.test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureWorktreeDeps(main, wt, "branch.main.test", true)
+
+	info, err := os.Stat(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("env mode = %o, want 0600", got)
+	}
+}
+
+// EnsureWorktreeDeps must not bump .env mtime when APP_URL already matches
+// the worktree domain. Dev-side watchers (vite, IDE indexers, opcache) react
+// to mtime changes, so a no-op scan should be a no-op on disk.
+func TestEnsureWorktreeDeps_skipsWriteWhenAppURLUnchanged(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local/share"))
+
+	main := filepath.Join(home, "main")
+	wt := filepath.Join(home, "wt")
+	for _, d := range []string{main, wt} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	envPath := filepath.Join(wt, ".env")
+	if err := os.WriteFile(envPath, []byte("APP_NAME=Worktree\nAPP_URL=https://branch.main.test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(envPath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureWorktreeDeps(main, wt, "branch.main.test", true)
+
+	info, err := os.Stat(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().Equal(old) {
+		t.Fatalf("env mtime bumped from %v to %v on a no-op rewrite", old, info.ModTime())
 	}
 }
 


### PR DESCRIPTION
Follow-up to #263 and #264, addressing two of the three points from the #263 review that landed unaddressed when the contributor's PRs were merged as-is.

## What

- `rewriteAppURL` short-circuits when the new bytes match the existing `.env`. Without this, every worktree scan rewrites the file and bumps mtime, which trips vite, IDE indexers, opcache `file_update_protection`, and similar dev-side watchers.
- `cleanupWorktreeVhosts` no longer calls `EnsureWorktreeDeps` on surviving worktrees when one is removed. `EnsureWorktreeDeps` runs `composer install` plus the JS install via `InstallDependencies`, so removing a worktree on a site with several survivors kicked off a full deps install for each one. The rename and add paths handle deps via `syncWorktree`; cleanup never needed it.

## What I dropped

The mode-preservation point in the #263 review turned out to be a misread of `os.WriteFile`. It only applies its `perm` arg when the file is created via `O_CREATE`; on an existing file it just truncates and writes, preserving the inode and the mode. A 0600 `.env` already survives the rewrite. I added `TestEnsureWorktreeDeps_preservesEnvMode` as a regression guard but no implementation change.

## Docs and changelog

- `docs/features/git-worktrees.md` documents the rename auto-pickup (from #264) and the APP_URL realignment + skip-when-unchanged behavior.
- CHANGELOG entries for #263 and #264 with credit to @ropi-bc, plus these two fixes.