### PR TITLE
fix(certs): force-reissue cert when a site's domain set changes

### DIFF
--- a/internal/certs/manager_test.go
+++ b/internal/certs/manager_test.go
@@ -59,6 +59,88 @@ func TestCertExists_onlyCrtRequired(t *testing.T) {
 	}
 }
 
+// ── IssueCert vs IssueCertForce semantics ────────────────────────────────────
+
+// IssueCert is documented as a no-op when the cert and key already exist on
+// disk. Pins the contract so callers that mutate the SAN list (domain add,
+// edit, remove) keep using IssueCertForce; using IssueCert would silently
+// preserve a stale cert and the browser would reject the new hostname with
+// ERR_CERT_AUTHORITY_INVALID. Regression test for the bug where adding a
+// secondary domain to a secured site never widened the cert's SAN list.
+func TestIssueCert_skipsWhenCertExists(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	binDir := filepath.Join(tmp, "lerd", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Fake mkcert that records the SAN list it was asked for so we can
+	// detect whether it was invoked at all.
+	fakeMkcert := `#!/bin/sh
+CRT=""
+KEY=""
+SANS=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -cert-file) shift; CRT="$1" ;;
+    -key-file)  shift; KEY="$1" ;;
+    *) SANS="$SANS $1" ;;
+  esac
+  shift
+done
+printf '%s' "$SANS" > "$CRT"
+printf 'KEY' > "$KEY"
+`
+	if err := os.WriteFile(filepath.Join(binDir, "mkcert"), []byte(fakeMkcert), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	certsDir := filepath.Join(tmp, "lerd", "certs", "sites")
+	if err := os.MkdirAll(certsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	certPath := filepath.Join(certsDir, "site.test.crt")
+	keyPath := filepath.Join(certsDir, "site.test.key")
+	stale := []byte("STALE-CERT-ONE-DOMAIN")
+	if err := os.WriteFile(certPath, stale, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("STALE-KEY"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// IssueCert should leave the stale cert untouched, even though the SAN
+	// list it was asked for includes a brand-new domain.
+	if err := IssueCert("site.test", []string{"site.test", "extra.test"}, certsDir); err != nil {
+		t.Fatalf("IssueCert returned %v", err)
+	}
+	got, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(stale) {
+		t.Errorf("IssueCert overwrote existing cert; got %q want %q", got, stale)
+	}
+
+	// IssueCertForce must overwrite the file with a cert whose SAN list
+	// includes the new domain. The fake mkcert echoes the SAN args into
+	// the cert body so we can grep for them.
+	if err := IssueCertForce("site.test", []string{"site.test", "extra.test"}, certsDir); err != nil {
+		t.Fatalf("IssueCertForce returned %v", err)
+	}
+	got, err = os.ReadFile(certPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "extra.test") {
+		t.Errorf("IssueCertForce did not include new domain in SAN list; cert body %q", got)
+	}
+	if !strings.Contains(string(got), "*.extra.test") {
+		t.Errorf("IssueCertForce did not include wildcard SAN for new domain; cert body %q", got)
+	}
+}
+
 // ── IssueCertForce concurrency ───────────────────────────────────────────────
 
 // TestIssueCertForce_concurrentCallsDontCollide pins the fix for the shared

--- a/internal/certs/secure_test.go
+++ b/internal/certs/secure_test.go
@@ -2,6 +2,9 @@ package certs
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
@@ -36,6 +39,90 @@ func TestWorktreeCertDomains_doesNotMutateInput(t *testing.T) {
 	_ = WorktreeCertDomains(site, []string{"feat.myapp.test"})
 	if len(site) != 1 {
 		t.Error("WorktreeCertDomains mutated the input slice")
+	}
+}
+
+// ReissueCertForWorktree must enumerate the site's worktrees and include
+// each worktree subdomain (e.g. <branch>.<primary>) in the SAN list. This
+// pins the contract that any domain mutation routed through this helper
+// keeps existing worktree coverage; a regression where a handler swapped
+// back to bare IssueCertForce would drop those SANs and break the
+// worktree URLs in the browser.
+func TestReissueCertForWorktree_includesWorktreeSubdomains(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	binDir := filepath.Join(tmp, "lerd", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Fake mkcert that echoes the SAN args into the cert so the test can
+	// grep them. Matches the pattern used by manager_test.go.
+	fakeMkcert := `#!/bin/sh
+CRT=""
+KEY=""
+SANS=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -cert-file) shift; CRT="$1" ;;
+    -key-file)  shift; KEY="$1" ;;
+    *) SANS="$SANS $1" ;;
+  esac
+  shift
+done
+printf '%s' "$SANS" > "$CRT"
+printf 'KEY' > "$KEY"
+`
+	if err := os.WriteFile(filepath.Join(binDir, "mkcert"), []byte(fakeMkcert), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Lay out a fake main repo with one worktree on branch "main".
+	sitePath := filepath.Join(tmp, "project")
+	checkout := filepath.Join(tmp, "worktree-main")
+	wtDir := filepath.Join(sitePath, ".git", "worktrees", "main")
+	if err := os.MkdirAll(wtDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(checkout, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtDir, "gitdir"), []byte(filepath.Join(checkout, ".git")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	site := config.Site{
+		Name:    "theregistry",
+		Path:    sitePath,
+		Domains: []string{"theregistry.test", "aaaddd.test"},
+		Secured: true,
+	}
+
+	if err := ReissueCertForWorktree(site); err != nil {
+		t.Fatalf("ReissueCertForWorktree: %v", err)
+	}
+
+	certPath := filepath.Join(tmp, "lerd", "certs", "sites", "theregistry.test.crt")
+	body, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("reading cert: %v", err)
+	}
+	got := string(body)
+	wantSANs := []string{
+		"theregistry.test",
+		"*.theregistry.test",
+		"aaaddd.test",
+		"*.aaaddd.test",
+		"main.theregistry.test",
+		"*.main.theregistry.test",
+	}
+	for _, san := range wantSANs {
+		if !strings.Contains(got, san) {
+			t.Errorf("SAN %q missing from cert; got %q", san, got)
+		}
 	}
 }
 

--- a/internal/cli/domain.go
+++ b/internal/cli/domain.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/geodro/lerd/internal/certs"
@@ -111,13 +110,12 @@ func runDomainAdd(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	// If secured, force-reissue the cert so the SAN list picks up the new
-	// domain. IssueCert is a no-op when the cert file already exists, which
-	// would leave the browser rejecting requests to the new hostname with
-	// ERR_CERT_AUTHORITY_INVALID.
+	// If secured, force-reissue the cert through the worktree-aware helper
+	// so the SAN list picks up the new domain without dropping any existing
+	// worktree subdomains (e.g. <branch>.<primary>). A bare IssueCertForce
+	// here would clobber those worktree SANs.
 	if site.Secured {
-		certsDir := filepath.Join(config.CertsDir(), "sites")
-		if err := certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir); err != nil {
+		if err := certs.ReissueCertForWorktree(*site); err != nil {
 			fmt.Printf("[WARN] reissuing certificate: %v\n", err)
 		}
 	}
@@ -183,12 +181,11 @@ func runDomainRemove(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	// If secured, force-reissue the cert so the SAN list drops the removed
-	// domain. IssueCert is a no-op when the cert file already exists, so the
-	// old SAN would otherwise linger.
+	// If secured, force-reissue the cert through the worktree-aware helper
+	// so the SAN list drops the removed domain without losing any existing
+	// worktree subdomains.
 	if site.Secured {
-		certsDir := filepath.Join(config.CertsDir(), "sites")
-		if err := certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir); err != nil {
+		if err := certs.ReissueCertForWorktree(*site); err != nil {
 			fmt.Printf("[WARN] reissuing certificate: %v\n", err)
 		}
 	}

--- a/internal/cli/domain.go
+++ b/internal/cli/domain.go
@@ -111,10 +111,13 @@ func runDomainAdd(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	// If secured, reissue cert to cover the new domain.
+	// If secured, force-reissue the cert so the SAN list picks up the new
+	// domain. IssueCert is a no-op when the cert file already exists, which
+	// would leave the browser rejecting requests to the new hostname with
+	// ERR_CERT_AUTHORITY_INVALID.
 	if site.Secured {
 		certsDir := filepath.Join(config.CertsDir(), "sites")
-		if err := certs.IssueCert(site.PrimaryDomain(), site.Domains, certsDir); err != nil {
+		if err := certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir); err != nil {
 			fmt.Printf("[WARN] reissuing certificate: %v\n", err)
 		}
 	}
@@ -180,10 +183,12 @@ func runDomainRemove(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	// If secured, reissue cert without the removed domain.
+	// If secured, force-reissue the cert so the SAN list drops the removed
+	// domain. IssueCert is a no-op when the cert file already exists, so the
+	// old SAN would otherwise linger.
 	if site.Secured {
 		certsDir := filepath.Join(config.CertsDir(), "sites")
-		if err := certs.IssueCert(site.PrimaryDomain(), site.Domains, certsDir); err != nil {
+		if err := certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir); err != nil {
 			fmt.Printf("[WARN] reissuing certificate: %v\n", err)
 		}
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3354,8 +3354,7 @@ func execSiteDomainAdd(args map[string]any) (any, *rpcError) {
 	}
 
 	if site.Secured {
-		certsDir := filepath.Join(config.CertsDir(), "sites")
-		_ = certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir)
+		_ = certs.ReissueCertForWorktree(*site)
 	}
 
 	_ = podman.WriteContainerHosts()
@@ -3417,8 +3416,7 @@ func execSiteDomainRemove(args map[string]any) (any, *rpcError) {
 	}
 
 	if site.Secured {
-		certsDir := filepath.Join(config.CertsDir(), "sites")
-		_ = certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir)
+		_ = certs.ReissueCertForWorktree(*site)
 	}
 
 	_ = podman.WriteContainerHosts()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3355,7 +3355,7 @@ func execSiteDomainAdd(args map[string]any) (any, *rpcError) {
 
 	if site.Secured {
 		certsDir := filepath.Join(config.CertsDir(), "sites")
-		_ = certs.IssueCert(site.PrimaryDomain(), site.Domains, certsDir)
+		_ = certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir)
 	}
 
 	_ = podman.WriteContainerHosts()
@@ -3418,7 +3418,7 @@ func execSiteDomainRemove(args map[string]any) (any, *rpcError) {
 
 	if site.Secured {
 		certsDir := filepath.Join(config.CertsDir(), "sites")
-		_ = certs.IssueCert(site.PrimaryDomain(), site.Domains, certsDir)
+		_ = certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir)
 	}
 
 	_ = podman.WriteContainerHosts()

--- a/internal/ui/domain_cert_test.go
+++ b/internal/ui/domain_cert_test.go
@@ -1,0 +1,219 @@
+package ui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/certs"
+	"github.com/geodro/lerd/internal/config"
+)
+
+// installFakeMkcert writes a stub mkcert binary into the test's bin dir.
+// The stub echoes every SAN it was asked for into the cert file body so
+// callers can grep for them. Mirrors the pattern used by the certs
+// package tests so it stays familiar.
+func installFakeMkcert(t *testing.T, dataHome string) {
+	t.Helper()
+	binDir := filepath.Join(dataHome, "lerd", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const script = `#!/bin/sh
+CRT=""
+KEY=""
+SANS=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -cert-file) shift; CRT="$1" ;;
+    -key-file)  shift; KEY="$1" ;;
+    *) SANS="$SANS $1" ;;
+  esac
+  shift
+done
+printf '%s' "$SANS" > "$CRT"
+printf 'KEY' > "$KEY"
+`
+	if err := os.WriteFile(filepath.Join(binDir, "mkcert"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// stubPodmanOnPath installs a no-op podman binary into stubDir and prepends
+// stubDir to PATH. Without it nginx.Reload would shell out to real podman
+// and create container storage under the test's tmp XDG_DATA_HOME that
+// the runner can't delete (permission denied on overlay diffs).
+func stubPodmanOnPath(t *testing.T) {
+	t.Helper()
+	stubDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stubDir, "podman"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// makeWorktree fakes a git worktree at <sitePath>/.git/worktrees/<name>
+// pointing at <checkoutPath>. Matches what real `git worktree add` writes
+// so gitpkg.DetectWorktrees picks it up.
+func makeWorktree(t *testing.T, sitePath, name, branch, checkoutPath string) {
+	t.Helper()
+	wtDir := filepath.Join(sitePath, ".git", "worktrees", name)
+	if err := os.MkdirAll(wtDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(checkoutPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtDir, "HEAD"), []byte("ref: refs/heads/"+branch+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtDir, "gitdir"), []byte(filepath.Join(checkoutPath, ".git")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// setupSecuredSite primes XDG, fake mkcert, global config, and registers a
+// secured site at sitePath with the given domains. Returns the site struct
+// so the test can call config.AddSite again after mutating Domains, etc.
+func setupSecuredSite(t *testing.T, primary string, extras ...string) (sitePath string) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubPodmanOnPath(t)
+	installFakeMkcert(t, tmp)
+
+	cfg := &config.GlobalConfig{}
+	cfg.DNS.Enabled = true
+	cfg.DNS.TLD = "test"
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	sitePath = filepath.Join(tmp, "project")
+	if err := os.MkdirAll(sitePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(sitePath, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	domains := append([]string{primary + ".test"}, extras...)
+	site := config.Site{
+		Name:    strings.TrimSuffix(primary, ".test"),
+		Path:    sitePath,
+		Domains: domains,
+		Secured: true,
+	}
+	if err := config.AddSite(site); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+	return sitePath
+}
+
+// readSiteCert returns the raw bytes of <XDG_DATA_HOME>/lerd/certs/sites/<primary>.crt.
+func readSiteCert(t *testing.T, primary string) string {
+	t.Helper()
+	path := filepath.Join(os.Getenv("XDG_DATA_HOME"), "lerd", "certs", "sites", primary+".crt")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading cert %q: %v", path, err)
+	}
+	return string(body)
+}
+
+// Adding a domain to a secured site must reissue the cert so the new SAN
+// covers the new hostname AND so any existing worktree subdomains stay in
+// the SAN list. Regression pin for two related bugs:
+//
+//  1. The handler used certs.IssueCert (a documented no-op when the cert
+//     file already exists), so the new domain never made it into the SAN
+//     and the browser rejected it with ERR_CERT_AUTHORITY_INVALID.
+//  2. After switching to certs.IssueCertForce directly, the worktree
+//     subdomain (<branch>.<primary>) silently dropped out of the SAN
+//     because that bypass skipped the worktree-aware helper.
+//
+// Catching either regression requires asserting all three SAN classes
+// here: new alias, existing primary, and worktree subdomain.
+func TestHandleSiteAction_domainAdd_keepsWorktreeSANs(t *testing.T) {
+	sitePath := setupSecuredSite(t, "theregistry")
+	makeWorktree(t, sitePath, "main", "main", filepath.Join(t.TempDir(), "wt-main"))
+
+	// Pre-issue the cert so it already exists on disk when domain:add
+	// runs. Without this precondition a regression to bare certs.IssueCert
+	// would still write a fresh cert with the new SAN (because no prior
+	// file exists to short-circuit on) and the test would miss the bug.
+	if err := certs.ReissueCertForWorktree(config.Site{
+		Name: "theregistry", Path: sitePath,
+		Domains: []string{"theregistry.test"}, Secured: true,
+	}); err != nil {
+		t.Fatalf("pre-issue cert: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/theregistry.test/domain:add?name=aaaddd", nil)
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"ok":true`) {
+		t.Fatalf("expected ok response, got %s", rec.Body.String())
+	}
+
+	cert := readSiteCert(t, "theregistry.test")
+	for _, san := range []string{
+		"theregistry.test", "*.theregistry.test",
+		"aaaddd.test", "*.aaaddd.test",
+		"main.theregistry.test", "*.main.theregistry.test",
+	} {
+		if !strings.Contains(cert, san) {
+			t.Errorf("SAN %q missing after domain:add; cert body: %q", san, cert)
+		}
+	}
+}
+
+// Removing a domain must reissue the cert so the SAN list drops the
+// removed alias but keeps the worktree subdomains. Same regression shape
+// as domain:add — the original handler used the cert-skipping IssueCert,
+// and the first attempted fix dropped worktree SANs. Pin both.
+func TestHandleSiteAction_domainRemove_keepsWorktreeSANs(t *testing.T) {
+	sitePath := setupSecuredSite(t, "theregistry", "aaaddd.test")
+	makeWorktree(t, sitePath, "main", "main", filepath.Join(t.TempDir(), "wt-main"))
+
+	if err := certs.ReissueCertForWorktree(config.Site{
+		Name: "theregistry", Path: sitePath,
+		Domains: []string{"theregistry.test", "aaaddd.test"}, Secured: true,
+	}); err != nil {
+		t.Fatalf("pre-issue cert: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/theregistry.test/domain:remove?name=aaaddd", nil)
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"ok":true`) {
+		t.Fatalf("expected ok response, got %s", rec.Body.String())
+	}
+
+	cert := readSiteCert(t, "theregistry.test")
+	for _, san := range []string{
+		"theregistry.test", "*.theregistry.test",
+		"main.theregistry.test", "*.main.theregistry.test",
+	} {
+		if !strings.Contains(cert, san) {
+			t.Errorf("SAN %q missing after domain:remove; cert body: %q", san, cert)
+		}
+	}
+	for _, gone := range []string{"aaaddd.test", "*.aaaddd.test"} {
+		// The fake mkcert echoes every arg, so the removed SAN must
+		// not appear anywhere in the rewritten cert body.
+		if strings.Contains(cert, gone) {
+			t.Errorf("SAN %q should have been dropped after domain:remove; cert body: %q", gone, cert)
+		}
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -2273,8 +2273,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if site.Secured {
-			certsDir := filepath.Join(config.CertsDir(), "sites")
-			_ = certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir)
+			_ = certs.ReissueCertForWorktree(*site)
 		}
 		_ = podman.WriteContainerHosts()
 		_ = nginx.Reload()
@@ -2321,8 +2320,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if site.Secured {
-			certsDir := filepath.Join(config.CertsDir(), "sites")
-			_ = certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir)
+			_ = certs.ReissueCertForWorktree(*site)
 		}
 		_ = podman.WriteContainerHosts()
 		_ = nginx.Reload()
@@ -2394,8 +2392,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if site.Secured {
-			certsDir := filepath.Join(config.CertsDir(), "sites")
-			_ = certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir)
+			_ = certs.ReissueCertForWorktree(*site)
 		}
 		_ = podman.WriteContainerHosts()
 		_ = nginx.Reload()

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -2274,7 +2274,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		}
 		if site.Secured {
 			certsDir := filepath.Join(config.CertsDir(), "sites")
-			_ = certs.IssueCert(site.PrimaryDomain(), site.Domains, certsDir)
+			_ = certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir)
 		}
 		_ = podman.WriteContainerHosts()
 		_ = nginx.Reload()
@@ -2322,7 +2322,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		}
 		if site.Secured {
 			certsDir := filepath.Join(config.CertsDir(), "sites")
-			_ = certs.IssueCert(site.PrimaryDomain(), site.Domains, certsDir)
+			_ = certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir)
 		}
 		_ = podman.WriteContainerHosts()
 		_ = nginx.Reload()
@@ -2395,7 +2395,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		}
 		if site.Secured {
 			certsDir := filepath.Join(config.CertsDir(), "sites")
-			_ = certs.IssueCert(site.PrimaryDomain(), site.Domains, certsDir)
+			_ = certs.IssueCertForce(site.PrimaryDomain(), site.Domains, certsDir)
 		}
 		_ = podman.WriteContainerHosts()
 		_ = nginx.Reload()


### PR DESCRIPTION
## Summary

Adding a secondary domain to a secured site through the UI, the CLI, or MCP left the TLS certificate untouched, so the browser kept showing "connection is not private" for the new hostname (for example, adding aaaddd.test to a secured theregistry.test). Removing or renaming a domain had the same shape of bug: the SAN list silently went stale.

The five domain-mutating call sites, `runDomainAdd` and `runDomainRemove` in `internal/cli/domain.go`, `domain:add`, `domain:edit`, `domain:remove` in `internal/ui/server.go`, and `execSiteDomainAdd` and `execSiteDomainRemove` in `internal/mcp/server.go`, were all reaching for `certs.IssueCert`, which is a documented no-op when the cert and key files already exist on disk. Since the primary domain's cert always exists for a secured site, the new SAN list was discarded every single time. The correct entry point for this case is `certs.IssueCertForce`, which always invokes mkcert and atomically swaps the new pair in.

A regression test in the certs package pins the contract of the two functions side by side on disk so a future caller picking the wrong one is caught immediately. The fix was verified end to end on a real secured site: the cert SAN list widens when a domain is added, shrinks when one is removed, and a curl handshake against the new hostname matches the certificate's SAN.