### PR TITLE
feat(mcp): add a logs tool to read every log source with filtering

### DIFF
--- a/docs/features/logs.md
+++ b/docs/features/logs.md
@@ -1,0 +1,42 @@
+# Logs
+
+lerd gives AI assistants a single, filtered view over every log it can reach, so debugging a broken site doesn't mean opening files by hand. It is exposed as the `logs` MCP tool with two actions: `sources` and `fetch`.
+
+## Sources
+
+Call `logs` with `action: "sources"` to enumerate what you can query for the current site plus the shared infrastructure. Source names:
+
+| Name | Backend | What it is |
+|---|---|---|
+| `app:<file>` | file | Framework application logs (e.g. `app:laravel.log` from `storage/logs/*.log`), parsed with real timestamps and levels |
+| `fpm` | container | The site's PHP-FPM container stdout |
+| `worker:<name>` | journal | A declared worker unit: `worker:queue`, `worker:horizon`, `worker:schedule`, custom workers |
+| `nginx` | container | nginx access/error output |
+| `dns` | container | dnsmasq |
+| `watcher`, `ui` | journal | The lerd file watcher and UI server |
+| `<service>` | container | A default service (`mysql`, `redis`, `mailpit`, …) |
+| `php<ver>` | container | An installed PHP-FPM container, for site-less sessions |
+
+Sources are listed whether or not they are currently running; a source that isn't up simply returns no lines at fetch time.
+
+## Fetch
+
+Call `logs` with `action: "fetch"`, a `source` name, and any of these filters:
+
+- `grep` — keep only lines matching this pattern. It is compiled as a regular expression and falls back to a literal substring match when the pattern isn't valid regex.
+- `since` / `until` — a time window. Accepts relative durations (`15m`, `1h`, `2h30m`), absolute timestamps (`2026-06-11T10:00:00Z` or `2026-06-11 10:00:00`), or a `cursor` returned by a previous fetch.
+- `level` — application logs only: filter by `error`, `warning`, `info`, `debug`, etc.
+- `lines` — maximum number of lines to return (default 50).
+
+Entries come back in chronological order, oldest first. Container-stdout and journal sources push the time window down to `podman logs --since/--until` and `journalctl --since/--until -g` respectively; application-log files are filtered in process.
+
+## Streaming via cursor
+
+MCP is a request/response protocol, so there is no live follow. Instead every `fetch` returns an opaque `cursor` marking the newest line returned. To watch a log evolve, call `fetch` again with `since` (or `cursor`) set to that value and you receive only the lines that arrived since. The cursor format differs per backend (a journal cursor, an RFC3339 timestamp, or a log entry's own timestamp), so treat it as opaque and just echo it back.
+
+## Notes and limitations
+
+- Raw logs without timestamps (most non-monolog files) ignore `since`/`until`/`level` and simply return the last N lines; their cursor is empty.
+- A container or unit that isn't running returns whatever partial output exists rather than an error.
+- On macOS, worker/watcher/ui sources read from `~/Library/Logs/lerd/<unit>.log` (or `podman logs` for container-mode workers) since there is no systemd journal; on Linux they read the user journal.
+- Large files are read from a 512 KB tail; when that cap is hit the result is flagged as truncated.

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -107,7 +107,7 @@ Most actions accept an optional `path` argument. When omitted, the server resolv
 
 ## Available MCP tools
 
-The MCP surface is **ten grouped tools**, each driven by an `action` argument. Always pass `action`; start by calling `site` with `action: "list"` to discover sites.
+The MCP surface is **eleven grouped tools**, each driven by an `action` argument. Always pass `action`; start by calling `site` with `action: "list"` to discover sites.
 
 | Tool | Actions |
 |---|---|
@@ -119,12 +119,17 @@ The MCP surface is **ten grouped tools**, each driven by an `action` argument. A
 | `worker` | `list` (call first), `start`, `stop`, `add`, `remove`, `health`, `heal`, `mode_get`, `mode_set`, `queue_start`, `queue_stop`, `horizon_start`, `horizon_stop`, `reverb_start`, `reverb_stop`, `schedule_start`, `schedule_stop`, `stripe_start`, `stripe_stop`, `stripe_config` |
 | `exec` | `artisan`, `console`, `composer`, `vendor_bins`, `vendor_run`, `commands_list`, `commands_run`, `command_add`, `command_remove` |
 | `framework` | `list`, `add`, `remove`, `search`, `install`, `project_new`, `setup` |
-| `diag` | `status`, `doctor`, `logs`, `which`, `check`, `dns_diagnose`, `bug_report`, `analyze_queries`, `dumps_recent`, `dumps_status`, `dumps_clear`, `dumps_toggle`, `profiler_toggle`, `profiler_status`, `profiler_clear`, `xdebug_on`, `xdebug_off`, `xdebug_status` |
+| `diag` | `status`, `doctor`, `which`, `check`, `dns_diagnose`, `bug_report`, `analyze_queries`, `dumps_recent`, `dumps_status`, `dumps_clear`, `dumps_toggle`, `profiler_toggle`, `profiler_status`, `profiler_clear`, `xdebug_on`, `xdebug_off`, `xdebug_status` |
+| `logs` | `sources`, `fetch` |
 | `worktree` | `list`, `add`, `remove`, `db_isolate`, `db_share` |
 
 The injected context files document each action's arguments and the key conventions in full.
 
-> **Grouped surface:** earlier lerd versions exposed ~80 individual MCP tools (`sites`, `artisan`, `db_set`, …). These were consolidated into the ten grouped tools above to cut the per-session token cost and sharpen the model's tool selection. Old flat tool names no longer exist; call the group with the matching `action` instead (e.g. `artisan` → `exec` with `action: "artisan"`, `db_set` → `db` with `action: "set"`).
+### Reading logs
+
+The `logs` tool lets an assistant debug a site's logs without opening files by hand. Call `logs` with `action: "sources"` to list every queryable source for a site (`app:<file>` framework logs, `fpm`, `worker:<name>`) plus shared infrastructure (`nginx`, `dns`, `watcher`, `ui`, services, `php<ver>`), then `action: "fetch"` with a `source` and any of `grep` (regex or literal substring), `since`/`until` (relative like `15m`/`2h30m`, or a timestamp), `level` (app logs only), and `lines`. Each `fetch` returns an opaque `cursor`; pass it back as `since` on the next call to receive only the new lines, which is how streaming is modelled over MCP's request/response transport. See [the logs feature page](logs.md) for the full source list, filter semantics, and platform notes.
+
+> **Grouped surface:** earlier lerd versions exposed ~80 individual MCP tools (`sites`, `artisan`, `db_set`, …). These were consolidated into the grouped tools above to cut the per-session token cost and sharpen the model's tool selection. Old flat tool names no longer exist; call the group with the matching `action` instead (e.g. `artisan` → `exec` with `action: "artisan"`, `db_set` → `db` with `action: "set"`).
 
 ---
 
@@ -190,6 +195,7 @@ AI:  → worker(action: "list", site: "myapp")
      ✓  queue worker started for myapp
 
 You: the app is throwing 500s, check the logs
-AI:  → diag(action: "logs", target: "8.5", lines: 50)
+AI:  → logs(action: "sources", site: "myapp")
+     → logs(action: "fetch", source: "app:laravel.log", level: "error", since: "15m")
      PHP Fatal error: Class "App\Jobs\ProcessOrder" not found ...
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ features:
     details: One global toggle and every PHP-FPM request becomes a flame graph viewable in the dashboard's Profiler view. No FPM restart, no code changes, `lerd profile run` for one-shot CLI commands.
   - icon: 🤖
     title: AI integration (MCP)
-    details: Built-in Model Context Protocol server with ten grouped tools. Claude Code, Cursor, Codex, Gemini, GitHub Copilot, Google Antigravity, JetBrains Junie, and Windsurf scaffold projects and run migrations straight from chat.
+    details: Built-in Model Context Protocol server with eleven grouped tools. Claude Code, Cursor, Codex, Gemini, GitHub Copilot, Google Antigravity, JetBrains Junie, and Windsurf scaffold projects and run migrations straight from chat.
   - icon: ⚡
     title: FrankenPHP runtime
     details: Per-site FrankenPHP as an alternative to shared PHP-FPM, with Laravel Octane and Symfony Runtime worker mode wired up out of the box.

--- a/internal/applog/parser.go
+++ b/internal/applog/parser.go
@@ -27,8 +27,8 @@ type LogFile struct {
 	ModTime string `json:"mod_time"`
 }
 
-// maxReadBytes is the maximum number of bytes to read from the end of a file.
-const maxReadBytes = 512 * 1024
+// MaxReadBytes is the maximum number of bytes to read from the end of a file.
+const MaxReadBytes = 512 * 1024
 
 // laravelRe matches the opening line of a Laravel/Monolog log entry:
 // [2024-01-09 13:13:49] local.ERROR: message text
@@ -153,7 +153,7 @@ func FormatForFile(sources []config.FrameworkLogSource, filename string) string 
 // When maxEntries is 0, the entire file is read and all entries are returned.
 // Returns entries in reverse-chronological order (newest first).
 func ParseFile(path, format string, maxEntries int) ([]LogEntry, error) {
-	readLimit := maxReadBytes
+	readLimit := MaxReadBytes
 	if maxEntries == 0 {
 		readLimit = 0 // read entire file
 	}

--- a/internal/cli/aidocs/lerd-reference.md
+++ b/internal/cli/aidocs/lerd-reference.md
@@ -2,7 +2,7 @@
 
 This project runs on **lerd**, a Podman-based Laravel development environment. The `lerd` MCP server is available — use it to manage the environment without leaving the chat.
 
-The MCP surface is **ten grouped tools**, each driven by an `action` argument: `site`, `service`, `db`, `env`, `runtime`, `worker`, `exec`, `framework`, `diag`, `worktree`. Always pass `action`. Most actions also accept an optional `path` that defaults to the directory the assistant was opened in (then `LERD_SITE_PATH` if set), so you can usually omit it. Start by calling `site` with `action: "list"` to discover sites.
+The MCP surface is **eleven grouped tools**, each driven by an `action` argument: `site`, `service`, `db`, `env`, `runtime`, `worker`, `exec`, `framework`, `diag`, `logs`, `worktree`. Always pass `action`. Most actions also accept an optional `path` that defaults to the directory the assistant was opened in (then `LERD_SITE_PATH` if set), so you can usually omit it. Start by calling `site` with `action: "list"` to discover sites.
 
 ### Architecture
 
@@ -28,7 +28,7 @@ Read `diag` `action: "status"` for `dns.tld` and `dns.enabled` instead of assumi
 
 ### MCP tools
 
-Ten grouped tools, each selecting behaviour via `action`.
+Eleven grouped tools, each selecting behaviour via `action`.
 
 #### `site` — sites and their configuration
 Actions: `list` (discover sites — CALL FIRST), `link`, `unlink`, `domain_add`, `domain_remove`, `group_assign`, `group_unassign`, `group_label`, `group_db`, `group_list`, `tls_enable`, `tls_disable`, `php`, `node`, `pause`, `unpause`, `restart`, `rebuild`, `runtime`, `nginx_read`, `nginx_write`, `nginx_reset`, `park`, `unpark`.
@@ -89,13 +89,20 @@ Actions: `list`, `add`, `remove`, `search`, `install`, `project_new`, `setup`.
 - `setup` runs the framework's post-install steps (migrations, storage:link…) — MANDATORY after `env setup` on new/cloned projects; idempotent
 
 #### `diag` — diagnostics & observability
-Actions: `status`, `doctor`, `logs`, `which`, `check`, `dns_diagnose`, `bug_report`, `analyze_queries`, `dumps_recent`, `dumps_status`, `dumps_clear`, `dumps_toggle`, `profiler_toggle`, `profiler_status`, `profiler_clear`, `xdebug_on`, `xdebug_off`, `xdebug_status`.
+Actions: `status`, `doctor`, `which`, `check`, `dns_diagnose`, `bug_report`, `analyze_queries`, `dumps_recent`, `dumps_status`, `dumps_clear`, `dumps_toggle`, `profiler_toggle`, `profiler_status`, `profiler_clear`, `xdebug_on`, `xdebug_off`, `xdebug_status`.
 - `status` (DNS/nginx/FPM/watcher health) and `doctor` (full JSON diagnostic) are the first stops when something is broken; `dns_diagnose` walks the DNS chain
-- `logs` defaults to the current site's FPM; `target` can be nginx, a service, a PHP version, or a site name
+- reading logs lives in the `logs` tool (below), not here
 - `which` shows resolved PHP/Node/docroot/nginx for a site; `check` validates `.lerd.yaml`
 - debug bridge loop: `dumps_toggle` (enable) → `dumps_clear` → hit the page → `analyze_queries` (N+1 / slow-query report with file:line) or `dumps_recent` (filter by site/branch/ctx/kind/since/limit)
 - `profiler_*` toggle the global SPX profiler and surface the flame-graph UI; `xdebug_*` control Xdebug on port 9003 (`mode` defaults to debug)
 - `bug_report` writes an anonymised diagnostic report for a GitHub issue
+
+#### `logs` — read logs from any source, filtered
+Actions: `sources`, `fetch`. Debug without opening files by hand.
+- `sources` lists every queryable source for the site plus shared infra: `app:<file>` (framework log files), `fpm`, `worker:<name>` (queue/horizon/schedule/custom), and the globals `nginx`, `dns`, `watcher`, `ui`, services, `php<ver>`. Call it first to learn the names
+- `fetch source=<name>` reads one source. Filter with `grep` (regex, falls back to literal substring), `since`/`until` (relative like `15m`/`1h`/`2h30m`, or a timestamp), `level` (app logs only: error/warning/info/debug), and `lines` (default 50)
+- streaming is polling: every `fetch` returns an opaque `cursor`; call again with `since=<cursor>` (or `cursor=<cursor>`) to get only the new lines. The cursor format differs per backend, so treat it as opaque and echo it back
+- entries come back chronological (oldest first). Raw logs with no timestamps ignore `since`/`level` and just return the last N; a not-running container returns partial output, not an error
 
 #### `worktree` — git worktrees
 Actions: `list`, `add`, `remove`, `db_isolate`, `db_share`.

--- a/internal/logsource/read.go
+++ b/internal/logsource/read.go
@@ -1,0 +1,258 @@
+package logsource
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/geodro/lerd/internal/applog"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+const defaultLines = 50
+
+// Opts are the filters applied to a fetch. Empty fields are ignored.
+type Opts struct {
+	Since string // relative ("15m", "2h30m"), absolute timestamp, or a prior Cursor
+	Until string // upper time bound (same formats)
+	Grep  string // regex, falling back to a literal substring when it won't compile
+	Lines int    // tail cap (default 50)
+	Level string // KindFile/monolog only: error, warning, info, debug…
+}
+
+// Entry is one normalised log line. Time/Level/Channel are populated when the
+// backend exposes them (monolog files, journal); container stdout fills Text only.
+type Entry struct {
+	Time    string `json:"time,omitempty"`
+	Level   string `json:"level,omitempty"`
+	Channel string `json:"channel,omitempty"`
+	Text    string `json:"text"`
+}
+
+// Result is a window of entries in chronological order (oldest first, newest
+// last). Cursor is the newest entry's opaque position — pass it back as
+// Opts.Since on the next call to fetch only newer lines.
+type Result struct {
+	Entries   []Entry
+	Cursor    string
+	Truncated bool
+}
+
+// Lines returns just the text of each entry, oldest first.
+func (r Result) Lines() []string {
+	out := make([]string, len(r.Entries))
+	for i, e := range r.Entries {
+		out[i] = e.Text
+	}
+	return out
+}
+
+// Read fetches a filtered window from a single source, dispatching on its kind.
+func Read(src Source, opts Opts) (Result, error) {
+	if opts.Lines <= 0 {
+		opts.Lines = defaultLines
+	}
+	switch src.Kind {
+	case KindFile:
+		return readFile(src, opts)
+	case KindPodman:
+		return readPodman(src, opts)
+	case KindJournal:
+		return readJournal(src, opts) // platform-specific (read_linux.go / read_darwin.go)
+	}
+	return Result{}, fmt.Errorf("unsupported log source kind %d", src.Kind)
+}
+
+func readFile(src Source, opts Opts) (Result, error) {
+	structured := src.Format == "monolog" || src.Format == "laravel"
+
+	// When any filter is active, scan the whole capped tail rather than just the
+	// last N raw entries, so matches further back aren't missed.
+	readCount := opts.Lines
+	if opts.Grep != "" || opts.Level != "" || opts.Since != "" || opts.Until != "" {
+		readCount = 0
+	}
+	entries, err := applog.ParseFile(src.Locator, src.Format, readCount) // newest first
+	if err != nil {
+		return Result{}, err
+	}
+
+	matcher := compileGrep(opts.Grep)
+	since, sinceOK := parseSince(opts.Since)
+	until, untilOK := parseSince(opts.Until)
+
+	kept := make([]Entry, 0, opts.Lines)
+	for _, e := range entries { // newest -> oldest
+		if opts.Level != "" && structured && !strings.EqualFold(e.Level, opts.Level) {
+			continue
+		}
+		text := e.Message
+		if e.Detail != "" {
+			text = e.Detail
+		}
+		if matcher != nil && !matcher(text) {
+			continue
+		}
+		if structured && (sinceOK || untilOK) {
+			if t, ok := parseEntryTime(e.Date); ok {
+				if sinceOK && t.Before(since) {
+					continue
+				}
+				if untilOK && t.After(until) {
+					continue
+				}
+			}
+		}
+		kept = append(kept, Entry{Time: e.Date, Level: e.Level, Channel: e.Channel, Text: text})
+		if len(kept) >= opts.Lines {
+			break
+		}
+	}
+
+	reverse(kept) // chronological: oldest first
+	res := Result{Entries: kept}
+	if len(kept) > 0 {
+		res.Cursor = kept[len(kept)-1].Time // newest
+	}
+	if info, err := os.Stat(src.Locator); err == nil && info.Size() > applog.MaxReadBytes {
+		res.Truncated = true
+	}
+	return res, nil
+}
+
+// podmanScanCap bounds the tail we pull when filtering, so grep/time filters
+// (applied in Go below) can see beyond the last opts.Lines lines without
+// streaming the container's entire history. Mirrors readFile's whole-tail scan.
+const podmanScanCap = 5000
+
+func readPodman(src Source, opts Opts) (Result, error) {
+	tail := opts.Lines
+	if opts.Grep != "" || opts.Since != "" || opts.Until != "" {
+		tail = podmanScanCap
+	}
+	args := []string{"logs", "--timestamps", "--tail", strconv.Itoa(tail)}
+	if opts.Since != "" {
+		args = append(args, "--since", podmanTime(opts.Since))
+	}
+	if opts.Until != "" {
+		args = append(args, "--until", podmanTime(opts.Until))
+	}
+	args = append(args, src.Locator)
+
+	var buf bytes.Buffer
+	cmd := podman.Cmd(args...)
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	_ = cmd.Run() // non-zero when the container isn't running — return what we have
+
+	matcher := compileGrep(opts.Grep)
+	var out []Entry
+	for _, line := range strings.Split(strings.TrimRight(StripANSI(buf.String()), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		ts, text := splitPodmanTimestamp(line)
+		if matcher != nil && !matcher(text) {
+			continue
+		}
+		out = append(out, Entry{Time: ts, Text: text})
+	}
+	// podman output is chronological; keep the newest opts.Lines after filtering.
+	if len(out) > opts.Lines {
+		out = out[len(out)-opts.Lines:]
+	}
+	cursor := ""
+	if len(out) > 0 {
+		cursor = out[len(out)-1].Time
+	}
+	return Result{Entries: out, Cursor: cursor}, nil
+}
+
+// ---- shared filter helpers ----
+
+func compileGrep(pattern string) func(string) bool {
+	if pattern == "" {
+		return nil
+	}
+	if re, err := regexp.Compile(pattern); err == nil {
+		return re.MatchString
+	}
+	return func(s string) bool { return strings.Contains(s, pattern) }
+}
+
+// parseSince accepts a Go relative duration ("15m", "2h30m"), an absolute
+// timestamp (RFC3339, "2006-01-02 15:04:05", or "2006-01-02"), and reports
+// whether it resolved to a usable time.
+func parseSince(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	if d, err := time.ParseDuration(s); err == nil {
+		return time.Now().Add(-d), true
+	}
+	return parseAbs(s)
+}
+
+// parseAbs parses an absolute timestamp. Zone-less forms are read as UTC to
+// match monolog entry timestamps (Laravel's default app timezone), so a
+// since/until value compares cleanly against the entries returned.
+func parseAbs(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, true
+	}
+	for _, layout := range []string{"2006-01-02 15:04:05", "2006-01-02"} {
+		if t, err := time.ParseInLocation(layout, s, time.UTC); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// parseEntryTime reads a monolog entry's zone-less timestamp as UTC, matching
+// parseAbs so relative windows ("15m") and absolute bounds line up.
+func parseEntryTime(s string) (time.Time, bool) {
+	if t, err := time.ParseInLocation("2006-01-02 15:04:05", s, time.UTC); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+// podmanTime translates a since/until value into something `podman logs`
+// understands: relative durations pass through, absolute times become RFC3339.
+func podmanTime(s string) string {
+	s = strings.TrimSpace(s)
+	if _, err := time.ParseDuration(s); err == nil {
+		return s
+	}
+	if t, ok := parseAbs(s); ok {
+		return t.Format(time.RFC3339)
+	}
+	return s
+}
+
+func splitPodmanTimestamp(line string) (ts, text string) {
+	if i := strings.IndexByte(line, ' '); i > 0 {
+		cand := line[:i]
+		if _, err := time.Parse(time.RFC3339Nano, cand); err == nil {
+			return cand, line[i+1:]
+		}
+	}
+	return "", line
+}
+
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// StripANSI removes ANSI escape sequences from log output.
+func StripANSI(s string) string { return ansiRe.ReplaceAllString(s, "") }
+
+func reverse(e []Entry) {
+	for i, j := 0, len(e)-1; i < j; i, j = i+1, j-1 {
+		e[i], e[j] = e[j], e[i]
+	}
+}

--- a/internal/logsource/read_darwin.go
+++ b/internal/logsource/read_darwin.go
@@ -1,0 +1,24 @@
+//go:build darwin
+
+package logsource
+
+import "github.com/geodro/lerd/internal/unitlog"
+
+// readJournal has no journald on macOS. Units that actually run as detached
+// podman containers are read with `podman logs`; the launchd-supervised ones
+// (dns, watcher, ui, exec-mode workers) tail their ~/Library/Logs/lerd file.
+func readJournal(src Source, opts Opts) (Result, error) {
+	if unitlog.IsContainerUnit(src.Locator) {
+		podSrc := src
+		podSrc.Kind = KindPodman
+		return readPodman(podSrc, opts)
+	}
+	fileSrc := Source{
+		Name:    src.Name,
+		Kind:    KindFile,
+		Locator: unitlog.LogPath(src.Locator),
+		Scope:   src.Scope,
+		Format:  "raw",
+	}
+	return readFile(fileSrc, opts)
+}

--- a/internal/logsource/read_linux.go
+++ b/internal/logsource/read_linux.go
@@ -1,0 +1,107 @@
+//go:build linux
+
+package logsource
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// readJournal reads a unit's logs from the systemd user journal. Time and grep
+// filters push down to journalctl; the cursor is the journal's own opaque
+// __CURSOR so the next poll resumes exactly with --after-cursor.
+func readJournal(src Source, opts Opts) (Result, error) {
+	args := []string{"--user", "-u", src.Locator + ".service", "--no-pager", "--output=json"}
+	if opts.Since != "" {
+		if isJournalCursor(opts.Since) {
+			args = append(args, "--after-cursor="+opts.Since)
+		} else {
+			args = append(args, "--since", journalTime(opts.Since))
+		}
+	}
+	if opts.Until != "" {
+		args = append(args, "--until", journalTime(opts.Until))
+	}
+	if opts.Grep != "" {
+		args = append(args, "-g", opts.Grep)
+	}
+	args = append(args, "-n", strconv.Itoa(opts.Lines))
+
+	var buf bytes.Buffer
+	cmd := exec.Command("journalctl", args...)
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	_ = cmd.Run() // missing unit / no journal access — return what we have
+
+	var out []Entry
+	var cursor string
+	dec := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+	for {
+		var je journalEntry
+		if err := dec.Decode(&je); err != nil {
+			break
+		}
+		out = append(out, Entry{Time: je.timeString(), Text: je.message()})
+		if je.Cursor != "" {
+			cursor = je.Cursor
+		}
+	}
+	return Result{Entries: out, Cursor: cursor}, nil
+}
+
+func isJournalCursor(s string) bool {
+	return strings.HasPrefix(s, "s=") && strings.Contains(s, ";i=")
+}
+
+// journalTime converts a since/until value to journalctl's accepted forms:
+// relative Go durations become "-15m"; absolute times become "YYYY-MM-DD HH:MM:SS".
+func journalTime(s string) string {
+	s = strings.TrimSpace(s)
+	if _, err := time.ParseDuration(s); err == nil {
+		return "-" + s
+	}
+	if t, ok := parseAbs(s); ok {
+		// journalctl reads a zone-less time in the system's local zone, so emit
+		// the local wall-clock of the parsed instant.
+		return t.In(time.Local).Format("2006-01-02 15:04:05")
+	}
+	return s
+}
+
+type journalEntry struct {
+	Cursor   string          `json:"__CURSOR"`
+	Realtime string          `json:"__REALTIME_TIMESTAMP"`
+	Message  json.RawMessage `json:"MESSAGE"`
+}
+
+func (j journalEntry) message() string {
+	if len(j.Message) == 0 {
+		return ""
+	}
+	if j.Message[0] == '"' {
+		var s string
+		_ = json.Unmarshal(j.Message, &s)
+		return s
+	}
+	// journalctl encodes binary messages as a JSON array of bytes.
+	var b []byte
+	if json.Unmarshal(j.Message, &b) == nil {
+		return string(b)
+	}
+	return ""
+}
+
+func (j journalEntry) timeString() string {
+	if j.Realtime == "" {
+		return ""
+	}
+	usec, err := strconv.ParseInt(j.Realtime, 10, 64)
+	if err != nil {
+		return ""
+	}
+	return time.Unix(0, usec*1000).Format(time.RFC3339)
+}

--- a/internal/logsource/read_test.go
+++ b/internal/logsource/read_test.go
@@ -1,0 +1,186 @@
+package logsource
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const monologFixture = `[2026-06-11 10:00:00] local.INFO: started up
+[2026-06-11 10:05:00] local.ERROR: SQLSTATE[HY000] connection refused
+[2026-06-11 10:10:00] local.WARNING: slow query detected
+[2026-06-11 10:15:00] local.ERROR: SQLSTATE[42S02] table missing
+`
+
+func writeFixture(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "laravel.log")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func monologSource(t *testing.T, content string) Source {
+	return Source{Name: "app:laravel.log", Kind: KindFile, Locator: writeFixture(t, content), Format: "monolog"}
+}
+
+func TestRead_File_NoFilter_Chronological(t *testing.T) {
+	res, err := Read(monologSource(t, monologFixture), Opts{Lines: 10})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(res.Entries) != 4 {
+		t.Fatalf("want 4 entries, got %d", len(res.Entries))
+	}
+	if !contains(res.Entries[0].Text, "started up") {
+		t.Errorf("first entry should be oldest, got %q", res.Entries[0].Text)
+	}
+	if !contains(res.Entries[3].Text, "table missing") {
+		t.Errorf("last entry should be newest, got %q", res.Entries[3].Text)
+	}
+	if res.Cursor != "2026-06-11 10:15:00" {
+		t.Errorf("cursor = %q, want newest entry date", res.Cursor)
+	}
+}
+
+func TestRead_File_Grep(t *testing.T) {
+	cases := []struct {
+		name string
+		grep string
+		want int
+	}{
+		{"literal-substring-as-regex", "SQLSTATE", 2},
+		{"regex", "42S0[0-9]", 1},
+		{"invalid-regex-falls-back-to-literal", "[", 2},
+		{"no-match", "nope", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := Read(monologSource(t, monologFixture), Opts{Lines: 10, Grep: tc.grep})
+			if err != nil {
+				t.Fatalf("Read: %v", err)
+			}
+			if len(res.Entries) != tc.want {
+				t.Fatalf("grep %q: want %d entries, got %d", tc.grep, tc.want, len(res.Entries))
+			}
+		})
+	}
+}
+
+func TestRead_File_Level(t *testing.T) {
+	res, err := Read(monologSource(t, monologFixture), Opts{Lines: 10, Level: "error"})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(res.Entries) != 2 {
+		t.Fatalf("want 2 error entries, got %d", len(res.Entries))
+	}
+	for _, e := range res.Entries {
+		if e.Level != "ERROR" {
+			t.Errorf("entry level = %q, want ERROR", e.Level)
+		}
+	}
+}
+
+func TestRead_File_LinesCap(t *testing.T) {
+	res, err := Read(monologSource(t, monologFixture), Opts{Lines: 2})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(res.Entries) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(res.Entries))
+	}
+	// Newest two, still chronological.
+	if !contains(res.Entries[0].Text, "slow query") || !contains(res.Entries[1].Text, "table missing") {
+		t.Errorf("unexpected window: %q / %q", res.Entries[0].Text, res.Entries[1].Text)
+	}
+}
+
+func TestRead_File_TimeWindow(t *testing.T) {
+	res, err := Read(monologSource(t, monologFixture), Opts{Lines: 10, Since: "2026-06-11 10:07:00"})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(res.Entries) != 2 {
+		t.Fatalf("want 2 entries after 10:07, got %d", len(res.Entries))
+	}
+	if !contains(res.Entries[0].Text, "slow query") {
+		t.Errorf("first kept entry = %q", res.Entries[0].Text)
+	}
+}
+
+func TestRead_File_CursorAdvances(t *testing.T) {
+	src := monologSource(t, monologFixture)
+	first, err := Read(src, Opts{Lines: 10})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	second, err := Read(src, Opts{Lines: 10, Since: first.Cursor})
+	if err != nil {
+		t.Fatalf("Read poll: %v", err)
+	}
+	// Only the boundary (newest) entry remains, not the whole file again.
+	if len(second.Entries) != 1 || !contains(second.Entries[0].Text, "table missing") {
+		t.Fatalf("polling with cursor should narrow to the newest entry, got %d: %+v", len(second.Entries), second.Entries)
+	}
+}
+
+func TestRead_RawFile_SinceIsBestEffortNoOp(t *testing.T) {
+	raw := "line one\nline two\nline three\n"
+	src := Source{Name: "raw", Kind: KindFile, Locator: writeFixture(t, raw), Format: "raw"}
+	res, err := Read(src, Opts{Lines: 10, Since: "5m"})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(res.Entries) != 3 {
+		t.Fatalf("raw since should be a no-op (last-N), got %d entries", len(res.Entries))
+	}
+	if res.Cursor != "" {
+		t.Errorf("raw source has no timestamp cursor, got %q", res.Cursor)
+	}
+}
+
+func TestParseSince(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		in   string
+		ok   bool
+		near time.Time
+	}{
+		{"15m", true, now.Add(-15 * time.Minute)},
+		{"2h30m", true, now.Add(-150 * time.Minute)},
+		{"2026-06-11T10:00:00Z", true, time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)},
+		{"", false, time.Time{}},
+		{"garbage", false, time.Time{}},
+	}
+	for _, tc := range cases {
+		got, ok := parseSince(tc.in)
+		if ok != tc.ok {
+			t.Errorf("parseSince(%q) ok = %v, want %v", tc.in, ok, tc.ok)
+			continue
+		}
+		if tc.ok && got.Sub(tc.near).Abs() > 2*time.Second {
+			t.Errorf("parseSince(%q) = %v, want near %v", tc.in, got, tc.near)
+		}
+	}
+}
+
+func TestCompileGrep(t *testing.T) {
+	if compileGrep("") != nil {
+		t.Error("empty pattern should yield no matcher")
+	}
+	re := compileGrep("ab.c")
+	if !re("abXc") || re("abc") {
+		t.Error("regex matcher behaved unexpectedly")
+	}
+	lit := compileGrep("[") // invalid regex
+	if !lit("a[b") || lit("ab") {
+		t.Error("literal fallback behaved unexpectedly")
+	}
+}
+
+func contains(s, sub string) bool { return strings.Contains(s, sub) }

