### PR TITLE
fix(macos): tray Quit actually exits and stops services

### DIFF
--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -133,7 +133,19 @@ func xmlEscStr(s string) string {
 	return buf.String()
 }
 
-func buildPlist(lbl string, args []string, runAtLoad, keepAlive bool, stdoutPath, stderrPath string) string {
+// keepAlivePolicy mirrors the subset of systemd Restart= values we care about.
+// launchd's bare `KeepAlive=true` respawns on any exit, including a clean one,
+// which doesn't match systemd `Restart=on-failure` semantics — that mismatch
+// caused the tray Quit button to be reincarnated by launchd immediately.
+type keepAlivePolicy int
+
+const (
+	keepAliveNever keepAlivePolicy = iota
+	keepAliveAlways
+	keepAliveOnFailure
+)
+
+func buildPlist(lbl string, args []string, runAtLoad bool, keepAlive keepAlivePolicy, stdoutPath, stderrPath string) string {
 	var sb strings.Builder
 	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -152,8 +164,11 @@ func buildPlist(lbl string, args []string, runAtLoad, keepAlive bool, stdoutPath
 	if runAtLoad {
 		sb.WriteString("\t<key>RunAtLoad</key>\n\t<true/>\n")
 	}
-	if keepAlive {
+	switch keepAlive {
+	case keepAliveAlways:
 		sb.WriteString("\t<key>KeepAlive</key>\n\t<true/>\n")
+	case keepAliveOnFailure:
+		sb.WriteString("\t<key>KeepAlive</key>\n\t<dict>\n\t\t<key>SuccessfulExit</key>\n\t\t<false/>\n\t</dict>\n")
 	}
 	if stdoutPath != "" {
 		sb.WriteString("\t<key>StandardOutPath</key>\n\t<string>")
@@ -360,7 +375,7 @@ func containerToPodmanArgs(c map[string][]string) ([]string, error) {
 // --- Service unit files ---
 
 // parseServiceUnit parses a systemd-format service unit and returns the argv
-// and keepAlive flag for the launchd plist.
+// and keepAlive policy for the launchd plist.
 //
 // Binary resolution rules for args[0]:
 //   - Absolute path that exists → use as-is.
@@ -368,15 +383,15 @@ func containerToPodmanArgs(c map[string][]string) ([]string, error) {
 //     (handles Homebrew → ~/.local/bin migration).
 //   - Bare command name (no '/') → resolve via PATH; if not found, substitute
 //     the running lerd binary (should not normally happen).
-func parseServiceUnit(name, content string) (args []string, keepAlive bool, err error) {
+func parseServiceUnit(name, content string) (args []string, keepAlive keepAlivePolicy, err error) {
 	svc := parseSection(content, "Service")
 	execStarts := svc["ExecStart"]
 	if len(execStarts) == 0 {
-		return nil, false, fmt.Errorf("no ExecStart= found in service unit %s", name)
+		return nil, keepAliveNever, fmt.Errorf("no ExecStart= found in service unit %s", name)
 	}
 	args = strings.Fields(expandSpecifiers(execStarts[0]))
 	if len(args) == 0 {
-		return nil, false, fmt.Errorf("empty ExecStart in service unit %s", name)
+		return nil, keepAliveNever, fmt.Errorf("empty ExecStart in service unit %s", name)
 	}
 
 	// Resolve args[0] to an absolute path suitable for a launchd plist.
@@ -404,17 +419,26 @@ func parseServiceUnit(name, content string) (args []string, keepAlive bool, err 
 			}
 		}
 		if resolved == "" {
-			return nil, false, fmt.Errorf("command %q in ExecStart of %s not found; use an absolute path", args[0], name)
+			return nil, keepAliveNever, fmt.Errorf("command %q in ExecStart of %s not found; use an absolute path", args[0], name)
 		}
 		args[0] = resolved
 	}
 
-	// Map Restart= to KeepAlive so launchd restarts the job like systemd would.
+	// Map Restart= to a launchd policy. `Restart=on-failure` translates to
+	// KeepAlive: SuccessfulExit=false so a clean exit (e.g. tray Quit) is
+	// honoured; only crashes or non-zero exits trigger a respawn.
 	restart := ""
 	if restarts := svc["Restart"]; len(restarts) > 0 {
 		restart = restarts[0]
 	}
-	keepAlive = restart == "always" || restart == "on-failure"
+	switch restart {
+	case "always":
+		keepAlive = keepAliveAlways
+	case "on-failure":
+		keepAlive = keepAliveOnFailure
+	default:
+		keepAlive = keepAliveNever
+	}
 	return args, keepAlive, nil
 }
 
@@ -517,7 +541,7 @@ func (m *darwinServiceManager) WriteContainerUnit(name, content string) error {
 	// the machine is up causes silent failures, so we let lerd-autostart sequence it.
 	// Stdout is suppressed (/dev/null) because `podman run -d` only prints the container
 	// ID there; real container output is accessible via `podman logs <name>`.
-	plist := buildPlist(plistLabel(name), args, false, false, "/dev/null", logPath)
+	plist := buildPlist(plistLabel(name), args, false, keepAliveNever, "/dev/null", logPath)
 	return os.WriteFile(plistPath(name), []byte(plist), 0644)
 }
 

--- a/internal/services/launchd_test.go
+++ b/internal/services/launchd_test.go
@@ -91,7 +91,7 @@ func TestXmlEscStr(t *testing.T) {
 }
 
 func TestBuildPlist(t *testing.T) {
-	plist := buildPlist("com.lerd.test", []string{"/bin/sh", "--flag"}, true, true, "/tmp/out.log", "/tmp/err.log")
+	plist := buildPlist("com.lerd.test", []string{"/bin/sh", "--flag"}, true, keepAliveAlways, "/tmp/out.log", "/tmp/err.log")
 
 	checks := []string{
 		`<string>com.lerd.test</string>`,
@@ -115,7 +115,7 @@ func TestBuildPlist(t *testing.T) {
 }
 
 func TestBuildPlistNoOptionalFields(t *testing.T) {
-	plist := buildPlist("com.lerd.minimal", []string{"/bin/true"}, false, false, "", "")
+	plist := buildPlist("com.lerd.minimal", []string{"/bin/true"}, false, keepAliveNever, "", "")
 
 	if strings.Contains(plist, "RunAtLoad") {
 		t.Error("expected no RunAtLoad key")
@@ -128,8 +128,22 @@ func TestBuildPlistNoOptionalFields(t *testing.T) {
 	}
 }
 
+func TestBuildPlistOnFailureEmitsSuccessfulExitDict(t *testing.T) {
+	plist := buildPlist("com.lerd.onfail", []string{"/bin/true"}, false, keepAliveOnFailure, "", "")
+
+	if !strings.Contains(plist, "<key>KeepAlive</key>") {
+		t.Fatal("expected KeepAlive key")
+	}
+	if !strings.Contains(plist, "<key>SuccessfulExit</key>") || !strings.Contains(plist, "<false/>") {
+		t.Errorf("on-failure policy should emit KeepAlive: SuccessfulExit=false, got:\n%s", plist)
+	}
+	if strings.Contains(plist, "<key>KeepAlive</key>\n\t<true/>") {
+		t.Errorf("on-failure must not emit bare KeepAlive=true, got:\n%s", plist)
+	}
+}
+
 func TestBuildPlistXMLEscaping(t *testing.T) {
-	plist := buildPlist("com.lerd.esc", []string{"/bin/echo", "a<b>&c"}, false, false, "", "")
+	plist := buildPlist("com.lerd.esc", []string{"/bin/echo", "a<b>&c"}, false, keepAliveNever, "", "")
 	if !strings.Contains(plist, "a&lt;b&gt;&amp;c") {
 		t.Error("arguments should be XML-escaped in plist")
 	}

--- a/internal/services/launchd_test.go
+++ b/internal/services/launchd_test.go
@@ -282,6 +282,30 @@ func TestPlistLabel(t *testing.T) {
 	}
 }
 
+func TestParseServiceUnitRestartPolicy(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want keepAlivePolicy
+	}{
+		{"always", "[Service]\nExecStart=/bin/sh\nRestart=always\n", keepAliveAlways},
+		{"on-failure", "[Service]\nExecStart=/bin/sh\nRestart=on-failure\n", keepAliveOnFailure},
+		{"none", "[Service]\nExecStart=/bin/sh\n", keepAliveNever},
+		{"no", "[Service]\nExecStart=/bin/sh\nRestart=no\n", keepAliveNever},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, got, err := parseServiceUnit("lerd-test", tc.body)
+			if err != nil {
+				t.Fatalf("parseServiceUnit: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Restart=%q → policy %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestWriteAndRemoveServiceUnit(t *testing.T) {
 	tmp := t.TempDir()
 	origHome := os.Getenv("HOME")

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"syscall"
 	"time"
 
@@ -65,6 +66,37 @@ type serviceInfo struct {
 }
 
 const daemonEnv = "LERD_TRAY_DAEMON"
+
+// lerdBin resolves the absolute path to the `lerd` binary. The tray often
+// runs under launchd, whose environment has no PATH that points at Homebrew
+// (`/opt/homebrew/bin`) where `lerd` lives, so a bare `exec.Command("lerd", …)`
+// silently fails to start. Falls back to "lerd" when nothing resolves so the
+// shell-launched path keeps working.
+var lerdBin = sync.OnceValue(func() string {
+	if p, err := exec.LookPath("lerd"); err == nil {
+		return p
+	}
+	home, _ := os.UserHomeDir()
+	candidates := []string{
+		"/opt/homebrew/bin/lerd",
+		"/usr/local/bin/lerd",
+	}
+	if home != "" {
+		candidates = append(candidates, filepath.Join(home, ".local", "bin", "lerd"))
+	}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c
+		}
+	}
+	return "lerd"
+})
+
+// lerdCmd is a thin wrapper around exec.Command that uses the resolved
+// `lerd` binary path so handlers work under launchd's empty PATH.
+func lerdCmd(args ...string) *exec.Cmd {
+	return exec.Command(lerdBin(), args...)
+}
 
 // Run starts the system tray applet.
 // Unless already running as a daemon (or under launchd), it re-execs itself
@@ -323,7 +355,7 @@ func handleToggle(item *systray.MenuItem, refresh func()) {
 			} else {
 				arg = "start"
 			}
-			runAndRefresh(exec.Command("lerd", arg), refresh)
+			runAndRefresh(lerdCmd(arg), refresh)
 		}()
 	}
 }
@@ -343,7 +375,7 @@ func handleServices(menu *menuState, refresh func()) {
 				if status == "active" {
 					arg = "stop"
 				}
-				runAndRefresh(exec.Command("lerd", "service", arg, name), refresh)
+				runAndRefresh(lerdCmd("service", arg, name), refresh)
 			}
 		}(i)
 	}
@@ -359,7 +391,7 @@ func handlePHP(menu *menuState, refresh func()) {
 				if version == "" {
 					continue
 				}
-				runAndRefresh(exec.Command("lerd", "use", version), refresh)
+				runAndRefresh(lerdCmd("use", version), refresh)
 			}
 		}(i)
 	}
@@ -371,7 +403,7 @@ func handleAutostart(item *systray.MenuItem, refresh func()) {
 		if lerdSystemd.IsAutostartEnabled() {
 			arg = "disable"
 		}
-		runAndRefresh(exec.Command("lerd", "autostart", arg), refresh)
+		runAndRefresh(lerdCmd("autostart", arg), refresh)
 	}
 }
 
@@ -388,7 +420,7 @@ func handleLAN(item *systray.MenuItem, refresh func()) {
 		if exposed {
 			arg = "unexpose"
 		}
-		runAndRefresh(exec.Command("lerd", "lan", arg), refresh)
+		runAndRefresh(lerdCmd("lan", arg), refresh)
 	}
 }
 
@@ -398,7 +430,7 @@ func handleDumps(item *systray.MenuItem, refresh func()) {
 		if cfg, err := config.LoadGlobal(); err == nil && cfg != nil {
 			enabled = cfg.IsDumpsEnabled()
 		}
-		runAndRefresh(exec.Command("lerd", "dump", offOn(enabled)), refresh)
+		runAndRefresh(lerdCmd("dump", offOn(enabled)), refresh)
 	}
 }
 
