### PR TITLE
feat(tui): clickable tabbed dashboard with mouse support

### DIFF
--- a/docs/features/tui.md
+++ b/docs/features/tui.md
@@ -8,12 +8,23 @@ lerd tui
 
 This is the terminal-native counterpart to the [Web UI](/features/web-ui) and the [System Tray](/features/system-tray). Use it when you prefer to keep everything in a tmux or terminal pane, or when you're on a remote machine over SSH.
 
+## Tabs
+
+A clickable tab strip sits at the top and switches the whole screen between three views: **Dashboard**, **Sites**, and **Services**. The TUI opens on the **Dashboard**. Click a tab to switch, or cycle with `ctrl+←` / `ctrl+→` from the keyboard. The active tab reads as a filled accent pill in the lerd palette; the others sit dim.
+
+- **Dashboard** — a six-card overview that mirrors the web UI's home page (see [Dashboard tab](#dashboard-tab)).
+- **Sites** — the sites list plus the full-height site detail pane.
+- **Services** — the services list plus the service detail pane.
+
+The version (and an `update <ver>` note when a newer release is available) sits on the far right of the tab row; there is no separate status line. The at-a-glance health that used to live in a header now lives on the Dashboard tab's cards instead.
+
+Mouse support is on: clicking a tab switches screens, clicking a site or service row selects it, clicking a site/service on the Dashboard jumps to its tab, and the wheel scrolls whichever scrollable pane it's over (any dashboard card, the lists, the detail pane, or the log panes). The keyboard keeps working exactly as before, so nothing in the rest of this page requires a mouse. (Enabling mouse tracking means your terminal's native click-drag text selection is intercepted while the TUI runs; hold `Shift` — or your terminal's selection modifier — to select text the usual way.)
+
 ## Layout
 
-- **Header** shows the lerd version, DNS / nginx / FPM status, watcher state, the wall clock, and an `update: vX.Y.Z` banner when a newer release is available (populated from the same 24-hour cache `lerd status` and `lerd doctor` use, so no extra network on startup). When any framework worker is failing a red `⚠ N` pill appears alongside the clock; press `H` to fire `lerd worker heal` and clear it.
-- **Sites pane (left column, top)** lists every linked site by its primary domain, with an FPM running dot, PHP version, and worker glyphs (`q` queue, `s` schedule, `v` reverb, `h` horizon, plus a dot per custom framework worker). Paused sites are dimmed and marked. Columns line up across rows regardless of how many workers each site runs.
-- **Services pane (left column, bottom)** is a compact list of built-in services (mysql, redis, postgres, meilisearch, rustfs, mailpit), custom services, and every site-owned worker (`queue-<site>`, `schedule-<site>`, `horizon-<site>`, `reverb-<site>`, and custom framework workers). Each row shows a running dot, how many sites use it, and `pinned` / `custom` tags where applicable.
-- **Site detail (right column, full height)** always mirrors the focused site and shows primary domain, the Laravel `APP_NAME` when the site sets a custom one, internal name, disk path, all domains, services used (with live state), workers, git worktrees, HTTPS / LAN share toggles, and PHP / Node version pickers. `S` swaps it for global Settings, `?` swaps it for the Keybindings reference.
+- **Sites pane (Sites tab, left column)** lists every linked site by its primary domain, with an FPM running dot and worker glyphs (`q` queue, `s` schedule, `v` reverb, `h` horizon, plus a dot per custom framework worker). Paused sites are dimmed and marked. Columns line up across rows regardless of how many workers each site runs. The column is intentionally slim; the Services tab keeps a wider list since its rows carry version and usage metadata.
+- **Services pane (Services tab, left column)** is a compact list of built-in services (mysql, redis, postgres, meilisearch, rustfs, mailpit), custom services, and every site-owned worker (`queue-<site>`, `schedule-<site>`, `horizon-<site>`, `reverb-<site>`, and custom framework workers). Each row shows a running dot, how many sites use it, and `pinned` / `custom` tags where applicable.
+- **Site detail (Sites tab, right column, full height)** always mirrors the focused site and shows primary domain, the Laravel `APP_NAME` when the site sets a custom one, internal name, disk path, all domains, services used (with live state), workers, git worktrees, HTTPS / LAN share toggles, and PHP / Node version pickers. On the Sites tab, `S` swaps it for global Settings, `?` swaps it for the Keybindings reference. When the Overview sub-tab is showing a site that writes app logs, a separate **App logs pane** opens beneath the detail showing a live tail of the newest log file; scroll it with `{` / `}` (or the mouse wheel).
 - **Logs pane** (toggle with `l`) tails the container, worker-journal, or app log file behind the focused item. Takes at least half the window and renders a right-edge scrollbar showing position in the buffer.
 - **Status bar** briefly shows the most recent action (e.g. `✓ lerd service stop redis` or `✖ …exit 1`).
 - **Footer** summarises active keybindings for the current mode.
@@ -26,8 +37,10 @@ Dots follow the same convention everywhere: green `●` running, grey `○` stop
 
 | Key | Action |
 | --- | --- |
-| `tab` / `shift+tab` | Cycle focus through Sites · Detail · Services so a tab from a freshly-selected site lands on its detail pane. Use `v` to hide Services from the cycle entirely |
-| `↑` `↓` / `j` `k` | Move selection in the focused pane |
+| `ctrl+←` / `ctrl+→` | Switch the top tab (Dashboard · Sites · Services). Tabs are also clickable |
+| click | Click a tab to switch screens, or a site / service row to select it |
+| `tab` / `shift+tab` | Cycle focus between the list and the detail pane on the current tab |
+| `↑` `↓` / `j` `k` | Move selection in the focused pane (scrolls the grid on the Dashboard tab) |
 | `pgup` `pgdn` | Jump by 10 rows |
 | `home` `g` | Jump to first row |
 | `end` `G` | Jump to last row |
@@ -77,12 +90,12 @@ Available when focus is on the Detail pane with the cursor on a domain row.
 
 ### Panes and overlays
 
