### PR TITLE
Post-1.25: navigable TUI dashboard, unified CLI output, and review fixes

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
 	"github.com/geodro/lerd/internal/eventbus"
+	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/nginx"
 	nodeDet "github.com/geodro/lerd/internal/node"
@@ -61,6 +62,10 @@ func main() {
 		Use:     "lerd",
 		Short:   "Lerd — Podman-powered local PHP dev environment for Linux and macOS",
 		Version: version.String(),
+		// Errors are printed once below: a command that already surfaced its
+		// failure through the feedback UI (a red ✗ line) is suppressed here so
+		// cobra doesn't reprint the same message as a second "Error: …" line.
+		SilenceErrors: true,
 	}
 
 	// Register all subcommands
@@ -201,6 +206,11 @@ func main() {
 	maybeDispatchVendorBin(root)
 
 	if err := root.Execute(); err != nil {
+		// Only print errors the command didn't already show the user via a
+		// feedback Fail line, so the same failure never appears twice.
+		if !feedback.AlreadyShown(err) {
+			fmt.Fprintf(os.Stderr, "\nError: %s\n\n", err.Error())
+		}
 		os.Exit(1)
 	}
 }

--- a/internal/cli/build_ui.go
+++ b/internal/cli/build_ui.go
@@ -38,7 +38,10 @@ func RunParallel(jobs []BuildJob) error {
 func runSequential(jobs []BuildJob) error {
 	var firstErr error
 	for _, job := range jobs {
-		fmt.Printf("==> %s\n", job.Label)
+		// Non-TTY path: announce the label BEFORE the job runs so it heads the
+		// job's streamed output. feedback.Start is non-animated here and prints
+		// nothing until OK/Fail, which would leave the label trailing its output.
+		feedback.Line(job.Label)
 		if err := job.Run(os.Stdout); err != nil {
 			feedback.Warn("%s: %v", job.Label, err)
 			if firstErr == nil {
@@ -172,6 +175,7 @@ func runParallelTUI(jobs []BuildJob) error {
 			fmt.Fprintf(&sb, "\033[%dA\033[J", prevLines)
 		}
 		lines := 0
+		lw := maxLabelWidth(states)
 
 		for _, s := range states {
 			done, err, end, _ := s.snapshot()
@@ -185,19 +189,19 @@ func runParallelTUI(jobs []BuildJob) error {
 			var icon string
 			switch {
 			case done && err != nil:
-				icon = "\033[31m✗\033[0m"
+				icon = feedback.Red("✗")
 			case done:
-				icon = "\033[32m✓\033[0m"
+				icon = feedback.Green("✓")
 			default:
-				icon = "\033[33m" + string(spinnerFrames[frame%len(spinnerFrames)]) + "\033[0m"
+				icon = feedback.Amber(string(spinnerFrames[frame%len(spinnerFrames)]))
 			}
 
 			if elapsed >= time.Second {
 				mins := int(elapsed.Minutes())
 				secs := int(elapsed.Seconds()) % 60
-				fmt.Fprintf(&sb, "  %s  %-26s  %02d:%02d\r\n", icon, s.label, mins, secs)
+				fmt.Fprintf(&sb, " %s %-*s  %02d:%02d\r\n", icon, lw, s.label, mins, secs)
 			} else {
-				fmt.Fprintf(&sb, "  %s  %-26s\r\n", icon, s.label)
+				fmt.Fprintf(&sb, " %s %s\r\n", icon, s.label)
 			}
 			lines++
 		}
@@ -207,7 +211,7 @@ func runParallelTUI(jobs []BuildJob) error {
 			if show {
 				hint = "Ctrl+O: hide output"
 			}
-			fmt.Fprintf(&sb, "  \033[2m%s\033[0m\r\n", hint)
+			fmt.Fprintf(&sb, "  %s\r\n", feedback.Dim(hint))
 			lines++
 		}
 
@@ -217,7 +221,7 @@ func runParallelTUI(jobs []BuildJob) error {
 				if len(out) == 0 {
 					continue
 				}
-				fmt.Fprintf(&sb, "  \033[2m─── %s ───\033[0m\r\n", s.label)
+				fmt.Fprintf(&sb, "  %s\r\n", feedback.Dim("─── "+s.label+" ───"))
 				lines++
 				for _, l := range strings.Split(tailLines(out, 20, termWidth-4), "\n") {
 					fmt.Fprintf(&sb, "  %s\r\n", l)
@@ -248,9 +252,9 @@ func runParallelTUI(jobs []BuildJob) error {
 					if firstErr == nil {
 						firstErr = err
 					}
-					fmt.Printf("\033[31m✗ %s:\033[0m %v\n", s.label, err)
+					fmt.Printf("%s %v\n", feedback.Red("✗ "+s.label+":"), err)
 					if len(out) > 0 {
-						fmt.Printf("  \033[2m─── output ───\033[0m\n%s\n", out)
+						fmt.Printf("  %s\n%s\n", feedback.Dim("─── output ───"), out)
 					}
 				}
 			}
@@ -355,12 +359,12 @@ func NewStepRunner() *StepRunner {
 // while running and ✓/✗ when done. Returns fn's error.
 func (r *StepRunner) Run(label string, fn func(w io.Writer) error) error {
 	if !r.isTTY {
-		fmt.Printf("  --> %s ... ", label)
+		s := feedback.Start(label)
 		err := fn(io.Discard)
 		if err != nil {
-			fmt.Printf("[WARN: %v]\n", err)
+			s.Fail(err)
 		} else {
-			fmt.Println("OK")
+			s.OK("")
 		}
 		return err
 	}
@@ -380,10 +384,10 @@ func (r *StepRunner) Run(label string, fn func(w io.Writer) error) error {
 // The spinner pauses, the step runs with full terminal access, then raw mode resumes.
 func (r *StepRunner) RunInteractive(label string, fn func() error) error {
 	if !r.isTTY {
-		fmt.Printf("  --> %s\n", label)
+		feedback.Line(label)
 		err := fn()
 		if err != nil {
-			fmt.Printf("  [WARN: %v]\n", err)
+			feedback.Warn("%v", err)
 		}
 		return err
 	}
@@ -398,10 +402,10 @@ func (r *StepRunner) RunInteractive(label string, fn func() error) error {
 		r.stdinDup = nil
 	}
 
-	fmt.Printf("  --> %s\n", label)
+	feedback.Line(label)
 	err := fn()
 	if err != nil {
-		fmt.Printf("  [WARN: %v]\n", err)
+		feedback.Warn("%v", err)
 	}
 
 	if oldState, rawErr := term.MakeRaw(int(os.Stdin.Fd())); rawErr == nil {
@@ -440,6 +444,7 @@ func (r *StepRunner) renderSteps(prevLines, frame int, final bool) (int, int) {
 		fmt.Fprintf(&sb, "\033[%dA\033[J", prevLines)
 	}
 	lines := 0
+	lw := maxLabelWidth(steps)
 
 	for _, s := range steps {
 		done, err, end, _ := s.snapshot()
@@ -452,19 +457,19 @@ func (r *StepRunner) renderSteps(prevLines, frame int, final bool) (int, int) {
 		var icon string
 		switch {
 		case done && err != nil:
-			icon = "\033[31m✗\033[0m"
+			icon = feedback.Red("✗")
 		case done:
-			icon = "\033[32m✓\033[0m"
+			icon = feedback.Green("✓")
 		default:
-			icon = "\033[33m" + string(spinnerFrames[frame%len(spinnerFrames)]) + "\033[0m"
+			icon = feedback.Amber(string(spinnerFrames[frame%len(spinnerFrames)]))
 		}
 
 		if elapsed >= time.Second {
 			mins := int(elapsed.Minutes())
 			secs := int(elapsed.Seconds()) % 60
-			fmt.Fprintf(&sb, "  %s  %-32s  %02d:%02d\r\n", icon, s.label, mins, secs)
+			fmt.Fprintf(&sb, " %s %-*s  %02d:%02d\r\n", icon, lw, s.label, mins, secs)
 		} else {
-			fmt.Fprintf(&sb, "  %s  %-32s\r\n", icon, s.label)
+			fmt.Fprintf(&sb, " %s %s\r\n", icon, s.label)
 		}
 		lines++
 	}
@@ -474,7 +479,7 @@ func (r *StepRunner) renderSteps(prevLines, frame int, final bool) (int, int) {
 		if show {
 			hint = "Ctrl+O: hide output"
 		}
-		fmt.Fprintf(&sb, "  \033[2m%s\033[0m\r\n", hint)
+		fmt.Fprintf(&sb, "  %s\r\n", feedback.Dim(hint))
 		lines++
 	}
 
@@ -484,7 +489,7 @@ func (r *StepRunner) renderSteps(prevLines, frame int, final bool) (int, int) {
 			if len(out) == 0 {
 				continue
 			}
-			fmt.Fprintf(&sb, "  \033[2m─── %s ───\033[0m\r\n", s.label)
+			fmt.Fprintf(&sb, "  %s\r\n", feedback.Dim("─── "+s.label+" ───"))
 			lines++
 			for _, l := range strings.Split(tailLines(out, 20, r.termWidth-4), "\n") {
 				fmt.Fprintf(&sb, "  %s\r\n", l)
@@ -495,6 +500,23 @@ func (r *StepRunner) renderSteps(prevLines, frame int, final bool) (int, int) {
 
 	fmt.Print(sb.String())
 	return lines, frame + 1
+}
+
+// maxLabelWidth returns the longest label across states (rune count), capped so
+// one very long label can't push the timing column off the right edge. Used to
+// align the timing column without over-padding short labels into a ragged run
+// of trailing whitespace.
+func maxLabelWidth(states []*jobState) int {
+	w := 0
+	for _, s := range states {
+		if n := len([]rune(s.label)); n > w {
+			w = n
+		}
+	}
+	if w > 40 {
+		w = 40
+	}
+	return w
 }
 
 // tailLines returns the last n lines of b, truncated to maxWidth chars each.

--- a/internal/cli/capture_stderr_test.go
+++ b/internal/cli/capture_stderr_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// runCapturingStdout must capture stderr as well as stdout: subprocesses (npm,
+// vite, mysql) write warnings to stderr, and a leaked stderr line clobbers the
+// live spinner the setup loop animates on the real stdout.
+func TestRunCapturingStdout_CapturesStderr(t *testing.T) {
+	out, err := runCapturingStdout(func() error {
+		fmt.Fprint(os.Stdout, "on-stdout ")
+		fmt.Fprint(os.Stderr, "on-stderr")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "on-stdout") {
+		t.Errorf("captured = %q, missing stdout", got)
+	}
+	if !strings.Contains(got, "on-stderr") {
+		t.Errorf("captured = %q, missing stderr (it would leak past the spinner)", got)
+	}
+}
+
+// A bare service entry whose name is a bundled tool preset (phpmyadmin, pgadmin)
+// must be resolvable as a preset, while default presets (mysql, redis) must not
+// be — they are built-in and handled separately.
+func TestBundledToolPresetGate(t *testing.T) {
+	if !config.PresetExists("phpmyadmin") || config.IsDefaultPreset("phpmyadmin") {
+		t.Error("phpmyadmin should be a non-default bundled preset (resolvable as a preset)")
+	}
+	if config.PresetExists("mysql") && !config.IsDefaultPreset("mysql") {
+		t.Error("mysql is a default preset and must be excluded from tool-preset resolution")
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -40,21 +40,16 @@ func runDoctor(_ *cobra.Command, _ []string) error {
 // safe to embed in a plain-text file (used by `lerd bug-report`). Returns
 // the failure and warning counts for callers that want to summarise.
 func RunDoctorTo(w io.Writer, useColor bool) (fails, warns int, err error) {
-	cR, cG, cY, cReset := colorRed, colorGreen, colorYellow, colorReset
-	if !useColor {
-		cR, cG, cY, cReset = "", "", "", ""
-	}
-
 	ok := func(label string) {
-		fmt.Fprintf(w, "  %s✓%s %s\n", cG, cReset, label)
+		fmt.Fprintf(w, "  %s %s\n", feedback.GreenIf(useColor, feedback.GlyphOK), label)
 	}
 	fail := func(label, msg, hint string) {
 		fails++
-		fmt.Fprintf(w, "  %s✗%s %s  %s\n    hint: %s\n", cR, cReset, label, msg, hint)
+		fmt.Fprintf(w, "  %s %s  %s\n    hint: %s\n", feedback.RedIf(useColor, feedback.GlyphFail), label, msg, hint)
 	}
 	warn := func(label, msg string) {
 		warns++
-		fmt.Fprintf(w, "  %s⚠%s %s  %s\n", cY, cReset, label, msg)
+		fmt.Fprintf(w, "  %s %s  %s\n", feedback.AmberIf(useColor, feedback.GlyphWarn), label, msg)
 	}
 	info := func(label, val string) {
 		fmt.Fprintf(w, "  %-34s %s\n", label, val)
@@ -403,13 +398,13 @@ func RunDoctorTo(w io.Writer, useColor bool) (fails, warns int, err error) {
 	fmt.Fprintln(w, "\n══════════════════════════════════════════════")
 	switch {
 	case fails > 0 && warns > 0:
-		fmt.Fprintf(w, "%s%d failure(s), %d warning(s) found.%s\n", cR, fails, warns, cReset)
+		fmt.Fprintln(w, feedback.RedIf(useColor, fmt.Sprintf("%d failure(s), %d warning(s) found.", fails, warns)))
 	case fails > 0:
-		fmt.Fprintf(w, "%s%d failure(s) found.%s\n", cR, fails, cReset)
+		fmt.Fprintln(w, feedback.RedIf(useColor, fmt.Sprintf("%d failure(s) found.", fails)))
 	case warns > 0:
-		fmt.Fprintf(w, "%s%d warning(s) found.%s  All critical checks passed.\n", cY, warns, cReset)
+		fmt.Fprintf(w, "%s  All critical checks passed.\n", feedback.AmberIf(useColor, fmt.Sprintf("%d warning(s) found.", warns)))
 	default:
-		fmt.Fprintf(w, "%sAll checks passed.%s\n", cG, cReset)
+		fmt.Fprintln(w, feedback.GreenIf(useColor, "All checks passed."))
 	}
 
 	return fails, warns, nil

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -168,6 +168,7 @@ func NewEnvCmd() *cobra.Command {
   - Starts any referenced services that are not already running
   - Generates APP_KEY if missing
   - Sets APP_URL to the registered .test domain`,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// --verbose (and any non-animated output, e.g. the MCP server or a
 			// pipe) prints the full per-step detail. An interactive terminal gets

--- a/internal/cli/env_reentrant_test.go
+++ b/internal/cli/env_reentrant_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/geodro/lerd/internal/feedback"
@@ -27,5 +28,28 @@ func TestRunEnvLive_RestoresPreviousLive(t *testing.T) {
 	}
 	if envLive != sentinel {
 		t.Errorf("runEnvLive left envLive = %v, want the previous live line restored", envLive)
+	}
+}
+
+// On the animated path runEnvLive shows the failure through live.Fail, which
+// marks the error as already shown so the top-level handler in main doesn't
+// reprint it as a second "Error: …" line. Verify the returned error is flagged
+// AlreadyShown, and that a non-nil error still propagates for the non-zero exit.
+func TestEnvCmd_AnimatedFailureIsMarkedAlreadyShown(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+
+	var buf bytes.Buffer
+	defer feedback.SetTestWriter(&buf)()
+	defer feedback.SetAnimated(true)()
+
+	cmd := NewEnvCmd()
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected an error running env in an unlinked, non-interactive dir")
+	}
+	if !feedback.AlreadyShown(err) {
+		t.Error("env animated failure was not marked AlreadyShown; main will reprint the error")
 	}
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -480,6 +480,13 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 			}
 			continue
 		}
+		// A bundled tool preset (e.g. phpmyadmin, pgadmin) selected but not yet
+		// installed has no on-disk custom service; record it as a preset so link
+		// installs it, rather than a bare name that resolves to nothing and warns.
+		if loaded == nil && config.PresetExists(name) && !config.IsDefaultPreset(name) {
+			services[i] = config.ProjectService{Name: name, Preset: name}
+			continue
+		}
 		services[i] = config.ProjectService{Name: name, Custom: loaded}
 	}
 
@@ -700,6 +707,13 @@ func buildProjectServices(selectedServices []string, defaults *config.ProjectCon
 				Preset:        loaded.Preset,
 				PresetVersion: loaded.PresetVersion,
 			}
+			continue
+		}
+		// A bundled tool preset (e.g. phpmyadmin, pgadmin) selected but not yet
+		// installed has no on-disk custom service; record it as a preset so link
+		// installs it, rather than a bare name that resolves to nothing and warns.
+		if loaded == nil && config.PresetExists(name) && !config.IsDefaultPreset(name) {
+			services[i] = config.ProjectService{Name: name, Preset: name}
 			continue
 		}
 		services[i] = config.ProjectService{Name: name, Custom: loaded}
@@ -1345,19 +1359,24 @@ func applyEnvStep(cwd string) {
 // setup step's verbose output behind a single feedback line, surfacing it only
 // when the step fails.
 func runCapturingStdout(fn func() error) ([]byte, error) {
-	prev := os.Stdout
+	prevOut, prevErr := os.Stdout, os.Stderr
 	r, w, err := os.Pipe()
 	if err != nil {
 		return nil, fn()
 	}
+	// Swap both streams: subprocesses (npm/vite, artisan) write progress and
+	// warnings to stderr too (e.g. Browserslist), and a leaked stderr line would
+	// clobber the live spinner the caller animates on the real stdout.
 	os.Stdout = w
+	os.Stderr = w
 	captured := make(chan []byte, 1)
 	go func() {
 		b, _ := io.ReadAll(r)
 		captured <- b
 	}()
 	runErr := fn()
-	os.Stdout = prev
+	os.Stdout = prevOut
+	os.Stderr = prevErr
 	_ = w.Close()
 	return <-captured, runErr
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -43,8 +43,14 @@ func NewInstallCmd() *cobra.Command {
 	return cmd
 }
 
-func step(label string) { fmt.Printf("  --> %s ... ", label) }
-func ok()               { fmt.Println("OK") }
+// step/ok render one install action in the shared feedback vocabulary: step
+// prints a dim "→ label…" in place (no spinner, so steps that wrap verbose
+// subprocess output don't fight an animation), ok finishes the line with a
+// green check. There's no trailing newline after step, so on the error path a
+// feedback.Warn completes the dangling line as "→ label… ⚠ msg" in place of the
+// check; steps that print multi-line output first emit their own newline.
+func step(label string) { fmt.Printf(" %s %s ", feedback.Dim("→"), feedback.Dim(label+"…")) }
+func ok()               { fmt.Println(feedback.Green("✓")) }
 
 // fileChangedBy runs mutate and reports whether the file at path differs
 // before vs after. A read error on either side is treated as empty content,
@@ -61,7 +67,7 @@ func fileChangedBy(path string, mutate func() error) (bool, error) {
 }
 
 func runInstall(cmd *cobra.Command, _ []string) error {
-	fmt.Println("==> Installing Lerd")
+	feedback.Header("Installing Lerd")
 
 	noIPv6, _ := cmd.Flags().GetBool("no-ipv6")
 	if !noIPv6 && os.Getenv("LERD_DISABLE_IPV6") == "1" {
@@ -71,9 +77,8 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	dnsFlag, _ := cmd.Flags().GetString("dns")
 	if noIPv6 {
 		podman.MarkIPv6Disabled("lerd")
-		fmt.Println("  IPv6 disabled by user; lerd network will be v4-only.")
-		fmt.Printf("  Delete %s and re-run `lerd install` to re-enable.\n",
-			podman.IPv6DisabledMarkerPath("lerd"))
+		feedback.Line("IPv6 disabled by user, lerd network will be v4-only")
+		feedback.Note("delete " + podman.IPv6DisabledMarkerPath("lerd") + " and re-run `lerd install` to re-enable")
 	}
 
 	// Sample LastUp before ensure so an internal stop+start isn't mistaken
@@ -131,11 +136,11 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 				return mErr
 			}
 			if dualStack {
-				fmt.Println("    Recreated lerd network as dual-stack v4+v6.")
+				feedback.Note("recreated lerd network as dual-stack v4+v6")
 			} else {
-				fmt.Println("    Recreated lerd network as v4-only (IPv6 not available for containers).")
+				feedback.Note("recreated lerd network as v4-only (IPv6 not available for containers)")
 			}
-			fmt.Println("    Existing containers on this network were recreated.")
+			feedback.Note("existing containers on this network were recreated")
 			migrated = restored
 			step("Creating lerd podman network")
 		} else {
@@ -172,12 +177,12 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	// and mirrored into the PHP container on setup.
 	bunPath := nodeDet.BunPath()
 	if bunPath != "" {
-		fmt.Printf("  --> bun detected at %s — lerd will use it automatically for projects that use bun\n", bunPath)
+		feedback.Line(fmt.Sprintf("bun detected at %s, lerd will use it automatically for projects that use bun", bunPath))
 	}
 
 	wantLerdNode := true
 	if systemNode := detectSystemNode(); systemNode != "" {
-		fmt.Printf("  --> Node.js detected at %s\n", systemNode)
+		feedback.Line("Node.js detected at " + systemNode)
 		prompt := "Let lerd manage Node.js versions (installs fnm shims, may override system node)?"
 		if bunPath != "" {
 			prompt += " Decline to keep your system Node and use bun."
@@ -226,8 +231,8 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 
 		if newTLD != prevTLD {
 			if affected := sitesWithTLD(prevTLD); len(affected) > 0 {
-				fmt.Printf("  --> TLD change: %d site(s) currently on .%s -> .%s\n", len(affected), prevTLD, newTLD)
-				fmt.Printf("      %s\n", strings.Join(affected, ", "))
+				feedback.Line(fmt.Sprintf("TLD change: %d site(s) currently on .%s -> .%s", len(affected), prevTLD, newTLD))
+				feedback.Note(strings.Join(affected, ", "))
 				migrate := fromUpdate || confirmInstallPromptDefault(
 					fmt.Sprintf("Rewrite domains, .env APP_URL, and vhosts to .%s?", newTLD),
 					true,
@@ -235,7 +240,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 				if migrate {
 					migrateSiteTLD(prevTLD, newTLD, !wantDNS)
 				} else {
-					fmt.Println("      skipped, sites still reference ." + prevTLD)
+					feedback.Note("skipped, sites still reference ." + prevTLD)
 				}
 			}
 		}
@@ -255,7 +260,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	// already matches the desired state (e.g. fresh install with no
 	// lerd-dns yet, or rerun where the unit is already gone).
 	if !wantDNS {
-		fmt.Println("  --> Tearing down lerd-dns service")
+		feedback.Line("tearing down lerd-dns service")
 		teardownDNS()
 	}
 
@@ -267,7 +272,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 
 	if wantDNS {
 		// 4. mkcert CA, interactive (may prompt for sudo)
-		fmt.Println("  --> Installing mkcert CA")
+		feedback.Line("installing mkcert CA")
 		mkcertCmd := exec.Command(certs.MkcertPath(), "-install")
 		mkcertCmd.Stdin = os.Stdin
 		mkcertCmd.Stdout = os.Stdout
@@ -286,10 +291,10 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		dnsChanged = dnsChanged || confChanged
 		ok()
 
-		fmt.Println("  --> Installing DNS sudoers rule")
+		feedback.Line("installing DNS sudoers rule")
 		dns.InstallSudoers() //nolint:errcheck
 	} else {
-		fmt.Println("  --> DNS disabled, skipping mkcert CA, dnsmasq and sudoers")
+		feedback.Line("DNS disabled, skipping mkcert CA, dnsmasq and sudoers")
 	}
 
 	// 6. Nginx
@@ -605,7 +610,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		}
 		ok()
 
-		fmt.Println("  --> Configuring DNS resolver")
+		feedback.Line("configuring DNS resolver")
 		if err := dns.ConfigureResolver(); err != nil {
 			fmt.Printf("    WARN: %v\n", err)
 		}
@@ -623,9 +628,9 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	migratedSet := make(map[string]bool, len(migrated))
 	for _, c := range migrated {
 		migratedSet[c] = true
-		fmt.Printf("  --> Starting %s (network migration) ", c)
+		step("starting " + c + " (network migration)")
 		if err := podman.StartUnit(c); err != nil {
-			fmt.Printf("WARN: %v\n", err)
+			feedback.Warn("%v", err)
 		} else {
 			ok()
 		}
@@ -641,9 +646,9 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		if running, _ := podman.ContainerRunning(name); !running {
 			continue
 		}
-		fmt.Printf("  --> Restarting %s (PublishPort changed) ", name)
+		step("restarting " + name + " (PublishPort changed)")
 		if err := services.Mgr.Restart(name); err != nil {
-			fmt.Printf("WARN: %v\n", err)
+			feedback.Warn("%v", err)
 		} else {
 			ok()
 		}
@@ -675,7 +680,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		}
 		ok()
 
-		fmt.Println("  --> Configuring DNS resolver")
+		feedback.Line("configuring DNS resolver")
 		if err := dns.ConfigureResolver(); err != nil {
 			fmt.Printf("    WARN: %v\n", err)
 		}
@@ -789,7 +794,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		// php:rebuild restarts FPM and worker units unconditionally.
 		activeFPM, _ := phpDet.ListInstalled()
 		if podman.NeedsFPMRebuild(activeFPM) || podman.NeedsFrankenPHPRebuild(activeFrankenPHPVersions()) {
-			fmt.Println("\n==> PHP image definitions changed — rebuilding images")
+			feedback.Header("Rebuilding PHP images")
 			self, err := os.Executable()
 			if err != nil {
 				fmt.Printf("  WARN: locating lerd binary for php:rebuild: %v\n", err)
@@ -820,6 +825,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 				})
 			}
 			if len(fpmJobs) > 0 {
+				feedback.Header("Starting PHP-FPM")
 				RunParallel(fpmJobs) //nolint:errcheck
 			}
 		}
@@ -829,11 +835,11 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	}
 
 	if wantLaravelInstaller {
-		fmt.Println("  --> Installing Laravel installer")
+		step("installing Laravel installer")
 		if err := installLaravelInstaller(); err != nil {
-			fmt.Printf("    WARN: %v\n", err)
+			feedback.Warn("%v", err)
 		} else {
-			fmt.Println("    OK")
+			ok()
 		}
 	}
 
@@ -873,9 +879,12 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	refreshGlobalMCPSkills()
 	refreshProjectMCPSkills()
 
+	feedback.Begin()
 	feedback.Done("lerd installation complete")
+	feedback.Begin()
 	feedback.Note("Dashboard: " + feedback.Val("http://lerd.localhost"))
 	feedback.Note("Terminal:  " + feedback.Val("lerd tui"))
+	feedback.Begin()
 	return nil
 }
 
@@ -913,6 +922,7 @@ func startPerSiteContainers() {
 			Run:   func(_ io.Writer) error { return podman.StartUnit(unit) },
 		}
 	}
+	feedback.Header("Starting per-site containers")
 	RunParallel(jobs) //nolint:errcheck
 }
 
@@ -990,11 +1000,12 @@ func ensureSystemdLinger() error {
 		return nil
 	}
 
-	fmt.Println("\n  ! systemd user linger is disabled for this account.")
-	fmt.Println("    Without it, lerd's containers (DNS, nginx, PHP-FPM) are torn down")
-	fmt.Println("    by systemd-logind on screen blank, lock, or logout, and lerd will")
-	fmt.Println("    appear to stop working until you manually restart it.")
-	fmt.Print("  --> Enabling linger via `sudo loginctl enable-linger ", user, "` ...\n\n")
+	feedback.Warn("systemd user linger is disabled for this account")
+	feedback.Note("without it, lerd's containers (DNS, nginx, PHP-FPM) are torn down by")
+	feedback.Note("systemd-logind on screen blank, lock, or logout, and lerd will appear")
+	feedback.Note("to stop working until you manually restart it")
+	step("enabling linger via `sudo loginctl enable-linger " + user + "`")
+	fmt.Println()
 
 	cmd := exec.Command("sudo", "loginctl", "enable-linger", user)
 	cmd.Stdin = os.Stdin
@@ -1004,7 +1015,7 @@ func ensureSystemdLinger() error {
 		fmt.Println()
 		return fmt.Errorf("enabling linger: %w", err)
 	}
-	fmt.Println("OK")
+	ok()
 	return nil
 }
 
@@ -1023,10 +1034,11 @@ func ensureUnprivilegedPorts() error {
 		return nil // already fine
 	}
 
-	fmt.Printf("\n  ! Port 80/443 require net.ipv4.ip_unprivileged_port_start ≤ 80 (current: %d)\n", val)
-	fmt.Println("    This is needed for rootless Podman to run Nginx on standard HTTP/HTTPS ports.")
+	feedback.Warn("port 80/443 require net.ipv4.ip_unprivileged_port_start ≤ 80 (current: %d)", val)
+	feedback.Note("this is needed for rootless Podman to run Nginx on standard HTTP/HTTPS ports")
 
-	fmt.Print("  --> Setting net.ipv4.ip_unprivileged_port_start=80 ... ")
+	step("setting net.ipv4.ip_unprivileged_port_start=80")
+	fmt.Println()
 	cmds := [][]string{
 		{"sudo", "sysctl", "-w", "net.ipv4.ip_unprivileged_port_start=80"},
 		{"sudo", "sh", "-c", "echo 'net.ipv4.ip_unprivileged_port_start=80' > /etc/sysctl.d/99-lerd-ports.conf"},
@@ -1040,7 +1052,7 @@ func ensureUnprivilegedPorts() error {
 			return fmt.Errorf("setting unprivileged port start: %w", err)
 		}
 	}
-	fmt.Println("OK")
+	ok()
 	return nil
 }
 
@@ -1255,13 +1267,12 @@ func parseDNSMode(flag string) (enabled bool, ok bool) {
 func confirmInstallPromptDefault(question string, defaultYes bool) bool {
 	src, closer, ok := promptSource()
 	if !ok {
-		hint := "[Y/n]"
 		ans := "yes"
 		if !defaultYes {
-			hint = "[y/N]"
 			ans = "no"
 		}
-		fmt.Printf("  --> %s %s (no terminal, defaulting to %s)\n", question, hint, ans)
+		feedback.Prompt(question, defaultYes)
+		fmt.Println(feedback.Dim("(no terminal, defaulting to " + ans + ")"))
 		return defaultYes
 	}
 	if closer != nil {
@@ -1284,11 +1295,7 @@ func promptSource() (io.Reader, io.Closer, bool) {
 }
 
 func readConfirmAnswer(r io.Reader, question string, defaultYes bool) bool {
-	hint := "[Y/n]"
-	if !defaultYes {
-		hint = "[y/N]"
-	}
-	fmt.Printf("  --> %s %s ", question, hint)
+	feedback.Prompt(question, defaultYes)
 	reader := bufio.NewReader(r)
 	answer, _ := reader.ReadString('\n')
 	answer = strings.TrimSpace(strings.ToLower(answer))

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -571,6 +571,13 @@ func linkApplyServices(cwd string, proj *config.ProjectConfig) error {
 		return nil
 	}
 	for _, svc := range proj.Services {
+		// A bare entry whose name is a bundled tool preset (e.g. phpmyadmin from a
+		// detected docker-compose, or an older .lerd.yaml written before this was
+		// normalised) has no Preset/Custom set; resolve it to its preset so it
+		// installs instead of failing as a missing custom service.
+		if svc.Preset == "" && svc.Custom == nil && config.PresetExists(svc.Name) && !config.IsDefaultPreset(svc.Name) {
+			svc.Preset = svc.Name
+		}
 		if svc.Preset != "" {
 			if _, err := config.LoadCustomService(svc.Name); err != nil {
 				fmt.Printf("  Installing preset %s%s\n", svc.Preset, presetVersionSuffix(svc.PresetVersion))

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -224,7 +224,7 @@ func RunMCPEnableGlobal() error {
 func writeGlobalMCPConfigs(home string, verbose bool) error {
 	log := func(msg string) {
 		if verbose {
-			fmt.Println(msg)
+			feedback.Note(msg)
 		}
 	}
 	for _, c := range aiClients {
@@ -233,10 +233,10 @@ func writeGlobalMCPConfigs(home string, verbose bool) error {
 			_, _ = claudeMCP("remove", "--scope", "user", "lerd")
 			out, err := claudeMCP("add", "--scope", "user", "lerd", "--", "lerd", "mcp")
 			if err != nil {
-				fmt.Printf("  warning: could not register with Claude Code (%v): %s\n", err, strings.TrimSpace(string(out)))
-				fmt.Println("  Run manually: claude mcp add --scope user lerd -- lerd mcp")
+				feedback.Warn("could not register with Claude Code (%v): %s", err, strings.TrimSpace(string(out)))
+				feedback.Note("run manually: claude mcp add --scope user lerd -- lerd mcp")
 			} else {
-				log("  registered in Claude Code (user scope)")
+				log("registered in Claude Code (user scope)")
 			}
 			continue
 		}
@@ -246,7 +246,7 @@ func writeGlobalMCPConfigs(home string, verbose bool) error {
 		if err := writeClientMCP(filepath.Join(home, c.GlobalMCP), c, ""); err != nil {
 			return err
 		}
-		log("  updated ~/" + c.GlobalMCP)
+		log("updated ~/" + c.GlobalMCP)
 	}
 	return nil
 }
@@ -281,7 +281,7 @@ func writeGlobalContexts(home string, verbose, createMissing bool) error {
 				return fmt.Errorf("writing %s: %w", cx.Global, err)
 			}
 			if verbose {
-				fmt.Println("  wrote   ~/" + cx.Global)
+				feedback.Note("wrote ~/" + cx.Global)
 			}
 		}
 	}

--- a/internal/cli/node_manage.go
+++ b/internal/cli/node_manage.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sync"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
@@ -118,11 +119,21 @@ func runNodeUnmanage(_ *cobra.Command, _ []string) error {
 // host worker units (Vite and other host:true workers) so they pick up the
 // current JS-runtime decision after node:manage / node:unmanage flips what Node
 // is available. Best-effort: failures are warned, not fatal.
+// hostWorkerHeader, when set, prints the "Starting host workers" section header
+// exactly once, just before the first worker is actually started. It is wired
+// up only by the install-time regenerateHostWorkers sweep, so the per-site
+// dashboard runtime toggle (which also calls RegenerateHostWorkersForSite)
+// doesn't emit a header, and a sweep that starts nothing leaves no orphan.
+var hostWorkerHeader func()
+
 func regenerateHostWorkers() {
 	reg, err := config.LoadSites()
 	if err != nil {
 		return
 	}
+	var once sync.Once
+	hostWorkerHeader = func() { once.Do(func() { feedback.Header("Re-syncing host workers") }) }
+	defer func() { hostWorkerHeader = nil }()
 	for _, s := range reg.Sites {
 		RegenerateHostWorkersForSite(s)
 	}
@@ -221,28 +232,36 @@ func regenerateWorkerUnit(siteName, sitePath, phpVersion, workerName string, wDe
 	// Snapshot the unit before rewriting so we only restart it when its
 	// ExecStart actually changed. On macOS the unit is a launchd plist
 	// elsewhere, so before is empty and we always fall through to restart.
+	// Rewrite the unit quietly first so we can tell whether the runtime actually
+	// changed, without starting or announcing it. startRestoredServices already
+	// started this worker during install (or it's a build-replacer like Vite that
+	// isn't persisted), so an unchanged rewrite should stay silent rather than
+	// print a second time under its own header.
 	unitPath := filepath.Join(config.SystemdUserDir(), unitName+".service")
 	before, _ := os.ReadFile(unitPath)
-	if err := WorkerStartForSite(siteName, sitePath, phpVersion, workerName, wDef, false); err != nil {
-		feedback.Warn("regenerating %s: %v", unitName, err)
-		return
-	}
+	restoreWorker(siteName, sitePath, phpVersion, workerName, wDef)
 	after, _ := os.ReadFile(unitPath)
 	if len(before) > 0 && string(before) == string(after) {
+		// Linux, genuinely unchanged: StartUnit no-ops on an active unit, so just
+		// make sure it's running without announcing it again.
+		_ = podman.StartUnit(unitName)
 		return
 	}
-	// WorkerStartForSite only writes the unit file; systemd caches the old
-	// definition until a reload, so reload before the restart picks up the new
-	// ExecStart (StartUnit no-ops on an already-active unit).
-	_ = podman.DaemonReload()
-	// Clear any failed / start-rate-limit state first: a worker that
-	// crash-looped under the previous runtime (e.g. bun on a project bun can't
-	// run) would otherwise refuse to restart when switched back, so the toggle
-	// would not heal it.
-	podman.ResetFailedUnit(unitName)
-	if err := podman.RestartUnit(unitName); err != nil {
-		feedback.Warn("restarting %s: %v", unitName, err)
-	} else {
-		feedback.Note("regenerated " + unitName)
+	// The unit changed, or can't be diffed (macOS host workers are launchd plists,
+	// not .service files, so both reads come back empty): announce under the
+	// host-workers header, then do a full platform-correct (re)start.
+	// WorkerStartForSite owns the macOS launchd lifecycle, clears stale
+	// idle-suspend state, and regenerates the proxy vhost; the reload+restart
+	// afterward bounces a running Linux worker onto the new ExecStart, which
+	// StartUnit alone would not.
+	if hostWorkerHeader != nil {
+		hostWorkerHeader()
 	}
+	if err := WorkerStartForSite(siteName, sitePath, phpVersion, workerName, wDef, false); err != nil {
+		feedback.Warn("re-syncing %s: %v", unitName, err)
+		return
+	}
+	_ = podman.DaemonReload()
+	podman.ResetFailedUnit(unitName)
+	_ = podman.RestartUnit(unitName)
 }

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -232,14 +232,19 @@ func runSetup(allSteps, skipOpen bool) error {
 	// runtime elsewhere — so the step is omitted entirely for them, not just left
 	// unchecked, since `lerd setup -a` runs every listed step. Idempotent and
 	// non-fatal: skips when the container bun is already present.
-	if siteServedByPHPFPM(site) && nodeDet.BunPath() != "" && bunPHPVersion != "" {
+	// Mirror bun into the container only when it isn't already there. The volume
+	// is host-backed at BunVolumeDir(), so a plain stat of its bun binary tells us
+	// this without a podman exec, keeping setup planning off podman. Once bun is
+	// present, updates go through `bun upgrade`, so there's nothing to offer here.
+	_, bunStatErr := os.Stat(filepath.Join(podman.BunVolumeDir(), "bin", "bun"))
+	if siteServedByPHPFPM(site) && nodeDet.BunPath() != "" && bunPHPVersion != "" && os.IsNotExist(bunStatErr) {
 		steps = append(steps, setupStep{
 			label:    "bun (container)",
 			enabled:  true,
 			optional: true,
 			run: func() error {
-				// Cheap exec check deferred to run time so setup planning never
-				// blocks on podman; installContainerBun is the no-op fast path.
+				// Exec check deferred to run time as a final guard; installContainerBun
+				// is the no-op fast path if bun appeared since planning.
 				if bunInstalledInContainer(bunPHPVersion) {
 					return nil
 				}

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -738,6 +738,7 @@ func startRestoredServices() {
 			Run:   func(_ io.Writer) error { return podman.StartUnit(unit) },
 		})
 	}
+	feedback.Header("Starting services")
 	RunParallel(startJobs) //nolint:errcheck
 
 	// Workers exec into the FPM containers and depend on lerd-redis et al.
@@ -770,6 +771,7 @@ func startRestoredServices() {
 			Run:   func(_ io.Writer) error { return podman.StartUnit(unit) },
 		})
 	}
+	feedback.Header("Starting workers")
 	RunParallel(workerJobs) //nolint:errcheck
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -19,13 +19,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	colorGreen  = "\033[32m"
-	colorRed    = "\033[31m"
-	colorYellow = "\033[33m"
-	colorReset  = "\033[0m"
-)
-
 func ok2(label string) {
 	fmt.Printf("  %s %s\n", feedback.Green(feedback.GlyphOK), label)
 }
@@ -304,8 +297,8 @@ func runStatus(_ *cobra.Command, _ []string) error {
 			// already point at journalctl for the underlying cause; this
 			// surfaces the recovery primitive once instead of N times.
 			if failedCount > 0 {
-				fmt.Printf("\n  %d failed worker(s). Reset and restart with: %slerd worker heal%s\n",
-					failedCount, colorYellow, colorReset)
+				fmt.Printf("\n  %d failed worker(s). Reset and restart with: %s\n",
+					failedCount, feedback.Amber("lerd worker heal"))
 			}
 		}
 	}
@@ -377,10 +370,10 @@ func printRemoteAccessStatus(cfg *config.GlobalConfig, lanIP string) {
 func printUpdateNotice(info *lerdUpdate.UpdateInfo) {
 	bar := "══════════════════════════════════════════════"
 	fmt.Println()
-	fmt.Printf("%s%s%s\n", colorYellow, bar, colorReset)
-	fmt.Printf("%s  Update available: %s  →  run: lerd update%s\n", colorYellow, info.LatestVersion, colorReset)
-	fmt.Printf("%s  Run lerd whatsnew to see what changed.%s\n", colorYellow, colorReset)
-	fmt.Printf("%s%s%s\n", colorYellow, bar, colorReset)
+	fmt.Println(feedback.Amber(bar))
+	fmt.Println(feedback.Amber("  Update available: " + info.LatestVersion + "  →  run: lerd update"))
+	fmt.Println(feedback.Amber("  Run lerd whatsnew to see what changed."))
+	fmt.Println(feedback.Amber(bar))
 }
 
 // certExpiry reads the expiry date from a PEM certificate file.

--- a/internal/cli/unlink.go
+++ b/internal/cli/unlink.go
@@ -64,7 +64,9 @@ func runUnlink(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("no site registered for %s — link it first with lerd link", cwd)
 	}
 	feedback.Begin()
-	return UnlinkSite(site.Name)
+	unlinkErr := UnlinkSite(site.Name)
+	feedback.Begin()
+	return unlinkErr
 }
 
 // UnlinkSite removes the nginx vhost for the named site. For sites under a parked

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -207,7 +207,7 @@ func refreshStoreFrameworks() {
 	if len(targets) == 0 {
 		return
 	}
-	feedback.Line(fmt.Sprintf("refreshing %d framework definition%s", len(targets), pluralS(len(targets))))
+	feedback.Header(fmt.Sprintf("Refreshing %d framework%s", len(targets), pluralS(len(targets))))
 	client := store.NewClient()
 	for _, t := range targets {
 		label := t.name
@@ -242,12 +242,12 @@ func refreshGlobalMCPSkills() {
 	if !mcpEnabledGlobally(home) {
 		return
 	}
-	feedback.Line("refreshing global MCP skills and guidelines")
+	feedback.Header("Refreshing global AI skills")
 	if err := RefreshGlobalAISkills(home, true); err != nil {
 		feedback.Warn("could not refresh global AI skills: %v", err)
 	}
 	if !IsMCPGloballyRegistered() {
-		fmt.Println("  Re-registering lerd with Claude Code (was missing)")
+		feedback.Note("re-registering lerd with Claude Code (was missing)")
 		ensureClaudeMCPRegistered()
 	}
 }
@@ -271,13 +271,14 @@ func refreshProjectMCPSkills() {
 		return
 	}
 
-	fmt.Printf("\n==> Refreshing project MCP skills (%d project%s)\n", len(opted), pluralS(len(opted)))
+	feedback.Header(fmt.Sprintf("Refreshing project AI skills (%d)", len(opted)))
 	for _, p := range opted {
+		s := feedback.Start(p)
 		if err := RefreshProjectAISkills(p, false); err != nil {
-			feedback.Warn("%s: %v", p, err)
+			s.Fail(err)
 			continue
 		}
-		fmt.Printf("  refreshed %s\n", p)
+		s.OK("")
 	}
 }
 

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -117,8 +117,9 @@ type ProjectConfig struct {
 func (c *ProjectConfig) IsEmpty() bool {
 	return len(c.Domains) == 0 && c.PHPVersion == "" && c.NodeVersion == "" &&
 		c.JSRuntime == "" &&
-		c.Framework == "" && c.PublicDir == "" && len(c.Services) == 0 &&
-		len(c.Workers) == 0 && len(c.CustomWorkers) == 0 && len(c.ReloadWorkers) == 0 && !c.Secured &&
+		c.Framework == "" && c.FrameworkVersion == "" && c.FrameworkDef == nil &&
+		c.PublicDir == "" && len(c.Services) == 0 &&
+		len(c.Workers) == 0 && len(c.CustomWorkers) == 0 && len(c.ReloadWorkers) == 0 && len(c.Commands) == 0 && !c.Secured &&
 		c.AppURL == "" && c.DB.Service == "" && c.DB.Database == "" &&
 		c.Container == nil && c.Proxy == nil && c.Runtime == "" && !c.RuntimeWorker &&
 		!c.DBIsolated && len(c.EnvOverrides) == 0 && c.RequestTimeout == 0 && c.Stripe == nil

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -317,6 +317,30 @@ func TestProjectConfig_Container_RoundTrip(t *testing.T) {
 	}
 }
 
+// A .lerd.yaml that carries only custom commands (or a framework version/def)
+// is meaningful user config: IsEmpty must report false so the link wizard
+// doesn't classify it as a blank file and overwrite it.
+func TestProjectConfig_Commands_IsEmpty(t *testing.T) {
+	cfg := &ProjectConfig{}
+	if !cfg.IsEmpty() {
+		t.Error("empty config should be empty")
+	}
+	cfg.Commands = []FrameworkCommand{{Name: "deploy", Command: "php artisan deploy"}}
+	if cfg.IsEmpty() {
+		t.Error("config with custom commands should not be empty")
+	}
+
+	cfg = &ProjectConfig{FrameworkVersion: "11"}
+	if cfg.IsEmpty() {
+		t.Error("config with a framework version should not be empty")
+	}
+
+	cfg = &ProjectConfig{FrameworkDef: &Framework{Name: "laravel"}}
+	if cfg.IsEmpty() {
+		t.Error("config with an embedded framework definition should not be empty")
+	}
+}
+
 func TestProjectConfig_Container_IsEmpty(t *testing.T) {
 	cfg := &ProjectConfig{}
 	if !cfg.IsEmpty() {

--- a/internal/dns/linkchanges_darwin.go
+++ b/internal/dns/linkchanges_darwin.go
@@ -42,8 +42,13 @@ func LinkChanges(out chan<- struct{}, done <-chan struct{}) error {
 	// own (e.g. a read error the supervisor will restart from), so a restart
 	// loop doesn't accumulate one parked goroutine per attempt.
 	stopped := make(chan struct{})
-	defer close(stopped)
+	gone := make(chan struct{})
+	// Join the interrupt goroutine (via gone) before the deferred unix.Close(fd)
+	// runs, so its unix.Shutdown(fd) can't land on an fd the runtime has already
+	// closed and reassigned to a freshly-opened socket on a fast restart.
+	defer func() { close(stopped); <-gone }()
 	go func() {
+		defer close(gone)
 		select {
 		case <-done:
 		case <-stopped:

--- a/internal/dns/linkchanges_linux.go
+++ b/internal/dns/linkchanges_linux.go
@@ -43,8 +43,13 @@ func LinkChanges(out chan<- struct{}, done <-chan struct{}) error {
 	// own (e.g. a read error the supervisor will restart from), so a restart
 	// loop doesn't accumulate one parked goroutine per attempt.
 	stopped := make(chan struct{})
-	defer close(stopped)
+	gone := make(chan struct{})
+	// Join the interrupt goroutine (via gone) before the deferred unix.Close(fd)
+	// runs, so its unix.Shutdown(fd) can't land on an fd the runtime has already
+	// closed and reassigned to a freshly-opened socket on a fast restart.
+	defer func() { close(stopped); <-gone }()
 	go func() {
+		defer close(gone)
 		select {
 		case <-done:
 		case <-stopped:

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -4,6 +4,7 @@
 package feedback
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -62,6 +63,15 @@ func Red(s string) string   { return paint(redStyle, s) }
 func Amber(s string) string { return paint(warnStyle, s) }
 func Dim(s string) string   { return paint(dimStyle, s) }
 
+// GreenIf, RedIf, and AmberIf colour s from the palette only when on is true,
+// else return it plain — for renderers that target an arbitrary writer and gate
+// colour per-writer (e.g. doctor forcing plain text into a bug report). When on
+// is true the usual global NO_COLOR/TTY state is still honoured, so a coloured
+// caller never produces escapes the environment asked to suppress.
+func GreenIf(on bool, s string) string { return paintIf(on, okStyle, s) }
+func RedIf(on bool, s string) string   { return paintIf(on, redStyle, s) }
+func AmberIf(on bool, s string) string { return paintIf(on, warnStyle, s) }
+
 // spinnerFrames is the Braille spinner used by the Live progress line.
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
@@ -79,6 +89,48 @@ var (
 )
 
 func init() { colorOn.Store(detectColor()) }
+
+// reported collects errors already shown to the user by a Step/Live Fail. The
+// top-level command handler consults it so a failure surfaced through the
+// feedback UI isn't reprinted as a second raw "Error: …" line by cobra. It is
+// capped because long-running processes (lerd-ui, the MCP server) also drive
+// Fail through shared CLI helpers and would otherwise grow it without bound; a
+// CLI command only ever checks the most recent failure, so an old-entry cap is
+// harmless. The trim copies into a fresh slice so the backing array is freed.
+const maxReported = 64
+
+var (
+	reportedMu sync.Mutex
+	reported   []error
+)
+
+func markReported(err error) {
+	if err == nil {
+		return
+	}
+	reportedMu.Lock()
+	reported = append(reported, err)
+	if len(reported) > maxReported {
+		reported = append([]error(nil), reported[len(reported)-maxReported:]...)
+	}
+	reportedMu.Unlock()
+}
+
+// AlreadyShown reports whether err, or any error it wraps, was already displayed
+// to the user by a Fail. Callers in main use it to avoid double-printing.
+func AlreadyShown(err error) bool {
+	if err == nil {
+		return false
+	}
+	reportedMu.Lock()
+	defer reportedMu.Unlock()
+	for _, r := range reported {
+		if errors.Is(err, r) {
+			return true
+		}
+	}
+	return false
+}
 
 // target returns the writer to render to: an explicit test writer when set,
 // otherwise the live os.Stdout (looked up per call so os.Stdout redirection,
@@ -104,6 +156,15 @@ func paint(st lipgloss.Style, s string) string {
 		return s
 	}
 	return st.Render(s)
+}
+
+// paintIf is paint gated by an explicit flag (and still honours global colour
+// state), for callers that decide per-writer whether to colour.
+func paintIf(on bool, st lipgloss.Style, s string) string {
+	if !on {
+		return s
+	}
+	return paint(st, s)
 }
 
 // Val styles a value fragment (violet) for embedding inside a step or summary.
@@ -237,6 +298,7 @@ func (s *Step) Info(result string) { s.finish("", result) }
 
 // Fail collapses the step with a red cross and the error text.
 func (s *Step) Fail(err error) {
+	markReported(err)
 	msg := ""
 	if err != nil {
 		msg = err.Error()
@@ -250,6 +312,19 @@ func Line(msg string) {
 	mu.Lock()
 	defer mu.Unlock()
 	fmt.Fprintf(target(), "%s%s %s\n", pad, paint(dimStyle, "→"), msg)
+}
+
+// Header prints a section header — a brand-red "▸ title" with a blank line
+// above and below — to delimit the major phases of a long multi-step command
+// (install, update) so the step lines beneath read as a group instead of one
+// flat wall of output. Routed through emit so it lands cleanly above any live
+// spinner that is still animating.
+func Header(title string) {
+	emit(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		fmt.Fprintf(target(), "\n%s%s %s\n\n", pad, paint(titleStyle, "▸"), paint(titleStyle, title))
+	})
 }
 
 // Note prints a dim, indented sub-detail under a step (e.g. a log hint). It has
@@ -337,6 +412,20 @@ func Confirm(question string, defaultYes bool) bool {
 		return defaultYes
 	}
 	return answer[0] == 'y'
+}
+
+// Prompt renders a styled yes/no question (violet "?", dim "[Y/n]" hint),
+// preceded by a blank line, WITHOUT reading the answer — for callers that read
+// from a custom source (e.g. /dev/tty so `curl … | bash` prompts still work)
+// instead of stdin. Mirrors Confirm's styling so every prompt looks the same.
+func Prompt(question string, defaultYes bool) {
+	hint := "[Y/n]"
+	if !defaultYes {
+		hint = "[y/N]"
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintf(target(), "\n%s%s %s %s ", pad, paint(promptStyle, "?"), question, paint(dimStyle, hint))
 }
 
 // Animated reports whether output supports in-place animation (a colour TTY).
@@ -479,6 +568,7 @@ func (l *Live) Done() {
 
 // Fail stops the spinner and finalises the line with a red cross.
 func (l *Live) Fail(err error) {
+	markReported(err)
 	if l.animated {
 		// Stop the spinner before deregistering (see Done).
 		close(l.stop)
@@ -494,7 +584,9 @@ func (l *Live) Fail(err error) {
 	if err != nil {
 		msg = err.Error()
 	}
-	fmt.Fprintf(target(), "%s%s %s\n", pad, paint(failStyle, "✗"), paint(failStyle, msg))
+	// A live line fails the whole operation, so give the cross some breathing
+	// room with a blank line above and below, matching the top-level handler.
+	fmt.Fprintf(target(), "\n%s%s %s\n\n", pad, paint(failStyle, "✗"), paint(failStyle, msg))
 }
 
 // Summary is an aligned key/value block printed after an operation completes.
@@ -544,6 +636,15 @@ func SetTestWriter(w io.Writer) func() {
 		colorOn.Store(prevColor)
 		mu.Unlock()
 	}
+}
+
+// SetAnimated forces Animated() to on (or off) and returns a restore func.
+// Pair it with SetTestWriter so a test can exercise an animated code path while
+// the spinner frames land in a buffer instead of os.Stdout.
+func SetAnimated(on bool) func() {
+	prev := colorOn.Load()
+	colorOn.Store(on)
+	return func() { colorOn.Store(prev) }
 }
 
 func humanDur(d time.Duration) string {

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -55,6 +55,82 @@ func TestStepInfoAndFail(t *testing.T) {
 	}
 }
 
+// A Step/Live Fail records its error so the top-level handler can tell it was
+// already shown to the user, covering both the bare error returned as-is and a
+// wrapped error that adds context around it. An unrelated error stays unshown.
+func TestAlreadyShownAfterFail(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	bare := errors.New("mkcert missing")
+	Start("provisioning TLS").Fail(bare)
+
+	if !AlreadyShown(bare) {
+		t.Error("bare error not marked AlreadyShown after Fail")
+	}
+	wrapped := fmt.Errorf("provisioning TLS: %w", bare)
+	if !AlreadyShown(wrapped) {
+		t.Error("error wrapping a shown error not detected as AlreadyShown")
+	}
+	if AlreadyShown(errors.New("something else")) {
+		t.Error("unrelated error wrongly reported as AlreadyShown")
+	}
+	if AlreadyShown(nil) {
+		t.Error("nil error reported as AlreadyShown")
+	}
+}
+
+// Header frames a section with a ▸ glyph and a blank line above and below, so
+// the steps beneath it read as a group rather than a flat wall of output.
+// The *If helpers gate colour on an explicit flag: on=false always returns the
+// plain string (so a renderer writing a plain-text bug report gets no escapes),
+// while on=true delegates to the same palette painter as the unconditional form.
+func TestColourIf(t *testing.T) {
+	if got := GreenIf(false, "ok"); got != "ok" {
+		t.Errorf("GreenIf(false) = %q, want plain", got)
+	}
+	if got := RedIf(false, "bad"); got != "bad" {
+		t.Errorf("RedIf(false) = %q, want plain", got)
+	}
+	if got := AmberIf(false, "warn"); got != "warn" {
+		t.Errorf("AmberIf(false) = %q, want plain", got)
+	}
+	if GreenIf(true, "ok") != Green("ok") {
+		t.Error("GreenIf(true) should match Green()")
+	}
+	if RedIf(true, "bad") != Red("bad") {
+		t.Error("RedIf(true) should match Red()")
+	}
+}
+
+func TestHeader(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	Header("Rebuilding PHP images")
+
+	if got := buf.String(); got != "\n ▸ Rebuilding PHP images\n\n" {
+		t.Fatalf("Header output = %q", got)
+	}
+}
+
+// Prompt renders the same styled question as Confirm (blank line, "?", dim
+// hint) but reads nothing, for callers that read from their own source.
+func TestPrompt(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	Prompt("Continue?", true)
+	if got := buf.String(); got != "\n ? Continue? [Y/n] " {
+		t.Fatalf("Prompt(Y) = %q", got)
+	}
+	buf.Reset()
+	Prompt("Wipe data?", false)
+	if got := buf.String(); got != "\n ? Wipe data? [y/N] " {
+		t.Fatalf("Prompt(N) = %q", got)
+	}
+}
+
 func TestLine(t *testing.T) {
 	var buf bytes.Buffer
 	defer SetTestWriter(&buf)()

--- a/internal/serviceops/preserved_image_test.go
+++ b/internal/serviceops/preserved_image_test.go
@@ -133,6 +133,21 @@ func TestMatchVersionByImageTag(t *testing.T) {
 	if got := matchVersionByImageTag("docker.io/library/mysql:8.4.9", mysqlVersions); got != "8.4" {
 		t.Errorf("mysql 8.4.9 should match 8.4, got %q", got)
 	}
+
+	// timescaledb pins floating tags (latest-pgNN) that aren't derived from the
+	// version string, so the tag heuristic can't recover the version — the full
+	// image must be matched instead, or canonical-pin sync silently flips the
+	// major on the next update.
+	tsVersions := []config.PresetVersion{
+		{Tag: "17", Image: "docker.io/timescale/timescaledb:latest-pg17"},
+		{Tag: "16", Image: "docker.io/timescale/timescaledb:latest-pg16"},
+	}
+	if got := matchVersionByImageTag("docker.io/timescale/timescaledb:latest-pg16", tsVersions); got != "16" {
+		t.Errorf("timescaledb latest-pg16 should match 16, got %q", got)
+	}
+	if got := matchVersionByImageTag("docker.io/timescale/timescaledb:latest-pg17", tsVersions); got != "17" {
+		t.Errorf("timescaledb latest-pg17 should match 17, got %q", got)
+	}
 }
 
 func TestEnsureDefaultPresetQuadlet_honorsCanonicalPinAcrossFlip(t *testing.T) {

--- a/internal/serviceops/provision.go
+++ b/internal/serviceops/provision.go
@@ -42,8 +42,14 @@ func CreateDatabase(svc, name string) (bool, error) {
 			}
 			cmd := podman.Cmd("exec", container, bin, "-uroot", "-plerd",
 				"-e", fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`;", name))
-			cmd.Stderr = os.Stderr
-			return true, cmd.Run()
+			// Capture stderr rather than inheriting it: mysql prints a noisy
+			// "[Warning] Using a password on the command line interface" that would
+			// otherwise clobber the live "configuring .env" spinner. Surface it only
+			// on a real failure.
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return false, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+			}
+			return true, nil
 		}
 		return false, lastErr
 	case "postgres":

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -359,6 +359,15 @@ func EnsureDefaultPresetQuadletPinned(name, pinnedImage string) error {
 // the installed image's tag. Lets backfill recognise postgis:16.5-3.5-alpine
 // as version "16" and mysql:8.4.9 as version "8.4".
 func matchVersionByImageTag(image string, versions []config.PresetVersion) string {
+	// Exact full-image match first: presets whose image tag isn't derived from
+	// the version string (e.g. timescaledb's …/timescaledb:latest-pg17 for
+	// version "17") can only be recovered this way. Without it the tag heuristic
+	// below returns "", and canonical-pin sync silently flips the major on update.
+	for _, v := range versions {
+		if v.Image != "" && image == v.Image {
+			return v.Tag
+		}
+	}
 	at := strings.LastIndex(image, ":")
 	if at < 0 {
 		return ""

--- a/internal/ui/ws_origin_test.go
+++ b/internal/ui/ws_origin_test.go
@@ -17,6 +17,7 @@ func TestWSOriginAllowed(t *testing.T) {
 		{"allowlisted lerd.localhost", "lerd.localhost", "http://lerd.localhost", true},
 		{"same-origin custom domain", "myapp.test", "http://myapp.test", true},
 		{"same-origin LAN ip", "192.168.1.10:7073", "http://192.168.1.10:7073", true},
+		{"same-origin with host casing divergence", "MyApp.test", "http://myapp.test", true},
 		{"cross-site hijack attempt", "localhost:7073", "http://evil.example", false},
 		{"foreign origin same path", "myapp.test", "https://attacker.test", false},
 		{"malformed origin", "localhost:7073", "::::not a url", false},

--- a/internal/ui/wsframe.go
+++ b/internal/ui/wsframe.go
@@ -57,7 +57,9 @@ func wsOriginAllowed(r *http.Request) bool {
 	if err != nil || u.Host == "" {
 		return false
 	}
-	return u.Host == r.Host
+	// Hostnames are case-insensitive (RFC 3986), and r.Host casing isn't
+	// guaranteed to match the browser-normalised Origin, so compare case-folded.
+	return strings.EqualFold(u.Host, r.Host)
 }
 
 // wsUpgrade performs the RFC6455 handshake and returns a wsConn ready for

--- a/internal/watcher/dns.go
+++ b/internal/watcher/dns.go
@@ -205,7 +205,7 @@ func WatchDNS(interval time.Duration, tld string) {
 
 	linkRaw := make(chan struct{}, 32)
 	linkSettled := make(chan struct{}, 4)
-	go superviseLinkChanges(dns.LinkChanges, linkRaw, done, linkChangeBackoff)
+	go superviseLinkChanges(dns.LinkChanges, linkRaw, done, linkChangeBackoff, linkChangeResetAfter)
 	go dns.DebounceEvents(linkRaw, linkSettled, linkChangeDebounce, done)
 
 	runDNSLoop(deps, state, tld, ticker.C, linkSettled, done)
@@ -221,6 +221,13 @@ func linkChangeBackoff(attempt int) time.Duration {
 	return d
 }
 
+// linkChangeResetAfter is how long a single watch must stay up before the next
+// restart is treated as fresh: a watch that ran healthy for this long and then
+// hit one late transient error should restart promptly, not at the grown 30s
+// cap. Passed into superviseLinkChanges so tests can shrink it without a shared
+// global.
+const linkChangeResetAfter = 60 * time.Second
+
 // superviseLinkChanges keeps dns.LinkChanges alive: when it returns an error
 // before done closes (a transient netlink/route socket failure) it restarts it
 // after a backoff, so the watcher doesn't go permanently deaf to host network
@@ -228,10 +235,13 @@ func linkChangeBackoff(attempt int) time.Duration {
 // life. It returns once done is closed or LinkChanges returns nil (a clean
 // shutdown, or an unsupported platform that simply waits on done).
 func superviseLinkChanges(fn func(chan<- struct{}, <-chan struct{}) error,
-	out chan<- struct{}, done <-chan struct{}, backoff func(int) time.Duration) {
+	out chan<- struct{}, done <-chan struct{}, backoff func(int) time.Duration, resetAfter time.Duration) {
 
-	for attempt := 0; ; attempt++ {
+	attempt := 0
+	for {
+		start := time.Now()
 		err := fn(out, done)
+		healthyRun := time.Since(start) >= resetAfter
 		select {
 		case <-done:
 			return
@@ -240,6 +250,12 @@ func superviseLinkChanges(fn func(chan<- struct{}, <-chan struct{}) error,
 		if err == nil {
 			return
 		}
+		// A watch that stayed up a long time before failing was healthy, so one
+		// late transient error shouldn't inherit the grown backoff and leave us
+		// capped at 30s; restart it promptly instead.
+		if healthyRun {
+			attempt = 0
+		}
 		logger.Warn("host network change watcher errored, restarting; DNS reacts on the safety-net poll meanwhile",
 			"err", err, "attempt", attempt+1)
 		select {
@@ -247,6 +263,7 @@ func superviseLinkChanges(fn func(chan<- struct{}, <-chan struct{}) error,
 		case <-done:
 			return
 		}
+		attempt++
 	}
 }
 

--- a/internal/watcher/dns_test.go
+++ b/internal/watcher/dns_test.go
@@ -565,7 +565,7 @@ func TestSuperviseLinkChanges_RestartsOnTransientError(t *testing.T) {
 		return nil
 	}
 
-	go superviseLinkChanges(fn, make(chan struct{}, 1), done, func(int) time.Duration { return 0 })
+	go superviseLinkChanges(fn, make(chan struct{}, 1), done, func(int) time.Duration { return 0 }, time.Minute)
 
 	// We expect three attempts: two that error and restart, one that sticks.
 	for want := 1; want <= 3; want++ {
@@ -577,6 +577,54 @@ func TestSuperviseLinkChanges_RestartsOnTransientError(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatalf("attempt %d never happened", want)
 		}
+	}
+}
+
+func TestSuperviseLinkChanges_ResetsBackoffAfterHealthyRun(t *testing.T) {
+	done := make(chan struct{})
+	defer close(done)
+
+	// Reset threshold of 15ms; the "healthy" run below sleeps 30ms before failing.
+	attempts := make(chan int, 16)
+	backoff := func(a int) time.Duration { attempts <- a; return 0 }
+
+	var n int
+	fn := func(out chan<- struct{}, d <-chan struct{}) error {
+		n++
+		switch {
+		case n <= 3:
+			return errors.New("rapid transient failure") // short runs grow the backoff
+		case n == 4:
+			time.Sleep(30 * time.Millisecond) // healthy run, then a late error
+			return errors.New("late transient failure")
+		default:
+			<-d // stay up until shutdown
+			return nil
+		}
+	}
+
+	go superviseLinkChanges(fn, make(chan struct{}, 1), done, backoff, 15*time.Millisecond)
+
+	// The three rapid failures grow the backoff attempt: 0, 1, 2.
+	for want := 0; want <= 2; want++ {
+		select {
+		case got := <-attempts:
+			if got != want {
+				t.Fatalf("backoff attempt %d, want %d", got, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("backoff not called")
+		}
+	}
+	// The fourth attempt ran longer than the reset threshold before failing, so
+	// the next restart must reset the backoff to 0 rather than stay near the cap.
+	select {
+	case got := <-attempts:
+		if got != 0 {
+			t.Fatalf("backoff after a healthy run = %d, want 0 (reset)", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("backoff not called after the healthy run")
 	}
 }
 
@@ -592,7 +640,7 @@ func TestSuperviseLinkChanges_StopsAfterDone(t *testing.T) {
 
 	stopped := make(chan struct{})
 	go func() {
-		superviseLinkChanges(fn, make(chan struct{}, 1), done, func(int) time.Duration { return 0 })
+		superviseLinkChanges(fn, make(chan struct{}, 1), done, func(int) time.Duration { return 0 }, time.Minute)
 		close(stopped)
 	}()
 


### PR DESCRIPTION
This is the post-1.25 cleanup branch. It grows the TUI dashboard into a navigable surface and gives the CLI output a single styled voice, fixing a string of regressions a fresh review surfaced along the way.

The dashboard cards are now navigable with the arrow keys, a caret marks the selection in the accent colour, and Enter opens a row exactly like a click through one shared activation helper. The footer colour-codes its hints, the cards sit flush, and the domain add, edit and remove actions are gated to the Sites tab so they can't fire against a hidden site. The websocket upgrade now rejects cross-origin requests while still allowing same-origin, allowlisted and non-browser clients, and the broadcast handler serialises its writes through a mutex.

On the CLI side the install, link, update and setup commands speak one styled voice through the feedback package instead of a mix of ==> and --> markers and raw ANSI. Headers, steps, prompts, warnings and the parallel build grid all render from the shared palette, so its eight colour vars are the complete source of truth for theming the CLI and the TUI together, and NO_COLOR is honoured everywhere including the build grid. Errors print once, with a blank line above and below, and host worker re-sync during install stays silent unless a worker's unit actually changed.

The review fixes round it out. The DNS link-change watcher restarts with capped backoff and resets it after a healthy run, then joins its interrupt goroutine before closing the socket. The timescaledb preset's floating image tags resolve back to their version so canonical pinning can't silently flip the major. The project-config empty-check counts custom commands and framework fields so the link wizard can't overwrite a meaningful .lerd.yaml. The mysql password warning and npm build noise are captured instead of clobbering the live spinner, a bundled tool preset like phpmyadmin installs as a preset instead of warning that a custom service is missing, and the bun container step in setup only shows when bun isn't already in the container.