### PR TITLE
feat(xdebug): pause into running workers via the control socket, plus on-demand mode

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -110,9 +110,10 @@ Supported PHP versions: **8.5**, **8.4**, **8.3**, **8.2**, **8.1**, and the fro
 | `lerd php:list` | List all installed PHP-FPM versions |
 | `lerd php:rebuild [--local]` | Force-rebuild all installed PHP-FPM images (pulls pre-built base by default; `--local` builds from source) |
 | `lerd fetch [version...] [--local]` | Pull pre-built PHP FPM base images from ghcr.io for the given (or all supported) versions; `--local` builds from source instead |
-| `lerd xdebug on [version] [--mode MODE]` | Enable Xdebug for a PHP version. `--mode` defaults to `debug`; accepts `coverage`, `develop`, `profile`, `trace`, `gcstats`, or comma combos like `debug,coverage` |
+| `lerd xdebug on [version] [--mode MODE] [--on-demand]` | Enable Xdebug for a PHP version. `--mode` defaults to `debug`; accepts `coverage`, `develop`, `profile`, `trace`, `gcstats`, or comma combos like `debug,coverage`. `--on-demand` sets `start_with_request=trigger` so nothing auto-connects |
 | `lerd xdebug off [version]` | Disable Xdebug |
 | `lerd xdebug status` | Show Xdebug enabled/disabled state and active mode for all installed PHP versions |
+| `lerd xdebug pause [site] [--list] [--pid PID]` | Break the IDE debugger into a running worker/CLI process via Xdebug's control socket (`xdebugctl`). `--list` shows candidate processes, `--pid` targets one |
 | `lerd php:ext add <ext> [version] [--apk-deps PKG[,PKG]]` | Add a custom PHP extension and rebuild the FPM image. `--apk-deps` accepts additional Alpine packages that the extension needs at build time (e.g. `--apk-deps libwebp-dev,libpng-dev` for `gd` with WebP support); the package list is persisted in `~/.config/lerd/config.yaml` so future rebuilds reapply it |
 | `lerd php:ext remove <ext> [version]` | Remove a custom PHP extension and rebuild |
 | `lerd php:ext list [version]` | List custom extensions for a PHP version |

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -9,9 +9,10 @@
 | `lerd php:list` | List all installed PHP-FPM versions |
 | `lerd php:rebuild [--local]` | Force-rebuild all installed PHP-FPM images; `--local` builds from source instead of pulling a base |
 | `lerd fetch [version...] [--local]` | Pull pre-built PHP FPM base images from ghcr.io; `--local` builds from source instead |
-| `lerd xdebug on [version] [--mode MODE]` | Enable Xdebug for a PHP version with the given mode (default `debug`) and restart the FPM container |
+| `lerd xdebug on [version] [--mode MODE] [--on-demand]` | Enable Xdebug for a PHP version with the given mode (default `debug`) and restart the FPM container. `--on-demand` sets `start_with_request=trigger` so nothing auto-connects |
 | `lerd xdebug off [version]` | Disable Xdebug and restart the FPM container |
 | `lerd xdebug status` | Show Xdebug enabled/disabled state and active mode for all installed PHP versions |
+| `lerd xdebug pause [site] [--list] [--pid PID]` | Break the IDE debugger into a running worker/CLI process via Xdebug's control socket. `--list` shows candidate processes |
 | `lerd php:ext add <ext> [version] [--apk-deps "pkg ..."]` | Add a custom PHP extension to the FPM image and rebuild; `--apk-deps` lists extra Alpine packages the extension needs to build |
 | `lerd php:ext remove <ext> [version]` | Remove a custom PHP extension and rebuild |
 | `lerd php:ext list [version]` | List custom extensions configured for a PHP version |
@@ -125,7 +126,7 @@ systemctl --user stop   lerd-php84-fpm
 Xdebug is configured with:
 
 - `xdebug.mode=<mode>` (defaults to `debug`, configurable per PHP version)
-- `xdebug.start_with_request=yes`
+- `xdebug.start_with_request=yes` (or `trigger` with `--on-demand`)
 - `xdebug.client_host=host.containers.internal` (reaches your host IDE from the container)
 - `xdebug.client_port=9003`
 
@@ -147,6 +148,20 @@ lerd xdebug on 8.4 --mode trace       # explicit version
 When combined with PCOV this matters in one direction: if your test runner's `phpunit.xml` prefers PCOV it still wins for coverage, but once you enable Xdebug in `coverage` mode your runner can fall back to Xdebug when PCOV isn't available or is disabled (`pcov.enabled = 0` in `lerd php:ini`). Running Xdebug in `coverage` mode carries the usual runtime cost, so only switch while you actually need coverage.
 
 Re-run `lerd xdebug on --mode <new>` at any time to swap modes without going through `off` first.
