### PR TITLE
test(status): add bun fields to dnsState base fixture

### DIFF
--- a/internal/ui/web/src/stores/status.test.ts
+++ b/internal/ui/web/src/stores/status.test.ts
@@ -108,7 +108,7 @@ describe('status store', () => {
 
   it('dnsState reads the status field and falls back to ok for old payloads', async () => {
     const { dnsState } = await import('./status');
-    const base = { nginx: { running: true }, php_fpms: [], php_default: '', node_default: '', node_managed_by_lerd: true, watcher_running: true };
+    const base = { nginx: { running: true }, php_fpms: [], php_default: '', node_default: '', node_managed_by_lerd: true, watcher_running: true, bun_available: false, bun_version: '', using_system_bun: false };
     expect(dnsState({ ...base, dns: { ok: false, status: 'degraded', enabled: true, tld: 'test' } })).toBe('degraded');
     expect(dnsState({ ...base, dns: { ok: false, status: 'down', enabled: true, tld: 'test' } })).toBe('down');
     expect(dnsState({ ...base, dns: { ok: true, enabled: true, tld: 'test' } })).toBe('ok');


### PR DESCRIPTION
The php-containerfile change (#511) added `bun_available`, `bun_version` and `using_system_bun` to `StatusResponse`, but the `dnsState` test fixture in `status.test.ts` was not updated to match. As a result `npm run check` (svelte-check) fails on `main` with five errors, all in `src/stores/status.test.ts`, because the `base` object is missing those three required fields.

This adds the three fields (`bun_available: false`, `bun_version: ''`, `using_system_bun: false`) to the fixture so the typecheck goes green again. Test-only change, no runtime impact.

Before:
```
COMPLETED 1408 FILES 5 ERRORS 0 WARNINGS 1 FILES_WITH_PROBLEMS
```
After:
```
COMPLETED 1408 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
```