### PR TITLE
Add Google Antigravity support and isolate the Claude CLI in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ If you're a PHP developer on Linux and want frictionless local development — a
 - ⚒️ **Worker self-heal**, failed queue, schedule, horizon, reverb, and stripe workers are surfaced everywhere (CLI, dashboard banner, TUI, MCP) and recovered with one click or `lerd worker heal`
 - 📋 **Live logs** for PHP-FPM, Queue, Schedule, Reverb, per site
 - 🔒 **Rootless & daemonless** - Podman-native, no Docker required, dual-stack IPv4 + IPv6
-- 🤖 **MCP server** - let AI assistants (Claude Code, Cursor, JetBrains Junie, Codex CLI, Gemini CLI, GitHub Copilot, Windsurf) manage your environment directly
+- 🤖 **MCP server** - let AI assistants (Claude Code, Cursor, JetBrains Junie, Codex CLI, Gemini CLI, GitHub Copilot, Google Antigravity, Windsurf) manage your environment directly
 - 🧩 **Framework store** - community definitions for Laravel, Symfony, WordPress, Drupal, CakePHP, Statamic with versioned auto-detection
 - ⚡ **Framework-agnostic** workers, env setup, and nginx proxy — driven by YAML definitions, not hardcoded
 
 ## AI Integration (MCP)
 
-Lerd ships a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server. Connect it to Claude Code, Cursor, JetBrains Junie, Codex CLI, Gemini CLI, GitHub Copilot, Windsurf, or any MCP-compatible AI assistant and manage your dev environment without leaving the chat.
+Lerd ships a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server. Connect it to Claude Code, Cursor, JetBrains Junie, Codex CLI, Gemini CLI, GitHub Copilot, Google Antigravity, Windsurf, or any MCP-compatible AI assistant and manage your dev environment without leaving the chat.
 
 ```bash
 lerd mcp:enable-global   # register once, works in every project
@@ -56,14 +56,14 @@ Then just ask:
 
 ```
 You: set up the project I just cloned
