### PR TITLE
Add a styled feedback layer for CLI output

### DIFF
--- a/internal/certs/manager.go
+++ b/internal/certs/manager.go
@@ -1,11 +1,13 @@
 package certs
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -99,13 +101,16 @@ func issueCertAtomic(primaryDomain string, allDomains []string, certsDir string)
 	args := []string{"-cert-file", tmpCert, "-key-file", tmpKey}
 	args = append(args, sans...)
 
+	// Capture mkcert's chatty success banner instead of letting it spill into
+	// the CLI's clean step output; surface it only when the command fails.
 	cmd := exec.Command(MkcertPath(), args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	var mkOut bytes.Buffer
+	cmd.Stdout = &mkOut
+	cmd.Stderr = &mkOut
 	if err := cmd.Run(); err != nil {
 		os.Remove(tmpCert) //nolint:errcheck
 		os.Remove(tmpKey)  //nolint:errcheck
-		return fmt.Errorf("mkcert for %s: %w", primaryDomain, err)
+		return fmt.Errorf("mkcert for %s: %w\n%s", primaryDomain, err, strings.TrimSpace(mkOut.String()))
 	}
 
 	// Two-phase rename: back up the previous cert (if any), swap in the

--- a/internal/cli/about.go
+++ b/internal/cli/about.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/version"
 	"github.com/spf13/cobra"
 )
@@ -17,14 +18,16 @@ func NewAboutCmd() *cobra.Command {
 }
 
 func runAbout(_ *cobra.Command, _ []string) error {
-	fmt.Println("Lerd — Podman-powered local PHP development environment for Linux and macOS")
-	fmt.Println()
-	fmt.Printf("  Version  %s\n", version.Version)
-	fmt.Printf("  Commit   %s\n", version.Commit)
-	fmt.Printf("  Built    %s\n", version.Date)
-	fmt.Println()
-	fmt.Println("  https://github.com/geodro/lerd")
-	fmt.Println()
-	fmt.Println("  (c) George Dumitrescu")
+	feedback.Begin()
+	fmt.Println("  " + feedback.Title("lerd"))
+	fmt.Println("  " + feedback.Dim("Podman-powered local PHP development for Linux & macOS"))
+	feedback.NewSummary().
+		Row("Version", feedback.Val(version.Version)).
+		Row("Commit", version.Commit).
+		Row("Built", version.Date).
+		Row("Repo", feedback.Val("https://github.com/geodro/lerd")).
+		Print()
+	feedback.Begin()
+	fmt.Println("  " + feedback.Dim("© George Dumitrescu"))
 	return nil
 }

--- a/internal/cli/autostart.go
+++ b/internal/cli/autostart.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/spf13/cobra"
@@ -60,7 +61,8 @@ func newAutostartEnableCmd() *cobra.Command {
 			if err := ApplyAutostart(false); err != nil {
 				return fmt.Errorf("enabling autostart: %w", err)
 			}
-			fmt.Println("Autostart enabled — lerd will start automatically on login.")
+			feedback.Begin()
+			feedback.Done("autostart enabled — lerd will start automatically on login")
 			return nil
 		},
 	}
@@ -74,7 +76,8 @@ func newAutostartDisableCmd() *cobra.Command {
 			if err := ApplyAutostart(true); err != nil {
 				return fmt.Errorf("disabling autostart: %w", err)
 			}
-			fmt.Println("Autostart disabled — lerd will not start automatically on login.")
+			feedback.Begin()
+			feedback.Done("autostart disabled — lerd will not start automatically on login")
 			return nil
 		},
 	}

--- a/internal/cli/build_ui.go
+++ b/internal/cli/build_ui.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/geodro/lerd/internal/feedback"
 	"golang.org/x/term"
 )
 
