### PR TITLE
feat(ui): batch worker failure notifications

### DIFF
--- a/internal/ui/notify_diff.go
+++ b/internal/ui/notify_diff.go
@@ -1,6 +1,10 @@
 package ui
 
 import (
+	"sort"
+	"strconv"
+	"strings"
+
 	"github.com/geodro/lerd/internal/push"
 	"github.com/geodro/lerd/internal/workerheal"
 )
@@ -50,5 +54,55 @@ func notificationForWorkerFailure(w workerheal.UnhealthyWorker) push.Notificatio
 		Data:     map[string]string{"unit": w.Unit, "site": site},
 		Urgency:  "high",
 		TTL:      300,
+	}
+}
+
+// notificationForWorkerFailures collapses a batch of new failures into a
+// single push payload. A one-element batch falls through to the per-unit
+// shape so existing tag-based dedupe on a single worker still works; two
+// or more failures get a grouped title/body and a stable group tag so a
+// later supersedes-an-earlier grouped push doesn't pile up.
+func notificationForWorkerFailures(ws []workerheal.UnhealthyWorker) push.Notification {
+	if len(ws) == 1 {
+		return notificationForWorkerFailure(ws[0])
+	}
+	siteSet := make(map[string]struct{}, len(ws))
+	entries := make([]string, 0, len(ws))
+	for _, w := range ws {
+		site := w.Site
+		if site == "" {
+			site = w.Unit
+		}
+		worker := w.Worker
+		if worker == "" {
+			worker = w.Unit
+		}
+		siteSet[site] = struct{}{}
+		entries = append(entries, worker+"@"+site)
+	}
+	sort.Strings(entries)
+	sites := make([]string, 0, len(siteSet))
+	for s := range siteSet {
+		sites = append(sites, s)
+	}
+	sort.Strings(sites)
+	count := strconv.Itoa(len(ws))
+	workers := strings.Join(entries, ", ")
+	return push.Notification{
+		Kind:     "worker_failed",
+		TitleKey: "notify_worker_failed_group_title",
+		Title:    count + " workers failed",
+		BodyKey:  "notify_worker_failed_group_body",
+		Body:     workers + ". Open lerd to heal.",
+		Params: map[string]string{
+			"count":   count,
+			"workers": workers,
+			"sites":   strings.Join(sites, ", "),
+		},
+		Tag:     "lerd-workers-group",
+		URL:     "#sites",
+		Data:    map[string]string{"count": count},
+		Urgency: "high",
+		TTL:     300,
 	}
 }

--- a/internal/ui/notify_diff_test.go
+++ b/internal/ui/notify_diff_test.go
@@ -56,6 +56,54 @@ func TestNewWorkerFailures_StateChangeIsNotNewFailure(t *testing.T) {
 	}
 }
 