+`S`, `Y`, and `D` swap the **Sites tab** detail pane; they no-op on the Dashboard and Services tabs. The Dashboard is now its own top tab (see [Dashboard tab](#dashboard-tab)).
+
 | Key | Action |
 | --- | --- |
-| `v` | Show / hide the Services pane |
-| `F` | Swap the Detail pane for the Dashboard (counts, system health, container resources) and focus it |
-| `S` | Swap the Detail pane for global Settings (LAN expose, autostart, Xdebug) and focus it |
-| `Y` | Swap the Detail pane for the System overview (DNS, Nginx, Watcher, Notifications, Debug bridge, PHP per-version, Node, Lerd) and focus it |
+| `S` | Swap the Detail pane for global Settings (LAN expose, autostart, Xdebug) and focus it — Sites tab |
+| `Y` | Swap the Detail pane for the System overview (DNS, Nginx, Watcher, Notifications, Debug bridge, PHP per-version, Node, Lerd) and focus it — Sites tab |
 | `D` | Open the Debug window, the same capture the web dashboard shows. `[` / `]` switch lens across `Dumps · Queries · Jobs · Views · Mail · Cache · Events · HTTP`; the Queries lens groups by request with N+1 and slow-query (≥100ms) flags, and the other lenses group by request too. Use `/` to search the active lens (site, request, worker, file, text, payload) · `1`/`2` toggle the FPM / CLI context-filter chips · `enter` expands the selected row (query bindings and caller, job exception, view template, mail recipients, …) · `w` toggles worker capture (queue / scheduler events, off by default) · `c` clears the buffer (and runs `lerd dump clear`) · `T` toggles the bridge globally. The buffer is independent of the lerd-ui ring because the TUI runs in its own process and only sees what the SSE connection delivers |
 | `?` | Open the Keybindings reference as a centered modal overlay; `?` again or `esc` closes it |
 | `esc` | Dismiss the active modal (palette / picker / help / confirm), return to the pane underneath |
@@ -120,15 +133,14 @@ For worker rows (queue-X, schedule-X, custom framework workers) the detail varia
 
 ## Site detail tabs
 
-The site detail pane is split into four read-side tabs the user can jump between with the number keys, mirroring the web UI's `Overview / Env / Tinker / Debug` strip (Tinker is CLI-only since it needs an interactive REPL):
+The site detail pane is split into read-side tabs the user can jump between with the number keys, mirroring the web UI's `Overview / Env / Debug` strip (Tinker is CLI-only since it needs an interactive REPL). App logs no longer have their own tab — the Overview tab shows a live tail of the newest log file in a pane beneath it (see [Layout](#layout)).
 
 | Key | Tab | Contents |
 | --- | --- | --- |
-| `1` | Overview | The default — domains, services used, workers, worktrees, toggles (HTTPS / LAN / PHP / Node) |
+| `1` | Overview | The default — domains, services used, workers, worktrees, toggles (HTTPS / LAN / PHP / Node), and an app-logs pane beneath it |
 | `2` | Env | Read-only display of the site's `.env` file (read up to 256 KB so a runaway file can't wedge the render loop) |
 | `3` | Debug | This site's slice of the Debug window: the active lens (Dumps · Queries · Jobs · Views · Mail · Cache · Events · HTTP) scoped to the focused site, with `[` / `]` to switch lens and `w` to toggle worker capture. Rows show their detail inline; press `D` for the full cross-site window |
-| `4` | App logs | Every framework-declared log file with size and modification time; press `l` to actually tail one — the file targets are wired into `logTargetsForSite`, so `[` / `]` cycle through them once the log pane is open |
-| `5` | Doctor | Laravel only — the same app-level health checks the web dashboard runs (`APP_KEY`, `.env` drift against `.env.example` warning only on keys the code reads without a default, the `APP_DEBUG`-in-production footgun, the `public/storage` symlink, and pending migrations). The migrations check execs artisan in the container, so the run is on-demand: the tab appears only for Laravel sites, press `5` to run and again to re-run. The panel is read-only and names the suggested fix (e.g. `key:generate`, `migrate`) rather than running it, so a status view can never migrate a database |
+| `4` | Doctor | Laravel only — the same app-level health checks the web dashboard runs (`APP_KEY`, `.env` drift against `.env.example` warning only on keys the code reads without a default, the `APP_DEBUG`-in-production footgun, the `public/storage` symlink, and pending migrations). The migrations check execs artisan in the container, so the run is on-demand: the tab appears only for Laravel sites, press `4` to run and again to re-run. The panel is read-only and names the suggested fix (e.g. `key:generate`, `migrate`) rather than running it, so a status view can never migrate a database |
 
 Switching tabs resets the detail-pane scroll so the user lands at the top of the new tab. Picker overlays (PHP / Node version) only show in Overview; selecting a different tab dismisses them.
 
@@ -146,9 +158,20 @@ Sections, top to bottom:
 - **Worktrees** — every git worktree with its branch, domain, and path when the site uses them. Each worktree row carries its own controls — PHP / Node version pickers, LAN-share toggle, isolated-DB toggle, and per-worktree framework worker toggles (e.g. vite) — so a branch's runtime can be tuned without affecting the parent. `space` on a worktree-scoped row toggles the matching state via the same CLI commands the parent rows use, just with the worktree's path threaded through.
 - **Toggles** — HTTPS (runs `lerd secure` / `lerd unsecure`), LAN share (runs `lerd lan share` / `unshare` — shows the full `http://<lan-ip>:<port>` URL when enabled), PHP version (opens an inline picker from installed versions → `lerd isolate <ver>`; a FrankenPHP site only lists the versions FrankenPHP publishes an image for, so the picker never offers one that would silently downgrade), Node version (picker backed by `fnm list` → `lerd isolate:node <ver>`; when a host bun is installed the list also carries a `bun` entry that pins the site's JS runtime via `lerd js:runtime bun`, and picking a Node version while pinned to bun clears the pin first so the dev worker actually switches back).
 
+## Dashboard tab
+
+The **Dashboard** tab is the terminal counterpart to the web UI's home page: a responsive grid of the same six cards. It reflows from three columns (wide) to two (medium) to one (narrow). Each card shows its whole list and scrolls within its own box — the **focused** card (accent border) scrolls with `↑` `↓` / `j` `k`; `tab` / `shift+tab` moves focus between cards; the mouse wheel scrolls whichever card it's over.
+
+- **Sites** — total · running · paused counts, then every linked site with its FPM running dot. Clicking a site jumps to the Sites tab on that site.
+- **Services** — total · running counts, then every core / custom service with state dot and version. Clicking a service jumps to the Services tab on that service.
+- **Workers** — active · asleep · failing counts, then every worker (site · kind) with its state, and the failing units with a `press H to heal` hint.
+- **System Health** — DNS (ok / degraded / down / disabled), Nginx, Watcher, and the running PHP FPM versions.
+- **Resources** — total CPU% and memory across lerd's footprint, then every container by load. Polled in the background every 3 s, matching the cache TTL the web UI uses; a `collecting…` placeholder shows until the first sample lands.
+- **Lerd** — version, an `update:` banner when a newer release is available, autostart, LAN expose, platform, and a **Recent activity** feed (site link/pause/resume/start/stop, service add/remove/start/stop, worker fail/heal, DNS transitions) derived live, mirroring the web UI's activity list.
+
 ## Settings view
 
-Press `S` to swap the detail pane for global settings. Navigate with `↑` `↓`, toggle with `space`:
+Press `S` (on the Sites tab) to swap the detail pane for global settings. Navigate with `↑` `↓`, toggle with `space`:
 
 - **LAN expose** — flip every container to 0.0.0.0 binds (`lerd lan expose on/off`).
 - **Autostart on login** — `lerd autostart enable/disable`.
@@ -156,21 +179,9 @@ Press `S` to swap the detail pane for global settings. Navigate with `↑` `↓`
 
 `S` again (or `esc`) returns to Site detail.
 
-## Dashboard view
-
-Press `F` to swap the detail pane for the Dashboard — the terminal counterpart to the web UI's home page. It is purely informational; every reversible action lives in the System pane (`Y`) instead. Sections:
-
-- **Hero** — failing-worker count (or an "all workers healthy" confirmation), plus an update banner when a newer lerd release is available, or the current version if not.
-- **Overview** — `Sites` (total · running · paused), `Services` (total · running · stopped), `Workers` (active · failing with a `press H` hint when any are red).
-- **System health** — DNS (mirrors the header pill: ok / degraded / down / disabled), Nginx, Watcher, and the comma-separated list of running PHP FPM versions.
-- **Resources** — total CPU% and total memory across lerd's whole footprint: the `lerd-*` containers (via `podman stats`) plus lerd's own host-side processes (the lerd-ui/watcher/tray daemons and any host worker such as a Vite dev server, via systemd cgroup accounting on Linux). The top five are ranked by combined CPU+memory load, so a CPU-heavy but low-memory process surfaces rather than being hidden behind idle memory hogs. CPU is the instantaneous rate (lerd reads past `podman stats`'s first sample, which is a misleading lifetime average). Polled in the background every 3 s, matching the cache TTL the web UI uses so the two surfaces stay aligned. While the first sample is in flight a `collecting…` placeholder renders so an empty pane is never shown.
-- **Lerd** — version, autostart, LAN expose, and platform (`linux/amd64`, `darwin/arm64`, …).
-
-`F` again or `esc` returns to Site detail.
-
 ## System view
 
-Press `Y` to swap the detail pane for the System overview — the terminal-side counterpart to the web UI's System tab. Sections cover every shared subject lerd manages outside of an individual site, with informational rows for status and reversible toggles for safe operations:
+Press `Y` (on the Sites tab) to swap the detail pane for the System overview — the terminal-side counterpart to the web UI's System tab. Sections cover every shared subject lerd manages outside of an individual site, with informational rows for status and reversible toggles for safe operations:
 
 - **DNS** — TLD, live status (ok · degraded · down · disabled) computed by `dns.CheckStatus`, plus a VPN-active hint when an interface that typically rewrites the system resolver is up.
 - **Nginx** — running / stopped.
@@ -190,7 +201,7 @@ Press `?` to open the full keybinding reference as a centered modal overlay. Scr
 
 ## Toasts
 
-Action results (a service restart, a worker heal, a toggle) land as **toast notifications** in the bottom-right corner: a coloured severity dot (green / amber / red), bold title (the CLI invocation), and a dim subtext for any error message. Up to three toasts stack vertically; older ones drop after 30 s. Press `d` to dismiss the newest manually. Identical back-to-back toasts coalesce so a busy moment doesn't bury the screen.
+Action results (a service restart, a worker heal, a toggle) land as **toast notifications** in the bottom-right corner: a coloured severity dot (green / amber / red), bold title (the CLI invocation), and a dim subtext for any error message. They composite **over** the content as an overlay rather than reflowing the panes, so a transient notification never shifts what you're looking at. Up to three toasts stack vertically; older ones drop after 30 s. Press `d` to dismiss the newest manually. Identical back-to-back toasts coalesce so a busy moment doesn't bury the screen.
 
 During an in-flight action the status line (just above the toasts) shows an animated Braille spinner (`⠋⠙⠹…`) so the user feels the action is alive even when the underlying CLI takes a few seconds.
 

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 // indirect
-	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
+	github.com/charmbracelet/colorprofile v0.3.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
@@ -50,6 +50,7 @@ require (
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/lrstanley/bubblezone v1.0.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlv
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc/go.mod h1:X4/0JoqgTIPSFcRA/P6INZzIuyqdFY5rm8tb41s9okk=
+github.com/charmbracelet/colorprofile v0.3.1 h1:k8dTHMd7fgw4bnFd7jXTLZrSU/CQrKnL3m+AxCzDz40=
+github.com/charmbracelet/colorprofile v0.3.1/go.mod h1:/GkGusxNs8VB/RSOh3fu0TJmQ4ICMMPApIIVn0KszZ0=
 github.com/charmbracelet/glamour v1.0.0 h1:AWMLOVFHTsysl4WV8T8QgkQ0s/ZNZo7CiE4WKhk8l08=
 github.com/charmbracelet/glamour v1.0.0/go.mod h1:DSdohgOBkMr2ZQNhw4LZxSGpx3SvpeujNoXrQyH2hxo=
 github.com/charmbracelet/huh v1.0.0 h1:wOnedH8G4qzJbmhftTqrpppyqHakl/zbbNdXIWJyIxw=
@@ -104,6 +106,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/lrstanley/bubblezone v1.0.0 h1:bIpUaBilD42rAQwlg/4u5aTqVAt6DSRKYZuSdmkr8UA=
+github.com/lrstanley/bubblezone v1.0.0/go.mod h1:kcTekA8HE/0Ll2bWzqHlhA2c513KDNLW7uDfDP4Mly8=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lxn/walk v0.0.0-20210112085537-c389da54e794/go.mod h1:E23UucZGqpuUANJooIbHWCufXvOcT6E7Stq81gU+CSQ=

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -18,14 +18,16 @@ import (
 // Canonical lerd palette (Tailwind hex values). The TUI theme aliases these so
 // CLI feedback and the dashboard share one set of colours.
 var (
-	ColTitle   = lipgloss.Color("#FF2D20") // lerd red
+	ColTitle   = lipgloss.Color("#FF2D20") // lerd red (Laravel brand)
 	ColDim     = lipgloss.Color("#6b7280") // gray-500
 	ColDivider = lipgloss.Color("#374151") // gray-700
 	ColRunning = lipgloss.Color("#10b981") // emerald-500
 	ColStopped = lipgloss.Color("#6b7280") // gray-500
 	ColFailing = lipgloss.Color("#ef4444") // red-500
 	ColPaused  = lipgloss.Color("#f59e0b") // amber-400
-	ColAccent  = lipgloss.Color("#a78bfa") // violet-400
+	// Interactive accent is the brand red so the TUI, CLI feedback, and the web
+	// UI all share one accent rather than diverging on a separate hue.
+	ColAccent = lipgloss.Color("#FF2D20") // lerd red
 )
 
 var (

--- a/internal/tui/activity.go
+++ b/internal/tui/activity.go
@@ -1,0 +1,182 @@
+package tui
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// activityCap bounds the recent-activity ring so a long-running TUI doesn't
+// accumulate events forever. Matches the web UI's MAX of 30.
+const activityCap = 30
+
+type activityTone int
+
+const (
+	toneGood activityTone = iota
+	toneBad
+	toneWarn
+)
+
+// activityEvent is one entry in the Recent Activity feed, derived by diffing
+// two consecutive snapshots. text is the pre-built label; at is used to render
+// a relative timestamp lazily so the line re-renders without per-event timers.
+type activityEvent struct {
+	text string
+	tone activityTone
+	at   time.Time
+}
+
+func (e activityEvent) render() string {
+	dot := runningStyle.Render(glyphRunning)
+	switch e.tone {
+	case toneBad:
+		dot = failingStyle.Render(glyphFailing)
+	case toneWarn:
+		dot = pausedStyle.Render(glyphPaused)
+	}
+	return dot + " " + e.text + "  " + dimStyle.Render(humanAgo(time.Since(e.at)))
+}
+
+// humanAgo renders a coarse relative duration ("now", "5m", "2h", "3d").
+func humanAgo(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+// recordActivity diffs the incoming snapshot against the previous one, prepends
+// any new events to the ring (newest first), and stores the snapshot as the
+// baseline for next time. The first snapshot only sets the baseline.
+func (m *Model) recordActivity(next Snapshot, now time.Time) {
+	if m.prevSnap != nil {
+		if evs := diffSnapshots(*m.prevSnap, next, now); len(evs) > 0 {
+			m.activity = append(evs, m.activity...)
+			if len(m.activity) > activityCap {
+				m.activity = m.activity[:activityCap]
+			}
+		}
+	}
+	cp := next
+	m.prevSnap = &cp
+}
+
+// diffSnapshots compares two snapshots and returns the state-change events
+// between them, mirroring the subset of the web UI's activity diff the TUI
+// can derive from its own snapshot: site link/remove/pause/resume/run/stop,
+// service add/remove/start/stop, worker fail/heal, and DNS transitions.
+func diffSnapshots(prev, cur Snapshot, now time.Time) []activityEvent {
+	var out []activityEvent
+	add := func(text string, tone activityTone) {
+		out = append(out, activityEvent{text: text, tone: tone, at: now})
+	}
+
+	siteSubject := func(s siteinfo.EnrichedSite) string {
+		if d := s.PrimaryDomain(); d != "" {
+			return d
+		}
+		return s.Name
+	}
+
+	prevSites := make(map[string]siteinfo.EnrichedSite, len(prev.Sites))
+	for _, s := range prev.Sites {
+		prevSites[s.Name] = s
+	}
+	curSites := make(map[string]bool, len(cur.Sites))
+	for _, s := range cur.Sites {
+		curSites[s.Name] = true
+		old, ok := prevSites[s.Name]
+		if !ok {
+			add("linked "+siteSubject(s), toneGood)
+			continue
+		}
+		switch {
+		case old.Paused != s.Paused:
+			if s.Paused {
+				add("paused "+siteSubject(s), toneWarn)
+			} else {
+				add("resumed "+siteSubject(s), toneGood)
+			}
+		case old.FPMRunning != s.FPMRunning:
+			if s.FPMRunning {
+				add(siteSubject(s)+" started", toneGood)
+			} else {
+				add(siteSubject(s)+" stopped", toneBad)
+			}
+		}
+	}
+	for name, s := range prevSites {
+		if !curSites[name] {
+			add("removed "+siteSubject(s), toneBad)
+		}
+	}
+
+	prevSvc := make(map[string]ServiceRow)
+	for _, s := range prev.Services {
+		if s.WorkerKind == "" {
+			prevSvc[s.Name] = s
+		}
+	}
+	curSvc := make(map[string]bool)
+	for _, s := range cur.Services {
+		if s.WorkerKind != "" {
+			continue
+		}
+		curSvc[s.Name] = true
+		old, ok := prevSvc[s.Name]
+		if !ok {
+			add("added "+s.Name, toneGood)
+			continue
+		}
+		if (old.State == stateRunning) != (s.State == stateRunning) {
+			if s.State == stateRunning {
+				add(s.Name+" started", toneGood)
+			} else {
+				add(s.Name+" stopped", toneBad)
+			}
+		}
+	}
+	for name := range prevSvc {
+		if !curSvc[name] {
+			add("removed "+name, toneBad)
+		}
+	}
+
+	prevFail := make(map[string]bool)
+	for _, n := range failingWorkerNames(prev) {
+		prevFail[n] = true
+	}
+	curFail := make(map[string]bool)
+	for _, n := range failingWorkerNames(cur) {
+		curFail[n] = true
+		if !prevFail[n] {
+			add(n+" failed", toneBad)
+		}
+	}
+	for n := range prevFail {
+		if !curFail[n] {
+			add(n+" healed", toneGood)
+		}
+	}
+
+	if prev.Status.DNSOk != cur.Status.DNSOk || prev.Status.DNSDegraded != cur.Status.DNSDegraded {
+		switch {
+		case cur.Status.DNSOk:
+			add("DNS recovered", toneGood)
+		case cur.Status.DNSDegraded:
+			add("DNS degraded", toneWarn)
+		default:
+			add("DNS down", toneBad)
+		}
+	}
+
+	return out
+}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/geodro/lerd/internal/config"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/geodro/lerd/internal/stats"
-	lerdSystemd "github.com/geodro/lerd/internal/systemd"
+	zone "github.com/lrstanley/bubblezone"
 )
 
 // statsPollInterval is how often the background poller refreshes resource
@@ -46,150 +46,347 @@ func runStatsPoller(ctx context.Context, p *tea.Program) {
 	}
 }
 
-// dashboardContentLinesWithCursor renders the Dashboard detail pane. It is
-// purely informational — no toggles live here because the System pane (Y)
-// already owns every reversible action. Reports a cursor line of 0 so the
-// scrollbar treats the view as a plain scroll surface.
-func dashboardContentLinesWithCursor(m *Model, _ bool, innerW int) ([]string, int) {
-	out := make([]string, 0, 64)
-	add := func(s string) { out = append(out, padToWidth(clipLine(s, innerW), innerW)) }
+// numDashCards is the number of cards in the dashboard grid; it bounds the
+// per-card focus index and scroll-offset array on the model.
+const numDashCards = 6
 
-	add(sectionStyle.Render("Dashboard"))
-	add(dimStyle.Render("  press F or esc to return to site detail"))
-	add("")
+// cardContent is a dashboard card's full body. rowZones maps a body line index
+// to a bubblezone id so individual rows (sites, services) become clickable —
+// the rest of the lines are plain.
+type cardContent struct {
+	lines    []string
+	rowZones map[int]string
+}
 
-	// Hero: failing workers + update banner.
-	hero := []string{}
-	if n := countFailingWorkers(m.snap); n > 0 {
-		hero = append(hero, failingStyle.Render(fmt.Sprintf("⚠ %d workers failing", n)))
-	} else {
-		hero = append(hero, runningStyle.Render("all workers healthy"))
+// renderDashboardGrid draws the Dashboard tab as a responsive grid of six
+// cards mirroring the lerd web UI: Sites, Services, Workers, System Health,
+// Resources and Lerd. Three columns when wide, two at medium width, one when
+// narrow. Each card shows its whole list and scrolls within its own box; the
+// focused card (j/k or mouse wheel) gets an accent border.
+func (m *Model) renderDashboardGrid(w, h int) string {
+	cols := 3
+	switch {
+	case w < 70:
+		cols = 1
+	case w < narrowWidth:
+		cols = 2
 	}
-	if m.updateAvailable != "" {
-		hero = append(hero, accentStyle.Render("update: "+m.updateAvailable))
-	} else {
-		hero = append(hero, dimStyle.Render("lerd "+m.version))
+	const gap = 1
+	cardW := (w - (cols-1)*gap) / cols
+	if cardW < 24 {
+		cardW = 24
 	}
-	add("  " + strings.Join(hero, "   "))
-	add("")
+	innerW := cardW - 4 // rounded border (2) + horizontal padding (2)
+	if innerW < 16 {
+		innerW = 16
+	}
 
-	// Counts: sites, services, workers — keep on one line so the user sees
-	// the whole instance at a glance without scrolling.
-	siteRunning, sitePaused := 0, 0
+	titles := []string{"Sites", "Services", "Workers", "System Health", "Resources", "Lerd"}
+	cw := innerW - 1 // content width inside the scrollbar column
+	contents := []cardContent{
+		m.dashSitesCard(cw),
+		m.dashServicesCard(cw),
+		m.dashWorkersCard(cw),
+		m.dashSystemHealthCard(cw),
+		m.dashResourcesCard(cw),
+		m.dashLerdCard(cw),
+	}
+
+	rows := (numDashCards + cols - 1) / cols
+	cardH := h / rows
+	// Floor at 3 (border + border + a line) only when it still fits, so a short
+	// terminal shrinks every card rather than clipping whole cards off the
+	// bottom via the safety net below.
+	if cardH < 3 && rows*3 <= h {
+		cardH = 3
+	}
+	if cardH < 1 {
+		cardH = 1
+	}
+	boxes := make([]string, numDashCards)
+	for i := range contents {
+		boxes[i] = m.renderScrollableCard(i, titles[i], contents[i], innerW, cardH)
+	}
+
+	spacer := strings.Repeat(" ", gap)
+	var rowStrs []string
+	for r := 0; r < rows; r++ {
+		var rowParts []string
+		for c := 0; c < cols; c++ {
+			idx := r*cols + c
+			if idx >= len(boxes) {
+				break
+			}
+			if c > 0 {
+				rowParts = append(rowParts, spacer)
+			}
+			rowParts = append(rowParts, boxes[idx])
+		}
+		rowStrs = append(rowStrs, lipgloss.JoinHorizontal(lipgloss.Top, rowParts...))
+	}
+	grid := lipgloss.JoinVertical(lipgloss.Left, rowStrs...)
+	// Safety net: never let the grid push the footer off-screen if rounding
+	// made it a hair taller than the body budget.
+	if gl := strings.Split(grid, "\n"); len(gl) > h {
+		grid = strings.Join(gl[:h], "\n")
+	}
+	return grid
+}
+
+// renderScrollableCard boxes a titled card and shows a scroll window over its
+// full content. The whole card is a bubblezone ("card:<idx>") for wheel/click
+// hit-testing; clickable rows carry their own marks. The focused card gets an
+// accent border.
+func (m *Model) renderScrollableCard(idx int, title string, c cardContent, innerW, cardH int) string {
+	bodyH := cardH - 2 // top + bottom border
+	if bodyH < 1 {
+		bodyH = 1
+	}
+	avail := bodyH - 1 // title row
+	if avail < 1 {
+		avail = 1
+	}
+
+	maxScroll := len(c.lines) - avail
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	scroll := m.dashScroll[idx]
+	if scroll > maxScroll {
+		scroll = maxScroll
+	}
+	if scroll < 0 {
+		scroll = 0
+	}
+	m.dashScroll[idx] = scroll
+
+	contentW := innerW - 1 // reserve the scrollbar column
+	if contentW < 1 {
+		contentW = innerW
+	}
+
+	visible := len(c.lines) - scroll
+	if visible > avail {
+		visible = avail
+	}
+	if visible < 0 {
+		visible = 0
+	}
+	bar := renderScrollbar(avail, len(c.lines), scroll, visible)
+
+	body := []string{padToWidth(clipLine(sectionStyle.Render(title), innerW), innerW)}
+	for i := 0; i < avail; i++ {
+		row := spaces(contentW)
+		if li := scroll + i; li < len(c.lines) {
+			row = padToWidth(clipLine(c.lines[li], contentW), contentW)
+			if z, ok := c.rowZones[li]; ok {
+				row = zone.Mark(z, row)
+			}
+		}
+		body = append(body, row+bar[i])
+	}
+
+	style := cardStyle
+	if m.activeTab == tabDashboard && m.dashFocus == idx {
+		style = style.BorderForeground(colAccent)
+	}
+	return zone.Mark(fmt.Sprintf("card:%d", idx), style.Render(strings.Join(body, "\n")))
+}
+
+// dashRowRight lays a label on the left and its value flush against the right
+// edge of width, with the gap between them, so columns of values line up at
+// the card's right side. Both label and value may already be styled.
+func dashRowRight(label, value string, width int) string {
+	gap := width - lipgloss.Width(label) - lipgloss.Width(value)
+	if gap < 1 {
+		gap = 1
+	}
+	return label + spaces(gap) + value
+}
+
+func (m *Model) dashSitesCard(width int) cardContent {
+	running, paused := 0, 0
 	for _, s := range m.snap.Sites {
 		if s.Paused {
-			sitePaused++
+			paused++
 		} else if s.FPMRunning {
-			siteRunning++
+			running++
 		}
 	}
-	svcRunning, svcStopped := 0, 0
-	workerActive, workerFailing := 0, 0
+	lines := []string{
+		fmt.Sprintf("%d total · %s · %s", len(m.snap.Sites),
+			runningStyle.Render(fmt.Sprintf("%d running", running)),
+			pausedStyle.Render(fmt.Sprintf("%d paused", paused))),
+		"",
+	}
+	if len(m.snap.Sites) == 0 {
+		return cardContent{append(lines, dimStyle.Render("no linked sites yet")), nil}
+	}
+	zones := map[int]string{}
+	for i, s := range m.snap.Sites {
+		name := s.PrimaryDomain()
+		if name == "" {
+			name = s.Name
+		}
+		// Domain on the left, framework label flush right.
+		right := ""
+		if s.FrameworkLabel != "" {
+			right = dimStyle.Render(s.FrameworkLabel)
+		}
+		zones[len(lines)] = fmt.Sprintf("dashsite:%d", i)
+		lines = append(lines, dashRowRight(fpmGlyph(s)+" "+name, right, width))
+	}
+	return cardContent{lines, zones}
+}
+
+func (m *Model) dashServicesCard(width int) cardContent {
+	total, running := 0, 0
 	for _, s := range m.snap.Services {
 		if s.WorkerKind != "" {
-			if s.State == stateRunning {
-				workerActive++
-			}
 			continue
 		}
+		total++
 		if s.State == stateRunning {
-			svcRunning++
-		} else {
-			svcStopped++
+			running++
 		}
 	}
-	for _, s := range m.snap.Sites {
-		if s.QueueFailing {
-			workerFailing++
-		}
-		if s.ScheduleFailing {
-			workerFailing++
-		}
-		if s.HorizonFailing {
-			workerFailing++
-		}
-		if s.ReverbFailing {
-			workerFailing++
-		}
-		for _, fw := range s.FrameworkWorkers {
-			if fw.Failing {
-				workerFailing++
-			}
-		}
-		for _, wt := range s.Worktrees {
-			for _, fw := range wt.FrameworkWorkers {
-				if fw.Failing {
-					workerFailing++
-				}
-			}
-		}
+	lines := []string{
+		fmt.Sprintf("%d total · %s", total, runningStyle.Render(fmt.Sprintf("%d running", running))),
+		"",
 	}
+	if total == 0 {
+		return cardContent{append(lines, dimStyle.Render("no services configured")), nil}
+	}
+	zones := map[int]string{}
+	for i, s := range m.snap.Services {
+		if s.WorkerKind != "" {
+			continue
+		}
+		// Name on the left, version flush right.
+		right := ""
+		if s.Version != "" {
+			right = dimStyle.Render(s.Version)
+		}
+		zones[len(lines)] = fmt.Sprintf("dashsvc:%d", i)
+		lines = append(lines, dashRowRight(serviceStateGlyph(s.State)+" "+s.Name, right, width))
+	}
+	return cardContent{lines, zones}
+}
 
-	add(sectionStyle.Render("Overview"))
-	add(renderSystemInfoRow("Sites",
-		fmt.Sprintf("%d total · %s · %s",
-			len(m.snap.Sites),
-			runningStyle.Render(fmt.Sprintf("%d running", siteRunning)),
-			pausedStyle.Render(fmt.Sprintf("%d paused", sitePaused)))))
-	add(renderSystemInfoRow("Services",
-		fmt.Sprintf("%d total · %s · %s",
-			svcRunning+svcStopped,
-			runningStyle.Render(fmt.Sprintf("%d running", svcRunning)),
-			dimStyle.Render(fmt.Sprintf("%d stopped", svcStopped)))))
-	workerLine := runningStyle.Render(fmt.Sprintf("%d active", workerActive))
-	if workerFailing > 0 {
-		workerLine += " · " + failingStyle.Render(fmt.Sprintf("%d failing (press H)", workerFailing))
+func (m *Model) dashWorkersCard(width int) cardContent {
+	active, asleep := 0, 0
+	// Track each worker's index into m.snap.Services so a clicked row can map
+	// back to the matching service-list entry.
+	var workerIdx []int
+	for i, s := range m.snap.Services {
+		if s.WorkerKind == "" {
+			continue
+		}
+		workerIdx = append(workerIdx, i)
+		switch s.State {
+		case stateRunning:
+			active++
+		case stateSuspended:
+			asleep++
+		}
 	}
-	add(renderSystemInfoRow("Workers", workerLine))
+	failing := failingWorkerNames(m.snap)
+	summary := runningStyle.Render(fmt.Sprintf("%d active", active))
+	if asleep > 0 {
+		summary += " · " + suspendedStyle.Render(fmt.Sprintf("%d asleep", asleep))
+	}
+	if len(failing) > 0 {
+		summary += " · " + failingStyle.Render(fmt.Sprintf("%d failing", len(failing)))
+	}
+	lines := []string{summary, ""}
+	if len(workerIdx) == 0 && len(failing) == 0 {
+		return cardContent{append(lines, runningStyle.Render("all workers healthy")), nil}
+	}
+	zones := map[int]string{}
+	for _, idx := range workerIdx {
+		wk := m.snap.Services[idx]
+		// The status dot already conveys running/stopped/suspended, so the
+		// site sits on the left and the worker kind (queue / schedule / vite)
+		// is flush right instead of a redundant state word.
+		left := serviceStateGlyph(wk.State) + " " + wk.WorkerSite
+		right := dimStyle.Render(wk.WorkerKind)
+		if wk.WorkerSite == "" {
+			left = serviceStateGlyph(wk.State) + " " + wk.WorkerKind
+			right = ""
+		}
+		zones[len(lines)] = fmt.Sprintf("dashworker:%d", idx)
+		lines = append(lines, dashRowRight(left, right, width))
+	}
+	if len(failing) > 0 {
+		lines = append(lines, "")
+		for _, n := range failing {
+			lines = append(lines, failingStyle.Render("⚠ "+n))
+		}
+		lines = append(lines, dimStyle.Render("press H to heal"))
+	}
+	if len(zones) == 0 {
+		zones = nil
+	}
+	return cardContent{lines, zones}
+}
 
-	// System health row: DNS / Nginx / Watcher / PHP — mirrors the header
-	// but in the dashboard layout so the user has one consolidated view.
-	add("")
-	add(sectionStyle.Render("System health"))
-	add(renderSystemInfoRow("DNS", dnsHealthText(m.snap.Status)))
-	add(renderSystemInfoRow("Nginx", runningOrStoppedColoured(m.snap.Status.NginxRunning)))
-	add(renderSystemInfoRow("Watcher", runningOrStoppedColoured(m.snap.Status.WatcherRunning)))
+func (m *Model) dashSystemHealthCard(width int) cardContent {
+	row := func(label, value string) string {
+		return dashRowRight(dimStyle.Render(label), value, width)
+	}
+	lines := []string{
+		row("DNS", dnsHealthText(m.snap.Status)),
+		row("Nginx", runningOrStoppedColoured(m.snap.Status.NginxRunning)),
+		row("Watcher", runningOrStoppedColoured(m.snap.Status.WatcherRunning)),
+	}
 	if len(m.snap.Status.PHPRunning) > 0 {
-		add(renderSystemInfoRow("PHP FPM", runningStyle.Render(strings.Join(m.snap.Status.PHPRunning, ", "))))
+		lines = append(lines, row("PHP FPM", runningStyle.Render(strings.Join(m.snap.Status.PHPRunning, ", "))))
 	} else {
-		add(renderSystemInfoRow("PHP FPM", dimStyle.Render("none running")))
+		lines = append(lines, row("PHP FPM", dimStyle.Render("none running")))
 	}
+	return cardContent{lines, nil}
+}
 
-	// Resources: total CPU + memory + top 5 by memory.
-	add("")
-	add(sectionStyle.Render("Resources"))
+func (m *Model) dashResourcesCard(width int) cardContent {
 	if !m.stats.Available {
-		add(renderSystemInfoRow("Status", dimStyle.Render("collecting…")))
+		return cardContent{[]string{dimStyle.Render("collecting…")}, nil}
+	}
+	lines := []string{dashRowRight("CPU", fmt.Sprintf("%.1f%%", m.stats.TotalCPUPercent), width)}
+	memText := stats.FormatBytes(m.stats.TotalMemBytes)
+	if m.stats.HostMemBytes > 0 {
+		memText += " / " + stats.FormatBytes(m.stats.HostMemBytes)
+	}
+	lines = append(lines, dashRowRight("Memory", memText, width), "")
+	for _, c := range m.stats.Containers {
+		name := dimStyle.Render(truncatePlain(c.Name, 18))
+		value := fmt.Sprintf("%5.1f%%  %s", c.CPUPercent, stats.FormatBytes(c.MemBytes))
+		lines = append(lines, dashRowRight(name, value, width))
+	}
+	return cardContent{lines, nil}
+}
+
+func (m *Model) dashLerdCard(width int) cardContent {
+	row := func(label, value string) string {
+		return dashRowRight(dimStyle.Render(label), value, width)
+	}
+	lines := []string{row("Version", m.version)}
+	if m.updateAvailable != "" {
+		lines = append(lines, accentStyle.Render("update: "+m.updateAvailable))
+	}
+	// Autostart / LAN come from the periodic snapshot, not a syscall per frame.
+	lines = append(lines, row("Autostart", onOffWord(m.snap.Status.Autostart)))
+	lines = append(lines, row("LAN", onOffWord(m.snap.Status.LANExposed)))
+	lines = append(lines, row("Platform", runtime.GOOS+"/"+runtime.GOARCH))
+
+	lines = append(lines, "", sectionStyle.Render("Recent activity"))
+	if len(m.activity) == 0 {
+		lines = append(lines, dimStyle.Render("no recent activity"))
 	} else {
-		add(renderSystemInfoRow("Total CPU", fmt.Sprintf("%.1f%%", m.stats.TotalCPUPercent)))
-		memText := stats.FormatBytes(m.stats.TotalMemBytes)
-		if m.stats.HostMemBytes > 0 {
-			memText += " / " + stats.FormatBytes(m.stats.HostMemBytes)
-		}
-		add(renderSystemInfoRow("Total memory", memText))
-		add(renderSystemInfoRow("Processes", fmt.Sprintf("%d running (top 5 by load)", len(m.stats.Containers))))
-		max := 5
-		if len(m.stats.Containers) < max {
-			max = len(m.stats.Containers)
-		}
-		for i := 0; i < max; i++ {
-			c := m.stats.Containers[i]
-			add("    " + dimStyle.Render(padRight(truncatePlain(c.Name, 24), 24)) +
-				" " + fmt.Sprintf("%5.1f%%  %s", c.CPUPercent, stats.FormatBytes(c.MemBytes)))
+		for _, e := range m.activity {
+			lines = append(lines, e.render())
 		}
 	}
-
-	// Lerd settings summary so the dashboard mirrors lerd-ui's Lerd Info
-	// widget without re-implementing the toggles (those live in System).
-	add("")
-	add(sectionStyle.Render("Lerd"))
-	add(renderSystemInfoRow("Version", m.version))
-	add(renderSystemInfoRow("Autostart", onOffWord(lerdSystemd.IsAutostartEnabled())))
-	cfg, _ := config.LoadGlobal()
-	add(renderSystemInfoRow("LAN expose", onOffWord(cfg != nil && cfg.LAN.Exposed)))
-	add(renderSystemInfoRow("Platform", runtime.GOOS+"/"+runtime.GOARCH))
-
-	return out, 0
+	return cardContent{lines, nil}
 }
 
 // dnsHealthText renders the DNS pill the same way the header does so the

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -8,54 +8,48 @@ import (
 	"github.com/geodro/lerd/internal/stats"
 )
 
-// TestDashboardContent_RendersAllSections ensures every promised section
-// header is present so the dashboard never silently loses a widget after a
-// refactor.
-func TestDashboardContent_RendersAllSections(t *testing.T) {
+// TestDashboardGrid_RendersAllCards ensures every promised card title is
+// present so the dashboard never silently loses a widget after a refactor.
+func TestDashboardGrid_RendersAllCards(t *testing.T) {
 	m := NewModel("test")
-	lines, _ := dashboardContentLinesWithCursor(m, false, 120)
-	joined := stripANSI(strings.Join(lines, "\n"))
-	for _, want := range []string{"Dashboard", "Overview", "System health", "Resources", "Lerd"} {
+	joined := stripANSI(m.renderDashboardGrid(150, 30))
+	for _, want := range []string{"Sites", "Services", "Workers", "System Health", "Resources", "Lerd"} {
 		if !strings.Contains(joined, want) {
-			t.Errorf("missing section %q in dashboard:\n%s", want, joined)
+			t.Errorf("missing card %q in dashboard grid:\n%s", want, joined)
 		}
 	}
 }
 
-// TestDashboardContent_ShowsHealthyWhenNoFailures verifies the hero line
-// reflects the heal state so users see the positive signal even when the
-// header banner is hidden.
-func TestDashboardContent_ShowsHealthyWhenNoFailures(t *testing.T) {
+// TestWorkersCard_HealthyWhenNoFailures verifies the workers card reflects the
+// heal state so users see the positive signal at a glance.
+func TestWorkersCard_HealthyWhenNoFailures(t *testing.T) {
 	m := NewModel("test")
-	lines, _ := dashboardContentLinesWithCursor(m, false, 120)
-	joined := stripANSI(strings.Join(lines, "\n"))
+	joined := stripANSI(strings.Join(m.dashWorkersCard(60).lines, "\n"))
 	if !strings.Contains(joined, "all workers healthy") {
-		t.Errorf("expected healthy hero with no failing workers:\n%s", joined)
+		t.Errorf("expected healthy state with no failing workers:\n%s", joined)
 	}
 }
 
-// TestDashboardContent_ShowsFailingWorkerCount counts failing workers from
-// the snapshot so the dashboard summary always matches the heal hint in the
-// header.
-func TestDashboardContent_ShowsFailingWorkerCount(t *testing.T) {
+// TestWorkersCard_ShowsFailingCount counts failing workers from the snapshot
+// so the card summary always matches the heal hint in the header.
+func TestWorkersCard_ShowsFailingCount(t *testing.T) {
 	m := NewModel("test")
 	m.snap.Sites = []siteinfo.EnrichedSite{
 		{Name: "a", QueueFailing: true, HasQueueWorker: true},
 		{Name: "b", ScheduleFailing: true, HasScheduleWorker: true},
 	}
-	lines, _ := dashboardContentLinesWithCursor(m, false, 120)
-	joined := stripANSI(strings.Join(lines, "\n"))
-	if !strings.Contains(joined, "2 workers failing") {
-		t.Errorf("expected '2 workers failing':\n%s", joined)
+	joined := stripANSI(strings.Join(m.dashWorkersCard(60).lines, "\n"))
+	if !strings.Contains(joined, "2 failing") {
+		t.Errorf("expected '2 failing':\n%s", joined)
 	}
 	if !strings.Contains(joined, "press H") {
-		t.Errorf("dashboard should hint at H to heal:\n%s", joined)
+		t.Errorf("workers card should hint at H to heal:\n%s", joined)
 	}
 }
 
-// TestDashboardContent_ShowsStatsWhenAvailable verifies the resources block
+// TestResourcesCard_ShowsStatsWhenAvailable verifies the resources card
 // renders concrete numbers from the cached snapshot, not the placeholder.
-func TestDashboardContent_ShowsStatsWhenAvailable(t *testing.T) {
+func TestResourcesCard_ShowsStatsWhenAvailable(t *testing.T) {
 	m := NewModel("test")
 	m.stats = stats.Snapshot{
 		Available:       true,
@@ -67,8 +61,7 @@ func TestDashboardContent_ShowsStatsWhenAvailable(t *testing.T) {
 			{Name: "lerd-redis", CPUPercent: 1.0, MemBytes: 28 * 1024 * 1024},
 		},
 	}
-	lines, _ := dashboardContentLinesWithCursor(m, false, 120)
-	joined := stripANSI(strings.Join(lines, "\n"))
+	joined := stripANSI(strings.Join(m.dashResourcesCard(60).lines, "\n"))
 	if !strings.Contains(joined, "12.5%") {
 		t.Errorf("expected '12.5%%' total CPU:\n%s", joined)
 	}
@@ -80,13 +73,12 @@ func TestDashboardContent_ShowsStatsWhenAvailable(t *testing.T) {
 	}
 }
 
-// TestDashboardContent_PlaceholderWhenStatsCollecting renders the polite
-// "collecting…" message during the first window before the poller has run.
-func TestDashboardContent_PlaceholderWhenStatsCollecting(t *testing.T) {
+// TestResourcesCard_PlaceholderWhenCollecting renders the polite "collecting…"
+// message during the first window before the poller has run.
+func TestResourcesCard_PlaceholderWhenCollecting(t *testing.T) {
 	m := NewModel("test")
 	// stats zero-valued: Available=false
-	lines, _ := dashboardContentLinesWithCursor(m, false, 120)
-	joined := stripANSI(strings.Join(lines, "\n"))
+	joined := stripANSI(strings.Join(m.dashResourcesCard(60).lines, "\n"))
 	if !strings.Contains(joined, "collecting") {
 		t.Errorf("expected 'collecting…' placeholder when stats unavailable:\n%s", joined)
 	}
@@ -103,7 +95,13 @@ func stripANSI(s string) string {
 			continue
 		}
 		if inEsc {
-			if r == 'm' {
+			// CSI introducer; params/intermediates are skipped until the
+			// final byte (0x40–0x7E) ends the sequence. Handles both SGR
+			// colour codes (…m) and bubblezone markers (…z).
+			if r == '[' {
+				continue
+			}
+			if r >= 0x40 && r <= 0x7e {
 				inEsc = false
 			}
 			continue

--- a/internal/tui/debug.go
+++ b/internal/tui/debug.go
@@ -12,6 +12,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/devtoolsops"
 	lerddumps "github.com/geodro/lerd/internal/dumps"
+	zone "github.com/lrstanley/bubblezone"
 )
 
 // debugLenses are the Debug view's switchable lenses, in tab order, mirroring
@@ -294,13 +295,16 @@ func renderDebugTabs(m *Model, site string) string {
 		if c := counts[l.kind]; c > 0 {
 			label = fmt.Sprintf("%s %d", l.label, c)
 		}
+		var chip string
 		if i == m.debugLens {
-			parts = append(parts, keyChipStyle.Render(" "+label+" "))
+			chip = keyChipStyle.Render(" " + label + " ")
 		} else {
-			parts = append(parts, dimStyle.Render(label))
+			chip = dimStyle.Render(" " + label + " ")
 		}
+		// Each lens is a clickable tab; handleMouse maps the zone to the lens.
+		parts = append(parts, zone.Mark(fmt.Sprintf("debuglens:%d", i), chip))
 	}
-	return strings.Join(parts, "  ")
+	return strings.Join(parts, " ")
 }
 
 // debugContentLines renders the whole Debug pane: the bridge/worker state, the
@@ -311,7 +315,9 @@ func debugContentLines(m *Model, focused bool, innerW int) ([]string, int) {
 	add := func(s string) { out = append(out, padToWidth(clipLine(s, innerW), innerW)) }
 
 	add(sectionStyle.Render("Debug") + "  " + dumpsBridgeStateLabel() + "  " + debugWorkersStateLabel())
+	add("")
 	add("  " + renderDebugTabs(m, ""))
+	add("")
 	add(dimStyle.Render("  [ ] lens · / search · 1/2 ctx · enter expand · w workers · c clear · T bridge · D return"))
 	add("  " + renderDumpsChips(m.dumpsCtxFilter))
 	if m.dumpsFilterActive || m.dumpsFilter != "" {

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -449,8 +449,6 @@ func (m *Model) renderDetailInline(w, h int, focused bool) string {
 		content = settingsContentLines(m, focused, contentW)
 	case detailSystem:
 		content, cursorLine = systemContentLinesWithCursor(m, focused, contentW)
-	case detailDashboard:
-		content, cursorLine = dashboardContentLinesWithCursor(m, focused, contentW)
 	case detailDumps:
 		content, cursorLine = debugContentLines(m, focused, contentW)
 	default:
@@ -485,9 +483,6 @@ func (m *Model) renderDetailInline(w, h int, focused bool) string {
 			case tabSiteDebug:
 				content = siteDebugContentLines(m, site, contentW)
 				cursorLine = -1
-			case tabSiteAppLogs:
-				content = siteAppLogsContentLines(m, site, contentW)
-				cursorLine = -1
 			case tabSiteDoctor:
 				content = siteDoctorContentLines(m, site, contentW)
 				cursorLine = -1
@@ -497,7 +492,11 @@ func (m *Model) renderDetailInline(w, h int, focused bool) string {
 		}
 	}
 
-	visible := viewport(content, cursorLine, innerH, &m.detailScroll)
+	cur := -1
+	if focused && m.followCursor {
+		cur = cursorLine
+	}
+	visible := viewport(content, cur, innerH, &m.detailScroll)
 	bar := renderScrollbar(innerH, len(content), m.detailScroll, len(visible))
 
 	lines := make([]string, 0, innerH)

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -13,8 +13,10 @@ var helpReference = []helpSection{
 	{
 		title: "Navigation",
 		rows: [][2]string{
-			{"tab / shift+tab", "cycle focus through Sites · Detail · Services (use `v` to hide services from the cycle)"},
-			{"↑ ↓  j k", "move selection within the focused pane"},
+			{"ctrl+← / ctrl+→", "switch the top tab (Dashboard · Sites · Services); tabs are also clickable"},
+			{"tab / shift+tab", "cycle focus between the list and the detail pane on the current tab"},
+			{"click", "click a tab to switch screens, or a site / service row to select it"},
+			{"↑ ↓  j k", "move selection within the focused pane (scrolls the grid on the Dashboard)"},
 			{"pgup / pgdn", "jump by 10 rows"},
 			{"home / end · g G", "jump to first / last row"},
 		},
@@ -45,11 +47,11 @@ var helpReference = []helpSection{
 	{
 		title: "Site detail tabs",
 		rows: [][2]string{
-			{"1", "Overview tab (default — workers, toggles, worktrees)"},
+			{"1", "Overview tab (default — workers, toggles, worktrees, app-logs pane beneath)"},
 			{"2", "Env tab (read-only .env display)"},
 			{"3", "Debug tab (this site's lenses: dumps, queries, jobs, mail, …)"},
-			{"4", "App logs tab (every framework-declared log file with size and mtime)"},
-			{"5", "Doctor tab (Laravel only — APP_KEY, env drift, migrations, storage link; press again to re-run)"},
+			{"4", "Doctor tab (Laravel only — APP_KEY, env drift, migrations, storage link; press again to re-run)"},
+			{"{ / }", "scroll the Overview app-logs pane (or the logs pane when open)"},
 		},
 	},
 	{
@@ -96,11 +98,10 @@ var helpReference = []helpSection{
 	{
 		title: "Panes & overlays",
 		rows: [][2]string{
-			{"v", "show / hide the services pane"},
-			{"F", "swap the detail pane for the Dashboard (counts, system health, resources)"},
-			{"S", "swap the detail pane for global Settings (LAN expose, autostart, Xdebug)"},
-			{"Y", "swap the detail pane for the System overview (DNS, Nginx, Watcher, PHP, Node, Lerd)"},
-			{"D", "open the Debug window (dumps, queries with N+1, jobs, mail, …)"},
+			{"Dashboard tab", "six-card overview (Sites · Services · Workers · System Health · Resources · Lerd)"},
+			{"S", "swap the detail pane for global Settings (LAN expose, autostart, Xdebug) — Sites tab"},
+			{"Y", "swap the detail pane for the System overview (DNS, Nginx, Watcher, PHP, Node, Lerd) — Sites tab"},
+			{"D", "open the Debug window (dumps, queries with N+1, jobs, mail, …) — Sites tab"},
 			{"?", "swap the detail pane for this help reference"},
 			{"esc", "close picker or return to site detail"},
 		},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -19,6 +19,7 @@ import (
 	"github.com/geodro/lerd/internal/siteinfo"
 	"github.com/geodro/lerd/internal/stats"
 	lerdUpdate "github.com/geodro/lerd/internal/update"
+	zone "github.com/lrstanley/bubblezone"
 )
 
 // focusPane identifies which pane currently owns keyboard focus. Detail sits
@@ -43,8 +44,34 @@ const (
 	detailSettings
 	detailDumps
 	detailSystem
-	detailDashboard
 )
+
+// topTab identifies the active top-level screen. The tab bar switches the
+// whole body between a 6-card dashboard overview, the sites screen (list +
+// site detail) and the services screen (list + service detail). Clickable in
+// the tab strip and cyclable with ctrl+left / ctrl+right.
+type topTab int
+
+const (
+	tabDashboard topTab = iota
+	tabSites
+	tabServices
+)
+
+func (t topTab) label() string {
+	switch t {
+	case tabDashboard:
+		return "Dashboard"
+	case tabServices:
+		return "Services"
+	default:
+		return "Sites"
+	}
+}
+
+// orderedTabs is the left-to-right order the tab bar renders and the order
+// nextTab cycles through.
+var orderedTabs = []topTab{tabDashboard, tabSites, tabServices}
 
 // Model is the bubbletea root. Panes are all projections of snap plus small
 // per-pane cursor/scroll state, so every refresh cycle rebuilds from a single
@@ -54,6 +81,7 @@ type Model struct {
 
 	snap Snapshot
 
+	activeTab  topTab
 	detailMode detailMode
 	focus      focusPane
 
@@ -110,11 +138,10 @@ type Model struct {
 	domainInput        string
 	domainInputEditing string
 
-	showLogs     bool
-	logScroll    int // lines scrolled back from tail (0 = live tail)
-	hideServices bool
-	logTail      *logTail
-	logCursor    int // index into currentLogTargets() for the focused item
+	showLogs  bool
+	logScroll int // lines scrolled back from tail (0 = live tail)
+	logTail   *logTail
+	logCursor int // index into currentLogTargets() for the focused item
 
 	status       string
 	statusExpiry time.Time
@@ -185,6 +212,37 @@ type Model struct {
 	// once the snapshot is zero-valued (Available=false) and the
 	// dashboard renders a "collecting…" placeholder.
 	stats stats.Snapshot
+
+	// Dashboard grid state: which of the numDashCards cards has focus (so
+	// j/k and the mouse wheel know what to scroll) and the per-card vertical
+	// scroll offset. Cards show their whole list and clip to a scroll window.
+	dashFocus  int
+	dashScroll [numDashCards]int
+
+	// Activity feed: a capped ring of recent state-change events derived by
+	// diffing successive snapshots, mirroring the web UI's Recent Activity.
+	// prevSnap holds the last snapshot the diff ran against.
+	activity []activityEvent
+	prevSnap *Snapshot
+
+	// overviewLogScroll is how many lines the Overview app-logs pane is
+	// scrolled back from the live tail (0 = newest at the bottom).
+	overviewLogScroll int
+
+	// Overview app-log read cache: the file is re-read only when its path,
+	// mtime or size changes, so wheel-scrolling and idle ticks don't re-read
+	// (and re-style) the same bytes off disk every frame.
+	appLogCachePath  string
+	appLogCacheMod   time.Time
+	appLogCacheSize  int64
+	appLogCacheLines []string
+
+	// followCursor is set by keyboard navigation so the next render scrolls
+	// the focused pane to keep the selected row visible. The mouse wheel
+	// leaves it false and moves the scroll offset directly, so wheeling scrolls
+	// the viewport without dragging the selection along. Cleared after each
+	// render.
+	followCursor bool
 }
 
 // DumpEntry is a TUI-side mirror of dumps.Event with the fields rendering
@@ -205,11 +263,13 @@ type DumpEntry struct {
 // podman.Cache.Start before running; NewModel itself is pure.
 func NewModel(version string) *Model {
 	return &Model{
-		width:   100,
-		height:  30,
-		logTail: newLogTail(),
-		sub:     eventbus.Default.Subscribe(),
-		version: version,
+		width:     100,
+		height:    30,
+		activeTab: tabDashboard,
+		focus:     paneDetail,
+		logTail:   newLogTail(),
+		sub:       eventbus.Default.Subscribe(),
+		version:   version,
 	}
 }
 
@@ -246,6 +306,11 @@ func updateCheckCmd(current string) tea.Cmd {
 
 // Update implements tea.Model.
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// followCursor is a one-shot consumed by the render that follows this
+	// update: clear it here, before any handler runs, so keyboard navigation
+	// can re-arm it and the wheel (which doesn't) leaves the scroll offset put.
+	m.followCursor = false
+
 	switch msg := msg.(type) {
 	case dumpsClearedMsg:
 		m.debug = nil
@@ -260,6 +325,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 
+	case tea.MouseMsg:
+		return m.handleMouse(msg)
+
 	case refreshMsg:
 		return m, loadCmd()
 
@@ -269,6 +337,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(loadCmd(), busCmd(m.sub))
 
 	case snapshotMsg:
+		m.recordActivity(msg.snap, time.Now())
 		m.snap = msg.snap
 		m.clampCursors()
 		return m, tickCmd(10 * time.Second)
@@ -396,6 +465,11 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "S":
+		// Settings / system / dumps swap the Sites tab's detail pane; they
+		// have no surface on the other tabs, so they no-op there.
+		if m.activeTab != tabSites {
+			return m, nil
+		}
 		if m.detailMode == detailSettings {
 			m.detailMode = detailSite
 		} else {
@@ -418,6 +492,9 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "D":
+		if m.activeTab != tabSites {
+			return m, nil
+		}
 		if m.detailMode == detailDumps {
 			m.detailMode = detailSite
 		} else {
@@ -430,6 +507,9 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "Y":
+		if m.activeTab != tabSites {
+			return m, nil
+		}
 		if m.detailMode == detailSystem {
 			m.detailMode = detailSite
 		} else {
@@ -440,21 +520,29 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
-	case "F":
-		if m.detailMode == detailDashboard {
-			m.detailMode = detailSite
-		} else {
-			m.detailMode = detailDashboard
-			m.detailScroll = 0
-			m.focus = paneDetail
-		}
-		return m, nil
+	case "ctrl+right":
+		m.switchTab(m.nextTab(+1))
+		return m, m.syncLogs()
+
+	case "ctrl+left":
+		m.switchTab(m.nextTab(-1))
+		return m, m.syncLogs()
 
 	case "tab":
+		// On the Dashboard tab there are no list panes; tab moves focus
+		// between the grid cards so j/k and the wheel scroll the right one.
+		if m.activeTab == tabDashboard {
+			m.dashFocus = (m.dashFocus + 1) % numDashCards
+			return m, nil
+		}
 		m.focus = m.nextFocus(+1)
 		return m, m.syncLogs()
 
 	case "shift+tab":
+		if m.activeTab == tabDashboard {
+			m.dashFocus = (m.dashFocus - 1 + numDashCards) % numDashCards
+			return m, nil
+		}
 		m.focus = m.nextFocus(-1)
 		return m, m.syncLogs()
 
@@ -487,22 +575,6 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "t":
 		return m, m.actionShell()
-
-	case "v":
-		if m.width < narrowWidth {
-			// Narrow: v switches the top list between sites and services.
-			if m.focus == paneServices {
-				m.focus = paneSites
-			} else {
-				m.focus = paneServices
-			}
-		} else {
-			m.hideServices = !m.hideServices
-			if m.hideServices && m.focus == paneServices {
-				m.focus = paneSites
-			}
-		}
-		return m, nil
 
 	case "/":
 		if m.detailMode == detailDumps {
@@ -583,6 +655,8 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "{":
 		if m.showLogs {
 			m.logScroll += 10
+		} else if _, _, ok := m.overviewLogsActive(); ok {
+			m.overviewLogScroll += 5
 		}
 		return m, nil
 
@@ -591,6 +665,11 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.logScroll -= 10
 			if m.logScroll < 0 {
 				m.logScroll = 0
+			}
+		} else if _, _, ok := m.overviewLogsActive(); ok {
+			m.overviewLogScroll -= 5
+			if m.overviewLogScroll < 0 {
+				m.overviewLogScroll = 0
 			}
 		}
 		return m, nil
@@ -948,7 +1027,12 @@ func (m *Model) resetFilteredCursor() {
 // change. Resets to the first target of the new selection; previous logCursor
 // doesn't transfer since target lists differ per item.
 func (m *Model) syncLogs() tea.Cmd {
-	if !m.showLogs {
+	// The Services tab keeps a logs sub-pane open for the selected service even
+	// without the manual `l` toggle, so the tail follows the selection there too.
+	// When neither surface wants logs, stop the tail so it doesn't keep
+	// streaming a container we've navigated away from.
+	if !m.showLogs && !m.serviceLogsActive() {
+		m.logTail.Stop()
 		return nil
 	}
 	targets := m.currentLogTargets()
@@ -967,6 +1051,243 @@ func (m *Model) syncLogs() tea.Cmd {
 	return m.logTail.Start(targets[0])
 }
 
+// nextTab returns the tab `dir` steps (±1) along orderedTabs, wrapping at
+// both ends so ctrl+left from Dashboard lands on Services and ctrl+right
+// from Services lands on Dashboard.
+func (m *Model) nextTab(dir int) topTab {
+	n := len(orderedTabs)
+	idx := 0
+	for i, t := range orderedTabs {
+		if t == m.activeTab {
+			idx = i
+			break
+		}
+	}
+	idx = ((idx+dir)%n + n) % n
+	return orderedTabs[idx]
+}
+
+// switchTab moves to tab t and parks focus on the pane that screen leads
+// with: the sites list on the Sites tab, the services list on the Services
+// tab, and the (non-list) detail surface on the Dashboard so j/k scrolls the
+// grid. Closes any open picker so a half-finished version pick doesn't bleed
+// across screens.
+func (m *Model) switchTab(t topTab) {
+	if t == m.activeTab {
+		return
+	}
+	m.activeTab = t
+	m.closePicker()
+	switch t {
+	case tabServices:
+		m.focus = paneServices
+	case tabSites:
+		m.focus = paneSites
+		m.detailMode = detailSite
+	case tabDashboard:
+		m.focus = paneDetail
+		m.detailScroll = 0
+	}
+}
+
+// handleMouse turns mouse input into tab switches, row selections, card focus
+// and scrolling. The wheel scrolls whichever dashboard card it's over; a
+// left-click switches tabs, selects a list row, or (on the dashboard) jumps to
+// a clicked site/service's tab or focuses a card. Every clickable region is a
+// bubblezone mark laid down during render, so hit-testing is a bounds check.
+func (m *Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if msg.Button == tea.MouseButtonWheelUp || msg.Button == tea.MouseButtonWheelDown {
+		return m.handleWheel(msg)
+	}
+	if msg.Action != tea.MouseActionPress || msg.Button != tea.MouseButtonLeft {
+		return m, nil
+	}
+	for _, t := range orderedTabs {
+		if zone.Get("tab:" + t.label()).InBounds(msg) {
+			m.switchTab(t)
+			return m, m.syncLogs()
+		}
+	}
+	// The Debug lens tabs (Dumps / Queries / …) are clickable wherever the
+	// Debug view is showing — the per-site Debug tab or the full window.
+	if m.inDebugView() {
+		for i := range debugLenses {
+			if zone.Get(fmt.Sprintf("debuglens:%d", i)).InBounds(msg) {
+				m.debugLens = i
+				m.dumpsCursor = 0
+				m.dumpsScroll = 0
+				m.detailScroll = 0
+				return m, nil
+			}
+		}
+	}
+	switch m.activeTab {
+	case tabSites:
+		for i := range m.visibleSites() {
+			if zone.Get(fmt.Sprintf("site:%d", i)).InBounds(msg) {
+				m.focus = paneSites
+				m.siteCursor = i
+				m.closePicker()
+				return m, m.syncLogs()
+			}
+		}
+		// The site-detail tab strip ([1] Overview · [2] Env · …) is clickable.
+		if m.detailMode == detailSite {
+			tabs := availableSiteTabs(m.currentSite())
+			for i := range tabs {
+				if zone.Get(fmt.Sprintf("sitetab:%d", i)).InBounds(msg) {
+					return m, m.selectSiteTab(i + 1)
+				}
+			}
+		}
+	case tabServices:
+		for i := range m.visibleServices() {
+			if zone.Get(fmt.Sprintf("svc:%d", i)).InBounds(msg) {
+				m.focus = paneServices
+				m.svcCursor = i
+				return m, m.syncLogs()
+			}
+		}
+	case tabDashboard:
+		// Clicking a site or service row jumps to that item on its own tab.
+		for i := range m.snap.Sites {
+			if zone.Get(fmt.Sprintf("dashsite:%d", i)).InBounds(msg) {
+				m.switchTab(tabSites)
+				m.selectSiteByName(m.snap.Sites[i].Name)
+				return m, m.syncLogs()
+			}
+		}
+		for i := range m.snap.Services {
+			if zone.Get(fmt.Sprintf("dashsvc:%d", i)).InBounds(msg) {
+				m.switchTab(tabServices)
+				m.selectServiceByName(m.snap.Services[i].Name)
+				return m, m.syncLogs()
+			}
+		}
+		// Worker rows live in the services list too, so a click jumps there
+		// with the worker selected.
+		for i := range m.snap.Services {
+			if zone.Get(fmt.Sprintf("dashworker:%d", i)).InBounds(msg) {
+				m.switchTab(tabServices)
+				m.selectServiceByName(m.snap.Services[i].Name)
+				return m, m.syncLogs()
+			}
+		}
+		// A click elsewhere on a card just focuses it for keyboard scrolling.
+		for i := 0; i < numDashCards; i++ {
+			if zone.Get(fmt.Sprintf("card:%d", i)).InBounds(msg) {
+				m.dashFocus = i
+				return m, nil
+			}
+		}
+	}
+	return m, nil
+}
+
+// handleWheel scrolls whichever scrollable pane the cursor is over: a
+// dashboard card, the app-logs / logs panes, the detail pane, or a list. Each
+// pane is a bubblezone region laid down during render; if the wheel isn't over
+// any known pane it falls back to scrolling the currently focused one.
+func (m *Model) handleWheel(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	up := msg.Button == tea.MouseButtonWheelUp
+	delta := 3
+	if up {
+		delta = -3
+	}
+
+	if m.activeTab == tabDashboard {
+		for i := 0; i < numDashCards; i++ {
+			if zone.Get(fmt.Sprintf("card:%d", i)).InBounds(msg) {
+				m.dashFocus = i
+				m.dashScroll[i] += delta
+				if m.dashScroll[i] < 0 {
+					m.dashScroll[i] = 0
+				}
+				return m, nil
+			}
+		}
+		return m, nil
+	}
+
+	// Logs pane (full-width when open) takes priority.
+	if m.showLogs && zone.Get("pane:logs").InBounds(msg) {
+		if up {
+			m.logScroll += 3
+		} else if m.logScroll -= 3; m.logScroll < 0 {
+			m.logScroll = 0
+		}
+		return m, nil
+	}
+	if _, _, ok := m.overviewLogsActive(); ok && zone.Get("pane:overviewlogs").InBounds(msg) {
+		if up {
+			m.overviewLogScroll += 3
+		} else if m.overviewLogScroll -= 3; m.overviewLogScroll < 0 {
+			m.overviewLogScroll = 0
+		}
+		return m, nil
+	}
+	if zone.Get("pane:detail").InBounds(msg) {
+		m.scrollOffset(&m.detailScroll, delta)
+		return m, nil
+	}
+	if zone.Get("pane:sites").InBounds(msg) {
+		m.scrollOffset(&m.siteScroll, delta)
+		return m, nil
+	}
+	if zone.Get("pane:services").InBounds(msg) {
+		m.scrollOffset(&m.svcScroll, delta)
+		return m, nil
+	}
+	// Fallback: scroll the offset of whatever pane currently holds focus.
+	switch m.focus {
+	case paneSites:
+		m.scrollOffset(&m.siteScroll, delta)
+	case paneServices:
+		m.scrollOffset(&m.svcScroll, delta)
+	case paneDetail:
+		m.scrollOffset(&m.detailScroll, delta)
+	}
+	return m, nil
+}
+
+// scrollOffset nudges a viewport scroll offset by delta, clamping the lower
+// bound; the upper bound is clamped by viewport() against the content height at
+// render time. It deliberately leaves the selection cursor alone, so wheeling
+// moves the view without changing what's selected.
+func (m *Model) scrollOffset(off *int, delta int) {
+	*off += delta
+	if *off < 0 {
+		*off = 0
+	}
+}
+
+// selectSiteByName focuses the Sites list on the site with the given name,
+// matched against the current (filtered/sorted) view so the cursor lands on
+// the row the user actually sees.
+func (m *Model) selectSiteByName(name string) {
+	for i, s := range m.visibleSites() {
+		if s.Name == name {
+			m.focus = paneSites
+			m.siteCursor = i
+			m.followCursor = true // scroll the destination list to it
+			return
+		}
+	}
+}
+
+// selectServiceByName focuses the Services list on the service with the given
+// name, matched against the current view.
+func (m *Model) selectServiceByName(name string) {
+	for i, s := range m.visibleServices() {
+		if s.Name == name {
+			m.focus = paneServices
+			m.svcCursor = i
+			m.followCursor = true // scroll the destination list to it
+			return
+		}
+	}
+}
+
 // nextFocus returns the focus after moving `dir` steps (±1) through the
 // list of panes that are currently visible and usable. Wide-mode order is
 // sites → detail → services so tab from a selected site lands on its
@@ -976,23 +1297,20 @@ func (m *Model) syncLogs() tea.Cmd {
 // moves between the current list pane and detail.
 func (m *Model) nextFocus(dir int) focusPane {
 	var panes []focusPane
-	if m.width < narrowWidth {
-		// In narrow mode, tab only moves between the current list pane and detail.
-		listPane := paneSites
-		if m.focus == paneServices {
-			listPane = paneServices
-		}
-		panes = []focusPane{listPane}
-		if m.currentSite() != nil {
+	switch m.activeTab {
+	case tabDashboard:
+		// The dashboard grid has no list panes; focus stays on detail so
+		// j/k scrolls the grid.
+		return paneDetail
+	case tabServices:
+		panes = []focusPane{paneServices}
+		if m.currentService() != nil {
 			panes = append(panes, paneDetail)
 		}
-	} else {
+	default: // tabSites
 		panes = []focusPane{paneSites}
 		if m.currentSite() != nil {
 			panes = append(panes, paneDetail)
-		}
-		if !m.hideServices {
-			panes = append(panes, paneServices)
 		}
 	}
 	n := len(panes)
@@ -1011,6 +1329,17 @@ func (m *Model) nextFocus(dir int) focusPane {
 }
 
 func (m *Model) moveCursor(delta int) {
+	// The Dashboard tab has no list selection — j/k scrolls the focused card.
+	if m.activeTab == tabDashboard {
+		m.dashScroll[m.dashFocus] += delta
+		if m.dashScroll[m.dashFocus] < 0 {
+			m.dashScroll[m.dashFocus] = 0
+		}
+		return
+	}
+	// Keyboard navigation should keep the moved selection on screen; the next
+	// render follows the cursor for the focused pane.
+	m.followCursor = true
 	switch m.focus {
 	case paneSites:
 		m.siteCursor = clamp(m.siteCursor+delta, 0, max(0, len(m.visibleSites())-1))
@@ -1033,14 +1362,6 @@ func (m *Model) moveCursor(delta int) {
 		case detailSystem:
 			nav := navigableSystemRows(m.systemRows())
 			m.systemRow = clamp(m.systemRow+delta, 0, max(0, len(nav)-1))
-		case detailDashboard:
-			// Dashboard has no selection — j/k just scrolls the content.
-			// Without this case the default branch would silently advance
-			// m.detailCursor on the hidden site-overview rows.
-			m.detailScroll += delta
-			if m.detailScroll < 0 {
-				m.detailScroll = 0
-			}
 		case detailDumps:
 			visible := len(m.debugVisibleEvents(""))
 			m.dumpsCursor = clamp(m.dumpsCursor+delta, 0, max(0, visible-1))
@@ -1064,6 +1385,7 @@ func (m *Model) moveCursor(delta int) {
 }
 
 func (m *Model) setCursor(pos int) {
+	m.followCursor = true
 	switch m.focus {
 	case paneSites:
 		m.siteCursor = clamp(pos, 0, max(0, len(m.visibleSites())-1))
@@ -1465,8 +1787,9 @@ func (m *Model) actionPauseToggle() tea.Cmd {
 // command registry.
 func Run(version string) error {
 	podman.Cache.Start(context.Background())
+	zone.NewGlobal()
 	m := NewModel(version)
-	p := tea.NewProgram(m, tea.WithAltScreen())
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 
 	// Wire the cache's change callback into the program so an external
 	// state change (CLI mutation in another process, container crash,

--- a/internal/tui/model_extra_test.go
+++ b/internal/tui/model_extra_test.go
@@ -8,27 +8,27 @@ import (
 	"github.com/geodro/lerd/internal/siteinfo"
 )
 
-func TestNextFocus_SkipsServicesWhenHidden(t *testing.T) {
+func TestNextFocus_SitesTabCyclesSitesAndDetail(t *testing.T) {
 	m := NewModel("test")
 	m.snap = fakeSnap()
-	m.hideServices = true
+	m.activeTab = tabSites
 	m.focus = paneSites
 
+	// Sites tab cycles sites → detail; services is never in the cycle.
 	got := m.nextFocus(+1)
 	if got != paneDetail {
-		t.Fatalf("hideServices + tab should skip to detail, got %d", got)
+		t.Fatalf("sites tab: tab from sites should land on detail, got %d", got)
 	}
 }
 
-func TestNextFocus_NoSitesSkipsDetail(t *testing.T) {
+func TestNextFocus_ServicesTabNoServiceSkipsDetail(t *testing.T) {
 	m := NewModel("test")
-	m.snap = Snapshot{
-		Services: []ServiceRow{{Name: "mysql", State: stateRunning}},
-	}
+	m.snap = Snapshot{} // no services → detail has nothing to show
+	m.activeTab = tabServices
 	m.focus = paneServices
 	got := m.nextFocus(+1)
-	if got != paneSites {
-		t.Fatalf("without sites, tab from services should wrap to sites (skipping detail), got %d", got)
+	if got != paneServices {
+		t.Fatalf("services tab with no service should stay on services, got %d", got)
 	}
 }
 
@@ -76,6 +76,7 @@ func TestFilterInput_CollectsRunes(t *testing.T) {
 func TestDetailMode_SToggleSetsFocus(t *testing.T) {
 	m := NewModel("test")
 	m.snap = fakeSnap()
+	m.activeTab = tabSites
 	m.focus = paneSites
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'S'}})
 	m = next.(*Model)
@@ -109,17 +110,25 @@ func TestHelpModal_Toggle(t *testing.T) {
 	}
 }
 
-func TestHideServicesToggle(t *testing.T) {
+func TestTabSwitch_CtrlArrowsCycle(t *testing.T) {
 	m := NewModel("test")
 	m.snap = fakeSnap()
-	m.focus = paneServices
-	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+	m.switchTab(tabSites)
+	// From Sites: ctrl+right → Services, ctrl+left twice → Dashboard.
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlRight})
 	m = next.(*Model)
-	if !m.hideServices {
-		t.Fatalf("v should hide services")
+	if m.activeTab != tabServices {
+		t.Fatalf("ctrl+right from Sites should land on Services, got %d", m.activeTab)
 	}
-	if m.focus == paneServices {
-		t.Fatalf("focus should move off hidden pane, got %d", m.focus)
+	if m.focus != paneServices {
+		t.Fatalf("switching to Services should focus the services pane, got %d", m.focus)
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlLeft})
+	m = next.(*Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlLeft})
+	m = next.(*Model)
+	if m.activeTab != tabDashboard {
+		t.Fatalf("ctrl+left twice should reach Dashboard, got %d", m.activeTab)
 	}
 }
 
@@ -127,6 +136,7 @@ func TestViewRendersUnderSettingsMode(t *testing.T) {
 	m := NewModel("test")
 	m.snap = fakeSnap()
 	m.width, m.height = 150, 40
+	m.switchTab(tabSites)
 	m.detailMode = detailSettings
 	out := m.View()
 	if !strings.Contains(out, "Settings") {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -30,6 +30,7 @@ func fakeSnap() Snapshot {
 func TestMoveCursor_Sites_Bounds(t *testing.T) {
 	m := NewModel("test")
 	m.snap = fakeSnap()
+	m.activeTab = tabSites
 	m.focus = paneSites
 
 	m.moveCursor(1)
@@ -49,6 +50,7 @@ func TestMoveCursor_Sites_Bounds(t *testing.T) {
 func TestMoveCursor_Services_Bounds(t *testing.T) {
 	m := NewModel("test")
 	m.snap = fakeSnap()
+	m.activeTab = tabServices
 	m.focus = paneServices
 
 	m.moveCursor(2)
@@ -64,12 +66,12 @@ func TestMoveCursor_Services_Bounds(t *testing.T) {
 func TestTabCyclesFocus(t *testing.T) {
 	m := NewModel("test")
 	m.snap = fakeSnap()
+	m.switchTab(tabSites)
 	if m.focus != paneSites {
 		t.Fatalf("initial focus should be sites, got %d", m.focus)
 	}
-	// Tab order is sites → detail → services so the user who just
-	// selected a site lands on its detail next (the most likely
-	// next action) rather than jumping sideways to services.
+	// On the Sites tab, focus cycles sites → detail → sites. Services now
+	// live on their own tab, so they're no longer in the cycle.
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = next.(*Model)
 	if m.focus != paneDetail {
@@ -77,26 +79,20 @@ func TestTabCyclesFocus(t *testing.T) {
 	}
 	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = next.(*Model)
-	if m.focus != paneServices {
-		t.Fatalf("second tab should move focus to services, got %d", m.focus)
-	}
-	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
-	m = next.(*Model)
 	if m.focus != paneSites {
-		t.Fatalf("third tab should return focus to sites, got %d", m.focus)
+		t.Fatalf("second tab should wrap back to sites, got %d", m.focus)
 	}
 }
 
 func TestTabSkipsDetailWhenNoSite(t *testing.T) {
 	m := NewModel("test")
-	m.snap = Snapshot{
-		Services: []ServiceRow{{Name: "mysql", State: stateRunning}},
-	}
-	m.focus = paneServices
+	m.snap = Snapshot{} // no sites
+	m.switchTab(tabSites)
+	// With no site selected there is no detail pane, so tab stays on the list.
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
 	m = next.(*Model)
 	if m.focus != paneSites {
-		t.Fatalf("tab with no sites should skip detail and wrap to sites, got %d", m.focus)
+		t.Fatalf("tab with no sites should stay on the sites pane, got %d", m.focus)
 	}
 }
 
@@ -120,11 +116,21 @@ func TestViewRendersCoreContent(t *testing.T) {
 	m := NewModel("v1.0.0")
 	m.snap = fakeSnap()
 	m.width, m.height = 120, 30
+	m.switchTab(tabSites)
 
+	// Sites tab: tab-bar labels plus the sites list and detail.
 	out := m.View()
-	for _, want := range []string{"Sites", "Services", "alpha", "beta", "mysql", "redis"} {
+	for _, want := range []string{"Dashboard", "Sites", "Services", "alpha", "beta"} {
 		if !strings.Contains(out, want) {
-			t.Fatalf("view missing %q\n---\n%s", want, out)
+			t.Fatalf("sites view missing %q\n---\n%s", want, out)
+		}
+	}
+	// Services tab renders the services list.
+	m.switchTab(tabServices)
+	out = m.View()
+	for _, want := range []string{"mysql", "redis"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("services view missing %q\n---\n%s", want, out)
 		}
 	}
 }

--- a/internal/tui/panes.go
+++ b/internal/tui/panes.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/geodro/lerd/internal/siteinfo"
+	zone "github.com/lrstanley/bubblezone"
 )
 
 // narrowWidth is the terminal width below which the TUI switches from the
@@ -41,47 +42,140 @@ func (m *Model) View() string {
 		return out
 	}
 
-	header := m.renderHeader()
+	tabs := m.renderTabs(m.width)
 	footer := m.renderFooter()
 	statusBar := m.renderStatus()
 
-	toasts := m.renderToasts(m.width)
-	reserved := lipgloss.Height(header) + lipgloss.Height(footer)
+	// Toasts float over the content as an overlay rather than claiming layout
+	// rows, so a transient notification never reflows the panes underneath.
+	reserved := lipgloss.Height(tabs) + lipgloss.Height(footer)
 	if statusBar != "" {
 		reserved += lipgloss.Height(statusBar)
-	}
-	if toasts != "" {
-		reserved += lipgloss.Height(toasts)
 	}
 	bodyH := m.height - reserved
 	if bodyH < 6 {
 		bodyH = 6
 	}
 
-	// Logs pane gets at least half the full window when open. Clamp so the
-	// top lists always keep at least 6 rows to stay useful.
+	// The full-width logs pane is the manual `l` toggle. On the Services tab the
+	// logs live in a sub-pane inside the detail column instead, so the
+	// full-width one steps aside to avoid showing the tail twice.
+	showFullLogs := m.showLogs && !m.serviceLogsActive()
+
+	// Logs pane takes at least half the window when open, and can grow larger,
+	// leaving only a sliver of the top pane so the log view dominates.
 	logH := 0
-	if m.showLogs {
-		logH = m.height / 2
-		if half := bodyH / 2; logH < half {
-			logH = half
+	if showFullLogs {
+		logH = bodyH / 2
+		if h := m.height / 2; h > logH {
+			logH = h
 		}
 		if logH < 10 {
 			logH = 10
 		}
-		if logH > bodyH-6 {
-			logH = bodyH - 6
+		if logH > bodyH-4 {
+			logH = bodyH - 4
 		}
 	}
 	topH := bodyH - logH
-	if topH < 6 {
-		topH = 6
+	if topH < 4 {
+		topH = 4
 	}
 
-	var top string
+	top := m.renderBody(topH)
+
+	sections := []string{tabs, top}
+	if showFullLogs {
+		sections = append(sections, zone.Mark("pane:logs", m.renderLogs(m.width, logH)))
+	}
+	if statusBar != "" {
+		sections = append(sections, statusBar)
+	}
+	sections = append(sections, footer)
+
+	out := lipgloss.JoinVertical(lipgloss.Left, sections...)
+	// Composite toasts over the bottom-right, just above the footer, without
+	// having reserved any rows for them above.
+	if stack := m.toastStack(); stack != "" {
+		out = overlayBottomRight(out, stack, lipgloss.Height(footer))
+	}
+	return zone.Scan(out)
+}
+
+// overlayBottomRight paints overlay onto base anchored to the right edge, with
+// its last line marginBottom rows above the bottom of base. Each overlay line
+// is right-aligned individually and only the cells it covers are overwritten,
+// so content to the left of the overlay shows through.
+func overlayBottomRight(base, overlay string, marginBottom int) string {
+	baseLines := strings.Split(base, "\n")
+	ovLines := strings.Split(overlay, "\n")
+	start := len(baseLines) - marginBottom - len(ovLines)
+	if start < 0 {
+		start = 0
+	}
+	for i, ol := range ovLines {
+		row := start + i
+		if row < 0 || row >= len(baseLines) {
+			continue
+		}
+		olW := ansi.StringWidth(ol)
+		col := ansi.StringWidth(baseLines[row]) - olW
+		if col < 0 {
+			col = 0
+		}
+		left := padToWidth(ansi.Truncate(baseLines[row], col, ""), col)
+		baseLines[row] = left + ol
+	}
+	return strings.Join(baseLines, "\n")
+}
+
+// renderTabs draws the clickable top tab strip. Each label is wrapped in a
+// bubblezone mark ("tab:<label>") so handleMouse can hit-test a click without
+// tracking column offsets by hand; the active tab reads as a filled accent
+// pill, the rest sit dim.
+func (m *Model) renderTabs(width int) string {
+	parts := make([]string, 0, len(orderedTabs))
+	for _, t := range orderedTabs {
+		style := tabInactiveStyle
+		if t == m.activeTab {
+			style = tabActiveStyle
+		}
+		parts = append(parts, zone.Mark("tab:"+t.label(), style.Render(t.label())))
+	}
+	bar := lipgloss.JoinHorizontal(lipgloss.Top, parts...)
+
+	// The version sits on the far right of the same row; an update banner
+	// follows it in accent when a newer release is available.
+	right := titleStyle.Render("lerd " + m.version)
+	if m.updateAvailable != "" {
+		right += "  " + accentStyle.Render("update "+m.updateAvailable)
+	}
+	inner := width - 2 // tabBarStyle horizontal padding
+	gap := inner - lipgloss.Width(bar) - lipgloss.Width(right)
+	if gap < 1 {
+		gap = 1
+	}
+	return tabBarStyle.Render(bar + spaces(gap) + right)
+}
+
+// renderBody renders the active tab's screen into the given height: the
+// six-card dashboard grid, the sites list + site detail, or the services list
+// + service detail. Sites/Services reuse the wide/narrow split that the old
+// combined layout used, minus the second list pane.
+func (m *Model) renderBody(topH int) string {
+	if m.activeTab == tabDashboard {
+		return m.renderDashboardGrid(m.width, topH)
+	}
+
+	listPane := m.renderSites
+	listZone := "pane:sites"
+	if m.activeTab == tabServices {
+		listPane = m.renderServices
+		listZone = "pane:services"
+	}
+
 	if m.width < narrowWidth {
-		// Narrow: stack list on top, detail below — both always visible.
-		// Give the list 40% of the body height, detail gets the rest.
+		// Narrow: stack the list on top, detail below.
 		listH := topH * 2 / 5
 		if listH < 6 {
 			listH = 6
@@ -91,124 +185,67 @@ func (m *Model) View() string {
 		}
 		detailH := topH - listH
 
-		switch {
-		case m.focus == paneServices:
-			// Services focused: take the full height, hide detail.
-			top = m.renderServices(m.width, topH)
-		case m.detailMode == detailSettings || m.detailMode == detailSystem || m.detailMode == detailDumps || m.detailMode == detailDashboard:
-			// Help / settings / system / dumps: take full height so content
-			// isn't cramped between the list and a slim detail pane.
-			top = m.renderDetailInline(m.width, topH, true)
-		default:
-			list := m.renderSites(m.width, listH)
-			detail := m.renderDetailInline(m.width, detailH, m.focus == paneDetail)
-			top = lipgloss.JoinVertical(lipgloss.Left, list, detail)
+		// Settings / system / dumps take the full height so the content isn't
+		// cramped between the list and a slim detail pane (Sites tab only).
+		if m.activeTab == tabSites && (m.detailMode == detailSettings || m.detailMode == detailSystem || m.detailMode == detailDumps) {
+			return zone.Mark("pane:detail", m.renderDetailInline(m.width, topH, true))
 		}
-	} else {
-		// Wide: left column stacks sites on top of services; right column is
-		// the site detail (full topH). When services is hidden, sites takes
-		// the whole left column.
-		leftW := m.width * 2 / 5
-		if leftW < 36 {
-			leftW = 36
-		}
-		if leftW > m.width-30 {
-			leftW = m.width - 30
-		}
-		rightW := m.width - leftW
-
-		var left string
-		if m.hideServices {
-			left = m.renderSites(leftW, topH)
-		} else {
-			// +3 was the original budget for title + filter + scrollbar
-			// padding; the grouped renderer adds up to 2 lines per group
-			// header (blank separator + label), so reserve 6 extra cells
-			// for the worst case of three visible groups.
-			svcNeeded := len(m.snap.Services) + 9
-			if svcNeeded < 8 {
-				svcNeeded = 8
-			}
-			svcH := svcNeeded
-			if lim := topH / 2; svcH > lim {
-				svcH = lim
-			}
-			if svcH > topH-6 {
-				svcH = topH - 6
-			}
-			if svcH < 4 {
-				svcH = 4
-			}
-			siteH := topH - svcH
-			sites := m.renderSites(leftW, siteH)
-			services := m.renderServices(leftW, svcH)
-			left = lipgloss.JoinVertical(lipgloss.Left, sites, services)
-		}
-		detail := m.renderDetailInline(rightW, topH, m.focus == paneDetail)
-		top = lipgloss.JoinHorizontal(lipgloss.Top, left, detail)
+		list := zone.Mark(listZone, listPane(m.width, listH))
+		detail := m.renderDetailColumn(m.width, detailH, m.focus == paneDetail)
+		return lipgloss.JoinVertical(lipgloss.Left, list, detail)
 	}
 
-	sections := []string{header, top}
-	if m.showLogs {
-		sections = append(sections, m.renderLogs(m.width, logH))
+	// Wide: list on the left, detail on the right. The lists are slim (status
+	// dot, name, short meta), so they take about a quarter of the width and are
+	// capped so they never sprawl on a wide terminal — the detail gets the rest.
+	leftW := m.width / 4
+	if leftW < 28 {
+		leftW = 28
 	}
-	if statusBar != "" {
-		sections = append(sections, statusBar)
+	if leftW > 46 {
+		leftW = 46
 	}
-	if toasts != "" {
-		sections = append(sections, toasts)
+	if leftW > m.width-30 {
+		leftW = m.width - 30
 	}
-	sections = append(sections, footer)
-
-	return lipgloss.JoinVertical(lipgloss.Left, sections...)
+	rightW := m.width - leftW
+	left := zone.Mark(listZone, listPane(leftW, topH))
+	detail := m.renderDetailColumn(rightW, topH, m.focus == paneDetail)
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, detail)
 }
 
-func (m *Model) renderHeader() string {
-	parts := []string{titleStyle.Render("lerd " + m.version)}
-
-	if m.updateAvailable != "" {
-		parts = append(parts, accentStyle.Render("update: "+m.updateAvailable+" (run `lerd update`)"))
+// renderDetailColumn renders the right-hand detail surface, splitting off a
+// scrollable app-logs pane beneath it when the Overview tab is showing a site
+// with declared log files. Falls back to the plain detail pane otherwise.
+func (m *Model) renderDetailColumn(w, h int, focused bool) string {
+	// A bottom logs sub-pane opens for the Sites Overview (app-log file tail)
+	// and for the selected service/worker on the Services tab (streaming logs).
+	_, logPath, siteLogs := m.overviewLogsActive()
+	svcLogs := m.serviceLogsActive()
+	if !siteLogs && !svcLogs {
+		return zone.Mark("pane:detail", m.renderDetailInline(w, h, focused))
 	}
-
-	if m.snap.Status.DNSDisabled {
-		parts = append(parts, dimStyle.Render("DNS off"))
-	} else if m.snap.Status.DNSOk {
-		parts = append(parts, runningStyle.Render("DNS ok"))
-	} else if m.snap.Status.DNSDegraded {
-		parts = append(parts, accentStyle.Render("DNS degraded"))
+	// The logs sub-pane takes at least half the detail column so it's actually
+	// usable; the detail keeps the rest.
+	logsH := h / 2
+	if logsH < 6 {
+		logsH = 6
+	}
+	if logsH > h-6 {
+		logsH = h - 6
+	}
+	if logsH < 4 || h-logsH < 4 {
+		// Too short to split usefully; show the detail alone.
+		return zone.Mark("pane:detail", m.renderDetailInline(w, h, focused))
+	}
+	detail := zone.Mark("pane:detail", m.renderDetailInline(w, h-logsH, focused))
+	var logPane string
+	if siteLogs {
+		logPane = zone.Mark("pane:overviewlogs", m.renderOverviewLogs(logPath, w, logsH))
 	} else {
-		parts = append(parts, failingStyle.Render("DNS down"))
+		logPane = zone.Mark("pane:logs", m.renderLogs(w, logsH))
 	}
-
-	if m.snap.Status.NginxRunning {
-		parts = append(parts, runningStyle.Render("nginx up"))
-	} else {
-		parts = append(parts, stoppedStyle.Render("nginx down"))
-	}
-
-	if len(m.snap.Status.PHPRunning) > 0 {
-		parts = append(parts, accentStyle.Render("FPM "+strings.Join(m.snap.Status.PHPRunning, ",")))
-	}
-
-	if m.snap.Status.WatcherRunning {
-		parts = append(parts, dimStyle.Render("watcher"))
-	}
-
-	if names := failingWorkerNames(m.snap); len(names) > 0 {
-		parts = append(parts, failingStyle.Render(fmt.Sprintf("⚠ %s failing · H to heal", joinTruncated(names, 3))))
-	}
-
-	parts = append(parts, dimStyle.Render(time.Now().Format("15:04:05")))
-
-	return strings.Join(parts, "  ·  ")
-}
-
-// countFailingWorkers totals workers in the systemd "failed" state. Kept
-// for callers that only need the count (dashboard hero); the header now
-// uses failingWorkerNames so users see which units are red, not just how
-// many.
-func countFailingWorkers(snap Snapshot) int {
-	return len(failingWorkerNames(snap))
+	return lipgloss.JoinVertical(lipgloss.Left, detail, logPane)
 }
 
 // failingWorkerNames returns kind-site pairs ("queue-acme", "vite-shop")
@@ -277,36 +314,27 @@ func (m *Model) renderFooter() string {
 	if m.filterActive {
 		return helpStyle.Render("  filter: type to match · enter apply · esc clear")
 	}
+
+	// Narrow terminals only have room for the essentials; `?` reveals the rest.
 	if m.width < narrowWidth {
-		keys := []string{
-			"tab panes",
-			"↑↓ nav",
-			"space toggle",
-			"l logs",
-			"v services",
-			"q quit",
-		}
-		return helpStyle.Render("  " + strings.Join(keys, "   "))
+		return helpStyle.Render("  " + strings.Join([]string{
+			"ctrl+←→ tabs", "↑↓ nav", "space toggle", "? help", "q quit",
+		}, "  ·  "))
 	}
-	keys := []string{
-		"tab panes",
-		"↑↓ nav",
-		"space toggle",
-		"/ filter",
-		"o sort",
-		"s start",
-		"x stop",
-		"r restart",
-		"l logs",
-		"t shell",
-		"v services",
-		"F dash",
-		"S settings",
-		"Y system",
-		"? help",
-		"q quit",
+
+	// Context-aware: each tab shows only the keys that act on it, so the bar
+	// reads as a relevant cheat-sheet rather than a wall of every binding.
+	var keys []string
+	switch m.activeTab {
+	case tabDashboard:
+		keys = []string{"ctrl+←→ tabs", "↑↓ scroll", "tab card", "click open", "H heal", "? help", "q quit"}
+	case tabServices:
+		keys = []string{"ctrl+←→ tabs", "↑↓ nav", "/ filter", "s start", "x stop", "r restart", "u update", "b rollback", "t shell", "O open", "? help", "q quit"}
+	default: // tabSites
+		keys = []string{"ctrl+←→ tabs", "tab panes", "↑↓ nav", "space toggle", "/ filter", "s start", "x stop", "r restart", "l logs", "t shell", "S settings", "Y system", "D debug", "? help", "q quit"}
 	}
-	return helpStyle.Render("  " + strings.Join(keys, "   "))
+	// Clip to the window so a long bar can't overflow and break the layout.
+	return helpStyle.Render(clipLine("  "+strings.Join(keys, "  ·  "), m.width))
 }
 
 func (m *Model) renderStatus() string {
@@ -372,11 +400,19 @@ func (m *Model) renderSites(w, h int) string {
 	default:
 		for i, s := range sites {
 			row := renderSiteRow(i == m.siteCursor && m.focus == paneSites, s, contentW)
-			rowData = append(rowData, padToWidth(clipLine(row, contentW), contentW))
+			row = padToWidth(clipLine(row, contentW), contentW)
+			// Mark the padded row so a click anywhere on it selects this site.
+			// The marker wraps the final content, so width math above is
+			// unaffected (bubblezone markers are zero-width to ansi).
+			rowData = append(rowData, zone.Mark(fmt.Sprintf("site:%d", i), row))
 		}
 	}
 
-	visible := viewport(rowData, m.siteCursor, availRows, &m.siteScroll)
+	cur := -1
+	if m.focus == paneSites && m.followCursor {
+		cur = m.siteCursor
+	}
+	visible := viewport(rowData, cur, availRows, &m.siteScroll)
 	bar := renderScrollbar(availRows, len(rowData), m.siteScroll, len(visible))
 	for i := 0; i < availRows; i++ {
 		row := ""
@@ -418,16 +454,11 @@ func renderSiteRow(selected bool, s siteinfo.EnrichedSite, paneW int) string {
 		name += " (paused)"
 	}
 
-	php := s.PHPVersion
-	if php == "" && s.ContainerPort > 0 {
-		php = "custom"
-	}
-
-	// Reserve the SAME budget on every row so PHP and worker columns line
-	// up vertically, regardless of which workers a site happens to run.
-	// The previous version subtracted workersW per row, which left empty-
-	// worker rows with a wider name column and shifted PHP leftward.
-	reserved := 4 /* prefix + glyph + spaces */ + 7 /* php %-7s */ + 1 + siteWorkerColWidth
+	// Reserve the SAME budget on every row so the worker column lines up
+	// vertically, regardless of which workers a site happens to run. The
+	// previous version subtracted workersW per row, which left empty-worker
+	// rows with a wider name column.
+	reserved := 4 /* prefix + glyph + spaces */ + 1 + siteWorkerColWidth
 	nameW := paneW - reserved
 	if nameW < 16 {
 		nameW = 16
@@ -457,7 +488,7 @@ func renderSiteRow(selected bool, s siteinfo.EnrichedSite, paneW int) string {
 		styled = selectedStyle.Render(name)
 	}
 
-	return fmt.Sprintf("%s %s %s %-7s %s", prefix, glyph, styled, php, padToWidth(workers, siteWorkerColWidth))
+	return fmt.Sprintf("%s %s %s %s", prefix, glyph, styled, padToWidth(workers, siteWorkerColWidth))
 }
 
 func fpmGlyph(s siteinfo.EnrichedSite) string {
@@ -535,7 +566,11 @@ func (m *Model) renderServices(w, h int) string {
 		rowData, cursorLine = renderGroupedServiceRows(services, m.svcCursor, m.focus == paneServices, contentW)
 	}
 
-	visible := viewport(rowData, cursorLine, availRows, &m.svcScroll)
+	cur := -1
+	if m.focus == paneServices && m.followCursor {
+		cur = cursorLine
+	}
+	visible := viewport(rowData, cur, availRows, &m.svcScroll)
 	bar := renderScrollbar(availRows, len(rowData), m.svcScroll, len(visible))
 	for i := 0; i < availRows; i++ {
 		row := ""
@@ -636,7 +671,8 @@ func renderGroupedServiceRows(services []ServiceRow, cursor int, paneFocused boo
 		} else {
 			row = renderServiceRow(selected, s, contentW)
 		}
-		rows = append(rows, padToWidth(clipLine(row, contentW), contentW))
+		row = padToWidth(clipLine(row, contentW), contentW)
+		rows = append(rows, zone.Mark(fmt.Sprintf("svc:%d", i), row))
 	}
 	return rows, cursorLine
 }
@@ -645,7 +681,7 @@ func renderGroupedServiceRows(services []ServiceRow, cursor int, paneFocused boo
 // (version + site count + pinned/custom tags). Reserved identically on
 // every row so the meta column starts at the same column regardless of
 // which tags are present, mirroring the aligned layout in the sites pane.
-const serviceMetaColWidth = 32
+const serviceMetaColWidth = 18
 
 // serviceStateGlyph maps a service/worker state to its coloured dot, shared by
 // the service and worker row renderers so the two never drift.
@@ -685,15 +721,11 @@ func renderWorkerRow(selected bool, s ServiceRow, paneW int) string {
 func renderServiceRow(selected bool, s ServiceRow, paneW int) string {
 	glyph := serviceStateGlyph(s.State)
 
-	// A worker row already names its single owning site (queue-<site>), so the
-	// "(1 site)" count every worker would carry is noise — only real services,
-	// which several sites can share, show the count.
+	// The site-count lives in the service detail pane now, so the list row
+	// just carries the version and any pinned/custom tags.
 	meta := ""
-	if s.WorkerKind == "" {
-		meta = fmt.Sprintf("(%d site%s)", s.SiteCount, plural(s.SiteCount))
-	}
 	if s.Version != "" {
-		meta = dimStyle.Render(s.Version) + "  " + meta
+		meta = dimStyle.Render(s.Version)
 	}
 	if s.Pinned {
 		meta += "  " + accentStyle.Render("pinned")
@@ -967,11 +999,4 @@ func spaces(n int) string {
 		b[i] = ' '
 	}
 	return string(b)
-}
-
-func plural(n int) string {
-	if n == 1 {
-		return ""
-	}
-	return "s"
 }

--- a/internal/tui/panes_test.go
+++ b/internal/tui/panes_test.go
@@ -169,8 +169,8 @@ func TestCountFailingWorkers_AggregatesAcrossSitesAndWorktrees(t *testing.T) {
 			{HorizonFailing: true}, // +1
 		},
 	}
-	if got := countFailingWorkers(snap); got != 4 {
-		t.Errorf("countFailingWorkers = %d, want 4", got)
+	if got := len(failingWorkerNames(snap)); got != 4 {
+		t.Errorf("failingWorkerNames count = %d, want 4", got)
 	}
 }
 
@@ -183,7 +183,7 @@ func TestCountFailingWorkers_ZeroWhenAllHealthy(t *testing.T) {
 			{HasHorizon: true, HorizonRunning: true},
 		},
 	}
-	if got := countFailingWorkers(snap); got != 0 {
-		t.Errorf("countFailingWorkers = %d, want 0", got)
+	if got := len(failingWorkerNames(snap)); got != 0 {
+		t.Errorf("failingWorkerNames count = %d, want 0", got)
 	}
 }

--- a/internal/tui/sitetabs.go
+++ b/internal/tui/sitetabs.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	lerddumps "github.com/geodro/lerd/internal/dumps"
 	"github.com/geodro/lerd/internal/siteinfo"
+	zone "github.com/lrstanley/bubblezone"
 )
 
 // siteTab identifies which sub-view of Site detail is showing. Tabs let the
@@ -24,7 +26,6 @@ const (
 	tabSiteOverview siteTab = iota
 	tabSiteEnv
 	tabSiteDebug
-	tabSiteAppLogs
 	tabSiteDoctor
 )
 
@@ -40,8 +41,6 @@ func siteTabLabel(t siteTab) string {
 		return "Env"
 	case tabSiteDebug:
 		return "Debug"
-	case tabSiteAppLogs:
-		return "App logs"
 	case tabSiteDoctor:
 		return "Doctor"
 	default:
@@ -59,10 +58,12 @@ func siteTabsHeader(active siteTab, tabs []siteTab) string {
 	for i, t := range tabs {
 		label := fmt.Sprintf("[%d] %s", i+1, siteTabLabel(t))
 		if t == active {
-			parts = append(parts, selectedStyle.Render(label))
+			label = selectedStyle.Render(label)
 		} else {
-			parts = append(parts, dimStyle.Render(label))
+			label = dimStyle.Render(label)
 		}
+		// Each tab label is clickable; handleMouse maps the zone to selectSiteTab.
+		parts = append(parts, zone.Mark(fmt.Sprintf("sitetab:%d", i), label))
 	}
 	return "  " + strings.Join(parts, "  ")
 }
@@ -82,7 +83,7 @@ func renderSiteTabHeader(active siteTab, innerW int, tabs []siteTab) []string {
 // shortcuts, and the render dispatch all derive from, so a tab's position,
 // label, and availability can never drift apart.
 func availableSiteTabs(s *siteinfo.EnrichedSite) []siteTab {
-	tabs := []siteTab{tabSiteOverview, tabSiteEnv, tabSiteDebug, tabSiteAppLogs}
+	tabs := []siteTab{tabSiteOverview, tabSiteEnv, tabSiteDebug}
 	if siteIsLaravel(s) {
 		tabs = append(tabs, tabSiteDoctor)
 	}
@@ -150,7 +151,9 @@ func siteDebugContentLines(m *Model, site *siteinfo.EnrichedSite, innerW int) []
 
 	kind := m.activeLensKind()
 	add(sectionStyle.Render("Debug for "+site.Name) + "  " + dumpsBridgeStateLabel())
+	add("")
 	add("  " + renderDebugTabs(m, site.Name))
+	add("")
 	hint := "  [ ] switch lens · D for the full window"
 	if m.dumpsCtxFilter != "" {
 		hint += " · ctx:" + m.dumpsCtxFilter
@@ -227,50 +230,160 @@ func siteDebugContentLines(m *Model, site *siteinfo.EnrichedSite, innerW int) []
 	return out
 }
 
-// siteAppLogsContentLines lists every tail-able file behind the focused
-// site (framework-declared app logs) with its size and modification time.
-// Informational only; users press `l` to actually tail one — the file
-// targets are wired into logTargetsForSite so `l` / `[` / `]` already do
-// the right thing.
-func siteAppLogsContentLines(m *Model, site *siteinfo.EnrichedSite, innerW int) []string {
-	out := make([]string, 0, 32)
-	out = append(out, renderSiteTabHeader(tabSiteAppLogs, innerW, availableSiteTabs(site))...)
-	add := func(s string) { out = append(out, padToWidth(clipLine(s, innerW), innerW)) }
-
-	if site == nil {
-		add(dimStyle.Render("  no site selected"))
-		return out
+// overviewLogsActive reports whether the Overview app-logs pane should render:
+// on the Sites tab, viewing a site's Overview, with at least one declared app
+// log path. It resolves the log paths once and also returns the newest log's
+// path (empty when none is written yet) so the renderer doesn't re-glob.
+func (m *Model) overviewLogsActive() (site *siteinfo.EnrichedSite, newest string, ok bool) {
+	if m.activeTab != tabSites || m.detailMode != detailSite || m.siteTab != tabSiteOverview {
+		return nil, "", false
 	}
-
-	add(sectionStyle.Render("App logs"))
-	add(dimStyle.Render("  press l to tail · [ / ] to cycle through targets"))
-	add("")
-
+	site = m.currentSite()
+	if site == nil {
+		return nil, "", false
+	}
 	paths := appLogPathsForSite(site)
 	if len(paths) == 0 {
-		add(dimStyle.Render("  no app log paths declared for this framework"))
-		add("")
-		add("  " + dimStyle.Render("for Laravel: ") + accentStyle.Render("storage/logs/*.log") + dimStyle.Render(" once the app starts writing them"))
-		add("  " + dimStyle.Render("for FPM containers: press ") + accentStyle.Render("l") + dimStyle.Render(" to tail the container log instead"))
-		return out
+		return nil, "", false
 	}
+	return site, newestOf(paths), true
+}
 
+// serviceLogsActive reports whether the Services tab should show a logs
+// sub-pane beneath the service detail: any time a service or worker row is
+// selected on that tab. The streaming tail is fed by the same logTail the
+// manual `l` pane uses, retargeted by syncLogs as the selection moves.
+func (m *Model) serviceLogsActive() bool {
+	return m.activeTab == tabServices && m.currentService() != nil
+}
+
+// newestOf returns the most-recently-modified path among the given app-log
+// paths, or "" if none can be stat'd. Takes pre-resolved paths so the caller
+// globs only once per render.
+func newestOf(paths []string) string {
+	newest := ""
+	var newestT time.Time
 	for _, p := range paths {
 		info, err := os.Stat(p)
 		if err != nil {
-			add(failingStyle.Render("  ! ") + p + "  " + dimStyle.Render(err.Error()))
 			continue
 		}
-		size := humanSize(info.Size())
-		mtime := info.ModTime().Local().Format("15:04:05")
-		short := filepath.Base(p)
-		add("  " + accentStyle.Render("·") + " " +
-			padRight(truncatePlain(short, 30), 30) + " " +
-			dimStyle.Render(padRight(size, 9)) + " " +
-			dimStyle.Render(mtime) + "  " +
-			dimStyle.Render(p))
+		if newest == "" || info.ModTime().After(newestT) {
+			newest, newestT = p, info.ModTime()
+		}
 	}
+	return newest
+}
+
+// appLogTailBytes bounds how much of the newest app log the Overview pane
+// reads. 64 KB of tail is plenty of recent history without risking the render
+// loop on a multi-megabyte log.
+const appLogTailBytes = 64 * 1024
+
+// siteAppLogTail returns the severity-styled tail of the given app-log file.
+// The result is cached against the file's path, mtime and size so repeated
+// renders (wheel scrolling, idle ticks) reuse it instead of re-reading and
+// re-styling the same bytes every frame. The returned slice is owned by the
+// cache — callers must treat it as read-only.
+func (m *Model) siteAppLogTail(path string) []string {
+	if path == "" {
+		return []string{dimStyle.Render("no app log file written yet")}
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return []string{failingStyle.Render("! " + err.Error())}
+	}
+	if m.appLogCacheLines != nil && path == m.appLogCachePath &&
+		info.ModTime().Equal(m.appLogCacheMod) && info.Size() == m.appLogCacheSize {
+		return m.appLogCacheLines
+	}
+
+	data, err := readTailBytes(path, appLogTailBytes)
+	if err != nil {
+		return []string{failingStyle.Render("! " + err.Error())}
+	}
+	raw := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	// When we seeked into the file the first line is probably a fragment; drop
+	// it so the pane never opens on half a log line.
+	if info.Size() > appLogTailBytes && len(raw) > 1 {
+		raw = raw[1:]
+	}
+	out := make([]string, 0, len(raw))
+	for _, l := range raw {
+		out = append(out, styleLogLine(l, ""))
+	}
+	m.appLogCachePath = path
+	m.appLogCacheMod = info.ModTime()
+	m.appLogCacheSize = info.Size()
+	m.appLogCacheLines = out
 	return out
+}
+
+// readTailBytes returns up to max bytes from the end of path.
+func readTailBytes(path string, max int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > max {
+		if _, err := f.Seek(info.Size()-max, io.SeekStart); err != nil {
+			return nil, err
+		}
+	}
+	return io.ReadAll(f)
+}
+
+// renderOverviewLogs draws the scrollable app-logs pane shown beneath the site
+// Overview. overviewLogScroll counts lines back from the live tail, so the
+// newest output sits at the bottom by default and `{` / `}` page through the
+// history.
+func (m *Model) renderOverviewLogs(path string, w, h int) string {
+	style := unfocusedPane
+	innerW, innerH := innerSize(style, w, h)
+	contentW := innerW - 1
+	if contentW < 10 {
+		contentW = innerW
+	}
+
+	header := sectionStyle.Render("App logs")
+	if path != "" {
+		header += "  " + dimStyle.Render(filepath.Base(path)+" · { } scroll")
+	}
+	header = padToWidth(clipLine(header, innerW), innerW)
+
+	lines := m.siteAppLogTail(path)
+	avail := innerH - 1
+	if avail < 1 {
+		avail = 1
+	}
+	maxScroll := len(lines) - avail
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if m.overviewLogScroll > maxScroll {
+		m.overviewLogScroll = maxScroll
+	}
+	if m.overviewLogScroll < 0 {
+		m.overviewLogScroll = 0
+	}
+	start := maxScroll - m.overviewLogScroll
+	window := lines[start:min(start+avail, len(lines))]
+	bar := renderScrollbar(avail, len(lines), start, len(window))
+
+	body := []string{header}
+	for i := 0; i < avail; i++ {
+		row := spaces(contentW)
+		if i < len(window) {
+			row = padToWidth(clipLine(window[i], contentW), contentW)
+		}
+		body = append(body, row+bar[i])
+	}
+	return style.Render(strings.Join(body, "\n"))
 }
 
 // readBoundedFile reads up to max bytes of path. Used for the env reader so
@@ -287,22 +400,6 @@ func readBoundedFile(path string, max int64) ([]byte, error) {
 		return buf[:n], err
 	}
 	return buf[:n], nil
-}
-
-// humanSize formats a byte count as the smallest unit ≥1: "512B", "12KB",
-// "3.4MB". Kept terser than stats.FormatBytes so the file-list column stays
-// narrow when several logs share a row.
-func humanSize(n int64) string {
-	switch {
-	case n < 1024:
-		return fmt.Sprintf("%dB", n)
-	case n < 1024*1024:
-		return fmt.Sprintf("%.0fKB", float64(n)/1024)
-	case n < 1024*1024*1024:
-		return fmt.Sprintf("%.1fMB", float64(n)/(1024*1024))
-	default:
-		return fmt.Sprintf("%.1fGB", float64(n)/(1024*1024*1024))
-	}
 }
 
 // openInBrowserCmd opens the focused row in the browser: a service's dashboard

--- a/internal/tui/sitetabs_test.go
+++ b/internal/tui/sitetabs_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSiteTabsHeader_HighlightsActive(t *testing.T) {
-	base := []siteTab{tabSiteOverview, tabSiteEnv, tabSiteDebug, tabSiteAppLogs}
+	base := []siteTab{tabSiteOverview, tabSiteEnv, tabSiteDebug}
 	for _, tab := range base {
 		got := stripANSI(siteTabsHeader(tab, base))
 		want := siteTabLabel(tab)
@@ -31,9 +31,9 @@ func TestAvailableSiteTabs_DoctorOnlyForLaravel(t *testing.T) {
 	if !slices.Contains(laravel, tabSiteDoctor) {
 		t.Errorf("Laravel site should offer the Doctor tab, got %v", laravel)
 	}
-	// Doctor is the fifth tab, so the strip numbers it [5].
-	if got := stripANSI(siteTabsHeader(tabSiteOverview, laravel)); !strings.Contains(got, "[5] Doctor") {
-		t.Errorf("Laravel strip should carry [5] Doctor, got %q", got)
+	// Doctor is the fourth tab, so the strip numbers it [4].
+	if got := stripANSI(siteTabsHeader(tabSiteOverview, laravel)); !strings.Contains(got, "[4] Doctor") {
+		t.Errorf("Laravel strip should carry [4] Doctor, got %q", got)
 	}
 }
 
@@ -127,33 +127,5 @@ func TestSiteDumpsContent_EmptyShowsHint(t *testing.T) {
 	joined := stripANSI(strings.Join(lines, "\n"))
 	if !strings.Contains(joined, "no dumps from this site") {
 		t.Errorf("expected empty-state hint:\n%s", joined)
-	}
-}
-
-func TestSiteAppLogsContent_NoLogsShowsHint(t *testing.T) {
-	m := NewModel("test")
-	site := &siteinfo.EnrichedSite{Name: "acme", Path: t.TempDir()}
-	lines := siteAppLogsContentLines(m, site, 120)
-	joined := stripANSI(strings.Join(lines, "\n"))
-	if !strings.Contains(joined, "no app log paths declared") {
-		t.Errorf("expected empty-state hint:\n%s", joined)
-	}
-}
-
-func TestHumanSize(t *testing.T) {
-	cases := []struct {
-		in   int64
-		want string
-	}{
-		{0, "0B"},
-		{500, "500B"},
-		{2048, "2KB"},
-		{int64(5 * 1024 * 1024), "5.0MB"},
-		{int64(2 * 1024 * 1024 * 1024), "2.0GB"},
-	}
-	for _, c := range cases {
-		if got := humanSize(c.in); got != c.want {
-			t.Errorf("humanSize(%d) = %q, want %q", c.in, got, c.want)
-		}
 	}
 }

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -9,6 +9,7 @@ import (
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteinfo"
+	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 )
 
 // Snapshot is the full view-model the TUI renders from. Produced by
@@ -60,6 +61,8 @@ type StatusRow struct {
 	WatcherRunning bool
 	PHPRunning     []string
 	Version        string
+	Autostart      bool
+	LANExposed     bool
 }
 
 // loadSnapshot collects everything the TUI needs in one shot. Called on every
@@ -196,6 +199,8 @@ func loadStatus() StatusRow {
 		DNSDegraded:  dnsStatus == dns.StatusDegraded,
 		DNSDisabled:  dnsDisabled,
 		NginxRunning: podman.Cache.Running("lerd-nginx"),
+		Autostart:    lerdSystemd.IsAutostartEnabled(),
+		LANExposed:   cfg != nil && cfg.LAN.Exposed,
 	}
 
 	if versions, err := phpPkg.ListInstalled(); err == nil {

--- a/internal/tui/snapshot_test.go
+++ b/internal/tui/snapshot_test.go
@@ -67,14 +67,19 @@ func TestWorkerRows_MarksIdleSuspended(t *testing.T) {
 	}
 }
 
-func TestRenderServiceRow_WorkerOmitsSiteCount(t *testing.T) {
+func TestRenderServiceRow_OmitsSiteCount(t *testing.T) {
+	// The site count moved to the service detail pane, so neither worker nor
+	// plain service rows carry it in the list anymore.
 	worker := stripANSI(renderServiceRow(false, ServiceRow{Name: "queue-acme", WorkerKind: "queue", SiteCount: 1, State: stateRunning}, 80))
 	if strings.Contains(worker, "site") {
 		t.Errorf("worker row should not show a site count, got %q", worker)
 	}
-	svc := stripANSI(renderServiceRow(false, ServiceRow{Name: "mysql", SiteCount: 3, State: stateRunning}, 80))
-	if !strings.Contains(svc, "(3 sites)") {
-		t.Errorf("service row should keep its site count, got %q", svc)
+	svc := stripANSI(renderServiceRow(false, ServiceRow{Name: "mysql", SiteCount: 3, State: stateRunning, Version: "8.0"}, 80))
+	if strings.Contains(svc, "site") {
+		t.Errorf("service row should no longer show a site count, got %q", svc)
+	}
+	if !strings.Contains(svc, "8.0") {
+		t.Errorf("service row should still show its version, got %q", svc)
 	}
 }
 

--- a/internal/tui/tabs_test.go
+++ b/internal/tui/tabs_test.go
@@ -1,0 +1,284 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/siteinfo"
+	zone "github.com/lrstanley/bubblezone"
+)
+
+// TestMain initialises the global bubblezone manager so View() (which marks
+// clickable regions) doesn't panic outside of Run.
+func TestMain(m *testing.M) {
+	zone.NewGlobal()
+	os.Exit(m.Run())
+}
+
+// waitZone polls for a zone to register. zone.Scan hands positions to a
+// background worker, so a Get immediately after a render can race ahead of it;
+// this gives the worker a bounded window to catch up.
+func waitZone(id string) *zone.ZoneInfo {
+	for i := 0; i < 200; i++ {
+		if z := zone.Get(id); !z.IsZero() {
+			return z
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return zone.Get(id)
+}
+
+func TestNextTab_CyclesBothDirections(t *testing.T) {
+	m := NewModel("test")
+	m.activeTab = tabDashboard
+	if got := m.nextTab(+1); got != tabSites {
+		t.Fatalf("dashboard +1 should be sites, got %d", got)
+	}
+	m.activeTab = tabServices
+	if got := m.nextTab(+1); got != tabDashboard {
+		t.Fatalf("services +1 should wrap to dashboard, got %d", got)
+	}
+	m.activeTab = tabDashboard
+	if got := m.nextTab(-1); got != tabServices {
+		t.Fatalf("dashboard -1 should wrap to services, got %d", got)
+	}
+}
+
+func TestSwitchTab_ParksFocus(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.switchTab(tabServices)
+	if m.activeTab != tabServices || m.focus != paneServices {
+		t.Fatalf("switch to services should focus services pane, got tab=%d focus=%d", m.activeTab, m.focus)
+	}
+	m.switchTab(tabDashboard)
+	if m.activeTab != tabDashboard || m.focus != paneDetail {
+		t.Fatalf("switch to dashboard should park focus on detail, got tab=%d focus=%d", m.activeTab, m.focus)
+	}
+}
+
+func TestNextFocus_DashboardStaysOnDetail(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.activeTab = tabDashboard
+	if got := m.nextFocus(+1); got != paneDetail {
+		t.Fatalf("dashboard tab has no list panes, expected detail, got %d", got)
+	}
+}
+
+func TestMouseClick_SwitchesTab(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.width, m.height = 150, 40
+	_ = m.View() // register zones
+
+	z := waitZone("tab:" + tabServices.label())
+	if z.IsZero() {
+		t.Fatalf("services tab zone not registered after render")
+	}
+	msg := tea.MouseMsg{X: z.StartX, Y: z.StartY, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft}
+	next, _ := m.Update(msg)
+	m = next.(*Model)
+	if m.activeTab != tabServices {
+		t.Fatalf("clicking the Services tab should switch to it, got %d", m.activeTab)
+	}
+}
+
+func TestMouseClick_SelectsSiteRow(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.activeTab = tabSites
+	m.focus = paneSites
+	m.width, m.height = 150, 40
+	_ = m.View()
+
+	z := waitZone("site:1")
+	if z.IsZero() {
+		t.Fatalf("second site row zone not registered after render")
+	}
+	msg := tea.MouseMsg{X: z.StartX, Y: z.StartY, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft}
+	next, _ := m.Update(msg)
+	m = next.(*Model)
+	if m.siteCursor != 1 {
+		t.Fatalf("clicking the second site row should select index 1, got %d", m.siteCursor)
+	}
+}
+
+func TestMouseClick_IgnoresNonLeftPress(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.width, m.height = 150, 40
+	_ = m.View()
+	z := zone.Get("tab:" + tabServices.label())
+	// Motion (not a press) must not switch tabs.
+	msg := tea.MouseMsg{X: z.StartX, Y: z.StartY, Action: tea.MouseActionMotion, Button: tea.MouseButtonLeft}
+	next, _ := m.Update(msg)
+	m = next.(*Model)
+	if m.activeTab == tabServices {
+		t.Fatalf("motion event should not switch tabs")
+	}
+}
+
+func TestRenderDashboardGrid_HasAllSixCards(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	out := m.renderDashboardGrid(150, 30)
+	for _, title := range []string{"Sites", "Services", "Workers", "System Health", "Resources", "Lerd"} {
+		if !strings.Contains(out, title) {
+			t.Fatalf("dashboard grid missing %q card:\n%s", title, out)
+		}
+	}
+}
+
+func TestDashboardClick_JumpsToSiteTab(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.activeTab = tabDashboard
+	m.width, m.height = 150, 40
+	_ = m.View() // register dashboard row zones
+
+	z := waitZone("dashsite:1")
+	if z.IsZero() {
+		t.Fatalf("dashsite row zone not registered after render")
+	}
+	msg := tea.MouseMsg{X: z.StartX, Y: z.StartY, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft}
+	next, _ := m.Update(msg)
+	m = next.(*Model)
+	if m.activeTab != tabSites {
+		t.Fatalf("clicking a dashboard site should switch to the Sites tab, got %d", m.activeTab)
+	}
+	if s := m.currentSite(); s == nil || s.Name != "beta" {
+		t.Fatalf("expected the clicked site (beta) selected, got %+v", s)
+	}
+}
+
+func TestDashboardTab_CyclesCardFocus(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.activeTab = tabDashboard
+	m.dashFocus = 0
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = next.(*Model)
+	if m.dashFocus != 1 {
+		t.Fatalf("tab on dashboard should advance card focus, got %d", m.dashFocus)
+	}
+}
+
+func TestDiffSnapshots_DetectsChanges(t *testing.T) {
+	now := time.Now()
+	// Newly linked site.
+	if evs := diffSnapshots(Snapshot{}, fakeSnap(), now); len(evs) == 0 {
+		t.Fatalf("expected events for newly linked sites")
+	}
+	// Pausing a site emits a paused event.
+	prev := fakeSnap()
+	cur := fakeSnap()
+	cur.Sites[0].Paused = true
+	cur.Sites[0].FPMRunning = false
+	got := diffSnapshots(prev, cur, now)
+	found := false
+	for _, e := range got {
+		if strings.Contains(e.text, "paused") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a paused event, got %+v", got)
+	}
+}
+
+func TestRecordActivity_CapsRing(t *testing.T) {
+	m := NewModel("test")
+	m.prevSnap = &Snapshot{}
+	// Each record diffs a snapshot with many fresh sites against the previous
+	// (empty) baseline; after the first the baseline matches, so drive churn by
+	// alternating an empty snapshot with a populated one.
+	for i := 0; i < activityCap+5; i++ {
+		if i%2 == 0 {
+			m.recordActivity(fakeSnap(), time.Now())
+		} else {
+			m.recordActivity(Snapshot{}, time.Now())
+		}
+	}
+	if len(m.activity) > activityCap {
+		t.Fatalf("activity ring should be capped at %d, got %d", activityCap, len(m.activity))
+	}
+}
+
+func TestOverviewLogsActive_GatedToSitesOverview(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+
+	m.activeTab = tabDashboard
+	if _, _, ok := m.overviewLogsActive(); ok {
+		t.Fatal("overview logs should be inactive on the Dashboard tab")
+	}
+	m.activeTab = tabServices
+	if _, _, ok := m.overviewLogsActive(); ok {
+		t.Fatal("overview logs should be inactive on the Services tab")
+	}
+	m.activeTab = tabSites
+	m.siteTab = tabSiteEnv
+	if _, _, ok := m.overviewLogsActive(); ok {
+		t.Fatal("overview logs should be inactive on a non-Overview site tab")
+	}
+}
+
+func TestRenderOverviewLogs_NoLogsPlaceholder(t *testing.T) {
+	m := NewModel("test")
+	// An empty path (no log file written yet) shows the placeholder rather
+	// than panicking.
+	out := stripANSI(m.renderOverviewLogs("", 60, 10))
+	if !strings.Contains(out, "App logs") {
+		t.Fatalf("overview logs pane missing title:\n%s", out)
+	}
+	if !strings.Contains(out, "no app log file written yet") {
+		t.Fatalf("expected placeholder for a site with no logs:\n%s", out)
+	}
+}
+
+func TestWheel_ScrollsSitesPaneNotSelection(t *testing.T) {
+	m := NewModel("test")
+	sites := make([]siteinfo.EnrichedSite, 40)
+	for i := range sites {
+		sites[i] = siteinfo.EnrichedSite{Name: fmt.Sprintf("site%02d", i)}
+	}
+	m.snap = Snapshot{Sites: sites}
+	m.switchTab(tabSites)
+	m.width, m.height = 150, 20
+	_ = m.View()
+
+	z := waitZone("pane:sites")
+	if z.IsZero() {
+		t.Fatalf("sites pane zone not registered after render")
+	}
+	msg := tea.MouseMsg{X: z.StartX, Y: z.StartY, Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown}
+	next, _ := m.Update(msg)
+	m = next.(*Model)
+	if m.siteScroll == 0 {
+		t.Fatalf("wheel down over the sites pane should scroll the viewport, siteScroll still 0")
+	}
+	if m.siteCursor != 0 {
+		t.Fatalf("wheel must not move the selection, got cursor %d", m.siteCursor)
+	}
+}
+
+func TestView_RendersEachTab(t *testing.T) {
+	for _, tab := range orderedTabs {
+		m := NewModel("test")
+		m.snap = fakeSnap()
+		m.width, m.height = 150, 40
+		m.activeTab = tab
+		out := m.View()
+		// The tab bar labels are always present regardless of the active tab.
+		for _, label := range []string{"Dashboard", "Sites", "Services"} {
+			if !strings.Contains(out, label) {
+				t.Fatalf("tab %d view missing tab label %q", tab, label)
+			}
+		}
+	}
+}

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -35,6 +35,20 @@ var (
 	helpStyle      = lipgloss.NewStyle().Foreground(colDim)
 )
 
+// Top tab bar styles. The active tab reads as a filled accent pill so it
+// stands out as the current screen; inactive tabs sit dim until hovered or
+// clicked. Both keep the same padding so the bar's hit regions line up.
+var (
+	tabActiveStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#0b0b0b")).Background(colAccent).Padding(0, 2)
+	tabInactiveStyle = lipgloss.NewStyle().Foreground(colDim).Padding(0, 2)
+	tabBarStyle      = lipgloss.NewStyle().Padding(0, 1)
+)
+
+// cardStyle is the bordered box every dashboard grid card draws inside. It
+// mirrors unfocusedPane (rounded divider border, single-cell padding) so the
+// grid reads as a set of panels in the same visual language as the lists.
+var cardStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(colDivider).Padding(0, 1)
+
 const (
 	glyphRunning   = "●"
 	glyphStopped   = "○"

--- a/internal/tui/toast.go
+++ b/internal/tui/toast.go
@@ -133,14 +133,23 @@ func (m *Model) renderToasts(width int) string {
 	if len(m.toasts) == 0 {
 		return ""
 	}
+	// Right-align the raw stack within the full width. Used by the modal
+	// path, which stacks toasts as a section rather than compositing them.
+	return lipgloss.PlaceHorizontal(width, lipgloss.Right, m.toastStack())
+}
+
+// toastStack returns the raw toast boxes joined vertically with no horizontal
+// placement, so the overlay compositor can anchor each line to the right edge
+// itself without painting full-width blank rows over the content beneath.
+func (m *Model) toastStack() string {
+	if len(m.toasts) == 0 {
+		return ""
+	}
 	boxes := make([]string, 0, len(m.toasts))
 	for _, t := range m.toasts {
 		boxes = append(boxes, renderToastBox(t))
 	}
-	stack := strings.Join(boxes, "\n")
-	// Right-align the stack within the full width so each toast sits in
-	// the bottom-right corner of its row.
-	return lipgloss.PlaceHorizontal(width, lipgloss.Right, stack)
+	return strings.Join(boxes, "\n")
 }
 
 // renderToastBox draws one toast: coloured severity dot, bold title, dim


### PR DESCRIPTION
Reshapes `lerd tui` around a clickable top tab bar with three screens, Dashboard, Sites, and Services, replacing the old single combined layout. Tabs switch with a click or ctrl+left/right, and the lerd version moves to the far right of the tab row in place of the old status line.

Mouse support runs throughout, clicking a tab switches screens, clicking a site or service row selects it, clicking a site, service, or worker on the Dashboard jumps to its tab with that item selected, the site detail tab strip and the Debug lenses are clickable tabs, and the wheel scrolls whichever pane it is over without moving the selection. Keyboard navigation keeps the selection on screen via a one shot follow flag while the wheel only moves the scroll offset.

The Dashboard is a six card overview mirroring the web UI, Sites, Services, Workers, System Health, Resources, and Lerd, where each card shows its full list and scrolls within its own box, values are right aligned flush to the card edge, and the Lerd card carries a live recent activity feed derived from snapshot diffs. Logs surface in context too, a scrollable app logs pane under the site Overview that tails the newest file, and a service or worker logs pane under the service detail that follows the selection.

Colours align with the lerd and Laravel brand by making the interactive accent the brand red across the TUI and the CLI feedback layer. A UX pass makes the footer context aware per tab, reads the app log tail once per render behind an mtime cache, and folds autostart and LAN state into the periodic snapshot so the dashboard does no filesystem or systemd work on the hot render path.

Refs #573