### PR TITLE
fix: MySQL readiness probe, dump bridge on legacy PHP, and PHP 7.2 image build

### DIFF
--- a/internal/podman/dumpbridge/dump-bridge.php
+++ b/internal/podman/dumpbridge/dump-bridge.php
@@ -67,7 +67,7 @@ namespace Lerd\DumpBridge {
         // Allow both `unix:///path/to/sock` and `tcp://host:port`. The
         // installer defaults to the unix scheme so dumps stay confined to
         // the user's home directory.
-        if (!str_contains($target, '://')) {
+        if (strpos($target, '://') === false) {
             $target = 'tcp://'.$target;
         }
         $sock = @\stream_socket_client($target, $errno, $errstr, 0.05, \STREAM_CLIENT_CONNECT);
@@ -136,15 +136,17 @@ namespace Lerd\DumpBridge {
     function source_frame(): array
     {
         $bt = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 12);
+        $self = 'dump-bridge.php';
+        $selfLen = strlen($self);
         foreach ($bt as $f) {
             if (!isset($f['file'])) {
                 continue;
             }
             $file = $f['file'];
-            if (str_contains($file, 'symfony/var-dumper')) {
+            if (strpos($file, 'symfony/var-dumper') !== false) {
                 continue;
             }
-            if (str_ends_with($file, 'dump-bridge.php')) {
+            if (substr($file, -$selfLen) === $self) {
                 continue;
             }
             return ['file' => $file, 'line' => $f['line'] ?? 0];
@@ -214,7 +216,10 @@ namespace {
     // through Symfony's VarDumper when it's available so existing display
     // pipelines (Whoops, Ignition) keep working in the response.
     if (!function_exists('dump')) {
-        function dump(mixed ...$vars): mixed
+        // No `mixed`/`never` type hints, `match`, or `array_key_first`: this
+        // file is an auto_prepend_file for every PHP lerd builds, down to the
+        // 7.2 legacy tier, and must parse and run on all of them.
+        function dump(...$vars)
         {
             $passthrough = \Lerd\DumpBridge\passthrough_enabled();
             foreach ($vars as $label => $var) {
@@ -223,15 +228,17 @@ namespace {
                     \Symfony\Component\VarDumper\VarDumper::dump($var);
                 }
             }
-            return match (true) {
-                count($vars) === 0 => null,
-                count($vars) === 1 => $vars[array_key_first($vars)],
-                default            => $vars,
-            };
+            if (count($vars) === 0) {
+                return null;
+            }
+            if (count($vars) === 1) {
+                return reset($vars);
+            }
+            return $vars;
         }
     }
     if (!function_exists('dd')) {
-        function dd(mixed ...$vars): never
+        function dd(...$vars)
         {
             dump(...$vars);
             exit(1);

--- a/internal/podman/dumps_test.go
+++ b/internal/podman/dumps_test.go
@@ -151,6 +151,35 @@ func TestFPMQuadletAlwaysMountsBridge(t *testing.T) {
 	}
 }
 
+func TestDumpBridgeIsLegacyPHPCompatible(t *testing.T) {
+	// dump-bridge.php is an auto_prepend_file loaded by every PHP version lerd
+	// builds, down to the 7.2 legacy tier. A single newer-than-7.2 token makes
+	// it unparseable and takes down every CLI command and web request there.
+	src, err := DumpBridgePHP()
+	if err != nil {
+		t.Fatalf("DumpBridgePHP: %v", err)
+	}
+	forbidden := map[string]string{
+		"match (":          "match expression (PHP 8.0+)",
+		"match(":           "match expression (PHP 8.0+)",
+		"str_contains(":    "str_contains() (PHP 8.0+)",
+		"str_ends_with(":   "str_ends_with() (PHP 8.0+)",
+		"str_starts_with(": "str_starts_with() (PHP 8.0+)",
+		"array_key_first(": "array_key_first() (PHP 7.3+)",
+		"array_key_last(":  "array_key_last() (PHP 7.3+)",
+		"mixed ...":        "mixed type hint (PHP 8.0+)",
+		": mixed":          "mixed return type (PHP 8.0+)",
+		": never":          "never return type (PHP 8.1+)",
+		"?->":              "nullsafe operator (PHP 8.0+)",
+		"??=":              "null-coalescing assignment (PHP 7.4+)",
+	}
+	for tok, desc := range forbidden {
+		if strings.Contains(src, tok) {
+			t.Errorf("dump-bridge.php contains %q — %s; it must parse on PHP 7.2", tok, desc)
+		}
+	}
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -264,6 +264,11 @@ func RestartUnit(name string) error {
 	return nil
 }
 
+// mysqlReadyArgs probes lerd-mysql over IPv4 loopback TCP, never the Unix
+// socket (its path differs across mysql/mariadb images). Container-internal
+// 127.0.0.1 holds on macOS and IPv6-only host networks too.
+var mysqlReadyArgs = []string{"mysqladmin", "ping", "-h127.0.0.1", "-P3306", "-uroot", "-plerd", "--silent"}
+
 // WaitReady polls until the named service is ready to accept connections, or
 // timeout is reached. Readiness is tested by running a lightweight probe inside
 // the container: mysqladmin ping for mysql, pg_isready for postgres. For other
@@ -275,10 +280,9 @@ func WaitReady(service string, timeout time.Duration) error {
 	var probe func() bool
 	switch service {
 	case "mysql":
+		args := append([]string{"exec", "lerd-mysql"}, mysqlReadyArgs...)
 		probe = func() bool {
-			cmd := exec.Command(PodmanBin(), "exec", "lerd-mysql",
-				"mysqladmin", "ping", "-uroot", "-plerd", "--silent")
-			return cmd.Run() == nil
+			return exec.Command(PodmanBin(), args...).Run() == nil
 		}
 	case "postgres":
 		probe = func() bool {

--- a/internal/podman/quadlet_embed_test.go
+++ b/internal/podman/quadlet_embed_test.go
@@ -398,29 +398,57 @@ func TestNginxQuadletMountsCustomD(t *testing.T) {
 }
 
 func TestPHPFPMContainerfileBundlesFullICUData(t *testing.T) {
-	// Alpine splits ICU's locale database: the base php:*-fpm-alpine image
-	// only carries icu-data-en, so ext-intl (NumberFormatter, IntlDateFormatter,
-	// Laravel Number::currency) silently falls back to the root/en locale for
-	// every non-English locale. icu-data-full carries the full CLDR set. See #332.
+	// icu-data-full carries ext-intl's full CLDR set (#332) but only exists on
+	// Alpine 3.16+. The install must tolerate its absence (|| true) so
+	// legacy-PHP builds on older Alpine bases don't hard-fail.
 	content, err := GetQuadletTemplate("lerd-php-fpm.Containerfile")
 	if err != nil {
 		t.Fatalf("GetQuadletTemplate: %v", err)
 	}
-	if !strings.Contains(content, "icu-data-full") {
-		t.Errorf("lerd-php-fpm.Containerfile must apk add icu-data-full so non-English locales work in ext-intl:\n%s", content)
+	installed := false
+	for _, line := range strings.Split(content, "\n") {
+		if !strings.Contains(line, "icu-data-full") || !strings.HasPrefix(strings.TrimSpace(line), "RUN ") {
+			continue
+		}
+		installed = true
+		if !strings.Contains(line, "|| true") {
+			t.Errorf("icu-data-full install must tolerate a missing package (|| true):\n%s", line)
+		}
+	}
+	if !installed {
+		t.Errorf("lerd-php-fpm.Containerfile must apk add icu-data-full so non-English locales work in ext-intl")
 	}
 }
 
 func TestPHPFPMContainerfilePinsLegacyXdebug(t *testing.T) {
 	// xdebug 3.2+ requires PHP 8.0+ and 3.4+ requires PHP 8.1+, so the frozen
-	// legacy 7.4 / 8.0 images must select an older xdebug release at build time.
+	// legacy 7.2 / 7.4 / 8.0 images must select an older xdebug at build time.
 	content, err := GetQuadletTemplate("lerd-php-fpm.Containerfile")
 	if err != nil {
 		t.Fatalf("GetQuadletTemplate: %v", err)
 	}
-	for _, want := range []string{`7.4) XDEBUG_PKG="xdebug-3.1.6"`, `8.0) XDEBUG_PKG="xdebug-3.3.2"`} {
+	for _, want := range []string{
+		`7.2) XDEBUG_PKG="xdebug-3.1.6"`,
+		`7.4) XDEBUG_PKG="xdebug-3.1.6"`,
+		`8.0) XDEBUG_PKG="xdebug-3.3.2"`,
+	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("lerd-php-fpm.Containerfile must pin legacy xdebug (%q):\n%s", want, content)
+		}
+	}
+}
+
+func TestPHPFPMContainerfileBuildsLegacyPHP(t *testing.T) {
+	// PHP 7.2's Alpine 3.12 base predates gd's 7.4 configure flags and modern
+	// phpredis, so the Containerfile branches on PHP_VERSION_ID; without the
+	// older forms a 7.2 build hard-fails at gd configure.
+	content, err := GetQuadletTemplate("lerd-php-fpm.Containerfile")
+	if err != nil {
+		t.Fatalf("GetQuadletTemplate: %v", err)
+	}
+	for _, want := range []string{"PHP_VERSION_ID", "--with-freetype-dir", "REDIS_PKG=redis-5.3.7"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("lerd-php-fpm.Containerfile missing legacy-PHP build branch (%q)", want)
 		}
 	}
 }

--- a/internal/podman/quadlet_waitready_test.go
+++ b/internal/podman/quadlet_waitready_test.go
@@ -1,0 +1,23 @@
+package podman
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMySQLReadinessProbeForcesTCP(t *testing.T) {
+	// The probe runs inside the container. With no host, mysqladmin falls back
+	// to the Unix socket, whose path differs between the mysql and mariadb
+	// images, so a socket probe times out even when the server is up.
+	joined := strings.Join(mysqlReadyArgs, " ")
+
+	if mysqlReadyArgs[0] != "mysqladmin" || mysqlReadyArgs[1] != "ping" {
+		t.Fatalf("mysql readiness probe should be a mysqladmin ping, got: %s", joined)
+	}
+	if !strings.Contains(joined, "-h127.0.0.1") {
+		t.Errorf("mysql readiness probe must force TCP via -h127.0.0.1, got: %s", joined)
+	}
+	if strings.Contains(joined, "localhost") {
+		t.Errorf("mysql readiness probe must not use localhost — mysqladmin resolves it to the Unix socket, got: %s", joined)
+	}
+}

--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -18,7 +18,6 @@ RUN apk update && apk add --no-cache \
         freetype-dev \
         libwebp-dev \
         icu-dev \
-        icu-data-full \
         oniguruma-dev \
         libxml2-dev \
         postgresql-dev \
@@ -29,7 +28,12 @@ RUN apk update && apk add --no-cache \
         sqlite-dev \
         libxslt-dev \
         zlib-dev \
-    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
+    && PHP_ID="$(php -r 'echo PHP_VERSION_ID;')" \
+    && if [ "$PHP_ID" -lt 70400 ]; then \
+           docker-php-ext-configure gd --with-freetype-dir=/usr --with-jpeg-dir=/usr --with-png-dir=/usr --with-webp-dir=/usr; \
+       else \
+           docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp; \
+       fi \
     && docker-php-ext-install -j$(nproc) \
         curl \
         pdo_mysql \
@@ -56,7 +60,8 @@ RUN apk update && apk add --no-cache \
         sysvshm \
         xsl \
     && (docker-php-ext-enable opcache || true) \
-    && { (yes '' | pecl install redis && docker-php-ext-enable redis) \
+    && if [ "$PHP_ID" -lt 70400 ]; then REDIS_PKG=redis-5.3.7; else REDIS_PKG=redis; fi \
+    && { (yes '' | pecl install "$REDIS_PKG" && docker-php-ext-enable redis) \
          || (git clone --depth 1 https://github.com/phpredis/phpredis /tmp/phpredis \
              && cd /tmp/phpredis && phpize && ./configure && make -j$(nproc) && make install \
              && docker-php-ext-enable redis \
@@ -80,6 +85,7 @@ RUN apk update && apk add --no-cache \
 # Xdebug compiled in the builder too. Legacy PHP needs older xdebug majors.
 RUN PHPVER="$(php -r 'echo PHP_MAJOR_VERSION,".",PHP_MINOR_VERSION;')" \
     && case "$PHPVER" in \
+        7.2) XDEBUG_PKG="xdebug-3.1.6" ;; \
         7.4) XDEBUG_PKG="xdebug-3.1.6" ;; \
         8.0) XDEBUG_PKG="xdebug-3.3.2" ;; \
         *)   XDEBUG_PKG="xdebug" ;; \
@@ -95,11 +101,11 @@ RUN PHPVER="$(php -r 'echo PHP_MAJOR_VERSION,".",PHP_MINOR_VERSION;')" \
 FROM docker.io/library/php:{{.Version}}-fpm-alpine
 
 # Runtime libraries only (no -dev headers, no toolchain). PHP's
-# compiled extensions dlopen these. icu-data-full is bulky but
-# i18n needs it.
+# compiled extensions dlopen these.
 RUN apk update && apk add --no-cache \
         ghostscript \
         imagemagick \
+        libgomp \
         ffmpeg \
         git \
         mysql-client \
@@ -111,7 +117,6 @@ RUN apk update && apk add --no-cache \
         freetype \
         libwebp \
         icu-libs \
-        icu-data-full \
         oniguruma \
         libxml2 \
         libpq \
@@ -121,6 +126,11 @@ RUN apk update && apk add --no-cache \
         sqlite-libs \
         libxslt \
     && rm -rf /var/cache/apk/*
+
+# icu-data-full carries the full CLDR locale set for ext-intl (#332). Alpine
+# 3.16+ ships it as a separate package; older bases fold the full data into
+# icu-libs, so the package is absent there and the install is skipped.
+RUN apk add --no-cache icu-data-full 2>/dev/null || true
 
 # Runtime system libs for user-configured custom extensions (e.g.
 # imap needs c-client.so). Empty when no custom exts have apk deps.
@@ -143,10 +153,11 @@ RUN mkdir -p /etc/my.cnf.d && printf '[client]\nssl=0\n' > /etc/my.cnf.d/lerd-no
 # Composer from the official image.
 COPY --from=composer-bin /usr/bin/composer /usr/local/bin/composer
 
-# Interactive shell for lerd shell. zsh/fzf/bat exist on every alpine;
-# starship/eza/zoxide need alpine 3.18+, so legacy php 7.4/8.0 (alpine
-# 3.16) get them via || true and the zshrc inits starship conditionally.
-RUN apk add --no-cache zsh fzf bat \
+# Interactive shell for lerd shell. zsh/fzf exist on every alpine base;
+# bat lands on 3.16+ and starship/eza/zoxide on 3.18+, so the optional
+# tools install tolerantly and zshrc inits starship only when present.
+RUN apk add --no-cache zsh fzf \
+    && { apk add --no-cache bat 2>/dev/null || true; } \
     && { apk add --no-cache starship eza zoxide 2>/dev/null || true; } \
     && mkdir -p /etc/zsh /root/.zsh_state \
     && printf 'export EDITOR=vi\nexport PAGER=less\nexport HISTFILE=/root/.zsh_state/history\nexport HISTSIZE=10000\nexport SAVEHIST=10000\nsetopt INC_APPEND_HISTORY SHARE_HISTORY\nautoload -Uz compinit && compinit -u\nif command -v starship >/dev/null 2>&1; then\n  eval "$(starship init zsh)"\nfi\n' \

--- a/internal/serviceops/migrate.go
+++ b/internal/serviceops/migrate.go
@@ -347,7 +347,7 @@ func migrateMysql(name, targetImage string, emit func(PhaseEvent)) error {
 	rootEnv := []string{"MYSQL_PWD=lerd"}
 
 	emit(PhaseEvent{Phase: "dumping_data", Message: "mysqldump → " + dump})
-	dumpCmd := "mysqldump -uroot --all-databases --single-transaction --routines --triggers --events --quick"
+	dumpCmd := "mysqldump -h 127.0.0.1 -uroot --all-databases --single-transaction --routines --triggers --events --quick"
 	if err := dumpToHost(unit, dumpCmd, rootEnv, dump, dumpRestoreTimeout); err != nil {
 		return fmt.Errorf("mysqldump: %w", err)
 	}
@@ -375,13 +375,13 @@ func migrateMysql(name, targetImage string, emit func(PhaseEvent)) error {
 	}
 
 	emit(PhaseEvent{Phase: "waiting_ready", Unit: unit})
-	probe := "mysql -uroot -e 'SELECT 1' >/dev/null 2>&1 || mariadb -uroot -e 'SELECT 1' >/dev/null 2>&1"
+	probe := "mysql -h 127.0.0.1 -uroot -e 'SELECT 1' >/dev/null 2>&1 || mariadb -h 127.0.0.1 -uroot -e 'SELECT 1' >/dev/null 2>&1"
 	if err := waitContainerReady(unit, probe, rootEnv, 90*time.Second); err != nil {
 		return fmt.Errorf("%w. Dump preserved at %s; old data dir at %s", err, dump, backup)
 	}
 
 	emit(PhaseEvent{Phase: "restoring_data", Message: dump})
-	restoreCmd := "mysql -uroot 2>&1 || mariadb -uroot 2>&1"
+	restoreCmd := "mysql -h 127.0.0.1 -uroot 2>&1 || mariadb -h 127.0.0.1 -uroot 2>&1"
 	if err := restoreFromHost(unit, restoreCmd, rootEnv, dump, dumpRestoreTimeout); err != nil {
 		return fmt.Errorf("restore: %w. Dump preserved at %s; old data dir at %s", err, dump, backup)
 	}


### PR DESCRIPTION
Forward-port of the v1.21.2 hotfix to main. v1.21.2 was cut from the v1.21.1 tag and released separately; this brings the same three fixes onto main so the 1.22 line does not regress them.

The MySQL readiness probe ran mysqladmin with no host and fell back to the Unix socket, so on images whose socket is not at /var/run/mysqld/mysqld.sock it failed for the full 30 second timeout and warned could not start mysql before every PHP command even though the server was healthy. It now forces IPv4 loopback TCP, which is independent of the image's socket path and stays correct inside the container on macOS and IPv6-only host networks. The mysql service-migration probe, dump, and restore commands force TCP the same way.

The dump() and dd() bridge that lerd installs as an auto_prepend_file used match, mixed and never type declarations, str_contains, str_ends_with, and array_key_first, none of which parse on PHP 7.4 and several not on 8.0, so those versions aborted with a fatal parse error before running any code and broke every CLI command and web request. The bridge is rewritten in syntax valid from PHP 7.2 through 8.5, with identical behaviour on current PHP.

Building a PHP 7.2 image failed because its Alpine 3.12 base predates the icu-data-full package, gd's post-7.4 configure flags, current phpredis and xdebug, the bat package, and a transitive libgomp that ImageMagick needs. icu-data-full now installs tolerantly, gd's configure branches on PHP_VERSION_ID, xdebug and phpredis are pinned to the last releases supporting the older PHP line, bat installs tolerantly, and libgomp is added explicitly.

The cherry-pick conflicted only where SPX's zlib-dev line meets the gd configure change; resolved by keeping both.
