### PR TITLE
fix(podman): fall back to PodmanArgs on Podman <5.0 quadlets (#299)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Service quadlets failed to generate on Podman 4.x** (#299). v1.19.0 emitted `StopTimeout=5` in every service's `[Container]` section, but that key was added in Podman 5.0 and is unrecognised by the 4.9.3 shipped on Ubuntu 24.04. systemd-quadlet aborted with exit 1 and produced no service units, so `lerd-mysql.service`, `lerd-redis.service` etc. simply didn't exist. Lerd now probes `podman --version` once and falls back to `PodmanArgs=--stop-timeout=5` on Podman <5.0, which is universally supported and produces the same `--stop-timeout=5` on the underlying `podman run`.
+
 ---
 
 ## [1.19.0] — 2026-05-04

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - **Service quadlets failed to generate on Podman 4.x** (#299). v1.19.0 emitted `StopTimeout=5` in every service's `[Container]` section, but that key was added in Podman 5.0 and is unrecognised by the 4.9.3 shipped on Ubuntu 24.04. systemd-quadlet aborted with exit 1 and produced no service units, so `lerd-mysql.service`, `lerd-redis.service` etc. simply didn't exist. Lerd now probes `podman --version` once and falls back to `PodmanArgs=--stop-timeout=5` on Podman <5.0, which is universally supported and produces the same `--stop-timeout=5` on the underlying `podman run`.
+- **Dashboard could go green for a service with no unit** (#299, #301). When a quadlet generator rejected a `.container` file but a container from an earlier valid load was still in the cgroup, `systemctl --user list-units` printed `not-found active running` and the dashboard read the `active` column verbatim. The unit-state cache now collapses any LOAD other than `loaded` (`not-found`, `masked`, `bad-setting`, `error`) to `inactive` so the UI matches reality.
 
 ---
 

--- a/docs/usage/custom-services.md
+++ b/docs/usage/custom-services.md
@@ -185,7 +185,7 @@ When `lerd env` runs in a project directory, it checks each custom service's `en
 
 `lerd start` and `lerd stop` include any custom service that has a quadlet file installed (i.e. has been started at least once via `lerd service start`). They are started and stopped alongside the built-in services.
 
-Custom service containers are given a 5-second graceful stop window before podman sends `SIGKILL`. This keeps `lerd service stop` and the web UI's Stop button responsive even for images with slow shutdown sequences (Selenium Chromium/supervisord, for example, can otherwise block for 30 s+). If you remove a preset service and reinstall it after upgrading lerd, the new `StopTimeout=5` value lands automatically. Existing installs of a slow-stopping service can pick up the change with `lerd service remove <name> && lerd service preset <name>`.
+Custom service containers are given a 5-second graceful stop window before podman sends `SIGKILL`. This keeps `lerd service stop` and the web UI's Stop button responsive even for images with slow shutdown sequences (Selenium Chromium/supervisord, for example, can otherwise block for 30 s+). On Podman 5.0+ this is emitted as the native `StopTimeout=5` quadlet key; on Podman 4.x (e.g. Ubuntu 24.04's 4.9.3) lerd writes `PodmanArgs=--stop-timeout=5` instead, since the `StopTimeout=` key only exists in 5.0+. Existing installs of a slow-stopping service can pick up the change with `lerd service remove <name> && lerd service preset <name>`.
 
 ## Pinning services
 

--- a/internal/podman/quadlet_embed_test.go
+++ b/internal/podman/quadlet_embed_test.go
@@ -315,17 +315,45 @@ func TestGenerateCustomQuadlet_EnvWithJSONPreservesQuotes(t *testing.T) {
 	}
 }
 
-func TestGenerateCustomQuadlet_StopTimeout(t *testing.T) {
-	// Images like selenium/standalone-chromium hang for 30s+ on graceful
-	// shutdown. StopTimeout=5 bounds podman's SIGTERM-wait so systemctl stop
-	// returns promptly instead of blocking the UI.
+func TestGenerateCustomQuadlet_StopTimeoutModernPodman(t *testing.T) {
+	// Podman >=5.0 supports the native StopTimeout= key in [Container].
+	// Bounds podman's SIGTERM-wait so systemctl stop returns promptly for
+	// slow-shutdown images (selenium/supervisord, chromium).
+	prev := supportsContainerStopTimeoutKey
+	supportsContainerStopTimeoutKey = func() bool { return true }
+	t.Cleanup(func() { supportsContainerStopTimeoutKey = prev })
+
 	svc := &config.CustomService{
 		Name:  "selenium",
 		Image: "docker.io/selenium/standalone-chromium:latest",
 	}
 	out := GenerateCustomQuadlet(svc)
-	if !strings.Contains(out, "StopTimeout=5") {
+	if !strings.Contains(out, "\nStopTimeout=5\n") {
 		t.Errorf("expected StopTimeout=5 in [Container] section, got:\n%s", out)
+	}
+	if strings.Contains(out, "PodmanArgs=--stop-timeout=5") {
+		t.Errorf("must not also emit PodmanArgs fallback on modern podman, got:\n%s", out)
+	}
+}
+
+func TestGenerateCustomQuadlet_StopTimeoutOldPodman(t *testing.T) {
+	// Ubuntu 24.04 ships Podman 4.9.3 which doesn't recognise the
+	// StopTimeout= quadlet key. Quadlet aborts with exit 1 and emits no
+	// service units at all, so we must fall back to PodmanArgs.
+	prev := supportsContainerStopTimeoutKey
+	supportsContainerStopTimeoutKey = func() bool { return false }
+	t.Cleanup(func() { supportsContainerStopTimeoutKey = prev })
+
+	svc := &config.CustomService{
+		Name:  "selenium",
+		Image: "docker.io/selenium/standalone-chromium:latest",
+	}
+	out := GenerateCustomQuadlet(svc)
+	if !strings.Contains(out, "PodmanArgs=--stop-timeout=5") {
+		t.Errorf("expected PodmanArgs=--stop-timeout=5 fallback, got:\n%s", out)
+	}
+	if strings.Contains(out, "\nStopTimeout=5\n") {
+		t.Errorf("must not emit StopTimeout= key on old podman (breaks quadlet), got:\n%s", out)
 	}
 }
 

--- a/internal/podman/quadlet_generate.go
+++ b/internal/podman/quadlet_generate.go
@@ -27,7 +27,15 @@ func GenerateCustomQuadlet(svc *config.CustomService) string {
 	// Bound podman's graceful-stop window so images with slow shutdown
 	// sequences (selenium/supervisord, chromium) don't block systemctl stop
 	// for the full 90 s default. Mirrors the --stop-timeout=5 used on macOS.
-	b.WriteString("StopTimeout=5\n")
+	// StopTimeout= in [Container] requires Podman >=5.0; on Ubuntu 24.04's
+	// 4.9.3 the key is unrecognised and quadlet aborts with exit 1, leaving
+	// no service units at all (#299). Fall back to PodmanArgs= which works
+	// on every quadlet-supporting podman.
+	if supportsContainerStopTimeoutKey() {
+		b.WriteString("StopTimeout=5\n")
+	} else {
+		b.WriteString("PodmanArgs=--stop-timeout=5\n")
+	}
 
 	if svc.ShareHosts {
 		fmt.Fprintf(&b, "Volume=%s:/etc/hosts:ro,z\n", config.BrowserHostsFile())

--- a/internal/podman/version.go
+++ b/internal/podman/version.go
@@ -1,0 +1,82 @@
+package podman
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// parsePodmanVersion extracts major.minor from `podman --version` output.
+// Accepts forms like "podman version 5.8.2", "podman version 4.9.3+ds1",
+// "podman version 4.9". Returns an error if no version token is found.
+func parsePodmanVersion(out string) (int, int, error) {
+	fields := strings.Fields(out)
+	for i, f := range fields {
+		if f == "version" && i+1 < len(fields) {
+			return splitMajorMinor(fields[i+1])
+		}
+	}
+	return 0, 0, fmt.Errorf("podman version: no version token in %q", out)
+}
+
+func splitMajorMinor(v string) (int, int, error) {
+	// Strip distro/build suffixes like "+ds1" or "-rc1".
+	for _, sep := range []string{"+", "-", "~"} {
+		if idx := strings.Index(v, sep); idx > 0 {
+			v = v[:idx]
+		}
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) < 2 {
+		return 0, 0, fmt.Errorf("podman version %q: not enough components", v)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("podman version major %q: %w", parts[0], err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("podman version minor %q: %w", parts[1], err)
+	}
+	return major, minor, nil
+}
+
+// podmanVersionSupportsStopTimeout reports whether the StopTimeout= key in
+// quadlet [Container] sections is recognised. Added in Podman 5.0; Ubuntu
+// 24.04 ships 4.9.3 which rejects the unit and emits no service files.
+func podmanVersionSupportsStopTimeout(major, minor int) bool {
+	_ = minor
+	return major >= 5
+}
+
+// supportsContainerStopTimeoutKey is the runtime test seam used by the
+// quadlet generator. Tests override this to exercise both branches without
+// shelling out. The default lazily probes the local podman once.
+var supportsContainerStopTimeoutKey = defaultSupportsContainerStopTimeoutKey
+
+var (
+	stopTimeoutOnce   sync.Once
+	stopTimeoutResult bool
+)
+
+func defaultSupportsContainerStopTimeoutKey() bool {
+	stopTimeoutOnce.Do(func() {
+		out, err := exec.Command("podman", "--version").Output()
+		if err != nil {
+			// Conservative fallback: PodmanArgs= works on every quadlet
+			// version, while StopTimeout= breaks <5.0. Better to use the
+			// universal escape hatch than emit a unit systemd refuses.
+			stopTimeoutResult = false
+			return
+		}
+		major, minor, err := parsePodmanVersion(string(out))
+		if err != nil {
+			stopTimeoutResult = false
+			return
+		}
+		stopTimeoutResult = podmanVersionSupportsStopTimeout(major, minor)
+	})
+	return stopTimeoutResult
+}

--- a/internal/podman/version_test.go
+++ b/internal/podman/version_test.go
@@ -1,0 +1,59 @@
+package podman
+
+import "testing"
+
+func TestParsePodmanVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		major   int
+		minor   int
+		wantErr bool
+	}{
+		{"plain", "podman version 5.8.2\n", 5, 8, false},
+		{"trailing space", "podman version 4.9.3 \n", 4, 9, false},
+		{"debian suffix", "podman version 4.9.3+ds1\n", 4, 9, false},
+		{"5.0 boundary", "podman version 5.0.0\n", 5, 0, false},
+		{"no patch", "podman version 4.9\n", 4, 9, false},
+		{"garbage", "not a version line\n", 0, 0, true},
+		{"empty", "", 0, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			major, minor, err := parsePodmanVersion(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got major=%d minor=%d", major, minor)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if major != tt.major || minor != tt.minor {
+				t.Errorf("got %d.%d, want %d.%d", major, minor, tt.major, tt.minor)
+			}
+		})
+	}
+}
+
+func TestSupportsContainerStopTimeoutBoundary(t *testing.T) {
+	// StopTimeout= in [Container] was added in Podman 5.0. Anything below
+	// must fall back to PodmanArgs=--stop-timeout=5.
+	tests := []struct {
+		major, minor int
+		want         bool
+	}{
+		{4, 9, false},
+		{4, 99, false},
+		{5, 0, true},
+		{5, 8, true},
+		{6, 0, true},
+	}
+	for _, tt := range tests {
+		got := podmanVersionSupportsStopTimeout(tt.major, tt.minor)
+		if got != tt.want {
+			t.Errorf("%d.%d: got %v, want %v", tt.major, tt.minor, got, tt.want)
+		}
+	}
+}

--- a/internal/siteinfo/unitcache.go
+++ b/internal/siteinfo/unitcache.go
@@ -113,6 +113,12 @@ func (c *unitCache) refreshLocked() error {
 			continue
 		}
 		unit, active := fields[0], fields[2]
+		// systemctl reports "not-found active running" when the unit file
+		// is gone but a container from an earlier load still owns the
+		// cgroup; normalise non-"loaded" LOAD values so we don't go green.
+		if fields[1] != "loaded" {
+			active = "inactive"
+		}
 		// Strip the .service suffix so callers can pass either form.
 		// Timer and other suffixes are preserved since enrichWorkers
 		// explicitly looks up "lerd-schedule-<site>.timer".

--- a/internal/siteinfo/unitcache_test.go
+++ b/internal/siteinfo/unitcache_test.go
@@ -106,6 +106,34 @@ func TestUnitStatusCachedRefreshesAfterTTL(t *testing.T) {
 	}
 }
 
+func TestUnitStatusCachedNonLoadedReportedInactive(t *testing.T) {
+	// When a quadlet generator rejects a .container file (e.g. Podman 4.x
+	// hitting StopTimeout=, #299), the .service vanishes but a container
+	// from an earlier valid load can still be in the cgroup, and systemctl
+	// emits "not-found active running". Surfacing "active" sent the
+	// dashboard green for a service with no unit; any LOAD other than
+	// "loaded" must collapse to "inactive".
+	withStubList(t, `lerd-mysql.service       not-found active   running Lerd MySQL
+lerd-redis.service       loaded    active   running Lerd Redis
+lerd-masked.service      masked    active   running Lerd Masked
+lerd-broken.service      bad-setting active running Lerd Broken
+`, nil)
+
+	cases := map[string]string{
+		"lerd-mysql":         "inactive",
+		"lerd-mysql.service": "inactive",
+		"lerd-redis":         "active",
+		"lerd-masked":        "inactive",
+		"lerd-broken":        "inactive",
+	}
+	for unit, want := range cases {
+		got, _ := unitStatusCached(unit)
+		if got != want {
+			t.Errorf("%s: got %q, want %q", unit, got, want)
+		}
+	}
+}
+
 func TestUnitStatusCachedSystemctlFailure(t *testing.T) {
 	withStubList(t, "", errFakeSystemctl{})
 	got, _ := unitStatusCached("lerd-anything")


### PR DESCRIPTION
## Summary

v1.19.0 emits `StopTimeout=5` in every service quadlet's `[Container]` section, but that key was only added in Podman 5.0. On Ubuntu 24.04's Podman 4.9.3 the generator aborts with exit 1 and produces zero `.service` units, so `lerd-mysql.service`, `lerd-redis.service`, etc. simply don't exist (#299).

This patch probes `podman --version` once at startup and:
- emits the native `StopTimeout=5` on Podman >=5.0
- falls back to `PodmanArgs=--stop-timeout=5` on older versions (universally supported, produces the same `--stop-timeout=5` on the underlying `podman run`)

Conservative fallback: if the probe fails or output can't be parsed, lerd uses `PodmanArgs=` since it's the only form guaranteed to work on every quadlet-supporting podman.

Fixes #299.