### PR TITLE
fix: let the env editor scroll all the way to the bottom

### DIFF
--- a/internal/ui/web/src/tabs/sites/SiteEnvTab.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteEnvTab.svelte
@@ -188,7 +188,7 @@
   }
 </script>
 
-<div class="flex flex-col h-full">
+<div class="flex-1 flex flex-col min-h-0 overflow-hidden">
   <div class="sticky top-0 z-10">
     <div class="flex items-center justify-between bg-gray-50 dark:bg-white/3 px-3 py-1.5 border-b border-gray-200 dark:border-lerd-border">
       <div class="flex items-center gap-2">
@@ -237,7 +237,7 @@
     </div>
   </div>
 
-  <div class="flex-1 overflow-hidden bg-gray-50 dark:bg-black/40">
+  <div class="flex-1 min-h-0 overflow-hidden bg-gray-50 dark:bg-black/40">
     {#if loading}
       <p class="text-xs text-gray-400 px-3 py-2.5">{m.common_loading()}</p>
     {:else if error}


### PR DESCRIPTION
The env editor had a chunk of content stuck below the visible area that you could never scroll to. The env tab's root container used h-full, so inside the DetailPanel flex column it claimed the panel's entire height on top of the site header above it. That pushed its bottom slice past the panel's overflow-hidden, where it got clipped off the bottom of the screen, and CodeMirror's own scroller could never reach that clipped region so the last lines stayed stranded under the page.

The fix switches the root to flex-1 with min-h-0 so it only takes the space left after the header, which is exactly how the logs and tinker tabs already fill the panel. The inner editor area also gets min-h-0 so the flex child can shrink to fit.