### PR TITLE
Resolve post-1.25 review findings and make the TUI dashboard navigable

### DIFF
--- a/internal/dns/linkchanges_darwin.go
+++ b/internal/dns/linkchanges_darwin.go
@@ -38,8 +38,16 @@ func LinkChanges(out chan<- struct{}, done <-chan struct{}) error {
 		return fmt.Errorf("route socket nonblock: %w", err)
 	}
 
+	// stopped lets the interrupt goroutine exit when LinkChanges returns on its
+	// own (e.g. a read error the supervisor will restart from), so a restart
+	// loop doesn't accumulate one parked goroutine per attempt.
+	stopped := make(chan struct{})
+	defer close(stopped)
 	go func() {
-		<-done
+		select {
+		case <-done:
+		case <-stopped:
+		}
 		_ = unix.Shutdown(fd, unix.SHUT_RDWR)
 	}()
 

--- a/internal/dns/linkchanges_linux.go
+++ b/internal/dns/linkchanges_linux.go
@@ -39,8 +39,16 @@ func LinkChanges(out chan<- struct{}, done <-chan struct{}) error {
 		return fmt.Errorf("rtnetlink bind: %w", err)
 	}
 
+	// stopped lets the interrupt goroutine exit when LinkChanges returns on its
+	// own (e.g. a read error the supervisor will restart from), so a restart
+	// loop doesn't accumulate one parked goroutine per attempt.
+	stopped := make(chan struct{})
+	defer close(stopped)
 	go func() {
-		<-done
+		select {
+		case <-done:
+		case <-stopped:
+		}
 		_ = unix.Shutdown(fd, unix.SHUT_RDWR)
 	}()
 

--- a/internal/dns/setup_common.go
+++ b/internal/dns/setup_common.go
@@ -248,15 +248,17 @@ func primaryLANIPv6() string {
 }
 
 // deriveV6Target picks the AAAA target for .test mirroring v4's reach:
-// loopback or empty → ::1; LAN-exposed → host's primary global v6, else ::1.
+// loopback or empty → ::1; LAN-exposed → host's primary global v6, or "" (no
+// AAAA record) when there is no reachable global v6.
 func deriveV6Target(v4 string) string {
 	if v4 == "" || v4 == "127.0.0.1" {
 		return "::1"
 	}
-	if v6 := primaryLANIPv6(); v6 != "" {
-		return v6
-	}
-	return "::1"
+	// LAN-exposed: publish only a real, reachable global v6. Falling back to
+	// ::1 here would answer remote AAAA queries with their own loopback, and
+	// flipping between a real v6 and ::1 as v6 connectivity comes and goes
+	// would churn the config. Omit AAAA entirely when there's no global v6.
+	return primaryLANIPv6()
 }
 
 // WriteDnsmasqConfigFor writes the lerd dnsmasq config with `target` as the

--- a/internal/dns/setup_test.go
+++ b/internal/dns/setup_test.go
@@ -278,10 +278,12 @@ func TestDeriveV6Target(t *testing.T) {
 			t.Errorf("deriveV6Target(%q) = %q, want %q", c.v4, got, c.want)
 		}
 	}
