### PR TITLE
fix(install): rebuild PHP-FPM images when the Containerfile changes

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -712,6 +712,22 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	// after a clean install from config backup).
 	migrateServiceUnits()
 
+	// Rebuild FPM images when the embedded Containerfile changed since the
+	// last build — ensureFPMQuadlet above no-ops on existing images, so a
+	// `brew upgrade && lerd install` would otherwise ship against stale ones.
+	if podman.NeedsFPMRebuild() {
+		fmt.Println("\n==> PHP-FPM Containerfile changed — rebuilding images")
+		if self, err := os.Executable(); err == nil {
+			rebuildCmd := exec.Command(self, "php:rebuild")
+			rebuildCmd.Stdout = os.Stdout
+			rebuildCmd.Stderr = os.Stderr
+			rebuildCmd.Stdin = os.Stdin
+			if err := rebuildCmd.Run(); err != nil {
+				fmt.Printf("  WARN: php:rebuild failed: %v\n", err)
+			}
+		}
+	}
+
 	// Start service containers and workers only when autostart is on.
 	// When the user has explicitly disabled autostart we leave them
 	// stopped — `lerd update` running install via re-exec must not flip

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -712,27 +712,32 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	// after a clean install from config backup).
 	migrateServiceUnits()
 
-	// Rebuild FPM images when the embedded Containerfile changed since the
-	// last build — ensureFPMQuadlet above no-ops on existing images, so a
-	// `brew upgrade && lerd install` would otherwise ship against stale ones.
-	if podman.NeedsFPMRebuild() {
-		fmt.Println("\n==> PHP-FPM Containerfile changed — rebuilding images")
-		if self, err := os.Executable(); err == nil {
-			rebuildCmd := exec.Command(self, "php:rebuild")
-			rebuildCmd.Stdout = os.Stdout
-			rebuildCmd.Stderr = os.Stderr
-			rebuildCmd.Stdin = os.Stdin
-			if err := rebuildCmd.Run(); err != nil {
-				fmt.Printf("  WARN: php:rebuild failed: %v\n", err)
-			}
-		}
-	}
-
 	// Start service containers and workers only when autostart is on.
 	// When the user has explicitly disabled autostart we leave them
 	// stopped — `lerd update` running install via re-exec must not flip
 	// disabled units back on.
 	if autostartOn {
+		// Rebuild FPM images when the embedded Containerfile changed since
+		// the last build — BuildFPMImage no-ops when the image already
+		// exists, so `brew upgrade && lerd install` would otherwise ship
+		// new binary against stale images. Gated by autostartOn because
+		// php:rebuild restarts FPM and worker units unconditionally.
+		if podman.NeedsFPMRebuild() {
+			fmt.Println("\n==> PHP-FPM Containerfile changed — rebuilding images")
+			self, err := os.Executable()
+			if err != nil {
+				fmt.Printf("  WARN: locating lerd binary for php:rebuild: %v\n", err)
+			} else {
+				rebuildCmd := exec.Command(self, "php:rebuild")
+				rebuildCmd.Stdout = os.Stdout
+				rebuildCmd.Stderr = os.Stderr
+				rebuildCmd.Stdin = os.Stdin
+				if err := rebuildCmd.Run(); err != nil {
+					fmt.Printf("  WARN: php:rebuild failed: %v\n", err)
+				}
+			}
+		}
+
 		// Start installed PHP FPM containers whose images are now available.
 		if fpmVersions, _ := phpDet.ListInstalled(); len(fpmVersions) > 0 {
 			var fpmJobs []BuildJob

--- a/internal/cli/park.go
+++ b/internal/cli/park.go
@@ -299,7 +299,6 @@ func ensureFPMQuadletTo(phpVersion string, w io.Writer) error {
 	if err := podman.BuildFPMImageTo(phpVersion, false, w); err != nil {
 		return fmt.Errorf("building FPM image for PHP %s: %w", phpVersion, err)
 	}
-	_ = podman.StoreFPMHash()
 
 	_ = podman.EnsureXdebugIni(phpVersion)
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
-	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/store"
 	"github.com/geodro/lerd/internal/systemd"
@@ -178,30 +177,8 @@ func runUpdate(currentVersion string, beta bool) error {
 		}
 	}
 
-	// Only rebuild PHP-FPM images if the embedded Containerfile changed.
-	if podman.NeedsFPMRebuild() {
-		fmt.Println("\n==> PHP-FPM Containerfile changed — rebuilding images")
-		rebuildCmd := exec.Command(self, "php:rebuild")
-		rebuildCmd.Stdout = os.Stdout
-		rebuildCmd.Stderr = os.Stderr
-		rebuildCmd.Stdin = os.Stdin
-		if err := rebuildCmd.Run(); err != nil {
-			return err
-		}
-	} else {
-		fmt.Println("\n==> PHP-FPM images are up to date, skipping rebuild")
-		// Ensure FPM containers are running after the install step.
-		versions, _ := phpPkg.ListInstalled()
-		for _, v := range versions {
-			unit := "lerd-php" + strings.ReplaceAll(v, ".", "") + "-fpm"
-			fmt.Printf("  --> %s ... ", unit)
-			if err := podman.StartUnit(unit); err != nil {
-				fmt.Printf("WARN (%v)\n", err)
-			} else {
-				fmt.Println("OK")
-			}
-		}
-	}
+	// FPM rebuild + container starts now happen inside `lerd install`
+	// (gated on autostart), so we don't repeat them here.
 
 	restartLerdUserServices()
 	return nil

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -328,6 +328,13 @@ build:
 		return fmt.Errorf("building PHP %s image: %w", version, err)
 	}
 
+	// Stamp the hash only after a real build — callers that no-op when the
+	// image already exists must not advance the hash, otherwise a later
+	// install would skip rebuilds for a template that never hit disk.
+	if err := StoreFPMHash(); err != nil {
+		fmt.Fprintf(w, "  WARN: storing PHP-FPM image hash: %v\n", err)
+	}
+
 	fmt.Fprintf(w, "  PHP %s image built successfully.\n", version)
 	return nil
 }

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -159,12 +159,18 @@ func NeedsFPMRebuild() bool {
 	return strings.TrimSpace(string(stored)) != current
 }
 
