### PR TITLE
fix(podman): probe mariadb with mariadb-admin instead of mysqladmin

### DIFF
--- a/internal/cli/import_sail.go
+++ b/internal/cli/import_sail.go
@@ -938,27 +938,41 @@ func sailDetectDatabase(composeArgs []string, service string, env *dbEnv, compos
 	return "", nil
 }
 
+// sailDBProbes returns the in-container readiness probe command(s) tried each
+// poll. mysql/mariadb lists two binaries: mariadb-admin (mariadb:11 dropped the
+// mysqladmin symlink) and mysqladmin (mysql images lack mariadb-admin).
+func sailDBProbes(service string, env *dbEnv) [][]string {
+	switch env.connection {
+	case "mysql", "mariadb":
+		// -h 127.0.0.1 forces TCP: Sail sets MYSQL_ROOT_HOST="%" which allows
+		// TCP but not Unix socket (localhost) connections.
+		var cmds [][]string
+		for _, bin := range []string{"mariadb-admin", "mysqladmin"} {
+			cmds = append(cmds, []string{"-e", "MYSQL_PWD=" + env.password,
+				service, bin, "ping", "-h", "127.0.0.1", "-u" + env.username, "--silent"})
+		}
+		return cmds
+	case "pgsql", "postgres":
+		return [][]string{{service, "pg_isready", "-U", env.username}}
+	default:
+		return nil
+	}
+}
+
 // sailWaitDB polls until the Sail database is accepting connections (up to 60 s).
 func sailWaitDB(composeArgs []string, service string, env *dbEnv, composeBin string) error {
+	probes := sailDBProbes(service, env)
+	if probes == nil {
+		return nil
+	}
 	deadline := time.Now().Add(60 * time.Second)
 	for time.Now().Before(deadline) {
-		var args []string
-		args = append(args, composeArgs...)
-		args = append(args, "exec", "-T")
-		switch env.connection {
-		case "mysql", "mariadb":
-			// -h 127.0.0.1 forces TCP: Sail sets MYSQL_ROOT_HOST="%" which allows
-			// TCP but not Unix socket (localhost) connections.
-			args = append(args, "-e", "MYSQL_PWD="+env.password,
-				service, "mysqladmin", "ping", "-h", "127.0.0.1", "-u"+env.username, "--silent")
-		case "pgsql", "postgres":
-			args = append(args, service, "pg_isready", "-U", env.username)
-		default:
-			return nil
-		}
-		cmd := exec.Command(composeBin, args...)
-		if cmd.Run() == nil {
-			return nil
+		for _, p := range probes {
+			args := append(append([]string{}, composeArgs...), "exec", "-T")
+			args = append(args, p...)
+			if exec.Command(composeBin, args...).Run() == nil {
+				return nil
+			}
 		}
 		time.Sleep(2 * time.Second)
 	}

--- a/internal/cli/import_sail_test.go
+++ b/internal/cli/import_sail_test.go
@@ -814,3 +814,49 @@ func TestSailPortRemapRoundTrip(t *testing.T) {
 		}
 	}
 }
