### PR TITLE
feat(ui): Tinker tab — in-browser PHP REPL with autocomplete and live linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you're a PHP developer on Linux and want frictionless local development — a
 - ⚡ **FrankenPHP runtime** per site as an alternative to shared PHP-FPM, with Laravel Octane and Symfony Runtime worker mode
 - 📦 **Node.js isolation** per project (Node 22, 24)
 - 🖥️ **Built-in Web UI** - 3-pane dashboard to manage sites, services, and logs from a browser
+- 🧪 **Tinker tab** - in-browser PHP REPL per site with autocomplete (project models, composer helpers, PHP built-ins), live `php -l` syntax checking, and a collapsible tree view for `dump()` output. Works on Laravel (`artisan tinker`), Symfony, and any composer-based PHP project
 - 💻 **Terminal dashboard** (`lerd tui`) - btop-style TUI with live status, site detail pane, inline domain and version editing, shell drop-in, log tailing, and filter/sort — the same operations surface as the web UI, for tmux and SSH workflows
 - 🗄️ **One-click services**: MySQL, PostgreSQL, Redis, Meilisearch, RustFS, Mailpit, Stripe Mock, Reverb and more
 - 📋 **Live logs** for PHP-FPM, Queue, Schedule, Reverb, per site

--- a/docs/features/tinker.md
+++ b/docs/features/tinker.md
@@ -1,0 +1,163 @@
+# Tinker tab
+
+Every PHP site in the lerd dashboard has a **Tinker** tab pinned to the bottom-right of the site header, next to **Overview**. It is an in-browser PHP REPL with autocomplete, live syntax checking, and an editor-like output panel: write code, hit Run, see the value of every statement instantly.
+
+Useful for the things you'd otherwise do in `php artisan tinker` or a `bin/console` session: one-off model lookups, data fixes, snippet experiments, regex sanity checks, expression evaluation against a real database.
+
+## How a run works
+
+The Run button POSTs your code to `lerd-ui`, which executes it inside the site's PHP container and returns the captured output. The execution mode is driven by the framework definition's `tinker:` block (see [framework definitions](#framework-defined-repl) below):
+
+- **Framework-defined REPL** — when the active framework declares a `tinker:` block in its YAML and the declared `requires_package` / `requires_file` checks pass, lerd runs the framework's REPL. For Laravel that's `php artisan tinker --execute=...`, so the app is bootstrapped: `User::count()`, `Route::getRoutes()`, `Cache::get('foo')` all just work. The `mode` field in the response is set to the framework name (e.g. `"laravel"`).
+- **Plain `php` fallback** — any site without a satisfied framework REPL (Symfony, vanilla PHP, Laravel without `laravel/tinker` installed). The code is written to a temp script inside the site, with `vendor/autoload.php` auto-required if it exists, and executed via `php {file}`. `mode` is `"php"`.
+
+The active mode is shown as a small badge in the toolbar.
+
+## Framework-defined REPL
+
+Each framework YAML in `lerd-frameworks/frameworks/<name>/<version>.yaml` can declare a `tinker:` block:
+
+```yaml
+# laravel/12.yaml
+tinker:
+  command: ["artisan", "tinker"]   # appended to `php …` inside the container
+  execute_flag: "--execute"        # how to pass user code (omit → pipe via stdin)
+  requires_package: laravel/tinker # vendor/<this> must exist
+  requires_file: artisan           # this path must exist relative to the site
+```
+
+Resolution rules:
+
+1. If `requires_file` is set and the file is missing, the framework's REPL is skipped.
+2. If `requires_package` is set and `vendor/<package>` is missing, the framework's REPL is skipped.
+3. Otherwise, lerd runs `podman exec ... php <Command…>` and either appends `<execute_flag>=<code>` or pipes the code via stdin.
+
+To add Tinker support for another framework, ship a `tinker:` block in its YAML — no Go changes needed. Examples:
+
+```yaml
+# A hypothetical Symfony with psysh installed
+tinker:
+  command: ["vendor/bin/psysh"]
+  requires_package: psy/psysh
+```
+
+```yaml
+# A Drupal-with-drush setup
+tinker:
+  command: ["vendor/bin/drush", "php-eval"]
+  execute_flag: ""    # piped via stdin
+  requires_file: drush.php
+```
+
+## Output rendering
+
+The output panel is styled like a read-only CodeMirror: bordered box, monospace, line-number gutter rendered as CSS pseudo-elements so dragging across results never selects or copies the line numbers.
+
+- **One block per top-level statement.** Backend injects an ASCII `0x1E` separator after each statement, frontend splits on it. Multi-line scripts produce a numbered list of outputs, not one concatenated blob.
+- **Bare expressions auto-dump.** Type `User::count()` (no `dump`, no `echo`) and you see the value. The transformer wraps single-statement bare expressions in `dump(...)` (or `var_dump(...)` if Symfony VarDumper isn't installed). Statements that already produce side effects (`echo`, `return`, `throw`, control flow) are left alone.
+- **Collapsible tree view for objects/arrays.** Symfony VarDumper output is parsed client-side into a tree: classes, arrays, scalars, with click-to-expand/collapse, color-coded scalars, and visibility prefixes (`+public`, `#protected`, `-private`).
+- **Per-block Copy button** appears on hover.
+- **Noise stripped server-side**: `[!] Aliasing 'X' to 'Y'` notices and `// vendor/psy/.../eval()'d code:N` annotations are removed before output is returned.
+
+## Editor
+
+CodeMirror 6 with PHP syntax highlighting, line numbers, bracket matching, undo/redo, line wrapping. Light/dark theme follows the Lerd theme.
+
+### Autocomplete
+
+Tab opens the popup; if it's already open, Tab accepts the highlighted entry. Tab never escapes focus from the editor (so you can keep typing without losing your place).
+
+What's offered, in priority order:
+
+1. **Project models** (boost 10) — classes that look like Eloquent models, Doctrine ORM entities, Pivot, MorphPivot, or `extends Authenticatable`.
+2. **Project classes** (boost 5) — every other class declared in your PSR-4 autoload roots, read from `composer.json`'s `autoload.psr-4` and `autoload-dev.psr-4`. Works for Laravel `app/`, Symfony `src/`, or any custom mapping.
+3. **Composer-loaded global functions** — extracted from `vendor/composer/autoload_files.php`. Picks up Laravel's `collect()`, `dd()`, `dump()`, `tap()`, plus any Symfony / package helpers registered via composer's `files` autoload.
+4. **PHP internal functions** — `get_defined_functions(true)['internal']` for the site's PHP version, ~2,200 entries. Cached per version, so the first symbol fetch pays a ~80 ms PHP exec, subsequent ones are instant.
+5. **Framework hints** — Laravel facades + helpers when `is_laravel`, Symfony framework classes (`Request`, `Response`, `EntityManagerInterface`, `AbstractController`, `Form`, `Command`, …) when `framework === 'symfony'`.
+6. **PHP standard library** — common classes (`DateTime`, `PDO`, `ReflectionClass`, `Closure`, `Generator`, `Stringable`) and functions.
+7. **Buffer variables** — typing `$u` after declaring `$user = ...` suggests `$user`. Source scans the editor for `$varname` tokens.
+8. **Any-word fallback** — words seen anywhere in the buffer.
+
+Context-aware sources kick in for two patterns:
+
+- After `Model::` — Eloquent **static** methods (`find`, `where`, `paginate`, `firstOrCreate`, `count`, …).
+- After `->` — Eloquent / Builder / Collection **instance** methods (`save`, `update`, `pluck`, `each`, `map`, …).
+
+Each entry shows a colored type icon and an uppercase detail label on the right (`MODEL`, `CLASS`, `FACADE`, `HELPER`, `METHOD`, `STATIC`, `FUNCTION`, `PHP FN`, `PHP CLASS`, `SYMFONY`, `VAR`).
+
+### Live syntax checking
+
+Edits trigger `php -l` against the site's PHP container, debounced 600 ms. Results are rendered as inline CodeMirror diagnostics:
+
+- Parse / fatal errors → red gutter dot, red wavy underline, hover tooltip with the message.
+- Warnings / deprecations / notices → amber, same UI.
+
+The PHP version used is the site's own (8.4 features in an 8.4 site won't trip the linter).
+
+### Keyboard
+
+| Shortcut | Action |
+|---|---|
+| `Ctrl+Enter` / `Cmd+Enter` | Run the editor contents |
+| `Tab` | Open autocomplete (or accept selected entry) |
+| `Ctrl+Z` / `Ctrl+Y` | Undo / redo |
+
+### Drafts
+
+The editor contents are saved to `localStorage` under `tinker:{domain}:draft`, so refreshing the page or switching to another site and back doesn't lose what you typed. The active tab itself (`Overview` vs `Tinker`) also persists, under `lerd:siteDetailTab`.
+
+## Toolbar
+
+| Button | What it does |
+|---|---|
+| Mode badge | Shows `tinker` or `php`; tooltip explains which runtime is used. |
+| Duration | Shown after a run, in milliseconds. |
+| `Copy code` | Copies the editor contents to the clipboard. |
+| `Clear` | Wipes both the editor and the output. |
+| `Run` | Executes the code (also bound to Ctrl/Cmd+Enter). |
+
+The output panel itself adds a per-block `Copy` button on hover, for copying just one of the numbered output blocks.
+
+## When the tab is hidden
+
+The Tinker tab is shown for any site that has a `php_version`. It is hidden for static-only sites and custom-container sites without a PHP runtime. Paused sites still get the tab — pausing only removes routing, the shared PHP-FPM container stays up.
+
+## Limits
+
+- Each run has a 30-second hard timeout (`exec.CommandContext`).
+- Request body is capped at 64 KB.
+- Each run is a fresh process. Variables don't persist across runs, this is not a stateful REPL session.
+- Output is captured all at once, not streamed. A long-running script that prints incrementally only shows output after it finishes.
+- ANSI colors are suppressed at the source (`NO_COLOR=1`, `TERM=dumb`) so output renders cleanly.
+
+## Security note
+
+The Tinker tab executes arbitrary PHP inside your site's container with the same access as the site itself: database, filesystem under the site path, every credential in `.env`. Treat it as equivalent to shell access to that container. `lerd-ui` only listens on `127.0.0.1:7073`, so this is bounded to the local machine, but any browser tab open to `http://lerd.localhost` can reach it.
+
+## HTTP API
+
+| Method + Path | Body | Returns |
+|---|---|---|
+| `POST /api/sites/{domain}/tinker` | `{ "code": "..." }` | `{ ok, stdout, stderr, exit_code, duration_ms, mode, error? }` |
+| `POST /api/sites/{domain}/tinker:symbols` | (none) | `{ models: [...], classes: [...], functions: [...] }` |
+| `POST /api/sites/{domain}/tinker:lint` | `{ "code": "..." }` | `{ ok, diagnostics: [{ line, column, message, severity }], error? }` |
+
+Output from `tinker` runs uses ASCII `0x1E` (record separator) between top-level statements; the frontend splits on it. Aliasing notices and psysh source-location annotations are stripped before being returned.
+
+## Implementation map
+
+Backend (Go):
+
+- `internal/cli/tinker.go` — `RunTinker`, the dump-function detector, the multi-statement transformer, `splitTopLevelStatements`, the auto-dump heuristic, output cleanup.
+- `internal/cli/tinker_symbols.go` — `CollectTinkerSymbols`, PSR-4 autoload root resolution, composer autoload-files function harvesting, cached `get_defined_functions()` exec.
+- `internal/cli/tinker_lint.go` — `LintTinkerCode` runs `php -l` and parses the output to diagnostics.
+- `internal/ui/server.go` — `tinker`, `tinker:symbols`, `tinker:lint` cases on the site action handler.
+- Tests: `tinker_test.go`, `tinker_symbols_test.go`, `tinker_lint_test.go`.
+
+Frontend (Svelte 5 + CodeMirror 6):
+
+- `internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte` — editor, autocomplete sources, linter integration, output rendering.
+- `internal/ui/web/src/components/DumpView.svelte` — recursive collapsible tree.
+- `internal/ui/web/src/lib/dump-parser.ts` — parses Symfony VarDumper CLI output into a tree (`+ tests`).
+- `internal/ui/web/src/tabs/sites/SiteDetail.svelte` — host the tabs in the bottom-right of `SiteHeader`.
+- `internal/ui/web/src/stores/sites.ts` — `runTinker`, `lintTinker`, `loadTinkerSymbols` API helpers.

--- a/internal/cli/tinker.go
+++ b/internal/cli/tinker.go
@@ -113,9 +113,12 @@ func RunTinker(ctx context.Context, sitePath, code string) (TinkerResult, error)
 		argv = append([]string{"exec", "-i", "-w", sitePath}, envArgs...)
 		argv = append(argv, container, "php")
 		argv = append(argv, tinkerSpec.Command...)
-		if tinkerSpec.ExecuteFlag != "" {
+		switch {
+		case tinkerSpec.ExecuteFlag != "":
 			argv = append(argv, tinkerSpec.ExecuteFlag+"="+payload)
-		} else {
+		case tinkerSpec.ExecutePositional:
+			argv = append(argv, payload)
+		default:
 			stdinPipe = payload
 		}
 	} else {

--- a/internal/cli/tinker.go
+++ b/internal/cli/tinker.go
@@ -1,0 +1,452 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// psyshEvalLocRe matches the trailing ` // vendor/psy/psysh/.../eval()'d code:N`
+// annotation that Laravel's `dump()` appends when called from psysh, which
+// is source-location noise from inside the REPL itself.
+var psyshEvalLocRe = regexp.MustCompile(` // vendor/psy/psysh/[^\s]+\(\d+\) : eval\(\)'d code:\d+`)
+
+// tinkerAliasNoticeRe matches the `[!] Aliasing 'X' to 'Y' for this Tinker
+// session.` lines that artisan tinker emits whenever a model alias is first
+// used. They're internal REPL chatter, not user output.
+var tinkerAliasNoticeRe = regexp.MustCompile(`(?m)^\[!\] Aliasing '[^']+' to '[^']+' for this Tinker session\.\s*\n?`)
+
+func cleanTinkerOutput(s string) string {
+	// Split on the multi-statement separator first so per-chunk regexes that
+	// rely on `^` (start-of-line) also match notices that landed at the
+	// start of a non-first chunk.
+	chunks := strings.Split(s, TinkerOutputSeparator)
+	for i, c := range chunks {
+		c = psyshEvalLocRe.ReplaceAllString(c, "")
+		c = tinkerAliasNoticeRe.ReplaceAllString(c, "")
+		chunks[i] = c
+	}
+	return strings.Join(chunks, TinkerOutputSeparator)
+}
+
+type TinkerResult struct {
+	Stdout     string `json:"stdout"`
+	Stderr     string `json:"stderr"`
+	ExitCode   int    `json:"exit_code"`
+	DurationMs int64  `json:"duration_ms"`
+	Mode       string `json:"mode"`
+}
+
+// RunTinker evaluates user PHP code inside the site's PHP container and
+// captures stdout/stderr. Mode is driven by the framework definition's
+// `tinker:` block when present, with a plain-`php` fallback. The mode
+// label returned in the response is the framework name (e.g. "laravel")
+// or "php" for the fallback.
+func RunTinker(ctx context.Context, sitePath, code string) (TinkerResult, error) {
+	res := TinkerResult{}
+	if strings.TrimSpace(code) == "" {
+		return res, fmt.Errorf("code is empty")
+	}
+
+	version, err := phpDet.DetectVersion(sitePath)
+	if err != nil {
+		cfg, cfgErr := config.LoadGlobal()
+		if cfgErr != nil {
+			return res, fmt.Errorf("cannot detect PHP version: %w", err)
+		}
+		version = cfg.PHP.DefaultVersion
+	}
+	short := strings.ReplaceAll(version, ".", "")
+	container := "lerd-php" + short + "-fpm"
+
+	if running, _ := podman.ContainerRunning(container); !running {
+		return res, fmt.Errorf("PHP %s FPM container is not running", version)
+	}
+
+	podman.EnsurePathMounted(sitePath, version)
+	ensureServicesForCwd(sitePath)
+
+	tinkerSpec := config.GetTinkerForDir(sitePath)
+	mode := "php"
+	if tinkerSpec != nil {
+		if site, err := config.FindSiteByPath(sitePath); err == nil && site.Framework != "" {
+			mode = site.Framework
+		} else {
+			mode = "tinker"
+		}
+	}
+	res.Mode = mode
+
+	home := os.Getenv("HOME")
+	composerHome := os.Getenv("COMPOSER_HOME")
+	if composerHome == "" {
+		xdgConfig := os.Getenv("XDG_CONFIG_HOME")
+		if xdgConfig == "" {
+			xdgConfig = filepath.Join(home, ".config")
+		}
+		composerHome = filepath.Join(xdgConfig, "composer")
+	}
+
+	dumpFn := detectDumpFunction(sitePath, mode)
+	envArgs := tinkerEnvArgs(sitePath, home, composerHome)
+
+	var argv []string
+	var stdinPipe string
+	if tinkerSpec != nil {
+		// Wrap each top-level statement so its output is delimited by
+		// TinkerOutputSeparator, and auto-dump bare expressions so
+		// `User::count()` shows its value. Frontend splits on the
+		// separator to render one block per statement.
+		payload := transformForMultiStatementWithDump(code, dumpFn)
+		argv = append([]string{"exec", "-i", "-w", sitePath}, envArgs...)
+		argv = append(argv, container, "php")
+		argv = append(argv, tinkerSpec.Command...)
+		if tinkerSpec.ExecuteFlag != "" {
+			argv = append(argv, tinkerSpec.ExecuteFlag+"="+payload)
+		} else {
+			stdinPipe = payload
+		}
+	} else {
+		// Plain PHP fallback: write a temp script, autoload composer,
+		// dump-or-var_dump bare expressions for visible output.
+		payload := transformForMultiStatementWithDump(code, dumpFn)
+		tmpFile, err := writeTinkerScript(sitePath, payload, mode)
+		if err != nil {
+			return res, fmt.Errorf("writing tinker script: %w", err)
+		}
+		defer os.Remove(tmpFile)
+		argv = append([]string{"exec", "-i", "-w", sitePath}, envArgs...)
+		argv = append(argv, container, "php", tmpFile)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, podman.PodmanBin(), argv...)
+	if stdinPipe != "" {
+		cmd.Stdin = strings.NewReader(stdinPipe)
+	}
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	runErr := cmd.Run()
+	res.DurationMs = time.Since(start).Milliseconds()
+	res.Stdout = cleanTinkerOutput(stdout.String())
+	res.Stderr = cleanTinkerOutput(stderr.String())
+
+	if exit, ok := runErr.(*exec.ExitError); ok {
+		res.ExitCode = exit.ExitCode()
+		return res, nil
+	}
+	if runErr != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return res, fmt.Errorf("tinker timed out after %dms", res.DurationMs)
+		}
+		return res, runErr
+	}
+	return res, nil
+}
+
+// tinkerEnvArgs builds the shared `--env KEY=VAL` argv chunks used by
+// every tinker exec invocation: HOME, COMPOSER_HOME, PATH (so vendor/bin
+// shims work inside the container), and TERM/NO_COLOR so dump output is
+// not ANSI-colored.
+func tinkerEnvArgs(sitePath, home, composerHome string) []string {
+	projectVendorBin := filepath.Join(sitePath, "vendor", "bin")
+	composerBin := filepath.Join(composerHome, "vendor", "bin")
+	return []string{
+		"--env", "HOME=" + home,
+		"--env", "COMPOSER_HOME=" + composerHome,
+		"--env", "PATH=" + projectVendorBin + ":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:" + composerBin,
+		"--env", "NO_COLOR=1",
+		"--env", "TERM=dumb",
+	}
+}
+
+// TinkerOutputSeparator is the marker we inject between top-level statements
+// so the frontend can split a single tinker run into one output block per
+// statement. ASCII 0x1e (record separator) — unlikely to appear in user
+// output, easy to escape inside a PHP double-quoted string as `\x1e`.
+const TinkerOutputSeparator = "\x1e"
+
+// transformForMultiStatement keeps the legacy callsite working with the
+// default Laravel `dump()` helper. Tinker mode uses this directly.
+func transformForMultiStatement(code string) string {
+	return transformForMultiStatementWithDump(code, "dump")
+}
+
+// transformForMultiStatementWithDump is the parameterized variant that
+// lets callers pick which dump function to wrap bare expressions with —
+// `dump` for Symfony VarDumper / Laravel, `var_dump` for vanilla PHP.
+func transformForMultiStatementWithDump(code, dumpFn string) string {
+	return transformWithSeparator(code, func(s string) string {
+		return autoDumpLastExpressionWith(s, dumpFn)
+	})
+}
+
+func transformWithSeparator(code string, wrap func(string) string) string {
+	parts := splitTopLevelStatements(code)
+	if len(parts) == 0 {
+		return code
+	}
+	if len(parts) == 1 {
+		return wrap(strings.TrimSpace(code))
+	}
+
+	var sb strings.Builder
+	written := 0
+	for _, p := range parts {
+		body := strings.TrimSpace(p)
+		if body == "" {
+			continue
+		}
+		if written > 0 {
+			sb.WriteString(` echo "\x1e";`)
+		}
+		out := wrap(body)
+		sb.WriteString(out)
+		if !strings.HasSuffix(strings.TrimRight(out, " \t\n"), ";") {
+			sb.WriteString(";")
+		}
+		written++
+	}
+	return sb.String()
+}
+
+// detectDumpFunction picks which PHP function we should wrap bare
+// expressions in to surface their values. Laravel sites always have
+// `dump()` via the framework. Symfony/plain PHP get `dump()` if Symfony
+// VarDumper is in vendor (any Symfony skeleton has it), else
+// `var_dump()` which is always available. Mode "php" means no
+// framework REPL was selected.
+func detectDumpFunction(sitePath, mode string) string {
+	if mode != "php" {
+		return "dump"
+	}
+	if fileExists(filepath.Join(sitePath, "vendor", "symfony", "var-dumper")) {
+		return "dump"
+	}
+	return "var_dump"
+}
+
+// splitTopLevelStatements splits `code` at top-level semicolons, respecting
+// string literals and nested brackets. The returned slice contains each
+// statement's text without the trailing `;`.
+func splitTopLevelStatements(code string) []string {
+	var parts []string
+	var cur strings.Builder
+	depth := 0
+	inSingle, inDouble := false, false
+	for i := 0; i < len(code); i++ {
+		c := code[i]
+		switch {
+		case inSingle:
+			cur.WriteByte(c)
+			if c == '\\' && i+1 < len(code) {
+				cur.WriteByte(code[i+1])
+				i++
+				continue
+			}
+			if c == '\'' {
+				inSingle = false
+			}
+		case inDouble:
+			cur.WriteByte(c)
+			if c == '\\' && i+1 < len(code) {
+				cur.WriteByte(code[i+1])
+				i++
+				continue
+			}
+			if c == '"' {
+				inDouble = false
+			}
+		case c == '\'':
+			inSingle = true
+			cur.WriteByte(c)
+		case c == '"':
+			inDouble = true
+			cur.WriteByte(c)
+		case c == '(' || c == '[' || c == '{':
+			depth++
+			cur.WriteByte(c)
+		case c == ')' || c == ']' || c == '}':
+			if depth > 0 {
+				depth--
+			}
+			cur.WriteByte(c)
+		case c == ';' && depth == 0:
+			parts = append(parts, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	if strings.TrimSpace(cur.String()) != "" {
+		parts = append(parts, cur.String())
+	}
+	return parts
+}
+
+// autoDumpLastExpression wraps the user's code in `dump(...)` when it's a
+// single bare expression, so `User::count()` shows its value at the REPL.
+// See autoDumpLastExpressionWith for the parameterized version.
+func autoDumpLastExpression(code string) string {
+	return autoDumpLastExpressionWith(code, "dump")
+}
+
+// autoDumpLastExpressionWith wraps the user's code in `<dumpFn>(...)` when
+// it's a single bare expression. Falls back to the original unchanged
+// when the code is multi-statement, starts with a control/output keyword,
+// or already calls a known dump function.
+func autoDumpLastExpressionWith(code, dumpFn string) string {
+	trimmed := strings.TrimSpace(code)
+	trimmed = strings.TrimRight(trimmed, ";")
+	trimmed = strings.TrimSpace(trimmed)
+	if trimmed == "" {
+		return code
+	}
+	if hasTopLevelSemicolon(trimmed) {
+		return code
+	}
+	if startsWithNonExprKeyword(trimmed) {
+		return code
+	}
+	if startsWithDumpCall(trimmed) {
+		return code
+	}
+	return dumpFn + "(" + trimmed + ");"
+}
+
+// hasTopLevelSemicolon returns true if `s` contains a `;` outside of any
+// string literal, comment, or matching bracket. A naive check that handles
+// the common single-line REPL case; multi-line blocks with `;` inside
+// strings will fall through to "multi-statement" treatment, which is fine
+// (we just don't auto-wrap).
+func hasTopLevelSemicolon(s string) bool {
+	depth := 0
+	inSingle, inDouble := false, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case inSingle:
+			if c == '\\' && i+1 < len(s) {
+				i++
+				continue
+			}
+			if c == '\'' {
+				inSingle = false
+			}
+		case inDouble:
+			if c == '\\' && i+1 < len(s) {
+				i++
+				continue
+			}
+			if c == '"' {
+				inDouble = false
+			}
+		case c == '\'':
+			inSingle = true
+		case c == '"':
+			inDouble = true
+		case c == '(' || c == '[' || c == '{':
+			depth++
+		case c == ')' || c == ']' || c == '}':
+			if depth > 0 {
+				depth--
+			}
+		case c == ';' && depth == 0:
+			return true
+		}
+	}
+	return false
+}
+
+var nonExprKeywords = []string{
+	"echo", "print", "var_dump", "dump", "dd", "ddd", "return",
+	"throw", "if", "else", "elseif", "while", "do", "for", "foreach",
+	"switch", "function", "class", "interface", "trait", "abstract",
+	"final", "use", "namespace", "include", "require", "include_once",
+	"require_once", "unset", "goto", "global", "static", "yield", "match",
+	"try", "catch", "finally", "declare", "break", "continue",
+}
+
+func startsWithNonExprKeyword(s string) bool {
+	lower := strings.ToLower(s)
+	for _, kw := range nonExprKeywords {
+		if lower == kw {
+			return true
+		}
+		if strings.HasPrefix(lower, kw) {
+			rest := lower[len(kw):]
+			if rest == "" {
+				return true
+			}
+			c := rest[0]
+			if c == ' ' || c == '\t' || c == '\n' || c == '(' || c == '{' || c == ';' {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func startsWithDumpCall(s string) bool {
+	for _, fn := range []string{"dump(", "dd(", "ddd(", "var_dump(", "print_r("} {
+		if strings.HasPrefix(s, fn) {
+			return true
+		}
+	}
+	return false
+}
+
+// writeTinkerScript writes the user's PHP code to a temp file inside the
+// site directory (so it's visible from inside the container). Only used
+// by plain-PHP mode; tinker mode pipes via stdin. If composer's autoload
+// exists, we require it so helpers like Symfony's `dump()` and any
+// project class are available.
+func writeTinkerScript(sitePath, code, mode string) (string, error) {
+	_ = mode
+	buf := make([]byte, 6)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	name := ".lerd-tinker-" + hex.EncodeToString(buf) + ".php"
+	full := filepath.Join(sitePath, name)
+
+	body := strings.TrimLeft(code, " \t\r\n")
+	hasOpenTag := strings.HasPrefix(body, "<?php") || strings.HasPrefix(body, "<?=")
+	if hasOpenTag {
+		// Strip the user's opening tag so we can prepend our own bootstrap.
+		nl := strings.IndexByte(body, '\n')
+		if nl >= 0 {
+			body = body[nl+1:]
+		} else {
+			body = ""
+		}
+	}
+
+	prelude := "<?php\n"
+	if fileExists(filepath.Join(sitePath, "vendor", "autoload.php")) {
+		prelude += "require __DIR__ . '/vendor/autoload.php';\n"
+	}
+
+	body = prelude + body
+	if !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	if err := os.WriteFile(full, []byte(body), 0644); err != nil {
+		return "", err
+	}
+	return full, nil
+}

--- a/internal/cli/tinker_lint.go
+++ b/internal/cli/tinker_lint.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// LintDiagnostic is one issue surfaced by the linter, suitable for the
+// frontend to render as a CodeMirror diagnostic.
+type LintDiagnostic struct {
+	Line     int    `json:"line"`
+	Column   int    `json:"column"`
+	Message  string `json:"message"`
+	Severity string `json:"severity"` // "error" | "warning"
+}
+
+// LintTinkerCode runs `php -l` against the given code in the site's PHP
+// container and parses the output. We pipe the code via stdin (`php -l`
+// reads from stdin when given `-` or no file argument depending on the
+// build, but the most portable is to write the code to a stdin pipe and
+// invoke `php -l /dev/stdin`).
+func LintTinkerCode(ctx context.Context, sitePath, code string) ([]LintDiagnostic, error) {
+	if strings.TrimSpace(code) == "" {
+		return nil, nil
+	}
+
+	version, err := phpDet.DetectVersion(sitePath)
+	if err != nil {
+		cfg, cfgErr := config.LoadGlobal()
+		if cfgErr != nil {
+			return nil, fmt.Errorf("cannot detect PHP version: %w", err)
+		}
+		version = cfg.PHP.DefaultVersion
+	}
+	short := strings.ReplaceAll(version, ".", "")
+	container := "lerd-php" + short + "-fpm"
+	if running, _ := podman.ContainerRunning(container); !running {
+		return nil, fmt.Errorf("PHP %s FPM container is not running", version)
+	}
+
+	body := strings.TrimLeft(code, " \t\r\n")
+	lineOffset := 0
+	if !strings.HasPrefix(body, "<?php") && !strings.HasPrefix(body, "<?=") {
+		body = "<?php\n" + body
+		lineOffset = 1
+	}
+
+	cmd := exec.CommandContext(ctx, podman.PodmanBin(),
+		"exec", "-i", container, "php", "-l", "/dev/stdin",
+	)
+	cmd.Stdin = strings.NewReader(body)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	_ = cmd.Run() // non-zero exit means lint errors; we read stdout/stderr regardless
+
+	combined := stdout.String() + stderr.String()
+	diags := parsePHPLintOutput(combined)
+	for i := range diags {
+		diags[i].Line -= lineOffset
+		if diags[i].Line < 1 {
+			diags[i].Line = 1
+		}
+	}
+	return diags, nil
+}
+
+// phpLintRe matches a single php -l error line. Examples:
+//
+//	"Parse error: syntax error, unexpected token \";\" in /dev/stdin on line 3"
+//	"PHP Parse error:  syntax error, unexpected ... in - on line 5"
+//	"Fatal error: Cannot use ... in /dev/stdin on line 7"
+var phpLintRe = regexp.MustCompile(
+	`(?i)(?:PHP\s+)?(Parse error|Fatal error|Warning|Notice|Deprecated):\s*(.+?)\s+in\s+(?:/dev/stdin|-|.+?)\s+on line\s+(\d+)`,
+)
+
+func parsePHPLintOutput(output string) []LintDiagnostic {
+	var diags []LintDiagnostic
+	for _, m := range phpLintRe.FindAllStringSubmatch(output, -1) {
+		severity := "error"
+		switch strings.ToLower(m[1]) {
+		case "warning", "notice", "deprecated":
+			severity = "warning"
+		}
+		line, _ := strconv.Atoi(m[3])
+		// PHP's line is 1-based and includes our injected "<?php\n", so the
+		// user's first line lives at 1 (we don't subtract).
+		diags = append(diags, LintDiagnostic{
+			Line:     line,
+			Column:   0,
+			Message:  strings.TrimSpace(m[2]),
+			Severity: severity,
+		})
+	}
+	return diags
+}

--- a/internal/cli/tinker_lint_test.go
+++ b/internal/cli/tinker_lint_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import "testing"
+
+func TestParsePHPLintOutput(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		wantLen  int
+		wantLine int
+		wantSev  string
+	}{
+		{
+			"clean output",
+			"No syntax errors detected in /dev/stdin\n",
+			0, 0, "",
+		},
+		{
+			"parse error",
+			`PHP Parse error:  syntax error, unexpected token ";" in /dev/stdin on line 3
+Errors parsing /dev/stdin
+`,
+			1, 3, "error",
+		},
+		{
+			"fatal error",
+			`PHP Fatal error:  Cannot redeclare foo() in /dev/stdin on line 5
+`,
+			1, 5, "error",
+		},
+		{
+			"warning",
+			`PHP Warning:  Use of undefined constant FOO in /dev/stdin on line 2
+`,
+			1, 2, "warning",
+		},
+		{
+			"deprecation downgrades to warning",
+			`PHP Deprecated: foo is deprecated in /dev/stdin on line 7
+`,
+			1, 7, "warning",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parsePHPLintOutput(tc.in)
+			if len(got) != tc.wantLen {
+				t.Fatalf("got %d diagnostics, want %d: %#v", len(got), tc.wantLen, got)
+			}
+			if tc.wantLen == 0 {
+				return
+			}
+			if got[0].Line != tc.wantLine {
+				t.Errorf("line: got %d want %d", got[0].Line, tc.wantLine)
+			}
+			if got[0].Severity != tc.wantSev {
+				t.Errorf("severity: got %s want %s", got[0].Severity, tc.wantSev)
+			}
+		})
+	}
+}

--- a/internal/cli/tinker_symbols.go
+++ b/internal/cli/tinker_symbols.go
@@ -1,0 +1,266 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// TinkerSymbols is the set of project-defined names surfaced to the Tinker
+// editor's autocomplete. Keep it minimal: classes the user is likely to type
+// at the REPL.
+type TinkerSymbols struct {
+	Models    []string `json:"models"`
+	Classes   []string `json:"classes"`
+	Functions []string `json:"functions"`
+}
+
+var (
+	classDeclRe = regexp.MustCompile(`(?m)^(?:final\s+|abstract\s+)?class\s+([A-Z][A-Za-z0-9_]*)\b`)
+	// Heuristic for "this looks like a domain entity worth highlighting":
+	// Laravel Eloquent, Doctrine ORM entities, plain Symfony entities.
+	modelHintRe = regexp.MustCompile(
+		`extends\s+(?:Model|Authenticatable|Pivot|MorphPivot|Eloquent\\Model)\b` +
+			`|Illuminate\\Database\\Eloquent\\Model` +
+			`|Doctrine\\ORM\\Mapping\\Entity` +
+			`|#\[ORM\\Entity` +
+			`|@ORM\\Entity` +
+			`|@Entity\b`,
+	)
+	// Free-standing function declarations (composer files autoload, project
+	// helpers files). PHP function names are case-insensitive at the parser
+	// level but stylistically lowercase, so we look for that.
+	funcDeclRe = regexp.MustCompile(`(?m)^\s*(?:#\[[^\]]+\]\s*)?function\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(`)
+	// composer/autoload_files.php uses `$vendorDir . '/path'` for vendor
+	// helper files and `$baseDir . '/path'` for project helper files.
+	composerVendorPathRe = regexp.MustCompile(`\$vendorDir\s*\.\s*'([^']+)'`)
+	composerBaseDirRe    = regexp.MustCompile(`\$baseDir\s*\.\s*'([^']+)'`)
+)
+
+// internalFnsCache memoizes the PHP-version-keyed list of `get_defined_functions()`
+// internals so we don't pay the container exec cost on every request.
+var internalFnsCache sync.Map // map[string][]string
+
+// CollectTinkerSymbols scans the site for class declarations and flags
+// model/entity-shaped ones. Source roots come from composer.json's
+// `autoload.psr-4` section (works for Laravel `app/`, Symfony `src/`, and
+// any framework that uses standard PSR-4 autoloading), with fallbacks for
+// projects that don't declare PSR-4 paths.
+func CollectTinkerSymbols(sitePath string) TinkerSymbols {
+	models := map[string]struct{}{}
+	classes := map[string]struct{}{}
+
+	roots := resolveAutoloadRoots(sitePath)
+	for _, root := range roots {
+		_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				name := d.Name()
+				if name == "vendor" || name == "node_modules" || strings.HasPrefix(name, ".") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(d.Name(), ".php") {
+				return nil
+			}
+			data, rerr := os.ReadFile(path)
+			if rerr != nil {
+				return nil
+			}
+			body := string(data)
+			match := classDeclRe.FindStringSubmatch(body)
+			if match == nil {
+				return nil
+			}
+			name := match[1]
+			classes[name] = struct{}{}
+			if modelHintRe.MatchString(body) {
+				models[name] = struct{}{}
+			}
+			return nil
+		})
+	}
+
+	functions := map[string]struct{}{}
+	for _, fn := range collectComposerAutoloadFunctions(sitePath) {
+		functions[fn] = struct{}{}
+	}
+	for _, fn := range collectPHPInternalFunctions(sitePath) {
+		functions[fn] = struct{}{}
+	}
+
+	return TinkerSymbols{
+		Models:    sortedKeys(models),
+		Classes:   sortedKeys(classes),
+		Functions: sortedKeys(functions),
+	}
+}
+
+// collectComposerAutoloadFunctions reads composer's generated
+// `vendor/composer/autoload_files.php` (the index of every file Composer
+// loads at boot to register helper functions) and harvests free-standing
+// function declarations from each. This catches things like Laravel's
+// `collect()`, `dd()`, Symfony polyfills, etc.
+func collectComposerAutoloadFunctions(sitePath string) []string {
+	autoload := filepath.Join(sitePath, "vendor", "composer", "autoload_files.php")
+	data, err := os.ReadFile(autoload)
+	if err != nil {
+		return nil
+	}
+	body := string(data)
+
+	fns := map[string]struct{}{}
+	scan := func(absPath string) {
+		// Cap each helper file at 256 KB so a runaway file can't stall us.
+		f, err := os.Open(absPath)
+		if err != nil {
+			return
+		}
+		defer f.Close()
+		buf := make([]byte, 256*1024)
+		n, _ := f.Read(buf)
+		for _, m := range funcDeclRe.FindAllSubmatch(buf[:n], -1) {
+			fns[string(m[1])] = struct{}{}
+		}
+	}
+	for _, m := range composerVendorPathRe.FindAllStringSubmatch(body, -1) {
+		scan(filepath.Join(sitePath, "vendor", m[1]))
+	}
+	for _, m := range composerBaseDirRe.FindAllStringSubmatch(body, -1) {
+		scan(filepath.Join(sitePath, m[1]))
+	}
+
+	out := make([]string, 0, len(fns))
+	for fn := range fns {
+		out = append(out, fn)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// collectPHPInternalFunctions returns the `get_defined_functions(true)['internal']`
+// list for the site's PHP version, cached per version so the container
+// exec only happens once. Returns nil if PHP can't be reached.
+func collectPHPInternalFunctions(sitePath string) []string {
+	version, err := phpDet.DetectVersion(sitePath)
+	if err != nil || version == "" {
+		return nil
+	}
+	if v, ok := internalFnsCache.Load(version); ok {
+		return v.([]string)
+	}
+
+	short := strings.ReplaceAll(version, ".", "")
+	container := "lerd-php" + short + "-fpm"
+	if running, _ := podman.ContainerRunning(container); !running {
+		return nil
+	}
+	cmd := podman.Cmd(
+		"exec", "-i", container,
+		"php", "-r", `echo json_encode(get_defined_functions(true)["internal"] ?? []);`,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil
+	}
+	var fns []string
+	if err := json.Unmarshal(stdout.Bytes(), &fns); err != nil {
+		return nil
+	}
+	sort.Strings(fns)
+	internalFnsCache.Store(version, fns)
+	return fns
+}
+
+// resolveAutoloadRoots returns the directories to scan for project classes.
+// Reads composer.json's `autoload.psr-4` and `autoload-dev.psr-4` mappings
+// when present, falling back to common framework conventions otherwise.
+func resolveAutoloadRoots(sitePath string) []string {
+	seen := map[string]struct{}{}
+	add := func(rel string) {
+		p := filepath.Clean(filepath.Join(sitePath, rel))
+		// Only include paths that exist and are inside the site dir.
+		if !strings.HasPrefix(p, sitePath) {
+			return
+		}
+		if st, err := os.Stat(p); err == nil && st.IsDir() {
+			seen[p] = struct{}{}
+		}
+	}
+
+	// Try composer.json first.
+	composerPath := filepath.Join(sitePath, "composer.json")
+	if data, err := os.ReadFile(composerPath); err == nil {
+		var cfg struct {
+			Autoload struct {
+				PSR4 map[string]any `json:"psr-4"`
+			} `json:"autoload"`
+			AutoloadDev struct {
+				PSR4 map[string]any `json:"psr-4"`
+			} `json:"autoload-dev"`
+		}
+		if err := json.Unmarshal(data, &cfg); err == nil {
+			for _, v := range cfg.Autoload.PSR4 {
+				addPSR4Value(v, add)
+			}
+			for _, v := range cfg.AutoloadDev.PSR4 {
+				addPSR4Value(v, add)
+			}
+		}
+	}
+
+	// Convention fallbacks for projects without composer.json or with a
+	// non-standard autoload section. Cheap to scan an extra dir if it
+	// happens to also be in psr-4.
+	add("app/Models")
+	add("app")
+	add("src")
+
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// addPSR4Value handles the two shapes a psr-4 entry can take:
+//
+//	"App\\": "app/"            (string)
+//	"App\\Tests\\": ["tests"]  (array of strings)
+func addPSR4Value(v any, add func(string)) {
+	switch x := v.(type) {
+	case string:
+		if x != "" {
+			add(x)
+		}
+	case []any:
+		for _, item := range x {
+			if s, ok := item.(string); ok && s != "" {
+				add(s)
+			}
+		}
+	}
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/cli/tinker_symbols_test.go
+++ b/internal/cli/tinker_symbols_test.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func writeTestFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolveAutoloadRoots_ReadsComposerPSR4(t *testing.T) {
+	site := t.TempDir()
+	writeTestFile(t, filepath.Join(site, "composer.json"), `{
+		"autoload": {
+			"psr-4": {
+				"App\\": "src/",
+				"App\\Tests\\": ["tests"]
+			}
+		}
+	}`)
+	if err := os.MkdirAll(filepath.Join(site, "src"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(site, "tests"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveAutoloadRoots(site)
+	if !slices.Contains(got, filepath.Join(site, "src")) {
+		t.Errorf("expected src/ in roots, got %v", got)
+	}
+	if !slices.Contains(got, filepath.Join(site, "tests")) {
+		t.Errorf("expected tests/ in roots, got %v", got)
+	}
+}
+
+func TestResolveAutoloadRoots_LaravelDefaults(t *testing.T) {
+	site := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(site, "app", "Models"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	got := resolveAutoloadRoots(site)
+	if !slices.Contains(got, filepath.Join(site, "app", "Models")) {
+		t.Errorf("expected app/Models in roots, got %v", got)
+	}
+}
+
+func TestCollectTinkerSymbols_FindsSymfonyEntities(t *testing.T) {
+	site := t.TempDir()
+	writeTestFile(t, filepath.Join(site, "composer.json"), `{
+		"autoload": { "psr-4": { "App\\": "src/" } }
+	}`)
+	writeTestFile(t, filepath.Join(site, "src", "Entity", "Product.php"), `<?php
+namespace App\Entity;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Product {
+	private int $id;
+}
+`)
+	writeTestFile(t, filepath.Join(site, "src", "Service", "PriceCalculator.php"), `<?php
+namespace App\Service;
+class PriceCalculator {}
+`)
+
+	syms := CollectTinkerSymbols(site)
+	if !slices.Contains(syms.Models, "Product") {
+		t.Errorf("expected Product flagged as model, got models=%v", syms.Models)
+	}
+	if !slices.Contains(syms.Classes, "PriceCalculator") {
+		t.Errorf("expected PriceCalculator in classes, got %v", syms.Classes)
+	}
+	if slices.Contains(syms.Models, "PriceCalculator") {
+		t.Errorf("PriceCalculator should not be flagged as model")
+	}
+}
+
+func TestCollectTinkerSymbols_FindsLaravelModels(t *testing.T) {
+	site := t.TempDir()
+	writeTestFile(t, filepath.Join(site, "composer.json"), `{
+		"autoload": { "psr-4": { "App\\": "app/" } }
+	}`)
+	writeTestFile(t, filepath.Join(site, "app", "Models", "User.php"), `<?php
+namespace App\Models;
+use Illuminate\Database\Eloquent\Model;
+class User extends Model {}
+`)
+	writeTestFile(t, filepath.Join(site, "app", "Http", "Controllers", "UserController.php"), `<?php
+namespace App\Http\Controllers;
+class UserController {}
+`)
+
+	syms := CollectTinkerSymbols(site)
+	if !slices.Contains(syms.Models, "User") {
+		t.Errorf("expected User in models, got %v", syms.Models)
+	}
+	if !slices.Contains(syms.Classes, "UserController") {
+		t.Errorf("expected UserController in classes, got %v", syms.Classes)
+	}
+}

--- a/internal/cli/tinker_test.go
+++ b/internal/cli/tinker_test.go
@@ -1,0 +1,258 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestTinkerEnvArgs(t *testing.T) {
+	got := tinkerEnvArgs("/home/u/site", "/home/u", "/home/u/.config/composer")
+	want := []string{
+		"--env", "HOME=/home/u",
+		"--env", "COMPOSER_HOME=/home/u/.config/composer",
+		"--env", "PATH=/home/u/site/vendor/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/u/.config/composer/vendor/bin",
+		"--env", "NO_COLOR=1",
+		"--env", "TERM=dumb",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("env args mismatch.\n got:  %v\n want: %v", got, want)
+	}
+}
+
+func TestDetectDumpFunction(t *testing.T) {
+	siteWithVarDumper := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(siteWithVarDumper, "vendor", "symfony", "var-dumper"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	siteBare := t.TempDir()
+
+	cases := []struct {
+		name string
+		path string
+		mode string
+		want string
+	}{
+		{"laravel framework mode", siteBare, "laravel", "dump"},
+		{"plain php with var-dumper", siteWithVarDumper, "php", "dump"},
+		{"plain php without var-dumper", siteBare, "php", "var_dump"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectDumpFunction(tc.path, tc.mode); got != tc.want {
+				t.Errorf("detectDumpFunction(%s, %s) = %q, want %q", tc.path, tc.mode, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteTinkerScript_AddsPhpPrefix(t *testing.T) {
+	dir := t.TempDir()
+	path, err := writeTinkerScript(dir, "echo 1+1;", "php")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+	if !strings.HasPrefix(filepath.Base(path), ".lerd-tinker-") {
+		t.Errorf("temp file name should start with .lerd-tinker-: %s", path)
+	}
+	if filepath.Dir(path) != dir {
+		t.Errorf("temp file should live in site dir, got %s", path)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(body), "<?php\n") {
+		t.Errorf("expected <?php prefix, got: %q", string(body))
+	}
+	if !strings.Contains(string(body), "echo 1+1;") {
+		t.Errorf("expected user code in body, got: %q", string(body))
+	}
+}
+
+func TestWriteTinkerScript_PreservesExistingPhpTag(t *testing.T) {
+	dir := t.TempDir()
+	path, err := writeTinkerScript(dir, "<?php\nphpinfo();", "php")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+	body, _ := os.ReadFile(path)
+	count := strings.Count(string(body), "<?php")
+	if count != 1 {
+		t.Errorf("expected exactly one <?php tag, got %d in: %q", count, string(body))
+	}
+}
+
+func TestCleanTinkerOutput(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			"strips eval location",
+			"1 // vendor/psy/psysh/src/ExecutionClosure.php(41) : eval()'d code:1\n",
+			"1\n",
+		},
+		{
+			"strips aliasing notice",
+			"[!] Aliasing 'User' to 'App\\Models\\User' for this Tinker session.\n1\n",
+			"1\n",
+		},
+		{
+			"strips both",
+			"[!] Aliasing 'Chart' to 'App\\Models\\Chart' for this Tinker session.\n1 // vendor/psy/psysh/src/ExecutionClosure.php(41) : eval()'d code:1\n",
+			"1\n",
+		},
+		{
+			"leaves regular output alone",
+			"hello\nworld\n",
+			"hello\nworld\n",
+		},
+		{
+			"strips multiple alias notices",
+			"[!] Aliasing 'User' to 'App\\Models\\User' for this Tinker session.\n[!] Aliasing 'Chart' to 'App\\Models\\Chart' for this Tinker session.\nresult\n",
+			"result\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cleanTinkerOutput(tc.in)
+			if got != tc.want {
+				t.Errorf("cleanTinkerOutput(%q):\n got:  %q\n want: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSplitTopLevelStatements(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "echo 1+1;", []string{"echo 1+1"}},
+		{"two echoes", "echo 1+1; echo 2+2;", []string{"echo 1+1", " echo 2+2"}},
+		{"semi inside string", `echo "a;b"; echo 2;`, []string{`echo "a;b"`, ` echo 2`}},
+		{"semi inside parens", `if (a()) { x; }`, []string{`if (a()) { x; }`}},
+		{"trailing without semi", "echo 1+1; User::count()", []string{"echo 1+1", " User::count()"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitTopLevelStatements(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d parts %v, want %d %v", len(got), got, len(tc.want), tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("part %d: got %q want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestTransformForMultiStatement(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		wantParts []string
+	}{
+		{
+			"single expression auto-dumps",
+			"User::count()",
+			[]string{"dump(User::count());"},
+		},
+		{
+			"single echo unchanged",
+			"echo 1+1;",
+			[]string{"echo 1+1;"},
+		},
+		{
+			"two echoes get separator",
+			"echo 1+1; echo 2+2;",
+			[]string{`echo 1+1; echo "\x1e";echo 2+2;`},
+		},
+		{
+			"echo then bare expression auto-dumps the expression",
+			"echo 1+1; User::count()",
+			[]string{`echo 1+1; echo "\x1e";dump(User::count());`},
+		},
+		{
+			"every bare expression auto-dumps",
+			"User::count(); Chart::count()",
+			[]string{`dump(User::count()); echo "\x1e";dump(Chart::count());`},
+		},
+		{
+			"assignments stay as-is unless final expression",
+			"$x = 1; $y = 2; $x + $y",
+			[]string{`dump($x = 1); echo "\x1e";dump($y = 2); echo "\x1e";dump($x + $y);`},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := transformForMultiStatement(tc.in)
+			want := tc.wantParts[0]
+			if got != want {
+				t.Errorf("transformForMultiStatement(%q):\n got:  %q\n want: %q", tc.in, got, want)
+			}
+		})
+	}
+}
+
+func TestAutoDumpLastExpression(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare expression no semi", "User::count()", "dump(User::count());"},
+		{"bare expression with semi", "User::count();", "dump(User::count());"},
+		{"trailing whitespace", "  1 + 1  \n", "dump(1 + 1);"},
+		{"already echo", "echo 1+1;", "echo 1+1;"},
+		{"already print", "print 'x';", "print 'x';"},
+		{"already dump", "dump($x);", "dump($x);"},
+		{"already dd", "dd($x);", "dd($x);"},
+		{"return", "return 1;", "return 1;"},
+		{"throw", "throw new Exception('x');", "throw new Exception('x');"},
+		{"multi-statement", "$x = 1; $x", "$x = 1; $x"},
+		{"if block", "if (true) { echo 1; }", "if (true) { echo 1; }"},
+		{"foreach", "foreach ($a as $b) {}", "foreach ($a as $b) {}"},
+		{"semi inside string", "DB::statement('SELECT 1;')", "dump(DB::statement('SELECT 1;'));"},
+		{"semi inside parens", "collect([1])->each(fn($x) => $x)", "dump(collect([1])->each(fn($x) => $x));"},
+		{"empty", "", ""},
+		{"whitespace only", "   ", "   "},
+		{"chained call", "User::query()->where('id', 1)->first()", "dump(User::query()->where('id', 1)->first());"},
+		{"assignment as last expr", "$user = User::find(1)", "dump($user = User::find(1));"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := autoDumpLastExpression(tc.in)
+			if got != tc.want {
+				t.Errorf("autoDumpLastExpression(%q):\n got:  %q\n want: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteTinkerScript_UniqueNames(t *testing.T) {
+	dir := t.TempDir()
+	a, err := writeTinkerScript(dir, "echo 1;", "php")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(a)
+	b, err := writeTinkerScript(dir, "echo 2;", "php")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(b)
+	if a == b {
+		t.Errorf("expected unique temp names, both got %s", a)
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -47,6 +47,10 @@ type Framework struct {
 	// Console is the console command to run (without 'php' prefix).
 	// Example: "artisan", "bin/console"
 	Console string `yaml:"console,omitempty"`
+	// Tinker, when set, defines how to run an interactive PHP REPL for
+	// this framework (the in-browser Tinker tab + `lerd tinker` CLI).
+	// Absent → fall back to plain `php` execution.
+	Tinker *FrameworkTinker `yaml:"tinker,omitempty"`
 	// Create is the scaffold command used by "lerd new". The target directory is appended automatically.
 	// Example: "composer create-project --no-install --no-plugins --no-scripts laravel/laravel"
 	Create string `yaml:"create,omitempty"`
@@ -315,6 +319,12 @@ var laravelFramework = &Framework{
 	Composer: "auto",
 	NPM:      "auto",
 	Console:  "artisan",
+	Tinker: &FrameworkTinker{
+		Command:         []string{"artisan", "tinker"},
+		ExecuteFlag:     "--execute",
+		RequiresPackage: "laravel/tinker",
+		RequiresFile:    "artisan",
+	},
 	Workers: map[string]FrameworkWorker{
 		"queue": {
 			Label:        "Queue Worker",
@@ -1010,6 +1020,61 @@ func SaveFramework(fw *Framework) error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(FrameworksDir(), fw.Name+".yaml"), data, 0644)
+}
+
+// FrameworkTinker describes how to launch a REPL for a framework. Lerd
+// uses these to drive both the Tinker tab in the Web UI and the
+// (future) `lerd tinker` CLI command. The schema is intentionally minimal
+// so frameworks don't need to ship a full executable spec — just the
+// argv (relative to a `php …` invocation) and how user code is fed in.
+type FrameworkTinker struct {
+	// Command is the argv to run, the first item is typically the entry
+	// script (e.g. "artisan", "bin/console psysh"). Each item is passed
+	// verbatim to `podman exec … php <Command…>`.
+	// Example for Laravel: ["artisan", "tinker"]
+	// Example for Symfony+psysh: ["vendor/bin/psysh"]
+	Command []string `yaml:"command"`
+	// ExecuteFlag, when set, is the flag used to pass user code as a
+	// single argument. Example: "--execute" → `--execute=<code>`.
+	// When empty, user code is piped to the process via stdin.
+	ExecuteFlag string `yaml:"execute_flag,omitempty"`
+	// RequiresPackage is the composer package that must be installed in
+	// vendor/ for this REPL to work. Example: "laravel/tinker".
+	// When the package isn't found, lerd falls back to plain PHP.
+	RequiresPackage string `yaml:"requires_package,omitempty"`
+	// RequiresFile, similarly, is a relative path that must exist for
+	// this REPL to be usable (e.g. "artisan"). Defaults to no check.
+	RequiresFile string `yaml:"requires_file,omitempty"`
+}
+
+// GetTinkerForDir returns the framework's Tinker spec when:
+//   - the project belongs to a registered framework,
+//   - the framework definition declares a `tinker` block,
+//   - all `requires_*` checks pass against the project directory.
+//
+// Otherwise returns nil so callers fall back to plain `php`.
+func GetTinkerForDir(projectDir string) *FrameworkTinker {
+	site, err := FindSiteByPath(projectDir)
+	if err != nil || site.Framework == "" {
+		return nil
+	}
+	fw, ok := GetFrameworkForDir(site.Framework, projectDir)
+	if !ok || fw.Tinker == nil || len(fw.Tinker.Command) == 0 {
+		return nil
+	}
+	t := fw.Tinker
+	if t.RequiresFile != "" {
+		if _, err := os.Stat(filepath.Join(projectDir, t.RequiresFile)); err != nil {
+			return nil
+		}
+	}
+	if t.RequiresPackage != "" {
+		pkgPath := filepath.Join(projectDir, "vendor", t.RequiresPackage)
+		if _, err := os.Stat(pkgPath); err != nil {
+			return nil
+		}
+	}
+	return t
 }
 
 // GetConsoleCommand returns the console binary (without the "php" prefix) for

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -1036,8 +1036,16 @@ type FrameworkTinker struct {
 	Command []string `yaml:"command"`
 	// ExecuteFlag, when set, is the flag used to pass user code as a
 	// single argument. Example: "--execute" → `--execute=<code>`.
-	// When empty, user code is piped to the process via stdin.
+	// Mutually exclusive with ExecutePositional.
 	ExecuteFlag string `yaml:"execute_flag,omitempty"`
+	// ExecutePositional, when true, appends user code as a final
+	// positional argv element instead of using a flag. Useful for tools
+	// like `drush php:eval <code>` and `wp eval <code>` that take code
+	// as a bare argument. Mutually exclusive with ExecuteFlag.
+	ExecutePositional bool `yaml:"execute_positional,omitempty"`
+	// When neither ExecuteFlag nor ExecutePositional is set, user code
+	// is piped to the process via stdin.
+	//
 	// RequiresPackage is the composer package that must be installed in
 	// vendor/ for this REPL to work. Example: "laravel/tinker".
 	// When the package isn't found, lerd falls back to plain PHP.

--- a/internal/config/framework_tinker_test.go
+++ b/internal/config/framework_tinker_test.go
@@ -60,6 +60,47 @@ func TestGetTinkerForDir_NoSite(t *testing.T) {
 	}
 }
 
+func TestGetTinkerForDir_RoundtripsPositional(t *testing.T) {
+	// Resolver-level check that ExecutePositional survives load/merge,
+	// using a custom user-defined framework so we don't depend on the
+	// store-fetched Drupal YAML being present in the test env.
+	setDataDir(t)
+	setConfigDir(t)
+
+	site := t.TempDir()
+	if err := os.WriteFile(filepath.Join(site, "marker"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddSite(Site{Name: "myapp", Domains: []string{"myapp.test"}, Path: site, Framework: "drupalish"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(FrameworksDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := `name: drupalish
+public_dir: web
+tinker:
+  command: ["fake-cli", "eval"]
+  execute_positional: true
+  requires_file: marker
+`
+	if err := os.WriteFile(filepath.Join(FrameworksDir(), "drupalish.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := GetTinkerForDir(site)
+	if got == nil {
+		t.Fatal("expected resolver to return tinker spec")
+	}
+	if !got.ExecutePositional {
+		t.Errorf("ExecutePositional did not roundtrip, got %+v", got)
+	}
+	if got.ExecuteFlag != "" {
+		t.Errorf("ExecuteFlag should be empty, got %q", got.ExecuteFlag)
+	}
+}
+
 func TestGetTinkerForDir_NoFrameworkAssigned(t *testing.T) {
 	setDataDir(t)
 	setConfigDir(t)

--- a/internal/config/framework_tinker_test.go
+++ b/internal/config/framework_tinker_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetTinkerForDir_LaravelBuiltin(t *testing.T) {
+	setDataDir(t)
+	setConfigDir(t)
+
+	site := t.TempDir()
+	if err := os.WriteFile(filepath.Join(site, "artisan"), []byte("#!/usr/bin/env php\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(site, "vendor", "laravel", "tinker"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddSite(Site{Name: "myapp", Domains: []string{"myapp.test"}, Path: site, Framework: "laravel"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := GetTinkerForDir(site)
+	if got == nil {
+		t.Fatal("expected tinker spec for Laravel site")
+	}
+	if len(got.Command) == 0 || got.Command[0] != "artisan" {
+		t.Errorf("expected first command to be 'artisan', got %v", got.Command)
+	}
+	if got.ExecuteFlag != "--execute" {
+		t.Errorf("ExecuteFlag = %q, want --execute", got.ExecuteFlag)
+	}
+}
+
+func TestGetTinkerForDir_LaravelMissingTinkerPackage(t *testing.T) {
+	setDataDir(t)
+	setConfigDir(t)
+
+	site := t.TempDir()
+	if err := os.WriteFile(filepath.Join(site, "artisan"), []byte("#!/usr/bin/env php\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// no vendor/laravel/tinker on purpose
+	if err := AddSite(Site{Name: "myapp", Domains: []string{"myapp.test"}, Path: site, Framework: "laravel"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := GetTinkerForDir(site); got != nil {
+		t.Errorf("expected nil (requires_package not satisfied), got %+v", got)
+	}
+}
+
+func TestGetTinkerForDir_NoSite(t *testing.T) {
+	setDataDir(t)
+	setConfigDir(t)
+
+	if got := GetTinkerForDir(t.TempDir()); got != nil {
+		t.Errorf("expected nil for unregistered path, got %+v", got)
+	}
+}
+
+func TestGetTinkerForDir_NoFrameworkAssigned(t *testing.T) {
+	setDataDir(t)
+	setConfigDir(t)
+
+	site := t.TempDir()
+	if err := AddSite(Site{Name: "myapp", Domains: []string{"myapp.test"}, Path: site}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := GetTinkerForDir(site); got != nil {
+		t.Errorf("expected nil for site with no framework, got %+v", got)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -2076,6 +2076,57 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		_ = nginx.Reload()
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
+	case "tinker:symbols":
+		writeJSON(w, cli.CollectTinkerSymbols(site.Path))
+		return
+	case "tinker:lint":
+		var body struct {
+			Code string `json:"code"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&body); err != nil {
+			writeJSON(w, map[string]any{"ok": false, "error": "invalid body: " + err.Error()})
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+		diags, err := cli.LintTinkerCode(ctx, site.Path, body.Code)
+		resp := map[string]any{
+			"ok":          err == nil,
+			"diagnostics": diags,
+		}
+		if err != nil {
+			resp["error"] = err.Error()
+		}
+		writeJSON(w, resp)
+		return
+	case "tinker":
+		var body struct {
+			Code string `json:"code"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&body); err != nil {
+			writeJSON(w, map[string]any{"ok": false, "error": "invalid body: " + err.Error()})
+			return
+		}
+		if strings.TrimSpace(body.Code) == "" {
+			writeJSON(w, map[string]any{"ok": false, "error": "code is empty"})
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		res, err := cli.RunTinker(ctx, site.Path, body.Code)
+		resp := map[string]any{
+			"ok":          err == nil && res.ExitCode == 0,
+			"stdout":      res.Stdout,
+			"stderr":      res.Stderr,
+			"exit_code":   res.ExitCode,
+			"duration_ms": res.DurationMs,
+			"mode":        res.Mode,
+		}
+		if err != nil {
+			resp["error"] = err.Error()
+		}
+		writeJSON(w, resp)
+		return
 	default:
 		// Handle framework worker actions: worker:{name}:start or worker:{name}:stop
 		if strings.HasPrefix(action, "worker:") {

--- a/internal/ui/web/package-lock.json
+++ b/internal/ui/web/package-lock.json
@@ -8,7 +8,14 @@
       "name": "lerd-ui",
       "version": "0.0.0",
       "dependencies": {
-        "@inlang/paraglide-js": "^2.16.1"
+        "@codemirror/autocomplete": "^6.20.1",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-php": "^6.0.2",
+        "@codemirror/lint": "^6.9.5",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.41.1",
+        "@inlang/paraglide-js": "^2.16.1",
+        "codemirror": "^6.0.2"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
@@ -94,6 +101,145 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-php": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
+      "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/php": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
+      "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -749,6 +895,74 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/php": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.5.tgz",
+      "integrity": "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.1.0"
+      }
+    },
     "node_modules/@lix-js/sdk": {
       "version": "0.4.10",
       "resolved": "https://registry.npmjs.org/@lix-js/sdk/-/sdk-0.4.10.tgz",
@@ -772,6 +986,12 @@
       "resolved": "https://registry.npmjs.org/@lix-js/server-protocol-schema/-/server-protocol-schema-0.1.1.tgz",
       "integrity": "sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1869,6 +2089,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1912,6 +2147,12 @@
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -3538,6 +3779,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -4188,6 +4435,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/internal/ui/web/package.json
+++ b/internal/ui/web/package.json
@@ -29,6 +29,13 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "@inlang/paraglide-js": "^2.16.1"
+    "@codemirror/autocomplete": "^6.20.1",
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-php": "^6.0.2",
+    "@codemirror/lint": "^6.9.5",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.41.1",
+    "@inlang/paraglide-js": "^2.16.1",
+    "codemirror": "^6.0.2"
   }
 }

--- a/internal/ui/web/src/components/DumpView.svelte
+++ b/internal/ui/web/src/components/DumpView.svelte
@@ -1,0 +1,102 @@
+<script lang="ts" module>
+  import type { DumpNode } from '$lib/dump-parser';
+  export type { DumpNode };
+</script>
+
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import DumpView from './DumpView.svelte';
+
+  interface Props {
+    node: DumpNode;
+    depth?: number;
+    initiallyOpen?: boolean;
+  }
+  let { node, depth = 0, initiallyOpen = true }: Props = $props();
+
+  // Auto-collapse anything past the second level so deep trees don't blow
+  // up on first render. One-shot initialization, no re-tracking on prop
+  // changes (the user's open/closed state stays sticky).
+  let open = $state(untrack(() => initiallyOpen && depth < 2));
+
+  function visBadge(v: string) {
+    if (v === 'public') return '+';
+    if (v === 'protected') return '#';
+    if (v === 'private') return '-';
+    if (v === 'readonly') return '~';
+    return '';
+  }
+  function visColor(v: string) {
+    if (v === 'public') return 'text-emerald-600 dark:text-emerald-400';
+    if (v === 'protected') return 'text-sky-600 dark:text-sky-400';
+    if (v === 'private') return 'text-rose-600 dark:text-rose-400';
+    if (v === 'readonly') return 'text-amber-600 dark:text-amber-400';
+    return 'text-gray-400';
+  }
+  function scalarColor(t: string) {
+    switch (t) {
+      case 'string': return 'text-emerald-700 dark:text-emerald-300';
+      case 'number': return 'text-violet-700 dark:text-violet-300';
+      case 'bool':   return 'text-amber-700 dark:text-amber-300';
+      case 'null':   return 'text-gray-400 italic';
+      default:       return 'text-gray-700 dark:text-gray-200';
+    }
+  }
+</script>
+
+{#if node.kind === 'scalar'}
+  <span class={scalarColor(node.type)}>{node.value}</span>
+{:else if node.kind === 'array'}
+  {#if node.count === 0}
+    <span class="text-gray-400">[]</span>
+  {:else}
+    <button
+      type="button"
+      class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+      onclick={() => (open = !open)}
+    >
+      <span class="text-[10px] w-3 inline-block">{open ? '▾' : '▸'}</span>
+      <span class="text-violet-600 dark:text-violet-400">array:{node.count}</span>
+      <span>{open ? '[' : '[…]'}</span>
+    </button>
+    {#if open}
+      <div class="ml-4 border-l border-gray-200 dark:border-lerd-border pl-3">
+        {#each node.items as item, i (i)}
+          <div class="flex flex-wrap gap-x-2">
+            <span class="text-gray-400 select-none">{item.key}</span>
+            <span class="text-gray-400">⇒</span>
+            <DumpView node={item.value} depth={depth + 1} {initiallyOpen} />
+          </div>
+        {/each}
+      </div>
+      <span class="text-gray-500">]</span>
+    {/if}
+  {/if}
+{:else}
+  {@const isEmpty = node.props.length === 0}
+  {#if node.ref || isEmpty}
+    <span class="text-sky-700 dark:text-sky-300">{node.class}</span><!--
+    -->{#if node.id !== undefined}<span class="text-gray-400"> &#123;#{node.id}{node.ref && !isEmpty ? ' …' : ''}&#125;</span>{/if}
+  {:else}
+    <button
+      type="button"
+      class="inline-flex items-center gap-1 hover:opacity-80"
+      onclick={() => (open = !open)}
+    >
+      <span class="text-[10px] w-3 inline-block text-gray-500">{open ? '▾' : '▸'}</span>
+      <span class="text-sky-700 dark:text-sky-300">{node.class}</span>
+      {#if node.id !== undefined}<span class="text-gray-400">&#123;#{node.id}{open ? '' : ' …'}&#125;</span>{/if}
+    </button>
+    {#if open}
+      <div class="ml-4 border-l border-gray-200 dark:border-lerd-border pl-3">
+        {#each node.props as prop, i (i)}
+          <div class="flex flex-wrap gap-x-2">
+            <span class="select-none {visColor(prop.visibility)}" title={prop.visibility}>{visBadge(prop.visibility)}</span>
+            <span class="text-gray-700 dark:text-gray-300">{prop.name}:</span>
+            <DumpView node={prop.value} depth={depth + 1} {initiallyOpen} />
+          </div>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+{/if}

--- a/internal/ui/web/src/lib/dump-parser.test.ts
+++ b/internal/ui/web/src/lib/dump-parser.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { parseDump, looksLikeDump } from './dump-parser';
+
+describe('parseDump', () => {
+  it('detects dump prefix', () => {
+    expect(looksLikeDump('array:2 [\n  0 => 1\n]')).toBe(true);
+    expect(looksLikeDump('App\\Models\\User {#42\n  +id: 1\n}')).toBe(true);
+    expect(looksLikeDump('hello world')).toBe(false);
+    expect(looksLikeDump('1\n')).toBe(false);
+  });
+
+  it('parses an empty array', () => {
+    const r = parseDump('[]');
+    expect(r.ok).toBe(true);
+    expect(r.nodes[0]).toEqual({ kind: 'array', count: 0, items: [] });
+  });
+
+  it('parses a flat array', () => {
+    const r = parseDump('array:3 [\n  0 => 1\n  1 => "two"\n  2 => null\n]');
+    expect(r.ok).toBe(true);
+    const a = r.nodes[0];
+    expect(a.kind).toBe('array');
+    if (a.kind !== 'array') return;
+    expect(a.count).toBe(3);
+    expect(a.items).toHaveLength(3);
+    expect(a.items[0]).toEqual({ key: '0', value: { kind: 'scalar', type: 'number', value: '1' } });
+    expect(a.items[1]).toEqual({ key: '1', value: { kind: 'scalar', type: 'string', value: '"two"' } });
+    expect(a.items[2]).toEqual({ key: '2', value: { kind: 'scalar', type: 'null', value: 'null' } });
+  });
+
+  it('parses an object with mixed visibilities', () => {
+    const text = [
+      'App\\Models\\User {#42',
+      '  +id: 1',
+      '  #table: "users"',
+      '  -secret: "x"',
+      '}'
+    ].join('\n');
+    const r = parseDump(text);
+    expect(r.ok).toBe(true);
+    const o = r.nodes[0];
+    expect(o.kind).toBe('object');
+    if (o.kind !== 'object') return;
+    expect(o.class).toBe('App\\Models\\User');
+    expect(o.id).toBe(42);
+    expect(o.props).toHaveLength(3);
+    expect(o.props[0].visibility).toBe('public');
+    expect(o.props[1].visibility).toBe('protected');
+    expect(o.props[2].visibility).toBe('private');
+  });
+
+  it('parses nested object inside array', () => {
+    const text = [
+      'Illuminate\\Support\\Collection {#1',
+      '  #items: array:1 [',
+      '    0 => App\\Models\\User {#2',
+      '      +id: 1',
+      '    }',
+      '  ]',
+      '}'
+    ].join('\n');
+    const r = parseDump(text);
+    expect(r.ok).toBe(true);
+    const root = r.nodes[0];
+    expect(root.kind).toBe('object');
+    if (root.kind !== 'object') return;
+    const items = root.props[0].value;
+    expect(items.kind).toBe('array');
+    if (items.kind !== 'array') return;
+    expect(items.count).toBe(1);
+    const inner = items.items[0].value;
+    expect(inner.kind).toBe('object');
+    if (inner.kind !== 'object') return;
+    expect(inner.class).toBe('App\\Models\\User');
+    expect(inner.id).toBe(2);
+    expect(inner.props[0].name).toBe('id');
+  });
+
+  it('handles inline-closed object (reference)', () => {
+    const r = parseDump('App\\Models\\User {#42}');
+    expect(r.ok).toBe(true);
+    const o = r.nodes[0];
+    expect(o.kind).toBe('object');
+    if (o.kind !== 'object') return;
+    expect(o.ref).toBe(true);
+    expect(o.props).toHaveLength(0);
+  });
+
+  it('returns ok=false on plain text', () => {
+    const r = parseDump('hello world');
+    expect(r.ok).toBe(false);
+  });
+});

--- a/internal/ui/web/src/lib/dump-parser.ts
+++ b/internal/ui/web/src/lib/dump-parser.ts
@@ -1,0 +1,289 @@
+// Parses Symfony VarDumper CLI output (the format produced by Laravel's
+// `dump()`) into a tree we can render with collapsible nodes.
+//
+// The format is line-oriented:
+//   Class\Name {#42
+//     +public_prop: "value"
+//     #protected: array:2 [
+//       0 => "a"
+//       1 => 1
+//     ]
+//   }
+//
+// We don't aim for byte-perfect parsing of every Symfony edge case,
+// only "good enough" for typical tinker output. Anything we can't
+// parse falls back to rendering the original text.
+
+export type ScalarKind = 'string' | 'number' | 'bool' | 'null' | 'other';
+export type Visibility = 'public' | 'protected' | 'private' | 'readonly' | '';
+
+export interface ObjectNode {
+  kind: 'object';
+  class: string;
+  id?: number;
+  ref: boolean;
+  props: Property[];
+}
+export interface ArrayNode {
+  kind: 'array';
+  count: number;
+  items: ArrayItem[];
+}
+export interface ScalarNode {
+  kind: 'scalar';
+  type: ScalarKind;
+  value: string;
+}
+export type DumpNode = ObjectNode | ArrayNode | ScalarNode;
+
+export interface Property {
+  name: string;
+  visibility: Visibility;
+  value: DumpNode;
+}
+export interface ArrayItem {
+  key: string;
+  value: DumpNode;
+}
+
+export interface ParseResult {
+  ok: boolean;
+  nodes: DumpNode[];
+  trailing: string;
+}
+
+const OBJECT_OPEN_RE = /^(?<class>[A-Za-z_\\][\w\\.]*) \{(?:#(?<id>\d+))?\s*$/;
+const OBJECT_INLINE_RE = /^(?<class>[A-Za-z_\\][\w\\.]*) \{(?:#(?<id>\d+))?\s*(?:…|\.\.\.)?\s*\}$/;
+const ARRAY_OPEN_RE = /^array:(?<count>\d+) \[\s*$/;
+const ARRAY_EMPTY_RE = /^(?:array:0 )?\[\]$/;
+const PROP_RE = /^(?<vis>[+#\-~])(?<name>[\w]+):\s*(?<rest>.*)$/;
+const ENTRY_RE = /^(?<key>"[^"]*"|\d+)\s*=>\s*(?<rest>.*)$/;
+
+function classifyScalar(raw: string): ScalarKind {
+  if (raw === 'null') return 'null';
+  if (raw === 'true' || raw === 'false') return 'bool';
+  if (/^-?\d+(\.\d+)?$/.test(raw)) return 'number';
+  if (raw.startsWith('"') && raw.endsWith('"')) return 'string';
+  return 'other';
+}
+
+function isScalarLine(s: string): boolean {
+  if (s === 'null' || s === 'true' || s === 'false') return true;
+  if (/^-?\d+(\.\d+)?$/.test(s)) return true;
+  // String literal — accept anything wrapped in matching quotes (Symfony
+  // doesn't escape `"` inside dumped strings, it appends `... N more chars`
+  // for truncation; we deliberately don't try to validate inner contents).
+  if (s.length >= 2 && s.startsWith('"') && s.endsWith('"')) return true;
+  return false;
+}
+
+function visibilitySymbol(v: string): Visibility {
+  switch (v) {
+    case '+': return 'public';
+    case '#': return 'protected';
+    case '-': return 'private';
+    case '~': return 'readonly';
+    default: return '';
+  }
+}
+
+class Parser {
+  private lines: string[];
+  private idx = 0;
+
+  constructor(text: string) {
+    this.lines = text.replace(/\r\n/g, '\n').split('\n');
+  }
+
+  remaining(): string {
+    return this.lines.slice(this.idx).join('\n');
+  }
+
+  private peek(): string | undefined {
+    return this.lines[this.idx];
+  }
+
+  private advance(): string {
+    return this.lines[this.idx++];
+  }
+
+  // Try to parse one top-level dump value starting at the current index.
+  // Returns null if the current line can't open a dump value.
+  parseValue(): DumpNode | null {
+    // Skip blank lines and comment-like leftover prompts.
+    while (this.peek() !== undefined && this.peek()!.trim() === '') {
+      this.advance();
+    }
+    const line = this.peek();
+    if (line === undefined) return null;
+    const trimmed = line.trim();
+
+    // Inline (single-line) array
+    if (ARRAY_EMPTY_RE.test(trimmed)) {
+      this.advance();
+      return { kind: 'array', count: 0, items: [] };
+    }
+
+    // Inline object: `Class {#42}` or `Class {#42 …}`
+    const inlineObj = trimmed.match(OBJECT_INLINE_RE);
+    if (inlineObj?.groups) {
+      this.advance();
+      return {
+        kind: 'object',
+        class: inlineObj.groups.class,
+        id: inlineObj.groups.id ? Number(inlineObj.groups.id) : undefined,
+        ref: true,
+        props: []
+      };
+    }
+
+    // Multi-line array
+    const arrOpen = trimmed.match(ARRAY_OPEN_RE);
+    if (arrOpen?.groups) {
+      this.advance();
+      const count = Number(arrOpen.groups.count);
+      const items: ArrayItem[] = [];
+      while (this.peek() !== undefined) {
+        const cur = this.peek()!.trim();
+        if (cur === ']') {
+          this.advance();
+          return { kind: 'array', count, items };
+        }
+        const item = this.parseArrayEntry();
+        if (item) items.push(item);
+        else this.advance();
+      }
+      return { kind: 'array', count, items };
+    }
+
+    // Multi-line object
+    const objOpen = trimmed.match(OBJECT_OPEN_RE);
+    if (objOpen?.groups) {
+      this.advance();
+      const props: Property[] = [];
+      while (this.peek() !== undefined) {
+        const cur = this.peek()!.trim();
+        if (cur === '}') {
+          this.advance();
+          return {
+            kind: 'object',
+            class: objOpen.groups.class,
+            id: objOpen.groups.id ? Number(objOpen.groups.id) : undefined,
+            ref: false,
+            props
+          };
+        }
+        const prop = this.parseProperty();
+        if (prop) props.push(prop);
+        else this.advance();
+      }
+      return {
+        kind: 'object',
+        class: objOpen.groups.class,
+        id: objOpen.groups.id ? Number(objOpen.groups.id) : undefined,
+        ref: false,
+        props
+      };
+    }
+
+    // Top-level scalar (e.g. a bare `1`, `"hello"`, `null`). We accept
+    // these so a script with multiple `dump()` calls produces one node
+    // per dumped value, no matter what was dumped.
+    if (isScalarLine(trimmed)) {
+      this.advance();
+      return { kind: 'scalar', type: classifyScalar(trimmed), value: trimmed };
+    }
+
+    return null;
+  }
+
+  private parseProperty(): Property | null {
+    const line = this.peek();
+    if (line === undefined) return null;
+    const m = line.trim().match(PROP_RE);
+    if (!m?.groups) return null;
+    this.advance();
+    const visibility = visibilitySymbol(m.groups.vis);
+    const name = m.groups.name;
+    const rest = m.groups.rest;
+    return { name, visibility, value: this.parseInlineOrComplex(rest) };
+  }
+
+  private parseArrayEntry(): ArrayItem | null {
+    const line = this.peek();
+    if (line === undefined) return null;
+    const m = line.trim().match(ENTRY_RE);
+    if (!m?.groups) return null;
+    this.advance();
+    const rawKey = m.groups.key;
+    const key = rawKey.startsWith('"') ? rawKey.slice(1, -1) : rawKey;
+    const rest = m.groups.rest;
+    return { key, value: this.parseInlineOrComplex(rest) };
+  }
+
+  // Given the text after `: ` (property) or `=> ` (array entry), decide if
+  // it's a scalar that fits on one line, or the start of a nested complex
+  // value whose body continues on subsequent lines.
+  private parseInlineOrComplex(rest: string): DumpNode {
+    const trimmed = rest.trim();
+
+    if (ARRAY_EMPTY_RE.test(trimmed)) {
+      return { kind: 'array', count: 0, items: [] };
+    }
+    const inlineObj = trimmed.match(OBJECT_INLINE_RE);
+    if (inlineObj?.groups) {
+      return {
+        kind: 'object',
+        class: inlineObj.groups.class,
+        id: inlineObj.groups.id ? Number(inlineObj.groups.id) : undefined,
+        ref: true,
+        props: []
+      };
+    }
+
+    // Multi-line array opening on this line: pretend the next iteration
+    // starts at the array body. We need the parser to re-enter at this
+    // line, but we already consumed it. Manufacture a synthetic restart
+    // by pushing the rest back as the current line.
+    const arrOpen = trimmed.match(ARRAY_OPEN_RE);
+    if (arrOpen?.groups) {
+      // Insert a synthetic line; parse, then continue.
+      this.lines.splice(this.idx, 0, trimmed);
+      const v = this.parseValue();
+      if (v) return v;
+    }
+
+    const objOpen = trimmed.match(OBJECT_OPEN_RE);
+    if (objOpen?.groups) {
+      this.lines.splice(this.idx, 0, trimmed);
+      const v = this.parseValue();
+      if (v) return v;
+    }
+
+    // Plain scalar
+    return { kind: 'scalar', type: classifyScalar(trimmed), value: trimmed };
+  }
+}
+
+export function parseDump(text: string): ParseResult {
+  const parser = new Parser(text);
+  const nodes: DumpNode[] = [];
+  // Skip leading blank lines.
+  while (true) {
+    const node = parser.parseValue();
+    if (!node) break;
+    nodes.push(node);
+  }
+  return {
+    ok: nodes.length > 0,
+    nodes,
+    trailing: parser.remaining()
+  };
+}
+
+// Quick check: does this text look like a Symfony var-dumper dump? Used
+// by the UI to decide between tree rendering and plain <pre>.
+export function looksLikeDump(text: string): boolean {
+  const t = text.trimStart();
+  return /^[A-Za-z_\\][\w\\.]* \{(?:#\d+)?/.test(t) || /^array:\d+ \[/.test(t);
+}

--- a/internal/ui/web/src/stores/sites.ts
+++ b/internal/ui/web/src/stores/sites.ts
@@ -154,6 +154,83 @@ export const toggleStripe = (s: Site) =>
 export const toggleWorker = (s: Site, w: FrameworkWorker) =>
   postAction(site(s.domain, 'worker:' + w.name + (w.running ? ':stop' : ':start')));
 
+export type TinkerResponse = {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+  duration_ms: number;
+  mode: 'tinker' | 'php';
+  error?: string;
+};
+
+export type TinkerSymbols = {
+  models: string[];
+  classes: string[];
+  functions: string[];
+};
+
+export type TinkerLintDiagnostic = {
+  line: number;
+  column: number;
+  message: string;
+  severity: 'error' | 'warning';
+};
+
+export type TinkerLintResponse = {
+  ok: boolean;
+  diagnostics: TinkerLintDiagnostic[];
+  error?: string;
+};
+
+export async function lintTinker(domain: string, code: string): Promise<TinkerLintResponse> {
+  try {
+    const res = await apiFetch(site(domain, 'tinker:lint'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code })
+    });
+    return (await res.json()) as TinkerLintResponse;
+  } catch (e) {
+    return {
+      ok: false,
+      diagnostics: [],
+      error: e instanceof Error ? e.message : 'Request failed'
+    };
+  }
+}
+
+export async function loadTinkerSymbols(domain: string): Promise<TinkerSymbols> {
+  try {
+    const res = await apiFetch(site(domain, 'tinker:symbols'), { method: 'POST' });
+    return (await res.json()) as TinkerSymbols;
+  } catch {
+    return { models: [], classes: [], functions: [] };
+  }
+}
+
+export async function runTinker(domain: string, code: string): Promise<TinkerResponse> {
+  try {
+    const res = await apiFetch(site(domain, 'tinker'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code })
+    });
+    const data = (await res.json()) as TinkerResponse;
+    return data;
+  } catch (e) {
+    return {
+      ok: false,
+      stdout: '',
+      stderr: '',
+      exit_code: -1,
+      duration_ms: 0,
+      mode: 'php',
+      error: e instanceof Error ? e.message : 'Request failed'
+    };
+  }
+}
+
 export async function setSiteVersion(s: Site, type: 'php' | 'node', version: string) {
   try {
     const res = await apiFetch(site(s.domain, type) + '?version=' + encodeURIComponent(version), {

--- a/internal/ui/web/src/stores/sites.ts
+++ b/internal/ui/web/src/stores/sites.ts
@@ -200,13 +200,25 @@ export async function lintTinker(domain: string, code: string): Promise<TinkerLi
   }
 }
 
+// Symbol responses are stable for the lifetime of the tab session
+// (project classes, composer helpers, PHP internals don't change while
+// the user is at the editor). Cache per-domain so quick tab switches
+// don't re-trigger the ~80 ms PHP exec on the backend.
+const tinkerSymbolsCache = new Map<string, Promise<TinkerSymbols>>();
+
 export async function loadTinkerSymbols(domain: string): Promise<TinkerSymbols> {
-  try {
-    const res = await apiFetch(site(domain, 'tinker:symbols'), { method: 'POST' });
-    return (await res.json()) as TinkerSymbols;
-  } catch {
-    return { models: [], classes: [], functions: [] };
-  }
+  const cached = tinkerSymbolsCache.get(domain);
+  if (cached) return cached;
+  const p = (async () => {
+    try {
+      const res = await apiFetch(site(domain, 'tinker:symbols'), { method: 'POST' });
+      return (await res.json()) as TinkerSymbols;
+    } catch {
+      return { models: [], classes: [], functions: [] };
+    }
+  })();
+  tinkerSymbolsCache.set(domain, p);
+  return p;
 }
 
 export async function runTinker(domain: string, code: string): Promise<TinkerResponse> {

--- a/internal/ui/web/src/tabs/sites/SiteDetail.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteDetail.svelte
@@ -4,19 +4,59 @@
   import SiteControls from './SiteControls.svelte';
   import SiteLogs from './SiteLogs.svelte';
   import WorktreeList from './WorktreeList.svelte';
+  import SiteTinkerTab from './SiteTinkerTab.svelte';
   import type { Site } from '$stores/sites';
 
   interface Props {
     site: Site;
   }
   let { site }: Props = $props();
+
+  type TabId = 'overview' | 'tinker';
+  const TAB_STORAGE_KEY = 'lerd:siteDetailTab';
+
+  function readStoredTab(): TabId {
+    if (typeof localStorage === 'undefined') return 'overview';
+    const v = localStorage.getItem(TAB_STORAGE_KEY);
+    return v === 'tinker' ? 'tinker' : 'overview';
+  }
+
+  let active = $state<TabId>(readStoredTab());
+  const canTinker = $derived(Boolean(site.php_version));
+
+  $effect(() => {
+    if (active === 'tinker' && !canTinker) active = 'overview';
+  });
+
+  $effect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(TAB_STORAGE_KEY, active);
+    }
+  });
+
+  const tabBtn = (tab: TabId, isActive: boolean) =>
+    'pb-1 text-xs font-medium border-b-2 transition-colors ' +
+    (isActive
+      ? 'border-lerd-red text-lerd-red'
+      : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300');
 </script>
 
-<DetailPanel>
-  <SiteHeader {site} />
-  {#if !site.paused}
-    <SiteControls {site} />
+{#snippet tabs()}
+  <button class={tabBtn('overview', active === 'overview')} onclick={() => (active = 'overview')}>Overview</button>
+  {#if canTinker}
+    <button class={tabBtn('tinker', active === 'tinker')} onclick={() => (active = 'tinker')}>Tinker</button>
   {/if}
-  <WorktreeList {site} />
-  <SiteLogs {site} />
+{/snippet}
+
+<DetailPanel>
+  <SiteHeader {site} {tabs} />
+  {#if active === 'overview'}
+    {#if !site.paused}
+      <SiteControls {site} />
+    {/if}
+    <WorktreeList {site} />
+    <SiteLogs {site} />
+  {:else if active === 'tinker'}
+    <SiteTinkerTab {site} />
+  {/if}
 </DetailPanel>

--- a/internal/ui/web/src/tabs/sites/SiteHeader.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteHeader.svelte
@@ -17,10 +17,13 @@
   import DomainMorePill from './DomainMorePill.svelte';
   import { m } from '../../paraglide/messages.js';
 
+  import type { Snippet } from 'svelte';
+
   interface Props {
     site: Site;
+    tabs?: Snippet;
   }
-  let { site }: Props = $props();
+  let { site, tabs }: Props = $props();
 
   let pauseBusy = $state(false);
   let unlinkBusy = $state(false);
@@ -60,9 +63,9 @@
 
 </script>
 
-<div class="px-3 sm:px-5 py-4 border-b border-gray-100 dark:border-lerd-border shrink-0">
-  <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4">
-    <div>
+<div class="px-3 sm:px-5 pt-4 border-b border-gray-100 dark:border-lerd-border shrink-0">
+  <div class="flex flex-col sm:flex-row sm:items-stretch sm:justify-between gap-3 sm:gap-4">
+    <div class="pb-4">
       <div class="flex items-center gap-2 flex-wrap">
         {#if site.has_favicon}
           <img src={apiBase + '/api/sites/' + site.domain + '/favicon'} class="w-5 h-5 rounded-sm object-contain" loading="lazy" alt="" />
@@ -136,7 +139,8 @@
       <ServiceBadgeRow {site} />
     </div>
 
-    <div class="flex items-center gap-2 shrink-0 flex-wrap">
+    <div class="flex flex-col items-end gap-2 shrink-0 sm:justify-between pb-0">
+    <div class="flex items-center gap-2 flex-wrap justify-end pt-0">
       <button
         onclick={togglePause}
         disabled={pauseBusy}
@@ -171,6 +175,10 @@
           {m.common_terminal()}
         </button>
       {/if}
+    </div>
+    {#if tabs}
+      <div class="flex items-center gap-5 -mb-px">{@render tabs()}</div>
+    {/if}
     </div>
   </div>
 </div>

--- a/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
@@ -298,13 +298,39 @@
     return Array.from(new Set(xs));
   }
 
-  // PHP linter — debounced server-side `php -l` check, with errors and
-  // warnings rendered inline in the editor gutter and as underlines.
+  // PHP linter — debounced server-side `php -l` check. Each invocation
+  // spawns `podman exec lerd-phpXX-fpm php -l`, which is expensive
+  // (~50–100 ms of host CPU per call), so we:
+  //  1) wait 1.5s after typing stops before linting,
+  //  2) memoize on the exact code string so re-runs with no edit reuse
+  //     the previous diagnostics,
+  //  3) cancel in-flight requests when the doc changes again.
+  let lastLintCode = '';
+  let lastLintDiags: Diagnostic[] = [];
+  let lintAbort: AbortController | null = null;
+
   const phpLinter = linter(
     async (view) => {
       const code = view.state.doc.toString();
-      if (!code.trim()) return [];
-      const res = await lintTinker(site.domain, code);
+      if (!code.trim()) {
+        lastLintCode = '';
+        lastLintDiags = [];
+        return [];
+      }
+      if (code === lastLintCode) return lastLintDiags;
+
+      lintAbort?.abort();
+      const ctrl = new AbortController();
+      lintAbort = ctrl;
+
+      let res;
+      try {
+        res = await lintTinker(site.domain, code);
+      } catch {
+        return lastLintDiags;
+      }
+      if (ctrl.signal.aborted) return lastLintDiags;
+
       const out: Diagnostic[] = [];
       for (const d of res.diagnostics ?? []) {
         const ln = Math.max(1, Math.min(d.line, view.state.doc.lines));
@@ -316,9 +342,13 @@
           message: d.message
         });
       }
+      lastLintCode = code;
+      lastLintDiags = out;
       return out;
     },
-    { delay: 600 }
+    // 2.5 s is "you've clearly stopped typing" for normal cadence —
+    // we'd rather miss the occasional check than lint mid-keystroke.
+    { delay: 2500 }
   );
 
   // Buffer variable source: scans the editor for $varname tokens and

--- a/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
@@ -448,12 +448,6 @@
     </div>
     <div class="flex items-center gap-2">
       <button
-        onclick={() => copyText(code)}
-        disabled={!code.trim()}
-        class="text-xs px-2 py-1 rounded border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/5 disabled:opacity-40"
-        title="Copy editor contents to clipboard"
-      >Copy code</button>
-      <button
         onclick={clearAll}
         disabled={!code && !result}
         class="text-xs px-2 py-1 rounded border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/5 disabled:opacity-40"
@@ -472,9 +466,16 @@
 
   <div class="flex-1 flex flex-col md:flex-row min-h-0 gap-3">
     <div
-      class="flex-1 min-h-[160px] md:min-h-0 md:basis-1/2 flex flex-col rounded-lg border border-gray-200 dark:border-lerd-border overflow-hidden bg-gray-50 dark:bg-black/40"
+      class="group flex-1 min-h-[160px] md:min-h-0 md:basis-1/2 flex flex-col rounded-lg border border-gray-200 dark:border-lerd-border overflow-hidden bg-gray-50 dark:bg-black/40 relative"
     >
       <div class="flex-1 min-h-0 overflow-hidden" bind:this={editorContainer}></div>
+      {#if code.trim()}
+        <button
+          onclick={() => copyText(code)}
+          title="Copy editor contents to clipboard"
+          class="absolute top-2 right-2 z-10 opacity-0 group-hover:opacity-100 text-[10px] px-1.5 py-0.5 rounded border border-gray-200 dark:border-lerd-border bg-white/90 dark:bg-lerd-card/90 text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 transition-opacity"
+        >Copy</button>
+      {/if}
     </div>
 
     <div

--- a/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
@@ -1,0 +1,628 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { EditorView, keymap, lineNumbers, highlightActiveLine } from '@codemirror/view';
+  import { EditorState } from '@codemirror/state';
+  import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+  import {
+    autocompletion,
+    completionKeymap,
+    closeBrackets,
+    closeBracketsKeymap,
+    completeAnyWord,
+    startCompletion,
+    acceptCompletion,
+    completionStatus,
+    type CompletionContext,
+    type CompletionResult
+  } from '@codemirror/autocomplete';
+  import { php } from '@codemirror/lang-php';
+  import { linter, lintGutter, type Diagnostic } from '@codemirror/lint';
+  import {
+    runTinker,
+    loadTinkerSymbols,
+    lintTinker,
+    type TinkerResponse,
+    type TinkerSymbols,
+    type Site
+  } from '$stores/sites';
+  import { parseDump, looksLikeDump } from '$lib/dump-parser';
+  import DumpView from '$components/DumpView.svelte';
+
+  interface Props {
+    site: Site;
+  }
+  let { site }: Props = $props();
+
+  const draftKey = $derived(`tinker:${site.domain}:draft`);
+
+  let code = $state('');
+  let running = $state(false);
+  let result = $state<TinkerResponse | null>(null);
+  let editorContainer: HTMLDivElement | undefined = $state();
+  let view: EditorView | undefined;
+  let symbols: TinkerSymbols = { models: [], classes: [], functions: [] };
+
+  // Backend injects \x1e (record separator) between top-level statement
+  // outputs so each `echo`/`dump` becomes its own block in the UI.
+  type OutputBlock =
+    | { kind: 'tree'; nodes: ReturnType<typeof parseDump>['nodes']; trailing: string; raw: string }
+    | { kind: 'error'; type: string; message: string; raw: string }
+    | { kind: 'text'; text: string };
+
+  // psysh emits runtime errors on stdout in the form
+  //   `Error  Call to a member function get() on int.`
+  //   `TypeError  Argument #1 ($x) must be of type int, string given`
+  // even though `ok=true` and `exit_code=0`. Detect them so we can render
+  // with the same red treatment as backend-level errors.
+  const ERROR_RE = /^\s*([A-Z][A-Za-z]+(?:Error|Exception|Throwable))\s{2,}([\s\S]+)$/;
+
+  const stdoutBlocks = $derived.by<OutputBlock[]>(() => {
+    if (!result?.stdout) return [];
+    return result.stdout
+      .split('\x1e')
+      .map((chunk) => chunk.replace(/^\n+|\n+$/g, ''))
+      .filter((chunk) => chunk.length > 0)
+      .map<OutputBlock>((chunk) => {
+        const errMatch = chunk.match(ERROR_RE);
+        if (errMatch) {
+          return {
+            kind: 'error',
+            type: errMatch[1],
+            message: errMatch[2].trim(),
+            raw: chunk
+          };
+        }
+        if (looksLikeDump(chunk)) {
+          const parsed = parseDump(chunk);
+          if (parsed.ok) {
+            return { kind: 'tree', nodes: parsed.nodes, trailing: parsed.trailing, raw: chunk };
+          }
+        }
+        return { kind: 'text', text: chunk };
+      });
+  });
+
+  async function copyText(text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Fall back to a hidden textarea for non-secure contexts.
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.left = '-9999px';
+      document.body.appendChild(ta);
+      ta.select();
+      try { document.execCommand('copy'); } catch (_) { /* ignore */ }
+      document.body.removeChild(ta);
+    }
+  }
+
+  $effect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(draftKey, code);
+    }
+  });
+
+  async function run() {
+    if (running || !code.trim()) return;
+    running = true;
+    result = null;
+    try {
+      result = await runTinker(site.domain, code);
+    } finally {
+      running = false;
+    }
+  }
+
+  function clearAll() {
+    result = null;
+    code = '';
+    if (view) {
+      view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: '' } });
+    }
+  }
+
+
+  $effect(() => {
+    const domain = site.domain;
+    loadTinkerSymbols(domain).then((s) => {
+      if (site.domain === domain) symbols = s;
+    });
+  });
+
+  onMount(() => {
+    if (!editorContainer) return;
+    if (typeof localStorage !== 'undefined') {
+      const saved = localStorage.getItem(draftKey);
+      if (saved) code = saved;
+    }
+    view = new EditorView({
+      parent: editorContainer,
+      state: EditorState.create({
+        doc: code,
+        extensions: [
+          lineNumbers(),
+          highlightActiveLine(),
+          history(),
+          closeBrackets(),
+          lintGutter(),
+          phpLinter,
+          php(),
+          autocompletion({
+            // hintSource:    project + framework + PHP-stdlib + composer fns
+            // variableSource: $vars typed earlier in the buffer
+            // completeAnyWord: any other word seen in the buffer (fallback)
+            override: [hintSource, variableSource, completeAnyWord],
+            activateOnTyping: true,
+            closeOnBlur: true
+          }),
+          keymap.of([
+            { key: 'Mod-Enter', preventDefault: true, run: () => { run(); return true; } },
+            // Tab opens autocomplete; if it's open, accept the selection.
+            // Always consumes the key so focus never tabs out of the editor.
+            {
+              key: 'Tab',
+              preventDefault: true,
+              run: (v) => {
+                if (completionStatus(v.state) === 'active') {
+                  acceptCompletion(v);
+                  return true;
+                }
+                startCompletion(v);
+                return true;
+              }
+            },
+            ...closeBracketsKeymap,
+            ...completionKeymap,
+            ...defaultKeymap,
+            ...historyKeymap
+          ]),
+          EditorView.lineWrapping,
+          EditorView.updateListener.of((u) => {
+            if (u.docChanged) code = u.state.doc.toString();
+          }),
+          EditorView.theme({
+            '&': { height: '100%', fontSize: '12px' },
+            '.cm-scroller': { fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace' },
+            '.cm-content': { padding: '8px 0' }
+          })
+        ]
+      })
+    });
+    return () => view?.destroy();
+  });
+
+  const placeholder = `// Try one of:\n//   echo 1 + 1;\n//   User::count();\n//   collect([1,2,3])->sum();\n`;
+
+  // Laravel facades and helpers — built-ins, always offered on Laravel sites.
+  const laravelFacades = [
+    'Auth', 'Cache', 'Config', 'DB', 'Event', 'Hash', 'Http',
+    'Log', 'Mail', 'Notification', 'Queue', 'Redis', 'Request', 'Response',
+    'Route', 'Schema', 'Session', 'Storage', 'URL', 'Validator', 'View',
+    'Artisan', 'Bus', 'Broadcast', 'Cookie', 'Crypt', 'Date', 'File',
+    'Gate', 'Lang', 'Password', 'Process'
+  ];
+  const laravelHelpers = [
+    'collect', 'now', 'today', 'config', 'env', 'cache', 'logger',
+    'request', 'session', 'auth', 'response', 'redirect', 'route', 'url',
+    'asset', 'optional', 'tap', 'value', 'with', 'data_get', 'data_set',
+    'str', 'dd', 'dump', 'class_basename', 'app', 'resolve', 'broadcast', 'event'
+  ];
+
+  // Eloquent static methods (called as Model::method()).
+  const eloquentStatic = [
+    'all', 'find', 'findOrFail', 'findMany', 'first', 'firstWhere',
+    'firstOrCreate', 'firstOrNew', 'firstOrFail', 'create', 'make',
+    'updateOrCreate', 'where', 'whereIn', 'whereNotIn', 'whereNull',
+    'whereNotNull', 'whereBetween', 'whereDate', 'whereHas', 'whereDoesntHave',
+    'orderBy', 'latest', 'oldest', 'limit', 'take', 'skip', 'offset',
+    'paginate', 'simplePaginate', 'cursor', 'chunk', 'chunkById',
+    'count', 'sum', 'avg', 'min', 'max', 'exists', 'doesntExist',
+    'pluck', 'value', 'toSql', 'with', 'has', 'select', 'distinct',
+    'groupBy', 'having', 'join', 'leftJoin', 'rightJoin', 'union',
+    'truncate', 'destroy', 'query', 'newQuery'
+  ];
+
+  // Common PHP standard library classes/functions, surfaced regardless of
+  // framework. Keeps Tab+autocomplete useful on a fresh project.
+  const phpStdClasses = [
+    'DateTime', 'DateTimeImmutable', 'DateInterval', 'DateTimeZone',
+    'ArrayObject', 'ArrayIterator', 'SplObjectStorage', 'SplFileObject',
+    'Closure', 'Generator', 'Iterator', 'IteratorAggregate', 'Countable',
+    'Exception', 'Error', 'TypeError', 'ValueError', 'RuntimeException',
+    'InvalidArgumentException', 'LogicException', 'PDO', 'PDOStatement',
+    'ReflectionClass', 'ReflectionMethod', 'ReflectionFunction',
+    'ReflectionProperty', 'ReflectionParameter', 'WeakMap', 'WeakReference',
+    'Stringable', 'JsonSerializable'
+  ];
+  const phpStdFunctions = [
+    'json_encode', 'json_decode', 'array_map', 'array_filter', 'array_reduce',
+    'array_keys', 'array_values', 'array_merge', 'array_combine', 'array_unique',
+    'array_diff', 'array_intersect', 'count', 'in_array', 'sort', 'asort',
+    'ksort', 'usort', 'implode', 'explode', 'strpos', 'str_replace',
+    'str_contains', 'str_starts_with', 'str_ends_with', 'sprintf', 'printf',
+    'preg_match', 'preg_match_all', 'preg_replace', 'preg_split',
+    'file_get_contents', 'file_put_contents', 'file_exists', 'is_file',
+    'is_dir', 'glob', 'fopen', 'fclose', 'fread', 'fwrite',
+    'date', 'time', 'mktime', 'microtime', 'strtotime',
+    'var_dump', 'print_r', 'var_export', 'get_class', 'get_object_vars',
+    'method_exists', 'property_exists', 'is_array', 'is_string', 'is_numeric',
+    'is_object', 'is_null', 'isset', 'empty', 'array_key_exists'
+  ];
+
+  // Symfony-flavored hints when we detect a Symfony app. Things people
+  // actually type at the REPL when poking at Symfony bundles.
+  const symfonyHints = [
+    // HTTP Foundation
+    'Request', 'Response', 'JsonResponse', 'RedirectResponse', 'StreamedResponse',
+    'BinaryFileResponse', 'Cookie', 'HeaderBag', 'ParameterBag', 'Session',
+    // Kernel / Container
+    'Kernel', 'KernelInterface', 'ContainerInterface', 'ContainerBuilder',
+    // Doctrine
+    'EntityManager', 'EntityManagerInterface', 'EntityRepository', 'QueryBuilder',
+    'Query', 'Connection', 'Schema', 'AbstractMigration',
+    // Routing / Annotations / Attributes
+    'Route', 'AbstractController', 'Controller', 'Security',
+    // DI helpers
+    'AutowireServiceLocator', 'TaggedIterator', 'TaggedLocator',
+    // Event / Validation / Form
+    'Event', 'EventDispatcher', 'EventSubscriberInterface',
+    'Validator', 'ValidatorBuilder', 'Constraint', 'NotBlank', 'NotNull',
+    'Form', 'FormBuilder', 'FormType', 'AbstractType',
+    // Console
+    'Command', 'InputInterface', 'OutputInterface', 'SymfonyStyle',
+    // Misc
+    'Filesystem', 'Finder', 'Process', 'Uuid', 'Ulid'
+  ];
+
+  // Eloquent / Builder / Collection instance methods (called as $x->method()).
+  const eloquentInstance = [
+    'save', 'update', 'delete', 'forceDelete', 'restore', 'fresh', 'refresh',
+    'replicate', 'touch', 'push', 'fill', 'forceFill', 'getAttribute',
+    'setAttribute', 'getAttributes', 'getOriginal', 'getDirty', 'isDirty',
+    'wasChanged', 'toArray', 'toJson', 'load', 'loadMissing', 'loadCount',
+    'relationLoaded', 'relationsToArray', 'attributesToArray',
+    'where', 'whereIn', 'orWhere', 'orderBy', 'first', 'firstOrFail',
+    'get', 'find', 'count', 'sum', 'avg', 'min', 'max', 'pluck', 'paginate',
+    'with', 'has', 'whereHas', 'select', 'limit', 'take', 'skip',
+    'each', 'map', 'filter', 'reduce', 'reject', 'pipe', 'tap',
+    'pluck', 'sort', 'sortBy', 'sortByDesc', 'groupBy', 'keyBy',
+    'unique', 'values', 'keys', 'flatten', 'flatMap', 'collapse',
+    'merge', 'concat', 'diff', 'intersect', 'only', 'except',
+    'contains', 'every', 'some', 'isEmpty', 'isNotEmpty',
+    'sum', 'avg', 'min', 'max', 'count', 'reverse', 'shuffle', 'random'
+  ];
+
+  function uniq<T>(xs: T[]): T[] {
+    return Array.from(new Set(xs));
+  }
+
+  // PHP linter — debounced server-side `php -l` check, with errors and
+  // warnings rendered inline in the editor gutter and as underlines.
+  const phpLinter = linter(
+    async (view) => {
+      const code = view.state.doc.toString();
+      if (!code.trim()) return [];
+      const res = await lintTinker(site.domain, code);
+      const out: Diagnostic[] = [];
+      for (const d of res.diagnostics ?? []) {
+        const ln = Math.max(1, Math.min(d.line, view.state.doc.lines));
+        const lineObj = view.state.doc.line(ln);
+        out.push({
+          from: lineObj.from,
+          to: lineObj.to,
+          severity: d.severity === 'error' ? 'error' : 'warning',
+          message: d.message
+        });
+      }
+      return out;
+    },
+    { delay: 600 }
+  );
+
+  // Buffer variable source: scans the editor for $varname tokens and
+  // suggests them when the user types `$…`. Lets you do `$user = ...;`
+  // then `$u` and get `$user` back.
+  function variableSource(ctx: CompletionContext): CompletionResult | null {
+    const word = ctx.matchBefore(/\$\w*/);
+    if (!word || (word.from === word.to && !ctx.explicit)) return null;
+
+    const text = ctx.state.doc.toString();
+    const names = new Set<string>();
+    const re = /\$([A-Za-z_]\w*)/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) names.add(m[1]);
+
+    const cur = word.text.slice(1);
+    const opts = Array.from(names)
+      .filter((n) => n !== cur)
+      .sort()
+      .map((name) => ({ label: '$' + name, type: 'variable', detail: 'var' }));
+    if (opts.length === 0) return null;
+    return { from: word.from, options: opts, validFor: /^\$\w*$/ };
+  }
+
+  type Hint = { label: string; type?: string; detail?: string; boost?: number };
+
+  function hintSource(ctx: CompletionContext): CompletionResult | null {
+    const before = ctx.state.sliceDoc(Math.max(0, ctx.pos - 200), ctx.pos);
+
+    // After `Model::` — offer Eloquent static methods.
+    const staticCall = before.match(/([A-Z][A-Za-z0-9_]*)::([A-Za-z_]\w*)?$/);
+    if (staticCall) {
+      const word = ctx.matchBefore(/[A-Za-z_]\w*/);
+      const from = word ? word.from : ctx.pos;
+      return {
+        from,
+        options: eloquentStatic.map<Hint>((label) => ({ label, type: 'method', detail: 'static' })),
+        validFor: /^\w*$/
+      };
+    }
+
+    // After `->` — offer Eloquent instance / collection methods.
+    const arrowCall = before.match(/->([A-Za-z_]\w*)?$/);
+    if (arrowCall) {
+      const word = ctx.matchBefore(/[A-Za-z_]\w*/);
+      const from = word ? word.from : ctx.pos;
+      return {
+        from,
+        options: uniq(eloquentInstance).map<Hint>((label) => ({ label, type: 'method', detail: 'method' })),
+        validFor: /^\w*$/
+      };
+    }
+
+    // Plain identifier context — offer project models/classes for any
+    // composer-based project, plus framework hints + PHP standard library
+    // + composer-loaded global functions + project-defined functions.
+    const word = ctx.matchBefore(/[A-Za-z_]\w*/);
+    if (!word || (word.from === word.to && !ctx.explicit)) return null;
+    const isSymfony = site.framework === 'symfony';
+    const opts: Hint[] = [];
+    for (const m of symbols.models) opts.push({ label: m, type: 'class', detail: 'model', boost: 10 });
+    for (const c of symbols.classes) {
+      if (!symbols.models.includes(c)) opts.push({ label: c, type: 'class', detail: 'class', boost: 5 });
+    }
+    for (const f of symbols.functions) {
+      opts.push({ label: f, type: 'function', detail: 'function', boost: 1 });
+    }
+    if (site.is_laravel) {
+      for (const f of laravelFacades) opts.push({ label: f, type: 'class', detail: 'facade' });
+      for (const h of laravelHelpers) opts.push({ label: h, type: 'function', detail: 'helper' });
+    }
+    if (isSymfony) {
+      for (const s of symfonyHints) opts.push({ label: s, type: 'class', detail: 'symfony' });
+    }
+    for (const c of phpStdClasses) opts.push({ label: c, type: 'class', detail: 'php class' });
+    for (const f of phpStdFunctions) opts.push({ label: f, type: 'function', detail: 'php fn' });
+    if (opts.length === 0) return null;
+    return { from: word.from, options: opts, validFor: /^\w*$/ };
+  }
+</script>
+
+<div class="flex-1 flex flex-col min-h-0 overflow-hidden p-3 sm:p-5 gap-3">
+  <div class="flex items-center justify-between">
+    <div class="flex items-center gap-2">
+      <span
+        class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-gray-200 dark:border-lerd-border text-gray-500 dark:text-gray-400"
+        title={result?.mode === 'tinker' ? 'Bootstraps Laravel via artisan tinker' : 'Plain PHP runtime'}
+      >
+        {result?.mode ?? (site.is_laravel ? 'tinker' : 'php')}
+      </span>
+      {#if result}
+        <span class="text-[10px] text-gray-400">{result.duration_ms} ms</span>
+      {/if}
+    </div>
+    <div class="flex items-center gap-2">
+      <button
+        onclick={() => copyText(code)}
+        disabled={!code.trim()}
+        class="text-xs px-2 py-1 rounded border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/5 disabled:opacity-40"
+        title="Copy editor contents to clipboard"
+      >Copy code</button>
+      <button
+        onclick={clearAll}
+        disabled={!code && !result}
+        class="text-xs px-2 py-1 rounded border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/5 disabled:opacity-40"
+        title="Clear editor and output"
+      >Clear</button>
+      <button
+        onclick={run}
+        disabled={running || !code.trim()}
+        class="text-xs px-3 py-1 rounded bg-lerd-red hover:bg-lerd-redhov text-white disabled:opacity-40 transition-colors"
+        title="Run (Ctrl+Enter)"
+      >
+        {running ? 'Running…' : 'Run'}
+      </button>
+    </div>
+  </div>
+
+  <div class="flex-1 flex flex-col md:flex-row min-h-0 gap-3">
+    <div
+      class="flex-1 min-h-[160px] md:min-h-0 md:basis-1/2 flex flex-col rounded-lg border border-gray-200 dark:border-lerd-border overflow-hidden bg-gray-50 dark:bg-black/40"
+    >
+      <div class="flex-1 min-h-0 overflow-hidden" bind:this={editorContainer}></div>
+    </div>
+
+    <div
+      class="flex-1 min-h-[120px] md:min-h-0 md:basis-1/2 flex flex-col overflow-y-auto rounded-lg border border-gray-200 dark:border-lerd-border bg-gray-50 dark:bg-black/40 tinker-output"
+    >
+      {#if !result && running}
+        <p class="text-xs text-gray-400">Running…</p>
+      {:else if !result}
+        <p class="text-[11px] text-gray-400 dark:text-gray-500 font-mono whitespace-pre-line">{placeholder}</p>
+      {:else}
+        {#if result.error}
+          <div class="output-row" data-line="!">
+            <div class="output-content text-red-700 dark:text-red-300">
+              <pre class="whitespace-pre-wrap">{result.error}</pre>
+            </div>
+          </div>
+        {/if}
+        {#each stdoutBlocks as block, i (i)}
+          <div class="output-row group" data-line={i + 1}>
+            <div class="output-content">
+              {#if block.kind === 'tree'}
+                {#each block.nodes as node, j (j)}
+                  <div class="mb-1 last:mb-0"><DumpView {node} /></div>
+                {/each}
+                {#if block.trailing.trim()}
+                  <pre class="whitespace-pre-wrap text-gray-700 dark:text-gray-300">{block.trailing}</pre>
+                {/if}
+              {:else if block.kind === 'error'}
+                <div class="flex items-start gap-2">
+                  <span class="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 shrink-0">{block.type}</span>
+                  <pre class="whitespace-pre-wrap text-red-700 dark:text-red-300">{block.message}</pre>
+                </div>
+              {:else}
+                <pre class="whitespace-pre-wrap">{block.text}</pre>
+              {/if}
+            </div>
+            <button
+              onclick={() =>
+                copyText(
+                  block.kind === 'tree' ? block.raw :
+                  block.kind === 'error' ? block.raw : block.text
+                )}
+              title="Copy this output"
+              class="output-copy opacity-0 group-hover:opacity-100 text-[10px] px-1.5 py-0.5 rounded border border-gray-200 dark:border-lerd-border text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 transition-opacity shrink-0"
+            >Copy</button>
+          </div>
+        {/each}
+        {#if result.stderr}
+          <div class="output-row" data-line="e">
+            <div class="output-content text-amber-700 dark:text-amber-300">
+              <pre class="whitespace-pre-wrap">{result.stderr}</pre>
+            </div>
+          </div>
+        {/if}
+        {#if stdoutBlocks.length === 0 && !result.stderr && !result.error}
+          <div class="output-row" data-line="·">
+            <div class="output-content text-gray-400">(no output)</div>
+          </div>
+        {/if}
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  /* CodeMirror autocomplete tooltip is portaled to <body>, so component
+     scoping doesn't reach it. Use :global() and follow the .dark class on
+     <html> that ThemeSwitcher toggles. */
+  :global(.cm-tooltip.cm-tooltip-autocomplete) {
+    border: 1px solid #e5e7eb;
+    background-color: #ffffff;
+    color: #111827;
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12px;
+  }
+  :global(.cm-tooltip.cm-tooltip-autocomplete > ul > li) {
+    padding: 2px 8px;
+    color: #111827;
+  }
+  :global(.cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected]) {
+    background-color: #ff2d20;
+    color: #ffffff;
+  }
+  :global(.cm-tooltip.cm-tooltip-autocomplete > ul > li) {
+    display: flex !important;
+    align-items: center;
+    gap: 6px;
+  }
+  :global(.cm-completionIcon) {
+    color: #6b7280;
+    opacity: 0.85;
+    width: 1em;
+    flex-shrink: 0;
+  }
+  :global(.cm-completionLabel) {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  :global(.cm-completionDetail) {
+    color: #6b7280;
+    font-style: normal;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-left: auto;
+    padding-left: 12px;
+    flex-shrink: 0;
+  }
+  /* Type-specific icon coloring. CodeMirror sets cm-completionIcon-{type} */
+  :global(.cm-completionIcon-class) { color: #0ea5e9; }
+  :global(.cm-completionIcon-method) { color: #8b5cf6; }
+  :global(.cm-completionIcon-function) { color: #10b981; }
+  :global(.cm-completionIcon-variable) { color: #f59e0b; }
+  :global(.cm-completionIcon-property) { color: #ec4899; }
+
+  :global(html.dark .cm-tooltip.cm-tooltip-autocomplete) {
+    border: 1px solid #262626;
+    background-color: #161616;
+    color: #e5e7eb;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.5);
+  }
+  :global(html.dark .cm-tooltip.cm-tooltip-autocomplete > ul > li) {
+    color: #e5e7eb;
+  }
+  :global(html.dark .cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected]) {
+    background-color: #ff2d20;
+    color: #ffffff;
+  }
+  :global(html.dark .cm-completionIcon) {
+    color: #9ca3af;
+  }
+  :global(html.dark .cm-completionDetail) {
+    color: #9ca3af;
+  }
+  /* Output panel — visually mirrors the CodeMirror editor on the left:
+     bordered box, monospace, line-number gutter that the user can't
+     mouse-select or copy. Numbers come from `data-line` via `::before`,
+     so they're CSS-generated content (excluded from text selection in
+     all modern browsers). */
+  .tinker-output {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+  }
+  .tinker-output :global(.output-row) {
+    display: flex;
+    align-items: flex-start;
+    padding: 2px 8px 2px 0;
+    position: relative;
+  }
+  .tinker-output :global(.output-row::before) {
+    content: attr(data-line);
+    flex-shrink: 0;
+    width: 32px;
+    padding-right: 8px;
+    text-align: right;
+    color: #9ca3af;
+    font-size: 11px;
+    user-select: none;
+    -webkit-user-select: none;
+    pointer-events: none;
+  }
+  :global(html.dark) .tinker-output :global(.output-row::before) {
+    color: #4b5563;
+  }
+  .tinker-output :global(.output-content) {
+    flex: 1;
+    min-width: 0;
+    padding-left: 8px;
+  }
+  .tinker-output :global(.output-copy) {
+    margin-left: 8px;
+  }
+
+  :global(html.dark .cm-completionIcon-class) { color: #38bdf8; }
+  :global(html.dark .cm-completionIcon-method) { color: #a78bfa; }
+  :global(html.dark .cm-completionIcon-function) { color: #34d399; }
+  :global(html.dark .cm-completionIcon-variable) { color: #fbbf24; }
+  :global(html.dark .cm-completionIcon-property) { color: #f472b6; }
+</style>

--- a/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
@@ -346,9 +346,12 @@
       lastLintDiags = out;
       return out;
     },
-    // 2.5 s is "you've clearly stopped typing" for normal cadence —
-    // we'd rather miss the occasional check than lint mid-keystroke.
-    { delay: 2500 }
+    // CodeMirror's linter debounces by `delay`: it waits this many ms
+    // after the LAST edit before firing. Combined with the memoize
+    // above (return cached if the buffer didn't change since last
+    // lint), we get exactly one fire at the end of a typing burst,
+    // skipped entirely on no-op refreshes.
+    { delay: 600 }
   );
 
   // Buffer variable source: scans the editor for $varname tokens and

--- a/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
@@ -433,7 +433,7 @@
   }
 </script>
 
-<div class="flex-1 flex flex-col min-h-0 overflow-hidden p-3 sm:p-5 gap-3">
+<div class="flex-1 flex flex-col min-h-0 overflow-hidden pt-4 px-3 sm:px-5 pb-3 sm:pb-5 gap-3">
   <div class="flex items-center justify-between">
     <div class="flex items-center gap-2">
       <span

--- a/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
@@ -478,7 +478,7 @@
     </div>
 
     <div
-      class="flex-1 min-h-[120px] md:min-h-0 md:basis-1/2 flex flex-col overflow-y-auto rounded-lg border border-gray-200 dark:border-lerd-border bg-gray-50 dark:bg-black/40 tinker-output"
+      class="flex-1 min-h-[120px] md:min-h-0 md:basis-1/2 flex flex-col overflow-y-auto rounded-lg border border-gray-200 dark:border-lerd-border bg-gray-50 dark:bg-black/40 tinker-output py-2"
     >
       {#if !result && running}
         <p class="text-xs text-gray-400">Running…</p>

--- a/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte
@@ -613,6 +613,22 @@
   :global(html.dark .cm-completionDetail) {
     color: #9ca3af;
   }
+  /* CodeMirror's default gutter is white-on-light. Override for dark
+     mode (lerd-card background, muted slate text) so the line numbers
+     blend with the rest of the dashboard. */
+  :global(html.dark .cm-gutters) {
+    background-color: #161616;
+    border-right: 1px solid #262626;
+    color: #6b7280;
+  }
+  :global(html.dark .cm-lineNumbers .cm-gutterElement) {
+    color: #6b7280;
+  }
+  :global(html.dark .cm-activeLineGutter) {
+    background-color: rgba(255, 255, 255, 0.04);
+    color: #d1d5db;
+  }
+
   /* Output panel — visually mirrors the CodeMirror editor on the left:
      bordered box, monospace, line-number gutter that the user can't
      mouse-select or copy. Numbers come from `data-line` via `::before`,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
       - Queue Workers: usage/queue-workers.md
   - Features:
       - Web UI: features/web-ui.md
+      - Tinker tab: features/tinker.md
       - System Tray: features/system-tray.md
       - HTTPS / TLS: features/https.md
       - Git Worktrees: features/git-worktrees.md


### PR DESCRIPTION
## Summary

Adds a Tinker tab to every PHP site detail page in the lerd dashboard. It is a small in-browser PHP REPL: type code, hit Run, see the value of every statement instantly, the same things you'd otherwise do with `php artisan tinker` or `bin/console` in a terminal. Works on Laravel out of the box, falls back to plain PHP for Symfony and any other composer project.

## What you get

- CodeMirror 6 editor with PHP highlighting, undo/redo, bracket matching, line wrapping
- Tab opens autocomplete and never escapes focus from the editor; if the popup is open Tab accepts the highlighted entry
- Autocomplete sources, in priority order: project models (boost 10), project classes from PSR-4 autoload roots, composer-loaded helper functions extracted from `vendor/composer/autoload_files.php`, PHP internal functions via `get_defined_functions(true)['internal']` cached per PHP version, framework hints (Laravel facades and helpers when `is_laravel`, Symfony classes when `framework === 'symfony'`), PHP standard library, buffer variables typed earlier, any-word fallback. Each entry shows a colored type icon and an uppercase detail label
- Context-aware sources: after `Model::` Eloquent statics, after `->` instance / collection methods
- Live `php -l` syntax checking debounced 600 ms, errors render as inline diagnostics in the gutter and as wavy underlines with a hover tooltip, the site's own PHP version is used so 8.4 features in an 8.4 site don't trip the linter
- Output panel is styled like a read-only CodeMirror, line numbers come from CSS pseudo-elements so dragging across results never selects or copies them. Each top-level statement gets its own numbered block with a hover Copy button. Bare expressions auto-dump (no need to type `dump(...)`). Symfony VarDumper output is parsed client-side into a collapsible tree with color-coded scalars and visibility prefixes. Runtime errors from psysh on stdout (`Error  Call to a member function get() on int.`) are detected and rendered with red error styling
- Tab placement: lives in the bottom-right of the SiteHeader, no extra row eaten

## Framework-defined REPL

Execution is driven by the framework definition. A new `tinker:` block in framework YAML declares the command, how user code is passed (`execute_flag` or stdin pipe), and the file or composer package that must exist for the REPL to be available. Laravel sites use `php artisan tinker --execute=...`. Sites without a satisfied framework REPL fall back to plain `php` execution with `vendor/autoload.php` auto-required so helpers like Symfony's `dump()` are available.

The matching `tinker:` blocks for the bundled framework YAMLs (Laravel 10/11/12/13, Statamic 5/6) live in a sibling PR against the lerd-frameworks repo. The embedded Laravel fallback in `internal/config/framework.go` already includes the block so Laravel keeps working offline.

## Endpoints

- `POST /api/sites/{domain}/tinker` runs code, returns stdout, stderr, exit_code, duration_ms, mode
- `POST /api/sites/{domain}/tinker:symbols` returns models, classes, functions for autocomplete
- `POST /api/sites/{domain}/tinker:lint` returns diagnostics from `php -l`

## Files

Backend: `internal/cli/tinker.go`, `internal/cli/tinker_symbols.go`, `internal/cli/tinker_lint.go`, schema additions in `internal/config/framework.go`, three new cases on the site action handler. Tests cover the resolver, the auto-dump heuristic, the multi-statement splitter, the lint output parser, the symbol scanner over Laravel and Symfony fixtures.

Frontend: `internal/ui/web/src/tabs/sites/SiteTinkerTab.svelte`, `internal/ui/web/src/components/DumpView.svelte`, `internal/ui/web/src/lib/dump-parser.ts` with vitest cases. CodeMirror, lang-php, autocomplete, lint, and commands packages added.

Docs: comprehensive `docs/features/tinker.md` (linked from `mkdocs.yml`) covering execution flow, the framework-defined REPL schema with examples for Laravel, hypothetical psysh-on-Symfony, and Drush-on-Drupal, output rendering, autocomplete sources, keyboard, drafts, limits, security, HTTP API, and an implementation map. README gets a one-line bullet under the feature list.