### PR TITLE
fix(dns): recognise legacy host-side resolver in dns:check

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -259,37 +260,45 @@ func newDNSCheckCmd() *cobra.Command {
 			}
 
 			diag := dns.Diagnose(cfg.DNS.TLD)
-			if diag.FirstFailure < 0 {
-				fmt.Printf("DNS is working: *.%s resolves to 127.0.0.1\n\n", cfg.DNS.TLD)
-			} else {
-				fmt.Printf("DNS is NOT working for .%s\n\n", cfg.DNS.TLD)
-			}
-			for _, s := range diag.Steps {
-				marker := "  "
-				switch s.Status {
-				case dns.StepOK:
-					marker = "✓ "
-				case dns.StepFail:
-					marker = "✗ "
-				case dns.StepWarn:
-					marker = "! "
-				case dns.StepSkip:
-					marker = "  "
-				}
-				if s.Detail != "" {
-					fmt.Printf("%s%-34s %s\n", marker, s.Name, s.Detail)
-				} else {
-					fmt.Printf("%s%s\n", marker, s.Name)
-				}
-				if (s.Status == dns.StepFail || s.Status == dns.StepWarn) && s.Hint != "" {
-					fmt.Printf("    hint: %s\n", s.Hint)
-				}
-			}
+			printDNSDiagnostic(os.Stdout, diag)
 			if diag.FirstFailure >= 0 {
 				os.Exit(1)
 			}
 			return nil
 		},
+	}
+}
+
+// printDNSDiagnostic writes the human-facing dns:check report for one
+// Diagnostic to w. Extracted from newDNSCheckCmd so the renderer (top
+// line, marker prefixes, hint-printing on Fail+Warn) can be exercised
+// in tests without spawning the CLI process.
+func printDNSDiagnostic(w io.Writer, diag dns.Diagnostic) {
+	if diag.FirstFailure < 0 {
+		fmt.Fprintf(w, "DNS is working: *.%s resolves to 127.0.0.1\n\n", diag.TLD)
+	} else {
+		fmt.Fprintf(w, "DNS is NOT working for .%s\n\n", diag.TLD)
+	}
+	for _, s := range diag.Steps {
+		marker := "  "
+		switch s.Status {
+		case dns.StepOK:
+			marker = "✓ "
+		case dns.StepFail:
+			marker = "✗ "
+		case dns.StepWarn:
+			marker = "! "
+		case dns.StepSkip:
+			marker = "  "
+		}
+		if s.Detail != "" {
+			fmt.Fprintf(w, "%s%-34s %s\n", marker, s.Name, s.Detail)
+		} else {
+			fmt.Fprintf(w, "%s%s\n", marker, s.Name)
+		}
+		if (s.Status == dns.StepFail || s.Status == dns.StepWarn) && s.Hint != "" {
+			fmt.Fprintf(w, "    hint: %s\n", s.Hint)
+		}
 	}
 }
 

--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -281,7 +281,7 @@ func newDNSCheckCmd() *cobra.Command {
 				} else {
 					fmt.Printf("%s%s\n", marker, s.Name)
 				}
-				if s.Status == dns.StepFail && s.Hint != "" {
+				if (s.Status == dns.StepFail || s.Status == dns.StepWarn) && s.Hint != "" {
 					fmt.Printf("    hint: %s\n", s.Hint)
 				}
 			}