+
+// ── sailDBProbes ────────────────────────────────────────────────────────────
+
+func TestSailDBProbesTriesBothMySQLBinaries(t *testing.T) {
+	for _, conn := range []string{"mysql", "mariadb"} {
+		probes := sailDBProbes("db", &dbEnv{connection: conn, username: "sail", password: "pw"})
+		if len(probes) != 2 {
+			t.Fatalf("conn=%q: expected 2 probes (mariadb-admin + mysqladmin), got %d", conn, len(probes))
+		}
+		// mariadb-admin must be tried first: mariadb:11 dropped mysqladmin.
+		if !containsArg(probes[0], "mariadb-admin") {
+			t.Errorf("conn=%q: first probe should call mariadb-admin, got %v", conn, probes[0])
+		}
+		if !containsArg(probes[1], "mysqladmin") {
+			t.Errorf("conn=%q: second probe should call mysqladmin, got %v", conn, probes[1])
+		}
+		for _, p := range probes {
+			joined := strings.Join(p, " ")
+			if !strings.Contains(joined, "-h 127.0.0.1") {
+				t.Errorf("conn=%q: probe must force TCP via -h 127.0.0.1, got %v", conn, p)
+			}
+			if !strings.Contains(joined, "MYSQL_PWD=pw") {
+				t.Errorf("conn=%q: probe must pass MYSQL_PWD, got %v", conn, p)
+			}
+		}
+	}
+}
+
+func TestSailDBProbesPostgresAndUnknown(t *testing.T) {
+	pg := sailDBProbes("pg", &dbEnv{connection: "pgsql", username: "sail"})
+	if len(pg) != 1 || !containsArg(pg[0], "pg_isready") {
+		t.Errorf("pgsql should yield a single pg_isready probe, got %v", pg)
+	}
+	if got := sailDBProbes("x", &dbEnv{connection: "sqlite"}); got != nil {
+		t.Errorf("unknown connection should yield no probes, got %v", got)
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -269,6 +269,12 @@ func RestartUnit(name string) error {
 // 127.0.0.1 holds on macOS and IPv6-only host networks too.
 var mysqlReadyArgs = []string{"mysqladmin", "ping", "-h127.0.0.1", "-P3306", "-uroot", "-plerd", "--silent"}
 
+// mariadbReadyArgs mirrors mysqlReadyArgs but calls mariadb-admin. The
+// mariadb:11 image dropped the legacy mysqladmin symlink, so probing it with
+// mysqladmin can never succeed and WaitReady would time out on every poll.
+// mariadb-admin is present in every mariadb version lerd ships (10.5+).
+var mariadbReadyArgs = []string{"mariadb-admin", "ping", "-h127.0.0.1", "-P3306", "-uroot", "-plerd", "--silent"}
+
 // readyFamily strips known version suffixes ("mariadb-10-11" →
 // "mariadb", "mysql-8.0" → "mysql", "postgres-16" → "postgres") so
 // WaitReady's family-aware probes apply to versioned preset names too.
@@ -279,11 +285,6 @@ var mysqlReadyArgs = []string{"mysqladmin", "ping", "-h127.0.0.1", "-P3306", "-u
 func readyFamily(service string) string {
 	for _, fam := range []string{"mariadb", "mysql", "postgres", "redis", "rustfs"} {
 		if service == fam || strings.HasPrefix(service, fam+"-") {
-			// mariadb and mysql share the same container probe
-			// (mysqladmin ping) so collapse mariadb onto mysql.
-			if fam == "mariadb" {
-				return "mysql"
-			}
 			return fam
 		}
 	}
@@ -292,9 +293,9 @@ func readyFamily(service string) string {
 
 // WaitReady polls until the named service is ready to accept connections, or
 // timeout is reached. Readiness is tested by running a lightweight probe inside
-// the container: mysqladmin ping for mysql/mariadb, pg_isready for postgres,
-// redis-cli ping for redis. For other services it falls back to waiting until
-// the systemd unit is "active".
+// the container: mysqladmin ping for mysql, mariadb-admin ping for mariadb,
+// pg_isready for postgres, redis-cli ping for redis. For other services it
+// falls back to waiting until the systemd unit is "active".
 func WaitReady(service string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	unit := "lerd-" + service
@@ -304,6 +305,11 @@ func WaitReady(service string, timeout time.Duration) error {
 	switch family {
 	case "mysql":
 		args := append([]string{"exec", unit}, mysqlReadyArgs...)
+		probe = func() bool {
+			return exec.Command(PodmanBin(), args...).Run() == nil
+		}
+	case "mariadb":
+		args := append([]string{"exec", unit}, mariadbReadyArgs...)
 		probe = func() bool {
 			return exec.Command(PodmanBin(), args...).Run() == nil
 		}

--- a/internal/podman/quadlet_waitready_test.go
+++ b/internal/podman/quadlet_waitready_test.go
@@ -21,3 +21,39 @@ func TestMySQLReadinessProbeForcesTCP(t *testing.T) {
 		t.Errorf("mysql readiness probe must not use localhost — mysqladmin resolves it to the Unix socket, got: %s", joined)
 	}
 }
+
+func TestMariaDBReadinessProbeUsesMariaDBAdmin(t *testing.T) {
+	// mariadb:11 dropped the mysqladmin symlink, so the probe must call
+	// mariadb-admin or WaitReady times out on every poll (issue #478).
+	joined := strings.Join(mariadbReadyArgs, " ")
+
+	if mariadbReadyArgs[0] != "mariadb-admin" || mariadbReadyArgs[1] != "ping" {
+		t.Fatalf("mariadb readiness probe should be a mariadb-admin ping, got: %s", joined)
+	}
+	if strings.Contains(joined, "mysqladmin") {
+		t.Errorf("mariadb readiness probe must not call mysqladmin — absent in mariadb:11, got: %s", joined)
+	}
+	if !strings.Contains(joined, "-h127.0.0.1") {
+		t.Errorf("mariadb readiness probe must force TCP via -h127.0.0.1, got: %s", joined)
+	}
+}
+
+func TestReadyFamilyRoutesVersionedNames(t *testing.T) {
+	cases := map[string]string{
+		"mariadb":       "mariadb",
+		"mariadb-11":    "mariadb",
+		"mariadb-10-11": "mariadb",
+		"mysql":         "mysql",
+		"mysql-8-0":     "mysql",
+		"postgres":      "postgres",
+		"postgres-16":   "postgres",
+		"redis":         "redis",
+		"rustfs":        "rustfs",
+		"custom-thing":  "custom-thing",
+	}
+	for service, want := range cases {
+		if got := readyFamily(service); got != want {
+			t.Errorf("readyFamily(%q) = %q, want %q", service, got, want)
+		}
+	}
+}


### PR DESCRIPTION
lerd's container readiness probe treated the whole mariadb family as mysql and ran mysqladmin ping inside the container. The mariadb:11 image dropped the legacy mysqladmin symlink (only mariadb-admin remains), so on the default mariadb preset that probe can never succeed and WaitReady runs to its deadline on every poll. A site linked onto mariadb then hangs for the full timeout on every php artisan call, which is what #478 reports as "mariadb-11 is active but not yet ready: did not become ready within 30s". The same broken probe was silently used by the serviceops tuning rollback and reinstall paths for any mariadb-versioned service.

readyFamily no longer folds mariadb into mysql, and WaitReady gets a dedicated mariadb branch that pings with mariadb-admin, which ships in every mariadb version lerd offers (10.5 and up). The mysql preset stays on mysqladmin because its images still carry it.

While in here I fixed the same hardcoded mysqladmin in the Sail import readiness loop, where a project pinned to mariadb:11 would false-timeout after 60s. The probe builder now tries mariadb-admin first and falls back to mysqladmin, so it works for mysql images, mariadb images, and the older apps that run DB_CONNECTION=mysql against a mariadb image.

Reported in #478.