### PR TITLE
Fix regressions and bugs found reviewing the post-1.24.1 work

### DIFF
--- a/internal/cli/idle_engine.go
+++ b/internal/cli/idle_engine.go
@@ -35,10 +35,39 @@ func SuspendWorkersForIdle(site *config.Site) []string {
 		if w == "vite" && !viteSleepable {
 			continue // no usable build; keep vite running so the page isn't broken
 		}
+		if !idleWorkerResumable(site, w) {
+			// An orphaned unit (no framework definition) can't be brought back by
+			// ResumeWorkersForIdle, so leave it running rather than strand it
+			// suspended forever. collectRunningWorkers includes such orphans.
+			continue
+		}
 		stopWorkerByName(site, w)
 		suspended = append(suspended, w)
 	}
 	return suspended
+}
+
+// idleWorkerResumable reports whether ResumeWorkersForIdle (resumeWorkerByName)
+// can bring a worker back. Idle-suspend must never stop a worker it can't
+// restart, or the worker is stranded suspended forever. Mirrors the branches of
+// resumeWorkerByName so the two stay in lockstep.
+func idleWorkerResumable(site *config.Site, workerName string) bool {
+	switch workerName {
+	case "stripe":
+		return true
+	case hostProxyWorkerName:
+		// resumeWorkerByName only restarts the host-proxy worker when the project
+		// still declares a proxy command; without this guard a site whose proxy
+		// block was removed would be suspended but never resumed.
+		proj, _ := config.LoadProjectConfig(site.Path)
+		return proj != nil && proj.Proxy != nil
+	}
+	fw, ok := config.GetFrameworkForDir(site.Framework, site.Path)
+	if !ok || fw.Workers == nil {
+		return false
+	}
+	_, ok = fw.Workers[workerName]
+	return ok
 }
 
 // ResumeWorkersForIdle restarts workers previously suspended by idle-suspend.

--- a/internal/cli/idle_test.go
+++ b/internal/cli/idle_test.go
@@ -1,9 +1,63 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/geodro/lerd/internal/config"
 )
+
+// idleWorkerResumable must mirror resumeWorkerByName exactly: a worker the resume
+// path can't bring back (an orphaned unit with no framework definition) must be
+// reported non-resumable so idle-suspend never strands it stopped.
+func TestIdleWorkerResumable(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	dir := filepath.Join(tmp, "site")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	proj, err := config.LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proj.CustomWorkers = map[string]config.FrameworkWorker{
+		"queue": {Command: "php artisan queue:work"},
+	}
+	proj.Proxy = &config.ProxyConfig{Command: "npm run dev", Port: 5173}
+	if err := config.SaveProjectConfig(dir, proj); err != nil {
+		t.Fatal(err)
+	}
+
+	site := &config.Site{Name: "site", Framework: "laravel", Path: dir}
+	cases := map[string]bool{
+		"queue":             true,  // framework worker
+		"stripe":            true,  // handled explicitly by resumeWorkerByName
+		hostProxyWorkerName: true,  // resumable while the project declares a proxy
+		"some-orphan-unit":  false, // no framework definition -> not resumable
+	}
+	for name, want := range cases {
+		if got := idleWorkerResumable(site, name); got != want {
+			t.Errorf("idleWorkerResumable(%q) = %v, want %v", name, got, want)
+		}
+	}
+
+	// With the proxy block removed, the host-proxy worker is no longer resumable
+	// (resumeWorkerByName would no-op), so idle-suspend must not stop it.
+	proj.Proxy = nil
+	if err := config.SaveProjectConfig(dir, proj); err != nil {
+		t.Fatal(err)
+	}
+	if idleWorkerResumable(site, hostProxyWorkerName) {
+		t.Error("host-proxy worker must be non-resumable when the project has no proxy block")
+	}
+}
 
 func TestCompactDuration(t *testing.T) {
 	cases := []struct {

--- a/internal/cli/node_manage.go
+++ b/internal/cli/node_manage.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 
 	"github.com/geodro/lerd/internal/config"
+	gitpkg "github.com/geodro/lerd/internal/git"
 	nodeDet "github.com/geodro/lerd/internal/node"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
@@ -161,6 +162,35 @@ func RegenerateHostWorkersForSite(s config.Site) {
 			continue
 		}
 		regenerateWorkerUnit(s.Name, s.Path, phpVersion, w, wDef, "lerd-"+w+"-"+s.Name)
+	}
+	// A site's git worktrees run their own per-worktree host workers (e.g. Vite)
+	// under suffixed units; regenerate those too so a runtime toggle reaches a
+	// worktree's dev server instead of leaving it on the old runtime.
+	regenerateWorktreeHostWorkers(&s, fw, phpVersion)
+}
+
+// regenerateWorktreeHostWorkers rewrites and restarts (only when changed) the
+// per-worktree host worker units of a site, the worktree analogue of the main
+// loop in RegenerateHostWorkersForSite. Idle-suspended worktree workers are left
+// down (regenerateWorkerUnit also skips any unit that isn't enabled).
+func regenerateWorktreeHostWorkers(site *config.Site, fw *config.Framework, phpVersion string) {
+	wts, err := gitpkg.DetectWorktrees(site.Path, site.PrimaryDomain())
+	if err != nil {
+		return
+	}
+	for _, wt := range wts {
+		if wt.Path == site.Path {
+			continue // the main checkout, handled by the caller
+		}
+		wtBase := config.WorktreeUnitSlug(filepath.Base(wt.Path))
+		names := worktreeWorkersToStart(site, wtBase, OptedInHostWorkers(site, wt.Path))
+		for _, name := range names {
+			wDef, ok := fw.Workers[name]
+			if !ok {
+				continue
+			}
+			regenerateWorkerUnit(site.Name, wt.Path, phpVersion, name, wDef, "lerd-"+name+"-"+site.Name+"-"+wtBase)
+		}
 	}
 }
 

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -462,8 +462,15 @@ func stopWorkerByName(site *config.Site, workerName string) {
 	WorkerStopForSite(site.Name, site.Path, workerName) //nolint:errcheck
 }
 