--- a/internal/logsource/source.go
+++ b/internal/logsource/source.go
@@ -1,0 +1,282 @@
+// Package logsource gives a single, filtered view over every log lerd can
+// reach: framework application log files, PHP-FPM/nginx/dns/service container
+// stdout, and worker/watcher/ui units (systemd journal on Linux, launchd log
+// files on macOS). It wraps the existing readers (internal/applog, podman
+// logs, journalctl) behind one Source registry + Read dispatcher so callers —
+// the MCP `logs` tool, the `diag.logs` alias — never reimplement log access.
+package logsource
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/geodro/lerd/internal/applog"
+	"github.com/geodro/lerd/internal/config"
+	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+var phpVerRe = regexp.MustCompile(`^\d+\.\d+$`)
+
+// Kind is the physical backend a Source is read from.
+type Kind int
+
+const (
+	KindFile    Kind = iota // application log file on disk (real timestamps)
+	KindPodman              // container stdout via `podman logs`
+	KindJournal             // systemd journal (Linux) / launchd log file (macOS)
+)
+
+func (k Kind) String() string {
+	switch k {
+	case KindFile:
+		return "file"
+	case KindPodman:
+		return "podman"
+	case KindJournal:
+		return "journal"
+	}
+	return "unknown"
+}
+
+// Scope distinguishes per-site sources from shared infrastructure.
+type Scope string
+
+const (
+	ScopeSite   Scope = "site"
+	ScopeGlobal Scope = "global"
+)
+
+// Source is one addressable log stream. Locator is a file path (KindFile), a
+// container name (KindPodman), or a unit name (KindJournal).
+type Source struct {
+	Name    string
+	Kind    Kind
+	Locator string
+	Scope   Scope
+	Format  string // "monolog"|"raw" for KindFile, empty otherwise
+	Label   string
+}
+
+// Sources enumerates every queryable source for the given site context plus the
+// always-present global infrastructure sources. Either siteName or sitePath may
+// be empty; when neither resolves to a registered site only globals are returned.
+func Sources(siteName, sitePath string) ([]Source, error) {
+	var out []Source
+	if site := resolveSite(siteName, sitePath); site != nil {
+		out = append(out, siteSources(site)...)
+	}
+	out = append(out, globalSources()...)
+	return out, nil
+}
+
+// Resolve looks up a single source by name within the current context. It
+// resolves the deterministic names (fpm, worker:*, globals) directly so a fetch
+// doesn't pay for a full Sources() enumeration (framework resolution, log-file
+// globbing, installed-PHP discovery); only app:* files and the unknown-name
+// error path fall back to the full listing.
+func Resolve(siteName, sitePath, name string) (Source, error) {
+	site := resolveSite(siteName, sitePath)
+	if site != nil {
+		if s, ok := resolveSiteDirect(site, name); ok {
+			return s, nil
+		}
+	}
+	if s, ok := globalDirect(name); ok {
+		return s, nil
+	}
+
+	srcs, err := Sources(siteName, sitePath)
+	if err != nil {
+		return Source{}, err
+	}
+	names := make([]string, 0, len(srcs))
+	for _, s := range srcs {
+		if s.Name == name {
+			return s, nil
+		}
+		names = append(names, s.Name)
+	}
+	return Source{}, fmt.Errorf("unknown log source %q; valid: %s", name, strings.Join(names, ", "))
+}
+
+// resolveSiteDirect resolves the non-file site sources by name without touching
+// the framework definition or globbing the log directory.
+func resolveSiteDirect(site *config.Site, name string) (Source, bool) {
+	if name == "fpm" {
+		if c := FPMContainer(site); c != "" {
+			return fpmSource(site, c), true
+		}
+		return Source{}, false
+	}
+	if worker, ok := strings.CutPrefix(name, "worker:"); ok {
+		if proj, err := config.LoadProjectConfig(site.Path); err == nil && projectHasWorker(proj, worker) {
+			return workerSource(site.Name, worker), true
+		}
+	}
+	return Source{}, false
+}
+
+func projectHasWorker(proj *config.ProjectConfig, worker string) bool {
+	for _, w := range proj.Workers {
+		if w == worker {
+			return true
+		}
+	}
+	_, ok := proj.CustomWorkers[worker]
+	return ok
+}
+
+func resolveSite(siteName, sitePath string) *config.Site {
+	if siteName != "" {
+		if s, err := config.FindSite(siteName); err == nil {
+			return s
+		}
+	}
+	if sitePath != "" {
+		if s, err := config.FindSiteByPath(sitePath); err == nil {
+			return s
+		}
+	}
+	return nil
+}
+
+func siteSources(site *config.Site) []Source {
+	var out []Source
+
+	// 1. Application log files discovered from the framework definition.
+	if fw, ok := config.GetFrameworkForDir(site.Framework, site.Path); ok && len(fw.Logs) > 0 {
+		files, _ := applog.DiscoverLogFiles(site.Path, fw.Logs)
+		for _, f := range files {
+			path := applog.ResolveLogFilePath(site.Path, fw.Logs, f.Name)
+			if path == "" {
+				continue
+			}
+			out = append(out, Source{
+				Name:    "app:" + f.Name,
+				Kind:    KindFile,
+				Locator: path,
+				Scope:   ScopeSite,
+				Format:  applog.FormatForFile(fw.Logs, f.Name),
+				Label:   "app log " + f.Name + " (" + site.Name + ")",
+			})
+		}
+	}
+
+	// 2. The site's primary app container (shared FPM, or its own custom /
+	//    FrankenPHP / custom-FPM container). Skipped for host-proxy sites that
+	//    run no container.
+	if c := FPMContainer(site); c != "" {
+		out = append(out, fpmSource(site, c))
+	}
+
+	// 3. Worker units declared by the project.
+	if proj, err := config.LoadProjectConfig(site.Path); err == nil {
+		for _, w := range proj.Workers {
+			out = append(out, workerSource(site.Name, w))
+		}
+		names := make([]string, 0, len(proj.CustomWorkers))
+		for w := range proj.CustomWorkers {
+			names = append(names, w)
+		}
+		sort.Strings(names)
+		for _, w := range names {
+			out = append(out, workerSource(site.Name, w))
+		}
+	}
+
+	return out
+}
+
+// FPMContainer resolves the container that serves a site: its own custom /
+// FrankenPHP / custom-FPM container when applicable, otherwise the shared
+// lerd-php<version>-fpm. Returns "" for host-proxy sites, which run no
+// container. Mirrors cli.resolveWorkerFPMUnit so logs target the same place
+// workers exec into.
+func FPMContainer(site *config.Site) string {
+	switch {
+	case site.IsHostProxy():
+		return ""
+	case site.IsCustomContainer():
+		return podman.CustomContainerName(site.Name)
+	case site.IsFrankenPHP():
+		return podman.FrankenPHPContainerName(site.Name)
+	case site.IsCustomFPM():
+		return podman.CustomFPMContainerName(site.Name)
+	}
+	v := site.PHPVersion
+	if detected, err := phpDet.DetectVersion(site.Path); err == nil && detected != "" {
+		v = detected
+	}
+	return "lerd-php" + strings.ReplaceAll(v, ".", "") + "-fpm"
+}
+
+func fpmSource(site *config.Site, container string) Source {
+	return Source{Name: "fpm", Kind: KindPodman, Locator: container, Scope: ScopeSite, Label: "PHP-FPM (" + site.Name + ")"}
+}
+
+func workerSource(siteName, worker string) Source {
+	return Source{
+		Name:    "worker:" + worker,
+		Kind:    KindJournal,
+		Locator: "lerd-" + worker + "-" + siteName,
+		Scope:   ScopeSite,
+		Label:   worker + " worker (" + siteName + ")",
+	}
+}
+
+// staticGlobals are the fixed infrastructure sources present on every machine.
+func staticGlobals() []Source {
+	return []Source{
+		{Name: "nginx", Kind: KindPodman, Locator: "lerd-nginx", Scope: ScopeGlobal, Label: "nginx"},
+		{Name: "dns", Kind: KindPodman, Locator: "lerd-dns", Scope: ScopeGlobal, Label: "dnsmasq"},
+		{Name: "watcher", Kind: KindJournal, Locator: "lerd-watcher", Scope: ScopeGlobal, Label: "file watcher"},
+		{Name: "ui", Kind: KindJournal, Locator: "lerd-ui", Scope: ScopeGlobal, Label: "lerd UI server"},
+	}
+}
+
+func serviceSource(name string) Source {
+	return Source{Name: name, Kind: KindPodman, Locator: "lerd-" + name, Scope: ScopeGlobal, Label: name + " service"}
+}
+
+func phpSource(version string) Source {
+	return Source{
+		Name:    "php" + version,
+		Kind:    KindPodman,
+		Locator: "lerd-php" + strings.ReplaceAll(version, ".", "") + "-fpm",
+		Scope:   ScopeGlobal,
+		Label:   "PHP-FPM " + version,
+	}
+}
+
+func globalSources() []Source {
+	out := staticGlobals()
+	for _, svc := range config.DefaultPresetNames() {
+		out = append(out, serviceSource(svc))
+	}
+	if versions, err := phpDet.ListInstalled(); err == nil {
+		for _, v := range versions {
+			out = append(out, phpSource(v))
+		}
+	}
+	return out
+}
+
+// globalDirect resolves a global source by name without enumerating services or
+// probing installed PHP versions.
+func globalDirect(name string) (Source, bool) {
+	for _, s := range staticGlobals() {
+		if s.Name == name {
+			return s, true
+		}
+	}
+	if config.IsDefaultPreset(name) {
+		return serviceSource(name), true
+	}
+	if v, ok := strings.CutPrefix(name, "php"); ok && phpVerRe.MatchString(v) {
+		return phpSource(v), true
+	}
+	return Source{}, false
+}

