### PR TITLE
fix: resolve bugs and regressions found reviewing the v1.24.x work before release

### DIFF
--- a/internal/cli/idle_activity.go
+++ b/internal/cli/idle_activity.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/geodro/lerd/internal/activityping"
 	"github.com/geodro/lerd/internal/config"
+	gitpkg "github.com/geodro/lerd/internal/git"
 )
 
 // recordCwdActivity tells lerd-ui that the site containing dir is being worked
@@ -18,5 +22,40 @@ func recordCwdActivity(dir string) {
 	if site == nil {
 		return
 	}
+	// A command run inside a git worktree checkout must wake that worktree's
+	// own workers, which idle on an independent timer, not the parent site's.
+	if key := worktreeActivityKey(site, dir); key != "" {
+		activityping.Site(key)
+		return
+	}
 	activityping.Site(site.Name)
+}
+
+// worktreeActivityKey returns the idle key (site/wtBase) for the site's worktree
+// that contains dir, or "" when dir is in the main checkout or detection fails.
+// The key format mirrors the one the idle engine derives so the activity ping
+// lands on the worktree's record.
+func worktreeActivityKey(site *config.Site, dir string) string {
+	// recordCwdActivity fires on every php/node shim, so skip the worktree scan
+	// for the common case where the command runs in the site's main checkout.
+	if filepath.Clean(dir) == filepath.Clean(site.Path) {
+		return ""
+	}
+	wts, err := gitpkg.DetectWorktrees(site.Path, site.PrimaryDomain())
+	if err != nil {
+		return ""
+	}
+	return matchWorktreeKey(site.Name, dir, wts)
+}
+
+// matchWorktreeKey returns site/wtBase when dir falls inside one of wts, else "".
+func matchWorktreeKey(siteName, dir string, wts []gitpkg.Worktree) string {
+	dir = filepath.Clean(dir)
+	for _, wt := range wts {
+		wtPath := filepath.Clean(wt.Path)
+		if dir == wtPath || strings.HasPrefix(dir, wtPath+string(filepath.Separator)) {
+			return siteName + "/" + config.WorktreeUnitSlug(filepath.Base(wt.Path))
+		}
+	}
+	return ""
 }

