### PR TITLE
fix: resolve bugs and regressions found reviewing the v1.24.1 work

### DIFF
--- a/internal/cli/frankenphp_reconcile_test.go
+++ b/internal/cli/frankenphp_reconcile_test.go
@@ -98,3 +98,65 @@ func TestReconcileStaleFrankenPHP(t *testing.T) {
 		}
 	})
 }
+
+func writeFakeCFPMQuadlet(t *testing.T, siteName string) string {
+	t.Helper()
+	dir := config.QuadletDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, podman.CustomFPMContainerName(siteName)+".container")
+	if err := os.WriteFile(path, []byte("[Container]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestReconcileStaleCustomFPM covers the mirror of the FrankenPHP orphan: a
+// custom-FPM site re-linked as plain FPM (or a reverse-proxied container) leaves
+// its per-site lerd-cfpm-<site> quadlet auto-starting. The reconcile removes it
+// only when the site is no longer fpm-custom, and never touches one still custom.
+func TestReconcileStaleCustomFPM(t *testing.T) {
+	t.Run("removes stale quadlet when site is no longer custom-fpm", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		rec := &stopRecorder{}
+		stubFrankenPHPTeardown(t, rec)
+
+		path := writeFakeCFPMQuadlet(t, "shopapp")
+		reconcileStaleCustomFPM(config.Site{Name: "shopapp"})
+
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("stale cfpm quadlet should be removed, stat err = %v", err)
+		}
+		if len(rec.stopped) != 1 || rec.stopped[0] != podman.CustomFPMContainerName("shopapp") {
+			t.Errorf("stopped = %v, want [%s]", rec.stopped, podman.CustomFPMContainerName("shopapp"))
+		}
+	})
+
+	t.Run("keeps quadlet when site is still custom-fpm", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		rec := &stopRecorder{}
+		stubFrankenPHPTeardown(t, rec)
+
+		path := writeFakeCFPMQuadlet(t, "billing")
+		reconcileStaleCustomFPM(config.Site{Name: "billing", Runtime: "fpm-custom"})
+
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("custom-fpm quadlet should be kept, stat err = %v", err)
+		}
+		if len(rec.stopped) != 0 {
+			t.Errorf("stopped = %v, want none (site still custom-fpm)", rec.stopped)
+		}
+	})
+
+	t.Run("no-op when no cfpm quadlet exists", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		rec := &stopRecorder{}
+		stubFrankenPHPTeardown(t, rec)
+
+		reconcileStaleCustomFPM(config.Site{Name: "freshapp"})
+		if len(rec.stopped) != 0 {
+			t.Errorf("stopped = %v, want none (no quadlet)", rec.stopped)
+		}
+	})
+}

--- a/internal/cli/idle.go
+++ b/internal/cli/idle.go
@@ -56,14 +56,12 @@ func newIdlePinCmd(verb string, pinned bool) *cobra.Command {
 	}
 }
 
