### PR TITLE
feat(profiler): SPX env passthrough and profiler UI improvements

### DIFF
--- a/docs/features/profiler.md
+++ b/docs/features/profiler.md
@@ -24,13 +24,13 @@ lerd profile off       # stop profiling
 lerd profile clear     # delete every captured report
 ```
 
-In the dashboard, the System health card carries a Profiler toggle next to the dump bridge one: click it to flip profiling on or off, and a pulsing emerald dot marks it as live. The flame icon in the left rail opens the **Profiler** view and shows the same green dot while profiling is on. Inside the Profiler view, the header has a **Start profiling** / **Stop profiling** button and a **Clear data** button.
+In the dashboard, the System health card carries a Profiler toggle next to the dump bridge one: click it to flip profiling on or off, and a pulsing emerald dot marks it as live. The Sites column carries the same toggle above the site list. The flame icon in the left rail opens the **Profiler** view and shows the same green dot while profiling is on. Inside the Profiler view, the header has a **Start profiling** / **Stop profiling** button and a **Clear data** button. The button is emerald with a live pulsing dot while profiling is on, and muted grey while it is off.
 
-While the profiler is on, every HTTP request to every PHP-FPM site is profiled. Reload the sites you care about a few times, then open the Profiler view to read the reports. Turn it off when you are done so the profiler is not adding overhead to every request.
+While the profiler is on, every HTTP request to every PHP-FPM site is profiled. Reload the sites you care about a few times, then open the Profiler view to read the reports. The report list refreshes itself while profiling is on, so new captures appear without a manual reload. Turn it off when you are done so the profiler is not adding overhead to every request.
 
 ## Reading flame graphs
 
-The Profiler view embeds the SPX report UI, served by a dedicated `profiler.localhost` nginx vhost so it does not depend on any one site. Each report lists wall time, CPU time, memory, and the call tree. SPX's time-line view is an interactive flame graph: wide frames are where the time went. Click a frame to zoom, and use the flat-profile table to find the most expensive functions.
+The Profiler view embeds the SPX report UI, served by a dedicated `profiler.localhost` nginx vhost so it does not depend on any one site. Its landing page is SPX's control panel, the list of captured reports. SPX's Configuration form above the list is collapsed by default so the list takes the whole view; the **Show configuration** button in the header brings it back. Each report lists wall time, CPU time, memory, and the call tree. SPX's time-line view is an interactive flame graph: wide frames are where the time went. Click a frame to zoom, and use the flat-profile table to find the most expensive functions.
 
 All reports land in one shared directory, `~/.local/share/lerd/spx/`, regardless of which site or PHP version produced them. Each report is labelled with its request host and URI so they stay distinguishable.
 
@@ -44,6 +44,8 @@ lerd profile run artisan app:heavy-report
 ```
 
 The command runs as `php <command>` inside the project's container with SPX enabled, and the report lands in the same Profiler view alongside the HTTP reports. This works whether or not the global profiler is on.
+
+Because the `php` shim runs PHP inside the container, you can also profile any shim'd PHP tool by setting `SPX_ENABLED=1` in front of it. lerd forwards every `SPX_*` variable from your shell into the container, so `SPX_ENABLED=1 composer update` or `SPX_ENABLED=1 php artisan migrate` is profiled too. When SPX is enabled and you have not set `SPX_REPORT`, lerd defaults it to `full` so the run shows up in the Profiler view rather than only printing a flat profile to the terminal. Other SPX knobs work the same way, for example `SPX_SAMPLING_PERIOD=100 SPX_ENABLED=1 composer update`.
 
 ## Open the SPX UI directly
 

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -123,6 +123,12 @@ func RunPHPCaptureEnv(cwd string, args []string, extraEnv []string) (int, error)
 		"--env", "COMPOSER_HOME="+composerHome,
 		"--env", "PATH="+projectVendorBin+":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:"+composerBin,
 	)
+	// Forward SPX_* profiler vars from the host so `SPX_ENABLED=1 php ...` (or
+	// any shim'd tool like composer) reaches SPX inside the container. extraEnv
+	// is applied after, so an explicit caller like `lerd profile run` wins.
+	for _, e := range spxPassthroughEnv(os.Environ()) {
+		cmdArgs = append(cmdArgs, "--env", e)
+	}
 	for _, e := range extraEnv {
 		cmdArgs = append(cmdArgs, "--env", e)
 	}
