### PR TITLE
fix(install): auto-detect poisoned FPM hash via image labels

### DIFF
--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -162,11 +162,18 @@ var (
 // signals, in order of strength:
 //
 //  1. Cache file (~/.local/share/lerd/php-image-hash) vs the embedded
-//     hash. Fast and correct for well-behaved installs.
+//     hash. Fast and correct for well-behaved installs. A missing cache
+//     file is not itself a trigger: we still need at least one signal
+//     that the on-disk images disagree with the embed.
 //  2. The fpmContainerfileHashLabel on each installed image. Authoritative
 //     when the cache file is stale (e.g. an older lerd binary advanced
-//     the hash without rebuilding), so the rebuild fires automatically on
-//     the next install instead of needing a manual `lerd php:rebuild`.
+//     the hash without rebuilding) or missing entirely, so the rebuild
+//     fires automatically on the next install instead of needing a
+//     manual `lerd php:rebuild`.
+//
+// Returns false when no images are installed (nothing to rebuild) and
+// the cache file isn't disagreeing — first install hits this path and
+// proceeds to build cleanly via ensureFPMQuadlet.
 func NeedsFPMRebuild() bool {
 	current, err := ContainerfileHash()
 	if err != nil {
@@ -225,6 +232,26 @@ func imageLabel(image, key string) string {
 		return ""
 	}
 	return v
+}
+
+// fpmBuildArgs returns the `podman build` flags shared by both the fast
+// (pre-built base) and slow (full local build) paths in buildFPMImage,
+// before either path appends the `-f <containerfile> <ctx>` tail. Factored
+// out so a regression on the load-bearing `--label` arg can be caught in
+// a unit test without spawning podman.
+func fpmBuildArgs(imageName, containerfileHash string, force bool) []string {
+	args := []string{
+		"build",
+		"-t", imageName,
+		"--label", fpmContainerfileHashLabel + "=" + containerfileHash,
+	}
+	if force {
+		// Bypass layer cache so changes are fully applied. The old image
+		// stays tagged and the container keeps running until we restart
+		// the unit.
+		args = append(args, "--no-cache")
+	}
+	return args
 }
 
 // fpmHashMu serializes StoreFPMHash so the per-version buildFPMImage calls
@@ -356,14 +383,14 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 
 	// Stamp the Containerfile hash as an image label so NeedsFPMRebuild
 	// can detect drift even when the on-disk cache file is stale (the
-	// pre-v1.22.0 poisoning bug). Both build paths inherit this tag.
+	// pre-v1.22.0 poisoning bug). Both build paths inherit the same args.
 	canonicalHash, hashErr := ContainerfileHash()
 	if hashErr != nil {
 		return fmt.Errorf("computing Containerfile hash for label: %w", hashErr)
 	}
 
 	var containerfile string
-	buildArgs := []string{"build", "-t", imageName, "--label", fpmContainerfileHashLabel + "=" + canonicalHash}
+	buildArgs := fpmBuildArgs(imageName, canonicalHash, force)
 
 	// Fast path: pull pre-built base and layer just mkcert CA + custom extensions on top.
 	if !local {
@@ -372,9 +399,6 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 				"RUN mkdir -p /etc/my.cnf.d && printf '[client]\\nssl=0\\n' > /etc/my.cnf.d/lerd-no-ssl.cnf\n" +
 				buildCustomExtBlock(customExts, extDeps) +
 				mkcertCABlock(tmp)
-			if force {
-				buildArgs = append(buildArgs, "--no-cache")
-			}
 			goto build
 		}
 	}
@@ -389,11 +413,6 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 		containerfile = strings.ReplaceAll(containerfile, "{{.CustomExtensions}}", buildCustomExtBlock(customExts, extDeps))
 		containerfile = strings.ReplaceAll(containerfile, "{{.CustomExtensionsRuntime}}", buildCustomExtRuntimeDeps(customExts, extDeps))
 		containerfile = strings.ReplaceAll(containerfile, "{{.MkcertCA}}", mkcertCABlock(tmp))
-		if force {
-			// Bypass layer cache so changes are fully applied. The old image stays
-			// tagged and the container keeps running until we restart the unit.
-			buildArgs = append(buildArgs, "--no-cache")
-		}
 	}
 
 build:

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -144,19 +144,87 @@ func ContainerfileHash() (string, error) {
 	return fmt.Sprintf("%x", sum), nil
 }
 
