### PR TITLE
feat(workers): cross-surface self-heal for failed worker units

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -120,6 +120,7 @@ export default defineConfig({
             { text: 'Framework Definitions', link: '/usage/framework-definitions' },
             { text: 'Queue Workers', link: '/usage/queue-workers' },
             { text: 'Worker Runtime (macOS)', link: '/usage/worker-runtime' },
+            { text: 'Healing Failed Workers', link: '/usage/worker-heal' },
             { text: 'Browser Testing', link: '/usage/browser-testing' },
           ],
         },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,14 +13,13 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Security
+### Added
 
-- **Bumped npm dev dependencies to clear five medium-severity Dependabot advisories**. `internal/ui/web` upgraded vite 5 to 7.1, `@sveltejs/vite-plugin-svelte` 4 to 6.2, and vitest 2 to 3.2, which resolves vite to 7.3.2 (path traversal in `.map` handling) and esbuild to 0.27.7 (dev-server SOP). `docs/package.json` keeps vitepress at 1.6.4 and uses npm `overrides` to pull vite ^6.4.2, esbuild ^0.25.0, and postcss ^8.5.10 (XSS in CSS stringify) into vitepress's transitive tree. Both manifests now report zero vulnerabilities under `npm audit`.
+- **Worker self-heal across CLI, dashboard, TUI, and MCP**. New `lerd worker heal [name]` command resets the failed state and restarts every worker unit systemd lists as `failed` (or one named unit, if given). Same recovery is reachable from an amber sticky banner in the dashboard, the `H` keybind in the TUI, and the `workers_heal` / `workers_health` MCP tools. `lerd status` surfaces a one-line hint when any worker is in failed state. Heal is intentionally narrow: it never writes `.lerd.yaml` or rewrites the unit file, since a failed worker is a runtime condition, not a change of user intent. The dashboard banner is push-driven over WebSocket: a 5-second cached-detector watcher publishes only when the unhealthy set changes, and rides the existing `KindSites` snapshot pipeline so there is no extra HTTP round-trip and no extra subprocess. See [healing failed workers](usage/worker-heal.md) for the full surface map.
 
 ### Fixed
 
-- **`lerd install` and other unit-lifecycle calls no longer leak `[lerd] unit-op` debug lines into normal stdout**. The `UnitOpDebug` flag introduced for the FPM-restart-cascade investigation defaulted to on and only switched off when `LERD_UNIT_OP_DEBUG=0` was set; for everyone else, every `StartUnit` / `StopUnit` / `RestartUnit` interleaved a one-line caller trace with the curated installer output. The default is now off; opt back in with `LERD_UNIT_OP_DEBUG=1` when chasing a cascade.
-- **Svelte 5 dashboard mounted blank after the vite 7 / vite-plugin-svelte 6 upgrade**. Svelte 5's package `exports` route to the client runtime only under the `browser` condition and otherwise fall through to the *server* entry. Vite 7 + vite-plugin-svelte 6 don't carry `browser` implicitly the way their predecessors did, so the production bundle silently swapped to Svelte's server `mount` shim and threw `lifecycle_function_unavailable` at runtime. `vite.config.ts` now sets `resolve.conditions: ['browser']` for every build, not just test.
+- **`go test ./...` no longer rewrites the user's PHP-FPM quadlets and daemon-reloads systemd, which used to cascade workers into start-limit-hit**. `internal/php/versions.go::ListInstalled()` had a self-heal step that, when called from a test with `XDG_CONFIG_HOME` redirected to a temp dir, looked at the user's real running FPM containers, decided their quadlets were "missing", and wrote fresh quadlets plus ran `systemd --user daemon-reload` against the real session. Each reload triggered a systemd quadlet-generator pass which restarted the FPM unit; with workers `BindsTo=lerd-php8X-fpm`, that cascade rapidly tripped `StartLimitBurst` and parked every worker in `failed`. `ListInstalled()` is now read-only; production code paths that previously relied on the implicit heal already call `ensureFPMQuadlet()` explicitly.
 
 ---
 

--- a/docs/usage/worker-heal.md
+++ b/docs/usage/worker-heal.md
@@ -1,0 +1,54 @@
+# Healing failed workers
+
+Framework workers (queue, schedule, horizon, reverb, custom) run as systemd user units on Linux and as launchd jobs wrapping `podman exec` on macOS. Both supervisors restart a worker that crashes, but both also stop trying after enough rapid failures and mark the unit `failed`. Once a unit is in `failed` state, neither systemd nor launchd will lift it out without an explicit reset.
+
+`lerd worker heal` is the recovery primitive: it reset-clears the failed state and starts the unit again, on every surface (CLI, dashboard, TUI, MCP).
+
+## When workers go to `failed`
+
+Two common paths:
+
+1. **Restart-rate-limit cascade.** If something stops the unit's parent FPM container repeatedly (a quadlet rewrite cascade, a podman-machine bridge wedge on macOS, an external process), the worker's `BindsTo=` directive stops it as collateral. systemd then tries to restart it, hits `StartLimitBurst`, and parks the unit in `failed`.
+2. **Application crash loop.** A worker that throws on startup (missing env var, bad migration, dependency removed) exits faster than `RestartSec=`, exhausts the burst budget, and lands in `failed` with the same message.
+
+The second case requires fixing the underlying error before heal will stick. Heal will start the unit, but if it crashes again it'll burn through the rate limit and re-enter `failed`. The dashboard banner will reappear; check the worker logs (`lerd worker logs <name>` or the dashboard logs pane) for the real cause.
+
+## CLI
+
+```sh
+lerd worker heal
+```
+
+Scans every registered, non-paused site and resets-and-starts every worker unit currently in `failed`. Prints one line per unit.
+
+```sh
+lerd worker heal queue
+```
+
+Heals one worker for the site at the current working directory. Equivalent to `systemctl --user reset-failed lerd-queue-<site> && systemctl --user start lerd-queue-<site>` but runs through the same code path the dashboard and MCP use.
+
+## Dashboard
+
+When the detector finds any failed worker, an amber banner appears at the top of the Sites tab listing the affected workers. Clicking **Heal** runs the same reset-and-start sequence and streams per-unit progress (`Starting lerd-queue-myapp…`) until done. The banner disappears when the count returns to zero.
+
+The banner refresh is event-driven: the dashboard reloads health on every `sites` WebSocket push (debounced 500ms), so heal results show up without polling.
+
+## TUI
+
+Press `H` from any pane to heal every failed worker on the box. The status line tracks progress; the snapshot reloads automatically once heal returns. Failing workers also show as red glyphs (`q`, `s`, `v`, `h`, `•`) in the site list — the same surface the dashboard banner reflects.
+
+## MCP
+
+Two tools:
+
+- **`workers_health`** — read-only. Returns the JSON list of unhealthy workers (site, worker name, full unit name, state). Call before deciding whether to heal.
+- **`workers_heal`** — heals every failed worker, or one named unit if `unit` is passed. Returns `{summary, healed, failed}` so the agent can report what was fixed without re-querying.
+
+## What heal will not do
+
+Heal is intentionally narrow. It is a runtime recovery, not an enable/disable knob:
+
+- **It does not write `.lerd.yaml`.** A failed worker is a transient runtime condition, not a change of user intent. Adding or removing workers from a site's enabled list still belongs to `lerd worker add` / `lerd worker remove` (or the equivalent dashboard / TUI / MCP actions).
+- **It does not rewrite the unit file.** If the unit drifted (e.g. you renamed the site directory and the `WorkingDirectory=` is stale), heal won't fix it. Run `lerd install` to regenerate the unit file from the framework definition first.
+- **It does not touch paused sites.** A worker that's failed because its site is paused stays as it is.
+- **It does not loop.** Heal makes one attempt per unit. If the underlying cause is still present, the unit will go back to `failed` shortly after; the banner is the signal to look at logs, not a button to mash.

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -192,6 +192,7 @@ func runStatus(_ *cobra.Command, _ []string) error {
 		workerReg, wErr := config.LoadSites()
 		if wErr == nil {
 			hasWorkers := false
+			failedCount := 0
 			for _, s := range workerReg.Sites {
 				if s.Ignored || s.Paused {
 					continue
@@ -210,6 +211,7 @@ func runStatus(_ *cobra.Command, _ []string) error {
 					case "failed":
 						fail2(s.Name+"/"+w, "failed", unitLogHint(unit))
 						hasWorkers = true
+						failedCount++
 					}
 				}
 				// Check custom framework workers.
@@ -235,6 +237,7 @@ func runStatus(_ *cobra.Command, _ []string) error {
 						case "failed":
 							fail2(s.Name+"/"+wName, "failed", unitLogHint(unit))
 							hasWorkers = true
+							failedCount++
 						}
 					}
 				}
@@ -248,12 +251,20 @@ func runStatus(_ *cobra.Command, _ []string) error {
 						warn2(label, "restarting")
 					} else {
 						fail2(label, "failed", unitLogHint("lerd-stripe-"+s.Name))
+						failedCount++
 					}
 					hasWorkers = true
 				}
 			}
 			if !hasWorkers {
 				fmt.Println("  No workers running.")
+			}
+			// One consolidated heal hint per status run. Per-line hints
+			// already point at journalctl for the underlying cause; this
+			// surfaces the recovery primitive once instead of N times.
+			if failedCount > 0 {
+				fmt.Printf("\n  %d failed worker(s). Reset and restart with: %slerd worker heal%s\n",
+					failedCount, colorYellow, colorReset)
 			}
 		}
 	}

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -27,6 +27,7 @@ func NewWorkerCmd() *cobra.Command {
 	cmd.AddCommand(newWorkerListCmd())
 	cmd.AddCommand(newWorkerAddCmd())
 	cmd.AddCommand(newWorkerRemoveCmd())
+	cmd.AddCommand(newWorkerHealCmd())
 	return cmd
 }
 

