### PR TITLE
feat: add db:move to relocate sites between same-family DB services

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -147,6 +147,7 @@ func main() {
 	root.AddCommand(cli.NewDbSnapshotsCmd())
 	root.AddCommand(cli.NewDbRestoreCmd())
 	root.AddCommand(cli.NewDbSnapshotRmCmd())
+	root.AddCommand(cli.NewDbMoveCmd())
 	root.AddCommand(cli.NewXdebugCmd())
 	root.AddCommand(cli.NewDumpCmd())
 	root.AddCommand(cli.NewWSLSetupCmd())

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -112,6 +112,7 @@ Once the MCP server is connected, your AI assistant has access to:
 | `db_snapshots` | List stored database snapshots (`all` spans every database on the service) |
 | `db_restore` | Restore the project database from a stored snapshot (destructive: drops and recreates the database) |
 | `db_snapshot_delete` | Delete a stored database snapshot |
+| `db_move` | Move sites' databases between two installed same-family services (`from` → `to`) and repoint each site's `.env`; pass `sites` or `all`. Source data is left intact |
 | `queue` | Start or stop the queue worker for a site — `action`: `start` / `stop` (any framework with a `queue` worker) |
 | `horizon` | Start or stop Laravel Horizon for a site — `action`: `start` / `stop` (use instead of `queue` when `laravel/horizon` is installed) |
 | `reverb` | Start or stop the Reverb WebSocket server for a site — `action`: `start` / `stop` |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -190,6 +190,7 @@ Switch the PHP runtime for the current site between shared PHP-FPM and per-site 
 | `lerd db:snapshots [--all]` | List stored database snapshots |
 | `lerd db:restore <name> [-A] [-f]` | Restore a database from a stored snapshot |
 | `lerd db:snapshot:rm <name> [-A]` | Delete a stored database snapshot |
+| `lerd db:move [--from svc] [--to svc] [--all\|--site name]` | Move sites' databases between two installed services in the same family and repoint their `.env`; wizard when run without flags |
 
 ## Import
 

--- a/docs/usage/database.md
+++ b/docs/usage/database.md
@@ -141,6 +141,35 @@ You can change the choice at any time by editing the `services:` list in `.lerd.
 
 ---
 
+## Moving sites between services
+
+`lerd service migrate <service> <version>` upgrades one service in place (e.g. `postgres` from 16 to 18): the service keeps its name, so every site on it follows automatically and no `.env` changes. Use that when you want to move everyone off a major version at once. See [Service updates](service-updates.md#migrate-automated-dump-restore).
+
+`lerd db:move` is the other half: when you run two services of the same family **side by side** (e.g. the canonical `postgres` and an installed `postgres-18` alternate), it moves selected sites from one to the other and repoints their `.env`. For each site it dumps the database from the source, creates and restores it on the target, then rewrites the site's `.env` `DB_HOST`/`DB_PORT` (the same code path as `lerd env`, so host-proxy sites get loopback host + published port). The source data is left intact as a safety net.
+
+Run it without flags for an interactive wizard:
+
+```bash
+lerd db:move
+# ? Move databases from which service?  postgres (3 sites)
+# ? Move to which service?              postgres-18
+# ? Which sites?                        [x] shop  [x] blog  [ ] api
+```
+
+Or script it:
+
+```bash
+lerd db:move --from postgres --to postgres-18 --all      # every site on postgres
+lerd db:move --from postgres --to postgres-18 --site shop --site blog
+lerd db:move --from postgres --to postgres-18 --all --force   # skip the confirmation prompt
+```
+
+Both services must already be installed and in the same family (`mysql`→`mysql-5-7`, `postgres`→`postgres-18`, etc.); cross-family moves are rejected. A site's current service is detected from its `.lerd.yaml` `services:`/`db:` entry, falling back to the `lerd-<service>` hostname in `.env`. The target's `_testing` database is recreated empty by the env step; only the primary database is copied. Because the source data is preserved, clean it up by hand once you're happy with the move (drop the old databases via `lerd db:shell --service <source>`, or reinstall/remove the old service).
+
+The repoint reuses `lerd env`, so the site needs a detectable framework (Laravel, Symfony, etc.); if the env step fails the `.lerd.yaml` change is rolled back so the site stays on its original service.
+
+---
+
 ## Non-PHP projects
 
 For projects without a lerd framework definition (NestJS, Next.js, Go, etc.), db commands work without any lerd-specific configuration if the project's `.env` uses a recognised key:

--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -309,10 +309,12 @@ func dbImportCmd(env *dbEnv) (*exec.Cmd, error) {
 	container := "lerd-" + env.service
 	switch env.connection {
 	case "mysql", "mariadb":
+		// MariaDB 11+ images ship `mariadb` instead of `mysql`; resolve whichever
+		// client exists in the container at runtime.
+		shellCmd := "$(command -v mysql || command -v mariadb) -u" + podman.ShellQuote(env.username) + " " + podman.ShellQuote(env.database)
 		return podman.Cmd("exec", "-i",
 			"-e", "MYSQL_PWD="+env.password,
-			container,
-			"mysql", "-u"+env.username, env.database), nil
+			container, "sh", "-c", shellCmd), nil
 	case "pgsql", "postgres":
 		return podman.Cmd("exec", "-i", "-e", "PGPASSWORD="+env.password,
 			container, "psql", "-U", env.username, env.database), nil
@@ -366,10 +368,12 @@ func dbExportCmd(env *dbEnv) (*exec.Cmd, error) {
 	container := "lerd-" + env.service
 	switch env.connection {
 	case "mysql", "mariadb":
+		// MariaDB 11+ images ship `mariadb-dump` instead of `mysqldump`; resolve
+		// whichever exists in the container at runtime.
+		shellCmd := "$(command -v mysqldump || command -v mariadb-dump) -u" + podman.ShellQuote(env.username) + " " + podman.ShellQuote(env.database)
 		return podman.Cmd("exec", "-i",
 			"-e", "MYSQL_PWD="+env.password,
-			container,
-			"mysqldump", "-u"+env.username, env.database), nil
+			container, "sh", "-c", shellCmd), nil
 	case "pgsql", "postgres":
 		return podman.Cmd("exec", "-i", "-e", "PGPASSWORD="+env.password,
 			container, "pg_dump", "-U", env.username, env.database), nil

--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -28,6 +28,7 @@ func NewDbCmd() *cobra.Command {
 	cmd.AddCommand(newDbSnapshotsCmd("snapshots"))
 	cmd.AddCommand(newDbRestoreCmd("restore"))
 	cmd.AddCommand(newDbSnapshotRmCmd("snapshot:rm"))
+	cmd.AddCommand(newDbMoveCmd("move"))
 	return cmd
 }
 

--- a/internal/cli/db_move.go
+++ b/internal/cli/db_move.go
@@ -1,0 +1,409 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/serviceops"
+	"github.com/spf13/cobra"
+)
+
+// NewDbMoveCmd returns the standalone db:move command.
+func NewDbMoveCmd() *cobra.Command { return newDbMoveCmd("db:move") }
+
+func newDbMoveCmd(use string) *cobra.Command {
+	var from, to string
+	var sites []string
+	var all, force bool
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: "Move site databases from one service to another in the same family",
+		Long: `Move one or more sites' databases between two installed services in the same
+family (e.g. postgres -> postgres-18, or mysql-5-7 -> mysql).
+
+For each site it dumps the database from the source service, creates and restores
+it on the target, then rewrites that site's .env (DB_HOST/DB_PORT) to point at the
+target. The source data is left intact as a safety net.
+
+Run without flags for an interactive wizard, or script it with --from/--to and
+either --all or one or more --site flags.`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runDbMove(from, to, sites, all, force)
+		},
+	}
+	cmd.Flags().StringVar(&from, "from", "", "Source service (e.g. postgres)")
+	cmd.Flags().StringVar(&to, "to", "", "Target service (e.g. postgres-18)")
+	cmd.Flags().StringArrayVar(&sites, "site", nil, "Site to move by name (repeatable)")
+	cmd.Flags().BoolVar(&all, "all", false, "Move every site currently on the source service")
+	cmd.Flags().BoolVar(&force, "force", false, "Skip the confirmation prompt")
+	return cmd
+}
+
+// supportedMoveFamily reports whether a service family supports the dump/restore
+// move. Only the SQL families whose dumps replay cleanly across versions qualify.
+func supportedMoveFamily(family string) bool {
+	switch family {
+	case "mysql", "mariadb", "postgres":
+		return true
+	}
+	return false
+}
+
+// validateMovePair checks that a from/to service pair is a legal move: distinct
+// services in the same supported family.
+func validateMovePair(from, to string) error {
+	if from == "" || to == "" {
+		return fmt.Errorf("both a source and target service are required")
+	}
+	if from == to {
+		return fmt.Errorf("source and target are the same service (%q)", from)
+	}
+	ff := config.FamilyOfName(from)
+	tf := config.FamilyOfName(to)
+	if !supportedMoveFamily(ff) {
+		return fmt.Errorf("source %q is not a movable database service (supported families: mysql, mariadb, postgres)", from)
+	}
+	if ff != tf {
+		return fmt.Errorf("cannot move across families: %q is %s but %q is %s", from, ff, to, familyLabel(tf))
+	}
+	return nil
+}
+
+func familyLabel(f string) string {
+	if f == "" {
+		return "not a database service"
+	}
+	return f
+}
+
+// siteDBService returns the concrete DB service a site currently uses (e.g.
+// "postgres-18"), reading the explicit choice from .lerd.yaml first and falling
+// back to the container hostname in .env. Returns "" for sqlite or when no lerd
+// DB service can be determined.
+func siteDBService(sitePath string) string {
+	if pc, err := config.LoadProjectConfig(sitePath); err == nil {
+		if pc.DB.Service != "" && pc.DB.Service != "sqlite" {
+			return pc.DB.Service
+		}
+		for _, svc := range pc.Services {
+			if svc.Name != "sqlite" && config.IsDBServiceName(svc.Name) {
+				return svc.Name
+			}
+		}
+	}
+	host := strings.TrimSpace(envfile.ReadKey(filepath.Join(sitePath, ".env"), "DB_HOST"))
+	if strings.HasPrefix(host, "lerd-") {
+		return strings.TrimPrefix(host, "lerd-")
+	}
+	return ""
+}
+
+func findSiteByName(reg *config.SiteRegistry, name string) *config.Site {
+	for i := range reg.Sites {
+		if reg.Sites[i].Name == name {
+			return &reg.Sites[i]
+		}
+	}
+	return nil
+}
+
+// sitesOnService returns every registered site whose current DB service is svc.
+func sitesOnService(reg *config.SiteRegistry, svc string) []config.Site {
+	var out []config.Site
+	for _, s := range reg.Sites {
+		if siteDBService(s.Path) == svc {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// resolveMoveSites turns the --all / --site selection into a concrete site list.
+// With --all it returns every site detected on the source service; with named
+// sites it validates each exists and is not already on a different service.
+func resolveMoveSites(reg *config.SiteRegistry, from string, names []string, all bool) ([]config.Site, error) {
+	if all {
+		return sitesOnService(reg, from), nil
+	}
+	var out []config.Site
+	for _, name := range names {
+		s := findSiteByName(reg, name)
+		if s == nil {
+			return nil, fmt.Errorf("unknown site %q", name)
+		}
+		if detected := siteDBService(s.Path); detected != "" && detected != from {
+			return nil, fmt.Errorf("site %q is on %q, not %q", name, detected, from)
+		}
+		out = append(out, *s)
+	}
+	return out, nil
+}
+
+func runDbMove(from, to string, siteNames []string, all, force bool) error {
+	reg, err := config.LoadSites()
+	if err != nil {
+		return err
+	}
+
+	interactive := isInteractive()
+	if from == "" || to == "" || (!all && len(siteNames) == 0) {
+		if !interactive {
+			return fmt.Errorf("non-interactive: provide --from, --to, and either --all or --site <name>")
+		}
+		from, to, siteNames, err = dbMoveWizard(reg, from, to)
+		if err != nil {
+			return err
+		}
+		all = false
+	}
+
+	if err := validateMovePair(from, to); err != nil {
+		return err
+	}
+	if !serviceops.ServiceInstalled(to) {
+		return fmt.Errorf("target service %q is not installed — add it from the Services tab or with `lerd service preset %s`", to, config.FamilyOfName(to))
+	}
+
+	targets, err := resolveMoveSites(reg, from, siteNames, all)
+	if err != nil {
+		return err
+	}
+	if len(targets) == 0 {
+		return fmt.Errorf("no sites to move from %q", from)
+	}
+
+	if !force && interactive {
+		fmt.Printf("About to move %d site(s) from %s to %s:\n", len(targets), from, to)
+		for _, s := range targets {
+			fmt.Printf("  %s (%s)\n", s.Name, s.Path)
+		}
+		fmt.Print("Source data is left intact. Continue? [y/N] ")
+		var ans string
+		fmt.Scanln(&ans) //nolint:errcheck
+		if ans == "" || (ans[0] != 'y' && ans[0] != 'Y') {
+			return fmt.Errorf("aborted")
+		}
+	}
+
+	failed := 0
+	for _, s := range targets {
+		fmt.Printf("\n== %s: %s -> %s ==\n", s.Name, from, to)
+		if err := runDbMoveOne(s.Path, s.Name, from, to); err != nil {
+			failed++
+			fmt.Fprintf(os.Stderr, "[FAIL] %s: %v\n", s.Name, err)
+			continue
+		}
+		fmt.Printf("[OK] %s moved to %s, .env updated\n", s.Name, to)
+	}
+	if failed > 0 {
+		return fmt.Errorf("%d of %d site(s) failed to move", failed, len(targets))
+	}
+	fmt.Printf("\nDone. %d site(s) moved %s -> %s. Source data left intact.\n", len(targets), from, to)
+	return nil
+}
+
+// runDbMoveOne dumps a single site's database from the source service, repoints
+// the site's config + .env at the target (which creates the empty database), and
+// restores the dump into the target.
+func runDbMoveOne(sitePath, siteName, from, to string) error {
+	base, err := resolveDB(sitePath, "", "")
+	if err != nil {
+		return fmt.Errorf("cannot resolve database from .env: %w", err)
+	}
+	if base.database == "" {
+		return fmt.Errorf("no database name found in .env")
+	}
+
+	if err := ensureServiceRunning(from); err != nil {
+		return fmt.Errorf("could not start %s: %w", from, err)
+	}
+
+	tmp, err := os.CreateTemp("", "lerd-dbmove-*.sql")
+	if err != nil {
+		return fmt.Errorf("creating temp dump: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	srcEnv := serviceToDBEnv(from)
+	srcEnv.database = base.database
+	dump, err := dbExportCmd(srcEnv)
+	if err != nil {
+		tmp.Close() //nolint:errcheck
+		return err
+	}
+	dump.Stdout = tmp
+	dump.Stderr = os.Stderr
+	fmt.Printf("Dumping %s from %s...\n", base.database, from)
+	if err := dump.Run(); err != nil {
+		tmp.Close() //nolint:errcheck
+		return fmt.Errorf("dump failed: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing dump: %w", err)
+	}
+
+	// Repoint the site at the target service. This mirrors db_set: it rewrites
+	// the DB_ keys in .env (host-proxy aware), starts the target, and creates
+	// the database, so the dump has somewhere to land. Snapshot .lerd.yaml's
+	// source and the .env bytes first so a failed repoint can be fully undone.
+	fmt.Printf("Repointing %s at %s...\n", siteName, to)
+	envPath := filepath.Join(sitePath, ".env")
+	prevEnv, _ := os.ReadFile(envPath)
+	if err := config.ReplaceProjectDBService(sitePath, to); err != nil {
+		return fmt.Errorf("saving .lerd.yaml: %w", err)
+	}
+	if err := runLerdEnv(sitePath); err != nil {
+		// Roll both files back so a failed repoint leaves the site exactly as it
+		// was on the source service.
+		rbErr := config.ReplaceProjectDBService(sitePath, from)
+		if prevEnv != nil {
+			if wErr := os.WriteFile(envPath, prevEnv, 0o644); wErr != nil && rbErr == nil {
+				rbErr = wErr
+			}
+		}
+		if rbErr != nil {
+			return fmt.Errorf("applying env for target: %w (rollback also failed: %v)", err, rbErr)
+		}
+		return fmt.Errorf("applying env for target: %w", err)
+	}
+
+	// The target database name is whatever env setup landed on. env starts the
+	// target and creates the DB on a best-effort basis, so make both certain
+	// before restoring rather than letting a warned-over failure surface here.
+	tgt, err := resolveDB(sitePath, "", "")
+	if err != nil {
+		return fmt.Errorf("cannot resolve target database: %w", err)
+	}
+	if err := ensureServiceRunning(to); err != nil {
+		return fmt.Errorf("could not start target %s: %w", to, err)
+	}
+	if _, err := createDatabase(to, tgt.database); err != nil {
+		return fmt.Errorf("creating database %q on %s: %w", tgt.database, to, err)
+	}
+	tgtEnv := serviceToDBEnv(to)
+	tgtEnv.database = tgt.database
+
+	f, err := os.Open(tmp.Name())
+	if err != nil {
+		return fmt.Errorf("reopening dump: %w", err)
+	}
+	defer f.Close()
+	restore, err := dbImportCmd(tgtEnv)
+	if err != nil {
+		return err
+	}
+	restore.Stdin = f
+	restore.Stdout = os.Stdout
+	restore.Stderr = os.Stderr
+	fmt.Printf("Restoring %s into %s...\n", tgtEnv.database, to)
+	if err := restore.Run(); err != nil {
+		return fmt.Errorf("restore failed: %w", err)
+	}
+	return nil
+}
+
+// runLerdEnv re-execs `lerd env` in the project directory so the existing env
+// setup (service start, .env rewrite, database provisioning) runs unchanged.
+func runLerdEnv(dir string) error {
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving lerd executable: %w", err)
+	}
+	cmd := exec.Command(self, "env")
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// dbMoveWizard interactively collects the source service, target service, and
+// sites to move. Pre-supplied from/to skip the corresponding prompt.
+func dbMoveWizard(reg *config.SiteRegistry, from, to string) (string, string, []string, error) {
+	// Count sites per movable source service.
+	siteCounts := map[string]int{}
+	for _, s := range reg.Sites {
+		if svc := siteDBService(s.Path); svc != "" && supportedMoveFamily(config.FamilyOfName(svc)) {
+			siteCounts[svc]++
+		}
+	}
+
+	if from == "" {
+		if len(siteCounts) == 0 {
+			return "", "", nil, fmt.Errorf("no sites are using a movable database service")
+		}
+		opts := make([]huh.Option[string], 0, len(siteCounts))
+		for _, svc := range sortedCountKeys(siteCounts) {
+			label := fmt.Sprintf("%s (%d site%s)", svc, siteCounts[svc], pluralS(siteCounts[svc]))
+			opts = append(opts, huh.NewOption(label, svc))
+		}
+		if err := huh.NewForm(huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Move databases from which service?").
+				Options(opts...).
+				Value(&from),
+		)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
+			return "", "", nil, err
+		}
+	}
+
+	family := config.FamilyOfName(from)
+	if to == "" {
+		var targets []string
+		for _, host := range config.ServicesInFamily(family) {
+			name := strings.TrimPrefix(host, "lerd-")
+			if name != from && serviceops.ServiceInstalled(name) {
+				targets = append(targets, name)
+			}
+		}
+		if len(targets) == 0 {
+			return "", "", nil, fmt.Errorf("no other installed %s service to move to — install an alternate first (Services tab or `lerd service preset %s`)", family, family)
+		}
+		if err := huh.NewForm(huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Move to which service?").
+				Options(huh.NewOptions(targets...)...).
+				Value(&to),
+		)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
+			return "", "", nil, err
+		}
+	}
+
+	var siteOpts []string
+	for _, s := range sitesOnService(reg, from) {
+		siteOpts = append(siteOpts, s.Name)
+	}
+	if len(siteOpts) == 0 {
+		return "", "", nil, fmt.Errorf("no sites found on %q", from)
+	}
+	selected := append([]string(nil), siteOpts...)
+	if err := huh.NewForm(huh.NewGroup(
+		huh.NewMultiSelect[string]().
+			Title(fmt.Sprintf("Which sites to move from %s to %s?", from, to)).
+			Description("All selected by default; deselect any you want to leave behind.").
+			Options(huh.NewOptions(siteOpts...)...).
+			Value(&selected),
+	)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
+		return "", "", nil, err
+	}
+	if len(selected) == 0 {
+		return "", "", nil, fmt.Errorf("no sites selected")
+	}
+	return from, to, selected, nil
+}
+
+func sortedCountKeys(m map[string]int) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/cli/db_move_test.go
+++ b/internal/cli/db_move_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestValidateMovePair(t *testing.T) {
+	cases := []struct {
+		name    string
+		from    string
+		to      string
+		wantErr bool
+	}{
+		{"postgres to alternate", "postgres", "postgres-18", false},
+		{"alternate to canonical", "postgres-17", "postgres", false},
+		{"mysql to alternate", "mysql", "mysql-5-7", false},
+		{"same service", "postgres", "postgres", true},
+		{"cross family", "postgres", "mysql", true},
+		{"mysql to mariadb is cross family", "mysql", "mariadb", true},
+		{"sqlite source unsupported", "sqlite", "postgres", true},
+		{"empty source", "", "postgres", true},
+		{"empty target", "postgres", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateMovePair(tc.from, tc.to)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateMovePair(%q,%q) = nil, want error", tc.from, tc.to)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateMovePair(%q,%q) = %v, want nil", tc.from, tc.to, err)
+			}
+		})
+	}
+}
+
+func TestSiteDBService(t *testing.T) {
+	t.Run("explicit services entry wins", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, ".lerd.yaml", "services:\n  - postgres-18\n")
+		writeFile(t, dir, ".env", "DB_HOST=lerd-postgres\n")
+		if got := siteDBService(dir); got != "postgres-18" {
+			t.Fatalf("siteDBService = %q, want postgres-18", got)
+		}
+	})
+
+	t.Run("db block service", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, ".lerd.yaml", "db:\n  service: postgres-17\n")
+		if got := siteDBService(dir); got != "postgres-17" {
+			t.Fatalf("siteDBService = %q, want postgres-17", got)
+		}
+	})
+
+	t.Run("falls back to .env DB_HOST", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, ".env", "DB_HOST=lerd-mysql-5-7\n")
+		if got := siteDBService(dir); got != "mysql-5-7" {
+			t.Fatalf("siteDBService = %q, want mysql-5-7", got)
+		}
+	})
+
+	t.Run("sqlite returns empty", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, dir, ".lerd.yaml", "services:\n  - sqlite\n")
+		if got := siteDBService(dir); got != "" {
+			t.Fatalf("siteDBService = %q, want empty", got)
+		}
+	})
+
+	t.Run("nothing configured returns empty", func(t *testing.T) {
+		dir := t.TempDir()
+		if got := siteDBService(dir); got != "" {
+			t.Fatalf("siteDBService = %q, want empty", got)
+		}
+	})
+}
+
+func TestResolveMoveSites(t *testing.T) {
+	shop := t.TempDir()
+	writeFile(t, shop, ".lerd.yaml", "services:\n  - postgres\n")
+	blog := t.TempDir()
+	writeFile(t, blog, ".lerd.yaml", "services:\n  - postgres\n")
+	api := t.TempDir()
+	writeFile(t, api, ".lerd.yaml", "services:\n  - mysql\n")
+
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "shop", Path: shop},
+		{Name: "blog", Path: blog},
+		{Name: "api", Path: api},
+	}}
+
+	t.Run("all picks every site on source", func(t *testing.T) {
+		got, err := resolveMoveSites(reg, "postgres", nil, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %d sites, want 2 (shop, blog)", len(got))
+		}
+	})
+
+	t.Run("named sites pass when on source", func(t *testing.T) {
+		got, err := resolveMoveSites(reg, "postgres", []string{"shop"}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 || got[0].Name != "shop" {
+			t.Fatalf("got %+v, want [shop]", got)
+		}
+	})
+
+	t.Run("named site on a different service errors", func(t *testing.T) {
+		if _, err := resolveMoveSites(reg, "postgres", []string{"api"}, false); err == nil {
+			t.Fatal("expected error moving a mysql site from postgres")
+		}
+	})
+
+	t.Run("unknown site errors", func(t *testing.T) {
+		if _, err := resolveMoveSites(reg, "postgres", []string{"nope"}, false); err == nil {
+			t.Fatal("expected error for unknown site")
+		}
+	})
+}

--- a/internal/cli/db_test.go
+++ b/internal/cli/db_test.go
@@ -69,6 +69,33 @@ func TestDbCmdPostgresUsesEnv(t *testing.T) {
 	}
 }
 
+func TestDbExportCmdMariaDBBinaryFallback(t *testing.T) {
+	env := &dbEnv{connection: "mariadb", database: "shop", username: "root", password: "lerd"}
+	cmd, err := dbExportCmd(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(cmd.Args, " ")
+	if !strings.Contains(joined, "command -v mysqldump || command -v mariadb-dump") {
+		t.Errorf("expected mariadb-dump fallback, got: %q", joined)
+	}
+	if !strings.Contains(joined, "shop") {
+		t.Errorf("expected database name in command, got: %q", joined)
+	}
+}
+
+func TestDbImportCmdMariaDBBinaryFallback(t *testing.T) {
+	env := &dbEnv{connection: "mysql", database: "shop", username: "root", password: "lerd"}
+	cmd, err := dbImportCmd(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(cmd.Args, " ")
+	if !strings.Contains(joined, "command -v mysql || command -v mariadb") {
+		t.Errorf("expected mariadb client fallback, got: %q", joined)
+	}
+}
+
 func TestDbCmdUnsupportedConnection(t *testing.T) {
 	env := &dbEnv{connection: "sqlite"}
 	_, err := dbImportCmd(env)

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -877,6 +877,23 @@ db_set(database: "sqlite")
 
 > Use this **before** ` + bt + `env_setup` + bt + ` on a fresh Laravel project so the database lands in ` + bt + `.env` + bt + ` deliberately. Switching databases later via ` + bt + `db_set` + bt + ` removes the previous database entry from ` + bt + `.lerd.yaml` + bt + ` automatically.
 
+### ` + bt + `db_move` + bt + `
+Move sites' databases between two installed services in the **same family** (e.g. ` + bt + `postgres` + bt + ` → ` + bt + `postgres-18` + bt + `, ` + bt + `mysql-5-7` + bt + ` → ` + bt + `mysql` + bt + `) and repoint each site's ` + bt + `.env` + bt + `. For each site it dumps from the source, creates and restores on the target, then rewrites ` + bt + `DB_HOST` + bt + ` / ` + bt + `DB_PORT` + bt + `. The source data is left intact. Both services must already be installed; cross-family moves are rejected.
+
+Arguments:
+- ` + bt + `from` + bt + ` (required): source service, e.g. ` + bt + `postgres` + bt + `
+- ` + bt + `to` + bt + ` (required): target service, same family, e.g. ` + bt + `postgres-18` + bt + `
+- ` + bt + `sites` + bt + ` (array): site names to move; omit when ` + bt + `all` + bt + ` is true
+- ` + bt + `all` + bt + ` (boolean): move every site currently on the source service
+
+Examples:
+` + "```" + `
+db_move(from: "postgres", to: "postgres-18", all: true)
+db_move(from: "postgres", to: "postgres-18", sites: ["shop", "blog"])
+` + "```" + `
+
+> This is for running two versions **side by side** and moving sites selectively. To upgrade one service in place so every site follows at once (no ` + bt + `.env` + bt + ` changes), use ` + bt + `service_control` + bt + ` with ` + bt + `migrate` + bt + ` instead.
+
 ### ` + bt + `db_snapshot` + bt + ` / ` + bt + `db_snapshots` + bt + ` / ` + bt + `db_restore` + bt + ` / ` + bt + `db_snapshot_delete` + bt + `
 Named, restorable point-in-time copies of the project database — take one before a risky migration or a destructive experiment, then roll back in a single call. SQL engines only (MySQL, MariaDB, PostgreSQL); snapshots are stored under lerd's data dir, keyed by service and database.
 
@@ -1513,6 +1530,7 @@ Read ` + bt + `status()` + bt + ` for ` + bt + `dns.tld` + bt + ` and ` + bt + `
 | ` + bt + `node` + bt + ` | Install or uninstall a Node.js version via fnm — ` + bt + `action` + bt + `: ` + bt + `install` + bt + ` / ` + bt + `uninstall` + bt + ` (e.g. ` + bt + `"20"` + bt + `, ` + bt + `"lts"` + bt + `) |
 | ` + bt + `env_setup` + bt + ` | Configure ` + bt + `.env` + bt + ` for lerd: detects services, starts them, creates DB, generates APP_KEY (leaves ` + bt + `DB_CONNECTION=sqlite` + bt + ` alone — call ` + bt + `db_set` + bt + ` first); ` + bt + `APP_URL` + bt + ` follows ` + bt + `.lerd.yaml app_url` + bt + ` → ` + bt + `sites.yaml app_url` + bt + ` → default chain |
 | ` + bt + `db_set` + bt + ` | Pick the database for a Laravel project: ` + bt + `sqlite` + bt + `, a built-in (` + bt + `mysql` + bt + ` / ` + bt + `postgres` + bt + `), or any installed family alternate (` + bt + `mariadb` + bt + `, ` + bt + `postgres-pgvector` + bt + `, ` + bt + `mysql-5-7` + bt + `, …); persists to ` + bt + `.lerd.yaml` + bt + `, rewrites ` + bt + `DB_` + bt + ` keys in ` + bt + `.env` + bt + `, starts the service, creates the database |
+| ` + bt + `db_move` + bt + ` | Move sites' databases between two installed same-family services (e.g. ` + bt + `from: postgres` + bt + ` ` + bt + `to: postgres-18` + bt + `) and repoint each site's ` + bt + `.env` + bt + `; pass ` + bt + `sites: [..]` + bt + ` or ` + bt + `all: true` + bt + `. Source data is left intact. To upgrade one service in place for every site at once, use ` + bt + `service_control` + bt + ` ` + bt + `migrate` + bt + ` instead |
 | ` + bt + `env_check` + bt + ` | Compare all ` + bt + `.env` + bt + ` files against ` + bt + `.env.example` + bt + ` — returns structured JSON with per-key sync status |
 | ` + bt + `env_override` + bt + ` | Manage the personal, gitignored ` + bt + `.env.lerd_override` + bt + ` (` + bt + `KEY=VALUE` + bt + ` pairs win over lerd's defaults on ` + bt + `env_setup` + bt + `; ` + bt + `LERD_EXTERNAL_SERVICES=<svc,svc>` + bt + ` marks services lerd writes vars for but won't start) |
 | ` + bt + `site_link` + bt + ` | Register a directory as a lerd site — **non-PHP projects** must have a Containerfile (default name ` + bt + `Containerfile.lerd` + bt + `; set ` + bt + `container.containerfile` + bt + ` for a different path, e.g. ` + bt + `Dockerfile` + bt + `) + ` + bt + `.lerd.yaml` + bt + ` with ` + bt + `container: {port: N}` + bt + ` written first, otherwise the site registers as PHP (wrong) |

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -539,7 +539,8 @@ func TestClaudeSkillContent_underSizeCeiling(t *testing.T) {
 	// (service_config, service_check_updates, workers_health, workers_heal,
 	// framework_search, framework_install, dns_diagnose, analyze_queries,
 	// site_nginx); TestEveryMCPToolIsDocumented now guards against re-drift.
-	const ceiling = 55500
+	// Bumped to 57000 for the db_move section (cross-service same-family DB move).
+	const ceiling = 57000
 	if got := len(claudeSkillContent); got > ceiling {
 		t.Errorf("claudeSkillContent is %d bytes, ceiling is %d — trim before raising", got, ceiling)
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -455,6 +455,20 @@ func toolList() []mcpTool {
 			},
 		},
 		{
+			Name:        "db_move",
+			Description: "Move sites' databases between two installed same-family services (e.g. postgres -> postgres-18) and repoint each site's .env. Dumps from source, creates+restores on target; source data left intact. Pass sites (names) or all=true. To upgrade one service in place for all sites, use service_control migrate.",
+			InputSchema: mcpSchema{
+				Type: "object",
+				Properties: map[string]mcpProp{
+					"from":  {Type: "string", Description: "Source service, e.g. postgres."},
+					"to":    {Type: "string", Description: "Target service, same family, e.g. postgres-18."},
+					"sites": {Type: "array", Description: `Site names to move, e.g. ["shop","blog"]. Omit with all=true.`},
+					"all":   {Type: "boolean", Description: "Move every site currently on the source service."},
+				},
+				Required: []string{"from", "to"},
+			},
+		},
+		{
 			Name:        "env_check",
 			Description: "Compare .env against .env.example; flag missing/extra keys.",
 			InputSchema: mcpSchema{
@@ -1352,6 +1366,8 @@ func handleToolCall(params json.RawMessage) (any, *rpcError) {
 		return execEnvSetup(args)
 	case "db_set":
 		return execDbSet(args)
+	case "db_move":
+		return execDbMove(args)
 	case "env_check":
 		return execEnvCheck(args)
 	case "env_override":
@@ -3521,6 +3537,42 @@ func execDbSet(args map[string]any) (any, *rpcError) {
 		summary = fmt.Sprintf("Database changed from %s to %s", previous, choice)
 	}
 	return toolOK(summary + "\n\n" + strings.TrimSpace(out.String())), nil
+}
+
+func execDbMove(args map[string]any) (any, *rpcError) {
+	from := strings.TrimSpace(strArg(args, "from"))
+	to := strings.TrimSpace(strArg(args, "to"))
+	if from == "" || to == "" {
+		return toolErr("from and to are required (e.g. from=postgres, to=postgres-18)"), nil
+	}
+	sites := strSliceArg(args, "sites")
+	all := boolArg(args, "all")
+	if !all && len(sites) == 0 {
+		return toolErr("pass sites (a list of site names) or all=true"), nil
+	}
+
+	// Re-exec the CLI so the move runs through the same code path as
+	// `lerd db:move`. --force skips the prompt; output is captured rather than
+	// written to the MCP stdio channel.
+	self, err := os.Executable()
+	if err != nil {
+		return toolErr("could not resolve lerd executable: " + err.Error()), nil
+	}
+	cmdArgs := []string{"db:move", "--from", from, "--to", to, "--force"}
+	if all {
+		cmdArgs = append(cmdArgs, "--all")
+	}
+	for _, s := range sites {
+		cmdArgs = append(cmdArgs, "--site", s)
+	}
+	var out bytes.Buffer
+	cmd := exec.Command(self, cmdArgs...)
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return toolErr(fmt.Sprintf("db_move failed (%v):\n%s", err, strings.TrimSpace(out.String()))), nil
+	}
+	return toolOK(strings.TrimSpace(out.String())), nil
 }
 
 func execEnvCheck(args map[string]any) (any, *rpcError) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -189,7 +189,9 @@ func TestToolList_underSizeCeiling(t *testing.T) {
 	// kind filter on dumps_recent; both descriptions trimmed to the bone first.
 	// Bumped to 31000 for env_override (personal .env.lerd_override file with
 	// LERD_EXTERNAL_SERVICES support); description already trimmed.
-	const ceiling = 31000
+	// Bumped to 32000 for db_move (cross-service same-family DB move); description
+	// already trimmed to the bone first.
+	const ceiling = 32000
 	got, err := json.Marshal(toolList())
 	if err != nil {
 		t.Fatalf("marshal tool list: %v", err)


### PR DESCRIPTION
This adds lerd db:move, the counterpart to lerd service migrate. service migrate upgrades one service in place so every site on it follows automatically, but it can't move sites between two versions that run side by side. db:move handles exactly that: pick a source and a target service in the same family (postgres to postgres-18, mysql-5-7 to mysql, and so on), choose specific sites or all of them, and for each site it dumps the database from the source, recreates and restores it on the target, and repoints that site's .env. The source data is left intact as a safety net.

Run it without flags for an interactive wizard that lists the services your sites are actually on, or script it with --from, --to, and either --all or repeated --site. If the repoint step fails the .lerd.yaml and .env changes are rolled back so the site stays on its original service, and the target service and database are made certain before the restore runs.

The same operation is available over MCP as db_move, and the bundled Claude, Junie, and Cursor skill and guidelines are updated to describe it. Documentation lives under Moving sites between services in the database guide, with the command reference and MCP tool list updated alongside.