### PR TITLE
Document the framework-agnostic Stripe listener

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,7 @@ A portable, self-contained description of a project's local environment. Created
 | `container` | Custom container config for non-PHP sites. When present, lerd builds a dedicated container from the project's Containerfile and nginx reverse-proxies to it. See below and [Custom Containers](./usage/custom-containers.md) |
 | `custom_workers` | Custom worker definitions (name to config map). Works for both PHP and custom container sites. See below |
 | `db` | Database targeting for non-PHP projects: `service` (e.g. `mysql`, `postgres`) and `database` name |
+| `stripe` | Optional Stripe webhook listener config: `path` (forward route, defaults to `/stripe/webhook`) and `secret_env_key` (which `.env` key holds the secret, defaults to auto-detection). See [Stripe](./usage/stripe.md) |
 
 ### Basic example
 

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -133,7 +133,7 @@ Once the MCP server is connected, your AI assistant has access to:
 | `site_node` | Change the Node.js version for a registered site: writes `.node-version`, installs via fnm if needed. Accepts an optional `branch` to set the version per worktree |
 | `site_control` | Pause, unpause, restart, or rebuild a site — `action`: `pause` / `unpause` / `restart` / `rebuild` (pause replaces vhost with landing page; rebuild only for custom containers) |
 | `site_runtime` | Switch between shared PHP-FPM and per-site FrankenPHP runtime; supports framework-aware worker mode (Laravel Octane, Symfony runtime) |
