### PR TITLE
feat(dns): VPN-aware DNS status and automatic container DNS re-sync

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -66,7 +66,7 @@ The chain in order:
 | `dig @127.0.0.1 -p 5300` | A direct query at port 5300 returns 127.0.0.1 for `lerd-probe.<tld>`. | dnsmasq is up but its config drifted. `systemctl --user restart lerd-dns`. |
 | `resolver hookup` | The NetworkManager dispatcher script or systemd-resolved drop-in is installed. | Rerun `lerd install`. |
 | `interface routes .test to 5300` | `resolvectl status` shows `127.0.0.1:5300` and `~<tld>` on the active interface. | `sudo systemctl restart NetworkManager`, or set the routing manually with `sudo resolvectl domain <iface> ~test ~.`. |
-| `system DNS lookup` | `host lerd-probe.test` (the system resolver) returns 127.0.0.1. | The drop-in is installed but resolved isn't honouring it. Check whether cloud-init or another tool wrote a higher-priority resolver config. Common on EC2 / cloud images. |
+| `system DNS lookup` | `host lerd-probe.test` (the system resolver) returns 127.0.0.1. | The drop-in is installed but resolved isn't honouring it. Check whether cloud-init or another tool wrote a higher-priority resolver config. Common on EC2 / cloud images. With a VPN connected this rung is reported as a warning rather than a failure, see the VPN section below. |
 
 You can also call this programmatically over MCP via the `dns_diagnose` tool, useful for AI-driven troubleshooting:
 
