### PR TITLE
Keep lerd-dns running across `lerd stop`

### DIFF
--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1155,7 +1156,10 @@ func RunStop() error { return runStop(nil, nil) }
 // RunQuit stops all lerd processes and containers (exported for use by the UI server).
 func RunQuit() error { return runQuit(nil, nil) }
 
-func runStop(_ *cobra.Command, _ []string) error {
+// stopUnitSet returns every unit `lerd stop` tears down. lerd-dns is
+// deliberately excluded: the resolver points .test at it until uninstall, so
+// it stays up as install-level DNS plumbing (the watcher would restart it).
+func stopUnitSet() []string {
 	units := append(coreUnits(), allInstalledServiceUnits()...)
 	units = append(units, installedCustomContainerUnits()...)
 	units = append(units, registeredQueueUnits()...)
@@ -1167,6 +1171,11 @@ func runStop(_ *cobra.Command, _ []string) error {
 	// oneshot .service is a no-op (it isn't running between firings),
 	// so without this the timer keeps dispatching after `lerd stop`.
 	units = append(units, registeredTimerUnits()...)
+	return slices.DeleteFunc(units, func(u string) bool { return u == "lerd-dns" })
+}
+
+func runStop(_ *cobra.Command, _ []string) error {
+	units := stopUnitSet()
 
 	fmt.Println("Stopping Lerd...")
 

--- a/internal/cli/startstop_test.go
+++ b/internal/cli/startstop_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
@@ -183,4 +184,24 @@ func TestEnsurePodmanMachineRunning_linux(t *testing.T) {
 func TestMigrateExecWorkerPlists_linux(t *testing.T) {
 	// On Linux this is a no-op — should not panic
 	migrateExecWorkerPlists()
+}
+
+// TestStopUnitSet_KeepsDNSRunning pins that `lerd stop` excludes lerd-dns even
+// when lerd manages DNS, while coreUnits (the start path) still includes it.
+// The resolver keeps pointing .test at lerd-dns until uninstall, so stopping
+// it would strand that pointer at a dead :5300.
+func TestStopUnitSet_KeepsDNSRunning(t *testing.T) {
+	withTempXDG(t)
+	cfg := &config.GlobalConfig{}
+	cfg.DNS.Enabled = true
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	if !slices.Contains(coreUnits(), "lerd-dns") {
+		t.Fatal("coreUnits must include lerd-dns when DNS is managed (start path)")
+	}
+	if slices.Contains(stopUnitSet(), "lerd-dns") {
+		t.Error("stopUnitSet must exclude lerd-dns so it stays running across `lerd stop`")
+	}
 }


### PR DESCRIPTION
Closes #569.

`lerd stop` used to stop the lerd-dns forwarder, but the resolver hookup that points .test at 127.0.0.1:5300 lives until `lerd uninstall`, so stopping the forwarder stranded the system resolver at a dead port: .test lookups failed or stalled while lerd was stopped and the DNS health pill read down even though nothing was wrong.

This keeps lerd-dns running across `lerd stop` and treats it as install-level DNS plumbing, removed only on uninstall, which matches how the resolver config already persists across stop and start. The stop unit set is now assembled by `stopUnitSet`, which drops lerd-dns while `coreUnits` (the start path) keeps it. It has no effect on reboot, which is governed by the unit enable state.

It also avoids a collision with the lan:expose mapping heal in #553: lerd-watcher keeps running after `lerd stop` and would otherwise restart lerd-dns right after stop killed it. The deeper follow-up of making the DNS watcher honor the intentional-stop marker is tracked separately in #570.
