### PR TITLE
Host-proxy regression fixes, systemd injection hardening, and consent gates

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -924,8 +924,26 @@ func removeStale(_ *config.GlobalConfig) bool {
 		}
 		if _, statErr := os.Stat(site.Path); os.IsNotExist(statErr) {
 			fmt.Printf("Removing stale site: %s (%s)\n", site.Name, site.Path)
-			_ = nginx.RemoveVhost(site.PrimaryDomain())
-			_ = config.RemoveSite(site.Name)
+			s := site
+			// Tear down the site's workers and any per-site container before
+			// dropping the vhost and registry entry. Without this a host-proxy
+			// site's always-restart dev server (and a custom-container/FrankenPHP
+			// container) keeps running after the project directory is gone. The
+			// nginx reload is batched by the caller.
+			if siteops.StopSiteWorkers != nil {
+				siteops.StopSiteWorkers(&s)
+			}
+			if s.IsCustomContainer() {
+				_ = podman.StopUnit(podman.CustomContainerName(s.Name))
+				podman.RemoveCustomContainer(s.Name)
+				_ = podman.RemoveCustomContainerQuadlet(s.Name)
+			}
+			if s.IsFrankenPHP() {
+				_ = podman.StopUnit(podman.FrankenPHPContainerName(s.Name))
+				_ = podman.RemoveFrankenPHPQuadlet(s.Name)
+			}
+			_ = nginx.RemoveVhost(s.PrimaryDomain())
+			_ = config.RemoveSite(s.Name)
 			removed = true
 		}
 	}

--- a/cmd/lerd/main_test.go
+++ b/cmd/lerd/main_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
+	"github.com/geodro/lerd/internal/siteops"
 )
 
 func isolateConfig(t *testing.T) {
@@ -25,6 +26,36 @@ func isolateConfig(t *testing.T) {
 		if err := os.MkdirAll(d, 0755); err != nil {
 			t.Fatalf("mkdir %s: %v", d, err)
 		}
+	}
+}
+
+// A deleted host-proxy site must have its dev-server worker torn down, not just
+// its registry entry removed, or the always-restart unit leaks. removeStale
+// routes through siteops.UnlinkSiteCore, which calls the StopSiteWorkers hook.
+func TestRemoveStale_tearsDownStaleHostProxyWorkers(t *testing.T) {
+	isolateConfig(t)
+
+	prev := siteops.StopSiteWorkers
+	var stopped []string
+	siteops.StopSiteWorkers = func(s *config.Site) { stopped = append(stopped, s.Name) }
+	t.Cleanup(func() { siteops.StopSiteWorkers = prev })
+
+	deletedDir := filepath.Join(t.TempDir(), "ghost")
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "ghost", Domains: []string{"ghost.test"}, Path: deletedDir, HostPort: 5197, HostCommand: "sleep 600"},
+	}}
+	if err := config.SaveSites(reg); err != nil {
+		t.Fatal(err)
+	}
+
+	if !removeStale(&config.GlobalConfig{}) {
+		t.Fatal("expected removeStale to report a removal")
+	}
+	if len(stopped) != 1 || stopped[0] != "ghost" {
+		t.Errorf("removeStale must stop a stale host-proxy site's workers; stopped=%v", stopped)
+	}
+	if after, _ := config.LoadSites(); len(after.Sites) != 0 {
+		t.Errorf("stale site should be removed from the registry; got %d sites", len(after.Sites))
 	}
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,14 @@ nginx:
                         # .lerd.yaml request_timeout overrides it per site.
 dns:
   tld: "test"
+host_proxy:
+  disabled: false         # set true to refuse setting up or starting any
+                          # host-proxy dev server (lerd never supervises a
+                          # process on the host). Default false.
+  skip_confirmation: false # set true to link a host-proxy project without the
+                          # "start this command on your host?" confirmation.
+                          # Default false so a command from a cloned repo is
+                          # never run unconfirmed. See usage/host-proxy.md.
 parked_directories:
   - ~/Lerd
 services:
@@ -171,6 +179,8 @@ Framework yamls (under `lerd-frameworks/frameworks/<framework>/<version>.yaml`) 
 ### Inline custom service definitions
 
 Custom services can be defined directly in `.lerd.yaml` instead of (or in addition to) registering them with `lerd service add`. This makes the project fully self-contained: cloning it and running `lerd link` is enough to reproduce the environment.
+
+Because an inline service runs a container image and command that come from the project, `lerd link` shows the image, command, and ports of a not-yet-installed inline service and asks before installing it (a non-interactive or dashboard link, which is itself an explicit action, proceeds without the prompt). lerd also rejects control characters in service fields so a definition can't inject directives into the generated container unit. Only link projects you trust, the same as before running their build or dev scripts.
 
 ```yaml
 php_version: "8.5"

--- a/docs/usage/host-proxy.md
+++ b/docs/usage/host-proxy.md
@@ -77,6 +77,24 @@ The dashboard shows a **Proxy** badge with the port (mirroring the container bad
 journalctl --user -u lerd-app-<site> -f
 ```
 