-// NeedsFPMRebuild returns true if the stored Containerfile hash differs from the
-// current embedded Containerfile, meaning images should be rebuilt.
+// fpmContainerfileHashLabel is written on every PHP-FPM image at build
+// time so NeedsFPMRebuild can detect drift independently of the cache
+// file. A bug in lerd < v1.22.0 advanced the cache file without actually
+// rebuilding, leaving images that were stale-but-not-detectable. The
+// label is the source of truth; the cache file is a fast-path.
+const fpmContainerfileHashLabel = "dev.lerd.fpm.containerfile-hash"
+
+// Seams for NeedsFPMRebuild so tests can fake the podman shell-outs.
+var (
+	installedFPMImagesFn = installedFPMImages
+	imageLabelFn         = imageLabel
+)
+
+// NeedsFPMRebuild returns true when at least one installed PHP-FPM image
+// was built from a Containerfile other than the embedded one. Two
+// signals, in order of strength:
+//
+//  1. Cache file (~/.local/share/lerd/php-image-hash) vs the embedded
+//     hash. Fast and correct for well-behaved installs.
+//  2. The fpmContainerfileHashLabel on each installed image. Authoritative
+//     when the cache file is stale (e.g. an older lerd binary advanced
+//     the hash without rebuilding), so the rebuild fires automatically on
+//     the next install instead of needing a manual `lerd php:rebuild`.
 func NeedsFPMRebuild() bool {
 	current, err := ContainerfileHash()
 	if err != nil {
 		return false
 	}
-	stored, err := os.ReadFile(config.PHPImageHashFile())
-	if err != nil {
-		// No stored hash yet — treat as needing rebuild only if images exist
-		return false
+	if stored, err := os.ReadFile(config.PHPImageHashFile()); err == nil {
+		if strings.TrimSpace(string(stored)) != current {
+			return true
+		}
 	}
-	return strings.TrimSpace(string(stored)) != current
+	// Cache file says we're up to date; verify against the labels on the
+	// images themselves so a poisoned cache from older lerd binaries
+	// (hash advanced without a rebuild) still triggers a rebuild.
+	for _, image := range installedFPMImagesFn() {
+		label := imageLabelFn(image, fpmContainerfileHashLabel)
+		if label != current {
+			return true
+		}
+	}
+	return false
+}
+
+// installedFPMImages returns the local lerd PHP-FPM image names that
+// currently exist. NeedsFPMRebuild walks this list to compare labels.
+func installedFPMImages() []string {
+	out, err := exec.Command(PodmanBin(), "images",
+		"--format", "{{.Repository}}:{{.Tag}}",
+		"--filter", "reference=lerd-php*-fpm:local",
+	).Output()
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		names = append(names, line)
+	}
+	return names
+}
+
+// imageLabel reads a single label from a local image. Returns "" on any
+// error (image missing, podman unreachable, label absent) so callers
+// treat that as "doesn't match" and fall back to a rebuild.
+func imageLabel(image, key string) string {
+	out, err := exec.Command(PodmanBin(), "inspect",
+		"--format", "{{index .Config.Labels \""+key+"\"}}",
+		image,
+	).Output()
+	if err != nil {
+		return ""
+	}
+	v := strings.TrimSpace(string(out))
+	if v == "<no value>" {
+		return ""
+	}
+	return v
 }
 
 // fpmHashMu serializes StoreFPMHash so the per-version buildFPMImage calls
@@ -286,8 +354,16 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 	}
 	defer os.RemoveAll(tmp)
 
+	// Stamp the Containerfile hash as an image label so NeedsFPMRebuild
+	// can detect drift even when the on-disk cache file is stale (the
+	// pre-v1.22.0 poisoning bug). Both build paths inherit this tag.
+	canonicalHash, hashErr := ContainerfileHash()
+	if hashErr != nil {
+		return fmt.Errorf("computing Containerfile hash for label: %w", hashErr)
+	}
+
 	var containerfile string
