### PR TITLE
fix(ui): notification clicks land on the right tab

### DIFF
--- a/internal/ui/notify_diff.go
+++ b/internal/ui/notify_diff.go
@@ -5,9 +5,24 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/push"
 	"github.com/geodro/lerd/internal/workerheal"
 )
+
+// siteDomainForRoute resolves a registered site name to its primary domain
+// so the notification URL can be opened by the dashboard's hash router,
+// which keys the Sites tab by domain. Falls back to the input when no
+// registered site matches (test fixtures, races between unlink and a
+// late-arriving notification).
+func siteDomainForRoute(name string) string {
+	if s, err := config.FindSite(name); err == nil && s != nil {
+		if d := s.PrimaryDomain(); d != "" {
+			return d
+		}
+	}
+	return name
+}
 
 // newWorkerFailures returns workers in cur whose Unit names weren't in prev.
 // Identity by unit only — a state change on a known-failed unit doesn't
@@ -50,7 +65,7 @@ func notificationForWorkerFailure(w workerheal.UnhealthyWorker) push.Notificatio
 		Body:     worker + " is in " + state + ". Open lerd to heal.",
 		Params:   map[string]string{"site": site, "worker": worker, "state": state},
 		Tag:      "lerd-worker-" + w.Unit,
-		URL:      "#sites/" + site,
+		URL:      "#sites/" + siteDomainForRoute(site),
 		Data:     map[string]string{"unit": w.Unit, "site": site},
 		Urgency:  "high",
 		TTL:      300,

--- a/internal/ui/notify_diff_test.go
+++ b/internal/ui/notify_diff_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"testing"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/workerheal"
 )
 
