### PR TITLE
fix: harden TUI mouse input, link wizard routing, and websocket writes

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -51,7 +51,7 @@ func runInit(fresh bool) error {
 
 	feedback.Begin()
 
-	if !hasExisting || fresh {
+	if initShouldRunWizard(hasExisting, fresh) {
 		existing, err := config.LoadProjectConfig(cwd)
 		if err != nil {
 			return err
@@ -86,6 +86,14 @@ func runInit(fresh bool) error {
 	}
 
 	return nil
+}
+
+// initShouldRunWizard reports whether runInit runs the configuration wizard
+// rather than applying an existing .lerd.yaml directly. It runs when no config
+// file is present, or when fresh forces it (the `lerd link` route passes fresh
+// for an absent-or-empty config, and `lerd init --fresh` for an explicit redo).
+func initShouldRunWizard(hasExisting, fresh bool) bool {
+	return !hasExisting || fresh
 }
 
 func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfig, error) {

--- a/internal/cli/init_wizard_gate_test.go
+++ b/internal/cli/init_wizard_gate_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import "testing"
+
+// A present-but-empty .lerd.yaml reached through `lerd link` must still run the
+// wizard. runLinkOrInit routes on content (IsEmpty), but runInit decides on
+// file existence, so it must be forced with fresh=true. This pins the chain:
+// empty config -> linkShouldRunWizard=true -> runInit(fresh=true) ->
+// initShouldRunWizard=true.
+func TestInitShouldRunWizard_EmptyPresentConfigForcedByLinkPath(t *testing.T) {
+	// The link path passes fresh=true once it has decided to run the wizard.
+	const linkPathFresh = true
+
+	// File present (empty), link path forces fresh -> wizard runs.
+	if !initShouldRunWizard(true, linkPathFresh) {
+		t.Fatal("empty present .lerd.yaml via lerd link should run the wizard")
+	}
+	// Documents the regression: with fresh=false the present file skips the
+	// wizard into a bare link, which is what the old runInit(false) call did.
+	if initShouldRunWizard(true, false) {
+		t.Fatal("guard sanity: a present file with fresh=false must skip the wizard")
+	}
+	// Absent config always runs the wizard regardless of fresh.
+	if !initShouldRunWizard(false, false) {
+		t.Fatal("absent .lerd.yaml should always run the wizard")
+	}
+}
+
+// linkShouldRunWizard must treat an empty config the same as an absent one, so
+// the link path routes into the (now forced) wizard.
+func TestLinkShouldRunWizard_EmptyConfigRoutesToWizard(t *testing.T) {
+	if !linkShouldRunWizard(false /* hasConfig */, true, false, false) {
+		t.Fatal("no committed config + interactive + no arg + not worktree should run the wizard")
+	}
+	if linkShouldRunWizard(true /* hasConfig */, true, false, false) {
+		t.Fatal("a real committed config should do a bare link, not the wizard")
+	}
+}

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -91,7 +91,11 @@ func runLinkOrInit(args []string) error {
 	hasConfig := proj != nil && !proj.IsEmpty()
 	_, _, isWorktree := findOwningWorktree(cwd)
 	if linkShouldRunWizard(hasConfig, isInteractive(), len(args) > 0, isWorktree) {
-		return runInit(false)
+		// fresh=true: linkShouldRunWizard already gated on !hasConfig (absent or
+		// empty .lerd.yaml), so force the wizard. Without it runInit re-decides on
+		// file existence and a present-but-empty file would skip the wizard into a
+		// bare link, contradicting the IsEmpty routing above.
+		return runInit(true)
 	}
 	return runLink(args)
 }

--- a/internal/tui/dash_failworker_test.go
+++ b/internal/tui/dash_failworker_test.go
@@ -1,0 +1,71 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// Two failing workers on the same site must get distinct zone ids, otherwise
+// bubblezone keeps a single region per id and the second row is unclickable.
+func TestDashWorkersCard_DistinctZonesPerFailingWorker(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{
+		Sites: []siteinfo.EnrichedSite{
+			{Name: "alpha", QueueFailing: true, ScheduleFailing: true},
+		},
+	}
+	c := m.dashWorkersCard(80)
+
+	var failZones []string
+	for _, id := range c.rowZones {
+		if strings.HasPrefix(id, "dashfailsite:") {
+			failZones = append(failZones, id)
+		}
+	}
+	if len(failZones) != 2 {
+		t.Fatalf("expected 2 failing-worker zones, got %d (%v)", len(failZones), failZones)
+	}
+	seen := map[string]bool{}
+	for _, id := range failZones {
+		if seen[id] {
+			t.Fatalf("duplicate failing-worker zone id %q; second row would be a dead click", id)
+		}
+		seen[id] = true
+	}
+}
+
+// Navigating to a site by name must clear a leftover filter that would hide the
+// target, so a dashboard click can't silently fail to select.
+func TestSelectSiteByName_ClearsHidingFilter(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap() // sites: alpha, beta
+	m.siteFilter = "alpha"
+
+	m.selectSiteByName("beta")
+
+	if m.siteFilter != "" {
+		t.Fatalf("filter %q hid the target; it should have been cleared", m.siteFilter)
+	}
+	vis := m.visibleSites()
+	if m.siteCursor < 0 || m.siteCursor >= len(vis) || vis[m.siteCursor].Name != "beta" {
+		t.Fatalf("cursor %d does not point at beta in %d visible sites", m.siteCursor, len(vis))
+	}
+}
+
+func TestSelectServiceByName_ClearsHidingFilter(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap() // services: mysql, redis, mailpit
+	m.svcFilter = "mysql"
+
+	m.selectServiceByName("redis")
+
+	if m.svcFilter != "" {
+		t.Fatalf("filter %q hid the target; it should have been cleared", m.svcFilter)
+	}
+	vis := m.visibleServices()
+	if m.svcCursor < 0 || m.svcCursor >= len(vis) || vis[m.svcCursor].Name != "redis" {
+		t.Fatalf("cursor %d does not point at redis in %d visible services", m.svcCursor, len(vis))
+	}
+}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -319,8 +319,11 @@ func (m *Model) dashWorkersCard(width int) cardContent {
 	}
 	if len(failing) > 0 {
 		lines = append(lines, "")
-		for _, f := range failing {
-			zones[len(lines)] = fmt.Sprintf("dashfailsite:%d", f.siteIdx)
+		// Key the zone by the failing-worker index, not f.siteIdx: two failing
+		// workers on the same site would otherwise share one id and bubblezone
+		// keeps a single region per id, leaving the second row a dead click.
+		for fi, f := range failing {
+			zones[len(lines)] = fmt.Sprintf("dashfailsite:%d", fi)
 			lines = append(lines, failingStyle.Render("⚠ "+f.name))
 		}
 		lines = append(lines, dimStyle.Render("press H to heal"))

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1097,6 +1097,14 @@ func (m *Model) switchTab(t topTab) {
 // a clicked site/service's tab or focuses a card. Every clickable region is a
 // bubblezone mark laid down during render, so hit-testing is a bounds check.
 func (m *Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	// While a modal overlay is open, View() returns the modal frame without
+	// rescanning zones, so the registered click regions are stale from the last
+	// base frame. Swallow mouse input here (mirroring handleMainKey, which routes
+	// through the modal handlers before any pane action) so a stray click can't
+	// switch tabs, move a cursor, or silently dismiss a half-finished picker.
+	if m.modalActive() {
+		return m, nil
+	}
 	if msg.Button == tea.MouseButtonWheelUp || msg.Button == tea.MouseButtonWheelDown {
 		return m.handleWheel(msg)
 	}
@@ -1176,10 +1184,14 @@ func (m *Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		}
 		// A failing-worker row carries no service entry of its own, so it jumps
 		// to the owning site's detail where the worker state and heal action live.
-		for i := range m.snap.Sites {
-			if zone.Get(fmt.Sprintf("dashfailsite:%d", i)).InBounds(msg) {
+		// Zones are keyed by failing-worker index, mapped back to the site here.
+		failing := failingWorkers(m.snap)
+		for fi, f := range failing {
+			if zone.Get(fmt.Sprintf("dashfailsite:%d", fi)).InBounds(msg) {
 				m.switchTab(tabSites)
-				m.selectSiteByName(m.snap.Sites[i].Name)
+				if f.siteIdx >= 0 && f.siteIdx < len(m.snap.Sites) {
+					m.selectSiteByName(m.snap.Sites[f.siteIdx].Name)
+				}
 				return m, m.syncLogs()
 			}
 		}
@@ -1275,27 +1287,52 @@ func (m *Model) scrollOffset(off *int, delta int) {
 // matched against the current (filtered/sorted) view so the cursor lands on
 // the row the user actually sees.
 func (m *Model) selectSiteByName(name string) {
+	if m.focusSiteIfVisible(name) {
+		return
+	}
+	// A leftover filter on the destination tab can hide the target (e.g. when
+	// jumping in from a dashboard click). Clear it and retry so the navigation
+	// lands rather than silently doing nothing.
+	if m.siteFilter != "" {
+		m.siteFilter = ""
+		m.focusSiteIfVisible(name)
+	}
+}
+
+func (m *Model) focusSiteIfVisible(name string) bool {
 	for i, s := range m.visibleSites() {
 		if s.Name == name {
 			m.focus = paneSites
 			m.siteCursor = i
 			m.followCursor = true // scroll the destination list to it
-			return
+			return true
 		}
 	}
+	return false
 }
 
 // selectServiceByName focuses the Services list on the service with the given
 // name, matched against the current view.
 func (m *Model) selectServiceByName(name string) {
+	if m.focusServiceIfVisible(name) {
+		return
+	}
+	if m.svcFilter != "" {
+		m.svcFilter = ""
+		m.focusServiceIfVisible(name)
+	}
+}
+
+func (m *Model) focusServiceIfVisible(name string) bool {
 	for i, s := range m.visibleServices() {
 		if s.Name == name {
 			m.focus = paneServices
 			m.svcCursor = i
 			m.followCursor = true // scroll the destination list to it
-			return
+			return true
 		}
 	}
+	return false
 }
 
 // nextFocus returns the focus after moving `dir` steps (±1) through the

--- a/internal/tui/mouse_modal_test.go
+++ b/internal/tui/mouse_modal_test.go
@@ -1,0 +1,68 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// A click while a modal overlay is open must be swallowed: View() stops
+// rescanning zones during a modal, so the registered regions are stale and a
+// click would otherwise act on whatever was under the cursor in the last base
+// frame (switch tabs, move a cursor, or dismiss a half-finished picker).
+func TestMouseClick_IgnoredWhileModalOpen(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.activeTab = tabDashboard
+	m.width, m.height = 150, 40
+	_ = m.View() // register the base-frame zones, including the Services tab
+
+	z := waitZone("tab:" + tabServices.label())
+	if z.IsZero() {
+		t.Fatalf("services tab zone not registered after render")
+	}
+
+	// Open a modal, then click where the Services tab used to be.
+	m.paletteActive = true
+	msg := tea.MouseMsg{X: z.StartX, Y: z.StartY, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft}
+	next, _ := m.Update(msg)
+	m = next.(*Model)
+
+	if m.activeTab != tabDashboard {
+		t.Fatalf("click under an open modal switched tabs to %d; should have been swallowed", m.activeTab)
+	}
+	if !m.paletteActive {
+		t.Fatalf("click under an open modal closed the modal; should have been swallowed")
+	}
+}
+
+// A picker open in modal mode must not be dismissed by a stray click, since
+// switchTab (reachable from a tab-zone click) calls closePicker().
+func TestMouseClick_DoesNotDismissOpenPicker(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.activeTab = tabSites
+	m.focus = paneSites
+	m.width, m.height = 150, 40
+	_ = m.View()
+
+	z := waitZone("tab:" + tabServices.label())
+	if z.IsZero() {
+		t.Fatalf("services tab zone not registered after render")
+	}
+
+	m.pickerKind = kindPHP // open the picker in modal mode
+	if !m.modalActive() {
+		t.Fatalf("setting pickerKind should make a modal active")
+	}
+	msg := tea.MouseMsg{X: z.StartX, Y: z.StartY, Action: tea.MouseActionPress, Button: tea.MouseButtonLeft}
+	next, _ := m.Update(msg)
+	m = next.(*Model)
+
+	if m.pickerKind != kindPHP {
+		t.Fatalf("click under an open picker dismissed it (pickerKind=%d)", m.pickerKind)
+	}
+	if m.activeTab != tabSites {
+		t.Fatalf("click under an open picker switched tabs to %d", m.activeTab)
+	}
+}

--- a/internal/ui/ws.go
+++ b/internal/ui/ws.go
@@ -33,6 +33,12 @@ const (
 	wsReadTimeout  = 75 * time.Second
 )
 
+// wsWriteTimeout bounds a single outbound frame write. Without it a peer that
+// stops reading (suspended tab, half-open TCP) wedges conn.Write forever while
+// holding the write lock, so the ping/pump goroutines never observe cancel and
+// the handler's deferred join leaks. A var so tests can shorten it.
+var wsWriteTimeout = 10 * time.Second
+
 // chooseInterval returns the cache poll cadence implied by the current
 // (visibility, session-idle) pair. Fast cadence requires both an engaged
 // browser tab and an active desktop session: a focused tab on a locked

--- a/internal/ui/wsframe.go
+++ b/internal/ui/wsframe.go
@@ -105,6 +105,9 @@ func (c *wsConn) WriteClose() error {
 }
 
 func (c *wsConn) writeFrame(op byte, payload []byte) error {
+	if err := c.conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout)); err != nil {
+		return err
+	}
 	header := make([]byte, 2, 10)
 	header[0] = 0x80 | op // FIN | opcode
 	n := len(payload)

--- a/internal/ui/wsframe_deadline_test.go
+++ b/internal/ui/wsframe_deadline_test.go
@@ -1,0 +1,37 @@
+package ui
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// A peer that stops reading must not wedge a frame write forever: writeFrame
+// sets a write deadline so conn.Write fails instead of blocking, which is what
+// lets the LSP/WS ping and stdout-pump goroutines observe cancel and exit.
+func TestWriteFrame_WriteDeadlineUnblocksStuckPeer(t *testing.T) {
+	prev := wsWriteTimeout
+	wsWriteTimeout = 50 * time.Millisecond
+	defer func() { wsWriteTimeout = prev }()
+
+	// net.Pipe is unbuffered and synchronous, so a write blocks until the other
+	// end reads. We never read, modelling a stuck/half-open peer.
+	srv, cli := net.Pipe()
+	defer cli.Close()
+	ws := &wsConn{conn: srv}
+
+	done := make(chan error, 1)
+	go func() { done <- ws.WriteText([]byte("hello")) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected a write-deadline error, got nil (write succeeded against a non-reading peer)")
+		}
+		if ne, ok := err.(net.Error); !ok || !ne.Timeout() {
+			t.Fatalf("expected a timeout net.Error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WriteText blocked past the write deadline; goroutine would leak")
+	}
+}


### PR DESCRIPTION
These are a few correctness follow ups found while reviewing everything that landed since 1.25.

A click that landed under an open modal could switch tabs or quietly dismiss a half finished picker, because the mouse handler never checked for an active overlay and the modal frame stops rescanning its click zones while it is up. handleMouse now swallows mouse input whenever a modal is open, mirroring the keyboard path that already routes through the modal handlers before any pane action.

On the dashboard two failing workers on the same site collapsed onto a single click zone so the second row was dead, and jumping to a site or service whose name happened to be hidden by a leftover filter silently did nothing. Failing rows now get a distinct zone keyed by their own position and mapped back to the owning site, and the select by name helpers drop a hiding filter and retry before giving up.

A fresh lerd link against a present but empty .lerd.yaml fell through to a bare link instead of the wizard, because the routing decided on file content while runInit re-decided on file existence. The link path now forces the wizard once it has chosen to run it, leaving the standalone lerd init behaviour untouched.

Finally a websocket peer that stopped reading could wedge a frame write forever and leak the handler goroutine, so every outbound frame now carries a write deadline and a stuck socket fails the write instead of blocking.