### PR TITLE
fix: make .localhost mode consistent across init, secure, and the installer

### DIFF
--- a/docs/features/dns.md
+++ b/docs/features/dns.md
@@ -17,7 +17,7 @@ When DNS is disabled lerd will:
 - leave NetworkManager / `/etc/resolver` untouched
 - write its config with `dns.tld: localhost` so newly created sites use a TLD that the system resolver libraries hardwire to `127.0.0.1` per RFC 6761
 
-In this mode your sites are reachable at `http://<name>.localhost`. HTTPS is intentionally unavailable, the dashboard hides the per-site HTTPS toggle, `lerd secure` refuses with a clear message, and the API endpoint returns the same. `lerd dns:check` reports `DNS managed externally` instead of probing, the dashboard DNS panel shows a `disabled` pill, the System tab drops the DNS row, and the tray shows a muted dot for DNS so you do not get nagged that the container is missing.
+In this mode your sites are reachable at `http://<name>.localhost`. HTTPS is intentionally unavailable, the `lerd init` wizard skips the "Enable HTTPS?" question, the dashboard replaces the per-site HTTPS toggle with a muted lock icon that explains HTTPS needs lerd-managed DNS, `lerd secure` refuses with a clear message, and the API endpoint returns the same. `lerd dns:check` reports `DNS managed externally` instead of probing, the dashboard DNS panel shows a `disabled` pill, the System tab drops the DNS row, and the tray shows a muted dot for DNS so you do not get nagged that the container is missing.
 
 ## LAN exposure in disabled-DNS mode
 

