### PR TITLE
feat(presets): mysql 9.7 LTS, postgres 17/18, canonical version pinning

### DIFF
--- a/docs/usage/service-presets.md
+++ b/docs/usage/service-presets.md
@@ -11,8 +11,8 @@ Both kinds use the same YAML schema in `internal/config/presets/*.yaml` and the 
 
 | Preset | Default image | Update strategy | Notes |
 |---|---|---|---|
-| `mysql` | `docker.io/library/mysql:8.4` (LTS) | `minor` (track_latest) | Multi-version: 8.4 canonical + 5.7, 8.0 alternates on host ports 3357 / 3380. SQL migration supported. |
-| `postgres` | `docker.io/postgis/postgis:16-3.5-alpine` | `minor` (track_latest) | Darwin platform override → `imresamu/postgis` for ARM64 compatibility. SQL migration supported. |
+| `mysql` | `docker.io/library/mysql:8.4` (LTS) | `minor` (track_latest) | Multi-version: 8.4 canonical + 9.7 LTS, 5.7 alternates on host ports 3397 / 3357. SQL migration supported. |
+| `postgres` | `docker.io/postgis/postgis:16-3.5-alpine` | `minor` (track_latest) | Multi-version: 16 canonical + 17, 18 alternates on host ports 5417 / 5418. SQL migration supported. |
 | `redis` | `docker.io/library/redis:7-alpine` | `minor` (track_latest) | Forward-compat across 7.x patches. |
 | `meilisearch` | `docker.io/getmeili/meilisearch:v1.42` | `patch` (track_latest) | Cross-minor upgrades require manual dump/restore — automated migration is **not** offered for Meilisearch (binary dump format is version-specific). |
 | `rustfs` | `docker.io/rustfs/rustfs:latest` | `rolling` | S3-compatible. |
@@ -24,7 +24,8 @@ Both kinds use the same YAML schema in `internal/config/presets/*.yaml` and the 
 |---|---|---|---|
 | `phpmyadmin` | `docker.io/library/phpmyadmin:latest` | `mysql` (default) | `http://localhost:8080` |
 | `pgadmin` | `docker.io/dpage/pgadmin4:latest` | `postgres` (default) | `http://localhost:8081` |
-| `mysql` alternates | `5.7` / `8.0` (canonical 8.4 lives in the default preset) | - | `127.0.0.1:3357` / `127.0.0.1:3380` |
+| `mysql` alternates | `5.7` / `9.7` LTS (canonical 8.4 lives in the default preset) | - | `127.0.0.1:3357` / `127.0.0.1:3397` |
+| `postgres` alternates | `17` / `18` (canonical 16 lives in the default preset) | - | `127.0.0.1:5417` / `127.0.0.1:5418` |
 | `mariadb` | `11` (default) / `10.11` LTS | - | `127.0.0.1:3411` / `127.0.0.1:3410` |
 | `mongo` | `docker.io/library/mongo:7` | - | `127.0.0.1:27017` |
 | `mongo-express` | `docker.io/library/mongo-express:latest` | `mongo` (preset) | `http://localhost:8082` |
@@ -74,13 +75,16 @@ persists in `localStorage`.
 
 ## Multi-version presets
 
