### PR TITLE
fix(image): restore git in the PHP-FPM runtime stage

### DIFF
--- a/internal/podman/build_test.go
+++ b/internal/podman/build_test.go
@@ -147,6 +147,22 @@ func TestParseApkDeps(t *testing.T) {
 	}
 }
 
+// git is needed at runtime by composer for VCS-typed repositories and
+// any plugin that shells out to it. Re-dropped accidentally by #364.
+func TestPhpFpmContainerfile_RuntimeIncludesGit(t *testing.T) {
+	tmpl, err := GetQuadletTemplate("lerd-php-fpm.Containerfile")
+	if err != nil {
+		t.Fatalf("read containerfile: %v", err)
+	}
+	_, runtime, ok := strings.Cut(tmpl, "# ── Runtime stage")
+	if !ok {
+		t.Fatal("runtime stage marker missing from Containerfile")
+	}
+	if !strings.Contains(runtime, "\n        git \\\n") {
+		t.Errorf("runtime stage must apk add git so composer can clone VCS repos:\n%s", runtime)
+	}
+}
+
 func TestPhpExtensionLoaded(t *testing.T) {
 	out := "Core\ndate\nimap\nPDO\nZend OPcache\n"
 	cases := map[string]bool{

--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -96,6 +96,7 @@ RUN apk update && apk add --no-cache \
         ghostscript \
         imagemagick \
         ffmpeg \
+        git \
         mysql-client \
         nodejs \
         npm \


### PR DESCRIPTION
The multi-stage rebuild in #364 cut image size by moving `git` into the builder stage, where it was only needed for the phpredis/imagick fallback clones. The runtime stage lost it without anyone noticing. Composer falls back to dist for most flows, but VCS-typed repositories declared in `composer.json` hard-require a git clone, and any plugin that shells out to git for tag detection or repo state breaks the same way. Re-adding it to the runtime `apk add` brings the previous behaviour back at the cost of a few megabytes, and a smoke test on the embedded Containerfile catches a future drop.