### PR TITLE
feat(nginx): configurable request timeout per site and globally

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,12 @@ node:
 nginx:
   http_port: 80
   https_port: 443
+  request_timeout: 60   # optional, default 60. Seconds nginx waits on a slow
+                        # request before returning 504. Maps to
+                        # fastcgi_read_timeout/fastcgi_send_timeout for PHP-FPM
+                        # sites and proxy_read_timeout/proxy_send_timeout for
+                        # proxy and custom-container sites. A project's
+                        # .lerd.yaml request_timeout overrides it per site.
 dns:
   tld: "test"
 parked_directories:
@@ -61,6 +67,7 @@ A portable, self-contained description of a project's local environment. Created
 | `framework` | Framework name (overrides auto-detection) |
 | `framework_def` | Full framework definition, embedded automatically for custom (non-Laravel) frameworks so the project is portable across machines |
 | `public_dir` | Override for the framework's default document-root subdirectory, e.g. `public_html` for a Laravel skeleton that doesn't use the conventional `public/` folder. Empty means use the framework default |
+| `request_timeout` | nginx request timeout in seconds for this site. Maps to `fastcgi_read_timeout`/`fastcgi_send_timeout` for PHP-FPM sites and `proxy_read_timeout`/`proxy_send_timeout` for proxy and custom-container sites. Overrides the global `nginx.request_timeout`. Omit (or `0`) to inherit the global default of 60s. Raise it for apps with deliberately long-running requests |
 | `secured` | When `true`, HTTPS is enabled on apply |
 | `domains` | Site hostnames without the TLD (e.g. `[myapp, api]`). The first entry is the primary; additional entries become aliases. Conflict-filtered domains stay in this list on disk but are not registered |
 | `app_url` | Override for `APP_URL` (or the framework's URL key) written to `.env`. Highest priority, it beats the per-machine `sites.yaml` override and the default `<scheme>://<primary-domain>` generator. Use for custom path prefixes, ports, or unrelated hostnames you want shared across machines |

--- a/docs/usage/nginx-overrides.md
+++ b/docs/usage/nginx-overrides.md
@@ -14,6 +14,27 @@ include /etc/nginx/custom.d/{your-domain}.conf*;
 
 The trailing `*` makes the include a glob, so nginx treats a missing override file as empty (no 500). The directory is bind-mounted read-only into the `lerd-nginx` container and is never touched by lerd after creation.
 
+## Request timeouts
+
+By default nginx waits 60 seconds for a request to complete before returning `504 Gateway Timeout`. Apps with deliberately long-running requests (heavy reports, slow third-party calls, hardware that answers on its own schedule) need that raised, and this does not need a `custom.d` snippet.
+
+Set `request_timeout` in seconds and lerd writes it straight into the generated vhost. Globally, in `~/.config/lerd/config.yaml`:
+
+```yaml
+nginx:
+  request_timeout: 300
+```
+
+or per project in `.lerd.yaml`, which overrides the global value and travels with the repo:
+
+```yaml
+request_timeout: 300
+```
+
+lerd renders this into `fastcgi_read_timeout` and `fastcgi_send_timeout` for PHP-FPM sites, and into `proxy_read_timeout` and `proxy_send_timeout` for proxy, FrankenPHP, and custom-container sites, so the same setting works whatever runtime the site uses. Run `lerd link` (or `lerd install`) afterwards to regenerate the vhost and reload nginx.
+
+A long nginx timeout only helps if PHP is allowed to run that long too. For requests that are CPU-bound rather than waiting on I/O, also raise `max_execution_time` in the per-version php.ini via `lerd php:ini <version>`.
+
 ## Example: raise the upload limit for one site
 
 Create `~/.local/share/lerd/nginx/custom.d/bigapp.test.conf`:
@@ -22,10 +43,10 @@ Create `~/.local/share/lerd/nginx/custom.d/bigapp.test.conf`:
 client_max_body_size 200m;
 ```
 
-Then reload nginx so the include picks it up:
+Then reload nginx so the include picks it up. The `custom.d` directory is read by the nginx container, so restart that container (`lerd restart` only restarts a site's PHP-FPM container and will not pick up a `custom.d` change):
 
 ```sh
-lerd restart bigapp.test
+systemctl --user restart lerd-nginx
 ```
 
 That's it. The snippet is merged into the generated server block for `bigapp.test` and nothing lerd does afterwards (including a version upgrade) will touch it.

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -59,6 +59,16 @@ func runCheck(_ *cobra.Command, _ []string) error {
 		fmt.Printf("  OK    node_version: %s\n", cfg.NodeVersion)
 	}
 
+	// Request timeout
+	if cfg.RequestTimeout != 0 {
+		if cfg.RequestTimeout < 0 {
+			fmt.Printf("  FAIL  request_timeout: %d — must be a positive number of seconds\n", cfg.RequestTimeout)
+			errors++
+		} else {
+			fmt.Printf("  OK    request_timeout: %ds\n", cfg.RequestTimeout)
+		}
+	}
+
 	// Framework
 	if cfg.Framework != "" {
 		if cfg.FrameworkDef != nil {

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -1368,6 +1368,7 @@ The ` + bt + `container.port` + bt + ` field is required. ` + bt + `container.co
 | ` + bt + `node_version` + bt + ` | Node version (e.g. ` + bt + `"22"` + bt + `) |
 | ` + bt + `framework` + bt + ` | Framework name (e.g. ` + bt + `laravel` + bt + `, ` + bt + `symfony` + bt + `, ` + bt + `wordpress` + bt + `) |
 | ` + bt + `secured` + bt + ` | ` + bt + `true` + bt + ` to enable HTTPS |
+| ` + bt + `request_timeout` + bt + ` | nginx request timeout in seconds (default 60). Raises ` + bt + `fastcgi_read/send_timeout` + bt + ` for FPM sites or ` + bt + `proxy_read/send_timeout` + bt + ` for proxy/container sites — for deliberately long-running requests. Overrides the global ` + bt + `nginx.request_timeout` + bt + ` |
 | ` + bt + `services` + bt + ` | Services to start (e.g. ` + bt + `[mysql, redis]` + bt + `) |
 | ` + bt + `workers` + bt + ` | Active worker names (e.g. ` + bt + `[queue, schedule]` + bt + `) — auto-synced by start/stop |
 | ` + bt + `app_url` + bt + ` | Override for APP_URL in ` + bt + `.env` + bt + ` |
@@ -1384,6 +1385,7 @@ The ` + bt + `container.port` + bt + ` field is required. ` + bt + `container.co
 | ` + bt + `custom_workers` + bt + ` | no | | Worker definitions — see below |
 | ` + bt + `domains` + bt + ` | no | | Same as PHP sites |
 | ` + bt + `secured` + bt + ` | no | | Same as PHP sites |
+| ` + bt + `request_timeout` + bt + ` | no | 60 | Same as PHP sites — sets ` + bt + `proxy_read/send_timeout` + bt + ` for the container |
 | ` + bt + `services` + bt + ` | no | | Same as PHP sites |
 
 When ` + bt + `container` + bt + ` is present, ` + bt + `php_version` + bt + `, ` + bt + `framework` + bt + `, and ` + bt + `node_version` + bt + ` are ignored — the container defines its own runtime.

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -51,6 +51,10 @@ type GlobalConfig struct {
 	Nginx struct {
 		HTTPPort  int `yaml:"http_port"  mapstructure:"http_port"`
 		HTTPSPort int `yaml:"https_port" mapstructure:"https_port"`
+		// RequestTimeout is the default nginx request timeout in seconds,
+		// overridable per project via .lerd.yaml request_timeout. Zero falls
+		// back to nginx's own 60s default; read it via RequestTimeoutSeconds.
+		RequestTimeout int `yaml:"request_timeout,omitempty" mapstructure:"request_timeout"`
 	} `yaml:"nginx" mapstructure:"nginx"`
 	DNS struct {
 		// Enabled=false skips lerd-dns, mkcert CA, sudoers, and resolver
@@ -153,6 +157,19 @@ type GlobalConfig struct {
 	} `yaml:"notifications,omitempty" mapstructure:"notifications"`
 	ParkedDirectories []string                 `yaml:"parked_directories" mapstructure:"parked_directories"`
 	Services          map[string]ServiceConfig `yaml:"services"           mapstructure:"services"`
+}
+
+// DefaultRequestTimeout is nginx's built-in fastcgi/proxy read-timeout default
+// (seconds), used when neither the project nor the global config sets one.
+const DefaultRequestTimeout = 60
+
+// RequestTimeoutSeconds returns the effective global nginx request timeout in
+// seconds, falling back to nginx's 60s default when unset or non-positive.
+func (c *GlobalConfig) RequestTimeoutSeconds() int {
+	if c.Nginx.RequestTimeout > 0 {
+		return c.Nginx.RequestTimeout
+	}
+	return DefaultRequestTimeout
 }
 
 // Worker exec-mode constants. `exec` is the default on every platform;

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -73,6 +73,50 @@ func TestSaveLoadGlobal_RoundTrip(t *testing.T) {
 	}
 }
 
+// ── RequestTimeoutSeconds ─────────────────────────────────────────────────────
+
+func TestRequestTimeoutSeconds_DefaultsTo60WhenUnset(t *testing.T) {
+	cfg := &GlobalConfig{}
+	if got := cfg.RequestTimeoutSeconds(); got != DefaultRequestTimeout {
+		t.Errorf("RequestTimeoutSeconds = %d, want %d", got, DefaultRequestTimeout)
+	}
+}
+
+func TestRequestTimeoutSeconds_HonoursConfiguredValue(t *testing.T) {
+	cfg := &GlobalConfig{}
+	cfg.Nginx.RequestTimeout = 300
+	if got := cfg.RequestTimeoutSeconds(); got != 300 {
+		t.Errorf("RequestTimeoutSeconds = %d, want 300", got)
+	}
+}
+
+func TestRequestTimeoutSeconds_NonPositiveFallsBack(t *testing.T) {
+	cfg := &GlobalConfig{}
+	cfg.Nginx.RequestTimeout = -5
+	if got := cfg.RequestTimeoutSeconds(); got != DefaultRequestTimeout {
+		t.Errorf("RequestTimeoutSeconds = %d, want %d for non-positive", got, DefaultRequestTimeout)
+	}
+}
+
+func TestSaveLoadGlobal_RequestTimeoutRoundTrip(t *testing.T) {
+	setConfigDir(t)
+	cfg, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	cfg.Nginx.RequestTimeout = 240
+	if err := SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+	got, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal after save: %v", err)
+	}
+	if got.Nginx.RequestTimeout != 240 {
+		t.Errorf("Nginx.RequestTimeout = %d, want 240", got.Nginx.RequestTimeout)
+	}
+}
+
 // ── Cache ─────────────────────────────────────────────────────────────────────
 
 func TestLoadGlobal_CacheReturnsIndependentCopy(t *testing.T) {

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -77,6 +77,10 @@ type ProjectConfig struct {
 	// {{site}} (database-safe name). When APP_URL is present here it takes
 	// precedence over the default scheme://domain rewrite.
 	EnvOverrides map[string]string `yaml:"env_overrides,omitempty"`
+	// RequestTimeout overrides the nginx request timeout for this project, in
+	// seconds. Zero inherits the global nginx.request_timeout (default 60s).
+	// Raise it for apps with deliberately long-running requests.
+	RequestTimeout int `yaml:"request_timeout,omitempty"`
 }
 
 // IsEmpty returns true when the config has no meaningful content, which
@@ -87,7 +91,7 @@ func (c *ProjectConfig) IsEmpty() bool {
 		len(c.Workers) == 0 && len(c.CustomWorkers) == 0 && !c.Secured &&
 		c.AppURL == "" && c.DB.Service == "" && c.DB.Database == "" &&
 		c.Container == nil && c.Runtime == "" && !c.RuntimeWorker &&
-		!c.DBIsolated && len(c.EnvOverrides) == 0
+		!c.DBIsolated && len(c.EnvOverrides) == 0 && c.RequestTimeout == 0
 }
 
 // ServiceNames returns the name of every service in the config, for callers

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -413,6 +413,41 @@ func TestProjectConfig_PublicDir_IsEmpty(t *testing.T) {
 	}
 }
 
+func TestProjectConfig_RequestTimeout(t *testing.T) {
+	input := `php_version: "8.4"
+request_timeout: 300
+`
+	var cfg ProjectConfig
+	if err := yaml.Unmarshal([]byte(input), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.RequestTimeout != 300 {
+		t.Errorf("RequestTimeout = %d, want 300", cfg.RequestTimeout)
+	}
+}
+
+func TestProjectConfig_RequestTimeout_OmittedWhenZero(t *testing.T) {
+	cfg := ProjectConfig{PHPVersion: "8.4"}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "request_timeout") {
+		t.Errorf("request_timeout should be omitted when zero, got:\n%s", string(data))
+	}
+}
+
+func TestProjectConfig_RequestTimeout_IsEmpty(t *testing.T) {
+	cfg := &ProjectConfig{}
+	if !cfg.IsEmpty() {
+		t.Error("empty config should be empty")
+	}
+	cfg.RequestTimeout = 300
+	if cfg.IsEmpty() {
+		t.Error("config with request_timeout should not be empty")
+	}
+}
+
 func TestProjectConfig_OldFormatCompat(t *testing.T) {
 	// Old .lerd.yaml used services: [mysql, redis] — must still parse.
 	input := `php_version: "8.3"

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2455,6 +2455,15 @@ func execCheck(args map[string]any) (any, *rpcError) {
 		add("node_version", "ok", cfg.NodeVersion)
 	}
 
+	// Request timeout
+	if cfg.RequestTimeout != 0 {
+		if cfg.RequestTimeout < 0 {
+			add("request_timeout", "fail", fmt.Sprintf("%d — must be a positive number of seconds", cfg.RequestTimeout))
+		} else {
+			add("request_timeout", "ok", fmt.Sprintf("%ds", cfg.RequestTimeout))
+		}
+	}
+
 	// Framework
 	if cfg.Framework != "" {
 		if cfg.FrameworkDef != nil {

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -69,6 +69,26 @@ type VhostData struct {
 	// profiled. SPX_KEY is injected regardless (gated by the $spx_key map)
 	// so the profiler UI is reachable.
 	Profiling bool
+	// RequestTimeout is the nginx request timeout in seconds rendered into the
+	// fastcgi_*_timeout / proxy_*_timeout directives. Resolved per site by
+	// resolveRequestTimeout (project .lerd.yaml, then global config, then 60s).
+	RequestTimeout int
+}
+
+// resolveRequestTimeout returns the effective request timeout in seconds for
+// the site at sitePath: project .lerd.yaml wins, then global config, then 60s.
+// An empty sitePath skips the project lookup (site-less proxy vhosts).
+func resolveRequestTimeout(sitePath string) int {
+	if sitePath != "" {
+		if pc, err := config.LoadProjectConfig(sitePath); err == nil && pc.RequestTimeout > 0 {
+			return pc.RequestTimeout
+		}
+	}
+	gc, err := config.LoadGlobal()
+	if err != nil {
+		return config.DefaultRequestTimeout
+	}
+	return gc.RequestTimeoutSeconds()
 }
 
 // phpShort converts "8.4" → "84".
@@ -142,6 +162,7 @@ func GenerateVhost(site config.Site, phpVersion string) error {
 		ProxyPort:       proxyPort,
 		LerdSite:        site.Name,
 		Profiling:       profilerEnabled(),
+		RequestTimeout:  resolveRequestTimeout(site.Path),
 	}
 
 	var buf bytes.Buffer
@@ -185,6 +206,7 @@ func GenerateSSLVhost(site config.Site, phpVersion string) error {
 		ProxyPort:       proxyPort,
 		LerdSite:        site.Name,
 		Profiling:       profilerEnabled(),
+		RequestTimeout:  resolveRequestTimeout(site.Path),
 	}
 
 	var buf bytes.Buffer
@@ -217,6 +239,7 @@ func GenerateFrankenPHPVhost(site config.Site) error {
 		ServerNames:     serverNamesWithWildcards(site.Domains),
 		CustomContainer: podman.FrankenPHPContainerName(site.Name),
 		CustomPort:      podman.FrankenPHPPort,
+		RequestTimeout:  resolveRequestTimeout(site.Path),
 	}
 
 	var buf bytes.Buffer
@@ -247,6 +270,7 @@ func GenerateFrankenPHPSSLVhost(site config.Site) error {
 		CertDomain:      site.PrimaryDomain(),
 		CustomContainer: podman.FrankenPHPContainerName(site.Name),
 		CustomPort:      podman.FrankenPHPPort,
+		RequestTimeout:  resolveRequestTimeout(site.Path),
 	}
 
 	var buf bytes.Buffer
@@ -280,6 +304,7 @@ func GenerateCustomVhost(site config.Site) error {
 		CustomContainer: podman.CustomContainerName(site.Name),
 		CustomPort:      site.ContainerPort,
 		BackendSSL:      site.ContainerSSL,
+		RequestTimeout:  resolveRequestTimeout(site.Path),
 	}
 
 	var buf bytes.Buffer
@@ -314,6 +339,7 @@ func GenerateCustomSSLVhost(site config.Site) error {
 		CustomContainer: podman.CustomContainerName(site.Name),
 		CustomPort:      site.ContainerPort,
 		BackendSSL:      site.ContainerSSL,
+		RequestTimeout:  resolveRequestTimeout(site.Path),
 	}
 
 	var buf bytes.Buffer
@@ -364,6 +390,7 @@ func GenerateWorktreeVhost(domain, path, phpVersion, siteName, branch string) er
 		LerdSite:        siteName,
 		LerdBranch:      branch,
 		Profiling:       profilerEnabled(),
+		RequestTimeout:  resolveRequestTimeout(path),
 	}
 
 	var buf bytes.Buffer
@@ -402,6 +429,7 @@ func GenerateWorktreeSSLVhost(domain, path, phpVersion, parentDomain, siteName, 
 		LerdSite:        siteName,
 		LerdBranch:      branch,
 		Profiling:       profilerEnabled(),
+		RequestTimeout:  resolveRequestTimeout(path),
 	}
 
 	var buf bytes.Buffer
@@ -536,9 +564,10 @@ func RemoveVhost(domain string) error {
 
 // proxyVhostData is the template data for vhost-proxy.conf.tmpl.
 type proxyVhostData struct {
-	Domain       string
-	UpstreamHost string
-	UpstreamPort int
+	Domain         string
+	UpstreamHost   string
+	UpstreamPort   int
+	RequestTimeout int
 }
 
 // GenerateProxyVhost renders vhost-proxy.conf.tmpl and writes conf.d/{domain}.conf.
@@ -554,9 +583,10 @@ func GenerateProxyVhost(domain, upstreamHost string, upstreamPort int) error {
 	}
 
 	data := proxyVhostData{
-		Domain:       domain,
-		UpstreamHost: upstreamHost,
-		UpstreamPort: upstreamPort,
+		Domain:         domain,
+		UpstreamHost:   upstreamHost,
+		UpstreamPort:   upstreamPort,
+		RequestTimeout: resolveRequestTimeout(""),
 	}
 
 	var buf bytes.Buffer

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -10,11 +10,14 @@ import (
 	"github.com/geodro/lerd/internal/config"
 )
 
-// setupConfD points NginxConfD() at a temp dir via XDG_DATA_HOME and returns the conf.d path.
+// setupConfD points NginxConfD() at a temp dir via XDG_DATA_HOME and returns the
+// conf.d path. XDG_CONFIG_HOME is redirected too so resolveRequestTimeout reads
+// a hermetic (empty) global config instead of the developer's real one.
 func setupConfD(t *testing.T) string {
 	t.Helper()
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
 	return filepath.Join(tmp, "lerd", "nginx", "conf.d")
 }
 
@@ -62,6 +65,113 @@ func TestGenerateVhost_honoursSitePublicDir(t *testing.T) {
 	content := readConf(t, filepath.Join(confD, "myapp.test.conf"))
 	if !strings.Contains(content, "root /srv/myapp/public_html") {
 		t.Errorf("expected custom public_html doc root in:\n%s", content)
+	}
+}
+
+// ── resolveRequestTimeout ─────────────────────────────────────────────────────
+
+func TestResolveRequestTimeout_DefaultsTo60(t *testing.T) {
+	setupConfD(t)
+	if got := resolveRequestTimeout("/srv/nonexistent"); got != 60 {
+		t.Errorf("resolveRequestTimeout = %d, want 60 (nginx default)", got)
+	}
+}
+
+func TestResolveRequestTimeout_GlobalConfigWins(t *testing.T) {
+	setupConfD(t)
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	cfg.Nginx.RequestTimeout = 120
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+	if got := resolveRequestTimeout("/srv/nonexistent"); got != 120 {
+		t.Errorf("resolveRequestTimeout = %d, want 120 (global config)", got)
+	}
+}
+
+func TestResolveRequestTimeout_ProjectOverrideWins(t *testing.T) {
+	setupConfD(t)
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	cfg.Nginx.RequestTimeout = 120
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+	projectDir := t.TempDir()
+	if err := config.SaveProjectConfig(projectDir, &config.ProjectConfig{RequestTimeout: 300}); err != nil {
+		t.Fatalf("SaveProjectConfig: %v", err)
+	}
+	if got := resolveRequestTimeout(projectDir); got != 300 {
+		t.Errorf("resolveRequestTimeout = %d, want 300 (.lerd.yaml override)", got)
+	}
+}
+
+// ── request timeout rendering ─────────────────────────────────────────────────
+
+func TestGenerateVhost_rendersDefaultRequestTimeout(t *testing.T) {
+	confD := setupConfD(t)
+	site := config.Site{Name: "app", Domains: []string{"app.test"}, Path: "/srv/app"}
+	if err := GenerateVhost(site, "8.4"); err != nil {
+		t.Fatalf("GenerateVhost: %v", err)
+	}
+	content := readConf(t, filepath.Join(confD, "app.test.conf"))
+	for _, want := range []string{"fastcgi_read_timeout 60s;", "fastcgi_send_timeout 60s;"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("expected %q in:\n%s", want, content)
+		}
+	}
+}
+
+func TestGenerateVhost_honoursProjectRequestTimeout(t *testing.T) {
+	confD := setupConfD(t)
+	projectDir := t.TempDir()
+	if err := config.SaveProjectConfig(projectDir, &config.ProjectConfig{RequestTimeout: 300}); err != nil {
+		t.Fatalf("SaveProjectConfig: %v", err)
+	}
+	site := config.Site{Name: "app", Domains: []string{"app.test"}, Path: projectDir}
+	if err := GenerateVhost(site, "8.4"); err != nil {
+		t.Fatalf("GenerateVhost: %v", err)
+	}
+	content := readConf(t, filepath.Join(confD, "app.test.conf"))
+	if !strings.Contains(content, "fastcgi_read_timeout 300s;") {
+		t.Errorf("expected fastcgi_read_timeout 300s in:\n%s", content)
+	}
+}
+
+func TestGenerateSSLVhost_honoursProjectRequestTimeout(t *testing.T) {
+	confD := setupConfD(t)
+	projectDir := t.TempDir()
+	if err := config.SaveProjectConfig(projectDir, &config.ProjectConfig{RequestTimeout: 240}); err != nil {
+		t.Fatalf("SaveProjectConfig: %v", err)
+	}
+	site := config.Site{Name: "app", Domains: []string{"app.test"}, Path: projectDir}
+	if err := GenerateSSLVhost(site, "8.4"); err != nil {
+		t.Fatalf("GenerateSSLVhost: %v", err)
+	}
+	content := readConf(t, filepath.Join(confD, "app.test-ssl.conf"))
+	if !strings.Contains(content, "fastcgi_read_timeout 240s;") {
+		t.Errorf("expected fastcgi_read_timeout 240s in:\n%s", content)
+	}
+}
+
+func TestGenerateCustomVhost_honoursProjectRequestTimeout(t *testing.T) {
+	confD := setupConfD(t)
+	projectDir := t.TempDir()
+	if err := config.SaveProjectConfig(projectDir, &config.ProjectConfig{RequestTimeout: 180}); err != nil {
+		t.Fatalf("SaveProjectConfig: %v", err)
+	}
+	site := config.Site{Name: "nestapp", Domains: []string{"nestapp.test"}, Path: projectDir, ContainerPort: 3000}
+	if err := GenerateCustomVhost(site); err != nil {
+		t.Fatalf("GenerateCustomVhost: %v", err)
+	}
+	content := readConf(t, filepath.Join(confD, "nestapp.test.conf"))
+	if !strings.Contains(content, "proxy_read_timeout 180s;") {
+		t.Errorf("expected proxy_read_timeout 180s in:\n%s", content)
 	}
 }
 

--- a/internal/nginx/templates/vhost-custom-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-custom-ssl.conf.tmpl
@@ -25,8 +25,8 @@ server {
         proxy_set_header X-Forwarded-Host $real_forwarded_host;
         proxy_set_header X-Forwarded-Proto $real_forwarded_proto;
         proxy_set_header X-Forwarded-Port $server_port;
-        proxy_read_timeout 60s;
-        proxy_send_timeout 60s;
+        proxy_read_timeout {{.RequestTimeout}}s;
+        proxy_send_timeout {{.RequestTimeout}}s;
         {{- if .BackendSSL}}
         proxy_ssl_verify off;
         {{- end}}

--- a/internal/nginx/templates/vhost-custom.conf.tmpl
+++ b/internal/nginx/templates/vhost-custom.conf.tmpl
@@ -15,8 +15,8 @@ server {
         proxy_set_header X-Forwarded-Host $real_forwarded_host;
         proxy_set_header X-Forwarded-Proto $real_forwarded_proto;
         proxy_set_header X-Forwarded-Port $server_port;
-        proxy_read_timeout 60s;
-        proxy_send_timeout 60s;
+        proxy_read_timeout {{.RequestTimeout}}s;
+        proxy_send_timeout {{.RequestTimeout}}s;
         {{- if .BackendSSL}}
         proxy_ssl_verify off;
         {{- end}}

--- a/internal/nginx/templates/vhost-proxy.conf.tmpl
+++ b/internal/nginx/templates/vhost-proxy.conf.tmpl
@@ -8,7 +8,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_read_timeout 60s;
+        proxy_read_timeout {{.RequestTimeout}}s;
         proxy_connect_timeout 5s;
     }
 }

--- a/internal/nginx/templates/vhost-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-ssl.conf.tmpl
@@ -25,8 +25,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 60s;
-        proxy_send_timeout 60s;
+        proxy_read_timeout {{.RequestTimeout}}s;
+        proxy_send_timeout {{.RequestTimeout}}s;
     }
 {{end}}
     location / {
@@ -37,6 +37,8 @@ server {
         set $fpm "lerd-php{{.PHPVersionShort}}-fpm";
         fastcgi_pass $fpm:9000;
         fastcgi_index index.php;
+        fastcgi_read_timeout {{.RequestTimeout}}s;
+        fastcgi_send_timeout {{.RequestTimeout}}s;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param HTTPS on;
         fastcgi_buffers 16 16k;

--- a/internal/nginx/templates/vhost.conf.tmpl
+++ b/internal/nginx/templates/vhost.conf.tmpl
@@ -15,8 +15,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 60s;
-        proxy_send_timeout 60s;
+        proxy_read_timeout {{.RequestTimeout}}s;
+        proxy_send_timeout {{.RequestTimeout}}s;
     }
 {{end}}
     location / {
@@ -27,6 +27,8 @@ server {
         set $fpm "lerd-php{{.PHPVersionShort}}-fpm";
         fastcgi_pass $fpm:9000;
         fastcgi_index index.php;
+        fastcgi_read_timeout {{.RequestTimeout}}s;
+        fastcgi_send_timeout {{.RequestTimeout}}s;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_buffers 16 16k;
         fastcgi_buffer_size 32k;


### PR DESCRIPTION
nginx's built in fastcgi and proxy read timeout of 60 seconds was not adjustable in lerd, so any site with a deliberately long running request hit a 504 Gateway Timeout with no supported way to raise the ceiling. This came up in #399, where the reporter interacts with hardware that has its own 65 second external timeout and needs the request to stay open long enough for the frontend to observe it.

This adds a request_timeout setting in seconds, resolved per site as the project's .lerd.yaml value first, then the global nginx.request_timeout, then nginx's 60s default. The two tier model matches how lerd already handles php_version, node_version, and app_url: a machine wide default plus a committed per project override that travels with the repo.

The resolved value is rendered into every generated vhost, fastcgi_read_timeout and fastcgi_send_timeout for PHP-FPM sites and proxy_read_timeout and proxy_send_timeout for proxy, FrankenPHP, and custom container sites, so the same knob works whatever runtime a site uses. lerd check and the MCP config_validate tool report the configured value, the MCP skill reference lists the new field, and the configuration and nginx overrides docs describe both the global and per project forms.

The nginx overrides doc also corrects a misleading instruction: it told users to run lerd restart to pick up a custom.d override, but that only restarts a site's PHP-FPM container and never reloads nginx, so the snippet was silently ignored. It now points at restarting the nginx container.

Addresses #399.