@@ -39,7 +40,7 @@ func runSequential(jobs []BuildJob) error {
 	for _, job := range jobs {
 		fmt.Printf("==> %s\n", job.Label)
 		if err := job.Run(os.Stdout); err != nil {
-			fmt.Printf("  [WARN] %s: %v\n", job.Label, err)
+			feedback.Warn("%s: %v", job.Label, err)
 			if firstErr == nil {
 				firstErr = err
 			}

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -7,10 +7,24 @@ import (
 	"slices"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/serviceops"
 	"github.com/spf13/cobra"
 )
+
+// check-report markers, coloured once via the shared palette (plain when piped
+// / NO_COLOR). ckOK/ckWarn/ckFail are printf wrappers so go vet keeps verifying
+// the format strings at every call site.
+var (
+	ckOKGlyph   = feedback.Green("✓")
+	ckWarnGlyph = feedback.Amber("⚠")
+	ckFailGlyph = feedback.Red("✗")
+)
+
+func ckOK(format string, a ...any)   { fmt.Printf("  %s %s", ckOKGlyph, fmt.Sprintf(format, a...)) }
+func ckWarn(format string, a ...any) { fmt.Printf("  %s %s", ckWarnGlyph, fmt.Sprintf(format, a...)) }
+func ckFail(format string, a ...any) { fmt.Printf("  %s %s", ckFailGlyph, fmt.Sprintf(format, a...)) }
 
 // NewCheckCmd returns the check command.
 func NewCheckCmd() *cobra.Command {
@@ -34,7 +48,7 @@ func runCheck(_ *cobra.Command, _ []string) error {
 
 	cfg, err := config.LoadProjectConfig(cwd)
 	if err != nil {
-		fmt.Printf("  FAIL  .lerd.yaml has invalid YAML syntax\n")
+		ckFail(".lerd.yaml has invalid YAML syntax\n")
 		fmt.Printf("        %v\n", err)
 		return fmt.Errorf("validation failed")
 	}
@@ -45,51 +59,51 @@ func runCheck(_ *cobra.Command, _ []string) error {
 	// PHP version
 	if cfg.PHPVersion != "" {
 		if err := validatePHPVersion(cfg.PHPVersion); err != nil {
-			fmt.Printf("  FAIL  php_version: %s — %v\n", cfg.PHPVersion, err)
+			ckFail("php_version: %s — %v\n", cfg.PHPVersion, err)
 			errors++
 		} else if !phpPkg.IsInstalled(cfg.PHPVersion) {
-			fmt.Printf("  WARN  php_version: %s is not installed — run lerd php:install %s\n", cfg.PHPVersion, cfg.PHPVersion)
+			ckWarn("php_version: %s is not installed — run lerd php:install %s\n", cfg.PHPVersion, cfg.PHPVersion)
 			warnings++
 		} else {
-			fmt.Printf("  OK    php_version: %s\n", cfg.PHPVersion)
+			ckOK("php_version: %s\n", cfg.PHPVersion)
 		}
 	}
 
 	// Node version
 	if cfg.NodeVersion != "" {
-		fmt.Printf("  OK    node_version: %s\n", cfg.NodeVersion)
+		ckOK("node_version: %s\n", cfg.NodeVersion)
 	}
 
 	// Request timeout
 	if cfg.RequestTimeout != 0 {
 		if cfg.RequestTimeout < 0 {
-			fmt.Printf("  FAIL  request_timeout: %d — must be a positive number of seconds\n", cfg.RequestTimeout)
+			ckFail("request_timeout: %d — must be a positive number of seconds\n", cfg.RequestTimeout)
 			errors++
 		} else {
-			fmt.Printf("  OK    request_timeout: %ds\n", cfg.RequestTimeout)
+			ckOK("request_timeout: %ds\n", cfg.RequestTimeout)
 		}
 	}
 
 	// Framework
 	if cfg.Framework != "" {
 		if cfg.FrameworkDef != nil {
-			fmt.Printf("  OK    framework: %s (inline definition)\n", cfg.Framework)
+			ckOK("framework: %s (inline definition)\n", cfg.Framework)
 		} else if _, ok := config.GetFramework(cfg.Framework); ok {
-			fmt.Printf("  OK    framework: %s\n", cfg.Framework)
+			ckOK("framework: %s\n", cfg.Framework)
 		} else {
-			fmt.Printf("  WARN  framework: %q is not a known or user-defined framework\n", cfg.Framework)
+			ckWarn("framework: %q is not a known or user-defined framework\n", cfg.Framework)
 			warnings++
 		}
 	}
 
 	// Secured
 	if cfg.Secured {
-		fmt.Printf("  OK    secured: true\n")
+		ckOK("secured: true\n")
 	}
 
 	// Domains
 	if len(cfg.Domains) > 0 {
-		fmt.Printf("  OK    domains: %v\n", cfg.Domains)
+		ckOK("domains: %v\n", cfg.Domains)
 	}
 
 	// Workers
@@ -98,9 +112,9 @@ func runCheck(_ *cobra.Command, _ []string) error {
 			// Custom container site: workers must be defined in custom_workers.
 			for _, w := range cfg.Workers {
 				if _, ok := cfg.CustomWorkers[w]; ok {
-					fmt.Printf("  OK    worker: %s\n", w)
+					ckOK("worker: %s\n", w)
 				} else {
-					fmt.Printf("  FAIL  worker: %q is not defined in custom_workers\n", w)
+					ckFail("worker: %q is not defined in custom_workers\n", w)
 					errors++
 				}
 			}
@@ -120,34 +134,34 @@ func runCheck(_ *cobra.Command, _ []string) error {
 
 				if !hasFw || fw.Workers == nil {
 					if fwName != "" {
-						fmt.Printf("  WARN  worker: %q — framework %s has no worker definitions\n", w, fwName)
+						ckWarn("worker: %q — framework %s has no worker definitions\n", w, fwName)
 						warnings++
 					} else {
-						fmt.Printf("  WARN  worker: %q — no framework detected\n", w)
+						ckWarn("worker: %q — no framework detected\n", w)
 						warnings++
 					}
 					continue
 				}
 				wDef, ok := fw.Workers[w]
 				if !ok {
-					fmt.Printf("  FAIL  worker: %q is not defined for framework %s\n", w, fwName)
+					ckFail("worker: %q is not defined for framework %s\n", w, fwName)
 					errors++
 					continue
 				}
 				if wDef.Check != nil && !config.MatchesRule(cwd, *wDef.Check) {
-					fmt.Printf("  WARN  worker: %s — prerequisite not met (check rule failed)\n", w)
+					ckWarn("worker: %s — prerequisite not met (check rule failed)\n", w)
 					warnings++
 				} else {
-					fmt.Printf("  OK    worker: %s\n", w)
+					ckOK("worker: %s\n", w)
 				}
 			}
 
 			if hasQueue && hasHorizon {
-				fmt.Printf("  WARN  workers: both queue and horizon are listed — horizon manages queues, queue worker will be skipped\n")
+				ckWarn("workers: both queue and horizon are listed — horizon manages queues, queue worker will be skipped\n")
 				warnings++
 			}
 			if hasQueue && SiteHasHorizon(cwd) {
-				fmt.Printf("  WARN  workers: queue is listed but laravel/horizon is installed — horizon will be started instead\n")
+				ckWarn("workers: queue is listed but laravel/horizon is installed — horizon will be started instead\n")
 				warnings++
 			}
 		}
@@ -158,10 +172,10 @@ func runCheck(_ *cobra.Command, _ []string) error {
 		if svc.Custom != nil {
 			// Inline definition — check required fields.
 			if svc.Custom.Image == "" {
-				fmt.Printf("  FAIL  service %q: inline definition is missing required \"image\" field\n", svc.Name)
+				ckFail("service %q: inline definition is missing required \"image\" field\n", svc.Name)
 				errors++
 			} else {
-				fmt.Printf("  OK    service: %s (inline, image: %s)\n", svc.Name, svc.Custom.Image)
+				ckOK("service: %s (inline, image: %s)\n", svc.Name, svc.Custom.Image)
 			}
 			continue
 		}
@@ -170,26 +184,26 @@ func runCheck(_ *cobra.Command, _ []string) error {
 			// Preset reference — verify the preset exists in the catalog, then
 			// check whether it has been installed on this machine.
 			if _, err := config.LoadPreset(svc.Preset); err != nil {
-				fmt.Printf("  FAIL  service %q: unknown preset %q\n", svc.Name, svc.Preset)
+				ckFail("service %q: unknown preset %q\n", svc.Name, svc.Preset)
 				errors++
 			} else if _, err := config.LoadCustomService(svc.Name); err != nil {
-				fmt.Printf("  WARN  service %s: preset %q not installed — run: lerd service preset install %s\n", svc.Name, svc.Preset, svc.Preset)
+				ckWarn("service %s: preset %q not installed — run: lerd service preset install %s\n", svc.Name, svc.Preset, svc.Preset)
 				warnings++
 			} else {
-				fmt.Printf("  OK    service: %s (preset: %s)\n", svc.Name, svc.Preset)
+				ckOK("service: %s (preset: %s)\n", svc.Name, svc.Preset)
 			}
 			continue
 		}
 
 		if isKnownService(svc.Name) {
-			fmt.Printf("  OK    service: %s\n", svc.Name)
+			ckOK("service: %s\n", svc.Name)
 			continue
 		}
 
 		if serviceops.ServiceInstalled(svc.Name) {
-			fmt.Printf("  OK    service: %s (custom)\n", svc.Name)
+			ckOK("service: %s (custom)\n", svc.Name)
 		} else {
-			fmt.Printf("  FAIL  service %q: not installed — run `lerd service preset install %s` (if it's a bundled preset) or `lerd service add --name %s ...`\n",
+			ckFail("service %q: not installed — run `lerd service preset install %s` (if it's a bundled preset) or `lerd service add --name %s ...`\n",
 				svc.Name, svc.Name, svc.Name)
 			errors++
 		}
@@ -198,41 +212,41 @@ func runCheck(_ *cobra.Command, _ []string) error {
 	// Container
 	if cfg.Container != nil {
 		if cfg.Container.Port <= 0 || cfg.Container.Port > 65535 {
-			fmt.Printf("  FAIL  container.port: required and must be 1–65535\n")
+			ckFail("container.port: required and must be 1–65535\n")
 			errors++
 		} else {
-			fmt.Printf("  OK    container.port: %d\n", cfg.Container.Port)
+			ckOK("container.port: %d\n", cfg.Container.Port)
 		}
 		cfPath := cfg.Container.Containerfile
 		if cfPath == "" {
 			cfPath = "Containerfile.lerd"
 		}
 		if _, err := os.Stat(filepath.Join(cwd, cfPath)); os.IsNotExist(err) {
-			fmt.Printf("  WARN  container.containerfile: %s not found — lerd link will fail\n", cfPath)
+			ckWarn("container.containerfile: %s not found — lerd link will fail\n", cfPath)
 			warnings++
 		} else {
-			fmt.Printf("  OK    container.containerfile: %s\n", cfPath)
+			ckOK("container.containerfile: %s\n", cfPath)
 		}
 		if cfg.Container.BuildContext != "" {
 			if _, err := os.Stat(filepath.Join(cwd, cfg.Container.BuildContext)); os.IsNotExist(err) {
-				fmt.Printf("  WARN  container.build_context: %s not found\n", cfg.Container.BuildContext)
+				ckWarn("container.build_context: %s not found\n", cfg.Container.BuildContext)
 				warnings++
 			} else {
-				fmt.Printf("  OK    container.build_context: %s\n", cfg.Container.BuildContext)
+				ckOK("container.build_context: %s\n", cfg.Container.BuildContext)
 			}
 		}
 		if cfg.Container.SSL {
-			fmt.Printf("  OK    container.ssl: true (nginx will proxy_pass via HTTPS with ssl_verify off)\n")
+			ckOK("container.ssl: true (nginx will proxy_pass via HTTPS with ssl_verify off)\n")
 		}
 	}
 
 	// custom_workers
 	for name, w := range cfg.CustomWorkers {
 		if w.Command == "" {
-			fmt.Printf("  FAIL  custom_worker.%s: command is required\n", name)
+			ckFail("custom_worker.%s: command is required\n", name)
 			errors++
 		} else {
-			fmt.Printf("  OK    custom_worker.%s\n", name)
+			ckOK("custom_worker.%s\n", name)
 		}
 	}
 
@@ -240,49 +254,49 @@ func runCheck(_ *cobra.Command, _ []string) error {
 	seenCmdNames := map[string]bool{}
 	for i, c := range cfg.Commands {
 		if c.Name == "" {
-			fmt.Printf("  FAIL  commands[%d]: name is required\n", i)
+			ckFail("commands[%d]: name is required\n", i)
 			errors++
 			continue
 		}
 		if seenCmdNames[c.Name] {
-			fmt.Printf("  FAIL  command %q: duplicate name\n", c.Name)
+			ckFail("command %q: duplicate name\n", c.Name)
 			errors++
 			continue
 		}
 		seenCmdNames[c.Name] = true
 		if c.Disabled {
-			fmt.Printf("  OK    command.%s (disabled)\n", c.Name)
+			ckOK("command.%s (disabled)\n", c.Name)
 			continue
 		}
 		if c.Command == "" {
-			fmt.Printf("  FAIL  command %q: command is required (or set disabled: true)\n", c.Name)
+			ckFail("command %q: command is required (or set disabled: true)\n", c.Name)
 			errors++
 			continue
 		}
 		if c.Label == "" {
-			fmt.Printf("  WARN  command %q: label is empty, the UI will fall back to the name\n", c.Name)
+			ckWarn("command %q: label is empty, the UI will fall back to the name\n", c.Name)
 			warnings++
 		}
 		if c.Output != "" && !slices.Contains(config.ValidCommandOutputs, c.Output) {
-			fmt.Printf("  FAIL  command %q: output %q is invalid (expected: %v)\n", c.Name, c.Output, config.ValidCommandOutputs)
+			ckFail("command %q: output %q is invalid (expected: %v)\n", c.Name, c.Output, config.ValidCommandOutputs)
 			errors++
 			continue
 		}
 		if c.Icon != "" && !slices.Contains(config.KnownCommandIcons, c.Icon) {
-			fmt.Printf("  WARN  command %q: icon %q is not in the known set, UI will fall back to a generic icon\n", c.Name, c.Icon)
+			ckWarn("command %q: icon %q is not in the known set, UI will fall back to a generic icon\n", c.Name, c.Icon)
 			warnings++
 		}
-		fmt.Printf("  OK    command.%s\n", c.Name)
+		ckOK("command.%s\n", c.Name)
 	}
 
 	// db
 	if cfg.DB.Service != "" {
 		if isKnownService(cfg.DB.Service) {
-			fmt.Printf("  OK    db.service: %s\n", cfg.DB.Service)
+			ckOK("db.service: %s\n", cfg.DB.Service)
 		} else if serviceops.ServiceInstalled(cfg.DB.Service) {
-			fmt.Printf("  OK    db.service: %s (custom)\n", cfg.DB.Service)
+			ckOK("db.service: %s (custom)\n", cfg.DB.Service)
 		} else {
-			fmt.Printf("  FAIL  db.service: %q is not a known service\n", cfg.DB.Service)
+			ckFail("db.service: %q is not a known service\n", cfg.DB.Service)
 			errors++
 		}
 	}

--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
@@ -297,11 +298,12 @@ func runDbImport(file, service, database string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	fmt.Printf("Importing %s into %s (%s)...\n", file, env.database, env.connection)
+	feedback.Begin()
+	feedback.Line("importing " + file + " into " + feedback.Val(env.database) + " (" + env.connection + ")")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("import failed: %w", err)
 	}
-	fmt.Println("Import complete.")
+	feedback.Done("import complete")
 	return nil
 }
 
@@ -355,12 +357,13 @@ func runDbExport(output, service, database string) error {
 	cmd.Stdout = f
 	cmd.Stderr = os.Stderr
 
-	fmt.Printf("Exporting %s (%s) to %s...\n", env.database, env.connection, output)
+	feedback.Begin()
+	feedback.Line("exporting " + feedback.Val(env.database) + " (" + env.connection + ") to " + output)
 	if err := cmd.Run(); err != nil {
 		_ = os.Remove(output)
 		return fmt.Errorf("export failed: %w", err)
 	}
-	fmt.Printf("Export complete: %s\n", output)
+	feedback.Done("export complete · " + output)
 	return nil
 }
 
@@ -421,15 +424,16 @@ func runDbCreate(flagService string, args []string) error {
 		return fmt.Errorf("could not start %s: %w", env.service, err)
 	}
 
+	feedback.Begin()
 	for _, name := range []string{dbName, dbName + "_testing"} {
 		created, err := createDatabase(env.service, name)
 		if err != nil {
 			return fmt.Errorf("creating %q: %w", name, err)
 		}
 		if created {
-			fmt.Printf("Created database %q\n", name)
+			feedback.Done("created database " + feedback.Val(name))
 		} else {
-			fmt.Printf("Database %q already exists\n", name)
+			feedback.Line("database " + feedback.Val(name) + " already exists")
 		}
 	}
 	return nil
@@ -473,16 +477,13 @@ func runDbShell(flagService, flagDatabase string) error {
 			if !isInteractive() {
 				return fmt.Errorf("database %q does not exist in %s — run 'lerd db:create %s'", env.database, env.service, env.database)
 			}
-			fmt.Printf("Database %q does not exist in %s. Create it? [Y/n] ", env.database, env.service)
-			var answer string
-			fmt.Scanln(&answer) //nolint:errcheck
-			if answer != "" && answer[0] != 'Y' && answer[0] != 'y' {
+			if !feedback.Confirm(fmt.Sprintf("Database %q does not exist in %s. Create it?", env.database, env.service), true) {
 				return fmt.Errorf("database %q does not exist", env.database)
 			}
 			if _, err := createDatabase(env.service, env.database); err != nil {
 				return fmt.Errorf("creating database %q: %w", env.database, err)
 			}
-			fmt.Printf("Created database %q\n", env.database)
+			feedback.Done("created database " + feedback.Val(env.database))
 		}
 	}
 

--- a/internal/cli/db_isolate.go
+++ b/internal/cli/db_isolate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +39,8 @@ The --source flag controls how the new schema is seeded:
 			if err := SetWorktreeDBIsolated(site, branch, true, source); err != nil {
 				return err
 			}
-			fmt.Printf("Worktree %s of %s now uses an isolated database.\n", branch, site.Name)
+			feedback.Begin()
+			feedback.Done(fmt.Sprintf("worktree %s of %s now uses an isolated database", branch, site.Name))
 			return nil
 		},
 	}
@@ -63,7 +65,8 @@ func NewDBShareCmd() *cobra.Command {
 			if err := SetWorktreeDBIsolated(site, branch, false, ""); err != nil {
 				return err
 			}
-			fmt.Printf("Worktree %s of %s now shares the parent's database.\n", branch, site.Name)
+			feedback.Begin()
+			feedback.Done(fmt.Sprintf("worktree %s of %s now shares the parent's database", branch, site.Name))
 			return nil
 		},
 	}

--- a/internal/cli/db_move.go
+++ b/internal/cli/db_move.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/serviceops"
 	"github.com/spf13/cobra"
 )
@@ -181,32 +182,33 @@ func runDbMove(from, to string, siteNames []string, all, force bool) error {
 	}
 
 	if !force && interactive {
-		fmt.Printf("About to move %d site(s) from %s to %s:\n", len(targets), from, to)
+		feedback.Begin()
+		feedback.Line(fmt.Sprintf("about to move %d site(s) from %s to %s:", len(targets), from, to))
 		for _, s := range targets {
-			fmt.Printf("  %s (%s)\n", s.Name, s.Path)
+			feedback.Note(s.Name + " (" + s.Path + ")")
 		}
-		fmt.Print("Source data is left intact. Continue? [y/N] ")
-		var ans string
-		fmt.Scanln(&ans) //nolint:errcheck
-		if ans == "" || (ans[0] != 'y' && ans[0] != 'Y') {
+		if !feedback.Confirm("Source data is left intact. Continue?", false) {
 			return fmt.Errorf("aborted")
 		}
 	}
 
 	failed := 0
 	for _, s := range targets {
-		fmt.Printf("\n== %s: %s -> %s ==\n", s.Name, from, to)
+		feedback.Line(fmt.Sprintf("moving %s: %s → %s", s.Name, from, to))
 		if err := runDbMoveOne(s.Path, s.Name, from, to); err != nil {
+			// Per-site failure detail goes to stderr so scripts that parse the
+			// error stream still see which sites failed (the command also
+			// returns a non-nil aggregate error below).
+			fmt.Fprintf(os.Stderr, "  %s %s: %v\n", feedback.Red(feedback.GlyphFail), s.Name, err)
 			failed++
-			fmt.Fprintf(os.Stderr, "[FAIL] %s: %v\n", s.Name, err)
 			continue
 		}
-		fmt.Printf("[OK] %s moved to %s, .env updated\n", s.Name, to)
+		feedback.Note(s.Name + " moved · .env updated")
 	}
 	if failed > 0 {
 		return fmt.Errorf("%d of %d site(s) failed to move", failed, len(targets))
 	}
-	fmt.Printf("\nDone. %d site(s) moved %s -> %s. Source data left intact.\n", len(targets), from, to)
+	feedback.Done(fmt.Sprintf("moved %d site(s) %s → %s · source data left intact", len(targets), from, to))
 	return nil
 }
 
@@ -241,7 +243,7 @@ func runDbMoveOne(sitePath, siteName, from, to string) error {
 	}
 	dump.Stdout = tmp
 	dump.Stderr = os.Stderr
-	fmt.Printf("Dumping %s from %s...\n", base.database, from)
+	feedback.Note("dumping " + base.database + " from " + from)
 	if err := dump.Run(); err != nil {
 		tmp.Close() //nolint:errcheck
 		return fmt.Errorf("dump failed: %w", err)
@@ -254,7 +256,7 @@ func runDbMoveOne(sitePath, siteName, from, to string) error {
 	// the DB_ keys in .env (host-proxy aware), starts the target, and creates
 	// the database, so the dump has somewhere to land. Snapshot .lerd.yaml's
 	// source and the .env bytes first so a failed repoint can be fully undone.
-	fmt.Printf("Repointing %s at %s...\n", siteName, to)
+	feedback.Note("repointing " + siteName + " at " + to)
 	envPath := filepath.Join(sitePath, ".env")
 	prevEnv, _ := os.ReadFile(envPath)
 	if err := config.ReplaceProjectDBService(sitePath, to); err != nil {
@@ -307,7 +309,7 @@ func runDbMoveOne(sitePath, siteName, from, to string) error {
 	restore.Stdin = f
 	restore.Stdout = os.Stdout
 	restore.Stderr = os.Stderr
-	fmt.Printf("Restoring %s into %s...\n", tgtEnv.database, to)
+	feedback.Note("restoring " + tgtEnv.database + " into " + to)
 	if err := restore.Run(); err != nil {
 		return rollback(fmt.Errorf("restore failed: %w", err))
 	}

--- a/internal/cli/db_snapshot.go
+++ b/internal/cli/db_snapshot.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/serviceops"
 	"github.com/spf13/cobra"
@@ -126,7 +127,8 @@ func runDbSnapshot(name, service, database string, allDatabases bool) error {
 	if snap.AllDatabases {
 		scope = "all databases"
 	}
-	fmt.Printf("Snapshot %q created for %s (%s).\n", snap.Name, scope, humanSize(snap.SizeBytes))
+	feedback.Begin()
+	feedback.Done(fmt.Sprintf("snapshot %s created for %s (%s)", snap.Name, scope, humanSize(snap.SizeBytes)))
 	return nil
 }
 
@@ -148,10 +150,11 @@ func runDbSnapshots(service, database string, all bool) error {
 		return err
 	}
 	if len(snaps) == 0 {
+		feedback.Begin()
 		if listDatabase == "" {
-			fmt.Printf("No snapshots for service %q.\n", env.service)
+			feedback.Line("no snapshots for service " + env.service)
 		} else {
-			fmt.Printf("No snapshots for %q.\n", listDatabase)
+			feedback.Line("no snapshots for " + listDatabase)
 		}
 		return nil
 	}
@@ -184,10 +187,7 @@ func runDbRestore(name, service, database string, allDatabases, force bool) erro
 		if !isInteractive() {
 			return fmt.Errorf("restoring %q overwrites %s — rerun with --force to confirm", name, scope)
 		}
-		fmt.Printf("Restore snapshot %q into %s? This overwrites the current data. [y/N] ", name, scope)
-		var answer string
-		fmt.Scanln(&answer) //nolint:errcheck
-		if !strings.EqualFold(strings.TrimSpace(answer), "y") && !strings.EqualFold(strings.TrimSpace(answer), "yes") {
+		if !feedback.Confirm(fmt.Sprintf("Restore snapshot %q into %s? This overwrites the current data.", name, scope), false) {
 			return fmt.Errorf("restore cancelled")
 		}
 	}
@@ -198,7 +198,8 @@ func runDbRestore(name, service, database string, allDatabases, force bool) erro
 	if err := serviceops.RestoreSnapshot(target, name, snapshotEmit()); err != nil {
 		return err
 	}
-	fmt.Printf("Snapshot %q restored.\n", name)
+	feedback.Begin()
+	feedback.Done("snapshot " + name + " restored")
 	return nil
 }
 
@@ -214,7 +215,8 @@ func runDbSnapshotRm(name, service, database string, allDatabases bool) error {
 	if err := serviceops.DeleteSnapshot(env.service, env.database, name, allDatabases); err != nil {
 		return err
 	}
-	fmt.Printf("Snapshot %q deleted.\n", name)
+	feedback.Begin()
+	feedback.Done("snapshot " + name + " deleted")
 	return nil
 }
 

--- a/internal/cli/db_snapshot_test.go
+++ b/internal/cli/db_snapshot_test.go
@@ -93,7 +93,7 @@ func TestRunDbSnapshotsEmpty(t *testing.T) {
 			t.Fatalf("runDbSnapshots: %v", err)
 		}
 	})
-	if !strings.Contains(out, "No snapshots") {
+	if !strings.Contains(out, "no snapshots") {
 		t.Errorf("expected empty-state message, got:\n%s", out)
 	}
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
+	"github.com/geodro/lerd/internal/feedback"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
@@ -30,7 +31,7 @@ func NewDoctorCmd() *cobra.Command {
 }
 
 func runDoctor(_ *cobra.Command, _ []string) error {
-	_, _, err := RunDoctorTo(os.Stdout, true)
+	_, _, err := RunDoctorTo(os.Stdout, feedback.Animated())
 	return err
 }
 
@@ -45,15 +46,15 @@ func RunDoctorTo(w io.Writer, useColor bool) (fails, warns int, err error) {
 	}
 
 	ok := func(label string) {
-		fmt.Fprintf(w, "  %s%-34s%s OK\n", cG, label, cReset)
+		fmt.Fprintf(w, "  %s✓%s %s\n", cG, cReset, label)
 	}
 	fail := func(label, msg, hint string) {
 		fails++
-		fmt.Fprintf(w, "  %s%-34s%s FAIL  %s\n    hint: %s\n", cR, label, cReset, msg, hint)
+		fmt.Fprintf(w, "  %s✗%s %s  %s\n    hint: %s\n", cR, cReset, label, msg, hint)
 	}
 	warn := func(label, msg string) {
 		warns++
-		fmt.Fprintf(w, "  %s%-34s%s WARN  %s\n", cY, label, cReset, msg)
+		fmt.Fprintf(w, "  %s⚠%s %s  %s\n", cY, cReset, label, msg)
 	}
 	info := func(label, val string) {
 		fmt.Fprintf(w, "  %-34s %s\n", label, val)

--- a/internal/cli/domain.go
+++ b/internal/cli/domain.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/grouping"
 	"github.com/geodro/lerd/internal/nginx"
 	"github.com/geodro/lerd/internal/podman"
@@ -107,27 +108,28 @@ func runDomainAdd(_ *cobra.Command, args []string) error {
 	// here would clobber those worktree SANs.
 	if site.Secured {
 		if err := certs.ReissueCertForWorktree(*site); err != nil {
-			fmt.Printf("[WARN] reissuing certificate: %v\n", err)
+			feedback.Warn("reissuing certificate: %v", err)
 		}
 	}
 
 	if err := podman.WriteContainerHosts(); err != nil {
-		fmt.Printf("[WARN] updating container hosts file: %v\n", err)
+		feedback.Warn("updating container hosts file: %v", err)
 	}
 
 	nginx.ReloadOrWarn("")
 
 	if err := siteops.SyncEnvIfPrimaryChanged(site, oldPrimary); err != nil {
-		fmt.Printf("[WARN] syncing .env to new primary domain: %v\n", err)
+		feedback.Warn("syncing .env to new primary domain: %v", err)
 	}
 
 	if site.IsGroupMain() {
 		if err := grouping.CascadeMainDomainChange(site); err != nil {
-			fmt.Printf("[WARN] cascading group domain change: %v\n", err)
+			feedback.Warn("cascading group domain change: %v", err)
 		}
 	}
 
-	fmt.Printf("Added domain %s to site %s\n", fullDomain, site.Name)
+	feedback.Begin()
+	feedback.Done("added " + feedback.Val(fullDomain) + " to " + site.Name)
 	return nil
 }
 
@@ -181,27 +183,28 @@ func runDomainRemove(_ *cobra.Command, args []string) error {
 	// worktree subdomains.
 	if site.Secured {
 		if err := certs.ReissueCertForWorktree(*site); err != nil {
-			fmt.Printf("[WARN] reissuing certificate: %v\n", err)
+			feedback.Warn("reissuing certificate: %v", err)
 		}
 	}
 
 	if err := podman.WriteContainerHosts(); err != nil {
-		fmt.Printf("[WARN] updating container hosts file: %v\n", err)
+		feedback.Warn("updating container hosts file: %v", err)
 	}
 
 	nginx.ReloadOrWarn("")
 
 	if err := siteops.SyncEnvIfPrimaryChanged(site, oldPrimary); err != nil {
-		fmt.Printf("[WARN] syncing .env to new primary domain: %v\n", err)
+		feedback.Warn("syncing .env to new primary domain: %v", err)
 	}
 
 	if site.IsGroupMain() {
 		if err := grouping.CascadeMainDomainChange(site); err != nil {
-			fmt.Printf("[WARN] cascading group domain change: %v\n", err)
+			feedback.Warn("cascading group domain change: %v", err)
 		}
 	}
 
-	fmt.Printf("Removed domain %s from site %s\n", fullDomain, site.Name)
+	feedback.Begin()
+	feedback.Done("removed " + feedback.Val(fullDomain) + " from " + site.Name)
 	return nil
 }
 

--- a/internal/cli/domain_conflict.go
+++ b/internal/cli/domain_conflict.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 )
 
 // filterConflictingDomains splits desired into the domains that ownPath is
@@ -92,9 +93,9 @@ func warnFilteredDomains(removed []string) {
 	}
 	for _, d := range removed {
 		if existing, err := config.IsDomainUsed(d); err == nil && existing != nil {
-			fmt.Printf("  [WARN] domain %q already used by site %q — skipped\n", d, existing.Name)
+			feedback.Warn("domain %q already used by site %q — skipped", d, existing.Name)
 			continue
 		}
-		fmt.Printf("  [WARN] domain %q is reserved — skipped\n", d)
+		feedback.Warn("domain %q is reserved — skipped", d)
 	}
 }

--- a/internal/cli/dump.go
+++ b/internal/cli/dump.go
@@ -16,6 +16,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dumps"
 	"github.com/geodro/lerd/internal/dumpsops"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 )
 
@@ -108,14 +109,16 @@ func runDumpToggle(enable bool) error {
 	if res.Enabled {
 		state = "enabled"
 	}
+	feedback.Begin()
 	if res.NoChange {
-		fmt.Printf("Debug bridge already %s.\n", state)
+		feedback.Line("debug bridge already " + state)
 		return nil
 	}
 	if res.Enabled {
-		fmt.Println("Debug bridge enabled. Next dump() / dd() call will land in the dashboard.")
+		feedback.Done("debug bridge enabled")
+		feedback.Note("next dump() / dd() call lands in the dashboard")
 	} else {
-		fmt.Println("Debug bridge disabled.")
+		feedback.Done("debug bridge disabled")
 	}
 	nudgeUIDumpsChanged()
 	return nil
@@ -134,13 +137,11 @@ func runDumpStatus(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	state := "disabled"
-	colour := "\033[33m"
+	state := feedback.Amber("disabled")
 	if cfg.IsDumpsEnabled() {
-		state = "enabled"
-		colour = "\033[32m"
+		state = feedback.Green("enabled")
 	}
-	fmt.Printf("Debug bridge: %s%s\033[0m\n", colour, state)
+	fmt.Printf("Debug bridge: %s\n", state)
 	fmt.Printf("Listener:    unix:%s\n", config.DumpsSocketPath())
 	fmt.Printf("Bridge file: %s\n", config.DumpsBridgeFile())
 	fmt.Printf("Bridge ini:  %s\n", config.DumpsIniFile())

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -19,6 +19,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/grouping"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
@@ -157,7 +158,8 @@ func projectDBName(path string) string {
 
 // NewEnvCmd returns the env command.
 func NewEnvCmd() *cobra.Command {
-	return &cobra.Command{
+	var verbose bool
+	cmd := &cobra.Command{
 		Use:   "env",
 		Short: "Configure .env for this project with lerd service connection settings",
 		Long: `Sets up .env for the current project:
@@ -166,7 +168,57 @@ func NewEnvCmd() *cobra.Command {
   - Starts any referenced services that are not already running
   - Generates APP_KEY if missing
   - Sets APP_URL to the registered .test domain`,
-		RunE: runEnv,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// --verbose (and any non-animated output, e.g. the MCP server or a
+			// pipe) prints the full per-step detail. An interactive terminal gets
+			// the single live "configuring .env" line instead.
+			if verbose || !feedback.Animated() {
+				return runEnv(cmd, args)
+			}
+			feedback.Begin()
+			return runEnvLive(cmd, args)
+		},
+	}
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "Print detailed per-service output (used by the MCP server)")
+	return cmd
+}
+
+// envLive, when set, redirects runEnv's per-service reporting to a single live
+// progress line instead of the detailed multi-line output.
+var envLive *feedback.Live
+
+// runEnvLive runs runEnv under a live "configuring .env" line that accumulates
+// each service as it is applied.
+func runEnvLive(cmd *cobra.Command, args []string) error {
+	envLive = feedback.StartLive("configuring .env")
+	err := runEnv(cmd, args)
+	if err != nil {
+		envLive.Fail(err)
+	} else {
+		envLive.Done()
+	}
+	envLive = nil
+	return err
+}
+
+// envInfo prints a detailed runEnv line, suppressed while the live line is active.
+func envInfo(format string, a ...any) {
+	if envLive == nil {
+		fmt.Printf(format, a...)
+	}
+}
+
+// envApplyLine reports a service as its connection values are applied: it feeds
+// the live line when active, otherwise prints the detailed "applying" line.
+func envApplyLine(svc string, detectedFromEnv bool) {
+	if envLive != nil {
+		envLive.Add(svc)
+		return
+	}
+	if detectedFromEnv {
+		fmt.Printf("  Detected %-12s — applying lerd connection values\n", svc)
+	} else {
+		fmt.Printf("  From .lerd.yaml %-4s — applying lerd connection values\n", svc)
 	}
 }
 
@@ -277,7 +329,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	// 1. Create env file from example if it doesn't exist
 	if _, err := os.Stat(envPath); os.IsNotExist(err) {
 		if _, err := os.Stat(examplePath); err == nil {
-			fmt.Printf("Creating %s from %s...\n", envRelPath, exampleRelPath)
+			envInfo("Creating %s from %s...\n", envRelPath, exampleRelPath)
 			if err := copyEnvFile(examplePath, envPath); err != nil {
 				return fmt.Errorf("copying %s: %w", exampleRelPath, err)
 			}
@@ -287,7 +339,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			if dir := filepath.Dir(envPath); dir != "." {
 				_ = os.MkdirAll(dir, 0755)
 			}
-			fmt.Printf("Creating empty %s (no example file found)...\n", envRelPath)
+			envInfo("Creating empty %s (no example file found)...\n", envRelPath)
 			if err := os.WriteFile(envPath, []byte(""), 0644); err != nil {
 				return fmt.Errorf("creating %s: %w", envRelPath, err)
 			}
@@ -295,7 +347,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("no %s or %s found in %s", envRelPath, exampleRelPath, cwd)
 		}
 	} else {
-		fmt.Printf("Updating existing %s...\n", envRelPath)
+		envInfo("Updating existing %s...\n", envRelPath)
 		// Back up the original .env the first time lerd modifies it (so the user
 		// can inspect what changed and restore with `lerd env:restore`), but only
 		// if lerd hasn't already written to it — detected by presence of the word
@@ -304,9 +356,9 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		if !envFileHasLerd(envPath) {
 			if _, err := os.Stat(backupPath); os.IsNotExist(err) {
 				if err := copyEnvFile(envPath, backupPath); err != nil {
-					fmt.Printf("  [WARN] could not back up %s: %v\n", envRelPath, err)
+					feedback.Warn("could not back up %s: %v", envRelPath, err)
 				} else {
-					fmt.Printf("  Backed up original %s → .env.before_lerd\n", envRelPath)
+					envInfo("  Backed up original %s → .env.before_lerd\n", envRelPath)
 					addToGitignore(cwd, ".env.before_lerd")
 				}
 			}
@@ -350,7 +402,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		}
 		val := applySiteHandle(v, tplCtx)
 		updates[k] = val
-		fmt.Printf("  Setting %s=%s\n", k, val)
+		envInfo("  Setting %s=%s\n", k, val)
 	}
 
 	// Load .lerd.yaml service hints so we can apply env vars for services
@@ -395,7 +447,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 				return fmt.Errorf("database prompt: %w", err)
 			}
 		} else {
-			fmt.Println("  Defaulting to SQLite (non-interactive). Run `lerd db set <service>` or call db_set to switch.")
+			envInfo("  Defaulting to SQLite (non-interactive). Run `lerd db set <service>` or call db_set to switch.\n")
 		}
 
 		// Persist the choice to .lerd.yaml so future runs don't re-ask, and
@@ -406,7 +458,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		}
 		proj.Services = append(proj.Services, config.ProjectService{Name: dbChoice})
 		if err := config.SaveProjectConfig(cwd, proj); err != nil {
-			fmt.Printf("  [WARN] could not save .lerd.yaml: %v\n", err)
+			feedback.Warn("could not save .lerd.yaml: %v", err)
 		}
 		lerdYAMLServices[dbChoice] = true
 	}
@@ -429,11 +481,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 				continue
 			}
 
-			if detectedFromEnv {
-				fmt.Printf("  Detected %-12s — applying lerd connection values\n", svc)
-			} else {
-				fmt.Printf("  From .lerd.yaml %-4s — applying lerd connection values\n", svc)
-			}
+			envApplyLine(svc, detectedFromEnv)
 			isDB := svc == "mysql" || svc == "postgres"
 			for _, kv := range def.Vars {
 				k, v, _ := strings.Cut(kv, "=")
@@ -444,16 +492,16 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			}
 			if isDB {
 				if err := ensureServiceRunning(svc); err != nil {
-					fmt.Printf("  [WARN] could not start %s: %v\n", svc, err)
+					feedback.Warn("could not start %s: %v", svc, err)
 				} else {
 					for _, name := range []string{dbName, dbName + "_testing"} {
 						created, err := createDatabase(svc, name)
 						if err != nil {
-							fmt.Printf("  [WARN] could not create database %q: %v\n", name, err)
+							feedback.Warn("could not create database %q: %v", name, err)
 						} else if created {
-							fmt.Printf("  Created database %q\n", name)
+							envInfo("  Created database %q\n", name)
 						} else {
-							fmt.Printf("  Database %q already exists\n", name)
+							envInfo("  Database %q already exists\n", name)
 						}
 					}
 				}
@@ -470,20 +518,20 @@ func runEnv(_ *cobra.Command, _ []string) error {
 				updates["AWS_BUCKET"] = bucketName
 				updates["AWS_URL"] = "http://localhost:9000/" + bucketName
 				if err := ensureServiceRunning(svc); err != nil {
-					fmt.Printf("  [WARN] could not start %s: %v\n", svc, err)
+					feedback.Warn("could not start %s: %v", svc, err)
 				}
 				created, err := createS3Bucket(bucketName)
 				if err != nil {
-					fmt.Printf("  [WARN] could not create bucket %q: %v\n", bucketName, err)
+					feedback.Warn("could not create bucket %q: %v", bucketName, err)
 				} else if created {
-					fmt.Printf("  Created bucket %q\n", bucketName)
+					envInfo("  Created bucket %q\n", bucketName)
 				} else {
-					fmt.Printf("  Bucket %q already exists\n", bucketName)
+					envInfo("  Bucket %q already exists\n", bucketName)
 				}
 				continue
 			}
 			if err := ensureServiceRunning(svc); err != nil {
-				fmt.Printf("  [WARN] could not start %s: %v\n", svc, err)
+				feedback.Warn("could not start %s: %v", svc, err)
 			}
 		}
 	} else {
@@ -508,11 +556,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 				continue
 			}
 
-			if detectedFromEnv {
-				fmt.Printf("  Detected %-12s — applying lerd connection values\n", svc)
-			} else {
-				fmt.Printf("  From .lerd.yaml %-4s — applying lerd connection values\n", svc)
-			}
+			envApplyLine(svc, detectedFromEnv)
 			for _, kv := range envs {
 				k, v, _ := strings.Cut(kv, "=")
 				updates[k] = v
@@ -528,16 +572,16 @@ func runEnv(_ *cobra.Command, _ []string) error {
 
 			if isDB {
 				if err := ensureServiceRunning(svc); err != nil {
-					fmt.Printf("  [WARN] could not start %s: %v\n", svc, err)
+					feedback.Warn("could not start %s: %v", svc, err)
 				} else {
 					for _, name := range []string{dbName, dbName + "_testing"} {
 						created, err := createDatabase(svc, name)
 						if err != nil {
-							fmt.Printf("  [WARN] could not create database %q: %v\n", name, err)
+							feedback.Warn("could not create database %q: %v", name, err)
 						} else if created {
-							fmt.Printf("  Created database %q\n", name)
+							envInfo("  Created database %q\n", name)
 						} else {
-							fmt.Printf("  Database %q already exists\n", name)
+							envInfo("  Database %q already exists\n", name)
 						}
 					}
 				}
@@ -555,24 +599,24 @@ func runEnv(_ *cobra.Command, _ []string) error {
 				updates["AWS_BUCKET"] = bucketName
 				updates["AWS_URL"] = "http://localhost:9000/" + bucketName
 				if err := ensureServiceRunning(svc); err != nil {
-					fmt.Printf("  [WARN] could not start %s: %v\n", svc, err)
+					feedback.Warn("could not start %s: %v", svc, err)
 				}
 				// Always attempt bucket creation — ensureServiceRunning may have
 				// timed out on the host probe while the container network is already
 				// up, or rustfs was already running before lerd env ran.
 				created, err := createS3Bucket(bucketName)
 				if err != nil {
-					fmt.Printf("  [WARN] could not create bucket %q: %v\n", bucketName, err)
+					feedback.Warn("could not create bucket %q: %v", bucketName, err)
 				} else if created {
-					fmt.Printf("  Created bucket %q\n", bucketName)
+					envInfo("  Created bucket %q\n", bucketName)
 				} else {
-					fmt.Printf("  Bucket %q already exists\n", bucketName)
+					envInfo("  Bucket %q already exists\n", bucketName)
 				}
 				continue
 			}
 
 			if err := ensureServiceRunning(svc); err != nil {
-				fmt.Printf("  [WARN] could not start %s: %v\n", svc, err)
+				feedback.Warn("could not start %s: %v", svc, err)
 			}
 		}
 	}
@@ -582,7 +626,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	// standard Laravel sqlite env vars and ensure the database file exists so
 	// migrations can run immediately. No service to start, no SQL DB to create.
 	if lerdYAMLServices["sqlite"] {
-		fmt.Printf("  From .lerd.yaml %-4s — applying lerd connection values\n", "sqlite")
+		envApplyLine("sqlite", false)
 		for _, kv := range serviceEnvVars("sqlite") {
 			k, v, _ := strings.Cut(kv, "=")
 			updates[k] = v
@@ -592,7 +636,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			if err := os.MkdirAll(filepath.Dir(sqlitePath), 0o755); err == nil {
 				if f, err := os.Create(sqlitePath); err == nil {
 					_ = f.Close()
-					fmt.Printf("  Created %s\n", filepath.Join("database", "database.sqlite"))
+					envInfo("  Created %s\n", filepath.Join("database", "database.sqlite"))
 				}
 			}
 		}
@@ -629,16 +673,12 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			// project can reach it once running, unless it's externally managed.
 			if !extServices[svc.Name] {
 				if err := ensureServiceRunning(svc.Name); err != nil {
-					fmt.Printf("  [WARN] could not start %s: %v\n", svc.Name, err)
+					feedback.Warn("could not start %s: %v", svc.Name, err)
 				}
 			}
 			continue
 		}
-		if pickedFromYAML {
-			fmt.Printf("  From .lerd.yaml %-4s — applying lerd connection values\n", svc.Name)
-		} else {
-			fmt.Printf("  Detected %-12s — applying lerd connection values\n", svc.Name)
-		}
+		envApplyLine(svc.Name, !pickedFromYAML)
 		for _, kv := range svc.EnvVars {
 			k, v, _ := strings.Cut(kv, "=")
 			updates[k] = applySiteHandle(v, tplCtx)
@@ -652,18 +692,18 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			continue
 		}
 		if err := ensureServiceRunning(svc.Name); err != nil {
-			fmt.Printf("  [WARN] could not start %s: %v\n", svc.Name, err)
+			feedback.Warn("could not start %s: %v", svc.Name, err)
 			continue
 		}
 		if isDB {
 			for _, name := range []string{dbName, dbName + "_testing"} {
 				created, err := createDatabase(svc.Name, name)
 				if err != nil {
-					fmt.Printf("  [WARN] could not create database %q: %v\n", name, err)
+					feedback.Warn("could not create database %q: %v", name, err)
 				} else if created {
-					fmt.Printf("  Created database %q\n", name)
+					envInfo("  Created database %q\n", name)
 				} else {
-					fmt.Printf("  Database %q already exists\n", name)
+					envInfo("  Database %q already exists\n", name)
 				}
 			}
 		}
@@ -683,7 +723,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	if config.ComposerHasPackage(cwd, "pestphp/pest-plugin-browser") {
 		if v, derr := phpDet.DetectVersion(cwd); derr == nil && pestBrowserSupportedVersion(v) == nil {
 			if gcfg, cerr := config.LoadGlobal(); cerr == nil && !slices.Contains(gcfg.GetPackages(v), pestBrowserPkg) {
-				fmt.Println("  Detected pest-plugin-browser — run `lerd pest:browser install` to enable in-container browser testing")
+				envInfo("  Detected pest-plugin-browser — run `lerd pest:browser install` to enable in-container browser testing\n")
 			}
 		}
 	}
@@ -692,7 +732,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	// BROADCAST_CONNECTION=reverb is set.
 	if fw.HasWorker("reverb", cwd) &&
 		strings.ToLower(strings.Trim(overrideOr(envOverrides, envMap, "BROADCAST_CONNECTION"), `"'`)) == "reverb" {
-		fmt.Println("  Detected reverb     — configuring REVERB_ connection values")
+		envApplyLine("reverb", true)
 		for k, v := range reverbEnvUpdates(envMap, site.PrimaryDomain(), site.Secured, cwd) {
 			updates[k] = v
 		}
@@ -708,7 +748,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	}
 	if url := resolveAppURL(cwd, site); url != "" {
 		updates[urlKey] = url
-		fmt.Printf("  Setting %s=%s\n", urlKey, url)
+		envInfo("  Setting %s=%s\n", urlKey, url)
 	}
 
 	// 4d. Host-proxy apps run on the host, so point service connections at
@@ -724,7 +764,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	// 4e. Apply personal .env.lerd_override values last so they win over lerd's
 	// defaults and every computed value (DB_DATABASE, APP_URL, reverb, …).
 	if len(envOverrides) > 0 {
-		fmt.Printf("  Applying %d override(s) from %s\n", len(envOverrides), envOverrideFile)
+		envInfo("  Applying %d override(s) from %s\n", len(envOverrides), envOverrideFile)
 		for k, v := range envOverrides {
 			updates[k] = v
 		}
@@ -748,30 +788,30 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	if kg := fw.Env.KeyGeneration; kg != nil && strings.TrimSpace(overrideOr(envOverrides, envMap, kg.EnvKey)) == "" {
 		if kg.Command != "" {
 			if _, statErr := os.Stat(filepath.Join(cwd, "vendor")); statErr == nil {
-				fmt.Printf("  Generating %s...\n", kg.EnvKey)
+				envInfo("  Generating %s...\n", kg.EnvKey)
 				// Use the framework's console binary (e.g. "spark" for
 				// CodeIgniter), not a hardcoded "artisan", so key generation
 				// works for non-Laravel frameworks.
 				if err := consoleIn(cwd, fw.Console, kg.Command); err != nil {
-					fmt.Printf("  [WARN] %s failed: %v\n", kg.Command, err)
+					feedback.Warn("%s failed: %v", kg.Command, err)
 				}
 			} else if kg.FallbackPrefix != "" {
-				fmt.Printf("  Generating %s (vendor not installed yet)...\n", kg.EnvKey)
+				envInfo("  Generating %s (vendor not installed yet)...\n", kg.EnvKey)
 				key := generateRandomKey(kg.FallbackPrefix)
 				if err := envfile.ApplyUpdates(envPath, map[string]string{kg.EnvKey: key}); err != nil {
-					fmt.Printf("  [WARN] writing %s: %v\n", kg.EnvKey, err)
+					feedback.Warn("writing %s: %v", kg.EnvKey, err)
 				}
 			}
 		} else if kg.FallbackPrefix != "" {
-			fmt.Printf("  Generating %s...\n", kg.EnvKey)
+			envInfo("  Generating %s...\n", kg.EnvKey)
 			key := generateRandomKey(kg.FallbackPrefix)
 			if err := envfile.ApplyUpdates(envPath, map[string]string{kg.EnvKey: key}); err != nil {
-				fmt.Printf("  [WARN] writing %s: %v\n", kg.EnvKey, err)
+				feedback.Warn("writing %s: %v", kg.EnvKey, err)
 			}
 		}
 	}
 
-	fmt.Println("Done.")
+	envInfo("Done.\n")
 	return nil
 }
 
@@ -1072,7 +1112,7 @@ func runSiteInit(svc *config.CustomService, ctx siteTemplateCtx) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		fmt.Printf("  [WARN] site_init for %s failed: %v\n", svc.Name, err)
+		feedback.Warn("site_init for %s failed: %v", svc.Name, err)
 	}
 }
 
@@ -1295,7 +1335,7 @@ func patchDuskTestCase(dir string) {
 
 	if changed {
 		if err := os.WriteFile(path, []byte(src), 0644); err != nil {
-			fmt.Printf("  [WARN] could not patch DuskTestCase.php: %v\n", err)
+			feedback.Warn("could not patch DuskTestCase.php: %v", err)
 			return
 		}
 		fmt.Println("  Patched tests/DuskTestCase.php for lerd Selenium")

--- a/internal/cli/env_override.go
+++ b/internal/cli/env_override.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 )
 
@@ -85,7 +86,7 @@ func readEnvOverride(cwd string) (overrides map[string]string, external map[stri
 // `continue` past start/provision after writing the connection vars.
 func externalManaged(name string, external map[string]bool) bool {
 	if external[name] {
-		fmt.Printf("  %-12s externally managed (%s) — not starting it\n", name, envOverrideFile)
+		feedback.Note(name + " externally managed (" + envOverrideFile + ") — not starting it")
 		return true
 	}
 	return false
@@ -153,15 +154,16 @@ func runEnvOverride(_ *cobra.Command, args []string) error {
 		return err
 	}
 
+	feedback.Begin()
 	if created {
-		fmt.Printf("Created %s (gitignored).\n", envOverrideFile)
+		feedback.Done("created " + envOverrideFile + " (gitignored)")
 	} else {
-		fmt.Printf("Updated %s.\n", envOverrideFile)
+		feedback.Done("updated " + envOverrideFile)
 	}
 	for _, kv := range args {
-		fmt.Printf("  %s\n", kv)
+		feedback.Note(kv)
 	}
-	fmt.Println("Run 'lerd env' to apply these overrides to your .env.")
+	feedback.Note("run `lerd env` to apply these overrides to your .env")
 	return nil
 }
 

--- a/internal/cli/fetch.go
+++ b/internal/cli/fetch.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
@@ -81,8 +82,8 @@ func runFetch(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := RunParallel(jobs); err != nil {
-		fmt.Printf("[WARN] some images failed to build: %v\n", err)
+		feedback.Warn("some images failed to build: %v", err)
 	}
-	fmt.Println("\nAll requested PHP images ready.")
+	feedback.Done("all requested PHP images ready")
 	return nil
 }

--- a/internal/cli/framework.go
+++ b/internal/cli/framework.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/store"
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/spf13/cobra"
@@ -58,7 +59,7 @@ func runFrameworkList(check bool) error {
 		client := store.NewClient()
 		idx, err := client.FetchIndex()
 		if err != nil {
-			fmt.Printf("[WARN] could not fetch store index: %v\n", err)
+			feedback.Warn("could not fetch store index: %v", err)
 		} else {
 			storeIndex = idx
 		}
@@ -254,7 +255,8 @@ YAML file format:
 				return fmt.Errorf("saving framework: %w", err)
 			}
 
-			fmt.Printf("Framework %q saved (%s).\n", fw.Name, config.FrameworksDir()+"/"+fw.Name+".yaml")
+			feedback.Begin()
+			feedback.Done(fmt.Sprintf("framework %q saved (%s)", fw.Name, config.FrameworksDir()+"/"+fw.Name+".yaml"))
 			if fw.Name == "laravel" {
 				fmt.Println("Custom workers merged with built-in Laravel definition.")
 			} else {
@@ -305,7 +307,7 @@ Examples:
 					}
 					return err
 				}
-				fmt.Printf("Custom laravel overlay removed (built-in definition remains).\n")
+				feedback.Done("custom laravel overlay removed (built-in definition remains)")
 				return nil
 			}
 
@@ -321,7 +323,7 @@ Examples:
 						if err := config.RemoveFrameworkFile(f.Path); err != nil {
 							return err
 						}
-						fmt.Printf("Removed %s@%s.\n", name, version)
+						feedback.Done(fmt.Sprintf("removed %s@%s", name, version))
 						return nil
 					}
 				}
