### PR TITLE
feat(container): target field in .lerd.yaml selects a multi-stage build stage

### DIFF
--- a/docs/usage/custom-containers.md
+++ b/docs/usage/custom-containers.md
@@ -59,6 +59,7 @@ The `container` section in `.lerd.yaml` accepts these fields:
 | `port` | yes | | Port the app listens on inside the container |
 | `containerfile` | no | `Containerfile.lerd` | Path to the Containerfile (relative to project root) |
 | `build_context` | no | `.` | Build context directory (relative to project root) |
+| `target` | no | (last stage) | Stage to build in a multi-stage Containerfile, passed as `podman build --target`. Useful when your Containerfile has separate `development` and `production` stages and you want lerd to build the dev one locally. |
 | `ssl` | no | `false` | Set to `true` if the app serves HTTPS on its port (nginx will `proxy_pass https://` with `proxy_ssl_verify off`) |
 
 ## How it works

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -1374,6 +1374,7 @@ The ` + bt + `container.port` + bt + ` field is required. ` + bt + `container.co
 | ` + bt + `container.port` + bt + ` | yes | | Port the app listens on inside the container |
 | ` + bt + `container.containerfile` + bt + ` | no | ` + bt + `Containerfile.lerd` + bt + ` | Path to the Containerfile (relative to project root) |
 | ` + bt + `container.build_context` + bt + ` | no | ` + bt + `.` + bt + ` | Build context directory |
+| ` + bt + `container.target` + bt + ` | no | (last stage) | Stage to build in a multi-stage Containerfile, passed as ` + bt + `podman build --target` + bt + ` |
 | ` + bt + `custom_workers` + bt + ` | no | | Worker definitions — see below |
 | ` + bt + `domains` + bt + ` | no | | Same as PHP sites |
 | ` + bt + `secured` + bt + ` | no | | Same as PHP sites |

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -26,6 +26,7 @@ type ContainerConfig struct {
 	Port          int    `yaml:"port"`                    // port the app listens on inside the container (required)
 	Containerfile string `yaml:"containerfile,omitempty"` // path to Containerfile, default "Containerfile.lerd"
 	BuildContext  string `yaml:"build_context,omitempty"` // build context directory, default "."
+	Target        string `yaml:"target,omitempty"`        // multi-stage build target passed as --target to podman build
 	SSL           bool   `yaml:"ssl,omitempty"`           // proxy to the container via HTTPS (app serves TLS on its port)
 }
 

--- a/internal/podman/custom_container.go
+++ b/internal/podman/custom_container.go
@@ -97,7 +97,15 @@ func hashContainerfile(projectPath string, cfg *config.ContainerConfig) string {
 	if err != nil {
 		return ""
 	}
-	return fmt.Sprintf("%x", md5.Sum(data))
+	target := ""
+	if cfg != nil {
+		target = cfg.Target
+	}
+	// Mix the build target into the hash so flipping target: development to
+	// target: production in .lerd.yaml invalidates the cache. Without this,
+	// CustomImageUpToDate would return a stale image when only the target
+	// changed (issue #379).
+	return fmt.Sprintf("%x", md5.Sum([]byte(string(data)+"\x00--target="+target)))
 }
 
 func readContainerfileHash(siteName string) string {
@@ -107,6 +115,17 @@ func readContainerfileHash(siteName string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(data))
+}
+
+// buildCustomImageArgs assembles the podman build argv for a custom site
+// image. Centralised so BuildCustomImage and BuildCustomImageTo stay in
+// sync and the --target plumbing only lives in one place.
+func buildCustomImageArgs(imageName, containerfile, buildCtx string, cfg *config.ContainerConfig) []string {
+	args := []string{"build", "-t", imageName, "-f", containerfile}
+	if cfg != nil && cfg.Target != "" {
+		args = append(args, "--target", cfg.Target)
+	}
+	return append(args, buildCtx)
 }
 
 // BuildCustomImage builds the OCI image for a site's custom container from
@@ -120,7 +139,7 @@ func BuildCustomImage(siteName, projectPath string, cfg *config.ContainerConfig)
 	buildCtx := ResolveBuildContext(projectPath, cfg)
 	imageName := CustomImageName(siteName)
 
