### PR TITLE
feat(presets): postgres-pgvector preset + dynamic DB picker

### DIFF
--- a/docs/usage/database.md
+++ b/docs/usage/database.md
@@ -85,9 +85,11 @@ The database for a Laravel project is configured through `.lerd.yaml` and applie
 | `mysql` | `lerd-mysql` (Podman) | `DB_CONNECTION=mysql`, `DB_HOST=lerd-mysql`, `DB_PORT=3306`, `DB_DATABASE=<project>`, `DB_USERNAME=root`, `DB_PASSWORD=lerd` |
 | `postgres` | `lerd-postgres` (Podman) | `DB_CONNECTION=pgsql`, `DB_HOST=lerd-postgres`, `DB_PORT=5432`, `DB_DATABASE=<project>`, `DB_USERNAME=postgres`, `DB_PASSWORD=lerd` |
 
+Installed family alternates are valid picks too: `mariadb` / `mariadb-10-11`, `mysql-5-7`, `postgres-pgvector` / `postgres-17`, etc. They go through the same env-write + database-create flow as the built-ins, using the host and port from their preset. Install one first with `lerd service preset <name>`, then list it in `.lerd.yaml` under `services:` or pick it in the `lerd init` wizard.
+
 For SQLite, the `database/database.sqlite` file is created automatically if it doesn't exist. No service is started.
 
-For MySQL or PostgreSQL, the matching `lerd-<engine>` service is started if it isn't already, and the project database (plus a `_testing` variant) is created via `lerd db:create`.
+For MySQL or PostgreSQL (and their family alternates), the matching `lerd-<service>` container is started if it isn't already, and the project database (plus a `_testing` variant) is created via `lerd db:create`.
 
 You can change the choice at any time by editing the `services:` list in `.lerd.yaml` and re-running `lerd env`, or by running `lerd init --fresh` and picking a different database in the wizard.
 

--- a/docs/usage/service-presets.md
+++ b/docs/usage/service-presets.md
@@ -26,6 +26,7 @@ Both kinds use the same YAML schema in `internal/config/presets/*.yaml` and the 
 | `pgadmin` | `docker.io/dpage/pgadmin4:latest` | `postgres` (default) | `http://localhost:8081` |
 | `mysql` alternates | `5.7` / `9.7` LTS (canonical 8.4 lives in the default preset) | - | `127.0.0.1:3357` / `127.0.0.1:3397` |
 | `postgres` alternates | `17` / `18` (canonical 16 lives in the default preset) | - | `127.0.0.1:5417` / `127.0.0.1:5418` |
+| `postgres-pgvector` | `pgvector/pgvector:pg18` (canonical) / `pg17` / `pg16` — pgvector instead of PostGIS | - | `127.0.0.1:5518` / `127.0.0.1:5517` / `127.0.0.1:5516` |
 | `mariadb` | `11` (default) / `10.11` LTS | - | `127.0.0.1:3411` / `127.0.0.1:3410` |
 | `mongo` | `docker.io/library/mongo:7` | - | `127.0.0.1:27017` |
 | `mongo-express` | `docker.io/library/mongo-express:latest` | `mongo` (preset) | `http://localhost:8082` |

--- a/docs/usage/service-updates.md
+++ b/docs/usage/service-updates.md
@@ -43,8 +43,14 @@ If anything fails before step 5, the data dir is restored and the unit goes back
 
 ```bash
 # Migrate mysql to a specific 9.x tag (one major above the running 8.x)
-lerd service migrate mysql 9.0
+lerd service migrate mysql 9.7
+
+# Postgres takes the major version label; lerd resolves the compound image
+# tag for you (18 becomes postgis/postgis:18-3.6-alpine)
+lerd service migrate postgres 18
 ```
+
+`<version>` is a preset version label as shown in `lerd service list` or the install picker. lerd looks it up in the preset and substitutes the right registry image, so you never have to type a compound tag like `18-3.6-alpine` or `pg18`. An argument that matches no preset version is used verbatim as the image tag, which still lets you pin an exact patch release.
 
 ```jsonc
 // MCP
@@ -105,7 +111,7 @@ allow_major_upgrade: false      # NewestStable stays in current major when false
 lerd service list                            # Update column shows badges
 lerd service update <name>                   # safe in-strategy patch
 lerd service update <name> <tag>             # explicit upgrade target
-lerd service migrate <name> <target-tag>     # SQL dump + restore
+lerd service migrate <name> <version>        # SQL dump + restore
 lerd service rollback <name>                 # toggle back to previous image
 ```
 

--- a/docs/usage/services.md
+++ b/docs/usage/services.md
@@ -10,7 +10,7 @@
 | `lerd service status <name>` | Show systemd unit status |
 | `lerd service list` | All services with status, version, and an Update column |
 | `lerd service update <name> [tag]` | Pull a newer image and restart; tag selects an explicit upgrade target |
-| `lerd service migrate <name> <target-tag>` | SQL dump + restore for cross-version moves (mysql, postgres) |
+| `lerd service migrate <name> <version>` | SQL dump + restore for cross-version moves (mysql, mariadb, postgres); `<version>` is a preset version label such as `18` |
 | `lerd service rollback <name>` | Swap back to the previously-running image (toggles) |
 | `lerd service pin <name>` | Pin a service so it is never auto-stopped |
 | `lerd service unpin <name>` | Unpin a service so it can be auto-stopped when unused |