@@ -140,4 +146,29 @@ func RunPHPCaptureEnv(cwd string, args []string, extraEnv []string) (int, error)
 		return 0, err
 	}
 	return 0, nil
+}
+
+// spxPassthroughEnv picks the SPX_* profiler vars out of environ. When SPX is
+// enabled but no report type is set, it defaults SPX_REPORT to full so the run
+// lands in the Profiler view instead of a terminal flat profile.
+func spxPassthroughEnv(environ []string) []string {
+	var out []string
+	enabled, hasReport := false, false
+	for _, e := range environ {
+		if !strings.HasPrefix(e, "SPX_") {
+			continue
+		}
+		out = append(out, e)
+		k, v, _ := strings.Cut(e, "=")
+		switch k {
+		case "SPX_ENABLED":
+			enabled = v != "" && v != "0"
+		case "SPX_REPORT":
+			hasReport = true
+		}
+	}
+	if enabled && !hasReport {
+		out = append(out, "SPX_REPORT=full")
+	}
+	return out
 }

--- a/internal/cli/php_exec_test.go
+++ b/internal/cli/php_exec_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSpxPassthroughEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		environ []string
+		want    []string
+	}{
+		{
+			name:    "no SPX vars yields nothing",
+			environ: []string{"HOME=/home/x", "PATH=/bin"},
+			want:    nil,
+		},
+		{
+			name:    "enabled with no report defaults to full",
+			environ: []string{"PATH=/bin", "SPX_ENABLED=1"},
+			want:    []string{"SPX_ENABLED=1", "SPX_REPORT=full"},
+		},
+		{
+			name:    "explicit report is left untouched",
+			environ: []string{"SPX_ENABLED=1", "SPX_REPORT=fp"},
+			want:    []string{"SPX_ENABLED=1", "SPX_REPORT=fp"},
+		},
+		{
+			name:    "disabled SPX never gets a default report",
+			environ: []string{"SPX_ENABLED=0"},
+			want:    []string{"SPX_ENABLED=0"},
+		},
+		{
+			name:    "other SPX vars are forwarded as-is",
+			environ: []string{"SPX_SAMPLING_PERIOD=100", "SPX_ENABLED=1"},
+			want:    []string{"SPX_SAMPLING_PERIOD=100", "SPX_ENABLED=1", "SPX_REPORT=full"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := spxPassthroughEnv(tt.environ)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("spxPassthroughEnv(%v) = %v, want %v", tt.environ, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -130,6 +130,8 @@
   "profiler_clear": "Daten löschen",
   "profiler_clear_busy": "Wird gelöscht…",
   "profiler_clear_title": "Alle erfassten Profilberichte löschen",
+  "profiler_config_hide": "Konfiguration ausblenden",
+  "profiler_config_show": "Konfiguration einblenden",
   "notify_toggle_on": "Benachrichtigungen sind an, zum Deaktivieren klicken",
   "notify_toggle_off": "Benachrichtigungen sind aus, zum Aktivieren klicken",
   "notify_toggle_busy": "Benachrichtigungen werden aktualisiert…",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -526,6 +526,8 @@
   "profiler_clear": "Clear data",
   "profiler_clear_busy": "Clearing…",
   "profiler_clear_title": "Delete all captured profile reports",
+  "profiler_config_hide": "Hide configuration",
+  "profiler_config_show": "Show configuration",
   "notify_toggle_on": "Notifications are on, click to disable",
   "notify_toggle_off": "Notifications are off, click to enable",
   "notify_toggle_busy": "Updating notifications…",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -130,6 +130,8 @@
   "profiler_clear": "Borrar datos",
   "profiler_clear_busy": "Borrando…",
   "profiler_clear_title": "Eliminar todos los informes de perfilado capturados",
+  "profiler_config_hide": "Ocultar configuración",
+  "profiler_config_show": "Mostrar configuración",
   "notify_toggle_on": "Notificaciones activas, clic para desactivar",
   "notify_toggle_off": "Notificaciones inactivas, clic para activar",
   "notify_toggle_busy": "Actualizando notificaciones…",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -130,6 +130,8 @@
   "profiler_clear": "Effacer les données",
   "profiler_clear_busy": "Effacement…",
   "profiler_clear_title": "Supprimer tous les rapports de profilage capturés",
+  "profiler_config_hide": "Masquer la configuration",
+  "profiler_config_show": "Afficher la configuration",
   "notify_toggle_on": "Notifications activées, cliquez pour désactiver",
   "notify_toggle_off": "Notifications désactivées, cliquez pour activer",
   "notify_toggle_busy": "Mise à jour des notifications…",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -130,6 +130,8 @@
   "profiler_clear": "Hapus data",
   "profiler_clear_busy": "Menghapus…",
   "profiler_clear_title": "Hapus semua laporan profil yang terekam",
+  "profiler_config_hide": "Sembunyikan konfigurasi",
+  "profiler_config_show": "Tampilkan konfigurasi",
   "notify_toggle_on": "Notifikasi aktif, klik untuk menonaktifkan",
   "notify_toggle_off": "Notifikasi nonaktif, klik untuk mengaktifkan",
   "notify_toggle_busy": "Memperbarui notifikasi…",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -130,6 +130,8 @@
   "profiler_clear": "Gegevens wissen",
   "profiler_clear_busy": "Bezig met wissen…",
   "profiler_clear_title": "Alle vastgelegde profielrapporten verwijderen",
+  "profiler_config_hide": "Configuratie verbergen",
+  "profiler_config_show": "Configuratie tonen",
   "notify_toggle_on": "Meldingen staan aan, klik om uit te schakelen",
   "notify_toggle_off": "Meldingen staan uit, klik om in te schakelen",
   "notify_toggle_busy": "Meldingen bijwerken…",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -130,6 +130,8 @@
   "profiler_clear": "Limpar dados",
   "profiler_clear_busy": "A limpar…",
   "profiler_clear_title": "Eliminar todos os relatórios de perfilamento capturados",
+  "profiler_config_hide": "Ocultar configuração",
+  "profiler_config_show": "Mostrar configuração",
   "notify_toggle_on": "Notificações ativas, clique para desativar",
   "notify_toggle_off": "Notificações inativas, clique para ativar",
   "notify_toggle_busy": "A atualizar notificações…",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -130,6 +130,8 @@
   "profiler_clear": "Verileri temizle",
   "profiler_clear_busy": "Temizleniyor…",
   "profiler_clear_title": "Yakalanan tüm profil raporlarını sil",
+  "profiler_config_hide": "Yapılandırmayı gizle",
+  "profiler_config_show": "Yapılandırmayı göster",
   "notify_toggle_on": "Bildirimler açık, devre dışı bırakmak için tıklayın",
   "notify_toggle_off": "Bildirimler kapalı, etkinleştirmek için tıklayın",
   "notify_toggle_busy": "Bildirimler güncelleniyor…",

--- a/internal/ui/web/src/components/DashboardOverlay.svelte
+++ b/internal/ui/web/src/components/DashboardOverlay.svelte
@@ -8,6 +8,13 @@
     clearProfilerData
   } from '$stores/profiler';
   import Icon from './Icon.svelte';
+  import StatusDot from './StatusDot.svelte';
+  import {
+    isSpxReportView,
+    setSpxConfigHidden,
+    padSpxControlPanel,
+    fetchSpxReportCount
+  } from '$lib/spxControls';
   import { m } from '../paraglide/messages.js';
 
   let busy = $state(false);
@@ -15,18 +22,44 @@
   let iframeEl = $state<HTMLIFrameElement | null>(null);
   let entryHref = $state('');
   let canGoBack = $state(false);
+  let isReportView = $state(false);
+  // The SPX Configuration form is collapsed by default so the report list
+  // gets the whole view; the header button restores it on demand.
+  let configHidden = $state(true);
 
   const isProfiler = $derived($dashboardOpen?.name === 'profiler');
+
+  const headerBtnClass =
+    'text-xs rounded-sm border border-gray-200 dark:border-lerd-border px-2 py-1 ' +
+    'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors';
 
   // Reset iframe-history tracking whenever a different dashboard opens.
   $effect(() => {
     $dashboardOpen;
     entryHref = '';
     canGoBack = false;
+    isReportView = false;
+    configHidden = true;
   });
 
   $effect(() => {
     if (isProfiler) void loadProfilerStatus();
+  });
+
+  // SPX never re-fetches its report list while the control panel page is open,
+  // so new captures stay hidden. Poll and reload the iframe only once the
+  // report count has actually grown.
+  $effect(() => {
+    if (!isProfiler || isReportView || !$profilerEnabled) return;
+    let lastReportCount = -1;
+    const id = setInterval(async () => {
+      if (document.hidden) return;
+      const count = await fetchSpxReportCount();
+      if (count === null) return;
+      if (lastReportCount >= 0 && count > lastReportCount) reloadIframe();
+      lastReportCount = count;
+    }, 4000);
+    return () => clearInterval(id);
   });
 
   // iframeWindow returns the embedded window only when it is same-origin and
@@ -42,13 +75,26 @@
   }
 
   function onIframeLoad() {
-    const href = iframeWindow()?.location.href ?? '';
-    if (href === '') {
+    const w = iframeWindow();
+    const href = w?.location.href ?? '';
+    if (href === '' || !w) {
       canGoBack = false;
+      isReportView = false;
       return;
     }
     if (entryHref === '') entryHref = href;
     canGoBack = href !== entryHref;
+    isReportView = isSpxReportView(href);
+    if (!isReportView && isProfiler) {
+      padSpxControlPanel(w.document);
+      setSpxConfigHidden(w.document, configHidden);
+    }
+  }
+
+  function toggleConfig() {
+    configHidden = !configHidden;
+    const w = iframeWindow();
+    if (w) setSpxConfigHidden(w.document, configHidden);
   }
 
   function goBack() {
@@ -118,21 +164,34 @@
       </div>
       <div class="flex items-center gap-2 shrink-0">
         {#if isProfiler}
+          {#if !isReportView}
+            <button
+              onclick={toggleConfig}
+              title={configHidden ? m.profiler_config_show() : m.profiler_config_hide()}
+              class={headerBtnClass}
+            >
+              {configHidden ? m.profiler_config_show() : m.profiler_config_hide()}
+            </button>
+          {/if}
           <button
             onclick={clearProfilerReports}
             disabled={clearing}
             title={m.profiler_clear_title()}
-            class="text-xs rounded-sm border border-gray-200 dark:border-lerd-border px-2 py-1 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
+            class="{headerBtnClass} disabled:opacity-50"
           >
             {clearing ? m.profiler_clear_busy() : m.profiler_clear()}
           </button>
           <button
             onclick={toggleProfiler}
             disabled={busy}
-            class="text-xs rounded-sm border px-2 py-1 transition-colors disabled:opacity-50 {$profilerEnabled
-              ? 'border-gray-200 dark:border-lerd-border text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
-              : 'border-emerald-500/40 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300 hover:border-emerald-500'}"
+            aria-pressed={$profilerEnabled}
+            class="flex items-center gap-1.5 text-xs rounded-sm border px-2 py-1 transition-colors disabled:opacity-50 {$profilerEnabled
+              ? 'border-emerald-500/40 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300 hover:border-emerald-500'
+              : 'border-gray-200 dark:border-lerd-border text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'}"
           >
+            {#if $profilerEnabled}
+              <StatusDot color="emerald" size="xs" pulse />
+            {/if}
             {busy ? m.profiler_busy() : $profilerEnabled ? m.profiler_disarm() : m.profiler_arm()}
           </button>
         {/if}

--- a/internal/ui/web/src/components/DashboardOverlay.test.ts
+++ b/internal/ui/web/src/components/DashboardOverlay.test.ts
@@ -2,22 +2,58 @@ import { render, screen } from '@testing-library/svelte';
 import { describe, it, expect, beforeEach } from 'vitest';
 import DashboardOverlay from './DashboardOverlay.svelte';
 import { dashboardOpen } from '../stores/dashboard';
+import { profilerEnabled } from '../stores/profiler';
+
+function openProfiler() {
+  dashboardOpen.set({
+    name: 'profiler',
+    label: 'Profiler',
+    dashboard: '/_spx/?SPX_UI_URI=/'
+  });
+}
 
 describe('DashboardOverlay', () => {
   beforeEach(() => {
     dashboardOpen.set(null);
+    profilerEnabled.set(false);
   });
 
   it('disables Back until the embedded iframe has somewhere to go back to', () => {
-    dashboardOpen.set({
-      name: 'profiler',
-      label: 'Profiler',
-      dashboard: '/_spx/?SPX_UI_URI=/'
-    });
+    openProfiler();
     render(DashboardOverlay);
 
     // Freshly opened: the SPX iframe has no internal history yet, so Back is a
     // dead end. It must be disabled rather than silently tear down the overlay.
     expect(screen.getByTitle('Back')).toBeDisabled();
+  });
+
+  it('shows the profiler toggle as off: muted, not pressed, no live dot', () => {
+    profilerEnabled.set(false);
+    openProfiler();
+    const { container } = render(DashboardOverlay);
+
+    const btn = screen.getByRole('button', { name: /start profiling/i });
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+    expect(btn.className).not.toMatch(/emerald/);
+    expect(container.querySelector('.animate-pulse')).toBeNull();
+  });
+
+  it('shows the profiler toggle as on: emerald, pressed, live pulsing dot', () => {
+    profilerEnabled.set(true);
+    openProfiler();
+    const { container } = render(DashboardOverlay);
+
+    const btn = screen.getByRole('button', { name: /stop profiling/i });
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+    expect(btn.className).toMatch(/emerald/);
+    expect(container.querySelector('.animate-pulse')).not.toBeNull();
+  });
+
+  it('collapses the SPX Configuration form by default on the control panel page', () => {
+    openProfiler();
+    render(DashboardOverlay);
+
+    // The form starts hidden, so the header offers to show it.
+    expect(screen.getByRole('button', { name: /show configuration/i })).toBeTruthy();
   });
 });

--- a/internal/ui/web/src/lib/spxControls.test.ts
+++ b/internal/ui/web/src/lib/spxControls.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  isSpxReportView,
+  setSpxConfigHidden,
+  padSpxControlPanel,
+  fetchSpxReportCount
+} from './spxControls';
+
+describe('isSpxReportView', () => {
+  it('is true for the single-report analysis URL', () => {
+    expect(isSpxReportView('http://h/_spx/?SPX_UI_URI=/report.html&key=abc')).toBe(true);
+  });
+
+  it('is false for the control panel list URL', () => {
+    expect(isSpxReportView('http://h/_spx/?SPX_UI_URI=/')).toBe(false);
+  });
+});
+
+describe('setSpxConfigHidden', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('hides and restores the Configuration form', () => {
+    document.body.innerHTML = '<form id="config"><fieldset></fieldset></form>';
+    const form = document.getElementById('config')!;
+
+    expect(setSpxConfigHidden(document, true)).toBe(true);
+    expect(form.style.display).toBe('none');
+
+    setSpxConfigHidden(document, false);
+    expect(form.style.display).toBe('');
+  });
+
+  it('returns false when the Configuration form is absent', () => {
+    document.body.innerHTML = '<div>nothing here</div>';
+    expect(setSpxConfigHidden(document, true)).toBe(false);
+  });
+
+  it('hides the form in a separate realm, as the SPX iframe is', () => {
+    // The SPX page is an iframe: its elements belong to the iframe's own JS
+    // realm, so the helper must not rely on this document's HTMLElement.
+    document.body.innerHTML = '<iframe></iframe>';
+    const idoc = document.querySelector('iframe')!.contentDocument!;
+    idoc.body.innerHTML = '<form id="config"><fieldset></fieldset></form>';
+    const form = idoc.getElementById('config') as HTMLElement;
+
+    expect(setSpxConfigHidden(idoc, true)).toBe(true);
+    expect(form.style.display).toBe('none');
+  });
+});
+
+describe('padSpxControlPanel', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  it('adds a padding style tag and is idempotent', () => {
+    padSpxControlPanel(document);
+    padSpxControlPanel(document);
+    expect(document.querySelectorAll('#lerd-spx-pad').length).toBe(1);
+    expect(document.getElementById('lerd-spx-pad')!.textContent).toContain('padding');
+  });
+});
+
+describe('fetchSpxReportCount', () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('returns the number of reports from the metadata endpoint', async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ results: [{ key: 'a' }, { key: 'b' }] }), { status: 200 })
+    ) as unknown as typeof fetch;
+    expect(await fetchSpxReportCount()).toBe(2);
+  });
+
+  it('returns null when the request fails', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('nope', { status: 500 })) as unknown as typeof fetch;
+    expect(await fetchSpxReportCount()).toBeNull();
+  });
+
+  it('returns null when the payload has no results array', async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(JSON.stringify({}), { status: 200 })
+    ) as unknown as typeof fetch;
+    expect(await fetchSpxReportCount()).toBeNull();
+  });
+});

