### PR TITLE
feat(shell): bake zsh + starship into PHP-FPM image

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -256,7 +256,7 @@ If a library you depend on calls `setlocale()` and branches on whether it succee
 
 ## PHP shell
 
-`lerd shell` opens an interactive `sh` session inside the PHP-FPM container for the current project:
+`lerd shell` opens an interactive shell inside the PHP-FPM container for the current project:
 
 ```bash
 lerd shell
@@ -267,6 +267,21 @@ The PHP version is resolved the same way as every other lerd command (`.php-vers
 If the container is not running, lerd prints the `systemctl` command needed to start it rather than silently failing.
 
 If the site is paused, any services referenced in `.env` (MySQL, Redis, etc.) are started automatically before the shell opens; the site itself stays paused.
+
+### Shell environment
+
+The lerd PHP-FPM image ships zsh with a self-contained config (starship prompt, persistent history, sensible defaults). When you run `lerd shell` or open a shell from the TUI, lerd execs zsh inside the container; for non-PHP service containers (Redis, MySQL, etc.) the fallback chain is `zsh > bash > sh` depending on what the upstream image provides.
+
+The in-container shell is deliberately isolated from your host shell config. Every developer's `~/.zshrc` or `~/.config/fish` is different, and sourcing distro-specific paths or host-only binaries inside the alpine container cascades into noisy errors (missing oh-my-zsh, missing pacman, missing fastfetch, etc.). Rather than play whack-a-mole, lerd ships a clean, predictable shell environment that's identical across every machine and contributor.
+
+What you get inside the container:
+
+- **starship** as the default prompt — branch, dir, git status, all the usual.
+- **eza**, **bat**, **fzf**, **zoxide** on `$PATH` for nicer file listing, paging, fuzzy-find, and `cd` history.
+- Shell history persisted under `~/.local/share/lerd/shell-state/php-<version>/zsh/history`, so commands survive container rebuilds.
+- `HostName=` set to your host's hostname so the prompt reads `root@your-machine` instead of the auto-generated container id.
+
+If you want extra packages in the image (additional CLI tools, language toolchains, etc.), use `lerd php:ext` for PHP extensions, or fork the Containerfile at `internal/podman/quadlets/lerd-php-fpm.Containerfile`.
 
 ---
 

