### PR TITLE
feat(init): seed the setup wizard from herd, ddev and lando config

### DIFF
--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -46,6 +46,30 @@ Use `--fresh` when you want to change the database engine, swap PHP versions, ad
 
 ---
 
+## Migrating from Herd, DDEV or Lando
+
+When you run `lerd init` in a project that still carries a `herd.yml`, `.ddev/config.yaml`, or `.lando.yml`, lerd detects it and offers to pre-fill the wizard from that file:
+
+```
+Detected herd.yml. Use it for wizard defaults? [Y/n]
+```
+
+Accept and the PHP version, Node version, HTTPS preference, document root, domains, and database/services are translated into the wizard's defaults, which you then review and confirm exactly like any other run. Decline and the wizard starts from plain auto-detection instead.
+
+The translation is intentionally partial, and anything it drops or changes is printed before the wizard opens:
+
+| Source field | Becomes | Note |
+|---|---|---|
+| PHP version | `php_version` | direct |
+| `secured` (Herd) | HTTPS | direct |
+| docroot / webroot | `public_dir` | direct |
+| project name + aliases / hostnames / proxy | `domains` | wildcards and full FQDNs are skipped |
+| database engine | a database service | pinned versions and ports are dropped; lerd resolves them per machine |
+
+MariaDB folds into MySQL because lerd's `mariadb` preset is an opt-in alternate; run `lerd service preset mariadb` first if you need MariaDB specifically. The framework is never translated from the source file because lerd auto-detects it. The seed only ever runs when no `.lerd.yaml` exists yet, so it never overwrites an existing lerd configuration.
+
+---
+
 ## `lerd setup`
 
 `lerd setup` is the one-shot bootstrap command for a fresh PHP project. It runs `lerd init` first (so the wizard described above appears), then shows a checkbox list of install/migrate/build steps:

--- a/internal/cli/import_seed.go
+++ b/internal/cli/import_seed.go
@@ -1,0 +1,437 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// importSeed is a ProjectConfig translated from another local-dev tool's
+// project file, used to pre-fill the `lerd init` wizard. label names the
+// source file for the confirmation prompt; notes explain what the translation
+// dropped or changed so the user can review it before the wizard opens.
+type importSeed struct {
+	label  string
+	config *config.ProjectConfig
+	notes  []string
+}
+
+// Candidate filenames for each supported tool, in preference order. Shared by
+// the per-tool seed functions and detectImportSeed so the prompt label always
+// names the file actually found.
+var (
+	herdFiles  = []string{"herd.yml", "herd.yaml"}
+	ddevFiles  = []string{filepath.Join(".ddev", "config.yaml"), filepath.Join(".ddev", "config.yml")}
+	landoFiles = []string{".lando.yml", ".lando.yaml"}
+)
+
+// detectImportSeed looks for a herd, ddev or lando project file in dir and
+// returns a seed translated from the first one found. ok is false when no
+// recognised file is present.
+func detectImportSeed(dir string) (importSeed, bool) {
+	sources := []struct {
+		files []string
+		parse func(string) (*config.ProjectConfig, []string, bool)
+	}{
+		{herdFiles, herdSeed},
+		{ddevFiles, ddevSeed},
+		{landoFiles, landoSeed},
+	}
+	for _, src := range sources {
+		cfg, notes, ok := src.parse(dir)
+		if !ok {
+			continue
+		}
+		label := "config file"
+		if path, found := findFirst(dir, src.files...); found {
+			if rel, err := filepath.Rel(dir, path); err == nil {
+				label = rel
+			}
+		}
+		return importSeed{label: label, config: cfg, notes: notes}, true
+	}
+	return importSeed{}, false
+}
+
+// applyImportSeed offers, when interactive and .lerd.yaml does not exist yet,
+// to seed the init wizard's defaults from a detected herd/ddev/lando project
+// file. It returns existing unchanged when nothing is found or the user
+// declines. Every translated value is still shown in the wizard (or printed as
+// a note here) so accepting the seed never writes anything unreviewed.
+func applyImportSeed(cwd string, existing *config.ProjectConfig) *config.ProjectConfig {
+	if !existing.IsEmpty() || !isInteractive() {
+		return existing
+	}
+	seed, ok := detectImportSeed(cwd)
+	if !ok {
+		return existing
+	}
+	fmt.Printf("Detected %s. Use it for wizard defaults? [Y/n] ", seed.label)
+	var answer string
+	fmt.Scanln(&answer) //nolint:errcheck
+	if answer != "" && answer[0] != 'Y' && answer[0] != 'y' {
+		return existing
+	}
+	for _, n := range seed.notes {
+		fmt.Printf("  - %s\n", n)
+	}
+	return seed.config
+}
+
+// ── shared helpers ───────────────────────────────────────────────────────────
+
+// flexStr decodes any YAML scalar into a string, so an unquoted `php: 8.3`
+// parses as cleanly as a quoted `php: '8.3'`.
+type flexStr string
+
+func (f *flexStr) UnmarshalYAML(value *yaml.Node) error {
+	*f = flexStr(value.Value)
+	return nil
+}
+
+// findFirst returns the path of the first of names that exists in dir.
+func findFirst(dir string, names ...string) (string, bool) {
+	for _, n := range names {
+		p := filepath.Join(dir, n)
+		if fileExists(p) {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// collectDomains normalises hostnames into lerd domains: trimmed, lowercased,
+// de-duplicated, with empty and wildcard entries removed and order preserved.
+func collectDomains(in []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, d := range in {
+		d = strings.ToLower(strings.TrimSpace(d))
+		if d == "" || strings.Contains(d, "*") || seen[d] {
+			continue
+		}
+		seen[d] = true
+		out = append(out, d)
+	}
+	return out
+}
+
+// sortedMapKeys returns the keys of m in sorted order, for deterministic output.
+func sortedMapKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// splitVersionedName splits a "name:version" string (e.g. "mariadb:11.8") into
+// its two parts. A bare "name" yields an empty version.
+func splitVersionedName(s string) (name, version string) {
+	name, version, _ = strings.Cut(strings.TrimSpace(s), ":")
+	return strings.TrimSpace(name), strings.TrimSpace(version)
+}
+
+// dbServiceForType maps another tool's database engine name to the lerd service
+// the init wizard recognises. MariaDB folds into mysql: lerd's mariadb preset
+// is an opt-in alternate the wizard does not offer by default, and the two are
+// wire-compatible for local development.
+func dbServiceForType(engine string) (service, note string, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(engine)) {
+	case "mysql":
+		return "mysql", "", true
+	case "mariadb":
+		return "mysql", "database MariaDB mapped to MySQL — run 'lerd service preset mariadb' if you need MariaDB specifically", true
+	case "postgres", "postgresql", "pgsql":
+		return "postgres", "", true
+	}
+	return "", "", false
+}
+
+// dbVersionNote reports a dropped pinned database version, if any.
+func dbVersionNote(version string) string {
+	if version == "" {
+		return ""
+	}
+	return fmt.Sprintf("database version %s dropped — lerd resolves service versions per machine", version)
+}
+
+// addService appends a ProjectService for name unless one with that name is
+// already present, so a config naming the same engine twice yields one entry.
+func addService(cfg *config.ProjectConfig, name string) {
+	for _, s := range cfg.Services {
+		if s.Name == name {
+			return
+		}
+	}
+	cfg.Services = append(cfg.Services, config.ProjectService{Name: name})
+}
+
+// ── Laravel Herd: herd.yml ───────────────────────────────────────────────────
+
+// herdConfig mirrors the subset of Laravel Herd's herd.yml that maps onto a
+// lerd project. The per-service `port` is not parsed: lerd allocates service
+// ports per machine, so a pinned Herd port carries no meaning here.
+type herdConfig struct {
+	Name     string                       `yaml:"name"`
+	PHP      flexStr                      `yaml:"php"`
+	Secured  bool                         `yaml:"secured"`
+	Aliases  []string                     `yaml:"aliases"`
+	Services map[string]herdServiceConfig `yaml:"services"`
+}
+
+type herdServiceConfig struct {
+	Version string `yaml:"version"`
+}
+
+// herdServiceToLerd maps Herd service keys to lerd service names. Herd's S3
+// service is MinIO; lerd ships RustFS as its S3-compatible store.
+var herdServiceToLerd = map[string]string{
+	"mysql":       "mysql",
+	"postgres":    "postgres",
+	"postgresql":  "postgres",
+	"redis":       "redis",
+	"meilisearch": "meilisearch",
+	"minio":       "rustfs",
+}
+
+// herdSeed reads herd.yml / herd.yaml from dir and translates it into a
+// ProjectConfig. ok is false when no Herd file is present.
+func herdSeed(dir string) (*config.ProjectConfig, []string, bool) {
+	path, ok := findFirst(dir, herdFiles...)
+	if !ok {
+		return nil, nil, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, false
+	}
+	var hc herdConfig
+	if err := yaml.Unmarshal(data, &hc); err != nil {
+		return nil, []string{fmt.Sprintf("could not parse %s: %v", filepath.Base(path), err)}, true
+	}
+
+	cfg := &config.ProjectConfig{
+		PHPVersion: strings.TrimSpace(string(hc.PHP)),
+		Secured:    hc.Secured,
+	}
+	var notes []string
+
+	cfg.Domains = collectDomains(append([]string{hc.Name}, hc.Aliases...))
+	if len(cfg.Domains) > 0 {
+		notes = append(notes, "domains: "+strings.Join(cfg.Domains, ", "))
+	}
+
+	for _, key := range sortedMapKeys(hc.Services) {
+		name, mapped := herdServiceToLerd[strings.ToLower(key)]
+		if !mapped {
+			notes = append(notes, fmt.Sprintf("service %q has no lerd equivalent — skipped", key))
+			continue
+		}
+		addService(cfg, name)
+		if v := hc.Services[key].Version; v != "" {
+			notes = append(notes, fmt.Sprintf("service %q version %s dropped — lerd resolves service versions per machine", key, v))
+		}
+	}
+	return cfg, notes, true
+}
+
+// ── DDEV: .ddev/config.yaml ──────────────────────────────────────────────────
+
+// ddevConfig mirrors the subset of DDEV's .ddev/config.yaml that maps onto a
+// lerd project. The framework (`type`) is not translated — lerd auto-detects it.
+type ddevConfig struct {
+	Name                string       `yaml:"name"`
+	PHPVersion          flexStr      `yaml:"php_version"`
+	NodeJSVersion       flexStr      `yaml:"nodejs_version"`
+	Docroot             string       `yaml:"docroot"`
+	Database            ddevDatabase `yaml:"database"`
+	AdditionalHostnames []string     `yaml:"additional_hostnames"`
+	AdditionalFQDNs     []string     `yaml:"additional_fqdns"`
+}
+
+// ddevDatabase accepts both the current scalar form ("mariadb:11.8") and the
+// legacy nested form ({type: mariadb, version: "10.11"}).
+type ddevDatabase struct {
+	Type    string
+	Version string
+}
+
+func (d *ddevDatabase) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		d.Type, d.Version = splitVersionedName(value.Value)
+		return nil
+	case yaml.MappingNode:
+		var nested struct {
+			Type    string `yaml:"type"`
+			Version string `yaml:"version"`
+		}
+		if err := value.Decode(&nested); err != nil {
+			return err
+		}
+		d.Type, d.Version = strings.TrimSpace(nested.Type), strings.TrimSpace(nested.Version)
+		return nil
+	default:
+		return nil
+	}
+}
+
+// ddevSeed reads .ddev/config.yaml (or .yml) from dir and translates it into a
+// ProjectConfig. ok is false when no DDEV config is present.
+func ddevSeed(dir string) (*config.ProjectConfig, []string, bool) {
+	path, ok := findFirst(dir, ddevFiles...)
+	if !ok {
+		return nil, nil, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, false
+	}
+	var dc ddevConfig
+	if err := yaml.Unmarshal(data, &dc); err != nil {
+		return nil, []string{fmt.Sprintf("could not parse %s: %v", filepath.Base(path), err)}, true
+	}
+
+	cfg := &config.ProjectConfig{
+		PHPVersion:  strings.TrimSpace(string(dc.PHPVersion)),
+		NodeVersion: strings.TrimSpace(string(dc.NodeJSVersion)),
+		PublicDir:   strings.TrimSpace(dc.Docroot),
+	}
+	var notes []string
+	if cfg.PublicDir != "" {
+		notes = append(notes, "public_dir: "+cfg.PublicDir)
+	}
+
+	cfg.Domains = collectDomains(append([]string{dc.Name}, dc.AdditionalHostnames...))
+	if len(cfg.Domains) > 0 {
+		notes = append(notes, "domains: "+strings.Join(cfg.Domains, ", "))
+	}
+	if len(dc.AdditionalFQDNs) > 0 {
+		notes = append(notes, "additional_fqdns not imported — add custom domains with 'lerd domain add'")
+	}
+
+	if dc.Database.Type != "" {
+		if svc, note, mapped := dbServiceForType(dc.Database.Type); mapped {
+			addService(cfg, svc)
+			if note != "" {
+				notes = append(notes, note)
+			}
+			if n := dbVersionNote(dc.Database.Version); n != "" {
+				notes = append(notes, n)
+			}
+		} else {
+			notes = append(notes, fmt.Sprintf("database %q has no lerd equivalent — skipped", dc.Database.Type))
+		}
+	}
+	return cfg, notes, true
+}
+
+// ── Lando: .lando.yml ────────────────────────────────────────────────────────
+
+// landoConfig mirrors the subset of a Lando .lando.yml that maps onto a lerd
+// project. The recipe is not translated — lerd auto-detects the framework.
+type landoConfig struct {
+	Name     string                   `yaml:"name"`
+	Config   landoRecipeConfig        `yaml:"config"`
+	Proxy    map[string][]interface{} `yaml:"proxy"`
+	Services map[string]landoService  `yaml:"services"`
+}
+
+type landoRecipeConfig struct {
+	PHP      flexStr `yaml:"php"`
+	Webroot  string  `yaml:"webroot"`
+	Database string  `yaml:"database"`
+}
+
+type landoService struct {
+	Type string `yaml:"type"`
+}
+
+// landoServiceTypeToLerd maps Lando service types to lerd service names.
+var landoServiceTypeToLerd = map[string]string{
+	"redis":         "redis",
+	"memcached":     "memcached",
+	"elasticsearch": "elasticsearch",
+	"mailhog":       "mailpit",
+}
+
+// landoSeed reads .lando.yml / .lando.yaml from dir and translates it into a
+// ProjectConfig. ok is false when no Lando file is present.
+func landoSeed(dir string) (*config.ProjectConfig, []string, bool) {
+	path, ok := findFirst(dir, landoFiles...)
+	if !ok {
+		return nil, nil, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, false
+	}
+	var lc landoConfig
+	if err := yaml.Unmarshal(data, &lc); err != nil {
+		return nil, []string{fmt.Sprintf("could not parse %s: %v", filepath.Base(path), err)}, true
+	}
+
+	cfg := &config.ProjectConfig{
+		PHPVersion: strings.TrimSpace(string(lc.Config.PHP)),
+		PublicDir:  strings.TrimSpace(lc.Config.Webroot),
+	}
+	var notes []string
+	if cfg.PublicDir != "" {
+		notes = append(notes, "public_dir: "+cfg.PublicDir)
+	}
+
+	// name + proxy hostnames (with the .lndo.site suffix and any :port removed).
+	hostnames := []string{lc.Name}
+	for _, svc := range sortedMapKeys(lc.Proxy) {
+		for _, entry := range lc.Proxy[svc] {
+			s, isStr := entry.(string)
+			if !isStr {
+				continue
+			}
+			host, _, _ := strings.Cut(s, ":")
+			hostnames = append(hostnames, strings.TrimSuffix(host, ".lndo.site"))
+		}
+	}
+	cfg.Domains = collectDomains(hostnames)
+	if len(cfg.Domains) > 0 {
+		notes = append(notes, "domains: "+strings.Join(cfg.Domains, ", "))
+	}
+
+	if lc.Config.Database != "" {
+		engine, version := splitVersionedName(lc.Config.Database)
+		if svc, note, mapped := dbServiceForType(engine); mapped {
+			addService(cfg, svc)
+			if note != "" {
+				notes = append(notes, note)
+			}
+			if n := dbVersionNote(version); n != "" {
+				notes = append(notes, n)
+			}
+		} else {
+			notes = append(notes, fmt.Sprintf("database %q has no lerd equivalent — skipped", engine))
+		}
+	}
+
+	// Extra services: a node service contributes a Node version, the rest map
+	// to lerd services where an equivalent exists.
+	for _, key := range sortedMapKeys(lc.Services) {
+		engine, version := splitVersionedName(lc.Services[key].Type)
+		if engine == "node" {
+			if version != "" && cfg.NodeVersion == "" {
+				cfg.NodeVersion = version
+			}
+			continue
+		}
+		if name, mapped := landoServiceTypeToLerd[engine]; mapped {
+			addService(cfg, name)
+		}
+	}
+	return cfg, notes, true
+}

