### PR TITLE
feat(frankenphp): extension and debug-tooling parity with FPM

### DIFF
--- a/docs/features/frankenphp.md
+++ b/docs/features/frankenphp.md
@@ -50,7 +50,7 @@ Each framework can declare how to launch FrankenPHP via a `frankenphp:` block in
 **Laravel** has two modes:
 
 - **Non-worker (`runtime_worker: false`, default)**: lerd runs `frankenphp php-server -r public/`. Each request boots Laravel from scratch; code edits take effect on the next request, same as FPM. You still get FrankenPHP's HTTP/2, HTTP/3, and TLS, but not Octane's per-request speedup.
-- **Worker (`runtime_worker: true`)**: lerd runs `php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=8000 --workers=auto`. Octane keeps Laravel resident; requests skip the full bootstrap. Octane registers Symfony Console signal handlers which need the `pcntl` PHP extension — since the stock `dunglas/frankenphp` image doesn't ship `pcntl`, lerd installs it at container boot via the image's bundled `install-php-extensions` script. First boot takes ~10s longer; subsequent boots reuse the install.
+- **Worker (`runtime_worker: true`)**: lerd runs `php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=8000 --workers=auto`. Octane keeps Laravel resident; requests skip the full bootstrap. Octane registers Symfony Console signal handlers which need the `pcntl` PHP extension; it is baked into lerd's derived FrankenPHP image (see the Extensions section) so the container boots straight into Octane.
 
 **Symfony** uses FrankenPHP's native worker flag:
 
@@ -124,30 +124,46 @@ Worker mode keeps PHP resident, so a source file change is **not** picked up on 
 
   When on, lerd serves the site with `octane:start --watch` so edits restart the resident workers within a second or two. The toggle is also a refresh button next to the **Octane** segment in the Web UI site controls. Two prerequisites are handled for you:
 
-  - Octane's file watcher runs under `node` and resolves `chokidar` from the project. Reload-on stays off until `chokidar` is installed; the CLI and the Web UI both offer a one-click `npm install -D chokidar` (Vite 8 no longer ships it transitively). Node itself is installed into the FrankenPHP container at boot, but **only** on the reload path, so the default image stays slim.
+  - Octane's file watcher runs under `node` and resolves `chokidar` from the project. Reload-on stays off until `chokidar` is installed; the CLI and the Web UI both offer a one-click `npm install -D chokidar` (Vite 8 no longer ships it transitively). Node is baked into lerd's derived FrankenPHP image, so the watcher works without an install step at boot.
   - On macOS (and WSL2 `/mnt` projects) the container can't observe host filesystem events, so lerd appends `--poll` automatically.
 
   If you'd rather not enable reload, the older workarounds still apply: `lerd restart <site>` (~5s), `php artisan octane:reload` inside the project (drops warm workers without restarting the container), or `lerd runtime frankenphp --no-worker` to hot-reload every request like FPM.
 
 ---
 
-## Limitations
+## Extensions and debug tooling
 
-- **Xdebug** is not wired up for FrankenPHP. `lerd xdebug on` still works, but it affects only the shared FPM container and is silently ignored by FrankenPHP sites. Switch back to FPM to debug.
-- **Per-site PHP extensions** (beyond those in the dunglas image) aren't installable from `lerd php:ext add` yet. To add an extension, either publish a custom `Containerfile.lerd` and use lerd's custom-container runtime instead, or wait for a follow-up that extends the FrankenPHP path.
-- **PHP version picker** (in the Web UI and `lerd isolate`) does re-pull the matching `dunglas/frankenphp:php<version>-alpine` image and restart the site. Versions without published dunglas images fall back to 8.4.
+lerd builds a derived image, `localhost/lerd-frankenphp<version>:local`, FROM the dunglas base with the same runtime extension set the FPM image ships (redis, gd, pdo_mysql/pgsql, intl, imagick, igbinary, mongodb, gmp, bcmath, soap, ldap, zip, ...), plus any extensions and packages you add globally. They are compiled for the ZTS runtime and baked once, so `pcntl` and `nodejs` are present from first boot rather than installed at container start. The image rebuilds automatically when lerd's definition changes or via `lerd php:rebuild`.
+
+The per-request debug tooling works for requests Octane serves too: lerd bind-mounts the same dump bridge, `lerd_devtools` (the Debug window's query/job/view/mail/event/http capture), and Xdebug config into the FrankenPHP container. `lerd dump on`, the Debug window, and the Xdebug toggle all apply to a FrankenPHP site. `dump()`/`dd()` and captured queries from a live Octane request land in the dashboard exactly as they do under FPM.
+
+CLI tooling (`lerd test`, `lerd pest`, `lerd php:bun`, `lerd pest:browser`, `php`, `composer`) execs into the shared FPM container for the site's PHP version, so bun and Pest browser testing work for FrankenPHP sites with no extra setup.
+
+**php.ini** is edited per site on FrankenPHP, not per PHP version. A FrankenPHP site runs its own container, so it has its own `php.ini` file edited from a **php.ini tab in the site's config modal** (the gear/Nginx button); the change applies to that site only and restarts just its container. This is different from FPM sites, which share one per-version `php.ini` edited under System → PHP. The System → PHP per-version editor does not affect FrankenPHP sites.
+
+## What is not supported on FrankenPHP
+
+Everything the FPM runtime offers works on FrankenPHP **except one thing**:
+
+- **SPX profiler** (`lerd profile`). SPX profiles per request and does not hook Octane's resident-worker loop (its `/_spx` UI 404s under Octane, and lerd's profiler injection is fastcgi-only), so it stays FPM-only. The global profiler toggle still profiles your FPM sites; to profile a FrankenPHP site with SPX, switch it back to FPM (`lerd runtime fpm`, run from the project).
+
+Everything else — the full runtime extension set, Xdebug, the dump()/dd() bridge, the Debug window (`lerd_devtools`), per-site php.ini, bun, and Pest browser testing — is supported.
+
+## Other notes
+
+- **PHP version picker** (in the Web UI and `lerd isolate`) rebuilds the derived image for the matching `dunglas/frankenphp:php<version>-alpine` base and restarts the site. Versions without published dunglas images fall back to the latest.
 - **macOS** works the same way as Linux because FrankenPHP runs inside the Podman Machine VM; no extra wiring required.
 
 ---
 
 ## Runtime badge
 
-The Web UI site detail panel shows an orange **FrankenPHP** badge next to the framework and services, with a `worker` suffix when worker mode is on. The same badge appears in `lerd tui` beside the PHP version line. The Xdebug toggle is hidden on FrankenPHP sites since the shared FPM Xdebug state doesn't apply.
+The Web UI site detail panel shows an orange **FrankenPHP** badge next to the framework and services, with a `worker` suffix when worker mode is on. The same badge appears in `lerd tui` beside the PHP version line.
 
 ---
 
 ## Related pages
 
