### PR TITLE
release: v1.20.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,16 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.20.1] — 2026-05-14
+
+A 1.20.0 follow-up for the `curl|bash` / `wget|bash` install path. When the installer script is piped through bash the script's own stdin is the pipe, not the terminal, and that pipe was inherited by `lerd install` so its `[Y/n]` prompts hit EOF the moment they were issued. The Node-management and DNS questions flashed past without ever showing up to the user, both silently defaulted to yes, and the mkcert step then jumped straight to a sudo password request that looked like it came out of nowhere. `lerd install` now reopens `/dev/tty` for its prompts whenever stdin is not itself a TTY, and `install.sh` separately redirects `lerd install`'s stdin from `/dev/tty` when one is available, so the prompts reach the user from either side of the pipe. If neither a TTY stdin nor `/dev/tty` is available (unattended CI, containers without a controlling terminal) the prompts now print `(no terminal, defaulting to yes/no)` instead of vanishing.
+
+### Fixed
+
+- **Install prompts no longer skipped when piping the installer through bash** (Ubuntu and other distros). `lerd install` falls back to `/dev/tty` when stdin is a pipe, and `install.sh` hands `/dev/tty` to `lerd install` so the Node-management and DNS questions actually reach the user during `curl … | bash` / `wget … | bash` installs.
+
+---
+
 ## [1.20.0] — 2026-05-14
 
 The 1.20.0 line makes git worktrees a first-class concept throughout the stack. Per-worktree workers are surfaced in CLI, dashboard, and TUI; a built-in Vite dev server worker runs on the host with auto-start per worktree; wildcard cert SANs cover deep subdomains; `env_overrides` templating handles multi-tenant apps; per-worktree dump tagging keeps the live viewer accurate; and the dashboard ships a manage-worktrees modal alongside an upgrade to Tailwind CSS v4. The TUI catches up to the dashboard with service update and rollback keybinds, a failing-workers header pill, and per-worktree controls in the site detail pane. PHP 7.4 and 8.0 land as a frozen legacy tier, `lerd php:ext add` learns `--apk-deps` for extensions that need extra Alpine build packages, the dashboard ships in German, Indonesian, and Dutch with a wide i18n pass across all seven locales, and MCP gains `workers_mode`, `bug_report`, and a `branch` parameter across its per-worktree CLI wrappers. The post-beta fix queue covers macOS phantom launchd workers restarting healthy units every cooldown, dashboard update-banner glitches, and the worktree-add modal's "Automatic" resolver now announcing what it picked instead of going silent.