--- a/internal/logsource/source_test.go
+++ b/internal/logsource/source_test.go
@@ -1,0 +1,179 @@
+package logsource
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+var fpmRe = regexp.MustCompile(`^lerd-php\d+-fpm$`)
+
+// seedSite points the data dir at a temp location and registers a site whose
+// project dir declares two workers.
+func seedSite(t *testing.T) (siteName, sitePath string) {
+	t.Helper()
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	sitePath = t.TempDir()
+	yaml := "workers:\n  - queue\n  - horizon\n"
+	if err := os.WriteFile(filepath.Join(sitePath, ".lerd.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatalf("write .lerd.yaml: %v", err)
+	}
+	site := config.Site{Name: "myapp", Domains: []string{"myapp.test"}, Path: sitePath, PHPVersion: "8.4"}
+	if err := config.AddSite(site); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+	return "myapp", sitePath
+}
+
+func sourceByName(srcs []Source, name string) (Source, bool) {
+	for _, s := range srcs {
+		if s.Name == name {
+			return s, true
+		}
+	}
+	return Source{}, false
+}
+
+func TestSources_EnumeratesSiteAndGlobals(t *testing.T) {
+	name, path := seedSite(t)
+	srcs, err := Sources(name, path)
+	if err != nil {
+		t.Fatalf("Sources: %v", err)
+	}
+
+	want := map[string]struct {
+		kind  Kind
+		scope Scope
+	}{
+		"fpm":            {KindPodman, ScopeSite},
+		"worker:queue":   {KindJournal, ScopeSite},
+		"worker:horizon": {KindJournal, ScopeSite},
+		"nginx":          {KindPodman, ScopeGlobal},
+		"dns":            {KindPodman, ScopeGlobal},
+		"watcher":        {KindJournal, ScopeGlobal},
+		"ui":             {KindJournal, ScopeGlobal},
+	}
+	for n, exp := range want {
+		s, ok := sourceByName(srcs, n)
+		if !ok {
+			t.Errorf("missing source %q", n)
+			continue
+		}
+		if s.Kind != exp.kind {
+			t.Errorf("%s kind = %v, want %v", n, s.Kind, exp.kind)
+		}
+		if s.Scope != exp.scope {
+			t.Errorf("%s scope = %v, want %v", n, s.Scope, exp.scope)
+		}
+	}
+
+	// The FPM container follows the detected/registered PHP version; assert the
+	// shape rather than a fixed version, which varies by machine default.
+	if fpm, _ := sourceByName(srcs, "fpm"); !fpmRe.MatchString(fpm.Locator) {
+		t.Errorf("fpm locator = %q, want lerd-php<NN>-fpm", fpm.Locator)
+	}
+	if w, _ := sourceByName(srcs, "worker:queue"); w.Locator != "lerd-queue-myapp" {
+		t.Errorf("worker locator = %q, want lerd-queue-myapp", w.Locator)
+	}
+}
+
+func TestSources_NoSiteStillReturnsGlobals(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	srcs, err := Sources("", "")
+	if err != nil {
+		t.Fatalf("Sources: %v", err)
+	}
+	if _, ok := sourceByName(srcs, "nginx"); !ok {
+		t.Error("expected global nginx source even without a site")
+	}
+	if _, ok := sourceByName(srcs, "fpm"); ok {
+		t.Error("did not expect a site fpm source without a site")
+	}
+}
+
+func TestResolve_UnknownListsValidNames(t *testing.T) {
+	name, path := seedSite(t)
+	_, err := Resolve(name, path, "bogus")
+	if err == nil {
+		t.Fatal("expected error for unknown source")
+	}
+	if !strings.Contains(err.Error(), "nginx") {
+		t.Errorf("error should list valid names, got %q", err.Error())
+	}
+}
+
+func TestResolve_FindsKnownSource(t *testing.T) {
+	name, path := seedSite(t)
+	s, err := Resolve(name, path, "worker:horizon")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if s.Locator != "lerd-horizon-myapp" {
+		t.Errorf("locator = %q, want lerd-horizon-myapp", s.Locator)
+	}
+}
+
+func TestFPMContainer_SiteTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		site config.Site
+		want string
+	}{
+		{"custom-container", config.Site{Name: "nestapp", ContainerPort: 3000}, "lerd-custom-nestapp"},
+		{"frankenphp", config.Site{Name: "fapp", Runtime: "frankenphp"}, "lerd-fp-fapp"},
+		{"custom-fpm", config.Site{Name: "cfapp", Runtime: "fpm-custom"}, "lerd-cfpm-cfapp"},
+		{"host-proxy", config.Site{Name: "hp", HostPort: 5173}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := tc.site
+			if got := FPMContainer(&s); got != tc.want {
+				t.Errorf("FPMContainer = %q, want %q", got, tc.want)
+			}
+		})
+	}
+	// A normal site falls back to the shared per-version container.
+	plain := config.Site{Name: "plain", PHPVersion: "8.4", Path: t.TempDir()}
+	if got := FPMContainer(&plain); !fpmRe.MatchString(got) {
+		t.Errorf("normal FPMContainer = %q, want lerd-php<NN>-fpm", got)
+	}
+}
+
+func TestResolve_DirectSources(t *testing.T) {
+	name, path := seedSite(t)
+	cases := []struct{ in, wantLocator string }{
+		{"fpm", ""}, // matched by pattern below
+		{"worker:queue", "lerd-queue-myapp"},
+		{"nginx", "lerd-nginx"},
+		{"dns", "lerd-dns"},
+		{"php8.4", "lerd-php84-fpm"},
+	}
+	for _, tc := range cases {
+		s, err := Resolve(name, path, tc.in)
+		if err != nil {
+			t.Errorf("Resolve(%q): %v", tc.in, err)
+			continue
+		}
+		if tc.in == "fpm" {
+			if !fpmRe.MatchString(s.Locator) {
+				t.Errorf("fpm locator = %q, want lerd-php<NN>-fpm", s.Locator)
+			}
+			continue
+		}
+		if s.Locator != tc.wantLocator {
+			t.Errorf("Resolve(%q) locator = %q, want %q", tc.in, s.Locator, tc.wantLocator)
+		}
+	}
+}
+
+func TestResolve_UndeclaredWorkerIsUnknown(t *testing.T) {
+	name, path := seedSite(t)
+	if _, err := Resolve(name, path, "worker:bogus"); err == nil {
+		t.Error("expected undeclared worker to be unknown")
+	}
+}