--- a/cmd/lerd/main_test.go
+++ b/cmd/lerd/main_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/dns"
 )
 
 func isolateConfig(t *testing.T) {
@@ -156,5 +159,77 @@ func TestShouldAutoStartWorkersOnSync(t *testing.T) {
 		if got := shouldAutoStartWorkersOnSync(action); got != want {
 			t.Errorf("shouldAutoStartWorkersOnSync(%q) = %v, want %v", action, got, want)
 		}
+	}
+}
+
+func TestPrintDNSDiagnostic_WarnStepShowsHint(t *testing.T) {
+	// Regression for the field-report scenario: the legacy-host-resolver
+	// path emits a WARN step whose Hint explains how to switch back to
+	// lerd-managed DNS. The renderer used to print hints only on FAIL
+	// steps, silently swallowing this guidance.
+	diag := dns.Diagnostic{
+		TLD:          "test",
+		FirstFailure: -1,
+		Steps: []dns.Step{{
+			Name:   "lerd-dns container",
+			Status: dns.StepWarn,
+			Detail: "not running; a host-side resolver on :5300 is answering .test with 127.0.0.1",
+			Hint:   "lerd is not managing DNS here. Stop your host resolver and run `lerd start` to switch.",
+		}},
+	}
+	var buf bytes.Buffer
+	printDNSDiagnostic(&buf, diag)
+	out := buf.String()
+
+	for _, want := range []string{
+		"DNS is working",
+		"! lerd-dns container",
+		"host-side resolver on :5300",
+		"hint:",
+		"Stop your host resolver",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintDNSDiagnostic_FailStepShowsHint(t *testing.T) {
+	diag := dns.Diagnostic{
+		TLD:          "test",
+		FirstFailure: 0,
+		Steps: []dns.Step{{
+			Name:   "lerd-dns container",
+			Status: dns.StepFail,
+			Detail: "not running",
+			Hint:   "lerd start  (or check podman logs lerd-dns)",
+		}},
+	}
+	var buf bytes.Buffer
+	printDNSDiagnostic(&buf, diag)
+	out := buf.String()
+	for _, want := range []string{"DNS is NOT working", "✗ lerd-dns container", "hint: lerd start"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintDNSDiagnostic_OKStepHasNoHintLine(t *testing.T) {
+	diag := dns.Diagnostic{
+		TLD:          "test",
+		FirstFailure: -1,
+		Steps: []dns.Step{{
+			Name:   "lerd-dns container",
+			Status: dns.StepOK,
+			Detail: "running",
+			Hint:   "this hint should be ignored on OK steps",
+		}},
+	}
+	var buf bytes.Buffer
+	printDNSDiagnostic(&buf, diag)
+	out := buf.String()
+	if strings.Contains(out, "hint:") {
+		t.Errorf("OK step should not print a hint line, got:\n%s", out)
 	}
 }

--- a/internal/dns/diagnose.go
+++ b/internal/dns/diagnose.go
@@ -71,10 +71,36 @@ func diagnose(tld string, p probeFns) Diagnostic {
 	}
 	d := Diagnostic{TLD: tld, FirstFailure: -1}
 
-	// Rung 1 — lerd-dns container.
-	if p.containerRunning() {
+	// Rung 1 — lerd-dns container, with a fallback check for legacy
+	// host-side resolvers. The original chain reported "container not
+	// running" whenever lerd-dns was absent, which was a false negative
+	// for users running a host dnsmasq (Homebrew, system package) that
+	// owns :5300 and resolves .test correctly without lerd's container.
+	switch {
+	case p.containerRunning():
 		d.Steps = append(d.Steps, Step{Name: "lerd-dns container", Status: StepOK, Detail: "running"})
-	} else {
+	case p.portOpen("127.0.0.1", 5300):
+		// Something is on :5300 but it's not our container. Probe it: if
+		// it answers .tld correctly we're looking at a legacy host-side
+		// resolver and lerd just isn't managing DNS here. If it doesn't
+		// answer correctly the port is squatted by something unrelated.
+		if answer, err := p.dnsmasqAnswer(tld); err == nil && answer == "127.0.0.1" {
+			d.Steps = append(d.Steps, Step{
+				Name:   "lerd-dns container",
+				Status: StepWarn,
+				Detail: "not running; a host-side resolver on :5300 is answering ." + tld + " correctly",
+				Hint:   "lerd is not managing DNS here. Either keep your host resolver (no action), or stop it (e.g. `brew services stop dnsmasq`) and run `lerd start` to switch to lerd-managed DNS.",
+			})
+			return finalize(d)
+		}
+		d.Steps = append(d.Steps, Step{
+			Name:   "lerd-dns container",
+			Status: StepFail,
+			Detail: "not running; another process owns :5300 but doesn't resolve ." + tld,
+			Hint:   "identify the holder: " + findListenerCmd(5300),
+		})
+		return finalize(d)
+	default:
 		d.Steps = append(d.Steps, Step{
 			Name:   "lerd-dns container",
 			Status: StepFail,

--- a/internal/dns/diagnose.go
+++ b/internal/dns/diagnose.go
@@ -75,30 +75,46 @@ func diagnose(tld string, p probeFns) Diagnostic {
 	// host-side resolvers. The original chain reported "container not
 	// running" whenever lerd-dns was absent, which was a false negative
 	// for users running a host dnsmasq (Homebrew, system package) that
-	// owns :5300 and resolves .test correctly without lerd's container.
+	// owns :5300 and resolves .test without lerd's container.
 	switch {
 	case p.containerRunning():
 		d.Steps = append(d.Steps, Step{Name: "lerd-dns container", Status: StepOK, Detail: "running"})
 	case p.portOpen("127.0.0.1", 5300):
-		// Something is on :5300 but it's not our container. Probe it: if
-		// it answers .tld correctly we're looking at a legacy host-side
-		// resolver and lerd just isn't managing DNS here. If it doesn't
-		// answer correctly the port is squatted by something unrelated.
-		if answer, err := p.dnsmasqAnswer(tld); err == nil && answer == "127.0.0.1" {
+		// Something is on :5300 but it's not our container. Probe it:
+		//   - answer == 127.0.0.1: legacy resolver matching lerd's mapping
+		//   - any other IP:        legacy resolver pointing elsewhere
+		//                          (e.g. LAN IP for cross-device testing)
+		//   - error or empty:      port squatted by something non-DNS
+		answer, err := p.dnsmasqAnswer(tld)
+		switch {
+		case err == nil && answer == "127.0.0.1":
 			d.Steps = append(d.Steps, Step{
 				Name:   "lerd-dns container",
 				Status: StepWarn,
-				Detail: "not running; a host-side resolver on :5300 is answering ." + tld + " correctly",
+				Detail: "not running; a host-side resolver on :5300 is answering ." + tld + " with 127.0.0.1",
 				Hint:   "lerd is not managing DNS here. Either keep your host resolver (no action), or stop it (e.g. `brew services stop dnsmasq`) and run `lerd start` to switch to lerd-managed DNS.",
 			})
-			return finalize(d)
+		case err == nil && answer != "":
+			d.Steps = append(d.Steps, Step{
+				Name:   "lerd-dns container",
+				Status: StepWarn,
+				Detail: fmt.Sprintf("not running; a host-side resolver on :5300 is answering .%s with %s (lerd's default is 127.0.0.1)", tld, answer),
+				Hint:   "lerd is not managing DNS here. Your host resolver is mapping ." + tld + " to a different address. Keep using it, or stop it and run `lerd start` to switch to lerd-managed DNS pointing at 127.0.0.1.",
+			})
+		default:
+			detail := "not running; another process owns :5300 but didn't resolve ." + tld
+			if err != nil {
+				detail += " (" + err.Error() + ")"
+			} else if answer == "" {
+				detail += " (empty answer)"
+			}
+			d.Steps = append(d.Steps, Step{
+				Name:   "lerd-dns container",
+				Status: StepFail,
+				Detail: detail,
+				Hint:   "identify the holder: " + findListenerCmd(5300),
+			})
 		}
-		d.Steps = append(d.Steps, Step{
-			Name:   "lerd-dns container",
-			Status: StepFail,
-			Detail: "not running; another process owns :5300 but doesn't resolve ." + tld,
-			Hint:   "identify the holder: " + findListenerCmd(5300),
-		})
 		return finalize(d)
 	default:
 		d.Steps = append(d.Steps, Step{

--- a/internal/dns/diagnose_test.go
+++ b/internal/dns/diagnose_test.go
@@ -81,7 +81,8 @@ func TestDiagnose_legacyHostResolverDetectedAsWarn(t *testing.T) {
 func TestDiagnose_portSquattedByNonDNSReportsFail(t *testing.T) {
 	// Something is on :5300 but it isn't a working DNS resolver (e.g. a
 	// stale process). Distinct from the legacy-resolver case so the user
-	// gets a different hint.
+	// gets a different hint, and the actual error is preserved in Detail
+	// so the user can tell NXDOMAIN apart from a timeout or refused.
 	p := fakeProbes()
 	p.containerRunning = func() bool { return false }
 	p.dnsmasqAnswer = func(string) (string, error) { return "", errors.New("nxdomain") }
@@ -94,6 +95,35 @@ func TestDiagnose_portSquattedByNonDNSReportsFail(t *testing.T) {
 	}
 	if !strings.Contains(d.Steps[0].Hint, "identify the holder") {
 		t.Errorf("hint should suggest identifying the squatter, got %q", d.Steps[0].Hint)
+	}
+	if !strings.Contains(d.Steps[0].Detail, "nxdomain") {
+		t.Errorf("Detail should surface the actual probe error, got %q", d.Steps[0].Detail)
+	}
+}
+
+func TestDiagnose_legacyResolverPointingAtNon127ReportsWarn(t *testing.T) {
+	// User runs a host dnsmasq mapping .test to a LAN IP (e.g. for
+	// cross-device testing). Still a working resolver, still not lerd's,
+	// but the IP differs from lerd's default. Surface as WARN with the
+	// actual answer included so the user can confirm intent.
+	p := fakeProbes()
+	p.containerRunning = func() bool { return false }
+	p.dnsmasqAnswer = func(string) (string, error) { return "192.168.1.20", nil }
+	d := diagnose("test", p)
+	if len(d.Steps) != 1 {
+		t.Fatalf("expected exactly 1 step, got %d: %+v", len(d.Steps), d.Steps)
+	}
+	if d.Steps[0].Status != StepWarn {
+		t.Errorf("step status = %s, want warn", d.Steps[0].Status)
+	}
+	if d.FirstFailure != -1 {
+		t.Errorf("FirstFailure = %d, want -1 (not a failure, lerd just isn't the resolver)", d.FirstFailure)
+	}
+	if !strings.Contains(d.Steps[0].Detail, "192.168.1.20") {
+		t.Errorf("Detail should mention the actual IP the host resolver returned, got %q", d.Steps[0].Detail)
+	}
+	if !strings.Contains(d.Steps[0].Detail, "lerd's default is 127.0.0.1") {
+		t.Errorf("Detail should call out the difference from lerd's default, got %q", d.Steps[0].Detail)
 	}
 }
 

--- a/internal/dns/diagnose_test.go
+++ b/internal/dns/diagnose_test.go
@@ -34,9 +34,10 @@ func TestDiagnose_allOK(t *testing.T) {
 	}
 }
 
-func TestDiagnose_containerDownStopsChain(t *testing.T) {
+func TestDiagnose_containerDownAndPortClosedStopsChain(t *testing.T) {
 	p := fakeProbes()
 	p.containerRunning = func() bool { return false }
+	p.portOpen = func(string, int) bool { return false }
 	d := diagnose("test", p)
 	if len(d.Steps) != 1 {
 		t.Fatalf("expected 1 step (no chain after container fail), got %d", len(d.Steps))
@@ -49,6 +50,50 @@ func TestDiagnose_containerDownStopsChain(t *testing.T) {
 	}
 	if !strings.Contains(d.Steps[0].Hint, "lerd start") {
 		t.Errorf("hint %q should mention `lerd start`", d.Steps[0].Hint)
+	}
+}
+
+func TestDiagnose_legacyHostResolverDetectedAsWarn(t *testing.T) {
+	// Field-report scenario: user has Homebrew/launchd dnsmasq holding
+	// :5300, lerd-dns container is absent. The chain should surface this
+	// as a WARN (not a hard fail) with a hint explaining the situation.
+	p := fakeProbes()
+	p.containerRunning = func() bool { return false }
+	// portOpen / dnsmasqAnswer default to "yes, answers correctly".
+	d := diagnose("test", p)
+	if len(d.Steps) != 1 {
+		t.Fatalf("expected exactly 1 step (chain stops at the warn), got %d: %+v", len(d.Steps), d.Steps)
+	}
+	step := d.Steps[0]
+	if step.Status != StepWarn {
+		t.Errorf("step status = %s, want warn", step.Status)
+	}
+	if d.FirstFailure != -1 {
+		t.Errorf("FirstFailure = %d, want -1 (no failure, lerd just isn't managing DNS)", d.FirstFailure)
+	}
+	for _, want := range []string{"host-side resolver", "not managing DNS", "lerd start"} {
+		if !strings.Contains(step.Detail+step.Hint, want) {
+			t.Errorf("step detail+hint should mention %q\ndetail: %s\nhint: %s", want, step.Detail, step.Hint)
+		}
+	}
+}
+
+func TestDiagnose_portSquattedByNonDNSReportsFail(t *testing.T) {
+	// Something is on :5300 but it isn't a working DNS resolver (e.g. a
+	// stale process). Distinct from the legacy-resolver case so the user
+	// gets a different hint.
+	p := fakeProbes()
+	p.containerRunning = func() bool { return false }
+	p.dnsmasqAnswer = func(string) (string, error) { return "", errors.New("nxdomain") }
+	d := diagnose("test", p)
+	if d.FirstFailure != 0 {
+		t.Errorf("FirstFailure = %d, want 0 (rung 1 fails when port is squatted by non-DNS)", d.FirstFailure)
+	}
+	if d.Steps[0].Status != StepFail {
+		t.Errorf("step status = %s, want fail", d.Steps[0].Status)
+	}
+	if !strings.Contains(d.Steps[0].Hint, "identify the holder") {
+		t.Errorf("hint should suggest identifying the squatter, got %q", d.Steps[0].Hint)
 	}
 }
 


### PR DESCRIPTION
`lerd dns:check` reported "lerd-dns container not running" as a hard failure whenever the container was absent, even if a host-side resolver (Homebrew/launchd dnsmasq, system package) owned :5300 and answered the TLD correctly. The output read "DNS is NOT working" when DNS was in fact working, just not through lerd's container. Reported in https://github.com/geodro/lerd/discussions/414.

Rung 1 of the diagnostic now distinguishes four states when the lerd-dns container isn't running:

- port :5300 in use AND answers .tld with 127.0.0.1: warn, "host-side resolver matching lerd's default mapping is handling DNS"
- port :5300 in use AND answers .tld with a different IP (e.g. a LAN IP for cross-device testing): warn, "host-side resolver answering .tld with <IP>; lerd's default is 127.0.0.1"
- port :5300 in use but doesn't answer or errored: fail, "another process owns :5300 but didn't resolve .tld (<actual error>)"
- port :5300 free: fail, "not running" (the original message)

The warn paths return FirstFailure=-1 so the top-line summary now reads "DNS is working" with the WARN explaining lerd isn't the resolver in play. The CLI now prints hints for WARN steps as well as FAIL (previously WARN hints were silently dropped). The renderer was extracted to a testable function so the rendering of WARN+Hint and FAIL+Hint paths has dedicated coverage.

The renderer expansion also exposes useful WARN hints elsewhere in the chain that were previously dropped: the VPN-active rung-7 case explains "a VPN tunnel has taken over the system resolver, lerd re-syncs container DNS automatically", and the rung-6 resolvectl-parse-error case notes "could not parse resolvectl status, skipping check".

Verified on a host running launchd dnsmasq on 127.0.0.1:5300: before, `dns:check` exited 1 with "DNS is NOT working"; after, it exits 0 with "DNS is working" and the warning explaining lerd isn't managing DNS. `lerd doctor` automatically picks up the same improvement since it uses the same underlying Diagnose call.