@@ -333,7 +335,7 @@ Examples:
 				if err := config.RemoveFramework(name); err != nil {
 					return err
 				}
-				fmt.Printf("Framework %q removed.\n", name)
+				feedback.Done(fmt.Sprintf("framework %q removed", name))
 				return nil
 			}
 
@@ -361,7 +363,7 @@ Examples:
 				if err := config.RemoveFramework(name); err != nil {
 					return err
 				}
-				fmt.Printf("Framework %q removed (all versions).\n", name)
+				feedback.Done(fmt.Sprintf("framework %q removed (all versions)", name))
 				return nil
 			}
 
@@ -377,7 +379,7 @@ Examples:
 			if v == "" {
 				v = "unversioned"
 			}
-			fmt.Printf("Removed %s (%s).\n", name, v)
+			feedback.Done(fmt.Sprintf("removed %s (%s)", name, v))
 			return nil
 		},
 	}
@@ -480,8 +482,8 @@ Examples:
 			if fw.Version != "" {
 				filename = fw.Name + "@" + fw.Version + ".yaml"
 			}
-			fmt.Printf("Installed %s@%s (%s).\n", fw.Name, versionStr, fw.Label)
-			fmt.Printf("Saved to %s/%s\n", config.StoreFrameworksDir(), filename)
+			feedback.Done(fmt.Sprintf("installed %s@%s (%s)", fw.Name, versionStr, fw.Label))
+			feedback.Note("saved to " + config.StoreFrameworksDir() + "/" + filename)
 			return nil
 		},
 	}
@@ -547,7 +549,7 @@ func updateSingleFramework(client *store.Client, name, version string, showDiff 
 	}
 	// Remove old user-defined file if it exists — the store version should take effect.
 	config.RemoveUserFramework(name)
-	fmt.Printf("Updated %s@%s (%s).\n", remote.Name, versionOrLatest(remote), remote.Label)
+	feedback.Done(fmt.Sprintf("updated %s@%s (%s)", remote.Name, versionOrLatest(remote), remote.Label))
 	return nil
 }
 
@@ -579,14 +581,14 @@ func updateAllFrameworks(client *store.Client, showDiff bool) error {
 		}
 		remote, fetchErr := client.FetchFramework(info.Name, info.Version)
 		if fetchErr != nil {
-			fmt.Printf("  [WARN] %s@%s: %v\n", info.Name, info.Version, fetchErr)
+			feedback.Warn("%s@%s: %v", info.Name, info.Version, fetchErr)
 			continue
 		}
 
 		if showDiff {
 			changed, diffErr := showFrameworkDiff(info.Name, info.Framework, remote)
 			if diffErr != nil {
-				fmt.Printf("  [WARN] %s@%s: %v\n", info.Name, info.Version, diffErr)
+				feedback.Warn("%s@%s: %v", info.Name, info.Version, diffErr)
 				continue
 			}
 			if !changed {
@@ -596,17 +598,17 @@ func updateAllFrameworks(client *store.Client, showDiff bool) error {
 		}
 
 		if saveErr := config.SaveStoreFramework(remote); saveErr != nil {
-			fmt.Printf("  [WARN] %s@%s: %v\n", info.Name, info.Version, saveErr)
+			feedback.Warn("%s@%s: %v", info.Name, info.Version, saveErr)
 			continue
 		}
 		config.RemoveUserFramework(info.Name)
-		fmt.Printf("  Updated %s@%s\n", remote.Name, versionOrLatest(remote))
+		feedback.Note(fmt.Sprintf("updated %s@%s", remote.Name, versionOrLatest(remote)))
 		updated++
 	}
 	if updated == 0 {
-		fmt.Println("No frameworks to update.")
+		feedback.Line("no frameworks to update")
 	} else {
-		fmt.Printf("Updated %d framework(s).\n", updated)
+		feedback.Done(fmt.Sprintf("updated %d framework(s)", updated))
 	}
 	return nil
 }
@@ -647,12 +649,12 @@ func showFrameworkDiff(name string, local, remote *config.Framework) (bool, erro
 	fmt.Printf("\n%s:\n", name)
 	for _, line := range strings.Split(strings.TrimRight(diff, "\n"), "\n") {
 		switch {
-		case strings.HasPrefix(line, "+"):
-			fmt.Printf("\033[32m%s\033[0m\n", line)
-		case strings.HasPrefix(line, "-"):
-			fmt.Printf("\033[31m%s\033[0m\n", line)
 		case strings.HasPrefix(line, "@@") || strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++"):
-			fmt.Printf("\033[34m%s\033[0m\n", line)
+			fmt.Println(feedback.Dim(line))
+		case strings.HasPrefix(line, "+"):
+			fmt.Println(feedback.Green(line))
+		case strings.HasPrefix(line, "-"):
+			fmt.Println(feedback.Red(line))
 		default:
 			fmt.Println(line)
 		}

--- a/internal/cli/group.go
+++ b/internal/cli/group.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/grouping"
 	"github.com/spf13/cobra"
 )
@@ -91,9 +92,10 @@ func runGroupAdd(_ *cobra.Command, args []string) error {
 	if err := grouping.AssignSecondary(main, secondary, label, groupShareDB); err != nil {
 		return err
 	}
-	fmt.Printf("Grouped %s under %s at %s\n", secondary.Name, main.Name, secondary.PrimaryDomain())
+	feedback.Begin()
+	feedback.Done("grouped " + secondary.Name + " under " + main.Name + " at " + feedback.Val(secondary.PrimaryDomain()))
 	if groupShareDB {
-		fmt.Printf("Sharing the %s database\n", main.Name)
+		feedback.Note("sharing the " + main.Name + " database")
 	}
 	return nil
 }
@@ -115,10 +117,11 @@ func runGroupDB(_ *cobra.Command, args []string) error {
 	if err := grouping.SetSecondarySharedDB(secondary, share); err != nil {
 		return err
 	}
+	feedback.Begin()
 	if share {
-		fmt.Println("Now sharing the main site's database")
+		feedback.Done("now sharing the main site's database")
 	} else {
-		fmt.Println("Now using a separate database")
+		feedback.Done("now using a separate database")
 	}
 	return nil
 }
@@ -131,7 +134,8 @@ func runGroupRemove(_ *cobra.Command, _ []string) error {
 	if err := grouping.UnassignSecondary(secondary); err != nil {
 		return err
 	}
-	fmt.Printf("Ungrouped %s -> %s\n", secondary.Name, secondary.PrimaryDomain())
+	feedback.Begin()
+	feedback.Done("ungrouped " + secondary.Name + " → " + feedback.Val(secondary.PrimaryDomain()))
 	return nil
 }
 
@@ -144,7 +148,8 @@ func runGroupLabel(_ *cobra.Command, args []string) error {
 	if err := grouping.SetSecondaryLabel(secondary, label); err != nil {
 		return err
 	}
-	fmt.Printf("Changed subdomain to %s\n", secondary.PrimaryDomain())
+	feedback.Begin()
+	feedback.Done("changed subdomain to " + feedback.Val(secondary.PrimaryDomain()))
 	return nil
 }
 

--- a/internal/cli/horizon.go
+++ b/internal/cli/horizon.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
@@ -83,10 +84,12 @@ func newHorizonReloadCmd(use string) *cobra.Command {
 				return err
 			}
 
+			feedback.Begin()
 			if enable {
-				fmt.Println("Horizon auto-reload enabled, Horizon will restart workers on file changes.")
+				feedback.Done("Horizon auto-reload enabled")
+				feedback.Note("Horizon restarts workers on file changes")
 			} else {
-				fmt.Println("Horizon auto-reload disabled, Horizon runs in standard mode.")
+				feedback.Done("Horizon auto-reload disabled")
 			}
 			return nil
 		},

--- a/internal/cli/hostproxy.go
+++ b/internal/cli/hostproxy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/nginx"
 	"github.com/geodro/lerd/internal/siteops"
@@ -55,7 +56,7 @@ func RegenerateHostProxyVhostsOnGatewayChange() {
 			continue
 		}
 		if err := siteops.RegenerateSiteVhost(&s, s.PrimaryDomain()); err != nil {
-			fmt.Printf("[WARN] regenerating host-proxy vhost for %s: %v\n", s.Name, err)
+			feedback.Warn("regenerating host-proxy vhost for %s: %v", s.Name, err)
 			continue
 		}
 		if wts, wErr := gitpkg.ServableWorktrees(s.Path, s.PrimaryDomain()); wErr == nil {
@@ -420,11 +421,11 @@ func startHostProxyWorker(site config.Site, proxy *config.ProxyConfig) {
 		return
 	}
 	if err := gateHostProxyAutostart(site, proxy.Command); err != nil {
-		fmt.Printf("[WARN] dev server not started: %v\n", err)
+		feedback.Warn("dev server not started: %v", err)
 		return
 	}
 	if err := WorkerStartForSite(site.Name, site.Path, "", hostProxyWorkerName, w, false); err != nil {
-		fmt.Printf("[WARN] starting dev server: %v\n", err)
+		feedback.Warn("starting dev server: %v", err)
 	}
 }
 

--- a/internal/cli/idle.go
+++ b/internal/cli/idle.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/geodro/lerd/internal/activityping"
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 )
 
 // NewIdleCmd returns the parent `lerd idle` command: a global on/off toggle, a
@@ -50,7 +51,8 @@ func newIdlePinCmd(verb string, pinned bool) *cobra.Command {
 			if !pinned {
 				verbed = "unpinned"
 			}
-			fmt.Printf("%s %s (idle-suspend %s).\n", verbed, args[0], map[bool]string{true: "off", false: "on"}[pinned])
+			feedback.Begin()
+			feedback.Done(fmt.Sprintf("%s %s (idle-suspend %s)", verbed, args[0], map[bool]string{true: "off", false: "on"}[pinned]))
 			return nil
 		},
 	}
@@ -105,7 +107,8 @@ func setIdleEnabled(enabled bool) error {
 	} else {
 		activityping.Disable()
 	}
-	fmt.Printf("Idle-suspend %s.\n", onOff(enabled))
+	feedback.Begin()
+	feedback.Done("idle-suspend " + onOff(enabled))
 	return nil
 }
 
@@ -122,7 +125,8 @@ func setIdleTimeout(dur string) error {
 	if err := config.SaveGlobal(cfg); err != nil {
 		return err
 	}
-	fmt.Printf("Idle timeout set to %s.\n", compactDuration(d))
+	feedback.Begin()
+	feedback.Done("idle timeout set to " + compactDuration(d))
 	return nil
 }
 

