### PR TITLE
docs: point the Linux install one-liner at lerd.sh/install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Eleven grouped tools, each driven by an `action`: `site`, `service`, `db`, `env`
 ### Linux
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/geodro/lerd/main/install.sh | bash
+curl -fsSL https://lerd.sh/install.sh | bash
 ```
 
 Update later with:

--- a/docs/.vitepress/theme/components/ShipIt.vue
+++ b/docs/.vitepress/theme/components/ShipIt.vue
@@ -15,7 +15,7 @@
         </div>
         <div class="term-body">
           <div class="c"># Linux</div>
-          <div><span class="p">$</span> curl -fsSL https://raw.githubusercontent.com/geodro/lerd/main/install.sh | bash</div>
+          <div><span class="p">$</span> curl -fsSL https://lerd.sh/install.sh | bash</div>
           <div class="c"># macOS</div>
           <div><span class="p">$</span> brew install geodro/lerd/lerd &amp;&amp; lerd install</div>
           <div class="c"># then, in any project</div>


### PR DESCRIPTION
Now that the docs site serves the install script from the custom domain, the README quick-install and the homepage hero terminal both use `curl -fsSL https://lerd.sh/install.sh | bash` instead of the raw.githubusercontent URL. The macOS brew line and the GitHub release download paths are unchanged.