--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -504,7 +504,7 @@ func runDbShell(flagService, flagDatabase string) error {
 func databaseExists(svc, name string) (bool, error) {
 	container := "lerd-" + svc
 	family := svc
-	if inferred := config.InferFamily(svc); inferred != "" {
+	if inferred := config.FamilyOfName(svc); inferred != "" {
 		family = inferred
 	}
 	switch family {

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -63,7 +63,7 @@ func userPickedDBFromYAML(lerdYAMLServices map[string]bool) bool {
 		return true
 	}
 	for name := range lerdYAMLServices {
-		switch config.InferFamily(name) {
+		switch config.FamilyOfName(name) {
 		case "mysql", "mariadb", "postgres", "mongo":
 			return true
 		}
@@ -233,27 +233,24 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	// so they don't hit a 500 from the missing .sqlite file; the user can
 	// still switch later with `lerd db set mysql` or the db_set MCP tool.
 	if len(fw.Env.Services) == 0 &&
-		!lerdYAMLServices["mysql"] && !lerdYAMLServices["postgres"] && !lerdYAMLServices["sqlite"] &&
+		!userPickedDBFromYAML(lerdYAMLServices) &&
 		strings.EqualFold(strings.TrimSpace(envMap["DB_CONNECTION"]), "sqlite") {
 
 		dbChoice := "sqlite"
 		if isInteractive() {
+			options, _ := buildDatabaseOptions()
 			dbForm := huh.NewForm(huh.NewGroup(
 				huh.NewSelect[string]().
 					Title("Database").
-					Description(envRelPath+" uses SQLite. Use a lerd-managed database service instead?").
-					Options(
-						huh.NewOption("Keep SQLite", "sqlite"),
-						huh.NewOption("MySQL (lerd-mysql)", "mysql"),
-						huh.NewOption("PostgreSQL (lerd-postgres)", "postgres"),
-					).
+					Description(envRelPath + " uses SQLite. Use a lerd-managed database service instead?").
+					Options(options...).
 					Value(&dbChoice),
 			)).WithTheme(huh.ThemeCatppuccin())
 			if err := dbForm.Run(); err != nil {
 				return fmt.Errorf("database prompt: %w", err)
 			}
 		} else {
-			fmt.Println("  Defaulting to SQLite (non-interactive). Run `lerd db set <mysql|postgres>` or call db_set to switch.")
+			fmt.Println("  Defaulting to SQLite (non-interactive). Run `lerd db set <service>` or call db_set to switch.")
 		}
 
 		// Persist the choice to .lerd.yaml so future runs don't re-ask, and
@@ -488,7 +485,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			k, v, _ := strings.Cut(kv, "=")
 			updates[k] = applySiteHandle(v, tplCtx)
 		}
-		family := config.InferFamily(svc.Name)
+		family := config.FamilyOf(svc)
 		isDB := family == "mysql" || family == "mariadb" || family == "postgres"
 		if isDB {
 			updates["DB_DATABASE"] = dbName
@@ -608,7 +605,7 @@ func CreateDatabase(svc, name string) (bool, error) { return serviceops.CreateDa
 func CloneDatabase(svc, src, dst string) error {
 	container := "lerd-" + svc
 	family := svc
-	if inferred := config.InferFamily(svc); inferred != "" {
+	if inferred := config.FamilyOfName(svc); inferred != "" {
 		family = inferred
 	}
 	switch family {
@@ -648,7 +645,7 @@ func CloneDatabase(svc, src, dst string) error {
 func DropDatabase(svc, name string) (bool, error) {
 	container := "lerd-" + svc
 	family := svc
-	if inferred := config.InferFamily(svc); inferred != "" {
+	if inferred := config.FamilyOfName(svc); inferred != "" {
 		family = inferred
 	}
 	switch family {

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -138,6 +138,56 @@ func TestUserPickedDBFromYAML(t *testing.T) {
 	}
 }
 
+func TestUserPickedDBFromYAML_CustomFamilyMember(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, "lerd", "services"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	yaml := `name: postgres-pgvector
+family: postgres
+image: docker.io/pgvector/pgvector:pg18
+`
+	if err := os.WriteFile(filepath.Join(tmp, "lerd", "services", "postgres-pgvector.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write fake service: %v", err)
+	}
+	if !userPickedDBFromYAML(map[string]bool{"postgres-pgvector": true}) {
+		t.Errorf("userPickedDBFromYAML should count postgres-pgvector as a picked DB via Family=postgres")
+	}
+}
+
+func TestBuildDatabaseOptions_IncludesInstalledFamilyAlternates(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, "lerd", "services"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	yaml := `name: postgres-pgvector
+family: postgres
+image: docker.io/pgvector/pgvector:pg18
+`
+	if err := os.WriteFile(filepath.Join(tmp, "lerd", "services", "postgres-pgvector.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write fake service: %v", err)
+	}
+	options, nameSet := buildDatabaseOptions()
+	if !nameSet["sqlite"] || !nameSet["mysql"] || !nameSet["postgres"] {
+		t.Errorf("buildDatabaseOptions must always include the built-in trio, got %v", nameSet)
+	}
+	if !nameSet["postgres-pgvector"] {
+		t.Errorf("buildDatabaseOptions must surface installed postgres-family alternate, got %v", nameSet)
+	}
+	foundPgvector := false
+	for _, opt := range options {
+		if opt.Value == "postgres-pgvector" {
+			foundPgvector = true
+			break
+		}
+	}
+	if !foundPgvector {
+		t.Errorf("buildDatabaseOptions must offer postgres-pgvector as a selectable option")
+	}
+}
+
 func TestShouldApplyService(t *testing.T) {
 	for _, tc := range []struct {
 		name         string

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -668,11 +668,8 @@ var dbFamilies = map[string]bool{
 // database. Honours the explicit Family field first, then falls back to
 // pattern inference for legacy installs that pre-date the field.
 func dbFamilyOf(svc *config.CustomService) string {
-	if svc.Family != "" && dbFamilies[svc.Family] {
-		return svc.Family
-	}
-	if inferred := config.InferFamily(svc.Name); dbFamilies[inferred] {
-		return inferred
+	if family := config.FamilyOf(svc); dbFamilies[family] {
+		return family
 	}
 	return ""
 }
@@ -691,8 +688,8 @@ var dbFamilyLabels = map[string]string{
 func formatDBOptionLabel(name string) string {
 	family := name
 	version := ""
-	if config.InferFamily(name) != "" {
-		family = config.InferFamily(name)
+	if inferred := config.FamilyOfName(name); inferred != "" {
+		family = inferred
 		if rest := strings.TrimPrefix(name, family); rest != "" && rest != name {
 			version = strings.TrimPrefix(rest, "-")
 			version = strings.ReplaceAll(version, "-", ".")

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -853,23 +853,20 @@ Arguments:
 
 > Run this right after ` + bt + `site_link` + bt + ` when setting up a fresh project.
 >
-> **Database default:** on a fresh Laravel clone where ` + bt + `.env` + bt + ` still says ` + bt + `DB_CONNECTION=sqlite` + bt + `, ` + bt + `env_setup` + bt + ` leaves the database choice alone. Call ` + bt + `db_set` + bt + ` first to pick ` + bt + `mysql` + bt + ` / ` + bt + `postgres` + bt + ` / ` + bt + `sqlite` + bt + ` deliberately, then ` + bt + `env_setup` + bt + ` (or just ` + bt + `db_set` + bt + ` alone — it already runs the env step).
+> **Database default:** on a fresh Laravel clone where ` + bt + `.env` + bt + ` still says ` + bt + `DB_CONNECTION=sqlite` + bt + `, ` + bt + `env_setup` + bt + ` leaves the database choice alone. Call ` + bt + `db_set` + bt + ` first to pick ` + bt + `sqlite` + bt + `, a built-in (` + bt + `mysql` + bt + ` / ` + bt + `postgres` + bt + `), or an installed family alternate (` + bt + `mariadb` + bt + `, ` + bt + `postgres-pgvector` + bt + `, …) deliberately, then ` + bt + `env_setup` + bt + ` (or just ` + bt + `db_set` + bt + ` alone — it already runs the env step).
 
 ### ` + bt + `db_set` + bt + `
-Pick the database for a Laravel project. Persists the choice to ` + bt + `.lerd.yaml` + bt + ` (replacing any prior database entry — the choice is exclusive), rewrites the relevant ` + bt + `DB_` + bt + ` keys in ` + bt + `.env` + bt + `, and provisions the backing storage:
-- ` + bt + `sqlite` + bt + ` — sets ` + bt + `DB_CONNECTION=sqlite` + bt + ` and ` + bt + `DB_DATABASE=database/database.sqlite` + bt + `, creates the file if missing. No service is started.
-- ` + bt + `mysql` + bt + ` — sets ` + bt + `DB_CONNECTION=mysql` + bt + ` and the ` + bt + `lerd-mysql` + bt + ` connection vars, starts ` + bt + `lerd-mysql` + bt + ` if needed, creates ` + bt + `<project>` + bt + ` and ` + bt + `<project>_testing` + bt + ` databases.
-- ` + bt + `postgres` + bt + ` — sets ` + bt + `DB_CONNECTION=pgsql` + bt + ` and the ` + bt + `lerd-postgres` + bt + ` connection vars, starts ` + bt + `lerd-postgres` + bt + ` if needed, creates the project databases.
+Pick the database for a Laravel project. Persists the choice to ` + bt + `.lerd.yaml` + bt + ` (replacing any prior DB entry), rewrites ` + bt + `DB_` + bt + ` keys in ` + bt + `.env` + bt + `, and provisions storage. Accepts ` + bt + `sqlite` + bt + `, the built-in ` + bt + `mysql` + bt + ` / ` + bt + `postgres` + bt + `, or any installed family alternate (` + bt + `mariadb` + bt + `, ` + bt + `mysql-5-7` + bt + `, ` + bt + `postgres-pgvector` + bt + `, ` + bt + `postgres-17` + bt + `, …). Alternates must be installed first with ` + bt + `lerd service preset <name>` + bt + `.
 
 Arguments:
-- ` + bt + `path` + bt + ` (optional): absolute path to the Laravel project root — defaults to ` + bt + `LERD_SITE_PATH` + bt + ` / cwd
-- ` + bt + `database` + bt + ` (required): one of ` + bt + `"sqlite"` + bt + `, ` + bt + `"mysql"` + bt + `, ` + bt + `"postgres"` + bt + `
+- ` + bt + `path` + bt + ` (optional): project root, defaults to ` + bt + `LERD_SITE_PATH` + bt + ` / cwd
+- ` + bt + `database` + bt + ` (required): see above
 
 Examples:
 ` + "```" + `
-db_set(database: "mysql")        // fresh Laravel clone, switch to MySQL
-db_set(database: "postgres")     // switch from MySQL → PostgreSQL (removes mysql)
-db_set(database: "sqlite")       // explicitly keep SQLite (and create the file)
+db_set(database: "mysql")
+db_set(database: "postgres-pgvector")
+db_set(database: "sqlite")
 ` + "```" + `
 
 > Use this **before** ` + bt + `env_setup` + bt + ` on a fresh Laravel project so the database lands in ` + bt + `.env` + bt + ` deliberately. Switching databases later via ` + bt + `db_set` + bt + ` removes the previous database entry from ` + bt + `.lerd.yaml` + bt + ` automatically.
@@ -1453,7 +1450,7 @@ Read ` + bt + `status()` + bt + ` for ` + bt + `dns.tld` + bt + ` and ` + bt + `
 | ` + bt + `vendor_run` + bt + ` | Run a binary from ` + bt + `vendor/bin` + bt + ` (pest, phpunit, pint, phpstan, rector, …) inside the PHP-FPM container |
 | ` + bt + `node` + bt + ` | Install or uninstall a Node.js version via fnm — ` + bt + `action` + bt + `: ` + bt + `install` + bt + ` / ` + bt + `uninstall` + bt + ` (e.g. ` + bt + `"20"` + bt + `, ` + bt + `"lts"` + bt + `) |
 | ` + bt + `env_setup` + bt + ` | Configure ` + bt + `.env` + bt + ` for lerd: detects services, starts them, creates DB, generates APP_KEY (leaves ` + bt + `DB_CONNECTION=sqlite` + bt + ` alone — call ` + bt + `db_set` + bt + ` first); ` + bt + `APP_URL` + bt + ` follows ` + bt + `.lerd.yaml app_url` + bt + ` → ` + bt + `sites.yaml app_url` + bt + ` → default chain |
-| ` + bt + `db_set` + bt + ` | Pick the database for a Laravel project: ` + bt + `sqlite` + bt + ` / ` + bt + `mysql` + bt + ` / ` + bt + `postgres` + bt + `; persists to ` + bt + `.lerd.yaml` + bt + `, rewrites ` + bt + `DB_` + bt + ` keys in ` + bt + `.env` + bt + `, starts the service, creates the database |
+| ` + bt + `db_set` + bt + ` | Pick the database for a Laravel project: ` + bt + `sqlite` + bt + `, a built-in (` + bt + `mysql` + bt + ` / ` + bt + `postgres` + bt + `), or any installed family alternate (` + bt + `mariadb` + bt + `, ` + bt + `postgres-pgvector` + bt + `, ` + bt + `mysql-5-7` + bt + `, …); persists to ` + bt + `.lerd.yaml` + bt + `, rewrites ` + bt + `DB_` + bt + ` keys in ` + bt + `.env` + bt + `, starts the service, creates the database |
 | ` + bt + `env_check` + bt + ` | Compare all ` + bt + `.env` + bt + ` files against ` + bt + `.env.example` + bt + ` — returns structured JSON with per-key sync status |
 | ` + bt + `site_link` + bt + ` | Register a directory as a lerd site — **non-PHP projects** must have a Containerfile (default name ` + bt + `Containerfile.lerd` + bt + `; set ` + bt + `container.containerfile` + bt + ` for a different path, e.g. ` + bt + `Dockerfile` + bt + `) + ` + bt + `.lerd.yaml` + bt + ` with ` + bt + `container: {port: N}` + bt + ` written first, otherwise the site registers as PHP (wrong) |
 | ` + bt + `site_unlink` + bt + ` | Unregister a site and remove its nginx vhost (all domains) |
@@ -1504,7 +1501,7 @@ Read ` + bt + `status()` + bt + ` for ` + bt + `dns.tld` + bt + ` and ` + bt + `
 - ` + bt + `path` + bt + ` argument is optional on most tools — defaults to the directory the AI assistant was opened in (cwd), then ` + bt + `LERD_SITE_PATH` + bt + ` if set; you can almost always omit it
 - ` + bt + `artisan` + bt + ` is Laravel-only; ` + bt + `console` + bt + ` is the equivalent for non-Laravel frameworks — both take ` + bt + `path` + bt + ` (absolute project root) and ` + bt + `args` + bt + ` (array)
 - ` + bt + `vendor_run` + bt + ` is the right way to invoke project tooling like pest, phpunit, pint, phpstan, rector — call ` + bt + `vendor_bins` + bt + ` first to discover what's installed, then ` + bt + `vendor_run(bin: "<name>", args: [...])` + bt + `; prefer it over ` + bt + `composer(args: ["exec", ...])` + bt + `
-- On a **fresh Laravel clone** (DB_CONNECTION=sqlite in ` + bt + `.env` + bt + `), call ` + bt + `db_set(database: "mysql"|"postgres"|"sqlite")` + bt + ` before ` + bt + `env_setup` + bt + ` to pick a database deliberately. ` + bt + `env_setup` + bt + ` on its own won't switch the database away from sqlite.
+- On a **fresh Laravel clone** (DB_CONNECTION=sqlite in ` + bt + `.env` + bt + `), call ` + bt + `db_set` + bt + ` before ` + bt + `env_setup` + bt + ` to pick a database deliberately — ` + bt + `sqlite` + bt + `, a built-in (` + bt + `mysql` + bt + ` / ` + bt + `postgres` + bt + `), or any installed family alternate (` + bt + `mariadb` + bt + `, ` + bt + `postgres-pgvector` + bt + `, ` + bt + `mysql-5-7` + bt + `, …). ` + bt + `env_setup` + bt + ` on its own won't switch the database away from sqlite.
 - **Domain conflicts on link**: when ` + bt + `lerd link` + bt + ` (or the parked-directory watcher) tries to register a ` + bt + `.lerd.yaml` + bt + ` domain that another site already owns, the conflicting domain is filtered out and a ` + bt + `[WARN] domain "X" already used by site "Y" — skipped` + bt + ` line is printed. The site still gets registered with surviving domains, falling back to ` + bt + `<dirname>.<tld>` + bt + ` if everything was filtered. ` + bt + `.lerd.yaml` + bt + ` is not modified on disk so the conflict is visible in the UI and self-heals on the next link if the owning site is removed. The ` + bt + `site_link` + bt + ` and ` + bt + `site_domain(action: "add", ...)` + bt + ` MCP tools, by contrast, hard-error on conflicts so you can react explicitly — read the error message for the owning site name.
 - **Custom APP_URL**: ` + bt + `env_setup` + bt + ` writes ` + bt + `<scheme>://<primary-domain>` + bt + ` by default. Override by setting ` + bt + `app_url` + bt + ` in ` + bt + `.lerd.yaml` + bt + ` (committed) or in the per-machine ` + bt + `sites.yaml` + bt + ` site entry. No MCP tool sets it — edit the YAML and re-run ` + bt + `env_setup` + bt + `.
 - ` + bt + `tinker` + bt + ` must use ` + bt + `--execute=<code>` + bt + ` for non-interactive use

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -649,7 +649,7 @@ func printPresetList() error {
 		} else {
 			anyInstalled := false
 			for _, v := range p.Versions {
-				if _, err := config.LoadCustomService(p.Name + "-" + config.SanitizeImageTag(v.Tag)); err == nil {
+				if _, err := config.LoadCustomService(config.PresetVersionServiceName(p.Name, v)); err == nil {
 					anyInstalled = true
 					break
 				}
@@ -671,7 +671,7 @@ func printPresetList() error {
 			if v.Label != "" {
 				label = v.Label
 			}
-			if _, err := config.LoadCustomService(p.Name + "-" + config.SanitizeImageTag(v.Tag)); err == nil {
+			if _, err := config.LoadCustomService(config.PresetVersionServiceName(p.Name, v)); err == nil {
 				versionStatus = "installed"
 			}
 			marker := " "

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -235,20 +235,24 @@ v1.7.6 → v1.42.1) — this may require manual data migration; you've been warn
 
 func newServiceMigrateCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "migrate <service> <target-tag>",
+		Use:   "migrate <service> <version>",
 		Short: "Migrate a service across data-incompatible versions (dump + restore)",
 		Long: `Migrate a service across versions whose on-disk data dirs are NOT compatible
 (e.g. mysql 8.x → 9.x, postgres 16 → 17, meilisearch v1.x → v1.y across minors).
+
+<version> is a preset version label such as 18, resolved to that version's
+image (postgres 18 becomes postgis/postgis:18-3.6-alpine). An argument that
+matches no preset version is used verbatim as the target image tag.
 
 Flow: dump current data into ~/.local/share/lerd/backups/<svc>-<ts>.sql, stop
 the unit, move the data dir aside, pull the target image, start fresh, restore
 the dump. The old data dir is preserved alongside the dump so manual recovery
 is always possible.
 
-Supported families: mysql, mariadb, postgres, meilisearch.`,
+Supported families: mysql, mariadb, postgres.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
-			name, tag := args[0], args[1]
+			name, version := args[0], args[1]
 			avail, err := serviceops.CheckUpdateAvailable(name)
 			if err != nil {
 				return err
@@ -256,9 +260,9 @@ Supported families: mysql, mariadb, postgres, meilisearch.`,
 			if avail.CurrentImage == "" {
 				return fmt.Errorf("could not resolve current image for %q", name)
 			}
-			targetImage := avail.CurrentImage
-			if at := strings.LastIndex(targetImage, ":"); at > 0 {
-				targetImage = targetImage[:at] + ":" + tag
+			targetImage, err := serviceops.ResolveMigrateTarget(name, avail.CurrentImage, version)
+			if err != nil {
+				return err
 			}
 			fmt.Printf("Migrating %s: %s → %s\n", name, avail.CurrentImage, targetImage)
 			fmt.Println("Dumps and the previous data dir will be preserved under ~/.local/share/lerd/backups.")

--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -255,6 +255,31 @@ func InferFamily(name string) string {
 	return ""
 }
 
+// FamilyOf returns the family for a resolved CustomService, preferring the
+// explicit Family field over name-pattern inference. Use this anywhere
+// behavior branches on family (env wiring, DB creation, migration) so
+// services with non-digit suffixes like postgres-pgvector are recognised.
+func FamilyOf(svc *CustomService) string {
+	if svc == nil {
+		return ""
+	}
+	if svc.Family != "" {
+		return svc.Family
+	}
+	return InferFamily(svc.Name)
+}
+
+// FamilyOfName resolves a family by service name. Loads the installed custom
+// service definition (if any) to honour its Family field, falling back to
+// InferFamily for built-ins, uninstalled names, or anything without a saved
+// definition. Use this from call sites that only have the bare service name.
+func FamilyOfName(name string) string {
+	if svc, err := LoadCustomService(name); err == nil && svc != nil {
+		return FamilyOf(svc)
+	}
+	return InferFamily(name)
+}
+
 // ResolveDynamicEnv applies any dynamic_env directives on svc, writing the
 // computed values into svc.Environment. Called immediately before quadlet
 // generation so the resolved values land in the rendered .container file.

--- a/internal/config/custom_service_test.go
+++ b/internal/config/custom_service_test.go
@@ -7,6 +7,38 @@ import (
 	"testing"
 )
 
+func TestFamilyOf_PrefersExplicitFamily(t *testing.T) {
+	svc := &CustomService{Name: "postgres-pgvector", Family: "postgres"}
+	if got := FamilyOf(svc); got != "postgres" {
+		t.Errorf("FamilyOf(postgres-pgvector w/ Family=postgres) = %q, want postgres (this is the postgres-pgvector fix)", got)
+	}
+}
+
+func TestFamilyOf_FallsBackToInferWhenFamilyEmpty(t *testing.T) {
+	svc := &CustomService{Name: "mariadb-10-11"}
+	if got := FamilyOf(svc); got != "mariadb" {
+		t.Errorf("FamilyOf(mariadb-10-11 w/o Family) = %q, want mariadb via InferFamily fallback", got)
+	}
+}
+
+func TestFamilyOf_NilSafe(t *testing.T) {
+	if got := FamilyOf(nil); got != "" {
+		t.Errorf("FamilyOf(nil) = %q, want empty", got)
+	}
+}
+
+func TestFamilyOfName_BuiltinViaInferFamily(t *testing.T) {
+	if got := FamilyOfName("postgres"); got != "postgres" {
+		t.Errorf("FamilyOfName(postgres) = %q, want postgres (built-in family lookup)", got)
+	}
+}
+
+func TestFamilyOfName_UnknownReturnsEmpty(t *testing.T) {
+	if got := FamilyOfName("not-a-real-service"); got != "" {
+		t.Errorf("FamilyOfName(not-a-real-service) = %q, want empty", got)
+	}
+}
+
 func TestSaveCustomService_RejectsNewlineInEnv(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -288,13 +288,21 @@ func (p *Preset) Resolve(version string) (*CustomService, error) {
 	return &svc, nil
 }
 
+// canonicalVersion returns the version flagged canonical, or nil when none is.
+func (p *Preset) canonicalVersion() *PresetVersion {
+	for i := range p.Versions {
+		if p.Versions[i].Canonical {
+			return &p.Versions[i]
+		}
+	}
+	return nil
+}
+
 // CanonicalTag returns the tag of the version marked canonical, or empty
 // when no version is flagged (single-version presets or all-alternate families).
 func (p *Preset) CanonicalTag() string {
-	for _, v := range p.Versions {
-		if v.Canonical {
-			return v.Tag
-		}
+	if v := p.canonicalVersion(); v != nil {
+		return v.Tag
 	}
 	return ""
 }
@@ -321,9 +329,16 @@ func (p *Preset) ResolvePinned(tag string) (*CustomService, error) {
 	svc.Image = picked.Image
 	svc.Preset = p.Name
 	svc.PresetVersion = picked.Tag
+	// The bare canonical instance always occupies the canonical port; only the
+	// image follows the pinned version, so {{host_port}} must not drift onto a
+	// non-canonical version's alternate port (e.g. a migrated pg16 → 18).
+	portSource := picked
+	if canon := p.canonicalVersion(); canon != nil {
+		portSource = canon
+	}
 	var hostPort string
-	if picked.HostPort > 0 {
-		hostPort = fmt.Sprintf("%d", picked.HostPort)
+	if portSource.HostPort > 0 {
+		hostPort = fmt.Sprintf("%d", portSource.HostPort)
 	}
 	repl := strings.NewReplacer(
 		"{{name}}", svc.Name,

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -107,37 +107,17 @@ func ListPresets() ([]PresetMeta, error) {
 		if len(p.Versions) > 0 {
 			image = ""
 		}
-		// Canonical version IS the default install; filter it out of the
-		// alternates picker so users only see versions they can install
-		// alongside the canonical.
-		alternates := make([]PresetVersion, 0, len(p.Versions))
-		altDefault := p.DefaultVersion
-		for _, v := range p.Versions {
-			if v.Canonical {
-				continue
-			}
-			alternates = append(alternates, v)
-		}
-		if altDefault != "" {
-			found := false
-			for _, v := range alternates {
-				if v.Tag == altDefault {
-					found = true
-					break
-				}
-			}
-			if !found && len(alternates) > 0 {
-				altDefault = alternates[0].Tag
-			}
-		}
+		// All versions (including canonical) are exposed so the picker shows
+		// the default install explicitly. The canonical's label typically
+		// carries a "(default)" hint and DefaultVersion preselects it.
 		out = append(out, PresetMeta{
 			Name:           p.Name,
 			Description:    p.Description,
 			Dashboard:      p.Dashboard,
 			DependsOn:      p.DependsOn,
 			Image:          image,
-			Versions:       alternates,
-			DefaultVersion: altDefault,
+			Versions:       p.Versions,
+			DefaultVersion: p.DefaultVersion,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
@@ -211,6 +191,18 @@ func ValidatePresetYAML(data []byte, name string) error {
 func PresetExists(name string) bool {
 	_, err := presetFS.Open("presets/" + name + ".yaml")
 	return err == nil
+}
+
+// PresetVersionServiceName returns the resolved service (container) name for
+// a specific version of a multi-version preset. Canonical versions keep the
+// bare preset name; non-canonical versions get the sanitised-tag suffix. Use
+// this anywhere code needs to map a (preset, version) pair to the on-disk
+// custom service name (e.g. install-state probes).
+func PresetVersionServiceName(presetName string, v PresetVersion) string {
+	if v.Canonical {
+		return presetName
+	}
+	return presetName + "-" + SanitizeImageTag(v.Tag)
 }
 
 // SanitizeImageTag returns a container-name-safe form of an image tag by

--- a/internal/config/presets/postgres-pgvector.yaml
+++ b/internal/config/presets/postgres-pgvector.yaml
@@ -1,0 +1,33 @@
+name: postgres-pgvector
+description: PostgreSQL with pgvector (vector embeddings, no PostGIS)
+family: postgres
+default_version: "18"
+versions:
+  - tag: "18"
+    label: "18 (default)"
+    image: docker.io/pgvector/pgvector:pg18
+    canonical: true
+    host_port: 5518
+  - tag: "17"
+    label: "17"
+    image: docker.io/pgvector/pgvector:pg17
+    host_port: 5517
+  - tag: "16"
+    label: "16"
+    image: docker.io/pgvector/pgvector:pg16
+    host_port: 5516
+ports:
+  - "{{host_port}}:5432"
+data_dir: /var/lib/postgresql/data
+environment:
+  POSTGRES_PASSWORD: lerd
+  POSTGRES_DB: lerd
+  PGDATA: /var/lib/postgresql/data
+env_vars:
+  - DB_CONNECTION=pgsql
+  - DB_HOST=lerd-{{name}}
+  - DB_PORT=5432
+  - DB_DATABASE=lerd
+  - DB_USERNAME=postgres
+  - DB_PASSWORD=lerd
+connection_url: postgresql://postgres:lerd@127.0.0.1:{{host_port}}/lerd

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -618,6 +618,37 @@ func TestPresetCanonicalTag(t *testing.T) {
 	}
 }
 
+// A pinned canonical service keeps the canonical port: ResolvePinned templates
+// {{host_port}} from the canonical version, not the pinned one. Regression
+// guard for the pg16 → 18 migrate binding 5418 instead of 5432.
+func TestResolvePinned_CanonicalKeepsCanonicalPort(t *testing.T) {
+	p, err := LoadPreset("postgres")
+	if err != nil {
+		t.Fatalf("LoadPreset: %v", err)
+	}
+	svc, err := p.ResolvePinned("18")
+	if err != nil {
+		t.Fatalf("ResolvePinned: %v", err)
+	}
+	if svc.Name != "postgres" {
+		t.Errorf("name = %q, want bare postgres", svc.Name)
+	}
+	if svc.Image != "docker.io/postgis/postgis:18-3.6-alpine" {
+		t.Errorf("image = %q, want the pinned pg18 image", svc.Image)
+	}
+	if len(svc.Ports) == 0 || !strings.HasPrefix(svc.Ports[0], "5432:") {
+		t.Errorf("ports = %v, want canonical 5432:5432", svc.Ports)
+	}
+	for _, port := range svc.Ports {
+		if strings.Contains(port, "5418") {
+			t.Errorf("pinned canonical postgres must not adopt version 18's alternate port: %v", svc.Ports)
+		}
+	}
+	if strings.Contains(svc.ConnectionURL, "5418") {
+		t.Errorf("connection url must use the canonical port, got %q", svc.ConnectionURL)
+	}
+}
+
 func TestPresetResolvePinned_KeepsBareName(t *testing.T) {
 	p, err := LoadPreset("postgres")
 	if err != nil {

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -416,10 +416,11 @@ func TestLoadPreset_DefaultsTrackLatest(t *testing.T) {
 	}
 }
 
-func TestListPresets_CanonicalHiddenFromAlternates(t *testing.T) {
-	// The canonical version is the default install — listing it as an
-	// "alternate" would let users pick it from the picker and clobber the
-	// default service. Filter it out of PresetMeta.Versions.
+func TestListPresets_IncludesCanonicalInVersions(t *testing.T) {
+	// Canonical IS the default install but it must show in the picker so the
+	// user can pick it explicitly (e.g. install pgvector 18 when 18 is the
+	// canonical). The label carries a "(default)" marker and DefaultVersion
+	// preselects the canonical in the UI dropdown.
 	metas, err := ListPresets()
 	if err != nil {
 		t.Fatalf("ListPresets: %v", err)
@@ -434,24 +435,46 @@ func TestListPresets_CanonicalHiddenFromAlternates(t *testing.T) {
 	if mysql == nil {
 		t.Fatal("mysql preset missing from ListPresets")
 	}
+	wantAll := map[string]bool{"8.4": false, "9.7": false, "5.7": false}
+	canonicalFound := false
 	for _, v := range mysql.Versions {
+		if _, ok := wantAll[v.Tag]; ok {
+			wantAll[v.Tag] = true
+		}
 		if v.Canonical {
-			t.Errorf("ListPresets must not surface canonical version %q in the alternates picker", v.Tag)
-		}
-		if v.Tag == "8.4" {
-			t.Errorf("8.4 is canonical and should be filtered out of mysql alternates")
+			canonicalFound = true
 		}
 	}
-	wantAlts := map[string]bool{"9.7": false, "5.7": false}
-	for _, v := range mysql.Versions {
-		if _, ok := wantAlts[v.Tag]; ok {
-			wantAlts[v.Tag] = true
-		}
-	}
-	for tag, found := range wantAlts {
+	for tag, found := range wantAll {
 		if !found {
-			t.Errorf("expected mysql alternate %q in picker, got %v", tag, mysql.Versions)
+			t.Errorf("expected mysql version %q in picker, got %v", tag, mysql.Versions)
 		}
+	}
+	if !canonicalFound {
+		t.Errorf("ListPresets must surface the canonical version so users can pick the default install explicitly")
+	}
+	if mysql.DefaultVersion != "8.4" {
+		t.Errorf("mysql DefaultVersion = %q, want 8.4 (the canonical) so the picker preselects it", mysql.DefaultVersion)
+	}
+}
+
+func TestPresetVersionServiceName(t *testing.T) {
+	cases := []struct {
+		name string
+		v    PresetVersion
+		want string
+	}{
+		{"postgres-pgvector", PresetVersion{Tag: "18", Canonical: true}, "postgres-pgvector"},
+		{"postgres-pgvector", PresetVersion{Tag: "17", Canonical: false}, "postgres-pgvector-17"},
+		{"mysql", PresetVersion{Tag: "8.4", Canonical: true}, "mysql"},
+		{"mysql", PresetVersion{Tag: "5.7", Canonical: false}, "mysql-5-7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+"-"+tc.v.Tag, func(t *testing.T) {
+			if got := PresetVersionServiceName(tc.name, tc.v); got != tc.want {
+				t.Errorf("PresetVersionServiceName(%q, %+v) = %q, want %q", tc.name, tc.v, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -783,6 +806,104 @@ func TestPresetResolve_PostgresAlternates(t *testing.T) {
 		for _, port := range svc.Ports {
 			if strings.Contains(port, "{{") {
 				t.Errorf("postgres %s alternate ports must be substituted, got %q", tag, port)
+			}
+		}
+	}
+}
+
+func TestLoadPreset_PostgresPgvector(t *testing.T) {
+	p, err := LoadPreset("postgres-pgvector")
+	if err != nil {
+		t.Fatalf("LoadPreset(postgres-pgvector): %v", err)
+	}
+	if p.Default {
+		t.Errorf("postgres-pgvector must be opt-in, not a default preset")
+	}
+	if p.Family != "postgres" {
+		t.Errorf("postgres-pgvector Family = %q, want postgres (so pgadmin auto-discovers it)", p.Family)
+	}
+	if p.DefaultVersion != "18" {
+		t.Errorf("postgres-pgvector DefaultVersion = %q, want 18 (issue #378 specifically asks for PG18 + pgvector)", p.DefaultVersion)
+	}
+	if got := p.CanonicalTag(); got != "18" {
+		t.Errorf("postgres-pgvector CanonicalTag() = %q, want 18", got)
+	}
+	if got := p.Environment["PGDATA"]; got != "/var/lib/postgresql/data" {
+		t.Errorf("postgres-pgvector must pin PGDATA=/var/lib/postgresql/data for v18+ compat, got %q", got)
+	}
+	wantTags := map[string]bool{"18": false, "17": false, "16": false}
+	for _, v := range p.Versions {
+		if _, ok := wantTags[v.Tag]; ok {
+			wantTags[v.Tag] = true
+		}
+		if !strings.Contains(v.Image, "pgvector/pgvector") {
+			t.Errorf("postgres-pgvector version %q must use the pgvector/pgvector image, got %q", v.Tag, v.Image)
+		}
+	}
+	for tag, found := range wantTags {
+		if !found {
+			t.Errorf("postgres-pgvector preset missing version %q", tag)
+		}
+	}
+}
+
+func TestPresetResolve_PostgresPgvectorCanonical(t *testing.T) {
+	p, err := LoadPreset("postgres-pgvector")
+	if err != nil {
+		t.Fatalf("LoadPreset: %v", err)
+	}
+	svc, err := p.Resolve("18")
+	if err != nil {
+		t.Fatalf("Resolve(18): %v", err)
+	}
+	if svc.Name != "postgres-pgvector" {
+		t.Errorf("canonical postgres-pgvector Name = %q, want bare postgres-pgvector", svc.Name)
+	}
+	if len(svc.Ports) != 1 || svc.Ports[0] != "5518:5432" {
+		t.Errorf("canonical postgres-pgvector Ports = %v, want [5518:5432]", svc.Ports)
+	}
+	if svc.ConnectionURL != "postgresql://postgres:lerd@127.0.0.1:5518/lerd" {
+		t.Errorf("canonical postgres-pgvector ConnectionURL = %q", svc.ConnectionURL)
+	}
+	wantHost := "DB_HOST=lerd-postgres-pgvector"
+	found := false
+	for _, kv := range svc.EnvVars {
+		if kv == wantHost {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected %s in env_vars, got %v", wantHost, svc.EnvVars)
+	}
+}
+
+func TestPresetResolve_PostgresPgvectorAlternates(t *testing.T) {
+	p, err := LoadPreset("postgres-pgvector")
+	if err != nil {
+		t.Fatalf("LoadPreset: %v", err)
+	}
+	cases := map[string]struct {
+		wantName string
+		wantPort string
+	}{
+		"17": {"postgres-pgvector-17", "5517:5432"},
+		"16": {"postgres-pgvector-16", "5516:5432"},
+	}
+	for tag, want := range cases {
+		svc, err := p.Resolve(tag)
+		if err != nil {
+			t.Fatalf("Resolve(%s): %v", tag, err)
+		}
+		if svc.Name != want.wantName {
+			t.Errorf("postgres-pgvector %s: Name = %q, want %q", tag, svc.Name, want.wantName)
+		}
+		if len(svc.Ports) == 0 || svc.Ports[0] != want.wantPort {
+			t.Errorf("postgres-pgvector %s: Ports = %v, want [%s]", tag, svc.Ports, want.wantPort)
+		}
+		for _, port := range svc.Ports {
+			if strings.Contains(port, "{{") {
+				t.Errorf("postgres-pgvector %s alternate ports must be substituted, got %q", tag, port)
 			}
 		}
 	}

--- a/internal/config/project_update.go
+++ b/internal/config/project_update.go
@@ -231,21 +231,37 @@ type CommandValidationError struct{ Reason string }
 
 func (e *CommandValidationError) Error() string { return "invalid command: " + e.Reason }
 
-// ReplaceProjectDBService removes any existing sqlite/mysql/postgres service
-// and adds the given choice. Creates .lerd.yaml entries even if the file
-// doesn't exist yet (database choice is typically part of initial setup).
+// ReplaceProjectDBService removes any existing DB service entry from the
+// project's .lerd.yaml and adds the given choice. A "DB service" is sqlite or
+// any service in the mysql / mariadb / postgres / mongo families, so alternates
+// like postgres-pgvector or mariadb-10-11 replace the previous DB pick
+// cleanly. Creates .lerd.yaml entries even if the file doesn't exist yet.
 func ReplaceProjectDBService(dir string, choice string) error {
 	cfg, err := LoadProjectConfig(dir)
 	if err != nil {
 		return err
 	}
-	dbNames := map[string]bool{"sqlite": true, "mysql": true, "postgres": true}
 	filtered := cfg.Services[:0]
 	for _, svc := range cfg.Services {
-		if !dbNames[svc.Name] {
+		if !IsDBServiceName(svc.Name) {
 			filtered = append(filtered, svc)
 		}
 	}
 	cfg.Services = append(filtered, ProjectService{Name: choice})
 	return SaveProjectConfig(dir, cfg)
+}
+
+// IsDBServiceName reports whether name refers to a database service: sqlite,
+// or any service whose family is mysql, mariadb, postgres, or mongo. Used by
+// the DB-picker logic in `lerd env` and `db_set` to decide what counts as
+// "the database for this project".
+func IsDBServiceName(name string) bool {
+	if name == "sqlite" {
+		return true
+	}
+	switch FamilyOfName(name) {
+	case "mysql", "mariadb", "postgres", "mongo":
+		return true
+	}
+	return false
 }

--- a/internal/config/project_update_test.go
+++ b/internal/config/project_update_test.go
@@ -425,3 +425,67 @@ func TestReplaceProjectDBService_CreatesFileIfMissing(t *testing.T) {
 		t.Errorf("Services = %v, want [{mysql}]", cfg.Services)
 	}
 }
+
+func TestReplaceProjectDBService_ReplacesFamilyAlternate(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, "lerd", "services"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	yaml := `name: postgres-pgvector
+family: postgres
+image: docker.io/pgvector/pgvector:pg18
+`
+	if err := os.WriteFile(filepath.Join(tmp, "lerd", "services", "postgres-pgvector.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write fake service: %v", err)
+	}
+	dir := setupProjectConfig(t, &ProjectConfig{
+		Services: []ProjectService{
+			{Name: "postgres-pgvector"},
+			{Name: "redis"},
+		},
+	})
+	if err := ReplaceProjectDBService(dir, "mysql"); err != nil {
+		t.Fatal(err)
+	}
+	cfg := loadConfig(t, dir)
+	for _, svc := range cfg.Services {
+		if svc.Name == "postgres-pgvector" {
+			t.Errorf("postgres-pgvector should have been replaced, got services: %v", cfg.Services)
+		}
+	}
+}
+
+func TestIsDBServiceName(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, "lerd", "services"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	yaml := `name: postgres-pgvector
+family: postgres
+image: docker.io/pgvector/pgvector:pg18
+`
+	if err := os.WriteFile(filepath.Join(tmp, "lerd", "services", "postgres-pgvector.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write fake service: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{
+		{"sqlite", true},
+		{"mysql", true},
+		{"postgres", true},
+		{"postgres-pgvector", true},
+		{"redis", false},
+		{"meilisearch", false},
+		{"", false},
+		{"made-up-service", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsDBServiceName(tc.name); got != tc.want {
+				t.Errorf("IsDBServiceName(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -401,12 +401,12 @@ func toolList() []mcpTool {
 		},
 		{
 			Name:        "db_set",
-			Description: "Pick the project database. Persists to .lerd.yaml, rewrites DB_ keys in .env, starts service, creates DB + _testing. Call before env_setup on fresh clones.",
+			Description: "Pick the project database: sqlite, mysql, postgres, or an installed family alternate (mariadb, postgres-pgvector, …). Persists to .lerd.yaml, rewrites DB_ keys, starts service, creates DB + _testing.",
 			InputSchema: mcpSchema{
 				Type: "object",
 				Properties: map[string]mcpProp{
 					"path":     {Type: "string", Description: "Project root."},
-					"database": {Type: "string", Enum: []string{"sqlite", "mysql", "postgres"}},
+					"database": {Type: "string"},
 				},
 				Required: []string{"database"},
 			},
@@ -2765,8 +2765,7 @@ func execServicePresetList(_ map[string]any) (any, *rpcError) {
 		} else {
 			anyInstalled := false
 			for _, v := range p.Versions {
-				name := p.Name + "-" + config.SanitizeImageTag(v.Tag)
-				_, loadErr := config.LoadCustomService(name)
+				_, loadErr := config.LoadCustomService(config.PresetVersionServiceName(p.Name, v))
 				vi := versionEntry{
 					Tag:       v.Tag,
 					Label:     v.Label,
@@ -3044,20 +3043,18 @@ func execDbSet(args map[string]any) (any, *rpcError) {
 		return toolErr("path is required — pass a path argument or open Claude in the project directory"), nil
 	}
 	choice := strings.ToLower(strings.TrimSpace(strArg(args, "database")))
-	switch choice {
-	case "sqlite", "mysql", "postgres":
-	case "":
-		return toolErr("database is required — must be one of: sqlite, mysql, postgres"), nil
-	default:
-		return toolErr(fmt.Sprintf("invalid database %q — must be one of: sqlite, mysql, postgres", choice)), nil
+	if choice == "" {
+		return toolErr("database is required — pass sqlite, a built-in (mysql/postgres), or an installed family alternate (e.g. mariadb, postgres-pgvector, mysql-5-7)"), nil
+	}
+	if !config.IsDBServiceName(choice) {
+		return toolErr(fmt.Sprintf("invalid database %q — must be sqlite or a service in the mysql/mariadb/postgres/mongo families (install the preset with `lerd service preset %s` first if needed)", choice, choice)), nil
 	}
 
 	// Check existing DB for the summary message.
 	previous := ""
 	if proj, _ := config.LoadProjectConfig(projectPath); proj != nil {
-		dbNames := map[string]bool{"sqlite": true, "mysql": true, "postgres": true}
 		for _, svc := range proj.Services {
-			if dbNames[svc.Name] {
+			if config.IsDBServiceName(svc.Name) {
 				previous = svc.Name
 				break
 			}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2888,9 +2888,9 @@ func execServiceMigrate(args map[string]any) (any, *rpcError) {
 	if err != nil || avail.CurrentImage == "" {
 		return toolErr("could not resolve current image for " + name), nil
 	}
-	target := avail.CurrentImage
-	if at := strings.LastIndex(target, ":"); at > 0 {
-		target = target[:at] + ":" + tag
+	target, err := serviceops.ResolveMigrateTarget(name, avail.CurrentImage, tag)
+	if err != nil {
+		return toolErr(err.Error()), nil
 	}
 	var lastImage string
 	emit := func(ev serviceops.PhaseEvent) {

--- a/internal/serviceops/migrate.go
+++ b/internal/serviceops/migrate.go
@@ -72,21 +72,20 @@ func familyOf(name string) string {
 	return config.FamilyOfName(name)
 }
 
-// presetForService returns the bundled preset a service was installed from,
-// resolving a default-preset name directly and an installed custom service via
-// its saved Preset reference. Returns nil when the service has no preset.
-func presetForService(name string) (*config.Preset, error) {
+// presetForService returns the bundled preset a service was installed from, or
+// nil when it has none or cannot be resolved. A nil result makes the migrate
+// target fall back to literal-tag substitution on the current image.
+func presetForService(name string) *config.Preset {
 	if config.IsDefaultPreset(name) {
-		return config.LoadPreset(name)
+		p, _ := config.LoadPreset(name)
+		return p
 	}
 	svc, err := config.LoadCustomService(name)
-	if err != nil {
-		return nil, fmt.Errorf("unknown service %q", name)
+	if err != nil || svc.Preset == "" {
+		return nil
 	}
-	if svc.Preset == "" {
-		return nil, nil
-	}
-	return config.LoadPreset(svc.Preset)
+	p, _ := config.LoadPreset(svc.Preset)
+	return p
 }
 
 // ResolveMigrateTarget maps a migrate version argument to a target image. A
@@ -97,8 +96,7 @@ func ResolveMigrateTarget(name, currentImage, version string) (string, error) {
 	if version == "" {
 		return "", fmt.Errorf("a target version is required")
 	}
-	p, _ := presetForService(name)
-	return migrateTargetImage(p, currentImage, version)
+	return migrateTargetImage(presetForService(name), currentImage, version)
 }
 
 // migrateTargetImage is the pure resolution behind ResolveMigrateTarget, split
@@ -259,19 +257,80 @@ func waitContainerReady(container, probeCmd string, envPairs []string, timeout t
 	return fmt.Errorf("container %s never became ready within %s", container, timeout)
 }
 
-// abortMigrate is the shared post-failure recovery: try to put the old data
-// dir back and restart the old unit, joining errors so neither fix is silent.
-func abortMigrate(unit, name, backup string, restartOldUnit bool, cause error) error {
+// serviceConfigSnapshot captures a service's pre-migrate config so a failed
+// image switch can be fully reverted instead of left half-applied.
+type serviceConfigSnapshot struct {
+	defaultPreset bool
+	entry         config.ServiceConfig
+	custom        *config.CustomService
+}
+
+// captureServiceConfig snapshots the on-disk service config before a migrate
+// mutates it.
+func captureServiceConfig(name string) (*serviceConfigSnapshot, error) {
+	if config.IsDefaultPreset(name) {
+		cfg, err := config.LoadGlobal()
+		if err != nil {
+			return nil, err
+		}
+		return &serviceConfigSnapshot{defaultPreset: true, entry: cfg.Services[name]}, nil
+	}
+	svc, err := config.LoadCustomService(name)
+	if err != nil {
+		return nil, err
+	}
+	return &serviceConfigSnapshot{custom: svc}, nil
+}
+
+// restoreConfig writes the snapshot back. It skips the quadlet so the config
+// revert stays unit-testable; restoreQuadlet regenerates the unit file.
+func (s *serviceConfigSnapshot) restoreConfig(name string) error {
+	invalidateUpdateAvailability(name)
+	if s.defaultPreset {
+		cfg, err := config.LoadGlobal()
+		if err != nil {
+			return err
+		}
+		cfg.Services[name] = s.entry
+		return config.SaveGlobal(cfg)
+	}
+	if s.custom == nil {
+		return nil
+	}
+	return config.SaveCustomService(s.custom)
+}
+
+// restoreQuadlet regenerates the unit file from the restored config.
+func (s *serviceConfigSnapshot) restoreQuadlet(name string) error {
+	if s.defaultPreset {
+		return EnsureDefaultPresetQuadlet(name)
+	}
+	if s.custom == nil {
+		return nil
+	}
+	return EnsureCustomServiceQuadlet(s.custom)
+}
+
+// abortMigrate is the shared post-failure recovery: restore the old data dir,
+// revert a persisted image switch via the snapshot, and bring the unit back up,
+// joining errors so no fix is silent.
+func abortMigrate(unit, name, backup string, snapshot *serviceConfigSnapshot, cause error) error {
 	parts := []string{cause.Error()}
 	if backup != "" {
 		if err := restoreDataDirFromBackup(name, backup); err != nil {
 			parts = append(parts, "data-dir restore failed: "+err.Error()+" (backup left at "+backup+")")
 		}
 	}
-	if restartOldUnit {
-		if err := podman.StartUnit(unit); err != nil {
-			parts = append(parts, "restarting old unit failed: "+err.Error())
+	if snapshot != nil {
+		if err := snapshot.restoreConfig(name); err != nil {
+			parts = append(parts, "reverting service config failed: "+err.Error())
 		}
+		if err := snapshot.restoreQuadlet(name); err != nil {
+			parts = append(parts, "reverting quadlet failed: "+err.Error())
+		}
+	}
+	if err := podman.StartUnit(unit); err != nil {
+		parts = append(parts, "restarting unit failed: "+err.Error())
 	}
 	return fmt.Errorf("%s", strings.Join(parts, "; "))
 }
@@ -280,6 +339,10 @@ func abortMigrate(unit, name, backup string, restartOldUnit bool, cause error) e
 
 func migrateMysql(name, targetImage string, emit func(PhaseEvent)) error {
 	unit := "lerd-" + name
+	snapshot, err := captureServiceConfig(name)
+	if err != nil {
+		return fmt.Errorf("reading service config: %w", err)
+	}
 	dump := filepath.Join(config.BackupsDir(), name+"-"+timestamped()+".sql")
 	rootEnv := []string{"MYSQL_PWD=lerd"}
 
@@ -297,18 +360,18 @@ func migrateMysql(name, targetImage string, emit func(PhaseEvent)) error {
 	emit(PhaseEvent{Phase: "swapping_data_dir", Message: "old data preserved alongside the dump"})
 	backup, err := swapDataDirAside(name)
 	if err != nil {
-		return abortMigrate(unit, name, "", true, err)
+		return abortMigrate(unit, name, "", nil, err)
 	}
 
 	emit(PhaseEvent{Phase: "pulling_image", Image: targetImage})
 	if err := podman.PullImageWithProgress(targetImage, func(line string) {
 		emit(PhaseEvent{Phase: "pulling_image", Message: line})
 	}); err != nil {
-		return abortMigrate(unit, name, backup, true, fmt.Errorf("pulling target: %w", err))
+		return abortMigrate(unit, name, backup, nil, fmt.Errorf("pulling target: %w", err))
 	}
 
 	if err := switchToTargetImage(name, targetImage, emit); err != nil {
-		return abortMigrate(unit, name, backup, false, err)
+		return abortMigrate(unit, name, backup, snapshot, err)
 	}
 
 	emit(PhaseEvent{Phase: "waiting_ready", Unit: unit})
@@ -334,6 +397,10 @@ func migrateMysql(name, targetImage string, emit func(PhaseEvent)) error {
 
 func migratePostgres(name, targetImage string, emit func(PhaseEvent)) error {
 	unit := "lerd-" + name
+	snapshot, err := captureServiceConfig(name)
+	if err != nil {
+		return fmt.Errorf("reading service config: %w", err)
+	}
 	dump := filepath.Join(config.BackupsDir(), name+"-"+timestamped()+".sql")
 	pgEnv := []string{"PGPASSWORD=lerd"}
 
@@ -351,18 +418,18 @@ func migratePostgres(name, targetImage string, emit func(PhaseEvent)) error {
 	emit(PhaseEvent{Phase: "swapping_data_dir"})
 	backup, err := swapDataDirAside(name)
 	if err != nil {
-		return abortMigrate(unit, name, "", true, err)
+		return abortMigrate(unit, name, "", nil, err)
 	}
 
 	emit(PhaseEvent{Phase: "pulling_image", Image: targetImage})
 	if err := podman.PullImageWithProgress(targetImage, func(line string) {
 		emit(PhaseEvent{Phase: "pulling_image", Message: line})
 	}); err != nil {
-		return abortMigrate(unit, name, backup, true, fmt.Errorf("pulling target: %w", err))
+		return abortMigrate(unit, name, backup, nil, fmt.Errorf("pulling target: %w", err))
 	}
 
 	if err := switchToTargetImage(name, targetImage, emit); err != nil {
-		return abortMigrate(unit, name, backup, false, err)
+		return abortMigrate(unit, name, backup, snapshot, err)
 	}
 
 	emit(PhaseEvent{Phase: "waiting_ready", Unit: unit})

--- a/internal/serviceops/migrate.go
+++ b/internal/serviceops/migrate.go
@@ -67,13 +67,7 @@ func familyOf(name string) string {
 			return p.Family
 		}
 	}
-	if svc, err := config.LoadCustomService(name); err == nil {
-		if svc.Family != "" {
-			return svc.Family
-		}
-		return config.InferFamily(svc.Name)
-	}
-	return ""
+	return config.FamilyOfName(name)
 }
 
 func timestamped() string { return time.Now().UTC().Format("20060102-150405") }

--- a/internal/serviceops/migrate.go
+++ b/internal/serviceops/migrate.go
@@ -1,11 +1,13 @@
 package serviceops
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -70,6 +72,53 @@ func familyOf(name string) string {
 	return config.FamilyOfName(name)
 }
 
+// presetForService returns the bundled preset a service was installed from,
+// resolving a default-preset name directly and an installed custom service via
+// its saved Preset reference. Returns nil when the service has no preset.
+func presetForService(name string) (*config.Preset, error) {
+	if config.IsDefaultPreset(name) {
+		return config.LoadPreset(name)
+	}
+	svc, err := config.LoadCustomService(name)
+	if err != nil {
+		return nil, fmt.Errorf("unknown service %q", name)
+	}
+	if svc.Preset == "" {
+		return nil, nil
+	}
+	return config.LoadPreset(svc.Preset)
+}
+
+// ResolveMigrateTarget maps a migrate version argument to a target image. A
+// bare preset version ("18") resolves to that version's full preset image; an
+// unknown argument is substituted as a literal tag onto the current image.
+func ResolveMigrateTarget(name, currentImage, version string) (string, error) {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return "", fmt.Errorf("a target version is required")
+	}
+	p, _ := presetForService(name)
+	return migrateTargetImage(p, currentImage, version)
+}
+
+// migrateTargetImage is the pure resolution behind ResolveMigrateTarget, split
+// out so the rules can be tested without an installed service on disk.
+func migrateTargetImage(p *config.Preset, currentImage, version string) (string, error) {
+	if p != nil && len(p.Versions) > 0 {
+		if svc, err := p.Resolve(version); err == nil {
+			p.ApplyPlatformOverride(svc, runtime.GOOS)
+			return svc.Image, nil
+		}
+	}
+	if currentImage == "" {
+		return "", fmt.Errorf("no preset version %q and no current image to derive a tag from", version)
+	}
+	if at := strings.LastIndex(currentImage, ":"); at > 0 {
+		return currentImage[:at] + ":" + version, nil
+	}
+	return currentImage + ":" + version, nil
+}
+
 func timestamped() string { return time.Now().UTC().Format("20060102-150405") }
 
 // containerExec runs shellCmd inside a running container with a hard timeout.
@@ -107,10 +156,21 @@ func dumpToHost(container, shellCmd string, envPairs []string, hostPath string, 
 	}
 	args = append(args, container, "sh", "-c", shellCmd)
 	cmd := exec.CommandContext(ctx, podman.PodmanBin(), args...)
+	if err := runStreaming(cmd, out); err != nil {
+		return fmt.Errorf("dump command failed: %w", err)
+	}
+	return nil
+}
+
+// runStreaming runs cmd with stdout written to out and stderr captured for
+// error context. CombinedOutput refuses to run once Stdout is set, so the dump
+// path has to wire the two streams explicitly instead.
+func runStreaming(cmd *exec.Cmd, out *os.File) error {
+	var stderr bytes.Buffer
 	cmd.Stdout = out
-	stderr, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("dump command failed: %w\n%s", err, string(stderr))
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w\n%s", err, stderr.String())
 	}
 	return nil
 }

--- a/internal/serviceops/migrate_test.go
+++ b/internal/serviceops/migrate_test.go
@@ -118,3 +118,64 @@ func TestResolveMigrateTarget_EmptyVersionErrors(t *testing.T) {
 		t.Fatal("expected error for blank version argument")
 	}
 }
+
+// A migrate that fails after the image switch must leave config back on the
+// pre-migrate state, not half-applied. captureServiceConfig + restoreConfig is
+// the recovery path abortMigrate uses; this exercises it without podman.
+func TestServiceConfigSnapshot_RevertsImage(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	cfg.Services["postgres"] = config.ServiceConfig{
+		Enabled:          true,
+		Image:            "docker.io/postgis/postgis:16-3.5-alpine",
+		Port:             5432,
+		CanonicalVersion: "16",
+	}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	snap, err := captureServiceConfig("postgres")
+	if err != nil {
+		t.Fatalf("captureServiceConfig: %v", err)
+	}
+
+	// Stand in for the image switch a migrate persists right before it fails.
+	cfg, _ = config.LoadGlobal()
+	cfg.Services["postgres"] = config.ServiceConfig{
+		Enabled:          true,
+		Image:            "docker.io/postgis/postgis:18-3.6-alpine",
+		Port:             5432,
+		PreviousImage:    "docker.io/postgis/postgis:16-3.5-alpine",
+		LastOp:           "migrate",
+		CanonicalVersion: "18",
+	}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal (switch): %v", err)
+	}
+
+	if err := snap.restoreConfig("postgres"); err != nil {
+		t.Fatalf("restoreConfig: %v", err)
+	}
+
+	got, _ := config.LoadGlobal()
+	entry := got.Services["postgres"]
+	if entry.Image != "docker.io/postgis/postgis:16-3.5-alpine" {
+		t.Errorf("Image = %q, want reverted to pg16", entry.Image)
+	}
+	if entry.CanonicalVersion != "16" {
+		t.Errorf("CanonicalVersion = %q, want 16", entry.CanonicalVersion)
+	}
+	if entry.LastOp != "" {
+		t.Errorf("LastOp = %q, want cleared", entry.LastOp)
+	}
+	if entry.PreviousImage != "" {
+		t.Errorf("PreviousImage = %q, want cleared", entry.PreviousImage)
+	}
+}

--- a/internal/serviceops/migrate_test.go
+++ b/internal/serviceops/migrate_test.go
@@ -1,0 +1,120 @@
+package serviceops
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// runStreaming must write stdout to the dump file and not trip the
+// "exec: Stdout already set" error that CombinedOutput raises. This is the
+// regression guard for the dump step that broke every service migrate.
+func TestRunStreaming_WritesStdoutCapturesStderr(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dump.sql")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer f.Close()
+	cmd := exec.Command("sh", "-c", "echo dump-body; echo noise >&2")
+	if err := runStreaming(cmd, f); err != nil {
+		t.Fatalf("runStreaming: %v", err)
+	}
+	f.Close()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "dump-body" {
+		t.Errorf("dump file = %q, want dump-body", got)
+	}
+}
+
+func TestRunStreaming_FailureIncludesStderr(t *testing.T) {
+	f, err := os.Create(filepath.Join(t.TempDir(), "dump.sql"))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer f.Close()
+	cmd := exec.Command("sh", "-c", "echo boom >&2; exit 3")
+	err = runStreaming(cmd, f)
+	if err == nil {
+		t.Fatal("expected error for non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("error %q should carry stderr 'boom'", err.Error())
+	}
+}
+
+// A bare preset version label must resolve to that version's full preset image,
+// not get string-substituted as a literal tag. This is the regression guard for
+// `migrate postgres 18` producing the invalid tag postgis/postgis:18.
+func TestMigrateTargetImage_ResolvesPresetVersionLabel(t *testing.T) {
+	cases := []struct {
+		preset  string
+		version string
+		want    string
+	}{
+		{"postgres", "18", "docker.io/postgis/postgis:18-3.6-alpine"},
+		{"postgres", "16", "docker.io/postgis/postgis:16-3.5-alpine"},
+		{"postgres-pgvector", "18", "docker.io/pgvector/pgvector:pg18"},
+		{"postgres-pgvector", "17", "docker.io/pgvector/pgvector:pg17"},
+		{"mysql", "9.7", "docker.io/library/mysql:9.7"},
+		{"mariadb", "11", "docker.io/library/mariadb:11"},
+	}
+	for _, c := range cases {
+		p, err := config.LoadPreset(c.preset)
+		if err != nil {
+			t.Fatalf("LoadPreset(%q): %v", c.preset, err)
+		}
+		got, err := migrateTargetImage(p, "irrelevant/current:tag", c.version)
+		if err != nil {
+			t.Fatalf("%s %s: unexpected error: %v", c.preset, c.version, err)
+		}
+		if got != c.want {
+			t.Errorf("%s %s = %q, want %q", c.preset, c.version, got, c.want)
+		}
+	}
+}
+
+// An argument matching no preset version is substituted verbatim onto the
+// current image so exact-tag invocations keep working.
+func TestMigrateTargetImage_FallsBackToLiteralTag(t *testing.T) {
+	p, err := config.LoadPreset("postgres")
+	if err != nil {
+		t.Fatalf("LoadPreset: %v", err)
+	}
+	got, err := migrateTargetImage(p, "docker.io/postgis/postgis:16-3.5-alpine", "16.5-3.5-alpine")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "docker.io/postgis/postgis:16.5-3.5-alpine"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestMigrateTargetImage_NoPresetSubstitutesTag(t *testing.T) {
+	got, err := migrateTargetImage(nil, "docker.io/library/redis:7", "8")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "docker.io/library/redis:8"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestMigrateTargetImage_NoPresetNoCurrentImageErrors(t *testing.T) {
+	if _, err := migrateTargetImage(nil, "", "18"); err == nil {
+		t.Fatal("expected error when no preset and no current image")
+	}
+}
+
+func TestResolveMigrateTarget_EmptyVersionErrors(t *testing.T) {
+	if _, err := ResolveMigrateTarget("postgres", "docker.io/postgis/postgis:16-3.5-alpine", "  "); err == nil {
+		t.Fatal("expected error for blank version argument")
+	}
+}

--- a/internal/serviceops/provision.go
+++ b/internal/serviceops/provision.go
@@ -19,7 +19,7 @@ import (
 func CreateDatabase(svc, name string) (bool, error) {
 	container := "lerd-" + svc
 	family := svc
-	if inferred := config.InferFamily(svc); inferred != "" {
+	if inferred := config.FamilyOfName(svc); inferred != "" {
 		family = inferred
 	}
 	switch family {

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -374,12 +374,7 @@ func StopWithDependents(name string) {
 // ServiceFamily returns the family of a service by name. Honours the
 // explicit Family field on a custom service first, falls back to
 // config.InferFamily for built-ins and pattern-matched alternates.
-func ServiceFamily(name string) string {
-	if svc, err := config.LoadCustomService(name); err == nil && svc.Family != "" {
-		return svc.Family
-	}
-	return config.InferFamily(name)
-}
+func ServiceFamily(name string) string { return config.FamilyOfName(name) }
 
 // RegenerateFamilyConsumersForService is a convenience that wraps
 // RegenerateFamilyConsumers in a no-op when name has no recognised family.

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1189,7 +1189,8 @@ func handleServicePresets(w http.ResponseWriter, r *http.Request) {
 		}
 		// For single-version presets installed reflects "is the canonical
 		// service installed". For multi-version presets it reflects "are any
-		// version-suffixed instances installed", and InstalledTags lists them.
+		// instances installed" (canonical at the bare preset name OR alternates
+		// at the suffixed name), and InstalledTags lists them.
 		installed := false
 		var installedTags []string
 		if len(p.Versions) == 0 {
@@ -1198,8 +1199,7 @@ func handleServicePresets(w http.ResponseWriter, r *http.Request) {
 			}
 		} else {
 			for _, v := range p.Versions {
-				name := p.Name + "-" + config.SanitizeImageTag(v.Tag)
-				if _, err := config.LoadCustomService(name); err == nil {
+				if _, err := config.LoadCustomService(config.PresetVersionServiceName(p.Name, v)); err == nil {
 					installed = true
 					installedTags = append(installedTags, v.Tag)
 				}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1345,9 +1345,10 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "could not resolve current image", http.StatusBadRequest)
 			return
 		}
-		targetImage := avail.CurrentImage
-		if at := strings.LastIndex(targetImage, ":"); at > 0 {
-			targetImage = targetImage[:at] + ":" + targetTag
+		targetImage, err := serviceops.ResolveMigrateTarget(name, avail.CurrentImage, targetTag)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 		writeLine, _ := startNDJSONStream(w, r)
 		start := time.Now()


### PR DESCRIPTION
Adds the postgres-pgvector preset (v18 canonical, plus v17 and v16 alternates) so users wanting vector embeddings can install it as a first-class lerd service instead of hand-rolling a custom yaml. The image is pgvector/pgvector:pg<N>, no PostGIS, host ports 5518/5517/5516 to avoid colliding with the default postgres preset.

While wiring it up, three rough edges around the postgres-family code paths needed fixing for pgvector to behave like every other DB family alternate. First, config.InferFamily only matches the <family>-<digit> shape, so postgres-pgvector returned an empty family and cli/env.go decided it was not a database, skipping DB_DATABASE rewrite and createDatabase. Second, the env wizard and the MCP db_set tool hardcoded a sqlite/mysql/postgres choice, so pgvector was invisible to the pick UX even once installed. Third, the multi-version preset picker filtered the canonical version out, so users staring at the postgres-pgvector row saw only v17 and v16 in the dropdown with no obvious way to install v18.

Family resolution is now a single helper. config.FamilyOf(*CustomService) and config.FamilyOfName(string) prefer the explicit Family field over name-pattern inference, and the four sites that used to inline the same Family-then-InferFamily dance (serviceops/migrate.go, serviceops/serviceops.go, cli/init.go, plus the new env-side check) now route through it. config.IsDBServiceName is the same idea for the boolean "does this name refer to a DB" used by db_set validation and ReplaceProjectDBService.

The env wizard and db_set both build their option list dynamically from ServicesInFamily(\"mysql\") + ServicesInFamily(\"postgres\") + sqlite, so any installed family alternate (mariadb, mysql-5-7, postgres-pgvector, future ones) shows up by name. Picking pgvector in .lerd.yaml now correctly suppresses the default postgres preset via userPickedDBFromYAML and lands the right env_vars and DB creation in pgvector's container.

The preset picker dropdown gains canonical versions, marked (default) in the label and preselected via default_version. A new config.PresetVersionServiceName helper centralises the canonical-vs-suffixed name resolution so the CLI table, web UI handler, and MCP list all check install state through the same path. An installed canonical now correctly shows up in installed_tags and disappears from the dropdown the same way installed alternates always did, leaving only what the user can still install.

lerd-postgres-pgvector (and its alternates) participate in pgadmin auto-discovery via discover_family:postgres without any pgadmin-side change. There is no env_detect on the preset on purpose: DB_CONNECTION=pgsql already belongs to the default postgres detector, so first-clone auto-detection would require a tiebreaker we have not designed. The intended UX is install once via lerd service preset postgres-pgvector, pick once via wizard or db_set or .lerd.yaml, every subsequent lerd env re-run routes everything through pgvector.

Refs #378.