### PR TITLE
feat(commands): on-demand framework commands across UI, CLI, and MCP

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -106,6 +106,7 @@ func main() {
 	root.AddCommand(cli.NewTuiCmd())
 	root.AddCommand(cli.NewWhichCmd())
 	root.AddCommand(cli.NewCheckCmd())
+	root.AddCommand(cli.NewRunCmd())
 	root.AddCommand(cli.NewAboutCmd())
 	root.AddCommand(cli.NewWhatsnewCmd())
 	root.AddCommand(cli.NewManCmd())

--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -1,0 +1,123 @@
+# Framework commands
+
+Every PHP site in the lerd dashboard exposes a **Commands ▾** dropdown in the site controls band, alongside the version pickers and worker toggles. It surfaces a curated set of one-shot admin actions for the detected framework, plus anything the project adds in its `.lerd.yaml`. The same set is reachable from the command palette (`⌘K` / `/`) and from the terminal via `lerd run <name>`.
+
+The feature exists for the actions you'd otherwise ssh in for: clearing caches, applying migrations, generating an admin login link, exporting the database before a risky change.
+
+## Canonical commands per framework
+
+| Framework | Commands |
+|---|---|
+| Laravel | `optimize:clear`, `migrate`, `migrate:fresh` |
+| WordPress | `cache:flush`, `rewrite:flush`, `db:export` |
+| Drupal | `cr`, `uli`, `updb`, `cex`, `cim` |
+| Symfony | `cache:clear`, `doctrine:migrations:migrate`, `doctrine:fixtures:load` |
+| CakePHP | `cache:clear`, `migrate`, `schema:cache:clear` |
+| Statamic | `cache:clear`, `stache:warm`, `search:update` |
+
+Destructive commands (`migrate:fresh`, `cim`, `doctrine:fixtures:load`) are gated by a confirmation modal before running.
+
+Some commands include a `check:` rule and only surface when the relevant package is installed (`doctrine:migrations:migrate` requires `doctrine/doctrine-migrations-bundle`, CakePHP `migrate` requires `cakephp/migrations`).
+
+## How a run works
+
+Clicking a command (or pressing Enter on a palette entry, or running `lerd run <name>`) executes the shell command in the project's directory, with stdio routed depending on the command's `output:` value:
+
+- **`silent`** (default) — runs, captures output, shows a brief success or failure indicator in the modal.
+- **`text`** — same as silent but with the captured stdout rendered in a scrollable monospace block. Use for commands whose output you'd want to read (test runs, route lists, config diffs).
+- **`url`** — captures stdout, scans it for the first `http(s)://...` URL, and surfaces it with Copy and Open buttons. The killer feature for `drush uli` and similar one-time-login generators.
+- **`terminal`** — spawns the user's terminal emulator (kitty, foot, alacritty, wezterm, ghostty, ptyxis, konsole, gnome-terminal, xterm; on macOS iTerm or Terminal.app) with the command running inside. Use for interactive commands like `php artisan tinker`, `bin/cake bake`, `wp shell` that need a real TTY. The lerd-ui modal stays closed.
+
+The dashboard modal streams output as it arrives via Server-Sent Events from `POST /api/sites/:domain/commands/:name/run`; the CLI streams straight to your terminal (`lerd run` is stdio-passthrough).
+
+## Project commands
+
+Any `.lerd.yaml` can add or override commands via a `commands:` block:
+
+```yaml
+# .lerd.yaml
+commands:
+  - name: deploy
+    label: Deploy to staging
+    command: ./bin/deploy staging
+    description: Push the current branch to the staging environment
+    output: text
+    icon: arrow-up
+
+  - name: search:replace
+    label: Replace URL across the database
+    command: wp search-replace https://old.example https://new.example --all-tables
+    output: text
+    confirm: true
+    icon: edit
+
+  - name: migrate:fresh
+    disabled: true                 # suppress the Laravel default
+```
+
+The merge rules are:
+
+- A project entry with the same `name` as a framework entry **fully replaces** it. Use this to point `test` at Pest, swap the migration command for a custom wrapper, etc.
+- `disabled: true` on a name that matches a framework entry **suppresses** the framework default without contributing a replacement.
+- A project entry with a new `name` is **appended** after the framework set.
+- Framework entries whose `check:` rule fails are dropped before the merge.
+
+Validation runs as part of `lerd check`. Invalid `output:` values, unknown icons, duplicate names, and missing commands all surface there.
+
+## Schema
+
+```yaml
+commands:
+  - name: optimize:clear         # stable id; also the `lerd run` argument and override key
+    label: Clear all caches       # UI label
+    command: php artisan optimize:clear   # shell, passed to `sh -c`
+    description: Clear config, route, view, event, and compiled caches
+    output: silent                # silent | text | url | terminal
+    confirm: false                # ask before running
+    icon: broom                   # from the known icon set
+    cwd: .                        # optional, relative to project root
+    check:                        # optional; hide when this rule fails
+      composer: doctrine/doctrine-migrations-bundle
+    # `disabled: true` is only meaningful in .lerd.yaml; ignored in framework yamls
+```
+
+**Known icons**: `broom`, `database`, `refresh`, `link`, `check`, `list`, `key`, `edit`, `arrow-down`, `arrow-up`, `play`, `terminal`. An unknown icon falls back to a generic glyph; `lerd check` warns.
+
+**Output values:** invalid values fail `lerd check`. Defaults to `silent`.
+
+**Check rules**: reuse `FrameworkRule`. The two common forms are `composer: <package>` (the package must be in `composer.json`) and `file: <path>` (the file must exist relative to the project root).
+
+## Agents (MCP)
+
+When the lerd MCP server is registered, an AI assistant can:
+
+- `commands_list(site)` — see what's available for a site
+- `commands_run(site, name, force?)` — execute one (with `force: true` to bypass `confirm`)
+- `command_add(site, name, command, ...)` — write a new entry into `.lerd.yaml`'s `commands:` block. Same `name` as a framework default replaces it. Use `disabled: true` to suppress a framework default
+- `command_remove(site, name)` — delete a project entry
+
+Agents should prefer `commands_run` over invoking `php artisan` / `drush` / `wp` directly so per-project overrides are honored, and `command_add` over hand-editing yaml so the entry passes the same validation `lerd check` runs.
+
+## CLI
+
+```
+$ lerd run                            # list available commands for the current project
+    optimize:clear   Clear all caches
+    migrate          Run migrations
+  * migrate:fresh    Drop and re-migrate
+
+  * = asks for confirmation. Use --yes to skip.
+
+$ lerd run optimize:clear             # execute, stream stdout to your terminal
+$ lerd run migrate:fresh --yes        # bypass the confirm prompt
+```
+
+`lerd run` walks up from the current directory to find the nearest `.lerd.yaml`, so it works from any subdirectory of a site (including inside a git worktree). The exit code propagates from the underlying shell.
+
+Shell completion populates command names: `lerd run <TAB>` lists what's available in the current project.
+
+## Concurrency & security
+
+Two commands cannot run on the same site at the same time; the API returns `409 Conflict` if a second run is attempted while one is in flight. This protects against accidentally running `migrate:fresh` twice from two tabs.
+
+The run endpoint is loopback-only — LAN clients (when the access mode allows remote viewing) can see the list of commands but cannot execute them. The list endpoint is read-only and exposed everywhere lerd-ui is reachable.

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -112,6 +112,10 @@ Once the MCP server is connected, your AI assistant has access to:
 | `schedule` | Start or stop the task scheduler for a site — `action`: `start` / `stop` |
 | `worker` | Start or stop any named framework worker (e.g. `messenger`, `pulse`) — `action`: `start` / `stop`. Accepts an optional `branch` to target a per-worktree unit (e.g. `vite` on `feat-a`) instead of the parent site's worker |
 | `worker_list` | List all workers defined for a site's framework with running status. Accepts an optional `branch` so worktree-scoped runtime can be inspected separately from the parent |
+| `commands_list` | List one-shot framework commands available for a site (resolved from framework yaml + `.lerd.yaml`). Same set the dashboard dropdown and `lerd run` see |
+| `commands_run` | Execute a named command on a site (e.g. `optimize:clear`, `drush uli`, `cache:flush`). Returns combined stdout/stderr + exit code. Destructive commands (`confirm: true`) require `force: true` |
+| `command_add` | Add or update a project command in `.lerd.yaml`'s `commands:` block. Same name as a framework default replaces it. Use `disabled: true` to suppress a framework default |
+| `command_remove` | Remove a project command from `.lerd.yaml` by name. Does not affect framework defaults |
 | `workers_mode` | Get or set the worker exec mode for a site — `action`: `get` / `set`, `mode`: `exec` (default; one container shared by all workers) or `container` (one container per worker). Used when an Octane-style runtime needs process isolation per worker |
 | `workers_heal` | Restart every worker reported as failing in one pass. Mirrors the dashboard's heal-all button and the TUI `H` keybind |
 | `workers_health` | Snapshot of every framework worker across every site with its running / failing state and the last error captured from journalctl, useful before deciding to heal |

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/geodro/lerd/internal/config"
 	phpPkg "github.com/geodro/lerd/internal/php"
@@ -223,6 +224,45 @@ func runCheck(_ *cobra.Command, _ []string) error {
 		} else {
 			fmt.Printf("  OK    custom_worker.%s\n", name)
 		}
+	}
+
+	// commands
+	seenCmdNames := map[string]bool{}
+	for i, c := range cfg.Commands {
+		if c.Name == "" {
+			fmt.Printf("  FAIL  commands[%d]: name is required\n", i)
+			errors++
+			continue
+		}
+		if seenCmdNames[c.Name] {
+			fmt.Printf("  FAIL  command %q: duplicate name\n", c.Name)
+			errors++
+			continue
+		}
+		seenCmdNames[c.Name] = true
+		if c.Disabled {
+			fmt.Printf("  OK    command.%s (disabled)\n", c.Name)
+			continue
+		}
+		if c.Command == "" {
+			fmt.Printf("  FAIL  command %q: command is required (or set disabled: true)\n", c.Name)
+			errors++
+			continue
+		}
+		if c.Label == "" {
+			fmt.Printf("  WARN  command %q: label is empty, the UI will fall back to the name\n", c.Name)
+			warnings++
+		}
+		if c.Output != "" && !slices.Contains(config.ValidCommandOutputs, c.Output) {
+			fmt.Printf("  FAIL  command %q: output %q is invalid (expected: %v)\n", c.Name, c.Output, config.ValidCommandOutputs)
+			errors++
+			continue
+		}
+		if c.Icon != "" && !slices.Contains(config.KnownCommandIcons, c.Icon) {
+			fmt.Printf("  WARN  command %q: icon %q is not in the known set, UI will fall back to a generic icon\n", c.Name, c.Icon)
+			warnings++
+		}
+		fmt.Printf("  OK    command.%s\n", c.Name)
 	}
 
 	// db

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -1011,6 +1011,20 @@ Arguments:
 - ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
 - ` + bt + `branch` + bt + ` (optional): worktree branch name. With ` + bt + `branch` + bt + `, status is reported for ` + bt + `lerd-<worker>-<site>-<branch>` + bt + ` units instead of the parent-site units
 
+### ` + bt + `commands_list` + bt + ` / ` + bt + `commands_run` + bt + ` / ` + bt + `command_add` + bt + ` / ` + bt + `command_remove` + bt + `
+One-shot framework commands (` + bt + `optimize:clear` + bt + `, ` + bt + `migrate` + bt + `, ` + bt + `drush uli` + bt + `, ` + bt + `cache:flush` + bt + `, etc). Set = framework yaml + project ` + bt + `.lerd.yaml` + bt + ` ` + bt + `commands:` + bt + `. Prefer over invoking ` + bt + `php artisan` + bt + ` / ` + bt + `drush` + bt + ` / ` + bt + `wp` + bt + ` directly because per-project overrides are honored. ` + bt + `command_add` + bt + ` writes to ` + bt + `.lerd.yaml` + bt + `; use ` + bt + `disabled: true` + bt + ` to suppress a framework default without replacement.
+
+Arguments:
+- ` + bt + `site` + bt + ` (required): site name
+- ` + bt + `name` + bt + ` (commands_run / command_add / command_remove): name from ` + bt + `commands_list` + bt + ` or a new identifier
+- ` + bt + `command` + bt + ` (command_add): shell command (required unless ` + bt + `disabled: true` + bt + `)
+- ` + bt + `label` + bt + `, ` + bt + `description` + bt + `, ` + bt + `icon` + bt + ` (command_add, optional)
+- ` + bt + `output` + bt + ` (command_add): ` + bt + `silent | text | url | terminal` + bt + ` (default silent)
+- ` + bt + `confirm` + bt + ` (command_add): gate behind a safety modal
+- ` + bt + `check_file` + bt + ` / ` + bt + `check_composer` + bt + ` (command_add): hide unless the rule passes
+- ` + bt + `disabled` + bt + ` (command_add): suppress a framework default of the same name
+- ` + bt + `force` + bt + ` (commands_run): required for confirm-gated commands
+
 ### ` + bt + `worker_add` + bt + `
 Add or update a custom worker for a project. Saves to ` + bt + `.lerd.yaml` + bt + ` ` + bt + `custom_workers` + bt + ` by default, or to the global framework overlay (` + bt + `~/.config/lerd/frameworks/` + bt + `) with ` + bt + `global: true` + bt + `. Does not auto-start — use ` + bt + `worker(action: "start", ...)` + bt + ` afterwards.
 

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -506,9 +506,9 @@ func TestIsLerdBuiltImage_matchers(t *testing.T) {
 // and globally; drift upward gets expensive fast. Raise the ceiling only
 // when adding content that justifies the bytes.
 func TestClaudeSkillContent_underSizeCeiling(t *testing.T) {
-	// Bumped to 50000 for the four new dumps_* tool sections and the dump
-	// bridge entry in the quick-reference table.
-	const ceiling = 50000
+	// Bumped to 51000 for commands_list / commands_run tools (framework
+	// command runner) plus their quick-reference table entries.
+	const ceiling = 51000
 	if got := len(claudeSkillContent); got > ceiling {
 		t.Errorf("claudeSkillContent is %d bytes, ceiling is %d — trim before raising", got, ceiling)
 	}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// NewRunCmd returns the `lerd run` command, the CLI alias for the framework
+// commands feature. With no args it lists available commands for the current
+// site; with a name it executes that command in the project directory.
+func NewRunCmd() *cobra.Command {
+	var assumeYes bool
+	cmd := &cobra.Command{
+		Use:   "run [name]",
+		Short: "Run a framework command (artisan optimize:clear, drush cr, etc.) in the current site",
+		Long: `Run a command defined by the site's framework or its .lerd.yaml.
+
+With no arguments, lists all commands available in the current project.
+With a command name, executes that command in the project's directory and
+streams output to your terminal.
+
+Commands marked confirm: true prompt before running unless --yes is set.`,
+		Args: cobra.MaximumNArgs(1),
+		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			cwd, err := os.Getwd()
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			cmds := resolveCommandsForCwd(cwd)
+			names := make([]string, 0, len(cmds))
+			for _, c := range cmds {
+				names = append(names, c.Name)
+			}
+			return names, cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			cmds := resolveCommandsForCwd(cwd)
+			if len(args) == 0 {
+				return listCommands(cmds)
+			}
+			return runNamedCommand(cwd, cmds, args[0], assumeYes)
+		},
+	}
+	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "Skip confirmation prompts on destructive commands")
+	return cmd
+}
+
+// projectRootFromCwd walks up from cwd looking for the nearest .lerd.yaml.
+// Returns cwd unchanged if nothing is found (lets callers handle the
+// "no project" case downstream). Stops at the filesystem root.
+func projectRootFromCwd(cwd string) string {
+	d := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(d, ".lerd.yaml")); err == nil {
+			return d
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			return cwd
+		}
+		d = parent
+	}
+}
+
+func resolveCommandsForCwd(cwd string) []config.FrameworkCommand {
+	root := projectRootFromCwd(cwd)
+	proj, _ := config.LoadProjectConfig(root)
+	var fw *config.Framework
+	if proj != nil && proj.Framework != "" {
+		fw, _ = config.GetFrameworkForDir(proj.Framework, root)
+	}
+	if fw == nil {
+		// Fall back to detection in case .lerd.yaml is absent.
+		if name, ok := config.DetectFramework(root); ok {
+			fw, _ = config.GetFrameworkForDir(name, root)
+		}
+	}
+	return config.ResolveCommands(fw, proj, root)
+}
+
+func listCommands(cmds []config.FrameworkCommand) error {
+	if len(cmds) == 0 {
+		fmt.Println("No commands available for this project.")
+		fmt.Println("Add a commands: block to .lerd.yaml or install the framework store.")
+		return nil
+	}
+	maxName := 0
+	for _, c := range cmds {
+		if len(c.Name) > maxName {
+			maxName = len(c.Name)
+		}
+	}
+	for _, c := range cmds {
+		marker := " "
+		if c.Confirm {
+			marker = "*"
+		}
+		desc := c.Description
+		if desc == "" {
+			desc = c.Label
+		}
+		fmt.Printf("  %s %-*s  %s\n", marker, maxName, c.Name, desc)
+	}
+	fmt.Println()
+	fmt.Println("  * = asks for confirmation. Use --yes to skip.")
+	return nil
+}
+
+func runNamedCommand(cwd string, cmds []config.FrameworkCommand, name string, assumeYes bool) error {
+	var target *config.FrameworkCommand
+	for i := range cmds {
+		if cmds[i].Name == name {
+			target = &cmds[i]
+			break
+		}
+	}
+	if target == nil {
+		return fmt.Errorf("command %q not found. Run `lerd run` to list available commands", name)
+	}
+	if target.Command == "" {
+		return fmt.Errorf("command %q has no shell invocation", name)
+	}
+
+	if target.Confirm && !assumeYes {
+		fmt.Printf("This will run: %s\n", target.Command)
+		fmt.Printf("Continue? [y/N] ")
+		reader := bufio.NewReader(os.Stdin)
+		line, _ := reader.ReadString('\n')
+		ans := strings.ToLower(strings.TrimSpace(line))
+		if ans != "y" && ans != "yes" {
+			return fmt.Errorf("aborted")
+		}
+	}
+
+	runDir := projectRootFromCwd(cwd)
+	if target.CWD != "" && target.CWD != "." {
+		runDir = filepath.Join(runDir, target.CWD)
+	}
+
+	c := exec.Command("sh", "-c", target.Command)
+	c.Dir = runDir
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			os.Exit(ee.ExitCode())
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// projectWithCommands writes a .lerd.yaml containing only a commands: block
+// (no framework reference) so resolveCommandsForCwd returns the project
+// entries without needing a framework store fetch.
+func projectWithCommands(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestResolveCommandsForCwd_ProjectOnly(t *testing.T) {
+	dir := projectWithCommands(t, `
+commands:
+  - name: hello
+    label: Say hello
+    command: echo hi
+    output: text
+  - name: deploy
+    label: Deploy
+    command: ./bin/deploy
+    confirm: true
+`)
+	got := resolveCommandsForCwd(dir)
+	if len(got) != 2 {
+		t.Fatalf("want 2 commands, got %d: %+v", len(got), got)
+	}
+	if got[0].Name != "hello" || got[1].Name != "deploy" {
+		t.Errorf("order/names: %+v", got)
+	}
+}
+
+func TestResolveCommandsForCwd_NoConfig(t *testing.T) {
+	dir := t.TempDir()
+	got := resolveCommandsForCwd(dir)
+	if len(got) != 0 {
+		t.Errorf("want 0 commands in bare dir, got %d: %+v", len(got), got)
+	}
+}
+
+func TestListCommands_Empty(t *testing.T) {
+	if err := listCommands(nil); err != nil {
+		t.Errorf("list with nil should succeed: %v", err)
+	}
+}
+
+func TestListCommands_FormatsConfirmMarker(t *testing.T) {
+	// Just verify it doesn't error; pretty-printing is exercised via
+	// the binary smoke. We assert the marker logic via reading back state.
+	cmds := []config.FrameworkCommand{
+		{Name: "a", Label: "Item A", Description: "Does A"},
+		{Name: "b", Label: "Item B", Description: "Does B", Confirm: true},
+	}
+	if err := listCommands(cmds); err != nil {
+		t.Errorf("list: %v", err)
+	}
+}
+
+func TestRunNamedCommand_NotFound(t *testing.T) {
+	err := runNamedCommand(t.TempDir(), nil, "missing", true)
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("want not-found error, got: %v", err)
+	}
+}
+
+func TestRunNamedCommand_EmptyCommand(t *testing.T) {
+	cmds := []config.FrameworkCommand{{Name: "noop"}}
+	err := runNamedCommand(t.TempDir(), cmds, "noop", true)
+	if err == nil || !strings.Contains(err.Error(), "no shell invocation") {
+		t.Errorf("want empty-cmd error, got: %v", err)
+	}
+}
+
+func TestResolveCommandsForCwd_WalksUpFromSubdir(t *testing.T) {
+	dir := projectWithCommands(t, `
+commands:
+  - name: ping
+    label: Ping
+    command: echo pong
+`)
+	sub := filepath.Join(dir, "app", "Http", "Controllers")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got := resolveCommandsForCwd(sub)
+	if len(got) != 1 || got[0].Name != "ping" {
+		t.Errorf("walk-up should find .lerd.yaml in parent: %+v", got)
+	}
+}
+
+func TestRunNamedCommand_DisabledFromProjectIsHidden(t *testing.T) {
+	// Project entry with disabled: true should not appear in the resolved list,
+	// so runNamedCommand sees it as not-found.
+	dir := projectWithCommands(t, `
+commands:
+  - name: hello
+    label: Hi
+    command: echo hi
+  - name: bye
+    disabled: true
+`)
+	cmds := resolveCommandsForCwd(dir)
+	for _, c := range cmds {
+		if c.Name == "bye" {
+			t.Errorf("disabled project entry should not be returned: %+v", c)
+		}
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -44,6 +44,10 @@ type Framework struct {
 	NPM       string                     `yaml:"npm,omitempty"`      // auto | true | false
 	Workers   map[string]FrameworkWorker `yaml:"workers,omitempty"`
 	Setup     []FrameworkSetupCmd        `yaml:"setup,omitempty"`
+	// Commands are on-demand actions surfaced in the dashboard "Run command"
+	// dropdown. See FrameworkCommand for the schema. Projects extend or
+	// override this list in .lerd.yaml; use ResolveCommands to merge.
+	Commands []FrameworkCommand `yaml:"commands,omitempty"`
 	// Console is the console command to run (without 'php' prefix).
 	// Example: "artisan", "bin/console"
 	Console string `yaml:"console,omitempty"`
@@ -139,6 +143,94 @@ type FrameworkSetupCmd struct {
 	Command string         `yaml:"command"`
 	Default bool           `yaml:"default,omitempty"`
 	Check   *FrameworkRule `yaml:"check,omitempty"` // only show when check passes (file exists or composer package installed)
+}
+
+// FrameworkCommand describes a one-shot, on-demand action surfaced in the
+// dashboard "Commands" dropdown and as `lerd run <name>`. The framework yaml
+// ships canonical defaults; projects extend or override them by name in
+// .lerd.yaml. Distinct from FrameworkWorker (long-running) and
+// FrameworkSetupCmd (install-time only).
+type FrameworkCommand struct {
+	Name        string         `yaml:"name" json:"name"`                                   // stable identifier, also the `lerd run` argument
+	Label       string         `yaml:"label" json:"label"`                                 // human label shown in the UI
+	Command     string         `yaml:"command" json:"command"`                             // shell command, passed to `sh -c`
+	Description string         `yaml:"description,omitempty" json:"description,omitempty"` // one-line description for tooltips
+	Output      string         `yaml:"output,omitempty" json:"output,omitempty"`           // silent | text | url | terminal (default: silent)
+	Confirm     bool           `yaml:"confirm,omitempty" json:"confirm,omitempty"`         // gate behind a confirm modal before running
+	Icon        string         `yaml:"icon,omitempty" json:"icon,omitempty"`               // icon name from the known set
+	Check       *FrameworkRule `yaml:"check,omitempty" json:"check,omitempty"`             // hide the command when this rule fails
+	CWD         string         `yaml:"cwd,omitempty" json:"cwd,omitempty"`                 // working dir relative to project root (default: ".")
+	// Disabled, in a project .lerd.yaml entry, suppresses the framework default
+	// of the same Name without replacing it. Ignored when read from a framework yaml.
+	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+}
+
+// Valid Output values for FrameworkCommand.
+const (
+	CommandOutputSilent   = "silent"
+	CommandOutputText     = "text"
+	CommandOutputURL      = "url"
+	CommandOutputTerminal = "terminal" // spawn the user's terminal emulator instead of streaming to the modal
+)
+
+// ValidCommandOutputs lists the accepted Output values; used by validation.
+var ValidCommandOutputs = []string{CommandOutputSilent, CommandOutputText, CommandOutputURL, CommandOutputTerminal}
+
+// KnownCommandIcons is the curated icon vocabulary. .lerd.yaml entries with an
+// icon outside this set fail `lerd check`. Keep in sync with the UI Icon
+// component so an icon present here always resolves to a visual on screen.
+var KnownCommandIcons = []string{
+	"broom", "database", "refresh", "link", "check", "list",
+	"key", "edit", "arrow-down", "arrow-up", "play", "terminal",
+}
+
+// ResolveCommands merges the framework's command set with project-level entries
+// from .lerd.yaml. Rules:
+//   - Project entry with the same Name as a framework entry fully replaces it.
+//   - Project entry with Disabled=true suppresses the framework default and
+//     does not contribute a runnable command.
+//   - Project entries with no matching framework entry are appended.
+//   - Framework entries with a failing Check are dropped before merging.
+//
+// The resulting slice preserves framework ordering, with project-only
+// additions appended in declaration order.
+func ResolveCommands(fw *Framework, proj *ProjectConfig, projectDir string) []FrameworkCommand {
+	overrides := map[string]FrameworkCommand{}
+	var extras []FrameworkCommand
+	frameworkNames := map[string]bool{}
+	if fw != nil {
+		for _, c := range fw.Commands {
+			frameworkNames[c.Name] = true
+		}
+	}
+	if proj != nil {
+		for _, c := range proj.Commands {
+			if frameworkNames[c.Name] {
+				overrides[c.Name] = c
+			} else if !c.Disabled {
+				extras = append(extras, c)
+			}
+		}
+	}
+
+	var out []FrameworkCommand
+	if fw != nil {
+		for _, c := range fw.Commands {
+			if ov, ok := overrides[c.Name]; ok {
+				if ov.Disabled {
+					continue
+				}
+				out = append(out, ov)
+				continue
+			}
+			if c.Check != nil && !MatchesRule(projectDir, *c.Check) {
+				continue
+			}
+			out = append(out, c)
+		}
+	}
+	out = append(out, extras...)
+	return out
 }
 
 // FrameworkPHP defines the supported PHP version range for a framework version.
@@ -392,6 +484,11 @@ var laravelFramework = &Framework{
 				`exec php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=8000 --workers=auto`},
 		SupportsWorker: true,
 	},
+	Commands: []FrameworkCommand{
+		{Name: "optimize:clear", Label: "Clear all caches", Command: "php artisan optimize:clear", Description: "Clear config, route, view, event, and compiled caches", Output: "silent", Icon: "broom"},
+		{Name: "migrate", Label: "Run migrations", Command: "php artisan migrate --force", Description: "Apply pending database migrations", Output: "silent", Icon: "database"},
+		{Name: "migrate:fresh", Label: "Drop and re-migrate", Command: "php artisan migrate:fresh --seed --force", Description: "Wipe the database, re-run all migrations, then seed", Output: "silent", Confirm: true, Icon: "refresh"},
+	},
 }
 
 // symfonyFramework is a built-in Symfony adapter. It detects Symfony via
@@ -463,6 +560,11 @@ var symfonyFramework = &Framework{
 			"--worker=public/index.php", "--watch",
 		},
 		SupportsWorker: true,
+	},
+	Commands: []FrameworkCommand{
+		{Name: "cache:clear", Label: "Clear cache", Command: "bin/console cache:clear", Description: "Clear the Symfony cache for the current environment", Output: "silent", Icon: "broom"},
+		{Name: "doctrine:migrations:migrate", Label: "Run migrations", Command: "bin/console doctrine:migrations:migrate --no-interaction", Description: "Apply pending Doctrine migrations", Output: "silent", Icon: "database", Check: &FrameworkRule{Composer: "doctrine/doctrine-migrations-bundle"}},
+		{Name: "doctrine:fixtures:load", Label: "Load fixtures", Command: "bin/console doctrine:fixtures:load --no-interaction", Description: "Wipe data and load fixtures", Output: "silent", Confirm: true, Icon: "refresh", Check: &FrameworkRule{Composer: "doctrine/doctrine-fixtures-bundle"}},
 	},
 }
 

