### PR TITLE
feat: route lerd link through the init wizard and handle non-PHP projects

### DIFF
--- a/docs/usage/sites.md
+++ b/docs/usage/sites.md
@@ -8,7 +8,7 @@
 | `lerd init --fresh` | Re-run the wizard with existing `.lerd.yaml` values as defaults |
 | `lerd park [dir]` | Register all Laravel projects inside `dir` (defaults to cwd) |
 | `lerd unpark [dir]` | Remove a parked directory and unlink all its sites |
-| `lerd link [domain]` | Register the current directory as a site (domain name without TLD, defaults to directory name) |
+| `lerd link [domain]` | Register the current directory as a site (domain name without TLD, defaults to directory name). On a fresh project in an interactive terminal it runs the `lerd init` wizard first |
 | `lerd unlink` | Unlink the current directory site (removes all domains) |
 | `lerd domain add <name>` | Add an additional domain to the current site |
 | `lerd domain remove <name>` | Remove a domain from the current site |
@@ -27,6 +27,8 @@
 ## Project initialisation
 
 `lerd init` runs an interactive wizard, writes the answers to `.lerd.yaml` in the project root, and then applies the configuration: linking the site, enabling HTTPS if requested, picking a database, and starting any required services.
+
+`lerd link` and `lerd init` overlap on purpose. When you run `lerd link` on a project that has no `.lerd.yaml` yet and you're in an interactive terminal, link routes straight into the init wizard, so you don't have to know to reach for `init` first. If the project already has a `.lerd.yaml`, link just applies it. And in a non-interactive shell (a script, CI, `lerd park`, or any piped invocation) link always does a fast, bare auto-detected registration with no wizard, so automation never blocks on a prompt. Passing an explicit domain (`lerd link myapp`) also skips the wizard and links directly.
 
 ```bash
 cd ~/Projects/my-app

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -98,7 +98,6 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 	framework, hasFramework := resolveFramework(cwd)
 	hasComposer := fileExists(filepath.Join(cwd, "composer.json"))
 	hasContainerfile := podman.HasContainerfile(cwd)
-	hasPkgJSON := fileExists(filepath.Join(cwd, "package.json"))
 	alreadyCustom := defaults.Container != nil
 	alreadyProxy := defaults.Proxy != nil
 
@@ -112,37 +111,39 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 		return runCustomContainerWizard(cwd, defaults, gcfg)
 	}
 	if !hasFramework && !hasComposer {
-		// Non-PHP project. With a package.json, offer to run the dev server on
-		// the host (proxy) — the default — or build a custom container.
-		if hasPkgJSON {
-			const proxyChoice = "Dev server (proxy to a host port)"
-			const customChoice = "Custom container"
-			choice := proxyChoice
-			if err := huh.NewForm(huh.NewGroup(
-				huh.NewSelect[string]().
-					Title("This looks like a Node project. How should lerd run it?").
-					Options(huh.NewOptions(proxyChoice, customChoice)...).
-					Value(&choice),
-			)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
-				return nil, err
-			}
-			if choice == customChoice {
-				return runCustomContainerWizard(cwd, defaults, gcfg)
-			}
-			return runHostProxyWizard(cwd, defaults, gcfg)
+		// Non-PHP project. Offer the same language-aware choice to every runtime,
+		// not just Node: run the dev server on the host (proxy) or build a custom
+		// container. When the project's runtime is recognised we say so and drop
+		// the plain-PHP option; an unknown/empty directory keeps it as a fallback
+		// (declining both non-PHP paths sets the project up as a PHP site).
+		const proxyChoice = "Dev server (proxy to a host port)"
+		const customChoice = "Custom container (Containerfile.lerd)"
+		const phpChoice = "Plain PHP site"
+
+		rt, knownRuntime := detectProjectRuntime(cwd)
+		title := "No PHP project detected. How should lerd run it?"
+		options := []string{proxyChoice, customChoice, phpChoice}
+		if knownRuntime {
+			title = fmt.Sprintf("This looks like a %s project. How should lerd run it?", rt.label)
+			options = []string{proxyChoice, customChoice}
 		}
-		useCustom := false
+
+		choice := proxyChoice
 		if err := huh.NewForm(huh.NewGroup(
-			huh.NewConfirm().
-				Title("No PHP project detected. Set up a custom container?").
-				Description("A Containerfile.lerd in the project root defines the container image").
-				Value(&useCustom),
+			huh.NewSelect[string]().
+				Title(title).
+				Options(huh.NewOptions(options...)...).
+				Value(&choice),
 		)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
 			return nil, err
 		}
-		if useCustom {
+		switch choice {
+		case proxyChoice:
+			return runHostProxyWizard(cwd, defaults, gcfg)
+		case customChoice:
 			return runCustomContainerWizard(cwd, defaults, gcfg)
 		}
+		// phpChoice falls through to the PHP wizard below.
 	}
 
 	// Seed defaults from the site registry when no saved config exists yet,
@@ -559,6 +560,10 @@ func runCustomContainerWizard(cwd string, defaults *config.ProjectConfig, gcfg *
 	port := 0
 	fmt.Sscanf(portStr, "%d", &port)
 
+	// Offer to scaffold the Containerfile if it isn't there yet, so picking
+	// "custom container" on a project without one isn't a dead end.
+	maybeCreateContainerfile(cwd, containerfile, port)
+
 	// Services: same flow as the PHP wizard but without the database select
 	// since custom containers manage their own database connections.
 	serviceOptions := nonDatabaseServiceOptions()
@@ -689,52 +694,35 @@ func buildProjectServices(selectedServices []string, defaults *config.ProjectCon
 	return services
 }
 
-// runHostProxyWizard runs the init wizard for a host-proxy (Node) project: lerd
-// supervises the dev command on the host and nginx proxies the domain to it.
-// Collects the command, port, HTTPS, and services.
+// runHostProxyWizard runs the init wizard for a host-proxy project (Node, or
+// any runtime that serves on a host port): lerd supervises the dev command on
+// the host and nginx proxies the domain to it. Command, port, and HTTPS are
+// collected on a single screen (like the custom container wizard), followed by
+// services.
 func runHostProxyWizard(cwd string, defaults *config.ProjectConfig, gcfg *config.GlobalConfig) (*config.ProjectConfig, error) {
 	manifest := readPackageManifest(cwd)
 	devScripts := manifest.devScripts()
 
-	const otherOption = "Other (enter a command)"
+	// Default command: a saved one wins, else the first detected dev script,
+	// else a runtime-appropriate guess. Blank is allowed (proxy-only mode).
 	command := ""
 	if defaults.Proxy != nil {
 		command = defaults.Proxy.Command
 	}
-
-	// Pick the dev command: choose a detected npm script or enter a custom one.
-	selected := otherOption
+	if command == "" {
+		if len(devScripts) > 0 {
+			command = devScripts[0]
+		} else {
+			command = defaultDevCommand(cwd)
+		}
+	}
+	commandDesc := "How lerd starts the app (lerd supervises and restarts it). Blank = run it yourself."
 	if len(devScripts) > 0 {
-		selected = devScripts[0]
-		options := append(append([]string{}, devScripts...), otherOption)
-		if err := huh.NewForm(huh.NewGroup(
-			huh.NewSelect[string]().
-				Title("Dev command").
-				Description("How lerd starts the app (lerd supervises and restarts it)").
-				Options(huh.NewOptions(options...)...).
-				Value(&selected),
-		)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
-			return nil, err
-		}
-	}
-	if selected == otherOption {
-		if command == "" {
-			command = "npm run start:dev"
-		}
-		if err := huh.NewForm(huh.NewGroup(
-			huh.NewInput().
-				Title("Dev command").
-				Description("Leave blank to run the server yourself (proxy-only mode)").
-				Value(&command),
-		)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil {
-			return nil, err
-		}
-	} else {
-		command = selected
+		commandDesc = "Detected scripts: " + strings.Join(devScripts, ", ") + ". Blank = run it yourself."
 	}
 
-	// Port: default from an explicit flag in the command, else the tool's
-	// conventional port, else 3000.
+	// Port default: a saved one wins, else parse a --port from the command, else
+	// auto-assign the next free dev-server port.
 	port := 0
 	if defaults.Proxy != nil && defaults.Proxy.Port > 0 {
 		port = defaults.Proxy.Port
@@ -743,8 +731,6 @@ func runHostProxyWizard(cwd string, defaults *config.ProjectConfig, gcfg *config
 		if p := portFromCommand(command); p > 0 {
 			port = p
 		} else {
-			// No explicit port: auto-assign from the default base, walking up
-			// past anything already taken (other sites, lerd services).
 			siteName := ""
 			if s, err := config.FindSiteByPath(cwd); err == nil {
 				siteName = s.Name
@@ -756,6 +742,10 @@ func runHostProxyWizard(cwd string, defaults *config.ProjectConfig, gcfg *config
 	secured, httpsAvailable := resolveSecuredDefault(cwd, defaults.Secured, gcfg)
 
 	proxyFields := []huh.Field{
+		huh.NewInput().
+			Title("Dev command").
+			Description(commandDesc).
+			Value(&command),
 		huh.NewInput().
 			Title("Port").
 			Description("The port the dev server listens on (lerd injects PORT and proxies here)").
@@ -778,6 +768,12 @@ func runHostProxyWizard(cwd string, defaults *config.ProjectConfig, gcfg *config
 	}
 	port = 0
 	fmt.Sscanf(portStr, "%d", &port)
+	// An explicit --port in the (possibly edited) command is the port the server
+	// actually binds, so let it win over the port field, which only carried the
+	// pre-form default derived from the default command.
+	if p := portFromCommand(command); p > 0 {
+		port = p
+	}
 
 	// Services multi-select (same flow as the custom container wizard).
 	serviceOptions := nonDatabaseServiceOptions()
@@ -950,6 +946,137 @@ func envExampleFallback(path string) string {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// projectRuntime describes how lerd runs a non-PHP project of a given language.
+// One entry drives all three consumers (detection, the host-proxy default dev
+// command, and the custom-container starter), so adding a language is a single
+// table entry rather than three switch/maps that must stay in sync.
+type projectRuntime struct {
+	label      string   // human name shown in the wizard
+	manifests  []string // files whose presence identifies the runtime
+	devCommand string   // default host-proxy dev command
+	// container is the Containerfile body for this runtime. lerd bind-mounts the
+	// project at runtime (same absolute path), so it needs no COPY or WORKDIR; it
+	// only provides the base image and global tools, app deps come from the mount.
+	container string
+}
+
+// knownRuntimes is the single source of truth for non-PHP runtime support.
+// First match wins on detection. Node's manifests mirror isNodeProject so the
+// two agree on what a Node project is.
+var knownRuntimes = []projectRuntime{
+	{
+		label:      "Node",
+		manifests:  []string{"package.json", ".nvmrc", ".node-version"},
+		devCommand: "npm run dev",
+		container:  "FROM node:20-alpine\nRUN npm install -g nodemon\nCMD [\"npm\", \"run\", \"dev\"]\n",
+	},
+	{
+		label:      "Go",
+		manifests:  []string{"go.mod"},
+		devCommand: "go run .",
+		container:  "FROM golang:1.23-alpine\n# Optional hot reload: RUN go install github.com/air-verse/air@latest (then CMD [\"air\"])\nCMD [\"go\", \"run\", \".\"]\n",
+	},
+	{
+		label:      "Python",
+		manifests:  []string{"pyproject.toml", "requirements.txt", "Pipfile", "manage.py"},
+		devCommand: "python app.py",
+		container:  "FROM python:3.12-slim\n# Install app deps at build time only if they aren't in the mounted project.\nCMD [\"python\", \"app.py\"]\n",
+	},
+	{
+		label:      "Ruby",
+		manifests:  []string{"Gemfile"},
+		devCommand: "ruby app.rb",
+		container:  "FROM ruby:3.3-alpine\nCMD [\"ruby\", \"app.rb\"]\n",
+	},
+	{
+		label:      "Rust",
+		manifests:  []string{"Cargo.toml"},
+		devCommand: "cargo run",
+		container:  "FROM rust:1-alpine\nCMD [\"cargo\", \"run\"]\n",
+	},
+}
+
+// detectProjectRuntime returns the runtime whose manifest is present in cwd, so
+// the wizard can give every language the same language-aware prompt instead of
+// treating anything without a package.json as an unknown blob.
+func detectProjectRuntime(cwd string) (*projectRuntime, bool) {
+	for i := range knownRuntimes {
+		for _, f := range knownRuntimes[i].manifests {
+			if fileExists(filepath.Join(cwd, f)) {
+				return &knownRuntimes[i], true
+			}
+		}
+	}
+	return nil, false
+}
+
+// defaultDevCommand guesses the host-proxy dev command from the detected
+// runtime, refining Python to Django's runserver when manage.py is present
+// (the table default of python app.py is wrong for Django/Flask). Returns "" for
+// an unknown runtime so the wizard offers a blank (proxy-only) default.
+func defaultDevCommand(cwd string) string {
+	rt, ok := detectProjectRuntime(cwd)
+	if !ok {
+		return ""
+	}
+	if rt.label == "Python" && fileExists(filepath.Join(cwd, "manage.py")) {
+		return "python manage.py runserver"
+	}
+	return rt.devCommand
+}
+
+// starterContainerfile returns a commented starter Containerfile.lerd tailored
+// to the project's detected runtime. It's a scaffold for the user to edit; an
+// unrecognised runtime gets a generic skeleton. See projectRuntime.container for
+// why there is no COPY/WORKDIR.
+func starterContainerfile(cwd string, port int) string {
+	header := fmt.Sprintf("# Containerfile.lerd — lerd builds this image and runs your app in it.\n"+
+		"# Your project is bind-mounted into the container at runtime (no COPY or WORKDIR\n"+
+		"# needed) so your edits are live. Install global dev tools here; app dependencies\n"+
+		"# come from the mounted project. Your app must listen on port %d.\n\n", port)
+	body := "FROM alpine:latest\n# RUN <install the global dev tools your app needs>\n# CMD [\"<command that starts your server>\"]\n"
+	if rt, ok := detectProjectRuntime(cwd); ok {
+		body = rt.container
+	}
+	return header + body
+}
+
+// maybeCreateContainerfile offers to scaffold a missing Containerfile and open
+// it in the user's editor. No-op when the file already exists or the shell is
+// non-interactive (scripts/CI shouldn't block on an editor). Best-effort: a
+// failure to write or open is warned, not fatal, since the link still proceeds.
+func maybeCreateContainerfile(cwd, containerfile string, port int) {
+	if !isInteractive() {
+		return
+	}
+	path := filepath.Join(cwd, containerfile)
+	if fileExists(path) {
+		return
+	}
+	create := true
+	if err := huh.NewForm(huh.NewGroup(
+		huh.NewConfirm().
+			Title(fmt.Sprintf("%s doesn't exist yet. Create it and open your editor?", containerfile)).
+			Description("Lerd writes a starter image for your runtime; edit it to fit your app.").
+			Value(&create),
+	)).WithTheme(huh.ThemeCatppuccin()).Run(); err != nil || !create {
+		return
+	}
+	if dir := filepath.Dir(path); dir != "" {
+		_ = os.MkdirAll(dir, 0755)
+	}
+	if err := os.WriteFile(path, []byte(starterContainerfile(cwd, port)), 0644); err != nil {
+		fmt.Printf("[WARN] could not create %s: %v\n", containerfile, err)
+		return
+	}
+	fmt.Printf("Created %s\n", containerfile)
+	if launched, err := launchEditor(path); err != nil {
+		fmt.Printf("[WARN] %v\n", err)
+	} else if !launched {
+		fmt.Printf("Set $EDITOR to edit it automatically; the starter file is at %s\n", containerfile)
+	}
 }
 
 // resolveSecuredDefault computes a wizard's initial "secured" value and whether

--- a/internal/cli/init_runtime_test.go
+++ b/internal/cli/init_runtime_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDetectProjectRuntime(t *testing.T) {
+	cases := []struct {
+		name      string
+		manifest  string
+		wantLabel string
+		wantFound bool
+	}{
+		{"node package.json", "package.json", "Node", true},
+		{"node nvmrc only", ".nvmrc", "Node", true},
+		{"go", "go.mod", "Go", true},
+		{"python pyproject", "pyproject.toml", "Python", true},
+		{"python requirements", "requirements.txt", "Python", true},
+		{"python manage.py", "manage.py", "Python", true},
+		{"ruby", "Gemfile", "Ruby", true},
+		{"rust", "Cargo.toml", "Rust", true},
+		{"empty dir", "", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if c.manifest != "" {
+				if err := os.WriteFile(filepath.Join(dir, c.manifest), []byte("x"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			rt, found := detectProjectRuntime(dir)
+			label := ""
+			if rt != nil {
+				label = rt.label
+			}
+			if label != c.wantLabel || found != c.wantFound {
+				t.Errorf("detectProjectRuntime(%s) = (%q, %v), want (%q, %v)",
+					c.manifest, label, found, c.wantLabel, c.wantFound)
+			}
+		})
+	}
+}
+
+func TestDefaultDevCommand(t *testing.T) {
+	cases := []struct {
+		manifest string
+		want     string
+	}{
+		{"go.mod", "go run ."},
+		{"requirements.txt", "python app.py"},
+		{"manage.py", "python manage.py runserver"}, // Django: not python app.py
+		{"Gemfile", "ruby app.rb"},
+		{"Cargo.toml", "cargo run"},
+		{"package.json", "npm run dev"},
+		{"", ""}, // unknown runtime -> blank (proxy-only)
+	}
+	for _, c := range cases {
+		dir := t.TempDir()
+		if c.manifest != "" {
+			if err := os.WriteFile(filepath.Join(dir, c.manifest), []byte("x"), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if got := defaultDevCommand(dir); got != c.want {
+			t.Errorf("defaultDevCommand(%q) = %q, want %q", c.manifest, got, c.want)
+		}
+	}
+}
+
+func TestStarterContainerfile(t *testing.T) {
+	t.Run("runtime-specific base image, bind-mount model", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		out := starterContainerfile(dir, 8080)
+		if !strings.Contains(out, "FROM golang:") {
+			t.Errorf("expected a Go base image, got:\n%s", out)
+		}
+		if !strings.Contains(out, "port 8080") {
+			t.Errorf("expected the chosen port noted in the header, got:\n%s", out)
+		}
+		// Project is bind-mounted, so no instruction line should COPY the source
+		// or set a WORKDIR (comment lines mentioning them are fine).
+		for _, line := range strings.Split(out, "\n") {
+			instr := strings.TrimSpace(line)
+			if strings.HasPrefix(instr, "COPY") || strings.HasPrefix(instr, "WORKDIR") {
+				t.Errorf("starter should not COPY/WORKDIR with a bind-mount, got line: %q", instr)
+			}
+		}
+	})
+
+	t.Run("unknown runtime falls back to a generic skeleton", func(t *testing.T) {
+		out := starterContainerfile(t.TempDir(), 3000)
+		if !strings.Contains(out, "FROM alpine:") {
+			t.Errorf("expected a generic alpine base, got:\n%s", out)
+		}
+		if !strings.Contains(out, "port 3000") {
+			t.Errorf("expected the chosen port noted in the header, got:\n%s", out)
+		}
+	})
+}

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -16,8 +16,9 @@ import (
 	"golang.org/x/term"
 )
 
-// linkSkipSetupPrompt suppresses the "Run lerd setup?" prompt when runLink
-// is called from within lerd setup / lerd init (prevents infinite recursion).
+// linkSkipSetupPrompt suppresses the post-link "Run lerd setup?" suggestion
+// when runLink is called from within lerd setup / lerd init (prevents infinite
+// recursion and a redundant nag while setup is already running).
 var linkSkipSetupPrompt bool
 
 // linkAssumeYes approves a host-proxy dev command without the interactive
@@ -41,11 +42,44 @@ func NewLinkCmd() *cobra.Command {
 		Long:  "Register the current directory as a lerd site. The optional argument is the domain name without the TLD (e.g. 'myapp' becomes myapp.test). Defaults to the directory name.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLink(args)
+			return runLinkOrInit(args)
 		},
 	}
 	cmd.Flags().BoolVar(&linkAssumeYes, "yes", false, "Approve a host-proxy dev command without the confirmation prompt")
 	return cmd
+}
+
+// runLinkOrInit routes a user-typed `lerd link` into the init wizard when the
+// project has no usable .lerd.yaml and we have an interactive terminal, so a
+// fresh link guides the user through configuration (the wizard then links and
+// offers setup) instead of leaving a bare, unconfigured registration. Every
+// other case — a configured .lerd.yaml, a non-interactive shell (park, CI,
+// scripts), or an explicit domain argument — falls through to a direct link.
+// Internal runLink callers bypass this routing entirely.
+func runLinkOrInit(args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	// IsEmpty (not file existence) so a present-but-empty .lerd.yaml still routes
+	// to the wizard, matching what runLink's old empty-project branch did.
+	proj, _ := config.LoadProjectConfig(cwd)
+	hasConfig := proj != nil && !proj.IsEmpty()
+	_, _, isWorktree := findOwningWorktree(cwd)
+	if linkShouldRunWizard(hasConfig, isInteractive(), len(args) > 0, isWorktree) {
+		return runInit(false)
+	}
+	return runLink(args)
+}
+
+// linkShouldRunWizard reports whether a user-invoked `lerd link` should run the
+// init wizard rather than a bare link. Only true for a fresh, interactive,
+// argument-free link on a real site directory: a missing .lerd.yaml means
+// nothing is committed yet, the terminal can host the wizard, no explicit
+// domain was requested, and the directory isn't a worktree (which inherits its
+// parent's registration). Any false input keeps the fast, scriptable link.
+func linkShouldRunWizard(hasConfig, interactive, hasDomainArg, isWorktree bool) bool {
+	return !hasConfig && interactive && !hasDomainArg && !isWorktree
 }
 
 func runLink(args []string) error {
@@ -337,20 +371,7 @@ func runLink(args []string) error {
 		}
 	}
 
-	if proj.IsEmpty() {
-		if isInteractive() {
-			fmt.Print("\nNo .lerd.yaml found. Run lerd init? [Y/n] ")
-			var answer string
-			fmt.Scanln(&answer) //nolint:errcheck
-			if answer == "" || answer[0] == 'Y' || answer[0] == 'y' {
-				if err := runInit(false); err != nil {
-					fmt.Printf("[WARN] init: %v\n", err)
-				}
-			}
-		} else {
-			fmt.Println("\nNo .lerd.yaml found. Run 'lerd init' to configure domains, services, and workers.")
-		}
-	} else if !linkSkipSetupPrompt {
+	if hint, suggest := linkNextStep(linkSkipSetupPrompt); suggest {
 		if isInteractive() {
 			fmt.Print("\nRun lerd setup? [Y/n] ")
 			var answer string
@@ -361,7 +382,7 @@ func runLink(args []string) error {
 				}
 			}
 		} else {
-			fmt.Println("\nRun 'lerd setup' to install dependencies, run migrations, and start workers.")
+			fmt.Println(hint)
 		}
 	}
 
@@ -564,6 +585,19 @@ func hasRunningWorkers(site *config.Site) bool {
 // isInteractive returns true if stdin is a terminal.
 func isInteractive() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// linkNextStep returns the guidance shown after a standalone lerd link, and
+// whether to show it at all. It always points at lerd setup: setup takes a
+// freshly linked project the rest of the way (deps, migrations, workers, HTTPS)
+// and runs the init wizard itself when there is no .lerd.yaml, so suggesting
+// init separately is redundant friction. Returns suggest=false when link runs
+// inside setup/init (skipPrompt), so the guidance never nags mid-setup.
+func linkNextStep(skipPrompt bool) (hint string, suggest bool) {
+	if skipPrompt {
+		return "", false
+	}
+	return "\nRun 'lerd setup' to install dependencies, run migrations, and start workers.", true
 }
 
 // resolveFramework returns the framework name for the project at dir.

--- a/internal/cli/link_nextstep_test.go
+++ b/internal/cli/link_nextstep_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLinkNextStep(t *testing.T) {
+	t.Run("standalone link suggests setup, never init", func(t *testing.T) {
+		hint, suggest := linkNextStep(false)
+		if !suggest {
+			t.Fatal("expected a next-step suggestion after a standalone link")
+		}
+		if !strings.Contains(hint, "lerd setup") {
+			t.Errorf("expected the hint to point at lerd setup, got %q", hint)
+		}
+		if strings.Contains(hint, "lerd init") {
+			t.Errorf("hint should not mention lerd init, got %q", hint)
+		}
+	})
+
+	t.Run("suppressed when link runs inside setup/init", func(t *testing.T) {
+		hint, suggest := linkNextStep(true)
+		if suggest {
+			t.Error("expected no suggestion when link runs inside setup/init")
+		}
+		if hint != "" {
+			t.Errorf("expected an empty hint when suppressed, got %q", hint)
+		}
+	})
+}
+
+func TestLinkShouldRunWizard(t *testing.T) {
+	// hasConfig, interactive, hasDomainArg, isWorktree
+	cases := []struct {
+		name                                          string
+		hasConfig, interactive, domainArg, isWorktree bool
+		want                                          bool
+	}{
+		{"fresh interactive bare link runs wizard", false, true, false, false, true},
+		{"existing config links directly", true, true, false, false, false},
+		{"non-interactive stays bare (park/CI/scripts)", false, false, false, false, false},
+		{"explicit domain arg links directly", false, true, true, false, false},
+		{"worktree inherits parent, no wizard", false, true, false, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := linkShouldRunWizard(c.hasConfig, c.interactive, c.domainArg, c.isWorktree); got != c.want {
+				t.Errorf("linkShouldRunWizard(%v,%v,%v,%v) = %v, want %v",
+					c.hasConfig, c.interactive, c.domainArg, c.isWorktree, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -71,6 +71,21 @@ mode with no .lerd.yaml, site registration falls back to auto-detection.`,
 	return cmd
 }
 