+
+### On-demand debugging (workers and CLI)
+
+By default `start_with_request=yes`, so with the debugger listening every request and every running worker tries to connect at once. To debug a single process on demand instead, enable on-demand mode and attach with `pause`:
+
+```bash
+lerd xdebug on --on-demand        # start_with_request=trigger — nothing auto-connects
+lerd xdebug pause --list          # list running PHP processes that expose a control socket
+lerd xdebug pause --pid 1234      # break the IDE into that process
+```
+
+`pause` uses Xdebug's [control socket](https://xdebug.org/docs/xdebugctl) (Xdebug >= 3.3, baked into lerd's FPM images) via the `xdebugctl` tool. It is the practical way to debug a **queue/Horizon worker, a scheduled task, or a CLI script** — processes where you can't set a trigger cookie. Run it from a project directory (or pass a site name); lerd resolves the site's container, scopes the candidate list to that site's own processes, and tells the running process to connect to your IDE on port `9003`. The worker must have been started *after* Xdebug was enabled, and your IDE must be listening.
+
+For ordinary web requests under `--on-demand`, use the [Xdebug Helper](https://xdebug.org/docs/step_debug#browser-extensions) browser extension (or append `?XDEBUG_TRIGGER=1`) to trigger a session per page.
 
 ---
 

--- a/internal/cli/xdebug.go
+++ b/internal/cli/xdebug.go
@@ -20,25 +20,33 @@ func NewXdebugCmd() *cobra.Command {
 	cmd.AddCommand(newXdebugOnCmd())
 	cmd.AddCommand(newXdebugOffCmd())
 	cmd.AddCommand(newXdebugStatusCmd())
+	cmd.AddCommand(newXdebugPauseCmd())
 	return cmd
 }
 
 func newXdebugOnCmd() *cobra.Command {
 	var mode string
+	var onDemand bool
 	cmd := &cobra.Command{
 		Use:   "on [version]",
 		Short: "Enable Xdebug for a PHP version (rebuilds the FPM image)",
-		Long:  "Enable Xdebug for a PHP version. Use --mode to pick a non-default mode, e.g. --mode coverage for code coverage, or --mode debug,coverage to combine.",
-		Args:  cobra.MaximumNArgs(1),
+		Long: "Enable Xdebug for a PHP version. Use --mode to pick a non-default mode, e.g. --mode coverage for code coverage, or --mode debug,coverage to combine.\n\n" +
+			"Use --on-demand to set xdebug.start_with_request=trigger: requests and workers no longer auto-connect (no IDE flood); debug a running worker with `lerd xdebug pause`, or a web request via a trigger cookie.",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			normalised, err := podman.NormaliseXdebugMode(mode)
 			if err != nil {
 				return err
 			}
-			return runXdebugToggle(args, true, normalised)
+			start := "yes"
+			if onDemand {
+				start = "trigger"
+			}
+			return runXdebugToggle(args, true, normalised, start)
 		},
 	}
 	cmd.Flags().StringVar(&mode, "mode", "debug", "xdebug.mode value (debug, coverage, develop, profile, trace, gcstats, or a comma-separated combo)")
+	cmd.Flags().BoolVar(&onDemand, "on-demand", false, "set start_with_request=trigger so nothing auto-connects; attach with `lerd xdebug pause` or a trigger cookie")
 	return cmd
 }
 
@@ -48,7 +56,7 @@ func newXdebugOffCmd() *cobra.Command {
 		Short: "Disable Xdebug for a PHP version (rebuilds the FPM image)",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runXdebugToggle(args, false, "")
+			return runXdebugToggle(args, false, "", "yes")
 		},
 	}
 }
@@ -80,7 +88,7 @@ func xdebugVersion(args []string) (string, error) {
 	return v, nil
 }
 