--- a/internal/mcp/groups.go
+++ b/internal/mcp/groups.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 )
 
-// This file consolidates what used to be ~80 flat MCP tools into ten
+// This file consolidates what used to be ~80 flat MCP tools into eleven
 // resource-grouped tools (site, service, db, env, runtime, worker, exec,
-// framework, diag, worktree), each selecting behaviour via an `action` enum.
+// framework, diag, logs, worktree), each selecting behaviour via an `action` enum.
 // The grouped manifest is a fraction of the old tools/list payload (cheaper per
 // session, sharper model focus) and is now STATIC — framework-specific actions
 // like queue/horizon are gated inside their handlers rather than by toggling the
@@ -31,6 +31,7 @@ func toolList() []mcpTool {
 		execTool(),
 		frameworkTool(),
 		diagTool(),
+		logsTool(),
 		worktreeTool(),
 	}
 }
@@ -160,7 +161,6 @@ var groupDispatch = map[string]map[string]handlerFn{
 	"diag": {
 		"status":          func(a map[string]any) (any, *rpcError) { return execStatus() },
 		"doctor":          func(a map[string]any) (any, *rpcError) { return execDoctor() },
-		"logs":            execLogs,
 		"which":           execWhich,
 		"check":           execCheck,
 		"dns_diagnose":    execDNSDiagnose,
@@ -176,6 +176,10 @@ var groupDispatch = map[string]map[string]handlerFn{
 		"xdebug_on":       func(a map[string]any) (any, *rpcError) { return execXdebugToggle(a, true) },
 		"xdebug_off":      func(a map[string]any) (any, *rpcError) { return execXdebugToggle(a, false) },
 		"xdebug_status":   func(a map[string]any) (any, *rpcError) { return execXdebugStatus() },
+	},
+	"logs": {
+		"sources": execLogsSources,
+		"fetch":   execLogsFetch,
 	},
 }
 
@@ -441,14 +445,12 @@ func frameworkTool() mcpTool {
 func diagTool() mcpTool {
 	return mcpTool{
 		Name:        "diag",
-		Description: "Diagnostics & observability. action: status, doctor, logs, which, check, dns_diagnose, bug_report, analyze_queries (N+1/slow queries), dumps_recent, dumps_status, dumps_clear, dumps_toggle, profiler_toggle, profiler_status, profiler_clear, xdebug_on, xdebug_off, xdebug_status.",
+		Description: "Diagnostics & observability. action: status, doctor, which, check, dns_diagnose, bug_report, analyze_queries (N+1/slow queries), dumps_recent, dumps_status, dumps_clear, dumps_toggle, profiler_toggle, profiler_status, profiler_clear, xdebug_on, xdebug_off, xdebug_status. (Reading logs moved to the `logs` tool.)",
 		InputSchema: mcpSchema{
 			Type: "object",
 			Properties: map[string]mcpProp{
-				"action":          {Type: "string", Enum: []string{"status", "doctor", "logs", "which", "check", "dns_diagnose", "bug_report", "analyze_queries", "dumps_recent", "dumps_status", "dumps_clear", "dumps_toggle", "profiler_toggle", "profiler_status", "profiler_clear", "xdebug_on", "xdebug_off", "xdebug_status"}},
+				"action":          {Type: "string", Enum: []string{"status", "doctor", "which", "check", "dns_diagnose", "bug_report", "analyze_queries", "dumps_recent", "dumps_status", "dumps_clear", "dumps_toggle", "profiler_toggle", "profiler_status", "profiler_clear", "xdebug_on", "xdebug_off", "xdebug_status"}},
 				"path":            {Type: "string", Description: "Project root (which/check). Defaults to cwd."},
-				"target":          {Type: "string", Description: "logs: nginx, service, PHP version, or site name."},
-				"lines":           {Type: "integer", Description: "logs: tail count (default 50)."},
 				"site":            {Type: "string", Description: "dumps/analyze_queries: site filter."},
 				"branch":          {Type: "string", Description: "dumps_recent: worktree branch filter."},
 				"ctx":             {Type: "string", Enum: []string{"fpm", "cli"}, Description: "dumps_recent: context filter."},

--- a/internal/mcp/groups_test.go
+++ b/internal/mcp/groups_test.go
@@ -56,9 +56,9 @@ func TestWorkerModeActions_split(t *testing.T) {
 	}
 }
 
-// TestToolList_tenGroups is a guardrail on the consolidated surface.
-func TestToolList_tenGroups(t *testing.T) {
-	want := []string{"db", "diag", "env", "exec", "framework", "runtime", "service", "site", "worker", "worktree"}
+// TestToolList_groups is a guardrail on the consolidated surface.
+func TestToolList_groups(t *testing.T) {
+	want := []string{"db", "diag", "env", "exec", "framework", "logs", "runtime", "service", "site", "worker", "worktree"}
 	got := make([]string, 0, len(toolList()))
 	for _, tool := range toolList() {
 		got = append(got, tool.Name)

--- a/internal/mcp/logs.go
+++ b/internal/mcp/logs.go
@@ -1,0 +1,104 @@
+package mcp
+
+import (
+	"encoding/json"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/logsource"
+)
+
+func logsTool() mcpTool {
+	return mcpTool{
+		Name:        "logs",
+		Description: "Read logs from any source lerd can reach (app/framework files, PHP-FPM, workers, nginx, dns, services) filtered by string and time. action: sources (list what you can query), fetch (read one source). fetch returns a cursor; call again with since=<cursor> for only the new lines.",
+		InputSchema: mcpSchema{
+			Type: "object",
+			Properties: map[string]mcpProp{
+				"action": {Type: "string", Enum: []string{"sources", "fetch"}},
+				"source": {Type: "string", Description: "fetch: a source name from `sources` (e.g. app:laravel.log, fpm, worker:queue, nginx, dns)."},
+				"path":   {Type: "string", Description: "Project root. Defaults to the open site."},
+				"site":   {Type: "string", Description: "Site name override when not running inside the project."},
+				"grep":   {Type: "string", Description: "fetch: keep only lines matching this regex (falls back to literal substring)."},
+				"since":  {Type: "string", Description: "fetch: window start — relative (15m, 1h, 2h30m), a timestamp, or a cursor from a prior fetch."},
+				"until":  {Type: "string", Description: "fetch: window end (same formats as since)."},
+				"level":  {Type: "string", Description: "fetch: app logs only — filter by level (error, warning, info, debug)."},
+				"lines":  {Type: "integer", Description: "fetch: max lines to return (default 50)."},
+				"cursor": {Type: "string", Description: "fetch: convenience alias for since when polling for new lines."},
+			},
+			Required: []string{"action"},
+		},
+	}
+}
+
+func execLogsSources(args map[string]any) (any, *rpcError) {
+	siteName := strArg(args, "site")
+	srcs, err := logsource.Sources(siteName, logsSitePath(args, siteName))
+	if err != nil {
+		return toolErr(err.Error()), nil
+	}
+	type srcOut struct {
+		Name   string `json:"name"`
+		Kind   string `json:"kind"`
+		Scope  string `json:"scope"`
+		Format string `json:"format,omitempty"`
+	}
+	out := make([]srcOut, 0, len(srcs))
+	for _, s := range srcs {
+		out = append(out, srcOut{Name: s.Name, Kind: s.Kind.String(), Scope: string(s.Scope), Format: s.Format})
+	}
+	b, _ := json.MarshalIndent(out, "", "  ")
+	return toolOK(string(b)), nil
+}
+
+func execLogsFetch(args map[string]any) (any, *rpcError) {
+	source := strArg(args, "source")
+	if source == "" {
+		return toolErr("source is required — call logs.sources to list available sources"), nil
+	}
+	siteName := strArg(args, "site")
+	src, err := logsource.Resolve(siteName, logsSitePath(args, siteName), source)
+	if err != nil {
+		return toolErr(err.Error()), nil
+	}
+
+	since := strArg(args, "since")
+	if c := strArg(args, "cursor"); c != "" {
+		since = c
+	}
+	res, err := logsource.Read(src, logsource.Opts{
+		Since: since,
+		Until: strArg(args, "until"),
+		Grep:  strArg(args, "grep"),
+		Lines: intArg(args, "lines", 50),
+		Level: strArg(args, "level"),
+	})
+	if err != nil {
+		return toolErr(err.Error()), nil
+	}
+
+	out := map[string]any{
+		"source":    src.Name,
+		"kind":      src.Kind.String(),
+		"cursor":    res.Cursor,
+		"truncated": res.Truncated,
+		"count":     len(res.Entries),
+		"entries":   res.Entries,
+	}
+	b, _ := json.MarshalIndent(out, "", "  ")
+	return toolOK(string(b)), nil
+}
+
+// logsSitePath resolves the project path used for source enumeration: an
+// explicit path arg, else the registered path of the named site, else the
+// injected default site path.
+func logsSitePath(args map[string]any, siteName string) string {
+	if p := strArg(args, "path"); p != "" {
+		return p
+	}
+	if siteName != "" {
+		if s, err := config.FindSite(siteName); err == nil {
+			return s.Path
+		}
+	}
+	return defaultSitePath
+}

--- a/internal/mcp/logs_test.go
+++ b/internal/mcp/logs_test.go
@@ -1,0 +1,93 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func seedSiteForLogs(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	sitePath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sitePath, ".lerd.yaml"), []byte("workers:\n  - queue\n"), 0644); err != nil {
+		t.Fatalf("write .lerd.yaml: %v", err)
+	}
+	if err := config.AddSite(config.Site{Name: "logsite", Domains: []string{"logsite.test"}, Path: sitePath, PHPVersion: "8.4"}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+}
+
+// textOf pulls the text payload out of a toolOK/toolErr envelope.
+func textOf(t *testing.T, v any) (string, bool) {
+	t.Helper()
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("result is not a map: %T", v)
+	}
+	isErr, _ := m["isError"].(bool)
+	content, ok := m["content"].([]map[string]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("result has no content: %+v", m)
+	}
+	text, _ := content[0]["text"].(string)
+	return text, isErr
+}
+
+func TestExecLogsSources_ListsSiteAndGlobals(t *testing.T) {
+	seedSiteForLogs(t)
+	res, rpcErr := execLogsSources(map[string]any{"site": "logsite"})
+	if rpcErr != nil {
+		t.Fatalf("execLogsSources: %v", rpcErr)
+	}
+	text, isErr := textOf(t, res)
+	if isErr {
+		t.Fatalf("unexpected error result: %s", text)
+	}
+	for _, name := range []string{"fpm", "worker:queue", "nginx", "dns"} {
+		if !strings.Contains(text, `"name": "`+name+`"`) {
+			t.Errorf("sources output missing %q:\n%s", name, text)
+		}
+	}
+}
+
+func TestExecLogsFetch_UnknownSourceListsValidNames(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	res, _ := execLogsFetch(map[string]any{"source": "does-not-exist"})
+	text, isErr := textOf(t, res)
+	if !isErr {
+		t.Fatalf("expected error for unknown source, got: %s", text)
+	}
+	if !strings.Contains(text, "nginx") {
+		t.Errorf("error should list valid sources, got: %s", text)
+	}
+}
+
+func TestExecLogsFetch_RequiresSource(t *testing.T) {
+	seedSiteForLogs(t)
+	res, _ := execLogsFetch(map[string]any{"site": "logsite"})
+	text, isErr := textOf(t, res)
+	if !isErr || !strings.Contains(text, "source is required") {
+		t.Fatalf("expected source-required error, got isErr=%v text=%s", isErr, text)
+	}
+}
+
+func TestExecLogsFetch_FetchShapeIsJSON(t *testing.T) {
+	// Sanity check the JSON envelope shape produced by a successful fetch by
+	// round-tripping a hand-built result through the marshaller path the
+	// handler uses. This guards the field names the agent relies on.
+	out := map[string]any{"source": "fpm", "kind": "podman", "cursor": "", "truncated": false, "count": 0, "entries": []any{}}
+	b, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, k := range []string{"source", "kind", "cursor", "truncated", "count", "entries"} {
+		if !strings.Contains(string(b), `"`+k+`"`) {
+			t.Errorf("fetch JSON missing key %q", k)
+		}
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/geodro/lerd/internal/dns"
 	"github.com/geodro/lerd/internal/envfile"
 	gitpkg "github.com/geodro/lerd/internal/git"
+	"github.com/geodro/lerd/internal/logsource"
 	"github.com/geodro/lerd/internal/nginx"
 	lerdNode "github.com/geodro/lerd/internal/node"
 	phpDet "github.com/geodro/lerd/internal/php"
@@ -46,7 +47,6 @@ func builtinServiceEnv(name string) []string { return config.DefaultPresetEnvVar
 
 // phpVersionRe matches PHP version strings like "8.4" or "8.3" — digits only, no domain names.
 var phpVersionRe = regexp.MustCompile(`^\d+\.\d+$`)
-var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 
 // defaultSitePath is resolved at startup: LERD_SITE_PATH takes precedence (injected by
 // mcp:inject for project-scoped use); if not set, the working directory is used so that
@@ -201,7 +201,7 @@ func toolErr(text string) map[string]any {
 }
 
 func stripANSI(s string) string {
-	return ansiRe.ReplaceAllString(s, "")
+	return logsource.StripANSI(s)
 }
 
 func strArg(args map[string]any, key string) string {
@@ -898,61 +898,6 @@ func execStripeConfig(args map[string]any) (any, *rpcError) {
 	}
 	return toolOK(fmt.Sprintf("Updated Stripe config for %s\nWebhook path: %s",
 		siteName, config.StripeWebhookPath(site.Path))), nil
-}
-
-func execLogs(args map[string]any) (any, *rpcError) {
-	target := strArg(args, "target")
-	lines := intArg(args, "lines", 50)
-
-	// When no target is given, derive the FPM container from the current site path.
-	if target == "" {
-		projectPath := resolvedPath(args)
-		if projectPath == "" {
-			return toolErr("target is required (or set LERD_SITE_PATH via mcp:inject)"), nil
-		}
-		site, err := config.FindSiteByPath(projectPath)
-		if err != nil {
-			return toolErr("could not find site for path: " + projectPath), nil
-		}
-		target = site.Name
-	}
-
-	container, err := resolveLogsContainer(target)
-	if err != nil {
-		return toolErr(err.Error()), nil
-	}
-
-	var out bytes.Buffer
-	cmd := podman.Cmd("logs", "--tail", fmt.Sprintf("%d", lines), container)
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	_ = cmd.Run() // non-zero exit if container not running is fine — we return what we have
-
-	return toolOK(stripANSI(strings.TrimSpace(out.String()))), nil
-}
-
-func resolveLogsContainer(target string) (string, error) {
-	if target == "nginx" {
-		return "lerd-nginx", nil
-	}
-	if isKnownService(target) {
-		return "lerd-" + target, nil
-	}
-	// PHP version like "8.4" — match digits.digits only, not domain names
-	if phpVersionRe.MatchString(target) {
-		short := strings.ReplaceAll(target, ".", "")
-		return "lerd-php" + short + "-fpm", nil
-	}
-	// Site name — look up PHP version from registry
-	if site, err := config.FindSite(target); err == nil {
-		phpVersion := site.PHPVersion
-		if detected, err := phpDet.DetectVersion(site.Path); err == nil && detected != "" {
-			phpVersion = detected
-		}
-		short := strings.ReplaceAll(phpVersion, ".", "")
-		return "lerd-php" + short + "-fpm", nil
-	}
-	return "", fmt.Errorf("unknown log target %q — valid: nginx, service name, PHP version (e.g. 8.4), or site name", target)
 }
 
 func execComposer(args map[string]any) (any, *rpcError) {

--- a/internal/ui/logs_darwin.go
+++ b/internal/ui/logs_darwin.go
@@ -8,56 +8,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
-	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/unitlog"
 )
 
-func lerdLogPath(unit string) string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, "Library", "Logs", "lerd", unit+".log")
-}
+func lerdLogPath(unit string) string { return unitlog.LogPath(unit) }
 
-// isContainerUnit returns true for units that run as detached podman containers
-// (podman run -d). Their logs come from `podman logs`, not the launchd log file.
-//
-// In exec mode, framework workers run as launchd service units; host workers
-// (vite + future Node tooling) always do, regardless of mode. Detection
-// reads the plist when present (RunAtLoad = service unit), and the on-disk
-// guard script as a second tell — host workers always write one, container
-// workers never do. Falls back to the global config for known framework
-// worker patterns when neither artifact is on disk.
-func isContainerUnit(unit string) bool {
-	switch unit {
-	case "lerd-dns", "lerd-watcher", "lerd-ui":
-		return false
-	}
-	home, _ := os.UserHomeDir()
-	plist, err := os.ReadFile(filepath.Join(home, "Library", "LaunchAgents", unit+".plist"))
-	if err == nil {
-		return !strings.Contains(string(plist), "<key>RunAtLoad</key>")
-	}
-	// No plist on disk yet — the unit may have been removed mid-migration
-	// or never reached the write step. A guard script under run/workers
-	// is the second source of truth: writeWorkerExecUnit and
-	// writeWorkerHostUnit both create one, container workers don't.
-	if _, err := os.Stat(filepath.Join(config.RunDir(), "workers", unit+".sh")); err == nil {
-		return false
-	}
-	// Last resort: built-in framework worker prefix + exec mode means
-	// "launchd-supervised service unit", not a container.
-	if isFrameworkWorkerUnit(unit) {
-		cfg, _ := config.LoadGlobal()
-		if cfg != nil && cfg.WorkerExecMode() != config.WorkerExecModeContainer {
-			return false
-		}
-	}
-	return true
-}
+// isContainerUnit returns true for units whose logs come from `podman logs`
+// rather than the launchd log file.
+func isContainerUnit(unit string) bool { return unitlog.IsContainerUnit(unit) }
 
 func serviceRecentLogs(unit string) string {
 	if isContainerUnit(unit) {

--- a/internal/ui/logs_linux.go
+++ b/internal/ui/logs_linux.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"os/exec"
 	"strings"
+
+	"github.com/geodro/lerd/internal/unitlog"
 )
 
 func serviceRecentLogs(unit string) string {
@@ -24,7 +26,7 @@ func logStreamCmd(ctx context.Context, unit string) *exec.Cmd {
 }
 
 // isContainerUnit returns true on Linux — all lerd units run as Podman containers.
-func isContainerUnit(_ string) bool { return true }
+func isContainerUnit(unit string) bool { return unitlog.IsContainerUnit(unit) }
 
 func streamUnitLogs(w http.ResponseWriter, r *http.Request, unit string) {
 	flusher, ok := w.(http.Flusher)

--- a/internal/ui/worker_units.go
+++ b/internal/ui/worker_units.go
@@ -1,16 +1,9 @@
 package ui
 
-import "strings"
+import "github.com/geodro/lerd/internal/unitlog"
 
 // isFrameworkWorkerUnit reports whether unit looks like a built-in framework
 // worker (queue, schedule, horizon, reverb). Used by handleLogs to decide
 // whether to register the SSE stream with logStreams so a worker-mode
 // migration can cancel it before issuing podman rm calls.
-func isFrameworkWorkerUnit(unit string) bool {
-	for _, prefix := range []string{"lerd-queue-", "lerd-schedule-", "lerd-horizon-", "lerd-reverb-"} {
-		if strings.HasPrefix(unit, prefix) {
-			return true
-		}
-	}
-	return false
-}
+func isFrameworkWorkerUnit(unit string) bool { return unitlog.IsFrameworkWorkerUnit(unit) }

--- a/internal/unitlog/unitlog.go
+++ b/internal/unitlog/unitlog.go
@@ -1,0 +1,19 @@
+// Package unitlog centralises how lerd locates a unit's logs across platforms:
+// whether a unit runs as a detached podman container (logs via `podman logs`)
+// versus a launchd-supervised service on macOS (logs in ~/Library/Logs/lerd),
+// and the framework-worker classification both decisions lean on. Shared by the
+// UI log streamer and the logsource reader so the rules live in one place.
+package unitlog
+
+import "strings"
+
+// IsFrameworkWorkerUnit reports whether unit looks like a built-in framework
+// worker (queue, schedule, horizon, reverb).
+func IsFrameworkWorkerUnit(unit string) bool {
+	for _, prefix := range []string{"lerd-queue-", "lerd-schedule-", "lerd-horizon-", "lerd-reverb-"} {
+		if strings.HasPrefix(unit, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/unitlog/unitlog_darwin.go
+++ b/internal/unitlog/unitlog_darwin.go
@@ -1,0 +1,47 @@
+//go:build darwin
+
+package unitlog
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// LogPath is where a launchd-supervised lerd unit writes its log on macOS.
+func LogPath(unit string) string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, "Library", "Logs", "lerd", unit+".log")
+}
+
+// IsContainerUnit returns true for units that run as detached podman containers
+// (podman run -d). Their logs come from `podman logs`, not the launchd log file.
+//
+// In exec mode, framework workers run as launchd service units; host workers
+// (vite + future Node tooling) always do, regardless of mode. Detection reads
+// the plist when present (RunAtLoad = service unit), and the on-disk guard
+// script as a second tell — host workers always write one, container workers
+// never do. Falls back to the global config for known framework worker patterns
+// when neither artifact is on disk.
+func IsContainerUnit(unit string) bool {
+	switch unit {
+	case "lerd-dns", "lerd-watcher", "lerd-ui":
+		return false
+	}
+	home, _ := os.UserHomeDir()
+	if plist, err := os.ReadFile(filepath.Join(home, "Library", "LaunchAgents", unit+".plist")); err == nil {
+		return !strings.Contains(string(plist), "<key>RunAtLoad</key>")
+	}
+	if _, err := os.Stat(filepath.Join(config.RunDir(), "workers", unit+".sh")); err == nil {
+		return false
+	}
+	if IsFrameworkWorkerUnit(unit) {
+		cfg, _ := config.LoadGlobal()
+		if cfg != nil && cfg.WorkerExecMode() != config.WorkerExecModeContainer {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/unitlog/unitlog_linux.go
+++ b/internal/unitlog/unitlog_linux.go
@@ -1,0 +1,7 @@
+//go:build linux
+
+package unitlog
+
+// IsContainerUnit returns true on Linux — all lerd units run as Podman
+// containers, so their logs come from `podman logs` / the journal.
+func IsContainerUnit(_ string) bool { return true }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
       - Project Setup: features/project-setup.md
       - Environment Setup: features/env-setup.md
       - AI Integration (MCP): features/mcp.md
+      - Logs: features/logs.md
   - Reference:
       - Command Reference: reference/commands.md
       - Configuration: reference/configuration.md


### PR DESCRIPTION
Agents debugging a site through the MCP server only had `diag.logs`, which tailed a single container with no string or time filtering and no access to application, worker, or journal logs. This adds a dedicated `logs` tool that enumerates every source lerd can reach and fetches from any one of them filtered by string, time window, and level.

A new `internal/logsource` package wraps the three existing readers, the `applog` file parser, `podman logs`, and journalctl or the launchd log files on macOS, behind one Source registry and a `Read` dispatcher with a build-tagged platform split. The tool exposes `sources`, which lists the queryable sources for a site plus shared infrastructure such as nginx, dns, services, and the watcher, and `fetch`, which reads one source with `grep`, `since` and `until`, `level`, and `lines`. Because MCP is request and response, streaming is modelled as cursor polling: every `fetch` returns an opaque `cursor` the agent passes back as `since` to receive only the new lines.

The `fpm` source resolves a site's actual serving container, so custom-container, FrankenPHP, and custom-FPM sites point at the right place rather than the shared image. Grep and time filters on podman sources widen the scan beyond the tail so older matches are not missed, and resolving one source by name no longer enumerates the whole registry. Shared macOS unit detection moves into a new `internal/unitlog` package used by both the UI log streamer and the reader, so the launchd-versus-container logic lives in one place.

`diag.logs` is removed. Reading logs now lives entirely in the `logs` tool, and since the skill files regenerate from the embedded reference on update, nothing references the old action. The reference, the MCP feature page, and a new logs feature page are updated to match.
