### PR TITLE
fix: dashboard update banner + test cache pollution

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,12 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dashboard "Open terminal & update" button failed with `lerd: command not found`.** The handler shelled out via `sh -c "lerd update; …"`, but the spawned terminal inherits a non-login shell environment that doesn't source `.bashrc` / `.zshrc`, so `~/.local/bin` is off `PATH`. The script now uses `os.Executable()` to resolve the absolute path of the running `lerd-ui` binary (which is the `lerd` binary itself) before passing it to the shell. Same fix pattern the TUI's `runLerd` already uses.
+- **Dashboard update banner showed `Lerd vv1.19.2 is available`.** Two bugs compounded: the wire payload from `/api/version` returned the GitHub tag verbatim (with leading `v`) while the Svelte template `Lerd v{version} is available` already prepends `v`, producing the double-`v`. `handleVersion` now strips the `v` via `lerdUpdate.StripV` before sending so the wire data is bare and the template renders cleanly.
+- **`internal/update` test pollution rewrote the user's real `update-check.json`.** `withTempCache` set `XDG_CONFIG_HOME` but `config.UpdateCheckFile` reads `XDG_DATA_HOME`, so test cache writes leaked to `~/.local/share/lerd/update-check.json` and surfaced bogus version tags (e.g. `v1.19.2`) in the dashboard banner for 24h. Test now sets the correct env var so writes stay in the temp dir.
+
 ### Added
 
 - **TUI service lifecycle keybinds** (`u` update, `b` rollback). Pressing `u` while focused on the Services pane runs `lerd service update <name>` for the highlighted service (no tag, applies the safe in-strategy update). Pressing `b` runs `lerd service rollback <name>`. Both fire and refresh the snapshot, mirroring the dashboard's Update / Rollback buttons. No-op on worker rows (queue-alpha, etc.) since they have no upstream image. Help reference (`?`) lists both. Migrate, remove, and reinstall stay CLI/dashboard-only for now since they need tag pickers or destructive-action confirmation.

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1762,7 +1762,9 @@ func handleVersion(w http.ResponseWriter, _ *http.Request, currentVersion string
 	info, _ := lerdUpdate.CachedUpdateCheck(currentVersion)
 	resp := VersionResponse{Current: currentVersion}
 	if info != nil {
-		resp.Latest = info.LatestVersion
+		// The dashboard banner template ("Lerd v{version} is available")
+		// already includes the v, so the wire payload must be bare.
+		resp.Latest = lerdUpdate.StripV(info.LatestVersion)
 		resp.HasUpdate = true
 		resp.Changelog = info.Changelog
 	}
@@ -2886,14 +2888,18 @@ func handleLerdQuit(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleLerdUpdateTerminal opens the user's terminal emulator running
-// `lerd update`, with a "press Enter to close" tail so the user can read
-// the output. Loopback-only — listed in loopbackOnlyRoutes.
+// `lerd update`. Loopback-only. Uses os.Executable() because the spawned
+// `sh -c` doesn't source .bashrc, so ~/.local/bin is off PATH otherwise.
 func handleLerdUpdateTerminal(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	script := `lerd update; echo; read -rp "Press Enter to close..."`
+	self, err := os.Executable()
+	if err != nil || self == "" {
+		self = "lerd"
+	}
+	script := shQuote(self) + ` update; echo; read -rp "Press Enter to close..."`
 	if err := openTerminalCommand(script); err != nil {
 		writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
 		return

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1760,15 +1760,21 @@ type VersionResponse struct {
 
 func handleVersion(w http.ResponseWriter, _ *http.Request, currentVersion string) {
 	info, _ := lerdUpdate.CachedUpdateCheck(currentVersion)
+	writeJSON(w, buildVersionResponse(currentVersion, info))
+}
+
+// buildVersionResponse builds the wire payload for /api/version. The
+// dashboard banner template already prepends "v" so the Latest field
+// must be stripped of any leading v from the GitHub tag, otherwise
+// users see "vv1.20.0" in the banner.
+func buildVersionResponse(currentVersion string, info *lerdUpdate.UpdateInfo) VersionResponse {
 	resp := VersionResponse{Current: currentVersion}
 	if info != nil {
-		// The dashboard banner template ("Lerd v{version} is available")
-		// already includes the v, so the wire payload must be bare.
 		resp.Latest = lerdUpdate.StripV(info.LatestVersion)
 		resp.HasUpdate = true
 		resp.Changelog = info.Changelog
 	}
-	writeJSON(w, resp)
+	return resp
 }
 
 func handlePHPVersions(w http.ResponseWriter, _ *http.Request) {
@@ -2899,12 +2905,18 @@ func handleLerdUpdateTerminal(w http.ResponseWriter, r *http.Request) {
 	if err != nil || self == "" {
 		self = "lerd"
 	}
-	script := shQuote(self) + ` update; echo; read -rp "Press Enter to close..."`
-	if err := openTerminalCommand(script); err != nil {
+	if err := openTerminalCommand(buildUpdateScript(self)); err != nil {
 		writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
 	writeJSON(w, map[string]any{"ok": true})
+}
+
+// buildUpdateScript returns the sh -c payload the spawned terminal runs.
+// Extracted so tests can pin the absolute-path quoting without launching
+// a real terminal emulator.
+func buildUpdateScript(executable string) string {
+	return shQuote(executable) + ` update; echo; read -rp "Press Enter to close..."`
 }
 
 // openTerminalCommand opens the user's terminal emulator and runs the given

--- a/internal/ui/server_version_test.go
+++ b/internal/ui/server_version_test.go
@@ -1,0 +1,72 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	lerdUpdate "github.com/geodro/lerd/internal/update"
+)
+
+// TestBuildVersionResponse_StripsLeadingV pins the fix for "Lerd vv1.19.2
+// is available" — the GitHub tag is e.g. "v1.19.2" but the Svelte banner
+// template already prepends "v", so the wire data must be bare.
+func TestBuildVersionResponse_StripsLeadingV(t *testing.T) {
+	resp := buildVersionResponse("1.19.1", &lerdUpdate.UpdateInfo{LatestVersion: "v1.19.2"})
+	if resp.Latest != "1.19.2" {
+		t.Errorf("Latest = %q, want %q (no leading v)", resp.Latest, "1.19.2")
+	}
+	if !resp.HasUpdate {
+		t.Errorf("HasUpdate should be true when info is non-nil")
+	}
+}
+
+// TestBuildVersionResponse_NoUpdateLeavesLatestEmpty keeps the banner hidden
+// when no update is available — no Latest, no HasUpdate.
+func TestBuildVersionResponse_NoUpdateLeavesLatestEmpty(t *testing.T) {
+	resp := buildVersionResponse("1.19.1", nil)
+	if resp.Latest != "" || resp.HasUpdate {
+		t.Errorf("expected zero-update response, got %+v", resp)
+	}
+	if resp.Current != "1.19.1" {
+		t.Errorf("Current should be passed through, got %q", resp.Current)
+	}
+}
+
+// TestBuildVersionResponse_HandlesPrereleaseTag covers the beta channel
+// where the tag is e.g. "v1.20.0-beta.1" — strip-v still applies.
+func TestBuildVersionResponse_HandlesPrereleaseTag(t *testing.T) {
+	resp := buildVersionResponse("1.20.0-beta.1", &lerdUpdate.UpdateInfo{LatestVersion: "v1.20.0-beta.2"})
+	if resp.Latest != "1.20.0-beta.2" {
+		t.Errorf("prerelease Latest mishandled, got %q", resp.Latest)
+	}
+}
+
+// TestBuildUpdateScript_UsesAbsolutePath pins the fix for "lerd: command
+// not found" when the dashboard's "Open terminal & update" button spawned
+// a terminal whose non-login shell didn't have ~/.local/bin on PATH.
+// The script must reference the resolved executable, not the bare name.
+func TestBuildUpdateScript_UsesAbsolutePath(t *testing.T) {
+	got := buildUpdateScript("/home/alice/.local/bin/lerd")
+	if !strings.Contains(got, "/home/alice/.local/bin/lerd") {
+		t.Errorf("script should reference absolute path, got %q", got)
+	}
+	if strings.HasPrefix(got, "lerd ") {
+		t.Errorf("script should not start with bare 'lerd', got %q", got)
+	}
+	if !strings.Contains(got, " update;") {
+		t.Errorf("script should run `update` subcommand, got %q", got)
+	}
+	if !strings.Contains(got, "Press Enter to close") {
+		t.Errorf("script should keep the wait-for-input tail, got %q", got)
+	}
+}
+
+// TestBuildUpdateScript_QuotesPathWithSpaces protects the shell substitution
+// when the binary lives under a path with spaces (a Mac install in
+// "/Users/J D/.local/bin/lerd", say). shQuote should single-quote it.
+func TestBuildUpdateScript_QuotesPathWithSpaces(t *testing.T) {
+	got := buildUpdateScript("/Users/J D/.local/bin/lerd")
+	if !strings.Contains(got, `'/Users/J D/.local/bin/lerd'`) {
+		t.Errorf("path with spaces should be single-quoted, got %q", got)
+	}
+}

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -77,11 +77,13 @@ func TestCachedUpdateCheck_stableUserSeesNewerStable(t *testing.T) {
 }
 
 // withTempCache pre-seeds the on-disk update-check cache so CachedUpdateCheck
-// returns the given tag without hitting the network.
+// returns the given tag without hitting the network. Sets XDG_DATA_HOME (the
+// var DataDir() reads) so the writes land in the temp dir and never touch
+// the user's real ~/.local/share/lerd/update-check.json.
 func withTempCache(t *testing.T, tag string) {
 	t.Helper()
 	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("XDG_DATA_HOME", dir)
 	cacheDir := filepath.Dir(config.UpdateCheckFile())
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

Three small fixes around the dashboard update flow, all hit in one session:

- **"Open terminal & update" button failed with `lerd: command not found`.** The handler shelled out via `sh -c "lerd update; …"`, but the spawned terminal inherits a non-login shell environment that doesn't source `.bashrc` / `.zshrc`, so `~/.local/bin` is off `PATH`. `handleLerdUpdateTerminal` now resolves `os.Executable()` (which gives `~/.local/bin/lerd` for the running `lerd-ui` process, since it's the same binary) and passes the absolute path into the script. Same pattern the TUI's `runLerd` already uses.

- **Banner showed `Lerd vv1.19.2 is available` (double-`v`).** The `/api/version` payload returned the GitHub tag verbatim (with leading `v`) while the Svelte template `Lerd v{version} is available` already prepends `v`. `handleVersion` now strips the `v` via `lerdUpdate.StripV` so the wire data is bare.

- **`internal/update` tests polluted the user's real update-check cache.** `withTempCache` set `XDG_CONFIG_HOME` but `config.UpdateCheckFile` reads `XDG_DATA_HOME`, so test cache writes leaked to `~/.local/share/lerd/update-check.json` and surfaced bogus tags (e.g. `v1.19.2`) in the dashboard banner for up to 24h. The bogus `v1.19.2` came from this leak. Test now sets the correct env var so writes stay isolated to the temp dir.