--- a/internal/cli/import_seed_test.go
+++ b/internal/cli/import_seed_test.go
@@ -1,0 +1,373 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// writeSeedFile writes content to dir/rel, creating parent directories.
+func writeSeedFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// notesContain reports whether any note contains sub.
+func notesContain(notes []string, sub string) bool {
+	for _, n := range notes {
+		if strings.Contains(n, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// ── shared helpers ───────────────────────────────────────────────────────────
+
+func TestSplitVersionedName(t *testing.T) {
+	cases := []struct {
+		in            string
+		name, version string
+	}{
+		{"mariadb:11.8", "mariadb", "11.8"},
+		{"mysql:8.0", "mysql", "8.0"},
+		{"postgres", "postgres", ""},
+		{"  redis:6  ", "redis", "6"},
+		{"", "", ""},
+	}
+	for _, c := range cases {
+		name, version := splitVersionedName(c.in)
+		if name != c.name || version != c.version {
+			t.Errorf("splitVersionedName(%q) = (%q, %q), want (%q, %q)", c.in, name, version, c.name, c.version)
+		}
+	}
+}
+
+func TestCollectDomains(t *testing.T) {
+	cases := []struct {
+		desc string
+		in   []string
+		want []string
+	}{
+		{"dedup and lowercase", []string{"Foo", "foo", "bar"}, []string{"foo", "bar"}},
+		{"drop empty and wildcard", []string{"app", "", "*.app", "  "}, []string{"app"}},
+		{"order preserved", []string{"c", "a", "b"}, []string{"c", "a", "b"}},
+	}
+	for _, c := range cases {
+		got := collectDomains(c.in)
+		if strings.Join(got, ",") != strings.Join(c.want, ",") {
+			t.Errorf("[%s] collectDomains(%v) = %v, want %v", c.desc, c.in, got, c.want)
+		}
+	}
+}
+
+func TestDBServiceForType(t *testing.T) {
+	cases := []struct {
+		engine  string
+		service string
+		ok      bool
+		hasNote bool
+	}{
+		{"mysql", "mysql", true, false},
+		{"MariaDB", "mysql", true, true},
+		{"postgres", "postgres", true, false},
+		{"postgresql", "postgres", true, false},
+		{"pgsql", "postgres", true, false},
+		{"mssql", "", false, false},
+	}
+	for _, c := range cases {
+		service, note, ok := dbServiceForType(c.engine)
+		if service != c.service || ok != c.ok || (note != "") != c.hasNote {
+			t.Errorf("dbServiceForType(%q) = (%q, note=%q, %v), want (%q, hasNote=%v, %v)",
+				c.engine, service, note, ok, c.service, c.hasNote, c.ok)
+		}
+	}
+}
+
+// ── Herd ─────────────────────────────────────────────────────────────────────
+
+func TestHerdSeed(t *testing.T) {
+	dir := t.TempDir()
+	writeSeedFile(t, dir, "herd.yml", `name: herd-website
+php: '8.3'
+secured: true
+aliases: ['herd-laravel']
+services:
+    mysql:
+        version: 8.0.36
+        port: '${DB_PORT}'
+    redis:
+        version: 7.0.0
+        port: '${REDIS_PORT}'
+    minio:
+        version: latest
+    soketi:
+        version: 1.0
+`)
+	cfg, notes, ok := herdSeed(dir)
+	if !ok {
+		t.Fatal("herdSeed: ok=false, want true")
+	}
+	if cfg.PHPVersion != "8.3" {
+		t.Errorf("PHPVersion = %q, want 8.3", cfg.PHPVersion)
+	}
+	if !cfg.Secured {
+		t.Error("Secured = false, want true")
+	}
+	if got := strings.Join(cfg.Domains, ","); got != "herd-website,herd-laravel" {
+		t.Errorf("Domains = %q, want herd-website,herd-laravel", got)
+	}
+	// Services are emitted in sorted Herd-key order: minio, mysql, redis,
+	// soketi — so minio (→rustfs) lands first and soketi is skipped.
+	if got := strings.Join(cfg.ServiceNames(), ","); got != "rustfs,mysql,redis" {
+		t.Errorf("Services = %q, want rustfs,mysql,redis", got)
+	}
+	if !notesContain(notes, "8.0.36") || !notesContain(notes, "7.0.0") {
+		t.Errorf("notes missing dropped versions: %v", notes)
+	}
+	if !notesContain(notes, "soketi") {
+		t.Errorf("notes missing skipped service: %v", notes)
+	}
+}
+
+func TestHerdSeedUnquotedPHP(t *testing.T) {
+	dir := t.TempDir()
+	writeSeedFile(t, dir, "herd.yaml", "name: app\nphp: 8.4\n")
+	cfg, _, ok := herdSeed(dir)
+	if !ok || cfg.PHPVersion != "8.4" {
+		t.Errorf("herdSeed unquoted php = (%q, ok=%v), want (8.4, true)", cfg.PHPVersion, ok)
+	}
+}
+
+func TestHerdSeedMissing(t *testing.T) {
+	if _, _, ok := herdSeed(t.TempDir()); ok {
+		t.Error("herdSeed on empty dir: ok=true, want false")
+	}
+}
+
+// ── DDEV ─────────────────────────────────────────────────────────────────────
+
+func TestDdevSeedScalarDatabase(t *testing.T) {
+	dir := t.TempDir()
+	writeSeedFile(t, dir, ".ddev/config.yaml", `name: my-project
+type: laravel
+php_version: "8.3"
+nodejs_version: "20"
+docroot: public
+database: mariadb:11.8
+additional_hostnames:
+  - staging
+additional_fqdns:
+  - example.com
+`)
+	cfg, notes, ok := ddevSeed(dir)
+	if !ok {
+		t.Fatal("ddevSeed: ok=false, want true")
+	}
+	if cfg.PHPVersion != "8.3" || cfg.NodeVersion != "20" || cfg.PublicDir != "public" {
+		t.Errorf("got php=%q node=%q docroot=%q", cfg.PHPVersion, cfg.NodeVersion, cfg.PublicDir)
+	}
+	if got := strings.Join(cfg.Domains, ","); got != "my-project,staging" {
+		t.Errorf("Domains = %q, want my-project,staging", got)
+	}
+	if got := strings.Join(cfg.ServiceNames(), ","); got != "mysql" {
+		t.Errorf("Services = %q, want mysql (mariadb folds into mysql)", got)
+	}
+	if !notesContain(notes, "MariaDB") || !notesContain(notes, "11.8") {
+		t.Errorf("notes missing mariadb/version info: %v", notes)
+	}
+	if !notesContain(notes, "additional_fqdns") {
+		t.Errorf("notes missing additional_fqdns warning: %v", notes)
+	}
+}
+
+func TestDdevSeedNestedDatabase(t *testing.T) {
+	dir := t.TempDir()
+	writeSeedFile(t, dir, ".ddev/config.yaml", `name: legacy
+php_version: "8.2"
+database:
+  type: postgres
+  version: "15"
+`)
+	cfg, _, ok := ddevSeed(dir)
+	if !ok {
+		t.Fatal("ddevSeed: ok=false, want true")
+	}
+	if got := strings.Join(cfg.ServiceNames(), ","); got != "postgres" {
+		t.Errorf("Services = %q, want postgres", got)
+	}
+}
+
+func TestDdevSeedNoDatabase(t *testing.T) {
+	dir := t.TempDir()
+	writeSeedFile(t, dir, ".ddev/config.yaml", "name: minimal\nphp_version: \"8.3\"\n")
+	cfg, _, ok := ddevSeed(dir)
+	if !ok {
+		t.Fatal("ddevSeed: ok=false, want true")
+	}
+	if len(cfg.Services) != 0 {
+		t.Errorf("Services = %v, want none", cfg.ServiceNames())
+	}
+}
+
+// ── Lando ────────────────────────────────────────────────────────────────────
+
+func TestLandoSeed(t *testing.T) {
+	dir := t.TempDir()
+	writeSeedFile(t, dir, ".lando.yml", `name: my-app
+recipe: laravel
+config:
+  php: '8.2'
+  webroot: public
+  database: mariadb:10.11
+proxy:
+  appserver:
+    - my-app.lndo.site
+    - my-app.lndo.site:8080
+services:
+  cache:
+    type: redis:6
+  node:
+    type: node:18
+`)
+	cfg, notes, ok := landoSeed(dir)
+	if !ok {
+		t.Fatal("landoSeed: ok=false, want true")
+	}
+	if cfg.PHPVersion != "8.2" || cfg.PublicDir != "public" {
+		t.Errorf("got php=%q webroot=%q", cfg.PHPVersion, cfg.PublicDir)
+	}
+	if cfg.NodeVersion != "18" {
+		t.Errorf("NodeVersion = %q, want 18 (from node service)", cfg.NodeVersion)
+	}
+	if got := strings.Join(cfg.Domains, ","); got != "my-app" {
+		t.Errorf("Domains = %q, want my-app", got)
+	}
+	if got := strings.Join(cfg.ServiceNames(), ","); got != "mysql,redis" {
+		t.Errorf("Services = %q, want mysql,redis", got)
+	}
+	if !notesContain(notes, "10.11") {
+		t.Errorf("notes missing dropped database version: %v", notes)
+	}
+}
+
+func TestLandoSeedMissing(t *testing.T) {
+	if _, _, ok := landoSeed(t.TempDir()); ok {
+		t.Error("landoSeed on empty dir: ok=true, want false")
+	}
+}
+
+// Two Lando services of the same type must collapse to a single lerd service.
+func TestLandoSeedDeduplicatesServices(t *testing.T) {
+	dir := t.TempDir()
+	writeSeedFile(t, dir, ".lando.yml", `name: dup-app
+config:
+  php: '8.2'
+services:
+  cache:
+    type: redis:6
+  sessions:
+    type: redis:7
+`)
+	cfg, _, ok := landoSeed(dir)
+	if !ok {
+		t.Fatal("landoSeed: ok=false, want true")
+	}
+	if got := strings.Join(cfg.ServiceNames(), ","); got != "redis" {
+		t.Errorf("Services = %q, want a single deduplicated redis", got)
+	}
+}
+
+// ── detectImportSeed ─────────────────────────────────────────────────────────
+
+func TestDetectImportSeed(t *testing.T) {
+	t.Run("none", func(t *testing.T) {
+		if _, ok := detectImportSeed(t.TempDir()); ok {
+			t.Error("detectImportSeed on empty dir: ok=true, want false")
+		}
+	})
+
+	t.Run("ddev", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSeedFile(t, dir, ".ddev/config.yaml", "name: d\nphp_version: \"8.3\"\n")
+		seed, ok := detectImportSeed(dir)
+		if !ok || seed.label != ".ddev/config.yaml" {
+			t.Errorf("detectImportSeed = (%q, %v), want (.ddev/config.yaml, true)", seed.label, ok)
+		}
+	})
+
+	t.Run("herd wins over ddev", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSeedFile(t, dir, "herd.yml", "name: h\nphp: '8.3'\n")
+		writeSeedFile(t, dir, ".ddev/config.yaml", "name: d\nphp_version: \"8.2\"\n")
+		seed, ok := detectImportSeed(dir)
+		if !ok || seed.label != "herd.yml" {
+			t.Errorf("detectImportSeed = (%q, %v), want (herd.yml, true)", seed.label, ok)
+		}
+	})
+}
+
+// Verify a seeded config is non-empty so applyImportSeed's IsEmpty guard
+// behaves as expected.
+func TestSeedIsNonEmpty(t *testing.T) {
+	dir := t.TempDir()
+	writeSeedFile(t, dir, "herd.yml", "name: app\nphp: '8.3'\n")
+	cfg, _, ok := herdSeed(dir)
+	if !ok {
+		t.Fatal("herdSeed: ok=false")
+	}
+	if (&config.ProjectConfig{}).IsEmpty() != true {
+		t.Error("empty ProjectConfig should report IsEmpty")
+	}
+	if cfg.IsEmpty() {
+		t.Error("seeded ProjectConfig should not report IsEmpty")
+	}
+}
+
+// TestSeedFileVariants exercises every supported filename for each tool, so a
+// project using the .yml or .yaml spelling is detected and parsed either way.
+func TestSeedFileVariants(t *testing.T) {
+	cases := []struct {
+		desc    string
+		rel     string
+		content string
+		seed    func(string) (*config.ProjectConfig, []string, bool)
+	}{
+		{"herd.yml", "herd.yml", "name: a\nphp: '8.3'\n", herdSeed},
+		{"herd.yaml", "herd.yaml", "name: a\nphp: '8.3'\n", herdSeed},
+		{"ddev config.yaml", filepath.Join(".ddev", "config.yaml"), "name: a\nphp_version: \"8.3\"\n", ddevSeed},
+		{"ddev config.yml", filepath.Join(".ddev", "config.yml"), "name: a\nphp_version: \"8.3\"\n", ddevSeed},
+		{"lando .lando.yml", ".lando.yml", "name: a\nconfig:\n  php: '8.3'\n", landoSeed},
+		{"lando .lando.yaml", ".lando.yaml", "name: a\nconfig:\n  php: '8.3'\n", landoSeed},
+	}
+	for _, c := range cases {
+		dir := t.TempDir()
+		writeSeedFile(t, dir, c.rel, c.content)
+
+		cfg, _, ok := c.seed(dir)
+		if !ok {
+			t.Errorf("[%s] seed: ok=false, want true", c.desc)
+			continue
+		}
+		if cfg.PHPVersion != "8.3" {
+			t.Errorf("[%s] PHPVersion = %q, want 8.3", c.desc, cfg.PHPVersion)
+		}
+		seed, found := detectImportSeed(dir)
+		if !found {
+			t.Errorf("[%s] detectImportSeed: found=false, want true", c.desc)
+			continue
+		}
+		if seed.label != c.rel {
+			t.Errorf("[%s] label = %q, want %q (must name the actual file)", c.desc, seed.label, c.rel)
+		}
+	}
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -51,6 +51,7 @@ func runInit(fresh bool) error {
 		if err != nil {
 			return err
 		}
+		existing = applyImportSeed(cwd, existing)
 		cfg, err := runWizard(cwd, existing)
 		if err != nil {
 			return err
@@ -915,6 +916,7 @@ func runSetupInit(cwd string, skipWizard bool) error {
 
 	if !hasExisting {
 		existing, _ := config.LoadProjectConfig(cwd)
+		existing = applyImportSeed(cwd, existing)
 		cfg, err := runWizard(cwd, existing)
 		if err != nil {
 			return err


### PR DESCRIPTION
Teams migrating to lerd from Laravel Herd, DDEV or Lando already have a project config file that lerd previously ignored. This wires those files into `lerd init` so the migration starts from real values instead of a blank wizard.

When `lerd init` runs in a project that still carries a `herd.yml`, a `.ddev/config.yaml` or a `.lando.yml`, it detects the file and asks whether to use it for the wizard defaults. Both filename spellings are recognised for each tool. Accepting it translates the PHP version, Node version, HTTPS preference, document root, domains and the database or service list into the wizard's defaults, which are then reviewed and confirmed exactly like any other run. Declining leaves the wizard on plain auto-detection. The prompt is gated so a stale config file that someone has mentally moved past does not silently steer the setup, and the whole thing only fires when no `.lerd.yaml` exists yet, so it never touches an existing lerd configuration.

The translation is deliberately partial, and everything it drops or changes is printed as a note before the wizard opens. Pinned service versions and ports are dropped because lerd resolves those per machine. MariaDB folds into MySQL because lerd's mariadb preset is an opt-in alternate the wizard does not list by default, with a note pointing at `lerd service preset mariadb` for anyone who needs it specifically. The framework is never translated from the source file since lerd auto-detects it more reliably. Seeded domains and document root are surfaced in the notes too, because the wizard has no prompt for them.
