### PR TITLE
Sleep idle sites on enable and resume robustly on disable

### DIFF
--- a/internal/watcher/idle_engine.go
+++ b/internal/watcher/idle_engine.go
@@ -138,20 +138,25 @@ func newIdleEngine(t *idle.Tracker) *idleEngine {
 	return e
 }
 
-// run drives the periodic suspend evaluation until the process exits.
+// run drives the suspend evaluation until the session is cancelled. It evaluates
+// once immediately so enabling idle-suspend sleeps already-idle sites at once
+// rather than waiting a full tick interval, then re-evaluates periodically.
 func (e *idleEngine) run(ctx context.Context) {
 	defer recoverEngine("ticker")
 	t := time.NewTicker(idleTickInterval)
 	defer t.Stop()
 	for {
+		if ctx.Err() != nil { // cancelled: don't evaluate after disable
+			return
+		}
+		e.tick()
+		// Persist last-active so a restart/deploy restores the countdowns
+		// instead of re-seeding to now.
+		_ = e.tracker.Save(config.IdleActivityFile())
 		select {
 		case <-ctx.Done(): // idle-suspend disabled: stop ticking
 			return
 		case <-t.C:
-			e.tick()
-			// Persist last-active so a restart/deploy restores the countdowns
-			// instead of re-seeding to now.
-			_ = e.tracker.Save(config.IdleActivityFile())
 		}
 	}
 }
@@ -416,21 +421,6 @@ func (e *idleEngine) ResumeAllSuspended() {
 	if e == nil {
 		return
 	}
-	// Resume the main sites the engine genuinely has suspended (workers stopped).
-	e.mu.Lock()
-	var mainNames []string
-	for name, on := range e.suspended {
-		if on {
-			if _, _, isWt := splitWtKey(name); !isWt {
-				mainNames = append(mainNames, name)
-			}
-		}
-	}
-	e.mu.Unlock()
-	for _, name := range mainNames {
-		e.resume(name)
-	}
-
 	reg, err := config.LoadSites()
 	if err != nil {
 		return
@@ -438,16 +428,14 @@ func (e *idleEngine) ResumeAllSuspended() {
 	changed := false
 	for i := range reg.Sites {
 		s := reg.Sites[i]
-		// Reconcile a stale main-site list (workers already running) by clearing it.
-		// Skip while a suspend is in-flight: it has written the list but not yet set
-		// e.suspended, so clearing now would strand it stopped with nothing to resume.
-		e.mu.Lock()
-		inSet := e.suspended[s.Name]
-		inFlight := e.inFlight[s.Name]
-		e.mu.Unlock()
-		if len(s.IdleSuspendedWorkers) > 0 && !inSet && !inFlight {
-			_ = config.SetSiteIdleSuspendedWorkers(s.Name, nil)
-			changed = true
+		// Resume the main site straight from its persisted list, forcing e.suspended
+		// so resume() proceeds even if our view drifted (idempotent: a stale running
+		// list is a no-op start, then resume clears it and publishes its own refresh).
+		if len(s.IdleSuspendedWorkers) > 0 {
+			e.mu.Lock()
+			e.suspended[s.Name] = true
+			e.mu.Unlock()
+			e.resume(s.Name)
 		}
 
 		// Resume every suspended worktree; if its checkout is gone, just clear the

--- a/internal/watcher/idle_engine_test.go
+++ b/internal/watcher/idle_engine_test.go
@@ -258,10 +258,10 @@ func TestTickWorktrees_reconcilesStaleSuspendedCache(t *testing.T) {
 	}
 }
 
-// TestResumeAllSuspended_skipsReconcileWhileInFlight guards the toggle-off
-// stranding bug: a suspend that has persisted its list but not yet set e.suspended
-// must not have that list cleared by the reconcile branch (which would strand it).
-func TestResumeAllSuspended_skipsReconcileWhileInFlight(t *testing.T) {
+// TestResumeAllSuspended_preservesInFlightList guards the toggle-off stranding
+// bug: while a suspend is in-flight, ResumeAllSuspended must not clear its
+// persisted list (resume no-ops on the inFlight guard and the drain retries).
+func TestResumeAllSuspended_preservesInFlightList(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	podman.UnitLifecycle = stubUnitStatus{active: map[string]bool{}}
@@ -287,7 +287,7 @@ func TestResumeAllSuspended_skipsReconcileWhileInFlight(t *testing.T) {
 		t.Fatalf("reload: %v", err)
 	}
 	if len(site.IdleSuspendedWorkers) == 0 {
-		t.Error("reconcile cleared an in-flight suspend's list, stranding it")
+		t.Error("cleared an in-flight suspend's list, stranding it")
 	}
 }
 


### PR DESCRIPTION
Two follow-up fixes to idle-suspend, both reported from real use after the dormant-when-off work landed.

Enabling idle-suspend waited up to a full 30 second tick before sleeping already-idle sites, because starting a session created a fresh ticker that only fires after its interval. The engine now evaluates once immediately when a session starts, so toggling idle-suspend on sleeps idle sites at once instead of a tick later.

Turning it off could also leave some workers stopped. The resume walked the engine's in-memory suspended set, and for a site whose persisted list was present but absent from that set it cleared the list without restarting the workers, stranding the site whenever the in-memory view had drifted, for instance while a suspend was still settling. Resume now works straight from each site's persisted list the same way the worktree path already did, forcing the restart and relying on it being idempotent, so a stale-but-running list is a harmless no-op and nothing is ever left stopped.
