### PR TITLE
Keep workers healthy when switching a site's PHP runtime

### DIFF
--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -95,6 +95,14 @@ func runtimeLabel(site *config.Site) string {
 }
 
 func switchToFPM(site *config.Site) error {
+	// Capture the running workers before teardown: they exec into (and BindsTo)
+	// the FrankenPHP container, so removing it would both stop them and lose
+	// the list we need to re-establish on the shared FPM unit.
+	running := collectRunningWorkers(site)
+	for _, w := range running {
+		WorkerStopForSite(site.Name, site.Path, w) //nolint:errcheck
+	}
+
 	_ = podman.StopUnit(podman.FrankenPHPContainerName(site.Name))
 	_ = podman.RemoveFrankenPHPQuadlet(site.Name)
 	_ = podman.DaemonReloadFn()
@@ -116,11 +124,23 @@ func switchToFPM(site *config.Site) error {
 		}
 	}
 	_ = nginx.Reload()
+
+	// Recreate the workers so their units exec into the shared FPM container
+	// instead of the per-site FrankenPHP one that no longer exists.
+	startWorkersForSite(site, running, site.PHPVersion)
+
 	fmt.Printf("Runtime: fpm (switched from FrankenPHP)\n")
 	return nil
 }
 
 func switchToFrankenPHP(site *config.Site, worker bool) error {
+	// Workers currently exec into the shared FPM container; stop them so they
+	// can be recreated against the per-site FrankenPHP container below.
+	running := collectRunningWorkers(site)
+	for _, w := range running {
+		WorkerStopForSite(site.Name, site.Path, w) //nolint:errcheck
+	}
+
 	site.Runtime = "frankenphp"
 	site.RuntimeWorker = worker
 	if err := config.AddSite(*site); err != nil {
@@ -131,6 +151,10 @@ func switchToFrankenPHP(site *config.Site, worker bool) error {
 	if err := siteops.FinishFrankenPHPLink(*site); err != nil {
 		return err
 	}
+
+	// Re-point the site's workers at the new per-site FrankenPHP container.
+	startWorkersForSite(site, running, site.PHPVersion)
+
 	label := "frankenphp"
 	if worker {
 		label = "frankenphp (worker mode)"

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -365,6 +365,12 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 	}
 
 	if changed {
+		// A rewritten unit (e.g. a runtime switch re-pointed the worker at a
+		// different container) only takes effect once systemd re-reads it;
+		// without this, Enable/Start act on the stale cached unit.
+		if err := podman.DaemonReloadFn(); err != nil {
+			fmt.Printf("[WARN] daemon-reload: %v\n", err)
+		}
 		if err := services.Mgr.Enable(lifecycleTarget); err != nil {
 			fmt.Printf("[WARN] enable: %v\n", err)
 		}

--- a/internal/cli/worker_reload_linux_test.go
+++ b/internal/cli/worker_reload_linux_test.go
@@ -1,0 +1,73 @@
+//go:build linux
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// fakeLifecycle satisfies podman.UnitLifecycle so StartUnit does not touch the
+// real systemd manager during the test.
+type fakeLifecycle struct{}
+
+func (fakeLifecycle) Start(string) error                { return nil }
+func (fakeLifecycle) Stop(string) error                 { return nil }
+func (fakeLifecycle) Restart(string) error              { return nil }
+func (fakeLifecycle) UnitStatus(string) (string, error) { return "active", nil }
+func (fakeLifecycle) AllUnitStates() map[string]string  { return nil }
+
+func stubStartAndReload(t *testing.T) *int {
+	t.Helper()
+	prevLC := podman.UnitLifecycle
+	podman.UnitLifecycle = fakeLifecycle{}
+	t.Cleanup(func() { podman.UnitLifecycle = prevLC })
+
+	reloads := 0
+	prevReload := podman.DaemonReloadFn
+	podman.DaemonReloadFn = func() error { reloads++; return nil }
+	t.Cleanup(func() { podman.DaemonReloadFn = prevReload })
+	return &reloads
+}
+
+// A worker unit whose content changed (e.g. a runtime switch re-pointed it at a
+// different container) must trigger a daemon-reload before enable/start, or
+// systemd keeps acting on the stale cached unit.
+func TestWorkerStartForSite_reloadsWhenUnitChanged(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	mgr := &captureWriteMgr{writeChange: true}
+	swapServiceMgr(t, mgr)
+	reloads := stubStartAndReload(t)
+
+	w := config.FrameworkWorker{Command: "npm run dev", Host: true, Label: "Vite"}
+	if err := WorkerStartForSite("ws", "/p/ws", "8.4", "vite", w, false); err != nil {
+		t.Fatalf("WorkerStartForSite: %v", err)
+	}
+
+	if *reloads == 0 {
+		t.Error("expected a daemon-reload after the changed unit, got none")
+	}
+	if len(mgr.enabled) == 0 {
+		t.Error("expected the unit to be enabled after reload")
+	}
+}
+
+// An unchanged unit must not reload: nothing on disk moved, so the cached unit
+// is already correct and a reload would be wasted churn.
+func TestWorkerStartForSite_noReloadWhenUnchanged(t *testing.T) {
+	registerSite(t, "ws", "/p/ws")
+	mgr := &captureWriteMgr{writeChange: false}
+	swapServiceMgr(t, mgr)
+	reloads := stubStartAndReload(t)
+
+	w := config.FrameworkWorker{Command: "npm run dev", Host: true, Label: "Vite"}
+	if err := WorkerStartForSite("ws", "/p/ws", "8.4", "vite", w, false); err != nil {
+		t.Fatalf("WorkerStartForSite: %v", err)
+	}
+
+	if *reloads != 0 {
+		t.Errorf("expected no daemon-reload for an unchanged unit, got %d", *reloads)
+	}
+}


### PR DESCRIPTION
Switching a site between FPM and FrankenPHP left its worker units pointing at the previous container. Going back to FPM removed the per-site FrankenPHP container while the queue and schedule units still had BindsTo and exec'd into it, so the workers could not start and healing could not recover them, since the healer only resets and restarts a unit and never rewrites one. The runtime switch now stops the site's running workers and recreates them against the new container in both directions, so they always exec into the container that actually exists.

A second issue compounded it. WorkerStartForSite rewrote a changed unit but never asked systemd to re-read it, so enable and start operated on the stale cached unit and a re-pointed worker kept failing on the old container even though the file on disk was already correct. It now runs a daemon-reload whenever the unit content changed, before enabling and starting, which also makes any on-demand worker start robust to a content change.