### PR TITLE
feat(services): add Typesense, Valkey, and Typesense Dashboard presets

### DIFF
--- a/docs/usage/service-presets.md
+++ b/docs/usage/service-presets.md
@@ -3,7 +3,7 @@
 Service presets are the YAML-driven definitions for every service lerd manages. There are two kinds:
 
 - **Default presets** (`default: true`) — the always-recognised services that ship with lerd: `mysql`, `redis`, `postgres`, `meilisearch`, `rustfs`, `mailpit`. They get auto-listed in `lerd service` everywhere; their lifecycle is identical to add-on presets but they don't need an explicit install step.
-- **Add-on presets** — opt-in installers for phpMyAdmin, pgAdmin, MongoDB, alternate MySQL / MariaDB versions, Selenium, Stripe Mock, Memcached, RabbitMQ, Elasticsearch, Elasticvue.
+- **Add-on presets** — opt-in installers for phpMyAdmin, pgAdmin, MongoDB, alternate MySQL / MariaDB versions, Selenium, Stripe Mock, Memcached, Valkey, RabbitMQ, Elasticsearch, Typesense, Typesense Dashboard, Elasticvue.
 
 Both kinds use the same YAML schema in `internal/config/presets/*.yaml` and the same code path. Adding or replacing a default service is a YAML edit, not a code change. See [Service updates](service-updates.md) for the configuration knobs (`update_strategy`, `track_latest`, `allow_major_upgrade`).
 
@@ -33,8 +33,11 @@ Both kinds use the same YAML schema in `internal/config/presets/*.yaml` and the 
 | `selenium` | `docker.io/selenium/standalone-chromium:latest` | - | `http://localhost:7900` (noVNC) |
 | `stripe-mock` | `docker.io/stripemock/stripe-mock:latest` | - | `127.0.0.1:12111` |
 | `memcached` | `docker.io/library/memcached:1.6-alpine` | - | `127.0.0.1:11211` |
+| `valkey` | `docker.io/valkey/valkey:9-alpine` | - | `127.0.0.1:6380` |
 | `rabbitmq` | `docker.io/library/rabbitmq:3-management-alpine` | - | `http://localhost:15672` (mgmt UI, opens in new tab) |
 | `elasticsearch` | `docker.elastic.co/elasticsearch/elasticsearch:8.13.4` | - | `127.0.0.1:9200` |
+| `typesense` | `docker.io/typesense/typesense:30.2` | - | `127.0.0.1:8108` |
+| `typesense-dashboard` | `docker.io/bfritscher/typesense-dashboard:latest` | `typesense` (preset) | `http://localhost:8084` |
 | `elasticvue` | `docker.io/cars10/elasticvue:latest` | `elasticsearch` (preset) | `http://localhost:8083` |
 
 ```bash
@@ -69,10 +72,11 @@ first install is the image pull; the progress line shows what layer is being
 copied so a slow registry is distinguishable from a stuck install.
 
 The detail panel of every database service (built-in `mysql` / `postgres`, any
-installed `mongo`, and any installed alternate like `mysql-5-7`) surfaces a
-sky-blue suggestion banner offering to install the paired admin UI when it
-isn't installed yet. The banner is dismissable per-preset and dismissal
-persists in `localStorage`.
+installed `mongo`, and any installed alternate like `mysql-5-7`) and search
+engine (`elasticsearch` → Elasticvue, `typesense` → Typesense Dashboard)
+surfaces a sky-blue suggestion banner offering to install the paired admin UI
+when it isn't installed yet. The banner is dismissable per-preset and
+dismissal persists in `localStorage`.
 
 ## Multi-version presets
 
@@ -178,8 +182,11 @@ A preset's `depends_on` is enforced two ways:
 | `mongo-express` | basic auth disabled, open `http://localhost:8082` directly |
 | `stripe-mock` | no auth (Stripe test mock) |
 | `memcached` | no auth (Memcached has no native authentication) |
+| `valkey` | no auth (no password set for local dev, same as `redis`) |
 | `rabbitmq` | management UI: `root` / `lerd` (also the default AMQP user) |
 | `elasticsearch` | no auth (`xpack.security.enabled=false` for local dev) |
