### PR TITLE
fix(siteinfo): restore vite toggle and log tab on parent site rows

### DIFF
--- a/internal/siteinfo/parent_workers_test.go
+++ b/internal/siteinfo/parent_workers_test.go
@@ -1,18 +1,70 @@
 package siteinfo
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
 )
 
-// TestEnrichWorkers_excludesPerWorktreeFromParent pins the regression that
-// surfaced after #319 wired per_worktree workers: enrichWorkers iterated
-// every worker in fw.Workers and queried `lerd-<n>-<site>`, which for
-// per_worktree workers (vite) is a unit that never exists on the parent.
-// The dashboard rendered a perma-inactive vite row on the parent site.
-// Parent-only workers must skip anything with per_worktree:true.
-func TestEnrichWorkers_excludesPerWorktreeFromParent(t *testing.T) {
+// TestEnrichWorkers_keepsPerWorktreeOnParentWhenCheckPasses pins that
+// per_worktree workers (vite) are kept on the parent row when their
+// check rule matches at the parent path. The previous gate that skipped
+// IsPerWorktree() unconditionally stripped the toggle from sites without
+// worktrees that legitimately ran the worker at the parent, and stripped
+// the log tab from parents that did have worktrees.
+func TestEnrichWorkers_keepsPerWorktreeOnParentWhenCheckPasses(t *testing.T) {
+	origUnit := unitStatusFn
+	unitStatusFn = func(name string) (string, error) {
+		if name == "lerd-vite-whitewaters" {
+			return "active", nil
+		}
+		return "inactive", nil
+	}
+	defer func() { unitStatusFn = origUnit }()
+
+	tmp := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmp, "node_modules", "vite"), 0755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	tr := true
+	fw := &config.Framework{
+		Workers: map[string]config.FrameworkWorker{
+			"vite": {
+				Label:       "Vite",
+				Command:     "npm run dev",
+				PerWorktree: &tr,
+				Check:       &config.FrameworkRule{File: "node_modules/vite"},
+			},
+		},
+	}
+
+	e := &EnrichedSite{Name: "whitewaters", Path: tmp}
+	e.enrichWorkers(fw, true)
+
+	var got *WorkerInfo
+	for i, w := range e.FrameworkWorkers {
+		if w.Name == "vite" {
+			got = &e.FrameworkWorkers[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("expected vite on parent FrameworkWorkers, got %+v", e.FrameworkWorkers)
+	}
+	if !got.Running {
+		t.Errorf("parent unit was active, want running=true: %+v", *got)
+	}
+}
+
+// TestEnrichWorkers_dropsPerWorktreeWhenCheckFails pins that the check
+// rule still gates parent visibility: a per_worktree worker whose check
+// file is absent at the parent path must not leak into FrameworkWorkers,
+// otherwise every Laravel project would show a vite toggle even without
+// vite installed.
+func TestEnrichWorkers_dropsPerWorktreeWhenCheckFails(t *testing.T) {
 	origUnit := unitStatusFn
 	unitStatusFn = func(string) (string, error) { return "inactive", nil }
 	defer func() { unitStatusFn = origUnit }()
@@ -20,27 +72,28 @@ func TestEnrichWorkers_excludesPerWorktreeFromParent(t *testing.T) {
 	tr := true
 	fw := &config.Framework{
 		Workers: map[string]config.FrameworkWorker{
-			"vite":    {Label: "Vite", Command: "npm run dev", PerWorktree: &tr},
-			"reverb":  {Label: "Reverb", Command: "php artisan reverb:start"},
-			"horizon": {Label: "Horizon", Command: "php artisan horizon"},
+			"vite": {
+				Label:       "Vite",
+				Command:     "npm run dev",
+				PerWorktree: &tr,
+				Check:       &config.FrameworkRule{File: "node_modules/vite"},
+			},
 		},
 	}
 
-	// Use the real theregistry.test fixture's site name so the failure
-	// signal carries production context if a regression slips in.
-	e := &EnrichedSite{Name: "whitewaters", Path: "/projects/whitewaters"}
+	e := &EnrichedSite{Name: "whitewaters", Path: t.TempDir()}
 	e.enrichWorkers(fw, true)
 
 	for _, w := range e.FrameworkWorkers {
 		if w.Name == "vite" {
-			t.Errorf("vite (per_worktree:true) leaked into parent FrameworkWorkers: %+v", e.FrameworkWorkers)
+			t.Errorf("vite leaked into parent when node_modules/vite was absent: %+v", e.FrameworkWorkers)
 		}
 	}
 }
 
-// TestEnrichWorkers_keepsNonPerWorktreeOnParent makes sure the new
-// per_worktree gate doesn't accidentally hide a custom non-per-worktree
-// worker that the framework yaml ships (e.g. a "search-indexer" daemon).
+// TestEnrichWorkers_keepsNonPerWorktreeOnParent makes sure a custom
+// non-per-worktree worker that the framework yaml ships (e.g. a
+// "search-indexer" daemon) still reports correctly on the parent.
 func TestEnrichWorkers_keepsNonPerWorktreeOnParent(t *testing.T) {
 	origUnit := unitStatusFn
 	unitStatusFn = func(name string) (string, error) {

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -449,17 +449,14 @@ func (e *EnrichedSite) enrichWorkers(fw *config.Framework, hasFw bool) {
 		e.HasQueueWorker = false // Horizon manages queues
 	}
 
-	// Custom framework workers. Skip per_worktree:true workers — those
-	// only run as lerd-<w>-<site>-<wt> per worktree and are enriched
-	// separately via enrichWorktreeWorkers. Including them here surfaces
-	// an always-inactive row on the parent (e.g. vite for Laravel 12+).
+	// Custom framework workers. per_worktree workers still surface on the
+	// parent so the toggle and log tab stay available when the check rule
+	// matches at the parent path (e.g. node_modules/vite). enrichWorktreeWorkers
+	// reports per-worktree unit state separately on each worktree row.
 	names := make([]string, 0, len(fw.Workers))
 	for n, wDef := range fw.Workers {
 		switch n {
 		case "queue", "schedule", "reverb", "horizon":
-			continue
-		}
-		if wDef.IsPerWorktree() {
 			continue
 		}
 		if wDef.Check != nil && !config.MatchesRule(e.Path, *wDef.Check) {


### PR DESCRIPTION
The siteinfo guard I added in a35fe01 skipped IsPerWorktree() workers from enrichWorkers unconditionally, which removed the vite toggle and log tab from places they belong. Sites with no worktrees still run the worker at the parent level (astrolov.test has lerd-vite-astrolov.service as the live unit), and worktree-using parents like theregistry.test still want vite opted in for project-level control. The check rule on the worker, file: node_modules/vite for the Laravel store yaml, is already a tight enough gate, so the per_worktree skip was just removing correct rows along with the perma-inactive ones.

The gate is gone. The test file now pins both directions, a per_worktree worker whose check matches at the parent path stays on the parent's FrameworkWorkers list and reports its live unit status, while one whose check file is missing still gets filtered so vanilla Laravel projects without vite installed do not grow a stray toggle.