### PR TITLE
feat(services): allow removing default services, --purge data wipe, and reinstall with linked-site reprovision

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -152,7 +152,8 @@ Switch the PHP runtime for the current site between shared PHP-FPM and per-site 
 | `lerd service unpin <name>` | Unpin a service so it can be auto-stopped when unused |
 | `lerd service add [file.yaml]` | Register a new custom service (from a YAML file or flags) |
 | `lerd service preset [name]` | List bundled presets, or install one (use `--version` for multi-version presets) |
-| `lerd service remove <name>` | Stop and remove a custom service |
+| `lerd service remove <name> [--purge]` | Stop and remove a service (custom or default). With `--purge`, also rename the data dir aside (recoverable as `<name>.pre-remove-<ts>`) |
+| `lerd service reinstall <name> [--reset-data]` | Stop, remove, and reinstall at the current version. With `--reset-data`, rename the data dir aside and recreate linked sites' databases or buckets on the fresh service |
 | `lerd minio:migrate` | Migrate existing MinIO data to RustFS |
 
 ## Database

--- a/docs/usage/custom-services.md
+++ b/docs/usage/custom-services.md
@@ -30,13 +30,38 @@ lerd service add \
   --init-exec "mongosh admin -u root -p secret --eval \"db.getSiblingDB('{{site}}').createCollection('_init')\""
 ```
 
-## Removing a custom service
+## Removing a service (custom or default)
 
 ```bash
-lerd service remove mongodb
+lerd service remove mongodb            # stops + removes; data preserved
+lerd service remove mongodb --purge    # also wipes data dir
 ```
 
-This stops the container, removes the quadlet and config file. **Data at `~/.local/share/lerd/data/mongodb/` is not deleted**. Remove it manually if you no longer need it.
+`lerd service remove` works for any service, including default presets (postgres, redis, mariadb, mysql, meilisearch, mailpit, rustfs). The flow stops the unit if it's running, removes the container, deletes the quadlet, and removes the on-disk config (a no-op for default presets, which are embedded in the binary).
+
+Pass `--purge` to also wipe the persistent data. The data dir at `~/.local/share/lerd/data/<service>/` is **renamed aside** to `<service>.pre-remove-<timestamp>` (a sibling directory), not hard-deleted. To recover, rename it back before reinstalling. The orphaned aside copies can be cleaned up later by hand.
+
+Without `--purge`, data is preserved and a subsequent `lerd service preset install <name>` (for default presets) or `lerd service add` (for custom services) will pick up where you left off.
+
+## Reinstalling a service
+
+```bash
+lerd service reinstall postgres                # same version, data preserved
+lerd service reinstall postgres --reset-data   # same version, fresh data
+```
+
+`reinstall` stops, removes, and reinstalls the service at its current version. Use it when:
+
+- A service update produced data incompatible with the new image and you want a clean slate.
+- The container has drifted into a bad state and a full quadlet rewrite would be cleaner than a restart.
+
+`--reset-data` adds a data-dir rename-aside (same recovery semantics as `--purge`) and **automatically reprovisions linked-site state** on the freshly installed service:
+
+- For database families (mysql, mariadb, postgres): each linked site's expected database is created via `CREATE DATABASE IF NOT EXISTS`. The database name comes from `.lerd.yaml` `db.database`, then `.env` `DB_DATABASE`, then the site name with hyphens converted to underscores.
+- For object-storage families (rustfs): each linked site's expected bucket is created via `mc mb`. The bucket name comes from `.env` `AWS_BUCKET`, otherwise derived from the site name.
+- For cache services (redis, memcached): no per-site state to recreate, so reprovisioning is a no-op.
+
+If a single linked site fails to reprovision (e.g. malformed `.env`), the reinstall continues with the remaining sites and reports the joined errors at the end.
 
 ## YAML schema
 

--- a/docs/usage/database.md
+++ b/docs/usage/database.md
@@ -113,3 +113,11 @@ lerd db:shell --service postgres --database myapp
 #   database: myapp
 lerd db:shell
 ```
+
+## Recovering after a service reinstall
+
+`lerd service reinstall <name> --reset-data` wipes the database server's data dir (rename-aside, recoverable) and then walks every active site that depends on the service to recreate the database it expects via `CREATE DATABASE IF NOT EXISTS`. Database name resolution is the same as `lerd env`: `.lerd.yaml` `db.database` first, then `.env` `DB_DATABASE`, then a name derived from the site name.
+
+The DBs come back empty. The previous data lives next door as `~/.local/share/lerd/data/<name>.pre-remove-<timestamp>`. If you need the old contents, stop the service, rename the aside dir back over the new data dir, and start the service again.
+
+If you only want to recreate a single missing database without wiping the whole server, use `lerd db:create` against the live service instead.

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -143,3 +143,7 @@ Shows a live snapshot: DNS reachability, nginx, PHP-FPM containers, watcher, ser
 | Free up CPU / RAM during a heavy build | `lerd stop` |
 | Full shutdown before a reinstall | `lerd quit` |
 | Verify everything's healthy | `lerd status` |
+| Uninstall a service entirely (data preserved) | `lerd service remove <name>` |
+| Uninstall and wipe data | `lerd service remove <name> --purge` |
+| Reinstall a service in place | `lerd service reinstall <name>` |
+| Reinstall with fresh data + reprovision linked sites | `lerd service reinstall <name> --reset-data` |