-	// LAN target derives to either a global v6 (if host has one) or ::1
-	// fallback. Both are acceptable; assert it never returns empty.
-	if got := deriveV6Target("10.0.0.5"); got == "" {
-		t.Error("deriveV6Target(LAN) returned empty, expected global v6 or ::1")
+	// A LAN target derives to the host's global v6 when it has one, or ""
+	// (no AAAA record) when it doesn't. It must never fall back to ::1, which
+	// would wrongly answer remote AAAA queries with loopback. We can't pin the
+	// exact value (host-dependent), but it must not be ::1.
+	if got := deriveV6Target("10.0.0.5"); got == "::1" {
+		t.Error("deriveV6Target(LAN) must not fall back to ::1")
 	}
 }
 

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -121,10 +121,13 @@ func Begin() {
 // finishes it. On a colour TTY a spinner animates until then; otherwise nothing
 // prints until the finishing call writes the line once.
 type Step struct {
-	msg  string
-	w    io.Writer // fixed render target; nil → the live target() (honours redirects)
-	stop chan struct{}
-	wg   sync.WaitGroup
+	msg      string
+	w        io.Writer // fixed render target; nil → the live target() (honours redirects)
+	animated bool      // snapshotted at Start so finish() can't disagree with start()
+	stop     chan struct{}
+	wg       sync.WaitGroup
+	prev     *activeBox // active spinner this one suspends, restored on finish
+	paused   bool       // guarded by the package mu; set by Interrupt
 }
 
 // Start records a step with the given present-tense label (e.g. "detecting
@@ -138,9 +141,10 @@ func Start(msg string) *Step { return start(msg, nil) }
 func StartOn(w io.Writer, msg string) *Step { return start(msg, w) }
 
 func start(msg string, w io.Writer) *Step {
-	s := &Step{msg: msg, w: w}
-	if Animated() {
+	s := &Step{msg: msg, w: w, animated: Animated()}
+	if s.animated {
 		s.stop = make(chan struct{})
+		s.prev = pushActive(s)
 		s.wg.Add(1)
 		go s.spin()
 	}
@@ -175,13 +179,39 @@ func (s *Step) spin() {
 func (s *Step) frame(f string) {
 	mu.Lock()
 	defer mu.Unlock()
+	if s.paused {
+		return
+	}
 	fmt.Fprintf(s.dst(), "\r\033[2K%s%s %s %s", pad, paint(dimStyle, "→"), paint(dimStyle, s.msg), paint(spinStyle, f))
 }
 
+// Interrupt suspends the step's spinner and clears its line so fn can print
+// standalone output above it, mirroring Live.Interrupt. On a non-animated step
+// it just runs fn. paused is read and written under the package mu, the same
+// lock frame() holds, so no redraw slips between the clear and fn's output.
+func (s *Step) Interrupt(fn func()) {
+	if !s.animated {
+		fn()
+		return
+	}
+	mu.Lock()
+	wasPaused := s.paused
+	s.paused = true
+	if !wasPaused {
+		fmt.Fprint(s.dst(), "\r\033[2K")
+	}
+	mu.Unlock()
+	fn()
+	mu.Lock()
+	s.paused = wasPaused
+	mu.Unlock()
+}
+
 func (s *Step) finish(mark, result string) {
-	if Animated() {
+	if s.animated {
 		close(s.stop)
 		s.wg.Wait()
+		popActive(s.prev)
 	}
 	mu.Lock()
 	defer mu.Unlock()
@@ -192,7 +222,7 @@ func (s *Step) finish(mark, result string) {
 	if result != "" {
 		line += " " + result
 	}
-	if Animated() {
+	if s.animated {
 		fmt.Fprintf(s.dst(), "\r\033[2K%s\n", line)
 	} else {
 		fmt.Fprintln(s.dst(), line)
@@ -242,17 +272,32 @@ func Warn(format string, a ...any) {
 	})
 }
 
+// interruptible is anything that animates a spinner line and can pause it so a
+// standalone print lands cleanly above it. Both Step and Live implement it.
+type interruptible interface{ Interrupt(fn func()) }
+
+// activeBox boxes the active interruptible so it can live in an atomic.Pointer
+// (which needs a concrete element type).
+type activeBox struct{ line interruptible }
+
 // liveActive holds the spinner currently animating, if any, so standalone
 // prints (Warn / Note) can pause it and print cleanly above the live line
 // instead of being clobbered by its in-place redraw.
-var liveActive atomic.Pointer[Live]
+var liveActive atomic.Pointer[activeBox]
 
-// emit runs a standalone print, routing it through the active live line's
-// Interrupt when one is animating so the spinner doesn't overwrite it. With no
-// live line it just runs fn.
+// pushActive registers l as the active spinner, returning the one it suspends
+// (restored later via popActive).
+func pushActive(l interruptible) *activeBox { return liveActive.Swap(&activeBox{line: l}) }
+
+// popActive restores the previously-active spinner saved by pushActive.
+func popActive(prev *activeBox) { liveActive.Store(prev) }
+
+// emit runs a standalone print, routing it through the active spinner's
+// Interrupt when one is animating so it doesn't overwrite it. With no active
+// spinner it just runs fn.
 func emit(fn func()) {
-	if l := liveActive.Load(); l != nil {
-		l.Interrupt(fn)
+	if b := liveActive.Load(); b != nil {
+		b.line.Interrupt(fn)
 		return
 	}
 	fn()
@@ -302,25 +347,26 @@ func Animated() bool { return colorOn.Load() }
 // accumulates completed items, e.g. "→ configuring .env… ✓ a · b · c ⠙". When
 // it finishes the spinner is dropped and the ✓ line stays put.
 type Live struct {
-	msg    string
-	imu    sync.Mutex
-	items  []string
-	paused bool  // guarded by the package mu; set by Interrupt
-	prev   *Live // the live line this one suspends, restored on Done/Fail
-	stop   chan struct{}
-	wg     sync.WaitGroup
+	msg      string
+	imu      sync.Mutex
+	items    []string
+	animated bool       // snapshotted at StartLive so Done/Fail can't disagree
+	paused   bool       // guarded by the package mu; set by Interrupt
+	prev     *activeBox // the spinner this one suspends, restored on Done/Fail
+	stop     chan struct{}
+	wg       sync.WaitGroup
 }
 
 // StartLive begins a live line with the given label. On a non-animated output
 // it just prints the header and each Add on its own line.
 func StartLive(msg string) *Live {
-	l := &Live{msg: msg}
-	if Animated() {
+	l := &Live{msg: msg, animated: Animated()}
+	if l.animated {
 		// Register as the active line (saving any line we nest inside) so
 		// Warn/Note route through Interrupt while this spinner animates. Only
 		// the animated spinner clobbers standalone prints, so plain mode skips
 		// this and prints warnings on their own line as before.
-		l.prev = liveActive.Swap(l)
+		l.prev = pushActive(l)
 		l.stop = make(chan struct{})
 		l.wg.Add(1)
 		go l.spin()
@@ -379,7 +425,7 @@ func (l *Live) draw(frame string) {
 // and written under the package mu, the same lock draw holds while writing, so
 // no redraw can slip between the clear and fn's output.
 func (l *Live) Interrupt(fn func()) {
-	if !Animated() {
+	if !l.animated {
 		fn()
 		return
 	}
@@ -401,7 +447,7 @@ func (l *Live) Interrupt(fn func()) {
 
 // Add records a completed item; the spinning line redraws to include it.
 func (l *Live) Add(item string) {
-	if !Animated() {
+	if !l.animated {
 		mu.Lock()
 		fmt.Fprintf(target(), "%s  %s\n", pad, item)
 		mu.Unlock()
@@ -414,15 +460,17 @@ func (l *Live) Add(item string) {
 
 // Done stops the spinner, leaving the ✓ line (checkbox replaces the loader).
 func (l *Live) Done() {
-	liveActive.Store(l.prev)
-	if !Animated() {
+	if !l.animated {
 		mu.Lock()
 		fmt.Fprintf(target(), "%s%s %s\n", pad, paint(okStyle, "✓"), l.msg)
 		mu.Unlock()
 		return
 	}
+	// Stop the spinner before deregistering, so a concurrent Warn never routes
+	// past this line while the goroutine is still drawing it.
 	close(l.stop)
 	l.wg.Wait()
+	popActive(l.prev)
 	l.draw("")
 	mu.Lock()
 	fmt.Fprintln(target())
@@ -431,14 +479,15 @@ func (l *Live) Done() {
 
 // Fail stops the spinner and finalises the line with a red cross.
 func (l *Live) Fail(err error) {
-	liveActive.Store(l.prev)
-	if Animated() {
+	if l.animated {
+		// Stop the spinner before deregistering (see Done).
 		close(l.stop)
 		l.wg.Wait()
+		popActive(l.prev)
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	if Animated() {
+	if l.animated {
 		fmt.Fprint(target(), "\r\033[2K")
 	}
 	msg := ""

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -160,7 +160,7 @@ func TestLiveInterrupt_SuppressesSpinnerWhilePaused(t *testing.T) {
 	var buf bytes.Buffer
 	withAnimatedBuffer(t, &buf)
 
-	l := &Live{msg: "configuring .env"}
+	l := &Live{msg: "configuring .env", animated: true}
 	buf.Reset()
 
 	// A spinner tick that fires during the interrupt must not redraw, and the
@@ -205,9 +205,9 @@ func TestWarn_PausesActiveLine(t *testing.T) {
 	var buf bytes.Buffer
 	withAnimatedBuffer(t, &buf)
 
-	l := &Live{msg: "configuring .env"}
-	prev := liveActive.Swap(l)
-	t.Cleanup(func() { liveActive.Store(prev) })
+	l := &Live{msg: "configuring .env", animated: true}
+	prev := pushActive(l)
+	t.Cleanup(func() { popActive(prev) })
 
 	buf.Reset()
 	Warn("could not start %s: boom", "mysql")
@@ -233,16 +233,23 @@ func TestStartLive_TracksActiveAcrossNesting(t *testing.T) {
 	baseline := liveActive.Load()
 	t.Cleanup(func() { liveActive.Store(baseline) })
 
+	activeLine := func() interruptible {
+		if b := liveActive.Load(); b != nil {
+			return b.line
+		}
+		return nil
+	}
+
 	outer := StartLive("outer")
-	if liveActive.Load() != outer {
+	if activeLine() != outer {
 		t.Fatal("StartLive did not register the outer line")
 	}
 	inner := StartLive("inner")
-	if liveActive.Load() != inner {
+	if activeLine() != inner {
 		t.Fatal("nested StartLive did not register the inner line")
 	}
 	inner.Done()
-	if liveActive.Load() != outer {
+	if activeLine() != outer {
 		t.Fatal("inner Done did not restore the outer line")
 	}
 	outer.Fail(nil)

--- a/internal/feedback/spinner_test.go
+++ b/internal/feedback/spinner_test.go
@@ -1,0 +1,60 @@
+package feedback
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestStep_ColorEnabledBetweenStartAndFinish_NoPanic guards the landmine where
+// finish() re-read Animated() independently of start(): a Step begun in plain
+// mode (nil stop channel) would panic on close(nil) if color turned on before
+// it finished. The animated decision must be snapshotted at Start.
+func TestStep_ColorEnabledBetweenStartAndFinish_NoPanic(t *testing.T) {
+	var buf bytes.Buffer
+	restore := SetTestWriter(&buf) // forces plain mode: no spinner, stop is nil
+	defer restore()
+
+	s := Start("doing thing")
+	colorOn.Store(true) // color flips on mid-flight
+	s.OK("done")        // must not panic on a nil stop channel
+}
+
+// TestStep_ColorDisabledBetweenStartAndFinish_NoLeak is the mirror: a Step begun
+// animated must still close its spinner on finish even if color flips off, so
+// the goroutine and ticker don't leak.
+func TestStep_ColorDisabledBetweenStartAndFinish_NoLeak(t *testing.T) {
+	var buf bytes.Buffer
+	withAnimatedBuffer(t, &buf)
+
+	s := Start("doing thing")
+	colorOn.Store(false) // color flips off mid-flight
+	done := make(chan struct{})
+	go func() { s.OK("done"); close(done) }()
+	<-done // finish must return (it joins the spinner goroutine), not block forever
+}
+
+// TestStep_WarnNotClobberedBySpinner verifies a Warn emitted while an animated
+// Step spins is routed through the step's Interrupt, so the spinner's in-place
+// redraw doesn't overwrite it.
+func TestStep_WarnNotClobberedBySpinner(t *testing.T) {
+	var buf bytes.Buffer
+	withAnimatedBuffer(t, &buf)
+
+	// Register the step as the active spinner without launching the real
+	// goroutine, so reading buf doesn't race the spinner (mirrors the Live test).
+	s := &Step{msg: "doing thing", animated: true}
+	prev := pushActive(s)
+	t.Cleanup(func() { popActive(prev) })
+
+	buf.Reset()
+	Warn("could not start %s: boom", "mysql")
+
+	got := buf.String()
+	if !strings.Contains(got, "could not start mysql") {
+		t.Fatalf("warning text missing: %q", got)
+	}
+	if !strings.Contains(got, "\r\033[2K") {
+		t.Fatalf("warn did not pause/clear the step line: %q", got)
+	}
+}

--- a/internal/tui/dash_failworker_test.go
+++ b/internal/tui/dash_failworker_test.go
@@ -16,7 +16,7 @@ func TestDashWorkersCard_DistinctZonesPerFailingWorker(t *testing.T) {
 			{Name: "alpha", QueueFailing: true, ScheduleFailing: true},
 		},
 	}
-	c := m.dashWorkersCard(80)
+	c := m.dashWorkersCard(80, -1)
 
 	var failZones []string
 	for _, id := range c.rowZones {

--- a/internal/tui/dash_nav_test.go
+++ b/internal/tui/dash_nav_test.go
@@ -1,0 +1,106 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func dashNavModel() *Model {
+	m := NewModel("test")
+	m.width = 120
+	m.height = 30
+	m.activeTab = tabDashboard
+	m.snap = Snapshot{
+		Sites: []siteinfo.EnrichedSite{
+			{Name: "alpha", Domains: []string{"alpha.test"}, FPMRunning: true},
+			{Name: "beta", Domains: []string{"beta.test"}, Paused: true},
+		},
+		Services: []ServiceRow{
+			{Name: "mysql", State: stateRunning},
+			{Name: "redis", State: stateStopped},
+			{Name: "queue-alpha", State: stateRunning, WorkerKind: "queue", WorkerSite: "alpha"},
+		},
+		Status: StatusRow{TLD: "test"},
+	}
+	// Render once so dashZones reflects what's on screen, like the real loop.
+	_ = m.renderDashboardGrid(120, 24)
+	return m
+}
+
+func TestDashNav_ArrowsMoveRowCursorAndEnterJumps(t *testing.T) {
+	m := dashNavModel() // Sites card focused by default
+	if got := len(m.dashZones[0]); got != 2 {
+		t.Fatalf("expected 2 site zones, got %d", got)
+	}
+	m.moveCursor(1)
+	if m.dashRowCursor[0] != 1 {
+		t.Fatalf("down should move the row cursor to 1, got %d", m.dashRowCursor[0])
+	}
+	m.moveCursor(5)
+	if m.dashRowCursor[0] != 1 {
+		t.Fatalf("cursor should clamp at the last row (1), got %d", m.dashRowCursor[0])
+	}
+	m.activateDashSelection()
+	if m.activeTab != tabSites {
+		t.Fatalf("enter should jump to the Sites tab, got %d", m.activeTab)
+	}
+	if s := m.currentSite(); s == nil || s.Name != "beta" {
+		t.Fatalf("enter should select the cursor's site (beta), got %v", s)
+	}
+}
+
+func TestDashNav_InfoCardScrollsInsteadOfSelecting(t *testing.T) {
+	m := dashNavModel()
+	m.dashFocus = 5 // Lerd card: info only, no selectable rows
+	if len(m.dashZones[5]) != 0 {
+		t.Fatalf("info card should have no selectable zones")
+	}
+	m.moveCursor(1)
+	if m.dashScroll[5] != 1 {
+		t.Fatalf("an info card should scroll on ↑↓, got scroll %d", m.dashScroll[5])
+	}
+	if m.dashRowCursor[5] != 0 {
+		t.Fatalf("an info card should not move a row cursor, got %d", m.dashRowCursor[5])
+	}
+}
+
+func TestDashNav_ServicesEnterSelectsService(t *testing.T) {
+	m := dashNavModel()
+	m.dashFocus = 1 // Services card (mysql, redis; the worker is excluded)
+	if len(m.dashZones[1]) != 2 {
+		t.Fatalf("expected 2 service zones, got %d", len(m.dashZones[1]))
+	}
+	m.dashRowCursor[1] = 1 // redis
+	m.activateDashSelection()
+	if m.activeTab != tabServices {
+		t.Fatalf("enter should jump to the Services tab, got %d", m.activeTab)
+	}
+	if s := m.currentService(); s == nil || s.Name != "redis" {
+		t.Fatalf("enter should select redis, got %v", s)
+	}
+}
+
+func TestDashNav_WorkerEnterJumpsToOwningService(t *testing.T) {
+	m := dashNavModel()
+	m.dashFocus = 2 // Workers card
+	if len(m.dashZones[2]) != 1 {
+		t.Fatalf("expected 1 worker zone, got %d", len(m.dashZones[2]))
+	}
+	m.activateDashSelection()
+	if m.activeTab != tabServices {
+		t.Fatalf("worker enter should jump to the Services tab, got %d", m.activeTab)
+	}
+	if s := m.currentService(); s == nil || s.Name != "queue-alpha" {
+		t.Fatalf("worker enter should select queue-alpha, got %v", s)
+	}
+}
+
+func TestDashNav_SelectedRowDrawsCaret(t *testing.T) {
+	m := dashNavModel() // Sites card focused, row 0 selected
+	out := stripANSI(m.renderDashboardGrid(120, 24))
+	if !strings.Contains(out, "▸ ● alpha.test") {
+		t.Fatalf("focused card's selected row should show the caret:\n%s", out)
+	}
+}

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -58,6 +59,34 @@ type cardContent struct {
 	rowZones map[int]string
 }
 
+// orderedZoneIDs returns a card's clickable zone ids ordered by line, so the
+// row cursor index lines up with the visual top-to-bottom order of the rows.
+func orderedZoneIDs(c cardContent) []string {
+	if len(c.rowZones) == 0 {
+		return nil
+	}
+	lis := make([]int, 0, len(c.rowZones))
+	for li := range c.rowZones {
+		lis = append(lis, li)
+	}
+	sort.Ints(lis)
+	ids := make([]string, len(lis))
+	for i, li := range lis {
+		ids[i] = c.rowZones[li]
+	}
+	return ids
+}
+
+// dashSelGutter is the 2-col left margin on a selectable dashboard row: a caret
+// in the accent (navigation) colour when selected, blank otherwise. Reserving
+// it on every selectable row keeps the rows aligned whether or not focused.
+func dashSelGutter(rowIdx, sel int) string {
+	if rowIdx == sel {
+		return accentStyle.Render("▸ ")
+	}
+	return "  "
+}
+
 // renderDashboardGrid draws the Dashboard tab as a responsive grid of six
 // cards mirroring the lerd web UI: Sites, Services, Workers, System Health,
 // Resources and Lerd. Three columns when wide, two at medium width, one when
@@ -71,7 +100,9 @@ func (m *Model) renderDashboardGrid(w, h int) string {
 	case w < narrowWidth:
 		cols = 2
 	}
-	const gap = 1
+	// No gap between cards: tmux-style flush panels read cleaner than columns
+	// floating apart, especially in terminals that don't draw inter-pane gaps.
+	const gap = 0
 	cardW := (w - (cols-1)*gap) / cols
 	if cardW < 24 {
 		cardW = 24
@@ -82,14 +113,26 @@ func (m *Model) renderDashboardGrid(w, h int) string {
 	}
 
 	titles := []string{"Sites", "Services", "Workers", "System Health", "Resources", "Lerd"}
-	cw := innerW - 1 // content width inside the scrollbar column
+	cw := innerW - 2 // content width inside the 1-col gap + scrollbar column
+
+	// The focused navigable card gets its selected-row index so it can draw the
+	// caret; every other card passes -1 (no selection highlight).
+	sels := [numDashCards]int{-1, -1, -1, -1, -1, -1}
+	if m.activeTab == tabDashboard {
+		sels[m.dashFocus] = m.dashRowCursor[m.dashFocus]
+	}
 	contents := []cardContent{
-		m.dashSitesCard(cw),
-		m.dashServicesCard(cw),
-		m.dashWorkersCard(cw),
+		m.dashSitesCard(cw, sels[0]),
+		m.dashServicesCard(cw, sels[1]),
+		m.dashWorkersCard(cw, sels[2]),
 		m.dashSystemHealthCard(cw),
 		m.dashResourcesCard(cw),
 		m.dashLerdCard(cw),
+	}
+	// Cache each card's ordered clickable zone ids so the row cursor and enter
+	// resolve against exactly what was just rendered.
+	for i := range contents {
+		m.dashZones[i] = orderedZoneIDs(contents[i])
 	}
 
 	rows := (numDashCards + cols - 1) / cols
@@ -152,6 +195,15 @@ func (m *Model) renderScrollableCard(idx int, title string, c cardContent, inner
 		maxScroll = 0
 	}
 	scroll := m.dashScroll[idx]
+	// Keep the selected row in view on the focused navigable card.
+	if selLine := m.dashSelectedLine(idx, c); selLine >= 0 {
+		if selLine < scroll {
+			scroll = selLine
+		}
+		if selLine >= scroll+avail {
+			scroll = selLine - avail + 1
+		}
+	}
 	if scroll > maxScroll {
 		scroll = maxScroll
 	}
@@ -160,7 +212,7 @@ func (m *Model) renderScrollableCard(idx int, title string, c cardContent, inner
 	}
 	m.dashScroll[idx] = scroll
 
-	contentW := innerW - 1 // reserve the scrollbar column
+	contentW := innerW - 2 // reserve a 1-col gap before the scrollbar column
 	if contentW < 1 {
 		contentW = innerW
 	}
@@ -183,7 +235,7 @@ func (m *Model) renderScrollableCard(idx int, title string, c cardContent, inner
 				row = zone.Mark(z, row)
 			}
 		}
-		body = append(body, row+bar[i])
+		body = append(body, row+" "+bar[i])
 	}
 
 	style := cardStyle
@@ -191,6 +243,26 @@ func (m *Model) renderScrollableCard(idx int, title string, c cardContent, inner
 		style = style.BorderForeground(colAccent)
 	}
 	return zone.Mark(fmt.Sprintf("card:%d", idx), style.Render(strings.Join(body, "\n")))
+}
+
+// dashSelectedLine returns the line index of the focused navigable card's
+// selected row, or -1 when this card isn't the focused one or has no selection.
+func (m *Model) dashSelectedLine(idx int, c cardContent) int {
+	if m.activeTab != tabDashboard || m.dashFocus != idx {
+		return -1
+	}
+	zones := m.dashZones[idx]
+	if len(zones) == 0 {
+		return -1
+	}
+	cur := clamp(m.dashRowCursor[idx], 0, len(zones)-1)
+	want := zones[cur]
+	for li, id := range c.rowZones {
+		if id == want {
+			return li
+		}
+	}
+	return -1
 }
 
 // dashRowRight lays a label on the left and its value flush against the right
@@ -204,7 +276,7 @@ func dashRowRight(label, value string, width int) string {
 	return label + spaces(gap) + value
 }
 
-func (m *Model) dashSitesCard(width int) cardContent {
+func (m *Model) dashSitesCard(width, sel int) cardContent {
 	running, paused := 0, 0
 	for _, s := range m.snap.Sites {
 		if s.Paused {
@@ -234,12 +306,12 @@ func (m *Model) dashSitesCard(width int) cardContent {
 			right = dimStyle.Render(s.FrameworkLabel)
 		}
 		zones[len(lines)] = fmt.Sprintf("dashsite:%d", i)
-		lines = append(lines, dashRowRight(fpmGlyph(s)+" "+name, right, width))
+		lines = append(lines, dashSelGutter(i, sel)+dashRowRight(fpmGlyph(s)+" "+name, right, width-2))
 	}
 	return cardContent{lines, zones}
 }
 
-func (m *Model) dashServicesCard(width int) cardContent {
+func (m *Model) dashServicesCard(width, sel int) cardContent {
 	total, running := 0, 0
 	for _, s := range m.snap.Services {
 		if s.WorkerKind != "" {
@@ -258,6 +330,7 @@ func (m *Model) dashServicesCard(width int) cardContent {
 		return cardContent{append(lines, dimStyle.Render("no services configured")), nil}
 	}
 	zones := map[int]string{}
+	si := 0
 	for i, s := range m.snap.Services {
 		if s.WorkerKind != "" {
 			continue
@@ -268,12 +341,13 @@ func (m *Model) dashServicesCard(width int) cardContent {
 			right = dimStyle.Render(s.Version)
 		}
 		zones[len(lines)] = fmt.Sprintf("dashsvc:%d", i)
-		lines = append(lines, dashRowRight(serviceStateGlyph(s.State)+" "+s.Name, right, width))
+		lines = append(lines, dashSelGutter(si, sel)+dashRowRight(serviceStateGlyph(s.State)+" "+s.Name, right, width-2))
+		si++
 	}
 	return cardContent{lines, zones}
 }
 
-func (m *Model) dashWorkersCard(width int) cardContent {
+func (m *Model) dashWorkersCard(width, sel int) cardContent {
 	active, asleep := 0, 0
 	// Track each worker's index into m.snap.Services so a clicked row can map
 	// back to the matching service-list entry.
@@ -303,6 +377,7 @@ func (m *Model) dashWorkersCard(width int) cardContent {
 		return cardContent{append(lines, runningStyle.Render("all workers healthy")), nil}
 	}
 	zones := map[int]string{}
+	si := 0
 	for _, idx := range workerIdx {
 		wk := m.snap.Services[idx]
 		// The status dot already conveys running/stopped/suspended, so the
@@ -315,7 +390,8 @@ func (m *Model) dashWorkersCard(width int) cardContent {
 			right = ""
 		}
 		zones[len(lines)] = fmt.Sprintf("dashworker:%d", idx)
-		lines = append(lines, dashRowRight(left, right, width))
+		lines = append(lines, dashSelGutter(si, sel)+dashRowRight(left, right, width-2))
+		si++
 	}
 	if len(failing) > 0 {
 		lines = append(lines, "")
@@ -324,7 +400,8 @@ func (m *Model) dashWorkersCard(width int) cardContent {
 		// keeps a single region per id, leaving the second row a dead click.
 		for fi, f := range failing {
 			zones[len(lines)] = fmt.Sprintf("dashfailsite:%d", fi)
-			lines = append(lines, failingStyle.Render("⚠ "+f.name))
+			lines = append(lines, dashSelGutter(si, sel)+failingStyle.Render("⚠ "+f.name))
+			si++
 		}
 		lines = append(lines, dimStyle.Render("press H to heal"))
 	}

--- a/internal/tui/dashboard_test.go
+++ b/internal/tui/dashboard_test.go
@@ -24,7 +24,7 @@ func TestDashboardGrid_RendersAllCards(t *testing.T) {
 // heal state so users see the positive signal at a glance.
 func TestWorkersCard_HealthyWhenNoFailures(t *testing.T) {
 	m := NewModel("test")
-	joined := stripANSI(strings.Join(m.dashWorkersCard(60).lines, "\n"))
+	joined := stripANSI(strings.Join(m.dashWorkersCard(60, -1).lines, "\n"))
 	if !strings.Contains(joined, "all workers healthy") {
 		t.Errorf("expected healthy state with no failing workers:\n%s", joined)
 	}
@@ -38,7 +38,7 @@ func TestWorkersCard_ShowsFailingCount(t *testing.T) {
 		{Name: "a", QueueFailing: true, HasQueueWorker: true},
 		{Name: "b", ScheduleFailing: true, HasScheduleWorker: true},
 	}
-	joined := stripANSI(strings.Join(m.dashWorkersCard(60).lines, "\n"))
+	joined := stripANSI(strings.Join(m.dashWorkersCard(60, -1).lines, "\n"))
 	if !strings.Contains(joined, "2 failing") {
 		t.Errorf("expected '2 failing':\n%s", joined)
 	}

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -302,7 +302,7 @@ func worktreeWorkerLabel(wt *siteinfo.WorktreeInfo, name string) string {
 // Returns handled=true once the prompt opens; the actual command fires
 // later from handleConfirmKey when the user presses y.
 func (m *Model) removeFocusedDomain() (handled bool, cmd tea.Cmd) {
-	if m.focus != paneDetail || m.detailMode != detailSite {
+	if m.activeTab != tabSites || m.focus != paneDetail || m.detailMode != detailSite {
 		return false, nil
 	}
 	s := m.currentSite()
@@ -452,11 +452,11 @@ func (m *Model) renderDetailInline(w, h int, focused bool) string {
 	case detailDumps:
 		content, cursorLine = debugContentLines(m, focused, contentW)
 	default:
-		// When focus is on the services list, the detail pane shows the
-		// matching service — same surface area the web UI's ServiceDetail
-		// covers. Site detail is only the right answer when sites or detail
-		// itself is focused.
-		if m.focus == paneServices {
+		// On the Services tab the detail pane always shows the selected
+		// service, same surface area the web UI's ServiceDetail covers,
+		// whether focus sits on the list or has moved onto the pane itself.
+		// Site detail is only the right answer on the Sites tab.
+		if m.activeTab == tabServices {
 			content = serviceDetailContentLines(m, m.currentService(), contentW)
 			cursorLine = -1
 			break

--- a/internal/tui/domain_gate_test.go
+++ b/internal/tui/domain_gate_test.go
@@ -1,0 +1,83 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// domainGateSnap gives one site with a domain plus a service, so focus can
+// legitimately reach the detail pane on either tab.
+func domainGateSnap() Snapshot {
+	return Snapshot{
+		Sites: []siteinfo.EnrichedSite{
+			{Name: "alpha", Domains: []string{"alpha.test"}, PHPVersion: "8.3"},
+		},
+		Services: []ServiceRow{
+			{Name: "mysql", State: stateRunning, SiteCount: 1},
+		},
+		Status: StatusRow{TLD: "test"},
+	}
+}
+
+// TestDomainActions_GatedToSitesTab guards the regression where add/edit/remove
+// domain fired on the carried-over (hidden) site from the Services tab: there
+// focus can reach paneDetail while detailMode is still detailSite, so the
+// focus+mode guard alone let the mutators touch a site the user can't see.
+func TestDomainActions_GatedToSitesTab(t *testing.T) {
+	m := NewModel("test")
+	m.snap = domainGateSnap()
+	m.activeTab = tabServices
+	m.detailMode = detailSite
+	m.focus = paneDetail
+	m.siteCursor = 0
+	m.detailCursor = 0 // first navigable row is the domain row
+
+	if m.editFocusedDomain() {
+		t.Fatal("editFocusedDomain should not fire off the Sites tab")
+	}
+	if m.domainInputActive {
+		t.Fatal("no domain edit input should open off the Sites tab")
+	}
+	if handled, _ := m.removeFocusedDomain(); handled {
+		t.Fatal("removeFocusedDomain should not fire off the Sites tab")
+	}
+	if m.confirmActive {
+		t.Fatal("no remove-domain confirm should open off the Sites tab")
+	}
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	m = next.(*Model)
+	if m.domainInputActive {
+		t.Fatal("the `a` add binding should not open input off the Sites tab")
+	}
+}
+
+// TestDomainActions_WorkOnSitesTab is the positive control: the same actions
+// still fire on the Sites tab, so the gate isn't over-broad.
+func TestDomainActions_WorkOnSitesTab(t *testing.T) {
+	mkModel := func() *Model {
+		m := NewModel("test")
+		m.snap = domainGateSnap()
+		m.activeTab = tabSites
+		m.detailMode = detailSite
+		m.focus = paneDetail
+		m.siteCursor = 0
+		m.detailCursor = 0
+		return m
+	}
+
+	if m := mkModel(); !m.editFocusedDomain() || !m.domainInputActive {
+		t.Fatal("editFocusedDomain should open the edit input on the Sites tab")
+	}
+	if m := mkModel(); func() bool { h, _ := m.removeFocusedDomain(); return h }() == false || !m.confirmActive {
+		t.Fatal("removeFocusedDomain should open the confirm on the Sites tab")
+	}
+	if m := mkModel(); func() bool {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+		return next.(*Model).domainInputActive
+	}() == false {
+		t.Fatal("the `a` add binding should open the input on the Sites tab")
+	}
+}

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -15,8 +15,9 @@ var helpReference = []helpSection{
 		rows: [][2]string{
 			{"ctrl+← / ctrl+→", "switch the top tab (Dashboard · Sites · Services); tabs are also clickable"},
 			{"tab / shift+tab", "cycle focus between the list and the detail pane on the current tab"},
-			{"click", "click a tab to switch screens, or a site / service row to select it"},
-			{"↑ ↓  j k", "move selection within the focused pane (scrolls the grid on the Dashboard)"},
+			{"click", "click a tab to switch screens, or a site / service / worker row to open it"},
+			{"↑ ↓  j k", "move the selection in the focused pane or Dashboard card (info cards scroll)"},
+			{"enter", "on the Dashboard, open the selected row (same as clicking it)"},
 			{"pgup / pgdn", "jump by 10 rows"},
 			{"home / end · g G", "jump to first / last row"},
 		},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -222,6 +222,13 @@ type Model struct {
 	// scroll offset. Cards show their whole list and clip to a scroll window.
 	dashFocus  int
 	dashScroll [numDashCards]int
+	// dashRowCursor is the selected row within each card (an index into
+	// dashZones[card]); ↑↓ moves it on the Sites/Services/Workers cards and
+	// enter activates it like a click. dashZones caches, per card, the ordered
+	// clickable zone ids laid down at the last render so the cursor and enter
+	// resolve against exactly what's on screen.
+	dashRowCursor [numDashCards]int
+	dashZones     [numDashCards][]string
 
 	// Activity feed: a capped ring of recent state-change events derived by
 	// diffing successive snapshots, mirroring the web UI's Recent Activity.
@@ -441,6 +448,11 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 
 	case "enter", " ":
+		// On the Dashboard, enter (or space) acts like a click on the selected
+		// row: it jumps to that site / service / worker on its own tab.
+		if m.activeTab == tabDashboard {
+			return m, m.activateDashSelection()
+		}
 		if m.focus == paneDetail {
 			if m.pickerKind != kindInfo {
 				return m, m.applyPicker()
@@ -694,7 +706,7 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.actionStop()
 
 	case "a":
-		if m.focus == paneDetail && m.detailMode == detailSite && m.currentSite() != nil {
+		if m.activeTab == tabSites && m.focus == paneDetail && m.detailMode == detailSite && m.currentSite() != nil {
 			m.openDomainInput()
 			return m, nil
 		}
@@ -844,7 +856,7 @@ func (m *Model) openDomainEdit(full string) {
 // the detail cursor on a domain row. Returns false when the focus/row
 // doesn't match so other bindings keep working.
 func (m *Model) editFocusedDomain() (handled bool) {
-	if m.focus != paneDetail || m.detailMode != detailSite {
+	if m.activeTab != tabSites || m.focus != paneDetail || m.detailMode != detailSite {
 		return false
 	}
 	s := m.currentSite()
@@ -1167,44 +1179,21 @@ func (m *Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case tabDashboard:
-		// Clicking a site or service row jumps to that item on its own tab.
-		for i := range m.snap.Sites {
-			if zone.Get(fmt.Sprintf("dashsite:%d", i)).InBounds(msg) {
-				m.switchTab(tabSites)
-				m.selectSiteByName(m.snap.Sites[i].Name)
-				return m, m.syncLogs()
-			}
-		}
-		for i := range m.snap.Services {
-			if zone.Get(fmt.Sprintf("dashsvc:%d", i)).InBounds(msg) {
-				m.switchTab(tabServices)
-				m.selectServiceByName(m.snap.Services[i].Name)
-				return m, m.syncLogs()
-			}
-		}
-		// Worker rows live in the services list too, so a click jumps there
-		// with the worker selected.
-		for i := range m.snap.Services {
-			if zone.Get(fmt.Sprintf("dashworker:%d", i)).InBounds(msg) {
-				m.switchTab(tabServices)
-				m.selectServiceByName(m.snap.Services[i].Name)
-				return m, m.syncLogs()
-			}
-		}
-		// A failing-worker row carries no service entry of its own, so it jumps
-		// to the owning site's detail where the worker state and heal action live.
-		// Zones are keyed by failing-worker index, mapped back to the site here.
-		failing := failingWorkers(m.snap)
-		for fi, f := range failing {
-			if zone.Get(fmt.Sprintf("dashfailsite:%d", fi)).InBounds(msg) {
-				m.switchTab(tabSites)
-				if f.siteIdx >= 0 && f.siteIdx < len(m.snap.Sites) {
-					m.selectSiteByName(m.snap.Sites[f.siteIdx].Name)
+		// A click on any clickable row jumps to that item via the same path as
+		// the keyboard enter. Each card's selectable zone ids are cached at
+		// render time, so we just hit-test those rather than rebuilding them.
+		for ci := 0; ci < numDashCards; ci++ {
+			for ri, id := range m.dashZones[ci] {
+				if zone.Get(id).InBounds(msg) {
+					// Keep the keyboard cursor in sync so returning to the
+					// dashboard lands on the row the user last clicked.
+					m.dashFocus = ci
+					m.dashRowCursor[ci] = ri
+					return m, m.activateDashZone(id)
 				}
-				return m, m.syncLogs()
 			}
 		}
-		// A click elsewhere on a card just focuses it for keyboard scrolling.
+		// A click elsewhere on a card just focuses it for keyboard navigation.
 		for i := 0; i < numDashCards; i++ {
 			if zone.Get(fmt.Sprintf("card:%d", i)).InBounds(msg) {
 				m.dashFocus = i
@@ -1290,6 +1279,60 @@ func (m *Model) scrollOffset(off *int, delta int) {
 	if *off < 0 {
 		*off = 0
 	}
+}
+
+// activateDashSelection activates the focused dashboard card's selected row,
+// the keyboard equivalent of clicking it. No-op on info-only cards.
+func (m *Model) activateDashSelection() tea.Cmd {
+	zones := m.dashZones[m.dashFocus]
+	cur := m.dashRowCursor[m.dashFocus]
+	if cur < 0 || cur >= len(zones) {
+		return nil
+	}
+	return m.activateDashZone(zones[cur])
+}
+
+// activateDashZone performs the jump for a dashboard row zone id, shared by the
+// mouse click handler and keyboard enter so both behave identically. A site /
+// service / worker jumps to its own tab with that item selected; a failing
+// worker jumps to its owning site's detail.
+func (m *Model) activateDashZone(id string) tea.Cmd {
+	idx := func(prefix string) (int, bool) {
+		if !strings.HasPrefix(id, prefix) {
+			return 0, false
+		}
+		var n int
+		if _, err := fmt.Sscanf(id[len(prefix):], "%d", &n); err != nil {
+			return 0, false
+		}
+		return n, true
+	}
+	if i, ok := idx("dashsite:"); ok && i >= 0 && i < len(m.snap.Sites) {
+		m.switchTab(tabSites)
+		m.selectSiteByName(m.snap.Sites[i].Name)
+		return m.syncLogs()
+	}
+	if i, ok := idx("dashsvc:"); ok && i >= 0 && i < len(m.snap.Services) {
+		m.switchTab(tabServices)
+		m.selectServiceByName(m.snap.Services[i].Name)
+		return m.syncLogs()
+	}
+	if i, ok := idx("dashworker:"); ok && i >= 0 && i < len(m.snap.Services) {
+		m.switchTab(tabServices)
+		m.selectServiceByName(m.snap.Services[i].Name)
+		return m.syncLogs()
+	}
+	if fi, ok := idx("dashfailsite:"); ok {
+		failing := failingWorkers(m.snap)
+		if fi >= 0 && fi < len(failing) {
+			m.switchTab(tabSites)
+			if si := failing[fi].siteIdx; si >= 0 && si < len(m.snap.Sites) {
+				m.selectSiteByName(m.snap.Sites[si].Name)
+			}
+			return m.syncLogs()
+		}
+	}
+	return nil
 }
 
 // selectSiteByName focuses the Sites list on the site with the given name,
@@ -1385,8 +1428,14 @@ func (m *Model) nextFocus(dir int) focusPane {
 }
 
 func (m *Model) moveCursor(delta int) {
-	// The Dashboard tab has no list selection — j/k scrolls the focused card.
+	// On the Dashboard, a card with selectable rows (Sites, Services, Workers)
+	// moves its row cursor; the render follows it. Info-only cards (System
+	// Health, Resources, Lerd) have nothing to select, so j/k scrolls them.
 	if m.activeTab == tabDashboard {
+		if zones := m.dashZones[m.dashFocus]; len(zones) > 0 {
+			m.dashRowCursor[m.dashFocus] = clamp(m.dashRowCursor[m.dashFocus]+delta, 0, len(zones)-1)
+			return
+		}
 		m.dashScroll[m.dashFocus] += delta
 		if m.dashScroll[m.dashFocus] < 0 {
 			m.dashScroll[m.dashFocus] = 0
@@ -1449,6 +1498,11 @@ func (m *Model) setCursor(pos int) {
 func (m *Model) clampCursors() {
 	m.siteCursor = clamp(m.siteCursor, 0, max(0, len(m.visibleSites())-1))
 	m.svcCursor = clamp(m.svcCursor, 0, max(0, len(m.visibleServices())-1))
+	// Keep each dashboard card's row cursor within the rows it had at the last
+	// render; the next render rebuilds dashZones and re-clamps as needed.
+	for i := range m.dashRowCursor {
+		m.dashRowCursor[i] = clamp(m.dashRowCursor[i], 0, max(0, len(m.dashZones[i])-1))
+	}
 }
 
 // visibleSites is the view-ready sites list: m.snap.Sites with the active

--- a/internal/tui/panes.go
+++ b/internal/tui/panes.go
@@ -329,6 +329,32 @@ func siteHasFailingWorker(s siteinfo.EnrichedSite) bool {
 	return false
 }
 
+// footChip is one footer key-hint. action=true colours the key amber (it
+// mutates state); otherwise it's accent-coloured navigation/view.
+type footChip struct {
+	key    string
+	label  string
+	action bool
+}
+
+func nav(key, label string) footChip { return footChip{key, label, false} }
+func act(key, label string) footChip { return footChip{key, label, true} }
+
+// renderFootChips joins coloured key-hints with dim dot separators and clips
+// the result to the window width.
+func (m *Model) renderFootChips(chips []footChip) string {
+	parts := make([]string, len(chips))
+	for i, c := range chips {
+		keyStyle := footNavKeyStyle
+		if c.action {
+			keyStyle = footActionKeyStyle
+		}
+		parts[i] = keyStyle.Render(c.key) + " " + footLabelStyle.Render(c.label)
+	}
+	sep := footLabelStyle.Render("  ·  ")
+	return clipLine("  "+strings.Join(parts, sep), m.width)
+}
+
 func (m *Model) renderFooter() string {
 	if m.filterActive {
 		return helpStyle.Render("  filter: type to match · enter apply · esc clear")
@@ -336,24 +362,34 @@ func (m *Model) renderFooter() string {
 
 	// Narrow terminals only have room for the essentials; `?` reveals the rest.
 	if m.width < narrowWidth {
-		return helpStyle.Render("  " + strings.Join([]string{
-			"ctrl+←→ tabs", "↑↓ nav", "space toggle", "? help", "q quit",
-		}, "  ·  "))
+		return m.renderFootChips([]footChip{
+			nav("ctrl+←→", "tabs"), nav("↑↓", "nav"), act("space", "toggle"), nav("?", "help"), act("q", "quit"),
+		})
 	}
 
 	// Context-aware: each tab shows only the keys that act on it, so the bar
 	// reads as a relevant cheat-sheet rather than a wall of every binding.
-	var keys []string
+	var chips []footChip
 	switch m.activeTab {
 	case tabDashboard:
-		keys = []string{"ctrl+←→ tabs", "↑↓ scroll", "tab card", "click open", "H heal", "? help", "q quit"}
+		chips = []footChip{
+			nav("ctrl+←→", "tabs"), nav("↑↓", "nav"), nav("tab", "card"), nav("enter", "open"),
+			act("H", "heal"), nav("?", "help"), act("q", "quit"),
+		}
 	case tabServices:
-		keys = []string{"ctrl+←→ tabs", "↑↓ nav", "/ filter", "s start", "x stop", "r restart", "u update", "b rollback", "t shell", "O open", "? help", "q quit"}
+		chips = []footChip{
+			nav("ctrl+←→", "tabs"), nav("↑↓", "nav"), nav("/", "filter"),
+			act("s", "start"), act("x", "stop"), act("r", "restart"), act("u", "update"), act("b", "rollback"),
+			act("t", "shell"), act("O", "open"), nav("?", "help"), act("q", "quit"),
+		}
 	default: // tabSites
-		keys = []string{"ctrl+←→ tabs", "tab panes", "↑↓ nav", "space toggle", "/ filter", "s start", "x stop", "r restart", "l logs", "t shell", "S settings", "Y system", "D debug", "? help", "q quit"}
+		chips = []footChip{
+			nav("ctrl+←→", "tabs"), nav("tab", "panes"), nav("↑↓", "nav"), act("space", "toggle"), nav("/", "filter"),
+			act("s", "start"), act("x", "stop"), act("r", "restart"), nav("l", "logs"), act("t", "shell"),
+			nav("S", "settings"), nav("Y", "system"), nav("D", "debug"), nav("?", "help"), act("q", "quit"),
+		}
 	}
-	// Clip to the window so a long bar can't overflow and break the layout.
-	return helpStyle.Render(clipLine("  "+strings.Join(keys, "  ·  "), m.width))
+	return m.renderFootChips(chips)
 }
 
 func (m *Model) renderStatus() string {
@@ -899,8 +935,10 @@ func renderScrollbar(height, total, start, visible int) []string {
 		return out
 	}
 	if total <= visible || total == 0 {
+		// Nothing to scroll: leave the column blank rather than drawing a full
+		// track, which otherwise reads as a stray second border inside the box.
 		for i := range out {
-			out[i] = dimStyle.Render("│")
+			out[i] = " "
 		}
 		return out
 	}

--- a/internal/tui/services_detail_focus_test.go
+++ b/internal/tui/services_detail_focus_test.go
@@ -1,0 +1,38 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+// TestDetailPane_ServicesTabShowsServiceEvenWhenDetailFocused guards the
+// regression where moving focus onto the detail pane on the Services tab fell
+// through to rendering the carried-over site's detail instead of the selected
+// service.
+func TestDetailPane_ServicesTabShowsServiceEvenWhenDetailFocused(t *testing.T) {
+	m := NewModel("test")
+	m.snap = Snapshot{
+		Sites: []siteinfo.EnrichedSite{
+			{Name: "alpha", Domains: []string{"alpha.test"}, PHPVersion: "8.3"},
+		},
+		Services: []ServiceRow{
+			{Name: "mysql", State: stateRunning, SiteCount: 1},
+		},
+		Status: StatusRow{TLD: "test"},
+	}
+	m.activeTab = tabServices
+	m.detailMode = detailSite
+	m.focus = paneDetail // focus moved off the list onto the detail pane
+	m.siteCursor = 0
+	m.svcCursor = 0
+
+	out := stripANSI(m.renderDetailInline(80, 24, true))
+	if strings.Contains(out, "alpha.test") {
+		t.Fatalf("Services tab detail pane should not render the hidden site:\n%s", out)
+	}
+	if !strings.Contains(out, "mysql") {
+		t.Fatalf("Services tab detail pane should render the selected service:\n%s", out)
+	}
+}

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -35,13 +35,25 @@ var (
 	helpStyle      = lipgloss.NewStyle().Foreground(colDim)
 )
 
+// Footer key-hint styles. Navigation/view keys stay in the main accent colour
+// so movement reads as one family; keys that act on something (start, stop,
+// toggle, heal, …) are amber so destructive/mutating shortcuts stand apart at
+// a glance. Labels stay dim so the coloured key is what the eye catches.
+var (
+	footNavKeyStyle    = lipgloss.NewStyle().Foreground(colAccent).Bold(true)
+	footActionKeyStyle = lipgloss.NewStyle().Foreground(colPaused).Bold(true)
+	footLabelStyle     = lipgloss.NewStyle().Foreground(colDim)
+)
+
 // Top tab bar styles. The active tab reads as a filled accent pill so it
 // stands out as the current screen; inactive tabs sit dim until hovered or
 // clicked. Both keep the same padding so the bar's hit regions line up.
 var (
 	tabActiveStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#0b0b0b")).Background(colAccent).Padding(0, 2)
 	tabInactiveStyle = lipgloss.NewStyle().Foreground(colDim).Padding(0, 2)
-	tabBarStyle      = lipgloss.NewStyle().Padding(0, 1)
+	// A blank row above the tabs keeps the active pill off the terminal's own
+	// top chrome (tmux/term tab line) instead of butting right against it.
+	tabBarStyle = lipgloss.NewStyle().Padding(1, 1, 0, 1)
 )
 
 // cardStyle is the bordered box every dashboard grid card draws inside. It

--- a/internal/ui/web/src/components/MonacoEditor.svelte
+++ b/internal/ui/web/src/components/MonacoEditor.svelte
@@ -29,7 +29,10 @@
   }: Props = $props();
 
   let container: HTMLDivElement | undefined = $state();
-  let editor: Monaco.editor.IStandaloneCodeEditor | undefined;
+  // $state so the value-mirroring $effect below re-runs once the async monaco
+  // load assigns the editor, reconciling any value change that arrived while
+  // the module was still loading.
+  let editor: Monaco.editor.IStandaloneCodeEditor | undefined = $state();
   // Guards external value writes from looping back through onChange.
   let internalUpdate = false;
   let disposed = false;

--- a/internal/ui/web/src/lib/lsp.ts
+++ b/internal/ui/web/src/lib/lsp.ts
@@ -560,7 +560,12 @@ export function attachPhpLsp(opts: {
     dispose() {
       disposed = true;
       for (const d of disposables) d.dispose();
-      for (const p of pending.values()) clearTimeout(p.timer);
+      // Reject in-flight requests (not just clear their timers): a provider
+      // awaiting one would otherwise hang on a promise that never settles.
+      for (const p of pending.values()) {
+        clearTimeout(p.timer);
+        p.reject(new Error('lsp disposed'));
+      }
       pending.clear();
       const model = editor.getModel();
       if (model) monaco.editor.setModelMarkers(model, 'phpantom', []);

--- a/internal/ui/ws.go
+++ b/internal/ui/ws.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -97,6 +98,31 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 	}
 	defer ws.Close()
 
+	// All frame writes funnel through these helpers: the reader goroutine
+	// writes pong/close frames while the main loop writes snapshots and pings,
+	// and the hand-rolled wsConn is not write-safe.
+	var writeMu sync.Mutex
+	sendText := func(b []byte) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return ws.WriteText(b)
+	}
+	sendPing := func() error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return ws.WritePing(nil)
+	}
+	sendPong := func(b []byte) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return ws.WritePong(b)
+	}
+	sendClose := func() error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return ws.WriteClose()
+	}
+
 	ch := broker.add()
 	defer broker.remove(ch)
 
@@ -122,7 +148,7 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 		nil,
 		[]string{"snapshot"},
 	)
-	if err := ws.WriteText(initial); err != nil {
+	if err := sendText(initial); err != nil {
 		return
 	}
 
@@ -155,13 +181,13 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 			}
 			switch op {
 			case wsOpPing:
-				if err := ws.WritePong(payload); err != nil {
+				if err := sendPong(payload); err != nil {
 					return
 				}
 			case wsOpPong:
 				// Client responded to our ping; loop body resets the deadline.
 			case wsOpClose:
-				_ = ws.WriteClose()
+				_ = sendClose()
 				return
 			case wsOpText:
 				var msg struct {
@@ -186,11 +212,11 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			frame := assembleSnapshot(msg.Sites, msg.Services, msg.Status, msg.UnhealthyWorkers, msg.DumpsStatus, msg.DevtoolsStatus, msg.ProfilerStatus, msg.Notification, msg.Kinds)
-			if err := ws.WriteText(frame); err != nil {
+			if err := sendText(frame); err != nil {
 				return
 			}
 		case <-pingTicker.C:
-			if err := ws.WritePing(nil); err != nil {
+			if err := sendPing(); err != nil {
 				return
 			}
 		case <-done:

--- a/internal/ui/ws_origin_test.go
+++ b/internal/ui/ws_origin_test.go
@@ -1,0 +1,36 @@
+package ui
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestWSOriginAllowed(t *testing.T) {
+	cases := []struct {
+		name   string
+		host   string
+		origin string
+		want   bool
+	}{
+		{"no origin (non-browser client)", "localhost:7073", "", true},
+		{"allowlisted localhost", "localhost:7073", "http://localhost:7073", true},
+		{"allowlisted lerd.localhost", "lerd.localhost", "http://lerd.localhost", true},
+		{"same-origin custom domain", "myapp.test", "http://myapp.test", true},
+		{"same-origin LAN ip", "192.168.1.10:7073", "http://192.168.1.10:7073", true},
+		{"cross-site hijack attempt", "localhost:7073", "http://evil.example", false},
+		{"foreign origin same path", "myapp.test", "https://attacker.test", false},
+		{"malformed origin", "localhost:7073", "::::not a url", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _ := http.NewRequest("GET", "http://"+tc.host+"/api/lsp/php", nil)
+			r.Host = tc.host
+			if tc.origin != "" {
+				r.Header.Set("Origin", tc.origin)
+			}
+			if got := wsOriginAllowed(r); got != tc.want {
+				t.Fatalf("wsOriginAllowed(host=%q, origin=%q) = %v, want %v", tc.host, tc.origin, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ui/wsframe.go
+++ b/internal/ui/wsframe.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -38,9 +39,33 @@ type wsConn struct {
 	br   *bufio.Reader
 }
 
+// wsOriginAllowed defends against cross-site WebSocket hijacking: browsers
+// don't apply CORS to the WS handshake, so without this an arbitrary page
+// could open a socket to the dashboard. A missing Origin means a non-browser
+// client (lerd's own tools, curl), which isn't a hijack vector. Otherwise the
+// Origin must be in the CORS allowlist or be same-origin with the request Host,
+// which keeps custom-domain and LAN access working.
+func wsOriginAllowed(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	if allowedCORSOrigins[origin] {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return u.Host == r.Host
+}
+
 // wsUpgrade performs the RFC6455 handshake and returns a wsConn ready for
 // ReadFrame / WriteText. The http.ResponseWriter must support Hijack.
 func wsUpgrade(w http.ResponseWriter, r *http.Request) (*wsConn, error) {
+	if !wsOriginAllowed(r) {
+		return nil, errors.New("websocket origin not allowed")
+	}
 	if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
 		return nil, errors.New("missing Upgrade: websocket header")
 	}

--- a/internal/watcher/dns.go
+++ b/internal/watcher/dns.go
@@ -110,10 +110,35 @@ func defaultRepairExposeMapping(tld string) (bool, error) {
 	if err := dns.WriteDnsmasqConfig(config.DnsmasqDir()); err != nil {
 		return false, err
 	}
-	if after, _ := os.ReadFile(confPath); bytes.Equal(before, after) {
+	after, _ := os.ReadFile(confPath)
+	if !exposeConfigChanged(before, after) {
 		return false, nil
 	}
 	return true, podman.RestartUnit("lerd-dns")
+}
+
+// exposeConfigChanged reports whether the rendered dnsmasq config changed in a
+// way that warrants restarting lerd-dns. A change confined to the AAAA (IPv6)
+// address lines is ignored: a global v6 coming and going, or a privacy address
+// rotating, would otherwise restart lerd-dns on every tick, while v4 is what
+// LAN clients overwhelmingly rely on. The new config is still written to disk,
+// so a later v4 drift or a fresh setup picks up the current AAAA.
+func exposeConfigChanged(before, after []byte) bool {
+	return !bytes.Equal(stripAAAALines(before), stripAAAALines(after))
+}
+
+// stripAAAALines drops the IPv6 `address=/.test/<v6>` lines (those whose target
+// contains a colon) so AAAA-only drift compares equal.
+func stripAAAALines(conf []byte) []byte {
+	lines := strings.Split(string(conf), "\n")
+	kept := lines[:0]
+	for _, ln := range lines {
+		if strings.HasPrefix(ln, "address=/") && strings.Contains(ln[strings.LastIndex(ln, "/")+1:], ":") {
+			continue
+		}
+		kept = append(kept, ln)
+	}
+	return []byte(strings.Join(kept, "\n"))
 }
 
 // linkChangeDebounce caps how long the netlink burst from a single VPN
@@ -180,14 +205,49 @@ func WatchDNS(interval time.Duration, tld string) {
 
 	linkRaw := make(chan struct{}, 32)
 	linkSettled := make(chan struct{}, 4)
-	go func() {
-		if err := dns.LinkChanges(linkRaw, done); err != nil {
-			logger.Warn("host network change watcher unavailable, DNS reacts on the safety-net poll only", "err", err)
-		}
-	}()
+	go superviseLinkChanges(dns.LinkChanges, linkRaw, done, linkChangeBackoff)
 	go dns.DebounceEvents(linkRaw, linkSettled, linkChangeDebounce, done)
 
 	runDNSLoop(deps, state, tld, ticker.C, linkSettled, done)
+}
+
+// linkChangeBackoff is the capped exponential delay before restarting the
+// host-network-change watcher after a transient error: 1s, 2s, 4s … up to 30s.
+func linkChangeBackoff(attempt int) time.Duration {
+	d := time.Second << attempt
+	if d <= 0 || d > 30*time.Second {
+		d = 30 * time.Second
+	}
+	return d
+}
+
+// superviseLinkChanges keeps dns.LinkChanges alive: when it returns an error
+// before done closes (a transient netlink/route socket failure) it restarts it
+// after a backoff, so the watcher doesn't go permanently deaf to host network
+// changes and fall back to the safety-net poll for the rest of the daemon's
+// life. It returns once done is closed or LinkChanges returns nil (a clean
+// shutdown, or an unsupported platform that simply waits on done).
+func superviseLinkChanges(fn func(chan<- struct{}, <-chan struct{}) error,
+	out chan<- struct{}, done <-chan struct{}, backoff func(int) time.Duration) {
+
+	for attempt := 0; ; attempt++ {
+		err := fn(out, done)
+		select {
+		case <-done:
+			return
+		default:
+		}
+		if err == nil {
+			return
+		}
+		logger.Warn("host network change watcher errored, restarting; DNS reacts on the safety-net poll meanwhile",
+			"err", err, "attempt", attempt+1)
+		select {
+		case <-time.After(backoff(attempt)):
+		case <-done:
+			return
+		}
+	}
 }
 
 // runDNSLoop runs the tick state machine: an immediate first probe, then

--- a/internal/watcher/dns_test.go
+++ b/internal/watcher/dns_test.go
@@ -548,3 +548,88 @@ func deref(p *bool) any {
 	}
 	return *p
 }
+
+func TestSuperviseLinkChanges_RestartsOnTransientError(t *testing.T) {
+	done := make(chan struct{})
+	defer close(done)
+
+	calls := make(chan int, 8)
+	var n int
+	fn := func(out chan<- struct{}, d <-chan struct{}) error {
+		n++
+		calls <- n
+		if n < 3 {
+			return errors.New("transient netlink failure")
+		}
+		<-d // the third attempt stays up until shutdown
+		return nil
+	}
+
+	go superviseLinkChanges(fn, make(chan struct{}, 1), done, func(int) time.Duration { return 0 })
+
+	// We expect three attempts: two that error and restart, one that sticks.
+	for want := 1; want <= 3; want++ {
+		select {
+		case got := <-calls:
+			if got != want {
+				t.Fatalf("attempt %d, want %d", got, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("attempt %d never happened", want)
+		}
+	}
+}
+
+func TestSuperviseLinkChanges_StopsAfterDone(t *testing.T) {
+	done := make(chan struct{})
+	close(done) // already shutting down
+
+	var n int
+	fn := func(out chan<- struct{}, d <-chan struct{}) error {
+		n++
+		return errors.New("read after shutdown")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		superviseLinkChanges(fn, make(chan struct{}, 1), done, func(int) time.Duration { return 0 })
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("supervisor did not return after done was closed")
+	}
+	if n != 1 {
+		t.Fatalf("expected exactly one attempt with done closed, got %d", n)
+	}
+}
+
+func TestExposeConfigChanged_IgnoresAAAAOnlyDrift(t *testing.T) {
+	base := "# Lerd DNS configuration\nport=5300\nno-resolv\nserver=1.1.1.1\naddress=/.test/192.168.1.5\n"
+	withV6 := base + "address=/.test/2001:db8::1\n"
+	withOtherV6 := base + "address=/.test/2001:db8::2\n"
+
+	// A v6 address appearing, rotating, or disappearing must not trigger a restart.
+	if exposeConfigChanged([]byte(base), []byte(withV6)) {
+		t.Fatal("adding an AAAA record should not warrant a restart")
+	}
+	if exposeConfigChanged([]byte(withV6), []byte(withOtherV6)) {
+		t.Fatal("rotating the AAAA record should not warrant a restart")
+	}
+	if exposeConfigChanged([]byte(withV6), []byte(base)) {
+		t.Fatal("dropping the AAAA record should not warrant a restart")
+	}
+
+	// A v4 drift (the real LAN IP change) must still trigger a restart.
+	v4Changed := "# Lerd DNS configuration\nport=5300\nno-resolv\nserver=1.1.1.1\naddress=/.test/192.168.1.9\n"
+	if !exposeConfigChanged([]byte(base), []byte(v4Changed)) {
+		t.Fatal("a v4 address change must warrant a restart")
+	}
+	// An upstream change must still trigger a restart.
+	upstreamChanged := "# Lerd DNS configuration\nport=5300\nno-resolv\nserver=8.8.8.8\naddress=/.test/192.168.1.5\n"
+	if !exposeConfigChanged([]byte(base), []byte(upstreamChanged)) {
+		t.Fatal("an upstream change must warrant a restart")
+	}
+}


### PR DESCRIPTION
Closes #597.

A review of the changes since v1.25.0 turned up a handful of real regressions, which this fixes, and then grows the TUI dashboard into something you can drive from the keyboard.

The TUI domain actions were only gated by detail focus and mode, so on the Services tab they could act on the hidden carried-over site. They are now gated to the Sites tab, and the Services detail pane renders the selected service whenever that tab is active. The websocket upgrade gained an Origin check so the new phpantom LSP endpoint can't be driven cross-site, and the broadcast handler now serialises its writes through a mutex. The feedback spinner snapshots its animated state at start so a colour-mode flip can't close a nil channel or leak the goroutine, a step now routes warnings through the same interrupt path as a live line, and the active line is cleared only after the spinner stops. The DNS link-change watcher restarts with backoff instead of falling back to the poll forever, LAN mode no longer publishes a loopback AAAA, and the expose healer ignores AAAA-only drift so a flapping IPv6 address won't restart lerd-dns each tick. On the web side the Monaco editor reconciles a value change that lands during its async load, and the LSP client rejects in-flight requests on dispose.

The dashboard then becomes navigable: the Sites, Services and Workers cards move a row cursor with the arrows and a caret marks the selection, info-only cards still scroll, and enter opens the selected row exactly like a click through a shared activation path. The footer colour-codes navigation and view keys in the accent colour and state-changing actions in amber, the cards sit flush instead of floating apart, the phantom scrollbar track is gone, right-aligned labels get a column of breathing room before the scrollbar, and a blank row sits above the tab strip.