### PR TITLE
feat(services): add postgres-timescaledb preset

### DIFF
--- a/docs/usage/service-presets.md
+++ b/docs/usage/service-presets.md
@@ -27,6 +27,7 @@ Both kinds use the same YAML schema in `internal/config/presets/*.yaml` and the 
 | `mysql` alternates | `5.7` / `9.7` LTS (canonical 8.4 lives in the default preset) | - | `127.0.0.1:3357` / `127.0.0.1:3397` |
 | `postgres` alternates | `17` / `18` (canonical 16 lives in the default preset) | - | `127.0.0.1:5417` / `127.0.0.1:5418` |
 | `postgres-pgvector` | `pgvector/pgvector:pg18` (canonical) / `pg17` / `pg16` — pgvector instead of PostGIS | - | `127.0.0.1:5518` / `127.0.0.1:5517` / `127.0.0.1:5516` |
+| `postgres-timescaledb` | `timescale/timescaledb:latest-pg17` (canonical) / `pg16` — TimescaleDB time-series extension | - | `127.0.0.1:5617` / `127.0.0.1:5616`. `lerd env` / `lerd link` enables the `timescaledb` extension automatically via `site_init`. |
 | `mariadb` | `12` / `12.3` LTS / `11.8` LTS (default) / `11.4` LTS / `10.11` LTS / `11` (legacy) | - | host ports `3412` / `3423` / `3418` / `3414` / `3410` / `3411` |
 | `mongo` | `docker.io/library/mongo:7` | - | `127.0.0.1:27017` |
 | `mongo-express` | `docker.io/library/mongo-express:latest` | `mongo` (preset) | `http://localhost:8082` |

--- a/docs/usage/service-presets.md
+++ b/docs/usage/service-presets.md
@@ -27,7 +27,7 @@ Both kinds use the same YAML schema in `internal/config/presets/*.yaml` and the 
 | `mysql` alternates | `5.7` / `9.7` LTS (canonical 8.4 lives in the default preset) | - | `127.0.0.1:3357` / `127.0.0.1:3397` |
 | `postgres` alternates | `17` / `18` (canonical 16 lives in the default preset) | - | `127.0.0.1:5417` / `127.0.0.1:5418` |
 | `postgres-pgvector` | `pgvector/pgvector:pg18` (canonical) / `pg17` / `pg16` — pgvector instead of PostGIS | - | `127.0.0.1:5518` / `127.0.0.1:5517` / `127.0.0.1:5516` |
-| `postgres-timescaledb` | `timescale/timescaledb:latest-pg17` (canonical) / `pg16` — TimescaleDB time-series extension | - | `127.0.0.1:5617` / `127.0.0.1:5616`. `lerd env` / `lerd link` enables the `timescaledb` extension automatically via `site_init`. |
+| `postgres-timescaledb` | `timescale/timescaledb:latest-pg17` (canonical) / `pg16` — TimescaleDB time-series extension, enabled automatically by `lerd env` / `lerd link` via `site_init` | - | `127.0.0.1:5617` / `127.0.0.1:5616` |
 | `mariadb` | `12` / `12.3` LTS / `11.8` LTS (default) / `11.4` LTS / `10.11` LTS / `11` (legacy) | - | host ports `3412` / `3423` / `3418` / `3414` / `3410` / `3411` |
 | `mongo` | `docker.io/library/mongo:7` | - | `127.0.0.1:27017` |
 | `mongo-express` | `docker.io/library/mongo-express:latest` | `mongo` (preset) | `http://localhost:8082` |

--- a/internal/config/presets/postgres-timescaledb.yaml
+++ b/internal/config/presets/postgres-timescaledb.yaml
@@ -1,0 +1,33 @@
+name: postgres-timescaledb
+description: PostgreSQL with TimescaleDB (time-series extension)
+family: postgres
+update_strategy: minor
+track_latest: true
+default_version: "17"
+versions:
+  - tag: "17"
+    label: "17 (default)"
+    image: docker.io/timescale/timescaledb:latest-pg17
+    canonical: true
+    host_port: 5617
+  - tag: "16"
+    label: "16"
+    image: docker.io/timescale/timescaledb:latest-pg16
+    host_port: 5616
+ports:
+  - "{{host_port}}:5432"
+data_dir: /var/lib/postgresql/data
+environment:
+  POSTGRES_PASSWORD: lerd
+  POSTGRES_DB: lerd
+  PGDATA: /var/lib/postgresql/data
+env_vars:
+  - DB_CONNECTION=pgsql
+  - DB_HOST=lerd-{{name}}
+  - DB_PORT=5432
+  - DB_DATABASE=lerd
+  - DB_USERNAME=postgres
+  - DB_PASSWORD=lerd
+connection_url: postgresql://postgres:lerd@127.0.0.1:{{host_port}}/lerd
+site_init:
+  exec: psql -U postgres -d {{site}} -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE"

--- a/internal/config/presets/postgres-timescaledb.yaml
+++ b/internal/config/presets/postgres-timescaledb.yaml
@@ -1,8 +1,6 @@
 name: postgres-timescaledb
 description: PostgreSQL with TimescaleDB (time-series extension)
 family: postgres
-update_strategy: minor
-track_latest: true
 default_version: "17"
 versions:
   - tag: "17"


### PR DESCRIPTION
**feat(services): add postgres-timescaledb preset**

  Adds a new opt-in service preset for PostgreSQL with the TimescaleDB time-series extension, following the same pattern as the existing postgres-pgvector preset.

  **What's included**

  - internal/config/presets/postgres-timescaledb.yaml — new preset supporting pg17 (canonical, port 5617) and pg16 (port 5616), using the official timescale/timescaledb image
  - docs/usage/service-presets.md — adds the new preset to the add-on services table

  **How it works**

  lerd service preset postgres-timescaledb          # installs pg17 by default
  lerd service preset postgres-timescaledb --version 16
  lerd env   # creates the project database and enables the timescaledb extension

  The site_init hook runs CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE automatically after the database is created when lerd env / lerd link is invoked — no manual setup
  required.

  **No conflicts with existing postgres**

  Every resource is namespaced by service name — separate container (lerd-postgres-timescaledb), separate ports (56xx), separate data directory. Both services can run simultaneously.
  pgAdmin auto-discovers both via the shared family: postgres.

  **No code changes required**

  - serviceToDBEnv already matches any service prefixed with postgres
  - FamilyOfName reads the family: postgres field from the installed YAML and routes all DB operations (create, drop, shell, import, export, snapshot) through the standard psql path
  - pgAdmin's discover_family:postgres picks it up automatically