-// SetSitePinned toggles whether a site is excluded from idle-suspend.
+// SetSitePinned toggles whether a site is excluded from idle-suspend. It delegates
+// to the locked, single-field config mutator so a pin/unpin can't clobber a
+// concurrent idle-engine write (the old FindSite -> mutate -> AddSite replaced the
+// whole record and would lose a SetSiteIdleSuspendedWorkers write that raced it).
 func SetSitePinned(name string, pinned bool) error {
-	site, err := config.FindSite(name)
-	if err != nil {
-		return err
-	}
-	site.Pinned = pinned
-	return config.AddSite(*site)
+	return config.SetSitePinned(name, pinned)
 }
 
 func newIdleToggleCmd(verb string, enabled bool) *cobra.Command {

--- a/internal/cli/idle_worktree_test.go
+++ b/internal/cli/idle_worktree_test.go
@@ -7,6 +7,30 @@ import (
 	"github.com/geodro/lerd/internal/config"
 )
 
+func TestWorktreeWorkerIdleSuspended(t *testing.T) {
+	site := &config.Site{
+		Name: "shop",
+		WorktreeIdleSuspended: map[string][]string{
+			"feature-x": {"vite", "queue"},
+		},
+	}
+	cases := []struct {
+		name   string
+		wtPath string
+		worker string
+		want   bool
+	}{
+		{"suspended worker in worktree", "/home/u/shop-worktrees/feature-x", "vite", true},
+		{"other worker in same worktree", "/home/u/shop-worktrees/feature-x", "reverb", false},
+		{"worker in a worktree with no suspensions", "/home/u/shop-worktrees/main", "vite", false},
+	}
+	for _, c := range cases {
+		if got := worktreeWorkerIdleSuspended(site, c.wtPath, c.worker); got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
 func TestIdleTimingStatus(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	timeout := time.Hour

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -9,6 +9,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteops"
 	"github.com/geodro/lerd/internal/store"
 	"github.com/spf13/cobra"
@@ -159,6 +160,9 @@ func runLink(args []string) error {
 		if err := config.AddSite(site); err != nil {
 			return fmt.Errorf("registering site: %w", err)
 		}
+		// A site that used to be FrankenPHP or custom-FPM and now reverse-proxies a
+		// container leaves its old per-site PHP quadlet auto-starting; clear it.
+		reconcileStaleRuntimeQuadlets(site)
 		_ = config.SyncProjectDomains(cwd, site.Domains, cfg.DNS.TLD)
 		if err := siteops.FinishCustomLink(site, proj.Container); err != nil {
 			return err
@@ -193,6 +197,9 @@ func runLink(args []string) error {
 		if err := config.AddSite(site); err != nil {
 			return fmt.Errorf("registering site: %w", err)
 		}
+		// A site that used to be FrankenPHP or custom-FPM and now proxies a host
+		// dev server leaves its old per-site PHP quadlet auto-starting; clear it.
+		reconcileStaleRuntimeQuadlets(site)
 		_ = config.SyncProjectDomains(cwd, site.Domains, cfg.DNS.TLD)
 		if err := siteops.FinishHostProxyLink(site); err != nil {
 			return err
@@ -271,15 +278,22 @@ func runLink(args []string) error {
 	// by fastcgi from its own image, built from the project's Containerfile.
 	if proj != nil && proj.Container != nil && proj.Container.Port == 0 {
 		site.Runtime = "fpm-custom"
+		// The PHP version is fixed by the Containerfile's FROM lerd-php<ver>-fpm line,
+		// not project detection; honour it so the reported version and the per-version
+		// ini mounts match the image the container actually runs.
+		if v := podman.CustomFPMBaseVersion(cwd, proj.Container); v != "" {
+			site.PHPVersion = v
+			phpVersion = v
+		}
 	}
 
 	if err := config.AddSite(site); err != nil {
 		return fmt.Errorf("registering site: %w", err)
 	}
 
-	// A re-link of a site that dropped its frankenphp runtime leaves the old
-	// per-site FrankenPHP quadlet behind; reconcile it to the site's real type.
-	reconcileStaleFrankenPHP(site)
+	// A re-link of a site that dropped its frankenphp or custom-FPM runtime
+	// leaves the old per-site quadlet behind; reconcile it to the site's real type.
+	reconcileStaleRuntimeQuadlets(site)
 
 	_ = config.SyncProjectDomains(cwd, site.Domains, cfg.DNS.TLD)
 

--- a/internal/cli/node_exec.go
+++ b/internal/cli/node_exec.go
@@ -84,10 +84,13 @@ func runNpmCaptured(dir string, args ...string) (string, error) {
 }
 
 // bunRunnerFor returns the host bun binary to use for dir, or "" to fall back
-// to npm/fnm. When the project is configured for bun but no bun is installed it
-// prints a one-line install hint and returns "" so the caller uses npm instead
-// of failing. lerd never installs or version-manages the host bun itself.
-func bunRunnerFor(dir string) string {
+// to npm/fnm. When the project is configured for bun but no bun is installed and
+// warn is set it prints a one-line install hint and returns "" so the caller uses
+// npm instead of failing. warn is true only for interactive CLI runs; the worker
+// unit-generation path (which also runs on the daemon-side idle resume) passes
+// false so the hint doesn't spam the daemon's stderr on every reconcile. lerd
+// never installs or version-manages the host bun itself.
+func bunRunnerFor(dir string, warn bool) string {
 	// An explicit `js_runtime: node` pins the project to Node and opts out of
 	// both bun detection and the no-Node fallback — for apps bun can't run, e.g.
 	// NestJS with native addons. (JSRuntime normalizes node/nodejs/npm.)
@@ -96,7 +99,7 @@ func bunRunnerFor(dir string) string {
 	}
 	bun := nodeDet.BunPath()
 	if nodeDet.UsesBun(dir) {
-		if bun == "" {
+		if bun == "" && warn {
 			fmt.Fprintln(os.Stderr, "lerd: this project uses bun but bun isn't installed — falling back to npm.")
 			fmt.Fprintln(os.Stderr, "      install it with: curl -fsSL https://bun.sh/install | bash")
 		}
@@ -140,7 +143,7 @@ func runBun(dir, bun string, args []string) error {
 // uses bun (frozen adds --frozen-lockfile), otherwise `npm ci`/`npm install`
 // via fnm.
 func runJSInstall(dir string, frozen bool) error {
-	if bun := bunRunnerFor(dir); bun != "" {
+	if bun := bunRunnerFor(dir, true); bun != "" {
 		args := []string{"install"}
 		// --frozen-lockfile only makes sense when a bun lockfile exists; npm's
 		// package-lock (the `frozen` arg) doesn't apply to bun.
@@ -161,7 +164,7 @@ func runJSInstall(dir string, frozen bool) error {
 // runJSScript runs a package.json script in dir via `bun run <script>` when the
 // project uses bun, otherwise `npm run <script>` via fnm.
 func runJSScript(dir, script string) error {
-	if bun := bunRunnerFor(dir); bun != "" {
+	if bun := bunRunnerFor(dir, true); bun != "" {
 		return runBun(dir, bun, []string{"run", script})
 	}
 	return runWithFnm("npm", []string{"run", script})

--- a/internal/cli/php_bun.go
+++ b/internal/cli/php_bun.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
@@ -34,11 +35,11 @@ func newPhpBunUpdateCmd() *cobra.Command {
 		Short: "Update the container's bun in place (bun upgrade)",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			version, err := phpExtVersion(args)
+			version, err := bunDisplayVersion(args)
 			if err != nil {
 				return err
 			}
-			container := fpmContainerName(version)
+			container := bunFPMContainer(version)
 			if running, _ := podman.ContainerRunning(container); !running {
 				return fmt.Errorf("PHP %s FPM container is not running — start it with: %s", version, serviceStartHint(container))
 			}
@@ -119,11 +120,52 @@ func fpmContainerName(version string) string {
 	return "lerd-php" + strings.ReplaceAll(version, ".", "") + "-fpm"
 }
 
+// bunFPMSite returns the custom-FPM site the current directory belongs to, or nil
+// when the cwd isn't inside one (the common shared-container case).
+func bunFPMSite() *config.Site {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+	s, err := config.FindSiteByPath(siteRootFor(cwd))
+	if err != nil || s == nil || !s.IsCustomFPM() {
+		return nil
+	}
+	return s
+}
+
+// bunFPMContainer resolves the FPM container php:bun should exec into for version:
+// the per-site custom-FPM container when run inside a custom-FPM site, otherwise
+// the shared lerd-php<version>-fpm container. bun lives in a host-backed volume
+// every FPM container shares, so a custom-FPM-only user can reach it through their
+// own running container instead of being told to start a shared one they don't use.
+func bunFPMContainer(version string) string {
+	if s := bunFPMSite(); s != nil {
+		return podman.CustomFPMContainerName(s.Name)
+	}
+	return fpmContainerName(version)
+}
+
 // bunInstalledInContainer reports whether a working bun already lives in the
-// version's FPM container volume.
+// resolved FPM container volume.
 func bunInstalledInContainer(version string) bool {
-	container := fpmContainerName(version)
+	container := bunFPMContainer(version)
 	return podman.Cmd("exec", container, "/root/.bun/bin/bun", "--version").Run() == nil
+}
+
+// bunDisplayVersion is the PHP version php:bun reports in its messages: a
+// custom-FPM site's pinned version (fixed by its Containerfile FROM line, which can
+// differ from what the project would detect), otherwise the version from args or
+// cwd detection. Keeps the reported version aligned with the container actually used.
+func bunDisplayVersion(args []string) (string, error) {
+	version, err := phpExtVersion(args)
+	if err != nil {
+		return "", err
+	}
+	if s := bunFPMSite(); s != nil {
+		return s.PHPVersion, nil
+	}
+	return version, nil
 }
 
 // bunVolumeMounted reports whether the persistent /root/.bun volume is already
@@ -154,9 +196,20 @@ func restartFPMAndWait(container string) error {
 // musl build. It only restarts the container when the persistent volume isn't
 // mounted yet, so reruns on an already-prepared container are non-disruptive.
 func installContainerBun(version, pin string, w io.Writer) error {
+	// Target the per-site custom-FPM container when run inside one, otherwise the
+	// shared per-version container. Either way we rewrite the matching quadlet so a
+	// container created before the bun volume shipped gains the /root/.bun mount.
+	site := bunFPMSite()
 	container := fpmContainerName(version)
-
-	if err := podman.WriteFPMQuadlet(version); err != nil {
+	if site != nil {
+		container = podman.CustomFPMContainerName(site.Name)
+		// A custom-FPM site's version is pinned by its Containerfile, so report that
+		// rather than the detected one in the messages below and the quadlet.
+		version = site.PHPVersion
+		if err := podman.WriteCustomFPMQuadlet(site.Name, version); err != nil {
+			return fmt.Errorf("updating custom FPM quadlet: %w", err)
+		}
+	} else if err := podman.WriteFPMQuadlet(version); err != nil {
 		return fmt.Errorf("updating FPM quadlet: %w", err)
 	}
 	if running, _ := podman.ContainerRunning(container); !running {
@@ -195,11 +248,11 @@ func newPhpBunVersionCmd() *cobra.Command {
 		Short: "Show the bun version installed in the PHP-FPM container",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			version, err := phpExtVersion(args)
+			version, err := bunDisplayVersion(args)
 			if err != nil {
 				return err
 			}
-			container := fpmContainerName(version)
+			container := bunFPMContainer(version)
 			if running, _ := podman.ContainerRunning(container); !running {
 				return fmt.Errorf("PHP %s FPM container is not running — start it with: %s", version, serviceStartHint(container))
 			}

--- a/internal/cli/php_bun_test.go
+++ b/internal/cli/php_bun_test.go
@@ -7,8 +7,70 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
 )
+
+// bunFPMContainer must target a custom-FPM site's per-site container when run from
+// inside it (so a custom-FPM-only user can reach the shared bun volume), and the
+// shared per-version container everywhere else.
+func TestBunFPMContainer_CustomFPMSite(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+
+	siteDir := filepath.Join(home, "shop")
+	if err := os.MkdirAll(siteDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveSites(&config.SiteRegistry{Sites: []config.Site{
+		{Name: "shop", Path: siteDir, PHPVersion: "8.4", Runtime: "fpm-custom"},
+	}}); err != nil {
+		t.Fatalf("seed sites: %v", err)
+	}
+
+	t.Chdir(siteDir)
+	if got, want := bunFPMContainer("8.4"), podman.CustomFPMContainerName("shop"); got != want {
+		t.Errorf("inside custom-FPM site: bunFPMContainer = %q, want %q", got, want)
+	}
+
+	t.Chdir(home)
+	if got, want := bunFPMContainer("8.4"), fpmContainerName("8.4"); got != want {
+		t.Errorf("outside any custom-FPM site: bunFPMContainer = %q, want %q", got, want)
+	}
+}
+
+// bunDisplayVersion must report a custom-FPM site's pinned version (fixed by its
+// Containerfile FROM line) rather than what the project would detect, so php:bun's
+// messages don't show a version that differs from the container it actually uses.
+func TestBunDisplayVersion_CustomFPMUsesPinned(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+
+	siteDir := filepath.Join(home, "shop")
+	if err := os.MkdirAll(siteDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// .php-version says 8.3, but the site is pinned to 8.4 by its FROM line.
+	if err := os.WriteFile(filepath.Join(siteDir, ".php-version"), []byte("8.3\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveSites(&config.SiteRegistry{Sites: []config.Site{
+		{Name: "shop", Path: siteDir, PHPVersion: "8.4", Runtime: "fpm-custom"},
+	}}); err != nil {
+		t.Fatalf("seed sites: %v", err)
+	}
+
+	t.Chdir(siteDir)
+	got, err := bunDisplayVersion(nil)
+	if err != nil {
+		t.Fatalf("bunDisplayVersion: %v", err)
+	}
+	if got != "8.4" {
+		t.Errorf("inside custom-FPM site: bunDisplayVersion = %q, want 8.4 (pinned, not detected 8.3)", got)
+	}
+}
 
 // removeContainerBun should clear every entry in the shared bun volume so a
 // later install starts clean, while leaving the mount dir itself in place.

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -112,6 +112,35 @@ func reconcileStaleFrankenPHP(site config.Site) {
 	removeFrankenPHPContainer(site.Name)
 }
 
+// removeCustomFPMContainer stops a site's per-site custom-FPM container, removes
+// its quadlet, and reloads systemd so the generated unit disappears. Mirrors
+// removeFrankenPHPContainer for the fpm-custom runtime.
+func removeCustomFPMContainer(siteName string) {
+	_ = podman.StopUnit(podman.CustomFPMContainerName(siteName))
+	_ = podman.RemoveCustomFPMQuadlet(siteName)
+	_ = podman.DaemonReloadFn()
+}
+
+// reconcileStaleCustomFPM removes a leftover per-site custom-FPM quadlet when a
+// (re)linked site is no longer fpm-custom (e.g. the Containerfile was removed, or
+// a port was added so it became a reverse-proxied custom container). Like the
+// FrankenPHP one, that quadlet is WantedBy=default.target with Restart=always, so
+// podman's generator keeps auto-starting an orphan that lerd start/stop miss.
+func reconcileStaleCustomFPM(site config.Site) {
+	if site.IsCustomFPM() || !podman.QuadletInstalled(podman.CustomFPMContainerName(site.Name)) {
+		return
+	}
+	removeCustomFPMContainer(site.Name)
+}
+
+// reconcileStaleRuntimeQuadlets clears any per-site FrankenPHP or custom-FPM
+// quadlet a site no longer uses, so changing a project's runtime (or dropping its
+// Containerfile) on re-link never strands an auto-starting orphan container.
+func reconcileStaleRuntimeQuadlets(site config.Site) {
+	reconcileStaleFrankenPHP(site)
+	reconcileStaleCustomFPM(site)
+}
+
 func runtimeLabel(site *config.Site) string {
 	if site.IsFrankenPHP() {
 		if site.RuntimeWorker {

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -954,6 +954,13 @@ func restoreSiteInfrastructure() {
 				continue
 			}
 			for _, wt := range worktrees {
+				// Leave a worktree worker the idle engine suspended fully down, the
+				// same as the main-site guard above: restoreWorker re-enables it (so a
+				// later boot's default.target pulls it in, past dropIdleSuspendedUnits)
+				// and the engine, not install, owns resuming it on real activity.
+				if worktreeWorkerIdleSuspended(&s, wt.Path, w) {
+					continue
+				}
 				if services.Mgr.IsEnabled(workerUnitName(s.Name, wt.Path, w)) {
 					continue
 				}

--- a/internal/cli/worker_darwin.go
+++ b/internal/cli/worker_darwin.go
@@ -88,7 +88,7 @@ func writeWorkerHostUnit(unitName, sitePath, command, restart string) (bool, err
 	// host-proxy sites in any other language run the command directly.
 	nodeVersion := ""
 	bunDir := ""
-	if bun := bunRunnerFor(sitePath); bun != "" {
+	if bun := bunRunnerFor(sitePath, false); bun != "" {
 		command = nodeDet.Bunify(command)
 		bunDir = filepath.Dir(bun)
 	} else if isNodeProject(sitePath) && lerdManagesNode() {

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -122,7 +122,7 @@ func writeHostWorkerUnitFile(unitName, label, siteName, sitePath, command, resta
 	envPath := config.BinDir() + ":" + filepath.Join(home, ".local", "bin") + ":/usr/local/bin:/usr/bin:/bin"
 
 	shellCommand := command
-	if bun := bunRunnerFor(sitePath); bun != "" {
+	if bun := bunRunnerFor(sitePath, false); bun != "" {
 		// bun is self-contained: rewrite npm/npx/node to bun/bunx and run it
 		// directly, no fnm wrap. Put ~/.bun/bin on PATH so a bare `bun` resolves.
 		shellCommand = nodeDet.Bunify(command)

--- a/internal/cli/worktree_add.go
+++ b/internal/cli/worktree_add.go
@@ -589,6 +589,15 @@ func AutoStartOptedInWorktreeWorkers(site *config.Site, worktreePath, phpVersion
 	}
 }
 
+// worktreeWorkerIdleSuspended reports whether the idle engine has suspended the
+// named worker for the worktree at wtPath (keyed by its unit-slug base), so the
+// restore/autostart paths can leave it down rather than re-enabling a unit a
+// later boot's default.target would then resurrect.
+func worktreeWorkerIdleSuspended(site *config.Site, wtPath, worker string) bool {
+	wtBase := config.WorktreeUnitSlug(filepath.Base(wtPath))
+	return containsString(site.WorktreeIdleSuspended[wtBase], worker)
+}
+
 // worktreeWorkersToStart drops any worker the idle engine has suspended for the
 // worktree (keyed by its unit-slug base) from names, so an autostart pass never
 // resurrects a deliberately-sleeping worker. Returns names unchanged when the

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -496,6 +496,26 @@ func SetSiteIdleSuspendedWorkers(name string, workers []string) error {
 	return fmt.Errorf("site %q not found", name)
 }
 
+// SetSitePinned atomically updates just a site's idle-suspend pin flag. Like
+// SetSiteIdleSuspendedWorkers it rewrites only that field under the write lock, so
+// `lerd idle pin/unpin` can't clobber a concurrent SetSiteIdleSuspendedWorkers
+// write the idle engine makes for the same site.
+func SetSitePinned(name string, pinned bool) error {
+	siteWriteMu.Lock()
+	defer siteWriteMu.Unlock()
+	reg, err := LoadSites()
+	if err != nil {
+		return err
+	}
+	for i := range reg.Sites {
+		if reg.Sites[i].Name == name {
+			reg.Sites[i].Pinned = pinned
+			return SaveSites(reg)
+		}
+	}
+	return fmt.Errorf("site %q not found", name)
+}
+
 // SetWorktreeIdleSuspendedWorkers atomically updates a single worktree's
 // idle-suspended worker list (keyed by the worktree's unit-slug base). Passing an
 // empty list clears that worktree's entry, and clearing the last entry drops the

--- a/internal/config/site_idle_test.go
+++ b/internal/config/site_idle_test.go
@@ -81,6 +81,36 @@ func TestSetSiteIdleSuspendedWorkers_preservesOtherFields(t *testing.T) {
 	}
 }
 
+// TestSetSitePinned_preservesOtherFields pins that toggling the pin flag through
+// the atomic setter rewrites only Pinned, so `lerd idle pin/unpin` can't lose a
+// concurrent idle-engine SetSiteIdleSuspendedWorkers write for the same site.
+func TestSetSitePinned_preservesOtherFields(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dir)
+
+	seed := Site{Name: "a", Path: "/x", PHPVersion: "8.4", Paused: true, IdleSuspendedWorkers: []string{"queue"}}
+	if err := SaveSites(&SiteRegistry{Sites: []Site{seed}}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := SetSitePinned("a", true); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	reg, err := LoadSites()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	s := reg.Sites[0]
+	if !s.Pinned {
+		t.Errorf("Pinned=%v, want true", s.Pinned)
+	}
+	if !s.Paused || len(s.IdleSuspendedWorkers) != 1 || s.IdleSuspendedWorkers[0] != "queue" {
+		t.Errorf("Paused=%v IdleSuspendedWorkers=%v, want both preserved", s.Paused, s.IdleSuspendedWorkers)
+	}
+	if err := SetSitePinned("missing", true); err == nil {
+		t.Errorf("want error for unknown site")
+	}
+}
+
 // TestConcurrentAddSite_noLostUpdate guards the write-mutex fix: many goroutines
 // each adding a distinct site must all land, with no interleaved read-modify-write
 // silently dropping one (the race that let one site's worker list bleed onto

--- a/internal/logsource/read.go
+++ b/internal/logsource/read.go
@@ -15,6 +15,12 @@ import (
 
 const defaultLines = 50
 
+// maxLines caps Opts.Lines so a caller-supplied value (the MCP logs tool exposes
+// it directly) can't drive a huge slice preallocation — make([]Entry, 0, n) with
+// a billion would OOM the process, an unrecoverable fatal error. The byte tail is
+// already capped at applog.MaxReadBytes, so no real source yields more than this.
+const maxLines = 10000
+
 // Opts are the filters applied to a fetch. Empty fields are ignored.
 type Opts struct {
 	Since string // relative ("15m", "2h30m"), absolute timestamp, or a prior Cursor
@@ -55,6 +61,9 @@ func (r Result) Lines() []string {
 func Read(src Source, opts Opts) (Result, error) {
 	if opts.Lines <= 0 {
 		opts.Lines = defaultLines
+	}
+	if opts.Lines > maxLines {
+		opts.Lines = maxLines
 	}
 	switch src.Kind {
 	case KindFile:
@@ -164,6 +173,12 @@ func readPodman(src Source, opts Opts) (Result, error) {
 	_ = cmd.Run() // non-zero when the container isn't running — return what we have
 
 	matcher := compileGrep(opts.Grep)
+	// `podman logs --since` is inclusive and only second-granular, and the cursor we
+	// hand back is a full-precision timestamp, so polling with since=<cursor> would
+	// otherwise re-emit the boundary line (and its same-second siblings) every call.
+	// Drop entries at or before `since` here, mirroring the file path's exclusive
+	// cursor so a poll yields only genuinely newer lines.
+	since, sinceOK := parseSince(opts.Since)
 	var out []Entry
 	for _, line := range strings.Split(strings.TrimRight(StripANSI(buf.String()), "\n"), "\n") {
 		if line == "" {
@@ -172,6 +187,11 @@ func readPodman(src Source, opts Opts) (Result, error) {
 		ts, text := splitPodmanTimestamp(line)
 		if matcher != nil && !matcher(text) {
 			continue
+		}
+		if sinceOK {
+			if t, ok := parseAbs(ts); ok && !t.After(since) {
+				continue
+			}
 		}
 		out = append(out, Entry{Time: ts, Text: text})
 	}

--- a/internal/logsource/read_test.go
+++ b/internal/logsource/read_test.go
@@ -100,6 +100,21 @@ func TestRead_File_LinesCap(t *testing.T) {
 	}
 }
 
+// TestRead_LinesClampedToMax guards the MCP-exposed lines arg: a huge value must
+// be clamped before it reaches make([]Entry, 0, n), which would otherwise OOM the
+// process on an unrecoverable fatal error rather than just return fewer lines.
+func TestRead_LinesClampedToMax(t *testing.T) {
+	res, err := Read(monologSource(t, monologFixture), Opts{Lines: 1 << 40})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	// The fixture has only a handful of entries; the point is that the absurd Lines
+	// value was clamped (no OOM) and we still got the available window back.
+	if len(res.Entries) == 0 {
+		t.Fatalf("want the available entries back, got none")
+	}
+}
+
 func TestRead_File_TimeWindow(t *testing.T) {
 	res, err := Read(monologSource(t, monologFixture), Opts{Lines: 10, Since: "2026-06-11 10:07:00"})
 	if err != nil {

--- a/internal/podman/customfpm.go
+++ b/internal/podman/customfpm.go
@@ -79,3 +79,25 @@ func generateCustomFPMQuadlet(siteName, version string) (string, error) {
 func RemoveCustomFPMQuadlet(siteName string) error {
 	return RemoveQuadlet(CustomFPMContainerName(siteName))
 }
+
+// CustomFPMBaseVersion returns the dotted PHP version a custom-FPM site's
+// Containerfile builds FROM (e.g. "FROM lerd-php84-fpm:local" -> "8.4"), or "" when
+// the base isn't a lerd FPM image. A custom-FPM site's PHP version is fixed by that
+// FROM line, not project detection, so the caller can report the right version and
+// mount the matching per-version inis instead of a detected one that may differ.
+func CustomFPMBaseVersion(projectPath string, cfg *config.ContainerConfig) string {
+	base := ContainerBaseImage(projectPath, cfg)
+	if i := strings.IndexByte(base, ':'); i >= 0 {
+		base = base[:i]
+	}
+	if !strings.HasPrefix(base, "lerd-php") || !strings.HasSuffix(base, "-fpm") {
+		return ""
+	}
+	short := strings.TrimSuffix(strings.TrimPrefix(base, "lerd-php"), "-fpm")
+	for _, v := range config.SupportedPHPVersions {
+		if strings.ReplaceAll(v, ".", "") == short {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/podman/customfpm_test.go
+++ b/internal/podman/customfpm_test.go
@@ -1,11 +1,36 @@
 package podman
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
 )
+
+func TestCustomFPMBaseVersion(t *testing.T) {
+	cases := []struct {
+		name string
+		from string
+		want string
+	}{
+		{"short-form lerd fpm base", "FROM lerd-php84-fpm:local\n", "8.4"},
+		{"older version", "FROM lerd-php82-fpm:local\nWORKDIR /app\n", "8.2"},
+		{"no tag", "FROM lerd-php83-fpm\n", "8.3"},
+		{"non-lerd base returns empty", "FROM php:8.4-fpm-alpine\n", ""},
+		{"unknown version returns empty", "FROM lerd-php99-fpm:local\n", ""},
+	}
+	for _, c := range cases {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "Containerfile.lerd"), []byte(c.from), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if got := CustomFPMBaseVersion(dir, nil); got != c.want {
+			t.Errorf("%s: CustomFPMBaseVersion = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
 
 func TestCustomFPMContainerName(t *testing.T) {
 	if got := CustomFPMContainerName("myapp"); got != "lerd-cfpm-myapp" {

--- a/internal/podman/frankenphp_build_test.go
+++ b/internal/podman/frankenphp_build_test.go
@@ -112,6 +112,12 @@ func TestRenderFrankenPHPContainerfile(t *testing.T) {
 	if !strings.Contains(cf, "jq") {
 		t.Errorf("custom package not rendered:\n%s", cf)
 	}
+	// Custom packages (which carry a custom extension's apk build deps) must be
+	// installed BEFORE the extension loop, or a custom extension that needs them
+	// can't compile and silently degrades to "missing".
+	if pkgIdx, extIdx := strings.Index(cf, "apk add --no-cache jq"), strings.Index(cf, "install-php-extensions"); pkgIdx < 0 || extIdx < 0 || pkgIdx > extIdx {
+		t.Errorf("custom packages must be installed before the extension loop (pkg at %d, ext at %d):\n%s", pkgIdx, extIdx, cf)
+	}
 }
 
 // TestNeedsFrankenPHPRebuild exercises the label-vs-hash comparison through the

--- a/internal/podman/quadlets/lerd-frankenphp.Containerfile
+++ b/internal/podman/quadlets/lerd-frankenphp.Containerfile
@@ -10,6 +10,12 @@
 # only via CLI, which execs into the shared FPM container. Both stay FPM-only.
 FROM docker.io/dunglas/frankenphp:php{{.Version}}-alpine
 
+# User-requested extra Alpine packages (lerd php:pkg) plus any apk build deps a
+# custom extension needs to compile. Installed BEFORE the extension loop below so
+# a custom extension that builds on FPM can find its deps here too; empty until
+# opted in.
+{{.CustomPackages}}
+
 # Runtime extensions + Xdebug. install-php-extensions (shipped in the base) builds
 # each for the ZTS runtime, pulls its runtime libs, and trims the build toolchain.
 # The core set installs in one step; the PECL-built extensions, any user custom
@@ -40,9 +46,6 @@ RUN apk add --no-cache --virtual .lerd-devtools-build autoconf make g++ \
          && make -j"$(nproc)" && make install && docker-php-ext-enable lerd_devtools; } || true; \
     apk del .lerd-devtools-build || true; \
     rm -rf /tmp/lerd-devtools /var/cache/apk/*
-
-# User-requested extra Alpine packages (lerd php:pkg). Empty until opted in.
-{{.CustomPackages}}
 
 # Lerd mkcert CA so the app trusts local .test HTTPS from inside the container.
 {{.MkcertCA}}

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -388,14 +388,20 @@ func (e *EnrichedSite) enrichVersions(s config.Site, fw *config.Framework, hasFw
 		return
 	}
 
-	phpMin, phpMax := "", ""
-	if hasFw {
-		phpMin, phpMax = fw.PHP.Min, fw.PHP.Max
-	}
-	detected := phpPkg.DetectVersionClamped(s.Path, phpMin, phpMax, s.PHPVersion)
-	if detected != s.PHPVersion {
-		e.PHPVersion = detected
-		e.PHPVersionChanged = true
+	// A custom-FPM site's PHP version is fixed by its Containerfile FROM line, so
+	// don't let detection override it — otherwise this enrichment (run by lerd-ui
+	// and the TUI, then persisted) drifts the stored version away from the image the
+	// container actually runs, undoing what link pinned. Node tooling still applies.
+	if !s.IsCustomFPM() {
+		phpMin, phpMax := "", ""
+		if hasFw {
+			phpMin, phpMax = fw.PHP.Min, fw.PHP.Max
+		}
+		detected := phpPkg.DetectVersionClamped(s.Path, phpMin, phpMax, s.PHPVersion)
+		if detected != s.PHPVersion {
+			e.PHPVersion = detected
+			e.PHPVersionChanged = true
+		}
 	}
 
 	if nodeDetected, err := nodePkg.DetectVersion(s.Path); err == nil && nodeDetected != "" {

--- a/internal/siteinfo/siteinfo_test.go
+++ b/internal/siteinfo/siteinfo_test.go
@@ -87,6 +87,28 @@ func TestEnrichVersions_CustomContainerSkipped(t *testing.T) {
 			t.Error("PHPVersion should not be empty for a non-container site")
 		}
 	})
+
+	// A custom-FPM site's PHP version is fixed by its Containerfile FROM line. The
+	// detection-and-persist enrichment path must not override it, or it drifts the
+	// stored version away from the image the container runs (it did, clobbering the
+	// link-pinned value, until enrichVersions learned to skip custom-FPM).
+	t.Run("custom-FPM site keeps its pinned PHP version", func(t *testing.T) {
+		dir := t.TempDir()
+		// .php-version says 8.4, but the site is pinned to 8.3 by its FROM line.
+		if err := os.WriteFile(filepath.Join(dir, ".php-version"), []byte("8.4\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		e := &EnrichedSite{Name: "cfpm", Path: dir, PHPVersion: "8.3"}
+		s := config.Site{Name: "cfpm", Path: dir, PHPVersion: "8.3", Runtime: "fpm-custom"}
+		e.enrichVersions(s, nil, false)
+
+		if e.PHPVersion != "8.3" {
+			t.Errorf("PHPVersion = %q, want 8.3 (pinned by FROM, not re-detected)", e.PHPVersion)
+		}
+		if e.PHPVersionChanged {
+			t.Error("PHPVersionChanged should be false for a custom-FPM site")
+		}
+	})
 }
 
 // ── Enrich: UsesPHP detection ──────────────────────────────────────────────

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"context"
 	"os/exec"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -44,6 +45,11 @@ type Snapshot struct {
 // need a live podman or systemd.
 var readerFn = readPodmanStats
 var hostReaderFn = readHostProcesses
+
+// numCPU reports the host core count used to normalize the per-core CPU sum into a
+// host fraction. A function var so tests can pin it and assert deterministically
+// regardless of the machine they run on.
+var numCPU = runtime.NumCPU
 
 const readTimeout = 6 * time.Second
 
@@ -112,6 +118,15 @@ func Read() Snapshot {
 		}
 		return out.Containers[i].MemBytes > out.Containers[j].MemBytes
 	})
+	// Each row's CPU% is normalized to a single core (podman stats and the host
+	// systemd-accounting reader both report per-core), so the raw sum is per-core
+	// and on a multi-core box can far exceed 100%. The headline frames it as a
+	// share of the whole host (like the memory total), so divide by the core count
+	// to turn the per-core sum into a true host fraction. Per-row CPU% stays
+	// per-core, the intuitive "this process is pegging one core" reading.
+	if cores := numCPU(); cores > 1 {
+		out.TotalCPUPercent /= float64(cores)
+	}
 	return out
 }
 

--- a/internal/stats/stats_test.go
+++ b/internal/stats/stats_test.go
@@ -89,7 +89,17 @@ func noHostProcesses(t *testing.T) {
 	t.Cleanup(SetHostReader(func() ([]ContainerStat, error) { return nil, nil }))
 }
 
+// pinNumCPU pins the host core count Read uses to normalize the CPU total, so the
+// per-core-sum assertions below stay deterministic regardless of the test machine.
+func pinNumCPU(t *testing.T, n int) {
+	t.Helper()
+	prev := numCPU
+	numCPU = func() int { return n }
+	t.Cleanup(func() { numCPU = prev })
+}
+
 func TestRead_SortsByCombinedLoad(t *testing.T) {
+	pinNumCPU(t, 1)
 	noHostProcesses(t)
 	restore := SetReader(func() ([]ContainerStat, error) {
 		return []ContainerStat{
@@ -186,6 +196,7 @@ func TestRead_HandlesNoContainers(t *testing.T) {
 // one set of totals, dropping any host unit that is really a container quadlet so
 // it isn't double-counted.
 func TestRead_MergesHostProcesses(t *testing.T) {
+	pinNumCPU(t, 1)
 	t.Cleanup(SetReader(func() ([]ContainerStat, error) {
 		return []ContainerStat{
 			{Name: "lerd-mysql", CPUPercent: 0.1, MemBytes: 400_000_000, MemLimit: 33_000_000_000},
@@ -219,6 +230,30 @@ func TestRead_MergesHostProcesses(t *testing.T) {
 	wantCPU := 0.1 + 0.2 + 3.0
 	if resp.TotalCPUPercent < wantCPU-0.001 || resp.TotalCPUPercent > wantCPU+0.001 {
 		t.Errorf("total cpu = %v, want ~%v", resp.TotalCPUPercent, wantCPU)
+	}
+}
+
+// The per-row CPU% is per-core, so the raw sum can exceed 100% on a multi-core
+// box. The headline total must be normalized to a host fraction (sum / cores) so
+// it reads as "% of the whole host", never an unexplained 300%.
+func TestRead_TotalCPUNormalizedToHostCores(t *testing.T) {
+	pinNumCPU(t, 4)
+	noHostProcesses(t)
+	t.Cleanup(SetReader(func() ([]ContainerStat, error) {
+		return []ContainerStat{
+			{Name: "lerd-a", CPUPercent: 100, MemBytes: 1, MemLimit: 8_000_000_000},
+			{Name: "lerd-b", CPUPercent: 100, MemBytes: 1, MemLimit: 8_000_000_000},
+		}, nil
+	}))
+
+	resp := Read()
+	// Raw per-core sum is 200%; on 4 cores that's 50% of the host.
+	if resp.TotalCPUPercent < 49.99 || resp.TotalCPUPercent > 50.01 {
+		t.Errorf("total cpu = %v, want ~50 (200%% per-core / 4 cores)", resp.TotalCPUPercent)
+	}
+	// Per-row CPU% stays per-core (unnormalized).
+	if resp.Containers[0].CPUPercent != 100 {
+		t.Errorf("per-row cpu = %v, want 100 (per-core, unchanged)", resp.Containers[0].CPUPercent)
 	}
 }
 


### PR DESCRIPTION
A pass over everything that landed since v1.24.1 turned up a handful of bugs and regressions worth clearing before the next release.

The biggest one is a custom-FPM site that gets re-linked after dropping its Containerfile (or after a port turns it into a reverse-proxied container). The per-site lerd-cfpm quadlet was left behind, and since it carries WantedBy=default.target and Restart=always, podman kept auto-starting an orphan container that lerd start and stop never see. It now reconciles on every link path, the same way the FrankenPHP orphan already does, including the custom-container and host-proxy transitions.

An idle-suspended worktree worker was being resurrected by lerd install: the worktree restore loop never checked the suspended set that the main-site path already guards against, so re-enabling the unit let the next boot pull it back in through default.target. The guard now applies to worktree workers too and the engine keeps ownership of resuming them.

A custom-FPM site reported the PHP version detected from the project rather than the one its Containerfile builds from, and the siteinfo enrichment then persisted that detected version straight back over the pinned one. The version now comes from the FROM line at link time, and the enrichment leaves custom-FPM sites alone, so the reported version and the per-version ini mounts line up with the image the container actually runs.

php:bun always reached for the shared per-version container, so a user whose only PHP site is custom-FPM could not get to the install path at all, and the version it printed could disagree with the container it used. It now resolves the per-site container and its pinned version.

A custom extension's Alpine build dependencies were emitted after the extension install step in the FrankenPHP image, so an extension that compiles fine under FPM quietly degraded to missing. Those packages now install before the extension step.

The MCP logs tool passed an unbounded line count straight into a slice preallocation, so a large value took the server down with an unrecoverable out-of-memory. It is now clamped.

Rounding out the smaller ones: idle pin and unpin moved onto the locked single-field mutator so they can no longer clobber a concurrent idle-engine write, the dashboard CPU total is normalized to a share of the host instead of summing per-core percentages into numbers well above a hundred, the bun fallback hint no longer prints to the daemon's stderr on every idle resume, and container log polling no longer re-emits the boundary line on each fetch.