### PR TITLE
feat(image): multi-stage PHP-FPM build cuts image size by ~60%

### DIFF
--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -38,6 +38,7 @@ jobs:
           with open('internal/podman/quadlets/lerd-php-fpm.Containerfile') as f:
               content = f.read()
           content = content.replace('{{.CustomExtensions}}', '')
+          content = content.replace('{{.CustomExtensionsRuntime}}', '')
           content = content.replace('{{.MkcertCA}}', '')
           h = hashlib.sha256(content.encode()).hexdigest()[:12]
           print(f'Computed base image tag: {h}')
@@ -57,6 +58,7 @@ jobs:
               content = f.read()
           content = content.replace('{{.Version}}', version)
           content = content.replace('{{.CustomExtensions}}', '')
+          content = content.replace('{{.CustomExtensionsRuntime}}', '')
           content = content.replace('{{.MkcertCA}}', '')
           with open('/tmp/Containerfile', 'w') as f:
               f.write(content)
@@ -102,6 +104,35 @@ jobs:
           cache-from: type=gha,scope=php-${{ matrix.php }}-${{ matrix.arch.name }}
           cache-to: type=gha,mode=max,scope=php-${{ matrix.php }}-${{ matrix.arch.name }}
 
+      - name: Smoke-test built image
+        if: steps.check.outputs.exists != 'true' && matrix.arch.name == 'amd64'
+        run: |
+          IMG="ghcr.io/geodro/lerd-php${{ steps.tag.outputs.php_short }}-fpm-base:${{ steps.tag.outputs.tag }}-${{ matrix.arch.name }}"
+          docker pull "$IMG" >/dev/null
+          MODULES=$(docker run --rm "$IMG" php -m 2>&1 | grep -v '^\[' | sort -u)
+          COUNT=$(echo "$MODULES" | grep -c .)
+          echo "PHP ${{ matrix.php }}: $COUNT modules loaded"
+          echo "$MODULES"
+          # Drift guard: catch silent extension drops from Containerfile edits.
+          # 50 is the safe floor; new modules push the count up, removed ones
+          # trip the check here instead of in users' rebuilds.
+          if [ "$COUNT" -lt 50 ]; then
+            echo "::error::PHP ${{ matrix.php }} module count dropped to $COUNT (expected >=50)"
+            exit 1
+          fi
+          # Spot check the load-bearing ones every framework needs.
+          REQUIRED="curl gd intl mbstring pdo_mysql redis xdebug zip"
+          MISSING=""
+          for ext in $REQUIRED; do
+            echo "$MODULES" | grep -qxF "$ext" || MISSING="$MISSING $ext"
+          done
+          if [ -n "$MISSING" ]; then
+            echo "::error::Critical PHP extensions missing from PHP ${{ matrix.php }}:$MISSING"
+            exit 1
+          fi
+          docker run --rm "$IMG" php -r 'exit(count(PDO::getAvailableDrivers()) >= 3 ? 0 : 1);'
+          docker run --rm "$IMG" composer --version >/dev/null
+
   manifest:
     name: Manifest PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
@@ -124,6 +155,7 @@ jobs:
           with open('internal/podman/quadlets/lerd-php-fpm.Containerfile') as f:
               content = f.read()
           content = content.replace('{{.CustomExtensions}}', '')
+          content = content.replace('{{.CustomExtensionsRuntime}}', '')
           content = content.replace('{{.MkcertCA}}', '')
           h = hashlib.sha256(content.encode()).hexdigest()[:12]
           with open('/tmp/tag_output', 'w') as f:

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -217,6 +217,7 @@ func baseContainerfileHash() (string, error) {
 		return "", err
 	}
 	base := strings.ReplaceAll(tmpl, "{{.CustomExtensions}}", "")
+	base = strings.ReplaceAll(base, "{{.CustomExtensionsRuntime}}", "")
 	base = strings.ReplaceAll(base, "{{.MkcertCA}}", "")
 	sum := sha256.Sum256([]byte(base))
 	return fmt.Sprintf("%x", sum)[:12], nil
@@ -304,6 +305,7 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 		}
 		containerfile = strings.ReplaceAll(tmpl, "{{.Version}}", version)
 		containerfile = strings.ReplaceAll(containerfile, "{{.CustomExtensions}}", buildCustomExtBlock(customExts, extDeps))
