### PR TITLE
fix: post-1.25 dashboard actions, env warnings, and quit teardown

### DIFF
--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -1205,14 +1205,25 @@ func runStop(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
+// quitProcessUnits is the ordered set of host process units `lerd quit` tears
+// down after runStop. Unlike `lerd stop`, quit is a full teardown, so it
+// includes lerd-dns. lerd-watcher precedes lerd-dns because the watcher is the
+// only thing that restarts lerd-dns; stopping it first keeps dns down.
+func quitProcessUnits() []string {
+	return []string{"lerd-ui", "lerd-watcher", "lerd-tray", "lerd-dns"}
+}
+
 func runQuit(_ *cobra.Command, _ []string) error {
-	// Stop containers and services (same as stop).
+	// Stop containers and services (same as stop). `lerd stop` leaves lerd-dns
+	// up as install-level plumbing; `lerd quit` is a full teardown, so it also
+	// stops lerd-dns below.
 	if err := runStop(nil, nil); err != nil {
 		return err
 	}
 
-	// Stop process units.
-	for _, unit := range []string{"lerd-ui", "lerd-watcher", "lerd-tray"} {
+	// Stop process units. lerd-watcher comes before lerd-dns: the watcher is the
+	// only thing that restarts lerd-dns, so stopping it first keeps dns down.
+	for _, unit := range quitProcessUnits() {
 		s := feedback.Start("stopping " + unit)
 		if err := podman.StopUnit(unit); err != nil {
 			s.Fail(err)

--- a/internal/cli/startstop_test.go
+++ b/internal/cli/startstop_test.go
@@ -205,3 +205,21 @@ func TestStopUnitSet_KeepsDNSRunning(t *testing.T) {
 		t.Error("stopUnitSet must exclude lerd-dns so it stays running across `lerd stop`")
 	}
 }
+
+// TestQuitProcessUnits_FullTeardown pins that `lerd quit` is a full teardown: it
+// stops lerd-dns (unlike `lerd stop`), and stops lerd-watcher before lerd-dns so
+// the watcher can't restart dns after it goes down.
+func TestQuitProcessUnits_FullTeardown(t *testing.T) {
+	units := quitProcessUnits()
+	dns := slices.Index(units, "lerd-dns")
+	watcher := slices.Index(units, "lerd-watcher")
+	if dns < 0 {
+		t.Fatal("quit must stop lerd-dns for a full teardown")
+	}
+	if watcher < 0 {
+		t.Fatal("quit must stop lerd-watcher")
+	}
+	if watcher > dns {
+		t.Errorf("lerd-watcher (%d) must be stopped before lerd-dns (%d) so the watcher can't restart dns", watcher, dns)
+	}
+}

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -225,17 +225,37 @@ func Line(msg string) {
 // Note prints a dim, indented sub-detail under a step (e.g. a log hint). It has
 // no glyph so it reads as secondary to the step lines above it.
 func Note(msg string) {
-	mu.Lock()
-	defer mu.Unlock()
-	fmt.Fprintf(target(), "%s  %s\n", pad, paint(dimStyle, msg))
+	emit(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		fmt.Fprintf(target(), "%s  %s\n", pad, paint(dimStyle, msg))
+	})
 }
 
 // Warn prints a warning line: an amber warning glyph and amber message. Use in
 // place of a plain "[WARN] …" print.
 func Warn(format string, a ...any) {
-	mu.Lock()
-	defer mu.Unlock()
-	fmt.Fprintf(target(), "%s%s %s\n", pad, paint(warnStyle, "⚠"), paint(warnStyle, fmt.Sprintf(format, a...)))
+	emit(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		fmt.Fprintf(target(), "%s%s %s\n", pad, paint(warnStyle, "⚠"), paint(warnStyle, fmt.Sprintf(format, a...)))
+	})
+}
+
+// liveActive holds the spinner currently animating, if any, so standalone
+// prints (Warn / Note) can pause it and print cleanly above the live line
+// instead of being clobbered by its in-place redraw.
+var liveActive atomic.Pointer[Live]
+
+// emit runs a standalone print, routing it through the active live line's
+// Interrupt when one is animating so the spinner doesn't overwrite it. With no
+// live line it just runs fn.
+func emit(fn func()) {
+	if l := liveActive.Load(); l != nil {
+		l.Interrupt(fn)
+		return
+	}
+	fn()
 }
 
 // Done prints a green-check completion line with no timing, for operations
@@ -285,7 +305,8 @@ type Live struct {
 	msg    string
 	imu    sync.Mutex
 	items  []string
-	paused bool // guarded by the package mu; set by Interrupt
+	paused bool  // guarded by the package mu; set by Interrupt
+	prev   *Live // the live line this one suspends, restored on Done/Fail
 	stop   chan struct{}
 	wg     sync.WaitGroup
 }
@@ -295,6 +316,11 @@ type Live struct {
 func StartLive(msg string) *Live {
 	l := &Live{msg: msg}
 	if Animated() {
+		// Register as the active line (saving any line we nest inside) so
+		// Warn/Note route through Interrupt while this spinner animates. Only
+		// the animated spinner clobbers standalone prints, so plain mode skips
+		// this and prints warnings on their own line as before.
+		l.prev = liveActive.Swap(l)
 		l.stop = make(chan struct{})
 		l.wg.Add(1)
 		go l.spin()
@@ -358,12 +384,18 @@ func (l *Live) Interrupt(fn func()) {
 		return
 	}
 	mu.Lock()
+	// Save and restore the prior paused state so nested Interrupts (e.g. a
+	// child step that itself emits a Warn) keep the line paused until the
+	// outermost call returns, rather than resuming the spinner early.
+	wasPaused := l.paused
 	l.paused = true
-	fmt.Fprint(target(), "\r\033[2K")
+	if !wasPaused {
+		fmt.Fprint(target(), "\r\033[2K")
+	}
 	mu.Unlock()
 	fn()
 	mu.Lock()
-	l.paused = false
+	l.paused = wasPaused
 	mu.Unlock()
 }
 
@@ -382,6 +414,7 @@ func (l *Live) Add(item string) {
 
 // Done stops the spinner, leaving the ✓ line (checkbox replaces the loader).
 func (l *Live) Done() {
+	liveActive.Store(l.prev)
 	if !Animated() {
 		mu.Lock()
 		fmt.Fprintf(target(), "%s%s %s\n", pad, paint(okStyle, "✓"), l.msg)
@@ -398,6 +431,7 @@ func (l *Live) Done() {
 
 // Fail stops the spinner and finalises the line with a red cross.
 func (l *Live) Fail(err error) {
+	liveActive.Store(l.prev)
 	if Animated() {
 		close(l.stop)
 		l.wg.Wait()

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -197,3 +197,56 @@ func TestLiveInterrupt_PlainModeJustRunsFn(t *testing.T) {
 		t.Fatal("Interrupt did not run fn in plain mode")
 	}
 }
+
+// TestWarn_PausesActiveLine verifies that a Warn emitted while a live spinner is
+// animating is routed through Interrupt: the spinner doesn't clobber it and the
+// warning text reaches the writer. This is the env.go clobber regression.
+func TestWarn_PausesActiveLine(t *testing.T) {
+	var buf bytes.Buffer
+	withAnimatedBuffer(t, &buf)
+
+	l := &Live{msg: "configuring .env"}
+	prev := liveActive.Swap(l)
+	t.Cleanup(func() { liveActive.Store(prev) })
+
+	buf.Reset()
+	Warn("could not start %s: boom", "mysql")
+
+	got := buf.String()
+	if !strings.Contains(got, "could not start mysql") {
+		t.Fatalf("warning text missing: %q", got)
+	}
+	// The line must have been cleared (Interrupt's \r\033[2K) so the spinner
+	// redraw doesn't overwrite the warning.
+	if !strings.Contains(got, "\r\033[2K") {
+		t.Fatalf("warn did not pause/clear the live line: %q", got)
+	}
+}
+
+// TestStartLive_TracksActiveAcrossNesting verifies StartLive registers the active
+// line and Done/Fail restore the previous one, so a nested configure step doesn't
+// leave the outer line unregistered (which would re-expose the clobber).
+func TestStartLive_TracksActiveAcrossNesting(t *testing.T) {
+	var buf bytes.Buffer
+	withAnimatedBuffer(t, &buf)
+
+	baseline := liveActive.Load()
+	t.Cleanup(func() { liveActive.Store(baseline) })
+
+	outer := StartLive("outer")
+	if liveActive.Load() != outer {
+		t.Fatal("StartLive did not register the outer line")
+	}
+	inner := StartLive("inner")
+	if liveActive.Load() != inner {
+		t.Fatal("nested StartLive did not register the inner line")
+	}
+	inner.Done()
+	if liveActive.Load() != outer {
+		t.Fatal("inner Done did not restore the outer line")
+	}
+	outer.Fail(nil)
+	if liveActive.Load() != baseline {
+		t.Fatal("outer Fail did not restore the baseline active line")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -454,6 +454,12 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if m.detailMode == detailDumps {
 				return m, m.toggleDumpExpand()
 			}
+			// Row toggling only applies to a site's detail; the Dashboard parks
+			// focus on the detail pane with no list selection, so don't mutate
+			// the carried-over site there.
+			if m.activeTab != tabSites {
+				return m, nil
+			}
 			return m, m.detailToggleSelected(m.currentSite(), detailRows(m.currentSite()), navigableRows(detailRows(m.currentSite())))
 		}
 		return m, nil
@@ -1079,12 +1085,15 @@ func (m *Model) switchTab(t topTab) {
 	}
 	m.activeTab = t
 	m.closePicker()
+	// Settings / System / Debug are Sites-only detail surfaces; leaving the mode
+	// set when moving to another tab would render that stale surface there (and
+	// the S/Y/D toggles are gated to Sites, so it couldn't be cleared).
+	m.detailMode = detailSite
 	switch t {
 	case tabServices:
 		m.focus = paneServices
 	case tabSites:
 		m.focus = paneSites
-		m.detailMode = detailSite
 	case tabDashboard:
 		m.focus = paneDetail
 		m.detailScroll = 0
@@ -1512,14 +1521,14 @@ func (m *Model) cycleLogTarget(delta int) tea.Cmd {
 // per running-or-defined worker (each worker is a systemd user unit tailed
 // via journalctl --user). Services have just the one container.
 func (m *Model) currentLogTargets() []LogTarget {
-	switch m.focus {
-	case paneSites, paneDetail:
+	switch m.activeTab {
+	case tabSites:
 		s := m.currentSite()
 		if s == nil {
 			return nil
 		}
 		return logTargetsForSite(s)
-	case paneServices:
+	case tabServices:
 		svc := m.currentService()
 		if svc == nil {
 			return nil
@@ -1651,13 +1660,13 @@ func (m *Model) currentService() *ServiceRow {
 }
 
 func (m *Model) actionStart() tea.Cmd {
-	switch m.focus {
-	case paneSites, paneDetail:
+	switch m.activeTab {
+	case tabSites:
 		if s := m.currentSite(); s != nil {
 			m.setStatus("starting "+s.Name+"…", 5*time.Second)
 			return runLerd(s.Path, "unpause", s.Name)
 		}
-	case paneServices:
+	case tabServices:
 		if svc := m.currentService(); svc != nil {
 			if cmd := m.workerActionCmd(svc, "start"); cmd != nil {
 				return cmd
@@ -1702,13 +1711,13 @@ func (m *Model) workerActionCmd(svc *ServiceRow, verb string) tea.Cmd {
 }
 
 func (m *Model) actionStop() tea.Cmd {
-	switch m.focus {
-	case paneSites, paneDetail:
+	switch m.activeTab {
+	case tabSites:
 		if s := m.currentSite(); s != nil {
 			m.setStatus("pausing "+s.Name+"…", 5*time.Second)
 			return runLerd(s.Path, "pause", s.Name)
 		}
-	case paneServices:
+	case tabServices:
 		if svc := m.currentService(); svc != nil {
 			if cmd := m.workerActionCmd(svc, "stop"); cmd != nil {
 				return cmd
@@ -1721,13 +1730,13 @@ func (m *Model) actionStop() tea.Cmd {
 }
 
 func (m *Model) actionRestart() tea.Cmd {
-	switch m.focus {
-	case paneSites, paneDetail:
+	switch m.activeTab {
+	case tabSites:
 		if s := m.currentSite(); s != nil {
 			m.setStatus("restarting "+s.Name+"…", 5*time.Second)
 			return runLerd(s.Path, "restart", s.Name)
 		}
-	case paneServices:
+	case tabServices:
 		if svc := m.currentService(); svc != nil {
 			if cmd := m.workerActionCmd(svc, "restart"); cmd != nil {
 				return cmd
@@ -1745,8 +1754,8 @@ func (m *Model) actionRestart() tea.Cmd {
 // site's project path means PHP tools (composer, artisan) run as if the
 // user had cd'd into the project first.
 func (m *Model) actionShell() tea.Cmd {
-	switch m.focus {
-	case paneSites, paneDetail:
+	switch m.activeTab {
+	case tabSites:
 		s := m.currentSite()
 		if s == nil {
 			return nil
@@ -1761,7 +1770,7 @@ func (m *Model) actionShell() tea.Cmd {
 			return nil
 		}
 		return runShellIn(container, s.Path)
-	case paneServices:
+	case tabServices:
 		svc := m.currentService()
 		if svc == nil {
 			return nil
@@ -1810,7 +1819,7 @@ func (m *Model) siteByName(name string) *siteinfo.EnrichedSite {
 }
 
 func (m *Model) actionPauseToggle() tea.Cmd {
-	if m.focus != paneSites && m.focus != paneDetail {
+	if m.activeTab != tabSites {
 		return nil
 	}
 	s := m.currentSite()

--- a/internal/tui/servicedetail_test.go
+++ b/internal/tui/servicedetail_test.go
@@ -73,6 +73,7 @@ func TestServiceDetail_ShowsOpenDashboardHint(t *testing.T) {
 
 func TestOpenInBrowser_ServiceDashboard(t *testing.T) {
 	m := NewModel("test")
+	m.activeTab = tabServices
 	m.focus = paneServices
 	m.snap.Services = []ServiceRow{{Name: "rabbitmq", State: stateRunning, Dashboard: "http://localhost:15672"}}
 	m.svcCursor = 0

--- a/internal/tui/sitetabs.go
+++ b/internal/tui/sitetabs.go
@@ -407,23 +407,26 @@ func readBoundedFile(path string, max int64) ([]byte, error) {
 // domain. Falls back to a status-bar message when there's nothing to open or
 // the platform lacks a known opener.
 func (m *Model) openInBrowserCmd() tea.Cmd {
-	if m.focus == paneServices {
+	switch m.activeTab {
+	case tabServices:
 		return m.openServiceDashboardCmd()
+	case tabSites:
+		site := m.currentSite()
+		if site == nil {
+			return nil
+		}
+		domain := site.PrimaryDomain()
+		if domain == "" {
+			m.setStatus("no domain to open for "+site.Name, 3*time.Second)
+			return nil
+		}
+		scheme := "http"
+		if site.Secured {
+			scheme = "https"
+		}
+		return m.openURL(scheme + "://" + domain)
 	}
-	site := m.currentSite()
-	if site == nil {
-		return nil
-	}
-	domain := site.PrimaryDomain()
-	if domain == "" {
-		m.setStatus("no domain to open for "+site.Name, 3*time.Second)
-		return nil
-	}
-	scheme := "http"
-	if site.Secured {
-		scheme = "https"
-	}
-	return m.openURL(scheme + "://" + domain)
+	return nil
 }
 
 // openServiceDashboardCmd opens the focused service's dashboard URL. Worker

--- a/internal/tui/tab_detailmode_test.go
+++ b/internal/tui/tab_detailmode_test.go
@@ -1,0 +1,99 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestSwitchTab_ResetsDetailMode guards against the Settings/System/Debug pane
+// bleeding across tabs. Opening Settings on Sites leaves detailMode=detailSettings;
+// switching to Services must drop back to detailSite so the Services detail column
+// renders the selected service, not the stale global surface. The S/Y/D toggles are
+// gated to the Sites tab, so a stuck pane would otherwise be unrecoverable there.
+func TestSwitchTab_ResetsDetailMode(t *testing.T) {
+	for _, mode := range []struct {
+		key  rune
+		want detailMode
+	}{{'S', detailSettings}, {'Y', detailSystem}, {'D', detailDumps}} {
+		m := NewModel("test")
+		m.snap = fakeSnap()
+		m.switchTab(tabSites)
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{mode.key}})
+		m = next.(*Model)
+		if m.detailMode != mode.want {
+			t.Fatalf("%c on Sites should enter mode %d, got %d", mode.key, mode.want, m.detailMode)
+		}
+		m.switchTab(tabServices)
+		if m.detailMode != detailSite {
+			t.Fatalf("switching to Services after %c should reset to detailSite, got %d", mode.key, m.detailMode)
+		}
+		// And switching to the Dashboard must also clear it.
+		m.switchTab(tabSites)
+		next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{mode.key}})
+		m = next.(*Model)
+		m.switchTab(tabDashboard)
+		if m.detailMode != detailSite {
+			t.Fatalf("switching to Dashboard after %c should reset to detailSite, got %d", mode.key, m.detailMode)
+		}
+	}
+}
+
+// TestDashboardActions_NoSiteTarget guards against destructive/site actions firing
+// against an invisible site on the Dashboard, where focus parks on paneDetail but no
+// site list or cursor is shown. pause/unpause/restart/shell must no-op there rather
+// than act on siteCursor (index 0 by default).
+func TestDashboardActions_NoSiteTarget(t *testing.T) {
+	actions := map[string]func(*Model) tea.Cmd{
+		"stop":        (*Model).actionStop,
+		"start":       (*Model).actionStart,
+		"restart":     (*Model).actionRestart,
+		"shell":       (*Model).actionShell,
+		"pauseToggle": (*Model).actionPauseToggle,
+		"openBrowser": (*Model).openInBrowserCmd,
+	}
+	for name, fn := range actions {
+		m := NewModel("test")
+		m.snap = fakeSnap()
+		m.switchTab(tabDashboard)
+		if cmd := fn(m); cmd != nil {
+			t.Fatalf("action %q on Dashboard should no-op, got a command", name)
+		}
+		if m.status != "" {
+			t.Fatalf("action %q on Dashboard should not set a status, got %q", name, m.status)
+		}
+	}
+}
+
+// TestDashboardEnter_NoSiteToggle guards the enter/space path: on the Dashboard
+// it must not fall through to detailToggleSelected against the carried-over site
+// (which would silently flip a worker / HTTPS / LAN share or open a picker modal).
+func TestDashboardEnter_NoSiteToggle(t *testing.T) {
+	for _, key := range []tea.KeyMsg{{Type: tea.KeyEnter}, {Type: tea.KeyRunes, Runes: []rune{' '}}} {
+		m := NewModel("test")
+		m.snap = fakeSnap()
+		m.switchTab(tabDashboard)
+		next, cmd := m.Update(key)
+		m = next.(*Model)
+		if cmd != nil {
+			t.Fatalf("enter/space on Dashboard should no-op, got a command")
+		}
+		if m.pickerKind != kindInfo {
+			t.Fatalf("enter/space on Dashboard should not open a picker")
+		}
+		if m.status != "" {
+			t.Fatalf("enter/space on Dashboard should not set a status, got %q", m.status)
+		}
+	}
+}
+
+// TestSitesActions_StillTargetSite confirms the gating doesn't break the real path:
+// on the Sites tab the same actions still resolve to the selected site.
+func TestSitesActions_StillTargetSite(t *testing.T) {
+	m := NewModel("test")
+	m.snap = fakeSnap()
+	m.switchTab(tabSites)
+	if cmd := m.actionStop(); cmd == nil {
+		t.Fatalf("actionStop on Sites with a selected site should return a command")
+	}
+}


### PR DESCRIPTION
Three fixes from a full review of everything since v1.25.0.

The tabbed dashboard parks focus on the detail pane with no visible site list, but the start, stop, restart, shell, pause, open-in-browser and enter/space row-toggle handlers resolved against the focused pane and fell through to the site at the leftover cursor, so an ordinary keystroke on the dashboard could silently pause a worker, flip HTTPS or LAN sharing, or open a browser to an unrelated site, and the same grouping let the Services tab act on a site when focus sat in its detail pane. They now dispatch on the active tab so they no-op on the dashboard and target the right entity per tab, and switchTab resets the detail mode on every switch so the Settings, System and Debug surfaces no longer bleed across tabs.

Warnings emitted while the `lerd env` live line is animating printed onto the spinner's line and were erased by its next redraw, so a failed backup or a service that wouldn't start went unseen. The feedback layer now tracks the active live line and routes its warnings through the interrupt that already protects child-process output, and that interrupt is reentrant so a nested step keeps the line paused until the outermost call returns.

`lerd quit` advertises stopping all processes and containers and stops the podman machine, but it inherited `stop`'s deliberate exclusion of `lerd-dns` and left the resolver pointing at a daemon it never shut down. Quit now stops `lerd-dns` too, after lerd-watcher so the watcher can't restart it, while `lerd stop` still leaves dns up as install-level plumbing.