### PR TITLE
fix(link): reconcile a stale FrankenPHP container when a re-linked site is no longer FrankenPHP

### DIFF
--- a/docs/features/frankenphp.md
+++ b/docs/features/frankenphp.md
@@ -26,6 +26,8 @@ lerd runtime frankenphp --worker
 
 Flip back to FPM with `lerd runtime fpm`. `lerd runtime` without an argument prints the current runtime. Both surfaces restart the container, regenerate the nginx vhost, and reload nginx automatically.
 
+If a site loses its `runtime: frankenphp` line in `.lerd.yaml` (a git revert, a branch switch, a manual edit) and you re-link it, lerd reconciles the change for you: the leftover `lerd-fp-<site>.container` quadlet and its container are removed during the link, so a stale FrankenPHP container is never left running outside lerd's start/stop control.
+
 ---
 
 ## What happens under the hood

--- a/internal/cli/frankenphp_reconcile_test.go
+++ b/internal/cli/frankenphp_reconcile_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// stopRecorder records Stop calls so reconcileStaleFrankenPHP's teardown can be
+// asserted without touching real systemd.
+type stopRecorder struct{ stopped []string }
+
+func (s *stopRecorder) Start(string) error                { return nil }
+func (s *stopRecorder) Stop(name string) error            { s.stopped = append(s.stopped, name); return nil }
+func (s *stopRecorder) Restart(string) error              { return nil }
+func (s *stopRecorder) UnitStatus(string) (string, error) { return "inactive", nil }
+func (s *stopRecorder) AllUnitStates() map[string]string  { return nil }
+
+// stubFrankenPHPTeardown routes the podman teardown calls through the recorder
+// and a no-op daemon-reload, restoring the originals on cleanup.
+func stubFrankenPHPTeardown(t *testing.T, lc *stopRecorder) {
+	t.Helper()
+	origLC := podman.UnitLifecycle
+	origReload := podman.DaemonReloadFn
+	origRemoveUnit := podman.RemoveContainerUnitFn
+	podman.UnitLifecycle = lc
+	podman.DaemonReloadFn = func() error { return nil }
+	podman.RemoveContainerUnitFn = nil
+	t.Cleanup(func() {
+		podman.UnitLifecycle = origLC
+		podman.DaemonReloadFn = origReload
+		podman.RemoveContainerUnitFn = origRemoveUnit
+	})
+}
+
+func writeFakeFPQuadlet(t *testing.T, siteName string) string {
+	t.Helper()
+	dir := config.QuadletDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, podman.FrankenPHPContainerName(siteName)+".container")
+	if err := os.WriteFile(path, []byte("[Container]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestReconcileStaleFrankenPHP covers the orphan a FrankenPHP->FPM re-link
+// leaves behind: the per-site fp quadlet is WantedBy=default.target with
+// Restart=always, so podman's generator keeps auto-starting a container that
+// lerd start/stop never enumerate. The reconcile must remove it only when the
+// site is no longer FrankenPHP, and never touch a still-FrankenPHP site.
+func TestReconcileStaleFrankenPHP(t *testing.T) {
+	t.Run("removes stale quadlet when site is no longer frankenphp", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		rec := &stopRecorder{}
+		stubFrankenPHPTeardown(t, rec)
+
+		path := writeFakeFPQuadlet(t, "scorediviner")
+		reconcileStaleFrankenPHP(config.Site{Name: "scorediviner"})
+
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("stale fp quadlet should be removed, stat err = %v", err)
+		}
+		if len(rec.stopped) != 1 || rec.stopped[0] != "lerd-fp-scorediviner" {
+			t.Errorf("stopped = %v, want [lerd-fp-scorediviner]", rec.stopped)
+		}
+	})
+
+	t.Run("keeps quadlet when site is still frankenphp", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		rec := &stopRecorder{}
+		stubFrankenPHPTeardown(t, rec)
+
+		path := writeFakeFPQuadlet(t, "personal")
+		reconcileStaleFrankenPHP(config.Site{Name: "personal", Runtime: "frankenphp"})
+
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("frankenphp quadlet should be kept, stat err = %v", err)
+		}
+		if len(rec.stopped) != 0 {
+			t.Errorf("stopped = %v, want none (site still frankenphp)", rec.stopped)
+		}
+	})
+
+	t.Run("no-op when no fp quadlet exists", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		rec := &stopRecorder{}
+		stubFrankenPHPTeardown(t, rec)
+
+		reconcileStaleFrankenPHP(config.Site{Name: "freshapp"})
+		if len(rec.stopped) != 0 {
+			t.Errorf("stopped = %v, want none (no quadlet)", rec.stopped)
+		}
+	})
+}

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -268,6 +268,10 @@ func runLink(args []string) error {
 		return fmt.Errorf("registering site: %w", err)
 	}
 