--- a/internal/cli/php_shell.go
+++ b/internal/cli/php_shell.go
@@ -52,7 +52,8 @@ func runPhpShell(_ *cobra.Command, _ []string) error {
 	podman.EnsurePathMounted(workDir, version)
 	ensureServicesForCwd(workDir)
 
-	cmd := podman.Cmd("exec", "-it", "-w", workDir, container, "sh")
+	cmd := podman.Cmd("exec", "-it", "-w", workDir, container,
+		"sh", "-c", podman.InteractiveShellScript())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -591,6 +591,8 @@ func WriteFPMQuadlet(version string) error {
 	content = strings.ReplaceAll(content, "{{.UserIniPath}}", config.PHPUserIniFile(version))
 	content = strings.ReplaceAll(content, "{{.DumpsDir}}", config.DumpsAssetsDir())
 	content = strings.ReplaceAll(content, "{{.DumpsIniPath}}", config.DumpsIniFile())
+	content = strings.ReplaceAll(content, "{{.HostNameLine}}", hostNameLine())
+	content = applyShellMounts(content, short)
 	content = InjectExtraVolumes(content, ExtraVolumePaths())
 
 	// Skip the write and daemon-reload if the quadlet is already up to date.
@@ -634,6 +636,8 @@ func RewriteFPMQuadlets() error {
 		content = strings.ReplaceAll(content, "{{.UserIniPath}}", config.PHPUserIniFile(v))
 		content = strings.ReplaceAll(content, "{{.DumpsDir}}", config.DumpsAssetsDir())
 		content = strings.ReplaceAll(content, "{{.DumpsIniPath}}", config.DumpsIniFile())
+		content = strings.ReplaceAll(content, "{{.HostNameLine}}", hostNameLine())
+		content = applyShellMounts(content, short)
 		content = InjectExtraVolumes(content, extraPaths)
 
 		changed, writeErr := WriteQuadletDiff(unitName, content)
@@ -664,6 +668,45 @@ func RewriteFPMQuadlets() error {
 		_ = WriteContainerHosts()
 	}
 	return nil
+}
+
+// zshHistoryDir returns the per-PHP-version host directory that backs the
+// container's /root/.zsh_state mount, creating it so the bind mount succeeds
+// on first start. We deliberately do not mount any host shell config —
+// see internal/podman/quadlets/lerd-php-fpm.Containerfile for the rationale.
+func zshHistoryDir(versionShort string) string {
+	dir := filepath.Join(config.DataDir(), "shell-state", "php-"+versionShort, "zsh")
+	_ = os.MkdirAll(dir, 0o755)
+	return dir
+}
+
+// hostNameLine returns the `HostName=<host>` directive for the FPM quadlet so
+// prompts inside the container read e.g. "root@laptop" instead of the
+// auto-generated podman container id. Returns an empty string when the host
+// hostname can't be read or contains characters podman would reject, so the
+// placeholder line collapses cleanly.
+func hostNameLine() string {
+	h, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return ""
+	}
+	for _, r := range h {
+		ok := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '-' || r == '.'
+		if !ok {
+			return ""
+		}
+	}
+	return "HostName=" + h
+}
+
+// applyShellMounts substitutes shell-related template fields.
+func applyShellMounts(content, versionShort string) string {
+	return strings.ReplaceAll(content, "{{.ZshHistoryDir}}", zshHistoryDir(versionShort))
 }
 
 // listInstalledPHPVersions returns PHP versions that have a quadlet installed.

--- a/internal/podman/interactive.go
+++ b/internal/podman/interactive.go
@@ -1,0 +1,30 @@
+package podman
+
+import "strings"
+
+// InteractiveShellScript returns the `sh -c '...'` payload that picks an
+// interactive shell inside a container. The PHP-FPM image ships zsh with
+// a lerd-controlled config (starship prompt, persistent history); other
+// images fall through to bash or sh.
+func InteractiveShellScript() string {
+	return buildShellChain([]string{"zsh", "bash", "sh"})
+}
+
+func buildShellChain(shells []string) string {
+	var b strings.Builder
+	for i, s := range shells {
+		if i > 0 {
+			b.WriteString(" || ")
+		}
+		if i == len(shells)-1 {
+			b.WriteString("exec ")
+			b.WriteString(s)
+			continue
+		}
+		b.WriteString("command -v ")
+		b.WriteString(s)
+		b.WriteString(" >/dev/null 2>&1 && exec ")
+		b.WriteString(s)
+	}
+	return b.String()
+}

--- a/internal/podman/interactive_test.go
+++ b/internal/podman/interactive_test.go
@@ -1,0 +1,63 @@
+package podman
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInteractiveShellScript_PrefersZsh(t *testing.T) {
+	got := InteractiveShellScript()
+	if !strings.HasPrefix(got, "command -v zsh ") {
+		t.Errorf("chain should start with zsh, got: %s", got)
+	}
+	if !strings.Contains(got, "exec bash") {
+		t.Errorf("chain must include bash fallback, got: %s", got)
+	}
+	if !strings.HasSuffix(got, "exec sh") {
+		t.Errorf("chain must end with sh fallback, got: %s", got)
+	}
+}
+
+func TestZshHistoryDir_CreatedAndScoped(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+
+	dir := zshHistoryDir("84")
+	if dir == "" {
+		t.Fatalf("zshHistoryDir returned empty path")
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("zsh history dir should be created: %v", err)
+	}
+	if !strings.Contains(dir, "shell-state/php-84/zsh") {
+		t.Errorf("path should be scoped per PHP version, got: %s", dir)
+	}
+}
+
+func TestHostNameLine_ValidHostnameRenders(t *testing.T) {
+	got := hostNameLine()
+	if got == "" {
+		t.Skip("host hostname unreadable or has unusual characters; nothing to assert")
+	}
+	if !strings.HasPrefix(got, "HostName=") {
+		t.Errorf("expected HostName= prefix, got %q", got)
+	}
+}
+
+func TestApplyShellMounts_RendersZshHistoryDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+
+	tmpl := "Volume=before\nVolume={{.ZshHistoryDir}}:/root/.zsh_state:rw\n"
+	got := applyShellMounts(tmpl, "84")
+	if !strings.Contains(got, "/root/.zsh_state:rw") {
+		t.Errorf("zsh history volume missing:\n%s", got)
+	}
+	if strings.Contains(got, "{{.ZshHistoryDir}}") {
+		t.Errorf("template placeholder not substituted:\n%s", got)
+	}
+}

--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -79,6 +79,16 @@ RUN mkdir -p /etc/my.cnf.d && printf '[client]\nssl=0\n' > /etc/my.cnf.d/lerd-no
 COPY --from=composer-bin /usr/bin/composer /usr/local/bin/composer
 RUN apk add --no-cache nodejs npm ffmpeg
 
