### PR TITLE
fix(services): unify installed-detection on quadlet presence

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	phpPkg "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/serviceops"
 	"github.com/spf13/cobra"
 )
 
@@ -185,12 +186,11 @@ func runCheck(_ *cobra.Command, _ []string) error {
 			continue
 		}
 
-		// Check for custom service definition on disk.
-		if _, err := config.LoadCustomService(svc.Name); err == nil {
+		if serviceops.ServiceInstalled(svc.Name) {
 			fmt.Printf("  OK    service: %s (custom)\n", svc.Name)
 		} else {
-			fmt.Printf("  FAIL  service %q: not a built-in service and no definition found at %s\n",
-				svc.Name, filepath.Join(config.CustomServicesDir(), svc.Name+".yaml"))
+			fmt.Printf("  FAIL  service %q: not installed — run `lerd service preset install %s` (if it's a bundled preset) or `lerd service add --name %s ...`\n",
+				svc.Name, svc.Name, svc.Name)
 			errors++
 		}
 	}
@@ -279,7 +279,7 @@ func runCheck(_ *cobra.Command, _ []string) error {
 	if cfg.DB.Service != "" {
 		if isKnownService(cfg.DB.Service) {
 			fmt.Printf("  OK    db.service: %s\n", cfg.DB.Service)
-		} else if _, err := config.LoadCustomService(cfg.DB.Service); err == nil {
+		} else if serviceops.ServiceInstalled(cfg.DB.Service) {
 			fmt.Printf("  OK    db.service: %s (custom)\n", cfg.DB.Service)
 		} else {
 			fmt.Printf("  FAIL  db.service: %q is not a known service\n", cfg.DB.Service)

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -508,7 +508,7 @@ Or specify inline with flags (--name and --image are required):
 			if isKnownService(svc.Name) {
 				return fmt.Errorf("%q is a built-in service and cannot be redefined", svc.Name)
 			}
-			if _, err := config.LoadCustomService(svc.Name); err == nil {
+			if serviceops.ServiceInstalled(svc.Name) {
 				return fmt.Errorf("custom service %q already exists; remove it first with: lerd service remove %s", svc.Name, svc.Name)
 			}
 
@@ -603,12 +603,11 @@ stopped, removed, exposed, or pinned with the usual service subcommands.`,
 func promptPresetVersion(p *config.Preset) (string, error) {
 	options := make([]huh.Option[string], 0, len(p.Versions))
 	for _, v := range p.Versions {
-		svcName := p.Name + "-" + config.SanitizeImageTag(v.Tag)
 		label := v.Label
 		if label == "" {
 			label = v.Tag
 		}
-		if _, err := config.LoadCustomService(svcName); err == nil {
+		if serviceops.ServiceInstalled(config.PresetVersionServiceName(p.Name, v)) {
 			label += " (already installed)"
 		}
 		options = append(options, huh.NewOption(label, v.Tag))
@@ -647,13 +646,13 @@ func printPresetList() error {
 	for _, p := range presets {
 		status := "available"
 		if len(p.Versions) == 0 {
-			if _, err := config.LoadCustomService(p.Name); err == nil {
+			if serviceops.ServiceInstalled(p.Name) {
 				status = "installed"
 			}
 		} else {
 			anyInstalled := false
 			for _, v := range p.Versions {
-				if _, err := config.LoadCustomService(config.PresetVersionServiceName(p.Name, v)); err == nil {
+				if serviceops.ServiceInstalled(config.PresetVersionServiceName(p.Name, v)) {
 					anyInstalled = true
 					break
 				}
@@ -675,7 +674,7 @@ func printPresetList() error {
 			if v.Label != "" {
 				label = v.Label
 			}
-			if _, err := config.LoadCustomService(config.PresetVersionServiceName(p.Name, v)); err == nil {
+			if serviceops.ServiceInstalled(config.PresetVersionServiceName(p.Name, v)) {
 				versionStatus = "installed"
 			}
 			marker := " "

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2608,7 +2608,7 @@ func execCheck(args map[string]any) (any, *rpcError) {
 		if svc.Preset != "" {
 			if _, err := config.LoadPreset(svc.Preset); err != nil {
 				add("service_"+svc.Name, "fail", fmt.Sprintf("unknown preset %q", svc.Preset))
-			} else if _, err := config.LoadCustomService(svc.Name); err != nil {
+			} else if !serviceops.ServiceInstalled(svc.Name) {
 				add("service_"+svc.Name, "warn", fmt.Sprintf("preset %q not installed — run: lerd service preset install %s", svc.Preset, svc.Preset))
 			} else {
 				add("service_"+svc.Name, "ok", "preset: "+svc.Preset)
@@ -2619,10 +2619,10 @@ func execCheck(args map[string]any) (any, *rpcError) {
 			add("service_"+svc.Name, "ok", "")
 			continue
 		}
-		if _, err := config.LoadCustomService(svc.Name); err == nil {
+		if serviceops.ServiceInstalled(svc.Name) {
 			add("service_"+svc.Name, "ok", "custom")
 		} else {
-			add("service_"+svc.Name, "fail", "not a built-in and no definition found")
+			add("service_"+svc.Name, "fail", fmt.Sprintf("not installed — run `lerd service preset install %s` (if it's a bundled preset) or `lerd service add --name %s ...`", svc.Name, svc.Name))
 		}
 	}
 
@@ -2667,7 +2667,7 @@ func execCheck(args map[string]any) (any, *rpcError) {
 	if cfg.DB.Service != "" {
 		if isKnownService(cfg.DB.Service) {
 			add("db.service", "ok", cfg.DB.Service)
-		} else if _, err := config.LoadCustomService(cfg.DB.Service); err == nil {
+		} else if serviceops.ServiceInstalled(cfg.DB.Service) {
 			add("db.service", "ok", cfg.DB.Service+" (custom)")
 		} else {
 			add("db.service", "fail", cfg.DB.Service+" is not a known service")
@@ -2727,7 +2727,7 @@ func execServiceAdd(args map[string]any) (any, *rpcError) {
 	if isKnownService(name) {
 		return toolErr(name + " is a built-in service and cannot be redefined"), nil
 	}
-	if _, err := config.LoadCustomService(name); err == nil {
+	if serviceops.ServiceInstalled(name) {
 		return toolErr("custom service " + name + " already exists; remove it first with service_remove"), nil
 	}
 
@@ -2826,18 +2826,17 @@ func execServicePresetList(_ map[string]any) (any, *rpcError) {
 			DefaultVersion: p.DefaultVersion,
 		}
 		if len(p.Versions) == 0 {
-			if _, err := config.LoadCustomService(p.Name); err == nil {
+			if serviceops.ServiceInstalled(p.Name) {
 				e.Installed = true
 			}
 		} else {
 			anyInstalled := false
 			for _, v := range p.Versions {
-				_, loadErr := config.LoadCustomService(config.PresetVersionServiceName(p.Name, v))
 				vi := versionEntry{
 					Tag:       v.Tag,
 					Label:     v.Label,
 					Image:     v.Image,
-					Installed: loadErr == nil,
+					Installed: serviceops.ServiceInstalled(config.PresetVersionServiceName(p.Name, v)),
 				}
 				if vi.Installed {
 					anyInstalled = true

--- a/internal/serviceops/remove_test.go
+++ b/internal/serviceops/remove_test.go
@@ -190,6 +190,40 @@ func TestRemoveService_DefaultPresetSucceeds(t *testing.T) {
 	}
 }
 
+// TestRemoveService_OrphanQuadlet_NoYAML_Succeeds covers the recovery path for
+// the orphan-quadlet bug: a service whose YAML config is missing but whose
+// .container quadlet still exists must be removable so users can fully clean
+// up the drift that motivated unifying installed-detection on the quadlet.
+func TestRemoveService_OrphanQuadlet_NoYAML_Succeeds(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	rec := stubPodmanRemove(t)
+
+	qdir := config.QuadletDir()
+	if err := os.MkdirAll(qdir, 0o755); err != nil {
+		t.Fatalf("mkdir quadlet dir: %v", err)
+	}
+	quadletPath := filepath.Join(qdir, "lerd-mysql.container")
+	if err := os.WriteFile(quadletPath, []byte("[Container]\nImage=docker.io/library/mysql:8.4\n"), 0o644); err != nil {
+		t.Fatalf("write quadlet: %v", err)
+	}
+	if !ServiceInstalled("mysql") {
+		t.Fatalf("precondition: ServiceInstalled should report true with quadlet on disk")
+	}
+	if _, err := config.LoadCustomService("mysql"); err == nil {
+		t.Fatalf("precondition: no YAML expected for mysql in this temp tree")
+	}
+
+	if err := RemoveService("mysql", RemoveOptions{RemoveData: false}, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("RemoveService for orphan quadlet should not error: %v", err)
+	}
+	if got := rec.removedQuadlets; len(got) != 1 || got[0] != "lerd-mysql" {
+		t.Errorf("expected RemoveQuadlet(\"lerd-mysql\"), got %v", got)
+	}
+}
+
 func TestRemoveService_InactiveUnit_SkipsStop(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)

--- a/internal/serviceops/service_installed_test.go
+++ b/internal/serviceops/service_installed_test.go
@@ -1,0 +1,41 @@
+package serviceops
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// TestServiceInstalled_quadletIsSourceOfTruth covers the orphan-quadlet case
+// that motivated the helper: a service whose YAML config has been deleted but
+// whose .container quadlet still exists must still report as installed,
+// matching the real runtime state podman sees.
+func TestServiceInstalled_quadletIsSourceOfTruth(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	if ServiceInstalled("mysql") {
+		t.Fatalf("expected mysql not installed on a clean tree")
+	}
+
+	quadletDir := config.QuadletDir()
+	if err := os.MkdirAll(quadletDir, 0o755); err != nil {
+		t.Fatalf("mkdir quadlet dir: %v", err)
+	}
+	quadletPath := filepath.Join(quadletDir, "lerd-mysql.container")
+	if err := os.WriteFile(quadletPath, []byte("[Container]\nImage=docker.io/library/mysql:8.4\n"), 0o644); err != nil {
+		t.Fatalf("write quadlet: %v", err)
+	}
+
+	if !ServiceInstalled("mysql") {
+		t.Fatalf("expected mysql installed when quadlet exists, even with no YAML")
+	}
+
+	if _, err := config.LoadCustomService("mysql"); err == nil {
+		t.Fatalf("test precondition broken: YAML should not exist for this scenario")
+	}
+}

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -20,6 +20,16 @@ import (
 // Kept as a passthrough so callers don't have to import config.
 func IsBuiltin(name string) bool { return config.IsDefaultPreset(name) }
 
+// ServiceInstalled is the single source of truth for whether a lerd service
+// is installed on this host. It checks for the quadlet (lerd-<name>.container)
+// because that's what podman actually uses to run the service, and it can
+// outlive the YAML when the on-disk config drifts (older installs, partial
+// removes, etc.). Use this instead of probing config.LoadCustomService when
+// you only care about install presence.
+func ServiceInstalled(name string) bool {
+	return podman.QuadletInstalled("lerd-" + name)
+}
+
 // PhaseEvent is one step of the streaming preset-install flow.
 type PhaseEvent struct {
 	Phase   string `json:"phase"`
@@ -99,7 +109,10 @@ func InstallPresetByName(name, version string) (*config.CustomService, error) {
 	if IsBuiltin(svc.Name) {
 		return nil, fmt.Errorf("%q collides with the built-in service of the same name", svc.Name)
 	}
-	if _, err := config.LoadCustomService(svc.Name); err == nil {
+	// Quadlet presence is the install-state truth (see ServiceInstalled); a
+	// yaml-only remnant from a partial install gets silently rewritten by
+	// SaveCustomService + EnsureCustomServiceQuadlet below as the heal path.
+	if ServiceInstalled(svc.Name) {
 		return nil, fmt.Errorf("custom service %q already exists; remove it first with: lerd service remove %s", svc.Name, svc.Name)
 	}
 	if missing := MissingPresetDependencies(svc); len(missing) > 0 {
@@ -118,23 +131,13 @@ func InstallPresetByName(name, version string) (*config.CustomService, error) {
 }
 
 // MissingPresetDependencies returns the names of services that svc declares
-// in depends_on but which are not currently installed. A built-in (default
-// preset) counts as installed only when its quadlet is on disk: the legacy
-// "built-ins are always available" assumption broke once
-// `lerd service remove <builtin>` shipped, and a dependent install that
-// later hits EnsureServiceRunning on a missing built-in would fail with no
-// rollback (which is exactly what reinstall pre-flight is meant to prevent).
+// in depends_on but which are not currently installed. Install-state is
+// resolved through ServiceInstalled (quadlet presence), so a dep that has a
+// quadlet but a missing YAML still counts as installed.
 func MissingPresetDependencies(svc *config.CustomService) []string {
 	var missing []string
 	for _, dep := range svc.DependsOn {
-		if IsBuiltin(dep) {
-			if podman.QuadletInstalled("lerd-" + dep) {
-				continue
-			}
-			missing = append(missing, dep)
-			continue
-		}
-		if _, err := config.LoadCustomService(dep); err == nil {
+		if ServiceInstalled(dep) {
 			continue
 		}
 		missing = append(missing, dep)

--- a/internal/tui/servicedetail.go
+++ b/internal/tui/servicedetail.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/serviceops"
 )
 
 // presetSuggestions mirrors internal/ui/web/src/stores/presetSuggestions.ts:
@@ -160,7 +161,7 @@ func serviceEnvLines(name string, custom bool) []string {
 // presetSuggestionFor returns a one-line nudge string when the focused
 // service has an associated admin-dashboard preset the user hasn't
 // installed yet. Returns "" when there's no suggestion or the admin
-// service is already running (we detect via custom service registration).
+// service is already installed (detected via serviceops.ServiceInstalled).
 func presetSuggestionFor(svc *ServiceRow) string {
 	if svc == nil {
 		return ""
@@ -169,8 +170,7 @@ func presetSuggestionFor(svc *ServiceRow) string {
 	if !ok {
 		return ""
 	}
-	if _, err := config.LoadCustomService(target); err == nil {
-		// Already installed — no banner.
+	if serviceops.ServiceInstalled(target) {
 		return ""
 	}
 	return "install " + target + " for a browser dashboard (run `lerd preset install " + target + "`)"

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1201,12 +1201,12 @@ func handleServicePresets(w http.ResponseWriter, r *http.Request) {
 		installed := false
 		var installedTags []string
 		if len(p.Versions) == 0 {
-			if _, err := config.LoadCustomService(p.Name); err == nil {
+			if serviceops.ServiceInstalled(p.Name) {
 				installed = true
 			}
 		} else {
 			for _, v := range p.Versions {
-				if _, err := config.LoadCustomService(config.PresetVersionServiceName(p.Name, v)); err == nil {
+				if serviceops.ServiceInstalled(config.PresetVersionServiceName(p.Name, v)) {
 					installed = true
 					installedTags = append(installedTags, v.Tag)
 				}


### PR DESCRIPTION
service_preset_list (MCP), the web UI /api/services/presets endpoint, and lerd service preset both probed for the YAML in ~/.config/lerd/services/ when answering "is this installed?". The rest of the codebase (dependency checks, reinstall preflight) probes the quadlet at ~/.config/containers/systemd/lerd-<name>.container. Those two views drift in real installs: a user with an orphan lerd-mysql.container and no mysql.yaml gets a running MySQL that the MCP layer insists is not installed, which is exactly the symptom one of my workflows hit when asking about a project that depends on MySQL.

Add serviceops.ServiceInstalled as the canonical helper, probing the quadlet because that's what podman actually runs and what the rest of the codebase already trusted. Route every presence check through it across MCP, the web UI, the CLI, the TUI, and the lerd check validators. The lerd check failure path now suggests the concrete remediation command rather than printing the yaml path that the user is supposed to populate. Bundle in a pre-existing CLI version-picker bug where canonical multi-version presets (mysql 8.4, postgres 16) were probed under the wrong sanitized-tag name instead of via PresetVersionServiceName.