### PR TITLE
fix: serve legacy framework versions with the lowest available definition

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -99,6 +99,20 @@ To change the global default (applies to all projects that don't have a per-proj
 lerd use 8.5
 ```
 
+## Framework PHP ranges
+
+Each framework version declares the PHP range it supports (for example Laravel 11 supports PHP 8.2 to 8.4). Lerd clamps the resolved PHP version into that range so a site never runs on a version its framework can't boot, and the PHP version picker in the dashboard and the TUI shows out-of-range versions as disabled rather than hiding them, so the constraint is visible.
+
+The range comes from the framework definition that matches your project. Lerd detects the framework major version from `composer.json` (for Laravel, the `laravel/framework` constraint) and loads that version's definition.
+
+### Legacy projects
+
+When a project's framework version predates every definition lerd ships, lerd serves it with the **lowest** available definition instead of the latest. A Laravel 6 project, for instance, is served by the Laravel 10 definition rather than Laravel 13.
+
+In that case the version is a best-effort guess: the definition targets a newer framework than your project, so its PHP range is **not** enforced. PHP clamping is relaxed and every installed version stays selectable, which lets a legacy Laravel 6 app keep running on PHP 7.4 even though the Laravel 10 definition asks for 8.1 and up. Pin the version you want with `lerd isolate 7.4`.
+
+Newer-than-shipped versions fall back to the latest definition as before, with its range enforced normally.
+
 ---
 
 ## FPM lifecycle

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -35,6 +36,14 @@ type Framework struct {
 	Label string `yaml:"label"`
 	// Version is the framework major version this definition targets (e.g. "11", "7").
 	Version string `yaml:"version,omitempty"`
+	// DetectedVersion is the project's real major version when it differs from
+	// Version because no exact definition existed and we clamped to the nearest
+	// available one. Runtime only, never serialized.
+	DetectedVersion string `yaml:"-"`
+	// VersionGuessed is true when Version was clamped to a borrowed definition
+	// because the detected version had none of its own (Laravel 6 served by the
+	// Laravel 10 definition); callers must not clamp PHP to its range.
+	VersionGuessed bool `yaml:"-"`
 	// PHP defines the supported PHP version range for this framework version.
 	PHP       FrameworkPHP    `yaml:"php,omitempty"`
 	Detect    []FrameworkRule `yaml:"detect,omitempty"`
@@ -787,6 +796,27 @@ func GetFrameworkForDir(name, projectDir string) (*Framework, bool) {
 		}
 	}
 
+	// 3b. Legacy project below every available definition: serve it with the
+	//     lowest one (not the latest) and mark it guessed, so callers relax PHP
+	//     clamping (a Laravel 6 project must still allow PHP 7.4).
+	guessed := false
+	guessedVersion := ""
+	if base == nil && version != "" {
+		if clamped := clampFrameworkVersion(name, version); clamped != "" {
+			clampedPath := filepath.Join(StoreFrameworksDir(), name+"@"+clamped+".yaml")
+			base = loadFrameworkYAML(clampedPath)
+			if base == nil && frameworkFetchHook != nil {
+				if fetched, err := frameworkFetchHook(name, clamped); err == nil && fetched != nil {
+					base = fetched
+				}
+			}
+			if base != nil {
+				guessed = true
+				guessedVersion = version
+			}
+		}
+	}
+
 	// 4. Fall back to any available local definition.
 	if base == nil {
 		base = loadFrameworkYAML(filepath.Join(StoreFrameworksDir(), name+".yaml"))
@@ -796,6 +826,10 @@ func GetFrameworkForDir(name, projectDir string) (*Framework, bool) {
 	}
 
 	if base != nil {
+		if guessed {
+			base.VersionGuessed = true
+			base.DetectedVersion = guessedVersion
+		}
 		base = mergeUserOverlay(base)
 		base = mergeBuiltinFrankenPHP(base)
 		base = mergeBuiltinTinker(base)
@@ -945,6 +979,43 @@ func cloneFrameworkMutable(in *Framework) *Framework {
 		out.FrankenPHP = &cp
 	}
 	return &out
+}
+
+// availableFrameworkVersions returns the major versions for which a versioned
+// store definition (<name>@<version>.yaml) exists locally, sorted ascending.
+// Only numeric versions are considered, since clamping compares them as ints.
+func availableFrameworkVersions(name string) []int {
+	pattern := filepath.Join(StoreFrameworksDir(), name+"@*.yaml")
+	matches, _ := filepath.Glob(pattern)
+	prefix := name + "@"
+	var vers []int
+	for _, p := range matches {
+		base := strings.TrimSuffix(filepath.Base(p), ".yaml")
+		v := strings.TrimPrefix(base, prefix)
+		if n, err := strconv.Atoi(v); err == nil {
+			vers = append(vers, n)
+		}
+	}
+	sort.Ints(vers)
+	return vers
+}
+
+// clampFrameworkVersion returns the lowest available definition version for a
+// legacy project whose detected version predates them all (so Laravel 6 uses the
+// Laravel 10 definition), or "" when no such clamping applies.
+func clampFrameworkVersion(name, detected string) string {
+	d, err := strconv.Atoi(detected)
+	if err != nil {
+		return ""
+	}
+	vers := availableFrameworkVersions(name)
+	if len(vers) == 0 {
+		return ""
+	}
+	if lo := vers[0]; d < lo {
+		return strconv.Itoa(lo)
+	}
+	return ""
 }
 
 // loadBestVersionedFramework scans StoreFrameworksDir for <name>@<version>.yaml files.

--- a/internal/config/framework_clamp_test.go
+++ b/internal/config/framework_clamp_test.go
@@ -1,0 +1,143 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// installLaravelVersions writes minimal laravel@<v>.yaml store definitions with
+// the given PHP ranges, so GetFrameworkForDir has a versioned set to clamp to.
+func installLaravelVersions(t *testing.T, versions map[string][2]string) {
+	t.Helper()
+	storeDir := StoreFrameworksDir()
+	if err := os.MkdirAll(storeDir, 0755); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+	for v, php := range versions {
+		body := "name: laravel\nlabel: Laravel\nversion: \"" + v + "\"\n" +
+			"public_dir: public\n" +
+			"php:\n  min: \"" + php[0] + "\"\n  max: \"" + php[1] + "\"\n" +
+			"detect:\n  - composer: laravel/framework\n"
+		path := filepath.Join(storeDir, "laravel@"+v+".yaml")
+		if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+}
+
+func writeComposer(t *testing.T, dir, laravelConstraint string) {
+	t.Helper()
+	body := `{"require":{"laravel/framework":"` + laravelConstraint + `"}}`
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte(body), 0644); err != nil {
+		t.Fatalf("write composer.json: %v", err)
+	}
+}
+
+func TestClampFrameworkVersion(t *testing.T) {
+	setConfigDir(t)
+	installLaravelVersions(t, map[string][2]string{
+		"10": {"8.1", "8.3"},
+		"11": {"8.2", "8.4"},
+		"12": {"8.2", "8.4"},
+		"13": {"8.3", "8.5"},
+	})
+
+	cases := []struct {
+		detected string
+		want     string
+	}{
+		{"6", "10"}, // below lowest → lowest
+		{"9", "10"}, // below lowest → lowest
+		{"14", ""},  // above highest → no clamp (falls back to latest)
+		{"12", ""},  // in a gap → no clamp (falls back to latest)
+		{"11", ""},  // exact exists → no clamp
+		{"13", ""},  // exact exists → no clamp
+		{"x", ""},   // non-numeric → no clamp
+	}
+	for _, c := range cases {
+		if got := clampFrameworkVersion("laravel", c.detected); got != c.want {
+			t.Errorf("clampFrameworkVersion(%q) = %q, want %q", c.detected, got, c.want)
+		}
+	}
+}
+
+func TestClampFrameworkVersion_NoVersionedDefs(t *testing.T) {
+	setConfigDir(t)
+	if got := clampFrameworkVersion("laravel", "6"); got != "" {
+		t.Errorf("clampFrameworkVersion with no defs = %q, want empty", got)
+	}
+}
+
+// A Laravel 6 project (no laravel@6.yaml) is served by the lowest available
+// definition and flagged as guessed.
+func TestGetFrameworkForDir_LegacyClampsToLowest(t *testing.T) {
+	setConfigDir(t)
+	installLaravelVersions(t, map[string][2]string{
+		"10": {"8.1", "8.3"},
+		"13": {"8.3", "8.5"},
+	})
+	dir := t.TempDir()
+	writeComposer(t, dir, "^6.0")
+
+	fw, ok := GetFrameworkForDir("laravel", dir)
+	if !ok {
+		t.Fatal("expected a framework definition")
+	}
+	if fw.Version != "10" {
+		t.Errorf("Version = %q, want 10 (lowest available)", fw.Version)
+	}
+	if !fw.VersionGuessed {
+		t.Error("VersionGuessed = false, want true for a clamped legacy project")
+	}
+	if fw.DetectedVersion != "6" {
+		t.Errorf("DetectedVersion = %q, want 6", fw.DetectedVersion)
+	}
+}
+
+// A future Laravel 14 project falls back to the latest available definition
+// (existing behavior) and is NOT flagged as guessed, so PHP stays clamped: its
+// composer asks for a high PHP that's inside the latest def's range anyway.
+func TestGetFrameworkForDir_FutureFallsBackToLatest(t *testing.T) {
+	setConfigDir(t)
+	installLaravelVersions(t, map[string][2]string{
+		"10": {"8.1", "8.3"},
+		"13": {"8.3", "8.5"},
+	})
+	dir := t.TempDir()
+	writeComposer(t, dir, "^14.0")
+
+	fw, ok := GetFrameworkForDir("laravel", dir)
+	if !ok {
+		t.Fatal("expected a framework definition")
+	}
+	if fw.Version != "13" {
+		t.Errorf("Version = %q, want 13 (latest available)", fw.Version)
+	}
+	if fw.VersionGuessed {
+		t.Error("VersionGuessed = true, want false for a future-version fallback")
+	}
+}
+
+// An exact match is never flagged as guessed.
+func TestGetFrameworkForDir_ExactNotGuessed(t *testing.T) {
+	setConfigDir(t)
+	installLaravelVersions(t, map[string][2]string{
+		"10": {"8.1", "8.3"},
+		"11": {"8.2", "8.4"},
+		"13": {"8.3", "8.5"},
+	})
+	dir := t.TempDir()
+	writeComposer(t, dir, "^11.0")
+
+	fw, ok := GetFrameworkForDir("laravel", dir)
+	if !ok {
+		t.Fatal("expected a framework definition")
+	}
+	if fw.Version != "11" {
+		t.Errorf("Version = %q, want 11", fw.Version)
+	}
+	if fw.VersionGuessed {
+		t.Error("VersionGuessed = true, want false for an exact match")
+	}
+}

--- a/internal/php/detector.go
+++ b/internal/php/detector.go
@@ -335,6 +335,26 @@ func stripOp(s, op string) string {
 	return strings.TrimSpace(strings.TrimPrefix(s, op))
 }
 
+// CompareMajorMinor compares two "major.minor" version strings numerically and
+// returns -1, 0, or 1. An unparseable version sorts below any numeric one.
+func CompareMajorMinor(a, b string) int {
+	aMaj, aMin := parseMajorMinor(a)
+	bMaj, bMin := parseMajorMinor(b)
+	if aMaj != bMaj {
+		if aMaj < bMaj {
+			return -1
+		}
+		return 1
+	}
+	if aMin < bMin {
+		return -1
+	}
+	if aMin > bMin {
+		return 1
+	}
+	return 0
+}
+
 func parseMajorMinor(s string) (int, int) {
 	s = strings.TrimSpace(s)
 	// Strip trailing .patch if present (e.g. "8.3.0" → "8.3")

--- a/internal/siteinfo/enrich_guessed_test.go
+++ b/internal/siteinfo/enrich_guessed_test.go
@@ -1,0 +1,83 @@
+package siteinfo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// A guessed (clamped) framework definition must not clamp the PHP version during
+// snapshot enrichment: a legacy Laravel 6 project pinned to 7.4 via composer
+// stays on 7.4 instead of being bumped to the Laravel 10 minimum on every
+// snapshot. An exact-match framework still clamps normally.
+func TestEnrichVersions_GuessedFrameworkSkipsPHPClamp(t *testing.T) {
+	stubPodman(t)
+	dir := t.TempDir()
+	composer := `{"require":{"php":"^7.4","laravel/framework":"^6.0"}}`
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0644); err != nil {
+		t.Fatalf("write composer: %v", err)
+	}
+
+	guessed := &config.Framework{
+		Name:           "laravel",
+		Version:        "10",
+		VersionGuessed: true,
+		PHP:            config.FrameworkPHP{Min: "8.1", Max: "8.3"},
+	}
+	e := &EnrichedSite{Name: "legacy", Path: dir, PHPVersion: "7.4"}
+	s := config.Site{Name: "legacy", Path: dir, PHPVersion: "7.4", Framework: "laravel"}
+	e.enrichVersions(s, guessed, true)
+
+	if e.PHPVersion != "7.4" {
+		t.Errorf("PHPVersion = %q, want 7.4 (guessed framework must not clamp)", e.PHPVersion)
+	}
+	if e.PHPVersionChanged {
+		t.Error("PHPVersionChanged = true, want false (7.4 should be left as-is)")
+	}
+}
+
+// A guessed framework is labelled by the project's detected version, not the
+// borrowed definition's version: a Laravel 6 project reads "Laravel 6".
+func TestFrameworkLabel_GuessedUsesDetectedVersion(t *testing.T) {
+	guessed := &config.Framework{
+		Name:            "laravel",
+		Label:           "Laravel",
+		Version:         "10",
+		DetectedVersion: "6",
+		VersionGuessed:  true,
+	}
+	if got := frameworkLabel("laravel", "", guessed, true); got != "Laravel 6" {
+		t.Errorf("frameworkLabel(guessed) = %q, want %q", got, "Laravel 6")
+	}
+
+	exact := &config.Framework{Name: "laravel", Label: "Laravel", Version: "10"}
+	if got := frameworkLabel("laravel", "", exact, true); got != "Laravel 10" {
+		t.Errorf("frameworkLabel(exact) = %q, want %q", got, "Laravel 10")
+	}
+}
+
+// An exact-match framework with a PHP range still clamps an out-of-range pin.
+func TestEnrichVersions_ExactFrameworkClamps(t *testing.T) {
+	stubPodman(t)
+	dir := t.TempDir()
+	composer := `{"require":{"php":"^7.4","laravel/framework":"^10.0"}}`
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0644); err != nil {
+		t.Fatalf("write composer: %v", err)
+	}
+
+	exact := &config.Framework{
+		Name:    "laravel",
+		Version: "10",
+		PHP:     config.FrameworkPHP{Min: "8.1", Max: "8.3"},
+	}
+	e := &EnrichedSite{Name: "modern", Path: dir, PHPVersion: "7.4"}
+	s := config.Site{Name: "modern", Path: dir, PHPVersion: "7.4", Framework: "laravel"}
+	e.enrichVersions(s, exact, true)
+
+	// 7.4 is below the 8.1 minimum, so it must be clamped up out of 7.4.
+	if e.PHPVersion == "7.4" {
+		t.Error("PHPVersion = 7.4, want a clamped version within 8.1-8.3 for an exact framework")
+	}
+}

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -98,6 +98,11 @@ type EnrichedSite struct {
 	FrameworkName    string
 	FrameworkLabel   string
 	FrameworkVersion string
+	// FrameworkPHPMin/Max are the framework's supported PHP range, so the UI and
+	// TUI can disable out-of-range versions. Empty when the version was guessed
+	// (clamped), since the range then belongs to a different version.
+	FrameworkPHPMin string
+	FrameworkPHPMax string
 
 	// UsesPHP reports whether the site is actually a PHP project (composer.json
 	// or .php files present) served by the shared FPM image or FrankenPHP.
@@ -299,6 +304,16 @@ func Enrich(s config.Site, flags EnrichFlag) EnrichedSite {
 		fw, hasFw = config.GetFrameworkForDir(s.Framework, s.Path)
 		if hasFw {
 			e.FrameworkVersion = fw.Version
+			if fw.VersionGuessed {
+				// Report the project's real version, not the borrowed
+				// definition's, and don't enforce that definition's PHP range.
+				if fw.DetectedVersion != "" {
+					e.FrameworkVersion = fw.DetectedVersion
+				}
+			} else {
+				e.FrameworkPHPMin = fw.PHP.Min
+				e.FrameworkPHPMax = fw.PHP.Max
+			}
 		}
 	}
 
@@ -394,7 +409,10 @@ func (e *EnrichedSite) enrichVersions(s config.Site, fw *config.Framework, hasFw
 	// container actually runs, undoing what link pinned. Node tooling still applies.
 	if !s.IsCustomFPM() {
 		phpMin, phpMax := "", ""
-		if hasFw {
+		// A guessed framework targets a different version than the project, so its
+		// PHP range must not constrain detection, or a Laravel 6 project pinned to
+		// 7.4 would be bumped to the Laravel 10 minimum on every snapshot.
+		if hasFw && !fw.VersionGuessed {
 			phpMin, phpMax = fw.PHP.Min, fw.PHP.Max
 		}
 		detected := phpPkg.DetectVersionClamped(s.Path, phpMin, phpMax, s.PHPVersion)
@@ -614,6 +632,9 @@ func (e *EnrichedSite) enrichGit() {
 			}
 			if fw, ok := config.GetFrameworkForDir(e.FrameworkName, wt.Path); ok {
 				info.FrameworkVersion = fw.Version
+				if fw.VersionGuessed && fw.DetectedVersion != "" {
+					info.FrameworkVersion = fw.DetectedVersion
+				}
 				info.FrameworkLabel = frameworkLabel(e.FrameworkName, wt.Path, fw, true)
 				info.FrameworkWorkers = enrichWorktreeWorkers(e.Name, wt.Path, fw)
 			} else {
@@ -708,6 +729,12 @@ func frameworkLabel(name, path string, fw *config.Framework, hasFw bool) string 
 		return ""
 	}
 	if hasFw {
+		// A guessed version is labelled by the version detected from the project,
+		// not the borrowed definition's, so a Laravel 6 project reads "Laravel 6"
+		// rather than "Laravel 10".
+		if fw.VersionGuessed && fw.DetectedVersion != "" {
+			return fw.Label + " " + fw.DetectedVersion
+		}
 		if fw.Version != "" {
 			return fw.Label + " " + fw.Version
 		}

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -16,10 +16,14 @@ import (
 type VersionResult struct {
 	PHP            string // best installed PHP version (clamped to framework range)
 	Node           string // detected Node version
-	PHPMin         string // framework minimum PHP version (empty if no framework)
-	PHPMax         string // framework maximum PHP version (empty if no framework)
+	PHPMin         string // framework minimum PHP version (empty if no framework or guessed)
+	PHPMax         string // framework maximum PHP version (empty if no framework or guessed)
 	SuggestedPHP   string // better PHP version to install (empty if current is optimal)
 	FrameworkLabel string // human-readable framework name for messages
+	// FrameworkGuessed is true when the framework version was clamped to a
+	// borrowed definition; its PHP range is not enforced (PHPMin/PHPMax stay
+	// empty) since it describes a different version than the project.
+	FrameworkGuessed bool
 }
 
 // DetectSiteVersions resolves the framework, PHP version (clamped to framework
@@ -30,9 +34,15 @@ func DetectSiteVersions(dir, framework, defaultPHP, defaultNode string) VersionR
 
 	if framework != "" {
 		if fw, ok := config.GetFrameworkForDir(framework, dir); ok {
-			result.PHPMin = fw.PHP.Min
-			result.PHPMax = fw.PHP.Max
 			result.FrameworkLabel = fw.Label
+			result.FrameworkGuessed = fw.VersionGuessed
+			// A guessed definition's PHP range must not constrain the project (a
+			// Laravel 6 served by the Laravel 10 def must still allow 7.4), so
+			// leave Min/Max empty when guessed and no clamping happens.
+			if !fw.VersionGuessed {
+				result.PHPMin = fw.PHP.Min
+				result.PHPMax = fw.PHP.Max
+			}
 		}
 	}
 

--- a/internal/siteops/link_test.go
+++ b/internal/siteops/link_test.go
@@ -1,8 +1,49 @@
 package siteops
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/geodro/lerd/internal/config"
 )
+
+// A legacy Laravel 6 project served by a clamped (guessed) definition must not
+// inherit that definition's PHP range, so PHP 7.4 in composer.json is honoured
+// rather than clamped up to the Laravel 10 minimum.
+func TestDetectSiteVersions_GuessedFrameworkSkipsPHPClamp(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	storeDir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(storeDir, 0755); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+	def := "name: laravel\nlabel: Laravel\nversion: \"10\"\npublic_dir: public\n" +
+		"php:\n  min: \"8.1\"\n  max: \"8.3\"\n" +
+		"detect:\n  - composer: laravel/framework\n"
+	if err := os.WriteFile(filepath.Join(storeDir, "laravel@10.yaml"), []byte(def), 0644); err != nil {
+		t.Fatalf("write def: %v", err)
+	}
+
+	dir := t.TempDir()
+	composer := `{"require":{"php":"^7.4","laravel/framework":"^6.0"}}`
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0644); err != nil {
+		t.Fatalf("write composer: %v", err)
+	}
+
+	result := DetectSiteVersions(dir, "laravel", "8.4", "22")
+	if !result.FrameworkGuessed {
+		t.Error("FrameworkGuessed = false, want true for a Laravel 6 project")
+	}
+	if result.PHPMin != "" || result.PHPMax != "" {
+		t.Errorf("expected no PHP clamp range when guessed, got min=%q max=%q", result.PHPMin, result.PHPMax)
+	}
+	if result.PHP != "7.4" {
+		t.Errorf("PHP = %q, want 7.4 (composer constraint honoured, not clamped)", result.PHP)
+	}
+}
 
 func TestDetectSiteVersions_Defaults(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/tui/modal.go
+++ b/internal/tui/modal.go
@@ -296,12 +296,18 @@ func (m *Model) renderPickerModal(w, h int) string {
 	}
 	for i, opt := range m.pickerOptions {
 		marker := "  "
-		styled := opt
-		if i == m.pickerCursor {
+		switch {
+		case m.pickerIsDisabled(i):
+			// Out-of-range PHP version: shown for context, but dimmed and not
+			// selectable, so the framework's constraint is visible.
+			lines = append(lines, marker+dimStyle.Render(opt+"  out of range"))
+			continue
+		case i == m.pickerCursor:
 			marker = accentStyle.Render("▸ ")
-			styled = selectedStyle.Render(opt)
+			lines = append(lines, marker+selectedStyle.Render(opt))
+		default:
+			lines = append(lines, marker+opt)
 		}
-		lines = append(lines, marker+styled)
 	}
 	return renderModal(w, h,
 		title,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -124,8 +124,12 @@ type Model struct {
 	// pickerWorktreePath is set when the picker was opened from a per-
 	// worktree row; applyPicker uses it as the cwd so the change writes
 	// .php-version / .node-version inside the worktree's checkout.
-	pickerKind         detailKind
-	pickerOptions      []string
+	pickerKind    detailKind
+	pickerOptions []string
+	// pickerDisabled is parallel to pickerOptions: a true entry is shown dimmed
+	// and skipped on navigation and apply. Used to reflect a framework's PHP
+	// range so out-of-range versions are visible but not selectable.
+	pickerDisabled     []bool
 	pickerCursor       int
 	pickerWorktreePath string
 	pickerWorktreeName string
@@ -1352,7 +1356,20 @@ func (m *Model) moveCursor(delta int) {
 			if n == 0 {
 				return
 			}
-			m.pickerCursor = clamp(m.pickerCursor+delta, 0, n-1)
+			next := clamp(m.pickerCursor+delta, 0, n-1)
+			// Skip over disabled (out-of-range) entries in the direction of
+			// travel; fall back to the original cursor if every step is disabled.
+			step := 1
+			if delta < 0 {
+				step = -1
+			}
+			for next >= 0 && next < n && m.pickerIsDisabled(next) {
+				next += step
+			}
+			if next < 0 || next >= n || m.pickerIsDisabled(next) {
+				return
+			}
+			m.pickerCursor = next
 			return
 		}
 		switch m.detailMode {

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -24,7 +24,8 @@ func (m *Model) openPHPPicker(s *siteinfo.EnrichedSite) {
 	versions = frankenPHPRunnable(s.Runtime, versions, s.PHPVersion)
 	m.pickerKind = kindPHP
 	m.pickerOptions = versions
-	m.pickerCursor = indexOf(versions, s.PHPVersion)
+	m.pickerDisabled = phpDisabledMask(versions, s.FrameworkPHPMin, s.FrameworkPHPMax, s.PHPVersion)
+	m.pickerCursor = firstEnabledFrom(indexOf(versions, s.PHPVersion), m.pickerDisabled)
 }
 
 // openNodePicker shells out to fnm (same path lerd-ui uses) because node
@@ -45,6 +46,7 @@ func (m *Model) openNodePicker(s *siteinfo.EnrichedSite) {
 	}
 	m.pickerKind = kindNode
 	m.pickerOptions = versions
+	m.pickerDisabled = nil
 	if nodeDet.JSRuntime(s.Path) == "bun" {
 		m.pickerCursor = indexOf(versions, "bun")
 	} else {
@@ -68,7 +70,9 @@ func (m *Model) openWorktreePHPPicker(s *siteinfo.EnrichedSite, row detailRow) {
 	versions = frankenPHPRunnable(s.Runtime, versions, wt.PHPVersion)
 	m.pickerKind = kindWorktreePHP
 	m.pickerOptions = versions
-	m.pickerCursor = indexOf(versions, wt.PHPVersion)
+	// A worktree shares the parent site's framework, so it inherits its range.
+	m.pickerDisabled = phpDisabledMask(versions, s.FrameworkPHPMin, s.FrameworkPHPMax, wt.PHPVersion)
+	m.pickerCursor = firstEnabledFrom(indexOf(versions, wt.PHPVersion), m.pickerDisabled)
 	m.pickerWorktreePath = row.branchPath
 	m.pickerWorktreeName = row.branch
 }
@@ -86,15 +90,23 @@ func (m *Model) openWorktreeNodePicker(s *siteinfo.EnrichedSite, row detailRow) 
 	}
 	m.pickerKind = kindWorktreeNode
 	m.pickerOptions = versions
+	m.pickerDisabled = nil
 	m.pickerCursor = indexOf(versions, wt.NodeVersion)
 	m.pickerWorktreePath = row.branchPath
 	m.pickerWorktreeName = row.branch
+}
+
+// pickerIsDisabled reports whether the option at index i is disabled (an
+// out-of-range PHP version that can't be selected).
+func (m *Model) pickerIsDisabled(i int) bool {
+	return i >= 0 && i < len(m.pickerDisabled) && m.pickerDisabled[i]
 }
 
 // closePicker exits picker mode without applying a choice.
 func (m *Model) closePicker() {
 	m.pickerKind = kindInfo
 	m.pickerOptions = nil
+	m.pickerDisabled = nil
 	m.pickerCursor = 0
 	m.pickerWorktreePath = ""
 	m.pickerWorktreeName = ""
@@ -114,6 +126,11 @@ func (m *Model) applyPicker() tea.Cmd {
 	}
 	if m.pickerCursor >= len(m.pickerOptions) {
 		m.pickerCursor = len(m.pickerOptions) - 1
+	}
+	// A disabled (out-of-range) entry can't be applied; ignore the keystroke
+	// and leave the picker open so the user can pick a valid version.
+	if m.pickerIsDisabled(m.pickerCursor) {
+		return nil
 	}
 	ver := m.pickerOptions[m.pickerCursor]
 	kind := m.pickerKind
@@ -218,6 +235,48 @@ func frankenPHPRunnable(runtime string, versions []string, current string) []str
 		return versions
 	}
 	return out
+}
+
+// phpDisabledMask returns a slice parallel to versions marking those outside
+// the framework's [min, max] range as disabled. The current version is never
+// disabled, so the active selection always shows. An empty min and max (no
+// framework range, or a guessed version) disables nothing.
+func phpDisabledMask(versions []string, min, max, current string) []bool {
+	mask := make([]bool, len(versions))
+	if min == "" && max == "" {
+		return mask
+	}
+	for i, v := range versions {
+		if v == current {
+			continue
+		}
+		if (min != "" && phpPkg.CompareMajorMinor(v, min) < 0) || (max != "" && phpPkg.CompareMajorMinor(v, max) > 0) {
+			mask[i] = true
+		}
+	}
+	return mask
+}
+
+// firstEnabledFrom returns start if enabled, otherwise the nearest enabled index
+// scanning forward then wrapping to the top. Returns start when all are disabled.
+func firstEnabledFrom(start int, disabled []bool) int {
+	if start < 0 || start >= len(disabled) {
+		start = 0
+	}
+	if len(disabled) == 0 || !disabled[start] {
+		return start
+	}
+	for i := start; i < len(disabled); i++ {
+		if !disabled[i] {
+			return i
+		}
+	}
+	for i := 0; i < start; i++ {
+		if !disabled[i] {
+			return i
+		}
+	}
+	return start
 }
 
 func indexOf(ss []string, target string) int {

--- a/internal/tui/picker_clamp_test.go
+++ b/internal/tui/picker_clamp_test.go
@@ -1,0 +1,77 @@
+package tui
+
+import "testing"
+
+func TestPhpDisabledMask(t *testing.T) {
+	versions := []string{"7.4", "8.1", "8.3", "8.4", "8.5"}
+
+	t.Run("no range disables nothing", func(t *testing.T) {
+		mask := phpDisabledMask(versions, "", "", "8.4")
+		for i, d := range mask {
+			if d {
+				t.Errorf("%s disabled with no range", versions[i])
+			}
+		}
+	})
+
+	t.Run("disables out-of-range versions", func(t *testing.T) {
+		// Laravel 10 range 8.1–8.3, site on 8.3.
+		mask := phpDisabledMask(versions, "8.1", "8.3", "8.3")
+		want := map[string]bool{"7.4": true, "8.4": true, "8.5": true}
+		for i, v := range versions {
+			if mask[i] != want[v] {
+				t.Errorf("%s disabled=%v, want %v", v, mask[i], want[v])
+			}
+		}
+	})
+
+	t.Run("never disables the current version", func(t *testing.T) {
+		// Legacy site pinned to 7.4 keeps it selectable even below the range.
+		mask := phpDisabledMask(versions, "8.1", "8.3", "7.4")
+		if mask[0] {
+			t.Error("current version 7.4 should not be disabled")
+		}
+	})
+}
+
+func TestFirstEnabledFrom(t *testing.T) {
+	cases := []struct {
+		name     string
+		start    int
+		disabled []bool
+		want     int
+	}{
+		{"start enabled", 1, []bool{false, false, true}, 1},
+		{"skip forward", 0, []bool{true, true, false}, 2},
+		{"wrap to top", 2, []bool{false, true, true}, 0},
+		{"all disabled returns start", 1, []bool{true, true, true}, 1},
+		{"empty returns start", 0, nil, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := firstEnabledFrom(c.start, c.disabled); got != c.want {
+				t.Errorf("firstEnabledFrom(%d, %v) = %d, want %d", c.start, c.disabled, got, c.want)
+			}
+		})
+	}
+}
+
+// Navigation must land only on enabled entries, skipping disabled ones.
+func TestPickerNavSkipsDisabled(t *testing.T) {
+	m := &Model{
+		activeTab:      tabSites,
+		focus:          paneDetail,
+		pickerKind:     kindPHP,
+		pickerOptions:  []string{"7.4", "8.1", "8.3", "8.4"},
+		pickerDisabled: []bool{false, true, true, false},
+		pickerCursor:   0,
+	}
+	m.moveCursor(1)
+	if m.pickerCursor != 3 {
+		t.Errorf("after down from 0, cursor = %d, want 3 (8.1 and 8.3 disabled)", m.pickerCursor)
+	}
+	m.moveCursor(-1)
+	if m.pickerCursor != 0 {
+		t.Errorf("after up from 3, cursor = %d, want 0", m.pickerCursor)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -660,6 +660,8 @@ type WorktreeResponse struct {
 	Domain              string         `json:"domain"`
 	Path                string         `json:"path"`
 	PHPVersion          string         `json:"php_version,omitempty"`
+	PHPMin              string         `json:"php_min,omitempty"`
+	PHPMax              string         `json:"php_max,omitempty"`
 	NodeVersion         string         `json:"node_version,omitempty"`
 	PHPVersionOverride  bool           `json:"php_version_override,omitempty"`
 	NodeVersionOverride bool           `json:"node_version_override,omitempty"`
@@ -702,39 +704,44 @@ type SiteResponse struct {
 	ConflictingDomains []ConflictingDomain `json:"conflicting_domains,omitempty"`
 	Path               string              `json:"path"`
 	PHPVersion         string              `json:"php_version"`
-	UsesPHP            bool                `json:"uses_php"`
-	NodeVersion        string              `json:"node_version"`
-	JSRuntime          string              `json:"js_runtime,omitempty"`
-	TLS                bool                `json:"tls"`
-	Framework          string              `json:"framework"`
-	FPMRunning         bool                `json:"fpm_running"`
-	IsLaravel          bool                `json:"is_laravel"`
-	FrameworkLabel     string              `json:"framework_label"`
-	QueueRunning       bool                `json:"queue_running"`
-	QueueFailing       bool                `json:"queue_failing,omitempty"`
-	StripeRunning      bool                `json:"stripe_running"`
-	StripeSecretSet    bool                `json:"stripe_secret_set"`
-	StripeWebhookPath  string              `json:"stripe_webhook_path,omitempty"`
-	ScheduleRunning    bool                `json:"schedule_running"`
-	ScheduleFailing    bool                `json:"schedule_failing,omitempty"`
-	ReverbRunning      bool                `json:"reverb_running"`
-	ReverbFailing      bool                `json:"reverb_failing,omitempty"`
-	HasReverb          bool                `json:"has_reverb"`
-	HasHorizon         bool                `json:"has_horizon"`
-	HorizonRunning     bool                `json:"horizon_running"`
-	HorizonFailing     bool                `json:"horizon_failing,omitempty"`
-	HorizonReload      bool                `json:"horizon_reload,omitempty"`       // horizon runs via horizon:listen (auto-reload)
-	HorizonReloadReady bool                `json:"horizon_reload_ready,omitempty"` // chokidar present, so auto-reload can be enabled without installing it
-	OctaneReload       bool                `json:"octane_reload,omitempty"`        // FrankenPHP worker serves via octane:start --watch (auto-reload)
-	OctaneReloadReady  bool                `json:"octane_reload_ready,omitempty"`  // FrankenPHP worker mode + chokidar present, so auto-reload can be enabled
-	HasQueueWorker     bool                `json:"has_queue_worker"`
-	HasScheduleWorker  bool                `json:"has_schedule_worker"`
-	FrameworkWorkers   []WorkerStatus      `json:"framework_workers,omitempty"`
-	HasAppLogs         bool                `json:"has_app_logs"`
-	LatestLogTime      string              `json:"latest_log_time,omitempty"`
-	HasFavicon         bool                `json:"has_favicon"`
-	HasEnv             bool                `json:"has_env"`
-	Paused             bool                `json:"paused"`
+	// PHPMin/PHPMax are the framework's supported PHP range. The dashboard
+	// disables out-of-range versions in the picker. Empty when there is no
+	// framework or its version was guessed (clamped), so nothing is disabled.
+	PHPMin             string         `json:"php_min,omitempty"`
+	PHPMax             string         `json:"php_max,omitempty"`
+	UsesPHP            bool           `json:"uses_php"`
+	NodeVersion        string         `json:"node_version"`
+	JSRuntime          string         `json:"js_runtime,omitempty"`
+	TLS                bool           `json:"tls"`
+	Framework          string         `json:"framework"`
+	FPMRunning         bool           `json:"fpm_running"`
+	IsLaravel          bool           `json:"is_laravel"`
+	FrameworkLabel     string         `json:"framework_label"`
+	QueueRunning       bool           `json:"queue_running"`
+	QueueFailing       bool           `json:"queue_failing,omitempty"`
+	StripeRunning      bool           `json:"stripe_running"`
+	StripeSecretSet    bool           `json:"stripe_secret_set"`
+	StripeWebhookPath  string         `json:"stripe_webhook_path,omitempty"`
+	ScheduleRunning    bool           `json:"schedule_running"`
+	ScheduleFailing    bool           `json:"schedule_failing,omitempty"`
+	ReverbRunning      bool           `json:"reverb_running"`
+	ReverbFailing      bool           `json:"reverb_failing,omitempty"`
+	HasReverb          bool           `json:"has_reverb"`
+	HasHorizon         bool           `json:"has_horizon"`
+	HorizonRunning     bool           `json:"horizon_running"`
+	HorizonFailing     bool           `json:"horizon_failing,omitempty"`
+	HorizonReload      bool           `json:"horizon_reload,omitempty"`       // horizon runs via horizon:listen (auto-reload)
+	HorizonReloadReady bool           `json:"horizon_reload_ready,omitempty"` // chokidar present, so auto-reload can be enabled without installing it
+	OctaneReload       bool           `json:"octane_reload,omitempty"`        // FrankenPHP worker serves via octane:start --watch (auto-reload)
+	OctaneReloadReady  bool           `json:"octane_reload_ready,omitempty"`  // FrankenPHP worker mode + chokidar present, so auto-reload can be enabled
+	HasQueueWorker     bool           `json:"has_queue_worker"`
+	HasScheduleWorker  bool           `json:"has_schedule_worker"`
+	FrameworkWorkers   []WorkerStatus `json:"framework_workers,omitempty"`
+	HasAppLogs         bool           `json:"has_app_logs"`
+	LatestLogTime      string         `json:"latest_log_time,omitempty"`
+	HasFavicon         bool           `json:"has_favicon"`
+	HasEnv             bool           `json:"has_env"`
+	Paused             bool           `json:"paused"`
 	// Pinned excludes the site from idle-suspend (kept always-warm).
 	Pinned bool `json:"pinned,omitempty"`
 	// LastActive is the unix-seconds time the site last saw a request, from the
@@ -879,6 +886,8 @@ func buildSites() []SiteResponse {
 				Domain:               wt.Domain,
 				Path:                 wt.Path,
 				PHPVersion:           wt.PHPVersion,
+				PHPMin:               e.FrameworkPHPMin,
+				PHPMax:               e.FrameworkPHPMax,
 				NodeVersion:          wt.NodeVersion,
 				PHPVersionOverride:   wt.PHPVersionOverride,
 				NodeVersionOverride:  wt.NodeVersionOverride,
@@ -906,6 +915,8 @@ func buildSites() []SiteResponse {
 			ConflictingDomains:   conflicting,
 			Path:                 e.Path,
 			PHPVersion:           e.PHPVersion,
+			PHPMin:               e.FrameworkPHPMin,
+			PHPMax:               e.FrameworkPHPMax,
 			UsesPHP:              e.UsesPHP,
 			NodeVersion:          e.NodeVersion,
 			JSRuntime:            projectJSRuntime(e.Path),

--- a/internal/ui/web/src/stores/phpVersions.test.ts
+++ b/internal/ui/web/src/stores/phpVersions.test.ts
@@ -4,23 +4,45 @@ import { phpOptionsForSite } from './phpVersions';
 describe('phpOptionsForSite', () => {
   const installed = ['7.4', '8.1', '8.3', '8.4', '8.5'];
   const franken = ['8.2', '8.3', '8.4', '8.5'];
+  const values = (opts: { value: string }[]) => opts.map((o) => o.value);
+  const disabled = (opts: { value: string; disabled?: boolean }[]) =>
+    opts.filter((o) => o.disabled).map((o) => o.value);
 
   it('returns every installed version for non-FrankenPHP runtimes', () => {
-    expect(phpOptionsForSite('fpm', installed, franken, '8.4')).toEqual(installed);
-    expect(phpOptionsForSite(undefined, installed, franken, '8.4')).toEqual(installed);
+    expect(values(phpOptionsForSite('fpm', installed, franken, '8.4'))).toEqual(installed);
+    expect(values(phpOptionsForSite(undefined, installed, franken, '8.4'))).toEqual(installed);
   });
 
   it('limits FrankenPHP to installed versions that are also publishable', () => {
-    expect(phpOptionsForSite('frankenphp', installed, franken, '8.4')).toEqual(['8.3', '8.4', '8.5']);
+    expect(values(phpOptionsForSite('frankenphp', installed, franken, '8.4'))).toEqual(['8.3', '8.4', '8.5']);
   });
 
   it('keeps the current version even when it is not FPM-installed', () => {
-    expect(phpOptionsForSite('frankenphp', ['8.3', '8.4'], franken, '8.5')).toEqual(['8.3', '8.4', '8.5']);
+    expect(values(phpOptionsForSite('frankenphp', ['8.3', '8.4'], franken, '8.5'))).toEqual(['8.3', '8.4', '8.5']);
   });
 
   it('never offers a version FrankenPHP cannot run', () => {
-    expect(phpOptionsForSite('frankenphp', installed, franken, '8.4')).not.toContain('7.4');
-    expect(phpOptionsForSite('frankenphp', installed, franken, '8.4')).not.toContain('8.1');
+    expect(values(phpOptionsForSite('frankenphp', installed, franken, '8.4'))).not.toContain('7.4');
+    expect(values(phpOptionsForSite('frankenphp', installed, franken, '8.4'))).not.toContain('8.1');
+  });
+
+  it('disables nothing when the framework declares no range', () => {
+    expect(disabled(phpOptionsForSite('fpm', installed, franken, '8.4'))).toEqual([]);
+  });
+
+  it('disables versions outside the framework PHP range', () => {
+    // Laravel 10: 8.1–8.3 with the site already on 8.3. Everything below 8.1
+    // and above 8.3 is kept in the list but disabled.
+    const opts = phpOptionsForSite('fpm', installed, franken, '8.3', '8.1', '8.3');
+    expect(values(opts)).toEqual(installed); // all kept, none hidden
+    expect(disabled(opts)).toEqual(['7.4', '8.4', '8.5']);
+  });
+
+  it('never disables the current version even if it is out of range', () => {
+    // A legacy site already pinned to 7.4 keeps 7.4 selectable.
+    const opts = phpOptionsForSite('fpm', installed, franken, '7.4', '8.1', '8.3');
+    expect(disabled(opts)).toEqual(['8.4', '8.5']);
+    expect(disabled(opts)).not.toContain('7.4');
   });
 });
 

--- a/internal/ui/web/src/stores/phpVersions.ts
+++ b/internal/ui/web/src/stores/phpVersions.ts
@@ -5,18 +5,53 @@ import type { SiteNginxBackup, LoadNginxBackupsResult, ResetNginxResult, SaveNgi
 
 export const phpVersions = writable<string[]>([]);
 
-// phpOptionsForSite returns the versions to offer in a site's PHP dropdown.
+export interface PhpOption {
+  value: string;
+  disabled?: boolean;
+  description?: string;
+}
+
+// cmpVersion compares two "major.minor" strings numerically.
+function cmpVersion(a: string, b: string): number {
+  const [aMaj, aMin] = a.split('.').map((n) => parseInt(n, 10) || 0);
+  const [bMaj, bMin] = b.split('.').map((n) => parseInt(n, 10) || 0);
+  return aMaj !== bMaj ? aMaj - bMaj : aMin - bMin;
+}
+
+// outOfFrameworkRange reports whether a PHP version falls outside the
+// framework's [min, max] range. An empty bound means unconstrained on that side.
+function outOfFrameworkRange(v: string, min?: string, max?: string): boolean {
+  if (min && cmpVersion(v, min) < 0) return true;
+  if (max && cmpVersion(v, max) > 0) return true;
+  return false;
+}
+
+// phpOptionsForSite returns the options to offer in a site's PHP dropdown.
 // FrankenPHP sites are limited to the versions dunglas/frankenphp publishes an
 // image for, intersected with what's installed, plus the site's current version
 // so the control never renders blank. Other runtimes offer every installed one.
+// When the framework declares a PHP range (min/max), versions outside it are
+// kept in the list but disabled, so the constraint is visible rather than
+// silently hidden. The site's current version is never disabled. min/max are
+// empty when the framework version was guessed, leaving every version enabled.
 export function phpOptionsForSite(
   runtime: string | undefined,
   installed: string[],
   frankenphpVersions: string[],
-  current: string
-): string[] {
-  if (runtime !== 'frankenphp') return installed;
-  return frankenphpVersions.filter((v) => installed.includes(v) || v === current);
+  current: string,
+  min?: string,
+  max?: string
+): PhpOption[] {
+  const base =
+    runtime === 'frankenphp'
+      ? frankenphpVersions.filter((v) => installed.includes(v) || v === current)
+      : installed;
+  return base.map((v) => {
+    const disabled = v !== current && outOfFrameworkRange(v, min, max);
+    return disabled
+      ? { value: v, disabled: true, description: `needs PHP ${min || '*'} to ${max || '*'}` }
+      : { value: v };
+  });
 }
 
 export async function loadPhpVersions() {

--- a/internal/ui/web/src/stores/sites.ts
+++ b/internal/ui/web/src/stores/sites.ts
@@ -18,6 +18,8 @@ export interface Site {
   path?: string;
   branch?: string;
   php_version?: string;
+  php_min?: string;
+  php_max?: string;
   uses_php?: boolean;
   node_version?: string;
   js_runtime?: string;
@@ -51,6 +53,8 @@ export interface Site {
     domain?: string;
     path?: string;
     php_version?: string;
+    php_min?: string;
+    php_max?: string;
     node_version?: string;
     php_version_override?: boolean;
     node_version_override?: boolean;

--- a/internal/ui/web/src/tabs/sites/SiteControls.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteControls.svelte
@@ -49,8 +49,19 @@
   const effectiveNode = $derived(activeWorktree?.node_version ?? site.node_version ?? '');
   const phpInherited = $derived(Boolean(activeWorktree) && !activeWorktree?.php_version_override);
   const nodeInherited = $derived(Boolean(activeWorktree) && !activeWorktree?.node_version_override);
+  // Framework PHP range (empty when guessed), used to disable out-of-range
+  // versions in the picker. A worktree carries the parent's range.
+  const effectivePhpMin = $derived(activeWorktree?.php_min ?? site.php_min);
+  const effectivePhpMax = $derived(activeWorktree?.php_max ?? site.php_max);
   const phpOptions = $derived(
-    phpOptionsForSite(site.runtime, $phpVersions, $status.frankenphp_php_versions, effectivePhp)
+    phpOptionsForSite(
+      site.runtime,
+      $phpVersions,
+      $status.frankenphp_php_versions,
+      effectivePhp,
+      effectivePhpMin,
+      effectivePhpMax
+    )
   );
   // When host bun is available, the Node dropdown offers a "bun" entry that
   // pins .lerd.yaml js_runtime (project-level), leaving node_version intact.


### PR DESCRIPTION
A project whose framework major version predates every definition lerd ships had no exact match, so it fell back to the latest definition and a Laravel 6 project was treated as Laravel 13. That definition's PHP range then clamped the version upward, so an app declaring php ^7.4 could never be set to 7.4, and the snapshot refresh kept re-applying the clamp and persisting the bumped version back into the registry.

Legacy projects below every available definition are now served by the lowest one instead of the latest, and that match is flagged as a guess. When the version is guessed the borrowed definition's PHP range is no longer enforced, so the project keeps whatever its composer constraint asks for, and the site is labelled by its detected version rather than the borrowed one.

The framework's supported PHP range is exposed through the dashboard API, and both the dashboard and the TUI now show out-of-range PHP versions as disabled in the picker rather than hiding them. When the version was guessed nothing is disabled.

Refs #581