### PR TITLE
Compile lerd_devtools in the base image

### DIFF
--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'internal/podman/quadlets/lerd-php-fpm.Containerfile'
+      - 'internal/podman/devtools/**'
       - '.github/workflows/base-images.yml'
   workflow_dispatch:
     inputs:

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -352,11 +352,6 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 	}
 	defer os.RemoveAll(tmp)
 
-	// Both build paths COPY the lerd_devtools source from the context.
-	if err := writeDevtoolsSource(tmp); err != nil {
-		return fmt.Errorf("staging devtools source: %w", err)
-	}
-
 	// Stamp the Containerfile hash as an image label so NeedsFPMRebuild
 	// can detect drift even when the on-disk cache file is stale (the
 	// pre-v1.22.0 poisoning bug). Both build paths inherit the same args.
@@ -374,14 +369,20 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 			containerfile = "FROM " + baseRef + "\n" +
 				"RUN mkdir -p /etc/my.cnf.d && printf '[client]\\nssl=0\\n' > /etc/my.cnf.d/lerd-no-ssl.cnf\n" +
 				buildCustomExtBlock(customExts, extDeps) +
-				devtoolsBuildBlock() +
 				mkcertCABlock(tmp)
 			goto build
 		}
 	}
 
 	// Slow path: full local build from the embedded Containerfile template.
