### PR TITLE
fix(watcher): dedup concurrent handleNewEntry for the same worktree

### DIFF
--- a/internal/watcher/worktree.go
+++ b/internal/watcher/worktree.go
@@ -4,10 +4,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
+
+// inFlightWorktrees serializes handleNewEntry per (sitePath, name). Git
+// worktree add fires multiple fsnotify events (worktrees/ create, entry
+// create, gitdir write) so without dedup three to four goroutines race
+// onAdded → composer install on the same vendor/ tree and corrupt the
+// extraction by clobbering each other's vendor/composer/tmp-*.zip files.
+var inFlightWorktrees sync.Map
 
 // WatchWorktrees monitors the .git/worktrees/ directory for each site returned
 // by getSites and calls onAdded/onRemoved when entries appear or disappear.
@@ -179,9 +187,19 @@ func WatchWorktrees(
 // poll closes a race where fsnotify fires Create on the entry dir before git
 // has finalised HEAD: lerd would otherwise read an empty HEAD, treat the
 // worktree as detached, and write a `detached.<site>.conf` vhost that
-// shadows the eventual `<branch>.<site>.conf`. Safe to call multiple times —
-// onAdded is idempotent.
+// shadows the eventual `<branch>.<site>.conf`.
+//
+// Concurrent invocations for the same (sitePath, name) are deduped: the
+// first goroutine claims the in-flight slot and runs to completion; the
+// rest return immediately. Late HEAD changes after the first goroutine
+// returned are caught by the entryDir HEAD watcher (onChanged path).
 func handleNewEntry(entryDir, sitePath, name string, onAdded func(string, string)) {
+	key := sitePath + "\x00" + name
+	if _, busy := inFlightWorktrees.LoadOrStore(key, struct{}{}); busy {
+		return
+	}
+	defer inFlightWorktrees.Delete(key)
+
 	// Wait up to 5s for gitdir to be written.
 	gitdirPath := filepath.Join(entryDir, "gitdir")
 	var checkoutPath string

--- a/internal/watcher/worktree_test.go
+++ b/internal/watcher/worktree_test.go
@@ -3,9 +3,75 @@ package watcher
 import (
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+// TestHandleNewEntry_DedupsConcurrentCalls pins the regression that produced
+// "unzip: can't open vendor/composer/tmp-*.zip" failures: git worktree add
+// fires multiple fsnotify events so three to four handleNewEntry goroutines
+// would run concurrently on the same worktree, racing each other through
+// onAdded → composer install. The first goroutine must claim the slot and
+// the rest must return without invoking onAdded.
+func TestHandleNewEntry_DedupsConcurrentCalls(t *testing.T) {
+	site := t.TempDir()
+	checkout := t.TempDir()
+	entryDir := filepath.Join(site, ".git", "worktrees", "feat")
+	if err := os.MkdirAll(entryDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(entryDir, "gitdir"), []byte(filepath.Join(checkout, ".git")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(entryDir, "HEAD"), []byte("ref: refs/heads/feat\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int32
+	var concurrent atomic.Int32
+	var maxConcurrent atomic.Int32
+	slowOnAdded := func(_, _ string) {
+		n := concurrent.Add(1)
+		for {
+			cur := maxConcurrent.Load()
+			if n <= cur || maxConcurrent.CompareAndSwap(cur, n) {
+				break
+			}
+		}
+		calls.Add(1)
+		// Hold the slot long enough that the other goroutines reach the
+		// LoadOrStore guard while this one is still running. Mirrors a
+		// real composer install which takes seconds.
+		time.Sleep(50 * time.Millisecond)
+		concurrent.Add(-1)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			handleNewEntry(entryDir, site, "feat", slowOnAdded)
+		}()
+	}
+	wg.Wait()
+
+	if got := maxConcurrent.Load(); got != 1 {
+		t.Errorf("max concurrent onAdded = %d, want 1 (dedup failed)", got)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("onAdded called %d times, want exactly 1 (the four events should collapse)", got)
+	}
+
+	// After the first call returns, the in-flight slot is released so a
+	// subsequent event (e.g. HEAD rewrite on rename) re-fires onAdded.
+	handleNewEntry(entryDir, site, "feat", slowOnAdded)
+	if got := calls.Load(); got != 2 {
+		t.Errorf("onAdded after slot release: total = %d, want 2", got)
+	}
+}
 
 func TestWatchWorktrees_HEADWriteTriggersChangedForExistingWorktree(t *testing.T) {
 	site := t.TempDir()


### PR DESCRIPTION
## Summary

`git worktree add` fires three to four fsnotify events in quick succession (create on `.git/worktrees`, create on the entry dir, write on `gitdir`), each spawning a `handleNewEntry` goroutine. All of them end up calling `onAdded → syncWorktree → composer install` on the same `vendor/` tree, racing on `vendor/composer/tmp-*.zip` files.

Real-world symptom (just hit during a `lerd worktree add main` on a Laravel project):

```
Failed to extract pestphp/pest-plugin: ... unzip: can't open .../tmp-96573b01b866454e2c69300b335da20f.zip
[WARN] worktree dependency install: composer install: exit status 1
```

`vendor/autoload.php` never lands, so `lerd worktree add` hangs in its `waitForWorktreeReady` poll until the 5-minute timeout.

## Fix

Adds a `sync.Map` keyed by `(sitePath, name)`. The first goroutine claims the slot and runs `handleNewEntry` to completion; the rest return immediately. The slot is released on return so a later HEAD rewrite (e.g. `git branch -m`) still re-fires `onAdded` via the existing `entryDir` HEAD watcher.

## Test

New `TestHandleNewEntry_DedupsConcurrentCalls` fires four concurrent goroutines against a slow `onAdded` (50ms hold) and asserts `maxConcurrent == 1` and total `calls == 1`. A subsequent serialised call after the slot release fires `onAdded` again, pinning that legitimate later events still propagate.

Runs clean under `-race`.