+// siteServedByPHPFPM reports whether a site has a PHP-FPM container an
+// in-container bun install can target. That covers plain PHP sites (shared FPM),
+// custom-FPM sites (a per-site FPM image built from a Containerfile), and
+// FrankenPHP; it excludes host-proxy and custom-(non-PHP)-container sites, whose
+// runtime lives elsewhere. A nil site is a bare-linked plain PHP site, which
+// qualifies. Driven off the resolved site (which setup folds a worktree back to
+// its parent for) rather than cwd's .lerd.yaml, so a worktree of a proxy site is
+// classified by its parent.
+func siteServedByPHPFPM(site *config.Site) bool {
+	if site == nil {
+		return true
+	}
+	return !site.IsHostProxy() && !site.IsCustomContainer()
+}
+
 func runSetup(allSteps, skipOpen bool) error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -198,15 +213,19 @@ func runSetup(allSteps, skipOpen bool) error {
 				return runJSScript(cwd, buildScript)
 			},
 		},
-		{
-			// Mirror the host's bun into the PHP-FPM container so `lerd shell`
-			// has a working (musl) bun, with no extra command. lerd never
-			// installs bun on the host; this only fires when the user already
-			// has bun installed there. Idempotent: skips when the container bun
-			// is already present, and installContainerBun only restarts the
-			// container if the volume isn't mounted yet. Non-fatal.
+	}...)
+
+	// Mirror the host's bun into the PHP-FPM container so `lerd shell` has a
+	// working (musl) bun, with no extra command. lerd never installs bun on the
+	// host; this only fires when the user already has it there. Only PHP-FPM
+	// sites have that container — host-proxy and custom-container sites run their
+	// runtime elsewhere — so the step is omitted entirely for them, not just left
+	// unchecked, since `lerd setup -a` runs every listed step. Idempotent and
+	// non-fatal: skips when the container bun is already present.
+	if siteServedByPHPFPM(site) && nodeDet.BunPath() != "" && bunPHPVersion != "" {
+		steps = append(steps, setupStep{
 			label:   "bun (container)",
-			enabled: nodeDet.BunPath() != "" && bunPHPVersion != "",
+			enabled: true,
 			run: func() error {
 				// Cheap exec check deferred to run time so setup planning never
 				// blocks on podman; installContainerBun is the no-op fast path.
@@ -218,8 +237,8 @@ func runSetup(allSteps, skipOpen bool) error {
 				}
 				return nil
 			},
-		},
-	}...)
+		})
+	}
 
 	// Offer in-container Pest browser testing when the project depends on the
 	// Playwright-based browser plugin and isn't set up yet. Left unchecked by

