### PR TITLE
FrankenPHP: run the selected PHP version and limit the dropdown to runnable versions

### DIFF
--- a/internal/certs/secure_test.go
+++ b/internal/certs/secure_test.go
@@ -95,9 +95,9 @@ printf 'KEY' > "$KEY"
 	}
 
 	site := config.Site{
-		Name:    "theregistry",
+		Name:    "harborlist",
 		Path:    sitePath,
-		Domains: []string{"theregistry.test", "aaaddd.test"},
+		Domains: []string{"harborlist.test", "aaaddd.test"},
 		Secured: true,
 	}
 
@@ -105,19 +105,19 @@ printf 'KEY' > "$KEY"
 		t.Fatalf("ReissueCertForWorktree: %v", err)
 	}
 
-	certPath := filepath.Join(tmp, "lerd", "certs", "sites", "theregistry.test.crt")
+	certPath := filepath.Join(tmp, "lerd", "certs", "sites", "harborlist.test.crt")
 	body, err := os.ReadFile(certPath)
 	if err != nil {
 		t.Fatalf("reading cert: %v", err)
 	}
 	got := string(body)
 	wantSANs := []string{
-		"theregistry.test",
-		"*.theregistry.test",
+		"harborlist.test",
+		"*.harborlist.test",
 		"aaaddd.test",
 		"*.aaaddd.test",
-		"main.theregistry.test",
-		"*.main.theregistry.test",
+		"main.harborlist.test",
+		"*.main.harborlist.test",
 	}
 	for _, san := range wantSANs {
 		if !strings.Contains(got, san) {

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -84,8 +84,8 @@ func TestS3BucketName(t *testing.T) {
 	cases := []struct {
 		in, want string
 	}{
-		{"admin_astrolov", "admin-astrolov"},
-		{"Admin_Astrolov", "admin-astrolov"},
+		{"admin_starlane", "admin-starlane"},
+		{"Admin_Starlane", "admin-starlane"},
 		{"my-app", "my-app"},
 		{"MyApp 2", "myapp-2"},
 		{"my.bucket.v2", "my.bucket.v2"},
@@ -106,13 +106,13 @@ func TestS3BucketName(t *testing.T) {
 }
 
 func TestApplySiteHandleBucket(t *testing.T) {
-	ctx := siteTemplateCtx{site: "admin_astrolov", bucket: "admin-astrolov"}
+	ctx := siteTemplateCtx{site: "admin_starlane", bucket: "admin-starlane"}
 	got := applySiteHandle("AWS_BUCKET={{bucket}}", ctx)
-	if got != "AWS_BUCKET=admin-astrolov" {
+	if got != "AWS_BUCKET=admin-starlane" {
 		t.Errorf("expected sanitised bucket, got %q", got)
 	}
 	gotSite := applySiteHandle("DB_DATABASE={{site}}", ctx)
-	if gotSite != "DB_DATABASE=admin_astrolov" {
+	if gotSite != "DB_DATABASE=admin_starlane" {
 		t.Errorf("{{site}} should preserve underscores, got %q", gotSite)
 	}
 }
@@ -291,10 +291,10 @@ func TestApplyHostProxyEnv_rewritesHostAndPort(t *testing.T) {
 	updates := map[string]string{
 		"DB_HOST":     "lerd-mariadb-11",
 		"DB_PORT":     "3306",
-		"DB_DATABASE": "gonitro",
+		"DB_DATABASE": "flowmeter",
 		"REDIS_HOST":  "lerd-redis",
 		"REDIS_PORT":  "6379",
-		"APP_URL":     "https://gonitro.test",
+		"APP_URL":     "https://flowmeter.test",
 		"APP_NAME":    "ecom",
 	}
 	applyHostProxyEnv(updates, map[string]string{"3306": "3411", "6379": "6379"})
@@ -312,10 +312,10 @@ func TestApplyHostProxyEnv_rewritesHostAndPort(t *testing.T) {
 		t.Errorf("REDIS_PORT = %q, want 6379 (unchanged when host==container)", updates["REDIS_PORT"])
 	}
 	// Non-service values must be left alone.
-	if updates["DB_DATABASE"] != "gonitro" {
+	if updates["DB_DATABASE"] != "flowmeter" {
 		t.Errorf("DB_DATABASE was mangled: %q", updates["DB_DATABASE"])
 	}
-	if updates["APP_URL"] != "https://gonitro.test" {
+	if updates["APP_URL"] != "https://flowmeter.test" {
 		t.Errorf("APP_URL was mangled: %q", updates["APP_URL"])
 	}
 	if updates["APP_NAME"] != "ecom" {

--- a/internal/cli/fetch.go
+++ b/internal/cli/fetch.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
 
-// SupportedPHPVersions lists the PHP versions lerd can build FPM images for.
-// 7.4 and 8.0 are a frozen legacy tier for old projects: still buildable from
-// Alpine 3.16, but pinned (older xdebug, no mongodb ext) and not security-updated.
-var SupportedPHPVersions = []string{"7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"}
+// SupportedPHPVersions re-exports the canonical list from internal/config, the
+// single source of truth shared with the FrankenPHP image picker.
+var SupportedPHPVersions = config.SupportedPHPVersions
 
 // LegacyPHPVersions is the frozen legacy tier built from Alpine 3.16 with an old
 // bundled Node. Kept here next to SupportedPHPVersions so the single definition
@@ -21,12 +21,7 @@ var LegacyPHPVersions = []string{"7.4", "8.0"}
 
 // IsSupportedPHPVersion reports whether v is a version lerd can install.
 func IsSupportedPHPVersion(v string) bool {
-	for _, s := range SupportedPHPVersions {
-		if s == v {
-			return true
-		}
-	}
-	return false
+	return config.IsSupportedPHPVersion(v)
 }
 
 // IsLegacyPHPVersion reports whether v belongs to the frozen legacy tier.

--- a/internal/cli/horizon.go
+++ b/internal/cli/horizon.go
@@ -211,13 +211,8 @@ func HorizonStartForSite(siteName, sitePath, phpVersion string) error {
 
 // buildHorizonUnit renders the Horizon systemd unit body. Horizon always
 // uses Redis so lerd-redis is in After=/Wants= alongside the FPM container.
-func buildHorizonUnit(siteName, sitePath, phpVersion string) string {
-	versionShort := strings.ReplaceAll(phpVersion, ".", "")
-	// Per-site container for custom-FPM sites, else the shared lerd-php<ver>-fpm.
-	fpmUnit := resolveWorkerFPMUnit(siteName, phpVersion)
-	if fpmUnit == "" {
-		fpmUnit = "lerd-php" + versionShort + "-fpm"
-	}
+// Pure: the caller resolves fpmUnit, so tests don't touch the live registry.
+func buildHorizonUnit(siteName, sitePath, fpmUnit string) string {
 	container := fpmUnit
 
 	return fmt.Sprintf(`[Unit]

--- a/internal/cli/lanshare_test.go
+++ b/internal/cli/lanshare_test.go
@@ -163,14 +163,14 @@ bar: url("http://192.168.1.42:9100/__lerd_vite__/5173/y.png");`
 func TestRewriteLoopbackViteURLs_rewritesJSONEscapedSlashes(t *testing.T) {
 	// Inertia.js page payloads embed JSON in the data-page attribute using
 	// json_encode, which escapes forward slashes by default. The avatar
-	// URLs end up looking like http:\/\/localhost:9000\/astrolov\/... —
+	// URLs end up looking like http:\/\/localhost:9000\/starlane\/... —
 	// the plain regex skips them because there's no literal `://`. The
 	// escaped pass must catch them and emit the same JSON-escape style.
-	in := []byte(`<div id="app" data-page='{"props":{"avatar_url":"http:\/\/localhost:9000\/astrolov\/avatars\/1\/foo.jpg","other":"http:\/\/127.0.0.1:9000\/bucket"}}'></div>`)
+	in := []byte(`<div id="app" data-page='{"props":{"avatar_url":"http:\/\/localhost:9000\/starlane\/avatars\/1\/foo.jpg","other":"http:\/\/127.0.0.1:9000\/bucket"}}'></div>`)
 
 	got := string(rewriteLoopbackViteURLs(in, "192.168.1.42:9100"))
 
-	want := `<div id="app" data-page='{"props":{"avatar_url":"http:\/\/192.168.1.42:9100\/__lerd_vite__\/9000\/astrolov\/avatars\/1\/foo.jpg","other":"http:\/\/192.168.1.42:9100\/__lerd_vite__\/9000\/bucket"}}'></div>`
+	want := `<div id="app" data-page='{"props":{"avatar_url":"http:\/\/192.168.1.42:9100\/__lerd_vite__\/9000\/starlane\/avatars\/1\/foo.jpg","other":"http:\/\/192.168.1.42:9100\/__lerd_vite__\/9000\/bucket"}}'></div>`
 
 	if got != want {
 		t.Errorf("rewriteLoopbackViteURLs JSON-escaped:\nGOT:\n%s\nWANT:\n%s", got, want)
@@ -302,7 +302,7 @@ func TestLANShareHandler_nonVitePrefixPathDoesNotPoisonActivePort(t *testing.T) 
 	//    Stripped path is /bucket/key.jpg — not Vite-internal. The
 	//    request must still proxy correctly to the named port, but it
 	//    must NOT change activeVitePort.
-	resp, err = http.Get(srv.URL + fmt.Sprintf("/__lerd_vite__/%d/astrolov/avatars/1/foo.jpg", rustfsPort))
+	resp, err = http.Get(srv.URL + fmt.Sprintf("/__lerd_vite__/%d/starlane/avatars/1/foo.jpg", rustfsPort))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/link_worktree_test.go
+++ b/internal/cli/link_worktree_test.go
@@ -53,22 +53,22 @@ func writeSitesYAML(t *testing.T, sites []config.Site) {
 
 func TestFindOwningWorktree_match(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
-	parent, wtPath := makeWorktreeLayout(t, "whitewaters", "main")
-	writeSitesYAML(t, []config.Site{{Name: "whitewaters", Path: parent}})
+	parent, wtPath := makeWorktreeLayout(t, "rapids", "main")
+	writeSitesYAML(t, []config.Site{{Name: "rapids", Path: parent}})
 
 	owner, branch, ok := findOwningWorktree(wtPath)
 	if !ok {
 		t.Fatal("expected worktree to be matched to parent")
 	}
-	if owner.Name != "whitewaters" || branch != "main" {
-		t.Errorf("got %s/%s, want whitewaters/main", owner.Name, branch)
+	if owner.Name != "rapids" || branch != "main" {
+		t.Errorf("got %s/%s, want rapids/main", owner.Name, branch)
 	}
 }
 
 func TestFindOwningWorktree_noMatchForUnrelatedDir(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
-	parent, _ := makeWorktreeLayout(t, "whitewaters", "main")
-	writeSitesYAML(t, []config.Site{{Name: "whitewaters", Path: parent}})
+	parent, _ := makeWorktreeLayout(t, "rapids", "main")
+	writeSitesYAML(t, []config.Site{{Name: "rapids", Path: parent}})
 
 	if _, _, ok := findOwningWorktree(t.TempDir()); ok {
 		t.Error("unrelated dir must not match a worktree")
@@ -77,8 +77,8 @@ func TestFindOwningWorktree_noMatchForUnrelatedDir(t *testing.T) {
 
 func TestFindOwningWorktree_skipsParentItself(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
-	parent, _ := makeWorktreeLayout(t, "whitewaters", "main")
-	writeSitesYAML(t, []config.Site{{Name: "whitewaters", Path: parent}})
+	parent, _ := makeWorktreeLayout(t, "rapids", "main")
+	writeSitesYAML(t, []config.Site{{Name: "rapids", Path: parent}})
 
 	if _, _, ok := findOwningWorktree(parent); ok {
 		t.Error("the parent path itself must not register as one of its own worktrees")

--- a/internal/cli/park_test.go
+++ b/internal/cli/park_test.go
@@ -20,7 +20,7 @@ func TestSiteNameAndDomain(t *testing.T) {
 	}{
 		{"myapp", "test", "myapp", "myapp.test"},
 		{"MyApp", "test", "myapp", "myapp.test"},
-		{"admin.astrolov.com", "test", "admin-astrolov", "admin-astrolov.test"},
+		{"admin.starlane.com", "test", "admin-starlane", "admin-starlane.test"},
 		{"my.project.io", "test", "my-project", "my-project.test"},
 		{"shop.co", "test", "shop", "shop.test"},
 		{"api.dev", "test", "api", "api.test"},

--- a/internal/cli/queue.go
+++ b/internal/cli/queue.go
@@ -168,14 +168,9 @@ func QueueStartForSite(siteName, sitePath, phpVersion string) error {
 }
 
 // buildQueueUnit renders the systemd unit body for a queue worker. Pure
-// function so the dep wiring can be exercised in tests.
-func buildQueueUnit(siteName, sitePath, phpVersion, queue string, tries, timeout int) string {
-	versionShort := strings.ReplaceAll(phpVersion, ".", "")
-	// Per-site container for custom-FPM sites, else the shared lerd-php<ver>-fpm.
-	fpmUnit := resolveWorkerFPMUnit(siteName, phpVersion)
-	if fpmUnit == "" {
-		fpmUnit = "lerd-php" + versionShort + "-fpm"
-	}
+// function: fpmUnit (the container to exec into) is resolved by the caller,
+// so the dep wiring can be exercised in tests without the live site registry.
+func buildQueueUnit(siteName, sitePath, fpmUnit, queue string, tries, timeout int) string {
 	container := fpmUnit
 	artisanArgs := fmt.Sprintf("queue:work --queue=%s --tries=%d --timeout=%d", queue, tries, timeout)
 

--- a/internal/cli/queue_test.go
+++ b/internal/cli/queue_test.go
@@ -89,9 +89,9 @@ func TestQueueDependencyUnits_NoEnv(t *testing.T) {
 // rejected the write before lerd-redis was up.
 func TestBuildQueueUnit_RedisBackendRendersDependencies(t *testing.T) {
 	sitePath := writeTempEnv(t, map[string]string{"QUEUE_CONNECTION": "redis"})
-	unit := buildQueueUnit("whitewaters", sitePath, "8.4", "default", 3, 60)
+	unit := buildQueueUnit("example-redis", sitePath, "lerd-php84-fpm", "default", 3, 60)
 
-	mustContain(t, unit, "Description=Lerd Queue Worker (whitewaters)")
+	mustContain(t, unit, "Description=Lerd Queue Worker (example-redis)")
 	mustContain(t, unit, "After=network.target lerd-php84-fpm.service lerd-redis.service")
 	mustContain(t, unit, "Wants=lerd-php84-fpm.service lerd-redis.service")
 	mustContain(t, unit, "BindsTo=lerd-php84-fpm.service")
@@ -102,7 +102,7 @@ func TestBuildQueueUnit_RedisBackendRendersDependencies(t *testing.T) {
 
 func TestBuildQueueUnit_SyncBackendOmitsServiceDep(t *testing.T) {
 	sitePath := writeTempEnv(t, map[string]string{"QUEUE_CONNECTION": "sync"})
-	unit := buildQueueUnit("astrolov", sitePath, "8.4", "default", 3, 60)
+	unit := buildQueueUnit("example-sync", sitePath, "lerd-php84-fpm", "default", 3, 60)
 
 	mustContain(t, unit, "After=network.target lerd-php84-fpm.service")
 	mustContain(t, unit, "Wants=lerd-php84-fpm.service")
@@ -116,20 +116,20 @@ func TestBuildQueueUnit_DatabaseBackendUsesDBConnection(t *testing.T) {
 		"QUEUE_CONNECTION": "database",
 		"DB_CONNECTION":    "pgsql",
 	})
-	unit := buildQueueUnit("admin-astrolov", sitePath, "8.3", "default", 3, 60)
+	unit := buildQueueUnit("example-db", sitePath, "lerd-php83-fpm", "default", 3, 60)
 
 	mustContain(t, unit, "After=network.target lerd-php83-fpm.service lerd-postgres.service")
 	mustContain(t, unit, "Wants=lerd-php83-fpm.service lerd-postgres.service")
 }
 
 func TestBuildHorizonUnit_AlwaysDependsOnRedis(t *testing.T) {
-	unit := buildHorizonUnit("score-diviner", "/home/u/score-diviner", "8.4")
+	unit := buildHorizonUnit("example-horizon", "/home/u/example-horizon", "lerd-php84-fpm")
 
-	mustContain(t, unit, "Description=Lerd Horizon (score-diviner)")
+	mustContain(t, unit, "Description=Lerd Horizon (example-horizon)")
 	mustContain(t, unit, "After=network.target lerd-php84-fpm.service lerd-redis.service")
 	mustContain(t, unit, "Wants=lerd-php84-fpm.service lerd-redis.service")
 	mustContain(t, unit, "BindsTo=lerd-php84-fpm.service")
-	mustContain(t, unit, "ExecStart="+podman.PodmanBin()+" exec -w /home/u/score-diviner lerd-php84-fpm php artisan horizon")
+	mustContain(t, unit, "ExecStart="+podman.PodmanBin()+" exec -w /home/u/example-horizon lerd-php84-fpm php artisan horizon")
 }
 
 func mustContain(t *testing.T, body, needle string) {

--- a/internal/cli/xdebug_pause_test.go
+++ b/internal/cli/xdebug_pause_test.go
@@ -3,9 +3,9 @@ package cli
 import "testing"
 
 const xdebugctlPS = `       PID      RSS     TIME COMMAND
-        15    50384    76.20 /home/george/Projects/score-diviner/artisan (Xdebug3.5.3)
-        36    49527    76.11 /home/george/Projects/astrolov.com/artisan (Xdebug3.5.3)
-        52    51077    75.19 /home/george/Projects/score-diviner/artisan (Xdebug3.5.3)
+        15    50384    76.20 /home/george/Projects/tallyboard/artisan (Xdebug3.5.3)
+        36    49527    76.11 /home/george/Projects/starlane.com/artisan (Xdebug3.5.3)
+        52    51077    75.19 /home/george/Projects/tallyboard/artisan (Xdebug3.5.3)
        104 Error: No response on: @xdebug-ctrl.104
 `
 
@@ -14,7 +14,7 @@ func TestParseXdebugctlProcs_skipsHeaderAndErrors(t *testing.T) {
 	if len(procs) != 3 {
 		t.Fatalf("want 3 procs (header + Error row skipped), got %d: %+v", len(procs), procs)
 	}
-	if procs[0].pid != 15 || procs[0].command != "/home/george/Projects/score-diviner/artisan (Xdebug3.5.3)" {
+	if procs[0].pid != 15 || procs[0].command != "/home/george/Projects/tallyboard/artisan (Xdebug3.5.3)" {
 		t.Errorf("unexpected first proc: %+v", procs[0])
 	}
 }
@@ -22,7 +22,7 @@ func TestParseXdebugctlProcs_skipsHeaderAndErrors(t *testing.T) {
 // xdebugctl colours its output; the parser must strip ANSI so the PID is field 0.
 func TestParseXdebugctlProcs_stripsANSIColour(t *testing.T) {
 	const colored = "\x1b[2m       PID\x1b[0m      RSS     TIME \x1b[97mCOMMAND\x1b[0m\n" +
-		"\x1b[2m        81\x1b[0m    49183    37.17 \x1b[97m/home/george/Projects/score-diviner/artisan\x1b[0m \x1b[2m(Xdebug3.5.3)\x1b[0m\n"
+		"\x1b[2m        81\x1b[0m    49183    37.17 \x1b[97m/home/george/Projects/tallyboard/artisan\x1b[0m \x1b[2m(Xdebug3.5.3)\x1b[0m\n"
 	procs := parseXdebugctlProcs(colored)
 	if len(procs) != 1 {
 		t.Fatalf("want 1 proc from coloured output, got %d: %+v", len(procs), procs)
@@ -30,16 +30,16 @@ func TestParseXdebugctlProcs_stripsANSIColour(t *testing.T) {
 	if procs[0].pid != 81 {
 		t.Errorf("pid = %d, want 81 (ANSI not stripped?)", procs[0].pid)
 	}
-	if scoped := procsForSite(procs, "/home/george/Projects/score-diviner"); len(scoped) != 1 {
+	if scoped := procsForSite(procs, "/home/george/Projects/tallyboard"); len(scoped) != 1 {
 		t.Errorf("coloured path should still scope, got %d", len(scoped))
 	}
 }
 
 func TestProcsForSite_scopesByProjectPath(t *testing.T) {
 	procs := parseXdebugctlProcs(xdebugctlPS)
-	scoped := procsForSite(procs, "/home/george/Projects/score-diviner")
+	scoped := procsForSite(procs, "/home/george/Projects/tallyboard")
 	if len(scoped) != 2 {
-		t.Fatalf("want 2 score-diviner procs, got %d: %+v", len(scoped), scoped)
+		t.Fatalf("want 2 tallyboard procs, got %d: %+v", len(scoped), scoped)
 	}
 	for _, p := range scoped {
 		if p.pid != 15 && p.pid != 52 {

--- a/internal/config/php_versions.go
+++ b/internal/config/php_versions.go
@@ -41,6 +41,17 @@ func IsFrankenPHPVersion(v string) bool {
 	return IsSupportedPHPVersion(v) && phpVersionAtLeast(v, FrankenPHPMinVersion)
 }
 
+// LatestFrankenPHPVersion returns the newest PHP version dunglas/frankenphp
+// publishes an image for, used as the fallback for unsupported versions. Falls
+// back to FrankenPHPMinVersion so callers never index an empty slice.
+func LatestFrankenPHPVersion() string {
+	v := FrankenPHPVersions()
+	if len(v) == 0 {
+		return FrankenPHPMinVersion
+	}
+	return v[len(v)-1]
+}
+
 // phpVersionAtLeast reports whether "major.minor" version a is >= b.
 func phpVersionAtLeast(a, b string) bool {
 	amaj, amin := splitMajorMinor(a)

--- a/internal/config/php_versions.go
+++ b/internal/config/php_versions.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"strconv"
+	"strings"
+)
+
+// SupportedPHPVersions lists the PHP versions lerd can build FPM images for.
+// 7.4 and 8.0 are a frozen legacy tier for old projects: still buildable from
+// Alpine 3.16, but pinned (older xdebug, no mongodb ext) and not security-updated.
+var SupportedPHPVersions = []string{"7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"}
+
+// FrankenPHPMinVersion is the oldest PHP version dunglas/frankenphp publishes an
+// image for; supported versions below it run under FPM only.
+const FrankenPHPMinVersion = "8.2"
+
+// IsSupportedPHPVersion reports whether v is a version lerd can install.
+func IsSupportedPHPVersion(v string) bool {
+	for _, s := range SupportedPHPVersions {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+// FrankenPHPVersions returns the subset of SupportedPHPVersions that
+// dunglas/frankenphp publishes an image for, in the same ascending order.
+func FrankenPHPVersions() []string {
+	var out []string
+	for _, v := range SupportedPHPVersions {
+		if phpVersionAtLeast(v, FrankenPHPMinVersion) {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// IsFrankenPHPVersion reports whether dunglas/frankenphp publishes an image for v.
+func IsFrankenPHPVersion(v string) bool {
+	return IsSupportedPHPVersion(v) && phpVersionAtLeast(v, FrankenPHPMinVersion)
+}
+
+// phpVersionAtLeast reports whether "major.minor" version a is >= b.
+func phpVersionAtLeast(a, b string) bool {
+	amaj, amin := splitMajorMinor(a)
+	bmaj, bmin := splitMajorMinor(b)
+	if amaj != bmaj {
+		return amaj > bmaj
+	}
+	return amin >= bmin
+}
+
+func splitMajorMinor(v string) (int, int) {
+	parts := strings.SplitN(v, ".", 2)
+	major, _ := strconv.Atoi(parts[0])
+	minor := 0
+	if len(parts) > 1 {
+		minor, _ = strconv.Atoi(parts[1])
+	}
+	return major, minor
+}

--- a/internal/config/php_versions_test.go
+++ b/internal/config/php_versions_test.go
@@ -39,6 +39,17 @@ func TestIsFrankenPHPVersion(t *testing.T) {
 	}
 }
 
+func TestLatestFrankenPHPVersion(t *testing.T) {
+	got := LatestFrankenPHPVersion()
+	want := FrankenPHPVersions()[len(FrankenPHPVersions())-1]
+	if got != want {
+		t.Errorf("LatestFrankenPHPVersion() = %q, want %q", got, want)
+	}
+	if got != "8.5" {
+		t.Errorf("LatestFrankenPHPVersion() = %q, want 8.5", got)
+	}
+}
+
 func TestPHPVersionAtLeast(t *testing.T) {
 	cases := []struct {
 		a, b string

--- a/internal/config/php_versions_test.go
+++ b/internal/config/php_versions_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsSupportedPHPVersion(t *testing.T) {
+	for _, v := range []string{"7.4", "8.0", "8.5"} {
+		if !IsSupportedPHPVersion(v) {
+			t.Errorf("IsSupportedPHPVersion(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"5.6", "9.0", ""} {
+		if IsSupportedPHPVersion(v) {
+			t.Errorf("IsSupportedPHPVersion(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestFrankenPHPVersions(t *testing.T) {
+	got := FrankenPHPVersions()
+	want := []string{"8.2", "8.3", "8.4", "8.5"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("FrankenPHPVersions() = %v, want %v", got, want)
+	}
+}
+
+func TestIsFrankenPHPVersion(t *testing.T) {
+	cases := map[string]bool{
+		"7.4": false, "8.0": false, "8.1": false,
+		"8.2": true, "8.4": true, "8.5": true,
+		"9.0": false, "": false,
+	}
+	for v, want := range cases {
+		if got := IsFrankenPHPVersion(v); got != want {
+			t.Errorf("IsFrankenPHPVersion(%q) = %v, want %v", v, got, want)
+		}
+	}
+}
+
+func TestPHPVersionAtLeast(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"8.2", "8.2", true},
+		{"8.5", "8.2", true},
+		{"8.1", "8.2", false},
+		{"7.4", "8.2", false},
+		{"8.10", "8.9", true},
+		{"9.0", "8.5", true},
+	}
+	for _, c := range cases {
+		if got := phpVersionAtLeast(c.a, c.b); got != c.want {
+			t.Errorf("phpVersionAtLeast(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/internal/config/project_update_test.go
+++ b/internal/config/project_update_test.go
@@ -208,14 +208,14 @@ func TestSyncProjectDomains_CaseInsensitiveDedup(t *testing.T) {
 }
 
 func TestReplaceProjectDomain_dropsRenamedDomain(t *testing.T) {
-	// admin-astrolov grouped into admin.astrolov: the old standalone domain
+	// admin-starlane grouped into admin.starlane: the old standalone domain
 	// must not survive in .lerd.yaml, while a genuine conflict-filtered extra is.
-	dir := setupProjectConfig(t, &ProjectConfig{Domains: []string{"admin-astrolov", "conflict-domain"}})
-	if err := ReplaceProjectDomain(dir, []string{"admin.astrolov.test"}, "admin-astrolov.test", "test"); err != nil {
+	dir := setupProjectConfig(t, &ProjectConfig{Domains: []string{"admin-starlane", "conflict-domain"}})
+	if err := ReplaceProjectDomain(dir, []string{"admin.starlane.test"}, "admin-starlane.test", "test"); err != nil {
 		t.Fatal(err)
 	}
 	cfg := loadConfig(t, dir)
-	want := []string{"admin.astrolov", "conflict-domain"}
+	want := []string{"admin.starlane", "conflict-domain"}
 	if len(cfg.Domains) != len(want) {
 		t.Fatalf("Domains = %v, want %v", cfg.Domains, want)
 	}

--- a/internal/config/site_test.go
+++ b/internal/config/site_test.go
@@ -652,9 +652,9 @@ func TestSaveLoad_GroupFields_RoundTrip(t *testing.T) {
 
 	reg := &SiteRegistry{
 		Sites: []Site{
-			{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: "/srv/astrolov", Group: "astrolov"},
-			{Name: "admin-astrolov", Domains: []string{"admin.astrolov.test"}, Path: "/srv/admin",
-				Group: "astrolov", GroupSubdomain: "admin"},
+			{Name: "starlane", Domains: []string{"starlane.test"}, Path: "/srv/starlane", Group: "starlane"},
+			{Name: "admin-starlane", Domains: []string{"admin.starlane.test"}, Path: "/srv/admin",
+				Group: "starlane", GroupSubdomain: "admin"},
 		},
 	}
 	if err := SaveSites(reg); err != nil {
@@ -666,14 +666,14 @@ func TestSaveLoad_GroupFields_RoundTrip(t *testing.T) {
 		t.Fatalf("LoadSites: %v", err)
 	}
 	main, sec := got.Sites[0], got.Sites[1]
-	if main.Group != "astrolov" || main.GroupSubdomain != "" {
-		t.Errorf("main group fields = %q/%q, want astrolov/empty", main.Group, main.GroupSubdomain)
+	if main.Group != "starlane" || main.GroupSubdomain != "" {
+		t.Errorf("main group fields = %q/%q, want starlane/empty", main.Group, main.GroupSubdomain)
 	}
 	if !main.IsGroupMain() || main.IsGroupSecondary() {
 		t.Errorf("main classification wrong: IsGroupMain=%v IsGroupSecondary=%v", main.IsGroupMain(), main.IsGroupSecondary())
 	}
-	if sec.Group != "astrolov" || sec.GroupSubdomain != "admin" {
-		t.Errorf("secondary group fields = %q/%q, want astrolov/admin", sec.Group, sec.GroupSubdomain)
+	if sec.Group != "starlane" || sec.GroupSubdomain != "admin" {
+		t.Errorf("secondary group fields = %q/%q, want starlane/admin", sec.Group, sec.GroupSubdomain)
 	}
 	if !sec.IsGroupSecondary() || sec.IsGroupMain() {
 		t.Errorf("secondary classification wrong: IsGroupSecondary=%v IsGroupMain=%v", sec.IsGroupSecondary(), sec.IsGroupMain())

--- a/internal/git/worktree_env_test.go
+++ b/internal/git/worktree_env_test.go
@@ -279,24 +279,24 @@ func TestEnsureWorktreeEnv_fallsBackWithoutOverrides(t *testing.T) {
 // env_overrides template, or the isolated DB silently goes back to the
 // templated value on the next watcher refresh.
 //
-// Modelled on the real theregistry.test fixture (Laravel parent at
-// /home/george/Projects/whitewaters with a branch worktree), but uses
+// Modelled on the real harborlist.test fixture (Laravel parent at
+// /home/george/Projects/rapids with a branch worktree), but uses
 // tempdirs so the suite stays hermetic.
 func TestEnsureWorktreeEnv_isolatedDBOverrideSkipped(t *testing.T) {
 	main := t.TempDir()
 	wt := t.TempDir()
 
-	mainEnv := "APP_URL=http://theregistry.test\nDB_DATABASE=whitewaters\n"
+	mainEnv := "APP_URL=http://harborlist.test\nDB_DATABASE=rapids\n"
 	if err := os.WriteFile(filepath.Join(main, ".env"), []byte(mainEnv), 0644); err != nil {
 		t.Fatal(err)
 	}
-	lerdYAML := "domains:\n  - theregistry\nenv_overrides:\n  DB_DATABASE: \"{{parent}}_{{branch}}\"\n"
+	lerdYAML := "domains:\n  - harborlist\nenv_overrides:\n  DB_DATABASE: \"{{parent}}_{{branch}}\"\n"
 	if err := os.WriteFile(filepath.Join(main, ".lerd.yaml"), []byte(lerdYAML), 0644); err != nil {
 		t.Fatal(err)
 	}
 	// Seed the worktree as if `lerd db:isolate` already ran: explicit
 	// DB_DATABASE plus db_isolated:true in its .lerd.yaml.
-	wtEnv := "APP_URL=http://theregistry.test\nDB_DATABASE=whitewaters_feat_x\n"
+	wtEnv := "APP_URL=http://harborlist.test\nDB_DATABASE=rapids_feat_x\n"
 	if err := os.WriteFile(filepath.Join(wt, ".env"), []byte(wtEnv), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -304,21 +304,21 @@ func TestEnsureWorktreeEnv_isolatedDBOverrideSkipped(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	EnsureWorktreeEnv(main, wt, "feat-x.theregistry.test", false)
+	EnsureWorktreeEnv(main, wt, "feat-x.harborlist.test", false)
 
 	got, err := os.ReadFile(filepath.Join(wt, ".env"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	s := string(got)
-	if !strings.Contains(s, "DB_DATABASE=whitewaters_feat_x") {
+	if !strings.Contains(s, "DB_DATABASE=rapids_feat_x") {
 		t.Errorf("isolated DB_DATABASE was clobbered by env_overrides:\n%s", s)
 	}
-	if strings.Contains(s, "DB_DATABASE=whitewaters_feat-x") || strings.Contains(s, "DB_DATABASE=_feat-x") {
+	if strings.Contains(s, "DB_DATABASE=rapids_feat-x") || strings.Contains(s, "DB_DATABASE=_feat-x") {
 		t.Errorf("env_overrides template replaced isolated DB:\n%s", s)
 	}
 	// APP_URL must still be rewritten — only DB_DATABASE is sticky.
-	if !strings.Contains(s, "APP_URL=http://feat-x.theregistry.test") {
+	if !strings.Contains(s, "APP_URL=http://feat-x.harborlist.test") {
 		t.Errorf("APP_URL rewrite skipped alongside DB_DATABASE:\n%s", s)
 	}
 }
@@ -331,16 +331,16 @@ func TestEnsureWorktreeEnv_envOverridesWinWhenNotIsolated(t *testing.T) {
 	main := t.TempDir()
 	wt := t.TempDir()
 
-	mainEnv := "APP_URL=http://theregistry.test\nDB_DATABASE=whitewaters\n"
+	mainEnv := "APP_URL=http://harborlist.test\nDB_DATABASE=rapids\n"
 	if err := os.WriteFile(filepath.Join(main, ".env"), []byte(mainEnv), 0644); err != nil {
 		t.Fatal(err)
 	}
-	lerdYAML := "domains:\n  - theregistry\nenv_overrides:\n  DB_DATABASE: \"{{parent}}_{{branch}}\"\n"
+	lerdYAML := "domains:\n  - harborlist\nenv_overrides:\n  DB_DATABASE: \"{{parent}}_{{branch}}\"\n"
 	if err := os.WriteFile(filepath.Join(main, ".lerd.yaml"), []byte(lerdYAML), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	EnsureWorktreeEnv(main, wt, "feat-x.theregistry.test", false)
+	EnsureWorktreeEnv(main, wt, "feat-x.harborlist.test", false)
 
 	got, err := os.ReadFile(filepath.Join(wt, ".env"))
 	if err != nil {
@@ -350,8 +350,8 @@ func TestEnsureWorktreeEnv_envOverridesWinWhenNotIsolated(t *testing.T) {
 		// The exact value depends on whether parent resolves; with no
 		// site registered, {{parent}} resolves to "". The point is that
 		// env_overrides DID apply (DB_DATABASE changed away from the
-		// inherited "whitewaters").
-		if strings.Contains(string(got), "DB_DATABASE=whitewaters\n") {
+		// inherited "rapids").
+		if strings.Contains(string(got), "DB_DATABASE=rapids\n") {
 			t.Errorf("env_overrides was skipped even though db_isolated is false:\n%s", got)
 		}
 	}

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -509,20 +509,20 @@ func TestEnsureWorktreeDeps_mainMissingVendor(t *testing.T) {
 func TestFilterReservedWorktrees_dropsSecondaryDomain(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
-	// A group secondary owns admin.astrolov.test.
+	// A group secondary owns admin.starlane.test.
 	if err := config.AddSite(config.Site{
-		Name: "admin", Domains: []string{"admin.astrolov.test"}, Path: "/srv/admin",
-		Group: "astrolov", GroupSubdomain: "admin",
+		Name: "admin", Domains: []string{"admin.starlane.test"}, Path: "/srv/admin",
+		Group: "starlane", GroupSubdomain: "admin",
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	wts := []Worktree{
-		{Name: "admin", Branch: "admin", Domain: "admin.astrolov.test", Path: "/wt/admin"},
-		{Name: "feat", Branch: "feat", Domain: "feat.astrolov.test", Path: "/wt/feat"},
+		{Name: "admin", Branch: "admin", Domain: "admin.starlane.test", Path: "/wt/admin"},
+		{Name: "feat", Branch: "feat", Domain: "feat.starlane.test", Path: "/wt/feat"},
 	}
 	got := FilterReservedWorktrees(wts)
-	if len(got) != 1 || got[0].Domain != "feat.astrolov.test" {
+	if len(got) != 1 || got[0].Domain != "feat.starlane.test" {
 		t.Errorf("expected only feat worktree to survive, got %+v", got)
 	}
 }
@@ -530,7 +530,7 @@ func TestFilterReservedWorktrees_dropsSecondaryDomain(t *testing.T) {
 func TestFilterReservedWorktrees_noReservations(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
-	wts := []Worktree{{Name: "feat", Branch: "feat", Domain: "feat.astrolov.test", Path: "/wt/feat"}}
+	wts := []Worktree{{Name: "feat", Branch: "feat", Domain: "feat.starlane.test", Path: "/wt/feat"}}
 	got := FilterReservedWorktrees(wts)
 	if len(got) != 1 {
 		t.Errorf("expected worktree to survive when no secondaries exist, got %+v", got)

--- a/internal/grouping/grouping_test.go
+++ b/internal/grouping/grouping_test.go
@@ -63,8 +63,8 @@ func fakeMainRepo(t *testing.T, branch, checkout string) string {
 // ── ComputeSecondaryDomain ───────────────────────────────────────────────────
 
 func TestComputeSecondaryDomain(t *testing.T) {
-	if got := ComputeSecondaryDomain("astrolov.test", "admin"); got != "admin.astrolov.test" {
-		t.Errorf("got %q, want admin.astrolov.test", got)
+	if got := ComputeSecondaryDomain("starlane.test", "admin"); got != "admin.starlane.test" {
+		t.Errorf("got %q, want admin.starlane.test", got)
 	}
 }
 
@@ -98,25 +98,25 @@ func TestValidateLabel(t *testing.T) {
 
 func TestAssignSecondary_groupsExistingSite(t *testing.T) {
 	setup(t)
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: "/srv/astrolov"})
-	mustAdd(t, config.Site{Name: "admin-astrolov", Domains: []string{"admin-astrolov.test"}, Path: "/srv/admin"})
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: "/srv/starlane"})
+	mustAdd(t, config.Site{Name: "admin-starlane", Domains: []string{"admin-starlane.test"}, Path: "/srv/admin"})
 
-	main := reload(t, "astrolov")
-	sec := reload(t, "admin-astrolov")
+	main := reload(t, "starlane")
+	sec := reload(t, "admin-starlane")
 	if err := AssignSecondary(main, sec, "admin", false); err != nil {
 		t.Fatalf("AssignSecondary: %v", err)
 	}
 
-	gotMain := reload(t, "astrolov")
-	if !gotMain.IsGroupMain() || gotMain.Group != "astrolov" {
+	gotMain := reload(t, "starlane")
+	if !gotMain.IsGroupMain() || gotMain.Group != "starlane" {
 		t.Errorf("main not promoted: group=%q subdomain=%q", gotMain.Group, gotMain.GroupSubdomain)
 	}
-	gotSec := reload(t, "admin-astrolov")
+	gotSec := reload(t, "admin-starlane")
 	if !gotSec.IsGroupSecondary() {
 		t.Errorf("secondary not grouped: group=%q subdomain=%q", gotSec.Group, gotSec.GroupSubdomain)
 	}
-	if gotSec.PrimaryDomain() != "admin.astrolov.test" {
-		t.Errorf("secondary domain = %q, want admin.astrolov.test", gotSec.PrimaryDomain())
+	if gotSec.PrimaryDomain() != "admin.starlane.test" {
+		t.Errorf("secondary domain = %q, want admin.starlane.test", gotSec.PrimaryDomain())
 	}
 	if len(gotSec.Domains) != 1 {
 		t.Errorf("old standalone domain not replaced: %v", gotSec.Domains)
@@ -126,10 +126,10 @@ func TestAssignSecondary_groupsExistingSite(t *testing.T) {
 func TestAssignSecondary_rollsBackOnRegenFailure(t *testing.T) {
 	setup(t)
 	regenerateSecondary = func(_ *config.Site, _ string) error { return fmt.Errorf("boom") }
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: "/srv/astrolov"})
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: "/srv/starlane"})
 	mustAdd(t, config.Site{Name: "admin", Domains: []string{"admin.test"}, Path: "/srv/admin"})
 
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "admin"), "admin", false); err == nil {
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "admin"), "admin", false); err == nil {
 		t.Fatal("expected regeneration failure to surface")
 	}
 	sec := reload(t, "admin")
@@ -139,7 +139,7 @@ func TestAssignSecondary_rollsBackOnRegenFailure(t *testing.T) {
 	if sec.PrimaryDomain() != "admin.test" {
 		t.Errorf("secondary domain not restored: %q", sec.PrimaryDomain())
 	}
-	if reload(t, "astrolov").Group != "" {
+	if reload(t, "starlane").Group != "" {
 		t.Error("main not demoted after rollback")
 	}
 }
@@ -148,8 +148,8 @@ func TestAssignSecondary_rollsBackOnRegenFailure(t *testing.T) {
 
 func TestAssignSecondary_rejectsSelf(t *testing.T) {
 	setup(t)
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: "/srv/astrolov"})
-	s := reload(t, "astrolov")
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: "/srv/starlane"})
+	s := reload(t, "starlane")
 	if err := AssignSecondary(s, s, "admin", false); err == nil {
 		t.Error("expected error grouping a site under itself")
 	}
@@ -157,30 +157,30 @@ func TestAssignSecondary_rejectsSelf(t *testing.T) {
 
 func TestAssignSecondary_rejectsInvalidLabel(t *testing.T) {
 	setup(t)
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: "/srv/astrolov"})
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: "/srv/starlane"})
 	mustAdd(t, config.Site{Name: "admin", Domains: []string{"admin.test"}, Path: "/srv/admin"})
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "admin"), "Bad_Label", false); err == nil {
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "admin"), "Bad_Label", false); err == nil {
 		t.Error("expected error for invalid label")
 	}
 }
 
 func TestAssignSecondary_rejectsDomainInUse(t *testing.T) {
 	setup(t)
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: "/srv/astrolov"})
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: "/srv/starlane"})
 	mustAdd(t, config.Site{Name: "admin", Domains: []string{"admin.test"}, Path: "/srv/admin"})
 	// A third site already squats the computed subdomain.
-	mustAdd(t, config.Site{Name: "squatter", Domains: []string{"admin.astrolov.test"}, Path: "/srv/squatter"})
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "admin"), "admin", false); err == nil {
+	mustAdd(t, config.Site{Name: "squatter", Domains: []string{"admin.starlane.test"}, Path: "/srv/squatter"})
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "admin"), "admin", false); err == nil {
 		t.Error("expected error when computed subdomain is already used")
 	}
 }
 
 func TestAssignSecondary_rejectsSiblingLabelDup(t *testing.T) {
 	setup(t)
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: "/srv/astrolov", Group: "astrolov"})
-	mustAdd(t, config.Site{Name: "admin1", Domains: []string{"admin.astrolov.test"}, Path: "/srv/admin1", Group: "astrolov", GroupSubdomain: "admin"})
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: "/srv/starlane", Group: "starlane"})
+	mustAdd(t, config.Site{Name: "admin1", Domains: []string{"admin.starlane.test"}, Path: "/srv/admin1", Group: "starlane", GroupSubdomain: "admin"})
 	mustAdd(t, config.Site{Name: "admin2", Domains: []string{"admin2.test"}, Path: "/srv/admin2"})
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "admin2"), "admin", false); err == nil {
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "admin2"), "admin", false); err == nil {
 		t.Error("expected error for duplicate sibling label")
 	}
 }
@@ -188,16 +188,16 @@ func TestAssignSecondary_rejectsSiblingLabelDup(t *testing.T) {
 func TestAssignSecondary_rejectsWorktreeLabelCollision(t *testing.T) {
 	setup(t)
 	mainPath := fakeMainRepo(t, "admin", "")
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: mainPath})
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: mainPath})
 	mustAdd(t, config.Site{Name: "admin", Domains: []string{"admin.test"}, Path: "/srv/admin"})
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "admin"), "admin", false); err == nil {
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "admin"), "admin", false); err == nil {
 		t.Error("expected error when a main-site worktree already uses the label")
 	}
 }
 
 func TestAssignSecondary_rejectsMainThatIsSecondary(t *testing.T) {
 	setup(t)
-	mustAdd(t, config.Site{Name: "sub", Domains: []string{"sub.astrolov.test"}, Path: "/srv/sub", Group: "astrolov", GroupSubdomain: "sub"})
+	mustAdd(t, config.Site{Name: "sub", Domains: []string{"sub.starlane.test"}, Path: "/srv/sub", Group: "starlane", GroupSubdomain: "sub"})
 	mustAdd(t, config.Site{Name: "other", Domains: []string{"other.test"}, Path: "/srv/other"})
 	if err := AssignSecondary(reload(t, "sub"), reload(t, "other"), "x", false); err == nil {
 		t.Error("expected error using a secondary as a group main")
@@ -206,10 +206,10 @@ func TestAssignSecondary_rejectsMainThatIsSecondary(t *testing.T) {
 
 func TestAssignSecondary_rejectsSecondaryWithOwnSecondaries(t *testing.T) {
 	setup(t)
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: "/srv/astrolov"})
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: "/srv/starlane"})
 	mustAdd(t, config.Site{Name: "other", Domains: []string{"other.test"}, Path: "/srv/other", Group: "other"})
 	mustAdd(t, config.Site{Name: "othersub", Domains: []string{"sub.other.test"}, Path: "/srv/othersub", Group: "other", GroupSubdomain: "sub"})
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "other"), "x", false); err == nil {
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "other"), "x", false); err == nil {
 		t.Error("expected error: groups are only one level deep")
 	}
 }
@@ -218,32 +218,32 @@ func TestAssignSecondary_rejectsSecondaryWithOwnSecondaries(t *testing.T) {
 
 func TestUnassignSecondary_restoresStandalone(t *testing.T) {
 	setup(t)
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: "/srv/astrolov"})
-	mustAdd(t, config.Site{Name: "admin-astrolov", Domains: []string{"admin-astrolov.test"}, Path: "/srv/admin-astrolov"})
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "admin-astrolov"), "admin", false); err != nil {
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: "/srv/starlane"})
+	mustAdd(t, config.Site{Name: "admin-starlane", Domains: []string{"admin-starlane.test"}, Path: "/srv/admin-starlane"})
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "admin-starlane"), "admin", false); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := UnassignSecondary(reload(t, "admin-astrolov")); err != nil {
+	if err := UnassignSecondary(reload(t, "admin-starlane")); err != nil {
 		t.Fatalf("UnassignSecondary: %v", err)
 	}
-	sec := reload(t, "admin-astrolov")
+	sec := reload(t, "admin-starlane")
 	if sec.IsGroupSecondary() {
 		t.Errorf("still grouped: group=%q subdomain=%q", sec.Group, sec.GroupSubdomain)
 	}
-	if sec.PrimaryDomain() != "admin-astrolov.test" {
-		t.Errorf("standalone domain = %q, want admin-astrolov.test", sec.PrimaryDomain())
+	if sec.PrimaryDomain() != "admin-starlane.test" {
+		t.Errorf("standalone domain = %q, want admin-starlane.test", sec.PrimaryDomain())
 	}
 	// Last secondary gone -> main's group key cleared.
-	if reload(t, "astrolov").Group != "" {
+	if reload(t, "starlane").Group != "" {
 		t.Errorf("main group key not cleared after last secondary removed")
 	}
 }
 
 func TestUnassignSecondary_rejectsNonSecondary(t *testing.T) {
 	setup(t)
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: "/srv/astrolov"})
-	if err := UnassignSecondary(reload(t, "astrolov")); err == nil {
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: "/srv/starlane"})
+	if err := UnassignSecondary(reload(t, "starlane")); err == nil {
 		t.Error("expected error unassigning a non-secondary")
 	}
 }
@@ -252,16 +252,16 @@ func TestUnassignSecondary_rejectsNonSecondary(t *testing.T) {
 
 func TestSetSecondaryLabel_changesDomain(t *testing.T) {
 	setup(t)
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: "/srv/astrolov"})
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: "/srv/starlane"})
 	mustAdd(t, config.Site{Name: "admin", Domains: []string{"admin.test"}, Path: "/srv/admin"})
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "admin"), "admin", false); err != nil {
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "admin"), "admin", false); err != nil {
 		t.Fatal(err)
 	}
 	if err := SetSecondaryLabel(reload(t, "admin"), "backoffice"); err != nil {
 		t.Fatalf("SetSecondaryLabel: %v", err)
 	}
 	sec := reload(t, "admin")
-	if sec.GroupSubdomain != "backoffice" || sec.PrimaryDomain() != "backoffice.astrolov.test" {
+	if sec.GroupSubdomain != "backoffice" || sec.PrimaryDomain() != "backoffice.starlane.test" {
 		t.Errorf("label not changed: subdomain=%q domain=%q", sec.GroupSubdomain, sec.PrimaryDomain())
 	}
 }
@@ -270,21 +270,21 @@ func TestSetSecondaryLabel_changesDomain(t *testing.T) {
 
 func TestCascadeMainDomainChange_reflowsSecondaries(t *testing.T) {
 	setup(t)
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: "/srv/astrolov"})
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: "/srv/starlane"})
 	mustAdd(t, config.Site{Name: "admin", Domains: []string{"admin.test"}, Path: "/srv/admin"})
 	mustAdd(t, config.Site{Name: "api", Domains: []string{"api.test"}, Path: "/srv/api"})
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "admin"), "admin", false); err != nil {
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "admin"), "admin", false); err != nil {
 		t.Fatal(err)
 	}
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "api"), "api", false); err != nil {
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "api"), "api", false); err != nil {
 		t.Fatal(err)
 	}
 
 	// Rename the main's base domain, then cascade.
-	main := reload(t, "astrolov")
+	main := reload(t, "starlane")
 	main.Domains = []string{"astro.test"}
 	mustAdd(t, *main)
-	if err := CascadeMainDomainChange(reload(t, "astrolov")); err != nil {
+	if err := CascadeMainDomainChange(reload(t, "starlane")); err != nil {
 		t.Fatalf("CascadeMainDomainChange: %v", err)
 	}
 
@@ -300,18 +300,18 @@ func TestCascadeMainDomainChange_reflowsSecondaries(t *testing.T) {
 
 func TestDissolveGroup_ungroupsAll(t *testing.T) {
 	setup(t)
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: "/srv/astrolov"})
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: "/srv/starlane"})
 	mustAdd(t, config.Site{Name: "admin", Domains: []string{"admin.test"}, Path: "/srv/admin"})
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "admin"), "admin", false); err != nil {
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "admin"), "admin", false); err != nil {
 		t.Fatal(err)
 	}
-	if err := DissolveGroup("astrolov"); err != nil {
+	if err := DissolveGroup("starlane"); err != nil {
 		t.Fatalf("DissolveGroup: %v", err)
 	}
 	if reload(t, "admin").IsGroupSecondary() {
 		t.Error("secondary still grouped after dissolve")
 	}
-	if reload(t, "astrolov").Group != "" {
+	if reload(t, "starlane").Group != "" {
 		t.Error("main still has group key after dissolve")
 	}
 }
@@ -336,62 +336,62 @@ func envDB(t *testing.T, dir string) string {
 
 func TestAssignSecondary_sharedDB_pointsAtMainDB(t *testing.T) {
 	setup(t)
-	mainDir := siteWithEnv(t, "astrolov")
-	secDir := siteWithEnv(t, "admin_astrolov")
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: mainDir})
-	mustAdd(t, config.Site{Name: "admin-astrolov", Domains: []string{"admin-astrolov.test"}, Path: secDir})
+	mainDir := siteWithEnv(t, "starlane")
+	secDir := siteWithEnv(t, "admin_starlane")
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: mainDir})
+	mustAdd(t, config.Site{Name: "admin-starlane", Domains: []string{"admin-starlane.test"}, Path: secDir})
 
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "admin-astrolov"), "admin", true); err != nil {
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "admin-starlane"), "admin", true); err != nil {
 		t.Fatalf("AssignSecondary: %v", err)
 	}
-	if !reload(t, "admin-astrolov").GroupSharedDB {
+	if !reload(t, "admin-starlane").GroupSharedDB {
 		t.Error("GroupSharedDB not persisted")
 	}
-	if got := envDB(t, secDir); got != "astrolov" {
-		t.Errorf("secondary DB_DATABASE = %q, want astrolov", got)
+	if got := envDB(t, secDir); got != "starlane" {
+		t.Errorf("secondary DB_DATABASE = %q, want starlane", got)
 	}
 }
 
 func TestSetSecondarySharedDB_toggle(t *testing.T) {
 	setup(t)
-	mainDir := siteWithEnv(t, "astrolov")
-	secDir := siteWithEnv(t, "admin_astrolov")
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: mainDir})
-	mustAdd(t, config.Site{Name: "admin-astrolov", Domains: []string{"admin-astrolov.test"}, Path: secDir})
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "admin-astrolov"), "admin", false); err != nil {
+	mainDir := siteWithEnv(t, "starlane")
+	secDir := siteWithEnv(t, "admin_starlane")
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: mainDir})
+	mustAdd(t, config.Site{Name: "admin-starlane", Domains: []string{"admin-starlane.test"}, Path: secDir})
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "admin-starlane"), "admin", false); err != nil {
 		t.Fatal(err)
 	}
 	// Independent by default.
-	if got := envDB(t, secDir); got != "admin_astrolov" {
-		t.Errorf("default DB_DATABASE = %q, want admin_astrolov", got)
+	if got := envDB(t, secDir); got != "admin_starlane" {
+		t.Errorf("default DB_DATABASE = %q, want admin_starlane", got)
 	}
 	// Turn sharing on.
-	if err := SetSecondarySharedDB(reload(t, "admin-astrolov"), true); err != nil {
+	if err := SetSecondarySharedDB(reload(t, "admin-starlane"), true); err != nil {
 		t.Fatalf("SetSecondarySharedDB on: %v", err)
 	}
-	if got := envDB(t, secDir); got != "astrolov" {
-		t.Errorf("after share DB_DATABASE = %q, want astrolov", got)
+	if got := envDB(t, secDir); got != "starlane" {
+		t.Errorf("after share DB_DATABASE = %q, want starlane", got)
 	}
 	// Turn it back off — restores the secondary's own slug.
-	if err := SetSecondarySharedDB(reload(t, "admin-astrolov"), false); err != nil {
+	if err := SetSecondarySharedDB(reload(t, "admin-starlane"), false); err != nil {
 		t.Fatalf("SetSecondarySharedDB off: %v", err)
 	}
-	if got := envDB(t, secDir); got != "admin_astrolov" {
-		t.Errorf("after unshare DB_DATABASE = %q, want admin_astrolov", got)
+	if got := envDB(t, secDir); got != "admin_starlane" {
+		t.Errorf("after unshare DB_DATABASE = %q, want admin_starlane", got)
 	}
 }
 
 func TestSharedDBNameFor(t *testing.T) {
 	setup(t)
-	mainDir := siteWithEnv(t, "astrolov")
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: mainDir, Group: "astrolov"})
-	shared := config.Site{Name: "admin", Domains: []string{"admin.astrolov.test"}, Path: "/srv/admin", Group: "astrolov", GroupSubdomain: "admin", GroupSharedDB: true}
+	mainDir := siteWithEnv(t, "starlane")
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: mainDir, Group: "starlane"})
+	shared := config.Site{Name: "admin", Domains: []string{"admin.starlane.test"}, Path: "/srv/admin", Group: "starlane", GroupSubdomain: "admin", GroupSharedDB: true}
 	mustAdd(t, shared)
-	if name, ok := SharedDBNameFor(&shared); !ok || name != "astrolov" {
-		t.Errorf("SharedDBNameFor = %q,%v, want astrolov,true", name, ok)
+	if name, ok := SharedDBNameFor(&shared); !ok || name != "starlane" {
+		t.Errorf("SharedDBNameFor = %q,%v, want starlane,true", name, ok)
 	}
 	// A non-sharing secondary returns false.
-	indep := config.Site{Name: "i", Domains: []string{"i.astrolov.test"}, Path: "/srv/i", Group: "astrolov", GroupSubdomain: "i"}
+	indep := config.Site{Name: "i", Domains: []string{"i.starlane.test"}, Path: "/srv/i", Group: "starlane", GroupSubdomain: "i"}
 	if _, ok := SharedDBNameFor(&indep); ok {
 		t.Error("expected SharedDBNameFor=false for non-sharing secondary")
 	}
@@ -399,18 +399,18 @@ func TestSharedDBNameFor(t *testing.T) {
 
 func TestUnassignSecondary_sharedDB_restoresOwnDB(t *testing.T) {
 	setup(t)
-	mainDir := siteWithEnv(t, "astrolov")
-	secDir := siteWithEnv(t, "admin_astrolov")
-	mustAdd(t, config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: mainDir})
-	mustAdd(t, config.Site{Name: "admin-astrolov", Domains: []string{"admin-astrolov.test"}, Path: secDir})
-	if err := AssignSecondary(reload(t, "astrolov"), reload(t, "admin-astrolov"), "admin", true); err != nil {
+	mainDir := siteWithEnv(t, "starlane")
+	secDir := siteWithEnv(t, "admin_starlane")
+	mustAdd(t, config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: mainDir})
+	mustAdd(t, config.Site{Name: "admin-starlane", Domains: []string{"admin-starlane.test"}, Path: secDir})
+	if err := AssignSecondary(reload(t, "starlane"), reload(t, "admin-starlane"), "admin", true); err != nil {
 		t.Fatal(err)
 	}
-	if err := UnassignSecondary(reload(t, "admin-astrolov")); err != nil {
+	if err := UnassignSecondary(reload(t, "admin-starlane")); err != nil {
 		t.Fatalf("UnassignSecondary: %v", err)
 	}
-	if got := envDB(t, secDir); got != "admin_astrolov" {
-		t.Errorf("after ungroup DB_DATABASE = %q, want admin_astrolov", got)
+	if got := envDB(t, secDir); got != "admin_starlane" {
+		t.Errorf("after ungroup DB_DATABASE = %q, want admin_starlane", got)
 	}
 }
 
@@ -420,19 +420,19 @@ func TestSyncSecondaryProjectDomains_replacesOldStandalone(t *testing.T) {
 	setup(t)
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"),
-		[]byte("php_version: \"8.4\"\ndomains:\n  - admin-astrolov\n"), 0o644); err != nil {
+		[]byte("php_version: \"8.4\"\ndomains:\n  - admin-starlane\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	sec := &config.Site{Name: "admin-astrolov", Domains: []string{"admin.astrolov.test"}, Path: dir}
+	sec := &config.Site{Name: "admin-starlane", Domains: []string{"admin.starlane.test"}, Path: dir}
 
-	syncSecondaryProjectDomains(sec, "admin-astrolov.test")
+	syncSecondaryProjectDomains(sec, "admin-starlane.test")
 
 	cfg, err := config.LoadProjectConfig(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(cfg.Domains) != 1 || cfg.Domains[0] != "admin.astrolov" {
-		t.Errorf(".lerd.yaml domains = %v, want [admin.astrolov] (old standalone dropped)", cfg.Domains)
+	if len(cfg.Domains) != 1 || cfg.Domains[0] != "admin.starlane" {
+		t.Errorf(".lerd.yaml domains = %v, want [admin.starlane] (old standalone dropped)", cfg.Domains)
 	}
 }
 
@@ -441,7 +441,7 @@ func TestSyncSecondaryProjectDomains_replacesOldStandalone(t *testing.T) {
 func TestWorktreeLabelTaken(t *testing.T) {
 	setup(t)
 	mainPath := fakeMainRepo(t, "admin", "")
-	main := &config.Site{Name: "astrolov", Domains: []string{"astrolov.test"}, Path: mainPath}
+	main := &config.Site{Name: "starlane", Domains: []string{"starlane.test"}, Path: mainPath}
 	if taken, err := WorktreeLabelTaken(main, "admin"); err != nil || !taken {
 		t.Errorf("expected admin label taken, got taken=%v err=%v", taken, err)
 	}

--- a/internal/podman/frankenphp.go
+++ b/internal/podman/frankenphp.go
@@ -15,12 +15,12 @@ func FrankenPHPContainerName(siteName string) string {
 }
 
 // FrankenPHPImage returns the official dunglas/frankenphp image tag for the
-// requested PHP version. Versions outside the published build set fall back
-// to the latest stable (php8.4).
+// requested PHP version. Versions without a published frankenphp image fall
+// back to the latest one lerd knows about.
 func FrankenPHPImage(phpVersion string) string {
-	supported := map[string]bool{"8.2": true, "8.3": true, "8.4": true}
-	if !supported[phpVersion] {
-		phpVersion = "8.4"
+	if !config.IsFrankenPHPVersion(phpVersion) {
+		published := config.FrankenPHPVersions()
+		phpVersion = published[len(published)-1]
 	}
 	return "docker.io/dunglas/frankenphp:php" + phpVersion + "-alpine"
 }

--- a/internal/podman/frankenphp.go
+++ b/internal/podman/frankenphp.go
@@ -19,8 +19,7 @@ func FrankenPHPContainerName(siteName string) string {
 // back to the latest one lerd knows about.
 func FrankenPHPImage(phpVersion string) string {
 	if !config.IsFrankenPHPVersion(phpVersion) {
-		published := config.FrankenPHPVersions()
-		phpVersion = published[len(published)-1]
+		phpVersion = config.LatestFrankenPHPVersion()
 	}
 	return "docker.io/dunglas/frankenphp:php" + phpVersion + "-alpine"
 }

--- a/internal/podman/frankenphp_test.go
+++ b/internal/podman/frankenphp_test.go
@@ -19,8 +19,9 @@ func TestFrankenPHPImage(t *testing.T) {
 		{"8.2", "docker.io/dunglas/frankenphp:php8.2-alpine"},
 		{"8.3", "docker.io/dunglas/frankenphp:php8.3-alpine"},
 		{"8.4", "docker.io/dunglas/frankenphp:php8.4-alpine"},
-		{"8.1", "docker.io/dunglas/frankenphp:php8.4-alpine"}, // unsupported → fallback
-		{"", "docker.io/dunglas/frankenphp:php8.4-alpine"},
+		{"8.5", "docker.io/dunglas/frankenphp:php8.5-alpine"},
+		{"8.1", "docker.io/dunglas/frankenphp:php8.5-alpine"}, // no frankenphp tag → latest
+		{"", "docker.io/dunglas/frankenphp:php8.5-alpine"},
 	}
 	for _, tt := range tests {
 		if got := FrankenPHPImage(tt.version); got != tt.want {

--- a/internal/siteinfo/parent_workers_test.go
+++ b/internal/siteinfo/parent_workers_test.go
@@ -17,7 +17,7 @@ import (
 func TestEnrichWorkers_keepsPerWorktreeOnParentWhenCheckPasses(t *testing.T) {
 	origUnit := unitStatusFn
 	unitStatusFn = func(name string) (string, error) {
-		if name == "lerd-vite-whitewaters" {
+		if name == "lerd-vite-rapids" {
 			return "active", nil
 		}
 		return "inactive", nil
@@ -41,7 +41,7 @@ func TestEnrichWorkers_keepsPerWorktreeOnParentWhenCheckPasses(t *testing.T) {
 		},
 	}
 
-	e := &EnrichedSite{Name: "whitewaters", Path: tmp}
+	e := &EnrichedSite{Name: "rapids", Path: tmp}
 	e.enrichWorkers(fw, true)
 
 	var got *WorkerInfo
@@ -81,7 +81,7 @@ func TestEnrichWorkers_dropsPerWorktreeWhenCheckFails(t *testing.T) {
 		},
 	}
 
-	e := &EnrichedSite{Name: "whitewaters", Path: t.TempDir()}
+	e := &EnrichedSite{Name: "rapids", Path: t.TempDir()}
 	e.enrichWorkers(fw, true)
 
 	for _, w := range e.FrameworkWorkers {
@@ -97,7 +97,7 @@ func TestEnrichWorkers_dropsPerWorktreeWhenCheckFails(t *testing.T) {
 func TestEnrichWorkers_keepsNonPerWorktreeOnParent(t *testing.T) {
 	origUnit := unitStatusFn
 	unitStatusFn = func(name string) (string, error) {
-		if name == "lerd-search-indexer-whitewaters" {
+		if name == "lerd-search-indexer-rapids" {
 			return "active", nil
 		}
 		return "inactive", nil
@@ -110,7 +110,7 @@ func TestEnrichWorkers_keepsNonPerWorktreeOnParent(t *testing.T) {
 		},
 	}
 
-	e := &EnrichedSite{Name: "whitewaters", Path: "/projects/whitewaters"}
+	e := &EnrichedSite{Name: "rapids", Path: "/projects/rapids"}
 	e.enrichWorkers(fw, true)
 
 	if len(e.FrameworkWorkers) != 1 || e.FrameworkWorkers[0].Name != "search-indexer" {

--- a/internal/siteinfo/unitcache_test.go
+++ b/internal/siteinfo/unitcache_test.go
@@ -17,14 +17,14 @@ func withStubList(t *testing.T, out string, err error) {
 }
 
 func TestUnitStatusCachedParsesListUnits(t *testing.T) {
-	withStubList(t, `lerd-queue-astrolov.service     loaded active   running Lerd Queue Worker
+	withStubList(t, `lerd-queue-starlane.service     loaded active   running Lerd Queue Worker
 lerd-schedule-silvia.timer      loaded active   waiting Lerd Schedule Timer
 lerd-reverb-boom.service        loaded failed   failed  Lerd Reverb
 `, nil)
 
 	cases := map[string]string{
-		"lerd-queue-astrolov":         "active",
-		"lerd-queue-astrolov.service": "active",
+		"lerd-queue-starlane":         "active",
+		"lerd-queue-starlane.service": "active",
 		"lerd-schedule-silvia.timer":  "active",
 		"lerd-reverb-boom":            "failed",
 		"lerd-ghost":                  "unknown",

--- a/internal/siteinfo/worktree_workers_test.go
+++ b/internal/siteinfo/worktree_workers_test.go
@@ -27,7 +27,7 @@ func TestEnrichWorktreeWorkers_skipsParentOnlyWorkers(t *testing.T) {
 			"vite":     vitePerWT(),
 		},
 	}
-	got := enrichWorktreeWorkers("whitewaters", "/projects/whitewaters/main", fw)
+	got := enrichWorktreeWorkers("rapids", "/projects/rapids/main", fw)
 	if len(got) != 1 || got[0].Name != "vite" {
 		t.Fatalf("expected only vite worker, got %+v", got)
 	}
@@ -36,7 +36,7 @@ func TestEnrichWorktreeWorkers_skipsParentOnlyWorkers(t *testing.T) {
 func TestEnrichWorktreeWorkers_unitNamePerWorktree(t *testing.T) {
 	origUnit := unitStatusFn
 	unitStatusFn = func(name string) (string, error) {
-		if name == "lerd-vite-whitewaters-main" {
+		if name == "lerd-vite-rapids-main" {
 			return "active", nil
 		}
 		return "inactive", nil
@@ -48,7 +48,7 @@ func TestEnrichWorktreeWorkers_unitNamePerWorktree(t *testing.T) {
 			"vite": vitePerWT(),
 		},
 	}
-	got := enrichWorktreeWorkers("whitewaters", "/projects/whitewaters/main", fw)
+	got := enrichWorktreeWorkers("rapids", "/projects/rapids/main", fw)
 	if len(got) != 1 {
 		t.Fatalf("expected 1 worker, got %d", len(got))
 	}

--- a/internal/siteops/naming_test.go
+++ b/internal/siteops/naming_test.go
@@ -19,7 +19,7 @@ func TestSiteNameAndDomain(t *testing.T) {
 		{"dots.in.name", "test", "dots-in-name", "dots-in-name.test"},
 
 		// ccTLDs handled by the 2-letter regex, no enumeration needed.
-		{"astrolov.ro", "test", "astrolov", "astrolov.test"},
+		{"starlane.ro", "test", "starlane", "starlane.test"},
 		{"mysite.nl", "test", "mysite", "mysite.test"},
 		{"mysite.be", "test", "mysite", "mysite.test"},
 		{"project.pl", "test", "project", "project.test"},

--- a/internal/siteops/vhost_test.go
+++ b/internal/siteops/vhost_test.go
@@ -24,17 +24,17 @@ func TestMoveCustomNginxConfig_carriesWorktreeOverridesAndBackups(t *testing.T) 
 	live := config.NginxCustomD()
 	bkp := config.NginxCustomDBkp()
 	// Main override + a worktree override (keyed by {branch}.{primary}).
-	seedFile(t, filepath.Join(live, "rental-registry.test.conf"), "# main\n")
-	seedFile(t, filepath.Join(live, "feat.rental-registry.test.conf"), "# worktree feat\n")
-	seedFile(t, filepath.Join(bkp, "feat.rental-registry.test.conf.bkp.20260101-101010"), "# wt backup\n")
+	seedFile(t, filepath.Join(live, "leasebook.test.conf"), "# main\n")
+	seedFile(t, filepath.Join(live, "feat.leasebook.test.conf"), "# worktree feat\n")
+	seedFile(t, filepath.Join(bkp, "feat.leasebook.test.conf.bkp.20260101-101010"), "# wt backup\n")
 	// A different site must be untouched.
 	seedFile(t, filepath.Join(live, "other.test.conf"), "# other\n")
 
-	if err := MoveCustomNginxConfig("rental-registry.test", "rentals.test"); err != nil {
+	if err := MoveCustomNginxConfig("leasebook.test", "rentals.test"); err != nil {
 		t.Fatalf("MoveCustomNginxConfig: %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(live, "feat.rental-registry.test.conf")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(live, "feat.leasebook.test.conf")); !os.IsNotExist(err) {
 		t.Errorf("old worktree override still present, want renamed")
 	}
 	body, err := os.ReadFile(filepath.Join(live, "feat.rentals.test.conf"))
@@ -88,16 +88,16 @@ func TestMoveCustomNginxConfig_movesLiveOverrideAndBackups(t *testing.T) {
 
 	live := config.NginxCustomD()
 	bkp := config.NginxCustomDBkp()
-	seedFile(t, filepath.Join(live, "scorediviner.test.conf"), "client_max_body_size 200m;\n")
-	seedFile(t, filepath.Join(bkp, "scorediviner.test.conf.bkp.20260101-101010"), "old1\n")
-	seedFile(t, filepath.Join(bkp, "scorediviner.test.conf.bkp.20260101-101010-1"), "old2\n")
+	seedFile(t, filepath.Join(live, "tallyboard.test.conf"), "client_max_body_size 200m;\n")
+	seedFile(t, filepath.Join(bkp, "tallyboard.test.conf.bkp.20260101-101010"), "old1\n")
+	seedFile(t, filepath.Join(bkp, "tallyboard.test.conf.bkp.20260101-101010-1"), "old2\n")
 	seedFile(t, filepath.Join(bkp, "other.test.conf.bkp.20260101-101010"), "unrelated\n")
 
-	if err := MoveCustomNginxConfig("scorediviner.test", "therealscore.test"); err != nil {
+	if err := MoveCustomNginxConfig("tallyboard.test", "therealscore.test"); err != nil {
 		t.Fatalf("MoveCustomNginxConfig: %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(live, "scorediviner.test.conf")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(live, "tallyboard.test.conf")); !os.IsNotExist(err) {
 		t.Errorf("old live override still present, want removed")
 	}
 	body, err := os.ReadFile(filepath.Join(live, "therealscore.test.conf"))
@@ -106,7 +106,7 @@ func TestMoveCustomNginxConfig_movesLiveOverrideAndBackups(t *testing.T) {
 	}
 
 	for _, suffix := range []string{"20260101-101010", "20260101-101010-1"} {
-		if _, err := os.Stat(filepath.Join(bkp, "scorediviner.test.conf.bkp."+suffix)); !os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(bkp, "tallyboard.test.conf.bkp."+suffix)); !os.IsNotExist(err) {
 			t.Errorf("old backup %s still present, want renamed", suffix)
 		}
 		if _, err := os.Stat(filepath.Join(bkp, "therealscore.test.conf.bkp."+suffix)); err != nil {
@@ -122,7 +122,7 @@ func TestMoveCustomNginxConfig_movesLiveOverrideAndBackups(t *testing.T) {
 func TestMoveCustomNginxConfig_noOverrideIsNoError(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
-	if err := MoveCustomNginxConfig("scorediviner.test", "therealscore.test"); err != nil {
+	if err := MoveCustomNginxConfig("tallyboard.test", "therealscore.test"); err != nil {
 		t.Fatalf("MoveCustomNginxConfig with no files present: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(config.NginxCustomD(), "therealscore.test.conf")); !os.IsNotExist(err) {
@@ -134,10 +134,10 @@ func TestMoveCustomNginxConfig_liveOverrideReplacesStaleOrphan(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
 	live := config.NginxCustomD()
-	seedFile(t, filepath.Join(live, "scorediviner.test.conf"), "current config\n")
+	seedFile(t, filepath.Join(live, "tallyboard.test.conf"), "current config\n")
 	seedFile(t, filepath.Join(live, "therealscore.test.conf"), "stale orphan\n")
 
-	if err := MoveCustomNginxConfig("scorediviner.test", "therealscore.test"); err != nil {
+	if err := MoveCustomNginxConfig("tallyboard.test", "therealscore.test"); err != nil {
 		t.Fatalf("MoveCustomNginxConfig: %v", err)
 	}
 	body, err := os.ReadFile(filepath.Join(live, "therealscore.test.conf"))
@@ -150,17 +150,17 @@ func TestMoveCustomNginxConfig_doesNotClobberExistingBackup(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
 	bkp := config.NginxCustomDBkp()
-	seedFile(t, filepath.Join(bkp, "scorediviner.test.conf.bkp.20260101-101010"), "source\n")
+	seedFile(t, filepath.Join(bkp, "tallyboard.test.conf.bkp.20260101-101010"), "source\n")
 	seedFile(t, filepath.Join(bkp, "therealscore.test.conf.bkp.20260101-101010"), "existing\n")
 
-	if err := MoveCustomNginxConfig("scorediviner.test", "therealscore.test"); err != nil {
+	if err := MoveCustomNginxConfig("tallyboard.test", "therealscore.test"); err != nil {
 		t.Fatalf("MoveCustomNginxConfig: %v", err)
 	}
 	body, err := os.ReadFile(filepath.Join(bkp, "therealscore.test.conf.bkp.20260101-101010"))
 	if err != nil || string(body) != "existing\n" {
 		t.Errorf("colliding backup = %q err=%v; want existing history preserved, not clobbered", body, err)
 	}
-	if _, err := os.Stat(filepath.Join(bkp, "scorediviner.test.conf.bkp.20260101-101010")); err != nil {
+	if _, err := os.Stat(filepath.Join(bkp, "tallyboard.test.conf.bkp.20260101-101010")); err != nil {
 		t.Errorf("source backup should be left in place when destination collides: %v", err)
 	}
 }
@@ -169,12 +169,12 @@ func TestMoveCustomNginxConfig_samePrimaryIsNoop(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
 	live := config.NginxCustomD()
-	seedFile(t, filepath.Join(live, "scorediviner.test.conf"), "keep me\n")
+	seedFile(t, filepath.Join(live, "tallyboard.test.conf"), "keep me\n")
 
-	if err := MoveCustomNginxConfig("scorediviner.test", "scorediviner.test"); err != nil {
+	if err := MoveCustomNginxConfig("tallyboard.test", "tallyboard.test"); err != nil {
 		t.Fatalf("MoveCustomNginxConfig noop: %v", err)
 	}
-	body, err := os.ReadFile(filepath.Join(live, "scorediviner.test.conf"))
+	body, err := os.ReadFile(filepath.Join(live, "tallyboard.test.conf"))
 	if err != nil || string(body) != "keep me\n" {
 		t.Errorf("override disturbed by same-domain call: %q err=%v", body, err)
 	}

--- a/internal/systemd/orphan_worktree_test.go
+++ b/internal/systemd/orphan_worktree_test.go
@@ -41,31 +41,31 @@ func TestUnitBelongsToOtherSiteWorktree_noHyphen(t *testing.T) {
 
 func TestUnitBelongsToOtherSiteWorktree_unknownParent(t *testing.T) {
 	sites := []config.Site{{Name: "other", Path: "/tmp/nope"}}
-	if UnitBelongsToOtherSiteWorktree("vite-whitewaters", "main", sites) {
-		t.Error("must not match when no registered site is named 'whitewaters'")
+	if UnitBelongsToOtherSiteWorktree("vite-rapids", "main", sites) {
+		t.Error("must not match when no registered site is named 'rapids'")
 	}
 }
 
 func TestUnitBelongsToOtherSiteWorktree_realWorktree(t *testing.T) {
-	parent := setupParentWithWorktree(t, "whitewaters", "main")
-	sites := []config.Site{{Name: "whitewaters", Path: parent}}
-	if !UnitBelongsToOtherSiteWorktree("vite-whitewaters", "main", sites) {
-		t.Error("expected match: lerd-vite-whitewaters-main belongs to whitewaters")
+	parent := setupParentWithWorktree(t, "rapids", "main")
+	sites := []config.Site{{Name: "rapids", Path: parent}}
+	if !UnitBelongsToOtherSiteWorktree("vite-rapids", "main", sites) {
+		t.Error("expected match: lerd-vite-rapids-main belongs to rapids")
 	}
 }
 
 func TestUnitBelongsToOtherSiteWorktree_hyphenatedParentName(t *testing.T) {
-	parent := setupParentWithWorktree(t, "admin-astrolov", "feature-foo")
-	sites := []config.Site{{Name: "admin-astrolov", Path: parent}}
-	if !UnitBelongsToOtherSiteWorktree("vite-admin-astrolov", "feature-foo", sites) {
+	parent := setupParentWithWorktree(t, "admin-starlane", "feature-foo")
+	sites := []config.Site{{Name: "admin-starlane", Path: parent}}
+	if !UnitBelongsToOtherSiteWorktree("vite-admin-starlane", "feature-foo", sites) {
 		t.Error("expected match across multiple hyphens in parent name")
 	}
 }
 
 func TestUnitBelongsToOtherSiteWorktree_parentExistsButNoMatchingWorktree(t *testing.T) {
-	parent := setupParentWithWorktree(t, "whitewaters", "branch-other")
-	sites := []config.Site{{Name: "whitewaters", Path: parent}}
-	if UnitBelongsToOtherSiteWorktree("vite-whitewaters", "main", sites) {
+	parent := setupParentWithWorktree(t, "rapids", "branch-other")
+	sites := []config.Site{{Name: "rapids", Path: parent}}
+	if UnitBelongsToOtherSiteWorktree("vite-rapids", "main", sites) {
 		t.Error("must not match when the parent has no worktree named 'main'")
 	}
 }

--- a/internal/tui/filter_test.go
+++ b/internal/tui/filter_test.go
@@ -135,12 +135,12 @@ func svcNames(ss []ServiceRow) []string {
 
 func TestGroupSecondariesUnderMains(t *testing.T) {
 	list := []siteinfo.EnrichedSite{
-		{Name: "admin-astrolov", Domains: []string{"admin.astrolov.test"}, Group: "astrolov", GroupSubdomain: "admin"},
-		{Name: "astrolov", Domains: []string{"astrolov.test"}, Group: "astrolov"},
+		{Name: "admin-starlane", Domains: []string{"admin.starlane.test"}, Group: "starlane", GroupSubdomain: "admin"},
+		{Name: "starlane", Domains: []string{"starlane.test"}, Group: "starlane"},
 		{Name: "blog", Domains: []string{"blog.test"}},
 	}
 	got := groupSecondariesUnderMains(list)
-	want := []string{"astrolov", "admin-astrolov", "blog"}
+	want := []string{"starlane", "admin-starlane", "blog"}
 	if len(got) != len(want) {
 		t.Fatalf("len = %d, want %d", len(got), len(want))
 	}
@@ -154,7 +154,7 @@ func TestGroupSecondariesUnderMains(t *testing.T) {
 func TestGroupSecondariesUnderMains_orphanKeepsPlace(t *testing.T) {
 	// Secondary whose main is absent (e.g. filtered out) must still appear.
 	list := []siteinfo.EnrichedSite{
-		{Name: "admin-astrolov", Domains: []string{"admin.astrolov.test"}, Group: "astrolov", GroupSubdomain: "admin"},
+		{Name: "admin-starlane", Domains: []string{"admin.starlane.test"}, Group: "starlane", GroupSubdomain: "admin"},
 		{Name: "blog", Domains: []string{"blog.test"}},
 	}
 	got := groupSecondariesUnderMains(list)

--- a/internal/ui/domain_cert_test.go
+++ b/internal/ui/domain_cert_test.go
@@ -139,7 +139,7 @@ func readSiteCert(t *testing.T, primary string) string {
 // Catching either regression requires asserting all three SAN classes
 // here: new alias, existing primary, and worktree subdomain.
 func TestHandleSiteAction_domainAdd_keepsWorktreeSANs(t *testing.T) {
-	sitePath := setupSecuredSite(t, "theregistry")
+	sitePath := setupSecuredSite(t, "harborlist")
 	makeWorktree(t, sitePath, "main", "main", filepath.Join(t.TempDir(), "wt-main"))
 
 	// Pre-issue the cert so it already exists on disk when domain:add
@@ -147,13 +147,13 @@ func TestHandleSiteAction_domainAdd_keepsWorktreeSANs(t *testing.T) {
 	// would still write a fresh cert with the new SAN (because no prior
 	// file exists to short-circuit on) and the test would miss the bug.
 	if err := certs.ReissueCertForWorktree(config.Site{
-		Name: "theregistry", Path: sitePath,
-		Domains: []string{"theregistry.test"}, Secured: true,
+		Name: "harborlist", Path: sitePath,
+		Domains: []string{"harborlist.test"}, Secured: true,
 	}); err != nil {
 		t.Fatalf("pre-issue cert: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/api/sites/theregistry.test/domain:add?name=aaaddd", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/harborlist.test/domain:add?name=aaaddd", nil)
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
 	if rec.Code != http.StatusOK {
@@ -163,11 +163,11 @@ func TestHandleSiteAction_domainAdd_keepsWorktreeSANs(t *testing.T) {
 		t.Fatalf("expected ok response, got %s", rec.Body.String())
 	}
 
-	cert := readSiteCert(t, "theregistry.test")
+	cert := readSiteCert(t, "harborlist.test")
 	for _, san := range []string{
-		"theregistry.test", "*.theregistry.test",
+		"harborlist.test", "*.harborlist.test",
 		"aaaddd.test", "*.aaaddd.test",
-		"main.theregistry.test", "*.main.theregistry.test",
+		"main.harborlist.test", "*.main.harborlist.test",
 	} {
 		if !strings.Contains(cert, san) {
 			t.Errorf("SAN %q missing after domain:add; cert body: %q", san, cert)
@@ -180,17 +180,17 @@ func TestHandleSiteAction_domainAdd_keepsWorktreeSANs(t *testing.T) {
 // as domain:add — the original handler used the cert-skipping IssueCert,
 // and the first attempted fix dropped worktree SANs. Pin both.
 func TestHandleSiteAction_domainRemove_keepsWorktreeSANs(t *testing.T) {
-	sitePath := setupSecuredSite(t, "theregistry", "aaaddd.test")
+	sitePath := setupSecuredSite(t, "harborlist", "aaaddd.test")
 	makeWorktree(t, sitePath, "main", "main", filepath.Join(t.TempDir(), "wt-main"))
 
 	if err := certs.ReissueCertForWorktree(config.Site{
-		Name: "theregistry", Path: sitePath,
-		Domains: []string{"theregistry.test", "aaaddd.test"}, Secured: true,
+		Name: "harborlist", Path: sitePath,
+		Domains: []string{"harborlist.test", "aaaddd.test"}, Secured: true,
 	}); err != nil {
 		t.Fatalf("pre-issue cert: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/api/sites/theregistry.test/domain:remove?name=aaaddd", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/harborlist.test/domain:remove?name=aaaddd", nil)
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
 	if rec.Code != http.StatusOK {
@@ -200,10 +200,10 @@ func TestHandleSiteAction_domainRemove_keepsWorktreeSANs(t *testing.T) {
 		t.Fatalf("expected ok response, got %s", rec.Body.String())
 	}
 
-	cert := readSiteCert(t, "theregistry.test")
+	cert := readSiteCert(t, "harborlist.test")
 	for _, san := range []string{
-		"theregistry.test", "*.theregistry.test",
-		"main.theregistry.test", "*.main.theregistry.test",
+		"harborlist.test", "*.harborlist.test",
+		"main.harborlist.test", "*.main.harborlist.test",
 	} {
 		if !strings.Contains(cert, san) {
 			t.Errorf("SAN %q missing after domain:remove; cert body: %q", san, cert)

--- a/internal/ui/framework_workers_test.go
+++ b/internal/ui/framework_workers_test.go
@@ -31,9 +31,9 @@ func vitePerWT() config.FrameworkWorker {
 
 func TestFrameworkWorkerServicesForSite_parentOnly(t *testing.T) {
 	site := config.Site{
-		Name:    "whitewaters",
-		Domains: []string{"theregistry.test"},
-		Path:    "/projects/whitewaters",
+		Name:    "rapids",
+		Domains: []string{"harborlist.test"},
+		Path:    "/projects/rapids",
 	}
 	fw := &config.Framework{
 		Workers: map[string]config.FrameworkWorker{
@@ -42,17 +42,17 @@ func TestFrameworkWorkerServicesForSite_parentOnly(t *testing.T) {
 	}
 	got := frameworkWorkerServicesForSite(
 		site, fw,
-		fakeStatus(map[string]bool{"lerd-vite-whitewaters": true}),
+		fakeStatus(map[string]bool{"lerd-vite-rapids": true}),
 		fakeWorktrees(nil),
 	)
 	if len(got) != 1 {
 		t.Fatalf("got %d entries, want 1: %+v", len(got), got)
 	}
 	r := got[0]
-	if r.Name != "vite-whitewaters" {
-		t.Errorf("Name = %q, want vite-whitewaters", r.Name)
+	if r.Name != "vite-rapids" {
+		t.Errorf("Name = %q, want vite-rapids", r.Name)
 	}
-	if r.WorkerSite != "whitewaters" || r.WorkerName != "vite" || r.WorkerLabel != "Vite" {
+	if r.WorkerSite != "rapids" || r.WorkerName != "vite" || r.WorkerLabel != "Vite" {
 		t.Errorf("worker fields = %+v", r)
 	}
 	if r.WorkerWorktree != "" || r.WorkerWorktreeDomain != "" {
@@ -64,9 +64,9 @@ func TestFrameworkWorkerServicesForSite_parentInactiveWorktreeActive(t *testing.
 	// Worktree vite unit is running but the parent's is not. Vite must opt
 	// into per_worktree:true for the worktree variant to enumerate.
 	site := config.Site{
-		Name:    "whitewaters",
-		Domains: []string{"theregistry.test"},
-		Path:    "/projects/whitewaters",
+		Name:    "rapids",
+		Domains: []string{"harborlist.test"},
+		Path:    "/projects/rapids",
 	}
 	fw := &config.Framework{
 		Workers: map[string]config.FrameworkWorker{
@@ -75,36 +75,36 @@ func TestFrameworkWorkerServicesForSite_parentInactiveWorktreeActive(t *testing.
 	}
 	wts := []gitpkg.Worktree{{
 		Branch: "main",
-		Path:   "/projects/whitewaters/main",
-		Domain: "main.theregistry.test",
+		Path:   "/projects/rapids/main",
+		Domain: "main.harborlist.test",
 	}}
 	active := map[string]bool{
-		"lerd-vite-whitewaters-main": true, // worktree only
+		"lerd-vite-rapids-main": true, // worktree only
 	}
 	got := frameworkWorkerServicesForSite(site, fw, fakeStatus(active), fakeWorktrees(wts))
 	if len(got) != 1 {
 		t.Fatalf("got %d entries, want 1: %+v", len(got), got)
 	}
 	r := got[0]
-	if r.Name != "vite-whitewaters-main" {
-		t.Errorf("Name = %q, want vite-whitewaters-main", r.Name)
+	if r.Name != "vite-rapids-main" {
+		t.Errorf("Name = %q, want vite-rapids-main", r.Name)
 	}
-	if r.WorkerSite != "whitewaters" {
-		t.Errorf("WorkerSite = %q, want whitewaters (parent for grouping)", r.WorkerSite)
+	if r.WorkerSite != "rapids" {
+		t.Errorf("WorkerSite = %q, want rapids (parent for grouping)", r.WorkerSite)
 	}
 	if r.WorkerWorktree != "main" {
 		t.Errorf("WorkerWorktree = %q, want main", r.WorkerWorktree)
 	}
-	if r.WorkerWorktreeDomain != "main.theregistry.test" {
-		t.Errorf("WorkerWorktreeDomain = %q, want main.theregistry.test", r.WorkerWorktreeDomain)
+	if r.WorkerWorktreeDomain != "main.harborlist.test" {
+		t.Errorf("WorkerWorktreeDomain = %q, want main.harborlist.test", r.WorkerWorktreeDomain)
 	}
 }
 
 func TestFrameworkWorkerServicesForSite_parentAndWorktreeActive(t *testing.T) {
 	site := config.Site{
-		Name:    "whitewaters",
-		Domains: []string{"theregistry.test"},
-		Path:    "/projects/whitewaters",
+		Name:    "rapids",
+		Domains: []string{"harborlist.test"},
+		Path:    "/projects/rapids",
 	}
 	fw := &config.Framework{
 		Workers: map[string]config.FrameworkWorker{
@@ -113,12 +113,12 @@ func TestFrameworkWorkerServicesForSite_parentAndWorktreeActive(t *testing.T) {
 	}
 	wts := []gitpkg.Worktree{{
 		Branch: "main",
-		Path:   "/projects/whitewaters/main",
-		Domain: "main.theregistry.test",
+		Path:   "/projects/rapids/main",
+		Domain: "main.harborlist.test",
 	}}
 	active := map[string]bool{
-		"lerd-vite-whitewaters":      true,
-		"lerd-vite-whitewaters-main": true,
+		"lerd-vite-rapids":      true,
+		"lerd-vite-rapids-main": true,
 	}
 	got := frameworkWorkerServicesForSite(site, fw, fakeStatus(active), fakeWorktrees(wts))
 	names := make([]string, len(got))
@@ -126,7 +126,7 @@ func TestFrameworkWorkerServicesForSite_parentAndWorktreeActive(t *testing.T) {
 		names[i] = r.Name
 	}
 	sort.Strings(names)
-	want := []string{"vite-whitewaters", "vite-whitewaters-main"}
+	want := []string{"vite-rapids", "vite-rapids-main"}
 	if len(names) != len(want) || names[0] != want[0] || names[1] != want[1] {
 		t.Errorf("names = %v, want %v", names, want)
 	}
@@ -136,9 +136,9 @@ func TestFrameworkWorkerServicesForSite_skipsBuiltinWorkers(t *testing.T) {
 	// queue/schedule/reverb are surfaced through dedicated lerd-queue-*
 	// listing helpers; this loop must not double-list them.
 	site := config.Site{
-		Name:    "whitewaters",
-		Domains: []string{"theregistry.test"},
-		Path:    "/projects/whitewaters",
+		Name:    "rapids",
+		Domains: []string{"harborlist.test"},
+		Path:    "/projects/rapids",
 	}
 	fw := &config.Framework{
 		Workers: map[string]config.FrameworkWorker{
@@ -149,10 +149,10 @@ func TestFrameworkWorkerServicesForSite_skipsBuiltinWorkers(t *testing.T) {
 		},
 	}
 	active := map[string]bool{
-		"lerd-queue-whitewaters":    true,
-		"lerd-schedule-whitewaters": true,
-		"lerd-reverb-whitewaters":   true,
-		"lerd-vite-whitewaters":     true,
+		"lerd-queue-rapids":    true,
+		"lerd-schedule-rapids": true,
+		"lerd-reverb-rapids":   true,
+		"lerd-vite-rapids":     true,
 	}
 	got := frameworkWorkerServicesForSite(site, fw, fakeStatus(active), fakeWorktrees(nil))
 	if len(got) != 1 || got[0].WorkerName != "vite" {
@@ -162,9 +162,9 @@ func TestFrameworkWorkerServicesForSite_skipsBuiltinWorkers(t *testing.T) {
 
 func TestFrameworkWorkerServicesForSite_inactiveOmitted(t *testing.T) {
 	site := config.Site{
-		Name:    "whitewaters",
-		Domains: []string{"theregistry.test"},
-		Path:    "/projects/whitewaters",
+		Name:    "rapids",
+		Domains: []string{"harborlist.test"},
+		Path:    "/projects/rapids",
 	}
 	fw := &config.Framework{
 		Workers: map[string]config.FrameworkWorker{

--- a/internal/ui/mailpit_webhook_test.go
+++ b/internal/ui/mailpit_webhook_test.go
@@ -93,6 +93,8 @@ func decodeMailNotification(t *testing.T, raw []byte) (kind, titleKey, bodyKey, 
 }
 
 func TestMailpitWebhook_BroadcastsAsGenericNotification(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	got, cleanup := captureBroadcast(t)
 	defer cleanup()
 
@@ -100,7 +102,7 @@ func TestMailpitWebhook_BroadcastsAsGenericNotification(t *testing.T) {
 		"ID": "abc123",
 		"Subject": "Welcome!",
 		"From": {"Name": "Alice", "Address": "alice@example.com"},
-		"To": [{"Address": "user@astrolov.test"}],
+		"To": [{"Address": "user@starlane.test"}],
 		"Created": "2026-05-15T10:00:00Z"
 	}`
 	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/mailpit", strings.NewReader(payload))
@@ -151,6 +153,8 @@ func TestMailpitWebhook_BroadcastsAsGenericNotification(t *testing.T) {
 }
 
 func TestMailpitWebhook_AddressOnlySender(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	got, cleanup := captureBroadcast(t)
 	defer cleanup()
 

--- a/internal/ui/main_test.go
+++ b/internal/ui/main_test.go
@@ -1,0 +1,29 @@
+package ui
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/push"
+)
+
+// TestMain neutralises the real web-push client for the whole package so no
+// test can fire a notification at the developer's actual browser, even through
+// the async goroutine in dispatchNotification that can outlive a single test.
+func TestMain(m *testing.M) {
+	push.HTTPClient = &http.Client{Transport: discardPushTransport{}}
+	os.Exit(m.Run())
+}
+
+type discardPushTransport struct{}
+
+func (discardPushTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusCreated,
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+	}, nil
+}

--- a/internal/ui/notify_diff_test.go
+++ b/internal/ui/notify_diff_test.go
@@ -136,20 +136,20 @@ func TestNotificationForWorkerFailure_Shape(t *testing.T) {
 // The Sites tab keys by primary domain, but workerheal.UnhealthyWorker.Site
 // is the registered site name. The notification URL must resolve name to
 // domain so the click handler lands on the matching site, not an empty
-// state when name != domain (e.g. whitewaters / theregistry.test).
+// state when name != domain (e.g. rapids / harborlist.test).
 func TestNotificationForWorkerFailure_URLResolvesNameToDomain(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	if err := config.AddSite(config.Site{
-		Name:    "whitewaters",
-		Domains: []string{"theregistry.test"},
+		Name:    "rapids",
+		Domains: []string{"harborlist.test"},
 		Path:    t.TempDir(),
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	n := notificationForWorkerFailure(uw("lerd-queue-whitewaters.service", "whitewaters", "queue", "failed"))
-	if n.URL != "#sites/theregistry.test" {
-		t.Errorf("URL = %q, want #sites/theregistry.test", n.URL)
+	n := notificationForWorkerFailure(uw("lerd-queue-rapids.service", "rapids", "queue", "failed"))
+	if n.URL != "#sites/harborlist.test" {
+		t.Errorf("URL = %q, want #sites/harborlist.test", n.URL)
 	}
 }

--- a/internal/ui/notify_dumps_test.go
+++ b/internal/ui/notify_dumps_test.go
@@ -45,12 +45,12 @@ func TestRunDumpsNotifier_OnlyNotifiesDumpKind(t *testing.T) {
 }
 
 func TestNotificationForDump_Shape(t *testing.T) {
-	evt := dumps.Event{ID: "abc", Kind: "dump", Ctx: dumps.Context{Site: "astrolov.test", Type: "fpm"}}
+	evt := dumps.Event{ID: "abc", Kind: "dump", Ctx: dumps.Context{Site: "starlane.test", Type: "fpm"}}
 	n := notificationForDump(evt)
 	if n.Kind != "dump" {
 		t.Errorf("Kind = %q", n.Kind)
 	}
-	if n.Params["site"] != "astrolov.test" {
+	if n.Params["site"] != "starlane.test" {
 		t.Errorf("Params.site = %q", n.Params["site"])
 	}
 	if n.Params["kind"] != "fpm" {
@@ -59,7 +59,7 @@ func TestNotificationForDump_Shape(t *testing.T) {
 	// No site is registered with that name in this test, so siteDomainForRoute
 	// falls back to the input verbatim. The URL still lands on a sites sub-tab
 	// route shape the frontend can parse.
-	if n.URL != "#sites/astrolov.test/dumps" {
+	if n.URL != "#sites/starlane.test/dumps" {
 		t.Errorf("URL = %q", n.URL)
 	}
 }
@@ -68,7 +68,7 @@ func TestNotificationForDump_BodyContainsDumpText(t *testing.T) {
 	evt := dumps.Event{
 		ID:   "abc",
 		Kind: "dump",
-		Ctx:  dumps.Context{Site: "astrolov.test", Type: "fpm"},
+		Ctx:  dumps.Context{Site: "starlane.test", Type: "fpm"},
 		Text: "string(5) \"hello\"",
 	}
 	n := notificationForDump(evt)
@@ -165,16 +165,16 @@ func TestNotificationForDump_URLResolvesNameToDomain(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	if err := config.AddSite(config.Site{
-		Name:    "whitewaters",
-		Domains: []string{"theregistry.test"},
+		Name:    "rapids",
+		Domains: []string{"harborlist.test"},
 		Path:    t.TempDir(),
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	evt := dumps.Event{ID: "z", Kind: "dump", Ctx: dumps.Context{Site: "whitewaters", Type: "fpm"}}
+	evt := dumps.Event{ID: "z", Kind: "dump", Ctx: dumps.Context{Site: "rapids", Type: "fpm"}}
 	n := notificationForDump(evt)
-	if n.URL != "#sites/theregistry.test/dumps" {
-		t.Errorf("URL = %q, want #sites/theregistry.test/dumps", n.URL)
+	if n.URL != "#sites/harborlist.test/dumps" {
+		t.Errorf("URL = %q, want #sites/harborlist.test/dumps", n.URL)
 	}
 }

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -563,6 +563,10 @@ type StatusResponse struct {
 	BunVersion     string `json:"bun_version"`
 	UsingSystemBun bool   `json:"using_system_bun"`
 	WatcherRunning bool   `json:"watcher_running"`
+	// FrankenPHPVersions are the PHP versions dunglas/frankenphp publishes an
+	// image for, so the UI can limit a FrankenPHP site's version dropdown to
+	// the ones it can actually run (intersected client-side with installed).
+	FrankenPHPVersions []string `json:"frankenphp_php_versions"`
 }
 
 type DNSStatus struct {
@@ -630,16 +634,17 @@ func buildStatus() StatusResponse {
 	}
 	usingSystemBun := bunAvailable && !nodeManagedByLerd && !lerdNode.SystemNodeAvailable()
 	return StatusResponse{
-		DNS:               DNSStatus{OK: dnsStatus == dns.StatusOK, Status: string(dnsStatus), VPN: dns.VPNActive(), Enabled: dnsEnabled, TLD: tld},
-		Nginx:             ServiceCheck{Running: nginxRunning},
-		PHPFPMs:           phpStatuses,
-		PHPDefault:        phpDefault,
-		NodeDefault:       nodeDefault,
-		NodeManagedByLerd: nodeManagedByLerd,
-		BunAvailable:      bunAvailable,
-		BunVersion:        bunVersion,
-		UsingSystemBun:    usingSystemBun,
-		WatcherRunning:    watcherRunning,
+		DNS:                DNSStatus{OK: dnsStatus == dns.StatusOK, Status: string(dnsStatus), VPN: dns.VPNActive(), Enabled: dnsEnabled, TLD: tld},
+		Nginx:              ServiceCheck{Running: nginxRunning},
+		PHPFPMs:            phpStatuses,
+		PHPDefault:         phpDefault,
+		NodeDefault:        nodeDefault,
+		NodeManagedByLerd:  nodeManagedByLerd,
+		BunAvailable:       bunAvailable,
+		BunVersion:         bunVersion,
+		UsingSystemBun:     usingSystemBun,
+		WatcherRunning:     watcherRunning,
+		FrankenPHPVersions: config.FrankenPHPVersions(),
 	}
 }
 

--- a/internal/ui/status_versions_test.go
+++ b/internal/ui/status_versions_test.go
@@ -1,0 +1,22 @@
+package ui
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// The site PHP dropdown filters FrankenPHP sites against this field, so the
+// status payload must expose the FrankenPHP-publishable set under the exact
+// json tag the frontend reads.
+func TestStatusResponseFrankenPHPVersionsTag(t *testing.T) {
+	b, err := json.Marshal(StatusResponse{FrankenPHPVersions: config.FrankenPHPVersions()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"frankenphp_php_versions":["8.2","8.3","8.4","8.5"]`) {
+		t.Errorf("status JSON missing expected frankenphp_php_versions: %s", b)
+	}
+}

--- a/internal/ui/web/src/stores/phpVersions.test.ts
+++ b/internal/ui/web/src/stores/phpVersions.test.ts
@@ -1,4 +1,28 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { phpOptionsForSite } from './phpVersions';
+
+describe('phpOptionsForSite', () => {
+  const installed = ['7.4', '8.1', '8.3', '8.4', '8.5'];
+  const franken = ['8.2', '8.3', '8.4', '8.5'];
+
+  it('returns every installed version for non-FrankenPHP runtimes', () => {
+    expect(phpOptionsForSite('fpm', installed, franken, '8.4')).toEqual(installed);
+    expect(phpOptionsForSite(undefined, installed, franken, '8.4')).toEqual(installed);
+  });
+
+  it('limits FrankenPHP to installed versions that are also publishable', () => {
+    expect(phpOptionsForSite('frankenphp', installed, franken, '8.4')).toEqual(['8.3', '8.4', '8.5']);
+  });
+
+  it('keeps the current version even when it is not FPM-installed', () => {
+    expect(phpOptionsForSite('frankenphp', ['8.3', '8.4'], franken, '8.5')).toEqual(['8.3', '8.4', '8.5']);
+  });
+
+  it('never offers a version FrankenPHP cannot run', () => {
+    expect(phpOptionsForSite('frankenphp', installed, franken, '8.4')).not.toContain('7.4');
+    expect(phpOptionsForSite('frankenphp', installed, franken, '8.4')).not.toContain('8.1');
+  });
+});
 
 describe('phpVersions store', () => {
   const realFetch = globalThis.fetch;

--- a/internal/ui/web/src/stores/phpVersions.ts
+++ b/internal/ui/web/src/stores/phpVersions.ts
@@ -5,6 +5,20 @@ import type { SiteNginxBackup, LoadNginxBackupsResult, ResetNginxResult, SaveNgi
 
 export const phpVersions = writable<string[]>([]);
 
+// phpOptionsForSite returns the versions to offer in a site's PHP dropdown.
+// FrankenPHP sites are limited to the versions dunglas/frankenphp publishes an
+// image for, intersected with what's installed, plus the site's current version
+// so the control never renders blank. Other runtimes offer every installed one.
+export function phpOptionsForSite(
+  runtime: string | undefined,
+  installed: string[],
+  frankenphpVersions: string[],
+  current: string
+): string[] {
+  if (runtime !== 'frankenphp') return installed;
+  return frankenphpVersions.filter((v) => installed.includes(v) || v === current);
+}
+
 export async function loadPhpVersions() {
   try {
     const list = await apiJson<string[]>('/api/php-versions');

--- a/internal/ui/web/src/stores/status.ts
+++ b/internal/ui/web/src/stores/status.ts
@@ -21,6 +21,7 @@ export interface StatusResponse {
   bun_version: string;
   using_system_bun: boolean;
   watcher_running: boolean;
+  frankenphp_php_versions: string[];
 }
 
 const empty: StatusResponse = {
@@ -33,7 +34,8 @@ const empty: StatusResponse = {
   bun_available: false,
   bun_version: '',
   using_system_bun: false,
-  watcher_running: false
+  watcher_running: false,
+  frankenphp_php_versions: []
 };
 
 export const status = writable<StatusResponse>(empty);

--- a/internal/ui/web/src/tabs/sites/SiteControls.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteControls.svelte
@@ -15,7 +15,7 @@
     loadSites
   } from '$stores/sites';
   import { loadServices } from '$stores/services';
-  import { phpVersions } from '$stores/phpVersions';
+  import { phpVersions, phpOptionsForSite } from '$stores/phpVersions';
   import { nodeVersions } from '$stores/nodeVersions';
   import { status } from '$stores/status';
   import WorktreeDBIsolateModal from './WorktreeDBIsolateModal.svelte';
@@ -42,6 +42,9 @@
   const effectiveNode = $derived(activeWorktree?.node_version ?? site.node_version ?? '');
   const phpInherited = $derived(Boolean(activeWorktree) && !activeWorktree?.php_version_override);
   const nodeInherited = $derived(Boolean(activeWorktree) && !activeWorktree?.node_version_override);
+  const phpOptions = $derived(
+    phpOptionsForSite(site.runtime, $phpVersions, $status.frankenphp_php_versions, effectivePhp)
+  );
   // When host bun is available, the Node dropdown offers a "bun" entry that
   // pins .lerd.yaml js_runtime (project-level), leaving node_version intact.
   // js_runtime is project-level, so the bun toggle only belongs on the main
@@ -253,11 +256,11 @@
         PHP {effectivePhp} · custom image
       </span>
     {:else if site.uses_php}
-      {#if $phpVersions.length > 0}
+      {#if phpOptions.length > 0}
         <Dropdown
           label="PHP"
           value={effectivePhp}
-          options={$phpVersions}
+          options={phpOptions}
           disabled={versionBusy}
           inherited={phpInherited}
           inheritedSuffix={m.sites_controls_inheritedSuffix()}

--- a/internal/workerheal/workerheal_test.go
+++ b/internal/workerheal/workerheal_test.go
@@ -169,9 +169,9 @@ func TestDetect_HyphenatedWorkerName(t *testing.T) {
 	// Custom worker with a hyphen in its name plus a site whose name itself
 	// contains hyphens — make sure the longest-suffix match keeps both.
 	stubEnv(t,
-		[]string{"score-diviner"}, nil,
+		[]string{"tallyboard"}, nil,
 		map[string]string{
-			"lerd-emit-events-score-diviner.service": "failed",
+			"lerd-emit-events-tallyboard.service": "failed",
 		},
 		nil,
 	)
@@ -180,7 +180,7 @@ func TestDetect_HyphenatedWorkerName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Detect: %v", err)
 	}
-	if len(got) != 1 || got[0].Worker != "emit-events" || got[0].Site != "score-diviner" {
+	if len(got) != 1 || got[0].Worker != "emit-events" || got[0].Site != "tallyboard" {
 		t.Errorf("split wrong: %+v", got)
 	}
 }


### PR DESCRIPTION
FrankenPHP mode chose its dunglas/frankenphp image from a hardcoded version set that stopped at 8.4, so a site set to PHP 8.5 was quietly served by the 8.4 image while FPM mode ran 8.5 correctly. The image now derives from the single SupportedPHPVersions list in internal/config, with the FrankenPHP-publishable subset, the tags dunglas actually ships from 8.2 up, computed from it, and the fallback for an unsupported version resolving to the latest published one through a shared helper. cli re-exports the same list so there is a single source of truth.

Building on that, the per-site PHP dropdown is now runtime aware. A FrankenPHP site only offers the publishable versions that are installed, plus whatever version it is currently on, so it never lists something FrankenPHP cannot boot. The status endpoint carries the publishable set for the frontend to intersect against.