### PR TITLE
refactor: dedupe service-set helpers and nginx reload-or-warn

### DIFF
--- a/internal/cli/domain.go
+++ b/internal/cli/domain.go
@@ -123,9 +123,7 @@ func runDomainAdd(_ *cobra.Command, args []string) error {
 		fmt.Printf("[WARN] updating container hosts file: %v\n", err)
 	}
 
-	if err := nginx.Reload(); err != nil {
-		fmt.Printf("[WARN] nginx reload: %v\n", err)
-	}
+	nginx.ReloadOrWarn("")
 
 	if site.PrimaryDomain() != oldPrimary {
 		if err := envfile.SyncPrimaryDomain(site.Path, site.PrimaryDomain(), site.Secured); err != nil {
@@ -194,9 +192,7 @@ func runDomainRemove(_ *cobra.Command, args []string) error {
 		fmt.Printf("[WARN] updating container hosts file: %v\n", err)
 	}
 
-	if err := nginx.Reload(); err != nil {
-		fmt.Printf("[WARN] nginx reload: %v\n", err)
-	}
+	nginx.ReloadOrWarn("")
 
 	if site.PrimaryDomain() != oldPrimary {
 		if err := envfile.SyncPrimaryDomain(site.Path, site.PrimaryDomain(), site.Secured); err != nil {

--- a/internal/cli/isolate.go
+++ b/internal/cli/isolate.go
@@ -42,8 +42,8 @@ func runIsolate(_ *cobra.Command, args []string) error {
 		}
 		if err := regenerateWorktreeVhost(site, branch, version); err != nil {
 			fmt.Printf("[WARN] regenerating worktree vhost: %v\n", err)
-		} else if err := nginx.Reload(); err != nil {
-			fmt.Printf("[WARN] nginx reload: %v\n", err)
+		} else {
+			nginx.ReloadOrWarn("")
 		}
 		fmt.Printf("PHP version pinned to %s for worktree %s of %s\n", version, branch, site.Name)
 		return nil

--- a/internal/cli/park.go
+++ b/internal/cli/park.go
@@ -124,9 +124,7 @@ func runPark(_ *cobra.Command, args []string) error {
 
 	if count > 0 {
 		fmt.Printf("Reloading nginx (%d sites registered)...\n", count)
-		if err := nginx.Reload(); err != nil {
-			fmt.Printf("  [WARN] nginx reload: %v\n", err)
-		}
+		nginx.ReloadOrWarn("  ")
 	} else {
 		fmt.Println("No PHP projects found in directory.")
 	}

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -95,9 +95,7 @@ func PauseSite(name string) error {
 
 	pauseWorktrees(site)
 
-	if err := nginx.Reload(); err != nil {
-		fmt.Printf("[WARN] nginx reload: %v\n", err)
-	}
+	nginx.ReloadOrWarn("")
 
 	fmt.Printf("Paused: %s (%s)\n", name, site.PrimaryDomain())
 	if len(running) > 0 {
@@ -189,9 +187,7 @@ func UnpauseSite(name string) error {
 		unpauseWorktrees(site, phpVersion)
 	}
 
-	if err := nginx.Reload(); err != nil {
-		fmt.Printf("[WARN] nginx reload: %v\n", err)
-	}
+	nginx.ReloadOrWarn("")
 
 	startServicesForSite(site.Path)
 

--- a/internal/cli/secure.go
+++ b/internal/cli/secure.go
@@ -74,9 +74,7 @@ func runSecure(_ *cobra.Command, args []string) error {
 	updateEnvAppURL(site.Path, "https", site.PrimaryDomain())
 	_ = config.SetProjectSecured(site.Path, true)
 
-	if err := nginx.Reload(); err != nil {
-		fmt.Printf("[WARN] nginx reload: %v\n", err)
-	}
+	nginx.ReloadOrWarn("")
 	restartStripeIfActive(site)
 	fmt.Printf("Secured: https://%s\n", site.PrimaryDomain())
 	return nil
@@ -107,9 +105,7 @@ func runUnsecure(_ *cobra.Command, args []string) error {
 	updateEnvAppURL(site.Path, "http", site.PrimaryDomain())
 	_ = config.SetProjectSecured(site.Path, false)
 
-	if err := nginx.Reload(); err != nil {
-		fmt.Printf("[WARN] nginx reload: %v\n", err)
-	}
+	nginx.ReloadOrWarn("")
 	restartStripeIfActive(site)
 	fmt.Printf("Unsecured: http://%s\n", site.PrimaryDomain())
 	return nil

--- a/internal/cli/unpark.go
+++ b/internal/cli/unpark.go
@@ -87,9 +87,7 @@ func runUnpark(_ *cobra.Command, args []string) error {
 	fmt.Printf("Unparked: %s (%d site(s) removed)\n", absDir, removed)
 
 	if removed > 0 {
-		if err := nginx.Reload(); err != nil {
-			fmt.Printf("  [WARN] nginx reload: %v\n", err)
-		}
+		nginx.ReloadOrWarn("  ")
 	}
 
 	// Rewrite FPM quadlets to remove volume mounts that are no longer needed.

--- a/internal/config/paused.go
+++ b/internal/config/paused.go
@@ -1,71 +1,17 @@
 package config
 
-import (
-	"os"
-	"path/filepath"
+import "path/filepath"
 
-	"gopkg.in/yaml.v3"
-)
-
-// pausedServicesFile returns the path to paused-services.yaml.
 func pausedServicesFile() string {
 	return filepath.Join(DataDir(), "paused-services.yaml")
 }
 
-// loadPausedServices reads the set of manually-stopped service names.
-func loadPausedServices() (map[string]bool, error) {
-	data, err := os.ReadFile(pausedServicesFile())
-	if os.IsNotExist(err) {
-		return map[string]bool{}, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	var names []string
-	if err := yaml.Unmarshal(data, &names); err != nil {
-		return nil, err
-	}
-	m := make(map[string]bool, len(names))
-	for _, n := range names {
-		m[n] = true
-	}
-	return m, nil
-}
-
-func savePausedServices(paused map[string]bool) error {
-	var names []string
-	for n := range paused {
-		names = append(names, n)
-	}
-	if err := os.MkdirAll(DataDir(), 0755); err != nil {
-		return err
-	}
-	data, err := yaml.Marshal(names)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(pausedServicesFile(), data, 0644)
-}
-
 // ServiceIsPaused returns true if the service was manually stopped by the user.
 func ServiceIsPaused(name string) bool {
-	paused, err := loadPausedServices()
-	if err != nil {
-		return false
-	}
-	return paused[name]
+	return serviceSetContains(pausedServicesFile(), name)
 }
 
 // SetServicePaused marks or clears the manual-stop flag for the named service.
 func SetServicePaused(name string, paused bool) error {
-	m, err := loadPausedServices()
-	if err != nil {
-		m = map[string]bool{}
-	}
-	if paused {
-		m[name] = true
-	} else {
-		delete(m, name)
-	}
-	return savePausedServices(m)
+	return serviceSetUpdate(pausedServicesFile(), name, paused)
 }

--- a/internal/config/service_manual.go
+++ b/internal/config/service_manual.go
@@ -4,134 +4,38 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"gopkg.in/yaml.v3"
 )
 
 func manuallyStartedServicesFile() string {
 	return filepath.Join(DataDir(), "manually-started-services.yaml")
 }
 
-func loadManuallyStartedServices() (map[string]bool, error) {
-	data, err := os.ReadFile(manuallyStartedServicesFile())
-	if os.IsNotExist(err) {
-		return map[string]bool{}, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	var names []string
-	if err := yaml.Unmarshal(data, &names); err != nil {
-		return nil, err
-	}
-	m := make(map[string]bool, len(names))
-	for _, n := range names {
-		m[n] = true
-	}
-	return m, nil
-}
-
-func saveManuallyStartedServices(m map[string]bool) error {
-	var names []string
-	for n := range m {
-		names = append(names, n)
-	}
-	if err := os.MkdirAll(DataDir(), 0755); err != nil {
-		return err
-	}
-	data, err := yaml.Marshal(names)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(manuallyStartedServicesFile(), data, 0644)
-}
-
 // ServiceIsManuallyStarted returns true if the service was explicitly started by
 // the user (via `lerd service start` or the dashboard), making it exempt from
 // auto-stop when no sites reference it.
 func ServiceIsManuallyStarted(name string) bool {
-	m, err := loadManuallyStartedServices()
-	if err != nil {
-		return false
-	}
-	return m[name]
+	return serviceSetContains(manuallyStartedServicesFile(), name)
 }
 
 // SetServiceManuallyStarted marks or clears the manually-started flag for the
 // named service.
 func SetServiceManuallyStarted(name string, v bool) error {
-	m, err := loadManuallyStartedServices()
-	if err != nil {
-		m = map[string]bool{}
-	}
-	if v {
-		m[name] = true
-	} else {
-		delete(m, name)
-	}
-	return saveManuallyStartedServices(m)
+	return serviceSetUpdate(manuallyStartedServicesFile(), name, v)
 }
 
 func pinnedServicesFile() string {
 	return filepath.Join(DataDir(), "pinned-services.yaml")
 }
 
-func loadPinnedServices() (map[string]bool, error) {
-	data, err := os.ReadFile(pinnedServicesFile())
-	if os.IsNotExist(err) {
-		return map[string]bool{}, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	var names []string
-	if err := yaml.Unmarshal(data, &names); err != nil {
-		return nil, err
-	}
-	m := make(map[string]bool, len(names))
-	for _, n := range names {
-		m[n] = true
-	}
-	return m, nil
-}
-
-func savePinnedServices(m map[string]bool) error {
-	var names []string
-	for n := range m {
-		names = append(names, n)
-	}
-	if err := os.MkdirAll(DataDir(), 0755); err != nil {
-		return err
-	}
-	data, err := yaml.Marshal(names)
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(pinnedServicesFile(), data, 0644)
-}
-
 // ServiceIsPinned returns true if the service has been pinned by the user,
 // meaning it will never be auto-stopped even when no sites reference it.
 func ServiceIsPinned(name string) bool {
-	m, err := loadPinnedServices()
-	if err != nil {
-		return false
-	}
-	return m[name]
+	return serviceSetContains(pinnedServicesFile(), name)
 }
 
 // SetServicePinned marks or clears the pinned flag for the named service.
 func SetServicePinned(name string, v bool) error {
-	m, err := loadPinnedServices()
-	if err != nil {
-		m = map[string]bool{}
-	}
-	if v {
-		m[name] = true
-	} else {
-		delete(m, name)
-	}
-	return savePinnedServices(m)
+	return serviceSetUpdate(pinnedServicesFile(), name, v)
 }
 
 // CountSitesUsingPHP returns how many non-ignored, non-paused sites are

--- a/internal/config/service_set.go
+++ b/internal/config/service_set.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// loadServiceNameSet reads a yaml list of service names from path and returns
+// it as a set. A missing file is treated as an empty set, not an error.
+func loadServiceNameSet(path string) (map[string]bool, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return map[string]bool{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	if err := yaml.Unmarshal(data, &names); err != nil {
+		return nil, err
+	}
+	m := make(map[string]bool, len(names))
+	for _, n := range names {
+		m[n] = true
+	}
+	return m, nil
+}
+
+// saveServiceNameSet writes the set back to path as a yaml list, creating the
+// data directory if needed.
+func saveServiceNameSet(path string, m map[string]bool) error {
+	names := make([]string, 0, len(m))
+	for n := range m {
+		names = append(names, n)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(names)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// serviceSetContains reports whether name is in the set stored at path.
+// Any read or parse error is treated as "not a member" so callers don't have
+// to distinguish missing-file from on-disk corruption.
+func serviceSetContains(path, name string) bool {
+	m, err := loadServiceNameSet(path)
+	if err != nil {
+		return false
+	}
+	return m[name]
+}
+
+// serviceSetUpdate flips name's membership in the set stored at path.
+func serviceSetUpdate(path, name string, want bool) error {
+	m, err := loadServiceNameSet(path)
+	if err != nil {
+		m = map[string]bool{}
+	}
+	if want {
+		m[name] = true
+	} else {
+		delete(m, name)
+	}
+	return saveServiceNameSet(path, m)
+}

--- a/internal/config/service_set_test.go
+++ b/internal/config/service_set_test.go
@@ -1,0 +1,133 @@
+package config
+
+import "testing"
+
+// These tests pin down the round-trip behaviour of the three service-name-set
+// pairs (paused / manually-started / pinned) so the helper extraction below
+// cannot silently change semantics.
+
+func TestServicePaused_RoundTrip(t *testing.T) {
+	setDataDir(t)
+
+	if ServiceIsPaused("redis") {
+		t.Fatal("expected redis not paused on empty store")
+	}
+
+	if err := SetServicePaused("redis", true); err != nil {
+		t.Fatalf("SetServicePaused true: %v", err)
+	}
+	if !ServiceIsPaused("redis") {
+		t.Fatal("expected redis paused after Set(true)")
+	}
+
+	if err := SetServicePaused("redis", false); err != nil {
+		t.Fatalf("SetServicePaused false: %v", err)
+	}
+	if ServiceIsPaused("redis") {
+		t.Fatal("expected redis not paused after Set(false)")
+	}
+}
+
+func TestServiceManuallyStarted_RoundTrip(t *testing.T) {
+	setDataDir(t)
+
+	if ServiceIsManuallyStarted("postgres") {
+		t.Fatal("expected postgres not manually-started on empty store")
+	}
+
+	if err := SetServiceManuallyStarted("postgres", true); err != nil {
+		t.Fatalf("SetServiceManuallyStarted true: %v", err)
+	}
+	if !ServiceIsManuallyStarted("postgres") {
+		t.Fatal("expected postgres manually-started after Set(true)")
+	}
+
+	if err := SetServiceManuallyStarted("postgres", false); err != nil {
+		t.Fatalf("SetServiceManuallyStarted false: %v", err)
+	}
+	if ServiceIsManuallyStarted("postgres") {
+		t.Fatal("expected postgres not manually-started after Set(false)")
+	}
+}
+
+func TestServicePinned_RoundTrip(t *testing.T) {
+	setDataDir(t)
+
+	if ServiceIsPinned("mysql") {
+		t.Fatal("expected mysql not pinned on empty store")
+	}
+
+	if err := SetServicePinned("mysql", true); err != nil {
+		t.Fatalf("SetServicePinned true: %v", err)
+	}
+	if !ServiceIsPinned("mysql") {
+		t.Fatal("expected mysql pinned after Set(true)")
+	}
+
+	if err := SetServicePinned("mysql", false); err != nil {
+		t.Fatalf("SetServicePinned false: %v", err)
+	}
+	if ServiceIsPinned("mysql") {
+		t.Fatal("expected mysql not pinned after Set(false)")
+	}
+}
+
+func TestServiceSets_AreIndependent(t *testing.T) {
+	setDataDir(t)
+
+	if err := SetServicePaused("redis", true); err != nil {
+		t.Fatalf("SetServicePaused: %v", err)
+	}
+	if err := SetServiceManuallyStarted("redis", true); err != nil {
+		t.Fatalf("SetServiceManuallyStarted: %v", err)
+	}
+	if err := SetServicePinned("redis", true); err != nil {
+		t.Fatalf("SetServicePinned: %v", err)
+	}
+
+	if err := SetServicePaused("redis", false); err != nil {
+		t.Fatalf("SetServicePaused false: %v", err)
+	}
+
+	if ServiceIsPaused("redis") {
+		t.Fatal("paused should be cleared")
+	}
+	if !ServiceIsManuallyStarted("redis") {
+		t.Fatal("manually-started should still be set after clearing paused")
+	}
+	if !ServiceIsPinned("redis") {
+		t.Fatal("pinned should still be set after clearing paused")
+	}
+}
+
+func TestServicePaused_PersistsAcrossLoads(t *testing.T) {
+	setDataDir(t)
+
+	if err := SetServicePaused("a", true); err != nil {
+		t.Fatalf("SetServicePaused a: %v", err)
+	}
+	if err := SetServicePaused("b", true); err != nil {
+		t.Fatalf("SetServicePaused b: %v", err)
+	}
+
+	if !ServiceIsPaused("a") || !ServiceIsPaused("b") {
+		t.Fatal("expected a and b paused")
+	}
+	if ServiceIsPaused("c") {
+		t.Fatal("did not expect c paused")
+	}
+}
+
+func TestServiceIs_MissingFile(t *testing.T) {
+	setDataDir(t)
+
+	if ServiceIsPaused("anything") {
+		t.Error("ServiceIsPaused on missing file should be false")
+	}
+	if ServiceIsManuallyStarted("anything") {
+		t.Error("ServiceIsManuallyStarted on missing file should be false")
+	}
+	if ServiceIsPinned("anything") {
+		t.Error("ServiceIsPinned on missing file should be false")
+	}
+}

--- a/internal/nginx/reload_warn.go
+++ b/internal/nginx/reload_warn.go
@@ -1,0 +1,20 @@
+package nginx
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// ReloadOrWarn reloads nginx and, on failure, prints a single warning line
+// to stdout. Pass indent="" for top-level output, or a leading-space prefix
+// when the warning sits under an indented status line in CLI output.
+func ReloadOrWarn(indent string) {
+	reloadOrWarn(Reload, os.Stdout, indent)
+}
+
+func reloadOrWarn(reload func() error, w io.Writer, indent string) {
+	if err := reload(); err != nil {
+		fmt.Fprintf(w, "%s[WARN] nginx reload: %v\n", indent, err)
+	}
+}

--- a/internal/nginx/reload_warn_test.go
+++ b/internal/nginx/reload_warn_test.go
@@ -1,0 +1,31 @@
+package nginx
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestReloadOrWarn_SilentOnSuccess(t *testing.T) {
+	var buf bytes.Buffer
+	reloadOrWarn(func() error { return nil }, &buf, "")
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output on success, got %q", buf.String())
+	}
+}
+
+func TestReloadOrWarn_PrintsOnFailure(t *testing.T) {
+	var buf bytes.Buffer
+	reloadOrWarn(func() error { return errors.New("boom") }, &buf, "")
+	if got, want := buf.String(), "[WARN] nginx reload: boom\n"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestReloadOrWarn_HonoursIndent(t *testing.T) {
+	var buf bytes.Buffer
+	reloadOrWarn(func() error { return errors.New("boom") }, &buf, "  ")
+	if got, want := buf.String(), "  [WARN] nginx reload: boom\n"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Two cross-cutting dedup passes, both behaviour-preserving and TDD'd.

- **`internal/config`**: `paused.go` and `service_manual.go` each carried their own load/save/Is/Set quartet for a yaml list of service names (paused, manually-started, pinned). The three implementations differed only in the file path. Extracted four unexported helpers (`loadServiceNameSet`, `saveServiceNameSet`, `serviceSetContains`, `serviceSetUpdate`) into a new `service_set.go`; the six exported wrappers collapse to one-line delegations. `service_set_test.go` pins the previously-untested round-trip, set-independence, persistence-across-loads, and missing-file behaviour.

- **`internal/nginx`**: nine occurrences of `if err := nginx.Reload(); err != nil { fmt.Printf("[WARN] nginx reload: %v\n", err) }` across six files in `internal/cli` (`domain.go`, `secure.go`, `pause.go`, `park.go`, `unpark.go`, `isolate.go`) become a single `nginx.ReloadOrWarn(indent string)`. The `indent` parameter preserves the two callers (park, unpark) that print the warning under an indented status line. `reload_warn_test.go` covers silent-on-success, prints-on-failure, and indent-honoured.

Public API unchanged, on-disk yaml format unchanged (verified byte-for-byte against the live empty-list `[]\n` form), CLI output for the modified commands unchanged. Net production code drop: 75 lines, plus 9 new tests covering paths that previously had none.