--- a/internal/cli/worker_heal_cmd.go
+++ b/internal/cli/worker_heal_cmd.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// newWorkerHealCmd returns the `lerd worker heal [name]` command. Heal is a
+// runtime recovery operation: it never writes to .lerd.yaml or rewrites the
+// worker's unit file. With no argument, it scans every registered site and
+// heals any worker whose unit is in the systemd "failed" state. With a
+// worker name, it heals that worker for the site at the current working
+// directory.
+func newWorkerHealCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "heal [name]",
+		Short: "Reset failed worker units and start them again",
+		Long: `Heal worker units stuck in systemd's "failed" state.
+
+Workers that crash and exhaust their Restart= rate limit land in "failed"
+and stay there until something resets them. This command finds those
+units (across every registered site by default, or the named worker for
+the current site if an argument is given) and runs the equivalent of
+` + "`systemctl --user reset-failed UNIT && systemctl --user start UNIT`" + `
+for each one.
+
+Heal is intentionally surgical:
+  - It does NOT rewrite the unit file from .lerd.yaml.
+  - It does NOT change the workers list in .lerd.yaml.
+  - It does NOT touch sites the user has paused.
+
+Worker enable/disable belongs to 'lerd worker start/stop/add/remove'.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				return runHealOne(args[0])
+			}
+			return runHealAll()
+		},
+	}
+}
+
+func runHealAll() error {
+	report, err := HealWorkers(func(evt HealEvent) {
+		switch evt.Phase {
+		case "starting":
+			fmt.Printf("  ➜  %s ", evt.Unit)
+		case "healed":
+			fmt.Println("OK")
+		case "failed":
+			if evt.Unit != "" {
+				fmt.Printf("FAIL (%s)\n", evt.Error)
+			}
+		}
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Println(HealSummary(report))
+	return nil
+}
+
+func runHealOne(workerName string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	site, err := config.FindSiteByPath(cwd)
+	if err != nil {
+		return fmt.Errorf("not a registered site — run 'lerd link' first")
+	}
+	unit := "lerd-" + workerName + "-" + site.Name
+	fmt.Printf("  ➜  %s ", unit)
+	if err := HealUnit(unit); err != nil {
+		fmt.Printf("FAIL (%v)\n", err)
+		return err
+	}
+	fmt.Println("OK")
+	return nil
+}

--- a/internal/cli/worker_health.go
+++ b/internal/cli/worker_health.go
@@ -1,0 +1,29 @@
+package cli
+
+import "github.com/geodro/lerd/internal/workerheal"
+
+// Re-exports of internal/workerheal so existing CLI / UI server callers
+// can keep importing from internal/cli. The MCP package can't import cli
+// (cli imports mcp for `lerd mcp:serve`), which is why the implementation
+// itself lives in internal/workerheal.
+
+type (
+	UnhealthyWorker = workerheal.UnhealthyWorker
+	HealEvent       = workerheal.Event
+	HealResult      = workerheal.Result
+	HealFailure     = workerheal.Failure
+)
+
+// DetectUnhealthyWorkers is the CLI/UI-facing alias for workerheal.Detect.
+func DetectUnhealthyWorkers() ([]UnhealthyWorker, error) { return workerheal.Detect() }
+
+// HealUnit is the CLI/UI-facing alias for workerheal.HealUnit.
+func HealUnit(unit string) error { return workerheal.HealUnit(unit) }
+
+// HealWorkers is the CLI/UI-facing alias for workerheal.HealAll.
+func HealWorkers(emit func(HealEvent)) (HealResult, error) {
+	return workerheal.HealAll(emit)
+}
+
+// HealSummary is the CLI-facing alias for workerheal.Summary.
+func HealSummary(r HealResult) string { return workerheal.Summary(r) }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -26,6 +26,7 @@ import (
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	lerdUpdate "github.com/geodro/lerd/internal/update"
 	"github.com/geodro/lerd/internal/version"
+	"github.com/geodro/lerd/internal/workerheal"
 	"github.com/geodro/lerd/internal/xdebugops"
 )
 
@@ -750,6 +751,21 @@ func toolList() []mcpTool {
 			},
 		},
 		mcpTool{
+			Name:        "workers_health",
+			Description: "Failed worker units, grouped per site. Read-only.",
+			InputSchema: mcpSchema{Type: "object", Properties: map[string]mcpProp{}},
+		},
+		mcpTool{
+			Name:        "workers_heal",
+			Description: "Reset failed and restart every failed worker. Pass `unit` for one. Never writes .lerd.yaml or unit files.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"unit": {Type: "string", Description: "Full unit name (lerd-<worker>-<site>). Omit to heal all."},
+				},
+			},
+		},
+		mcpTool{
 			Name:        "framework_list",
 			Description: "List framework definitions (built-in + user YAMLs), with their workers and setup commands.",
 			InputSchema: mcpSchema{Type: "object", Properties: map[string]mcpProp{}},
@@ -1016,6 +1032,10 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execWorkerRemove(args)
 	case "worker_list":
 		return execWorkerList(args)
+	case "workers_health":
+		return execWorkersHealth()
+	case "workers_heal":
+		return execWorkersHeal(args)
 
 	case "logs":
 		return execLogs(args)
@@ -3926,6 +3946,44 @@ func execWorkerList(args map[string]any) (any, *rpcError) {
 	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
 
 	data, _ := json.MarshalIndent(result, "", "  ")
+	return toolOK(string(data)), nil
+}
+
+// execWorkersHealth returns every worker unit currently in the systemd
+// "failed" state, grouped per site. Read-only counterpart to workers_heal.
+func execWorkersHealth() (any, *rpcError) {
+	unhealthy, err := workerheal.Detect()
+	if err != nil {
+		return toolErr("detecting workers: " + err.Error()), nil
+	}
+	if unhealthy == nil {
+		unhealthy = []workerheal.UnhealthyWorker{}
+	}
+	data, _ := json.MarshalIndent(unhealthy, "", "  ")
+	return toolOK(string(data)), nil
+}
+
+// execWorkersHeal heals every failed worker (or the named one if `unit` is
+// passed). Returns a per-unit summary so the agent can report what was
+// fixed without re-querying. Mirrors `lerd worker heal` exactly: no
+// .lerd.yaml writes, no unit-file rewrites.
+func execWorkersHeal(args map[string]any) (any, *rpcError) {
+	if unit := strArg(args, "unit"); unit != "" {
+		if err := workerheal.HealUnit(unit); err != nil {
+			return toolErr("heal " + unit + ": " + err.Error()), nil
+		}
+		return toolOK("Healed " + unit + "."), nil
+	}
+	report, err := workerheal.HealAll(nil)
+	if err != nil {
+		return toolErr("heal: " + err.Error()), nil
+	}
+	out := map[string]any{
+		"summary": workerheal.Summary(report),
+		"healed":  report.Healed,
+		"failed":  report.Failed,
+	}
+	data, _ := json.MarshalIndent(out, "", "  ")
 	return toolOK(string(data)), nil
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -168,7 +168,9 @@ func TestExecEnvCheck_missingKeys(t *testing.T) {
 // context for the whole session; raise the ceiling only with a justified
 // content addition, not by accreting description verbosity.
 func TestToolList_underSizeCeiling(t *testing.T) {
-	const ceiling = 17000
+	// Raised from 17000 to 17500 in v1.19.0-beta.2 for the two new
+	// workers_heal / workers_health tools.
+	const ceiling = 17500
 	got, err := json.Marshal(toolList())
 	if err != nil {
 		t.Fatalf("marshal tool list: %v", err)

--- a/internal/php/versions.go
+++ b/internal/php/versions.go
@@ -39,18 +39,17 @@ func ListInstalled() ([]string, error) {
 	}
 
 	// Source 2: podman containers (catches installs where the quadlet is missing).
-	// Reads from the daemon's container cache when available; falls back to a
-	// real podman ps in CLI contexts where the cache has not been started.
+	// Read-only: this MUST stay free of side effects. Production heal of a
+	// missing quadlet happens explicitly in install/start paths via
+	// ensureFPMQuadlet. Calling restoreQuadlet here would daemon-reload the
+	// user's real systemd from any test that triggered ListInstalled, and
+	// trigger a worker-stopping cascade via BindsTo.
 	for name := range podman.Cache.Snapshot() {
 		sub := fpmContainerRe.FindStringSubmatch(name)
 		if len(sub) != 3 {
 			continue
 		}
-		v := sub[1] + "." + sub[2]
-		seen[v] = true
-		if !quadletExists(v) {
-			_ = restoreQuadlet(v)
-		}
+		seen[sub[1]+"."+sub[2]] = true
 	}
 
 	versions := make([]string, 0, len(seen))
@@ -64,10 +63,6 @@ func ListInstalled() ([]string, error) {
 func quadletExists(version string) bool {
 	short := version[0:1] + version[2:]
 	return services.Mgr.ContainerUnitInstalled("lerd-php" + short + "-fpm")
-}
-
-func restoreQuadlet(version string) error {
-	return podman.WriteFPMQuadlet(version)
 }
 
 // IsInstalled returns true if the given PHP version has an FPM quadlet.

--- a/internal/php/versions_test.go
+++ b/internal/php/versions_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/geodro/lerd/internal/podman"
 )
 
 // --- listInstalledFromServiceDir ---
@@ -111,5 +113,36 @@ func TestListInstalled_fromQuadlets(t *testing.T) {
 	}
 	if !found["8.3"] {
 		t.Error("expected 8.3 in installed versions")
+	}
+}
+
+// ListInstalled used to call WriteFPMQuadlet -> DaemonReloadFn whenever it
+// saw a running FPM container without a matching local quadlet, which under
+// `go test` daemon-reloaded the user's real systemd and stopped every
+// worker via BindsTo. Pin the read-only contract here so it can't regress.
+func TestListInstalled_hasNoSideEffects(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only quadlet path")
+	}
+
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	prev := podman.DaemonReloadFn
+	t.Cleanup(func() { podman.DaemonReloadFn = prev })
+	var reloads int
+	podman.DaemonReloadFn = func() error { reloads++; return nil }
+
+	if _, err := ListInstalled(); err != nil {
+		t.Fatalf("ListInstalled: %v", err)
+	}
+
+	if reloads != 0 {
+		t.Errorf("ListInstalled triggered %d daemon-reloads, want 0", reloads)
+	}
+
+	systemd := filepath.Join(tmp, "containers", "systemd")
+	if entries, err := os.ReadDir(systemd); err == nil && len(entries) > 0 {
+		t.Errorf("ListInstalled wrote %d entries under %s, want 0", len(entries), systemd)
 	}
 }

--- a/internal/siteinfo/unitcache.go
+++ b/internal/siteinfo/unitcache.go
@@ -39,6 +39,25 @@ func InvalidateUnitCache() {
 	globalUnitCache.mu.Unlock()
 }
 
+// AllUnitStates returns a snapshot of every cached lerd-* unit state
+// (unit name → "active" | "inactive" | "failed" | …). The map is a copy
+// safe for callers to walk without holding the cache mutex. Triggers a
+// refresh if the cache is stale, but otherwise reuses the same batched
+// systemctl snapshot the dashboard's enrichment path is already populating
+// — zero extra subprocess cost for callers like the worker-health detector.
+func AllUnitStates() map[string]string {
+	globalUnitCache.mu.Lock()
+	defer globalUnitCache.mu.Unlock()
+	if globalUnitCache.states == nil || time.Since(globalUnitCache.at) > unitCacheTTL {
+		_ = globalUnitCache.refreshLocked()
+	}
+	out := make(map[string]string, len(globalUnitCache.states))
+	for k, v := range globalUnitCache.states {
+		out[k] = v
+	}
+	return out
+}
+
 // unitStatusCached returns the active state of a lerd-* unit, consulting a
 // short-lived batched snapshot. One systemctl call populates ~all lerd units
 // instead of one subprocess per worker.

--- a/internal/siteinfo/unitcache_darwin.go
+++ b/internal/siteinfo/unitcache_darwin.go
@@ -10,4 +10,11 @@ func init() {
 	// that worker status is queried through the darwinServiceManager instead,
 	// which checks launchd state and the running podman container directly.
 	unitStatusFn = podman.UnitStatus
+
+	// AllUnitStates is the batched-state accessor used by the worker-health
+	// detector. On macOS there is no systemctl batched-list equivalent (each
+	// `launchctl print` is one process), so return empty rather than shell
+	// out per call. The macOS exec-mode self-heal watcher already covers the
+	// drift cases the Linux detector targets.
+	unitCacheListFn = func() (string, error) { return "", nil }
 }

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -67,6 +67,7 @@ var helpReference = []helpSection{
 		title: "General",
 		rows: [][2]string{
 			{"R", "force a manual refresh"},
+			{"H", "heal every failed worker (reset-failed + start)"},
 			{"q / ctrl+c", "quit"},
 		},
 	},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -365,8 +365,21 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "R":
 		return m, loadCmd()
+
+	case "H":
+		return m, m.actionHealWorkers()
 	}
 	return m, nil
+}
+
+// actionHealWorkers shells out to `lerd worker heal` so every failed
+// worker on the box gets reset-failed + start. The CLI command is the
+// single source of heal logic; the TUI just triggers it and refreshes
+// the snapshot once it returns. No site context required — heal scans
+// every registered site.
+func (m *Model) actionHealWorkers() tea.Cmd {
+	m.setStatus("healing failed workers…", 10*time.Second)
+	return tea.Sequence(runLerd("", "worker", "heal"), loadCmd())
 }
 
 // openDomainInput switches into domain-input mode for adding a new domain.

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -144,6 +144,12 @@ func Start(currentVersion string) error {
 	// the freshly rebuilt bytes to every connected browser.
 	go runSnapshotInvalidator()
 
+	// systemd transitions a worker to "failed" without telling lerd-ui (e.g.
+	// after start-limit-hit on a crash loop). The health watcher closes
+	// that gap by polling the cached detector on a slow tick and publishing
+	// KindSites only when the unhealthy set actually changes.
+	go runWorkerHealthWatcher()
+
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/api/status", withCORS(handleStatus))
@@ -191,6 +197,8 @@ func Start(currentVersion string) error {
 	mux.HandleFunc("/api/settings", withCORS(handleSettings))
 	mux.HandleFunc("/api/settings/autostart", withCORS(handleSettingsAutostart))
 	mux.HandleFunc("/api/settings/worker-mode", withCORS(handleSettingsWorkerMode))
+	mux.HandleFunc("/api/workers/health", withCORS(handleWorkersHealth))
+	mux.HandleFunc("/api/workers/heal", withCORS(handleWorkersHeal))
 	mux.HandleFunc("/api/xdebug/", withCORS(publishAfter(handleXdebugAction, eventbus.KindStatus)))
 	mux.HandleFunc("/api/lerd/start", withCORS(handleLerdStart))
 	mux.HandleFunc("/api/lerd/stop", withCORS(handleLerdStop))
@@ -2423,6 +2431,37 @@ func handleSettingsWorkerMode(w http.ResponseWriter, r *http.Request) {
 		writeLine(evt)
 	}); err != nil {
 		writeLine(cli.WorkerModePhaseEvent{Phase: "error", Error: err.Error()})
+	}
+}
+
+// handleWorkersHealth reports every worker unit currently in the systemd
+// "failed" state, grouped per site. Reads the existing batched unit-state
+// cache so polling stays cheap (no extra subprocess per request).
+func handleWorkersHealth(w http.ResponseWriter, _ *http.Request) {
+	unhealthy, err := cli.DetectUnhealthyWorkers()
+	if err != nil {
+		writeJSON(w, map[string]any{"unhealthy": []cli.UnhealthyWorker{}, "error": err.Error()})
+		return
+	}
+	if unhealthy == nil {
+		unhealthy = []cli.UnhealthyWorker{}
+	}
+	writeJSON(w, map[string]any{"unhealthy": unhealthy})
+}
+
+// handleWorkersHeal streams NDJSON heal events to the dashboard so the
+// banner can show real per-unit progress. Heal is intentionally narrow:
+// reset-failed + start; no .lerd.yaml or unit-file writes.
+func handleWorkersHeal(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeLine, _ := startNDJSONStream(w, r)
+	if _, err := cli.HealWorkers(func(evt cli.HealEvent) {
+		writeLine(evt)
+	}); err != nil {
+		writeLine(cli.HealEvent{Phase: "failed", Error: err.Error()})
 	}
 }
 

--- a/internal/ui/snapshot.go
+++ b/internal/ui/snapshot.go
@@ -39,10 +39,16 @@ type snapshotCache struct {
 	sites, services, status       []byte
 	sitesAt, servicesAt, statusAt time.Time
 
+	// Unhealthy-workers JSON shadows the sites cycle: it is derived from
+	// the same batched unit-state cache and invalidated alongside KindSites,
+	// so callers don't pay any extra subprocess cost.
+	unhealthy   []byte
+	unhealthyAt time.Time
+
 	// One build-mutex per kind serialises concurrent rebuilds so that when
 	// podman inspect is slow, goroutines queue behind one in-flight rebuild
 	// rather than each spawning their own batch of subprocesses.
-	sitesBuild, servicesBuild, statusBuild sync.Mutex
+	sitesBuild, servicesBuild, statusBuild, unhealthyBuild sync.Mutex
 }
 
 var snapshots = &snapshotCache{}
@@ -149,6 +155,40 @@ func (c *snapshotCache) Status() []byte {
 	return b
 }
 
+// UnhealthyWorkers returns cached worker-health JSON, rebuilding if stale.
+// Pinned to the KindSites lifecycle: same source cache, same invalidation
+// signal, no extra polling.
+func (c *snapshotCache) UnhealthyWorkers() []byte {
+	c.mu.Lock()
+	if c.unhealthy != nil && time.Since(c.unhealthyAt) < currentSnapshotTTL() {
+		b := c.unhealthy
+		c.mu.Unlock()
+		return b
+	}
+	stale := c.unhealthy
+	c.mu.Unlock()
+
+	if !c.unhealthyBuild.TryLock() {
+		return stale
+	}
+	defer c.unhealthyBuild.Unlock()
+
+	c.mu.Lock()
+	if c.unhealthy != nil && time.Since(c.unhealthyAt) < currentSnapshotTTL() {
+		b := c.unhealthy
+		c.mu.Unlock()
+		return b
+	}
+	c.mu.Unlock()
+
+	b := buildUnhealthyWorkersJSON()
+	c.mu.Lock()
+	c.unhealthy = b
+	c.unhealthyAt = time.Now()
+	c.mu.Unlock()
+	return b
+}
+
 // Invalidate drops the cached bytes for one kind so the next read rebuilds.
 func (c *snapshotCache) Invalidate(kind string) {
 	c.mu.Lock()
@@ -156,6 +196,8 @@ func (c *snapshotCache) Invalidate(kind string) {
 	switch kind {
 	case eventbus.KindSites:
 		c.sitesAt = time.Time{}
+		// Worker health shares the sites lifecycle.
+		c.unhealthyAt = time.Time{}
 	case eventbus.KindServices:
 		c.servicesAt = time.Time{}
 	case eventbus.KindStatus:
@@ -169,5 +211,6 @@ func (c *snapshotCache) InvalidateAll() {
 	c.sitesAt = time.Time{}
 	c.servicesAt = time.Time{}
 	c.statusAt = time.Time{}
+	c.unhealthyAt = time.Time{}
 	c.mu.Unlock()
 }

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -331,5 +331,11 @@
   "link_linking": "Linking...",
   "link_linkThisDir": "Link This Directory",
   "link_waitingOutput": "Waiting for output...",
-  "link_failed": "Link failed"
+  "link_failed": "Link failed",
+  "workers_health_banner_title": "{count} worker(s) failing",
+  "workers_health_banner_starting": "Starting {unit}…",
+  "workers_health_banner_heal": "Heal",
+  "workers_health_banner_healing": "Healing…",
+  "workers_health_banner_dismiss": "Dismiss",
+  "workers_health_banner_progress": "Healing {done} of {total}…"
 }

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -331,5 +331,11 @@
   "link_linking": "Enlazando...",
   "link_linkThisDir": "Enlazar este directorio",
   "link_waitingOutput": "Esperando salida...",
-  "link_failed": "Enlace fallido"
+  "link_failed": "Enlace fallido",
+  "workers_health_banner_title": "{count} worker(s) fallando",
+  "workers_health_banner_starting": "Iniciando {unit}…",
+  "workers_health_banner_heal": "Reparar",
+  "workers_health_banner_healing": "Reparando…",
+  "workers_health_banner_dismiss": "Descartar",
+  "workers_health_banner_progress": "Reparando {done} de {total}…"
 }

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -331,5 +331,11 @@
   "link_linking": "Liaison...",
   "link_linkThisDir": "Lier ce répertoire",
   "link_waitingOutput": "En attente de sortie...",
-  "link_failed": "Échec de la liaison"
+  "link_failed": "Échec de la liaison",
+  "workers_health_banner_title": "{count} worker(s) en échec",
+  "workers_health_banner_starting": "Démarrage de {unit}…",
+  "workers_health_banner_heal": "Réparer",
+  "workers_health_banner_healing": "Réparation…",
+  "workers_health_banner_dismiss": "Masquer",
+  "workers_health_banner_progress": "Réparation {done} sur {total}…"
 }

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -331,5 +331,11 @@
   "link_linking": "Vinculando...",
   "link_linkThisDir": "Vincular este diretório",
   "link_waitingOutput": "Aguardando saída...",
-  "link_failed": "Vinculação falhou"
+  "link_failed": "Vinculação falhou",
+  "workers_health_banner_title": "{count} worker(s) falhando",
+  "workers_health_banner_starting": "Iniciando {unit}…",
+  "workers_health_banner_heal": "Reparar",
+  "workers_health_banner_healing": "Reparando…",
+  "workers_health_banner_dismiss": "Dispensar",
+  "workers_health_banner_progress": "Reparando {done} de {total}…"
 }

--- a/internal/ui/web/src/App.svelte
+++ b/internal/ui/web/src/App.svelte
@@ -14,11 +14,13 @@
   import { loadAutostart } from '$stores/autostart';
   import { loadSites } from '$stores/sites';
   import { loadServices } from '$stores/services';
+  import { loadWorkerHealth } from '$stores/workerHealth';
   import { connectWs, disconnectWs } from '$lib/ws';
   import { initDashboardRoute } from '$stores/dashboard';
   import { mobileView } from '$stores/mobileView';
   import ModalHost from './modals/ModalHost.svelte';
   import DashboardOverlay from '$components/DashboardOverlay.svelte';
+  import WorkerHealthBanner from '$components/WorkerHealthBanner.svelte';
 
   import SitesTab from '$tabs/SitesTab.svelte';
   import ServicesTab from '$tabs/ServicesTab.svelte';
@@ -41,6 +43,7 @@
     loadAutostart();
     loadSites();
     loadServices();
+    loadWorkerHealth();
     connectWs();
     initDashboardRoute();
     window.addEventListener('pagehide', handlePageHide);
@@ -117,4 +120,5 @@
   <MobileNav />
   <ModalHost />
   <DashboardOverlay />
+  <WorkerHealthBanner />
 </div>

--- a/internal/ui/web/src/components/WorkerHealthBanner.svelte
+++ b/internal/ui/web/src/components/WorkerHealthBanner.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  import {
+    unhealthyWorkers,
+    healLoading,
+    healProgressUnit,
+    healDoneCount,
+    healTotalCount,
+    healAll,
+    loadWorkerHealth
+  } from '$stores/workerHealth';
+  import { m } from '../paraglide/messages.js';
+
+  // In-session dismiss only: deliberately not persisted to localStorage so
+  // a fresh tab always re-surfaces failing workers. The set tracks the
+  // canonical signature of the unhealthy list at dismiss time, so when a
+  // NEW worker fails after dismissal the banner reappears.
+  let dismissedSignature = $state<string | null>(null);
+  const currentSignature = $derived(
+    $unhealthyWorkers
+      .map((u) => u.unit)
+      .slice()
+      .sort()
+      .join(',')
+  );
+  // Stay visible while healing even if the underlying list briefly reaches
+  // zero — otherwise the loader would unmount mid-stream and the user
+  // wouldn't see the final "Healing 3 of 3" tick.
+  const visible = $derived(
+    ($healLoading || $unhealthyWorkers.length > 0) && currentSignature !== dismissedSignature
+  );
+
+  // progressPercent is a deliberate 0-100 derivation so the bar advances
+  // smoothly as units complete. When total is unknown (zero) we keep the
+  // bar at indeterminate width via CSS.
+  const progressPercent = $derived(
+    $healTotalCount > 0 ? Math.min(100, Math.round(($healDoneCount / $healTotalCount) * 100)) : 0
+  );
+
+  async function onHeal() {
+    const r = await healAll();
+    await loadWorkerHealth();
+    if (!r.ok && r.error) {
+      console.error('[lerd] heal failed:', r.error);
+    }
+  }
+
+  function onDismiss() {
+    dismissedSignature = currentSignature;
+  }
+</script>
+
+{#if visible}
+  <div class="fixed bottom-3 left-1/2 -translate-x-1/2 z-[60] w-[min(92vw,640px)] rounded-lg border-l-4 border border-amber-400 dark:border-amber-500/50 border-l-amber-500 bg-white/85 dark:bg-lerd-card/80 backdrop-blur-md shadow-2xl overflow-hidden">
+    {#if $healLoading}
+      <div class="h-1 bg-amber-200/40 dark:bg-amber-500/20">
+        <div
+          class="h-full bg-amber-500 transition-[width] duration-300 ease-out"
+          style="width: {progressPercent}%"
+        ></div>
+      </div>
+    {/if}
+    <div class="flex items-center gap-3 px-3 py-2.5">
+      {#if $healLoading}
+        <svg class="w-5 h-5 shrink-0 text-amber-600 dark:text-amber-400 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
+        </svg>
+      {:else}
+        <svg class="w-5 h-5 shrink-0 text-amber-600 dark:text-amber-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+        </svg>
+      {/if}
+      <div class="flex-1 min-w-0">
+        {#if $healLoading}
+          <p class="text-xs font-semibold text-amber-900 dark:text-amber-200">
+            {m.workers_health_banner_progress({
+              done: $healDoneCount,
+              total: $healTotalCount
+            })}
+          </p>
+          <p class="text-[11px] text-amber-700 dark:text-amber-300/80 mt-0.5 truncate">
+            {$healProgressUnit ?? ''}
+          </p>
+        {:else}
+          <p class="text-xs font-semibold text-amber-900 dark:text-amber-200">
+            {m.workers_health_banner_title({ count: $unhealthyWorkers.length })}
+          </p>
+          <p class="text-[11px] text-amber-700 dark:text-amber-300/80 mt-0.5 truncate">
+            {$unhealthyWorkers.map((u) => `${u.worker}@${u.site}`).join(', ')}
+          </p>
+        {/if}
+      </div>
+      <button
+        onclick={onHeal}
+        disabled={$healLoading}
+        class="shrink-0 inline-flex items-center gap-1.5 text-xs font-medium bg-amber-600 hover:bg-amber-700 text-white rounded px-3 py-1.5 transition-colors disabled:opacity-50"
+      >
+        {#if $healLoading}
+          {m.workers_health_banner_healing()}
+        {:else}
+          {m.workers_health_banner_heal()}
+        {/if}
+      </button>
+      <button
+        onclick={onDismiss}
+        disabled={$healLoading}
+        title={m.workers_health_banner_dismiss()}
+        aria-label={m.workers_health_banner_dismiss()}
+        class="shrink-0 text-amber-600/60 hover:text-amber-700 dark:text-amber-400/60 dark:hover:text-amber-300 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+{/if}

--- a/internal/ui/web/src/lib/ws.ts
+++ b/internal/ui/web/src/lib/ws.ts
@@ -6,6 +6,7 @@ export interface WsMessage {
   sites?: unknown;
   services?: unknown;
   status?: unknown;
+  unhealthy_workers?: unknown;
 }
 
 export const wsConnected = writable<boolean>(false);

--- a/internal/ui/web/src/stores/workerHealth.ts
+++ b/internal/ui/web/src/stores/workerHealth.ts
@@ -1,0 +1,126 @@
+import { writable } from 'svelte/store';
+import { apiJson, apiFetch } from '$lib/api';
+import { wsMessage } from '$lib/ws';
+
+export interface UnhealthyWorker {
+  site: string;
+  worker: string;
+  unit: string;
+  state: string;
+}
+
+interface HealthResponse {
+  unhealthy?: UnhealthyWorker[];
+  error?: string;
+}
+
+interface HealEvent {
+  phase: 'starting' | 'healed' | 'failed' | 'done';
+  site?: string;
+  unit?: string;
+  error?: string;
+}
+
+export const unhealthyWorkers = writable<UnhealthyWorker[]>([]);
+export const healLoading = writable(false);
+export const healProgressUnit = writable<string | null>(null);
+export const healDoneCount = writable(0);
+export const healTotalCount = writable(0);
+
+// loadWorkerHealth GETs the current snapshot. Backed by the existing
+// 3-second batched unit-state cache on the server, so polling on every
+// site-list refresh is cheap.
+export async function loadWorkerHealth() {
+  try {
+    const res = await apiJson<HealthResponse>('/api/workers/health');
+    unhealthyWorkers.set(res.unhealthy ?? []);
+  } catch {
+    /* keep previous */
+  }
+}
+
+// The server pushes `unhealthy_workers` as a top-level WS field whenever
+// the health-watcher detects the set has changed (it diffs a cached
+// detector every 5s; idle tabs skip entirely). No extra HTTP round-trip,
+// no extra subprocess: the watcher reads the same 3-second-TTL unit-state
+// cache the sites snapshot already uses. The fall-back loadWorkerHealth()
+// stays available for non-WS callers (initial mount, post-heal refresh).
+wsMessage.subscribe((msg) => {
+  if (!msg) return;
+  if (Array.isArray(msg.unhealthy_workers)) {
+    unhealthyWorkers.set(msg.unhealthy_workers as UnhealthyWorker[]);
+  }
+});
+
+// healAll triggers the server-side detector + reset-failed + start sequence
+// for every unhealthy worker. Reads the NDJSON stream so the banner can
+// show per-unit progress instead of a blank spinner. Returns once the
+// "done" event arrives; the caller usually re-runs loadWorkerHealth to
+// confirm the count went to zero.
+export async function healAll(): Promise<{ ok: boolean; healed: number; failed: number; error?: string }> {
+  // Snapshot the count up front so "Healing X of Y" stays stable even if
+  // the underlying unhealthyWorkers list gets refreshed mid-stream.
+  let total = 0;
+  unhealthyWorkers.subscribe((w) => (total = w.length))();
+  healLoading.set(true);
+  healProgressUnit.set(null);
+  healDoneCount.set(0);
+  healTotalCount.set(total);
+  let healed = 0;
+  let failed = 0;
+  try {
+    const res = await apiFetch('/api/workers/heal', { method: 'POST' });
+    if (!res.ok || !res.body) {
+      return { ok: false, healed, failed, error: `${res.status} ${res.statusText}` };
+    }
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    let lastError: string | undefined;
+    let sawDone = false;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let nl: number;
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (!line) continue;
+        let evt: HealEvent;
+        try {
+          evt = JSON.parse(line) as HealEvent;
+        } catch {
+          continue;
+        }
+        switch (evt.phase) {
+          case 'starting':
+            healProgressUnit.set(evt.unit ?? null);
+            break;
+          case 'healed':
+            healed++;
+            healDoneCount.set(healed + failed);
+            break;
+          case 'failed':
+            // Without a unit the failure is the detector itself.
+            if (evt.unit) {
+              failed++;
+              healDoneCount.set(healed + failed);
+            } else {
+              lastError = evt.error;
+            }
+            break;
+          case 'done':
+            sawDone = true;
+            break;
+        }
+      }
+    }
+    return { ok: sawDone && !lastError, healed, failed, error: lastError };
+  } catch (e) {
+    return { ok: false, healed, failed, error: e instanceof Error ? e.message : 'request failed' };
+  } finally {
+    healLoading.set(false);
+    healProgressUnit.set(null);
+  }
+}

--- a/internal/ui/worker_health_watcher.go
+++ b/internal/ui/worker_health_watcher.go
@@ -1,0 +1,87 @@
+package ui
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/geodro/lerd/internal/eventbus"
+	"github.com/geodro/lerd/internal/workerheal"
+)
+
+// healthWatchInterval is how often the watcher re-runs the cached detector
+// when at least one UI tab is open. Each tick is one map walk over the
+// existing 3-second-TTL unit-state cache plus a string compare; no
+// subprocess, no file read. Idle tabs drop to no work at all.
+const healthWatchInterval = 5 * time.Second
+
+// lastHealthSig is the last unhealthy-set signature seen by the watcher.
+// Stored as an unsafe pointer through atomic so the watcher and broker
+// don't race when the watcher updates it after publishing.
+var lastHealthSig atomic.Value // string
+
+// runWorkerHealthWatcher closes the gap between systemd's internal state
+// transitions (start-limit-hit, external `systemctl stop`, anything that
+// happens without lerd-ui's involvement) and the dashboard banner. Each
+// tick:
+//
+//  1. If no tab is visible, skip — the next tab open does an initial fetch
+//     anyway, and idle tabs shouldn't burn CPU.
+//  2. Read the unhealthy set from the existing cached detector. Cheap.
+//  3. Compare to the last seen signature. If unchanged, do nothing.
+//  4. If changed, publish KindSites — the snapshot path then rebuilds the
+//     unhealthy_workers JSON and the broker pushes it to every tab.
+//
+// The watcher does NOT run the heal itself; it only surfaces drift.
+func runWorkerHealthWatcher() {
+	ticker := time.NewTicker(healthWatchInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if visibleClients.Load() == 0 {
+			continue
+		}
+		unhealthy, err := workerheal.Detect()
+		if err != nil {
+			continue
+		}
+		sig := healthSignature(unhealthy)
+		prev, _ := lastHealthSig.Load().(string)
+		if sig == prev {
+			continue
+		}
+		lastHealthSig.Store(sig)
+		// Riding KindSites means the existing snapshot/broker pipeline
+		// rebuilds and pushes without needing a separate event kind.
+		eventbus.Default.Publish(eventbus.KindSites)
+	}
+}
+
+// healthSignature renders a stable string for set-equality checks. Sorting
+// keeps the comparison robust against map-iteration order.
+func healthSignature(ws []workerheal.UnhealthyWorker) string {
+	if len(ws) == 0 {
+		return ""
+	}
+	parts := make([]string, len(ws))
+	for i, w := range ws {
+		parts[i] = w.Unit + ":" + w.State
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+// buildUnhealthyWorkersJSON serialises the current detector output. Errors
+// degrade to an empty array so the dashboard never sees a malformed frame.
+func buildUnhealthyWorkersJSON() []byte {
+	out, err := workerheal.Detect()
+	if err != nil || len(out) == 0 {
+		return []byte("[]")
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return []byte("[]")
+	}
+	return b
+}

--- a/internal/ui/ws.go
+++ b/internal/ui/ws.go
@@ -104,8 +104,14 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 	snapshots.Invalidate(eventbus.KindServices)
 	snapshots.Invalidate(eventbus.KindStatus)
 
-	// Initial snapshot: assemble one JSON object containing all three kinds.
-	initial := assembleSnapshot(snapshots.Sites(), snapshots.Services(), snapshots.Status(), []string{"snapshot"})
+	// Initial snapshot: assemble one JSON object containing all kinds.
+	initial := assembleSnapshot(
+		snapshots.Sites(),
+		snapshots.Services(),
+		snapshots.Status(),
+		snapshots.UnhealthyWorkers(),
+		[]string{"snapshot"},
+	)
 	if err := ws.WriteText(initial); err != nil {
 		return
 	}
@@ -169,7 +175,7 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 			if !ok {
 				return
 			}
-			frame := assembleSnapshot(msg.Sites, msg.Services, msg.Status, msg.Kinds)
+			frame := assembleSnapshot(msg.Sites, msg.Services, msg.Status, msg.UnhealthyWorkers, msg.Kinds)
 			if err := ws.WriteText(frame); err != nil {
 				return
 			}
@@ -185,10 +191,10 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 
 // assembleSnapshot builds a JSON object of the form:
 //
-//	{"type":"<type>","sites":<sites>,"services":<services>,"status":<status>}
+//	{"type":"<type>","sites":<sites>,"services":<services>,"status":<status>,"unhealthy_workers":<unhealthy>}
 //
 // Any nil slice is omitted so clients can treat missing keys as "unchanged".
-func assembleSnapshot(sites, services, status []byte, kinds []string) []byte {
+func assembleSnapshot(sites, services, status, unhealthy []byte, kinds []string) []byte {
 	var buf bytes.Buffer
 	buf.WriteString(`{"type":"`)
 	if len(kinds) == 1 {
@@ -208,6 +214,10 @@ func assembleSnapshot(sites, services, status []byte, kinds []string) []byte {
 	if len(status) > 0 {
 		buf.WriteString(`,"status":`)
 		buf.Write(status)
+	}
+	if len(unhealthy) > 0 {
+		buf.WriteString(`,"unhealthy_workers":`)
+		buf.Write(unhealthy)
 	}
 	buf.WriteByte('}')
 	return buf.Bytes()

--- a/internal/ui/ws_broker.go
+++ b/internal/ui/ws_broker.go
@@ -43,10 +43,11 @@ type wsBroker struct {
 // Kinds names which snapshots changed; Sites/Services/Status hold the fresh
 // JSON bytes for only the kinds in Kinds.
 type wsMessage struct {
-	Kinds    []string
-	Sites    []byte
-	Services []byte
-	Status   []byte
+	Kinds            []string
+	Sites            []byte
+	Services         []byte
+	Status           []byte
+	UnhealthyWorkers []byte
 }
 
 var broker = &wsBroker{peers: make(map[chan wsMessage]struct{})}
@@ -116,6 +117,11 @@ func runSnapshotInvalidator() {
 			switch k {
 			case eventbus.KindSites:
 				msg.Sites = snapshots.Sites()
+				// Worker health rides the same KindSites cycle: it's
+				// derived from the same unit-state cache, and the only
+				// signals that can change it (unit lifecycle ops, the
+				// periodic health-watcher) all publish KindSites.
+				msg.UnhealthyWorkers = snapshots.UnhealthyWorkers()
 			case eventbus.KindServices:
 				msg.Services = snapshots.Services()
 			case eventbus.KindStatus:

--- a/internal/workerheal/workerheal.go
+++ b/internal/workerheal/workerheal.go
@@ -1,0 +1,181 @@
+// Package workerheal detects and recovers worker units stuck in systemd's
+// "failed" state. The detector is deliberately cheap — it walks the existing
+// batched unit-state cache shared with the dashboard, so polling stays free
+// even on busy installs. The healer is a single primitive: reset-failed +
+// start. It never writes .lerd.yaml or rewrites unit files; that belongs to
+// `lerd worker add/remove/start/stop` and `lerd init`.
+package workerheal
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// UnhealthyWorker is a single failing/stuck worker unit.
+type UnhealthyWorker struct {
+	Site   string `json:"site"`
+	Worker string `json:"worker"`
+	Unit   string `json:"unit"`
+	State  string `json:"state"` // "failed" today; reserve for future "start-limit-hit", "expected-but-stopped"
+}
+
+// Event is one line in the streaming heal report. Dashboard, MCP, and TUI
+// all consume these so progress is visible without polling.
+type Event struct {
+	Phase string `json:"phase"` // "starting" | "healed" | "failed" | "done"
+	Site  string `json:"site,omitempty"`
+	Unit  string `json:"unit,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+// Result is the aggregate report for non-streaming callers.
+type Result struct {
+	Healed []UnhealthyWorker `json:"healed"`
+	Failed []Failure         `json:"failed"`
+}
+
+// Failure is one heal attempt that errored.
+type Failure struct {
+	Worker UnhealthyWorker `json:"worker"`
+	Err    string          `json:"error"`
+}
+
+// nonWorkerPerSitePrefixes lists lerd-<X>-<site> patterns that match a
+// registered site suffix but are NOT worker units (per-site containers
+// rather than worker processes). Heal must skip these — restarting a
+// crashed lerd-fp-myapp via this path is a different operation.
+var nonWorkerPerSitePrefixes = map[string]bool{
+	"custom": true, // lerd-custom-<site> — per-site custom container
+	"fp":     true, // lerd-fp-<site>     — per-site FrankenPHP container
+}
+
+// Swappable for tests so the detector can be exercised without touching the
+// real systemd unit-state cache or starting real units.
+var (
+	unitStatesFn = siteinfo.AllUnitStates
+	healFn       = podman.StartUnit
+)
+
+// Detect returns every worker unit systemd considers "failed". Cheap by
+// design: it reads only the existing batched unit-state cache (one
+// systemctl call per 3s, shared with the dashboard's enrichment path) plus
+// sites.yaml. No per-site .lerd.yaml or composer.json reads, no extra
+// subprocess calls. Safe to invoke from a hot endpoint.
+//
+// Heuristic kept narrow on purpose: worker units that hit Restart= rate
+// limits or crash repeatedly land in "failed" and stay there until
+// something resets them. "Inactive" is too broad — users routinely stop
+// individual workers on purpose, and we can't tell intent apart from
+// drift without an explicit per-worker desired-state field.
+func Detect() ([]UnhealthyWorker, error) {
+	reg, err := config.LoadSites()
+	if err != nil {
+		return nil, err
+	}
+	siteSet := make(map[string]bool, len(reg.Sites))
+	for _, s := range reg.Sites {
+		if s.Paused || s.Ignored {
+			continue
+		}
+		siteSet[s.Name] = true
+	}
+	if len(siteSet) == 0 {
+		return nil, nil
+	}
+
+	states := unitStatesFn()
+	var out []UnhealthyWorker
+	for unit, state := range states {
+		if state != "failed" {
+			continue
+		}
+		// The unit-state cache aliases each .service unit under both
+		// "lerd-foo" and "lerd-foo.service"; pick one canonical form so
+		// we don't emit duplicates. .timer units (paired oneshot
+		// schedulers) are skipped — their .service sibling, if it ever
+		// fails, will surface here under its own key.
+		if !strings.HasSuffix(unit, ".service") {
+			continue
+		}
+		body := strings.TrimPrefix(unit, "lerd-")
+		body = strings.TrimSuffix(body, ".service")
+		// Find the longest site-name suffix match so worker names with
+		// embedded hyphens (e.g. emit-events) survive intact.
+		var site, worker string
+		for s := range siteSet {
+			if strings.HasSuffix(body, "-"+s) {
+				if len(s) > len(site) {
+					site = s
+					worker = strings.TrimSuffix(body, "-"+s)
+				}
+			}
+		}
+		if site == "" || worker == "" {
+			continue
+		}
+		if nonWorkerPerSitePrefixes[worker] {
+			continue
+		}
+		out = append(out, UnhealthyWorker{
+			Site:   site,
+			Worker: worker,
+			Unit:   "lerd-" + worker + "-" + site,
+			State:  "failed",
+		})
+	}
+	return out, nil
+}
+
+// HealUnit clears any failed state and starts the named worker unit. The
+// single "fix this" primitive — every surface (CLI / UI / TUI / MCP) goes
+// through here. Crucially, it does NOT touch .lerd.yaml or rewrite the
+// unit file: a failed worker is a transient runtime condition, not a
+// change of user intent. The reset-failed step is implicit: on Linux,
+// systemd.DBusStartUnit calls DBusResetFailed first; on macOS launchd's
+// bootstrap path replaces the job entirely.
+func HealUnit(unit string) error {
+	return healFn(unit)
+}
+
+// HealAll detects every unhealthy worker and heals them in order. emit,
+// when non-nil, receives one Event per phase transition so the dashboard's
+// banner and the MCP tool can stream progress instead of blocking on a
+// final summary.
+func HealAll(emit func(Event)) (Result, error) {
+	if emit == nil {
+		emit = func(Event) {}
+	}
+	unhealthy, err := Detect()
+	if err != nil {
+		emit(Event{Phase: "failed", Error: err.Error()})
+		return Result{}, err
+	}
+	report := Result{}
+	for _, u := range unhealthy {
+		emit(Event{Phase: "starting", Site: u.Site, Unit: u.Unit})
+		if err := HealUnit(u.Unit); err != nil {
+			report.Failed = append(report.Failed, Failure{Worker: u, Err: err.Error()})
+			emit(Event{Phase: "failed", Site: u.Site, Unit: u.Unit, Error: err.Error()})
+			continue
+		}
+		report.Healed = append(report.Healed, u)
+		emit(Event{Phase: "healed", Site: u.Site, Unit: u.Unit})
+	}
+	emit(Event{Phase: "done"})
+	return report, nil
+}
+
+// Summary renders a one-line CLI-friendly summary of a Result.
+func Summary(r Result) string {
+	if len(r.Healed) == 0 && len(r.Failed) == 0 {
+		return "No unhealthy workers."
+	}
+	if len(r.Failed) == 0 {
+		return fmt.Sprintf("Healed %d worker(s).", len(r.Healed))
+	}
+	return fmt.Sprintf("Healed %d worker(s), %d failed.", len(r.Healed), len(r.Failed))
+}

--- a/internal/workerheal/workerheal_test.go
+++ b/internal/workerheal/workerheal_test.go
@@ -1,0 +1,283 @@
+package workerheal
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// stubEnv stages a sites.yaml with the given names in a temp XDG_DATA_HOME
+// and swaps out the unit-state and heal hooks so the test never touches
+// real systemd or podman.
+func stubEnv(t *testing.T, sites []string, paused map[string]bool, states map[string]string, heal func(string) error) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dir)
+
+	lerdDir := filepath.Join(dir, "lerd")
+	if err := os.MkdirAll(lerdDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := "sites:\n"
+	for _, name := range sites {
+		body += "  - name: " + name + "\n"
+		body += "    path: /tmp/" + name + "\n"
+		body += "    domains: [" + name + ".test]\n"
+		if paused[name] {
+			body += "    paused: true\n"
+		}
+	}
+	if err := os.WriteFile(filepath.Join(lerdDir, "sites.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write sites.yaml: %v", err)
+	}
+
+	prevStates, prevHeal := unitStatesFn, healFn
+	unitStatesFn = func() map[string]string {
+		out := make(map[string]string, len(states))
+		for k, v := range states {
+			out[k] = v
+		}
+		return out
+	}
+	healFn = heal
+	t.Cleanup(func() {
+		unitStatesFn = prevStates
+		healFn = prevHeal
+	})
+}
+
+func unitNames(ws []UnhealthyWorker) []string {
+	out := make([]string, len(ws))
+	for i, w := range ws {
+		out[i] = w.Unit
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestDetect_FailedWorkerReturned(t *testing.T) {
+	stubEnv(t,
+		[]string{"myapp"}, nil,
+		map[string]string{
+			"lerd-queue-myapp.service": "failed",
+			"lerd-php85-fpm.service":   "active",
+		},
+		nil,
+	)
+
+	got, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if names := unitNames(got); len(names) != 1 || names[0] != "lerd-queue-myapp" {
+		t.Errorf("got %v, want [lerd-queue-myapp]", names)
+	}
+	if got[0].Site != "myapp" || got[0].Worker != "queue" {
+		t.Errorf("site/worker split: site=%q worker=%q", got[0].Site, got[0].Worker)
+	}
+}
+
+func TestDetect_PausedSiteExcluded(t *testing.T) {
+	stubEnv(t,
+		[]string{"alpha", "beta"},
+		map[string]bool{"beta": true},
+		map[string]string{
+			"lerd-queue-alpha.service": "failed",
+			"lerd-queue-beta.service":  "failed",
+		},
+		nil,
+	)
+
+	got, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if names := unitNames(got); len(names) != 1 || names[0] != "lerd-queue-alpha" {
+		t.Errorf("paused site bled in: got %v", names)
+	}
+}
+
+func TestDetect_NonWorkerPerSiteUnitsSkipped(t *testing.T) {
+	stubEnv(t,
+		[]string{"myapp"}, nil,
+		map[string]string{
+			"lerd-fp-myapp.service":     "failed", // per-site FrankenPHP container, not a worker
+			"lerd-custom-myapp.service": "failed", // per-site custom container, not a worker
+			"lerd-queue-myapp.service":  "failed", // worker
+		},
+		nil,
+	)
+
+	got, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if names := unitNames(got); len(names) != 1 || names[0] != "lerd-queue-myapp" {
+		t.Errorf("non-worker per-site units leaked into detection: %v", names)
+	}
+}
+
+func TestDetect_GlobalUnitsSkipped(t *testing.T) {
+	stubEnv(t,
+		[]string{"myapp"}, nil,
+		map[string]string{
+			"lerd-php85-fpm.service": "failed", // global FPM unit
+			"lerd-nginx.service":     "failed",
+			"lerd-dns.service":       "failed",
+		},
+		nil,
+	)
+
+	got, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("global units flagged as worker drift: %v", unitNames(got))
+	}
+}
+
+func TestDetect_HyphenatedWorkerName(t *testing.T) {
+	// Custom worker with a hyphen in its name plus a site whose name itself
+	// contains hyphens — make sure the longest-suffix match keeps both.
+	stubEnv(t,
+		[]string{"score-diviner"}, nil,
+		map[string]string{
+			"lerd-emit-events-score-diviner.service": "failed",
+		},
+		nil,
+	)
+
+	got, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(got) != 1 || got[0].Worker != "emit-events" || got[0].Site != "score-diviner" {
+		t.Errorf("split wrong: %+v", got)
+	}
+}
+
+func TestDetect_DeduplicatesAliasedCacheEntries(t *testing.T) {
+	// The siteinfo unit-state cache aliases every .service unit under both
+	// "lerd-foo" and "lerd-foo.service". Detect must emit each unit only once.
+	stubEnv(t,
+		[]string{"myapp"}, nil,
+		map[string]string{
+			"lerd-queue-myapp":         "failed",
+			"lerd-queue-myapp.service": "failed",
+		},
+		nil,
+	)
+
+	got, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("got %d entries, want 1: %+v", len(got), got)
+	}
+}
+
+func TestDetect_OnlyFailedStateMatches(t *testing.T) {
+	stubEnv(t,
+		[]string{"myapp"}, nil,
+		map[string]string{
+			"lerd-queue-myapp.service":    "active",
+			"lerd-schedule-myapp.service": "inactive",
+			"lerd-reverb-myapp.service":   "failed",
+		},
+		nil,
+	)
+
+	got, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if names := unitNames(got); len(names) != 1 || names[0] != "lerd-reverb-myapp" {
+		t.Errorf("got %v, want [lerd-reverb-myapp]", names)
+	}
+}
+
+func TestHealAll_EmitsEventsAndReports(t *testing.T) {
+	healed := []string{}
+	stubEnv(t,
+		[]string{"myapp"}, nil,
+		map[string]string{
+			"lerd-queue-myapp.service":  "failed",
+			"lerd-reverb-myapp.service": "failed",
+		},
+		func(unit string) error {
+			healed = append(healed, unit)
+			return nil
+		},
+	)
+
+	var events []Event
+	report, err := HealAll(func(e Event) { events = append(events, e) })
+	if err != nil {
+		t.Fatalf("HealAll: %v", err)
+	}
+
+	if len(report.Healed) != 2 || len(report.Failed) != 0 {
+		t.Errorf("report: %+v", report)
+	}
+	sort.Strings(healed)
+	if len(healed) != 2 || healed[0] != "lerd-queue-myapp" || healed[1] != "lerd-reverb-myapp" {
+		t.Errorf("heal calls: %v", healed)
+	}
+	// Each worker should produce at least starting + healed; the loop ends
+	// with a single done event.
+	if events[len(events)-1].Phase != "done" {
+		t.Errorf("missing done event; got %+v", events)
+	}
+	var startCount, healCount int
+	for _, e := range events {
+		switch e.Phase {
+		case "starting":
+			startCount++
+		case "healed":
+			healCount++
+		}
+	}
+	if startCount != 2 || healCount != 2 {
+		t.Errorf("events: %d starting, %d healed (want 2 each)", startCount, healCount)
+	}
+}
+
+func TestHealAll_CapturesPerUnitFailures(t *testing.T) {
+	stubEnv(t,
+		[]string{"myapp"}, nil,
+		map[string]string{
+			"lerd-queue-myapp.service":  "failed",
+			"lerd-reverb-myapp.service": "failed",
+		},
+		func(unit string) error {
+			if unit == "lerd-reverb-myapp" {
+				return errors.New("boom")
+			}
+			return nil
+		},
+	)
+
+	report, err := HealAll(nil)
+	if err != nil {
+		t.Fatalf("HealAll: %v", err)
+	}
+	if len(report.Healed) != 1 || report.Healed[0].Unit != "lerd-queue-myapp" {
+		t.Errorf("healed: %+v", report.Healed)
+	}
+	if len(report.Failed) != 1 || report.Failed[0].Worker.Unit != "lerd-reverb-myapp" {
+		t.Errorf("failed: %+v", report.Failed)
+	}
+	if got := Summary(report); got != "Healed 1 worker(s), 1 failed." {
+		t.Errorf("summary = %q", got)
+	}
+}
+
+func TestSummary_NoUnhealthy(t *testing.T) {
+	if got := Summary(Result{}); got != "No unhealthy workers." {
+		t.Errorf("Summary(empty) = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

A worker unit that hits `StartLimitBurst` parks in systemd's `failed` state, and neither `Restart=always` nor launchd will lift it out without an explicit reset. Until now, the only recovery was `systemctl --user reset-failed UNIT && systemctl --user start UNIT` from a shell. This PR turns that into a first-class capability with the same primitive reachable from every surface lerd ships: CLI, dashboard, TUI, and MCP. `lerd status` also gets a heads-up line when any worker is failed.

The heal logic is intentionally surgical: it never touches `.lerd.yaml` and never rewrites the unit file. A failed worker is a runtime condition, not a change of user intent; enable / disable still belongs to `lerd worker add` / `remove` / `start` / `stop` and `lerd init`.

Bundles a separate hermetic-tests fix: `internal/php/versions.go::ListInstalled()` used to write quadlets and run `daemon-reload` against the real user systemd from any test that triggered it, which was the root cause of the worker cascades I kept chasing during development. The first commit fixes it; the regression test pins the read-only contract.

## What it looks like

**CLI**
```sh
lerd worker heal           # scan every site, heal everything in failed
lerd worker heal queue     # heal one worker for the cwd's site
```

**Status**
```
[Workers]
  ...
  whitewaters/queue              FAIL (failed)
    hint: journalctl --user -u lerd-queue-whitewaters -n 20

  3 failed worker(s). Reset and restart with: lerd worker heal
```

**Dashboard**

Sticky bottom banner with backdrop blur, large spinner during heal, top-edge progress bar, `Healing X of Y…` text, session-only dismiss (`×`) that tracks the unhealthy-set signature so a newly failing worker re-surfaces the banner.

**TUI**

`H` keybind, listed under General in `?` help.

**MCP**

`workers_health` (read), `workers_heal` (write, optional `unit` arg for one-shot).

## CPU profile

The dashboard banner is push-driven over the existing WebSocket snapshot pipeline. Cost analysis:

- **Idle tab (no failures, nothing changing):** zero. The watcher tick is gated on `visibleClients > 0` and only publishes on signature change.
- **Active tab, stable state:** one map walk over the existing 3-second-TTL unit-state cache + one string compare every 5s. No subprocess. No file read.
- **State transition (worker fails or recovers):** publishes `KindSites`, the existing snapshot rebuild path runs, the broker fans out the new frame. Same cost as any user-driven `lerd queue start` mutation.

The new `unhealthy_workers` field in the WS frame piggybacks on the same `KindSites` cache slot the sites snapshot already uses, so there is no parallel cache and no parallel poll cadence.

## Layout

- **`internal/workerheal/`** new shared package. `cli` already imports `mcp` (for `lerd mcp:serve`), so the heal primitives can't live in `cli`. Re-exported from `internal/cli/worker_health.go` for compat with existing imports.
- **`internal/cli/worker_heal_cmd.go`** the cobra command, wired into `NewWorkerCmd`.
- **`internal/cli/status.go`** per-failed-worker line + a consolidated heal hint.
- **`internal/ui/server.go`** + **`worker_health_watcher.go`** new endpoints and the 5s gated watcher.
- **`internal/ui/snapshot.go`** + **`ws_broker.go`** + **`ws.go`** new `unhealthy_workers` cache slot and WS field, both riding `KindSites`.
- **`internal/ui/web/`** Svelte store, banner component, App + ws-type wiring, four locales.
- **`internal/tui/model.go`** + **`help.go`** `H` keybind.
- **`internal/mcp/server.go`** two new tools. Manifest ceiling raised 17000 → 17500 to fit them.
- **`internal/siteinfo/unitcache.go`** + **`unitcache_darwin.go`** `AllUnitStates()` accessor; darwin override keeps the watcher a no-op there since `WatchExecWorkers` already covers exec-mode drift on macOS.
- **`docs/usage/worker-heal.md`** + sidebar entry, full surface map and the explicit list of what heal will not do.

## Tests

9 new hermetic tests in `internal/workerheal/workerheal_test.go` covering: paused-site exclusion, non-worker per-site unit skipping (`lerd-fp-*`, `lerd-custom-*`), global unit skipping (`lerd-php85-fpm`, `lerd-nginx`), hyphenated worker/site name splitting, only-failed-state matching, alias-key dedup (the cache stores both `lerd-foo` and `lerd-foo.service`), heal event emission ordering, per-unit failure capture, summary text. Tests stub both `unitStatesFn` and `healFn` so nothing touches the real environment.

The php hermetic-tests fix lands as the first commit with its own regression test (`TestListInstalled_hasNoSideEffects`) pinning the read-only contract.