--- a/internal/cli/import_sail.go
+++ b/internal/cli/import_sail.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -144,7 +145,7 @@ func runImportSail(noStop, skipS3 bool, sailDBUser, sailDBPassword, sailDBName s
 	// Warn (non-fatal) if vendor/laravel/sail is absent.
 	if _, sailErr := os.Stat(filepath.Join(cwd, "vendor", "laravel", "sail")); os.IsNotExist(sailErr) {
 		if _, sailErr2 := os.Stat(filepath.Join(cwd, "sail")); os.IsNotExist(sailErr2) {
-			fmt.Println("Warning: vendor/laravel/sail not found — proceeding anyway.")
+			feedback.Warn("vendor/laravel/sail not found — proceeding anyway")
 		}
 	}
 
@@ -173,8 +174,8 @@ func runImportSail(noStop, skipS3 bool, sailDBUser, sailDBPassword, sailDBName s
 		sailEnv.database = lerdEnv.database
 		// Warn when DB_DATABASE looks like lerd already overwrote it.
 		if lerdEnv.database == "lerd" {
-			fmt.Println("Warning: DB_DATABASE is 'lerd' — lerd may have already overwritten your .env.")
-			fmt.Println("  If your Sail database had a different name, pass --sail-db-name <name>.")
+			feedback.Warn("DB_DATABASE is 'lerd' — lerd may have already overwritten your .env")
+			feedback.Note("if your Sail database had a different name, pass --sail-db-name <name>")
 		}
 	}
 
@@ -195,13 +196,14 @@ func runImportSail(noStop, skipS3 bool, sailDBUser, sailDBPassword, sailDBName s
 	// etc.) even though we're passing a path to a temp file.
 	composeArgs := []string{"compose", "--project-directory", cwd, "-f", tempComposePath}
 
+	feedback.Begin()
 	if len(strippedSvcs) > 0 {
-		fmt.Printf("Stripping ports from app services: %s\n", strings.Join(strippedSvcs, ", "))
+		feedback.Line("stripping ports from app services: " + strings.Join(strippedSvcs, ", "))
 	}
 	if len(portRemap) > 0 {
-		fmt.Println("Remapping conflicting ports for Sail:")
+		feedback.Line("remapping conflicting ports for Sail")
 		for orig, remapped := range portRemap {
-			fmt.Printf("  %-5d → %d\n", orig, remapped)
+			feedback.Note(fmt.Sprintf("%d → %d", orig, remapped))
 		}
 	}
 
@@ -248,7 +250,7 @@ func runImportSail(noStop, skipS3 bool, sailDBUser, sailDBPassword, sailDBName s
 
 	// --force-recreate guarantees a clean container even if a previous run
 	// left one behind. Volumes are preserved.
-	fmt.Printf("Starting Sail services: %s\n", strings.Join(servicesToStart, ", "))
+	feedback.Line("starting Sail services: " + strings.Join(servicesToStart, ", "))
 	upArgs := append(composeArgs, "up", "-d", "--no-deps", "--force-recreate")
 	upArgs = append(upArgs, servicesToStart...)
 	upCmd := exec.Command(composeBin, upArgs...)
@@ -261,7 +263,7 @@ func runImportSail(noStop, skipS3 bool, sailDBUser, sailDBPassword, sailDBName s
 	// Tear Sail down when we're done (deferred so it runs even on error).
 	if !noStop {
 		defer func() {
-			fmt.Println("Stopping Sail...")
+			feedback.Line("stopping Sail")
 			downArgs := append(composeArgs, "down")
 			downCmd := exec.Command(composeBin, downArgs...)
 			downCmd.Stdout = os.Stdout
@@ -271,7 +273,7 @@ func runImportSail(noStop, skipS3 bool, sailDBUser, sailDBPassword, sailDBName s
 	}
 
 	// --- Wait for DB readiness ---
-	fmt.Printf("Waiting for Sail %s to be ready...\n", dbService)
+	feedback.Line("waiting for Sail " + dbService + " to be ready")
 	if err := sailWaitDB(composeArgs, dbService, sailEnv, composeBin); err != nil {
 		return fmt.Errorf("Sail DB not ready: %w", err)
 	}
@@ -291,32 +293,33 @@ func runImportSail(noStop, skipS3 bool, sailDBUser, sailDBPassword, sailDBName s
 		return fmt.Errorf("inspecting Sail database %q: %w", sailEnv.database, err)
 	}
 	if tableCount == 0 {
-		fmt.Printf("Sail database %q has no tables — refusing to overwrite lerd DB with empty data.\n", sailEnv.database)
-		fmt.Println("Skipping database import.")
+		feedback.Warn("Sail database %q has no tables — refusing to overwrite lerd DB with empty data", sailEnv.database)
+	} else if !feedback.Confirm(fmt.Sprintf("Found database %q with %d tables. Import into lerd (will overwrite %q)?", sailEnv.database, tableCount, lerdEnv.database), false) {
+		feedback.Line("database import skipped")
 	} else {
-		fmt.Printf("Found database %q with %d tables. ", sailEnv.database, tableCount)
-		if !promptConfirm(fmt.Sprintf("Import into lerd (will overwrite %q)?", lerdEnv.database)) {
-			fmt.Println("Database import skipped.")
-		} else {
-			fmt.Printf("Dumping database %q from Sail...\n", sailEnv.database)
-			dumpFile, err := sailDumpDB(composeArgs, dbService, sailEnv, composeBin)
-			if err != nil {
-				return fmt.Errorf("dumping Sail DB: %w", err)
-			}
-			defer os.Remove(dumpFile)
-
-			fmt.Printf("Importing into lerd (%s / %s)...\n", lerdEnv.connection, lerdEnv.database)
-			if err := ensureServiceRunning(connToService(lerdEnv.connection)); err != nil {
-				return fmt.Errorf("starting lerd DB service: %w", err)
-			}
-			if err := sailRecreateDB(lerdEnv); err != nil {
-				return fmt.Errorf("recreating database: %w", err)
-			}
-			if err := sailImportDump(dumpFile, lerdEnv); err != nil {
-				return fmt.Errorf("importing dump: %w", err)
-			}
-			fmt.Println("Database imported.")
+		dump := feedback.Start("dumping database " + sailEnv.database + " from Sail")
+		dumpFile, err := sailDumpDB(composeArgs, dbService, sailEnv, composeBin)
+		if err != nil {
+			dump.Fail(err)
+			return fmt.Errorf("dumping Sail DB: %w", err)
 		}
+		dump.OK("")
+		defer os.Remove(dumpFile)
+
+		imp := feedback.Start("importing into lerd (" + lerdEnv.connection + " / " + lerdEnv.database + ")")
+		if err := ensureServiceRunning(connToService(lerdEnv.connection)); err != nil {
+			imp.Fail(err)
+			return fmt.Errorf("starting lerd DB service: %w", err)
+		}
+		if err := sailRecreateDB(lerdEnv); err != nil {
+			imp.Fail(err)
+			return fmt.Errorf("recreating database: %w", err)
+		}
+		if err := sailImportDump(dumpFile, lerdEnv); err != nil {
+			imp.Fail(err)
+			return fmt.Errorf("importing dump: %w", err)
+		}
+		imp.OK("")
 	}
 
 	// --- S3 import ---
@@ -327,19 +330,19 @@ func runImportSail(noStop, skipS3 bool, sailDBUser, sailDBPassword, sailDBName s
 			// / AWS_SECRET_ACCESS_KEY — lerd setup may have overwritten those.
 			s3.accessKey = minioUser
 			s3.secretKey = minioPass
-			fmt.Println("Importing S3/MinIO files into lerd RustFS...")
+			s3step := feedback.Start("importing S3/MinIO files into lerd RustFS")
 			if err := sailImportS3(s3, minioPort, lerdEnv.database); err != nil {
-				fmt.Printf("  Warning: S3 import failed: %v\n", err)
-				fmt.Println("  Re-run with --skip-s3 to skip this step.")
+				s3step.Fail(err)
+				feedback.Note("re-run with --skip-s3 to skip this step")
 			} else {
-				fmt.Println("S3 import complete.")
+				s3step.OK("")
 			}
 		} else {
-			fmt.Println("No MinIO service found in docker-compose — skipping S3 import.")
+			feedback.Line("no MinIO service found in docker-compose — skipping S3 import")
 		}
 	}
 
-	fmt.Println("\nImport complete.")
+	feedback.Done("import complete")
 	return nil
 }
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -8,10 +8,12 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/huh"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/feedback"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
@@ -47,6 +49,8 @@ func runInit(fresh bool) error {
 	_, statErr := os.Stat(lerdYAMLPath)
 	hasExisting := statErr == nil
 
+	feedback.Begin()
+
 	if !hasExisting || fresh {
 		existing, err := config.LoadProjectConfig(cwd)
 		if err != nil {
@@ -57,10 +61,12 @@ func runInit(fresh bool) error {
 		if err != nil {
 			return err
 		}
+		write := feedback.Start("writing .lerd.yaml")
 		if err := config.SaveProjectConfig(cwd, cfg); err != nil {
+			write.Fail(err)
 			return fmt.Errorf("saving .lerd.yaml: %w", err)
 		}
-		fmt.Println("Saved .lerd.yaml")
+		write.OK("")
 		// The wizard already had the user choose the dev command, so the link
 		// it triggers below shouldn't prompt to confirm that same command again.
 		hostProxyPreApproved = true
@@ -72,12 +78,9 @@ func runInit(fresh bool) error {
 	}
 
 	if isInteractive() {
-		fmt.Print("\nRun lerd setup? [Y/n] ")
-		var answer string
-		fmt.Scanln(&answer) //nolint:errcheck
-		if answer == "" || answer[0] == 'Y' || answer[0] == 'y' {
+		if feedback.Confirm("Run lerd setup?", true) {
 			if err := runSetup(false, false); err != nil {
-				fmt.Printf("[WARN] setup: %v\n", err)
+				feedback.Warn("setup: %v", err)
 			}
 		}
 	}
@@ -1068,12 +1071,12 @@ func maybeCreateContainerfile(cwd, containerfile string, port int) {
 		_ = os.MkdirAll(dir, 0755)
 	}
 	if err := os.WriteFile(path, []byte(starterContainerfile(cwd, port)), 0644); err != nil {
-		fmt.Printf("[WARN] could not create %s: %v\n", containerfile, err)
+		feedback.Warn("could not create %s: %v", containerfile, err)
 		return
 	}
 	fmt.Printf("Created %s\n", containerfile)
 	if launched, err := launchEditor(path); err != nil {
-		fmt.Printf("[WARN] %v\n", err)
+		feedback.Warn("%v", err)
 	} else if !launched {
 		fmt.Printf("Set $EDITOR to edit it automatically; the starter file is at %s\n", containerfile)
 	}
@@ -1228,7 +1231,7 @@ func runSetupInit(cwd string, skipWizard bool) error {
 			return err
 		}
 		if err := runEnv(nil, nil); err != nil {
-			fmt.Printf("[WARN] lerd env: %v\n", err)
+			feedback.Warn("lerd env: %v", err)
 		}
 		return nil
 	}
@@ -1240,50 +1243,110 @@ func runSetupInit(cwd string, skipWizard bool) error {
 		if err != nil {
 			return err
 		}
+		write := feedback.Start("writing .lerd.yaml")
 		if err := config.SaveProjectConfig(cwd, cfg); err != nil {
+			write.Fail(err)
 			return fmt.Errorf("saving .lerd.yaml: %w", err)
 		}
-		fmt.Println("Saved .lerd.yaml")
+		write.OK("")
 	}
 
 	return applyProjectConfig(cwd)
 }
 
 func applyProjectConfig(cwd string) error {
-	// Suppress the "Run lerd setup?" prompt inside runLink — we're already
-	// in init/setup and the caller handles worker steps separately.
+	// Suppress the "Run lerd setup?" prompt and the link summary inside runLink —
+	// we're already in init/setup, the caller handles worker steps, and the
+	// summary is printed here after the .env step so it lands last.
 	linkSkipSetupPrompt = true
-	defer func() { linkSkipSetupPrompt = false }()
+	linkSkipSummary = true
+	defer func() { linkSkipSetupPrompt = false; linkSkipSummary = false }()
+
+	start := time.Now()
 	proj, err := config.LoadProjectConfig(cwd)
 	if err != nil {
 		return err
 	}
 
-	// Install PHP FPM with a progress loader if the version is not yet installed.
-	// runLink handles everything else (framework restore, node-version, secure, services).
-	if proj.PHPVersion != "" && !phpPkg.IsInstalled(proj.PHPVersion) {
-		phpVersion := proj.PHPVersion
-		jobs := []BuildJob{{
-			Label: "PHP " + phpVersion + " FPM",
-			Run: func(w io.Writer) error {
-				return ensureFPMQuadletTo(phpVersion, w)
-			},
-		}}
-		if err := RunParallel(jobs); err != nil {
-			fmt.Printf("[WARN] PHP %s FPM: %v\n", phpVersion, err)
+	// Skip work that already ran earlier in this process. When a `lerd link`
+	// flows into `lerd setup` via the prompt, the link (and often .env) is
+	// already done, so re-running it would just repeat the same output.
+	ranLink := false
+	if !linkApplied {
+		// Install PHP FPM with a progress loader if the version is not yet installed.
+		// runLink handles everything else (framework restore, node-version, secure, services).
+		if proj.PHPVersion != "" && !phpPkg.IsInstalled(proj.PHPVersion) {
+			phpVersion := proj.PHPVersion
+			jobs := []BuildJob{{
+				Label: "PHP " + phpVersion + " FPM",
+				Run: func(w io.Writer) error {
+					return ensureFPMQuadletTo(phpVersion, w)
+				},
+			}}
+			if err := RunParallel(jobs); err != nil {
+				feedback.Warn("PHP %s FPM: %v", phpVersion, err)
+			}
 		}
-	}
 
-	if err := runLink([]string{}); err != nil {
-		return err
+		if err := runLink([]string{}); err != nil {
+			return err
+		}
+		ranLink = true
 	}
 
 	// Apply the wizard's service choices (database, etc.) to .env so the user
 	// sees DB_CONNECTION/DB_HOST/etc. updated immediately after the wizard.
-	// Best-effort — failures are warned, not fatal, since the link itself
-	// succeeded and the user can re-run `lerd env` manually.
-	if err := runEnv(nil, nil); err != nil {
-		fmt.Printf("[WARN] lerd env: %v\n", err)
+	if !envApplied {
+		applyEnvStep(cwd)
+	}
+
+	// Print the deferred link summary now, so it reads as the final word after
+	// every provisioning step (including .env) has reported. Skip it when we
+	// didn't link this pass — the summary was already shown.
+	linkSkipSummary = false
+	if ranLink {
+		if site, err := config.FindSiteByPath(cwd); err == nil {
+			printLinkSummary(*site, start)
+		}
 	}
 	return nil
+}
+
+// applyEnvStep runs `lerd env` quietly under a single condensed feedback step,
+// listing the services it configured (from envSummary) rather than its full
+// per-service output.
+func applyEnvStep(cwd string) {
+	envApplied = true
+	if !feedback.Animated() {
+		if err := runEnv(nil, nil); err != nil {
+			feedback.Warn("lerd env: %v", err)
+		}
+		return
+	}
+	if err := runEnvLive(nil, nil); err != nil {
+		feedback.Warn("lerd env: %v", err)
+	}
+}
+
+// runCapturingStdout redirects os.Stdout to a pipe for the duration of fn and
+// returns everything it wrote. A reader goroutine drains continuously so even
+// large output (composer/npm) never blocks on the pipe buffer. Used to fold a
+// setup step's verbose output behind a single feedback line, surfacing it only
+// when the step fails.
+func runCapturingStdout(fn func() error) ([]byte, error) {
+	prev := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, fn()
+	}
+	os.Stdout = w
+	captured := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		captured <- b
+	}()
+	runErr := fn()
+	os.Stdout = prev
+	_ = w.Close()
+	return <-captured, runErr
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -15,6 +15,7 @@ import (
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/nginx"
 	nodeDet "github.com/geodro/lerd/internal/node"
 	phpDet "github.com/geodro/lerd/internal/php"
@@ -872,9 +873,9 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	refreshGlobalMCPSkills()
 	refreshProjectMCPSkills()
 
-	fmt.Println("\nLerd installation complete!")
-	fmt.Println("\n  Dashboard: \033[96mhttp://lerd.localhost\033[0m")
-	fmt.Println("  Terminal:  \033[96mlerd tui\033[0m")
+	feedback.Done("lerd installation complete")
+	feedback.Note("Dashboard: " + feedback.Val("http://lerd.localhost"))
+	feedback.Note("Terminal:  " + feedback.Val("lerd tui"))
 	return nil
 }
 

--- a/internal/cli/isolate.go
+++ b/internal/cli/isolate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/nginx"
 	"github.com/spf13/cobra"
@@ -45,22 +46,24 @@ func runIsolate(_ *cobra.Command, args []string) error {
 			return fmt.Errorf("updating .lerd.yaml: %w", err)
 		}
 		if err := regenerateWorktreeVhost(site, branch, version); err != nil {
-			fmt.Printf("[WARN] regenerating worktree vhost: %v\n", err)
+			feedback.Warn("regenerating worktree vhost: %v", err)
 		} else {
 			nginx.ReloadOrWarn("")
 		}
-		fmt.Printf("PHP version pinned to %s for worktree %s of %s\n", version, branch, site.Name)
+		feedback.Begin()
+		feedback.Done("PHP pinned to " + feedback.Val(version) + " · worktree " + branch + " of " + site.Name)
 		return nil
 	}
 
 	// Parent-site path: keep the legacy behaviour — write .lerd.yaml when it
 	// exists, then re-link so the registry and nginx pick up the change.
 	_ = config.SetProjectPHPVersion(cwd, version)
-	fmt.Printf("PHP version pinned to %s\n", version)
+	feedback.Begin()
+	feedback.Done("PHP pinned to " + feedback.Val(version))
 
 	if _, err := config.FindSiteByPath(cwd); err == nil {
 		if err := runLink([]string{}); err != nil {
-			fmt.Printf("[WARN] re-linking site: %v\n", err)
+			feedback.Warn("re-linking site: %v", err)
 		} else if site, err := config.FindSiteByPath(cwd); err == nil && site.PHPVersion != "" && site.PHPVersion != version {
 			// The framework caps the usable PHP (e.g. Laravel 11 → 8.4), so the
 			// re-link clamped the pin. Sync the committed files to the version
@@ -68,7 +71,7 @@ func runIsolate(_ *cobra.Command, args []string) error {
 			// advertise a version lerd silently overrides on every link.
 			_ = config.SetProjectPHPVersion(cwd, site.PHPVersion)
 			_ = os.WriteFile(filepath.Join(cwd, ".php-version"), []byte(site.PHPVersion+"\n"), 0644)
-			fmt.Printf("Note: %s isn't usable here; clamped to %s and updated .lerd.yaml / .php-version to match.\n", version, site.PHPVersion)
+			feedback.Note(version + " isn't usable here; clamped to " + site.PHPVersion + " and updated .lerd.yaml / .php-version")
 		}
 	}
 

--- a/internal/cli/isolate_node.go
+++ b/internal/cli/isolate_node.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 )
 
@@ -38,13 +39,14 @@ func runIsolateNode(_ *cobra.Command, args []string) error {
 	// file is created if missing; for parents we only touch an existing file.
 	if _, _, ok := FindParentSiteForWorktree(cwd); ok {
 		if err := config.SetWorktreeNodeVersion(cwd, version); err != nil {
-			fmt.Printf("[WARN] updating .lerd.yaml: %v\n", err)
+			feedback.Warn("updating .lerd.yaml: %v", err)
 		}
 	} else {
 		_ = updateProjectNodeVersionIfExists(cwd, version)
 	}
 
-	fmt.Printf("Node.js version pinned to %s in %s\n", version, cwd)
+	feedback.Begin()
+	feedback.Done("Node pinned to " + feedback.Val(version))
 
 	// Run fnm install for this version
 	fnmPath := filepath.Join(config.BinDir(), "fnm")
@@ -53,10 +55,10 @@ func runIsolateNode(_ *cobra.Command, args []string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
-			fmt.Printf("[WARN] fnm install %s: %v\n", version, err)
+			feedback.Warn("fnm install %s: %v", version, err)
 		}
 	} else {
-		fmt.Println("[WARN] fnm not found — run 'lerd install' to set up Node.js management")
+		feedback.Warn("fnm not found — run 'lerd install' to set up Node.js management")
 	}
 
 	return nil

--- a/internal/cli/lan.go
+++ b/internal/cli/lan.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 )
 
@@ -114,34 +115,36 @@ generates a one-shot bootstrap code for a remote machine.`,
 			// remote-control credential prompt into this single command if
 			// it has not already been set.
 			if !dnsOn && cfg != nil && cfg.UI.PasswordHash == "" {
-				fmt.Println("DNS is disabled, the dashboard is the only thing reachable on the LAN, set HTTP Basic credentials so it is gated:")
+				feedback.Line("DNS is disabled — the dashboard is the only thing reachable on the LAN, set HTTP Basic credentials so it is gated")
 				if err := promptAndPersistRemoteControl(); err != nil {
 					return err
 				}
 				cfg, _ = config.LoadGlobal()
 			}
+			feedback.Begin()
+			expose := feedback.Start("exposing lerd on the LAN")
 			lanIP, err := EnableLANExposure(func(step string) {
-				fmt.Printf("  • %s\n", step)
+				feedback.Note(step)
 			})
 			if err != nil {
+				expose.Fail(err)
 				return err
 			}
-			fmt.Printf("Lerd is now reachable on the LAN at %s.\n", lanIP)
+			expose.OK(feedback.Val(lanIP))
 			if dnsOn {
-				fmt.Printf("  - sites: http://*.test (resolved via dnsmasq on %s:5300)\n", lanIP)
+				feedback.Note("sites: http://*.test (resolved via dnsmasq on " + lanIP + ":5300)")
 			} else {
-				fmt.Println("  - sites: only reachable via per-site `lerd lan:share` (no dnsmasq, *.localhost cannot resolve to a remote host)")
+				feedback.Note("sites: only reachable via per-site `lerd lan:share` (no dnsmasq, *.localhost cannot resolve to a remote host)")
 			}
 			if cfg != nil && cfg.UI.PasswordHash != "" {
-				fmt.Printf("  - dashboard: http://%s:7073 (HTTP Basic auth required)\n", lanIP)
+				feedback.Note(fmt.Sprintf("dashboard: http://%s:7073 (HTTP Basic auth required)", lanIP))
 			} else {
-				fmt.Printf("  - dashboard: http://%s:7073 (LAN clients get 403 — run `lerd remote-control on` to grant LAN access)\n", lanIP)
+				feedback.Note(fmt.Sprintf("dashboard: http://%s:7073 (LAN clients get 403 — run `lerd remote-control on` to grant LAN access)", lanIP))
 			}
 			if dnsOn {
-				fmt.Println("Make sure your firewall allows ports 80, 443, 5300, 7073 from the devices you want to grant access.")
-				fmt.Println("Run `lerd remote-setup` to generate a one-time bootstrap code for a remote machine.")
+				feedback.Note("allow ports 80, 443, 5300, 7073 through your firewall; `lerd remote-setup` generates a one-time bootstrap code")
 			} else {
-				fmt.Println("Make sure your firewall allows ports 80, 443, 7073 plus any `lerd lan:share` ports from the devices you want to grant access.")
+				feedback.Note("allow ports 80, 443, 7073 plus any `lerd lan:share` ports through your firewall")
 			}
 			return nil
 		},
@@ -153,14 +156,17 @@ func newLANUnexposeCmd() *cobra.Command {
 		Use:   "unexpose",
 		Short: "Restrict lerd to loopback only — safe for untrusted wifi",
 		RunE: func(_ *cobra.Command, _ []string) error {
+			feedback.Begin()
+			restrict := feedback.Start("restricting lerd to loopback")
 			if err := DisableLANExposure(func(step string) {
-				fmt.Printf("  • %s\n", step)
+				feedback.Note(step)
 			}); err != nil {
+				restrict.Fail(err)
 				return err
 			}
-			fmt.Println("Lerd is now restricted to loopback (127.0.0.1).")
-			fmt.Println("LAN devices can no longer reach sites, services, or the dashboard.")
-			fmt.Println("Any active remote-setup code has been revoked.")
+			restrict.OK(feedback.Val("127.0.0.1"))
+			feedback.Note("LAN devices can no longer reach sites, services, or the dashboard")
+			feedback.Note("any active remote-setup code has been revoked")
 			return nil
 		},
 	}
@@ -204,12 +210,13 @@ Run 'lerd lan:unshare' to stop sharing and release the port.`,
 				ip = "<your-LAN-IP>"
 			}
 			shareURL := fmt.Sprintf("http://%s:%d", ip, port)
-			fmt.Printf("Sharing %s at %s\n", siteName, shareURL)
-			fmt.Println("Other devices on the network can use that URL directly — no DNS setup needed.")
+			feedback.Begin()
+			feedback.Done("sharing " + siteName + " at " + feedback.Val(shareURL))
+			feedback.Note("other devices on the network can use that URL directly — no DNS setup needed")
 			fmt.Println()
 			PrintLANShareQR(shareURL)
 			fmt.Println()
-			fmt.Println("Run 'lerd lan:unshare' to stop.")
+			feedback.Note("run `lerd lan:unshare` to stop")
 			return nil
 		},
 	}
@@ -239,7 +246,8 @@ func newLANUnshareCmd() *cobra.Command {
 				site.LANPort = 0
 				_ = config.AddSite(*site)
 			}
-			fmt.Printf("LAN sharing stopped for %s.\n", siteName)
+			feedback.Begin()
+			feedback.Done("LAN sharing stopped for " + siteName)
 			return nil
 		},
 	}
@@ -278,9 +286,11 @@ func newLANStatusCmd() *cobra.Command {
 				if lanIP == "" {
 					lanIP = "(unknown)"
 				}
-				fmt.Printf("Lerd is exposed to the LAN at %s.\n", lanIP)
+				feedback.Begin()
+				feedback.Done("exposed to the LAN at " + feedback.Val(lanIP))
 			} else {
-				fmt.Println("Lerd is loopback-only (127.0.0.1). LAN devices cannot reach it.")
+				feedback.Begin()
+				feedback.Line("loopback-only (127.0.0.1) — LAN devices cannot reach it")
 			}
 			return nil
 		},

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -5,8 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
@@ -20,6 +23,20 @@ import (
 // when runLink is called from within lerd setup / lerd init (prevents infinite
 // recursion and a redundant nag while setup is already running).
 var linkSkipSetupPrompt bool
+
+// linkSkipSummary defers runLink's success line and details block to the
+// caller. Set by the init/setup flow so the ".env" step prints before the
+// "linked" summary rather than after it.
+var linkSkipSummary bool
+
+// linkApplied and envApplied track whether the current process has already
+// linked the site and applied its .env. When a link flows straight into setup
+// (the "Run lerd setup?" prompt), this lets the setup pass skip re-printing the
+// same provisioning steps and jump to the step selector.
+var (
+	linkApplied bool
+	envApplied  bool
+)
 
 // linkAssumeYes approves a host-proxy dev command without the interactive
 // confirmation prompt. Set by `lerd link --yes` and by the UI link flow, where
@@ -93,6 +110,13 @@ func runLink(args []string) error {
 		fmt.Printf("Worktrees inherit the parent's registration; not linking %s as a separate site.\n", cwd)
 		fmt.Printf("Manage it from the parent (%s) or via `lerd worktree`.\n", parent.Path)
 		return nil
+	}
+
+	start := time.Now()
+	// A standalone link opens the feedback block with a blank line for breathing
+	// room; when embedded in init/setup the caller already printed one.
+	if !linkSkipSetupPrompt {
+		feedback.Begin()
 	}
 
 	cfg, err := config.LoadGlobal()
@@ -201,7 +225,7 @@ func runLink(args []string) error {
 		if err := siteops.FinishCustomLink(site, proj.Container); err != nil {
 			return err
 		}
-		fmt.Printf("Linked: %s -> %s (custom container, port %d)\n", name, strings.Join(domains, ", "), proj.Container.Port)
+		printLinkSummary(site, start)
 		return linkApplyServices(cwd, proj)
 	}
 
@@ -239,7 +263,7 @@ func runLink(args []string) error {
 			return err
 		}
 		startHostProxyWorker(site, proj.Proxy)
-		fmt.Printf("Linked: %s -> %s (host proxy, port %d)\n", name, strings.Join(domains, ", "), proj.Proxy.Port)
+		printLinkSummary(site, start)
 		return linkApplyServices(cwd, proj)
 	}
 
@@ -251,6 +275,17 @@ func runLink(args []string) error {
 		detectedPublicDir = config.DetectPublicDir(cwd)
 	}
 
+	frameworkLabel := framework
+	if frameworkLabel == "" {
+		frameworkLabel = "unknown (public: " + detectedPublicDir + ")"
+	}
+	fwStep := feedback.Start("detecting framework")
+	if framework != "" {
+		fwStep.OK(frameworkLabel)
+	} else {
+		fwStep.Info(frameworkLabel)
+	}
+
 	versions := siteops.DetectSiteVersions(cwd, framework, cfg.PHP.DefaultVersion, cfg.Node.DefaultVersion)
 	phpVersion, nodeVersion := versions.PHP, versions.Node
 	if proj != nil && proj.PHPVersion != "" {
@@ -260,15 +295,14 @@ func runLink(args []string) error {
 		unclamped, _ := phpDet.DetectVersion(cwd)
 		if unclamped != phpVersion {
 			if versions.SuggestedPHP != "" {
-				fmt.Printf("Using PHP %s (best installed in range %s–%s). Install PHP %s? [Y/n] ",
+				q := fmt.Sprintf("Using PHP %s (best installed in range %s–%s). Install PHP %s?",
 					phpVersion, versions.PHPMin, versions.PHPMax, versions.SuggestedPHP)
-				var answer string
-				fmt.Scanln(&answer) //nolint:errcheck
-				if answer == "" || answer[0] == 'Y' || answer[0] == 'y' {
-					fmt.Printf("Installing PHP %s...\n", versions.SuggestedPHP)
+				if feedback.Confirm(q, true) {
+					inst := feedback.Start("installing PHP " + versions.SuggestedPHP)
 					if err := ensureFPMQuadlet(versions.SuggestedPHP); err != nil {
-						fmt.Printf("[WARN] installing PHP %s: %v\n", versions.SuggestedPHP, err)
+						inst.Fail(err)
 					} else {
+						inst.OK("")
 						phpVersion = versions.SuggestedPHP
 					}
 				}
@@ -332,53 +366,48 @@ func runLink(args []string) error {
 	_ = config.SyncProjectDomains(cwd, site.Domains, cfg.DNS.TLD)
 
 	if site.IsCustomFPM() {
-		if err := siteops.FinishCustomFPMLink(site, proj.Container); err != nil {
+		result := "php " + feedback.Val(phpVersion) + " · nginx vhost written"
+		if err := provisionAndSecure("building custom FPM image", result, site,
+			func(s config.Site) error { return siteops.FinishCustomFPMLink(s, proj.Container) }); err != nil {
 			return err
 		}
-		fmt.Printf("Linked: %s -> %s (custom FPM image, PHP %s, Framework: %s)\n", name, strings.Join(domains, ", "), phpVersion, framework)
+		printLinkSummary(site, start)
 		return linkApplyServices(cwd, proj)
 	}
 
 	if site.IsFrankenPHP() {
-		if err := siteops.FinishFrankenPHPLink(site); err != nil {
+		result := "php " + feedback.Val(phpVersion) + " · node " + feedback.Val(nodeVersion) + " · nginx vhost written"
+		if err := provisionAndSecure("provisioning FrankenPHP runtime", result, site,
+			func(s config.Site) error { return siteops.FinishFrankenPHPLink(s) }); err != nil {
 			return err
 		}
-		fmt.Printf("Linked: %s -> %s (FrankenPHP, PHP %s, Node %s, Framework: %s)\n", name, strings.Join(domains, ", "), phpVersion, nodeVersion, framework)
+		printLinkSummary(site, start)
 		return linkApplyServices(cwd, proj)
 	}
 
-	if err := siteops.FinishLink(site, phpVersion); err != nil {
+	result := "php " + feedback.Val(phpVersion) + " · node " + feedback.Val(nodeVersion) + " · nginx vhost written"
+	if err := provisionAndSecure("provisioning PHP-FPM runtime", result, site,
+		func(s config.Site) error { return siteops.FinishLink(s, phpVersion) }); err != nil {
 		return err
 	}
-
-	frameworkLabel := framework
-	if frameworkLabel == "" {
-		frameworkLabel = "unknown (public: " + detectedPublicDir + ")"
-	}
-	fmt.Printf("Linked: %s -> %s (PHP %s, Node %s, Framework: %s)\n", name, strings.Join(domains, ", "), phpVersion, nodeVersion, frameworkLabel)
+	printLinkSummary(site, start)
 
 	// Sail detection — offer to import data before setup so lerd's DB is
 	// populated from the existing Sail environment.
 	if isInteractive() && !linkSkipSetupPrompt && config.ComposerHasPackage(cwd, "laravel/sail") {
 		sailDBName := sailLinkDetectDBName(cwd)
-		fmt.Print("\nThis project uses Laravel Sail. Import database (and S3 files) from Sail into lerd? [Y/n] ")
-		var sailAnswer string
-		fmt.Scanln(&sailAnswer) //nolint:errcheck
-		if sailAnswer == "" || sailAnswer[0] == 'Y' || sailAnswer[0] == 'y' {
+		if feedback.Confirm("This project uses Laravel Sail. Import database (and S3 files) from Sail into lerd?", false) {
 			if err := runImportSail(false, false, "sail", "password", sailDBName, sailDBName != "", false, false); err != nil {
-				fmt.Printf("[WARN] sail import: %v\n", err)
+				feedback.Warn("sail import: %v", err)
 			}
 		}
 	}
 
 	if hint, suggest := linkNextStep(linkSkipSetupPrompt); suggest {
 		if isInteractive() {
-			fmt.Print("\nRun lerd setup? [Y/n] ")
-			var answer string
-			fmt.Scanln(&answer) //nolint:errcheck
-			if answer == "" || answer[0] == 'Y' || answer[0] == 'y' {
+			if feedback.Confirm("Run lerd setup?", true) {
 				if err := runSetup(false, false); err != nil {
-					fmt.Printf("[WARN] setup: %v\n", err)
+					feedback.Warn("setup: %v", err)
 				}
 			}
 		} else {
@@ -393,11 +422,11 @@ func runLink(args []string) error {
 	if proj != nil {
 		if proj.Secured && !secured && cfg.DNSManaged() {
 			if err := runSecure(nil, []string{}); err != nil {
-				fmt.Printf("[WARN] securing site: %v\n", err)
+				feedback.Warn("securing site: %v", err)
 			}
 		} else if !proj.Secured && secured {
 			if err := runUnsecure(nil, []string{}); err != nil {
-				fmt.Printf("[WARN] disabling HTTPS: %v\n", err)
+				feedback.Warn("disabling HTTPS: %v", err)
 			}
 		}
 
@@ -407,6 +436,84 @@ func runLink(args []string) error {
 	}
 
 	return nil
+}
+
+// provisionAndSecure runs a PHP runtime's link finisher as plain HTTP under a
+// "provisioning" step, then, when the site is secured, issues its certificate
+// under a separate "generating certificate" step. Splitting the secure work out
+// of the finisher keeps mkcert's work on its own clean line instead of buried
+// inside the runtime step.
+func provisionAndSecure(label, result string, site config.Site, finish func(config.Site) error) error {
+	unsecured := site
+	unsecured.Secured = false
+	prov := feedback.Start(label)
+	if err := finish(unsecured); err != nil {
+		prov.Fail(err)
+		return err
+	}
+	prov.OK(result)
+
+	if site.Secured {
+		cert := feedback.Start("generating certificate")
+		if err := certs.SecureSite(site); err != nil {
+			cert.Fail(err)
+			return err
+		}
+		cert.OK("trusted")
+	}
+	return nil
+}
+
+// printLinkSummary prints the green success line and an aligned details block,
+// deriving every field from the registered site so callers don't repeat them.
+func printLinkSummary(site config.Site, start time.Time) {
+	// Reached on every successful link path, so this is where we record that the
+	// site is linked for this process (even when the summary itself is deferred).
+	linkApplied = true
+	if linkSkipSummary {
+		return
+	}
+	feedback.Success("linked", time.Since(start))
+
+	scheme := "http"
+	if site.Secured {
+		scheme = "https"
+	}
+	sum := feedback.NewSummary().Row("Site", feedback.Val(scheme+"://"+site.PrimaryDomain()))
+	switch {
+	case site.HostPort > 0:
+		sum.Row("Serving", fmt.Sprintf("host proxy · port %d", site.HostPort))
+	case site.ContainerPort > 0:
+		sum.Row("Serving", fmt.Sprintf("custom container · port %d", site.ContainerPort))
+	case site.PHPVersion != "":
+		sum.Row("PHP", feedback.Val(site.PHPVersion)+" · "+linkRuntimeLabel(site))
+	}
+	if site.NodeVersion != "" {
+		sum.Row("Node", feedback.Val(site.NodeVersion))
+	}
+	if site.Framework != "" {
+		sum.Row("Framework", site.Framework)
+	}
+	if env := sailReadRawEnv(site.Path); env["DB_CONNECTION"] != "" {
+		db := env["DB_CONNECTION"]
+		if cache := env["CACHE_STORE"]; cache != "" {
+			db += " · cache " + cache
+		}
+		sum.Row("DB", db)
+	}
+	sum.Print()
+}
+
+// linkRuntimeLabel names the serving runtime for the link summary's PHP row.
+func linkRuntimeLabel(site config.Site) string {
+	switch {
+	case site.IsFrankenPHP():
+		return "FrankenPHP"
+	case site.IsCustomFPM():
+		return "custom FPM"
+	default:
+		return "FPM"
+	}
 }
 
 // linkApplyServices installs and starts services declared in .lerd.yaml.
@@ -441,7 +548,7 @@ func linkApplyServices(cwd string, proj *config.ProjectConfig) error {
 			if _, err := config.LoadCustomService(svc.Name); err != nil {
 				fmt.Printf("  Installing preset %s%s\n", svc.Preset, presetVersionSuffix(svc.PresetVersion))
 				if _, err := InstallPresetByName(svc.Preset, svc.PresetVersion); err != nil {
-					fmt.Printf("[WARN] installing preset %s: %v\n", svc.Preset, err)
+					feedback.Warn("installing preset %s: %v", svc.Preset, err)
 					continue
 				}
 			}
@@ -484,13 +591,13 @@ func linkApplyServices(cwd string, proj *config.ProjectConfig) error {
 			}
 			if shouldSave {
 				if err := config.SaveCustomService(svc.Custom); err != nil {
-					fmt.Printf("[WARN] registering service %s: %v\n", svc.Name, err)
+					feedback.Warn("registering service %s: %v", svc.Name, err)
 					continue
 				}
 			}
 		}
 		if err := ensureServiceRunning(svc.Name); err != nil {
-			fmt.Printf("[WARN] service %s: %v\n", svc.Name, err)
+			feedback.Warn("service %s: %v", svc.Name, err)
 		}
 	}
 	return nil
@@ -520,7 +627,7 @@ func startWorkersForSite(site *config.Site, workers []string, phpVersion string)
 			}
 			baseURL := scheme + "://" + site.PrimaryDomain()
 			if err := StripeStartForSite(site.Name, site.Path, baseURL); err != nil {
-				fmt.Printf("[WARN] starting stripe listener: %v\n", err)
+				feedback.Warn("starting stripe listener: %v", err)
 			}
 			break
 		}
@@ -572,7 +679,7 @@ func startWorkersForSite(site *config.Site, workers []string, phpVersion string)
 			WorkerStopForSite(site.Name, site.Path, conflict) //nolint:errcheck
 		}
 		if err := WorkerStartForSite(site.Name, site.Path, phpVersion, w, worker, true); err != nil {
-			fmt.Printf("[WARN] starting worker %s: %v\n", w, err)
+			feedback.Warn("starting worker %s: %v", w, err)
 		}
 	}
 }

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/mcp"
 	"github.com/spf13/cobra"
 )
@@ -74,11 +75,12 @@ func runMCPInject(targetPath string) error {
 		return err
 	}
 
-	fmt.Printf("Injecting lerd MCP config into: %s\n\n", abs)
+	feedback.Begin()
+	feedback.Line("injecting lerd MCP config into " + feedback.Val(abs))
 	if err := WriteProjectAISkills(abs, true); err != nil {
 		return err
 	}
-	fmt.Println("\nDone! Restart your AI assistant to load the lerd MCP server.")
+	feedback.Done("done — restart your AI assistant to load the lerd MCP server")
 	return nil
 }
 
@@ -195,7 +197,8 @@ This command updates:
 // RunMCPEnableGlobal registers lerd MCP at user scope for all supported AI tools.
 // It is exported so the install command can call it directly.
 func RunMCPEnableGlobal() error {
-	fmt.Println("Registering lerd MCP globally...")
+	feedback.Begin()
+	feedback.Line("registering lerd MCP globally")
 
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -209,8 +212,8 @@ func RunMCPEnableGlobal() error {
 		return err
 	}
 
-	fmt.Println("\nDone! Restart your AI assistant for changes to take effect.")
-	fmt.Println("lerd will use the directory you open Claude in as the site context.")
+	feedback.Done("done — restart your AI assistant for changes to take effect")
+	feedback.Note("lerd uses the directory you open Claude in as the site context")
 	return nil
 }
 
@@ -323,7 +326,7 @@ func ensureClaudeMCPRegistered() {
 		return
 	}
 	if _, err := claudeMCP("add", "-s", "user", "lerd", "--", "lerd", "mcp"); err != nil {
-		fmt.Printf("  [WARN] could not register lerd with Claude Code: %v\n", err)
+		feedback.Warn("could not register lerd with Claude Code: %v", err)
 		fmt.Println("  Run manually: claude mcp add -s user lerd -- lerd mcp")
 	}
 }

--- a/internal/cli/migrate_tld.go
+++ b/internal/cli/migrate_tld.go
@@ -9,6 +9,7 @@ import (
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/nginx"
 	"github.com/geodro/lerd/internal/siteops"
@@ -134,7 +135,7 @@ func migrateSiteTLD(oldTLD, newTLD string, forceUnsecure bool) []string {
 		_ = config.SetProjectSecured(s.Path, s.Secured)
 		_ = config.SyncProjectDomains(s.Path, s.Domains, newTLD)
 
-		fmt.Printf("    --> %s: %s -> %s://%s\n", s.Name, oldPrimary, scheme, newPrimary)
+		feedback.Note(fmt.Sprintf("%s: %s → %s://%s", s.Name, oldPrimary, scheme, newPrimary))
 		changed = append(changed, s.Name)
 	}
 	return changed

--- a/internal/cli/minio_migrate.go
+++ b/internal/cli/minio_migrate.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
@@ -36,39 +37,43 @@ func runMinioMigrate(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("no MinIO data found at %s\nNothing to migrate", minioDataDir)
 	}
 
-	fmt.Println("Migrating MinIO data to RustFS...")
+	feedback.Begin()
+	feedback.Line("migrating MinIO data to RustFS")
 
 	// Stop minio if running.
 	status, _ := podman.UnitStatus("lerd-minio")
 	if status == "active" || status == "activating" {
-		fmt.Print("  Stopping lerd-minio...          ")
+		st := feedback.Start("stopping lerd-minio")
 		if err := podman.StopUnit("lerd-minio"); err != nil {
+			st.Fail(err)
 			return fmt.Errorf("could not stop lerd-minio: %w", err)
 		}
-		fmt.Println("done")
+		st.OK("")
 	}
 
 	// Remove minio quadlet so it no longer auto-starts.
-	fmt.Print("  Removing MinIO quadlet...       ")
+	rm := feedback.Start("removing MinIO quadlet")
 	if err := podman.RemoveQuadlet("lerd-minio"); err != nil && !os.IsNotExist(err) {
-		fmt.Printf("warn (%v)\n", err)
+		rm.Fail(err)
 	} else {
-		fmt.Println("done")
+		rm.OK("")
 	}
 	if err := podman.DaemonReloadFn(); err != nil {
 		fmt.Printf("  warn: daemon-reload failed: %v\n", err)
 	}
 
 	// Copy minio data to rustfs data dir.
-	fmt.Print("  Copying data directory...       ")
+	cpStep := feedback.Start("copying data directory")
 	if err := os.MkdirAll(rustfsDataDir, 0755); err != nil {
+		cpStep.Fail(err)
 		return fmt.Errorf("creating rustfs data dir: %w", err)
 	}
 	cp := exec.Command("cp", "-a", minioDataDir+"/.", rustfsDataDir+"/")
 	if out, err := cp.CombinedOutput(); err != nil {
+		cpStep.Fail(fmt.Errorf("%s", out))
 		return fmt.Errorf("copying data: %s", out)
 	}
-	fmt.Println("done")
+	cpStep.OK("")
 
 	// Update global config: disable minio entry if present, ensure rustfs exists.
 	cfg, err := config.LoadGlobal()
@@ -92,25 +97,23 @@ func runMinioMigrate(_ *cobra.Command, _ []string) error {
 	}
 
 	// Install and start RustFS.
-	fmt.Print("  Installing RustFS...            ")
+	inst := feedback.Start("installing RustFS")
 	if err := ensureServiceQuadlet("rustfs"); err != nil {
+		inst.Fail(err)
 		return fmt.Errorf("installing rustfs quadlet: %w", err)
 	}
-	fmt.Println("done")
+	inst.OK("")
 
-	fmt.Print("  Starting lerd-rustfs...         ")
+	startStep := feedback.Start("starting lerd-rustfs")
 	if err := podman.StartUnit("lerd-rustfs"); err != nil {
+		startStep.Fail(err)
 		return fmt.Errorf("starting lerd-rustfs: %w", err)
 	}
 	_ = config.SetServiceManuallyStarted("rustfs", true)
-	fmt.Println("done")
+	startStep.OK("")
 
-	fmt.Println()
-	fmt.Println("Migration complete.")
-	fmt.Println("  RustFS console: http://localhost:9001")
-	fmt.Println("  Credentials:    lerd / lerdpassword")
-	fmt.Println()
-	fmt.Printf("MinIO data directory at %s was not removed.\n", minioDataDir)
-	fmt.Println("Delete it manually once you have verified the migration: rm -rf " + minioDataDir)
+	feedback.Done("migration complete")
+	feedback.Note("RustFS console: http://localhost:9001 · credentials lerd / lerdpassword")
+	feedback.Note("MinIO data left at " + minioDataDir + " — delete once verified: rm -rf " + minioDataDir)
 	return nil
 }

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -6,8 +6,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 )
 
@@ -77,8 +79,10 @@ func runNew(target, frameworkName string, extraArgs []string) error {
 	parts = append(parts, target)
 	parts = append(parts, extraArgs...)
 
-	fmt.Printf("Creating new %s project at %s\n", fw.Label, target)
-	fmt.Printf("Running: %s\n\n", strings.Join(parts, " "))
+	start := time.Now()
+	feedback.Begin()
+	feedback.Line("scaffolding " + feedback.Val(fw.Label) + " · " + strings.Join(parts, " "))
+	fmt.Println()
 
 	cmd := exec.Command(parts[0], parts[1:]...)
 	cmd.Stdout = os.Stdout
@@ -89,10 +93,10 @@ func runNew(target, frameworkName string, extraArgs []string) error {
 		return fmt.Errorf("scaffold command failed: %w", err)
 	}
 
-	fmt.Printf("\nProject created at %s\n", target)
-	fmt.Printf("\nNext steps:\n")
-	fmt.Printf("  cd %s\n", target)
-	fmt.Printf("  lerd link\n")
-	fmt.Printf("  lerd setup\n")
+	feedback.Success("created "+filepath.Base(target), time.Since(start))
+	feedback.NewSummary().
+		Row("Path", target).
+		Row("Next", "cd "+filepath.Base(target)+" && lerd link && lerd setup").
+		Print()
 	return nil
 }

--- a/internal/cli/node_manage.go
+++ b/internal/cli/node_manage.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	nodeDet "github.com/geodro/lerd/internal/node"
 	"github.com/geodro/lerd/internal/podman"
@@ -29,22 +30,27 @@ func NewNodeManageCmd() *cobra.Command {
 
 func runNodeManage(_ *cobra.Command, _ []string) error {
 	if lerdManagesNode() {
-		fmt.Println("lerd is already managing Node.js.")
+		feedback.Begin()
+		feedback.Line("lerd is already managing Node.js")
 		return nil
 	}
 	fnmPath := filepath.Join(config.BinDir(), "fnm")
 	if _, err := os.Stat(fnmPath); err != nil {
 		return fmt.Errorf("fnm not found at %s — run 'lerd install' first", fnmPath)
 	}
-	fmt.Println("Installing fnm-managed node/npm/npx shims into", config.BinDir())
+	feedback.Begin()
+	step := feedback.Start("installing fnm-managed node/npm/npx shims")
 	if err := addShellShims(true); err != nil {
+		step.Fail(err)
 		return fmt.Errorf("writing shims: %w", err)
 	}
+	step.OK("")
 	ensureDefaultNode()
 	// Host workers (Vite etc.) were generated to run directly or via bun while
 	// Node was unmanaged; rewrite them so they route through fnm again.
 	regenerateHostWorkers()
-	fmt.Println("lerd is now managing Node.js. Pin a version per project with `lerd isolate:node <v>`.")
+	feedback.Done("lerd is now managing Node.js")
+	feedback.Note("pin a version per project with `lerd isolate:node <v>`")
 	return nil
 }
 
@@ -76,9 +82,9 @@ func runNodeUnmanage(_ *cobra.Command, _ []string) error {
 				}
 				seen[v] = true
 				if uo, uerr := exec.Command(fnmPath, "uninstall", v).CombinedOutput(); uerr != nil {
-					fmt.Printf("  [WARN] fnm uninstall %s: %s\n", v, string(uo))
+					feedback.Warn("fnm uninstall %s: %s", v, string(uo))
 				} else {
-					fmt.Printf("  removed Node %s\n", v)
+					feedback.Note("removed Node " + v)
 				}
 			}
 		}
@@ -93,16 +99,18 @@ func runNodeUnmanage(_ *cobra.Command, _ []string) error {
 	// Existing host worker units still reference `fnm exec --using=… -- npm …`,
 	// which now has no Node to run; rewrite them so they use bun (when present)
 	// or the user's system Node directly.
-	fmt.Println("Regenerating host worker units...")
+	feedback.Begin()
+	regen := feedback.Start("regenerating host worker units")
 	regenerateHostWorkers()
+	regen.OK("")
 
-	fmt.Println("lerd is no longer managing Node.js.")
+	feedback.Done("lerd is no longer managing Node.js")
 	if nodeDet.BunPath() != "" {
-		fmt.Println("bun is installed, so JS host workers (e.g. Vite) now run through bun.")
+		feedback.Note("bun is installed, so JS host workers (e.g. Vite) now run through bun")
 	} else {
-		fmt.Println("JS host workers (e.g. Vite) now use your system Node. Install bun or a system Node if you have neither.")
+		feedback.Note("JS host workers (e.g. Vite) now use your system Node; install bun or a system Node if you have neither")
 	}
-	fmt.Println("Re-enable lerd-managed Node with `lerd node:manage`.")
+	feedback.Note("re-enable lerd-managed Node with `lerd node:manage`")
 	return nil
 }
 
@@ -216,7 +224,7 @@ func regenerateWorkerUnit(siteName, sitePath, phpVersion, workerName string, wDe
 	unitPath := filepath.Join(config.SystemdUserDir(), unitName+".service")
 	before, _ := os.ReadFile(unitPath)
 	if err := WorkerStartForSite(siteName, sitePath, phpVersion, workerName, wDef, false); err != nil {
-		fmt.Printf("  [WARN] regenerating %s: %v\n", unitName, err)
+		feedback.Warn("regenerating %s: %v", unitName, err)
 		return
 	}
 	after, _ := os.ReadFile(unitPath)
@@ -233,8 +241,8 @@ func regenerateWorkerUnit(siteName, sitePath, phpVersion, workerName string, wDe
 	// would not heal it.
 	podman.ResetFailedUnit(unitName)
 	if err := podman.RestartUnit(unitName); err != nil {
-		fmt.Printf("  [WARN] restarting %s: %v\n", unitName, err)
+		feedback.Warn("restarting %s: %v", unitName, err)
 	} else {
-		fmt.Printf("  regenerated %s\n", unitName)
+		feedback.Note("regenerated " + unitName)
 	}
 }

--- a/internal/cli/node_use.go
+++ b/internal/cli/node_use.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 )
 
@@ -41,6 +42,7 @@ func runNodeUse(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Default Node.js version set to %s\n", major)
+	feedback.Begin()
+	feedback.Done("default Node set to " + feedback.Val(major))
 	return nil
 }

--- a/internal/cli/notify.go
+++ b/internal/cli/notify.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 )
 
@@ -79,13 +80,11 @@ func runNotifyStatus() error {
 	if err != nil {
 		return err
 	}
-	state := "disabled"
-	colour := "\033[33m"
+	state := feedback.Amber("disabled")
 	if cfg.IsNotificationsEnabled() {
-		state = "enabled"
-		colour = "\033[32m"
+		state = feedback.Green("enabled")
 	}
-	fmt.Printf("Notifications: %s%s\033[0m\n", colour, state)
+	fmt.Printf("Notifications: %s\n", state)
 	return nil
 }
 

--- a/internal/cli/octane.go
+++ b/internal/cli/octane.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/siteops"
 	"github.com/spf13/cobra"
@@ -76,10 +77,12 @@ func newOctaneReloadCmd(use string) *cobra.Command {
 				return err
 			}
 
+			feedback.Begin()
 			if enable {
-				fmt.Println("Octane auto-reload enabled, Octane will restart workers on file changes.")
+				feedback.Done("Octane auto-reload enabled")
+				feedback.Note("Octane restarts workers on file changes")
 			} else {
-				fmt.Println("Octane auto-reload disabled, Octane runs in standard mode.")
+				feedback.Done("Octane auto-reload disabled")
 			}
 			return nil
 		},

--- a/internal/cli/park.go
+++ b/internal/cli/park.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/nginx"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
@@ -86,7 +87,8 @@ func runPark(_ *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Printf("Parking directory: %s\n", absDir)
+	feedback.Begin()
+	feedback.Line("parking " + feedback.Val(absDir))
 
 	// Add to parked directories in global config
 	found := false
@@ -116,17 +118,18 @@ func runPark(_ *cobra.Command, args []string) error {
 		}
 		projectDir := filepath.Join(absDir, entry.Name())
 		if registered, err := RegisterProject(projectDir, cfg); err != nil {
-			fmt.Printf("  [WARN] could not register %s: %v\n", entry.Name(), err)
+			feedback.Warn("could not register %s: %v", entry.Name(), err)
 		} else if registered {
 			count++
 		}
 	}
 
 	if count > 0 {
-		fmt.Printf("Reloading nginx (%d sites registered)...\n", count)
+		reload := feedback.Start("reloading nginx")
 		nginx.ReloadOrWarn("  ")
+		reload.OK(fmt.Sprintf("%d site(s) registered", count))
 	} else {
-		fmt.Println("No PHP projects found in directory.")
+		feedback.Line("no PHP projects found in directory")
 	}
 
 	// Rewrite FPM quadlets so volume mounts cover the new parked directory.
@@ -176,7 +179,7 @@ func RegisterProject(projectDir string, cfg *config.GlobalConfig) (bool, error) 
 	// This prevents Laravel subdirs (app/, vendor/, public/, etc.) from being
 	// registered as sites when a project root is accidentally used as a park dir.
 	if _, ok := config.DetectFramework(filepath.Dir(projectDir)); ok {
-		fmt.Printf("  [WARN] skipping %s — looks like a subdirectory of a framework project.\n         Run 'lerd link' from %s instead.\n", projectDir, filepath.Dir(projectDir))
+		feedback.Warn("skipping %s — looks like a subdirectory of a framework project.\n         Run 'lerd link' from %s instead.", projectDir, filepath.Dir(projectDir))
 		return false, nil
 	}
 
@@ -258,7 +261,7 @@ func RegisterProject(projectDir string, cfg *config.GlobalConfig) (bool, error) 
 	if frameworkLabel == "" {
 		frameworkLabel = "unknown (public: " + detectedPublicDir + ")"
 	}
-	fmt.Printf("  + %s -> %s (PHP %s, Node %s, Framework: %s)\n", name, strings.Join(domains, ", "), phpVersion, nodeVersion, frameworkLabel)
+	feedback.Start("linking " + name).OK(feedback.Val(strings.Join(domains, ", ")) + " · php " + feedback.Val(phpVersion) + " · " + frameworkLabel)
 	return true, nil
 }
 

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/nginx"
 	phpDet "github.com/geodro/lerd/internal/php"
@@ -27,6 +28,7 @@ func NewPauseCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			feedback.Begin()
 			return PauseSite(name)
 		},
 	}
@@ -44,6 +46,7 @@ func NewUnpauseCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			feedback.Begin()
 			return UnpauseSite(name)
 		},
 	}
