### PR TITLE
feat: per-worktree dump tagging + worktree-add warnings + macOS plist heal fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,18 @@ LDFLAGS    = -s -w \
 
 .PHONY: build build-tray build-ui install-ui-deps test-ui install install-installer test clean release release-snapshot
 
-install-ui-deps:
-	@if [ ! -d "$(UI_DIR)/node_modules" ]; then \
-		cd $(UI_DIR) && npm ci; \
-	fi
+UI_INSTALL_STAMP = $(UI_DIR)/node_modules/.package-lock.json
 
-build-ui: install-ui-deps
+install-ui-deps: $(UI_INSTALL_STAMP)
+
+$(UI_INSTALL_STAMP): $(UI_DIR)/package-lock.json $(UI_DIR)/package.json
+	cd $(UI_DIR) && npm ci
+	@touch $@
+
+build-ui: $(UI_INSTALL_STAMP)
 	cd $(UI_DIR) && npm run build
 
-test-ui: install-ui-deps
+test-ui: $(UI_INSTALL_STAMP)
 	cd $(UI_DIR) && npm test
 
 build: build-ui

--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -609,7 +609,7 @@ func scanWorktrees() bool {
 		}
 		for _, wt := range worktrees {
 			gitpkg.EnsureWorktreeDeps(s.Path, wt.Path, wt.Domain, s.Secured)
-			vhostErr := nginx.GenerateWorktreeVhostFor(wt.Domain, wt.Path, s.PHPVersion, s.PrimaryDomain(), s.Secured)
+			vhostErr := nginx.GenerateWorktreeVhostFor(wt.Domain, wt.Path, s.PHPVersion, s.PrimaryDomain(), s.Name, wt.Branch, s.Secured)
 			if vhostErr != nil {
 				fmt.Printf("[WARN] worktree vhost for %s: %v\n", wt.Domain, vhostErr)
 				continue
@@ -648,7 +648,7 @@ func syncWorktree(sitePath, worktreeName, action string, pruneStale bool) bool {
 		}
 		gitpkg.EnsureWorktreeDeps(sitePath, wt.Path, wt.Domain, site.Secured)
 		effectivePHP := config.WorktreePHPVersion(wt.Path, site.PHPVersion)
-		vhostErr := nginx.GenerateWorktreeVhostFor(wt.Domain, wt.Path, effectivePHP, site.PrimaryDomain(), site.Secured)
+		vhostErr := nginx.GenerateWorktreeVhostFor(wt.Domain, wt.Path, effectivePHP, site.PrimaryDomain(), site.Name, wt.Branch, site.Secured)
 		if site.Secured {
 			if reissueErr := certs.ReissueCertForWorktree(*site); reissueErr != nil {
 				fmt.Printf("[WARN] reissue cert for worktree %s: %v\n", wt.Domain, reissueErr)
@@ -687,9 +687,9 @@ func cleanupWorktreeVhosts(site *config.Site) bool {
 		effectivePHP := config.WorktreePHPVersion(wt.Path, site.PHPVersion)
 		var vhostErr error
 		if site.Secured {
-			vhostErr = nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, effectivePHP, site.PrimaryDomain())
+			vhostErr = nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, effectivePHP, site.PrimaryDomain(), site.Name, wt.Branch)
 		} else {
-			vhostErr = nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, effectivePHP)
+			vhostErr = nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, effectivePHP, site.Name, wt.Branch)
 		}
 		if vhostErr != nil {
 			fmt.Printf("[WARN] worktree vhost for %s: %v\n", wt.Domain, vhostErr)

--- a/internal/certs/secure.go
+++ b/internal/certs/secure.go
@@ -50,7 +50,7 @@ func SecureSite(site config.Site) error {
 	if worktrees, err := gitpkg.DetectWorktrees(site.Path, site.PrimaryDomain()); err == nil {
 		for _, wt := range worktrees {
 			effectivePHP := config.WorktreePHPVersion(wt.Path, site.PHPVersion)
-			_ = nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, effectivePHP, site.PrimaryDomain())
+			_ = nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, effectivePHP, site.PrimaryDomain(), site.Name, wt.Branch)
 			envfile.SyncPrimaryDomain(wt.Path, wt.Domain, true) //nolint:errcheck
 		}
 	}
@@ -119,7 +119,7 @@ func UnsecureSite(site config.Site) error {
 	if worktrees, err := gitpkg.DetectWorktrees(site.Path, site.PrimaryDomain()); err == nil {
 		for _, wt := range worktrees {
 			effectivePHP := config.WorktreePHPVersion(wt.Path, site.PHPVersion)
-			_ = nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, effectivePHP)
+			_ = nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, effectivePHP, site.Name, wt.Branch)
 			envfile.SyncPrimaryDomain(wt.Path, wt.Domain, false) //nolint:errcheck
 		}
 	}

--- a/internal/cli/isolate.go
+++ b/internal/cli/isolate.go
@@ -76,9 +76,9 @@ func regenerateWorktreeVhost(site *config.Site, branch, phpVersion string) error
 			continue
 		}
 		if site.Secured {
-			return nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, phpVersion, site.PrimaryDomain())
+			return nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, phpVersion, site.PrimaryDomain(), site.Name, wt.Branch)
 		}
-		return nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, phpVersion)
+		return nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, phpVersion, site.Name, wt.Branch)
 	}
 	return fmt.Errorf("worktree %q not found", branch)
 }