+## Trust and consent
+
+A host-proxy dev server runs your project's command directly on the host (as a systemd `--user` unit on Linux, launchd on macOS), outside any container. Because the command can come from a project's committed `.lerd.yaml`, lerd will not silently supervise a command you have not agreed to run. Three gates enforce this:
+
+- **Explicit setup only.** A dev-server unit is only ever created by an explicit action: `lerd init`, `lerd link`, or clicking Link in the dashboard. Nothing is installed just because a folder appears in a parked directory.
+- **Command confirmation.** When you `lerd link` a project whose `.lerd.yaml` already carries a `proxy:` block you did not author through the wizard, lerd prints the exact command and asks before installing and starting it. Re-linking with the same approved command, choosing it in the `lerd init` wizard, clicking Link in the dashboard, or passing `lerd link --yes` all count as consent and skip the prompt. A non-interactive `lerd link` with an unapproved command is refused rather than run blindly.
+- **Drift protection.** lerd records the approved command in its site registry. If `.lerd.yaml`'s dev command later changes (for example after a `git pull`), `lerd start` and boot restore will not auto-run the new command; they warn and wait for you to `lerd link` again to review and approve it.
+
+Two global settings in `config.yaml` tune this (both default to the safe value, so existing installs are unaffected):
+
+```yaml
+host_proxy:
+  disabled: false           # set true to refuse all host-proxy dev servers
+  skip_confirmation: false  # set true to link without the confirmation prompt
+```
+
+Note that this gate is about consent, not sandboxing: a dev server you approve runs with your full user privileges, exactly as if you had run it in a terminal. Only link projects you trust, the same way you would before running `npm run dev` or `npm install` on them.
+
 ## Env
 
 A host-proxy app runs on the host, off the podman bridge, so it can't resolve container DNS names like `lerd-postgres`. `lerd env` rewrites service connections accordingly: any `lerd-<name>` host, whether bare (`DB_HOST=lerd-postgres`) or embedded in a URL (`MONGO_DSN=...@lerd-mongo:27017/db`), becomes `127.0.0.1`, and the port is remapped from the container port to the service's published host port (so mariadb's `3306` becomes `3411` while redis stays `6379`).

--- a/internal/cli/db_move.go
+++ b/internal/cli/db_move.go
@@ -260,9 +260,10 @@ func runDbMoveOne(sitePath, siteName, from, to string) error {
 	if err := config.ReplaceProjectDBService(sitePath, to); err != nil {
 		return fmt.Errorf("saving .lerd.yaml: %w", err)
 	}
-	if err := runLerdEnv(sitePath); err != nil {
-		// Roll both files back so a failed repoint leaves the site exactly as it
-		// was on the source service.
+	// Once the site is repointed at the target, any later failure has to undo
+	// .lerd.yaml and .env so the live site keeps pointing at the source (whose
+	// data is still intact) rather than an empty or half-restored target DB.
+	rollback := func(cause error) error {
 		rbErr := config.ReplaceProjectDBService(sitePath, from)
 		if prevEnv != nil {
 			if wErr := os.WriteFile(envPath, prevEnv, 0o644); wErr != nil && rbErr == nil {
@@ -270,9 +271,12 @@ func runDbMoveOne(sitePath, siteName, from, to string) error {
 			}
 		}
 		if rbErr != nil {
-			return fmt.Errorf("applying env for target: %w (rollback also failed: %v)", err, rbErr)
+			return fmt.Errorf("%w (rollback also failed: %v)", cause, rbErr)
 		}
-		return fmt.Errorf("applying env for target: %w", err)
+		return cause
+	}
+	if err := runLerdEnv(sitePath); err != nil {
+		return rollback(fmt.Errorf("applying env for target: %w", err))
 	}
 
 	// The target database name is whatever env setup landed on. env starts the
@@ -280,32 +284,32 @@ func runDbMoveOne(sitePath, siteName, from, to string) error {
 	// before restoring rather than letting a warned-over failure surface here.
 	tgt, err := resolveDB(sitePath, "", "")
 	if err != nil {
-		return fmt.Errorf("cannot resolve target database: %w", err)
+		return rollback(fmt.Errorf("cannot resolve target database: %w", err))
 	}
 	if err := ensureServiceRunning(to); err != nil {
-		return fmt.Errorf("could not start target %s: %w", to, err)
+		return rollback(fmt.Errorf("could not start target %s: %w", to, err))
 	}
 	if _, err := createDatabase(to, tgt.database); err != nil {
-		return fmt.Errorf("creating database %q on %s: %w", tgt.database, to, err)
+		return rollback(fmt.Errorf("creating database %q on %s: %w", tgt.database, to, err))
 	}
 	tgtEnv := serviceToDBEnv(to)
 	tgtEnv.database = tgt.database
 
 	f, err := os.Open(tmp.Name())
 	if err != nil {
-		return fmt.Errorf("reopening dump: %w", err)
+		return rollback(fmt.Errorf("reopening dump: %w", err))
 	}
 	defer f.Close()
 	restore, err := dbImportCmd(tgtEnv)
 	if err != nil {
-		return err
+		return rollback(err)
 	}
 	restore.Stdin = f
 	restore.Stdout = os.Stdout
 	restore.Stderr = os.Stderr
 	fmt.Printf("Restoring %s into %s...\n", tgtEnv.database, to)
 	if err := restore.Run(); err != nil {
-		return fmt.Errorf("restore failed: %w", err)
+		return rollback(fmt.Errorf("restore failed: %w", err))
 	}
 	return nil
 }

--- a/internal/cli/hostproxy.go
+++ b/internal/cli/hostproxy.go
@@ -415,10 +415,15 @@ var hostProxyPreApproved bool
 // asking; prompt reports that an interactive confirmation is still owed; reason
 // explains a refusal. A site can only run a command the user has consented to.
 func hostProxyGate(command string, disabled, skipConfirm, approved, interactive bool) (proceed, prompt bool, reason string) {
+	if command == "" {
+		// Proxy-only: lerd supervises nothing, so neither the disable switch
+		// nor the confirmation applies.
+		return true, false, ""
+	}
 	if disabled {
 		return false, false, "host-proxy dev servers are disabled (set host_proxy.disabled: false to enable)"
 	}
-	if command == "" || approved || hostProxyPreApproved || skipConfirm {
+	if approved || hostProxyPreApproved || skipConfirm {
 		return true, false, ""
 	}
 	if !interactive {
@@ -440,10 +445,8 @@ func approveHostProxyCommand(siteName, command string, approved bool) error {
 	if !prompt {
 		return fmt.Errorf("host-proxy %s: %s", siteName, reason)
 	}
-	fmt.Printf("\nlerd supervises this dev-server command on your host, outside any container:\n\n  %s\n\nStart and auto-restart it for %s? [y/N] ", command, siteName)
-	var ans string
-	fmt.Scanln(&ans) //nolint:errcheck
-	if ans == "" || (ans[0] != 'y' && ans[0] != 'Y') {
+	fmt.Printf("\nlerd supervises this dev-server command on your host, outside any container:\n\n  %s\n", command)
+	if !promptConfirm(fmt.Sprintf("Start and auto-restart it for %s?", siteName)) {
 		return fmt.Errorf("host-proxy setup declined for %s", siteName)
 	}
 	return nil

--- a/internal/cli/hostproxy.go
+++ b/internal/cli/hostproxy.go
@@ -404,3 +404,47 @@ func startHostProxyWorker(site config.Site, proxy *config.ProxyConfig) {
 		fmt.Printf("[WARN] starting dev server: %v\n", err)
 	}
 }
+
+// hostProxyPreApproved lets the init wizard mark the command the user just chose
+// as approved, so the link it triggers doesn't prompt again for the same command.
+var hostProxyPreApproved bool
+
+// hostProxyGate is the pure decision for whether lerd may install and start a
+// host-proxy dev-server command. It is split out so the policy is unit-testable
+// without a TTY or global-config file. proceed reports whether to run without
+// asking; prompt reports that an interactive confirmation is still owed; reason
+// explains a refusal. A site can only run a command the user has consented to.
+func hostProxyGate(command string, disabled, skipConfirm, approved, interactive bool) (proceed, prompt bool, reason string) {
+	if disabled {
+		return false, false, "host-proxy dev servers are disabled (set host_proxy.disabled: false to enable)"
+	}
+	if command == "" || approved || hostProxyPreApproved || skipConfirm {
+		return true, false, ""
+	}
+	if !interactive {
+		return false, false, "command not approved; re-run `lerd link` interactively, pass --yes, or set host_proxy.skip_confirmation: true"
+	}
+	return false, true, ""
+}
+
+// approveHostProxyCommand enforces the consent gates before lerd supervises a
+// dev-server command on the host: the global disable switch and an interactive
+// confirmation of the exact command. approved short-circuits the prompt when the
+// command already matches the registry-approved one or the caller passed --yes.
+func approveHostProxyCommand(siteName, command string, approved bool) error {
+	gcfg, _ := config.LoadGlobal()
+	proceed, prompt, reason := hostProxyGate(command, gcfg.HostProxy.Disabled, gcfg.HostProxy.SkipConfirmation, approved, isInteractive())
+	if proceed {
+		return nil
+	}
+	if !prompt {
+		return fmt.Errorf("host-proxy %s: %s", siteName, reason)
+	}
+	fmt.Printf("\nlerd supervises this dev-server command on your host, outside any container:\n\n  %s\n\nStart and auto-restart it for %s? [y/N] ", command, siteName)
+	var ans string
+	fmt.Scanln(&ans) //nolint:errcheck
+	if ans == "" || (ans[0] != 'y' && ans[0] != 'Y') {
+		return fmt.Errorf("host-proxy setup declined for %s", siteName)
+	}
+	return nil
+}

--- a/internal/cli/hostproxy_test.go
+++ b/internal/cli/hostproxy_test.go
@@ -83,6 +83,7 @@ func TestHostProxyGate(t *testing.T) {
 	}{
 		{"disabled blocks even when approved", "npm run dev", true, false, true, true, false, false},
 		{"proxy-only empty command proceeds", "", false, false, false, false, true, false},
+		{"disabled still allows proxy-only", "", true, false, false, false, true, false},
 		{"already approved proceeds", "npm run dev", false, false, true, false, true, false},
 		{"skip_confirmation proceeds", "npm run dev", false, true, false, false, true, false},
 		{"interactive unapproved needs prompt", "npm run dev", false, false, false, true, false, true},

--- a/internal/cli/hostproxy_test.go
+++ b/internal/cli/hostproxy_test.go
@@ -74,6 +74,41 @@ func TestRunsVite(t *testing.T) {
 	}
 }
 
+func TestHostProxyGate(t *testing.T) {
+	cases := []struct {
+		name                                 string
+		command                              string
+		disabled, skipConfirm, approved, tty bool
+		wantProceed, wantPrompt              bool
+	}{
+		{"disabled blocks even when approved", "npm run dev", true, false, true, true, false, false},
+		{"proxy-only empty command proceeds", "", false, false, false, false, true, false},
+		{"already approved proceeds", "npm run dev", false, false, true, false, true, false},
+		{"skip_confirmation proceeds", "npm run dev", false, true, false, false, true, false},
+		{"interactive unapproved needs prompt", "npm run dev", false, false, false, true, false, true},
+		{"non-interactive unapproved is refused", "npm run dev", false, false, false, false, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			proceed, prompt, reason := hostProxyGate(c.command, c.disabled, c.skipConfirm, c.approved, c.tty)
+			if proceed != c.wantProceed || prompt != c.wantPrompt {
+				t.Errorf("hostProxyGate = (proceed %v, prompt %v), want (%v, %v)", proceed, prompt, c.wantProceed, c.wantPrompt)
+			}
+			if !proceed && !prompt && reason == "" {
+				t.Errorf("a refusal must carry a reason")
+			}
+		})
+	}
+}
+
+func TestHostProxyGate_PreApprovedOverridesPrompt(t *testing.T) {
+	hostProxyPreApproved = true
+	defer func() { hostProxyPreApproved = false }()
+	if proceed, prompt, _ := hostProxyGate("npm run dev", false, false, false, true); !proceed || prompt {
+		t.Errorf("wizard pre-approval should proceed without prompting; got proceed=%v prompt=%v", proceed, prompt)
+	}
+}
+
 func TestPortFromCommand(t *testing.T) {
 	cases := map[string]int{
 		"vite --port 4000":       4000,

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -61,6 +61,10 @@ func runInit(fresh bool) error {
 			return fmt.Errorf("saving .lerd.yaml: %w", err)
 		}
 		fmt.Println("Saved .lerd.yaml")
+		// The wizard already had the user choose the dev command, so the link
+		// it triggers below shouldn't prompt to confirm that same command again.
+		hostProxyPreApproved = true
+		defer func() { hostProxyPreApproved = false }()
 	}
 
 	if err := applyProjectConfig(cwd); err != nil {

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -365,10 +365,7 @@ func approveInlineService(svc *config.CustomService) bool {
 	if len(svc.Ports) > 0 {
 		fmt.Printf("  ports: %s\n", strings.Join(svc.Ports, ", "))
 	}
-	fmt.Printf("Install and start it? [y/N] ")
-	var ans string
-	fmt.Scanln(&ans) //nolint:errcheck
-	return ans != "" && (ans[0] == 'y' || ans[0] == 'Y')
+	return promptConfirm("Install and start it?")
 }
 
 func linkApplyServices(cwd string, proj *config.ProjectConfig) error {

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -19,6 +19,11 @@ import (
 // is called from within lerd setup / lerd init (prevents infinite recursion).
 var linkSkipSetupPrompt bool
 
+// linkAssumeYes approves a host-proxy dev command without the interactive
+// confirmation prompt. Set by `lerd link --yes` and by the UI link flow, where
+// the user's explicit action is the consent.
+var linkAssumeYes bool
+
 // presetVersionSuffix returns " (5.7)" for a non-empty version, otherwise "".
 func presetVersionSuffix(version string) string {
 	if version == "" {
@@ -29,7 +34,7 @@ func presetVersionSuffix(version string) string {
 
 // NewLinkCmd returns the link command.
 func NewLinkCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "link [domain]",
 		Short: "Link the current directory as a site",
 		Long:  "Register the current directory as a lerd site. The optional argument is the domain name without the TLD (e.g. 'myapp' becomes myapp.test). Defaults to the directory name.",
@@ -38,6 +43,8 @@ func NewLinkCmd() *cobra.Command {
 			return runLink(args)
 		},
 	}
+	cmd.Flags().BoolVar(&linkAssumeYes, "yes", false, "Approve a host-proxy dev command without the confirmation prompt")
+	return cmd
 }
 
 func runLink(args []string) error {
@@ -163,6 +170,16 @@ func runLink(args []string) error {
 	// Host-proxy path: the project runs a dev server on the host and nginx
 	// reverse-proxies to it. No container, no PHP/framework detection.
 	if proj != nil && proj.Proxy != nil && proj.Proxy.Port > 0 {
+		// Gate supervising a dev command on the host behind explicit consent: a
+		// re-link with the same approved command, --yes, or the wizard's own
+		// choice passes silently; a fresh repo-authored command prompts.
+		approved := linkAssumeYes
+		if existing, err := config.FindSite(name); err == nil && existing.HostCommand == proj.Proxy.Command {
+			approved = true
+		}
+		if err := approveHostProxyCommand(name, proj.Proxy.Command, approved); err != nil {
+			return err
+		}
 		secured := siteops.CleanupRelink(cwd, name) || proj.Secured
 		site := config.Site{
 			Name:        name,
@@ -330,6 +347,30 @@ func runLink(args []string) error {
 
 // linkApplyServices installs and starts services declared in .lerd.yaml.
 // Shared by both the standard PHP link path and the custom container path.
+// approveInlineService surfaces a brand-new inline service defined in a
+// project's .lerd.yaml and confirms it before lerd installs and runs it as a
+// container, since the image and command come from the (possibly cloned) repo.
+// A scripted or UI link (--yes) and a non-interactive run proceed; an
+// interactive run prompts.
+func approveInlineService(svc *config.CustomService) bool {
+	if linkAssumeYes || !isInteractive() {
+		return true
+	}
+	fmt.Printf("\nThis project defines a service lerd will run as a container:\n")
+	fmt.Printf("  name:  %s\n", svc.Name)
+	fmt.Printf("  image: %s\n", svc.Image)
+	if svc.Exec != "" {
+		fmt.Printf("  exec:  %s\n", svc.Exec)
+	}
+	if len(svc.Ports) > 0 {
+		fmt.Printf("  ports: %s\n", strings.Join(svc.Ports, ", "))
+	}
+	fmt.Printf("Install and start it? [y/N] ")
+	var ans string
+	fmt.Scanln(&ans) //nolint:errcheck
+	return ans != "" && (ans[0] == 'y' || ans[0] == 'Y')
+}
+
 func linkApplyServices(cwd string, proj *config.ProjectConfig) error {
 	if proj == nil {
 		return nil
@@ -347,6 +388,15 @@ func linkApplyServices(cwd string, proj *config.ProjectConfig) error {
 			svc.Custom.Name = svc.Name
 			existing, loadErr := config.LoadCustomService(svc.Name)
 			shouldSave := true
+			if loadErr != nil {
+				// Brand-new inline service from the project's .lerd.yaml: its
+				// image and command come from the (possibly cloned) repo, so
+				// show what it will run and confirm before installing it.
+				if !approveInlineService(svc.Custom) {
+					fmt.Printf("  Skipped service %s\n", svc.Name)
+					continue
+				}
+			}
 			if loadErr == nil {
 				action, err := confirmReplace("service", svc.Name, existing, svc.Custom)
 				if err != nil {

--- a/internal/cli/migrate_tld.go
+++ b/internal/cli/migrate_tld.go
@@ -98,7 +98,14 @@ func migrateSiteTLD(oldTLD, newTLD string, forceUnsecure bool) []string {
 				fmt.Printf("    WARN: %s: migrate custom nginx override: %v\n", s.Name, err)
 			}
 		}
-		migrateWorktreeVhosts(worktrees, newPrimary, s.PHPVersion, s.Name, s.Secured, parentProxyConfig(s))
+		// Only mirror a proxy config for sites the registry records as
+		// host-proxy; a PHP site with a stray proxy block in .lerd.yaml must
+		// still get PHP worktree vhosts, not reverse-proxy ones.
+		var wtProxy *config.ProxyConfig
+		if s.IsHostProxy() {
+			wtProxy = parentProxyConfig(s)
+		}
+		migrateWorktreeVhosts(worktrees, newPrimary, s.PHPVersion, s.Name, s.Secured, wtProxy)
 
 		// Reissue the parent cert under the NEW primary so wildcard SANs
 		// cover the renamed worktree subdomains. Without this, SSL

--- a/internal/cli/migrate_tld.go
+++ b/internal/cli/migrate_tld.go
@@ -98,7 +98,7 @@ func migrateSiteTLD(oldTLD, newTLD string, forceUnsecure bool) []string {
 				fmt.Printf("    WARN: %s: migrate custom nginx override: %v\n", s.Name, err)
 			}
 		}
-		migrateWorktreeVhosts(worktrees, newPrimary, s.PHPVersion, s.Name, s.Secured, s.IsHostProxy())
+		migrateWorktreeVhosts(worktrees, newPrimary, s.PHPVersion, s.Name, s.Secured, parentProxyConfig(s))
 
 		// Reissue the parent cert under the NEW primary so wildcard SANs
 		// cover the renamed worktree subdomains. Without this, SSL
@@ -138,18 +138,18 @@ func migrateSiteTLD(oldTLD, newTLD string, forceUnsecure bool) []string {
 // <branch>.<newPrimary> domain, and rewrites the worktree's .env APP_URL.
 // Worktree errors are warnings, not fatal; the parent site rename has already
 // landed and partial worktree state is preferable to abandoning the migration.
-func migrateWorktreeVhosts(worktrees []gitpkg.Worktree, newPrimary, phpVersion, siteName string, secured, hostProxy bool) {
+func migrateWorktreeVhosts(worktrees []gitpkg.Worktree, newPrimary, phpVersion, siteName string, secured bool, proxy *config.ProxyConfig) {
 	for _, wt := range worktrees {
 		removeStaleVhosts(wt.Domain)
 		newWTDomain := wt.Branch + "." + newPrimary
 		// Host-proxy worktrees keep their dev server (the unit is keyed by site
-		// and branch, not domain); only the proxy vhost domain changes.
-		if hostProxy {
-			if proj, err := config.LoadProjectConfig(wt.Path); err == nil && proj.Proxy != nil {
-				port := WorktreeHostPort(proj.Proxy.Port, wt.Path, hostProxyPortEnvKey(proj.Proxy))
-				if err := nginx.GenerateWorktreeHostProxyVhostFor(newWTDomain, wt.Path, newPrimary, port, proj.Proxy.SSL, secured); err != nil {
-					fmt.Printf("    WARN: worktree %s: regenerate vhost: %v\n", wt.Branch, err)
-				}
+		// and branch, not domain); only the proxy vhost domain changes. Mirror
+		// the parent's proxy config rather than the worktree's .lerd.yaml, which
+		// the worktree checkout often doesn't have.
+		if proxy != nil {
+			port := WorktreeHostPort(proxy.Port, wt.Path, hostProxyPortEnvKey(proxy))
+			if err := nginx.GenerateWorktreeHostProxyVhostFor(newWTDomain, wt.Path, newPrimary, port, proxy.SSL, secured); err != nil {
+				fmt.Printf("    WARN: worktree %s: regenerate vhost: %v\n", wt.Branch, err)
 			}
 			scheme := "http"
 			if secured {

--- a/internal/cli/migrate_tld_test.go
+++ b/internal/cli/migrate_tld_test.go
@@ -134,7 +134,7 @@ func TestMigrateWorktreeVhosts_RewritesConfsAndEnv(t *testing.T) {
 	worktrees := []gitpkg.Worktree{
 		{Name: "wt", Branch: "feat-x", Path: wtPath, Domain: "feat-x.alpha.test"},
 	}
-	migrateWorktreeVhosts(worktrees, "alpha.localhost", "8.4", "alpha", false, false)
+	migrateWorktreeVhosts(worktrees, "alpha.localhost", "8.4", "alpha", false, nil)
 
 	if _, err := os.Stat(staleConf); !os.IsNotExist(err) {
 		t.Errorf("stale worktree conf should be gone; stat err = %v", err)
@@ -145,6 +145,41 @@ func TestMigrateWorktreeVhosts_RewritesConfsAndEnv(t *testing.T) {
 	}
 
 	envBytes, _ := os.ReadFile(envPath)
+	if !contains(envBytes, "APP_URL=http://feat-x.alpha.localhost") {
+		t.Errorf(".env not updated; got %q", envBytes)
+	}
+}
+
+// A host-proxy worktree checkout usually has no .lerd.yaml of its own, so the
+// migration must mirror the parent's proxy config (passed in) rather than
+// loading config from the worktree path, or the new vhost never gets written.
+func TestMigrateWorktreeVhosts_HostProxyUsesParentProxy(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
+		t.Fatalf("mkdir confD: %v", err)
+	}
+	wtPath := filepath.Join(tmp, "alpha-wt")
+	if err := os.MkdirAll(wtPath, 0755); err != nil {
+		t.Fatalf("mkdir wt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wtPath, ".env"), []byte("APP_URL=http://feat-x.alpha.test\n"), 0644); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+
+	worktrees := []gitpkg.Worktree{
+		{Name: "wt", Branch: "feat-x", Path: wtPath, Domain: "feat-x.alpha.test"},
+	}
+	proxy := &config.ProxyConfig{Command: "npm run dev", Port: 5173}
+	migrateWorktreeVhosts(worktrees, "alpha.localhost", "", "alpha", false, proxy)
+
+	freshConf := filepath.Join(config.NginxConfD(), "feat-x.alpha.localhost.conf")
+	if _, err := os.Stat(freshConf); err != nil {
+		t.Errorf("host-proxy worktree vhost missing without a worktree .lerd.yaml: %v", err)
+	}
+	envBytes, _ := os.ReadFile(filepath.Join(wtPath, ".env"))
 	if !contains(envBytes, "APP_URL=http://feat-x.alpha.localhost") {
 		t.Errorf(".env not updated; got %q", envBytes)
 	}

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -158,6 +158,10 @@ func UnpauseSite(name string) error {
 				return fmt.Errorf("generating host-proxy vhost: %w", err)
 			}
 		}
+		// pauseWorktrees swapped each worktree to the paused page; the PHP
+		// unpauseWorktrees below never runs for host-proxy sites, so restore
+		// their host-proxy vhosts and dev servers here.
+		unpauseHostProxyWorktrees(site)
 	case site.IsFrankenPHP():
 		_ = podman.StartUnit(podman.FrankenPHPContainerName(site.Name))
 		if site.Secured {
@@ -522,12 +526,35 @@ func pauseWorktrees(site *config.Site) {
 		return
 	}
 	for _, wt := range worktrees {
+		// Host-proxy worktrees run their own supervised dev server; stop it so
+		// it doesn't keep holding its host port while the site is paused.
+		if site.IsHostProxy() {
+			if err := StopAllWorkersForWorktree(site.Name, wt.Branch); err != nil {
+				fmt.Printf("  [WARN] stopping worktree dev server %s: %v\n", wt.Domain, err)
+			}
+		}
 		if err := writePausedWorktreeHTML(wt, site); err != nil {
 			fmt.Printf("  [WARN] paused page for worktree %s: %v\n", wt.Domain, err)
 			continue
 		}
 		if err := nginx.GeneratePausedWorktreeVhost(wt.Domain, site.PrimaryDomain(), config.PausedDir(), site.Secured); err != nil {
 			fmt.Printf("  [WARN] paused vhost for worktree %s: %v\n", wt.Domain, err)
+		}
+	}
+}
+
+// unpauseHostProxyWorktrees restores the host-proxy vhost and dev server for
+// every worktree of a site that has just been unpaused. SetupHostProxyWorktree
+// mirrors the parent's proxy config (registry fallback), so it works even when
+// the worktree checkout has no .lerd.yaml of its own.
+func unpauseHostProxyWorktrees(site *config.Site) {
+	worktrees, err := gitpkg.DetectWorktrees(site.Path, site.PrimaryDomain())
+	if err != nil || len(worktrees) == 0 {
+		return
+	}
+	for _, wt := range worktrees {
+		if err := SetupHostProxyWorktree(*site, wt.Path, wt.Domain); err != nil {
+			fmt.Printf("  [WARN] restoring worktree %s: %v\n", wt.Domain, err)
 		}
 	}
 }

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -991,10 +991,11 @@ func registeredFrameworkWorkerUnits() []string {
 			}
 			out = append(out, "lerd-"+w+"-"+s.Name)
 		}
-		// Skip the dev-server unit when the command drifted from the approved
-		// one; restoreSiteInfrastructure deliberately didn't rewrite it.
-		if s.IsHostProxy() && proj.Proxy != nil && proj.Proxy.Command != "" &&
-			(s.HostCommand == "" || proj.Proxy.Command == s.HostCommand) {
+		// Enumerate the dev-server unit unconditionally: this list also drives
+		// stop/quit, so a drifted unit must stay visible to be stoppable. The
+		// drift guard lives in restoreSiteInfrastructure, which won't write the
+		// drifted command, so start can only ever launch the approved one.
+		if s.IsHostProxy() && proj.Proxy != nil && proj.Proxy.Command != "" {
 			out = append(out, hostProxyWorkerUnit(s.Name))
 		}
 	}

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -814,8 +814,13 @@ func restoreSiteInfrastructure() {
 
 		// Restore the host-proxy dev-server worker unit. Phase 2 of runStart
 		// launches it (it is enumerated by registeredFrameworkWorkerUnits).
+		// Bind to the command the user approved at link time: if .lerd.yaml's
+		// dev command drifted since (e.g. a git pull), don't silently run the
+		// new one, warn and wait for a re-link to re-approve it.
 		if s.IsHostProxy() && proj.Proxy != nil {
-			if w, ok := hostProxyWorker(proj.Proxy); ok && !services.Mgr.IsEnabled(hostProxyWorkerUnit(s.Name)) {
+			if s.HostCommand != "" && proj.Proxy.Command != s.HostCommand {
+				fmt.Printf("[WARN] %s: dev command in .lerd.yaml changed since link; not auto-starting. Run `lerd link` to review and approve.\n", s.Name)
+			} else if w, ok := hostProxyWorker(proj.Proxy); ok && !services.Mgr.IsEnabled(hostProxyWorkerUnit(s.Name)) {
 				restoreWorker(s.Name, s.Path, "", hostProxyWorkerName, w)
 			}
 		}
@@ -986,7 +991,10 @@ func registeredFrameworkWorkerUnits() []string {
 			}
 			out = append(out, "lerd-"+w+"-"+s.Name)
 		}
-		if s.IsHostProxy() && proj.Proxy != nil && proj.Proxy.Command != "" {
+		// Skip the dev-server unit when the command drifted from the approved
+		// one; restoreSiteInfrastructure deliberately didn't rewrite it.
+		if s.IsHostProxy() && proj.Proxy != nil && proj.Proxy.Command != "" &&
+			(s.HostCommand == "" || proj.Proxy.Command == s.HostCommand) {
 			out = append(out, hostProxyWorkerUnit(s.Name))
 		}
 	}

--- a/internal/cli/startstop_test.go
+++ b/internal/cli/startstop_test.go
@@ -4,7 +4,39 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/geodro/lerd/internal/config"
 )
+
+// A host-proxy site whose .lerd.yaml dev command has drifted from the approved
+// one must still be enumerated, because this list also drives lerd stop/quit:
+// excluding the unit would leave a running dev server unstoppable.
+func TestRegisteredFrameworkWorkerUnits_EnumeratesDriftedHostProxy(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	dir := t.TempDir()
+	if err := config.SaveProjectConfig(dir, &config.ProjectConfig{
+		Proxy: &config.ProxyConfig{Command: "npm run drifted", Port: 5173},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{
+		Name: "site", Domains: []string{"site.test"}, Path: dir,
+		HostPort: 5173, HostCommand: "npm run approved",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	want := config.HostProxyWorkerUnit("site")
+	found := false
+	for _, u := range registeredFrameworkWorkerUnits() {
+		if u == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("drifted host-proxy unit %q must stay enumerated so stop/quit can stop it", want)
+	}
+}
 
 func TestQuadletImage_found(t *testing.T) {
 	tmp := t.TempDir()

--- a/internal/cli/worker_preflight.go
+++ b/internal/cli/worker_preflight.go
@@ -25,6 +25,13 @@ import (
 // watcher's per-unit cooldown then prevents thrashing on a permanent
 // failure.
 func workerStartPreflight(sitePath, workerName string, w config.FrameworkWorker) error {
+	// A worker's command (from .lerd.yaml custom_workers or a framework def)
+	// is interpolated into the unit's ExecStart line. Refuse newline/NUL so a
+	// command from a cloned repo can't inject an extra systemd directive such
+	// as ExecStartPost=/bin/sh -c '...' onto its own line.
+	if config.ContainsUnitInjectionChars(w.Command) || config.ContainsUnitInjectionChars(w.ReloadCommand) {
+		return fmt.Errorf("worker %q has an invalid command: must not contain newline or NUL", workerName)
+	}
 	if w.Check != nil && !config.MatchesRule(sitePath, *w.Check) {
 		return fmt.Errorf(
 			"worker %q skipped: required dependency not satisfied (rule: %s)",

--- a/internal/cli/worker_preflight_test.go
+++ b/internal/cli/worker_preflight_test.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestWorkerStartPreflight_RejectsInjectionCommand(t *testing.T) {
+	// A worker command from .lerd.yaml custom_workers reaches the unit's
+	// ExecStart line; a newline would inject an extra systemd directive.
+	bad := config.FrameworkWorker{Command: "php artisan queue:work\nExecStartPost=/bin/sh -c pwned"}
+	if err := workerStartPreflight("/srv/x", "queue", bad); err == nil {
+		t.Fatal("expected rejection of a newline-bearing worker command")
+	}
+	badReload := config.FrameworkWorker{Command: "ok", ReloadCommand: "reload\nExecStart=evil"}
+	if err := workerStartPreflight("/srv/x", "queue", badReload); err == nil {
+		t.Fatal("expected rejection of a newline-bearing reload command")
+	}
+	// A clean command passes the injection check (no Check rules => nil).
+	if err := workerStartPreflight("/srv/x", "queue", config.FrameworkWorker{Command: "php artisan queue:work"}); err != nil {
+		t.Fatalf("clean command should pass: %v", err)
+	}
+}

--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -454,16 +454,48 @@ func LoadCustomServiceFromFile(path string) (*CustomService, error) {
 	return &svc, nil
 }
 
+// ContainsUnitInjectionChars reports whether s contains a newline, carriage
+// return, or NUL: characters that would let a value break out of its line in a
+// generated systemd unit or podman quadlet and inject an extra directive.
+func ContainsUnitInjectionChars(s string) bool {
+	return strings.ContainsAny(s, "\n\r\x00")
+}
+
 // SaveCustomService validates and writes a custom service config to disk.
 func SaveCustomService(svc *CustomService) error {
 	if !validServiceName.MatchString(svc.Name) {
 		return fmt.Errorf("invalid service name %q: must match [a-z0-9][a-z0-9-]*", svc.Name)
 	}
-	// Refuse env values with newlines/NUL so a malicious value can't inject
-	// extra systemd directives (e.g. Exec=) into the generated .container.
+	// Refuse newline/NUL in any field that reaches the generated .container
+	// quadlet, so a malicious value (e.g. from a cloned repo's inline service
+	// in .lerd.yaml) can't inject extra systemd directives such as
+	// Exec=/PodmanArgs=--privileged/Volume=/:/host onto their own line.
+	scalars := map[string]string{
+		"image": svc.Image, "exec": svc.Exec, "userns": svc.Userns,
+		"data_dir": svc.DataDir, "description": svc.Description,
+		"dashboard": svc.Dashboard, "connection_url": svc.ConnectionURL,
+	}
+	if svc.SiteInit != nil {
+		scalars["site_init.exec"] = svc.SiteInit.Exec
+	}
+	for label, v := range scalars {
+		if ContainsUnitInjectionChars(v) {
+			return fmt.Errorf("invalid %s for service %q: must not contain newline or NUL", label, svc.Name)
+		}
+	}
+	for _, p := range svc.Ports {
+		if ContainsUnitInjectionChars(p) {
+			return fmt.Errorf("invalid port %q for service %q: must not contain newline or NUL", p, svc.Name)
+		}
+	}
+	for _, f := range svc.Files {
+		if ContainsUnitInjectionChars(f.Target) || ContainsUnitInjectionChars(f.Mode) {
+			return fmt.Errorf("invalid file mount for service %q: must not contain newline or NUL", svc.Name)
+		}
+	}
 	for k, v := range svc.Environment {
-		if strings.ContainsAny(v, "\n\r\x00") {
-			return fmt.Errorf("invalid environment value for %q: must not contain newline or NUL", k)
+		if ContainsUnitInjectionChars(k) || ContainsUnitInjectionChars(v) {
+			return fmt.Errorf("invalid environment entry %q for service %q: must not contain newline or NUL", k, svc.Name)
 		}
 	}
 	dir := CustomServicesDir()

--- a/internal/config/custom_service_test.go
+++ b/internal/config/custom_service_test.go
@@ -56,6 +56,32 @@ func TestSaveCustomService_RejectsNewlineInEnv(t *testing.T) {
 	}
 }
 
+func TestSaveCustomService_RejectsNewlineInQuadletFields(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	// Each of these fields is written into the generated .container quadlet, so
+	// a newline must be rejected to stop directive injection (e.g. a repo's
+	// inline service smuggling PodmanArgs=--privileged / Volume=/:/host).
+	cases := []func(*CustomService){
+		func(s *CustomService) { s.Exec = "redis-server\nPodmanArgs=--privileged" },
+		func(s *CustomService) { s.Image = "alpine\nVolume=/:/host:rw" },
+		func(s *CustomService) { s.Userns = "keep-id\nPodmanArgs=--pid=host" },
+		func(s *CustomService) { s.DataDir = "/data\nExec=/bin/sh -c pwned" },
+		func(s *CustomService) { s.Description = "x\nExecStartPost=/bin/sh -c pwned" },
+		func(s *CustomService) { s.Ports = []string{"8080:80\nVolume=/:/host"} },
+	}
+	for i, mutate := range cases {
+		svc := &CustomService{Name: "evil", Image: "alpine"}
+		mutate(svc)
+		if err := SaveCustomService(svc); err == nil {
+			t.Errorf("case %d: expected rejection of a newline-bearing quadlet field", i)
+		}
+	}
+	// A clean service still saves.
+	if err := SaveCustomService(&CustomService{Name: "good", Image: "alpine", Exec: "redis-server"}); err != nil {
+		t.Errorf("clean service should save: %v", err)
+	}
+}
+
 func TestLoadCustomServiceFromFile_StripsLegacyFilesField(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "phpmyadmin.yaml")

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -169,6 +169,16 @@ type GlobalConfig struct {
 		// installs on. Toggled via `lerd notify on/off` and the tray.
 		Disabled bool `yaml:"disabled,omitempty" mapstructure:"disabled"`
 	} `yaml:"notifications,omitempty" mapstructure:"notifications"`
+	HostProxy struct {
+		// Disabled refuses to set up or start any host-proxy dev-server unit,
+		// for users who never want lerd supervising a process on the host.
+		// Inverted so the zero value keeps the feature available.
+		Disabled bool `yaml:"disabled,omitempty" mapstructure:"disabled"`
+		// SkipConfirmation runs a newly-linked host-proxy command without the
+		// interactive "start this on your host?" prompt. Off by default so a
+		// command from a cloned repo never runs unconfirmed.
+		SkipConfirmation bool `yaml:"skip_confirmation,omitempty" mapstructure:"skip_confirmation"`
+	} `yaml:"host_proxy,omitempty" mapstructure:"host_proxy"`
 	ParkedDirectories []string                 `yaml:"parked_directories" mapstructure:"parked_directories"`
 	Services          map[string]ServiceConfig `yaml:"services"           mapstructure:"services"`
 }

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -355,6 +355,15 @@ func LoadProjectConfig(dir string) (*ProjectConfig, error) {
 		cfg.Proxy = nil
 	}
 
+	// Neutralise a hostile webhook path at the source so it can never reach the
+	// Stripe listener unit's ExecStart line; readers fall back to the default.
+	if cfg.Stripe != nil && cfg.Stripe.Path != "" {
+		if _, err := ValidateStripeWebhookPath(cfg.Stripe.Path); err != nil {
+			fmt.Printf("[WARN] %s: %v, ignoring stripe path\n", path, err)
+			cfg.Stripe.Path = ""
+		}
+	}
+
 	projectConfigCacheMu.Lock()
 	projectConfigCache[path] = projectConfigCacheEntry{
 		cfg: &cfg, mtime: info.ModTime(), size: info.Size(),

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -330,6 +331,13 @@ func SaveSites(reg *SiteRegistry) error {
 
 // AddSite appends or updates a site in the registry.
 func AddSite(site Site) error {
+	// A site name flows into systemd unit file names and bodies (Description=,
+	// --env=LERD_SITE=, lerd-stripe-<name>, ...). Refuse newline/NUL (which
+	// would inject a unit directive) and slash (which would escape the unit
+	// path), closing the injection even for callers that bypass SiteNameAndDomain.
+	if ContainsUnitInjectionChars(site.Name) || strings.ContainsRune(site.Name, '/') {
+		return fmt.Errorf("invalid site name %q: must not contain newline, NUL, or slash", site.Name)
+	}
 	reg, err := LoadSites()
 	if err != nil {
 		return err

--- a/internal/config/site_test.go
+++ b/internal/config/site_test.go
@@ -34,6 +34,24 @@ func TestAddSite_Basic(t *testing.T) {
 	}
 }
 
+func TestAddSite_RejectsUnitInjectionNames(t *testing.T) {
+	setDataDir(t)
+	for _, name := range []string{
+		"app\nExecStartPre=/bin/sh -c evil",
+		"app\rfoo",
+		"a/b",
+		"app\x00",
+	} {
+		if err := AddSite(Site{Name: name, Domains: []string{"x.test"}, Path: "/srv/x"}); err == nil {
+			t.Errorf("AddSite(%q) should have been rejected", name)
+		}
+	}
+	// A clean name still works.
+	if err := AddSite(Site{Name: "myapp", Domains: []string{"myapp.test"}, Path: "/srv/myapp"}); err != nil {
+		t.Errorf("AddSite with clean name should succeed: %v", err)
+	}
+}
+
 func TestAddSite_UpdateExisting(t *testing.T) {
 	setDataDir(t)
 

--- a/internal/config/stripe.go
+++ b/internal/config/stripe.go
@@ -79,8 +79,8 @@ func ValidateStripeWebhookPath(path string) (string, error) {
 	if path == "" {
 		return "", nil
 	}
-	if strings.ContainsAny(path, " \t\r\n") {
-		return "", fmt.Errorf("invalid Stripe webhook path %q: must not contain whitespace", path)
+	if strings.ContainsAny(path, " \t\r\n\x00") {
+		return "", fmt.Errorf("invalid Stripe webhook path %q: must not contain whitespace or NUL", path)
 	}
 	return ensureLeadingSlash(path), nil
 }

--- a/internal/config/stripe.go
+++ b/internal/config/stripe.go
@@ -52,7 +52,13 @@ func ResolveStripeSecret(sitePath string) (envKey, value string) {
 // like "https://site.teststripe/webhook".
 func StripeWebhookPath(sitePath string) string {
 	if proj, err := LoadProjectConfig(sitePath); err == nil && proj.Stripe != nil && proj.Stripe.Path != "" {
-		return ensureLeadingSlash(proj.Stripe.Path)
+		// Validate on read, not just on write: a hand-edited or hostile
+		// .lerd.yaml can otherwise carry whitespace/newlines straight into the
+		// listener unit's ExecStart line, so reject those and fall back to the
+		// default rather than trusting the stored value.
+		if validated, err := ValidateStripeWebhookPath(proj.Stripe.Path); err == nil {
+			return validated
+		}
 	}
 	return DefaultStripeWebhookPath
 }

--- a/internal/config/stripe_test.go
+++ b/internal/config/stripe_test.go
@@ -63,6 +63,25 @@ func TestStripeWebhookPath_DefaultAndConfigured(t *testing.T) {
 	}
 }
 
+func TestStripeWebhookPath_RejectsInjectableStoredPath(t *testing.T) {
+	dir := t.TempDir()
+	// A hostile .lerd.yaml embeds a newline in the stored path to inject a
+	// systemd directive into the listener unit's ExecStart line. The read must
+	// reject it (fall back to default) and the load must neutralise it.
+	writeFile(t, filepath.Join(dir, ".lerd.yaml"),
+		"stripe:\n  path: \"/webhook\\nExecStartPre=/bin/sh -c evil\"\n")
+	if got := StripeWebhookPath(dir); got != DefaultStripeWebhookPath {
+		t.Errorf("StripeWebhookPath with injectable stored path = %q, want default %q", got, DefaultStripeWebhookPath)
+	}
+	proj, err := LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig: %v", err)
+	}
+	if proj.Stripe != nil && proj.Stripe.Path != "" {
+		t.Errorf("LoadProjectConfig left hostile stripe path in place: %q", proj.Stripe.Path)
+	}
+}
+
 func TestSetProjectStripe_PersistsAndRoundTrips(t *testing.T) {
 	dir := t.TempDir()
 	if err := SetProjectStripe(dir, "/webhooks/stripe", "STRIPE_SECRET_KEY"); err != nil {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1868,6 +1868,12 @@ func execQueueStart(args map[string]any) (any, *rpcError) {
 	if queue == "" {
 		queue = "default"
 	}
+	// The queue name is interpolated into the worker unit's ExecStart line;
+	// whitespace would add stray artisan arguments and a newline would inject a
+	// systemd directive, so reject both.
+	if strings.ContainsAny(queue, " \t\r\n") {
+		return toolErr("invalid queue name: must not contain whitespace"), nil
+	}
 	tries := intArg(args, "tries", 3)
 	timeout := intArg(args, "timeout", 60)
 
@@ -2124,6 +2130,12 @@ func execStripeListen(args map[string]any) (any, *rpcError) {
 		return toolErr("site not found: " + siteName), nil
 	}
 	apiKey := strArg(args, "api_key")
+	if apiKey != "" && strings.ContainsAny(apiKey, " \t\r\n") {
+		// Interpolated into the listener unit's ExecStart line alongside
+		// --forward-to; whitespace/newline would inject a stripe-cli argument
+		// or a systemd directive, the same vector the webhook path guards.
+		return toolErr("invalid api_key: must not contain whitespace"), nil
+	}
 	if apiKey == "" {
 		_, apiKey = config.ResolveStripeSecret(site.Path)
 	}
@@ -2134,6 +2146,15 @@ func execStripeListen(args map[string]any) (any, *rpcError) {
 	webhookPath := strArg(args, "webhook_path")
 	if webhookPath == "" {
 		webhookPath = config.StripeWebhookPath(site.Path)
+	} else {
+		// Validate as the CLI does: an unchecked path interpolates straight
+		// into the unit's ExecStart, where a space adds a stripe-cli argument
+		// and a newline ends the systemd directive.
+		validated, vErr := config.ValidateStripeWebhookPath(webhookPath)
+		if vErr != nil {
+			return toolErr(vErr.Error()), nil
+		}
+		webhookPath = validated
 	}
 	scheme := "http"
 	if site.Secured {

--- a/internal/mcp/stripe_test.go
+++ b/internal/mcp/stripe_test.go
@@ -1,0 +1,57 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// The MCP start path must reject an injectable webhook_path the same way the
+// CLI does; otherwise whitespace/newlines flow straight into the listener
+// unit's ExecStart line. The happy path writes a systemd unit, so only the
+// rejection (which returns before any side effect) is exercised here.
+func TestExecStripeListen_rejectsInjectableWebhookPath(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := config.AddSite(config.Site{Name: "acme", Path: t.TempDir(), Domains: []string{"acme.test"}}); err != nil {
+		t.Fatal(err)
+	}
+	res, _ := execStripeListen(map[string]any{
+		"site":         "acme",
+		"api_key":      "sk_test_x",
+		"webhook_path": "/x --skip-verify --forward-to https://evil",
+	})
+	if !mcpIsError(res) {
+		t.Fatalf("expected an error for a webhook_path with whitespace, got: %s", mcpText(t, res))
+	}
+}
+
+func TestExecStripeListen_rejectsInjectableApiKey(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := config.AddSite(config.Site{Name: "acme", Path: t.TempDir(), Domains: []string{"acme.test"}}); err != nil {
+		t.Fatal(err)
+	}
+	res, _ := execStripeListen(map[string]any{
+		"site":    "acme",
+		"api_key": "sk_x\nExecStartPost=/bin/sh -c evil",
+	})
+	if !mcpIsError(res) {
+		t.Fatalf("expected an error for an api_key with a newline, got: %s", mcpText(t, res))
+	}
+}
+
+func TestExecQueueStart_rejectsInjectableQueue(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := config.AddSite(config.Site{Name: "acme", Path: t.TempDir(), Domains: []string{"acme.test"}}); err != nil {
+		t.Fatal(err)
+	}
+	res, _ := execQueueStart(map[string]any{
+		"site":  "acme",
+		"queue": "default\nExecStartPost=/bin/sh -c evil",
+	})
+	if !mcpIsError(res) {
+		t.Fatalf("expected an error for a queue name with a newline, got: %s", mcpText(t, res))
+	}
+}

--- a/internal/siteops/naming.go
+++ b/internal/siteops/naming.go
@@ -37,11 +37,18 @@ func SiteNameAndDomain(dirName, tld string) (string, string) {
 		name = name[:m[0]]
 	}
 	name = strings.ReplaceAll(name, ".", "-")
+	// Strip characters that would be unsafe in a systemd unit name/body derived
+	// from this handle (newline/NUL inject a directive, slash escapes the path).
+	name = unsafeNameChars.ReplaceAllString(name, "")
 	if name == "" {
 		name = "site"
 	}
 	return name, name + "." + tld
 }
+
+// unsafeNameChars matches characters that must never reach a site handle used
+// in systemd unit names and bodies.
+var unsafeNameChars = regexp.MustCompile(`[\n\r\x00/]`)
 
 func stripGTLD(name string) (string, bool) {
 	for _, ext := range gTLDs {

--- a/internal/siteops/naming_test.go
+++ b/internal/siteops/naming_test.go
@@ -33,6 +33,12 @@ func TestSiteNameAndDomain(t *testing.T) {
 
 		// Unknown longer suffix is left alone.
 		{"backup.old", "test", "backup-old", "backup-old.test"},
+
+		// Characters that would inject a systemd directive or escape the unit
+		// path are stripped so the handle is safe to use in unit names/bodies.
+		{"app\nExecStartPre=evil", "test", "appexecstartpre=evil", "appexecstartpre=evil.test"},
+		{"a/b", "test", "ab", "ab.test"},
+		{"x\x00y", "test", "xy", "xy.test"},
 	}
 
 	for _, c := range cases {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -4726,7 +4726,9 @@ func handleSiteLink(w http.ResponseWriter, r *http.Request) {
 	// Run lerd link.
 	fmt.Fprintf(w, "data: → Linking site...\n\n")
 	flusher.Flush()
-	out, failed := streamCmd(self, "link")
+	// --yes: clicking Link in the UI is the explicit consent the host-proxy
+	// confirmation prompt would otherwise ask for at the (non-interactive) CLI.
+	out, failed := streamCmd(self, "link", "--yes")
 	if failed {
 		fmt.Fprintf(w, "event: done\ndata: %s\n\n", mustJSON(map[string]any{"ok": false, "error": "link failed: " + out}))
 		flusher.Flush()


### PR DESCRIPTION
This branch bundles the regression fixes, security hardening, and consent work that came out of reviewing everything since v1.23.1. It is three themed commits so the security commit can be reviewed and backported on its own.

Host-proxy regressions. db:move now rolls back the site's .env and .lerd.yaml on any failure after the repoint, so a restore that aborts midway leaves the site pointed back at the intact source instead of an empty target database. migrate rewrites a host-proxy worktree's vhost from the parent's proxy config rather than the worktree's own .lerd.yaml, which a worktree checkout usually lacks, so the new vhost is regenerated at the new TLD. pause now stops a host-proxy site's worktree dev servers and unpause restores their vhosts and dev servers, which previously only happened for PHP worktrees, so a paused host-proxy worktree no longer stays stuck on the landing page.

Systemd and quadlet injection hardening. lerd writes systemd units and podman quadlets by interpolating values into a line-delimited unit body, so a newline in an attacker-authored value could inject a directive that runs on unit start. Custom service definitions now reject newline, carriage return, and NUL in every field that reaches the quadlet (image, exec, userns, data_dir, description, ports, file mounts, site_init exec, and environment keys), closing a path where an inline service could smuggle a privileged container or a host-root volume. Worker commands from custom_workers are rejected if they carry a newline, the Stripe webhook path is now validated on read and neutralised at load (not only on write), site names cannot carry a newline, NUL, or slash into a unit, and the MCP queue and api_key arguments are rejected when they contain whitespace.

Consent gates. A host-proxy dev server and a brand-new inline service both run commands that can come from a committed .lerd.yaml, so lerd no longer supervises them without the user agreeing. Linking a host-proxy project whose command was not chosen through the wizard shows the exact command and asks first, while a re-link with the same approved command, the wizard, the dashboard, or lerd link --yes count as consent. Boot and lerd start bind to the command approved at link time and refuse to auto-run a drifted command. A new inline service is shown with its image, command, and ports and confirmed before install. Two global settings, host_proxy.disabled and host_proxy.skip_confirmation, tune this and default to the safe value. The consent model is documented under usage/host-proxy.md and configuration.md.
