### PR TITLE
release: v1.19.0-beta.4 - first-class git worktrees + layered DNS diagnostics

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,10 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.19.0-beta.4] — 2026-05-02
+
 ### Added
 
 - **Layered DNS diagnostic in `lerd doctor` and an `dns_diagnose` MCP tool** that walks the chain end to end (lerd-dns container → dnsmasq config file → port 5300 listening → direct dig at 127.0.0.1:5300 → resolver hookup script/drop-in installed → interface routing in `resolvectl status` → system-wide DNS lookup) and surfaces exactly which rung is broken with a one-line remediation hint per failure. Replaces the old single "not resolving to 127.0.0.1" error that conflated seven possible causes. The MCP variant returns the structured walk as JSON (`steps[].status`, `first_failure` index) so AI assistants can drive troubleshooting without scraping doctor's output. Inspired by issue #285. See [Troubleshooting → `.test` domains not resolving](troubleshooting.md#test-domains-not-resolving).

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.19.0-beta.3"
+	Version = "1.19.0-beta.4"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## What's in this beta

### feat(worktrees): first-class worktree support — picker UI, opt-in DB isolation, LAN-share, CLI + MCP wrappers (#286)

Make every git worktree a first-class scope inside lerd. The site detail
panel collapses N worktree rows into one inline branch picker, every
per-worktree resource (PHP/Node version, DB, LAN share, logs, Tinker)
becomes re-scopable from the dropdown, and three new entry points let
users drive worktree workflows end-to-end:

- dashboard branch picker with scoped Logs/Tinker, per-worktree PHP/Node
  selectors, isolated DB toggle (empty / clone-main / clone-other-branch
  + reuse/reset of preserved DBs), per-worktree LAN-share toggle.
- `lerd worktree add` / `lerd worktree remove` interactive wrappers
  passing every flag through to `git worktree`, with prompts for build
  script, DB isolation source, optional `php artisan migrate`, and
  force-retry on git's modified-files error.
- `lerd db:isolate` / `lerd db:share` for direct CLI use.
- MCP `worktree` tool with list / add / remove / db_isolate / db_share.

### feat(dns): layered diagnostic for lerd doctor, dns:check, and MCP (#287)

Replace the single "not resolving to 127.0.0.1" failure with a chain
walk that surfaces exactly which rung is broken, with a one-line
remediation hint per failure. `lerd doctor`, `lerd dns:check`, and the
new MCP `dns_diagnose` tool all share the same orchestration. Closes
#285.