### PR TITLE
fix(services): warn about host port conflicts on stopped services

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -62,7 +62,7 @@ The chain in order:
 |---|---|---|
 | `lerd-dns container` | The dnsmasq container is running. | `lerd start` (or `podman logs lerd-dns` to see why it crashed). |
 | `dnsmasq config` | `~/.local/share/lerd/dnsmasq/lerd.conf` exists with `port=5300` and `address=/.<tld>/`. | `lerd start` regenerates the config from your registered TLD. |
-| `port 5300 listening` | TCP/UDP 5300 is reachable on 127.0.0.1. | Another process owns the port. Find it with `ss -tlnp sport = :5300`. |
+| `port 5300 listening` | TCP/UDP 5300 is reachable on 127.0.0.1. | Another process owns the port. Find it with `ss -tlnp sport = :5300` on Linux, or `lsof -nP -iTCP:5300 -sTCP:LISTEN` on macOS. |
 | `dig @127.0.0.1 -p 5300` | A direct query at port 5300 returns 127.0.0.1 for `lerd-probe.<tld>`. | dnsmasq is up but its config drifted. `systemctl --user restart lerd-dns`. |
 | `resolver hookup` | The NetworkManager dispatcher script or systemd-resolved drop-in is installed. | Rerun `lerd install`. |
 | `interface routes .test to 5300` | `resolvectl status` shows `127.0.0.1:5300` and `~<tld>` on the active interface. | `sudo systemctl restart NetworkManager`, or set the routing manually with `sudo resolvectl domain <iface> ~test ~.`. |
@@ -216,10 +216,16 @@ Port conflicts detected:
 Common culprits are Apache, another nginx instance, or a previously running lerd that wasn't stopped cleanly. Find and stop the conflicting process:
 
 ```bash
-ss -tlnp sport = :80    # show what's listening on port 80
+# Linux
+ss -tlnp sport = :80
+
+# macOS
+lsof -nP -iTCP:80 -sTCP:LISTEN
 ```
 
-`lerd doctor` also checks for port conflicts as part of its full diagnostic.
+The exact command lerd suggests in `lerd doctor` and `lerd start` output is already platform-correct, so you can copy it from there.
+
+`lerd doctor` also checks for port conflicts as part of its full diagnostic, and adds a dedicated **[Stopped service ports]** section that flags installed services whose host port is already bound by another process. The same warning is shown next to the inactive status pill in the web UI, so you can spot the conflict without running anything: most often this is a system-installed service (Postgres, MySQL, Redis) listening on the default port. Stop the conflicting process and the warning clears on the next snapshot refresh.
 :::
 
 ::: details Workers missing after reinstall

