### PR TITLE
fix(presets): wire catatonit as PID 1 for mysql and mariadb

### DIFF
--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -130,6 +130,12 @@ type CustomService struct {
 	// of embedding it as an iframe. Use for admin UIs that set session
 	// cookies the iframe can't carry across origins (e.g. RabbitMQ Cowboy).
 	DashboardExternal bool `yaml:"dashboard_external,omitempty" json:"dashboard_external,omitempty"`
+	// Init injects podman's catatonit as PID 1 (--init) so SIGTERM gets
+	// forwarded to the container's main process. Required for images whose
+	// main binary (e.g. mysqld in mysql:8.4) doesn't install a signal
+	// handler when it runs as PID 1, which makes podman stop time out and
+	// systemctl restart wedge for ~90s.
+	Init bool `yaml:"init,omitempty" json:"init,omitempty"`
 }
 
 // ServiceFilePath returns the deterministic host path for a single FileMount

--- a/internal/config/presets/mariadb.yaml
+++ b/internal/config/presets/mariadb.yaml
@@ -2,6 +2,7 @@ name: mariadb
 description: MariaDB (MySQL-compatible) versions
 family: mariadb
 default_version: "11"
+init: true
 versions:
   - tag: "11"
     label: "11 (latest)"

--- a/internal/config/presets/mysql.yaml
+++ b/internal/config/presets/mysql.yaml
@@ -5,6 +5,7 @@ track_latest: true
 description: MySQL database
 family: mysql
 default_version: "8.4"
+init: true
 versions:
   - tag: "9.7"
     label: "9.7 LTS"

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -193,6 +193,9 @@ func TestLoadPreset_MySQL_MultiVersion(t *testing.T) {
 	if p.DefaultVersion != "8.4" {
 		t.Errorf("DefaultVersion should be 8.4 (the canonical LTS default), got %q", p.DefaultVersion)
 	}
+	if !p.Init {
+		t.Error("mysql preset must set init: true so PID 1 catches SIGTERM (issue #380)")
+	}
 }
 
 func TestPresetResolve_MultiVersion(t *testing.T) {
@@ -586,6 +589,9 @@ func TestPresetCanonicalTag(t *testing.T) {
 	}
 	if got := pm.CanonicalTag(); got != "" {
 		t.Errorf("mariadb has no canonical, CanonicalTag() = %q, want empty", got)
+	}
+	if !pm.Init {
+		t.Error("mariadb preset must set init: true so PID 1 catches SIGTERM (mysql fork, same issue as #380)")
 	}
 }
 

--- a/internal/podman/quadlet_embed_test.go
+++ b/internal/podman/quadlet_embed_test.go
@@ -264,6 +264,33 @@ func TestGenerateCustomQuadlet_NoShareHosts(t *testing.T) {
 	}
 }
 
+// mysql 8.4 runs mysqld as PID 1 and the kernel won't deliver SIGTERM
+// to a PID 1 process that hasn't installed a handler; podman stop times
+// out and systemctl restart wedges. --init wires catatonit in as PID 1
+// to forward signals — issue #380.
+func TestGenerateCustomQuadlet_InitTrueEmitsPodmanArgs(t *testing.T) {
+	svc := &config.CustomService{
+		Name:  "mysql",
+		Image: "docker.io/library/mysql:8.4",
+		Init:  true,
+	}
+	out := GenerateCustomQuadlet(svc)
+	if !strings.Contains(out, "PodmanArgs=--init\n") {
+		t.Errorf("Init=true must emit PodmanArgs=--init, got:\n%s", out)
+	}
+}
+
+func TestGenerateCustomQuadlet_InitFalseOmitsPodmanArgs(t *testing.T) {
+	svc := &config.CustomService{
+		Name:  "postgres",
+		Image: "docker.io/library/postgres:18",
+	}
+	out := GenerateCustomQuadlet(svc)
+	if strings.Contains(out, "PodmanArgs=--init") {
+		t.Errorf("Init=false must omit --init, got:\n%s", out)
+	}
+}
+
 func TestGenerateCustomQuadlet_UsernsAndChownData(t *testing.T) {
 	svc := &config.CustomService{
 		Name:      "elasticsearch",

--- a/internal/podman/quadlet_generate.go
+++ b/internal/podman/quadlet_generate.go
@@ -37,6 +37,13 @@ func GenerateCustomQuadlet(svc *config.CustomService) string {
 		b.WriteString("PodmanArgs=--stop-timeout=5\n")
 	}
 
+	// catatonit as PID 1 so SIGTERM reaches the main process. Without
+	// this, mysqld in 8.4 ignores podman stop and restarts time out at
+	// 90s (issue #380).
+	if svc.Init {
+		b.WriteString("PodmanArgs=--init\n")
+	}
+
 	if svc.ShareHosts {
 		fmt.Fprintf(&b, "Volume=%s:/etc/hosts:ro,z\n", config.BrowserHostsFile())
 	}


### PR DESCRIPTION
`mysqld` in `mysql:8.4` doesn't install a SIGTERM handler when it runs as PID 1, so `podman stop` waits the full grace window and `systemctl restart` wedges around the 30 to 90 second mark. The same shape affects the mariadb image (mysql fork, same daemon entrypoint).

The fix adds an `init` flag to the preset schema (via the inline `CustomService`), threads it into the quadlet generator as `PodmanArgs=--init`, and turns it on for the mysql and mariadb presets. Podman injects catatonit as PID 1, mysqld lands at PID 2 with its normal signal-handling thread intact, `podman stop` completes cleanly, and `lerd service restart` returns instead of timing out.

The flag is opt-in per preset. postgres, redis, and the rest of the bundled services already handle PID 1 signals correctly so they keep the existing shape. Custom services can opt in via `init: true` in their `.lerd.yaml`.

Upgrade behaviour: the rendered `.container` file regenerates on the next `lerd start` or `lerd install`, which `daemon-reload`s systemd. The currently-running mysql container is still on the old shape, so the very next restart pays the old slow path once, and every restart after that is fast. A reboot picks up the new shape without any slow restart.

Addresses #380.