### PR TITLE
Document the in-UI config editing added since 1.22.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ If you're a PHP developer on Linux and want frictionless local development — a
 - 🐘 **Per-project PHP version** (8.1–8.5, plus a frozen 7.4 / 8.0 legacy tier for hosted-on-the-old-stack projects), switch with one click
 - ⚡ **FrankenPHP runtime** per site as an alternative to shared PHP-FPM, with Laravel Octane and Symfony Runtime worker mode
 - 📦 **Node.js isolation** per project (Node 22, 24)
-- 🖥️ **Built-in Web UI** with a dashboard root, live widgets, a global Cmd+K command palette, and seven dashboard languages (English, German, Spanish, French, Indonesian, Dutch, Portuguese)
+- 🖥️ **Built-in Web UI** with a dashboard root, live widgets, a global Cmd+K command palette, install/remove of PHP and Node versions from the System page, and seven dashboard languages (English, German, Spanish, French, Indonesian, Dutch, Portuguese)
+- ✏️ **Edit config in the browser** — per-site and global nginx, per-version `php.ini`, `.env` files, and database/service runtime tuning, each validated (`nginx -t` where it applies), with timestamped backups and one-click restore
 - 🧪 **Tinker tab** - in-browser PHP REPL per site with autocomplete (project models, composer helpers, PHP built-ins), live `php -l` syntax checking, and a collapsible tree view for `dump()` output. Works on Laravel (`artisan tinker`), Symfony, and any composer-based PHP project
 - 🛰️ **Live dump() / dd() viewer** that intercepts every `dump()` and `dd()` call from your running app and streams it to the dashboard, TUI (`D` key), MCP, and `lerd dump tail`, scoped per site and per worktree branch, with the original response left clean unless you flip passthrough on
 - 🔥 **SPX profiler** with one-click on/off, every PHP-FPM request becomes a flame graph viewable in a same-origin Profiler view in the dashboard. No FPM restart, no code changes, and `lerd profile run` profiles a one-shot artisan or CLI command

--- a/docs/features/web-ui.md
+++ b/docs/features/web-ui.md
@@ -111,6 +111,8 @@ Selecting a site opens the detail panel with:
 - **App logs tab**: parses every `*.log` file the framework declares (Laravel: `storage/logs/*.log`) into level-coloured entries with click-to-expand stack traces and a live-search box. The dropdown switches between log files; the Latest / All toggle controls how many entries to fetch.
 
   ![App Logs tab on the site detail](/assets/screenshots/site-detail-applogs.png)
+- **Env tab**: edit the project's `.env` (and any `.env.*` variant) right in the browser. Saving goes through a confirmation modal with an optional back-up-first checkbox and an atomic write that preserves the file mode; when a backup exists a **Restore** button opens a diff before rolling back. See [Environment Setup](./env-setup.md).
+- **Edit nginx**: the sliders button at the end of the address bar opens the site's nginx override in a modal code editor with Save / Reset / Restore and timestamped backups, and every save runs `nginx -t` before committing. With a worktree tab selected it edits that worktree's override instead of the main branch's. See [Nginx Overrides](../usage/nginx-overrides.md).
 - **Service badges**: beneath the path / git branch line, every service from the project's `.lerd.yaml` is shown as a small pill (green when running, grey when stopped). Click any badge to jump to that service's detail panel on the Services tab.
 
 ## Services
@@ -129,6 +131,8 @@ Selecting a service opens the detail panel with Start, Stop, and Restart control
 - **Open admin button**: when the paired admin UI is installed, a button on the header opens its dashboard inline as a full-width iframe overlay and auto-starts the admin service if needed. When no admin UI is installed and the service is active, a fallback **Open connection URL** anchor hands the `mysql://` / `postgresql://` / `mongodb://` URL to your registered DB client (DBeaver, TablePlus, Compass, etc.).
 - **Dashboard button**: for any service that exposes a dashboard URL (Mailpit, RustFS, Meilisearch, phpMyAdmin, etc.), a Dashboard button in the header opens it as an inline full-width iframe. The iframe overlay has its own header with the service URL, an **Open in new tab** escape hatch, and a close button. Clicking one of the main nav icons (Sites / Services / System) also closes the overlay.
 