@@ -129,5 +130,26 @@ func TestNotificationForWorkerFailure_Shape(t *testing.T) {
 	}
 	if n.URL == "" {
 		t.Errorf("URL is empty; need a deep-link target")
+	}
+}
+
+// The Sites tab keys by primary domain, but workerheal.UnhealthyWorker.Site
+// is the registered site name. The notification URL must resolve name to
+// domain so the click handler lands on the matching site, not an empty
+// state when name != domain (e.g. whitewaters / theregistry.test).
+func TestNotificationForWorkerFailure_URLResolvesNameToDomain(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := config.AddSite(config.Site{
+		Name:    "whitewaters",
+		Domains: []string{"theregistry.test"},
+		Path:    t.TempDir(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	n := notificationForWorkerFailure(uw("lerd-queue-whitewaters.service", "whitewaters", "queue", "failed"))
+	if n.URL != "#sites/theregistry.test" {
+		t.Errorf("URL = %q, want #sites/theregistry.test", n.URL)
 	}
 }

--- a/internal/ui/notify_dumps.go
+++ b/internal/ui/notify_dumps.go
@@ -90,7 +90,7 @@ func notificationForDump(evt dumps.Event) push.Notification {
 			"text": body,
 		},
 		Tag:     "lerd-dump-" + site,
-		URL:     "#dumps",
+		URL:     "#sites/" + siteDomainForRoute(site) + "/dumps",
 		Data:    map[string]string{"site": site, "id": evt.ID},
 		Urgency: "low",
 		TTL:     60,

--- a/internal/ui/notify_dumps_test.go
+++ b/internal/ui/notify_dumps_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dumps"
 )
 
@@ -20,7 +21,10 @@ func TestNotificationForDump_Shape(t *testing.T) {
 	if n.Params["kind"] != "fpm" {
 		t.Errorf("Params.kind = %q", n.Params["kind"])
 	}
-	if n.URL != "#dumps" {
+	// No site is registered with that name in this test, so siteDomainForRoute
+	// falls back to the input verbatim. The URL still lands on a sites sub-tab
+	// route shape the frontend can parse.
+	if n.URL != "#sites/astrolov.test/dumps" {
 		t.Errorf("URL = %q", n.URL)
 	}
 }
@@ -115,5 +119,27 @@ func TestDumpDebouncer_DifferentSitesIndependent(t *testing.T) {
 	}
 	if !d.allow("b.test") {
 		t.Error("b.test should pass independently of a.test")
+	}
+}
+
+// The dump-bridge tags Ctx.Site with the registered site name (the value
+// of LERD_SITE), but the dashboard router keys the Sites tab by primary
+// domain. notificationForDump must resolve name → primary domain so the
+// click handler lands on the right site detail.
+func TestNotificationForDump_URLResolvesNameToDomain(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := config.AddSite(config.Site{
+		Name:    "whitewaters",
+		Domains: []string{"theregistry.test"},
+		Path:    t.TempDir(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	evt := dumps.Event{ID: "z", Kind: "dump", Ctx: dumps.Context{Site: "whitewaters", Type: "fpm"}}
+	n := notificationForDump(evt)
+	if n.URL != "#sites/theregistry.test/dumps" {
+		t.Errorf("URL = %q, want #sites/theregistry.test/dumps", n.URL)
 	}
 }

--- a/internal/ui/web/src/tabs/SitesDetail.svelte
+++ b/internal/ui/web/src/tabs/SitesDetail.svelte
@@ -5,7 +5,11 @@
   import SiteDetail from './sites/SiteDetail.svelte';
   import { m } from '../paraglide/messages.js';
 
-  const selected = $derived($routeRest);
+  // routeRest may be "<domain>" or "<domain>/<subtab>" (e.g. dump notification
+  // deep-links into the per-site dumps view). The sub-tab is handled inside
+  // SiteDetail; here we just match the first segment as the site domain.
+  const parts = $derived($routeRest.split('/'));
+  const selected = $derived(parts[0] ?? '');
   const site = $derived($sites.find((s) => s.domain === selected));
 </script>
 

--- a/internal/ui/web/src/tabs/sites/SiteDetail.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteDetail.svelte
@@ -7,6 +7,7 @@
   import SiteEnvTab from './SiteEnvTab.svelte';
   import DumpsTab from '$tabs/DumpsTab.svelte';
   import { resumeSite, loadSites, type Site } from '$stores/sites';
+  import { routeRest } from '$stores/route';
   import { m } from '../../paraglide/messages.js';
 
   let resumeBusy = $state(false);
@@ -39,6 +40,16 @@
   let activeWorktreeBranch = $state<string>('');
   const canTinker = $derived(Boolean(site.php_version));
   const canEnv = $derived(Boolean(site.has_env));
+
+  // The route can deep-link a sub-tab (e.g. dump notifications go to
+  // #sites/<domain>/dumps). When the second segment names a tab, honour it
+  // and overwrite the stored selection.
+  $effect(() => {
+    const seg = $routeRest.split('/')[1] ?? '';
+    if (seg === 'tinker' || seg === 'env' || seg === 'dumps' || seg === 'overview') {
+      active = seg;
+    }
+  });
 
   $effect(() => {
     if (active === 'tinker' && !canTinker) active = 'overview';


### PR DESCRIPTION
Two of the dashboard's push notifications carried URLs the router couldn't resolve. The `dump` notification used `#dumps`, which isn't a top-level tab, so `parseHash` silently fell back to dashboard and the click did nothing useful. The `worker_failed` notification used `#sites/<name>`, but the Sites tab is keyed by primary domain, so on any site where name and domain differ (whitewaters with theregistry.test, for example) the click landed on an empty state.

Both now route through a small `siteDomainForRoute` helper that resolves a registered site name to its primary domain at notification build time, falling back to the input verbatim when no site matches (covers test fixtures and races between unlink and a late notification). The dump notification now points at `#sites/<domain>/dumps` and `SiteDetail` switches to the dumps sub-tab on mount when the second segment is set. The worker_failed URL becomes `#sites/<domain>` so the existing detail-by-domain match works.

`SitesDetail` now splits `routeRest` on `/` and uses the first segment as the domain selector instead of comparing the whole rest verbatim, so URLs with sub-segments still find their site. `SiteDetail` gains a `$effect` that watches the second segment of `routeRest` and overrides the localStorage-restored tab when the segment names a known sub-tab.