### PR TITLE
fix: host-proxy regressions found reviewing changes since v1.23.1

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -452,7 +452,10 @@ func newWatchCmd() *cobra.Command {
 			// LAN IP for host.containers.internal in the shared /etc/hosts,
 			// and Xdebug silently times out until the next lerd start. The
 			// watcher verifies the current entry every tick and reprobes
-			// only when it stops responding.
+			// only when it stops responding. On a change, host-proxy vhosts
+			// (which bake the gateway IP into proxy_pass on Linux) are
+			// regenerated so they don't point at the old, now-dead address.
+			watcher.OnGatewayIPChange = cli.RegenerateHostProxyVhostsOnGatewayChange
 			go watcher.WatchHostGateway(30 * time.Second)
 
 			// Self-heal exec-mode framework workers on macOS. Container mode

--- a/internal/certs/secure.go
+++ b/internal/certs/secure.go
@@ -16,6 +16,13 @@ import (
 // `lerd secure` command and the dashboard HTTPS toggle.
 var ErrDNSDisabled = fmt.Errorf("HTTPS requires lerd-managed DNS, set dns.enabled: true and re-run lerd install")
 
+// RegenerateHostProxyWorktreeVhost regenerates the proxy vhost for a single
+// worktree of a host-proxy site, switching it between HTTP and HTTPS. It is
+// populated by the cli package (which owns host-proxy port allocation) so certs
+// can do this without importing cli. nil in builds that don't link cli, in
+// which case host-proxy worktree vhosts are left untouched.
+var RegenerateHostProxyWorktreeVhost func(site config.Site, wtPath, wtDomain string, secured bool) error
+
 // SecureSite issues a TLS certificate for the site and switches its nginx vhost to HTTPS.
 func SecureSite(site config.Site) error {
 	if cfg, _ := config.LoadGlobal(); cfg != nil && !cfg.DNS.Enabled {
@@ -53,6 +60,15 @@ func SecureSite(site config.Site) error {
 	// Regenerate SSL vhosts and sync APP_URL + VITE_REVERB_* for worktrees.
 	if worktrees, err := gitpkg.ServableWorktrees(site.Path, site.PrimaryDomain()); err == nil {
 		for _, wt := range worktrees {
+			if site.IsHostProxy() {
+				// Host-proxy worktrees have no PHP/FPM; render the proxy vhost
+				// pointing at the worktree's dev-server port instead of fastcgi.
+				if RegenerateHostProxyWorktreeVhost != nil {
+					_ = RegenerateHostProxyWorktreeVhost(site, wt.Path, wt.Domain, true)
+				}
+				envfile.SyncPrimaryDomain(wt.Path, wt.Domain, true) //nolint:errcheck
+				continue
+			}
 			effectivePHP := config.WorktreePHPVersion(wt.Path, site.PHPVersion)
 			_ = nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, effectivePHP, site.PrimaryDomain(), site.Name, wt.Branch)
 			envfile.SyncPrimaryDomain(wt.Path, wt.Domain, true) //nolint:errcheck
@@ -126,6 +142,13 @@ func UnsecureSite(site config.Site) error {
 	// Switch any worktree SSL vhosts back to plain HTTP and sync env.
 	if worktrees, err := gitpkg.ServableWorktrees(site.Path, site.PrimaryDomain()); err == nil {
 		for _, wt := range worktrees {
+			if site.IsHostProxy() {
+				if RegenerateHostProxyWorktreeVhost != nil {
+					_ = RegenerateHostProxyWorktreeVhost(site, wt.Path, wt.Domain, false)
+				}
+				envfile.SyncPrimaryDomain(wt.Path, wt.Domain, false) //nolint:errcheck
+				continue
+			}
 			effectivePHP := config.WorktreePHPVersion(wt.Path, site.PHPVersion)
 			_ = nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, effectivePHP, site.Name, wt.Branch)
 			envfile.SyncPrimaryDomain(wt.Path, wt.Domain, false) //nolint:errcheck

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -34,15 +35,35 @@ const hostProxyLoopback = "127.0.0.1"
 // map from the container port to the service's published host port (e.g. mariadb
 // 3306 -> 3411). Containerised sites keep the container DNS names untouched.
 func rewriteEnvForHostProxy(updates map[string]string, serviceNames []string) {
+	// Sort so a container port shared by two services (e.g. mysql and mariadb
+	// both on 3306) resolves to a stable host port rather than whichever map
+	// iteration happened to land last.
+	names := append([]string(nil), serviceNames...)
+	sort.Strings(names)
 	containerToHost := map[string]string{}
-	for _, name := range serviceNames {
+	for _, name := range names {
 		for _, mapping := range servicePortMappings(name) {
 			if host, container, ok := splitHostContainerPort(mapping); ok {
-				containerToHost[container] = host
+				if _, seen := containerToHost[container]; !seen {
+					containerToHost[container] = host
+				}
 			}
 		}
 	}
 	applyHostProxyEnv(updates, containerToHost)
+}
+
+// hostProxyConnKey reports whether an env key names a service connection target
+// (a host, port, URL, DSN, or endpoint). The host-proxy rewrite only touches
+// these so an unrelated value that happens to contain a "lerd-" token (e.g.
+// APP_NAME=lerd-demo) is never mangled into 127.0.0.1.
+func hostProxyConnKey(k string) bool {
+	for _, suf := range []string{"_HOST", "_PORT", "_URL", "_DSN", "_ENDPOINT", "_SERVER"} {
+		if strings.HasSuffix(k, suf) {
+			return true
+		}
+	}
+	return false
 }
 
 // lerdContainerHostRe matches a lerd container hostname with an optional
@@ -56,6 +77,9 @@ var lerdContainerHostRe = regexp.MustCompile(`lerd-[a-z0-9-]+(?::\d+)?`)
 // Split from rewriteEnvForHostProxy so the logic is testable without services.
 func applyHostProxyEnv(updates, containerToHost map[string]string) {
 	for k, v := range updates {
+		if !hostProxyConnKey(k) {
+			continue
+		}
 		nv := lerdContainerHostRe.ReplaceAllStringFunc(v, func(m string) string {
 			_, port, found := strings.Cut(m, ":")
 			if !found {

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -346,6 +346,31 @@ func TestApplyHostProxyEnv_rewritesEmbeddedUrlHosts(t *testing.T) {
 	}
 }
 
+func TestApplyHostProxyEnv_leavesNonConnectionKeysAlone(t *testing.T) {
+	// A value carrying a "lerd-" token in a key that is NOT a connection target
+	// must survive untouched — only host/port/url/dsn/endpoint keys get rewritten.
+	updates := map[string]string{
+		"APP_NAME":     "lerd-demo",                    // not a conn key: keep
+		"CACHE_PREFIX": "lerd-cache",                   // not a conn key: keep
+		"DB_HOST":      "lerd-mariadb",                 // conn key: rewrite to loopback
+		"MONGO_DSN":    "mongodb://lerd-mongo:27017/x", // conn key: rewrite host
+	}
+	applyHostProxyEnv(updates, map[string]string{"27017": "27017"})
+
+	if updates["APP_NAME"] != "lerd-demo" {
+		t.Errorf("APP_NAME mangled: %q", updates["APP_NAME"])
+	}
+	if updates["CACHE_PREFIX"] != "lerd-cache" {
+		t.Errorf("CACHE_PREFIX mangled: %q", updates["CACHE_PREFIX"])
+	}
+	if updates["DB_HOST"] != "127.0.0.1" {
+		t.Errorf("DB_HOST = %q, want 127.0.0.1", updates["DB_HOST"])
+	}
+	if updates["MONGO_DSN"] != "mongodb://127.0.0.1:27017/x" {
+		t.Errorf("MONGO_DSN = %q", updates["MONGO_DSN"])
+	}
+}
+
 func TestRewriteEnvForHostProxy_usesPresetPorts(t *testing.T) {
 	// postgres + redis are default presets resolvable from the embedded YAML,
 	// so the full path (preset lookup -> port map -> rewrite) works offline.

--- a/internal/cli/hostproxy.go
+++ b/internal/cli/hostproxy.go
@@ -2,17 +2,72 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
+	"syscall"
 
+	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
+	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/nginx"
+	"github.com/geodro/lerd/internal/siteops"
 )
+
+func init() {
+	// certs.SecureSite/UnsecureSite regenerate worktree vhosts but can't import
+	// cli (which owns host-proxy port allocation), so they call back through this
+	// hook for host-proxy worktrees. Mirrors SetupHostProxyWorktree's vhost step.
+	certs.RegenerateHostProxyWorktreeVhost = func(site config.Site, wtPath, wtDomain string, secured bool) error {
+		proxy := parentProxyConfig(site)
+		if proxy == nil {
+			return nil
+		}
+		port := WorktreeHostPort(proxy.Port, wtPath, hostProxyPortEnvKey(proxy))
+		return nginx.GenerateWorktreeHostProxyVhostFor(wtDomain, wtPath, site.PrimaryDomain(), port, proxy.SSL, secured)
+	}
+}
+
+// RegenerateHostProxyVhostsOnGatewayChange rewrites every host-proxy site's
+// nginx vhost so the host-gateway IP baked into proxy_pass (Linux only) tracks a
+// network change, then reloads nginx. Wired to the host-gateway watcher from
+// main. No-op on macOS, where the upstream is the gvproxy-resolved
+// host.containers.internal hostname rather than a literal IP.
+func RegenerateHostProxyVhostsOnGatewayChange() {
+	if runtime.GOOS == "darwin" {
+		return
+	}
+	reg, err := config.LoadSites()
+	if err != nil {
+		return
+	}
+	regenerated := false
+	for i := range reg.Sites {
+		s := reg.Sites[i]
+		if !s.IsHostProxy() {
+			continue
+		}
+		if err := siteops.RegenerateSiteVhost(&s, s.PrimaryDomain()); err != nil {
+			fmt.Printf("[WARN] regenerating host-proxy vhost for %s: %v\n", s.Name, err)
+			continue
+		}
+		if wts, wErr := gitpkg.ServableWorktrees(s.Path, s.PrimaryDomain()); wErr == nil {
+			for _, wt := range wts {
+				_ = certs.RegenerateHostProxyWorktreeVhost(s, wt.Path, wt.Domain, s.Secured)
+			}
+		}
+		regenerated = true
+	}
+	if regenerated {
+		_ = nginx.Reload()
+	}
+}
 
 // hostProxyWorkerName is the stable worker name for a host-proxy site's
 // supervised dev server. Aliases the shared config constant so the unit name
@@ -168,11 +223,19 @@ func firstFreePort(start int, isTaken func(int) bool) int {
 // Both IPv4 and IPv6 loopback are probed so a service bound only to [::1] (as
 // some lerd quadlets are) is still detected as taken.
 func portBoundOnHost(p int) bool {
-	for _, host := range []string{"127.0.0.1", "::1"} {
-		ln, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(p)))
-		if err != nil {
-			return true
-		}
+	// IPv4 loopback is authoritative: a failure here means the port is taken.
+	if ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(p))); err != nil {
+		return true
+	} else {
+		_ = ln.Close()
+	}
+	// IPv6 loopback catches services bound only to [::1], but on a host with
+	// IPv6 disabled the listen fails with EADDRNOTAVAIL / EAFNOSUPPORT for every
+	// port. Only an in-use error counts as taken, else allocation would report
+	// every port busy and fall back to the start port.
+	if ln, err := net.Listen("tcp", net.JoinHostPort("::1", strconv.Itoa(p))); err != nil {
+		return errors.Is(err, syscall.EADDRINUSE)
+	} else {
 		_ = ln.Close()
 	}
 	return false
@@ -184,15 +247,69 @@ func portBoundOnHost(p int) bool {
 // skipped so re-running init on a site keeps its own port.
 func reservedHostPorts(exceptSite string) map[int]bool {
 	out := map[int]bool{}
-	reg, err := config.LoadSites()
-	if err != nil {
-		return out
-	}
-	for _, s := range reg.Sites {
-		if s.Name == exceptSite || s.HostPort == 0 {
-			continue
+	exceptPort := 0
+	if reg, err := config.LoadSites(); err == nil {
+		for _, s := range reg.Sites {
+			if s.Name == exceptSite {
+				exceptPort = s.HostPort
+				continue
+			}
+			if s.HostPort == 0 {
+				continue
+			}
+			out[s.HostPort] = true
 		}
-		out[s.HostPort] = true
+	}
+	// Reserve host ports lerd services publish (e.g. gotenberg on 3000) even when
+	// the container is stopped: a stopped service still owns its published port
+	// and would collide the moment it starts, which portBoundOnHost can't foresee.
+	for p := range lerdServiceHostPorts() {
+		out[p] = true
+	}
+	// Honour exceptSite across the whole set: re-running init on a site keeps its
+	// own already-assigned port even when it coincides with a service's port, so
+	// allocation stays idempotent instead of silently bumping the site.
+	if exceptPort > 0 {
+		delete(out, exceptPort)
+	}
+	return out
+}
+
+// lerdServiceHostPorts returns every host port a lerd service may publish:
+// installed/default services (with their resolved ports), all bundled presets
+// (including optional ones like gotenberg that aren't in the default set), and
+// installed custom services. Used so a host-proxy dev server is never assigned a
+// port a service will reclaim.
+func lerdServiceHostPorts() map[int]bool {
+	out := map[int]bool{}
+	add := func(mappings []string) {
+		for _, m := range mappings {
+			if host, _, ok := splitHostContainerPort(m); ok {
+				if n, _ := strconv.Atoi(host); n > 0 {
+					out[n] = true
+				}
+			}
+		}
+	}
+	if cfg, err := config.LoadGlobal(); err == nil {
+		for _, svc := range cfg.Services {
+			if svc.Port > 0 {
+				out[svc.Port] = true
+			}
+			add(svc.ExtraPorts)
+		}
+	}
+	if presets, err := config.ListPresets(); err == nil {
+		for _, p := range presets {
+			if pr, err := config.LoadPreset(p.Name); err == nil {
+				add(pr.Ports)
+			}
+		}
+	}
+	if customs, err := config.ListCustomServices(); err == nil {
+		for _, svc := range customs {
+			add(svc.Ports)
+		}
 	}
 	return out
 }

--- a/internal/cli/hostproxy_fixes_test.go
+++ b/internal/cli/hostproxy_fixes_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/certs"
+	"github.com/geodro/lerd/internal/config"
+)
+
+// A host-proxy site has no FPM container, so workers must not get a bogus
+// lerd-php-fpm dependency: resolveWorkerFPMUnit returns "" so the host worker
+// writer skips the FPM ordering block entirely.
+func TestResolveWorkerFPMUnit_hostProxyReturnsEmpty(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "proxysite", Domains: []string{"proxysite.test"}, Path: t.TempDir(), HostPort: 5173, HostCommand: "npm run dev"},
+		{Name: "phpsite", Domains: []string{"phpsite.test"}, Path: t.TempDir()},
+	}}
+	if err := config.SaveSites(reg); err != nil {
+		t.Fatalf("SaveSites: %v", err)
+	}
+
+	if got := resolveWorkerFPMUnit("proxysite", ""); got != "" {
+		t.Errorf("host-proxy site FPM unit = %q, want empty", got)
+	}
+	if got := resolveWorkerFPMUnit("phpsite", "8.4"); got != "lerd-php84-fpm" {
+		t.Errorf("php site FPM unit = %q, want lerd-php84-fpm", got)
+	}
+}
+
+// reservedHostPorts must include the ports lerd services publish even when the
+// container is stopped, so a host-proxy dev server is never assigned a port a
+// service (e.g. gotenberg on 3000) will reclaim when it starts.
+func TestReservedHostPorts_includesServicePorts(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	reserved := reservedHostPorts("")
+	if !reserved[3000] {
+		t.Errorf("expected gotenberg's published port 3000 to be reserved, got %v", reserved)
+	}
+}
+
+// Reserving service ports must not break the exceptSite contract: re-running
+// init on a host-proxy site already sitting on a service-coinciding port (e.g.
+// 3000) keeps that port instead of silently bumping it.
+func TestReservedHostPorts_exceptSiteKeepsServiceCoincidingPort(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "node-app", Domains: []string{"node-app.test"}, Path: t.TempDir(), HostPort: 3000, HostCommand: "npm run dev"},
+	}}
+	if err := config.SaveSites(reg); err != nil {
+		t.Fatalf("SaveSites: %v", err)
+	}
+
+	if reservedHostPorts("node-app")[3000] {
+		t.Error("exceptSite's own port 3000 must not be reserved against itself, even though gotenberg also publishes 3000")
+	}
+	if !reservedHostPorts("")[3000] {
+		t.Error("with no exceptSite, 3000 should still be reserved (gotenberg)")
+	}
+}
+
+// The High fix: securing a host-proxy site's worktree must render a reverse
+// proxy vhost (proxy_pass) pointing at the dev-server port, not a PHP fastcgi
+// vhost. The wired certs hook is what makes this happen.
+func TestRegenerateHostProxyWorktreeVhost_writesProxyNotFastcgi(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if certs.RegenerateHostProxyWorktreeVhost == nil {
+		t.Fatal("cli init must wire certs.RegenerateHostProxyWorktreeVhost")
+	}
+
+	sitePath := t.TempDir()
+	site := config.Site{Name: "astro", Domains: []string{"astro.test"}, Path: sitePath, HostPort: 4321, HostCommand: "npm run dev"}
+
+	wtPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wtPath, ".env"), []byte("PORT=4322\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wtDomain := "feature.astro.test"
+
+	if err := certs.RegenerateHostProxyWorktreeVhost(site, wtPath, wtDomain, false); err != nil {
+		t.Fatalf("hook: %v", err)
+	}
+
+	conf := filepath.Join(config.NginxConfD(), wtDomain+".conf")
+	data, err := os.ReadFile(conf)
+	if err != nil {
+		t.Fatalf("read worktree vhost: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "proxy_pass") {
+		t.Errorf("host-proxy worktree vhost must reverse-proxy; got:\n%s", s)
+	}
+	if strings.Contains(s, "fastcgi_pass") {
+		t.Errorf("host-proxy worktree vhost must NOT be a PHP fastcgi vhost; got:\n%s", s)
+	}
+	if !strings.Contains(s, "4322") {
+		t.Errorf("host-proxy worktree vhost must point at the worktree dev-server port 4322; got:\n%s", s)
+	}
+}

--- a/internal/cli/unlink.go
+++ b/internal/cli/unlink.go
@@ -3,8 +3,10 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/geodro/lerd/internal/config"
+	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteops"
 	"github.com/spf13/cobra"
@@ -24,6 +26,15 @@ func init() {
 		// would otherwise orphan its .service file. stopWorkerUnit is idempotent.
 		if site.IsHostProxy() {
 			WorkerStopForSite(site.Name, site.Path, hostProxyWorkerName) //nolint:errcheck
+		}
+		// Worktrees run their own per-worktree units (lerd-<worker>-<site>-<slug>)
+		// that collectRunningWorkers (parent-only) misses. On unlink the site is
+		// going away, so stop every worktree's workers too — a host-proxy
+		// Restart=always dev server would otherwise loop against a removed dir.
+		if wts, err := gitpkg.ServableWorktrees(site.Path, site.PrimaryDomain()); err == nil {
+			for _, wt := range wts {
+				StopAllWorkersForWorktree(site.Name, filepath.Base(wt.Path)) //nolint:errcheck
+			}
 		}
 	}
 }

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -618,6 +618,11 @@ func workerUnitName(siteName, sitePath, workerName string) string {
 func resolveWorkerFPMUnit(siteName, phpVersion string) string {
 	if site, _ := config.FindSite(siteName); site != nil {
 		switch {
+		case site.IsHostProxy():
+			// Host-proxy sites run their dev server on the host and have no FPM
+			// container, so there is nothing to depend on or exec into. Returning
+			// "" lets writeHostWorkerUnitFile skip the FPM ordering block.
+			return ""
 		case site.IsCustomContainer():
 			return podman.CustomContainerName(siteName)
 		case site.IsFrankenPHP():

--- a/internal/watcher/host_gateway.go
+++ b/internal/watcher/host_gateway.go
@@ -15,8 +15,15 @@ type hostGatewayDeps struct {
 	reachable    func(ip string) bool
 	detectFresh  func() string
 	writeHosts   func() error
+	onUpdate     func()
 	log          func(level, msg string, kv ...any)
 }
+
+// OnGatewayIPChange, if set, runs after the shared hosts file is rewritten with
+// a fresh host-gateway IP. The cli package wires this (via main) to regenerate
+// host-proxy vhosts, which bake the gateway IP into proxy_pass on Linux and
+// would otherwise point at a dead address until the next manual regen.
+var OnGatewayIPChange func()
 
 // hostGatewayState is the cross-tick memory for WatchHostGateway. We only
 // keep the last-seen LAN IP so the fast path (compare and skip) is one
@@ -52,6 +59,7 @@ func WatchHostGateway(interval time.Duration) {
 		reachable:    podman.HostReachable,
 		detectFresh:  podman.DetectHostGatewayIPProbeOnly,
 		writeHosts:   podman.WriteContainerHosts,
+		onUpdate:     OnGatewayIPChange,
 		log: func(level, msg string, kv ...any) {
 			switch level {
 			case "info":
@@ -94,6 +102,9 @@ func tickHostGateway(d hostGatewayDeps, s *hostGatewayState) {
 		return
 	}
 	d.log("info", "host gateway IP updated", "old", current, "new", fresh)
+	if d.onUpdate != nil {
+		d.onUpdate()
+	}
 }
 
 // primaryLANIP returns the local IPv4 address the kernel would use to reach

--- a/internal/watcher/host_gateway_test.go
+++ b/internal/watcher/host_gateway_test.go
@@ -177,3 +177,48 @@ func TestTickHostGateway(t *testing.T) {
 		})
 	}
 }
+
+// onUpdate must fire only after the hosts file is actually rewritten, so
+// host-proxy vhosts are regenerated on a real gateway change and not on the
+// fast-path skip or a reachable-current no-op.
+func TestTickHostGateway_onUpdateFiresOnlyOnRewrite(t *testing.T) {
+	base := func(onUpdate func()) hostGatewayDeps {
+		return hostGatewayDeps{
+			primaryLANIP: func() string { return "10.0.0.50" },
+			readCurrent:  func() string { return "192.168.1.10" },
+			reachable:    func(string) bool { return false },
+			detectFresh:  func() string { return "10.0.0.50" },
+			writeHosts:   func() error { return nil },
+			onUpdate:     onUpdate,
+			log:          func(string, string, ...any) {},
+		}
+	}
+
+	t.Run("fires on rewrite", func(t *testing.T) {
+		called := false
+		deps := base(func() { called = true })
+		tickHostGateway(deps, &hostGatewayState{lastLAN: "192.168.1.10"})
+		if !called {
+			t.Error("onUpdate should fire after a successful hosts rewrite")
+		}
+	})
+
+	t.Run("skips when LAN unchanged", func(t *testing.T) {
+		called := false
+		deps := base(func() { called = true })
+		tickHostGateway(deps, &hostGatewayState{lastLAN: "10.0.0.50"})
+		if called {
+			t.Error("onUpdate must not fire on the fast-path skip")
+		}
+	})
+
+	t.Run("skips when write fails", func(t *testing.T) {
+		called := false
+		deps := base(func() { called = true })
+		deps.writeHosts = func() error { return errors.New("disk full") }
+		tickHostGateway(deps, &hostGatewayState{lastLAN: "192.168.1.10"})
+		if called {
+			t.Error("onUpdate must not fire when the hosts rewrite fails")
+		}
+	})
+}


### PR DESCRIPTION
Reviewing everything that landed since v1.23.1 turned up a cluster of host-proxy bugs, all fixed here.

Securing a host-proxy site that has worktrees was generating PHP fastcgi vhosts for each worktree, so those worktrees broke over HTTPS because a host-proxy worktree has no FPM to talk to. The worktree loops in SecureSite and UnsecureSite now render the reverse-proxy vhost pointing at the worktree's own dev-server port. Since certs cannot import cli (the package that owns host-proxy port allocation), this goes through a small hook the cli package wires up at init, the same pattern already used for worker teardown.

The host-port allocator only stepped over ports held by other host-proxy sites plus a live bind probe, so a fresh init could assign a dev server gotenberg's port 3000 while gotenberg happened to be stopped. It now reserves every port a lerd service can publish, collected from installed services, all bundled presets including optional ones like gotenberg, and custom services, while still honouring exceptSite so re-running init on a site keeps its own port even when that port coincides with a service's.

Unlinking a site left its per-worktree worker units running, because the teardown only stopped the parent units. A host-proxy dev server is Restart=always, so it would keep looping against a directory that is about to disappear. Unlink now stops every worktree's workers as well.

On Linux the host-proxy vhost bakes the host-gateway IP straight into proxy_pass, and on the common rootless setup that IP is the host's LAN address, so a laptop moving between networks left the vhost pointing at a dead address until someone regenerated it by hand. The host-gateway watcher now regenerates host-proxy vhosts and reloads nginx, but only on the tick where the gateway IP actually changed, so a stable machine is never touched. It is a no-op on macOS, where the upstream is the gvproxy-resolved hostname rather than a literal IP.

Three smaller fixes ride along. resolveWorkerFPMUnit returns empty for host-proxy sites so their host worker units stop declaring a dependency on a lerd-php-fpm unit that does not exist. The host-proxy env rewrite is scoped to connection keys so a value like APP_NAME=lerd-demo is no longer rewritten to loopback, and the container-to-host port map is built deterministically rather than depending on map iteration order. The loopback port probe now counts an IPv6 listen failure as taken only when the port is genuinely in use, so a host with IPv6 disabled no longer reports every port busy and falls back to the start port.