+func TestNotificationForWorkerFailures_SinglePassthrough(t *testing.T) {
+	ws := []workerheal.UnhealthyWorker{uw("lerd-queue-a.service", "a.test", "queue", "failed")}
+	got := notificationForWorkerFailures(ws)
+	if got.TitleKey != "notify_worker_failed_title" {
+		t.Errorf("single failure should use per-unit title key, got %q", got.TitleKey)
+	}
+	if got.Tag != "lerd-worker-lerd-queue-a.service" {
+		t.Errorf("single failure should use per-unit tag, got %q", got.Tag)
+	}
+}
+
+func TestNotificationForWorkerFailures_GroupedShape(t *testing.T) {
+	ws := []workerheal.UnhealthyWorker{
+		uw("lerd-queue-b.service", "b.test", "queue", "failed"),
+		uw("lerd-horizon-a.service", "a.test", "horizon", "start-limit-hit"),
+		uw("lerd-scheduler-a.service", "a.test", "scheduler", "failed"),
+	}
+	got := notificationForWorkerFailures(ws)
+	if got.Kind != "worker_failed" {
+		t.Errorf("Kind = %q", got.Kind)
+	}
+	if got.TitleKey != "notify_worker_failed_group_title" {
+		t.Errorf("TitleKey = %q", got.TitleKey)
+	}
+	if got.BodyKey != "notify_worker_failed_group_body" {
+		t.Errorf("BodyKey = %q", got.BodyKey)
+	}
+	if got.Params["count"] != "3" {
+		t.Errorf("Params.count = %q, want 3", got.Params["count"])
+	}
+	if got.Params["sites"] != "a.test, b.test" {
+		t.Errorf("Params.sites = %q, want sorted a.test, b.test", got.Params["sites"])
+	}
+	wantWorkers := "horizon@a.test, queue@b.test, scheduler@a.test"
+	if got.Params["workers"] != wantWorkers {
+		t.Errorf("Params.workers = %q, want %q", got.Params["workers"], wantWorkers)
+	}
+	if got.Tag != "lerd-workers-group" {
+		t.Errorf("Tag = %q, want stable group tag for supersede", got.Tag)
+	}
+	if got.URL != "#sites" {
+		t.Errorf("URL = %q, want top-level sites view", got.URL)
+	}
+	if got.Title != "3 workers failed" {
+		t.Errorf("Title = %q", got.Title)
+	}
+}
+
 func TestNotificationForWorkerFailure_Shape(t *testing.T) {
 	n := notificationForWorkerFailure(uw("lerd-queue-default-a.service", "a.test", "queue-default", "failed"))
 	if n.Kind != "worker_failed" {

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -611,6 +611,8 @@
   "notify_mail_body": "From: {from}",
   "notify_worker_failed_title": "Worker failed on {site}",
   "notify_worker_failed_body": "{worker} is in {state}. Open lerd to heal.",
+  "notify_worker_failed_group_title": "{count} workers failed",
+  "notify_worker_failed_group_body": "{workers}. Open lerd to heal.",
   "notify_op_done_title": "{op} finished: {service}",
   "notify_op_done_body": "Took {duration}. Click to open lerd.",
   "notify_op_failed_title": "{op} failed: {service}",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -611,6 +611,8 @@
   "notify_mail_body": "From: {from}",
   "notify_worker_failed_title": "Worker failed on {site}",
   "notify_worker_failed_body": "{worker} is in {state}. Open lerd to heal.",
+  "notify_worker_failed_group_title": "{count} workers failed",
+  "notify_worker_failed_group_body": "{workers}. Open lerd to heal.",
   "notify_op_done_title": "{op} finished: {service}",
   "notify_op_done_body": "Took {duration}. Click to open lerd.",
   "notify_op_failed_title": "{op} failed: {service}",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -611,6 +611,8 @@
   "notify_mail_body": "From: {from}",
   "notify_worker_failed_title": "Worker failed on {site}",
   "notify_worker_failed_body": "{worker} is in {state}. Open lerd to heal.",
+  "notify_worker_failed_group_title": "{count} workers failed",
+  "notify_worker_failed_group_body": "{workers}. Open lerd to heal.",
   "notify_op_done_title": "{op} finished: {service}",
   "notify_op_done_body": "Took {duration}. Click to open lerd.",
   "notify_op_failed_title": "{op} failed: {service}",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -611,6 +611,8 @@
   "notify_mail_body": "From: {from}",
   "notify_worker_failed_title": "Worker failed on {site}",
   "notify_worker_failed_body": "{worker} is in {state}. Open lerd to heal.",
+  "notify_worker_failed_group_title": "{count} workers failed",
+  "notify_worker_failed_group_body": "{workers}. Open lerd to heal.",
   "notify_op_done_title": "{op} finished: {service}",
   "notify_op_done_body": "Took {duration}. Click to open lerd.",
   "notify_op_failed_title": "{op} failed: {service}",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -611,6 +611,8 @@
   "notify_mail_body": "From: {from}",
   "notify_worker_failed_title": "Worker failed on {site}",
   "notify_worker_failed_body": "{worker} is in {state}. Open lerd to heal.",
+  "notify_worker_failed_group_title": "{count} workers failed",
+  "notify_worker_failed_group_body": "{workers}. Open lerd to heal.",
   "notify_op_done_title": "{op} finished: {service}",
   "notify_op_done_body": "Took {duration}. Click to open lerd.",
   "notify_op_failed_title": "{op} failed: {service}",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -611,6 +611,8 @@
   "notify_mail_body": "From: {from}",
   "notify_worker_failed_title": "Worker failed on {site}",
   "notify_worker_failed_body": "{worker} is in {state}. Open lerd to heal.",
+  "notify_worker_failed_group_title": "{count} workers failed",
+  "notify_worker_failed_group_body": "{workers}. Open lerd to heal.",
   "notify_op_done_title": "{op} finished: {service}",
   "notify_op_done_body": "Took {duration}. Click to open lerd.",
   "notify_op_failed_title": "{op} failed: {service}",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -611,6 +611,8 @@
   "notify_mail_body": "From: {from}",
   "notify_worker_failed_title": "Worker failed on {site}",
   "notify_worker_failed_body": "{worker} is in {state}. Open lerd to heal.",
+  "notify_worker_failed_group_title": "{count} workers failed",
+  "notify_worker_failed_group_body": "{workers}. Open lerd to heal.",
   "notify_op_done_title": "{op} finished: {service}",
   "notify_op_done_body": "Took {duration}. Click to open lerd.",
   "notify_op_failed_title": "{op} failed: {service}",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -611,6 +611,8 @@
   "notify_mail_body": "Kimden: {from}",
   "notify_worker_failed_title": "{site} sitesinde worker hatası",
   "notify_worker_failed_body": "{worker} {state} durumunda. Onarmak için lerd'i açın.",
+  "notify_worker_failed_group_title": "{count} worker hatası",
+  "notify_worker_failed_group_body": "{workers}. Onarmak için lerd'i açın.",
   "notify_op_done_title": "{op} tamamlandı: {service}",
   "notify_op_done_body": "{duration} sürdü. Lerd'i açmak için tıklayın.",
   "notify_op_failed_title": "{op} başarısız: {service}",

--- a/internal/ui/worker_failure_batcher.go
+++ b/internal/ui/worker_failure_batcher.go
@@ -1,0 +1,61 @@
+package ui
+
+import (
+	"sync"
+	"time"
+
+	"github.com/geodro/lerd/internal/workerheal"
+)
+
+// workerFailureBatchDelay is the quiet window between the first new failure
+// in a burst and the grouped dispatch. Five seconds collapses systemd
+// cascades (start-limit storms, OOM kills hitting several queues at once)
+// into one notification while still feeling immediate for a single failure.
+var workerFailureBatchDelay = 5 * time.Second
+
+// workerFailureDispatch is the sink used by the batcher. Production wires it
+// to dispatchNotification; tests override it to observe the grouped payload
+// without exercising the push subsystem.
+var workerFailureDispatch = func(ws []workerheal.UnhealthyWorker) {
+	dispatchNotification(notificationForWorkerFailures(ws))
+}
+
+var (
+	workerFailureBatchMu    sync.Mutex
+	pendingWorkerFailures   = map[string]workerheal.UnhealthyWorker{}
+	workerFailureFlushTimer *time.Timer
+)
+
+// queueWorkerFailureNotifications buffers the watcher's new-failure delta
+// and arms a single flush timer. The timer is intentionally not reset when
+// more failures arrive inside the window, so the grouped push lands at most
+// workerFailureBatchDelay after the *first* failure in the batch even if
+// new failures keep trickling in.
+func queueWorkerFailureNotifications(ws []workerheal.UnhealthyWorker) {
+	if len(ws) == 0 {
+		return
+	}
+	workerFailureBatchMu.Lock()
+	for _, w := range ws {
+		pendingWorkerFailures[w.Unit] = w
+	}
+	if workerFailureFlushTimer == nil {
+		workerFailureFlushTimer = time.AfterFunc(workerFailureBatchDelay, flushPendingWorkerFailures)
+	}
+	workerFailureBatchMu.Unlock()
+}
+
+func flushPendingWorkerFailures() {
+	workerFailureBatchMu.Lock()
+	ws := make([]workerheal.UnhealthyWorker, 0, len(pendingWorkerFailures))
+	for _, w := range pendingWorkerFailures {
+		ws = append(ws, w)
+	}
+	pendingWorkerFailures = map[string]workerheal.UnhealthyWorker{}
+	workerFailureFlushTimer = nil
+	workerFailureBatchMu.Unlock()
+	if len(ws) == 0 {
+		return
+	}
+	workerFailureDispatch(ws)
+}

--- a/internal/ui/worker_failure_batcher_test.go
+++ b/internal/ui/worker_failure_batcher_test.go
@@ -1,0 +1,139 @@
+package ui
+
+import (
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/geodro/lerd/internal/workerheal"
+)
+
+// installBatchTestSink swaps the dispatcher and shrinks the delay so a real
+// timer flush completes inside the test, then restores both on cleanup.
+func installBatchTestSink(t *testing.T, delay time.Duration) (wait func() [][]workerheal.UnhealthyWorker) {
+	t.Helper()
+	var mu sync.Mutex
+	var calls [][]workerheal.UnhealthyWorker
+	done := make(chan struct{}, 8)
+
+	origDispatch := workerFailureDispatch
+	origDelay := workerFailureBatchDelay
+	workerFailureDispatch = func(ws []workerheal.UnhealthyWorker) {
+		mu.Lock()
+		copyWs := append([]workerheal.UnhealthyWorker(nil), ws...)
+		calls = append(calls, copyWs)
+		mu.Unlock()
+		done <- struct{}{}
+	}
+	workerFailureBatchDelay = delay
+	t.Cleanup(func() {
+		workerFailureDispatch = origDispatch
+		workerFailureBatchDelay = origDelay
+		workerFailureBatchMu.Lock()
+		pendingWorkerFailures = map[string]workerheal.UnhealthyWorker{}
+		if workerFailureFlushTimer != nil {
+			workerFailureFlushTimer.Stop()
+			workerFailureFlushTimer = nil
+		}
+		workerFailureBatchMu.Unlock()
+	})
+	return func() [][]workerheal.UnhealthyWorker {
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for batched dispatch")
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		return calls
+	}
+}
+
+func TestQueueWorkerFailureNotifications_BatchesWithinWindow(t *testing.T) {
+	wait := installBatchTestSink(t, 200*time.Millisecond)
+	queueWorkerFailureNotifications([]workerheal.UnhealthyWorker{
+		uw("lerd-queue-a.service", "a.test", "queue", "failed"),
+	})
+	queueWorkerFailureNotifications([]workerheal.UnhealthyWorker{
+		uw("lerd-horizon-a.service", "a.test", "horizon", "failed"),
+		uw("lerd-scheduler-b.service", "b.test", "scheduler", "failed"),
+	})
+	calls := wait()
+	if len(calls) != 1 {
+		t.Fatalf("expected one grouped dispatch, got %d", len(calls))
+	}
+	got := calls[0]
+	if len(got) != 3 {
+		t.Fatalf("expected 3 batched workers, got %d", len(got))
+	}
+	units := make([]string, len(got))
+	for i, w := range got {
+		units[i] = w.Unit
+	}
+	sort.Strings(units)
+	want := []string{
+		"lerd-horizon-a.service",
+		"lerd-queue-a.service",
+		"lerd-scheduler-b.service",
+	}
+	for i := range want {
+		if units[i] != want[i] {
+			t.Errorf("units[%d] = %q, want %q", i, units[i], want[i])
+		}
+	}
+}
+
+func TestQueueWorkerFailureNotifications_DedupesByUnit(t *testing.T) {
+	wait := installBatchTestSink(t, 200*time.Millisecond)
+	queueWorkerFailureNotifications([]workerheal.UnhealthyWorker{
+		uw("lerd-queue-a.service", "a.test", "queue", "failed"),
+	})
+	queueWorkerFailureNotifications([]workerheal.UnhealthyWorker{
+		uw("lerd-queue-a.service", "a.test", "queue", "start-limit-hit"),
+	})
+	calls := wait()
+	if len(calls) != 1 || len(calls[0]) != 1 {
+		t.Fatalf("expected single dedup'd dispatch, got %+v", calls)
+	}
+	if calls[0][0].State != "start-limit-hit" {
+		t.Errorf("expected last-write-wins state, got %q", calls[0][0].State)
+	}
+}
+
+func TestQueueWorkerFailureNotifications_SecondBurstArmsFreshWindow(t *testing.T) {
+	wait := installBatchTestSink(t, 100*time.Millisecond)
+	queueWorkerFailureNotifications([]workerheal.UnhealthyWorker{
+		uw("lerd-queue-a.service", "a.test", "queue", "failed"),
+	})
+	first := wait()
+	if len(first) != 1 || len(first[0]) != 1 || first[0][0].Unit != "lerd-queue-a.service" {
+		t.Fatalf("first burst dispatch malformed: %+v", first)
+	}
+	// After the first batch has fired and cleared state, a fresh failure
+	// must arm a brand-new window and dispatch independently. Without this
+	// the batcher would silently swallow all post-first-burst notifications.
+	queueWorkerFailureNotifications([]workerheal.UnhealthyWorker{
+		uw("lerd-horizon-b.service", "b.test", "horizon", "failed"),
+	})
+	second := wait()
+	if len(second) != 2 {
+		t.Fatalf("expected two dispatches across two bursts, got %d", len(second))
+	}
+	if len(second[1]) != 1 || second[1][0].Unit != "lerd-horizon-b.service" {
+		t.Errorf("second burst payload wrong: %+v", second[1])
+	}
+}
+
+func TestQueueWorkerFailureNotifications_EmptyNoDispatch(t *testing.T) {
+	origDispatch := workerFailureDispatch
+	defer func() { workerFailureDispatch = origDispatch }()
+	var fired bool
+	workerFailureDispatch = func([]workerheal.UnhealthyWorker) { fired = true }
+	queueWorkerFailureNotifications(nil)
+	queueWorkerFailureNotifications([]workerheal.UnhealthyWorker{})
+	time.Sleep(20 * time.Millisecond)
+	if fired {
+		t.Errorf("empty batch should not arm timer or dispatch")
+	}
+}

--- a/internal/ui/worker_health_watcher.go
+++ b/internal/ui/worker_health_watcher.go
@@ -62,9 +62,7 @@ func runWorkerHealthWatcher() {
 			continue
 		}
 		lastHealthSig.Store(sig)
-		for _, w := range diffNewFailuresAndCommit(unhealthy) {
-			dispatchNotification(notificationForWorkerFailure(w))
-		}
+		queueWorkerFailureNotifications(diffNewFailuresAndCommit(unhealthy))
 		// Skip the eventbus publish when no tab is open; the snapshot
 		// rebuild would just rebuild bytes nobody reads. Notifications
 		// above still fire so closed-PWA users get the push.


### PR DESCRIPTION
## Summary

A systemd cascade like start-limit-hit hitting half a dozen queue workers at once, or an OOM kill taking out every worker for a site in the same tick, used to fire one push per unit and spam the user with five or six near-identical "Worker failed on …" notifications back to back. The watcher detects new failures every five seconds, so the bursts were tightly clustered and unavoidable on the wearer side.

The watcher now hands its new-failure delta to a small batcher that buffers by unit and arms a single five-second flush timer. Failures arriving later in the same window join the in-flight batch without resetting the timer, so the grouped push lands at most five seconds after the first failure even under a sustained cascade. A single isolated failure still goes out with the existing per-unit shape (deep link to the affected site, per-unit tag for browser dedupe), while two or more collapse into one "N workers failed" payload listing every worker@site and tagged lerd-workers-group so a later grouped push supersedes the earlier one in the notification tray instead of stacking.