### PR TITLE
Fix two issues from the post-1.22.1 review

### DIFF
--- a/internal/cfgedit/atomic_test.go
+++ b/internal/cfgedit/atomic_test.go
@@ -1,0 +1,59 @@
+package cfgedit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Per-site vhosts include custom.d/<domain>.conf* (note the trailing wildcard).
+// The atomic-write temp used during a restore or rollback must never match that
+// glob, or a concurrent nginx reload could load the half-written temp file.
+func TestAtomicTmpPrefixNeverMatchesNginxIncludeGlob(t *testing.T) {
+	const glob = "site.test.conf*"
+
+	// Sanity: the old sibling temp name (<path>.tmp) did match the glob, which
+	// is exactly the regression this prefix guards against.
+	if m, err := filepath.Match(glob, "site.test.conf.tmp"); err != nil {
+		t.Fatal(err)
+	} else if !m {
+		t.Fatal("sanity: expected the old <domain>.conf.tmp sibling to match the include glob")
+	}
+
+	tempName := atomicTmpPrefix + "site.test.conf" + ".1234567890"
+	if m, err := filepath.Match(glob, tempName); err != nil {
+		t.Fatal(err)
+	} else if m {
+		t.Fatalf("atomic temp name %q matches the per-site include glob %q", tempName, glob)
+	}
+}
+
+func TestWriteFileAtomicLeavesNoGlobMatchingTemp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "site.test.conf")
+	body := []byte("server {}\n")
+	if err := writeFileAtomic(path, body, 0o644); err != nil {
+		t.Fatalf("writeFileAtomic: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("content mismatch: got %q want %q", got, body)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() == "site.test.conf" {
+			continue
+		}
+		if m, _ := filepath.Match("site.test.conf*", e.Name()); m {
+			t.Errorf("leftover file %q matches nginx include glob site.test.conf*", e.Name())
+		}
+	}
+}

--- a/internal/cfgedit/cfgedit.go
+++ b/internal/cfgedit/cfgedit.go
@@ -396,21 +396,37 @@ func MentionsFile(output, path string) bool {
 	return strings.Contains(output, filepath.Base(path))
 }
 
+// atomicTmpPrefix is prepended to the temp file used while atomically writing
+// a config file. The dot prefix keeps the temp from matching an nginx include
+// glob such as custom.d/<domain>.conf*, so a concurrent reload during a
+// restore or rollback can never load the half-written temp.
+const atomicTmpPrefix = ".lerd-cfgtmp-"
+
 func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
 	effective := mode
 	if info, err := os.Stat(path); err == nil {
 		effective = info.Mode().Perm()
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, effective); err != nil {
+	tmp, err := os.CreateTemp(filepath.Dir(path), atomicTmpPrefix+filepath.Base(path)+".*")
+	if err != nil {
 		return err
 	}
-	if err := os.Chmod(tmp, effective); err != nil {
-		os.Remove(tmp)
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
 		return err
 	}
-	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp)
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Chmod(tmpName, effective); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
 		return err
 	}
 	return nil