+		containerfile = strings.ReplaceAll(containerfile, "{{.CustomExtensionsRuntime}}", buildCustomExtRuntimeDeps(customExts, extDeps))
 		containerfile = strings.ReplaceAll(containerfile, "{{.MkcertCA}}", mkcertCABlock(tmp))
 		if force {
 			// Bypass layer cache so changes are fully applied. The old image stays
@@ -382,6 +384,27 @@ func apkDepsForExt(ext string, userDeps map[string][]string) []string {
 	add(extApkDeps[ext])
 	add(userDeps[ext])
 	return out
+}
+
+// buildCustomExtRuntimeDeps emits an apk RUN line that reinstalls the
+// builder-stage deps in the runtime stage so compiled .so files can
+// dlopen against those system libs. Empty when no custom exts have deps.
+func buildCustomExtRuntimeDeps(exts []string, userDeps map[string][]string) string {
+	seen := map[string]bool{}
+	var deps []string
+	for _, ext := range exts {
+		for _, pkg := range apkDepsForExt(ext, userDeps) {
+			if seen[pkg] {
+				continue
+			}
+			seen[pkg] = true
+			deps = append(deps, pkg)
+		}
+	}
+	if len(deps) == 0 {
+		return ""
+	}
+	return "RUN apk add --no-cache " + strings.Join(deps, " ") + " && rm -rf /var/cache/apk/*\n"
 }
 
 // buildCustomExtBlock generates Dockerfile RUN blocks for user-configured

--- a/internal/podman/build_test.go
+++ b/internal/podman/build_test.go
@@ -49,6 +49,66 @@ func TestBuildCustomExtBlock_UserDepsUnionedWithBuiltin(t *testing.T) {
 	}
 }
 
