### PR TITLE
Fix regressions found reviewing the post-1.24 work

### DIFF
--- a/internal/cli/idle_engine.go
+++ b/internal/cli/idle_engine.go
@@ -148,6 +148,25 @@ func IdleSuspendStateIsStale(site *config.Site) bool {
 	return false
 }
 
+// WorktreeIdleSuspendStateIsStale is IdleSuspendStateIsStale for a single git
+// worktree: it reports whether the worktree's persisted idle-suspended set has
+// drifted from reality (a worker it claims suspended is actually running, e.g.
+// an install/relink restarted it without clearing the slot). The engine calls it
+// at startup so a stale worktree list is discarded rather than seeded from, which
+// would wedge the worktree as suspended forever and never re-suspend it.
+func WorktreeIdleSuspendStateIsStale(site *config.Site, wtBase string, suspended []string) bool {
+	if len(suspended) == 0 {
+		return false
+	}
+	running := collectRunningWorktreeWorkersByBase(site, wtBase)
+	for _, w := range suspended {
+		if containsString(running, w) {
+			return true
+		}
+	}
+	return false
+}
+
 // ensureViteSleepable makes a site safe to stop vite on. Vite needs a built
 // asset manifest to fall back to once its dev server stops; if one is missing it
 // runs `npm run build` (blocking) and reports whether a manifest now exists.

--- a/internal/cli/idle_worktree_test.go
+++ b/internal/cli/idle_worktree_test.go
@@ -86,6 +86,22 @@ func TestEnsureViteSleepable_buildsAtMostOnce(t *testing.T) {
 	}
 }
 
+// TestWorktreeIdleSuspendStateIsStale covers the conservative guards: an empty
+// persisted set is never stale, and an unknown framework (workers can't be
+// enumerated) keeps the worktree suspended rather than wrongly clearing it.
+func TestWorktreeIdleSuspendStateIsStale(t *testing.T) {
+	site := &config.Site{Name: "myapp", Path: "/srv/myapp", Framework: "laravel"}
+
+	if WorktreeIdleSuspendStateIsStale(site, "feature-x", nil) {
+		t.Errorf("empty suspended set reported stale")
+	}
+
+	noFW := &config.Site{Name: "myapp", Path: "/srv/myapp", Framework: "__nope__"}
+	if WorktreeIdleSuspendStateIsStale(noFW, "feature-x", []string{"vite"}) {
+		t.Errorf("unknown framework reported stale; should stay suspended")
+	}
+}
+
 // TestWorktreeWorkerUnitNaming pins that the unit name collectRunningWorktreeWorkers
 // checks (lerd-<w>-<site>-<wtBase>) is exactly what workerNames produces for a
 // worktree checkout, so idle-suspend detects, stops, and restarts the same unit.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -502,7 +502,7 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		FrameworkVersion: frameworkVersion,
 		FrameworkDef:     frameworkDef,
 		PublicDir:        defaults.PublicDir,
-		Secured:          secured,
+		Secured:          persistedSecured(secured, httpsAvailable, defaults.Secured),
 		Services:         services,
 		Workers:          selectedWorkers,
 		CustomWorkers:    filteredCustomWorkers,
