### PR TITLE
fix: make worktree MCP tool results visible to the host

### DIFF
--- a/internal/mcp/dns_diagnose.go
+++ b/internal/mcp/dns_diagnose.go
@@ -12,5 +12,5 @@ func execDNSDiagnose(args map[string]any) (any, *rpcError) {
 			tld = cfg.DNS.TLD
 		}
 	}
-	return dns.Diagnose(tld), nil
+	return toolJSON(dns.Diagnose(tld)), nil
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1936,7 +1936,7 @@ func execServiceCheckUpdates(args map[string]any) (any, *rpcError) {
 		}
 		results = append(results, entry)
 	}
-	return map[string]any{"services": results}, nil
+	return toolJSON(map[string]any{"services": results}), nil
 }
 
 func execServiceUpdate(args map[string]any) (any, *rpcError) {
@@ -2089,7 +2089,7 @@ func execServiceEnv(args map[string]any) (any, *rpcError) {
 			k, v, _ := strings.Cut(kv, "=")
 			vars[k] = v
 		}
-		return map[string]any{"service": name, "vars": vars}, nil
+		return toolJSON(map[string]any{"service": name, "vars": vars}), nil
 	}
 
 	// Fall back to custom service env_vars.
@@ -2102,7 +2102,7 @@ func execServiceEnv(args map[string]any) (any, *rpcError) {
 		k, v, _ := strings.Cut(kv, "=")
 		vars[k] = v
 	}
-	return map[string]any{"service": name, "vars": vars}, nil
+	return toolJSON(map[string]any{"service": name, "vars": vars}), nil
 }
 
 func execEnvSetup(args map[string]any) (any, *rpcError) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -200,6 +200,17 @@ func toolErr(text string) map[string]any {
 	}
 }
 
+// toolJSON renders a structured value as indented JSON inside a text content
+// block. Tool results must carry a "content" array for the host to display
+// anything; returning a bare map produces a silent "no output" response.
+func toolJSON(v any) map[string]any {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return toolErr("marshal result: " + err.Error())
+	}
+	return toolOK(string(data))
+}
+
 func stripANSI(s string) string {
 	return logsource.StripANSI(s)
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -165,6 +165,44 @@ func TestExecEnvCheck_missingKeys(t *testing.T) {
 	}
 }
 
+// TestExecServiceEnv_returnsContent guards the same "no output" regression for
+// the service env action: a built-in service's env vars must come back inside a
+// content block, not as a bare map the host can't render.
+func TestExecServiceEnv_returnsContent(t *testing.T) {
+	var name string
+	for _, s := range knownServices() {
+		if builtinServiceEnv(s) != nil {
+			name = s
+			break
+		}
+	}
+	if name == "" {
+		t.Skip("no built-in service exposes env vars")
+	}
+
+	result, rpcErr := execServiceEnv(map[string]any{"name": name})
+	if rpcErr != nil {
+		t.Fatal("unexpected rpc error:", rpcErr.Message)
+	}
+	content, ok := result.(map[string]any)["content"].([]map[string]any)
+	if !ok || len(content) != 1 {
+		t.Fatal("result has no content block")
+	}
+	var parsed struct {
+		Service string            `json:"service"`
+		Vars    map[string]string `json:"vars"`
+	}
+	if err := json.Unmarshal([]byte(content[0]["text"].(string)), &parsed); err != nil {
+		t.Fatal("content is not valid JSON:", err)
+	}
+	if parsed.Service != name {
+		t.Errorf("expected service=%q, got %q", name, parsed.Service)
+	}
+	if len(parsed.Vars) == 0 {
+		t.Error("expected at least one env var")
+	}
+}
+
 // TestToolList_underSizeCeiling guards against regrowth of the tools/list
 // manifest sent on every MCP session. Every byte above the ceiling is in
 // context for the whole session; raise the ceiling only with a justified

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -10,6 +10,28 @@ import (
 	"github.com/geodro/lerd/internal/config"
 )
 
