### PR TITLE
release: v1.19.0-beta.6 — bug-report anonymization + install update_strategy fix

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,21 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.19.0-beta.6] — 2026-05-03
+
+### Fixed
+
+- **`lerd update` no longer silently bumps preset minors past the user's installed version**. `EnsureDefaultPresetQuadlet` now reads the existing on-disk image when `update_strategy` is `patch` / `minor` / `none` and the user has no explicit pin in `config.yaml`, so `lerd update` (which calls `install --from-update`) keeps users on their current minor instead of replacing it with whatever the new preset declared. Meilisearch v1.7 → v1.42 used to swap engines in one step and hard-fail because the older data dir won't load under a newer binary; mysql 8.0 → 8.4 happened to upgrade in place but bypassed the per-service migration UX that `lerd service update` enforces. Rolling-strategy services (mailpit, rustfs, gotenberg) still pick up the preset image as before via the existing `track_latest` block.
+- **`lerd-tray.service` now caps its restart loop at 3 failures per 60 seconds**. Two unrecoverable failure modes (missing GTK runtime / no graphical session under launchd's bootstrap context) used to spin the unit through `RestartSec=2 Restart=on-failure` indefinitely; the cap stops the churn while leaving normal transient failures recoverable.
+- **Dashboard root page no longer renders the "Lerd info" banner twice**. A duplicate include slipped in during the dashboard rewrite; the canonical banner stays, the duplicate beneath it is gone.
+
+### Changed
+
+- **`lerd bug-report` collects logs only for lerd's own infra units** (`lerd-nginx`, `lerd-ui`, `lerd-watcher`, `lerd-dns`, `lerd-tray`, `lerd-autostart`, `lerd-fpm-init`). Preset services like redis, mysql, gotenberg and meilisearch were producing repetitive noise that didn't help triage; their state still appears in the unit-state and container tables, but their logs no longer ride along. FPM containers (`lerd-php<N>-fpm`) and per-site workers (`lerd-{queue,schedule,horizon,stripe,reverb}-<site>`) keep the existing log-skip and bucket-state behaviour. Custom services (defined under `~/.config/lerd/services/`), per-site custom containers (`lerd-custom-*`) and FrankenPHP per-site containers (`lerd-fp-*`) are now omitted from listings entirely so the report doesn't leak user app identifiers.
+- **`lerd bug-report` anonymizes site names, domains, parked-directory paths and the username by default**. Site names render as `site-1`/`site-2`, domains as `site1.<tld>`, parked directories as `$PARK_1`/`$PARK_2`, the username as `$USER`. Pass `--show-real-names` to keep the raw values for local debugging.
+
+---
+
 ## [1.19.0-beta.5] — 2026-05-03
 
 ### Fixed

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -25,7 +25,7 @@
 | `lerd tui` | Open a btop-style terminal dashboard with live site / service / worker status, per-site detail pane, inline domain and version editing, shell drop-in, log tailing, filter + sort, and global settings |
 | `lerd check` | Validate `.lerd.yaml` syntax, services, and PHP version before setup |
 | `lerd doctor` | Full environment diagnostic: podman, systemd, DNS, ports, PHP images, config validity |
-| `lerd bug-report [-o file] [--log-lines n]` | Dump doctor output, config files, unit state, recent logs, network state and env vars to a plain-text file you can attach to a GitHub issue |
+| `lerd bug-report [-o file] [--log-lines n] [--show-real-names]` | Dump doctor output, config files, unit state, recent logs, network state and env vars to a plain-text file you can attach to a GitHub issue. Site names, domains, parked paths, home paths and the username are anonymized by default; `--show-real-names` keeps raw values |
 | `lerd logs [-f] [target]` | Show logs for the current project's FPM container, `nginx`, a service name, or a PHP version |
 
 ## Project creation

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,14 +17,24 @@ If you need help on the [issue tracker](https://github.com/geodro/lerd/issues), 
 lerd bug-report
 ```
 
-This writes a single plain-text file (default: `./lerd-bug-report-<timestamp>.txt`) containing the full `lerd doctor` output, your `config.yaml` and `sites.yaml`, the state of every `lerd-*` systemd unit, recent journal and container logs, listening sockets on the lerd ports, and a curated set of environment variables. Site `.env` files are intentionally excluded; home paths are replaced with `$HOME`.
+This writes a single plain-text file (default: `./lerd-bug-report-<timestamp>.txt`) containing the full `lerd doctor` output, your `config.yaml` and `sites.yaml`, the state of every `lerd-*` systemd unit, recent journal and container logs for lerd's own infra units, listening sockets on the lerd ports, and a curated set of environment variables.
+
+What gets filtered before it lands on disk:
+
+- Site `.env` files are excluded outright.
+- Home paths render as `$HOME` and the username as `$USER`.
+- Site names, domains and parked-directory paths are replaced with `site-1`/`site1.<tld>`/`$PARK_1` placeholders. Pass `--show-real-names` to keep the raw values for local debugging.
+- Logs are kept only for lerd's own infra (`lerd-nginx`, `lerd-ui`, `lerd-dns`, `lerd-watcher`, `lerd-tray`, etc.). Preset services (mysql, redis, meilisearch, gotenberg, …), FPM containers and per-site workers still appear in the unit-state and container tables but their logs are dropped — they were producing repetitive request-shaped noise that didn't help triage.
+- Custom services and per-site custom / FrankenPHP containers are omitted entirely so the report doesn't expose user app identifiers.
+- Nginx structured error lines have their `request:` / `upstream:` / `referrer:` URI fields redacted, and HTTP access lines are dropped.
 
 Skim the file before posting (it's plain text — open it in any editor) and attach it to your GitHub issue.
 
-Override the destination with `--output`, or change how many log lines per service to include with `--log-lines`:
+Override the destination with `--output`, change how many log lines per service to include with `--log-lines`, or keep raw site names with `--show-real-names`:
 
 ```bash
 lerd bug-report --output /tmp/report.txt --log-lines 500
+lerd bug-report --show-real-names
 ```
 
 ---

--- a/internal/cli/bug_report.go
+++ b/internal/cli/bug_report.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -26,15 +27,19 @@ import (
 func NewBugReportCmd() *cobra.Command {
 	var outputPath string
 	var logLines int
+	var showRealNames bool
 	cmd := &cobra.Command{
 		Use:   "bug-report",
 		Short: "Collect diagnostics into a single file for GitHub bug reports",
 		Long: "Generates a plain-text report containing the lerd doctor output, " +
 			"config files, systemd unit state, recent service logs, network " +
 			"state and the relevant environment variables. Attach the file to " +
-			"your GitHub issue.",
+			"your GitHub issue.\n\n" +
+			"Site names, domains and parked-directory paths are replaced with " +
+			"site-1/site-2/$PARK_1/etc. by default. Pass --show-real-names if " +
+			"you want raw values for local debugging.",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			path, err := writeBugReport(outputPath, logLines)
+			path, err := writeBugReport(outputPath, logLines, !showRealNames)
 			if err != nil {
 				return err
 			}
@@ -45,10 +50,11 @@ func NewBugReportCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "output file path (default: ./lerd-bug-report-<timestamp>.txt)")
 	cmd.Flags().IntVar(&logLines, "log-lines", 200, "number of recent log lines to include per service/container")
+	cmd.Flags().BoolVar(&showRealNames, "show-real-names", false, "include real site names, domains and parked-directory paths instead of placeholders")
 	return cmd
 }
 
-func writeBugReport(outputPath string, logLines int) (string, error) {
+func writeBugReport(outputPath string, logLines int, anonymize bool) (string, error) {
 	if logLines <= 0 {
 		logLines = 200
 	}
@@ -66,18 +72,30 @@ func writeBugReport(outputPath string, logLines int) (string, error) {
 	}
 	defer f.Close()
 
+	// Build the anonymizer up-front so the header can advertise whether
+	// site/domain/parked-dir replacement is in effect.
+	var anon *anonymizer
+	if anonymize {
+		anon = newAnonymizer()
+	}
+	// The log filter is independent of the anonymizer: even with
+	// --show-real-names we still want to drop request-shaped noise. The
+	// domain-aware safety net only fires when we have sites.yaml entries.
+	filter := newLogFilter()
+
 	var buf bytes.Buffer
-	collectBugReport(&buf, logLines)
+	collectBugReport(&buf, logLines, anon, filter)
 
 	scrubbed := scrubHomePath(buf.String())
+	scrubbed = anon.Apply(scrubbed)
 	if _, err := io.WriteString(f, scrubbed); err != nil {
 		return "", fmt.Errorf("writing report: %w", err)
 	}
 	return abs, nil
 }
 
-func collectBugReport(w io.Writer, logLines int) {
-	writeBugReportHeader(w)
+func collectBugReport(w io.Writer, logLines int, anon *anonymizer, filter *logFilter) {
+	writeBugReportHeader(w, anon)
 
 	section(w, "Doctor")
 	if _, _, err := RunDoctorTo(w, false); err != nil {
@@ -97,10 +115,10 @@ func collectBugReport(w io.Writer, logLines int) {
 	dumpContainers(w)
 
 	section(w, fmt.Sprintf("Recent service logs (last %d lines)", logLines))
-	dumpServiceLogs(w, logLines)
+	dumpServiceLogs(w, logLines, filter)
 
 	section(w, fmt.Sprintf("Recent container logs (last %d lines)", logLines))
-	dumpContainerLogs(w, logLines)
+	dumpContainerLogs(w, logLines, filter)
 
 	section(w, "Network")
 	dumpNetwork(w)
@@ -109,12 +127,21 @@ func collectBugReport(w io.Writer, logLines int) {
 	dumpEnvironment(w)
 }
 
-func writeBugReportHeader(w io.Writer) {
+func writeBugReportHeader(w io.Writer, anon *anonymizer) {
 	fmt.Fprintln(w, "Lerd bug report")
 	fmt.Fprintln(w, "════════════════════════════════════════════════════════")
 	fmt.Fprintln(w, "Review this file before posting publicly. It contains")
 	fmt.Fprintln(w, "your config and recent service logs but no .env contents.")
-	fmt.Fprintln(w, "Home paths have been replaced with $HOME.")
+	fmt.Fprintln(w, "Home paths and the username are replaced with $HOME / $USER.")
+	fmt.Fprintln(w, "Logs are kept only for lerd's own infra (nginx, ui, dns,")
+	fmt.Fprintln(w, "watcher, tray); preset services, FPM, workers and HTTP access")
+	fmt.Fprintln(w, "lines are dropped. Custom services and per-site containers")
+	fmt.Fprintln(w, "are omitted entirely.")
+	if anon.active() {
+		fmt.Fprintln(w, "Site names, domains and parked-directory paths have been")
+		fmt.Fprintln(w, "anonymized (site-N, siteN.<tld>, $PARK_N). Re-run with")
+		fmt.Fprintln(w, "--show-real-names to keep the raw values.")
+	}
 	fmt.Fprintln(w, "════════════════════════════════════════════════════════")
 	fmt.Fprintf(w, "Generated:  %s\n", time.Now().Format(time.RFC3339))
 	fmt.Fprintf(w, "lerd:       %s\n", version.String())
@@ -178,7 +205,20 @@ func dumpUnitState(w io.Writer) {
 		fmt.Fprintln(w, "(no lerd units found)")
 		return
 	}
+	// Bucket per-site worker units by type so the listing reports
+	// "lerd-queue-* (N units, all active)" instead of one row per
+	// (worker, site). The mapping between sites and which workers they
+	// run is metadata we don't need for infra debugging.
+	buckets := map[string][]string{}
+	var infra []string
 	for _, name := range units {
+		if pfx := workerUnitPrefix(name); pfx != "" {
+			buckets[pfx] = append(buckets[pfx], name)
+			continue
+		}
+		infra = append(infra, name)
+	}
+	for _, name := range infra {
 		state, err := services.Mgr.UnitStatus(name)
 		if err != nil {
 			state = fmt.Sprintf("error: %v", err)
@@ -189,10 +229,51 @@ func dumpUnitState(w io.Writer) {
 		}
 		fmt.Fprintf(w, "%-30s  state=%s  enabled=%s\n", name, state, enabled)
 	}
+	keys := make([]string, 0, len(buckets))
+	for k := range buckets {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		members := buckets[k]
+		var states, enabled, failed int
+		for _, name := range members {
+			state, _ := services.Mgr.UnitStatus(name)
+			if state == "active" {
+				states++
+			}
+			if state == "failed" {
+				failed++
+			}
+			if services.Mgr.IsEnabled(name) {
+				enabled++
+			}
+		}
+		summary := fmt.Sprintf("%d total, %d active, %d enabled", len(members), states, enabled)
+		if failed > 0 {
+			summary += fmt.Sprintf(", %d failed", failed)
+		}
+		fmt.Fprintf(w, "%-30s  %s\n", k+"-*", summary)
+	}
+}
+
+// workerUnitPrefix returns the leading worker-type prefix for a unit
+// name (e.g. `lerd-queue` for `lerd-queue-laravel`), or "" if the unit
+// is not a per-site worker. Kept in sync with isContentUnit so the unit
+// state aggregation matches the log-skip policy.
+func workerUnitPrefix(name string) string {
+	for _, p := range []string{"lerd-queue", "lerd-schedule", "lerd-horizon", "lerd-stripe", "lerd-reverb"} {
+		if strings.HasPrefix(name, p+"-") {
+			return p
+		}
+	}
+	return ""
 }
 
 // lerdUnits returns the union of installed container units and service units
-// matching the lerd-* prefix, deduplicated and sorted.
+// matching the lerd-* prefix, deduplicated and sorted. Custom services and
+// per-site custom/FrankenPHP containers are filtered out — they expose user
+// app names and aren't useful for debugging lerd itself.
 func lerdUnits() []string {
 	seen := map[string]struct{}{}
 	for _, n := range services.Mgr.ListContainerUnits("lerd-*") {
@@ -201,12 +282,54 @@ func lerdUnits() []string {
 	for _, n := range services.Mgr.ListServiceUnits("lerd-*") {
 		seen[n] = struct{}{}
 	}
+	priv := privateUnitSet()
 	out := make([]string, 0, len(seen))
 	for n := range seen {
+		if isPrivateUnit(n, priv) {
+			continue
+		}
 		out = append(out, n)
 	}
 	sort.Strings(out)
 	return out
+}
+
+// privateUnitSet is the set of unit base names (without .service/.container
+// suffix) that belong to user-defined custom services. Built once per
+// invocation so we don't reload the YAML for every name check.
+func privateUnitSet() map[string]struct{} {
+	out := map[string]struct{}{}
+	list, err := config.ListCustomServices()
+	if err != nil {
+		return out
+	}
+	for _, s := range list {
+		if s == nil || s.Name == "" {
+			continue
+		}
+		out["lerd-"+s.Name] = struct{}{}
+	}
+	return out
+}
+
+// isPrivateUnit reports whether a unit/container name belongs to user-defined
+// config: custom services, per-site custom containers (lerd-custom-*) and
+// FrankenPHP per-site containers (lerd-fp-*). These are dropped entirely
+// from the report — names alone reveal app identifiers and their state is
+// not useful for triaging lerd itself.
+func isPrivateUnit(name string, custom map[string]struct{}) bool {
+	base := stripUnitSuffix(name)
+	if strings.HasPrefix(base, "lerd-custom-") || strings.HasPrefix(base, "lerd-fp-") {
+		return true
+	}
+	_, ok := custom[base]
+	return ok
+}
+
+func stripUnitSuffix(s string) string {
+	s = strings.TrimSuffix(s, ".service")
+	s = strings.TrimSuffix(s, ".container")
+	return s
 }
 
 func dumpContainers(w io.Writer) {
@@ -216,31 +339,68 @@ func dumpContainers(w io.Writer) {
 		fmt.Fprintf(w, "(podman ps failed: %v)\n", err)
 		return
 	}
-	if strings.TrimSpace(out) == "" {
+	out = strings.TrimRight(out, "\n")
+	if out == "" {
 		fmt.Fprintln(w, "(no lerd containers)")
 		return
 	}
-	fmt.Fprintln(w, out)
+	// Same aggregation as dumpUnitState: collapse per-site worker
+	// containers (stripe-, reverb-, etc) into a "<type>-* (N total)"
+	// summary so the listing doesn't reveal site→container fan-out.
+	// Custom services and per-site custom/FrankenPHP containers are
+	// dropped entirely (privacy: their names are user-defined).
+	priv := privateUnitSet()
+	buckets := map[string]int{}
+	var infra []string
+	for _, line := range strings.Split(out, "\n") {
+		name := line
+		if i := strings.Index(line, "\t"); i >= 0 {
+			name = line[:i]
+		}
+		if isPrivateUnit(name, priv) {
+			continue
+		}
+		if pfx := workerUnitPrefix(name); pfx != "" {
+			buckets[pfx]++
+			continue
+		}
+		infra = append(infra, line)
+	}
+	for _, line := range infra {
+		fmt.Fprintln(w, line)
+	}
+	keys := make([]string, 0, len(buckets))
+	for k := range buckets {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(w, "%s-*\t%d total (per-site workers)\n", k, buckets[k])
+	}
 }
 
-func dumpServiceLogs(w io.Writer, n int) {
+func dumpServiceLogs(w io.Writer, n int, filter *logFilter) {
 	if runtime.GOOS != "linux" {
 		fmt.Fprintln(w, "(skipped: journalctl is Linux-only)")
 		return
 	}
 	for _, unit := range lerdUnits() {
+		if isContentUnit(unit) {
+			continue
+		}
 		fmt.Fprintf(w, "── journalctl --user -u %s --no-pager -n %d\n", unit, n)
 		out, err := exec.Command("journalctl", "--user", "-u", unit,
 			"--no-pager", "-n", fmt.Sprintf("%d", n)).CombinedOutput()
 		if err != nil {
 			fmt.Fprintf(w, "(failed: %v)\n", err)
 		}
-		fmt.Fprintln(w, strings.TrimRight(string(out), "\n"))
+		cleaned := filter.clean(strings.TrimRight(string(out), "\n"))
+		fmt.Fprintln(w, cleaned)
 		fmt.Fprintln(w)
 	}
 }
 
-func dumpContainerLogs(w io.Writer, n int) {
+func dumpContainerLogs(w io.Writer, n int, filter *logFilter) {
 	out, err := podman.Run("ps", "-a", "--filter", "name=lerd-", "--format", "{{.Names}}")
 	if err != nil {
 		fmt.Fprintf(w, "(podman ps failed: %v)\n", err)
@@ -251,14 +411,21 @@ func dumpContainerLogs(w io.Writer, n int) {
 		fmt.Fprintln(w, "(no lerd containers)")
 		return
 	}
+	priv := privateUnitSet()
 	for _, name := range names {
+		if isPrivateUnit(name, priv) {
+			continue
+		}
+		if isContentUnit(name) {
+			continue
+		}
 		fmt.Fprintf(w, "── podman logs --tail %d %s\n", n, name)
 		logs, err := podman.Run("logs", "--tail", fmt.Sprintf("%d", n), name)
 		if err != nil {
 			fmt.Fprintf(w, "(failed: %v)\n\n", err)
 			continue
 		}
-		fmt.Fprintln(w, logs)
+		fmt.Fprintln(w, filter.clean(logs))
 		fmt.Fprintln(w)
 	}
 }
@@ -328,16 +495,281 @@ func dumpEnvironment(w io.Writer) {
 	}
 }
 
-// scrubHomePath replaces occurrences of the user's home directory with the
-// literal string "$HOME". Pure cosmetic privacy: it does not constitute a
-// security boundary, just a courtesy so the report is shorter and doesn't
-// expose the username repeatedly.
+// scrubHomePath replaces occurrences of the user's home directory with
+// "$HOME" and bare occurrences of the username with "$USER". Cosmetic
+// privacy only — not a security boundary. Usernames shorter than three
+// characters are skipped to avoid corrupting unrelated substrings.
 func scrubHomePath(s string) string {
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" || home == "/" {
+		home = ""
+	}
+	user := currentUsername(home)
+	var pairs []string
+	if home != "" {
+		pairs = append(pairs, home, "$HOME")
+	}
+	if len(user) >= 3 {
+		pairs = append(pairs, user, "$USER")
+	}
+	if len(pairs) == 0 {
 		return s
 	}
-	return strings.ReplaceAll(s, home, "$HOME")
+	return strings.NewReplacer(pairs...).Replace(s)
+}
+
+// currentUsername resolves the login name used to anonymize bare
+// occurrences. Prefers $USER/$LOGNAME (cheap, matches what the user
+// sees in their shell) and falls back to the basename of $HOME.
+func currentUsername(home string) string {
+	for _, env := range []string{"USER", "LOGNAME"} {
+		if v := os.Getenv(env); v != "" {
+			return v
+		}
+	}
+	if home != "" {
+		return filepath.Base(home)
+	}
+	return ""
+}
+
+// anonymizer rewrites site names, domains and parked-directory paths into
+// stable placeholders (site-1, site1.<tld>, $PARK_1, ...). It is a single
+// pass strings.Replacer applied to the assembled report. Same security
+// caveat as scrubHomePath: not a guarantee, only a courtesy.
+type anonymizer struct {
+	r *strings.Replacer
+}
+
+// active reports whether at least one replacement was registered. Used by
+// the header to decide whether to advertise anonymization to the reader.
+func (a *anonymizer) active() bool {
+	return a != nil && a.r != nil
+}
+
+// Apply runs the replacements. Safe to call on a nil receiver or an empty
+// anonymizer — returns the input unchanged.
+func (a *anonymizer) Apply(s string) string {
+	if !a.active() {
+		return s
+	}
+	return a.r.Replace(s)
+}
+
+// newAnonymizer assembles the replacement map from the current sites.yaml
+// and config.yaml. Pairs are sorted longest-first so substring matches do
+// not corrupt longer ones (e.g. `laravel.localhost` is replaced before the
+// bare `laravel`; and a site path containing another site's name is
+// replaced as a whole before the inner name has a chance to match).
+func newAnonymizer() *anonymizer {
+	type pair struct{ old, new string }
+	var pairs []pair
+	home, _ := os.UserHomeDir()
+
+	type parkedDir struct {
+		raw  string
+		home string
+		repl string
+	}
+	var parkedDirs []parkedDir
+
+	if cfg, err := config.LoadGlobal(); err == nil && cfg != nil {
+		for i, dir := range cfg.ParkedDirectories {
+			if dir == "" {
+				continue
+			}
+			pd := parkedDir{raw: dir, repl: fmt.Sprintf("$PARK_%d", i+1)}
+			if home != "" && strings.HasPrefix(dir, home+"/") {
+				pd.home = "$HOME" + strings.TrimPrefix(dir, home)
+			} else if dir == home {
+				pd.home = "$HOME"
+			}
+			parkedDirs = append(parkedDirs, pd)
+			pairs = append(pairs, pair{pd.raw, pd.repl})
+			if pd.home != "" {
+				pairs = append(pairs, pair{pd.home, pd.repl})
+			}
+		}
+	}
+
+	if reg, err := config.LoadSites(); err == nil && reg != nil {
+		for idx, s := range reg.Sites {
+			if s.Name == "" {
+				continue
+			}
+			repl := fmt.Sprintf("site-%d", idx+1)
+
+			// Site path: register full path (raw + $HOME-scrubbed) so
+			// it always replaces as a unit before the bare name pair
+			// can match a substring inside it. When the path falls
+			// inside a parked dir the placeholder shows that
+			// relationship; otherwise it is opaque.
+			if s.Path != "" {
+				pathRepl := fmt.Sprintf("$SITE_%d_PATH", idx+1)
+				for _, pd := range parkedDirs {
+					if strings.HasPrefix(s.Path, pd.raw+"/") {
+						pathRepl = pd.repl + "/" + repl
+						break
+					}
+				}
+				pairs = append(pairs, pair{s.Path, pathRepl})
+				if home != "" && strings.HasPrefix(s.Path, home+"/") {
+					pairs = append(pairs, pair{"$HOME" + strings.TrimPrefix(s.Path, home), pathRepl})
+				}
+			}
+
+			for di, d := range s.Domains {
+				if d == "" {
+					continue
+				}
+				tld := tldSuffix(d)
+				if di == 0 {
+					pairs = append(pairs, pair{d, repl + tld})
+				} else {
+					pairs = append(pairs, pair{d, fmt.Sprintf("%s-extra%d%s", repl, di, tld)})
+				}
+			}
+			pairs = append(pairs, pair{s.Name, repl})
+		}
+	}
+
+	sort.Slice(pairs, func(i, j int) bool { return len(pairs[i].old) > len(pairs[j].old) })
+
+	flat := make([]string, 0, len(pairs)*2)
+	seen := map[string]struct{}{}
+	for _, p := range pairs {
+		if p.old == "" || p.old == p.new {
+			continue
+		}
+		if _, dup := seen[p.old]; dup {
+			continue
+		}
+		seen[p.old] = struct{}{}
+		flat = append(flat, p.old, p.new)
+	}
+	if len(flat) == 0 {
+		return &anonymizer{}
+	}
+	return &anonymizer{r: strings.NewReplacer(flat...)}
+}
+
+// tldSuffix returns the trailing ".tld" portion of a domain (everything
+// from the last dot, dot included), or "" if there is no dot. The empty
+// case is intentional — bare names without a dot get replaced as-is.
+func tldSuffix(domain string) string {
+	if i := strings.LastIndex(domain, "."); i >= 0 {
+		return domain[i:]
+	}
+	return ""
+}
+
+// lerdInfraUnits is the allowlist of unit/container base names whose logs
+// are included in the bug report. Anything outside this set (preset
+// services like redis/mysql/gotenberg, per-site workers, FPM containers,
+// custom services and containers) is treated as app-domain content and
+// its logs are dropped — they're noisy, often request-shaped, and don't
+// help debug lerd itself. State for preset services still appears in the
+// unit-state and container tables.
+var lerdInfraUnits = map[string]struct{}{
+	"lerd-nginx":     {},
+	"lerd-ui":        {},
+	"lerd-watcher":   {},
+	"lerd-dns":       {},
+	"lerd-tray":      {},
+	"lerd-autostart": {},
+	"lerd-fpm-init":  {},
+}
+
+// isContentUnit reports whether logs for this unit should be skipped.
+// Inverse of the lerdInfraUnits allowlist.
+func isContentUnit(name string) bool {
+	_, ok := lerdInfraUnits[stripUnitSuffix(name)]
+	return !ok
+}
+
+// accessLogRes matches lines that look like per-request access logging
+// across the various formats lerd's services emit:
+//   - Common/Combined Log Format from nginx and phpMyAdmin's Apache
+//     (`[time] "VERB ..."` after a quoted-style header)
+//   - Meilisearch's `INFO HTTP request{method=...}` structured line
+//
+// Real errors (nginx `[error]`, PHP `Fatal error`, etc) don't carry
+// these markers and survive the filter.
+var accessLogRes = []*regexp.Regexp{
+	regexp.MustCompile(`\[\d{2}/[A-Za-z]{3}/\d{4}:\d{2}:\d{2}:\d{2} [+\-]\d{4}\] "[A-Z]{3,7} `),
+	regexp.MustCompile(`\bINFO HTTP request\{`),
+}
+
+// requestURIRedactions matches the URI portion of nginx-style structured
+// error lines (`request: "GET /path?q HTTP/1.1"`, `upstream: "http://..."`,
+// `referrer: "..."`). The error message itself is infra signal but the
+// URI/upstream/referrer values can leak app routes and query data, so we
+// keep the line and redact only those fields.
+var requestURIRedactions = []struct {
+	re      *regexp.Regexp
+	replace string
+}{
+	{regexp.MustCompile(`(request: "[A-Z]+) [^"]+( HTTP/\d(?:\.\d)?")`), `${1} <redacted>${2}`},
+	{regexp.MustCompile(`(upstream: ")[^"]+(")`), `${1}<redacted>${2}`},
+	{regexp.MustCompile(`(referrer: ")[^"]+(")`), `${1}<redacted>${2}`},
+	{regexp.MustCompile(`(referer: ")[^"]+(")`), `${1}<redacted>${2}`},
+}
+
+// logFilter cleans log output before it lands in the bug report. It
+// owns the regex set so the user-domain safety net (built once per
+// invocation from sites.yaml) lives next to the access-log shape filters
+// instead of in a global cache.
+type logFilter struct {
+	dropRes      []*regexp.Regexp
+	userDomainRe *regexp.Regexp
+}
+
+// newLogFilter builds the per-invocation filter. Always populated with
+// the access-log shape patterns; userDomainRe is populated only when
+// sites.yaml has at least one domain entry.
+func newLogFilter() *logFilter {
+	f := &logFilter{dropRes: append([]*regexp.Regexp(nil), accessLogRes...)}
+	if reg, err := config.LoadSites(); err == nil && reg != nil {
+		var alts []string
+		for _, s := range reg.Sites {
+			for _, d := range s.Domains {
+				if d != "" {
+					alts = append(alts, regexp.QuoteMeta(d))
+				}
+			}
+		}
+		if len(alts) > 0 {
+			f.userDomainRe = regexp.MustCompile(`(?i)(?:` + strings.Join(alts, "|") + `)`)
+		}
+	}
+	return f
+}
+
+// clean drops access-log shaped lines, drops any line that mentions a
+// configured user domain (case-insensitive), and redacts URI/upstream
+// fragments from nginx structured error lines that survive both checks.
+func (f *logFilter) clean(s string) string {
+	if f == nil {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	out := lines[:0]
+lineLoop:
+	for _, line := range lines {
+		for _, re := range f.dropRes {
+			if re.MatchString(line) {
+				continue lineLoop
+			}
+		}
+		if f.userDomainRe != nil && f.userDomainRe.MatchString(line) {
+			continue lineLoop
+		}
+		for _, r := range requestURIRedactions {
+			line = r.re.ReplaceAllString(line, r.replace)
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
 }
 
 // readOSRelease reads /etc/os-release and returns the PRETTY_NAME value.

--- a/internal/cli/bug_report_test.go
+++ b/internal/cli/bug_report_test.go
@@ -10,6 +10,8 @@ import (
 
 func TestScrubHomePath_replacesHome(t *testing.T) {
 	t.Setenv("HOME", "/home/testuser")
+	t.Setenv("USER", "testuser")
+	t.Setenv("LOGNAME", "testuser")
 	in := "log line referencing /home/testuser/.config/lerd/config.yaml here"
 	out := scrubHomePath(in)
 	if strings.Contains(out, "/home/testuser") {
@@ -17,6 +19,33 @@ func TestScrubHomePath_replacesHome(t *testing.T) {
 	}
 	if !strings.Contains(out, "$HOME/.config/lerd/config.yaml") {
 		t.Fatalf("expected $HOME placeholder, got: %q", out)
+	}
+}
+
+func TestScrubHomePath_replacesBareUsername(t *testing.T) {
+	t.Setenv("HOME", "/home/alice")
+	t.Setenv("USER", "alice")
+	t.Setenv("LOGNAME", "alice")
+	in := "user alice logged in; podman socket /run/user/1000/podman.sock; alice@host"
+	out := scrubHomePath(in)
+	if strings.Contains(out, "alice") {
+		t.Fatalf("bare username not scrubbed: %q", out)
+	}
+	for _, want := range []string{"user $USER logged in", "$USER@host"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output: %q", want, out)
+		}
+	}
+}
+
+func TestScrubHomePath_skipsShortUsername(t *testing.T) {
+	t.Setenv("HOME", "/home/jo")
+	t.Setenv("USER", "jo")
+	t.Setenv("LOGNAME", "jo")
+	in := "joined the channel; project=jojo"
+	out := scrubHomePath(in)
+	if out != in {
+		t.Fatalf("short username should not be replaced: got %q", out)
 	}
 }
 
@@ -38,7 +67,7 @@ func TestScrubHomePath_rootHome(t *testing.T) {
 
 func TestWriteBugReportHeader_includesVersionAndOS(t *testing.T) {
 	var buf bytes.Buffer
-	writeBugReportHeader(&buf)
+	writeBugReportHeader(&buf, nil)
 	out := buf.String()
 	for _, want := range []string{"Lerd bug report", "lerd:", "OS:", "Generated:"} {
 		if !strings.Contains(out, want) {
@@ -50,7 +79,7 @@ func TestWriteBugReportHeader_includesVersionAndOS(t *testing.T) {
 func TestWriteBugReport_createsFile(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "report.txt")
-	got, err := writeBugReport(target, 5)
+	got, err := writeBugReport(target, 5, false)
 	if err != nil {
 		t.Fatalf("writeBugReport: %v", err)
 	}
@@ -78,7 +107,7 @@ func TestWriteBugReport_defaultPath(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	got, err := writeBugReport("", 5)
+	got, err := writeBugReport("", 5, false)
 	if err != nil {
 		t.Fatalf("writeBugReport: %v", err)
 	}
@@ -91,6 +120,269 @@ func TestWriteBugReport_defaultPath(t *testing.T) {
 	wantDir, _ := filepath.EvalSymlinks(dir)
 	if gotDir != wantDir {
 		t.Errorf("default file not in cwd: %s (cwd=%s)", got, dir)
+	}
+}
+
+// ── Anonymizer ───────────────────────────────────────────────────────────────
+
+// setupAnonFixtures writes a sites.yaml and config.yaml into temp dirs so
+// newAnonymizer has something deterministic to read from.
+func setupAnonFixtures(t *testing.T, configYAML, sitesYAML string) {
+	t.Helper()
+	cfgDir := t.TempDir()
+	dataDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfgDir)
+	t.Setenv("XDG_DATA_HOME", dataDir)
+	t.Setenv("HOME", t.TempDir())
+
+	if err := os.MkdirAll(filepath.Join(cfgDir, "lerd"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "lerd", "config.yaml"), []byte(configYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dataDir, "lerd"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "lerd", "sites.yaml"), []byte(sitesYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAnonymizer_replacesSiteNamesAndDomains(t *testing.T) {
+	setupAnonFixtures(t, "dns:\n    enabled: true\n    tld: test\n", `sites:
+  - name: laravel
+    domains: [laravel.test, api.laravel.test]
+    path: /srv/laravel
+`)
+	a := newAnonymizer()
+	in := "lerd-queue-laravel restarted, see http://laravel.test/health and http://api.laravel.test/x"
+	out := a.Apply(in)
+	if strings.Contains(out, "laravel") {
+		t.Errorf("expected `laravel` to be replaced, got: %s", out)
+	}
+	for _, want := range []string{"lerd-queue-site-1", "site-1.test", "site-1-extra1.test"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestAnonymizer_replacesParkedDir(t *testing.T) {
+	t.Setenv("HOME", "/home/u")
+	setupAnonFixtures(t, "parked_directories:\n  - /home/u/Projects\n  - /srv/extra\n", "sites: []\n")
+	// Re-set HOME after setupAnonFixtures (it overrides it).
+	t.Setenv("HOME", "/home/u")
+	a := newAnonymizer()
+	in := "site at /home/u/Projects/foo and /srv/extra/bar"
+	out := a.Apply(in)
+	if !strings.Contains(out, "$PARK_1/foo") {
+		t.Errorf("expected $PARK_1, got: %s", out)
+	}
+	if !strings.Contains(out, "$PARK_2/bar") {
+		t.Errorf("expected $PARK_2, got: %s", out)
+	}
+}
+
+func TestAnonymizer_sitePathReplacedWholeBeforeBareName(t *testing.T) {
+	// Site `foo15` has its name appearing inside another site's path
+	// (`/srv/foo15.ro`). Without the full-path pair the bare-name
+	// replacement would corrupt the second site's path.
+	setupAnonFixtures(t, "", `sites:
+  - name: alpha
+    domains: [alpha.test]
+    path: /srv/foo15.ro
+  - name: foo15
+    domains: [foo15.test]
+    path: /srv/foo15
+`)
+	a := newAnonymizer()
+	in := "alpha lives at /srv/foo15.ro and foo15 lives at /srv/foo15"
+	out := a.Apply(in)
+	// Both site paths must collapse to opaque tokens, not partial
+	// substring rewrites.
+	if !strings.Contains(out, "$SITE_1_PATH") {
+		t.Errorf("expected $SITE_1_PATH, got: %s", out)
+	}
+	if !strings.Contains(out, "$SITE_2_PATH") {
+		t.Errorf("expected $SITE_2_PATH, got: %s", out)
+	}
+	// Bare site name in prose still becomes site-2.
+	if !strings.Contains(out, "site-2 lives at") {
+		t.Errorf("expected bare-name replacement, got: %s", out)
+	}
+}
+
+func TestAnonymizer_sitePathInsideParkedDir(t *testing.T) {
+	t.Setenv("HOME", "/home/u")
+	setupAnonFixtures(t, "parked_directories:\n  - /home/u/Lerd\n", `sites:
+  - name: laravel
+    domains: [laravel.test]
+    path: /home/u/Lerd/laravel
+`)
+	t.Setenv("HOME", "/home/u")
+	a := newAnonymizer()
+	in := "site path /home/u/Lerd/laravel"
+	out := a.Apply(in)
+	if !strings.Contains(out, "$PARK_1/site-1") {
+		t.Errorf("expected $PARK_1/site-1, got: %s", out)
+	}
+}
+
+func TestAnonymizer_nilAndEmptySafe(t *testing.T) {
+	var a *anonymizer
+	if got := a.Apply("hi"); got != "hi" {
+		t.Errorf("nil receiver: got %q", got)
+	}
+	empty := &anonymizer{}
+	if got := empty.Apply("hi"); got != "hi" {
+		t.Errorf("empty: got %q", got)
+	}
+	if a.active() {
+		t.Error("nil should not be active")
+	}
+	if empty.active() {
+		t.Error("empty should not be active")
+	}
+}
+
+// ── Content-unit and access-log filters ─────────────────────────────────────
+
+func TestIsContentUnit(t *testing.T) {
+	cases := map[string]bool{
+		// Lerd-core infra: kept, .service/.container suffixes tolerated.
+		"lerd-nginx":           false,
+		"lerd-ui":              false,
+		"lerd-watcher":         false,
+		"lerd-dns":             false,
+		"lerd-tray":            false,
+		"lerd-autostart":       false,
+		"lerd-fpm-init":        false,
+		"lerd-nginx.container": false,
+		"lerd-ui.service":      false,
+		// Preset services: dropped — app-domain noise.
+		"lerd-redis":       true,
+		"lerd-mysql":       true,
+		"lerd-postgres":    true,
+		"lerd-gotenberg":   true,
+		"lerd-meilisearch": true,
+		// FPM and per-site workers: dropped.
+		"lerd-php83-fpm":        true,
+		"lerd-php85-fpm":        true,
+		"lerd-queue-laravel":    true,
+		"lerd-schedule-laravel": true,
+		"lerd-horizon-myapp":    true,
+		"lerd-stripe-myapp":     true,
+		"lerd-reverb-myapp":     true,
+		// Custom containers / FrankenPHP per-site: dropped.
+		"lerd-custom-myapp": true,
+		"lerd-fp-myapp":     true,
+	}
+	for name, want := range cases {
+		if got := isContentUnit(name); got != want {
+			t.Errorf("isContentUnit(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestIsPrivateUnit(t *testing.T) {
+	custom := map[string]struct{}{
+		"lerd-myservice": {},
+	}
+	cases := map[string]bool{
+		"lerd-nginx":              false,
+		"lerd-redis":              false, // preset, not private
+		"lerd-myservice":          true,  // user-defined custom service
+		"lerd-myservice.service":  true,
+		"lerd-custom-myapp":       true,
+		"lerd-custom-x.container": true,
+		"lerd-fp-myapp":           true,
+		"lerd-fp-x.container":     true,
+		"lerd-queue-laravel":      false, // worker, not private
+		"lerd-php83-fpm":          false,
+	}
+	for name, want := range cases {
+		if got := isPrivateUnit(name, custom); got != want {
+			t.Errorf("isPrivateUnit(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestLogFilter_dropsCLF(t *testing.T) {
+	setupAnonFixtures(t, "", "sites: []\n")
+	f := newLogFilter()
+	in := strings.Join([]string{
+		`May 03 17:54:56 host lerd-nginx[1872]: 10.89.0.8 - - [03/May/2026:14:54:56 +0000] "GET / HTTP/1.1" 200 1205 "-" "UA"`,
+		`May 03 17:54:57 host lerd-nginx[1872]: 2026/05/03 14:54:57 [error] something broke`,
+	}, "\n")
+	out := f.clean(in)
+	if strings.Contains(out, `"GET / HTTP/1.1"`) {
+		t.Errorf("CLF line not dropped: %s", out)
+	}
+	if !strings.Contains(out, "something broke") {
+		t.Errorf("error line lost: %s", out)
+	}
+}
+
+func TestLogFilter_dropsMeilisearchHTTP(t *testing.T) {
+	setupAnonFixtures(t, "", "sites: []\n")
+	f := newLogFilter()
+	in := `INFO HTTP request{method=GET host="localhost:7700" route=/}: meilisearch: close`
+	if got := f.clean(in); got != "" {
+		t.Errorf("meilisearch HTTP line not dropped: %q", got)
+	}
+}
+
+func TestLogFilter_redactsRequestAndUpstream(t *testing.T) {
+	setupAnonFixtures(t, "", "sites: []\n")
+	f := newLogFilter()
+	in := `[error] 61#61: connect() failed, request: "GET /app/sensitive?token=abc HTTP/1.1", upstream: "http://10.89.7.8:8080/app/sensitive?token=abc", referrer: "https://other.com/page"`
+	out := f.clean(in)
+	for _, leaked := range []string{"sensitive", "token=abc", "other.com"} {
+		if strings.Contains(out, leaked) {
+			t.Errorf("%q leaked through redaction: %s", leaked, out)
+		}
+	}
+	for _, want := range []string{`"GET <redacted> HTTP/1.1"`, `upstream: "<redacted>"`, `referrer: "<redacted>"`, `connect() failed`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output: %s", want, out)
+		}
+	}
+}
+
+func TestLogFilter_passthroughWhenClean(t *testing.T) {
+	setupAnonFixtures(t, "", "sites: []\n")
+	f := newLogFilter()
+	in := "no http here\n[error] real error"
+	if got := f.clean(in); got != in {
+		t.Errorf("unexpected mutation: got %q want %q", got, in)
+	}
+}
+
+func TestLogFilter_dropsLinesMentioningUserDomain(t *testing.T) {
+	setupAnonFixtures(t, "", `sites:
+  - name: app
+    domains: [secret.example.test, api.secret.example.test]
+    path: /srv/app
+`)
+	f := newLogFilter()
+	in := strings.Join([]string{
+		`some infra line that is fine`,
+		`error from worker calling SECRET.EXAMPLE.test/api`,
+		`unrelated [error] keepme`,
+		`https://api.secret.example.test/x failed`,
+	}, "\n")
+	out := f.clean(in)
+	for _, leaked := range []string{"secret.example.test", "SECRET.EXAMPLE.test", "api.secret.example.test"} {
+		if strings.Contains(strings.ToLower(out), strings.ToLower(leaked)) {
+			t.Errorf("user domain %q leaked: %s", leaked, out)
+		}
+	}
+	if !strings.Contains(out, "some infra line that is fine") {
+		t.Errorf("infra line lost: %s", out)
+	}
+	if !strings.Contains(out, "unrelated [error] keepme") {
+		t.Errorf("unrelated error lost: %s", out)
 	}
 }
 

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -167,10 +167,36 @@ func EnsureDefaultPresetQuadlet(name string) error {
 			}
 		}
 	}
-	// track_latest: when there's no user pin, query the registry for the actual
-	// newest tag in the current major + variant line. The YAML preset.Image
-	// stays as a fallback when the registry is unreachable.
-	if !hasUserPin && p.TrackLatest {
+	// Honor the on-disk image when the preset's update_strategy says we
+	// shouldn't auto-jump to a newer line. Without this, the install rewrite
+	// (`lerd update` → `install --from-update` → this function) silently bumps
+	// users from their installed minor (e.g. meilisearch v1.7.x) to whatever
+	// the new preset.Image declares (v1.42), bypassing the per-service
+	// migration UX that `lerd service update` enforces. Rolling-strategy
+	// services (mailpit, rustfs, gotenberg) intentionally fall through to the
+	// preset image and the track_latest block below.
+	preservedExisting := false
+	if !hasUserPin {
+		strategy := registry.Strategy(p.UpdateStrategy)
+		if strategy == registry.StrategyPatch || strategy == registry.StrategyMinor || strategy == registry.StrategyNone {
+			if installed := podman.InstalledImage("lerd-" + name); installed != "" {
+				svc.Image = installed
+				preservedExisting = true
+				if strategy != registry.StrategyNone {
+					if newer, _ := registry.MaybeNewerTag(installed, strategy); newer != nil {
+						if at := strings.LastIndex(svc.Image, ":"); at > 0 {
+							svc.Image = svc.Image[:at] + ":" + newer.Name
+						}
+					}
+				}
+			}
+		}
+	}
+	// track_latest: when there's no user pin and we did not preserve an
+	// existing on-disk image, query the registry for the actual newest tag
+	// in the current major + variant line. The YAML preset.Image stays as a
+	// fallback when the registry is unreachable.
+	if !hasUserPin && !preservedExisting && p.TrackLatest {
 		if latest, _ := registry.NewestStable(svc.Image, p.AllowMajorUpgrade); latest != nil {
 			if at := strings.LastIndex(svc.Image, ":"); at > 0 {
 				svc.Image = svc.Image[:at] + ":" + latest.Name

--- a/internal/systemd/units/lerd-tray.service
+++ b/internal/systemd/units/lerd-tray.service
@@ -2,6 +2,14 @@
 Description=Lerd System Tray Applet
 After=graphical-session.target lerd-ui.service
 Wants=lerd-ui.service
+# Cap the restart loop. lerd-tray dies for two known unrecoverable reasons
+# that don't fix themselves on retry: missing libayatana-appindicator3.so.1
+# (Fedora 43 doesn't install it by default, dlopen fails with status 127),
+# and "Error reading events from display: Broken pipe" when the Wayland/X
+# session dies under it. Without these limits the unit restart-loops forever
+# at RestartSec cadence, spamming journalctl indefinitely.
+StartLimitBurst=3
+StartLimitIntervalSec=60
 
 [Service]
 # lerd-tray directly (not `lerd tray`, which is a nogui-build stub that
@@ -9,7 +17,7 @@ Wants=lerd-ui.service
 ExecStart=%h/.local/bin/lerd-tray
 Environment=LERD_TRAY_DAEMON=1
 Restart=on-failure
-RestartSec=5
+RestartSec=10
 Environment=DISPLAY=:0
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%U/bus
 

--- a/internal/ui/web/src/tabs/dashboard/HeroStatus.svelte
+++ b/internal/ui/web/src/tabs/dashboard/HeroStatus.svelte
@@ -19,7 +19,6 @@
   type HeroPriority = 'error' | 'updates' | 'ok';
 
   const failingWorkers = $derived($unhealthyWorkers.length);
-  const updatableServices = $derived($coreServices.filter((s) => s.update_available));
   const hasLerdUpdate = $derived($version.hasUpdate);
 
   const coreDown = $derived.by(() => {
@@ -33,7 +32,7 @@
 
   const priority = $derived.by((): HeroPriority => {
     if (failingWorkers > 0 || coreDown.length > 0) return 'error';
-    if (updatableServices.length > 0 || hasLerdUpdate) return 'updates';
+    if (hasLerdUpdate) return 'updates';
     return 'ok';
   });
 
@@ -116,21 +115,10 @@
       </svg>
       <div class="flex-1 min-w-0">
         <p class="text-sm font-semibold text-yellow-900 dark:text-yellow-200">
-          {#if hasLerdUpdate && updatableServices.length > 0}
-            {m.dashboard_hero_updatesMixed({ lerd: $version.latest, count: updatableServices.length })}
-          {:else if hasLerdUpdate}
-            {m.dashboard_hero_lerdUpdate({ version: $version.latest })}
-          {:else}
-            {m.dashboard_hero_serviceUpdates({ count: updatableServices.length })}
-          {/if}
+          {m.dashboard_hero_lerdUpdate({ version: $version.latest })}
         </p>
-        {#if updatableServices.length > 0}
-          <p class="text-xs text-yellow-700 dark:text-yellow-300/80 mt-0.5 truncate">
-            {updatableServices.map((s) => s.name).join(', ')}
-          </p>
-        {/if}
       </div>
-      {#if hasLerdUpdate && $accessMode.loopback}
+      {#if $accessMode.loopback}
         <button
           onclick={onUpdateLerd}
           disabled={updateTerminalLoading}
@@ -138,11 +126,6 @@
         >
           {updateTerminalLoading ? m.system_lerd_openingTerminal() : m.system_lerd_openTerminal()}
         </button>
-      {:else if updatableServices.length > 0}
-        <button
-          onclick={() => goToTab('services', updatableServices[0].name)}
-          class="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-yellow-600 hover:bg-yellow-700 text-white transition-colors"
-        >{m.dashboard_hero_review()}</button>
       {/if}
     </div>
   </div>

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.19.0-beta.5"
+	Version = "1.19.0-beta.6"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

Two follow-ups on top of beta.5, plus the release commit.

### Bug-report scope and anonymization

`lerd bug-report` was including too much app-domain noise and exposing user identifiers. Three changes:

- Logs are now collected only for lerd's own infra units (nginx, ui, dns, watcher, tray, autostart, fpm-init). Preset services (redis, mysql, gotenberg, meilisearch, …) still appear in the unit-state and container tables but their logs are dropped. They were producing repetitive request-shaped noise that didn't help triage.
- Custom services (defined under `~/.config/lerd/services/`), per-site custom containers (`lerd-custom-*`) and FrankenPHP per-site containers (`lerd-fp-*`) are now omitted from listings entirely, so the report doesn't expose user app identifiers.
- Site names / domains / parked-directory paths / home / username are anonymized by default into `site-N` / `siteN.<tld>` / `$PARK_N` / `$HOME` / `$USER`. `--show-real-names` keeps the raw values for local debugging.

### Install update_strategy and tray restart cap

- `lerd update` no longer silently bumps preset minors past the user's installed version. `EnsureDefaultPresetQuadlet` reads the existing on-disk image when `update_strategy` is `patch` / `minor` / `none` and there's no explicit pin in `config.yaml`, so users stay on their current minor and engines that hard-fail on cross-minor data dirs (meilisearch v1.7 → v1.42) no longer crash on `lerd update`.
- `lerd-tray.service` now caps the restart loop at 3 failures per 60 seconds. Two unrecoverable failure modes used to spin the unit indefinitely.
- Dashboard root page no longer renders the "Lerd info" banner twice.

Docs: `docs/troubleshooting.md` (Filing a bug report) and `docs/reference/commands.md` updated.