+	// A re-link of a site that dropped its frankenphp runtime leaves the old
+	// per-site FrankenPHP quadlet behind; reconcile it to the site's real type.
+	reconcileStaleFrankenPHP(site)
+
 	_ = config.SyncProjectDomains(cwd, site.Domains, cfg.DNS.TLD)
 
 	if site.IsCustomFPM() {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -92,6 +92,26 @@ func runRuntime(cmd *cobra.Command, args []string) error {
 	}
 }
 
+// removeFrankenPHPContainer stops a site's per-site FrankenPHP container,
+// removes its quadlet, and reloads systemd so the generated unit disappears.
+// Shared by switchToFPM and link's stale-quadlet reconcile.
+func removeFrankenPHPContainer(siteName string) {
+	_ = podman.StopUnit(podman.FrankenPHPContainerName(siteName))
+	_ = podman.RemoveFrankenPHPQuadlet(siteName)
+	_ = podman.DaemonReloadFn()
+}
+
+// reconcileStaleFrankenPHP removes a leftover per-site FrankenPHP quadlet when a
+// (re)linked site is no longer FrankenPHP. That quadlet is WantedBy=default.target
+// with Restart=always, so podman's generator keeps auto-starting an orphan that
+// lerd start/stop never enumerate.
+func reconcileStaleFrankenPHP(site config.Site) {
+	if site.IsFrankenPHP() || !podman.QuadletInstalled(podman.FrankenPHPContainerName(site.Name)) {
+		return
+	}
+	removeFrankenPHPContainer(site.Name)
+}
+
 func runtimeLabel(site *config.Site) string {
 	if site.IsFrankenPHP() {
 		if site.RuntimeWorker {
@@ -111,9 +131,7 @@ func switchToFPM(site *config.Site) error {
 		WorkerStopForSite(site.Name, site.Path, w) //nolint:errcheck
 	}
 
-	_ = podman.StopUnit(podman.FrankenPHPContainerName(site.Name))
-	_ = podman.RemoveFrankenPHPQuadlet(site.Name)
-	_ = podman.DaemonReloadFn()
+	removeFrankenPHPContainer(site.Name)
 
 	site.Runtime = ""
 	site.RuntimeWorker = false


### PR DESCRIPTION
Switching a site back to shared FPM with `lerd runtime fpm` tears down the per-site FrankenPHP container and removes its quadlet, but a re-link never did the same reconciliation. When a site's `.lerd.yaml` loses its `runtime: frankenphp` line through a git revert, a branch switch, or a manual edit and the site is then re-linked, the registry reverts to plain FPM while the old `lerd-fp-<site>.container` quadlet stays on disk. That quadlet is `WantedBy=default.target` with `Restart=always`, so podman's systemd generator keeps auto-starting an orphaned container that neither `lerd start` nor `lerd stop` ever names, which is how one ends up running outside lerd's control and surviving a full stop.

The link path now reconciles this after the site is registered: if the site is not FrankenPHP but a `lerd-fp-<site>` quadlet still exists, the container is stopped and the quadlet removed, mirroring what `lerd runtime fpm` already does. The shared teardown is extracted into a single helper so both paths stay in step.

This is unrelated to #530's networking problems, it was spotted on a real install while reproducing that report: a `lerd-fp-<site>` container was running and surviving `lerd stop` even though the site had reverted to plain FPM.