### PR TITLE
fix(start): auto-heal podman overlay corruption + lerd machine reset

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -115,6 +115,7 @@ func main() {
 	root.AddCommand(cli.NewWhatsnewCmd())
 	root.AddCommand(cli.NewManCmd())
 	root.AddCommand(cli.NewDoctorCmd())
+	root.AddCommand(cli.NewMachineCmd())
 	root.AddCommand(cli.NewBugReportCmd())
 	root.AddCommand(cli.NewLogsCmd())
 	root.AddCommand(cli.NewOpenCmd())

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -376,7 +376,7 @@ readlink /var/lib/containers/storage/overlay: invalid argument
 
 Cause: the macOS host was shut down ungracefully (forced power-off, battery death, kernel panic) while the Podman Machine VM was still running. The VM's container storage is left with a stale overlay mount and corrupt container layers, so no container can start until the storage is remounted and the stale containers are rebuilt.
 
-`lerd start` detects this and **self-heals automatically** on the first run: it restarts the Podman Machine to remount the storage, force-removes the stale `lerd-*` containers so they rebuild on fresh storage, and retries the start pass once. Your data is safe throughout — lerd bind-mounts every database and site directory to the host, not into the VM.
+`lerd start` detects this and **self-heals automatically** on the first run: it restarts the Podman Machine to remount the storage, force-removes the stale `lerd-*` containers so they rebuild on fresh storage, and retries the start pass once. Your data is safe throughout: lerd bind-mounts every database and site directory to the host, not into the VM.
 
 If the automatic recovery isn't enough (it prints guidance pointing here), recreate the VM:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -365,3 +365,24 @@ cat "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/containers/networks/aardvark-dns/ler
 # if only 10.89.7.1 is present, the drift fix didn't run — re-run lerd install
 ```
 :::
+
+::: details Podman Machine overlay-storage error (macOS)
+Symptom: on macOS, `lerd start` fails and **every** container start reports a graph-driver / overlay error:
+
+```
+exit status 125: Error: getting graph driver info "<id>":
+readlink /var/lib/containers/storage/overlay: invalid argument
+```
+
+Cause: the macOS host was shut down ungracefully (forced power-off, battery death, kernel panic) while the Podman Machine VM was still running. The VM's container storage is left with a stale overlay mount and corrupt container layers, so no container can start until the storage is remounted and the stale containers are rebuilt.
+
+`lerd start` detects this and **self-heals automatically** on the first run: it restarts the Podman Machine to remount the storage, force-removes the stale `lerd-*` containers so they rebuild on fresh storage, and retries the start pass once. Your data is safe throughout — lerd bind-mounts every database and site directory to the host, not into the VM.
+
+If the automatic recovery isn't enough (it prints guidance pointing here), recreate the VM:
+
+```bash
+lerd machine reset
+```
+
+This stops the VM, removes it, and re-initialises it. Databases and site data are preserved (they live on the host); container images are rebuilt automatically on the next `lerd start`. See [Start, Stop & Autostart → `lerd machine reset`](usage/lifecycle.md#lerd-machine-reset-macos).
+:::

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -89,6 +89,23 @@ The system tray's **Quit Lerd** menu item calls `lerd quit`.
 
 ---
 
+## `lerd machine reset` (macOS)
+
+```bash
+lerd machine reset        # asks for confirmation first
+lerd machine reset --yes  # skip the prompt
+```
+
+Recreates the Podman Machine VM. Reach for it only when `lerd start` reports a container-storage error such as `getting graph driver info ... overlay: invalid argument`, which happens after the macOS host is shut down ungracefully while the VM is still running and leaves the VM's container storage corrupt. See [Troubleshooting → Podman Machine overlay-storage error](../troubleshooting.md).
+
+The command stops the VM, removes it (`podman machine rm -f`), and re-initialises it. **Your data is preserved:** lerd bind-mounts every database and site directory to the host, not into the VM, so only the VM's container storage and images are discarded. Images are rebuilt automatically on the next `lerd start`.
+
+::: tip lerd start already tries to self-heal
+On macOS, `lerd start` detects this exact error and attempts an automatic recovery first (remount the VM's storage, rebuild the stale containers, retry once). `lerd machine reset` is the manual fallback for when that recovery isn't enough. This command is macOS-only; Linux runs podman natively with no VM.
+:::
+
+---
+
 ## Autostart on login
 
 Lerd can boot itself every time you log in. Autostart is a single switch over every lerd-owned systemd user unit on the machine:
@@ -142,6 +159,7 @@ Shows a live snapshot: DNS reachability, nginx, PHP-FPM containers, watcher, ser
 | Reboot, autostart enabled | Nothing, happens automatically |
 | Free up CPU / RAM during a heavy build | `lerd stop` |
 | Full shutdown before a reinstall | `lerd quit` |
+| `lerd start` fails with an overlay / graph-driver storage error (macOS) | `lerd machine reset` |
 | Verify everything's healthy | `lerd status` |
 | Uninstall a service entirely (data preserved) | `lerd service remove <name>` |
 | Uninstall and wipe data | `lerd service remove <name> --purge` |

--- a/internal/cli/machine.go
+++ b/internal/cli/machine.go
@@ -1,0 +1,33 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+// NewMachineCmd returns the machine parent command for Podman Machine
+// maintenance operations.
+func NewMachineCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "machine",
+		Short: "Manage the Podman Machine VM (macOS)",
+	}
+	cmd.AddCommand(newMachineResetCmd())
+	return cmd
+}
+
+func newMachineResetCmd() *cobra.Command {
+	var assumeYes bool
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Recreate the Podman Machine VM (fixes corrupted container storage; data is preserved)",
+		Long: `Recreate the Podman Machine VM.
+
+Use this when lerd start fails with a container-storage error such as
+"getting graph driver info ... overlay: invalid argument" after an unclean
+host shutdown. lerd's databases and site data are stored on the host and are
+preserved; container images are rebuilt automatically on the next start.`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runMachineReset(assumeYes)
+		},
+	}
+	cmd.Flags().BoolVarP(&assumeYes, "yes", "y", false, "Skip the confirmation prompt")
+	return cmd
+}

--- a/internal/cli/machine_reset_darwin.go
+++ b/internal/cli/machine_reset_darwin.go
@@ -19,7 +19,7 @@ import (
 func runMachineReset(assumeYes bool) error {
 	name := selectedMachineName()
 	if name == "" {
-		fmt.Println("No Podman Machine found — nothing to reset. Run `lerd start` to create one.")
+		fmt.Println("No Podman Machine found; nothing to reset. Run `lerd start` to create one.")
 		return nil
 	}
 
@@ -32,8 +32,8 @@ func runMachineReset(assumeYes bool) error {
 		line, _ := reader.ReadString('\n')
 		ans := strings.ToLower(strings.TrimSpace(line))
 		if ans != "y" && ans != "yes" {
-			// Declining the prompt is a normal choice, not a failure — print a
-			// plain notice and exit zero rather than letting cobra render
+			// Declining the prompt is a normal choice, not a failure, so print
+			// a plain notice and exit zero rather than letting cobra render
 			// "Error: aborted" with a non-zero status.
 			fmt.Println("Cancelled.")
 			return nil

--- a/internal/cli/machine_reset_darwin.go
+++ b/internal/cli/machine_reset_darwin.go
@@ -1,0 +1,61 @@
+//go:build darwin
+
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// runMachineReset stops and removes lerd's Podman Machine, then recreates it.
+// The VM's container storage (the source of overlay corruption after an
+// unclean shutdown) is discarded; lerd's persistent data lives in host
+// bind-mounts and survives. Images are rebuilt on the next lerd start.
+func runMachineReset(assumeYes bool) error {
+	name := selectedMachineName()
+	if name == "" {
+		fmt.Println("No Podman Machine found — nothing to reset. Run `lerd start` to create one.")
+		return nil
+	}
+
+	if !assumeYes {
+		fmt.Printf("This recreates the Podman Machine %q.\n", name)
+		fmt.Println("Databases and site data are preserved (stored on the host).")
+		fmt.Println("Container images and any non-lerd containers in this VM are removed and rebuilt on next start.")
+		fmt.Print("Continue? [y/N] ")
+		reader := bufio.NewReader(os.Stdin)
+		line, _ := reader.ReadString('\n')
+		ans := strings.ToLower(strings.TrimSpace(line))
+		if ans != "y" && ans != "yes" {
+			return fmt.Errorf("aborted")
+		}
+	}
+
+	fmt.Printf("  --> Stopping Podman Machine %q ...\n", name)
+	stop := exec.Command(podman.PodmanBin(), "machine", "stop", name)
+	stop.Stdout = os.Stdout
+	stop.Stderr = os.Stderr
+	_ = stop.Run() // a stopped machine still removes fine
+
+	fmt.Printf("  --> Removing Podman Machine %q ...\n", name)
+	rm := exec.Command(podman.PodmanBin(), "machine", "rm", "-f", name)
+	rm.Stdout = os.Stdout
+	rm.Stderr = os.Stderr
+	if err := rm.Run(); err != nil {
+		return fmt.Errorf("podman machine rm %s: %w", name, err)
+	}
+
+	// ensurePodmanMachineRunning re-inits a rootful machine when none exists
+	// and waits for the API socket to be ready.
+	ensurePodmanMachineRunning()
+	recordMachineLastUp()
+
+	fmt.Println()
+	fmt.Println("Podman Machine recreated. Run `lerd start` to bring your sites back up.")
+	return nil
+}

--- a/internal/cli/machine_reset_darwin.go
+++ b/internal/cli/machine_reset_darwin.go
@@ -32,7 +32,11 @@ func runMachineReset(assumeYes bool) error {
 		line, _ := reader.ReadString('\n')
 		ans := strings.ToLower(strings.TrimSpace(line))
 		if ans != "y" && ans != "yes" {
-			return fmt.Errorf("aborted")
+			// Declining the prompt is a normal choice, not a failure — print a
+			// plain notice and exit zero rather than letting cobra render
+			// "Error: aborted" with a non-zero status.
+			fmt.Println("Cancelled.")
+			return nil
 		}
 	}
 

--- a/internal/cli/machine_reset_other.go
+++ b/internal/cli/machine_reset_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin
+
+package cli
+
+import "fmt"
+
+// runMachineReset is macOS-only: Linux uses native rootless podman with no VM.
+func runMachineReset(_ bool) error {
+	fmt.Println("lerd machine reset is only supported on macOS (Podman Machine). On Linux, podman runs natively without a VM.")
+	return nil
+}

--- a/internal/cli/machine_restart_heal_darwin.go
+++ b/internal/cli/machine_restart_heal_darwin.go
@@ -120,7 +120,7 @@ func removeLerdContainersForGvproxyHeal() {
 
 // forceRemoveLerdContainers force-removes lerd-* containers so the next
 // StartUnit pass recreates them fresh via `podman run`. includeStopped adds
-// `-a` to also catch created/exited containers — used by the overlay heal,
+// `-a` to also catch created/exited containers, used by the overlay heal,
 // where the failed containers never reached running state. announce is
 // printed only when at least one container matched.
 func forceRemoveLerdContainers(includeStopped bool, announce string) {

--- a/internal/cli/machine_restart_heal_darwin.go
+++ b/internal/cli/machine_restart_heal_darwin.go
@@ -114,7 +114,21 @@ func healMachineRestartIfNeeded(preEnsureLastUp string) {
 // container so the next StartUnit pass invokes `podman run -p` fresh from
 // the host and gvproxy re-registers the host port forwards.
 func removeLerdContainersForGvproxyHeal() {
-	out, err := podman.Run("ps", "--format", "{{.Names}}", "--filter", "name=^lerd-")
+	forceRemoveLerdContainers(false,
+		"  --> Podman Machine was restarted; recreating containers to restore host port forwards ...")
+}
+
+// forceRemoveLerdContainers force-removes lerd-* containers so the next
+// StartUnit pass recreates them fresh via `podman run`. includeStopped adds
+// `-a` to also catch created/exited containers — used by the overlay heal,
+// where the failed containers never reached running state. announce is
+// printed only when at least one container matched.
+func forceRemoveLerdContainers(includeStopped bool, announce string) {
+	psArgs := []string{"ps", "--format", "{{.Names}}", "--filter", "name=^lerd-"}
+	if includeStopped {
+		psArgs = append(psArgs, "-a")
+	}
+	out, err := podman.Run(psArgs...)
 	if err != nil || strings.TrimSpace(out) == "" {
 		return
 	}
@@ -127,7 +141,7 @@ func removeLerdContainersForGvproxyHeal() {
 	if len(names) == 0 {
 		return
 	}
-	fmt.Println("  --> Podman Machine was restarted; recreating containers to restore host port forwards ...")
+	fmt.Println(announce)
 	args := append([]string{"rm", "-f"}, names...)
 	if out, err := exec.Command(podman.PodmanBin(), args...).CombinedOutput(); err != nil {
 		fmt.Printf("       WARN: podman rm -f failed: %v\n%s\n", err, strings.TrimSpace(string(out)))

--- a/internal/cli/overlay_heal.go
+++ b/internal/cli/overlay_heal.go
@@ -1,0 +1,23 @@
+package cli
+
+import "strings"
+
+// isOverlayStorageError reports whether err is the podman graph-driver /
+// overlay-storage failure that surfaces after an ungraceful host shutdown
+// leaves the Podman Machine's container storage with a stale overlay mount,
+// e.g. `getting graph driver info "<id>": readlink
+// /var/lib/containers/storage/overlay: invalid argument`. Every container
+// start fails with this until the VM remounts its storage. Matching requires
+// the graph-driver phrase plus an overlay/readlink signal so unrelated
+// failures (port conflicts, missing images) don't trip the heal.
+func isOverlayStorageError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "graph driver") {
+		return false
+	}
+	return strings.Contains(msg, "/containers/storage/overlay") ||
+		(strings.Contains(msg, "readlink") && strings.Contains(msg, "invalid argument"))
+}