@@ -408,7 +440,7 @@ func handleNotifications(item *systray.MenuItem, refresh func()) {
 		if cfg, err := config.LoadGlobal(); err == nil && cfg != nil {
 			enabled = cfg.IsNotificationsEnabled()
 		}
-		runAndRefresh(exec.Command("lerd", "notify", offOn(enabled)), refresh)
+		runAndRefresh(lerdCmd("notify", offOn(enabled)), refresh)
 	}
 }
 
@@ -470,7 +502,7 @@ func openUpdateTerminal(latestVer string) {
 func handleQuit(item *systray.MenuItem, cancel context.CancelFunc) {
 	<-item.ClickedCh
 	cancel()
-	_ = exec.Command("lerd", "quit").Run()
+	_ = lerdCmd("quit").Run()
 	systray.Quit()
 }
 

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sync"
 	"syscall"
 	"time"
 
@@ -68,20 +67,19 @@ type serviceInfo struct {
 const daemonEnv = "LERD_TRAY_DAEMON"
 
 // lerdBin resolves the absolute path to the `lerd` binary. The tray often
-// runs under launchd, whose environment has no PATH that points at Homebrew
-// (`/opt/homebrew/bin`) where `lerd` lives, so a bare `exec.Command("lerd", …)`
-// silently fails to start. Falls back to "lerd" when nothing resolves so the
-// shell-launched path keeps working.
-var lerdBin = sync.OnceValue(func() string {
+// runs under launchd, whose environment has no PATH covering Homebrew or
+// ~/.local/bin, so a bare `exec.Command("lerd", …)` silently fails. Resolved
+// on every call so reinstalls (Homebrew → ~/.local/bin, etc.) don't strand
+// a long-running tray on a stale cached path.
+func lerdBin() string {
 	if p, err := exec.LookPath("lerd"); err == nil {
 		return p
 	}
-	home, _ := os.UserHomeDir()
 	candidates := []string{
 		"/opt/homebrew/bin/lerd",
 		"/usr/local/bin/lerd",
 	}
-	if home != "" {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
 		candidates = append(candidates, filepath.Join(home, ".local", "bin", "lerd"))
 	}
 	for _, c := range candidates {
@@ -90,7 +88,7 @@ var lerdBin = sync.OnceValue(func() string {
 		}
 	}
 	return "lerd"
-})
+}
 
 // lerdCmd is a thin wrapper around exec.Command that uses the resolved
 // `lerd` binary path so handlers work under launchd's empty PATH.


### PR DESCRIPTION
## Summary

Two bugs combined to make the tray's Quit menu item appear to do nothing on macOS:

1. **`KeepAlive=true` for `Restart=on-failure`.** The launchd plist for `lerd-tray` (and `lerd-ui`, `lerd-watcher`) was generated with a bare `KeepAlive=true` whenever the systemd unit had `Restart=on-failure`. launchd's `KeepAlive=true` respawns the job on *any* exit, including a clean `os.Exit(0)` — which is not what systemd `Restart=on-failure` means. Clicking Quit killed the tray process and launchd reincarnated it within milliseconds.

   Map `Restart=on-failure` to `KeepAlive: SuccessfulExit=false` instead, matching systemd semantics. `Restart=always` still emits the bare `KeepAlive=true`. The plist generator gets a small `keepAlivePolicy` tri-state to make the encoding explicit.

2. **`lerd` binary not findable from a launchd-launched tray.** `handleQuit` ran `exec.Command("lerd", "quit").Run()`, but launchd's job environment has no PATH covering `/opt/homebrew/bin` (where the Homebrew-installed `lerd` lives) and `~/.local/bin` doesn't contain a `lerd` binary either, so the call silently failed. None of the containers/services Quit was supposed to stop got stopped.

   Resolve the `lerd` binary path (via `exec.LookPath` plus a known-prefix fallback) on every invocation, and route every tray-side `lerd …` invocation through a small `lerdCmd` wrapper.

## Notes

After upgrading, `lerd install` rewrites the plist with the corrected policy and `services.Mgr.Start("lerd-tray")` bootouts + bootstraps so the new policy takes effect immediately. Existing users don't need to do anything special beyond the normal `lerd install` after the upgrade.