### PR TITLE
fix(pause): stop a paused runtime site's container from autostarting at boot

### DIFF
--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -78,6 +78,14 @@ func PauseSite(name string) error {
 		_ = podman.StopUnit(podman.CustomFPMContainerName(site.Name))
 	}
 
+	// Strip the container's quadlet [Install] so a paused runtime site's
+	// container doesn't come back at the next login via the podman generator.
+	// StopUnit above only stops the running instance; the generator re-wires an
+	// [Install]-bearing quadlet into default.target.wants on every boot.
+	if setSiteContainerAutostart(site, false) {
+		_ = podman.DaemonReloadFn()
+	}
+
 	// Release the LAN share port while paused. The site's stored LANPort is
 	// preserved so unpause restores the same address.
 	LANShareStopServer(site.Name)
@@ -110,6 +118,48 @@ func PauseSite(name string) error {
 	return nil
 }
 
+// siteContainerUnit returns the per-site container unit name for a
+// runtime-backed site (FrankenPHP, custom container, custom FPM), or "" for a
+// plain FPM site that runs in the shared container and has no dedicated unit.
+func siteContainerUnit(site *config.Site) string {
+	switch {
+	case site.IsCustomContainer():
+		return podman.CustomContainerName(site.Name)
+	case site.IsFrankenPHP():
+		return podman.FrankenPHPContainerName(site.Name)
+	case site.IsCustomFPM():
+		return podman.CustomFPMContainerName(site.Name)
+	}
+	return ""
+}
+
+// setSiteContainerAutostart strips (on=false) or restores (on=true) the
+// [Install] section of a site container's quadlet, the same lever `lerd
+// autostart` uses globally, so a paused runtime site's container stops
+// autostarting at boot. Restoring is gated on the global autostart flag so
+// unpause never re-arms a container the user disabled globally. Returns whether
+// the file changed. No-op when the site has no container quadlet (plain FPM, or
+// the macOS plist path). Caller daemon-reloads when it returns true.
+func setSiteContainerAutostart(site *config.Site, on bool) bool {
+	unit := siteContainerUnit(site)
+	if unit == "" {
+		return false
+	}
+	path := filepath.Join(config.QuadletDir(), unit+".container")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	out := podman.StripInstallSection(string(raw), true)
+	if on && lerdSystemd.IsAutostartEnabled() {
+		out = strings.TrimRight(out, "\n") + "\n\n" + quadletInstallBlock
+	}
+	if out == string(raw) {
+		return false
+	}
+	return os.WriteFile(path, []byte(out), 0644) == nil
+}
+
 // UnpauseSite restores the site's nginx vhost, restarts any workers that were
 // running when the site was paused, and clears the paused state.
 func UnpauseSite(name string) error {
@@ -123,6 +173,13 @@ func UnpauseSite(name string) error {
 	}
 
 	phpVersion := site.PHPVersion
+
+	// Re-arm the container's quadlet [Install] that PauseSite stripped, before
+	// starting it, so it autostarts at login again. Gated on the global autostart
+	// flag inside the helper, so unpause never re-arms a globally-disabled site.
+	if setSiteContainerAutostart(site, true) {
+		_ = podman.DaemonReloadFn()
+	}
 
 	switch {
 	case site.IsCustomContainer():

--- a/internal/cli/pause_test.go
+++ b/internal/cli/pause_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// TestSetSiteContainerAutostart_stripAndRestore guards the fix for a paused
+// FrankenPHP site whose container came back at boot: pausing must strip the
+// quadlet's [Install] so the podman generator stops auto-wiring it into
+// default.target.wants, and unpausing must put it back.
+func TestSetSiteContainerAutostart_stripAndRestore(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir()) // QuadletDir + global config live here
+
+	site := &config.Site{Name: "personal", Runtime: "frankenphp"}
+	unit := podman.FrankenPHPContainerName(site.Name)
+	dir := config.QuadletDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir quadlet dir: %v", err)
+	}
+	path := filepath.Join(dir, unit+".container")
+	const withInstall = "[Container]\nImage=x\n\n[Install]\nWantedBy=default.target\n"
+	if err := os.WriteFile(path, []byte(withInstall), 0644); err != nil {
+		t.Fatalf("seed quadlet: %v", err)
+	}
+
+	// Pause strips [Install].
+	if !setSiteContainerAutostart(site, false) {
+		t.Fatal("strip reported no change")
+	}
+	if b, _ := os.ReadFile(path); strings.Contains(string(b), "[Install]") {
+		t.Errorf("[Install] not stripped:\n%s", b)
+	}
+
+	// Unpause restores it (no config file => global autostart enabled by default).
+	if !setSiteContainerAutostart(site, true) {
+		t.Fatal("restore reported no change")
+	}
+	b, _ := os.ReadFile(path)
+	if !strings.Contains(string(b), "[Install]") || !strings.Contains(string(b), "WantedBy=default.target") {
+		t.Errorf("[Install] not restored:\n%s", b)
+	}
+}
+
+// TestSetSiteContainerAutostart_plainFPMNoop confirms a plain FPM site (no
+// dedicated container quadlet) is a no-op, so pause/unpause never touch the
+// shared FPM container's autostart.
+func TestSetSiteContainerAutostart_plainFPMNoop(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	site := &config.Site{Name: "plain"} // no runtime, no custom container
+	if setSiteContainerAutostart(site, false) {
+		t.Error("plain FPM site should have no container quadlet to strip")
+	}
+}


### PR DESCRIPTION
A paused FrankenPHP site (and the same goes for custom container and custom FPM sites) came back to life at the next login. The per-site container is a podman quadlet whose `[Install] WantedBy=default.target` makes the generator wire it into `default.target.wants` on every boot, and pause only stopped the running instance without touching that wiring, so the container autostarted again.

Pause now strips the `[Install]` section from the site container's quadlet, the same lever `lerd autostart` uses globally, so the generator stops auto-starting it. Unpause restores the section before starting the container, gated on the global autostart flag so a globally-disabled container is never re-armed. Plain FPM sites are unaffected since they run in the shared container and have no dedicated quadlet.