### PR TITLE
release: v1.20.0-beta.2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,10 +7,13 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [1.20.0-beta.2] — 2026-05-11
+
+Second beta of the 1.20.0 line. The TUI catches up to the dashboard: service update / rollback keybinds, a failing-workers header pill, and per-worktree controls (workers, isolated DB, LAN share, PHP / Node pickers) in the site detail pane. PHP 7.4 and 8.0 land as a frozen legacy tier for old apps, `lerd php:ext add` learns `--apk-deps` for extensions that need extra Alpine build packages, the dashboard ships in German, Indonesian and Dutch (plus a wide i18n pass across all seven locales), and the MCP server gains `workers_mode`, `bug_report`, and a `branch` param on the PHP / Node version tools. Plus the dashboard update-banner fixes from the post-beta.1 queue.
 
 ### Fixed
 
+- **`lerd install` (and `lerd update`, which runs install) briefly dropped `.test` resolution on every run.** The installer unconditionally `systemctl restart`ed `lerd-dns`, which tears down and recreates the podman container — a few-second window where port 5300 isn't bound and `*.test` won't resolve. It now diffs the dnsmasq config (`lerd.conf`) and the `lerd-dns` quadlet against what's already on disk and only restarts when one of them actually changed (or the container isn't running); a no-op reinstall, the common case after a version bump, leaves the live container alone. New `fileChangedBy` helper wraps the read-mutate-read diff. macOS (native dnsmasq, no container teardown) is unchanged.
 - **Dashboard "Open terminal & update" button failed with `lerd: command not found`.** The handler shelled out via `sh -c "lerd update; …"`, but the spawned terminal inherits a non-login shell environment that doesn't source `.bashrc` / `.zshrc`, so `~/.local/bin` is off `PATH`. The script now uses `os.Executable()` to resolve the absolute path of the running `lerd-ui` binary (which is the `lerd` binary itself) before passing it to the shell. Same fix pattern the TUI's `runLerd` already uses.
 - **Dashboard update banner showed `Lerd vv1.19.2 is available`.** Two bugs compounded: the wire payload from `/api/version` returned the GitHub tag verbatim (with leading `v`) while the Svelte template `Lerd v{version} is available` already prepends `v`, producing the double-`v`. `handleVersion` now strips the `v` via `lerdUpdate.StripV` before sending so the wire data is bare and the template renders cleanly.
 - **`internal/update` test pollution rewrote the user's real `update-check.json`.** `withTempCache` set `XDG_CONFIG_HOME` but `config.UpdateCheckFile` reads `XDG_DATA_HOME`, so test cache writes leaked to `~/.local/share/lerd/update-check.json` and surfaced bogus version tags (e.g. `v1.19.2`) in the dashboard banner for 24h. Test now sets the correct env var so writes stay in the temp dir.

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -41,6 +41,20 @@ func NewInstallCmd() *cobra.Command {
 func step(label string) { fmt.Printf("  --> %s ... ", label) }
 func ok()               { fmt.Println("OK") }
 
+// fileChangedBy runs mutate and reports whether the file at path differs
+// before vs after. A read error on either side is treated as empty content,
+// so a file that didn't exist before and does after counts as a change. Used
+// by the install pass to bounce a unit only when its on-disk config actually
+// moved, rather than on every reinstall.
+func fileChangedBy(path string, mutate func() error) (bool, error) {
+	before, _ := os.ReadFile(path)
+	if err := mutate(); err != nil {
+		return false, err
+	}
+	after, _ := os.ReadFile(path)
+	return string(after) != string(before), nil
+}
+
 func runInstall(cmd *cobra.Command, _ []string) error {
 	fmt.Println("==> Installing Lerd")
 
@@ -221,6 +235,12 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		teardownDNS()
 	}
 
+	// Tracks whether the dnsmasq config or the lerd-dns quadlet actually
+	// changed this run. A no-op reinstall (the common case after a version
+	// bump) then leaves the running container alone instead of bouncing it,
+	// which used to drop .test resolution for a few seconds.
+	dnsChanged := false
+
 	if wantDNS {
 		// 4. mkcert CA, interactive (may prompt for sudo)
 		fmt.Println("  --> Installing mkcert CA")
@@ -232,9 +252,14 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 
 		// 5. DNS config + sudoers
 		step("Writing DNS configuration")
-		if err := dns.WriteDnsmasqConfig(config.DnsmasqDir()); err != nil {
+		dnsConfPath := filepath.Join(config.DnsmasqDir(), "lerd.conf")
+		confChanged, err := fileChangedBy(dnsConfPath, func() error {
+			return dns.WriteDnsmasqConfig(config.DnsmasqDir())
+		})
+		if err != nil {
 			return err
 		}
+		dnsChanged = dnsChanged || confChanged
 		ok()
 
 		fmt.Println("  --> Installing DNS sudoers rule")
@@ -380,9 +405,14 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 
 	if wantDNS {
 		step("Writing DNS service unit")
-		if err := writeDNSUnit(os.Stdout); err != nil {
+		dnsUnitPath := filepath.Join(config.QuadletDir(), "lerd-dns.container")
+		unitChanged, err := fileChangedBy(dnsUnitPath, func() error {
+			return writeDNSUnit(os.Stdout)
+		})
+		if err != nil {
 			return err
 		}
+		dnsChanged = dnsChanged || unitChanged
 		ok()
 	}
 
@@ -563,9 +593,20 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	// On Linux, DNS is a container — start it after images are pulled.
 	// On macOS it was already started before RunParallel above.
 	if wantDNS && isDNSContainerUnit() {
-		step("Starting lerd-dns")
-		if err := services.Mgr.Restart("lerd-dns"); err != nil {
-			fmt.Printf("    WARN: %v\n", err)
+		// Only bounce the running container when its config or quadlet
+		// actually changed. Otherwise Start is a no-op against the live
+		// unit, so a routine reinstall doesn't drop .test resolution.
+		dnsRunning, _ := podman.ContainerRunning("lerd-dns")
+		if dnsChanged || !dnsRunning {
+			step("Starting lerd-dns")
+			if err := services.Mgr.Restart("lerd-dns"); err != nil {
+				fmt.Printf("    WARN: %v\n", err)
+			}
+		} else {
+			step("Checking lerd-dns")
+			if err := services.Mgr.Start("lerd-dns"); err != nil {
+				fmt.Printf("    WARN: %v\n", err)
+			}
 		}
 		ok()
 

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -73,6 +74,48 @@ func TestPullDNSImages(t *testing.T) {
 		if len(jobs) != 0 {
 			t.Error("pullDNSImages should return nil on macOS")
 		}
+	}
+}
+
+func TestFileChangedBy(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f")
+
+	// Missing before, written after -> changed.
+	changed, err := fileChangedBy(path, func() error { return os.WriteFile(path, []byte("a"), 0644) })
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !changed {
+		t.Error("creating the file should count as a change")
+	}
+
+	// Same content rewritten -> not changed.
+	changed, err = fileChangedBy(path, func() error { return os.WriteFile(path, []byte("a"), 0644) })
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if changed {
+		t.Error("rewriting identical content should not count as a change")
+	}
+
+	// Different content -> changed.
+	changed, err = fileChangedBy(path, func() error { return os.WriteFile(path, []byte("b"), 0644) })
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !changed {
+		t.Error("new content should count as a change")
+	}
+
+	// mutate error is propagated and reported as no change.
+	wantErr := errors.New("boom")
+	changed, err = fileChangedBy(path, func() error { return wantErr })
+	if !errors.Is(err, wantErr) {
+		t.Errorf("expected mutate error to propagate, got %v", err)
+	}
+	if changed {
+		t.Error("a failed mutate should report no change")
 	}
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.20.0-beta.1"
+	Version = "1.20.0-beta.2"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
Second beta of the 1.20.0 line: TUI service update/rollback keybinds, a failing-workers header pill, and per-worktree controls in the site detail pane; PHP 7.4 / 8.0 frozen legacy tier; `lerd php:ext add --apk-deps`; de/id/nl locales plus a wide i18n pass; MCP workers_mode / bug_report tools and a branch param on the PHP/Node version tools; plus the post-beta.1 dashboard update-banner fixes.

Also stops `lerd install` from restarting lerd-dns on every run — it tore down and recreated the podman container, dropping .test resolution for a few seconds on each reinstall/update. Install now diffs the dnsmasq config and the lerd-dns quadlet and only restarts when one actually changed (or the container isn't running). New fileChangedBy helper wraps the read-mutate-read diff.