+// fpmHashMu serializes StoreFPMHash so the per-version buildFPMImage calls
+// fired in parallel by php:rebuild can't truncate-and-write each other.
+var fpmHashMu sync.Mutex
+
 // StoreFPMHash writes the current Containerfile hash to disk.
 func StoreFPMHash() error {
 	hash, err := ContainerfileHash()
 	if err != nil {
 		return err
 	}
+	fpmHashMu.Lock()
+	defer fpmHashMu.Unlock()
 	return os.WriteFile(config.PHPImageHashFile(), []byte(hash), 0644)
 }
 


### PR DESCRIPTION
## Summary

`lerd install` (and the install pass `lerd update` re-execs) called `ensureFPMQuadlet`, which no-ops `BuildFPMImage` when the image already exists yet unconditionally stamped the current Containerfile hash via `StoreFPMHash`. After a `brew upgrade` introduces template changes (e.g. SPX in v1.22.0), the on-disk hash got advanced to the new template even though the image was still built from the old one. `NeedsFPMRebuild` then reported "up to date" and the rebuild was silently skipped, leaving the user with a binary that expects SPX against an FPM image that does not have it.

## Changes

- Move `StoreFPMHash` inside `buildFPMImage` so the hash is only written after a real build completes — no more advancing the hash for the early-return "image already exists" path.
- Drop the now-redundant `StoreFPMHash` from `ensureFPMQuadletTo` in `park.go`.
- Have `lerd install` itself check `NeedsFPMRebuild` and re-exec `php:rebuild`, so `brew upgrade && lerd install` is self-healing without needing `lerd update` to run the same check afterwards.
- Gate the new rebuild block on `autostartOn` so users who ran `lerd autostart disable` don't get their FPM/queue/reverb/schedule units restarted behind their back (`php:rebuild` restarts unconditionally).
- Print a WARN if `os.Executable()` fails instead of silently skipping the rebuild.
- Drop the duplicate `NeedsFPMRebuild` + `StartUnit` block from `runUpdate` — `lerd install` owns this responsibility now.
- Serialize `StoreFPMHash` with a `sync.Mutex` so the parallel per-version builds fired by `php:rebuild` can't truncate-and-write each other's hash file.

## Recovery for currently-affected users

The hash file is already poisoned on machines that upgraded to v1.22.0 — the bug overwrote the stored hash with the new template's value even though the image was never rebuilt. A one-time `lerd php:rebuild` restores SPX (and any other v1.22.0 template additions). From then on installs detect template drift correctly.