+// decodeContent asserts a tool result carries exactly one text content block
+// and unmarshals that block's JSON text into v. It is the shared shape every
+// "handler returns content" regression test checks.
+func decodeContent(t *testing.T, result any, v any) {
+	t.Helper()
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatal("result is not a map")
+	}
+	content, ok := m["content"].([]map[string]any)
+	if !ok || len(content) != 1 {
+		t.Fatal("result has no content block")
+	}
+	text, ok := content[0]["text"].(string)
+	if !ok {
+		t.Fatal("content block has no text")
+	}
+	if err := json.Unmarshal([]byte(text), v); err != nil {
+		t.Fatal("content is not valid JSON:", err)
+	}
+}
+
 func TestStripANSI_removesColorCodes(t *testing.T) {
 	input := "\x1b[32mOK\x1b[0m some text \x1b[31mFAIL\x1b[0m"
 	got := stripANSI(input)
@@ -171,7 +193,7 @@ func TestExecEnvCheck_missingKeys(t *testing.T) {
 func TestExecServiceEnv_returnsContent(t *testing.T) {
 	var name string
 	for _, s := range knownServices() {
-		if builtinServiceEnv(s) != nil {
+		if len(builtinServiceEnv(s)) > 0 {
 			name = s
 			break
 		}
@@ -184,17 +206,11 @@ func TestExecServiceEnv_returnsContent(t *testing.T) {
 	if rpcErr != nil {
 		t.Fatal("unexpected rpc error:", rpcErr.Message)
 	}
-	content, ok := result.(map[string]any)["content"].([]map[string]any)
-	if !ok || len(content) != 1 {
-		t.Fatal("result has no content block")
-	}
 	var parsed struct {
 		Service string            `json:"service"`
 		Vars    map[string]string `json:"vars"`
 	}
-	if err := json.Unmarshal([]byte(content[0]["text"].(string)), &parsed); err != nil {
-		t.Fatal("content is not valid JSON:", err)
-	}
+	decodeContent(t, result, &parsed)
 	if parsed.Service != name {
 		t.Errorf("expected service=%q, got %q", name, parsed.Service)
 	}
@@ -211,16 +227,10 @@ func TestExecDNSDiagnose_returnsContent(t *testing.T) {
 	if rpcErr != nil {
 		t.Fatal("unexpected rpc error:", rpcErr.Message)
 	}
-	content, ok := result.(map[string]any)["content"].([]map[string]any)
-	if !ok || len(content) != 1 {
-		t.Fatal("result has no content block")
-	}
 	var parsed struct {
 		TLD string `json:"tld"`
 	}
-	if err := json.Unmarshal([]byte(content[0]["text"].(string)), &parsed); err != nil {
-		t.Fatal("content is not valid JSON:", err)
-	}
+	decodeContent(t, result, &parsed)
 	if parsed.TLD != "test" {
 		t.Errorf("expected tld=test, got %q", parsed.TLD)
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -203,6 +203,29 @@ func TestExecServiceEnv_returnsContent(t *testing.T) {
 	}
 }
 
+// TestExecDNSDiagnose_returnsContent guards the same "no output" regression for
+// the diag dns_diagnose action, whose handler returned a bare Diagnostic struct.
+// The result must come back inside a content block regardless of probe outcome.
+func TestExecDNSDiagnose_returnsContent(t *testing.T) {
+	result, rpcErr := execDNSDiagnose(map[string]any{"tld": "test"})
+	if rpcErr != nil {
+		t.Fatal("unexpected rpc error:", rpcErr.Message)
+	}
+	content, ok := result.(map[string]any)["content"].([]map[string]any)
+	if !ok || len(content) != 1 {
+		t.Fatal("result has no content block")
+	}
+	var parsed struct {
+		TLD string `json:"tld"`
+	}
+	if err := json.Unmarshal([]byte(content[0]["text"].(string)), &parsed); err != nil {
+		t.Fatal("content is not valid JSON:", err)
+	}
+	if parsed.TLD != "test" {
+		t.Errorf("expected tld=test, got %q", parsed.TLD)
+	}
+}
+
 // TestToolList_underSizeCeiling guards against regrowth of the tools/list
 // manifest sent on every MCP session. Every byte above the ceiling is in
 // context for the whole session; raise the ceiling only with a justified

--- a/internal/mcp/worktree.go
+++ b/internal/mcp/worktree.go
@@ -126,7 +126,7 @@ func execWorktreeList(args map[string]any) (any, *rpcError) {
 			})
 		}
 	}
-	return map[string]any{"site": site.Name, "worktrees": out}, nil
+	return toolJSON(map[string]any{"site": site.Name, "worktrees": out}), nil
 }
 
 func execWorktreeAdd(args map[string]any) (any, *rpcError) {
@@ -151,7 +151,7 @@ func execWorktreeAdd(args map[string]any) (any, *rpcError) {
 	if err != nil {
 		return toolErr("git " + strings.Join(gitArgs, " ") + ": " + out), nil
 	}
-	return map[string]any{"ok": true, "site": site.Name, "output": out}, nil
+	return toolJSON(map[string]any{"ok": true, "site": site.Name, "output": out}), nil
 }
 
 func execWorktreeRemove(args map[string]any) (any, *rpcError) {
@@ -191,12 +191,12 @@ func execWorktreeRemove(args map[string]any) (any, *rpcError) {
 	if err != nil {
 		return toolErr("git " + strings.Join(gitArgs, " ") + ": " + out), nil
 	}
-	return map[string]any{
+	return toolJSON(map[string]any{
 		"ok":                  true,
 		"site":                site.Name,
 		"output":              out,
 		"isolated_db_dropped": dbDropped,
-	}, nil
+	}), nil
 }
 
 func execWorktreeDBIsolate(args map[string]any) (any, *rpcError) {
@@ -226,7 +226,7 @@ func execWorktreeDBIsolate(args map[string]any) (any, *rpcError) {
 		resp["db_name"] = e.DBName
 		resp["db_service"] = e.Service
 	}
-	return resp, nil
+	return toolJSON(resp), nil
 }
 
 func execWorktreeDBShare(args map[string]any) (any, *rpcError) {
@@ -246,7 +246,7 @@ func execWorktreeDBShare(args map[string]any) (any, *rpcError) {
 	if err != nil {
 		return toolErr("lerd db:share: " + out), nil
 	}
-	return map[string]any{"ok": true, "site": site.Name, "branch": branch, "output": out}, nil
+	return toolJSON(map[string]any{"ok": true, "site": site.Name, "branch": branch, "output": out}), nil
 }
 
 func runIn(dir, name string, args ...string) (string, error) {

--- a/internal/mcp/worktree_test.go
+++ b/internal/mcp/worktree_test.go
@@ -28,10 +28,9 @@ func TestToolJSON_wrapsValueInContent(t *testing.T) {
 	}
 }
 
-// TestExecWorktreeList_returnsContent guards the regression where every
-// worktree handler returned a bare map with no "content" key, so the MCP host
-// rendered a live worktree as "no output". The result must carry a content
-// block whose JSON lists the detected worktree.
+// TestExecWorktreeList_returnsContent guards the regression where a handler
+// returned a bare map with no "content" key, so the MCP host rendered a live
+// worktree as "no output". The result must carry a content block.
 func TestExecWorktreeList_returnsContent(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")

--- a/internal/mcp/worktree_test.go
+++ b/internal/mcp/worktree_test.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,17 +11,11 @@ import (
 
 func TestToolJSON_wrapsValueInContent(t *testing.T) {
 	result := toolJSON(map[string]any{"site": "demo", "worktrees": []string{"a"}})
-	content, ok := result["content"].([]map[string]any)
-	if !ok || len(content) != 1 {
-		t.Fatal("expected a content array with one element")
-	}
 	if _, has := result["isError"]; has {
 		t.Error("toolJSON must not set isError on success")
 	}
 	var parsed map[string]any
-	if err := json.Unmarshal([]byte(content[0]["text"].(string)), &parsed); err != nil {
-		t.Fatal("content text is not valid JSON:", err)
-	}
+	decodeContent(t, result, &parsed)
 	if parsed["site"] != "demo" {
 		t.Errorf("expected site=demo, got %v", parsed["site"])
 	}
@@ -61,10 +54,6 @@ func TestExecWorktreeList_returnsContent(t *testing.T) {
 	if rpcErr != nil {
 		t.Fatal("unexpected rpc error:", rpcErr.Message)
 	}
-	content, ok := result.(map[string]any)["content"].([]map[string]any)
-	if !ok || len(content) != 1 {
-		t.Fatal("result has no content block")
-	}
 	var parsed struct {
 		Site      string `json:"site"`
 		Worktrees []struct {
@@ -72,9 +61,7 @@ func TestExecWorktreeList_returnsContent(t *testing.T) {
 			Domain string `json:"domain"`
 		} `json:"worktrees"`
 	}
-	if err := json.Unmarshal([]byte(content[0]["text"].(string)), &parsed); err != nil {
-		t.Fatal("content is not valid JSON:", err)
-	}
+	decodeContent(t, result, &parsed)
 	if parsed.Site != "demo" {
 		t.Errorf("expected site=demo, got %q", parsed.Site)
 	}

--- a/internal/mcp/worktree_test.go
+++ b/internal/mcp/worktree_test.go
@@ -1,0 +1,97 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestToolJSON_wrapsValueInContent(t *testing.T) {
+	result := toolJSON(map[string]any{"site": "demo", "worktrees": []string{"a"}})
+	content, ok := result["content"].([]map[string]any)
+	if !ok || len(content) != 1 {
+		t.Fatal("expected a content array with one element")
+	}
+	if _, has := result["isError"]; has {
+		t.Error("toolJSON must not set isError on success")
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(content[0]["text"].(string)), &parsed); err != nil {
+		t.Fatal("content text is not valid JSON:", err)
+	}
+	if parsed["site"] != "demo" {
+		t.Errorf("expected site=demo, got %v", parsed["site"])
+	}
+}
+
+// TestExecWorktreeList_returnsContent guards the regression where every
+// worktree handler returned a bare map with no "content" key, so the MCP host
+// rendered a live worktree as "no output". The result must carry a content
+// block whose JSON lists the detected worktree.
+func TestExecWorktreeList_returnsContent(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", filepath.Join(root, "data"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
+
+	repo := filepath.Join(root, "demo")
+	if err := os.MkdirAll(repo, 0755); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "init")
+	gitRun(t, repo, "config", "user.email", "test@example.com")
+	gitRun(t, repo, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hi\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "add", "README.md")
+	gitRun(t, repo, "commit", "-m", "init")
+	gitRun(t, repo, "worktree", "add", filepath.Join(repo, "feature"), "-b", "feature")
+
+	if err := config.AddSite(config.Site{Name: "demo", Domains: []string{"demo.test"}, Path: repo}); err != nil {
+		t.Fatal("add site:", err)
+	}
+
+	result, rpcErr := execWorktreeList(map[string]any{"site": "demo"})
+	if rpcErr != nil {
+		t.Fatal("unexpected rpc error:", rpcErr.Message)
+	}
+	content, ok := result.(map[string]any)["content"].([]map[string]any)
+	if !ok || len(content) != 1 {
+		t.Fatal("result has no content block")
+	}
+	var parsed struct {
+		Site      string `json:"site"`
+		Worktrees []struct {
+			Branch string `json:"branch"`
+			Domain string `json:"domain"`
+		} `json:"worktrees"`
+	}
+	if err := json.Unmarshal([]byte(content[0]["text"].(string)), &parsed); err != nil {
+		t.Fatal("content is not valid JSON:", err)
+	}
+	if parsed.Site != "demo" {
+		t.Errorf("expected site=demo, got %q", parsed.Site)
+	}
+	if len(parsed.Worktrees) != 1 || parsed.Worktrees[0].Branch != "feature" {
+		t.Fatalf("expected one worktree on branch feature, got %+v", parsed.Worktrees)
+	}
+	if parsed.Worktrees[0].Domain != "feature.demo.test" {
+		t.Errorf("expected domain feature.demo.test, got %q", parsed.Worktrees[0].Domain)
+	}
+}
+
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}


### PR DESCRIPTION
The worktree MCP tool was silently swallowing its own output. All five actions, list, add, remove, db_isolate and db_share, returned bare maps like {site, worktrees} directly from their handlers. Every MCP result has to carry a content array for the host to render anything, which is exactly why toolOK and toolErr wrap their payload that way, so these bare maps came back as a "no output" response even though the action had already succeeded. In practice creating a worktree looked like it did nothing, and listing worktrees showed nothing at all while git was reporting the checkout sitting right there on disk.

The fix routes all five success paths through a small toolJSON helper that marshals the structured value and wraps it in a content block, which is the same shape the rest of the server already uses for its JSON results. The error branches were always going through toolErr so they were never affected.