--- a/docs/usage/service-presets.md
+++ b/docs/usage/service-presets.md
@@ -186,3 +186,9 @@ natively. Right-click "Copy link" works.
 
 `mongo` declares its own `connection_url:` (see [YAML schema](custom-services.md#yaml-schema)
 in the custom services reference) so it gets the same treatment as the built-in databases.
+
+## Removing and reinstalling presets
+
+Default presets can be removed: `lerd service remove postgres` (or any other) stops the unit, deletes the quadlet, and frees the slot. The preset itself stays available in `lerd service preset list` as not-installed, so a future `lerd service preset postgres` brings it back. Pass `--purge` to also rename the data dir aside.
+
+`lerd service reinstall <name>` stops, removes, and reinstalls at the current version. `--reset-data` wipes the data and recreates per-site state on the fresh container (databases for mysql/mariadb/postgres, buckets for rustfs). See [custom services](custom-services.md#reinstalling-a-service) for the resolution rules.

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -18,6 +18,7 @@ import (
 	"github.com/geodro/lerd/internal/envfile"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/serviceops"
 	"github.com/spf13/cobra"
 )
 
@@ -566,7 +567,7 @@ func frameworkServiceDetected(def config.FrameworkServiceDef, envMap map[string]
 
 // CreateDatabase is the exported variant of createDatabase. Used by callers
 // outside the cli package (e.g. the worktree DB-isolation flow).
-func CreateDatabase(svc, name string) (bool, error) { return createDatabase(svc, name) }
+func CreateDatabase(svc, name string) (bool, error) { return serviceops.CreateDatabase(svc, name) }
 
 // CloneDatabase copies the schema and data from src into dst inside the same
 // service container. dst must already exist. Returns an error if the family
@@ -661,127 +662,15 @@ func DropDatabase(svc, name string) (bool, error) {
 	}
 }
 
-// createDatabase creates a database with the given name in the mysql or postgres container.
-// Returns (true, nil) if created, (false, nil) if it already existed, or (false, err) on failure.
-// createDatabase creates dbName inside the named service container if it does
-// not already exist. svc is the service name (e.g. "mysql", "mysql-5-6",
-// "mariadb-11", "postgres-14"); the container is always "lerd-<svc>". The
-// SQL client used is determined by the family inferred from svc.
-func createDatabase(svc, name string) (bool, error) {
-	container := "lerd-" + svc
-	family := svc
-	if inferred := config.InferFamily(svc); inferred != "" {
-		family = inferred
-	}
-	switch family {
-	case "mysql", "mariadb":
-		// MariaDB 11 removed the `mysql` client symlink. Try `mariadb` first
-		// for the mariadb family, `mysql` first for the mysql family, then
-		// fall back to the other so old MariaDB images and new MySQL images
-		// both work.
-		binaries := []string{"mysql", "mariadb"}
-		if family == "mariadb" {
-			binaries = []string{"mariadb", "mysql"}
-		}
-		var lastErr error
-		for _, bin := range binaries {
-			check := podman.Cmd("exec", container, bin, "-uroot", "-plerd",
-				"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", name))
-			out, err := check.Output()
-			if err != nil {
-				lastErr = err
-				continue
-			}
-			if strings.TrimSpace(string(out)) != "0" {
-				return false, nil
-			}
-			cmd := podman.Cmd("exec", container, bin, "-uroot", "-plerd",
-				"-e", fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`;", name))
-			cmd.Stderr = os.Stderr
-			return true, cmd.Run()
-		}
-		return false, lastErr
-	case "postgres":
-		cmd := podman.Cmd("exec", container, "psql", "-U", "postgres",
-			"-c", fmt.Sprintf(`CREATE DATABASE "%s";`, name))
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			if strings.Contains(string(out), "already exists") {
-				return false, nil
-			}
-			return false, fmt.Errorf("%s", strings.TrimSpace(string(out)))
-		}
-		return true, nil
-	default:
-		return false, nil
-	}
-}
+// createDatabase delegates to serviceops.CreateDatabase. Kept as a package-local
+// alias so existing call sites inside the cli package compile unchanged.
+func createDatabase(svc, name string) (bool, error) { return serviceops.CreateDatabase(svc, name) }
 
-// s3BucketName converts a project handle into a valid S3 bucket name:
-// lowercase, hyphens instead of underscores, leading/trailing non-alphanumerics
-// stripped, max length 63. Reuses the standard MinIO/S3 naming rules so the
-// resulting bucket is portable.
-func s3BucketName(name string) string {
-	var b strings.Builder
-	for _, r := range strings.ToLower(name) {
-		switch {
-		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.':
-			b.WriteRune(r)
-		case r == '_', r == '-', r == ' ':
-			b.WriteByte('-')
-		}
-	}
-	out := strings.Trim(b.String(), "-.")
-	if len(out) > 63 {
-		out = out[:63]
-	}
-	if out == "" {
-		out = "lerd"
-	}
-	return out
-}
+// s3BucketName delegates to serviceops.S3BucketName.
+func s3BucketName(name string) string { return serviceops.S3BucketName(name) }
 
-// createS3Bucket creates a bucket for the given name in lerd-rustfs using an ephemeral mc container.
-// Returns (true, nil) if created, (false, nil) if it already existed, or (false, err) on failure.
-// Retries up to 3 times (2 s apart) to bridge the window between the host TCP port becoming
-// reachable and the container network being fully ready for mc operations.
-func createS3Bucket(name string) (bool, error) {
-	const (
-		alias   = "lerd"
-		mcImage = "docker.io/minio/mc:latest"
-		mcEnv   = "MC_HOST_lerd=http://lerd:lerdpassword@lerd-rustfs:9000"
-	)
-
-	var lastErr error
-	for attempt := 0; attempt < 3; attempt++ {
-		if attempt > 0 {
-			time.Sleep(2 * time.Second)
-		}
-
-		// Bucket already exists?
-		lsCmd := podman.Cmd("run", "--rm", "--network", "lerd",
-			"-e", mcEnv, mcImage, "ls", alias+"/"+name)
-		if lsCmd.Run() == nil {
-			return false, nil
-		}
-
-		mbCmd := podman.Cmd("run", "--rm", "--network", "lerd",
-			"-e", mcEnv, mcImage, "mb", alias+"/"+name)
-		out, err := mbCmd.CombinedOutput()
-		if err != nil {
-			lastErr = fmt.Errorf("%s", strings.TrimSpace(string(out)))
-			continue
-		}
-
-		pubCmd := podman.Cmd("run", "--rm", "--network", "lerd",
-			"-e", mcEnv, mcImage, "anonymous", "set", "public", alias+"/"+name)
-		if out, err := pubCmd.CombinedOutput(); err != nil {
-			return false, fmt.Errorf("mc anonymous set public: %s", strings.TrimSpace(string(out)))
-		}
-		return true, nil
-	}
-	return false, lastErr
-}
+// createS3Bucket delegates to serviceops.EnsureS3Bucket.
+func createS3Bucket(name string) (bool, error) { return serviceops.EnsureS3Bucket(name) }
 
 // ensureServiceRunning starts the service if it is not already active, then
 // waits until it is ready to accept connections before returning.

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -57,6 +57,7 @@ func NewServiceCmd() *cobra.Command {
 	cmd.AddCommand(newServiceRollbackCmd())
 	cmd.AddCommand(newServiceMigrateCmd())
 	cmd.AddCommand(newServiceRemoveCmd())
+	cmd.AddCommand(newServiceReinstallCmd())
 	cmd.AddCommand(newServiceExposeCmd())
 	cmd.AddCommand(newServicePinCmd())
 	cmd.AddCommand(newServiceUnpinCmd())
@@ -698,63 +699,101 @@ func MissingPresetDependencies(svc *config.CustomService) []string {
 
 // newServiceRemoveCmd returns the `service remove` command.
 func newServiceRemoveCmd() *cobra.Command {
-	return &cobra.Command{
+	var purge bool
+	cmd := &cobra.Command{
 		Use:   "remove <service>",
-		Short: "Stop and remove a custom service",
+		Short: "Stop and remove a service (custom or default)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			name := args[0]
 
-			if isKnownService(name) {
-				return fmt.Errorf("%q is a built-in service and cannot be removed", name)
+			if purge {
+				dataPath := config.DataSubDir(name)
+				fmt.Printf("Removing service %q and ALL its data at %s.\n", name, dataPath)
 			}
 
-			// Capture the family before deletion so consumers can be regenerated.
-			var family string
-			if existing, err := config.LoadCustomService(name); err == nil {
-				family = existing.Family
-			}
-
-			unit := "lerd-" + name
-
-			// Stop the unit if it is running.
-			status, _ := podman.UnitStatus(unit)
-			if status == "active" || status == "activating" {
-				fmt.Printf("Stopping %s...\n", unit)
-				if err := podman.StopUnit(unit); err != nil {
-					return fmt.Errorf("could not stop %s: %w\nRemove aborted — the service is still running", unit, err)
+			emit := func(e serviceops.PhaseEvent) {
+				switch e.Phase {
+				case "stopping_unit":
+					fmt.Printf("Stopping %s...\n", e.Unit)
+				case "removing_data":
+					fmt.Printf("Renaming data dir aside: %s\n", e.Message)
+				case "done":
+					fmt.Printf("Removed service %q.\n", name)
 				}
 			}
-			podman.RemoveContainer(unit)
 
-			if err := podman.RemoveQuadlet(unit); err != nil {
-				fmt.Printf("  WARN: could not remove quadlet: %v\n", err)
-			}
-			if err := podman.DaemonReloadFn(); err != nil {
-				fmt.Printf("  WARN: daemon-reload failed: %v\n", err)
+			if err := serviceops.RemoveService(name, serviceops.RemoveOptions{RemoveData: purge}, emit); err != nil {
+				return err
 			}
 
-			if err := config.RemoveCustomService(name); err != nil {
-				return fmt.Errorf("removing service config: %w", err)
+			if !purge {
+				fmt.Printf("Data at %s was NOT removed. Pass --purge to wipe it.\n", config.DataSubDir(name))
 			}
-
-			if family != "" {
-				serviceops.RegenerateFamilyConsumers(family)
-			}
-
-			dataPath := config.DataSubDir(name)
-			fmt.Printf("Removed service %q.\n", name)
-			fmt.Printf("Data at %s was NOT removed. Delete it manually if no longer needed.\n", dataPath)
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&purge, "purge", false, "also rename the service data dir aside (recoverable as <dir>.pre-remove-<ts>)")
+	return cmd
+}
+
+// newServiceReinstallCmd returns the `service reinstall` command. Stops,
+// removes, and reinstalls the same version. With --reset-data the data dir
+// is renamed-aside and per-site DBs/buckets are recreated on the fresh service.
+func newServiceReinstallCmd() *cobra.Command {
+	var resetData bool
+	cmd := &cobra.Command{
+		Use:   "reinstall <service>",
+		Short: "Stop, remove, and reinstall a service in place",
+		Long:  "Reinstall the service at its current version. With --reset-data the data dir is renamed-aside (recoverable) and any linked sites' databases or buckets are recreated on the fresh service.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			name := args[0]
+			emit := func(e serviceops.PhaseEvent) {
+				switch e.Phase {
+				case "reinstall_starting":
+					fmt.Printf("Reinstalling %s...\n", name)
+				case "stopping_unit":
+					fmt.Printf("  stopping %s\n", e.Unit)
+				case "removing_data":
+					fmt.Printf("  renaming data dir aside: %s\n", e.Message)
+				case "pulling_image":
+					if e.Message == "" && e.Image != "" {
+						fmt.Printf("  pulling %s\n", e.Image)
+					}
+				case "starting_unit":
+					fmt.Printf("  starting %s\n", e.Unit)
+				case "waiting_ready":
+					fmt.Printf("  waiting for %s to be ready\n", e.Unit)
+				case "reprovisioning_sites":
+					fmt.Printf("  reprovisioning linked sites: %s\n", e.Message)
+				case "reprovisioning_site":
+					fmt.Printf("    %s\n", e.Message)
+				case "reprovisioning_skipped":
+					fmt.Printf("  reprovisioning skipped: %s\n", e.Message)
+				}
+			}
+			if err := serviceops.ReinstallService(name, resetData, emit); err != nil {
+				return err
+			}
+			fmt.Printf("Reinstalled %q.\n", name)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&resetData, "reset-data", false, "wipe data dir (rename-aside) and recreate linked-site databases/buckets on the fresh service")
+	return cmd
 }
 
 // migrateServiceUnits rewrites unit files for all globally configured services.
 // This ensures BindForLAN and other install-time settings are applied even for
-// services that already have a unit file on disk.
+// services that already have a unit file on disk. Default presets are skipped
+// when no quadlet exists for them (i.e. the user removed the service); without
+// this skip a subsequent CLI invocation would silently recreate the quadlet.
 func migrateServiceUnits() {
 	for _, svc := range knownServices() {
+		if !podman.QuadletInstalled("lerd-" + svc) {
+			continue
+		}
 		ensureServiceQuadlet(svc) //nolint:errcheck
 	}
 	customs, _ := config.ListCustomServices()

--- a/internal/cli/services_test.go
+++ b/internal/cli/services_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestServiceReinstallCmd_HasResetDataFlag(t *testing.T) {
+	cmd := newServiceReinstallCmd()
+	flag := cmd.Flags().Lookup("reset-data")
+	if flag == nil {
+		t.Fatal("--reset-data flag missing on `service reinstall`")
+	}
+	if flag.Value.Type() != "bool" {
+		t.Errorf("--reset-data flag type = %q, want bool", flag.Value.Type())
+	}
+}
+
+func TestServiceReinstallCmd_WiredIntoServiceCmd(t *testing.T) {
+	parent := NewServiceCmd()
+	var found bool
+	for _, c := range parent.Commands() {
+		if c.Name() == "reinstall" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("`service reinstall` subcommand not registered under `service`")
+	}
+}
+
+func TestServiceRemoveCmd_HasPurgeFlag(t *testing.T) {
+	cmd := newServiceRemoveCmd()
+	flag := cmd.Flags().Lookup("purge")
+	if flag == nil {
+		t.Fatal("--purge flag missing on `service remove`")
+	}
+	if flag.Value.Type() != "bool" {
+		t.Errorf("--purge flag type = %q, want bool", flag.Value.Type())
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--purge default = %q, want false", flag.DefValue)
+	}
+}
+
+// migrateServiceUnits must only refresh quadlets that already exist on disk.
+// If a default service was deliberately removed (no quadlet present), the
+// next CLI invocation must NOT silently recreate it.
+func TestMigrateServiceUnits_SkipsUninstalledDefaultPresets(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	quadletDir := config.QuadletDir()
+	if err := os.MkdirAll(quadletDir, 0o755); err != nil {
+		t.Fatalf("mkdir quadlet dir: %v", err)
+	}
+
+	// Sanity: no quadlets exist for any default preset in this fresh tmp env.
+	migrateServiceUnits()
+
+	for _, svc := range knownServices() {
+		path := filepath.Join(quadletDir, "lerd-"+svc+".container")
+		if _, err := os.Stat(path); err == nil {
+			t.Errorf("quadlet for uninstalled default preset %q was recreated at %s", svc, path)
+		}
+	}
+}

--- a/internal/config/service_manual.go
+++ b/internal/config/service_manual.go
@@ -153,36 +153,43 @@ func CountSitesUsingPHP(version string) int {
 	return count
 }
 
-// CountSitesUsingService returns how many active (non-ignored, non-paused) site
-// .env files reference lerd-{name}, i.e. are configured to use the service.
-func CountSitesUsingService(name string) int {
+// SitesUsingService returns the active (non-ignored, non-paused) sites whose
+// .lerd.yaml lists the service or whose .env references lerd-{name}.
+func SitesUsingService(name string) []Site {
 	reg, err := LoadSites()
 	if err != nil {
-		return 0
+		return nil
 	}
 	needle := "lerd-" + name
-	count := 0
+	var out []Site
 	for _, s := range reg.Sites {
 		if s.Ignored || s.Paused {
 			continue
 		}
-		// Check .lerd.yaml services list (covers custom container sites
-		// that may not have a .env with lerd-{name} references).
 		if proj, pErr := LoadProjectConfig(s.Path); pErr == nil {
+			matched := false
 			for _, svc := range proj.Services {
 				if svc.Name == name {
-					count++
-					goto next
+					out = append(out, s)
+					matched = true
+					break
 				}
 			}
-		}
-		// Fall back to .env scanning for PHP sites.
-		if data, err := os.ReadFile(filepath.Join(s.Path, ".env")); err == nil {
-			if strings.Contains(string(data), needle) {
-				count++
+			if matched {
+				continue
 			}
 		}
-	next:
+		if data, err := os.ReadFile(filepath.Join(s.Path, ".env")); err == nil {
+			if strings.Contains(string(data), needle) {
+				out = append(out, s)
+			}
+		}
 	}
-	return count
+	return out
+}
+
+// CountSitesUsingService returns how many active (non-ignored, non-paused) site
+// .env files reference lerd-{name}, i.e. are configured to use the service.
+func CountSitesUsingService(name string) int {
+	return len(SitesUsingService(name))
 }

--- a/internal/config/service_manual_test.go
+++ b/internal/config/service_manual_test.go
@@ -146,3 +146,83 @@ func TestCountSitesUsingService_PausedSiteSkipped(t *testing.T) {
 		t.Errorf("CountSitesUsingService(redis) = %d, want 0 for paused site", count)
 	}
 }
+
+func TestSitesUsingService_ReturnsLinkedSites(t *testing.T) {
+	setDataDir(t)
+
+	yamlSiteDir := t.TempDir()
+	os.WriteFile(filepath.Join(yamlSiteDir, ".lerd.yaml"), []byte("services:\n  - mariadb\n"), 0644)
+	if err := AddSite(Site{Name: "yaml-site", Domains: []string{"yaml.test"}, Path: yamlSiteDir}); err != nil {
+		t.Fatalf("AddSite yaml: %v", err)
+	}
+
+	envSiteDir := t.TempDir()
+	os.WriteFile(filepath.Join(envSiteDir, ".env"), []byte("DB_HOST=lerd-mariadb\n"), 0644)
+	if err := AddSite(Site{Name: "env-site", Domains: []string{"env.test"}, Path: envSiteDir}); err != nil {
+		t.Fatalf("AddSite env: %v", err)
+	}
+
+	otherSiteDir := t.TempDir()
+	os.WriteFile(filepath.Join(otherSiteDir, ".env"), []byte("DB_HOST=lerd-postgres\n"), 0644)
+	if err := AddSite(Site{Name: "other-site", Domains: []string{"other.test"}, Path: otherSiteDir}); err != nil {
+		t.Fatalf("AddSite other: %v", err)
+	}
+
+	sites := SitesUsingService("mariadb")
+	if len(sites) != 2 {
+		t.Fatalf("SitesUsingService(mariadb) returned %d sites, want 2", len(sites))
+	}
+	names := map[string]bool{}
+	for _, s := range sites {
+		names[s.Name] = true
+	}
+	if !names["yaml-site"] || !names["env-site"] {
+		t.Errorf("expected both yaml-site and env-site, got %v", names)
+	}
+	if names["other-site"] {
+		t.Errorf("other-site (uses postgres) should not be in mariadb result")
+	}
+}
+
+func TestSitesUsingService_SkipsIgnoredAndPaused(t *testing.T) {
+	setDataDir(t)
+
+	activeDir := t.TempDir()
+	os.WriteFile(filepath.Join(activeDir, ".lerd.yaml"), []byte("services:\n  - redis\n"), 0644)
+	if err := AddSite(Site{Name: "active", Domains: []string{"active.test"}, Path: activeDir}); err != nil {
+		t.Fatalf("AddSite active: %v", err)
+	}
+
+	ignoredDir := t.TempDir()
+	os.WriteFile(filepath.Join(ignoredDir, ".lerd.yaml"), []byte("services:\n  - redis\n"), 0644)
+	if err := AddSite(Site{Name: "ignored", Domains: []string{"i.test"}, Path: ignoredDir, Ignored: true}); err != nil {
+		t.Fatalf("AddSite ignored: %v", err)
+	}
+
+	pausedDir := t.TempDir()
+	os.WriteFile(filepath.Join(pausedDir, ".lerd.yaml"), []byte("services:\n  - redis\n"), 0644)
+	if err := AddSite(Site{Name: "paused", Domains: []string{"p.test"}, Path: pausedDir, Paused: true}); err != nil {
+		t.Fatalf("AddSite paused: %v", err)
+	}
+
+	sites := SitesUsingService("redis")
+	if len(sites) != 1 || sites[0].Name != "active" {
+		t.Errorf("SitesUsingService(redis) = %v, want only [active]", sites)
+	}
+}
+
+func TestSitesUsingService_LerdYAMLTakesPriorityOverEnv(t *testing.T) {
+	setDataDir(t)
+
+	siteDir := t.TempDir()
+	os.WriteFile(filepath.Join(siteDir, ".lerd.yaml"), []byte("services:\n  - postgres\n"), 0644)
+	os.WriteFile(filepath.Join(siteDir, ".env"), []byte("DB_HOST=lerd-postgres\n"), 0644)
+	if err := AddSite(Site{Name: "dual", Domains: []string{"d.test"}, Path: siteDir}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	sites := SitesUsingService("postgres")
+	if len(sites) != 1 {
+		t.Errorf("SitesUsingService(postgres) returned %d sites, want 1 (no double-counting)", len(sites))
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -206,13 +206,15 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "service_control",
-			Description: "Lifecycle. update=pull. migrate=dump+restore across data-breaking versions. rollback=revert. remove=delete custom.",
+			Description: "Lifecycle. update=pull. migrate=dump+restore. rollback=revert. remove=delete; remove_data also wipes data dir (rename-aside). reinstall=stop+remove+install same version; reset_data wipes data and reprovisions linked sites' DBs/buckets.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
-					"action": {Type: "string", Enum: []string{"start", "stop", "restart", "pin", "unpin", "update", "rollback", "migrate", "remove"}},
-					"name":   {Type: "string"},
-					"tag":    {Type: "string", Description: "For update/migrate."},
+					"action":      {Type: "string", Enum: []string{"start", "stop", "restart", "pin", "unpin", "update", "rollback", "migrate", "remove", "reinstall"}},
+					"name":        {Type: "string"},
+					"tag":         {Type: "string", Description: "For update/migrate."},
+					"remove_data": {Type: "boolean", Description: "remove: rename data aside."},
+					"reset_data":  {Type: "boolean", Description: "reinstall: wipe data, reprovision."},
 				},
 				Required: []string{"action", "name"},
 			},
@@ -965,6 +967,8 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 			return execServiceMigrate(args)
 		case "remove":
 			return execServiceRemove(args)
+		case "reinstall":
+			return execServiceReinstall(args)
 		default:
 			return unknownAction("service_control")
 		}
@@ -2584,22 +2588,31 @@ func execServiceRemove(args map[string]any) (any, *rpcError) {
 	if name == "" {
 		return toolErr("name is required"), nil
 	}
-	if isKnownService(name) {
-		return toolErr(name + " is a built-in service and cannot be removed"), nil
+	removeData := boolArg(args, "remove_data")
+
+	if err := serviceops.RemoveService(name, serviceops.RemoveOptions{RemoveData: removeData}, nil); err != nil {
+		return toolErr(err.Error()), nil
 	}
 
-	unit := "lerd-" + name
-	_ = podman.StopUnit(unit)
-	podman.RemoveContainer(unit)
-	if err := podman.RemoveQuadlet(unit); err != nil {
-		return toolErr("removing quadlet: " + err.Error()), nil
+	if removeData {
+		return toolOK(fmt.Sprintf("Service %q removed. Data renamed aside as %s.pre-remove-<ts>.", name, config.DataSubDir(name))), nil
 	}
-	_ = podman.DaemonReloadFn()
-	if err := config.RemoveCustomService(name); err != nil {
-		return toolErr("removing service config: " + err.Error()), nil
-	}
-
 	return toolOK(fmt.Sprintf("Service %q removed. Persistent data was NOT deleted.", name)), nil
+}
+
+func execServiceReinstall(args map[string]any) (any, *rpcError) {
+	name := strArg(args, "name")
+	if name == "" {
+		return toolErr("name is required"), nil
+	}
+	resetData := boolArg(args, "reset_data")
+	if err := serviceops.ReinstallService(name, resetData, nil); err != nil {
+		return toolErr(err.Error()), nil
+	}
+	if resetData {
+		return toolOK(fmt.Sprintf("Service %q reinstalled with fresh data; linked sites' DBs/buckets were recreated.", name)), nil
+	}
+	return toolOK(fmt.Sprintf("Service %q reinstalled (data preserved).", name)), nil
 }
 
 func execServicePresetList(_ map[string]any) (any, *rpcError) {

--- a/internal/serviceops/provision.go
+++ b/internal/serviceops/provision.go
@@ -1,0 +1,128 @@
+package serviceops
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// CreateDatabase creates dbName inside the named service container if it does
+// not already exist. svc is the service name (e.g. "mysql", "mysql-5-6",
+// "mariadb-11", "postgres-14"); the container is always "lerd-<svc>". The
+// SQL client used is determined by the family inferred from svc.
+// Returns (true, nil) if created, (false, nil) if it already existed,
+// or (false, err) on failure.
+func CreateDatabase(svc, name string) (bool, error) {
+	container := "lerd-" + svc
+	family := svc
+	if inferred := config.InferFamily(svc); inferred != "" {
+		family = inferred
+	}
+	switch family {
+	case "mysql", "mariadb":
+		binaries := []string{"mysql", "mariadb"}
+		if family == "mariadb" {
+			binaries = []string{"mariadb", "mysql"}
+		}
+		var lastErr error
+		for _, bin := range binaries {
+			check := podman.Cmd("exec", container, bin, "-uroot", "-plerd",
+				"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", name))
+			out, err := check.Output()
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			if strings.TrimSpace(string(out)) != "0" {
+				return false, nil
+			}
+			cmd := podman.Cmd("exec", container, bin, "-uroot", "-plerd",
+				"-e", fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`;", name))
+			cmd.Stderr = os.Stderr
+			return true, cmd.Run()
+		}
+		return false, lastErr
+	case "postgres":
+		cmd := podman.Cmd("exec", container, "psql", "-U", "postgres",
+			"-c", fmt.Sprintf(`CREATE DATABASE "%s";`, name))
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			if strings.Contains(string(out), "already exists") {
+				return false, nil
+			}
+			return false, fmt.Errorf("%s", strings.TrimSpace(string(out)))
+		}
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+// S3BucketName converts a project handle into a valid S3 bucket name:
+// lowercase, hyphens instead of underscores, leading/trailing non-alphanumerics
+// stripped, max length 63.
+func S3BucketName(name string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(name) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.':
+			b.WriteRune(r)
+		case r == '_', r == '-', r == ' ':
+			b.WriteByte('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-.")
+	if len(out) > 63 {
+		out = out[:63]
+	}
+	if out == "" {
+		out = "lerd"
+	}
+	return out
+}
+
+// EnsureS3Bucket creates a bucket for the given name in lerd-rustfs using an
+// ephemeral mc container. Returns (true, nil) if created, (false, nil) if it
+// already existed, or (false, err) on failure. Retries up to 3 times (2s apart)
+// to bridge the window between the host TCP port becoming reachable and the
+// container network being fully ready for mc operations.
+func EnsureS3Bucket(name string) (bool, error) {
+	const (
+		alias   = "lerd"
+		mcImage = "docker.io/minio/mc:latest"
+		mcEnv   = "MC_HOST_lerd=http://lerd:lerdpassword@lerd-rustfs:9000"
+	)
+
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			time.Sleep(2 * time.Second)
+		}
+
+		lsCmd := podman.Cmd("run", "--rm", "--network", "lerd",
+			"-e", mcEnv, mcImage, "ls", alias+"/"+name)
+		if lsCmd.Run() == nil {
+			return false, nil
+		}
+
+		mbCmd := podman.Cmd("run", "--rm", "--network", "lerd",
+			"-e", mcEnv, mcImage, "mb", alias+"/"+name)
+		out, err := mbCmd.CombinedOutput()
+		if err != nil {
+			lastErr = fmt.Errorf("%s", strings.TrimSpace(string(out)))
+			continue
+		}
+
+		pubCmd := podman.Cmd("run", "--rm", "--network", "lerd",
+			"-e", mcEnv, mcImage, "anonymous", "set", "public", alias+"/"+name)
+		if out, err := pubCmd.CombinedOutput(); err != nil {
+			return false, fmt.Errorf("mc anonymous set public: %s", strings.TrimSpace(string(out)))
+		}
+		return true, nil
+	}
+	return false, lastErr
+}

--- a/internal/serviceops/reinstall.go
+++ b/internal/serviceops/reinstall.go
@@ -1,0 +1,103 @@
+package serviceops
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// Seams for ReinstallService composition. The defaults wire to the real
+// install + reprovision functions; tests substitute fakes.
+var (
+	reinstallInstallFn = realReinstallInstall
+	reinstallReprovFn  = ReprovisionLinkedSites
+)
+
+// ReinstallService stops, removes, and reinstalls a service, optionally wiping
+// its data and reprovisioning per-site state (databases, buckets) on the
+// fresh service.
+//
+// Reinstall requires that the service is currently installed: for default
+// presets that means a quadlet on disk; for custom services that means a
+// custom-service YAML. If neither is found ReinstallService returns an error.
+//
+// When resetData is true the data dir is renamed-aside (recoverable as
+// .pre-remove-<ts>) and ReprovisionLinkedSites is invoked after the install
+// completes so dependent sites' DBs/buckets exist on the fresh service.
+func ReinstallService(name string, resetData bool, emit func(PhaseEvent)) error {
+	if emit == nil {
+		emit = func(PhaseEvent) {}
+	}
+	emit(PhaseEvent{Phase: "reinstall_starting"})
+
+	version, err := captureInstalledVersion(name)
+	if err != nil {
+		return err
+	}
+
+	if err := RemoveService(name, RemoveOptions{RemoveData: resetData}, emit); err != nil {
+		return fmt.Errorf("reinstall: remove step: %w", err)
+	}
+
+	if _, err := reinstallInstallFn(name, version, emit); err != nil {
+		return fmt.Errorf("reinstall: install step: %w", err)
+	}
+
+	if resetData {
+		if err := reinstallReprovFn(name, emit); err != nil {
+			return fmt.Errorf("reinstall: reprovision step: %w", err)
+		}
+	}
+	return nil
+}
+
+// captureInstalledVersion returns the saved PresetVersion for multi-version
+// presets (empty for single-version and default presets), so the reinstall
+// resolves to the same image without false-rejecting an extracted tag.
+func captureInstalledVersion(name string) (string, error) {
+	if existing, err := config.LoadCustomService(name); err == nil {
+		return existing.PresetVersion, nil
+	}
+	if config.IsDefaultPreset(name) && podman.QuadletInstalled("lerd-"+name) {
+		return "", nil
+	}
+	return "", fmt.Errorf("service %q is not installed; nothing to reinstall", name)
+}
+
+// realReinstallInstall dispatches to the right install path based on whether
+// name refers to a default preset or a custom service.
+func realReinstallInstall(name, version string, emit func(PhaseEvent)) (*config.CustomService, error) {
+	if config.IsDefaultPreset(name) {
+		emit(PhaseEvent{Phase: "installing_config"})
+		if err := EnsureDefaultPresetQuadlet(name); err != nil {
+			return nil, err
+		}
+		_ = podman.DaemonReloadFn()
+
+		unit := "lerd-" + name
+		emit(PhaseEvent{Phase: "starting_unit", Unit: unit})
+		var startErr error
+		for attempt := range 5 {
+			startErr = podman.StartUnit(unit)
+			if startErr == nil || !strings.Contains(startErr.Error(), "not found") {
+				break
+			}
+			time.Sleep(time.Duration(attempt+1) * 300 * time.Millisecond)
+		}
+		if startErr != nil {
+			return nil, startErr
+		}
+		_ = config.SetServicePaused(name, false)
+		_ = config.SetServiceManuallyStarted(name, true)
+
+		emit(PhaseEvent{Phase: "waiting_ready", Unit: unit})
+		if err := podman.WaitReady(name, 60*time.Second); err != nil {
+			return nil, err
+		}
+		return &config.CustomService{Name: name}, nil
+	}
+	return InstallPresetStreaming(name, version, emit)
+}

--- a/internal/serviceops/reinstall_test.go
+++ b/internal/serviceops/reinstall_test.go
@@ -1,0 +1,144 @@
+package serviceops
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// stubReinstallSeams swaps the install/reprovision seams so the test exercises
+// only ReinstallService's composition logic without hitting podman.
+type reinstallRecorder struct {
+	installCalls []reinstallCall
+	reprovCalls  []string
+	installErr   error
+	reprovErr    error
+}
+type reinstallCall struct {
+	Name    string
+	Version string
+}
+
+func stubReinstallSeams(t *testing.T) *reinstallRecorder {
+	t.Helper()
+	rec := &reinstallRecorder{}
+
+	prevInstall := reinstallInstallFn
+	prevReprov := reinstallReprovFn
+	reinstallInstallFn = func(name, version string, emit func(PhaseEvent)) (*config.CustomService, error) {
+		rec.installCalls = append(rec.installCalls, reinstallCall{Name: name, Version: version})
+		emit(PhaseEvent{Phase: "starting_unit"})
+		return &config.CustomService{Name: name}, rec.installErr
+	}
+	reinstallReprovFn = func(name string, emit func(PhaseEvent)) error {
+		rec.reprovCalls = append(rec.reprovCalls, name)
+		return rec.reprovErr
+	}
+	t.Cleanup(func() {
+		reinstallInstallFn = prevInstall
+		reinstallReprovFn = prevReprov
+	})
+	return rec
+}
+
+func saveCustomServiceForReinstall(t *testing.T, name, version string) {
+	t.Helper()
+	svc := &config.CustomService{
+		Name:          name,
+		Image:         "docker.io/library/" + name + ":" + version,
+		Family:        name,
+		PresetVersion: version,
+	}
+	if err := config.SaveCustomService(svc); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+}
+
+func TestReinstallService_FailsIfNotInstalled(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubPodmanRemove(t)
+	stubReinstallSeams(t)
+
+	err := ReinstallService("unknown-svc", false, func(PhaseEvent) {})
+	if err == nil {
+		t.Fatal("expected error reinstalling a service that was never installed")
+	}
+	if !strings.Contains(err.Error(), "not installed") && !strings.Contains(err.Error(), "no such") {
+		t.Errorf("error should explain it's not installed, got %v", err)
+	}
+}
+
+func TestReinstallService_PreservesVersionFromCustomServiceYAML(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubPodmanRemove(t)
+	rec := stubReinstallSeams(t)
+
+	saveCustomServiceForReinstall(t, "myservice", "1.2.3")
+
+	if err := ReinstallService("myservice", false, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("ReinstallService: %v", err)
+	}
+	if len(rec.installCalls) != 1 {
+		t.Fatalf("expected 1 install call, got %d (%v)", len(rec.installCalls), rec.installCalls)
+	}
+	if rec.installCalls[0].Name != "myservice" {
+		t.Errorf("install name = %q, want myservice", rec.installCalls[0].Name)
+	}
+	if !strings.Contains(rec.installCalls[0].Version, "1.2.3") {
+		t.Errorf("install version did not preserve original tag, got %q", rec.installCalls[0].Version)
+	}
+}
+
+func TestReinstallService_NoResetData_SkipsReprovision(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubPodmanRemove(t)
+	rec := stubReinstallSeams(t)
+	saveCustomServiceForReinstall(t, "mariadb", "11.4")
+
+	if err := ReinstallService("mariadb", false, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("ReinstallService: %v", err)
+	}
+	if len(rec.reprovCalls) != 0 {
+		t.Errorf("reprovision must not run when resetData=false, got %v", rec.reprovCalls)
+	}
+}
+
+func TestReinstallService_ResetData_CallsReprovision(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubPodmanRemove(t)
+	rec := stubReinstallSeams(t)
+	saveCustomServiceForReinstall(t, "postgres", "16")
+
+	if err := ReinstallService("postgres", true, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("ReinstallService: %v", err)
+	}
+	if len(rec.reprovCalls) != 1 || rec.reprovCalls[0] != "postgres" {
+		t.Errorf("expected reprovision('postgres'), got %v", rec.reprovCalls)
+	}
+}
+
+func TestReinstallService_EmitsReinstallStartingPhase(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubPodmanRemove(t)
+	stubReinstallSeams(t)
+	saveCustomServiceForReinstall(t, "mariadb", "11.4")
+
+	var events []PhaseEvent
+	if err := ReinstallService("mariadb", false, func(e PhaseEvent) { events = append(events, e) }); err != nil {
+		t.Fatalf("ReinstallService: %v", err)
+	}
+	if len(events) == 0 || events[0].Phase != "reinstall_starting" {
+		t.Errorf("expected first phase reinstall_starting, got %v", events)
+	}
+}

--- a/internal/serviceops/remove.go
+++ b/internal/serviceops/remove.go
@@ -1,0 +1,131 @@
+package serviceops
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// RemoveOptions controls optional side effects of RemoveService.
+type RemoveOptions struct {
+	// RemoveData renames the service's data directory to a timestamped
+	// `.pre-remove-<ts>` sibling. The data is recoverable by renaming back.
+	// On EXDEV the helper falls back to os.RemoveAll.
+	RemoveData bool
+}
+
+// Internal seams so tests can swap out the real podman calls. The defaults
+// route to the real package functions.
+var (
+	removeStopUnit     = podman.StopUnit
+	removeContainerFn  = podman.RemoveContainer
+	removeQuadletFn    = podman.RemoveQuadlet
+	removeUnitStatusFn = podman.UnitStatus
+)
+
+// RemoveService stops, removes, and (optionally) wipes the data of a service.
+// It is the single entry point shared by the CLI, MCP, and UI handlers.
+//
+// Order:
+//  1. emit stopping_unit, StopUnit (only if active/activating; abort on error)
+//  2. emit removing_container, RemoveContainer
+//  3. (if RemoveData) emit removing_data, rename-aside ~/.local/share/lerd/data/<name>
+//  4. emit removing_quadlet, RemoveQuadlet, DaemonReload
+//  5. emit removing_config, RemoveCustomService (no-op for default presets)
+//  6. emit regenerating_consumers, RegenerateFamilyConsumers (if family known)
+//  7. emit done
+//
+// emit may be nil. Default-preset services are accepted: their YAML doesn't
+// exist on disk, so RemoveCustomService is a tolerated no-op.
+func RemoveService(name string, opts RemoveOptions, emit func(PhaseEvent)) error {
+	if emit == nil {
+		emit = func(PhaseEvent) {}
+	}
+	unit := "lerd-" + name
+
+	var family string
+	if existing, err := config.LoadCustomService(name); err == nil {
+		family = existing.Family
+	}
+
+	emit(PhaseEvent{Phase: "stopping_unit", Unit: unit})
+	status, _ := removeUnitStatusFn(unit)
+	if status == "active" || status == "activating" {
+		if err := removeStopUnit(unit); err != nil {
+			return fmt.Errorf("stop %s: %w", unit, err)
+		}
+	}
+
+	emit(PhaseEvent{Phase: "removing_container", Unit: unit})
+	removeContainerFn(unit)
+
+	if opts.RemoveData {
+		dir := config.DataSubDir(name)
+		emit(PhaseEvent{Phase: "removing_data", Message: dir})
+		if err := renameDataAside(dir); err != nil {
+			return fmt.Errorf("rename data aside for %s: %w", name, err)
+		}
+	}
+
+	emit(PhaseEvent{Phase: "removing_quadlet", Unit: unit})
+	if err := removeQuadletFn(unit); err != nil {
+		return fmt.Errorf("remove quadlet %s: %w", unit, err)
+	}
+	_ = podman.DaemonReloadFn()
+
+	emit(PhaseEvent{Phase: "removing_config"})
+	if err := config.RemoveCustomService(name); err != nil {
+		return fmt.Errorf("remove service config: %w", err)
+	}
+
+	emit(PhaseEvent{Phase: "regenerating_consumers"})
+	if family != "" {
+		RegenerateFamilyConsumers(family)
+	}
+
+	emit(PhaseEvent{Phase: "done"})
+	return nil
+}
+
+// renameDataAside renames dir to `<dir>.pre-remove-<unix-nanos>` so the data
+// is recoverable. Falls back to os.RemoveAll on EXDEV (cross-filesystem). A
+// missing source is a no-op.
+func renameDataAside(dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	aside := fmt.Sprintf("%s.pre-remove-%d", dir, time.Now().UnixNano())
+	if err := os.Rename(dir, aside); err != nil {
+		if isCrossDeviceErr(err) {
+			return os.RemoveAll(dir)
+		}
+		return err
+	}
+	return nil
+}
+
+func isCrossDeviceErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	// LinkError wraps errno EXDEV. Match by string to avoid pulling in syscall.
+	return containsEXDEV(err.Error())
+}
+
+func containsEXDEV(s string) bool {
+	for _, needle := range []string{"invalid cross-device link", "EXDEV", "cross-device"} {
+		if len(s) >= len(needle) {
+			for i := 0; i+len(needle) <= len(s); i++ {
+				if s[i:i+len(needle)] == needle {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/serviceops/remove_test.go
+++ b/internal/serviceops/remove_test.go
@@ -1,0 +1,276 @@
+package serviceops
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// stubPodmanRemove swaps the podman seams used by RemoveService for in-memory
+// fakes and restores them on test cleanup. Returns a recorder so individual
+// tests can introspect what RemoveService called.
+type podmanRemoveRecorder struct {
+	stopped         []string
+	removed         []string
+	removedQuadlets []string
+	daemonReloads   int
+
+	stopErr       error
+	removeQuadErr error
+	currentStatus string
+}
+
+func stubPodmanRemove(t *testing.T) *podmanRemoveRecorder {
+	t.Helper()
+	rec := &podmanRemoveRecorder{currentStatus: "active"}
+
+	prevStop := removeStopUnit
+	prevRm := removeContainerFn
+	prevRmq := removeQuadletFn
+	prevStatus := removeUnitStatusFn
+	prevDaemon := podman.DaemonReloadFn
+
+	removeStopUnit = func(name string) error {
+		rec.stopped = append(rec.stopped, name)
+		return rec.stopErr
+	}
+	removeContainerFn = func(name string) {
+		rec.removed = append(rec.removed, name)
+	}
+	removeQuadletFn = func(name string) error {
+		rec.removedQuadlets = append(rec.removedQuadlets, name)
+		return rec.removeQuadErr
+	}
+	removeUnitStatusFn = func(name string) (string, error) {
+		return rec.currentStatus, nil
+	}
+	podman.DaemonReloadFn = func() error { rec.daemonReloads++; return nil }
+
+	t.Cleanup(func() {
+		removeStopUnit = prevStop
+		removeContainerFn = prevRm
+		removeQuadletFn = prevRmq
+		removeUnitStatusFn = prevStatus
+		podman.DaemonReloadFn = prevDaemon
+	})
+	return rec
+}
+
+func mkTestDataDir(t *testing.T, name string, contents string) string {
+	t.Helper()
+	dir := config.DataSubDir(name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	marker := filepath.Join(dir, "marker.txt")
+	if err := os.WriteFile(marker, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", marker, err)
+	}
+	return dir
+}
+
+func TestRemoveService_NoData_PreservesDataDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	stubPodmanRemove(t)
+
+	dir := mkTestDataDir(t, "redis", "important")
+
+	var events []PhaseEvent
+	if err := RemoveService("redis", RemoveOptions{RemoveData: false}, func(e PhaseEvent) {
+		events = append(events, e)
+	}); err != nil {
+		t.Fatalf("RemoveService: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "marker.txt")); err != nil {
+		t.Errorf("data marker should still exist when RemoveData=false: %v", err)
+	}
+
+	gotPhases := map[string]bool{}
+	for _, e := range events {
+		gotPhases[e.Phase] = true
+	}
+	if gotPhases["removing_data"] {
+		t.Errorf("removing_data phase emitted when RemoveData=false")
+	}
+	if !gotPhases["done"] {
+		t.Errorf("expected done phase, got %v", events)
+	}
+}
+
+func TestRemoveService_WithData_RenamesAside(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	stubPodmanRemove(t)
+
+	dir := mkTestDataDir(t, "mariadb", "user-data")
+
+	if err := RemoveService("mariadb", RemoveOptions{RemoveData: true}, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("RemoveService: %v", err)
+	}
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("live data dir should be gone, stat err = %v", err)
+	}
+
+	parent := filepath.Dir(dir)
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var aside string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "mariadb.pre-remove-") {
+			aside = filepath.Join(parent, e.Name())
+			break
+		}
+	}
+	if aside == "" {
+		t.Fatalf("expected mariadb.pre-remove-<ts> sibling in %s, got %v", parent, entries)
+	}
+	body, err := os.ReadFile(filepath.Join(aside, "marker.txt"))
+	if err != nil || string(body) != "user-data" {
+		t.Errorf("rename-aside should preserve marker contents, got body=%q err=%v", body, err)
+	}
+}
+
+func TestRemoveService_StopFailureAborts_DataUntouched(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	rec := stubPodmanRemove(t)
+	rec.stopErr = errors.New("systemctl stop boom")
+
+	dir := mkTestDataDir(t, "postgres", "do not touch")
+
+	err := RemoveService("postgres", RemoveOptions{RemoveData: true}, func(PhaseEvent) {})
+	if err == nil {
+		t.Fatal("expected error when StopUnit fails")
+	}
+
+	body, readErr := os.ReadFile(filepath.Join(dir, "marker.txt"))
+	if readErr != nil || string(body) != "do not touch" {
+		t.Errorf("data must be untouched on stop failure, body=%q err=%v", body, readErr)
+	}
+	if len(rec.removedQuadlets) != 0 {
+		t.Errorf("quadlet must not be removed when stop failed: %v", rec.removedQuadlets)
+	}
+}
+
+func TestRemoveService_DefaultPresetSucceeds(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	rec := stubPodmanRemove(t)
+
+	mkTestDataDir(t, "postgres", "x")
+
+	if !config.IsDefaultPreset("postgres") {
+		t.Skip("postgres is not a default preset on this build")
+	}
+
+	if err := RemoveService("postgres", RemoveOptions{RemoveData: false}, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("RemoveService(postgres) for default preset: %v", err)
+	}
+	if got := rec.removed; len(got) != 1 || got[0] != "lerd-postgres" {
+		t.Errorf("expected RemoveContainer(\"lerd-postgres\"), got %v", got)
+	}
+	if got := rec.removedQuadlets; len(got) != 1 || got[0] != "lerd-postgres" {
+		t.Errorf("expected RemoveQuadlet(\"lerd-postgres\"), got %v", got)
+	}
+}
+
+func TestRemoveService_InactiveUnit_SkipsStop(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	rec := stubPodmanRemove(t)
+	rec.currentStatus = "inactive"
+
+	if err := RemoveService("redis", RemoveOptions{}, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("RemoveService: %v", err)
+	}
+	if len(rec.stopped) != 0 {
+		t.Errorf("StopUnit should not be invoked when status=inactive, got %v", rec.stopped)
+	}
+}
+
+func TestRemoveService_PhaseOrder(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	stubPodmanRemove(t)
+	mkTestDataDir(t, "mariadb", "x")
+
+	var events []PhaseEvent
+	if err := RemoveService("mariadb", RemoveOptions{RemoveData: true}, func(e PhaseEvent) {
+		events = append(events, e)
+	}); err != nil {
+		t.Fatalf("RemoveService: %v", err)
+	}
+
+	want := []string{"stopping_unit", "removing_container", "removing_data", "removing_quadlet", "removing_config", "regenerating_consumers", "done"}
+	if len(events) != len(want) {
+		t.Fatalf("phase count mismatch: got %d want %d (events=%v)", len(events), len(want), events)
+	}
+	for i, p := range want {
+		if events[i].Phase != p {
+			t.Errorf("phase[%d] = %q, want %q (events=%v)", i, events[i].Phase, p, events)
+		}
+	}
+}
+
+// Ensure the package documentation example for nil-safe emit holds: callers
+// that pass nil for emit must not crash.
+func TestRemoveService_NilEmit(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	stubPodmanRemove(t)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RemoveService panicked with nil emit: %v", r)
+		}
+	}()
+	if err := RemoveService("redis", RemoveOptions{}, nil); err != nil {
+		t.Fatalf("RemoveService nil-emit: %v", err)
+	}
+}
+
+// Sanity check: rename-aside timestamp suffix is unique enough that two
+// successive removes don't collide on the same tick.
+func TestRemoveService_RenameAside_DistinctTimestamps(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	stubPodmanRemove(t)
+
+	for i := 0; i < 2; i++ {
+		mkTestDataDir(t, "redis", fmt.Sprintf("run-%d", i))
+		if err := RemoveService("redis", RemoveOptions{RemoveData: true}, func(PhaseEvent) {}); err != nil {
+			t.Fatalf("RemoveService run %d: %v", i, err)
+		}
+	}
+
+	parent := filepath.Dir(config.DataSubDir("redis"))
+	entries, _ := os.ReadDir(parent)
+	count := 0
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "redis.pre-remove-") {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("expected 2 distinct rename-aside dirs, got %d (%v)", count, entries)
+	}
+}

--- a/internal/serviceops/reprovision.go
+++ b/internal/serviceops/reprovision.go
@@ -1,0 +1,101 @@
+package serviceops
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/envfile"
+)
+
+// reprovDB and reprovBucket are the seams ReprovisionLinkedSites uses to talk
+// to the running service. They default to the real implementations and are
+// swapped in tests.
+var (
+	reprovDB     = CreateDatabase
+	reprovBucket = EnsureS3Bucket
+)
+
+// ReprovisionLinkedSites recreates per-site state on a freshly installed
+// service after a reset-data reinstall. For db families (mysql/mariadb/postgres)
+// it ensures each linked site's database exists. For object-storage families
+// (rustfs) it ensures each linked site's bucket exists. Other families are a
+// no-op (cache services hold no client-owned state).
+//
+// Per-site failures are collected and joined; the loop continues so one
+// misconfigured site doesn't block the rest.
+func ReprovisionLinkedSites(serviceName string, emit func(PhaseEvent)) error {
+	if emit == nil {
+		emit = func(PhaseEvent) {}
+	}
+
+	family := ServiceFamily(serviceName)
+	switch family {
+	case "mysql", "mariadb", "postgres", "rustfs":
+	default:
+		emit(PhaseEvent{Phase: "reprovisioning_skipped", Message: fmt.Sprintf("family %q has no per-site state to recreate", family)})
+		return nil
+	}
+
+	sites := config.SitesUsingService(serviceName)
+	if len(sites) == 0 {
+		return nil
+	}
+
+	emit(PhaseEvent{Phase: "reprovisioning_sites", Message: fmt.Sprintf("%d site(s)", len(sites))})
+
+	var errs []error
+	for _, s := range sites {
+		switch family {
+		case "mysql", "mariadb", "postgres":
+			dbName := resolveDBName(s)
+			if dbName == "" {
+				errs = append(errs, fmt.Errorf("%s: could not resolve db name", s.Name))
+				continue
+			}
+			if _, err := reprovDB(serviceName, dbName); err != nil {
+				errs = append(errs, fmt.Errorf("%s: create db %s: %w", s.Name, dbName, err))
+				continue
+			}
+			emit(PhaseEvent{Phase: "reprovisioning_site", Message: fmt.Sprintf("%s: created db %s", s.Name, dbName)})
+
+		case "rustfs":
+			bucket := resolveBucketName(s)
+			if bucket == "" {
+				errs = append(errs, fmt.Errorf("%s: could not resolve bucket name", s.Name))
+				continue
+			}
+			if _, err := reprovBucket(bucket); err != nil {
+				errs = append(errs, fmt.Errorf("%s: create bucket %s: %w", s.Name, bucket, err))
+				continue
+			}
+			emit(PhaseEvent{Phase: "reprovisioning_site", Message: fmt.Sprintf("%s: created bucket %s", s.Name, bucket)})
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func resolveDBName(s config.Site) string {
+	if proj, err := config.LoadProjectConfig(s.Path); err == nil && proj != nil {
+		if proj.DB.Database != "" {
+			return proj.DB.Database
+		}
+	}
+	if v := envfile.ReadKey(filepath.Join(s.Path, ".env"), "DB_DATABASE"); v != "" {
+		return v
+	}
+	return strings.ReplaceAll(strings.ToLower(s.Name), "-", "_")
+}
+
+func resolveBucketName(s config.Site) string {
+	if v := envfile.ReadKey(filepath.Join(s.Path, ".env"), "AWS_BUCKET"); v != "" {
+		return S3BucketName(v)
+	}
+	return S3BucketName(s.Name)
+}

--- a/internal/serviceops/reprovision_test.go
+++ b/internal/serviceops/reprovision_test.go
@@ -1,0 +1,286 @@
+package serviceops
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// reprovRecorder captures calls to the database/bucket creators. Tests swap
+// the package-level seams (reprovDB, reprovBucket) before exercising
+// ReprovisionLinkedSites.
+type reprovRecorder struct {
+	dbCalls     []reprovDBCall
+	bucketCalls []string
+	dbErrFor    map[string]error // keyed by db name
+}
+type reprovDBCall struct {
+	Service string
+	Name    string
+}
+
+func stubReprovProvision(t *testing.T) *reprovRecorder {
+	t.Helper()
+	rec := &reprovRecorder{dbErrFor: map[string]error{}}
+	prevDB := reprovDB
+	prevBucket := reprovBucket
+	reprovDB = func(svc, name string) (bool, error) {
+		rec.dbCalls = append(rec.dbCalls, reprovDBCall{Service: svc, Name: name})
+		if err, ok := rec.dbErrFor[name]; ok {
+			return false, err
+		}
+		return true, nil
+	}
+	reprovBucket = func(name string) (bool, error) {
+		rec.bucketCalls = append(rec.bucketCalls, name)
+		return true, nil
+	}
+	t.Cleanup(func() {
+		reprovDB = prevDB
+		reprovBucket = prevBucket
+	})
+	return rec
+}
+
+func mkSiteWithLerdYAML(t *testing.T, name string, services ...string) {
+	t.Helper()
+	dir := t.TempDir()
+	var b strings.Builder
+	b.WriteString("services:\n")
+	for _, s := range services {
+		b.WriteString("  - " + s + "\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte(b.String()), 0o644); err != nil {
+		t.Fatalf("write lerd.yaml: %v", err)
+	}
+	if err := config.AddSite(config.Site{Name: name, Domains: []string{name + ".test"}, Path: dir}); err != nil {
+		t.Fatalf("AddSite %s: %v", name, err)
+	}
+}
+
+func mkSiteWithEnv(t *testing.T, name, envContent string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(envContent), 0o644); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+	if err := config.AddSite(config.Site{Name: name, Domains: []string{name + ".test"}, Path: dir}); err != nil {
+		t.Fatalf("AddSite %s: %v", name, err)
+	}
+	return dir
+}
+
+func TestReprovisionLinkedSites_MysqlFamily_CreatesDBPerSite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	rec := stubReprovProvision(t)
+
+	mkSiteWithLerdYAML(t, "site-a", "mariadb")
+	mkSiteWithLerdYAML(t, "site-b", "mariadb")
+
+	if err := ReprovisionLinkedSites("mariadb", nil); err != nil {
+		t.Fatalf("ReprovisionLinkedSites: %v", err)
+	}
+
+	if len(rec.dbCalls) != 2 {
+		t.Fatalf("expected 2 CreateDatabase calls, got %d (%v)", len(rec.dbCalls), rec.dbCalls)
+	}
+	got := map[string]bool{}
+	for _, c := range rec.dbCalls {
+		if c.Service != "mariadb" {
+			t.Errorf("call service = %q, want mariadb", c.Service)
+		}
+		got[c.Name] = true
+	}
+	if !got["site_a"] || !got["site_b"] {
+		t.Errorf("expected dbs site_a and site_b, got %v", got)
+	}
+	if len(rec.bucketCalls) != 0 {
+		t.Errorf("bucket creator called for db family: %v", rec.bucketCalls)
+	}
+}
+
+func TestReprovisionLinkedSites_PostgresFamily_CreatesDBPerSite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	rec := stubReprovProvision(t)
+
+	mkSiteWithLerdYAML(t, "blog", "postgres")
+
+	if err := ReprovisionLinkedSites("postgres", nil); err != nil {
+		t.Fatalf("ReprovisionLinkedSites: %v", err)
+	}
+	if len(rec.dbCalls) != 1 || rec.dbCalls[0].Name != "blog" {
+		t.Errorf("expected one db call for 'blog', got %v", rec.dbCalls)
+	}
+}
+
+func TestReprovisionLinkedSites_ObjectStorage_CreatesBucketPerSite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	rec := stubReprovProvision(t)
+
+	mkSiteWithEnv(t, "uploads-app", "AWS_BUCKET=uploads-app\nFILESYSTEM_DISK=s3\nlerd-rustfs\n")
+
+	if err := ReprovisionLinkedSites("rustfs", nil); err != nil {
+		t.Fatalf("ReprovisionLinkedSites: %v", err)
+	}
+	if len(rec.bucketCalls) != 1 || rec.bucketCalls[0] != "uploads-app" {
+		t.Errorf("expected bucket call for uploads-app, got %v", rec.bucketCalls)
+	}
+}
+
+func TestReprovisionLinkedSites_RedisFamily_NoOps(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	rec := stubReprovProvision(t)
+
+	mkSiteWithEnv(t, "cache-app", "REDIS_HOST=lerd-redis\n")
+
+	if err := ReprovisionLinkedSites("redis", nil); err != nil {
+		t.Fatalf("ReprovisionLinkedSites: %v", err)
+	}
+	if len(rec.dbCalls) != 0 || len(rec.bucketCalls) != 0 {
+		t.Errorf("redis should be a no-op, got dbs=%v buckets=%v", rec.dbCalls, rec.bucketCalls)
+	}
+}
+
+func TestReprovisionLinkedSites_SkipsIgnoredAndPaused(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	rec := stubReprovProvision(t)
+
+	yamlActive := t.TempDir()
+	os.WriteFile(filepath.Join(yamlActive, ".lerd.yaml"), []byte("services:\n  - mariadb\n"), 0o644)
+	if err := config.AddSite(config.Site{Name: "active", Domains: []string{"a.test"}, Path: yamlActive}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+	yamlPaused := t.TempDir()
+	os.WriteFile(filepath.Join(yamlPaused, ".lerd.yaml"), []byte("services:\n  - mariadb\n"), 0o644)
+	if err := config.AddSite(config.Site{Name: "paused", Domains: []string{"p.test"}, Path: yamlPaused, Paused: true}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	if err := ReprovisionLinkedSites("mariadb", nil); err != nil {
+		t.Fatalf("ReprovisionLinkedSites: %v", err)
+	}
+	if len(rec.dbCalls) != 1 || rec.dbCalls[0].Name != "active" {
+		t.Errorf("expected only 'active' provisioned, got %v", rec.dbCalls)
+	}
+}
+
+func TestReprovisionLinkedSites_PerSiteFailure_ContinuesAndJoinsErrors(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	rec := stubReprovProvision(t)
+	rec.dbErrFor["site_b"] = errors.New("boom")
+
+	mkSiteWithLerdYAML(t, "site-a", "mariadb")
+	mkSiteWithLerdYAML(t, "site-b", "mariadb")
+	mkSiteWithLerdYAML(t, "site-c", "mariadb")
+
+	err := ReprovisionLinkedSites("mariadb", nil)
+	if err == nil {
+		t.Fatal("expected joined error for site-b failure")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("error should include underlying message, got %v", err)
+	}
+	if len(rec.dbCalls) != 3 {
+		t.Errorf("expected all 3 sites attempted (continue-on-error), got %v", rec.dbCalls)
+	}
+}
+
+func TestReprovisionLinkedSites_DBNameOverrideFromProjectConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	rec := stubReprovProvision(t)
+
+	dir := t.TempDir()
+	yaml := "services:\n  - postgres\ndb:\n  database: custom_name\n"
+	os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte(yaml), 0o644)
+	if err := config.AddSite(config.Site{Name: "weird-site", Domains: []string{"w.test"}, Path: dir}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	if err := ReprovisionLinkedSites("postgres", nil); err != nil {
+		t.Fatalf("ReprovisionLinkedSites: %v", err)
+	}
+	if len(rec.dbCalls) != 1 || rec.dbCalls[0].Name != "custom_name" {
+		t.Errorf("expected db name 'custom_name' from .lerd.yaml override, got %v", rec.dbCalls)
+	}
+}
+
+func TestReprovisionLinkedSites_DBNameFallbackToEnvFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	rec := stubReprovProvision(t)
+
+	mkSiteWithEnv(t, "envapp", "DB_HOST=lerd-mysql\nDB_DATABASE=env_chosen\n")
+
+	if err := ReprovisionLinkedSites("mysql", nil); err != nil {
+		t.Fatalf("ReprovisionLinkedSites: %v", err)
+	}
+	if len(rec.dbCalls) != 1 || rec.dbCalls[0].Name != "env_chosen" {
+		t.Errorf("expected db name 'env_chosen' from .env, got %v", rec.dbCalls)
+	}
+}
+
+func TestReprovisionLinkedSites_DBNameFallbackToSiteName(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	rec := stubReprovProvision(t)
+
+	// .lerd.yaml lists postgres but no db.database; .env is absent.
+	mkSiteWithLerdYAML(t, "no-overrides", "postgres")
+
+	if err := ReprovisionLinkedSites("postgres", nil); err != nil {
+		t.Fatalf("ReprovisionLinkedSites: %v", err)
+	}
+	if len(rec.dbCalls) != 1 || rec.dbCalls[0].Name != "no_overrides" {
+		t.Errorf("expected derived db 'no_overrides', got %v", rec.dbCalls)
+	}
+}
+
+func TestReprovisionLinkedSites_EmitsPerSiteEvent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubReprovProvision(t)
+
+	mkSiteWithLerdYAML(t, "site-x", "mariadb")
+
+	var events []PhaseEvent
+	if err := ReprovisionLinkedSites("mariadb", func(e PhaseEvent) { events = append(events, e) }); err != nil {
+		t.Fatalf("ReprovisionLinkedSites: %v", err)
+	}
+
+	var sawSiteEvent, sawSummary bool
+	for _, e := range events {
+		if e.Phase == "reprovisioning_site" && strings.Contains(e.Message, "site-x") {
+			sawSiteEvent = true
+		}
+		if e.Phase == "reprovisioning_sites" {
+			sawSummary = true
+		}
+	}
+	if !sawSummary {
+		t.Errorf("expected reprovisioning_sites phase, got %v", events)
+	}
+	if !sawSiteEvent {
+		t.Errorf("expected reprovisioning_site phase mentioning site-x, got %v", events)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -778,6 +778,7 @@ type ServiceResponse struct {
 	DashboardExternal  bool              `json:"dashboard_external,omitempty"`
 	ConnectionURL      string            `json:"connection_url,omitempty"`
 	Custom             bool              `json:"custom,omitempty"`
+	IsDefault          bool              `json:"is_default,omitempty"`
 	SiteCount          int               `json:"site_count"`
 	SiteDomains        []string          `json:"site_domains,omitempty"`
 	Pinned             bool              `json:"pinned"`
@@ -828,6 +829,7 @@ func buildServiceResponse(name string) ServiceResponse {
 		SiteDomains:   sitesUsingService(name),
 		Pinned:        config.ServiceIsPinned(name),
 		Paused:        config.ServiceIsPaused(name),
+		IsDefault:     config.IsDefaultPreset(name),
 	}
 	// Default-preset services advertise update availability so the dashboard
 	// can show an "→ v8.4.3" badge. Stopped services also run the check so the
@@ -1209,6 +1211,17 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Streaming reinstall: stop, remove (optionally with data wipe), reinstall,
+	// and reprovision linked sites' DBs/buckets when resetData=true.
+	if action == "reinstall" && r.Method == http.MethodPost {
+		resetData := r.URL.Query().Get("resetData") == "true"
+		writeLine, _ := startNDJSONStream(w, r)
+		if err := serviceops.ReinstallService(name, resetData, func(ev serviceops.PhaseEvent) { writeLine(ev) }); err != nil {
+			writeLine(map[string]any{"phase": "error", "error": err.Error()})
+		}
+		return
+	}
+
 	// Streaming update flow. Accepts ?tag=<tag> to target an explicit upgrade
 	// (e.g. cross-minor jumps that the safe-update strategy wouldn't suggest).
 	if action == "update" && r.Method == http.MethodPost {
@@ -1472,22 +1485,11 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 			cli.RegenerateFamilyConsumersForService(name)
 		}
 	case "remove":
-		if isBuiltin {
-			http.Error(w, "cannot remove built-in service", http.StatusForbidden)
-			return
-		}
-		_ = podman.StopUnit(unit)
-		podman.RemoveContainer(unit)
-		if err := podman.RemoveQuadlet(unit); err != nil {
+		removeData := r.URL.Query().Get("removeData") == "true"
+		if err := serviceops.RemoveService(name, serviceops.RemoveOptions{RemoveData: removeData}, nil); err != nil {
 			writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
 			return
 		}
-		_ = podman.DaemonReloadFn()
-		if err := config.RemoveCustomService(name); err != nil {
-			writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
-			return
-		}
-		cli.RegenerateFamilyConsumersForService(name)
 		writeJSON(w, map[string]any{"ok": true})
 		return
 	case "pin":

--- a/internal/ui/web/src/stores/services.ts
+++ b/internal/ui/web/src/stores/services.ts
@@ -11,6 +11,7 @@ export interface Service {
   dashboard_external?: boolean;
   connection_url?: string;
   custom?: boolean;
+  is_default?: boolean;
   site_count: number;
   site_domains?: string[];
   pinned?: boolean;
@@ -112,11 +113,21 @@ export const workerGroups = derived(services, ($s): WorkerGroup[] => {
 
 export type ServiceAction = 'start' | 'stop' | 'restart' | 'pin' | 'unpin' | 'remove';
 
-export async function serviceAction(name: string, action: ServiceAction): Promise<boolean> {
+export async function serviceAction(
+  name: string,
+  action: ServiceAction,
+  opts: { removeData?: boolean } = {}
+): Promise<boolean> {
   try {
-    const res = await apiFetch('/api/services/' + encodeURIComponent(name) + '/' + action, {
-      method: 'POST'
-    });
+    const params = new URLSearchParams();
+    if (action === 'remove' && opts.removeData) params.set('removeData', 'true');
+    const url =
+      '/api/services/' +
+      encodeURIComponent(name) +
+      '/' +
+      action +
+      (params.toString() ? '?' + params.toString() : '');
+    const res = await apiFetch(url, { method: 'POST' });
     if (res.ok) await loadServices();
     return res.ok;
   } catch {
@@ -124,7 +135,7 @@ export async function serviceAction(name: string, action: ServiceAction): Promis
   }
 }
 
-export type UpdateAction = 'update' | 'migrate' | 'rollback';
+export type UpdateAction = 'update' | 'migrate' | 'rollback' | 'reinstall';
 
 function setProgress(name: string, p: UpdateProgress | null) {
   updateProgress.update((m) => {
@@ -155,6 +166,30 @@ function phaseLabel(phase: string): string {
       return 'Swapping data dir…';
     case 'starting_deps':
       return 'Starting dependencies…';
+    case 'reinstall_starting':
+      return 'Reinstalling…';
+    case 'stopping_unit':
+      return 'Stopping…';
+    case 'removing_container':
+      return 'Removing container…';
+    case 'removing_data':
+      return 'Renaming data dir aside…';
+    case 'removing_quadlet':
+      return 'Removing unit…';
+    case 'removing_config':
+      return 'Removing config…';
+    case 'regenerating_consumers':
+      return 'Refreshing consumers…';
+    case 'reprovisioning_sites':
+      return 'Reprovisioning linked sites…';
+    case 'reprovisioning_site':
+      return 'Reprovisioning…';
+    case 'reprovisioning_skipped':
+      return 'Reprovisioning skipped';
+    case 'starting_unit':
+      return 'Starting…';
+    case 'installing_config':
+      return 'Writing config…';
     case 'done':
       return 'Done';
     default:
@@ -165,13 +200,15 @@ function phaseLabel(phase: string): string {
 export async function streamServiceAction(
   name: string,
   action: UpdateAction,
-  opts: { tag?: string } = {}
+  opts: { tag?: string; resetData?: boolean } = {}
 ): Promise<{ ok: boolean; error?: string }> {
   const params = new URLSearchParams();
   if (opts.tag) params.set('tag', opts.tag);
+  if (action === 'reinstall' && opts.resetData) params.set('resetData', 'true');
   const url = '/api/services/' + encodeURIComponent(name) + '/' + action + (params.toString() ? '?' + params.toString() : '');
 
-  setProgress(name, { phase: 'checking_registry', message: phaseLabel('checking_registry') });
+  const initialPhase = action === 'reinstall' ? 'reinstall_starting' : 'checking_registry';
+  setProgress(name, { phase: initialPhase, message: phaseLabel(initialPhase) });
   try {
     const res = await apiFetch(url, { method: 'POST' });
     if (!res.body) {

--- a/internal/ui/web/src/tabs/services/ServiceDeleteModal.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceDeleteModal.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  import Modal from '$components/Modal.svelte';
+  import type { Service } from '$stores/services';
+
+  interface Props {
+    open: boolean;
+    svc: Service;
+    onclose: () => void;
+    onconfirm: (opts: { removeData: boolean }) => void | Promise<void>;
+  }
+  let { open, svc, onclose, onconfirm }: Props = $props();
+
+  let removeData = $state(false);
+  let typedName = $state('');
+  let submitting = $state(false);
+
+  const dependents = $derived(svc.site_count || 0);
+  const requiresTypedConfirm = $derived(Boolean(svc.is_default) && dependents > 0);
+  const canConfirm = $derived(!submitting && (!requiresTypedConfirm || typedName.trim() === svc.name));
+
+  $effect(() => {
+    if (open) {
+      removeData = false;
+      typedName = '';
+      submitting = false;
+    }
+  });
+
+  async function confirm() {
+    if (!canConfirm) return;
+    submitting = true;
+    try {
+      await onconfirm({ removeData });
+    } finally {
+      submitting = false;
+      onclose();
+    }
+  }
+</script>
+
+<Modal {open} {onclose} title={`Remove ${svc.name}`} size="sm">
+  <div class="px-5 py-4 space-y-3">
+    {#if requiresTypedConfirm}
+      <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-900/40 rounded px-3 py-2 text-xs text-red-700 dark:text-red-300">
+        <p class="font-medium mb-1">{dependents} site{dependents === 1 ? '' : 's'} depend on this service.</p>
+        {#if svc.site_domains && svc.site_domains.length > 0}
+          <ul class="list-disc list-inside space-y-0.5">
+            {#each svc.site_domains as d (d)}
+              <li class="font-mono">{d}</li>
+            {/each}
+          </ul>
+        {/if}
+        <p class="mt-2">Removing it will break those sites until you reinstall.</p>
+      </div>
+    {/if}
+
+    <p class="text-sm text-gray-600 dark:text-gray-400">
+      Stops the unit, removes the container, and deletes the service config. Default services can be reinstalled later from the preset list.
+    </p>
+
+    <label class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+      <input
+        type="checkbox"
+        bind:checked={removeData}
+        class="mt-0.5 w-4 h-4 rounded border-gray-300 dark:border-lerd-border bg-white dark:bg-lerd-bg text-lerd-red focus:ring-lerd-red/40 cursor-pointer"
+      />
+      <span>
+        Also remove service data
+        <span class="block text-[11px] text-gray-500 dark:text-gray-400">
+          Renames <span class="font-mono">~/.local/share/lerd/data/{svc.name}</span> to <span class="font-mono">{svc.name}.pre-remove-&lt;ts&gt;</span> (recoverable).
+        </span>
+      </span>
+    </label>
+
+    {#if requiresTypedConfirm}
+      <div class="space-y-1">
+        <label for="confirm-name" class="text-xs text-gray-600 dark:text-gray-400">
+          Type <span class="font-mono font-medium text-gray-800 dark:text-gray-200">{svc.name}</span> to confirm:
+        </label>
+        <input
+          id="confirm-name"
+          type="text"
+          bind:value={typedName}
+          class="w-full text-sm bg-white dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border rounded px-2.5 py-1.5 text-gray-700 dark:text-gray-300 focus:outline-none focus:border-lerd-red/50"
+          autocomplete="off"
+        />
+      </div>
+    {/if}
+  </div>
+  {#snippet footer()}
+    <button
+      type="button"
+      onclick={onclose}
+      class="text-xs px-3 py-1.5 rounded border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors"
+    >Cancel</button>
+    <button
+      type="button"
+      onclick={confirm}
+      disabled={!canConfirm}
+      class="text-xs px-3 py-1.5 rounded bg-lerd-red hover:bg-lerd-redhov text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+    >{submitting ? 'Removing…' : 'Remove'}</button>
+  {/snippet}
+</Modal>

--- a/internal/ui/web/src/tabs/services/ServiceHeader.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceHeader.svelte
@@ -4,6 +4,8 @@
   import ButtonMenu, { type ButtonMenuAction } from '$components/ButtonMenu.svelte';
   import ParentSiteBadge from './ParentSiteBadge.svelte';
   import ServiceDependencies from './ServiceDependencies.svelte';
+  import ServiceDeleteModal from './ServiceDeleteModal.svelte';
+  import ServiceReinstallModal from './ServiceReinstallModal.svelte';
   import { goToTab } from '$stores/route';
   import {
     type Service,
@@ -53,6 +55,8 @@
   const parent = $derived(parentSiteDomain(svc));
 
   let localBusy = $state(false);
+  let deleteOpen = $state(false);
+  let reinstallOpen = $state(false);
   const updating = $derived($updateProgress[svc.name]);
   const busy = $derived(localBusy || Boolean(updating));
 
@@ -63,6 +67,19 @@
     } finally {
       localBusy = false;
     }
+  }
+
+  async function confirmDelete(opts: { removeData: boolean }) {
+    localBusy = true;
+    try {
+      await serviceAction(svc.name, 'remove', { removeData: opts.removeData });
+    } finally {
+      localBusy = false;
+    }
+  }
+
+  async function confirmReinstall(opts: { resetData: boolean }) {
+    await streamServiceAction(svc.name, 'reinstall', { resetData: opts.resetData });
   }
 
   async function runUpdate(tag?: string) {
@@ -114,7 +131,7 @@
 
     if (svc.upgrade_version && svc.migration_supported === false && !updating) {
       const tag = svc.upgrade_version;
-      lifecycle.push({
+      rest.push({
         id: 'upgrade',
         tone: 'warn',
         icon: icons.upgrade,
@@ -126,25 +143,13 @@
 
     if (svc.upgrade_version && svc.migration_supported === true && !updating) {
       const tag = svc.upgrade_version;
-      lifecycle.push({
+      rest.push({
         id: 'migrate',
         tone: 'info',
         icon: icons.migrate,
         label: m.services_migrateTo({ tag }),
         title: m.services_migrateExplain({ tag }),
         onclick: () => runMigrate(tag)
-      });
-    }
-
-    if (svc.previous_version && svc.can_rollback !== false && !updating) {
-      const tag = rollbackTagFromImage(svc.previous_version);
-      lifecycle.push({
-        id: 'rollback',
-        tone: 'secondary',
-        icon: icons.rollback,
-        label: m.services_rollbackTo({ tag }),
-        title: m.services_rollbackExplain({ tag }),
-        onclick: () => runRollback()
       });
     }
 
@@ -216,14 +221,38 @@
       });
     }
 
-    if (!isWorker && svc.custom && !active) {
+    if (!isWorker && !updating) {
+      rest.push({
+        id: 'reinstall',
+        tone: 'secondary',
+        icon: icons.restart,
+        label: 'Reinstall',
+        title: 'Stop, remove, and reinstall at the current version. Optional reset-data wipes the data dir and reprovisions linked sites.',
+        onclick: () => (reinstallOpen = true)
+      });
+    }
+
+    if (svc.previous_version && svc.can_rollback !== false && !updating) {
+      const tag = rollbackTagFromImage(svc.previous_version);
+      rest.push({
+        id: 'rollback',
+        tone: 'secondary',
+        icon: icons.rollback,
+        label: m.services_rollbackTo({ tag }),
+        title: m.services_rollbackExplain({ tag }),
+        onclick: () => runRollback()
+      });
+    }
+
+    if (!isWorker) {
+      const removeLabel = svc.is_default ? 'Remove' : m.services_removeCustom();
       rest.push({
         id: 'remove',
         tone: 'danger',
         icon: icons.trash,
-        label: m.services_removeCustom(),
-        title: m.services_removeCustom(),
-        onclick: () => run('remove')
+        label: removeLabel,
+        title: removeLabel,
+        onclick: () => (deleteOpen = true)
       });
     }
 
@@ -360,3 +389,17 @@
     {/if}
   </div>
 </div>
+
+<ServiceDeleteModal
+  open={deleteOpen}
+  {svc}
+  onclose={() => (deleteOpen = false)}
+  onconfirm={confirmDelete}
+/>
+
+<ServiceReinstallModal
+  open={reinstallOpen}
+  {svc}
+  onclose={() => (reinstallOpen = false)}
+  onconfirm={confirmReinstall}
+/>

--- a/internal/ui/web/src/tabs/services/ServiceReinstallModal.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceReinstallModal.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import Modal from '$components/Modal.svelte';
+  import type { Service } from '$stores/services';
+
+  interface Props {
+    open: boolean;
+    svc: Service;
+    onclose: () => void;
+    onconfirm: (opts: { resetData: boolean }) => void | Promise<void>;
+  }
+  let { open, svc, onclose, onconfirm }: Props = $props();
+
+  let resetData = $state(false);
+  let submitting = $state(false);
+
+  const dependents = $derived(svc.site_count || 0);
+
+  $effect(() => {
+    if (open) {
+      resetData = false;
+      submitting = false;
+    }
+  });
+
+  async function confirm() {
+    submitting = true;
+    try {
+      await onconfirm({ resetData });
+    } finally {
+      submitting = false;
+      onclose();
+    }
+  }
+</script>
+
+<Modal {open} {onclose} title={`Reinstall ${svc.name}`} size="sm">
+  <div class="px-5 py-4 space-y-3">
+    <p class="text-sm text-gray-600 dark:text-gray-400">
+      Stops, removes, and reinstalls {svc.name} at the current version. Use this when a service update produced data incompatible with the new image.
+    </p>
+
+    <label class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+      <input
+        type="checkbox"
+        bind:checked={resetData}
+        class="mt-0.5 w-4 h-4 rounded border-gray-300 dark:border-lerd-border bg-white dark:bg-lerd-bg text-lerd-red focus:ring-lerd-red/40 cursor-pointer"
+      />
+      <span>
+        Reset to clean state (remove data)
+        <span class="block text-[11px] text-gray-500 dark:text-gray-400">
+          Renames the data dir aside (recoverable as <span class="font-mono">{svc.name}.pre-remove-&lt;ts&gt;</span>) and recreates databases or buckets for {dependents} linked site{dependents === 1 ? '' : 's'} on the fresh service.
+        </span>
+      </span>
+    </label>
+
+    {#if resetData && dependents > 0}
+      <div class="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-900/40 rounded px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+        Data will be wiped. The reinstall will recreate empty databases or buckets for the linked site{dependents === 1 ? '' : 's'}, but their previous content is gone (the rename-aside copy can be restored manually).
+      </div>
+    {/if}
+  </div>
+  {#snippet footer()}
+    <button
+      type="button"
+      onclick={onclose}
+      class="text-xs px-3 py-1.5 rounded border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors"
+    >Cancel</button>
+    <button
+      type="button"
+      onclick={confirm}
+      disabled={submitting}
+      class="text-xs px-3 py-1.5 rounded {resetData ? 'bg-lerd-red hover:bg-lerd-redhov' : 'bg-lerd-red/80 hover:bg-lerd-red'} text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+    >{submitting ? 'Reinstalling…' : resetData ? 'Reinstall + reset data' : 'Reinstall'}</button>
+  {/snippet}
+</Modal>


### PR DESCRIPTION
## Summary

Three connected gaps in service lifecycle management:

1. **Default services (postgres, redis, mariadb, mysql, meilisearch, mailpit, rustfs, gotenberg, ...) could not be removed.** The CLI, MCP, and UI all rejected the request as 'built-in service'. A user who installed one and changed their mind had to edit quadlets by hand.
2. **Removing a service preserved the data dir** with no UI or CLI option to wipe it. Today the remove confirm is a one-click menu item with no modal at all.
3. **No reinstall path existed.** When a service update produced data incompatible with the new image (or the user just wanted a clean slate), the only escape was manual: stop the unit, `rm -rf` the data dir, then run preset install.

A reset-data reinstall on a database or object-storage service would also leave linked sites broken, since their `.env` references databases or buckets that no longer exist on the fresh service.

## What changed

**`serviceops`**: new RemoveService, ReinstallService, ReprovisionLinkedSites, plus CreateDatabase / EnsureS3Bucket moved down from `cli/env.go` to break a layering inversion. Data wipes use migrate-style rename-aside (`<dir>.pre-remove-<unix-nanos>`) so they're recoverable; falls back to `os.RemoveAll` on EXDEV. RemoveService is now the single entry point for the stop+remove flow that was previously duplicated three times across CLI, MCP, and UI.

**CLI**: `lerd service remove <name> [--purge]` now works on any service, including default presets. New `lerd service reinstall <name> [--reset-data]`. `migrateServiceUnits` only refreshes quadlets that already exist on disk so a removed default doesn't get silently recreated on the next CLI invocation.

**MCP**: `service_control` action enum gains `reinstall`, plus `remove_data` and `reset_data` boolean params. Tool description tightened to stay under the 19000-byte `tools/list` ceiling.

**UI**: new `ServiceDeleteModal.svelte` (checkbox + type-name confirmation when a default service has linked sites) and `ServiceReinstallModal.svelte` (checkbox with an amber warning when reset-data is on and there are dependents). `ServiceHeader.svelte` ungates Remove for default services and adds Reinstall. Promotion to the primary visible button is restricted to `update` only; migrate, upgrade, rollback, dashboard, restart, etc. live in the dropdown. Rollback sits at the bottom of the dropdown (above Remove) since it's the lowest-priority promotion candidate.

**Reprovisioning**: when reinstall runs with `--reset-data`, ReprovisionLinkedSites walks every active site that depends on the service and recreates the per-site state on the fresh container. CREATE DATABASE for mysql/mariadb/postgres (using `.lerd.yaml db.database`, then `.env DB_DATABASE`, then a name derived from the site name). `mc mb` for rustfs (using `.env AWS_BUCKET`, otherwise the site name). Cache families (redis, memcached) are a deliberate no-op. Per-site failures are joined and returned at the end so one misconfigured site doesn't strand the rest.

## Tests

32 new Go test cases across \`serviceops/{remove,reinstall,reprovision}_test.go\`, \`cli/services_test.go\`, \`config/service_manual_test.go\`. TDD red→green discipline for every behavior change.

## Migration notes

Existing CLI scripts using \`lerd service remove <custom>\` still work; the flag set is additive. The MCP \`service_control\` action enum is widened, not changed. The UI's \`?removeData=true\` query param on the remove endpoint is the only non-obvious wire change. Data dirs left aside as \`*.pre-remove-*\` are not auto-cleaned; a future \`lerd doctor\` check for stale \`.pre-*\` dirs older than 30 days is suggested but out of scope here.