### PR TITLE
fix: react to network changes while idle and skip disabled picker versions

### DIFF
--- a/internal/tui/modal.go
+++ b/internal/tui/modal.go
@@ -134,21 +134,22 @@ func (m *Model) handlePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter", " ":
 		return m, m.applyPicker()
 	case "up", "k":
-		if m.pickerCursor > 0 {
-			m.pickerCursor--
-		}
+		m.movePickerCursor(-1)
 		return m, nil
 	case "down", "j":
-		if m.pickerCursor < len(m.pickerOptions)-1 {
-			m.pickerCursor++
-		}
+		m.movePickerCursor(1)
 		return m, nil
 	case "home", "g":
-		m.pickerCursor = 0
+		m.pickerCursor = firstEnabledFrom(0, m.pickerDisabled)
 		return m, nil
 	case "end", "G":
-		if n := len(m.pickerOptions); n > 0 {
-			m.pickerCursor = n - 1
+		// Land on the last enabled entry, scanning back past any disabled tail.
+		cur := len(m.pickerOptions) - 1
+		for cur > 0 && m.pickerIsDisabled(cur) {
+			cur--
+		}
+		if cur >= 0 && !m.pickerIsDisabled(cur) {
+			m.pickerCursor = cur
 		}
 		return m, nil
 	case "ctrl+c":

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1395,24 +1395,7 @@ func (m *Model) moveCursor(delta int) {
 		m.svcCursor = clamp(m.svcCursor+delta, 0, max(0, len(m.visibleServices())-1))
 	case paneDetail:
 		if m.pickerKind != kindInfo {
-			n := len(m.pickerOptions)
-			if n == 0 {
-				return
-			}
-			next := clamp(m.pickerCursor+delta, 0, n-1)
-			// Skip over disabled (out-of-range) entries in the direction of
-			// travel; fall back to the original cursor if every step is disabled.
-			step := 1
-			if delta < 0 {
-				step = -1
-			}
-			for next >= 0 && next < n && m.pickerIsDisabled(next) {
-				next += step
-			}
-			if next < 0 || next >= n || m.pickerIsDisabled(next) {
-				return
-			}
-			m.pickerCursor = next
+			m.movePickerCursor(delta)
 			return
 		}
 		switch m.detailMode {

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -102,6 +102,31 @@ func (m *Model) pickerIsDisabled(i int) bool {
 	return i >= 0 && i < len(m.pickerDisabled) && m.pickerDisabled[i]
 }
 
+// movePickerCursor moves the picker cursor by delta, skipping disabled
+// (out-of-range) entries in the direction of travel so navigation never parks
+// on a version that applyPicker would silently reject. The cursor stays put
+// when every step that way is disabled. Both the modal key handler and the
+// (dead) detail-pane moveCursor branch funnel through here so the skip is
+// applied however the cursor moves.
+func (m *Model) movePickerCursor(delta int) {
+	n := len(m.pickerOptions)
+	if n == 0 {
+		return
+	}
+	step := 1
+	if delta < 0 {
+		step = -1
+	}
+	next := clamp(m.pickerCursor+delta, 0, n-1)
+	for next >= 0 && next < n && m.pickerIsDisabled(next) {
+		next += step
+	}
+	if next < 0 || next >= n || m.pickerIsDisabled(next) {
+		return
+	}
+	m.pickerCursor = next
+}
+
 // closePicker exits picker mode without applying a choice.
 func (m *Model) closePicker() {
 	m.pickerKind = kindInfo

--- a/internal/tui/picker_clamp_test.go
+++ b/internal/tui/picker_clamp_test.go
@@ -1,6 +1,10 @@
 package tui
 
-import "testing"
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
 
 func TestPhpDisabledMask(t *testing.T) {
 	versions := []string{"7.4", "8.1", "8.3", "8.4", "8.5"}
@@ -73,5 +77,35 @@ func TestPickerNavSkipsDisabled(t *testing.T) {
 	m.moveCursor(-1)
 	if m.pickerCursor != 0 {
 		t.Errorf("after up from 3, cursor = %d, want 0", m.pickerCursor)
+	}
+}
+
+// While the picker modal is open, every key is routed through handlePickerKey,
+// not moveCursor, so the skip-disabled logic has to live there too. Without it
+// the arrows park on a dimmed out-of-range version and enter silently no-ops.
+func TestPickerKeyNavSkipsDisabled(t *testing.T) {
+	m := &Model{
+		activeTab:      tabSites,
+		focus:          paneDetail,
+		pickerKind:     kindPHP,
+		pickerOptions:  []string{"7.4", "8.1", "8.3", "8.4"},
+		pickerDisabled: []bool{false, true, true, false},
+		pickerCursor:   0,
+	}
+	m.handlePickerKey(tea.KeyMsg{Type: tea.KeyDown})
+	if m.pickerCursor != 3 {
+		t.Errorf("after down from 0, cursor = %d, want 3 (8.1 and 8.3 disabled)", m.pickerCursor)
+	}
+	m.handlePickerKey(tea.KeyMsg{Type: tea.KeyUp})
+	if m.pickerCursor != 0 {
+		t.Errorf("after up from 3, cursor = %d, want 0", m.pickerCursor)
+	}
+	m.handlePickerKey(tea.KeyMsg{Type: tea.KeyEnd})
+	if m.pickerCursor != 3 {
+		t.Errorf("end cursor = %d, want 3 (last enabled)", m.pickerCursor)
+	}
+	m.handlePickerKey(tea.KeyMsg{Type: tea.KeyHome})
+	if m.pickerCursor != 0 {
+		t.Errorf("home cursor = %d, want 0 (first enabled)", m.pickerCursor)
 	}
 }

--- a/internal/watcher/dns.go
+++ b/internal/watcher/dns.go
@@ -196,25 +196,29 @@ func WatchDNS(interval time.Duration, tld string) {
 func runDNSLoop(d dnsWatchDeps, state *dnsWatchState, tld string,
 	tickerC <-chan time.Time, linkC <-chan struct{}, done <-chan struct{}) {
 
-	tickDNS(d, state, tld)
+	tickDNS(d, state, tld, false)
 	for {
 		select {
 		case <-done:
 			return
 		case <-tickerC:
-			tickDNS(d, state, tld)
+			tickDNS(d, state, tld, false)
 		case <-linkC:
-			tickDNS(d, state, tld)
+			// A real host network change must re-probe immediately, even on
+			// an idle/locked session, so it bypasses the polling backoff.
+			tickDNS(d, state, tld, true)
 		}
 	}
 }
 
-// tickDNS runs one iteration of the DNS health loop. It returns early
-// during idle backoff. On every tick that probes, the previous
-// observation is compared and a transition publishes KindStatus.
-func tickDNS(d dnsWatchDeps, s *dnsWatchState, tld string) {
+// tickDNS runs one iteration of the DNS health loop. A poll tick returns
+// early during idle backoff; a linkTriggered tick (a host network change)
+// always probes since that is the event the watcher exists to react to. On
+// every tick that probes, the previous observation is compared and a
+// transition publishes KindStatus.
+func tickDNS(d dnsWatchDeps, s *dnsWatchState, tld string, linkTriggered bool) {
 	s.tickCount++
-	if d.idleOrLocked() && s.tickCount%idleSkipEveryN != 0 {
+	if !linkTriggered && d.idleOrLocked() && s.tickCount%idleSkipEveryN != 0 {
 		return
 	}
 

--- a/internal/watcher/dns_test.go
+++ b/internal/watcher/dns_test.go
@@ -197,7 +197,7 @@ func TestTickDNS(t *testing.T) {
 				},
 			}
 			state := &dnsWatchState{lastOK: c.lastOK, tickCount: c.tickCount}
-			tickDNS(deps, state, "test")
+			tickDNS(deps, state, "test", false)
 
 			if got.checks != c.wantChecks {
 				t.Errorf("check() calls=%d, want %d", got.checks, c.wantChecks)
@@ -254,7 +254,7 @@ func TestTickDNS_repairUnavailable_logsOnceAndSkipsResolverWrite(t *testing.T) {
 
 	// Three consecutive ticks with DNS down; only the first should log.
 	for i := 0; i < 3; i++ {
-		tickDNS(deps, state, "test")
+		tickDNS(deps, state, "test", false)
 	}
 
 	if checks != 3 {
@@ -291,7 +291,7 @@ func TestTickDNS_repairAvailableAfterUnavailable_relogsOnNextOutage(t *testing.T
 	state := &dnsWatchState{}
 
 	// Tick with gate closed: one warn.
-	tickDNS(deps, state, "test")
+	tickDNS(deps, state, "test", false)
 	if len(logs) != 1 {
 		t.Fatalf("expected 1 log, got %d (%v)", len(logs), logs)
 	}
@@ -302,7 +302,7 @@ func TestTickDNS_repairAvailableAfterUnavailable_relogsOnNextOutage(t *testing.T
 	// repairUnavailable flag must be cleared so a future close-of-gate
 	// re-emits the once warn.
 	gate = true
-	tickDNS(deps, state, "test")
+	tickDNS(deps, state, "test", false)
 	if len(logs) < 1 {
 		t.Fatalf("expected repair pipeline logs after gate reopened, got %v", logs)
 	}
@@ -313,7 +313,7 @@ func TestTickDNS_repairAvailableAfterUnavailable_relogsOnNextOutage(t *testing.T
 	// Close gate again — should re-log the once-warn.
 	logs = nil
 	gate = false
-	tickDNS(deps, state, "test")
+	tickDNS(deps, state, "test", false)
 	if len(logs) != 1 {
 		t.Errorf("expected re-log after gate re-closes, got %v", logs)
 	}
@@ -337,23 +337,23 @@ func TestTickDNS_containerDNSResync(t *testing.T) {
 	state := &dnsWatchState{}
 
 	// First tick only records the baseline.
-	tickDNS(deps, state, "test")
+	tickDNS(deps, state, "test", false)
 	if resyncs != 0 {
 		t.Fatalf("first tick re-synced; want baseline only, got %d", resyncs)
 	}
 	// Unchanged environment: still quiet.
-	tickDNS(deps, state, "test")
+	tickDNS(deps, state, "test", false)
 	if resyncs != 0 {
 		t.Fatalf("unchanged env re-synced=%d, want 0", resyncs)
 	}
 	// VPN connects: the fingerprint changes, re-sync fires once.
 	fp = "1.1.1.1,10.0.0.1|1"
-	tickDNS(deps, state, "test")
+	tickDNS(deps, state, "test", false)
 	if resyncs != 1 {
 		t.Fatalf("changed env re-syncs=%d, want 1", resyncs)
 	}
 	// Stable at the new value: no further re-sync.
-	tickDNS(deps, state, "test")
+	tickDNS(deps, state, "test", false)
 	if resyncs != 1 {
 		t.Fatalf("re-syncs after settle=%d, want 1", resyncs)
 	}
@@ -383,7 +383,7 @@ func TestTickDNS_exposeMappingRepair(t *testing.T) {
 			log:                 func(level, _ string, _ ...any) { logs = append(logs, level) },
 		}
 		state := &dnsWatchState{lastOK: ptrBool(true)}
-		tickDNS(deps, state, "test")
+		tickDNS(deps, state, "test", false)
 
 		if exposeCalls != 1 {
 			t.Errorf("expose repair calls=%d, want 1", exposeCalls)
@@ -419,7 +419,7 @@ func TestTickDNS_exposeMappingRepair(t *testing.T) {
 			log:                 func(string, string, ...any) {},
 		}
 		state := &dnsWatchState{lastOK: ptrBool(false)}
-		tickDNS(deps, state, "test")
+		tickDNS(deps, state, "test", false)
 
 		if exposeCalls != 1 {
 			t.Errorf("expose repair calls=%d, want 1", exposeCalls)
@@ -442,7 +442,7 @@ func TestTickDNS_exposeMappingRepair(t *testing.T) {
 			log:                 func(level, _ string, _ ...any) { logs = append(logs, level) },
 		}
 		state := &dnsWatchState{lastOK: ptrBool(false)}
-		tickDNS(deps, state, "test")
+		tickDNS(deps, state, "test", false)
 
 		if resolverCalls != 1 {
 			t.Errorf("resolver repair must still run after a re-render error, got %d", resolverCalls)
@@ -490,6 +490,46 @@ func TestRunDNSLoop_linkChangeKicksTick(t *testing.T) {
 	case <-ticks:
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("ticker fire did not trigger a tick")
+	}
+}
+
+// TestRunDNSLoop_linkChangeKicksTickWhileIdle pins the whole point of the link
+// watcher: a host network change must re-probe immediately even on an idle or
+// locked session. The polling backoff (idleSkipEveryN) exists to save battery
+// on the timer path, but a VPN connect/disconnect or wifi switch frequently
+// happens while the laptop is asleep or on the lock screen, so routing the
+// link-change tick through the same idle skip would drop ~9 of every 10 events
+// and leave containers on the stale resolver until the next Nth poll.
+func TestRunDNSLoop_linkChangeKicksTickWhileIdle(t *testing.T) {
+	ticks := make(chan struct{}, 16)
+	deps := dnsWatchDeps{
+		check:         func(string) (bool, error) { ticks <- struct{}{}; return true, nil },
+		idleOrLocked:  func() bool { return true },
+		publishStatus: func() {},
+		log:           func(string, string, ...any) {},
+	}
+	state := &dnsWatchState{}
+	tickerC := make(chan time.Time, 4)
+	linkC := make(chan struct{}, 4)
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() { runDNSLoop(deps, state, "test", tickerC, linkC, done); close(stopped) }()
+	defer func() { close(done); <-stopped }()
+
+	// The initial poll is skipped while idle (tickCount 1, not the Nth), so it
+	// must not probe — confirm the loop is genuinely in the backoff state.
+	select {
+	case <-ticks:
+		t.Fatal("idle initial poll probed; backoff should have skipped it")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The link change must probe right away despite being idle.
+	linkC <- struct{}{}
+	select {
+	case <-ticks:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("link change did not kick a tick while idle")
 	}
 }
 


### PR DESCRIPTION
Refs #594

The DNS watcher routed a host network change through the same idle backoff as the routine poll, so a VPN connect or disconnect or a wifi switch was dropped roughly nine times out of ten whenever the session was idle or the screen was locked. That is exactly when those events fire, a laptop waking from sleep and reconnecting on the lock screen, so containers were left on the stale resolver until the next every-tenth poll. A link-triggered tick now bypasses the backoff and re-probes immediately while the routine timer keeps backing off to save battery.

The TUI version picker moved its cursor with bare increments while the modal was open, with no skip over disabled out-of-range versions, because the skip logic only lived in the moveCursor branch that the modal key handler never reaches. The arrows could park on a dimmed version and pressing enter then silently did nothing. The skip now lives in a shared movePickerCursor helper used by both paths, and home and end land on the first and last selectable version.