### PR TITLE
fix(framework): refresh every cached version, not just the latest

### DIFF
--- a/internal/cli/framework.go
+++ b/internal/cli/framework.go
@@ -561,37 +561,45 @@ func updateAllFrameworks(client *store.Client, showDiff bool) error {
 		if info.Source == config.SourceBuiltIn {
 			continue
 		}
-		for _, entry := range idx.Frameworks {
-			if entry.Name != info.Name {
-				continue
+		// Refresh the same version that's cached; previously this fetched
+		// entry.Latest for every entry, so users with multiple versions
+		// (laravel@10..@13) ended up only refreshing the latest file and
+		// the others stayed stale forever.
+		var indexed *store.IndexEntry
+		for i, entry := range idx.Frameworks {
+			if entry.Name == info.Name {
+				indexed = &idx.Frameworks[i]
+				break
 			}
-			remote, fetchErr := client.FetchFramework(entry.Name, entry.Latest)
-			if fetchErr != nil {
-				fmt.Printf("  [WARN] %s: %v\n", entry.Name, fetchErr)
-				continue
-			}
-
-			if showDiff {
-				changed, diffErr := showFrameworkDiff(entry.Name, info.Framework, remote)
-				if diffErr != nil {
-					fmt.Printf("  [WARN] %s: %v\n", entry.Name, diffErr)
-					continue
-				}
-				if !changed {
-					fmt.Printf("  %s@%s — up to date\n", entry.Name, versionOrLatest(remote))
-					continue
-				}
-			}
-
-			if saveErr := config.SaveStoreFramework(remote); saveErr != nil {
-				fmt.Printf("  [WARN] %s: %v\n", entry.Name, saveErr)
-				continue
-			}
-			config.RemoveUserFramework(entry.Name)
-			fmt.Printf("  Updated %s@%s\n", remote.Name, versionOrLatest(remote))
-			updated++
-			break
 		}
+		if indexed == nil {
+			continue
+		}
+		remote, fetchErr := client.FetchFramework(info.Name, info.Version)
+		if fetchErr != nil {
+			fmt.Printf("  [WARN] %s@%s: %v\n", info.Name, info.Version, fetchErr)
+			continue
+		}
+
+		if showDiff {
+			changed, diffErr := showFrameworkDiff(info.Name, info.Framework, remote)
+			if diffErr != nil {
+				fmt.Printf("  [WARN] %s@%s: %v\n", info.Name, info.Version, diffErr)
+				continue
+			}
+			if !changed {
+				fmt.Printf("  %s@%s — up to date\n", info.Name, versionOrLatest(remote))
+				continue
+			}
+		}
+
+		if saveErr := config.SaveStoreFramework(remote); saveErr != nil {
+			fmt.Printf("  [WARN] %s@%s: %v\n", info.Name, info.Version, saveErr)
+			continue
+		}
+		config.RemoveUserFramework(info.Name)
+		fmt.Printf("  Updated %s@%s\n", remote.Name, versionOrLatest(remote))
+		updated++
 	}
 	if updated == 0 {
 		fmt.Println("No frameworks to update.")

--- a/internal/cli/framework_update_test.go
+++ b/internal/cli/framework_update_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/store"
+)
+
+// TestUpdateAllFrameworks_refreshesEveryCachedVersion pins the bug fixed by
+// using info.Version instead of entry.Latest. With three versions cached, all
+// three must be rewritten — not just the latest.
+func TestUpdateAllFrameworks_refreshesEveryCachedVersion(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	storeDir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(storeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed three stale yamls. Version is what makes ListFrameworksDetailed
+	// surface them as separate entries and what FetchFramework will request.
+	stale := func(version string) string {
+		return "name: laravel\nlabel: Laravel\nversion: \"" + version + "\"\nconsole: artisan\nworkers:\n  queue:\n    command: stale\n"
+	}
+	for _, v := range []string{"10", "11", "12"} {
+		path := filepath.Join(storeDir, "laravel@"+v+".yaml")
+		if err := os.WriteFile(path, []byte(stale(v)), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Server returns a per-version yaml whose body embeds the version string
+	// so we can assert each file was refetched at its own version.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/index.json", func(w http.ResponseWriter, _ *http.Request) {
+		data, _ := json.Marshal(store.Index{
+			Frameworks: []store.IndexEntry{{
+				Name:     "laravel",
+				Label:    "Laravel",
+				Versions: []string{"12", "11", "10"},
+				Latest:   "12",
+			}},
+		})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	})
+	for _, v := range []string{"10", "11", "12"} {
+		v := v
+		mux.HandleFunc("/laravel/"+v+".yaml", func(w http.ResponseWriter, _ *http.Request) {
+			body := "name: laravel\nlabel: Laravel\nversion: \"" + v + "\"\nconsole: artisan\nworkers:\n  queue:\n    command: fresh-v" + v + "\n"
+			_, _ = w.Write([]byte(body))
+		})
+	}
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := &store.Client{BaseURL: srv.URL}
+	if err := updateAllFrameworks(client, false); err != nil {
+		t.Fatalf("updateAllFrameworks: %v", err)
+	}
+
+	for _, v := range []string{"10", "11", "12"} {
+		path := filepath.Join(storeDir, "laravel@"+v+".yaml")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		body := string(data)
+		want := "fresh-v" + v
+		if !strings.Contains(body, want) {
+			t.Errorf("laravel@%s.yaml was not refreshed; want substring %q, got:\n%s", v, want, body)
+		}
+		if strings.Contains(body, "stale") {
+			t.Errorf("laravel@%s.yaml still contains stale marker", v)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`lerd framework update` was iterating `ListFrameworksDetailed` (one
entry per `<name>@<version>`) but always fetching `entry.Latest` from
the store. A user with `laravel@10/11/12/13` cached only got
`laravel@13` refreshed; older cached versions stayed stale until
something else triggered a fetch (24h auto-refresh, or `lerd install`).

Fetch `info.Version` instead so each cached file is refreshed
individually.

## Repro

Cache multiple versions of the same framework, edit one of the
non-latest store yamls upstream, run `lerd framework update`. Before:
only `<name>@<latest>.yaml` is rewritten. After: every cached file is
rewritten.