+func TestBuildCustomExtRuntimeDeps_Empty(t *testing.T) {
+	if got := buildCustomExtRuntimeDeps(nil, nil); got != "" {
+		t.Errorf("empty input should produce empty runtime block, got: %q", got)
+	}
+	if got := buildCustomExtRuntimeDeps([]string{"redis"}, nil); got != "" {
+		t.Errorf("extension with no apk deps should produce empty block, got: %q", got)
+	}
+}
+
+func TestBuildCustomExtRuntimeDeps_MatchesBuilderDeps(t *testing.T) {
+	// The runtime block must install exactly the apk packages that the
+	// builder block (buildCustomExtBlock) installs for the same input.
+	// Drift between the two would mean compiled .so files can dlopen at
+	// build time but fail at runtime.
+	cases := []struct {
+		exts     []string
+		userDeps map[string][]string
+	}{
+		{[]string{"imap"}, nil},
+		{[]string{"imap", "ssh2"}, map[string][]string{"ssh2": {"libssh2-dev"}}},
+		{[]string{"imap"}, map[string][]string{"imap": {"extra-pkg"}}},
+	}
+	for _, c := range cases {
+		runtime := buildCustomExtRuntimeDeps(c.exts, c.userDeps)
+		builder := buildCustomExtBlock(c.exts, c.userDeps)
+		if runtime == "" {
+			t.Errorf("exts=%v deps=%v: runtime block unexpectedly empty", c.exts, c.userDeps)
+			continue
+		}
+		// Every package that appears in the builder block's `apk add` must
+		// also appear in the runtime block.
+		var seen []string
+		for _, ext := range c.exts {
+			seen = append(seen, apkDepsForExt(ext, c.userDeps)...)
+		}
+		for _, pkg := range seen {
+			if !strings.Contains(runtime, " "+pkg+" ") && !strings.HasSuffix(strings.TrimSpace(runtime), pkg+" && rm -rf /var/cache/apk/*") {
+				if !strings.Contains(runtime, pkg) {
+					t.Errorf("exts=%v: runtime block missing pkg %q\n  builder: %s\n  runtime: %s", c.exts, pkg, builder, runtime)
+				}
+			}
+		}
+	}
+}
+
+func TestBuildCustomExtRuntimeDeps_DedupsAcrossExts(t *testing.T) {
+	// Two extensions sharing the same dep (krb5-dev appears in imap's
+	// built-in list and is also a user dep) must list it exactly once.
+	got := buildCustomExtRuntimeDeps(
+		[]string{"imap", "ssh2"},
+		map[string][]string{
+			"imap": {"krb5-dev"},
+			"ssh2": {"krb5-dev", "libssh2-dev"},
+		},
+	)
+	if strings.Count(got, " krb5-dev ") > 1 {
+		t.Errorf("krb5-dev should appear once in the runtime apk list, got:\n%s", got)
+	}
+}
+
 func TestApkDepsForExt_Dedup(t *testing.T) {
 	got := apkDepsForExt("imap", map[string][]string{"imap": {" krb5-dev ", "extra", "", "imap-dev"}})
 	want := []string{"imap-dev", "krb5-dev", "openssl-dev", "c-client", "extra"}

--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -55,21 +55,21 @@ RUN apk update && apk add --no-cache \
         sysvshm \
         xsl \
     && (docker-php-ext-enable opcache || true) \
-    && { (pecl install redis && docker-php-ext-enable redis) \
+    && { (yes '' | pecl install redis && docker-php-ext-enable redis) \
          || (git clone --depth 1 https://github.com/phpredis/phpredis /tmp/phpredis \
              && cd /tmp/phpredis && phpize && ./configure && make -j$(nproc) && make install \
              && docker-php-ext-enable redis \
              && rm -rf /tmp/phpredis) \
          || true; } \
-    && { (pecl install imagick && docker-php-ext-enable imagick) \
+    && { (yes '' | pecl install imagick && docker-php-ext-enable imagick) \
          || (git clone --depth 1 https://github.com/Imagick/imagick /tmp/imagick \
              && cd /tmp/imagick && phpize && ./configure && make -j$(nproc) && make install \
              && docker-php-ext-enable imagick \
              && rm -rf /tmp/imagick) \
          || true; } \
-    && { (pecl install igbinary && docker-php-ext-enable igbinary) || true; } \
-    && { (pecl install mongodb && docker-php-ext-enable mongodb) || true; } \
-    && { (pecl install pcov && docker-php-ext-enable pcov) || true; } \
+    && { (yes '' | pecl install igbinary && docker-php-ext-enable igbinary) || true; } \
+    && { (yes '' | pecl install mongodb && docker-php-ext-enable mongodb) || true; } \
+    && { (yes '' | pecl install pcov && docker-php-ext-enable pcov) || true; } \
     && rm -rf /tmp/pear /var/cache/apk/*
 
 # Xdebug compiled in the builder too. Legacy PHP needs older xdebug majors.
@@ -79,7 +79,7 @@ RUN PHPVER="$(php -r 'echo PHP_MAJOR_VERSION,".",PHP_MINOR_VERSION;')" \
         8.0) XDEBUG_PKG="xdebug-3.3.2" ;; \
         *)   XDEBUG_PKG="xdebug" ;; \
     esac \
-    && pecl install "$XDEBUG_PKG" && docker-php-ext-enable xdebug \
+    && yes '' | pecl install "$XDEBUG_PKG" && docker-php-ext-enable xdebug \
     && rm -rf /tmp/pear /var/cache/apk/*
 
 # Project-defined custom extensions compile here while the toolchain

--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -1,12 +1,16 @@
 FROM docker.io/library/composer:latest AS composer-bin
-FROM docker.io/library/php:{{.Version}}-fpm-alpine
+
+# Builder stage: compile every PHP extension so the build toolchain
+# never lands in the final image. .so files and configs travel into
+# the runtime stage via COPY at the bottom.
+FROM docker.io/library/php:{{.Version}}-fpm-alpine AS builder
 
 RUN apk update && apk add --no-cache \
         autoconf \
         make \
         g++ \
         git \
-        ghostscript \
+        linux-headers \
         curl-dev \
         libzip-dev \
         libpng-dev \
@@ -18,15 +22,12 @@ RUN apk update && apk add --no-cache \
         oniguruma-dev \
         libxml2-dev \
         postgresql-dev \
-        linux-headers \
         imagemagick-dev \
-        imagemagick \
         gmp-dev \
         bzip2-dev \
         openldap-dev \
         sqlite-dev \
         libxslt-dev \
-        mysql-client \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j$(nproc) \
         curl \
@@ -71,29 +72,7 @@ RUN apk update && apk add --no-cache \
     && { (pecl install pcov && docker-php-ext-enable pcov) || true; } \
     && rm -rf /tmp/pear /var/cache/apk/*
 
-# MariaDB client (mysql-client) connecting to lerd MySQL uses self-signed certs;
-# disable SSL verification so CLI tools (mysqldump, schema loading) work out of the box.
-RUN mkdir -p /etc/my.cnf.d && printf '[client]\nssl=0\n' > /etc/my.cnf.d/lerd-no-ssl.cnf
-
-# Install Composer, Node.js, and FFmpeg (used by media libraries like spatie/media-library)
-COPY --from=composer-bin /usr/bin/composer /usr/local/bin/composer
-RUN apk add --no-cache nodejs npm ffmpeg
-
-# Interactive shell for `lerd shell` and the TUI shell action. Ships zsh with
-# a self-contained config (starship prompt, persistent history). Host shell
-# config is intentionally NOT mounted: every developer's host config is
-# different, and sourcing distro-specific paths or host-only binaries
-# cascades into noisy errors. The in-container shell is its own environment.
-RUN apk add --no-cache zsh starship fzf eza bat zoxide \
-    && mkdir -p /etc/zsh /root/.zsh_state \
-    && printf 'export EDITOR=vi\nexport PAGER=less\nexport HISTFILE=/root/.zsh_state/history\nexport HISTSIZE=10000\nexport SAVEHIST=10000\nsetopt INC_APPEND_HISTORY SHARE_HISTORY\nautoload -Uz compinit && compinit -u\nif command -v starship >/dev/null 2>&1; then\n  eval "$(starship init zsh)"\nfi\n' \
-        > /etc/zsh/zshrc
-
-# Override pool: run workers as root, log errors to stderr
-RUN printf '[www]\nuser=root\ngroup=root\ncatch_workers_output=yes\nphp_flag[display_errors]=off\nphp_admin_value[error_log]=/proc/self/fd/2\nphp_admin_flag[log_errors]=on\n' > /usr/local/etc/php-fpm.d/zz-lerd.conf
-
-# Xdebug always installed; mode controlled via mounted ini (mode=off by default).
-# Legacy PHP needs an older line: xdebug 3.2+ requires PHP 8.0+, 3.4+ requires 8.1+.
+# Xdebug compiled in the builder too. Legacy PHP needs older xdebug majors.
 RUN PHPVER="$(php -r 'echo PHP_MAJOR_VERSION,".",PHP_MINOR_VERSION;')" \
     && case "$PHPVER" in \
         7.4) XDEBUG_PKG="xdebug-3.1.6" ;; \
@@ -103,5 +82,69 @@ RUN PHPVER="$(php -r 'echo PHP_MAJOR_VERSION,".",PHP_MINOR_VERSION;')" \
     && pecl install "$XDEBUG_PKG" && docker-php-ext-enable xdebug \
     && rm -rf /tmp/pear /var/cache/apk/*
 
+# Project-defined custom extensions compile here while the toolchain
+# is available. Their .so files travel through the COPY below.
 {{.CustomExtensions}}
+
+# ── Runtime stage ───────────────────────────────────────────────────────────
+FROM docker.io/library/php:{{.Version}}-fpm-alpine
+
+# Runtime libraries only (no -dev headers, no toolchain). PHP's
+# compiled extensions dlopen these. icu-data-full is bulky but
+# i18n needs it.
+RUN apk update && apk add --no-cache \
+        ghostscript \
+        imagemagick \
+        ffmpeg \
+        mysql-client \
+        nodejs \
+        npm \
+        libzip \
+        libpng \
+        libjpeg-turbo \
+        freetype \
+        libwebp \
+        icu-libs \
+        icu-data-full \
+        oniguruma \
+        libxml2 \
+        libpq \
+        gmp \
+        bzip2 \
+        libldap \
+        sqlite-libs \
+        libxslt \
+    && rm -rf /var/cache/apk/*
+
+# Runtime system libs for user-configured custom extensions (e.g.
+# imap needs c-client.so). Empty when no custom exts have apk deps.
+{{.CustomExtensionsRuntime}}
+
+# Compiled extensions + config from the builder stage; ~25 extensions
+# plus xdebug + pecl modules without dragging autoconf/make/g++ across.
+COPY --from=builder /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/
+COPY --from=builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+
+# MariaDB client (mysql-client) connecting to lerd MySQL uses self-signed
+# certs; disable SSL verification so CLI tools (mysqldump, schema loading)
+# work out of the box.
+RUN mkdir -p /etc/my.cnf.d && printf '[client]\nssl=0\n' > /etc/my.cnf.d/lerd-no-ssl.cnf
+
+# Composer from the official image.
+COPY --from=composer-bin /usr/bin/composer /usr/local/bin/composer
+
+# Interactive shell for `lerd shell` and the TUI shell action. Ships zsh
+# with a self-contained config (starship prompt, persistent history).
+# Host shell config is intentionally NOT mounted: every developer's host
+# config is different, and sourcing distro-specific paths or host-only
+# binaries cascades into noisy errors. The in-container shell is its own
+# environment.
+RUN apk add --no-cache zsh starship fzf eza bat zoxide \
+    && mkdir -p /etc/zsh /root/.zsh_state \
+    && printf 'export EDITOR=vi\nexport PAGER=less\nexport HISTFILE=/root/.zsh_state/history\nexport HISTSIZE=10000\nexport SAVEHIST=10000\nsetopt INC_APPEND_HISTORY SHARE_HISTORY\nautoload -Uz compinit && compinit -u\nif command -v starship >/dev/null 2>&1; then\n  eval "$(starship init zsh)"\nfi\n' \
+        > /etc/zsh/zshrc
+
+# Override pool: run workers as root, log errors to stderr
+RUN printf '[www]\nuser=root\ngroup=root\ncatch_workers_output=yes\nphp_flag[display_errors]=off\nphp_admin_value[error_log]=/proc/self/fd/2\nphp_admin_flag[log_errors]=on\n' > /usr/local/etc/php-fpm.d/zz-lerd.conf
+
 {{.MkcertCA}}

--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -133,13 +133,11 @@ RUN mkdir -p /etc/my.cnf.d && printf '[client]\nssl=0\n' > /etc/my.cnf.d/lerd-no
 # Composer from the official image.
 COPY --from=composer-bin /usr/bin/composer /usr/local/bin/composer
 
-# Interactive shell for `lerd shell` and the TUI shell action. Ships zsh
-# with a self-contained config (starship prompt, persistent history).
-# Host shell config is intentionally NOT mounted: every developer's host
-# config is different, and sourcing distro-specific paths or host-only
-# binaries cascades into noisy errors. The in-container shell is its own
-# environment.
-RUN apk add --no-cache zsh starship fzf eza bat zoxide \
+# Interactive shell for lerd shell. zsh/fzf/bat exist on every alpine;
+# starship/eza/zoxide need alpine 3.18+, so legacy php 7.4/8.0 (alpine
+# 3.16) get them via || true and the zshrc inits starship conditionally.
+RUN apk add --no-cache zsh fzf bat \
+    && { apk add --no-cache starship eza zoxide 2>/dev/null || true; } \
     && mkdir -p /etc/zsh /root/.zsh_state \
     && printf 'export EDITOR=vi\nexport PAGER=less\nexport HISTFILE=/root/.zsh_state/history\nexport HISTSIZE=10000\nexport SAVEHIST=10000\nsetopt INC_APPEND_HISTORY SHARE_HISTORY\nautoload -Uz compinit && compinit -u\nif command -v starship >/dev/null 2>&1; then\n  eval "$(starship init zsh)"\nfi\n' \
         > /etc/zsh/zshrc


### PR DESCRIPTION
Stacked on top of #358 (now merged into main). Refactors the PHP-FPM Containerfile into a builder + runtime two-stage build so the ~800MB of autoconf/make/g++/-dev headers used to compile extensions doesn't carry into the final image.

localhost/lerd-php85-fpm:local goes from 1.36 GB to 535 MB after #358's base, a 60% reduction. Same set of PHP extensions loads (68 modules), composer/node/npm/ghostscript/imagemagick/ffmpeg/mysql-client/zsh toolchain all intact.

The custom-extension path needed a small fix. apkDepsForExt installs build-time apk packages in the builder stage, but their compiled .so files need those libs at runtime too (e.g. imap needs c-client to dlopen). A new buildCustomExtRuntimeDeps emits a single apk RUN line in the runtime stage that reinstalls the same packages, so user-added extensions keep working after the refactor.

baseContainerfileHash updated to strip the new {{.CustomExtensionsRuntime}} placeholder so pre-built base image cache keys stay stable.

Also includes a fix for #358's legacy-alpine break: PHP 7.4 and 8.0 pin to alpine 3.16 which doesn't ship starship/eza/zoxide, so their image builds failed after #358 merged. The zsh layer now splits the apk add into a must-have core (zsh, fzf, bat) and an optional set behind || true, so legacy tiers get a degraded but working shell instead of failing the build.