### PR TITLE
fix(lan): preflight DNS forwarder port before installing the unit

### DIFF
--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -98,6 +99,11 @@ func EnableLANExposure(progress LANProgressFunc) (lanIP string, err error) {
 
 		emit("Restarting lerd-dns")
 		if err := reloadAndRestartUnit("lerd-dns"); err != nil {
+			return "", err
+		}
+
+		emit("Pre-flight: checking " + lanIP + ":5300 is free")
+		if err := preflightForwarderPort(lanIP); err != nil {
 			return "", err
 		}
 
@@ -215,6 +221,70 @@ func regenerateLANContainerQuadlets(progress LANProgressFunc) error {
 		_ = services.Mgr.Restart(name)
 	}
 	return nil
+}
+
+// Seams for preflightForwarderPort so the logic can be unit-tested
+// without binding real ports, spawning lsof, or depending on services.Mgr.
+var (
+	forwarderUnitStatusFn = func() string {
+		s, _ := services.Mgr.UnitStatus("lerd-dns-forwarder")
+		return s
+	}
+	forwarderPortFreeFn   = forwarderPortFree
+	forwarderPortHolderFn = forwarderPortHolderLsof
+)
+
+// preflightForwarderPort refuses to install the LAN DNS forwarder when
+// something else (typically a legacy host-side dnsmasq) already owns
+// lanIP:5300. Without this check the launchd plist would write fine,
+// then the daemon would race against the existing holder on every boot.
+// Skipped when our own forwarder is already active: that's the
+// re-run-of-lan-expose case where the existing unit will be replaced.
+func preflightForwarderPort(lanIP string) error {
+	if s := forwarderUnitStatusFn(); s == "active" || s == "activating" {
+		return nil
+	}
+	if forwarderPortFreeFn(lanIP) {
+		return nil
+	}
+	holder := forwarderPortHolderFn(lanIP)
+	return fmt.Errorf("%s:5300 is already in use; lerd cannot install the LAN DNS forwarder.\n%s\nStop the conflicting service (or rebind it off port 5300) and re-run `lerd lan expose`", lanIP, holder)
+}
+
+// forwarderPortFree returns true when both UDP and TCP on lanIP:5300 are
+// free to bind. Best-effort: a transient bind in a SO_REUSEPORT-friendly
+// process can still slip through, but covers the common case of a
+// long-running dnsmasq holding the address.
+func forwarderPortFree(lanIP string) bool {
+	addr := lanIP + ":5300"
+	if conn, err := net.ListenPacket("udp", addr); err == nil {
+		conn.Close()
+	} else {
+		return false
+	}
+	if l, err := net.Listen("tcp", addr); err == nil {
+		l.Close()
+	} else {
+		return false
+	}
+	return true
+}
+
+// forwarderPortHolderLsof shells out to lsof to identify the conflicting
+// process. Works on both macOS and Linux. Returns a fallback hint when
+// lsof isn't present or returns nothing.
+func forwarderPortHolderLsof(lanIP string) string {
+	cmd := exec.Command("lsof", "-nP", "-iUDP@"+lanIP+":5300", "-iTCP@"+lanIP+":5300")
+	out, err := cmd.CombinedOutput()
+	trimmed := strings.TrimSpace(string(out))
+	if err != nil || trimmed == "" {
+		return "  (could not identify the holder; try: sudo lsof -nP -i :5300)"
+	}
+	var lines []string
+	for _, line := range strings.Split(trimmed, "\n") {
+		lines = append(lines, "  "+line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // installDNSForwarderUnit writes the user service that runs the

--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -104,8 +104,7 @@ func EnableLANExposure(progress LANProgressFunc) (lanIP string, err error) {
 			return "", err
 		}
 
-		emit("Pre-flight: checking " + lanIP + ":5300 is free")
-		if err := preflightForwarderPort(lanIP); err != nil {
+		if err := preflightForwarderPort(lanIP, emit); err != nil {
 			return "", err
 		}
 
@@ -243,11 +242,19 @@ const forwarderPort = 5300
 // something else (typically a legacy host-side dnsmasq) already owns
 // lanIP:5300. Without this check the launchd plist would write fine,
 // then the daemon would race against the existing holder on every boot.
-// Skipped when our own forwarder is already active: that's the
-// re-run-of-lan-expose case where the existing unit will be replaced.
-func preflightForwarderPort(lanIP string) error {
-	if s := forwarderUnitStatusFn(); s == "active" || s == "activating" {
+// Skipped when our own forwarder is already active or activating: that's
+// the re-run-of-lan-expose case where the existing unit will be replaced.
+// emit may be nil; when set it receives one user-visible progress line
+// describing the path taken.
+func preflightForwarderPort(lanIP string, emit func(string)) error {
+	if s := forwarderUnitStatusFn(); s == "active" || s == "activating" || s == "deactivating" {
+		if emit != nil {
+			emit("Pre-flight: lerd-dns-forwarder is " + s + "; skipping port check")
+		}
 		return nil
+	}
+	if emit != nil {
+		emit(fmt.Sprintf("Pre-flight: checking %s:%d is free", lanIP, forwarderPort))
 	}
 	if forwarderPortFreeFn(lanIP, forwarderPort) {
 		return nil
@@ -261,7 +268,7 @@ func preflightForwarderPort(lanIP string) error {
 // bound port with our probe and slip through; covers the common case of
 // a long-running dnsmasq holding the address.
 func forwarderPortFree(host string, port int) bool {
-	addr := host + ":" + strconv.Itoa(port)
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
 	if conn, err := net.ListenPacket("udp", addr); err == nil {
 		conn.Close()
 	} else {
@@ -276,13 +283,13 @@ func forwarderPortFree(host string, port int) bool {
 }
 
 // forwarderPortHolderLsof shells out to lsof to identify the conflicting
-// process. Works on both macOS and Linux when lsof is installed; falls
-// back to a per-platform suggestion (ss on Linux, lsof on macOS) when
-// lsof is missing or returns nothing.
+// process. Uses stdout only so transient lsof stderr warnings don't
+// leak into the user-facing error. Falls back to a per-platform hint
+// when lsof is missing or returns nothing.
 func forwarderPortHolderLsof(host string, port int) string {
-	addr := host + ":" + strconv.Itoa(port)
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
 	cmd := exec.Command("lsof", "-nP", "-iUDP@"+addr, "-iTCP@"+addr)
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	trimmed := strings.TrimSpace(string(out))
 	if err == nil && trimmed != "" {
 		var lines []string
@@ -291,7 +298,14 @@ func forwarderPortHolderLsof(host string, port int) string {
 		}
 		return strings.Join(lines, "\n")
 	}
-	if runtime.GOOS == "linux" {
+	return forwarderHolderFallbackHint(runtime.GOOS, port)
+}
+
+// forwarderHolderFallbackHint returns the per-OS suggestion shown when
+// lsof can't identify the conflicting process. Factored out so both
+// branches can be unit-tested from any build host.
+func forwarderHolderFallbackHint(goos string, port int) string {
+	if goos == "linux" {
 		return fmt.Sprintf("  (could not identify the holder; try: sudo ss -tulpn | grep ':%d')", port)
 	}
 	return fmt.Sprintf("  (could not identify the holder; try: sudo lsof -nP -i :%d)", port)

--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
@@ -234,6 +236,9 @@ var (
 	forwarderPortHolderFn = forwarderPortHolderLsof
 )
 
+// forwarderPort is the host port lerd-dns-forwarder listens on.
+const forwarderPort = 5300
+
 // preflightForwarderPort refuses to install the LAN DNS forwarder when
 // something else (typically a legacy host-side dnsmasq) already owns
 // lanIP:5300. Without this check the launchd plist would write fine,
@@ -244,19 +249,19 @@ func preflightForwarderPort(lanIP string) error {
 	if s := forwarderUnitStatusFn(); s == "active" || s == "activating" {
 		return nil
 	}
-	if forwarderPortFreeFn(lanIP) {
+	if forwarderPortFreeFn(lanIP, forwarderPort) {
 		return nil
 	}
-	holder := forwarderPortHolderFn(lanIP)
-	return fmt.Errorf("%s:5300 is already in use; lerd cannot install the LAN DNS forwarder.\n%s\nStop the conflicting service (or rebind it off port 5300) and re-run `lerd lan expose`", lanIP, holder)
+	holder := forwarderPortHolderFn(lanIP, forwarderPort)
+	return fmt.Errorf("%s:%d is already in use; lerd cannot install the LAN DNS forwarder.\n%s\nStop the conflicting service (or rebind it off port %d) and re-run `lerd lan expose`", lanIP, forwarderPort, holder, forwarderPort)
 }
 
-// forwarderPortFree returns true when both UDP and TCP on lanIP:5300 are
-// free to bind. Best-effort: a transient bind in a SO_REUSEPORT-friendly
-// process can still slip through, but covers the common case of a
-// long-running dnsmasq holding the address.
-func forwarderPortFree(lanIP string) bool {
-	addr := lanIP + ":5300"
+// forwarderPortFree returns true when both UDP and TCP on host:port are
+// free to bind. Best-effort: a process using SO_REUSEPORT can share a
+// bound port with our probe and slip through; covers the common case of
+// a long-running dnsmasq holding the address.
+func forwarderPortFree(host string, port int) bool {
+	addr := host + ":" + strconv.Itoa(port)
 	if conn, err := net.ListenPacket("udp", addr); err == nil {
 		conn.Close()
 	} else {
@@ -271,20 +276,25 @@ func forwarderPortFree(lanIP string) bool {
 }
 
 // forwarderPortHolderLsof shells out to lsof to identify the conflicting
-// process. Works on both macOS and Linux. Returns a fallback hint when
-// lsof isn't present or returns nothing.
-func forwarderPortHolderLsof(lanIP string) string {
-	cmd := exec.Command("lsof", "-nP", "-iUDP@"+lanIP+":5300", "-iTCP@"+lanIP+":5300")
+// process. Works on both macOS and Linux when lsof is installed; falls
+// back to a per-platform suggestion (ss on Linux, lsof on macOS) when
+// lsof is missing or returns nothing.
+func forwarderPortHolderLsof(host string, port int) string {
+	addr := host + ":" + strconv.Itoa(port)
+	cmd := exec.Command("lsof", "-nP", "-iUDP@"+addr, "-iTCP@"+addr)
 	out, err := cmd.CombinedOutput()
 	trimmed := strings.TrimSpace(string(out))
-	if err != nil || trimmed == "" {
-		return "  (could not identify the holder; try: sudo lsof -nP -i :5300)"
+	if err == nil && trimmed != "" {
+		var lines []string
+		for _, line := range strings.Split(trimmed, "\n") {
+			lines = append(lines, "  "+line)
+		}
+		return strings.Join(lines, "\n")
 	}
-	var lines []string
-	for _, line := range strings.Split(trimmed, "\n") {
-		lines = append(lines, "  "+line)
+	if runtime.GOOS == "linux" {
+		return fmt.Sprintf("  (could not identify the holder; try: sudo ss -tulpn | grep ':%d')", port)
 	}
-	return strings.Join(lines, "\n")
+	return fmt.Sprintf("  (could not identify the holder; try: sudo lsof -nP -i :%d)", port)
 }
 
 // installDNSForwarderUnit writes the user service that runs the

--- a/internal/cli/dns_preflight_test.go
+++ b/internal/cli/dns_preflight_test.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPreflightForwarderPort_OwnUnitActiveSkipsCheck(t *testing.T) {
+	prevStatus := forwarderUnitStatusFn
+	prevFree := forwarderPortFreeFn
+	prevHolder := forwarderPortHolderFn
+	t.Cleanup(func() {
+		forwarderUnitStatusFn = prevStatus
+		forwarderPortFreeFn = prevFree
+		forwarderPortHolderFn = prevHolder
+	})
+
+	forwarderUnitStatusFn = func() string { return "active" }
+	// The port check should never be reached when our own unit is active.
+	forwarderPortFreeFn = func(string) bool {
+		t.Error("forwarderPortFreeFn must not be called when our forwarder is active")
+		return true
+	}
+	forwarderPortHolderFn = func(string) string {
+		t.Error("forwarderPortHolderFn must not be called when our forwarder is active")
+		return ""
+	}
+
+	if err := preflightForwarderPort("192.168.1.10"); err != nil {
+		t.Errorf("preflight should pass when our forwarder is active, got %v", err)
+	}
+}
+
+func TestPreflightForwarderPort_PortFreeReturnsNil(t *testing.T) {
+	prevStatus := forwarderUnitStatusFn
+	prevFree := forwarderPortFreeFn
+	t.Cleanup(func() {
+		forwarderUnitStatusFn = prevStatus
+		forwarderPortFreeFn = prevFree
+	})
+
+	forwarderUnitStatusFn = func() string { return "inactive" }
+	forwarderPortFreeFn = func(string) bool { return true }
+
+	if err := preflightForwarderPort("192.168.1.10"); err != nil {
+		t.Errorf("preflight should pass when port is free, got %v", err)
+	}
+}
+
+func TestPreflightForwarderPort_PortInUseSurfacesHolder(t *testing.T) {
+	prevStatus := forwarderUnitStatusFn
+	prevFree := forwarderPortFreeFn
+	prevHolder := forwarderPortHolderFn
+	t.Cleanup(func() {
+		forwarderUnitStatusFn = prevStatus
+		forwarderPortFreeFn = prevFree
+		forwarderPortHolderFn = prevHolder
+	})
+
+	forwarderUnitStatusFn = func() string { return "inactive" }
+	forwarderPortFreeFn = func(string) bool { return false }
+	forwarderPortHolderFn = func(lanIP string) string {
+		return "  dnsmasq    1234 root  6u  IPv4  0x0  UDP " + lanIP + ":5300"
+	}
+
+	err := preflightForwarderPort("192.168.1.10")
+	if err == nil {
+		t.Fatal("expected preflight to fail when port is in use")
+	}
+	msg := err.Error()
+	for _, want := range []string{"192.168.1.10:5300", "already in use", "dnsmasq", "lerd lan expose"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q\nfull message: %s", want, msg)
+		}
+	}
+}
+
+func TestForwarderPortFree_BoundUDPDetectedAsInUse(t *testing.T) {
+	// Bind UDP on loopback:5300 ourselves. The check probes UDP first, so
+	// it should report the port as taken.
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("could not bind a UDP port for the test: %v", err)
+	}
+	defer conn.Close()
+	addr := conn.LocalAddr().(*net.UDPAddr)
+
+	// forwarderPortFree probes the hardcoded :5300 port, so we have to
+	// inject a host:port via a test variant. Inline the same logic against
+	// our chosen port to exercise the same code path.
+	free := func(host string, port int) bool {
+		probe := host + ":" + strconv.Itoa(port)
+		if c, err := net.ListenPacket("udp", probe); err == nil {
+			c.Close()
+		} else {
+			return false
+		}
+		if l, err := net.Listen("tcp", probe); err == nil {
+			l.Close()
+		} else {
+			return false
+		}
+		return true
+	}
+	if free("127.0.0.1", addr.Port) {
+		t.Errorf("expected port %d to read as taken while we hold it", addr.Port)
+	}
+}

--- a/internal/cli/dns_preflight_test.go
+++ b/internal/cli/dns_preflight_test.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"net"
-	"strconv"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -18,12 +18,11 @@ func TestPreflightForwarderPort_OwnUnitActiveSkipsCheck(t *testing.T) {
 	})
 
 	forwarderUnitStatusFn = func() string { return "active" }
-	// The port check should never be reached when our own unit is active.
-	forwarderPortFreeFn = func(string) bool {
+	forwarderPortFreeFn = func(string, int) bool {
 		t.Error("forwarderPortFreeFn must not be called when our forwarder is active")
 		return true
 	}
-	forwarderPortHolderFn = func(string) string {
+	forwarderPortHolderFn = func(string, int) string {
 		t.Error("forwarderPortHolderFn must not be called when our forwarder is active")
 		return ""
 	}
@@ -42,7 +41,7 @@ func TestPreflightForwarderPort_PortFreeReturnsNil(t *testing.T) {
 	})
 
 	forwarderUnitStatusFn = func() string { return "inactive" }
-	forwarderPortFreeFn = func(string) bool { return true }
+	forwarderPortFreeFn = func(string, int) bool { return true }
 
 	if err := preflightForwarderPort("192.168.1.10"); err != nil {
 		t.Errorf("preflight should pass when port is free, got %v", err)
@@ -60,9 +59,9 @@ func TestPreflightForwarderPort_PortInUseSurfacesHolder(t *testing.T) {
 	})
 
 	forwarderUnitStatusFn = func() string { return "inactive" }
-	forwarderPortFreeFn = func(string) bool { return false }
-	forwarderPortHolderFn = func(lanIP string) string {
-		return "  dnsmasq    1234 root  6u  IPv4  0x0  UDP " + lanIP + ":5300"
+	forwarderPortFreeFn = func(string, int) bool { return false }
+	forwarderPortHolderFn = func(host string, port int) string {
+		return "  dnsmasq    1234 root  6u  IPv4  0x0  UDP " + host + ":5300"
 	}
 
 	err := preflightForwarderPort("192.168.1.10")
@@ -77,34 +76,55 @@ func TestPreflightForwarderPort_PortInUseSurfacesHolder(t *testing.T) {
 	}
 }
 
-func TestForwarderPortFree_BoundUDPDetectedAsInUse(t *testing.T) {
-	// Bind UDP on loopback:5300 ourselves. The check probes UDP first, so
-	// it should report the port as taken.
+func TestForwarderPortFree_DetectsBoundUDP(t *testing.T) {
 	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
 	if err != nil {
 		t.Skipf("could not bind a UDP port for the test: %v", err)
 	}
 	defer conn.Close()
-	addr := conn.LocalAddr().(*net.UDPAddr)
+	port := conn.LocalAddr().(*net.UDPAddr).Port
 
-	// forwarderPortFree probes the hardcoded :5300 port, so we have to
-	// inject a host:port via a test variant. Inline the same logic against
-	// our chosen port to exercise the same code path.
-	free := func(host string, port int) bool {
-		probe := host + ":" + strconv.Itoa(port)
-		if c, err := net.ListenPacket("udp", probe); err == nil {
-			c.Close()
-		} else {
-			return false
-		}
-		if l, err := net.Listen("tcp", probe); err == nil {
-			l.Close()
-		} else {
-			return false
-		}
-		return true
+	if forwarderPortFree("127.0.0.1", port) {
+		t.Errorf("expected forwarderPortFree to report port %d as taken", port)
 	}
-	if free("127.0.0.1", addr.Port) {
-		t.Errorf("expected port %d to read as taken while we hold it", addr.Port)
+}
+
+func TestForwarderPortFree_DetectsBoundTCP(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("could not bind a TCP port for the test: %v", err)
+	}
+	defer l.Close()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	if forwarderPortFree("127.0.0.1", port) {
+		t.Errorf("expected forwarderPortFree to report TCP-bound port %d as taken", port)
+	}
+}
+
+func TestForwarderPortFree_FreePortReturnsTrue(t *testing.T) {
+	// Get a free port by binding, reading the port, closing.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("could not pick a free port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
+	if !forwarderPortFree("127.0.0.1", port) {
+		t.Errorf("expected just-released port %d to read as free", port)
+	}
+}
+
+func TestForwarderPortHolderLsof_FallbackHintTailoredByOS(t *testing.T) {
+	// We can't reliably force lsof to fail / succeed in a unit test, but
+	// we can verify the fallback string for a port that's almost certainly
+	// not bound (so lsof returns empty and we hit the fallback branch).
+	hint := forwarderPortHolderLsof("203.0.113.0", 65500)
+	if runtime.GOOS == "linux" && !strings.Contains(hint, "ss -tulpn") {
+		t.Errorf("Linux fallback should suggest ss, got %q", hint)
+	}
+	if runtime.GOOS == "darwin" && !strings.Contains(hint, "lsof") {
+		t.Errorf("macOS fallback should suggest lsof, got %q", hint)
 	}
 }

--- a/internal/cli/dns_preflight_test.go
+++ b/internal/cli/dns_preflight_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"net"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -27,8 +26,33 @@ func TestPreflightForwarderPort_OwnUnitActiveSkipsCheck(t *testing.T) {
 		return ""
 	}
 
-	if err := preflightForwarderPort("192.168.1.10"); err != nil {
+	var events []string
+	emit := func(s string) { events = append(events, s) }
+
+	if err := preflightForwarderPort("192.168.1.10", emit); err != nil {
 		t.Errorf("preflight should pass when our forwarder is active, got %v", err)
+	}
+	if len(events) == 0 || !strings.Contains(events[0], "skipping port check") {
+		t.Errorf("expected progress message to mention skipped port check, got %v", events)
+	}
+}
+
+func TestPreflightForwarderPort_DeactivatingAlsoSkipsCheck(t *testing.T) {
+	prevStatus := forwarderUnitStatusFn
+	prevFree := forwarderPortFreeFn
+	t.Cleanup(func() {
+		forwarderUnitStatusFn = prevStatus
+		forwarderPortFreeFn = prevFree
+	})
+
+	forwarderUnitStatusFn = func() string { return "deactivating" }
+	forwarderPortFreeFn = func(string, int) bool {
+		t.Error("port check must not run while our own forwarder is deactivating")
+		return true
+	}
+
+	if err := preflightForwarderPort("192.168.1.10", nil); err != nil {
+		t.Errorf("deactivating status should skip the port check, got %v", err)
 	}
 }
 
@@ -43,8 +67,12 @@ func TestPreflightForwarderPort_PortFreeReturnsNil(t *testing.T) {
 	forwarderUnitStatusFn = func() string { return "inactive" }
 	forwarderPortFreeFn = func(string, int) bool { return true }
 
-	if err := preflightForwarderPort("192.168.1.10"); err != nil {
+	var events []string
+	if err := preflightForwarderPort("192.168.1.10", func(s string) { events = append(events, s) }); err != nil {
 		t.Errorf("preflight should pass when port is free, got %v", err)
+	}
+	if len(events) != 1 || !strings.Contains(events[0], "192.168.1.10:5300") {
+		t.Errorf("expected one probe progress line mentioning the address, got %v", events)
 	}
 }
 
@@ -64,7 +92,7 @@ func TestPreflightForwarderPort_PortInUseSurfacesHolder(t *testing.T) {
 		return "  dnsmasq    1234 root  6u  IPv4  0x0  UDP " + host + ":5300"
 	}
 
-	err := preflightForwarderPort("192.168.1.10")
+	err := preflightForwarderPort("192.168.1.10", nil)
 	if err == nil {
 		t.Fatal("expected preflight to fail when port is in use")
 	}
@@ -103,7 +131,6 @@ func TestForwarderPortFree_DetectsBoundTCP(t *testing.T) {
 }
 
 func TestForwarderPortFree_FreePortReturnsTrue(t *testing.T) {
-	// Get a free port by binding, reading the port, closing.
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Skipf("could not pick a free port: %v", err)
@@ -116,15 +143,38 @@ func TestForwarderPortFree_FreePortReturnsTrue(t *testing.T) {
 	}
 }
 
-func TestForwarderPortHolderLsof_FallbackHintTailoredByOS(t *testing.T) {
-	// We can't reliably force lsof to fail / succeed in a unit test, but
-	// we can verify the fallback string for a port that's almost certainly
-	// not bound (so lsof returns empty and we hit the fallback branch).
-	hint := forwarderPortHolderLsof("203.0.113.0", 65500)
-	if runtime.GOOS == "linux" && !strings.Contains(hint, "ss -tulpn") {
-		t.Errorf("Linux fallback should suggest ss, got %q", hint)
+func TestForwarderPortFree_IPv6HostBracketedCorrectly(t *testing.T) {
+	// net.JoinHostPort must bracket the IPv6 host; without it the
+	// ListenPacket call would fail to parse the address and we'd
+	// report "taken" for an actually-free port.
+	if !forwarderPortFree("::1", 0) {
+		// Port 0 → kernel-assigned, always free. If JoinHostPort wasn't
+		// applied we'd get a parse error here.
+		t.Errorf("expected IPv6 loopback with kernel-assigned port to read as free")
 	}
-	if runtime.GOOS == "darwin" && !strings.Contains(hint, "lsof") {
-		t.Errorf("macOS fallback should suggest lsof, got %q", hint)
+}
+
+func TestForwarderHolderFallbackHint(t *testing.T) {
+	cases := []struct {
+		name     string
+		goos     string
+		port     int
+		wantSub  string
+		wantPort string
+	}{
+		{"linux suggests ss", "linux", 5300, "ss -tulpn", ":5300"},
+		{"darwin suggests lsof", "darwin", 5300, "lsof", ":5300"},
+		{"other OS falls back to lsof", "freebsd", 42, "lsof", ":42"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := forwarderHolderFallbackHint(c.goos, c.port)
+			if !strings.Contains(got, c.wantSub) {
+				t.Errorf("hint for %q missing %q: %s", c.goos, c.wantSub, got)
+			}
+			if !strings.Contains(got, c.wantPort) {
+				t.Errorf("hint for %q missing port substring %q: %s", c.goos, c.wantPort, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
`lerd lan expose` installed lerd-dns-forwarder (listening on lanIP:5300) without checking whether the address was already taken. On hosts running their own dnsmasq via Homebrew/launchd or a sibling tool, the new unit wrote fine and both daemons raced for the same address on every boot. Reported in https://github.com/geodro/lerd/discussions/414.

Pre-flight now tries to bind UDP and TCP on lanIP:5300 (via net.JoinHostPort, IPv6-safe). If either fails the install is refused with a clear error and the lsof output identifying the conflicting process. The probe is skipped when lerd's own forwarder is already active, activating, or deactivating so toggling lan expose is clean. When lsof is unavailable the fallback hint is tailored per OS: `ss -tulpn | grep ':5300'` on Linux, `lsof -nP -i :5300` on macOS.

Verified end-to-end on macOS against a real legacy dnsmasq holding 192.168.0.105:5300. Preflight refused with the dnsmasq pid and rows from lsof; `lerd lan unexpose` cleanly reverted the partial state.