+	// The template compiles lerd_devtools in the builder stage via
+	// `COPY internal/podman/devtools`, so stage that source into the build
+	// context (the prebuilt base already carries it, so the fast path above
+	// doesn't need it).
 	{
+		if err := writeDevtoolsSource(tmp); err != nil {
+			return fmt.Errorf("staging devtools source: %w", err)
+		}
 		tmpl, tmplErr := GetQuadletTemplate("lerd-php-fpm.Containerfile")
 		if tmplErr != nil {
 			return tmplErr
@@ -390,10 +391,6 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 		containerfile = strings.ReplaceAll(containerfile, "{{.CustomExtensions}}", buildCustomExtBlock(customExts, extDeps))
 		containerfile = strings.ReplaceAll(containerfile, "{{.CustomExtensionsRuntime}}", buildCustomExtRuntimeDeps(customExts, extDeps))
 		containerfile = strings.ReplaceAll(containerfile, "{{.MkcertCA}}", mkcertCABlock(tmp))
-		// Layer lerd_devtools onto the finished runtime stage (kept out of the
-		// base template so the base-image hash and its fast-path pull are
-		// unchanged).
-		containerfile += devtoolsBuildBlock()
 	}
 
 build:

--- a/internal/podman/devtools.go
+++ b/internal/podman/devtools.go
@@ -1,18 +1,21 @@
 package podman
 
 import (
+	"crypto/sha256"
 	"embed"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
 )
 
-// lerd_devtools C source, compiled into every FPM image. Written into the
-// build context so the Containerfile's COPY can pick it up; see
-// devtoolsBuildBlock and buildFPMImage.
+// lerd_devtools C source, compiled into every FPM image by the Containerfile's
+// builder stage. writeDevtoolsSource stages it into the local build context so
+// the `COPY internal/podman/devtools` resolves the same way it does in CI, and
+// devtoolsSourceHash feeds the Containerfile's sync marker.
 //
 //go:embed devtools
 var devtoolsSrcFS embed.FS
@@ -85,10 +88,13 @@ func SetDevtoolsWorkersFlag(enabled bool) error {
 	return nil
 }
 
-// writeDevtoolsSource copies the embedded extension source into ctxDir so the
-// Containerfile's `COPY lerd-devtools …` finds it in the build context.
+// writeDevtoolsSource copies the embedded extension source into the build
+// context at internal/podman/devtools so the Containerfile's
+// `COPY internal/podman/devtools` resolves the same way it does in CI (where
+// the context is the repo root). Only the slow local build needs this; the
+// prebuilt base already carries the compiled extension.
 func writeDevtoolsSource(ctxDir string) error {
-	dst := filepath.Join(ctxDir, "lerd-devtools")
+	dst := filepath.Join(ctxDir, "internal", "podman", "devtools")
 	if err := os.MkdirAll(dst, 0755); err != nil {
 		return err
 	}
@@ -111,19 +117,31 @@ func writeDevtoolsSource(ctxDir string) error {
 	return nil
 }
 
-// devtoolsBuildBlock returns the Containerfile snippet that compiles and
-// enables the lerd_devtools extension. It is layered on top of the final image
-// in both build paths (not baked into the base template), so the base-image
-// hash is unchanged and the prebuilt-base fast path keeps working — the .so
-// just compiles as one extra ~40s layer. The build pulls in the Alpine
-// toolchain and removes it in the same RUN so it adds no weight, and is wrapped
-// so a compile failure degrades to "queries silently unavailable" rather than
-// bricking the whole image, matching the SPX block.
-func devtoolsBuildBlock() string {
-	steps := "apk add --no-cache --virtual .lerd-build autoconf make g++ && " +
-		"cd /tmp/lerd-devtools && phpize && ./configure --enable-lerd-devtools && make -j$(nproc) && make install && docker-php-ext-enable lerd_devtools && " +
-		"apk del .lerd-build"
-	return "COPY lerd-devtools /tmp/lerd-devtools\n" +
-		"RUN { " + steps + "; } || true; \\\n" +
-		"    rm -rf /tmp/lerd-devtools /var/cache/apk/*\n"
+// devtoolsSourceHash is the short sha256 of the extension source (every file
+// under devtools/, in name order). The Containerfile carries this value in its
+// `lerd_devtools-src-sha256:` marker so that any change to the C source drifts
+// the Containerfile hash, which both rebuilds the prebuilt base in CI and trips
+// NeedsFPMRebuild for updating users. TestDevtoolsSourceMarkerInSync asserts the
+// marker matches this, so the marker can't silently fall out of date.
+func devtoolsSourceHash() (string, error) {
+	entries, err := devtoolsSrcFS.ReadDir("devtools")
+	if err != nil {
+		return "", err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	h := sha256.New()
+	for _, n := range names {
+		b, err := devtoolsSrcFS.ReadFile("devtools/" + n)
+		if err != nil {
+			return "", err
+		}
+		h.Write(b)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))[:12], nil
 }

--- a/internal/podman/devtools_test.go
+++ b/internal/podman/devtools_test.go
@@ -44,21 +44,27 @@ func TestEnsureDevtoolsAssets_WritesIni(t *testing.T) {
 	}
 }
 
-func TestDevtoolsBuildBlock_Shape(t *testing.T) {
-	b := devtoolsBuildBlock()
-	if !strings.Contains(b, "COPY lerd-devtools /tmp/lerd-devtools") {
-		t.Errorf("block missing COPY: %s", b)
+// The Containerfile compiles lerd_devtools in the builder stage and carries a
+// marker hashing the source, so any change to the C drifts the image hash and
+// triggers a base rebuild + a NeedsFPMRebuild for updating users. If this fails
+// after editing the extension, update the `lerd_devtools-src-sha256:` line in
+// lerd-php-fpm.Containerfile to the printed value.
+func TestDevtoolsSourceMarkerInSync(t *testing.T) {
+	want, err := devtoolsSourceHash()
+	if err != nil {
+		t.Fatalf("devtoolsSourceHash: %v", err)
 	}
-	if !strings.Contains(b, "docker-php-ext-enable lerd_devtools") {
-		t.Errorf("block missing enable: %s", b)
+	tmpl, err := GetQuadletTemplate("lerd-php-fpm.Containerfile")
+	if err != nil {
+		t.Fatalf("template: %v", err)
 	}
-	if !strings.Contains(b, "|| true") {
-		t.Errorf("block must degrade gracefully on build failure: %s", b)
+	marker := "lerd_devtools-src-sha256: " + want
+	if !strings.Contains(tmpl, marker) {
+		t.Errorf("Containerfile marker out of date; expected %q. Update the lerd_devtools-src-sha256 line.", marker)
 	}
-	// Layered onto a toolchain-less image, so it adds and removes the build
-	// deps in the same RUN to avoid bloating the layer.
-	if !strings.Contains(b, "apk add --no-cache --virtual .lerd-build") || !strings.Contains(b, "apk del .lerd-build") {
-		t.Errorf("block must add and remove the toolchain: %s", b)
+	// The builder must actually compile and enable the extension.
+	if !strings.Contains(tmpl, "COPY internal/podman/devtools") || !strings.Contains(tmpl, "docker-php-ext-enable lerd_devtools") {
+		t.Error("Containerfile no longer compiles/enables lerd_devtools in the builder stage")
 	}
 }
 
@@ -67,8 +73,9 @@ func TestWriteDevtoolsSource_StagesFiles(t *testing.T) {
 	if err := writeDevtoolsSource(dir); err != nil {
 		t.Fatalf("writeDevtoolsSource: %v", err)
 	}
+	// Staged at the repo-relative path the Containerfile's COPY expects.
 	for _, name := range []string{"config.m4", "php_lerd_devtools.h", "lerd_devtools.c"} {
-		if _, err := os.Stat(dir + "/lerd-devtools/" + name); err != nil {
+		if _, err := os.Stat(dir + "/internal/podman/devtools/" + name); err != nil {
 			t.Errorf("expected staged %s: %v", name, err)
 		}
 	}

--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -93,6 +93,20 @@ RUN PHPVER="$(php -r 'echo PHP_MAJOR_VERSION,".",PHP_MINOR_VERSION;')" \
     && yes '' | pecl install "$XDEBUG_PKG" && docker-php-ext-enable xdebug \
     && rm -rf /tmp/pear /var/cache/apk/*
 
+# lerd_devtools: lerd's engine-level Debug-window capture (queries, mail, views,
+# events, jobs, http). Compiled in the builder so its .so and the
+# docker-php-ext-enable conf.d travel into the runtime stage via the
+# COPY --from=builder below, like every other extension, so users pull it
+# ready-built instead of compiling C on their own machine. The marker line
+# hashes the extension source so any change to it drifts the image hash and
+# rebuilds the base; TestDevtoolsSourceMarkerInSync keeps the marker honest.
+# No-op at runtime on PHP < 8.0 (no zend_observer); the || true degrades a
+# compile failure to "Debug window unavailable" rather than bricking the image.
+# lerd_devtools-src-sha256: 0afa730e05b7
+COPY internal/podman/devtools /tmp/lerd-devtools
+RUN { cd /tmp/lerd-devtools && phpize && ./configure --enable-lerd-devtools && make -j$(nproc) && make install && docker-php-ext-enable lerd_devtools; } || true; \
+    rm -rf /tmp/lerd-devtools /var/cache/apk/*
+
 # Project-defined custom extensions compile here while the toolchain
 # is available. Their .so files travel through the COPY below.
 {{.CustomExtensions}}


### PR DESCRIPTION
Follow-up to the Debug window (#462). The lerd_devtools extension was layered onto every user's FPM image at install time, which meant compiling C on the user's machine and, because the extension lived outside the hashed Containerfile template, an update that changed only the extension never drifted the image hash, so existing users never rebuilt to pick it up.

This moves the build into the Containerfile's builder stage so the extension ships in the prebuilt base alongside every other extension. The toolchain stays in the builder and the compiled .so plus its docker-php-ext-enable conf.d travel into the runtime stage through the existing COPY, so users pull it ready-built and a compile failure surfaces in CI rather than silently degrading on someone's box.

To keep the rebuild trigger honest for future changes, the extension source is hashed into a marker line in the Containerfile, so any edit drifts both the base-image tag, which rebuilds the base in CI, and NeedsFPMRebuild, so updating users rebuild. A test keeps the marker in sync with the source, and the base-image workflow now also triggers on the extension source path.
