### PR TITLE
fix(node): widen detection, install LTS on opt-in, guard CLI/UI

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -705,6 +705,10 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	}
 	ok()
 
+	if wantLerdNode {
+		ensureDefaultNode()
+	}
+
 	refreshGlobalMCPSkills()
 	refreshProjectMCPSkills()
 
@@ -964,18 +968,89 @@ func lerdManagesNode() bool {
 	return err == nil
 }
 
-// detectSystemNode returns the path to a node binary found in PATH outside of
-// lerd's own bin dir, or "" if none exists. Used during install to decide
-// whether to write fnm-backed node/npm/npx shims.
+// ensureNodeManaged is called by the node:install/use/uninstall commands to
+// guard against running fnm operations while the user has opted out of
+// lerd-managed Node. Prompts for confirmation and writes shims on accept.
+// Returns an error when stdin is not a TTY so scripted callers fail loudly
+// instead of silently flipping the user's choice.
+func ensureNodeManaged() error {
+	if lerdManagesNode() {
+		return nil
+	}
+	if fi, err := os.Stdin.Stat(); err != nil || (fi.Mode()&os.ModeCharDevice) == 0 {
+		return fmt.Errorf("lerd is not managing Node.js; run 'lerd install' to enable it")
+	}
+	fmt.Println("Lerd is currently using your system Node.js.")
+	fmt.Println("Continuing will install fnm-managed shims into", config.BinDir(), "and override your system node, npm and npx in PATH.")
+	if !confirmInstallPromptDefault("Switch to lerd-managed Node.js?", false) {
+		return fmt.Errorf("aborted")
+	}
+	if err := addShellShims(true); err != nil {
+		return fmt.Errorf("writing shims: %w", err)
+	}
+	return nil
+}
+
+// ensureDefaultNode installs the configured default Node.js version via fnm
+// and pins it as the fnm default if no version is already set up. Skips when
+// fnm already has a working default so reruns of `lerd install` stay quiet.
+func ensureDefaultNode() {
+	fnmPath := filepath.Join(config.BinDir(), "fnm")
+	if _, err := os.Stat(fnmPath); err != nil {
+		fmt.Printf("    WARN: fnm not found at %s, skipping default Node install\n", fnmPath)
+		return
+	}
+	if exec.Command(fnmPath, "exec", "--using=default", "--", "true").Run() == nil {
+		return
+	}
+	version := "22"
+	if cfg, err := config.LoadGlobal(); err == nil && cfg != nil && cfg.Node.DefaultVersion != "" {
+		version = cfg.Node.DefaultVersion
+	}
+	step(fmt.Sprintf("Installing Node.js %s", version))
+	if out, err := exec.Command(fnmPath, "install", version).CombinedOutput(); err != nil {
+		fmt.Printf("    WARN: fnm install %s: %s\n", version, strings.TrimSpace(string(out)))
+		return
+	}
+	if out, err := exec.Command(fnmPath, "default", version).CombinedOutput(); err != nil {
+		fmt.Printf("    WARN: fnm default %s: %s\n", version, strings.TrimSpace(string(out)))
+		return
+	}
+	ok()
+}
+
+// detectSystemNode returns a hint about an existing node install outside of
+// lerd's own bin dir, or "" if none can be found. Probes node/npm/npx in PATH
+// and well-known version-manager directories (nvm, volta, mise, asdf, fnm),
+// since most version managers inject node via a shell hook rather than a
+// static PATH entry and would otherwise be invisible here.
 func detectSystemNode() string {
 	lerdBin := config.BinDir()
 	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
 		if dir == lerdBin {
 			continue
 		}
-		candidate := filepath.Join(dir, "node")
-		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
-			return candidate
+		for _, bin := range []string{"node", "npm", "npx"} {
+			candidate := filepath.Join(dir, bin)
+			if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+				return candidate
+			}
+		}
+	}
+	home, _ := os.UserHomeDir()
+	if home != "" {
+		for _, rel := range []string{
+			".nvm/versions/node",
+			".volta/bin",
+			".local/share/mise/installs/node",
+			".asdf/installs/nodejs",
+			".local/share/fnm/node-versions",
+			"Library/Application Support/fnm/node-versions",
+		} {
+			p := filepath.Join(home, rel)
+			if entries, err := os.ReadDir(p); err == nil && len(entries) > 0 {
+				return p
+			}
 		}
 	}
 	return ""
@@ -1111,8 +1186,8 @@ if [ -n "$VERSION" ]; then
   "$FNM" install "$VERSION" >/dev/null 2>&1 || true
   exec "$FNM" exec --using="$VERSION" -- %s "$@"
 else