--- a/internal/ui/web/src/lib/spxControls.ts
+++ b/internal/ui/web/src/lib/spxControls.ts
@@ -1,0 +1,56 @@
+// Helpers for tailoring the embedded SPX profiler UI. SPX's web UI is
+// upstream php-spx, reverse-proxied same-origin under /_spx/; lerd reaches
+// into that iframe to collapse the control panel's Configuration form, pad
+// the control panel page, and surface freshly captured reports without a
+// manual refresh. The selectors and the metadata URL below are the only
+// points of coupling to SPX's internals.
+
+// SPX_METADATA_URL is the endpoint the SPX control panel page itself uses to
+// list captured reports. Polling it lets lerd notice new captures.
+const SPX_METADATA_URL = '/_spx/?SPX_UI_URI=/data/reports/metadata';
+
+// CONFIG_FORM is the Configuration fieldset wrapper on the control panel page.
+const CONFIG_FORM = '#config';
+const PAD_STYLE_ID = 'lerd-spx-pad';
+
+// True for the SPX single-report analysis screen, false for the control panel.
+export function isSpxReportView(href: string): boolean {
+  return href.includes('SPX_UI_URI=/report.html');
+}
+
+// setSpxConfigHidden shows or hides the Configuration form on the SPX control
+// panel page, which otherwise pushes the report list far down the page.
+// Returns whether the form was found.
+export function setSpxConfigHidden(doc: Document, hidden: boolean): boolean {
+  const form = doc.querySelector(CONFIG_FORM);
+  // The SPX page runs in the iframe's own realm, so test against that realm's
+  // HTMLElement; a plain `instanceof HTMLElement` would always be false here.
+  const HtmlEl = doc.defaultView?.HTMLElement ?? HTMLElement;
+  if (!(form instanceof HtmlEl)) return false;
+  form.style.display = hidden ? 'none' : '';
+  return true;
+}
+
+// padSpxControlPanel insets the SPX control panel page, whose content
+// otherwise sits flush against the iframe edges. Idempotent.
+export function padSpxControlPanel(doc: Document): void {
+  if (doc.getElementById(PAD_STYLE_ID)) return;
+  const style = doc.createElement('style');
+  style.id = PAD_STYLE_ID;
+  style.textContent = 'body{padding:20px;box-sizing:border-box}';
+  doc.head.appendChild(style);
+}
+
+// fetchSpxReportCount returns how many SPX reports currently exist, read from
+// the same metadata endpoint the control panel page uses. Returns null on any
+// failure so callers can simply skip that poll.
+export async function fetchSpxReportCount(): Promise<number | null> {
+  try {
+    const res = await fetch(SPX_METADATA_URL, { credentials: 'same-origin' });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { results?: unknown };
+    return Array.isArray(data.results) ? data.results.length : null;
+  } catch {
+    return null;
+  }
+}