--- a/internal/config/framework_commands_test.go
+++ b/internal/config/framework_commands_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestParseFrameworkCommands_YAML(t *testing.T) {
+	src := []byte(`
+name: laravel
+version: "13"
+public_dir: public
+commands:
+  - name: cache-clear
+    label: Clear all caches
+    command: php artisan optimize:clear
+    output: silent
+    icon: broom
+  - name: migrate-fresh
+    label: Drop and re-migrate
+    command: php artisan migrate:fresh --seed --force
+    confirm: true
+    output: silent
+    icon: refresh
+`)
+	var fw Framework
+	if err := yaml.Unmarshal(src, &fw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(fw.Commands) != 2 {
+		t.Fatalf("want 2 commands, got %d", len(fw.Commands))
+	}
+	if fw.Commands[0].Name != "cache-clear" || fw.Commands[0].Output != "silent" {
+		t.Errorf("commands[0]: %+v", fw.Commands[0])
+	}
+	if !fw.Commands[1].Confirm {
+		t.Errorf("commands[1].Confirm should be true: %+v", fw.Commands[1])
+	}
+}
+
+func TestParseProjectCommands_YAML(t *testing.T) {
+	src := []byte(`
+framework: laravel
+commands:
+  - name: test
+    label: Run Pest
+    command: vendor/bin/pest
+    output: text
+  - name: migrate-fresh
+    disabled: true
+  - name: deploy
+    label: Deploy to staging
+    command: ./bin/deploy staging
+    output: text
+    confirm: true
+`)
+	var pc ProjectConfig
+	if err := yaml.Unmarshal(src, &pc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(pc.Commands) != 3 {
+		t.Fatalf("want 3 project commands, got %d", len(pc.Commands))
+	}
+	if !pc.Commands[1].Disabled {
+		t.Errorf("commands[1].Disabled should be true: %+v", pc.Commands[1])
+	}
+}
+
+func TestResolveCommands_OverrideByName(t *testing.T) {
+	fw := &Framework{Commands: []FrameworkCommand{
+		{Name: "test", Label: "Run tests", Command: "php artisan test", Output: "text"},
+		{Name: "cache-clear", Label: "Clear caches", Command: "php artisan optimize:clear"},
+	}}
+	proj := &ProjectConfig{Commands: []FrameworkCommand{
+		{Name: "test", Label: "Run Pest", Command: "vendor/bin/pest", Output: "text"},
+	}}
+	got := ResolveCommands(fw, proj, t.TempDir())
+	if len(got) != 2 {
+		t.Fatalf("want 2 resolved, got %d: %+v", len(got), got)
+	}
+	if got[0].Command != "vendor/bin/pest" || got[0].Label != "Run Pest" {
+		t.Errorf("project should override framework test command, got %+v", got[0])
+	}
+	if got[1].Name != "cache-clear" {
+		t.Errorf("framework cache-clear should remain, got %+v", got[1])
+	}
+}
+
+func TestResolveCommands_DisabledSuppresses(t *testing.T) {
+	fw := &Framework{Commands: []FrameworkCommand{
+		{Name: "migrate-fresh", Label: "Fresh", Command: "php artisan migrate:fresh --seed --force", Confirm: true},
+		{Name: "cache-clear", Label: "Clear", Command: "php artisan optimize:clear"},
+	}}
+	proj := &ProjectConfig{Commands: []FrameworkCommand{
+		{Name: "migrate-fresh", Disabled: true},
+	}}
+	got := ResolveCommands(fw, proj, t.TempDir())
+	if len(got) != 1 {
+		t.Fatalf("want 1 after disable, got %d: %+v", len(got), got)
+	}
+	if got[0].Name != "cache-clear" {
+		t.Errorf("only cache-clear should remain: %+v", got)
+	}
+}
+
+func TestResolveCommands_ProjectExtras(t *testing.T) {
+	fw := &Framework{Commands: []FrameworkCommand{
+		{Name: "cache-clear", Command: "php artisan optimize:clear"},
+	}}
+	proj := &ProjectConfig{Commands: []FrameworkCommand{
+		{Name: "deploy", Label: "Deploy", Command: "./bin/deploy"},
+		{Name: "smoke", Label: "Smoke", Command: "./bin/smoke"},
+	}}
+	got := ResolveCommands(fw, proj, t.TempDir())
+	if len(got) != 3 {
+		t.Fatalf("want 3 (1 framework + 2 project), got %d: %+v", len(got), got)
+	}
+	names := []string{got[0].Name, got[1].Name, got[2].Name}
+	want := []string{"cache-clear", "deploy", "smoke"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("order: want %v, got %v", want, names)
+	}
+}
+
+func TestResolveCommands_NilFrameworkOrProject(t *testing.T) {
+	got := ResolveCommands(nil, nil, t.TempDir())
+	if got != nil {
+		t.Errorf("nil framework + nil project should return nil, got %+v", got)
+	}
+
+	proj := &ProjectConfig{Commands: []FrameworkCommand{
+		{Name: "deploy", Command: "./bin/deploy"},
+	}}
+	got = ResolveCommands(nil, proj, t.TempDir())
+	if len(got) != 1 || got[0].Name != "deploy" {
+		t.Errorf("nil framework should still surface project extras: %+v", got)
+	}
+}
+
+func TestResolveCommands_FailingCheckDrops(t *testing.T) {
+	fw := &Framework{Commands: []FrameworkCommand{
+		{Name: "horizon-stats", Label: "Horizon status", Command: "php artisan horizon:status", Check: &FrameworkRule{Composer: "laravel/horizon"}},
+		{Name: "cache-clear", Label: "Clear", Command: "php artisan optimize:clear"},
+	}}
+	got := ResolveCommands(fw, nil, t.TempDir())
+	if len(got) != 1 || got[0].Name != "cache-clear" {
+		t.Errorf("horizon-stats with failing check should be dropped, got %+v", got)
+	}
+}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -41,6 +41,11 @@ type ProjectConfig struct {
 	Services         []ProjectService           `yaml:"services,omitempty"`
 	Workers          []string                   `yaml:"workers,omitempty"`
 	CustomWorkers    map[string]FrameworkWorker `yaml:"custom_workers,omitempty"`
+	// Commands extends or overrides the framework's command set. Entries with
+	// a Name matching a framework command replace it (set Disabled: true to
+	// suppress instead). Entries with a new Name are appended. See
+	// ResolveCommands for the merge logic.
+	Commands []FrameworkCommand `yaml:"commands,omitempty"`
 	// AppURL, when set, is the value lerd writes to the project's APP_URL (or
 	// the framework-configured URL key) on every `lerd env` run. Committed to
 	// the repo so the choice is shared across machines. Takes precedence over

--- a/internal/config/project_command_test.go
+++ b/internal/config/project_command_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSetProjectCommand_AppendsToEmptyConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := FrameworkCommand{Name: "deploy", Label: "Deploy", Command: "./bin/deploy", Output: "text"}
+	if err := SetProjectCommand(dir, cmd); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	cfg, _ := LoadProjectConfig(dir)
+	if len(cfg.Commands) != 1 || cfg.Commands[0].Name != "deploy" {
+		t.Errorf("commands: %+v", cfg.Commands)
+	}
+}
+
+func TestSetProjectCommand_UpdatesExistingByName(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\ncommands:\n  - name: deploy\n    command: old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := FrameworkCommand{Name: "deploy", Label: "Deploy v2", Command: "new", Output: "text"}
+	if err := SetProjectCommand(dir, cmd); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	cfg, _ := LoadProjectConfig(dir)
+	if len(cfg.Commands) != 1 {
+		t.Fatalf("want 1 command after update, got %d", len(cfg.Commands))
+	}
+	if cfg.Commands[0].Command != "new" || cfg.Commands[0].Label != "Deploy v2" {
+		t.Errorf("update failed: %+v", cfg.Commands[0])
+	}
+}
+
+func TestSetProjectCommand_RequiresName(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := SetProjectCommand(dir, FrameworkCommand{Command: "echo hi"})
+	if err == nil {
+		t.Fatal("want validation error, got nil")
+	}
+	if _, ok := err.(*CommandValidationError); !ok {
+		t.Errorf("want CommandValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSetProjectCommand_CreatesYamlIfMissing(t *testing.T) {
+	dir := t.TempDir()
+	// No .lerd.yaml yet — SetProjectCommand should create it.
+	cmd := FrameworkCommand{Name: "deploy", Label: "Deploy", Command: "./bin/deploy"}
+	if err := SetProjectCommand(dir, cmd); err != nil {
+		t.Fatalf("set on missing yaml: %v", err)
+	}
+	cfg, _ := LoadProjectConfig(dir)
+	if len(cfg.Commands) != 1 || cfg.Commands[0].Name != "deploy" {
+		t.Errorf("yaml not created with command: %+v", cfg)
+	}
+}
+
+func TestRemoveProjectCommand_DropsExistingEntry(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\ncommands:\n  - name: a\n    command: x\n  - name: b\n    command: y\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveProjectCommand(dir, "a"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	cfg, _ := LoadProjectConfig(dir)
+	if len(cfg.Commands) != 1 || cfg.Commands[0].Name != "b" {
+		t.Errorf("remove failed: %+v", cfg.Commands)
+	}
+}
+
+func TestRemoveProjectCommand_ReportsMissing(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := RemoveProjectCommand(dir, "ghost")
+	if err == nil {
+		t.Fatal("want not-found error, got nil")
+	}
+	if _, ok := err.(*CommandNotFoundError); !ok {
+		t.Errorf("want CommandNotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestRemoveProjectCommand_NoYamlReturnsNotFound(t *testing.T) {
+	dir := t.TempDir()
+	err := RemoveProjectCommand(dir, "anything")
+	if _, ok := err.(*CommandNotFoundError); !ok {
+		t.Errorf("missing yaml should report not found, got %T: %v", err, err)
+	}
+}

--- a/internal/config/project_update.go
+++ b/internal/config/project_update.go
@@ -171,6 +171,66 @@ func (e *WorkerNotFoundError) Error() string {
 	return "custom worker " + e.Name + " not found in .lerd.yaml"
 }
 
+// SetProjectCommand adds or replaces a command in .lerd.yaml's commands: block,
+// matched by Name. Creates the file if it doesn't exist (commands can land on
+// fresh projects, unlike custom workers which presume a registered site).
+func SetProjectCommand(dir string, cmd FrameworkCommand) error {
+	if cmd.Name == "" {
+		return &CommandValidationError{Reason: "name is required"}
+	}
+	cfg, err := LoadProjectConfig(dir)
+	if err != nil {
+		return err
+	}
+	replaced := false
+	for i := range cfg.Commands {
+		if cfg.Commands[i].Name == cmd.Name {
+			cfg.Commands[i] = cmd
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		cfg.Commands = append(cfg.Commands, cmd)
+	}
+	return SaveProjectConfig(dir, cfg)
+}
+
+// RemoveProjectCommand deletes a project-level command entry by Name.
+// Returns CommandNotFoundError if .lerd.yaml has no entry with that name.
+func RemoveProjectCommand(dir string, name string) error {
+	path := filepath.Join(dir, ".lerd.yaml")
+	if _, err := os.Stat(path); err != nil {
+		return &CommandNotFoundError{Name: name}
+	}
+	cfg, err := LoadProjectConfig(dir)
+	if err != nil {
+		return err
+	}
+	for i := range cfg.Commands {
+		if cfg.Commands[i].Name == name {
+			cfg.Commands = append(cfg.Commands[:i], cfg.Commands[i+1:]...)
+			if len(cfg.Commands) == 0 {
+				cfg.Commands = nil
+			}
+			return SaveProjectConfig(dir, cfg)
+		}
+	}
+	return &CommandNotFoundError{Name: name}
+}
+
+// CommandNotFoundError is returned when a project command name is not in .lerd.yaml.
+type CommandNotFoundError struct{ Name string }
+
+func (e *CommandNotFoundError) Error() string {
+	return "command " + e.Name + " not found in .lerd.yaml"
+}
+
+// CommandValidationError flags structural problems before we touch the yaml.
+type CommandValidationError struct{ Reason string }
+
+func (e *CommandValidationError) Error() string { return "invalid command: " + e.Reason }
+
 // ReplaceProjectDBService removes any existing sqlite/mysql/postgres service
 // and adds the given choice. Creates .lerd.yaml entries even if the file
 // doesn't exist yet (database choice is typically part of initial setup).

--- a/internal/mcp/commands_test.go
+++ b/internal/mcp/commands_test.go
@@ -1,0 +1,161 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// registerTestSite gives the MCP exec functions a real site to look up via
+// config.FindSite. Uses XDG_*_HOME tempdirs so we don't touch the user's
+// real registry.
+func registerTestSite(t *testing.T, name string) string {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{Name: name, Path: dir, Domains: []string{name + ".test"}}); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func resultText(t *testing.T, res any) string {
+	t.Helper()
+	m, ok := res.(map[string]any)
+	if !ok {
+		t.Fatalf("result is not a map: %T", res)
+	}
+	content, ok := m["content"].([]map[string]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("result has no content: %+v", m)
+	}
+	text, _ := content[0]["text"].(string)
+	return text
+}
+
+func resultIsError(res any) bool {
+	m, ok := res.(map[string]any)
+	if !ok {
+		return false
+	}
+	return m["isError"] == true
+}
+
+func TestExecCommandAdd_RequiresSiteAndName(t *testing.T) {
+	res, _ := execCommandAdd(map[string]any{})
+	if !resultIsError(res) || !strings.Contains(resultText(t, res), "site is required") {
+		t.Errorf("want site required, got %v", res)
+	}
+	res, _ = execCommandAdd(map[string]any{"site": "x"})
+	if !resultIsError(res) || !strings.Contains(resultText(t, res), "name is required") {
+		t.Errorf("want name required, got %v", res)
+	}
+}
+
+func TestExecCommandAdd_RequiresCommandUnlessDisabled(t *testing.T) {
+	registerTestSite(t, "alpha")
+	res, _ := execCommandAdd(map[string]any{"site": "alpha", "name": "deploy"})
+	if !resultIsError(res) {
+		t.Fatalf("want error when command missing, got %v", res)
+	}
+}
+
+func TestExecCommandAdd_PersistsToYaml(t *testing.T) {
+	dir := registerTestSite(t, "alpha")
+	res, _ := execCommandAdd(map[string]any{
+		"site":        "alpha",
+		"name":        "deploy",
+		"command":     "./bin/deploy",
+		"label":       "Deploy",
+		"description": "Push to staging",
+		"output":      "text",
+		"confirm":     true,
+		"icon":        "arrow-up",
+	})
+	if resultIsError(res) {
+		t.Fatalf("add failed: %s", resultText(t, res))
+	}
+	if !strings.Contains(resultText(t, res), "added") {
+		t.Errorf("response should say added: %s", resultText(t, res))
+	}
+	cfg, _ := config.LoadProjectConfig(dir)
+	if len(cfg.Commands) != 1 || cfg.Commands[0].Name != "deploy" || cfg.Commands[0].Command != "./bin/deploy" {
+		t.Errorf("yaml not updated: %+v", cfg.Commands)
+	}
+	if !cfg.Commands[0].Confirm || cfg.Commands[0].Icon != "arrow-up" {
+		t.Errorf("optional fields lost: %+v", cfg.Commands[0])
+	}
+}
+
+func TestExecCommandAdd_UpdatesExistingByName(t *testing.T) {
+	dir := registerTestSite(t, "alpha")
+	_, _ = execCommandAdd(map[string]any{"site": "alpha", "name": "deploy", "command": "v1"})
+	res, _ := execCommandAdd(map[string]any{"site": "alpha", "name": "deploy", "command": "v2", "label": "v2"})
+	if resultIsError(res) {
+		t.Fatalf("update failed: %s", resultText(t, res))
+	}
+	if !strings.Contains(resultText(t, res), "updated") {
+		t.Errorf("response should say updated: %s", resultText(t, res))
+	}
+	cfg, _ := config.LoadProjectConfig(dir)
+	if len(cfg.Commands) != 1 || cfg.Commands[0].Command != "v2" {
+		t.Errorf("update did not replace: %+v", cfg.Commands)
+	}
+}
+
+func TestExecCommandAdd_DisabledDoesNotRequireCommand(t *testing.T) {
+	dir := registerTestSite(t, "alpha")
+	res, _ := execCommandAdd(map[string]any{"site": "alpha", "name": "migrate:fresh", "disabled": true})
+	if resultIsError(res) {
+		t.Fatalf("disabled add failed: %s", resultText(t, res))
+	}
+	if !strings.Contains(resultText(t, res), "suppresses") {
+		t.Errorf("response should mention suppress: %s", resultText(t, res))
+	}
+	cfg, _ := config.LoadProjectConfig(dir)
+	if len(cfg.Commands) != 1 || !cfg.Commands[0].Disabled {
+		t.Errorf("disabled flag not persisted: %+v", cfg.Commands)
+	}
+}
+
+func TestExecCommandRemove_RemovesEntry(t *testing.T) {
+	dir := registerTestSite(t, "alpha")
+	_, _ = execCommandAdd(map[string]any{"site": "alpha", "name": "deploy", "command": "x"})
+	res, _ := execCommandRemove(map[string]any{"site": "alpha", "name": "deploy"})
+	if resultIsError(res) {
+		t.Fatalf("remove failed: %s", resultText(t, res))
+	}
+	cfg, _ := config.LoadProjectConfig(dir)
+	if len(cfg.Commands) != 0 {
+		t.Errorf("entry not removed: %+v", cfg.Commands)
+	}
+}
+
+func TestExecCommandRemove_ReportsMissing(t *testing.T) {
+	registerTestSite(t, "alpha")
+	res, _ := execCommandRemove(map[string]any{"site": "alpha", "name": "ghost"})
+	if !resultIsError(res) || !strings.Contains(resultText(t, res), "not found") {
+		t.Errorf("want not-found error, got %v", res)
+	}
+}
+
+func TestExecCommandAdd_HonoursCheckRule(t *testing.T) {
+	dir := registerTestSite(t, "alpha")
+	_, _ = execCommandAdd(map[string]any{
+		"site":           "alpha",
+		"name":           "fixtures:load",
+		"command":        "bin/console doctrine:fixtures:load",
+		"check_composer": "doctrine/doctrine-fixtures-bundle",
+	})
+	cfg, _ := config.LoadProjectConfig(dir)
+	if cfg.Commands[0].Check == nil || cfg.Commands[0].Check.Composer != "doctrine/doctrine-fixtures-bundle" {
+		t.Errorf("check rule not set: %+v", cfg.Commands[0])
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -784,6 +784,64 @@ func toolList() []mcpTool {
 			},
 		},
 		mcpTool{
+			Name:        "commands_list",
+			Description: "List on-demand framework commands available for a site (framework defaults merged with the project's .lerd.yaml commands: block).",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"site": {Type: "string", Description: "Site name (from sites)."},
+				},
+				Required: []string{"site"},
+			},
+		},
+		mcpTool{
+			Name:        "commands_run",
+			Description: "Run a framework command on a site by name (same names as commands_list). Returns combined stdout/stderr and exit code. Confirm-gated commands require force: true.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"site":  {Type: "string", Description: "Site name (from sites)."},
+					"name":  {Type: "string", Description: "Command name (e.g. optimize:clear, drush uli)."},
+					"force": {Type: "boolean", Description: "Required for commands with confirm: true. Skips the safety prompt."},
+				},
+				Required: []string{"site", "name"},
+			},
+		},
+		mcpTool{
+			Name:        "command_add",
+			Description: "Add or update a project command in .lerd.yaml's commands: block. Same name as a framework default replaces it.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"site":           {Type: "string", Description: "Site name (from sites)."},
+					"name":           {Type: "string", Description: "Stable identifier (e.g. deploy, optimize:clear). Also the lerd run argument."},
+					"command":        {Type: "string", Description: "Shell command, passed to sh -c. Required unless disabled: true."},
+					"label":          {Type: "string", Description: "Human label shown in the dashboard."},
+					"description":    {Type: "string", Description: "Tooltip / one-line description."},
+					"output":         {Type: "string", Enum: []string{"silent", "text", "url", "terminal"}, Description: "silent | text | url | terminal (default: silent)."},
+					"confirm":        {Type: "boolean", Description: "Gate behind a confirm modal (destructive commands)."},
+					"icon":           {Type: "string", Description: "Icon name (broom, database, refresh, link, check, list, key, edit, arrow-down, arrow-up, play, terminal)."},
+					"cwd":            {Type: "string", Description: "Working dir relative to project root (default: .)."},
+					"check_file":     {Type: "string", Description: "Hide unless this file exists."},
+					"check_composer": {Type: "string", Description: "Hide unless this composer package is installed."},
+					"disabled":       {Type: "boolean", Description: "Suppress a framework default of the same name without replacing it."},
+				},
+				Required: []string{"site", "name"},
+			},
+		},
+		mcpTool{
+			Name:        "command_remove",
+			Description: "Remove a project command from .lerd.yaml by name. Does not affect framework defaults (use command_add with disabled: true to hide a framework command).",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"site": {Type: "string", Description: "Site name (from sites)."},
+					"name": {Type: "string", Description: "Command name to remove."},
+				},
+				Required: []string{"site", "name"},
+			},
+		},
+		mcpTool{
 			Name:        "bug_report",
 			Description: "Generate a plain-text diagnostic report (lerd doctor + config + systemd / podman state + recent logs + env vars) for attaching to a GitHub issue. Site names, domains and parked-directory paths are anonymised by default. Returns the file path.",
 			InputSchema: mcpSchema{
@@ -1075,6 +1133,14 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execWorkersHeal(args)
 	case "workers_mode":
 		return execWorkersMode(args)
+	case "commands_list":
+		return execCommandsList(args)
+	case "commands_run":
+		return execCommandsRun(args)
+	case "command_add":
+		return execCommandAdd(args)
+	case "command_remove":
+		return execCommandRemove(args)
 	case "bug_report":
 		return execBugReport(args)
 
@@ -3815,6 +3881,176 @@ func resolveWorkerCwd(site *config.Site, branch string) (string, map[string]any)
 		return "", toolErr(fmt.Sprintf("worktree branch %q not found on site %q", branch, site.Name))
 	}
 	return wtPath, nil
+}
+
+func execCommandsList(args map[string]any) (any, *rpcError) {
+	siteName := strArg(args, "site")
+	if siteName == "" {
+		return toolErr("site is required"), nil
+	}
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return toolErr("site not found: " + siteName), nil
+	}
+	proj, _ := config.LoadProjectConfig(site.Path)
+	var fw *config.Framework
+	if site.Framework != "" {
+		fw, _ = config.GetFrameworkForDir(site.Framework, site.Path)
+	}
+	cmds := config.ResolveCommands(fw, proj, site.Path)
+	if len(cmds) == 0 {
+		return toolOK("(no commands defined for this site)"), nil
+	}
+	var b strings.Builder
+	for _, c := range cmds {
+		marker := " "
+		if c.Confirm {
+			marker = "*"
+		}
+		desc := c.Description
+		if desc == "" {
+			desc = c.Label
+		}
+		fmt.Fprintf(&b, "  %s %-30s  %s\n", marker, c.Name, desc)
+	}
+	b.WriteString("\n  * = asks for confirmation. Pass force: true to commands_run.\n")
+	return toolOK(b.String()), nil
+}
+
+func execCommandsRun(args map[string]any) (any, *rpcError) {
+	siteName := strArg(args, "site")
+	if siteName == "" {
+		return toolErr("site is required"), nil
+	}
+	name := strArg(args, "name")
+	if name == "" {
+		return toolErr("name is required"), nil
+	}
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return toolErr("site not found: " + siteName), nil
+	}
+	proj, _ := config.LoadProjectConfig(site.Path)
+	var fw *config.Framework
+	if site.Framework != "" {
+		fw, _ = config.GetFrameworkForDir(site.Framework, site.Path)
+	}
+	cmds := config.ResolveCommands(fw, proj, site.Path)
+	var target *config.FrameworkCommand
+	for i := range cmds {
+		if cmds[i].Name == name {
+			target = &cmds[i]
+			break
+		}
+	}
+	if target == nil {
+		return toolErr(fmt.Sprintf("command %q not found. Run commands_list(site: %q) to see available names", name, siteName)), nil
+	}
+	if target.Command == "" {
+		return toolErr(fmt.Sprintf("command %q has no shell invocation", name)), nil
+	}
+	if target.Confirm {
+		force, _ := args["force"].(bool)
+		if !force {
+			return toolErr(fmt.Sprintf("command %q is destructive (confirm: true). Re-run with force: true to confirm. Will execute: %s", name, target.Command)), nil
+		}
+	}
+	if target.Output == config.CommandOutputTerminal {
+		return toolErr(fmt.Sprintf("command %q has output: terminal — only runnable from the dashboard or `lerd run`, not via MCP", name)), nil
+	}
+	cwd := site.Path
+	if target.CWD != "" && target.CWD != "." {
+		cwd = filepath.Join(site.Path, target.CWD)
+	}
+	cmd := exec.Command("sh", "-c", target.Command)
+	cmd.Dir = cwd
+	out, runErr := cmd.CombinedOutput()
+	body := string(out)
+	if runErr != nil {
+		if ee, ok := runErr.(*exec.ExitError); ok {
+			return toolErr(fmt.Sprintf("exit %d:\n%s", ee.ExitCode(), body)), nil
+		}
+		return toolErr(fmt.Sprintf("run failed: %v\n%s", runErr, body)), nil
+	}
+	return toolOK(body), nil
+}
+
+func execCommandAdd(args map[string]any) (any, *rpcError) {
+	siteName := strArg(args, "site")
+	if siteName == "" {
+		return toolErr("site is required"), nil
+	}
+	name := strArg(args, "name")
+	if name == "" {
+		return toolErr("name is required"), nil
+	}
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return toolErr("site not found: " + siteName), nil
+	}
+
+	disabled := boolArg(args, "disabled")
+	command := strArg(args, "command")
+	if !disabled && command == "" {
+		return toolErr("command is required (or set disabled: true to suppress a framework default)"), nil
+	}
+
+	cmd := config.FrameworkCommand{
+		Name:        name,
+		Label:       strArg(args, "label"),
+		Command:     command,
+		Description: strArg(args, "description"),
+		Output:      strArg(args, "output"),
+		Confirm:     boolArg(args, "confirm"),
+		Icon:        strArg(args, "icon"),
+		CWD:         strArg(args, "cwd"),
+		Disabled:    disabled,
+	}
+	if checkFile, checkComposer := strArg(args, "check_file"), strArg(args, "check_composer"); checkFile != "" || checkComposer != "" {
+		cmd.Check = &config.FrameworkRule{File: checkFile, Composer: checkComposer}
+	}
+
+	// Detect whether this name overwrites an existing project entry vs replacing
+	// a framework default vs being net-new, to give the agent a useful response.
+	proj, _ := config.LoadProjectConfig(site.Path)
+	action := "added"
+	for _, c := range proj.Commands {
+		if c.Name == name {
+			action = "updated"
+			break
+		}
+	}
+
+	if err := config.SetProjectCommand(site.Path, cmd); err != nil {
+		return toolErr("saving .lerd.yaml: " + err.Error()), nil
+	}
+	hint := ""
+	if disabled {
+		hint = " (suppresses framework default)"
+	}
+	return toolOK(fmt.Sprintf("Command %q %s in .lerd.yaml%s. Run it via commands_run(site: %q, name: %q) or `lerd run %s`.", name, action, hint, siteName, name, name)), nil
+}
+
+func execCommandRemove(args map[string]any) (any, *rpcError) {
+	siteName := strArg(args, "site")
+	if siteName == "" {
+		return toolErr("site is required"), nil
+	}
+	name := strArg(args, "name")
+	if name == "" {
+		return toolErr("name is required"), nil
+	}
+	site, err := config.FindSite(siteName)
+	if err != nil {
+		return toolErr("site not found: " + siteName), nil
+	}
+	if err := config.RemoveProjectCommand(site.Path, name); err != nil {
+		if _, ok := err.(*config.CommandNotFoundError); ok {
+			return toolErr(fmt.Sprintf("command %q not found in .lerd.yaml for site %q", name, siteName)), nil
+		}
+		return toolErr("saving .lerd.yaml: " + err.Error()), nil
+	}
+	return toolOK(fmt.Sprintf("Command %q removed from .lerd.yaml.", name)), nil
 }
 
 func execWorkerStart(args map[string]any) (any, *rpcError) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -173,7 +173,10 @@ func TestToolList_underSizeCeiling(t *testing.T) {
 	// Bumped to 23000 for the four new dumps_* tools (recent/status/clear/toggle).
 	// Descriptions trimmed in dumpToolDefs to keep the delta as small as possible.
 	// Bumped to 23200 for the php_ext `apk_deps` parameter (new content, not verbosity).
-	const ceiling = 23200
+	// Bumped to 24200 for commands_list / commands_run tools.
+	// Bumped to 26000 for command_add / command_remove tools (let agents
+	// author .lerd.yaml commands blocks alongside the read/run path).
+	const ceiling = 26000
 	got, err := json.Marshal(toolList())
 	if err != nil {
 		t.Fatalf("marshal tool list: %v", err)

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -1,0 +1,277 @@
+package ui
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// runLocks holds a per-site mutex so two browser tabs (or the palette + the
+// dropdown) can't fire the same destructive command concurrently. Keyed by
+// site domain; the value is the locked flag plus a name for debugging.
+var (
+	runLocksMu sync.Mutex
+	runLocks   = map[string]string{} // domain → currently-running command name
+)
+
+func tryAcquireRun(domain, name string) (release func(), busyWith string, ok bool) {
+	runLocksMu.Lock()
+	defer runLocksMu.Unlock()
+	if cur, busy := runLocks[domain]; busy {
+		return nil, cur, false
+	}
+	runLocks[domain] = name
+	return func() {
+		runLocksMu.Lock()
+		delete(runLocks, domain)
+		runLocksMu.Unlock()
+	}, "", true
+}
+
+// commandRoute dispatches the two commands subroutes:
+//
+//	GET  /api/sites/{domain}/commands              → list
+//	POST /api/sites/{domain}/commands/{name}/run   → execute + stream
+//
+// Returns true if the request was a commands subroute (handled here), false
+// otherwise so the caller can fall through to the generic site action handler.
+func commandRoute(w http.ResponseWriter, r *http.Request, domain string, rest []string) bool {
+	if len(rest) == 0 || rest[0] != "commands" {
+		return false
+	}
+	site, err := config.FindSiteByDomain(domain)
+	if err != nil {
+		writeJSON(w, map[string]any{"error": "site not found: " + domain})
+		return true
+	}
+	switch {
+	case len(rest) == 1 && r.Method == http.MethodGet:
+		// List is read-only and safe to expose to LAN viewers.
+		handleCommandsList(w, r, site)
+	case len(rest) == 3 && rest[2] == "run" && r.Method == http.MethodPost:
+		// Run executes arbitrary shell as the lerd-ui user. Loopback-only
+		// so a LAN client can't trigger commands on the host.
+		if !isLoopbackRequest(r) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return true
+		}
+		handleCommandRun(w, r, site, rest[1])
+	default:
+		http.NotFound(w, r)
+	}
+	return true
+}
+
+func handleCommandsList(w http.ResponseWriter, r *http.Request, site *config.Site) {
+	branch := r.URL.Query().Get("branch")
+	cmds := resolveSiteCommands(site, branch)
+	writeJSON(w, map[string]any{"commands": cmds})
+}
+
+// resolveSiteCommands merges the framework's command set with the project's
+// .lerd.yaml entries. When `branch` is non-empty, resolves from the
+// worktree's path so the worktree's .lerd.yaml overrides (or extras)
+// take precedence over the main checkout's.
+func resolveSiteCommands(site *config.Site, branch string) []config.FrameworkCommand {
+	if site == nil {
+		return nil
+	}
+	path := site.Path
+	if branch != "" {
+		if wt := resolveSitePath(site, branch); wt != "" {
+			path = wt
+		}
+	}
+	fw, _ := config.GetFrameworkForDir(site.Framework, path)
+	proj, _ := config.LoadProjectConfig(path)
+	return config.ResolveCommands(fw, proj, path)
+}
+
+// urlRegex matches the first http/https URL in stdout, used when the command
+// declares output: url (e.g. drush uli, wp user create-session-token).
+var urlRegex = regexp.MustCompile(`https?://[^\s'"]+`)
+
+// handleCommandRun executes the named command in the site's project directory
+// and streams stdout+stderr to the client as Server-Sent Events. Frames:
+//
+//	event: stdout    data: <single line of output>
+//	event: stderr    data: <single line of output>
+//	event: done      data: {"exit": 0, "durationMs": 1234, "url": "..."}
+//	event: error     data: <message>     (when setup fails before exec)
+//
+// stderr is interleaved into the same stream so the UI can render a unified
+// terminal view, with a separate event type if we later want to colour it.
+func handleCommandRun(w http.ResponseWriter, r *http.Request, site *config.Site, name string) {
+	branch := r.URL.Query().Get("branch")
+	cmds := resolveSiteCommands(site, branch)
+	var target *config.FrameworkCommand
+	for i := range cmds {
+		if cmds[i].Name == name {
+			target = &cmds[i]
+			break
+		}
+	}
+	if target == nil {
+		writeJSON(w, map[string]any{"error": "command not found: " + name})
+		return
+	}
+	if target.Command == "" {
+		writeJSON(w, map[string]any{"error": "command has no shell invocation"})
+		return
+	}
+
+	// Per-site mutex: refuse if another command is already running on this
+	// site. Prevents two tabs (or palette + dropdown) from concurrently
+	// hammering migrate:fresh, etc. Prefer site.Name, fall back to the
+	// first domain, then the project path so we always have a unique key.
+	lockKey := site.Name
+	if lockKey == "" && len(site.Domains) > 0 {
+		lockKey = site.Domains[0]
+	}
+	if lockKey == "" {
+		lockKey = site.Path
+	}
+	release, busyWith, ok := tryAcquireRun(lockKey, target.Name)
+	if !ok {
+		w.WriteHeader(http.StatusConflict)
+		writeJSON(w, map[string]any{"error": "another command is already running on this site: " + busyWith})
+		return
+	}
+	defer release()
+
+	// When a worktree branch is in play, run the command from the
+	// worktree's checkout — that way `php artisan migrate` etc hits the
+	// worktree's database (when DB isolation is on) and reads worktree
+	// env vars rather than the main checkout's.
+	basePath := site.Path
+	if branch != "" {
+		if wt := resolveSitePath(site, branch); wt != "" {
+			basePath = wt
+		}
+	}
+	cwd := basePath
+	if target.CWD != "" && target.CWD != "." {
+		cwd = filepath.Join(basePath, target.CWD)
+	}
+
+	// Terminal mode: spawn the user's terminal emulator with the command
+	// running inside, then return immediately. The UI handles this by
+	// skipping the modal and showing a toast.
+	if target.Output == config.CommandOutputTerminal {
+		script := "cd " + shQuote(cwd) + " && " + target.Command + "\nprintf '\\n[press any key to close]'\nread -n 1 -s -r 2>/dev/null || read"
+		if err := openTerminalCommand(script); err != nil {
+			writeJSON(w, map[string]any{"error": err.Error()})
+			return
+		}
+		writeJSON(w, map[string]any{"terminal": true})
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeJSON(w, map[string]any{"error": "streaming not supported"})
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no") // disable nginx proxy buffering
+	w.WriteHeader(http.StatusOK)
+
+	// writeMu serializes SSE frame writes and `captured` appends across the
+	// two pipe-reader goroutines. http.ResponseWriter and strings.Builder
+	// are not safe for concurrent use; without this lock the bytes from
+	// stdout and stderr can interleave inside a frame and corrupt the
+	// stream (caught by `go test -race`).
+	var writeMu sync.Mutex
+
+	send := func(event, data string) {
+		// Each non-empty data line must be prefixed; multi-line bodies use
+		// multiple `data:` lines per the SSE spec.
+		var b strings.Builder
+		b.WriteString("event: ")
+		b.WriteString(event)
+		b.WriteByte('\n')
+		for _, line := range strings.Split(data, "\n") {
+			b.WriteString("data: ")
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+		b.WriteByte('\n')
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		_, _ = io.WriteString(w, b.String())
+		flusher.Flush()
+	}
+
+	ctx := r.Context()
+	cmd := exec.CommandContext(ctx, "sh", "-c", target.Command)
+	cmd.Dir = cwd
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		send("error", "stdout pipe: "+err.Error())
+		return
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		send("error", "stderr pipe: "+err.Error())
+		return
+	}
+
+	start := time.Now()
+	if err := cmd.Start(); err != nil {
+		send("error", "start: "+err.Error())
+		return
+	}
+
+	var captured strings.Builder
+	streamPipe := func(pipe io.Reader, event string) {
+		s := bufio.NewScanner(pipe)
+		s.Buffer(make([]byte, 64*1024), 1024*1024)
+		for s.Scan() {
+			line := s.Text()
+			writeMu.Lock()
+			captured.WriteString(line)
+			captured.WriteByte('\n')
+			writeMu.Unlock()
+			send(event, line)
+		}
+	}
+
+	done := make(chan struct{}, 2)
+	go func() { streamPipe(stdout, "stdout"); done <- struct{}{} }()
+	go func() { streamPipe(stderr, "stderr"); done <- struct{}{} }()
+	<-done
+	<-done
+
+	exitCode := 0
+	if err := cmd.Wait(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			exitCode = ee.ExitCode()
+		} else {
+			send("error", "wait: "+err.Error())
+			return
+		}
+	}
+
+	payload := map[string]any{
+		"exit":       exitCode,
+		"durationMs": time.Since(start).Milliseconds(),
+	}
+	if target.Output == config.CommandOutputURL {
+		if u := urlRegex.FindString(captured.String()); u != "" {
+			payload["url"] = u
+		}
+	}
+	body, _ := json.Marshal(payload)
+	send("done", string(body))
+}

--- a/internal/ui/commands_test.go
+++ b/internal/ui/commands_test.go
@@ -1,0 +1,322 @@
+package ui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// writeProjectYAML writes a .lerd.yaml containing a commands: block so tests
+// can exercise the merge + run paths without depending on the built-in
+// laravel framework def.
+func writeProjectYAML(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func registerSite(t *testing.T, name, domain string) string {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	sitePath := t.TempDir()
+	if err := config.AddSite(config.Site{Name: name, Path: sitePath, Domains: []string{domain}}); err != nil {
+		t.Fatal(err)
+	}
+	return sitePath
+}
+
+func TestCommandsList_ReturnsProjectCommands(t *testing.T) {
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: hello
+    label: Say hello
+    command: echo hi
+    output: text
+  - name: deploy
+    label: Deploy
+    command: ./bin/deploy
+    confirm: true
+    output: silent
+`)
+	req := httptest.NewRequest(http.MethodGet, "/api/sites/acme.test/commands", nil)
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d body %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Commands []config.FrameworkCommand `json:"commands"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Commands) != 2 {
+		t.Fatalf("want 2 commands, got %d: %+v", len(resp.Commands), resp.Commands)
+	}
+	if resp.Commands[0].Name != "hello" || resp.Commands[1].Name != "deploy" {
+		t.Errorf("order: %+v", resp.Commands)
+	}
+	if !resp.Commands[1].Confirm {
+		t.Errorf("deploy.Confirm should be true: %+v", resp.Commands[1])
+	}
+}
+
+func TestCommandsRun_StreamsStdoutThenDone(t *testing.T) {
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: echo
+    label: Echo
+    command: printf 'first\nsecond\n'
+    output: text
+`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/echo/run", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: stdout\ndata: first\n") {
+		t.Errorf("expected stdout event for 'first': %q", body)
+	}
+	if !strings.Contains(body, "event: stdout\ndata: second\n") {
+		t.Errorf("expected stdout event for 'second': %q", body)
+	}
+	if !strings.Contains(body, "event: done") {
+		t.Errorf("expected done event: %q", body)
+	}
+	// Parse the done event payload.
+	idx := strings.Index(body, "event: done\ndata: ")
+	if idx < 0 {
+		t.Fatalf("done event not found")
+	}
+	rest := body[idx+len("event: done\ndata: "):]
+	end := strings.IndexByte(rest, '\n')
+	if end < 0 {
+		t.Fatalf("done payload not terminated: %q", rest)
+	}
+	var done struct {
+		Exit       int    `json:"exit"`
+		DurationMs int64  `json:"durationMs"`
+		URL        string `json:"url"`
+	}
+	if err := json.Unmarshal([]byte(rest[:end]), &done); err != nil {
+		t.Fatalf("decode done: %v (%q)", err, rest[:end])
+	}
+	if done.Exit != 0 {
+		t.Errorf("exit code: got %d want 0", done.Exit)
+	}
+}
+
+func TestCommandsRun_NonZeroExit(t *testing.T) {
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: fail
+    label: Fail
+    command: sh -c 'echo boom; exit 7'
+    output: text
+`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/fail/run", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	body := rec.Body.String()
+	if !strings.Contains(body, `"exit":7`) {
+		t.Errorf("expected exit 7 in done payload: %q", body)
+	}
+}
+
+func TestCommandsRun_URLExtraction(t *testing.T) {
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: uli
+    label: Login link
+    command: echo 'https://acme.test/login/one-time/abc123'
+    output: url
+`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/uli/run", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	body := rec.Body.String()
+	if !strings.Contains(body, `"url":"https://acme.test/login/one-time/abc123"`) {
+		t.Errorf("expected url in done payload: %q", body)
+	}
+}
+
+func TestCommandsRun_NotFound(t *testing.T) {
+	registerSite(t, "acme", "acme.test")
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/missing/run", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if !strings.Contains(rec.Body.String(), "command not found") {
+		t.Errorf("expected not-found error: %q", rec.Body.String())
+	}
+}
+
+func TestCommandsRun_TerminalModeReturnsImmediately(t *testing.T) {
+	// Force openTerminalCommand to fail by clearing PATH so no terminal
+	// emulator binary can be looked up. The handler must enter the
+	// terminal branch (JSON response with "error", not SSE).
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: shell
+    label: Open shell
+    command: bash
+    output: terminal
+`)
+	t.Setenv("PATH", "")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/shell/run", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	body := rec.Body.String()
+	if strings.Contains(body, "event: stdout") || strings.Contains(body, "event: done") {
+		t.Errorf("terminal mode should not produce SSE events: %q", body)
+	}
+	// PATH is empty so no terminal emulator can be spawned; the handler
+	// returns the "no terminal emulator found" error. This proves the
+	// terminal branch was taken without actually opening a window.
+	if !strings.Contains(body, `"error"`) {
+		t.Errorf("expected error JSON (no terminal in empty PATH): %q", body)
+	}
+}
+
+func TestCommandsRun_RejectsNonLoopback(t *testing.T) {
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: hello
+    label: Hi
+    command: echo hi
+    output: text
+`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/hello/run", nil)
+	req.RemoteAddr = "192.168.1.50:42000"
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("non-loopback should get 403, got %d body %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCommandsList_AllowsNonLoopback(t *testing.T) {
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: hello
+    label: Hi
+    command: echo hi
+`)
+	req := httptest.NewRequest(http.MethodGet, "/api/sites/acme.test/commands", nil)
+	req.RemoteAddr = "192.168.1.50:42000"
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("list endpoint must allow LAN viewers (read-only): %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCommandsRun_RejectsConcurrent(t *testing.T) {
+	// Pre-acquire the lock to simulate an in-flight run, then assert the
+	// second request gets a 409 Conflict.
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: hello
+    label: Hi
+    command: sleep 5
+`)
+	release, _, ok := tryAcquireRun("acme", "first")
+	if !ok {
+		t.Fatal("could not acquire lock for setup")
+	}
+	defer release()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/hello/run", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("concurrent run should get 409, got %d body %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "already running") {
+		t.Errorf("expected 'already running' in body: %q", rec.Body.String())
+	}
+}
+
+func TestCommandsRun_ConcurrentStdoutStderrNoRace(t *testing.T) {
+	// Race-detector smoke test. The handler spawns two goroutines that both
+	// write to the same strings.Builder and the same http.ResponseWriter
+	// (one for stdout, one for stderr). Without serialization that's a
+	// data race; run this test with -race to catch it.
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: noisy
+    label: Noisy
+    command: "for i in $(seq 1 50); do echo out-$i; echo err-$i >&2; done"
+    output: text
+`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/noisy/run", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if !strings.Contains(rec.Body.String(), "event: done") {
+		t.Errorf("expected done event: %q", rec.Body.String()[:200])
+	}
+}
+
+func TestCommandsList_UnknownBranchFallsBackToParent(t *testing.T) {
+	// Branch lookup uses gitpkg.DetectWorktrees, which requires a real git
+	// checkout that's expensive to set up. Test the soft-fall-back path:
+	// an unknown ?branch=<x> on a non-git site should return the parent's
+	// commands rather than empty.
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: hello
+    label: Hi
+    command: echo hi
+`)
+	req := httptest.NewRequest(http.MethodGet, "/api/sites/acme.test/commands?branch=does-not-exist", nil)
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if !strings.Contains(rec.Body.String(), "hello") {
+		t.Errorf("unknown branch should soft-fall-back to parent commands: %s", rec.Body.String())
+	}
+}
+
+func TestCommandsRun_DisabledOverride(t *testing.T) {
+	// A project entry with Disabled: true on a framework-provided name
+	// must suppress the framework default, even when the framework is the
+	// real laravel one. We do that here by giving the site no framework
+	// (so resolveSiteCommands sees only the project entries) and asking
+	// for a disabled name, which should 404.
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: cache-clear
+    disabled: true
+`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/cache-clear/run", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if !strings.Contains(rec.Body.String(), "command not found") {
+		t.Errorf("disabled command should be missing from list: %q", rec.Body.String())
+	}
+}