--- a/install.sh
+++ b/install.sh
@@ -386,7 +386,14 @@ cmd_install() {
   echo ""
   info "Running 'lerd install' to complete setup ..."
   echo ""
-  "${INSTALL_DIR}/${BINARY}" install
+  # When this script is piped through `curl|bash`, our own stdin is the pipe
+  # and lerd's prompts would silently hit EOF. Hand it /dev/tty when one is
+  # available so [Y/n] questions reach the user.
+  if [ -r /dev/tty ]; then
+    "${INSTALL_DIR}/${BINARY}" install </dev/tty
+  else
+    "${INSTALL_DIR}/${BINARY}" install
+  fi
   star_note
 }
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1122,14 +1122,46 @@ func confirmInstallPrompt(question string) bool {
 
 // confirmInstallPromptDefault is like confirmInstallPrompt but lets the caller
 // pick the default for an empty answer, so re-running install can mirror the
-// user's previous choice.
+// user's previous choice. Falls back to /dev/tty when stdin is not a TTY so
+// prompts still work when lerd is piped, e.g. `curl ... | bash` -> `lerd install`.
 func confirmInstallPromptDefault(question string, defaultYes bool) bool {
+	src, closer, ok := promptSource()
+	if !ok {
+		hint := "[Y/n]"
+		ans := "yes"
+		if !defaultYes {
+			hint = "[y/N]"
+			ans = "no"
+		}
+		fmt.Printf("  --> %s %s (no terminal, defaulting to %s)\n", question, hint, ans)
+		return defaultYes
+	}
+	if closer != nil {
+		defer closer.Close()
+	}
+	return readConfirmAnswer(src, question, defaultYes)
+}
+
+// promptSource returns a reader suitable for interactive prompts. It prefers
+// os.Stdin when it is a TTY, otherwise opens /dev/tty. The returned closer is
+// non-nil only for /dev/tty and must be closed by the caller.
+func promptSource() (io.Reader, io.Closer, bool) {
+	if fi, err := os.Stdin.Stat(); err == nil && (fi.Mode()&os.ModeCharDevice) != 0 {
+		return os.Stdin, nil, true
+	}
+	if tty, err := os.Open("/dev/tty"); err == nil {
+		return tty, tty, true
+	}
+	return nil, nil, false
+}
+
+func readConfirmAnswer(r io.Reader, question string, defaultYes bool) bool {
 	hint := "[Y/n]"
 	if !defaultYes {
 		hint = "[y/N]"
 	}
 	fmt.Printf("  --> %s %s ", question, hint)
-	reader := bufio.NewReader(os.Stdin)
+	reader := bufio.NewReader(r)
 	answer, _ := reader.ReadString('\n')
 	answer = strings.TrimSpace(strings.ToLower(answer))
 	if answer == "" {

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -500,5 +501,93 @@ func TestAddShellShims_OptOutWhenNoNodeShims(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(binDir, "php")); err != nil {
 		t.Errorf("php shim should still be written: %v", err)
+	}
+}
+
+// withSilencedStdout pipes os.Stdout to a discarded sink for the duration of
+// f, so prompt prints don't pollute test output.
+func withSilencedStdout(t *testing.T, f func()) {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, r)
+		close(done)
+	}()
+	defer func() {
+		_ = w.Close()
+		<-done
+		os.Stdout = orig
+	}()
+	f()
+}
+
+func TestReadConfirmAnswer(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		defaultYes bool
+		want       bool
+	}{
+		{"empty defaults yes", "\n", true, true},
+		{"empty defaults no", "\n", false, false},
+		{"eof defaults yes", "", true, true},
+		{"eof defaults no", "", false, false},
+		{"y", "y\n", false, true},
+		{"yes", "yes\n", false, true},
+		{"Y", "Y\n", false, true},
+		{"n", "n\n", true, false},
+		{"no", "no\n", true, false},
+		{"NO", "NO\n", true, false},
+		{"whitespace defaults yes", "  \n", true, true},
+		{"random falls back to yes", "maybe\n", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got bool
+			withSilencedStdout(t, func() {
+				got = readConfirmAnswer(strings.NewReader(tc.input), "test?", tc.defaultYes)
+			})
+			if got != tc.want {
+				t.Errorf("readConfirmAnswer(%q, default=%v) = %v, want %v",
+					tc.input, tc.defaultYes, got, tc.want)
+			}
+		})
+	}
+}
+
+// When stdin is a pipe (not a TTY) and /dev/tty isn't accessible either,
+// promptSource must report no terminal so confirmInstallPromptDefault can
+// fall back to the default rather than reading EOF from the pipe.
+func TestPromptSource_PipedStdinFallsBackToTTY(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	src, closer, ok := promptSource()
+	if closer != nil {
+		_ = closer.Close()
+	}
+
+	// On a developer machine /dev/tty usually opens fine, so we accept either
+	// outcome but assert the invariants: when ok is true, src must not be the
+	// piped stdin (since stdin isn't a character device here).
+	if ok && src == os.Stdin {
+		t.Fatal("promptSource returned piped stdin as the prompt source")
+	}
+	if !ok && src != nil {
+		t.Fatal("promptSource reported no source but returned non-nil reader")
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.20.0"
+	Version = "1.20.1"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
Hotfix for v1.20.0's install path. When the installer is piped through bash, as in the documented `curl … | bash` and `wget … | bash` one-liners, the script's own stdin is the pipe rather than the user's terminal. That pipe was inherited by `lerd install`, so the Node-management and DNS `[Y/n]` prompts read EOF the moment they were issued and silently defaulted to yes. The first thing the user actually saw was the mkcert sudo password prompt, which made it look like the installer was asking for sudo without warning.

`lerd install` now opens `/dev/tty` for its confirmation prompts whenever its own stdin is not a TTY, and `install.sh` separately redirects `lerd install`'s stdin from `/dev/tty` when one is available. With both halves in place the prompts reach the user from either side of the pipe. If neither a TTY stdin nor `/dev/tty` is reachable (unattended CI, containers without a controlling terminal) the prompts now print `(no terminal, defaulting to yes/no)` and continue, rather than disappearing into the void.

Reported by george@ on an Ubuntu VM minutes after v1.20.0 shipped.