### PR TITLE
fix(domain): sync .env APP_URL when primary domain changes in the UI

### DIFF
--- a/internal/cli/domain.go
+++ b/internal/cli/domain.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
-	"github.com/geodro/lerd/internal/envfile"
 	"github.com/geodro/lerd/internal/nginx"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteops"
@@ -126,10 +125,8 @@ func runDomainAdd(_ *cobra.Command, args []string) error {
 
 	nginx.ReloadOrWarn("")
 
-	if site.PrimaryDomain() != oldPrimary {
-		if err := envfile.SyncPrimaryDomain(site.Path, site.PrimaryDomain(), site.Secured); err != nil {
-			fmt.Printf("[WARN] syncing .env to new primary domain: %v\n", err)
-		}
+	if err := siteops.SyncEnvIfPrimaryChanged(site, oldPrimary); err != nil {
+		fmt.Printf("[WARN] syncing .env to new primary domain: %v\n", err)
 	}
 
 	fmt.Printf("Added domain %s to site %s\n", fullDomain, site.Name)
@@ -196,10 +193,8 @@ func runDomainRemove(_ *cobra.Command, args []string) error {
 
 	nginx.ReloadOrWarn("")
 
-	if site.PrimaryDomain() != oldPrimary {
-		if err := envfile.SyncPrimaryDomain(site.Path, site.PrimaryDomain(), site.Secured); err != nil {
-			fmt.Printf("[WARN] syncing .env to new primary domain: %v\n", err)
-		}
+	if err := siteops.SyncEnvIfPrimaryChanged(site, oldPrimary); err != nil {
+		fmt.Printf("[WARN] syncing .env to new primary domain: %v\n", err)
 	}
 
 	fmt.Printf("Removed domain %s from site %s\n", fullDomain, site.Name)

--- a/internal/siteops/env_sync.go
+++ b/internal/siteops/env_sync.go
@@ -1,0 +1,39 @@
+package siteops
+
+import (
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/envfile"
+	gitpkg "github.com/geodro/lerd/internal/git"
+)
+
+// SyncEnvIfPrimaryChanged updates APP_URL and the VITE_REVERB_* keys in the
+// site's project .env and rewrites APP_URL in each worktree .env to the new
+// <branch>.<newPrimary> subdomain, but only when the primary domain has
+// actually changed since oldPrimary. Returns the first non-nil error so
+// callers can warn; a worktree-detection failure is treated as no worktrees
+// rather than as a fatal error because the parent sync has already landed.
+func SyncEnvIfPrimaryChanged(site *config.Site, oldPrimary string) error {
+	newPrimary := site.PrimaryDomain()
+	if newPrimary == oldPrimary {
+		return nil
+	}
+	if err := envfile.SyncPrimaryDomain(site.Path, newPrimary, site.Secured); err != nil {
+		return err
+	}
+	scheme := "http"
+	if site.Secured {
+		scheme = "https"
+	}
+	worktrees, err := gitpkg.DetectWorktrees(site.Path, oldPrimary)
+	if err != nil {
+		return nil
+	}
+	var firstErr error
+	for _, wt := range worktrees {
+		newWTDomain := wt.Branch + "." + newPrimary
+		if err := envfile.UpdateAppURL(wt.Path, scheme, newWTDomain); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/internal/ui/domain_env_sync_test.go
+++ b/internal/ui/domain_env_sync_test.go
@@ -1,0 +1,125 @@
+package ui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSiteEnv writes a .env file at sitePath with the given body.
+func writeSiteEnv(t *testing.T, sitePath, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(sitePath, ".env"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+}
+
+func readSiteEnv(t *testing.T, sitePath string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(sitePath, ".env"))
+	if err != nil {
+		t.Fatalf("read .env: %v", err)
+	}
+	return string(body)
+}
+
+// Renaming the primary domain via the UI's domain:edit handler must rewrite
+// APP_URL in the project's .env to reflect the new domain. Mirrors the
+// envfile.SyncPrimaryDomain call the CLI domain handlers run after every
+// primary-changing mutation; previously the UI did the registry/vhost/cert
+// work but never touched .env, so APP_URL kept pointing at the old domain.
+func TestHandleSiteAction_domainEdit_syncsAppURLOnPrimaryChange(t *testing.T) {
+	sitePath := setupSecuredSite(t, "oldname")
+	writeSiteEnv(t, sitePath, "APP_NAME=Demo\nAPP_URL=https://oldname.test\nAPP_ENV=local\n")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/oldname.test/domain:edit?old=oldname&new=newname", nil)
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"ok":true`) {
+		t.Fatalf("expected ok response, got %s", rec.Body.String())
+	}
+
+	got := readSiteEnv(t, sitePath)
+	if !strings.Contains(got, "APP_URL=https://newname.test") {
+		t.Errorf("APP_URL not rewritten to new primary, got:\n%s", got)
+	}
+	if strings.Contains(got, "APP_URL=https://oldname.test") {
+		t.Errorf("old APP_URL still present, got:\n%s", got)
+	}
+}
+
+// Removing the primary domain must sync APP_URL to the next-in-line domain
+// that becomes primary. Same regression shape as domain:edit.
+func TestHandleSiteAction_domainRemove_syncsAppURLWhenPrimaryShifts(t *testing.T) {
+	sitePath := setupSecuredSite(t, "primary", "secondary.test")
+	writeSiteEnv(t, sitePath, "APP_URL=https://primary.test\n")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/primary.test/domain:remove?name=primary", nil)
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"ok":true`) {
+		t.Fatalf("expected ok response, got %s", rec.Body.String())
+	}
+
+	got := readSiteEnv(t, sitePath)
+	if !strings.Contains(got, "APP_URL=https://secondary.test") {
+		t.Errorf("APP_URL not shifted to new primary, got:\n%s", got)
+	}
+}
+
+// Worktree .env files must also get APP_URL rewritten to <branch>.<newPrimary>
+// when the parent primary changes. Previously each worktree kept pointing at
+// <branch>.<oldPrimary> until the user manually fixed it. Matches the
+// migrate_tld behaviour for full-site renames.
+func TestHandleSiteAction_domainEdit_syncsWorktreeAppURLOnPrimaryChange(t *testing.T) {
+	sitePath := setupSecuredSite(t, "oldname")
+	writeSiteEnv(t, sitePath, "APP_URL=https://oldname.test\n")
+
+	wtPath := filepath.Join(t.TempDir(), "wt-feature")
+	makeWorktree(t, sitePath, "feature", "feature", wtPath)
+	writeSiteEnv(t, wtPath, "APP_URL=https://feature.oldname.test\n")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/oldname.test/domain:edit?old=oldname&new=newname", nil)
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got := readSiteEnv(t, wtPath)
+	if !strings.Contains(got, "APP_URL=https://feature.newname.test") {
+		t.Errorf("worktree APP_URL not rewritten to <branch>.<newPrimary>, got:\n%s", got)
+	}
+}
+
+// Adding a non-primary domain must leave .env byte-identical, since the
+// primary is untouched (new domains are appended). The test plants a
+// VITE_REVERB_HOST that doesn't match the current primary so any erroneous
+// call to SyncPrimaryDomain would rewrite it and the byte compare fails.
+// Without that decoy a same-value SyncPrimaryDomain call would be invisible.
+func TestHandleSiteAction_domainAdd_leavesEnvUntouchedWhenPrimaryUnchanged(t *testing.T) {
+	sitePath := setupSecuredSite(t, "primary")
+	original := "APP_URL=https://primary.test\nVITE_REVERB_HOST=stale.test\n"
+	writeSiteEnv(t, sitePath, original)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/primary.test/domain:add?name=alias", nil)
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got := readSiteEnv(t, sitePath)
+	if got != original {
+		t.Errorf(".env was modified despite primary unchanged.\nwant:\n%s\n got:\n%s", original, got)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -2323,6 +2323,9 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		}
 		_ = podman.WriteContainerHosts()
 		_ = nginx.Reload()
+		if err := siteops.SyncEnvIfPrimaryChanged(site, oldPrimary); err != nil {
+			fmt.Fprintf(os.Stderr, "lerd-ui: syncing .env to new primary domain: %v\n", err)
+		}
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
 	case "domain:edit":
@@ -2370,6 +2373,9 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		}
 		_ = podman.WriteContainerHosts()
 		_ = nginx.Reload()
+		if err := siteops.SyncEnvIfPrimaryChanged(site, oldPrimary); err != nil {
+			fmt.Fprintf(os.Stderr, "lerd-ui: syncing .env to new primary domain: %v\n", err)
+		}
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
 	case "domain:remove":
@@ -2442,6 +2448,9 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		}
 		_ = podman.WriteContainerHosts()
 		_ = nginx.Reload()
+		if err := siteops.SyncEnvIfPrimaryChanged(site, oldPrimary); err != nil {
+			fmt.Fprintf(os.Stderr, "lerd-ui: syncing .env to new primary domain: %v\n", err)
+		}
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
 	case "tinker:symbols":


### PR DESCRIPTION
The web UI's domain mutation handlers regenerated the vhost, reissued the cert, and reloaded nginx, but never touched the project's .env. So renaming the primary domain from the domain modal left APP_URL pointing at the old host with VITE_REVERB_HOST and the other reverb keys stale alongside it. The CLI's runDomainAdd and runDomainRemove already had the right guard, but the UI is the only surface that can rename a domain in place since the CLI has no domain edit subcommand, which is why the gap was only visible through the web UI.

Extract siteops.SyncEnvIfPrimaryChanged as the seam both surfaces call when the primary changes. The helper runs envfile.SyncPrimaryDomain on the parent site (touching only the keys already present in the .env, so it never adds anything you didn't already have) and then iterates gitpkg.DetectWorktrees to rewrite each worktree's APP_URL to <branch>.<newPrimary> via envfile.UpdateAppURL, matching what migrate_tld does on a full-site rename. The three UI handlers and the two CLI handlers all route through it, collapsing five copies of the same conditional. UI handlers now log a stderr warning on sync failure so the lerd-ui journal has a trace, matching the CLI's existing [WARN] style. Worktree .env files now follow the parent rename, which neither surface did before for the regular add/remove flow.