--- a/internal/cli/idle_activity_test.go
+++ b/internal/cli/idle_activity_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	gitpkg "github.com/geodro/lerd/internal/git"
+)
+
+func TestMatchWorktreeKey(t *testing.T) {
+	wts := []gitpkg.Worktree{
+		{Name: "wt", Branch: "feature-x", Path: "/home/u/Code/app-feature-x", Domain: "feature-x.app.test"},
+		{Name: "wt", Branch: "bugfix/login", Path: "/home/u/Code/app-bugfix-login", Domain: "bugfix-login.app.test"},
+	}
+
+	cases := []struct {
+		name string
+		dir  string
+		want string
+	}{
+		{"main checkout", "/home/u/Code/app", ""},
+		{"worktree root", "/home/u/Code/app-feature-x", "app/" + config.WorktreeUnitSlug("app-feature-x")},
+		{"nested in worktree", "/home/u/Code/app-feature-x/database/migrations", "app/" + config.WorktreeUnitSlug("app-feature-x")},
+		{"second worktree", "/home/u/Code/app-bugfix-login/app", "app/" + config.WorktreeUnitSlug("app-bugfix-login")},
+		{"sibling prefix not a match", "/home/u/Code/app-feature-x-extra", ""},
+		{"trailing slash normalised", "/home/u/Code/app-feature-x/", "app/" + config.WorktreeUnitSlug("app-feature-x")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := matchWorktreeKey("app", filepath.Clean(tc.dir), wts); got != tc.want {
+				t.Errorf("matchWorktreeKey(%q) = %q, want %q", tc.dir, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/isolate.go
+++ b/internal/cli/isolate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/geodro/lerd/internal/config"
 	gitpkg "github.com/geodro/lerd/internal/git"
@@ -23,6 +24,9 @@ func NewIsolateCmd() *cobra.Command {
 
 func runIsolate(_ *cobra.Command, args []string) error {
 	version := args[0]
+	if !config.IsSupportedPHPVersion(version) {
+		return fmt.Errorf("unsupported PHP version %q (supported: %s)", version, strings.Join(config.SupportedPHPVersions, ", "))
+	}
 
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -11,6 +11,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Wire the siteops demote helper to the cli worker lifecycle so the UI, MCP,
+// and install-refresh paths recreate workers when a FrankenPHP site falls back
+// to FPM, the same way switchToFPM does for `lerd runtime fpm`.
+func init() {
+	siteops.StopRuntimeWorkers = func(site *config.Site) []string {
+		running := collectRunningWorkers(site)
+		for _, w := range running {
+			WorkerStopForSite(site.Name, site.Path, w) //nolint:errcheck
+		}
+		return running
+	}
+	siteops.RecreateFPMWorkers = func(site *config.Site, workers []string) {
+		startWorkersForSite(site, workers, site.PHPVersion)
+	}
+}
+
 // NewRuntimeCmd returns the `lerd runtime` parent command.
 func NewRuntimeCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -96,9 +112,7 @@ func runRuntime(cmd *cobra.Command, args []string) error {
 // removes its quadlet, and reloads systemd so the generated unit disappears.
 // Shared by switchToFPM and link's stale-quadlet reconcile.
 func removeFrankenPHPContainer(siteName string) {
-	_ = podman.StopUnit(podman.FrankenPHPContainerName(siteName))
-	_ = podman.RemoveFrankenPHPQuadlet(siteName)
-	_ = podman.DaemonReloadFn()
+	podman.RemoveFrankenPHPContainer(siteName)
 }
 
 // reconcileStaleFrankenPHP removes a leftover per-site FrankenPHP quadlet when a

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -433,6 +433,14 @@ func cloneGlobalConfig(in *GlobalConfig) *GlobalConfig {
 			out.PHP.ExtApkDeps[k] = cp
 		}
 	}
+	if in.PHP.Packages != nil {
+		out.PHP.Packages = make(map[string][]string, len(in.PHP.Packages))
+		for k, v := range in.PHP.Packages {
+			cp := make([]string, len(v))
+			copy(cp, v)
+			out.PHP.Packages[k] = cp
+		}
+	}
 	if in.ParkedDirectories != nil {
 		out.ParkedDirectories = append([]string(nil), in.ParkedDirectories...)
 	}

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -38,6 +38,38 @@ func TestLoadGlobal_Defaults(t *testing.T) {
 	}
 }
 
+// A config returned by LoadGlobal must not share its PHP.Packages map with the
+// cache: php:pkg's AddPackage/RemovePackage mutate the loaded copy in place
+// before SaveGlobal, and that must not corrupt what later LoadGlobal calls see.
+func TestLoadGlobal_PackagesNotAliasedWithCache(t *testing.T) {
+	setConfigDir(t)
+
+	seed, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	seed.AddPackage("8.4", "vim")
+	if err := SaveGlobal(seed); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	loaded, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	// Mutate the loaded copy without saving — must not reach the cache.
+	loaded.AddPackage("8.4", "htop")
+
+	again, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	got := again.GetPackages("8.4")
+	if len(got) != 1 || got[0] != "vim" {
+		t.Errorf("cache corrupted by an unsaved mutation: GetPackages = %v, want [vim]", got)
+	}
+}
+
 func TestSaveLoadGlobal_RoundTrip(t *testing.T) {
 	setConfigDir(t)
 

--- a/internal/logsource/read.go
+++ b/internal/logsource/read.go
@@ -232,6 +232,12 @@ func parseSince(s string) (time.Time, bool) {
 		return time.Time{}, false
 	}
 	if d, err := time.ParseDuration(s); err == nil {
+		// "since" is always a look-back, so a negative duration (a natural typo,
+		// "-15m") means the same as its positive form rather than a future time
+		// that would silently match nothing.
+		if d < 0 {
+			d = -d
+		}
 		return time.Now().Add(-d), true
 	}
 	return parseAbs(s)
@@ -267,7 +273,9 @@ func parseEntryTime(s string) (time.Time, bool) {
 func podmanTime(s string) string {
 	s = strings.TrimSpace(s)
 	if _, err := time.ParseDuration(s); err == nil {
-		return s
+		// podman --since reads a bare duration as a look-back; normalize a "-15m"
+		// typo to its positive magnitude so it isn't rejected or misread.
+		return strings.TrimLeft(s, "+-")
 	}
 	if t, ok := parseAbs(s); ok {
 		return t.Format(time.RFC3339)

--- a/internal/logsource/read_linux.go
+++ b/internal/logsource/read_linux.go
@@ -16,9 +16,63 @@ import (
 // filters push down to journalctl; the cursor is the journal's own opaque
 // __CURSOR so the next poll resumes exactly with --after-cursor.
 func readJournal(src Source, opts Opts) (Result, error) {
+	args, fallback := journalArgs(src, opts)
+	tailCap := journalTailCap(opts)
+
+	var buf bytes.Buffer
+	cmd := exec.Command("journalctl", args...)
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	_ = cmd.Run() // missing unit / no journal access — return what we have
+
+	var out []Entry
+	var cursor string
+	raw := 0
+	dec := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+	for {
+		var je journalEntry
+		if err := dec.Decode(&je); err != nil {
+			break
+		}
+		raw++
+		// Advance the cursor past every decoded entry, including ones the literal
+		// fallback drops, so the next poll resumes after them rather than re-scanning.
+		if je.Cursor != "" {
+			cursor = je.Cursor
+		}
+		text := je.message()
+		if fallback != nil && !fallback(text) {
+			continue
+		}
+		out = append(out, Entry{Time: je.timeString(), Text: text})
+	}
+	// journalctl -n tails the newest cap entries; if it returned a full cap's
+	// worth, older lines were dropped, so report it truncated like the file and
+	// podman paths rather than letting the loss pass silently.
+	truncated := tailCap > 0 && raw >= tailCap
+	return Result{Entries: out, Cursor: cursor, Truncated: truncated}, nil
+}
+
+// journalTailCap is the -n value journalArgs applies: the per-call tail on a
+// fresh read, or maxLines when resuming from a cursor.
+func journalTailCap(opts Opts) int {
+	if opts.Since != "" && isJournalCursor(opts.Since) {
+		return maxLines
+	}
+	return opts.Lines
+}
+
+// journalArgs builds the journalctl argv for a unit read and returns an
+// in-process grep fallback when the pattern can't be pushed down. The -n tail
+// (journalTailCap) is the per-call opts.Lines on a fresh read, raised to maxLines
+// on a cursor resume so a busy unit's recent lines aren't clipped to the small
+// per-call tail while memory stays bounded; readJournal flags Truncated when the
+// cap is hit so the dropped older lines aren't a silent loss.
+func journalArgs(src Source, opts Opts) ([]string, func(string) bool) {
 	args := []string{"--user", "-u", src.Locator + ".service", "--no-pager", "--output=json"}
+	resuming := opts.Since != "" && isJournalCursor(opts.Since)
 	if opts.Since != "" {
-		if isJournalCursor(opts.Since) {
+		if resuming {
 			args = append(args, "--after-cursor="+opts.Since)
 		} else {
 			args = append(args, "--since", journalTime(opts.Since))
@@ -39,34 +93,10 @@ func readJournal(src Source, opts Opts) (Result, error) {
 			fallback = compileGrep(opts.Grep)
 		}
 	}
-	args = append(args, "-n", strconv.Itoa(opts.Lines))
-
-	var buf bytes.Buffer
-	cmd := exec.Command("journalctl", args...)
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
-	_ = cmd.Run() // missing unit / no journal access — return what we have
-
-	var out []Entry
-	var cursor string
-	dec := json.NewDecoder(bytes.NewReader(buf.Bytes()))
-	for {
-		var je journalEntry
-		if err := dec.Decode(&je); err != nil {
-			break
-		}
-		// Advance the cursor past every decoded entry, including ones the literal
-		// fallback drops, so the next poll resumes after them rather than re-scanning.
-		if je.Cursor != "" {
-			cursor = je.Cursor
-		}
-		text := je.message()
-		if fallback != nil && !fallback(text) {
-			continue
-		}
-		out = append(out, Entry{Time: je.timeString(), Text: text})
+	if tailCap := journalTailCap(opts); tailCap > 0 {
+		args = append(args, "-n", strconv.Itoa(tailCap))
 	}
-	return Result{Entries: out, Cursor: cursor}, nil
+	return args, fallback
 }
 
 func isJournalCursor(s string) bool {
@@ -78,7 +108,9 @@ func isJournalCursor(s string) bool {
 func journalTime(s string) string {
 	s = strings.TrimSpace(s)
 	if _, err := time.ParseDuration(s); err == nil {
-		return "-" + s
+		// "-" makes it a look-back; strip any sign the user already typed so a
+		// "-15m" typo becomes "-15m" not the invalid "--15m".
+		return "-" + strings.TrimLeft(s, "+-")
 	}
 	if t, ok := parseAbs(s); ok {
 		// journalctl reads a zone-less time in the system's local zone, so emit

--- a/internal/logsource/read_linux_test.go
+++ b/internal/logsource/read_linux_test.go
@@ -1,0 +1,48 @@
+//go:build linux
+
+package logsource
+
+import (
+	"slices"
+	"strconv"
+	"testing"
+)
+
+// nFlag returns the value following "-n" in an argv, or "".
+func nFlag(args []string) string {
+	for i, a := range args {
+		if a == "-n" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func TestJournalArgs_ResumeCapsAtMaxLinesNotTheSmallTail(t *testing.T) {
+	src := Source{Name: "ui", Kind: KindJournal, Locator: "lerd-ui"}
+	cursor := "s=abc;i=1f;b=2;m=3;t=4;x=5"
+
+	resume, _ := journalArgs(src, Opts{Since: cursor, Lines: 50})
+	if !slices.Contains(resume, "--after-cursor="+cursor) {
+		t.Errorf("resume args must carry --after-cursor, got %v", resume)
+	}
+	// Resume must stay bounded (memory) but not clamp to the small per-call tail
+	// (which would drop a busy unit's gap lines): it caps at maxLines.
+	if got := nFlag(resume); got != strconv.Itoa(maxLines) {
+		t.Errorf("resume -n = %q, want maxLines %d so gap lines aren't dropped to the 50-line tail", got, maxLines)
+	}
+
+	fresh, _ := journalArgs(src, Opts{Lines: 50})
+	if got := nFlag(fresh); got != "50" {
+		t.Errorf("a fresh read should tail with -n 50, got %q", got)
+	}
+}
+
+func TestJournalTime_NegativeDurationIsLookBack(t *testing.T) {
+	if got := journalTime("15m"); got != "-15m" {
+		t.Errorf("journalTime(15m) = %q, want -15m", got)
+	}
+	if got := journalTime("-15m"); got != "-15m" {
+		t.Errorf("journalTime(-15m) = %q, want -15m (not the invalid --15m)", got)
+	}
+}

--- a/internal/logsource/read_test.go
+++ b/internal/logsource/read_test.go
@@ -14,6 +14,33 @@ const monologFixture = `[2026-06-11 10:00:00] local.INFO: started up
 [2026-06-11 10:15:00] local.ERROR: SQLSTATE[42S02] table missing
 `
 
+func TestParseSince_NegativeDurationIsLookBack(t *testing.T) {
+	pos, ok := parseSince("15m")
+	if !ok {
+		t.Fatal("parseSince(15m) failed")
+	}
+	neg, ok := parseSince("-15m")
+	if !ok {
+		t.Fatal("parseSince(-15m) failed")
+	}
+	// Both must resolve to ~15 minutes in the past, never the future.
+	if neg.After(time.Now()) {
+		t.Errorf("parseSince(-15m) = %v is in the future; a negative duration must be treated as a look-back", neg)
+	}
+	if d := pos.Sub(neg); d < -time.Second || d > time.Second {
+		t.Errorf("parseSince(15m)=%v and parseSince(-15m)=%v should match; delta=%v", pos, neg, d)
+	}
+}
+
+func TestPodmanTime_NegativeDurationIsLookBack(t *testing.T) {
+	if got := podmanTime("15m"); got != "15m" {
+		t.Errorf("podmanTime(15m) = %q, want 15m", got)
+	}
+	if got := podmanTime("-15m"); got != "15m" {
+		t.Errorf("podmanTime(-15m) = %q, want 15m (positive look-back magnitude)", got)
+	}
+}
+
 func writeFixture(t *testing.T, content string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/mcp/activity_test.go
+++ b/internal/mcp/activity_test.go
@@ -22,11 +22,29 @@ func TestSiteForToolArgs(t *testing.T) {
 		{"site beats path", map[string]any{"site": "myapp", "path": "/elsewhere"}, "myapp"},
 		{"path resolves to site", map[string]any{"path": "/srv/myapp"}, "myapp"},
 		{"unknown path", map[string]any{"path": "/no/such/site"}, ""},
-		{"no site or path", map[string]any{"action": "list"}, ""},
 	}
 	for _, c := range cases {
 		if got := siteForToolArgs(c.args); got != c.want {
 			t.Errorf("%s: siteForToolArgs = %q, want %q", c.name, got, c.want)
 		}
+	}
+}
+
+// In an mcp:inject context the tool args carry no explicit site/path; the
+// activity ping must still resolve the injected default site so idle-suspend
+// doesn't sleep the project the agent is actively working on.
+func TestSiteForToolArgs_FallsBackToDefaultSite(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dir)
+	if err := config.AddSite(config.Site{Name: "myapp", Path: "/srv/myapp", PHPVersion: "8.4"}); err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+
+	orig := defaultSitePath
+	defaultSitePath = "/srv/myapp"
+	t.Cleanup(func() { defaultSitePath = orig })
+
+	if got := siteForToolArgs(map[string]any{"action": "list"}); got != "myapp" {
+		t.Errorf("siteForToolArgs with no explicit site/path = %q, want myapp (the injected default)", got)
 	}
 }

--- a/internal/mcp/groups.go
+++ b/internal/mcp/groups.go
@@ -17,13 +17,15 @@ func recordToolActivity(args map[string]any) {
 }
 
 // siteForToolArgs resolves the site a tool call targets, from the explicit
-// `site` (by name) or `path` (by directory) argument. Returns "" when the call
-// names no site.
+// `site` (by name) or `path` (by directory) argument, falling back to the
+// injected/cwd default site so a tool call in an mcp:inject context (no explicit
+// site/path) still keeps the site the agent is working on awake under
+// idle-suspend. Returns "" when no site can be resolved.
 func siteForToolArgs(args map[string]any) string {
 	if name := strArg(args, "site"); name != "" {
 		return name
 	}
-	if path := strArg(args, "path"); path != "" {
+	if path := resolvedPath(args); path != "" {
 		if s, err := config.FindSiteByPath(path); err == nil && s != nil {
 			return s.Name
 		}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3852,6 +3852,9 @@ func execSitePHP(args map[string]any) (any, *rpcError) {
 	if version == "" {
 		return toolErr("version is required"), nil
 	}
+	if !config.IsSupportedPHPVersion(version) {
+		return toolErr(fmt.Sprintf("unsupported PHP version %q — supported: %s", version, strings.Join(config.SupportedPHPVersions, ", "))), nil
+	}
 
 	site, err := config.FindSite(siteName)
 	if err != nil {

--- a/internal/mcp/site_php_test.go
+++ b/internal/mcp/site_php_test.go
@@ -1,0 +1,39 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// execSitePHP must reject an unsupported version before it writes .php-version
+// or touches the registry, so a typo like "9.9" returns a clean error instead
+// of persisting a bad pin that only fails later with "container not found".
+func TestExecSitePHP_RejectsUnsupportedVersion(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := config.AddSite(config.Site{Name: "acme", Path: t.TempDir(), Domains: []string{"acme.test"}, PHPVersion: "8.4"}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, rpcErr := execSitePHP(map[string]any{"site": "acme", "version": "9.9"})
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpcError: %v", rpcErr)
+	}
+	if !mcpIsError(res) {
+		t.Fatalf("expected an error result for an unsupported version, got %v", res)
+	}
+	if msg := mcpText(t, res); !strings.Contains(msg, "unsupported PHP version") {
+		t.Errorf("error message = %q, want it to name the unsupported version", msg)
+	}
+
+	// The registry must be untouched — no bad version persisted.
+	site, err := config.FindSite("acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if site.PHPVersion != "8.4" {
+		t.Errorf("site PHPVersion = %q, want 8.4 (unchanged)", site.PHPVersion)
+	}
+}

--- a/internal/node/bun.go
+++ b/internal/node/bun.go
@@ -125,11 +125,56 @@ func SystemNodeAvailable() bool {
 }
 
 // Bunify rewrites the npm/npx/node command verb to its bun equivalent
-// (npm->bun, npx->bunx, node->bun), leaving the rest verbatim. It first walks
+// (npm->bun, npx->bunx, node->bun) for every command in a shell chain, so
+// `npm run build && npm run preview` becomes `bun run build && bun run preview`.
+// Segments are split on the shell operators &&, ||, |, ;, & (operators inside
+// quotes don't split); each segment is rewritten independently.
+func Bunify(command string) string {
+	var out, seg strings.Builder
+	flush := func() {
+		out.WriteString(bunifySegment(seg.String()))
+		seg.Reset()
+	}
+	var quote byte
+	for i := 0; i < len(command); i++ {
+		c := command[i]
+		if quote != 0 {
+			seg.WriteByte(c)
+			// Inside double quotes a backslash escapes the next byte, so a \" does
+			// not close the string; single quotes have no escaping (POSIX). Without
+			// this the quote state desyncs and an operator inside the string would
+			// wrongly split it, rewriting an npm/node/npx token that is really an
+			// argument.
+			if quote == '"' && c == '\\' && i+1 < len(command) {
+				i++
+				seg.WriteByte(command[i])
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"':
+			quote = c
+			seg.WriteByte(c)
+		case ';', '|', '&':
+			flush()
+			out.WriteByte(c)
+		default:
+			seg.WriteByte(c)
+		}
+	}
+	flush()
+	return out.String()
+}
+
+// bunifySegment rewrites the leading verb of one command segment. It first walks
 // past a leading `env` invocation and any KEY=VALUE assignments, since host-proxy
 // commands are wrapped as `env PORT=N npm run ...` and would otherwise never
-// switch. Commands whose verb isn't npm/npx/node are returned unchanged.
-func Bunify(command string) string {
+// switch. A segment whose verb isn't npm/npx/node is returned unchanged.
+func bunifySegment(command string) string {
 	pos := 0
 	for {
 		ws := 0

--- a/internal/node/bun_test.go
+++ b/internal/node/bun_test.go
@@ -101,6 +101,19 @@ func TestBunify(t *testing.T) {
 		{"env FOO=a BAR=b npx tsx watch", "env FOO=a BAR=b bunx tsx watch"},
 		{"env", "env"},
 		{"PORT=3000 python app.py", "PORT=3000 python app.py"},
+		// Compound commands: every segment's verb is rewritten, not just the first.
+		{"npm run build && npm run preview", "bun run build && bun run preview"},
+		{"npm install && npm run dev", "bun install && bun run dev"},
+		{"npm ci; node server.js", "bun ci; bun server.js"},
+		{"npm run build | tee out.log", "bun run build | tee out.log"},
+		{"composer install && npm run dev", "composer install && bun run dev"},
+		{"npm run build 2>&1", "bun run build 2>&1"},
+		// An operator inside quotes must not split the command.
+		{`node -e "console.log(1 && 2)"`, `bun -e "console.log(1 && 2)"`},
+		// An escaped quote inside double quotes must not desync the quote state and
+		// let an operator split the string (which would rewrite an npm/node arg).
+		{`node -e "x\" ; npm install"`, `bun -e "x\" ; npm install"`},
+		{`node -e 'a && npm b'`, `bun -e 'a && npm b'`},
 	}
 	for _, tc := range cases {
 		if got := Bunify(tc.in); got != tc.want {

--- a/internal/podman/frankenphp.go
+++ b/internal/podman/frankenphp.go
@@ -103,9 +103,13 @@ func RestartSiteContainersForVersion(version string) {
 		}
 		switch {
 		case s.IsCustomFPM():
-			_ = RestartUnit(CustomFPMContainerName(s.Name))
+			if err := RestartUnit(CustomFPMContainerName(s.Name)); err != nil {
+				fmt.Printf("[WARN] restarting %s for xdebug: %v\n", CustomFPMContainerName(s.Name), err)
+			}
 		case s.IsFrankenPHP():
-			_ = RestartUnit(FrankenPHPContainerName(s.Name))
+			if err := RestartUnit(FrankenPHPContainerName(s.Name)); err != nil {
+				fmt.Printf("[WARN] restarting %s for xdebug: %v\n", FrankenPHPContainerName(s.Name), err)
+			}
 		}
 	}
 }
@@ -147,6 +151,17 @@ func RemoveFrankenPHPQuadlet(siteName string) error {
 	return RemoveQuadlet(FrankenPHPContainerName(siteName))
 }
 
+// RemoveFrankenPHPContainer fully tears down a site's per-site FrankenPHP
+// container: stop the unit (the container is Restart=always, so removing only
+// the quadlet leaves it running and orphaned), drop the quadlet, and reload the
+// daemon. Shared by the CLI runtime switch and siteops' demote-to-FPM so the
+// teardown sequence lives in one place. Best-effort: each step is independent.
+func RemoveFrankenPHPContainer(siteName string) {
+	_ = StopUnit(FrankenPHPContainerName(siteName))
+	_ = RemoveFrankenPHPQuadlet(siteName)
+	_ = DaemonReloadFn()
+}
+
 // shellJoin quotes each argument for embedding in a quadlet Exec= line.
 // Quadlet Exec values are passed through podman's argv parser which already
 // handles single-word args; anything with whitespace needs quoting.
@@ -154,7 +169,12 @@ func shellJoin(args []string) string {
 	out := make([]string, len(args))
 	for i, a := range args {
 		if strings.ContainsAny(a, " \t\"'\\") {
-			out[i] = `"` + strings.ReplaceAll(a, `"`, `\"`) + `"`
+			// Escape backslashes before quotes so an arg ending in a backslash
+			// can't turn the closing quote into an escaped one; splitSystemdExec
+			// (and systemd's own Exec parser) decode \\ and \" symmetrically.
+			esc := strings.ReplaceAll(a, `\`, `\\`)
+			esc = strings.ReplaceAll(esc, `"`, `\"`)
+			out[i] = `"` + esc + `"`
 		} else {
 			out[i] = a
 		}

--- a/internal/podman/frankenphp_test.go
+++ b/internal/podman/frankenphp_test.go
@@ -74,3 +74,13 @@ func TestShellJoinQuotesWhitespace(t *testing.T) {
 		t.Fatalf("shellJoin:\n  want %s\n  got  %s", want, got)
 	}
 }
+
+func TestShellJoinEscapesBackslash(t *testing.T) {
+	// An arg ending in a backslash must escape it so the closing quote isn't
+	// swallowed by the parser on the other side.
+	got := shellJoin([]string{"cmd", `path\`})
+	want := `cmd "path\\"`
+	if got != want {
+		t.Fatalf("shellJoin backslash:\n  want %s\n  got  %s", want, got)
+	}
+}

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -245,8 +245,8 @@ func splitSystemdExec(s string) []string {
 		c := s[i]
 		switch {
 		case inQuote:
-			if c == '\\' && i+1 < len(s) && s[i+1] == '"' {
-				cur.WriteByte('"')
+			if c == '\\' && i+1 < len(s) && (s[i+1] == '"' || s[i+1] == '\\') {
+				cur.WriteByte(s[i+1])
 				i++
 			} else if c == '"' {
 				inQuote = false

--- a/internal/services/launchd_test.go
+++ b/internal/services/launchd_test.go
@@ -187,6 +187,8 @@ func TestSplitSystemdExec(t *testing.T) {
 			[]string{"sh", "-c", "install-php-extensions pcntl >/dev/null && exec php artisan octane:start --workers=auto --watch --poll"}},
 		{"escaped inner quote", `echo "say \"hi\" now"`,
 			[]string{"echo", `say "hi" now`}},
+		{"escaped backslash decoded", `cmd "a\\b"`, []string{"cmd", `a\b`}},
+		{"trailing backslash before closing quote", `cmd "path\\"`, []string{"cmd", `path\`}},
 		{"empty quoted arg preserved", `cmd ""`, []string{"cmd", ""}},
 		{"collapses runs of whitespace", "a   b\tc", []string{"a", "b", "c"}},
 	}

--- a/internal/sitedoctor/sitedoctor.go
+++ b/internal/sitedoctor/sitedoctor.go
@@ -208,8 +208,9 @@ func scanEnvUsage(path string) (map[string]envKeyUsage, int) {
 // classifyMissingEnvKeys splits missing keys into required (read with no
 // default, or a VITE_ key the frontend actually references) and optional (read
 // only with defaults, unreferenced, or a VITE_ key nothing in the JS uses). A
-// VITE_ key is judged by the frontend scan, not PHP env() usage, since Vite reads
-// it via import.meta.env; non-VITE keys fall back to "all required" when no
+// VITE_ key is primarily judged by the frontend scan (Vite reads it via
+// import.meta.env), but a VITE_ key also read by PHP env() without a default
+// still counts as required; non-VITE keys fall back to "all required" when no
 // env() call is found at all.
 func classifyMissingEnvKeys(path string, missing []string) (required, optional []string) {
 	usage, total := scanEnvUsage(path)
@@ -220,7 +221,11 @@ func classifyMissingEnvKeys(path string, missing []string) (required, optional [
 			if viteRefs == nil {
 				viteRefs = scanViteEnvRefs(path)
 			}
-			if viteRefs[k] {
+			// A VITE_ key is usually consumed by the JS bundler (import.meta.env),
+			// but it can also be read by PHP via env('VITE_…'); treat a JS source
+			// reference or a no-default PHP read as required, otherwise optional
+			// (e.g. only present in a compiled public/ bundle).
+			if viteRefs[k] || usage[k].noDefault {
 				required = append(required, k)
 			} else {
 				optional = append(optional, k)

--- a/internal/sitedoctor/sitedoctor_test.go
+++ b/internal/sitedoctor/sitedoctor_test.go
@@ -138,6 +138,29 @@ func TestCheckEnvDrift_ignoresCompiledPublicBundle(t *testing.T) {
 	}
 }
 
+// TestCheckEnvDrift_ViteKeyReadByPhpNoDefault: a VITE_ key that isn't referenced
+// in JS but is read by PHP via env('VITE_…') without a default must still be
+// classified required, not optional.
+func TestCheckEnvDrift_ViteKeyReadByPhpNoDefault(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	writeEnv(t, dir, ".env.example", "VITE_SSR=\n")
+	writeEnv(t, dir, ".env", "") // missing
+
+	mustMkdir(t, filepath.Join(dir, "config"))
+	writeEnv(t, dir, filepath.Join("config", "app.php"),
+		"<?php return ['ssr' => env('VITE_SSR')];\n")
+
+	c, ok := checkEnvDrift(dir, envPath)
+	if !ok || c.Status != StatusWarn {
+		t.Fatalf("got ok=%v status=%q, want true/warn", ok, c.Status)
+	}
+	if !strings.Contains(c.Detail, "VITE_SSR") {
+		t.Errorf("a VITE_ key read by PHP without a default must be required, got %q", c.Detail)
+	}
+}
+
 // TestCheckEnvDrift_allOptionalStaysGreen: when every missing key is read with a
 // default, the check passes quietly with an informational note instead of
 // warning.

--- a/internal/siteops/demote_test.go
+++ b/internal/siteops/demote_test.go
@@ -1,0 +1,115 @@
+package siteops
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// recordingLifecycle records which units were stopped so the demote test can
+// assert the FrankenPHP container is actually torn down.
+type recordingLifecycle struct{ stopped map[string]bool }
+
+func (r *recordingLifecycle) Start(string) error { return nil }
+func (r *recordingLifecycle) Stop(name string) error {
+	if r.stopped == nil {
+		r.stopped = map[string]bool{}
+	}
+	r.stopped[name] = true
+	return nil
+}
+func (r *recordingLifecycle) Restart(string) error              { return nil }
+func (r *recordingLifecycle) UnitStatus(string) (string, error) { return "inactive", nil }
+func (r *recordingLifecycle) AllUnitStates() map[string]string  { return map[string]string{} }
+
+// fakePodmanOnPath drops a no-op `podman` binary early on PATH so calls that
+// shell out (nginx.Reload runs `podman exec lerd-nginx ...`) succeed.
+func fakePodmanOnPath(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "podman"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// Demoting a FrankenPHP site to FPM must stop the per-site FrankenPHP container
+// (so it is not orphaned) and must stop the site's workers before teardown then
+// recreate them against the shared FPM container after the registry is flipped.
+func TestDemoteFrankenPHPToFPM_stopsContainerAndRecreatesWorkers(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	fakePodmanOnPath(t)
+
+	rec := &recordingLifecycle{}
+	origLC := podman.UnitLifecycle
+	podman.UnitLifecycle = rec
+	origDR := podman.DaemonReloadFn
+	podman.DaemonReloadFn = func() error { return nil }
+	origStop := StopRuntimeWorkers
+	origRecreate := RecreateFPMWorkers
+	t.Cleanup(func() {
+		podman.UnitLifecycle = origLC
+		podman.DaemonReloadFn = origDR
+		StopRuntimeWorkers = origStop
+		RecreateFPMWorkers = origRecreate
+	})
+
+	var events []string
+	var recreatedWorkers []string
+	var runtimeAtRecreate = "unset"
+	captured := []string{"queue", "schedule"}
+	StopRuntimeWorkers = func(*config.Site) []string {
+		events = append(events, "stop")
+		return captured
+	}
+	RecreateFPMWorkers = func(s *config.Site, workers []string) {
+		events = append(events, "recreate")
+		recreatedWorkers = workers
+		runtimeAtRecreate = s.Runtime
+	}
+
+	projectDir := filepath.Join(tmp, "app")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	site := config.Site{
+		Name:       "app",
+		Domains:    []string{"app.test"},
+		Path:       projectDir,
+		PHPVersion: "8.1",
+		Runtime:    "frankenphp",
+	}
+	if err := config.AddSite(site); err != nil {
+		t.Fatal(err)
+	}
+
+	s := site
+	if err := DemoteFrankenPHPToFPM(&s); err != nil {
+		t.Fatalf("DemoteFrankenPHPToFPM: %v", err)
+	}
+
+	if len(events) != 2 || events[0] != "stop" || events[1] != "recreate" {
+		t.Fatalf("hook order = %v, want [stop recreate]", events)
+	}
+	if wantUnit := podman.FrankenPHPContainerName("app"); !rec.stopped[wantUnit] {
+		t.Errorf("FrankenPHP container not stopped: stopped=%v want %q", rec.stopped, wantUnit)
+	}
+	if runtimeAtRecreate != "" {
+		t.Errorf("runtime at recreate = %q, want empty (registry already flipped to FPM)", runtimeAtRecreate)
+	}
+	if len(recreatedWorkers) != len(captured) {
+		t.Errorf("recreated workers = %v, want the captured set %v", recreatedWorkers, captured)
+	}
+	got, err := config.FindSite("app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Runtime != "" || got.RuntimeWorker {
+		t.Errorf("registry still on FrankenPHP: runtime=%q worker=%v", got.Runtime, got.RuntimeWorker)
+	}
+}

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -226,15 +226,32 @@ func FinishFrankenPHPLink(site config.Site) error {
 	return nil
 }
 
+// StopRuntimeWorkers and RecreateFPMWorkers let the cli package (which owns
+// worker lifecycle) tear down a FrankenPHP site's workers before its per-site
+// container is removed and rebuild them against the shared FPM container once
+// the registry has been flipped to FPM. They mirror switchToFPM, wired at init
+// the same way as StopSiteWorkers. Without them a demote leaves the workers'
+// units still pointed at (and BindsTo) the removed FrankenPHP container, where
+// heal can't recover them. StopRuntimeWorkers returns the names it stopped.
+var (
+	StopRuntimeWorkers func(site *config.Site) []string
+	RecreateFPMWorkers func(site *config.Site, workers []string)
+)
+
 // DemoteFrankenPHPToFPM drops a FrankenPHP site back to the FPM runtime: it
-// tears down the per-site FrankenPHP quadlet, clears the runtime in the registry
-// and the project's .lerd.yaml, and regenerates the normal fastcgi vhost. It is
-// the fallback the CLI takes (via runLink) when a site's PHP version is changed
-// below the FrankenPHP minimum, mirrored here so the UI and MCP never silently
-// upgrade PHP behind the user's back. The passed site is mutated to FPM.
+// stops and tears down the per-site FrankenPHP container, clears the runtime in
+// the registry and the project's .lerd.yaml, regenerates the normal fastcgi
+// vhost, and recreates any running workers against the shared FPM container. It
+// is the fallback the CLI takes (via runLink) when a site's PHP version is
+// changed below the FrankenPHP minimum, mirrored here so the UI and MCP never
+// silently upgrade PHP behind the user's back. The passed site is mutated to FPM.
 func DemoteFrankenPHPToFPM(site *config.Site) error {
-	_ = podman.RemoveFrankenPHPQuadlet(site.Name)
-	_ = podman.DaemonReloadFn()
+	var workers []string
+	if StopRuntimeWorkers != nil {
+		workers = StopRuntimeWorkers(site)
+	}
+
+	podman.RemoveFrankenPHPContainer(site.Name)
 
 	site.Runtime = ""
 	site.RuntimeWorker = false
@@ -253,6 +270,10 @@ func DemoteFrankenPHPToFPM(site *config.Site) error {
 
 	if err := nginx.Reload(); err != nil {
 		return fmt.Errorf("nginx reload: %w", err)
+	}
+
+	if RecreateFPMWorkers != nil {
+		RecreateFPMWorkers(site, workers)
 	}
 	return nil
 }

--- a/internal/ui/dashproxy.go
+++ b/internal/ui/dashproxy.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -87,7 +88,11 @@ func newDashProxy(name string, target *url.URL, bootstrap string) *httputil.Reve
 		// lerd.localhost is served over https) so an upstream that builds absolute
 		// URLs from X-Forwarded-Proto doesn't downgrade them to http. Default to
 		// http only when nothing upstream told us otherwise.
-		if req.Header.Get("X-Forwarded-Proto") == "" {
+		if proto := req.Header.Get("X-Forwarded-Proto"); proto != "http" && proto != "https" {
+			// nginx (lerd.localhost) sets this from $scheme, overwriting any client
+			// value; only an unexpected/injected value or a direct-to-socket client
+			// reaches here, so recompute it from the connection rather than forward
+			// whatever the client supplied.
 			if req.TLS != nil {
 				req.Header.Set("X-Forwarded-Proto", "https")
 			} else {
@@ -123,6 +128,19 @@ func newDashProxy(name string, target *url.URL, bootstrap string) *httputil.Reve
 		http.Error(w, "dashboard upstream unavailable", http.StatusBadGateway)
 	}
 	return proxy
+}
+
+// isLoopbackTarget reports whether host is a loopback destination: the literal
+// "localhost" or a loopback IP (127.0.0.0/8, ::1). A non-literal hostname is
+// rejected rather than resolved, so DNS can't be used to slip past the gate.
+func isLoopbackTarget(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // stripFrameAncestors removes the frame-ancestors directive from a CSP value so
@@ -178,7 +196,11 @@ func rewriteCookiePath(cookie, mountPath string) string {
 func rewriteLocation(loc, targetHost, prefix string) string {
 	if u, err := url.Parse(loc); err == nil && u.Host != "" {
 		if u.Host != targetHost {
-			return loc // points somewhere else entirely, leave it
+			// Off-origin redirect (a foreign absolute URL, or a scheme-relative
+			// //host that the browser would follow away from the iframe). These
+			// local admin dashboards never legitimately redirect off-host, so
+			// neutralize the escape by keeping the browser inside the mount.
+			return prefix + "/"
 		}
 		loc = u.EscapedPath()
 		if loc == "" {
@@ -259,6 +281,14 @@ func handleDashProxy(w http.ResponseWriter, r *http.Request) {
 	target, err := url.Parse(svc.Dashboard)
 	if err != nil || target.Host == "" {
 		http.Error(w, fmt.Sprintf("invalid dashboard URL for %s", name), http.StatusBadGateway)
+		return
+	}
+	// The dashboard URL comes from a user-writable service file; every bundled
+	// preset points at a loopback admin UI. Refuse anything else so the proxy
+	// can't be coerced into reaching an arbitrary host (cloud metadata, internal
+	// services) with the dashboard's injected credentials attached.
+	if !isLoopbackTarget(target.Hostname()) {
+		http.Error(w, fmt.Sprintf("dashboard for %s must be loopback", name), http.StatusBadGateway)
 		return
 	}
 	dashProxyFor(name, target, config.PresetDashboardBootstrap(svc)).ServeHTTP(w, r)

--- a/internal/ui/dashproxy_test.go
+++ b/internal/ui/dashproxy_test.go
@@ -81,7 +81,10 @@ func TestRewriteLocation(t *testing.T) {
 		"/login":                       "/_svc/rabbitmq/login",
 		"/_svc/rabbitmq/already":       "/_svc/rabbitmq/already",
 		"http://localhost:15672/login": "/_svc/rabbitmq/login",
-		"https://elsewhere.test/x":     "https://elsewhere.test/x",
+		// Off-origin redirects are neutralized to the mount root so the upstream
+		// can't bounce the iframe off-site (foreign absolute URL or scheme-relative).
+		"https://elsewhere.test/x": "/_svc/rabbitmq/",
+		"//evil.com/path":          "/_svc/rabbitmq/",
 		// A redirect to the upstream's bare origin must land at the mount root,
 		// not become an empty Location (no-op reload).
 		"http://localhost:15672":          "/_svc/rabbitmq/",
@@ -183,6 +186,44 @@ func TestHandleDashProxy_RejectsCrossOrigin(t *testing.T) {
 		if rec.Code != http.StatusForbidden {
 			t.Errorf("Sec-Fetch-Site=%s: status = %d, want 403", site, rec.Code)
 		}
+	}
+}
+
+func TestIsLoopbackTarget(t *testing.T) {
+	cases := map[string]bool{
+		"localhost":       true,
+		"LocalHost":       true,
+		"127.0.0.1":       true,
+		"127.5.6.7":       true,
+		"::1":             true,
+		"169.254.169.254": false,
+		"10.0.0.5":        false,
+		"evil.com":        false,
+		"":                false,
+	}
+	for host, want := range cases {
+		if got := isLoopbackTarget(host); got != want {
+			t.Errorf("isLoopbackTarget(%q) = %v, want %v", host, got, want)
+		}
+	}
+}
+
+func TestDashProxyDirector_RecomputesInjectedForwardedProto(t *testing.T) {
+	target, _ := url.Parse("http://localhost:15672")
+	p := newDashProxy("rabbitmq", target, "")
+	req := httptest.NewRequest("GET", "http://lerd.localhost/_svc/rabbitmq/", nil)
+	req.Header.Set("X-Forwarded-Proto", "https\nX-Injected: 1")
+	p.Director(req)
+	if got := req.Header.Get("X-Forwarded-Proto"); got != "http" {
+		t.Errorf("X-Forwarded-Proto = %q, want it recomputed to http (no TLS) when the inbound value is not http/https", got)
+	}
+
+	// A legitimate nginx-set https value is preserved.
+	req2 := httptest.NewRequest("GET", "http://lerd.localhost/_svc/rabbitmq/", nil)
+	req2.Header.Set("X-Forwarded-Proto", "https")
+	p.Director(req2)
+	if got := req2.Header.Get("X-Forwarded-Proto"); got != "https" {
+		t.Errorf("X-Forwarded-Proto = %q, want the nginx-set https preserved", got)
 	}
 }
 

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -3085,6 +3085,10 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, SiteActionResponse{Error: "version parameter required"})
 			return
 		}
+		if !config.IsSupportedPHPVersion(version) {
+			writeJSON(w, SiteActionResponse{Error: "unsupported PHP version: " + version})
+			return
+		}
 		if branch := r.URL.Query().Get("branch"); branch != "" {
 			if err := setWorktreePHPVersion(site, branch, version); err != nil {
 				writeJSON(w, SiteActionResponse{Error: err.Error()})
@@ -4589,14 +4593,21 @@ func handleXdebugAction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	applyMode := ""
+	applyStart := "yes"
 	if action == "on" {
 		applyMode = r.URL.Query().Get("mode")
 		if applyMode == "" {
 			applyMode = "debug"
 		}
+		// The dashboard doesn't expose on-demand (start_with_request=trigger), so
+		// preserve whatever the CLI last set instead of silently resetting a user's
+		// on-demand choice back to connect-on-every-request.
+		if cfg, err := config.LoadGlobal(); err == nil {
+			applyStart = cfg.GetXdebugStart(version)
+		}
 	}
 
-	res, err := xdebugops.Apply(version, applyMode)
+	res, err := xdebugops.ApplyWithStart(version, applyMode, applyStart)
 	if err != nil {
 		writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
 		return

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -388,6 +388,7 @@
   "sites_appLogs_clearModalTitle": "Logdateien leeren?",
   "sites_appLogs_clearModalBody": "Dies löscht dauerhaft jede Logdatei in storage/logs dieser Site, um {size} freizugeben. Das aktive Log wird beim nächsten Schreibvorgang der App automatisch neu erstellt.",
   "sites_appLogs_clearModalConfirm": "Logs leeren",
+  "sites_appLogs_clearFailed": "Löschen der Logs fehlgeschlagen: {error}",
   "sites_appLogs_latest": "Neueste",
   "sites_appLogs_all": "Alle",
   "services_title": "Dienste",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -368,6 +368,7 @@
   "sites_appLogs_clearModalTitle": "Clear log files?",
   "sites_appLogs_clearModalBody": "This permanently deletes every log file in this site's storage/logs to reclaim {size}. The active log is recreated automatically on the app's next write.",
   "sites_appLogs_clearModalConfirm": "Clear logs",
+  "sites_appLogs_clearFailed": "Clearing logs failed: {error}",
   "sites_appLogs_latest": "Latest",
   "sites_appLogs_all": "All",
   "services_title": "Services",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -388,6 +388,7 @@
   "sites_appLogs_clearModalTitle": "¿Borrar archivos de registro?",
   "sites_appLogs_clearModalBody": "Esto elimina permanentemente todos los archivos de registro en storage/logs de este sitio para liberar {size}. El registro activo se recrea automáticamente en la siguiente escritura de la app.",
   "sites_appLogs_clearModalConfirm": "Borrar registros",
+  "sites_appLogs_clearFailed": "No se pudieron borrar los registros: {error}",
   "sites_appLogs_latest": "Últimas",
   "sites_appLogs_all": "Todas",
   "services_title": "Servicios",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -388,6 +388,7 @@
   "sites_appLogs_clearModalTitle": "Vider les fichiers journaux ?",
   "sites_appLogs_clearModalBody": "Cela supprime définitivement tous les fichiers journaux dans storage/logs de ce site pour libérer {size}. Le journal actif est recréé automatiquement à la prochaine écriture de l'application.",
   "sites_appLogs_clearModalConfirm": "Vider les journaux",
+  "sites_appLogs_clearFailed": "Échec de l'effacement des journaux : {error}",
   "sites_appLogs_latest": "Récents",
   "sites_appLogs_all": "Tous",
   "services_title": "Services",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -388,6 +388,7 @@
   "sites_appLogs_clearModalTitle": "Bersihkan file log?",
   "sites_appLogs_clearModalBody": "Ini menghapus permanen setiap file log di storage/logs situs ini untuk mengosongkan {size}. Log aktif dibuat ulang otomatis saat aplikasi menulis berikutnya.",
   "sites_appLogs_clearModalConfirm": "Bersihkan log",
+  "sites_appLogs_clearFailed": "Gagal menghapus log: {error}",
   "sites_appLogs_latest": "Terbaru",
   "sites_appLogs_all": "Semua",
   "services_title": "Layanan",

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -373,6 +373,7 @@
   "sites_appLogs_clearModalTitle": "Svuotare i file di log?",
   "sites_appLogs_clearModalBody": "Questa operazione elimina definitivamente ogni file di log in storage/logs di questo sito per liberare {size}. Il log attivo viene ricreato automaticamente alla successiva scrittura dell'app.",
   "sites_appLogs_clearModalConfirm": "Svuota i log",
+  "sites_appLogs_clearFailed": "Cancellazione dei log non riuscita: {error}",
   "sites_appLogs_latest": "Più recente",
   "sites_appLogs_all": "Tutti",
   "services_title": "Servizi",

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -373,6 +373,7 @@
   "sites_appLogs_clearModalTitle": "ログファイルを削除しますか？",
   "sites_appLogs_clearModalBody": "このサイトの storage/logs にあるすべてのログファイルを完全に削除して {size} を解放します。アクティブなログはアプリの次回書き込み時に自動的に再作成されます。",
   "sites_appLogs_clearModalConfirm": "ログを削除",
+  "sites_appLogs_clearFailed": "ログの消去に失敗しました: {error}",
   "sites_appLogs_latest": "最新",
   "sites_appLogs_all": "すべて",
   "services_title": "サービス",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -388,6 +388,7 @@
   "sites_appLogs_clearModalTitle": "Logbestanden wissen?",
   "sites_appLogs_clearModalBody": "Dit verwijdert permanent elk logbestand in storage/logs van deze site om {size} vrij te maken. Het actieve log wordt automatisch opnieuw aangemaakt bij de volgende schrijfactie van de app.",
   "sites_appLogs_clearModalConfirm": "Logs wissen",
+  "sites_appLogs_clearFailed": "Logs wissen mislukt: {error}",
   "sites_appLogs_latest": "Nieuwste",
   "sites_appLogs_all": "Alle",
   "services_title": "Services",

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -373,6 +373,7 @@
   "sites_appLogs_clearModalTitle": "Wyczyścić pliki logów?",
   "sites_appLogs_clearModalBody": "Spowoduje to trwałe usunięcie wszystkich plików logów w storage/logs tej witryny, aby zwolnić {size}. Aktywny log zostanie automatycznie utworzony ponownie przy następnym zapisie aplikacji.",
   "sites_appLogs_clearModalConfirm": "Wyczyść logi",
+  "sites_appLogs_clearFailed": "Czyszczenie logów nie powiodło się: {error}",
   "sites_appLogs_latest": "Najnowsze",
   "sites_appLogs_all": "Wszystkie",
   "services_title": "Usługi",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -388,6 +388,7 @@
   "sites_appLogs_clearModalTitle": "Limpar arquivos de log?",
   "sites_appLogs_clearModalBody": "Isto exclui permanentemente todos os arquivos de log em storage/logs deste site para liberar {size}. O log ativo é recriado automaticamente na próxima gravação da aplicação.",
   "sites_appLogs_clearModalConfirm": "Limpar logs",
+  "sites_appLogs_clearFailed": "Falha ao limpar os logs: {error}",
   "sites_appLogs_latest": "Últimos",
   "sites_appLogs_all": "Todos",
   "services_title": "Serviços",

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -373,6 +373,7 @@
   "sites_appLogs_clearModalTitle": "Ștergi fișierele de jurnal?",
   "sites_appLogs_clearModalBody": "Aceasta șterge definitiv fiecare fișier de jurnal din storage/logs al acestui site pentru a elibera {size}. Jurnalul activ este recreat automat la următoarea scriere a aplicației.",
   "sites_appLogs_clearModalConfirm": "Șterge jurnalele",
+  "sites_appLogs_clearFailed": "Ștergerea jurnalelor a eșuat: {error}",
   "sites_appLogs_latest": "Cel mai recent",
   "sites_appLogs_all": "Toate",
   "services_title": "Servicii",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -388,6 +388,7 @@
   "sites_appLogs_clearModalTitle": "Günlük dosyaları temizlensin mi?",
   "sites_appLogs_clearModalBody": "Bu işlem, {size} boşaltmak için bu sitenin storage/logs klasöründeki tüm günlük dosyalarını kalıcı olarak siler. Etkin günlük, uygulamanın bir sonraki yazışında otomatik olarak yeniden oluşturulur.",
   "sites_appLogs_clearModalConfirm": "Günlükleri temizle",
+  "sites_appLogs_clearFailed": "Günlükler temizlenemedi: {error}",
   "sites_appLogs_latest": "En son",
   "sites_appLogs_all": "Tümü",
   "services_title": "Servisler",

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -373,6 +373,7 @@
   "sites_appLogs_clearModalTitle": "Xóa các tệp nhật ký?",
   "sites_appLogs_clearModalBody": "Thao tác này xóa vĩnh viễn mọi tệp nhật ký trong storage/logs của trang này để giải phóng {size}. Nhật ký đang hoạt động sẽ được tạo lại tự động ở lần ghi tiếp theo của ứng dụng.",
   "sites_appLogs_clearModalConfirm": "Xóa nhật ký",
+  "sites_appLogs_clearFailed": "Xóa nhật ký thất bại: {error}",
   "sites_appLogs_latest": "Mới nhất",
   "sites_appLogs_all": "Tất cả",
   "services_title": "Dịch vụ",

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -373,6 +373,7 @@
   "sites_appLogs_clearModalTitle": "清除日志文件？",
   "sites_appLogs_clearModalBody": "这将永久删除此站点 storage/logs 中的所有日志文件以释放 {size}。活动日志会在应用下次写入时自动重新创建。",
   "sites_appLogs_clearModalConfirm": "清除日志",
+  "sites_appLogs_clearFailed": "清除日志失败：{error}",
   "sites_appLogs_latest": "最新",
   "sites_appLogs_all": "全部",
   "services_title": "服务",

--- a/internal/ui/web/src/tabs/sites/AppLogsTab.svelte
+++ b/internal/ui/web/src/tabs/sites/AppLogsTab.svelte
@@ -45,7 +45,11 @@
     if (clearing) return;
     clearing = true;
     try {
-      await clearAppLogs(site.domain, branch);
+      const r = await clearAppLogs(site.domain, branch);
+      if (!r.ok) {
+        alert(m.sites_appLogs_clearFailed({ error: r.error || '' }));
+        return;
+      }
       await loadFiles();
       confirmOpen = false;
     } finally {

--- a/internal/ui/xdebug_action_test.go
+++ b/internal/ui/xdebug_action_test.go
@@ -1,0 +1,66 @@
+package ui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+type noopXdebugLifecycle struct{}
+
+func (noopXdebugLifecycle) Start(string) error                { return nil }
+func (noopXdebugLifecycle) Stop(string) error                 { return nil }
+func (noopXdebugLifecycle) Restart(string) error              { return nil }
+func (noopXdebugLifecycle) UnitStatus(string) (string, error) { return "active", nil }
+func (noopXdebugLifecycle) AllUnitStates() map[string]string  { return map[string]string{} }
+
+// Toggling Xdebug on from the dashboard must keep a CLI-set on-demand mode
+// (start_with_request=trigger) rather than resetting it to connect-on-request.
+func TestHandleXdebugAction_PreservesOnDemandStart(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	origLC := podman.UnitLifecycle
+	podman.UnitLifecycle = noopXdebugLifecycle{}
+	t.Cleanup(func() { podman.UnitLifecycle = origLC })
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.SetXdebugMode("8.4", "debug")
+	cfg.SetXdebugStart("8.4", "trigger")
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("POST", "/api/xdebug/8.4/on?mode=debug", nil)
+	req.RemoteAddr = "127.0.0.1:5050"
+	rec := httptest.NewRecorder()
+	handleXdebugAction(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (%s)", err, rec.Body.String())
+	}
+	if resp["ok"] != true {
+		t.Fatalf("ok = %v, body=%s", resp["ok"], rec.Body.String())
+	}
+
+	got, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if start := got.GetXdebugStart("8.4"); start != "trigger" {
+		t.Errorf("xdebug_start = %q, want trigger preserved through the dashboard toggle", start)
+	}
+}


### PR DESCRIPTION
This collects the bug fixes and regressions turned up while reviewing everything that landed since v1.24.1, ahead of the next release.

The headline one is the FrankenPHP demote path. Dropping a FrankenPHP site back to FPM only removed the quadlet, so the per-site container kept running orphaned and the site's workers were left bound to a container that no longer existed. DemoteFrankenPHPToFPM now stops the container and recreates the workers against the shared FPM image the way the CLI runtime switch already does, and it is wired through the cli package so the install refresh, the dashboard and the MCP server all take the same path.

A few correctness fixes around the newer features: terminal activity inside a git worktree now keeps that worktree awake instead of the parent under idle-suspend; a log "since" of -15m is read as a look-back on the file, journal and podman sources instead of silently returning nothing, and the journal cursor resume stays bounded while reporting truncation; and cloneGlobalConfig now copies the php:pkg packages map so adding or removing a package no longer corrupts the cached config.

The bundled dashboard proxy is hardened so it can only reach a loopback upstream, keeps an off-origin redirect inside the mount, and recomputes the forwarded scheme rather than trusting the client.

Input handling is tightened too: pinning an unsupported PHP version through isolate, the dashboard or MCP is now rejected before anything is written, and the bun runtime rewrite handles a compound shell command so every npm, npx and node verb switches rather than just the first.

Rounding it out, the dashboard xdebug toggle keeps a CLI set on-demand mode, the macOS launchd exec translation round-trips a trailing backslash, an MCP call in an injected project keeps its site awake, the Laravel Doctor treats a VITE_ key read by PHP without a default as required, and clearing app logs surfaces a server error instead of swallowing it.