@@ -57,7 +60,7 @@ func PauseSite(name string) error {
 		return fmt.Errorf("site %q not found", name)
 	}
 	if site.Paused {
-		fmt.Printf("%s is already paused.\n", name)
+		feedback.Line(name + " is already paused")
 		return nil
 	}
 
@@ -108,10 +111,7 @@ func PauseSite(name string) error {
 
 	nginx.ReloadOrWarn("")
 
-	fmt.Printf("Paused: %s (%s)\n", name, site.PrimaryDomain())
-	if len(running) > 0 {
-		fmt.Printf("  Workers stopped: %s\n", strings.Join(running, ", "))
-	}
+	feedback.Start("pausing " + name).OK(feedback.Val(site.PrimaryDomain()))
 
 	autoStopUnusedServices()
 
@@ -168,7 +168,7 @@ func UnpauseSite(name string) error {
 		return fmt.Errorf("site %q not found", name)
 	}
 	if !site.Paused {
-		fmt.Printf("%s is not paused.\n", name)
+		feedback.Line(name + " is not paused")
 		return nil
 	}
 
@@ -249,7 +249,7 @@ func UnpauseSite(name string) error {
 			_ = podman.StartUnit(podman.CustomFPMContainerName(site.Name))
 		} else if phpVersion != "" {
 			if err := ensureFPMQuadlet(phpVersion); err != nil {
-				fmt.Printf("[WARN] ensuring FPM for PHP %s: %v\n", phpVersion, err)
+				feedback.Warn("ensuring FPM for PHP %s: %v", phpVersion, err)
 			}
 		}
 
@@ -294,16 +294,13 @@ func UnpauseSite(name string) error {
 
 	if site.LANPort != 0 {
 		if _, err := LANShareStart(site.Name); err != nil {
-			fmt.Printf("[WARN] restoring LAN share: %v\n", err)
+			feedback.Warn("restoring LAN share: %v", err)
 		}
 	}
 
 	// The shared paused.html is left in place for other paused sites.
 
-	fmt.Printf("Resumed: %s (%s)\n", name, site.PrimaryDomain())
-	if len(resumed) > 0 {
-		fmt.Printf("  Workers restarted: %s\n", strings.Join(resumed, ", "))
-	}
+	feedback.Start("resuming " + name).OK(feedback.Val(site.PrimaryDomain()))
 	return nil
 }
 
@@ -355,7 +352,7 @@ func startServicesForSiteNoticed(sitePath, siteName string) {
 			headerPrinted = true
 		}
 		if err := ensureServiceRunning(name); err != nil {
-			fmt.Printf("  [WARN] could not start %s: %v\n", name, err)
+			feedback.Warn("could not start %s: %v", name, err)
 		}
 	}
 }
@@ -640,14 +637,14 @@ func pauseWorktrees(site *config.Site) {
 		// host-proxy worktree's dev server (which also frees its host port). The
 		// unit suffix is the slugged checkout basename, so pass that.
 		if err := StopAllWorkersForWorktree(site.Name, filepath.Base(wt.Path)); err != nil {
-			fmt.Printf("  [WARN] stopping worktree workers %s: %v\n", wt.Domain, err)
+			feedback.Warn("stopping worktree workers %s: %v", wt.Domain, err)
 		}
 		if err := writePausedWorktreeHTML(wt, site); err != nil {
-			fmt.Printf("  [WARN] paused page for worktree %s: %v\n", wt.Domain, err)
+			feedback.Warn("paused page for worktree %s: %v", wt.Domain, err)
 			continue
 		}
 		if err := nginx.GeneratePausedWorktreeVhost(wt.Domain, site.PrimaryDomain(), config.PausedDir(), site.Secured); err != nil {
-			fmt.Printf("  [WARN] paused vhost for worktree %s: %v\n", wt.Domain, err)
+			feedback.Warn("paused vhost for worktree %s: %v", wt.Domain, err)
 		}
 	}
 }
@@ -663,7 +660,7 @@ func unpauseHostProxyWorktrees(site *config.Site) {
 	}
 	for _, wt := range worktrees {
 		if err := SetupHostProxyWorktree(*site, wt.Path, wt.Domain); err != nil {
-			fmt.Printf("  [WARN] restoring worktree %s: %v\n", wt.Domain, err)
+			feedback.Warn("restoring worktree %s: %v", wt.Domain, err)
 		}
 	}
 }
@@ -684,7 +681,7 @@ func unpauseWorktrees(site *config.Site, phpVersion string) {
 			vhostErr = nginx.GenerateWorktreeVhost(wt.Domain, wt.Path, effectivePHP, site.Name, wt.Branch)
 		}
 		if vhostErr != nil {
-			fmt.Printf("  [WARN] restoring worktree vhost %s: %v\n", wt.Domain, vhostErr)
+			feedback.Warn("restoring worktree vhost %s: %v", wt.Domain, vhostErr)
 		}
 	}
 }

--- a/internal/cli/php_bun.go
+++ b/internal/cli/php_bun.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
@@ -46,7 +47,8 @@ func newPhpBunUpdateCmd() *cobra.Command {
 			if !bunInstalledInContainer(version) {
 				return fmt.Errorf("bun is not installed in the PHP %s container — run: lerd php:bun install", version)
 			}
-			fmt.Printf("Updating bun in the PHP %s container...\n", version)
+			feedback.Begin()
+			feedback.Line("updating bun in the PHP " + version + " container")
 			up := podman.Cmd("exec", container, "/root/.bun/bin/bun", "upgrade")
 			up.Stdout = os.Stdout
 			up.Stderr = os.Stderr
@@ -54,7 +56,7 @@ func newPhpBunUpdateCmd() *cobra.Command {
 				return fmt.Errorf("bun upgrade: %w", err)
 			}
 			out, _ := podman.Cmd("exec", container, "/root/.bun/bin/bun", "--version").CombinedOutput()
-			fmt.Printf("bun is now %s in the PHP %s container.\n", strings.TrimSpace(string(out)), version)
+			feedback.Done("bun is now " + feedback.Val(strings.TrimSpace(string(out))) + " in the PHP " + version + " container")
 			return nil
 		},
 	}
@@ -257,11 +259,12 @@ func newPhpBunVersionCmd() *cobra.Command {
 				return fmt.Errorf("PHP %s FPM container is not running — start it with: %s", version, serviceStartHint(container))
 			}
 			out, err := podman.Cmd("exec", container, "/root/.bun/bin/bun", "--version").CombinedOutput()
+			feedback.Begin()
 			if err != nil {
-				fmt.Printf("bun is not installed in the PHP %s container — run: lerd php:bun install\n", version)
+				feedback.Line("bun is not installed in the PHP " + version + " container — run: lerd php:bun install")
 				return nil
 			}
-			fmt.Printf("bun %s (PHP %s container)\n", strings.TrimSpace(string(out)), version)
+			feedback.Line("bun " + feedback.Val(strings.TrimSpace(string(out))) + " (PHP " + version + " container)")
 			return nil
 		},
 	}

--- a/internal/cli/php_ext.go
+++ b/internal/cli/php_ext.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
@@ -59,9 +60,10 @@ func newPhpExtAddCmd() *cobra.Command {
 				return fmt.Errorf("saving config: %w", err)
 			}
 
-			fmt.Printf("Adding extension %q to PHP %s image...\n", ext, version)
+			feedback.Begin()
+			feedback.Line("adding extension " + feedback.Val(ext) + " to PHP " + version)
 			if len(deps) > 0 {
-				fmt.Printf("  with Alpine packages: %s\n", strings.Join(deps, " "))
+				feedback.Note("alpine packages: " + strings.Join(deps, " "))
 			}
 			if err := podman.RebuildFPMImage(version, false); err != nil {
 				return err
@@ -70,14 +72,14 @@ func newPhpExtAddCmd() *cobra.Command {
 			if err := podman.VerifyExtensionLoaded(version, ext); err != nil {
 				cfg.RemoveExtension(version, ext)
 				if saveErr := config.SaveGlobal(cfg); saveErr != nil {
-					fmt.Printf("[WARN] reverting config: %v\n", saveErr)
+					feedback.Warn("reverting config: %v", saveErr)
 				}
 				return fmt.Errorf("extension %q was not installed (config reverted): %w", ext, err)
 			}
 
 			applyPHPImageChange(version)
 
-			fmt.Printf("Extension %q installed for PHP %s.\n", ext, version)
+			feedback.Done("extension " + feedback.Val(ext) + " installed for PHP " + version)
 			return nil
 		},
 	}
@@ -110,14 +112,15 @@ func newPhpExtRemoveCmd() *cobra.Command {
 				return fmt.Errorf("saving config: %w", err)
 			}
 
-			fmt.Printf("Removing extension %q from PHP %s image...\n", ext, version)
+			feedback.Begin()
+			feedback.Line("removing extension " + feedback.Val(ext) + " from PHP " + version)
 			if err := podman.RebuildFPMImage(version, false); err != nil {
 				return err
 			}
 
 			applyPHPImageChange(version)
 
-			fmt.Printf("Extension %q removed for PHP %s.\n", ext, version)
+			feedback.Done("extension " + feedback.Val(ext) + " removed for PHP " + version)
 			return nil
 		},
 	}

--- a/internal/cli/php_ini.go
+++ b/internal/cli/php_ini.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
@@ -35,8 +36,9 @@ func runPhpIni(_ *cobra.Command, args []string) error {
 		return err
 	}
 	if !launched {
-		fmt.Printf("User ini file: %s\n", path)
-		fmt.Println("Set $EDITOR to open it automatically.")
+		feedback.Begin()
+		feedback.Line("user ini file: " + feedback.Val(path))
+		feedback.Note("set $EDITOR to open it automatically")
 		return nil
 	}
 
@@ -48,13 +50,15 @@ func runPhpIni(_ *cobra.Command, args []string) error {
 
 	short := strings.ReplaceAll(version, ".", "")
 	unit := "lerd-php" + short + "-fpm"
-	fmt.Printf("Saved. Restarting %s...\n", unit)
+	feedback.Begin()
+	step := feedback.Start("restarting " + unit)
 	if err := podman.RestartUnit(unit); err != nil {
+		step.Fail(err)
 		return fmt.Errorf("restarting %s: %w", unit, err)
 	}
 	// Per-site containers (FrankenPHP, custom-FPM) on this version mount the same
 	// user ini; restart them so the edit applies there too.
 	podman.RestartSiteContainersForVersion(version)
-	fmt.Println("Done.")
+	step.OK("")
 	return nil
 }

--- a/internal/cli/php_pkg.go
+++ b/internal/cli/php_pkg.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
@@ -71,7 +72,8 @@ func newPhpPkgAddCmd() *cobra.Command {
 				return fmt.Errorf("saving config: %w", err)
 			}
 
-			fmt.Printf("Adding packages to PHP %s image: %s\n", version, strings.Join(pkgs, " "))
+			feedback.Begin()
+			feedback.Line("adding packages to PHP " + version + ": " + feedback.Val(strings.Join(pkgs, " ")))
 			if err := podman.RebuildFPMImage(version, false); err != nil {
 				// A bad package name fails the build; revert so a broken entry
 				// doesn't linger in config and poison future rebuilds.
@@ -79,13 +81,13 @@ func newPhpPkgAddCmd() *cobra.Command {
 					cfg.RemovePackage(version, p)
 				}
 				if saveErr := config.SaveGlobal(cfg); saveErr != nil {
-					fmt.Printf("[WARN] reverting config: %v\n", saveErr)
+					feedback.Warn("reverting config: %v", saveErr)
 				}
 				return fmt.Errorf("rebuild failed (config reverted): %w", err)
 			}
 
 			applyPHPImageChange(version)
-			fmt.Printf("Packages installed for PHP %s.\n", version)
+			feedback.Done("packages installed for PHP " + version)
 			return nil
 		},
 	}
@@ -115,12 +117,13 @@ func newPhpPkgRemoveCmd() *cobra.Command {
 				return fmt.Errorf("saving config: %w", err)
 			}
 
-			fmt.Printf("Removing packages from PHP %s image: %s\n", version, strings.Join(args, " "))
+			feedback.Begin()
+			feedback.Line("removing packages from PHP " + version + ": " + feedback.Val(strings.Join(args, " ")))
 			if err := podman.RebuildFPMImage(version, false); err != nil {
 				return err
 			}
 			applyPHPImageChange(version)
-			fmt.Printf("Packages removed for PHP %s.\n", version)
+			feedback.Done("packages removed for PHP " + version)
 			return nil
 		},
 	}
@@ -164,9 +167,9 @@ func newPhpPkgListCmd() *cobra.Command {
 func restartFPMUnit(version string) {
 	unit := "lerd-php" + strings.ReplaceAll(version, ".", "") + "-fpm"
 	if err := podman.RestartUnit(unit); err != nil {
-		fmt.Printf("[WARN] restart %s: %v\n", unit, err)
+		feedback.Warn("restart %s: %v", unit, err)
 		fmt.Printf("Run: systemctl --user restart %s\n", unit)
 	} else {
-		fmt.Printf("FPM container restarted.\n")
+		feedback.Note("restarted " + unit)
 	}
 }

--- a/internal/cli/php_rebuild.go
+++ b/internal/cli/php_rebuild.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
@@ -65,9 +66,9 @@ func rebuildFrankenPHPForVersion(version string) {
 		return
 	}
 	for _, v := range versions {
-		fmt.Printf("Rebuilding FrankenPHP %s image so the change reaches Octane sites...\n", v)
+		feedback.Note("rebuilding FrankenPHP " + v + " image for Octane sites")
 		if err := podman.BuildFrankenPHPImage(v, false, os.Stdout); err != nil {
-			fmt.Printf("[WARN] rebuild FrankenPHP %s image: %v\n", v, err)
+			feedback.Warn("rebuild FrankenPHP %s image: %v", v, err)
 			fmt.Printf("       the change is live under FPM; run 'lerd php:rebuild %s' to retry the Octane image\n", v)
 			return
 		}
@@ -91,13 +92,13 @@ func applyPHPImageChange(version string) {
 func restartFrankenPHPUnits(units []frankenRestart) {
 	for _, u := range units {
 		if podman.RunSilent("image", "exists", podman.FrankenPHPImageName(u.version)) != nil {
-			fmt.Printf("  [WARN] %s: image not built, leaving container as-is\n", u.unit)
+			feedback.Warn("%s: image not built, leaving container as-is", u.unit)
 			continue
 		}
 		if err := podman.RestartUnit(u.unit); err != nil {
-			fmt.Printf("  [WARN] restart %s: %v\n", u.unit, err)
+			feedback.Warn("restart %s: %v", u.unit, err)
 		} else {
-			fmt.Printf("  restarted %s\n", u.unit)
+			feedback.Note("restarted " + u.unit)
 		}
 	}
 }
@@ -130,10 +131,11 @@ func runPhpRebuild(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(versions) == 0 {
-		fmt.Println("No PHP versions installed.")
+		feedback.Line("no PHP versions installed")
 		return nil
 	}
 
+	feedback.Begin()
 	jobs := make([]BuildJob, 0, len(versions))
 	for _, v := range versions {
 		ver := v
@@ -159,20 +161,20 @@ func runPhpRebuild(cmd *cobra.Command, args []string) error {
 
 	// Store the new Containerfile hash so future updates know images are current.
 	if err := podman.StoreFPMHash(); err != nil {
-		fmt.Printf("  [WARN] could not store image hash: %v\n", err)
+		feedback.Warn("could not store image hash: %v", err)
 	}
 
 	label := "PHP-FPM images"
 	if len(versions) == 1 {
 		label = "PHP " + versions[0] + " image"
 	}
-	fmt.Printf("\n%s rebuilt. Restarting containers...\n", label)
+	feedback.Line("restarting containers")
 	for _, v := range versions {
 		unit := "lerd-php" + strings.ReplaceAll(v, ".", "") + "-fpm"
 		if err := podman.RestartUnit(unit); err != nil {
-			fmt.Printf("  [WARN] restart %s: %v\n", unit, err)
+			feedback.Warn("restart %s: %v", unit, err)
 		} else {
-			fmt.Printf("  restarted %s\n", unit)
+			feedback.Note("restarted " + unit)
 		}
 	}
 
@@ -182,12 +184,13 @@ func runPhpRebuild(cmd *cobra.Command, args []string) error {
 	for _, unit := range append(append(registeredReverbUnits(), registeredQueueUnits()...), registeredScheduleUnits()...) {
 		if lerdSystemd.IsServiceActive(unit) || lerdSystemd.IsServiceEnabled(unit) {
 			if err := lerdSystemd.RestartService(unit); err != nil {
-				fmt.Printf("  [WARN] restart %s: %v\n", unit, err)
+				feedback.Warn("restart %s: %v", unit, err)
 			} else {
-				fmt.Printf("  restarted %s\n", unit)
+				feedback.Note("restarted " + unit)
 			}
 		}
 	}
 
+	feedback.Done(label + " rebuilt")
 	return nil
 }

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/profiler"
 	"github.com/spf13/cobra"
 )
@@ -107,11 +108,11 @@ func runProfileStatus(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	state, colour := "off", colorYellow
+	state := feedback.Amber("off")
 	if cfg.IsProfilerEnabled() {
-		state, colour = "on", colorGreen
+		state = feedback.Green("on")
 	}
-	fmt.Printf("Profiler:   %s%s%s\n", colour, state, colorReset)
+	fmt.Printf("Profiler:   %s\n", state)
 	fmt.Printf("SPX web UI: %s\n", profiler.SpxUIURL)
 	return nil
 }

--- a/internal/cli/rebuild.go
+++ b/internal/cli/rebuild.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
@@ -46,7 +47,8 @@ func RebuildSite(name string) error {
 	// Remove old image so build starts fresh.
 	_ = podman.RemoveCustomImage(name)
 
-	fmt.Printf("Building %s...\n", podman.CustomImageName(name))
+	feedback.Begin()
+	feedback.Line("building " + podman.CustomImageName(name))
 	if err := podman.BuildCustomImage(name, site.Path, proj.Container); err != nil {
 		return err
 	}
@@ -64,6 +66,6 @@ func RebuildSite(name string) error {
 		}
 	}
 
-	fmt.Printf("Rebuilt and restarted: %s\n", name)
+	feedback.Done("rebuilt and restarted " + feedback.Val(name))
 	return nil
 }

--- a/internal/cli/remote_control.go
+++ b/internal/cli/remote_control.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/term"
@@ -116,11 +117,11 @@ Re-running this command rotates the password.`,
 				return fmt.Errorf("saving config: %w", err)
 			}
 
-			fmt.Println("Remote dashboard access enabled.")
-			fmt.Printf("  Username: %s\n", username)
-			fmt.Println("  LAN clients can now reach http://<server-ip>:7073 with HTTP Basic auth.")
-			fmt.Println("  Loopback (127.0.0.1) bypasses authentication as always.")
-			fmt.Println("  Run `lerd remote-control off` to lock LAN access back down.")
+			feedback.Begin()
+			feedback.Done("remote dashboard access enabled (user: " + feedback.Val(username) + ")")
+			feedback.Note("LAN clients can now reach http://<server-ip>:7073 with HTTP Basic auth")
+			feedback.Note("loopback (127.0.0.1) bypasses authentication as always")
+			feedback.Note("run `lerd remote-control off` to lock LAN access back down")
 			return nil
 		},
 	}
@@ -147,7 +148,8 @@ the password — you cannot lock yourself out of your own machine.`,
 			if err := config.SaveGlobal(cfg); err != nil {
 				return fmt.Errorf("saving config: %w", err)
 			}
-			fmt.Println("Remote dashboard access disabled. LAN clients now get 403 Forbidden.")
+			feedback.Begin()
+			feedback.Done("remote dashboard access disabled — LAN clients now get 403 Forbidden")
 			return nil
 		},
 	}
@@ -162,17 +164,16 @@ func newRemoteControlStatusCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("loading config: %w", err)
 			}
+			feedback.Begin()
 			if cfg.UI.PasswordHash == "" {
-				fmt.Println("Remote dashboard access: DISABLED")
-				fmt.Println("  LAN clients get 403 Forbidden. Loopback (127.0.0.1) is always allowed.")
-				fmt.Println("  Enable with: lerd remote-control on")
+				feedback.Line("remote dashboard access: " + feedback.Amber("disabled"))
+				feedback.Note("LAN clients get 403 Forbidden; loopback (127.0.0.1) is always allowed")
+				feedback.Note("enable with: lerd remote-control on")
 				return nil
 			}
-			fmt.Println("Remote dashboard access: ENABLED")
-			fmt.Printf("  Username: %s\n", cfg.UI.Username)
-			fmt.Println("  LAN clients must present HTTP Basic auth.")
-			fmt.Println("  Loopback (127.0.0.1) bypasses authentication.")
-			fmt.Println("  Disable with: lerd remote-control off")
+			feedback.Line("remote dashboard access: " + feedback.Green("enabled") + " (user: " + cfg.UI.Username + ")")
+			feedback.Note("LAN clients must present HTTP Basic auth; loopback bypasses it")
+			feedback.Note("disable with: lerd remote-control off")
 			return nil
 		},
 	}