--- a/internal/cli/migrate_tld.go
+++ b/internal/cli/migrate_tld.go
@@ -90,7 +90,7 @@ func migrateSiteTLD(oldTLD, newTLD string, forceUnsecure bool) []string {
 
 		removeStaleVhosts(oldPrimary)
 		newPrimary := s.PrimaryDomain()
-		migrateWorktreeVhosts(worktrees, newPrimary, s.PHPVersion, s.Secured)
+		migrateWorktreeVhosts(worktrees, newPrimary, s.PHPVersion, s.Name, s.Secured)
 
 		// Reissue the parent cert under the NEW primary so wildcard SANs
 		// cover the renamed worktree subdomains. Without this, SSL
@@ -130,12 +130,12 @@ func migrateSiteTLD(oldTLD, newTLD string, forceUnsecure bool) []string {
 // <branch>.<newPrimary> domain, and rewrites the worktree's .env APP_URL.
 // Worktree errors are warnings, not fatal; the parent site rename has already
 // landed and partial worktree state is preferable to abandoning the migration.
-func migrateWorktreeVhosts(worktrees []gitpkg.Worktree, newPrimary, phpVersion string, secured bool) {
+func migrateWorktreeVhosts(worktrees []gitpkg.Worktree, newPrimary, phpVersion, siteName string, secured bool) {
 	for _, wt := range worktrees {
 		removeStaleVhosts(wt.Domain)
 		newWTDomain := wt.Branch + "." + newPrimary
 		effectivePHP := config.WorktreePHPVersion(wt.Path, phpVersion)
-		err := nginx.GenerateWorktreeVhostFor(newWTDomain, wt.Path, effectivePHP, newPrimary, secured)
+		err := nginx.GenerateWorktreeVhostFor(newWTDomain, wt.Path, effectivePHP, newPrimary, siteName, wt.Branch, secured)
 		if err != nil {
 			fmt.Printf("    WARN: worktree %s: regenerate vhost: %v\n", wt.Branch, err)
 		}

--- a/internal/cli/migrate_tld_test.go
+++ b/internal/cli/migrate_tld_test.go
@@ -134,7 +134,7 @@ func TestMigrateWorktreeVhosts_RewritesConfsAndEnv(t *testing.T) {
 	worktrees := []gitpkg.Worktree{
 		{Name: "wt", Branch: "feat-x", Path: wtPath, Domain: "feat-x.alpha.test"},
 	}
-	migrateWorktreeVhosts(worktrees, "alpha.localhost", "8.4", false)
+	migrateWorktreeVhosts(worktrees, "alpha.localhost", "8.4", "alpha", false)
 
 	if _, err := os.Stat(staleConf); !os.IsNotExist(err) {
 		t.Errorf("stale worktree conf should be gone; stat err = %v", err)

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -511,9 +511,9 @@ func unpauseWorktrees(site *config.Site, phpVersion string) {
 		effectivePHP := config.WorktreePHPVersion(wt.Path, phpVersion)
 		var vhostErr error
 		if site.Secured {
-			vhostErr = nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, effectivePHP, site.PrimaryDomain())
+			vhostErr = nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, effectivePHP, site.PrimaryDomain(), site.Name, wt.Branch)
 		} else {
-			vhostErr = nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, effectivePHP)
+			vhostErr = nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, effectivePHP, site.Name, wt.Branch)
 		}
 		if vhostErr != nil {
 			fmt.Printf("  [WARN] restoring worktree vhost %s: %v\n", wt.Domain, vhostErr)

--- a/internal/cli/tinker.go
+++ b/internal/cli/tinker.go
@@ -61,7 +61,12 @@ type TinkerResult struct {
 // `tinker:` block when present, with a plain-`php` fallback. The mode
 // label returned in the response is the framework name (e.g. "laravel")
 // or "php" for the fallback.
-func RunTinker(ctx context.Context, sitePath, code string) (TinkerResult, error) {
+//
+// siteName + branch are forwarded to the container as LERD_SITE / LERD_BRANCH
+// env vars so the dump bridge tags `dump()` / `dd()` events with the same
+// identifiers FPM requests use (otherwise tinker dumps land under the
+// worktree's directory basename rather than the parent site).
+func RunTinker(ctx context.Context, sitePath, siteName, branch, code string) (TinkerResult, error) {
 	res := TinkerResult{}
 	if strings.TrimSpace(code) == "" {
 		return res, fmt.Errorf("code is empty")
@@ -108,6 +113,12 @@ func RunTinker(ctx context.Context, sitePath, code string) (TinkerResult, error)
 
 	dumpFn := detectDumpFunction(sitePath, mode)
 	envArgs := tinkerEnvArgs(sitePath, home, composerHome)
+	if siteName != "" {
+		envArgs = append(envArgs, "--env", "LERD_SITE="+siteName)
+	}
+	if branch != "" {
+		envArgs = append(envArgs, "--env", "LERD_BRANCH="+branch)
+	}
 
 	var argv []string
 	var stdinPipe string

--- a/internal/cli/worktree_add.go
+++ b/internal/cli/worktree_add.go
@@ -123,7 +123,7 @@ func ApplyWorktreeBuildChoice(site *config.Site, worktreePath string, choice wor
 		}
 	case "script":
 		logf(log, "Running npm run %s...", choice.value)
-		if err := gitpkg.RunNpmScript(worktreePath, choice.value); err != nil {
+		if err := gitpkg.RunNpmScript(worktreePath, choice.value, log); err != nil {
 			logf(log, "[WARN] npm run %s failed: %v, first request will throw ViteManifestNotFoundException; rerun manually after fixing.", choice.value, err)
 		} else {
 			logf(log, "Frontend built.")

--- a/internal/cli/worktree_ui.go
+++ b/internal/cli/worktree_ui.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,35 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	gitpkg "github.com/geodro/lerd/internal/git"
 )
+
+// warningCapturingWriter forwards every write to the underlying writer while
+// scanning for lines prefixed with "[WARN]" so RunWorktreeAdd can return them
+// to the caller. RunWorktreeAdd treats most failures (timeout waiting for
+// installs, build script error, db setup skipped) as soft warnings and keeps
+// going — the dashboard needs to know they happened so it doesn't auto-close
+// the modal on a half-finished setup.
+type warningCapturingWriter struct {
+	w        io.Writer
+	buf      []byte
+	warnings []string
+}
+
+func (c *warningCapturingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.buf = append(c.buf, p[:n]...)
+	for {
+		i := bytes.IndexByte(c.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := strings.TrimRight(string(c.buf[:i]), "\r")
+		c.buf = c.buf[i+1:]
+		if strings.HasPrefix(strings.TrimSpace(line), "[WARN]") {
+			c.warnings = append(c.warnings, line)
+		}
+	}
+	return n, err
+}
 
 // WorktreeAddRequest carries the choices the dashboard (or any non-interactive
 // caller) makes for `lerd worktree add`, mirroring what the CLI's huh prompts
@@ -148,8 +178,12 @@ func normalizeAddRequest(sitePath string, req WorktreeAddRequest) WorktreeAddReq
 // RunWorktreeAdd creates a git worktree for site, waits for lerd's watcher to
 // install dependencies, applies the build choice, configures the database, and
 // optionally runs migrations. Progress lines are written to log (may be nil).
-// Returns the sanitized branch name and the checkout path.
-func RunWorktreeAdd(site *config.Site, req WorktreeAddRequest, log io.Writer) (string, string, error) {
+// Returns the sanitized branch name, the checkout path, and any "[WARN]" lines
+// emitted along the way so callers (e.g. the dashboard) can keep the modal
+// open and surface them instead of silently treating the setup as success.
+func RunWorktreeAdd(site *config.Site, req WorktreeAddRequest, log io.Writer) (string, string, []string, error) {
+	capturer := &warningCapturingWriter{w: log}
+	log = capturer
 	req = normalizeAddRequest(site.Path, req)
 	branchInput := req.NewBranch
 	if branchInput == "" {
@@ -160,7 +194,7 @@ func RunWorktreeAdd(site *config.Site, req WorktreeAddRequest, log io.Writer) (s
 
 	gitArgs, err := buildWorktreeAddGitArgs(req, checkoutPath)
 	if err != nil {
-		return "", "", err
+		return "", "", capturer.warnings, err
 	}
 	logf(log, "Running: git %s", strings.Join(gitArgs, " "))
 	gitCmd := exec.Command("git", gitArgs...)
@@ -168,7 +202,7 @@ func RunWorktreeAdd(site *config.Site, req WorktreeAddRequest, log io.Writer) (s
 	gitCmd.Stdout = log
 	gitCmd.Stderr = log
 	if err := gitCmd.Run(); err != nil {
-		return "", "", fmt.Errorf("git worktree add: %w", err)
+		return "", "", capturer.warnings, fmt.Errorf("git worktree add: %w", err)
 	}
 
 	logf(log, "Waiting for lerd to install dependencies (composer + JS)...")
@@ -193,7 +227,7 @@ func RunWorktreeAdd(site *config.Site, req WorktreeAddRequest, log io.Writer) (s
 		scheme = "https"
 	}
 	logf(log, "Worktree ready: %s://%s.%s", scheme, branch, site.PrimaryDomain())
-	return branch, checkoutPath, nil
+	return branch, checkoutPath, capturer.warnings, nil
 }
 
 // applyWorktreeBuildRequest resolves the UI build request against what's

--- a/internal/dumps/event.go
+++ b/internal/dumps/event.go
@@ -22,9 +22,13 @@ type Source struct {
 
 // Context describes where a dump came from. Type is "fpm" (web request) or
 // "cli" (artisan, tinker, queue worker). Empty fields are omitted on the wire.
+// Branch is non-empty only when the event originated inside a git worktree
+// (set by the bridge from LERD_BRANCH, injected by nginx for worktree vhosts
+// and by lerd's CLI helpers when shelling into a worktree path).
 type Context struct {
 	Type    string `json:"type"`
 	Site    string `json:"site,omitempty"`
+	Branch  string `json:"branch,omitempty"`
 	Domain  string `json:"domain,omitempty"`
 	Request string `json:"request,omitempty"`
 	PID     int    `json:"pid,omitempty"`

--- a/internal/git/copy.go
+++ b/internal/git/copy.go
@@ -129,8 +129,10 @@ func InstallDependencies(projectPath string) error {
 // RunNpmScript executes `<package-manager> run <script>` in projectPath,
 // using the lerd npm shim for npm projects so fnm's current Node version
 // wins and falling back to PATH for pnpm/yarn/bun. Exported for callers like
-// `lerd worktree add` that opt into a build step interactively.
-func RunNpmScript(projectPath, script string) error {
+// `lerd worktree add` that opt into a build step interactively. out receives
+// both stdout and stderr from the build; pass os.Stdout for CLI use or an
+// SSE writer to surface vite/webpack failures in the dashboard modal.
+func RunNpmScript(projectPath, script string, out io.Writer) error {
 	name, _ := jsPackageManager(projectPath)
 	var bin string
 	if name == "npm" {
@@ -140,7 +142,14 @@ func RunNpmScript(projectPath, script string) error {
 	} else {
 		return fmt.Errorf("%s not found on PATH", name)
 	}
-	return runIn(projectPath, bin, "run", script)
+	if out == nil {
+		out = os.Stdout
+	}
+	cmd := exec.Command(bin, "run", script)
+	cmd.Dir = projectPath
+	cmd.Stdout = out
+	cmd.Stderr = out
+	return cmd.Run()
 }
 
 // composerNeedsInstall reports whether composer install must run for the

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -59,6 +59,11 @@ type VhostData struct {
 	CustomContainer string // container name for custom container sites (e.g. "lerd-custom-nestapp")
 	CustomPort      int    // port the app listens on inside the custom container
 	BackendSSL      bool   // proxy to the container via HTTPS (app serves TLS on its own port)
+	// LerdSite / LerdBranch surface the parent site name and (for worktrees)
+	// the branch to PHP via fastcgi_param so the dump bridge can tag events
+	// with stable identifiers instead of guessing from DOCUMENT_ROOT.
+	LerdSite   string
+	LerdBranch string
 }
 
 // phpShort converts "8.4" → "84".
@@ -117,6 +122,7 @@ func GenerateVhost(site config.Site, phpVersion string) error {
 		Proxy:           hasProxy,
 		ProxyPath:       proxyPath,
 		ProxyPort:       proxyPort,
+		LerdSite:        site.Name,
 	}
 
 	var buf bytes.Buffer
@@ -158,6 +164,7 @@ func GenerateSSLVhost(site config.Site, phpVersion string) error {
 		Proxy:           hasProxy,
 		ProxyPath:       proxyPath,
 		ProxyPort:       proxyPort,
+		LerdSite:        site.Name,
 	}
 
 	var buf bytes.Buffer
@@ -305,16 +312,18 @@ func GenerateCustomSSLVhost(site config.Site) error {
 // based on the secured flag, so callers (scanWorktrees, syncWorktree,
 // migrateWorktreeVhosts) don't repeat the if/else around the two
 // underlying generators. parentDomain is consulted only on the SSL path.
-func GenerateWorktreeVhostFor(domain, path, phpVersion, parentDomain string, secured bool) error {
+// siteName + branch are forwarded so the worktree's PHP requests get tagged
+// with LERD_SITE / LERD_BRANCH for dump grouping.
+func GenerateWorktreeVhostFor(domain, path, phpVersion, parentDomain, siteName, branch string, secured bool) error {
 	if secured {
-		return GenerateWorktreeSSLVhost(domain, path, phpVersion, parentDomain)
+		return GenerateWorktreeSSLVhost(domain, path, phpVersion, parentDomain, siteName, branch)
 	}
-	return GenerateWorktreeVhost(domain, path, phpVersion)
+	return GenerateWorktreeVhost(domain, path, phpVersion, siteName, branch)
 }
 
 // GenerateWorktreeVhost renders the HTTP vhost template for a worktree checkout
 // and writes it to conf.d/<domain>.conf.
-func GenerateWorktreeVhost(domain, path, phpVersion string) error {
+func GenerateWorktreeVhost(domain, path, phpVersion, siteName, branch string) error {
 	tmplData, err := GetTemplate("vhost.conf.tmpl")
 	if err != nil {
 		return err
@@ -332,6 +341,8 @@ func GenerateWorktreeVhost(domain, path, phpVersion string) error {
 		PHPVersion:      phpVersion,
 		PHPVersionShort: phpShort(phpVersion),
 		PublicDir:       "public",
+		LerdSite:        siteName,
+		LerdBranch:      branch,
 	}
 
 	var buf bytes.Buffer
@@ -348,7 +359,7 @@ func GenerateWorktreeVhost(domain, path, phpVersion string) error {
 
 // GenerateWorktreeSSLVhost renders the SSL vhost template for a worktree checkout,
 // reusing the parent site's wildcard certificate (*.parentDomain).
-func GenerateWorktreeSSLVhost(domain, path, phpVersion, parentDomain string) error {
+func GenerateWorktreeSSLVhost(domain, path, phpVersion, parentDomain, siteName, branch string) error {
 	tmplData, err := GetTemplate("vhost-ssl.conf.tmpl")
 	if err != nil {
 		return err
@@ -367,6 +378,8 @@ func GenerateWorktreeSSLVhost(domain, path, phpVersion, parentDomain string) err
 		PHPVersionShort: phpShort(phpVersion),
 		CertDomain:      parentDomain,
 		PublicDir:       "public",
+		LerdSite:        siteName,
+		LerdBranch:      branch,
 	}
 
 	var buf bytes.Buffer

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -187,7 +187,7 @@ func TestGenerateVhost_confFileNamedAfterPrimary(t *testing.T) {
 
 func TestGenerateWorktreeVhost_createsConfFile(t *testing.T) {
 	confD := setupConfD(t)
-	if err := GenerateWorktreeVhost("feat-x.myapp.test", "/srv/myapp-feat", "8.3"); err != nil {
+	if err := GenerateWorktreeVhost("feat-x.myapp.test", "/srv/myapp-feat", "8.3", "myapp", "feat-x"); err != nil {
 		t.Fatalf("GenerateWorktreeVhost: %v", err)
 	}
 	content := readConf(t, filepath.Join(confD, "feat-x.myapp.test.conf"))
@@ -206,7 +206,7 @@ func TestGenerateWorktreeVhost_createsConfFile(t *testing.T) {
 
 func TestGenerateWorktreeSSLVhost_usesParentCert(t *testing.T) {
 	confD := setupConfD(t)
-	if err := GenerateWorktreeSSLVhost("feat-x.myapp.test", "/srv/myapp-feat", "8.3", "myapp.test"); err != nil {
+	if err := GenerateWorktreeSSLVhost("feat-x.myapp.test", "/srv/myapp-feat", "8.3", "myapp.test", "myapp", "feat-x"); err != nil {
 		t.Fatalf("GenerateWorktreeSSLVhost: %v", err)
 	}
 	content := readConf(t, filepath.Join(confD, "feat-x.myapp.test.conf"))
@@ -234,7 +234,7 @@ func TestGenerateWorktreeSSLVhost_usesParentCert(t *testing.T) {
 func TestGenerateWorktreeVhostFor_routesByFlag(t *testing.T) {
 	confD := setupConfD(t)
 
-	if err := GenerateWorktreeVhostFor("feat-x.myapp.test", "/srv/myapp-feat", "8.3", "myapp.test", false); err != nil {
+	if err := GenerateWorktreeVhostFor("feat-x.myapp.test", "/srv/myapp-feat", "8.3", "myapp.test", "myapp", "feat-x", false); err != nil {
 		t.Fatalf("HTTP wrapper: %v", err)
 	}
 	httpContent := readConf(t, filepath.Join(confD, "feat-x.myapp.test.conf"))
@@ -244,7 +244,7 @@ func TestGenerateWorktreeVhostFor_routesByFlag(t *testing.T) {
 
 	// Re-run with secured=true; the same conf path should now point at
 	// the parent's wildcard cert.
-	if err := GenerateWorktreeVhostFor("feat-x.myapp.test", "/srv/myapp-feat", "8.3", "myapp.test", true); err != nil {
+	if err := GenerateWorktreeVhostFor("feat-x.myapp.test", "/srv/myapp-feat", "8.3", "myapp.test", "myapp", "feat-x", true); err != nil {
 		t.Fatalf("HTTPS wrapper: %v", err)
 	}
 	sslContent := readConf(t, filepath.Join(confD, "feat-x.myapp.test.conf"))

--- a/internal/nginx/templates/vhost-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-ssl.conf.tmpl
@@ -49,7 +49,9 @@ server {
         fastcgi_param HTTP_X_FORWARDED_PORT $server_port;
         fastcgi_param HTTP_X_REAL_IP $remote_addr;
         fastcgi_param HTTP_X_FORWARDED_FOR $remote_addr;
-    }
+{{if .LerdSite}}        fastcgi_param LERD_SITE {{.LerdSite}};
+{{end}}{{if .LerdBranch}}        fastcgi_param LERD_BRANCH {{.LerdBranch}};
+{{end}}    }
 
     location ~ /\.ht {
         deny all;

--- a/internal/nginx/templates/vhost.conf.tmpl
+++ b/internal/nginx/templates/vhost.conf.tmpl
@@ -38,7 +38,9 @@ server {
         fastcgi_param HTTP_X_FORWARDED_PORT $server_port;
         fastcgi_param HTTP_X_REAL_IP $remote_addr;
         fastcgi_param HTTP_X_FORWARDED_FOR $remote_addr;
-    }
+{{if .LerdSite}}        fastcgi_param LERD_SITE {{.LerdSite}};
+{{end}}{{if .LerdBranch}}        fastcgi_param LERD_BRANCH {{.LerdBranch}};
+{{end}}    }
 
     location ~ /\.ht {
         deny all;

--- a/internal/podman/dumpbridge/dump-bridge.php
+++ b/internal/podman/dumpbridge/dump-bridge.php
@@ -84,11 +84,23 @@ namespace Lerd\DumpBridge {
         @\fclose($sock);
     }
 
+    // Read a tagging variable lerd may set either as a fastcgi_param (which
+    // lands in $_SERVER) or as a real environment variable (CLI/tinker via
+    // `podman exec --env`). $_SERVER first since FPM is the common case.
+    function lerd_var(string $key): string
+    {
+        if (!empty($_SERVER[$key])) {
+            return (string) $_SERVER[$key];
+        }
+        $env = getenv($key);
+        return $env === false ? '' : $env;
+    }
+
     function detect_site(): string
     {
-        $env = getenv('LERD_SITE');
-        if ($env !== false && $env !== '') {
-            return $env;
+        $v = lerd_var('LERD_SITE');
+        if ($v !== '') {
+            return $v;
         }
         if (\PHP_SAPI === 'cli') {
             $cwd = @getcwd();
@@ -98,6 +110,11 @@ namespace Lerd\DumpBridge {
             return basename(dirname($_SERVER['DOCUMENT_ROOT']));
         }
         return '';
+    }
+
+    function detect_branch(): string
+    {
+        return lerd_var('LERD_BRANCH');
     }
 
     function ulid(): string
@@ -140,6 +157,7 @@ namespace Lerd\DumpBridge {
         return [
             'type'    => \PHP_SAPI === 'cli' ? 'cli' : 'fpm',
             'site'    => detect_site(),
+            'branch'  => detect_branch(),
             'domain'  => isset($_SERVER['HTTP_HOST']) ? (string) $_SERVER['HTTP_HOST'] : '',
             'request' => isset($_SERVER['REQUEST_METHOD'])
                 ? $_SERVER['REQUEST_METHOD'].' '.($_SERVER['REQUEST_URI'] ?? '')

--- a/internal/tui/log_tail_darwin.go
+++ b/internal/tui/log_tail_darwin.go
@@ -41,7 +41,7 @@ func workerLogCmd(ctx context.Context, unit string) *exec.Cmd {
 //     infrastructure containers (FPM, nginx, services) are never misclassified.
 func isExecModeUnit(unit string) bool {
 	home, _ := os.UserHomeDir()
-	plist, err := os.ReadFile(filepath.Join(home, "Library", "LaunchAgents", "lerd."+unit+".plist"))
+	plist, err := os.ReadFile(filepath.Join(home, "Library", "LaunchAgents", unit+".plist"))
 	if err == nil {
 		return strings.Contains(string(plist), "<key>RunAtLoad</key>")
 	}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -2418,7 +2418,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		ensureWorktreeEnvIfBranch(site, branch)
 		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 		defer cancel()
-		res, err := cli.RunTinker(ctx, tinkerPath, body.Code)
+		res, err := cli.RunTinker(ctx, tinkerPath, site.Name, branch, body.Code)
 		resp := map[string]any{
 			"ok":          err == nil && res.ExitCode == 0,
 			"stdout":      res.Stdout,
@@ -3133,9 +3133,9 @@ func setWorktreePHPVersion(site *config.Site, branch, version string) error {
 			continue
 		}
 		if site.Secured {
-			return nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, version, site.PrimaryDomain())
+			return nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, version, site.PrimaryDomain(), site.Name, wt.Branch)
 		}
-		return nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, version)
+		return nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, version, site.Name, wt.Branch)
 	}
 	return fmt.Errorf("worktree %s not found", branch)
 }
@@ -3616,13 +3616,13 @@ func handleSiteWorktreeAdd(w http.ResponseWriter, r *http.Request) {
 		flusher.Flush()
 	}
 	sw := &sseLineWriter{w: w, f: flusher}
-	branch, _, addErr := cli.RunWorktreeAdd(site, req, sw)
+	branch, _, warnings, addErr := cli.RunWorktreeAdd(site, req, sw)
 	sw.flushTail()
 	if addErr != nil {
-		done(map[string]any{"ok": false, "error": addErr.Error()})
+		done(map[string]any{"ok": false, "error": addErr.Error(), "warnings": warnings})
 		return
 	}
-	done(map[string]any{"ok": true, "branch": branch, "domain": branch + "." + site.PrimaryDomain()})
+	done(map[string]any{"ok": true, "branch": branch, "domain": branch + "." + site.PrimaryDomain(), "warnings": warnings})
 }
 
 // syncLerdYAMLWorkersDelayed waits briefly for the worker unit to start, then syncs.

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -547,5 +547,7 @@
   "worktreeMgr_assetsHeading": "Frontend-Assets",
   "worktreeMgr_create": "Worktree erstellen",
   "worktreeMgr_creating": "Wird erstellt…",
-  "worktreeMgr_createFailed": "Worktree konnte nicht erstellt werden"
+  "worktreeMgr_createFailed": "Worktree konnte nicht erstellt werden",
+  "worktreeMgr_completedWithWarnings": "Mit Warnungen abgeschlossen",
+  "worktreeMgr_backToList": "Zurück zur Liste"
 }

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -547,5 +547,7 @@
   "worktreeMgr_assetsHeading": "Frontend assets",
   "worktreeMgr_create": "Create worktree",
   "worktreeMgr_creating": "Creating…",
-  "worktreeMgr_createFailed": "Could not create worktree"
+  "worktreeMgr_createFailed": "Could not create worktree",
+  "worktreeMgr_completedWithWarnings": "Completed with warnings",
+  "worktreeMgr_backToList": "Back to list"
 }

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -547,5 +547,7 @@
   "worktreeMgr_assetsHeading": "Recursos del frontend",
   "worktreeMgr_create": "Crear worktree",
   "worktreeMgr_creating": "Creando…",
-  "worktreeMgr_createFailed": "No se pudo crear el worktree"
+  "worktreeMgr_createFailed": "No se pudo crear el worktree",
+  "worktreeMgr_completedWithWarnings": "Completado con advertencias",
+  "worktreeMgr_backToList": "Volver a la lista"
 }

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -547,5 +547,7 @@
   "worktreeMgr_assetsHeading": "Ressources front-end",
   "worktreeMgr_create": "Créer le worktree",
   "worktreeMgr_creating": "Création…",
-  "worktreeMgr_createFailed": "Impossible de créer le worktree"
+  "worktreeMgr_createFailed": "Impossible de créer le worktree",
+  "worktreeMgr_completedWithWarnings": "Terminé avec des avertissements",
+  "worktreeMgr_backToList": "Retour à la liste"
 }

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -547,5 +547,7 @@
   "worktreeMgr_assetsHeading": "Aset frontend",
   "worktreeMgr_create": "Buat worktree",
   "worktreeMgr_creating": "Membuat…",
-  "worktreeMgr_createFailed": "Tidak dapat membuat worktree"
+  "worktreeMgr_createFailed": "Tidak dapat membuat worktree",
+  "worktreeMgr_completedWithWarnings": "Selesai dengan peringatan",
+  "worktreeMgr_backToList": "Kembali ke daftar"
 }

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -547,5 +547,7 @@
   "worktreeMgr_assetsHeading": "Frontend-assets",
   "worktreeMgr_create": "Worktree aanmaken",
   "worktreeMgr_creating": "Aanmaken…",
-  "worktreeMgr_createFailed": "Kan worktree niet aanmaken"
+  "worktreeMgr_createFailed": "Kan worktree niet aanmaken",
+  "worktreeMgr_completedWithWarnings": "Voltooid met waarschuwingen",
+  "worktreeMgr_backToList": "Terug naar de lijst"
 }

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -547,5 +547,7 @@
   "worktreeMgr_assetsHeading": "Recursos do frontend",
   "worktreeMgr_create": "Criar worktree",
   "worktreeMgr_creating": "A criar…",
-  "worktreeMgr_createFailed": "Não foi possível criar o worktree"
+  "worktreeMgr_createFailed": "Não foi possível criar o worktree",
+  "worktreeMgr_completedWithWarnings": "Concluído com avisos",
+  "worktreeMgr_backToList": "Voltar à lista"
 }

--- a/internal/ui/web/src/lib/dumpsStream.ts
+++ b/internal/ui/web/src/lib/dumpsStream.ts
@@ -12,6 +12,7 @@ export interface DumpSource {
 export interface DumpContext {
   type: 'fpm' | 'cli' | string;
   site?: string;
+  branch?: string;
   domain?: string;
   request?: string;
   pid?: number;

--- a/internal/ui/web/src/modals/WorktreeModal.svelte
+++ b/internal/ui/web/src/modals/WorktreeModal.svelte
@@ -66,6 +66,8 @@
   let migrate = $state(false);
   let build = $state('auto');
   let creating = $state(false);
+  let finished = $state(false);
+  let warnings = $state<string[]>([]);
   let logs = $state<string[]>([]);
   let scrollEl: HTMLDivElement | null = $state(null);
   let optsTimer: ReturnType<typeof setTimeout> | undefined;
@@ -107,11 +109,21 @@
     view = 'add';
     error = '';
     logs = [];
+    warnings = [];
+    finished = false;
     branchMode = 'new';
     newBranch = '';
     db = 'share';
     migrate = false;
     void loadOpts();
+  }
+
+  function backToList() {
+    view = 'list';
+    finished = false;
+    error = '';
+    warnings = [];
+    logs = [];
   }
 
   // When the new-branch name changes, refetch db options for that branch
@@ -123,12 +135,14 @@
 
   async function create() {
     creating = true;
+    finished = false;
     error = '';
+    warnings = [];
     logs = [];
     try {
-      const box: { result: { ok?: boolean; branch?: string; error?: string } | null } = {
-        result: null
-      };
+      const box: {
+        result: { ok?: boolean; branch?: string; error?: string; warnings?: string[] } | null;
+      } = { result: null };
       await streamWorktreeAdd(
         cur.domain,
         {
@@ -141,7 +155,12 @@
         },
         (ev) => {
           if (ev.done) {
-            box.result = { ok: ev.ok, branch: ev.branch, error: ev.error };
+            box.result = {
+              ok: ev.ok,
+              branch: ev.branch,
+              error: ev.error,
+              warnings: ev.warnings
+            };
             return;
           }
           if (ev.line !== undefined) {
@@ -153,14 +172,24 @@
         }
       );
       const result = box.result;
+      await loadSites();
+      warnings = result?.warnings ?? [];
       if (!result || !result.ok) {
         error = result?.error || m.worktreeMgr_createFailed();
+        finished = true;
         return;
       }
-      await loadSites();
+      // Stay on the logs view when anything emitted a [WARN] so the user
+      // can read the messages instead of the modal silently jumping back
+      // to the list with a half-finished setup.
+      if (warnings.length > 0) {
+        finished = true;
+        return;
+      }
       view = 'list';
     } catch (e) {
       error = e instanceof Error ? e.message : m.common_failed();
+      finished = true;
     } finally {
       creating = false;
     }
@@ -243,7 +272,7 @@
         </div>
       {/if}
     </div>
-  {:else if !creating}
+  {:else if !creating && !finished}
     <div class="px-5 py-4 space-y-4 max-h-[60vh] overflow-y-auto">
       <!-- branch -->
       <div class="space-y-1.5">
@@ -331,7 +360,16 @@
       </div>
     </div>
   {:else}
-    <div class="px-5 py-3">
+    <div class="px-5 py-3 space-y-2">
+      {#if finished && error}
+        <div class="rounded-lg border border-red-200 dark:border-red-500/30 bg-red-50 dark:bg-red-500/10 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+          {error}
+        </div>
+      {:else if finished && warnings.length > 0}
+        <div class="rounded-lg border border-amber-200 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+          {m.worktreeMgr_completedWithWarnings()}
+        </div>
+      {/if}
       <div
         bind:this={scrollEl}
         class="bg-gray-50 dark:bg-black/30 rounded-lg p-3 max-h-72 overflow-y-auto font-mono text-xs text-gray-600 dark:text-gray-400 space-y-0.5"
@@ -346,14 +384,16 @@
     </div>
   {/if}
 
-  {#if error}
+  {#if error && !finished}
     <div class="px-5 pb-1"><p class="text-xs text-red-500">{error}</p></div>
   {/if}
 
   {#snippet footer()}
     {#if view === 'list'}
       <DetailButton onclick={closeModal}>{m.common_close()}</DetailButton>
-      <DetailButton tone="primary" onclick={startAdd}>{m.worktreeMgr_add()}</DetailButton>
+      <DetailButton tone="primary" onclick={startAdd} disabled={confirmBranch !== ''}>{m.worktreeMgr_add()}</DetailButton>
+    {:else if finished}
+      <DetailButton tone="primary" onclick={backToList}>{m.worktreeMgr_backToList()}</DetailButton>
     {:else}
       {#if !creating}
         <DetailButton onclick={() => (view = 'list')}>{m.common_cancel()}</DetailButton>

--- a/internal/ui/web/src/stores/worktree.ts
+++ b/internal/ui/web/src/stores/worktree.ts
@@ -63,6 +63,7 @@ export interface WorktreeAddEvent {
   branch?: string;
   domain?: string;
   error?: string;
+  warnings?: string[];
 }
 
 // streamWorktreeAdd POSTs to the SSE endpoint and invokes onEvent for each
@@ -105,8 +106,16 @@ export async function streamWorktreeAdd(
               branch?: string;
               domain?: string;
               error?: string;
+              warnings?: string[];
             };
-            onEvent({ done: true, ok: Boolean(r.ok), branch: r.branch, domain: r.domain, error: r.error });
+            onEvent({
+              done: true,
+              ok: Boolean(r.ok),
+              branch: r.branch,
+              domain: r.domain,
+              error: r.error,
+              warnings: Array.isArray(r.warnings) ? r.warnings : []
+            });
           } catch {
             onEvent({ done: true, ok: false, error: 'bad done payload' });
           }

--- a/internal/watcher/exec_workers_darwin.go
+++ b/internal/watcher/exec_workers_darwin.go
@@ -243,7 +243,12 @@ func conflictingWorkerRunning(w expectedExecWorker) bool {
 // means the worker looks healthy.
 func workerNeedsHealing(unit string) string {
 	home, _ := os.UserHomeDir()
-	plistPath := filepath.Join(home, "Library", "LaunchAgents", "lerd."+unit+".plist")
+	// Plist file name mirrors the unit name (e.g. "lerd-horizon-acme.plist") —
+	// only the launchd Label inside the plist gets the "com.lerd." prefix
+	// (see services.plistPath / plistLabel). The earlier "lerd."+unit form
+	// looked for a file that never existed, so the heal loop fired every
+	// cooldown and pointlessly restarted healthy workers.
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", unit+".plist")
 	if _, err := os.Stat(plistPath); os.IsNotExist(err) {
 		return "plist missing"
 	}
@@ -324,9 +329,11 @@ func sweepOrphanWorkerArtifacts(expected map[string]bool) {
 			continue
 		}
 		// Also keep artifacts whose plist still exists — sweeping those
-		// would race a freshly-bootstrapped worker mid-launch.
+		// would race a freshly-bootstrapped worker mid-launch. Plist file
+		// is named after the unit (no "lerd." prefix; that lives on the
+		// launchd Label only).
 		home, _ := os.UserHomeDir()
-		if _, err := os.Stat(filepath.Join(home, "Library", "LaunchAgents", "lerd."+unit+".plist")); err == nil {
+		if _, err := os.Stat(filepath.Join(home, "Library", "LaunchAgents", unit+".plist")); err == nil {
 			continue
 		}
 		_ = os.Remove(filepath.Join(dir, name))

--- a/internal/watcher/exec_workers_darwin_test.go
+++ b/internal/watcher/exec_workers_darwin_test.go
@@ -84,3 +84,95 @@ func units(ws []expectedExecWorker) []string {
 	}
 	return out
 }
+
+// Locks in the LaunchAgents file-name convention: workerNeedsHealing must
+// read `~/Library/LaunchAgents/<unit>.plist`, NOT `lerd.<unit>.plist`. The
+// `com.lerd.` prefix lives only on the launchd Label inside the plist (see
+// services.plistPath / plistLabel). The earlier prefixed form mistook every
+// healthy worker for a missing plist, so the heal loop restarted them each
+// cooldown.
+func TestWorkerNeedsHealing_PlistFileName(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	laDir := filepath.Join(tmp, "Library", "LaunchAgents")
+	if err := os.MkdirAll(laDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const unit = "lerd-horizon-acme"
+
+	if got := workerNeedsHealing(unit); got != "plist missing" {
+		t.Fatalf("no plist present: got %q, want \"plist missing\"", got)
+	}
+
+	// Old buggy form only — the function must NOT match this, otherwise the
+	// path-prefix regression slips back in unnoticed.
+	legacy := filepath.Join(laDir, "lerd."+unit+".plist")
+	if err := os.WriteFile(legacy, []byte("<plist/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := workerNeedsHealing(unit); got != "plist missing" {
+		t.Fatalf("legacy lerd.<unit>.plist only: got %q, want \"plist missing\"", got)
+	}
+
+	// Correct form. The function should advance past the plist check —
+	// launchctl won't have our fake unit registered so we expect either
+	// "not loaded in launchd" or "loaded but no live process", but never
+	// "plist missing".
+	correct := filepath.Join(laDir, unit+".plist")
+	if err := os.WriteFile(correct, []byte("<plist/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := workerNeedsHealing(unit); got == "plist missing" {
+		t.Fatalf("<unit>.plist present: got \"plist missing\", expected to advance past the plist check")
+	}
+}
+
+// sweepOrphanWorkerArtifacts must keep .sh / .pid files whose plist still
+// exists on disk under the unit-name convention. The earlier `lerd.`+unit
+// path looked for a file that never existed, so the sweep happily deleted
+// guard scripts for healthy workers mid-launch.
+func TestSweepOrphanWorkerArtifacts_KeepsArtifactsWhenPlistPresent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	workersDir := filepath.Join(config.RunDir(), "workers")
+	if err := os.MkdirAll(workersDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	laDir := filepath.Join(tmp, "Library", "LaunchAgents")
+	if err := os.MkdirAll(laDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	const unit = "lerd-horizon-acme"
+	shPath := filepath.Join(workersDir, unit+".sh")
+	pidPath := filepath.Join(workersDir, unit+".pid")
+	for _, p := range []string{shPath, pidPath} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(laDir, unit+".plist"), []byte("<plist/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty expected set + plist present → both artifacts must survive.
+	sweepOrphanWorkerArtifacts(map[string]bool{})
+	for _, p := range []string{shPath, pidPath} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("artifact %q deleted despite plist present: %v", filepath.Base(p), err)
+		}
+	}
+
+	// Plist gone → with empty expected set, both artifacts should be swept.
+	if err := os.Remove(filepath.Join(laDir, unit+".plist")); err != nil {
+		t.Fatal(err)
+	}
+	sweepOrphanWorkerArtifacts(map[string]bool{})
+	for _, p := range []string{shPath, pidPath} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("artifact %q survived sweep with plist absent and unit not expected: stat err = %v", filepath.Base(p), err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Dump bridge — per-worktree tagging.** Plumbs `LERD_SITE` + `LERD_BRANCH` through nginx `fastcgi_param` (worktree + parent vhosts) and through `podman exec --env` from `RunTinker`. The dump bridge now reads `$_SERVER` first, then `getenv()`, so both FPM and CLI (tinker) requests get the same identifiers. Dump payload gains a `branch` field across Go (`internal/dumps/event.go`), PHP, and the TypeScript stream type — events from a worktree are no longer mis-grouped under the worktree's directory basename.

- **Worktree-add warnings surface in the dashboard.** `RunWorktreeAdd` now wraps its log writer in a `warningCapturingWriter` that scans for `[WARN]` lines and returns them alongside `branch` / `path`. The SSE done payload forwards them; `WorktreeModal` keeps the log view open with an amber "completed with warnings" banner and a "back to list" button instead of silently jumping back to the list on a half-finished setup (db skipped, build script error, install timeout, etc.). Two new i18n keys added across de/en/es/fr/id/nl/pt.

- **macOS phantom launchd workers — root cause.** `workerNeedsHealing` and `sweepOrphanWorkerArtifacts` were looking for `~/Library/LaunchAgents/lerd.<unit>.plist`, but the file on disk is `<unit>.plist` — the `com.lerd.` prefix lives only on the launchd Label inside the plist (see `services.plistPath` / `plistLabel`). The heal loop therefore saw every unit as "plist missing" and restarted healthy workers each cooldown; the orphan sweep simultaneously failed to keep real orphan `.sh` / `.pid` files. Both now read the correct path. `isExecModeUnit` gets the same fix in `internal/tui/log_tail_darwin.go`.

- **Makefile — stamp file for UI deps.** `node_modules/.package-lock.json` is now an explicit target depending on `package-lock.json` + `package.json`, so `npm ci` runs only when the lockfile/package.json change instead of every `make build` / `make test-ui`.