### PR TITLE
Surface community links, fix orphaned docs pages, and refresh the homepage

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -102,6 +102,7 @@ export default defineConfig({
             { text: 'PHP', link: '/usage/php' },
             { text: 'Node', link: '/usage/node' },
             { text: 'Custom Containers', link: '/usage/custom-containers' },
+            { text: 'Host-Proxy Sites', link: '/usage/host-proxy' },
             { text: 'Nginx Overrides', link: '/usage/nginx-overrides' },
           ],
         },
@@ -120,6 +121,7 @@ export default defineConfig({
           items: [
             { text: 'Frameworks', link: '/usage/frameworks' },
             { text: 'Framework Workers', link: '/usage/framework-workers' },
+            { text: 'Framework Commands', link: '/features/commands' },
             { text: 'Framework Definitions', link: '/usage/framework-definitions' },
             { text: 'Queue Workers', link: '/usage/queue-workers' },
             { text: 'Worker Runtime (macOS)', link: '/usage/worker-runtime' },
@@ -235,6 +237,13 @@ export default defineConfig({
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/geodro/lerd' },
+      { icon: 'discord', link: 'https://discord.gg/ej33c5N9s' },
+      {
+        icon: {
+          svg: '<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Reddit</title><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>',
+        },
+        link: 'https://reddit.com/r/lerd',
+      },
     ],
 
     footer: {

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ features:
     details: One global toggle and every PHP-FPM request becomes a flame graph viewable in the dashboard's Profiler view. No FPM restart, no code changes, `lerd profile run` for one-shot CLI commands.
   - icon: 🤖
     title: AI integration (MCP)
-    details: Built-in Model Context Protocol server. Claude Code, Cursor, Windsurf, and Junie scaffold projects and run migrations straight from chat.
+    details: Built-in Model Context Protocol server with ten grouped tools. Claude Code, Cursor, Codex, Gemini, GitHub Copilot, Google Antigravity, JetBrains Junie, and Windsurf scaffold projects and run migrations straight from chat.
   - icon: ⚡
     title: FrankenPHP runtime
     details: Per-site FrankenPHP as an alternative to shared PHP-FPM, with Laravel Octane and Symfony Runtime worker mode wired up out of the box.
@@ -60,5 +60,8 @@ features:
     details: YAML framework definitions for Laravel, Symfony, WordPress, Drupal, CakePHP, and Statamic, auto-detected and applied on `lerd link`.
   - icon: 🧱
     title: Polyglot sites
-    details: Drop a `Containerfile.lerd` to run Node, Python, Ruby, or Go sites alongside your PHP ones, with the same HTTPS, DNS, and worker pipeline.
+    details: Drop a `Containerfile.lerd` to run Node, Python, Ruby, or Go sites alongside your PHP ones, or point a host-proxy site at a dev server running on your host. Same HTTPS, DNS, and worker pipeline either way.
+  - icon: 🔗
+    title: Site groups
+    details: Group related sites so a main owns a base domain and the rest occupy its subdomains, with optional shared databases, for multi-app and multi-tenant setups.
 ---


### PR DESCRIPTION
This adds Discord and Reddit to the docs site navbar social links, so the docs reach the community the README badges already point to. Discord uses VitePress's built-in icon; Reddit uses a custom inline SVG since there's no built-in one.

It also links two pages that existed but were unreachable from the sidebar: the host-proxy sites page now sits under Sites and Runtimes, and the framework commands page (the dashboard Commands dropdown and lerd run) under Frameworks and Workers. An orphan sweep over usage, features, getting-started, and reference now comes back clean.

Finally it refreshes the homepage for what landed since the last release. The AI integration card was stale, naming only four clients and no grouped tools; it now names all eight assistants and the ten grouped tools. The polyglot card mentions host-proxy sites alongside Containerfile sites, and a new site groups card covers grouping related sites under one base domain.