+| `typesense` | API key `lerd`, sent as the `X-TYPESENSE-API-KEY` header |
+| `typesense-dashboard` | no sign-in, opens pre-connected to the lerd Typesense node at `localhost:8108` |
 | `elasticvue` | no auth, opens straight to the pre-configured `Lerd Elasticsearch` cluster at `http://localhost:9200` |
 
 ## Database service quality-of-life

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -74,10 +74,17 @@ func userPickedDBFromYAML(lerdYAMLServices map[string]bool) bool {
 // shouldApplyService decides whether to apply env vars for svc. A built-in
 // DB service that wasn't explicitly picked is skipped when the user picked a
 // different DB, so a fresh-Laravel DB_CONNECTION=sqlite never re-imprints
-// itself when the wizard selected mysql. Otherwise apply when the env file
+// itself when the wizard selected mysql. The built-in redis is likewise
+// skipped when the project picked valkey. Otherwise apply when the env file
 // references the service or .lerd.yaml lists it.
-func shouldApplyService(svc string, detectedFromEnv, pickedFromYAML, userPickedDB bool) bool {
+func shouldApplyService(svc string, detectedFromEnv, pickedFromYAML, userPickedDB, valkeyPicked bool) bool {
 	if userPickedDB && (svc == "mysql" || svc == "postgres") && !pickedFromYAML {
+		return false
+	}
+	// Valkey writes the same REDIS_* keys, so a redis-shaped .env re-detects
+	// the built-in redis on every later run; skip it so valkey projects don't
+	// also boot a redundant redis container.
+	if svc == "redis" && valkeyPicked && !pickedFromYAML {
 		return false
 	}
 	return detectedFromEnv || pickedFromYAML
@@ -267,6 +274,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	}
 
 	userPickedDB := userPickedDBFromYAML(lerdYAMLServices)
+	valkeyPicked := lerdYAMLServices["valkey"]
 
 	if len(fw.Env.Services) > 0 {
 		// Framework defines its own service detection and vars — use those.
@@ -279,7 +287,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			detectedFromEnv := frameworkServiceDetected(def, envMap)
 			pickedFromYAML := lerdYAMLServices[svc]
 
-			if !shouldApplyService(svc, detectedFromEnv, pickedFromYAML, userPickedDB) {
+			if !shouldApplyService(svc, detectedFromEnv, pickedFromYAML, userPickedDB, valkeyPicked) {
 				continue
 			}
 
@@ -350,7 +358,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			detectedFromEnv := ok && detector(envMap)
 			pickedFromYAML := lerdYAMLServices[svc]
 
-			if !shouldApplyService(svc, detectedFromEnv, pickedFromYAML, userPickedDB) {
+			if !shouldApplyService(svc, detectedFromEnv, pickedFromYAML, userPickedDB, valkeyPicked) {
 				continue
 			}
 

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -195,37 +195,45 @@ func TestShouldApplyService(t *testing.T) {
 		detected     bool
 		picked       bool
 		userPickedDB bool
+		valkeyPicked bool
 		want         bool
 	}{
 		// Regression: fresh Laravel project, user picks mysql in `lerd init`.
 		// Existing .env still says DB_CONNECTION=sqlite, so detection misses.
 		// The .lerd.yaml pick must still cause mysql vars to be applied.
-		{"mysql picked, not detected", "mysql", false, true, true, true},
+		{"mysql picked, not detected", "mysql", false, true, true, false, true},
 
 		// Detection-driven application keeps working when the user did not
 		// pre-pick a DB (e.g. an imported Sail project where .env already
 		// references mysql).
-		{"mysql detected, no yaml", "mysql", true, false, false, true},
+		{"mysql detected, no yaml", "mysql", true, false, false, false, true},
 
 		// User picked postgres but .env mentions mysql — don't reapply mysql
 		// on top of postgres, otherwise switching DBs via the wizard silently
 		// keeps the old credentials.
-		{"mysql detected, postgres picked", "mysql", true, false, true, false},
+		{"mysql detected, postgres picked", "mysql", true, false, true, false, false},
 
 		// Non-DB services aren't affected by the userPickedDB guard.
-		{"redis detected", "redis", true, false, true, true},
-		{"redis picked", "redis", false, true, false, true},
-		{"redis neither", "redis", false, false, false, false},
+		{"redis detected", "redis", true, false, true, false, true},
+		{"redis picked", "redis", false, true, false, false, true},
+		{"redis neither", "redis", false, false, false, false, false},
 
 		// Postgres mirror of the mysql cases.
-		{"postgres picked, not detected", "postgres", false, true, true, true},
-		{"postgres detected, mysql picked", "postgres", true, false, true, false},
+		{"postgres picked, not detected", "postgres", false, true, true, false, true},
+		{"postgres detected, mysql picked", "postgres", true, false, true, false, false},
+
+		// Valkey is a redis replacement: a redis-shaped .env must not reapply
+		// the built-in redis when the project picked valkey.
+		{"redis detected, valkey picked", "redis", true, false, false, true, false},
+
+		// ...unless redis itself is also explicitly picked alongside valkey.
+		{"redis picked, valkey picked", "redis", false, true, false, true, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := shouldApplyService(tc.svc, tc.detected, tc.picked, tc.userPickedDB)
+			got := shouldApplyService(tc.svc, tc.detected, tc.picked, tc.userPickedDB, tc.valkeyPicked)
 			if got != tc.want {
-				t.Errorf("shouldApplyService(%q, det=%v, picked=%v, userPickedDB=%v) = %v, want %v",
-					tc.svc, tc.detected, tc.picked, tc.userPickedDB, got, tc.want)
+				t.Errorf("shouldApplyService(%q, det=%v, picked=%v, userPickedDB=%v, valkeyPicked=%v) = %v, want %v",
+					tc.svc, tc.detected, tc.picked, tc.userPickedDB, tc.valkeyPicked, got, tc.want)
 			}
 		})
 	}

--- a/internal/config/presets/typesense-dashboard.yaml
+++ b/internal/config/presets/typesense-dashboard.yaml
@@ -1,0 +1,13 @@
+name: typesense-dashboard
+image: docker.io/bfritscher/typesense-dashboard:latest
+description: Typesense Dashboard web UI for the lerd Typesense service
+ports:
+  - "8084:80"
+environment:
+  # Base64-encoded connection config the image expands into config.json at
+  # startup; decodes to the lerd Typesense node (localhost:8108, api key
+  # "lerd") so the dashboard connects with no manual setup.
+  TYPESENSE_DASHBOARD_CONFIG: eyJhcGlLZXkiOiJsZXJkIiwibm9kZSI6eyJob3N0IjoibG9jYWxob3N0IiwicG9ydCI6IjgxMDgiLCJwcm90b2NvbCI6Imh0dHAiLCJwYXRoIjoiIiwidGxzIjpmYWxzZX0sImhpc3RvcnkiOltdfQ==
+depends_on:
+  - typesense
+dashboard: http://localhost:8084

--- a/internal/config/presets/typesense.yaml
+++ b/internal/config/presets/typesense.yaml
@@ -1,0 +1,19 @@
+name: typesense
+description: Typesense search engine
+family: typesense
+image: docker.io/typesense/typesense:30.2
+# typesense-server refuses to boot without --api-key and --data-dir, and the
+# image entrypoint takes them as flags rather than env vars.
+exec: --data-dir /data --api-key=lerd --enable-cors
+ports:
+  - "8108:8108"
+data_dir: /data
+env_vars:
+  - SCOUT_DRIVER=typesense
+  - TYPESENSE_API_KEY=lerd
+  - TYPESENSE_HOST=lerd-typesense
+  - TYPESENSE_PORT=8108
+  - TYPESENSE_PROTOCOL=http
+env_detect:
+  composer: typesense/typesense-php
+connection_url: http://127.0.0.1:8108

--- a/internal/config/presets/valkey.yaml
+++ b/internal/config/presets/valkey.yaml
@@ -1,0 +1,17 @@
+name: valkey
+description: Valkey in-memory store (Redis-compatible)
+family: valkey
+image: docker.io/valkey/valkey:9-alpine
+# Valkey speaks the Redis protocol on 6379 inside the container; it is
+# published on 6380 so it can coexist with the redis preset on the host.
+ports:
+  - "6380:6379"
+data_dir: /data
+env_vars:
+  - REDIS_HOST=lerd-valkey
+  - REDIS_PORT=6379
+  - REDIS_PASSWORD=null
+  - CACHE_STORE=redis
+  - SESSION_DRIVER=redis
+  - QUEUE_CONNECTION=redis
+connection_url: redis://127.0.0.1:6380

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -11,17 +11,20 @@ func TestListPresets_IncludesShippedPresets(t *testing.T) {
 		t.Fatalf("ListPresets() error = %v", err)
 	}
 	want := map[string]bool{
-		"phpmyadmin":    false,
-		"pgadmin":       false,
-		"mongo":         false,
-		"mongo-express": false,
-		"selenium":      false,
-		"stripe-mock":   false,
-		"mysql":         false,
-		"memcached":     false,
-		"rabbitmq":      false,
-		"elasticsearch": false,
-		"elasticvue":    false,
+		"phpmyadmin":          false,
+		"pgadmin":             false,
+		"mongo":               false,
+		"mongo-express":       false,
+		"selenium":            false,
+		"stripe-mock":         false,
+		"mysql":               false,
+		"memcached":           false,
+		"rabbitmq":            false,
+		"elasticsearch":       false,
+		"elasticvue":          false,
+		"typesense":           false,
+		"typesense-dashboard": false,
+		"valkey":              false,
 	}
 	for _, p := range presets {
 		if _, ok := want[p.Name]; ok {
@@ -103,6 +106,81 @@ func TestLoadPreset_Memcached(t *testing.T) {
 	}
 	if p.EnvDetect == nil || p.EnvDetect.Key != "MEMCACHED_HOST" {
 		t.Errorf("memcached env_detect should be key=MEMCACHED_HOST, got %+v", p.EnvDetect)
+	}
+}
+
+func TestLoadPreset_Valkey(t *testing.T) {
+	p, err := LoadPreset("valkey")
+	if err != nil {
+		t.Fatalf("LoadPreset(valkey) error = %v", err)
+	}
+	if p.Image == "" || len(p.Ports) != 1 {
+		t.Errorf("valkey preset missing image or port, got: %+v", p)
+	}
+	if p.Ports[0] != "6380:6379" {
+		t.Errorf("valkey must publish 6380:6379 to avoid colliding with redis, got %q", p.Ports[0])
+	}
+	if p.DataDir != "/data" {
+		t.Errorf("valkey should persist /data so its dataset survives restarts, got %q", p.DataDir)
+	}
+	hasRedisHost := false
+	for _, kv := range p.EnvVars {
+		if kv == "REDIS_HOST=lerd-valkey" {
+			hasRedisHost = true
+		}
+	}
+	if !hasRedisHost {
+		t.Errorf("valkey must point REDIS_HOST at lerd-valkey, got %v", p.EnvVars)
+	}
+	if p.Default {
+		t.Errorf("valkey is an opt-in add-on preset and must not be default")
+	}
+}
+
+func TestLoadPreset_Typesense(t *testing.T) {
+	p, err := LoadPreset("typesense")
+	if err != nil {
+		t.Fatalf("LoadPreset(typesense) error = %v", err)
+	}
+	if p.Image == "" || len(p.Ports) != 1 || p.Ports[0] != "8108:8108" {
+		t.Errorf("typesense preset missing image or 8108:8108 port, got: %+v", p)
+	}
+	if p.DataDir != "/data" {
+		t.Errorf("typesense must persist /data so the search index survives restarts, got %q", p.DataDir)
+	}
+	if !strings.Contains(p.Exec, "--api-key=") || !strings.Contains(p.Exec, "--data-dir") {
+		t.Errorf("typesense exec must pass --api-key and --data-dir, got %q", p.Exec)
+	}
+	if p.EnvDetect == nil || p.EnvDetect.Composer != "typesense/typesense-php" {
+		t.Errorf("typesense env_detect should fire on composer typesense/typesense-php, got %+v", p.EnvDetect)
+	}
+	hasScout := false
+	for _, kv := range p.EnvVars {
+		if kv == "SCOUT_DRIVER=typesense" {
+			hasScout = true
+		}
+	}
+	if !hasScout {
+		t.Errorf("typesense must set SCOUT_DRIVER=typesense for Laravel Scout, got %v", p.EnvVars)
+	}
+	if p.Default {
+		t.Errorf("typesense is an opt-in add-on preset and must not be default")
+	}
+}
+
+func TestLoadPreset_TypesenseDashboard(t *testing.T) {
+	p, err := LoadPreset("typesense-dashboard")
+	if err != nil {
+		t.Fatalf("LoadPreset(typesense-dashboard) error = %v", err)
+	}
+	if len(p.DependsOn) != 1 || p.DependsOn[0] != "typesense" {
+		t.Errorf("typesense-dashboard should depend on typesense, got %v", p.DependsOn)
+	}
+	if p.Dashboard == "" {
+		t.Errorf("typesense-dashboard must expose its UI as dashboard")
+	}
+	if p.Environment["TYPESENSE_DASHBOARD_CONFIG"] == "" {
+		t.Errorf("typesense-dashboard must pre-wire the connection via TYPESENSE_DASHBOARD_CONFIG")
 	}
 }
 

--- a/internal/ui/web/src/lib/dashboardIcons.ts
+++ b/internal/ui/web/src/lib/dashboardIcons.ts
@@ -35,6 +35,7 @@ const BY_NAME: Record<string, string> = {
   elasticsearch: ICONS.search,
   elasticvue: ICONS.search,
   typesense: ICONS.search,
+  'typesense-dashboard': ICONS.search,
   rustfs: ICONS.storage,
   minio: ICONS.storage,
   'mongo-express': ICONS.leaf,

--- a/internal/ui/web/src/stores/presetSuggestions.ts
+++ b/internal/ui/web/src/stores/presetSuggestions.ts
@@ -6,7 +6,8 @@ const SUGGESTIONS: Record<string, string> = {
   mysql: 'phpmyadmin',
   postgres: 'pgadmin',
   mongo: 'mongo-express',
-  elasticsearch: 'elasticvue'
+  elasticsearch: 'elasticvue',
+  typesense: 'typesense-dashboard'
 };
 
 const STORAGE_KEY = 'lerd-dismissed-preset-suggestions';

--- a/internal/ui/web/src/stores/services.ts
+++ b/internal/ui/web/src/stores/services.ts
@@ -332,7 +332,10 @@ export function serviceLabel(name: string): string {
     elasticsearch: 'Elasticsearch',
     elasticvue: 'Elasticvue',
     memcached: 'Memcached',
-    rabbitmq: 'RabbitMQ'
+    rabbitmq: 'RabbitMQ',
+    valkey: 'Valkey',
+    typesense: 'Typesense',
+    'typesense-dashboard': 'Typesense Dashboard'
   };
   if (overrides[name]) return overrides[name];
   // Versioned variants like "mysql-5-7"; show the family label.


### PR DESCRIPTION
Typesense and Valkey land as opt-in add-on service presets. Valkey is the Redis-compatible store, published on host port 6380 so it can sit alongside the redis preset, and it carries the same REDIS_* env vars pointed at its own container. Typesense is the search engine, on port 8108 with the api key lerd, and it writes SCOUT_DRIVER plus the TYPESENSE_* keys so Laravel Scout projects pick it up; it is auto-detected from the typesense/typesense-php composer package the same way elasticsearch is.

Typesense Dashboard is the paired web UI for Typesense, the same engine-plus-UI split that elasticsearch and elasticvue already use. It depends on typesense, so the preset picker gates its Add button until Typesense is installed, and a base64 connection config wires it to the lerd Typesense node so it opens already connected. The suggestion banner inside the Typesense service panel offers to install it with one click.

Because Valkey writes the same REDIS_* keys as Redis, a project that picks Valkey would otherwise see lerd env re-detect and boot the built-in redis container on every later run. shouldApplyService now skips the built-in redis when a project has picked valkey, mirroring how it already skips an unpicked database service.