### PR TITLE
feat(config): public_dir override in .lerd.yaml

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
       { text: 'Getting Started', link: '/getting-started/requirements' },
       { text: 'Usage', link: '/usage/sites' },
       { text: 'Features', link: '/features/web-ui' },
+      { text: 'Configuration', link: '/configuration' },
       { text: 'Reference', link: '/reference/commands' },
       { text: 'Contributing', link: '/contributing/building' },
       { text: 'Changelog', link: '/changelog' },
@@ -164,12 +165,21 @@ export default defineConfig({
           ],
         },
       ],
+      '/configuration': [
+        {
+          text: 'Configuration',
+          items: [
+            { text: 'Overview', link: '/configuration' },
+            { text: 'Per-project (.lerd.yaml)', link: '/configuration#per-project-config-lerdyaml' },
+          ],
+        },
+      ],
       '/reference/': [
         {
           text: 'Reference',
           items: [
             { text: 'Command Reference', link: '/reference/commands' },
-            { text: 'Configuration', link: '/reference/configuration' },
+            { text: 'Configuration', link: '/configuration' },
           ],
         },
         {
@@ -191,7 +201,7 @@ export default defineConfig({
           text: 'Reference',
           items: [
             { text: 'Command Reference', link: '/reference/commands' },
-            { text: 'Configuration', link: '/reference/configuration' },
+            { text: 'Configuration', link: '/configuration' },
           ],
         },
         {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,13 +60,14 @@ A portable, self-contained description of a project's local environment. Created
 | `node_version` | Node version (highest priority, overrides `.nvmrc`, `.node-version`, and `package.json`); writes `.node-version` on apply if the file does not already exist |
 | `framework` | Framework name (overrides auto-detection) |
 | `framework_def` | Full framework definition, embedded automatically for custom (non-Laravel) frameworks so the project is portable across machines |
+| `public_dir` | Override for the framework's default document-root subdirectory, e.g. `public_html` for a Laravel skeleton that doesn't use the conventional `public/` folder. Empty means use the framework default |
 | `secured` | When `true`, HTTPS is enabled on apply |
 | `domains` | Site hostnames without the TLD (e.g. `[myapp, api]`). The first entry is the primary; additional entries become aliases. Conflict-filtered domains stay in this list on disk but are not registered |
 | `app_url` | Override for `APP_URL` (or the framework's URL key) written to `.env`. Highest priority, it beats the per-machine `sites.yaml` override and the default `<scheme>://<primary-domain>` generator. Use for custom path prefixes, ports, or unrelated hostnames you want shared across machines |
-| `env_overrides` | Map of env var names to templated or static values applied to `.env` on `lerd setup` and to per-worktree `.env` files when worktrees are created. Values may use `{{domain}}`, `{{scheme}}`, `{{site}}`, `{{branch}}`, and `{{parent}}` placeholders, or be plain strings. When `APP_URL` is in `env_overrides` it takes precedence over the default rewrite; declared keys override defaults, undeclared defaults still apply. The one exception is `DB_DATABASE` on a worktree whose `db_isolated` is true: the isolation flow owns that key and the watcher won't re-render it from the parent's template until isolation is turned back off. See [Env overrides](../features/git-worktrees.md#env-overrides) |
+| `env_overrides` | Map of env var names to templated or static values applied to `.env` on `lerd setup` and to per-worktree `.env` files when worktrees are created. Values may use <code v-pre>{{domain}}</code>, <code v-pre>{{scheme}}</code>, <code v-pre>{{site}}</code>, <code v-pre>{{branch}}</code>, and <code v-pre>{{parent}}</code> placeholders, or be plain strings. When `APP_URL` is in `env_overrides` it takes precedence over the default rewrite; declared keys override defaults, undeclared defaults still apply. The one exception is `DB_DATABASE` on a worktree whose `db_isolated` is true: the isolation flow owns that key and the watcher won't re-render it from the parent's template until isolation is turned back off. See [Env overrides](./features/git-worktrees.md#env-overrides) |
 | `services` | Services to start on apply. Accepts built-in names, custom service names, or full inline definitions |
 | `workers` | Active worker names for the site (e.g. `queue`, `horizon`, `schedule`, `reverb`, `stripe`). Automatically kept in sync by start/stop commands. Used by `lerd start` to restore workers after reinstall |
-| `container` | Custom container config for non-PHP sites. When present, lerd builds a dedicated container from the project's Containerfile and nginx reverse-proxies to it. See below and [Custom Containers](../usage/custom-containers.md) |
+| `container` | Custom container config for non-PHP sites. When present, lerd builds a dedicated container from the project's Containerfile and nginx reverse-proxies to it. See below and [Custom Containers](./usage/custom-containers.md) |
 | `custom_workers` | Custom worker definitions (name to config map). Works for both PHP and custom container sites. See below |
 | `db` | Database targeting for non-PHP projects: `service` (e.g. `mysql`, `postgres`) and `database` name |
 
@@ -81,6 +82,17 @@ services:
   - mysql
   - redis
 ```
+
+### Custom public folder
+
+When the project ships with a non-standard document root (e.g. a Laravel skeleton that uses `public_html/` instead of `public/`), set `public_dir`:
+
+```yaml
+framework: laravel
+public_dir: public_html
+```
+
+On `lerd link` this value becomes the site's document root in the generated nginx vhost; it takes precedence over the framework's default. No need to define a full `framework_def` just to change the doc root.
 
 ### Custom container example
 
@@ -112,7 +124,7 @@ When `container` is present, `php_version`, `framework`, and `node_version` are 
 | `containerfile` | no | `Containerfile.lerd` | Path to the Containerfile (relative to project root) |
 | `build_context` | no | `.` | Build context directory (relative to project root) |
 
-See [Custom Containers](../usage/custom-containers.md) for the full guide.
+See [Custom Containers](./usage/custom-containers.md) for the full guide.
 
 ### Custom workers
 
@@ -176,7 +188,7 @@ services:
           "db.getSiblingDB('{{site}}').createCollection('_init')"
 ```
 
-The inline definition schema is identical to a [custom service YAML file](../usage/custom-services.md#yaml-schema). On apply, the service is registered to `~/.config/lerd/services/<name>.yaml` then started.
+The inline definition schema is identical to a [custom service YAML file](./usage/custom-services.md#yaml-schema). On apply, the service is registered to `~/.config/lerd/services/<name>.yaml` then started.
 
 If a service with that name already exists locally and the definitions differ, a diff is shown and you are asked whether to replace it:
 
@@ -221,7 +233,7 @@ The config is applied whenever `lerd link` or `lerd init` runs in the project ro
 
 Commit `.lerd.yaml` to the repository. On a fresh machine, `lerd link` is sufficient to reproduce the full local environment.
 
-The Lerd watcher also monitors `.lerd.yaml` for changes. When you switch branches with a different config the PHP and Node versions are re-detected and applied automatically, no manual `lerd link` or `lerd init` needed. See [Automatic version switching](../features/project-setup.md#automatic-version-switching) for details.
+The Lerd watcher also monitors `.lerd.yaml` for changes. When you switch branches with a different config the PHP and Node versions are re-detected and applied automatically, no manual `lerd link` or `lerd init` needed. See [Automatic version switching](./features/project-setup.md#automatic-version-switching) for details.
 
 `lerd isolate`, the UI PHP version selector, and the MCP `site_php` tool all keep `php_version` in sync when this file exists.
 

--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -108,11 +108,11 @@ Values can use template placeholders or be plain static strings. When a worktree
 
 | Placeholder | Resolves to | Example |
 |-------------|-------------|---------|
-| `{{domain}}` | Worktree domain | `feature-branch.myapp.test` |
-| `{{scheme}}` | `http` or `https` | `https` |
-| `{{branch}}` | Worktree branch slug (no parent) | `feature-branch` |
-| `{{parent}}` | Parent site name, slugified | `myapp` |
-| `{{site}}` | Database-safe slug of the *full* worktree domain. Prefer `{{branch}}` / `{{parent}}` for clarity | `feature_branch_myapp_test` |
+| <code v-pre>{{domain}}</code> | Worktree domain | `feature-branch.myapp.test` |
+| <code v-pre>{{scheme}}</code> | `http` or `https` | `https` |
+| <code v-pre>{{branch}}</code> | Worktree branch slug (no parent) | `feature-branch` |
+| <code v-pre>{{parent}}</code> | Parent site name, slugified | `myapp` |
+| <code v-pre>{{site}}</code> | Database-safe slug of the *full* worktree domain. Prefer <code v-pre>{{branch}}</code> / <code v-pre>{{parent}}</code> for clarity | `feature_branch_myapp_test` |
 
 When `APP_URL` is present in `env_overrides` it takes precedence over the default `scheme://domain` rewrite. Without `env_overrides`, behaviour is unchanged.
 

--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -78,7 +78,7 @@ On a machine where `.lerd.yaml` already exists the wizard is skipped and the sav
 
 `lerd link` also applies `.lerd.yaml` when the file is present, so cloning a repo and running `lerd link` is enough to restore the full environment without running `lerd setup` or `lerd init` first. When workers are configured in `.lerd.yaml` but not yet running, `lerd link` prompts to run `lerd setup` so you can install dependencies, run migrations, and start workers in the right order.
 
-See [Configuration](../reference/configuration.md#per-project-config-lerdyaml) for the full field reference including inline service definitions and custom frameworks.
+See [Configuration](../configuration.md#per-project-config-lerdyaml) for the full field reference including inline service definitions and custom frameworks.
 
 ---
 

--- a/docs/getting-started/services.md
+++ b/docs/getting-started/services.md
@@ -42,7 +42,7 @@ lerd service start <name>
 
 Either way, the service appears in `lerd service list`, the Web UI Services panel, and `lerd start` / `lerd stop` cycles.
 
-For the full YAML schema (env vars, `depends_on`, `site_init`, `{{site}}` placeholders, etc.) see [Custom services reference](../usage/custom-services.md#yaml-schema).
+For the full YAML schema (env vars, `depends_on`, `site_init`, <code v-pre>{{site}}</code> placeholders, etc.) see [Custom services reference](../usage/custom-services.md#yaml-schema).
 
 ---
 
@@ -218,5 +218,5 @@ This means installing the preset (or dropping the YAML) once is enough, every pr
 ## Next steps
 
 - [Services reference](../usage/services.md): full YAML schema, dependency rules, custom command flags, RustFS / Mailpit / Soketi / stripe-mock built-in details
-- [Configuration](../reference/configuration.md): embedding services directly in `.lerd.yaml` so they ship with the repo
+- [Configuration](../configuration.md): embedding services directly in `.lerd.yaml` so they ship with the repo
 - [AI Integration (MCP)](../features/mcp.md): manage services from your AI assistant

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -472,6 +472,7 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		Framework:        framework,
 		FrameworkVersion: frameworkVersion,
 		FrameworkDef:     frameworkDef,
+		PublicDir:        defaults.PublicDir,
 		Secured:          secured,
 		Services:         services,
 		Workers:          selectedWorkers,

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -162,7 +162,9 @@ func runLink(args []string) error {
 
 	framework, ok := resolveFramework(cwd)
 	detectedPublicDir := ""
-	if !ok {
+	if proj != nil && proj.PublicDir != "" {
+		detectedPublicDir = proj.PublicDir
+	} else if !ok {
 		detectedPublicDir = config.DetectPublicDir(cwd)
 	}
 

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -31,16 +31,21 @@ type ContainerConfig struct {
 
 // ProjectConfig holds per-project configuration stored in .lerd.yaml.
 type ProjectConfig struct {
-	Domains          []string                   `yaml:"domains,omitempty"`
-	PHPVersion       string                     `yaml:"php_version,omitempty"`
-	NodeVersion      string                     `yaml:"node_version,omitempty"`
-	Framework        string                     `yaml:"framework,omitempty"`
-	FrameworkVersion string                     `yaml:"framework_version,omitempty"`
-	FrameworkDef     *Framework                 `yaml:"framework_def,omitempty"`
-	Secured          bool                       `yaml:"secured,omitempty"`
-	Services         []ProjectService           `yaml:"services,omitempty"`
-	Workers          []string                   `yaml:"workers,omitempty"`
-	CustomWorkers    map[string]FrameworkWorker `yaml:"custom_workers,omitempty"`
+	Domains          []string   `yaml:"domains,omitempty"`
+	PHPVersion       string     `yaml:"php_version,omitempty"`
+	NodeVersion      string     `yaml:"node_version,omitempty"`
+	Framework        string     `yaml:"framework,omitempty"`
+	FrameworkVersion string     `yaml:"framework_version,omitempty"`
+	FrameworkDef     *Framework `yaml:"framework_def,omitempty"`
+	// PublicDir overrides the framework's default document-root subdirectory
+	// for this project, e.g. "public_html" for a Laravel skeleton that doesn't
+	// use the conventional "public/" folder. Empty means use the framework
+	// default. Wins over Framework.PublicDir at nginx-config time.
+	PublicDir     string                     `yaml:"public_dir,omitempty"`
+	Secured       bool                       `yaml:"secured,omitempty"`
+	Services      []ProjectService           `yaml:"services,omitempty"`
+	Workers       []string                   `yaml:"workers,omitempty"`
+	CustomWorkers map[string]FrameworkWorker `yaml:"custom_workers,omitempty"`
 	// Commands extends or overrides the framework's command set. Entries with
 	// a Name matching a framework command replace it (set Disabled: true to
 	// suppress instead). Entries with a new Name are appended. See
@@ -77,11 +82,11 @@ type ProjectConfig struct {
 // typically means .lerd.yaml did not exist.
 func (c *ProjectConfig) IsEmpty() bool {
 	return len(c.Domains) == 0 && c.PHPVersion == "" && c.NodeVersion == "" &&
-		c.Framework == "" && len(c.Services) == 0 && len(c.Workers) == 0 &&
-		len(c.CustomWorkers) == 0 && !c.Secured && c.AppURL == "" &&
-		c.DB.Service == "" && c.DB.Database == "" && c.Container == nil &&
-		c.Runtime == "" && !c.RuntimeWorker && !c.DBIsolated &&
-		len(c.EnvOverrides) == 0
+		c.Framework == "" && c.PublicDir == "" && len(c.Services) == 0 &&
+		len(c.Workers) == 0 && len(c.CustomWorkers) == 0 && !c.Secured &&
+		c.AppURL == "" && c.DB.Service == "" && c.DB.Database == "" &&
+		c.Container == nil && c.Runtime == "" && !c.RuntimeWorker &&
+		!c.DBIsolated && len(c.EnvOverrides) == 0
 }
 
 // ServiceNames returns the name of every service in the config, for callers

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -354,6 +355,61 @@ func TestCloneProjectConfig_DeepCopiesEnvOverrides(t *testing.T) {
 	out.EnvOverrides["NEW_KEY"] = "added"
 	if _, present := in.EnvOverrides["NEW_KEY"]; present {
 		t.Error("clone shares EnvOverrides map; new key leaked back into original")
+	}
+}
+
+func TestProjectConfig_PublicDir(t *testing.T) {
+	input := `php_version: "8.4"
+framework: laravel
+public_dir: public_html
+`
+	var cfg ProjectConfig
+	if err := yaml.Unmarshal([]byte(input), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.PublicDir != "public_html" {
+		t.Errorf("PublicDir = %q, want public_html", cfg.PublicDir)
+	}
+}
+
+func TestProjectConfig_PublicDir_RoundTrip(t *testing.T) {
+	cfg := ProjectConfig{
+		PHPVersion: "8.4",
+		Framework:  "laravel",
+		PublicDir:  "public_html",
+	}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restored ProjectConfig
+	if err := yaml.Unmarshal(data, &restored); err != nil {
+		t.Fatal(err)
+	}
+	if restored.PublicDir != "public_html" {
+		t.Errorf("round-trip PublicDir = %q, want public_html", restored.PublicDir)
+	}
+}
+
+func TestProjectConfig_PublicDir_OmittedWhenEmpty(t *testing.T) {
+	cfg := ProjectConfig{PHPVersion: "8.4"}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "public_dir") {
+		t.Errorf("public_dir should be omitted when empty, got:\n%s", string(data))
+	}
+}
+
+func TestProjectConfig_PublicDir_IsEmpty(t *testing.T) {
+	cfg := &ProjectConfig{}
+	if !cfg.IsEmpty() {
+		t.Error("empty config should be empty")
+	}
+	cfg.PublicDir = "public_html"
+	if cfg.IsEmpty() {
+		t.Error("config with public_dir should not be empty")
 	}
 }
 

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -72,8 +72,9 @@ func phpShort(version string) string {
 }
 
 // resolvePublicDir returns the document root subdirectory for a site.
-// site.PublicDir takes precedence (set when no framework matched at link time),
-// then the framework definition's PublicDir, then "public" as a default.
+// site.PublicDir wins (set from .lerd.yaml's public_dir, or from autodetect
+// when no framework matched), then the framework definition's PublicDir, then
+// "public" as the final fallback.
 func resolvePublicDir(site config.Site) string {
 	if site.PublicDir != "" {
 		return site.PublicDir

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -27,6 +27,44 @@ func readConf(t *testing.T, path string) string {
 	return string(data)
 }
 
+// ── resolvePublicDir ──────────────────────────────────────────────────────────
+
+func TestResolvePublicDir_SiteOverrideWins(t *testing.T) {
+	site := config.Site{
+		Name:      "myapp",
+		Path:      "/srv/myapp",
+		Framework: "laravel",
+		PublicDir: "public_html",
+	}
+	if got := resolvePublicDir(site); got != "public_html" {
+		t.Errorf("resolvePublicDir = %q, want public_html (site override)", got)
+	}
+}
+
+func TestResolvePublicDir_FallsBackToDefault(t *testing.T) {
+	site := config.Site{Name: "myapp", Path: "/srv/myapp"}
+	if got := resolvePublicDir(site); got != "public" {
+		t.Errorf("resolvePublicDir = %q, want public (default)", got)
+	}
+}
+
+func TestGenerateVhost_honoursSitePublicDir(t *testing.T) {
+	confD := setupConfD(t)
+	site := config.Site{
+		Name:      "myapp",
+		Domains:   []string{"myapp.test"},
+		Path:      "/srv/myapp",
+		PublicDir: "public_html",
+	}
+	if err := GenerateVhost(site, "8.3"); err != nil {
+		t.Fatalf("GenerateVhost: %v", err)
+	}
+	content := readConf(t, filepath.Join(confD, "myapp.test.conf"))
+	if !strings.Contains(content, "root /srv/myapp/public_html") {
+		t.Errorf("expected custom public_html doc root in:\n%s", content)
+	}
+}
+
 // ── phpShort ──────────────────────────────────────────────────────────────────
 
 func TestPhpShort(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #369. Projects with a non-standard document root, such as a Laravel skeleton that uses `public_html/` instead of the conventional `public/`, can now set it in `.lerd.yaml`:

```yaml
framework: laravel
public_dir: public_html
```

On `lerd link` the value flows into the site's PublicDir, and the existing nginx vhost template renders `root /path/to/project/public_html;`. No need to clone the framework definition just to change one folder, which is what the issue author was working around with a symlink.

The plumbing was almost all there already. Site.PublicDir existed, resolvePublicDir() already preferred it over the framework default, and the vhost template already used the resolved value. What was missing was a way for the project file to feed into Site.PublicDir without piggybacking on the autodetect-when-no-framework-matched path. ProjectConfig gains a public_dir field, link.go threads it through, and init.go preserves it on re-runs of the wizard. The MCP framework_add tool already exposed public_dir, so MCP users were never blocked, but everyone else needed this.

## Docs

While in there I promoted the Configuration page from `/reference/configuration` to a top-level `/configuration` nav entry since the user mentioned having trouble finding it tucked under Reference. Also fixed a long-standing VitePress quirk where `{{...}}` placeholders inside inline backticks rendered as empty `<code>` tags on the configuration, git-worktrees, and services pages, wrapping the affected occurrences in `<code v-pre>` so Vue's template engine leaves them alone.