### PR TITLE
fix(link): keep secured projects on http when DNS is disabled

### DIFF
--- a/docs/features/https.md
+++ b/docs/features/https.md
@@ -3,7 +3,7 @@
 Lerd uses [mkcert](https://github.com/FiloSottile/mkcert), a locally-trusted CA that your browser will accept without warnings.
 
 > [!NOTE]
-> HTTPS is only available when lerd is managing DNS. If you installed in disabled-DNS mode (`dns.enabled: false`, sites under `*.localhost`), the mkcert root CA was never installed, the `lerd init` wizard skips the "Enable HTTPS?" question, the per-site HTTPS toggle in the dashboard becomes a muted lock icon, and `lerd secure` refuses with `HTTPS requires lerd-managed DNS, set dns.enabled: true and re-run lerd install`. See [DNS](dns.md) for the toggle and how to switch back.
+> HTTPS is only available when lerd is managing DNS. If you installed in disabled-DNS mode (`dns.enabled: false`, sites under `*.localhost`), the mkcert root CA was never installed, the `lerd init` wizard skips the "Enable HTTPS?" question, the per-site HTTPS toggle in the dashboard becomes a muted lock icon, and `lerd secure` refuses with `HTTPS requires lerd-managed DNS, set dns.enabled: true and re-run lerd install`. A project whose committed `.lerd.yaml` carries `secured: true` is linked over http on a disabled-DNS install rather than registered as a non-functional HTTPS site. See [DNS](dns.md) for the toggle and how to switch back.
 
 ```bash
 cd ~/Lerd/my-app

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -147,7 +147,7 @@ func runLink(args []string) error {
 	// Custom container path: the project defines its own Containerfile and
 	// nginx reverse-proxies to it. Skip PHP/framework detection entirely.
 	if proj != nil && proj.Container != nil && proj.Container.Port > 0 {
-		secured := siteops.CleanupRelink(cwd, name) || (proj != nil && proj.Secured)
+		secured := siteops.ResolveSecured(siteops.CleanupRelink(cwd, name), proj, cfg)
 		site := config.Site{
 			Name:          name,
 			Domains:       domains,
@@ -180,7 +180,7 @@ func runLink(args []string) error {
 		if err := approveHostProxyCommand(name, proj.Proxy.Command, approved); err != nil {
 			return err
 		}
-		secured := siteops.CleanupRelink(cwd, name) || proj.Secured
+		secured := siteops.ResolveSecured(siteops.CleanupRelink(cwd, name), proj, cfg)
 		site := config.Site{
 			Name:        name,
 			Domains:     domains,
@@ -238,7 +238,7 @@ func runLink(args []string) error {
 		}
 	}
 
-	secured := siteops.CleanupRelink(cwd, name) || (proj != nil && proj.Secured)
+	secured := siteops.ResolveSecured(siteops.CleanupRelink(cwd, name), proj, cfg)
 
 	site := config.Site{
 		Name:        name,
@@ -342,9 +342,12 @@ func runLink(args []string) error {
 		}
 	}
 
-	// Apply remaining .lerd.yaml settings: HTTPS and services.
+	// Apply remaining .lerd.yaml settings: HTTPS and services. secured already
+	// folds in the DNS-managed gate, so a secured: true project on a localhost
+	// install lands here with secured=false and is left on http rather than
+	// triggering a runSecure that the cert layer would only reject.
 	if proj != nil {
-		if proj.Secured && !secured {
+		if proj.Secured && !secured && cfg.DNSManaged() {
 			if err := runSecure(nil, []string{}); err != nil {
 				fmt.Printf("[WARN] securing site: %v\n", err)
 			}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2384,7 +2384,7 @@ func execSiteLink(args map[string]any) (any, *rpcError) {
 
 	// Custom container path: .lerd.yaml has a container section with a port.
 	if proj != nil && proj.Container != nil && proj.Container.Port > 0 {
-		secured := siteops.CleanupRelink(projectPath, name) || (proj != nil && proj.Secured)
+		secured := siteops.ResolveSecured(siteops.CleanupRelink(projectPath, name), proj, cfg)
 		site := config.Site{
 			Name:          name,
 			Domains:       domains,
@@ -2414,7 +2414,7 @@ func execSiteLink(args map[string]any) (any, *rpcError) {
 		phpVersion = proj.PHPVersion
 	}
 
-	secured := siteops.CleanupRelink(projectPath, name) || (proj != nil && proj.Secured)
+	secured := siteops.ResolveSecured(siteops.CleanupRelink(projectPath, name), proj, cfg)
 	site := config.Site{
 		Name:        name,
 		Domains:     domains,

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -115,6 +115,16 @@ func CleanupRelink(path, newName string) bool {
 	return secured
 }
 
+// ResolveSecured decides whether a freshly linked site is secured. A re-link
+// preserves the prior secured state (relinkSecured, from CleanupRelink),
+// otherwise .lerd.yaml's secured flag is honoured only when lerd manages DNS,
+// so a project authored with secured: true degrades to http on a localhost
+// install rather than being registered as a non-functional HTTPS site that
+// the cert layer would refuse with ErrDNSDisabled.
+func ResolveSecured(relinkSecured bool, proj *config.ProjectConfig, cfg *config.GlobalConfig) bool {
+	return relinkSecured || (proj != nil && proj.Secured && cfg.DNSManaged())
+}
+
 // FinishLink performs the post-registration steps shared by link, park, and MCP:
 // vhost generation, FPM quadlet setup, container hosts update, and nginx reload.
 func FinishLink(site config.Site, phpVersion string) error {

--- a/internal/siteops/resolvesecured_test.go
+++ b/internal/siteops/resolvesecured_test.go
@@ -1,0 +1,40 @@
+package siteops
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestResolveSecured(t *testing.T) {
+	dnsOn := &config.GlobalConfig{}
+	dnsOn.DNS.Enabled = true
+	dnsOff := &config.GlobalConfig{}
+	dnsOff.DNS.Enabled = false
+
+	securedProj := &config.ProjectConfig{Secured: true}
+	plainProj := &config.ProjectConfig{Secured: false}
+
+	cases := []struct {
+		name   string
+		relink bool
+		proj   *config.ProjectConfig
+		cfg    *config.GlobalConfig
+		want   bool
+	}{
+		{"secured project, DNS managed", false, securedProj, dnsOn, true},
+		{"secured project, DNS disabled stays http", false, securedProj, dnsOff, false},
+		{"plain project, DNS managed", false, plainProj, dnsOn, false},
+		{"no .lerd.yaml", false, nil, dnsOn, false},
+		{"re-link preserves prior secured even with DNS disabled", true, plainProj, dnsOff, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveSecured(tc.relink, tc.proj, tc.cfg); got != tc.want {
+				t.Errorf("ResolveSecured(%v, %+v, dns=%v) = %v, want %v",
+					tc.relink, tc.proj, tc.cfg.DNS.Enabled, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A project whose committed .lerd.yaml carries secured: true was being registered as a secured site even on a localhost install where lerd is not managing DNS. The CLI then opened it over https and the dashboard treated it as secured, but no certificate was ever issued because the mkcert CA and .test resolution don't exist in that mode, so the site never actually loaded for the user. The MCP site link tool was in even worse shape, since its FinishLink call runs SecureSite which bails out with the DNS-disabled error, so linking a secured project through MCP failed outright rather than registering anything.

This gates the project's secured flag on whether lerd manages DNS, which is exactly what the init wizard already does, so a secured: true project degrades to http on a localhost install instead of becoming a non-functional HTTPS site. The decision now lives in one siteops.ResolveSecured helper shared by the three link paths and the two MCP registration paths so the gate can't drift between the CLI and the MCP server again. A genuine re-link still preserves the prior secured state through CleanupRelink. The link reconciliation block is also gated on managed DNS, so a secured project on localhost no longer triggers a runSecure that the cert layer would only reject with a confusing warning.