--- a/docs/features/https.md
+++ b/docs/features/https.md
@@ -3,7 +3,7 @@
 Lerd uses [mkcert](https://github.com/FiloSottile/mkcert), a locally-trusted CA that your browser will accept without warnings.
 
 > [!NOTE]
-> HTTPS is only available when lerd is managing DNS. If you installed in disabled-DNS mode (`dns.enabled: false`, sites under `*.localhost`), the mkcert root CA was never installed, the per-site HTTPS toggle is hidden in the dashboard, and `lerd secure` refuses with `HTTPS requires lerd-managed DNS, set dns.enabled: true and re-run lerd install`. See [DNS](dns.md) for the toggle and how to switch back.
+> HTTPS is only available when lerd is managing DNS. If you installed in disabled-DNS mode (`dns.enabled: false`, sites under `*.localhost`), the mkcert root CA was never installed, the `lerd init` wizard skips the "Enable HTTPS?" question, the per-site HTTPS toggle in the dashboard becomes a muted lock icon, and `lerd secure` refuses with `HTTPS requires lerd-managed DNS, set dns.enabled: true and re-run lerd install`. See [DNS](dns.md) for the toggle and how to switch back.
 
 ```bash
 cd ~/Lerd/my-app

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -47,7 +47,7 @@ sudo dnf install crun
 :::
 
 - **`unzip`**: used during install to extract fnm
-- **`certutil` / `nss-tools`**: for mkcert to install the CA into Chrome/Firefox
+- **`certutil` / `nss-tools`**: for mkcert to install the CA into Chrome/Firefox. Only needed when lerd manages DNS for `.test` sites with HTTPS. If you pick the `.localhost` mode at install time the installer skips this package, so immutable hosts like Fedora Silverblue don't need to layer it.
     - Arch: `nss`
     - Debian/Ubuntu: `libnss3-tools`
     - Fedora: `nss-tools`

--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,32 @@ distro_family() {
 # ── Prerequisite checks ──────────────────────────────────────────────────────
 MISSING_PKGS=()
 
+# DNS mode chosen by the user before prerequisites are checked. "managed" runs
+# lerd's dnsmasq + mkcert so sites resolve at https://<name>.test with trusted
+# certs; "localhost" skips all of that and serves http://<name>.localhost over
+# plain HTTP. The choice is passed straight to `lerd install --dns` so the
+# prompt isn't shown twice, and it lets us skip the HTTPS-only packages
+# (certutil / nss-tools) when the user only wants .localhost.
+DNS_MODE="managed"
+
+ask_dns_mode() {
+  local _ans=""
+  header "DNS mode"
+  echo "  lerd can manage local DNS so sites resolve at https://<name>.test with"
+  echo "  trusted certificates, or stay out of the way and serve them at"
+  echo "  http://<name>.localhost over plain HTTP. The .localhost mode needs no"
+  echo "  dnsmasq, no mkcert, and no extra packages."
+  echo ""
+  echo -en "  ${BOLD}?${RESET}  Let lerd manage DNS for .test sites with HTTPS? [Y/n] "
+  read -r _ans </dev/tty 2>/dev/null || true
+  if [[ "$_ans" =~ ^[Nn]$ ]]; then
+    DNS_MODE="localhost"
+    info "Using *.localhost over HTTP, mkcert and nss-tools are not required"
+  else
+    DNS_MODE="managed"
+  fi
+}
+
 check_cmd() {
   local cmd="$1" pkg="${2:-$1}" desc="${3:-}"
   if command -v "$cmd" &>/dev/null; then
@@ -139,7 +165,9 @@ check_prerequisites() {
   check_dns_resolver
   check_systemd_user
   check_podman_rootless
-  check_certutil
+  if [ "$DNS_MODE" = "managed" ]; then
+    check_certutil
+  fi
 
   if [ ${#MISSING_PKGS[@]} -eq 0 ]; then
     success "All prerequisites met"
@@ -345,6 +373,7 @@ cmd_install() {
     [ -f "$local_binary" ] || die "File not found: $local_binary"
   fi
 
+  ask_dns_mode
   check_prerequisites
 
   if ! command -v podman &>/dev/null; then
@@ -390,9 +419,9 @@ cmd_install() {
   # and lerd's prompts would silently hit EOF. Hand it /dev/tty when one is
   # available so [Y/n] questions reach the user.
   if [ -r /dev/tty ]; then
-    "${INSTALL_DIR}/${BINARY}" install </dev/tty
+    "${INSTALL_DIR}/${BINARY}" install --dns "$DNS_MODE" </dev/tty
   else
-    "${INSTALL_DIR}/${BINARY}" install
+    "${INSTALL_DIR}/${BINARY}" install --dns "$DNS_MODE"
   fi
   star_note
 }
@@ -495,6 +524,9 @@ main() {
     --update|-u|update)     cmd_update ;;
     --uninstall|uninstall)  cmd_uninstall ;;
     --check|check)
+      # Non-interactive: report the full requirement set (managed DNS), so the
+      # check never blocks on a prompt. Picking .localhost at real install time
+      # is what skips the HTTPS-only packages.
       MISSING_PKGS=()
       check_prerequisites
       ;;

--- a/internal/certs/secure.go
+++ b/internal/certs/secure.go
@@ -25,7 +25,7 @@ var RegenerateHostProxyWorktreeVhost func(site config.Site, wtPath, wtDomain str
 
 // SecureSite issues a TLS certificate for the site and switches its nginx vhost to HTTPS.
 func SecureSite(site config.Site) error {
-	if cfg, _ := config.LoadGlobal(); cfg != nil && !cfg.DNS.Enabled {
+	if cfg, _ := config.LoadGlobal(); !cfg.DNSManaged() {
 		return ErrDNSDisabled
 	}
 	if err := issueCertWithWorktrees(site); err != nil {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -236,7 +236,8 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 
 	phpVersion := phpDefault
 	nodeVersion := defaults.NodeVersion
-	secured := defaults.Secured
+	httpsAvailable := gcfg.DNSManaged()
+	secured := defaults.Secured && httpsAvailable
 
 	// FrankenPHP detection. If the project has signals we offer it as a
 	// choice in the wizard; default to whatever the existing config says.
@@ -281,10 +282,8 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 				Value(&nodeVersion),
 		)
 	}
+	firstGroupFields = appendHTTPSField(firstGroupFields, httpsAvailable, &secured)
 	firstGroupFields = append(firstGroupFields,
-		huh.NewConfirm().
-			Title("Enable HTTPS?").
-			Value(&secured),
 		huh.NewSelect[string]().
 			Title("Database").
 			Options(dbOptions...).
@@ -520,7 +519,7 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 func runCustomContainerWizard(cwd string, defaults *config.ProjectConfig, gcfg *config.GlobalConfig) (*config.ProjectConfig, error) {
 	portStr := "3000"
 	containerfile := "Containerfile.lerd"
-	secured := defaults.Secured
+	secured, httpsAvailable := resolveSecuredDefault(cwd, defaults.Secured, gcfg)
 
 	if defaults.Container != nil {
 		if defaults.Container.Port > 0 {
@@ -531,14 +530,7 @@ func runCustomContainerWizard(cwd string, defaults *config.ProjectConfig, gcfg *
 		}
 	}
 
-	// Seed secured from site registry if available.
-	if !defaults.Secured {
-		if site, err := config.FindSiteByPath(cwd); err == nil && site.Secured {
-			secured = true
-		}
-	}
-
-	if err := huh.NewForm(huh.NewGroup(
+	containerFields := []huh.Field{
 		huh.NewInput().
 			Title("Container port").
 			Description("Port the app listens on inside the container").
@@ -558,10 +550,9 @@ func runCustomContainerWizard(cwd string, defaults *config.ProjectConfig, gcfg *
 			Title("Containerfile").
 			Description("Path relative to project root").
 			Value(&containerfile),
-		huh.NewConfirm().
-			Title("Enable HTTPS?").
-			Value(&secured),
-	)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
+	}
+	containerFields = appendHTTPSField(containerFields, httpsAvailable, &secured)
+	if err := huh.NewForm(huh.NewGroup(containerFields...)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
 		return nil, err
 	}
 
@@ -762,14 +753,9 @@ func runHostProxyWizard(cwd string, defaults *config.ProjectConfig, gcfg *config
 		}
 	}
 	portStr := strconv.Itoa(port)
-	secured := defaults.Secured
-	if !secured {
-		if site, err := config.FindSiteByPath(cwd); err == nil && site.Secured {
-			secured = true
-		}
-	}
+	secured, httpsAvailable := resolveSecuredDefault(cwd, defaults.Secured, gcfg)
 
-	if err := huh.NewForm(huh.NewGroup(
+	proxyFields := []huh.Field{
 		huh.NewInput().
 			Title("Port").
 			Description("The port the dev server listens on (lerd injects PORT and proxies here)").
@@ -785,10 +771,9 @@ func runHostProxyWizard(cwd string, defaults *config.ProjectConfig, gcfg *config
 				}
 				return nil
 			}),
-		huh.NewConfirm().
-			Title("Enable HTTPS?").
-			Value(&secured),
-	)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
+	}
+	proxyFields = appendHTTPSField(proxyFields, httpsAvailable, &secured)
+	if err := huh.NewForm(huh.NewGroup(proxyFields...)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
 		return nil, err
 	}
 	port = 0
@@ -965,6 +950,32 @@ func envExampleFallback(path string) string {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// resolveSecuredDefault computes a wizard's initial "secured" value and whether
+// the HTTPS prompt should be offered at all. HTTPS is only available when lerd
+// manages DNS; otherwise secured is forced off and the prompt is hidden so the
+// wizard never offers a choice that `lerd secure` would later refuse. When
+// available, an already-secured linked site seeds the default to on.
+func resolveSecuredDefault(cwd string, defaultsSecured bool, gcfg *config.GlobalConfig) (secured, httpsAvailable bool) {
+	httpsAvailable = gcfg.DNSManaged()
+	secured = defaultsSecured && httpsAvailable
+	if httpsAvailable && !secured {
+		if site, err := config.FindSiteByPath(cwd); err == nil && site.Secured {
+			secured = true
+		}
+	}
+	return secured, httpsAvailable
+}
+
+// appendHTTPSField adds the "Enable HTTPS?" confirm to a wizard's field list
+// only when HTTPS is available; in localhost mode the prompt is omitted. Shared
+// by all three wizards so the gating rule lives in one place.
+func appendHTTPSField(fields []huh.Field, httpsAvailable bool, secured *bool) []huh.Field {
+	if !httpsAvailable {
+		return fields
+	}
+	return append(fields, huh.NewConfirm().Title("Enable HTTPS?").Value(secured))
 }
 
 // validatePHPVersion checks that the input looks like a valid PHP version

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -34,6 +34,8 @@ func NewInstallCmd() *cobra.Command {
 	}
 	cmd.Flags().Bool("no-ipv6", false,
 		"Force the lerd network to v4-only even if the host supports IPv6 (also: LERD_DISABLE_IPV6=1)")
+	cmd.Flags().String("dns", "",
+		"Preselect the DNS mode and skip the prompt: 'managed' (.test + HTTPS) or 'localhost' (.localhost, plain HTTP)")
 	cmd.Flags().Bool("from-update", false, "")
 	_ = cmd.Flags().MarkHidden("from-update")
 	return cmd
@@ -64,6 +66,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		noIPv6 = true
 	}
 	fromUpdate, _ := cmd.Flags().GetBool("from-update")
+	dnsFlag, _ := cmd.Flags().GetString("dns")
 	if noIPv6 {
 		podman.MarkIPv6Disabled("lerd")
 		fmt.Println("  IPv6 disabled by user; lerd network will be v4-only.")
@@ -200,6 +203,8 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		}
 		if fromUpdate {
 			wantDNS = prevEnabled
+		} else if flagDNS, ok := parseDNSMode(dnsFlag); ok {
+			wantDNS = flagDNS
 		} else {
 			wantDNS = confirmInstallPromptDefault(
 				"Let lerd manage DNS for local sites (No: use *.localhost, no dnsmasq, no HTTPS)?",
@@ -1212,6 +1217,22 @@ func detectSystemNode() string {
 // RunParallel invocation, which leaves a goroutine reading from os.Stdin.
 func confirmInstallPrompt(question string) bool {
 	return confirmInstallPromptDefault(question, true)
+}
+
+// parseDNSMode maps the --dns flag to a wantDNS bool. It lets the installer
+// script ask the .test/.localhost question up front (so it can skip the
+// HTTPS-only prerequisites for localhost mode) and hand the answer to
+// `lerd install` instead of prompting twice. An empty or unrecognised value
+// returns ok=false so the caller falls back to the interactive prompt.
+func parseDNSMode(flag string) (enabled bool, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(flag)) {
+	case "managed", "enabled", "test", "on", "yes", "true":
+		return true, true
+	case "localhost", "disabled", "off", "no", "false":
+		return false, true
+	default:
+		return false, false
+	}
 }
 
 // confirmInstallPromptDefault is like confirmInstallPrompt but lets the caller

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -620,3 +620,29 @@ func TestPromptSource_PipedStdinFallsBackToTTY(t *testing.T) {
 		t.Fatal("promptSource reported no source but returned non-nil reader")
 	}
 }
+
+func TestParseDNSMode(t *testing.T) {
+	cases := []struct {
+		in          string
+		wantEnabled bool
+		wantOK      bool
+	}{
+		{"managed", true, true},
+		{"enabled", true, true},
+		{"test", true, true},
+		{"  TEST  ", true, true},
+		{"localhost", false, true},
+		{"disabled", false, true},
+		{"off", false, true},
+		{"LocalHost", false, true},
+		{"", false, false},
+		{"bogus", false, false},
+	}
+	for _, c := range cases {
+		gotEnabled, gotOK := parseDNSMode(c.in)
+		if gotEnabled != c.wantEnabled || gotOK != c.wantOK {
+			t.Errorf("parseDNSMode(%q) = (%v, %v), want (%v, %v)",
+				c.in, gotEnabled, gotOK, c.wantEnabled, c.wantOK)
+		}
+	}
+}

--- a/internal/cli/secure.go
+++ b/internal/cli/secure.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/siteops"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
@@ -69,6 +70,11 @@ func toggleSecureCmd(args []string, secured bool) error {
 	site, err := config.FindSite(name)
 	if err != nil {
 		return fmt.Errorf("site %q not found — run 'lerd link' first", name)
+	}
+	if secured {
+		if gcfg, _ := config.LoadGlobal(); !gcfg.DNSManaged() {
+			return certs.ErrDNSDisabled
+		}
 	}
 	verb := "Issuing certificate"
 	if !secured {

--- a/internal/cli/secure_dns_test.go
+++ b/internal/cli/secure_dns_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/geodro/lerd/internal/certs"
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestSecureCmd_RefusesWhenDNSDisabled(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cfg := &config.GlobalConfig{}
+	cfg.DNS.Enabled = false
+	cfg.DNS.TLD = "localhost"
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+	if err := config.AddSite(config.Site{Name: "myapp", Path: tmp, Domains: []string{"myapp.localhost"}}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	err := toggleSecureCmd([]string{"myapp"}, true)
+	if !errors.Is(err, certs.ErrDNSDisabled) {
+		t.Fatalf("toggleSecureCmd err = %v, want ErrDNSDisabled", err)
+	}
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -251,6 +251,15 @@ func (c *GlobalConfig) WorkerExecMode() string {
 	return WorkerExecModeExec
 }
 
+// DNSManaged reports whether lerd is managing local DNS, which is the
+// prerequisite for HTTPS (mkcert CA, *.test resolution). A nil receiver counts
+// as managed, matching how the rest of the codebase treats an absent config
+// (an unconfigured install behaves as if DNS is enabled). It is the single
+// predicate the install wizard, `lerd secure`, and the cert layer all share.
+func (c *GlobalConfig) DNSManaged() bool {
+	return c == nil || c.DNS.Enabled
+}
+
 func defaultConfig() *GlobalConfig {
 	cfg := &GlobalConfig{}
 	cfg.PHP.DefaultVersion = "8.5"

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -580,3 +580,20 @@ func TestNotifications_RoundTripsThroughYAML(t *testing.T) {
 		t.Error("notifications should remain disabled after YAML round trip")
 	}
 }
+
+func TestDNSManaged(t *testing.T) {
+	var nilCfg *GlobalConfig
+	if !nilCfg.DNSManaged() {
+		t.Error("nil config should count as DNS-managed, matching the rest of the codebase")
+	}
+	enabled := &GlobalConfig{}
+	enabled.DNS.Enabled = true
+	if !enabled.DNSManaged() {
+		t.Error("DNSManaged() = false with DNS.Enabled true, want true")
+	}
+	disabled := &GlobalConfig{}
+	disabled.DNS.Enabled = false
+	if disabled.DNSManaged() {
+		t.Error("DNSManaged() = true with DNS.Enabled false, want false")
+	}
+}

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -308,6 +308,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "HTTPS deaktivieren",
   "sites_controls_httpsToggle_off": "HTTPS aktivieren",
+  "sites_controls_httpsUnavailable": "HTTPS nicht verfügbar, lerd verwaltet kein DNS",
   "sites_controls_lanToggle_on": "LAN-Freigabe stoppen",
   "sites_controls_lanToggle_off": "Im LAN freigeben",
   "sites_controls_queueToggle_on": "Queue-Worker stoppen",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -288,6 +288,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "Disable HTTPS",
   "sites_controls_httpsToggle_off": "Enable HTTPS",
+  "sites_controls_httpsUnavailable": "HTTPS unavailable, lerd is not managing DNS",
   "sites_controls_lanToggle_on": "Stop LAN sharing",
   "sites_controls_lanToggle_off": "Share on LAN",
   "sites_controls_queueToggle_on": "Stop queue worker",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -308,6 +308,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "Desactivar HTTPS",
   "sites_controls_httpsToggle_off": "Activar HTTPS",
+  "sites_controls_httpsUnavailable": "HTTPS no disponible, lerd no gestiona el DNS",
   "sites_controls_lanToggle_on": "Detener compartición LAN",
   "sites_controls_lanToggle_off": "Compartir en LAN",
   "sites_controls_queueToggle_on": "Detener worker de cola",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -308,6 +308,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "Désactiver HTTPS",
   "sites_controls_httpsToggle_off": "Activer HTTPS",
+  "sites_controls_httpsUnavailable": "HTTPS indisponible, lerd ne gère pas le DNS",
   "sites_controls_lanToggle_on": "Arrêter le partage LAN",
   "sites_controls_lanToggle_off": "Partager sur le LAN",
   "sites_controls_queueToggle_on": "Arrêter le worker de file",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -308,6 +308,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "Nonaktifkan HTTPS",
   "sites_controls_httpsToggle_off": "Aktifkan HTTPS",
+  "sites_controls_httpsUnavailable": "HTTPS tidak tersedia, lerd tidak mengelola DNS",
   "sites_controls_lanToggle_on": "Hentikan berbagi LAN",
   "sites_controls_lanToggle_off": "Bagikan di LAN",
   "sites_controls_queueToggle_on": "Hentikan worker queue",

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -293,6 +293,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "Disabilita HTTPS",
   "sites_controls_httpsToggle_off": "Abilita HTTPS",
+  "sites_controls_httpsUnavailable": "HTTPS non disponibile, lerd non gestisce il DNS",
   "sites_controls_lanToggle_on": "Interrompi condivisione LAN",
   "sites_controls_lanToggle_off": "Condividi sulla LAN",
   "sites_controls_queueToggle_on": "Ferma worker della coda",

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -293,6 +293,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "HTTPS を無効化",
   "sites_controls_httpsToggle_off": "HTTPS を有効化",
+  "sites_controls_httpsUnavailable": "HTTPS は利用できません。lerd が DNS を管理していません",
   "sites_controls_lanToggle_on": "LAN 共有を停止",
   "sites_controls_lanToggle_off": "LAN で共有",
   "sites_controls_queueToggle_on": "キューワーカーを停止",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -308,6 +308,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "HTTPS uitschakelen",
   "sites_controls_httpsToggle_off": "HTTPS inschakelen",
+  "sites_controls_httpsUnavailable": "HTTPS niet beschikbaar, lerd beheert geen DNS",
   "sites_controls_lanToggle_on": "LAN-delen stoppen",
   "sites_controls_lanToggle_off": "Delen op LAN",
   "sites_controls_queueToggle_on": "Queue-worker stoppen",

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -293,6 +293,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "Wyłącz HTTPS",
   "sites_controls_httpsToggle_off": "Włącz HTTPS",
+  "sites_controls_httpsUnavailable": "HTTPS niedostępny, lerd nie zarządza DNS",
   "sites_controls_lanToggle_on": "Zatrzymaj udostępnianie w LAN",
   "sites_controls_lanToggle_off": "Udostępnij w LAN",
   "sites_controls_queueToggle_on": "Zatrzymaj worker kolejki",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -308,6 +308,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "Desativar HTTPS",
   "sites_controls_httpsToggle_off": "Ativar HTTPS",
+  "sites_controls_httpsUnavailable": "HTTPS indisponível, o lerd não gere o DNS",
   "sites_controls_lanToggle_on": "Parar compartilhamento LAN",
   "sites_controls_lanToggle_off": "Compartilhar na LAN",
   "sites_controls_queueToggle_on": "Parar worker de fila",

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -293,6 +293,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "Dezactivează HTTPS",
   "sites_controls_httpsToggle_off": "Activează HTTPS",
+  "sites_controls_httpsUnavailable": "HTTPS indisponibil, lerd nu gestionează DNS",
   "sites_controls_lanToggle_on": "Oprește partajarea LAN",
   "sites_controls_lanToggle_off": "Partajează pe LAN",
   "sites_controls_queueToggle_on": "Oprește workerul de coadă",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -308,6 +308,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "HTTPS'i devre dışı bırak",
   "sites_controls_httpsToggle_off": "HTTPS'i etkinleştir",
+  "sites_controls_httpsUnavailable": "HTTPS kullanılamıyor, lerd DNS yönetmiyor",
   "sites_controls_lanToggle_on": "LAN paylaşımını durdur",
   "sites_controls_lanToggle_off": "LAN'da paylaş",
   "sites_controls_queueToggle_on": "Kuyruk worker'ını durdur",

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -293,6 +293,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "Tắt HTTPS",
   "sites_controls_httpsToggle_off": "Bật HTTPS",
+  "sites_controls_httpsUnavailable": "HTTPS không khả dụng, lerd không quản lý DNS",
   "sites_controls_lanToggle_on": "Dừng chia sẻ LAN",
   "sites_controls_lanToggle_off": "Chia sẻ trên LAN",
   "sites_controls_queueToggle_on": "Dừng queue worker",

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -293,6 +293,7 @@
   "sites_controls_reverb": "Reverb",
   "sites_controls_httpsToggle_on": "禁用 HTTPS",
   "sites_controls_httpsToggle_off": "启用 HTTPS",
+  "sites_controls_httpsUnavailable": "HTTPS 不可用，lerd 未管理 DNS",
   "sites_controls_lanToggle_on": "停止 LAN 共享",
   "sites_controls_lanToggle_off": "在 LAN 上共享",
   "sites_controls_queueToggle_on": "停止队列 worker",

--- a/internal/ui/web/src/tabs/sites/SiteHeader.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteHeader.svelte
@@ -345,6 +345,21 @@
             />
           </svg>
         </span>
+      {:else if !dnsEnabled}
+        <span
+          class="shrink-0 -ml-1 p-1 inline-flex items-center text-gray-400 dark:text-gray-500"
+          title={m.sites_controls_httpsUnavailable()}
+          aria-label={m.sites_controls_httpsUnavailable()}
+        >
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+            />
+          </svg>
+        </span>
       {:else}
         <span class="shrink-0 -ml-1 p-1 inline-flex items-center text-gray-400 dark:text-gray-500" aria-label="No TLS">
           <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/tests/installer/installer.bats
+++ b/tests/installer/installer.bats
@@ -302,3 +302,42 @@ teardown() {
   run bash "$INSTALLER" --check
   [ "$status" -eq 0 ]
 }
+
+# ── DNS mode gating of the HTTPS-only prerequisites ───────────────────────────
+
+@test "check_prerequisites skips certutil in localhost DNS mode" {
+  function command() {
+    case "$2" in
+      podman|unzip) return 0 ;;
+      certutil) return 1 ;;
+      *) builtin command "$@" ;;
+    esac
+  }
+  function systemctl() { return 0; }
+  function podman() { if [[ "$1" == "info" ]]; then echo "true"; fi; }
+  export -f command systemctl podman
+
+  MISSING_PKGS=()
+  DNS_MODE="localhost"
+  run check_prerequisites
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"certutil not found"* ]]
+}
+
+@test "check_prerequisites flags certutil in managed DNS mode" {
+  function command() {
+    case "$2" in
+      podman|unzip) return 0 ;;
+      certutil) return 1 ;;
+      *) builtin command "$@" ;;
+    esac
+  }
+  function systemctl() { return 0; }
+  function podman() { if [[ "$1" == "info" ]]; then echo "true"; fi; }
+  export -f command systemctl podman
+
+  MISSING_PKGS=()
+  DNS_MODE="managed"
+  run check_prerequisites
+  [[ "$output" == *"certutil not found"* ]]
+}


### PR DESCRIPTION
In disabled-DNS mode sites run under `*.localhost` over plain HTTP with no mkcert CA, but several surfaces still acted as if HTTPS were available. The `lerd init` wizard asked "Enable HTTPS?" in all three paths even though `lerd secure` would later refuse, and the dashboard showed a bare open padlock indistinguishable from a normal unsecured site. The wizards now skip the HTTPS prompt and force plain HTTP whenever lerd is not managing DNS, the dashboard renders a muted lock with a tooltip explaining HTTPS needs lerd-managed DNS, and `lerd secure` returns a clean error up front instead of printing "Issuing certificate" and then failing deep in the cert layer.

The installer asked the `.test` versus `.localhost` question too late, inside `lerd install`, after it had already checked for and offered to install the HTTPS-only certutil/nss-tools packages. On immutable hosts like Fedora Silverblue that package layering does not even work, and it makes no sense for someone who only wants `.localhost`. `install.sh` now asks the DNS mode first, gates the certutil check behind managed mode, and passes the answer straight to `lerd install` via a new `--dns` flag so the question is never shown twice.

The "is lerd managing DNS" question now has a single source of truth: a `DNSManaged()` method on `GlobalConfig`, defined so an absent config counts as managed to match how the rest of the codebase already treats a nil config. The init wizards, `lerd secure`, and the cert layer all call it, and the three wizards share `resolveSecuredDefault` and `appendHTTPSField` helpers instead of repeating the gating inline.