### PR TITLE
fix(install): clear error when podman is too old for --dns

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -3,10 +3,25 @@
 ## Linux
 
 - **Distribution**: Arch, Debian/Ubuntu, Fedora-based, or omarchy
-- **[Podman](https://podman.io/)**: rootless, with systemd user session active
+- **[Podman](https://podman.io/)** 4.5 or newer, rootless, with systemd user session active
 - **[crun](https://github.com/containers/crun)**: recommended OCI runtime for rootless Podman
 - **DNS resolver**: [NetworkManager](https://networkmanager.dev/) or [systemd-resolved](https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html) (at least one is required for `.test` DNS)
 - **`systemctl --user` functional**: run `loginctl enable-linger $USER` if needed
+
+### Podman 4.5 minimum
+
+::: warning
+Lerd creates the `lerd` podman network with `podman network create --dns`, a flag added in podman 4.5 (April 2023). Older releases fail install with `Error: unknown flag: --dns`. Distribution defaults that ship podman older than 4.5:
+
+| Distro                 | Default podman | Workaround                                                                       |
+|------------------------|---------------:|----------------------------------------------------------------------------------|
+| Ubuntu 22.04           | 3.4.4          | Install a newer podman from the [Kubic libcontainers OBS repo](https://podman.io/docs/installation#ubuntu-2204-2104-2010-2004) |
+| Zorin 17               | 3.4.4          | Same Kubic instructions as Ubuntu 22.04 (Zorin 17 is jammy-based)                |
+| Debian 12 (bookworm)   | 4.3.1          | `sudo apt install -t bookworm-backports podman` (ships 4.9+)                     |
+| Debian 11 (bullseye)   | 3.0.1          | Upgrade to Debian 12 + enable bookworm-backports                                 |
+
+Fedora 38+, Ubuntu 24.04+, openSUSE Tumbleweed, Arch and CachyOS all ship podman 4.5 or newer out of the box.
+:::
 
 ::: warning Linger must be enabled
 If `systemctl --user` units do not survive logout, run:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -283,6 +283,14 @@ podman system reset
 ```
 :::
 
+::: details Error: unknown flag: --dns (during `lerd install`)
+Symptom: `lerd install` aborts at the `podman network create` step with `Error: unknown flag: --dns`.
+
+Cause: your podman is older than 4.5. The `--dns` flag on `podman network create` was added in podman 4.5 (April 2023), and lerd needs it to write upstream DNS servers into netavark's per-network JSON atomically (otherwise the post-create `network update --dns-add` path crashes on Ubuntu 24.04's netavark <1.11). Distributions that ship podman older than 4.5: Ubuntu 22.04 / Zorin 17 (3.4.4), Debian 12 (4.3.1), Debian 11 (3.0.1).
+
+Fix: upgrade podman to 4.5 or newer. On Ubuntu 22.04 and Zorin 17 the main archive doesn't ship a new enough podman, but the [Kubic libcontainers OBS repo](https://podman.io/docs/installation#ubuntu-2204-2104-2010-2004) does (it's the path podman's own docs recommend). On Debian 12 enable bookworm-backports and run `sudo apt install -t bookworm-backports podman`. See the [requirements page](getting-started/requirements.md#podman-4-5-minimum) for the full distro/version table.
+:::
+
 ::: details Error: unable to parse ip fe80::...%18 specified in AddDNSServer: invalid argument
 Your host's DNS configuration includes a zoned link-local IPv6 nameserver, typically advertised by your router via SLAAC + RDNSS. The zone identifier (`%18` is a kernel interface index) is meaningless inside a container's network namespace, and netavark refuses to accept it.
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -119,7 +119,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 			fmt.Println()
 			restored, dualStack, mErr := podman.RecreateNetwork("lerd", desiredDNS)
 			if mErr != nil {
-				return fmt.Errorf("recreating lerd network: %w", mErr)
+				return mErr
 			}
 			if dualStack {
 				fmt.Println("    Recreated lerd network as dual-stack v4+v6.")

--- a/internal/podman/network.go
+++ b/internal/podman/network.go
@@ -197,7 +197,7 @@ func IPv6DisabledMarkerPath(name string) string {
 // torn down and recreated as v4-only. Returns the actual dual-stack state.
 func createNetworkWithProbe(name string, dualStack bool, dns []string) (bool, error) {
 	if err := RunSilent(networkCreateArgs(name, dualStack, dns)...); err != nil {
-		return dualStack, err
+		return dualStack, friendlyNetworkCreateError(err)
 	}
 
 	if dualStack {
@@ -437,4 +437,24 @@ func EnsureNetworkDNS(name string, servers []string) error {
 	}
 
 	return nil
+}
+
+// friendlyNetworkCreateError detects the `unknown flag: --dns` signature from
+// pre-4.5 podman (Ubuntu 22.04 / Zorin 17 / Debian 12 all ship older builds)
+// and replaces the raw cobra error with an upgrade hint pointing at the
+// minimum supported version. The trailing `\n` anchors the match to bare --dns
+// so flag names that merely start with --dns (--dns-add, --dns-search, …)
+// don't trip the rewrite.
+func friendlyNetworkCreateError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if !strings.Contains(err.Error(), "unknown flag: --dns\n") {
+		return err
+	}
+	const prose = "podman is too old: `podman network create` does not support --dns " +
+		"(added in podman 4.5). Upgrade podman to 4.5 or newer; several distro " +
+		"releases (Ubuntu 22.04, Zorin 17, Debian 11/12) still ship older builds, see " +
+		"https://geodro.github.io/lerd/getting-started/requirements for options"
+	return fmt.Errorf("%s: %w", prose, err)
 }

--- a/internal/podman/network_test.go
+++ b/internal/podman/network_test.go
@@ -1,6 +1,8 @@
 package podman
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -72,6 +74,52 @@ func TestNetworkCreateArgs(t *testing.T) {
 			got := networkCreateArgs("lerd", tt.dualStack, tt.dns)
 			if strings.Join(got, " ") != strings.Join(tt.want, " ") {
 				t.Errorf("networkCreateArgs:\n got  %v\n want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFriendlyNetworkCreateError(t *testing.T) {
+	raw := errors.New("podman network create --driver bridge --dns 1.1.1.1 lerd: exit status 125\nError: unknown flag: --dns\nUsage: ...")
+	// An unrelated unknown flag whose argv echo still contains --dns must not
+	// be rewritten as "podman too old", since Run() always prepends the full
+	// command line to its error string.
+	otherFlag := errors.New("podman network create --driver bridge --dns 1.1.1.1 lerd: exit status 125\nError: unknown flag: --driver\nUsage: ...")
+	dnsSearchFlag := errors.New("podman network create --dns-search example.com lerd: exit status 125\nError: unknown flag: --dns-search\nUsage: ...")
+	tests := []struct {
+		name        string
+		in          error
+		wantSame    bool
+		wantContain string
+	}{
+		{"nil passthrough", nil, true, ""},
+		{"unrelated passthrough", errors.New("podman: command not found"), true, ""},
+		{"unknown flag without --dns passthrough", errors.New("Error: unknown flag: --quiet"), true, ""},
+		{"unknown flag --driver with --dns in argv passthrough", otherFlag, true, ""},
+		{"unknown flag --dns-search passthrough", dnsSearchFlag, true, ""},
+		{"old podman --dns rewritten", raw, false, "podman 4.5"},
+		{"wrapped old podman --dns rewritten", fmt.Errorf("wrapper: %w", raw), false, "podman 4.5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := friendlyNetworkCreateError(tt.in)
+			if tt.in == nil {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+			if tt.wantSame {
+				if !errors.Is(got, tt.in) {
+					t.Fatalf("expected passthrough (errors.Is true), got %v", got)
+				}
+				return
+			}
+			if !strings.Contains(got.Error(), tt.wantContain) {
+				t.Fatalf("expected %q in %q", tt.wantContain, got.Error())
+			}
+			if !errors.Is(got, tt.in) {
+				t.Fatalf("rewritten error must still unwrap to the original via %%w; got %v", got)
 			}
 		})
 	}


### PR DESCRIPTION
When podman is older than 4.5 (the version where `podman network create --dns` was added), lerd install used to bail with a raw cobra "Error: unknown flag: --dns" and no hint about what to do next. The install path now translates that specific stderr signature into a message that names the minimum supported podman version and points at the requirements page for per-distro upgrade options. The substring match is anchored to bare --dns followed by a newline so flag names sharing the prefix don't trip the rewrite, and the wrap uses fmt.Errorf %w so callers (including the existing ErrNetworkNeedsMigration sentinel check on the migration path) still see the original error via errors.Is.

The requirements docs gained a Podman 4.5 minimum section listing the affected distros (Ubuntu 22.04, Zorin 17, Debian 11 and 12) and the actionable workaround for each: Kubic libcontainers OBS for jammy-based, bookworm-backports for Debian 12. The troubleshooting page got a matching entry that links straight to the workaround table. Also dropped the redundant "recreating lerd network" wrap from runInstall, since RecreateNetwork already prefixes "recreating lerd:" and the doubled prefix was just noise.

Refs #420.