### PR TITLE
fix(macos): heal gvproxy port forwards after a Podman Machine restart

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -70,8 +70,11 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 			podman.IPv6DisabledMarkerPath("lerd"))
 	}
 
-	// On macOS, Podman Machine must be running before any podman commands.
+	// Sample LastUp before ensure so an internal stop+start isn't mistaken
+	// for an external machine restart by healMachineRestartIfNeeded below.
+	preEnsureLastUp := currentMachineLastUp()
 	ensurePodmanMachineRunning()
+	healMachineRestartIfNeeded(preEnsureLastUp)
 
 	if err := ensureUnprivilegedPorts(); err != nil {
 		return err

--- a/internal/cli/machine_restart_heal_darwin.go
+++ b/internal/cli/machine_restart_heal_darwin.go
@@ -1,0 +1,135 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// machineLastUpFile records the Podman Machine LastUp from the prior run.
+// Compared on the next run to detect a machine restart that orphaned
+// gvproxy's host-side port forwards.
+func machineLastUpFile() string {
+	return filepath.Join(config.DataDir(), "podman-machine-lastup")
+}
+
+// selectedMachineName mirrors ensurePodmanMachineRunning's selection order
+// (default-marked, else first) so inspect targets the VM lerd actually
+// uses. Returns "" when no machine exists yet.
+func selectedMachineName() string {
+	out, err := exec.Command(podman.PodmanBin(), "machine", "list",
+		"--format", "{{.Name}}").Output()
+	if err != nil {
+		return ""
+	}
+	var first, def string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		raw := strings.TrimSpace(line)
+		if raw == "" {
+			continue
+		}
+		name := strings.TrimSuffix(raw, "*")
+		if first == "" {
+			first = name
+		}
+		if strings.HasSuffix(raw, "*") {
+			def = name
+			break
+		}
+	}
+	if def != "" {
+		return def
+	}
+	return first
+}
+
+// currentMachineLastUp returns the LastUp of lerd's Podman Machine, or ""
+// when the machine doesn't exist or podman can't report it. The name is
+// pinned explicitly so other machines don't perturb the comparison.
+func currentMachineLastUp() string {
+	name := selectedMachineName()
+	if name == "" {
+		return ""
+	}
+	out, err := exec.Command(podman.PodmanBin(), "machine", "inspect",
+		"--format", "{{.LastUp}}", name).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// recordMachineLastUp persists the current LastUp so the next run has a
+// baseline to compare against.
+func recordMachineLastUp() {
+	cur := currentMachineLastUp()
+	if cur == "" {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(machineLastUpFile()), 0755)
+	_ = os.WriteFile(machineLastUpFile(), []byte(cur), 0644)
+}
+
+// readPriorMachineLastUp returns the LastUp recorded on the prior run, or
+// "" if the state file is missing or unreadable.
+func readPriorMachineLastUp() string {
+	data, err := os.ReadFile(machineLastUpFile())
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// shouldHealAfterMachineStart returns true when the machine was restarted
+// externally between runs; comparing the pre-ensure LastUp rules out
+// stop+starts the ensure itself performs.
+func shouldHealAfterMachineStart(preEnsureLastUp, priorBaseline string) bool {
+	if priorBaseline == "" {
+		return false
+	}
+	if preEnsureLastUp == "" {
+		return true
+	}
+	return preEnsureLastUp != priorBaseline
+}
+
+// healMachineRestartIfNeeded force-removes running lerd-* containers when
+// the machine was restarted externally, then records the post-ensure
+// LastUp so an interrupted run still leaves a usable baseline.
+func healMachineRestartIfNeeded(preEnsureLastUp string) {
+	if shouldHealAfterMachineStart(preEnsureLastUp, readPriorMachineLastUp()) {
+		removeLerdContainersForGvproxyHeal()
+	}
+	recordMachineLastUp()
+}
+
+// removeLerdContainersForGvproxyHeal force-removes every running lerd-*
+// container so the next StartUnit pass invokes `podman run -p` fresh from
+// the host and gvproxy re-registers the host port forwards.
+func removeLerdContainersForGvproxyHeal() {
+	out, err := podman.Run("ps", "--format", "{{.Names}}", "--filter", "name=^lerd-")
+	if err != nil || strings.TrimSpace(out) == "" {
+		return
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if n := strings.TrimSpace(line); n != "" {
+			names = append(names, n)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+	fmt.Println("  --> Podman Machine was restarted; recreating containers to restore host port forwards ...")
+	args := append([]string{"rm", "-f"}, names...)
+	if out, err := exec.Command(podman.PodmanBin(), args...).CombinedOutput(); err != nil {
+		fmt.Printf("       WARN: podman rm -f failed: %v\n%s\n", err, strings.TrimSpace(string(out)))
+	}
+}

--- a/internal/cli/machine_restart_heal_darwin_test.go
+++ b/internal/cli/machine_restart_heal_darwin_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestShouldHealAfterMachineStart(t *testing.T) {
 	cases := []struct {
-		name           string
+		name            string
 		preEnsureLastUp string
 		priorBaseline   string
-		want           bool
+		want            bool
 	}{
 		{"first run, no baseline yet", "2026-05-27T12:00:00Z", "", false},
 		{"first run, machine was down", "", "", false},

--- a/internal/cli/machine_restart_heal_darwin_test.go
+++ b/internal/cli/machine_restart_heal_darwin_test.go
@@ -1,0 +1,53 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestShouldHealAfterMachineStart(t *testing.T) {
+	cases := []struct {
+		name           string
+		preEnsureLastUp string
+		priorBaseline   string
+		want           bool
+	}{
+		{"first run, no baseline yet", "2026-05-27T12:00:00Z", "", false},
+		{"first run, machine was down", "", "", false},
+		{"unchanged across runs", "2026-05-26T12:00:00Z", "2026-05-26T12:00:00Z", false},
+		{"external restart between runs", "2026-05-27T08:30:00Z", "2026-05-26T12:00:00Z", true},
+		{"machine was down, baseline exists", "", "2026-05-26T12:00:00Z", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldHealAfterMachineStart(c.preEnsureLastUp, c.priorBaseline); got != c.want {
+				t.Errorf("shouldHealAfterMachineStart(%q, %q) = %v, want %v",
+					c.preEnsureLastUp, c.priorBaseline, got, c.want)
+			}
+		})
+	}
+}
+
+func TestReadPriorMachineLastUp_missing(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if got := readPriorMachineLastUp(); got != "" {
+		t.Errorf("expected empty when state file missing, got %q", got)
+	}
+}
+
+func TestReadPriorMachineLastUp_roundTrip(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(machineLastUpFile()), 0755); err != nil {
+		t.Fatal(err)
+	}
+	want := "2026-05-26T15:32:41.93164+03:00"
+	if err := os.WriteFile(machineLastUpFile(), []byte(want+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := readPriorMachineLastUp(); got != want {
+		t.Errorf("readPriorMachineLastUp() = %q, want %q (trailing whitespace must be trimmed)", got, want)
+	}
+}

--- a/internal/cli/machine_restart_heal_linux.go
+++ b/internal/cli/machine_restart_heal_linux.go
@@ -1,0 +1,12 @@
+//go:build linux
+
+package cli
+
+// currentMachineLastUp is a no-op on Linux. Podman runs natively without
+// a VM, so there is no LastUp to read and no gvproxy to lose host-side
+// port forwards.
+func currentMachineLastUp() string { return "" }
+
+// healMachineRestartIfNeeded is a no-op on Linux. See
+// currentMachineLastUp for the rationale.
+func healMachineRestartIfNeeded(_ string) {}

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -402,9 +402,13 @@ func checkPortConflicts(units []string) {
 }
 
 func runStart(_ *cobra.Command, _ []string) error {
-	// On macOS, ensure Podman Machine is up and migrate any stale plists.
+	// Pre-ensure LastUp lets healMachineRestartIfNeeded distinguish an
+	// external podman-machine restart (which orphans gvproxy port forwards)
+	// from a stop+start the ensure itself performs. No-op on Linux.
+	preEnsureLastUp := currentMachineLastUp()
 	ensurePodmanMachineRunning()
 	migrateExecWorkerPlists()
+	healMachineRestartIfNeeded(preEnsureLastUp)
 
 	// Ensure the lerd bridge network exists. On macOS the network is stored
 	// inside the Podman Machine VM; it may be absent after a fresh machine


### PR DESCRIPTION
After a Podman Machine restart on macOS (machine stop/start, Mac reboot, or a crash) `lerd-*` containers come back up inside the VM via `--restart=always`, but gvproxy on the host loses its port-forward table and only learns about forwards when `podman run -p` is invoked from the host CLI. Sites look "running" but refuse on :80/:443; reported in https://github.com/geodro/lerd/discussions/414. Previously, neither `lerd start`, `service restart nginx`, nor kicking the launchd job would heal it. The workaround was recreating the nginx container by hand.

lerd now records the machine's `LastUp` at every successful `lerd start` / `lerd install` and compares it on the next run. When the value moved (external restart), the heal force-removes running `lerd-*` containers so the StartUnit pass that follows invokes `podman run -p` fresh from the host, which re-registers the forwards with gvproxy.

The `LastUp` is sampled before `ensurePodmanMachineRunning` so internal stop+starts (rootful or memory adjustment) don't trigger a phantom heal. The same pattern runs from `lerd install` so users who reach container-start through `lerd update` get healed too. On Linux every function is a no-op since podman runs natively without a VM or gvproxy.

Heal output:

    --> Podman Machine was restarted; recreating containers to restore host port forwards ...

Closes the user-facing bug raised in #414.