-| `stripe` | Start or stop a Stripe webhook listener for a site — `action`: `start` / `stop` (reads `STRIPE_SECRET` from `.env` on start) |
+| `stripe` | Start, stop, or configure a Stripe webhook listener for a site — `action`: `start` / `stop` / `config` (secret auto-detected from `STRIPE_SECRET`, `STRIPE_SECRET_KEY`, or `STRIPE_API_KEY`; `config` sets `webhook_path` / `secret_env_key` in `.lerd.yaml`) |
 | `logs` | Fetch container logs; defaults to current site's FPM; optionally specify nginx, service name, PHP version, or site name |
 | `status` | Health snapshot of DNS, nginx, PHP-FPM containers, and the watcher; use when a site isn't loading |
 | `doctor` | Full diagnostic as structured JSON: podman, systemd, DNS, ports, PHP images, config, updates; use when the user reports setup issues |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -258,6 +258,7 @@ Requires [Laravel Broadcasting](https://laravel.com/docs/13.x/broadcasting) with
 |---|---|
 | `lerd stripe:listen` | Start a Stripe webhook listener for the current project as a background service |
 | `lerd stripe:listen stop` | Stop the Stripe webhook listener |
+| `lerd stripe:config` | Show or set the webhook path and secret env key in `.lerd.yaml` without starting the listener |
 
 ## Console & runtime passthrough
 

--- a/docs/usage/stripe.md
+++ b/docs/usage/stripe.md
@@ -1,4 +1,6 @@
-# Stripe / Laravel Cashier
+# Stripe
+
+The webhook listener works for any project type, not just Laravel. It runs the Stripe CLI in a container and forwards events to your app, so a NestJS or plain Node site reached through the host proxy is supported the same way a Laravel Cashier site is. The secret is auto-detected from common env keys and the forward route is configurable per project.
 
 ## stripe-mock
 
@@ -35,13 +37,43 @@ Forwards live or test webhook events from Stripe to your local app. Lerd runs th
 ```bash
 cd ~/Lerd/myapp
 lerd stripe:listen                         # forwards to https://myapp.test/stripe/webhook
-lerd stripe:listen --path /webhooks/stripe # custom webhook path
+lerd stripe:listen --path /webhooks/stripe # custom webhook path (persisted to .lerd.yaml)
 lerd stripe:listen --api-key sk_test_...   # override key
+lerd stripe:listen --secret-env-key STRIPE_SECRET_KEY # pin the .env key (persisted)
 ```
 
-Lerd reads `STRIPE_SECRET` automatically from the project's `.env` file. No flags are required if the key is set there.
-
 The target URL is auto-detected from the registered site in the current directory. Run `lerd link` first if the project is not yet registered.
+
+### Secret detection
+
+Lerd resolves the Stripe secret from the project's `.env` automatically, probing these keys in order until one is set:
+
+1. `STRIPE_SECRET` — Laravel / Cashier
+2. `STRIPE_SECRET_KEY` — the common Stripe Node / NestJS convention
+3. `STRIPE_API_KEY` — the generic SDK name
+
+No flags are required if any of these is present. To force a specific key (for example a project that stores it under a non-standard name), pin it with `--secret-env-key` or the `stripe.secret_env_key` field in `.lerd.yaml`.
+
+### Configuring the route without starting
+
+`lerd stripe:config` shows or sets the webhook path and secret env key without touching the listener:
+
+```bash
+lerd stripe:config                              # show current route and resolved secret key
+lerd stripe:config --path /webhooks/stripe      # set the forward route
+lerd stripe:config --secret-env-key STRIPE_API_KEY
+```
+
+Both `stripe:config` and `stripe:listen` write the same optional `stripe:` block to the project's `.lerd.yaml`, so the route survives reinstalls and is shared by the CLI, the MCP server, and the web UI:
+
+```yaml
+# .lerd.yaml
+stripe:
+  path: /webhooks/stripe      # optional, defaults to /stripe/webhook
+  secret_env_key: STRIPE_API_KEY  # optional, defaults to auto-detection
+```
+
+Both fields are optional. Routes are normalised to a leading slash and rejected if they contain whitespace, so the generated systemd unit stays well formed. Changing the route while the listener is running re-forwards it to the new path automatically.
 
 ### Stopping the listener
 
@@ -65,14 +97,17 @@ Logs are also available live in the **web UI**, see [Web UI](#web-ui) below.
 
 ### Options
 
+These flags apply to `stripe:listen`; `stripe:config` accepts `--path` and `--secret-env-key` only.
+
 | Flag | Default | Description |
 |---|---|---|
-| `--api-key` | `$STRIPE_SECRET` / `.env` | Stripe secret key (`sk_test_…` or `sk_live_…`) |
-| `--path` | `/stripe/webhook` | Webhook route path on your app |
+| `--api-key` | resolved from `.env` | Stripe secret key (`sk_test_…` or `sk_live_…`) |
+| `--path` | `/stripe/webhook` | Webhook route path on your app (persisted to `.lerd.yaml`) |
+| `--secret-env-key` | auto-detected | Which `.env` key holds the Stripe secret (persisted to `.lerd.yaml`) |
 
 ### Web UI
 
-When `STRIPE_SECRET` is present in a site's `.env`, a **Stripe** toggle appears in the site detail panel alongside HTTPS and Queue. Toggling it starts or stops the listener. While running:
+When a Stripe secret is detected in a site's `.env` (under any of the recognised keys), a **Stripe** toggle appears in the site detail panel alongside HTTPS and Queue. Toggling it starts or stops the listener. A gear next to the toggle opens a small modal for setting the webhook route, mirroring the Horizon control. While running:
 
 - A violet dot appears next to the site in the sidebar.
 - A **Stripe** log tab opens automatically beside PHP-FPM and Queue.

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -1246,13 +1246,16 @@ FrankenPHP is framework-aware: Laravel uses ` + bt + `octane:start --server=fran
 Read, write, or reset a site's custom nginx override block. Saving runs ` + bt + `nginx -t` + bt + `, backs up the prior file, and reloads nginx. ` + bt + `branch=<name>` + bt + ` targets a worktree (new worktrees inherit main's override); ` + bt + `content` + bt + ` is the full file on write.
 
 ### ` + bt + `stripe` + bt + `
-Start or stop a Stripe webhook listener for a site using the Stripe CLI container. On ` + bt + `start` + bt + ` it reads ` + bt + `STRIPE_SECRET` + bt + ` from the site's ` + bt + `.env` + bt + ` and forwards webhooks to ` + bt + `/stripe/webhook` + bt + ` by default.
+Start, stop, or configure a Stripe webhook listener for a site using the Stripe CLI container. Works for any framework, not just Laravel. On ` + bt + `start` + bt + ` the secret is auto-detected from the site's ` + bt + `.env` + bt + ` (probing ` + bt + `STRIPE_SECRET` + bt + `, ` + bt + `STRIPE_SECRET_KEY` + bt + `, then ` + bt + `STRIPE_API_KEY` + bt + `) and events are forwarded to ` + bt + `/stripe/webhook` + bt + ` by default.
 
 Arguments:
-- ` + bt + `action` + bt + ` (required): ` + bt + `"start"` + bt + ` or ` + bt + `"stop"` + bt + `
+- ` + bt + `action` + bt + ` (required): ` + bt + `"start"` + bt + `, ` + bt + `"stop"` + bt + `, or ` + bt + `"config"` + bt + `
 - ` + bt + `site` + bt + ` (required): site name from ` + bt + `sites` + bt + ` tool
-- ` + bt + `api_key` + bt + ` (optional, ` + bt + `start` + bt + ` only): Stripe secret key (defaults to ` + bt + `STRIPE_SECRET` + bt + ` in the site's ` + bt + `.env` + bt + `)
-- ` + bt + `webhook_path` + bt + ` (optional, ` + bt + `start` + bt + ` only): webhook route path (default: ` + bt + `"/stripe/webhook"` + bt + `)
+- ` + bt + `api_key` + bt + ` (optional, ` + bt + `start` + bt + ` only): Stripe secret key (defaults to the secret auto-detected in the site's ` + bt + `.env` + bt + `)
+- ` + bt + `webhook_path` + bt + ` (optional): forward route path, persisted to ` + bt + `.lerd.yaml` + bt + ` (default: ` + bt + `"/stripe/webhook"` + bt + `)
+- ` + bt + `secret_env_key` + bt + ` (optional): which ` + bt + `.env` + bt + ` key holds the secret, persisted to ` + bt + `.lerd.yaml` + bt + ` (empty auto-detects)
+
+Use ` + bt + `action="config"` + bt + ` to set ` + bt + `webhook_path` + bt + `/` + bt + `secret_env_key` + bt + ` without starting the listener; passing ` + bt + `config` + bt + ` with no fields reports the current settings.
 
 ### ` + bt + `db_export` + bt + `
 Export a database to a SQL dump file. Works with any project type — service and database are auto-detected. Arguments:
@@ -1585,7 +1588,7 @@ Read ` + bt + `status()` + bt + ` for ` + bt + `dns.tld` + bt + ` and ` + bt + `
 | ` + bt + `site_control` + bt + ` | Pause, unpause, restart, or rebuild a site — ` + bt + `action` + bt + `: ` + bt + `pause` + bt + ` / ` + bt + `unpause` + bt + ` / ` + bt + `restart` + bt + ` / ` + bt + `rebuild` + bt + ` (pause replaces vhost with landing page; rebuild only for custom containers) |
 | ` + bt + `site_runtime` + bt + ` | Switch between shared PHP-FPM and per-site FrankenPHP runtime (supports worker mode) |
 | ` + bt + `site_nginx` + bt + ` | Read/write/reset a site's custom nginx override (saving runs ` + bt + `nginx -t` + bt + `, backs up the prior file, reloads); ` + bt + `branch` + bt + ` targets a worktree |
-| ` + bt + `stripe` + bt + ` | Start or stop a Stripe webhook listener for a site — ` + bt + `action` + bt + `: ` + bt + `start` + bt + ` / ` + bt + `stop` + bt + ` |
+| ` + bt + `stripe` + bt + ` | Start, stop, or configure a Stripe webhook listener for a site — ` + bt + `action` + bt + `: ` + bt + `start` + bt + ` / ` + bt + `stop` + bt + ` / ` + bt + `config` + bt + ` (secret auto-detected; ` + bt + `config` + bt + ` sets ` + bt + `webhook_path` + bt + `/` + bt + `secret_env_key` + bt + ` in ` + bt + `.lerd.yaml` + bt + `) |
 | ` + bt + `logs` + bt + ` | Fetch container logs — defaults to current site's FPM; optionally specify nginx, service name, PHP version, or site name |
 | ` + bt + `status` + bt + ` | Health snapshot of DNS, nginx, PHP-FPM containers, and the file watcher |
 | ` + bt + `doctor` + bt + ` | Full diagnostic as structured JSON: podman, systemd, DNS, ports, PHP images, config, updates |


### PR DESCRIPTION
PR #490 made the Stripe webhook listener work for any project type but shipped without documentation. This fills that gap.

The Stripe usage page now explains that the listener is not Laravel only, that the secret is auto-detected from STRIPE_SECRET, STRIPE_SECRET_KEY or STRIPE_API_KEY, and that the forward route is configurable per project. It documents the new lerd stripe:config command, the optional stripe block in .lerd.yaml with its path and secret_env_key fields, the new --secret-env-key flag on stripe:listen, and the gear next to the web UI toggle that opens the route modal.

The command reference gains a stripe:config row, the configuration reference gains the stripe field on .lerd.yaml, and the MCP tool table picks up the new config action and secret_env_key argument. The same updates land in the embedded Claude skill and Junie guidelines that ship with the MCP server, so the injected AI artefacts stay in sync with the tool.