### PR TITLE
fix: worker and doc issues found smoke-testing the v1.24.x work

### DIFF
--- a/internal/cli/isolate.go
+++ b/internal/cli/isolate.go
@@ -61,6 +61,14 @@ func runIsolate(_ *cobra.Command, args []string) error {
 	if _, err := config.FindSiteByPath(cwd); err == nil {
 		if err := runLink([]string{}); err != nil {
 			fmt.Printf("[WARN] re-linking site: %v\n", err)
+		} else if site, err := config.FindSiteByPath(cwd); err == nil && site.PHPVersion != "" && site.PHPVersion != version {
+			// The framework caps the usable PHP (e.g. Laravel 11 → 8.4), so the
+			// re-link clamped the pin. Sync the committed files to the version
+			// that actually runs; otherwise .lerd.yaml and .php-version would
+			// advertise a version lerd silently overrides on every link.
+			_ = config.SetProjectPHPVersion(cwd, site.PHPVersion)
+			_ = os.WriteFile(filepath.Join(cwd, ".php-version"), []byte(site.PHPVersion+"\n"), 0644)
+			fmt.Printf("Note: %s isn't usable here; clamped to %s and updated .lerd.yaml / .php-version to match.\n", version, site.PHPVersion)
 		}
 	}
 

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -487,6 +487,24 @@ func sailLinkDetectDBName(cwd string) string {
 // Workers with a Check rule that doesn't pass are skipped. Workers that conflict
 // with another requested worker are resolved via ConflictsWith (e.g. horizon replaces queue).
 func startWorkersForSite(site *config.Site, workers []string, phpVersion string) {
+	// Stripe is not a framework worker, so the framework loop below skips it.
+	// Start its listener directly when it was among the workers being restored
+	// (e.g. recreated after a runtime switch), before the no-framework early
+	// return so it survives even on a site lerd has no framework definition for.
+	for _, w := range workers {
+		if w == "stripe" {
+			scheme := "http"
+			if site.Secured {
+				scheme = "https"
+			}
+			baseURL := scheme + "://" + site.PrimaryDomain()
+			if err := StripeStartForSite(site.Name, site.Path, baseURL); err != nil {
+				fmt.Printf("[WARN] starting stripe listener: %v\n", err)
+			}
+			break
+		}
+	}
+
 	fw, hasFw := config.GetFrameworkForDir(site.Framework, site.Path)
 	if !hasFw || fw.Workers == nil {
 		return

--- a/internal/cli/worker_guard.go
+++ b/internal/cli/worker_guard.go
@@ -35,7 +35,9 @@ import (
 //  1. If the pid file exists AND its PID is alive, the previous outer
 //     process is still driving the worker — exit 0.
 //  2. Otherwise SIGTERM any in-container process matching workerCmd
-//     whose cwd is sitePath. Failures are swallowed.
+//     whose cwd is sitePath, wait for it to exit (SIGKILL after a grace
+//     period), then proceed. The wait frees a held listening socket
+//     before the replacement binds it. Failures are swallowed.
 //  3. Record our own PID, install an EXIT trap to clean up, and replace
 //     ourselves with runCmd.
 //
@@ -46,10 +48,18 @@ func buildWorkerGuard(pidFile, podmanBin, container, sitePath, workerCmd, runCmd
 	// quotes around literal arg interpolations because ShellQuote already
 	// produces single-quoted strings; they nest correctly when the whole
 	// inner is itself shell-quoted as a sh -c argument.
+	// m() lists in-container PIDs whose command matches workerCmd AND whose cwd
+	// is this site. SIGTERM them, then wait (up to ~5s) for them to actually
+	// exit before SIGKILLing any straggler. The wait is what lets a worker that
+	// holds a listening socket — e.g. Reverb bound to a fixed port — release it
+	// before the replacement starts; without it the new instance races the old
+	// one and dies with EADDRINUSE.
 	inner := fmt.Sprintf(
-		`for p in $(pgrep -f -- %s 2>/dev/null); do `+
-			`[ "$(readlink /proc/$p/cwd 2>/dev/null)" = %s ] && kill -TERM $p 2>/dev/null; `+
-			`done`,
+		`m() { for p in $(pgrep -f -- %[1]s 2>/dev/null); do `+
+			`[ "$(readlink /proc/$p/cwd 2>/dev/null)" = %[2]s ] && echo "$p"; done; }; `+
+			`for p in $(m); do kill -TERM "$p" 2>/dev/null; done; `+
+			`i=0; while [ -n "$(m)" ] && [ "$i" -lt 50 ]; do i=$((i+1)); sleep 0.1; done; `+
+			`for p in $(m); do kill -KILL "$p" 2>/dev/null; done`,
 		podman.ShellQuote(workerCmd), podman.ShellQuote(sitePath))
 
 	return fmt.Sprintf(`if [ -f %[1]s ] && kill -0 "$(cat %[1]s 2>/dev/null)" 2>/dev/null; then

--- a/internal/cli/worker_guard_test.go
+++ b/internal/cli/worker_guard_test.go
@@ -41,6 +41,21 @@ func TestBuildWorkerGuard_WrapsCommand(t *testing.T) {
 	}
 }
 
+// TestBuildWorkerGuard_WaitsForOrphanExit locks in the fix for a worker that
+// holds a listening socket (e.g. Reverb): the orphan cleanup must SIGTERM, then
+// WAIT for the process to exit, then SIGKILL stragglers — otherwise the
+// replacement binds the port before the old one frees it (EADDRINUSE).
+func TestBuildWorkerGuard_WaitsForOrphanExit(t *testing.T) {
+	a := defaultGuardArgs("/tmp/lerd-reverb-alpha.pid", "podman exec -w /site lerd-php84-fpm php artisan reverb:start")
+	got := a.build()
+
+	for _, want := range []string{"kill -TERM", "while [ -n", "kill -KILL", "sleep 0.1"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("guard missing orphan-exit wait construct %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestBuildWorkerGuard_ExitsZeroWhenPIDAlive(t *testing.T) {
 	tmp := t.TempDir()
 	pidFile := filepath.Join(tmp, "worker.pid")

--- a/internal/cli/xdebug_pause.go
+++ b/internal/cli/xdebug_pause.go
@@ -14,10 +14,11 @@ import (
 )
 
 // `lerd xdebug pause` drives Xdebug's control socket (Xdebug >= 3.3) to break
-// the IDE debugger into an already-running PHP process — a queue/Horizon worker,
-// a CLI script, a FrankenPHP/Octane worker — without a trigger cookie or
-// per-request connection attempts. It shells out to the upstream `xdebugctl`
-// tool, which is baked into the FPM image (see lerd-php-fpm.Containerfile).
+// the IDE debugger into an already-running PHP process — a queue/Horizon worker
+// or a CLI script — without a trigger cookie or per-request connection attempts.
+// It shells out to the upstream `xdebugctl` tool, which is baked into the FPM
+// image (see lerd-php-fpm.Containerfile); FrankenPHP and custom-container sites
+// run their own image without it, so the command is PHP-FPM only.
 const xdebugctlInContainer = "/usr/local/bin/xdebugctl"
 
 func newXdebugPauseCmd() *cobra.Command {
@@ -26,9 +27,10 @@ func newXdebugPauseCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pause [site]",
 		Short: "(experimental) Break the IDE debugger into a running PHP process via Xdebug's control socket",
-		Long: "Use Xdebug's control socket to make a running PHP process (a queue/Horizon worker, a CLI\n" +
-			"script, a FrankenPHP worker) connect to your IDE and break in — no trigger cookie, no\n" +
-			"per-request overhead. Requires Xdebug debug mode enabled for the site's PHP version\n" +
+		Long: "Use Xdebug's control socket to make a running PHP process (a queue/Horizon worker or a\n" +
+			"CLI script) connect to your IDE and break in — no trigger cookie, no per-request\n" +
+			"overhead. PHP-FPM sites only: FrankenPHP and custom-container sites run their own image\n" +
+			"without xdebugctl. Requires Xdebug debug mode enabled for the site's PHP version\n" +
 			"(`lerd xdebug on`) and your IDE listening on port 9003.\n\n" +
 			"Run with --list to see the candidate processes, then --pid to target one.",
 		Args: cobra.MaximumNArgs(1),


### PR DESCRIPTION
Four issues surfaced while exercising the post-1.24.1 changes on macOS.

### Stripe listener dropped on a runtime switch

Switching a site's PHP runtime (`lerd runtime fpm|frankenphp`) silently stopped its Stripe listener. `collectRunningWorkers` captured stripe and stopped it, but `startWorkersForSite` only restarts framework workers, so it stayed stopped, and `lerd worker heal` reported nothing to heal because the unit was gone rather than unhealthy. The listener is now started directly when stripe is among the workers being restored, before the no-framework early return so it also works on sites lerd has no framework definition for.

### Port-listening worker crash-loop on idle resume

A worker bound to a fixed port (Reverb) could crash-loop with `EADDRINUSE` after an idle suspend/resume left the old in-container process briefly alive. The macOS worker guard SIGTERMed the orphan and then launched the replacement immediately, racing the old listener for the port. It now waits for the orphan to exit (SIGKILL after a short grace period) so the socket is released before the new instance binds.

### `lerd xdebug pause` documentation

The command refuses FrankenPHP and custom-container sites (they run their own image without `xdebugctl`), but its help and doc comment advertised a FrankenPHP/Octane worker as a target. The docs now state it is PHP-FPM only.

### `lerd isolate` left committed files advertising an overridden version

`lerd isolate <version>` wrote the requested version to `.lerd.yaml` and `.php-version` even when the framework clamps it down on re-link (for example Laravel 11 capping at 8.4). The committed files then advertised a version lerd silently overrides on every link. isolate now syncs both files to the version that actually runs and prints a note.