### PR TITLE
fix: post-#319 audit followups for worker lifecycle, certs, env, DNS

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -381,18 +381,25 @@ func newWatchCmd() *cobra.Command {
 							eventbus.Default.Publish(eventbus.KindSites)
 						}
 					},
-					func(sitePath, _ string) {
+					func(sitePath, worktreeName string) {
 						site, err := config.FindSiteByPath(sitePath)
 						if err != nil {
 							return
 						}
 						// Cleanup order on plain `git worktree remove`:
-						// vhost first (URL stops resolving), then LAN
-						// share. Isolated databases are intentionally NOT
-						// dropped here — `lerd worktree remove` prompts
-						// the user about the DB explicitly, and the
-						// daemon's startup `scanWorktrees` pass catches
-						// any orphans left by direct git users.
+						// stop per-worktree worker units first so they
+						// don't restart-loop against the deleted dir, then
+						// vhost (URL stops resolving), then LAN share.
+						// Isolated databases are intentionally NOT dropped
+						// here — `lerd worktree remove` prompts the user
+						// about the DB explicitly, and the daemon's
+						// startup scanWorktrees pass catches any orphans
+						// left by direct git users.
+						if worktreeName != "" {
+							if err := cli.StopAllWorkersForWorktree(site.Name, worktreeName); err != nil {
+								fmt.Printf("[WARN] stopping worktree workers for %s/%s: %v\n", site.Name, worktreeName, err)
+							}
+						}
 						if cleanupWorktreeVhosts(site) {
 							if err := nginx.Reload(); err != nil {
 								fmt.Printf("[WARN] nginx reload: %v\n", err)
@@ -601,18 +608,19 @@ func scanWorktrees() bool {
 		}
 		for _, wt := range worktrees {
 			gitpkg.EnsureWorktreeDeps(s.Path, wt.Path, wt.Domain, s.Secured)
-			var vhostErr error
-			if s.Secured {
-				vhostErr = nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, s.PHPVersion, s.PrimaryDomain())
-			} else {
-				vhostErr = nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, s.PHPVersion)
-			}
+			vhostErr := nginx.GenerateWorktreeVhostFor(wt.Domain, wt.Path, s.PHPVersion, s.PrimaryDomain(), s.Secured)
 			if vhostErr != nil {
 				fmt.Printf("[WARN] worktree vhost for %s: %v\n", wt.Domain, vhostErr)
 				continue
 			}
 			fmt.Printf("Worktree vhost: %s -> %s\n", wt.Branch, wt.Domain)
 			generated = true
+
+			// Per-worktree host workers (e.g. vite) need to be (re)started
+			// at daemon boot too, not just when fsnotify fires onAdded.
+			// Without this, units stopped during downtime never come back.
+			effectivePHP := config.WorktreePHPVersion(wt.Path, s.PHPVersion)
+			cli.AutoStartOptedInWorktreeWorkers(&site, wt.Path, effectivePHP)
 		}
 	}
 	return generated
@@ -639,14 +647,11 @@ func syncWorktree(sitePath, worktreeName, action string, pruneStale bool) bool {
 		}
 		gitpkg.EnsureWorktreeDeps(sitePath, wt.Path, wt.Domain, site.Secured)
 		effectivePHP := config.WorktreePHPVersion(wt.Path, site.PHPVersion)
-		var vhostErr error
+		vhostErr := nginx.GenerateWorktreeVhostFor(wt.Domain, wt.Path, effectivePHP, site.PrimaryDomain(), site.Secured)
 		if site.Secured {
-			vhostErr = nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, effectivePHP, site.PrimaryDomain())
 			if reissueErr := certs.ReissueCertForWorktree(*site); reissueErr != nil {
 				fmt.Printf("[WARN] reissue cert for worktree %s: %v\n", wt.Domain, reissueErr)
 			}
-		} else {
-			vhostErr = nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, effectivePHP)
 		}
 		if vhostErr != nil {
 			fmt.Printf("[WARN] worktree vhost for %s: %v\n", wt.Domain, vhostErr)
@@ -657,19 +662,7 @@ func syncWorktree(sitePath, worktreeName, action string, pruneStale bool) bool {
 		// Auto-start only the host workers the user opted into via
 		// .lerd.yaml workers:. Worktrees inherit the parent's project
 		// intent rather than every host:true worker the framework defines.
-		for _, name := range cli.OptedInHostWorkers(site, wt.Path) {
-			fw, ok := config.GetFrameworkForDir(site.Framework, sitePath)
-			if !ok {
-				break
-			}
-			w, ok := fw.Workers[name]
-			if !ok {
-				continue
-			}
-			if err := cli.WorkerStartForSite(site.Name, wt.Path, effectivePHP, name, w, false); err != nil {
-				fmt.Printf("[WARN] auto-start %s for worktree %s: %v\n", name, wt.Branch, err)
-			}
-		}
+		cli.AutoStartOptedInWorktreeWorkers(site, wt.Path, effectivePHP)
 
 		return true
 	}

--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -33,7 +33,9 @@ After git completes, the wrapper:
 3. Prompts how to set up the worktree's database — see [Per-worktree database](#per-worktree-database) below.
 4. If you pick "isolated empty", asks whether to run `php artisan migrate --force` against the new schema right away.
 
-When the framework defines a host worker like `vite` (with `host: true` and a passing `check`), the build prompt is skipped and the watcher auto-starts `npm run dev` as a per-worktree systemd unit instead. Multiple worktrees can run Vite simultaneously — each gets its own unit (`lerd-vite-site-branch`) and Vite auto-increments ports.
+When the framework defines a host worker like `vite` (with `host: true` and a passing `check`), the build prompt is skipped and the watcher auto-starts `npm run dev` as a per-worktree systemd unit instead. Multiple worktrees can run Vite simultaneously — each gets its own unit (`lerd-vite-<site>-<branch>`) and Vite auto-increments ports.
+
+The same auto-start runs at daemon boot too, so per-worktree units recover after a host reboot or `lerd stop && lerd start` even when fsnotify hasn't fired. On `lerd worktree remove`, the matching units are stopped and their `.service` files removed before git tears the worktree down — without that step, systemd would restart-loop the unit against the deleted `WorkingDirectory`.
 
 If no host worker is defined, skipping the build step leaves the worktree without a Vite manifest, which means the first request will throw `ViteManifestNotFoundException` until you run `npm run dev` or `npm run build` yourself. That's intentional — the alternative is silently rendering main's compiled UI on the worktree, which is worse.
 
@@ -98,16 +100,19 @@ By default lerd only rewrites `APP_URL` in worktree `.env` files. Multi-tenant a
 env_overrides:
     APP_URL: "{{scheme}}://app.{{domain}}"
     CENTRAL_DOMAIN: "{{domain}}"
+    DB_DATABASE: "{{parent}}_{{branch}}"
     CACHE_DRIVER: redis
 ```
 
-Values can use template placeholders or be plain static strings. When a worktree is created (or the watcher re-syncs), each value is resolved and written into the worktree's `.env`.
+Values can use template placeholders or be plain static strings. When a worktree is created (or the watcher re-syncs), each value is resolved and written into the worktree's `.env`. Newlines or `\r` characters in a value are rejected so a malformed override can't inject a second key into `.env`; the same check rejects `=` or newline characters in keys.
 
 | Placeholder | Resolves to | Example |
 |-------------|-------------|---------|
 | `{{domain}}` | Worktree domain | `feature-branch.myapp.test` |
 | `{{scheme}}` | `http` or `https` | `https` |
-| `{{site}}` | Database-safe name (underscored) | `feature_branch_myapp_test` |
+| `{{branch}}` | Worktree branch slug (no parent) | `feature-branch` |
+| `{{parent}}` | Parent site name, slugified | `myapp` |
+| `{{site}}` | Database-safe slug of the *full* worktree domain. Prefer `{{branch}}` / `{{parent}}` for clarity | `feature_branch_myapp_test` |
 
 When `APP_URL` is present in `env_overrides` it takes precedence over the default `scheme://domain` rewrite. Without `env_overrides`, behaviour is unchanged.
 
@@ -171,9 +176,10 @@ LAN share has a separate toggle that's worktree-aware: when a worktree is active
 
 When a worktree is removed (via `git worktree remove` directly or `lerd worktree remove`) the watcher tears state down in this order so that any earlier failure leaves the database intact:
 
-1. nginx vhost (URL stops resolving)
-2. LAN-share proxy + registry entry (port released)
-3. Isolated database — *only* via `lerd worktree remove`'s explicit prompt or the daemon's `scanWorktrees` startup sweep. Plain `git worktree remove` leaves the DB and its registry entry alone, so the user can recover by re-adding the worktree without losing migrations or seed data.
+1. Per-worktree host-worker units (`lerd-<worker>-<site>-<branch>.service`) — stopped and removed so systemd doesn't restart-loop them against the deleted `WorkingDirectory`.
+2. nginx vhost (URL stops resolving).
+3. LAN-share proxy + registry entry (port released).
+4. Isolated database — *only* via `lerd worktree remove`'s explicit prompt or the daemon's `scanWorktrees` startup sweep. Plain `git worktree remove` leaves the DB and its registry entry alone, so the user can recover by re-adding the worktree without losing migrations or seed data.
 
 The startup sweep also catches any registry entries whose worktree directory disappeared while the watcher was offline — restarting `lerd-watcher` reconciles state.
 

--- a/docs/usage/framework-workers.md
+++ b/docs/usage/framework-workers.md
@@ -61,7 +61,15 @@ workers:
       file: vite.config.js
 ```
 
-Host workers auto-start when a worktree is created, with per-worktree systemd units (`lerd-vite-site-branch`) so multiple Vite instances can run simultaneously with auto-incremented ports.
+The `command` is wrapped in `/bin/sh -c` so shell features (`&&`, `|`, env-var expansion, redirects) work as written. A composite command like `npm run build && npm run preview` runs end-to-end without quoting tricks.
+
+Host workers auto-start in three places:
+
+- when a worktree is created, with per-worktree systemd units (`lerd-vite-<site>-<branch>`) so multiple Vite instances can run simultaneously with auto-incremented ports.
+- at daemon boot, so worktree units recover after a host reboot or `lerd stop && lerd start` even when fsnotify hasn't fired.
+- on `lerd worktree remove`, the matching unit is stopped and its file removed; without this the unit would restart-loop against the deleted `WorkingDirectory`.
+
+Host workers are not yet supported on macOS — the watcher prints a one-line `[WARN]` and skips the lifecycle calls; container-mode workers remain unaffected.
 
 ## Project-specific custom workers
 

--- a/internal/certs/manager.go
+++ b/internal/certs/manager.go
@@ -5,9 +5,34 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
 )
+
+// issueCertMu serialises issueCertAtomic calls per primaryDomain. Two
+// concurrent reissues for the same site (e.g. boot scanWorktrees racing the
+// watcher's syncWorktree on the same site) must not interleave their
+// renames — pre-fix both used a fixed "<primary>.crt.new" tempfile path,
+// so one would clobber the other's tempfile or rename a partially-flushed
+// file. Lock per domain so unrelated sites still issue in parallel.
+var issueCertMu sync.Map // map[string]*sync.Mutex
+
+func lockForDomain(domain string) *sync.Mutex {
+	if m, ok := issueCertMu.Load(domain); ok {
+		return m.(*sync.Mutex)
+	}
+	m, _ := issueCertMu.LoadOrStore(domain, &sync.Mutex{})
+	return m.(*sync.Mutex)
+}
+
+// tempSuffixSeq increments per call to issueCertAtomic so concurrent
+// callers (across processes too) don't share a tempfile path even if the
+// per-domain mutex is bypassed somehow.
+var tempSuffixSeq atomic.Uint64
 
 // MkcertPath returns the path to the mkcert binary.
 func MkcertPath() string {
@@ -48,14 +73,23 @@ func IssueCertForce(primaryDomain string, allDomains []string, certsDir string) 
 }
 
 func issueCertAtomic(primaryDomain string, allDomains []string, certsDir string) error {
+	mu := lockForDomain(primaryDomain)
+	mu.Lock()
+	defer mu.Unlock()
+
 	if err := os.MkdirAll(certsDir, 0755); err != nil {
 		return err
 	}
 
 	certFile := filepath.Join(certsDir, primaryDomain+".crt")
 	keyFile := filepath.Join(certsDir, primaryDomain+".key")
-	tmpCert := certFile + ".new"
-	tmpKey := keyFile + ".new"
+	// Per-call unique suffix: pid + monotonic seq + ns time. Ensures
+	// cross-process concurrent issuers (e.g. lerd-watcher and lerd-ui)
+	// don't collide on the .new path even when the in-process mutex
+	// can't help.
+	suffix := ".new." + strconv.Itoa(os.Getpid()) + "." + strconv.FormatUint(tempSuffixSeq.Add(1), 10) + "." + strconv.FormatInt(time.Now().UnixNano(), 10)
+	tmpCert := certFile + suffix
+	tmpKey := keyFile + suffix
 
 	var sans []string
 	for _, d := range allDomains {

--- a/internal/certs/manager_test.go
+++ b/internal/certs/manager_test.go
@@ -3,6 +3,8 @@ package certs
 import (
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -54,6 +56,93 @@ func TestCertExists_onlyCrtRequired(t *testing.T) {
 
 	if !CertExists("site.test") {
 		t.Error("expected true when only .crt file exists")
+	}
+}
+
+// ── IssueCertForce concurrency ───────────────────────────────────────────────
+
+// TestIssueCertForce_concurrentCallsDontCollide pins the fix for the shared
+// .new tempfile race: two parallel IssueCertForce calls for the same domain
+// (e.g. boot scanWorktrees + a watcher syncWorktree event firing on the same
+// site) must not interleave their renames. Pre-fix both writers used a
+// fixed "<primary>.crt.new" path; one would clobber the other's tempfile
+// mid-write or rename a partially-flushed file. The fix uses a unique
+// tempfile per goroutine.
+func TestIssueCertForce_concurrentCallsDontCollide(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	binDir := filepath.Join(tmp, "lerd", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Fake mkcert that writes its SAN list into the cert/key tempfiles
+	// so we can detect a half-written / clobbered cert. A 50ms sleep
+	// widens the race window beyond filesystem-rename atomicity.
+	fakeMkcert := `#!/bin/sh
+CRT=""
+KEY=""
+SANS=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -cert-file) shift; CRT="$1" ;;
+    -key-file)  shift; KEY="$1" ;;
+    *) SANS="$SANS $1" ;;
+  esac
+  shift
+done
+sleep 0.05
+echo "$SANS" > "$CRT"
+echo "FAKE-KEY" > "$KEY"
+`
+	if err := os.WriteFile(filepath.Join(binDir, "mkcert"), []byte(fakeMkcert), 0755); err != nil {
+		t.Fatal(err)
+	}
+	certsDir := filepath.Join(tmp, "lerd", "certs", "sites")
+	if err := os.MkdirAll(certsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := IssueCertForce("alpha.test", []string{"alpha.test"}, certsDir)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for e := range errs {
+		if e != nil {
+			t.Errorf("concurrent IssueCertForce returned error: %v", e)
+		}
+	}
+
+	// Cert must exist and contain a complete SAN write (the fake echoes
+	// SANs verbatim; truncation or interleaving would break the prefix).
+	body, err := os.ReadFile(filepath.Join(certsDir, "alpha.test.crt"))
+	if err != nil {
+		t.Fatalf("cert missing after concurrent issue: %v", err)
+	}
+	if !strings.Contains(string(body), "alpha.test") {
+		t.Errorf("cert content corrupted by concurrent rename; got %q", body)
+	}
+
+	// No leftover temp files: each goroutine should have cleaned up its
+	// own .new.* paths even on the rename-loser side.
+	entries, _ := os.ReadDir(certsDir)
+	for _, e := range entries {
+		name := e.Name()
+		if name == "alpha.test.crt" || name == "alpha.test.key" {
+			continue
+		}
+		if strings.Contains(name, ".new") {
+			t.Errorf("leftover temp file %q after concurrent issue", name)
+		}
 	}
 }
 

--- a/internal/cli/framework.go
+++ b/internal/cli/framework.go
@@ -565,14 +565,14 @@ func updateAllFrameworks(client *store.Client, showDiff bool) error {
 		// entry.Latest for every entry, so users with multiple versions
 		// (laravel@10..@13) ended up only refreshing the latest file and
 		// the others stayed stale forever.
-		var indexed *store.IndexEntry
-		for i, entry := range idx.Frameworks {
+		inIndex := false
+		for _, entry := range idx.Frameworks {
 			if entry.Name == info.Name {
-				indexed = &idx.Frameworks[i]
+				inIndex = true
 				break
 			}
 		}
-		if indexed == nil {
+		if !inIndex {
 			continue
 		}
 		remote, fetchErr := client.FetchFramework(info.Name, info.Version)

--- a/internal/cli/horizon.go
+++ b/internal/cli/horizon.go
@@ -128,7 +128,7 @@ WantedBy=default.target
 
 // HorizonStopForSite stops and removes the Horizon unit for the named site.
 func HorizonStopForSite(siteName string) error {
-	return WorkerStopForSite(siteName, "horizon")
+	return WorkerStopForSite(siteName, "", "horizon")
 }
 
 // SiteHasHorizon returns true if composer.json lists laravel/horizon as a dependency.

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -413,7 +413,7 @@ func startWorkersForSite(site *config.Site, workers []string, phpVersion string)
 		}
 		// Stop conflicting workers before starting.
 		for _, conflict := range worker.ConflictsWith {
-			WorkerStopForSite(site.Name, conflict) //nolint:errcheck
+			WorkerStopForSite(site.Name, site.Path, conflict) //nolint:errcheck
 		}
 		if err := WorkerStartForSite(site.Name, site.Path, phpVersion, w, worker, true); err != nil {
 			fmt.Printf("[WARN] starting worker %s: %v\n", w, err)

--- a/internal/cli/migrate_tld.go
+++ b/internal/cli/migrate_tld.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
 	gitpkg "github.com/geodro/lerd/internal/git"
@@ -88,11 +89,25 @@ func migrateSiteTLD(oldTLD, newTLD string, forceUnsecure bool) []string {
 		}
 
 		removeStaleVhosts(oldPrimary)
-		if forceUnsecure {
-			removeStaleCerts(oldPrimary)
-		}
 		newPrimary := s.PrimaryDomain()
 		migrateWorktreeVhosts(worktrees, newPrimary, s.PHPVersion, s.Secured)
+
+		// Reissue the parent cert under the NEW primary so wildcard SANs
+		// cover the renamed worktree subdomains. Without this, SSL
+		// handshakes to branch.<newPrimary> fail because the old cert's
+		// SANs still reference the old TLD. Skip when forceUnsecure flips
+		// the site to plain HTTP — old certs go through removeStaleCerts.
+		if s.Secured {
+			if err := certs.ReissueCertForWorktree(s); err != nil {
+				fmt.Printf("    WARN: %s: reissue cert: %v\n", s.Name, err)
+			}
+		}
+		// Clean up the old cert files at the previous primary so the
+		// certs dir doesn't accumulate stale entries. Mirrors the
+		// nginx-vhost removeStaleVhosts path above.
+		if forceUnsecure || oldPrimary != newPrimary {
+			removeStaleCerts(oldPrimary)
+		}
 
 		scheme := "http"
 		if s.Secured {
@@ -120,12 +135,7 @@ func migrateWorktreeVhosts(worktrees []gitpkg.Worktree, newPrimary, phpVersion s
 		removeStaleVhosts(wt.Domain)
 		newWTDomain := wt.Branch + "." + newPrimary
 		effectivePHP := config.WorktreePHPVersion(wt.Path, phpVersion)
-		var err error
-		if secured {
-			err = nginx.GenerateWorktreeSSLVhost(newWTDomain, wt.Path, effectivePHP, newPrimary)
-		} else {
-			err = nginx.GenerateWorktreeVhost(newWTDomain, wt.Path, effectivePHP)
-		}
+		err := nginx.GenerateWorktreeVhostFor(newWTDomain, wt.Path, effectivePHP, newPrimary, secured)
 		if err != nil {
 			fmt.Printf("    WARN: worktree %s: regenerate vhost: %v\n", wt.Branch, err)
 		}

--- a/internal/cli/migrate_tld_test.go
+++ b/internal/cli/migrate_tld_test.go
@@ -150,6 +150,116 @@ func TestMigrateWorktreeVhosts_RewritesConfsAndEnv(t *testing.T) {
 	}
 }
 
+// TestMigrateSiteTLD_ReissuesCertForSecuredSiteWithWorktree pins the fix
+// for the regression where migrating a secured site's TLD regenerated the
+// worktree vhosts but never reissued the parent cert. SSL handshakes to
+// branch.<newPrimary> would fail because the cert SANs still carried the
+// old TLD's wildcard. The migration must produce a cert at the NEW primary
+// path that covers the renamed worktree subdomain.
+func TestMigrateSiteTLD_ReissuesCertForSecuredSiteWithWorktree(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	binDir := filepath.Join(tmp, "lerd", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Fake mkcert that writes its SAN list into the cert/key files so the
+	// test can assert the new TLD's wildcard SAN was passed.
+	fakeMkcert := `#!/bin/sh
+CRT=""
+KEY=""
+SANS=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -cert-file) shift; CRT="$1" ;;
+    -key-file) shift; KEY="$1" ;;
+    *) SANS="$SANS $1" ;;
+  esac
+  shift
+done
+echo "$SANS" > "$CRT"
+echo "FAKE-KEY" > "$KEY"
+`
+	if err := os.WriteFile(filepath.Join(binDir, "mkcert"), []byte(fakeMkcert), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a worktree via .git/worktrees/<entry>/ — DetectWorktrees
+	// reads gitdir + HEAD from the entry dir.
+	siteDir := filepath.Join(tmp, "alpha")
+	if err := os.MkdirAll(siteDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	checkout := filepath.Join(tmp, "feat-x-checkout")
+	if err := os.MkdirAll(checkout, 0755); err != nil {
+		t.Fatal(err)
+	}
+	wtMeta := filepath.Join(siteDir, ".git", "worktrees", "feat-x")
+	os.MkdirAll(wtMeta, 0755)
+	os.WriteFile(filepath.Join(wtMeta, "HEAD"), []byte("ref: refs/heads/feat-x\n"), 0644)
+	os.WriteFile(filepath.Join(wtMeta, "gitdir"), []byte(filepath.Join(checkout, ".git")+"\n"), 0644)
+
+	if err := os.WriteFile(filepath.Join(siteDir, ".env"), []byte("APP_URL=https://alpha.test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(checkout, ".env"), []byte("APP_URL=https://feat-x.alpha.test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := config.AddSite(config.Site{
+		Name:       "alpha",
+		Path:       siteDir,
+		Domains:    []string{"alpha.test"},
+		PHPVersion: "8.4",
+		Secured:    true,
+	}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	// Seed an OLD cert at the old primary so we can verify it's torn down.
+	certsDir := filepath.Join(tmp, "lerd", "certs", "sites")
+	if err := os.MkdirAll(certsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(certsDir, "alpha.test.crt"), []byte("OLD-CERT"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(certsDir, "alpha.test.key"), []byte("OLD-KEY"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed := migrateSiteTLD("test", "localhost", false)
+	if !slices.Equal(changed, []string{"alpha"}) {
+		t.Fatalf("changed = %v, want [alpha]", changed)
+	}
+
+	// New cert must exist at the new primary.
+	newCert := filepath.Join(certsDir, "alpha.localhost.crt")
+	body, err := os.ReadFile(newCert)
+	if err != nil {
+		t.Fatalf("expected cert at %s, got %v", newCert, err)
+	}
+	// Cert SANs must include the renamed worktree wildcard.
+	wantSAN := "*.feat-x.alpha.localhost"
+	if !contains(body, wantSAN) {
+		t.Errorf("cert %s missing SAN %q; got %q", newCert, wantSAN, body)
+	}
+	// Old cert files must be cleaned up so the certs/sites dir doesn't
+	// accumulate stale entries across migrations.
+	if _, err := os.Stat(filepath.Join(certsDir, "alpha.test.crt")); !os.IsNotExist(err) {
+		t.Errorf("old cert should be removed after migration; stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(certsDir, "alpha.test.key")); !os.IsNotExist(err) {
+		t.Errorf("old key should be removed after migration; stat err = %v", err)
+	}
+}
+
 func TestMigrateSiteTLD_NoOpWhenSameTLD(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -324,7 +324,7 @@ func stopWorkerByName(site *config.Site, workerName string) {
 		StripeStopForSite(site.Name) //nolint:errcheck
 		return
 	}
-	WorkerStopForSite(site.Name, workerName) //nolint:errcheck
+	WorkerStopForSite(site.Name, site.Path, workerName) //nolint:errcheck
 }
 
 // resumeWorkerByName restarts a single named worker for the site.

--- a/internal/cli/queue.go
+++ b/internal/cli/queue.go
@@ -259,5 +259,5 @@ func QueueRestartForSite(siteName, sitePath, phpVersion string) error {
 
 // QueueStopForSite stops and removes the queue worker for the named site.
 func QueueStopForSite(siteName string) error {
-	return WorkerStopForSite(siteName, "queue")
+	return WorkerStopForSite(siteName, "", "queue")
 }

--- a/internal/cli/restore_worker_linux_test.go
+++ b/internal/cli/restore_worker_linux_test.go
@@ -1,0 +1,93 @@
+//go:build linux
+
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/services"
+)
+
+// captureWriteMgr records every WriteServiceUnitIfChanged call so a test can
+// assert which unit name and content the production code wrote.
+type captureWriteMgr struct {
+	stopTrackingMgr
+	writes      []writeCall
+	enabled     []string
+	writeChange bool
+}
+
+type writeCall struct {
+	name    string
+	content string
+}
+
+func (c *captureWriteMgr) WriteServiceUnitIfChanged(name, content string) (bool, error) {
+	c.writes = append(c.writes, writeCall{name: name, content: content})
+	return c.writeChange, nil
+}
+func (c *captureWriteMgr) Enable(name string) error {
+	c.enabled = append(c.enabled, name)
+	return nil
+}
+
+func swapServiceMgr(t *testing.T, m services.ServiceManager) {
+	t.Helper()
+	prev := services.Mgr
+	services.Mgr = m
+	t.Cleanup(func() { services.Mgr = prev })
+}
+
+// TestRestoreWorker_parentPath_writesParentUnit pins the regression-free
+// case: a parent-path restore should produce lerd-<worker>-<site> exactly
+// like before the workerUnitName refactor.
+func TestRestoreWorker_parentPath_writesParentUnit(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	mgr := &captureWriteMgr{writeChange: true}
+	swapServiceMgr(t, mgr)
+
+	w := config.FrameworkWorker{Command: "npm run dev", Host: true, Label: "Vite"}
+	restoreWorker("ws", "/p/ws", "8.4", "vite", w)
+
+	if len(mgr.writes) == 0 {
+		t.Fatal("expected at least one WriteServiceUnitIfChanged call")
+	}
+	if got := mgr.writes[0].name; got != "lerd-vite-ws" {
+		t.Errorf("got unit %q, want %q", got, "lerd-vite-ws")
+	}
+	if !strings.Contains(mgr.writes[0].content, "WorkingDirectory=/p/ws") {
+		t.Errorf("expected WorkingDirectory=/p/ws in unit content, got %q", mgr.writes[0].content)
+	}
+}
+
+// TestRestoreWorker_worktreePath_writesSuffixedUnit pins the fix: when
+// restoreWorker is invoked for a worktree path under the parent site, the
+// produced unit must be lerd-<worker>-<site>-<wtBase> with WorkingDirectory
+// set to the worktree path. Pre-fix, restoreWorker built the parent-shaped
+// unit name from siteName alone, so per-worktree workers couldn't survive
+// a daemon restart cleanly.
+func TestRestoreWorker_worktreePath_writesSuffixedUnit(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	mgr := &captureWriteMgr{writeChange: true}
+	swapServiceMgr(t, mgr)
+
+	w := config.FrameworkWorker{Command: "npm run dev", Host: true, Label: "Vite"}
+	restoreWorker("ws", "/p/ws/main", "8.4", "vite", w)
+
+	if len(mgr.writes) == 0 {
+		t.Fatal("expected at least one WriteServiceUnitIfChanged call")
+	}
+	if got := mgr.writes[0].name; got != "lerd-vite-ws-main" {
+		t.Errorf("got unit %q, want %q", got, "lerd-vite-ws-main")
+	}
+	if !strings.Contains(mgr.writes[0].content, "WorkingDirectory=/p/ws/main") {
+		t.Errorf("expected WorkingDirectory=/p/ws/main in unit content, got %q", mgr.writes[0].content)
+	}
+	// The systemd Description should reflect the worktree label so users
+	// can tell parent and worktree units apart in journalctl / systemctl.
+	if !strings.Contains(mgr.writes[0].content, "ws/main") {
+		t.Errorf("expected ws/main label in unit content for worktree, got %q", mgr.writes[0].content)
+	}
+}

--- a/internal/cli/reverb.go
+++ b/internal/cli/reverb.go
@@ -113,7 +113,7 @@ func ReverbStartForSite(siteName, sitePath, phpVersion string) error {
 
 // ReverbStopForSite stops and removes the Reverb unit for the named site.
 func ReverbStopForSite(siteName string) error {
-	return WorkerStopForSite(siteName, "reverb")
+	return WorkerStopForSite(siteName, "", "reverb")
 }
 
 // regenNginxVhost regenerates the nginx vhost for the site so proxy blocks are updated.

--- a/internal/cli/schedule.go
+++ b/internal/cli/schedule.go
@@ -104,5 +104,5 @@ func ScheduleStartForSite(siteName, sitePath, phpVersion string) error {
 
 // ScheduleStopForSite stops and removes the scheduler unit for the named site.
 func ScheduleStopForSite(siteName string) error {
-	return WorkerStopForSite(siteName, "schedule")
+	return WorkerStopForSite(siteName, "", "schedule")
 }

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -224,7 +224,7 @@ func runSetup(allSteps, skipOpen bool) error {
 				label:   on + ":stop (orphaned)",
 				enabled: true,
 				run: func() error {
-					return WorkerStopForSite(site.Name, on)
+					return WorkerStopForSite(site.Name, site.Path, on)
 				},
 			})
 		}
@@ -273,7 +273,7 @@ func runSetup(allSteps, skipOpen bool) error {
 							}
 						}
 						for _, conflict := range wd.ConflictsWith {
-							WorkerStopForSite(ownerSite.Name, conflict) //nolint:errcheck
+							WorkerStopForSite(ownerSite.Name, cwd, conflict) //nolint:errcheck
 						}
 						return WorkerStartForSite(ownerSite.Name, cwd, phpVersion, wn, wd, true)
 					},

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
+	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/nginx"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
@@ -748,15 +749,16 @@ func restoreSiteInfrastructure() {
 		// file and let phase 2 of runStart launch it (macOS).
 		for _, w := range proj.Workers {
 			unitName := "lerd-" + w + "-" + s.Name
-			if services.Mgr.IsEnabled(unitName) {
-				continue
-			}
+			parentEnabled := services.Mgr.IsEnabled(unitName)
 			phpVersion := s.PHPVersion
 			if phpVersion == "" {
 				cfg, _ := config.LoadGlobal()
 				phpVersion = cfg.PHP.DefaultVersion
 			}
 			if w == "stripe" {
+				if parentEnabled {
+					continue
+				}
 				base := siteURL(s.Path)
 				if base != "" {
 					StripeRestoreUnit(s.Name, s.Path, base) //nolint:errcheck
@@ -764,10 +766,34 @@ func restoreSiteInfrastructure() {
 				continue
 			}
 			fwName := s.Framework
-			if fw, ok := config.GetFrameworkForDir(fwName, s.Path); ok && fw.Workers != nil {
-				if wDef, ok := fw.Workers[w]; ok {
-					restoreWorker(s.Name, s.Path, phpVersion, w, wDef)
+			fw, fwOK := config.GetFrameworkForDir(fwName, s.Path)
+			if !fwOK || fw.Workers == nil {
+				continue
+			}
+			wDef, ok := fw.Workers[w]
+			if !ok {
+				continue
+			}
+			if !parentEnabled {
+				restoreWorker(s.Name, s.Path, phpVersion, w, wDef)
+			}
+			// Per-worktree host workers: rewrite each worktree's unit so
+			// stop/start cycles don't leave them stale. The parent unit
+			// alone is not enough because PR #319 shipped per-worktree
+			// units (lerd-<w>-<site>-<wtBase>) with a separate lifecycle.
+			if !wDef.Host {
+				continue
+			}
+			worktrees, err := gitpkg.DetectWorktrees(s.Path, s.PrimaryDomain())
+			if err != nil {
+				continue
+			}
+			for _, wt := range worktrees {
+				if services.Mgr.IsEnabled(workerUnitName(s.Name, wt.Path, w)) {
+					continue
 				}
+				wtPHP := config.WorktreePHPVersion(wt.Path, phpVersion)
+				restoreWorker(s.Name, wt.Path, wtPHP, w, wDef)
 			}
 		}
 	}

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -88,7 +88,7 @@ func newWorkerStopCmd() *cobra.Command {
 					return fmt.Errorf("framework %q has no worker named %q\nRun 'lerd worker list' to see available workers", fw.Label, workerName)
 				}
 			}
-			if err := WorkerStopForSite(site.Name, workerName); err != nil {
+			if err := WorkerStopForSite(site.Name, cwd, workerName); err != nil {
 				return err
 			}
 			if !site.Paused {
@@ -222,9 +222,21 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 		return err
 	}
 
-	// Stop conflicting workers before starting.
+	// Skip lifecycle for worker shapes the current platform can't run.
+	// Without this gate macOS hosts proceed past writeWorkerUnitFile (which
+	// returns (false, nil) and prints a WARN) into podman.StartUnit on a
+	// unit that was never written, surfacing a confusing podman error
+	// behind the original WARN.
+	if ok, reason := workerSupportedOnPlatform(w); !ok {
+		fmt.Printf("[WARN] worker %s skipped: %s\n", workerName, reason)
+		return nil
+	}
+
+	// Stop conflicting workers before starting. Match the new worker's
+	// path so a per-worktree start tears down only the same worktree's
+	// conflicting unit and doesn't touch the parent's.
 	for _, conflict := range w.ConflictsWith {
-		WorkerStopForSite(siteName, conflict) //nolint:errcheck
+		WorkerStopForSite(siteName, sitePath, conflict) //nolint:errcheck
 	}
 
 	command := w.Command
@@ -240,27 +252,12 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 		command = command + " --port=" + port
 	}
 
-	// Workers exec into the container that hosts the site's runtime:
-	//   - custom container sites → lerd-custom-<site>
-	//   - FrankenPHP sites       → lerd-fp-<site>
-	//   - shared FPM sites       → lerd-php<version>-fpm
-	var fpmUnit string
-	switch site, _ := config.FindSite(siteName); {
-	case site != nil && site.IsCustomContainer():
-		fpmUnit = podman.CustomContainerName(siteName)
-	case site != nil && site.IsFrankenPHP():
-		fpmUnit = podman.FrankenPHPContainerName(siteName)
-	default:
-		versionShort := strings.ReplaceAll(phpVersion, ".", "")
-		fpmUnit = "lerd-php" + versionShort + "-fpm"
-	}
-	unitName := "lerd-" + workerName + "-" + siteName
-	unitSiteName := siteName
-	if s, _ := config.FindSite(siteName); s != nil && s.Path != sitePath {
-		wtDir := filepath.Base(sitePath)
-		unitName = "lerd-" + workerName + "-" + siteName + "-" + wtDir
-		unitSiteName = siteName + "/" + wtDir
-	}
+	// Workers exec into the container that hosts the site's runtime —
+	// custom container, FrankenPHP, or shared FPM. resolveWorkerFPMUnit
+	// owns the per-runtime mapping; restoreWorker / writeWorkerExecUnit
+	// share the same helper.
+	fpmUnit := resolveWorkerFPMUnit(siteName, phpVersion)
+	unitName, unitSiteName := workerNames(siteName, sitePath, workerName)
 
 	restart := w.Restart
 	if restart == "" {
@@ -441,7 +438,7 @@ func newWorkerRemoveCmd() *cobra.Command {
 			// Stop the worker if running.
 			unitName := "lerd-" + name + "-" + site.Name
 			if isServiceActiveOrRestarting(unitName) {
-				_ = WorkerStopForSite(site.Name, name)
+				_ = WorkerStopForSite(site.Name, site.Path, name)
 			}
 
 			if global {
@@ -488,16 +485,72 @@ func siteFrameworkName(siteName string) string {
 	return site.Framework
 }
 
-// WorkerStopForSite stops and removes the named worker unit for the given site.
-func WorkerStopForSite(siteName, workerName string) error {
-	unitName := "lerd-" + workerName + "-" + siteName
+// workerNames returns the systemd unit name and the human-readable display
+// site for the given (siteName, sitePath, workerName). When sitePath is a
+// worktree under the parent site, both values carry a "-<wtBase>" /
+// "/<wtBase>" suffix so per-worktree units don't collide with the parent's
+// and CLI output can tell them apart. Single config.FindSite call serves
+// both shapes — formerly two helpers each looked up independently.
+func workerNames(siteName, sitePath, workerName string) (unit, display string) {
+	unit = "lerd-" + workerName + "-" + siteName
+	display = siteName
+	if siteName == "" || workerName == "" || sitePath == "" {
+		return unit, display
+	}
+	s, _ := config.FindSite(siteName)
+	if s == nil || s.Path == "" || s.Path == sitePath {
+		return unit, display
+	}
+	wtBase := filepath.Base(sitePath)
+	return unit + "-" + wtBase, display + "/" + wtBase
+}
 
-	// Stop and disable both possible shapes (daemon .service and
-	// scheduled .timer + oneshot .service). We don't know up-front
-	// whether the worker was scheduled, and the framework yaml may
-	// have flipped between the two shapes since the unit was written,
-	// so we tear down both unconditionally — missing units are no-ops
-	// at this layer.
+// workerUnitName is a thin wrapper around workerNames for callers that only
+// need the unit name (legacy callers, mostly).
+func workerUnitName(siteName, sitePath, workerName string) string {
+	unit, _ := workerNames(siteName, sitePath, workerName)
+	return unit
+}
+
+// resolveWorkerFPMUnit returns the container name that workers for siteName
+// should `podman exec` into. Three cases:
+//
+//   - custom container site → its own dedicated container
+//   - FrankenPHP site       → its dunglas/frankenphp container
+//   - everything else       → shared lerd-php<v>-fpm
+//
+// Centralised here because restoreWorker (linux + darwin) and the macOS
+// writeWorker* helpers used to repeat the resolution and missed the
+// FrankenPHP branch — workers on FrankenPHP sites ended up exec'ing into
+// the shared FPM container that doesn't run their PHP at all.
+func resolveWorkerFPMUnit(siteName, phpVersion string) string {
+	if site, _ := config.FindSite(siteName); site != nil {
+		switch {
+		case site.IsCustomContainer():
+			return podman.CustomContainerName(siteName)
+		case site.IsFrankenPHP():
+			return podman.FrankenPHPContainerName(siteName)
+		}
+	}
+	return "lerd-php" + strings.ReplaceAll(phpVersion, ".", "") + "-fpm"
+}
+
+// WorkerStopForSite stops and removes the named worker unit for the given site.
+// When sitePath is a path under a worktree (i.e. differs from the registered
+// site path), the per-worktree unit is targeted instead of the parent's.
+// Pass site.Path (or any path on the parent site) to stop the parent unit.
+func WorkerStopForSite(siteName, sitePath, workerName string) error {
+	unitName, displaySite := workerNames(siteName, sitePath, workerName)
+	return stopWorkerUnit(unitName, workerName, displaySite)
+}
+
+// stopWorkerUnit tears down a fully-qualified unit name. Used by both the
+// per-site stop entry point and the worktree-removal cleanup pass. Disable
+// + Stop + RemoveTimerUnit + RemoveServiceUnit are run unconditionally so
+// the call works regardless of whether the worker was scheduled (.timer +
+// oneshot .service) or a long-running daemon (.service alone). Missing
+// units are no-ops at this layer.
+func stopWorkerUnit(unitName, label, displaySite string) error {
 	_ = services.Mgr.Disable(unitName + ".timer")
 	podman.StopUnit(unitName + ".timer") //nolint:errcheck
 	_ = services.Mgr.Disable(unitName)
@@ -517,9 +570,47 @@ func WorkerStopForSite(siteName, workerName string) error {
 		fmt.Printf("[WARN] daemon-reload: %v\n", err)
 	}
 
-	label := workerName
-	fmt.Printf("%s stopped for %s\n", label, siteName)
+	if label == "" {
+		label = unitName
+	}
+	if displaySite == "" {
+		displaySite = unitName
+	}
+	fmt.Printf("%s stopped for %s\n", label, displaySite)
 	return nil
+}
+
+// StopAllWorkersForWorktree stops every per-worktree worker unit attached
+// to the given (site, worktree) pair. Called from `lerd worktree remove`
+// and from the watcher's onRemoved hook so units don't restart-loop
+// against a deleted WorkingDirectory after the user tears down a worktree.
+// Returns the first underlying error so the caller can log it; siblings
+// keep being torn down regardless.
+func StopAllWorkersForWorktree(siteName, wtBase string) error {
+	if siteName == "" || wtBase == "" {
+		return nil
+	}
+	suffix := "-" + siteName + "-" + wtBase
+	pattern := "lerd-*" + suffix
+	units := services.Mgr.ListServiceUnits(pattern)
+	displaySite := siteName + "/" + wtBase
+	var firstErr error
+	for _, unit := range units {
+		// Defensive trim: globs can theoretically return false positives
+		// or the mgr may widen the result set. Skip anything that doesn't
+		// actually end in our suffix.
+		if !strings.HasSuffix(unit, suffix) {
+			continue
+		}
+		workerName := strings.TrimSuffix(strings.TrimPrefix(unit, "lerd-"), suffix)
+		if workerName == "" {
+			continue
+		}
+		if err := stopWorkerUnit(unit, workerName, displaySite); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 // isServiceActiveOrRestarting returns true if the unit is active or activating.

--- a/internal/cli/worker_darwin.go
+++ b/internal/cli/worker_darwin.go
@@ -61,16 +61,12 @@ func writeWorkerExecUnit(unitName, siteName, sitePath, phpVersion, command, rest
 	scriptPath := filepath.Join(workersDir, unitName+".sh")
 	pidFile := filepath.Join(workersDir, unitName+".pid")
 
-	// Resolve the container to exec into: custom site → its own container,
-	// PHP site → shared FPM for that version.
-	var container string
-	if site, _ := config.FindSite(siteName); site != nil && site.IsCustomContainer() {
-		container = podman.CustomContainerName(siteName)
-	} else {
-		versionShort := strings.ReplaceAll(phpVersion, ".", "")
-		container = "lerd-php" + versionShort + "-fpm"
-		_ = fpmUnit // kept for API parity with the Linux implementation
-	}
+	// Resolve the container to exec into via the shared helper, which
+	// handles custom container + FrankenPHP + default shared FPM. fpmUnit
+	// is the same value the Linux backend sets via BindsTo=, kept on the
+	// signature for API parity.
+	_ = fpmUnit
+	container := resolveWorkerFPMUnit(siteName, phpVersion)
 
 	podmanExec := fmt.Sprintf("%s exec -w %s %s %s", podman.PodmanBin(), sitePath, container, command)
 	script := buildDarwinExecWorkerGuardScript(pidFile, podman.PodmanBin(), container, sitePath, command, podmanExec)
@@ -148,14 +144,8 @@ func removeWorkerExecArtifacts(unitName string) {
 // phase 2 of runStart so we don't saturate the Podman Machine SSH connection
 // before containers are ready.
 func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.FrameworkWorker) {
-	var fpmUnit string
-	if site, _ := config.FindSite(siteName); site != nil && site.IsCustomContainer() {
-		fpmUnit = podman.CustomContainerName(siteName)
-	} else {
-		versionShort := strings.ReplaceAll(phpVersion, ".", "")
-		fpmUnit = "lerd-php" + versionShort + "-fpm"
-	}
-	unitName := "lerd-" + workerName + "-" + siteName
+	fpmUnit := resolveWorkerFPMUnit(siteName, phpVersion)
+	unitName, displaySite := workerNames(siteName, sitePath, workerName)
 	restart := w.Restart
 	if restart == "" {
 		restart = "always"
@@ -164,5 +154,5 @@ func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.F
 	if label == "" {
 		label = workerName
 	}
-	writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, w.Command, restart, w.Schedule, fpmUnit, w.Host) //nolint:errcheck
+	writeWorkerUnitFile(unitName, label, displaySite, sitePath, phpVersion, w.Command, restart, w.Schedule, fpmUnit, w.Host) //nolint:errcheck
 }

--- a/internal/cli/worker_host_linux_test.go
+++ b/internal/cli/worker_host_linux_test.go
@@ -96,6 +96,79 @@ func TestWriteWorkerUnitFile_hostFalse_usesPodman(t *testing.T) {
 	}
 }
 
+// TestWriteHostWorkerUnitFile_shellCommandPreserved pins the fix for the
+// raw-ExecStart bug: framework worker commands containing shell
+// metacharacters (&&, |, env-var expansion, redirects) must be wrapped in
+// /bin/sh -c so systemd's argv-style splitting doesn't pass them as
+// literal arguments to fnm. Without the wrap, "npm run build && npm run
+// preview" would invoke fnm with "&&" as an argument and silently fail.
+func TestWriteHostWorkerUnitFile_shellCommandPreserved(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	binDir := filepath.Join(tmp, "lerd", "bin")
+	os.MkdirAll(binDir, 0755)
+	os.WriteFile(filepath.Join(binDir, "fnm"), []byte("#!/bin/sh"), 0755)
+
+	sitePath := t.TempDir()
+	os.WriteFile(filepath.Join(sitePath, ".node-version"), []byte("20"), 0644)
+
+	cases := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{
+			name:    "simple command works as before",
+			command: "npm run dev",
+			want:    "npm run dev",
+		},
+		{
+			name:    "command with && passes through to shell",
+			command: "npm run build && npm run preview",
+			want:    "npm run build && npm run preview",
+		},
+		{
+			name:    "command with pipe",
+			command: "tail -f log | grep error",
+			want:    "tail -f log | grep error",
+		},
+		{
+			name:    "command with single quote escapes safely",
+			command: "echo 'hello world'",
+			want:    "echo",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			os.RemoveAll(filepath.Join(tmp, "systemd"))
+			_, err := writeWorkerUnitFile(
+				"lerd-vite-shellcase", "Test", "shellcase",
+				sitePath, "8.4", c.command,
+				"on-failure", "", "lerd-php84-fpm", true,
+			)
+			if err != nil {
+				t.Fatalf("writeWorkerUnitFile: %v", err)
+			}
+			data, err := os.ReadFile(filepath.Join(tmp, "systemd", "user", "lerd-vite-shellcase.service"))
+			if err != nil {
+				t.Fatalf("read unit: %v", err)
+			}
+			unit := string(data)
+			// ExecStart must invoke /bin/sh -c with the raw command so
+			// shell metacharacters work. Verify the wrapper presence
+			// and that the command substring survives.
+			if !strings.Contains(unit, "/bin/sh -c") && !strings.Contains(unit, "/bin/sh' -c") {
+				t.Errorf("ExecStart should wrap in /bin/sh -c for shell parsing; got:\n%s", unit)
+			}
+			if !strings.Contains(unit, c.want) {
+				t.Errorf("command substring %q missing from unit:\n%s", c.want, unit)
+			}
+		})
+	}
+}
+
 func TestWorkerStartForSite_worktreeUnitNaming(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -110,6 +110,15 @@ func writeHostWorkerUnitFile(unitName, label, siteName, sitePath, command, resta
 		}
 	}
 
+	// Wrap the framework worker command in /bin/sh -c so shell features
+	// (&&, |, env-var expansion, redirects) work. systemd's ExecStart
+	// performs argv-style splitting on whitespace and execve's the result
+	// directly — without the wrapper, `npm run build && npm run preview`
+	// passes "&&" to fnm as a literal argument and silently fails. Single
+	// quotes inside the command are escaped via the standard '"'"' idiom
+	// so the wrapper survives any user-provided string verbatim.
+	shellCommand := fmt.Sprintf("%s exec --using=%s -- %s", fnm, nodeVersion, command)
+	escaped := strings.ReplaceAll(shellCommand, "'", `'"'"'`)
 	unit := fmt.Sprintf(`[Unit]
 Description=Lerd %s (%s)
 
@@ -119,11 +128,11 @@ Restart=%s
 RestartSec=5
 WorkingDirectory=%s
 SuccessExitStatus=1 130 143
-ExecStart=%s exec --using=%s -- %s
+ExecStart=/bin/sh -c '%s'
 
 [Install]
 WantedBy=default.target
-`, label, siteName, restart, sitePath, fnm, nodeVersion, command)
+`, label, siteName, restart, sitePath, escaped)
 
 	_ = services.Mgr.RemoveTimerUnit(unitName)
 	return services.Mgr.WriteServiceUnitIfChanged(unitName, unit)
@@ -151,14 +160,8 @@ func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.F
 		command = command + " --port=" + port
 	}
 
-	var fpmUnit string
-	if site, _ := config.FindSite(siteName); site != nil && site.IsCustomContainer() {
-		fpmUnit = podman.CustomContainerName(siteName)
-	} else {
-		versionShort := strings.ReplaceAll(phpVersion, ".", "")
-		fpmUnit = "lerd-php" + versionShort + "-fpm"
-	}
-	unitName := "lerd-" + workerName + "-" + siteName
+	fpmUnit := resolveWorkerFPMUnit(siteName, phpVersion)
+	unitName, displaySite := workerNames(siteName, sitePath, workerName)
 
 	restart := w.Restart
 	if restart == "" {
@@ -169,7 +172,7 @@ func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.F
 		label = workerName
 	}
 
-	changed, err := writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, command, restart, w.Schedule, fpmUnit, w.Host)
+	changed, err := writeWorkerUnitFile(unitName, label, displaySite, sitePath, phpVersion, command, restart, w.Schedule, fpmUnit, w.Host)
 	if err != nil {
 		fmt.Printf("[WARN] writing worker unit %s: %v\n", unitName, err)
 		return

--- a/internal/cli/worker_migrate_darwin.go
+++ b/internal/cli/worker_migrate_darwin.go
@@ -5,9 +5,11 @@ package cli
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
 )
@@ -243,7 +245,7 @@ func restartWorkerByUnitName(unit string) error {
 	// hyphens ("custom-worker-mysite") while site names should not
 	// contain hyphens within the short registry form, but we match
 	// "<kind>-<siteName>" by matching the site name first.
-	kind, siteName, ok := splitWorkerUnit(rest)
+	kind, siteName, wtBase, ok := splitWorkerUnit(rest)
 	if !ok {
 		return fmt.Errorf("could not parse worker unit %q", unit)
 	}
@@ -259,24 +261,22 @@ func restartWorkerByUnitName(unit string) error {
 	if !ok {
 		return fmt.Errorf("worker %q not defined for framework %q", kind, fw.Label)
 	}
-	return WorkerStartForSite(siteName, site.Path, site.PHPVersion, kind, worker, true)
-}
-
-// splitWorkerUnit splits "<kind>-<siteName>" into (kind, siteName, ok).
-// Uses config.LoadSites to find a matching site, so kinds with hyphens
-// (e.g. "laravel-reverb") work as long as the site name itself is a
-// registered site.
-func splitWorkerUnit(rest string) (kind, siteName string, ok bool) {
-	reg, err := config.LoadSites()
-	if err != nil || reg == nil {
-		return "", "", false
-	}
-	for _, s := range reg.Sites {
-		suffix := "-" + s.Name
-		if strings.HasSuffix(rest, suffix) {
-			kind = strings.TrimSuffix(rest, suffix)
-			return kind, s.Name, kind != ""
+	// Preserve the worktree dimension on restart: a unit named
+	// lerd-vite-mysite-feat-x must be brought back at the worktree path,
+	// not the parent's, otherwise the migration silently rebinds the
+	// per-worktree unit to the parent's WorkingDirectory.
+	startPath := site.Path
+	startPHP := site.PHPVersion
+	if wtBase != "" {
+		if wts, derr := gitpkg.DetectWorktrees(site.Path, site.PrimaryDomain()); derr == nil {
+			for _, wt := range wts {
+				if filepath.Base(wt.Path) == wtBase {
+					startPath = wt.Path
+					startPHP = config.WorktreePHPVersion(wt.Path, site.PHPVersion)
+					break
+				}
+			}
 		}
 	}
-	return "", "", false
+	return WorkerStartForSite(siteName, startPath, startPHP, kind, worker, true)
 }

--- a/internal/cli/worker_resolve_test.go
+++ b/internal/cli/worker_resolve_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// TestResolveWorkerFPMUnit_defaultSharedFPM pins the default case: a plain
+// PHP-FPM site resolves to the shared lerd-php<v>-fpm container regardless
+// of platform.
+func TestResolveWorkerFPMUnit_defaultSharedFPM(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := config.AddSite(config.Site{
+		Name: "alpha", Path: filepath.Join(tmp, "alpha"),
+		Domains: []string{"alpha.test"}, PHPVersion: "8.4",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveWorkerFPMUnit("alpha", "8.4"); got != "lerd-php84-fpm" {
+		t.Errorf("got %q, want lerd-php84-fpm", got)
+	}
+}
+
+// TestResolveWorkerFPMUnit_customContainer pins the per-project custom
+// container path so workers exec into the site's own container instead of
+// the shared FPM.
+func TestResolveWorkerFPMUnit_customContainer(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := config.AddSite(config.Site{
+		Name: "beta", Path: filepath.Join(tmp, "beta"),
+		Domains: []string{"beta.test"}, ContainerPort: 8080,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := resolveWorkerFPMUnit("beta", "8.4")
+	if got == "lerd-php84-fpm" {
+		t.Errorf("expected custom container name, got shared FPM %q", got)
+	}
+	// Just sanity-check the prefix; podman.CustomContainerName owns the format.
+	if got == "" {
+		t.Error("got empty container name for custom container site")
+	}
+}
+
+// TestResolveWorkerFPMUnit_frankenPHP regression-pins the FrankenPHP
+// branch that restoreWorker (linux + darwin) and writeWorkerExecUnit
+// (darwin) used to miss: they hard-coded the shared FPM, so FrankenPHP
+// sites' workers ended up exec'ing into a container that doesn't run their
+// PHP. The shared helper now routes FrankenPHP sites to their own FrankenPHP
+// container.
+func TestResolveWorkerFPMUnit_frankenPHP(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := config.AddSite(config.Site{
+		Name: "gamma", Path: filepath.Join(tmp, "gamma"),
+		Domains: []string{"gamma.test"}, PHPVersion: "8.4", Runtime: "frankenphp",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := resolveWorkerFPMUnit("gamma", "8.4")
+	if got == "lerd-php84-fpm" {
+		t.Errorf("expected FrankenPHP container, got shared FPM %q", got)
+	}
+	if got == "" {
+		t.Error("got empty container name for FrankenPHP site")
+	}
+}
+
+// TestResolveWorkerFPMUnit_unknownSite falls back to the shared FPM. This
+// preserves prior behaviour of the inline FPM resolution in WorkerStartForSite,
+// which served as the safe default when the site lookup races site removal.
+func TestResolveWorkerFPMUnit_unknownSite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if got := resolveWorkerFPMUnit("noexist", "8.3"); got != "lerd-php83-fpm" {
+		t.Errorf("got %q, want lerd-php83-fpm", got)
+	}
+}
+
+// TestWorkerNames_singleLookup pins that the unified helper returns both
+// the unit name and the display string in one config.FindSite call. Pre-
+// refactor `workerUnitName` and `workerDisplaySite` each looked up the
+// site independently — same answer, twice the lookup.
+func TestWorkerNames_parentPath(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	unit, display := workerNames("ws", "/p/ws", "vite")
+	if unit != "lerd-vite-ws" {
+		t.Errorf("unit = %q, want lerd-vite-ws", unit)
+	}
+	if display != "ws" {
+		t.Errorf("display = %q, want ws", display)
+	}
+}
+
+func TestWorkerNames_worktreePath(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	unit, display := workerNames("ws", "/p/ws/feat-x", "vite")
+	if unit != "lerd-vite-ws-feat-x" {
+		t.Errorf("unit = %q, want lerd-vite-ws-feat-x", unit)
+	}
+	if display != "ws/feat-x" {
+		t.Errorf("display = %q, want ws/feat-x", display)
+	}
+}
+
+func TestWorkerNames_emptyPath(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	unit, display := workerNames("ws", "", "vite")
+	if unit != "lerd-vite-ws" || display != "ws" {
+		t.Errorf("got (%q,%q), want (lerd-vite-ws, ws)", unit, display)
+	}
+}

--- a/internal/cli/worker_stop_worktree_test.go
+++ b/internal/cli/worker_stop_worktree_test.go
@@ -1,0 +1,253 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// stopTrackingMgr extends fakeServiceMgr with call tracking for the stop /
+// disable / remove paths exercised by WorkerStopForSite + StopAllWorkersForWorktree.
+type stopTrackingMgr struct {
+	fakeServiceMgr
+	disableCalls       []string
+	removeServiceCalls []string
+	removeTimerCalls   []string
+	listResults        map[string][]string
+}
+
+func (s *stopTrackingMgr) Disable(name string) error {
+	s.disableCalls = append(s.disableCalls, name)
+	return nil
+}
+func (s *stopTrackingMgr) RemoveServiceUnit(name string) error {
+	s.removeServiceCalls = append(s.removeServiceCalls, name)
+	return nil
+}
+func (s *stopTrackingMgr) RemoveTimerUnit(name string) error {
+	s.removeTimerCalls = append(s.removeTimerCalls, name)
+	return nil
+}
+func (s *stopTrackingMgr) ListServiceUnits(pattern string) []string {
+	if s.listResults == nil {
+		return nil
+	}
+	if out, ok := s.listResults[pattern]; ok {
+		return out
+	}
+	// Allow callers to register a single canonical glob. If lerd ever
+	// passes a different pattern we'd fail to match, surfacing a real bug
+	// rather than silently returning empty.
+	for _, v := range s.listResults {
+		return v
+	}
+	return nil
+}
+
+// registerSite writes a sites.yaml so config.FindSite resolves the parent
+// path used by workerUnitName / workerDisplaySite.
+func registerSite(t *testing.T, name, path string) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	dir := filepath.Join(tmp, "lerd")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "sites:\n" +
+		"    - name: " + name + "\n" +
+		"      domains:\n" +
+		"        - " + name + ".test\n" +
+		"      path: " + path + "\n" +
+		"      php_version: \"8.4\"\n" +
+		"      node_version: \"22\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "sites.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Sanity check.
+	if _, err := config.FindSite(name); err != nil {
+		t.Fatalf("FindSite(%q): %v", name, err)
+	}
+}
+
+// TestWorkerUnitName_parentPath pins that the parent unit name has no
+// worktree suffix when sitePath equals the registered site path.
+func TestWorkerUnitName_parentPath(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	got := workerUnitName("ws", "/p/ws", "vite")
+	if got != "lerd-vite-ws" {
+		t.Errorf("got %q, want %q", got, "lerd-vite-ws")
+	}
+}
+
+// TestWorkerUnitName_worktreePath pins that worktree paths produce the
+// suffixed unit name format used by per-worktree worker units.
+func TestWorkerUnitName_worktreePath(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	got := workerUnitName("ws", "/p/ws/feat-x", "vite")
+	if got != "lerd-vite-ws-feat-x" {
+		t.Errorf("got %q, want %q", got, "lerd-vite-ws-feat-x")
+	}
+}
+
+// TestWorkerUnitName_emptyPath is the safe fallback: callers that don't
+// know the path get the parent unit name, matching pre-refactor behaviour.
+func TestWorkerUnitName_emptyPath(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	got := workerUnitName("ws", "", "vite")
+	if got != "lerd-vite-ws" {
+		t.Errorf("got %q, want %q", got, "lerd-vite-ws")
+	}
+}
+
+// TestStopAllWorkersForWorktree pins that every per-worktree unit attached
+// to the given (site, worktree) pair is disabled and its unit file removed,
+// while parent-site units and other-worktree units are left alone. This is
+// the regression that #319 left behind: lerd worktree remove never stopped
+// these units, so they restart-looped against a deleted WorkingDirectory.
+func TestStopAllWorkersForWorktree(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	fake := &stopTrackingMgr{
+		listResults: map[string][]string{
+			"lerd-*-ws-feat-x": {
+				"lerd-vite-ws-feat-x",
+				"lerd-queue-ws-feat-x",
+			},
+		},
+	}
+	swapMgr(t, fake)
+
+	if err := StopAllWorkersForWorktree("ws", "feat-x"); err != nil {
+		t.Fatalf("StopAllWorkersForWorktree: %v", err)
+	}
+
+	gotRemoved := append([]string(nil), fake.removeServiceCalls...)
+	sort.Strings(gotRemoved)
+	wantRemoved := []string{"lerd-queue-ws-feat-x", "lerd-vite-ws-feat-x"}
+	if !equalStrings(gotRemoved, wantRemoved) {
+		t.Errorf("removeServiceCalls = %v, want %v", gotRemoved, wantRemoved)
+	}
+	for _, want := range wantRemoved {
+		found := false
+		for _, got := range fake.disableCalls {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected Disable(%q) but did not see it in %v", want, fake.disableCalls)
+		}
+	}
+}
+
+// TestStopAllWorkersForWorktree_noUnits is a no-op when nothing matches.
+// Important so the worktree-remove path doesn't fail loudly when the user
+// never opted into any host workers.
+func TestStopAllWorkersForWorktree_noUnits(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	fake := &stopTrackingMgr{listResults: map[string][]string{}}
+	swapMgr(t, fake)
+
+	if err := StopAllWorkersForWorktree("ws", "feat-x"); err != nil {
+		t.Fatalf("expected nil for no matching units, got %v", err)
+	}
+	if len(fake.removeServiceCalls) != 0 {
+		t.Errorf("unexpected RemoveServiceUnit calls: %v", fake.removeServiceCalls)
+	}
+}
+
+// TestStopAllWorkersForWorktree_emptyArgs guards against a glob that would
+// match every parent-site unit (`lerd-*--`) or every unit whatsoever.
+func TestStopAllWorkersForWorktree_emptyArgs(t *testing.T) {
+	fake := &stopTrackingMgr{listResults: map[string][]string{
+		"shouldNotBeQueried": {"lerd-vite-ws"},
+	}}
+	swapMgr(t, fake)
+
+	if err := StopAllWorkersForWorktree("", ""); err != nil {
+		t.Fatalf("empty args should be no-op, got %v", err)
+	}
+	if err := StopAllWorkersForWorktree("ws", ""); err != nil {
+		t.Fatalf("empty wtBase should be no-op, got %v", err)
+	}
+	if err := StopAllWorkersForWorktree("", "feat"); err != nil {
+		t.Fatalf("empty siteName should be no-op, got %v", err)
+	}
+	if len(fake.removeServiceCalls) != 0 {
+		t.Errorf("expected zero removals, got %v", fake.removeServiceCalls)
+	}
+}
+
+// TestStopAllWorkersForWorktree_filtersSpuriousMatches guards the suffix
+// match: a glob like lerd-*-ws-feat-x can theoretically match a unit that
+// happens to *contain* the suffix mid-string. Defensive trimming is what
+// keeps the operation safe if Mgr returns unexpected results.
+func TestStopAllWorkersForWorktree_filtersSpuriousMatches(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	fake := &stopTrackingMgr{
+		listResults: map[string][]string{
+			"lerd-*-ws-feat-x": {
+				"lerd-vite-ws-feat-x",
+				"lerd-vite-ws", // parent unit, should not be touched
+			},
+		},
+	}
+	swapMgr(t, fake)
+
+	if err := StopAllWorkersForWorktree("ws", "feat-x"); err != nil {
+		t.Fatalf("StopAllWorkersForWorktree: %v", err)
+	}
+
+	for _, removed := range fake.removeServiceCalls {
+		if !strings.HasSuffix(removed, "-ws-feat-x") {
+			t.Errorf("removed parent or unrelated unit: %q", removed)
+		}
+	}
+}
+
+// TestStopAllWorkersForWorktree_propagatesError returns the first underlying
+// error so the caller can log it but keeps tearing down siblings — a single
+// broken unit shouldn't block the rest of the cleanup.
+func TestStopAllWorkersForWorktree_propagatesError(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	fake := &errOnRemoveMgr{
+		stopTrackingMgr: stopTrackingMgr{
+			listResults: map[string][]string{
+				"lerd-*-ws-feat-x": {
+					"lerd-vite-ws-feat-x",
+					"lerd-queue-ws-feat-x",
+				},
+			},
+		},
+	}
+	swapMgr(t, fake)
+
+	err := StopAllWorkersForWorktree("ws", "feat-x")
+	if err == nil {
+		t.Fatal("expected a non-nil error from RemoveServiceUnit failure")
+	}
+	if !errors.Is(err, errFakeRemove) && !strings.Contains(err.Error(), "fake remove") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Both units should still have been attempted.
+	if len(fake.removeServiceCalls) != 2 {
+		t.Errorf("expected both removals to be attempted, got %v", fake.removeServiceCalls)
+	}
+}
+
+var errFakeRemove = errors.New("fake remove")
+
+type errOnRemoveMgr struct {
+	stopTrackingMgr
+}
+
+func (e *errOnRemoveMgr) RemoveServiceUnit(name string) error {
+	e.removeServiceCalls = append(e.removeServiceCalls, name)
+	return errFakeRemove
+}

--- a/internal/cli/worker_support_darwin.go
+++ b/internal/cli/worker_support_darwin.go
@@ -1,0 +1,26 @@
+//go:build darwin
+
+package cli
+
+import "github.com/geodro/lerd/internal/config"
+
+// workerSupportedOnPlatform reports whether the given worker can run on the
+// current host. Two shapes lack a macOS path today:
+//
+//   - host: true → would need a launchd plist that runs through fnm on the
+//     host instead of `podman exec` into the FPM container.
+//   - schedule != "" → launchd has StartCalendarInterval but the unit
+//     translation hasn't been wired through services.Mgr yet.
+//
+// Returning false here makes WorkerStartForSite skip the lifecycle calls
+// entirely instead of writing nothing and then trying to StartUnit on a
+// unit that was never written.
+var workerSupportedOnPlatform = func(w config.FrameworkWorker) (bool, string) {
+	if w.Host {
+		return false, "host: true workers aren't supported on macOS yet — run the command manually from the project root"
+	}
+	if w.Schedule != "" {
+		return false, "scheduled workers aren't supported on macOS yet"
+	}
+	return true, ""
+}

--- a/internal/cli/worker_support_linux.go
+++ b/internal/cli/worker_support_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package cli
+
+import "github.com/geodro/lerd/internal/config"
+
+// workerSupportedOnPlatform reports whether the given worker can run on the
+// current host. Linux supports every shape — host workers go through fnm +
+// systemd user units; scheduled workers via .timer + Type=oneshot — so the
+// gate is unconditionally permissive.
+//
+// This is a package var (not a function) so tests can substitute it to
+// exercise the unsupported path without a darwin build. The macOS build
+// installs the real darwin variant in worker_support_darwin.go.
+var workerSupportedOnPlatform = func(_ config.FrameworkWorker) (bool, string) {
+	return true, ""
+}

--- a/internal/cli/worker_support_linux_test.go
+++ b/internal/cli/worker_support_linux_test.go
@@ -1,0 +1,30 @@
+//go:build linux
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// TestWorkerSupportedOnPlatform_linuxAlwaysOK pins that Linux supports
+// every worker shape: host, scheduled, both. The platform gate exists
+// only for macOS where launchd doesn't yet have parity for these.
+func TestWorkerSupportedOnPlatform_linuxAlwaysOK(t *testing.T) {
+	cases := []config.FrameworkWorker{
+		{Command: "true"},
+		{Command: "true", Host: true},
+		{Command: "true", Schedule: "*-*-* 03:00:00"},
+		{Command: "true", Host: true, Schedule: "@daily"},
+	}
+	for i, w := range cases {
+		ok, reason := workerSupportedOnPlatform(w)
+		if !ok {
+			t.Errorf("case %d (%+v): unexpected unsupported, reason=%q", i, w, reason)
+		}
+		if reason != "" {
+			t.Errorf("case %d: unexpected non-empty reason %q", i, reason)
+		}
+	}
+}

--- a/internal/cli/worker_support_test.go
+++ b/internal/cli/worker_support_test.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// TestWorkerStartForSite_skipsLifecycleWhenUnsupported pins the contract
+// fixed in this round: when workerSupportedOnPlatform reports the worker
+// can't run on this platform, WorkerStartForSite must return nil without
+// calling Enable/StartUnit. On macOS the prior behaviour was to print a
+// WARN, return (false, nil) from writeWorkerUnitFile, then proceed to
+// StartUnit on a non-existent unit — producing a confusing podman error
+// after the WARN.
+func TestWorkerStartForSite_skipsLifecycleWhenUnsupported(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	fake := &stopTrackingMgr{}
+	swapMgr(t, fake)
+
+	prev := workerSupportedOnPlatform
+	workerSupportedOnPlatform = func(_ config.FrameworkWorker) (bool, string) {
+		return false, "host: true workers aren't supported on macOS yet"
+	}
+	t.Cleanup(func() { workerSupportedOnPlatform = prev })
+
+	w := config.FrameworkWorker{Command: "npm run dev", Host: true}
+	if err := WorkerStartForSite("ws", "/p/ws", "8.4", "vite", w, false); err != nil {
+		t.Fatalf("expected nil error for unsupported worker, got %v", err)
+	}
+
+	if len(fake.disableCalls)+len(fake.removeServiceCalls)+len(fake.removeTimerCalls) != 0 {
+		t.Errorf("expected zero lifecycle calls, got disable=%v remove=%v removeTimer=%v",
+			fake.disableCalls, fake.removeServiceCalls, fake.removeTimerCalls)
+	}
+}
+
+// TestWorkerStartForSite_unsupportedReasonPrinted ensures the WARN line
+// surfaces the reason verbatim so users can tell *why* a worker was
+// silently skipped.
+func TestWorkerStartForSite_unsupportedReasonPrinted(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	swapMgr(t, &stopTrackingMgr{})
+
+	prev := workerSupportedOnPlatform
+	workerSupportedOnPlatform = func(_ config.FrameworkWorker) (bool, string) {
+		return false, "fake-platform-reason"
+	}
+	t.Cleanup(func() { workerSupportedOnPlatform = prev })
+
+	out := captureStdout(t, func() {
+		_ = WorkerStartForSite("ws", "/p/ws", "8.4", "vite", config.FrameworkWorker{Command: "x"}, false)
+	})
+	if !strings.Contains(out, "fake-platform-reason") {
+		t.Errorf("expected reason in WARN output, got %q", out)
+	}
+	if !strings.Contains(out, "[WARN]") {
+		t.Errorf("expected [WARN] marker in output, got %q", out)
+	}
+}

--- a/internal/cli/worker_unit_split.go
+++ b/internal/cli/worker_unit_split.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	gitpkg "github.com/geodro/lerd/internal/git"
+)
+
+// splitWorkerUnit parses the body of a worker unit name (i.e. without the
+// leading "lerd-") into (kind, siteName, wtBase). It accepts both shapes
+// the worker writers produce:
+//
+//   - parent: <kind>-<siteName>                          → wtBase = ""
+//   - worktree: <kind>-<siteName>-<wtBase>               → wtBase = "<wtBase>"
+//
+// kinds with embedded hyphens (e.g. "custom-worker") are supported by
+// matching the registered site name as the anchor. wtBase is verified
+// against the parent's live worktrees so a registered site whose name
+// happens to share a suffix with a worktree directory can't false-match.
+//
+// Lives in a non-tagged file (originally darwin-only) so the parsing logic
+// is testable on Linux CI; only the migration *machinery* is darwin-only.
+func splitWorkerUnit(rest string) (kind, siteName, wtBase string, ok bool) {
+	reg, err := config.LoadSites()
+	if err != nil || reg == nil {
+		return "", "", "", false
+	}
+	// One pass over sites: parent suffix (longest wins) and internal-
+	// token-with-worktree shape are checked in the same loop. Tracking
+	// `bestParent` lets the longest registered name win without a second
+	// scan, e.g. lerd-vite-alpha-beta resolves to site "alpha-beta" even
+	// when "alpha" is also registered.
+	bestParent := ""
+	for _, s := range reg.Sites {
+		if strings.HasSuffix(rest, "-"+s.Name) && len(s.Name) > len(bestParent) {
+			bestParent = s.Name
+		}
+	}
+	if bestParent != "" {
+		if k := strings.TrimSuffix(rest, "-"+bestParent); k != "" {
+			return k, bestParent, "", true
+		}
+	}
+	for _, s := range reg.Sites {
+		marker := "-" + s.Name + "-"
+		idx := strings.Index(rest, marker)
+		if idx <= 0 {
+			continue
+		}
+		after := rest[idx+len(marker):]
+		if after == "" {
+			continue
+		}
+		k := rest[:idx]
+		// Confirm `after` matches an actual worktree dir basename. If
+		// DetectWorktrees errors (e.g. .git/worktrees gone) accept the
+		// parse — better to retry the unit at parent path than to leave
+		// it stuck.
+		wts, derr := gitpkg.DetectWorktrees(s.Path, s.PrimaryDomain())
+		if derr != nil {
+			return k, s.Name, after, true
+		}
+		for _, wt := range wts {
+			if filepath.Base(wt.Path) == after {
+				return k, s.Name, after, true
+			}
+		}
+	}
+	return "", "", "", false
+}

--- a/internal/cli/worker_unit_split_test.go
+++ b/internal/cli/worker_unit_split_test.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// TestSplitWorkerUnit_parentUnit is the simple case the original macOS
+// migration code already handled: lerd-vite-mysite parses to (vite, mysite, "").
+func TestSplitWorkerUnit_parentUnit(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := config.AddSite(config.Site{
+		Name: "mysite", Path: filepath.Join(tmp, "mysite"), Domains: []string{"mysite.test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	kind, site, wt, ok := splitWorkerUnit("vite-mysite")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if kind != "vite" || site != "mysite" || wt != "" {
+		t.Errorf("got (%q,%q,%q), want (vite,mysite,)", kind, site, wt)
+	}
+}
+
+// TestSplitWorkerUnit_worktreeUnit pins the regression fix: a unit named
+// lerd-vite-mysite-feat-x must parse to (vite, mysite, feat-x), not get
+// mis-anchored on `feat-x` (which would happen if a stray site named
+// "feat-x" existed) or fall back to (vite-mysite, feat-x, ""). Pre-fix the
+// migrate flow ran restartWorkerByUnitName with the wrong site, corrupting
+// the worktree worker.
+func TestSplitWorkerUnit_worktreeUnit(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	sitePath := filepath.Join(tmp, "mysite")
+	if err := os.MkdirAll(sitePath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	checkout := filepath.Join(tmp, "checkouts", "feat-x")
+	if err := os.MkdirAll(checkout, 0755); err != nil {
+		t.Fatal(err)
+	}
+	wtMeta := filepath.Join(sitePath, ".git", "worktrees", "feat-x")
+	os.MkdirAll(wtMeta, 0755)
+	os.WriteFile(filepath.Join(wtMeta, "HEAD"), []byte("ref: refs/heads/feat-x\n"), 0644)
+	os.WriteFile(filepath.Join(wtMeta, "gitdir"), []byte(filepath.Join(checkout, ".git")+"\n"), 0644)
+
+	if err := config.AddSite(config.Site{
+		Name: "mysite", Path: sitePath, Domains: []string{"mysite.test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	kind, site, wt, ok := splitWorkerUnit("vite-mysite-feat-x")
+	if !ok {
+		t.Fatal("expected ok=true for worktree unit name")
+	}
+	if kind != "vite" || site != "mysite" || wt != "feat-x" {
+		t.Errorf("got (%q,%q,%q), want (vite,mysite,feat-x)", kind, site, wt)
+	}
+}
+
+// TestSplitWorkerUnit_hyphenatedKind_parent ensures kinds containing
+// hyphens (e.g. custom framework workers like "custom-worker") still
+// resolve correctly when no worktree is present.
+func TestSplitWorkerUnit_hyphenatedKind_parent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := config.AddSite(config.Site{
+		Name: "mysite", Path: filepath.Join(tmp, "mysite"), Domains: []string{"mysite.test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	kind, site, wt, ok := splitWorkerUnit("custom-worker-mysite")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if kind != "custom-worker" || site != "mysite" || wt != "" {
+		t.Errorf("got (%q,%q,%q), want (custom-worker,mysite,)", kind, site, wt)
+	}
+}
+
+// TestSplitWorkerUnit_unknownSite returns ok=false so the caller surfaces
+// "could not parse" instead of randomly anchoring on a substring.
+func TestSplitWorkerUnit_unknownSite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if _, _, _, ok := splitWorkerUnit("vite-stranger"); ok {
+		t.Error("expected ok=false for unknown site")
+	}
+}
+
+// TestSplitWorkerUnit_longestSuffixWins guards against partial-match
+// false positives: with sites "alpha" and "alpha-beta" registered, the
+// unit lerd-vite-alpha-beta must resolve to site "alpha-beta", not site
+// "alpha" with kind "vite-alpha".
+func TestSplitWorkerUnit_longestSuffixWins(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	for _, name := range []string{"alpha", "alpha-beta"} {
+		if err := config.AddSite(config.Site{
+			Name: name, Path: filepath.Join(tmp, name), Domains: []string{name + ".test"},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	kind, site, wt, ok := splitWorkerUnit("vite-alpha-beta")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if site != "alpha-beta" || kind != "vite" || wt != "" {
+		t.Errorf("got (%q,%q,%q), want (vite,alpha-beta,)", kind, site, wt)
+	}
+}

--- a/internal/cli/worktree_add.go
+++ b/internal/cli/worktree_add.go
@@ -434,6 +434,31 @@ func OptedInBuildReplacers(site *config.Site, path string) []string {
 	return out
 }
 
+// AutoStartOptedInWorktreeWorkers writes (and starts, on Linux) every
+// host worker the user opted into via the parent's .lerd.yaml workers
+// list, scoped to the given worktree path. Idempotent — used by the
+// watcher's onAdded hook AND by the daemon's boot-time scanWorktrees pass
+// so per-worktree units survive a daemon restart cleanly. Errors are
+// surfaced as warnings so a single broken unit doesn't block siblings.
+func AutoStartOptedInWorktreeWorkers(site *config.Site, worktreePath, phpVersion string) {
+	if site == nil || worktreePath == "" {
+		return
+	}
+	for _, name := range OptedInHostWorkers(site, worktreePath) {
+		fw, ok := config.GetFrameworkForDir(site.Framework, site.Path)
+		if !ok {
+			return
+		}
+		w, ok := fw.Workers[name]
+		if !ok {
+			continue
+		}
+		if err := WorkerStartForSite(site.Name, worktreePath, phpVersion, name, w, false); err != nil {
+			fmt.Printf("[WARN] auto-start %s for worktree %s: %v\n", name, filepath.Base(worktreePath), err)
+		}
+	}
+}
+
 // OptedInHostWorkers returns the names of host-mode workers the user has
 // opted into for this project (.lerd.yaml workers:) and whose check rule
 // matches the worktree path. Worker auto-start now follows project intent

--- a/internal/cli/worktree_remove.go
+++ b/internal/cli/worktree_remove.go
@@ -50,8 +50,25 @@ func newWorktreeRemoveCmd() *cobra.Command {
 				}
 			}
 
+			// Snapshot the worktree dir basename before git removes the
+			// worktree — once the directory is gone we can't derive it
+			// reliably from the user's positional arg.
+			var wtBase string
+			if last := lastNonFlag(args); last != "" {
+				wtBase = filepath.Base(last)
+			}
+
 			if err := runGitWorktreeRemove(args); err != nil {
 				return err
+			}
+
+			// Stop any per-worktree worker units before they restart-loop
+			// against the now-deleted WorkingDirectory. Best-effort — a
+			// failure here is a warning, not a hard error.
+			if wtBase != "" {
+				if err := StopAllWorkersForWorktree(site.Name, wtBase); err != nil {
+					fmt.Printf("[WARN] stopping worktree workers: %v\n", err)
+				}
 			}
 
 			if branch != "" {
@@ -152,6 +169,17 @@ func runGitWorktreeRemove(args []string) error {
 		return fmt.Errorf("aborted")
 	}
 	return runGit(append([]string{"worktree", "remove", "--force"}, args...), true)
+}
+
+// lastNonFlag returns the trailing positional argument from a git command,
+// which is the worktree path or basename. Returns "" if every arg is a flag.
+func lastNonFlag(args []string) string {
+	for i := len(args) - 1; i >= 0; i-- {
+		if !strings.HasPrefix(args[i], "-") {
+			return args[i]
+		}
+	}
+	return ""
 }
 
 func hasForceFlag(args []string) bool {

--- a/internal/dns/repair_darwin.go
+++ b/internal/dns/repair_darwin.go
@@ -1,0 +1,21 @@
+//go:build darwin
+
+package dns
+
+import "os"
+
+// RepairPossible reports whether the DNS watcher can rewrite
+// /etc/resolver/<tld> from the current process. macOS requires root to
+// touch /etc/resolver, so the watcher relies on the passwordless sudo
+// drop-in installed by `lerd install` (renderDarwinSudoers). Without that
+// file in place every repair attempt would prompt for a password and fail
+// non-interactively, spamming the log.
+//
+// We detect "drop-in is installed" by stat'ing /etc/sudoers.d/lerd. The
+// drop-in's content is the contract; if a user manually trimmed or moved
+// it, the gate stays open and repairs will still be attempted (visudo /
+// sudoers parsers will surface the issue more usefully than this stat).
+func RepairPossible() bool {
+	_, err := os.Stat("/etc/sudoers.d/lerd")
+	return err == nil
+}

--- a/internal/dns/repair_linux.go
+++ b/internal/dns/repair_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+
+package dns
+
+// RepairPossible reports whether the DNS watcher can fix /etc/resolv.conf
+// or NetworkManager configuration from the current process. Linux's repair
+// path runs through systemd-resolved / nmcli / resolvectl and does not
+// require root for the user-scoped commands lerd issues, so this is always
+// true. Mirrors the macOS variant which gates on whether the lerd
+// passwordless-sudo drop-in is in place.
+func RepairPossible() bool { return true }

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -4,17 +4,35 @@ package envfile
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
 // ApplyUpdates rewrites the .env at path, replacing values for any key in updates.
-// Keys not already present are appended at the end. Comments and blank lines are
-// preserved. The write is skipped when the resulting contents match the existing
-// file, so dev-side watchers (vite, IDE indexers, opcache) don't see mtime churn
-// on idempotent calls. The file's existing mode is preserved.
+// Keys not already present are appended at the end in stable (sorted) order so
+// idempotent calls produce identical bytes regardless of Go's map-range
+// nondeterminism. Comments and blank lines are preserved. The write is skipped
+// when the resulting contents match the existing file, so dev-side watchers
+// (vite, IDE indexers, opcache) don't see mtime churn on idempotent calls.
+// The file's existing mode is preserved.
+//
+// Keys must not contain '=' or any newline character; values must not contain
+// newline characters. These checks reject the env_overrides injection vector
+// where a malicious .lerd.yaml value containing "\nADMIN_TOKEN=stolen" would
+// otherwise split a single .env line into two and silently introduce an
+// unrelated key.
 func ApplyUpdates(path string, updates map[string]string) error {
+	for k, v := range updates {
+		if err := validateEnvKey(k); err != nil {
+			return err
+		}
+		if err := validateEnvValue(v); err != nil {
+			return fmt.Errorf("value for %q: %w", k, err)
+		}
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -44,10 +62,21 @@ func ApplyUpdates(path string, updates map[string]string) error {
 		return err
 	}
 
-	for k, v := range updates {
+	// Stable iteration order: a Go map's range is randomised, so the first
+	// write of N new keys could produce a different byte ordering each
+	// run. Sorted append makes the output reproducible and lets the
+	// "skip if unchanged" mtime guard at the end of this function actually
+	// do its job on the second call.
+	pending := make([]string, 0, len(updates))
+	for k := range updates {
 		if applied[k] {
 			continue
 		}
+		pending = append(pending, k)
+	}
+	sort.Strings(pending)
+	for _, k := range pending {
+		v := updates[k]
 		// Look for a commented-out version to uncomment in place.
 		found := false
 		for i, line := range lines {
@@ -80,6 +109,32 @@ func ApplyUpdates(path string, updates map[string]string) error {
 		return nil
 	}
 	return os.WriteFile(path, []byte(out), info.Mode().Perm())
+}
+
+// validateEnvKey rejects keys that would corrupt .env structure if written
+// verbatim: empty keys, keys containing '=', or keys with embedded newlines.
+func validateEnvKey(k string) error {
+	if k == "" {
+		return fmt.Errorf("invalid env key: empty")
+	}
+	if strings.ContainsAny(k, "\n\r") {
+		return fmt.Errorf("invalid env key %q: contains newline", k)
+	}
+	if strings.Contains(k, "=") {
+		return fmt.Errorf("invalid env key %q: contains '='", k)
+	}
+	return nil
+}
+
+// validateEnvValue rejects values that would split a single .env line into
+// multiple lines when written. The unquoted writer used by ApplyUpdates
+// cannot represent embedded newlines safely, and surfacing the error to
+// the caller is preferable to silently injecting unrelated keys.
+func validateEnvValue(v string) error {
+	if strings.ContainsAny(v, "\n\r") {
+		return fmt.Errorf("invalid env value: contains newline")
+	}
+	return nil
 }
 
 // ReadKey returns the value of a single key from the .env file at path,

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -276,3 +276,86 @@ func TestSyncPrimaryDomain_noEnvFile_silent(t *testing.T) {
 		t.Errorf("expected no error for missing .env, got: %v", err)
 	}
 }
+
+// TestApplyUpdates_rejectsNewlineInValue pins the fix for the env-overrides
+// injection vector: a value containing \n could split a single .env line
+// into two, silently introducing an unrelated key. Refuse the write so the
+// caller surfaces a clean error instead of mutating .env in place.
+func TestApplyUpdates_rejectsNewlineInValue(t *testing.T) {
+	f := writeEnv(t, "APP_NAME=MyApp\n")
+	err := ApplyUpdates(f, map[string]string{"APP_URL": "http://x.test\nADMIN_TOKEN=stolen"})
+	if err == nil {
+		t.Fatal("expected error for value containing newline, got nil")
+	}
+	if !strings.Contains(err.Error(), "newline") && !strings.Contains(err.Error(), "invalid") {
+		t.Errorf("error should mention newline / invalid, got %v", err)
+	}
+	// .env must remain untouched.
+	got := readEnv(t, f)
+	if got != "APP_NAME=MyApp\n" {
+		t.Errorf(".env was mutated despite invalid input; got:\n%s", got)
+	}
+}
+
+// TestApplyUpdates_rejectsCarriageReturnInValue covers the same injection
+// surface using \r alone (some Windows tooling produces CR-only values).
+func TestApplyUpdates_rejectsCarriageReturnInValue(t *testing.T) {
+	f := writeEnv(t, "APP_NAME=MyApp\n")
+	err := ApplyUpdates(f, map[string]string{"FOO": "bar\rBAZ=evil"})
+	if err == nil {
+		t.Fatal("expected error for value containing CR, got nil")
+	}
+}
+
+// TestApplyUpdates_rejectsNewlineInKey defends the same surface against
+// key-side injection. ApplyUpdates also has to reject a literal '=' in the
+// key, otherwise the resulting line still parses as the wrong key.
+func TestApplyUpdates_rejectsNewlineInKey(t *testing.T) {
+	f := writeEnv(t, "APP_NAME=MyApp\n")
+	err := ApplyUpdates(f, map[string]string{"K1\nK2": "v"})
+	if err == nil {
+		t.Fatal("expected error for key containing newline, got nil")
+	}
+}
+
+// TestApplyUpdates_rejectsEqualsInKey ensures keys with '=' don't slip
+// through and corrupt the .env structure.
+func TestApplyUpdates_rejectsEqualsInKey(t *testing.T) {
+	f := writeEnv(t, "APP_NAME=MyApp\n")
+	err := ApplyUpdates(f, map[string]string{"K=hack": "v"})
+	if err == nil {
+		t.Fatal("expected error for key containing =, got nil")
+	}
+}
+
+// TestApplyUpdates_deterministicAppendOrder pins the fix for the map-range
+// nondeterminism: two runs with identical inputs against an empty .env
+// must produce identical bytes. Pre-fix the loop ranged over a Go map, so
+// the first write of N new keys produced different byte orderings each
+// run, defeating the "skip if unchanged" mtime guard on subsequent calls.
+func TestApplyUpdates_deterministicAppendOrder(t *testing.T) {
+	updates := map[string]string{
+		"ZZZ": "1",
+		"AAA": "2",
+		"MMM": "3",
+		"BBB": "4",
+		"YYY": "5",
+		"NNN": "6",
+	}
+	first := writeEnv(t, "APP_NAME=MyApp\n")
+	if err := ApplyUpdates(first, updates); err != nil {
+		t.Fatal(err)
+	}
+	firstOut := readEnv(t, first)
+
+	for i := 0; i < 10; i++ {
+		again := writeEnv(t, "APP_NAME=MyApp\n")
+		if err := ApplyUpdates(again, updates); err != nil {
+			t.Fatal(err)
+		}
+		againOut := readEnv(t, again)
+		if firstOut != againOut {
+			t.Fatalf("non-deterministic output on iteration %d:\nfirst:\n%s\nagain:\n%s", i, firstOut, againOut)
+		}
+	}
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -240,11 +240,26 @@ func EnsureWorktreeEnv(mainRepoPath, worktreePath, worktreeDomain string, secure
 
 	cfg, _ := config.LoadProjectConfig(mainRepoPath)
 	if cfg != nil && len(cfg.EnvOverrides) > 0 {
+		// {{site}}: legacy DB-safe slug of the FULL worktree domain, e.g.
+		// feat_a_acme_test. Kept for backward compatibility — new templates
+		// should prefer {{branch}} or {{parent}} which match user intent.
+		// {{branch}}: first segment of the worktree domain, e.g. "feat-a".
+		// {{parent}}: parent site name slug (DB-safe), e.g. "acme".
 		site := config.SiteSlug(worktreeDomain)
+		branch := worktreeDomain
+		if i := strings.IndexByte(worktreeDomain, '.'); i > 0 {
+			branch = worktreeDomain[:i]
+		}
+		parent := ""
+		if s, err := config.FindSiteByPath(mainRepoPath); err == nil && s != nil {
+			parent = config.SiteSlug(s.Name)
+		}
 		for k, v := range cfg.EnvOverrides {
 			v = strings.ReplaceAll(v, "{{domain}}", worktreeDomain)
 			v = strings.ReplaceAll(v, "{{scheme}}", scheme)
 			v = strings.ReplaceAll(v, "{{site}}", site)
+			v = strings.ReplaceAll(v, "{{branch}}", branch)
+			v = strings.ReplaceAll(v, "{{parent}}", parent)
 			updates[k] = v
 		}
 	}

--- a/internal/git/worktree_env_test.go
+++ b/internal/git/worktree_env_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 // EnsureWorktreeEnv must materialise .env in a fresh worktree (git worktree
@@ -114,6 +116,67 @@ func TestEnsureWorktreeEnv_siteTemplatePlaceholder(t *testing.T) {
 	}
 	if !strings.Contains(string(got), "DB_DATABASE=feat_a_acme_test") {
 		t.Errorf("{{site}} not resolved:\n%s", got)
+	}
+}
+
+// TestEnsureWorktreeEnv_branchAndParentTokens pins the new explicit
+// templating tokens that disambiguate the surprising {{site}} semantics:
+//
+//   - {{branch}}: the worktree branch slug, no parent context. Lets users
+//     write DB_DATABASE=app_{{branch}} and get app_feat_a (sane).
+//   - {{parent}}: the parent site name, slugified. Lets users write
+//     DB_PREFIX={{parent}}_ and get acme_ (matches their mental model
+//     of "this is project acme").
+//
+// {{site}} is intentionally left alone for backward compatibility — it
+// continues to resolve to the worktree FQDN slug (feat_a_acme_test).
+// Documented as such; new templates should prefer {{parent}}/{{branch}}.
+func TestEnsureWorktreeEnv_branchAndParentTokens(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	main := filepath.Join(tmp, "acme")
+	if err := os.MkdirAll(main, 0755); err != nil {
+		t.Fatal(err)
+	}
+	wt := t.TempDir()
+
+	if err := config.AddSite(config.Site{
+		Name: "acme", Path: main, Domains: []string{"acme.test"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mainEnv := "APP_URL=http://acme.test\n"
+	if err := os.WriteFile(filepath.Join(main, ".env"), []byte(mainEnv), 0644); err != nil {
+		t.Fatal(err)
+	}
+	lerdYAML := `domains:
+  - acme
+env_overrides:
+  DB_BRANCH: "{{branch}}"
+  DB_PARENT: "{{parent}}"
+  DB_NAME: "{{parent}}_{{branch}}"
+`
+	if err := os.WriteFile(filepath.Join(main, ".lerd.yaml"), []byte(lerdYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureWorktreeEnv(main, wt, "feat-a.acme.test", false)
+
+	got, err := os.ReadFile(filepath.Join(wt, ".env"))
+	if err != nil {
+		t.Fatalf("worktree .env not created: %v", err)
+	}
+	s := string(got)
+	if !strings.Contains(s, "DB_BRANCH=feat-a") {
+		t.Errorf("{{branch}} should resolve to the worktree branch slug; got:\n%s", s)
+	}
+	if !strings.Contains(s, "DB_PARENT=acme") {
+		t.Errorf("{{parent}} should resolve to the parent site primary subdomain slug; got:\n%s", s)
+	}
+	if !strings.Contains(s, "DB_NAME=acme_feat-a") {
+		t.Errorf("composite {{parent}}_{{branch}} should resolve; got:\n%s", s)
 	}
 }
 

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -301,6 +301,17 @@ func GenerateCustomSSLVhost(site config.Site) error {
 	return os.WriteFile(confPath, buf.Bytes(), 0644)
 }
 
+// GenerateWorktreeVhostFor picks GenerateWorktreeSSLVhost or GenerateWorktreeVhost
+// based on the secured flag, so callers (scanWorktrees, syncWorktree,
+// migrateWorktreeVhosts) don't repeat the if/else around the two
+// underlying generators. parentDomain is consulted only on the SSL path.
+func GenerateWorktreeVhostFor(domain, path, phpVersion, parentDomain string, secured bool) error {
+	if secured {
+		return GenerateWorktreeSSLVhost(domain, path, phpVersion, parentDomain)
+	}
+	return GenerateWorktreeVhost(domain, path, phpVersion)
+}
+
 // GenerateWorktreeVhost renders the HTTP vhost template for a worktree checkout
 // and writes it to conf.d/<domain>.conf.
 func GenerateWorktreeVhost(domain, path, phpVersion string) error {

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -225,6 +225,34 @@ func TestGenerateWorktreeSSLVhost_usesParentCert(t *testing.T) {
 	}
 }
 
+// ── GenerateWorktreeVhostFor ──────────────────────────────────────────────────
+
+// TestGenerateWorktreeVhostFor_routesByFlag pins the behaviour of the
+// shared wrapper that callers (scanWorktrees, syncWorktree, migrateTLD)
+// use to avoid repeating the secured-vs-plain branch around the two
+// underlying generators.
+func TestGenerateWorktreeVhostFor_routesByFlag(t *testing.T) {
+	confD := setupConfD(t)
+
+	if err := GenerateWorktreeVhostFor("feat-x.myapp.test", "/srv/myapp-feat", "8.3", "myapp.test", false); err != nil {
+		t.Fatalf("HTTP wrapper: %v", err)
+	}
+	httpContent := readConf(t, filepath.Join(confD, "feat-x.myapp.test.conf"))
+	if strings.Contains(httpContent, "ssl_certificate") {
+		t.Error("HTTP variant must not emit ssl_certificate")
+	}
+
+	// Re-run with secured=true; the same conf path should now point at
+	// the parent's wildcard cert.
+	if err := GenerateWorktreeVhostFor("feat-x.myapp.test", "/srv/myapp-feat", "8.3", "myapp.test", true); err != nil {
+		t.Fatalf("HTTPS wrapper: %v", err)
+	}
+	sslContent := readConf(t, filepath.Join(confD, "feat-x.myapp.test.conf"))
+	if !strings.Contains(sslContent, "myapp.test.crt") {
+		t.Errorf("HTTPS variant should reference parent cert, got:\n%s", sslContent)
+	}
+}
+
 // ── RemoveVhost ───────────────────────────────────────────────────────────────
 
 func TestRemoveVhost_removesConfAndSSLConf(t *testing.T) {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1504,7 +1504,7 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 					}
 					prefix := wname + "-" + s.Name
 					if name == prefix {
-						opErr := cli.WorkerStopForSite(s.Name, wname)
+						opErr := cli.WorkerStopForSite(s.Name, s.Path, wname)
 						resp := ServiceActionResponse{
 							ServiceResponse: ServiceResponse{Name: name, Status: "inactive", EnvVars: map[string]string{}, WorkerSite: s.Name, WorkerName: wname},
 							OK:              opErr == nil,
@@ -1521,17 +1521,17 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 					}
 					wtBase := strings.TrimPrefix(name, prefix+"-")
 					wts, _ := gitpkg.DetectWorktrees(s.Path, s.PrimaryDomain())
-					matched := false
+					var wtPath string
 					for _, wt := range wts {
 						if filepath.Base(wt.Path) == wtBase {
-							matched = true
+							wtPath = wt.Path
 							break
 						}
 					}
-					if !matched {
+					if wtPath == "" {
 						continue
 					}
-					opErr := cli.WorkerStopForSite(s.Name+"-"+wtBase, wname)
+					opErr := cli.WorkerStopForSite(s.Name, wtPath, wname)
 					resp := ServiceActionResponse{
 						ServiceResponse: ServiceResponse{
 							Name: name, Status: "inactive", EnvVars: map[string]string{},
@@ -2420,7 +2420,6 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 				workerName := parts[1]
 				branch := r.URL.Query().Get("branch")
 				targetPath := site.Path
-				targetUnitSite := site.Name
 				if branch != "" {
 					wtPath := resolveSitePath(site, branch)
 					if wtPath == "" {
@@ -2428,11 +2427,10 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 					targetPath = wtPath
-					targetUnitSite = site.Name + "-" + filepath.Base(wtPath)
 				}
 				if parts[2] == "stop" {
 					// Stops orphans without a framework definition too.
-					if err := cli.WorkerStopForSite(targetUnitSite, workerName); err != nil {
+					if err := cli.WorkerStopForSite(site.Name, targetPath, workerName); err != nil {
 						writeJSON(w, SiteActionResponse{Error: err.Error()})
 						return
 					}

--- a/internal/watcher/dns.go
+++ b/internal/watcher/dns.go
@@ -19,6 +19,7 @@ type dnsWatchDeps struct {
 	check             func(tld string) (bool, error)
 	waitReady         func(time.Duration) error
 	configureResolver func() error
+	repairPossible    func() bool
 	idleOrLocked      func() bool
 	publishStatus     func()
 	log               func(level, msg string, kv ...any)
@@ -28,8 +29,9 @@ type dnsWatchDeps struct {
 // so the first observation always publishes, in case the snapshot built
 // during boot baked in a stale dns.ok=false.
 type dnsWatchState struct {
-	lastOK    *bool
-	tickCount int
+	lastOK            *bool
+	tickCount         int
+	repairUnavailable bool
 }
 
 // WatchDNS polls DNS health for the given TLD every interval. When resolution
@@ -46,6 +48,7 @@ func WatchDNS(interval time.Duration, tld string) {
 		check:             dns.Check,
 		waitReady:         dns.WaitReady,
 		configureResolver: dns.ConfigureResolver,
+		repairPossible:    dns.RepairPossible,
 		idleOrLocked:      systemd.SessionIsIdleOrLocked,
 		publishStatus:     func() { eventbus.Default.Publish(eventbus.KindStatus) },
 		log: func(level, msg string, kv ...any) {
@@ -93,6 +96,18 @@ func tickDNS(d dnsWatchDeps, s *dnsWatchState, tld string) {
 	if ok {
 		return
 	}
+
+	// Skip repair when the platform can't write the resolver config from
+	// this process (macOS without /etc/sudoers.d/lerd in place). Logging
+	// this every tick would spam — emit once and remember the gate.
+	if d.repairPossible != nil && !d.repairPossible() {
+		if !s.repairUnavailable {
+			d.log("warn", "DNS resolution broken; automatic repair unavailable on this host (run lerd install to grant the watcher resolver write access)", "tld", tld)
+			s.repairUnavailable = true
+		}
+		return
+	}
+	s.repairUnavailable = false
 
 	d.log("warn", "DNS resolution broken, repairing", "tld", tld)
 

--- a/internal/watcher/dns_test.go
+++ b/internal/watcher/dns_test.go
@@ -230,6 +230,95 @@ func TestTickDNS(t *testing.T) {
 	}
 }
 
+// TestTickDNS_repairUnavailable_logsOnceAndSkipsResolverWrite pins the
+// macOS-without-sudoers fix: when repairPossible() returns false, the
+// watcher must not call configureResolver (which would prompt for a sudo
+// password from a non-interactive systemd / launchd context and spam the
+// log every tick). Instead, log exactly once until the gate opens again.
+func TestTickDNS_repairUnavailable_logsOnceAndSkipsResolverWrite(t *testing.T) {
+	var checks, repairs, waits int
+	var logs []string
+
+	deps := dnsWatchDeps{
+		check:             func(string) (bool, error) { checks++; return false, nil },
+		waitReady:         func(time.Duration) error { waits++; return nil },
+		configureResolver: func() error { repairs++; return nil },
+		repairPossible:    func() bool { return false },
+		idleOrLocked:      func() bool { return false },
+		publishStatus:     func() {},
+		log: func(level, _ string, _ ...any) {
+			logs = append(logs, level)
+		},
+	}
+	state := &dnsWatchState{}
+
+	// Three consecutive ticks with DNS down; only the first should log.
+	for i := 0; i < 3; i++ {
+		tickDNS(deps, state, "test")
+	}
+
+	if checks != 3 {
+		t.Errorf("expected 3 checks, got %d", checks)
+	}
+	if waits != 0 {
+		t.Errorf("expected zero waitReady calls when repair is unavailable, got %d", waits)
+	}
+	if repairs != 0 {
+		t.Errorf("expected zero configureResolver calls when repair is unavailable, got %d", repairs)
+	}
+	// Two log entries: first publish-on-transition (no log) then a single
+	// "repair unavailable" warn. Subsequent ticks must not re-log.
+	if len(logs) != 1 {
+		t.Errorf("expected 1 log line over 3 ticks, got %d (%v)", len(logs), logs)
+	}
+}
+
+// TestTickDNS_repairAvailableAfterUnavailable_relogsOnNextOutage pins the
+// reset behaviour: once DNS comes back up (or the gate opens), the
+// "repair unavailable" warn flag clears so the next outage logs again.
+func TestTickDNS_repairAvailableAfterUnavailable_relogsOnNextOutage(t *testing.T) {
+	gate := false
+	var logs []string
+	deps := dnsWatchDeps{
+		check:             func(string) (bool, error) { return false, nil },
+		waitReady:         func(time.Duration) error { return errors.New("not relevant") },
+		configureResolver: func() error { return nil },
+		repairPossible:    func() bool { return gate },
+		idleOrLocked:      func() bool { return false },
+		publishStatus:     func() {},
+		log:               func(level, _ string, _ ...any) { logs = append(logs, level) },
+	}
+	state := &dnsWatchState{}
+
+	// Tick with gate closed: one warn.
+	tickDNS(deps, state, "test")
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d (%v)", len(logs), logs)
+	}
+	logs = nil
+
+	// Open the gate: next tick should run the normal repair pipeline,
+	// which logs warn + error (waitReady fails). Importantly the
+	// repairUnavailable flag must be cleared so a future close-of-gate
+	// re-emits the once warn.
+	gate = true
+	tickDNS(deps, state, "test")
+	if len(logs) < 1 {
+		t.Fatalf("expected repair pipeline logs after gate reopened, got %v", logs)
+	}
+	if state.repairUnavailable {
+		t.Error("expected repairUnavailable flag to clear when gate reopens")
+	}
+
+	// Close gate again — should re-log the once-warn.
+	logs = nil
+	gate = false
+	tickDNS(deps, state, "test")
+	if len(logs) != 1 {
+		t.Errorf("expected re-log after gate re-closes, got %v", logs)
+	}
+}
+
 func ptrBool(b bool) *bool { return &b }
 
 func ptrBoolEq(a, b *bool) bool {

--- a/internal/watcher/exec_workers_darwin.go
+++ b/internal/watcher/exec_workers_darwin.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/geodro/lerd/internal/cli"
 	"github.com/geodro/lerd/internal/config"
+	gitpkg "github.com/geodro/lerd/internal/git"
 )
 
 // WatchExecWorkers self-heals macOS framework workers when the configured
@@ -160,6 +161,36 @@ func expectedExecWorkers() []expectedExecWorker {
 				kind:       kind,
 				def:        def,
 			})
+		}
+
+		// Per-worktree host workers (vite, etc.) get a unit per worktree
+		// (lerd-<kind>-<site>-<wtBase>) under PR #319. The self-heal loop
+		// must enumerate them too — without this, a worktree unit booted
+		// out of launchd never recovers because the watcher pretends it
+		// doesn't exist.
+		wts, derr := gitpkg.DetectWorktrees(s.Path, s.PrimaryDomain())
+		if derr != nil || len(wts) == 0 {
+			continue
+		}
+		for _, wt := range wts {
+			wtPHP := config.WorktreePHPVersion(wt.Path, php)
+			for _, kind := range cli.OptedInHostWorkers(&s, wt.Path) {
+				if paused[kind] {
+					continue
+				}
+				def, ok := fw.Workers[kind]
+				if !ok {
+					continue
+				}
+				out = append(out, expectedExecWorker{
+					unit:       "lerd-" + kind + "-" + s.Name + "-" + filepath.Base(wt.Path),
+					site:       s.Name,
+					sitePath:   wt.Path,
+					phpVersion: wtPHP,
+					kind:       kind,
+					def:        def,
+				})
+			}
 		}
 	}
 	return out


### PR DESCRIPTION
## Summary

Audit of `v1.19.1..898446e` surfaced thirteen real defects. This branch lands the fixes in one batch with regression tests for each, plus a DRY pass that uncovered a latent FrankenPHP miss along the way.

## Worker lifecycle

- `lerd worktree remove` (and the watcher's onRemoved hook) now stop every per-worktree unit before git tears the directory down. Previously systemd kept restarting them against the deleted `WorkingDirectory` with `Restart=always`, generating a tight failure loop in the journal.
- Per-worktree host workers restart at daemon boot via `scanWorktrees`, not just on the fsnotify add event, so they survive a host reboot or `lerd stop && lerd start`. `restoreSiteInfrastructure` iterates worktrees per host worker for the `lerd start` path.
- macOS `host: true` workers short-circuit cleanly via a `workerSupportedOnPlatform` gate. The previous code printed `[WARN]` and then proceeded into `podman.StartUnit` against a unit that was never written, producing a confusing podman error chasing the WARN.
- macOS `splitWorkerUnit` (used by the worker-mode flip) parses `lerd-<kind>-<site>-<wtBase>` correctly, with worktree-set verification + longest-suffix wins so a same-prefixed unrelated site can't false-match.
- macOS exec-mode self-heal (`expectedExecWorkers`) walks worktrees too, so a launchd-booted worktree unit recovers like the parent does.

## Certs / nginx

- `migrate_tld` reissues the parent cert with the new wildcard SANs and removes the old crt/key under the previous primary, so HTTPS to `<branch>.<newprimary>` works immediately after the migration. Without this the old cert SANs lingered and the SSL handshake failed.
- `issueCertAtomic` uses a unique pid+seq+ns tempfile suffix and a per-domain mutex. Concurrent reissues (boot scan racing a watcher event) used to clobber each other's `.new` files and produce a zero-byte cert under the rename loser.
- `nginx.GenerateWorktreeVhostFor` wraps the secured-vs-plain branch so `scanWorktrees`, `syncWorktree`, and `migrateWorktreeVhosts` stop repeating the if/else.

## env_overrides

- `envfile.ApplyUpdates` rejects newlines/CR in values and newlines/`=` in keys so a malicious `.lerd.yaml` override can't inject a second key into `.env`.
- Deterministic byte output: pending keys are sorted before append, so identical inputs produce identical `.env` content. The skip-write-if-unchanged guard now actually prevents mtime churn on idempotent watcher passes (vite, IDE indexers, opcache react to mtime).
- `{{branch}}` and `{{parent}}` template tokens added; `{{site}}` kept as the legacy full-FQDN slug. Documented in `git-worktrees.md`.

## DNS watcher

- macOS DNS repair gates on the lerd sudoers drop-in being installed (`/etc/sudoers.d/lerd`). Without it the watcher would prompt for a password every tick and spam the log; now it logs once and skips repair until the gate opens.

## Worker units

- `writeHostWorkerUnitFile` wraps `ExecStart` in `/bin/sh -c '<cmd>'` with single-quote escaping. Framework worker commands containing shell features (`&&`, `|`, redirects) used to fail silently because systemd's argv splitting handed the metacharacters to fnm as literal arguments.

## DRY pass

- `workerNames(siteName, sitePath, workerName) (unit, display string)` replaces parallel `workerUnitName` + `workerDisplaySite` lookups; one `config.FindSite` call serves both shapes.
- `resolveWorkerFPMUnit(siteName, phpVersion)` centralises the custom container / FrankenPHP / shared FPM mapping. **Latent bug fixed**: `restoreWorker` (linux + darwin) and the macOS `writeWorkerExecUnit` path used to skip the FrankenPHP branch — workers on FrankenPHP sites had their `BindsTo=` and `podman exec` targets pointing at the shared `lerd-php<v>-fpm` container instead of the site's own FrankenPHP container. Regression test pins it.
- `WorkerStopForSite` signature now matches `WorkerStartForSite` by taking `sitePath`. Thirteen callers updated. The UI server's `s.Name+"-"+wtBase` hack was replaced with the real `wtPath`.
- Dropped a dead `indexed *store.IndexEntry` lookup in `updateAllFrameworks`.

## Tests

New regression tests pinning every fix above:

- `internal/cli`: `TestStopAllWorkersForWorktree*`, `TestWorkerStartForSite_skipsLifecycleWhenUnsupported`, `TestRestoreWorker_*`, `TestSplitWorkerUnit_worktreeUnit`, `TestSplitWorkerUnit_longestSuffixWins`, `TestResolveWorkerFPMUnit_frankenPHP`, `TestWorkerNames_*`, `TestMigrateSiteTLD_ReissuesCertForSecuredSiteWithWorktree`, `TestWriteHostWorkerUnitFile_shellCommandPreserved`.
- `internal/certs`: `TestIssueCertForce_concurrentCallsDontCollide`.
- `internal/envfile`: `TestApplyUpdates_rejectsNewlineInValue`, `_rejectsCarriageReturnInValue`, `_rejectsNewlineInKey`, `_rejectsEqualsInKey`, `_deterministicAppendOrder`.
- `internal/nginx`: `TestGenerateWorktreeVhostFor_routesByFlag`.
- `internal/git`: `TestEnsureWorktreeEnv_branchAndParentTokens`.
- `internal/watcher`: `TestTickDNS_repairUnavailable_logsOnceAndSkipsResolverWrite`, `TestTickDNS_repairAvailableAfterUnavailable_relogsOnNextOutage`.

## Docs

- `docs/usage/framework-workers.md`: shell command support, three auto-start triggers (worktree create + daemon boot + cleanup on remove), macOS host limitation note.
- `docs/features/git-worktrees.md`: clarified daemon-boot auto-start, updated cleanup ordering to reflect worker-stop-first, added `{{branch}}` / `{{parent}}` template tokens with examples.