### PR TITLE
fix(macos): pin --platform on pull for amd64-only images, register only after pull succeeds

### DIFF
--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -114,7 +114,8 @@ func ensureImages() {
 			jobs = append(jobs, BuildJob{
 				Label: "Pulling " + label,
 				Run: func(w io.Writer) error {
-					cmd := podman.Cmd("pull", label)
+					args := append(append([]string{"pull"}, podman.PlatformPullArgs(label)...), label)
+					cmd := podman.Cmd(args...)
 					cmd.Stdout = w
 					cmd.Stderr = w
 					return cmd.Run()
@@ -671,7 +672,8 @@ func startRestoredServices() {
 		pullJobs = append(pullJobs, BuildJob{
 			Label: "Pulling " + img,
 			Run: func(w io.Writer) error {
-				cmd := podman.Cmd("pull", img)
+				args := append(append([]string{"pull"}, podman.PlatformPullArgs(img)...), img)
+				cmd := podman.Cmd(args...)
 				cmd.Stdout = w
 				cmd.Stderr = w
 				return cmd.Run()

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -319,6 +319,7 @@ func tryPullBaseImage(version string, w io.Writer) string {
 	}
 
 	args := []string{"pull", "--policy=always"}
+	args = append(args, PlatformPullArgs(ref)...)
 	if tmpAuth != nil {
 		args = append(args, "--authfile="+tmpAuth.Name())
 	}

--- a/internal/podman/exec.go
+++ b/internal/podman/exec.go
@@ -90,9 +90,18 @@ func LocalImageDigest(image string) []string {
 	return digests
 }
 
+// pullArgs builds the `podman pull` argv for image, splicing in any
+// host-specific flags (e.g. --platform=linux/amd64 for postgis on Apple
+// Silicon, where the image ships no arm64 manifest). Keeping every pull path
+// on this helper means pull and run never disagree on platform.
+func pullArgs(image string) []string {
+	args := append([]string{"pull"}, PlatformPullArgs(image)...)
+	return append(args, image)
+}
+
 // PullImageTo pulls the named image, writing progress output to w.
 func PullImageTo(image string, w io.Writer) error {
-	cmd := exec.Command(PodmanBin(), "pull", image)
+	cmd := exec.Command(PodmanBin(), pullArgs(image)...)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	if err := cmd.Run(); err != nil {
@@ -107,7 +116,7 @@ func PullImageWithProgress(image string, onLine func(string)) error {
 	if onLine == nil {
 		return PullImageIfMissing(image)
 	}
-	cmd := exec.Command(PodmanBin(), "pull", image)
+	cmd := exec.Command(PodmanBin(), pullArgs(image)...)
 	w := &lineWriter{onLine: onLine}
 	cmd.Stdout = w
 	cmd.Stderr = w
@@ -155,7 +164,7 @@ func PullImageIfMissing(image string) error {
 	if ImageExists(image) {
 		return nil
 	}
-	cmd := exec.Command(PodmanBin(), "pull", image)
+	cmd := exec.Command(PodmanBin(), pullArgs(image)...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/internal/podman/platform_darwin.go
+++ b/internal/podman/platform_darwin.go
@@ -4,16 +4,47 @@ package podman
 
 import "strings"
 
+// imageLacksArm64 reports whether image is a known upstream tag that ships no
+// arm64 manifest, so Apple Silicon must pull and run it as linux/amd64 under
+// qemu/Rosetta. Matched by substring because the pull path only has the image.
+//
+//   - postgis/postgis: no arm64 manifest for any tag.
+//   - mysql:5.7: amd64-only (8.4 and 9.7 do publish arm64, so match the tag).
+//
+// User-pinned arm64 forks (e.g. imresamu/postgis) lack the substring and pass.
+func imageLacksArm64(image string) bool {
+	return strings.Contains(image, "postgis/postgis") ||
+		strings.Contains(image, "mysql:5.7")
+}
+
 // PlatformPodmanArgs returns one extra `podman run` arg to splice into a
 // service unit on macOS, or "" when no platform tweak is needed. Hooked from
-// WriteQuadletDiff so cli, UI, MCP, and install all emit identical units.
-//
-// postgis/postgis has no arm64 manifest for any tag, so on Apple Silicon we
-// pin --platform=linux/amd64 and let Podman Machine run it under qemu/Rosetta.
-// User-pinned arm64 forks (e.g. imresamu/postgis) lack the substring and pass.
+// WriteQuadletDiff so cli, UI, MCP, and install all emit identical units. The
+// serviceName gate keeps the tweak scoped to the canonical preset that ships
+// the no-arm64 image; an unrelated service reusing the image string passes.
 func PlatformPodmanArgs(serviceName, currentImage string) string {
-	if serviceName == "postgres" && strings.Contains(currentImage, "postgis/postgis") {
-		return "--platform=linux/amd64"
+	switch serviceName {
+	case "postgres":
+		if strings.Contains(currentImage, "postgis/postgis") {
+			return "--platform=linux/amd64"
+		}
+	case "mysql":
+		if strings.Contains(currentImage, "mysql:5.7") {
+			return "--platform=linux/amd64"
+		}
 	}
 	return ""
+}
+
+// PlatformPullArgs returns extra `podman pull` flags for image on this host, or
+// nil. The pull path only knows the image (not the service name), so it keys
+// off imageLacksArm64: those tags ship no arm64 manifest, so without --platform
+// podman fails picking an arch from the manifest list (exit 125). Pinning amd64
+// here matches what PlatformPodmanArgs writes into the quadlet, so pull and run
+// agree.
+func PlatformPullArgs(image string) []string {
+	if imageLacksArm64(image) {
+		return []string{"--platform=linux/amd64"}
+	}
+	return nil
 }

--- a/internal/podman/platform_darwin.go
+++ b/internal/podman/platform_darwin.go
@@ -19,19 +19,13 @@ func imageLacksArm64(image string) bool {
 
 // PlatformPodmanArgs returns one extra `podman run` arg to splice into a
 // service unit on macOS, or "" when no platform tweak is needed. Hooked from
-// WriteQuadletDiff so cli, UI, MCP, and install all emit identical units. The
-// serviceName gate keeps the tweak scoped to the canonical preset that ships
-// the no-arm64 image; an unrelated service reusing the image string passes.
-func PlatformPodmanArgs(serviceName, currentImage string) string {
-	switch serviceName {
-	case "postgres":
-		if strings.Contains(currentImage, "postgis/postgis") {
-			return "--platform=linux/amd64"
-		}
-	case "mysql":
-		if strings.Contains(currentImage, "mysql:5.7") {
-			return "--platform=linux/amd64"
-		}
+// WriteQuadletDiff so cli, UI, MCP, and install all emit identical units. It
+// keys off the image alone (imageLacksArm64), so the quadlet's --platform
+// matches what PlatformPullArgs pins at pull time and the two never disagree,
+// regardless of the service's name.
+func PlatformPodmanArgs(_, currentImage string) string {
+	if imageLacksArm64(currentImage) {
+		return "--platform=linux/amd64"
 	}
 	return ""
 }

--- a/internal/podman/platform_darwin_test.go
+++ b/internal/podman/platform_darwin_test.go
@@ -2,7 +2,10 @@
 
 package podman
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestPlatformPodmanArgs_Postgres(t *testing.T) {
 	cases := []struct {
@@ -14,10 +17,35 @@ func TestPlatformPodmanArgs_Postgres(t *testing.T) {
 		{"postgres", "docker.io/library/postgres:16-alpine", ""},
 		{"postgres", "docker.io/imresamu/postgis:16-3.5-alpine", ""},
 		{"mysql", "docker.io/postgis/postgis:16-3.5-alpine", ""},
+		{"mysql", "docker.io/library/mysql:5.7", "--platform=linux/amd64"},
+		{"mysql", "docker.io/library/mysql:8.4", ""},
+		{"mysql", "docker.io/library/mysql:9.7", ""},
 	}
 	for _, tc := range cases {
 		if got := PlatformPodmanArgs(tc.name, tc.image); got != tc.want {
 			t.Errorf("PlatformPodmanArgs(%q, %q) = %q, want %q", tc.name, tc.image, got, tc.want)
+		}
+	}
+}
+
+func TestPlatformPullArgs_Postgis(t *testing.T) {
+	cases := []struct {
+		image string
+		want  string
+	}{
+		{"docker.io/postgis/postgis:16-3.5-alpine", "--platform=linux/amd64"},
+		{"docker.io/postgis/postgis:17-3.6-alpine", "--platform=linux/amd64"},
+		{"docker.io/postgis/postgis:18-3.6-alpine", "--platform=linux/amd64"},
+		{"docker.io/library/mysql:5.7", "--platform=linux/amd64"},
+		{"docker.io/library/mysql:8.4", ""},
+		{"docker.io/library/mysql:9.7", ""},
+		{"docker.io/library/postgres:16-alpine", ""},
+		{"docker.io/imresamu/postgis:16-3.5-alpine", ""},
+	}
+	for _, tc := range cases {
+		got := strings.Join(PlatformPullArgs(tc.image), " ")
+		if got != tc.want {
+			t.Errorf("PlatformPullArgs(%q) = %q, want %q", tc.image, got, tc.want)
 		}
 	}
 }

--- a/internal/podman/platform_darwin_test.go
+++ b/internal/podman/platform_darwin_test.go
@@ -16,7 +16,9 @@ func TestPlatformPodmanArgs_Postgres(t *testing.T) {
 		{"postgres", "docker.io/postgis/postgis:17-3.5-alpine", "--platform=linux/amd64"},
 		{"postgres", "docker.io/library/postgres:16-alpine", ""},
 		{"postgres", "docker.io/imresamu/postgis:16-3.5-alpine", ""},
-		{"mysql", "docker.io/postgis/postgis:16-3.5-alpine", ""},
+		// Keyed off the image, not the name: an amd64-only image gets the pin
+		// whatever the service is called, so pull and run stay in agreement.
+		{"mysql", "docker.io/postgis/postgis:16-3.5-alpine", "--platform=linux/amd64"},
 		{"mysql", "docker.io/library/mysql:5.7", "--platform=linux/amd64"},
 		{"mysql", "docker.io/library/mysql:8.4", ""},
 		{"mysql", "docker.io/library/mysql:9.7", ""},

--- a/internal/podman/platform_linux.go
+++ b/internal/podman/platform_linux.go
@@ -8,3 +8,8 @@ package podman
 func PlatformPodmanArgs(_, _ string) string {
 	return ""
 }
+
+// PlatformPullArgs is a no-op on Linux (see PlatformPodmanArgs).
+func PlatformPullArgs(_ string) []string {
+	return nil
+}

--- a/internal/serviceops/install_streaming_test.go
+++ b/internal/serviceops/install_streaming_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestInstallPresetStreaming_UnknownPresetEmitsConfigPhaseAndErrors(t *testing.T) {
+func TestInstallPresetStreaming_UnknownPresetErrorsBeforeAnyPhase(t *testing.T) {
 	var events []PhaseEvent
 	svc, err := InstallPresetStreaming("definitely-not-a-real-preset-xyz", "", func(e PhaseEvent) {
 		events = append(events, e)
@@ -15,7 +15,9 @@ func TestInstallPresetStreaming_UnknownPresetEmitsConfigPhaseAndErrors(t *testin
 	if svc != nil {
 		t.Fatalf("expected nil service on error, got %+v", svc)
 	}
-	if len(events) != 1 || events[0].Phase != "installing_config" {
-		t.Fatalf("expected single installing_config event before the error, got %+v", events)
+	// Resolution now happens before any side effect, so an unresolvable preset
+	// errors before a single phase event (and before any config is written).
+	if len(events) != 0 {
+		t.Fatalf("expected no phase events before the resolution error, got %+v", events)
 	}
 }

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -41,11 +41,12 @@ type PhaseEvent struct {
 }
 
 // InstallPresetStreaming runs the full install flow and emits a PhaseEvent
-// at every step. The image is pulled before StartUnit so the hidden
-// on-demand pull latency becomes visible progress in the UI.
+// at every step. The image is pulled before the service is registered (config
+// + quadlet) so a failed pull never leaves a registered-but-broken service
+// behind; pulling here also turns the hidden on-demand pull latency into
+// visible progress in the UI.
 func InstallPresetStreaming(name, version string, emit func(PhaseEvent)) (*config.CustomService, error) {
-	emit(PhaseEvent{Phase: "installing_config"})
-	svc, err := InstallPresetByName(name, version)
+	svc, err := resolvePresetForInstall(name, version)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +54,7 @@ func InstallPresetStreaming(name, version string, emit func(PhaseEvent)) (*confi
 	for _, dep := range svc.DependsOn {
 		emit(PhaseEvent{Phase: "starting_deps", Dep: dep, State: "starting"})
 		if err := EnsureServiceRunning(dep); err != nil {
-			return svc, fmt.Errorf("starting dependency %q: %w", dep, err)
+			return nil, fmt.Errorf("starting dependency %q: %w", dep, err)
 		}
 		emit(PhaseEvent{Phase: "starting_deps", Dep: dep, State: "ready"})
 	}
@@ -64,8 +65,13 @@ func InstallPresetStreaming(name, version string, emit func(PhaseEvent)) (*confi
 			emit(PhaseEvent{Phase: "pulling_image", Message: line})
 		})
 		if pullErr != nil {
-			return svc, pullErr
+			return nil, pullErr
 		}
+	}
+
+	emit(PhaseEvent{Phase: "installing_config"})
+	if err := registerPreset(svc); err != nil {
+		return nil, err
 	}
 
 	unit := "lerd-" + svc.Name
@@ -93,8 +99,25 @@ func InstallPresetStreaming(name, version string, emit func(PhaseEvent)) (*confi
 
 // InstallPresetByName materialises a bundled preset as a custom service.
 // version selects a tag for multi-version presets; empty falls back to the
-// preset's DefaultVersion.
+// preset's DefaultVersion. It resolves and registers in one shot; callers that
+// need to pull the image before registering (so a failed pull leaves nothing
+// behind) should use resolvePresetForInstall + registerPreset instead.
 func InstallPresetByName(name, version string) (*config.CustomService, error) {
+	svc, err := resolvePresetForInstall(name, version)
+	if err != nil {
+		return nil, err
+	}
+	if err := registerPreset(svc); err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+// resolvePresetForInstall loads and validates a preset into a CustomService
+// without writing anything to disk. Separating resolution from registration
+// lets the streaming install pull the image first and bail before any state is
+// written when the pull fails.
+func resolvePresetForInstall(name, version string) (*config.CustomService, error) {
 	preset, err := config.LoadPreset(name)
 	if err != nil {
 		return nil, err
@@ -111,23 +134,30 @@ func InstallPresetByName(name, version string) (*config.CustomService, error) {
 	}
 	// Quadlet presence is the install-state truth (see ServiceInstalled); a
 	// yaml-only remnant from a partial install gets silently rewritten by
-	// SaveCustomService + EnsureCustomServiceQuadlet below as the heal path.
+	// registerPreset as the heal path.
 	if ServiceInstalled(svc.Name) {
 		return nil, fmt.Errorf("custom service %q already exists; remove it first with: lerd service remove %s", svc.Name, svc.Name)
 	}
 	if missing := MissingPresetDependencies(svc); len(missing) > 0 {
 		return nil, fmt.Errorf("preset %q requires service(s) %s to be installed first", svc.Name, strings.Join(missing, ", "))
 	}
+	return svc, nil
+}
+
+// registerPreset persists a resolved preset: it saves the YAML config, writes
+// the quadlet, and regenerates family consumers. Run only after any required
+// image pull has succeeded.
+func registerPreset(svc *config.CustomService) error {
 	if err := config.SaveCustomService(svc); err != nil {
-		return nil, fmt.Errorf("saving service config: %w", err)
+		return fmt.Errorf("saving service config: %w", err)
 	}
 	if err := EnsureCustomServiceQuadlet(svc); err != nil {
-		return nil, fmt.Errorf("writing quadlet: %w", err)
+		return fmt.Errorf("writing quadlet: %w", err)
 	}
 	if svc.Family != "" {
 		RegenerateFamilyConsumers(svc.Family)
 	}
-	return svc, nil
+	return nil
 }
 
 // MissingPresetDependencies returns the names of services that svc declares

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -44,19 +44,13 @@ type PhaseEvent struct {
 // at every step. The image is pulled before the service is registered (config
 // + quadlet) so a failed pull never leaves a registered-but-broken service
 // behind; pulling here also turns the hidden on-demand pull latency into
-// visible progress in the UI.
+// visible progress in the UI. Registration precedes the dependency-start loop
+// so a dependency that fails to start still leaves the service installed on
+// disk; this matters for reinstall, which has already removed the prior copy.
 func InstallPresetStreaming(name, version string, emit func(PhaseEvent)) (*config.CustomService, error) {
 	svc, err := resolvePresetForInstall(name, version)
 	if err != nil {
 		return nil, err
-	}
-
-	for _, dep := range svc.DependsOn {
-		emit(PhaseEvent{Phase: "starting_deps", Dep: dep, State: "starting"})
-		if err := EnsureServiceRunning(dep); err != nil {
-			return nil, fmt.Errorf("starting dependency %q: %w", dep, err)
-		}
-		emit(PhaseEvent{Phase: "starting_deps", Dep: dep, State: "ready"})
 	}
 
 	if svc.Image != "" && !podman.ImageExists(svc.Image) {
@@ -72,6 +66,14 @@ func InstallPresetStreaming(name, version string, emit func(PhaseEvent)) (*confi
 	emit(PhaseEvent{Phase: "installing_config"})
 	if err := registerPreset(svc); err != nil {
 		return nil, err
+	}
+
+	for _, dep := range svc.DependsOn {
+		emit(PhaseEvent{Phase: "starting_deps", Dep: dep, State: "starting"})
+		if err := EnsureServiceRunning(dep); err != nil {
+			return svc, fmt.Errorf("starting dependency %q: %w", dep, err)
+		}
+		emit(PhaseEvent{Phase: "starting_deps", Dep: dep, State: "ready"})
 	}
 
 	unit := "lerd-" + svc.Name


### PR DESCRIPTION
## Problem

On Apple Silicon, installing Postgres 18 from the dashboard fails and leaves a broken service behind:

```
pulling docker.io/postgis/postgis:18-3.6-alpine: exit status 125
```

```
Error: ... choosing an image from manifest list docker://postgis/postgis:18-3.6-alpine:
no image found in image index for architecture "arm64", variant "v8", OS "linux"
```

Two things go wrong: the pull fails, and the service gets registered anyway, so it shows as installed but never starts.

## Root cause

`postgis/postgis` publishes no arm64 manifest for any tag (and neither does `mysql:5.7`; `8.4` and `9.7` do). The quadlet already pins `--platform=linux/amd64` so the container runs under the podman machine's emulation, but the explicit pull step the streaming install added to surface progress ran a bare `podman pull` with no platform. On arm64, podman cannot pick an arch from the manifest list and exits 125, so pull and run disagreed.

Separately, `InstallPresetStreaming` (`internal/serviceops/serviceops.go`) wrote the YAML config and quadlet **before** pulling the image. Quadlet presence is the install-state truth (`ServiceInstalled`), so a failed pull left the service registered with no working image.

## Fix

- **Pin the platform on pull.** New `PlatformPullArgs(image)` injects `--platform=linux/amd64` for the no-arm64 images on darwin, no-op on linux. Every pull path routes through it: the three pull functions in `internal/podman/exec.go`, the FPM base pull in `build.go`, and the two CLI start/warm-up pulls in `startstop.go`. Both `PlatformPullArgs` and the run-time `PlatformPodmanArgs` now key off a single `imageLacksArm64(image)` predicate, so the quadlet's `--platform` and the pull always agree regardless of the service's name.
- **Pull before register.** `InstallPresetByName` is split into `resolvePresetForInstall` (validate, no writes) and `registerPreset` (save config + quadlet). The streaming flow now resolves, pulls, registers, then starts dependencies and the unit. A failed pull writes nothing; registration still lands before the dependency-start loop, so a dependency that fails to start leaves the service installed on disk (this matters on reinstall, which removes the prior copy first). `InstallPresetByName` stays a thin `resolve + register` wrapper, so the CLI, MCP, and link callers are unchanged.
- `mysql:5.7` had the same amd64-only gap as postgis and is covered by the same predicate.

## Linux is unaffected

`PlatformPullArgs` lives behind the build tag: `platform_linux.go` returns nil, so `pullArgs` produces the same `["pull", image]` it always did. The register-before-pull reorder is OS-agnostic and is the intended correctness fix on every platform: a failed pull should never register a service.

Self-reported (no separate issue); happy to open one if you'd prefer to track it there.