-`mysql` and `mariadb` ship multiple selectable versions. The canonical version (mysql 8.4 LTS, mariadb 11) is the default install — recognised as the bare service `mysql` / `mariadb` on the canonical host port. Non-canonical alternates materialise as distinct custom services named `<family>-<sanitized-tag>`, runnable side-by-side with the canonical. The alternates picker only shows non-canonical versions (it doesn't list 8.4 because that IS the default install).
+`mysql`, `postgres` and `mariadb` ship multiple selectable versions. The canonical version (mysql 8.4 LTS, postgres 16, mariadb 11) is the default install — recognised as the bare service `mysql` / `postgres` / `mariadb` on the canonical host port. Non-canonical alternates materialise as distinct custom services named `<family>-<sanitized-tag>`, runnable side-by-side with the canonical. The alternates picker only shows non-canonical versions (it doesn't list 8.4 because that IS the default install).
 
 | Picked | Service name | Container | Host port | Data dir |
 |---|---|---|---|---|
 | `mysql 8.4` (canonical) | `mysql` | `lerd-mysql` | `127.0.0.1:3306` | `~/.local/share/lerd/data/mysql/` |
-| `mysql 8.0` | `mysql-8-0` | `lerd-mysql-8-0` | `127.0.0.1:3380` | `~/.local/share/lerd/data/mysql-8-0/` |
+| `mysql 9.7` LTS | `mysql-9-7` | `lerd-mysql-9-7` | `127.0.0.1:3397` | `~/.local/share/lerd/data/mysql-9-7/` |
 | `mysql 5.7` | `mysql-5-7` | `lerd-mysql-5-7` | `127.0.0.1:3357` | `~/.local/share/lerd/data/mysql-5-7/` |
+| `postgres 16` (canonical) | `postgres` | `lerd-postgres` | `127.0.0.1:5432` | `~/.local/share/lerd/data/postgres/` |
+| `postgres 17` | `postgres-17` | `lerd-postgres-17` | `127.0.0.1:5417` | `~/.local/share/lerd/data/postgres-17/` |
+| `postgres 18` | `postgres-18` | `lerd-postgres-18` | `127.0.0.1:5418` | `~/.local/share/lerd/data/postgres-18/` |
 | `mariadb 11` (canonical) | `mariadb-11` | `lerd-mariadb-11` | `127.0.0.1:3411` | `~/.local/share/lerd/data/mariadb-11/` |
 | `mariadb 10.11` | `mariadb-10-11` | `lerd-mariadb-10-11` | `127.0.0.1:3410` | `~/.local/share/lerd/data/mariadb-10-11/` |
 
@@ -92,6 +96,12 @@ machine; note that another process on the host bound to the same port will
 make the alternate fail to start with a `bind: address already in use` error
 in `journalctl --user -u lerd-<service>`. Use `lerd service expose <service>
 <other:3306>` to add a different mapping if you hit a collision.
+
+### Canonical version pinning
+
+Each default-preset install records which version's tag was canonical at install time in `~/.config/lerd/config.yaml` under `services.<name>.canonical_version`. That pin survives future canonical flips in the bundled YAML: when a later lerd release promotes (say) `postgres 18` to canonical, existing installs whose pin says `16` continue to resolve against 16 and keep their bare service name. New installs land on whatever the YAML currently calls canonical and get pinned to that.
+
+`lerd service migrate <service> <tag>` is the explicit cross-major path. Beyond the dump/restore, it rewrites `canonical_version` to the new tag so the next reconcile honors the move instead of reverting to the original pin.
 
 The mysql preset bundles a `my.cnf` (`/etc/mysql/conf.d/lerd.cnf`) that
 enables `innodb_large_prefix`, `Barracuda`, `innodb_default_row_format=DYNAMIC`

--- a/docs/usage/services.md
+++ b/docs/usage/services.md
@@ -17,7 +17,7 @@
 | `lerd service expose <name> <host:container>` | Publish an extra port on a built-in service |
 | `lerd service expose <name> <host:container> --remove` | Remove a previously exposed port |
 
-Available services: `mysql` (8.4 LTS), `redis` (7-alpine), `postgres` (16 with PostGIS), `meilisearch` (v1.42), `rustfs` (S3-compatible), `mailpit` (SMTP catcher).
+Available services: `mysql` (8.4 LTS canonical, 9.7 LTS / 5.7 alternates), `redis` (7-alpine), `postgres` (16 canonical with PostGIS, 17 / 18 alternates), `meilisearch` (v1.42), `rustfs` (S3-compatible), `mailpit` (SMTP catcher).
 
 Default services are defined as YAML presets with `default: true` in the lerd binary. Adding or replacing a default service is a YAML edit, not a code change. Each preset declares its own `update_strategy` (patch / minor / rolling), whether `track_latest` should auto-bump fresh installs to the current upstream, and whether `allow_major_upgrade` lets the cross-strategy upgrade button cross numeric majors. See [Service updates](service-updates.md) for the full update / upgrade / migrate / rollback flow.
 

--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -46,8 +46,14 @@ type SiteInit struct {
 type FileMount struct {
 	// Target is the absolute path inside the container where the file appears.
 	Target string `yaml:"target"`
-	// Content is the literal file body, written verbatim.
+	// Content is the literal file body, written verbatim. Ignored when
+	// ContentFn is set.
 	Content string `yaml:"content"`
+	// ContentFn dynamically generates the file body at materialise time
+	// based on the resolved service (e.g. to inject family-discovered
+	// hosts into pgAdmin's servers.json). Cannot be loaded from YAML, only
+	// the Go-side preset_files map sets it.
+	ContentFn func(*CustomService) (string, error) `yaml:"-"`
 	// Mode is the octal permission bits, e.g. "0600". Defaults to "0644".
 	Mode string `yaml:"mode,omitempty"`
 	// Chown adds the :U flag to the volume mount so podman re-chowns the file
@@ -328,13 +334,21 @@ func MaterializeServiceFiles(svc *CustomService) error {
 			mode = os.FileMode(parsed)
 		}
 		path := ServiceFilePath(svc.Name, f.Target)
+		content := f.Content
+		if f.ContentFn != nil {
+			out, err := f.ContentFn(svc)
+			if err != nil {
+				return fmt.Errorf("generating %s for service %s: %w", path, svc.Name, err)
+			}
+			content = out
+		}
 		// Unlink first: with chown:true podman's :U flag re-owns the file to a
 		// userns-mapped uid, so a plain rewrite would EACCES. Removing the dir
 		// entry succeeds because the parent dir is owned by us.
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("removing stale %s for service %s: %w", path, svc.Name, err)
 		}
-		if err := os.WriteFile(path, []byte(f.Content), mode); err != nil {
+		if err := os.WriteFile(path, []byte(content), mode); err != nil {
 			return fmt.Errorf("writing %s for service %s: %w", path, svc.Name, err)
 		}
 		// WriteFile honours umask; chmod explicitly so 0600 sticks.

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -27,6 +27,10 @@ type ServiceConfig struct {
 	// when the most recent operation was a migrate. Used by rollback to refuse
 	// (or, in future, restore) when undoing the migrate would corrupt data.
 	PreMigrateBackup string `yaml:"pre_migrate_backup,omitempty" mapstructure:"pre_migrate_backup"`
+	// CanonicalVersion pins the preset version tag this service was first
+	// installed on, so flipping the YAML's canonical (e.g. pg 16 → 18 in a
+	// future release) never silently major-jumps existing installs.
+	CanonicalVersion string `yaml:"canonical_version,omitempty" mapstructure:"canonical_version"`
 }
 
 // GlobalConfig is the top-level lerd configuration.

--- a/internal/config/preset_files.go
+++ b/internal/config/preset_files.go
@@ -1,5 +1,11 @@
 package config
 
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
 // presetFiles holds the file mounts shipped with each bundled preset. This
 // lives in Go rather than the preset YAMLs so that new lerd versions can
 // update the mounted file contents automatically on the next service start
@@ -12,11 +18,9 @@ var presetFiles = map[string][]FileMount{
 	"mysql": {
 		{
 			Target: "/etc/mysql/conf.d/lerd.cnf",
-			// loose- prefix lets the file load across mysql 5.7/8.0/8.4 even
-			// when a directive is unknown to that version. innodb_large_prefix
-			// and innodb_file_format used to live here for 5.6 compatibility,
-			// but lerd no longer ships 5.6 and both were removed in 8.0,
-			// so they generated startup warnings on every modern run.
+			// loose- prefix skips directives unknown to a given mysql version;
+			// authentication_policy is omitted because mysql 9.x removed
+			// mysql_native_password, which made the variable refuse to load.
 			Content: `[mysqld]
 character-set-server=utf8mb4
 collation-server=utf8mb4_unicode_ci
@@ -24,35 +28,20 @@ innodb_file_per_table=ON
 innodb_strict_mode=OFF
 loose-innodb_default_row_format=DYNAMIC
 loose-mysql-native-password=ON
-authentication_policy='mysql_native_password,,'
 loose-restrict-fk-on-non-standard-key=OFF
 `,
 		},
 	},
 	"pgadmin": {
 		{
-			Target: "/pgadmin4/servers.json",
-			Content: `{
-  "Servers": {
-    "1": {
-      "Name": "Lerd Postgres",
-      "Group": "Servers",
-      "Host": "lerd-postgres",
-      "Port": 5432,
-      "MaintenanceDB": "postgres",
-      "Username": "postgres",
-      "SSLMode": "prefer",
-      "PassFile": "/pgpass"
-    }
-  }
-}
-`,
+			Target:    "/pgadmin4/servers.json",
+			ContentFn: pgadminServersJSON,
 		},
 		{
-			Target:  "/pgpass",
-			Mode:    "0600",
-			Chown:   true,
-			Content: "lerd-postgres:5432:*:postgres:lerd\n",
+			Target:    "/pgpass",
+			Mode:      "0600",
+			Chown:     true,
+			ContentFn: pgadminPgpass,
 		},
 		{
 			Target: "/pgadmin4/config_local.py",
@@ -118,4 +107,72 @@ func PresetFiles(presetName string) []FileMount {
 	out := make([]FileMount, len(src))
 	copy(out, src)
 	return out
+}
+
+// pgadminFriendlyName turns a container hostname like "lerd-postgres-18"
+// into a human-friendly server label "Lerd Postgres 18".
+func pgadminFriendlyName(host string) string {
+	parts := strings.Split(strings.TrimPrefix(host, "lerd-"), "-")
+	for i, p := range parts {
+		if len(p) > 0 {
+			parts[i] = strings.ToUpper(p[:1]) + p[1:]
+		}
+	}
+	return "Lerd " + strings.Join(parts, " ")
+}
+
+// pgadminPostgresHosts returns the postgres family members, falling back to
+// the canonical lerd-postgres when discovery is empty (fresh install before
+// the family registry has been populated).
+func pgadminPostgresHosts() []string {
+	hosts := ServicesInFamily("postgres")
+	if len(hosts) == 0 {
+		return []string{"lerd-postgres"}
+	}
+	return hosts
+}
+
+// pgadminServersJSON renders pgAdmin's servers.json with every installed
+// postgres family member, so alternates like postgres-18 appear in the
+// dashboard alongside the canonical postgres without manual server setup.
+func pgadminServersJSON(_ *CustomService) (string, error) {
+	type server struct {
+		Name          string `json:"Name"`
+		Group         string `json:"Group"`
+		Host          string `json:"Host"`
+		Port          int    `json:"Port"`
+		MaintenanceDB string `json:"MaintenanceDB"`
+		Username      string `json:"Username"`
+		SSLMode       string `json:"SSLMode"`
+		PassFile      string `json:"PassFile"`
+	}
+	servers := map[string]server{}
+	for i, host := range pgadminPostgresHosts() {
+		servers[strconv.Itoa(i+1)] = server{
+			Name:          pgadminFriendlyName(host),
+			Group:         "Servers",
+			Host:          host,
+			Port:          5432,
+			MaintenanceDB: "postgres",
+			Username:      "postgres",
+			SSLMode:       "prefer",
+			PassFile:      "/pgpass",
+		}
+	}
+	data, err := json.MarshalIndent(map[string]any{"Servers": servers}, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data) + "\n", nil
+}
+
+// pgadminPgpass renders a libpq passfile with one line per postgres family
+// member so pgAdmin's PassFile=/pgpass entry auto-logs every alternate.
+func pgadminPgpass(_ *CustomService) (string, error) {
+	var b strings.Builder
+	for _, host := range pgadminPostgresHosts() {
+		b.WriteString(host)
+		b.WriteString(":5432:*:postgres:lerd\n")
+	}
+	return b.String(), nil
 }

--- a/internal/config/preset_files_test.go
+++ b/internal/config/preset_files_test.go
@@ -5,6 +5,81 @@ import (
 	"testing"
 )
 
+func TestPgadminServersJSON_listsEveryFamilyMember(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	// Built-in postgres + one alternate exercises the family-discovery path.
+	if err := SaveCustomService(&CustomService{
+		Name:   "postgres-18",
+		Image:  "docker.io/postgis/postgis:18-3.6-alpine",
+		Family: "postgres",
+	}); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+
+	out, err := pgadminServersJSON(nil)
+	if err != nil {
+		t.Fatalf("pgadminServersJSON: %v", err)
+	}
+	for _, want := range []string{
+		`"Host": "lerd-postgres"`,
+		`"Host": "lerd-postgres-18"`,
+		`"Name": "Lerd Postgres"`,
+		`"Name": "Lerd Postgres 18"`,
+		`"Port": 5432`,
+		`"PassFile": "/pgpass"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("servers.json missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestPgadminPgpass_oneLinePerFamilyMember(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if err := SaveCustomService(&CustomService{
+		Name:   "postgres-17",
+		Image:  "docker.io/postgis/postgis:17-3.6-alpine",
+		Family: "postgres",
+	}); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+
+	out, err := pgadminPgpass(nil)
+	if err != nil {
+		t.Fatalf("pgadminPgpass: %v", err)
+	}
+	for _, want := range []string{
+		"lerd-postgres:5432:*:postgres:lerd",
+		"lerd-postgres-17:5432:*:postgres:lerd",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("pgpass missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestPgadminPreset_consumesPostgresFamily(t *testing.T) {
+	// dynamic_env wires pgadmin into the family-consumer regeneration path,
+	// so installing/removing a postgres alternate triggers a servers.json
+	// rebuild and a pgadmin restart.
+	p, err := LoadPreset("pgadmin")
+	if err != nil {
+		t.Fatalf("LoadPreset(pgadmin): %v", err)
+	}
+	if got := p.DynamicEnv["LERD_POSTGRES_HOSTS"]; got != "discover_family:postgres" {
+		t.Errorf("pgadmin must declare discover_family:postgres dynamic_env, got %q", got)
+	}
+	if p.Environment["PGADMIN_REPLACE_SERVERS_ON_STARTUP"] != "True" {
+		t.Errorf("pgadmin must set PGADMIN_REPLACE_SERVERS_ON_STARTUP=True so the regenerated servers.json gets re-imported on restart")
+	}
+}
+
 func TestMySQLPresetContainsCompatDirectives(t *testing.T) {
 	files := PresetFiles("mysql")
 	if len(files) == 0 {
@@ -15,12 +90,16 @@ func TestMySQLPresetContainsCompatDirectives(t *testing.T) {
 
 	for _, directive := range []string{
 		"mysql-native-password=ON",
-		"authentication_policy='mysql_native_password,,'",
 		"restrict-fk-on-non-standard-key=OFF",
 	} {
 		if !strings.Contains(cnf, directive) {
 			t.Errorf("mysql lerd.cnf missing %q", directive)
 		}
+	}
+	// mysql 9.x removed mysql_native_password, so the policy line must not
+	// pin it as the primary or the server refuses to initialise.
+	if strings.Contains(cnf, "authentication_policy=") {
+		t.Errorf("mysql lerd.cnf must not pin authentication_policy: it breaks mysql 9.x init")
 	}
 }
 

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -296,6 +296,72 @@ func (p *Preset) Resolve(version string) (*CustomService, error) {
 	return &svc, nil
 }
 
+// CanonicalTag returns the tag of the version marked canonical, or empty
+// when no version is flagged (single-version presets or all-alternate families).
+func (p *Preset) CanonicalTag() string {
+	for _, v := range p.Versions {
+		if v.Canonical {
+			return v.Tag
+		}
+	}
+	return ""
+}
+
+// ResolvePinned is like Resolve but always returns the preset's bare family
+// name even when the picked version is not flagged canonical. Used so a
+// canonical flip in the YAML doesn't rename installed services.
+func (p *Preset) ResolvePinned(tag string) (*CustomService, error) {
+	if len(p.Versions) == 0 {
+		return nil, fmt.Errorf("preset %q has no versions, cannot pin", p.Name)
+	}
+	var picked *PresetVersion
+	for i := range p.Versions {
+		if p.Versions[i].Tag == tag {
+			picked = &p.Versions[i]
+			break
+		}
+	}
+	if picked == nil {
+		return nil, fmt.Errorf("preset %q has no version %q", p.Name, tag)
+	}
+	safe := SanitizeImageTag(picked.Tag)
+	svc := p.CustomService
+	svc.Image = picked.Image
+	svc.Preset = p.Name
+	svc.PresetVersion = picked.Tag
+	var hostPort string
+	if picked.HostPort > 0 {
+		hostPort = fmt.Sprintf("%d", picked.HostPort)
+	}
+	repl := strings.NewReplacer(
+		"{{name}}", svc.Name,
+		"{{tag}}", picked.Tag,
+		"{{tag_safe}}", safe,
+		"{{host_port}}", hostPort,
+	)
+	if len(svc.Ports) > 0 {
+		out := make([]string, len(svc.Ports))
+		for i, port := range svc.Ports {
+			out[i] = repl.Replace(port)
+		}
+		svc.Ports = out
+	}
+	if len(svc.EnvVars) > 0 {
+		out := make([]string, len(svc.EnvVars))
+		for i, kv := range svc.EnvVars {
+			out[i] = repl.Replace(kv)
+		}
+		svc.EnvVars = out
+	}
+	if svc.ConnectionURL != "" {
+		svc.ConnectionURL = repl.Replace(svc.ConnectionURL)
+	}
+	if svc.Dashboard != "" {
+		svc.Dashboard = repl.Replace(svc.Dashboard)
+	}
+	return &svc, nil
+}
+
 // ApplyPlatformOverride swaps svc.Image with a platform-specific replacement
 // when the runtime OS matches and the current image satisfies ImageMatch.
 // The override image may use {{tag}} as a placeholder for the current image's

--- a/internal/config/presets/mysql.yaml
+++ b/internal/config/presets/mysql.yaml
@@ -6,15 +6,15 @@ description: MySQL database
 family: mysql
 default_version: "8.4"
 versions:
+  - tag: "9.7"
+    label: "9.7 LTS"
+    image: docker.io/library/mysql:9.7
+    host_port: 3397
   - tag: "8.4"
     label: "8.4 LTS (default)"
     image: docker.io/library/mysql:8.4
     canonical: true
     host_port: 3306
-  - tag: "8.0"
-    label: "8.0"
-    image: docker.io/library/mysql:8.0
-    host_port: 3380
   - tag: "5.7"
     label: "5.7"
     image: docker.io/library/mysql:5.7

--- a/internal/config/presets/pgadmin.yaml
+++ b/internal/config/presets/pgadmin.yaml
@@ -8,6 +8,9 @@ environment:
   PGADMIN_DEFAULT_PASSWORD: lerd
   PGADMIN_CONFIG_SERVER_MODE: "False"
   PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"
+  PGADMIN_REPLACE_SERVERS_ON_STARTUP: "True"
+dynamic_env:
+  LERD_POSTGRES_HOSTS: discover_family:postgres
 depends_on:
   - postgres
 dashboard: http://localhost:8081

--- a/internal/config/presets/postgres.yaml
+++ b/internal/config/presets/postgres.yaml
@@ -4,18 +4,33 @@ update_strategy: minor
 track_latest: true
 description: PostgreSQL with PostGIS
 family: postgres
-image: docker.io/postgis/postgis:16-3.5-alpine
+default_version: "16"
+versions:
+  - tag: "18"
+    label: "18"
+    image: docker.io/postgis/postgis:18-3.6-alpine
+    host_port: 5418
+  - tag: "17"
+    label: "17"
+    image: docker.io/postgis/postgis:17-3.6-alpine
+    host_port: 5417
+  - tag: "16"
+    label: "16 (default)"
+    image: docker.io/postgis/postgis:16-3.5-alpine
+    canonical: true
+    host_port: 5432
 ports:
-  - "5432:5432"
+  - "{{host_port}}:5432"
 data_dir: /var/lib/postgresql/data
 environment:
   POSTGRES_PASSWORD: lerd
   POSTGRES_DB: lerd
+  PGDATA: /var/lib/postgresql/data
 env_vars:
   - DB_CONNECTION=pgsql
-  - DB_HOST=lerd-postgres
+  - DB_HOST=lerd-{{name}}
   - DB_PORT=5432
   - DB_DATABASE=lerd
   - DB_USERNAME=postgres
   - DB_PASSWORD=lerd
-connection_url: postgresql://postgres:lerd@127.0.0.1:5432/lerd
+connection_url: postgresql://postgres:lerd@127.0.0.1:{{host_port}}/lerd

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -188,7 +188,7 @@ func TestLoadPreset_MySQL_MultiVersion(t *testing.T) {
 		t.Errorf("multi-version preset must not declare top-level image, got %q", p.Image)
 	}
 	if len(p.Versions) < 2 {
-		t.Errorf("expected at least 2 versions (8.4 canonical + 8.0 alternate), got %d", len(p.Versions))
+		t.Errorf("expected at least 2 versions (8.4 canonical + alternates), got %d", len(p.Versions))
 	}
 	if p.DefaultVersion != "8.4" {
 		t.Errorf("DefaultVersion should be 8.4 (the canonical LTS default), got %q", p.DefaultVersion)
@@ -439,7 +439,7 @@ func TestListPresets_CanonicalHiddenFromAlternates(t *testing.T) {
 			t.Errorf("8.4 is canonical and should be filtered out of mysql alternates")
 		}
 	}
-	wantAlts := map[string]bool{"8.0": false, "5.7": false}
+	wantAlts := map[string]bool{"9.7": false, "5.7": false}
 	for _, v := range mysql.Versions {
 		if _, ok := wantAlts[v.Tag]; ok {
 			wantAlts[v.Tag] = true
@@ -529,7 +529,7 @@ func TestPresetResolve_AlternatesUseHostPort(t *testing.T) {
 	}
 	cases := map[string]string{
 		"5.7": "3357:3306",
-		"8.0": "3380:3306",
+		"9.7": "3397:3306",
 	}
 	for tag, wantPort := range cases {
 		svc, err := p.Resolve(tag)
@@ -569,6 +569,56 @@ func TestPresetResolve_MysqlCanonical(t *testing.T) {
 		if strings.Contains(port, "{{") {
 			t.Errorf("non-canonical ports must be substituted, got %q", port)
 		}
+	}
+}
+
+func TestPresetCanonicalTag(t *testing.T) {
+	p, err := LoadPreset("postgres")
+	if err != nil {
+		t.Fatalf("LoadPreset: %v", err)
+	}
+	if got := p.CanonicalTag(); got != "16" {
+		t.Errorf("postgres CanonicalTag() = %q, want 16", got)
+	}
+	pm, err := LoadPreset("mariadb")
+	if err != nil {
+		t.Fatalf("LoadPreset(mariadb): %v", err)
+	}
+	if got := pm.CanonicalTag(); got != "" {
+		t.Errorf("mariadb has no canonical, CanonicalTag() = %q, want empty", got)
+	}
+}
+
+func TestPresetResolvePinned_KeepsBareName(t *testing.T) {
+	p, err := LoadPreset("postgres")
+	if err != nil {
+		t.Fatalf("LoadPreset: %v", err)
+	}
+	svc, err := p.ResolvePinned("17")
+	if err != nil {
+		t.Fatalf("ResolvePinned(17): %v", err)
+	}
+	if svc.Name != "postgres" {
+		t.Errorf("pinned alternate Name = %q, want bare postgres (canonical-flip protection)", svc.Name)
+	}
+	if !strings.Contains(svc.Image, ":17-") {
+		t.Errorf("pinned alternate Image = %q, want a :17- tag", svc.Image)
+	}
+	for _, kv := range svc.EnvVars {
+		if kv == "DB_HOST=lerd-postgres" {
+			return
+		}
+	}
+	t.Errorf("expected DB_HOST=lerd-postgres in pinned env_vars, got %v", svc.EnvVars)
+}
+
+func TestPresetResolvePinned_UnknownTag(t *testing.T) {
+	p, err := LoadPreset("postgres")
+	if err != nil {
+		t.Fatalf("LoadPreset: %v", err)
+	}
+	if _, err := p.ResolvePinned("99"); err == nil {
+		t.Errorf("ResolvePinned(99) should error for unknown tag")
 	}
 }
 
@@ -634,8 +684,101 @@ func TestLoadPreset_PostgresHasNoForkOverride(t *testing.T) {
 			t.Errorf("postgres preset must not ship a third-party fork override, got %+v", po)
 		}
 	}
-	if !strings.Contains(p.Image, "postgis/postgis") {
-		t.Errorf("postgres preset must keep the upstream postgis/postgis image, got %q", p.Image)
+	if len(p.Versions) == 0 {
+		t.Fatalf("postgres preset must declare versions, got none")
+	}
+	for _, v := range p.Versions {
+		if !strings.Contains(v.Image, "postgis/postgis") {
+			t.Errorf("postgres version %q must keep the upstream postgis/postgis image, got %q", v.Tag, v.Image)
+		}
+	}
+}
+
+func TestLoadPreset_PostgresMultiVersion(t *testing.T) {
+	p, err := LoadPreset("postgres")
+	if err != nil {
+		t.Fatalf("LoadPreset(postgres): %v", err)
+	}
+	if p.Image != "" {
+		t.Errorf("multi-version postgres must not declare top-level image, got %q", p.Image)
+	}
+	wantTags := map[string]bool{"18": false, "17": false, "16": false}
+	for _, v := range p.Versions {
+		if _, ok := wantTags[v.Tag]; ok {
+			wantTags[v.Tag] = true
+		}
+	}
+	for tag, found := range wantTags {
+		if !found {
+			t.Errorf("postgres preset missing version %q", tag)
+		}
+	}
+	if p.DefaultVersion != "16" {
+		t.Errorf("postgres DefaultVersion = %q, want 16 (canonical for back-compat)", p.DefaultVersion)
+	}
+}
+
+func TestPostgresPin_PGDATAEnvSet(t *testing.T) {
+	// PostgreSQL 18 moved the default PGDATA to /var/lib/postgresql/<major>/data,
+	// which breaks the legacy /var/lib/postgresql/data mount. Pinning PGDATA
+	// in the preset env forces all versions onto the old layout we mount.
+	p, err := LoadPreset("postgres")
+	if err != nil {
+		t.Fatalf("LoadPreset(postgres): %v", err)
+	}
+	if got := p.Environment["PGDATA"]; got != "/var/lib/postgresql/data" {
+		t.Errorf("postgres preset must pin PGDATA=/var/lib/postgresql/data for v18+ compat, got %q", got)
+	}
+}
+
+func TestPresetResolve_PostgresCanonical(t *testing.T) {
+	p, err := LoadPreset("postgres")
+	if err != nil {
+		t.Fatalf("LoadPreset: %v", err)
+	}
+	svc, err := p.Resolve("16")
+	if err != nil {
+		t.Fatalf("Resolve(16): %v", err)
+	}
+	if svc.Name != "postgres" {
+		t.Errorf("canonical postgres Name = %q, want bare postgres", svc.Name)
+	}
+	if len(svc.Ports) != 1 || svc.Ports[0] != "5432:5432" {
+		t.Errorf("canonical postgres Ports = %v, want [5432:5432]", svc.Ports)
+	}
+	if svc.ConnectionURL != "postgresql://postgres:lerd@127.0.0.1:5432/lerd" {
+		t.Errorf("canonical postgres ConnectionURL = %q", svc.ConnectionURL)
+	}
+}
+
+func TestPresetResolve_PostgresAlternates(t *testing.T) {
+	p, err := LoadPreset("postgres")
+	if err != nil {
+		t.Fatalf("LoadPreset: %v", err)
+	}
+	cases := map[string]struct {
+		wantName string
+		wantPort string
+	}{
+		"18": {"postgres-18", "5418:5432"},
+		"17": {"postgres-17", "5417:5432"},
+	}
+	for tag, want := range cases {
+		svc, err := p.Resolve(tag)
+		if err != nil {
+			t.Fatalf("Resolve(%s): %v", tag, err)
+		}
+		if svc.Name != want.wantName {
+			t.Errorf("postgres %s: Name = %q, want %q", tag, svc.Name, want.wantName)
+		}
+		if len(svc.Ports) == 0 || svc.Ports[0] != want.wantPort {
+			t.Errorf("postgres %s: Ports = %v, want [%s]", tag, svc.Ports, want.wantPort)
+		}
+		for _, port := range svc.Ports {
+			if strings.Contains(port, "{{") {
+				t.Errorf("postgres %s alternate ports must be substituted, got %q", tag, port)
+			}
+		}
 	}
 }
 

--- a/internal/serviceops/preserved_image_test.go
+++ b/internal/serviceops/preserved_image_test.go
@@ -67,6 +67,120 @@ func TestEnsureDefaultPresetQuadletPinned_emptyPinFallsThroughToPreset(t *testin
 	}
 }
 
+func TestEnsureDefaultPresetQuadlet_writesCanonicalPinOnFirstInstall(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	orig := podman.DaemonReloadFn
+	t.Cleanup(func() { podman.DaemonReloadFn = orig })
+	podman.DaemonReloadFn = func() error { return nil }
+
+	if err := EnsureDefaultPresetQuadlet("postgres"); err != nil {
+		t.Fatalf("EnsureDefaultPresetQuadlet: %v", err)
+	}
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if got := cfg.Services["postgres"].CanonicalVersion; got != "16" {
+		t.Errorf("first install must persist CanonicalVersion=16, got %q", got)
+	}
+}
+
+func TestEnsureDefaultPresetQuadlet_singleVersionPresetSkipsPin(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	orig := podman.DaemonReloadFn
+	t.Cleanup(func() { podman.DaemonReloadFn = orig })
+	podman.DaemonReloadFn = func() error { return nil }
+
+	if err := EnsureDefaultPresetQuadlet("mailpit"); err != nil {
+		t.Fatalf("EnsureDefaultPresetQuadlet(mailpit): %v", err)
+	}
+	cfg, _ := config.LoadGlobal()
+	if got := cfg.Services["mailpit"].CanonicalVersion; got != "" {
+		t.Errorf("single-version preset must not write a CanonicalVersion pin, got %q", got)
+	}
+}
+
+func TestMatchVersionByImageTag(t *testing.T) {
+	versions := []config.PresetVersion{
+		{Tag: "18", Image: "docker.io/postgis/postgis:18-3.6-alpine"},
+		{Tag: "17", Image: "docker.io/postgis/postgis:17-3.6-alpine"},
+		{Tag: "16", Image: "docker.io/postgis/postgis:16-3.5-alpine"},
+	}
+	cases := map[string]string{
+		"docker.io/postgis/postgis:16-3.5-alpine":   "16",
+		"docker.io/postgis/postgis:16.5-3.5-alpine": "16",
+		"docker.io/postgis/postgis:18-3.6-alpine":   "18",
+		"docker.io/postgis/postgis:17.2-3.6-alpine": "17",
+		"docker.io/library/mysql:8.4.9":             "",
+		"no-tag":                                    "",
+	}
+	for image, want := range cases {
+		if got := matchVersionByImageTag(image, versions); got != want {
+			t.Errorf("matchVersionByImageTag(%q) = %q, want %q", image, got, want)
+		}
+	}
+	mysqlVersions := []config.PresetVersion{
+		{Tag: "9.7"}, {Tag: "8.4"}, {Tag: "5.7"},
+	}
+	if got := matchVersionByImageTag("docker.io/library/mysql:8.4.9", mysqlVersions); got != "8.4" {
+		t.Errorf("mysql 8.4.9 should match 8.4, got %q", got)
+	}
+}
+
+func TestEnsureDefaultPresetQuadlet_honorsCanonicalPinAcrossFlip(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	orig := podman.DaemonReloadFn
+	t.Cleanup(func() { podman.DaemonReloadFn = orig })
+	podman.DaemonReloadFn = func() error { return nil }
+
+	// Simulate a user who installed postgres before a future YAML flip:
+	// CanonicalVersion="17" pretends the user's install pre-dated whatever
+	// the current YAML calls canonical. Reconcile must resolve against 17,
+	// not the YAML's canonical, but keep the bare "postgres" name.
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.Services == nil {
+		cfg.Services = map[string]config.ServiceConfig{}
+	}
+	cfg.Services["postgres"] = config.ServiceConfig{CanonicalVersion: "17"}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	if err := EnsureDefaultPresetQuadlet("postgres"); err != nil {
+		t.Fatalf("EnsureDefaultPresetQuadlet: %v", err)
+	}
+	quadlet, err := os.ReadFile(filepath.Join(config.QuadletDir(), "lerd-postgres.container"))
+	if err != nil {
+		t.Fatalf("read quadlet: %v", err)
+	}
+	if !strings.Contains(string(quadlet), ":17-") {
+		t.Errorf("pinned postgres must resolve to a :17- image, got:\n%s", string(quadlet))
+	}
+	if !strings.Contains(string(quadlet), "ContainerName=lerd-postgres\n") {
+		t.Errorf("pinned postgres must keep bare ContainerName=lerd-postgres, got:\n%s", string(quadlet))
+	}
+	// Pin must not be overwritten by reconcile.
+	cfg2, _ := config.LoadGlobal()
+	if got := cfg2.Services["postgres"].CanonicalVersion; got != "17" {
+		t.Errorf("reconcile must preserve existing CanonicalVersion=17, got %q", got)
+	}
+}
+
 func TestCaptureReinstallSpec_emptyPresetVersionRejected(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -166,19 +166,58 @@ func EnsureDefaultPresetQuadletPinned(name, pinnedImage string) error {
 	if err != nil {
 		return err
 	}
-	svc, err := p.Resolve("")
+	canonicalPin := ""
+	pinnedUserImage := ""
+	var extraPorts []string
+	if cfg, loadErr := config.LoadGlobal(); loadErr == nil {
+		if svcCfg, ok := cfg.Services[name]; ok {
+			canonicalPin = svcCfg.CanonicalVersion
+			pinnedUserImage = svcCfg.Image
+			extraPorts = svcCfg.ExtraPorts
+		}
+	}
+	hasUserPin := pinnedUserImage != ""
+	// Backfill for pre-existing installs that pre-date this feature: if no
+	// pin is recorded but a container is running, derive the major from the
+	// installed image tag and pin against the matching version.
+	if canonicalPin == "" && len(p.Versions) > 0 {
+		var probe string
+		if hasUserPin {
+			probe = pinnedUserImage
+		} else {
+			probe = podman.InstalledImage("lerd-" + name)
+		}
+		if probe != "" {
+			canonicalPin = matchVersionByImageTag(probe, p.Versions)
+		}
+	}
+	var svc *config.CustomService
+	if canonicalPin != "" && len(p.Versions) > 0 {
+		svc, err = p.ResolvePinned(canonicalPin)
+	} else {
+		svc, err = p.Resolve("")
+	}
 	if err != nil {
 		return err
 	}
-	hasUserPin := false
-	if cfg, loadErr := config.LoadGlobal(); loadErr == nil {
-		if svcCfg, ok := cfg.Services[name]; ok {
-			if svcCfg.Image != "" {
-				svc.Image = svcCfg.Image
-				hasUserPin = true
-			}
-			if len(svcCfg.ExtraPorts) > 0 {
-				svc.Ports = append(svc.Ports, svcCfg.ExtraPorts...)
+	if hasUserPin {
+		svc.Image = pinnedUserImage
+	}
+	if len(extraPorts) > 0 {
+		svc.Ports = append(svc.Ports, extraPorts...)
+	}
+	// First-install / backfill pin: persist the canonical tag so future YAML
+	// canonical flips don't silently major-jump this install.
+	if canonicalPin == "" && len(p.Versions) > 0 {
+		canonicalPin = p.CanonicalTag()
+	}
+	if canonicalPin != "" {
+		if cfg, _ := config.LoadGlobal(); cfg != nil {
+			entry := cfg.Services[name]
+			if entry.CanonicalVersion != canonicalPin {
+				entry.CanonicalVersion = canonicalPin
+				cfg.Services[name] = entry
+				_ = config.SaveGlobal(cfg)
 			}
 		}
 	}
@@ -226,6 +265,26 @@ func EnsureDefaultPresetQuadletPinned(name, pinnedImage string) error {
 	}
 	p.ApplyPlatformOverride(svc, runtime.GOOS)
 	return EnsureCustomServiceQuadlet(svc)
+}
+
+// matchVersionByImageTag picks the longest version tag that is a prefix of
+// the installed image's tag. Lets backfill recognise postgis:16.5-3.5-alpine
+// as version "16" and mysql:8.4.9 as version "8.4".
+func matchVersionByImageTag(image string, versions []config.PresetVersion) string {
+	at := strings.LastIndex(image, ":")
+	if at < 0 {
+		return ""
+	}
+	tag := image[at+1:]
+	best := ""
+	for _, v := range versions {
+		if tag == v.Tag || strings.HasPrefix(tag, v.Tag+".") || strings.HasPrefix(tag, v.Tag+"-") {
+			if len(v.Tag) > len(best) {
+				best = v.Tag
+			}
+		}
+	}
+	return best
 }
 
 // EnsureCustomServiceQuadlet writes the quadlet for a custom service and

--- a/internal/serviceops/update.go
+++ b/internal/serviceops/update.go
@@ -297,6 +297,22 @@ func persistImageChoice(name, newImage, op string) error {
 		if op != "migrate" {
 			next.PreMigrateBackup = ""
 		}
+		// Migrate is the explicit cross-version move, so sync the canonical
+		// pin to the new tag — otherwise a later reconcile would resolve
+		// against the pre-migrate version and clobber the migrated install.
+		if op == "migrate" {
+			if at := strings.LastIndex(newImage, ":"); at > 0 {
+				newTag := newImage[at+1:]
+				if p, perr := config.LoadPreset(name); perr == nil {
+					for _, v := range p.Versions {
+						if v.Tag == newTag {
+							next.CanonicalVersion = v.Tag
+							break
+						}
+					}
+				}
+			}
+		}
 		cfg.Services[name] = next
 		if err := config.SaveGlobal(cfg); err != nil {
 			return fmt.Errorf("saving global config: %w", err)


### PR DESCRIPTION
## Summary

Adds MySQL 9.7 LTS as an alternate to the mysql preset and restructures postgres into a multi-version preset with 16 canonical plus 17 and 18 alternates, closing the catalogue request in #360. The legacy mysql 8.0 alternate is removed because the canonical 8.4 LTS already covers that line and keeping both produced an awkward duplicate in the picker.

The bulk of the diff is the supporting infrastructure that makes future canonical promotions safe. Multi-version presets now snapshot the canonical version tag at install time into `ServiceConfig.CanonicalVersion`, and the reconcile loop resolves against that pin instead of whatever the YAML currently calls canonical. So when a later release flips postgres canonical from 16 to 18, existing installs stay on 16 because their pin says so, fresh installs land on 18 and get pinned to it, and only `lerd service migrate` updates the pin to reflect an intentional cross-major move. Pre-existing installs get backfilled from the running image's tag on the next reconcile so the protection works retroactively.

Postgres 18's upstream image moved the default `PGDATA` into a version subdirectory and refuses to start with the legacy mount layout, so the preset pins `PGDATA=/var/lib/postgresql/data` which is a no-op on 16 and 17 but forces 18 onto the layout we mount. MySQL 9.x removed `mysql_native_password` entirely and the shared `lerd.cnf` named it in `authentication_policy`, which broke server init across the whole 9.x line; the line is gone and the default `caching_sha2_password` works on every supported version.

pgadmin now auto-discovers postgres family members the same way phpmyadmin handles mysql and mariadb. A `dynamic_env` directive registers pgadmin as a postgres family consumer so `RegenerateFamilyConsumers` rebuilds its quadlet whenever an alternate is installed, removed, started, or stopped. The `servers.json` and `pgpass` mounts are generated at materialise time from `ServicesInFamily("postgres")` instead of being static, and `PGADMIN_REPLACE_SERVERS_ON_STARTUP=True` makes pgadmin re-import on every restart so newly installed alternates show up in the dashboard immediately. To support generated file content, `FileMount` gained an optional `ContentFn` alongside the static `Content` field.

Docs in `docs/usage/services.md` and `docs/usage/service-presets.md` are updated with the new version tables, alternate host ports, and a short note about the canonical pinning behaviour.