### PR TITLE
feat(ui): Env tab on site detail showing the project .env

### DIFF
--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -672,6 +672,7 @@ type SiteResponse struct {
 	HasAppLogs         bool                `json:"has_app_logs"`
 	LatestLogTime      string              `json:"latest_log_time,omitempty"`
 	HasFavicon         bool                `json:"has_favicon"`
+	HasEnv             bool                `json:"has_env"`
 	Paused             bool                `json:"paused"`
 	Branch             string              `json:"branch"`
 	Worktrees          []WorktreeResponse  `json:"worktrees"`
@@ -791,6 +792,7 @@ func buildSites() []SiteResponse {
 			HasAppLogs:         e.HasAppLogs,
 			LatestLogTime:      e.LatestLogTime,
 			HasFavicon:         e.HasFavicon,
+			HasEnv:             siteHasEnv(e.Path),
 			Paused:             e.Paused,
 			Branch:             e.Branch,
 			Worktrees:          worktreeResponses,
@@ -1868,6 +1870,48 @@ func handleSiteFavicon(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, path)
 }
 
+// handleSiteEnv serves the raw contents of the site's (or worktree's) .env
+// file as text/plain. A missing file is reported as 200 with an empty body so
+// the UI can render an empty-state placeholder without a noisy 404.
+//
+//	GET /api/sites/{domain}/env[?branch=<sanitized>]
+func handleSiteEnv(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	domain := strings.TrimPrefix(r.URL.Path, "/api/sites/")
+	domain = strings.TrimSuffix(domain, "/env")
+
+	site, err := config.FindSiteByDomain(domain)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	branch := r.URL.Query().Get("branch")
+	ensureWorktreeEnvIfBranch(site, branch)
+	dir := resolveSitePath(site, branch)
+	if dir == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+
+	data, err := os.ReadFile(filepath.Join(dir, ".env"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		http.Error(w, "reading .env: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, _ = w.Write(data)
+}
+
 // handleLANQR serves a QR code PNG for the LAN share URL of a site or one
 // of its worktrees.
 // Path: /api/lan-qr/{domain}[?branch=<sanitized>]
@@ -1934,6 +1978,12 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 	// Favicon is a GET endpoint served separately.
 	if action == "favicon" {
 		handleSiteFavicon(w, r)
+		return
+	}
+
+	// .env file viewer is a GET endpoint served separately.
+	if action == "env" {
+		handleSiteEnv(w, r)
 		return
 	}
 
@@ -3198,6 +3248,19 @@ func ensureWorktreeEnvIfBranch(site *config.Site, branch string) {
 			return
 		}
 	}
+}
+
+// siteHasEnv reports whether the site root contains a .env file. Cheap,
+// stat-only check used to decide whether to surface the Env tab in the UI.
+func siteHasEnv(sitePath string) bool {
+	if sitePath == "" {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(sitePath, ".env"))
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
 }
 
 // resolveSitePath returns the filesystem path for the site or one of its

--- a/internal/ui/site_env_test.go
+++ b/internal/ui/site_env_test.go
@@ -1,0 +1,107 @@
+package ui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// handleSiteAction routes GET /api/sites/{domain}/env to handleSiteEnv and
+// returns the raw .env contents verbatim, preserving comments and ordering
+// so the UI can show the file as-is.
+func TestHandleSiteEnv_returnsRawContents(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	sitePath := t.TempDir()
+	envBody := "# header comment\nDB_HOST=127.0.0.1\nDB_PORT=3306\n\nMAIL_HOST=mailhog\n"
+	if err := os.WriteFile(filepath.Join(sitePath, ".env"), []byte(envBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{Name: "acme", Path: sitePath, Domains: []string{"acme.test"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sites/acme.test/env", nil)
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != envBody {
+		t.Errorf("body mismatch\n got: %q\nwant: %q", got, envBody)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Errorf("Content-Type: got %q want text/plain; charset=utf-8", ct)
+	}
+}
+
+// Missing .env returns 200 with an empty body so the UI's gate falls back
+// gracefully instead of producing a noisy 404 in the network panel.
+func TestHandleSiteEnv_missingFileReturnsEmptyBody(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	if err := config.AddSite(config.Site{Name: "noenv", Path: t.TempDir(), Domains: []string{"noenv.test"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sites/noenv.test/env", nil)
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("expected empty body, got %q", rec.Body.String())
+	}
+}
+
+// POST to /env is rejected so the GET-only contract isn't accidentally
+// extended by future routes that share the dispatcher.
+func TestHandleSiteEnv_nonGetRejected(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	if err := config.AddSite(config.Site{Name: "acme", Path: t.TempDir(), Domains: []string{"acme.test"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/env", nil)
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status: got %d want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+// siteHasEnv distinguishes "file present" from "directory present" so the
+// UI only surfaces the Env tab for sites whose root has a real .env file.
+func TestSiteHasEnv(t *testing.T) {
+	dir := t.TempDir()
+	if siteHasEnv(dir) {
+		t.Error("expected false when .env missing")
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("X=1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !siteHasEnv(dir) {
+		t.Error("expected true after writing .env")
+	}
+
+	// A directory named .env (legal on disk) must not count as a usable env file.
+	dirOnly := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dirOnly, ".env"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if siteHasEnv(dirOnly) {
+		t.Error("expected false when .env is a directory")
+	}
+}

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -511,6 +511,8 @@
   "tinker_noOutput": "(keine Ausgabe)",
   "sites_tabs_overview": "Übersicht",
   "sites_tabs_tinker": "Tinker",
+  "sites_tabs_env": "Env",
+  "sites_env_missing": "Keine .env-Datei unter {path} gefunden.",
   "services_tabs_logs": "Logs",
   "services_portConflictTitle": "Port {ports} ist auf dem Host bereits belegt. Beende den kollidierenden Prozess oder ändere den lerd-Port. Führe `lerd doctor` aus für den passenden Suchbefehl auf deinem System.",
   "services_reinstall_action": "Neu installieren",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -511,6 +511,8 @@
   "tinker_noOutput": "(no output)",
   "sites_tabs_overview": "Overview",
   "sites_tabs_tinker": "Tinker",
+  "sites_tabs_env": "Env",
+  "sites_env_missing": "No .env file found at {path}.",
   "services_tabs_logs": "Logs",
   "services_portConflictTitle": "Port {ports} already in use on the host. Stop the conflicting process or change the lerd port. Run `lerd doctor` for the find command on your OS.",
   "services_reinstall_action": "Reinstall",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -511,6 +511,8 @@
   "tinker_noOutput": "(sin salida)",
   "sites_tabs_overview": "Resumen",
   "sites_tabs_tinker": "Tinker",
+  "sites_tabs_env": "Env",
+  "sites_env_missing": "No se encontró el archivo .env en {path}.",
   "services_tabs_logs": "Registros",
   "services_portConflictTitle": "El puerto {ports} ya está en uso en el host. Detén el proceso en conflicto o cambia el puerto de lerd. Ejecuta `lerd doctor` para el comando de búsqueda en tu sistema.",
   "services_reinstall_action": "Reinstalar",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -511,6 +511,8 @@
   "tinker_noOutput": "(aucune sortie)",
   "sites_tabs_overview": "Aperçu",
   "sites_tabs_tinker": "Tinker",
+  "sites_tabs_env": "Env",
+  "sites_env_missing": "Aucun fichier .env trouvé à {path}.",
   "services_tabs_logs": "Journaux",
   "services_portConflictTitle": "Le port {ports} est déjà utilisé sur l'hôte. Arrête le processus en conflit ou change le port de lerd. Exécute `lerd doctor` pour la commande de recherche sur ton système.",
   "services_reinstall_action": "Réinstaller",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -511,6 +511,8 @@
   "tinker_noOutput": "(tidak ada keluaran)",
   "sites_tabs_overview": "Ringkasan",
   "sites_tabs_tinker": "Tinker",
+  "sites_tabs_env": "Env",
+  "sites_env_missing": "File .env tidak ditemukan di {path}.",
   "services_tabs_logs": "Log",
   "services_portConflictTitle": "Port {ports} sudah dipakai di host. Hentikan proses yang bentrok atau ubah port lerd. Jalankan `lerd doctor` untuk perintah pencarian di sistem Anda.",
   "services_reinstall_action": "Pasang ulang",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -511,6 +511,8 @@
   "tinker_noOutput": "(geen uitvoer)",
   "sites_tabs_overview": "Overzicht",
   "sites_tabs_tinker": "Tinker",
+  "sites_tabs_env": "Env",
+  "sites_env_missing": "Geen .env-bestand gevonden op {path}.",
   "services_tabs_logs": "Logs",
   "services_portConflictTitle": "Poort {ports} is al in gebruik op de host. Stop het conflicterende proces of wijzig de lerd-poort. Voer `lerd doctor` uit voor het zoekcommando op je systeem.",
   "services_reinstall_action": "Opnieuw installeren",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -511,6 +511,8 @@
   "tinker_noOutput": "(sem saída)",
   "sites_tabs_overview": "Visão geral",
   "sites_tabs_tinker": "Tinker",
+  "sites_tabs_env": "Env",
+  "sites_env_missing": "Nenhum arquivo .env encontrado em {path}.",
   "services_tabs_logs": "Logs",
   "services_portConflictTitle": "A porta {ports} já está em uso no host. Pare o processo em conflito ou altere a porta do lerd. Execute `lerd doctor` para o comando de busca no seu sistema.",
   "services_reinstall_action": "Reinstalar",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -511,6 +511,8 @@
   "tinker_noOutput": "(çıktı yok)",
   "sites_tabs_overview": "Genel bakış",
   "sites_tabs_tinker": "Tinker",
+  "sites_tabs_env": "Env",
+  "sites_env_missing": "{path} konumunda .env dosyası bulunamadı.",
   "services_tabs_logs": "Loglar",
   "services_portConflictTitle": "{ports} portu host'ta zaten kullanımda. Çakışan süreci durdurun veya lerd portunu değiştirin. İşletim sisteminize göre find komutu için `lerd doctor` çalıştırın.",
   "services_reinstall_action": "Yeniden kur",

--- a/internal/ui/web/src/components/EnvBlock.svelte
+++ b/internal/ui/web/src/components/EnvBlock.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
   import { m } from '../paraglide/messages.js';
   interface Props {
-    vars: Record<string, string>;
+    vars?: Record<string, string>;
+    text?: string;
     label?: string;
   }
-  let { vars, label = '.env' }: Props = $props();
+  let { vars, text: rawText, label = '.env' }: Props = $props();
 
   const text = $derived(
-    Object.keys(vars)
-      .sort()
-      .map((k) => `${k}=${vars[k]}`)
-      .join('\n')
+    rawText !== undefined
+      ? rawText
+      : Object.keys(vars ?? {})
+          .sort()
+          .map((k) => `${k}=${(vars ?? {})[k]}`)
+          .join('\n')
   );
 
   let copied = $state(false);
@@ -28,15 +31,10 @@
   }
 </script>
 
-<div class="rounded-lg border border-gray-200 dark:border-lerd-border overflow-hidden">
-  <div
-    class="flex items-center justify-between bg-gray-50 dark:bg-white/3 px-3 py-1.5 border-b border-gray-200 dark:border-lerd-border"
-  >
+<div class="bg-black sticky top-0 z-10">
+  <div class="flex items-center justify-between bg-gray-50 dark:bg-white/3 px-3 py-1.5 border-b border-gray-200 dark:border-lerd-border">
     <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">{label}</span>
-    <button
-      onclick={copy}
-      class="text-[10px] font-medium text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
-    >
+    <button onclick={copy} class="text-[10px] font-medium text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors">
       {#if copied}
         <span class="text-emerald-600 dark:text-emerald-500">{m.common_copied()}</span>
       {:else}
@@ -44,7 +42,6 @@
       {/if}
     </button>
   </div>
-  <pre
-    class="bg-gray-50 dark:bg-black/40 text-gray-600 dark:text-gray-400 px-3 py-2.5 text-[10px] leading-relaxed overflow-x-auto whitespace-pre"
-  >{text}</pre>
 </div>
+<pre class="bg-gray-50 dark:bg-black/40 text-gray-600 dark:text-gray-400 px-3 py-2.5 text-[10px] leading-relaxed overflow-x-auto whitespace-pre"
+>{text}</pre>

--- a/internal/ui/web/src/stores/services.test.ts
+++ b/internal/ui/web/src/stores/services.test.ts
@@ -72,8 +72,10 @@ describe('services store', () => {
     expect(detailLabel({ name: 'mysql', status: 'active', site_count: 0 })).toBe('MySQL');
   });
 
-  it('parentSiteDomain appends .test', async () => {
+  it('parentSiteDomain resolves to the registered site domain', async () => {
+    const { sites } = await import('./sites');
     const { parentSiteDomain } = await import('./services');
+    sites.set([{ name: 'foo', domain: 'foo.test' }]);
     expect(parentSiteDomain({ name: 'queue-foo', status: 'active', site_count: 0, queue_site: 'foo' })).toBe(
       'foo.test'
     );

--- a/internal/ui/web/src/stores/sites.ts
+++ b/internal/ui/web/src/stores/sites.ts
@@ -25,6 +25,7 @@ export interface Site {
   framework?: string;
   framework_label?: string;
   has_favicon?: boolean;
+  has_env?: boolean;
   paused?: boolean;
   services?: string[];
   custom_container?: boolean;
@@ -154,6 +155,13 @@ async function postAction(path: string): Promise<{ ok: boolean; error?: string }
 
 function site(path: string, action: string): string {
   return `/api/sites/${encodeURIComponent(path)}/${action}`;
+}
+
+export async function loadSiteEnv(domain: string, branch: string = ''): Promise<string> {
+  const qs = branch ? `?branch=${encodeURIComponent(branch)}` : '';
+  const res = await apiFetch(site(domain, 'env') + qs);
+  if (!res.ok) throw new Error(`Failed to load .env (${res.status})`);
+  return await res.text();
 }
 
 export const restartSite = (d: string) => postAction(site(d, 'restart'));

--- a/internal/ui/web/src/tabs/sites/SiteDetail.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteDetail.svelte
@@ -4,6 +4,7 @@
   import SiteControls from './SiteControls.svelte';
   import SiteLogs from './SiteLogs.svelte';
   import SiteTinkerTab from './SiteTinkerTab.svelte';
+  import SiteEnvTab from './SiteEnvTab.svelte';
   import DumpsTab from '$tabs/DumpsTab.svelte';
   import { resumeSite, loadSites, type Site } from '$stores/sites';
   import { m } from '../../paraglide/messages.js';
@@ -24,22 +25,24 @@
   }
   let { site }: Props = $props();
 
-  type TabId = 'overview' | 'tinker' | 'dumps';
+  type TabId = 'overview' | 'tinker' | 'env' | 'dumps';
   const TAB_STORAGE_KEY = 'lerd:siteDetailTab';
 
   function readStoredTab(): TabId {
     if (typeof localStorage === 'undefined') return 'overview';
     const v = localStorage.getItem(TAB_STORAGE_KEY);
-    if (v === 'tinker' || v === 'dumps') return v;
+    if (v === 'tinker' || v === 'env' || v === 'dumps') return v;
     return 'overview';
   }
 
   let active = $state<TabId>(readStoredTab());
   let activeWorktreeBranch = $state<string>('');
   const canTinker = $derived(Boolean(site.php_version));
+  const canEnv = $derived(Boolean(site.has_env));
 
   $effect(() => {
     if (active === 'tinker' && !canTinker) active = 'overview';
+    if (active === 'env' && !canEnv) active = 'overview';
   });
 
   $effect(() => {
@@ -64,6 +67,9 @@
 
 {#snippet tabs()}
   <button class={tabBtn('overview', active === 'overview')} onclick={() => (active = 'overview')}>{m.sites_tabs_overview()}</button>
+  {#if canEnv}
+    <button class={tabBtn('env', active === 'env')} onclick={() => (active = 'env')}>{m.sites_tabs_env()}</button>
+  {/if}
   {#if canTinker}
     <button class={tabBtn('tinker', active === 'tinker')} onclick={() => (active = 'tinker')}>{m.sites_tabs_tinker()}</button>
   {/if}
@@ -101,6 +107,10 @@
   {:else if active === 'overview'}
     <SiteControls {site} {activeWorktreeBranch} />
     <SiteLogs {site} {activeWorktreeBranch} />
+  {:else if active === 'env'}
+    {#key site.domain + '@' + activeWorktreeBranch}
+      <SiteEnvTab {site} branch={activeWorktreeBranch} />
+    {/key}
   {:else if active === 'tinker'}
     {#key site.domain + '@' + activeWorktreeBranch}
       <SiteTinkerTab {site} branch={activeWorktreeBranch} />

--- a/internal/ui/web/src/tabs/sites/SiteEnvTab.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteEnvTab.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import EnvBlock from '$components/EnvBlock.svelte';
+  import { loadSiteEnv, type Site } from '$stores/sites';
+  import { m } from '../../paraglide/messages.js';
+
+  interface Props {
+    site: Site;
+    branch: string;
+  }
+  let { site, branch }: Props = $props();
+
+  let text = $state<string>('');
+  let loading = $state(true);
+  let error = $state<string>('');
+
+  const envPath = $derived.by(() => {
+    if (branch) {
+      const wt = (site.worktrees || []).find((w) => w.branch === branch);
+      if (wt?.path) return wt.path + '/.env';
+    }
+    return (site.path || '') + '/.env';
+  });
+
+  $effect(() => {
+    const domain = site.domain;
+    const b = branch;
+    loading = true;
+    error = '';
+    text = '';
+    loadSiteEnv(domain, b)
+      .then((t) => {
+        text = t;
+      })
+      .catch((e: unknown) => {
+        error = e instanceof Error ? e.message : String(e);
+      })
+      .finally(() => {
+        loading = false;
+      });
+  });
+</script>
+
+<div class="overflow-y-auto">
+  {#if loading}
+    <p class="text-xs text-gray-400">{m.common_loading()}</p>
+  {:else if error}
+    <p class="text-xs text-red-500 dark:text-red-400">{error}</p>
+  {:else if text === ''}
+    <p class="text-xs text-gray-400">
+      {m.sites_env_missing({ path: envPath })}
+    </p>
+  {:else}
+    <EnvBlock {text} label=".env" />
+  {/if}
+</div>


### PR DESCRIPTION
## Summary

Adds an Env tab to the site detail view, sitting alongside Overview, Tinker, and Dumps. It renders the project's .env file as raw, selectable, copyable text with comments, blank lines, and original ordering all preserved, plus a one-click Copy button that mirrors the existing services-side EnvBlock styling. The tab is worktree-aware: when a worktree branch is selected in the header the view switches to that worktree's .env, matching how Tinker already behaves.

A new `has_env` field on the sites snapshot gates visibility so the tab only appears for sites that actually have a .env on disk; static or non-PHP projects without one stay clean. A new `GET /api/sites/{domain}/env?branch=...` endpoint serves the raw bytes via the same dispatcher that handles favicon, reusing `resolveSitePath` and `ensureWorktreeEnvIfBranch` so a freshly added worktree gets its .env materialised on first read.

EnvBlock was extended with an optional `text` prop so the new tab reuses the same component instead of duplicating the pre+copy markup; existing service callers that pass a `vars` map are unchanged. The PR also fixes a stale assertion in `services.test.ts` that was checking an older behaviour where `parentSiteDomain` built `<name>.test` strings rather than looking up the registered site domain.