-	buildArgs := []string{"build", "-t", imageName}
+	buildArgs := []string{"build", "-t", imageName, "--label", fpmContainerfileHashLabel + "=" + canonicalHash}
 
 	// Fast path: pull pre-built base and layer just mkcert CA + custom extensions on top.
 	if !local {

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -157,23 +157,9 @@ var (
 	imageLabelFn         = imageLabel
 )
 
-// NeedsFPMRebuild returns true when at least one installed PHP-FPM image
-// was built from a Containerfile other than the embedded one. Two
-// signals, in order of strength:
-//
-//  1. Cache file (~/.local/share/lerd/php-image-hash) vs the embedded
-//     hash. Fast and correct for well-behaved installs. A missing cache
-//     file is not itself a trigger: we still need at least one signal
-//     that the on-disk images disagree with the embed.
-//  2. The fpmContainerfileHashLabel on each installed image. Authoritative
-//     when the cache file is stale (e.g. an older lerd binary advanced
-//     the hash without rebuilding) or missing entirely, so the rebuild
-//     fires automatically on the next install instead of needing a
-//     manual `lerd php:rebuild`.
-//
-// Returns false when no images are installed (nothing to rebuild) and
-// the cache file isn't disagreeing — first install hits this path and
-// proceeds to build cleanly via ensureFPMQuadlet.
+// NeedsFPMRebuild returns true when the embedded Containerfile differs
+// from the cache file OR from any installed image's hash label (catches
+// the pre-v1.22.0 poisoned-cache state). False on a fresh install.
 func NeedsFPMRebuild() bool {
 	current, err := ContainerfileHash()
 	if err != nil {
@@ -234,11 +220,9 @@ func imageLabel(image, key string) string {
 	return v
 }
 
-// fpmBuildArgs returns the `podman build` flags shared by both the fast
-// (pre-built base) and slow (full local build) paths in buildFPMImage,
-// before either path appends the `-f <containerfile> <ctx>` tail. Factored
-// out so a regression on the load-bearing `--label` arg can be caught in
-// a unit test without spawning podman.
+// fpmBuildArgs returns the `podman build` flags shared by both build
+// paths in buildFPMImage, before either appends the `-f <ctx>` tail.
+// Extracted so the load-bearing `--label` arg has unit-test coverage.
 func fpmBuildArgs(imageName, containerfileHash string, force bool) []string {
 	args := []string{
 		"build",

--- a/internal/podman/build_test.go
+++ b/internal/podman/build_test.go
@@ -300,3 +300,53 @@ func TestNeedsFPMRebuild_CacheMismatch_TriggersRebuild(t *testing.T) {
 		t.Error("expected rebuild when the cache file disagrees with the embedded Containerfile")
 	}
 }
+
+func TestFPMBuildArgs_ContainsHashLabel(t *testing.T) {
+	args := fpmBuildArgs("lerd-php84-fpm:local", "abc123", false)
+	if !sliceContainsPair(args, "--label", fpmContainerfileHashLabel+"=abc123") {
+		t.Errorf("build args missing the containerfile-hash label\nargs: %v", args)
+	}
+	if sliceContains(args, "--no-cache") {
+		t.Errorf("force=false should not add --no-cache, got: %v", args)
+	}
+}
+
+func TestFPMBuildArgs_ForceAddsNoCache(t *testing.T) {
+	args := fpmBuildArgs("lerd-php84-fpm:local", "abc123", true)
+	if !sliceContains(args, "--no-cache") {
+		t.Errorf("force=true should add --no-cache, got: %v", args)
+	}
+	// Label must still be present in the force path so a forced rebuild
+	// stamps the current hash and clears any poisoned-state label drift.
+	if !sliceContainsPair(args, "--label", fpmContainerfileHashLabel+"=abc123") {
+		t.Errorf("force path lost the containerfile-hash label\nargs: %v", args)
+	}
+}
+
+func TestFPMBuildArgs_TagsImageName(t *testing.T) {
+	args := fpmBuildArgs("lerd-php85-fpm:local", "h", false)
+	if !sliceContainsPair(args, "-t", "lerd-php85-fpm:local") {
+		t.Errorf("missing -t <image> pair\nargs: %v", args)
+	}
+}
+
+// sliceContains reports whether needle appears in haystack.
+func sliceContains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// sliceContainsPair reports whether haystack contains `flag` immediately
+// followed by `value` (the exec.Command space-separated arg/value form).
+func sliceContainsPair(haystack []string, flag, value string) bool {
+	for i := 0; i < len(haystack)-1; i++ {
+		if haystack[i] == flag && haystack[i+1] == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/podman/build_test.go
+++ b/internal/podman/build_test.go
@@ -1,9 +1,12 @@
 package podman
 
 import (
+	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 func TestBuildCustomExtBlock_Empty(t *testing.T) {
@@ -179,5 +182,121 @@ func TestPhpExtensionLoaded(t *testing.T) {
 		if got := phpExtensionLoaded(out, ext); got != want {
 			t.Errorf("phpExtensionLoaded(out, %q) = %v, want %v", ext, got, want)
 		}
+	}
+}
+
+func TestNeedsFPMRebuild_CacheMatches_NoImages_NoRebuild(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := os.MkdirAll(config.DataDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+	current, err := ContainerfileHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.PHPImageHashFile(), []byte(current), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := installedFPMImagesFn
+	installedFPMImagesFn = func() []string { return nil }
+	t.Cleanup(func() { installedFPMImagesFn = prev })
+
+	if NeedsFPMRebuild() {
+		t.Error("expected no rebuild when cache matches and no images installed")
+	}
+}
+
+func TestNeedsFPMRebuild_CacheMatches_LabelMatches_NoRebuild(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := os.MkdirAll(config.DataDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+	current, _ := ContainerfileHash()
+	_ = os.WriteFile(config.PHPImageHashFile(), []byte(current), 0644)
+
+	prevImages := installedFPMImagesFn
+	prevLabel := imageLabelFn
+	installedFPMImagesFn = func() []string { return []string{"lerd-php84-fpm:local"} }
+	imageLabelFn = func(image, key string) string { return current }
+	t.Cleanup(func() {
+		installedFPMImagesFn = prevImages
+		imageLabelFn = prevLabel
+	})
+
+	if NeedsFPMRebuild() {
+		t.Error("expected no rebuild when both cache and label match the embedded Containerfile")
+	}
+}
+
+func TestNeedsFPMRebuild_CacheMatches_LabelMismatch_TriggersRebuild(t *testing.T) {
+	// Poisoned-state recovery: an older lerd binary advanced the cache file
+	// without rebuilding, so the cache says "up to date" but the actual
+	// image was built from a previous Containerfile and carries the old
+	// hash as its label.
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := os.MkdirAll(config.DataDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+	current, _ := ContainerfileHash()
+	_ = os.WriteFile(config.PHPImageHashFile(), []byte(current), 0644)
+
+	prevImages := installedFPMImagesFn
+	prevLabel := imageLabelFn
+	installedFPMImagesFn = func() []string { return []string{"lerd-php84-fpm:local"} }
+	imageLabelFn = func(image, key string) string { return "deadbeefoldhash" }
+	t.Cleanup(func() {
+		installedFPMImagesFn = prevImages
+		imageLabelFn = prevLabel
+	})
+
+	if !NeedsFPMRebuild() {
+		t.Error("expected rebuild when image label disagrees with the embedded Containerfile hash (the poisoned-state recovery path)")
+	}
+}
+
+func TestNeedsFPMRebuild_CacheMatches_LegacyImageWithoutLabel_TriggersRebuild(t *testing.T) {
+	// Images built by an even older lerd that predates the label entirely
+	// must also recover automatically.
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := os.MkdirAll(config.DataDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+	current, _ := ContainerfileHash()
+	_ = os.WriteFile(config.PHPImageHashFile(), []byte(current), 0644)
+
+	prevImages := installedFPMImagesFn
+	prevLabel := imageLabelFn
+	installedFPMImagesFn = func() []string { return []string{"lerd-php84-fpm:local"} }
+	imageLabelFn = func(image, key string) string { return "" }
+	t.Cleanup(func() {
+		installedFPMImagesFn = prevImages
+		imageLabelFn = prevLabel
+	})
+
+	if !NeedsFPMRebuild() {
+		t.Error("expected rebuild when the image carries no fpm-containerfile-hash label (pre-label lerd build)")
+	}
+}
+
+func TestNeedsFPMRebuild_CacheMismatch_TriggersRebuild(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := os.MkdirAll(config.DataDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Stored hash from a hypothetical old template.
+	_ = os.WriteFile(config.PHPImageHashFile(), []byte("stale-cached-hash"), 0644)
+
+	prevImages := installedFPMImagesFn
+	installedFPMImagesFn = func() []string { return nil }
+	t.Cleanup(func() { installedFPMImagesFn = prevImages })
+
+	if !NeedsFPMRebuild() {
+		t.Error("expected rebuild when the cache file disagrees with the embedded Containerfile")
 	}
 }


### PR DESCRIPTION
PR #415 fixed the path that advanced ~/.local/share/lerd/php-image-hash without rebuilding, but couldn't auto-heal users already in the poisoned state: their cache file already matched the new Containerfile, so NeedsFPMRebuild returned false and `lerd install` skipped the rebuild even though the actual images were stale.

Every PHP-FPM image now carries a `dev.lerd.fpm.containerfile-hash` OCI label recording the canonical Containerfile hash it was actually built from. NeedsFPMRebuild checks two signals:

- cache file vs embed hash (fast path, unchanged behaviour)
- each installed image's label vs embed hash (catches poisoned cache)

Empty labels (images built by pre-fix lerd binaries) are treated as mismatches, so the first `lerd install` after this upgrade triggers a one-time rebuild that stamps the labels. After that the labels are authoritative and the cache file is just a fast-path.

The shared `podman build` arg construction was extracted into `fpmBuildArgs` so the load-bearing `--label` flag is unit-tested in both the force=false (idempotent rebuild path) and force=true (`php:rebuild`) configurations.

Verified locally on a host stuck in the poisoned state since v1.22.0: 4 lerd-php*-fpm:local images with empty labels, cache hash matching the embed. The new detection correctly returns true; old code returned false.