### PR TITLE
fix: restore Sail import, nested new path hint, and worker stop warning

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1226,9 +1226,10 @@ func runSetupInit(cwd string, skipWizard bool) error {
 
 	if !hasExisting && skipWizard {
 		// CI path: link with auto-detection, then run env so the caller
-		// (lerd setup) doesn't have to do it itself.
+		// (lerd setup) doesn't have to do it itself. No interactive data import.
 		linkSkipSetupPrompt = true
-		defer func() { linkSkipSetupPrompt = false }()
+		linkSkipDataImport = true
+		defer func() { linkSkipSetupPrompt = false; linkSkipDataImport = false }()
 		if err := runLink([]string{}); err != nil {
 			return err
 		}

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -30,6 +30,12 @@ var linkSkipSetupPrompt bool
 // "linked" summary rather than after it.
 var linkSkipSummary bool
 
+// linkSkipDataImport suppresses the Sail data-import offer. It is kept separate
+// from linkSkipSetupPrompt so routing `lerd link` through the init wizard
+// (which suppresses the setup prompt) still offers to import an existing Sail
+// database. Only the unattended (--all/CI) path sets it.
+var linkSkipDataImport bool
+
 // linkApplied and envApplied track whether the current process has already
 // linked the site and applied its .env. When a link flows straight into setup
 // (the "Run lerd setup?" prompt), this lets the setup pass skip re-printing the
@@ -98,6 +104,14 @@ func runLinkOrInit(args []string) error {
 // parent's registration). Any false input keeps the fast, scriptable link.
 func linkShouldRunWizard(hasConfig, interactive, hasDomainArg, isWorktree bool) bool {
 	return !hasConfig && interactive && !hasDomainArg && !isWorktree
+}
+
+// linkShouldImportSail reports whether runLink should offer to import an
+// existing Sail project's data. Gated on a live terminal and a dedicated
+// suppression flag (NOT linkSkipSetupPrompt), so a fresh `lerd link` that
+// routes through the init wizard still offers the import.
+func linkShouldImportSail(interactive, skipImport, hasSail bool) bool {
+	return interactive && !skipImport && hasSail
 }
 
 func runLink(args []string) error {
@@ -395,7 +409,7 @@ func runLink(args []string) error {
 
 	// Sail detection — offer to import data before setup so lerd's DB is
 	// populated from the existing Sail environment.
-	if isInteractive() && !linkSkipSetupPrompt && config.ComposerHasPackage(cwd, "laravel/sail") {
+	if linkShouldImportSail(isInteractive(), linkSkipDataImport, config.ComposerHasPackage(cwd, "laravel/sail")) {
 		sailDBName := sailLinkDetectDBName(cwd)
 		if feedback.Confirm("This project uses Laravel Sail. Import database (and S3 files) from Sail into lerd?", false) {
 			if err := runImportSail(false, false, "sail", "password", sailDBName, sailDBName != "", false, false); err != nil {

--- a/internal/cli/link_sail_test.go
+++ b/internal/cli/link_sail_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import "testing"
+
+func TestLinkShouldImportSail(t *testing.T) {
+	cases := []struct {
+		name        string
+		interactive bool
+		skipImport  bool
+		hasSail     bool
+		want        bool
+	}{
+		{"fresh interactive sail link", true, false, true, true},
+		{"non-interactive never prompts", false, false, true, false},
+		{"unattended import suppressed", true, true, true, false},
+		{"no sail dependency", true, false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := linkShouldImportSail(tc.interactive, tc.skipImport, tc.hasSail); got != tc.want {
+				t.Fatalf("linkShouldImportSail(%v, %v, %v) = %v, want %v",
+					tc.interactive, tc.skipImport, tc.hasSail, got, tc.want)
+			}
+		})
+	}
+}
+
+// Regression guard: routing `lerd link` through the init wizard suppresses the
+// post-link "Run lerd setup?" prompt via linkSkipSetupPrompt. That suppression
+// must not also drop the Sail data-import offer, which has its own
+// linkSkipDataImport flag — otherwise a fresh `lerd link` on a Sail project
+// silently skips importing the existing Sail database.
+func TestLinkImportsSailWhenWizardSuppressesSetupPrompt(t *testing.T) {
+	linkSkipSetupPrompt = true
+	linkSkipDataImport = false
+	t.Cleanup(func() { linkSkipSetupPrompt = false })
+	if !linkShouldImportSail(true, linkSkipDataImport, true) {
+		t.Fatal("Sail import must still be offered in the wizard flow that suppresses the setup prompt")
+	}
+}

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -55,7 +55,16 @@ After creation, register the site with:
 	return cmd
 }
 
+// newNextStep builds the post-scaffold hint, preserving the path the user
+// typed (filepath.Base would drop the parent dirs of a nested target).
+func newNextStep(typedTarget string) string {
+	return "cd " + typedTarget + " && lerd link && lerd setup"
+}
+
 func runNew(target, frameworkName string, extraArgs []string) error {
+	// Preserve the path as typed for the "Next" hint before resolving it.
+	typedTarget := target
+
 	// Resolve target to an absolute path
 	if !filepath.IsAbs(target) {
 		cwd, err := os.Getwd()
@@ -96,7 +105,7 @@ func runNew(target, frameworkName string, extraArgs []string) error {
 	feedback.Success("created "+filepath.Base(target), time.Since(start))
 	feedback.NewSummary().
 		Row("Path", target).
-		Row("Next", "cd "+filepath.Base(target)+" && lerd link && lerd setup").
+		Row("Next", newNextStep(typedTarget)).
 		Print()
 	return nil
 }

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -1,0 +1,21 @@
+package cli
+
+import "testing"
+
+// The "Next" hint must cd into the path the user actually typed. Using only the
+// base name breaks for nested targets (lerd new apps/myapp → cd myapp).
+func TestNewNextStep(t *testing.T) {
+	cases := []struct {
+		target string
+		want   string
+	}{
+		{"myapp", "cd myapp && lerd link && lerd setup"},
+		{"apps/myapp", "cd apps/myapp && lerd link && lerd setup"},
+		{"/abs/path/myapp", "cd /abs/path/myapp && lerd link && lerd setup"},
+	}
+	for _, tc := range cases {
+		if got := newNextStep(tc.target); got != tc.want {
+			t.Errorf("newNextStep(%q) = %q, want %q", tc.target, got, tc.want)
+		}
+	}
+}

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -679,11 +679,18 @@ func stopWorkerUnit(unitName, label, _ string) error {
 	// Without this they linger in ~/.local/share/lerd/run/workers after
 	// a normal stop and confuse later mode-migration discovery.
 	removeWorkerExecArtifacts(unitName)
-	if err := podman.DaemonReloadFn(); err != nil {
-		feedback.Warn("daemon-reload: %v", err)
-	}
-	step.OK("")
+	finalizeStopStep(step, podman.DaemonReloadFn())
 	return nil
+}
+
+// finalizeStopStep closes the worker-stop step and only then surfaces a
+// non-fatal daemon-reload error, so the warning lands on its own line instead
+// of being overwritten by the live spinner's in-place redraw.
+func finalizeStopStep(step *feedback.Step, reloadErr error) {
+	step.OK("")
+	if reloadErr != nil {
+		feedback.Warn("daemon-reload: %v", reloadErr)
+	}
 }
 
 // StopAllWorkersForWorktree stops every per-worktree worker unit attached

--- a/internal/cli/worker_stopstep_test.go
+++ b/internal/cli/worker_stopstep_test.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/feedback"
+)
+
+// A non-fatal daemon-reload warning must be emitted after the step completes,
+// not before, so the live spinner can't overwrite it. With output captured the
+// symptom shows as line order: the step's completion line must precede the
+// warning.
+func TestFinalizeStopStepOrdersWarningAfterStep(t *testing.T) {
+	var buf bytes.Buffer
+	restore := feedback.SetTestWriter(&buf)
+	defer restore()
+
+	step := feedback.Start("stopping worker")
+	finalizeStopStep(step, errors.New("boom"))
+
+	out := buf.String()
+	stepIdx := strings.Index(out, "stopping worker")
+	warnIdx := strings.Index(out, "daemon-reload")
+	if stepIdx < 0 || warnIdx < 0 {
+		t.Fatalf("expected both the step line and the warning in output, got:\n%s", out)
+	}
+	if stepIdx > warnIdx {
+		t.Fatalf("warning printed before the step completion line:\n%s", out)
+	}
+}
+
+// No daemon-reload error means no warning at all.
+func TestFinalizeStopStepNoWarningOnSuccess(t *testing.T) {
+	var buf bytes.Buffer
+	restore := feedback.SetTestWriter(&buf)
+	defer restore()
+
+	step := feedback.Start("stopping worker")
+	finalizeStopStep(step, nil)
+
+	if strings.Contains(buf.String(), "daemon-reload") {
+		t.Fatalf("unexpected daemon-reload warning on success:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
The init wizard reused linkSkipSetupPrompt to silence the post-link setup nag, but that flag also gated the Laravel Sail data-import offer, so a fresh interactive lerd link on a Sail project silently skipped importing its database. I split the concerns onto a dedicated linkSkipDataImport flag so the wizard suppresses only the setup prompt and the import offer comes back, with just the unattended path opting out of the import.

lerd new built its cd hint from filepath.Base of the resolved target, dropping the parent dirs of a nested path, so it now keeps the path as the user typed it.

A non-fatal daemon-reload warning during worker stop printed while the spinner was still live and got overwritten, so it now lands after the step is finalized.