@@ -75,6 +75,20 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"dns_diagno
 ```
 
 The response includes a `steps` array with a `status` (`ok` / `fail` / `warn` / `skip`) and `hint` per rung, plus a `first_failure` index so an LLM can jump straight to the broken layer.
+:::
+
+::: details DNS shows "Degraded" while connected to a VPN
+Corporate VPN clients such as Cisco AnyConnect take over the system resolver when they connect, rewriting systemd-resolved so `.test` no longer routes to lerd-dns through the normal path. lerd-dns itself keeps running and answering, so the dashboard shows a yellow **Degraded** pill rather than a red **Failed** one, and `lerd doctor` reports the `system DNS lookup` rung as a warning instead of a failure. Sites still resolve, because lerd-dns answers directly on `127.0.0.1:5300`.
+
+The watcher notices when the host resolver environment changes (a VPN connecting or disconnecting, or a network switch) and automatically re-syncs the container network's DNS: it re-points aardvark-dns at the current host resolvers and reloads the network so containers pick them up. This is what previously required a manual `lerd restart` after connecting the VPN before PHP could reach VPN-internal API endpoints. The re-sync briefly (about a second) interrupts DNS for lerd containers while aardvark-dns restarts with a fresh cache.
+
+If you want the system resolver path itself restored while the VPN is up, so the pill goes back to green, move `resolve` after `dns` in the `hosts:` line of `/etc/nsswitch.conf`:
+
+```text
+hosts: mymachines mdns_minimal [NOTFOUND=return] files myhostname dns resolve
+```
+
+This makes glibc consult the plain `dns` module before systemd-resolved's `nss-resolve`, which the VPN client no longer shadows.
 :::
 
 ::: details Nginx not serving a site

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -56,10 +56,13 @@ func runStatus(_ *cobra.Command, _ []string) error {
 	if !cfg.DNS.Enabled {
 		ok2(fmt.Sprintf("DNS managed externally (.%s)", cfg.DNS.TLD))
 	} else {
-		ok, _ := dns.Check(cfg.DNS.TLD)
-		if ok {
+		switch dns.CheckStatus(cfg.DNS.TLD) {
+		case dns.StatusOK:
 			ok2(fmt.Sprintf(".%s resolution", cfg.DNS.TLD))
-		} else {
+		case dns.StatusDegraded:
+			warn2(fmt.Sprintf(".%s resolution", cfg.DNS.TLD),
+				"lerd-dns healthy, system resolver bypassed (VPN?)")
+		default:
 			fail2(fmt.Sprintf(".%s resolution", cfg.DNS.TLD),
 				"not resolving",
 				dnsRestartHint())

--- a/internal/dns/diagnose.go
+++ b/internal/dns/diagnose.go
@@ -56,6 +56,7 @@ type probeFns struct {
 	resolverHookup   func() (kind string, exists bool, path string)
 	interfaceRouting func(tld string) (interfaceName string, has5300 bool, hasTLD bool, err error)
 	systemLookup     func(tld string) (addrs []string, err error)
+	vpnActive        func() bool
 }
 
 // Diagnose walks the DNS chain top to bottom and returns a structured
@@ -180,26 +181,40 @@ func diagnose(tld string, p probeFns) Diagnostic {
 
 	// Rung 7 — end to end resolution at port 53.
 	addrs, err := p.systemLookup(tld)
+	vpn := p.vpnActive != nil && p.vpnActive()
 	switch {
 	case err != nil:
-		d.Steps = append(d.Steps, Step{
-			Name:   "system DNS lookup",
-			Status: StepFail,
-			Detail: err.Error(),
-			Hint:   "lerd-dns is reachable directly but the system resolver isn't using it; check cloud-init or other tools that may overwrite resolved.conf",
-		})
+		d.Steps = append(d.Steps, systemLookupFailStep(err.Error(), vpn))
 	case !contains(addrs, "127.0.0.1"):
-		d.Steps = append(d.Steps, Step{
-			Name:   "system DNS lookup",
-			Status: StepFail,
-			Detail: fmt.Sprintf("got %v, want one entry to be 127.0.0.1", addrs),
-			Hint:   "drop-in is installed but resolved isn't honouring it; check whether cloud-init or another tool wrote a higher-priority resolver config",
-		})
+		d.Steps = append(d.Steps, systemLookupFailStep(
+			fmt.Sprintf("got %v, want one entry to be 127.0.0.1", addrs), vpn))
 	default:
 		d.Steps = append(d.Steps, Step{Name: "system DNS lookup", Status: StepOK, Detail: "127.0.0.1"})
 	}
 
 	return finalize(d)
+}
+
+// systemLookupFailStep builds the Rung 7 failure step. When a VPN tunnel
+// is up the system-resolver path failing is expected: the VPN client has
+// taken over DNS, .test still resolves via lerd-dns directly, and the
+// watcher re-syncs container DNS automatically. That is a warning, not a
+// failure, so the chain doesn't flag a broken state lerd already handles.
+func systemLookupFailStep(detail string, vpn bool) Step {
+	if vpn {
+		return Step{
+			Name:   "system DNS lookup",
+			Status: StepWarn,
+			Detail: detail,
+			Hint:   "a VPN tunnel is up and has taken over the system resolver; .test still resolves via lerd-dns directly and lerd re-syncs container DNS automatically when the VPN changes",
+		}
+	}
+	return Step{
+		Name:   "system DNS lookup",
+		Status: StepFail,
+		Detail: detail,
+		Hint:   "lerd-dns is reachable directly but the system resolver isn't using it; check cloud-init or other tools that may overwrite resolved.conf",
+	}
 }
 
 // finalize walks the steps once to find the first failure, marking every
@@ -244,6 +259,7 @@ func defaultProbes() probeFns {
 		resolverHookup:   defaultResolverHookup,
 		interfaceRouting: defaultInterfaceRouting,
 		systemLookup:     defaultSystemLookup,
+		vpnActive:        VPNActive,
 	}
 }
 

--- a/internal/dns/diagnose_test.go
+++ b/internal/dns/diagnose_test.go
@@ -18,6 +18,7 @@ func fakeProbes() probeFns {
 		resolverHookup:   func() (string, bool, string) { return "drop-in", true, "/etc/x" },
 		interfaceRouting: func(string) (string, bool, bool, error) { return "eth0", true, true, nil },
 		systemLookup:     func(string) ([]string, error) { return []string{"127.0.0.1"}, nil },
+		vpnActive:        func() bool { return false },
 	}
 }
 
@@ -106,6 +107,28 @@ func TestDiagnose_systemLookupNotFinalizedAsSkip(t *testing.T) {
 	}
 	if !strings.Contains(last.Hint, "cloud-init") {
 		t.Errorf("hint %q should mention cloud-init", last.Hint)
+	}
+}
+
+// TestDiagnose_systemLookupUnderVPNIsWarn pins the VPN-aware Rung 7: when a
+// tunnel is up, the system-resolver path failing is expected and lerd
+// recovers on its own, so it must downgrade to a warning rather than a
+// failure that would mark the whole chain broken.
+func TestDiagnose_systemLookupUnderVPNIsWarn(t *testing.T) {
+	p := fakeProbes()
+	p.systemLookup = func(string) ([]string, error) { return nil, errors.New("server misbehaving") }
+	p.vpnActive = func() bool { return true }
+	d := diagnose("test", p)
+
+	last := d.Steps[len(d.Steps)-1]
+	if last.Status != StepWarn {
+		t.Errorf("system lookup under VPN = %s, want warn", last.Status)
+	}
+	if d.FirstFailure != -1 {
+		t.Errorf("FirstFailure = %d, want -1 (a VPN warn is not a chain failure)", d.FirstFailure)
+	}
+	if !strings.Contains(last.Hint, "VPN") {
+		t.Errorf("hint %q should mention VPN", last.Hint)
 	}
 }
 

--- a/internal/dns/probe.go
+++ b/internal/dns/probe.go
@@ -46,3 +46,53 @@ func Check(tld string) (bool, error) {
 	}
 	return false, nil
 }
+
+// Status is the three-way DNS health the dashboard pill renders. It exists
+// to separate a genuine lerd-dns outage from the common case where
+// lerd-dns is perfectly healthy but the system resolver isn't routing the
+// TLD to it, which a VPN client typically causes by rewriting
+// systemd-resolved when it connects.
+type Status string
+
+const (
+	StatusOK       Status = "ok"       // system resolver routes the TLD to lerd-dns
+	StatusDegraded Status = "degraded" // lerd-dns answers directly, system resolver bypassed
+	StatusDown     Status = "down"     // lerd-dns itself is not answering
+)
+
+// CheckStatus reports three-way DNS health. It runs Check first (the
+// end-to-end system-resolver path); when that fails it queries lerd's
+// dnsmasq directly on 127.0.0.1:5300. A direct answer means lerd-dns is up
+// and only the resolver hookup is bypassed, so the result is Degraded
+// rather than Down.
+func CheckStatus(tld string) Status {
+	// Check already short-circuits to true in disabled mode, so that case
+	// resolves to StatusOK here without a separate branch.
+	if ok, _ := Check(tld); ok {
+		return StatusOK
+	}
+	if dnsmasqDirectOK(tld) {
+		return StatusDegraded
+	}
+	return StatusDown
+}
+
+// dnsmasqDirectOK queries lerd's dnsmasq straight on 127.0.0.1:5300,
+// bypassing the system resolver entirely. It returns true when dnsmasq
+// answers with an address lerd would legitimately hand out, which is the
+// signal that lerd-dns is alive even though the system resolver isn't
+// using it.
+func dnsmasqDirectOK(tld string) bool {
+	answer, err := defaultDnsmasqAnswer(tld)
+	if err != nil {
+		return false
+	}
+	if answer == "127.0.0.1" {
+		return true
+	}
+	cfg, _ := config.LoadGlobal()
+	if cfg != nil && cfg.LAN.Exposed && answer == primaryLANIP() {
+		return true
+	}
+	return false
+}

--- a/internal/dns/probe_test.go
+++ b/internal/dns/probe_test.go
@@ -30,3 +30,23 @@ func TestCheck_DNSDisabledReturnsOK(t *testing.T) {
 		t.Fatalf("Check should return OK when DNS disabled, got false")
 	}
 }
+
+// CheckStatus must short-circuit to StatusOK in disabled mode for the same
+// reason Check does: lerd does not own resolution there, so probing would
+// be misleading rather than actionable.
+func TestCheckStatus_DNSDisabledReturnsOK(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cfg := &config.GlobalConfig{}
+	cfg.DNS.Enabled = false
+	cfg.DNS.TLD = "localhost"
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	if got := CheckStatus("test"); got != StatusOK {
+		t.Fatalf("CheckStatus = %q, want %q when DNS disabled", got, StatusOK)
+	}
+}

--- a/internal/dns/vpn.go
+++ b/internal/dns/vpn.go
@@ -1,0 +1,37 @@
+package dns
+
+import (
+	"net"
+	"strings"
+)
+
+// vpnIfacePrefixes are the interface-name prefixes used by VPN tunnels:
+// OpenVPN/WireGuard/AnyConnect tun*, macOS utun*, tap*, wg*, IPsec and ppp.
+var vpnIfacePrefixes = []string{"tun", "utun", "tap", "wg", "ipsec", "ppp", "cscotun"}
+
+// isVPNIface reports whether an interface name belongs to a VPN tunnel.
+func isVPNIface(name string) bool {
+	for _, prefix := range vpnIfacePrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// VPNActive reports whether a VPN tunnel interface is currently up. It is
+// used to word the "DNS degraded" hint and the doctor diagnostic, since a
+// VPN client rewriting the system resolver is by far the most common cause
+// of the system-resolver path failing while lerd-dns itself stays healthy.
+func VPNActive() bool {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return false
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp != 0 && isVPNIface(iface.Name) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dns/vpn_test.go
+++ b/internal/dns/vpn_test.go
@@ -1,0 +1,35 @@
+package dns
+
+import "testing"
+
+func TestIsVPNIface(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"tun0", true},
+		{"utun3", true},
+		{"tap0", true},
+		{"wg0", true},
+		{"ipsec0", true},
+		{"ppp0", true},
+		{"cscotun0", true},
+		{"eth0", false},
+		{"enp1s0", false},
+		{"wlan0", false},
+		{"lo", false},
+		{"podman0", false},
+		{"docker0", false},
+	}
+	for _, tc := range cases {
+		if got := isVPNIface(tc.name); got != tc.want {
+			t.Errorf("isVPNIface(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// VPNActive walks real host interfaces; the smoke test just pins that it
+// never panics and returns a usable bool regardless of host state.
+func TestVPNActive_doesNotPanic(t *testing.T) {
+	_ = VPNActive()
+}

--- a/internal/podman/network.go
+++ b/internal/podman/network.go
@@ -380,6 +380,18 @@ func RecreateNetwork(name string, dns []string) ([]string, bool, error) {
 	return attached, actualV6, nil
 }
 
+// ReloadNetworks re-runs network setup for every running container via
+// `podman network reload`. aardvark-dns is killed first so the reload
+// respawns it with an empty cache: after a VPN connects, a hostname that
+// resolved to NXDOMAIN before the tunnel came up would otherwise stay
+// stuck on the cached negative answer. This is how lerd recovers
+// container DNS when the host's resolvers change without restarting the
+// containers themselves.
+func ReloadNetworks() error {
+	_ = exec.Command("pkill", "-f", "aardvark-dns").Run()
+	return RunSilent("network", "reload", "--all")
+}
+
 // EnsureNetworkDNS syncs the DNS servers on the named network to the provided list.
 // It drops servers no longer present and adds new ones. This sets the upstream
 // forwarders that aardvark-dns uses, which is necessary on systems where

--- a/internal/tray/menu.go
+++ b/internal/tray/menu.go
@@ -115,6 +115,8 @@ func (m *menuState) apply(snap *Snapshot) {
 		dnsDot := "🔴"
 		if snap.DNSOK {
 			dnsDot = "🟢"
+		} else if snap.DNSDegraded {
+			dnsDot = "🟡"
 		}
 		m.mDNS.SetTitle(fmt.Sprintf("  %s dns", dnsDot))
 	}

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -36,6 +36,7 @@ type Snapshot struct {
 	Running              bool
 	NginxRunning         bool
 	DNSOK                bool
+	DNSDegraded          bool // lerd-dns healthy but the system resolver is bypassed, typically a VPN
 	DNSDisabled          bool // explicit dns.enabled=false from API; zero value falls through to ok/error
 	PHPVersions          []phpInfo
 	PHPDefault           string
@@ -217,8 +218,9 @@ func fetchSnapshot() *Snapshot {
 			Running bool `json:"running"`
 		} `json:"nginx"`
 		DNS struct {
-			OK      bool `json:"ok"`
-			Enabled bool `json:"enabled"`
+			OK      bool   `json:"ok"`
+			Status  string `json:"status"`
+			Enabled bool   `json:"enabled"`
 		} `json:"dns"`
 		PHPFPMs []struct {
 			Version string `json:"version"`
@@ -231,6 +233,7 @@ func fetchSnapshot() *Snapshot {
 			snap.Running = sr.Nginx.Running
 			snap.NginxRunning = sr.Nginx.Running
 			snap.DNSOK = sr.DNS.OK
+			snap.DNSDegraded = sr.DNS.Status == "degraded"
 			snap.DNSDisabled = !sr.DNS.Enabled
 			snap.PHPDefault = sr.PHPDefault
 			for _, p := range sr.PHPFPMs {

--- a/internal/tui/panes.go
+++ b/internal/tui/panes.go
@@ -142,6 +142,8 @@ func (m *Model) renderHeader() string {
 		parts = append(parts, dimStyle.Render("DNS off"))
 	} else if m.snap.Status.DNSOk {
 		parts = append(parts, runningStyle.Render("DNS ok"))
+	} else if m.snap.Status.DNSDegraded {
+		parts = append(parts, accentStyle.Render("DNS degraded"))
 	} else {
 		parts = append(parts, failingStyle.Render("DNS down"))
 	}

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -52,6 +52,7 @@ const (
 // StatusRow drives the top header bar.
 type StatusRow struct {
 	DNSOk          bool
+	DNSDegraded    bool
 	DNSDisabled    bool
 	TLD            string
 	NginxRunning   bool
@@ -178,10 +179,11 @@ func loadStatus() StatusRow {
 		tld = cfg.DNS.TLD
 		dnsDisabled = !cfg.DNS.Enabled
 	}
-	dnsOK, _ := dns.Check(tld)
+	dnsStatus := dns.CheckStatus(tld)
 	row := StatusRow{
 		TLD:          tld,
-		DNSOk:        dnsOK,
+		DNSOk:        dnsStatus == dns.StatusOK,
+		DNSDegraded:  dnsStatus == dns.StatusDegraded,
 		DNSDisabled:  dnsDisabled,
 		NginxRunning: podman.Cache.Running("lerd-nginx"),
 	}

--- a/internal/ui/dns_status_watcher.go
+++ b/internal/ui/dns_status_watcher.go
@@ -10,19 +10,27 @@ import (
 )
 
 // dnsStatusWatchInterval is how often the watcher re-probes DNS while a UI
-// tab is visible. One net.LookupHost every 30s is well below the cost of
-// the existing per-15s container cache poll.
+// tab is visible. One probe every 30s is well below the cost of the
+// existing per-15s container cache poll.
 const dnsStatusWatchInterval = 30 * time.Second
 
-// lastDNSOK encodes the previously observed dns.Check result as an atomic
-// int32: 0 = never observed, 1 = up, 2 = down. Atomic so the watcher and
-// any future probe path can share state without a mutex.
-var lastDNSOK atomic.Int32
-
+// DNS observations the watcher tracks. They mirror dns.Status plus an
+// "unknown" zero value for "never observed".
 const (
-	dnsObsUnknown int32 = 0
-	dnsObsUp      int32 = 1
-	dnsObsDown    int32 = 2
+	dnsObsUnknown  int32 = 0
+	dnsObsOK       int32 = 1
+	dnsObsDegraded int32 = 2
+	dnsObsDown     int32 = 3
+)
+
+// lastDNSObs is the last *confirmed* observation, the one the published
+// snapshot reflects. pendingDNSObs is a candidate awaiting a second
+// consecutive tick before it latches, so a single transient probe failure
+// (common the moment a VPN connects) can't flip the dashboard pill on its
+// own. Both atomic so the watcher needs no mutex.
+var (
+	lastDNSObs    atomic.Int32
+	pendingDNSObs atomic.Int32
 )
 
 // dnsStatusDeps is the injection surface for tickDNSStatus so the
@@ -30,7 +38,7 @@ const (
 // real config, resolver, or event bus.
 type dnsStatusDeps struct {
 	tld     func() string
-	check   func(tld string) (bool, error)
+	check   func(tld string) dns.Status
 	visible func() bool
 	publish func()
 }
@@ -45,7 +53,7 @@ func defaultDNSStatusDeps() dnsStatusDeps {
 			}
 			return cfg.DNS.TLD
 		},
-		check:   dns.Check,
+		check:   dns.CheckStatus,
 		visible: func() bool { return visibleClients.Load() > 0 },
 		publish: func() { eventbus.Default.Publish(eventbus.KindStatus) },
 	}
@@ -59,7 +67,7 @@ func defaultDNSStatusDeps() dnsStatusDeps {
 // user manually refreshed even after lerd-dns came online.
 //
 // Probes immediately on startup so a UI tab opened during boot doesn't
-// sit on stale dns.ok=false for up to 30s while DNS comes online. Each
+// sit on stale state for up to 30s while DNS comes online. Each
 // subsequent tick: if no tab is visible, skip. Otherwise probe once,
 // compare to the last observation, and publish KindStatus on transition.
 func runDNSStatusWatcher() {
@@ -72,19 +80,45 @@ func runDNSStatusWatcher() {
 	}
 }
 
-// tickDNSStatus runs one observation and publishes on transition.
+// obsFromStatus maps a dns.Status onto the watcher's observation enum.
+func obsFromStatus(s dns.Status) int32 {
+	switch s {
+	case dns.StatusOK:
+		return dnsObsOK
+	case dns.StatusDegraded:
+		return dnsObsDegraded
+	default:
+		return dnsObsDown
+	}
+}
+
+// tickDNSStatus runs one observation and publishes on a confirmed
+// transition. A change must survive two consecutive ticks before it
+// latches, so a single transient blip never flips the pill on its own.
 func tickDNSStatus(d dnsStatusDeps) {
 	if !d.visible() {
 		return
 	}
-	ok, _ := d.check(d.tld())
-	cur := dnsObsDown
-	if ok {
-		cur = dnsObsUp
-	}
-	prev := lastDNSOK.Swap(cur)
-	if prev == cur {
+	cur := obsFromStatus(d.check(d.tld()))
+	confirmed := lastDNSObs.Load()
+
+	// First observation latches immediately so a tab opened during boot
+	// isn't stuck on unknown for a whole debounce cycle.
+	if confirmed == dnsObsUnknown {
+		lastDNSObs.Store(cur)
+		pendingDNSObs.Store(cur)
+		d.publish()
 		return
 	}
+	if cur == confirmed {
+		pendingDNSObs.Store(cur) // matches steady state, drop any stale candidate
+		return
+	}
+	// The observation differs from the confirmed state. Publish only once
+	// the same new value has been seen on two consecutive ticks.
+	if pendingDNSObs.Swap(cur) != cur {
+		return
+	}
+	lastDNSObs.Store(cur)
 	d.publish()
 }

--- a/internal/ui/dns_status_watcher_test.go
+++ b/internal/ui/dns_status_watcher_test.go
@@ -2,99 +2,119 @@ package ui
 
 import (
 	"testing"
+
+	"github.com/geodro/lerd/internal/dns"
 )
 
-func resetDNSObs() { lastDNSOK.Store(dnsObsUnknown) }
+func resetDNSObs() {
+	lastDNSObs.Store(dnsObsUnknown)
+	pendingDNSObs.Store(dnsObsUnknown)
+}
 
+// TestTickDNSStatus pins the three-way observation and the two-tick
+// debounce: a change publishes only after it survives two consecutive
+// ticks, so a single transient blip (common the moment a VPN connects)
+// never flips the dashboard pill.
 func TestTickDNSStatus(t *testing.T) {
 	cases := []struct {
 		name        string
 		visible     bool
-		startObs    int32
-		probeOK     bool
-		wantPublish bool
+		start       int32
+		probes      []dns.Status
 		wantObs     int32
+		wantPublish int
 	}{
 		{
-			name:        "skipped when no tab is visible",
-			visible:     false,
-			startObs:    dnsObsUnknown,
-			probeOK:     true,
-			wantPublish: false,
-			wantObs:     dnsObsUnknown,
+			name:    "skipped when no tab is visible",
+			visible: false,
+			start:   dnsObsUnknown,
+			probes:  []dns.Status{dns.StatusOK},
+			wantObs: dnsObsUnknown,
 		},
 		{
-			name:        "first up observation publishes (boot snapshot was stale-down)",
+			name:        "first ok observation latches and publishes",
 			visible:     true,
-			startObs:    dnsObsUnknown,
-			probeOK:     true,
-			wantPublish: true,
-			wantObs:     dnsObsUp,
+			start:       dnsObsUnknown,
+			probes:      []dns.Status{dns.StatusOK},
+			wantObs:     dnsObsOK,
+			wantPublish: 1,
 		},
 		{
-			name:        "first down observation publishes",
+			name:        "first down observation latches and publishes",
 			visible:     true,
-			startObs:    dnsObsUnknown,
-			probeOK:     false,
-			wantPublish: true,
+			start:       dnsObsUnknown,
+			probes:      []dns.Status{dns.StatusDown},
 			wantObs:     dnsObsDown,
+			wantPublish: 1,
 		},
 		{
-			name:        "steady up is silent",
-			visible:     true,
-			startObs:    dnsObsUp,
-			probeOK:     true,
-			wantPublish: false,
-			wantObs:     dnsObsUp,
+			name:    "steady ok is silent",
+			visible: true,
+			start:   dnsObsOK,
+			probes:  []dns.Status{dns.StatusOK, dns.StatusOK},
+			wantObs: dnsObsOK,
 		},
 		{
-			name:        "steady down is silent",
+			name:    "single blip does not latch",
+			visible: true,
+			start:   dnsObsOK,
+			probes:  []dns.Status{dns.StatusDown, dns.StatusOK},
+			wantObs: dnsObsOK,
+		},
+		{
+			name:        "change confirmed on second consecutive tick",
 			visible:     true,
-			startObs:    dnsObsDown,
-			probeOK:     false,
-			wantPublish: false,
+			start:       dnsObsOK,
+			probes:      []dns.Status{dns.StatusDown, dns.StatusDown},
 			wantObs:     dnsObsDown,
+			wantPublish: 1,
 		},
 		{
-			name:        "down to up publishes (post-repair recovery)",
+			name:        "ok to degraded publishes after debounce",
 			visible:     true,
-			startObs:    dnsObsDown,
-			probeOK:     true,
-			wantPublish: true,
-			wantObs:     dnsObsUp,
+			start:       dnsObsOK,
+			probes:      []dns.Status{dns.StatusDegraded, dns.StatusDegraded},
+			wantObs:     dnsObsDegraded,
+			wantPublish: 1,
 		},
 		{
-			name:        "up to down publishes (resolv.conf got clobbered)",
+			name:        "degraded recovery to ok publishes after debounce",
 			visible:     true,
-			startObs:    dnsObsUp,
-			probeOK:     false,
-			wantPublish: true,
-			wantObs:     dnsObsDown,
+			start:       dnsObsDegraded,
+			probes:      []dns.Status{dns.StatusOK, dns.StatusOK},
+			wantObs:     dnsObsOK,
+			wantPublish: 1,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			lastDNSOK.Store(tc.startObs)
+			lastDNSObs.Store(tc.start)
+			pendingDNSObs.Store(tc.start)
 			t.Cleanup(resetDNSObs)
 
 			published := 0
+			i := 0
 			deps := dnsStatusDeps{
-				tld:     func() string { return "test" },
-				check:   func(string) (bool, error) { return tc.probeOK, nil },
+				tld: func() string { return "test" },
+				check: func(string) dns.Status {
+					s := tc.probes[i]
+					i++
+					return s
+				},
 				visible: func() bool { return tc.visible },
 				publish: func() { published++ },
 			}
 
-			tickDNSStatus(deps)
-
-			gotObs := lastDNSOK.Load()
-			if gotObs != tc.wantObs {
-				t.Fatalf("lastDNSOK = %d, want %d", gotObs, tc.wantObs)
+			for range tc.probes {
+				tickDNSStatus(deps)
 			}
-			gotPublish := published > 0
-			if gotPublish != tc.wantPublish {
-				t.Fatalf("publish fired=%v, want %v", gotPublish, tc.wantPublish)
+
+			if got := lastDNSObs.Load(); got != tc.wantObs {
+				t.Fatalf("lastDNSObs = %d, want %d", got, tc.wantObs)
+			}
+			if published != tc.wantPublish {
+				t.Fatalf("publishes = %d, want %d", published, tc.wantPublish)
 			}
 		})
 	}
@@ -106,8 +126,11 @@ func TestTickDNSStatusTLDFromConfig(t *testing.T) {
 
 	var seen string
 	deps := dnsStatusDeps{
-		tld:     func() string { return "lerd" },
-		check:   func(tld string) (bool, error) { seen = tld; return true, nil },
+		tld: func() string { return "lerd" },
+		check: func(tld string) dns.Status {
+			seen = tld
+			return dns.StatusOK
+		},
 		visible: func() bool { return true },
 		publish: func() {},
 	}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -541,6 +541,8 @@ type StatusResponse struct {
 
 type DNSStatus struct {
 	OK      bool   `json:"ok"`
+	Status  string `json:"status"` // ok | degraded | down
+	VPN     bool   `json:"vpn"`    // a VPN tunnel is up; degraded is then expected
 	Enabled bool   `json:"enabled"`
 	TLD     string `json:"tld"`
 }
@@ -570,7 +572,7 @@ func buildStatus() StatusResponse {
 		dnsEnabled = cfg.DNS.Enabled
 	}
 
-	dnsOK, _ := dns.Check(tld)
+	dnsStatus := dns.CheckStatus(tld)
 	nginxRunning := podman.Cache.Running("lerd-nginx")
 	watcherRunning := services.Mgr.IsActive("lerd-watcher")
 
@@ -596,7 +598,7 @@ func buildStatus() StatusResponse {
 	_, nodeShimErr := os.Stat(nodeShim)
 	nodeManagedByLerd := nodeShimErr == nil
 	return StatusResponse{
-		DNS:               DNSStatus{OK: dnsOK, Enabled: dnsEnabled, TLD: tld},
+		DNS:               DNSStatus{OK: dnsStatus == dns.StatusOK, Status: string(dnsStatus), VPN: dns.VPNActive(), Enabled: dnsEnabled, TLD: tld},
 		Nginx:             ServiceCheck{Running: nginxRunning},
 		PHPFPMs:           phpStatuses,
 		PHPDefault:        phpDefault,

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -341,6 +341,8 @@
   "system_stopLerd": "Lerd stoppen",
   "system_dns_ok": "OK",
   "system_dns_failed": "Fehlgeschlagen",
+  "system_dns_degraded": "Eingeschränkt",
+  "system_dns_degradedHint": "lerd-dns funktioniert und antwortet direkt, aber der System-Resolver leitet deine Domains nicht dorthin weiter, meist weil ein VPN-Client das DNS überschrieben hat. Websites werden weiterhin aufgelöst, und lerd synchronisiert das Container-DNS automatisch, wenn sich die VPN-Verbindung ändert.",
   "system_dns_fixHint": "Versuche {start} oder führe {cmd} aus, um DNS zu reparieren.",
   "system_dns_quietDefault": "dnsmasq ist standardmäßig still. Füge {option} in {path} hinzu und starte lerd-dns neu, um aufgelöste Anfragen hier zu sehen.",
   "system_watcher_description": "Überwacht geparkte Verzeichnisse, Site-Dateien, Git-Worktrees und den DNS-Zustand. Protokolliert standardmäßig WARN- und ERROR-Ereignisse; setze {env} in der Dienstumgebung für ausführliche Ausgabe.",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -328,6 +328,8 @@
   "system_stopLerd": "Stop Lerd",
   "system_dns_ok": "OK",
   "system_dns_failed": "Failed",
+  "system_dns_degraded": "Degraded",
+  "system_dns_degradedHint": "lerd-dns is healthy and answering directly, but the system resolver isn't routing your domains to it, usually because a VPN client rewrote DNS. Sites still resolve, and lerd re-syncs container DNS automatically when the VPN connection changes.",
   "system_dns_fixHint": "Try {start}, or run {cmd} to fix DNS.",
   "system_dns_quietDefault": "dnsmasq is quiet by default. Add {option} to {path} and restart lerd-dns to see resolved queries here.",
   "system_watcher_description": "Monitors parked directories, site files, git worktrees, and DNS health. Logs WARN and ERROR events by default; set {env} in the service environment for verbose output.",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -341,6 +341,8 @@
   "system_stopLerd": "Detener Lerd",
   "system_dns_ok": "OK",
   "system_dns_failed": "Fallido",
+  "system_dns_degraded": "Degradado",
+  "system_dns_degradedHint": "lerd-dns funciona y responde directamente, pero el resolutor del sistema no le enruta tus dominios, normalmente porque un cliente VPN reescribió el DNS. Los sitios siguen resolviéndose, y lerd vuelve a sincronizar el DNS de los contenedores automáticamente cuando cambia la conexión VPN.",
   "system_dns_fixHint": "Prueba {start}, o ejecuta {cmd} para arreglar el DNS.",
   "system_dns_quietDefault": "dnsmasq está en silencio por defecto. Añade {option} a {path} y reinicia lerd-dns para ver las consultas resueltas aquí.",
   "system_watcher_description": "Monitoriza directorios parked, archivos del sitio, git worktrees y la salud del DNS. Registra eventos WARN y ERROR por defecto; define {env} en el entorno del servicio para salida detallada.",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -341,6 +341,8 @@
   "system_stopLerd": "Arrêter Lerd",
   "system_dns_ok": "OK",
   "system_dns_failed": "Échec",
+  "system_dns_degraded": "Dégradé",
+  "system_dns_degradedHint": "lerd-dns fonctionne et répond directement, mais le résolveur système n'y achemine pas vos domaines, généralement parce qu'un client VPN a réécrit le DNS. Les sites continuent de se résoudre, et lerd resynchronise automatiquement le DNS des conteneurs lorsque la connexion VPN change.",
   "system_dns_fixHint": "Essayez {start}, ou exécutez {cmd} pour réparer le DNS.",
   "system_dns_quietDefault": "dnsmasq est silencieux par défaut. Ajoutez {option} à {path} et redémarrez lerd-dns pour voir les requêtes résolues ici.",
   "system_watcher_description": "Surveille les répertoires parked, fichiers de site, git worktrees et la santé du DNS. Enregistre les événements WARN et ERROR par défaut ; définissez {env} dans l'environnement du service pour une sortie détaillée.",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -341,6 +341,8 @@
   "system_stopLerd": "Hentikan Lerd",
   "system_dns_ok": "OK",
   "system_dns_failed": "Gagal",
+  "system_dns_degraded": "Menurun",
+  "system_dns_degradedHint": "lerd-dns sehat dan menjawab secara langsung, tetapi resolver sistem tidak mengarahkan domain Anda ke sana, biasanya karena klien VPN menulis ulang DNS. Situs tetap dapat di-resolve, dan lerd menyinkronkan ulang DNS kontainer secara otomatis saat koneksi VPN berubah.",
   "system_dns_fixHint": "Coba {start}, atau jalankan {cmd} untuk memperbaiki DNS.",
   "system_dns_quietDefault": "dnsmasq diam secara bawaan. Tambahkan {option} ke {path} dan mulai ulang lerd-dns untuk melihat kueri yang terselesaikan di sini.",
   "system_watcher_description": "Memantau direktori yang diparkir, berkas situs, git worktree, dan kesehatan DNS. Mencatat peristiwa WARN dan ERROR secara bawaan; setel {env} di lingkungan layanan untuk keluaran verbose.",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -341,6 +341,8 @@
   "system_stopLerd": "Lerd stoppen",
   "system_dns_ok": "OK",
   "system_dns_failed": "Mislukt",
+  "system_dns_degraded": "Verminderd",
+  "system_dns_degradedHint": "lerd-dns werkt en antwoordt rechtstreeks, maar de systeemresolver routeert je domeinen er niet naartoe, meestal omdat een VPN-client de DNS heeft overschreven. Sites blijven werken en lerd synchroniseert de container-DNS automatisch wanneer de VPN-verbinding verandert.",
   "system_dns_fixHint": "Probeer {start}, of voer {cmd} uit om DNS te repareren.",
   "system_dns_quietDefault": "dnsmasq is standaard stil. Voeg {option} toe aan {path} en herstart lerd-dns om opgeloste queries hier te zien.",
   "system_watcher_description": "Bewaakt geparkeerde mappen, sitebestanden, git-worktrees en de DNS-status. Logt standaard WARN- en ERROR-gebeurtenissen; stel {env} in de serviceomgeving in voor uitgebreide uitvoer.",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -341,6 +341,8 @@
   "system_stopLerd": "Parar Lerd",
   "system_dns_ok": "OK",
   "system_dns_failed": "Falhou",
+  "system_dns_degraded": "Degradado",
+  "system_dns_degradedHint": "O lerd-dns está funcionando e respondendo diretamente, mas o resolvedor do sistema não encaminha seus domínios para ele, geralmente porque um cliente VPN reescreveu o DNS. Os sites continuam a resolver, e o lerd ressincroniza o DNS dos contêineres automaticamente quando a conexão VPN muda.",
   "system_dns_fixHint": "Tente {start}, ou execute {cmd} para corrigir o DNS.",
   "system_dns_quietDefault": "dnsmasq é silencioso por padrão. Adicione {option} a {path} e reinicie lerd-dns para ver as consultas resolvidas aqui.",
   "system_watcher_description": "Monitora diretórios parked, arquivos de site, git worktrees e a saúde do DNS. Registra eventos WARN e ERROR por padrão; defina {env} no ambiente do serviço para saída detalhada.",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -341,6 +341,8 @@
   "system_stopLerd": "Lerd'i durdur",
   "system_dns_ok": "Tamam",
   "system_dns_failed": "Başarısız",
+  "system_dns_degraded": "Düşük",
+  "system_dns_degradedHint": "lerd-dns sağlıklı ve doğrudan yanıt veriyor, ancak sistem çözücüsü alan adlarınızı ona yönlendirmiyor; bu genellikle bir VPN istemcisinin DNS'i değiştirmesinden kaynaklanır. Siteler çözülmeye devam eder ve VPN bağlantısı değiştiğinde lerd konteyner DNS'ini otomatik olarak yeniden eşitler.",
   "system_dns_fixHint": "{start} deneyin veya DNS'i düzeltmek için {cmd} çalıştırın.",
   "system_dns_quietDefault": "dnsmasq varsayılan olarak sessizdir. Çözümlenen sorguları burada görmek için {path} dosyasına {option} ekleyin ve lerd-dns'i yeniden başlatın.",
   "system_watcher_description": "Park edilen dizinleri, site dosyalarını, git worktree'lerini ve DNS sağlığını izler. Varsayılan olarak WARN ve ERROR olaylarını loglar; ayrıntılı çıktı için servis ortamında {env} ayarlayın.",

--- a/internal/ui/web/src/stores/status.test.ts
+++ b/internal/ui/web/src/stores/status.test.ts
@@ -79,4 +79,40 @@ describe('status store', () => {
     version.update((v) => ({ ...v, hasUpdate: false }));
     expect(get(lerdStatusColor)).toBe('green');
   });
+
+  it('lerdStatusColor is yellow when DNS is degraded, not red', async () => {
+    const { status, statusLoaded, lerdStatusColor } = await import('./status');
+    const { version } = await import('./version');
+    statusLoaded.set(true);
+    status.update((s) => ({
+      ...s,
+      dns: { ok: false, status: 'degraded', vpn: true, enabled: true, tld: 'test' },
+      nginx: { running: true },
+      watcher_running: true
+    }));
+    version.update((v) => ({ ...v, hasUpdate: false }));
+    expect(get(lerdStatusColor)).toBe('yellow');
+  });
+
+  it('lerdStatusColor is red when DNS is down', async () => {
+    const { status, statusLoaded, lerdStatusColor } = await import('./status');
+    statusLoaded.set(true);
+    status.update((s) => ({
+      ...s,
+      dns: { ok: false, status: 'down', vpn: false, enabled: true, tld: 'test' },
+      nginx: { running: true },
+      watcher_running: true
+    }));
+    expect(get(lerdStatusColor)).toBe('red');
+  });
+
+  it('dnsState reads the status field and falls back to ok for old payloads', async () => {
+    const { dnsState } = await import('./status');
+    const base = { nginx: { running: true }, php_fpms: [], php_default: '', node_default: '', node_managed_by_lerd: true, watcher_running: true };
+    expect(dnsState({ ...base, dns: { ok: false, status: 'degraded', enabled: true, tld: 'test' } })).toBe('degraded');
+    expect(dnsState({ ...base, dns: { ok: false, status: 'down', enabled: true, tld: 'test' } })).toBe('down');
+    expect(dnsState({ ...base, dns: { ok: true, enabled: true, tld: 'test' } })).toBe('ok');
+    expect(dnsState({ ...base, dns: { ok: false, enabled: true, tld: 'test' } })).toBe('down');
+    expect(dnsState({ ...base, dns: { ok: false, enabled: false, tld: 'test' } })).toBe('ok');
+  });
 });

--- a/internal/ui/web/src/stores/status.ts
+++ b/internal/ui/web/src/stores/status.ts
@@ -11,7 +11,7 @@ export interface PHPStatus {
 }
 
 export interface StatusResponse {
-  dns: { ok: boolean; enabled: boolean; tld: string };
+  dns: { ok: boolean; status?: 'ok' | 'degraded' | 'down'; vpn?: boolean; enabled: boolean; tld: string };
   nginx: { running: boolean };
   php_fpms: PHPStatus[];
   php_default: string;
@@ -21,7 +21,7 @@ export interface StatusResponse {
 }
 
 const empty: StatusResponse = {
-  dns: { ok: false, enabled: true, tld: 'test' },
+  dns: { ok: false, status: 'down', vpn: false, enabled: true, tld: 'test' },
   nginx: { running: false },
   php_fpms: [],
   php_default: '',
@@ -53,19 +53,31 @@ wsMessage.subscribe((msg) => {
   if (msg?.status) applyStatus(msg.status);
 });
 
+export type DnsState = 'ok' | 'degraded' | 'down';
+
+// dnsState collapses the payload into a three-way health value. It tolerates
+// older payloads without the `status` field by deriving it from `ok`, and
+// treats lerd-managed DNS being disabled as healthy since the system
+// resolver owns *.tld in that mode. "degraded" means lerd-dns answers fine
+// but the system resolver isn't routing to it, typically a VPN client.
+export function dnsState(s: StatusResponse): DnsState {
+  if (s.dns.enabled === false) return 'ok';
+  return s.dns.status ?? (s.dns.ok ? 'ok' : 'down');
+}
+
 export type LerdStatusColor = 'green' | 'yellow' | 'red' | 'gray';
 
 export const lerdStatusColor = derived([status, statusLoaded, version], ([$s, $loaded, $v]): LerdStatusColor => {
   if (!$loaded) return 'gray';
-  const coreOk = $s.dns.ok && $s.nginx.running && $s.watcher_running;
-  if (!coreOk) return 'red';
-  if ($v.hasUpdate) return 'yellow';
+  const dns = dnsState($s);
+  if (dns === 'down' || !$s.nginx.running || !$s.watcher_running) return 'red';
+  if (dns === 'degraded' || $v.hasUpdate) return 'yellow';
   return 'green';
 });
 
 export const allCoreRunning = derived(status, ($s): boolean => {
   return Boolean(
-    $s.dns.ok &&
+    dnsState($s) !== 'down' &&
       $s.nginx.running &&
       ($s.php_fpms || []).every((f) => f.running)
   );

--- a/internal/ui/web/src/tabs/dashboard/HeroStatus.svelte
+++ b/internal/ui/web/src/tabs/dashboard/HeroStatus.svelte
@@ -10,7 +10,7 @@
   import { version } from '$stores/version';
   import { coreServices } from '$stores/services';
   import { sites } from '$stores/sites';
-  import { status, statusLoaded } from '$stores/status';
+  import { status, statusLoaded, dnsState } from '$stores/status';
   import { accessMode } from '$stores/accessMode';
   import { goToTab } from '$stores/route';
   import { apiFetch } from '$lib/api';
@@ -24,7 +24,10 @@
   const coreDown = $derived.by(() => {
     if (!$statusLoaded) return [] as string[];
     const issues: string[] = [];
-    if ($status.dns?.enabled !== false && !$status.dns.ok) issues.push('DNS');
+    // Only a genuine lerd-dns outage is a core failure. "degraded" means
+    // lerd-dns is healthy but the system resolver is bypassed (typically a
+    // VPN), which lerd recovers from on its own, so it doesn't belong here.
+    if ($status.dns?.enabled !== false && dnsState($status) === 'down') issues.push('DNS');
     if (!$status.nginx.running) issues.push('Nginx');
     if (!$status.watcher_running) issues.push('Watcher');
     return issues;

--- a/internal/ui/web/src/tabs/dashboard/SystemHealthWidget.svelte
+++ b/internal/ui/web/src/tabs/dashboard/SystemHealthWidget.svelte
@@ -5,7 +5,7 @@
   import DumpBridgeToggle from '$components/DumpBridgeToggle.svelte';
   import ProfilerToggle from '$components/ProfilerToggle.svelte';
   import NotificationsToggle from '$components/NotificationsToggle.svelte';
-  import { status, lerdStatusColor } from '$stores/status';
+  import { status, lerdStatusColor, dnsState } from '$stores/status';
   import { sitesByPhp, sitesByNode } from '$stores/sites';
   import { goToTab } from '$stores/route';
   import { m } from '../../paraglide/messages.js';
@@ -37,10 +37,11 @@
   {/snippet}
 
   {#if $status.dns?.enabled !== false}
+    {@const dns = dnsState($status)}
     <div class="flex items-center justify-between text-sm">
       <span class="text-gray-600 dark:text-gray-300">{m.dashboard_health_dns({ tld: $status.dns.tld })}</span>
       <span class="inline-flex w-6 h-6 items-center justify-center shrink-0">
-        <StatusDot color={$status.dns.ok ? 'green' : 'red'} />
+        <StatusDot color={dns === 'ok' ? 'green' : dns === 'degraded' ? 'yellow' : 'red'} />
       </span>
     </div>
   {/if}

--- a/internal/ui/web/src/tabs/system/DnsDetail.svelte
+++ b/internal/ui/web/src/tabs/system/DnsDetail.svelte
@@ -4,7 +4,7 @@
   import StatusPill from '$components/StatusPill.svelte';
   import InfoRow from '$components/InfoRow.svelte';
   import LogViewer from '$components/LogViewer.svelte';
-  import { status } from '$stores/status';
+  import { status, dnsState } from '$stores/status';
   import { m } from '../../paraglide/messages.js';
 </script>
 
@@ -12,7 +12,11 @@
   {#if $status.dns?.enabled === false}
     <StatusPill tone="muted" label="disabled" />
   {:else}
-    <StatusPill tone={$status.dns.ok ? 'ok' : 'error'} label={$status.dns.ok ? m.system_dns_ok() : m.system_dns_failed()} />
+    {@const dns = dnsState($status)}
+    <StatusPill
+      tone={dns === 'ok' ? 'ok' : dns === 'degraded' ? 'warn' : 'error'}
+      label={dns === 'ok' ? m.system_dns_ok() : dns === 'degraded' ? m.system_dns_degraded() : m.system_dns_failed()}
+    />
   {/if}
 {/snippet}
 
@@ -24,6 +28,8 @@
       <p class="text-xs text-gray-400">
         lerd-dns is disabled. Sites resolve through the system resolver via *.{$status.dns.tld} (RFC 6761). HTTPS is unavailable in this mode. To re-enable, set <code class="bg-gray-100 dark:bg-white/5 px-1 rounded-sm">dns.enabled: true</code> in <code class="bg-gray-100 dark:bg-white/5 px-1 rounded-sm">~/.config/lerd/config.yaml</code> and run <code class="bg-gray-100 dark:bg-white/5 px-1 rounded-sm">lerd install</code>.
       </p>
+    {:else if dnsState($status) === 'degraded'}
+      <p class="text-xs text-gray-400">{m.system_dns_degradedHint()}</p>
     {:else if !$status.dns.ok}
       <p class="text-xs text-gray-400">
         {@html m.system_dns_fixHint({

--- a/internal/watcher/dns.go
+++ b/internal/watcher/dns.go
@@ -1,10 +1,14 @@
 package watcher
 
 import (
+	"runtime"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/geodro/lerd/internal/dns"
 	"github.com/geodro/lerd/internal/eventbus"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/systemd"
 )
 
@@ -16,13 +20,15 @@ const idleSkipEveryN = 10
 // dnsWatchDeps is the injection surface for tickDNS so the orchestration
 // can be unit-tested without an actual resolver or eventbus subscriber.
 type dnsWatchDeps struct {
-	check             func(tld string) (bool, error)
-	waitReady         func(time.Duration) error
-	configureResolver func() error
-	repairPossible    func() bool
-	idleOrLocked      func() bool
-	publishStatus     func()
-	log               func(level, msg string, kv ...any)
+	check              func(tld string) (bool, error)
+	waitReady          func(time.Duration) error
+	configureResolver  func() error
+	repairPossible     func() bool
+	idleOrLocked       func() bool
+	publishStatus      func()
+	dnsEnvFingerprint  func() string
+	resyncContainerDNS func() error
+	log                func(level, msg string, kv ...any)
 }
 
 // dnsWatchState is the cross-tick memory for WatchDNS. lastOK starts nil
@@ -32,6 +38,33 @@ type dnsWatchState struct {
 	lastOK            *bool
 	tickCount         int
 	repairUnavailable bool
+	dnsEnv            string
+	dnsEnvSeen        bool
+}
+
+// defaultDNSEnvFingerprint summarises the host DNS environment: the sorted
+// upstream resolver set plus whether a VPN tunnel is up. Either changing
+// (VPN connect/disconnect, network switch) means aardvark-dns is serving
+// stale forwarders and a stale cache, so container DNS needs a re-sync.
+func defaultDNSEnvFingerprint() string {
+	up := dns.ReadUpstreamDNS()
+	sort.Strings(up)
+	vpn := "0"
+	if dns.VPNActive() {
+		vpn = "1"
+	}
+	return strings.Join(up, ",") + "|" + vpn
+}
+
+// defaultResyncContainerDNS re-points the lerd network's aardvark-dns at
+// the current host resolvers and reloads the network so containers pick
+// them up. This is the automatic equivalent of a manual `lerd restart`
+// after a VPN connects.
+func defaultResyncContainerDNS() error {
+	if err := podman.EnsureNetworkDNS("lerd", dns.ReadContainerDNS()); err != nil {
+		return err
+	}
+	return podman.ReloadNetworks()
 }
 
 // WatchDNS polls DNS health for the given TLD every interval. When resolution
@@ -62,6 +95,16 @@ func WatchDNS(interval time.Duration, tld string) {
 			}
 		},
 	}
+
+	// Container DNS re-sync recovers from aardvark-dns forwarder staleness,
+	// which is specific to Linux rootless podman. macOS containers get DNS
+	// from the podman machine VM (ReadContainerDNS is nil there), so there
+	// is nothing to re-sync and the detection stays off.
+	if runtime.GOOS == "linux" {
+		deps.dnsEnvFingerprint = defaultDNSEnvFingerprint
+		deps.resyncContainerDNS = defaultResyncContainerDNS
+	}
+
 	state := &dnsWatchState{}
 
 	// Probe immediately so a UI opened during boot doesn't sit on stale
@@ -82,6 +125,26 @@ func tickDNS(d dnsWatchDeps, s *dnsWatchState, tld string) {
 	s.tickCount++
 	if d.idleOrLocked() && s.tickCount%idleSkipEveryN != 0 {
 		return
+	}
+
+	// Re-sync container DNS when the host resolver environment changes
+	// (VPN connect/disconnect, network switch). The lerd network's
+	// aardvark-dns is otherwise left on the pre-change forwarders and a
+	// stale cache, so containers can't resolve newly-routable hostnames
+	// until a manual `lerd restart`. The first tick only records the
+	// baseline so a fresh watcher start never triggers a re-sync.
+	if d.dnsEnvFingerprint != nil {
+		fp := d.dnsEnvFingerprint()
+		if s.dnsEnvSeen && fp != s.dnsEnv {
+			d.log("info", "host DNS changed, re-syncing container DNS")
+			if d.resyncContainerDNS != nil {
+				if err := d.resyncContainerDNS(); err != nil {
+					d.log("warn", "container DNS re-sync failed", "err", err)
+				}
+			}
+		}
+		s.dnsEnv = fp
+		s.dnsEnvSeen = true
 	}
 
 	ok, _ := d.check(tld)

--- a/internal/watcher/dns_test.go
+++ b/internal/watcher/dns_test.go
@@ -319,6 +319,46 @@ func TestTickDNS_repairAvailableAfterUnavailable_relogsOnNextOutage(t *testing.T
 	}
 }
 
+// TestTickDNS_containerDNSResync pins the VPN fix: the watcher records the
+// host DNS fingerprint as a baseline on its first tick, stays quiet while
+// it is unchanged, and re-syncs container DNS exactly once when it changes
+// (a VPN connecting), then settles again.
+func TestTickDNS_containerDNSResync(t *testing.T) {
+	fp := "1.1.1.1|0"
+	resyncs := 0
+	deps := dnsWatchDeps{
+		check:              func(string) (bool, error) { return true, nil },
+		idleOrLocked:       func() bool { return false },
+		publishStatus:      func() {},
+		dnsEnvFingerprint:  func() string { return fp },
+		resyncContainerDNS: func() error { resyncs++; return nil },
+		log:                func(string, string, ...any) {},
+	}
+	state := &dnsWatchState{}
+
+	// First tick only records the baseline.
+	tickDNS(deps, state, "test")
+	if resyncs != 0 {
+		t.Fatalf("first tick re-synced; want baseline only, got %d", resyncs)
+	}
+	// Unchanged environment: still quiet.
+	tickDNS(deps, state, "test")
+	if resyncs != 0 {
+		t.Fatalf("unchanged env re-synced=%d, want 0", resyncs)
+	}
+	// VPN connects: the fingerprint changes, re-sync fires once.
+	fp = "1.1.1.1,10.0.0.1|1"
+	tickDNS(deps, state, "test")
+	if resyncs != 1 {
+		t.Fatalf("changed env re-syncs=%d, want 1", resyncs)
+	}
+	// Stable at the new value: no further re-sync.
+	tickDNS(deps, state, "test")
+	if resyncs != 1 {
+		t.Fatalf("re-syncs after settle=%d, want 1", resyncs)
+	}
+}
+
 func ptrBool(b bool) *bool { return &b }
 
 func ptrBoolEq(a, b *bool) bool {


### PR DESCRIPTION
Connecting a corporate VPN such as Cisco AnyConnect makes the dashboard show a red DNS not running error even though lerd-dns is fine, and PHP inside the containers cannot reach VPN-internal API endpoints until lerd is restarted. This came up in #394. Both symptoms are addressed here.

For the false alarm, DNS health is now three-way. When the system resolver path fails, lerd queries dnsmasq directly on 127.0.0.1:5300, and if it answers the state is degraded rather than down, since lerd-dns is healthy and only the resolver hookup is bypassed. The dashboard pill, the tray icon, the TUI header and lerd status all render that degraded state, and lerd doctor downgrades the system lookup rung to a warning when a VPN tunnel is up. The UI status watcher debounces transitions across two ticks so a momentary blip while a VPN connects cannot latch the pill.

For the unreachable endpoints, the watcher fingerprints the host resolver environment every tick and, when it changes, re-syncs the container network DNS automatically, re-pointing aardvark-dns at the current resolvers and reloading the network so containers pick them up with a fresh cache. That makes the manual restart unnecessary. The re-sync runs on Linux only, since macOS containers resolve through the podman machine VM.