--- a/internal/tui/dumps.go
+++ b/internal/tui/dumps.go
@@ -333,6 +333,11 @@ func (m *Model) toggleDumpExpand() tea.Cmd {
 // zeroed and `lerd dump clear` runs against the daemon ring. Matches the
 // removeFocusedDomain pattern: single-key destructive actions go through
 // openConfirm so the policy is consistent across the TUI.
+// dumpsClearedMsg tells Update to zero the local dump buffer after the user
+// confirms a clear. Applied in Update so the model is never mutated from a
+// command goroutine.
+type dumpsClearedMsg struct{}
+
 func (m *Model) clearDumps() tea.Cmd {
 	count := len(m.dumps)
 	if count == 0 {
@@ -342,14 +347,11 @@ func (m *Model) clearDumps() tea.Cmd {
 		return runLerd("", "dump", "clear")
 	}
 	body := fmt.Sprintf("Drop %d buffered events from the dashboard and run `lerd dump clear` against the daemon ring? This cannot be undone.", count)
+	// Zeroing the buffer happens in Update via dumpsClearedMsg, never inside
+	// this command closure: a tea.Cmd runs on its own goroutine and mutating
+	// the model here would race View/Update.
 	m.openConfirm("Clear dumps", body, tea.Sequence(
-		func() tea.Msg {
-			m.dumps = nil
-			m.dumpsExpanded = nil
-			m.dumpsCursor = 0
-			m.dumpsScroll = 0
-			return nil
-		},
+		func() tea.Msg { return dumpsClearedMsg{} },
 		runLerd("", "dump", "clear"),
 	))
 	return nil

--- a/internal/tui/dumps_test.go
+++ b/internal/tui/dumps_test.go
@@ -264,6 +264,42 @@ func TestClearDumps_EmptyBufferSkipsPrompt(t *testing.T) {
 	}
 }
 
+func TestClearDumps_DefersBufferMutationToUpdate(t *testing.T) {
+	m := NewModel("test")
+	m.appendDump(DumpEntry{ID: "a"})
+	m.appendDump(DumpEntry{ID: "b"})
+	if cmd := m.clearDumps(); cmd != nil {
+		t.Fatalf("clearDumps should stage a confirm, got cmd %v", cmd)
+	}
+	// Clearing happens in Update via dumpsClearedMsg, so the buffer must be
+	// untouched until then; mutating it from the command goroutine would race
+	// the render path.
+	if len(m.dumps) != 2 {
+		t.Errorf("clearDumps mutated the buffer before confirmation: len=%d", len(m.dumps))
+	}
+}
+
+func TestDumpsClearedMsg_ZeroesBuffer(t *testing.T) {
+	m := NewModel("test")
+	m.appendDump(DumpEntry{ID: "a"})
+	m.appendDump(DumpEntry{ID: "b"})
+	m.dumpsExpanded = map[string]bool{"a": true}
+	m.dumpsCursor = 1
+	m.dumpsScroll = 5
+	if _, cmd := m.Update(dumpsClearedMsg{}); cmd != nil {
+		t.Errorf("dumpsClearedMsg should not emit a command, got %v", cmd)
+	}
+	if len(m.dumps) != 0 {
+		t.Errorf("dumps not cleared: %d", len(m.dumps))
+	}
+	if m.dumpsExpanded != nil {
+		t.Error("dumpsExpanded not cleared")
+	}
+	if m.dumpsCursor != 0 || m.dumpsScroll != 0 {
+		t.Errorf("cursor/scroll not reset: cursor=%d scroll=%d", m.dumpsCursor, m.dumpsScroll)
+	}
+}
+
 func rune2id(i int) string {
 	// Pad with leading zeros so lex order matches insertion order.
 	return string(rune('a')) + string(rune('0'+(i/100))) + string(rune('0'+((i/10)%10))) + string(rune('0'+(i%10)))

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -234,6 +234,12 @@ func updateCheckCmd(current string) tea.Cmd {
 // Update implements tea.Model.
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case dumpsClearedMsg:
+		m.dumps = nil
+		m.dumpsExpanded = nil
+		m.dumpsCursor = 0
+		m.dumpsScroll = 0
+		return m, nil
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		return m, nil


### PR DESCRIPTION
Two correctness fixes that came out of reviewing everything merged since 1.22.1.

The first is in the config editor's atomic writer. During a restore or rollback it staged its temp file as <path>.tmp right beside the live file, so a per-site override produced custom.d/<domain>.conf.tmp. The per-site vhost templates include custom.d/<domain>.conf* with a trailing wildcard, which means that temp matches the include glob, and an nginx reload landing in the middle of a restore could load the half-written file. The writer now stages a dot-prefixed temp through os.CreateTemp so its name can never match the glob, while keeping the same-directory rename atomic. The normal save path already staged inside the backup dir, so this just brings restore and rollback in line with it.

The second is a data race in the new TUI. Clearing the dashboard dump buffer mutated the model fields from inside a tea.Cmd closure, and bubbletea runs those on their own goroutine alongside the render loop. The clear now goes through a dumpsClearedMsg that Update applies on the update loop, so nothing touches the model off-thread. Behaviour from the user's side is identical.