@@ -214,7 +215,7 @@ func promptAndPersistRemoteControl() error {
 	if err := config.SaveGlobal(cfg); err != nil {
 		return fmt.Errorf("saving config: %w", err)
 	}
-	fmt.Printf("  Saved dashboard credentials for %s.\n", username)
+	feedback.Note("saved dashboard credentials for " + username)
 	return nil
 }
 

--- a/internal/cli/remote_setup.go
+++ b/internal/cli/remote_setup.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 )
 
@@ -163,7 +164,8 @@ Re-run this command to generate a new code if it expires or is consumed.`,
 				if err := ClearRemoteSetupToken(); err != nil {
 					return fmt.Errorf("revoking token: %w", err)
 				}
-				fmt.Println("Remote setup token revoked.")
+				feedback.Begin()
+				feedback.Done("remote setup token revoked")
 				return nil
 			}
 
@@ -177,15 +179,18 @@ Re-run this command to generate a new code if it expires or is consumed.`,
 			// dnsmasq config / lerd-ui bind. The whole point of generating
 			// a setup code is to provision a remote device, which can't
 			// work unless lerd is reachable from the LAN.
-			fmt.Println("Ensuring lerd is exposed on the LAN...")
+			feedback.Begin()
+			expose := feedback.Start("exposing lerd on the LAN")
 			lanIP, err := EnableLANExposure(func(step string) {
-				fmt.Printf("  • %s\n", step)
+				feedback.Note(step)
 			})
 			if err != nil {
+				expose.Fail(err)
 				return fmt.Errorf("enabling lan:expose: %w", err)
 			}
-			fmt.Printf("  lerd-dns-forwarder running on %s:5300 (UDP+TCP), answering *.test → %s\n", lanIP, lanIP)
-			fmt.Println("  Make sure your firewall allows port 5300 from the devices you want to grant access.")
+			expose.OK(feedback.Val(lanIP))
+			feedback.Note("lerd-dns-forwarder on " + lanIP + ":5300 (UDP+TCP), answering *.test → " + lanIP)
+			feedback.Note("allow port 5300 through your firewall from the devices you want to grant access")
 
 			code, err := GenerateRemoteSetupToken(ttl)
 			if err != nil {
@@ -194,8 +199,7 @@ Re-run this command to generate a new code if it expires or is consumed.`,
 
 			lanIP, ipErr := detectPrimaryLANIP()
 			fmt.Println()
-			fmt.Printf("  Code: %s\n", code)
-			fmt.Printf("  Expires in: %s\n", ttl)
+			feedback.Done("code: " + feedback.Val(code) + " (expires in " + ttl.String() + ")")
 			fmt.Println()
 			fmt.Println("On the laptop, run:")
 			fmt.Println()
@@ -203,7 +207,7 @@ Re-run this command to generate a new code if it expires or is consumed.`,
 				fmt.Printf("  curl -sSL 'http://%s:7073/api/remote-setup?code=%s' | bash\n", lanIP, code)
 			} else {
 				fmt.Printf("  curl -sSL 'http://<server-ip>:7073/api/remote-setup?code=%s' | bash\n", code)
-				fmt.Fprintln(os.Stderr, "warning: could not auto-detect a LAN IP — substitute the server's address yourself")
+				feedback.Warn("could not auto-detect a LAN IP — substitute the server's address yourself")
 			}
 			fmt.Println()
 			fmt.Println("The endpoint is restricted to RFC 1918 private source IPs and the code")

--- a/internal/cli/restart.go
+++ b/internal/cli/restart.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
@@ -21,6 +22,7 @@ func NewRestartCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			feedback.Begin()
 			return RestartSite(name)
 		},
 	}
@@ -39,7 +41,7 @@ func RestartSite(name string) error {
 		if err := podman.RestartUnit(unit); err != nil {
 			return fmt.Errorf("restarting container: %w", err)
 		}
-		fmt.Printf("Restarted: %s (%s)\n", name, unit)
+		feedback.Done("restarted " + feedback.Val(name) + " · " + unit)
 		return nil
 	}
 
@@ -48,7 +50,7 @@ func RestartSite(name string) error {
 		if err := podman.RestartUnit(unit); err != nil {
 			return fmt.Errorf("restarting FrankenPHP container: %w", err)
 		}
-		fmt.Printf("Restarted: %s (%s)\n", name, unit)
+		feedback.Done("restarted " + feedback.Val(name) + " · " + unit)
 		return nil
 	}
 
@@ -57,7 +59,7 @@ func RestartSite(name string) error {
 		if err := podman.RestartUnit(unit); err != nil {
 			return fmt.Errorf("restarting custom FPM container: %w", err)
 		}
-		fmt.Printf("Restarted: %s (%s)\n", name, unit)
+		feedback.Done("restarted " + feedback.Val(name) + " · " + unit)
 		return nil
 	}
 
@@ -69,7 +71,7 @@ func RestartSite(name string) error {
 		if err := podman.RestartUnit(unit); err != nil {
 			return fmt.Errorf("restarting dev server: %w", err)
 		}
-		fmt.Printf("Restarted: %s (%s)\n", name, unit)
+		feedback.Done("restarted " + feedback.Val(name) + " · " + unit)
 		return nil
 	}
 
@@ -87,6 +89,6 @@ func RestartSite(name string) error {
 	if err := podman.RestartUnit(unit); err != nil {
 		return fmt.Errorf("restarting %s: %w", unit, err)
 	}
-	fmt.Printf("Restarted: %s (%s)\n", name, unit)
+	feedback.Done("restarted " + feedback.Val(name) + " · " + unit)
 	return nil
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1,14 +1,13 @@
 package cli
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 )
 
@@ -94,8 +93,9 @@ func resolveCommandsForCwd(cwd string) []config.FrameworkCommand {
 
 func listCommands(cmds []config.FrameworkCommand) error {
 	if len(cmds) == 0 {
-		fmt.Println("No commands available for this project.")
-		fmt.Println("Add a commands: block to .lerd.yaml or install the framework store.")
+		feedback.Begin()
+		feedback.Line("no commands available for this project")
+		feedback.Note("add a commands: block to .lerd.yaml or install the framework store")
 		return nil
 	}
 	maxName := 0
@@ -136,12 +136,7 @@ func runNamedCommand(cwd string, cmds []config.FrameworkCommand, name string, as
 	}
 
 	if target.Confirm && !assumeYes {
-		fmt.Printf("This will run: %s\n", target.Command)
-		fmt.Printf("Continue? [y/N] ")
-		reader := bufio.NewReader(os.Stdin)
-		line, _ := reader.ReadString('\n')
-		ans := strings.ToLower(strings.TrimSpace(line))
-		if ans != "y" && ans != "yes" {
+		if !feedback.Confirm("This will run: "+target.Command+"\nContinue?", false) {
 			return fmt.Errorf("aborted")
 		}
 	}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/nginx"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteops"
@@ -67,10 +68,11 @@ func runRuntime(cmd *cobra.Command, args []string) error {
 	worker, _ := cmd.Flags().GetBool("worker")
 	noWorker, _ := cmd.Flags().GetBool("no-worker")
 
+	feedback.Begin()
 	switch target {
 	case "fpm":
 		if !site.IsFrankenPHP() {
-			fmt.Println("Already on FPM runtime.")
+			feedback.Line("already on FPM runtime")
 			return nil
 		}
 		return switchToFPM(site)
@@ -88,7 +90,7 @@ func runRuntime(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("site has no framework assigned — FrankenPHP needs a framework entrypoint or the generic public/ fallback")
 		}
 		if fw.FrankenPHP == nil && fw.PublicDir == "" {
-			fmt.Println("[INFO] framework has no FrankenPHP adapter, falling back to the generic `frankenphp php-server` entrypoint")
+			feedback.Note("framework has no FrankenPHP adapter, using the generic `frankenphp php-server` entrypoint")
 		}
 		wantWorker := site.RuntimeWorker
 		if worker {
@@ -193,7 +195,7 @@ func switchToFPM(site *config.Site) error {
 	// instead of the per-site FrankenPHP one that no longer exists.
 	startWorkersForSite(site, running, site.PHPVersion)
 
-	fmt.Printf("Runtime: fpm (switched from FrankenPHP)\n")
+	feedback.Done("runtime switched to " + feedback.Val("fpm"))
 	return nil
 }
 
@@ -223,6 +225,6 @@ func switchToFrankenPHP(site *config.Site, worker bool) error {
 	if worker {
 		label = "frankenphp (worker mode)"
 	}
-	fmt.Printf("Runtime: %s\n", label)
+	feedback.Done("runtime switched to " + feedback.Val(label))
 	return nil
 }

--- a/internal/cli/secure.go
+++ b/internal/cli/secure.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/siteops"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/spf13/cobra"
@@ -76,23 +77,21 @@ func toggleSecureCmd(args []string, secured bool) error {
 			return certs.ErrDNSDisabled
 		}
 	}
-	verb := "Issuing certificate"
+	verb := "enabling HTTPS"
 	if !secured {
-		verb = "Removing certificate"
+		verb = "disabling HTTPS"
 	}
-	fmt.Printf("%s for %s...\n", verb, site.PrimaryDomain())
-
+	feedback.Begin()
+	step := feedback.Start(verb)
 	if err := siteops.SetSecured(site, secured); err != nil {
+		step.Fail(err)
 		return err
 	}
 	scheme := "http"
-	state := "Unsecured"
 	if secured {
 		scheme = "https"
-		state = "Secured"
 	}
-	fmt.Printf("  Updated APP_URL=%s://%s and VITE_REVERB_* in .env\n", scheme, site.PrimaryDomain())
-	fmt.Printf("%s: %s://%s\n", state, scheme, site.PrimaryDomain())
+	step.OK(feedback.Val(scheme + "://" + site.PrimaryDomain()))
 	return nil
 }
 
@@ -115,11 +114,11 @@ func restartStripeIfActive(site *config.Site) {
 	}
 	baseURL := scheme + "://" + site.PrimaryDomain()
 	if err := StripeStartForSite(site.Name, site.Path, baseURL); err != nil {
-		fmt.Printf("[WARN] updating stripe listener unit: %v\n", err)
+		feedback.Warn("updating stripe listener unit: %v", err)
 		return
 	}
 	if err := lerdSystemd.RestartService(unitName); err != nil {
-		fmt.Printf("[WARN] restarting stripe listener: %v\n", err)
+		feedback.Warn("restarting stripe listener: %v", err)
 		return
 	}
 	fmt.Printf("  Restarted stripe listener → %s%s\n", baseURL, config.StripeWebhookPath(site.Path))

--- a/internal/cli/service_config.go
+++ b/internal/cli/service_config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/serviceops"
 	"github.com/spf13/cobra"
@@ -90,8 +91,9 @@ func newServiceConfigCmd() *cobra.Command {
 				return err
 			}
 			if !launched {
-				fmt.Printf("Tuning file: %s\n", path)
-				fmt.Println("Set $EDITOR to open it automatically.")
+				feedback.Begin()
+				feedback.Line("tuning file: " + feedback.Val(path))
+				feedback.Note("set $EDITOR to open it automatically")
 				return nil
 			}
 
@@ -105,15 +107,19 @@ func newServiceConfigCmd() *cobra.Command {
 				return err
 			}
 			if noRestart {
-				fmt.Printf("Saved %s. Run `lerd service restart %s` to apply.\n", path, name)
+				feedback.Begin()
+				feedback.Done("saved " + path)
+				feedback.Note("run `lerd service restart " + name + "` to apply")
 				return nil
 			}
 			unit := "lerd-" + name
-			fmt.Printf("Saved. Restarting %s...\n", unit)
+			feedback.Begin()
+			step := feedback.Start("restarting " + unit)
 			if err := podman.RestartUnit(unit); err != nil {
+				step.Fail(err)
 				return fmt.Errorf("restarting %s: %w", unit, err)
 			}
-			fmt.Println("Done.")
+			step.OK("")
 			return nil
 		},
 	}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/serviceops"
@@ -108,17 +109,20 @@ func newServiceStartCmd() *cobra.Command {
 				}
 			}
 
-			fmt.Printf("Starting %s...\n", unit)
+			feedback.Begin()
+			svcStep := feedback.Start("starting " + unit)
 			if err := podman.StartUnit(unit); err != nil {
+				svcStep.Fail(err)
 				return err
 			}
+			svcStep.OK("")
 			_ = config.SetServicePaused(name, false)
 			_ = config.SetServiceManuallyStarted(name, true)
 
 			// Start any custom services that depend on this one.
 			for _, dep := range config.CustomServicesDependingOn(name) {
 				if err := ensureServiceRunning(dep); err != nil {
-					fmt.Printf("  [WARN] could not start dependent service %s: %v\n", dep, err)
+					feedback.Warn("could not start dependent service %s: %v", dep, err)
 				}
 			}
 
@@ -141,7 +145,10 @@ func newServiceStopCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			name := args[0]
+			feedback.Begin()
+			step := feedback.Start("stopping " + name)
 			StopServiceAndDependents(name)
+			step.OK("")
 			_ = config.SetServicePaused(name, true)
 			_ = config.SetServiceManuallyStarted(name, false)
 			if fam := serviceops.ServiceFamily(name); fam != "" {
@@ -171,10 +178,10 @@ func serviceUpdateHint(name, status string) string {
 	}
 	parts := []string{}
 	if avail.Available && avail.LatestTag != "" {
-		parts = append(parts, "\033[32m→ "+avail.LatestTag+"\033[0m")
+		parts = append(parts, feedback.Green("→ "+avail.LatestTag))
 	}
 	if avail.UpgradeTag != "" {
-		parts = append(parts, "\033[33m⇧ "+avail.UpgradeTag+"\033[0m")
+		parts = append(parts, feedback.Amber("⇧ "+avail.UpgradeTag))
 	}
 	return strings.Join(parts, " ")
 }
@@ -209,25 +216,26 @@ v1.7.6 → v1.42.1) — this may require manual data migration; you've been warn
 			emit := func(ev serviceops.PhaseEvent) {
 				switch ev.Phase {
 				case "checking_registry":
-					fmt.Println("Checking registry...")
+					feedback.Line("checking registry")
 				case "pulling_image":
 					if ev.Message != "" {
-						fmt.Println("  " + strings.TrimSpace(ev.Message))
+						feedback.Note(strings.TrimSpace(ev.Message))
 					} else if ev.Image != "" {
-						fmt.Println("Pulling " + ev.Image)
+						feedback.Line("pulling " + ev.Image)
 					}
 				case "writing_quadlet":
-					fmt.Println("Writing quadlet for " + ev.Image)
+					feedback.Line("writing quadlet for " + ev.Image)
 				case "restarting_unit":
-					fmt.Println("Restarting " + ev.Unit)
+					feedback.Line("restarting " + ev.Unit)
 				case "done":
 					if ev.Message != "" {
-						fmt.Println(ev.Message)
+						feedback.Done(ev.Message)
 					} else {
-						fmt.Println("Done. Now on " + ev.Image)
+						feedback.Done("now on " + feedback.Val(ev.Image))
 					}
 				}
 			}
+			feedback.Begin()
 			return serviceops.UpdateServiceStreaming(name, targetImage, emit)
 		},
 	}