+Services with a tuning mount (mysql, mariadb, redis, postgres, and any custom service that declares a `tuning:` block) also get a **Config** tab on their detail panel. It edits the runtime tuning override in a code editor with the same Save / Reset / Revert / Restore-from-backup flow as the nginx and `.env` editors; saving restarts the service so it re-reads the file. See [Tuning a service](../usage/custom-services.md#tuning-a-service).
+
 ## System
 
 ![System tab](/assets/screenshots/system.png)
@@ -138,9 +142,11 @@ The middle panel lists individual system components: DNS, Nginx, Watcher, each i
 Selecting an item opens its detail panel:
 
 - **PHP-FPM cards**: show which sites use the version, Xdebug toggle with an inline mode selector (debug, coverage, debug-plus-coverage, develop, profile, trace, gcstats, visible when Xdebug is on), custom extension list, and a live FPM log stream. For versions with no active sites, a manual Start/Stop button is shown.
+- **Edit php.ini**: each PHP version's detail has a **php.ini** tab (next to Logs and Sites) that edits that version's user `php.ini` override in a code editor, with Save / Reset / Revert and timestamped backups you can **Restore**. Changes apply to the shared FPM container for that version. The same file is reachable from the CLI via `lerd php:ini <version>`.
 - **Install a PHP version**: a **+** button sits after the last PHP version tab (browser-tab style). It opens a modal with a dropdown of the supported versions that are not already installed; picking one and clicking Install builds the FPM image and streams the build log live. The build runs server-side, so closing the modal does not cancel it, and an *operation finished/failed* notification fires when it is done (see [Notifications](./notifications.md)).
 - **Site Xdebug button**: every PHP site detail shows an Xdebug (bug) button in the address-bar row, between the LAN-share and terminal buttons. It turns green when Xdebug is on for that site's PHP version, and clicking it toggles Xdebug on or off in place (restarting the shared FPM container for that version). The button is hidden for static sites, custom containers, and FrankenPHP sites.
 - **Node.js cards**: show which sites use the version, with a remove button. The **Install Node.js version** entry has an inline form; enter a version number (e.g. `22`) and click **Install**, equivalent to `lerd node:install <version>`.
+- **Nginx card**: a **Logs** tab streaming the `lerd-nginx` container log, and a **Config** tab that edits the global http-level nginx override (gzip, proxy buffers, a global `client_max_body_size`, custom `map` blocks) with the same Save / Reset / Restore / backup flow as the per-site editor; every save runs `nginx -t` first. See [Nginx Overrides](../usage/nginx-overrides.md#scope).
 - **Watcher card**: shows whether `lerd-watcher` is running; a Start button appears when stopped. Streams live watcher logs (DNS repair events, fsnotify errors, worktree timeouts).
 - **Notifications card**: per-category toggles (mail captured, worker failures, finished service operations, service updates, dumps), a *Send a test notification* button, and the list of subscribed browsers with *Forget* actions. See [Notifications](./notifications.md).
 - **Autostart card**: enable or disable automatic start of all services at login.

--- a/docs/usage/custom-services.md
+++ b/docs/usage/custom-services.md
@@ -73,7 +73,7 @@ lerd service config mariadb --no-restart
 
 `lerd service config` opens a user-editable tuning override for the service in `$EDITOR`. Lerd seeds the file once with a commented template and **never overwrites it afterward**, so your edits survive `lerd service reinstall` and `lerd update`. The override is bind-mounted *after* the bundled preset config, so any value you set wins. Saving restarts the service so it re-reads the config.
 
-Works for both custom services and built-in default presets (e.g. `lerd service preset install mariadb` then `lerd service config mariadb`). The bundled mysql, mariadb, and redis families ship with a built-in tuning mount; postgres is not yet supported because of how its include_dir directive is parsed. For any other image, declare your own tuning mount in the service YAML with a `tuning:` block:
+Works for both custom services and built-in default presets (e.g. `lerd service preset install mariadb` then `lerd service config mariadb`). The bundled mysql, mariadb, redis, and postgres families ship with a built-in tuning mount. Postgres needs a small wrapper: a bare `-c include_dir=...` is rejected at runtime, so lerd points postgres at a managed `config_file` that loads the cluster's own `postgresql.conf` first and then your override directory, additive, so your values win. For any other image, declare your own tuning mount in the service YAML with a `tuning:` block:
 
 ```yaml
 name: my-cache

--- a/docs/usage/nginx-overrides.md
+++ b/docs/usage/nginx-overrides.md
@@ -63,7 +63,9 @@ That's it. The snippet is merged into the generated server block for `bigapp.tes
 
 Lines you put in `custom.d/{domain}.conf` land inside the site's `server { ... }` block, so you can use anything nginx allows at server level: `client_max_body_size`, `add_header`, extra `location` blocks, `proxy_pass` overrides, `rewrite`, and so on.
 
-If you need directives at `http {}` level (like a new `map`), add them to `~/.local/share/lerd/nginx/conf.d/` with a filename that starts with an underscore (e.g. `_myorg.conf`). Files in `conf.d/` that lerd does not know about are left alone during regeneration.
+If you need directives at `http {}` level (gzip, proxy buffers, a global `client_max_body_size`, a new `map`), edit the **global override** from the web UI: open **System → Nginx** and pick the **Config** tab. It edits `~/.local/share/lerd/nginx/http.d/zz-lerd-user.conf`, which the generated `nginx.conf` includes last inside its `http {}` block, after lerd's own settings, so your values win. The editor is the same surface as the per-site one: Save runs `nginx -t` before the new bytes are committed, there is an optional backup-first checkbox with a **Restore** button, and **Reset** drops the file back to empty. The `http.d` directory is bind-mounted read-only into the `lerd-nginx` container and lerd never writes into it itself.
+
+Prefer keeping it on disk? Drop a snippet into `~/.local/share/lerd/nginx/conf.d/` with a filename that starts with an underscore (e.g. `_myorg.conf`). Files in `conf.d/` that lerd does not know about are left alone during regeneration.
 
 ## Customising the catch-all (`_default.conf`)
 

--- a/docs/usage/sites.md
+++ b/docs/usage/sites.md
@@ -152,7 +152,7 @@ domains:
   - admin
 ```
 
-You can also manage domains from the web UI: click the pencil icon next to the domain in the site header to open the domain management modal.
+You can also manage domains from the web UI: click the pencil icon next to the domain in the site header to open the domain management modal. Changing the primary domain there also rewrites `APP_URL` in the project's `.env` to match the new primary, unless you have pinned a custom `app_url` (see [Custom `APP_URL`](#custom-app-url) below).
 
 When a site is secured with HTTPS, the certificate is automatically reissued to cover all domains.
 


### PR DESCRIPTION
Fills the documentation gaps for everything the web UI gained since the last release.

On the site detail it documents the Env tab for editing .env in the browser and the sliders button that opens the per-site (and per-worktree) nginx override editor. The Services section now describes the runtime-tuning Config tab that mysql, mariadb, redis, postgres, and any custom service with a tuning block expose. Under System it adds the per-version php.ini tab and the Nginx Config tab that edits the global http-level override, and the nginx-overrides page now explains that global editor and the http.d directory it writes to.

It also corrects the custom-services tuning section, which still claimed postgres was unsupported, to describe the config_file wrapper that drives it now, notes that renaming the primary domain in the UI rewrites APP_URL, and refreshes the README feature list with browser config editing and installing PHP and Node versions from the dashboard.

The TUI page was already in the live VitePress nav, so no nav change was needed; mkdocs.yml is vestigial and left alone.