### PR TITLE
docs(seo): tighten homepage description and fix og:image dimensions

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,7 +5,7 @@ const OG_IMAGE = `${SITE_URL}/assets/social-preview.png`
 
 export default defineConfig({
   title: 'Lerd',
-  description: 'Open-source Herd-like local PHP development environment for Linux and macOS. Automatic .test domains and HTTPS, PHP 7.4–8.5, rootless Podman, no Docker daemon. Works on Ubuntu, Fedora, Arch, Debian, and macOS.',
+  description: 'Open-source, Herd-like local PHP development for Linux and macOS. Automatic .test domains, HTTPS, per-project PHP and Node, rootless Podman, no Docker daemon.',
   base: '/',
   lang: 'en-US',
   cleanUrls: true,
@@ -36,8 +36,8 @@ export default defineConfig({
     ['meta', { property: 'og:locale', content: 'en_US' }],
     ['meta', { property: 'og:image', content: OG_IMAGE }],
     ['meta', { property: 'og:image:type', content: 'image/png' }],
-    ['meta', { property: 'og:image:width', content: '1280' }],
-    ['meta', { property: 'og:image:height', content: '640' }],
+    ['meta', { property: 'og:image:width', content: '1499' }],
+    ['meta', { property: 'og:image:height', content: '787' }],
     ['meta', { property: 'og:image:alt', content: 'Lerd, local PHP development for Linux and macOS' }],
 
     // Twitter / X

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 layout: landing
-title: Lerd - Local PHP development for Linux
+title: Lerd - Local PHP development for Linux and macOS
 titleTemplate: false
-description: Open-source local PHP development environment built for Linux. Nginx + PHP on rootless Podman, with automatic .test domains, HTTPS, and a built-in Web UI. First-class on Arch, Ubuntu, Fedora, and Debian; also runs on macOS via Homebrew.
+description: Open-source, Herd-like local PHP development for Linux and macOS. Automatic .test domains, HTTPS, per-project PHP and Node, rootless Podman, no Docker daemon.
 ---


### PR DESCRIPTION
The homepage description ran 236 characters, over the 200 character ceiling that social cards use, so the Twitter and Open Graph descriptions were getting truncated. This trims both the `index.md` frontmatter and the site-level fallback in the VitePress config to a tighter 158 character line that still covers Linux and macOS, the `.test` domains and HTTPS, per-project PHP and Node, and the rootless, no-daemon Podman story.

It also corrects the `og:image` width and height, which advertised 1280x640 while the actual share image is 1499x787.

The Twitter card image itself was already defined correctly (`twitter:card: summary_large_image` plus `twitter:image`), so no change was needed there.