### PR TITLE
feat(services): YAML-declared tuning override + service_config MCP tool

### DIFF
--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -103,6 +103,7 @@ Once the MCP server is connected, your AI assistant has access to:
 | `service_add` | Register a new custom OCI-based service (MongoDB, RabbitMQ, etc.); supports `depends_on` for service dependencies |
 | `service_expose` | Add or remove an extra published port on a built-in service (persisted, auto-restarts if running) |
 | `service_env` | Return the recommended `.env` connection variables for a built-in or custom service |
+| `service_config` | Read / write / restore / reset / list_backups for a service's runtime tuning override. `action` defaults to `read`. `write` takes `content` and optional `backup`. `restore` takes optional `backup_name` (newest by default). `reset` writes the bundled template and stages an implicit recovery backup. Works for built-in mysql/mariadb/redis and any custom service that declares a `tuning:` block in its YAML. |
 | `db_export` | Export a database to a SQL dump file (defaults to site DB from `.env`) |
 | `db_import` | Import a SQL dump file into the project database (reads connection from `.env`) |
 | `db_create` | Create a database and `_testing` variant for the project (infers name from `.env` or project dir) |

--- a/docs/usage/custom-services.md
+++ b/docs/usage/custom-services.md
@@ -73,7 +73,21 @@ lerd service config mariadb --no-restart
 
 `lerd service config` opens a user-editable tuning override for the service in `$EDITOR`. Lerd seeds the file once with a commented template and **never overwrites it afterward**, so your edits survive `lerd service reinstall` and `lerd update`. The override is bind-mounted *after* the bundled preset config, so any value you set wins. Saving restarts the service so it re-reads the config.
 
-Works for both custom services and built-in default presets (e.g. `lerd service preset install mariadb` then `lerd service config mariadb`). Currently the mysql and mariadb families are tunable (mounted at `/etc/mysql/conf.d/zz-lerd-user.cnf`); services without a tuning mount report that they are not supported yet.
+Works for both custom services and built-in default presets (e.g. `lerd service preset install mariadb` then `lerd service config mariadb`). The bundled mysql, mariadb, and redis families ship with a built-in tuning mount; postgres is not yet supported because of how its include_dir directive is parsed. For any other image, declare your own tuning mount in the service YAML with a `tuning:` block:
+
+```yaml
+name: my-cache
+image: docker.io/library/memcached:1.6-alpine
+tuning:
+  target: /etc/memcached.conf         # required, where the override mounts in the container
+  template: |                          # optional, the seed body shown on first edit
+    # Lerd user tuning for memcached
+    # Uncomment, tune, then save to apply.
+    # -m 128
+  command: memcached -f /etc/memcached.conf   # optional, only when the image needs to be told to read the file
+```
+
+The inline `tuning:` block exposes the Config tab and the `lerd service config <name>` CLI for any custom service. `target` is required; if your image already auto-includes its target path, leave `command` empty (mysql / mariadb work this way). Set `command` when the image loads no config by default (redis is the built-in example). Inline tuning wins over the family-keyed defaults, so you can override the bundled mysql/mariadb/redis paths if you ship a non-standard image.
 
 The service must already be installed — running `lerd service config <name>` against a service whose quadlet isn't on disk errors out with a hint to `lerd service preset install <name>` first, rather than silently reinstalling it as a side effect of an edit.
 
@@ -140,6 +154,18 @@ depends_on:
 # of the same name. Multi-version preset alternates inherit this through the
 # preset YAML; hand-rolled custom services can opt in by setting the field.
 family: mysql
+
+# Tuning exposes the Config tab + `lerd service config` for this service.
+# Only target is required; template seeds the first-edit body, command sets
+# the container Exec when the image needs to be told to read the file
+# (mysql/mariadb auto-include their conf dir; redis needs `redis-server <path>`).
+# When set, inline tuning wins over the family-keyed defaults.
+tuning:
+  target: /etc/memcached.conf
+  template: |
+    # Lerd user tuning for memcached.
+    # -m 128
+  command: memcached -f /etc/memcached.conf
 
 # Dynamic env vars are computed at quadlet generation time. Currently supported
 # directive: discover_family:<name>[,<name>...] which expands to a comma-joined

