### PR TITLE
fix(service): make lerd service reinstall transactional and route via preset name

### DIFF
--- a/internal/cli/services_preset_test.go
+++ b/internal/cli/services_preset_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -18,6 +20,22 @@ func TestInstallPresetByName_Unknown(t *testing.T) {
 }
 
 func TestMissingPresetDependencies_BuiltinDepIsSatisfied(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	// MissingPresetDependencies now treats built-ins as installed only
+	// when their quadlet is on disk (see the reinstall transactionality
+	// PR). Materialise a lerd-mysql.container so the dep counts as
+	// satisfied — matches the post-`lerd install` state on a real host.
+	qdir := config.QuadletDir()
+	if err := os.MkdirAll(qdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(qdir, "lerd-mysql.container"), []byte("[Container]\nImage=docker.io/library/mysql:8\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	preset, err := config.LoadPreset("phpmyadmin")
 	if err != nil {
 		t.Fatalf("LoadPreset: %v", err)

--- a/internal/serviceops/reinstall.go
+++ b/internal/serviceops/reinstall.go
@@ -40,6 +40,11 @@ var (
 	// custom-service path passes spec.presetName (NOT the service name) to
 	// the install streaming function, which is the actual routing fix.
 	reinstallStreamingFn = InstallPresetStreaming
+	// reinstallFamilyRegenFn drives family-consumer regeneration outside
+	// of InstallPresetByName's internal call: default-preset reinstalls
+	// (where the install path doesn't regen) and the install-failure path
+	// (where consumers must sync to the post-Remove "target gone" state).
+	reinstallFamilyRegenFn = RegenerateFamilyConsumersForService
 )
 
 // realPrefetchImage pulls the pinned image when it isn't already local so a
@@ -100,24 +105,23 @@ func ReinstallService(name string, resetData bool, emit func(PhaseEvent)) error 
 		return fmt.Errorf("reinstall: pre-flight pull %q: %w", spec.image, err)
 	}
 
-	// SkipFamilyRegen because the regen-during-remove runs with the YAML
-	// already deleted: family consumers (e.g. phpmyadmin) would be
-	// rendered against a partial set, restarted against a partial plist,
-	// and rely on the subsequent install's regen to overwrite — which
-	// races with launchctl bootout/bootstrap on macOS. The custom-service
-	// install path (InstallPresetByName) regenerates once the new YAML is
-	// on disk; the default-preset path doesn't, so we trigger it ourselves
-	// below.
+	// Suppress regen-during-remove; we drive it ourselves below to
+	// eliminate the launchctl bootout/bootstrap race on macOS.
 	if err := RemoveService(name, RemoveOptions{RemoveData: resetData, SkipFamilyRegen: true}, emit); err != nil {
 		return fmt.Errorf("reinstall: remove step: %w", err)
 	}
 
 	if _, err := reinstallInstallFn(name, spec, emit); err != nil {
+		// Sync consumers to the post-Remove state so their plists stop
+		// referencing the deleted target.
+		reinstallFamilyRegenFn(name)
 		return fmt.Errorf("reinstall: install step: %w", err)
 	}
 
+	// InstallPresetByName regenerates internally for custom services;
+	// default-preset install doesn't, so do it here.
 	if config.IsDefaultPreset(name) {
-		RegenerateFamilyConsumersForService(name)
+		reinstallFamilyRegenFn(name)
 	}
 
 	if resetData {

--- a/internal/serviceops/reinstall.go
+++ b/internal/serviceops/reinstall.go
@@ -100,12 +100,24 @@ func ReinstallService(name string, resetData bool, emit func(PhaseEvent)) error 
 		return fmt.Errorf("reinstall: pre-flight pull %q: %w", spec.image, err)
 	}
 
-	if err := RemoveService(name, RemoveOptions{RemoveData: resetData}, emit); err != nil {
+	// SkipFamilyRegen because the regen-during-remove runs with the YAML
+	// already deleted: family consumers (e.g. phpmyadmin) would be
+	// rendered against a partial set, restarted against a partial plist,
+	// and rely on the subsequent install's regen to overwrite — which
+	// races with launchctl bootout/bootstrap on macOS. The custom-service
+	// install path (InstallPresetByName) regenerates once the new YAML is
+	// on disk; the default-preset path doesn't, so we trigger it ourselves
+	// below.
+	if err := RemoveService(name, RemoveOptions{RemoveData: resetData, SkipFamilyRegen: true}, emit); err != nil {
 		return fmt.Errorf("reinstall: remove step: %w", err)
 	}
 
 	if _, err := reinstallInstallFn(name, spec, emit); err != nil {
 		return fmt.Errorf("reinstall: install step: %w", err)
+	}
+
+	if config.IsDefaultPreset(name) {
+		RegenerateFamilyConsumersForService(name)
 	}
 
 	if resetData {

--- a/internal/serviceops/reinstall.go
+++ b/internal/serviceops/reinstall.go
@@ -14,8 +14,14 @@ import (
 // pin the same image / version the user was running, instead of re-resolving
 // the rolling preset.Image and silently jumping versions.
 type reinstallSpec struct {
-	// version is the multi-version preset tag (e.g. "8.4" for mysql). Empty
-	// for single-version and default presets.
+	// presetName is the bundled preset this service was installed from.
+	// Differs from the service name for non-canonical versions, e.g.
+	// service "mariadb-10-11" comes from preset "mariadb". For default
+	// presets and canonical-version services this equals name.
+	presetName string
+	// version is the multi-version preset tag (e.g. "8.4" for mysql).
+	// Empty for single-version presets and for default presets installed
+	// before the canonical-pin field existed.
 	version string
 	// image is the fully-qualified Image= line from the on-disk quadlet
 	// (e.g. "docker.io/library/mysql:8.4.9"). Empty when there's no quadlet.
@@ -23,11 +29,37 @@ type reinstallSpec struct {
 }
 
 // Seams for ReinstallService composition. The defaults wire to the real
-// install + reprovision functions; tests substitute fakes.
+// install + reprovision + validation functions; tests substitute fakes so
+// composition logic can be exercised without a real preset bundle or podman.
 var (
-	reinstallInstallFn = realReinstallInstall
-	reinstallReprovFn  = ReprovisionLinkedSites
+	reinstallInstallFn       = realReinstallInstall
+	reinstallReprovFn        = ReprovisionLinkedSites
+	reinstallValidateFn      = validateReinstall
+	reinstallPrefetchImageFn = realPrefetchImage
 )
+
+// realPrefetchImage pulls the pinned image when it isn't already local so a
+// network/registry failure surfaces before RemoveService deletes anything.
+// Always emits `preflight_image_ok` on success so callers driving a UI off
+// the event stream see a consistent terminal phase on both the warm-cache
+// and the cold-cache path.
+func realPrefetchImage(image string, emit func(PhaseEvent)) error {
+	if image == "" {
+		return nil
+	}
+	if podman.ImageExists(image) {
+		emit(PhaseEvent{Phase: "preflight_image_ok", Image: image})
+		return nil
+	}
+	emit(PhaseEvent{Phase: "pulling_image", Image: image})
+	if err := podman.PullImageWithProgress(image, func(line string) {
+		emit(PhaseEvent{Phase: "pulling_image", Message: line})
+	}); err != nil {
+		return err
+	}
+	emit(PhaseEvent{Phase: "preflight_image_ok", Image: image})
+	return nil
+}
 
 // ReinstallService stops, removes, and reinstalls a service, optionally wiping
 // its data and reprovisioning per-site state (databases, buckets) on the
@@ -36,6 +68,11 @@ var (
 // Reinstall requires that the service is currently installed: for default
 // presets that means a quadlet on disk; for custom services that means a
 // custom-service YAML. If neither is found ReinstallService returns an error.
+//
+// Pre-flight validation runs before RemoveService so configuration errors
+// (unknown preset, bad version, missing dependencies, unreachable image)
+// fail with the on-disk state intact rather than after the service config
+// has already been deleted.
 //
 // When resetData is true the data dir is renamed-aside (recoverable as
 // .pre-remove-<ts>) and ReprovisionLinkedSites is invoked after the install
@@ -51,12 +88,12 @@ func ReinstallService(name string, resetData bool, emit func(PhaseEvent)) error 
 		return err
 	}
 
-	// Pre-flight: if the image is already pulled locally we can guarantee the
-	// install step won't fail on a missing image after RemoveService has
-	// already deleted the quadlet (no rollback on a failed pull). For images
-	// not yet local, the install step will pull and surface failures normally.
-	if spec.image != "" && podman.ImageExists(spec.image) {
-		emit(PhaseEvent{Phase: "preflight_image_ok", Image: spec.image})
+	if err := reinstallValidateFn(name, spec); err != nil {
+		return fmt.Errorf("reinstall: pre-flight: %w", err)
+	}
+
+	if err := reinstallPrefetchImageFn(spec.image, emit); err != nil {
+		return fmt.Errorf("reinstall: pre-flight pull %q: %w", spec.image, err)
 	}
 
 	if err := RemoveService(name, RemoveOptions{RemoveData: resetData}, emit); err != nil {
@@ -76,24 +113,69 @@ func ReinstallService(name string, resetData bool, emit func(PhaseEvent)) error 
 }
 
 // captureReinstallSpec snapshots the on-disk state RemoveService is about to
-// destroy, so realReinstallInstall can pin the same version + image. For
-// custom services the version comes from the YAML; for default presets we
-// only have the rendered quadlet's Image line.
+// destroy, so realReinstallInstall can pin the same preset + version + image.
+// For custom services the values come from the YAML; for default presets we
+// only have the rendered quadlet's Image line and the service name itself.
 func captureReinstallSpec(name string) (reinstallSpec, error) {
 	if existing, err := config.LoadCustomService(name); err == nil {
+		// Backfill the preset reference for legacy YAMLs written before the
+		// Preset field existed: fall back to the service name, which is the
+		// canonical preset name for single-version presets.
+		presetName := existing.Preset
+		if presetName == "" {
+			presetName = name
+		}
 		// Multi-version presets must always carry a PresetVersion. An empty
-		// value here is a YAML corruption — falling through to InstallPresetByName
+		// value here is a YAML corruption: falling through to InstallPresetByName
 		// with version="" would silently resolve to DefaultVersion and move
 		// the user off whatever tag they were running.
-		if preset, perr := config.LoadPreset(name); perr == nil && len(preset.Versions) > 0 && existing.PresetVersion == "" {
+		if preset, perr := config.LoadPreset(presetName); perr == nil && len(preset.Versions) > 0 && existing.PresetVersion == "" {
 			return reinstallSpec{}, fmt.Errorf("service %q has empty preset_version; refusing to reinstall and silently jump to default version", name)
 		}
-		return reinstallSpec{version: existing.PresetVersion, image: existing.Image}, nil
+		return reinstallSpec{
+			presetName: presetName,
+			version:    existing.PresetVersion,
+			image:      existing.Image,
+		}, nil
 	}
 	if config.IsDefaultPreset(name) && podman.QuadletInstalled("lerd-"+name) {
-		return reinstallSpec{image: podman.InstalledImage("lerd-" + name)}, nil
+		return reinstallSpec{
+			presetName: name,
+			image:      podman.InstalledImage("lerd-" + name),
+		}, nil
 	}
 	return reinstallSpec{}, fmt.Errorf("service %q is not installed; nothing to reinstall", name)
+}
+
+// validateReinstall replays the preset/version/dependency checks the install
+// path will run, without writing anything. Catches configuration errors that
+// would otherwise fail after RemoveService has already deleted the YAML and
+// quadlet, leaving the user with neither the old install nor the new one.
+// Default-preset and custom-service paths share the same validation so both
+// fail closed under the same conditions.
+func validateReinstall(name string, spec reinstallSpec) error {
+	if spec.presetName == "" {
+		return fmt.Errorf("service %q has no preset reference; cannot determine reinstall source", name)
+	}
+	preset, err := config.LoadPreset(spec.presetName)
+	if err != nil {
+		hint := ""
+		if spec.presetName == name {
+			hint = " (legacy YAML without `preset:` field — add `preset: <name>` pointing at a bundled preset)"
+		}
+		return fmt.Errorf("preset %q (source of service %q) not found%s: %w", spec.presetName, name, hint, err)
+	}
+	if spec.version != "" && len(preset.Versions) == 0 {
+		return fmt.Errorf("preset %q does not declare versions, but service %q has preset_version=%q", spec.presetName, name, spec.version)
+	}
+	svc, err := preset.Resolve(spec.version)
+	if err != nil {
+		return fmt.Errorf("preset %q version %q: %w", spec.presetName, spec.version, err)
+	}
+	if missing := MissingPresetDependencies(svc); len(missing) > 0 {
+		return fmt.Errorf("preset %q requires %s to be installed first", spec.presetName, strings.Join(missing, ", "))
+	}
+	return nil
 }
 
 // realReinstallInstall dispatches to the right install path based on whether
@@ -143,5 +225,5 @@ func realReinstallInstall(name string, spec reinstallSpec, emit func(PhaseEvent)
 		}
 		return &config.CustomService{Name: name}, nil
 	}
-	return InstallPresetStreaming(name, spec.version, emit)
+	return InstallPresetStreaming(spec.presetName, spec.version, emit)
 }

--- a/internal/serviceops/reinstall.go
+++ b/internal/serviceops/reinstall.go
@@ -36,6 +36,10 @@ var (
 	reinstallReprovFn        = ReprovisionLinkedSites
 	reinstallValidateFn      = validateReinstall
 	reinstallPrefetchImageFn = realPrefetchImage
+	// reinstallStreamingFn lets tests of realReinstallInstall verify the
+	// custom-service path passes spec.presetName (NOT the service name) to
+	// the install streaming function, which is the actual routing fix.
+	reinstallStreamingFn = InstallPresetStreaming
 )
 
 // realPrefetchImage pulls the pinned image when it isn't already local so a
@@ -151,8 +155,16 @@ func captureReinstallSpec(name string) (reinstallSpec, error) {
 // path will run, without writing anything. Catches configuration errors that
 // would otherwise fail after RemoveService has already deleted the YAML and
 // quadlet, leaving the user with neither the old install nor the new one.
-// Default-preset and custom-service paths share the same validation so both
-// fail closed under the same conditions.
+//
+// Default-preset and custom-service paths share the same outer validation,
+// but the version-selection step mirrors each install path so the resolved
+// svc.DependsOn matches what the install will actually run against:
+//
+//   - custom service: install calls InstallPresetStreaming(spec.presetName,
+//     spec.version, ...) → preset.Resolve(version);
+//   - default preset: install calls EnsureDefaultPresetQuadletPinned which
+//     uses ResolvePinned(canonicalPin) from cfg.Services[name].CanonicalVersion,
+//     falling back to Resolve("") when no pin is recorded.
 func validateReinstall(name string, spec reinstallSpec) error {
 	if spec.presetName == "" {
 		return fmt.Errorf("service %q has no preset reference; cannot determine reinstall source", name)
@@ -161,21 +173,46 @@ func validateReinstall(name string, spec reinstallSpec) error {
 	if err != nil {
 		hint := ""
 		if spec.presetName == name {
-			hint = " (legacy YAML without `preset:` field — add `preset: <name>` pointing at a bundled preset)"
+			hint = " (legacy YAML without `preset:` field; add `preset: <name>` pointing at a bundled preset)"
 		}
 		return fmt.Errorf("preset %q (source of service %q) not found%s: %w", spec.presetName, name, hint, err)
 	}
 	if spec.version != "" && len(preset.Versions) == 0 {
 		return fmt.Errorf("preset %q does not declare versions, but service %q has preset_version=%q", spec.presetName, name, spec.version)
 	}
-	svc, err := preset.Resolve(spec.version)
+	svc, err := resolveForValidate(name, spec, preset)
 	if err != nil {
-		return fmt.Errorf("preset %q version %q: %w", spec.presetName, spec.version, err)
+		return err
 	}
 	if missing := MissingPresetDependencies(svc); len(missing) > 0 {
 		return fmt.Errorf("preset %q requires %s to be installed first", spec.presetName, strings.Join(missing, ", "))
 	}
 	return nil
+}
+
+// resolveForValidate picks the same preset version that the install path
+// would pick, so MissingPresetDependencies runs against the right svc.
+// Default presets read the canonical pin from global config (mirrors
+// EnsureDefaultPresetQuadletPinned); other paths use the captured version.
+func resolveForValidate(name string, spec reinstallSpec, preset *config.Preset) (*config.CustomService, error) {
+	if config.IsDefaultPreset(name) && len(preset.Versions) > 0 {
+		canonicalPin := ""
+		if cfg, _ := config.LoadGlobal(); cfg != nil {
+			canonicalPin = cfg.Services[name].CanonicalVersion
+		}
+		if canonicalPin != "" {
+			svc, err := preset.ResolvePinned(canonicalPin)
+			if err != nil {
+				return nil, fmt.Errorf("preset %q canonical pin %q: %w", spec.presetName, canonicalPin, err)
+			}
+			return svc, nil
+		}
+	}
+	svc, err := preset.Resolve(spec.version)
+	if err != nil {
+		return nil, fmt.Errorf("preset %q version %q: %w", spec.presetName, spec.version, err)
+	}
+	return svc, nil
 }
 
 // realReinstallInstall dispatches to the right install path based on whether
@@ -225,5 +262,5 @@ func realReinstallInstall(name string, spec reinstallSpec, emit func(PhaseEvent)
 		}
 		return &config.CustomService{Name: name}, nil
 	}
-	return InstallPresetStreaming(spec.presetName, spec.version, emit)
+	return reinstallStreamingFn(spec.presetName, spec.version, emit)
 }

--- a/internal/serviceops/reinstall_preflight_test.go
+++ b/internal/serviceops/reinstall_preflight_test.go
@@ -105,6 +105,98 @@ func TestReinstallService_SuppressesFamilyRegenDuringRemove(t *testing.T) {
 	}
 }
 
+func TestReinstallService_DefaultPreset_TriggersExplicitFamilyRegen(t *testing.T) {
+	// EnsureDefaultPresetQuadletPinned does not regen family consumers,
+	// so ReinstallService must do it explicitly after the install step.
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubPodmanRemove(t)
+	rec := stubReinstallSeams(t)
+
+	// mysql is a default preset in the embedded bundle. Save a YAML so
+	// captureReinstallSpec's custom-service branch fires; routing falls
+	// through to the default-preset path because IsDefaultPreset("mysql")
+	// returns true.
+	svc := &config.CustomService{
+		Name:          "mysql",
+		Image:         "docker.io/library/mysql:8.4",
+		Preset:        "mysql",
+		PresetVersion: "8.4",
+		Family:        "mysql",
+	}
+	if err := config.SaveCustomService(svc); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+
+	if err := ReinstallService("mysql", false, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("ReinstallService: %v", err)
+	}
+	if len(rec.familyRegenCalls) != 1 || rec.familyRegenCalls[0] != "mysql" {
+		t.Errorf("default-preset reinstall should call family regen once with %q, got %v", "mysql", rec.familyRegenCalls)
+	}
+}
+
+func TestReinstallService_InstallFailure_TriggersFamilyRegen(t *testing.T) {
+	// When the install step fails, consumers' plists still reference
+	// the now-deleted target. ReinstallService must sync them to the
+	// post-Remove "target gone" state.
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubPodmanRemove(t)
+	rec := stubReinstallSeams(t)
+	rec.installErr = errors.New("simulated install failure")
+
+	svc := &config.CustomService{
+		Name:          "mariadb-10-11",
+		Image:         "docker.io/library/mariadb:10.11",
+		Preset:        "mariadb",
+		PresetVersion: "10.11",
+		Family:        "mariadb",
+	}
+	if err := config.SaveCustomService(svc); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+
+	err := ReinstallService("mariadb-10-11", false, func(PhaseEvent) {})
+	if err == nil {
+		t.Fatal("expected install failure to propagate")
+	}
+	if len(rec.familyRegenCalls) != 1 || rec.familyRegenCalls[0] != "mariadb-10-11" {
+		t.Errorf("install failure should call family regen once with %q, got %v", "mariadb-10-11", rec.familyRegenCalls)
+	}
+}
+
+func TestReinstallService_CustomServiceSuccess_NoExtraFamilyRegen(t *testing.T) {
+	// For a custom-service reinstall that succeeds, InstallPresetByName's
+	// internal regen handles family consumers. ReinstallService must NOT
+	// fire its explicit regen (which would double-regen).
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubPodmanRemove(t)
+	rec := stubReinstallSeams(t)
+
+	svc := &config.CustomService{
+		Name:          "mariadb-10-11",
+		Image:         "docker.io/library/mariadb:10.11",
+		Preset:        "mariadb",
+		PresetVersion: "10.11",
+		Family:        "mariadb",
+	}
+	if err := config.SaveCustomService(svc); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+
+	if err := ReinstallService("mariadb-10-11", false, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("ReinstallService: %v", err)
+	}
+	if len(rec.familyRegenCalls) != 0 {
+		t.Errorf("custom-service success should not call the explicit family regen, got %v", rec.familyRegenCalls)
+	}
+}
+
 func TestRemoveService_SkipFamilyRegen_HonoursFlag(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/serviceops/reinstall_preflight_test.go
+++ b/internal/serviceops/reinstall_preflight_test.go
@@ -1,0 +1,163 @@
+package serviceops
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// stubPreflightSeams installs configurable pre-flight seams plus permissive
+// install/reprov fakes, so each test can verify that pre-flight failure
+// short-circuits before RemoveService deletes anything.
+func stubPreflightSeams(t *testing.T, validateErr, prefetchErr error) *reinstallRecorder {
+	t.Helper()
+	rec := stubReinstallSeams(t)
+	prevValidate := reinstallValidateFn
+	prevPrefetch := reinstallPrefetchImageFn
+	reinstallValidateFn = func(string, reinstallSpec) error { return validateErr }
+	reinstallPrefetchImageFn = func(string, func(PhaseEvent)) error { return prefetchErr }
+	t.Cleanup(func() {
+		reinstallValidateFn = prevValidate
+		reinstallPrefetchImageFn = prevPrefetch
+	})
+	return rec
+}
+
+func TestReinstallService_PreflightValidateFailure_LeavesYAMLIntact(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubPodmanRemove(t)
+	rec := stubPreflightSeams(t, errors.New("unknown preset"), nil)
+
+	saveCustomServiceForReinstall(t, "myservice", "1.2.3")
+
+	err := ReinstallService("myservice", false, func(PhaseEvent) {})
+	if err == nil || !strings.Contains(err.Error(), "unknown preset") {
+		t.Fatalf("expected pre-flight validate error, got %v", err)
+	}
+	if _, err := config.LoadCustomService("myservice"); err != nil {
+		t.Errorf("YAML must survive a pre-flight validate failure, got %v", err)
+	}
+	if len(rec.installCalls) != 0 {
+		t.Errorf("install must not run after pre-flight failure, got %v", rec.installCalls)
+	}
+}
+
+func TestReinstallService_PreflightPullFailure_LeavesYAMLIntact(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubPodmanRemove(t)
+	rec := stubPreflightSeams(t, nil, errors.New("registry unreachable"))
+
+	saveCustomServiceForReinstall(t, "myservice", "1.2.3")
+
+	err := ReinstallService("myservice", false, func(PhaseEvent) {})
+	if err == nil || !strings.Contains(err.Error(), "registry unreachable") {
+		t.Fatalf("expected pre-flight pull error, got %v", err)
+	}
+	if _, err := config.LoadCustomService("myservice"); err != nil {
+		t.Errorf("YAML must survive a pre-flight pull failure, got %v", err)
+	}
+	if len(rec.installCalls) != 0 {
+		t.Errorf("install must not run after pre-flight failure, got %v", rec.installCalls)
+	}
+}
+
+func TestCaptureReinstallSpec_UsesPresetFieldNotServiceName(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	// Non-canonical-version service: name "mariadb-10-11", preset "mariadb".
+	// captureReinstallSpec must pick up Preset from YAML so the install path
+	// loads the real preset, not the synthesised service name.
+	svc := &config.CustomService{
+		Name:          "mariadb-10-11",
+		Image:         "docker.io/library/mariadb:10.11",
+		Preset:        "mariadb",
+		PresetVersion: "10.11",
+	}
+	if err := config.SaveCustomService(svc); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+
+	spec, err := captureReinstallSpec("mariadb-10-11")
+	if err != nil {
+		t.Fatalf("captureReinstallSpec: %v", err)
+	}
+	if spec.presetName != "mariadb" {
+		t.Errorf("presetName = %q, want mariadb (from Preset field, not service name)", spec.presetName)
+	}
+	if spec.version != "10.11" {
+		t.Errorf("version = %q, want 10.11", spec.version)
+	}
+}
+
+func TestCaptureReinstallSpec_BackfillsPresetFromName_WhenYAMLLacksField(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	// Legacy YAML written before the Preset field existed: fall back to
+	// the service name itself, which is the canonical preset name for
+	// single-version presets.
+	svc := &config.CustomService{
+		Name:  "selenium",
+		Image: "docker.io/selenium/standalone-chrome:latest",
+	}
+	if err := config.SaveCustomService(svc); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+
+	spec, err := captureReinstallSpec("selenium")
+	if err != nil {
+		t.Fatalf("captureReinstallSpec: %v", err)
+	}
+	if spec.presetName != "selenium" {
+		t.Errorf("presetName = %q, want selenium (backfilled from name)", spec.presetName)
+	}
+}
+
+func TestRealReinstallInstall_CustomServicePath_RoutesViaPresetName(t *testing.T) {
+	// Verifies the bug fix: when reinstalling a non-canonical-version
+	// service, the install seam must receive spec.presetName="mariadb"
+	// (the source preset) so realReinstallInstall can call
+	// InstallPresetStreaming with the correct preset name, instead of
+	// "mariadb-10-11" which is not a preset and fails after RemoveService.
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	rec := stubReinstallSeams(t)
+	svc := &config.CustomService{
+		Name:          "mariadb-10-11",
+		Image:         "docker.io/library/mariadb:10.11",
+		Preset:        "mariadb",
+		PresetVersion: "10.11",
+	}
+	if err := config.SaveCustomService(svc); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+	stubPodmanRemove(t)
+
+	if err := ReinstallService("mariadb-10-11", false, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("ReinstallService: %v", err)
+	}
+	if len(rec.installCalls) != 1 {
+		t.Fatalf("expected 1 install call, got %d", len(rec.installCalls))
+	}
+	call := rec.installCalls[0]
+	if call.Name != "mariadb-10-11" {
+		t.Errorf("install Name = %q, want mariadb-10-11 (the service being reinstalled)", call.Name)
+	}
+	if call.PresetName != "mariadb" {
+		t.Errorf("install PresetName = %q, want mariadb (the SOURCE preset, not the service name)", call.PresetName)
+	}
+	if call.Version != "10.11" {
+		t.Errorf("install Version = %q, want 10.11", call.Version)
+	}
+}

--- a/internal/serviceops/reinstall_preflight_test.go
+++ b/internal/serviceops/reinstall_preflight_test.go
@@ -69,6 +69,81 @@ func TestReinstallService_PreflightPullFailure_LeavesYAMLIntact(t *testing.T) {
 	}
 }
 
+func TestReinstallService_SuppressesFamilyRegenDuringRemove(t *testing.T) {
+	// The regen-during-remove was racing with the post-install regen
+	// (rendering a plist without the service being reinstalled, then
+	// restarting consumers against the partial plist). Reinstall must
+	// pass SkipFamilyRegen so the install's own regen does the work
+	// once, after the new YAML is on disk.
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubPodmanRemove(t)
+	stubReinstallSeams(t)
+
+	regenCalls := 0
+	prev := removeRegenerateFamilyFn
+	removeRegenerateFamilyFn = func(string) { regenCalls++ }
+	t.Cleanup(func() { removeRegenerateFamilyFn = prev })
+
+	svc := &config.CustomService{
+		Name:          "mariadb-10-11",
+		Image:         "docker.io/library/mariadb:10.11",
+		Preset:        "mariadb",
+		PresetVersion: "10.11",
+		Family:        "mariadb",
+	}
+	if err := config.SaveCustomService(svc); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+
+	if err := ReinstallService("mariadb-10-11", false, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("ReinstallService: %v", err)
+	}
+	if regenCalls != 0 {
+		t.Errorf("RegenerateFamilyConsumers must not fire during RemoveService on the reinstall path, got %d calls", regenCalls)
+	}
+}
+
+func TestRemoveService_SkipFamilyRegen_HonoursFlag(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stubPodmanRemove(t)
+
+	regenCalls := 0
+	prev := removeRegenerateFamilyFn
+	removeRegenerateFamilyFn = func(string) { regenCalls++ }
+	t.Cleanup(func() { removeRegenerateFamilyFn = prev })
+
+	mkSvc := func(name string) {
+		svc := &config.CustomService{
+			Name:   name,
+			Image:  "docker.io/test/" + name + ":latest",
+			Family: "regen-family",
+		}
+		if err := config.SaveCustomService(svc); err != nil {
+			t.Fatalf("SaveCustomService %s: %v", name, err)
+		}
+	}
+
+	mkSvc("regen-target")
+	if err := RemoveService("regen-target", RemoveOptions{SkipFamilyRegen: true}, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("RemoveService: %v", err)
+	}
+	if regenCalls != 0 {
+		t.Errorf("SkipFamilyRegen=true should suppress regen, got %d calls", regenCalls)
+	}
+
+	mkSvc("regen-target-2")
+	if err := RemoveService("regen-target-2", RemoveOptions{}, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("RemoveService: %v", err)
+	}
+	if regenCalls != 1 {
+		t.Errorf("default RemoveOptions should regen, got %d calls", regenCalls)
+	}
+}
+
 func TestMissingPresetDependencies_BuiltinNotInstalled_Reports(t *testing.T) {
 	// Pre-fix: any IsBuiltin(dep) dep was treated as always-satisfied,
 	// so a phpmyadmin reinstall would pass validate even with mysql

--- a/internal/serviceops/reinstall_preflight_test.go
+++ b/internal/serviceops/reinstall_preflight_test.go
@@ -2,6 +2,8 @@ package serviceops
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -67,6 +69,49 @@ func TestReinstallService_PreflightPullFailure_LeavesYAMLIntact(t *testing.T) {
 	}
 }
 
+func TestMissingPresetDependencies_BuiltinNotInstalled_Reports(t *testing.T) {
+	// Pre-fix: any IsBuiltin(dep) dep was treated as always-satisfied,
+	// so a phpmyadmin reinstall would pass validate even with mysql
+	// uninstalled, then crash in EnsureServiceRunning after RemoveService
+	// had already wiped phpmyadmin. The fix: built-in deps must have a
+	// quadlet on disk to count as installed.
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	svc := &config.CustomService{
+		Name:      "phpmyadmin",
+		DependsOn: []string{"mysql"}, // mysql is a default preset (IsBuiltin true)
+	}
+	// No mysql quadlet on disk -> mysql is genuinely missing.
+	if missing := MissingPresetDependencies(svc); len(missing) != 1 || missing[0] != "mysql" {
+		t.Errorf("with no mysql quadlet, expected [mysql] missing, got %v", missing)
+	}
+}
+
+func TestMissingPresetDependencies_BuiltinInstalled_OK(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	// Materialise a lerd-mysql.container so podman.QuadletInstalled returns true.
+	quadletDir := config.QuadletDir()
+	if err := os.MkdirAll(quadletDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(quadletDir, "lerd-mysql.container"), []byte("[Container]\nImage=docker.io/library/mysql:8\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := &config.CustomService{
+		Name:      "phpmyadmin",
+		DependsOn: []string{"mysql"},
+	}
+	if missing := MissingPresetDependencies(svc); len(missing) != 0 {
+		t.Errorf("with lerd-mysql quadlet present, expected no missing deps, got %v", missing)
+	}
+}
+
 func TestCaptureReinstallSpec_UsesPresetFieldNotServiceName(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
@@ -122,12 +167,9 @@ func TestCaptureReinstallSpec_BackfillsPresetFromName_WhenYAMLLacksField(t *test
 	}
 }
 
-func TestRealReinstallInstall_CustomServicePath_RoutesViaPresetName(t *testing.T) {
-	// Verifies the bug fix: when reinstalling a non-canonical-version
-	// service, the install seam must receive spec.presetName="mariadb"
-	// (the source preset) so realReinstallInstall can call
-	// InstallPresetStreaming with the correct preset name, instead of
-	// "mariadb-10-11" which is not a preset and fails after RemoveService.
+func TestReinstallService_ForwardsPresetNameToInstallSeam(t *testing.T) {
+	// Composition-level check: ReinstallService passes spec.presetName
+	// (NOT the service name) to the install seam.
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
@@ -159,5 +201,39 @@ func TestRealReinstallInstall_CustomServicePath_RoutesViaPresetName(t *testing.T
 	}
 	if call.Version != "10.11" {
 		t.Errorf("install Version = %q, want 10.11", call.Version)
+	}
+}
+
+func TestRealReinstallInstall_CustomServicePath_CallsStreamingWithPresetName(t *testing.T) {
+	// Bug-fix coverage at the seam closest to the actual one-line fix:
+	// realReinstallInstall's custom-service branch must invoke the
+	// streaming fn with the PRESET name, not the service name. Pre-fix
+	// the call passed `name` ("mariadb-10-11") and InstallPresetStreaming
+	// errored with "unknown preset" AFTER RemoveService had run.
+	var captured struct {
+		name    string
+		version string
+	}
+	prev := reinstallStreamingFn
+	reinstallStreamingFn = func(name, version string, emit func(PhaseEvent)) (*config.CustomService, error) {
+		captured.name = name
+		captured.version = version
+		return &config.CustomService{Name: name}, nil
+	}
+	t.Cleanup(func() { reinstallStreamingFn = prev })
+
+	spec := reinstallSpec{
+		presetName: "mariadb",
+		version:    "10.11",
+		image:      "docker.io/library/mariadb:10.11",
+	}
+	if _, err := realReinstallInstall("mariadb-10-11", spec, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("realReinstallInstall: %v", err)
+	}
+	if captured.name != "mariadb" {
+		t.Errorf("streaming fn name = %q, want %q (preset name, NOT service name)", captured.name, "mariadb")
+	}
+	if captured.version != "10.11" {
+		t.Errorf("streaming fn version = %q, want %q", captured.version, "10.11")
 	}
 }

--- a/internal/serviceops/reinstall_test.go
+++ b/internal/serviceops/reinstall_test.go
@@ -10,10 +10,11 @@ import (
 // stubReinstallSeams swaps the install/reprovision seams so the test exercises
 // only ReinstallService's composition logic without hitting podman.
 type reinstallRecorder struct {
-	installCalls []reinstallCall
-	reprovCalls  []string
-	installErr   error
-	reprovErr    error
+	installCalls     []reinstallCall
+	reprovCalls      []string
+	familyRegenCalls []string
+	installErr       error
+	reprovErr        error
 }
 type reinstallCall struct {
 	Name       string
@@ -29,6 +30,7 @@ func stubReinstallSeams(t *testing.T) *reinstallRecorder {
 	prevReprov := reinstallReprovFn
 	prevValidate := reinstallValidateFn
 	prevPrefetch := reinstallPrefetchImageFn
+	prevFamilyRegen := reinstallFamilyRegenFn
 	reinstallInstallFn = func(name string, spec reinstallSpec, emit func(PhaseEvent)) (*config.CustomService, error) {
 		rec.installCalls = append(rec.installCalls, reinstallCall{Name: name, PresetName: spec.presetName, Version: spec.version})
 		emit(PhaseEvent{Phase: "starting_unit"})
@@ -42,11 +44,14 @@ func stubReinstallSeams(t *testing.T) *reinstallRecorder {
 	// composition tests don't care about them, so stub to permissive no-ops.
 	reinstallValidateFn = func(string, reinstallSpec) error { return nil }
 	reinstallPrefetchImageFn = func(string, func(PhaseEvent)) error { return nil }
+	// Family regen would otherwise touch real podman / real preset bundle.
+	reinstallFamilyRegenFn = func(name string) { rec.familyRegenCalls = append(rec.familyRegenCalls, name) }
 	t.Cleanup(func() {
 		reinstallInstallFn = prevInstall
 		reinstallReprovFn = prevReprov
 		reinstallValidateFn = prevValidate
 		reinstallPrefetchImageFn = prevPrefetch
+		reinstallFamilyRegenFn = prevFamilyRegen
 	})
 	return rec
 }

--- a/internal/serviceops/reinstall_test.go
+++ b/internal/serviceops/reinstall_test.go
@@ -16,8 +16,9 @@ type reinstallRecorder struct {
 	reprovErr    error
 }
 type reinstallCall struct {
-	Name    string
-	Version string
+	Name       string
+	PresetName string
+	Version    string
 }
 
 func stubReinstallSeams(t *testing.T) *reinstallRecorder {
@@ -26,8 +27,10 @@ func stubReinstallSeams(t *testing.T) *reinstallRecorder {
 
 	prevInstall := reinstallInstallFn
 	prevReprov := reinstallReprovFn
+	prevValidate := reinstallValidateFn
+	prevPrefetch := reinstallPrefetchImageFn
 	reinstallInstallFn = func(name string, spec reinstallSpec, emit func(PhaseEvent)) (*config.CustomService, error) {
-		rec.installCalls = append(rec.installCalls, reinstallCall{Name: name, Version: spec.version})
+		rec.installCalls = append(rec.installCalls, reinstallCall{Name: name, PresetName: spec.presetName, Version: spec.version})
 		emit(PhaseEvent{Phase: "starting_unit"})
 		return &config.CustomService{Name: name}, rec.installErr
 	}
@@ -35,9 +38,15 @@ func stubReinstallSeams(t *testing.T) *reinstallRecorder {
 		rec.reprovCalls = append(rec.reprovCalls, name)
 		return rec.reprovErr
 	}
+	// Pre-flight checks talk to the real preset bundle and podman; the
+	// composition tests don't care about them, so stub to permissive no-ops.
+	reinstallValidateFn = func(string, reinstallSpec) error { return nil }
+	reinstallPrefetchImageFn = func(string, func(PhaseEvent)) error { return nil }
 	t.Cleanup(func() {
 		reinstallInstallFn = prevInstall
 		reinstallReprovFn = prevReprov
+		reinstallValidateFn = prevValidate
+		reinstallPrefetchImageFn = prevPrefetch
 	})
 	return rec
 }

--- a/internal/serviceops/remove.go
+++ b/internal/serviceops/remove.go
@@ -23,12 +23,13 @@ type RemoveOptions struct {
 	RemoveData bool
 
 	// SkipFamilyRegen suppresses the post-remove RegenerateFamilyConsumers
-	// pass. Set by reinstall, where the regen-during-remove would render a
-	// plist that doesn't include the service being reinstalled, briefly
-	// restart consumers against the partial plist, and lose to the second
-	// regen on certain timings (slow launchctl bootout, podman socket
-	// flake). The reinstall path lets the subsequent install's own regen
-	// do the work once, after the new YAML is on disk.
+	// pass. Set by ReinstallService, which then drives the regen itself
+	// after install: InstallPresetByName regenerates internally for custom
+	// services, while default-preset and failure paths call regen
+	// explicitly. The regen-during-remove was racing the post-install
+	// regen on macOS (launchctl bootout/bootstrap can fall through to
+	// kickstart which doesn't re-read the plist), leaving consumers on
+	// the partial plist.
 	SkipFamilyRegen bool
 }
 

--- a/internal/serviceops/remove.go
+++ b/internal/serviceops/remove.go
@@ -21,6 +21,15 @@ type RemoveOptions struct {
 	// On EXDEV the helper falls back to copy-tree + delete so the
 	// recoverability promise holds across filesystems too.
 	RemoveData bool
+
+	// SkipFamilyRegen suppresses the post-remove RegenerateFamilyConsumers
+	// pass. Set by reinstall, where the regen-during-remove would render a
+	// plist that doesn't include the service being reinstalled, briefly
+	// restart consumers against the partial plist, and lose to the second
+	// regen on certain timings (slow launchctl bootout, podman socket
+	// flake). The reinstall path lets the subsequent install's own regen
+	// do the work once, after the new YAML is on disk.
+	SkipFamilyRegen bool
 }
 
 // Internal seams so tests can swap out the real podman calls. The defaults
@@ -30,6 +39,11 @@ var (
 	removeContainerFn  = podman.RemoveContainer
 	removeQuadletFn    = podman.RemoveQuadlet
 	removeUnitStatusFn = podman.UnitStatus
+
+	// removeRegenerateFamilyFn lets tests observe whether the regen pass
+	// fired without spinning up a real consumer. Defaults to the real
+	// RegenerateFamilyConsumers.
+	removeRegenerateFamilyFn = RegenerateFamilyConsumers
 
 	// osRenameFn is the rename seam used by renameDataAside. Tests swap it
 	// to inject EXDEV without needing two filesystems.
@@ -92,8 +106,8 @@ func RemoveService(name string, opts RemoveOptions, emit func(PhaseEvent)) error
 	}
 
 	emit(PhaseEvent{Phase: "regenerating_consumers"})
-	if family != "" {
-		RegenerateFamilyConsumers(family)
+	if family != "" && !opts.SkipFamilyRegen {
+		removeRegenerateFamilyFn(family)
 	}
 
 	emit(PhaseEvent{Phase: "done"})

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -118,12 +118,20 @@ func InstallPresetByName(name, version string) (*config.CustomService, error) {
 }
 
 // MissingPresetDependencies returns the names of services that svc declares
-// in depends_on but which are neither built-in nor already installed as
-// custom services.
+// in depends_on but which are not currently installed. A built-in (default
+// preset) counts as installed only when its quadlet is on disk: the legacy
+// "built-ins are always available" assumption broke once
+// `lerd service remove <builtin>` shipped, and a dependent install that
+// later hits EnsureServiceRunning on a missing built-in would fail with no
+// rollback (which is exactly what reinstall pre-flight is meant to prevent).
 func MissingPresetDependencies(svc *config.CustomService) []string {
 	var missing []string
 	for _, dep := range svc.DependsOn {
 		if IsBuiltin(dep) {
+			if podman.QuadletInstalled("lerd-" + dep) {
+				continue
+			}
+			missing = append(missing, dep)
 			continue
 		}
 		if _, err := config.LoadCustomService(dep); err == nil {


### PR DESCRIPTION
Three issues in `lerd service reinstall <name>` (reported in https://github.com/geodro/lerd/discussions/414).

Routing: custom-service reinstalls passed the SERVICE name (mariadb-10-11) to InstallPresetStreaming, which expects the PRESET name (mariadb). The reinstall failed with "unknown preset mariadb-10-11" after RemoveService had deleted the YAML. Fixed by reading CustomService.Preset in captureReinstallSpec and routing via spec.presetName.

Non-transactional: preset/version/dep errors and image-pull failures fired after RemoveService. Pre-flight now replays the install path's checks (LoadPreset, version resolve mirroring each install path, MissingPresetDependencies, single-version sanity) and pre-pulls the image. MissingPresetDependencies also stops treating built-ins as always-satisfied, since `lerd service remove <builtin>` can leave a default preset uninstalled.

Family-consumer regen race: reinstalling a family member used to restart phpmyadmin twice, once during RemoveService against a partial plist (target YAML just deleted), once after InstallPresetByName with the correct plist. On macOS the second restart can race with launchctl bootout/bootstrap and fall through to a kickstart that doesn't re-read the plist, leaving the partial plist running. RemoveOptions.SkipFamilyRegen suppresses the during-Remove pass; ReinstallService drives the regen itself (default-preset success and install-failure paths) so consumers see exactly one restart with on-disk state.

Verified with mariadb-10-11: single phpmyadmin restart, PMA_HOSTS=lerd-mariadb-10-11,lerd-mariadb-11,lerd-mysql correct first try.