### PR TITLE
feat(tui): service update + rollback keybinds

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,14 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **TUI service lifecycle keybinds** (`u` update, `b` rollback). Pressing `u` while focused on the Services pane runs `lerd service update <name>` for the highlighted service (no tag, applies the safe in-strategy update). Pressing `b` runs `lerd service rollback <name>`. Both fire and refresh the snapshot, mirroring the dashboard's Update / Rollback buttons. No-op on worker rows (queue-alpha, etc.) since they have no upstream image. Help reference (`?`) lists both. Migrate, remove, and reinstall stay CLI/dashboard-only for now since they need tag pickers or destructive-action confirmation.
+
+---
+
 ## [1.20.0-beta.1] — 2026-05-09
 
 First beta of the 1.20.0 line. The headline is a deeper pass on git worktrees: per-worktree workers as a first-class concept driven by framework yaml intent, a built-in Vite dev server worker that runs on the host (HMR with no port publishing), automatic wildcard cert SANs for worktree subdomains, `env_overrides` templating for multi-tenant apps, and a unified asset-worker / build prompt on `lerd worktree add`. Plus dashboard surfaces for per-worktree workers and the post-1.19.1 regression fixes around secured sites, certs, and the DNS pill.

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -37,6 +37,8 @@ var helpReference = []helpSection{
 			{"r", "restart the focused site or service"},
 			{"p", "pause / unpause toggle for a site"},
 			{"t", "open an interactive shell inside the focused container"},
+			{"u", "service update — pull a newer image and restart (services pane)"},
+			{"b", "service rollback — revert to the previously-running image (services pane)"},
 		},
 	},
 	{

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -368,8 +368,43 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "H":
 		return m, m.actionHealWorkers()
+
+	case "u":
+		return m, m.actionServiceUpdate()
+
+	case "b":
+		return m, m.actionServiceRollback()
 	}
 	return m, nil
+}
+
+// actionServiceUpdate runs `lerd service update <name>` for the focused
+// service row (no tag — applies the safe in-strategy update). Worker rows
+// have no upstream image so we no-op there.
+func (m *Model) actionServiceUpdate() tea.Cmd {
+	if m.focus != paneServices {
+		return nil
+	}
+	svc := m.currentService()
+	if svc == nil || svc.WorkerKind != "" {
+		return nil
+	}
+	m.setStatus("updating "+svc.Name+"…", 30*time.Second)
+	return runLerd("", "service", "update", svc.Name)
+}
+
+// actionServiceRollback runs `lerd service rollback <name>` for the focused
+// service row, reverting to the previously-running image.
+func (m *Model) actionServiceRollback() tea.Cmd {
+	if m.focus != paneServices {
+		return nil
+	}
+	svc := m.currentService()
+	if svc == nil || svc.WorkerKind != "" {
+		return nil
+	}
+	m.setStatus("rolling back "+svc.Name+"…", 30*time.Second)
+	return runLerd("", "service", "rollback", svc.Name)
 }
 
 // actionHealWorkers shells out to `lerd worker heal` so every failed

--- a/internal/tui/model_extra_test.go
+++ b/internal/tui/model_extra_test.go
@@ -220,6 +220,45 @@ func TestWorkerActionCmd_BuiltinWorker(t *testing.T) {
 	}
 }
 
+// TestActionServiceUpdate_focusGuards pins that update only fires from the
+// services pane (not sites/detail) and skips worker rows (which have no
+// upstream image to pull).
+func TestActionServiceUpdate_focusGuards(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{Services: []ServiceRow{{Name: "mysql"}}}
+	m.focus = paneSites
+	if cmd := m.actionServiceUpdate(); cmd != nil {
+		t.Errorf("update from sites pane should be nil")
+	}
+	m.focus = paneServices
+	if cmd := m.actionServiceUpdate(); cmd == nil {
+		t.Errorf("update on plain service should return a cmd")
+	}
+	m.snap.Services = []ServiceRow{{Name: "queue-alpha", WorkerKind: "queue"}}
+	if cmd := m.actionServiceUpdate(); cmd != nil {
+		t.Errorf("update on worker row should be nil")
+	}
+}
+
+// TestActionServiceRollback_focusGuards mirrors update — same paneServices
+// + non-worker constraint.
+func TestActionServiceRollback_focusGuards(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{Services: []ServiceRow{{Name: "mysql"}}}
+	m.focus = paneSites
+	if cmd := m.actionServiceRollback(); cmd != nil {
+		t.Errorf("rollback from sites pane should be nil")
+	}
+	m.focus = paneServices
+	if cmd := m.actionServiceRollback(); cmd == nil {
+		t.Errorf("rollback on plain service should return a cmd")
+	}
+	m.snap.Services = []ServiceRow{{Name: "queue-alpha", WorkerKind: "queue"}}
+	if cmd := m.actionServiceRollback(); cmd != nil {
+		t.Errorf("rollback on worker row should be nil")
+	}
+}
+
 func TestSiteByName(t *testing.T) {
 	m := NewModel("test")
 	m.snap = fakeSnap()


### PR DESCRIPTION
## Summary

Adds `u` (update) and `b` (rollback) keybinds to the TUI Services pane, mirroring the most-used buttons on the dashboard's service detail panel.

- Pressing `u` on a focused service runs `lerd service update <name>` (no tag, applies the safe in-strategy update).
- Pressing `b` runs `lerd service rollback <name>` to revert to the previously-running image.
- Both no-op on worker rows (e.g. `queue-alpha`) since workers have no upstream image to pull.
- Help reference (`?`) lists both under Actions.

Migrate, remove, and reinstall stay dashboard/CLI-only for now since they need tag pickers or destructive-action confirmation flows that the TUI doesn't have yet.

Lands under `[Unreleased]` in the changelog so it folds into the next beta cut.