### PR TITLE
fix: post-v1.22.0 review follow-ups

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -725,7 +725,8 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		// exists, so `brew upgrade && lerd install` would otherwise ship
 		// new binary against stale images. Gated by autostartOn because
 		// php:rebuild restarts FPM and worker units unconditionally.
-		if podman.NeedsFPMRebuild() {
+		activeFPM, _ := phpDet.ListInstalled()
+		if podman.NeedsFPMRebuild(activeFPM) {
 			fmt.Println("\n==> PHP-FPM Containerfile changed — rebuilding images")
 			self, err := os.Executable()
 			if err != nil {
@@ -742,9 +743,9 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		}
 
 		// Start installed PHP FPM containers whose images are now available.
-		if fpmVersions, _ := phpDet.ListInstalled(); len(fpmVersions) > 0 {
+		if len(activeFPM) > 0 {
 			var fpmJobs []BuildJob
-			for _, v := range fpmVersions {
+			for _, v := range activeFPM {
 				ver := v
 				short := strings.ReplaceAll(ver, ".", "")
 				if podman.RunSilent("image", "exists", "lerd-php"+short+"-fpm:local") != nil {

--- a/internal/dns/diagnose.go
+++ b/internal/dns/diagnose.go
@@ -71,11 +71,9 @@ func diagnose(tld string, p probeFns) Diagnostic {
 	}
 	d := Diagnostic{TLD: tld, FirstFailure: -1}
 
-	// Rung 1 — lerd-dns container, with a fallback check for legacy
-	// host-side resolvers. The original chain reported "container not
-	// running" whenever lerd-dns was absent, which was a false negative
-	// for users running a host dnsmasq (Homebrew, system package) that
-	// owns :5300 and resolves .test without lerd's container.
+	// Rung 1, lerd-dns container, with a fallback check so a host-side
+	// dnsmasq owning :5300 (Homebrew, system package) doesn't get
+	// misreported as "container not running".
 	switch {
 	case p.containerRunning():
 		d.Steps = append(d.Steps, Step{Name: "lerd-dns container", Status: StepOK, Detail: "running"})

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -755,10 +755,10 @@ func EnsureDefaultVhost() error {
 
 	onDisk, readErr := os.ReadFile(path)
 	if errors.Is(readErr, os.ErrNotExist) {
-		if err := os.WriteFile(path, canonical, 0644); err != nil {
+		if err := writeFileAtomic(path, canonical, 0644); err != nil {
 			return err
 		}
-		return os.WriteFile(sentinelPath, []byte(canonicalHash), 0644)
+		return writeFileAtomic(sentinelPath, []byte(canonicalHash), 0644)
 	}
 	if readErr != nil {
 		return readErr
@@ -767,17 +767,11 @@ func EnsureDefaultVhost() error {
 	onDiskHash := contentHashHex(onDisk)
 	lastWritten := strings.TrimSpace(readFileOrEmpty(sentinelPath))
 	if lastWritten == "" {
-		// Sentinel missing. Three plausible causes:
-		//   1. Sentinel-write crashed on a prior run (file content is
-		//      lerd's canonical → reclaim by writing the sentinel).
-		//   2. User upgraded from a pre-sentinel lerd binary; on-disk
-		//      content is OLD lerd's template, which the user may not
-		//      have edited but we can't tell apart from a real edit.
-		//   3. User has hand-edited the file.
-		// Cases 2 and 3 are indistinguishable, so we preserve and tell
-		// the user how to opt back in to lerd's catch-all if they want it.
+		// Sentinel missing: sentinel-write crash (reclaim if hashes match),
+		// pre-sentinel binary upgrade, or hand edit. The last two are
+		// indistinguishable, so preserve and tell the user how to opt back in.
 		if onDiskHash == canonicalHash {
-			return os.WriteFile(sentinelPath, []byte(canonicalHash), 0644)
+			return writeFileAtomic(sentinelPath, []byte(canonicalHash), 0644)
 		}
 		fmt.Printf("  [INFO] %s has no lerd sentinel; preserving on-disk content. If this is from a lerd upgrade and you haven't edited it, run: rm %s\n", path, path)
 		return nil
@@ -790,10 +784,10 @@ func EnsureDefaultVhost() error {
 		return nil
 	}
 	// On-disk matches what lerd last wrote, but the template moved on.
-	if err := os.WriteFile(path, canonical, 0644); err != nil {
+	if err := writeFileAtomic(path, canonical, 0644); err != nil {
 		return err
 	}
-	return os.WriteFile(sentinelPath, []byte(canonicalHash), 0644)
+	return writeFileAtomic(sentinelPath, []byte(canonicalHash), 0644)
 }
 
 // readFileOrEmpty returns the file's contents as a string, or "" on any
@@ -805,6 +799,31 @@ func readFileOrEmpty(path string) string {
 		return ""
 	}
 	return string(b)
+}
+
+// writeFileAtomic writes data to path via a sibling .tmp file followed by
+// a rename, so a crash mid-write can never leave nginx pointing at a
+// half-written conf. Preserves the destination file's mode if it already
+// existed so an out-of-band chmod survives the rewrite; uses the caller's
+// mode only when creating from scratch. Temp file is removed on any error.
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	effective := mode
+	if info, err := os.Stat(path); err == nil {
+		effective = info.Mode().Perm()
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, effective); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp, effective); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
 }
 
 // renderDefaultVhost returns the canonical _default.conf content.

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -849,6 +849,77 @@ func TestEnsureDefaultVhost_removingFileResetsManagement(t *testing.T) {
 	}
 }
 
+func TestWriteFileAtomic_writesContentAndLeavesNoTempBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "managed.conf")
+	if err := writeFileAtomic(path, []byte("server { listen 80; }\n"), 0644); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != "server { listen 80; }\n" {
+		t.Fatalf("content mismatch or read err: got=%q err=%v", got, err)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("expected sibling .tmp to be cleaned up, stat err=%v", err)
+	}
+}
+
+func TestWriteFileAtomic_preservesExistingFileMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "managed.conf")
+	if err := os.WriteFile(path, []byte("v1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFileAtomic(path, []byte("v2\n"), 0644); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Errorf("existing chmod was reset: got mode %o, want 0600", got)
+	}
+}
+
+func TestWriteFileAtomic_usesCallerModeForNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fresh.conf")
+	if err := writeFileAtomic(path, []byte("x"), 0644); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0644 {
+		t.Errorf("fresh-create mode: got %o, want 0644", got)
+	}
+}
+
+func TestEnsureDefaultVhost_leavesNoTempFilesInConfD(t *testing.T) {
+	confD := setupConfD(t)
+	if err := EnsureDefaultVhost(); err != nil {
+		t.Fatalf("EnsureDefaultVhost: %v", err)
+	}
+	// Second pass through the "on-disk matches what we last wrote" branch.
+	if err := EnsureDefaultVhost(); err != nil {
+		t.Fatalf("re-run EnsureDefaultVhost: %v", err)
+	}
+	entries, err := os.ReadDir(confD)
+	if err != nil {
+		t.Fatalf("readdir conf.d: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("unexpected leftover temp file in conf.d: %s", e.Name())
+		}
+	}
+}
+
 func TestEnsureLerdVhost_linuxProxiesUnixSocket(t *testing.T) {
 	if runtime.GOOS == "darwin" {
 		t.Skip("Linux uses the unix socket vhost; macOS uses TCP via host.containers.internal")

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -144,62 +144,50 @@ func ContainerfileHash() (string, error) {
 	return fmt.Sprintf("%x", sum), nil
 }
 
-// fpmContainerfileHashLabel is written on every PHP-FPM image at build
-// time so NeedsFPMRebuild can detect drift independently of the cache
-// file. A bug in lerd < v1.22.0 advanced the cache file without actually
-// rebuilding, leaving images that were stale-but-not-detectable. The
-// label is the source of truth; the cache file is a fast-path.
+// fpmContainerfileHashLabel is stamped on every PHP-FPM image so
+// NeedsFPMRebuild can detect drift even when the cache file lies (lerd
+// < v1.22.0 advanced the cache without actually rebuilding).
 const fpmContainerfileHashLabel = "dev.lerd.fpm.containerfile-hash"
 
 // Seams for NeedsFPMRebuild so tests can fake the podman shell-outs.
 var (
-	installedFPMImagesFn = installedFPMImages
-	imageLabelFn         = imageLabel
+	imageLabelFn        = imageLabel
+	containerfileHashFn = ContainerfileHash
 )
 
+// FPMImageName returns the local image tag for a PHP version, e.g.
+// "lerd-php83-fpm:local" for "8.3". Centralised so callers and the
+// rebuild-detection logic agree on the naming convention.
+func FPMImageName(version string) string {
+	return "lerd-php" + strings.ReplaceAll(version, ".", "") + "-fpm:local"
+}
+
 // NeedsFPMRebuild returns true when the embedded Containerfile differs
-// from the cache file OR from any installed image's hash label (catches
-// the pre-v1.22.0 poisoned-cache state). False on a fresh install.
-func NeedsFPMRebuild() bool {
-	current, err := ContainerfileHash()
+// from the cache file OR from any active version's image label (catches
+// the pre-v1.22.0 poisoned-cache state). Scoped to activeVersions so
+// orphaned legacy images for versions the user has since removed don't
+// trigger a perpetual rebuild loop. False on a fresh install.
+func NeedsFPMRebuild(activeVersions []string) bool {
+	current, err := containerfileHashFn()
 	if err != nil {
-		return false
+		// Hash unreadable means we cannot prove the image is current; force
+		// a rebuild rather than silently treat it as up to date.
+		return true
 	}
 	if stored, err := os.ReadFile(config.PHPImageHashFile()); err == nil {
 		if strings.TrimSpace(string(stored)) != current {
 			return true
 		}
 	}
-	// Cache file says we're up to date; verify against the labels on the
-	// images themselves so a poisoned cache from older lerd binaries
-	// (hash advanced without a rebuild) still triggers a rebuild.
-	for _, image := range installedFPMImagesFn() {
-		label := imageLabelFn(image, fpmContainerfileHashLabel)
-		if label != current {
+	// Cache file says we're up to date; verify against the label on each
+	// active version's image so a poisoned cache from older lerd binaries
+	// still triggers a rebuild, while ignoring orphan legacy images.
+	for _, v := range activeVersions {
+		if imageLabelFn(FPMImageName(v), fpmContainerfileHashLabel) != current {
 			return true
 		}
 	}
 	return false
-}
-
-// installedFPMImages returns the local lerd PHP-FPM image names that
-// currently exist. NeedsFPMRebuild walks this list to compare labels.
-func installedFPMImages() []string {
-	out, err := exec.Command(PodmanBin(), "images",
-		"--format", "{{.Repository}}:{{.Tag}}",
-		"--filter", "reference=lerd-php*-fpm:local",
-	).Output()
-	if err != nil {
-		return nil
-	}
-	var names []string
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if line == "" {
-			continue
-		}
-		names = append(names, line)
-	}
-	return names
 }
 
 // imageLabel reads a single label from a local image. Returns "" on any
@@ -347,8 +335,7 @@ func tryPullBaseImage(version string, w io.Writer) string {
 }
 
 func buildFPMImage(version string, force, local bool, customExts []string, extDeps map[string][]string, w io.Writer) error {
-	short := strings.ReplaceAll(version, ".", "")
-	imageName := "lerd-php" + short + "-fpm:local"
+	imageName := FPMImageName(version)
 
 	if !force {
 		// Skip if image already exists
@@ -541,8 +528,7 @@ func phpExtensionLoaded(moduleOutput, ext string) bool {
 // it isn't loaded (the PECL build failed and was swallowed by the "|| true" guard
 // in the custom-extension RUN block).
 func VerifyExtensionLoaded(version, ext string) error {
-	short := strings.ReplaceAll(version, ".", "")
-	imageName := "lerd-php" + short + "-fpm:local"
+	imageName := FPMImageName(version)
 	out, err := exec.Command(PodmanBin(), "run", "--rm", imageName, "php", "-m").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("inspecting extensions in %s: %w\n%s", imageName, err, out)

--- a/internal/podman/build_test.go
+++ b/internal/podman/build_test.go
@@ -1,6 +1,7 @@
 package podman
 
 import (
+	"errors"
 	"os"
 	"reflect"
 	"strings"
@@ -185,7 +186,7 @@ func TestPhpExtensionLoaded(t *testing.T) {
 	}
 }
 
-func TestNeedsFPMRebuild_CacheMatches_NoImages_NoRebuild(t *testing.T) {
+func TestNeedsFPMRebuild_CacheMatches_NoActiveVersions_NoRebuild(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)
 	if err := os.MkdirAll(config.DataDir(), 0755); err != nil {
@@ -199,12 +200,8 @@ func TestNeedsFPMRebuild_CacheMatches_NoImages_NoRebuild(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	prev := installedFPMImagesFn
-	installedFPMImagesFn = func() []string { return nil }
-	t.Cleanup(func() { installedFPMImagesFn = prev })
-
-	if NeedsFPMRebuild() {
-		t.Error("expected no rebuild when cache matches and no images installed")
+	if NeedsFPMRebuild(nil) {
+		t.Error("expected no rebuild when cache matches and no active versions")
 	}
 }
 
@@ -217,25 +214,19 @@ func TestNeedsFPMRebuild_CacheMatches_LabelMatches_NoRebuild(t *testing.T) {
 	current, _ := ContainerfileHash()
 	_ = os.WriteFile(config.PHPImageHashFile(), []byte(current), 0644)
 
-	prevImages := installedFPMImagesFn
 	prevLabel := imageLabelFn
-	installedFPMImagesFn = func() []string { return []string{"lerd-php84-fpm:local"} }
 	imageLabelFn = func(image, key string) string { return current }
-	t.Cleanup(func() {
-		installedFPMImagesFn = prevImages
-		imageLabelFn = prevLabel
-	})
+	t.Cleanup(func() { imageLabelFn = prevLabel })
 
-	if NeedsFPMRebuild() {
+	if NeedsFPMRebuild([]string{"8.4"}) {
 		t.Error("expected no rebuild when both cache and label match the embedded Containerfile")
 	}
 }
 
 func TestNeedsFPMRebuild_CacheMatches_LabelMismatch_TriggersRebuild(t *testing.T) {
 	// Poisoned-state recovery: an older lerd binary advanced the cache file
-	// without rebuilding, so the cache says "up to date" but the actual
-	// image was built from a previous Containerfile and carries the old
-	// hash as its label.
+	// without rebuilding, so the cache says "up to date" but the active
+	// image carries the old hash as its label.
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)
 	if err := os.MkdirAll(config.DataDir(), 0755); err != nil {
@@ -244,16 +235,11 @@ func TestNeedsFPMRebuild_CacheMatches_LabelMismatch_TriggersRebuild(t *testing.T
 	current, _ := ContainerfileHash()
 	_ = os.WriteFile(config.PHPImageHashFile(), []byte(current), 0644)
 
-	prevImages := installedFPMImagesFn
 	prevLabel := imageLabelFn
-	installedFPMImagesFn = func() []string { return []string{"lerd-php84-fpm:local"} }
 	imageLabelFn = func(image, key string) string { return "deadbeefoldhash" }
-	t.Cleanup(func() {
-		installedFPMImagesFn = prevImages
-		imageLabelFn = prevLabel
-	})
+	t.Cleanup(func() { imageLabelFn = prevLabel })
 
-	if !NeedsFPMRebuild() {
+	if !NeedsFPMRebuild([]string{"8.4"}) {
 		t.Error("expected rebuild when image label disagrees with the embedded Containerfile hash (the poisoned-state recovery path)")
 	}
 }
@@ -269,16 +255,11 @@ func TestNeedsFPMRebuild_CacheMatches_LegacyImageWithoutLabel_TriggersRebuild(t 
 	current, _ := ContainerfileHash()
 	_ = os.WriteFile(config.PHPImageHashFile(), []byte(current), 0644)
 
-	prevImages := installedFPMImagesFn
 	prevLabel := imageLabelFn
-	installedFPMImagesFn = func() []string { return []string{"lerd-php84-fpm:local"} }
 	imageLabelFn = func(image, key string) string { return "" }
-	t.Cleanup(func() {
-		installedFPMImagesFn = prevImages
-		imageLabelFn = prevLabel
-	})
+	t.Cleanup(func() { imageLabelFn = prevLabel })
 
-	if !NeedsFPMRebuild() {
+	if !NeedsFPMRebuild([]string{"8.4"}) {
 		t.Error("expected rebuild when the image carries no fpm-containerfile-hash label (pre-label lerd build)")
 	}
 }
@@ -292,12 +273,102 @@ func TestNeedsFPMRebuild_CacheMismatch_TriggersRebuild(t *testing.T) {
 	// Stored hash from a hypothetical old template.
 	_ = os.WriteFile(config.PHPImageHashFile(), []byte("stale-cached-hash"), 0644)
 
-	prevImages := installedFPMImagesFn
-	installedFPMImagesFn = func() []string { return nil }
-	t.Cleanup(func() { installedFPMImagesFn = prevImages })
-
-	if !NeedsFPMRebuild() {
+	if !NeedsFPMRebuild(nil) {
 		t.Error("expected rebuild when the cache file disagrees with the embedded Containerfile")
+	}
+}
+
+func TestNeedsFPMRebuild_OrphanLegacyImagesDoNotForceRebuild(t *testing.T) {
+	// Pre-v1.22.0 images for PHP versions the user has since removed
+	// (lerd-php72-fpm:local, etc.) carry no hash label. The first label
+	// scan iterated every lerd-php*-fpm:local image on disk and would
+	// return true forever on those orphans, even when every active
+	// version had a correct label.
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := os.MkdirAll(config.DataDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+	current, _ := ContainerfileHash()
+	_ = os.WriteFile(config.PHPImageHashFile(), []byte(current), 0644)
+
+	prevLabel := imageLabelFn
+	imageLabelFn = func(image, key string) string {
+		switch image {
+		case "lerd-php83-fpm:local", "lerd-php84-fpm:local", "lerd-php85-fpm:local":
+			return current
+		default:
+			return "" // orphan, no label
+		}
+	}
+	t.Cleanup(func() { imageLabelFn = prevLabel })
+
+	if NeedsFPMRebuild([]string{"8.3", "8.4", "8.5"}) {
+		t.Error("expected no rebuild: every active version's label matches current, orphans must be ignored")
+	}
+}
+
+func TestNeedsFPMRebuild_ActiveVersionLabelMismatchTriggersRebuild(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := os.MkdirAll(config.DataDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+	current, _ := ContainerfileHash()
+	_ = os.WriteFile(config.PHPImageHashFile(), []byte(current), 0644)
+
+	prevLabel := imageLabelFn
+	imageLabelFn = func(image, key string) string {
+		if image == "lerd-php84-fpm:local" {
+			return "stale-label-from-poisoned-cache"
+		}
+		return current
+	}
+	t.Cleanup(func() { imageLabelFn = prevLabel })
+
+	if !NeedsFPMRebuild([]string{"8.3", "8.4"}) {
+		t.Error("expected rebuild: active version 8.4's label disagrees with current")
+	}
+}
+
+func TestNeedsFPMRebuild_HashError_TriggersRebuild(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := os.MkdirAll(config.DataDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	prevHash := containerfileHashFn
+	containerfileHashFn = func() (string, error) { return "", errors.New("embed unreadable") }
+	t.Cleanup(func() { containerfileHashFn = prevHash })
+
+	if !NeedsFPMRebuild(nil) {
+		t.Error("expected rebuild when the Containerfile hash cannot be computed")
+	}
+}
+
+func TestNeedsFPMRebuild_NoCacheNoActiveVersions_NoRebuild(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := os.MkdirAll(config.DataDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if NeedsFPMRebuild(nil) {
+		t.Error("expected no rebuild on a fresh install (no cache, no active versions): nothing to update")
+	}
+}
+
+func TestFPMImageName(t *testing.T) {
+	cases := map[string]string{
+		"8.3": "lerd-php83-fpm:local",
+		"8.4": "lerd-php84-fpm:local",
+		"7.2": "lerd-php72-fpm:local",
+	}
+	for version, want := range cases {
+		if got := FPMImageName(version); got != want {
+			t.Errorf("FPMImageName(%q) = %q, want %q", version, got, want)
+		}
 	}
 }
 

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -133,10 +133,9 @@ func xmlEscStr(s string) string {
 	return buf.String()
 }
 
-// keepAlivePolicy mirrors the subset of systemd Restart= values we care about.
-// launchd's bare `KeepAlive=true` respawns on any exit, including a clean one,
-// which doesn't match systemd `Restart=on-failure` semantics — that mismatch
-// caused the tray Quit button to be reincarnated by launchd immediately.
+// keepAlivePolicy mirrors the subset of systemd Restart= values we care
+// about; bare KeepAlive=true respawns on clean exit, which is wrong for
+// Restart=on-failure (was breaking the tray Quit button).
 type keepAlivePolicy int
 
 const (

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -6,11 +6,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"syscall"
 	"time"
 
@@ -68,27 +70,39 @@ const daemonEnv = "LERD_TRAY_DAEMON"
 
 // lerdBin resolves the absolute path to the `lerd` binary. The tray often
 // runs under launchd, whose environment has no PATH covering Homebrew or
-// ~/.local/bin, so a bare `exec.Command("lerd", …)` silently fails. Resolved
-// on every call so reinstalls (Homebrew → ~/.local/bin, etc.) don't strand
-// a long-running tray on a stale cached path.
+// ~/.local/bin, so a bare `exec.Command("lerd", …)` silently fails.
+// Resolved on every call so reinstalls don't strand on a cached path.
 func lerdBin() string {
-	if p, err := exec.LookPath("lerd"); err == nil {
+	if p, err := lerdBinLookPath("lerd"); err == nil {
 		return p
 	}
-	candidates := []string{
-		"/opt/homebrew/bin/lerd",
-		"/usr/local/bin/lerd",
-	}
-	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		candidates = append(candidates, filepath.Join(home, ".local", "bin", "lerd"))
-	}
-	for _, c := range candidates {
+	for _, c := range lerdBinCandidates() {
 		if _, err := os.Stat(c); err == nil {
 			return c
 		}
 	}
+	lerdBinFallbackWarn.Do(func() {
+		fmt.Fprintln(lerdBinWarnW, "lerd-tray: could not locate the lerd binary on PATH or in known install dirs; menu actions will fail with 'executable file not found'")
+	})
 	return "lerd"
 }
+
+func defaultLerdBinCandidates() []string {
+	cands := []string{"/opt/homebrew/bin/lerd", "/usr/local/bin/lerd"}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		cands = append(cands, filepath.Join(home, ".local", "bin", "lerd"))
+	}
+	return cands
+}
+
+// Seams for tests so the fallback path can be exercised without depending
+// on what happens to be installed on the host running the tests.
+var (
+	lerdBinCandidates             = defaultLerdBinCandidates
+	lerdBinLookPath               = exec.LookPath
+	lerdBinWarnW        io.Writer = os.Stderr
+	lerdBinFallbackWarn sync.Once
+)
 
 // lerdCmd is a thin wrapper around exec.Command that uses the resolved
 // `lerd` binary path so handlers work under launchd's empty PATH.

--- a/internal/tray/tray_test.go
+++ b/internal/tray/tray_test.go
@@ -3,7 +3,12 @@
 package tray
 
 import (
+	"bytes"
+	"errors"
 	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -29,5 +34,57 @@ func TestRunAndRefresh_CallsRefreshEvenWhenCommandFails(t *testing.T) {
 	runAndRefresh(exec.Command("false"), func() { called = true })
 	if !called {
 		t.Error("refresh should be called even if the command fails so the menu still redraws")
+	}
+}
+
+func TestLerdBin_FallbackWarnsOnceAndReturnsBareName(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope")
+
+	prevLook := lerdBinLookPath
+	prevCands := lerdBinCandidates
+	prevW := lerdBinWarnW
+	lerdBinLookPath = func(string) (string, error) { return "", errors.New("not on PATH") }
+	lerdBinCandidates = func() []string { return []string{missing} }
+	var buf bytes.Buffer
+	lerdBinWarnW = &buf
+	lerdBinFallbackWarn = sync.Once{}
+	t.Cleanup(func() {
+		lerdBinLookPath = prevLook
+		lerdBinCandidates = prevCands
+		lerdBinWarnW = prevW
+		lerdBinFallbackWarn = sync.Once{}
+	})
+
+	if got := lerdBin(); got != "lerd" {
+		t.Errorf("first call: lerdBin() = %q, want %q (bare fallback)", got, "lerd")
+	}
+	if !strings.Contains(buf.String(), "could not locate the lerd binary") {
+		t.Errorf("expected fallback warning on stderr, got: %q", buf.String())
+	}
+	first := buf.Len()
+
+	if got := lerdBin(); got != "lerd" {
+		t.Errorf("second call: lerdBin() = %q, want %q", got, "lerd")
+	}
+	if buf.Len() != first {
+		t.Errorf("sync.Once should suppress repeat warnings; buffer grew from %d to %d", first, buf.Len())
+	}
+}
+
+func TestLerdBin_PrefersLookPathHit(t *testing.T) {
+	prevLook := lerdBinLookPath
+	prevCands := lerdBinCandidates
+	lerdBinLookPath = func(string) (string, error) { return "/opt/from-path/lerd", nil }
+	lerdBinCandidates = func() []string {
+		t.Error("candidates must not be consulted when LookPath succeeds")
+		return nil
+	}
+	t.Cleanup(func() {
+		lerdBinLookPath = prevLook
+		lerdBinCandidates = prevCands
+	})
+
+	if got := lerdBin(); got != "/opt/from-path/lerd" {
+		t.Errorf("lerdBin() = %q, want LookPath result", got)
 	}
 }


### PR DESCRIPTION
A small cluster of hardenings surfaced while reviewing the code that landed since v1.22.0. Three real fixes, plus a comment-trim chore.

Scoping the PHP-FPM rebuild check to active versions fixes a perpetual rebuild loop: the label scan introduced in v1.22.0 walked every lerd-php*-fpm:local image on disk, including orphaned legacy images for PHP versions the user had since removed. Those carry no containerfile-hash label, so `lerd install` re-fired the rebuild banner every run, even after a successful rebuild of the active versions. NeedsFPMRebuild now takes the active list from phpDet.ListInstalled and only checks labels on those versions' images, and the caller reuses the list for the start loop below. Also forces a rebuild when ContainerfileHash errors instead of silently treating images as up to date.

EnsureDefaultVhost now writes _default.conf atomically via a temp-and-rename helper. The previous back-to-back os.WriteFile calls could leave lerd-managed content with no sentinel after a crash, and an in-place truncate briefly exposes half-written content to a concurrent nginx reload. The new helper also preserves the destination's existing file mode so an out-of-band chmod survives the rewrite.

The system-tray binary resolver now logs a deduped warning to stderr the first time it falls through to the bare-name fallback. Under launchd the tray runs with an empty PATH; previously a missing lerd binary produced unresponsive menu clicks with no log trace.