-AI:  → site_link()
-     → composer install
-     → env_setup()    # detects MySQL + Redis, starts them, creates DB, generates APP_KEY
-     → setup()        # storage:link + migrate for Laravel, doctrine:migrations:migrate for Symfony
+AI:  → site(action: "link")
+     → exec(action: "composer", args: ["install"])
+     → env(action: "setup")        # detects MySQL + Redis, starts them, creates DB, generates APP_KEY
+     → framework(action: "setup")  # storage:link + migrate for Laravel, doctrine:migrations:migrate for Symfony
      ✓  myapp → https://myapp.test ready
 ```
 
-~50 tools available: scaffold new projects, run migrations, manage services, toggle workers, tail logs, enable Xdebug, manage databases, manage PHP extensions, park directories, switch runtimes between PHP-FPM and FrankenPHP, and more, all from your AI assistant.
+Ten grouped tools, each driven by an `action`: `site`, `service`, `db`, `env`, `runtime`, `worker`, `exec`, `framework`, `diag`, and `worktree`. Scaffold projects, run migrations, manage services, toggle workers, tail logs, enable Xdebug, manage databases and PHP extensions, park directories, switch runtimes between PHP-FPM and FrankenPHP, and more, all from your AI assistant.
 
 📖 [MCP documentation](https://geodro.github.io/lerd/features/mcp/)
 

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -2,7 +2,7 @@
 
 Lerd ships a [Model Context Protocol](https://modelcontextprotocol.io/) server, letting AI assistants manage your dev environment directly: run migrations, start services, toggle queue workers, and inspect logs without leaving the chat.
 
-Supported assistants: **Claude Code, Cursor, JetBrains Junie, Codex CLI, Gemini CLI, GitHub Copilot (VS Code), Windsurf**, and any other MCP-compatible tool.
+Supported assistants: **Claude Code, Cursor, JetBrains Junie, Codex CLI, Gemini CLI, GitHub Copilot (VS Code), Google Antigravity, Windsurf**, and any other MCP-compatible tool.
 
 ---
 
@@ -31,6 +31,7 @@ MCP server registration:
 | Gemini CLI | `~/.gemini/settings.json` |
 | Codex CLI | `~/.codex/config.toml` |
 | GitHub Copilot (VS Code) | `~/.config/Code/User/mcp.json` |
+| Google Antigravity | `~/.gemini/config/mcp_config.json` |
 
 Context / instructions files:
 
@@ -47,6 +48,8 @@ All clients share a single canonical tool reference, so the guidance never drift
 > **Claude Code** is registered via its own `claude mcp add` CLI rather than by editing `~/.claude.json` directly, since that file holds all of Claude's user state.
 
 > **GitHub Copilot** uses VS Code's `servers` key (each entry typed `stdio`), which differs from the `mcpServers` key the other clients use. Its instructions file (`.github/copilot-instructions.md`) is project-scoped only.
+
+> **Google Antigravity** registers at `~/.gemini/config/mcp_config.json` (its project-scoped MCP config is not honoured, so it is global only). It auto-loads `GEMINI.md` and `AGENTS.md`, which the Gemini and Codex entries already write, so no separate Antigravity context file is needed.
 
 > **During `lerd install`:** If Claude Code is detected, you'll be prompted to run this automatically.
 

--- a/docs/getting-started/laravel.md
+++ b/docs/getting-started/laravel.md
@@ -7,7 +7,7 @@ You've already run `lerd install` once on this machine. If not, see [Installatio
 :::
 
 ::: tip Drive it from your AI assistant
-Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Junie, Codex, Gemini, Copilot, Windsurf) can call every command below through the grouped MCP tools: `framework` `action: "project_new"`, `site` `action: "link"`, `env` `action: "setup"`, `framework` `action: "setup"`, `db` `action: "create"`, `site` `action: "tls_enable"`, `worker`, etc. See [AI Integration](../features/mcp.md).
+Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Junie, Codex, Gemini, Copilot, Antigravity, Windsurf) can call every command below through the grouped MCP tools: `framework` `action: "project_new"`, `site` `action: "link"`, `env` `action: "setup"`, `framework` `action: "setup"`, `db` `action: "create"`, `site` `action: "tls_enable"`, `worker`, etc. See [AI Integration](../features/mcp.md).
 :::
 
 ---

--- a/docs/getting-started/symfony.md
+++ b/docs/getting-started/symfony.md
@@ -7,7 +7,7 @@ You've already run `lerd install` once on this machine. If not, see [Installatio
 :::
 
 ::: tip Drive it from your AI assistant
-Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Junie, Codex, Gemini, Copilot, Windsurf) can call every command below through the grouped MCP tools: `framework` `action: "project_new"`, `site` `action: "link"`, `env` `action: "setup"`, `framework` `action: "setup"`, `db` `action: "create"`, `site` `action: "tls_enable"`, `worker`, etc. See [AI Integration](../features/mcp.md).
+Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Junie, Codex, Gemini, Copilot, Antigravity, Windsurf) can call every command below through the grouped MCP tools: `framework` `action: "project_new"`, `site` `action: "link"`, `env` `action: "setup"`, `framework` `action: "setup"`, `db` `action: "create"`, `site` `action: "tls_enable"`, `worker`, etc. See [AI Integration](../features/mcp.md).
 :::
 
 ---

--- a/docs/getting-started/wordpress.md
+++ b/docs/getting-started/wordpress.md
@@ -7,7 +7,7 @@ You've already run `lerd install` once on this machine. If not, see [Installatio
 :::
 
 ::: tip Drive it from your AI assistant
-Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Junie, Codex, Gemini, Copilot, Windsurf) can call every command below through the grouped MCP tools: `site` `action: "link"`, `env` `action: "setup"`, `framework` `action: "setup"`, `db` `action: "create"`, `site` `action: "tls_enable"`, etc. See [AI Integration](../features/mcp.md).
+Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Junie, Codex, Gemini, Copilot, Antigravity, Windsurf) can call every command below through the grouped MCP tools: `site` `action: "link"`, `env` `action: "setup"`, `framework` `action: "setup"`, `db` `action: "create"`, `site` `action: "tls_enable"`, etc. See [AI Integration](../features/mcp.md).
 :::
 
 ---

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -275,7 +275,7 @@ Requires [Laravel Broadcasting](https://laravel.com/docs/13.x/broadcasting) with
 
 | Command | Description |
 |---|---|
-| `lerd mcp:enable-global` | Register lerd MCP at user scope across every supported assistant (Claude Code, Cursor, Junie, Codex, Gemini, Copilot, Windsurf), available in every session regardless of directory |
+| `lerd mcp:enable-global` | Register lerd MCP at user scope across every supported assistant (Claude Code, Cursor, Junie, Codex, Gemini, Copilot, Antigravity, Windsurf), available in every session regardless of directory |
 | `lerd mcp:inject` | Inject the lerd MCP config and AI skill files into the current project |
 | `lerd mcp:inject --path <dir>` | Inject into a specific project directory |
 

--- a/internal/cli/aiclients.go
+++ b/internal/cli/aiclients.go
@@ -141,6 +141,15 @@ var aiClients = []aiClient{
 			Content: func() string { return lerdReference },
 		}},
 	},
+	{
+		Name: "antigravity",
+		// Antigravity reads only the HOME-level MCP config; its project scope is
+		// a known no-op, so register globally only. No Contexts: it auto-loads
+		// GEMINI.md and AGENTS.md, which the gemini and codex entries already write.
+		GlobalMCP: filepath.Join(".gemini", "config", "mcp_config.json"),
+		MCPFormat: fmtJSONMcpServers,
+		ServerKey: "mcpServers",
+	},
 }
 
 // lerdJSONEntry builds the JSON MCP server entry. sitePath, when non-empty, is

--- a/internal/cli/aiclients_test.go
+++ b/internal/cli/aiclients_test.go
@@ -10,6 +10,15 @@ import (
 	toml "github.com/pelletier/go-toml/v2"
 )
 
+// TestMain stubs the Claude Code CLI seam so the cli test suite never mutates the
+// developer's real `claude mcp` registration (RemoveGlobalAISkills and the
+// enable-global path otherwise shell out to the live binary).
+func TestMain(m *testing.M) {
+	claudeAvailable = func() bool { return false }
+	claudeMCP = func(args ...string) ([]byte, error) { return nil, nil }
+	os.Exit(m.Run())
+}
+
 // TestCopilotUsesServersKey verifies the VS Code config quirk: the top-level key
 // is "servers" (not "mcpServers") and each entry carries "type":"stdio".
 func TestCopilotUsesServersKey(t *testing.T) {
@@ -58,6 +67,44 @@ func TestGeminiUsesMcpServersKey(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"mcpServers"`) {
 		t.Errorf("gemini settings.json should use mcpServers key: %s", data)
+	}
+}
+
+// TestAntigravityGlobalConfig confirms Antigravity registers at its HOME-level
+// path with the mcpServers key and no stdio type field, and that it has no
+// project-scoped MCP config (its project scope is a no-op).
+func TestAntigravityGlobalConfig(t *testing.T) {
+	home := t.TempDir()
+	var ag aiClient
+	for _, c := range aiClients {
+		if c.Name == "antigravity" {
+			ag = c
+		}
+	}
+	if ag.Name == "" {
+		t.Fatal("antigravity client not registered")
+	}
+	if ag.ProjectMCP != "" {
+		t.Errorf("antigravity should be global-only, got ProjectMCP=%q", ag.ProjectMCP)
+	}
+	if err := writeClientMCP(filepath.Join(home, ag.GlobalMCP), ag, ""); err != nil {
+		t.Fatalf("writeClientMCP: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".gemini", "config", "mcp_config.json"))
+	if err != nil {
+		t.Fatalf("read antigravity config: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	servers, _ := cfg["mcpServers"].(map[string]any)
+	lerd, ok := servers["lerd"].(map[string]any)
+	if !ok {
+		t.Fatalf("mcpServers.lerd missing: %s", data)
+	}
+	if _, hasType := lerd["type"]; hasType {
+		t.Errorf("antigravity entry should not carry a type field: %s", data)
 	}
 }
 
@@ -194,6 +241,7 @@ func TestWriteGlobalMCPConfigs_writesFileBackedClients(t *testing.T) {
 		filepath.Join(".gemini", "settings.json"),
 		filepath.Join(".codex", "config.toml"),
 		filepath.Join(".config", "Code", "User", "mcp.json"),
+		filepath.Join(".gemini", "config", "mcp_config.json"),
 	} {
 		if _, err := os.Stat(filepath.Join(home, rel)); err != nil {
 			t.Errorf("global MCP config %s missing: %v", rel, err)

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -180,6 +180,7 @@ This command updates:
   ~/.gemini/settings.json          Gemini CLI global MCP config
   ~/.codex/config.toml             Codex CLI global MCP config
   ~/.config/Code/User/mcp.json     GitHub Copilot (VS Code) global MCP config
+  ~/.gemini/config/mcp_config.json Google Antigravity global MCP config
   ~/.claude/skills/lerd/SKILL.md   Claude Code user-scope skill
   ~/.cursor/rules/lerd.mdc         Cursor user-scope rules
   ~/.junie/guidelines.md           JetBrains Junie user-scope guidelines
@@ -226,8 +227,8 @@ func writeGlobalMCPConfigs(home string, verbose bool) error {
 	for _, c := range aiClients {
 		if c.GlobalViaCLI {
 			// Try remove first for idempotent re-registration, then add.
-			_ = exec.Command("claude", "mcp", "remove", "--scope", "user", "lerd").Run()
-			out, err := exec.Command("claude", "mcp", "add", "--scope", "user", "lerd", "--", "lerd", "mcp").CombinedOutput()
+			_, _ = claudeMCP("remove", "--scope", "user", "lerd")
+			out, err := claudeMCP("add", "--scope", "user", "lerd", "--", "lerd", "mcp")
 			if err != nil {
 				fmt.Printf("  warning: could not register with Claude Code (%v): %s\n", err, strings.TrimSpace(string(out)))
 				fmt.Println("  Run manually: claude mcp add --scope user lerd -- lerd mcp")
@@ -284,15 +285,30 @@ func writeGlobalContexts(home string, verbose, createMissing bool) error {
 	return nil
 }
 
+// claudeAvailable and claudeMCP are the single seam for the Claude Code CLI.
+// Claude global MCP registration goes through its own CLI (we never edit
+// ~/.claude.json directly), and these vars let tests stub it so the suite never
+// mutates the developer's real `claude mcp` registration.
+var (
+	claudeAvailable = func() bool {
+		_, err := exec.LookPath("claude")
+		return err == nil
+	}
+	claudeMCP = func(args ...string) ([]byte, error) {
+		return exec.Command("claude", append([]string{"mcp"}, args...)...).CombinedOutput()
+	}
+)
+
 // IsMCPGloballyRegistered reports whether lerd is registered with Claude Code.
 // Uses `claude mcp get lerd` which returns exit 0 when the server is known and
 // exit 1 otherwise. The older `claude mcp list --scope user` flag form breaks
 // on newer Claude CLI releases.
 func IsMCPGloballyRegistered() bool {
-	if _, err := exec.LookPath("claude"); err != nil {
+	if !claudeAvailable() {
 		return false
 	}
-	return exec.Command("claude", "mcp", "get", "lerd").Run() == nil
+	_, err := claudeMCP("get", "lerd")
+	return err == nil
 }
 
 // ensureClaudeMCPRegistered adds lerd to Claude Code at user scope only when
@@ -300,13 +316,13 @@ func IsMCPGloballyRegistered() bool {
 // a failing add can't leave the user unregistered. No-op when claude isn't
 // installed or lerd is already registered.
 func ensureClaudeMCPRegistered() {
-	if _, err := exec.LookPath("claude"); err != nil {
+	if !claudeAvailable() {
 		return
 	}
-	if exec.Command("claude", "mcp", "get", "lerd").Run() == nil {
+	if _, err := claudeMCP("get", "lerd"); err == nil {
 		return
 	}
-	if err := exec.Command("claude", "mcp", "add", "-s", "user", "lerd", "--", "lerd", "mcp").Run(); err != nil {
+	if _, err := claudeMCP("add", "-s", "user", "lerd", "--", "lerd", "mcp"); err != nil {
 		fmt.Printf("  [WARN] could not register lerd with Claude Code: %v\n", err)
 		fmt.Println("  Run manually: claude mcp add -s user lerd -- lerd mcp")
 	}
@@ -399,7 +415,7 @@ func RemoveGlobalAISkills(home string, verbose bool) error {
 
 	for _, c := range aiClients {
 		if c.GlobalViaCLI {
-			if err := exec.Command("claude", "mcp", "remove", "--scope", "user", "lerd").Run(); err == nil {
+			if _, err := claudeMCP("remove", "--scope", "user", "lerd"); err == nil {
 				log("  removed Claude Code user-scope MCP registration")
 			}
 		}


### PR DESCRIPTION
This adds Google Antigravity as a single entry in the client registry. Antigravity registers globally at ~/.gemini/config/mcp_config.json under the mcpServers key, with no type field. It is global only, because its project scoped MCP config is a known no-op, and it needs no separate context file since it auto loads GEMINI.md and AGENTS.md, which the Gemini and Codex entries already write. That keeps the supported set at Claude Code, Cursor, Junie, Codex, Gemini, Copilot, Antigravity, and Windsurf.

While wiring it up, a full test run turned out to be shelling out to the real claude mcp CLI and unregistering lerd from the developer's own Claude, because RemoveGlobalAISkills and the enable-global path invoke the binary directly with no seam. All five claude calls now route through a claudeAvailable and claudeMCP pair of package vars, and a TestMain stubs them so the cli suite is hermetic and never mutates a real registration.

The docs list Antigravity across the MCP page, the README, the getting started intros, and the commands reference. The README MCP example was also brought up to date with the grouped tool calls, since it had kept showing the old flat tool names from before the consolidation.