### PR TITLE
release: v1.19.0-beta.1: Svelte 5 dashboard, YAML services + update/migrate/rollback, worktree rename auto-pickup

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,10 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.19.0-beta.1] — 2026-04-29
+
 ### Added
 
 - **Default services as YAML presets**. The 6 built-in services (mysql, postgres, redis, meilisearch, rustfs, mailpit) moved out of hardcoded Go lists/maps/embedded `.container` templates into `internal/config/presets/*.yaml` files marked `default: true`. Adding or replacing a default service is now a YAML edit. The same code path serves default and add-on presets — one quadlet writer, one env-var resolver, one dependency engine. Six duplicated service-name lists collapsed into `config.DefaultPresetNames()`; three duplicated env-var maps collapsed into `config.DefaultPresetEnvVars(name)`.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.18.1"
+	Version = "1.19.0-beta.1"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
First beta of the 1.19 cycle. 12 PRs since v1.18.0 (#255, #260, #263 through #273), grouped under [1.19.0-beta.1] in the changelog. The 1.18.1 hotfix (#272) is already its own tagged release.

## Highlights

- **#260 Svelte 5 dashboard rewrite.** The web UI has been rebuilt from scratch in Svelte 5 + TypeScript + Tailwind, replacing the 4,800-line Alpine.js monolith. Every feature preserved (Sites/Services/System tabs, worktree list, domain-management modal, link-site modal, preset install modal with NDJSON phase progress, LAN exposure flow, remote dashboard access, mobile bottom nav with dedicated Apps page, offline PWA). Bundle is embedded into the Go binary.
- **#265 YAML-driven default services.** The 6 built-in services (mysql, postgres, redis, meilisearch, rustfs, mailpit) moved from hardcoded Go lists/maps/embedded `.container` templates into `internal/config/presets/*.yaml`. Same code path for default and add-on presets: one quadlet writer, one env-var resolver, one dependency engine.
- **#265, #267 Service update / migrate / rollback flow.** Per-preset `update_strategy` (`patch` / `minor` / `rolling` / `none`), `track_latest`, `allow_major_upgrade`. New `internal/registry` package against Docker Hub and GHCR with a 6-hour disk cache. Concurrent ops serialised per service, atomic config writes paired with quadlet regeneration, dump credentials no longer leak through argv, 30-minute timeouts on every in-container migrate exec.
- **#263, #264, #273 Worktree rename auto-pickup.** HEAD watcher fires on `git branch -m` (and similar) inside a worktree; vhost and `.env` `APP_URL` are re-synced surgically. Cleanup pass no longer kicks off composer install on every survivor; rewrite skipped when contents unchanged. Thanks to @ropi-bc for the contribution.
- **#268, #271 Gotenberg PDF preset** with corrected basic-auth wiring.
- **#270 Daemon idle CPU** cut to ~0%, FPM hardened against restart cascades.
- **#255 go-systemd integration**, idle-aware watcher (drops to 60 s when session is idle or locked), `sd_notify` readiness for systemd `Type=notify`.
- **#266 `lerd bug-report`** CLI for GitHub issue triage.

## Breaking changes

- MCP tool manifest: none new this cycle. The 1.18.0 manifest slim (#232) remains.
- `service_remove` and `service_update` standalone MCP tools were folded into `service_control` action enum (part of #265's expanded action surface).

## Migration notes

- MySQL canonical image is now 8.4 LTS (was 8.0). Existing users on saved 8.0 are untouched (viper merge wins; `migrateStaleServiceImages` skipped for `track_latest` presets); fresh installs land on 8.4.x.
- The `internal/podman/quadlets/lerd-{mysql,redis,postgres,meilisearch,rustfs,mailpit}.container` templates were deleted; quadlets are now generated from preset YAML on demand.
- Refer to the [1.19.0-beta.1] changelog entry for the full list of changes including the migration safety guards and registry hardening.