-func runXdebugToggle(args []string, enable bool, mode string) error {
+func runXdebugToggle(args []string, enable bool, mode, start string) error {
 	version, err := xdebugVersion(args)
 	if err != nil {
 		return err
@@ -91,7 +99,7 @@ func runXdebugToggle(args []string, enable bool, mode string) error {
 		applyMode = mode
 	}
 
-	res, err := xdebugops.Apply(version, applyMode)
+	res, err := xdebugops.ApplyWithStart(version, applyMode, start)
 	if err != nil {
 		return err
 	}
@@ -118,7 +126,10 @@ func runXdebugToggle(args []string, enable bool, mode string) error {
 	restartCustomFPMContainersForVersion(version)
 
 	if res.Enabled {
-		fmt.Printf("Xdebug enabled for PHP %s (mode=%s, port 9003, host.containers.internal)\n", version, res.Mode)
+		fmt.Printf("Xdebug enabled for PHP %s (mode=%s, start_with_request=%s, port 9003, host.containers.internal)\n", version, res.Mode, start)
+		if start == "trigger" {
+			fmt.Println("On-demand mode: requests and workers won't auto-connect. Attach with `lerd xdebug pause` or a trigger cookie.")
+		}
 	} else {
 		fmt.Printf("Xdebug disabled for PHP %s\n", version)
 	}

--- a/internal/cli/xdebug_pause.go
+++ b/internal/cli/xdebug_pause.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/logsource"
+	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/spf13/cobra"
+)
+
+// `lerd xdebug pause` drives Xdebug's control socket (Xdebug >= 3.3) to break
+// the IDE debugger into an already-running PHP process — a queue/Horizon worker,
+// a CLI script, a FrankenPHP/Octane worker — without a trigger cookie or
+// per-request connection attempts. It shells out to the upstream `xdebugctl`
+// tool, which is baked into the FPM image (see lerd-php-fpm.Containerfile).
+const xdebugctlInContainer = "/usr/local/bin/xdebugctl"
+
+func newXdebugPauseCmd() *cobra.Command {
+	var pid int
+	var list bool
+	cmd := &cobra.Command{
+		Use:   "pause [site]",
+		Short: "(experimental) Break the IDE debugger into a running PHP process via Xdebug's control socket",
+		Long: "Use Xdebug's control socket to make a running PHP process (a queue/Horizon worker, a CLI\n" +
+			"script, a FrankenPHP worker) connect to your IDE and break in — no trigger cookie, no\n" +
+			"per-request overhead. Requires Xdebug debug mode enabled for the site's PHP version\n" +
+			"(`lerd xdebug on`) and your IDE listening on port 9003.\n\n" +
+			"Run with --list to see the candidate processes, then --pid to target one.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runXdebugPause(args, pid, list)
+		},
+	}
+	cmd.Flags().IntVarP(&pid, "pid", "p", 0, "target a specific PHP process id (from --list)")
+	cmd.Flags().BoolVar(&list, "list", false, "list PHP processes that expose an Xdebug control socket")
+	return cmd
+}
+
+func runXdebugPause(args []string, pid int, list bool) error {
+	site, err := resolvePauseSite(args)
+	if err != nil {
+		return err
+	}
+	// xdebugctl is baked into the shared FPM image (which custom-FPM sites build
+	// FROM); FrankenPHP and custom-container images don't ship it.
+	if site.IsFrankenPHP() || site.IsCustomContainer() {
+		return fmt.Errorf("`lerd xdebug pause` is only available on PHP-FPM sites; %q runs its own container without xdebugctl", site.Name)
+	}
+	version := pauseSiteVersion(site)
+	container := resolveWorkerFPMUnit(site.Name, version)
+	if container == "" {
+		return fmt.Errorf("site %q runs no container to attach to", site.Name)
+	}
+
+	// Pausing needs debug mode actually loaded; listing is harmless either way
+	// (xdebugctl ps simply shows nothing when no process has a control socket).
+	if !list {
+		if cfg, err := config.LoadGlobal(); err == nil && !strings.Contains(cfg.GetXdebugMode(version), "debug") {
+			return fmt.Errorf("Xdebug debug mode is not enabled for PHP %s — run: lerd xdebug on %s", version, version)
+		}
+	}
+
+	ctl, err := ensureXdebugctl(container)
+	if err != nil {
+		return err
+	}
+
+	if pid == 0 {
+		out, _ := podman.Cmd("exec", container, ctl, "ps").CombinedOutput()
+		fmt.Print(string(out))
+		if list {
+			return nil
+		}
+		// The shared FPM container lists workers from every site; scope the
+		// auto-target to this site's own processes by project path.
+		scoped := procsForSite(parseXdebugctlProcs(string(out)), site.Path)
+		switch len(scoped) {
+		case 0:
+			return fmt.Errorf("no PHP process for %q with an Xdebug control socket in %s — start the worker/script after enabling Xdebug, or pass --pid", site.Name, container)
+		case 1:
+			pid = scoped[0].pid
+		default:
+			return fmt.Errorf("multiple processes for %q; re-run with --pid <PID> from the list above", site.Name)
+		}
+	}
+
+	out, err := podman.Cmd("exec", container, ctl, "-p", strconv.Itoa(pid), "pause").CombinedOutput()
+	if s := strings.TrimSpace(string(out)); s != "" {
+		fmt.Println(s)
+	}
+	if err != nil {
+		return fmt.Errorf("xdebugctl pause: %w", err)
+	}
+	fmt.Printf("Sent pause to PID %d in %s — your IDE (listening on :9003) should break in.\n", pid, container)
+	if cfg, err := config.LoadGlobal(); err == nil && cfg.GetXdebugStart(version) == "yes" {
+		fmt.Println("Tip: `lerd xdebug on --on-demand` stops every other request/worker from also connecting to your IDE.")
+	}
+	return nil
+}
+
+func resolvePauseSite(args []string) (*config.Site, error) {
+	if len(args) == 1 {
+		return config.FindSite(args[0])
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	site, err := config.FindSiteByPath(cwd)
+	if err != nil {
+		return nil, fmt.Errorf("no lerd site here — run inside a project or pass a site name")
+	}
+	return site, nil
+}
+
+func pauseSiteVersion(site *config.Site) string {
+	if d, err := phpDet.DetectVersion(site.Path); err == nil && d != "" {
+		return d
+	}
+	if site.PHPVersion != "" {
+		return site.PHPVersion
+	}
+	if cfg, err := config.LoadGlobal(); err == nil {
+		return cfg.PHP.DefaultVersion
+	}
+	return ""
+}
+
+type xdebugProc struct {
+	pid     int
+	command string
+}
+
+// parseXdebugctlProcs parses the data rows of `xdebugctl ps` output (PID, RSS,
+// TIME, COMMAND), skipping the header and any "Error: No response" rows for
+// idle processes that didn't answer the control socket in time.
+func parseXdebugctlProcs(out string) []xdebugProc {
+	// xdebugctl colours its output unconditionally; strip the escapes so the
+	// PID is the first field and project paths match cleanly.
+	out = logsource.StripANSI(out)
+	var procs []xdebugProc
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 || fields[1] == "Error:" {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		procs = append(procs, xdebugProc{pid: pid, command: strings.Join(fields[3:], " ")})
+	}
+	return procs
+}
+
+// procsForSite keeps the processes whose command path lives under the site's
+// project directory, so a bare `pause <site>` targets that site's own workers
+// rather than another site's that happen to share the FPM container.
+func procsForSite(procs []xdebugProc, sitePath string) []xdebugProc {
+	if sitePath == "" {
+		return procs
+	}
+	prefix := strings.TrimRight(sitePath, "/") + "/"
+	var out []xdebugProc
+	for _, p := range procs {
+		// The command begins with the script path; match on a path boundary so
+		// /proj/app doesn't also capture /proj/app2's workers.
+		if strings.HasPrefix(p.command, prefix) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// ensureXdebugctl confirms the baked-in xdebugctl binary is present in the
+// container. It ships in the FPM image; an older image won't have it.
+func ensureXdebugctl(container string) (string, error) {
+	if podman.Cmd("exec", container, "test", "-x", xdebugctlInContainer).Run() == nil {
+		return xdebugctlInContainer, nil
+	}
+	return "", fmt.Errorf("xdebugctl is not in %s — rebuild the PHP image with `lerd php:rebuild` to bake it in", container)
+}

--- a/internal/cli/xdebug_pause_test.go
+++ b/internal/cli/xdebug_pause_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import "testing"
+
+const xdebugctlPS = `       PID      RSS     TIME COMMAND
+        15    50384    76.20 /home/george/Projects/score-diviner/artisan (Xdebug3.5.3)
+        36    49527    76.11 /home/george/Projects/astrolov.com/artisan (Xdebug3.5.3)
+        52    51077    75.19 /home/george/Projects/score-diviner/artisan (Xdebug3.5.3)
+       104 Error: No response on: @xdebug-ctrl.104
+`
+
+func TestParseXdebugctlProcs_skipsHeaderAndErrors(t *testing.T) {
+	procs := parseXdebugctlProcs(xdebugctlPS)
+	if len(procs) != 3 {
+		t.Fatalf("want 3 procs (header + Error row skipped), got %d: %+v", len(procs), procs)
+	}
+	if procs[0].pid != 15 || procs[0].command != "/home/george/Projects/score-diviner/artisan (Xdebug3.5.3)" {
+		t.Errorf("unexpected first proc: %+v", procs[0])
+	}
+}
+
+// xdebugctl colours its output; the parser must strip ANSI so the PID is field 0.
+func TestParseXdebugctlProcs_stripsANSIColour(t *testing.T) {
+	const colored = "\x1b[2m       PID\x1b[0m      RSS     TIME \x1b[97mCOMMAND\x1b[0m\n" +
+		"\x1b[2m        81\x1b[0m    49183    37.17 \x1b[97m/home/george/Projects/score-diviner/artisan\x1b[0m \x1b[2m(Xdebug3.5.3)\x1b[0m\n"
+	procs := parseXdebugctlProcs(colored)
+	if len(procs) != 1 {
+		t.Fatalf("want 1 proc from coloured output, got %d: %+v", len(procs), procs)
+	}
+	if procs[0].pid != 81 {
+		t.Errorf("pid = %d, want 81 (ANSI not stripped?)", procs[0].pid)
+	}
+	if scoped := procsForSite(procs, "/home/george/Projects/score-diviner"); len(scoped) != 1 {
+		t.Errorf("coloured path should still scope, got %d", len(scoped))
+	}
+}
+
+func TestProcsForSite_scopesByProjectPath(t *testing.T) {
+	procs := parseXdebugctlProcs(xdebugctlPS)
+	scoped := procsForSite(procs, "/home/george/Projects/score-diviner")
+	if len(scoped) != 2 {
+		t.Fatalf("want 2 score-diviner procs, got %d: %+v", len(scoped), scoped)
+	}
+	for _, p := range scoped {
+		if p.pid != 15 && p.pid != 52 {
+			t.Errorf("unexpected pid in scoped set: %d", p.pid)
+		}
+	}
+
+	// Empty path is a no-op (returns all).
+	if got := len(procsForSite(procs, "")); got != 3 {
+		t.Errorf("empty sitePath should return all procs, got %d", got)
+	}
+}
+
+// A site path must match on a directory boundary, not a bare substring, so
+// /proj/app does not capture /proj/app2's workers.
+func TestProcsForSite_pathBoundaryNotSubstring(t *testing.T) {
+	procs := []xdebugProc{
+		{pid: 1, command: "/proj/app/artisan (Xdebug3.5.3)"},
+		{pid: 2, command: "/proj/app2/artisan (Xdebug3.5.3)"},
+	}
+	scoped := procsForSite(procs, "/proj/app")
+	if len(scoped) != 1 || scoped[0].pid != 1 {
+		t.Fatalf("want only /proj/app (pid 1), got %+v", scoped)
+	}
+	// A trailing slash on the site path must not break matching.
+	if got := procsForSite(procs, "/proj/app/"); len(got) != 1 || got[0].pid != 1 {
+		t.Errorf("trailing-slash sitePath should still match pid 1, got %+v", got)
+	}
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -41,10 +41,15 @@ type GlobalConfig struct {
 	// known GUI editor (code/cursor/phpstorm/subl/zed), then xdg-open/open.
 	Editor string `yaml:"editor,omitempty" mapstructure:"editor"`
 	PHP    struct {
-		DefaultVersion string              `yaml:"default_version" mapstructure:"default_version"`
-		XdebugEnabled  map[string]bool     `yaml:"xdebug_enabled"  mapstructure:"xdebug_enabled"`
-		XdebugMode     map[string]string   `yaml:"xdebug_mode,omitempty" mapstructure:"xdebug_mode"`
-		Extensions     map[string][]string `yaml:"extensions"      mapstructure:"extensions"`
+		DefaultVersion string            `yaml:"default_version" mapstructure:"default_version"`
+		XdebugEnabled  map[string]bool   `yaml:"xdebug_enabled"  mapstructure:"xdebug_enabled"`
+		XdebugMode     map[string]string `yaml:"xdebug_mode,omitempty" mapstructure:"xdebug_mode"`
+		// XdebugStart maps a PHP version to its xdebug.start_with_request value
+		// (yes | trigger | no). Absent means the default "yes" (connect on every
+		// request). "trigger"/"no" support on-demand debugging via the control
+		// socket without flooding the IDE from every request and worker.
+		XdebugStart map[string]string   `yaml:"xdebug_start,omitempty" mapstructure:"xdebug_start"`
+		Extensions  map[string][]string `yaml:"extensions"      mapstructure:"extensions"`
 		// ExtApkDeps maps a custom extension name to extra Alpine packages its
 		// build needs. Keyed by extension (deps don't vary by PHP version).
 		// lerd already knows the deps for some extensions; this is for the rest.
@@ -370,6 +375,12 @@ func cloneGlobalConfig(in *GlobalConfig) *GlobalConfig {
 			out.PHP.XdebugMode[k] = v
 		}
 	}
+	if in.PHP.XdebugStart != nil {
+		out.PHP.XdebugStart = make(map[string]string, len(in.PHP.XdebugStart))
+		for k, v := range in.PHP.XdebugStart {
+			out.PHP.XdebugStart[k] = v
+		}
+	}
 	if in.PHP.Extensions != nil {
 		out.PHP.Extensions = make(map[string][]string, len(in.PHP.Extensions))
 		for k, v := range in.PHP.Extensions {
@@ -515,6 +526,28 @@ func (c *GlobalConfig) SetXdebugMode(version, mode string) {
 	}
 	c.PHP.XdebugEnabled[version] = true
 	c.PHP.XdebugMode[version] = mode
+}
+
+// GetXdebugStart returns the xdebug.start_with_request value for version,
+// defaulting to "yes" (connect on every request) when unset.
+func (c *GlobalConfig) GetXdebugStart(version string) string {
+	if v, ok := c.PHP.XdebugStart[version]; ok && v != "" {
+		return v
+	}
+	return "yes"
+}
+
+// SetXdebugStart records the xdebug.start_with_request value for version. An
+// empty value (or "yes", the default) clears the entry so the config stays lean.
+func (c *GlobalConfig) SetXdebugStart(version, value string) {
+	if value == "" || value == "yes" {
+		delete(c.PHP.XdebugStart, version)
+		return
+	}
+	if c.PHP.XdebugStart == nil {
+		c.PHP.XdebugStart = map[string]string{}
+	}
+	c.PHP.XdebugStart[version] = value
 }
 
 // GetExtensions returns the custom extensions configured for the given PHP version.

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -224,6 +224,29 @@ func TestXdebug_ModeRoundtrip(t *testing.T) {
 	}
 }
 
+func TestXdebug_StartRoundtrip(t *testing.T) {
+	cfg := &GlobalConfig{}
+
+	// Default is "yes" when unset.
+	if got := cfg.GetXdebugStart("8.4"); got != "yes" {
+		t.Errorf("default GetXdebugStart = %q, want yes", got)
+	}
+
+	cfg.SetXdebugStart("8.4", "trigger")
+	if got := cfg.GetXdebugStart("8.4"); got != "trigger" {
+		t.Errorf("GetXdebugStart = %q, want trigger", got)
+	}
+
+	// Setting back to the default clears the entry so the config stays lean.
+	cfg.SetXdebugStart("8.4", "yes")
+	if _, ok := cfg.PHP.XdebugStart["8.4"]; ok {
+		t.Error(`setting "yes" should clear the stored entry`)
+	}
+	if got := cfg.GetXdebugStart("8.4"); got != "yes" {
+		t.Errorf("after clear GetXdebugStart = %q, want yes", got)
+	}
+}
+
 // Legacy configs (lerd <= 1.15.1) only wrote xdebug_enabled. GetXdebugMode
 // must fall back to "debug" for those entries so upgrade keeps working.
 func TestXdebug_LegacyEnabledFallsBackToDebug(t *testing.T) {

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -625,7 +625,8 @@ func NormaliseXdebugMode(raw string) (string, error) {
 // The file is volume-mounted into the FPM container at /usr/local/etc/php/conf.d/99-xdebug.ini.
 // An empty mode writes xdebug.mode=off (extension loaded but inactive); any other value
 // is emitted as-is, so callers can pass "debug", "coverage", "debug,coverage", etc.
-func WriteXdebugIni(version, mode string) error {
+// start is the xdebug.start_with_request value (yes | trigger | no); empty defaults to "yes".
+func WriteXdebugIni(version, mode, start string) error {
 	path := config.PHPConfFile(version)
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
@@ -638,7 +639,10 @@ func WriteXdebugIni(version, mode string) error {
 	if mode == "" {
 		mode = "off"
 	}
-	content := fmt.Sprintf("[xdebug]\nxdebug.mode=%s\nxdebug.start_with_request=yes\nxdebug.client_host=host.containers.internal\nxdebug.client_port=9003\n", mode)
+	if start == "" {
+		start = "yes"
+	}
+	content := fmt.Sprintf("[xdebug]\nxdebug.mode=%s\nxdebug.start_with_request=%s\nxdebug.client_host=host.containers.internal\nxdebug.client_port=9003\n", mode, start)
 	return os.WriteFile(path, []byte(content), 0644)
 }
 
@@ -692,7 +696,7 @@ func EnsureXdebugIni(version string) error {
 	if cfgErr != nil {
 		return cfgErr
 	}
-	return WriteXdebugIni(version, cfg.GetXdebugMode(version))
+	return WriteXdebugIni(version, cfg.GetXdebugMode(version), cfg.GetXdebugStart(version))
 }
 
 // WriteFPMQuadlet writes the systemd quadlet for a PHP-FPM version and reloads the

--- a/internal/podman/ini_race_test.go
+++ b/internal/podman/ini_race_test.go
@@ -140,7 +140,7 @@ func TestWriteXdebugIni_healsStaleDirectoryDirectly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := WriteXdebugIni("8.4", "debug"); err != nil {
+	if err := WriteXdebugIni("8.4", "debug", "yes"); err != nil {
 		t.Fatalf("WriteXdebugIni: %v", err)
 	}
 	info, err := os.Stat(path)
@@ -171,7 +171,7 @@ func TestWriteXdebugIni_writesRequestedMode(t *testing.T) {
 		{"", "xdebug.mode=off"},
 	}
 	for _, c := range cases {
-		if err := WriteXdebugIni("8.4", c.in); err != nil {
+		if err := WriteXdebugIni("8.4", c.in, "yes"); err != nil {
 			t.Fatalf("WriteXdebugIni(%q): %v", c.in, err)
 		}
 		body, _ := os.ReadFile(config.PHPConfFile("8.4"))

--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -170,6 +170,29 @@ RUN mkdir -p /etc/my.cnf.d && printf '[client]\nssl=0\n' > /etc/my.cnf.d/lerd-no
 # Composer from the official image.
 COPY --from=composer-bin /usr/bin/composer /usr/local/bin/composer
 
+# xdebugctl — Xdebug's control-socket CLI (Xdebug >= 3.3). `lerd xdebug pause`
+# uses it to break the IDE debugger into a running worker/CLI process on demand.
+# Pinned by SHA-256; bump BOTH hashes when upstream updates the binary. A bad
+# checksum fails the build (the binary changed under us); a network/arch miss is
+# tolerated and just leaves the pause feature unavailable in that image.
+RUN set -eu; \
+    apk add --no-cache --virtual .xdbgctl-dl ca-certificates wget; \
+    case "$(uname -m)" in \
+      x86_64)  U="https://xdebug.org/files/binaries/xdebugctl";       S="dbfe72bdb4e23e2245305b14cce2931cc86db40061b830d15f801d1249c4d3c8" ;; \
+      aarch64) U="https://xdebug.org/files/binaries/xdebugctl-arm64"; S="48543fb8aaae273c161efa05e07259cd49072a3ba0ad06669baa71b3f7f3ff32" ;; \
+      *)       U="" ;; \
+    esac; \
+    if [ -n "$U" ]; then \
+      if wget -qO /tmp/xdebugctl "$U"; then \
+        echo "$S  /tmp/xdebugctl" | sha256sum -c -; \
+        install -m 0755 /tmp/xdebugctl /usr/local/bin/xdebugctl; \
+        rm -f /tmp/xdebugctl; \
+      else \
+        echo "WARN: xdebugctl download failed; 'lerd xdebug pause' disabled in this image"; \
+      fi; \
+    fi; \
+    apk del .xdbgctl-dl
+
 # Interactive shell for lerd shell. zsh/fzf exist on every alpine base;
 # bat lands on 3.16+ and starship/eza/zoxide on 3.18+, so the optional
 # tools install tolerantly and zshrc inits starship only when present.

--- a/internal/xdebugops/xdebugops.go
+++ b/internal/xdebugops/xdebugops.go
@@ -26,11 +26,19 @@ type Result struct {
 	RestartErr error
 }
 
-// Apply toggles Xdebug for version. An empty mode disables xdebug; a non-empty
-// mode is validated via podman.NormaliseXdebugMode and enables xdebug with
-// that canonical value. Apply is idempotent: passing the current mode is a
-// no-op that returns NoChange=true without touching the FPM container.
+// Apply toggles Xdebug for version with the default start_with_request=yes
+// (connect on every request). See ApplyWithStart for on-demand modes.
 func Apply(version, rawMode string) (Result, error) {
+	return ApplyWithStart(version, rawMode, "yes")
+}
+
+// ApplyWithStart toggles Xdebug for version and sets its start_with_request
+// value (yes | trigger | no). An empty mode disables xdebug; a non-empty mode
+// is validated via podman.NormaliseXdebugMode. With "trigger"/"no", debugging
+// is driven on demand (a trigger cookie, or the control socket via
+// `lerd xdebug pause`) instead of every request and worker connecting. It is
+// idempotent: passing the current mode and start returns NoChange=true.
+func ApplyWithStart(version, rawMode, start string) (Result, error) {
 	targetMode := ""
 	if rawMode != "" {
 		m, err := podman.NormaliseXdebugMode(rawMode)
@@ -39,13 +47,17 @@ func Apply(version, rawMode string) (Result, error) {
 		}
 		targetMode = m
 	}
+	if start == "" {
+		start = "yes"
+	}
 
 	cfg, err := config.LoadGlobal()
 	if err != nil {
 		return Result{Version: version}, fmt.Errorf("loading config: %w", err)
 	}
 
-	if cfg.GetXdebugMode(version) == targetMode {
+	// Disabled state ignores start; enabled state must match both to be a no-op.
+	if cfg.GetXdebugMode(version) == targetMode && (targetMode == "" || cfg.GetXdebugStart(version) == start) {
 		return Result{
 			Version:  version,
 			Mode:     targetMode,
@@ -55,11 +67,16 @@ func Apply(version, rawMode string) (Result, error) {
 	}
 
 	cfg.SetXdebugMode(version, targetMode)
+	if targetMode == "" {
+		cfg.SetXdebugStart(version, "")
+	} else {
+		cfg.SetXdebugStart(version, start)
+	}
 	if err := config.SaveGlobal(cfg); err != nil {
 		return Result{Version: version}, fmt.Errorf("saving config: %w", err)
 	}
 
-	if err := podman.WriteXdebugIni(version, targetMode); err != nil {
+	if err := podman.WriteXdebugIni(version, targetMode, start); err != nil {
 		return Result{Version: version}, fmt.Errorf("writing xdebug ini: %w", err)
 	}
 

--- a/internal/xdebugops/xdebugops_test.go
+++ b/internal/xdebugops/xdebugops_test.go
@@ -55,6 +55,36 @@ func TestApply_EnablesWithDefaultMode(t *testing.T) {
 	}
 }
 
+func TestApplyWithStart_TriggerPersistsAndWritesIni(t *testing.T) {
+	setupConfigHome(t)
+
+	if _, err := ApplyWithStart("8.4", "debug", "trigger"); err != nil {
+		t.Fatalf("ApplyWithStart: %v", err)
+	}
+
+	cfg, _ := config.LoadGlobal()
+	if got := cfg.GetXdebugStart("8.4"); got != "trigger" {
+		t.Errorf("start not persisted: %q", got)
+	}
+
+	body, _ := os.ReadFile(config.PHPConfFile("8.4"))
+	if !strings.Contains(string(body), "xdebug.start_with_request=trigger") {
+		t.Errorf("ini missing start_with_request=trigger:\n%s", body)
+	}
+
+	// Re-applying the same mode+start is a no-op; switching start is not.
+	if res, _ := ApplyWithStart("8.4", "debug", "trigger"); !res.NoChange {
+		t.Error("same mode+start should be NoChange")
+	}
+	if res, _ := ApplyWithStart("8.4", "debug", "yes"); res.NoChange {
+		t.Error("changing start should not be NoChange")
+	}
+	body, _ = os.ReadFile(config.PHPConfFile("8.4"))
+	if !strings.Contains(string(body), "xdebug.start_with_request=yes") {
+		t.Errorf("ini should flip back to start_with_request=yes:\n%s", body)
+	}
+}
+
 func TestApply_EnablesWithCoverageMode(t *testing.T) {
 	setupConfigHome(t)
 


### PR DESCRIPTION
Debugging a queue or Horizon worker, a scheduled task, or a long-running CLI script in lerd meant setting `XDEBUG_TRIGGER` and restarting the process, because there is no request to hang a trigger cookie on. This adds `lerd xdebug pause`, which uses Xdebug's [control socket](https://xdebug.org/docs/xdebugctl) (Xdebug 3.3+) through the upstream `xdebugctl` tool to break the IDE debugger into an already-running PHP process on demand.

`lerd xdebug pause [site] [--list] [--pid N]` runs `xdebugctl` inside the site's FPM container, lists the candidate processes scoped to that site by project path, and tells the chosen one to connect to the listening IDE on port 9003. It is the practical way to debug background workers and CLI scripts, where the usual cookie/trigger flow doesn't apply. `xdebugctl` is baked into the FPM image at build time for amd64 and arm64 and pinned by SHA-256, so a changed upstream binary fails the build rather than landing silently.

The companion `lerd xdebug on --on-demand` sets `xdebug.start_with_request=trigger`, persisted per PHP version, so nothing auto-connects: you attach to exactly the process you want with `pause` instead of every request and worker flooding the IDE at once. Web requests under that mode still trigger normally via the Xdebug Helper extension or `?XDEBUG_TRIGGER=1`.

The feature works on shared-FPM and custom-FPM sites (the latter build `FROM` the shared image and inherit the binary). FrankenPHP and custom-container sites get a clear message that pause is not available there rather than a pointless rebuild prompt. Pausing an idle FPM web-pool worker is best-effort by nature; long-running workers, CLI, and FrankenPHP processes are the reliable targets.
