### PR TITLE
docs: link the Dump viewer page in the Features sidebar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -143,6 +143,7 @@ export default defineConfig({
             { text: 'System Tray', link: '/features/system-tray' },
             { text: 'AI Integration (MCP)', link: '/features/mcp' },
             { text: 'Tinker tab', link: '/features/tinker' },
+            { text: 'Dump viewer', link: '/features/dumps' },
           ],
         },
         {


### PR DESCRIPTION
## Summary

The Dump viewer page (`features/dumps.md`) existed on disk and was reachable through deep links, but it never appeared in the VitePress Features sidebar, so anyone browsing the docs had no way to find it. Added the missing entry under the UI & AI group next to the Tinker tab, where the same page already lives in `mkdocs.yml`.

I also audited the rest of the sidebar against the markdown files on disk and every other page is already linked.