--- a/internal/ui/dumps_test.go
+++ b/internal/ui/dumps_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -155,14 +156,51 @@ func TestHandleDumpsStatus_NoServerStillReturnsConfig(t *testing.T) {
 }
 
 // flusherRecorder wraps httptest.ResponseRecorder so handleDumpsStream sees
-// http.Flusher. The recorder's body grows synchronously, which is exactly
-// what we want so the test can assert on emitted SSE bytes deterministically.
+// http.Flusher. The handler runs on its own goroutine while the test polls
+// the body for SSE bytes, so writes and reads must be serialized — without
+// the mutex, go test -race trips on every poll loop iteration.
 type flusherRecorder struct {
 	*httptest.ResponseRecorder
+	mu      sync.Mutex
 	flushes int
 }
 
-func (f *flusherRecorder) Flush() { f.flushes++ }
+func (f *flusherRecorder) Write(p []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ResponseRecorder.Write(p)
+}
+
+// WriteString shadows ResponseRecorder.WriteString so io.WriteString takes
+// the same mutex as Write. Without this, callers using io.WriteString
+// bypass the lock and race against bodyBytes / bodyString.
+func (f *flusherRecorder) WriteString(s string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ResponseRecorder.WriteString(s)
+}
+
+func (f *flusherRecorder) bodyString() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.ResponseRecorder.Body.String()
+}
+
+func (f *flusherRecorder) bodyBytes() []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// Return a copy so the caller can read it without holding the lock.
+	b := f.ResponseRecorder.Body.Bytes()
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out
+}
+
+func (f *flusherRecorder) Flush() {
+	f.mu.Lock()
+	f.flushes++
+	f.mu.Unlock()
+}
 
 func TestHandleDumpsStream_ReplaysSnapshotThenExitsOnContextCancel(t *testing.T) {
 	srv := withDumpsServer(t)
@@ -179,10 +217,11 @@ func TestHandleDumpsStream_ReplaysSnapshotThenExitsOnContextCancel(t *testing.T)
 		handleDumpsStream(rec, req)
 	}()
 