@@ -265,35 +273,36 @@ Supported families: mysql, mariadb, postgres.`,
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Migrating %s: %s → %s\n", name, avail.CurrentImage, targetImage)
-			fmt.Println("Dumps and the previous data dir will be preserved under ~/.local/share/lerd/backups.")
+			feedback.Begin()
+			feedback.Line("migrating " + name + ": " + avail.CurrentImage + " → " + feedback.Val(targetImage))
+			feedback.Note("dumps and the previous data dir are kept under ~/.local/share/lerd/backups")
 			emit := func(ev serviceops.PhaseEvent) {
 				switch ev.Phase {
 				case "dumping_data":
-					fmt.Println("Dumping: " + ev.Message)
+					feedback.Line("dumping: " + ev.Message)
 				case "stopping_unit":
-					fmt.Println("Stopping " + ev.Unit)
+					feedback.Line("stopping " + ev.Unit)
 				case "swapping_data_dir":
-					fmt.Println("Moving data dir aside")
+					feedback.Line("moving data dir aside")
 				case "pulling_image":
 					if ev.Message != "" {
-						fmt.Println("  " + strings.TrimSpace(ev.Message))
+						feedback.Note(strings.TrimSpace(ev.Message))
 					} else if ev.Image != "" {
-						fmt.Println("Pulling " + ev.Image)
+						feedback.Line("pulling " + ev.Image)
 					}
 				case "writing_quadlet":
-					fmt.Println("Writing quadlet for " + ev.Image)
+					feedback.Line("writing quadlet for " + ev.Image)
 				case "restarting_unit":
-					fmt.Println("Restarting " + ev.Unit)
+					feedback.Line("restarting " + ev.Unit)
 				case "waiting_ready":
-					fmt.Println("Waiting for new container to be ready")
+					feedback.Line("waiting for the new container to be ready")
 				case "restoring_data":
-					fmt.Println("Restoring " + ev.Message)
+					feedback.Line("restoring " + ev.Message)
 				case "done":
 					if ev.Message != "" {
-						fmt.Println(ev.Message)
+						feedback.Note(ev.Message)
 					}
-					fmt.Println("Migration complete.")
+					feedback.Done("migration complete")
 				}
 			}
 			return serviceops.MigrateService(name, targetImage, emit)
@@ -315,18 +324,19 @@ Errors when no previous image is recorded — i.e. the service was never updated
 				switch ev.Phase {
 				case "pulling_image":
 					if ev.Message != "" {
-						fmt.Println("  " + strings.TrimSpace(ev.Message))
+						feedback.Note(strings.TrimSpace(ev.Message))
 					} else if ev.Image != "" {
-						fmt.Println("Pulling " + ev.Image)
+						feedback.Line("pulling " + ev.Image)
 					}
 				case "writing_quadlet":
-					fmt.Println("Writing quadlet for " + ev.Image)
+					feedback.Line("writing quadlet for " + ev.Image)
 				case "restarting_unit":
-					fmt.Println("Restarting " + ev.Unit)
+					feedback.Line("restarting " + ev.Unit)
 				case "done":
-					fmt.Println("Rolled back to " + ev.Image)
+					feedback.Done("rolled back to " + feedback.Val(ev.Image))
 				}
 			}
+			feedback.Begin()
 			return serviceops.RollbackService(name, emit)
 		},
 	}
@@ -353,10 +363,13 @@ func newServiceRestartCmd() *cobra.Command {
 					fmt.Fprintf(os.Stderr, "[WARN] regenerating quadlet for %s failed: %v; restarting with the existing one\n", name, err)
 				}
 			}
-			fmt.Printf("Restarting %s...\n", unit)
+			feedback.Begin()
+			svcStep := feedback.Start("restarting " + unit)
 			if err := podman.RestartUnit(unit); err != nil {
+				svcStep.Fail(err)
 				return err
 			}
+			svcStep.OK("")
 			printEnvVars(name)
 			return nil
 		},
@@ -711,19 +724,19 @@ func newServiceRemoveCmd() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			name := args[0]
 
+			feedback.Begin()
 			if purge {
-				dataPath := config.DataSubDir(name)
-				fmt.Printf("Removing service %q and ALL its data at %s.\n", name, dataPath)
+				feedback.Note("removing service " + name + " and ALL its data at " + config.DataSubDir(name))
 			}
 
 			emit := func(e serviceops.PhaseEvent) {
 				switch e.Phase {
 				case "stopping_unit":
-					fmt.Printf("Stopping %s...\n", e.Unit)
+					feedback.Line("stopping " + e.Unit)
 				case "removing_data":
-					fmt.Printf("Renaming data dir aside: %s\n", e.Message)
+					feedback.Line("renaming data dir aside: " + e.Message)
 				case "done":
-					fmt.Printf("Removed service %q.\n", name)
+					feedback.Done("removed service " + feedback.Val(name))
 				}
 			}
 
@@ -753,28 +766,29 @@ func newServiceReinstallCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			name := args[0]
+			feedback.Begin()
 			emit := func(e serviceops.PhaseEvent) {
 				switch e.Phase {
 				case "reinstall_starting":
-					fmt.Printf("Reinstalling %s...\n", name)
+					feedback.Line("reinstalling " + name)
 				case "stopping_unit":
-					fmt.Printf("  stopping %s\n", e.Unit)
+					feedback.Note("stopping " + e.Unit)
 				case "removing_data":
-					fmt.Printf("  renaming data dir aside: %s\n", e.Message)
+					feedback.Note("renaming data dir aside: " + e.Message)
 				case "pulling_image":
 					if e.Message == "" && e.Image != "" {
-						fmt.Printf("  pulling %s\n", e.Image)
+						feedback.Note("pulling " + e.Image)
 					}
 				case "starting_unit":
-					fmt.Printf("  starting %s\n", e.Unit)
+					feedback.Note("starting " + e.Unit)
 				case "waiting_ready":
-					fmt.Printf("  waiting for %s to be ready\n", e.Unit)
+					feedback.Note("waiting for " + e.Unit + " to be ready")
 				case "reprovisioning_sites":
-					fmt.Printf("  reprovisioning linked sites: %s\n", e.Message)
+					feedback.Note("reprovisioning linked sites: " + e.Message)
 				case "reprovisioning_site":
-					fmt.Printf("    %s\n", e.Message)
+					feedback.Note(e.Message)
 				case "reprovisioning_skipped":
-					fmt.Printf("  reprovisioning skipped: %s\n", e.Message)
+					feedback.Note("reprovisioning skipped: " + e.Message)
 				}
 			}
 			if err := serviceops.ReinstallService(name, resetData, emit); err != nil {
@@ -920,7 +934,7 @@ func newServicePinCmd() *cobra.Command {
 			}
 			fmt.Printf("Pinned %s — it will not be auto-stopped when no sites use it.\n", name)
 			if err := ensureServiceRunning(name); err != nil {
-				fmt.Printf("  [WARN] could not start %s: %v\n", name, err)
+				feedback.Warn("could not start %s: %v", name, err)
 			}
 			return nil
 		},
@@ -1048,7 +1062,7 @@ func autoStopUnusedFPMs() {
 		status, _ := podman.UnitStatus(unit)
 		if status == "active" || status == "activating" {
 			if err := podman.StopUnit(unit); err != nil {
-				fmt.Printf("[WARN] stopping %s: %v\n", unit, err)
+				feedback.Warn("stopping %s: %v", unit, err)
 			}
 		}
 	}
@@ -1067,11 +1081,11 @@ func serviceInactiveReason(name string) string {
 func colorStatus(status string) string {
 	switch status {
 	case "active":
-		return "\033[32m" + status + "\033[0m"
+		return feedback.Green(status)
 	case "inactive":
-		return "\033[33m" + status + "\033[0m"
+		return feedback.Amber(status)
 	case "failed":
-		return "\033[31m" + status + "\033[0m"
+		return feedback.Red(status)
 	default:
 		return status
 	}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -8,10 +8,12 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/huh"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/feedback"
 	nodeDet "github.com/geodro/lerd/internal/node"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
@@ -93,10 +95,15 @@ func runSetup(allSteps, skipOpen bool) error {
 	}
 
 	// Run init wizard (or apply saved .lerd.yaml) before any other step so
-	// PHP version, HTTPS, and services are configured first.
-	fmt.Println("→ Configuring site...")
+	// PHP version, HTTPS, and services are configured first. When a link already
+	// ran in this process (the "Run lerd setup?" prompt), the configure phase is
+	// a no-op, so skip the header and go straight to the steps.
+	feedback.Begin()
+	if !linkApplied {
+		feedback.Line("configuring site")
+	}
 	if err := runSetupInit(cwd, allSteps); err != nil {
-		fmt.Printf("  [WARN] %v\n", err)
+		feedback.Warn("%v", err)
 	}
 
 	site, _ := config.FindSiteByPath(cwd)
@@ -233,7 +240,7 @@ func runSetup(allSteps, skipOpen bool) error {
 					return nil
 				}
 				if err := installContainerBun(bunPHPVersion, "", os.Stdout); err != nil {
-					fmt.Printf("  [WARN] could not install bun in the container: %v\n", err)
+					feedback.Warn("could not install bun in the container: %v", err)
 				}
 				return nil
 			},
@@ -259,7 +266,7 @@ func runSetup(allSteps, skipOpen bool) error {
 				enabled: false,
 				run: func() error {
 					if err := installPestBrowser(bunPHPVersion, os.Stdout); err != nil {
-						fmt.Printf("  [WARN] could not set up Pest browser testing: %v\n", err)
+						feedback.Warn("could not set up Pest browser testing: %v", err)
 					}
 					return nil
 				},
@@ -406,6 +413,7 @@ func runSetup(allSteps, skipOpen bool) error {
 	// Determine which steps to run.
 	var selected []string
 	if allSteps {
+		feedback.Begin()
 		for _, s := range steps {
 			selected = append(selected, s.label)
 		}
@@ -420,6 +428,7 @@ func runSetup(allSteps, skipOpen bool) error {
 		}
 
 		selected = defaults // pre-select enabled steps
+		feedback.Begin()
 		if err := huh.NewForm(
 			huh.NewGroup(
 				huh.NewMultiSelect[string]().
@@ -443,21 +452,33 @@ func runSetup(allSteps, skipOpen bool) error {
 		selectedSet[s] = true
 	}
 
-	// Execute steps in order.
+	// Execute steps in order. Each step's own output is captured behind a single
+	// feedback line and only surfaced when the step fails, matching the link
+	// flow's "action … ✓" styling. The separating blank line was already printed
+	// before the step selector (or the --all branch below).
+	start := time.Now()
 	for _, s := range steps {
 		if !selectedSet[s.label] {
 			continue
 		}
-		fmt.Printf("\n→ Running: %s\n", s.label)
-		if err := s.run(); err != nil {
-			fmt.Printf("✗ %s failed: %v\n", s.label, err)
+		// Capture first, then render the step: starting an animated step before
+		// runCapturingStdout swaps os.Stdout would race the spinner goroutine
+		// against the swap and leak spinner frames into the captured buffer.
+		out, err := runCapturingStdout(s.run)
+		step := feedback.Start(s.label)
+		if err != nil {
+			step.Fail(err)
+			_, _ = os.Stdout.Write(out)
 			if !promptContinue() {
 				return fmt.Errorf("setup aborted after %q failed", s.label)
 			}
+			continue
 		}
+		step.OK("")
 	}
 
-	fmt.Println("\nSetup complete.")
+	feedback.Success("setup complete", time.Since(start))
+	feedback.Begin()
 	return nil
 }
 

--- a/internal/cli/sites.go
+++ b/internal/cli/sites.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/siteinfo"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -128,7 +129,7 @@ func printEnrichedSite(s siteinfo.EnrichedSite, width int, grouped bool) {
 	}
 }
 
-func pausedTag() string { return "\033[33mpaused\033[0m" }
+func pausedTag() string { return feedback.Amber("paused") }
 
 // Wide layout: Name Domain PHP Node TLS Framework Status Path  (≥120 cols)
 func printSiteWide(s config.Site, fwLabel string) {
@@ -243,7 +244,7 @@ func printSiteCompact(s config.Site, fwLabel string) {
 	fmt.Printf("%s%s%s\n", s.PrimaryDomain(), tls, status)
 	fmt.Printf("  %s\n", truncate(s.Path, 76))
 	if meta != "" {
-		fmt.Printf("  \033[2m%s\033[0m\n", meta)
+		fmt.Printf("  %s\n", feedback.Dim(meta))
 	}
 }
 
@@ -272,7 +273,7 @@ func printGroupSecondaryCompact(s config.Site, fwLabel string) {
 	fmt.Printf("  ↳ grp %s%s%s\n", s.PrimaryDomain(), tls, status)
 	fmt.Printf("    %s\n", truncate(s.Path, 74))
 	if meta != "" {
-		fmt.Printf("    \033[2m%s\033[0m\n", meta)
+		fmt.Printf("    %s\n", feedback.Dim(meta))
 	}
 }
 

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/nginx"
 	phpPkg "github.com/geodro/lerd/internal/php"
@@ -585,7 +586,8 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// Mirrors the worktree autostart filter; real activity wakes it via the engine.
 	workerUnits = dropIdleSuspendedUnits(workerUnits)
 
-	fmt.Println("Starting Lerd...")
+	feedback.Begin()
+	feedback.Line("starting lerd")
 
 	makeJobs := func(us []string) []BuildJob {
 		jobs := make([]BuildJob, len(us))
@@ -662,15 +664,15 @@ func runStart(_ *cobra.Command, _ []string) error {
 
 	// Restart the tray applet, stopping any existing instance first.
 	// Prefer the systemd service when enabled; otherwise launch directly.
-	fmt.Print("  --> lerd-tray ... ")
+	tray := feedback.Start("starting lerd-tray")
 	if services.Mgr.IsEnabled("lerd-tray") {
 		// Use Start (bootout+bootstrap) instead of Restart (kickstart -k) to
 		// avoid launchctl hanging while waiting for the tray process to die.
 		killTray()
 		if err := services.Mgr.Start("lerd-tray"); err != nil {
-			fmt.Printf("WARN (%v)\n", err)
+			tray.Fail(err)
 		} else {
-			fmt.Println("OK")
+			tray.OK("")
 		}
 	} else {
 		killTray()
@@ -679,9 +681,9 @@ func runStart(_ *cobra.Command, _ []string) error {
 			err = exec.Command(exe, "tray").Start()
 		}
 		if err != nil {
-			fmt.Printf("WARN (%v)\n", err)
+			tray.Fail(err)
 		} else {
-			fmt.Println("OK")
+			tray.OK("")
 		}
 	}
 
@@ -819,7 +821,7 @@ func restoreSiteInfrastructure() {
 				proj, _ := config.LoadProjectConfig(s.Path)
 				if proj != nil && proj.Container != nil {
 					if err := podman.WriteCustomContainerQuadlet(s.Name, s.Path, s.ContainerPort); err != nil {
-						fmt.Printf("[WARN] restoring custom container unit for %s: %v\n", s.Name, err)
+						feedback.Warn("restoring custom container unit for %s: %v", s.Name, err)
 					}
 				}
 			}
@@ -836,7 +838,7 @@ func restoreSiteInfrastructure() {
 						_ = podman.BuildCustomImage(s.Name, s.Path, proj.Container)
 					}
 					if err := podman.WriteCustomFPMQuadlet(s.Name, s.PHPVersion); err != nil {
-						fmt.Printf("[WARN] restoring custom FPM unit for %s: %v\n", s.Name, err)
+						feedback.Warn("restoring custom FPM unit for %s: %v", s.Name, err)
 					}
 				}
 			}
@@ -869,7 +871,7 @@ func restoreSiteInfrastructure() {
 		// new one, warn and wait for a re-link to re-approve it.
 		if s.IsHostProxy() && proj.Proxy != nil {
 			if s.HostCommand != "" && proj.Proxy.Command != s.HostCommand {
-				fmt.Printf("[WARN] %s: dev command in .lerd.yaml changed since link; not auto-starting. Run `lerd link` to review and approve.\n", s.Name)
+				feedback.Warn("%s: dev command in .lerd.yaml changed since link; not auto-starting. Run `lerd link` to review and approve.", s.Name)
 			} else if w, ok := hostProxyWorker(proj.Proxy); ok && !services.Mgr.IsEnabled(hostProxyWorkerUnit(s.Name)) {
 				restoreWorker(s.Name, s.Path, "", hostProxyWorkerName, w)
 			}
@@ -885,7 +887,7 @@ func restoreSiteInfrastructure() {
 			seenSvc[svc.Name] = true
 			cs, err := svc.Resolve()
 			if err != nil {
-				fmt.Printf("[WARN] resolving service %q for %s: %v\n", svc.Name, s.Name, err)
+				feedback.Warn("resolving service %q for %s: %v", svc.Name, s.Name, err)
 				continue
 			}
 			if cs != nil {
@@ -1168,7 +1170,8 @@ func runStop(_ *cobra.Command, _ []string) error {
 	// so without this the timer keeps dispatching after `lerd stop`.
 	units = append(units, registeredTimerUnits()...)
 
-	fmt.Println("Stopping Lerd...")
+	feedback.Begin()
+	feedback.Line("stopping lerd")
 
 	// Mark the intentional shutdown before tearing anything down, so the worker
 	// health watcher (which keeps running) suppresses heal/notification noise for
@@ -1201,11 +1204,11 @@ func runQuit(_ *cobra.Command, _ []string) error {
 
 	// Stop process units.
 	for _, unit := range []string{"lerd-ui", "lerd-watcher", "lerd-tray"} {
-		fmt.Printf("  --> %s ... ", unit)
+		s := feedback.Start("stopping " + unit)
 		if err := podman.StopUnit(unit); err != nil {
-			fmt.Printf("WARN (%v)\n", err)
+			s.Fail(err)
 		} else {
-			fmt.Println("OK")
+			s.OK("")
 		}
 	}
 	// Also kill any directly-launched tray instance not managed by launchd/systemd.

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
+	"github.com/geodro/lerd/internal/feedback"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
@@ -25,12 +26,14 @@ const (
 	colorReset  = "\033[0m"
 )
 
-func ok2(label string) { fmt.Printf("  %s%-30s%s OK\n", colorGreen, label, colorReset) }
+func ok2(label string) {
+	fmt.Printf("  %s %s\n", feedback.Green(feedback.GlyphOK), label)
+}
 
 // paused2 reports an idle-suspended worker: stopped on purpose, resumes on the
 // next request, so it's shown green (healthy) as paused rather than missing.
 func paused2(label string) {
-	fmt.Printf("  %s%-30s%s paused (idle)\n", colorGreen, label, colorReset)
+	fmt.Printf("  %s %s %s\n", feedback.Green(feedback.GlyphOK), label, feedback.Dim("(paused, idle)"))
 }
 
 // siteWorkerIdleSuspended reports whether the named worker is currently
@@ -45,10 +48,10 @@ func siteWorkerIdleSuspended(s config.Site, worker string) bool {
 }
 
 func fail2(label, msg, hint string) {
-	fmt.Printf("  %s%-30s%s FAIL (%s)\n    hint: %s\n", colorRed, label, colorReset, msg, hint)
+	fmt.Printf("  %s %s %s\n    %s %s\n", feedback.Red(feedback.GlyphFail), label, feedback.Dim("("+msg+")"), feedback.Dim("hint:"), hint)
 }
 func warn2(label, msg string) {
-	fmt.Printf("  %s%-30s%s WARN (%s)\n", colorYellow, label, colorReset, msg)
+	fmt.Printf("  %s %s %s\n", feedback.Amber(feedback.GlyphWarn), label, feedback.Dim("("+msg+")"))
 }
 
 // NewStatusCmd returns the status command.

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -62,7 +62,7 @@ func TestPrintRemoteAccessStatus(t *testing.T) {
 			lanIP:   "192.168.1.42",
 			wantSubstr: []string{
 				"LAN exposure (192.168.1.42)",
-				"OK",
+				"✓",
 				"Dashboard remote access",
 				"LAN clients get 403",
 			},

--- a/internal/cli/stripe.go
+++ b/internal/cli/stripe.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
 	"github.com/spf13/cobra"
@@ -198,7 +199,7 @@ WantedBy=default.target
 			return fmt.Errorf("daemon-reload: %w", err)
 		}
 		if err := services.Mgr.Enable(unitName); err != nil {
-			fmt.Printf("[WARN] enable: %v\n", err)
+			feedback.Warn("enable: %v", err)
 		}
 	}
 	return nil
@@ -215,9 +216,9 @@ func stripeStartExplicit(siteName, apiKey, forwardTo string) error {
 		return fmt.Errorf("starting stripe listener: %w", err)
 	}
 
-	fmt.Printf("Stripe listener started for %s\n", siteName)
-	fmt.Printf("  Forwarding to: %s\n", forwardTo)
-	fmt.Printf("  Logs: %s\n", unitLogHint(unitName))
+	feedback.Start("starting stripe listener").OK("")
+	feedback.Note("forwarding to: " + forwardTo)
+	feedback.Note("logs: " + unitLogHint(unitName))
 	return nil
 }
 
@@ -269,10 +270,10 @@ func StripeStopForSite(siteName string) error {
 	}
 
 	if err := podman.DaemonReloadFn(); err != nil {
-		fmt.Printf("[WARN] daemon-reload: %v\n", err)
+		feedback.Warn("daemon-reload: %v", err)
 	}
 
-	fmt.Printf("Stripe listener stopped for %s\n", siteName)
+	feedback.Start("stopping stripe listener").OK("")
 	return nil
 }
 

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -11,6 +11,7 @@ import (
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
 	"github.com/spf13/cobra"
@@ -31,12 +32,12 @@ func NewUninstallCmd() *cobra.Command {
 }
 
 func runUninstall(force bool) error {
-	fmt.Println("==> Uninstalling Lerd")
+	feedback.Begin()
+	feedback.Line("uninstalling lerd")
 
 	if !force {
-		fmt.Print("  This will stop all containers and remove Lerd. Continue? [y/N] ")
-		if !readYes() {
-			fmt.Println("  Aborted.")
+		if !feedback.Confirm("This will stop all containers and remove lerd. Continue?", false) {
+			feedback.Line("aborted")
 			return nil
 		}
 	}
@@ -159,11 +160,11 @@ func runUninstall(force bool) error {
 		os.RemoveAll(config.DataDir())
 		fmt.Println("OK")
 	} else {
-		fmt.Printf("  Config kept at %s\n", config.ConfigDir())
-		fmt.Printf("  Data kept at   %s\n", config.DataDir())
+		feedback.Note("config kept at " + config.ConfigDir())
+		feedback.Note("data kept at " + config.DataDir())
 	}
 
-	fmt.Println("\nLerd uninstalled.")
+	feedback.Done("lerd uninstalled")
 	return nil
 }
 

--- a/internal/cli/unlink.go
+++ b/internal/cli/unlink.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteops"
@@ -62,6 +63,7 @@ func runUnlink(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("no site registered for %s — link it first with lerd link", cwd)
 	}
+	feedback.Begin()
 	return UnlinkSite(site.Name)
 }
 
@@ -84,23 +86,19 @@ func UnlinkSite(name string) error {
 		parkedDirs = cfg.ParkedDirectories
 	}
 
+	step := feedback.Start("unlinking " + name)
 	if err := siteops.UnlinkSiteCore(site, parkedDirs); err != nil {
+		step.Fail(err)
 		return err
 	}
-
-	fmt.Printf("Unlinked: %s (%s)\n", name, site.PrimaryDomain())
+	step.OK(feedback.Val(site.PrimaryDomain()))
 
 	// Offer to remove the cached custom container image.
 	if site.IsCustomContainer() && podman.CustomImageExists(site.Name) {
-		if isInteractive() {
-			fmt.Print("Remove the container image? [y/N] ")
-			var answer string
-			fmt.Scanln(&answer) //nolint:errcheck
-			if answer != "" && (answer[0] == 'y' || answer[0] == 'Y') {
-				_ = podman.RemoveCustomImage(site.Name)
-				podman.RemoveContainerfileHash(site.Name)
-				fmt.Println("Image removed.")
-			}
+		if isInteractive() && feedback.Confirm("Remove the container image?", false) {
+			_ = podman.RemoveCustomImage(site.Name)
+			podman.RemoveContainerfileHash(site.Name)
+			feedback.Line("image removed")
 		}
 	}
 

--- a/internal/cli/unpark.go
+++ b/internal/cli/unpark.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/nginx"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
@@ -68,23 +69,24 @@ func runUnpark(_ *cobra.Command, args []string) error {
 		return err
 	}
 
+	feedback.Begin()
 	removed := 0
 	for _, site := range reg.Sites {
 		if !strings.HasPrefix(site.Path, absDir+string(filepath.Separator)) {
 			continue
 		}
 		if err := nginx.RemoveVhost(site.PrimaryDomain()); err != nil {
-			fmt.Printf("  [WARN] removing vhost for %s: %v\n", site.Name, err)
+			feedback.Warn("removing vhost for %s: %v", site.Name, err)
 		}
 		if err := config.RemoveSite(site.Name); err != nil {
-			fmt.Printf("  [WARN] removing site %s: %v\n", site.Name, err)
+			feedback.Warn("removing site %s: %v", site.Name, err)
 			continue
 		}
-		fmt.Printf("  - %s (%s)\n", site.Name, site.PrimaryDomain())
+		feedback.Start("unlinking " + site.Name).OK(feedback.Val(site.PrimaryDomain()))
 		removed++
 	}
 
-	fmt.Printf("Unparked: %s (%d site(s) removed)\n", absDir, removed)
+	feedback.Done(fmt.Sprintf("unparked %s · %d site(s) removed", filepath.Base(absDir), removed))
 
 	if removed > 0 {
 		nginx.ReloadOrWarn("  ")

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/store"
 	"github.com/geodro/lerd/internal/systemd"
@@ -48,7 +48,8 @@ func NewUpdateCmd(currentVersion string) *cobra.Command {
 }
 
 func runUpdate(currentVersion string, beta bool) error {
-	fmt.Println("==> Checking for updates")
+	feedback.Begin()
+	feedback.Line("checking for updates")
 
 	var latest string
 	var err error
@@ -71,15 +72,14 @@ func runUpdate(currentVersion string, beta bool) error {
 	lat := lerdUpdate.StripV(latest)
 
 	if !lerdUpdate.VersionGreaterThan(lat, cur) {
-		fmt.Printf("  Already on latest: v%s\n", cur)
+		feedback.Done("already on latest v" + cur)
 		return nil
 	}
 
-	fmt.Printf("  Current: v%s\n", cur)
-	fmt.Printf("  Latest:  v%s\n", lat)
+	feedback.Note("current v" + cur + " · latest " + feedback.Val("v"+lat))
 
 	// Show what's new between the current and latest version.
-	fmt.Println("\n==> What's new")
+	feedback.Line("what's new")
 	changelog, _ := lerdUpdate.FetchChangelog(cur, lat)
 	if changelog != "" {
 		for _, line := range strings.Split(changelog, "\n") {
@@ -97,12 +97,8 @@ func runUpdate(currentVersion string, beta bool) error {
 	}
 
 	// Ask for confirmation.
-	fmt.Printf("\nUpdate to v%s? [Y/n] ", lat)
-	reader := bufio.NewReader(os.Stdin)
-	answer, _ := reader.ReadString('\n')
-	answer = strings.TrimSpace(strings.ToLower(answer))
-	if answer == "n" || answer == "no" {
-		fmt.Println("Update cancelled.")
+	if !feedback.Confirm("Update to v"+lat+"?", true) {
+		feedback.Line("update cancelled")
 		return nil
 	}
 
@@ -114,13 +110,14 @@ func runUpdate(currentVersion string, beta bool) error {
 	// Back up current binary for rollback.
 	backupBinary(self, currentVersion)
 
-	fmt.Printf("  --> Downloading lerd v%s ... ", lat)
+	dl := feedback.Start("downloading lerd v" + lat)
 	extracted, cleanup, err := downloadReleaseBinary(latest)
 	if err != nil {
+		dl.Fail(err)
 		return err
 	}
 	defer cleanup()
-	fmt.Println("OK")
+	dl.OK("")
 
 	// Atomically replace lerd.
 	tmp := self + ".tmp"
@@ -145,7 +142,9 @@ func runUpdate(currentVersion string, beta bool) error {
 	// Update the cache so lerd status / doctor stop showing a stale notice.
 	lerdUpdate.WriteUpdateCache(lat)
 
-	fmt.Printf("\nLerd updated to v%s — applying infrastructure changes...\n\n", lat)
+	feedback.Done("lerd updated to v" + lat)
+	feedback.Line("applying infrastructure changes")
+	fmt.Println()
 
 	// Re-exec the new binary with `install` to reapply quadlet files,
 	// DNS config, sysctl, etc. lerd install is idempotent. Pass
@@ -166,13 +165,9 @@ func runUpdate(currentVersion string, beta bool) error {
 	// minio container is still running (skip if already migrated to RustFS).
 	minioRunning, _ := podman.ContainerRunning("lerd-minio")
 	if _, err := os.Stat(config.DataSubDir("minio")); err == nil && minioRunning {
-		fmt.Print("\n==> MinIO detected — migrate to RustFS? [y/N] ")
-		migrateReader := bufio.NewReader(os.Stdin)
-		migrateAnswer, _ := migrateReader.ReadString('\n')
-		migrateAnswer = strings.TrimSpace(strings.ToLower(migrateAnswer))
-		if migrateAnswer == "y" || migrateAnswer == "yes" {
+		if feedback.Confirm("MinIO detected — migrate to RustFS?", false) {
 			if err := runMinioMigrate(nil, nil); err != nil {
-				fmt.Fprintf(os.Stderr, "  warn: migration failed: %v\n", err)
+				feedback.Warn("migration failed: %v", err)
 			}
 		}
 	}
@@ -212,24 +207,24 @@ func refreshStoreFrameworks() {
 	if len(targets) == 0 {
 		return
 	}
-	fmt.Printf("\n==> Refreshing %d framework definition%s\n", len(targets), pluralS(len(targets)))
+	feedback.Line(fmt.Sprintf("refreshing %d framework definition%s", len(targets), pluralS(len(targets))))
 	client := store.NewClient()
 	for _, t := range targets {
 		label := t.name
 		if t.version != "" {
 			label = t.name + "@" + t.version
 		}
-		fmt.Printf("  --> %s ... ", label)
+		step := feedback.Start(label)
 		fw, err := client.FetchFramework(t.name, t.version)
 		if err != nil {
-			fmt.Printf("WARN (%v)\n", err)
+			step.Fail(err)
 			continue
 		}
 		if err := config.SaveStoreFramework(fw); err != nil {
-			fmt.Printf("WARN (%v)\n", err)
+			step.Fail(err)
 			continue
 		}
-		fmt.Println("OK")
+		step.OK("")
 	}
 }
 
@@ -247,7 +242,7 @@ func refreshGlobalMCPSkills() {
 	if !mcpEnabledGlobally(home) {
 		return
 	}
-	fmt.Println("\n==> Refreshing global MCP skills and guidelines")
+	feedback.Line("refreshing global MCP skills and guidelines")
 	if err := RefreshGlobalAISkills(home, true); err != nil {
 		fmt.Fprintf(os.Stderr, "  warn: could not refresh global AI skills: %v\n", err)
 	}

--- a/internal/cli/use.go
+++ b/internal/cli/use.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 )
 
@@ -30,11 +31,12 @@ func runUse(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("saving config: %w", err)
 	}
 
-	fmt.Printf("Default PHP version set to %s\n", version)
+	feedback.Begin()
+	feedback.Done("default PHP set to " + feedback.Val(version))
 
 	// Ensure FPM quadlet exists for this version
 	if err := ensureFPMQuadlet(version); err != nil {
-		fmt.Printf("[WARN] FPM quadlet for PHP %s: %v\n", version, err)
+		feedback.Warn("FPM quadlet for PHP %s: %v", version, err)
 	}
 
 	return nil

--- a/internal/cli/whatsnew.go
+++ b/internal/cli/whatsnew.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/geodro/lerd/internal/feedback"
 	lerdUpdate "github.com/geodro/lerd/internal/update"
 	"github.com/geodro/lerd/internal/version"
 	"github.com/spf13/cobra"
@@ -28,7 +29,8 @@ func runWhatsnew(_ *cobra.Command, _ []string) error {
 	latestStripped := lerdUpdate.StripV(latest)
 
 	if !lerdUpdate.VersionGreaterThan(latestStripped, current) {
-		fmt.Printf("You are on the latest version (%s).\n", version.Version)
+		feedback.Begin()
+		feedback.Done("you are on the latest version (" + version.Version + ")")
 		return nil
 	}
 

--- a/internal/cli/which.go
+++ b/internal/cli/which.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	nodeDet "github.com/geodro/lerd/internal/node"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/spf13/cobra"
@@ -47,16 +48,17 @@ func runWhich(_ *cobra.Command, _ []string) error {
 	docRoot := filepath.Join(site.Path, publicDir)
 	nginxConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
 
-	fmt.Printf("  Site         %s\n", strings.Join(site.Domains, ", "))
-	fmt.Printf("  PHP          %s\n", phpVersion)
-	fmt.Printf("  Node         %s\n", nodeVersion)
-	fmt.Printf("  Document root  %s\n", docRoot)
-	fmt.Printf("  Nginx config   %s\n", nginxConf)
-
+	sum := feedback.NewSummary().
+		Row("Site", feedback.Val(strings.Join(site.Domains, ", "))).
+		Row("PHP", phpVersion).
+		Row("Node", nodeVersion).
+		Row("Document root", docRoot).
+		Row("Nginx config", nginxConf)
 	if site.Secured {
 		sslConf := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
-		fmt.Printf("  Nginx SSL      %s\n", sslConf)
+		sum.Row("Nginx SSL", sslConf)
 	}
+	sum.Print()
 
 	return nil
 }

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
@@ -242,7 +243,7 @@ func resolveWorkerCommand(sitePath, workerName string, w config.FrameworkWorker)
 		return w.Command
 	}
 	if !projectHasChokidar(sitePath) {
-		fmt.Printf("[WARN] %s auto-reload is on but chokidar is not installed in %s, running the standard command. Install it with: npm install -D chokidar\n", workerName, sitePath)
+		feedback.Warn("%s auto-reload is on but chokidar is not installed in %s, running the standard command. Install it with: npm install -D chokidar", workerName, sitePath)
 		return w.Command
 	}
 	command := w.ReloadCommand
@@ -305,7 +306,7 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 	// unit that was never written, surfacing a confusing podman error
 	// behind the original WARN.
 	if ok, reason := workerSupportedOnPlatform(w); !ok {
-		fmt.Printf("[WARN] worker %s skipped: %s\n", workerName, reason)
+		feedback.Warn("worker %s skipped: %s", workerName, reason)
 		return nil
 	}
 
@@ -365,10 +366,10 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 		// different container) only takes effect once systemd re-reads it;
 		// without this, Enable/Start act on the stale cached unit.
 		if err := podman.DaemonReloadFn(); err != nil {
-			fmt.Printf("[WARN] daemon-reload: %v\n", err)
+			feedback.Warn("daemon-reload: %v", err)
 		}
 		if err := services.Mgr.Enable(lifecycleTarget); err != nil {
-			fmt.Printf("[WARN] enable: %v\n", err)
+			feedback.Warn("enable: %v", err)
 		}
 	}
 
@@ -377,12 +378,13 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 	// Linux the systemd DBus subscription catches direct services.Mgr
 	// calls as a fallback; macOS has no equivalent, so a direct call
 	// leaves the UI stale until the next 15s cache poll.
+	startStep := feedback.Start("starting " + label)
 	if err := podman.StartUnit(lifecycleTarget); err != nil {
+		startStep.Fail(err)
 		return fmt.Errorf("starting %s worker: %w", workerName, err)
 	}
-
-	fmt.Printf("%s started for %s\n", label, siteName)
-	fmt.Printf("  Logs: %s\n", workerLogHint(unitName, w.Host))
+	startStep.OK("")
+	feedback.Note("logs: " + workerLogHint(unitName, w.Host))
 
 	// A running worker can't be idle-suspended: clear any stale entry so the idle
 	// engine doesn't boot believing this site (or worktree) is still asleep.
@@ -655,16 +657,22 @@ func WorkerStopForSite(siteName, sitePath, workerName string) error {
 // the call works regardless of whether the worker was scheduled (.timer +
 // oneshot .service) or a long-running daemon (.service alone). Missing
 // units are no-ops at this layer.
-func stopWorkerUnit(unitName, label, displaySite string) error {
+func stopWorkerUnit(unitName, label, _ string) error {
+	if label == "" {
+		label = unitName
+	}
+	step := feedback.Start("stopping " + label)
 	_ = services.Mgr.Disable(unitName + ".timer")
 	podman.StopUnit(unitName + ".timer") //nolint:errcheck
 	_ = services.Mgr.Disable(unitName)
 	podman.StopUnit(unitName) //nolint:errcheck
 
 	if err := services.Mgr.RemoveTimerUnit(unitName); err != nil {
+		step.Fail(err)
 		return fmt.Errorf("removing timer unit file: %w", err)
 	}
 	if err := services.Mgr.RemoveServiceUnit(unitName); err != nil {
+		step.Fail(err)
 		return fmt.Errorf("removing unit file: %w", err)
 	}
 	// Drop the macOS exec-mode guard script + pid file (no-op on Linux).
@@ -672,16 +680,9 @@ func stopWorkerUnit(unitName, label, displaySite string) error {
 	// a normal stop and confuse later mode-migration discovery.
 	removeWorkerExecArtifacts(unitName)
 	if err := podman.DaemonReloadFn(); err != nil {
-		fmt.Printf("[WARN] daemon-reload: %v\n", err)
+		feedback.Warn("daemon-reload: %v", err)
 	}
-
-	if label == "" {
-		label = unitName
-	}
-	if displaySite == "" {
-		displaySite = unitName
-	}
-	fmt.Printf("%s stopped for %s\n", label, displaySite)
+	step.OK("")
 	return nil
 }
 

--- a/internal/cli/worker_darwin.go
+++ b/internal/cli/worker_darwin.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	nodeDet "github.com/geodro/lerd/internal/node"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
@@ -46,7 +47,7 @@ func writeWorkerUnitFile(unitName, label, siteName, sitePath, phpVersion, comman
 		return false, fmt.Errorf("worker unit %q: command must not contain newline or NUL", unitName)
 	}
 	if schedule != "" {
-		fmt.Printf("[WARN] worker %s has schedule=%q which is not yet supported on macOS — skipping\n", unitName, schedule)
+		feedback.Warn("worker %s has schedule=%q which is not yet supported on macOS — skipping", unitName, schedule)
 		return false, nil
 	}
 	if host {

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/feedback"
 	nodeDet "github.com/geodro/lerd/internal/node"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
@@ -214,7 +215,7 @@ func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.F
 
 	changed, err := writeWorkerUnitFile(unitName, label, displaySite, sitePath, phpVersion, command, restart, w.Schedule, fpmUnit, w.Host)
 	if err != nil {
-		fmt.Printf("[WARN] writing worker unit %s: %v\n", unitName, err)
+		feedback.Warn("writing worker unit %s: %v", unitName, err)
 		return
 	}
 	if changed {
@@ -223,7 +224,7 @@ func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.F
 			enableTarget = unitName + ".timer"
 		}
 		if err := services.Mgr.Enable(enableTarget); err != nil {
-			fmt.Printf("[WARN] enable %s: %v\n", enableTarget, err)
+			feedback.Warn("enable %s: %v", enableTarget, err)
 		}
 	}
 }

--- a/internal/cli/worker_migrate_darwin.go
+++ b/internal/cli/worker_migrate_darwin.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
@@ -77,7 +78,7 @@ func migrateWorkersOnModeChangeStreaming(fromMode, toMode string, emit func(Work
 		// quadlets and plain service units — it boots out of launchd
 		// and stops the container if any.
 		if err := podman.StopUnit(step.Unit); err != nil {
-			fmt.Printf("[WARN] stopping %s: %v\n", step.Unit, err)
+			feedback.Warn("stopping %s: %v", step.Unit, err)
 		}
 
 		emit(WorkerModePhaseEvent{Phase: "migrating_worker", Unit: step.Unit, Step: "cleaning"})
@@ -98,7 +99,7 @@ func migrateWorkersOnModeChangeStreaming(fromMode, toMode string, emit func(Work
 	for _, step := range steps {
 		emit(WorkerModePhaseEvent{Phase: "migrating_worker", Unit: step.Unit, Step: "starting"})
 		if err := restartWorkerByUnitName(step.Unit); err != nil {
-			fmt.Printf("[WARN] restart %s in %s mode: %v\n", step.Unit, step.To, err)
+			feedback.Warn("restart %s in %s mode: %v", step.Unit, step.To, err)
 		}
 	}
 

--- a/internal/cli/worker_support_test.go
+++ b/internal/cli/worker_support_test.go
@@ -55,7 +55,7 @@ func TestWorkerStartForSite_unsupportedReasonPrinted(t *testing.T) {
 	if !strings.Contains(out, "fake-platform-reason") {
 		t.Errorf("expected reason in WARN output, got %q", out)
 	}
-	if !strings.Contains(out, "[WARN]") {
-		t.Errorf("expected [WARN] marker in output, got %q", out)
+	if !strings.Contains(out, "⚠") {
+		t.Errorf("expected warning marker in output, got %q", out)
 	}
 }

--- a/internal/cli/workers_mode.go
+++ b/internal/cli/workers_mode.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 )
 
@@ -70,15 +71,16 @@ No manual 'lerd stop && lerd start' needed.`,
 			if err := applyWorkersMode(mode, nil); err != nil {
 				return err
 			}