--- a/internal/cli/bug_report.go
+++ b/internal/cli/bug_report.go
@@ -433,7 +433,7 @@ func dumpContainerLogs(w io.Writer, n int, filter *logFilter) {
 
 func dumpNetwork(w io.Writer) {
 	fmt.Fprintln(w, "── listening sockets (lerd-relevant ports)")
-	listing := portListOutput()
+	listing := PortListOutput()
 	for _, port := range []string{"53", "80", "443", "5300", "7073"} {
 		for _, line := range strings.Split(listing, "\n") {
 			if strings.Contains(line, ":"+port+" ") {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -203,8 +203,8 @@ func RunDoctorTo(w io.Writer, useColor bool) (fails, warns int, err error) {
 				dnsRunning = true
 			}
 		}
-		if !dnsRunning && portInUse("5300") {
-			warn("DNS port 5300", "port in use by another process — lerd-dns may fail to start")
+		if !dnsRunning && PortInUse("5300") {
+			warn("DNS port 5300", "port in use by another process, lerd-dns may fail to start (find: "+FindListenerCmd("5300")+")")
 		}
 	}
 
@@ -216,15 +216,66 @@ func RunDoctorTo(w io.Writer, useColor bool) (fails, warns int, err error) {
 		ok("port 80  (nginx running)")
 		ok("port 443 (nginx running)")
 	} else {
-		if portInUse("80") {
-			fail("port 80", "in use by another process", "find the process: ss -tlnp sport = :80")
+		if PortInUse("80") {
+			fail("port 80", "in use by another process", "find the process: "+FindListenerCmd("80"))
 		} else {
 			ok("port 80  (free)")
 		}
-		if portInUse("443") {
-			fail("port 443", "in use by another process", "find the process: ss -tlnp sport = :443")
+		if PortInUse("443") {
+			fail("port 443", "in use by another process", "find the process: "+FindListenerCmd("443"))
 		} else {
 			ok("port 443 (free)")
+		}
+	}
+
+	// ── Stopped service ports ────────────────────────────────────────────────
+	// Surfaces the same diagnosis the UI shows on inactive service cards: if
+	// a service unit is installed but stopped and its host port is already
+	// bound by another process (a system-installed postgres, a stray docker
+	// container, etc.), Start will fail with a generic bind error. List those
+	// upfront so the user sees the conflict before clicking anything.
+	fmt.Fprintln(w, "\n[Stopped service ports]")
+	{
+		var stoppedUnits []string
+		for _, name := range append([]string{}, knownServices()...) {
+			unit := "lerd-" + name
+			if !services.Mgr.ContainerUnitInstalled(unit) {
+				continue
+			}
+			if services.Mgr.IsActive(unit) {
+				continue
+			}
+			stoppedUnits = append(stoppedUnits, unit)
+		}
+		customs, _ := config.ListCustomServices()
+		for _, svc := range customs {
+			unit := "lerd-" + svc.Name
+			if !services.Mgr.ContainerUnitInstalled(unit) {
+				continue
+			}
+			if services.Mgr.IsActive(unit) {
+				continue
+			}
+			stoppedUnits = append(stoppedUnits, unit)
+		}
+
+		if len(stoppedUnits) == 0 {
+			ok("no stopped services to check")
+		} else {
+			ssOut := PortListOutput()
+			conflictsFound := 0
+			for _, unit := range stoppedUnits {
+				for _, c := range CollectPortChecks([]string{unit}) {
+					if PortInUseIn(c.Port, ssOut) {
+						conflictsFound++
+						warn(fmt.Sprintf("%s port %s", c.Label, c.Port),
+							fmt.Sprintf("in use by another process, %s start may fail (find: %s)", c.Label, FindListenerCmd(c.Port)))
+					}
+				}
+			}
+			if conflictsFound == 0 {
+				ok(fmt.Sprintf("%d stopped service(s), no port conflicts", len(stoppedUnits)))
+			}
 		}
 	}
 
@@ -338,11 +389,11 @@ func checkDirWritable(dir string) error {
 	return nil
 }
 
-// portInUse is implemented per-platform in doctor_linux.go / doctor_darwin.go.
+// PortInUse is implemented per-platform in doctor_linux.go / doctor_darwin.go.
 //
-// portInUseIn checks whether the given TCP port appears in pre-fetched output
+// PortInUseIn checks whether the given TCP port appears in pre-fetched output
 // from a port listing command (ss on Linux, lsof on macOS). Used by
 // checkPortConflicts in startstop.go for batch checks.
-func portInUseIn(port, output string) bool {
+func PortInUseIn(port, output string) bool {
 	return strings.Contains(output, ":"+port+" ")
 }

--- a/internal/cli/doctor_darwin.go
+++ b/internal/cli/doctor_darwin.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 )
 
-// portListOutput returns a summary of listening TCP ports for batch checks.
-func portListOutput() string {
+// PortListOutput returns a summary of listening TCP ports for batch checks.
+func PortListOutput() string {
 	out, err := exec.Command("lsof", "-nP", "-iTCP", "-sTCP:LISTEN").Output()
 	if err != nil {
 		return ""
@@ -16,11 +16,18 @@ func portListOutput() string {
 	return string(out)
 }
 
-// portInUse returns true if something is listening on the given TCP port.
-func portInUse(port string) bool {
+// PortInUse returns true if something is listening on the given TCP port.
+func PortInUse(port string) bool {
 	out, err := exec.Command("lsof", "-nP", "-iTCP:"+port, "-sTCP:LISTEN").Output()
 	if err != nil {
 		return false
 	}
 	return strings.Contains(string(out), ":"+port)
+}
+
+// FindListenerCmd returns the platform-appropriate shell command the user
+// can run to identify the process bound to the given TCP port. macOS lacks
+// ss(8) (iproute2), so we point users at lsof which is shipped with the OS.
+func FindListenerCmd(port string) string {
+	return "lsof -nP -iTCP:" + port + " -sTCP:LISTEN"
 }

--- a/internal/cli/doctor_linux.go
+++ b/internal/cli/doctor_linux.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 )
 
-// portListOutput returns the raw output of ss -tlnp for batch port checks.
-func portListOutput() string {
+// PortListOutput returns the raw output of ss -tlnp for batch port checks.
+func PortListOutput() string {
 	out, err := exec.Command("ss", "-tlnp").Output()
 	if err != nil {
 		return ""
@@ -16,7 +16,15 @@ func portListOutput() string {
 	return string(out)
 }
 
-// portInUse returns true if something is listening on the given TCP port.
-func portInUse(port string) bool {
-	return strings.Contains(portListOutput(), ":"+port+" ")
+// PortInUse returns true if something is listening on the given TCP port.
+func PortInUse(port string) bool {
+	return strings.Contains(PortListOutput(), ":"+port+" ")
+}
+
+// FindListenerCmd returns the platform-appropriate shell command the user
+// can run to identify the process bound to the given TCP port. The CLI/UI
+// surfaces it in conflict hints so users don't have to know that ss is
+// Linux-only and lsof is the macOS equivalent.
+func FindListenerCmd(port string) string {
+	return "ss -tlnp sport = :" + port
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -7,40 +7,40 @@ import (
 
 func TestPortInUseIn_match(t *testing.T) {
 	output := "LISTEN  0  128  127.0.0.1:5300  0.0.0.0:*"
-	if !portInUseIn("5300", output) {
+	if !PortInUseIn("5300", output) {
 		t.Error("expected port 5300 to be found in output")
 	}
 }
 
 func TestPortInUseIn_noMatch(t *testing.T) {
 	output := "LISTEN  0  128  127.0.0.1:5300  0.0.0.0:*"
-	if portInUseIn("80", output) {
+	if PortInUseIn("80", output) {
 		t.Error("expected port 80 not to be found")
 	}
 }
 
 func TestPortInUseIn_emptyOutput(t *testing.T) {
-	if portInUseIn("80", "") {
+	if PortInUseIn("80", "") {
 		t.Error("expected false for empty output")
 	}
 }
 
 func TestPortInUseIn_partialPortMatch(t *testing.T) {
 	output := "LISTEN  0  128  127.0.0.1:8080  0.0.0.0:*"
-	if portInUseIn("80", output) {
+	if PortInUseIn("80", output) {
 		t.Error("port 80 should not match :8080")
 	}
 }
 
 func TestPortInUse_unusedPort(t *testing.T) {
-	if portInUse("59999") {
+	if PortInUse("59999") {
 		t.Error("port 59999 should not be in use")
 	}
 }
 
 func TestPortListOutput_format(t *testing.T) {
-	output := portListOutput()
+	output := PortListOutput()
 	if output != "" && !strings.Contains(output, "LISTEN") && !strings.Contains(output, "State") {
-		t.Errorf("portListOutput should contain LISTEN headers, got: %.100s", output)
+		t.Errorf("PortListOutput should contain LISTEN headers, got: %.100s", output)
 	}
 }

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -275,11 +275,11 @@ func allInstalledServiceUnits() []string {
 	return units
 }
 
-// portCheck pairs a host port with a human-readable label and container name.
-type portCheck struct {
-	port      string // host port number
-	label     string // e.g. "nginx HTTP", "mysql"
-	container string // lerd container name
+// PortCheck pairs a host port with a human-readable label and container name.
+type PortCheck struct {
+	Port      string // host port number
+	Label     string // e.g. "nginx HTTP", "mysql"
+	Container string // lerd container name
 }
 
 // builtinExtraPorts lists secondary host ports for built-in services that are
@@ -298,14 +298,14 @@ func hostPort(mapping string) string {
 	return mapping
 }
 
-// collectPortChecks builds the list of ports to verify for the given units.
-func collectPortChecks(units []string) []portCheck {
+// CollectPortChecks builds the list of ports to verify for the given units.
+func CollectPortChecks(units []string) []PortCheck {
 	unitSet := make(map[string]bool, len(units))
 	for _, u := range units {
 		unitSet[u] = true
 	}
 
-	var checks []portCheck
+	var checks []PortCheck
 
 	// Nginx ports (configurable).
 	if unitSet["lerd-nginx"] {
@@ -321,14 +321,14 @@ func collectPortChecks(units []string) []portCheck {
 			}
 		}
 		checks = append(checks,
-			portCheck{strconv.Itoa(httpPort), "nginx HTTP", "lerd-nginx"},
-			portCheck{strconv.Itoa(httpsPort), "nginx HTTPS", "lerd-nginx"},
+			PortCheck{strconv.Itoa(httpPort), "nginx HTTP", "lerd-nginx"},
+			PortCheck{strconv.Itoa(httpsPort), "nginx HTTPS", "lerd-nginx"},
 		)
 	}
 
 	// DNS port.
 	if unitSet["lerd-dns"] {
-		checks = append(checks, portCheck{"5300", "dns", "lerd-dns"})
+		checks = append(checks, PortCheck{"5300", "dns", "lerd-dns"})
 	}
 
 	// Built-in services.
@@ -340,16 +340,16 @@ func collectPortChecks(units []string) []portCheck {
 		container := "lerd-" + svc
 		if cfg != nil {
 			if sc, ok := cfg.Services[svc]; ok && sc.Port > 0 {
-				checks = append(checks, portCheck{strconv.Itoa(sc.Port), svc, container})
+				checks = append(checks, PortCheck{strconv.Itoa(sc.Port), svc, container})
 			}
 			if sc, ok := cfg.Services[svc]; ok {
 				for _, ep := range sc.ExtraPorts {
-					checks = append(checks, portCheck{hostPort(ep), svc, container})
+					checks = append(checks, PortCheck{hostPort(ep), svc, container})
 				}
 			}
 		}
 		for _, ep := range builtinExtraPorts[svc] {
-			checks = append(checks, portCheck{ep, svc, container})
+			checks = append(checks, PortCheck{ep, svc, container})
 		}
 	}
 
@@ -361,7 +361,7 @@ func collectPortChecks(units []string) []portCheck {
 		}
 		container := "lerd-" + svc.Name
 		for _, p := range svc.Ports {
-			checks = append(checks, portCheck{hostPort(p), svc.Name, container})
+			checks = append(checks, PortCheck{hostPort(p), svc.Name, container})
 		}
 	}
 
@@ -370,25 +370,25 @@ func collectPortChecks(units []string) []portCheck {
 
 // checkPortConflicts warns about ports already in use by non-lerd processes.
 func checkPortConflicts(units []string) {
-	checks := collectPortChecks(units)
+	checks := CollectPortChecks(units)
 	if len(checks) == 0 {
 		return
 	}
 
-	ss := portListOutput()
+	ss := PortListOutput()
 	if ss == "" {
 		return
 	}
 
 	var conflicts []string
 	for _, c := range checks {
-		running, _ := podman.ContainerRunning(c.container)
+		running, _ := podman.ContainerRunning(c.Container)
 		if running {
 			continue
 		}
-		if portInUseIn(c.port, ss) {
+		if PortInUseIn(c.Port, ss) {
 			conflicts = append(conflicts,
-				fmt.Sprintf("  WARN: port %s (%s) already in use — may fail to start (check: ss -tlnp sport = :%s)", c.port, c.label, c.port))
+				fmt.Sprintf("  WARN: port %s (%s) already in use, may fail to start (check: %s)", c.Port, c.Label, FindListenerCmd(c.Port)))
 		}
 	}
 	if len(conflicts) > 0 {

--- a/internal/dns/diagnose.go
+++ b/internal/dns/diagnose.go
@@ -104,7 +104,7 @@ func diagnose(tld string, p probeFns) Diagnostic {
 			Name:   "port 5300 listening",
 			Status: StepFail,
 			Detail: "no TCP listener on 127.0.0.1:5300",
-			Hint:   "check whether another process owns the port: ss -tlnp sport = :5300",
+			Hint:   "check whether another process owns the port: " + findListenerCmd(5300),
 		})
 		return finalize(d)
 	}
@@ -222,6 +222,16 @@ func contains(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+// findListenerCmd returns the shell command the user can run to identify
+// the process bound to a TCP port. macOS lacks ss(8), so we point users at
+// lsof which ships with the OS; everywhere else we assume iproute2 ss.
+func findListenerCmd(port int) string {
+	if runtime.GOOS == "darwin" {
+		return fmt.Sprintf("lsof -nP -iTCP:%d -sTCP:LISTEN", port)
+	}
+	return fmt.Sprintf("ss -tlnp sport = :%d", port)
 }
 
 // defaultProbes wires the production implementations for each rung.

--- a/internal/dns/diagnose_test.go
+++ b/internal/dns/diagnose_test.go
@@ -58,8 +58,9 @@ func TestDiagnose_portClosedStopsChain(t *testing.T) {
 	if d.FirstFailure != 2 {
 		t.Errorf("FirstFailure = %d, want 2 (port rung)", d.FirstFailure)
 	}
-	if !strings.Contains(d.Steps[2].Hint, "ss -tlnp") {
-		t.Errorf("hint %q should suggest ss -tlnp", d.Steps[2].Hint)
+	hint := d.Steps[2].Hint
+	if !strings.Contains(hint, "ss -tlnp") && !strings.Contains(hint, "lsof") {
+		t.Errorf("hint %q should suggest ss/lsof for the bound port", hint)
 	}
 }
 

--- a/internal/ui/port_conflicts_test.go
+++ b/internal/ui/port_conflicts_test.go
@@ -1,0 +1,68 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPortConflictsFor_emptySsOutput verifies the helper short-circuits when
+// the listening-port listing is unavailable (e.g. ss/lsof failed). Stopped
+// services should not be flagged as conflicting just because we couldn't
+// scan the host.
+func TestPortConflictsFor_emptySsOutput(t *testing.T) {
+	if got := portConflictsFor("lerd-postgres", ""); got != nil {
+		t.Errorf("expected nil for empty ssOutput, got %+v", got)
+	}
+}
+
+// TestPortConflictsFor_unknownUnit covers the case where the unit name
+// matches no installed service. CollectPortChecks should return no entries
+// and the helper should return nil rather than scanning unrelated ports.
+func TestPortConflictsFor_unknownUnit(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	ss := "LISTEN 0 128 0.0.0.0:5432 0.0.0.0:*\n"
+	if got := portConflictsFor("lerd-not-a-real-service", ss); got != nil {
+		t.Errorf("expected nil for unknown unit, got %+v", got)
+	}
+}
+
+// TestPortConflictsFor_customService validates the end-to-end path for a
+// custom service: a YAML file in CustomServicesDir advertising port 5432,
+// against an ssOutput containing :5432, must surface a single conflict
+// labelled with the service name.
+func TestPortConflictsFor_customService(t *testing.T) {
+	tmp := t.TempDir()
+	cfgHome := filepath.Join(tmp, "config")
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	servicesDir := filepath.Join(cfgHome, "lerd", "services")
+	if err := os.MkdirAll(servicesDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	yaml := "name: myservice\nimage: example/myservice:latest\nports:\n  - \"5432:5432\"\n"
+	if err := os.WriteFile(filepath.Join(servicesDir, "myservice.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	ss := "LISTEN 0 128 0.0.0.0:5432 0.0.0.0:*\n"
+	got := portConflictsFor("lerd-myservice", ss)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 conflict, got %d (%+v)", len(got), got)
+	}
+	if got[0].Port != "5432" {
+		t.Errorf("port = %q, want 5432", got[0].Port)
+	}
+	if got[0].Label != "myservice" {
+		t.Errorf("label = %q, want myservice", got[0].Label)
+	}
+
+	// No conflict when the same port is absent from the listing.
+	if extra := portConflictsFor("lerd-myservice", "LISTEN 0 128 0.0.0.0:9999 0.0.0.0:*\n"); extra != nil {
+		t.Errorf("expected no conflict when port not listening, got %+v", extra)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -799,11 +799,44 @@ type ServiceResponse struct {
 	// MigrationSupported and CanRollback intentionally drop omitempty so the
 	// false case still appears in the JSON. The UI uses === to distinguish
 	// "field missing" (no avail check ran) from "explicitly false".
-	MigrationSupported bool `json:"migration_supported"`
-	CanRollback        bool `json:"can_rollback"`
+	MigrationSupported bool           `json:"migration_supported"`
+	CanRollback        bool           `json:"can_rollback"`
+	PortConflicts      []PortConflict `json:"port_conflicts,omitempty"`
+}
+
+// PortConflict reports a host port lerd wants to bind that is already taken
+// by another process. Surfaced for inactive services so the user sees the
+// blocker before clicking Start.
+type PortConflict struct {
+	Port  string `json:"port"`
+	Label string `json:"label,omitempty"`
+}
+
+// portConflictsFor returns conflicts for a single unit using a pre-fetched
+// listening-port listing. ssOutput is shared across the whole snapshot
+// rebuild so we never spawn ss/lsof more than once per refresh.
+func portConflictsFor(unit, ssOutput string) []PortConflict {
+	if ssOutput == "" {
+		return nil
+	}
+	checks := cli.CollectPortChecks([]string{unit})
+	if len(checks) == 0 {
+		return nil
+	}
+	var out []PortConflict
+	for _, c := range checks {
+		if cli.PortInUseIn(c.Port, ssOutput) {
+			out = append(out, PortConflict{Port: c.Port, Label: c.Label})
+		}
+	}
+	return out
 }
 
 func buildServiceResponse(name string) ServiceResponse {
+	return buildServiceResponseWithPortList(name, "")
+}
+
+func buildServiceResponseWithPortList(name, ssOutput string) ServiceResponse {
 	unit := "lerd-" + name
 	status, _ := podman.UnitStatus(unit)
 	if status == "" {
@@ -843,6 +876,9 @@ func buildServiceResponse(name string) ServiceResponse {
 		resp.PreviousVersion = avail.PreviousImage
 		resp.MigrationSupported = serviceops.SupportsMigration(name)
 		resp.CanRollback = avail.CanRollback
+	}
+	if status != "active" {
+		resp.PortConflicts = portConflictsFor(unit, ssOutput)
 	}
 	return resp
 }
@@ -886,10 +922,14 @@ func handleServices(w http.ResponseWriter, _ *http.Request) {
 func buildServicesJSON() []byte { return []byte(mustJSON(buildServicesList())) }
 
 func buildServicesList() []ServiceResponse {
+	// One ss/lsof call shared across all installed-but-stopped services in
+	// this rebuild; portConflictsFor is a no-op when ssOutput is empty.
+	ssOutput := cli.PortListOutput()
+
 	defaultNames := siteinfo.KnownServices()
 	services := make([]ServiceResponse, 0, len(defaultNames))
 	for _, name := range defaultNames {
-		services = append(services, buildServiceResponse(name))
+		services = append(services, buildServiceResponseWithPortList(name, ssOutput))
 	}
 	customs, _ := config.ListCustomServices()
 	for _, svc := range customs {
@@ -908,6 +948,10 @@ func buildServicesList() []ServiceResponse {
 				envMap[parts[0]] = v
 			}
 		}
+		var conflicts []PortConflict
+		if status != "active" {
+			conflicts = portConflictsFor(unit, ssOutput)
+		}
 		services = append(services, ServiceResponse{
 			Name:              svc.Name,
 			Status:            status,
@@ -922,6 +966,7 @@ func buildServicesList() []ServiceResponse {
 			Pinned:            config.ServiceIsPinned(svc.Name),
 			Paused:            config.ServiceIsPaused(svc.Name),
 			DependsOn:         svc.DependsOn,
+			PortConflicts:     conflicts,
 		})
 	}
 	for _, siteName := range listActiveQueueWorkers() {

--- a/internal/ui/web/src/stores/services.ts
+++ b/internal/ui/web/src/stores/services.ts
@@ -31,6 +31,12 @@ export interface Service {
   previous_version?: string;
   migration_supported?: boolean;
   can_rollback?: boolean;
+  port_conflicts?: PortConflict[];
+}
+
+export interface PortConflict {
+  port: string;
+  label?: string;
 }
 
 export interface PhaseEvent {

--- a/internal/ui/web/src/tabs/ServicesTab.svelte
+++ b/internal/ui/web/src/tabs/ServicesTab.svelte
@@ -52,6 +52,19 @@
     {#each $coreServices as svc (svc.name)}
       {#snippet leading()}<StatusDot color={svc.status === 'active' ? 'green' : 'gray'} />{/snippet}
       {#snippet trailing()}
+        {#if svc.status !== 'active' && svc.port_conflicts && svc.port_conflicts.length > 0}
+          <span
+            class="shrink-0 text-amber-500 dark:text-amber-400"
+            title={'Port ' + svc.port_conflicts.map((c) => c.port).join(', ') + ' already in use on the host. Start may fail until you stop the conflicting process.'}
+            aria-label="port conflict"
+          >
+            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+              <line x1="12" y1="9" x2="12" y2="13"/>
+              <line x1="12" y1="17" x2="12.01" y2="17"/>
+            </svg>
+          </span>
+        {/if}
         {#if svc.depends_on && svc.depends_on.length > 0}
           <span class="shrink-0 text-gray-300 dark:text-gray-600" title={m.services_hasDependencies()}>
             <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/internal/ui/web/src/tabs/services/ServiceHeader.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceHeader.svelte
@@ -53,6 +53,16 @@
   const isWorker = $derived(isServiceWorker(svc));
   const active = $derived(svc.status === 'active');
   const parent = $derived(parentSiteDomain(svc));
+  const portConflicts = $derived(
+    !active && svc.port_conflicts && svc.port_conflicts.length > 0 ? svc.port_conflicts : []
+  );
+  const portConflictTitle = $derived(
+    portConflicts.length > 0
+      ? 'Port ' +
+        portConflicts.map((c) => c.port).join(', ') +
+        ' already in use on the host. Stop the conflicting process or change the lerd port. Run `lerd doctor` for the find command on your OS.'
+      : ''
+  );
 
   let localBusy = $state(false);
   let deleteOpen = $state(false);
@@ -271,6 +281,21 @@
           <span class="text-xs font-normal tabular-nums text-gray-500 dark:text-gray-400">{svc.version}</span>
         {/if}
         <StatusPill tone={active ? 'ok' : 'muted'} label={svc.status} />
+        {#if portConflicts.length > 0}
+          <span
+            class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium bg-amber-50 dark:bg-amber-500/10 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-500/30"
+            title={portConflictTitle}
+            role="status"
+            aria-label={portConflictTitle}
+          >
+            <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+              <line x1="12" y1="9" x2="12" y2="13"/>
+              <line x1="12" y1="17" x2="12.01" y2="17"/>
+            </svg>
+            <span>port {portConflicts.map((c) => c.port).join(', ')} in use</span>
+          </span>
+        {/if}
       </div>
 
       {#if parent}


### PR DESCRIPTION
## Summary

A user reported PostgreSQL refused to start from lerd because a
system-installed PostgreSQL was already listening on :5432. The bind
failure surfaced as a generic Start error with no diagnosis. This change
makes the conflict visible passively so the user sees the blocker before
clicking Start.

* `lerd doctor` gains a `[Stopped service ports]` section that walks
  installed-but-inactive services and warns on each bound port.
* `/api/services` exposes a new `port_conflicts` field, populated from
  one `ss`/`lsof` scan per snapshot rebuild. The web UI renders an
  amber pill next to the inactive status pill on the service detail
  and a small alert icon on the sidebar row.
* All user-facing find-the-process hints (`lerd start` pre-flight,
  `lerd doctor` ports section, `dns.Diagnose` rung 3, the troubleshooting
  doc) now branch on `runtime.GOOS` so macOS users get
  `lsof -nP -iTCP:PORT -sTCP:LISTEN` instead of the Linux-only
  `ss -tlnp` string. A new `FindListenerCmd` helper in
  `internal/cli/doctor_{linux,darwin}.go` owns the split.

The `cli` port helpers are exported so `internal/ui` can reuse them
without duplicating the `ss`-vs-`lsof` logic.

Docs updated in `docs/troubleshooting.md`.