### PR TITLE
build: use `npm ci` for UI deps so release tree stays clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ LDFLAGS    = -s -w \
 
 install-ui-deps:
 	@if [ ! -d "$(UI_DIR)/node_modules" ]; then \
-		cd $(UI_DIR) && npm install; \
+		cd $(UI_DIR) && npm ci; \
 	fi
 
 build-ui: install-ui-deps


### PR DESCRIPTION
## Summary

The retagged `v1.19.0-beta.1` release run got past the embed problem from #275 but failed in the GoReleaser step:

```
⨯ release failed after 0s
  error=
  │ git is in a dirty state
  │ Please check in your pipeline what can be changing the following files:
  │  M internal/ui/web/package-lock.json
```

`make build-ui`'s `install-ui-deps` target uses `npm install`, which on a fresh CI checkout silently rewrites `internal/ui/web/package-lock.json` (likely fixing up minor lockfile churn). The CI Checks job didn't care, but GoReleaser refuses to release from a dirty working tree.

This switches the `install-ui-deps` target to `npm ci`. `npm ci` is the CI-correct primitive: it respects the lockfile and aborts on mismatch instead of mutating. Verified locally that `npm ci` against the current lockfile produces zero diff. The Makefile target only fires when `node_modules` is missing, so day-to-day dev workflow is unchanged.