### PR TITLE
fix(vite): order host worker units after the FPM container at boot

### DIFF
--- a/internal/cli/worker_host_linux_test.go
+++ b/internal/cli/worker_host_linux_test.go
@@ -63,6 +63,15 @@ func TestWriteHostWorkerUnitFile_useFnmExec(t *testing.T) {
 	if strings.Contains(unit, "BindsTo=") {
 		t.Error("host worker must not bind to FPM container")
 	}
+	// Boot ordering: host tools like Vite run wayfinder (php artisan) at
+	// startup and crash if the FPM container isn't up yet. After+Wants
+	// orders Vite behind FPM and pulls it up, without BindsTo's teardown.
+	if !strings.Contains(unit, "After=network.target lerd-php84-fpm.service") {
+		t.Errorf("host worker must order after the FPM unit; got:\n%s", unit)
+	}
+	if !strings.Contains(unit, "Wants=lerd-php84-fpm.service") {
+		t.Errorf("host worker must pull up the FPM unit at boot; got:\n%s", unit)
+	}
 }
 
 func TestWriteWorkerUnitFile_hostFalse_usesPodman(t *testing.T) {

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -32,7 +32,7 @@ func removeWorkerExecArtifacts(_ string) {}
 // restart-loop every 5s under Restart=always.
 func writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, command, restart, schedule, fpmUnit string, host bool) (bool, error) {
 	if host {
-		return writeHostWorkerUnitFile(unitName, label, siteName, sitePath, command, restart)
+		return writeHostWorkerUnitFile(unitName, label, siteName, sitePath, command, restart, fpmUnit)
 	}
 	container := fpmUnit
 
@@ -99,7 +99,7 @@ const defaultNodeVersion = "22"
 // writeHostWorkerUnitFile writes a systemd service unit for a worker that runs
 // on the host via fnm rather than inside a container. Used for Node.js tools
 // like Vite that need direct host access for HMR.
-func writeHostWorkerUnitFile(unitName, label, siteName, sitePath, command, restart string) (bool, error) {
+func writeHostWorkerUnitFile(unitName, label, siteName, sitePath, command, restart, fpmUnit string) (bool, error) {
 	fnm := filepath.Join(config.BinDir(), "fnm")
 	nodeVersion, err := nodeDet.DetectVersion(sitePath)
 	if err != nil {
@@ -125,8 +125,13 @@ func writeHostWorkerUnitFile(unitName, label, siteName, sitePath, command, resta
 	// `~/.local/bin` stays reachable — issue #375.
 	home, _ := os.UserHomeDir()
 	envPath := config.BinDir() + ":" + filepath.Join(home, ".local", "bin") + ":/usr/local/bin:/usr/bin:/bin"
+	// Order after and pull up the site's FPM container: host tools like Vite
+	// run wayfinder (php artisan) at startup, which fails if FPM isn't up yet
+	// at boot. Wants, not BindsTo, so a transient FPM restart can't kill Vite.
 	unit := fmt.Sprintf(`[Unit]
 Description=Lerd %s (%s)
+After=network.target %s.service
+Wants=%s.service
 
 [Service]
 Type=simple
@@ -139,7 +144,7 @@ ExecStart=/bin/sh -c '%s'
 
 [Install]
 WantedBy=default.target
-`, label, siteName, restart, sitePath, envPath, escaped)
+`, label, siteName, fpmUnit, fpmUnit, restart, sitePath, envPath, escaped)
 
 	_ = services.Mgr.RemoveTimerUnit(unitName)
 	return services.Mgr.WriteServiceUnitIfChanged(unitName, unit)


### PR DESCRIPTION
Host-executed framework workers like Vite were written with an empty `[Unit]` section, so at boot systemd brought them up in parallel with the PHP FPM container. Vite's wayfinder plugin shells out to `php artisan` the instant the dev server starts, loses the race against the not-yet-running container, and exits with code 1, leaving the worker dead until it's manually healed. Only some sites were affected on any given boot, purely down to which one lost the race. The containerised workers never hit this because they already order after and bind to their FPM unit.

This gives the host worker the same boot ordering, an `After` plus `Wants` on the site's runtime container, resolved through the same helper the containerised path uses so custom container and FrankenPHP sites depend on the right unit rather than a hardcoded php-fpm. I used `Wants` instead of `BindsTo` on purpose, so a transient FPM restart cascade can't tear Vite down with every blip, which also keeps the existing no-BindsTo contract on host workers intact.