### PR TITLE
feat(mcp): service_add accepts the init flag

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -317,6 +317,7 @@ func toolList() []mcpTool {
 					"description": {Type: "string", Description: "Human-readable description."},
 					"dashboard":   {Type: "string", Description: "Web dashboard URL."},
 					"depends_on":  {Type: "array", Description: `Services that must start first, e.g. ["mysql"].`},
+					"init":        {Type: "boolean", Description: "Pass --init for images that ignore SIGTERM as PID 1 (mysql, mariadb)."},
 				},
 				Required: []string{"name", "image"},
 			},
@@ -2672,6 +2673,7 @@ func execServiceAdd(args map[string]any) (any, *rpcError) {
 		Dashboard:   strArg(args, "dashboard"),
 		DataDir:     strArg(args, "data_dir"),
 		DependsOn:   strSliceArg(args, "depends_on"),
+		Init:        boolArg(args, "init"),
 	}
 
 	if envList := strSliceArg(args, "environment"); len(envList) > 0 {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -277,3 +277,53 @@ func TestExecWorkersMode_SetRequiresValidMode(t *testing.T) {
 		t.Errorf("invalid mode should be rejected, got %s", got)
 	}
 }
+
+// service_add now accepts an init flag so an MCP-driven agent can wire
+// catatonit (--init) for custom services whose main process ignores
+// SIGTERM as PID 1 (mysql forks, certain Elasticsearch versions).
+func TestExecServiceAdd_InitFlagPersists(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	resp, rpcErr := execServiceAdd(map[string]any{
+		"name":  "memcrash",
+		"image": "docker.io/library/alpine:3.19",
+		"init":  true,
+	})
+	if rpcErr != nil {
+		t.Fatalf("rpc error: %v", rpcErr)
+	}
+	if got, _ := json.Marshal(resp); bytes.Contains(got, []byte("\"error\"")) {
+		t.Fatalf("execServiceAdd reported error: %s", got)
+	}
+
+	svc, err := config.LoadCustomService("memcrash")
+	if err != nil {
+		t.Fatalf("LoadCustomService: %v", err)
+	}
+	if !svc.Init {
+		t.Error("Init flag did not persist to disk")
+	}
+}
+
+func TestExecServiceAdd_InitDefaultsFalse(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if _, rpcErr := execServiceAdd(map[string]any{
+		"name":  "redisish",
+		"image": "docker.io/library/alpine:3.19",
+	}); rpcErr != nil {
+		t.Fatalf("rpc error: %v", rpcErr)
+	}
+
+	svc, err := config.LoadCustomService("redisish")
+	if err != nil {
+		t.Fatalf("LoadCustomService: %v", err)
+	}
+	if svc.Init {
+		t.Error("Init flag should default to false when not provided")
+	}
+}


### PR DESCRIPTION
The `init` field landed on `CustomService` and the preset schema in #383 so the quadlet generator can wire podman's `--init` when an image's main process ignores SIGTERM as PID 1, but the MCP `service_add` tool never picked up the corresponding argument. An agent registering a custom service through the wire couldn't turn the flag on without editing the YAML by hand. `service_add` now reads `init` alongside the other `CustomService` fields and the tool's input schema advertises it, so MCP-driven workflows reach feature parity with the `.lerd.yaml` path.