### PR TITLE
fix(nginx): preserve user edits to _default.conf across lerd start

### DIFF
--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -767,19 +767,23 @@ func EnsureDefaultVhost() error {
 	onDiskHash := contentHashHex(onDisk)
 	lastWritten := strings.TrimSpace(readFileOrEmpty(sentinelPath))
 	if lastWritten == "" {
-		// Sentinel missing (deleted by user, or a prior sentinel-write
-		// crashed). If the file's content matches the canonical bytes
-		// lerd would write, treat it as ours and re-record the sentinel
-		// so subsequent runs can tell managed from edited. Otherwise
-		// it's effectively user-managed.
+		// Sentinel missing. Three plausible causes:
+		//   1. Sentinel-write crashed on a prior run (file content is
+		//      lerd's canonical → reclaim by writing the sentinel).
+		//   2. User upgraded from a pre-sentinel lerd binary; on-disk
+		//      content is OLD lerd's template, which the user may not
+		//      have edited but we can't tell apart from a real edit.
+		//   3. User has hand-edited the file.
+		// Cases 2 and 3 are indistinguishable, so we preserve and tell
+		// the user how to opt back in to lerd's catch-all if they want it.
 		if onDiskHash == canonicalHash {
 			return os.WriteFile(sentinelPath, []byte(canonicalHash), 0644)
 		}
-		fmt.Printf("  [INFO] preserving user-modified %s; remove the file to re-enable lerd's catch-all\n", path)
+		fmt.Printf("  [INFO] %s has no lerd sentinel; preserving on-disk content. If this is from a lerd upgrade and you haven't edited it, run: rm %s\n", path, path)
 		return nil
 	}
 	if lastWritten != onDiskHash {
-		fmt.Printf("  [INFO] preserving user-modified %s; remove the file to re-enable lerd's catch-all\n", path)
+		fmt.Printf("  [INFO] %s differs from lerd's recorded last-write; preserving your edits. Remove the file to restore lerd's catch-all.\n", path)
 		return nil
 	}
 	if onDiskHash == canonicalHash {

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -2,6 +2,9 @@ package nginx
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -718,6 +721,12 @@ func hasMissingCert(content, certsDir string) bool {
 	return false
 }
 
+// defaultVhostManagedHashSuffix is appended to the conf filename to form
+// a sentinel that records the sha256 of what lerd last wrote. nginx
+// ignores files that don't match its `*.conf` include glob, so the
+// sentinel stays out of the way.
+const defaultVhostManagedHashSuffix = ".lerd-managed-hash"
+
 // EnsureDefaultVhost writes a catch-all default server that shows a branded
 // error page for any HTTP request that doesn't match a registered site. For
 // HTTPS we cannot serve a real catch-all because browsers (Chrome especially)
@@ -725,18 +734,58 @@ func hasMissingCert(content, certsDir string) bool {
 // ERR_CERT_COMMON_NAME_INVALID, and we can't issue per-domain certs ahead of
 // time. ssl_reject_handshake produces a clean connection error
 // (ERR_SSL_UNRECOGNIZED_NAME_ALERT) which is the best UX available.
+//
+// The file is left alone when the user has manually edited it: lerd
+// stores a sentinel hash of what it last wrote, and skips rewriting when
+// the on-disk content no longer matches that hash. Removing the file (or
+// the sentinel) restores lerd's automatic management.
 func EnsureDefaultVhost() error {
 	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
 		return err
 	}
-
-	// Write the error page HTML.
 	if err := writeErrorPages(); err != nil {
 		return fmt.Errorf("writing error pages: %w", err)
 	}
 
+	canonical := renderDefaultVhost()
+	path := filepath.Join(config.NginxConfD(), "_default.conf")
+	sentinelPath := path + defaultVhostManagedHashSuffix
+
+	canonicalHash := contentHashHex(canonical)
+
+	onDisk, readErr := os.ReadFile(path)
+	if errors.Is(readErr, os.ErrNotExist) {
+		if err := os.WriteFile(path, canonical, 0644); err != nil {
+			return err
+		}
+		return os.WriteFile(sentinelPath, []byte(canonicalHash), 0644)
+	}
+	if readErr != nil {
+		return readErr
+	}
+
+	onDiskHash := contentHashHex(onDisk)
+	lastWritten, _ := os.ReadFile(sentinelPath)
+	if strings.TrimSpace(string(lastWritten)) != onDiskHash {
+		// User-edited (or sentinel missing). Preserve their content.
+		return nil
+	}
+	if onDiskHash == canonicalHash {
+		return nil
+	}
+	// On-disk matches what lerd last wrote, but the template moved on.
+	if err := os.WriteFile(path, canonical, 0644); err != nil {
+		return err
+	}
+	return os.WriteFile(sentinelPath, []byte(canonicalHash), 0644)
+}
+
+// renderDefaultVhost returns the canonical _default.conf content.
+// Separate from the writer so callers (and tests) can compute the same
+// bytes lerd would write without touching disk.
+func renderDefaultVhost() []byte {
 	errorDir := config.ErrorPagesDir()
-	content := fmt.Sprintf(`server {
+	return []byte(fmt.Sprintf(`server {
     listen 80 default_server;
     listen [::]:80 default_server;
     root %s;
@@ -750,8 +799,13 @@ server {
     listen [::]:443 default_server ssl;
     ssl_reject_handshake on;
 }
-`, errorDir)
-	return os.WriteFile(filepath.Join(config.NginxConfD(), "_default.conf"), []byte(content), 0644)
+`, errorDir))
+}
+
+// contentHashHex is sha256 → hex, used as the managed-file sentinel value.
+func contentHashHex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
 }
 
 const errorPageHTML = `<!DOCTYPE html>

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -765,9 +765,21 @@ func EnsureDefaultVhost() error {
 	}
 
 	onDiskHash := contentHashHex(onDisk)
-	lastWritten, _ := os.ReadFile(sentinelPath)
-	if strings.TrimSpace(string(lastWritten)) != onDiskHash {
-		// User-edited (or sentinel missing). Preserve their content.
+	lastWritten := strings.TrimSpace(readFileOrEmpty(sentinelPath))
+	if lastWritten == "" {
+		// Sentinel missing (deleted by user, or a prior sentinel-write
+		// crashed). If the file's content matches the canonical bytes
+		// lerd would write, treat it as ours and re-record the sentinel
+		// so subsequent runs can tell managed from edited. Otherwise
+		// it's effectively user-managed.
+		if onDiskHash == canonicalHash {
+			return os.WriteFile(sentinelPath, []byte(canonicalHash), 0644)
+		}
+		fmt.Printf("  [INFO] preserving user-modified %s; remove the file to re-enable lerd's catch-all\n", path)
+		return nil
+	}
+	if lastWritten != onDiskHash {
+		fmt.Printf("  [INFO] preserving user-modified %s; remove the file to re-enable lerd's catch-all\n", path)
 		return nil
 	}
 	if onDiskHash == canonicalHash {
@@ -778,6 +790,17 @@ func EnsureDefaultVhost() error {
 		return err
 	}
 	return os.WriteFile(sentinelPath, []byte(canonicalHash), 0644)
+}
+
+// readFileOrEmpty returns the file's contents as a string, or "" on any
+// error. Used for the sentinel read so a missing file and an unreadable
+// file collapse to the same "no recorded last-write" state.
+func readFileOrEmpty(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
 }
 
 // renderDefaultVhost returns the canonical _default.conf content.

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -777,6 +777,55 @@ func TestEnsureDefaultVhost_idempotentWhenUntouched(t *testing.T) {
 	}
 }
 
+func TestEnsureDefaultVhost_templateChangeAutoUpdatesWhenUnedited(t *testing.T) {
+	confD := setupConfD(t)
+	// Simulate a previously-installed lerd that wrote OLD content + a
+	// sentinel matching that old content. Reaching EnsureDefaultVhost
+	// today should detect the template-vs-on-disk drift and rewrite.
+	if err := os.MkdirAll(confD, 0755); err != nil {
+		t.Fatal(err)
+	}
+	stale := []byte("# old lerd template, before the latest binary\nserver { listen 80; }\n")
+	path := filepath.Join(confD, "_default.conf")
+	if err := os.WriteFile(path, stale, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path+defaultVhostManagedHashSuffix, []byte(contentHashHex(stale)), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureDefaultVhost(); err != nil {
+		t.Fatalf("EnsureDefaultVhost: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), "default_server") {
+		t.Errorf("expected lerd to overwrite stale content with the current template, got:\n%s", got)
+	}
+}
+
+func TestEnsureDefaultVhost_recoversManagementWhenSentinelMissingButContentMatches(t *testing.T) {
+	confD := setupConfD(t)
+	// Simulate a sentinel-write crash from a prior run: the conf is lerd's
+	// canonical bytes, but the sentinel file never made it to disk. The
+	// next run must reclaim management (write the sentinel) rather than
+	// silently treat the file as user-managed.
+	if err := EnsureDefaultVhost(); err != nil {
+		t.Fatalf("first EnsureDefaultVhost: %v", err)
+	}
+	path := filepath.Join(confD, "_default.conf")
+	sentinel := path + defaultVhostManagedHashSuffix
+	if err := os.Remove(sentinel); err != nil {
+		t.Fatalf("removing sentinel: %v", err)
+	}
+
+	if err := EnsureDefaultVhost(); err != nil {
+		t.Fatalf("recovery EnsureDefaultVhost: %v", err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("expected sentinel to be recreated when on-disk matches canonical, got %v", err)
+	}
+}
+
 func TestEnsureDefaultVhost_removingFileResetsManagement(t *testing.T) {
 	confD := setupConfD(t)
 	if err := EnsureDefaultVhost(); err != nil {

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -727,6 +727,77 @@ func TestEnsureDefaultVhost_writesDefaultConf(t *testing.T) {
 	if _, err := os.Stat(errorPage); err != nil {
 		t.Errorf("expected error page at %s", errorPage)
 	}
+	// Sentinel hash must be written alongside so subsequent runs can
+	// distinguish lerd-managed content from a user edit.
+	sentinel := filepath.Join(confD, "_default.conf"+defaultVhostManagedHashSuffix)
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("expected sentinel at %s", sentinel)
+	}
+}
+
+func TestEnsureDefaultVhost_preservesUserEdits(t *testing.T) {
+	confD := setupConfD(t)
+	// First pass: lerd writes the canonical content + sentinel.
+	if err := EnsureDefaultVhost(); err != nil {
+		t.Fatalf("first EnsureDefaultVhost: %v", err)
+	}
+	// User patches the file.
+	path := filepath.Join(confD, "_default.conf")
+	userEdited := []byte("# hand-tuned for staging\nserver {\n    listen 80;\n    ssl_reject_handshake off;\n}\n")
+	if err := os.WriteFile(path, userEdited, 0644); err != nil {
+		t.Fatalf("simulating user edit: %v", err)
+	}
+	// Second pass: should NOT overwrite.
+	if err := EnsureDefaultVhost(); err != nil {
+		t.Fatalf("second EnsureDefaultVhost: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-reading conf: %v", err)
+	}
+	if string(got) != string(userEdited) {
+		t.Errorf("user edit was overwritten\nwant:\n%s\ngot:\n%s", userEdited, got)
+	}
+}
+
+func TestEnsureDefaultVhost_idempotentWhenUntouched(t *testing.T) {
+	confD := setupConfD(t)
+	if err := EnsureDefaultVhost(); err != nil {
+		t.Fatalf("first EnsureDefaultVhost: %v", err)
+	}
+	path := filepath.Join(confD, "_default.conf")
+	before, _ := os.ReadFile(path)
+	// Second pass with no user edits: bytes should match exactly.
+	if err := EnsureDefaultVhost(); err != nil {
+		t.Fatalf("second EnsureDefaultVhost: %v", err)
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Errorf("re-run without edits should be a no-op\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestEnsureDefaultVhost_removingFileResetsManagement(t *testing.T) {
+	confD := setupConfD(t)
+	if err := EnsureDefaultVhost(); err != nil {
+		t.Fatalf("first EnsureDefaultVhost: %v", err)
+	}
+	path := filepath.Join(confD, "_default.conf")
+	sentinel := path + defaultVhostManagedHashSuffix
+	// User deletes the file (and may have left the sentinel; either way,
+	// lerd should regenerate the catch-all on the next run).
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("removing conf: %v", err)
+	}
+	if err := EnsureDefaultVhost(); err != nil {
+		t.Fatalf("regenerate after delete: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected lerd to recreate the file after user removed it: %v", err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("expected sentinel to be re-created alongside: %v", err)
+	}
 }
 
 func TestEnsureLerdVhost_linuxProxiesUnixSocket(t *testing.T) {


### PR DESCRIPTION
EnsureDefaultVhost rewrote _default.conf on every `lerd start` (called from the watcher and the install pass), clobbering any local patches. Users tuning the catch-all (e.g. swapping ssl_reject_handshake on→off for staging machines) had to re-apply the change after every restart. Reported in https://github.com/geodro/lerd/discussions/414.

EnsureDefaultVhost now stores a sentinel `_default.conf.lerd-managed-hash` alongside the conf, holding the sha256 of what lerd last wrote. On subsequent runs the on-disk content is hashed and compared:

- hash matches and canonical matches: no-op
- hash matches but canonical moved on: lerd updates the conf and the sentinel
- hash differs: user has edited; preserve, emit a `[INFO]` so the skip is visible
- sentinel missing but on-disk matches canonical: reclaim management (handles transient sentinel-write failures)
- sentinel missing and on-disk differs: preserve and tell the user how to opt back in
- file missing: first install, write content + sentinel

Removing _default.conf restores lerd's automatic management. The sentinel uses the `.lerd-managed-hash` suffix so it stays outside nginx's `*.conf` include glob.

Migration note: users upgrading from a pre-sentinel lerd binary will see a one-time `[INFO]` saying their `_default.conf` has no lerd sentinel and preserving the on-disk content. If they haven't edited it, `rm ~/.local/share/lerd/nginx/conf.d/_default.conf` on the next `lerd install` / `lerd update` regenerates it from the current template.