--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -87,6 +87,13 @@ type CustomService struct {
 	// member. e.g. the mysql preset declares family: mysql, and phpMyAdmin
 	// uses dynamic_env to read all family members at quadlet generation time.
 	Family string `yaml:"family,omitempty"`
+	// Tuning, when set, exposes a user-editable runtime config override
+	// for this service via the web UI's Config tab and the
+	// `lerd service config` CLI. Custom services declare their own
+	// override path here without needing a known family — the built-in
+	// mysql/mariadb/redis families remain the fallback when this is nil.
+	// See ServiceTuningMount / ServiceTuningTemplate / ServiceTuningCommand.
+	Tuning *TuningSpec `yaml:"tuning,omitempty"`
 	// Preset is the bundled preset name this service was installed from.
 	// Set by InstallPresetByName. Used so the init wizard can store a
 	// preset reference in .lerd.yaml instead of an inlined definition.

--- a/internal/config/service_tuning.go
+++ b/internal/config/service_tuning.go
@@ -9,8 +9,10 @@ import (
 
 // tuningMount describes where a service family's user tuning override is
 // bind-mounted inside the container, plus the commented template lerd seeds on
-// first use. Only families listed in tuningMounts expose a tuning file; every
-// other service reports ok=false from ServiceTuningMount.
+// first use. Only families listed in tuningMounts expose a tuning file as a
+// FALLBACK; user-authored services can also declare their own tuning via the
+// inline TuningSpec on CustomService, which takes precedence over the family
+// map.
 type tuningMount struct {
 	// Target is the absolute in-container path the override is mounted to. It
 	// is chosen so the container's config loader reads it after the bundled
@@ -24,6 +26,64 @@ type tuningMount struct {
 	// directory (mysql/mariadb) leave this empty. e.g. redis must be told
 	// "redis-server <conf>" since it loads no config file by default.
 	Command string
+}
+
+// TuningSpec is the YAML shape user-authored CustomService entries use to
+// declare their own tuning override without having to match a recognised
+// family. Set svc.Tuning to expose the Config tab + lerd service config
+// for any image whose config loader reads from a specific in-container
+// path.
+//
+//	tuning:
+//	  target: /etc/memcached.conf
+//	  template: |
+//	    # Lerd user tuning for this memcached service.
+//	    # -m 128
+//	  command: memcached -f /etc/memcached.conf   # optional, only when the
+//	                                                # image needs to be told
+//	                                                # to read the file
+type TuningSpec struct {
+	// Target is the absolute in-container path the override is mounted
+	// to. Required. Lerd bind-mounts the host file
+	// (ServiceTuningFile(svc.Name)) read-only at this path; the image
+	// must auto-include the file or be pointed at it via Command.
+	Target string `yaml:"target"`
+	// Template is the body lerd seeds the host file with on first use.
+	// Optional; defaults to an empty file. Conventionally a commented
+	// hint sheet so users discover the available knobs without lerd
+	// having to ship working defaults.
+	Template string `yaml:"template,omitempty"`
+	// Command, when set, overrides the container Exec so the image
+	// actually loads the override (e.g. `redis-server <path>` for an
+	// image that loads no config by default). Leave empty for images
+	// whose entrypoint already auto-includes the target path.
+	Command string `yaml:"command,omitempty"`
+}
+
+// inlineMount converts a YAML-declared TuningSpec into the same internal
+// tuningMount shape the family-keyed map uses, so every lookup downstream
+// can stay polymorphic over "inline OR family".
+func (s *TuningSpec) inlineMount() (tuningMount, bool) {
+	if s == nil || s.Target == "" {
+		return tuningMount{}, false
+	}
+	return tuningMount{Target: s.Target, Template: s.Template, Command: s.Command}, true
+}
+
+// resolveTuningMount returns the effective tuningMount for svc, preferring
+// the inline YAML TuningSpec when present so a user-authored custom service
+// can opt into the Config tab without lerd having to recognise its family.
+// Falls back to the family-keyed tuningMounts map for the built-in mysql /
+// mariadb / redis presets.
+func resolveTuningMount(svc *CustomService) (tuningMount, bool) {
+	if svc == nil {
+		return tuningMount{}, false
+	}
+	if m, ok := svc.Tuning.inlineMount(); ok {
+		return m, true
+	}
+	m, ok := tuningMounts[FamilyOf(svc)]
+	return m, ok
 }
 
 // mysqlTuningTemplate seeds the mysql/mariadb override. The zz- filename prefix
@@ -121,26 +181,26 @@ func TuningFamilies() []string {
 }
 
 // ServiceTuningMount returns the in-container mount target for svc's tuning
-// override and whether svc's family supports tuning. The matching host file is
-// ServiceTuningFile(svc.Name). Returns ok=false for nil services and families
-// without a known config-include path.
+// override and whether the service exposes one. The matching host file is
+// ServiceTuningFile(svc.Name). A service exposes a mount when either it
+// declares one inline via svc.Tuning, or its family is in the built-in
+// tuningMounts map (mysql / mariadb / redis). Returns ok=false otherwise.
 func ServiceTuningMount(svc *CustomService) (target string, ok bool) {
-	if svc == nil {
+	m, ok := resolveTuningMount(svc)
+	if !ok {
 		return "", false
 	}
-	m, ok := tuningMounts[FamilyOf(svc)]
-	return m.Target, ok
+	return m.Target, true
 }
 
 // ServiceTuningCommand returns the container command that makes svc's image
-// read its tuning override, and whether one applies. ok is false unless svc's
-// family declares a Command (mysql/mariadb auto-include their conf dir and need
-// none). Callers should only use it when the service has no Exec of its own.
+// read its tuning override, and whether one applies. ok is false unless the
+// effective tuningMount declares a Command (mysql/mariadb auto-include their
+// conf dir and need none; redis sets one because the image loads no config
+// file by default). Callers should only use it when the service has no Exec
+// of its own.
 func ServiceTuningCommand(svc *CustomService) (command string, ok bool) {
-	if svc == nil {
-		return "", false
-	}
-	m, found := tuningMounts[FamilyOf(svc)]
+	m, found := resolveTuningMount(svc)
 	if !found || m.Command == "" {
 		return "", false
 	}
@@ -149,11 +209,11 @@ func ServiceTuningCommand(svc *CustomService) (command string, ok bool) {
 
 // MaterializeServiceTuning seeds svc's tuning override with its commented
 // template when the host file does not exist yet, and is a no-op once the file
-// is present so user edits are never clobbered. Services whose family has no
-// tuning mount are skipped. Call this before GenerateCustomQuadlet so the
-// mounted host path always exists.
+// is present so user edits are never clobbered. Services without a tuning
+// mount (neither inline nor family-keyed) are skipped. Call this before
+// GenerateCustomQuadlet so the mounted host path always exists.
 func MaterializeServiceTuning(svc *CustomService) error {
-	m, ok := tuningMounts[FamilyOf(svc)]
+	m, ok := resolveTuningMount(svc)
 	if !ok {
 		return nil
 	}
@@ -169,16 +229,18 @@ func MaterializeServiceTuning(svc *CustomService) error {
 	return os.WriteFile(path, []byte(m.Template), 0644)
 }
 
-// ServiceTuningTemplate returns the commented template for svc's family
-// so callers (most notably the Reset endpoint) can restore the file to
-// the "no active directives" state without deleting it. Deleting the
+// ServiceTuningTemplate returns the commented template for svc's tuning
+// mount so callers (most notably the Reset endpoint) can restore the file
+// to the "no active directives" state without deleting it. Deleting the
 // file is unsafe in practice because the generated quadlet declares a
 // Volume= bind mount at the same path; a missing source path makes
 // podman refuse to start the container. Overwriting with the template
 // keeps the mount valid while making the service fall back to its
-// bundled defaults.
+// bundled defaults. Inline TuningSpec entries with no Template field
+// return ok=true with the empty string, which is still a valid "reset"
+// target.
 func ServiceTuningTemplate(svc *CustomService) (string, bool) {
-	m, ok := tuningMounts[FamilyOf(svc)]
+	m, ok := resolveTuningMount(svc)
 	if !ok {
 		return "", false
 	}

--- a/internal/config/service_tuning_test.go
+++ b/internal/config/service_tuning_test.go
@@ -135,6 +135,95 @@ func TestMaterializeServiceTuning_SkipsUntunedFamily(t *testing.T) {
 	}
 }
 
+// TestServiceTuningMount_InlineTuningSpec covers the user-extensible path:
+// a custom service that doesn't match any known family can still expose
+// the Config tab by declaring tuning: inline in its YAML. The inline
+// spec wins over the family map, so users can opt arbitrary services
+// into the editor without lerd having to recognise their image.
+func TestServiceTuningMount_InlineTuningSpec(t *testing.T) {
+	svc := &CustomService{
+		Name:   "my-cache",
+		Family: "memcached", // intentionally not in tuningMounts
+		Tuning: &TuningSpec{
+			Target:   "/etc/memcached.conf",
+			Template: "# my memcached overrides\n",
+			Command:  "memcached -f /etc/memcached.conf",
+		},
+	}
+	target, ok := ServiceTuningMount(svc)
+	if !ok {
+		t.Fatal("inline tuning spec should make the service tunable")
+	}
+	if target != "/etc/memcached.conf" {
+		t.Errorf("target = %q, want /etc/memcached.conf", target)
+	}
+	cmd, ok := ServiceTuningCommand(svc)
+	if !ok || cmd != "memcached -f /etc/memcached.conf" {
+		t.Errorf("command = %q ok=%v, want inline command", cmd, ok)
+	}
+	tmpl, ok := ServiceTuningTemplate(svc)
+	if !ok || tmpl != "# my memcached overrides\n" {
+		t.Errorf("template = %q ok=%v, want inline template", tmpl, ok)
+	}
+}
+
+// TestServiceTuningMount_InlineWinsOverFamily verifies an inline spec
+// takes precedence over the family-keyed fallback so a user can override
+// the bundled mysql/mariadb/redis defaults if they ship a non-standard
+// image whose conf path differs.
+func TestServiceTuningMount_InlineWinsOverFamily(t *testing.T) {
+	svc := &CustomService{
+		Name:   "weird-mysql",
+		Family: "mysql",
+		Tuning: &TuningSpec{
+			Target: "/custom/path/mysql.cnf",
+		},
+	}
+	target, ok := ServiceTuningMount(svc)
+	if !ok || target != "/custom/path/mysql.cnf" {
+		t.Errorf("inline target should override family default: got %q ok=%v", target, ok)
+	}
+}
+
+// TestServiceTuningMount_InlineRequiresTarget makes sure an empty / zero-
+// value TuningSpec doesn't accidentally enable tuning on a service that
+// would otherwise be untunable. Target is required; without it the spec
+// is treated as absent and the family fallback applies normally.
+func TestServiceTuningMount_InlineRequiresTarget(t *testing.T) {
+	svc := &CustomService{
+		Name:   "no-target",
+		Family: "memcached",
+		Tuning: &TuningSpec{Template: "anything"},
+	}
+	if _, ok := ServiceTuningMount(svc); ok {
+		t.Error("inline spec without target must not enable tuning")
+	}
+}
+
+// TestMaterializeServiceTuning_InlineSeedsTemplate covers the seeding
+// path for inline specs: lerd writes the template once and never
+// clobbers afterwards, same contract as the family-keyed path.
+func TestMaterializeServiceTuning_InlineSeedsTemplate(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	svc := &CustomService{
+		Name: "my-cache",
+		Tuning: &TuningSpec{
+			Target:   "/etc/memcached.conf",
+			Template: "# user-defined override hints\n",
+		},
+	}
+	if err := MaterializeServiceTuning(svc); err != nil {
+		t.Fatalf("MaterializeServiceTuning: %v", err)
+	}
+	body, err := os.ReadFile(ServiceTuningFile(svc.Name))
+	if err != nil {
+		t.Fatalf("tuning file not created: %v", err)
+	}
+	if string(body) != "# user-defined override hints\n" {
+		t.Errorf("inline template not seeded:\ngot:\n%s", body)
+	}
+}
+
 func TestServiceTuningCommand(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -351,6 +351,21 @@ func toolList() []mcpTool {
 			},
 		},
 		{
+			Name:        "service_config",
+			Description: "Read/write/restore/reset/list_backups a service's runtime tuning override. Built-in mysql/mariadb/redis; custom services opt in via `tuning:` block in YAML.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"name":        {Type: "string", Description: "Service name."},
+					"action":      {Type: "string", Description: "read|write|restore|reset|list_backups (default read)."},
+					"content":     {Type: "string", Description: "New contents (write only)."},
+					"backup":      {Type: "boolean", Description: "Stage backup before write (write only)."},
+					"backup_name": {Type: "string", Description: "Backup to restore (restore only). Omit for newest."},
+				},
+				Required: []string{"name"},
+			},
+		},
+		{
 			Name:        "service_preset_list",
 			Description: "List bundled service presets (name, description, versions, installed state). Call before service_preset_install.",
 			InputSchema: mcpSchema{
@@ -1120,6 +1135,28 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 			return execServiceReinstall(args)
 		default:
 			return unknownAction("service_control")
+		}
+
+	case "service_config":
+		// Default to read so the most common operation works without an
+		// explicit action — matches the CLI's `lerd service config --path`
+		// where the bare invocation is also a read.
+		if action == "" {
+			action = "read"
+		}
+		switch action {
+		case "read":
+			return execServiceConfigRead(args)
+		case "write":
+			return execServiceConfigWrite(args)
+		case "list_backups":
+			return execServiceConfigListBackups(args)
+		case "restore":
+			return execServiceConfigRestore(args)
+		case "reset":
+			return execServiceConfigReset(args)
+		default:
+			return unknownAction("service_config")
 		}
 
 	case "queue":
@@ -2792,6 +2829,154 @@ func execServiceReinstall(args map[string]any) (any, *rpcError) {
 		return toolOK(fmt.Sprintf("Service %q reinstalled with fresh data; linked sites' DBs/buckets were recreated.", name)), nil
 	}
 	return toolOK(fmt.Sprintf("Service %q reinstalled (data preserved).", name)), nil
+}
+
+// resolveTunableService returns the resolved service definition + the
+// in-container mount target, or a typed MCP error mapping the sentinel
+// errors from serviceops. Used as the shared preamble of every
+// service_config action so install / family checks stay in sync with
+// the HTTP handlers.
+func resolveTunableService(name string) (*config.CustomService, string, map[string]any) {
+	if name == "" {
+		return nil, "", toolErr("name is required")
+	}
+	if !serviceops.ServiceInstalled(name) {
+		return nil, "", toolErr(fmt.Sprintf("service %q is not installed; run `lerd service preset install %s` first", name, name))
+	}
+	svc, err := config.ResolveServiceForTuning(name)
+	if err != nil {
+		return nil, "", toolErr(fmt.Sprintf("service %q: %v", name, err))
+	}
+	target, ok := config.ServiceTuningMount(svc)
+	if !ok {
+		return nil, "", toolErr(fmt.Sprintf("service %q does not support tuning (family %q). Built-in tunable families: %s. Custom services can opt in via a `tuning:` block in the service YAML.", name, config.FamilyOf(svc), strings.Join(config.TuningFamilies(), ", ")))
+	}
+	return svc, target, nil
+}
+
+func execServiceConfigRead(args map[string]any) (any, *rpcError) {
+	name := strArg(args, "name")
+	svc, target, errResp := resolveTunableService(name)
+	if errResp != nil {
+		return errResp, nil
+	}
+	if err := config.MaterializeServiceTuning(svc); err != nil {
+		return toolErr("creating tuning file: " + err.Error()), nil
+	}
+	body, err := os.ReadFile(config.ServiceTuningFile(name))
+	exists := err == nil
+	if err != nil && !os.IsNotExist(err) {
+		return toolErr("reading tuning file: " + err.Error()), nil
+	}
+	backups, _ := serviceops.ListTuningBackups(name)
+	backupNames := make([]string, 0, len(backups))
+	for _, b := range backups {
+		backupNames = append(backupNames, b.Name)
+	}
+	payload, _ := json.MarshalIndent(map[string]any{
+		"name":    name,
+		"target":  target,
+		"path":    config.ServiceTuningFile(name),
+		"exists":  exists,
+		"content": string(body),
+		"backups": backupNames,
+	}, "", "  ")
+	return toolOK(string(payload)), nil
+}
+
+func execServiceConfigWrite(args map[string]any) (any, *rpcError) {
+	name := strArg(args, "name")
+	content := strArg(args, "content")
+	backup := boolArg(args, "backup")
+	if _, _, errResp := resolveTunableService(name); errResp != nil {
+		return errResp, nil
+	}
+	res, err := serviceops.SaveTuningOverride(name, content, backup)
+	if err != nil {
+		// The save may have auto-rolled back; surface that distinctly so
+		// callers know the running service is back on its prior bytes
+		// rather than wedged on the broken save.
+		msg := err.Error()
+		if res.RolledBack {
+			msg = "save reverted (prior config restored): " + msg
+		}
+		return toolErr(msg), nil
+	}
+	out := fmt.Sprintf("Saved tuning override for %q. ", name)
+	if res.BackupName != "" {
+		out += "Backup staged as " + res.BackupName + ". "
+	}
+	out += "Service restarted and ready."
+	return toolOK(out), nil
+}
+
+func execServiceConfigListBackups(args map[string]any) (any, *rpcError) {
+	name := strArg(args, "name")
+	if _, _, errResp := resolveTunableService(name); errResp != nil {
+		return errResp, nil
+	}
+	backups, err := serviceops.ListTuningBackups(name)
+	if err != nil {
+		return toolErr("listing backups: " + err.Error()), nil
+	}
+	if backups == nil {
+		backups = []serviceops.TuningBackup{}
+	}
+	payload, _ := json.MarshalIndent(map[string]any{
+		"name":    name,
+		"backups": backups,
+	}, "", "  ")
+	return toolOK(string(payload)), nil
+}
+
+func execServiceConfigRestore(args map[string]any) (any, *rpcError) {
+	name := strArg(args, "name")
+	backupName := strArg(args, "backup_name")
+	if _, _, errResp := resolveTunableService(name); errResp != nil {
+		return errResp, nil
+	}
+	// Resolve "newest" server-side so callers that omit backup_name still
+	// hit the same code path as the HTTP handler, and the response can
+	// report exactly which backup was consumed.
+	if backupName == "" {
+		list, err := serviceops.ListTuningBackups(name)
+		if err != nil {
+			return toolErr("listing backups: " + err.Error()), nil
+		}
+		if len(list) == 0 {
+			return toolErr("no backup available for " + name), nil
+		}
+		backupName = list[0].Name
+	}
+	res, err := serviceops.RestoreTuningFromBackup(name, backupName)
+	if err != nil {
+		msg := err.Error()
+		if res.RolledBack {
+			msg = "restore reverted (prior config restored): " + msg
+		}
+		return toolErr(msg), nil
+	}
+	return toolOK(fmt.Sprintf("Restored %q from %s. Service restarted and ready.", name, backupName)), nil
+}
+
+func execServiceConfigReset(args map[string]any) (any, *rpcError) {
+	name := strArg(args, "name")
+	if _, _, errResp := resolveTunableService(name); errResp != nil {
+		return errResp, nil
+	}
+	res, err := serviceops.ResetTuningOverride(name)
+	if err != nil {
+		msg := err.Error()
+		if res.RolledBack {
+			msg = "reset reverted (prior config restored): " + msg
+		}
+		return toolErr(msg), nil
+	}
+	out := fmt.Sprintf("Reset %q to the bundled template; service restarted.", name)
+	if res.AutoBackupName != "" {
+		out += " Prior config staged as " + res.AutoBackupName + " (use action=restore to recover)."
+	}
+	return toolOK(out), nil
 }
 
 func execServicePresetList(_ map[string]any) (any, *rpcError) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -180,7 +180,10 @@ func TestToolList_underSizeCeiling(t *testing.T) {
 	// descriptions trimmed to keep the delta small.
 	// Bumped to 29000 for db_snapshot / db_snapshots / db_restore /
 	// db_snapshot_delete (database snapshots); descriptions kept terse.
-	const ceiling = 29000
+	// Bumped to 29500 for service_config (five actions in one tool:
+	// read / write / restore / reset / list_backups); descriptions
+	// already trimmed to single-line shape.
+	const ceiling = 29500
 	got, err := json.Marshal(toolList())
 	if err != nil {
 		t.Fatalf("marshal tool list: %v", err)
@@ -329,5 +332,133 @@ func TestExecServiceAdd_InitDefaultsFalse(t *testing.T) {
 	}
 	if svc.Init {
 		t.Error("Init flag should default to false when not provided")
+	}
+}
+
+// installFakeQuadlet drops a stub .container file on disk so
+// serviceops.ServiceInstalled returns true without going through podman.
+// Mirrors the helper pattern in serviceops_test and internal/ui tests.
+func installFakeQuadlet(t *testing.T, name string) {
+	t.Helper()
+	dir := config.QuadletDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir quadlet dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "lerd-"+name+".container"), []byte("[Container]\n"), 0o644); err != nil {
+		t.Fatalf("write fake quadlet: %v", err)
+	}
+}
+
+// TestExecServiceConfig_ReadSurfacesTemplateOnFirstAccess covers the
+// most common MCP-driven path: an agent calls service_config (default
+// action=read) to see what tuning knobs the service exposes. The handler
+// materialises the seeded template on first read so the response always
+// has body content for the model to learn from.
+func TestExecServiceConfig_ReadSurfacesTemplateOnFirstAccess(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	installFakeQuadlet(t, "mysql")
+
+	resp, rpcErr := execServiceConfigRead(map[string]any{"name": "mysql"})
+	if rpcErr != nil {
+		t.Fatalf("rpc error: %v", rpcErr)
+	}
+	raw, _ := json.Marshal(resp)
+	if bytes.Contains(raw, []byte("\"isError\":true")) {
+		t.Fatalf("read reported error: %s", raw)
+	}
+	// The text payload is itself JSON with target/exists/content fields.
+	if !bytes.Contains(raw, []byte("/etc/mysql/conf.d/zz-lerd-user.cnf")) {
+		t.Errorf("response missing target path: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte("[mysqld]")) {
+		t.Errorf("response missing template body: %s", raw)
+	}
+}
+
+// TestExecServiceConfig_NotInstalledHintsAtInstall verifies the install
+// guard surfaces the same lerd CLI hint the HTTP handler does, so an
+// MCP-driven agent can recover without guessing the command.
+func TestExecServiceConfig_NotInstalledHintsAtInstall(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	// No installFakeQuadlet: ServiceInstalled returns false.
+
+	resp, _ := execServiceConfigRead(map[string]any{"name": "mysql"})
+	raw, _ := json.Marshal(resp)
+	if !bytes.Contains(raw, []byte("isError")) {
+		t.Fatalf("expected error response: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte("lerd service preset install mysql")) {
+		t.Errorf("expected install hint in error: %s", raw)
+	}
+}
+
+// TestExecServiceConfig_UnsupportedFamilyListsTunable verifies that a
+// service whose family is not on the built-in allowlist (and which has
+// no inline TuningSpec) gets a helpful error listing the supported
+// families, so the agent can either pick a different service or learn
+// to set tuning: inline.
+func TestExecServiceConfig_UnsupportedFamilyListsTunable(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := config.SaveCustomService(&config.CustomService{
+		Name:   "meilisearch",
+		Image:  "docker.io/getmeili/meilisearch:v1",
+		Family: "meilisearch",
+	}); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+	installFakeQuadlet(t, "meilisearch")
+
+	resp, _ := execServiceConfigRead(map[string]any{"name": "meilisearch"})
+	raw, _ := json.Marshal(resp)
+	if !bytes.Contains(raw, []byte("isError")) {
+		t.Fatalf("expected error: %s", raw)
+	}
+	// Hint should mention the inline `tuning:` opt-in so a model can
+	// fix the YAML itself.
+	if !bytes.Contains(raw, []byte("tuning:")) {
+		t.Errorf("expected inline-tuning hint in error: %s", raw)
+	}
+}
+
+// TestExecServiceConfig_ReadHonoursInlineTuningSpec covers the new
+// user-extensible path: a custom service with an inline tuning: block
+// surfaces in MCP's read response without lerd having to recognise its
+// family.
+func TestExecServiceConfig_ReadHonoursInlineTuningSpec(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := config.SaveCustomService(&config.CustomService{
+		Name:   "my-cache",
+		Image:  "docker.io/library/memcached:1.6-alpine",
+		Family: "memcached",
+		Tuning: &config.TuningSpec{
+			Target:   "/etc/memcached.conf",
+			Template: "# user-defined memcached overrides\n",
+		},
+	}); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+	installFakeQuadlet(t, "my-cache")
+
+	resp, rpcErr := execServiceConfigRead(map[string]any{"name": "my-cache"})
+	if rpcErr != nil {
+		t.Fatalf("rpc error: %v", rpcErr)
+	}
+	raw, _ := json.Marshal(resp)
+	if bytes.Contains(raw, []byte("isError")) {
+		t.Fatalf("inline tuning should be supported: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte("/etc/memcached.conf")) {
+		t.Errorf("response missing inline target: %s", raw)
+	}
+	if !bytes.Contains(raw, []byte("user-defined memcached overrides")) {
+		t.Errorf("response missing inline template: %s", raw)
 	}
 }


### PR DESCRIPTION
## Summary

Custom services can now expose the Config tab and the `lerd service config` CLI without lerd having to recognise their family. A new `tuning:` block on the service YAML carries the in-container mount target, the seeded template body, and an optional command override for images that need to be pointed at the file:

```yaml
name: my-cache
image: docker.io/library/memcached:1.6-alpine
tuning:
  target: /etc/memcached.conf
  template: |
    # Lerd user tuning for memcached.
  command: memcached -f /etc/memcached.conf
```

CustomService gained a `Tuning *TuningSpec` field and a small resolveTuningMount helper makes every existing lookup (ServiceTuningMount, ServiceTuningCommand, ServiceTuningTemplate, MaterializeServiceTuning) prefer the inline spec, falling back to the family-keyed map for the built-in mysql / mariadb / redis presets. An empty inline spec (no target) is treated as absent so a `tuning: {}` typo does not accidentally enable a half-wired editor. Inline tuning wins over the family default, so a custom image that does not match the bundled conf path can override it.

A new service_config MCP tool mirrors the HTTP API one-to-one with five actions (read default, write, restore, reset, list_backups). The shared resolveTunableService preamble maps the ErrTuningServiceNotInstalled and ErrTuningFamilyUnsupported sentinels to friendly error strings, and the unsupported-family case lists the built-in tunable families plus a hint at the inline `tuning:` YAML opt-in so an agent can self-correct by editing the service definition. Recovery semantics surface to MCP the same way they do to the web UI: a failed save / restore / reset that auto-rolls back to prior bytes returns a "save reverted (prior config restored)" message prefix instead of the bare runtime error, so the agent reads the service as healthy rather than wedged. Reset additionally reports the implicit AutoBackupName so a follow-up restore action can undo the reset.

The tools/list size ceiling rose from 29000 to 29500 with the standard justification comment; the new tool packs five sub-actions so the per-tool cost is reasonable. Docs got a new `tuning:` block in the custom-services schema example, a "Tuning a service" paragraph that explains the inline opt-in vs the family fallback, and a service_config row in the MCP tools table.