### PR TITLE
feat(tui): header pill for failing workers

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - **TUI service lifecycle keybinds** (`u` update, `b` rollback). Pressing `u` while focused on the Services pane runs `lerd service update <name>` for the highlighted service (no tag, applies the safe in-strategy update). Pressing `b` runs `lerd service rollback <name>`. Both fire and refresh the snapshot, mirroring the dashboard's Update / Rollback buttons. No-op on worker rows (queue-alpha, etc.) since they have no upstream image. Help reference (`?`) lists both. Migrate, remove, and reinstall stay CLI/dashboard-only for now since they need tag pickers or destructive-action confirmation.
+- **TUI header pill for failing workers.** When any framework worker (built-in queue/schedule/horizon/reverb, custom worker, or per-worktree worker) is in the systemd `failed` state, the TUI header renders `⚠ N workers failing · H to heal` in failing-style colour next to the existing DNS / nginx / FPM / watcher pills. Mirrors the dashboard's amber sticky banner from #319. Helper `countFailingWorkers` aggregates state across every site and worktree.
 
 ---
 

--- a/internal/tui/panes.go
+++ b/internal/tui/panes.go
@@ -160,9 +160,48 @@ func (m *Model) renderHeader() string {
 		parts = append(parts, dimStyle.Render("watcher"))
 	}
 
+	if n := countFailingWorkers(m.snap); n > 0 {
+		parts = append(parts, failingStyle.Render(fmt.Sprintf("⚠ %d workers failing · H to heal", n)))
+	}
+
 	parts = append(parts, dimStyle.Render(time.Now().Format("15:04:05")))
 
 	return strings.Join(parts, "  ·  ")
+}
+
+// countFailingWorkers totals workers in the systemd "failed" state across
+// every site (built-ins + custom framework workers + per-worktree workers).
+// Used to surface a heal hint in the header so users see the H keybind is
+// relevant without drilling into individual site rows.
+func countFailingWorkers(snap Snapshot) int {
+	n := 0
+	for _, s := range snap.Sites {
+		if s.QueueFailing {
+			n++
+		}
+		if s.ScheduleFailing {
+			n++
+		}
+		if s.HorizonFailing {
+			n++
+		}
+		if s.ReverbFailing {
+			n++
+		}
+		for _, fw := range s.FrameworkWorkers {
+			if fw.Failing {
+				n++
+			}
+		}
+		for _, wt := range s.Worktrees {
+			for _, fw := range wt.FrameworkWorkers {
+				if fw.Failing {
+					n++
+				}
+			}
+		}
+	}
+	return n
 }
 
 func (m *Model) renderFooter() string {

--- a/internal/tui/panes_test.go
+++ b/internal/tui/panes_test.go
@@ -114,3 +114,47 @@ func TestViewport_ScrollsDownAsCursorAdvances(t *testing.T) {
 		t.Fatalf("scroll should advance to keep cursor visible, got %d", scroll)
 	}
 }
+
+// TestCountFailingWorkers_AggregatesAcrossSitesAndWorktrees pins the helper
+// the header pill uses: every failed worker (built-in, custom, per-worktree)
+// counts so the "press H to heal" hint never under-reports.
+func TestCountFailingWorkers_AggregatesAcrossSitesAndWorktrees(t *testing.T) {
+	snap := Snapshot{
+		Sites: []siteinfo.EnrichedSite{
+			{
+				QueueFailing:    true, // +1
+				ScheduleFailing: false,
+				FrameworkWorkers: []siteinfo.WorkerInfo{
+					{Name: "vite", Failing: true}, // +1
+					{Name: "messenger", Failing: false},
+				},
+				Worktrees: []siteinfo.WorktreeInfo{
+					{
+						Branch: "feat-x",
+						FrameworkWorkers: []siteinfo.WorkerInfo{
+							{Name: "vite", Failing: true}, // +1
+						},
+					},
+				},
+			},
+			{HorizonFailing: true}, // +1
+		},
+	}
+	if got := countFailingWorkers(snap); got != 4 {
+		t.Errorf("countFailingWorkers = %d, want 4", got)
+	}
+}
+
+// TestCountFailingWorkers_ZeroWhenAllHealthy keeps the header clean when
+// every worker is happy.
+func TestCountFailingWorkers_ZeroWhenAllHealthy(t *testing.T) {
+	snap := Snapshot{
+		Sites: []siteinfo.EnrichedSite{
+			{HasQueueWorker: true, QueueRunning: true},
+			{HasHorizon: true, HorizonRunning: true},
+		},
+	}
+	if got := countFailingWorkers(snap); got != 0 {
+		t.Errorf("countFailingWorkers = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

When any framework worker (built-in queue/schedule/horizon/reverb, custom, or per-worktree) is in the systemd `failed` state, the TUI header now renders `⚠ N workers failing · H to heal` in failing-style colour next to the existing DNS / nginx / FPM / watcher pills.

Mirrors the amber sticky banner the dashboard added in #319 (worker self-heal). The `H` keybind already runs `lerd worker heal` across every site, the pill just makes the affordance discoverable without drilling into each site row.

## Test

- `TestCountFailingWorkers_AggregatesAcrossSitesAndWorktrees` exercises the helper across built-ins, custom `FrameworkWorkers`, and per-worktree `FrameworkWorkers` (3 surfaces × 2 sites = 4 failing units expected).
- `TestCountFailingWorkers_ZeroWhenAllHealthy` keeps the header clean when every worker is happy.