### PR TITLE
Resume every worker when idle-suspend is turned off

### DIFF
--- a/internal/watcher/idle_control_test.go
+++ b/internal/watcher/idle_control_test.go
@@ -87,6 +87,44 @@ func TestEnableDisableIdle_lifecycle(t *testing.T) {
 	disableIdle() // idempotent: a second disable is a no-op
 }
 
+// TestResumeUntilClear_exitsWhenClean proves the disable-path resume returns
+// promptly once nothing is left suspended, rather than spinning its full bound.
+func TestResumeUntilClear_exitsWhenClean(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	prev := activityTracker
+	t.Cleanup(func() { activityTracker = prev; idleEng = nil; idleActive.Store(false) })
+	activityTracker = idle.NewTracker(nil)
+	idleEng = newIdleEngine(activityTracker)
+	idleActive.Store(false)
+
+	done := make(chan struct{})
+	go func() { idleEng.resumeUntilClear(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("resumeUntilClear should return at once when nothing is suspended")
+	}
+}
+
+// TestResumeUntilClear_bailsWhenReenabled proves the drain bails the moment the
+// feature is re-enabled, so it never fights a fresh session's suspends.
+func TestResumeUntilClear_bailsWhenReenabled(t *testing.T) {
+	prev := activityTracker
+	t.Cleanup(func() { activityTracker = prev; idleEng = nil; idleActive.Store(false) })
+	activityTracker = idle.NewTracker(nil)
+	idleEng = newIdleEngine(activityTracker)
+	idleActive.Store(true)
+
+	done := make(chan struct{})
+	go func() { idleEng.resumeUntilClear(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("resumeUntilClear must bail when the feature is re-enabled")
+	}
+}
+
 func TestParseControlMsg(t *testing.T) {
 	cases := []struct {
 		in, kind, arg string

--- a/internal/watcher/idle_engine.go
+++ b/internal/watcher/idle_engine.go
@@ -358,6 +358,56 @@ func (e *idleEngine) worktreeKeyForHost(host string) string {
 	return e.worktreeKeyByDomain[strings.ToLower(host)]
 }
 
+// resumeUntilClear is the disable path's safety net (replacing the tick that used
+// to re-resume disabled-but-suspended sites): it retries until nothing is left
+// suspended, catching a site whose slow mid-flight suspend resume() had skipped.
+func (e *idleEngine) resumeUntilClear() {
+	if e == nil {
+		return
+	}
+	deadline := time.Now().Add(5 * time.Minute)
+	for time.Now().Before(deadline) {
+		if idleActive.Load() {
+			return // re-enabled: the live session owns suspend/resume again
+		}
+		e.ResumeAllSuspended()
+		// Keep going while a suspend is still in-flight: it may not have written
+		// its list yet, so an empty config alone doesn't mean nothing's suspended.
+		if !persistedIdleSuspendExists() && !e.anyInFlight() {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// anyInFlight reports whether any site's suspend or resume goroutine is running.
+func (e *idleEngine) anyInFlight() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.inFlight) > 0
+}
+
+// persistedIdleSuspendExists reports whether any site or worktree still records a
+// non-empty idle-suspended worker list on disk. A read error returns true so the
+// drain keeps retrying rather than giving up and stranding a worker.
+func persistedIdleSuspendExists() bool {
+	reg, err := config.LoadSites()
+	if err != nil {
+		return true
+	}
+	for i := range reg.Sites {
+		if len(reg.Sites[i].IdleSuspendedWorkers) > 0 {
+			return true
+		}
+		for _, w := range reg.Sites[i].WorktreeIdleSuspended {
+			if len(w) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ResumeAllSuspended resumes every currently-suspended site at once and clears
 // any stale persisted suspended-worker lists. Called when idle-suspend is turned
 // off so workers come straight back immediately, and so a site whose on-disk
@@ -388,12 +438,14 @@ func (e *idleEngine) ResumeAllSuspended() {
 	changed := false
 	for i := range reg.Sites {
 		s := reg.Sites[i]
-		// Reconcile a stale main-site list (workers already running) by clearing it
-		// so it can't keep the dashboard showing the site asleep.
+		// Reconcile a stale main-site list (workers already running) by clearing it.
+		// Skip while a suspend is in-flight: it has written the list but not yet set
+		// e.suspended, so clearing now would strand it stopped with nothing to resume.
 		e.mu.Lock()
 		inSet := e.suspended[s.Name]
+		inFlight := e.inFlight[s.Name]
 		e.mu.Unlock()
-		if len(s.IdleSuspendedWorkers) > 0 && !inSet {
+		if len(s.IdleSuspendedWorkers) > 0 && !inSet && !inFlight {
 			_ = config.SetSiteIdleSuspendedWorkers(s.Name, nil)
 			changed = true
 		}

--- a/internal/watcher/idle_engine_test.go
+++ b/internal/watcher/idle_engine_test.go
@@ -258,6 +258,39 @@ func TestTickWorktrees_reconcilesStaleSuspendedCache(t *testing.T) {
 	}
 }
 
+// TestResumeAllSuspended_skipsReconcileWhileInFlight guards the toggle-off
+// stranding bug: a suspend that has persisted its list but not yet set e.suspended
+// must not have that list cleared by the reconcile branch (which would strand it).
+func TestResumeAllSuspended_skipsReconcileWhileInFlight(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	podman.UnitLifecycle = stubUnitStatus{active: map[string]bool{}}
+	t.Cleanup(func() { podman.UnitLifecycle = nil })
+
+	if err := config.AddSite(config.Site{
+		Name: "myapp", Path: "/srv/myapp", PHPVersion: "8.4", Domains: []string{"myapp.test"},
+		IdleSuspendedWorkers: []string{"queue"},
+	}); err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+
+	e := newIdleEngine(idle.NewTracker(nil))
+	e.mu.Lock()
+	e.suspended["myapp"] = false // not yet set by the in-flight suspend
+	e.inFlight["myapp"] = true
+	e.mu.Unlock()
+
+	e.ResumeAllSuspended()
+
+	site, err := config.FindSite("myapp")
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(site.IdleSuspendedWorkers) == 0 {
+		t.Error("reconcile cleared an in-flight suspend's list, stranding it")
+	}
+}
+
 func TestSplitWtKey_mainSite(t *testing.T) {
 	site, wtBase, isWt := splitWtKey("myapp")
 	if isWt || site != "myapp" || wtBase != "" {

--- a/internal/watcher/idle_feed.go
+++ b/internal/watcher/idle_feed.go
@@ -48,7 +48,7 @@ func StartIdle(notify func(), sourceWatcher func(stop <-chan struct{}) error) {
 	if cfg, err := config.LoadGlobal(); err == nil && cfg.IdleSuspend.Enabled {
 		enableIdle()
 	} else {
-		idleEng.ResumeAllSuspended()
+		go idleEng.resumeUntilClear()
 	}
 }
 
@@ -84,19 +84,18 @@ func enableIdle() {
 	}
 }
 
-// disableIdle tears the session down: resume every suspended worker, then stop
-// the tick, access feed, and source watcher. Holds idleMu for the whole body
-// (mirroring enableIdle) so a concurrent boot enable can't overlap sessions.
+// disableIdle stops the session (tick, access feed, source watcher), then resumes
+// every suspended worker in the background via resumeUntilClear, which retries so
+// a suspend mid-flight isn't skipped now that no later tick will catch it.
 func disableIdle() {
 	idleMu.Lock()
-	defer idleMu.Unlock()
-	if idleCancel == nil {
-		return // already stopped
+	if idleCancel != nil {
+		idleActive.Store(false)
+		idleCancel()
+		idleCancel = nil
 	}
-	idleActive.Store(false)
-	idleEng.ResumeAllSuspended()
-	idleCancel()
-	idleCancel = nil
+	idleMu.Unlock()
+	go idleEng.resumeUntilClear()
 }
 
 // handleAccessDatagram records one site touch per nginx access datagram, waking a


### PR DESCRIPTION
This fixes a bug in the dormant-when-off idle-suspend work from #540: toggling idle-suspend off only resumed some of a site's workers and left the rest stopped until the next watcher restart.

The cause is a race between the resume and an in-flight suspend. disableIdle did a single ResumeAllSuspended and then cancelled the engine tick, but resume skips any site whose suspend goroutine is still running (a vite suspend runs a one-time npm build before it stops the workers), and a suspend that hasn't finished hasn't written its persisted worker list yet. With the tick cancelled there was nothing to retry, so a site that started suspending in the seconds before the toggle was left stopped, either with its list still missing or about to be wrongly cleared.

The disable path now resumes in the background and retries until nothing is left suspended and no suspend is still in-flight, so a mid-flight suspend is caught the moment it settles and commits. It also no longer clears a site's persisted worker list while that site's suspend is in-flight, which would otherwise strand it with nothing to resume from, and a transient config read error keeps the drain retrying rather than giving up.
