### PR TITLE
chore: clear open Dependabot alerts (vite, dompurify)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2617,9 +2617,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/internal/ui/web/package-lock.json
+++ b/internal/ui/web/package-lock.json
@@ -2093,9 +2093,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/internal/ui/web/package.json
+++ b/internal/ui/web/package.json
@@ -35,6 +35,7 @@
     "svelte-dnd-action": "^0.9.69"
   },
   "overrides": {
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "dompurify": "^3.4.9"
   }
 }


### PR DESCRIPTION
Clears the 18 open Dependabot alerts across the two lockfiles.

Bumps vite from 6.4.2 to 6.4.3 in the docs toolchain, which resolves the high-severity `server.fs.deny` bypass (GHSA-fx2h-pf6j-xcff) and the launch-editor NTLMv2 disclosure (GHSA-v6wh-96g9-6wx3). Both are Windows-only and build-time only, vite is not shipped in the static site.

Forces dompurify to 3.4.11 in the web UI through an overrides entry, since monaco-editor pins 3.2.7. That clears the stack of XSS and mutation-XSS bypass advisories in one move.

The docs site and the embedded demo both still build, and npm audit reports zero vulnerabilities in each project.

Refs #565