+			feedback.Begin()
 			if prev == mode {
-				fmt.Printf("Worker mode already %s.\n", mode)
+				feedback.Line("worker mode already " + mode)
 				return nil
 			}
-			fmt.Printf("Worker mode set to %s (was %s).\n", mode, prev)
+			feedback.Done("worker mode set to " + feedback.Val(mode) + " (was " + prev + ")")
 			if runtime.GOOS == "darwin" {
-				fmt.Println("Active workers have been restarted in the new shape.")
+				feedback.Note("active workers have been restarted in the new shape")
 			} else {
-				fmt.Println("Note: Linux always uses the exec runtime. This setting only applies on macOS.")
+				feedback.Note("Linux always uses the exec runtime; this setting only applies on macOS")
 			}
 			return nil
 		},

--- a/internal/cli/worktree_add.go
+++ b/internal/cli/worktree_add.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/spf13/cobra"
 )
@@ -58,38 +59,40 @@ func newWorktreeAddCmd() *cobra.Command {
 			}
 
 			gitArgs := append([]string{"worktree", "add"}, args...)
-			fmt.Printf("Running: git %s\n", strings.Join(gitArgs, " "))
+			feedback.Begin()
+			feedback.Line("git " + strings.Join(gitArgs, " "))
 			if err := gitpkg.RunTTY("", gitArgs...); err != nil {
 				return fmt.Errorf("git worktree add: %w", err)
 			}
 
 			worktreePath, branch, err := newestWorktree(cwd)
 			if err != nil {
-				fmt.Printf("[WARN] could not locate the new worktree on disk: %v\n", err)
+				feedback.Warn("could not locate the new worktree on disk: %v", err)
 				return nil
 			}
 
-			fmt.Println("Waiting for lerd to install dependencies (composer + JS)...")
+			deps := feedback.Start("installing dependencies (composer + JS)")
 			if err := WaitForWorktreeReady(worktreePath, 5*time.Minute); err != nil {
-				fmt.Printf("[WARN] %v, you can rerun setup later by editing the worktree.\n", err)
+				deps.Fail(err)
+				feedback.Note("you can rerun setup later by editing the worktree")
 			} else {
-				fmt.Println("Dependencies installed.")
+				deps.OK("")
 			}
 
 			if optedIn := OptedInHostWorkers(site, worktreePath); len(optedIn) > 0 {
-				fmt.Printf("Auto-starting opted-in workers: %s\n", strings.Join(optedIn, ", "))
+				feedback.Note("auto-starting opted-in workers: " + strings.Join(optedIn, ", "))
 			}
 			ApplyWorktreeBuildChoice(site, worktreePath, promptWorktreeBuild(site, worktreePath), os.Stdout)
 
 			if err := promptDBIsolation(site, branch); err != nil {
-				fmt.Printf("[WARN] DB setup skipped: %v\n", err)
+				feedback.Warn("DB setup skipped: %v", err)
 			}
 
 			scheme := "http"
 			if site.Secured {
 				scheme = "https"
 			}
-			fmt.Printf("\nWorktree ready: %s://%s.%s\n", scheme, branch, site.PrimaryDomain())
+			feedback.Done("worktree ready: " + feedback.Val(scheme+"://"+branch+"."+site.PrimaryDomain()))
 			return nil
 		},
 	}
@@ -584,7 +587,7 @@ func AutoStartOptedInWorktreeWorkers(site *config.Site, worktreePath, phpVersion
 			continue
 		}
 		if err := WorkerStartForSite(site.Name, worktreePath, phpVersion, name, w, false); err != nil {
-			fmt.Printf("[WARN] auto-start %s for worktree %s: %v\n", name, filepath.Base(worktreePath), err)
+			feedback.Warn("auto-start %s for worktree %s: %v", name, filepath.Base(worktreePath), err)
 		}
 	}
 }

--- a/internal/cli/worktree_remove.go
+++ b/internal/cli/worktree_remove.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/spf13/cobra"
 )
@@ -65,21 +66,21 @@ func newWorktreeRemoveCmd() *cobra.Command {
 			// failure here is a warning, not a hard error.
 			if wtBase != "" {
 				if err := StopAllWorkersForWorktree(site.Name, wtBase); err != nil {
-					fmt.Printf("[WARN] stopping worktree workers: %v\n", err)
+					feedback.Warn("stopping worktree workers: %v", err)
 				}
 			}
 
 			if branch != "" {
 				if err := promptDeleteIsolatedDB(site, branch); err != nil {
-					fmt.Printf("[WARN] DB cleanup skipped: %v\n", err)
+					feedback.Warn("DB cleanup skipped: %v", err)
 				}
 			}
 
 			if branch != "" {
 				if err := waitForWorktreeCleanup(site.Name, branch, 30*time.Second); err != nil {
-					fmt.Printf("[WARN] %v\n", err)
+					feedback.Warn("%v", err)
 				} else {
-					fmt.Println("Worktree removed and lerd state cleaned up.")
+					feedback.Done("worktree removed and lerd state cleaned up")
 				}
 			}
 			return nil
@@ -122,7 +123,7 @@ func promptDeleteIsolatedDB(site *config.Site, branch string) error {
 	if _, _, err := config.RemoveWorktreeDB(site.Name, branch); err != nil {
 		return fmt.Errorf("removing registry entry: %w", err)
 	}
-	fmt.Printf("Dropped database %q.\n", entry.DBName)
+	feedback.Note("dropped database " + entry.DBName)
 	return nil
 }
 
@@ -137,7 +138,7 @@ func runGitWorktreeRemove(args []string) error {
 	}
 
 	gitArgs := append([]string{"worktree", "remove"}, args...)
-	fmt.Printf("Running: git %s\n", strings.Join(gitArgs, " "))
+	feedback.Line("git " + strings.Join(gitArgs, " "))
 	stderr, err := gitpkg.RunCaptureStderr("", gitArgs...)
 	if err == nil {
 		return nil
@@ -191,7 +192,7 @@ func hasForceFlag(args []string) bool {
 // user sees git's progress live). The silent branch is kept for future
 // callers; nothing uses it today.
 func runGit(args []string, mirrorOutput bool) error {
-	fmt.Printf("Running: git %s\n", strings.Join(args, " "))
+	feedback.Line("git " + strings.Join(args, " "))
 	if !mirrorOutput {
 		return gitpkg.Run("", nil, args...)
 	}

--- a/internal/cli/xdebug.go
+++ b/internal/cli/xdebug.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/xdebugops"
@@ -104,21 +105,22 @@ func runXdebugToggle(args []string, enable bool, mode, start string) error {
 		return err
 	}
 
+	feedback.Begin()
 	if res.NoChange {
 		state := "disabled"
 		if res.Enabled {
 			state = fmt.Sprintf("enabled (mode=%s)", res.Mode)
 		}
-		fmt.Printf("Xdebug is already %s for PHP %s\n", state, version)
+		feedback.Line("Xdebug is already " + state + " for PHP " + version)
 		return nil
 	}
 
 	if res.RestartErr != nil {
 		unit := xdebugops.FPMUnit(version)
-		fmt.Printf("[WARN] restart %s: %v\n", unit, res.RestartErr)
+		feedback.Warn("restart %s: %v", unit, res.RestartErr)
 		fmt.Printf("Run: systemctl --user restart %s\n", unit)
 	} else if res.Restarted {
-		fmt.Printf("FPM container restarted.\n")
+		feedback.Note("restarted " + xdebugops.FPMUnit(version))
 	}
 
 	// Per-site containers (custom-FPM and FrankenPHP) on this version mount the
@@ -126,12 +128,12 @@ func runXdebugToggle(args []string, enable bool, mode, start string) error {
 	podman.RestartSiteContainersForVersion(version)
 
 	if res.Enabled {
-		fmt.Printf("Xdebug enabled for PHP %s (mode=%s, start_with_request=%s, port 9003, host.containers.internal)\n", version, res.Mode, start)
+		feedback.Done("Xdebug enabled for PHP " + version + " " + feedback.Val(fmt.Sprintf("mode=%s · start=%s · port 9003", res.Mode, start)))
 		if start == "trigger" {
-			fmt.Println("On-demand mode: requests and workers won't auto-connect. Attach with `lerd xdebug pause` or a trigger cookie.")
+			feedback.Note("on-demand: requests and workers won't auto-connect; attach with `lerd xdebug pause` or a trigger cookie")
 		}
 	} else {
-		fmt.Printf("Xdebug disabled for PHP %s\n", version)
+		feedback.Done("Xdebug disabled for PHP " + version)
 	}
 	return nil
 }
@@ -155,14 +157,12 @@ func runXdebugStatus(_ *cobra.Command, _ []string) error {
 	fmt.Printf("%-10s %-10s %s\n", "Version", "Xdebug", "Mode")
 	fmt.Printf("%-10s %-10s %s\n", "─────────", "──────────", "────")
 	for _, v := range versions {
-		state := "disabled"
-		color := "\033[33m"
 		mode := cfg.GetXdebugMode(v)
+		state := feedback.Amber(fmt.Sprintf("%-10s", "disabled"))
 		if mode != "" {
-			state = "enabled"
-			color = "\033[32m"
+			state = feedback.Green(fmt.Sprintf("%-10s", "enabled"))
 		}
-		fmt.Printf("%-10s %s%-10s\033[0m %s\n", v, color, state, mode)
+		fmt.Printf("%-10s %s %s\n", v, state, mode)
 	}
 	return nil
 }

--- a/internal/cli/xdebug_pause.go
+++ b/internal/cli/xdebug_pause.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/logsource"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
@@ -100,9 +101,10 @@ func runXdebugPause(args []string, pid int, list bool) error {
 	if err != nil {
 		return fmt.Errorf("xdebugctl pause: %w", err)
 	}
-	fmt.Printf("Sent pause to PID %d in %s — your IDE (listening on :9003) should break in.\n", pid, container)
+	feedback.Begin()
+	feedback.Done(fmt.Sprintf("sent pause to PID %d in %s — your IDE (listening on :9003) should break in", pid, container))
 	if cfg, err := config.LoadGlobal(); err == nil && cfg.GetXdebugStart(version) == "yes" {
-		fmt.Println("Tip: `lerd xdebug on --on-demand` stops every other request/worker from also connecting to your IDE.")
+		feedback.Note("`lerd xdebug on --on-demand` stops every other request/worker from also connecting to your IDE")
 	}
 	return nil
 }

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -1,0 +1,419 @@
+// Package feedback renders lerd's CLI progress output (animated steps, a live
+// line, summaries, prompts, warnings) and owns the shared lerd colour palette.
+// It degrades to plain text when stdout is piped, redirected, or NO_COLOR is set.
+package feedback
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
+)
+
+// Canonical lerd palette (Tailwind hex values). The TUI theme aliases these so
+// CLI feedback and the dashboard share one set of colours.
+var (
+	ColTitle   = lipgloss.Color("#FF2D20") // lerd red
+	ColDim     = lipgloss.Color("#6b7280") // gray-500
+	ColDivider = lipgloss.Color("#374151") // gray-700
+	ColRunning = lipgloss.Color("#10b981") // emerald-500
+	ColStopped = lipgloss.Color("#6b7280") // gray-500
+	ColFailing = lipgloss.Color("#ef4444") // red-500
+	ColPaused  = lipgloss.Color("#f59e0b") // amber-400
+	ColAccent  = lipgloss.Color("#a78bfa") // violet-400
+)
+
+var (
+	dimStyle    = lipgloss.NewStyle().Foreground(ColDim)
+	okStyle     = lipgloss.NewStyle().Foreground(ColRunning)
+	failStyle   = lipgloss.NewStyle().Foreground(ColFailing).Bold(true)
+	valueStyle  = lipgloss.NewStyle().Foreground(ColAccent)
+	promptStyle = lipgloss.NewStyle().Foreground(ColAccent).Bold(true)
+	spinStyle   = lipgloss.NewStyle().Foreground(ColAccent)
+	warnStyle   = lipgloss.NewStyle().Foreground(ColPaused)
+	redStyle    = lipgloss.NewStyle().Foreground(ColFailing)
+	titleStyle  = lipgloss.NewStyle().Bold(true).Foreground(ColTitle)
+)
+
+// Status glyphs for query/report output that renders its own layout rather than
+// using the Step/Live progress flow.
+const (
+	GlyphOK   = "✓"
+	GlyphFail = "✗"
+	GlyphWarn = "⚠"
+)
+
+// Title styles a fragment as the bold lerd-red wordmark colour.
+func Title(s string) string { return paint(titleStyle, s) }
+
+// Green, Red, Amber, and Dim colour a one-off fragment for status reports,
+// honouring NO_COLOR and non-TTY output. Use these so query commands share the
+// progress palette without reaching for raw ANSI codes.
+func Green(s string) string { return paint(okStyle, s) }
+func Red(s string) string   { return paint(redStyle, s) }
+func Amber(s string) string { return paint(warnStyle, s) }
+func Dim(s string) string   { return paint(dimStyle, s) }
+
+// spinnerFrames is the Braille spinner used by the Live progress line.
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// pad is the left margin printed before every feedback glyph line so the block
+// sits slightly indented from the shell prompt.
+const pad = " "
+
+var (
+	mu      sync.Mutex
+	out     io.Writer // nil → write to the current os.Stdout (so redirects are honoured)
+	colorOn = detectColor()
+)
+
+// target returns the writer to render to: an explicit test writer when set,
+// otherwise the live os.Stdout (looked up per call so os.Stdout redirection,
+// e.g. in tests, is respected).
+func target() io.Writer {
+	if out != nil {
+		return out
+	}
+	return os.Stdout
+}
+
+func detectColor() bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// paint applies a style only when colour is enabled, so plain-mode output (and
+// tests) stay free of escape codes.
+func paint(st lipgloss.Style, s string) string {
+	if !colorOn {
+		return s
+	}
+	return st.Render(s)
+}
+
+// Val styles a value fragment (violet) for embedding inside a step or summary.
+func Val(s string) string { return paint(valueStyle, s) }
+
+// Begin prints a single blank line to separate a feedback block from whatever
+// (a shell prompt, a wizard) came before it.
+func Begin() {
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintln(target())
+}
+
+// Step is one line of progress: Start it before the work, then OK/Info/Fail
+// finishes it. On a colour TTY a spinner animates until then; otherwise nothing
+// prints until the finishing call writes the line once.
+type Step struct {
+	msg  string
+	stop chan struct{}
+	wg   sync.WaitGroup
+}
+
+// Start records a step with the given present-tense label (e.g. "detecting
+// framework") and begins its spinner on an animated terminal.
+func Start(msg string) *Step {
+	s := &Step{msg: msg}
+	if Animated() {
+		s.stop = make(chan struct{})
+		s.wg.Add(1)
+		go s.spin()
+	}
+	return s
+}
+
+func (s *Step) spin() {
+	defer s.wg.Done()
+	t := time.NewTicker(90 * time.Millisecond)
+	defer t.Stop()
+	i := 0
+	s.frame(spinnerFrames[0])
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-t.C:
+			i++
+			s.frame(spinnerFrames[i%len(spinnerFrames)])
+		}
+	}
+}
+
+func (s *Step) frame(f string) {
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintf(target(), "\r\033[2K%s%s %s %s", pad, paint(dimStyle, "→"), paint(dimStyle, s.msg), paint(spinStyle, f))
+}
+
+func (s *Step) finish(mark, result string) {
+	if Animated() {
+		close(s.stop)
+		s.wg.Wait()
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	line := fmt.Sprintf("%s%s %s", pad, paint(dimStyle, "→"), paint(dimStyle, s.msg+"…"))
+	if mark != "" {
+		line += " " + mark
+	}
+	if result != "" {
+		line += " " + result
+	}
+	if Animated() {
+		fmt.Fprintf(target(), "\r\033[2K%s\n", line)
+	} else {
+		fmt.Fprintln(target(), line)
+	}
+}
+
+// OK collapses the step with a green check and a result (e.g. "Laravel 11").
+func (s *Step) OK(result string) { s.finish(paint(okStyle, "✓"), result) }
+
+// Info collapses the step with a plain result and no mark.
+func (s *Step) Info(result string) { s.finish("", result) }
+
+// Fail collapses the step with a red cross and the error text.
+func (s *Step) Fail(err error) {
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	s.finish(paint(failStyle, "✗"), paint(failStyle, msg))
+}
+
+// Line prints a standalone step (arrow prefix, no trailing ellipsis) for an
+// already-known fact, e.g. "php 8.4 · node 22 · nginx vhost written".
+func Line(msg string) {
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintf(target(), "%s%s %s\n", pad, paint(dimStyle, "→"), msg)
+}
+
+// Note prints a dim, indented sub-detail under a step (e.g. a log hint). It has
+// no glyph so it reads as secondary to the step lines above it.
+func Note(msg string) {
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintf(target(), "%s  %s\n", pad, paint(dimStyle, msg))
+}
+
+// Warn prints a warning line: an amber warning glyph and amber message. Use in
+// place of a plain "[WARN] …" print.
+func Warn(format string, a ...any) {
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintf(target(), "%s%s %s\n", pad, paint(warnStyle, "⚠"), paint(warnStyle, fmt.Sprintf(format, a...)))
+}
+
+// Done prints a green-check completion line with no timing, for operations
+// where elapsed time isn't meaningful.
+func Done(msg string) {
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintf(target(), "%s%s %s\n", pad, paint(okStyle, "✓"), msg)
+}
+
+// Success prints the terminal line: green check, message, dim elapsed time.
+func Success(msg string, d time.Duration) {
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintf(target(), "%s%s %s %s\n", pad, paint(okStyle, "✓"), msg, paint(dimStyle, "in "+humanDur(d)))
+}
+
+// Confirm prints a styled yes/no prompt (preceded by a blank line) and reads
+// the answer from stdin, returning defaultYes on an empty response. The prompt
+// matches the step styling: a violet "?" lead-in and a dim "[Y/n]" hint.
+func Confirm(question string, defaultYes bool) bool {
+	hint := "[Y/n]"
+	if !defaultYes {
+		hint = "[y/N]"
+	}
+	mu.Lock()
+	fmt.Fprintf(target(), "\n%s%s %s %s ", pad, paint(promptStyle, "?"), question, paint(dimStyle, hint))
+	mu.Unlock()
+
+	var answer string
+	fmt.Scanln(&answer) //nolint:errcheck
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer == "" {
+		return defaultYes
+	}
+	return answer[0] == 'y'
+}
+
+// Animated reports whether output supports in-place animation (a colour TTY).
+// When false, Live degrades to a header line plus one plain line per item.
+func Animated() bool { return colorOn }
+
+// Live is a single in-place progress line with a trailing spinner that
+// accumulates completed items, e.g. "→ configuring .env… ✓ a · b · c ⠙". When
+// it finishes the spinner is dropped and the ✓ line stays put.
+type Live struct {
+	msg   string
+	imu   sync.Mutex
+	items []string
+	stop  chan struct{}
+	wg    sync.WaitGroup
+}
+
+// StartLive begins a live line with the given label. On a non-animated output
+// it just prints the header and each Add on its own line.
+func StartLive(msg string) *Live {
+	l := &Live{msg: msg}
+	if Animated() {
+		l.stop = make(chan struct{})
+		l.wg.Add(1)
+		go l.spin()
+	} else {
+		mu.Lock()
+		fmt.Fprintf(target(), "%s%s %s\n", pad, "→", msg+"…")
+		mu.Unlock()
+	}
+	return l
+}
+
+func (l *Live) snapshot() []string {
+	l.imu.Lock()
+	defer l.imu.Unlock()
+	return append([]string(nil), l.items...)
+}
+
+func (l *Live) spin() {
+	defer l.wg.Done()
+	t := time.NewTicker(90 * time.Millisecond)
+	defer t.Stop()
+	i := 0
+	l.draw(spinnerFrames[0])
+	for {
+		select {
+		case <-l.stop:
+			return
+		case <-t.C:
+			i++
+			l.draw(spinnerFrames[i%len(spinnerFrames)])
+		}
+	}
+}
+
+func (l *Live) draw(frame string) {
+	items := l.snapshot()
+	mu.Lock()
+	defer mu.Unlock()
+	line := pad + paint(dimStyle, "→") + " " + paint(dimStyle, l.msg+"…")
+	if len(items) > 0 {
+		line += " " + paint(okStyle, "✓") + " " + strings.Join(items, " · ")
+	}
+	if frame != "" {
+		line += " " + paint(spinStyle, frame)
+	}
+	fmt.Fprintf(target(), "\r\033[2K%s", line)
+}
+
+// Add records a completed item; the spinning line redraws to include it.
+func (l *Live) Add(item string) {
+	if !Animated() {
+		mu.Lock()
+		fmt.Fprintf(target(), "%s  %s\n", pad, item)
+		mu.Unlock()
+		return
+	}
+	l.imu.Lock()
+	l.items = append(l.items, item)
+	l.imu.Unlock()
+}
+
+// Done stops the spinner, leaving the ✓ line (checkbox replaces the loader).
+func (l *Live) Done() {
+	if !Animated() {
+		mu.Lock()
+		fmt.Fprintf(target(), "%s%s %s\n", pad, paint(okStyle, "✓"), l.msg)
+		mu.Unlock()
+		return
+	}
+	close(l.stop)
+	l.wg.Wait()
+	l.draw("")
+	mu.Lock()
+	fmt.Fprintln(target())
+	mu.Unlock()
+}
+
+// Fail stops the spinner and finalises the line with a red cross.
+func (l *Live) Fail(err error) {
+	if Animated() {
+		close(l.stop)
+		l.wg.Wait()
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if Animated() {
+		fmt.Fprint(target(), "\r\033[2K")
+	}
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	fmt.Fprintf(target(), "%s%s %s\n", pad, paint(failStyle, "✗"), paint(failStyle, msg))
+}
+
+// Summary is an aligned key/value block printed after an operation completes.
+type Summary struct{ rows [][2]string }
+
+// NewSummary returns an empty summary block.
+func NewSummary() *Summary { return &Summary{} }
+
+// Row appends a label/value pair; value may contain styled fragments via Val.
+func (s *Summary) Row(label, value string) *Summary {
+	s.rows = append(s.rows, [2]string{label, value})
+	return s
+}
+
+// Print renders the block, label column padded to the widest label, preceded by
+// a blank line. No-op when empty.
+func (s *Summary) Print() {
+	if len(s.rows) == 0 {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	w := 0
+	for _, r := range s.rows {
+		if len(r[0]) > w {
+			w = len(r[0])
+		}
+	}
+	fmt.Fprintln(target())
+	for _, r := range s.rows {
+		label := r[0] + strings.Repeat(" ", w-len(r[0]))
+		fmt.Fprintf(target(), "  %s   %s\n", paint(dimStyle, label), r[1])
+	}
+}
+
+// SetTestWriter redirects output to w in plain mode (no colour) and returns a
+// restore func. Intended for tests in this and other packages.
+func SetTestWriter(w io.Writer) func() {
+	mu.Lock()
+	prevOut, prevColor := out, colorOn
+	out, colorOn = w, false
+	mu.Unlock()
+	return func() {
+		mu.Lock()
+		out, colorOn = prevOut, prevColor
+		mu.Unlock()
+	}
+}
+
+func humanDur(d time.Duration) string {
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	return fmt.Sprintf("%.1fs", d.Seconds())
+}

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -1,0 +1,121 @@
+package feedback
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStepOKPlain(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	Start("detecting framework").OK("Laravel 11")
+
+	got := buf.String()
+	want := " → detecting framework… ✓ Laravel 11\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestStepInfoAndFail(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	Start("writing vhost").Info("done")
+	Start("provisioning TLS").Fail(errors.New("mkcert missing"))
+
+	got := buf.String()
+	if !strings.Contains(got, " → writing vhost… done\n") {
+		t.Errorf("missing info line: %q", got)
+	}
+	if !strings.Contains(got, " → provisioning TLS… ✗ mkcert missing\n") {
+		t.Errorf("missing fail line: %q", got)
+	}
+}
+
+func TestLine(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	Line("php 8.4 · node 22 · nginx vhost written")
+
+	if got := buf.String(); got != " → php 8.4 · node 22 · nginx vhost written\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSuccess(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	Success("linked", 1800*time.Millisecond)
+
+	if got := buf.String(); got != " ✓ linked in 1.8s\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestDone(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	Done("unparked sites")
+
+	if got := buf.String(); got != " ✓ unparked sites\n" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSummaryAligned(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	NewSummary().
+		Row("Site", "https://acme.test").
+		Row("PHP", "8.4.3 · FPM running").
+		Row("DB", "mysql · cache redis").
+		Print()
+
+	want := "\n" +
+		"  Site   https://acme.test\n" +
+		"  PHP    8.4.3 · FPM running\n" +
+		"  DB     mysql · cache redis\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("got %q\nwant %q", got, want)
+	}
+}
+
+func TestEmptySummaryPrintsNothing(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	NewSummary().Print()
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("expected no output, got %q", got)
+	}
+}
+
+func TestValPlainPassthrough(t *testing.T) {
+	defer SetTestWriter(&bytes.Buffer{})()
+	if got := Val("8.4"); got != "8.4" {
+		t.Fatalf("plain Val should not style, got %q", got)
+	}
+}
+
+func TestHumanDur(t *testing.T) {
+	cases := map[time.Duration]string{
+		500 * time.Millisecond:  "500ms",
+		1800 * time.Millisecond: "1.8s",
+		2 * time.Second:         "2.0s",
+	}
+	for d, want := range cases {
+		if got := humanDur(d); got != want {
+			t.Errorf("humanDur(%v) = %q, want %q", d, got, want)
+		}
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2130,7 +2130,7 @@ func execEnvSetup(args map[string]any) (any, *rpcError) {
 	}
 
 	var out bytes.Buffer
-	cmd := exec.Command(self, "env")
+	cmd := exec.Command(self, "env", "--verbose")
 	cmd.Dir = projectPath
 	cmd.Stdout = &out
 	cmd.Stderr = &out
@@ -2211,7 +2211,7 @@ func execDbSet(args map[string]any) (any, *rpcError) {
 		return toolErr("could not resolve lerd executable: " + err.Error()), nil
 	}
 	var out bytes.Buffer
-	cmd := exec.Command(self, "env")
+	cmd := exec.Command(self, "env", "--verbose")
 	cmd.Dir = projectPath
 	cmd.Stdout = &out
 	cmd.Stderr = &out

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,17 +1,22 @@
 package tui
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/geodro/lerd/internal/feedback"
+)
 
+// Palette is shared with the CLI feedback package so the TUI and the
+// command-line progress output stay in lockstep.
 var (
-	colTitle    = lipgloss.Color("#FF2D20") // lerd red
-	colDim      = lipgloss.Color("#6b7280") // gray-500
-	colDivider  = lipgloss.Color("#374151") // gray-700
-	colRunning  = lipgloss.Color("#10b981") // emerald-500
-	colStopped  = lipgloss.Color("#6b7280") // gray-500
-	colFailing  = lipgloss.Color("#ef4444") // red-500
-	colPaused   = lipgloss.Color("#f59e0b") // amber-400
-	colAccent   = lipgloss.Color("#a78bfa") // violet-400
-	colSelected = lipgloss.Color("#FF2D20") // lerd red
+	colTitle    = feedback.ColTitle
+	colDim      = feedback.ColDim
+	colDivider  = feedback.ColDivider
+	colRunning  = feedback.ColRunning
+	colStopped  = feedback.ColStopped
+	colFailing  = feedback.ColFailing
+	colPaused   = feedback.ColPaused
+	colAccent   = feedback.ColAccent
+	colSelected = feedback.ColTitle
 )
 
 var (


### PR DESCRIPTION
Closes #567.

This adds `internal/feedback` as the single source of the lerd colour palette (shared with the TUI) and a small set of progress primitives, then routes the CLI through it so every command gives consistent terminal feedback: a step with a spinner that a check or cross replaces in place when it finishes, a live accumulating line (`lerd env` shows each service as it is configured), an aligned key/value summary, styled yes/no prompts, dim sub-notes, and an amber warning glyph in place of the old `[WARN]` prefix.

All of it degrades to plain text when stdout is piped, redirected, or `NO_COLOR` is set, so the MCP server and scripts keep parsing stable output. `lerd env` keeps a `--verbose` mode with the full per-service detail, which is what the MCP server invokes. The `install` and `start` build TUIs and the `dump tail` live stream keep their own rendering.

Along the way this fixes several commands that were leaking raw ANSI escape codes when piped (doctor, service list, xdebug status, notify, dump status), moves per-site `db:move` failures back to stderr, and leaves the `lerd update` sudo and install re-exec path untouched. The macOS-only flows (machine reset, overlay heal, startstop_darwin) are not converted yet.