--- a/internal/cli/setup_bun_test.go
+++ b/internal/cli/setup_bun_test.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestSiteServedByPHPFPM(t *testing.T) {
+	cases := []struct {
+		name string
+		site *config.Site
+		want bool
+	}{
+		{"nil site (bare-linked PHP)", nil, true},
+		{"plain PHP site", &config.Site{}, true},
+		{"custom-FPM site has a per-site FPM container", &config.Site{Runtime: "fpm-custom"}, true},
+		{"frankenphp site", &config.Site{Runtime: "frankenphp"}, true},
+		{"host-proxy site runs on the host", &config.Site{HostPort: 3000}, false},
+		{"custom-container (non-PHP) site", &config.Site{ContainerPort: 8080}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := siteServedByPHPFPM(c.site); got != c.want {
+				t.Errorf("siteServedByPHPFPM() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
On a fresh project in an interactive terminal, lerd link now routes into the init wizard so a single command takes you from an empty directory through configuration, linking, and the offer to run setup. Non interactive shells, an explicit domain argument, and worktrees keep the fast bare link, so park, CI, and scripts behave as before. The post link guidance points at lerd setup rather than init, since setup runs the wizard itself, and it no longer prints in the middle of a setup run.

The wizard now recognises Node, Go, Python, Ruby, and Rust and gives every runtime the same choice between a host proxy dev server and a custom container, falling back to a plain PHP site only when nothing is recognised. A single runtime table drives detection, the default dev command, and the starter Containerfile, so adding a language is one entry.

Choosing the custom container path without a Containerfile.lerd now offers to scaffold a runtime specific starter and open it in your editor. The starter matches lerd's bind mount model, so it has no COPY or WORKDIR and your edits stay live.

The host proxy wizard collects the dev command, port, and HTTPS on one screen, and the bun container setup step is now restricted to sites that actually have a PHP-FPM container.

Fixes #561