--- a/internal/ui/web/src/tabs/SitesTab.svelte
+++ b/internal/ui/web/src/tabs/SitesTab.svelte
@@ -2,6 +2,7 @@
   import ListPanel from '$components/ListPanel.svelte';
   import ActionButton from '$components/ActionButton.svelte';
   import DumpBridgeToggle from '$components/DumpBridgeToggle.svelte';
+  import ProfilerToggle from '$components/ProfilerToggle.svelte';
   import EmptyState from '$components/EmptyState.svelte';
   import Icon from '$components/Icon.svelte';
   import StatusDot from '$components/StatusDot.svelte';
@@ -38,6 +39,7 @@
 {#snippet actions()}
   {#if $accessMode.loopback}
     <DumpBridgeToggle />
+    <ProfilerToggle />
     <ActionButton title={m.sites_linkNew()} tone="accent" onclick={openLinkModal}>
       <Icon name="plus" class="w-3.5 h-3.5" />
     </ActionButton>


### PR DESCRIPTION
The lerd php shim runs PHP inside a container through podman exec but only forwarded HOME, COMPOSER_HOME and PATH, so an SPX_ENABLED set on the host never reached SPX inside the container. RunPHPCaptureEnv now forwards every SPX_* variable through, and when SPX is enabled without a report type it defaults SPX_REPORT to full, so SPX_ENABLED=1 composer update and other shim'd runs are profiled into the Profiler view instead of silently doing nothing.

On the UI side, the Sites column gains the profiler toggle next to the dump bridge one, and the arm button in the Profiler view now reflects state rather than action: emerald with a live pulsing dot while profiling is on, muted grey while off. Previously it was a green call-to-action that read as on when profiling was actually off.

The embedded SPX UI gets some polish: the control panel page is padded so its content is not flush against the iframe edges, its Configuration form is collapsible and starts collapsed so the report list has room, and the report list reloads itself when a new capture lands so results show up without a manual refresh.