-- [Per-project custom container](project-setup.md#custom-container) — for non-PHP apps or FrankenPHP setups that need extra extensions.
+- [Per-project custom container](project-setup.md#custom-container) — for non-PHP apps or a fully custom image.
 - [Web UI](web-ui.md) and [TUI](tui.md) — where the runtime badge appears.
 - [Environment setup](env-setup.md) — `.env` wiring is identical under both runtimes.

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -758,6 +758,18 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	// after a clean install from config backup).
 	migrateServiceUnits()
 
+	// Build any missing derived FrankenPHP image regardless of autostart: the
+	// quadlet refresh above already rewrote FrankenPHP quadlets to point at the
+	// localhost derived image, so the image must exist or the next container
+	// restart (reboot, manual, a php.ini save) would reference a missing image.
+	// BuildFrankenPHPImage no-ops when the image is already current; it never
+	// restarts a container, so it's safe to run with autostart disabled.
+	for _, v := range activeFrankenPHPVersions() {
+		if err := podman.BuildFrankenPHPImage(v, false, os.Stdout); err != nil {
+			fmt.Printf("  WARN: building FrankenPHP image for PHP %s: %v\n", v, err)
+		}
+	}
+
 	// Start service containers and workers only when autostart is on.
 	// When the user has explicitly disabled autostart we leave them
 	// stopped — `lerd update` running install via re-exec must not flip
@@ -769,8 +781,8 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		// new binary against stale images. Gated by autostartOn because
 		// php:rebuild restarts FPM and worker units unconditionally.
 		activeFPM, _ := phpDet.ListInstalled()
-		if podman.NeedsFPMRebuild(activeFPM) {
-			fmt.Println("\n==> PHP-FPM Containerfile changed — rebuilding images")
+		if podman.NeedsFPMRebuild(activeFPM) || podman.NeedsFrankenPHPRebuild(activeFrankenPHPVersions()) {
+			fmt.Println("\n==> PHP image definitions changed — rebuilding images")
 			self, err := os.Executable()
 			if err != nil {
 				fmt.Printf("  WARN: locating lerd binary for php:rebuild: %v\n", err)

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -312,7 +312,7 @@ func TestRefreshUnreferencedCustomQuadlets_rewritesFrankenPHPSite(t *testing.T) 
 	got := string(data)
 	wantFragments := []string{
 		"ContainerName=lerd-fp-my-app",
-		"Image=docker.io/dunglas/frankenphp:php8.4-alpine",
+		"Image=localhost/lerd-frankenphp84:local",
 		"Network=lerd",
 		"Volume=" + projectDir + ":" + projectDir + ":rw",
 	}

--- a/internal/cli/php_ini.go
+++ b/internal/cli/php_ini.go
@@ -52,6 +52,9 @@ func runPhpIni(_ *cobra.Command, args []string) error {
 	if err := podman.RestartUnit(unit); err != nil {
 		return fmt.Errorf("restarting %s: %w", unit, err)
 	}
+	// Per-site containers (FrankenPHP, custom-FPM) on this version mount the same
+	// user ini; restart them so the edit applies there too.
+	podman.RestartSiteContainersForVersion(version)
 	fmt.Println("Done.")
 	return nil
 }

--- a/internal/cli/php_rebuild.go
+++ b/internal/cli/php_rebuild.go
@@ -5,11 +5,50 @@ import (
 	"io"
 	"strings"
 
+	"github.com/geodro/lerd/internal/config"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/spf13/cobra"
 )
+
+// frankenRestart pairs a FrankenPHP container unit with its (normalized) image
+// version so the restart can confirm that version's image actually built.
+type frankenRestart struct {
+	unit    string
+	version string
+}
+
+// frankenPHPRebuildTargets returns the distinct normalized PHP versions to
+// rebuild, and the container units (with their versions) to restart, for
+// non-paused FrankenPHP sites whose version is among the requested ones, so
+// php:rebuild rebuilds and restarts only what's affected.
+func frankenPHPRebuildTargets(requested []string) (versions []string, units []frankenRestart) {
+	want := map[string]bool{}
+	for _, v := range requested {
+		want[config.NormalizeFrankenPHPVersion(v)] = true
+	}
+	reg, err := config.LoadSites()
+	if err != nil {
+		return nil, nil
+	}
+	seenVer := map[string]bool{}
+	for _, s := range reg.Sites {
+		if s.Ignored || s.Paused || !s.IsFrankenPHP() {
+			continue
+		}
+		v := config.NormalizeFrankenPHPVersion(s.PHPVersion)
+		if !want[v] {
+			continue
+		}
+		if !seenVer[v] {
+			seenVer[v] = true
+			versions = append(versions, v)
+		}
+		units = append(units, frankenRestart{unit: podman.FrankenPHPContainerName(s.Name), version: v})
+	}
+	return versions, units
+}
 
 // NewPhpRebuildCmd returns the php:rebuild command.
 func NewPhpRebuildCmd() *cobra.Command {
@@ -43,15 +82,41 @@ func runPhpRebuild(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	jobs := make([]BuildJob, len(versions))
-	for i, v := range versions {
+	jobs := make([]BuildJob, 0, len(versions))
+	for _, v := range versions {
 		ver := v
-		jobs[i] = BuildJob{
+		jobs = append(jobs, BuildJob{
 			Label: "PHP " + ver,
 			Run:   func(w io.Writer) error { return podman.RebuildFPMImageTo(ver, local, w) },
-		}
+		})
+	}
+	// Rebuild the derived FrankenPHP image for any requested version a FrankenPHP
+	// site uses, so its baked extensions track the FPM set, then restart those
+	// containers onto the new image.
+	fpVersions, fpUnits := frankenPHPRebuildTargets(versions)
+	for _, v := range fpVersions {
+		ver := v
+		jobs = append(jobs, BuildJob{
+			Label: "FrankenPHP " + ver,
+			Run:   func(w io.Writer) error { return podman.BuildFrankenPHPImage(ver, true, w) },
+		})
 	}
 	RunParallel(jobs) //nolint:errcheck — individual failures printed by RunParallel
+
+	for _, u := range fpUnits {
+		// Skip restart if the (force) rebuild left no image, so we don't bounce a
+		// running container onto a missing image; a failed build was already
+		// reported by RunParallel.
+		if podman.RunSilent("image", "exists", podman.FrankenPHPImageName(u.version)) != nil {
+			fmt.Printf("  [WARN] %s: image not built, leaving container as-is\n", u.unit)
+			continue
+		}
+		if err := podman.RestartUnit(u.unit); err != nil {
+			fmt.Printf("  [WARN] restart %s: %v\n", u.unit, err)
+		} else {
+			fmt.Printf("  restarted %s\n", u.unit)
+		}
+	}
 
 	// Store the new Containerfile hash so future updates know images are current.
 	if err := podman.StoreFPMHash(); err != nil {

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -1004,6 +1004,28 @@ func activePHPVersions() map[string]bool {
 	return active
 }
 
+// activeFrankenPHPVersions returns the distinct, normalized PHP versions used by
+// non-ignored, non-paused FrankenPHP sites, for derived-image rebuild detection.
+func activeFrankenPHPVersions() []string {
+	reg, err := config.LoadSites()
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range reg.Sites {
+		if s.Ignored || s.Paused || !s.IsFrankenPHP() {
+			continue
+		}
+		v := config.NormalizeFrankenPHPVersion(s.PHPVersion)
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
 // autoStopUnusedFPMs stops any PHP-FPM container whose PHP version is no longer
 // referenced by any active (non-ignored, non-paused) site.
 func autoStopUnusedFPMs() {

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -90,6 +90,19 @@ func ensureImages() {
 				Run:   func(w io.Writer) error { return podman.BuildFPMImageTo(v, false, w) },
 			})
 
+		case strings.HasPrefix(img, "localhost/lerd-frankenphp") && strings.HasSuffix(img, ":local"):
+			// Build the derived FrankenPHP image, e.g.
+			// localhost/lerd-frankenphp84:local → 8.4
+			short := strings.TrimSuffix(strings.TrimPrefix(img, "localhost/lerd-frankenphp"), ":local")
+			if len(short) < 2 {
+				continue // malformed tag with no version digits; skip rather than panic
+			}
+			v := short[:1] + "." + short[1:]
+			jobs = append(jobs, BuildJob{
+				Label: "FrankenPHP " + v,
+				Run:   func(w io.Writer) error { return podman.BuildFrankenPHPImage(v, false, w) },
+			})
+
 		case strings.HasPrefix(img, "lerd-custom-") && strings.HasSuffix(img, ":local"):
 			// Rebuild custom container from the site's Containerfile.
 			siteName := strings.TrimSuffix(strings.TrimPrefix(img, "lerd-custom-"), ":local")

--- a/internal/cli/xdebug.go
+++ b/internal/cli/xdebug.go
@@ -121,9 +121,9 @@ func runXdebugToggle(args []string, enable bool, mode, start string) error {
 		fmt.Printf("FPM container restarted.\n")
 	}
 
-	// Custom-FPM sites on this version mount the same xdebug ini; restart their
-	// per-site containers so the toggle takes effect there too.
-	restartCustomFPMContainersForVersion(version)
+	// Per-site containers (custom-FPM and FrankenPHP) on this version mount the
+	// same xdebug ini; restart them so the toggle takes effect there too.
+	podman.RestartSiteContainersForVersion(version)
 
 	if res.Enabled {
 		fmt.Printf("Xdebug enabled for PHP %s (mode=%s, start_with_request=%s, port 9003, host.containers.internal)\n", version, res.Mode, start)
@@ -134,21 +134,6 @@ func runXdebugToggle(args []string, enable bool, mode, start string) error {
 		fmt.Printf("Xdebug disabled for PHP %s\n", version)
 	}
 	return nil
-}
-
-// restartCustomFPMContainersForVersion restarts the per-site FPM container of
-// every custom-FPM site on the given PHP version, so per-version ini changes
-// (xdebug, dumps, profiler) reach them too.
-func restartCustomFPMContainersForVersion(version string) {
-	reg, err := config.LoadSites()
-	if err != nil {
-		return
-	}
-	for _, s := range reg.Sites {
-		if s.IsCustomFPM() && s.PHPVersion == version {
-			_ = podman.RestartUnit(podman.CustomFPMContainerName(s.Name))
-		}
-	}
 }
 
 func runXdebugStatus(_ *cobra.Command, _ []string) error {

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -506,23 +506,19 @@ var laravelFramework = &Framework{
 		// Non-worker serves via plain frankenphp php-server so code edits take effect
 		// immediately (fresh request lifecycle), same UX as FPM.
 		Entrypoint: []string{"frankenphp", "php-server", "-l", ":8000", "-r", "public/"},
-		// Worker runs Octane; pcntl is installed at boot since dunglas/frankenphp
-		// doesn't ship it. By default code edits need `lerd restart`; opting the
-		// octane worker into reload (lerd octane:reload on) selects the watch
-		// variant below so the server restarts workers on file changes.
+		// Worker runs Octane. pcntl and nodejs are baked into lerd's derived
+		// FrankenPHP image now (see podman.BuildFrankenPHPImage), so the entrypoint
+		// no longer installs them at container start. By default code edits need
+		// `lerd restart`; opting the octane worker into reload (lerd octane:reload
+		// on) selects the watch variant below so the server restarts on changes.
 		WorkerEntrypoint: []string{"sh", "-c",
-			`install-php-extensions pcntl >/dev/null && ` +
-				`exec php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=8000 --workers=auto`},
+			`exec php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=8000 --workers=auto`},
 		// Watch variant: same command plus --watch. Octane's watcher runs
-		// vendor/laravel/octane/bin/file-watcher.cjs under node and resolves the
-		// chokidar npm package from the project, so the otherwise node-less
-		// dunglas/frankenphp Alpine image needs node installed — done here (only on
-		// the opt-in reload path, so the default image stays slim). Core appends
-		// --poll on hosts where the container can't see host filesystem events.
+		// vendor/laravel/octane/bin/file-watcher.cjs under node (baked into the
+		// image) and resolves the chokidar npm package from the project. Core
+		// appends --poll on hosts where the container can't see host fs events.
 		WorkerReloadEntrypoint: []string{"sh", "-c",
-			`install-php-extensions pcntl >/dev/null && ` +
-				`apk add --no-cache nodejs >/dev/null 2>&1 && ` +
-				`exec php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=8000 --workers=auto --watch`},
+			`exec php artisan octane:start --server=frankenphp --host=0.0.0.0 --port=8000 --workers=auto --watch`},
 		SupportsWorker: true,
 	},
 	Commands: []FrameworkCommand{

--- a/internal/config/frankenphp_test.go
+++ b/internal/config/frankenphp_test.go
@@ -119,9 +119,24 @@ func TestLaravelOctaneFrankenPHPAdapter(t *testing.T) {
 	if e := fw.FrankenPHPEntrypoint(false); !strings.Contains(strings.Join(e, " "), "frankenphp php-server") {
 		t.Fatalf("laravel non-worker should use frankenphp php-server: %v", e)
 	}
-	// Worker mode runs Octane (wrapped in sh -c so pcntl is installed at boot).
+	// Worker mode runs Octane. Extensions are baked into lerd's derived image now,
+	// so the entrypoint must not install them at container start.
 	worker := strings.Join(fw.FrankenPHPEntrypoint(true), " ")
 	if !strings.Contains(worker, "octane:start") || !strings.Contains(worker, "frankenphp") {
 		t.Fatalf("laravel worker should use Octane: %s", worker)
+	}
+	if strings.Contains(worker, "install-php-extensions") || strings.Contains(worker, "apk add") {
+		t.Fatalf("worker entrypoint should not install anything at boot: %s", worker)
+	}
+}
+
+func TestNormalizeFrankenPHPVersion(t *testing.T) {
+	// A supported version passes through unchanged.
+	if got := NormalizeFrankenPHPVersion(LatestFrankenPHPVersion()); got != LatestFrankenPHPVersion() {
+		t.Errorf("supported version changed: %q", got)
+	}
+	// An unsupported/empty version falls back to the latest frankenphp version.
+	if got := NormalizeFrankenPHPVersion("5.6"); got != LatestFrankenPHPVersion() {
+		t.Errorf("NormalizeFrankenPHPVersion(5.6) = %q, want %q", got, LatestFrankenPHPVersion())
 	}
 }

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -160,6 +160,19 @@ func PHPUserIniFile(version string) string {
 	return filepath.Join(DataDir(), "php", version, "98-user.ini")
 }
 
+// SitePHPUserIniFile is the per-site user php.ini for a runtime site that runs
+// its own container (FrankenPHP). Unlike PHPUserIniFile (shared by every site on
+// a PHP version), this is scoped to one site so its php.ini is independent.
+func SitePHPUserIniFile(siteName string) string {
+	return filepath.Join(DataDir(), "php", "sites", siteName, "98-user.ini")
+}
+
+// SitePHPUserIniBkpDir holds timestamped backups of a site's per-site user ini,
+// next to (not inside) the file so the container's conf.d scan never loads them.
+func SitePHPUserIniBkpDir(siteName string) string {
+	return filepath.Join(DataDir(), "php", "sites", siteName, "ini.bkp")
+}
+
 // PHPUserIniBkpDir holds timestamped backups of the per-version user ini
 // produced by the web UI editor. It sits next to (not inside) the version
 // directory's ini scan path so the FPM container does not load backup files

--- a/internal/config/php_versions.go
+++ b/internal/config/php_versions.go
@@ -52,6 +52,16 @@ func LatestFrankenPHPVersion() string {
 	return v[len(v)-1]
 }
 
+// NormalizeFrankenPHPVersion returns v when dunglas/frankenphp publishes an
+// image for it, otherwise the latest version it does, so the base image, the
+// derived image name, and the quadlet all agree on one version.
+func NormalizeFrankenPHPVersion(v string) string {
+	if IsFrankenPHPVersion(v) {
+		return v
+	}
+	return LatestFrankenPHPVersion()
+}
+
 // phpVersionAtLeast reports whether "major.minor" version a is >= b.
 func phpVersionAtLeast(a, b string) bool {
 	amaj, amin := splitMajorMinor(a)

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -1064,3 +1064,29 @@ func EnsureUserIni(version string) error {
 		"; max_execution_time = 60\n"
 	return os.WriteFile(path, []byte(content), 0644)
 }
+
+// EnsureSitePHPUserIni creates a FrankenPHP site's own per-site user php.ini with
+// defaults if it doesn't exist, healing a stale podman-auto-created directory at
+// the bind-mount path the same way EnsureUserIni does for the per-version file.
+func EnsureSitePHPUserIni(siteName string) error {
+	path := config.SitePHPUserIniFile(siteName)
+	if info, err := os.Stat(path); err == nil {
+		if !info.IsDir() {
+			return nil
+		}
+		if rmErr := os.Remove(path); rmErr != nil {
+			return fmt.Errorf("removing stale user ini directory: %w", rmErr)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	content := "; Lerd per-site PHP settings for " + siteName + " (FrankenPHP)\n" +
+		"; Applies only to this site's container. Edit, then restart the site.\n" +
+		";\n" +
+		"; memory_limit = 512M\n" +
+		"; upload_max_filesize = 64M\n" +
+		"; post_max_size = 64M\n" +
+		"; max_execution_time = 60\n"
+	return os.WriteFile(path, []byte(content), 0644)
+}

--- a/internal/podman/frankenphp.go
+++ b/internal/podman/frankenphp.go
@@ -14,14 +14,19 @@ func FrankenPHPContainerName(siteName string) string {
 	return "lerd-fp-" + siteName
 }
 
-// FrankenPHPImage returns the official dunglas/frankenphp image tag for the
-// requested PHP version. Versions without a published frankenphp image fall
-// back to the latest one lerd knows about.
+// FrankenPHPImage returns the lerd-derived FrankenPHP image tag for the
+// requested PHP version, e.g. "localhost/lerd-frankenphp84:local". This is the
+// image the per-site quadlet runs: the dunglas base with lerd's standard
+// extension set baked in (see BuildFrankenPHPImage). Versions without a
+// published frankenphp base fall back to the latest one lerd knows about.
 func FrankenPHPImage(phpVersion string) string {
-	if !config.IsFrankenPHPVersion(phpVersion) {
-		phpVersion = config.LatestFrankenPHPVersion()
-	}
-	return "docker.io/dunglas/frankenphp:php" + phpVersion + "-alpine"
+	return FrankenPHPImageName(config.NormalizeFrankenPHPVersion(phpVersion))
+}
+
+// FrankenPHPBaseImage returns the upstream dunglas/frankenphp image tag the
+// derived image is built FROM, for the requested PHP version.
+func FrankenPHPBaseImage(phpVersion string) string {
+	return "docker.io/dunglas/frankenphp:php" + config.NormalizeFrankenPHPVersion(phpVersion) + "-alpine"
 }
 
 // FrankenPHPPort is the port FrankenPHP listens on inside the container. Kept
@@ -47,6 +52,22 @@ func GenerateFrankenPHPQuadlet(siteName, projectPath, phpVersion string, entrypo
 	b.WriteString("Network=lerd\n")
 	fmt.Fprintf(&b, "Volume=%s:/etc/hosts:ro,z\n", config.ContainerHostsFile())
 	fmt.Fprintf(&b, "Volume=%s:%s:rw\n", projectPath, projectPath)
+	// Debug tooling: bind-mount the same conf.d inis, bridge assets, and runtime
+	// socket dir the FPM container gets, so dump()/dd(), the Debug window
+	// (lerd_devtools), and Xdebug work for requests Octane serves from this
+	// container too. The baked extensions stay inert until these inis/sentinels
+	// arm them. RunDir carries the unix socket the bridges ship to; it must appear
+	// at its host path, matching the dump_host ini value. SPX is omitted: it can't
+	// profile Octane's resident-worker requests (see the Containerfile).
+	fmt.Fprintf(&b, "Volume=%s:/usr/local/etc/lerd:ro\n", config.DumpsAssetsDir())
+	fmt.Fprintf(&b, "Volume=%s:/usr/local/etc/php/conf.d/97-lerd-dump.ini:ro\n", config.DumpsIniFile())
+	fmt.Fprintf(&b, "Volume=%s:/usr/local/etc/php/conf.d/96-lerd-devtools.ini:ro\n", config.DevtoolsIniFile())
+	fmt.Fprintf(&b, "Volume=%s:/usr/local/etc/php/conf.d/99-xdebug.ini:ro\n", config.PHPConfFile(phpVersion))
+	// Per-site user php.ini override, edited from the site's config modal. Scoped
+	// to this site (not the shared per-version file), since a FrankenPHP site runs
+	// its own container.
+	fmt.Fprintf(&b, "Volume=%s:/usr/local/etc/php/conf.d/98-lerd-user.ini:ro\n", config.SitePHPUserIniFile(siteName))
+	fmt.Fprintf(&b, "Volume=%s:%s:rw\n", config.RunDir(), config.RunDir())
 	fmt.Fprintf(&b, "PodmanArgs=--security-opt=label=disable --workdir=%s\n", projectPath)
 	for _, k := range sortedKeys(env) {
 		// systemd Environment= splits on whitespace unless the whole
@@ -67,6 +88,28 @@ func GenerateFrankenPHPQuadlet(siteName, projectPath, phpVersion string, entrypo
 	return b.String()
 }
 
+// RestartSiteContainersForVersion restarts every per-site PHP container on the
+// given PHP version — custom-FPM and FrankenPHP — so a per-version ini change
+// (php.ini, xdebug) reaches them too. Paused/ignored sites are skipped; the
+// shared FPM container is restarted separately by the caller.
+func RestartSiteContainersForVersion(version string) {
+	reg, err := config.LoadSites()
+	if err != nil {
+		return
+	}
+	for _, s := range reg.Sites {
+		if s.Paused || s.Ignored || s.PHPVersion != version {
+			continue
+		}
+		switch {
+		case s.IsCustomFPM():
+			_ = RestartUnit(CustomFPMContainerName(s.Name))
+		case s.IsFrankenPHP():
+			_ = RestartUnit(FrankenPHPContainerName(s.Name))
+		}
+	}
+}
+
 // WriteFrankenPHPQuadlet writes the quadlet for a FrankenPHP site.
 func WriteFrankenPHPQuadlet(siteName, projectPath, phpVersion string, entrypoint []string, env map[string]string) error {
 	_, err := WriteFrankenPHPQuadletDiff(siteName, projectPath, phpVersion, entrypoint, env)
@@ -75,8 +118,16 @@ func WriteFrankenPHPQuadlet(siteName, projectPath, phpVersion string, entrypoint
 
 // WriteFrankenPHPQuadletDiff writes the quadlet and returns whether the content
 // changed on disk so callers can decide whether to restart the running
-// container.
+// container. It first ensures every bind-mount source exists as a regular file,
+// mirroring WriteFPMQuadlet: without this, a restart through any path other than
+// the full link (a php.ini save, an install-time refresh) could mount a missing
+// source, letting podman auto-create a directory at a conf.d/*.ini path and
+// break the container's PHP startup.
 func WriteFrankenPHPQuadletDiff(siteName, projectPath, phpVersion string, entrypoint []string, env map[string]string) (bool, error) {
+	_ = EnsureSitePHPUserIni(siteName)
+	_ = EnsureXdebugIni(phpVersion)
+	_ = EnsureDumpAssets()
+	_ = EnsureDevtoolsAssets()
 	content := GenerateFrankenPHPQuadlet(siteName, projectPath, phpVersion, entrypoint, env)
 	return WriteQuadletDiff(FrankenPHPContainerName(siteName), content)
 }

--- a/internal/podman/frankenphp_build.go
+++ b/internal/podman/frankenphp_build.go
@@ -1,0 +1,189 @@
+package podman
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// frankenPHPRuntimeExtensions is the standard PHP extension set baked into the
+// derived FrankenPHP image, mirroring the runtime extensions the lerd FPM image
+// ships so an Octane site has the same modules available instead of the bare
+// dunglas base. These are install-php-extensions names; curl/mbstring/xml are
+// already in the base image. Dev-only tooling (xdebug, pcov, spx, lerd_devtools)
+// is intentionally excluded — it carries octane-specific behaviour and is
+// tracked separately.
+var frankenPHPRuntimeExtensions = []string{
+	"bcmath", "bz2", "calendar", "dba", "exif", "gd", "gmp", "intl", "ldap",
+	"mysqli", "opcache", "pcntl", "pdo_mysql", "pdo_pgsql", "shmop", "soap",
+	"sockets", "sysvmsg", "sysvsem", "sysvshm", "xsl", "zip",
+	"redis", "igbinary", "imagick", "mongodb",
+}
+
+// frankenPHPContainerfileHashLabel stamps the derived image with the hash of the
+// Containerfile + extension list it was built from, so NeedsFrankenPHPRebuild can
+// tell an up-to-date image from one a newer lerd would build differently.
+const frankenPHPContainerfileHashLabel = "dev.lerd.frankenphp.containerfile-hash"
+
+// validExtName guards extension names interpolated into the build command so a
+// stray config value can't inject extra shell/build arguments.
+var validExtName = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+
+// FrankenPHPImageName returns the local derived image tag for a PHP version,
+// e.g. "localhost/lerd-frankenphp84:local" for "8.4".
+func FrankenPHPImageName(version string) string {
+	return "localhost/lerd-frankenphp" + strings.ReplaceAll(version, ".", "") + ":local"
+}
+
+// frankenPHPContainerfileHash hashes the embedded Containerfile template plus the
+// baked extension list, so a change to either drifts the hash and triggers a
+// rebuild after a lerd update.
+func frankenPHPContainerfileHash() (string, error) {
+	tmpl, err := GetQuadletTemplate("lerd-frankenphp.Containerfile")
+	if err != nil {
+		return "", err
+	}
+	// Fold in the lerd_devtools source hash so a change to that extension drifts
+	// the image hash and rebuilds, the same guarantee the FPM marker line gives.
+	dt, err := devtoolsSourceHash()
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(tmpl + "\n" + strings.Join(frankenPHPRuntimeExtensions, " ") + "\n" + dt))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// NeedsFrankenPHPRebuild reports whether any active FrankenPHP version's derived
+// image is missing or stamped with a different Containerfile hash than the
+// current binary builds, so a lerd update that changes the template or extension
+// set rebuilds the image. False when nothing is stale.
+func NeedsFrankenPHPRebuild(activeVersions []string) bool {
+	current, err := frankenPHPContainerfileHash()
+	if err != nil {
+		return true
+	}
+	for _, v := range activeVersions {
+		if imageLabelFn(FrankenPHPImageName(v), frankenPHPContainerfileHashLabel) != current {
+			return true
+		}
+	}
+	return false
+}
+
+// BuildFrankenPHPImage builds the derived FrankenPHP image for version, baking
+// the standard extension set plus any user-configured custom extensions and
+// packages. When force is false it no-ops if a current image already exists.
+func BuildFrankenPHPImage(version string, force bool, w io.Writer) error {
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return err
+	}
+	exts := cfg.GetExtensions(version)
+	packages := cfg.GetPackages(version)
+	// Custom extensions may need extra Alpine packages to compile;
+	// install-php-extensions only auto-resolves deps for extensions it knows, so
+	// fold the user-configured ext apk deps into the package set the way the FPM
+	// build does, otherwise a custom extension that builds on FPM fails here.
+	for _, ext := range exts {
+		packages = append(packages, cfg.GetExtApkDeps(ext)...)
+	}
+	return buildFrankenPHPImage(version, force, exts, packages, w)
+}
+
+func buildFrankenPHPImage(version string, force bool, customExts, packages []string, w io.Writer) error {
+	version = config.NormalizeFrankenPHPVersion(version)
+	imageName := FrankenPHPImageName(version)
+
+	// Compute the Containerfile hash once and use it for both the freshness check
+	// and the image label, instead of re-hashing via NeedsFrankenPHPRebuild.
+	hash, err := frankenPHPContainerfileHash()
+	if err != nil {
+		return fmt.Errorf("hashing FrankenPHP Containerfile: %w", err)
+	}
+	if !force {
+		if exec.Command(PodmanBin(), "image", "exists", imageName).Run() == nil &&
+			imageLabelFn(imageName, frankenPHPContainerfileHashLabel) == hash {
+			return nil // image exists and is current
+		}
+	}
+
+	fmt.Fprintf(w, "\n  Building FrankenPHP PHP %s image...\n", version)
+
+	tmp, err := os.MkdirTemp("", "lerd-frankenphp-build-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmp)
+
+	// Stage the lerd_devtools C source into the build context so the
+	// `COPY internal/podman/devtools` in the Containerfile resolves.
+	if err := writeDevtoolsSource(tmp); err != nil {
+		return fmt.Errorf("staging devtools source: %w", err)
+	}
+
+	exts := append(append([]string{}, frankenPHPRuntimeExtensions...), sanitizeExtNames(customExts)...)
+	containerfile, err := renderFrankenPHPContainerfile(version, exts, packages, mkcertCABlock(tmp))
+	if err != nil {
+		return err
+	}
+
+	cfPath := filepath.Join(tmp, "Containerfile")
+	if err := os.WriteFile(cfPath, []byte(containerfile), 0644); err != nil {
+		return err
+	}
+
+	args := []string{"build", "-t", imageName, "--label", frankenPHPContainerfileHashLabel + "=" + hash}
+	if force {
+		args = append(args, "--no-cache")
+	}
+	args = append(args, "-f", cfPath, tmp)
+	cmd := exec.Command(PodmanBin(), args...)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("building FrankenPHP PHP %s image: %w", version, err)
+	}
+	fmt.Fprintf(w, "  FrankenPHP PHP %s image built successfully.\n", version)
+	return nil
+}
+
+// renderFrankenPHPContainerfile substitutes the embedded template with the PHP
+// version, the full extension list (standard + custom), the user's extra
+// packages, and the mkcert CA block. Pure, so the build's image definition has
+// unit-test coverage without invoking podman.
+func renderFrankenPHPContainerfile(version string, exts, packages []string, mkcertBlock string) (string, error) {
+	tmpl, err := GetQuadletTemplate("lerd-frankenphp.Containerfile")
+	if err != nil {
+		return "", err
+	}
+	dt, err := devtoolsSourceHash()
+	if err != nil {
+		return "", err
+	}
+	cf := strings.ReplaceAll(tmpl, "{{.Version}}", version)
+	cf = strings.ReplaceAll(cf, "{{.Extensions}}", strings.Join(exts, " "))
+	cf = strings.ReplaceAll(cf, "{{.DevtoolsHash}}", dt)
+	cf = strings.ReplaceAll(cf, "{{.CustomPackages}}", buildCustomPackagesBlock(packages))
+	cf = strings.ReplaceAll(cf, "{{.MkcertCA}}", mkcertBlock)
+	return cf, nil
+}
+
+// sanitizeExtNames keeps only well-formed extension tokens, dropping anything a
+// stray config value might smuggle in.
+func sanitizeExtNames(in []string) []string {
+	var out []string
+	for _, e := range in {
+		if e = strings.TrimSpace(e); e != "" && validExtName.MatchString(e) {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/internal/podman/frankenphp_build_test.go
+++ b/internal/podman/frankenphp_build_test.go
@@ -1,0 +1,152 @@
+package podman
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFrankenPHPRuntimeExtensionParity guards against the FPM image gaining a
+// runtime extension that the FrankenPHP image silently misses. It parses the
+// docker-php-ext-install list from the FPM Containerfile and asserts each entry
+// is either baked into the FrankenPHP image (frankenPHPRuntimeExtensions) or is
+// a base-image builtin the dunglas image already provides. dev-only tooling
+// (xdebug/pcov/spx) is handled separately and excluded.
+func TestFrankenPHPRuntimeExtensionParity(t *testing.T) {
+	cf, err := GetQuadletTemplate("lerd-php-fpm.Containerfile")
+	if err != nil {
+		t.Fatalf("reading FPM Containerfile: %v", err)
+	}
+	fpmExts := fpmDockerExtInstallList(cf)
+	if len(fpmExts) < 10 {
+		t.Fatalf("parsed only %d FPM extensions, parser likely broke: %v", len(fpmExts), fpmExts)
+	}
+
+	franken := map[string]bool{}
+	for _, e := range frankenPHPRuntimeExtensions {
+		franken[e] = true
+	}
+	// Builtins the dunglas/frankenphp base already ships, verified present in the
+	// built image, so they need no explicit entry in the FrankenPHP list.
+	builtin := map[string]bool{"curl": true, "mbstring": true, "xml": true}
+
+	for _, ext := range fpmExts {
+		if !franken[ext] && !builtin[ext] {
+			t.Errorf("FPM installs %q but the FrankenPHP image neither bakes it nor gets it from the base — add it to frankenPHPRuntimeExtensions (or the builtin set)", ext)
+		}
+	}
+	// The pecl-installed runtime extensions must also be baked into FrankenPHP.
+	for _, ext := range []string{"redis", "imagick", "igbinary", "mongodb"} {
+		if !franken[ext] {
+			t.Errorf("FrankenPHP image missing pecl runtime extension %q present in FPM", ext)
+		}
+	}
+}
+
+// fpmDockerExtInstallList extracts the extension tokens from the FPM
+// Containerfile's `docker-php-ext-install -j$(nproc) \ ... ` block.
+func fpmDockerExtInstallList(containerfile string) []string {
+	var out []string
+	collecting := false
+	for _, ln := range strings.Split(containerfile, "\n") {
+		s := strings.TrimSpace(ln)
+		if strings.Contains(s, "docker-php-ext-install") {
+			collecting = true
+			continue
+		}
+		if !collecting {
+			continue
+		}
+		if strings.HasPrefix(s, "&") { // end of the continued install list
+			break
+		}
+		tok := strings.TrimSpace(strings.TrimSuffix(s, "\\"))
+		if tok != "" {
+			out = append(out, tok)
+		}
+	}
+	return out
+}
+
+func TestFrankenPHPImageName(t *testing.T) {
+	if got := FrankenPHPImageName("8.4"); got != "localhost/lerd-frankenphp84:local" {
+		t.Errorf("FrankenPHPImageName(8.4) = %q", got)
+	}
+	if got := FrankenPHPImage("8.4"); got != "localhost/lerd-frankenphp84:local" {
+		t.Errorf("FrankenPHPImage(8.4) = %q, want the derived image", got)
+	}
+	if got := FrankenPHPBaseImage("8.4"); got != "docker.io/dunglas/frankenphp:php8.4-alpine" {
+		t.Errorf("FrankenPHPBaseImage(8.4) = %q, want the upstream base", got)
+	}
+}
+
+// TestRenderFrankenPHPContainerfile checks the derived image is built FROM the
+// dunglas base and bakes the standard extension set with no leftover template
+// placeholders.
+func TestRenderFrankenPHPContainerfile(t *testing.T) {
+	exts := append(append([]string{}, frankenPHPRuntimeExtensions...), "myext")
+	cf, err := renderFrankenPHPContainerfile("8.4", exts, []string{"jq"}, "# mkcert\n")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if strings.Contains(cf, "{{") {
+		t.Errorf("unsubstituted placeholder remains:\n%s", cf)
+	}
+	if !strings.Contains(cf, "FROM docker.io/dunglas/frankenphp:php8.4-alpine") {
+		t.Errorf("missing FROM base:\n%s", cf)
+	}
+	for _, want := range []string{
+		"install-php-extensions", "redis", "gd", "pdo_mysql", "intl", "myext",
+		// dev-tooling baked into the image (xdebug + the compiled lerd_devtools)
+		"xdebug", "lerd_devtools",
+	} {
+		if !strings.Contains(cf, want) {
+			t.Errorf("rendered Containerfile missing %q", want)
+		}
+	}
+	// SPX is intentionally not baked: it can't profile Octane's resident workers.
+	if strings.Contains(cf, " spx ") || strings.Contains(cf, "spx \\") {
+		t.Errorf("spx should not be baked into the FrankenPHP image:\n%s", cf)
+	}
+	if !strings.Contains(cf, "jq") {
+		t.Errorf("custom package not rendered:\n%s", cf)
+	}
+}
+
+// TestNeedsFrankenPHPRebuild exercises the label-vs-hash comparison through the
+// imageLabelFn seam so a stale or missing image triggers a rebuild and a current
+// one does not.
+func TestNeedsFrankenPHPRebuild(t *testing.T) {
+	current, err := frankenPHPContainerfileHash()
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	prev := imageLabelFn
+	t.Cleanup(func() { imageLabelFn = prev })
+
+	imageLabelFn = func(string, string) string { return current }
+	if NeedsFrankenPHPRebuild([]string{"8.4"}) {
+		t.Error("matching label should not need a rebuild")
+	}
+
+	imageLabelFn = func(string, string) string { return "stale" }
+	if !NeedsFrankenPHPRebuild([]string{"8.4"}) {
+		t.Error("mismatched label should need a rebuild")
+	}
+
+	imageLabelFn = func(string, string) string { return "" } // image missing
+	if !NeedsFrankenPHPRebuild([]string{"8.4"}) {
+		t.Error("missing image should need a rebuild")
+	}
+
+	if NeedsFrankenPHPRebuild(nil) {
+		t.Error("no active versions should never need a rebuild")
+	}
+}
+
+func TestSanitizeExtNames(t *testing.T) {
+	got := sanitizeExtNames([]string{"redis", "  gd ", "", "bad name", "a;b", "pdo_mysql"})
+	want := []string{"redis", "gd", "pdo_mysql"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("sanitizeExtNames = %v, want %v", got, want)
+	}
+}

--- a/internal/podman/frankenphp_test.go
+++ b/internal/podman/frankenphp_test.go
@@ -13,19 +13,23 @@ func TestFrankenPHPContainerName(t *testing.T) {
 }
 
 func TestFrankenPHPImage(t *testing.T) {
+	// FrankenPHPImage is now the lerd-derived image; the upstream tag it builds
+	// FROM is FrankenPHPBaseImage.
 	tests := []struct {
-		version, want string
+		version, wantDerived, wantBase string
 	}{
-		{"8.2", "docker.io/dunglas/frankenphp:php8.2-alpine"},
-		{"8.3", "docker.io/dunglas/frankenphp:php8.3-alpine"},
-		{"8.4", "docker.io/dunglas/frankenphp:php8.4-alpine"},
-		{"8.5", "docker.io/dunglas/frankenphp:php8.5-alpine"},
-		{"8.1", "docker.io/dunglas/frankenphp:php8.5-alpine"}, // no frankenphp tag → latest
-		{"", "docker.io/dunglas/frankenphp:php8.5-alpine"},
+		{"8.2", "localhost/lerd-frankenphp82:local", "docker.io/dunglas/frankenphp:php8.2-alpine"},
+		{"8.4", "localhost/lerd-frankenphp84:local", "docker.io/dunglas/frankenphp:php8.4-alpine"},
+		{"8.5", "localhost/lerd-frankenphp85:local", "docker.io/dunglas/frankenphp:php8.5-alpine"},
+		{"8.1", "localhost/lerd-frankenphp85:local", "docker.io/dunglas/frankenphp:php8.5-alpine"}, // no frankenphp tag → latest
+		{"", "localhost/lerd-frankenphp85:local", "docker.io/dunglas/frankenphp:php8.5-alpine"},
 	}
 	for _, tt := range tests {
-		if got := FrankenPHPImage(tt.version); got != tt.want {
-			t.Errorf("FrankenPHPImage(%q): want %s, got %s", tt.version, tt.want, got)
+		if got := FrankenPHPImage(tt.version); got != tt.wantDerived {
+			t.Errorf("FrankenPHPImage(%q): want %s, got %s", tt.version, tt.wantDerived, got)
+		}
+		if got := FrankenPHPBaseImage(tt.version); got != tt.wantBase {
+			t.Errorf("FrankenPHPBaseImage(%q): want %s, got %s", tt.version, tt.wantBase, got)
 		}
 	}
 }
@@ -37,18 +41,29 @@ func TestGenerateFrankenPHPQuadlet(t *testing.T) {
 
 	mustContain := []string{
 		"ContainerName=lerd-fp-myapp",
-		"Image=docker.io/dunglas/frankenphp:php8.4-alpine",
+		"Image=localhost/lerd-frankenphp84:local",
 		"Network=lerd",
 		"Volume=/home/user/myapp:/home/user/myapp:rw",
 		"--workdir=/home/user/myapp",
 		`Environment="FRANKENPHP_CONFIG=worker ./public/index.php"`,
 		"Exec=php artisan octane:start --server=frankenphp",
 		"Restart=always",
+		// Debug tooling parity: the same conf.d inis and bridge dir the FPM
+		// container mounts (dump bridge, devtools, xdebug). SPX is excluded.
+		"/usr/local/etc/php/conf.d/97-lerd-dump.ini:ro",
+		"/usr/local/etc/php/conf.d/96-lerd-devtools.ini:ro",
+		"/usr/local/etc/php/conf.d/99-xdebug.ini:ro",
+		"/usr/local/etc/php/conf.d/98-lerd-user.ini:ro",
+		":/usr/local/etc/lerd:ro",
 	}
 	for _, s := range mustContain {
 		if !strings.Contains(content, s) {
 			t.Errorf("generated quadlet missing %q\n%s", s, content)
 		}
+	}
+	// SPX is not wired for FrankenPHP (can't profile Octane workers).
+	if strings.Contains(content, "spx") || strings.Contains(content, "/var/spx") {
+		t.Errorf("SPX should not be mounted in the FrankenPHP quadlet:\n%s", content)
 	}
 }
 

--- a/internal/podman/quadlets/lerd-frankenphp.Containerfile
+++ b/internal/podman/quadlets/lerd-frankenphp.Containerfile
@@ -1,0 +1,41 @@
+# Lerd FrankenPHP image: the upstream dunglas/frankenphp base plus the same
+# runtime PHP extensions the lerd FPM image ships, so a FrankenPHP (Octane) site
+# has redis/gd/pdo/intl/... plus Xdebug and the lerd_devtools / dump bridge
+# tooling. {{.Version}} is the PHP minor (e.g. 8.4); the extension list, extra
+# packages, and mkcert CA are injected by the builder.
+#
+# SPX and pcov are intentionally excluded: SPX is a per-request profiler that
+# doesn't hook Octane's resident-worker request loop (its /_spx UI 404s under
+# Octane and lerd's profiler injection is fastcgi-only), and pcov coverage runs
+# only via CLI, which execs into the shared FPM container. Both stay FPM-only.
+FROM docker.io/dunglas/frankenphp:php{{.Version}}-alpine
+
+# Runtime extensions + Xdebug. install-php-extensions (shipped in the base) builds
+# each for the ZTS runtime, pulls its runtime libs, and trims the build toolchain.
+# Xdebug loads but stays inert until its bind-mounted 99-xdebug.ini arms it,
+# exactly like the FPM image.
+RUN install-php-extensions {{.Extensions}} xdebug \
+    && rm -rf /tmp/* /var/cache/apk/*
+
+# nodejs+npm so the Octane file-watcher (lerd octane:reload on) and JS tooling
+# work without an apk add at container start, matching the FPM image.
+RUN apk add --no-cache nodejs npm && rm -rf /var/cache/apk/*
+
+# lerd_devtools: lerd's engine-level Debug-window capture (queries, mail, views,
+# events, jobs, http), compiled here for the ZTS base since install-php-extensions
+# can't build it. The marker hashes the extension source so any change rebuilds
+# the image; the || true degrades a compile failure to "Debug window unavailable"
+# rather than bricking the image.
+# lerd_devtools-src-sha256: {{.DevtoolsHash}}
+COPY internal/podman/devtools /tmp/lerd-devtools
+RUN apk add --no-cache --virtual .lerd-devtools-build autoconf make g++ \
+    && { cd /tmp/lerd-devtools && phpize && ./configure --enable-lerd-devtools \
+         && make -j"$(nproc)" && make install && docker-php-ext-enable lerd_devtools; } || true; \
+    apk del .lerd-devtools-build || true; \
+    rm -rf /tmp/lerd-devtools /var/cache/apk/*
+
+# User-requested extra Alpine packages (lerd php:pkg). Empty until opted in.
+{{.CustomPackages}}
+
+# Lerd mkcert CA so the app trusts local .test HTTPS from inside the container.
+{{.MkcertCA}}

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -2,6 +2,7 @@ package siteops
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
@@ -160,11 +161,15 @@ func FinishFrankenPHPLink(site config.Site) error {
 
 	_ = podman.WriteContainerHosts()
 
-	image := podman.FrankenPHPImage(site.PHPVersion)
-	if err := podman.PullImageIfMissing(image); err != nil {
-		fmt.Printf("[WARN] pulling %s: %v\n", image, err)
+	// Build the derived image (dunglas base + lerd's standard extension set) so
+	// the site has redis/gd/pdo/... instead of the bare base. The build pulls the
+	// base itself; a failure leaves the site registered to retry on next start.
+	if err := podman.BuildFrankenPHPImage(site.PHPVersion, false, os.Stdout); err != nil {
+		fmt.Printf("[WARN] building FrankenPHP image: %v\n", err)
 	}
 
+	// WriteFrankenPHPQuadletDiff ensures the debug-tooling bind-mount sources
+	// (user ini, xdebug, dump, devtools) exist before referencing them.
 	unitName := podman.FrankenPHPContainerName(site.Name)
 	changed, err := podman.WriteFrankenPHPQuadletDiff(site.Name, site.Path, site.PHPVersion, entrypoint, env)
 	if err != nil {

--- a/internal/ui/php_ini.go
+++ b/internal/ui/php_ini.go
@@ -27,6 +27,74 @@ func phpIniFile(version string) cfgedit.File {
 	}
 }
 
+// phpIniSiteName decodes a "site:<name>" editor scope, returning the site name
+// and true; a bare PHP version returns ("", false).
+func phpIniSiteName(scope string) (string, bool) {
+	return strings.CutPrefix(scope, "site:")
+}
+
+// phpIniValid reports whether a php.ini editor scope is valid: a bare installed
+// PHP version, or "site:<name>" for an existing FrankenPHP site (which has its
+// own per-site ini).
+func phpIniValid(scope string) bool {
+	if name, ok := phpIniSiteName(scope); ok {
+		s, err := config.FindSite(name)
+		return err == nil && s != nil && s.IsFrankenPHP()
+	}
+	installed, _ := phpPkg.ListInstalled()
+	return slices.Contains(installed, scope)
+}
+
+// phpIniScopeFile returns the cfgedit.File for a scope: the per-version file, or
+// a FrankenPHP site's own per-site file.
+func phpIniScopeFile(scope string) cfgedit.File {
+	if name, ok := phpIniSiteName(scope); ok {
+		return cfgedit.File{
+			Path:     config.SitePHPUserIniFile(name),
+			BkpDir:   config.SitePHPUserIniBkpDir(name),
+			BkpName:  "98-user.ini",
+			Template: phpUserIniTemplate,
+		}
+	}
+	return phpIniFile(scope)
+}
+
+// phpIniRestart applies a scope's ini change: for a version, the shared FPM plus
+// per-site containers on it; for a site, just that FrankenPHP container (after
+// refreshing its quadlet so the mount is current).
+func phpIniRestart(scope string) error {
+	name, ok := phpIniSiteName(scope)
+	if !ok {
+		return fpmRestartForVersion(scope)
+	}
+	site, err := config.FindSite(name)
+	if err != nil {
+		return err
+	}
+	entrypoint, env := site.FrankenPHPQuadletSpec()
+	if err := podman.WriteFrankenPHPQuadlet(site.Name, site.Path, site.PHPVersion, entrypoint, env); err != nil {
+		return fmt.Errorf("updating FrankenPHP quadlet: %w", err)
+	}
+	return podman.RestartUnit(podman.FrankenPHPContainerName(site.Name))
+}
+
+// phpIniRestartNoSeed restarts a scope's container(s) after a reset. For a
+// version it does not re-seed (the shared FPM tolerates a missing per-version
+// ini). For a FrankenPHP site, whose container mounts only this one file, it
+// re-seeds the defaults first so the bind-mount source stays a regular file and
+// podman can't auto-create a directory at the conf.d mount path.
+func phpIniRestartNoSeed(scope string) error {
+	if name, ok := phpIniSiteName(scope); ok {
+		site, err := config.FindSite(name)
+		if err != nil {
+			return err
+		}
+		_ = podman.EnsureSitePHPUserIni(name)
+		return podman.RestartUnit(podman.FrankenPHPContainerName(site.Name))
+	}
+	return restartFPMUnit(scope)
+}
+
 // PhpIniReadResponse mirrors SiteNginxReadResponse. Exists distinguishes a
 // real saved override from the seeded template the handler hands back when
 // the file is missing.
@@ -75,7 +143,13 @@ func fpmRestartForVersion(version string) error {
 	if err := podman.WriteFPMQuadlet(version); err != nil {
 		return fmt.Errorf("updating php quadlet: %w", err)
 	}
-	return restartFPMUnit(version)
+	if err := restartFPMUnit(version); err != nil {
+		return err
+	}
+	// Per-site containers (FrankenPHP, custom-FPM) on this version mount the same
+	// per-version inis; restart them so the php.ini edit reaches them too.
+	podman.RestartSiteContainersForVersion(version)
+	return nil
 }
 
 // restartFPMUnit restarts the FPM container without touching the on-disk user
@@ -104,12 +178,11 @@ const phpUserIniTemplate = `; Lerd per-version PHP settings.
 // FPM, and roll back to the snapshot if the restart fails — leaving the user
 // on a known-good config. Backups/snapshot/staging come from cfgedit.
 func handlePhpIniConfig(w http.ResponseWriter, r *http.Request, version string) {
-	installed, _ := phpPkg.ListInstalled()
-	if !slices.Contains(installed, version) {
+	if !phpIniValid(version) {
 		http.NotFound(w, r)
 		return
 	}
-	f := phpIniFile(version)
+	f := phpIniScopeFile(version)
 	if r.Method == http.MethodGet {
 		got, err := f.Read()
 		if err != nil {
@@ -153,12 +226,12 @@ func handlePhpIniConfig(w http.ResponseWriter, r *http.Request, version string) 
 		writeJSON(w, PhpIniWriteResponse{OK: false, Error: err.Error()})
 		return
 	}
-	if err := fpmRestartForVersion(version); err != nil {
+	if err := phpIniRestart(version); err != nil {
 		if rbErr := cfgedit.RestoreSnapshot(f.Path, snap); rbErr != nil {
 			writeJSON(w, PhpIniWriteResponse{OK: false, Error: "saved, but FPM restart failed and rollback failed: " + rbErr.Error() + " (restart error: " + err.Error() + ")", BackupName: backupName, Content: req.Content, Exists: true})
 			return
 		}
-		if rb2Err := fpmRestartForVersion(version); rb2Err != nil {
+		if rb2Err := phpIniRestart(version); rb2Err != nil {
 			writeJSON(w, PhpIniWriteResponse{OK: false, Error: "php.ini rejected and rollback restart also failed: " + rb2Err.Error() + " (original: " + err.Error() + ")"})
 			return
 		}
@@ -176,12 +249,11 @@ func handlePhpIniBackups(w http.ResponseWriter, r *http.Request, version string)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	installed, _ := phpPkg.ListInstalled()
-	if !slices.Contains(installed, version) {
+	if !phpIniValid(version) {
 		http.NotFound(w, r)
 		return
 	}
-	list, err := phpIniFile(version).ListBackups()
+	list, err := phpIniScopeFile(version).ListBackups()
 	if err != nil {
 		http.Error(w, "listing backups: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -197,12 +269,11 @@ func handlePhpIniBackupContent(w http.ResponseWriter, r *http.Request, version, 
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	installed, _ := phpPkg.ListInstalled()
-	if !slices.Contains(installed, version) {
+	if !phpIniValid(version) {
 		http.NotFound(w, r)
 		return
 	}
-	data, err := phpIniFile(version).ReadBackup(name)
+	data, err := phpIniScopeFile(version).ReadBackup(name)
 	if err != nil {
 		if os.IsNotExist(err) {
 			http.NotFound(w, r)
@@ -221,15 +292,14 @@ func handlePhpIniReset(w http.ResponseWriter, r *http.Request, version string) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	installed, _ := phpPkg.ListInstalled()
-	if !slices.Contains(installed, version) {
+	if !phpIniValid(version) {
 		http.NotFound(w, r)
 		return
 	}
 	// Restart via restartFPMUnit, not fpmRestartForVersion: the latter routes
 	// through WriteFPMQuadlet → EnsureUserIni, which would re-seed the file we
 	// just deleted. cfgedit.Reset skips the restart when nothing was removed.
-	if err := phpIniFile(version).Reset(func() error { return restartFPMUnit(version) }); err != nil {
+	if err := phpIniScopeFile(version).Reset(func() error { return phpIniRestartNoSeed(version) }); err != nil {
 		writeJSON(w, PhpIniResetResponse{OK: false, Error: "removed, but FPM restart failed: " + err.Error()})
 		return
 	}
@@ -241,8 +311,7 @@ func handlePhpIniRestore(w http.ResponseWriter, r *http.Request, version string)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	installed, _ := phpPkg.ListInstalled()
-	if !slices.Contains(installed, version) {
+	if !phpIniValid(version) {
 		http.NotFound(w, r)
 		return
 	}
@@ -251,12 +320,12 @@ func handlePhpIniRestore(w http.ResponseWriter, r *http.Request, version string)
 		writeJSON(w, PhpIniRestoreResponse{OK: false, Error: "invalid body: " + err.Error()})
 		return
 	}
-	f := phpIniFile(version)
+	f := phpIniScopeFile(version)
 	if !f.ValidBackupName(req.Name) {
 		writeJSON(w, PhpIniRestoreResponse{OK: false, Error: "invalid backup name"})
 		return
 	}
-	res, err := f.Restore(req.Name, func() error { return fpmRestartForVersion(version) })
+	res, err := f.Restore(req.Name, func() error { return phpIniRestart(version) })
 	if err != nil {
 		writeJSON(w, PhpIniRestoreResponse{OK: false, Error: err.Error()})
 		return

--- a/internal/ui/php_ini_test.go
+++ b/internal/ui/php_ini_test.go
@@ -1,0 +1,37 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// TestPhpIniScope checks the php.ini editor scope token resolves a bare version
+// to the shared per-version file and "site:<name>" to a FrankenPHP site's own
+// per-site file, so the same editor serves both.
+func TestPhpIniScope(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	if name, ok := phpIniSiteName("site:personal"); !ok || name != "personal" {
+		t.Errorf("phpIniSiteName(site:personal) = (%q, %v), want (personal, true)", name, ok)
+	}
+	if _, ok := phpIniSiteName("8.5"); ok {
+		t.Error("a bare version must not parse as a site scope")
+	}
+
+	verFile := phpIniScopeFile("8.5").Path
+	if verFile != config.PHPUserIniFile("8.5") {
+		t.Errorf("version scope path = %q, want the per-version file", verFile)
+	}
+	siteFile := phpIniScopeFile("site:personal").Path
+	if siteFile != config.SitePHPUserIniFile("personal") {
+		t.Errorf("site scope path = %q, want the per-site file", siteFile)
+	}
+	if verFile == siteFile {
+		t.Error("version and site scopes must resolve to different files")
+	}
+	if !strings.Contains(siteFile, "/sites/personal/") {
+		t.Errorf("site scope path %q should be under the per-site dir", siteFile)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -3762,7 +3762,14 @@ func handlePHPVersionAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	version, action := parts[0], parts[1]
-	if !validVersion.MatchString(version) {
+	// The php.ini editor (config) also accepts a "site:<name>" scope for a
+	// FrankenPHP site's own per-site ini; every other action is version-only.
+	isSiteScope := strings.HasPrefix(version, "site:")
+	if isSiteScope && action != "config" {
+		http.NotFound(w, r)
+		return
+	}
+	if !isSiteScope && !validVersion.MatchString(version) {
 		http.NotFound(w, r)
 		return
 	}

--- a/internal/ui/web/src/modals/SiteNginxModal.svelte
+++ b/internal/ui/web/src/modals/SiteNginxModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Modal from '$components/Modal.svelte';
   import SiteNginxTab from '$tabs/sites/SiteNginxTab.svelte';
+  import PhpIniTab from '$tabs/system/PhpIniTab.svelte';
   import { type Site } from '$stores/sites';
   import { modal } from '$stores/modals';
   import { m } from '../paraglide/messages.js';
@@ -14,6 +15,14 @@
   }
   let { site, domain, open, onclose }: Props = $props();
 
+  // FrankenPHP sites run their own container instead of the shared FPM pool, so
+  // their php.ini isn't reachable from the System → PHP per-version editor the
+  // way FPM users edit it. Surface that same per-version editor here as a second
+  // tab; the FrankenPHP container mounts the shared 98-lerd-user.ini, so edits
+  // apply to it after the save restarts the container.
+  const showPhpIni = $derived(site.runtime === 'frankenphp' && Boolean(site.php_version));
+  let tab = $state<'nginx' | 'phpini'>('nginx');
+
   // Save/Restore/Reset open their own confirm modal on top of this one via
   // the shared modal store. While one is up it owns Escape and the backdrop,
   // so don't let the editor close out from under it and discard the buffer.
@@ -21,12 +30,32 @@
     if ($modal.kind) return;
     onclose();
   }
+
+  const tabBtn = (id: 'nginx' | 'phpini') =>
+    'px-3 py-1.5 text-xs font-medium border-b-2 transition-colors ' +
+    (tab === id
+      ? 'border-lerd-red text-lerd-red'
+      : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300');
 </script>
 
 <Modal {open} title={m.sites_nginx_modalTitle({ domain })} onclose={handleClose} size="xl">
   <div class="h-[70vh] flex flex-col overflow-hidden rounded-b-xl">
-    {#key domain}
-      <SiteNginxTab {site} {domain} onSaved={onclose} />
-    {/key}
+    {#if showPhpIni}
+      <div class="flex gap-1 px-3 pt-1 border-b border-gray-200 dark:border-gray-700 shrink-0">
+        <button class={tabBtn('nginx')} onclick={() => (tab = 'nginx')}>Nginx</button>
+        <button class={tabBtn('phpini')} onclick={() => (tab = 'phpini')}>php.ini</button>
+      </div>
+    {/if}
+    <div class="flex-1 min-h-0 overflow-hidden">
+      {#if showPhpIni && tab === 'phpini'}
+        <!-- Per-site scope: a FrankenPHP site has its own php.ini, edited via the
+             same per-version editor keyed by a "site:<name>" scope token. -->
+        <PhpIniTab version={`site:${site.name}`} />
+      {:else}
+        {#key domain}
+          <SiteNginxTab {site} {domain} onSaved={onclose} />
+        {/key}
+      {/if}
+    </div>
   </div>
 </Modal>

--- a/internal/ui/web/src/tabs/sites/SiteHeader.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteHeader.svelte
@@ -56,10 +56,11 @@
   let overflowOpen = $state(false);
   let overflowEl: HTMLDivElement | null = $state(null);
 
-  // Xdebug toggles the shared FPM image for this site's PHP version. Only PHP
-  // sites on the shared FPM runtime have it (not FrankenPHP or containers).
+  // Xdebug toggles the per-version xdebug ini, which both the shared FPM image
+  // and a FrankenPHP site's own container mount, so the toggle applies to
+  // FrankenPHP sites too. Custom (non-PHP) containers have no xdebug.
   const showXdebug = $derived(
-    Boolean(site.uses_php) && !site.custom_container && site.runtime !== 'frankenphp'
+    Boolean(site.uses_php) && !site.custom_container
   );
   const xdebugFpm = $derived(
     site.php_version ? $status.php_fpms.find((f) => f.version === site.php_version) : undefined


### PR DESCRIPTION
A FrankenPHP site used to run the stock dunglas/frankenphp image with none of the extensions the FPM image carries, so redis, gd, the database drivers, intl and the rest were missing, and the debug tooling never reached a request Octane served. lerd now builds a derived image FROM the dunglas base that bakes the same runtime extension set the FPM image ships plus any globally configured extensions and packages, compiled for the thread-safe runtime, with pcntl and nodejs baked in so the container boots straight into Octane instead of installing them at startup. The image carries a Containerfile hash label so it rebuilds when the definition or the lerd_devtools source changes, on lerd update or via lerd php:rebuild.

The per-request debug tooling now works for FrankenPHP too. The container mounts the same dump bridge, the lerd_devtools extension behind the Debug window, and the Xdebug config, so dump() and dd(), the query/job/view/mail/event/http capture, and the Xdebug toggle all apply to a FrankenPHP site and land in the dashboard exactly as they do under FPM. php.ini is editable per site for FrankenPHP, since each site has its own container, from a new php.ini tab in the site config modal that edits a site-scoped file and restarts only that container; it reuses the existing per-version editor through a scope token so backups, reset and restore carry over. CLI tooling, bun and Pest browser testing already worked because they exec into the shared FPM container, which stays the home for those.

SPX is the one tool that stays FPM-only. It profiles per request and cannot hook Octane resident workers, so it is left out of the FrankenPHP image, and the docs spell out that it is the only unsupported feature.