### PR TITLE
fix(host-proxy): guard rebuild and warn about Vite allowedHosts

### DIFF
--- a/docs/usage/host-proxy.md
+++ b/docs/usage/host-proxy.md
@@ -56,6 +56,10 @@ For Node projects the port is auto-assigned: `lerd init` starts from a default a
 
 Lerd sets both sides of the contract: it injects the chosen port via `PORT` (or `port_env_key`) so a server that honours it binds there, and points nginx at the same port. It does not probe the live socket, so a server that ignores the env var and hardcodes a different port will not be reached. For those, name the port directly in the command (for example `vite --port 5173 --strictPort`, or `runserver 0.0.0.0:8000`) so both sides agree.
 
+## Vite
+
+Vite checks the request's `Host` header against its `allowedHosts` list and answers anything else with `403 Blocked request`. Because nginx proxies with the site domain as the `Host`, a default Vite project returns 403 through the lerd proxy until you allow the domain. Add it to `server.allowedHosts` in `vite.config` (or set `allowedHosts: true`). `lerd init` prints this reminder when it detects a Vite dev command.
+
 ## Lifecycle
 
 The dev server is the site's main process, not a togglable worker. Its health drives the site's running indicator, and its lifecycle follows the site:

--- a/internal/cli/hostproxy.go
+++ b/internal/cli/hostproxy.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"runtime"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/geodro/lerd/internal/certs"
@@ -173,6 +174,19 @@ func (m *packageManifest) devScripts() []string {
 // package.json, in preference order, each rendered as "npm run <name>".
 func AvailableDevScripts(cwd string) []string {
 	return readPackageManifest(cwd).devScripts()
+}
+
+// runsVite reports whether the wizard's chosen dev command launches Vite,
+// resolving "npm run <script>" against package.json so the allowedHosts note
+// only prints for Vite projects. A custom command naming vite counts too.
+func (m *packageManifest) runsVite(command string) bool {
+	if strings.Contains(command, "vite") {
+		return true
+	}
+	if name, ok := strings.CutPrefix(command, "npm run "); ok && m != nil {
+		return strings.Contains(m.Scripts[name], "vite")
+	}
+	return false
 }
 
 var portFlagRe = regexp.MustCompile(`(?:--port[ =]|PORT=)(\d+)`)

--- a/internal/cli/hostproxy_test.go
+++ b/internal/cli/hostproxy_test.go
@@ -52,6 +52,28 @@ func TestAvailableDevScripts_noPackageJSON(t *testing.T) {
 	}
 }
 
+func TestRunsVite(t *testing.T) {
+	m := &packageManifest{Scripts: map[string]string{"dev": "vite", "start:dev": "nest start --watch"}}
+	cases := []struct {
+		manifest *packageManifest
+		command  string
+		want     bool
+	}{
+		{m, "npm run dev", true},        // resolves script to vite
+		{m, "npm run start:dev", false}, // nest, not vite
+		{m, "vite --port 5173", true},   // custom command names vite
+		{m, "npm run build", false},     // script not present
+		{nil, "npm run dev", false},     // no manifest, not a vite command
+		{nil, "vite", true},             // no manifest but command is vite
+		{m, "", false},                  // proxy-only mode
+	}
+	for _, c := range cases {
+		if got := c.manifest.runsVite(c.command); got != c.want {
+			t.Errorf("runsVite(%q) = %v, want %v", c.command, got, c.want)
+		}
+	}
+}
+
 func TestPortFromCommand(t *testing.T) {
 	cases := map[string]int{
 		"vite --port 4000":       4000,

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -804,6 +804,15 @@ func runHostProxyWizard(cwd string, defaults *config.ProjectConfig, gcfg *config
 		}
 	}
 
+	// Vite rejects requests whose Host header isn't localhost/an IP (its
+	// allowedHosts check). nginx proxies with the site domain as Host, so the
+	// user has to allow it in vite.config or every request fails with a 403.
+	if manifest.runsVite(command) {
+		fmt.Println("\nNote: Vite blocks proxied requests by their Host header. Add your site")
+		fmt.Println("domain to server.allowedHosts in vite.config (or set allowedHosts: true),")
+		fmt.Println("or requests through the lerd proxy fail with \"host not allowed\".")
+	}
+
 	return &config.ProjectConfig{
 		Secured:     secured,
 		Services:    buildProjectServices(selectedServices, defaults),

--- a/internal/cli/rebuild.go
+++ b/internal/cli/rebuild.go
@@ -31,8 +31,11 @@ func RebuildSite(name string) error {
 	if err != nil {
 		return fmt.Errorf("site %q not found", name)
 	}
+	if site.IsHostProxy() {
+		return fmt.Errorf("site %q is a host-proxy site with no container to rebuild; use 'lerd restart' to restart its dev server", name)
+	}
 	if !site.IsCustomContainer() {
-		return fmt.Errorf("site %q is not a custom container site — use 'lerd php:rebuild' for PHP sites", name)
+		return fmt.Errorf("site %q is not a custom container site, use 'lerd php:rebuild' for PHP sites", name)
 	}
 
 	proj, err := config.LoadProjectConfig(site.Path)


### PR DESCRIPTION
Two host-proxy fixes that stand on their own.

RebuildSite handed host-proxy sites the custom-container error telling them to use lerd php:rebuild, which makes no sense because a host-proxy site has no container to rebuild. It now returns a clear message pointing at lerd restart instead, and the existing custom-container error drops its em dash to match the rest of our copy.

The init wizard also prints a note when it detects a Vite dev command. Vite checks the request Host header against its allowedHosts list and answers anything else with a 403, and since nginx proxies with the site domain as the Host a default Vite project gets blocked through the lerd proxy until the domain is allowed. lerd can't safely edit someone's vite.config, so it points them at server.allowedHosts. Detection resolves npm run scripts against package.json so the note only shows for actual Vite projects. The same gotcha is now written up in the host-proxy docs.

This started life as the macOS dev-server binding fix, but that work depends on the appendPortFlag path that main has since removed in favour of injecting the port through the PORT env var, so it needs redoing against the new mechanism and will land as a follow-up commit here.