-  if [ -z "$("$FNM" list 2>/dev/null)" ]; then
-    printf 'No Node.js version installed. Run: lerd node:install 22\n' >&2
+  if ! "$FNM" exec --using=default -- true >/dev/null 2>&1; then
+    printf 'No Node.js version available via lerd. Run: lerd node:install 22\n' >&2
     exit 1
   fi
   exec "$FNM" exec --using=default -- %s "$@"

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -331,3 +331,68 @@ func TestAddShellShims_LaravelShimRespectsComposerHome(t *testing.T) {
 		t.Errorf("laravel shim should use COMPOSER_HOME=%q, got:\n%s", customHome, shim)
 	}
 }
+
+func TestAddShellShims_NodeShimChecksDefaultAlias(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("HOME", tmp)
+	t.Setenv("SHELL", "/bin/sh")
+
+	binDir := filepath.Join(tmp, "lerd", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := addShellShims(true); err != nil {
+		t.Fatalf("addShellShims: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(binDir, "npm"))
+	if err != nil {
+		t.Fatalf("npm shim not created: %v", err)
+	}
+	shim := string(data)
+	if !strings.Contains(shim, `"$FNM" exec --using=default -- true`) {
+		t.Errorf("npm shim should probe the default alias before exec, got:\n%s", shim)
+	}
+	if !strings.Contains(shim, "No Node.js version available via lerd") {
+		t.Errorf("npm shim should print friendly fallback hint, got:\n%s", shim)
+	}
+}
+
+func TestDetectSystemNode_findsNvmDirEvenWhenPathIsEmpty(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("PATH", filepath.Join(tmp, "lerd", "bin"))
+
+	nvm := filepath.Join(tmp, ".nvm", "versions", "node", "v22.0.0")
+	if err := os.MkdirAll(nvm, 0755); err != nil {
+		t.Fatal(err)
+	}
+	got := detectSystemNode()
+	if got == "" {
+		t.Fatal("detectSystemNode returned empty even though ~/.nvm contains a version")
+	}
+	if !strings.Contains(got, ".nvm") {
+		t.Errorf("expected detectSystemNode to point at the nvm dir, got %q", got)
+	}
+}
+
+func TestDetectSystemNode_findsNpmInPath(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	binDir := filepath.Join(tmp, "shim-bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "npm"), []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	got := detectSystemNode()
+	if got == "" {
+		t.Fatal("detectSystemNode returned empty even though npm is on PATH")
+	}
+	if !strings.HasSuffix(got, "/npm") {
+		t.Errorf("expected detectSystemNode to find npm, got %q", got)
+	}
+}

--- a/internal/cli/node_install.go
+++ b/internal/cli/node_install.go
@@ -20,6 +20,9 @@ func NewNodeInstallCmd() *cobra.Command {
 }
 
 func runNodeInstall(_ *cobra.Command, args []string) error {
+	if err := ensureNodeManaged(); err != nil {
+		return err
+	}
 	version := args[0]
 	fnmPath := filepath.Join(config.BinDir(), "fnm")
 	cmd := exec.Command(fnmPath, "install", version)

--- a/internal/cli/node_uninstall.go
+++ b/internal/cli/node_uninstall.go
@@ -20,6 +20,9 @@ func NewNodeUninstallCmd() *cobra.Command {
 }
 
 func runNodeUninstall(_ *cobra.Command, args []string) error {
+	if !lerdManagesNode() {
+		return fmt.Errorf("lerd is not managing Node.js; nothing to uninstall")
+	}
 	version := args[0]
 	fnmPath := filepath.Join(config.BinDir(), "fnm")
 	cmd := exec.Command(fnmPath, "uninstall", version)

--- a/internal/cli/node_use.go
+++ b/internal/cli/node_use.go
@@ -21,6 +21,9 @@ func NewNodeUseCmd() *cobra.Command {
 }
 
 func runNodeUse(_ *cobra.Command, args []string) error {
+	if err := ensureNodeManaged(); err != nil {
+		return err
+	}
 	major := strings.SplitN(args[0], ".", 2)[0]
 	fnmPath := filepath.Join(config.BinDir(), "fnm")
 

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -2373,6 +2373,10 @@ func handleNodeVersionAction(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	if _, err := os.Stat(filepath.Join(config.BinDir(), "node")); err != nil {
+		writeJSON(w, map[string]any{"ok": false, "error": "lerd is not managing Node.js"})
+		return
+	}
 	version, action := parts[0], parts[1]
 	if !validVersion.MatchString(version) {
 		http.NotFound(w, r)
@@ -2434,6 +2438,10 @@ var validVersion = regexp.MustCompile(`^[0-9]+(\.[0-9]+)*$`)
 func handleInstallNodeVersion(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if _, err := os.Stat(filepath.Join(config.BinDir(), "node")); err != nil {
+		writeJSON(w, map[string]any{"ok": false, "error": "lerd is not managing Node.js"})
 		return
 	}
 	var req struct {

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -321,7 +321,7 @@
   "system_node_setDefault": "Set as default",
   "system_node_defaultVersion": "Default version",
   "system_node_managedBySystem": "Using system Node.js.",
-  "system_node_managedBySystemHint": "Installing a version below will switch to lerd-managed Node.js via fnm and override your system node.",
+  "system_node_managedBySystemHint": "To install or change Node.js versions from here, run `lerd install` in a terminal and accept lerd-managed Node.",
   "system_node_cannotRemove": "Cannot remove, sites are using this version",
   "system_node_cannotRemoveDefault": "Cannot remove the default version",
   "system_node_cannotRemoveSystem": "Node is managed by the system",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -321,7 +321,7 @@
   "system_node_setDefault": "Establecer como predeterminado",
   "system_node_defaultVersion": "Versión predeterminada",
   "system_node_managedBySystem": "Usando Node.js del sistema.",
-  "system_node_managedBySystemHint": "Instalar una versión aquí cambiará a Node.js gestionado por lerd vía fnm, sobrescribiendo el node del sistema.",
+  "system_node_managedBySystemHint": "Para instalar o cambiar versiones de Node.js desde aquí, ejecuta `lerd install` en un terminal y acepta Node.js gestionado por lerd.",
   "system_node_cannotRemove": "No se puede eliminar, hay sitios usando esta versión",
   "system_node_cannotRemoveDefault": "No se puede eliminar la versión predeterminada",
   "system_node_cannotRemoveSystem": "Node lo gestiona el sistema",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -321,7 +321,7 @@
   "system_node_setDefault": "Définir par défaut",
   "system_node_defaultVersion": "Version par défaut",
   "system_node_managedBySystem": "Node.js du système.",
-  "system_node_managedBySystemHint": "Installer une version ici bascule vers Node.js géré par lerd via fnm, et remplace votre node système.",
+  "system_node_managedBySystemHint": "Pour installer ou changer de version Node.js ici, lancez `lerd install` dans un terminal et acceptez Node.js géré par lerd.",
   "system_node_cannotRemove": "Impossible de supprimer, des sites utilisent cette version",
   "system_node_cannotRemoveDefault": "Impossible de supprimer la version par défaut",
   "system_node_cannotRemoveSystem": "Node est géré par le système",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -321,7 +321,7 @@
   "system_node_setDefault": "Definir como padrão",
   "system_node_defaultVersion": "Versão padrão",
   "system_node_managedBySystem": "Usando Node.js do sistema.",
-  "system_node_managedBySystemHint": "Instalar uma versão aqui vai mudar para Node.js gerenciado pelo lerd via fnm, sobrescrevendo seu node do sistema.",
+  "system_node_managedBySystemHint": "Para instalar ou mudar versões de Node.js daqui, rode `lerd install` num terminal e aceite o Node.js gerenciado pelo lerd.",
   "system_node_cannotRemove": "Não pode remover, sites estão usando esta versão",
   "system_node_cannotRemoveDefault": "Não pode remover a versão padrão",
   "system_node_cannotRemoveSystem": "Node é gerenciado pelo sistema",

--- a/internal/ui/web/src/tabs/system/NodePage.svelte
+++ b/internal/ui/web/src/tabs/system/NodePage.svelte
@@ -210,13 +210,14 @@
           bind:value={newVersion}
           onkeydown={(e) => e.key === 'Enter' && onInstall()}
           placeholder={m.system_node_installPlaceholder()}
-          disabled={installBusy}
-          class="text-sm bg-white dark:bg-lerd-card border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 w-28 text-gray-700 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-600 focus:outline-none focus:border-lerd-red/50 transition-colors"
+          disabled={installBusy || !$status.node_managed_by_lerd}
+          title={!$status.node_managed_by_lerd ? m.system_node_managedBySystem() : ''}
+          class="text-sm bg-white dark:bg-lerd-card border border-gray-200 dark:border-lerd-border rounded-lg px-3 py-1.5 w-28 text-gray-700 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-600 focus:outline-none focus:border-lerd-red/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         />
         <DetailButton
           tone="primary"
           onclick={onInstall}
-          disabled={installBusy || !newVersion.trim()}
+          disabled={installBusy || !newVersion.trim() || !$status.node_managed_by_lerd}
           loading={installBusy}
         >{m.common_install()}</DetailButton>
         {#if installDone}<span class="text-xs text-emerald-600 dark:text-emerald-500">{m.system_node_installed()}</span>{/if}


### PR DESCRIPTION
## Summary
- detectSystemNode also probes npm/npx in PATH and well-known version-manager dirs (nvm, volta, mise, asdf, fnm), so users on those managers actually get prompted instead of having shims silently installed
- after the user opts in to lerd-managed Node, install runs `fnm install` + `fnm default` so the system is left in a usable state, fixing the "can't find version: default" report on Reddit
- node/npm/npx shim probes the default alias before exec to catch "versions installed but no default" cases
- `lerd node:install`/`use`/`uninstall` warn and require confirmation when lerd is not currently managing node, and write shims on accept so CLI opt-in matches the install flow
- NodePage install input + button disabled when node is system-managed, with a revised hint, plus matching server-side guards on the UI endpoints