### PR TITLE
fix(ui): close LAN-reachable endpoints via the existing gate and validate public_dir

### DIFF
--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -930,6 +930,31 @@ func loadBestVersionedFramework(name, preferVersion string) *Framework {
 	return nil
 }
 
+// ValidatePublicDir returns nil when s is a safe relative subdirectory and
+// an error otherwise. A malicious .lerd.yaml could otherwise pivot the nginx
+// document root out of the project with `public_dir: ../../etc`. Callers
+// should reject the config or fall back to the framework default on error.
+func ValidatePublicDir(s string) error {
+	if s == "" || s == "." {
+		return nil
+	}
+	if strings.ContainsRune(s, 0) {
+		return fmt.Errorf("public_dir contains a NUL byte")
+	}
+	if strings.HasPrefix(s, "/") {
+		return fmt.Errorf("public_dir must be relative, got %q", s)
+	}
+	if strings.HasPrefix(s, "~") {
+		return fmt.Errorf("public_dir must not start with ~, got %q", s)
+	}
+	for _, seg := range strings.Split(s, "/") {
+		if seg == ".." {
+			return fmt.Errorf("public_dir must not contain .. segments, got %q", s)
+		}
+	}
+	return nil
+}
+
 // DetectPublicDir inspects dir for a well-known PHP public directory and returns it.
 // It checks directories used by common PHP frameworks in priority order.
 // A candidate is accepted only if it contains an index.php file, ensuring the

--- a/internal/config/framework_test.go
+++ b/internal/config/framework_test.go
@@ -310,3 +310,30 @@ func TestFrameworkLogSource_YAMLRoundTrip(t *testing.T) {
 		t.Errorf("entry 2 format should be empty, got %q", loaded[2].Format)
 	}
 }
+
+// ValidatePublicDir guards the nginx document root from a hostile .lerd.yaml
+// whose public_dir points outside the project, e.g. ../../etc.
+func TestValidatePublicDir(t *testing.T) {
+	good := []string{"", ".", "public", "web", "public_html", "src/public"}
+	for _, s := range good {
+		if err := ValidatePublicDir(s); err != nil {
+			t.Errorf("ValidatePublicDir(%q) = %v, want nil", s, err)
+		}
+	}
+	bad := []string{
+		"..",
+		"../etc",
+		"../../etc",
+		"public/../etc",
+		"public/..",
+		"/etc",
+		"/etc/passwd",
+		"~/.ssh",
+		"public\x00evil",
+	}
+	for _, s := range bad {
+		if err := ValidatePublicDir(s); err == nil {
+			t.Errorf("ValidatePublicDir(%q) = nil, want error", s)
+		}
+	}
+}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -287,6 +287,11 @@ func LoadProjectConfig(dir string) (*ProjectConfig, error) {
 		return nil, err
 	}
 