-	cmd := exec.Command(PodmanBin(), "build", "-t", imageName, "-f", containerfile, buildCtx)
+	cmd := exec.Command(PodmanBin(), buildCustomImageArgs(imageName, containerfile, buildCtx, cfg)...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -139,7 +158,7 @@ func BuildCustomImageTo(siteName, projectPath string, cfg *config.ContainerConfi
 	buildCtx := ResolveBuildContext(projectPath, cfg)
 	imageName := CustomImageName(siteName)
 
-	cmd := exec.Command(PodmanBin(), "build", "-t", imageName, "-f", containerfile, buildCtx)
+	cmd := exec.Command(PodmanBin(), buildCustomImageArgs(imageName, containerfile, buildCtx, cfg)...)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	if err := cmd.Run(); err != nil {

--- a/internal/podman/custom_container_test.go
+++ b/internal/podman/custom_container_test.go
@@ -3,6 +3,7 @@ package podman
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
@@ -144,6 +145,29 @@ func TestHashContainerfile_Missing(t *testing.T) {
 	}
 }
 
+// Flipping container.target between stages of an unchanged Containerfile
+// must invalidate the cache so CustomImageUpToDate rebuilds. Without this
+// a `target: development` → `target: production` edit kept serving the
+// dev image (issue #379).
+func TestHashContainerfile_TargetChangeInvalidatesHash(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "Containerfile.lerd"), []byte(
+		"FROM alpine AS production\nFROM alpine AS development\n",
+	), 0644)
+	hDev := hashContainerfile(dir, &config.ContainerConfig{Port: 8080, Target: "development"})
+	hProd := hashContainerfile(dir, &config.ContainerConfig{Port: 8080, Target: "production"})
+	if hDev == "" || hProd == "" {
+		t.Fatal("expected non-empty hashes")
+	}
+	if hDev == hProd {
+		t.Errorf("hash must change when only Target flips; both = %q", hDev)
+	}
+	hNoTarget := hashContainerfile(dir, &config.ContainerConfig{Port: 8080})
+	if hNoTarget == hDev || hNoTarget == hProd {
+		t.Errorf("hash with no target must differ from both targeted variants")
+	}
+}
+
 func TestStoreAndReadContainerfileHash(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)
@@ -168,5 +192,43 @@ func TestHasContainerfile_Absent(t *testing.T) {
 	dir := t.TempDir()
 	if HasContainerfile(dir) {
 		t.Error("expected HasContainerfile = false")
+	}
+}
+
+// Sn0wCrack's multi-stage Containerfile use case (issue #379): the target:
+// field in .lerd.yaml's container block must translate to --target on the
+// podman build invocation so the right stage gets built.
+func TestBuildCustomImageArgs_TargetEmittedWhenSet(t *testing.T) {
+	args := buildCustomImageArgs(
+		"lerd-custom-acme:local",
+		"/srv/acme/Containerfile.lerd",
+		"/srv/acme",
+		&config.ContainerConfig{Port: 3000, Target: "development"},
+	)
+	want := []string{"build", "-t", "lerd-custom-acme:local", "-f", "/srv/acme/Containerfile.lerd", "--target", "development", "/srv/acme"}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("args = %v\nwant %v", args, want)
+	}
+}
+
+func TestBuildCustomImageArgs_TargetOmittedWhenEmpty(t *testing.T) {
+	args := buildCustomImageArgs(
+		"lerd-custom-acme:local",
+		"/srv/acme/Containerfile.lerd",
+		"/srv/acme",
+		&config.ContainerConfig{Port: 3000},
+	)
+	for _, a := range args {
+		if a == "--target" {
+			t.Errorf("--target must not appear when Target is empty; got %v", args)
+		}
+	}
+}
+
+func TestBuildCustomImageArgs_NilConfigSafe(t *testing.T) {
+	args := buildCustomImageArgs("img:local", "/f", "/ctx", nil)
+	want := []string{"build", "-t", "img:local", "-f", "/f", "/ctx"}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("args = %v\nwant %v", args, want)
 	}
 }


### PR DESCRIPTION
Multi-stage Containerfiles often ship separate `development` and `production` stages. The development stage layers in xdebug, pcov, and other dev tooling; the production stage copies application files instead of mounting them. Without a way to tell lerd which stage to build, lerd always pulled the trailing stage, which forced projects to either reorganise the Containerfile or duplicate it for local use.

The `.lerd.yaml` container block now accepts an optional `target` field. When set, lerd threads it as `--target <name>` into both `podman build` invocations (the synchronous `lerd link` path and the streaming UI rebuild path). A shared `buildCustomImageArgs` helper carries the flag so the two code paths can't drift, and the multi-stage cache invalidation works by mixing the target value into `hashContainerfile`'s MD5 input with a NUL delimiter, without that flipping target between development and production with an unchanged Containerfile served the previously-built stage because the cache key didn't notice.

Docs and the MCP skill table both pick up the new field. The macOS path needs no change; the flag rides on the standard `podman build` argv that already gets forwarded into the podman-machine VM.

Addresses #379.