### PR TITLE
feat(cli): offer to link unlinked projects instead of dead-ending

### DIFF
--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -104,7 +104,7 @@ On a machine where `.lerd.yaml` already exists the wizard is skipped and the sav
 
 ## Running a command in an unlinked project
 
-Commands that operate on the current site (`lerd open`, `lerd runtime`, `lerd worker`, `lerd stripe`, `lerd env`, `lerd domain`, `lerd share`, `lerd xdebug`) need the directory to be linked. When you run one in a project that has not been linked yet, lerd offers to link it for you instead of stopping with an error:
+Commands that operate on the current site (`lerd open`, `lerd runtime`, `lerd worker`, `lerd stripe`, `lerd env`, `lerd domain`, `lerd share`, `lerd xdebug`, and the worker-backed `lerd reverb`, `lerd schedule`, `lerd queue`) need the directory to be linked. When you run one in a project that has not been linked yet, lerd offers to link it for you instead of stopping with an error:
 
 ```
 This directory isn't linked to lerd. Link it now? [Y/n]

--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -102,6 +102,16 @@ On a machine where `.lerd.yaml` already exists the wizard is skipped and the sav
 
 `lerd link` also applies `.lerd.yaml` when the file is present, so cloning a repo and running `lerd link` is enough to restore the full environment without running `lerd setup` or `lerd init` first. When workers are configured in `.lerd.yaml` but not yet running, `lerd link` prompts to run `lerd setup` so you can install dependencies, run migrations, and start workers in the right order.
 
+## Running a command in an unlinked project
+
+Commands that operate on the current site (`lerd open`, `lerd runtime`, `lerd worker`, `lerd stripe`, `lerd env`, `lerd domain`, `lerd share`, `lerd xdebug`) need the directory to be linked. When you run one in a project that has not been linked yet, lerd offers to link it for you instead of stopping with an error:
+
+```
+This directory isn't linked to lerd. Link it now? [Y/n]
+```
+
+Accepting runs `lerd link` (which cascades into `lerd init` when there is no `.lerd.yaml`), then the original command continues, so a single command is enough rather than a link, init, retry sequence. In a non-interactive context (a script or CI) the command returns a single clear error and does nothing else.
+
 See [Configuration](../configuration.md#per-project-config-lerdyaml) for the full field reference including inline service definitions and custom frameworks.
 
 ---

--- a/internal/cli/domain.go
+++ b/internal/cli/domain.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/geodro/lerd/internal/certs"
@@ -54,11 +53,7 @@ func newDomainListCmd() *cobra.Command {
 
 // resolveSiteForCwd finds the site registered for the current working directory.
 func resolveSiteForCwd() (*config.Site, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	return ensureSiteForCwd(cwd)
+	return ensureSiteForCwd()
 }
 
 func runDomainAdd(_ *cobra.Command, args []string) error {

--- a/internal/cli/domain.go
+++ b/internal/cli/domain.go
@@ -58,11 +58,7 @@ func resolveSiteForCwd() (*config.Site, error) {
 	if err != nil {
 		return nil, err
 	}
-	site, err := config.FindSiteByPath(cwd)
-	if err != nil {
-		return nil, fmt.Errorf("no site registered for %s — link it first with lerd link", cwd)
-	}
-	return site, nil
+	return ensureSiteForCwd(cwd)
 }
 
 func runDomainAdd(_ *cobra.Command, args []string) error {

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -243,7 +243,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	}
 
 	// Determine framework-specific env file path and format
-	site, err := ensureSiteForCwd(cwd)
+	site, err := ensureSiteForCwd()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -243,9 +243,9 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	}
 
 	// Determine framework-specific env file path and format
-	site, _ := config.FindSiteByPath(cwd)
-	if site == nil {
-		return fmt.Errorf("no site registered for this directory\nRun 'lerd link' first")
+	site, err := ensureSiteForCwd(cwd)
+	if err != nil {
+		return err
 	}
 
 	fwName := site.Framework

--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -45,7 +45,7 @@ func runOpen(_ *cobra.Command, args []string) error {
 			}
 		}
 		if url == "" {
-			site, err := ensureSiteForCwd(cwd)
+			site, err := ensureSiteForCwd()
 			if err != nil {
 				return err
 			}

--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -44,10 +44,17 @@ func runOpen(_ *cobra.Command, args []string) error {
 				url = siteURL(site.Path)
 			}
 		}
+		if url == "" {
+			site, err := ensureSiteForCwd(cwd)
+			if err != nil {
+				return err
+			}
+			url = siteURL(site.Path)
+		}
 	}
 
 	if url == "" {
-		return fmt.Errorf("no registered site found for this directory — run 'lerd link' first")
+		return errNotLinked()
 	}
 
 	fmt.Printf("Opening %s\n", url)

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/geodro/lerd/internal/config"
 )
@@ -13,10 +14,14 @@ func errNotLinked() error {
 	return fmt.Errorf("no site registered for this directory — run 'lerd link' first")
 }
 
-// ensureSiteForCwd resolves the site registered for cwd. When none is found in
-// an interactive terminal it offers to link the directory, which cascades into
-// lerd init, then re-resolves so the caller proceeds in one flow.
-func ensureSiteForCwd(cwd string) (*config.Site, error) {
+// ensureSiteForCwd resolves the site for the current working directory, using
+// os.Getwd for both lookup and link so they can't diverge. On a miss in an
+// interactive terminal it offers to link (cascading into init) and re-resolves.
+func ensureSiteForCwd() (*config.Site, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
 	if site, err := config.FindSiteByPath(cwd); err == nil {
 		return site, nil
 	}

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// errNotLinked is the single message every directory-scoped command shows when
+// the current directory has no registered site, replacing several earlier
+// phrasings so the guidance is consistent everywhere.
+func errNotLinked() error {
+	return fmt.Errorf("no site registered for this directory — run 'lerd link' first")
+}
+
+// ensureSiteForCwd resolves the site registered for cwd. When none is found in
+// an interactive terminal it offers to link the directory, which cascades into
+// lerd init, then re-resolves so the caller proceeds in one flow.
+func ensureSiteForCwd(cwd string) (*config.Site, error) {
+	if site, err := config.FindSiteByPath(cwd); err == nil {
+		return site, nil
+	}
+	if !isInteractive() {
+		return nil, errNotLinked()
+	}
+
+	fmt.Print("This directory isn't linked to lerd. Link it now? [Y/n] ")
+	var answer string
+	fmt.Scanln(&answer) //nolint:errcheck
+	if !(answer == "" || answer[0] == 'Y' || answer[0] == 'y') {
+		return nil, errNotLinked()
+	}
+
+	if err := runLink(nil); err != nil {
+		return nil, err
+	}
+	site, err := config.FindSiteByPath(cwd)
+	if err != nil {
+		return nil, errNotLinked()
+	}
+	return site, nil
+}

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -14,8 +14,9 @@ func TestErrNotLinkedMentionsLink(t *testing.T) {
 
 // In a test process stdin is not a terminal, so ensureSiteForCwd must take the
 // non-interactive branch and return the consistent error without prompting.
+// The package source dir it runs in is not a registered site.
 func TestEnsureSiteForCwdNonInteractiveErrors(t *testing.T) {
-	_, err := ensureSiteForCwd("/definitely/not/a/registered/lerd/site")
+	_, err := ensureSiteForCwd()
 	if err == nil {
 		t.Fatal("expected an error for an unlinked directory in non-interactive mode")
 	}

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestErrNotLinkedMentionsLink(t *testing.T) {
+	msg := errNotLinked().Error()
+	if !strings.Contains(msg, "run 'lerd link' first") {
+		t.Errorf("errNotLinked message changed, callers rely on it: %q", msg)
+	}
+}
+
+// In a test process stdin is not a terminal, so ensureSiteForCwd must take the
+// non-interactive branch and return the consistent error without prompting.
+func TestEnsureSiteForCwdNonInteractiveErrors(t *testing.T) {
+	_, err := ensureSiteForCwd("/definitely/not/a/registered/lerd/site")
+	if err == nil {
+		t.Fatal("expected an error for an unlinked directory in non-interactive mode")
+	}
+	if !strings.Contains(err.Error(), "lerd link") {
+		t.Errorf("error should point the user at lerd link, got: %v", err)
+	}
+}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -52,9 +52,9 @@ func runRuntime(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	site, err := config.FindSiteByPath(cwd)
+	site, err := ensureSiteForCwd(cwd)
 	if err != nil {
-		return fmt.Errorf("not a registered site — run 'lerd link' first")
+		return err
 	}
 	if site.IsCustomContainer() {
 		return fmt.Errorf("site uses a custom Containerfile; the runtime is defined by your Containerfile.lerd")

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/nginx"
@@ -48,11 +47,7 @@ choice is committed with the project.
 }
 
 func runRuntime(cmd *cobra.Command, args []string) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	site, err := ensureSiteForCwd(cwd)
+	site, err := ensureSiteForCwd()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/share.go
+++ b/internal/cli/share.go
@@ -167,11 +167,10 @@ func resolveShareSite(args []string) (*config.Site, error) {
 
 	// Fall back: treat the directory name as a site name.
 	name, _ := siteops.SiteNameAndDomain(filepath.Base(cwd), "test")
-	site, err = config.FindSite(name)
-	if err != nil {
-		return nil, fmt.Errorf("no registered site found for this directory — run 'lerd link' first")
+	if site, err = config.FindSite(name); err == nil {
+		return site, nil
 	}
-	return site, nil
+	return ensureSiteForCwd(cwd)
 }
 
 func pickShareTool(useNgrok, useCloudflare, useExpose, useServeo, useLocalhostRun bool) (*shareTool, error) {

--- a/internal/cli/share.go
+++ b/internal/cli/share.go
@@ -170,7 +170,7 @@ func resolveShareSite(args []string) (*config.Site, error) {
 	if site, err = config.FindSite(name); err == nil {
 		return site, nil
 	}
-	return ensureSiteForCwd(cwd)
+	return ensureSiteForCwd()
 }
 
 func pickShareTool(useNgrok, useCloudflare, useExpose, useServeo, useLocalhostRun bool) (*shareTool, error) {

--- a/internal/cli/stripe.go
+++ b/internal/cli/stripe.go
@@ -33,9 +33,9 @@ func newStripeConfigCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			site, err := config.FindSiteByPath(cwd)
+			site, err := ensureSiteForCwd(cwd)
 			if err != nil {
-				return fmt.Errorf("not a registered site — run 'lerd link' first")
+				return err
 			}
 
 			// No flags: report the current config instead of writing anything.
@@ -114,7 +114,13 @@ func newStripeListenCmd() *cobra.Command {
 
 			base := siteURL(cwd)
 			if base == "" {
-				return fmt.Errorf("no registered site found for this directory — run 'lerd link' first")
+				if _, err := ensureSiteForCwd(cwd); err != nil {
+					return err
+				}
+				base = siteURL(cwd)
+			}
+			if base == "" {
+				return errNotLinked()
 			}
 
 			siteName, err := queueSiteName(cwd)

--- a/internal/cli/stripe.go
+++ b/internal/cli/stripe.go
@@ -33,7 +33,7 @@ func newStripeConfigCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			site, err := ensureSiteForCwd(cwd)
+			site, err := ensureSiteForCwd()
 			if err != nil {
 				return err
 			}
@@ -114,7 +114,7 @@ func newStripeListenCmd() *cobra.Command {
 
 			base := siteURL(cwd)
 			if base == "" {
-				if _, err := ensureSiteForCwd(cwd); err != nil {
+				if _, err := ensureSiteForCwd(); err != nil {
 					return err
 				}
 				base = siteURL(cwd)

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -161,7 +161,10 @@ func resolveSiteAndFramework(cwd string) (*config.Site, *config.Framework, strin
 		if parent, ok := config.ParentSiteForWorktreeDir(cwd); ok {
 			site = parent
 		} else {
-			return nil, nil, "", fmt.Errorf("not a registered site — run 'lerd link' first")
+			site, err = ensureSiteForCwd(cwd)
+			if err != nil {
+				return nil, nil, "", err
+			}
 		}
 	}
 
@@ -426,9 +429,9 @@ func newWorkerAddCmd() *cobra.Command {
 				return err
 			}
 
-			site, err := config.FindSiteByPath(cwd)
+			site, err := ensureSiteForCwd(cwd)
 			if err != nil {
-				return fmt.Errorf("not a registered site — run 'lerd link' first")
+				return err
 			}
 
 			w := config.FrameworkWorker{
@@ -514,9 +517,9 @@ func newWorkerRemoveCmd() *cobra.Command {
 				return err
 			}
 
-			site, err := config.FindSiteByPath(cwd)
+			site, err := ensureSiteForCwd(cwd)
 			if err != nil {
-				return fmt.Errorf("not a registered site — run 'lerd link' first")
+				return err
 			}
 
 			// Stop the worker if running — on the parent and on every

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -161,7 +161,7 @@ func resolveSiteAndFramework(cwd string) (*config.Site, *config.Framework, strin
 		if parent, ok := config.ParentSiteForWorktreeDir(cwd); ok {
 			site = parent
 		} else {
-			site, err = ensureSiteForCwd(cwd)
+			site, err = ensureSiteForCwd()
 			if err != nil {
 				return nil, nil, "", err
 			}
@@ -429,7 +429,7 @@ func newWorkerAddCmd() *cobra.Command {
 				return err
 			}
 
-			site, err := ensureSiteForCwd(cwd)
+			site, err := ensureSiteForCwd()
 			if err != nil {
 				return err
 			}
@@ -517,7 +517,7 @@ func newWorkerRemoveCmd() *cobra.Command {
 				return err
 			}
 
-			site, err := ensureSiteForCwd(cwd)
+			site, err := ensureSiteForCwd()
 			if err != nil {
 				return err
 			}

--- a/internal/cli/worker_heal_cmd.go
+++ b/internal/cli/worker_heal_cmd.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/geodro/lerd/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -68,9 +67,9 @@ func runHealOne(workerName string) error {
 	if err != nil {
 		return err
 	}
-	site, err := config.FindSiteByPath(cwd)
+	site, err := ensureSiteForCwd(cwd)
 	if err != nil {
-		return fmt.Errorf("not a registered site — run 'lerd link' first")
+		return err
 	}
 	unit := "lerd-" + workerName + "-" + site.Name
 	fmt.Printf("  ➜  %s ", unit)

--- a/internal/cli/worker_heal_cmd.go
+++ b/internal/cli/worker_heal_cmd.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -63,11 +62,7 @@ func runHealAll() error {
 }
 
 func runHealOne(workerName string) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	site, err := ensureSiteForCwd(cwd)
+	site, err := ensureSiteForCwd()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/xdebug_pause.go
+++ b/internal/cli/xdebug_pause.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -112,11 +111,7 @@ func resolvePauseSite(args []string) (*config.Site, error) {
 	if len(args) == 1 {
 		return config.FindSite(args[0])
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	return ensureSiteForCwd(cwd)
+	return ensureSiteForCwd()
 }
 
 func pauseSiteVersion(site *config.Site) string {

--- a/internal/cli/xdebug_pause.go
+++ b/internal/cli/xdebug_pause.go
@@ -116,11 +116,7 @@ func resolvePauseSite(args []string) (*config.Site, error) {
 	if err != nil {
 		return nil, err
 	}
-	site, err := config.FindSiteByPath(cwd)
-	if err != nil {
-		return nil, fmt.Errorf("no lerd site here — run inside a project or pass a site name")
-	}
-	return site, nil
+	return ensureSiteForCwd(cwd)
 }
 
 func pauseSiteVersion(site *config.Site) string {


### PR DESCRIPTION
Running a directory-scoped command in a project that was not linked yet used to error out telling the user to run lerd link, and link would then point them at lerd init for the missing .lerd.yaml, so a single intent turned into three separate invocations. The exact wording also varied from command to command.

Site resolution for the current directory now goes through one ensureSiteForCwd helper. When nothing is registered and the session is interactive it offers to link the directory, which already cascades into init, then re-resolves so the original command continues in one flow. Non-interactive runs keep a single consistent error so scripts and CI are unaffected. The helper is wired into open, runtime, worker and worker heal, stripe, env, domain, share, and xdebug, which also collapses the four earlier phrasings into one message. unlink, which, and worktree remove are intentionally left out, since offering to link there makes no sense.

Closes #557