-// resumeWorkerByName restarts a single named worker for the site.
+// resumeWorkerByName restarts a single named worker for the site. It gates on
+// idleWorkerResumable so the set of workers it can bring back is identical to the
+// set idle-suspend is allowed to stop — keeping the two in lockstep means a
+// worker can never be suspended-but-unresumable (stranded). A new resumable
+// worker kind must be taught to idleWorkerResumable or this gate blocks it.
 func resumeWorkerByName(site *config.Site, workerName, phpVersion string) {
+	if !idleWorkerResumable(site, workerName) {
+		return
+	}
 	if workerName == "stripe" {
 		scheme := "http"
 		if site.Secured {

--- a/internal/cli/php_ext.go
+++ b/internal/cli/php_ext.go
@@ -75,7 +75,7 @@ func newPhpExtAddCmd() *cobra.Command {
 				return fmt.Errorf("extension %q was not installed (config reverted): %w", ext, err)
 			}
 
-			restartFPMUnit(version)
+			applyPHPImageChange(version)
 
 			fmt.Printf("Extension %q installed for PHP %s.\n", ext, version)
 			return nil
@@ -115,7 +115,7 @@ func newPhpExtRemoveCmd() *cobra.Command {
 				return err
 			}
 
-			restartFPMUnit(version)
+			applyPHPImageChange(version)
 
 			fmt.Printf("Extension %q removed for PHP %s.\n", ext, version)
 			return nil

--- a/internal/cli/php_pkg.go
+++ b/internal/cli/php_pkg.go
@@ -84,7 +84,7 @@ func newPhpPkgAddCmd() *cobra.Command {
 				return fmt.Errorf("rebuild failed (config reverted): %w", err)
 			}
 
-			restartFPMUnit(version)
+			applyPHPImageChange(version)
 			fmt.Printf("Packages installed for PHP %s.\n", version)
 			return nil
 		},
@@ -119,7 +119,7 @@ func newPhpPkgRemoveCmd() *cobra.Command {
 			if err := podman.RebuildFPMImage(version, false); err != nil {
 				return err
 			}
-			restartFPMUnit(version)
+			applyPHPImageChange(version)
 			fmt.Printf("Packages removed for PHP %s.\n", version)
 			return nil
 		},

--- a/internal/cli/php_rebuild.go
+++ b/internal/cli/php_rebuild.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
@@ -48,6 +49,57 @@ func frankenPHPRebuildTargets(requested []string) (versions []string, units []fr
 		units = append(units, frankenRestart{unit: podman.FrankenPHPContainerName(s.Name), version: v})
 	}
 	return versions, units
+}
+
+// rebuildFrankenPHPForVersion rebuilds and restarts the derived FrankenPHP image
+// for any non-paused FrankenPHP site on this version. php:ext/php:pkg changes
+// rebuild the FPM image directly; without this, the same change would silently
+// never reach Octane (FrankenPHP) sites until an explicit php:rebuild. The hash
+// now tracks the custom exts/packages, so a force-less rebuild detects the drift
+// and is a no-op when nothing actually changed. A FrankenPHP build failure is
+// only warned about: the change is already live under FPM and config stays
+// committed, so reverting it here would undo the successful FPM install too.
+func rebuildFrankenPHPForVersion(version string) {
+	versions, units := frankenPHPRebuildTargets([]string{version})
+	if len(versions) == 0 {
+		return
+	}
+	for _, v := range versions {
+		fmt.Printf("Rebuilding FrankenPHP %s image so the change reaches Octane sites...\n", v)
+		if err := podman.BuildFrankenPHPImage(v, false, os.Stdout); err != nil {
+			fmt.Printf("[WARN] rebuild FrankenPHP %s image: %v\n", v, err)
+			fmt.Printf("       the change is live under FPM; run 'lerd php:rebuild %s' to retry the Octane image\n", v)
+			return
+		}
+	}
+	restartFrankenPHPUnits(units)
+}
+
+// applyPHPImageChange propagates a freshly-rebuilt FPM image for a version to
+// every runtime: it restarts the shared FPM container and rebuilds/restarts any
+// FrankenPHP (Octane) site on that version. All php:ext/php:pkg handlers funnel
+// through here after their FPM rebuild, so none can forget the FrankenPHP step
+// and silently leave Octane sites on the old extension/package set.
+func applyPHPImageChange(version string) {
+	restartFPMUnit(version)
+	rebuildFrankenPHPForVersion(version)
+}
+
+// restartFrankenPHPUnits restarts each FrankenPHP container onto its freshly
+// built image, skipping any whose image isn't present so a failed build doesn't
+// bounce a running container onto a missing image.
+func restartFrankenPHPUnits(units []frankenRestart) {
+	for _, u := range units {
+		if podman.RunSilent("image", "exists", podman.FrankenPHPImageName(u.version)) != nil {
+			fmt.Printf("  [WARN] %s: image not built, leaving container as-is\n", u.unit)
+			continue
+		}
+		if err := podman.RestartUnit(u.unit); err != nil {
+			fmt.Printf("  [WARN] restart %s: %v\n", u.unit, err)
+		} else {
+			fmt.Printf("  restarted %s\n", u.unit)
+		}
+	}
 }
 
 // NewPhpRebuildCmd returns the php:rebuild command.
@@ -103,20 +155,7 @@ func runPhpRebuild(cmd *cobra.Command, args []string) error {
 	}
 	RunParallel(jobs) //nolint:errcheck — individual failures printed by RunParallel
 
-	for _, u := range fpUnits {
-		// Skip restart if the (force) rebuild left no image, so we don't bounce a
-		// running container onto a missing image; a failed build was already
-		// reported by RunParallel.
-		if podman.RunSilent("image", "exists", podman.FrankenPHPImageName(u.version)) != nil {
-			fmt.Printf("  [WARN] %s: image not built, leaving container as-is\n", u.unit)
-			continue
-		}
-		if err := podman.RestartUnit(u.unit); err != nil {
-			fmt.Printf("  [WARN] restart %s: %v\n", u.unit, err)
-		} else {
-			fmt.Printf("  restarted %s\n", u.unit)
-		}
-	}
+	restartFrankenPHPUnits(fpUnits)
 
 	// Store the new Containerfile hash so future updates know images are current.
 	if err := podman.StoreFPMHash(); err != nil {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -64,6 +64,14 @@ func runRuntime(cmd *cobra.Command, args []string) error {
 		}
 		return switchToFPM(site)
 	case "frankenphp":
+		// dunglas/frankenphp only publishes images for PHP >= 8.2; without this
+		// guard the build would normalize the version up (e.g. 8.1 -> 8.5) and
+		// silently run a different PHP than the site reports, with its ini files
+		// still mounted from the old version's path.
+		if !config.IsFrankenPHPVersion(site.PHPVersion) {
+			return fmt.Errorf("FrankenPHP requires PHP %s or newer; this site is on PHP %s — bump it first with 'lerd isolate %s' (or higher)",
+				config.FrankenPHPMinVersion, site.PHPVersion, config.FrankenPHPMinVersion)
+		}
 		fw, ok := config.GetFrameworkForDir(site.Framework, site.Path)
 		if !ok {
 			return fmt.Errorf("site has no framework assigned — FrankenPHP needs a framework entrypoint or the generic public/ fallback")

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -578,6 +578,12 @@ func runStart(_ *cobra.Command, _ []string) error {
 	workerUnits = append(workerUnits, registeredFrameworkWorkerUnits()...)
 	workerUnits = append(workerUnits, registeredTimerUnits()...)
 	workerUnits = collapseTimerSiblings(dedupeStrings(workerUnits))
+	// Don't resurrect workers the idle engine has gracefully suspended. Without
+	// this, a boot or a manual start after stop would start a deliberately-asleep
+	// worker while the registry still records it suspended, drifting the dashboard
+	// (site shown asleep, workers actually running) and making workerheal skip it.
+	// Mirrors the worktree autostart filter; real activity wakes it via the engine.
+	workerUnits = dropIdleSuspendedUnits(workerUnits)
 
 	fmt.Println("Starting Lerd...")
 
@@ -1035,6 +1041,52 @@ func registeredFrameworkWorkerUnits() []string {
 		if s.IsHostProxy() && proj.Proxy != nil && proj.Proxy.Command != "" {
 			out = append(out, hostProxyWorkerUnit(s.Name))
 		}
+	}
+	return out
+}
+
+// suspendedWorkerUnitSet returns the worker unit names (without any .timer
+// suffix) the idle engine currently has suspended across all sites, covering
+// both main-site workers (lerd-{worker}-{site}) and per-worktree workers
+// (lerd-{worker}-{site}-{wtslug}). Naming matches workerNames.
+func suspendedWorkerUnitSet() map[string]bool {
+	reg, err := config.LoadSites()
+	if err != nil || reg == nil {
+		return nil
+	}
+	out := map[string]bool{}
+	for _, s := range reg.Sites {
+		for _, w := range s.IdleSuspendedWorkers {
+			out["lerd-"+w+"-"+s.Name] = true
+		}
+		for wtBase, workers := range s.WorktreeIdleSuspended {
+			for _, w := range workers {
+				out["lerd-"+w+"-"+s.Name+"-"+wtBase] = true
+			}
+		}
+	}
+	return out
+}
+
+// dropIdleSuspendedUnits removes idle-suspended worker units from a start list,
+// matching on the unit name with any .timer suffix stripped so a suspended
+// scheduled worker's timer is dropped too.
+func dropIdleSuspendedUnits(units []string) []string {
+	return filterSuspendedUnits(units, suspendedWorkerUnitSet())
+}
+
+// filterSuspendedUnits is the pure filter behind dropIdleSuspendedUnits: it
+// removes any unit whose .timer-stripped name is in suspended.
+func filterSuspendedUnits(units []string, suspended map[string]bool) []string {
+	if len(suspended) == 0 {
+		return units
+	}
+	out := make([]string, 0, len(units))
+	for _, u := range units {
+		if suspended[strings.TrimSuffix(u, ".timer")] {
+			continue
+		}
+		out = append(out, u)
 	}
 	return out
 }

--- a/internal/cli/startstop_test.go
+++ b/internal/cli/startstop_test.go
@@ -38,6 +38,62 @@ func TestRegisteredFrameworkWorkerUnits_EnumeratesDriftedHostProxy(t *testing.T)
 	}
 }
 
+func TestFilterSuspendedUnits(t *testing.T) {
+	suspended := map[string]bool{
+		"lerd-queue-site":          true,
+		"lerd-schedule-site":       true,
+		"lerd-vite-site-feature-x": true,
+	}
+	units := []string{
+		"lerd-queue-site",          // suspended -> dropped
+		"lerd-schedule-site.timer", // suspended (timer sibling) -> dropped
+		"lerd-reverb-site",         // running -> kept
+		"lerd-vite-site-feature-x", // suspended worktree worker -> dropped
+		"lerd-queue-other",         // different site -> kept
+	}
+	got := filterSuspendedUnits(units, suspended)
+	want := []string{"lerd-reverb-site", "lerd-queue-other"}
+	if len(got) != len(want) {
+		t.Fatalf("filterSuspendedUnits = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("filterSuspendedUnits[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	// No suspended set is a passthrough.
+	if out := filterSuspendedUnits(units, nil); len(out) != len(units) {
+		t.Errorf("nil suspended set should be a passthrough, got %v", out)
+	}
+}
+
+// A site with idle-suspended workers must not have those workers (or a suspended
+// worktree worker) resurrected by the start path, so lerd start doesn't drift the
+// registry's suspend state apart from what is actually running.
+func TestSuspendedWorkerUnitSet_CoversMainAndWorktree(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := config.AddSite(config.Site{
+		Name: "site", Domains: []string{"site.test"}, Path: t.TempDir(),
+		IdleSuspendedWorkers:  []string{"queue", "schedule"},
+		WorktreeIdleSuspended: map[string][]string{"feature-x": {"vite"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	set := suspendedWorkerUnitSet()
+	for _, want := range []string{"lerd-queue-site", "lerd-schedule-site", "lerd-vite-site-feature-x"} {
+		if !set[want] {
+			t.Errorf("suspended set missing %q: %v", want, set)
+		}
+	}
+	// And the start filter actually drops them.
+	start := []string{"lerd-queue-site", "lerd-schedule-site.timer", "lerd-vite-site-feature-x", "lerd-reverb-site"}
+	got := dropIdleSuspendedUnits(start)
+	if len(got) != 1 || got[0] != "lerd-reverb-site" {
+		t.Errorf("dropIdleSuspendedUnits kept %v, want only lerd-reverb-site", got)
+	}
+}
+
 func TestQuadletImage_found(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/cli/xdebug_pause.go
+++ b/internal/cli/xdebug_pause.go
@@ -52,6 +52,9 @@ func runXdebugPause(args []string, pid int, list bool) error {
 		return fmt.Errorf("`lerd xdebug pause` is only available on PHP-FPM sites; %q runs its own container without xdebugctl", site.Name)
 	}
 	version := pauseSiteVersion(site)
+	if version == "" {
+		return fmt.Errorf("could not determine the PHP version for %q — set it with `lerd isolate <version>` first", site.Name)
+	}
 	container := resolveWorkerFPMUnit(site.Name, version)
 	if container == "" {
 		return fmt.Errorf("site %q runs no container to attach to", site.Name)
@@ -180,6 +183,11 @@ func procsForSite(procs []xdebugProc, sitePath string) []xdebugProc {
 // ensureXdebugctl confirms the baked-in xdebugctl binary is present in the
 // container. It ships in the FPM image; an older image won't have it.
 func ensureXdebugctl(container string) (string, error) {
+	// Distinguish a stopped container from a genuinely missing binary: exec fails
+	// either way, but the fix differs (start the site vs rebuild the image).
+	if running, _ := podman.ContainerRunning(container); !running {
+		return "", fmt.Errorf("container %s is not running — start the site (and its worker or CLI script) first, then retry", container)
+	}
 	if podman.Cmd("exec", container, "test", "-x", xdebugctlInContainer).Run() == nil {
 		return xdebugctlInContainer, nil
 	}

--- a/internal/logsource/read.go
+++ b/internal/logsource/read.go
@@ -67,14 +67,25 @@ func Read(src Source, opts Opts) (Result, error) {
 	return Result{}, fmt.Errorf("unsupported log source kind %d", src.Kind)
 }
 
+// fileScanCap bounds the entries parsed when a filter is active. The real bound
+// is the byte tail ParseFile reads (applog.MaxReadBytes); this only has to be
+// high enough never to drop an entry that fits in that window, so it is sized to
+// the byte cap (one entry per byte being the theoretical maximum). Passing 0
+// here instead would make ParseFile read the entire file uncapped, risking an
+// OOM on a multi-hundred-MB log.
+const fileScanCap = applog.MaxReadBytes
+
 func readFile(src Source, opts Opts) (Result, error) {
 	structured := src.Format == "monolog" || src.Format == "laravel"
 
-	// When any filter is active, scan the whole capped tail rather than just the
-	// last N raw entries, so matches further back aren't missed.
+	// When a filter that needs to look past the last N entries is active, scan
+	// the whole capped tail. Level and time filters only apply to structured
+	// formats (see below), so for a raw source they don't widen the scan — a bare
+	// last-N read is correct there and avoids reading the whole tail for nothing.
+	needScan := opts.Grep != "" || (structured && (opts.Level != "" || opts.Since != "" || opts.Until != ""))
 	readCount := opts.Lines
-	if opts.Grep != "" || opts.Level != "" || opts.Since != "" || opts.Until != "" {
-		readCount = 0
+	if needScan {
+		readCount = fileScanCap
 	}
 	entries, err := applog.ParseFile(src.Locator, src.Format, readCount) // newest first
 	if err != nil {
@@ -99,7 +110,10 @@ func readFile(src Source, opts Opts) (Result, error) {
 		}
 		if structured && (sinceOK || untilOK) {
 			if t, ok := parseEntryTime(e.Date); ok {
-				if sinceOK && t.Before(since) {
+				// since is exclusive so polling with a returned Cursor yields only
+				// newer lines rather than re-emitting the boundary entry (and every
+				// other entry sharing its whole-second timestamp) on each call.
+				if sinceOK && !t.After(since) {
 					continue
 				}
 				if untilOK && t.After(until) {

--- a/internal/logsource/read_test.go
+++ b/internal/logsource/read_test.go
@@ -123,9 +123,61 @@ func TestRead_File_CursorAdvances(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Read poll: %v", err)
 	}
-	// Only the boundary (newest) entry remains, not the whole file again.
-	if len(second.Entries) != 1 || !contains(second.Entries[0].Text, "table missing") {
-		t.Fatalf("polling with cursor should narrow to the newest entry, got %d: %+v", len(second.Entries), second.Entries)
+	// No new lines were written, so polling with the cursor returns nothing — the
+	// boundary entry is not re-emitted (since is exclusive of the cursor instant).
+	if len(second.Entries) != 0 {
+		t.Fatalf("polling with cursor and no new lines should return 0 entries, got %d: %+v", len(second.Entries), second.Entries)
+	}
+
+	// A line newer than the cursor is delivered; an appended same-second sibling
+	// of an already-seen line is not (the cursor only resolves to the second).
+	appended := monologFixture + "[2026-06-11 10:20:00] local.INFO: fresh line\n"
+	if err := os.WriteFile(src.Locator, []byte(appended), 0644); err != nil {
+		t.Fatalf("append fixture: %v", err)
+	}
+	third, err := Read(src, Opts{Lines: 10, Since: first.Cursor})
+	if err != nil {
+		t.Fatalf("Read poll after append: %v", err)
+	}
+	if len(third.Entries) != 1 || !contains(third.Entries[0].Text, "fresh line") {
+		t.Fatalf("polling after a new line should return just that line, got %d: %+v", len(third.Entries), third.Entries)
+	}
+}
+
+// A large structured log with a grep filter must not be read in full: ParseFile
+// is byte-capped at applog.MaxReadBytes, and the filtered path must keep that cap
+// rather than reading the whole file into memory.
+func TestRead_File_FilteredReadIsByteCapped(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < 40000; i++ { // well over MaxReadBytes once rendered
+		b.WriteString("[2026-06-11 10:00:00] local.INFO: noise line padding padding padding padding\n")
+	}
+	b.WriteString("[2026-06-11 23:59:59] local.ERROR: needle in the recent tail\n")
+	src := monologSource(t, b.String())
+
+	res, err := Read(src, Opts{Lines: 10, Grep: "needle"})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !res.Truncated {
+		t.Errorf("a file larger than the byte cap should report Truncated")
+	}
+	if len(res.Entries) != 1 || !contains(res.Entries[0].Text, "needle") {
+		t.Fatalf("grep should find the needle in the capped tail, got %d: %+v", len(res.Entries), res.Entries)
+	}
+}
+
+// A level filter on a raw (non-structured) source can't apply, so it must not be
+// silently ignored by reading the whole file — it falls back to a plain last-N.
+func TestRead_RawFile_LevelIsBestEffortNoOp(t *testing.T) {
+	raw := "line one\nline two\nline three\n"
+	src := Source{Name: "raw", Kind: KindFile, Locator: writeFixture(t, raw), Format: "raw"}
+	res, err := Read(src, Opts{Lines: 2, Level: "error"})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(res.Entries) != 2 {
+		t.Fatalf("raw level filter should be a last-N no-op, got %d entries", len(res.Entries))
 	}
 }
 

--- a/internal/podman/frankenphp_build.go
+++ b/internal/podman/frankenphp_build.go
@@ -28,6 +28,15 @@ var frankenPHPRuntimeExtensions = []string{
 	"redis", "igbinary", "imagick", "mongodb",
 }
 
+// frankenPHPFlakyExtensions are the runtime extensions install-php-extensions
+// builds from PECL/source, which can fail on a brand-new PHP base before upstream
+// catches up. They (and any user custom extension) install tolerantly so one
+// failure degrades to "extension missing" instead of bricking the whole image,
+// mirroring the FPM build's per-PECL `|| true`.
+var frankenPHPFlakyExtensions = map[string]bool{
+	"redis": true, "igbinary": true, "imagick": true, "mongodb": true,
+}
+
 // frankenPHPContainerfileHashLabel stamps the derived image with the hash of the
 // Containerfile + extension list it was built from, so NeedsFrankenPHPRebuild can
 // tell an up-to-date image from one a newer lerd would build differently.
@@ -43,10 +52,12 @@ func FrankenPHPImageName(version string) string {
 	return "localhost/lerd-frankenphp" + strings.ReplaceAll(version, ".", "") + ":local"
 }
 
-// frankenPHPContainerfileHash hashes the embedded Containerfile template plus the
-// baked extension list, so a change to either drifts the hash and triggers a
-// rebuild after a lerd update.
-func frankenPHPContainerfileHash() (string, error) {
+// frankenPHPContainerfileHash hashes the embedded Containerfile template, the
+// baked standard extension list, the user-configured custom extensions and extra
+// packages, and the devtools source, so a change to any of them drifts the hash
+// and triggers a rebuild. The custom exts/packages are folded in so that a
+// `php:ext`/`php:pkg` change is detected as drift rather than silently skipped.
+func frankenPHPContainerfileHash(customExts, packages []string) (string, error) {
 	tmpl, err := GetQuadletTemplate("lerd-frankenphp.Containerfile")
 	if err != nil {
 		return "", err
@@ -57,20 +68,45 @@ func frankenPHPContainerfileHash() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	sum := sha256.Sum256([]byte(tmpl + "\n" + strings.Join(frankenPHPRuntimeExtensions, " ") + "\n" + dt))
+	parts := []string{
+		tmpl,
+		strings.Join(frankenPHPRuntimeExtensions, " "),
+		strings.Join(customExts, " "),
+		strings.Join(packages, " "),
+		dt,
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
 	return hex.EncodeToString(sum[:]), nil
+}
+
+// frankenPHPBuildInputs returns the custom extensions and the full package set
+// (each custom extension's apk build deps folded in) baked into the derived image
+// for a version, so the build and the staleness check hash the same inputs.
+func frankenPHPBuildInputs(cfg *config.GlobalConfig, version string) (exts, packages []string) {
+	exts = cfg.GetExtensions(version)
+	packages = cfg.GetPackages(version)
+	for _, ext := range exts {
+		packages = append(packages, cfg.GetExtApkDeps(ext)...)
+	}
+	return exts, packages
 }
 
 // NeedsFrankenPHPRebuild reports whether any active FrankenPHP version's derived
 // image is missing or stamped with a different Containerfile hash than the
-// current binary builds, so a lerd update that changes the template or extension
-// set rebuilds the image. False when nothing is stale.
+// current binary builds, so a lerd update (or a php:ext/php:pkg change) that
+// alters the template, extension set or packages rebuilds the image. False when
+// nothing is stale.
 func NeedsFrankenPHPRebuild(activeVersions []string) bool {
-	current, err := frankenPHPContainerfileHash()
+	cfg, err := config.LoadGlobal()
 	if err != nil {
 		return true
 	}
 	for _, v := range activeVersions {
+		exts, packages := frankenPHPBuildInputs(cfg, v)
+		current, err := frankenPHPContainerfileHash(exts, packages)
+		if err != nil {
+			return true
+		}
 		if imageLabelFn(FrankenPHPImageName(v), frankenPHPContainerfileHashLabel) != current {
 			return true
 		}
@@ -86,15 +122,12 @@ func BuildFrankenPHPImage(version string, force bool, w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	exts := cfg.GetExtensions(version)
-	packages := cfg.GetPackages(version)
 	// Custom extensions may need extra Alpine packages to compile;
 	// install-php-extensions only auto-resolves deps for extensions it knows, so
-	// fold the user-configured ext apk deps into the package set the way the FPM
-	// build does, otherwise a custom extension that builds on FPM fails here.
-	for _, ext := range exts {
-		packages = append(packages, cfg.GetExtApkDeps(ext)...)
-	}
+	// frankenPHPBuildInputs folds the user-configured ext apk deps into the
+	// package set the way the FPM build does, otherwise a custom extension that
+	// builds on FPM fails here.
+	exts, packages := frankenPHPBuildInputs(cfg, version)
 	return buildFrankenPHPImage(version, force, exts, packages, w)
 }
 
@@ -104,7 +137,7 @@ func buildFrankenPHPImage(version string, force bool, customExts, packages []str
 
 	// Compute the Containerfile hash once and use it for both the freshness check
 	// and the image label, instead of re-hashing via NeedsFrankenPHPRebuild.
-	hash, err := frankenPHPContainerfileHash()
+	hash, err := frankenPHPContainerfileHash(customExts, packages)
 	if err != nil {
 		return fmt.Errorf("hashing FrankenPHP Containerfile: %w", err)
 	}
@@ -168,12 +201,44 @@ func renderFrankenPHPContainerfile(version string, exts, packages []string, mkce
 	if err != nil {
 		return "", err
 	}
+	core, optional := splitFrankenPHPExtensions(exts)
 	cf := strings.ReplaceAll(tmpl, "{{.Version}}", version)
-	cf = strings.ReplaceAll(cf, "{{.Extensions}}", strings.Join(exts, " "))
+	cf = strings.ReplaceAll(cf, "{{.CoreExtensions}}", strings.Join(core, " "))
+	cf = strings.ReplaceAll(cf, "{{.OptionalExtensions}}", strings.Join(optional, " "))
 	cf = strings.ReplaceAll(cf, "{{.DevtoolsHash}}", dt)
 	cf = strings.ReplaceAll(cf, "{{.CustomPackages}}", buildCustomPackagesBlock(packages))
 	cf = strings.ReplaceAll(cf, "{{.MkcertCA}}", mkcertBlock)
 	return cf, nil
+}
+
+// splitFrankenPHPExtensions partitions the full extension list into a core set
+// installed in one hard step (a failure there is a real toolchain problem) and an
+// optional set installed one-at-a-time and tolerantly: the PECL-built runtime
+// extensions, any user custom extension, and xdebug, none of which should brick
+// the image when a single one can't build on a given base.
+func splitFrankenPHPExtensions(exts []string) (core, optional []string) {
+	runtime := make(map[string]bool, len(frankenPHPRuntimeExtensions))
+	for _, e := range frankenPHPRuntimeExtensions {
+		runtime[e] = true
+	}
+	hasXdebug := false
+	for _, e := range exts {
+		switch {
+		case runtime[e] && !frankenPHPFlakyExtensions[e]:
+			core = append(core, e)
+		default: // flaky runtime PECL extension or a user custom extension
+			optional = append(optional, e)
+			if e == "xdebug" {
+				hasXdebug = true
+			}
+		}
+	}
+	// xdebug is always baked, but skip the duplicate when the user already added
+	// it as a custom extension (otherwise the install loop runs it twice).
+	if !hasXdebug {
+		optional = append(optional, "xdebug")
+	}
+	return core, optional
 }
 
 // sanitizeExtNames keeps only well-formed extension tokens, dropping anything a

--- a/internal/podman/frankenphp_build_test.go
+++ b/internal/podman/frankenphp_build_test.go
@@ -3,6 +3,8 @@ package podman
 import (
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 // TestFrankenPHPRuntimeExtensionParity guards against the FPM image gaining a
@@ -116,7 +118,12 @@ func TestRenderFrankenPHPContainerfile(t *testing.T) {
 // imageLabelFn seam so a stale or missing image triggers a rebuild and a current
 // one does not.
 func TestNeedsFrankenPHPRebuild(t *testing.T) {
-	current, err := frankenPHPContainerfileHash()
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	exts, packages := frankenPHPBuildInputs(cfg, "8.4")
+	current, err := frankenPHPContainerfileHash(exts, packages)
 	if err != nil {
 		t.Fatalf("hash: %v", err)
 	}
@@ -140,6 +147,100 @@ func TestNeedsFrankenPHPRebuild(t *testing.T) {
 
 	if NeedsFrankenPHPRebuild(nil) {
 		t.Error("no active versions should never need a rebuild")
+	}
+}
+
+// TestFrankenPHPContainerfileHashTracksConfig guards the regression where a
+// php:ext / php:pkg change did not drift the image hash, so the staleness check
+// considered the image current and the new extension never reached Octane.
+func TestFrankenPHPContainerfileHashTracksConfig(t *testing.T) {
+	base, err := frankenPHPContainerfileHash(nil, nil)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	withExt, err := frankenPHPContainerfileHash([]string{"imap"}, nil)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	withPkg, err := frankenPHPContainerfileHash(nil, []string{"jq"})
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if base == withExt {
+		t.Error("adding a custom extension must change the hash")
+	}
+	if base == withPkg {
+		t.Error("adding a custom package must change the hash")
+	}
+	if withExt == withPkg {
+		t.Error("an extension and a package change must hash differently")
+	}
+}
+
+// TestSplitFrankenPHPExtensions checks the core set installs reliably while the
+// PECL-built runtime extensions, custom extensions, and xdebug are routed to the
+// tolerant optional set so one failure can't brick the image.
+func TestSplitFrankenPHPExtensions(t *testing.T) {
+	exts := append(append([]string{}, frankenPHPRuntimeExtensions...), "myext")
+	core, optional := splitFrankenPHPExtensions(exts)
+
+	in := func(set []string, v string) bool {
+		for _, s := range set {
+			if s == v {
+				return true
+			}
+		}
+		return false
+	}
+	for _, reliable := range []string{"gd", "pdo_mysql", "intl", "opcache"} {
+		if !in(core, reliable) || in(optional, reliable) {
+			t.Errorf("%q should be a core extension", reliable)
+		}
+	}
+	for _, flaky := range []string{"redis", "igbinary", "imagick", "mongodb", "myext", "xdebug"} {
+		if !in(optional, flaky) || in(core, flaky) {
+			t.Errorf("%q should be an optional (tolerant) extension", flaky)
+		}
+	}
+
+	// xdebug is always baked, but a user who added it as a custom extension must
+	// not get it installed twice.
+	_, optional = splitFrankenPHPExtensions([]string{"xdebug"})
+	xcount := 0
+	for _, e := range optional {
+		if e == "xdebug" {
+			xcount++
+		}
+	}
+	if xcount != 1 {
+		t.Errorf("xdebug should appear exactly once, got %d in %v", xcount, optional)
+	}
+}
+
+// TestFrankenPHPContainerfileToleratesOptionalFailures asserts the rendered build
+// keeps the optional extensions in a per-extension tolerant loop rather than one
+// hard install that a single unavailable extension would fail.
+func TestFrankenPHPContainerfileToleratesOptionalFailures(t *testing.T) {
+	exts := append(append([]string{}, frankenPHPRuntimeExtensions...), "myext")
+	cf, err := renderFrankenPHPContainerfile("8.4", exts, nil, "")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if !strings.Contains(cf, "for ext in") || !strings.Contains(cf, "install-php-extensions \"$ext\"") {
+		t.Errorf("optional extensions should install in a tolerant per-extension loop:\n%s", cf)
+	}
+	// The core install must not carry a flaky/custom extension that could fail it.
+	coreLine := ""
+	for _, ln := range strings.Split(cf, "\n") {
+		if strings.Contains(ln, "install-php-extensions {{") || strings.Contains(ln, "install-php-extensions ") && !strings.Contains(ln, "$ext") {
+			coreLine = ln
+			break
+		}
+	}
+	for _, flaky := range []string{"myext", "redis", "imagick", "mongodb"} {
+		if strings.Contains(coreLine, " "+flaky) {
+			t.Errorf("core install line should not include flaky/custom %q: %q", flaky, coreLine)
+		}
 	}
 }
 

--- a/internal/podman/quadlets/lerd-frankenphp.Containerfile
+++ b/internal/podman/quadlets/lerd-frankenphp.Containerfile
@@ -12,9 +12,16 @@ FROM docker.io/dunglas/frankenphp:php{{.Version}}-alpine
 
 # Runtime extensions + Xdebug. install-php-extensions (shipped in the base) builds
 # each for the ZTS runtime, pulls its runtime libs, and trims the build toolchain.
-# Xdebug loads but stays inert until its bind-mounted 99-xdebug.ini arms it,
-# exactly like the FPM image.
-RUN install-php-extensions {{.Extensions}} xdebug \
+# The core set installs in one step; the PECL-built extensions, any user custom
+# extension, and xdebug install one-at-a-time and tolerantly, so a single one that
+# can't build on this base degrades to "extension missing" instead of bricking the
+# whole image (mirroring the FPM build's per-PECL `|| true`). Xdebug loads but
+# stays inert until its bind-mounted 99-xdebug.ini arms it, like the FPM image.
+RUN install-php-extensions {{.CoreExtensions}} \
+    && for ext in {{.OptionalExtensions}}; do \
+         install-php-extensions "$ext" \
+           || echo "WARN: optional PHP extension $ext unavailable for PHP {{.Version}}, skipping"; \
+       done \
     && rm -rf /tmp/* /var/cache/apk/*
 
 # nodejs+npm so the Octane file-watcher (lerd octane:reload on) and JS tooling

--- a/internal/sitedoctor/sitedoctor.go
+++ b/internal/sitedoctor/sitedoctor.go
@@ -157,30 +157,41 @@ type envKeyUsage struct {
 	noDefault bool
 }
 
+// projectSkipDirs are directories the doctor's source scans never descend into.
+var projectSkipDirs = map[string]bool{"vendor": true, "node_modules": true, ".git": true, "storage": true}
+
+// walkProjectSource walks path and invokes onFile with the contents of every
+// file whose lowercased extension (without the dot) is in exts, skipping the
+// vendor/build/VCS dirs. Best-effort: walk and per-file read errors are ignored.
+func walkProjectSource(path string, exts map[string]bool, onFile func(data []byte)) {
+	filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if projectSkipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(d.Name())), ".")
+		if !exts[ext] {
+			return nil
+		}
+		if data, err := os.ReadFile(p); err == nil {
+			onFile(data)
+		}
+		return nil
+	})
+}
+
 // scanEnvUsage walks the project's PHP for env() reads (skipping vendor and
 // build dirs) and returns per-key usage plus the total calls found, so the
 // caller can fall back to warning on everything when the scan finds nothing.
 func scanEnvUsage(path string) (map[string]envKeyUsage, int) {
 	usage := map[string]envKeyUsage{}
 	total := 0
-	filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			switch d.Name() {
-			case "vendor", "node_modules", ".git", "storage":
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.HasSuffix(d.Name(), ".php") {
-			return nil
-		}
-		data, err := os.ReadFile(p)
-		if err != nil {
-			return nil
-		}
+	walkProjectSource(path, map[string]bool{"php": true}, func(data []byte) {
 		for _, m := range envCallRe.FindAllStringSubmatch(string(data), -1) {
 			total++
 			u := usage[m[1]]
@@ -189,21 +200,31 @@ func scanEnvUsage(path string) (map[string]envKeyUsage, int) {
 			}
 			usage[m[1]] = u
 		}
-		return nil
 	})
 	return usage, total
 }
 
 // classifyMissingEnvKeys splits missing keys into required (read with no
-// default, or VITE_-prefixed so the frontend build needs them) and optional
-// (read only with defaults, or unreferenced). No env() calls found, all required.
+// default, or a VITE_ key the frontend actually references) and optional (read
+// only with defaults, unreferenced, or a VITE_ key nothing in the JS uses). A
+// VITE_ key is judged by the frontend scan, not PHP env() usage, since Vite reads
+// it via import.meta.env; non-VITE keys fall back to "all required" when no
+// env() call is found at all.
 func classifyMissingEnvKeys(path string, missing []string) (required, optional []string) {
 	usage, total := scanEnvUsage(path)
+	var viteRefs map[string]bool
 	for _, k := range missing {
 		switch {
-		case total == 0:
-			required = append(required, k)
 		case strings.HasPrefix(k, "VITE_"):
+			if viteRefs == nil {
+				viteRefs = scanViteEnvRefs(path)
+			}
+			if viteRefs[k] {
+				required = append(required, k)
+			} else {
+				optional = append(optional, k)
+			}
+		case total == 0:
 			required = append(required, k)
 		case usage[k].noDefault:
 			required = append(required, k)
@@ -212,6 +233,30 @@ func classifyMissingEnvKeys(path string, missing []string) (required, optional [
 		}
 	}
 	return required, optional
+}
+
+// viteKeyRe matches a VITE_-prefixed env identifier referenced in frontend code.
+var viteKeyRe = regexp.MustCompile(`VITE_[A-Za-z0-9_]+`)
+
+// viteSourceExts are the frontend file types that can reference import.meta.env.
+var viteSourceExts = map[string]bool{
+	"js": true, "mjs": true, "cjs": true, "ts": true,
+	"jsx": true, "tsx": true, "vue": true, "svelte": true,
+}
+
+// scanViteEnvRefs walks the project's frontend source and returns the set of
+// VITE_ env keys it references. VITE_ vars are read in JS through
+// import.meta.env, never PHP env(), so a missing VITE_ key only matters when the
+// frontend uses it — this stops the doctor flagging a stale VITE_ entry in
+// .env.example that nothing reads.
+func scanViteEnvRefs(path string) map[string]bool {
+	refs := map[string]bool{}
+	walkProjectSource(path, viteSourceExts, func(data []byte) {
+		for _, m := range viteKeyRe.FindAllString(string(data), -1) {
+			refs[m] = true
+		}
+	})
+	return refs
 }
 
 // summariseKeys joins keys for a detail line, capping the list so a project

--- a/internal/sitedoctor/sitedoctor_test.go
+++ b/internal/sitedoctor/sitedoctor_test.go
@@ -74,11 +74,11 @@ func TestCheckEnvDrift_classifiesRequiredVsOptional(t *testing.T) {
 	dir := t.TempDir()
 	envPath := filepath.Join(dir, ".env")
 
-	writeEnv(t, dir, ".env.example", "APP_KEY=\nDB_HOST=\nLOG_LEVEL=\nVITE_THING=\nUNUSED_KEY=\n")
+	writeEnv(t, dir, ".env.example", "APP_KEY=\nDB_HOST=\nLOG_LEVEL=\nVITE_THING=\nVITE_STALE=\nUNUSED_KEY=\n")
 	writeEnv(t, dir, ".env", "") // every example key is missing
 
 	// config/ reads APP_KEY with no default (required) and the other two with
-	// defaults (optional). VITE_THING and UNUSED_KEY aren't read in PHP.
+	// defaults (optional). VITE_* and UNUSED_KEY aren't read in PHP.
 	mustMkdir(t, filepath.Join(dir, "config"))
 	writeEnv(t, dir, filepath.Join("config", "app.php"),
 		"<?php return [\n"+
@@ -87,16 +87,22 @@ func TestCheckEnvDrift_classifiesRequiredVsOptional(t *testing.T) {
 			"  'log' => env('LOG_LEVEL', 'debug'),\n"+
 			"];\n")
 
+	// The frontend references VITE_THING (required) but not VITE_STALE, a leftover
+	// .env.example entry nothing reads (optional, must not turn the row red).
+	mustMkdir(t, filepath.Join(dir, "resources", "js"))
+	writeEnv(t, dir, filepath.Join("resources", "js", "app.js"),
+		"const api = import.meta.env.VITE_THING;\nconsole.log(api);\n")
+
 	c, ok := checkEnvDrift(dir, envPath)
 	if !ok || c.Status != StatusWarn {
 		t.Fatalf("got ok=%v status=%q, want true/warn", ok, c.Status)
 	}
-	// Required: APP_KEY (no default) and VITE_THING (frontend prefix).
+	// Required: APP_KEY (no default) and VITE_THING (referenced in JS).
 	if !strings.Contains(c.Detail, "APP_KEY") || !strings.Contains(c.Detail, "VITE_THING") {
 		t.Errorf("detail should name required keys APP_KEY and VITE_THING, got %q", c.Detail)
 	}
-	// Optional keys must not be listed as required.
-	for _, opt := range []string{"DB_HOST", "LOG_LEVEL", "UNUSED_KEY"} {
+	// Optional keys (including an unreferenced VITE_ key) must not be required.
+	for _, opt := range []string{"DB_HOST", "LOG_LEVEL", "UNUSED_KEY", "VITE_STALE"} {
 		if strings.Contains(c.Detail, opt) {
 			t.Errorf("optional key %q should not appear in the required list: %q", opt, c.Detail)
 		}

--- a/internal/ui/dashproxy.go
+++ b/internal/ui/dashproxy.go
@@ -171,6 +171,12 @@ func rewriteLocation(loc, targetHost, prefix string) string {
 			return loc // points somewhere else entirely, leave it
 		}
 		loc = u.EscapedPath()
+		if loc == "" {
+			// A redirect to the upstream's bare origin (no path) must map to the
+			// mount root, not an empty Location that the browser resolves to a
+			// no-op reload of the current page.
+			loc = "/"
+		}
 		if u.RawQuery != "" {
 			loc += "?" + u.RawQuery
 		}

--- a/internal/ui/dashproxy_test.go
+++ b/internal/ui/dashproxy_test.go
@@ -82,6 +82,10 @@ func TestRewriteLocation(t *testing.T) {
 		"/_svc/rabbitmq/already":       "/_svc/rabbitmq/already",
 		"http://localhost:15672/login": "/_svc/rabbitmq/login",
 		"https://elsewhere.test/x":     "https://elsewhere.test/x",
+		// A redirect to the upstream's bare origin must land at the mount root,
+		// not become an empty Location (no-op reload).
+		"http://localhost:15672":          "/_svc/rabbitmq/",
+		"http://localhost:15672?next=/ui": "/_svc/rabbitmq/?next=/ui",
 	}
 	for in, want := range cases {
 		if got := rewriteLocation(in, "localhost:15672", "/_svc/rabbitmq"); got != want {

--- a/internal/ui/idle_engine.go
+++ b/internal/ui/idle_engine.go
@@ -172,12 +172,19 @@ func (e *idleEngine) tick() {
 // aren't suspended inside their first window.
 func (e *idleEngine) tickWorktrees(s *config.Site, enabled bool, timeout time.Duration, now time.Time, outPath, outDomain map[string]string) {
 	wts, err := detectWorktrees(s.Path, s.PrimaryDomain())
-	if err != nil || len(wts) == 0 {
+	if err != nil {
+		// Detection failed (transient git error): leave state alone rather than
+		// risk pruning a worktree that still exists.
 		return
 	}
+	// Track which worktree keys still exist so stale suspended state for a deleted
+	// worktree can be cleared below; a deleted worktree is never revisited
+	// otherwise and would show as suspended forever.
+	detected := make(map[string]bool, len(wts))
 	for _, wt := range wts {
 		wtBase := config.WorktreeUnitSlug(filepath.Base(wt.Path))
 		key := wtKey(s.Name, wtBase)
+		detected[key] = true
 		outPath[key] = wt.Path
 		if wt.Domain != "" {
 			outDomain[strings.ToLower(wt.Domain)] = key
@@ -204,6 +211,33 @@ func (e *idleEngine) tickWorktrees(s *config.Site, enabled bool, timeout time.Du
 			e.suspendWorktree(s.Name, wtBase, wt.Path)
 		case idle.ActionResume:
 			e.resumeWorktree(s.Name, wtBase, wt.Path)
+		}
+	}
+	e.pruneStaleWorktrees(s.Name, detected)
+}
+
+// pruneStaleWorktrees clears in-memory and persisted suspended state for the
+// site's worktrees that no longer exist (detected is the set of worktree keys
+// present this tick), so a removed worktree stops showing as suspended forever.
+func (e *idleEngine) pruneStaleWorktrees(siteName string, detected map[string]bool) {
+	e.mu.Lock()
+	var stale []string
+	for key, susp := range e.suspended {
+		site, _, isWt := splitWtKey(key)
+		if !isWt || site != siteName || !susp {
+			continue
+		}
+		if !detected[key] {
+			stale = append(stale, key)
+		}
+	}
+	for _, key := range stale {
+		delete(e.suspended, key)
+	}
+	e.mu.Unlock()
+	for _, key := range stale {
+		if _, wtBase, ok := splitWtKey(key); ok {
+			_ = config.SetWorktreeIdleSuspendedWorkers(siteName, wtBase, nil)
 		}
 	}
 }

--- a/internal/ui/idle_engine_test.go
+++ b/internal/ui/idle_engine_test.go
@@ -42,6 +42,48 @@ func TestTick_pinnedSiteStillTicksWorktrees(t *testing.T) {
 	}
 }
 
+// TestPruneStaleWorktrees clears suspended state for a worktree that no longer
+// exists while leaving a still-present one untouched, so a removed worktree stops
+// showing as suspended forever.
+func TestPruneStaleWorktrees(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := config.AddSite(config.Site{
+		Name: "myapp", Path: "/srv/myapp", PHPVersion: "8.4", Domains: []string{"myapp.test"},
+		WorktreeIdleSuspended: map[string][]string{"gone": {"vite"}, "alive": {"vite"}},
+	}); err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+
+	e := newIdleEngine(idle.NewTracker(nil))
+	goneKey := wtKey("myapp", "gone")
+	aliveKey := wtKey("myapp", "alive")
+	e.suspended[goneKey] = true
+	e.suspended[aliveKey] = true
+
+	// Only "alive" is detected this tick.
+	e.pruneStaleWorktrees("myapp", map[string]bool{aliveKey: true})
+
+	if e.suspended[goneKey] {
+		t.Error("deleted worktree should be pruned from the suspended map")
+	}
+	if !e.suspended[aliveKey] {
+		t.Error("still-present worktree must not be pruned")
+	}
+	reg, err := config.LoadSites()
+	if err != nil {
+		t.Fatalf("reload sites: %v", err)
+	}
+	s := reg.Sites[0]
+	if _, ok := s.WorktreeIdleSuspended["gone"]; ok {
+		t.Error("deleted worktree's persisted suspend slot should be cleared")
+	}
+	if _, ok := s.WorktreeIdleSuspended["alive"]; !ok {
+		t.Error("present worktree's persisted suspend slot must remain")
+	}
+}
+
 func TestWtKeyRoundTrip(t *testing.T) {
 	key := wtKey("myapp", "feature-x")
 	if key != "myapp/feature-x" {


### PR DESCRIPTION
A review of everything that landed after v1.24.1 surfaced a handful of regressions and latent bugs. This collects the fixes.

The MCP logs reader could load an entire multi-hundred-MB log into memory because a filtered fetch passed a zero entry count to ParseFile, which it read as no byte cap. Filtered reads now stay bounded to the same tail cap as unfiltered ones, the level and time filters no longer force a whole-file scan on raw sources where they cannot apply, and the since boundary is now exclusive so polling with a returned cursor returns only genuinely newer lines instead of re-emitting the last second on every call.

FrankenPHP saw the most. A php:ext or php:pkg change rebuilt only the FPM image, so the new extension or package silently never reached Octane sites; the derived FrankenPHP image is now rebuilt for any affected version and its content hash folds in the per-version custom extensions and packages so the staleness check notices the change. The extension install was a single hard step that one unbuildable extension would fail and brick the whole image, so the core set installs together while the PECL-built, custom, and xdebug extensions install one at a time and tolerantly. And lerd runtime frankenphp now refuses a site below PHP 8.2 rather than silently normalizing the version up and running a different PHP than the site reports.

Idle-suspend no longer drifts from reality. lerd start filters out workers the engine has suspended rather than resurrecting them while the registry still records them asleep, the engine prunes suspended state for worktrees that have since been deleted, and it never suspends a worker it has no way to bring back. A JS-runtime or bun toggle now also reaches a site's per-worktree dev workers, not just the main checkout.

The smaller fixes: the embedded-dashboard proxy maps an upstream redirect to its bare origin to the mount root instead of an empty Location header, the Laravel Doctor only flags a missing VITE_ key when the frontend actually references it, and lerd xdebug pause distinguishes a stopped container from a genuinely missing binary and rejects an unresolvable PHP version up front.

A few internals were also consolidated: the project-source walker, the FrankenPHP unit-restart loop, and the FPM-image-change propagation each live in one place now, and the idle resume path is the single authority on which workers are resumable.