### PR TITLE
ci(release): build Svelte UI before Go build in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,15 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: internal/ui/web/package-lock.json
+
+      - name: Build UI
+        run: make build-ui
+
       - name: Install tray build dependencies
         run: |
           sudo apt-get update
@@ -89,6 +98,15 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: internal/ui/web/package-lock.json
+
+      - name: Build UI
+        run: make build-ui
 
       - name: Install tray build dependencies
         run: |


### PR DESCRIPTION
## Summary

The `Release` workflow on tag `v1.19.0-beta.1` failed at the `CI Checks → Build` step with:

```
internal/ui/svelte.go:10:12: pattern all:web/dist: no matching files found
```

`release.yml` was never updated when the Svelte 5 dashboard introduced the `//go:embed all:web/dist` directive in `internal/ui/svelte.go`. `ci.yml` got the Node setup + `make build-ui` step, but the release workflow still went straight from `go mod download` to `go build ./cmd/lerd`, so the embed had nothing to match.

This PR adds `actions/setup-node@v4` + `make build-ui` to both jobs that build the main `lerd` binary:
- `ci` (the CI Checks gate that runs before GoReleaser)
- `release` (where GoReleaser actually compiles the cross-platform archives)

The `build-darwin-tray` job is unchanged because `./cmd/lerd-tray` does not import `internal/ui` and so does not trigger the embed.

After this lands the `v1.19.0-beta.1` tag will need to be deleted and re-pushed (or rolled forward to `v1.19.0-beta.2`) so the tag-triggered Release workflow re-runs against a commit that has the fix.