### PR TITLE
docs: add Discord server link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20WSL2%20(beta)-lightgrey)]()
 [![Docs](https://img.shields.io/badge/docs-geodro.github.io%2Flerd-blue)](https://geodro.github.io/lerd/)
 [![Reddit](https://img.shields.io/badge/Reddit-r%2Flerd-ff2d20?logo=reddit)](https://reddit.com/r/lerd)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/ej33c5N9s)
 
 ![Lerd dashboard tour](docs/assets/screenshots/tour.gif)
 


### PR DESCRIPTION
Adds a Discord badge to the README badge row, right after the Reddit one, linking to our community server. Heads up that the invite code is 9 characters rather than the usual 10, so worth confirming it's a valid permanent invite so the link doesn't expire down the line.