+# Interactive shell for `lerd shell` and the TUI shell action. Ships zsh with
+# a self-contained config (starship prompt, persistent history). Host shell
+# config is intentionally NOT mounted: every developer's host config is
+# different, and sourcing distro-specific paths or host-only binaries
+# cascades into noisy errors. The in-container shell is its own environment.
+RUN apk add --no-cache zsh starship fzf eza bat zoxide \
+    && mkdir -p /etc/zsh /root/.zsh_state \
+    && printf 'export EDITOR=vi\nexport PAGER=less\nexport HISTFILE=/root/.zsh_state/history\nexport HISTSIZE=10000\nexport SAVEHIST=10000\nsetopt INC_APPEND_HISTORY SHARE_HISTORY\nautoload -Uz compinit && compinit -u\nif command -v starship >/dev/null 2>&1; then\n  eval "$(starship init zsh)"\nfi\n' \
+        > /etc/zsh/zshrc
+
 # Override pool: run workers as root, log errors to stderr
 RUN printf '[www]\nuser=root\ngroup=root\ncatch_workers_output=yes\nphp_flag[display_errors]=off\nphp_admin_value[error_log]=/proc/self/fd/2\nphp_admin_flag[log_errors]=on\n' > /usr/local/etc/php-fpm.d/zz-lerd.conf
 

--- a/internal/podman/quadlets/lerd-php-fpm.container.tmpl
+++ b/internal/podman/quadlets/lerd-php-fpm.container.tmpl
@@ -13,6 +13,7 @@ StartLimitBurst=20
 [Container]
 Image=lerd-php{{.VersionShort}}-fpm:local
 ContainerName=lerd-php{{.VersionShort}}-fpm
+{{.HostNameLine}}
 Network=lerd
 Volume=%h/.local/share/lerd/hosts:/etc/hosts:ro,z
 Volume=%h:%h:rw
@@ -20,6 +21,8 @@ Volume={{.XdebugIniPath}}:/usr/local/etc/php/conf.d/99-xdebug.ini:ro
 Volume={{.UserIniPath}}:/usr/local/etc/php/conf.d/98-lerd-user.ini:ro
 Volume={{.DumpsDir}}:/usr/local/etc/lerd:ro
 Volume={{.DumpsIniPath}}:/usr/local/etc/php/conf.d/97-lerd-dump.ini:ro
+Volume={{.ZshHistoryDir}}:/root/.zsh_state:rw
+Environment=HOME=/root
 PodmanArgs=--security-opt=label=disable
 Exec=php-fpm -F -R
 

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -22,17 +22,15 @@ type ActionResult struct {
 
 // runShellIn suspends bubbletea, opens an interactive shell inside the
 // chosen container (FPM for PHP sites, the custom container for Node/Go/etc.
-// sites, and the service's own container for services), then resumes. Uses
-// `sh -c 'command -v bash && exec bash || exec sh'` so bash is used when
-// available and sh is the fallback (matters for minimal service images like
-// alpine where bash isn't installed).
+// sites, and the service's own container for services), then resumes. The
+// shell fallback chain prefers the host user's shell (fish or zsh) when the
+// image has it, falling back through bash to sh for minimal images.
 func runShellIn(container, workDir string) tea.Cmd {
 	args := []string{"exec", "-it"}
 	if workDir != "" {
 		args = append(args, "-w", workDir)
 	}
-	args = append(args, container, "sh", "-c",
-		"command -v bash >/dev/null 2>&1 && exec bash || exec sh")
+	args = append(args, container, "sh", "-c", podman.InteractiveShellScript())
 	cmd := exec.Command(podman.PodmanBin(), args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
## Summary

The lerd PHP-FPM image now drops into zsh with starship instead of bare sh when you run `lerd shell` (or hit the TUI shell action). Container ships its own self-contained config so the experience is predictable across machines.

What's in the image: zsh, starship, eza, bat, fzf, zoxide. The lerd-shipped `/etc/zsh/zshrc` wires up persistent history (per PHP version, under `~/.local/share/lerd/shell-state/php-<ver>/zsh/`), enables completion with `compinit -u`, and inits starship. The FPM quadlet pins `HostName=` to the host's hostname so the prompt reads `root@your-machine`, not an opaque container id.

Host shell config is intentionally not mounted. An earlier round of this branch tried to bind-mount `~/.config/fish` and `~/.zshrc` for an OrbStack-like inherit-your-prompt experience, but every customised host config has its own pile of distro-specific source paths and binaries that simply don't exist inside alpine, so the container shell would fire off a cascade of "no such file or directory" errors on every login. Cleaner to ship one good environment than to play whack-a-mole.

After upgrading, existing users need to rebuild their PHP images (`lerd php:rebuild <ver>`) and recreate the FPM container (`systemctl --user daemon-reload && podman rm -f lerd-php<short>-fpm && systemctl --user start lerd-php<short>-fpm`) to pick up the new layer and the regenerated quadlet.