--- a/internal/cli/overlay_heal.go
+++ b/internal/cli/overlay_heal.go
@@ -6,8 +6,9 @@ import "strings"
 // that surfaces after an ungraceful host shutdown leaves the Podman Machine's
 // container storage corrupt. Every container start fails until the VM remounts
 // its storage and the stale containers are rebuilt. Two variants are matched,
-// both gated tightly so unrelated failures (port conflicts, missing images, bad
-// flags) don't trip the heal:
+// both anchored on the overlay store path so unrelated failures (port
+// conflicts, missing images, bad flags, or graph-driver/readlink errors that
+// don't touch the overlay store) don't trip the destructive heal:
 //
 //  1. graph-driver info query: `getting graph driver info "<id>": readlink
 //     /var/lib/containers/storage/overlay: invalid argument`
@@ -24,8 +25,7 @@ func isOverlayStorageError(err error) bool {
 	msg := strings.ToLower(err.Error())
 
 	if strings.Contains(msg, "graph driver") {
-		return strings.Contains(msg, "/containers/storage/overlay") ||
-			(strings.Contains(msg, "readlink") && strings.Contains(msg, "invalid argument"))
+		return strings.Contains(msg, "/containers/storage/overlay")
 	}
 
 	if strings.Contains(msg, "mounting storage for container") {

--- a/internal/cli/overlay_heal.go
+++ b/internal/cli/overlay_heal.go
@@ -9,10 +9,10 @@ import "strings"
 // both gated tightly so unrelated failures (port conflicts, missing images, bad
 // flags) don't trip the heal:
 //
-//	1. graph-driver info query — `getting graph driver info "<id>": readlink
-//	   /var/lib/containers/storage/overlay: invalid argument`
-//	2. container mount — `mounting storage for container <id>: readlink
-//	   /var/lib/containers/storage/overlay/<layer>/diff: no such file or directory`
+//  1. graph-driver info query: `getting graph driver info "<id>": readlink
+//     /var/lib/containers/storage/overlay: invalid argument`
+//  2. container mount: `mounting storage for container <id>: readlink
+//     /var/lib/containers/storage/overlay/<layer>/diff: no such file or directory`
 //
 // Variant 2 was observed reproducing a broken container layer (image layers
 // intact, so a fresh `podman run` still works); rebuilding the containers

--- a/internal/cli/overlay_heal.go
+++ b/internal/cli/overlay_heal.go
@@ -2,22 +2,36 @@ package cli
 
 import "strings"
 
-// isOverlayStorageError reports whether err is the podman graph-driver /
-// overlay-storage failure that surfaces after an ungraceful host shutdown
-// leaves the Podman Machine's container storage with a stale overlay mount,
-// e.g. `getting graph driver info "<id>": readlink
-// /var/lib/containers/storage/overlay: invalid argument`. Every container
-// start fails with this until the VM remounts its storage. Matching requires
-// the graph-driver phrase plus an overlay/readlink signal so unrelated
-// failures (port conflicts, missing images) don't trip the heal.
+// isOverlayStorageError reports whether err is a podman overlay-storage failure
+// that surfaces after an ungraceful host shutdown leaves the Podman Machine's
+// container storage corrupt. Every container start fails until the VM remounts
+// its storage and the stale containers are rebuilt. Two variants are matched,
+// both gated tightly so unrelated failures (port conflicts, missing images, bad
+// flags) don't trip the heal:
+//
+//	1. graph-driver info query — `getting graph driver info "<id>": readlink
+//	   /var/lib/containers/storage/overlay: invalid argument`
+//	2. container mount — `mounting storage for container <id>: readlink
+//	   /var/lib/containers/storage/overlay/<layer>/diff: no such file or directory`
+//
+// Variant 2 was observed reproducing a broken container layer (image layers
+// intact, so a fresh `podman run` still works); rebuilding the containers
+// recovers it, which is exactly what the heal does.
 func isOverlayStorageError(err error) bool {
 	if err == nil {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
-	if !strings.Contains(msg, "graph driver") {
-		return false
+
+	if strings.Contains(msg, "graph driver") {
+		return strings.Contains(msg, "/containers/storage/overlay") ||
+			(strings.Contains(msg, "readlink") && strings.Contains(msg, "invalid argument"))
 	}
-	return strings.Contains(msg, "/containers/storage/overlay") ||
-		(strings.Contains(msg, "readlink") && strings.Contains(msg, "invalid argument"))
+
+	if strings.Contains(msg, "mounting storage for container") {
+		return strings.Contains(msg, "/containers/storage/overlay") &&
+			strings.Contains(msg, "readlink")
+	}
+
+	return false
 }

--- a/internal/cli/overlay_heal_darwin.go
+++ b/internal/cli/overlay_heal_darwin.go
@@ -1,0 +1,59 @@
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// healOverlayCorruptionIfNeeded restarts the Podman Machine when the service
+// start pass failed with the overlay-storage error (see isOverlayStorageError).
+// A clean stop+start remounts the VM's container storage, which clears the
+// stale-mount form of the corruption. lerd's persistent data is host
+// bind-mounted, so the restart is non-destructive. Returns true when a restart
+// was performed and the caller should retry the start pass once.
+func healOverlayCorruptionIfNeeded(err error) bool {
+	if !isOverlayStorageError(err) {
+		return false
+	}
+	restartPodmanMachineForHeal()
+	return true
+}
+
+// restartPodmanMachineForHeal stops and restarts lerd's Podman Machine so its
+// container storage is remounted, then refreshes the restart baseline so the
+// next run doesn't mistake this restart for an external one.
+func restartPodmanMachineForHeal() {
+	name := selectedMachineName()
+	if name == "" {
+		return
+	}
+	fmt.Println("  --> Container storage looks stale after an unclean shutdown; restarting the Podman Machine to remount it ...")
+	stop := exec.Command(podman.PodmanBin(), "machine", "stop", name)
+	stop.Stdout = os.Stdout
+	stop.Stderr = os.Stderr
+	if err := stop.Run(); err != nil {
+		fmt.Printf("  WARN: podman machine stop: %v\n", err)
+	}
+	// ensurePodmanMachineRunning starts the VM and waits for the API socket.
+	ensurePodmanMachineRunning()
+	recordMachineLastUp()
+}
+
+// reportOverlayHealOutcome prints recovery guidance when the overlay-storage
+// error persisted after the automatic machine restart and retry.
+func reportOverlayHealOutcome(err error) {
+	if !isOverlayStorageError(err) {
+		return
+	}
+	fmt.Println()
+	fmt.Println("  Podman Machine container storage is still corrupted after a restart.")
+	fmt.Println("  This happens when the host shuts down while the VM is running.")
+	fmt.Println("  Your databases and site data are safe — they live on the host, not in the VM.")
+	fmt.Println("  Recreate the VM to fix it (images are rebuilt automatically on the next start):")
+	fmt.Println("      lerd machine reset")
+}

--- a/internal/cli/overlay_heal_darwin.go
+++ b/internal/cli/overlay_heal_darwin.go
@@ -50,10 +50,12 @@ func restartPodmanMachineForHeal() {
 }
 
 // reportOverlayHealOutcome prints recovery guidance when the overlay-storage
-// error persisted after the automatic machine restart and retry.
-func reportOverlayHealOutcome(err error) {
+// error persisted after the automatic machine restart and retry, and reports
+// whether it claimed the error so the caller can stop the start. It returns
+// false for any other error, leaving the normal start flow to continue.
+func reportOverlayHealOutcome(err error) bool {
 	if !isOverlayStorageError(err) {
-		return
+		return false
 	}
 	fmt.Println()
 	fmt.Println("  Podman Machine container storage is still corrupted after a restart.")
@@ -61,4 +63,5 @@ func reportOverlayHealOutcome(err error) {
 	fmt.Println("  Your databases and site data are safe; they live on the host, not in the VM.")
 	fmt.Println("  Recreate the VM to fix it (images are rebuilt automatically on the next start):")
 	fmt.Println("      lerd machine reset")
+	return true
 }

--- a/internal/cli/overlay_heal_darwin.go
+++ b/internal/cli/overlay_heal_darwin.go
@@ -15,7 +15,7 @@ import (
 // retry once. Two things are corrupt after an unclean shutdown: the VM's
 // overlay base mount, and the lerd-* container layers built on it. A machine
 // restart remounts the base; force-removing the stale containers makes the
-// retry's `podman run` allocate fresh container storage — the path a manual
+// retry's `podman run` allocate fresh container storage, the path a manual
 // `podman run` takes when it succeeds where a remount alone doesn't. lerd's
 // persistent data is host bind-mounted, so both steps are non-destructive.
 // Returns true when recovery ran and the caller should retry the start pass.
@@ -58,7 +58,7 @@ func reportOverlayHealOutcome(err error) {
 	fmt.Println()
 	fmt.Println("  Podman Machine container storage is still corrupted after a restart.")
 	fmt.Println("  This happens when the host shuts down while the VM is running.")
-	fmt.Println("  Your databases and site data are safe — they live on the host, not in the VM.")
+	fmt.Println("  Your databases and site data are safe; they live on the host, not in the VM.")
 	fmt.Println("  Recreate the VM to fix it (images are rebuilt automatically on the next start):")
 	fmt.Println("      lerd machine reset")
 }

--- a/internal/cli/overlay_heal_darwin.go
+++ b/internal/cli/overlay_heal_darwin.go
@@ -10,17 +10,22 @@ import (
 	"github.com/geodro/lerd/internal/podman"
 )
 
-// healOverlayCorruptionIfNeeded restarts the Podman Machine when the service
-// start pass failed with the overlay-storage error (see isOverlayStorageError).
-// A clean stop+start remounts the VM's container storage, which clears the
-// stale-mount form of the corruption. lerd's persistent data is host
-// bind-mounted, so the restart is non-destructive. Returns true when a restart
-// was performed and the caller should retry the start pass once.
+// healOverlayCorruptionIfNeeded recovers from the overlay-storage error (see
+// isOverlayStorageError) on the service start pass, then asks the caller to
+// retry once. Two things are corrupt after an unclean shutdown: the VM's
+// overlay base mount, and the lerd-* container layers built on it. A machine
+// restart remounts the base; force-removing the stale containers makes the
+// retry's `podman run` allocate fresh container storage — the path a manual
+// `podman run` takes when it succeeds where a remount alone doesn't. lerd's
+// persistent data is host bind-mounted, so both steps are non-destructive.
+// Returns true when recovery ran and the caller should retry the start pass.
 func healOverlayCorruptionIfNeeded(err error) bool {
 	if !isOverlayStorageError(err) {
 		return false
 	}
 	restartPodmanMachineForHeal()
+	forceRemoveLerdContainers(true,
+		"  --> Clearing stale lerd containers so they rebuild on fresh storage ...")
 	return true
 }
 

--- a/internal/cli/overlay_heal_other.go
+++ b/internal/cli/overlay_heal_other.go
@@ -2,7 +2,7 @@
 
 package cli
 
-// healOverlayCorruptionIfNeeded is a no-op on non-darwin platforms — the
+// healOverlayCorruptionIfNeeded is a no-op on non-darwin platforms; the
 // overlay-storage corruption it heals is specific to the macOS Podman Machine
 // VM. Native rootless podman on Linux doesn't use a separate VM.
 func healOverlayCorruptionIfNeeded(_ error) bool { return false }

--- a/internal/cli/overlay_heal_other.go
+++ b/internal/cli/overlay_heal_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin
+
+package cli
+
+// healOverlayCorruptionIfNeeded is a no-op on non-darwin platforms — the
+// overlay-storage corruption it heals is specific to the macOS Podman Machine
+// VM. Native rootless podman on Linux doesn't use a separate VM.
+func healOverlayCorruptionIfNeeded(_ error) bool { return false }
+
+// reportOverlayHealOutcome is a no-op on non-darwin platforms.
+func reportOverlayHealOutcome(_ error) {}

--- a/internal/cli/overlay_heal_other.go
+++ b/internal/cli/overlay_heal_other.go
@@ -7,5 +7,7 @@ package cli
 // VM. Native rootless podman on Linux doesn't use a separate VM.
 func healOverlayCorruptionIfNeeded(_ error) bool { return false }
 
-// reportOverlayHealOutcome is a no-op on non-darwin platforms.
-func reportOverlayHealOutcome(_ error) {}
+// reportOverlayHealOutcome is a no-op on non-darwin platforms: the overlay
+// corruption it guards against is specific to the macOS Podman Machine VM, so
+// it never claims the error and the start flow continues unchanged.
+func reportOverlayHealOutcome(_ error) bool { return false }

--- a/internal/cli/overlay_heal_other_test.go
+++ b/internal/cli/overlay_heal_other_test.go
@@ -1,0 +1,23 @@
+//go:build !darwin
+
+package cli
+
+import (
+	"errors"
+	"testing"
+)
+
+// On non-darwin platforms the overlay heal does not apply (no Podman Machine
+// VM), so reportOverlayHealOutcome must never claim the error. If it did,
+// runStart would stop early and skip the worker, DNS, and tray steps with no
+// guidance printed, even though the matcher can match a Linux container-storage
+// path. Guard that the gate stays open here.
+func TestReportOverlayHealOutcomeIsNoopOnLinux(t *testing.T) {
+	linuxOverlayErr := errors.New(`Error: getting graph driver info "abc": readlink /home/user/.local/share/containers/storage/overlay: invalid argument`)
+	if reportOverlayHealOutcome(linuxOverlayErr) {
+		t.Fatal("reportOverlayHealOutcome claimed a Linux overlay error; runStart would stop early without guidance")
+	}
+	if healOverlayCorruptionIfNeeded(linuxOverlayErr) {
+		t.Fatal("healOverlayCorruptionIfNeeded ran on a non-darwin platform")
+	}
+}

--- a/internal/cli/overlay_heal_test.go
+++ b/internal/cli/overlay_heal_test.go
@@ -23,7 +23,7 @@ func TestIsOverlayStorageError(t *testing.T) {
 		want bool
 	}{
 		{"real overlay corruption", realErr, true},
-		{"graph driver with readlink+invalid", errors.New(`getting graph driver info "x": readlink /foo: invalid argument`), true},
+		{"graph driver readlink+invalid but not overlay store", errors.New(`getting graph driver info "x": readlink /foo: invalid argument`), false},
 		{"container mount broken overlay layer", mountErr, true},
 		{"nil error", nil, false},
 		{"port conflict", errors.New("rootlessport cannot expose privileged port 80, bind: address already in use"), false},

--- a/internal/cli/overlay_heal_test.go
+++ b/internal/cli/overlay_heal_test.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsOverlayStorageError(t *testing.T) {
+	// The exact wrapping runStart produces: StartUnit wraps the podman stderr.
+	realErr := fmt.Errorf("podman run lerd-nginx: %w",
+		errors.New(`exit status 125: Error: getting graph driver info "b77616fb55fa": readlink /var/lib/containers/storage/overlay: invalid argument`))
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"real overlay corruption", realErr, true},
+		{"graph driver with readlink+invalid", errors.New(`getting graph driver info "x": readlink /foo: invalid argument`), true},
+		{"nil error", nil, false},
+		{"port conflict", errors.New("rootlessport cannot expose privileged port 80, bind: address already in use"), false},
+		{"missing image", errors.New(`short-name "lerd-php85-fpm:local" did not resolve to an alias`), false},
+		{"unrelated invalid argument", errors.New("some flag: invalid argument"), false},
+		{"generic failure", errors.New("some other failure"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isOverlayStorageError(tc.err); got != tc.want {
+				t.Fatalf("isOverlayStorageError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/overlay_heal_test.go
+++ b/internal/cli/overlay_heal_test.go
@@ -11,6 +11,12 @@ func TestIsOverlayStorageError(t *testing.T) {
 	realErr := fmt.Errorf("podman run lerd-nginx: %w",
 		errors.New(`exit status 125: Error: getting graph driver info "b77616fb55fa": readlink /var/lib/containers/storage/overlay: invalid argument`))
 
+	// Variant 2, captured reproducing a broken container layer in a throwaway
+	// Podman Machine: the existing container fails to mount its overlay storage
+	// while a fresh `podman run` (new layer, same intact image) still works.
+	mountErr := fmt.Errorf("podman run lerd-redis: %w",
+		errors.New(`exit status 125: Error: unable to start container "3752898bf744": mounting storage for container 3752898bf744: readlink /var/lib/containers/storage/overlay/312d216688349/diff: no such file or directory`))
+
 	cases := []struct {
 		name string
 		err  error
@@ -18,10 +24,12 @@ func TestIsOverlayStorageError(t *testing.T) {
 	}{
 		{"real overlay corruption", realErr, true},
 		{"graph driver with readlink+invalid", errors.New(`getting graph driver info "x": readlink /foo: invalid argument`), true},
+		{"container mount broken overlay layer", mountErr, true},
 		{"nil error", nil, false},
 		{"port conflict", errors.New("rootlessport cannot expose privileged port 80, bind: address already in use"), false},
 		{"missing image", errors.New(`short-name "lerd-php85-fpm:local" did not resolve to an alias`), false},
 		{"unrelated invalid argument", errors.New("some flag: invalid argument"), false},
+		{"mounting storage but not overlay", errors.New(`mounting storage for container abc: no such device`), false},
 		{"generic failure", errors.New("some other failure"), false},
 	}
 	for _, tc := range cases {

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -580,7 +580,15 @@ func runStart(_ *cobra.Command, _ []string) error {
 		return jobs
 	}
 
-	RunParallel(makeJobs(serviceUnits)) //nolint:errcheck
+	serviceErr := RunParallel(makeJobs(serviceUnits))
+	// When the Podman Machine's container storage is left with a stale overlay
+	// mount after an unclean host shutdown, every container start fails. Restart
+	// the VM to remount storage (data is host bind-mounted, so this is safe) and
+	// retry the start pass once; if it still fails, surface recovery guidance.
+	if healOverlayCorruptionIfNeeded(serviceErr) {
+		serviceErr = RunParallel(makeJobs(serviceUnits)) //nolint:errcheck
+	}
+	reportOverlayHealOutcome(serviceErr)
 	if len(workerUnits) > 0 {
 		RunParallel(makeJobs(workerUnits)) //nolint:errcheck
 	}

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -588,11 +588,13 @@ func runStart(_ *cobra.Command, _ []string) error {
 	if healOverlayCorruptionIfNeeded(serviceErr) {
 		serviceErr = RunParallel(makeJobs(serviceUnits))
 	}
-	// If the storage is still corrupt, every worker (and the DNS and tray steps
-	// below) would fail the same way and bury the recovery guidance. Stop here
-	// so the guidance is the last thing the user sees.
-	if isOverlayStorageError(serviceErr) {
-		reportOverlayHealOutcome(serviceErr)
+	// If the storage is still corrupt the heal couldn't fix it; every worker
+	// (and the DNS and tray steps below) would fail the same way and bury the
+	// recovery guidance. reportOverlayHealOutcome prints the guidance and
+	// reports true only on the platform where this error occurs (macOS), so we
+	// stop there; on every other platform it is a no-op that returns false and
+	// the start continues as normal.
+	if reportOverlayHealOutcome(serviceErr) {
 		return nil
 	}
 	if len(workerUnits) > 0 {

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -588,8 +588,8 @@ func runStart(_ *cobra.Command, _ []string) error {
 	if healOverlayCorruptionIfNeeded(serviceErr) {
 		serviceErr = RunParallel(makeJobs(serviceUnits))
 	}
-	// If the storage is still corrupt, every worker — and the DNS and tray steps
-	// below — would fail the same way and bury the recovery guidance. Stop here
+	// If the storage is still corrupt, every worker (and the DNS and tray steps
+	// below) would fail the same way and bury the recovery guidance. Stop here
 	// so the guidance is the last thing the user sees.
 	if isOverlayStorageError(serviceErr) {
 		reportOverlayHealOutcome(serviceErr)

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -581,14 +581,20 @@ func runStart(_ *cobra.Command, _ []string) error {
 	}
 
 	serviceErr := RunParallel(makeJobs(serviceUnits))
-	// When the Podman Machine's container storage is left with a stale overlay
-	// mount after an unclean host shutdown, every container start fails. Restart
-	// the VM to remount storage (data is host bind-mounted, so this is safe) and
-	// retry the start pass once; if it still fails, surface recovery guidance.
+	// When the Podman Machine's container storage is left corrupt after an
+	// unclean host shutdown, every container start fails. Remount storage and
+	// rebuild the stale containers (data is host bind-mounted, so this is safe),
+	// then retry the start pass once.
 	if healOverlayCorruptionIfNeeded(serviceErr) {
-		serviceErr = RunParallel(makeJobs(serviceUnits)) //nolint:errcheck
+		serviceErr = RunParallel(makeJobs(serviceUnits))
 	}
-	reportOverlayHealOutcome(serviceErr)
+	// If the storage is still corrupt, every worker — and the DNS and tray steps
+	// below — would fail the same way and bury the recovery guidance. Stop here
+	// so the guidance is the last thing the user sees.
+	if isOverlayStorageError(serviceErr) {
+		reportOverlayHealOutcome(serviceErr)
+		return nil
+	}
 	if len(workerUnits) > 0 {
 		RunParallel(makeJobs(workerUnits)) //nolint:errcheck
 	}

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -247,8 +247,18 @@ func ensurePodmanMachineRunning() {
 
 	if len(machines) == 0 {
 		fmt.Println("  --> Initialising Podman Machine (first run, this may take a minute) ...")
-		cmd := exec.Command(podman.PodmanBin(), "machine", "init", "--rootful",
-			"-v", "/Volumes:/Volumes")
+		// Size memory at init so a fresh VM (first run, or one recreated by
+		// `lerd machine reset`) boots at the host-scaled target rather than
+		// podman's stock default. The existing-machine branch below only
+		// resizes machines that already exist.
+		cfg, _ := config.LoadGlobal()
+		execMode := cfg != nil && cfg.WorkerExecMode() != config.WorkerExecModeContainer
+		targetMemoryMiB := recommendedVMMemoryMiB(hostMemoryGiB(), execMode)
+		initArgs := []string{"machine", "init", "--rootful", "-v", "/Volumes:/Volumes"}
+		if targetMemoryMiB > 0 {
+			initArgs = append(initArgs, "--memory", strconv.FormatInt(targetMemoryMiB, 10))
+		}
+		cmd := exec.Command(podman.PodmanBin(), initArgs...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {


### PR DESCRIPTION
## Problem

Closes #475.

After an ungraceful macOS host shutdown while the Podman Machine VM is still running, the VM's container storage is left with a stale overlay mount and **every** container start fails:

```
exit status 125: Error: getting graph driver info "<id>": readlink /var/lib/containers/storage/overlay: invalid argument
```

`podman run` manually works; the only known fix was deleting & recreating the machine. `lerd start` surfaced the raw podman error with no recovery path.

## Why recovery is safe in lerd

lerd bind-mounts all persistent data to the **host** (`internal/podman/quadlet_generate.go` → `Volume=<config.DataSubDir(name)>:/var/lib/mysql`), not into in-VM named volumes. So restarting **or** recreating the VM is non-destructive: databases and site data survive, and images are rebuilt by the existing "ensure images built" preflight. This makes auto-heal feasible where it wouldn't be in a generic podman setup.

## Changes (macOS; Linux uses native rootless podman, no VM)

1. **Auto-heal in `runStart`** — detect the overlay-storage error from the service start pass, restart the Podman Machine to remount its storage (reusing `ensurePodmanMachineRunning`), and retry the start pass **once**. If it still fails, print recovery guidance instead of the cryptic podman error.
2. **`lerd machine reset`** — recreate the VM (stop → `machine rm -f` → re-init) with a confirmation prompt (skip via `--yes`), automating the manual workaround safely.

The error matcher (`isOverlayStorageError`) lives in a platform-agnostic file so it's unit-tested on the Linux CI runner. The heal and reset command are darwin-only with non-darwin no-op stubs.

## Design notes

- **Single retry, no loop** — the heal restarts the VM at most once per `lerd start` to avoid a restart loop on genuinely unrecoverable storage.
- **Tier 2 is manual, not auto-recreate** — auto-recreating the user's machine would also drop non-lerd containers/images (e.g. Podman Desktop usage), so recreation stays behind an explicit, confirmed `lerd machine reset`.
- The heal refreshes the machine-restart baseline (`recordMachineLastUp`) so the next run doesn't mistake the heal's restart for an external one.

## Tests

`TestIsOverlayStorageError` — the real #475 string matches; port conflicts, missing-image, and unrelated "invalid argument" errors do not. Runs on the Linux CI runner (matcher is platform-agnostic).

## Verification

- `go build ./...`, `go vet ./internal/cli/... ./cmd/...`, and `go test ./internal/cli/ -run TestIsOverlayStorageError` all green on darwin.
- `lerd machine` / `lerd machine reset --help` render the expected command tree.