+	if err := ValidatePublicDir(cfg.PublicDir); err != nil {
+		fmt.Printf("[WARN] %s: %v, ignoring public_dir override\n", path, err)
+		cfg.PublicDir = ""
+	}
+
 	projectConfigCacheMu.Lock()
 	projectConfigCache[path] = projectConfigCacheEntry{
 		cfg: &cfg, mtime: info.ModTime(), size: info.Size(),

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -74,13 +74,18 @@ func phpShort(version string) string {
 // resolvePublicDir returns the document root subdirectory for a site.
 // site.PublicDir wins (set from .lerd.yaml's public_dir, or from autodetect
 // when no framework matched), then the framework definition's PublicDir, then
-// "public" as the final fallback.
+// "public" as the final fallback. Each candidate runs through ValidatePublicDir
+// so a hostile .lerd.yaml can't pivot the nginx root out of the project.
 func resolvePublicDir(site config.Site) string {
 	if site.PublicDir != "" {
-		return site.PublicDir
+		if err := config.ValidatePublicDir(site.PublicDir); err == nil {
+			return site.PublicDir
+		}
 	}
 	if fw, ok := config.GetFrameworkForDir(site.Framework, site.Path); ok && fw.PublicDir != "" {
-		return fw.PublicDir
+		if err := config.ValidatePublicDir(fw.PublicDir); err == nil {
+			return fw.PublicDir
+		}
 	}
 	return "public"
 }

--- a/internal/ui/mailpit_webhook_test.go
+++ b/internal/ui/mailpit_webhook_test.go
@@ -104,6 +104,7 @@ func TestMailpitWebhook_BroadcastsAsGenericNotification(t *testing.T) {
 		"Created": "2026-05-15T10:00:00Z"
 	}`
 	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/mailpit", strings.NewReader(payload))
+	req.RemoteAddr = "127.0.0.1:12345"
 	rec := httptest.NewRecorder()
 	handleMailpitWebhook(rec, req)
 
@@ -155,6 +156,7 @@ func TestMailpitWebhook_AddressOnlySender(t *testing.T) {
 
 	payload := `{"ID":"x","Subject":"","From":{"Address":"bob@example.com"},"Created":""}`
 	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/mailpit", strings.NewReader(payload))
+	req.RemoteAddr = "127.0.0.1:12345"
 	rec := httptest.NewRecorder()
 	handleMailpitWebhook(rec, req)
 
@@ -173,6 +175,7 @@ func TestMailpitWebhook_AddressOnlySender(t *testing.T) {
 
 func TestMailpitWebhook_RejectsGet(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/webhooks/mailpit", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
 	rec := httptest.NewRecorder()
 	handleMailpitWebhook(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
@@ -182,6 +185,7 @@ func TestMailpitWebhook_RejectsGet(t *testing.T) {
 
 func TestMailpitWebhook_RejectsBadJSON(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/mailpit", strings.NewReader("{not json"))
+	req.RemoteAddr = "127.0.0.1:12345"
 	rec := httptest.NewRecorder()
 	handleMailpitWebhook(rec, req)
 	if rec.Code != http.StatusBadRequest {
@@ -191,6 +195,7 @@ func TestMailpitWebhook_RejectsBadJSON(t *testing.T) {
 
 func TestMailpitWebhook_RejectsMissingID(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/mailpit", strings.NewReader(`{"Subject":"x"}`))
+	req.RemoteAddr = "127.0.0.1:12345"
 	rec := httptest.NewRecorder()
 	handleMailpitWebhook(rec, req)
 	if rec.Code != http.StatusBadRequest {

--- a/internal/ui/remote_control.go
+++ b/internal/ui/remote_control.go
@@ -27,6 +27,7 @@ var loopbackOnlyRoutes = []string{
 	"/api/lerd/update-terminal", // spawns a terminal emulator on the host
 	"/api/sites/link",           // links arbitrary host filesystem paths
 	"/api/browse",               // browses host filesystem
+	"/api/push/test",            // fires notifications onto subscribed devices
 }
 
 // loopbackOnlySiteSubactions are the per-site action suffixes (under
@@ -34,6 +35,40 @@ var loopbackOnlyRoutes = []string{
 // path includes a domain segment in the middle, so we check the suffix.
 var loopbackOnlySiteSubactions = []string{
 	"/terminal", // opens an interactive shell on the host
+	"/env",      // returns raw .env (APP_KEY, DB creds, third-party tokens)
+}
+
+// fromHost reports whether r's source IP belongs to one of the host's
+// own interfaces. The mailpit container reaches the dashboard via
+// host.containers.internal, which pasta (Linux) and gvproxy / vmnet
+// (macOS) source-NAT to the host, so lerd-ui sees the request as coming
+// from one of its own addresses. A LAN attacker arrives from a different
+// IP and is rejected. Spoofing a host-owned address would break the TCP
+// handshake because the SYN-ACK routes back into the host rather than
+// reaching the attacker.
+//
+// Interfaces are re-read on every call so VPN attach, WiFi switch, or
+// a late-arriving podman bridge are picked up without a daemon restart.
+// Each call is a few syscalls, fine for webhook-rate traffic.
+func fromHost(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false
+	}
+	for _, a := range addrs {
+		ipNet, ok := a.(*net.IPNet)
+		if !ok || ipNet.IP == nil {
+			continue
+		}
+		if ipNet.IP.String() == host {
+			return true
+		}
+	}
+	return false
 }
 
 // isLoopbackOnlyPath reports whether the given URL path is in either
@@ -96,14 +131,12 @@ func withRemoteControlGate(next http.Handler) http.Handler {
 		}
 
 		// 2b. Mailpit's webhook is POSTed from inside the mailpit container
-		// to host.containers.internal:7073, which arrives at lerd-ui with a
-		// non-loopback source IP (the podman bridge gateway). The handler
-		// itself only triggers a browser notification with the captured
-		// message's id/subject/from, so the worst-case spoofing impact is a
-		// fake notification — no data exposure, no state change. We let it
-		// through pre-auth so a fresh install doesn't need remote-control
-		// credentials to receive mail notifications locally.
-		if r.URL.Path == "/api/webhooks/mailpit" {
+		// to host.containers.internal:7073. pasta (Linux) and gvproxy /
+		// vmnet (macOS) source-NAT that to one of the host's own interface
+		// IPs, so we accept any caller whose source IP belongs to the
+		// host. A LAN attacker arrives from a different IP and is rejected,
+		// closing the "anyone on the WiFi can spam fake mail pushes" vector.
+		if r.URL.Path == "/api/webhooks/mailpit" && fromHost(r) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/ui/remote_control.go
+++ b/internal/ui/remote_control.go
@@ -55,6 +55,15 @@ func fromHost(r *http.Request) bool {
 	if err != nil {
 		host = r.RemoteAddr
 	}
+	// IPv6 link-local sources may carry a zone suffix (fe80::1%eth0);
+	// strip it before parsing so the value compare below works.
+	if i := strings.Index(host, "%"); i != -1 {
+		host = host[:i]
+	}
+	src := net.ParseIP(host)
+	if src == nil {
+		return false
+	}
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
 		return false
@@ -64,7 +73,7 @@ func fromHost(r *http.Request) bool {
 		if !ok || ipNet.IP == nil {
 			continue
 		}
-		if ipNet.IP.String() == host {
+		if src.Equal(ipNet.IP) {
 			return true
 		}
 	}

--- a/internal/ui/remote_control_test.go
+++ b/internal/ui/remote_control_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -265,7 +266,9 @@ func TestRemoteControlGate_loopbackOnlyRoutesBlockedFromLAN(t *testing.T) {
 		"/api/lerd/stop",
 		"/api/sites/link",
 		"/api/sites/myapp.test/terminal",
+		"/api/sites/myapp.test/env",
 		"/api/browse",
+		"/api/push/test",
 	}
 	for _, path := range cases {
 		t.Run(path, func(t *testing.T) {
@@ -342,6 +345,52 @@ func TestRemoteControlGate_unixSocketTreatedAsLoopback(t *testing.T) {
 	}
 	if rec.Code != http.StatusOK {
 		t.Errorf("unix socket status = %d, want 200", rec.Code)
+	}
+}
+
+// The mailpit container POSTs to host.containers.internal:7073 and is
+// source-NAT'd onto one of the host's interface IPs. The gate must let
+// that through pre-auth (so fresh installs receive mail notifications)
+// while still rejecting LAN attackers who arrive from a different IP.
+func TestRemoteControlGate_mailpitWebhookHostAllowedLanBlocked(t *testing.T) {
+	setupConfigDirRaw(t, "", "", false) // LAN off, no creds, default state
+
+	next := &nextHandler{}
+	gate := withRemoteControlGate(next)
+
+	addrs, err := net.InterfaceAddrs()
+	if err != nil || len(addrs) == 0 {
+		t.Skip("no interface addresses available")
+	}
+	var hostIP string
+	for _, a := range addrs {
+		if ipNet, ok := a.(*net.IPNet); ok && ipNet.IP != nil && !ipNet.IP.IsLoopback() {
+			hostIP = ipNet.IP.String()
+			break
+		}
+	}
+	if hostIP == "" {
+		t.Skip("no non-loopback host interface to probe")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/mailpit", nil)
+	req.RemoteAddr = hostIP + ":34567"
+	rec := httptest.NewRecorder()
+	gate.ServeHTTP(rec, req)
+	if !next.called {
+		t.Errorf("mailpit webhook from host IP %s blocked, status=%d", hostIP, rec.Code)
+	}
+
+	next.called = false
+	req2 := httptest.NewRequest(http.MethodPost, "/api/webhooks/mailpit", nil)
+	req2.RemoteAddr = "198.51.100.42:34567"
+	rec2 := httptest.NewRecorder()
+	gate.ServeHTTP(rec2, req2)
+	if next.called {
+		t.Error("mailpit webhook from LAN reached handler — should 403")
+	}
+	if rec2.Code != http.StatusForbidden {
+		t.Errorf("LAN mailpit status = %d, want 403", rec2.Code)
 	}
 }
 

--- a/internal/ui/remote_control_test.go
+++ b/internal/ui/remote_control_test.go
@@ -355,48 +355,92 @@ func TestRemoteControlGate_unixSocketTreatedAsLoopback(t *testing.T) {
 func TestRemoteControlGate_mailpitWebhookHostAllowedLanBlocked(t *testing.T) {
 	setupConfigDirRaw(t, "", "", false) // LAN off, no creds, default state
 
-	next := &nextHandler{}
-	gate := withRemoteControlGate(next)
-
 	addrs, err := net.InterfaceAddrs()
 	if err != nil || len(addrs) == 0 {
 		t.Skip("no interface addresses available")
 	}
-	var hostIP string
+	var v4, v6 string
 	for _, a := range addrs {
 		ipNet, ok := a.(*net.IPNet)
 		if !ok || ipNet.IP == nil || ipNet.IP.IsLoopback() {
 			continue
 		}
-		// Prefer IPv4 to avoid IPv6 link-local zone-suffix complications
-		// that differ between Linux and macOS test runners.
-		if ipNet.IP.To4() != nil {
-			hostIP = ipNet.IP.String()
-			break
+		if ipNet.IP.To4() != nil && v4 == "" {
+			v4 = ipNet.IP.String()
+		} else if ipNet.IP.To4() == nil && v6 == "" {
+			v6 = ipNet.IP.String()
 		}
 	}
-	if hostIP == "" {
-		t.Skip("no non-loopback IPv4 host interface to probe")
+
+	allowCases := []struct{ name, ip string }{}
+	if v4 != "" {
+		allowCases = append(allowCases, struct{ name, ip string }{"v4", v4})
+	}
+	if v6 != "" {
+		allowCases = append(allowCases, struct{ name, ip string }{"v6", v6})
+	}
+	if len(allowCases) == 0 {
+		t.Skip("no non-loopback host interfaces to probe")
+	}
+	for _, c := range allowCases {
+		t.Run("allow_"+c.name, func(t *testing.T) {
+			next := &nextHandler{}
+			gate := withRemoteControlGate(next)
+			req := httptest.NewRequest(http.MethodPost, "/api/webhooks/mailpit", nil)
+			req.RemoteAddr = net.JoinHostPort(c.ip, "34567")
+			rec := httptest.NewRecorder()
+			gate.ServeHTTP(rec, req)
+			if !next.called {
+				t.Errorf("mailpit webhook from host IP %s blocked, status=%d", c.ip, rec.Code)
+			}
+		})
 	}
 
+	denyCases := []struct{ name, ip string }{
+		{"v4_lan", "198.51.100.42"},
+		{"v6_documentation", "2001:db8::1"},
+	}
+	for _, c := range denyCases {
+		t.Run("deny_"+c.name, func(t *testing.T) {
+			next := &nextHandler{}
+			gate := withRemoteControlGate(next)
+			req := httptest.NewRequest(http.MethodPost, "/api/webhooks/mailpit", nil)
+			req.RemoteAddr = net.JoinHostPort(c.ip, "34567")
+			rec := httptest.NewRecorder()
+			gate.ServeHTTP(rec, req)
+			if next.called {
+				t.Errorf("mailpit webhook from non-host %s reached handler, want 403", c.ip)
+			}
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("status = %d, want 403", rec.Code)
+			}
+		})
+	}
+}
+
+// fromHost must compare by IP value so an IPv6 source carrying a zone
+// suffix (fe80::1%eth0) still matches the zoneless interface address.
+func TestFromHost_acceptsZonedIPv6Source(t *testing.T) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		t.Skip("no interface addresses available")
+	}
+	var v6 string
+	for _, a := range addrs {
+		ipNet, ok := a.(*net.IPNet)
+		if !ok || ipNet.IP == nil || ipNet.IP.To4() != nil {
+			continue
+		}
+		v6 = ipNet.IP.String()
+		break
+	}
+	if v6 == "" {
+		t.Skip("no IPv6 interface address to probe")
+	}
 	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/mailpit", nil)
-	req.RemoteAddr = net.JoinHostPort(hostIP, "34567")
-	rec := httptest.NewRecorder()
-	gate.ServeHTTP(rec, req)
-	if !next.called {
-		t.Errorf("mailpit webhook from host IP %s blocked, status=%d", hostIP, rec.Code)
-	}
-
-	next.called = false
-	req2 := httptest.NewRequest(http.MethodPost, "/api/webhooks/mailpit", nil)
-	req2.RemoteAddr = net.JoinHostPort("198.51.100.42", "34567")
-	rec2 := httptest.NewRecorder()
-	gate.ServeHTTP(rec2, req2)
-	if next.called {
-		t.Error("mailpit webhook from LAN reached handler — should 403")
-	}
-	if rec2.Code != http.StatusForbidden {
-		t.Errorf("LAN mailpit status = %d, want 403", rec2.Code)
+	req.RemoteAddr = "[" + v6 + "%eth0]:34567"
+	if !fromHost(req) {
+		t.Errorf("fromHost rejected zoned IPv6 source %s%%eth0", v6)
 	}
 }
 

--- a/internal/ui/remote_control_test.go
+++ b/internal/ui/remote_control_test.go
@@ -375,6 +375,11 @@ func TestRemoteControlGate_mailpitWebhookHostAllowedLanBlocked(t *testing.T) {
 	allowCases := []struct{ name, ip string }{}
 	if v4 != "" {
 		allowCases = append(allowCases, struct{ name, ip string }{"v4", v4})
+		// A v6-only client that connects to a v4 listener arrives with the
+		// v4-mapped form (::ffff:HOSTV4). fromHost relies on IP.Equal to
+		// normalise across both shapes; pin it here so a future readers
+		// don't reintroduce a string compare and break this path.
+		allowCases = append(allowCases, struct{ name, ip string }{"v4_mapped_v6", "::ffff:" + v4})
 	}
 	if v6 != "" {
 		allowCases = append(allowCases, struct{ name, ip string }{"v6", v6})

--- a/internal/ui/remote_control_test.go
+++ b/internal/ui/remote_control_test.go
@@ -364,17 +364,23 @@ func TestRemoteControlGate_mailpitWebhookHostAllowedLanBlocked(t *testing.T) {
 	}
 	var hostIP string
 	for _, a := range addrs {
-		if ipNet, ok := a.(*net.IPNet); ok && ipNet.IP != nil && !ipNet.IP.IsLoopback() {
+		ipNet, ok := a.(*net.IPNet)
+		if !ok || ipNet.IP == nil || ipNet.IP.IsLoopback() {
+			continue
+		}
+		// Prefer IPv4 to avoid IPv6 link-local zone-suffix complications
+		// that differ between Linux and macOS test runners.
+		if ipNet.IP.To4() != nil {
 			hostIP = ipNet.IP.String()
 			break
 		}
 	}
 	if hostIP == "" {
-		t.Skip("no non-loopback host interface to probe")
+		t.Skip("no non-loopback IPv4 host interface to probe")
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/mailpit", nil)
-	req.RemoteAddr = hostIP + ":34567"
+	req.RemoteAddr = net.JoinHostPort(hostIP, "34567")
 	rec := httptest.NewRecorder()
 	gate.ServeHTTP(rec, req)
 	if !next.called {
@@ -383,7 +389,7 @@ func TestRemoteControlGate_mailpitWebhookHostAllowedLanBlocked(t *testing.T) {
 
 	next.called = false
 	req2 := httptest.NewRequest(http.MethodPost, "/api/webhooks/mailpit", nil)
-	req2.RemoteAddr = "198.51.100.42:34567"
+	req2.RemoteAddr = net.JoinHostPort("198.51.100.42", "34567")
 	rec2 := httptest.NewRecorder()
 	gate.ServeHTTP(rec2, req2)
 	if next.called {

--- a/internal/ui/site_env_test.go
+++ b/internal/ui/site_env_test.go
@@ -27,6 +27,7 @@ func TestHandleSiteEnv_returnsRawContents(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/sites/acme.test/env", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
 
@@ -52,6 +53,7 @@ func TestHandleSiteEnv_missingFileReturnsEmptyBody(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/sites/noenv.test/env", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
 


### PR DESCRIPTION
Three dashboard endpoints leaked through the LAN-exposed listener. `GET /api/sites/{domain}/env` handed out the raw `.env` (APP_KEY, DB credentials, third-party tokens) once the user enabled `lan:expose`. `POST /api/push/test` let a LAN attacker spam pushes onto subscribed devices. `POST /api/webhooks/mailpit` was passing through the remote-control gate unconditionally, so anyone reachable from the host could fire fake mail notifications with attacker-controlled subject and from.

The first two now ride the existing `loopbackOnlyRoutes` and `loopbackOnlySiteSubactions` lists in `withRemoteControlGate`, so they 403 from non-loopback callers regardless of whether LAN exposure or remote-control credentials are configured. The mailpit bypass keeps the pre-auth path mailpit needs but tightens the check to `fromHost(r)`, which verifies the source IP belongs to one of the host's interfaces. pasta on Linux and gvproxy or vmnet on macOS source-NAT the mailpit container to the host's own address, so the bypass still works for the legitimate path. A LAN attacker arrives from a different IP and is rejected. Spoofing a host-owned IP from off-host fails because the TCP handshake's SYN-ACK routes back into the host instead of reaching the attacker.

A separate vector ran through `.lerd.yaml`'s `public_dir` override added in #370. The nginx vhost template concatenates it into `root {{.Path}}/{{.PublicDir}};`, and nothing was rejecting `"../../etc"` before it landed there, so cloning a hostile repo into a parked directory pivoted the document root out of the project. `ValidatePublicDir` now rejects absolute paths, leading `~`, NUL bytes, and any segment of `..`. `LoadProjectConfig` calls it and silently falls back to the framework default with a warn when the value is bad, and `resolvePublicDir` double-checks at the nginx render layer as defence in depth.