-	// Wait until the replay events are in the body, then cancel.
+	// Wait until the replay events are in the body, then cancel. Use the
+	// mutex-protected accessors since the handler goroutine is still writing.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if bytes.Count(rec.Body.Bytes(), []byte("data:")) >= 2 {
+		if bytes.Count(rec.bodyBytes(), []byte("data:")) >= 2 {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
@@ -194,7 +233,7 @@ func TestHandleDumpsStream_ReplaysSnapshotThenExitsOnContextCancel(t *testing.T)
 		t.Fatal("handler did not return after context cancel")
 	}
 
-	body := rec.Body.String()
+	body := rec.bodyString()
 	for _, id := range []string{"old1", "old2"} {
 		if !strings.Contains(body, id) {
 			t.Errorf("SSE body missing %q\n--- body ---\n%s", id, body)
@@ -224,7 +263,7 @@ func TestHandleDumpsStream_DeliversLiveEvent(t *testing.T) {
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if strings.Contains(rec.Body.String(), "live1") {
+		if strings.Contains(rec.bodyString(), "live1") {
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
@@ -232,7 +271,8 @@ func TestHandleDumpsStream_DeliversLiveEvent(t *testing.T) {
 	cancel()
 	<-done
 
-	if !strings.Contains(rec.Body.String(), "live1") {
-		t.Errorf("live event missing\n--- body ---\n%s", rec.Body.String())
+	body := rec.bodyString()
+	if !strings.Contains(body, "live1") {
+		t.Errorf("live event missing\n--- body ---\n%s", body)
 	}
 }

--- a/internal/ui/mailpit_webhook_test.go
+++ b/internal/ui/mailpit_webhook_test.go
@@ -5,37 +5,67 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
 
+// broadcastCapture buffers wsMessages broadcast during a test. Reads and
+// writes happen on different goroutines (the broker drains on its own),
+// so all access is serialized via mu, without which go test -race trips
+// on every assertion.
+type broadcastCapture struct {
+	mu   sync.Mutex
+	msgs []wsMessage
+}
+
+func (b *broadcastCapture) append(m wsMessage) {
+	b.mu.Lock()
+	b.msgs = append(b.msgs, m)
+	b.mu.Unlock()
+}
+
+func (b *broadcastCapture) len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.msgs)
+}
+
+func (b *broadcastCapture) snapshot() []wsMessage {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]wsMessage, len(b.msgs))
+	copy(out, b.msgs)
+	return out
+}
+
 // captureBroadcast swaps the package-level broker for one whose peers we
-// can drain. Returns a slice that accumulates every wsMessage broadcast
+// can drain. Returns a buffer that accumulates every wsMessage broadcast
 // during the test and a cleanup func to restore the original broker.
-func captureBroadcast(t *testing.T) (*[]wsMessage, func()) {
+func captureBroadcast(t *testing.T) (*broadcastCapture, func()) {
 	t.Helper()
 	prev := broker
 	repl := &wsBroker{peers: make(map[chan wsMessage]struct{})}
 	ch := repl.add()
-	var got []wsMessage
+	cap := &broadcastCapture{}
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		for msg := range ch {
-			got = append(got, msg)
+			cap.append(msg)
 		}
 	}()
 	broker = repl
-	return &got, func() {
+	return cap, func() {
 		repl.remove(ch)
 		<-done
 		broker = prev
 	}
 }
 
-func waitForBroadcast(got *[]wsMessage) {
+func waitForBroadcast(cap *broadcastCapture) {
 	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) && len(*got) == 0 {
+	for time.Now().Before(deadline) && cap.len() == 0 {
 		time.Sleep(5 * time.Millisecond)
 	}
 }
@@ -82,10 +112,10 @@ func TestMailpitWebhook_BroadcastsAsGenericNotification(t *testing.T) {
 	}
 
 	waitForBroadcast(got)
-	if len(*got) != 1 {
-		t.Fatalf("broadcasts = %d, want 1", len(*got))
+	if got.len() != 1 {
+		t.Fatalf("broadcasts = %d, want 1", got.len())
 	}
-	msg := (*got)[0]
+	msg := got.snapshot()[0]
 	if len(msg.Kinds) != 1 || msg.Kinds[0] != "notification" {
 		t.Errorf("Kinds = %v, want [notification]", msg.Kinds)
 	}
@@ -132,10 +162,10 @@ func TestMailpitWebhook_AddressOnlySender(t *testing.T) {
 		t.Fatalf("status = %d", rec.Code)
 	}
 	waitForBroadcast(got)
-	if len(*got) != 1 {
-		t.Fatalf("broadcasts = %d, want 1", len(*got))
+	if got.len() != 1 {
+		t.Fatalf("broadcasts = %d, want 1", got.len())
 	}
-	_, _, _, _, _, params, _ := decodeMailNotification(t, (*got)[0].Notification)
+	_, _, _, _, _, params, _ := decodeMailNotification(t, got.snapshot()[0].Notification)
 	if params["from"] != "bob@example.com" {
 		t.Errorf("from = %q, want bob@example.com", params["from"])
 	}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1915,11 +1915,21 @@ type SiteActionResponse struct {
 func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 	// path: /api/sites/{domain}/secure or /api/sites/{domain}/unsecure
 	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/sites/"), "/")
+	if len(parts) < 2 {
+		http.NotFound(w, r)
+		return
+	}
+	domain := parts[0]
+	// Commands subroutes have more than two segments
+	// (/api/sites/{d}/commands and /api/sites/{d}/commands/{name}/run).
+	if commandRoute(w, r, domain, parts[1:]) {
+		return
+	}
 	if len(parts) != 2 {
 		http.NotFound(w, r)
 		return
 	}
-	domain, action := parts[0], parts[1]
+	action := parts[1]
 
 	// Favicon is a GET endpoint served separately.
 	if action == "favicon" {

--- a/internal/ui/web/src/App.svelte
+++ b/internal/ui/web/src/App.svelte
@@ -24,6 +24,7 @@
   import WorkerHealthBanner from '$components/WorkerHealthBanner.svelte';
   import NotifyBanner from '$components/NotifyBanner.svelte';
   import CommandPalette from '$components/CommandPalette.svelte';
+  import CommandRunModal from '$components/CommandRunModal.svelte';
   import { initNotify } from '$lib/notify';
 
   import SitesTab from '$tabs/SitesTab.svelte';
@@ -138,4 +139,5 @@
   <WorkerHealthBanner />
   <NotifyBanner />
   <CommandPalette />
+  <CommandRunModal />
 </div>

--- a/internal/ui/web/src/app.css
+++ b/internal/ui/web/src/app.css
@@ -59,3 +59,11 @@
 button {
   cursor: pointer;
 }
+
+@utility no-scrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/internal/ui/web/src/components/CommandPalette.svelte
+++ b/internal/ui/web/src/components/CommandPalette.svelte
@@ -1,6 +1,18 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import { sites, openSiteInBrowser } from '$stores/sites';
+  import {
+    sites,
+    openSiteInBrowser,
+    toggleTLS,
+    toggleLANShare,
+    toggleQueue,
+    toggleHorizon,
+    toggleSchedule,
+    toggleReverb,
+    toggleStripe,
+    toggleWorker,
+    loadSites
+  } from '$stores/sites';
   import { coreServices, serviceLabel } from '$stores/services';
   import { unhealthyWorkers, healAll, loadWorkerHealth } from '$stores/workerHealth';
   import { openLinkModal, openPresetModal } from '$stores/modals';
@@ -10,9 +22,15 @@
   import { goToTab } from '$stores/route';
   import { accessMode } from '$stores/accessMode';
   import { paletteOpen, openCommandPalette, closeCommandPalette } from '$stores/commandPalette';
+  import {
+    commandsBySiteStore,
+    preloadCommandsFor,
+    launchCommand,
+    type Command
+  } from '$stores/commands';
   import { m } from '../paraglide/messages.js';
 
-  type Group = 'pages' | 'sites' | 'services' | 'actions';
+  type Group = 'pages' | 'sites' | 'services' | 'toggles' | 'commands' | 'actions';
   interface Entry {
     id: string;
     label: string;
@@ -54,6 +72,117 @@
       });
     }
 
+    // Toggles: site-level state toggles (HTTPS, LAN share) and worker
+    // start/stop entries. Labels flip between Enable/Disable or Start/Stop
+    // based on current state, so searches like "stop queue" only surface
+    // running queues and "enable https" only insecure sites.
+    for (const s of $sites) {
+      const d = s.domain;
+      const refresh = async () => { await loadSites(); };
+
+      // HTTPS toggle
+      {
+        const on = Boolean(s.tls);
+        list.push({
+          id: 'tgl:' + d + ':tls',
+          label: (on ? 'Disable' : 'Enable') + ' HTTPS',
+          hint: d,
+          group: 'toggles',
+          action: async () => { await toggleTLS(s); await refresh(); }
+        });
+      }
+
+      // LAN share toggle
+      {
+        const on = Boolean(s.lan_port);
+        list.push({
+          id: 'tgl:' + d + ':lan',
+          label: (on ? 'Stop' : 'Start') + ' LAN share',
+          hint: d,
+          group: 'toggles',
+          action: async () => { await toggleLANShare(s, ''); await refresh(); }
+        });
+      }
+
+      if (s.has_queue_worker) {
+        const on = Boolean(s.queue_running);
+        list.push({
+          id: 'tgl:' + d + ':queue',
+          label: (on ? 'Stop' : 'Start') + ' queue worker',
+          hint: d,
+          group: 'toggles',
+          action: async () => { await toggleQueue(s); await refresh(); }
+        });
+      }
+      if (s.has_horizon) {
+        const on = Boolean(s.horizon_running);
+        list.push({
+          id: 'tgl:' + d + ':horizon',
+          label: (on ? 'Stop' : 'Start') + ' Horizon',
+          hint: d,
+          group: 'toggles',
+          action: async () => { await toggleHorizon(s); await refresh(); }
+        });
+      }
+      if (s.has_schedule_worker) {
+        const on = Boolean(s.schedule_running);
+        list.push({
+          id: 'tgl:' + d + ':schedule',
+          label: (on ? 'Stop' : 'Start') + ' scheduler',
+          hint: d,
+          group: 'toggles',
+          action: async () => { await toggleSchedule(s); await refresh(); }
+        });
+      }
+      if (s.has_reverb) {
+        const on = Boolean(s.reverb_running);
+        list.push({
+          id: 'tgl:' + d + ':reverb',
+          label: (on ? 'Stop' : 'Start') + ' Reverb',
+          hint: d,
+          group: 'toggles',
+          action: async () => { await toggleReverb(s); await refresh(); }
+        });
+      }
+      if (s.stripe_secret_set) {
+        const on = Boolean(s.stripe_running);
+        list.push({
+          id: 'tgl:' + d + ':stripe',
+          label: (on ? 'Stop' : 'Start') + ' Stripe listener',
+          hint: d,
+          group: 'toggles',
+          action: async () => { await toggleStripe(s); await refresh(); }
+        });
+      }
+      for (const w of s.framework_workers || []) {
+        const on = Boolean(w.running);
+        const lbl = w.label || w.name;
+        list.push({
+          id: 'tgl:' + d + ':fw:' + w.name,
+          label: (on ? 'Stop' : 'Start') + ' ' + lbl,
+          hint: d,
+          group: 'toggles',
+          action: async () => { await toggleWorker(s, w); await refresh(); }
+        });
+      }
+    }
+
+    // Commands: per (site, command) entry from the cached lists. Cache
+    // populates on palette open; entries appear once the fetch lands.
+    for (const s of $sites) {
+      const list2 = $commandsBySiteStore[s.domain] as Command[] | undefined;
+      if (!list2) continue;
+      for (const c of list2) {
+        list.push({
+          id: 'cmd:' + s.domain + ':' + c.name,
+          label: 'Run ' + (c.label || c.name),
+          hint: s.domain + ' · ' + c.name,
+          group: 'commands',
+          action: () => launchCommand(s.domain, c)
+        });
+      }
+    }
+
     if ($accessMode.loopback) {
       list.push({ id: 'act:link', label: m.palette_action_link(), group: 'actions', action: openLinkModal });
       list.push({ id: 'act:preset', label: m.palette_action_addService(), group: 'actions', action: openPresetModal });
@@ -92,17 +221,20 @@
   });
 
   const filtered = $derived.by(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return entries;
-    return entries.filter(
-      (e) => e.label.toLowerCase().includes(q) || (e.hint && e.hint.toLowerCase().includes(q))
-    );
+    const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+    if (terms.length === 0) return entries;
+    return entries.filter((e) => {
+      const hay = (e.label + ' ' + (e.hint || '')).toLowerCase();
+      return terms.every((t) => hay.includes(t));
+    });
   });
 
   const groupLabel: Record<Group, () => string> = {
     pages: () => m.palette_group_pages(),
     sites: () => m.palette_group_sites(),
     services: () => m.palette_group_services(),
+    toggles: () => 'Toggles',
+    commands: () => 'Commands',
     actions: () => m.palette_group_actions()
   };
 
@@ -111,6 +243,7 @@
     selected = 0;
     openCommandPalette();
     queueMicrotask(() => inputEl?.focus());
+    void preloadCommandsFor($sites.map((s) => s.domain));
   }
 
   function closePalette() {

--- a/internal/ui/web/src/components/CommandRunModal.svelte
+++ b/internal/ui/web/src/components/CommandRunModal.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+  import { currentRun, closeRun, executeCommand, runToast, lastRunFor, type RunLine } from '$stores/commands';
+  import { ansiToHtml } from '$lib/ansi';
+
+  function relativeTime(ts: number): string {
+    const diffMs = Date.now() - ts;
+    const s = Math.floor(diffMs / 1000);
+    if (s < 60) return s + 's ago';
+    const m = Math.floor(s / 60);
+    if (m < 60) return m + 'm ago';
+    const h = Math.floor(m / 60);
+    if (h < 24) return h + 'h ago';
+    return Math.floor(h / 24) + 'd ago';
+  }
+
+  function viewPrevious() {
+    if ($currentRun.kind !== 'confirm') return;
+    const prev = lastRunFor($currentRun.domain, $currentRun.cmd.name);
+    if (!prev) return;
+    currentRun.set({
+      kind: 'done',
+      domain: prev.domain,
+      cmd: $currentRun.cmd,
+      lines: prev.lines,
+      exit: prev.exit,
+      durationMs: prev.durationMs,
+      url: prev.url
+    });
+  }
+
+  // Render each line with a color hint based on its source stream. stderr
+  // gets a soft red prefix, meta (lerd's own [error] / [aborted] markers)
+  // gets a yellow prefix. The ANSI renderer handles the inline escapes
+  // alongside any colors the command itself emitted.
+  function renderLines(lines: RunLine[]): string {
+    return lines
+      .map((l) => {
+        if (l.stream === 'stderr') return '\x1b[31m' + l.text + '\x1b[0m';
+        if (l.stream === 'meta') return '\x1b[33m' + l.text + '\x1b[0m';
+        return l.text;
+      })
+      .join('\n');
+  }
+
+  let copied = $state(false);
+  let toast: string | null = $state(null);
+
+  $effect(() => {
+    const unsub = runToast.subscribe((v) => (toast = v));
+    return unsub;
+  });
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Escape') return;
+    if ($currentRun.kind === 'idle') return;
+    e.preventDefault();
+    closeRun();
+  }
+
+  $effect(() => {
+    window.addEventListener('keydown', onKeydown);
+    return () => window.removeEventListener('keydown', onKeydown);
+  });
+
+  function copyUrl(url: string) {
+    void navigator.clipboard.writeText(url);
+    copied = true;
+    setTimeout(() => (copied = false), 1400);
+  }
+
+  const cmd = $derived.by(() => {
+    const s = $currentRun;
+    if (s.kind === 'idle') return null;
+    return s.cmd;
+  });
+</script>
+
+{#if $currentRun.kind === 'confirm' && cmd}
+  <div class="fixed inset-0 z-50 flex items-center justify-center">
+    <button class="absolute inset-0 bg-black/50" aria-label="Cancel" onclick={closeRun}></button>
+    <div class="relative bg-white dark:bg-lerd-card border border-gray-200 dark:border-lerd-border rounded-xl shadow-2xl w-full max-w-md mx-4 p-5">
+      <div class="flex items-start gap-3">
+        <span class="shrink-0 w-9 h-9 rounded-full bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 flex items-center justify-center">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M5 19h14a2 2 0 001.74-3l-7-12a2 2 0 00-3.48 0l-7 12A2 2 0 005 19z" />
+          </svg>
+        </span>
+        <div class="flex-1 min-w-0">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-white">Run {cmd.label || cmd.name}?</h3>
+          {#if $currentRun.kind === 'confirm'}
+            <p class="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">on {$currentRun.domain}</p>
+          {/if}
+          {#if cmd.description}
+            <p class="text-xs text-gray-600 dark:text-gray-400 mt-2">{cmd.description}</p>
+          {/if}
+          <pre class="mt-3 px-3 py-2 rounded bg-gray-100 dark:bg-black/40 text-[11px] font-mono text-gray-800 dark:text-gray-200 overflow-x-auto">$ {cmd.command}</pre>
+        </div>
+      </div>
+      {#if $currentRun.kind === 'confirm'}
+        {@const prev = lastRunFor($currentRun.domain, cmd.name)}
+        {#if prev}
+          <div class="mt-3 flex items-center gap-2 text-[11px] text-gray-500 dark:text-gray-400 pl-12">
+            <span>Last run: exit {prev.exit} · {prev.durationMs}ms · {relativeTime(prev.finishedAt)}</span>
+            <button onclick={viewPrevious} class="text-lerd-red hover:underline">view output</button>
+          </div>
+        {/if}
+      {/if}
+      <div class="mt-5 flex items-center justify-end gap-2">
+        <button onclick={closeRun} class="px-3 py-1.5 rounded-md text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5">Cancel</button>
+        <button
+          onclick={() => $currentRun.kind === 'confirm' && executeCommand($currentRun.domain, cmd)}
+          class="px-3 py-1.5 rounded-md text-xs font-medium bg-lerd-red hover:bg-lerd-redhov text-white"
+        >Run anyway</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+{#if ($currentRun.kind === 'running' || $currentRun.kind === 'done') && cmd}
+  <div class="fixed inset-0 z-50 flex items-center justify-center">
+    <button class="absolute inset-0 bg-black/50" aria-label="Close" onclick={closeRun}></button>
+    <div class="relative bg-white dark:bg-lerd-card border border-gray-200 dark:border-lerd-border rounded-xl shadow-2xl w-full max-w-2xl mx-4">
+      <header class="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-lerd-border">
+        <div class="min-w-0">
+          <h3 class="text-sm font-semibold text-gray-900 dark:text-white truncate">{cmd.label || cmd.name}</h3>
+          <p class="text-[11px] font-mono text-gray-500 dark:text-gray-400 truncate mt-0.5">{$currentRun.domain} · $ {cmd.command}</p>
+        </div>
+        <button onclick={closeRun} aria-label="Close" class="shrink-0 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 ml-3">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </header>
+
+      <div class="px-5 py-4">
+        <div class="flex items-center gap-2 mb-3">
+          {#if $currentRun.kind === 'running'}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-semibold bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+              <svg class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24"><circle class="opacity-30" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" /><path class="opacity-90" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" /></svg>
+              running
+            </span>
+          {:else if $currentRun.kind === 'done' && $currentRun.exit === 0}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-semibold bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+              <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+              exit 0
+            </span>
+          {:else if $currentRun.kind === 'done'}
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-semibold bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300">exit {$currentRun.exit}</span>
+          {/if}
+          {#if $currentRun.kind === 'done'}
+            <span class="text-[11px] text-gray-500 dark:text-gray-400">{$currentRun.durationMs}ms</span>
+          {/if}
+        </div>
+
+        {#if $currentRun.kind === 'done' && cmd.output === 'url' && $currentRun.url}
+          <div class="mb-3 rounded-md border border-gray-200 dark:border-lerd-border bg-gray-50 dark:bg-black/30 p-3">
+            <p class="text-[11px] text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">One-time URL</p>
+            <div class="flex items-center gap-2">
+              <code class="flex-1 min-w-0 text-xs font-mono text-gray-800 dark:text-gray-100 truncate">{$currentRun.url}</code>
+              <button onclick={() => $currentRun.kind === 'done' && copyUrl($currentRun.url!)} class="shrink-0 px-2 py-1 rounded text-[11px] font-medium bg-gray-200 hover:bg-gray-300 dark:bg-white/10 dark:hover:bg-white/20 text-gray-800 dark:text-gray-100">
+                {copied ? 'Copied' : 'Copy'}
+              </button>
+              <a href={$currentRun.url} target="_blank" rel="noopener" class="shrink-0 px-2 py-1 rounded text-[11px] font-medium bg-lerd-red hover:bg-lerd-redhov text-white">Open</a>
+            </div>
+          </div>
+        {/if}
+
+        {#if ($currentRun.kind === 'running' || $currentRun.kind === 'done') && $currentRun.lines.length > 0}
+          <pre class="max-h-[50vh] overflow-auto no-scrollbar rounded-md bg-black/90 text-gray-100 text-[11px] font-mono p-3 leading-relaxed whitespace-pre-wrap">{@html ansiToHtml(renderLines($currentRun.lines))}</pre>
+        {:else}
+          <pre class="max-h-[50vh] overflow-auto no-scrollbar rounded-md bg-black/90 text-gray-100 text-[11px] font-mono p-3 leading-relaxed whitespace-pre-wrap">{$currentRun.kind === 'running' ? 'waiting for output...' : '[no output]'}</pre>
+        {/if}
+      </div>
+
+      <footer class="px-5 py-3 border-t border-gray-100 dark:border-lerd-border flex items-center justify-end">
+        <button onclick={closeRun} class="px-3 py-1.5 rounded-md text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5">
+          {$currentRun.kind === 'running' ? 'Cancel' : 'Close'}
+        </button>
+      </footer>
+    </div>
+  </div>
+{/if}
+
+{#if toast}
+  <div class="fixed bottom-4 right-4 z-50 px-3 py-2 rounded-md shadow-lg bg-gray-900 text-white text-xs font-medium">
+    {toast}
+  </div>
+{/if}

--- a/internal/ui/web/src/components/CommandRunModal.test.svelte
+++ b/internal/ui/web/src/components/CommandRunModal.test.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import CommandRunModal from './CommandRunModal.svelte';
+</script>
+
+<CommandRunModal />

--- a/internal/ui/web/src/components/CommandRunModal.test.ts
+++ b/internal/ui/web/src/components/CommandRunModal.test.ts
@@ -1,0 +1,135 @@
+import { render, screen, cleanup } from '@testing-library/svelte';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { currentRun, closeRun } from '$stores/commands';
+import Harness from './CommandRunModal.test.svelte';
+
+beforeEach(() => {
+  closeRun();
+});
+afterEach(() => {
+  closeRun();
+  cleanup();
+});
+
+describe('CommandRunModal', () => {
+  it('renders nothing when state is idle', () => {
+    const { container } = render(Harness);
+    // Modal only renders when currentRun.kind is not idle.
+    expect(container.querySelector('[aria-label="Close"]')).toBeNull();
+    expect(container.querySelector('[aria-label="Cancel"]')).toBeNull();
+  });
+
+  it('renders the confirm view with command label and shell', async () => {
+    render(Harness);
+    currentRun.set({
+      kind: 'confirm',
+      domain: 'acme.test',
+      cmd: { name: 'migrate:fresh', label: 'Fresh migrate', command: 'php artisan migrate:fresh --force', confirm: true }
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByText(/Run Fresh migrate/)).toBeInTheDocument();
+    expect(screen.getByText(/acme\.test/)).toBeInTheDocument();
+    expect(screen.getByText(/php artisan migrate:fresh --force/)).toBeInTheDocument();
+    // Two buttons match Cancel (backdrop aria-label + footer text content).
+    expect(screen.getAllByRole('button', { name: 'Cancel' }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole('button', { name: 'Run anyway' })).toBeInTheDocument();
+  });
+
+  it('renders the running view with running pill and waiting message', async () => {
+    render(Harness);
+    currentRun.set({
+      kind: 'running',
+      domain: 'acme.test',
+      cmd: { name: 'echo', label: 'Echo', command: 'echo hi' },
+      lines: [],
+      started: Date.now()
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByText('running')).toBeInTheDocument();
+    expect(screen.getByText(/waiting for output/)).toBeInTheDocument();
+  });
+
+  it('renders the done view with exit 0 pill and duration', async () => {
+    render(Harness);
+    currentRun.set({
+      kind: 'done',
+      domain: 'acme.test',
+      cmd: { name: 'echo', label: 'Echo', command: 'echo hi' },
+      lines: [{stream: 'stdout', text: 'hello'}],
+      exit: 0,
+      durationMs: 42
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByText(/exit 0/)).toBeInTheDocument();
+    expect(screen.getByText(/42ms/)).toBeInTheDocument();
+    expect(screen.getByText(/hello/)).toBeInTheDocument();
+  });
+
+  it('renders red exit pill for non-zero exit', async () => {
+    const { container } = render(Harness);
+    currentRun.set({
+      kind: 'done',
+      domain: 'acme.test',
+      cmd: { name: 'fail', label: 'Fail', command: 'false-cmd' },
+      lines: [{stream: 'stdout', text: 'boom'}],
+      exit: 7,
+      durationMs: 12
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    // Pick the red exit pill specifically (it has bg-red-100).
+    const pill = container.querySelector('span.bg-red-100, span.bg-red-900\\/40');
+    expect(pill?.textContent?.trim()).toContain('exit 7');
+  });
+
+  it('renders the URL panel for output: url commands', async () => {
+    render(Harness);
+    currentRun.set({
+      kind: 'done',
+      domain: 'acme.test',
+      cmd: { name: 'uli', label: 'Login', command: 'drush uli', output: 'url' },
+      lines: [{stream: 'stdout', text: 'https://acme.test/login/abc'}],
+      exit: 0,
+      durationMs: 100,
+      url: 'https://acme.test/login/abc'
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByText('One-time URL')).toBeInTheDocument();
+    expect(screen.getAllByText(/https:\/\/acme\.test\/login\/abc/).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open' })).toBeInTheDocument();
+  });
+
+  it('closes on Cancel click in confirm view', async () => {
+    const { container } = render(Harness);
+    currentRun.set({
+      kind: 'confirm',
+      domain: 'acme.test',
+      cmd: { name: 'x', label: 'X', command: 'true', confirm: true }
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    // Two buttons match "Cancel" (backdrop has aria-label and the footer Cancel
+    // button has text content). Pick the footer one.
+    const cancels = screen.getAllByRole('button', { name: 'Cancel' });
+    const footer = cancels.find((b) => b.textContent?.includes('Cancel'))!;
+    footer.click();
+    await new Promise((r) => setTimeout(r, 0));
+    // The modal markup should be gone once state is idle.
+    expect(container.querySelector('[aria-label="Cancel"]')).toBeNull();
+  });
+
+  it('closes on Escape keypress when modal is open', async () => {
+    const { container } = render(Harness);
+    currentRun.set({
+      kind: 'done',
+      domain: 'acme.test',
+      cmd: { name: 'x', label: 'X', command: 'true' },
+      lines: [{stream: 'stdout', text: 'ok'}],
+      exit: 0,
+      durationMs: 10
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(container.querySelector('[aria-label="Close"]')).toBeNull();
+  });
+});

--- a/internal/ui/web/src/components/CommandsDropdown.svelte
+++ b/internal/ui/web/src/components/CommandsDropdown.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  import { loadCommands, launchCommand, runningName, type Command } from '$stores/commands';
+
+  interface Props {
+    domain: string;
+    branch?: string;
+  }
+  let { domain, branch = '' }: Props = $props();
+
+  let commands: Command[] = $state([]);
+  let menuOpen = $state(false);
+  let triggerEl: HTMLButtonElement | null = $state(null);
+  let menuPos = $state({ top: 0, left: 0, width: 288 });
+
+  async function refresh() {
+    if (!domain) return;
+    try {
+      commands = await loadCommands(domain, branch);
+    } catch {
+      commands = [];
+    }
+  }
+
+  // Initial load on mount, plus a refresh whenever the domain or branch prop changes.
+  $effect(() => {
+    void domain;
+    void branch;
+    void refresh();
+  });
+
+  function toggleMenu() {
+    if (menuOpen) {
+      menuOpen = false;
+      return;
+    }
+    if (!triggerEl) return;
+    // Refresh in the background so external edits (MCP command_add, manual
+    // .lerd.yaml edits since mount) show up the moment the menu opens.
+    // Fire-and-forget; the menu opens with whatever's cached and updates
+    // when the fetch resolves.
+    void refresh();
+    const r = triggerEl.getBoundingClientRect();
+    const margin = 8;
+    // On narrow viewports the 288px desktop width would overflow; cap to
+    // the viewport minus margins. Otherwise use the preferred width and
+    // right-clamp if anchoring at the trigger would overflow.
+    const desired = 288;
+    const maxWidth = Math.min(desired, window.innerWidth - margin * 2);
+    let left = r.left;
+    if (left + maxWidth + margin > window.innerWidth) {
+      left = Math.max(margin, window.innerWidth - maxWidth - margin);
+    }
+    menuPos = { top: r.bottom + 4, left, width: maxWidth };
+    menuOpen = true;
+  }
+
+  function pick(cmd: Command) {
+    menuOpen = false;
+    launchCommand(domain, cmd, { branch });
+  }
+
+  function iconPath(name?: string): string {
+    switch (name) {
+      case 'broom': return 'M4 20l6-6m4-4l6-6m-2 2l-2-2m-4 14l-2-2m-2-6l8 8';
+      case 'database': return 'M4 7c0-1.66 3.58-3 8-3s8 1.34 8 3-3.58 3-8 3-8-1.34-8-3zm0 0v10c0 1.66 3.58 3 8 3s8-1.34 8-3V7M4 12c0 1.66 3.58 3 8 3s8-1.34 8-3';
+      case 'refresh': return 'M4 4v5h5M20 20v-5h-5M20.49 9A9 9 0 005.64 5.64L4 4m16 16l-1.64-1.64A9 9 0 014.51 15';
+      case 'link': return 'M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71';
+      case 'check': return 'M5 13l4 4L19 7';
+      case 'list': return 'M4 6h16M4 12h16M4 18h16';
+      case 'key': return 'M21 2l-9.5 9.5M15.5 7.5L19 11M9 12a4 4 0 11-4-4 4 4 0 014 4z';
+      case 'edit': return 'M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.41-9.41a2 2 0 112.83 2.83L11.83 15H9v-2.83l8.59-8.58z';
+      case 'arrow-down': return 'M19 14l-7 7-7-7M12 4v17';
+      case 'arrow-up': return 'M5 10l7-7 7 7M12 3v18';
+      case 'play': return 'M5 3l14 9-14 9V3z';
+      case 'terminal': return 'M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z';
+      default: return 'M13 10V3L4 14h7v7l9-11h-7z';
+    }
+  }
+
+  function handleDocClick(e: MouseEvent) {
+    if (!menuOpen) return;
+    const t = e.target as Node;
+    if (triggerEl && (triggerEl === t || triggerEl.contains(t))) return;
+    const menu = document.getElementById('cmds-dropdown-menu');
+    if (menu && menu.contains(t)) return;
+    menuOpen = false;
+  }
+
+  function handleScroll() {
+    if (menuOpen) menuOpen = false;
+  }
+
+  function handleKey(e: KeyboardEvent) {
+    if (e.key === 'Escape' && menuOpen) {
+      e.preventDefault();
+      menuOpen = false;
+    }
+  }
+
+  $effect(() => {
+    document.addEventListener('click', handleDocClick);
+    window.addEventListener('scroll', handleScroll, true);
+    window.addEventListener('resize', handleScroll);
+    window.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('click', handleDocClick);
+      window.removeEventListener('scroll', handleScroll, true);
+      window.removeEventListener('resize', handleScroll);
+      window.removeEventListener('keydown', handleKey);
+    };
+  });
+
+  const hasCommands = $derived(commands.length > 0);
+</script>
+
+{#if hasCommands}
+<div class="relative inline-block">
+  <button
+    bind:this={triggerEl}
+    type="button"
+    onclick={toggleMenu}
+    disabled={$runningName !== null}
+    title=""
+    class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md border border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card hover:border-lerd-red hover:text-lerd-red transition-colors text-xs font-medium text-gray-700 dark:text-gray-200 disabled:opacity-40"
+  >
+    {#if $runningName}
+      <svg class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+      </svg>
+      <span>Running...</span>
+    {:else}
+      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+      </svg>
+      <span>Commands</span>
+      <svg class="w-3 h-3 ml-0.5 transition-transform {menuOpen ? 'rotate-180' : ''}" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+      </svg>
+    {/if}
+  </button>
+
+  {#if menuOpen}
+    <div
+      id="cmds-dropdown-menu"
+      style="position: fixed; top: {menuPos.top}px; left: {menuPos.left}px; width: {menuPos.width}px;"
+      class="z-50 rounded-lg border border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card shadow-xl ring-1 ring-black/5 py-1 max-h-96 overflow-y-auto no-scrollbar"
+    >
+      {#each commands as c (c.name)}
+        <button
+          type="button"
+          onclick={() => pick(c)}
+          title={(c.description ?? '') + (c.description ? '\n\n' : '') + '$ ' + c.command}
+          class="group w-full flex items-start gap-2.5 px-3 py-2 hover:bg-gray-50 dark:hover:bg-white/5 text-left transition-colors"
+        >
+          <span class="shrink-0 mt-0.5 w-5 h-5 rounded bg-gray-100 dark:bg-white/5 flex items-center justify-center text-gray-500 dark:text-gray-400 group-hover:text-lerd-red">
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" d={iconPath(c.icon)} />
+            </svg>
+          </span>
+          <span class="flex-1 min-w-0">
+            <span class="flex items-center gap-1.5">
+              <span class="text-xs font-medium text-gray-900 dark:text-gray-100">{c.label || c.name}</span>
+              {#if c.confirm}
+                <span class="shrink-0 w-1.5 h-1.5 rounded-full bg-amber-500" title="Asks before running"></span>
+              {/if}
+            </span>
+            <span class="block text-[10px] text-gray-500 dark:text-gray-400 font-mono truncate">{c.command}</span>
+          </span>
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>
+{/if}

--- a/internal/ui/web/src/components/Dropdown.svelte
+++ b/internal/ui/web/src/components/Dropdown.svelte
@@ -1,0 +1,276 @@
+<script lang="ts" module>
+  export interface DropdownOption {
+    value: string;
+    label?: string;       // display text; falls back to value
+    description?: string; // dim secondary line under label
+    disabled?: boolean;
+  }
+</script>
+
+<script lang="ts">
+  interface Props {
+    value: string;
+    options: Array<string | DropdownOption>;
+    onchange: (v: string) => void;
+    label?: string;          // optional prefix in trigger ("PHP 8.3" etc); also prefixes menu entries
+    placeholder?: string;    // shown when value is empty
+    disabled?: boolean;
+    title?: string;          // tooltip on trigger
+    inherited?: boolean;     // dashed violet border (used by PHP/Node version pickers)
+    inheritedSuffix?: string;
+    width?: 'auto' | 'full'; // trigger sizing; 'full' fills container (form-style)
+    minMenuWidth?: number;   // px; default 160
+    align?: 'left' | 'right';
+  }
+  let {
+    value,
+    options,
+    onchange,
+    label = '',
+    placeholder = '',
+    disabled = false,
+    title = '',
+    inherited = false,
+    inheritedSuffix = '',
+    width = 'auto',
+    minMenuWidth = 160,
+    align = 'left'
+  }: Props = $props();
+
+  let open = $state(false);
+  let triggerEl: HTMLButtonElement | null = $state(null);
+  let menuEl: HTMLDivElement | null = $state(null);
+  let menuPos = $state({ top: 0, left: 0, width: 160 });
+  let highlighted = $state(-1);
+  let typeahead = $state('');
+  let typeaheadTimer: ReturnType<typeof setTimeout> | null = null;
+  const menuId = `dd-${Math.random().toString(36).slice(2, 9)}`;
+
+  function normalize(opts: typeof options): DropdownOption[] {
+    return opts.map((o) =>
+      typeof o === 'string' ? { value: o, label: o } : { ...o, label: o.label ?? o.value }
+    );
+  }
+  const normalized = $derived(normalize(options));
+
+  function displayFor(opt: DropdownOption): string {
+    return label ? label + ' ' + (opt.label || opt.value) : (opt.label || opt.value);
+  }
+
+  const selectedIdx = $derived(normalized.findIndex((o) => o.value === value));
+  const display = $derived.by(() => {
+    if (!value) return placeholder || label || 'Select…';
+    if (selectedIdx >= 0) return displayFor(normalized[selectedIdx]);
+    return value;
+  });
+
+  function openMenu() {
+    if (!triggerEl) return;
+    const r = triggerEl.getBoundingClientRect();
+    const margin = 8;
+    const desired = Math.max(minMenuWidth, r.width);
+    const max = Math.min(desired, window.innerWidth - margin * 2);
+    let left = align === 'right' ? r.right - max : r.left;
+    if (left + max + margin > window.innerWidth) left = Math.max(margin, window.innerWidth - max - margin);
+    if (left < margin) left = margin;
+    menuPos = { top: r.bottom + 4, left, width: max };
+    highlighted = selectedIdx >= 0 ? selectedIdx : 0;
+    open = true;
+    queueMicrotask(scrollHighlightedIntoView);
+  }
+
+  function closeMenu() {
+    open = false;
+    highlighted = -1;
+    typeahead = '';
+    if (typeaheadTimer) {
+      clearTimeout(typeaheadTimer);
+      typeaheadTimer = null;
+    }
+  }
+
+  function toggle() {
+    if (open) closeMenu();
+    else openMenu();
+  }
+
+  function pick(opt: DropdownOption) {
+    closeMenu();
+    if (opt.disabled) return;
+    if (opt.value !== value) onchange(opt.value);
+  }
+
+  function scrollHighlightedIntoView() {
+    if (!menuEl) return;
+    const node = menuEl.querySelector<HTMLElement>('[data-highlighted="true"]');
+    // JSDOM doesn't implement scrollIntoView; guard so tests don't blow up.
+    if (node && typeof node.scrollIntoView === 'function') node.scrollIntoView({ block: 'nearest' });
+  }
+
+  function moveHighlight(delta: number) {
+    if (!normalized.length) return;
+    let next = highlighted < 0 ? 0 : highlighted + delta;
+    const n = normalized.length;
+    next = ((next % n) + n) % n;
+    // Skip disabled entries.
+    let safety = n;
+    while (normalized[next].disabled && safety-- > 0) {
+      next = ((next + delta) % n + n) % n;
+    }
+    highlighted = next;
+    scrollHighlightedIntoView();
+  }
+
+  function applyTypeahead(ch: string) {
+    if (typeaheadTimer) clearTimeout(typeaheadTimer);
+    typeahead = (typeahead + ch).toLowerCase();
+    typeaheadTimer = setTimeout(() => (typeahead = ''), 600);
+    const match = normalized.findIndex(
+      (o) => !o.disabled && (o.label || o.value).toLowerCase().startsWith(typeahead)
+    );
+    if (match >= 0) {
+      highlighted = match;
+      scrollHighlightedIntoView();
+    }
+  }
+
+  function onTriggerKey(e: KeyboardEvent) {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      // Stop the event from bubbling to the document-level menu handler,
+      // which would double-handle and advance the highlight again.
+      e.stopPropagation();
+      if (!open) openMenu();
+      if (e.key === 'ArrowDown') moveHighlight(1);
+      else if (e.key === 'ArrowUp') moveHighlight(-1);
+    } else if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      e.stopPropagation();
+      if (!open) openMenu();
+      applyTypeahead(e.key);
+    }
+  }
+
+  function onMenuKey(e: KeyboardEvent) {
+    if (!open) return;
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        closeMenu();
+        triggerEl?.focus();
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        moveHighlight(1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        moveHighlight(-1);
+        break;
+      case 'Home':
+        e.preventDefault();
+        highlighted = 0;
+        scrollHighlightedIntoView();
+        break;
+      case 'End':
+        e.preventDefault();
+        highlighted = normalized.length - 1;
+        scrollHighlightedIntoView();
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        if (highlighted >= 0 && highlighted < normalized.length) pick(normalized[highlighted]);
+        break;
+      case 'Tab':
+        closeMenu();
+        break;
+      default:
+        if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+          applyTypeahead(e.key);
+        }
+    }
+  }
+
+  function handleDocClick(e: MouseEvent) {
+    if (!open) return;
+    const t = e.target as Node;
+    if (triggerEl && (triggerEl === t || triggerEl.contains(t))) return;
+    if (menuEl && menuEl.contains(t)) return;
+    closeMenu();
+  }
+
+  function handleScroll() {
+    if (open) closeMenu();
+  }
+
+  $effect(() => {
+    document.addEventListener('click', handleDocClick);
+    document.addEventListener('keydown', onMenuKey);
+    window.addEventListener('scroll', handleScroll, true);
+    window.addEventListener('resize', handleScroll);
+    return () => {
+      document.removeEventListener('click', handleDocClick);
+      document.removeEventListener('keydown', onMenuKey);
+      window.removeEventListener('scroll', handleScroll, true);
+      window.removeEventListener('resize', handleScroll);
+      if (typeaheadTimer) clearTimeout(typeaheadTimer);
+    };
+  });
+</script>
+
+<div class="relative inline-block {width === 'full' ? 'w-full' : ''}">
+  <button
+    bind:this={triggerEl}
+    type="button"
+    onclick={toggle}
+    onkeydown={onTriggerKey}
+    {disabled}
+    {title}
+    aria-haspopup="listbox"
+    aria-expanded={open}
+    aria-controls={menuId}
+    class="{width === 'full' ? 'w-full' : ''} inline-flex items-center justify-between gap-1.5 h-7 px-2.5 rounded-md border bg-white dark:bg-lerd-card hover:border-lerd-red hover:text-lerd-red transition-colors text-xs font-medium text-gray-700 dark:text-gray-200 disabled:opacity-50 disabled:cursor-not-allowed {inherited ? 'border-dashed border-violet-300 dark:border-violet-700' : 'border-gray-200 dark:border-lerd-border'}"
+  >
+    <span class="truncate text-left">{display}</span>
+    <svg class="w-3 h-3 ml-0.5 shrink-0 transition-transform {open ? 'rotate-180' : ''}" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+    </svg>
+  </button>
+
+  {#if open}
+    <div
+      bind:this={menuEl}
+      id={menuId}
+      role="listbox"
+      style="position: fixed; top: {menuPos.top}px; left: {menuPos.left}px; width: {menuPos.width}px;"
+      class="z-50 rounded-lg border border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card shadow-xl ring-1 ring-black/5 py-1 max-h-72 overflow-y-auto no-scrollbar"
+    >
+      {#each normalized as opt, i (opt.value + ':' + i)}
+        {@const selected = opt.value === value}
+        {@const isHighlighted = i === highlighted}
+        <button
+          type="button"
+          role="option"
+          aria-selected={selected}
+          data-highlighted={isHighlighted}
+          disabled={opt.disabled}
+          onclick={() => pick(opt)}
+          onmouseenter={() => (highlighted = i)}
+          class="w-full flex items-start gap-2 px-3 py-1.5 text-left text-xs transition-colors disabled:opacity-40 disabled:cursor-not-allowed {isHighlighted ? 'bg-gray-100 dark:bg-white/10' : 'hover:bg-gray-50 dark:hover:bg-white/5'} {selected ? 'text-lerd-red font-semibold' : 'text-gray-700 dark:text-gray-200'}"
+        >
+          <span class="shrink-0 w-3 h-3 mt-0.5">
+            {#if selected}
+              <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+            {/if}
+          </span>
+          <span class="flex-1 min-w-0">
+            <span class="block truncate">{displayFor(opt)}{inherited && selected && inheritedSuffix ? ' ' + inheritedSuffix : ''}</span>
+            {#if opt.description}
+              <span class="block text-[10px] text-gray-500 dark:text-gray-400 truncate font-normal">{opt.description}</span>
+            {/if}
+          </span>
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/internal/ui/web/src/components/Dropdown.test.svelte
+++ b/internal/ui/web/src/components/Dropdown.test.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import Dropdown, { type DropdownOption } from './Dropdown.svelte';
+
+  interface Props {
+    label?: string;
+    value?: string;
+    options?: Array<string | DropdownOption>;
+    disabled?: boolean;
+    inherited?: boolean;
+    inheritedSuffix?: string;
+    title?: string;
+    placeholder?: string;
+    width?: 'auto' | 'full';
+    align?: 'left' | 'right';
+    onchange: (v: string) => void;
+  }
+  let {
+    label = '',
+    value = '',
+    options = [],
+    disabled = false,
+    inherited = false,
+    inheritedSuffix = '',
+    title = '',
+    placeholder = '',
+    width = 'auto',
+    align = 'left',
+    onchange
+  }: Props = $props();
+</script>
+
+<Dropdown
+  {label}
+  {value}
+  {options}
+  {disabled}
+  {inherited}
+  {inheritedSuffix}
+  {title}
+  {placeholder}
+  {width}
+  {align}
+  {onchange}
+/>

--- a/internal/ui/web/src/components/Dropdown.test.ts
+++ b/internal/ui/web/src/components/Dropdown.test.ts
@@ -1,0 +1,159 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect, vi } from 'vitest';
+import Harness from './Dropdown.test.svelte';
+
+async function tick() {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+function openMenu(): HTMLElement {
+  const menu = document.querySelector('[role="listbox"]') as HTMLElement | null;
+  if (!menu) throw new Error('menu did not open');
+  return menu;
+}
+
+describe('Dropdown', () => {
+  it('renders trigger with label + value', () => {
+    render(Harness, { props: { label: 'PHP', value: '8.3', options: ['8.2', '8.3'], onchange: () => {} } });
+    expect(screen.getByRole('button', { name: /PHP 8\.3/ })).toBeInTheDocument();
+  });
+
+  it('falls back to placeholder when value is empty', () => {
+    render(Harness, { props: { value: '', options: ['a'], placeholder: 'Choose…', onchange: () => {} } });
+    expect(screen.getByRole('button', { name: /Choose…/ })).toBeInTheDocument();
+  });
+
+  it('opens menu on click and lists options', async () => {
+    render(Harness, { props: { value: '8.3', options: ['8.2', '8.3', '8.4'], label: 'PHP', onchange: () => {} } });
+    screen.getByRole('button', { name: /PHP 8\.3/ }).click();
+    await tick();
+    const items = Array.from(openMenu().querySelectorAll('[role="option"]')).map((b) => b.textContent?.trim());
+    expect(items).toEqual(['PHP 8.2', 'PHP 8.3', 'PHP 8.4']);
+  });
+
+  it('supports object options with description', async () => {
+    render(Harness, {
+      props: {
+        value: 'mysql',
+        options: [
+          { value: 'mysql', label: 'MySQL', description: 'Most popular' },
+          { value: 'pgsql', label: 'PostgreSQL', description: 'Postgres 18' }
+        ],
+        onchange: () => {}
+      }
+    });
+    screen.getByRole('button').click();
+    await tick();
+    const menu = openMenu();
+    expect(menu.textContent).toContain('Most popular');
+    expect(menu.textContent).toContain('Postgres 18');
+  });
+
+  it('fires onchange when an option is picked', async () => {
+    const onchange = vi.fn();
+    render(Harness, { props: { value: '8.3', options: ['8.2', '8.3', '8.4'], label: 'PHP', onchange } });
+    screen.getByRole('button').click();
+    await tick();
+    const buttons = Array.from(openMenu().querySelectorAll('button')) as HTMLButtonElement[];
+    buttons.find((b) => b.textContent?.trim() === 'PHP 8.4')!.click();
+    expect(onchange).toHaveBeenCalledWith('8.4');
+  });
+
+  it('does not fire onchange when picking current value', async () => {
+    const onchange = vi.fn();
+    render(Harness, { props: { value: '8.3', options: ['8.2', '8.3'], label: 'PHP', onchange } });
+    screen.getByRole('button').click();
+    await tick();
+    const buttons = Array.from(openMenu().querySelectorAll('button')) as HTMLButtonElement[];
+    buttons.find((b) => b.textContent?.trim() === 'PHP 8.3')!.click();
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it('opens via ArrowDown keydown on trigger', async () => {
+    render(Harness, { props: { value: '', options: ['a', 'b', 'c'], onchange: () => {} } });
+    const trigger = screen.getByRole('button');
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await tick();
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('Enter selects the highlighted option', async () => {
+    const onchange = vi.fn();
+    render(Harness, { props: { value: 'a', options: ['a', 'b', 'c'], onchange } });
+    const trigger = screen.getByRole('button');
+    // ArrowDown on closed menu opens + advances past the selected item ('a')
+    // to the next ('b'), mirroring native <select> behaviour.
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await tick();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(onchange).toHaveBeenCalledWith('b');
+  });
+
+  it('type-ahead jumps highlight to matching prefix', async () => {
+    render(Harness, { props: { value: '', options: ['alpha', 'beta', 'beta-2', 'gamma'], onchange: () => {} } });
+    const trigger = screen.getByRole('button');
+    trigger.click();
+    await tick();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'b', bubbles: true }));
+    await tick();
+    const highlighted = document.querySelector('[data-highlighted="true"]');
+    expect(highlighted?.textContent?.trim()).toBe('beta');
+  });
+
+  it('Escape closes the menu', async () => {
+    render(Harness, { props: { value: '', options: ['a', 'b'], onchange: () => {} } });
+    const trigger = screen.getByRole('button');
+    trigger.click();
+    await tick();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await tick();
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('disabled options are skipped by keyboard nav', async () => {
+    const onchange = vi.fn();
+    render(Harness, {
+      props: {
+        value: 'a',
+        options: [
+          { value: 'a', label: 'A' },
+          { value: 'b', label: 'B', disabled: true },
+          { value: 'c', label: 'C' }
+        ],
+        onchange
+      }
+    });
+    const trigger = screen.getByRole('button');
+    // From 'a', ArrowDown should land on 'C' (skipping disabled 'B').
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await tick();
+    const highlighted = document.querySelector('[data-highlighted="true"]');
+    expect(highlighted?.textContent?.trim()).toBe('C');
+  });
+
+  it('exposes correct ARIA roles', () => {
+    render(Harness, { props: { value: 'a', options: ['a', 'b'], onchange: () => {} } });
+    const trigger = screen.getByRole('button');
+    expect(trigger.getAttribute('aria-haspopup')).toBe('listbox');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('marks the current value with aria-selected and red text class', async () => {
+    render(Harness, { props: { value: 'b', options: ['a', 'b', 'c'], onchange: () => {} } });
+    screen.getByRole('button').click();
+    await tick();
+    const selected = document.querySelector('[role="option"][aria-selected="true"]');
+    expect(selected?.textContent?.trim()).toBe('b');
+    expect(selected?.className).toMatch(/text-lerd-red/);
+  });
+
+  it('renders inherited dashed-violet border when inherited prop set', () => {
+    render(Harness, { props: { value: '8.3', options: ['8.3'], inherited: true, onchange: () => {} } });
+    expect(screen.getByRole('button').className).toMatch(/border-dashed/);
+  });
+
+  it('full width fills container when width="full"', () => {
+    render(Harness, { props: { value: 'a', options: ['a'], width: 'full', onchange: () => {} } });
+    expect(screen.getByRole('button').className).toMatch(/w-full/);
+  });
+});

--- a/internal/ui/web/src/components/LanguageSwitcher.svelte
+++ b/internal/ui/web/src/components/LanguageSwitcher.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
   import { locale, changeLocale, LOCALES, LOCALE_LABELS, LOCALE_CODES, type Locale } from '$stores/locale';
+  import Dropdown from './Dropdown.svelte';
 
   interface Props {
     variant?: 'compact' | 'select';
   }
   let { variant = 'select' }: Props = $props();
 
-  function onChange(e: Event) {
-    const v = (e.target as HTMLSelectElement).value as Locale;
-    if (v !== $locale) changeLocale(v);
-  }
+  const options = LOCALES.map((l) => ({ value: l, label: LOCALE_LABELS[l] }));
 </script>
 
 {#if variant === 'compact'}
@@ -25,13 +23,5 @@
     {/each}
   </div>
 {:else}
-  <select
-    value={$locale}
-    onchange={onChange}
-    class="text-xs bg-white dark:bg-lerd-muted border border-gray-200 dark:border-lerd-border rounded-sm px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-hidden focus:border-lerd-red/50 cursor-pointer transition-colors"
-  >
-    {#each LOCALES as l (l)}
-      <option value={l}>{LOCALE_LABELS[l]}</option>
-    {/each}
-  </select>
+  <Dropdown value={$locale} {options} onchange={(v) => changeLocale(v as Locale)} />
 {/if}

--- a/internal/ui/web/src/components/ToggleButton.svelte
+++ b/internal/ui/web/src/components/ToggleButton.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    label: string;
+    on: boolean;
+    failing?: boolean;
+    loading?: boolean;
+    disabled?: boolean;
+    title?: string;
+    onclick?: (e: MouseEvent) => void;
+    trailing?: Snippet;
+  }
+  let {
+    label,
+    on,
+    failing = false,
+    loading = false,
+    disabled = false,
+    title = '',
+    onclick,
+    trailing
+  }: Props = $props();
+
+  const state = $derived(
+    loading ? 'loading' : failing ? 'failing' : on ? 'on' : 'off'
+  );
+
+  const dotClass = $derived(
+    state === 'on'
+      ? 'bg-emerald-500'
+      : state === 'failing'
+        ? 'bg-red-500'
+        : state === 'loading'
+          ? 'bg-amber-400'
+          : 'border border-gray-300 dark:border-gray-600 bg-transparent'
+  );
+
+  const tintClass = $derived(
+    state === 'on'
+      ? 'bg-emerald-50/60 dark:bg-emerald-900/15 hover:bg-emerald-50 dark:hover:bg-emerald-900/25'
+      : state === 'failing'
+        ? 'bg-red-50/60 dark:bg-red-900/15 hover:bg-red-50 dark:hover:bg-red-900/25'
+        : 'bg-white dark:bg-lerd-card hover:bg-gray-50 dark:hover:bg-white/5'
+  );
+</script>
+
+<button
+  type="button"
+  {disabled}
+  {title}
+  {onclick}
+  class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md border border-gray-200 dark:border-lerd-border transition-colors text-xs font-medium text-gray-700 dark:text-gray-200 disabled:opacity-50 disabled:cursor-not-allowed {tintClass}"
+>
+  {#if state === 'loading'}
+    <svg class="w-2.5 h-2.5 animate-spin text-amber-500" fill="none" viewBox="0 0 24 24">
+      <circle class="opacity-30" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+      <path class="opacity-90" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+    </svg>
+  {:else}
+    <span class="shrink-0 w-2 h-2 rounded-full {dotClass}"></span>
+  {/if}
+  <span>{label}</span>
+  {#if trailing}{@render trailing()}{/if}
+</button>

--- a/internal/ui/web/src/components/ToggleButton.test.svelte
+++ b/internal/ui/web/src/components/ToggleButton.test.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import ToggleButton from './ToggleButton.svelte';
+
+  interface Props {
+    label?: string;
+    on?: boolean;
+    failing?: boolean;
+    loading?: boolean;
+    disabled?: boolean;
+    title?: string;
+    onclick?: (e: MouseEvent) => void;
+  }
+  let { label = 'HTTPS', on = false, failing = false, loading = false, disabled = false, title = '', onclick }: Props = $props();
+</script>
+
+<ToggleButton {label} {on} {failing} {loading} {disabled} {title} {onclick} />

--- a/internal/ui/web/src/components/ToggleButton.test.ts
+++ b/internal/ui/web/src/components/ToggleButton.test.ts
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect, vi } from 'vitest';
+import Harness from './ToggleButton.test.svelte';
+
+describe('ToggleButton', () => {
+  it('renders the label', () => {
+    render(Harness, { props: { label: 'HTTPS' } });
+    expect(screen.getByRole('button', { name: 'HTTPS' })).toBeInTheDocument();
+  });
+
+  it('shows a green dot when on', () => {
+    const { container } = render(Harness, { props: { label: 'queue', on: true } });
+    const dot = container.querySelector('span.rounded-full');
+    expect(dot?.className).toMatch(/bg-emerald-500/);
+  });
+
+  it('shows a red dot when failing (overrides on)', () => {
+    const { container } = render(Harness, { props: { label: 'queue', on: true, failing: true } });
+    const dot = container.querySelector('span.rounded-full');
+    expect(dot?.className).toMatch(/bg-red-500/);
+  });
+
+  it('shows an outlined gray dot when off', () => {
+    const { container } = render(Harness, { props: { label: 'LAN', on: false } });
+    const dot = container.querySelector('span.rounded-full');
+    expect(dot?.className).toMatch(/border-gray-300|border-gray-600/);
+  });
+
+  it('shows an amber spinner when loading', () => {
+    const { container } = render(Harness, { props: { label: 'queue', loading: true } });
+    expect(container.querySelector('svg.animate-spin')).toBeInTheDocument();
+    expect(container.querySelector('span.rounded-full')).not.toBeInTheDocument();
+  });
+
+  it('tints background emerald when on', () => {
+    render(Harness, { props: { label: 'queue', on: true } });
+    const btn = screen.getByRole('button', { name: 'queue' });
+    expect(btn.className).toMatch(/emerald/);
+  });
+
+  it('tints background red when failing', () => {
+    render(Harness, { props: { label: 'queue', on: true, failing: true } });
+    const btn = screen.getByRole('button', { name: 'queue' });
+    expect(btn.className).toMatch(/red/);
+  });
+
+  it('forwards click', () => {
+    const onclick = vi.fn();
+    render(Harness, { props: { label: 'queue', onclick } });
+    screen.getByRole('button', { name: 'queue' }).click();
+    expect(onclick).toHaveBeenCalledOnce();
+  });
+
+  it('disables button when disabled is true', () => {
+    render(Harness, { props: { label: 'queue', disabled: true } });
+    const btn = screen.getByRole('button', { name: 'queue' }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+});

--- a/internal/ui/web/src/lib/ansi.test.ts
+++ b/internal/ui/web/src/lib/ansi.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { ansiToHtml } from './ansi';
+
+describe('ansiToHtml', () => {
+  it('passes plain text through with HTML escaping', () => {
+    expect(ansiToHtml('hello world')).toBe('hello world');
+    expect(ansiToHtml('<script>')).toBe('&lt;script&gt;');
+    expect(ansiToHtml('a & b > c')).toBe('a &amp; b &gt; c');
+  });
+
+  it('strips reset and renders nothing for default colors', () => {
+    expect(ansiToHtml('\x1b[0mtext')).toBe('text');
+  });
+
+  it('wraps red foreground in a span', () => {
+    const html = ansiToHtml('\x1b[31mboom\x1b[0m');
+    expect(html).toContain('color:');
+    expect(html).toContain('boom');
+    expect(html).toContain('</span>');
+  });
+
+  it('closes the open span at end of input even without explicit reset', () => {
+    const html = ansiToHtml('\x1b[32mgreen-no-reset');
+    expect(html).toContain('green-no-reset');
+    expect(html.match(/<\/span>/g)).toHaveLength(1);
+  });
+
+  it('handles bold + color together', () => {
+    const html = ansiToHtml('\x1b[1;31mERROR\x1b[0m: details');
+    expect(html).toContain('font-weight:600');
+    expect(html).toContain('color:');
+    expect(html).toContain('ERROR');
+    expect(html).toContain('details');
+  });
+
+  it('strips cursor-positioning escapes without rendering them', () => {
+    // \x1b[2K clears the line, \x1b[1A moves cursor up — both should vanish.
+    const html = ansiToHtml('\x1b[2K\x1b[1Akept');
+    expect(html).toBe('kept');
+  });
+
+  it('handles 256-color foreground by mapping to nearest 8-color', () => {
+    const html = ansiToHtml('\x1b[38;5;9mbright-red\x1b[0m');
+    expect(html).toContain('bright-red');
+    expect(html).toContain('color:');
+  });
+
+  it('preserves newlines', () => {
+    expect(ansiToHtml('one\ntwo')).toBe('one\ntwo');
+  });
+
+  it('handles back-to-back color changes without nesting spans', () => {
+    const html = ansiToHtml('\x1b[31mred\x1b[32mgreen\x1b[0m');
+    // We should never have a <span> inside a <span> — closing the previous
+    // span happens before opening the next.
+    const opens = html.match(/<span/g)?.length ?? 0;
+    const closes = html.match(/<\/span>/g)?.length ?? 0;
+    expect(opens).toBe(closes);
+  });
+});

--- a/internal/ui/web/src/lib/ansi.ts
+++ b/internal/ui/web/src/lib/ansi.ts
@@ -1,0 +1,131 @@
+// Minimal SGR (Select Graphic Rendition) parser. Converts ANSI escape
+// sequences from CLI tools into safe HTML span tags. Handles:
+//   - foreground 30-37 / bright 90-97 / default 39
+//   - background 40-47 / bright 100-107 / default 49
+//   - bold (1) and reset (0 / 22)
+//   - 256-color foreground (38;5;N) — falls back to closest 8-color
+//
+// Skips cursor positioning, line clear, and other non-SGR sequences (they're
+// noise in a non-interactive replay). Strips them rather than letting them
+// reach the DOM.
+
+const FG: Record<number, string> = {
+  30: 'var(--ansi-black, #555)',
+  31: 'var(--ansi-red, #ff5555)',
+  32: 'var(--ansi-green, #50fa7b)',
+  33: 'var(--ansi-yellow, #f1fa8c)',
+  34: 'var(--ansi-blue, #6272ff)',
+  35: 'var(--ansi-magenta, #ff79c6)',
+  36: 'var(--ansi-cyan, #8be9fd)',
+  37: 'var(--ansi-white, #f8f8f2)',
+  90: 'var(--ansi-bright-black, #6272a4)',
+  91: 'var(--ansi-bright-red, #ff6e6e)',
+  92: 'var(--ansi-bright-green, #69ff94)',
+  93: 'var(--ansi-bright-yellow, #ffffa5)',
+  94: 'var(--ansi-bright-blue, #d6acff)',
+  95: 'var(--ansi-bright-magenta, #ff92df)',
+  96: 'var(--ansi-bright-cyan, #a4ffff)',
+  97: 'var(--ansi-bright-white, #ffffff)'
+};
+
+function htmlEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+interface SpanState {
+  fg?: string;
+  bold?: boolean;
+}
+
+function spanStyle(s: SpanState): string {
+  const parts: string[] = [];
+  if (s.fg) parts.push('color:' + s.fg);
+  if (s.bold) parts.push('font-weight:600');
+  return parts.join(';');
+}
+
+export function ansiToHtml(text: string): string {
+  // ESC[...m for SGR. We ignore non-m escapes (cursor moves, etc.) by
+  // matching ESC[ followed by any param chars then a terminator letter.
+  const sgrRe = /\x1b\[([\d;]*)m/g;
+  const otherEscRe = /\x1b\[[\d;]*[A-Za-z]/g;
+  // First scrub non-SGR escapes by replacing them with empty string.
+  // Then walk SGR matches.
+  let cleaned = text.replace(otherEscRe, (m) => (m.endsWith('m') ? m : ''));
+  // Also drop other common ESC sequences we don't model: ESC] OSC, ESC( charset.
+  cleaned = cleaned.replace(/\x1b\][^\x07\x1b]*(\x07|\x1b\\)/g, '').replace(/\x1b[()][\dA-Za-z]/g, '');
+
+  let out = '';
+  let last = 0;
+  const state: SpanState = {};
+  let openSpan = false;
+
+  const writeChunk = (chunk: string) => {
+    if (!chunk) return;
+    const escaped = htmlEscape(chunk);
+    if (openSpan) {
+      out += escaped;
+    } else {
+      const style = spanStyle(state);
+      if (style) {
+        out += '<span style="' + style + '">' + escaped;
+        openSpan = true;
+      } else {
+        out += escaped;
+      }
+    }
+  };
+
+  const closeSpan = () => {
+    if (openSpan) {
+      out += '</span>';
+      openSpan = false;
+    }
+  };
+
+  let m: RegExpExecArray | null;
+  while ((m = sgrRe.exec(cleaned)) !== null) {
+    writeChunk(cleaned.slice(last, m.index));
+    last = m.index + m[0].length;
+
+    const params = m[1].split(';').filter(Boolean).map(Number);
+    if (params.length === 0) params.push(0);
+
+    for (let i = 0; i < params.length; i++) {
+      const p = params[i];
+      if (p === 0) {
+        closeSpan();
+        state.fg = undefined;
+        state.bold = false;
+      } else if (p === 1) {
+        closeSpan();
+        state.bold = true;
+      } else if (p === 22) {
+        closeSpan();
+        state.bold = false;
+      } else if (p === 39) {
+        closeSpan();
+        state.fg = undefined;
+      } else if (FG[p]) {
+        closeSpan();
+        state.fg = FG[p];
+      } else if (p === 38 && params[i + 1] === 5) {
+        // 256-color: round to nearest 8-color base; good enough for readability.
+        const idx = params[i + 2] ?? 0;
+        const base = idx >= 8 && idx <= 15 ? 90 + (idx - 8) : 30 + (idx % 8);
+        closeSpan();
+        state.fg = FG[base];
+        i += 2;
+      }
+      // Ignore unrecognized codes (background, underline, italic, etc.) silently.
+    }
+  }
+  writeChunk(cleaned.slice(last));
+  closeSpan();
+  return out;
+}

--- a/internal/ui/web/src/modals/PresetModal.svelte
+++ b/internal/ui/web/src/modals/PresetModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import Modal from '$components/Modal.svelte';
+  import Dropdown from '$components/Dropdown.svelte';
   import DetailButton from '$components/DetailButton.svelte';
   import { closeModal } from '$stores/modals';
   import {
@@ -94,15 +95,13 @@
               {/if}
             </div>
             {#if (p.versions || []).length > 0}
-              <select
-                value={p.selected_version ?? ''}
-                onchange={(e) => setSelectedVersion(p.name, (e.target as HTMLSelectElement).value)}
-                class="shrink-0 text-xs bg-gray-50 dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border rounded-sm px-2 py-1.5 text-gray-700 dark:text-gray-300 focus:outline-hidden focus:border-lerd-red/50"
-              >
-                {#each availableVersions(p) as v (v.tag)}
-                  <option value={v.tag}>{v.label || v.tag}</option>
-                {/each}
-              </select>
+              <div class="shrink-0">
+                <Dropdown
+                  value={p.selected_version ?? ''}
+                  options={availableVersions(p).map((v) => ({ value: v.tag, label: v.label || v.tag }))}
+                  onchange={(v) => setSelectedVersion(p.name, v)}
+                />
+              </div>
             {/if}
             <DetailButton
               tone="primary"

--- a/internal/ui/web/src/modals/WorktreeModal.svelte
+++ b/internal/ui/web/src/modals/WorktreeModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Modal from '$components/Modal.svelte';
+  import Dropdown from '$components/Dropdown.svelte';
   import DetailButton from '$components/DetailButton.svelte';
   import { closeModal } from '$stores/modals';
   import { sites, loadSites, type Site } from '$stores/sites';
@@ -295,48 +296,39 @@
           />
           {#if hasAnyBranch}
             <div class="text-xs text-gray-400 pt-1">{m.worktreeMgr_basedOn()}</div>
-            <select bind:value={baseRef} class="w-full text-sm bg-white dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border rounded-sm px-2 py-1.5 text-gray-700 dark:text-gray-300">
-              <option value="">{currentBranchLabel(opts?.default_branch_label || 'HEAD')}</option>
-              {#each localBranches as b (b)}
-                <option value={b}>{b}</option>
-              {/each}
-              {#if remoteBranches.length}
-                <optgroup label="remote">
-                  {#each remoteBranches as b (b)}
-                    <option value={b}>{b}</option>
-                  {/each}
-                </optgroup>
-              {/if}
-            </select>
+            <Dropdown
+              value={baseRef}
+              width="full"
+              options={[
+                { value: '', label: currentBranchLabel(opts?.default_branch_label || 'HEAD') },
+                ...localBranches.map((b) => ({ value: b, label: b })),
+                ...remoteBranches.map((b) => ({ value: b, label: b, description: 'remote' }))
+              ]}
+              onchange={(v) => (baseRef = v)}
+            />
           {/if}
         {:else}
-          <select bind:value={existingBranch} class="w-full text-sm bg-white dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border rounded-sm px-2 py-1.5 text-gray-700 dark:text-gray-300">
-            {#each localBranches as b (b)}
-              <option value={b}>{b}</option>
-            {/each}
-            {#if remoteBranches.length}
-              <optgroup label="remote">
-                {#each remoteBranches as b (b)}
-                  <option value={b}>{b}</option>
-                {/each}
-              </optgroup>
-            {/if}
-          </select>
+          <Dropdown
+            value={existingBranch}
+            width="full"
+            options={[
+              ...localBranches.map((b) => ({ value: b, label: b })),
+              ...remoteBranches.map((b) => ({ value: b, label: b, description: 'remote' }))
+            ]}
+            onchange={(v) => (existingBranch = v)}
+          />
         {/if}
       </div>
 
       <!-- database -->
       <div class="space-y-1.5">
         <div class="text-xs font-medium text-gray-500 dark:text-gray-400">{m.worktreeMgr_databaseHeading()}</div>
-        <select bind:value={db} class="w-full text-sm bg-white dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border rounded-sm px-2 py-1.5 text-gray-700 dark:text-gray-300">
-          {#if dbOptions.length}
-            {#each dbOptions as o (o.value)}
-              <option value={o.value}>{o.label}</option>
-            {/each}
-          {:else}
-            <option value="share">…</option>
-          {/if}
-        </select>
+        <Dropdown
+          value={db}
+          width="full"
+          options={dbOptions.length ? dbOptions : [{ value: 'share', label: '…' }]}
+          onchange={(v) => (db = v)}
+        />
         {#if showMigrate}
           <label class="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400 pt-0.5">
             <input type="checkbox" bind:checked={migrate} class="rounded-sm border-gray-300 dark:border-lerd-border" />
@@ -348,15 +340,12 @@
       <!-- assets -->
       <div class="space-y-1.5">
         <div class="text-xs font-medium text-gray-500 dark:text-gray-400">{m.worktreeMgr_assetsHeading()}</div>
-        <select bind:value={build} class="w-full text-sm bg-white dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border rounded-sm px-2 py-1.5 text-gray-700 dark:text-gray-300">
-          {#if buildOptions.length}
-            {#each buildOptions as o (o.value)}
-              <option value={o.value}>{o.label}</option>
-            {/each}
-          {:else}
-            <option value="auto">…</option>
-          {/if}
-        </select>
+        <Dropdown
+          value={build}
+          width="full"
+          options={buildOptions.length ? buildOptions : [{ value: 'auto', label: '…' }]}
+          onchange={(v) => (build = v)}
+        />
       </div>
     </div>
   {:else}

--- a/internal/ui/web/src/stores/commands.test.ts
+++ b/internal/ui/web/src/stores/commands.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  runCommand,
+  launchCommand,
+  closeRun,
+  currentRun,
+  runningName,
+  type Command
+} from './commands';
+
+// Build a ReadableStream that emits a sequence of UTF-8 chunks. Used to
+// simulate the SSE response body for runCommand without hitting the network.
+function makeStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(encoder.encode(chunks[i++]));
+      } else {
+        controller.close();
+      }
+    }
+  });
+}
+
+function mockSSE(chunks: string[]) {
+  globalThis.fetch = vi.fn().mockResolvedValue(
+    new Response(makeStream(chunks), {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' }
+    })
+  ) as unknown as typeof fetch;
+}
+
+function mockJSON(body: unknown) {
+  globalThis.fetch = vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  ) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  closeRun();
+  vi.restoreAllMocks();
+});
+
+describe('runCommand (SSE parser)', () => {
+  it('dispatches stdout lines as they arrive', async () => {
+    mockSSE(['event: stdout\ndata: first\n\n', 'event: stdout\ndata: second\n\n', 'event: done\ndata: {"exit":0,"durationMs":42}\n\n']);
+    const stdout: string[] = [];
+    let exit: number | null = null;
+    await runCommand('acme.test', 'echo', {
+      onStdout: (l) => stdout.push(l),
+      onDone: ({ exit: e }) => (exit = e)
+    });
+    expect(stdout).toEqual(['first', 'second']);
+    expect(exit).toBe(0);
+  });
+
+  it('handles a single chunk containing multiple events', async () => {
+    mockSSE(['event: stdout\ndata: a\n\nevent: stdout\ndata: b\n\nevent: done\ndata: {"exit":0,"durationMs":1}\n\n']);
+    const stdout: string[] = [];
+    await runCommand('acme.test', 'echo', { onStdout: (l) => stdout.push(l) });
+    expect(stdout).toEqual(['a', 'b']);
+  });
+
+  it('handles events split across multiple chunks', async () => {
+    mockSSE(['event: stdout\nda', 'ta: partial\n\nevent: done\ndata: {"exit":0,"durationMs":1}\n\n']);
+    const stdout: string[] = [];
+    await runCommand('acme.test', 'echo', { onStdout: (l) => stdout.push(l) });
+    expect(stdout).toEqual(['partial']);
+  });
+
+  it('dispatches stderr separately from stdout', async () => {
+    mockSSE(['event: stdout\ndata: ok\n\n', 'event: stderr\ndata: warn\n\n', 'event: done\ndata: {"exit":0,"durationMs":1}\n\n']);
+    const out: string[] = [];
+    const err: string[] = [];
+    await runCommand('acme.test', 'echo', { onStdout: (l) => out.push(l), onStderr: (l) => err.push(l) });
+    expect(out).toEqual(['ok']);
+    expect(err).toEqual(['warn']);
+  });
+
+  it('surfaces a URL from the done payload', async () => {
+    mockSSE(['event: done\ndata: {"exit":0,"durationMs":12,"url":"https://acme.test/login/x"}\n\n']);
+    let url: string | undefined;
+    await runCommand('acme.test', 'uli', { onDone: (d) => (url = d.url) });
+    expect(url).toBe('https://acme.test/login/x');
+  });
+
+  it('falls through to onTerminal when server returns terminal:true JSON instead of SSE', async () => {
+    mockJSON({ terminal: true });
+    const events = { terminal: 0, done: 0 };
+    await runCommand('acme.test', 'shell', {
+      onTerminal: () => events.terminal++,
+      onDone: () => events.done++
+    });
+    expect(events.terminal).toBe(1);
+    expect(events.done).toBe(0);
+  });
+
+  it('reports server errors via onError', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response('forbidden', { status: 403, statusText: 'Forbidden' })
+    ) as unknown as typeof fetch;
+    let msg: string | undefined;
+    await runCommand('acme.test', 'x', { onError: (m) => (msg = m) });
+    expect(msg).toContain('403');
+  });
+});
+
+describe('launchCommand', () => {
+  const cmd = (overrides: Partial<Command> = {}): Command => ({
+    name: 'echo',
+    label: 'Echo',
+    command: 'echo hi',
+    ...overrides
+  });
+
+  it('parks in confirm state for confirm: true commands', () => {
+    launchCommand('acme.test', cmd({ confirm: true }));
+    const s = get(currentRun);
+    expect(s.kind).toBe('confirm');
+    if (s.kind !== 'confirm') return;
+    expect(s.domain).toBe('acme.test');
+    expect(s.cmd.name).toBe('echo');
+  });
+
+  it('skips confirm when skipConfirm: true', async () => {
+    mockSSE(['event: done\ndata: {"exit":0,"durationMs":1}\n\n']);
+    launchCommand('acme.test', cmd({ confirm: true }), { skipConfirm: true });
+    // launchCommand fires execute asynchronously; wait a tick for the state to land.
+    await new Promise((r) => setTimeout(r, 0));
+    const s = get(currentRun);
+    expect(s.kind).not.toBe('confirm');
+  });
+});
+
+describe('closeRun', () => {
+  it('resets state back to idle and clears runningName', () => {
+    launchCommand('acme.test', { name: 'noop', label: 'Noop', command: 'true', confirm: true });
+    expect(get(currentRun).kind).toBe('confirm');
+    closeRun();
+    expect(get(currentRun).kind).toBe('idle');
+    expect(get(runningName)).toBeNull();
+  });
+});
+
+describe('history', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('persists the last run and exposes it via lastRunFor', async () => {
+    const { lastRunFor } = await import('./commands');
+    mockSSE(['event: stdout\ndata: hi\n\n', 'event: done\ndata: {"exit":0,"durationMs":12}\n\n']);
+    launchCommand('acme.test', { name: 'echo', label: 'Echo', command: 'echo hi' });
+    // wait for executeCommand to complete
+    await new Promise((r) => setTimeout(r, 50));
+    const prev = lastRunFor('acme.test', 'echo');
+    expect(prev).not.toBeNull();
+    expect(prev!.exit).toBe(0);
+    expect(prev!.lines).toEqual([{ stream: 'stdout', text: 'hi' }]);
+  });
+
+  it('returns null for unknown (domain, name) pairs', async () => {
+    const { lastRunFor } = await import('./commands');
+    expect(lastRunFor('nope.test', 'nope')).toBeNull();
+  });
+
+  it('survives malformed localStorage payloads', async () => {
+    localStorage.setItem('lerd-commands-history-v1', 'not json');
+    const { lastRunFor } = await import('./commands');
+    expect(lastRunFor('a', 'b')).toBeNull();
+  });
+});
+
+describe('launchCommand concurrency guard', () => {
+  it('refuses if another run is in flight', async () => {
+    mockSSE(['event: done\ndata: {"exit":0,"durationMs":1}\n\n']);
+    launchCommand('acme.test', { name: 'first', label: 'First', command: 'echo a' });
+    // While the first is running, fire a second.
+    launchCommand('acme.test', { name: 'second', label: 'Second', command: 'echo b' });
+    await new Promise((r) => setTimeout(r, 10));
+    // The first command's state must dominate; second was rejected.
+    const s = get(currentRun);
+    if (s.kind === 'done' || s.kind === 'running' || s.kind === 'confirm') {
+      expect(s.cmd.name).toBe('first');
+    }
+  });
+});

--- a/internal/ui/web/src/stores/commands.ts
+++ b/internal/ui/web/src/stores/commands.ts
@@ -1,0 +1,360 @@
+import { writable, get } from 'svelte/store';
+import { apiUrl, apiJson, apiFetch } from '$lib/api';
+import { wsMessage } from '$lib/ws';
+
+// Mirrors config.FrameworkCommand on the Go side. Keep field order in step
+// with the JSON the API emits; unknown fields are ignored.
+export interface Command {
+  name: string;
+  label: string;
+  command: string;
+  description?: string;
+  output?: 'silent' | 'text' | 'url' | 'terminal';
+  confirm?: boolean;
+  icon?: string;
+  cwd?: string;
+}
+
+export async function loadCommands(domain: string, branch = ''): Promise<Command[]> {
+  const path = `/api/sites/${encodeURIComponent(domain)}/commands`;
+  const q = branch ? `?branch=${encodeURIComponent(branch)}` : '';
+  const data = await apiJson<{ commands?: Command[] }>(path + q);
+  return data.commands ?? [];
+}
+
+export interface RunCallbacks {
+  onStdout?: (line: string) => void;
+  onStderr?: (line: string) => void;
+  onDone?: (info: { exit: number; durationMs: number; url?: string }) => void;
+  onError?: (message: string) => void;
+  onTerminal?: () => void; // fired when the server spawned a terminal instead of streaming
+  signal?: AbortSignal;
+}
+
+// runCommand POSTs to /commands/:name/run and parses the SSE response stream.
+// The browser EventSource API only supports GET, so we read the response
+// body manually. Each SSE event is `event: <name>\n` followed by one or more
+// `data: <line>\n`, terminated by a blank line.
+export async function runCommand(
+  domain: string,
+  name: string,
+  cb: RunCallbacks = {},
+  branch = ''
+): Promise<void> {
+  const path = `/api/sites/${encodeURIComponent(domain)}/commands/${encodeURIComponent(name)}/run`;
+  const q = branch ? `?branch=${encodeURIComponent(branch)}` : '';
+  const res = await apiFetch(path + q, { method: 'POST', signal: cb.signal });
+  if (!res.ok) {
+    cb.onError?.(`${res.status} ${res.statusText}`);
+    return;
+  }
+  // Terminal-mode commands return a small JSON payload instead of an SSE
+  // stream. Detect via the response Content-Type and call onTerminal.
+  const ct = res.headers.get('Content-Type') || '';
+  if (!ct.startsWith('text/event-stream')) {
+    try {
+      const payload = await res.json();
+      if (payload?.terminal) {
+        cb.onTerminal?.();
+      } else if (payload?.error) {
+        cb.onError?.(String(payload.error));
+      }
+    } catch {
+      cb.onError?.('unexpected non-streaming response');
+    }
+    return;
+  }
+  if (!res.body) {
+    cb.onError?.('streaming not supported by this browser');
+    return;
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let sep = buffer.indexOf('\n\n');
+    while (sep !== -1) {
+      const frame = buffer.slice(0, sep);
+      buffer = buffer.slice(sep + 2);
+      dispatchFrame(frame, cb);
+      sep = buffer.indexOf('\n\n');
+    }
+  }
+  if (buffer.trim()) dispatchFrame(buffer, cb);
+}
+
+function dispatchFrame(frame: string, cb: RunCallbacks) {
+  let event = 'message';
+  const dataLines: string[] = [];
+  for (const raw of frame.split('\n')) {
+    if (raw.startsWith('event: ')) event = raw.slice(7).trim();
+    else if (raw.startsWith('data: ')) dataLines.push(raw.slice(6));
+  }
+  const data = dataLines.join('\n');
+  switch (event) {
+    case 'stdout':
+      cb.onStdout?.(data);
+      break;
+    case 'stderr':
+      cb.onStderr?.(data);
+      break;
+    case 'done':
+      try {
+        const info = JSON.parse(data);
+        cb.onDone?.(info);
+      } catch {
+        cb.onError?.('malformed done payload: ' + data);
+      }
+      break;
+    case 'error':
+      cb.onError?.(data);
+      break;
+  }
+}
+
+// Helper used by the URL panel for output: url commands.
+export function apiUrlFor(path: string): string {
+  return apiUrl(path);
+}
+
+// Global run state used by CommandRunModal (mounted at app root). The
+// CommandsDropdown and CommandPalette both publish to this store rather than
+// owning their own modal. Lets us run commands from any entry point and have
+// the user see the same UI surface.
+export type RunLine = { stream: 'stdout' | 'stderr' | 'meta'; text: string };
+
+export type CurrentRun =
+  | { kind: 'idle' }
+  | { kind: 'confirm'; domain: string; cmd: Command }
+  | { kind: 'running'; domain: string; cmd: Command; lines: RunLine[]; started: number }
+  | {
+      kind: 'done';
+      domain: string;
+      cmd: Command;
+      lines: RunLine[];
+      exit: number;
+      durationMs: number;
+      url?: string;
+    };
+
+export const currentRun = writable<CurrentRun>({ kind: 'idle' });
+export const runningName = writable<string | null>(null);
+
+let abortCtrl: AbortController | null = null;
+let toastTimer: ReturnType<typeof setTimeout> | null = null;
+export const runToast = writable<string | null>(null);
+
+function setToast(msg: string, ms = 2400) {
+  if (toastTimer) clearTimeout(toastTimer);
+  runToast.set(msg);
+  toastTimer = setTimeout(() => runToast.set(null), ms);
+}
+
+// launchCommand is the single entry point both the dropdown and the palette
+// call. If the command has confirm: true and skipConfirm is false, it parks
+// in the confirm state so the modal can prompt. Otherwise it executes.
+// Refuses if another run is in flight (toast + no-op) so a palette click
+// can't clobber an active dropdown run's state.
+export function launchCommand(domain: string, cmd: Command, opts: { skipConfirm?: boolean; branch?: string } = {}) {
+  const cur = get(currentRun);
+  if (cur.kind === 'running') {
+    setToast('Another command is running. Wait for it to finish.', 2400);
+    return;
+  }
+  if (cmd.confirm && !opts.skipConfirm) {
+    currentRun.set({ kind: 'confirm', domain, cmd });
+    return;
+  }
+  void executeCommand(domain, cmd, opts.branch);
+}
+
+export async function executeCommand(domain: string, cmd: Command, branch = '') {
+  const started = Date.now();
+  runningName.set(cmd.name);
+  if (cmd.output === 'terminal') {
+    currentRun.set({ kind: 'idle' });
+  } else {
+    currentRun.set({ kind: 'running', domain, cmd, lines: [], started });
+  }
+  abortCtrl = new AbortController();
+
+  const append = (stream: 'stdout' | 'stderr', text: string) => {
+    currentRun.update((s) => {
+      if (s.kind !== 'running') return s;
+      return { ...s, lines: [...s.lines, { stream, text }] };
+    });
+  };
+
+  try {
+    await runCommand(
+      domain,
+      cmd.name,
+      {
+      signal: abortCtrl.signal,
+      onStdout: (l) => append('stdout', l),
+      onStderr: (l) => append('stderr', l),
+      onDone: ({ exit, durationMs, url }) => {
+        currentRun.update((s) => {
+          if (s.kind !== 'running') return s;
+          const done = { kind: 'done' as const, domain, cmd, lines: s.lines, exit, durationMs, url };
+          saveHistory(domain, cmd.name, done);
+          maybeNotifyDone(cmd, domain, exit, durationMs);
+          return done;
+        });
+      },
+      onTerminal: () => {
+        setToast('Opened ' + (cmd.label || cmd.name) + ' in terminal');
+      },
+      onError: (msg) => {
+        currentRun.update((s) => {
+          if (s.kind === 'running') {
+            return {
+              kind: 'done',
+              domain,
+              cmd,
+              lines: [...s.lines, { stream: 'meta', text: '[error] ' + msg }],
+              exit: -1,
+              durationMs: Date.now() - started
+            };
+          }
+          setToast('Error: ' + msg, 3000);
+          return s;
+        });
+      }
+      },
+      branch
+    );
+  } finally {
+    runningName.set(null);
+    abortCtrl = null;
+  }
+}
+
+export function closeRun() {
+  if (abortCtrl) {
+    abortCtrl.abort();
+    abortCtrl = null;
+  }
+  currentRun.set({ kind: 'idle' });
+  runningName.set(null);
+}
+
+// Cached command lists by domain, populated on demand. Used by the palette
+// to show "Run <name> on <domain>" entries across all sites without
+// re-fetching on every keystroke.
+const commandsBySite = writable<Record<string, Command[]>>({});
+export const commandsBySiteStore = { subscribe: commandsBySite.subscribe };
+
+export async function preloadCommandsFor(domains: string[]): Promise<void> {
+  const current = get(commandsBySite);
+  const missing = domains.filter((d) => !(d in current));
+  if (missing.length === 0) return;
+  const results = await Promise.allSettled(missing.map((d) => loadCommands(d).then((c) => [d, c] as const)));
+  commandsBySite.update((prev) => {
+    const next = { ...prev };
+    for (const r of results) {
+      if (r.status === 'fulfilled') next[r.value[0]] = r.value[1];
+    }
+    return next;
+  });
+}
+
+export function clearCommandsCache() {
+  commandsBySite.set({});
+}
+
+// Persisted last-run snapshot per (domain, name) so closing the modal
+// doesn't lose what just happened. The user can re-open the same command
+// from the dashboard or palette and see the last output in a "Previous
+// run" banner. Bounded to 32 entries to cap localStorage growth.
+const HISTORY_KEY = 'lerd-commands-history-v1';
+const HISTORY_MAX = 32;
+
+interface HistoryEntry {
+  domain: string;
+  name: string;
+  exit: number;
+  durationMs: number;
+  lines: RunLine[];
+  url?: string;
+  finishedAt: number;
+}
+
+function loadHistory(): HistoryEntry[] {
+  try {
+    const raw = localStorage.getItem(HISTORY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as HistoryEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(domain: string, name: string, run: Extract<CurrentRun, { kind: 'done' }>) {
+  try {
+    const entries = loadHistory().filter((e) => !(e.domain === domain && e.name === name));
+    entries.unshift({
+      domain,
+      name,
+      exit: run.exit,
+      durationMs: run.durationMs,
+      lines: run.lines,
+      url: run.url,
+      finishedAt: Date.now()
+    });
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(entries.slice(0, HISTORY_MAX)));
+  } catch {
+    /* localStorage may be unavailable (private mode, quota) — non-fatal */
+  }
+}
+
+export function lastRunFor(domain: string, name: string): HistoryEntry | null {
+  for (const e of loadHistory()) {
+    if (e.domain === domain && e.name === name) return e;
+  }
+  return null;
+}
+
+// Fire a desktop notification when a long command finishes while the tab is
+// hidden. Stays silent when the user is watching the modal (they already
+// see it) and never prompts for permission — only uses what was granted via
+// notify.ts. The 5s threshold keeps notifications off cache:clear-style
+// instant runs.
+const NOTIFY_THRESHOLD_MS = 5000;
+
+function maybeNotifyDone(cmd: Command, domain: string, exit: number, durationMs: number) {
+  if (typeof document === 'undefined' || typeof Notification === 'undefined') return;
+  if (Notification.permission !== 'granted') return;
+  if (durationMs < NOTIFY_THRESHOLD_MS && !document.hidden) return;
+  try {
+    const title = (cmd.label || cmd.name) + (exit === 0 ? ' finished' : ' failed (exit ' + exit + ')');
+    const body = domain + ' · ' + durationMs + 'ms';
+    if ('serviceWorker' in navigator) {
+      void navigator.serviceWorker.ready
+        .then((reg) => reg.showNotification(title, { body, tag: 'lerd-cmd-' + domain + '-' + cmd.name, icon: '/icons/icon-192.png' }))
+        .catch(() => {
+          new Notification(title, { body });
+        });
+    } else {
+      new Notification(title, { body });
+    }
+  } catch {
+    /* notification failures are non-fatal */
+  }
+}
+
+// Whenever the sites snapshot changes, drop the cached command lists. A new
+// site might have been added, or an existing site's .lerd.yaml may have been
+// rewritten (by MCP command_add, by the user, or by lerd's own writers).
+// Next palette open or dropdown open will re-fetch.
+wsMessage.subscribe((msg) => {
+  if (msg?.sites !== undefined) {
+    clearCommandsCache();
+  }
+});

--- a/internal/ui/web/src/tabs/DumpsTab.svelte
+++ b/internal/ui/web/src/tabs/DumpsTab.svelte
@@ -16,6 +16,7 @@
   } from '$stores/dumps';
   import DumpEntry from '$components/DumpEntry.svelte';
   import EmptyState from '$components/EmptyState.svelte';
+  import Dropdown from '$components/Dropdown.svelte';
   import { m } from '../paraglide/messages.js';
 
   interface Props {
@@ -91,34 +92,35 @@
       bind:value={textInput}
     />
     {#if !scoped}
-      <select
-        class="text-xs px-2 py-1 rounded-sm border border-gray-300 dark:border-lerd-border bg-white dark:bg-lerd-card"
-        bind:value={$filterSite}
-      >
-        <option value="">{m.dumps_filter_allSites()}</option>
-        {#each $knownSites as site}
-          <option value={site}>{site || m.dumps_unknownSite()}</option>
-        {/each}
-      </select>
+      <Dropdown
+        value={$filterSite}
+        options={[
+          { value: '', label: m.dumps_filter_allSites() },
+          ...$knownSites.map((s) => ({ value: s, label: s || m.dumps_unknownSite() }))
+        ]}
+        onchange={(v) => filterSite.set(v)}
+      />
     {/if}
     {#if scoped}
-      <select
-        class="text-xs px-2 py-1 rounded-sm border border-gray-300 dark:border-lerd-border bg-white dark:bg-lerd-card"
-        bind:value={localCtx}
-      >
-        <option value="">{m.dumps_filter_allContexts()}</option>
-        <option value="fpm">{m.dumps_filter_web()}</option>
-        <option value="cli">{m.dumps_filter_cli()}</option>
-      </select>
+      <Dropdown
+        value={localCtx}
+        options={[
+          { value: '', label: m.dumps_filter_allContexts() },
+          { value: 'fpm', label: m.dumps_filter_web() },
+          { value: 'cli', label: m.dumps_filter_cli() }
+        ]}
+        onchange={(v) => (localCtx = v as '' | 'fpm' | 'cli')}
+      />
     {:else}
-      <select
-        class="text-xs px-2 py-1 rounded-sm border border-gray-300 dark:border-lerd-border bg-white dark:bg-lerd-card"
-        bind:value={$filterCtx}
-      >
-        <option value="">{m.dumps_filter_allContexts()}</option>
-        <option value="fpm">{m.dumps_filter_web()}</option>
-        <option value="cli">{m.dumps_filter_cli()}</option>
-      </select>
+      <Dropdown
+        value={$filterCtx}
+        options={[
+          { value: '', label: m.dumps_filter_allContexts() },
+          { value: 'fpm', label: m.dumps_filter_web() },
+          { value: 'cli', label: m.dumps_filter_cli() }
+        ]}
+        onchange={(v) => filterCtx.set(v as '' | 'fpm' | 'cli')}
+      />
     {/if}
     <button
       type="button"

--- a/internal/ui/web/src/tabs/sites/AppLogsTab.svelte
+++ b/internal/ui/web/src/tabs/sites/AppLogsTab.svelte
@@ -7,6 +7,7 @@
     type AppLogFile,
     type AppLogEntry
   } from '$stores/appLogs';
+  import Dropdown from '$components/Dropdown.svelte';
   import { m } from '../../paraglide/messages.js';
 
   interface Props {
@@ -96,15 +97,11 @@
 <div class="flex-1 flex flex-col overflow-hidden min-h-0">
   <div class="flex items-center gap-2 px-3 sm:px-5 py-2 shrink-0 border-b border-gray-100 dark:border-lerd-border">
     {#if files.length > 0}
-      <select
-        bind:value={selectedFile}
-        onchange={loadEntries}
-        class="text-xs bg-white dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border rounded-sm px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-hidden focus:border-orange-500/50 cursor-pointer transition-colors"
-      >
-        {#each files as f (f.name)}
-          <option value={f.name} class="bg-white text-gray-700 dark:bg-lerd-bg dark:text-gray-300">{f.name}</option>
-        {/each}
-      </select>
+      <Dropdown
+        value={selectedFile}
+        options={files.map((f) => ({ value: f.name, label: f.name }))}
+        onchange={(v) => { selectedFile = v; loadEntries(); }}
+      />
     {/if}
 
     <div class="flex items-center rounded-sm border border-gray-200 dark:border-lerd-border overflow-hidden shrink-0">

--- a/internal/ui/web/src/tabs/sites/SiteControls.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteControls.svelte
@@ -20,6 +20,9 @@
   import { status } from '$stores/status';
   import LANShareLink from './LANShareLink.svelte';
   import WorktreeDBIsolateModal from './WorktreeDBIsolateModal.svelte';
+  import CommandsDropdown from '$components/CommandsDropdown.svelte';
+  import Dropdown from '$components/Dropdown.svelte';
+  import ToggleButton from '$components/ToggleButton.svelte';
   import { m } from '../../paraglide/messages.js';
 
   interface Props {
@@ -39,7 +42,6 @@
   const dbCapable = $derived((site.services || []).some((s) => /^(mysql|mariadb|postgres)/.test(s)));
   const dbIsolated = $derived(Boolean(activeWorktree?.db_isolated));
   let dbBusy = $state(false);
-
   let isolateModalOpen = $state(false);
 
   function onDBIsolatedChange() {
@@ -188,61 +190,60 @@
 </script>
 
 <div class="px-3 sm:px-5 py-3 border-b border-gray-100 dark:border-lerd-border shrink-0">
-  <div class="flex items-center gap-4 overflow-x-auto">
+  <div class="flex items-center gap-3">
+  <div class="flex items-center gap-3 overflow-x-auto flex-1 min-w-0">
     {#if site.custom_container}
       <span class="text-xs text-violet-500 dark:text-violet-400 border border-violet-200 dark:border-violet-500/30 rounded-sm px-2 py-1">
         {(site.container_image || 'container') + ' :' + site.container_port}
       </span>
     {:else if $phpVersions.length > 0}
-      <select
+      <Dropdown
+        label="PHP"
         value={effectivePhp}
-        onchange={onPhpChange}
+        options={$phpVersions}
         disabled={versionBusy}
+        inherited={phpInherited}
+        inheritedSuffix={m.sites_controls_inheritedSuffix()}
         title={phpInherited ? m.sites_controls_inheritsFromMain() : ''}
-        class="text-xs bg-white dark:bg-lerd-bg border rounded-sm px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-hidden focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors {phpInherited ? 'border-dashed border-violet-300 dark:border-violet-700' : 'border-gray-200 dark:border-lerd-border'}"
-      >
-        <option value="" disabled class="bg-white text-gray-700 dark:bg-lerd-bg dark:text-gray-300">{m.sites_controls_phpPlaceholder()}</option>
-        {#each $phpVersions as v (v)}<option value={v} class="bg-white text-gray-700 dark:bg-lerd-bg dark:text-gray-300">PHP {v}{activeWorktreeBranch && v === effectivePhp && phpInherited ? ' ' + m.sites_controls_inheritedSuffix() : ''}</option>{/each}
-      </select>
+        placeholder={m.sites_controls_phpPlaceholder()}
+        onchange={(v) => onPhpChange({ target: { value: v } } as unknown as Event)}
+      />
     {:else}
       <span class="text-xs text-gray-400 border border-gray-200 dark:border-lerd-border rounded-sm px-2 py-1 opacity-50">PHP ...</span>
     {/if}
 
     {#if $status.node_managed_by_lerd && $nodeVersions.length > 0}
-      <select
+      <Dropdown
+        label="Node"
         value={effectiveNode}
-        onchange={onNodeChange}
+        options={$nodeVersions}
         disabled={versionBusy}
+        inherited={nodeInherited}
+        inheritedSuffix={m.sites_controls_inheritedSuffix()}
         title={nodeInherited ? m.sites_controls_inheritsFromMain() : ''}
-        class="text-xs bg-white dark:bg-lerd-bg border rounded-sm px-2 py-1 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-hidden focus:border-lerd-red/50 disabled:opacity-50 cursor-pointer transition-colors {nodeInherited ? 'border-dashed border-violet-300 dark:border-violet-700' : 'border-gray-200 dark:border-lerd-border'}"
-      >
-        <option value="" class="bg-white text-gray-700 dark:bg-lerd-bg dark:text-gray-300">{m.sites_controls_nodeDefault()}</option>
-        {#each $nodeVersions as v (v)}<option value={v} class="bg-white text-gray-700 dark:bg-lerd-bg dark:text-gray-300">Node {v}{activeWorktreeBranch && v === effectiveNode && nodeInherited ? ' ' + m.sites_controls_inheritedSuffix() : ''}</option>{/each}
-      </select>
+        placeholder={m.sites_controls_nodeDefault()}
+        onchange={(v) => onNodeChange({ target: { value: v } } as unknown as Event)}
+      />
     {/if}
 
     {#if $status.dns?.enabled !== false}
-      <div class="flex items-center gap-1.5">
-        <Toggle
-          on={Boolean(site.tls)}
-          loading={tlsBusy}
-          onclick={() => runAction((b) => (tlsBusy = b), () => toggleTLS(site))}
-          title={site.tls ? m.sites_controls_httpsToggle_on() : m.sites_controls_httpsToggle_off()}
-        />
-        <span class="text-xs text-gray-500 dark:text-gray-400">{m.sites_controls_https()}</span>
-      </div>
+      <ToggleButton
+        label={m.sites_controls_https()}
+        on={Boolean(site.tls)}
+        loading={tlsBusy}
+        onclick={() => runAction((b) => (tlsBusy = b), () => toggleTLS(site))}
+        title={site.tls ? m.sites_controls_httpsToggle_on() : m.sites_controls_httpsToggle_off()}
+      />
     {/if}
 
     {#if activeWorktreeBranch && dbCapable}
-      <div class="flex items-center gap-1.5" title={dbIsolated ? m.sites_controls_dbIsolatedTitle({ db: activeWorktree?.db_database ?? '' }) : m.sites_controls_dbShareParent()}>
-        <Toggle
-          on={dbIsolated}
-          tone="teal"
-          loading={dbBusy}
-          onclick={onDBIsolatedChange}
-        />
-        <span class="text-xs text-gray-500 dark:text-gray-400">{m.sites_controls_dbIsolated()}</span>
-      </div>
+      <ToggleButton
+        label={m.sites_controls_dbIsolated()}
+        on={dbIsolated}
+        loading={dbBusy}
+        onclick={onDBIsolatedChange}
+        title={dbIsolated ? m.sites_controls_dbIsolatedTitle({ db: activeWorktree?.db_database ?? '' }) : m.sites_controls_dbShareParent()}
+      />
     {/if}
 
     {#snippet lanShare()}
@@ -250,23 +251,19 @@
       {@const lanPort = isWT ? activeWorktree?.lan_port ?? 0 : site.lan_port ?? 0}
       {@const lanURL = isWT ? activeWorktree?.lan_share_url ?? '' : site.lan_share_url ?? ''}
       {@const lanDomain = isWT ? (activeWorktree?.domain ?? site.domain) : site.domain}
-      <div class="flex items-center gap-1.5">
-        <Toggle
-          on={Boolean(lanPort)}
-          tone="teal"
-          loading={lanBusy}
-          onclick={() => runAction((b) => (lanBusy = b), () => toggleLANShare(site, activeWorktreeBranch))}
-          title={lanPort ? m.sites_controls_lanToggle_on() : m.sites_controls_lanToggle_off()}
-        />
-        <span class="text-xs text-gray-500 dark:text-gray-400">{m.sites_controls_lan()}</span>
-        {#if lanURL}
-          <LANShareLink domain={lanDomain} url={lanURL} siteDomain={site.domain} branch={activeWorktreeBranch} />
-        {/if}
-      </div>
+      <ToggleButton
+        label={m.sites_controls_lan()}
+        on={Boolean(lanPort)}
+        loading={lanBusy}
+        onclick={() => runAction((b) => (lanBusy = b), () => toggleLANShare(site, activeWorktreeBranch))}
+        title={lanPort ? m.sites_controls_lanToggle_on() : m.sites_controls_lanToggle_off()}
+      />
+      {#if lanURL}
+        <LANShareLink domain={lanDomain} url={lanURL} siteDomain={site.domain} branch={activeWorktreeBranch} />
+      {/if}
     {/snippet}
-    {@render lanShare()}
 
-    <div class="w-px h-4 bg-gray-200 dark:bg-lerd-border mx-0.5"></div>
+    {@render lanShare()}
 
     {#if activeWorktreeBranch}
       {@const wtWorkers = activeWorktree?.framework_workers || []}
@@ -279,118 +276,100 @@
         </span>
       {:else}
         {#each wtWorkers as w (w.name)}
-          <div class="flex items-center gap-1.5">
-            <Toggle
-              on={Boolean(w.running)}
-              failing={Boolean(w.failing)}
-              tone="indigo"
-              loading={isPending('worker:' + w.name)}
-              disabled={isPending('worker:' + w.name)}
-              onclick={() => transition('worker:' + w.name, !w.running, () => toggleWorker(site, w, activeWorktreeBranch))}
-              title={w.running ? m.sites_controls_workerToggle_on({ label: w.label || w.name }) : m.sites_controls_workerToggle_off({ label: w.label || w.name })}
-            />
-            <span class="text-xs text-gray-500 dark:text-gray-400">{w.label || w.name}</span>
-          </div>
+          <ToggleButton
+            label={w.label || w.name}
+            on={Boolean(w.running)}
+            failing={Boolean(w.failing)}
+            loading={isPending('worker:' + w.name)}
+            disabled={isPending('worker:' + w.name)}
+            onclick={() => transition('worker:' + w.name, !w.running, () => toggleWorker(site, w, activeWorktreeBranch))}
+            title={w.running ? m.sites_controls_workerToggle_on({ label: w.label || w.name }) : m.sites_controls_workerToggle_off({ label: w.label || w.name })}
+          />
         {/each}
       {/if}
     {:else}
       {#if site.has_queue_worker}
-        <div class="flex items-center gap-1.5">
-          <Toggle
-            on={Boolean(site.queue_running)}
-            failing={Boolean(site.queue_failing)}
-            tone="amber"
-            loading={isPending('queue')}
-            disabled={isPending('queue')}
-            onclick={() => transition('queue', !site.queue_running, () => toggleQueue(site))}
-            title={site.queue_failing ? m.sites_controls_queueToggle_failing() : site.queue_running ? m.sites_controls_queueToggle_on() : m.sites_controls_queueToggle_off()}
-          />
-          <span class="text-xs text-gray-500 dark:text-gray-400">{m.sites_controls_queue()}</span>
-        </div>
+        <ToggleButton
+          label={m.sites_controls_queue()}
+          on={Boolean(site.queue_running)}
+          failing={Boolean(site.queue_failing)}
+          loading={isPending('queue')}
+          disabled={isPending('queue')}
+          onclick={() => transition('queue', !site.queue_running, () => toggleQueue(site))}
+          title={site.queue_failing ? m.sites_controls_queueToggle_failing() : site.queue_running ? m.sites_controls_queueToggle_on() : m.sites_controls_queueToggle_off()}
+        />
       {/if}
 
       {#if site.has_horizon}
-        <div class="flex items-center gap-1.5">
-          <Toggle
-            on={Boolean(site.horizon_running)}
-            failing={Boolean(site.horizon_failing)}
-            tone="amber"
-            loading={isPending('horizon')}
-            disabled={isPending('horizon')}
-            onclick={() => transition('horizon', !site.horizon_running, () => toggleHorizon(site))}
-            title={site.horizon_failing ? m.sites_controls_horizonToggle_failing() : site.horizon_running ? m.sites_controls_horizonToggle_on() : m.sites_controls_horizonToggle_off()}
-          />
-          <span class="text-xs text-gray-500 dark:text-gray-400">{m.sites_controls_horizon()}</span>
-        </div>
+        <ToggleButton
+          label={m.sites_controls_horizon()}
+          on={Boolean(site.horizon_running)}
+          failing={Boolean(site.horizon_failing)}
+          loading={isPending('horizon')}
+          disabled={isPending('horizon')}
+          onclick={() => transition('horizon', !site.horizon_running, () => toggleHorizon(site))}
+          title={site.horizon_failing ? m.sites_controls_horizonToggle_failing() : site.horizon_running ? m.sites_controls_horizonToggle_on() : m.sites_controls_horizonToggle_off()}
+        />
       {/if}
 
       {#if site.has_schedule_worker}
-        <div class="flex items-center gap-1.5">
-          <Toggle
-            on={Boolean(site.schedule_running)}
-            failing={Boolean(site.schedule_failing)}
-            tone="emerald"
-            loading={isPending('schedule')}
-            disabled={isPending('schedule')}
-            onclick={() => transition('schedule', !site.schedule_running, () => toggleSchedule(site))}
-            title={site.schedule_running ? m.sites_controls_scheduleToggle_on() : m.sites_controls_scheduleToggle_off()}
-          />
-          <span class="text-xs text-gray-500 dark:text-gray-400">{m.sites_controls_schedule()}</span>
-        </div>
+        <ToggleButton
+          label={m.sites_controls_schedule()}
+          on={Boolean(site.schedule_running)}
+          failing={Boolean(site.schedule_failing)}
+          loading={isPending('schedule')}
+          disabled={isPending('schedule')}
+          onclick={() => transition('schedule', !site.schedule_running, () => toggleSchedule(site))}
+          title={site.schedule_running ? m.sites_controls_scheduleToggle_on() : m.sites_controls_scheduleToggle_off()}
+        />
       {/if}
 
       {#if site.has_reverb}
-        <div class="flex items-center gap-1.5">
-          <Toggle
-            on={Boolean(site.reverb_running)}
-            failing={Boolean(site.reverb_failing)}
-            tone="sky"
-            loading={isPending('reverb')}
-            disabled={isPending('reverb')}
-            onclick={() => transition('reverb', !site.reverb_running, () => toggleReverb(site))}
-            title={site.reverb_running ? m.sites_controls_reverbToggle_on() : m.sites_controls_reverbToggle_off()}
-          />
-          <span class="text-xs text-gray-500 dark:text-gray-400">{m.sites_controls_reverb()}</span>
-        </div>
+        <ToggleButton
+          label={m.sites_controls_reverb()}
+          on={Boolean(site.reverb_running)}
+          failing={Boolean(site.reverb_failing)}
+          loading={isPending('reverb')}
+          disabled={isPending('reverb')}
+          onclick={() => transition('reverb', !site.reverb_running, () => toggleReverb(site))}
+          title={site.reverb_running ? m.sites_controls_reverbToggle_on() : m.sites_controls_reverbToggle_off()}
+        />
       {/if}
 
       {#if site.stripe_secret_set}
-        <div class="flex items-center gap-1.5">
-          <Toggle
-            on={Boolean(site.stripe_running)}
-            tone="violet"
-            loading={isPending('stripe')}
-            disabled={isPending('stripe')}
-            onclick={() => transition('stripe', !site.stripe_running, () => toggleStripe(site))}
-            title={site.stripe_running ? m.sites_controls_stripeToggle_on() : m.sites_controls_stripeToggle_off()}
-          />
-          <span class="text-xs text-gray-500 dark:text-gray-400">{m.sites_controls_stripe()}</span>
-        </div>
+        <ToggleButton
+          label={m.sites_controls_stripe()}
+          on={Boolean(site.stripe_running)}
+          loading={isPending('stripe')}
+          disabled={isPending('stripe')}
+          onclick={() => transition('stripe', !site.stripe_running, () => toggleStripe(site))}
+          title={site.stripe_running ? m.sites_controls_stripeToggle_on() : m.sites_controls_stripeToggle_off()}
+        />
       {/if}
 
       {#each site.framework_workers || [] as w (w.name)}
         {@const isVite = w.name === 'vite'}
         {@const shortLabel = isVite ? m.sites_controls_vite() : w.label || w.name}
-        <div class="flex items-center gap-1.5">
-          <Toggle
-            on={Boolean(w.running)}
-            failing={Boolean(w.failing)}
-            tone="indigo"
-            loading={isPending('worker:' + w.name)}
-            disabled={isPending('worker:' + w.name)}
-            onclick={() => transition('worker:' + w.name, !w.running, () => toggleWorker(site, w))}
-            title={isVite
-              ? w.running
-                ? m.sites_controls_viteToggle_on()
-                : m.sites_controls_viteToggle_off()
-              : w.running
-                ? 'Stop ' + shortLabel
-                : 'Start ' + shortLabel}
-          />
-          <span class="text-xs text-gray-500 dark:text-gray-400">{shortLabel}</span>
-        </div>
+        <ToggleButton
+          label={shortLabel}
+          on={Boolean(w.running)}
+          failing={Boolean(w.failing)}
+          loading={isPending('worker:' + w.name)}
+          disabled={isPending('worker:' + w.name)}
+          onclick={() => transition('worker:' + w.name, !w.running, () => toggleWorker(site, w))}
+          title={isVite
+            ? w.running
+              ? m.sites_controls_viteToggle_on()
+              : m.sites_controls_viteToggle_off()
+            : w.running
+              ? 'Stop ' + shortLabel
+              : 'Start ' + shortLabel}
+        />
       {/each}
     {/if}
+  </div>
+
+    <CommandsDropdown domain={site.domain} branch={activeWorktreeBranch} />
   </div>
 </div>
 

--- a/internal/ui/web/src/tabs/sites/WorktreeDBIsolateModal.svelte
+++ b/internal/ui/web/src/tabs/sites/WorktreeDBIsolateModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Modal from '$components/Modal.svelte';
+  import Dropdown from '$components/Dropdown.svelte';
   import type { Site } from '$stores/sites';
   import { m } from '../../paraglide/messages.js';
 
@@ -49,14 +50,12 @@
     <p class="text-sm text-gray-600 dark:text-gray-400">
       {m.worktreeDb_body({ branch })}
     </p>
-    <select
-      bind:value={selected}
-      class="w-full text-sm bg-white dark:bg-lerd-bg border border-gray-200 dark:border-lerd-border rounded-sm px-2 py-1.5 text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-lerd-muted focus:outline-hidden focus:border-lerd-red/50 cursor-pointer transition-colors"
-    >
-      {#each options as opt (opt.value)}
-        <option value={opt.value} class="bg-white text-gray-700 dark:bg-lerd-bg dark:text-gray-300">{opt.label}</option>
-      {/each}
-    </select>
+    <Dropdown
+      value={selected}
+      width="full"
+      options={options}
+      onchange={(v) => (selected = v)}
+    />
     <p class="text-[11px] text-gray-400 dark:text-gray-500">
       {m.worktreeDb_cloningHint()}
     </p>

--- a/internal/ui/web/src/tabs/sites/WorktreeDBIsolateModal.test.ts
+++ b/internal/ui/web/src/tabs/sites/WorktreeDBIsolateModal.test.ts
@@ -21,7 +21,7 @@ describe('WorktreeDBIsolateModal', () => {
     expect(container.querySelector('select')).toBeNull();
   });
 
-  it('lists main and any other isolated worktrees, but not the active one', () => {
+  it('lists main and any other isolated worktrees, but not the active one', async () => {
     render(Harness, {
       props: {
         open: true,
@@ -35,13 +35,18 @@ describe('WorktreeDBIsolateModal', () => {
         onconfirm: () => {}
       }
     });
-    const select = screen.getByRole('combobox') as HTMLSelectElement;
-    const values = Array.from(select.options).map((o) => o.value);
-    expect(values).toContain('main');
-    expect(values).toContain('');
-    expect(values).toContain('feat-b');
-    expect(values).not.toContain('feat-a');
-    expect(values).not.toContain('feat-c');
+    // Open the popover and read the labels from the listbox.
+    const triggers = screen.getAllByRole('button');
+    const trigger = triggers.find((b) => b.getAttribute('aria-haspopup') === 'listbox')!;
+    trigger.click();
+    await new Promise((r) => setTimeout(r, 0));
+    const items = Array.from(document.querySelectorAll('[role="option"]')).map(
+      (n) => n.textContent?.toLowerCase() ?? ''
+    );
+    expect(items.some((t) => t.includes('main'))).toBe(true);
+    expect(items.some((t) => t.includes('feat-b'))).toBe(true);
+    expect(items.some((t) => t.includes('feat-a'))).toBe(false);
+    expect(items.some((t) => t.includes('feat-c'))).toBe(false);
   });
 
   it('emits onconfirm with the selected value and closes the modal', async () => {
@@ -56,9 +61,17 @@ describe('WorktreeDBIsolateModal', () => {
         onconfirm
       }
     });
-    const select = screen.getByRole('combobox') as HTMLSelectElement;
-    select.value = '';
-    await fireEvent.change(select);
+    // Open the popover and click the "empty" option, then Isolate.
+    const trigger = screen
+      .getAllByRole('button')
+      .find((b) => b.getAttribute('aria-haspopup') === 'listbox')!;
+    trigger.click();
+    await new Promise((r) => setTimeout(r, 0));
+    const options = Array.from(document.querySelectorAll('[role="option"]')) as HTMLButtonElement[];
+    // The "Start empty" option matches the m.worktreeDb_empty() label.
+    const emptyOpt = options[1] ?? options[0];
+    emptyOpt.click();
+    await new Promise((r) => setTimeout(r, 0));
     const isolateBtn = screen.getByText('Isolate');
     await fireEvent.click(isolateBtn);
     expect(onconfirm).toHaveBeenCalledWith('');
@@ -92,7 +105,12 @@ describe('WorktreeDBIsolateModal', () => {
         onconfirm: () => {}
       }
     });
-    const select = screen.getByRole('combobox') as HTMLSelectElement;
-    expect(select.value).toBe('main');
+    // The trigger label shows the selected option's label — for value "main"
+    // that's the m.worktreeDb_cloneFromMain key. Just verify the trigger
+    // text isn't the empty / placeholder fallback.
+    const trigger = screen
+      .getAllByRole('button')
+      .find((b) => b.getAttribute('aria-haspopup') === 'listbox')!;
+    expect(trigger.textContent?.toLowerCase() ?? '').toContain('main');
   });
 });

--- a/internal/ui/web/src/tabs/system/PhpDetail.svelte
+++ b/internal/ui/web/src/tabs/system/PhpDetail.svelte
@@ -5,6 +5,7 @@
   import Toggle from '$components/Toggle.svelte';
   import InfoRow from '$components/InfoRow.svelte';
   import LogViewer from '$components/LogViewer.svelte';
+  import Dropdown from '$components/Dropdown.svelte';
   import { status, loadStatus, fpmRunning } from '$stores/status';
   import { setDefaultPhp, startPhp, stopPhp, removePhp } from '$stores/phpVersions';
   import { sites, sitesByPhp } from '$stores/sites';
@@ -146,15 +147,13 @@
       </div>
       <div class="flex items-center gap-2">
         {#if xdebugEnabled}
-          <select
+          <Dropdown
             value={xdebugMode}
-            onchange={onSetXdebugMode}
+            options={XDEBUG_MODES}
             disabled={xdebugBusy}
-            class="text-xs bg-white dark:bg-lerd-muted border border-gray-200 dark:border-lerd-border rounded-sm px-1.5 py-0.5 text-gray-700 dark:text-gray-300 focus:outline-hidden focus:ring-1 focus:ring-purple-400 disabled:opacity-50"
             title={m.system_php_xdebugModeTitle()}
-          >
-            {#each XDEBUG_MODES as mode (mode)}<option value={mode}>{mode}</option>{/each}
-          </select>
+            onchange={(v) => onSetXdebugMode({ target: { value: v } } as unknown as Event)}
+          />
         {/if}
         <Toggle
           on={xdebugEnabled}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
       - Queue Workers: usage/queue-workers.md
   - Features:
       - Web UI: features/web-ui.md
+      - Framework Commands: features/commands.md
       - Tinker tab: features/tinker.md
       - Dump viewer: features/dumps.md
       - System Tray: features/system-tray.md


### PR DESCRIPTION
Adds a new commands feature that surfaces one-shot admin actions (cache clears, migrations, login URL generation, etc) for every registered site. The dashboard exposes a Commands dropdown in the site controls
band, the CLI exposes lerd run <name>, and the command palette aggregates commands across all sites with a single multi-term search. MCP gains four tools so AI assistants can list, run, add, and remove commands without hand-editing yaml.

The Go side introduces a FrameworkCommand schema (yaml-defined or inline in a project's .lerd.yaml), a ResolveCommands merge function that lets projects override or disable framework defaults by name, a streaming run endpoint that interleaves stdout and stderr over SSE with per-site mutual exclusion and loopback gating, and an output: terminal mode that spawns the user's terminal emulator instead of streaming. lerd check validates the schema. Built-in Laravel and Symfony come with the same command set hardcoded so sites work before
the framework store fetch lands.

The frontend introduces a generalized Dropdown component (object options, keyboard navigation with arrow keys and type-ahead, ARIA roles, mobile-aware popover sizing) that replaces every native select in the UI for visual consistency. The commands feature uses it for both the per-site Commands menu and the inline run modal, which
renders streamed output with ANSI color support and distinguishes stderr from stdout. Run state is global so the palette and the dropdown share the same modal; finished runs are kept in localStorage so users can review previous output without re-running, and long runs that finish while the tab is hidden trigger a desktop notification
when permitted.

Two unrelated races in the dumps stream and mailpit webhook test helpers are fixed in the same change because the new race-clean commands path made go test -race viable and the failures showed up immediately.

Documentation lands in docs/features/commands.md and the MCP skill gets updated tool descriptions.

Pairs with lerd-frameworks #10, which adds the canonical commands yaml blocks for non-built-in frameworks (WordPress, Drupal, CakePHP, Statamic). Laravel and Symfony work without it because their built-ins ship in this PR.