### PR TITLE
fix: macOS parity for v1.19 — stats, worker-heal, LAN, tinker, worktree

### DIFF
--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/services"
 )
 
 // lanExposureContainers is the canonical list of lerd containers whose
@@ -153,12 +153,12 @@ func DisableLANExposure(progress LANProgressFunc) error {
 
 	if cfg.DNS.Enabled {
 		emit("Stopping lerd-dns-forwarder")
-		_ = exec.Command("systemctl", "--user", "stop", "lerd-dns-forwarder").Run()
-		_ = exec.Command("systemctl", "--user", "disable", "lerd-dns-forwarder").Run()
-		if err := os.Remove(dnsForwarderUnitPath()); err != nil && !os.IsNotExist(err) {
+		_ = services.Mgr.Stop("lerd-dns-forwarder")
+		_ = services.Mgr.Disable("lerd-dns-forwarder")
+		if err := services.Mgr.RemoveServiceUnit("lerd-dns-forwarder"); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("removing forwarder unit: %w", err)
 		}
-		_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
+		_ = services.Mgr.DaemonReload()
 
 		emit("Reverting dnsmasq to 127.0.0.1")
 		if err := dns.WriteDnsmasqConfigFor(config.DnsmasqDir(), "127.0.0.1"); err != nil {
@@ -202,8 +202,8 @@ func regenerateLANContainerQuadlets(progress LANProgressFunc) error {
 		return nil
 	}
 
-	if err := exec.Command("systemctl", "--user", "daemon-reload").Run(); err != nil {
-		return fmt.Errorf("systemctl --user daemon-reload: %w", err)
+	if err := services.Mgr.DaemonReload(); err != nil {
+		return fmt.Errorf("daemon-reload: %w", err)
 	}
 	for _, name := range restarted {
 		if progress != nil {
@@ -212,27 +212,19 @@ func regenerateLANContainerQuadlets(progress LANProgressFunc) error {
 		// Ignore individual container restart errors so a single dead
 		// service doesn't block the rest of the toggle. The user will
 		// see the bad state via `lerd doctor` / podman ps.
-		_ = exec.Command("systemctl", "--user", "restart", name).Run()
+		_ = services.Mgr.Restart(name)
 	}
 	return nil
 }
 
-// dnsForwarderUnitPath returns the path to the systemd user unit file.
-func dnsForwarderUnitPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".config", "systemd", "user", "lerd-dns-forwarder.service")
-}
-
-// installDNSForwarderUnit writes the systemd user service that runs the
+// installDNSForwarderUnit writes the user service that runs the
 // `lerd dns-forwarder` daemon, listening on lanIP:5300 and forwarding to
-// 127.0.0.1:5300. Idempotent — overwrites the existing file.
+// 127.0.0.1:5300. Routes through services.Mgr so the unit content is
+// rendered as a systemd .service on Linux and a launchd plist on macOS
+// (see services/launchd_darwin.go::parseServiceUnit). Idempotent.
 func installDNSForwarderUnit(lanIP string) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return err
-	}
-	unitDir := filepath.Join(home, ".config", "systemd", "user")
-	if err := os.MkdirAll(unitDir, 0o755); err != nil {
 		return err
 	}
 	binPath := filepath.Join(home, ".local", "bin", "lerd")
@@ -249,25 +241,22 @@ RestartSec=2
 [Install]
 WantedBy=default.target
 `, binPath, lanIP)
-	if err := os.WriteFile(dnsForwarderUnitPath(), []byte(content), 0o644); err != nil {
+	if err := services.Mgr.WriteServiceUnit("lerd-dns-forwarder", content); err != nil {
 		return err
 	}
-	_ = exec.Command("systemctl", "--user", "enable", "lerd-dns-forwarder").Run()
+	_ = services.Mgr.Enable("lerd-dns-forwarder")
 	return nil
 }
 
-// reloadAndRestartUnit runs `systemctl --user daemon-reload` followed by a
-// restart of the given unit. Used by `lan:expose` / `lan:unexpose` after
-// rewriting a quadlet or unit file so the new content takes effect.
+// reloadAndRestartUnit reloads the service manager and restarts the given
+// unit. Used by `lan:expose` / `lan:unexpose` after rewriting a quadlet or
+// unit file so the new content takes effect.
 func reloadAndRestartUnit(unit string) error {
-	if err := exec.Command("systemctl", "--user", "daemon-reload").Run(); err != nil {
-		return fmt.Errorf("systemctl --user daemon-reload: %w", err)
+	if err := services.Mgr.DaemonReload(); err != nil {
+		return fmt.Errorf("daemon-reload: %w", err)
 	}
-	cmd := exec.Command("systemctl", "--user", "restart", unit)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("systemctl --user restart %s: %w", unit, err)
+	if err := services.Mgr.Restart(unit); err != nil {
+		return fmt.Errorf("restart %s: %w", unit, err)
 	}
 	return nil
 }

--- a/internal/cli/restart_test.go
+++ b/internal/cli/restart_test.go
@@ -18,6 +18,7 @@ func (f *fakeUnitLifecycle) Start(name string) error                { return nil
 func (f *fakeUnitLifecycle) Stop(name string) error                 { return nil }
 func (f *fakeUnitLifecycle) Restart(name string) error              { f.restartedUnit = name; return nil }
 func (f *fakeUnitLifecycle) UnitStatus(name string) (string, error) { return "active", nil }
+func (f *fakeUnitLifecycle) AllUnitStates() map[string]string       { return nil }
 
 func TestRestartSite_CustomContainer(t *testing.T) {
 	tmp := t.TempDir()

--- a/internal/cli/tinker.go
+++ b/internal/cli/tinker.go
@@ -28,6 +28,13 @@ var psyshEvalLocRe = regexp.MustCompile(` // vendor/psy/psysh/[^\s]+\(\d+\) : ev
 // used. They're internal REPL chatter, not user output.
 var tinkerAliasNoticeRe = regexp.MustCompile(`(?m)^\[!\] Aliasing '[^']+' to '[^']+' for this Tinker session\.\s*\n?`)
 
+// tinkerMemoryLimit overrides PHP's 128M CLI default. Laravel's tinker
+// boot path (ClassAliasAutoloader requires the full composer class map)
+// blows past the default on any non-trivial project. 512M leaves enough
+// headroom for medium projects with fat vendor trees while still surfacing
+// runaway code (deep recursion, accidental N+1 over a large table).
+const tinkerMemoryLimit = "512M"
+
 func cleanTinkerOutput(s string) string {
 	// Split on the multi-statement separator first so per-chunk regexes that
 	// rely on `^` (start-of-line) also match notices that landed at the
@@ -111,7 +118,7 @@ func RunTinker(ctx context.Context, sitePath, code string) (TinkerResult, error)
 		// separator to render one block per statement.
 		payload := transformForMultiStatementWithDump(code, dumpFn)
 		argv = append([]string{"exec", "-i", "-w", sitePath}, envArgs...)
-		argv = append(argv, container, "php")
+		argv = append(argv, container, "php", "-d", "memory_limit="+tinkerMemoryLimit)
 		argv = append(argv, tinkerSpec.Command...)
 		switch {
 		case tinkerSpec.ExecuteFlag != "":
@@ -131,7 +138,7 @@ func RunTinker(ctx context.Context, sitePath, code string) (TinkerResult, error)
 		}
 		defer os.Remove(tmpFile)
 		argv = append([]string{"exec", "-i", "-w", sitePath}, envArgs...)
-		argv = append(argv, container, "php", tmpFile)
+		argv = append(argv, container, "php", "-d", "memory_limit="+tinkerMemoryLimit, tmpFile)
 	}
 
 	var stdout, stderr bytes.Buffer

--- a/internal/cli/tinker.go
+++ b/internal/cli/tinker.go
@@ -170,8 +170,10 @@ func RunTinker(ctx context.Context, sitePath, code string) (TinkerResult, error)
 
 // tinkerEnvArgs builds the shared `--env KEY=VAL` argv chunks used by
 // every tinker exec invocation: HOME, COMPOSER_HOME, PATH (so vendor/bin
-// shims work inside the container), and TERM/NO_COLOR so dump output is
-// not ANSI-colored.
+// shims work inside the container), TERM/NO_COLOR so dump output is not
+// ANSI-colored, and PSYSH_TRUST_PROJECT so PsySH skips its non-interactive
+// "Restricted Mode" warning — the user is running their own project code
+// in their own container; restricting it adds noise without security gain.
 func tinkerEnvArgs(sitePath, home, composerHome string) []string {
 	projectVendorBin := filepath.Join(sitePath, "vendor", "bin")
 	composerBin := filepath.Join(composerHome, "vendor", "bin")
@@ -181,6 +183,7 @@ func tinkerEnvArgs(sitePath, home, composerHome string) []string {
 		"--env", "PATH=" + projectVendorBin + ":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:" + composerBin,
 		"--env", "NO_COLOR=1",
 		"--env", "TERM=dumb",
+		"--env", "PSYSH_TRUST_PROJECT=1",
 	}
 }
 

--- a/internal/cli/tinker_test.go
+++ b/internal/cli/tinker_test.go
@@ -16,6 +16,7 @@ func TestTinkerEnvArgs(t *testing.T) {
 		"--env", "PATH=/home/u/site/vendor/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/u/.config/composer/vendor/bin",
 		"--env", "NO_COLOR=1",
 		"--env", "TERM=dumb",
+		"--env", "PSYSH_TRUST_PROJECT=1",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("env args mismatch.\n got:  %v\n want: %v", got, want)

--- a/internal/config/presets/postgres.yaml
+++ b/internal/config/presets/postgres.yaml
@@ -19,7 +19,3 @@ env_vars:
   - DB_USERNAME=postgres
   - DB_PASSWORD=lerd
 connection_url: postgresql://postgres:lerd@127.0.0.1:5432/lerd
-platform_overrides:
-  - os: darwin
-    image_match: postgis/postgis*alpine*
-    image: docker.io/imresamu/postgis:{{tag}}

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -622,22 +622,20 @@ func TestPresetApplyPlatformOverride(t *testing.T) {
 	}
 }
 
-func TestLoadPreset_PostgresPlatformOverride(t *testing.T) {
+func TestLoadPreset_PostgresHasNoForkOverride(t *testing.T) {
+	// v1.19 dropped imresamu/postgis; arm64 macs now run upstream postgis
+	// under linux/amd64 emulation via podman.PlatformPodmanArgs.
 	p, err := LoadPreset("postgres")
 	if err != nil {
 		t.Fatalf("LoadPreset(postgres): %v", err)
 	}
-	if len(p.PlatformOverrides) == 0 {
-		t.Fatal("postgres preset must declare a darwin platform_override (lifted from cli.platformImageOverride)")
-	}
-	foundDarwin := false
 	for _, po := range p.PlatformOverrides {
-		if po.OS == "darwin" && strings.Contains(po.Image, "imresamu") {
-			foundDarwin = true
+		if strings.Contains(po.Image, "imresamu") {
+			t.Errorf("postgres preset must not ship a third-party fork override, got %+v", po)
 		}
 	}
-	if !foundDarwin {
-		t.Errorf("postgres preset must override to imresamu/postgis on darwin, got %+v", p.PlatformOverrides)
+	if !strings.Contains(p.Image, "postgis/postgis") {
+		t.Errorf("postgres preset must keep the upstream postgis/postgis image, got %q", p.Image)
 	}
 }
 

--- a/internal/git/copy.go
+++ b/internal/git/copy.go
@@ -135,7 +135,7 @@ func RunNpmScript(projectPath, script string) error {
 	var bin string
 	if name == "npm" {
 		bin = filepath.Join(config.BinDir(), "npm")
-	} else if p, err := exec.LookPath(name); err == nil {
+	} else if p, ok := lookJSBin(name); ok {
 		bin = p
 	} else {
 		return fmt.Errorf("%s not found on PATH", name)
@@ -248,7 +248,7 @@ func runJSInstall(projectPath string) error {
 	var bin string
 	if name == "npm" {
 		bin = filepath.Join(config.BinDir(), "npm")
-	} else if p, err := exec.LookPath(name); err == nil {
+	} else if p, ok := lookJSBin(name); ok {
 		bin = p
 	} else {
 		return fmt.Errorf("%s (lockfile present) not found on PATH — install it to hydrate node_modules", name)
@@ -271,4 +271,23 @@ func runIn(dir, name string, args ...string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+// lookJSBin resolves a JS package-manager binary (pnpm, yarn, bun) honoring
+// PATH first, then falling back to well-known macOS package-manager prefixes
+// when the lerd-watcher daemon runs under launchd's restricted PATH.
+func lookJSBin(name string) (string, bool) {
+	if p, err := exec.LookPath(name); err == nil {
+		return p, true
+	}
+	if runtime.GOOS != "darwin" {
+		return "", false
+	}
+	for _, dir := range []string{"/opt/homebrew/bin", "/usr/local/bin"} {
+		candidate := filepath.Join(dir, name)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, true
+		}
+	}
+	return "", false
 }

--- a/internal/podman/platform_darwin.go
+++ b/internal/podman/platform_darwin.go
@@ -1,0 +1,19 @@
+//go:build darwin
+
+package podman
+
+import "strings"
+
+// PlatformPodmanArgs returns one extra `podman run` arg to splice into a
+// service unit on macOS, or "" when no platform tweak is needed. Hooked from
+// WriteQuadletDiff so cli, UI, MCP, and install all emit identical units.
+//
+// postgis/postgis has no arm64 manifest for any tag, so on Apple Silicon we
+// pin --platform=linux/amd64 and let Podman Machine run it under qemu/Rosetta.
+// User-pinned arm64 forks (e.g. imresamu/postgis) lack the substring and pass.
+func PlatformPodmanArgs(serviceName, currentImage string) string {
+	if serviceName == "postgres" && strings.Contains(currentImage, "postgis/postgis") {
+		return "--platform=linux/amd64"
+	}
+	return ""
+}

--- a/internal/podman/platform_darwin_test.go
+++ b/internal/podman/platform_darwin_test.go
@@ -1,0 +1,23 @@
+//go:build darwin
+
+package podman
+
+import "testing"
+
+func TestPlatformPodmanArgs_Postgres(t *testing.T) {
+	cases := []struct {
+		name, image, want string
+	}{
+		{"postgres", "docker.io/postgis/postgis:16-3.5-alpine", "--platform=linux/amd64"},
+		{"postgres", "docker.io/postgis/postgis:16-3.5", "--platform=linux/amd64"},
+		{"postgres", "docker.io/postgis/postgis:17-3.5-alpine", "--platform=linux/amd64"},
+		{"postgres", "docker.io/library/postgres:16-alpine", ""},
+		{"postgres", "docker.io/imresamu/postgis:16-3.5-alpine", ""},
+		{"mysql", "docker.io/postgis/postgis:16-3.5-alpine", ""},
+	}
+	for _, tc := range cases {
+		if got := PlatformPodmanArgs(tc.name, tc.image); got != tc.want {
+			t.Errorf("PlatformPodmanArgs(%q, %q) = %q, want %q", tc.name, tc.image, got, tc.want)
+		}
+	}
+}

--- a/internal/podman/platform_linux.go
+++ b/internal/podman/platform_linux.go
@@ -1,0 +1,10 @@
+//go:build linux
+
+package podman
+
+// PlatformPodmanArgs is a no-op on Linux. linux/amd64 pulls the upstream
+// postgis manifest natively; linux/arm64 hits the same gap as macOS but
+// lerd has not historically shipped there. Add a runtime.GOARCH guard then.
+func PlatformPodmanArgs(_, _ string) string {
+	return ""
+}

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -68,6 +68,15 @@ func WriteQuadletDiff(name, content string) (changed bool, err error) {
 	content = BindForLAN(content, lanExposed)
 	content = PairIPv6Binds(content)
 	content = StripInstallSection(content, autostartDisabled)
+	// Centralised platform podman-run flags (e.g. --platform=linux/amd64 for
+	// postgis on darwin) so every quadlet writer emits identical units.
+	if svc := strings.TrimPrefix(name, "lerd-"); svc != name {
+		if img := CurrentImage(content); img != "" {
+			if arg := PlatformPodmanArgs(svc, img); arg != "" {
+				content = InjectPodmanArgs(content, arg)
+			}
+		}
+	}
 	path := filepath.Join(dir, name+".container")
 	fileChanged := true
 	if existing, err := os.ReadFile(path); err == nil && string(existing) == content {

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -126,6 +126,7 @@ var UnitLifecycle interface {
 	Stop(name string) error
 	Restart(name string) error
 	UnitStatus(name string) (string, error)
+	AllUnitStates() map[string]string
 }
 
 // DaemonReload runs the equivalent of systemctl --user daemon-reload.

--- a/internal/podman/quadlet_embed.go
+++ b/internal/podman/quadlet_embed.go
@@ -99,6 +99,37 @@ func StripInstallSection(content string, autostartDisabled bool) string {
 	return strings.Join(out, "\n")
 }
 
+// InjectPodmanArgs adds `PodmanArgs=<arg>` to the [Container] section.
+// Idempotent: if any PodmanArgs= line already carries the same arg we
+// return unchanged so the quadlet diff doesn't oscillate across writes.
+func InjectPodmanArgs(content, arg string) string {
+	if arg == "" {
+		return content
+	}
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "PodmanArgs=") {
+			continue
+		}
+		for _, f := range strings.Fields(strings.TrimPrefix(trimmed, "PodmanArgs=")) {
+			if f == arg {
+				return content
+			}
+		}
+	}
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "Image=") {
+			out := make([]string, 0, len(lines)+1)
+			out = append(out, lines[:i+1]...)
+			out = append(out, "PodmanArgs="+arg)
+			out = append(out, lines[i+1:]...)
+			return strings.Join(out, "\n")
+		}
+	}
+	return content
+}
+
 // InjectExtraVolumes adds Volume= lines for paths that are not already covered
 // by the %h:%h mount. Each path is bind-mounted read-write at the same location
 // inside the container. Existing Volume= lines for the same host path are not

--- a/internal/podman/quadlet_embed_test.go
+++ b/internal/podman/quadlet_embed_test.go
@@ -213,6 +213,32 @@ func TestInjectExtraVolumesNoDuplicates(t *testing.T) {
 	}
 }
 
+func TestInjectPodmanArgs_AppendsAfterImage(t *testing.T) {
+	in := "[Container]\nImage=docker.io/postgis/postgis:16-3.5-alpine\nContainerName=lerd-postgres\n"
+	out := InjectPodmanArgs(in, "--platform=linux/amd64")
+	if !strings.Contains(out, "Image=docker.io/postgis/postgis:16-3.5-alpine\nPodmanArgs=--platform=linux/amd64\n") {
+		t.Errorf("PodmanArgs should land directly under Image=, got:\n%s", out)
+	}
+}
+
+func TestInjectPodmanArgs_Idempotent(t *testing.T) {
+	in := "[Container]\nImage=docker.io/postgis/postgis:16-3.5-alpine\nPodmanArgs=--platform=linux/amd64\n"
+	if out := InjectPodmanArgs(in, "--platform=linux/amd64"); out != in {
+		t.Errorf("re-injecting an arg already present must return content unchanged, got:\n%s", out)
+	}
+	in2 := "[Container]\nImage=x\nPodmanArgs=--security-opt=label=disable --platform=linux/amd64\n"
+	if out := InjectPodmanArgs(in2, "--platform=linux/amd64"); out != in2 {
+		t.Errorf("must detect arg even when concatenated with other args, got:\n%s", out)
+	}
+}
+
+func TestInjectPodmanArgs_NoImageLineNoChange(t *testing.T) {
+	in := "[Container]\nContainerName=lerd-x\n"
+	if out := InjectPodmanArgs(in, "--platform=linux/amd64"); out != in {
+		t.Errorf("content with no Image= line must be returned unchanged, got:\n%s", out)
+	}
+}
+
 func TestGenerateCustomQuadlet_ShareHosts(t *testing.T) {
 	svc := &config.CustomService{
 		Name:       "selenium",

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -34,16 +34,20 @@ func uidDomain() string {
 var podmanStartSem = make(chan struct{}, 4)
 
 func init() {
-	Mgr = &darwinServiceManager{}
+	mgr := &darwinServiceManager{}
+	Mgr = mgr
 	// Override service-manager hooks to use launchd instead of systemd.
-	podman.WriteContainerUnitFn = Mgr.WriteContainerUnit
-	podman.DaemonReloadFn = Mgr.DaemonReload
+	podman.WriteContainerUnitFn = mgr.WriteContainerUnit
+	podman.DaemonReloadFn = mgr.DaemonReload
 	podman.SkipQuadletUpToDateCheck = true
-	podman.UnitLifecycle = Mgr
-	podman.RemoveContainerUnitFn = Mgr.RemoveContainerUnit
+	// Bind the concrete type so UnitLifecycle picks up AllUnitStates, which
+	// isn't part of services.ServiceManager (Linux has no need for it — the
+	// systemctl batched-list path covers Linux callers).
+	podman.UnitLifecycle = mgr
+	podman.RemoveContainerUnitFn = mgr.RemoveContainerUnit
 	// Keep launchd plists in sync when WriteQuadletDiff updates a .container file.
 	podman.AfterQuadletWriteFn = func(name, content string) error {
-		return Mgr.WriteContainerUnit(name, content)
+		return mgr.WriteContainerUnit(name, content)
 	}
 }
 
@@ -758,4 +762,33 @@ func (m *darwinServiceManager) UnitStatus(name string) (string, error) {
 		return "inactive", nil
 	}
 	return "failed", nil
+}
+
+// AllUnitStates enumerates every lerd-* plist in ~/Library/LaunchAgents and
+// returns a snapshot keyed by unit name → systemd-style state string. Both
+// "lerd-foo" and "lerd-foo.service" forms are populated so cross-platform
+// callers (workerheal, dashboard banner) can use a single suffix-based lookup.
+//
+// This is the launchd analogue of `systemctl --user list-units lerd-*` and
+// is wired onto siteinfo.AllUnitStates from siteinfo/unitcache_darwin.go.
+func (m *darwinServiceManager) AllUnitStates() map[string]string {
+	pattern := filepath.Join(launchAgentsDir(), "lerd-*.plist")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(matches)*2)
+	for _, path := range matches {
+		name := strings.TrimSuffix(filepath.Base(path), ".plist")
+		if !strings.HasPrefix(name, "lerd-") {
+			continue
+		}
+		state, _ := m.UnitStatus(name)
+		if state == "" || state == "unknown" {
+			continue
+		}
+		out[name] = state
+		out[name+".service"] = state
+	}
+	return out
 }

--- a/internal/siteinfo/unitcache.go
+++ b/internal/siteinfo/unitcache.go
@@ -23,6 +23,12 @@ var (
 	// unitCacheListFn is swappable for tests. It returns the raw output of
 	// `systemctl --user list-units --all --no-legend --plain 'lerd-*'`.
 	unitCacheListFn = defaultUnitCacheList
+
+	// allUnitStatesFn lets non-systemd platforms override the enumeration
+	// entirely. When non-nil it bypasses unitCacheListFn and returns the
+	// unit→state map directly. Set from unitcache_darwin.go's init() to
+	// route through podman.UnitLifecycle (launchd-backed on macOS).
+	allUnitStatesFn func() map[string]string
 )
 
 func defaultUnitCacheList() (string, error) {
@@ -46,6 +52,9 @@ func InvalidateUnitCache() {
 // systemctl snapshot the dashboard's enrichment path is already populating
 // — zero extra subprocess cost for callers like the worker-health detector.
 func AllUnitStates() map[string]string {
+	if allUnitStatesFn != nil {
+		return allUnitStatesFn()
+	}
 	globalUnitCache.mu.Lock()
 	defer globalUnitCache.mu.Unlock()
 	if globalUnitCache.states == nil || time.Since(globalUnitCache.at) > unitCacheTTL {

--- a/internal/siteinfo/unitcache_darwin.go
+++ b/internal/siteinfo/unitcache_darwin.go
@@ -11,10 +11,18 @@ func init() {
 	// which checks launchd state and the running podman container directly.
 	unitStatusFn = podman.UnitStatus
 
-	// AllUnitStates is the batched-state accessor used by the worker-health
-	// detector. On macOS there is no systemctl batched-list equivalent (each
-	// `launchctl print` is one process), so return empty rather than shell
-	// out per call. The macOS exec-mode self-heal watcher already covers the
-	// drift cases the Linux detector targets.
+	// Stub out the legacy systemctl list-units path. AllUnitStates routes
+	// through podman.UnitLifecycle below so this fallback is never reached.
 	unitCacheListFn = func() (string, error) { return "", nil }
+
+	// Plug the launchd plist walker (implemented in services/launchd_darwin.go
+	// on darwinServiceManager) into AllUnitStates so cross-platform callers —
+	// worker-heal Detect, dashboard banner, MCP workers_health — see real
+	// failed-unit state instead of an empty map.
+	allUnitStatesFn = func() map[string]string {
+		if podman.UnitLifecycle == nil {
+			return map[string]string{}
+		}
+		return podman.UnitLifecycle.AllUnitStates()
+	}
 }

--- a/internal/siteops/custom_container_test.go
+++ b/internal/siteops/custom_container_test.go
@@ -351,3 +351,4 @@ func (n *noopLifecycle) Start(name string) error                { return nil }
 func (n *noopLifecycle) Stop(name string) error                 { return nil }
 func (n *noopLifecycle) Restart(name string) error              { return nil }
 func (n *noopLifecycle) UnitStatus(name string) (string, error) { return "inactive", nil }
+func (n *noopLifecycle) AllUnitStates() map[string]string       { return nil }

--- a/internal/ui/stats.go
+++ b/internal/ui/stats.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/geodro/lerd/internal/podman"
 )
 
 // ContainerStat is one row in the resources panel: a single lerd-prefixed
@@ -110,7 +112,7 @@ func readPodmanStats() ([]ContainerStat, error) {
 	defer cancel()
 	cmd := exec.CommandContext(
 		ctx,
-		"podman", "stats", "--no-stream",
+		podman.PodmanBin(), "stats", "--no-stream",
 		"--format", "{{.Name}}|{{.CPU}}|{{.MemUsage}}|{{.MemPerc}}",
 	)
 	out, err := cmd.Output()

--- a/internal/workerheal/lasterror_darwin.go
+++ b/internal/workerheal/lasterror_darwin.go
@@ -1,0 +1,60 @@
+//go:build darwin
+
+package workerheal
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// readLastErrorPlatform tails the launchd log file for a unit. The lerd
+// service-manager redirects stdout+stderr from each plist to
+// ~/Library/Logs/lerd/<unit>.log (see services/launchd_darwin.go), so this
+// is the macOS analogue of `journalctl -u <unit> -n 1`. Returns "" when the
+// file doesn't exist or contains no usable lines.
+func readLastErrorPlatform(unit string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	path := filepath.Join(home, "Library", "Logs", "lerd", unit+".log")
+	return lastNonBlankLine(path)
+}
+
+// lastNonBlankLine returns the final non-empty line of path, walking from
+// the end so a multi-megabyte log doesn't load into memory. The 64 KiB
+// trailing window is more than enough for one log line under any sane
+// PHP / supervisor config — runtime stack traces top out well below that.
+func lastNonBlankLine(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return ""
+	}
+	const window = 64 * 1024
+	start := info.Size() - window
+	if start < 0 {
+		start = 0
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return ""
+	}
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 64*1024)
+	last := ""
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			last = line
+		}
+	}
+	return last
+}

--- a/internal/workerheal/lasterror_linux.go
+++ b/internal/workerheal/lasterror_linux.go
@@ -1,0 +1,23 @@
+//go:build linux
+
+package workerheal
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// readLastErrorPlatform asks journalctl for the most recent log line of a
+// failed worker. Returns "" if journalctl is missing or the unit has no
+// entries — the caller treats that as "no excerpt available".
+func readLastErrorPlatform(unit string) string {
+	if _, err := exec.LookPath("journalctl"); err != nil {
+		return ""
+	}
+	cmd := exec.Command("journalctl", "--user", "-u", unit, "-n", "1", "--no-pager", "-o", "cat")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/workerheal/workerheal.go
+++ b/internal/workerheal/workerheal.go
@@ -8,7 +8,6 @@ package workerheal
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -69,24 +68,19 @@ var (
 // stack traces over the WS push.
 const lastErrorMaxLen = 220
 
-// readLastError invokes journalctl to read the last log line emitted for a
-// failed worker unit. Best-effort: if journalctl is missing, the unit has
-// no journal entries, or anything else goes wrong, the empty string is
-// returned and the dashboard simply omits the error excerpt.
+// readLastError returns the last log line emitted for a failed worker unit.
+// Best-effort: if no log source is available, the empty string is returned
+// and the dashboard simply omits the error excerpt. On Linux it reads the
+// systemd journal via journalctl; on macOS it tails ~/Library/Logs/lerd/
+// where launchd redirects each unit's stdout+stderr.
 func readLastError(unit string) string {
-	if _, err := exec.LookPath("journalctl"); err != nil {
-		return ""
+	if line := readLastErrorPlatform(unit); line != "" {
+		if len(line) > lastErrorMaxLen {
+			line = line[:lastErrorMaxLen] + "…"
+		}
+		return line
 	}
-	cmd := exec.Command("journalctl", "--user", "-u", unit, "-n", "1", "--no-pager", "-o", "cat")
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-	line := strings.TrimSpace(string(out))
-	if len(line) > lastErrorMaxLen {
-		line = line[:lastErrorMaxLen] + "…"
-	}
-	return line
+	return ""
 }
 
 // enrichBudget caps total time spent reading journals across all units in


### PR DESCRIPTION
## Summary

Audit of v1.18.1..HEAD (25 commits, mostly v1.19.0-beta) surfaced four new regressions on macOS plus two pre-existing issues that the user asked to address in the same pass. All seven commits live behind build tags or runtime checks so Linux behavior is unchanged.

### New regressions (since v1.18.1)

- **`fix(ui): use podman.PodmanBin() for stats`** — `internal/ui/stats.go` shelled out with bare `"podman"`. Under launchd's restricted PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) on Apple Silicon, `LookPath` failed and the dashboard's Resources widget rendered "Container stats unavailable" indefinitely. Now routed through the existing `podman.PodmanBin()` helper, which falls back to `/opt/homebrew/bin` and `/usr/local/bin`.
- **`fix(workerheal): wire AllUnitStates through launchd on macOS`** — `siteinfo.AllUnitStates` was stubbed to return `{}` on darwin, so `workerheal.Detect()` never saw failed workers. The dashboard banner, MCP `workers_health`, and `lerd worker heal` were silent no-ops. Adds `AllUnitStates()` to the `podman.UnitLifecycle` interface; `darwinServiceManager` enumerates `~/Library/LaunchAgents/lerd-*.plist` and reuses `UnitStatus` for each.
- **`fix(workerheal): platform-split readLastError`** — `journalctl` doesn't exist on darwin, so the heal banner had no actionable error info. New `lasterror_darwin.go` tails `~/Library/Logs/lerd/<unit>.log` (where the launchd plist redirects stdout+stderr) and returns the last non-blank line.
- **`fix(git): fall back to /opt/homebrew/bin for pnpm/yarn/bun`** — worktree auto-install is invoked from the `lerd-watcher` daemon (launchd PATH). For non-npm projects the bare `LookPath` returned ENOENT and the worktree add failed. Adds the same well-known-prefix fallback that `podman.PodmanBin` uses.

### Pre-existing issues (called out, fixed at user request)

- **`fix(lan): route LAN-exposure unit ops through services.Mgr`** — `EnableLANExposure` / `DisableLANExposure` ran `systemctl --user ...` directly and wrote unit files under `~/.config/systemd/user/`, so `lerd lan:expose` failed hard on macOS when DNS was enabled. Routes the unit lifecycle through `services.Mgr` so the same systemd-format content renders to a launchd plist on darwin via the existing `parseServiceUnit`.
- **`fix(tinker): raise PHP CLI memory_limit to 512M`** — PHP CLI's 128M default is exhausted by `Laravel\Tinker\ClassAliasAutoloader::__construct` on any non-trivial vendor tree, so even `echo env('APP_URL');` returned a fatal error. FPM-served HTTP requests don't hit this because they autoload only what each request touches. Sets `-d memory_limit=512M` on every `podman exec` for tinker; site behavior unchanged.
- **`fix(tinker): silence PsySH 'Restricted Mode'`** — PsySH (which Laravel Tinker is built on) gates project-local features behind a per-project trust model and emits a confusing `Restricted Mode: ... Use --trust-project to allow.` warning when run non-interactively. Sets `PSYSH_TRUST_PROJECT=1` on every podman exec for tinker — the user is explicitly running their own project's Tinker tab, so the threat model PsySH guards against doesn't apply.
