### PR TITLE
fix(tui): pass bare version to update check so the banner doesn't false-fire

### DIFF
--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -21,7 +21,7 @@ func NewTuiCmd() *cobra.Command {
 			if !term.IsTerminal(int(os.Stdout.Fd())) {
 				return fmt.Errorf("lerd tui requires an interactive terminal")
 			}
-			return tui.Run(version.String())
+			return tui.Run(version.Version)
 		},
 	}
 }


### PR DESCRIPTION
## Summary

`tui.Run` received `version.String()` (e.g. `"1.22.0 (commit ABCDEF, built 2026-05-25T15:43:56Z)"`) and threaded it through to `CachedUpdateCheck`. `splitPrerelease` in `internal/update/check.go` finds the first `-` in the build date and treats everything after it as a pre-release suffix, so the comparison degrades to "latest (no pre) > current (has pre)" and the banner fires even for users on the latest stable.

The TUI header was also rendering the whole `version.String()` next to "lerd", which is much longer than the rest of the bar wants.

Pass `version.Version` (the bare tag) instead, matching the other callers — `ui/server.go:1804`, `mcp/server.go:2415`, and `cli/whatsnew.go:27` all already use it.