### PR TITLE
fix(npm): keep lerd's php shim ahead of a global php for node child processes

### DIFF
--- a/internal/cli/idle_engine.go
+++ b/internal/cli/idle_engine.go
@@ -220,6 +220,7 @@ var runViteBuildAt = func(site *config.Site, dir string) {
 	fnm := filepath.Join(config.BinDir(), "fnm")
 	cmd := exec.Command(fnm, "exec", "--using="+nodeVersion, "--", "npm", "run", "build")
 	cmd.Dir = dir
+	cmd.Env = shimLeadingEnv(os.Environ()) // wayfinder needs lerd's php shim to lead PATH — issue #381
 	if out, err := cmd.CombinedOutput(); err != nil {
 		fmt.Printf("[idle] %s: `npm run build` failed, keeping vite running: %v\n%s\n",
 			site.Name, err, lastBytes(out, 600))

--- a/internal/cli/node_exec.go
+++ b/internal/cli/node_exec.go
@@ -78,7 +78,7 @@ func runNpmCaptured(dir string, args ...string) (string, error) {
 	cmdArgs := append([]string{"exec", "--using=" + version, "--", "npm"}, args...)
 	cmd := exec.Command(fnm, cmdArgs...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "npm_config_prefix="+config.NodeGlobalDir())
+	cmd.Env = append(shimLeadingEnv(os.Environ()), "npm_config_prefix="+config.NodeGlobalDir())
 	out, err := cmd.CombinedOutput()
 	return string(out), err
 }
@@ -126,6 +126,7 @@ func runBun(dir, bun string, args []string) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Env = shimLeadingEnv(os.Environ())
 	if err := cmd.Run(); err != nil {
 		if exit, ok := err.(*exec.ExitError); ok {
 			os.Exit(exit.ExitCode())
@@ -166,6 +167,27 @@ func runJSScript(dir, script string) error {
 	return runWithFnm("npm", []string{"run", script})
 }
 
+// shimLeadingEnv prepends lerd's bin dir (home of the `php` shim) to PATH so
+// child processes (e.g. Vite's wayfinder step) resolve `php` to lerd's managed
+// version instead of a global host php ahead of the shim on PATH — issue #381.
+func shimLeadingEnv(env []string) []string {
+	binDir := config.BinDir()
+	out := make([]string, 0, len(env)+1)
+	found := false
+	for _, kv := range env {
+		if name, val, ok := strings.Cut(kv, "="); ok && strings.EqualFold(name, "PATH") {
+			out = append(out, name+"="+binDir+string(os.PathListSeparator)+val)
+			found = true
+			continue
+		}
+		out = append(out, kv)
+	}
+	if !found {
+		out = append(out, "PATH="+binDir)
+	}
+	return out
+}
+
 func runWithFnm(bin string, args []string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -202,9 +224,10 @@ func runWithFnm(bin string, args []string) error {
 
 	manageGlobals := bin == "npm" || bin == "npx"
 	prefix := config.NodeGlobalDir()
+	cmd.Env = shimLeadingEnv(os.Environ())
 	if manageGlobals {
 		if err := os.MkdirAll(filepath.Join(prefix, "bin"), 0o755); err == nil {
-			cmd.Env = append(os.Environ(), "npm_config_prefix="+prefix)
+			cmd.Env = append(cmd.Env, "npm_config_prefix="+prefix)
 		}
 	}
 	runErr := cmd.Run()

--- a/internal/cli/node_exec_test.go
+++ b/internal/cli/node_exec_test.go
@@ -5,7 +5,68 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/config"
 )
+
+func TestShimLeadingEnv_PrependsBinDirToPath(t *testing.T) {
+	binDir := config.BinDir()
+	sep := string(os.PathListSeparator)
+
+	out := shimLeadingEnv([]string{"FOO=bar", "PATH=/usr/bin" + sep + "/bin", "BAZ=qux"})
+
+	var path string
+	for _, kv := range out {
+		if name, val, ok := strings.Cut(kv, "="); ok && name == "PATH" {
+			path = val
+		}
+	}
+	want := binDir + sep + "/usr/bin" + sep + "/bin"
+	if path != want {
+		t.Errorf("PATH = %q, want %q", path, want)
+	}
+	if !strings.HasPrefix(path, binDir+sep) {
+		t.Errorf("lerd bin dir must lead PATH so the php shim wins; got %q", path)
+	}
+	// non-PATH vars pass through untouched
+	if !envHas(out, "FOO=bar") || !envHas(out, "BAZ=qux") {
+		t.Errorf("non-PATH vars were not preserved: %v", out)
+	}
+}
+
+func TestShimLeadingEnv_AddsPathWhenAbsent(t *testing.T) {
+	out := shimLeadingEnv([]string{"FOO=bar"})
+	if !envHas(out, "PATH="+config.BinDir()) {
+		t.Errorf("expected PATH to be added with bin dir, got %v", out)
+	}
+}
+
+func TestShimLeadingEnv_MatchesPathCaseInsensitively(t *testing.T) {
+	sep := string(os.PathListSeparator)
+	out := shimLeadingEnv([]string{"Path=/usr/bin"})
+	// only one PATH-ish entry should exist, with the bin dir prepended
+	count := 0
+	for _, kv := range out {
+		if name, _, ok := strings.Cut(kv, "="); ok && strings.EqualFold(name, "PATH") {
+			count++
+			if !strings.HasPrefix(kv, "Path="+config.BinDir()+sep) {
+				t.Errorf("existing key casing not preserved or bin dir missing: %q", kv)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one PATH entry, got %d in %v", count, out)
+	}
+}
+
+func envHas(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
 
 func TestSyncNodeGlobalBins_CreatesWrappers(t *testing.T) {
 	root := t.TempDir()


### PR DESCRIPTION
Reported in #381. When you run lerd npm run dev, Vite's wayfinder step shells out to php artisan wayfinder:generate, and that child was resolving php off whatever PATH the parent shell happened to have. On a box with a global php installed ahead of lerd's shim directory, the global one won and failed Composer's platform check whenever the project required a newer PHP than the host had, which is exactly what the reporter hit on v1.24.1 with a system php 8.3.6 against a project needing 8.4.1.

This is the terminal side of the same gap the host worker units already closed in #375. The node spawn paths now prepend lerd's bin dir to PATH so the php shim always leads, which routes the wayfinder child through lerd php and gives it the project's pinned version inside the right FPM container. The same one-liner is applied to the interactive npm/npx/node path, the UI captured-npm path, the bun runner, and the idle engine's one-off vite build, since all of them spawn node on the host and can trigger the same wayfinder call.