### PR TITLE
fix(nginx): raise server_names_hash_bucket_size so long worktree branch names don't break nginx

### DIFF
--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -1106,6 +1106,29 @@ func TestEnsureNginxConfig_writesForwardedAndCustomD(t *testing.T) {
 	}
 }
 
+// TestEnsureNginxConfigServerNamesHashBucket guards against issue #455: a
+// worktree vhost emits a long "<branch>.<site>.test *.<branch>.<site>.test"
+// server_name that overflows nginx's default server_names_hash_bucket_size of
+// 64, crashing nginx for every site. The rendered global nginx.conf must raise
+// the bucket/max sizes so long branch names always fit.
+func TestEnsureNginxConfigServerNamesHashBucket(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := EnsureNginxConfig(); err != nil {
+		t.Fatalf("EnsureNginxConfig: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(tmp, "lerd", "nginx", "nginx.conf"))
+	if err != nil {
+		t.Fatalf("read rendered nginx.conf: %v", err)
+	}
+	if !strings.Contains(string(body), "server_names_hash_bucket_size 128;") {
+		t.Errorf("rendered nginx.conf missing server_names_hash_bucket_size directive, got:\n%s", body)
+	}
+	if !strings.Contains(string(body), "server_names_hash_max_size 1024;") {
+		t.Errorf("rendered nginx.conf missing server_names_hash_max_size directive, got:\n%s", body)
+	}
+}
+
 func TestEnsureForwardedConf_rewrittenOnEachCall(t *testing.T) {
 	confD := setupConfD(t)
 	if err := EnsureForwardedConf(); err != nil {

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -1121,7 +1121,7 @@ func TestEnsureNginxConfigServerNamesHashBucket(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read rendered nginx.conf: %v", err)
 	}
-	if !strings.Contains(string(body), "server_names_hash_bucket_size 128;") {
+	if !strings.Contains(string(body), "server_names_hash_bucket_size 256;") {
 		t.Errorf("rendered nginx.conf missing server_names_hash_bucket_size directive, got:\n%s", body)
 	}
 	if !strings.Contains(string(body), "server_names_hash_max_size 1024;") {

--- a/internal/nginx/templates/nginx.conf
+++ b/internal/nginx/templates/nginx.conf
@@ -14,6 +14,13 @@ http {
     keepalive_timeout 65;
     client_max_body_size 0;
 
+    # Allow long server_name values: a worktree vhost emits
+    # "<branch>.<site>.test *.<branch>.<site>.test", which can exceed nginx's
+    # default server_names_hash_bucket_size (64) for long branch names and
+    # crash nginx for every site. Bump the bucket/max so they always fit.
+    server_names_hash_max_size 1024;
+    server_names_hash_bucket_size 128;
+
     # Use Podman network DNS so upstream hostnames are re-resolved dynamically
     resolver {{.Resolver}} valid=5s ipv6=off;
 

--- a/internal/nginx/templates/nginx.conf
+++ b/internal/nginx/templates/nginx.conf
@@ -19,7 +19,7 @@ http {
     # default server_names_hash_bucket_size (64) for long branch names and
     # crash nginx for every site. Bump the bucket/max so they always fit.
     server_names_hash_max_size 1024;
-    server_names_hash_bucket_size 128;
+    server_names_hash_bucket_size 256;
 
     # Use Podman network DNS so upstream hostnames are re-resolved dynamically
     resolver {{.Resolver}} valid=5s ipv6=off;


### PR DESCRIPTION
Fixes #455

## Problem

When a lerd site has a git worktree with a long branch name, the generated vhost emits:

```
server_name <branch>.<site>.test *.<branch>.<site>.test;
```

A long branch name overflows nginx's default `server_names_hash_bucket_size: 64`, so nginx fails to start with:

```
[emerg] could not build server_names_hash, you should increase server_names_hash_bucket_size: 64
```

This is a **global** failure — every site goes down, including the lerd dashboard.

## Fix

Add `server_names_hash_max_size 1024;` and `server_names_hash_bucket_size 128;` to the `http {}` block of `internal/nginx/templates/nginx.conf`. This is the documented workaround from the issue, applied at the source so every generated config carries it.

## Existing installs get it automatically

No migration step needed. `EnsureNginxConfig` (`internal/nginx/manager.go`) already re-renders `~/.local/share/lerd/nginx/nginx.conf` from the template **unconditionally** on every call — and it's called on every `lerd start` (`startstop.go:441`, "Rewrite nginx.conf so any config changes in new binary versions take effect") and on `lerd update` (→ `lerd install` → `install.go:276`). So an existing user with a stale `nginx.conf` picks up the new directives the next time they start or update lerd. User customizations are untouched — they live in the separate `custom.d/` / `http.d/` includes, which the template still pulls in; the base `nginx.conf` is fully lerd-owned.

## Tests

`TestEnsureNginxConfigServerNamesHashBucket` (`internal/nginx/manager_test.go`) renders the config via `EnsureNginxConfig()` and asserts the http block contains both directives.

`go test ./internal/nginx/... -count=1` → all pass. `gofmt`/`go vet` clean.