### PR TITLE
feat: per-worktree worker lifecycle + dashboard surfaces

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -654,18 +654,20 @@ func syncWorktree(sitePath, worktreeName, action string, pruneStale bool) bool {
 		}
 		fmt.Printf("Worktree %s: %s -> %s\n", action, wt.Branch, wt.Domain)
 
-		// Auto-start host workers (e.g. vite) for the worktree.
-		if fw, ok := config.GetFrameworkForDir(site.Framework, sitePath); ok {
-			for name, w := range fw.Workers {
-				if !w.Host {
-					continue
-				}
-				if w.Check != nil && !config.MatchesRule(wt.Path, *w.Check) {
-					continue
-				}
-				if err := cli.WorkerStartForSite(site.Name, wt.Path, effectivePHP, name, w, false); err != nil {
-					fmt.Printf("[WARN] auto-start %s for worktree %s: %v\n", name, wt.Branch, err)
-				}
+		// Auto-start only the host workers the user opted into via
+		// .lerd.yaml workers:. Worktrees inherit the parent's project
+		// intent rather than every host:true worker the framework defines.
+		for _, name := range cli.OptedInHostWorkers(site, wt.Path) {
+			fw, ok := config.GetFrameworkForDir(site.Framework, sitePath)
+			if !ok {
+				break
+			}
+			w, ok := fw.Workers[name]
+			if !ok {
+				continue
+			}
+			if err := cli.WorkerStartForSite(site.Name, wt.Path, effectivePHP, name, w, false); err != nil {
+				fmt.Printf("[WARN] auto-start %s for worktree %s: %v\n", name, wt.Branch, err)
 			}
 		}
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -899,10 +899,17 @@ func runSetupInit(cwd string, skipWizard bool) error {
 	hasExisting := statErr == nil
 
 	if !hasExisting && skipWizard {
-		// Non-interactive and no saved config — just link with auto-detection.
+		// CI path: link with auto-detection, then run env so the caller
+		// (lerd setup) doesn't have to do it itself.
 		linkSkipSetupPrompt = true
 		defer func() { linkSkipSetupPrompt = false }()
-		return runLink([]string{})
+		if err := runLink([]string{}); err != nil {
+			return err
+		}
+		if err := runEnv(nil, nil); err != nil {
+			fmt.Printf("[WARN] lerd env: %v\n", err)
+		}
+		return nil
 	}
 
 	if !hasExisting {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -710,6 +710,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		ensureDefaultNode()
 	}
 
+	refreshStoreFrameworks()
 	refreshGlobalMCPSkills()
 	refreshProjectMCPSkills()
 

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	gitpkg "github.com/geodro/lerd/internal/git"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/siteops"
 	"github.com/geodro/lerd/internal/store"
@@ -43,6 +44,13 @@ func runLink(args []string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
+	}
+
+	if parent, branch, ok := findOwningWorktree(cwd); ok {
+		fmt.Printf("This directory is the %q worktree of site %q.\n", branch, parent.Name)
+		fmt.Printf("Worktrees inherit the parent's registration; not linking %s as a separate site.\n", cwd)
+		fmt.Printf("Manage it from the parent (%s) or via `lerd worktree`.\n", parent.Path)
+		return nil
 	}
 
 	cfg, err := config.LoadGlobal()
@@ -433,6 +441,29 @@ func resolveFramework(dir string) (string, bool) {
 	}
 	// Interactive store fallback — only for terminal commands.
 	return store.DetectFrameworkWithStore(dir)
+}
+
+// findOwningWorktree returns the parent site if cwd is one of its worktree
+// checkouts. Used to short-circuit runLink so worktrees don't get registered
+// as standalone sites.
+func findOwningWorktree(cwd string) (*config.Site, string, bool) {
+	reg, err := config.LoadSites()
+	if err != nil {
+		return nil, "", false
+	}
+	for i := range reg.Sites {
+		s := &reg.Sites[i]
+		if s.Ignored || s.Path == cwd {
+			continue
+		}
+		wts, _ := gitpkg.DetectWorktrees(s.Path, s.PrimaryDomain())
+		for _, wt := range wts {
+			if wt.Path == cwd {
+				return s, wt.Branch, true
+			}
+		}
+	}
+	return nil, "", false
 }
 
 // fetchFrameworkFromStore attempts to install a framework definition from the

--- a/internal/cli/link_worktree_test.go
+++ b/internal/cli/link_worktree_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// makeWorktreeLayout creates the minimal .git/worktrees/<wt>/ structure that
+// gitpkg.DetectWorktrees walks. Returns parent path and worktree path.
+func makeWorktreeLayout(t *testing.T, parentName, wtBase string) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	parent := filepath.Join(root, parentName)
+	if err := os.MkdirAll(filepath.Join(parent, ".git", "worktrees", wtBase), 0755); err != nil {
+		t.Fatal(err)
+	}
+	wtPath := filepath.Join(parent, wtBase)
+	if err := os.MkdirAll(wtPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	meta := filepath.Join(parent, ".git", "worktrees", wtBase)
+	if err := os.WriteFile(filepath.Join(meta, "HEAD"), []byte("ref: refs/heads/"+wtBase+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(meta, "gitdir"), []byte(filepath.Join(wtPath, ".git")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return parent, wtPath
+}
+
+// writeSitesYAML writes a minimal sites.yaml into the current XDG_DATA_HOME so
+// config.LoadSites returns the supplied sites.
+func writeSitesYAML(t *testing.T, sites []config.Site) {
+	t.Helper()
+	dir := filepath.Join(os.Getenv("XDG_DATA_HOME"), "lerd")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	body := "sites:\n"
+	for _, s := range sites {
+		body += "  - name: " + s.Name + "\n"
+		body += "    path: " + s.Path + "\n"
+		body += "    domains:\n      - " + s.Name + ".test\n"
+		body += "    php_version: \"8.4\"\n    node_version: \"22\"\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sites.yaml"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFindOwningWorktree_match(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	parent, wtPath := makeWorktreeLayout(t, "whitewaters", "main")
+	writeSitesYAML(t, []config.Site{{Name: "whitewaters", Path: parent}})
+
+	owner, branch, ok := findOwningWorktree(wtPath)
+	if !ok {
+		t.Fatal("expected worktree to be matched to parent")
+	}
+	if owner.Name != "whitewaters" || branch != "main" {
+		t.Errorf("got %s/%s, want whitewaters/main", owner.Name, branch)
+	}
+}
+
+func TestFindOwningWorktree_noMatchForUnrelatedDir(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	parent, _ := makeWorktreeLayout(t, "whitewaters", "main")
+	writeSitesYAML(t, []config.Site{{Name: "whitewaters", Path: parent}})
+
+	if _, _, ok := findOwningWorktree(t.TempDir()); ok {
+		t.Error("unrelated dir must not match a worktree")
+	}
+}
+
+func TestFindOwningWorktree_skipsParentItself(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	parent, _ := makeWorktreeLayout(t, "whitewaters", "main")
+	writeSitesYAML(t, []config.Site{{Name: "whitewaters", Path: parent}})
+
+	if _, _, ok := findOwningWorktree(parent); ok {
+		t.Error("the parent path itself must not register as one of its own worktrees")
+	}
+}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -83,6 +83,13 @@ func runSetup(allSteps, skipOpen bool) error {
 	}
 
 	site, _ := config.FindSiteByPath(cwd)
+	// Worktrees aren't registered as sites; fall back to the parent so
+	// setup steps (workers, framework cmds) still apply against cwd.
+	if site == nil {
+		if parent, _, ok := findOwningWorktree(cwd); ok {
+			site = parent
+		}
+	}
 
 	// Load saved workers from .lerd.yaml to pre-select them in the step selector.
 	projCfg, _ := config.LoadProjectConfig(cwd)
@@ -101,13 +108,15 @@ func runSetup(allSteps, skipOpen bool) error {
 	_, shrinkMissing := os.Stat(cwd + "/npm-shrinkwrap.json")
 	hasLockFile := lockMissing == nil || shrinkMissing == nil
 	buildScript := detectBuildScript(cwd + "/package.json")
-
-	// Always run lerd env first — it configures .env, starts services, and
-	// creates databases before any other step that may depend on them.
-	fmt.Println("\n→ Running: lerd env")
-	if err := runEnv(nil, nil); err != nil {
-		fmt.Printf("  [WARN] lerd env: %v\n", err)
+	// If the user opted into a worker that replaces the build (vite et al),
+	// pre-disable the build step. Still toggleable in the chooser.
+	buildReplaced := false
+	if site != nil {
+		buildReplaced = len(OptedInBuildReplacers(site, cwd)) > 0
 	}
+
+	// runSetupInit -> applyProjectConfig already ran `lerd env`; do not
+	// duplicate it here.
 
 	steps := []setupStep{
 		{
@@ -136,7 +145,7 @@ func runSetup(allSteps, skipOpen bool) error {
 		},
 		{
 			label:   "npm run " + buildScript,
-			enabled: hasPackageJSON && buildScript != "",
+			enabled: hasPackageJSON && buildScript != "" && !buildReplaced,
 			run: func() error {
 				if _, err := os.Stat(cwd + "/node_modules"); os.IsNotExist(err) {
 					fmt.Println("  node_modules not found.")
@@ -169,7 +178,7 @@ func runSetup(allSteps, skipOpen bool) error {
 		if fwName == "" {
 			fwName, _ = config.DetectFrameworkForDir(cwd)
 		}
-		if fw, ok := config.GetFramework(fwName); ok {
+		if fw, ok := config.GetFrameworkForDir(fwName, cwd); ok {
 			for _, sc := range fw.Setup {
 				// Skip commands whose check doesn't pass.
 				if sc.Check != nil && !config.MatchesRule(cwd, *sc.Check) {
@@ -229,7 +238,7 @@ func runSetup(allSteps, skipOpen bool) error {
 		if fwName == "" {
 			fwName, _ = config.DetectFrameworkForDir(cwd)
 		}
-		if fw, ok := config.GetFramework(fwName); ok && fw.Workers != nil {
+		if fw, ok := config.GetFrameworkForDir(fwName, cwd); ok && fw.Workers != nil {
 			suppressed := map[string]bool{}
 			for _, wDef := range fw.Workers {
 				if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
@@ -249,15 +258,12 @@ func runSetup(allSteps, skipOpen bool) error {
 				}
 				wn := wName
 				wd := wDef
+				ownerSite := site
 				steps = append(steps, setupStep{
 					label:   wn + ":start",
 					enabled: savedWorkers[wn],
 					run: func() error {
-						s, err := config.FindSiteByPath(cwd)
-						if err != nil {
-							return fmt.Errorf("site not registered: %w", err)
-						}
-						phpVersion := s.PHPVersion
+						phpVersion := ownerSite.PHPVersion
 						if phpVersion == "" {
 							if detected, detErr := phpDet.DetectVersion(cwd); detErr == nil {
 								phpVersion = detected
@@ -267,30 +273,27 @@ func runSetup(allSteps, skipOpen bool) error {
 							}
 						}
 						for _, conflict := range wd.ConflictsWith {
-							WorkerStopForSite(s.Name, conflict) //nolint:errcheck
+							WorkerStopForSite(ownerSite.Name, conflict) //nolint:errcheck
 						}
-						return WorkerStartForSite(s.Name, cwd, phpVersion, wn, wd, true)
+						return WorkerStartForSite(ownerSite.Name, cwd, phpVersion, wn, wd, true)
 					},
 				})
 			}
 		}
 	}
 
-	// Stripe listener (not a framework worker — still special-cased).
-	if siteHasStripeSecret(cwd) {
+	// Stripe listener (not a framework worker, still special-cased).
+	if site != nil && siteHasStripeSecret(cwd) {
+		ownerSite := site
 		steps = append(steps, setupStep{
 			label:   "stripe:listen",
-			enabled: siteHasStripeSecret(cwd),
+			enabled: true,
 			run: func() error {
-				s, err := config.FindSiteByPath(cwd)
-				if err != nil {
-					return fmt.Errorf("site not registered: %w", err)
-				}
 				base := siteURL(cwd)
 				if base == "" {
-					return fmt.Errorf("could not resolve site URL — run 'lerd link' first")
+					return fmt.Errorf("could not resolve site URL, run 'lerd link' first")
 				}
-				return StripeStartForSite(s.Name, cwd, base)
+				return StripeStartForSite(ownerSite.Name, cwd, base)
 			},
 		})
 	}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -13,6 +13,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/store"
 	"github.com/geodro/lerd/internal/systemd"
 	lerdUpdate "github.com/geodro/lerd/internal/update"
 	"github.com/spf13/cobra"
@@ -204,6 +205,55 @@ func runUpdate(currentVersion string, beta bool) error {
 
 	restartLerdUserServices()
 	return nil
+}
+
+// refreshStoreFrameworks re-fetches every cached framework yaml so users pick
+// up schema additions (per_worktree, etc.) without waiting for the 24h
+// staleness check in GetFrameworkForDir to expire.
+func refreshStoreFrameworks() {
+	dir := config.StoreFrameworksDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	type target struct{ name, version string }
+	var targets []target
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		base := strings.TrimSuffix(e.Name(), ".yaml")
+		var t target
+		if at := strings.Index(base, "@"); at != -1 {
+			t.name = base[:at]
+			t.version = base[at+1:]
+		} else {
+			t.name = base
+		}
+		targets = append(targets, t)
+	}
+	if len(targets) == 0 {
+		return
+	}
+	fmt.Printf("\n==> Refreshing %d framework definition%s\n", len(targets), pluralS(len(targets)))
+	client := store.NewClient()
+	for _, t := range targets {
+		label := t.name
+		if t.version != "" {
+			label = t.name + "@" + t.version
+		}
+		fmt.Printf("  --> %s ... ", label)
+		fw, err := client.FetchFramework(t.name, t.version)
+		if err != nil {
+			fmt.Printf("WARN (%v)\n", err)
+			continue
+		}
+		if err := config.SaveStoreFramework(fw); err != nil {
+			fmt.Printf("WARN (%v)\n", err)
+			continue
+		}
+		fmt.Println("OK")
+	}
 }
 
 // refreshGlobalMCPSkills re-writes the user-scope skill, rules, and guidelines

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -13,6 +13,7 @@ import (
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
+	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/spf13/cobra"
 )
 
@@ -532,6 +533,10 @@ func findOrphanedWorkers(siteName string, known map[string]bool) []string {
 	suffix := "-" + siteName
 	prefix := "lerd-"
 	units := services.Mgr.ListServiceUnits("lerd-*-" + siteName)
+	var sites []config.Site
+	if reg, err := config.LoadSites(); err == nil {
+		sites = reg.Sites
+	}
 	var orphans []string
 	for _, unit := range units {
 		workerName := strings.TrimPrefix(unit, prefix)
@@ -542,6 +547,9 @@ func findOrphanedWorkers(siteName string, known map[string]bool) []string {
 		switch workerName {
 		case "php84-fpm", "php83-fpm", "php82-fpm", "php81-fpm", "php80-fpm",
 			"nginx", "dns", "dns-forwarder", "watcher", "ui", "stripe":
+			continue
+		}
+		if lerdSystemd.UnitBelongsToOtherSiteWorktree(workerName, siteName, sites) {
 			continue
 		}
 		if isServiceActiveOrRestarting(unit) {

--- a/internal/cli/worktree_add.go
+++ b/internal/cli/worktree_add.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -75,12 +76,15 @@ func newWorktreeAddCmd() *cobra.Command {
 				fmt.Println("Dependencies installed.")
 			}
 
-			if hasHostWorkerAutoStart(site, worktreePath) {
-				fmt.Println("Vite dev server auto-started by the watcher — skipping build prompt.")
+			if optedIn := OptedInHostWorkers(site, worktreePath); len(optedIn) > 0 {
+				fmt.Printf("Auto-starting opted-in workers: %s\n", strings.Join(optedIn, ", "))
+			}
+			if replacers := OptedInBuildReplacers(site, worktreePath); len(replacers) > 0 {
+				fmt.Printf("Skipping build, %s will provide assets.\n", strings.Join(replacers, ", "))
 			} else if script := promptFrontendBuild(worktreePath); script != "" {
 				fmt.Printf("Running npm run %s...\n", script)
 				if err := gitpkg.RunNpmScript(worktreePath, script); err != nil {
-					fmt.Printf("[WARN] npm run %s failed: %v — first request will throw ViteManifestNotFoundException; rerun manually after fixing.\n", script, err)
+					fmt.Printf("[WARN] npm run %s failed: %v, first request will throw ViteManifestNotFoundException; rerun manually after fixing.\n", script, err)
 				} else {
 					fmt.Println("Frontend built.")
 				}
@@ -392,26 +396,76 @@ func worktreePathForBranch(site *config.Site, branch string) (string, error) {
 	return "", fmt.Errorf("worktree %q not found", branch)
 }
 
-// hasHostWorkerAutoStart returns true when the worktree path matches a
-// host worker check rule, meaning the watcher will auto-start that worker
-// for the new worktree. The check must run against worktreePath (not the
-// parent site path) because syncWorktree uses worktreePath when deciding
-// whether to spawn, and a divergence between the suppression check and the
-// spawn check causes either a duplicate build or a missing manifest.
-func hasHostWorkerAutoStart(site *config.Site, worktreePath string) bool {
+// OptedInBuildReplacers returns names of workers (a) opted into via
+// .lerd.yaml workers:, (b) declared replaces_build:true in the framework
+// yaml, and (c) able to run at the given path. When path != site.Path the
+// per_worktree:true gate applies; for the parent it doesn't.
+func OptedInBuildReplacers(site *config.Site, path string) []string {
 	if site.Framework == "" {
-		return false
+		return nil
 	}
 	fw, ok := config.GetFrameworkForDir(site.Framework, site.Path)
 	if !ok {
-		return false
+		return nil
 	}
-	for _, w := range fw.Workers {
-		if w.Host && (w.Check == nil || config.MatchesRule(worktreePath, *w.Check)) {
-			return true
+	proj, _ := config.LoadProjectConfig(site.Path)
+	if proj == nil || len(proj.Workers) == 0 {
+		return nil
+	}
+	wanted := make(map[string]bool, len(proj.Workers))
+	for _, n := range proj.Workers {
+		wanted[n] = true
+	}
+	isWorktree := path != site.Path
+	var out []string
+	for name, w := range fw.Workers {
+		if !wanted[name] || !w.ReplacesBuild {
+			continue
 		}
+		if isWorktree && !w.IsPerWorktree() {
+			continue
+		}
+		if w.Check != nil && !config.MatchesRule(path, *w.Check) {
+			continue
+		}
+		out = append(out, name)
 	}
-	return false
+	sort.Strings(out)
+	return out
+}
+
+// OptedInHostWorkers returns the names of host-mode workers the user has
+// opted into for this project (.lerd.yaml workers:) and whose check rule
+// matches the worktree path. Worker auto-start now follows project intent
+// instead of treating every host:true worker as implicitly desired.
+func OptedInHostWorkers(site *config.Site, worktreePath string) []string {
+	if site.Framework == "" {
+		return nil
+	}
+	fw, ok := config.GetFrameworkForDir(site.Framework, site.Path)
+	if !ok {
+		return nil
+	}
+	proj, _ := config.LoadProjectConfig(site.Path)
+	if proj == nil || len(proj.Workers) == 0 {
+		return nil
+	}
+	wanted := make(map[string]bool, len(proj.Workers))
+	for _, n := range proj.Workers {
+		wanted[n] = true
+	}
+	var out []string
+	for name, w := range fw.Workers {
+		if !w.Host || !wanted[name] || !w.IsPerWorktree() {
+			continue
+		}
+		if w.Check != nil && !config.MatchesRule(worktreePath, *w.Check) {
+			continue
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func branchesWithIsolatedDB(site *config.Site) []string {

--- a/internal/cli/worktree_optedin_test.go
+++ b/internal/cli/worktree_optedin_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// setupOptedInProject seeds .lerd.yaml with a host-mode custom worker named
+// "vite" and the given workers opt-in list, returning the project dir. We use
+// CustomWorkers so the worker definition lands in GetFrameworkForDir without
+// touching the global framework store.
+func setupOptedInProject(t *testing.T, optedIn []string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	dir := filepath.Join(tmp, "site")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	proj, err := config.LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := true
+	proj.Workers = optedIn
+	proj.CustomWorkers = map[string]config.FrameworkWorker{
+		"vite":  {Command: "npm run dev", Host: true, PerWorktree: &tr, ReplacesBuild: true},
+		"queue": {Command: "php artisan queue:work"},
+	}
+	if err := config.SaveProjectConfig(dir, proj); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestOptedInHostWorkers_optedIn(t *testing.T) {
+	dir := setupOptedInProject(t, []string{"vite"})
+	site := &config.Site{Name: "site", Path: dir, Framework: "laravel"}
+	wt := filepath.Join(dir, "wt-main")
+	if err := os.MkdirAll(wt, 0755); err != nil {
+		t.Fatal(err)
+	}
+	got := OptedInHostWorkers(site, wt)
+	if len(got) != 1 || got[0] != "vite" {
+		t.Errorf("got %v, want [vite]", got)
+	}
+}
+
+func TestOptedInHostWorkers_notOptedIn(t *testing.T) {
+	dir := setupOptedInProject(t, []string{"queue"})
+	site := &config.Site{Name: "site", Path: dir, Framework: "laravel"}
+	wt := filepath.Join(dir, "wt-main")
+	if err := os.MkdirAll(wt, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if got := OptedInHostWorkers(site, wt); len(got) != 0 {
+		t.Errorf("queue is not host-mode and vite is not opted in; want [], got %v", got)
+	}
+}
+
+func TestOptedInHostWorkers_emptyWorkers(t *testing.T) {
+	dir := setupOptedInProject(t, nil)
+	site := &config.Site{Name: "site", Path: dir, Framework: "laravel"}
+	wt := filepath.Join(dir, "wt-main")
+	if err := os.MkdirAll(wt, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if got := OptedInHostWorkers(site, wt); len(got) != 0 {
+		t.Errorf("no workers opted in; want [], got %v", got)
+	}
+}
+
+func TestOptedInHostWorkers_skipsContainerWorkers(t *testing.T) {
+	// queue is opted in but is not host:true. Auto-start belongs to other
+	// code paths (queue:start, the systemd queue services); we should not
+	// surface it here regardless.
+	dir := setupOptedInProject(t, []string{"vite", "queue"})
+	site := &config.Site{Name: "site", Path: dir, Framework: "laravel"}
+	wt := filepath.Join(dir, "wt-main")
+	if err := os.MkdirAll(wt, 0755); err != nil {
+		t.Fatal(err)
+	}
+	got := OptedInHostWorkers(site, wt)
+	if len(got) != 1 || got[0] != "vite" {
+		t.Errorf("got %v, want [vite] only", got)
+	}
+}
+
+func TestOptedInHostWorkers_emptyFramework(t *testing.T) {
+	dir := setupOptedInProject(t, []string{"vite"})
+	site := &config.Site{Name: "site", Path: dir, Framework: ""}
+	if got := OptedInHostWorkers(site, dir); len(got) != 0 {
+		t.Errorf("no framework, want [], got %v", got)
+	}
+}
+
+func TestOptedInBuildReplacers_optedInWorktree(t *testing.T) {
+	dir := setupOptedInProject(t, []string{"vite"})
+	site := &config.Site{Name: "site", Path: dir, Framework: "laravel"}
+	wt := filepath.Join(dir, "wt-main")
+	if err := os.MkdirAll(wt, 0755); err != nil {
+		t.Fatal(err)
+	}
+	got := OptedInBuildReplacers(site, wt)
+	if len(got) != 1 || got[0] != "vite" {
+		t.Errorf("want [vite] for opted-in vite worktree, got %v", got)
+	}
+}
+
+func TestOptedInBuildReplacers_optedInParent(t *testing.T) {
+	dir := setupOptedInProject(t, []string{"vite"})
+	site := &config.Site{Name: "site", Path: dir, Framework: "laravel"}
+	got := OptedInBuildReplacers(site, dir) // parent path == site.Path
+	if len(got) != 1 || got[0] != "vite" {
+		t.Errorf("want [vite] for opted-in vite parent, got %v", got)
+	}
+}
+
+func TestOptedInBuildReplacers_notOptedIn(t *testing.T) {
+	dir := setupOptedInProject(t, []string{"queue"})
+	site := &config.Site{Name: "site", Path: dir, Framework: "laravel"}
+	if got := OptedInBuildReplacers(site, dir); len(got) != 0 {
+		t.Errorf("vite not opted in; want [], got %v", got)
+	}
+}
+
+func TestOptedInBuildReplacers_skipsWhenNotPerWorktree(t *testing.T) {
+	// A replaces_build worker that lacks per_worktree:true must NOT suppress
+	// the build prompt for a worktree (it wouldn't run there). It should
+	// still suppress for the parent.
+	dir := setupOptedInProject(t, []string{"docs"})
+	proj, _ := config.LoadProjectConfig(dir)
+	proj.CustomWorkers["docs"] = config.FrameworkWorker{
+		Command:       "npm run docs",
+		Host:          true,
+		ReplacesBuild: true,
+		// PerWorktree intentionally unset (defaults to false)
+	}
+	if err := config.SaveProjectConfig(dir, proj); err != nil {
+		t.Fatal(err)
+	}
+	site := &config.Site{Name: "site", Path: dir, Framework: "laravel"}
+
+	wt := filepath.Join(dir, "wt-main")
+	_ = os.MkdirAll(wt, 0755)
+	if got := OptedInBuildReplacers(site, wt); len(got) != 0 {
+		t.Errorf("docs is parent-only; worktree should not see it as a replacer, got %v", got)
+	}
+	if got := OptedInBuildReplacers(site, dir); len(got) != 1 || got[0] != "docs" {
+		t.Errorf("docs should replace build at the parent, got %v", got)
+	}
+}
+
+func TestOptedInBuildReplacers_workerMissingFlag(t *testing.T) {
+	// Worker is opted in and per_worktree but doesn't declare replaces_build.
+	// It should NOT suppress the build prompt.
+	dir := setupOptedInProject(t, []string{"watcher"})
+	proj, _ := config.LoadProjectConfig(dir)
+	tr := true
+	proj.CustomWorkers["watcher"] = config.FrameworkWorker{
+		Command:     "npm run watch",
+		Host:        true,
+		PerWorktree: &tr,
+	}
+	if err := config.SaveProjectConfig(dir, proj); err != nil {
+		t.Fatal(err)
+	}
+	site := &config.Site{Name: "site", Path: dir, Framework: "laravel"}
+	wt := filepath.Join(dir, "wt-main")
+	_ = os.MkdirAll(wt, 0755)
+	if got := OptedInBuildReplacers(site, wt); len(got) != 0 {
+		t.Errorf("watcher lacks replaces_build; build must still run, got %v", got)
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -101,6 +101,21 @@ type FrameworkWorker struct {
 	ConflictsWith []string       `yaml:"conflicts_with,omitempty"` // workers to stop before starting this one (e.g. horizon conflicts_with queue)
 	Proxy         *WorkerProxy   `yaml:"proxy,omitempty"`          // WebSocket/HTTP proxy config for nginx
 	Host          bool           `yaml:"host,omitempty"`           // run on the host via fnm instead of inside the PHP-FPM container
+	// PerWorktree opts the worker into running independently per git worktree
+	// (lerd-<wname>-<site>-<wt>). Defaults to false; set true on workers that
+	// need a separate process per checkout (e.g. dev servers like vite).
+	PerWorktree *bool `yaml:"per_worktree,omitempty"`
+	// ReplacesBuild declares that, while this worker is running, the framework
+	// can render pages without a static asset build. Used by lerd worktree add
+	// and lerd setup to skip the npm run build step when the user opted into
+	// such a worker (vite is the canonical case).
+	ReplacesBuild bool `yaml:"replaces_build,omitempty"`
+}
+
+// IsPerWorktree reports whether this worker can run independently per git
+// worktree. Defaults to false; framework yamls opt in with per_worktree: true.
+func (w FrameworkWorker) IsPerWorktree() bool {
+	return w.PerWorktree != nil && *w.PerWorktree
 }
 
 // WorkerProxy describes an HTTP/WebSocket proxy that nginx should configure

--- a/internal/config/framework_perworktree_test.go
+++ b/internal/config/framework_perworktree_test.go
@@ -1,0 +1,38 @@
+package config
+
+import "testing"
+
+func TestIsPerWorktree_defaultFalse(t *testing.T) {
+	// Per-worktree is opt-in: framework yamls set per_worktree:true on
+	// workers that genuinely run independently per checkout (vite). Anything
+	// unset stays parent-only.
+	if (FrameworkWorker{}).IsPerWorktree() {
+		t.Error("default must be false; opt in via per_worktree:true")
+	}
+}
+
+func TestIsPerWorktree_explicitOverride(t *testing.T) {
+	tr, fa := true, false
+	if !(FrameworkWorker{PerWorktree: &tr}).IsPerWorktree() {
+		t.Error("explicit per_worktree:true must report true")
+	}
+	if (FrameworkWorker{PerWorktree: &fa}).IsPerWorktree() {
+		t.Error("explicit per_worktree:false must report false")
+	}
+}
+
+func TestBuiltinLaravel_workersStayParentOnly(t *testing.T) {
+	for n, w := range laravelFramework.Workers {
+		if w.IsPerWorktree() {
+			t.Errorf("builtin laravel %s must default to parent-only (no opt-in)", n)
+		}
+	}
+}
+
+func TestBuiltinSymfony_workersStayParentOnly(t *testing.T) {
+	for n, w := range symfonyFramework.Workers {
+		if w.IsPerWorktree() {
+			t.Errorf("builtin symfony %s must default to parent-only (no opt-in)", n)
+		}
+	}
+}

--- a/internal/config/framework_perworktree_test.go
+++ b/internal/config/framework_perworktree_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
 
 func TestIsPerWorktree_defaultFalse(t *testing.T) {
 	// Per-worktree is opt-in: framework yamls set per_worktree:true on
@@ -36,3 +40,54 @@ func TestBuiltinSymfony_workersStayParentOnly(t *testing.T) {
 		}
 	}
 }
+
+// TestFrameworkWorker_YAMLRoundtrip pins that per_worktree and replaces_build
+// survive marshal -> unmarshal. The pointer-typed PerWorktree is the easy one
+// to break since gopkg.in/yaml.v3 has different rules for pointers vs scalars.
+func TestFrameworkWorker_YAMLRoundtrip(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want FrameworkWorker
+	}{
+		{
+			name: "per_worktree true + replaces_build true",
+			yaml: "command: x\nper_worktree: true\nreplaces_build: true\n",
+			want: FrameworkWorker{Command: "x", PerWorktree: ptr(true), ReplacesBuild: true},
+		},
+		{
+			name: "per_worktree false explicit",
+			yaml: "command: x\nper_worktree: false\n",
+			want: FrameworkWorker{Command: "x", PerWorktree: ptr(false)},
+		},
+		{
+			name: "fields omitted",
+			yaml: "command: x\n",
+			want: FrameworkWorker{Command: "x"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got FrameworkWorker
+			if err := yaml.Unmarshal([]byte(tc.yaml), &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got.Command != tc.want.Command {
+				t.Errorf("Command = %q, want %q", got.Command, tc.want.Command)
+			}
+			if got.ReplacesBuild != tc.want.ReplacesBuild {
+				t.Errorf("ReplacesBuild = %v, want %v", got.ReplacesBuild, tc.want.ReplacesBuild)
+			}
+			switch {
+			case tc.want.PerWorktree == nil && got.PerWorktree != nil:
+				t.Errorf("PerWorktree = %v, want nil", *got.PerWorktree)
+			case tc.want.PerWorktree != nil && got.PerWorktree == nil:
+				t.Errorf("PerWorktree = nil, want %v", *tc.want.PerWorktree)
+			case tc.want.PerWorktree != nil && *got.PerWorktree != *tc.want.PerWorktree:
+				t.Errorf("PerWorktree = %v, want %v", *got.PerWorktree, *tc.want.PerWorktree)
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -62,6 +62,9 @@ type WorktreeInfo struct {
 	FrameworkLabel      string
 	DBIsolated          bool
 	DBDatabase          string
+	// Per-worktree worker state (lerd-<wname>-<site>-<wtBase>).
+	// queue/schedule/reverb/horizon are excluded; those bind to the parent.
+	FrameworkWorkers []WorkerInfo
 }
 
 // ConflictingDomain describes a domain declared in .lerd.yaml that is owned
@@ -475,6 +478,43 @@ func (e *EnrichedSite) enrichWorkers(fw *config.Framework, hasFw bool) {
 	}
 }
 
+// enrichWorktreeWorkers returns running state for framework workers that the
+// framework yaml flags as per_worktree (default true; q/s/r/h default false).
+func enrichWorktreeWorkers(siteName, wtPath string, fw *config.Framework) []WorkerInfo {
+	if fw == nil || fw.Workers == nil {
+		return nil
+	}
+	wtBase := filepath.Base(wtPath)
+	names := make([]string, 0, len(fw.Workers))
+	for n, wDef := range fw.Workers {
+		if !wDef.IsPerWorktree() {
+			continue
+		}
+		if wDef.Check != nil && !config.MatchesRule(wtPath, *wDef.Check) {
+			continue
+		}
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	out := make([]WorkerInfo, 0, len(names))
+	for _, wname := range names {
+		w := fw.Workers[wname]
+		unit := "lerd-" + wname + "-" + siteName + "-" + wtBase
+		status, _ := unitStatusFn(unit)
+		label := w.Label
+		if label == "" {
+			label = wname
+		}
+		out = append(out, WorkerInfo{
+			Name:    wname,
+			Label:   label,
+			Running: status == "active" || status == "activating",
+			Failing: status == "failed",
+		})
+	}
+	return out
+}
+
 func (e *EnrichedSite) enrichGit() {
 	e.Branch = gitpkg.MainBranch(e.Path)
 	if wts, err := gitpkg.DetectWorktrees(e.Path, e.PrimaryDomain()); err == nil {
@@ -501,6 +541,7 @@ func (e *EnrichedSite) enrichGit() {
 			if fw, ok := config.GetFrameworkForDir(e.FrameworkName, wt.Path); ok {
 				info.FrameworkVersion = fw.Version
 				info.FrameworkLabel = frameworkLabel(e.FrameworkName, wt.Path, fw, true)
+				info.FrameworkWorkers = enrichWorktreeWorkers(e.Name, wt.Path, fw)
 			} else {
 				info.FrameworkLabel = e.FrameworkLabel
 			}

--- a/internal/siteinfo/worktree_workers_test.go
+++ b/internal/siteinfo/worktree_workers_test.go
@@ -1,0 +1,96 @@
+package siteinfo
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func vitePerWT() config.FrameworkWorker {
+	tr := true
+	return config.FrameworkWorker{Label: "Vite Dev Server", Command: "npm run dev", PerWorktree: &tr}
+}
+
+func TestEnrichWorktreeWorkers_skipsParentOnlyWorkers(t *testing.T) {
+	// Default is parent-only. Only workers explicitly opted in with
+	// per_worktree:true surface on the worktree row.
+	origUnit := unitStatusFn
+	unitStatusFn = func(string) (string, error) { return "active", nil }
+	defer func() { unitStatusFn = origUnit }()
+
+	fw := &config.Framework{
+		Workers: map[string]config.FrameworkWorker{
+			"queue":    {Command: "x"},
+			"schedule": {Command: "x"},
+			"reverb":   {Command: "x"},
+			"horizon":  {Command: "x"},
+			"vite":     vitePerWT(),
+		},
+	}
+	got := enrichWorktreeWorkers("whitewaters", "/projects/whitewaters/main", fw)
+	if len(got) != 1 || got[0].Name != "vite" {
+		t.Fatalf("expected only vite worker, got %+v", got)
+	}
+}
+
+func TestEnrichWorktreeWorkers_unitNamePerWorktree(t *testing.T) {
+	origUnit := unitStatusFn
+	unitStatusFn = func(name string) (string, error) {
+		if name == "lerd-vite-whitewaters-main" {
+			return "active", nil
+		}
+		return "inactive", nil
+	}
+	defer func() { unitStatusFn = origUnit }()
+
+	fw := &config.Framework{
+		Workers: map[string]config.FrameworkWorker{
+			"vite": vitePerWT(),
+		},
+	}
+	got := enrichWorktreeWorkers("whitewaters", "/projects/whitewaters/main", fw)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 worker, got %d", len(got))
+	}
+	if got[0].Name != "vite" || !got[0].Running || got[0].Failing {
+		t.Errorf("vite worker not reported running: %+v", got[0])
+	}
+	if got[0].Label != "Vite Dev Server" {
+		t.Errorf("label = %q, want Vite Dev Server", got[0].Label)
+	}
+}
+
+func TestEnrichWorktreeWorkers_inactiveOmitted(t *testing.T) {
+	origUnit := unitStatusFn
+	unitStatusFn = func(string) (string, error) { return "inactive", nil }
+	defer func() { unitStatusFn = origUnit }()
+
+	fw := &config.Framework{
+		Workers: map[string]config.FrameworkWorker{
+			"vite": vitePerWT(),
+		},
+	}
+	got := enrichWorktreeWorkers("site", "/wt/path", fw)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+	if got[0].Running || got[0].Failing {
+		t.Errorf("expected inactive flags, got %+v", got[0])
+	}
+}
+
+func TestEnrichWorktreeWorkers_failedReported(t *testing.T) {
+	origUnit := unitStatusFn
+	unitStatusFn = func(string) (string, error) { return "failed", nil }
+	defer func() { unitStatusFn = origUnit }()
+
+	fw := &config.Framework{
+		Workers: map[string]config.FrameworkWorker{
+			"vite": vitePerWT(),
+		},
+	}
+	got := enrichWorktreeWorkers("site", "/wt/path", fw)
+	if len(got) != 1 || got[0].Running || !got[0].Failing {
+		t.Errorf("expected failing flag, got %+v", got)
+	}
+}

--- a/internal/systemd/orphan_worktree_test.go
+++ b/internal/systemd/orphan_worktree_test.go
@@ -1,0 +1,71 @@
+package systemd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// setupParentWithWorktree creates a fake parent repo with a single worktree
+// checkout, returning the parent path. Mirrors what gitpkg.DetectWorktrees
+// expects: .git/ as a real dir with a worktrees/<wtBase>/ entry that has HEAD
+// + gitdir files pointing to a real checkout dir.
+func setupParentWithWorktree(t *testing.T, parentName, wtBase string) string {
+	t.Helper()
+	root := t.TempDir()
+	parent := filepath.Join(root, parentName)
+	if err := os.MkdirAll(filepath.Join(parent, ".git", "worktrees", wtBase), 0755); err != nil {
+		t.Fatal(err)
+	}
+	wtPath := filepath.Join(parent, wtBase)
+	if err := os.MkdirAll(wtPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	wtMeta := filepath.Join(parent, ".git", "worktrees", wtBase)
+	if err := os.WriteFile(filepath.Join(wtMeta, "HEAD"), []byte("ref: refs/heads/"+wtBase+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtMeta, "gitdir"), []byte(filepath.Join(wtPath, ".git")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return parent
+}
+
+func TestUnitBelongsToOtherSiteWorktree_noHyphen(t *testing.T) {
+	if UnitBelongsToOtherSiteWorktree("vite", "main", nil) {
+		t.Error("non-hyphenated workerName must never be flagged as worktree")
+	}
+}
+
+func TestUnitBelongsToOtherSiteWorktree_unknownParent(t *testing.T) {
+	sites := []config.Site{{Name: "other", Path: "/tmp/nope"}}
+	if UnitBelongsToOtherSiteWorktree("vite-whitewaters", "main", sites) {
+		t.Error("must not match when no registered site is named 'whitewaters'")
+	}
+}
+
+func TestUnitBelongsToOtherSiteWorktree_realWorktree(t *testing.T) {
+	parent := setupParentWithWorktree(t, "whitewaters", "main")
+	sites := []config.Site{{Name: "whitewaters", Path: parent}}
+	if !UnitBelongsToOtherSiteWorktree("vite-whitewaters", "main", sites) {
+		t.Error("expected match: lerd-vite-whitewaters-main belongs to whitewaters")
+	}
+}
+
+func TestUnitBelongsToOtherSiteWorktree_hyphenatedParentName(t *testing.T) {
+	parent := setupParentWithWorktree(t, "admin-astrolov", "feature-foo")
+	sites := []config.Site{{Name: "admin-astrolov", Path: parent}}
+	if !UnitBelongsToOtherSiteWorktree("vite-admin-astrolov", "feature-foo", sites) {
+		t.Error("expected match across multiple hyphens in parent name")
+	}
+}
+
+func TestUnitBelongsToOtherSiteWorktree_parentExistsButNoMatchingWorktree(t *testing.T) {
+	parent := setupParentWithWorktree(t, "whitewaters", "branch-other")
+	sites := []config.Site{{Name: "whitewaters", Path: parent}}
+	if UnitBelongsToOtherSiteWorktree("vite-whitewaters", "main", sites) {
+		t.Error("must not match when the parent has no worktree named 'main'")
+	}
+}

--- a/internal/systemd/user.go
+++ b/internal/systemd/user.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	gitpkg "github.com/geodro/lerd/internal/git"
 )
 
 // WriteService writes a systemd user service unit file.
@@ -95,6 +96,12 @@ func FindOrphanedWorkers(siteName string, known map[string]bool) []string {
 	if err != nil {
 		return nil
 	}
+	// Pre-loaded so worktree units (lerd-<wname>-<parent>-<wt>.service) can
+	// be filtered out instead of mis-attributed as orphans of <wt>.
+	var sites []config.Site
+	if reg, err := config.LoadSites(); err == nil {
+		sites = reg.Sites
+	}
 	var orphans []string
 	for _, e := range entries {
 		name := e.Name()
@@ -115,6 +122,9 @@ func FindOrphanedWorkers(siteName string, known map[string]bool) []string {
 		if known[workerName] {
 			continue
 		}
+		if UnitBelongsToOtherSiteWorktree(workerName, siteName, sites) {
+			continue
+		}
 		unitName := strings.TrimSuffix(name, ".service")
 		if IsServiceActiveOrRestarting(unitName) {
 			orphans = append(orphans, workerName)
@@ -122,4 +132,33 @@ func FindOrphanedWorkers(siteName string, known map[string]bool) []string {
 	}
 	sort.Strings(orphans)
 	return orphans
+}
+
+// UnitBelongsToOtherSiteWorktree reports whether the parsed candidate
+// (workerName=<wname>-<parent>, thisSite=<wt>) is actually the worktree unit
+// lerd-<wname>-<parent>-<wt>.service of another registered site.
+func UnitBelongsToOtherSiteWorktree(workerName, thisSite string, sites []config.Site) bool {
+	if !strings.Contains(workerName, "-") {
+		return false
+	}
+	for off := 0; off < len(workerName); {
+		idx := strings.Index(workerName[off:], "-")
+		if idx == -1 {
+			return false
+		}
+		parentName := workerName[off+idx+1:]
+		off += idx + 1
+		for _, s := range sites {
+			if s.Name != parentName {
+				continue
+			}
+			wts, _ := gitpkg.DetectWorktrees(s.Path, s.PrimaryDomain())
+			for _, wt := range wts {
+				if filepath.Base(wt.Path) == thisSite {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/internal/ui/framework_workers_test.go
+++ b/internal/ui/framework_workers_test.go
@@ -1,0 +1,182 @@
+package ui
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	gitpkg "github.com/geodro/lerd/internal/git"
+)
+
+// fakeStatus returns a status function that maps unit name to "active" or "inactive".
+func fakeStatus(active map[string]bool) func(string) (string, error) {
+	return func(name string) (string, error) {
+		if active[name] {
+			return "active", nil
+		}
+		return "inactive", nil
+	}
+}
+
+// fakeWorktrees returns a detect function that returns the given list,
+// ignoring the path/domain inputs.
+func fakeWorktrees(wts []gitpkg.Worktree) func(string, string) ([]gitpkg.Worktree, error) {
+	return func(string, string) ([]gitpkg.Worktree, error) { return wts, nil }
+}
+
+func vitePerWT() config.FrameworkWorker {
+	tr := true
+	return config.FrameworkWorker{Label: "Vite Dev Server", Command: "npm run dev", PerWorktree: &tr}
+}
+
+func TestFrameworkWorkerServicesForSite_parentOnly(t *testing.T) {
+	site := config.Site{
+		Name:    "whitewaters",
+		Domains: []string{"theregistry.test"},
+		Path:    "/projects/whitewaters",
+	}
+	fw := &config.Framework{
+		Workers: map[string]config.FrameworkWorker{
+			"vite": {Label: "Vite Dev Server", Command: "npm run dev"},
+		},
+	}
+	got := frameworkWorkerServicesForSite(
+		site, fw,
+		fakeStatus(map[string]bool{"lerd-vite-whitewaters": true}),
+		fakeWorktrees(nil),
+	)
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1: %+v", len(got), got)
+	}
+	r := got[0]
+	if r.Name != "vite-whitewaters" {
+		t.Errorf("Name = %q, want vite-whitewaters", r.Name)
+	}
+	if r.WorkerSite != "whitewaters" || r.WorkerName != "vite" || r.WorkerLabel != "Vite Dev Server" {
+		t.Errorf("worker fields = %+v", r)
+	}
+	if r.WorkerWorktree != "" || r.WorkerWorktreeDomain != "" {
+		t.Errorf("parent should not carry worktree fields, got %+v", r)
+	}
+}
+
+func TestFrameworkWorkerServicesForSite_parentInactiveWorktreeActive(t *testing.T) {
+	// Worktree vite unit is running but the parent's is not. Vite must opt
+	// into per_worktree:true for the worktree variant to enumerate.
+	site := config.Site{
+		Name:    "whitewaters",
+		Domains: []string{"theregistry.test"},
+		Path:    "/projects/whitewaters",
+	}
+	fw := &config.Framework{
+		Workers: map[string]config.FrameworkWorker{
+			"vite": vitePerWT(),
+		},
+	}
+	wts := []gitpkg.Worktree{{
+		Branch: "main",
+		Path:   "/projects/whitewaters/main",
+		Domain: "main.theregistry.test",
+	}}
+	active := map[string]bool{
+		"lerd-vite-whitewaters-main": true, // worktree only
+	}
+	got := frameworkWorkerServicesForSite(site, fw, fakeStatus(active), fakeWorktrees(wts))
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1: %+v", len(got), got)
+	}
+	r := got[0]
+	if r.Name != "vite-whitewaters-main" {
+		t.Errorf("Name = %q, want vite-whitewaters-main", r.Name)
+	}
+	if r.WorkerSite != "whitewaters" {
+		t.Errorf("WorkerSite = %q, want whitewaters (parent for grouping)", r.WorkerSite)
+	}
+	if r.WorkerWorktree != "main" {
+		t.Errorf("WorkerWorktree = %q, want main", r.WorkerWorktree)
+	}
+	if r.WorkerWorktreeDomain != "main.theregistry.test" {
+		t.Errorf("WorkerWorktreeDomain = %q, want main.theregistry.test", r.WorkerWorktreeDomain)
+	}
+}
+
+func TestFrameworkWorkerServicesForSite_parentAndWorktreeActive(t *testing.T) {
+	site := config.Site{
+		Name:    "whitewaters",
+		Domains: []string{"theregistry.test"},
+		Path:    "/projects/whitewaters",
+	}
+	fw := &config.Framework{
+		Workers: map[string]config.FrameworkWorker{
+			"vite": vitePerWT(),
+		},
+	}
+	wts := []gitpkg.Worktree{{
+		Branch: "main",
+		Path:   "/projects/whitewaters/main",
+		Domain: "main.theregistry.test",
+	}}
+	active := map[string]bool{
+		"lerd-vite-whitewaters":      true,
+		"lerd-vite-whitewaters-main": true,
+	}
+	got := frameworkWorkerServicesForSite(site, fw, fakeStatus(active), fakeWorktrees(wts))
+	names := make([]string, len(got))
+	for i, r := range got {
+		names[i] = r.Name
+	}
+	sort.Strings(names)
+	want := []string{"vite-whitewaters", "vite-whitewaters-main"}
+	if len(names) != len(want) || names[0] != want[0] || names[1] != want[1] {
+		t.Errorf("names = %v, want %v", names, want)
+	}
+}
+
+func TestFrameworkWorkerServicesForSite_skipsBuiltinWorkers(t *testing.T) {
+	// queue/schedule/reverb are surfaced through dedicated lerd-queue-*
+	// listing helpers; this loop must not double-list them.
+	site := config.Site{
+		Name:    "whitewaters",
+		Domains: []string{"theregistry.test"},
+		Path:    "/projects/whitewaters",
+	}
+	fw := &config.Framework{
+		Workers: map[string]config.FrameworkWorker{
+			"queue":    {Command: "x"},
+			"schedule": {Command: "x"},
+			"reverb":   {Command: "x"},
+			"vite":     {Command: "npm run dev"},
+		},
+	}
+	active := map[string]bool{
+		"lerd-queue-whitewaters":    true,
+		"lerd-schedule-whitewaters": true,
+		"lerd-reverb-whitewaters":   true,
+		"lerd-vite-whitewaters":     true,
+	}
+	got := frameworkWorkerServicesForSite(site, fw, fakeStatus(active), fakeWorktrees(nil))
+	if len(got) != 1 || got[0].WorkerName != "vite" {
+		t.Fatalf("expected only vite entry, got %+v", got)
+	}
+}
+
+func TestFrameworkWorkerServicesForSite_inactiveOmitted(t *testing.T) {
+	site := config.Site{
+		Name:    "whitewaters",
+		Domains: []string{"theregistry.test"},
+		Path:    "/projects/whitewaters",
+	}
+	fw := &config.Framework{
+		Workers: map[string]config.FrameworkWorker{
+			"vite": {Command: "npm run dev"},
+		},
+	}
+	got := frameworkWorkerServicesForSite(
+		site, fw,
+		fakeStatus(map[string]bool{}), // nothing active
+		fakeWorktrees(nil),
+	)
+	if len(got) != 0 {
+		t.Errorf("expected no entries, got %+v", got)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -585,19 +585,20 @@ func buildStatusJSON() []byte { return []byte(mustJSON(buildStatus())) }
 // PHP/NodeVersion are the effective values; *Override flags signal whether
 // the worktree's .lerd.yaml set them explicitly or it's inherited.
 type WorktreeResponse struct {
-	Branch              string `json:"branch"`
-	Domain              string `json:"domain"`
-	Path                string `json:"path"`
-	PHPVersion          string `json:"php_version,omitempty"`
-	NodeVersion         string `json:"node_version,omitempty"`
-	PHPVersionOverride  bool   `json:"php_version_override,omitempty"`
-	NodeVersionOverride bool   `json:"node_version_override,omitempty"`
-	FrameworkVersion    string `json:"framework_version,omitempty"`
-	FrameworkLabel      string `json:"framework_label,omitempty"`
-	DBIsolated          bool   `json:"db_isolated,omitempty"`
-	DBDatabase          string `json:"db_database,omitempty"`
-	LANPort             int    `json:"lan_port,omitempty"`
-	LANShareURL         string `json:"lan_share_url,omitempty"`
+	Branch              string         `json:"branch"`
+	Domain              string         `json:"domain"`
+	Path                string         `json:"path"`
+	PHPVersion          string         `json:"php_version,omitempty"`
+	NodeVersion         string         `json:"node_version,omitempty"`
+	PHPVersionOverride  bool           `json:"php_version_override,omitempty"`
+	NodeVersionOverride bool           `json:"node_version_override,omitempty"`
+	FrameworkVersion    string         `json:"framework_version,omitempty"`
+	FrameworkLabel      string         `json:"framework_label,omitempty"`
+	DBIsolated          bool           `json:"db_isolated,omitempty"`
+	DBDatabase          string         `json:"db_database,omitempty"`
+	LANPort             int            `json:"lan_port,omitempty"`
+	LANShareURL         string         `json:"lan_share_url,omitempty"`
+	FrameworkWorkers    []WorkerStatus `json:"framework_workers,omitempty"`
 }
 
 // WorkerStatus represents a single framework worker and its running state.
@@ -707,6 +708,15 @@ func buildSites() []SiteResponse {
 				lanPort = entry.Port
 				lanURL = cli.LANShareURL(entry.Port)
 			}
+			var wtWorkers []WorkerStatus
+			for _, fw := range wt.FrameworkWorkers {
+				wtWorkers = append(wtWorkers, WorkerStatus{
+					Name:    fw.Name,
+					Label:   fw.Label,
+					Running: fw.Running,
+					Failing: fw.Failing,
+				})
+			}
 			worktreeResponses = append(worktreeResponses, WorktreeResponse{
 				Branch:              wt.Branch,
 				Domain:              wt.Domain,
@@ -721,6 +731,7 @@ func buildSites() []SiteResponse {
 				DBDatabase:          wt.DBDatabase,
 				LANPort:             lanPort,
 				LANShareURL:         lanURL,
+				FrameworkWorkers:    wtWorkers,
 			})
 		}
 		if worktreeResponses == nil {
@@ -798,11 +809,15 @@ type ServiceResponse struct {
 	WorkerSite         string            `json:"worker_site,omitempty"`
 	WorkerName         string            `json:"worker_name,omitempty"`
 	WorkerLabel        string            `json:"worker_label,omitempty"`
-	UpdateStrategy     string            `json:"update_strategy,omitempty"`
-	UpdateAvailable    bool              `json:"update_available,omitempty"`
-	LatestVersion      string            `json:"latest_version,omitempty"`
-	UpgradeVersion     string            `json:"upgrade_version,omitempty"`
-	PreviousVersion    string            `json:"previous_version,omitempty"`
+	// Set when this worker entry is for a per-worktree unit
+	// (lerd-<wname>-<site>-<wt>); empty for parent-site workers.
+	WorkerWorktree       string `json:"worker_worktree,omitempty"`
+	WorkerWorktreeDomain string `json:"worker_worktree_domain,omitempty"`
+	UpdateStrategy       string `json:"update_strategy,omitempty"`
+	UpdateAvailable      bool   `json:"update_available,omitempty"`
+	LatestVersion        string `json:"latest_version,omitempty"`
+	UpgradeVersion       string `json:"upgrade_version,omitempty"`
+	PreviousVersion      string `json:"previous_version,omitempty"`
 	// MigrationSupported and CanRollback intentionally drop omitempty so the
 	// false case still appears in the JSON. The UI uses === to distinguish
 	// "field missing" (no avail check ran) from "explicitly false".
@@ -1028,30 +1043,87 @@ func buildServicesList() []ServiceResponse {
 			if !ok2 || fw2.Workers == nil {
 				continue
 			}
-			for wname, w := range fw2.Workers {
-				switch wname {
-				case "queue", "schedule", "reverb":
-					continue
-				}
-				unitStatus, _ := podman.UnitStatus("lerd-" + wname + "-" + s.Name)
-				if unitStatus == "active" {
-					label := w.Label
-					if label == "" {
-						label = wname
-					}
-					services = append(services, ServiceResponse{
-						Name:        wname + "-" + s.Name,
-						Status:      "active",
-						EnvVars:     map[string]string{},
-						WorkerSite:  s.Name,
-						WorkerName:  wname,
-						WorkerLabel: label,
-					})
-				}
-			}
+			services = append(services, frameworkWorkerServicesForSite(s, fw2, frameworkUnitStatus, gitpkg.DetectWorktrees)...)
 		}
 	}
 	return services
+}
+
+// frameworkUnitStatus is the production status lookup; tests swap this with a
+// fake to drive the framework worker enumeration without systemd.
+var frameworkUnitStatus = podman.UnitStatus
+
+// frameworkWorkerTarget describes one (parent or worktree) target the worker
+// enumeration walks. wtBase is the worktree directory basename, empty for the
+// parent. domain is the worktree's full FQDN, empty for the parent.
+type frameworkWorkerTarget struct {
+	wtBase string
+	domain string
+}
+
+// frameworkWorkerServicesForSite enumerates active framework workers for one
+// site (parent + worktrees), excluding queue/schedule/reverb which surface
+// through their own loops. statusFn/detectWorktrees are injected for tests.
+func frameworkWorkerServicesForSite(
+	s config.Site,
+	fw *config.Framework,
+	statusFn func(string) (string, error),
+	detectWorktrees func(string, string) ([]gitpkg.Worktree, error),
+) []ServiceResponse {
+	if fw == nil || fw.Workers == nil {
+		return nil
+	}
+	// Worktree units follow lerd-<wname>-<site>-<wtBase>; parent uses wtBase="".
+	targets := []frameworkWorkerTarget{{}}
+	if wts, _ := detectWorktrees(s.Path, s.PrimaryDomain()); len(wts) > 0 {
+		for _, wt := range wts {
+			targets = append(targets, frameworkWorkerTarget{
+				wtBase: filepath.Base(wt.Path),
+				domain: wt.Domain,
+			})
+		}
+	}
+	var out []ServiceResponse
+	for wname, w := range fw.Workers {
+		switch wname {
+		case "queue", "schedule", "reverb":
+			continue
+		}
+		perWT := w.IsPerWorktree()
+		label := w.Label
+		if label == "" {
+			label = wname
+		}
+		for _, t := range targets {
+			if t.wtBase != "" && !perWT {
+				continue
+			}
+			unitName := "lerd-" + wname + "-" + s.Name
+			respName := wname + "-" + s.Name
+			if t.wtBase != "" {
+				unitName += "-" + t.wtBase
+				respName += "-" + t.wtBase
+			}
+			unitStatus, _ := statusFn(unitName)
+			if unitStatus != "active" {
+				continue
+			}
+			resp := ServiceResponse{
+				Name:        respName,
+				Status:      "active",
+				EnvVars:     map[string]string{},
+				WorkerSite:  s.Name,
+				WorkerName:  wname,
+				WorkerLabel: label,
+			}
+			if t.wtBase != "" {
+				resp.WorkerWorktree = t.wtBase
+				resp.WorkerWorktreeDomain = t.domain
+			}
+			out = append(out, resp)
+		}
+	}
+	return out
 }
 
 // PresetResponse describes a bundled service preset for the web UI.
@@ -1412,8 +1484,8 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Handle custom framework worker services: name is {workerName}-{siteName}.
-	// Detect by looking for a matching registered site + framework worker.
+	// Custom framework workers: {workerName}-{siteName} or
+	// {workerName}-{siteName}-{wtBase} for the worktree variant.
 	if action == "stop" {
 		if reg3, err3 := config.LoadSites(); err3 == nil {
 			for _, s := range reg3.Sites {
@@ -1421,7 +1493,7 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				fwN3 := s.Framework
-				fw3, ok3 := config.GetFramework(fwN3)
+				fw3, ok3 := config.GetFrameworkForDir(fwN3, s.Path)
 				if !ok3 || fw3.Workers == nil {
 					continue
 				}
@@ -1430,7 +1502,8 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 					case "queue", "schedule", "reverb":
 						continue
 					}
-					if wname+"-"+s.Name == name {
+					prefix := wname + "-" + s.Name
+					if name == prefix {
 						opErr := cli.WorkerStopForSite(s.Name, wname)
 						resp := ServiceActionResponse{
 							ServiceResponse: ServiceResponse{Name: name, Status: "inactive", EnvVars: map[string]string{}, WorkerSite: s.Name, WorkerName: wname},
@@ -1443,6 +1516,35 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 						writeJSON(w, resp)
 						return
 					}
+					if !strings.HasPrefix(name, prefix+"-") {
+						continue
+					}
+					wtBase := strings.TrimPrefix(name, prefix+"-")
+					wts, _ := gitpkg.DetectWorktrees(s.Path, s.PrimaryDomain())
+					matched := false
+					for _, wt := range wts {
+						if filepath.Base(wt.Path) == wtBase {
+							matched = true
+							break
+						}
+					}
+					if !matched {
+						continue
+					}
+					opErr := cli.WorkerStopForSite(s.Name+"-"+wtBase, wname)
+					resp := ServiceActionResponse{
+						ServiceResponse: ServiceResponse{
+							Name: name, Status: "inactive", EnvVars: map[string]string{},
+							WorkerSite: s.Name, WorkerName: wname, WorkerWorktree: wtBase,
+						},
+						OK: opErr == nil,
+					}
+					if opErr != nil {
+						resp.Error = opErr.Error()
+						resp.Status = "active"
+					}
+					writeJSON(w, resp)
+					return
 				}
 			}
 		}
@@ -2310,23 +2412,36 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, resp)
 		return
 	default:
-		// Handle framework worker actions: worker:{name}:start or worker:{name}:stop
+		// worker:{name}:start|stop. ?branch=<wt> targets the worktree unit
+		// lerd-<wname>-<site>-<wtBase> instead of the parent's lerd-<wname>-<site>.
 		if strings.HasPrefix(action, "worker:") {
 			parts := strings.SplitN(action, ":", 3)
 			if len(parts) == 3 && (parts[2] == "start" || parts[2] == "stop") {
 				workerName := parts[1]
+				branch := r.URL.Query().Get("branch")
+				targetPath := site.Path
+				targetUnitSite := site.Name
+				if branch != "" {
+					wtPath := resolveSitePath(site, branch)
+					if wtPath == "" {
+						writeJSON(w, SiteActionResponse{Error: "unknown worktree branch"})
+						return
+					}
+					targetPath = wtPath
+					targetUnitSite = site.Name + "-" + filepath.Base(wtPath)
+				}
 				if parts[2] == "stop" {
-					// Allow stopping orphaned workers that have no definition.
-					if err := cli.WorkerStopForSite(site.Name, workerName); err != nil {
+					// Stops orphans without a framework definition too.
+					if err := cli.WorkerStopForSite(targetUnitSite, workerName); err != nil {
 						writeJSON(w, SiteActionResponse{Error: err.Error()})
 						return
 					}
-					if !site.Paused {
+					if branch == "" && !site.Paused {
 						_ = config.SetProjectWorkers(site.Path, cli.CollectRunningWorkerNames(site))
 					}
 				} else {
 					fwN := site.Framework
-					fw, ok := config.GetFrameworkForDir(fwN, site.Path)
+					fw, ok := config.GetFrameworkForDir(fwN, targetPath)
 					if !ok || fw.Workers == nil {
 						writeJSON(w, SiteActionResponse{Error: "framework has no workers defined"})
 						return
@@ -2337,11 +2452,15 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 					phpVersion := site.PHPVersion
-					if detected, err := phpPkg.DetectVersion(site.Path); err == nil && detected != "" {
+					if detected, err := phpPkg.DetectVersion(targetPath); err == nil && detected != "" {
 						phpVersion = detected
 					}
-					go cli.WorkerStartForSite(site.Name, site.Path, phpVersion, workerName, worker, true) //nolint:errcheck
-					go syncLerdYAMLWorkersDelayed(site)
+					// WorkerStartForSite appends the worktree suffix when
+					// sitePath != site.Path — pass parent name + worktree path.
+					go cli.WorkerStartForSite(site.Name, targetPath, phpVersion, workerName, worker, branch == "") //nolint:errcheck
+					if branch == "" {
+						go syncLerdYAMLWorkersDelayed(site)
+					}
 				}
 				writeJSON(w, SiteActionResponse{OK: true})
 				return

--- a/internal/ui/web/src/stores/services.ts
+++ b/internal/ui/web/src/stores/services.ts
@@ -25,6 +25,8 @@ export interface Service {
   worker_site?: string;
   worker_name?: string;
   worker_label?: string;
+  worker_worktree?: string;
+  worker_worktree_domain?: string;
   update_strategy?: string;
   update_available?: boolean;
   latest_version?: string;
@@ -347,18 +349,19 @@ function capitalize(s: string): string {
 }
 
 export function workerSiteName(s: Service): string {
-  return (
+  const base =
     s.queue_site ||
     s.horizon_site ||
     s.schedule_worker_site ||
     s.reverb_site ||
     s.stripe_listener_site ||
     s.worker_site ||
-    s.name
-  );
+    s.name;
+  return s.worker_worktree ? base + '/' + s.worker_worktree : base;
 }
 
 export function parentSiteDomain(s: Service): string | null {
+  if (s.worker_worktree_domain) return s.worker_worktree_domain;
   const n =
     s.queue_site ||
     s.horizon_site ||

--- a/internal/ui/web/src/stores/sites.ts
+++ b/internal/ui/web/src/stores/sites.ts
@@ -44,6 +44,7 @@ export interface Site {
     db_database?: string;
     lan_port?: number;
     lan_share_url?: string;
+    framework_workers?: FrameworkWorker[];
   }>;
   has_queue_worker?: boolean;
   has_schedule_worker?: boolean;
@@ -191,8 +192,11 @@ export const toggleReverb = (s: Site) =>
   postAction(site(s.domain, s.reverb_running ? 'reverb:stop' : 'reverb:start'));
 export const toggleStripe = (s: Site) =>
   postAction(site(s.domain, s.stripe_running ? 'stripe:stop' : 'stripe:start'));
-export const toggleWorker = (s: Site, w: FrameworkWorker) =>
-  postAction(site(s.domain, 'worker:' + w.name + (w.running ? ':stop' : ':start')));
+export const toggleWorker = (s: Site, w: FrameworkWorker, branch: string = '') =>
+  postAction(
+    site(s.domain, 'worker:' + w.name + (w.running ? ':stop' : ':start')) +
+      (branch ? `?branch=${encodeURIComponent(branch)}` : '')
+  );
 
 export type TinkerResponse = {
   ok: boolean;

--- a/internal/ui/web/src/tabs/dashboard/WorkersWidget.svelte
+++ b/internal/ui/web/src/tabs/dashboard/WorkersWidget.svelte
@@ -2,7 +2,7 @@
   import DashboardCard from './DashboardCard.svelte';
   import StatusPill from '$components/StatusPill.svelte';
   import StatusDot from '$components/StatusDot.svelte';
-  import { workerGroups, workerSiteName, type Service } from '$stores/services';
+  import { workerGroups, workerSiteName, parentSiteDomain, type Service } from '$stores/services';
   import {
     unhealthyWorkers,
     healAll,
@@ -26,8 +26,12 @@
   }
 
   function jumpToSite(item: Service) {
-    const site = workerSiteName(item);
-    goToTab('sites', site + '.test');
+    const domain = parentSiteDomain(item);
+    if (domain) {
+      goToTab('sites', domain);
+      return;
+    }
+    goToTab('sites', workerSiteName(item) + '.test');
   }
 
   async function onHeal() {

--- a/internal/ui/web/src/tabs/services/ServiceDetail.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceDetail.svelte
@@ -27,7 +27,10 @@
     if (svc.stripe_listener_site) return `/api/stripe/${svc.stripe_listener_site}/logs`;
     if (svc.schedule_worker_site) return `/api/schedule/${svc.schedule_worker_site}/logs`;
     if (svc.reverb_site) return `/api/reverb/${svc.reverb_site}/logs`;
-    if (svc.worker_site && svc.worker_name) return `/api/worker/${svc.worker_site}/${svc.worker_name}/logs`;
+    if (svc.worker_site && svc.worker_name) {
+      const site = svc.worker_worktree ? `${svc.worker_site}-${svc.worker_worktree}` : svc.worker_site;
+      return `/api/worker/${site}/${svc.worker_name}/logs`;
+    }
     return `/api/logs/lerd-${svc.name}`;
   });
 

--- a/internal/ui/web/src/tabs/sites/SiteControls.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteControls.svelte
@@ -123,7 +123,10 @@
     reconcile('schedule', Boolean(site.schedule_running));
     reconcile('reverb', Boolean(site.reverb_running));
     reconcile('stripe', Boolean(site.stripe_running));
-    for (const w of site.framework_workers || []) {
+    const sourceWorkers = activeWorktreeBranch
+      ? activeWorktree?.framework_workers || []
+      : site.framework_workers || [];
+    for (const w of sourceWorkers) {
       reconcile('worker:' + w.name, Boolean(w.running));
     }
   });
@@ -266,12 +269,30 @@
     <div class="w-px h-4 bg-gray-200 dark:bg-lerd-border mx-0.5"></div>
 
     {#if activeWorktreeBranch}
-      <span
-        class="text-[11px] text-gray-400 dark:text-gray-500 italic"
-        title="Queue, schedule, Horizon, Reverb and custom workers run against the main branch only. Switch to main to start or stop them."
-      >
-        Workers run from main
-      </span>
+      {@const wtWorkers = activeWorktree?.framework_workers || []}
+      {#if wtWorkers.length === 0}
+        <span
+          class="text-[11px] text-gray-400 dark:text-gray-500 italic"
+          title="Queue, schedule, Horizon and Reverb run against the main branch only. Switch to main to start or stop them."
+        >
+          Workers run from main
+        </span>
+      {:else}
+        {#each wtWorkers as w (w.name)}
+          <div class="flex items-center gap-1.5">
+            <Toggle
+              on={Boolean(w.running)}
+              failing={Boolean(w.failing)}
+              tone="indigo"
+              loading={isPending('worker:' + w.name)}
+              disabled={isPending('worker:' + w.name)}
+              onclick={() => transition('worker:' + w.name, !w.running, () => toggleWorker(site, w, activeWorktreeBranch))}
+              title={w.running ? 'Stop ' + (w.label || w.name) : 'Start ' + (w.label || w.name)}
+            />
+            <span class="text-xs text-gray-500 dark:text-gray-400">{w.label || w.name}</span>
+          </div>
+        {/each}
+      {/if}
     {:else}
       {#if site.has_queue_worker}
         <div class="flex items-center gap-1.5">


### PR DESCRIPTION
## Summary

Makes per-worktree workers a first-class concept driven by framework
yaml intent rather than convention. The watcher previously auto-started
every `host: true` worker for every new worktree; this change replaces
that with a deliberate two-flag schema and a chain of fixes around it.

## Schema

Two new fields on `FrameworkWorker`:

- `per_worktree` (default `false`): worker can run independently per
  git worktree, under the `lerd-<wname>-<site>-<wt>` unit name.
- `replaces_build` (default `false`): while running, the worker provides
  the asset manifest, so the static `npm run build` step is unnecessary.

The two flags answer independent questions: "where can this run?" vs.
"do we still need a build?". Vite happens to satisfy both. A
hypothetical per-worktree Tailwind watcher would be `per_worktree: true`
without `replaces_build: true` (it watches CSS but doesn't produce the
JS manifest), so the build step would still fire alongside it.

## Behaviour changes

- Watcher `syncWorktree` only auto-starts host workers the user opted
  into via `.lerd.yaml workers:` AND that declare `per_worktree: true`.
- `lerd worktree add` brings back the `npm run <build>` prompt when no
  `replaces_build` worker is opted in; otherwise it announces what's
  being auto-started and skips the build.
- `lerd setup` pre-disables the build step when `replaces_build` is
  opted in, uses `GetFrameworkForDir` so vite (store-defined) shows in
  the worker toggles, and falls back to the parent site when run inside
  a worktree so the worker section still appears.
- `runLink` rejects worktree paths instead of registering them as a
  separate top-level site.
- `FindOrphanedWorkers` consults the sites registry so unit names
  shaped `lerd-<wname>-<parent>-<wt>.service` stop being mis-attributed
  as orphans of `<wt>`.

## Dashboard

- `/api/services` enumerates worktree workers for any site, with new
  `worker_worktree` / `worker_worktree_domain` fields so the UI groups
  and navigates correctly.
- `/api/sites` worktree responses carry `framework_workers`, so
  `SiteControls` renders per-worktree toggles next to the existing
  parent toggles.
- `ServiceDetail` builds `/api/worker/<site-wt>/<name>/logs` URLs for
  worktree-suffixed unit names.

## Refresh

`lerd install` now runs `refreshStoreFrameworks`, which re-fetches every
cached framework yaml so users pick up the new flags without waiting
for the 24h staleness check.

## Tests

`config` (per_worktree default + override + builtin parent-only +
yaml round-trip), `siteinfo` (worktree worker enrichment),
`systemd` (`UnitBelongsToOtherSiteWorktree`), `cli` (`findOwningWorktree`,
`OptedInHostWorkers`, `OptedInBuildReplacers`), `ui`
(`frameworkWorkerServicesForSite`).

## Pairs with

- `lerd-frameworks` PR #9 (`replaces_build:true` on Vite). The
  `per_worktree:true` PR is already merged.
- This branch does not depend on `lerd/pull/318` (the
  `lerd framework update` fix); they're independent and can land in
  either order.