### PR TITLE
Restore the sites overview dashboard (lost from main)

### DIFF
--- a/docs/features/web-ui.md
+++ b/docs/features/web-ui.md
@@ -83,6 +83,8 @@ The middle panel lists all registered projects. Active sites show a status dot (
 
 A **sort button** floats in the bottom-right corner of the list; clicking it opens a small menu with **Most used** (sites with the most recent app-log activity float to the top), **Alphabetical** (by domain), and **Newest first** (reverses the order sites were linked in). The choice is remembered across reloads. A drag handle appears on a site row when you hover it; grab it to drag the row into a new position, with the dragged row and the rest of the list animating smoothly into place. Dragging switches the list into a manual order seeded from whatever you were looking at, so there's no separate "manual" mode to pick. The new order is saved to `sites.yaml` and pushed live to any other open tab. Grouped subdomains always travel with their main site, and the paused section stays at the bottom.
 
+Before you pick a site the detail panel shows a **sites overview** instead of an empty prompt. The header carries an Overview line with the running-vs-total count, a paused tally, and a failing-workers indicator. Below it your sites are laid out as click-through tiles grouped by framework (Laravel, WordPress, and so on, with anything unrecognised folded into a trailing Other group), and a final Paused group for any suspended sites. Each tile shows the site favicon or status dot, the domain, a framework and PHP/Node subline, a TLS lock, a worktree marker, the same running-worker dots as the list, and an open-in-browser shortcut. A **Link new site** action sits at the bottom in loopback mode.
+
 ![Site detail with the Overview tab open](/assets/screenshots/site-detail-overview.png)
 
 Selecting a site opens the detail panel with:

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -204,6 +204,8 @@
   "sites_empty": "Noch keine Sites",
   "sites_emptyHint": "Führe {cmd} aus",
   "sites_select": "Site auswählen",
+  "sites_dash_overview": "Übersicht",
+  "sites_dash_otherFramework": "Andere",
   "sites_paused": "Pausiert",
   "sites_pausedDetail_title": "Diese Site ist pausiert",
   "sites_pausedDetail_hint": "Nginx liefert {domain} nicht aus, solange die Site pausiert ist. Fortsetzen, um sie wieder online zu bringen.",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -189,6 +189,8 @@
   "sites_empty": "No sites yet",
   "sites_emptyHint": "Run {cmd}",
   "sites_select": "Select a site",
+  "sites_dash_overview": "Overview",
+  "sites_dash_otherFramework": "Other",
   "sites_paused": "Paused",
   "sites_pausedDetail_title": "This site is paused",
   "sites_pausedDetail_hint": "Nginx is not serving {domain} while it's paused. Resume to bring it back online.",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -204,6 +204,8 @@
   "sites_empty": "Aún no hay sitios",
   "sites_emptyHint": "Ejecuta {cmd}",
   "sites_select": "Selecciona un sitio",
+  "sites_dash_overview": "Resumen",
+  "sites_dash_otherFramework": "Otros",
   "sites_paused": "Pausado",
   "sites_pausedDetail_title": "Este sitio está pausado",
   "sites_pausedDetail_hint": "Nginx no está sirviendo {domain} mientras está pausado. Reanúdalo para volver a ponerlo en línea.",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -204,6 +204,8 @@
   "sites_empty": "Aucun site pour l'instant",
   "sites_emptyHint": "Exécutez {cmd}",
   "sites_select": "Sélectionnez un site",
+  "sites_dash_overview": "Aperçu",
+  "sites_dash_otherFramework": "Autres",
   "sites_paused": "En pause",
   "sites_pausedDetail_title": "Ce site est en pause",
   "sites_pausedDetail_hint": "Nginx ne sert pas {domain} tant que le site est en pause. Reprenez-le pour le remettre en ligne.",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -204,6 +204,8 @@
   "sites_empty": "Belum ada situs",
   "sites_emptyHint": "Jalankan {cmd}",
   "sites_select": "Pilih sebuah situs",
+  "sites_dash_overview": "Ikhtisar",
+  "sites_dash_otherFramework": "Lainnya",
   "sites_paused": "Dijeda",
   "sites_pausedDetail_title": "Situs ini dijeda",
   "sites_pausedDetail_hint": "Nginx tidak menyajikan {domain} saat dijeda. Lanjutkan untuk membuatnya online kembali.",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -204,6 +204,8 @@
   "sites_empty": "Nog geen sites",
   "sites_emptyHint": "Voer {cmd} uit",
   "sites_select": "Selecteer een site",
+  "sites_dash_overview": "Overzicht",
+  "sites_dash_otherFramework": "Overige",
   "sites_paused": "Gepauzeerd",
   "sites_pausedDetail_title": "Deze site is gepauzeerd",
   "sites_pausedDetail_hint": "Nginx serveert {domain} niet zolang de site gepauzeerd is. Hervat om hem weer online te brengen.",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -204,6 +204,8 @@
   "sites_empty": "Nenhum site ainda",
   "sites_emptyHint": "Execute {cmd}",
   "sites_select": "Selecione um site",
+  "sites_dash_overview": "Visão geral",
+  "sites_dash_otherFramework": "Outros",
   "sites_paused": "Pausado",
   "sites_pausedDetail_title": "Este site está pausado",
   "sites_pausedDetail_hint": "O nginx não está a servir {domain} enquanto estiver pausado. Retome para voltar a colocá-lo online.",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -204,6 +204,8 @@
   "sites_empty": "Henüz site yok",
   "sites_emptyHint": "Şunu çalıştırın: {cmd}",
   "sites_select": "Bir site seçin",
+  "sites_dash_overview": "Genel bakış",
+  "sites_dash_otherFramework": "Diğer",
   "sites_paused": "Duraklatıldı",
   "sites_pausedDetail_title": "Bu site duraklatıldı",
   "sites_pausedDetail_hint": "Site duraklatıldığı sürece Nginx {domain} adresini sunmuyor. Tekrar çevrimiçi yapmak için devam ettirin.",

--- a/internal/ui/web/src/components/DashboardHeader.svelte
+++ b/internal/ui/web/src/components/DashboardHeader.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    title: string;
+    stats?: Snippet;
+  }
+  let { title, stats }: Props = $props();
+</script>
+
+<div class="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-3 border-b border-gray-100 dark:border-lerd-border">
+  <h1 class="text-base font-semibold text-gray-900 dark:text-white">{title}</h1>
+  {#if stats}
+    <div class="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
+      {@render stats()}
+    </div>
+  {/if}
+</div>

--- a/internal/ui/web/src/components/DashboardSection.svelte
+++ b/internal/ui/web/src/components/DashboardSection.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    label: string;
+    sub?: boolean;
+    children: Snippet;
+  }
+  let { label, sub = false, children }: Props = $props();
+</script>
+
+<section class={sub ? 'space-y-2' : 'space-y-2.5'}>
+  {#if sub}
+    <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">{label}</h3>
+  {:else}
+    <h2 class="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">{label}</h2>
+  {/if}
+  <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-2">
+    {@render children()}
+  </div>
+</section>

--- a/internal/ui/web/src/components/SiteIcon.svelte
+++ b/internal/ui/web/src/components/SiteIcon.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import StatusDot from '$components/StatusDot.svelte';
+  import { apiBase } from '$lib/api';
+  import type { Site } from '$stores/sites';
+
+  interface Props {
+    site: Site;
+    size?: string;
+  }
+  let { site, size = 'w-4 h-4' }: Props = $props();
+</script>
+
+{#if site.custom_container}
+  <svg class="{size} {site.fpm_running ? 'text-violet-500' : 'text-gray-300 dark:text-gray-600'}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
+  </svg>
+{:else if site.has_favicon}
+  <img src={apiBase + '/api/sites/' + site.domain + '/favicon'} class="{size} rounded-xs object-contain" loading="lazy" alt="" />
+{:else}
+  <StatusDot color={site.fpm_running ? 'green' : 'gray'} />
+{/if}

--- a/internal/ui/web/src/components/SiteIndicators.svelte
+++ b/internal/ui/web/src/components/SiteIndicators.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import StatusDot from '$components/StatusDot.svelte';
+  import { runningWorkerColors, siteWorkerFailing, type Site } from '$stores/sites';
+  import { m } from '../paraglide/messages.js';
+
+  interface Props {
+    site: Site;
+  }
+  let { site }: Props = $props();
+
+  const dots = $derived(runningWorkerColors(site));
+</script>
+
+{#if site.worktrees && site.worktrees.length > 0}
+  <span title={m.sites_gitWorktrees()} class="inline-flex shrink-0">
+    <svg class="w-3 h-3 text-violet-400" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+      <path d="M6 3v12M15 6a3 3 0 1 0 6 0a3 3 0 1 0-6 0M3 18a3 3 0 1 0 6 0a3 3 0 1 0-6 0M18 9a9 9 0 0 1-9 9"/>
+    </svg>
+  </span>
+{/if}
+{#if siteWorkerFailing(site)}
+  <span title={m.sites_workerFailing()} class="shrink-0"><StatusDot color="red" size="xs" pulse /></span>
+{/if}
+{#each dots as c, i (i + ':' + c)}
+  <StatusDot color={c} size="xs" />
+{/each}

--- a/internal/ui/web/src/stores/sites.ts
+++ b/internal/ui/web/src/stores/sites.ts
@@ -146,6 +146,21 @@ export function siteWorkerFailing(s: Site): boolean {
   );
 }
 
+export type WorkerDotColor = 'amber' | 'violet' | 'emerald' | 'sky' | 'indigo';
+
+// Colors for each running worker, used as little status dots in list rows and
+// dashboard tiles. Kept here so the row and tile views never drift apart.
+export function runningWorkerColors(s: Site): WorkerDotColor[] {
+  const dots: WorkerDotColor[] = [];
+  if (s.queue_running) dots.push('amber');
+  if (s.horizon_running) dots.push('amber');
+  if (s.stripe_running) dots.push('violet');
+  if (s.schedule_running) dots.push('emerald');
+  if (s.reverb_running) dots.push('sky');
+  for (const w of s.framework_workers || []) if (w.running) dots.push('indigo');
+  return dots;
+}
+
 export function openSiteInBrowser(s: Site, branch: string = '') {
   const target = activeWorktreeDomain(s, branch);
   const useTLS = Boolean(s.tls);

--- a/internal/ui/web/src/tabs/SitesDetail.svelte
+++ b/internal/ui/web/src/tabs/SitesDetail.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import { routeRest } from '$stores/route';
   import { sites } from '$stores/sites';
-  import EmptyState from '$components/EmptyState.svelte';
   import SiteDetail from './sites/SiteDetail.svelte';
-  import { m } from '../paraglide/messages.js';
+  import SitesDashboard from './sites/SitesDashboard.svelte';
 
   // routeRest may be "<domain>" or "<domain>/<subtab>" (e.g. dump notification
   // deep-links into the per-site dumps view). The sub-tab is handled inside
@@ -18,7 +17,5 @@
     <SiteDetail {site} />
   {/key}
 {:else}
-  <div class="flex-1 flex items-center justify-center">
-    <EmptyState title={m.sites_select()} />
-  </div>
+  <SitesDashboard />
 {/if}

--- a/internal/ui/web/src/tabs/SitesTab.svelte
+++ b/internal/ui/web/src/tabs/SitesTab.svelte
@@ -5,14 +5,14 @@
   import ProfilerToggle from '$components/ProfilerToggle.svelte';
   import EmptyState from '$components/EmptyState.svelte';
   import Icon from '$components/Icon.svelte';
-  import StatusDot from '$components/StatusDot.svelte';
+  import SiteIcon from '$components/SiteIcon.svelte';
+  import SiteIndicators from '$components/SiteIndicators.svelte';
   import LoadingRow from '$components/LoadingRow.svelte';
   import { accessMode } from '$stores/accessMode';
   import { routeRest, goToTab } from '$stores/route';
-  import { sites, sitesLoaded, siteWorkerFailing, reorderSites, type Site } from '$stores/sites';
+  import { sites, sitesLoaded, reorderSites, type Site } from '$stores/sites';
   import { sitesSort, type SitesSort } from '$stores/sitesSort';
   import { openLinkModal } from '$stores/modals';
-  import { apiBase } from '$lib/api';
   import { get } from 'svelte/store';
   import { flushSync, untrack } from 'svelte';
   import { dndzone, SOURCES, TRIGGERS, type DndEvent } from 'svelte-dnd-action';
@@ -165,19 +165,6 @@
     goToTab('sites', s.domain);
   }
 
-  function runningWorkerDots(s: Site): string[] {
-    const dots: string[] = [];
-    if (s.queue_running) dots.push('amber');
-    if (s.horizon_running) dots.push('amber');
-    if (s.stripe_running) dots.push('violet');
-    if (s.schedule_running) dots.push('emerald');
-    if (s.reverb_running) dots.push('sky');
-    for (const w of s.framework_workers || []) {
-      if (w.running) dots.push('indigo');
-    }
-    return dots;
-  }
-
   const sortOptions: Array<{ value: SitesSort; label: string }> = $derived([
     { value: 'recent', label: m.sites_sort_recent() },
     { value: 'alpha', label: m.sites_sort_alpha() },
@@ -287,15 +274,7 @@
       <Icon name="group" class="w-3.5 h-3.5 shrink-0 text-gray-400 dark:text-gray-500" />
     {/if}
     <span class="relative shrink-0 w-4 h-4 flex items-center justify-center">
-      {#if s.custom_container}
-        <svg class="w-4 h-4 {s.fpm_running ? 'text-violet-500' : 'text-gray-300 dark:text-gray-600'}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
-        </svg>
-      {:else if s.has_favicon}
-        <img src={apiBase + '/api/sites/' + s.domain + '/favicon'} class="w-4 h-4 rounded-xs object-contain" loading="lazy" alt="" />
-      {:else}
-        <StatusDot color={s.fpm_running ? 'green' : 'gray'} />
-      {/if}
+      <SiteIcon site={s} />
     </span>
     <span class="flex-1 text-sm truncate">{s.domain}</span>
     {#if s.tls}
@@ -303,17 +282,7 @@
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
       </svg>
     {/if}
-    {#if s.worktrees && s.worktrees.length > 0}
-      <svg class="w-3 h-3 shrink-0 text-violet-400" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
-        <path d="M6 3v12M15 6a3 3 0 1 0 6 0a3 3 0 1 0-6 0M3 18a3 3 0 1 0 6 0a3 3 0 1 0-6 0M18 9a9 9 0 0 1-9 9"/>
-      </svg>
-    {/if}
-    {#if siteWorkerFailing(s)}
-      <span title={m.sites_workerFailing()}><StatusDot color="red" size="xs" pulse /></span>
-    {/if}
-    {#each runningWorkerDots(s) as c, i (i + ':' + c)}
-      <StatusDot color={c as 'amber' | 'violet' | 'emerald' | 'sky' | 'indigo'} size="xs" />
-    {/each}
+    <SiteIndicators site={s} />
   </button>
 {/snippet}
 

--- a/internal/ui/web/src/tabs/services/ServicesDashboard.svelte
+++ b/internal/ui/web/src/tabs/services/ServicesDashboard.svelte
@@ -2,6 +2,8 @@
   import { onMount } from 'svelte';
   import StatusDot from '$components/StatusDot.svelte';
   import Icon from '$components/Icon.svelte';
+  import DashboardHeader from '$components/DashboardHeader.svelte';
+  import DashboardSection from '$components/DashboardSection.svelte';
   import InstalledServiceTile from './InstalledServiceTile.svelte';
   import PresetCard from './PresetCard.svelte';
   import { coreServices, servicesLoaded } from '$stores/services';
@@ -26,29 +28,7 @@
 </script>
 
 <div class="flex-1 overflow-y-auto">
-  <div class="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-3 border-b border-gray-100 dark:border-lerd-border">
-    <h1 class="text-base font-semibold text-gray-900 dark:text-white">{m.services_dash_overview()}</h1>
-    {#if $servicesLoaded && total > 0}
-      <div class="flex items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
-        <span class="inline-flex items-center gap-1.5">
-          <StatusDot color={running > 0 ? 'green' : 'gray'} />
-          {m.dashboard_services_summary({ running, total })}
-        </span>
-        {#if updates > 0}
-          <span class="inline-flex items-center gap-1.5 text-emerald-600 dark:text-emerald-400">
-            <span>↑</span>
-            {m.dashboard_services_updates({ count: updates })}
-          </span>
-        {/if}
-        {#if sitesServed > 0}
-          <span class="inline-flex items-center gap-1.5">
-            <Icon name="sites" class="w-3.5 h-3.5" />
-            {m.services_dash_sitesServed({ count: sitesServed })}
-          </span>
-        {/if}
-      </div>
-    {/if}
-  </div>
+  <DashboardHeader title={m.services_dash_overview()} stats={$servicesLoaded && total > 0 ? summary : undefined} />
 
   <div class="p-4 space-y-6">
     <section class="space-y-2.5">
@@ -83,14 +63,11 @@
         {:else}
           <div class="space-y-4">
             {#each groups as group (group.key)}
-              <div class="space-y-2">
-                <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">{CATEGORY_LABELS[group.key]()}</h3>
-                <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-2">
-                  {#each group.presets as preset (preset.name)}
-                    <PresetCard {preset} category={group.key} />
-                  {/each}
-                </div>
-              </div>
+              <DashboardSection label={CATEGORY_LABELS[group.key]()} sub>
+                {#each group.presets as preset (preset.name)}
+                  <PresetCard {preset} category={group.key} />
+                {/each}
+              </DashboardSection>
             {/each}
           </div>
         {/if}
@@ -98,3 +75,22 @@
     {/if}
   </div>
 </div>
+
+{#snippet summary()}
+  <span class="inline-flex items-center gap-1.5">
+    <StatusDot color={running > 0 ? 'green' : 'gray'} />
+    {m.dashboard_services_summary({ running, total })}
+  </span>
+  {#if updates > 0}
+    <span class="inline-flex items-center gap-1.5 text-emerald-600 dark:text-emerald-400">
+      <span>↑</span>
+      {m.dashboard_services_updates({ count: updates })}
+    </span>
+  {/if}
+  {#if sitesServed > 0}
+    <span class="inline-flex items-center gap-1.5">
+      <Icon name="sites" class="w-3.5 h-3.5" />
+      {m.services_dash_sitesServed({ count: sitesServed })}
+    </span>
+  {/if}
+{/snippet}

--- a/internal/ui/web/src/tabs/sites/SiteTile.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteTile.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import SiteIcon from '$components/SiteIcon.svelte';
+  import SiteIndicators from '$components/SiteIndicators.svelte';
+  import Icon from '$components/Icon.svelte';
+  import { goToTab } from '$stores/route';
+  import { openSiteInBrowser, type Site } from '$stores/sites';
+  import { m } from '../../paraglide/messages.js';
+
+  interface Props {
+    site: Site;
+  }
+  let { site }: Props = $props();
+
+  const subtitle = $derived.by(() => {
+    const parts: string[] = [];
+    if (site.framework_label) parts.push(site.framework_label);
+    if (site.php_version) parts.push('PHP ' + site.php_version);
+    else if (site.node_version) parts.push('Node ' + site.node_version);
+    return parts.join(' · ');
+  });
+
+  function openBrowser(e: MouseEvent) {
+    e.stopPropagation();
+    openSiteInBrowser(site);
+  }
+</script>
+
+<div
+  class="group flex items-center gap-3 rounded-xl border border-gray-200/80 dark:border-lerd-border bg-white dark:bg-lerd-card p-3 transition duration-150 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/5 hover:border-gray-300 dark:hover:border-white/15 {site.paused ? 'opacity-60' : ''}"
+>
+  <button onclick={() => goToTab('sites', site.domain)} class="flex items-center gap-3 min-w-0 flex-1 text-left">
+    <span class="shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-lg bg-gray-100 dark:bg-white/5 transition-transform group-hover:scale-105">
+      <SiteIcon {site} size="w-5 h-5" />
+    </span>
+    <div class="min-w-0 flex-1">
+      <div class="flex items-center gap-1.5">
+        <span class="text-sm font-semibold text-gray-900 dark:text-white truncate" title={site.domain}>{site.domain}</span>
+        {#if site.tls}
+          <svg class="w-3 h-3 shrink-0 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
+          </svg>
+        {/if}
+      </div>
+      {#if subtitle}
+        <p class="text-[11px] leading-snug text-gray-500 dark:text-gray-400 truncate" title={subtitle}>{subtitle}</p>
+      {/if}
+    </div>
+  </button>
+
+  <div class="shrink-0 flex items-center gap-1.5">
+    <SiteIndicators {site} />
+    {#if !site.paused}
+      <button
+        onclick={openBrowser}
+        title={m.sites_openInBrowser()}
+        aria-label={m.sites_openInBrowser()}
+        class="ml-0.5 inline-flex items-center justify-center w-7 h-7 rounded-lg text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-white/5 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+      >
+        <Icon name="external" class="w-3.5 h-3.5" />
+      </button>
+    {/if}
+  </div>
+</div>

--- a/internal/ui/web/src/tabs/sites/SiteTile.test.ts
+++ b/internal/ui/web/src/tabs/sites/SiteTile.test.ts
@@ -1,0 +1,52 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import SiteTile from './SiteTile.svelte';
+import type { Site } from '$stores/sites';
+
+function site(over: Partial<Site> = {}): Site {
+  return { domain: 'app.test', ...over } as Site;
+}
+
+describe('SiteTile', () => {
+  it('renders the site domain', () => {
+    const { getByText } = render(SiteTile, { props: { site: site() } });
+    expect(getByText('app.test')).toBeTruthy();
+  });
+
+  it('builds a subtitle from framework and php version', () => {
+    const { getByText } = render(SiteTile, {
+      props: { site: site({ framework_label: 'Laravel', php_version: '8.3' }) }
+    });
+    expect(getByText('Laravel · PHP 8.3')).toBeTruthy();
+  });
+
+  it('falls back to the node version when there is no php', () => {
+    const { getByText } = render(SiteTile, {
+      props: { site: site({ framework_label: 'Next.js', node_version: '20' }) }
+    });
+    expect(getByText('Next.js · Node 20')).toBeTruthy();
+  });
+
+  it('offers an open-in-browser button for active sites', () => {
+    const { getByLabelText } = render(SiteTile, { props: { site: site() } });
+    expect(getByLabelText('Open in browser')).toBeTruthy();
+  });
+
+  it('hides the open-in-browser button and dims the tile when paused', () => {
+    const { container, queryByLabelText } = render(SiteTile, {
+      props: { site: site({ paused: true }) }
+    });
+    expect(queryByLabelText('Open in browser')).toBeNull();
+    expect(container.querySelector('.opacity-60')).toBeTruthy();
+  });
+
+  it('shows a running worker dot when a worker is active', () => {
+    const { container } = render(SiteTile, { props: { site: site({ queue_running: true }) } });
+    expect(container.querySelector('.bg-amber-400')).toBeTruthy();
+  });
+
+  it('shows a pulsing red dot when a worker is failing', () => {
+    const { container } = render(SiteTile, { props: { site: site({ queue_failing: true }) } });
+    expect(container.querySelector('.bg-red-500')).toBeTruthy();
+  });
+});

--- a/internal/ui/web/src/tabs/sites/SitesDashboard.svelte
+++ b/internal/ui/web/src/tabs/sites/SitesDashboard.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+  import StatusDot from '$components/StatusDot.svelte';
+  import Icon from '$components/Icon.svelte';
+  import EmptyState from '$components/EmptyState.svelte';
+  import LoadingRow from '$components/LoadingRow.svelte';
+  import DashboardHeader from '$components/DashboardHeader.svelte';
+  import DashboardSection from '$components/DashboardSection.svelte';
+  import SiteTile from './SiteTile.svelte';
+  import { sites, sitesLoaded, siteWorkerFailing, type Site } from '$stores/sites';
+  import { accessMode } from '$stores/accessMode';
+  import { openLinkModal } from '$stores/modals';
+  import { m } from '../../paraglide/messages.js';
+
+  const total = $derived($sites.length);
+  const active = $derived($sites.filter((s) => !s.paused));
+  const paused = $derived($sites.filter((s) => s.paused));
+  const running = $derived(active.filter((s) => s.fpm_running).length);
+  const failing = $derived($sites.filter(siteWorkerFailing).length);
+
+  // Active sites grouped by framework so the overview reads like the services
+  // dashboard. Groups keep their first-seen order; unknown frameworks fold into
+  // a trailing "Other" bucket.
+  const groups = $derived.by(() => {
+    const order: string[] = [];
+    const byLabel = new Map<string, Site[]>();
+    for (const s of active) {
+      const label = s.framework_label || m.sites_dash_otherFramework();
+      if (!byLabel.has(label)) {
+        byLabel.set(label, []);
+        order.push(label);
+      }
+      byLabel.get(label)!.push(s);
+    }
+    const other = m.sites_dash_otherFramework();
+    order.sort((a, b) => (a === other ? 1 : b === other ? -1 : 0));
+    return order.map((label) => ({ label, sites: byLabel.get(label)! }));
+  });
+</script>
+
+<div class="flex-1 overflow-y-auto">
+  <DashboardHeader title={m.sites_dash_overview()} stats={$sitesLoaded && total > 0 ? summary : undefined} />
+
+  <div class="p-4 space-y-6">
+    {#if !$sitesLoaded}
+      <LoadingRow />
+    {:else if total === 0}
+      <EmptyState title={m.sites_empty()} hint={parkHint} />
+    {:else}
+      {#each groups as group (group.label)}
+        <DashboardSection label={group.label}>
+          {#each group.sites as site (site.domain)}
+            <SiteTile {site} />
+          {/each}
+        </DashboardSection>
+      {/each}
+
+      {#if paused.length > 0}
+        <DashboardSection label={m.sites_paused()}>
+          {#each paused as site (site.domain)}
+            <SiteTile {site} />
+          {/each}
+        </DashboardSection>
+      {/if}
+    {/if}
+
+    {#if $accessMode.loopback && $sitesLoaded && total > 0}
+      <button
+        onclick={openLinkModal}
+        class="inline-flex items-center gap-1 text-xs font-medium text-lerd-red hover:text-lerd-redhov"
+      >
+        <Icon name="plus" class="w-3.5 h-3.5" />
+        {m.sites_linkNew()}
+      </button>
+    {/if}
+  </div>
+</div>
+
+{#snippet summary()}
+  <span class="inline-flex items-center gap-1.5">
+    <StatusDot color={running > 0 ? 'green' : 'gray'} />
+    {m.dashboard_sites_summary({ running, total })}
+  </span>
+  {#if paused.length > 0}
+    <span class="inline-flex items-center gap-1.5">
+      <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M6 5h4v14H6zM14 5h4v14h-4z"/></svg>
+      {m.dashboard_sites_paused()} {paused.length}
+    </span>
+  {/if}
+  {#if failing > 0}
+    <span class="inline-flex items-center gap-1.5 text-red-500">
+      <StatusDot color="red" size="xs" pulse />
+      {m.dashboard_workers_failing({ count: failing })}
+    </span>
+  {/if}
+{/snippet}
+
+{#snippet parkHint()}
+  {@html m.sites_emptyHint({ cmd: '<code class="bg-gray-100 dark:bg-white/5 px-1 rounded-sm">lerd park</code>' })}
+{/snippet}

--- a/internal/ui/web/src/tabs/sites/SitesDashboard.test.ts
+++ b/internal/ui/web/src/tabs/sites/SitesDashboard.test.ts
@@ -1,0 +1,46 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect, beforeEach } from 'vitest';
+import SitesDashboard from './SitesDashboard.svelte';
+import { sites, sitesLoaded, type Site } from '$stores/sites';
+
+function site(over: Partial<Site> = {}): Site {
+  return { domain: 'app.test', ...over } as Site;
+}
+
+describe('SitesDashboard', () => {
+  beforeEach(() => {
+    sites.set([]);
+    sitesLoaded.set(true);
+  });
+
+  it('groups active sites under their framework label', () => {
+    sites.set([
+      site({ domain: 'shop.test', framework_label: 'Laravel', php_version: '8.3', fpm_running: true }),
+      site({ domain: 'blog.test', framework_label: 'WordPress', php_version: '8.2' })
+    ]);
+    const { getByText } = render(SitesDashboard);
+    expect(getByText('Laravel')).toBeTruthy();
+    expect(getByText('WordPress')).toBeTruthy();
+    expect(getByText('shop.test')).toBeTruthy();
+    expect(getByText('blog.test')).toBeTruthy();
+  });
+
+  it('buckets sites without a framework under Other', () => {
+    sites.set([site({ domain: 'static.test' })]);
+    const { getByText } = render(SitesDashboard);
+    expect(getByText('Other')).toBeTruthy();
+  });
+
+  it('lists paused sites in their own section', () => {
+    sites.set([site({ domain: 'old.test', paused: true })]);
+    const { getByText } = render(SitesDashboard);
+    expect(getByText('Paused')).toBeTruthy();
+    expect(getByText('old.test')).toBeTruthy();
+  });
+
+  it('shows the empty hint when there are no sites', () => {
+    sites.set([]);
+    const { getByText } = render(SitesDashboard);
+    expect(getByText('No sites yet')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
PR #492 was merged into the feat/services-dashboard branch rather than main, so after that branch landed first its dashboard commit never reached main and the files were absent. This cherry-picks that commit onto main, reconciled with the site-reorder and hardening changes that landed since.

It adds the Sites-tab overview shown when no site is selected: a running-vs-total count, a paused tally, and a failing-workers indicator, with sites laid out as click-through tiles grouped by framework plus Other and Paused buckets. Each tile shows the favicon or status dot, the domain with a TLS lock, a framework and PHP or Node subline, worktree and worker indicators, and an open-in-browser shortcut, with a Link new site action in loopback mode. The dashboard chrome shared with the services tab is extracted into DashboardHeader and DashboardSection, and the site icon and worker indicator cluster move into SiteIcon and SiteIndicators so the row and tile views stay in sync.