@@ -623,7 +623,7 @@ func runCustomContainerWizard(cwd string, defaults *config.ProjectConfig, gcfg *
 	}
 
 	return &config.ProjectConfig{
-		Secured:       secured,
+		Secured:       persistedSecured(secured, httpsAvailable, defaults.Secured),
 		Services:      services,
 		CustomWorkers: filteredCustomWorkers,
 		Container:     containerCfg,
@@ -803,7 +803,7 @@ func runHostProxyWizard(cwd string, defaults *config.ProjectConfig, gcfg *config
 	}
 
 	return &config.ProjectConfig{
-		Secured:     secured,
+		Secured:     persistedSecured(secured, httpsAvailable, defaults.Secured),
 		Services:    buildProjectServices(selectedServices, defaults),
 		Proxy:       &config.ProxyConfig{Command: command, Port: port, SSL: false},
 		AppURL:      defaults.AppURL,
@@ -966,6 +966,18 @@ func resolveSecuredDefault(cwd string, defaultsSecured bool, gcfg *config.Global
 		}
 	}
 	return secured, httpsAvailable
+}
+
+// persistedSecured keeps the user's HTTPS intent in .lerd.yaml even when DNS is
+// disabled. Without DNS the wizard force-gates `secured` off, but the link path
+// re-gates at runtime via ResolveSecured, so persisting the gated-off value
+// would silently strip a committed `secured: true` for teammates on a
+// DNS-managed box. When HTTPS is available we persist the user's choice.
+func persistedSecured(chosen, httpsAvailable, committed bool) bool {
+	if httpsAvailable {
+		return chosen
+	}
+	return committed
 }
 
 // appendHTTPSField adds the "Enable HTTPS?" confirm to a wizard's field list

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,29 @@
+package cli
+
+import "testing"
+
+// TestPersistedSecured pins that the wizard persists the user's HTTPS intent to
+// .lerd.yaml rather than the DNS-gated value: dropping a committed secured:true
+// on a localhost box would silently strip HTTPS for teammates on a DNS box.
+func TestPersistedSecured(t *testing.T) {
+	cases := []struct {
+		name           string
+		chosen         bool
+		httpsAvailable bool
+		committed      bool
+		want           bool
+	}{
+		{"dns on, user enabled", true, true, false, true},
+		{"dns on, user declined", false, true, true, false},
+		{"dns off keeps committed intent", false, false, true, true},
+		{"dns off, never committed", false, false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := persistedSecured(tc.chosen, tc.httpsAvailable, tc.committed); got != tc.want {
+				t.Errorf("persistedSecured(%v,%v,%v) = %v, want %v",
+					tc.chosen, tc.httpsAvailable, tc.committed, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -257,6 +257,15 @@ func runLink(args []string) error {
 	if proj != nil && proj.Runtime != "" {
 		site.Runtime = proj.Runtime
 		site.RuntimeWorker = proj.RuntimeWorker
+		// FrankenPHP only publishes images for PHP >= 8.2; without this guard the
+		// build normalizes the version up (e.g. 8.1 -> 8.5) and silently runs a
+		// different PHP than the site reports. Mirror the `lerd runtime` guard and
+		// fall back to FPM rather than upgrading PHP behind the user's back.
+		if site.IsFrankenPHP() && !config.IsFrankenPHPVersion(site.PHPVersion) {
+			fmt.Printf("  FrankenPHP has no PHP %s image; linking as FPM instead\n", site.PHPVersion)
+			site.Runtime = ""
+			site.RuntimeWorker = false
+		}
 	}
 	// A container: config with no port on a PHP project means the site is served
 	// by fastcgi from its own image, built from the project's Containerfile.

--- a/internal/cli/node_manage.go
+++ b/internal/cli/node_manage.go
@@ -161,6 +161,14 @@ func RegenerateHostWorkersForSite(s config.Site) {
 		if !wDef.Host {
 			continue
 		}
+		// Don't resurrect a host worker the idle engine has suspended. Restarting
+		// it here also runs ClearIdleSuspendOnStart, dropping it from the suspended
+		// list, so the engine can no longer see it running and it stays up forever
+		// on an idle site. The worktree path below already filters via
+		// worktreeWorkersToStart; this is the main-site equivalent.
+		if containsString(s.IdleSuspendedWorkers, w) {
+			continue
+		}
 		regenerateWorkerUnit(s.Name, s.Path, phpVersion, w, wDef, "lerd-"+w+"-"+s.Name)
 	}
 	// A site's git worktrees run their own per-worktree host workers (e.g. Vite)

--- a/internal/cli/node_manage_test.go
+++ b/internal/cli/node_manage_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/services"
+)
+
+// recordingMgr embeds the real ServiceManager interface (nil here, since only
+// IsEnabled is exercised on the path under test) and records which unit names
+// regenerateWorkerUnit probes via IsEnabled. Returning false makes
+// regenerateWorkerUnit return early, so no heavier lifecycle method runs.
+type recordingMgr struct {
+	services.ServiceManager
+	enabledProbed map[string]bool
+}
+
+func (m *recordingMgr) IsEnabled(name string) bool {
+	m.enabledProbed[name] = true
+	return false
+}
+
+// RegenerateHostWorkersForSite must not resurrect a host worker the idle engine
+// has suspended: restarting it runs ClearIdleSuspendOnStart, which drops it from
+// the suspended list so the engine can no longer see it running and it stays up
+// forever on an idle site (the live "vite up while site idle after install" bug).
+// The probe is whether regenerateWorkerUnit was even entered for the suspended
+// worker — it must be skipped before the IsEnabled check.
+func TestRegenerateHostWorkersForSite_skipsIdleSuspended(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	dir := filepath.Join(tmp, "site")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	proj, err := config.LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proj.CustomWorkers = map[string]config.FrameworkWorker{
+		"vite": {Command: "npm run dev", Host: true},
+		"echo": {Command: "npm run echo", Host: true},
+	}
+	if err := config.SaveProjectConfig(dir, proj); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := &recordingMgr{enabledProbed: map[string]bool{}}
+	prev := services.Mgr
+	services.Mgr = rec
+	t.Cleanup(func() { services.Mgr = prev })
+
+	// vite is idle-suspended; echo is not. Only echo should be regenerated.
+	site := config.Site{
+		Name: "myapp", Path: dir, PHPVersion: "8.4", Framework: "laravel",
+		IdleSuspendedWorkers: []string{"vite"},
+	}
+	RegenerateHostWorkersForSite(site)
+
+	if rec.enabledProbed["lerd-vite-myapp"] {
+		t.Error("suspended host worker vite was regenerated; it must be skipped to stay asleep")
+	}
+	if !rec.enabledProbed["lerd-echo-myapp"] {
+		t.Error("non-suspended host worker echo should still be regenerated")
+	}
+}

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -421,11 +421,17 @@ func collectRunningWorkers(site *config.Site) []string {
 // (lerd-<w>-<site>-<wtBase>). Only workers a framework marks per_worktree:true
 // run per worktree (for Laravel, just vite), so only those are enumerated.
 func collectRunningWorktreeWorkers(site *config.Site, wtPath string) []string {
+	return collectRunningWorktreeWorkersByBase(site, config.WorktreeUnitSlug(filepath.Base(wtPath)))
+}
+
+// collectRunningWorktreeWorkersByBase is collectRunningWorktreeWorkers keyed by
+// the worktree's unit-slug base directly, for callers that hold the base (e.g. a
+// persisted WorktreeIdleSuspended key) but not the checkout path.
+func collectRunningWorktreeWorkersByBase(site *config.Site, wtBase string) []string {
 	fw, ok := config.GetFrameworkForDir(site.Framework, site.Path)
 	if !ok || fw.Workers == nil {
 		return nil
 	}
-	wtBase := config.WorktreeUnitSlug(filepath.Base(wtPath))
 	names := make([]string, 0, len(fw.Workers))
 	for wName, w := range fw.Workers {
 		if w.IsPerWorktree() {

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -748,6 +748,13 @@ func startRestoredServices() {
 	workerUnits = append(workerUnits, registeredFrameworkWorkerUnits()...)
 	workerUnits = append(workerUnits, registeredTimerUnits()...)
 	workerUnits = collapseTimerSiblings(dedupeStrings(workerUnits))
+	// Don't resurrect workers the idle engine has gracefully suspended, exactly
+	// as runStart does. Without this, `lerd install`/`update` (which re-creates
+	// and re-enables every worker via restoreSiteInfrastructure) restarts a
+	// deliberately-asleep worker on an idle site and wedges the engine: the
+	// registry still records it suspended, so the dashboard shows the site asleep
+	// while its workers run and the engine never re-suspends them.
+	workerUnits = dropIdleSuspendedUnits(workerUnits)
 	if len(workerUnits) == 0 {
 		return
 	}
@@ -892,6 +899,14 @@ func restoreSiteInfrastructure() {
 		// decides whether to start immediately (Linux) or just write the unit
 		// file and let phase 2 of runStart launch it (macOS).
 		for _, w := range proj.Workers {
+			// Leave a worker the idle engine suspended fully down: don't recreate,
+			// enable, or start it. Restoring it here re-enables it (so a later boot
+			// resurrects it) and feeds it to the start passes, which is how an idle
+			// site ends up with running workers after `lerd install`. The engine
+			// owns a suspended worker's lifecycle and resumes it on real activity.
+			if containsString(s.IdleSuspendedWorkers, w) {
+				continue
+			}
 			unitName := "lerd-" + w + "-" + s.Name
 			parentEnabled := services.Mgr.IsEnabled(unitName)
 			phpVersion := s.PHPVersion

--- a/internal/siteops/secure.go
+++ b/internal/siteops/secure.go
@@ -59,6 +59,12 @@ func defaultNotifyDaemon(domain, action string) error {
 //     identical post-toggle path.
 func SetSecured(site *config.Site, secured bool) error {
 	if secured {
+		// HTTPS needs the lerd-managed DNS/cert layer; gate here so UI and MCP
+		// callers fail the same clean way the CLI does instead of erroring deep
+		// in the cert layer.
+		if gcfg, _ := config.LoadGlobal(); !gcfg.DNSManaged() {
+			return certs.ErrDNSDisabled
+		}
 		if err := secureCertFn(*site); err != nil {
 			return fmt.Errorf("issuing certificate: %w", err)
 		}

--- a/internal/siteops/secure_test.go
+++ b/internal/siteops/secure_test.go
@@ -194,6 +194,36 @@ func TestSetSecured_skipsNotificationsOnNginxReloadError(t *testing.T) {
 	}
 }
 
+func TestSetSecured_refusesWhenDNSDisabled(t *testing.T) {
+	stubs := stubSecureDeps(t)
+	projectDir := withTempEnv(t)
+
+	gcfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("load global: %v", err)
+	}
+	gcfg.DNS.Enabled = false
+	if err := config.SaveGlobal(gcfg); err != nil {
+		t.Fatalf("save global: %v", err)
+	}
+
+	site := &config.Site{Name: "myapp", Domains: []string{"myapp.test"}, Path: projectDir}
+	if err := config.AddSite(*site); err != nil {
+		t.Fatal(err)
+	}
+
+	err = SetSecured(site, true)
+	if !errors.Is(err, certs.ErrDNSDisabled) {
+		t.Fatalf("SetSecured err = %v, want ErrDNSDisabled", err)
+	}
+	if stubs.secureCallCount != 0 {
+		t.Errorf("certs.SecureSite ran despite DNS disabled (calls = %d)", stubs.secureCallCount)
+	}
+	if site.Secured {
+		t.Errorf("site.Secured flipped despite DNS disabled")
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/ui/idle_engine.go
+++ b/internal/ui/idle_engine.go
@@ -96,9 +96,17 @@ func newIdleEngine(t *idle.Tracker) *idleEngine {
 				}
 			}
 			for wtBase, workers := range s.WorktreeIdleSuspended {
-				if len(workers) > 0 {
-					e.suspended[wtKey(s.Name, wtBase)] = true
+				if len(workers) == 0 {
+					continue
 				}
+				// Same reality check as the main site above: drop a worktree slot whose
+				// workers are actually running so the engine doesn't believe a live
+				// worktree is asleep and never re-suspend it.
+				if cli.WorktreeIdleSuspendStateIsStale(&s, wtBase, workers) {
+					_ = config.SetWorktreeIdleSuspendedWorkers(s.Name, wtBase, nil)
+					continue
+				}
+				e.suspended[wtKey(s.Name, wtBase)] = true
 			}
 		}
 	}
@@ -143,13 +151,21 @@ func (e *idleEngine) tick() {
 		}
 		e.mu.Lock()
 		if !e.inFlight[s.Name] {
-			// Reconcile our cached belief against the persisted source of truth. If
-			// the workers were (re)started outside the engine (install, relink,
-			// `lerd worker start`), that path cleared the persisted list but our
-			// cache still says suspended; trust the list so an idle site gets
-			// re-suspended instead of staying up forever. Skipped mid-flight so a
-			// slow suspend/resume goroutine isn't second-guessed before it persists.
-			e.suspended[s.Name] = len(s.IdleSuspendedWorkers) > 0
+			// Reconcile our cached belief against reality, not just the persisted
+			// list. A restore/install/boot path can re-create, re-enable, and
+			// re-start the workers we suspended without clearing the list (they're
+			// left enabled), so trusting the list alone would wedge the site as
+			// "believed asleep" while its workers actually run, never re-suspending.
+			// When the list claims suspended but a listed worker is in fact running,
+			// drop the stale list so this same tick re-suspends the idle site.
+			// Skipped mid-flight so a slow suspend/resume goroutine isn't
+			// second-guessed before it persists.
+			believed := len(s.IdleSuspendedWorkers) > 0
+			if believed && cli.IdleSuspendStateIsStale(&s) {
+				_ = config.SetSiteIdleSuspendedWorkers(s.Name, nil)
+				believed = false
+			}
+			e.suspended[s.Name] = believed
 		}
 		suspended := e.suspended[s.Name]
 		e.mu.Unlock()
@@ -210,9 +226,16 @@ func (e *idleEngine) tickWorktrees(s *config.Site, enabled bool, timeout time.Du
 
 		e.mu.Lock()
 		if !e.inFlight[key] {
-			// Same reconcile as the main site: a worktree worker started outside the
-			// engine clears its persisted slot, so trust that over the stale cache.
-			e.suspended[key] = len(s.WorktreeIdleSuspended[wtBase]) > 0
+			// Same reality-based reconcile as the main site: if the slot claims
+			// suspended but the worktree's worker is actually running (a restore
+			// path restarted it without clearing the slot), drop the stale slot so
+			// this tick re-suspends it instead of believing it asleep forever.
+			believed := len(s.WorktreeIdleSuspended[wtBase]) > 0
+			if believed && cli.WorktreeIdleSuspendStateIsStale(s, wtBase, s.WorktreeIdleSuspended[wtBase]) {
+				_ = config.SetWorktreeIdleSuspendedWorkers(s.Name, wtBase, nil)
+				believed = false
+			}
+			e.suspended[key] = believed
 		}
 		suspended := e.suspended[key]
 		e.mu.Unlock()
@@ -355,7 +378,14 @@ func (e *idleEngine) ResumeAllSuspended() {
 			e.mu.Lock()
 			e.suspended[key] = true // ensure resumeWorktree proceeds
 			e.mu.Unlock()
-			if wtPath := e.worktreePathForBase(&s, wtBase); wtPath != "" {
+			wtPath, err := e.worktreePathForBase(&s, wtBase)
+			if err != nil {
+				// Transient git error: leave the worker suspended rather than clear
+				// the slot and flip state, which would strand it down forever. The
+				// next tick resumes it (Decide returns Resume while disabled).
+				continue
+			}
+			if wtPath != "" {
 				e.resumeWorktree(s.Name, wtBase, wtPath)
 			} else {
 				_ = config.SetWorktreeIdleSuspendedWorkers(s.Name, wtBase, nil)
@@ -372,18 +402,21 @@ func (e *idleEngine) ResumeAllSuspended() {
 }
 
 // worktreePathForBase resolves a worktree's checkout dir from its unit-slug base
-// by detecting the site's current worktrees. Returns "" if the worktree is gone.
-func (e *idleEngine) worktreePathForBase(s *config.Site, wtBase string) string {
+// by detecting the site's current worktrees. Returns ("", nil) when detection
+// succeeds but the worktree is genuinely gone, and ("", err) on a transient git
+// error so callers can tell the two apart instead of treating a hiccup as a
+// removal and stranding a suspended worker.
+func (e *idleEngine) worktreePathForBase(s *config.Site, wtBase string) (string, error) {
 	wts, err := detectWorktrees(s.Path, s.PrimaryDomain())
 	if err != nil {
-		return ""
+		return "", err
 	}
 	for _, wt := range wts {
 		if config.WorktreeUnitSlug(filepath.Base(wt.Path)) == wtBase {
-			return wt.Path
+			return wt.Path, nil
 		}
 	}
-	return ""
+	return "", nil
 }
 
 // IsSuspended reports whether the site's workers are currently idle-suspended.

--- a/internal/ui/idle_engine_test.go
+++ b/internal/ui/idle_engine_test.go
@@ -1,12 +1,30 @@
 package ui
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/idle"
+	"github.com/geodro/lerd/internal/podman"
 )
+
+// stubUnitStatus reports the named units as running and everything else stopped,
+// so a tick test can pin the ground-truth worker state behind podman.UnitStatus.
+type stubUnitStatus struct{ active map[string]bool }
+
+func (s stubUnitStatus) Start(string) error   { return nil }
+func (s stubUnitStatus) Stop(string) error    { return nil }
+func (s stubUnitStatus) Restart(string) error { return nil }
+func (s stubUnitStatus) UnitStatus(name string) (string, error) {
+	if s.active[name] {
+		return "active", nil
+	}
+	return "inactive", nil
+}
+func (s stubUnitStatus) AllUnitStates() map[string]string { return nil }
 
 // TestTick_pinnedSiteStillTicksWorktrees is the regression guard for a pinned
 // site stranding its worktrees. Pinning used to `continue` past tickWorktrees, so
@@ -122,6 +140,65 @@ func TestTick_reconcilesStaleSuspendedCache(t *testing.T) {
 
 	if e.suspended["myapp"] {
 		t.Error("stale suspended cache should be reconciled to false against the empty persisted list")
+	}
+}
+
+// TestTick_reconcilesStaleSuspendedListAgainstReality is the regression guard for
+// the live wedge: workers up on an idle site after an install/boot restore that
+// re-created and re-started them but left the persisted list intact. Here the list
+// still says [queue] suspended while the unit is actually running. Trusting the
+// list alone would keep believing the site asleep forever; the tick must verify
+// reality, drop the stale list, and reconcile the cache to not-suspended.
+func TestTick_reconcilesStaleSuspendedListAgainstReality(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	dir := filepath.Join(tmp, "site")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	proj, err := config.LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proj.CustomWorkers = map[string]config.FrameworkWorker{"queue": {Command: "php artisan queue:work"}}
+	if err := config.SaveProjectConfig(dir, proj); err != nil {
+		t.Fatal(err)
+	}
+
+	// Persisted list still claims queue suspended (the restore path never cleared it).
+	if err := config.AddSite(config.Site{
+		Name: "myapp", Path: dir, PHPVersion: "8.4", Domains: []string{"myapp.test"},
+		Framework: "laravel", IdleSuspendedWorkers: []string{"queue"},
+	}); err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+	prev := detectWorktrees
+	detectWorktrees = func(string, string) ([]gitpkg.Worktree, error) { return nil, nil }
+	t.Cleanup(func() { detectWorktrees = prev })
+
+	// queue unit is actually running, contradicting the suspended claim.
+	podman.UnitLifecycle = stubUnitStatus{active: map[string]bool{"lerd-queue-myapp": true}}
+	t.Cleanup(func() { podman.UnitLifecycle = nil })
+
+	e := newIdleEngine(idle.NewTracker(nil))
+	e.suspended["myapp"] = true
+
+	e.tick()
+
+	if e.suspended["myapp"] {
+		t.Error("stale suspended list with a running worker must reconcile to not-suspended")
+	}
+	site, err := config.FindSite("myapp")
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(site.IdleSuspendedWorkers) != 0 {
+		t.Errorf("stale persisted list should be cleared, got %v", site.IdleSuspendedWorkers)
 	}
 }
 

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -4607,6 +4607,10 @@ func handleXdebugAction(w http.ResponseWriter, r *http.Request) {
 	if res.RestartErr != nil {
 		fmt.Printf("[WARN] restart %s: %v\n", xdebugops.FPMUnit(version), res.RestartErr)
 	}
+	// Per-site FrankenPHP and custom-FPM containers mount the same per-version
+	// 99-xdebug.ini, so the shared-FPM restart above doesn't reach them; restart
+	// them too or the toggle is a silent no-op on those sites.
+	podman.RestartSiteContainersForVersion(version)
 	writeJSON(w, map[string]any{"ok": true, "xdebug_enabled": res.Enabled, "xdebug_mode": res.Mode})
 }
 


### PR DESCRIPTION
These are the fixes from a review of everything that landed since the v1.24.0 release, plus the worker problem that surfaced out of it.

The headline one is idle-suspend leaving workers running on an idle site after lerd install. The restore path recreated and re-enabled every saved worker, the restored-services start pass started them all, and on a machine with bun the host worker regeneration restarted vite and dropped it from the suspended set so the engine could no longer track it. All of those paths now leave an idle-suspended worker alone, and the per-tick reconcile checks the persisted suspended list against the units actually running, so anything that slips back up is re-suspended within a tick rather than wedging the site as believed-asleep forever. The same change stops a transient git error from stranding a worktree's worker down when idle-suspend is turned off, and reconciles a stale worktree suspend slot left behind by an older build.

The dashboard Xdebug toggle was a no-op on FrankenPHP and custom-FPM sites: it only restarted the shared FPM container, while those sites serve from their own per-site container that mounts the same ini, so the badge flipped on but nothing attached. It now restarts the per-site containers too, the way the CLI already does.

Securing a site from the dashboard or MCP on a localhost install used to fail deep in the cert layer with a confusing message because the managed-DNS check lived only in the CLI wrapper. The gate moved into SetSecured, the shared path all three callers go through, so they refuse the same clean way.

lerd link honored a committed runtime frankenphp on a sub-8.2 PHP version with no guard, quietly building and running an 8.5 image while still reporting the old version. Link now applies the same version guard the runtime command uses and falls back to FPM when FrankenPHP has no image for the site's PHP.

Finally, running the init wizard on a localhost box rewrote .lerd.yaml with the DNS-gated secured value, which is stored as absence, silently stripping a committed secured true and losing it for teammates on a DNS-managed machine. The wizard now keeps the HTTPS intent in the file and lets the link path gate it at runtime.