### PR TITLE
Make the geodro to lerd-env org move self-healing, plus pre-release fixes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -139,7 +139,7 @@ brews:
       owner: geodro
       name: homebrew-lerd
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    homepage: "https://github.com/geodro/lerd"
+    homepage: "https://lerd.sh"
     description: "Local Laravel development environment for Linux and macOS"
     license: "MIT"
     skip_upload: auto
@@ -199,7 +199,7 @@ release:
     ### Install on Linux
 
     ```bash
-    curl -fsSL https://raw.githubusercontent.com/geodro/lerd/main/install.sh | bash
+    curl -fsSL https://lerd.sh/install.sh | bash
     ```
 
     Or if already installed:

--- a/docs/features/dns.md
+++ b/docs/features/dns.md
@@ -67,3 +67,13 @@ dns:
 ```
 
 Entries are plain IPs; an optional `#port` suffix is supported (e.g. `192.168.100.129#5353`). When `upstream` is set it takes precedence over auto-detection everywhere, both when lerd writes the dnsmasq config and when the NetworkManager dispatcher rewrites it after a network change. Re-run `lerd install` (or restart lerd-dns) to apply it, then confirm with `cat ~/.local/share/lerd/dnsmasq/lerd.conf`.
+
+## Reacting to network changes
+
+lerd reacts to host network changes on its own, so the resolver and any LAN exposure keep working when you switch Wi-Fi, dock, or get a new DHCP lease without you re-running anything.
+
+- **Upstream re-detection (Linux).** A NetworkManager dispatcher hook re-resolves the upstream DNS servers and rewrites the dnsmasq config after a connection comes up. A pinned `dns.upstream` always wins over what it detects.
+- **LAN-IP healing.** When you expose a site to the LAN (see [LAN sharing](../usage/lan-sharing.md)) and the host's LAN IP later changes, `lerd-watcher` notices the drift, re-renders the `lan:expose` mapping to the current IP, and restarts `lerd-dns` so the exposed hostnames keep pointing at the right address. This runs even while lerd is otherwise idle.
+- **macOS network watcher.** On macOS the watcher subscribes to the kernel's `PF_ROUTE` socket and triggers the same healing the moment an interface or route changes, rather than waiting for the next poll.
+
+This is why a manual `lerd remote-setup` re-run after an IP change is usually no longer necessary.

--- a/docs/features/tinker.md
+++ b/docs/features/tinker.md
@@ -56,6 +56,8 @@ tinker:
 The output panel is styled like a read-only editor: bordered box, monospace, line-number gutter rendered as CSS pseudo-elements so dragging across results never selects or copies the line numbers.
 
 - **One block per top-level statement.** Backend injects an ASCII `0x1E` separator after each statement, frontend splits on it. Multi-line scripts produce a numbered list of outputs, not one concatenated blob.
+- **Each block is framed with its source line and a `Line N` badge.** Every result shows the editor line that produced it, so in a multi-statement script you can see at a glance which line emitted which value. The output gutter collapses on rows without a marker, so results sit flush against the left edge.
+- **Laravel runs capture executed SQL.** A DB query listener inlines the bindings and renders every query that ran during a statement as its own full-width card, ordered just ahead of the result that triggered it, so you see exactly what hit the database (Tinkerwell-style). Laravel REPL mode only.
 - **Bare expressions auto-dump.** Type `User::count()` (no `dump`, no `echo`) and you see the value. The transformer wraps single-statement bare expressions in `dump(...)` (or `var_dump(...)` if Symfony VarDumper isn't installed). Statements that already produce side effects (`echo`, `return`, `throw`, control flow) are left alone.
 - **Collapsible tree view for objects/arrays.** Symfony VarDumper output is parsed client-side into a tree: classes, arrays, scalars, with click-to-expand/collapse, color-coded scalars, and visibility prefixes (`+public`, `#protected`, `-private`).
 - **Per-block Copy button** appears on hover.
@@ -71,6 +73,8 @@ Autocomplete, diagnostics, hover, and signature help are powered by [phpantom_ls
 
 Because it analyzes the real project, completions are genuinely project-aware: your Eloquent models, relationships, scopes, casts and Builder chains resolve end-to-end, alongside framework facades, vendor classes, and the PHP standard library. Hover a symbol for its docblock; type `(` inside a call for signature help.
 
+Quick fixes and imports are wired in too: the "Class not found" diagnostic offers an **Import `App\Models\X`** action, and accepting a class from the completion list brings its `use` statement along. Imports land at the top of the buffer with a blank line separating them from your code. Document formatting runs through phpantom on `Shift+Alt+F` and automatically on paste.
+
 The browser connects to the server over a WebSocket (`/api/lsp/php`). `lerd-ui` spawns one `phpantom_lsp` process per connection, rooted at the site (or worktree) path, and bridges its stdio LSP traffic to Monaco. Tinker buffers are headerless PHP, so the bridge presents the document to the server with a synthetic leading `<?php` line (and offsets positions accordingly) — you keep typing bare snippets while the server still parses valid PHP.
 
 A small status hint sits in the toolbar while the server is starting, and switches to "Language server unavailable" if it can't be reached. When that happens (offline first-run download, unsupported platform) the editor still works and code still runs — only the live intelligence is missing.
@@ -83,6 +87,7 @@ The server binary is fetched at `lerd install` time, and lazily on first connect
 |---|---|
 | `Ctrl+Enter` / `Cmd+Enter` | Run the editor contents |
 | `Ctrl+Space` | Trigger autocomplete |
+| `Shift+Alt+F` | Format the document via phpantom (also runs on paste) |
 | `Ctrl+Z` / `Ctrl+Y` | Undo / redo |
 
 ### Drafts

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -6,8 +6,8 @@
 |---|---|
 | `lerd install` | One-time setup: directories, network, binaries, DNS, nginx, watcher |
 | `lerd start` | Start DNS, nginx, PHP-FPM containers, and all installed services; warns about port conflicts and builds or pulls any missing images first |
-| `lerd stop` | Stop DNS, nginx, PHP-FPM containers, and all running services |
-| `lerd quit` | Stop all Lerd processes and containers including the UI, watcher, and tray; on macOS also stops the Podman Machine VM |
+| `lerd stop` | Stop nginx, PHP-FPM containers, and all running services; leaves the `lerd-dns` forwarder running as install-level plumbing so `.test` keeps resolving |
+| `lerd quit` | Stop all Lerd processes and containers including the UI, watcher, tray, and the `lerd-dns` forwarder; on macOS also stops the Podman Machine VM |
 | `lerd update` | Check for updates and update after confirmation |
 | `lerd update --beta` | Update to the latest pre-release build |
 | `lerd update --rollback` | Revert to the previously installed version |
@@ -54,7 +54,7 @@ Setup steps include common tasks (composer install, npm install, lerd env) plus 
 |---|---|
 | `lerd park [dir]` | Register all Laravel projects inside `dir` (defaults to cwd) |
 | `lerd unpark [dir]` | Remove a parked directory and unlink all its sites |
-| `lerd link [name]` | Register the current directory as a site; prompts to import data when `laravel/sail` is detected in `composer.json`. **Non-PHP projects** (Node.js, Python, Go, etc.) must have `Containerfile.lerd` and `.lerd.yaml` with `container: {port: N}` already written before calling this, see [Custom Containers](../usage/custom-containers.md) |
+| `lerd link [name]` | Register the current directory as a site. On a fresh project with no `.lerd.yaml`, an interactive terminal routes through the `lerd init` wizard first (PHP version, HTTPS, services) before linking; prompts to import data when `laravel/sail` is detected in `composer.json`. **Non-PHP projects** (Node.js, Python, Go, etc.) must have `Containerfile.lerd` and `.lerd.yaml` with `container: {port: N}` already written before calling this, see [Custom Containers](../usage/custom-containers.md) |
 | `lerd link [name] --domain foo.test` | Register with a custom domain |
 | `lerd unlink [name]` | Stop serving the site |
 | `lerd sites` | Table view of all registered sites |

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -13,8 +13,8 @@ Day-to-day lifecycle commands for the entire lerd stack: DNS, nginx, PHP-FPM con
 | Command | Stops | Starts |
 |---|---|---|
 | `lerd start` | nothing | DNS, nginx, watcher, tray, all PHP-FPM containers in use, services that were running before stop, queue / schedule / reverb / messenger workers, stripe listeners, Web UI |
-| `lerd stop` | All containers and workers above. Leaves the watcher and Web UI alone. | nothing |
-| `lerd quit` | Everything `lerd stop` does, **plus** the Web UI, watcher, and tray. macOS: also stops the Podman Machine VM. | nothing |
+| `lerd stop` | All containers and workers above **except** `lerd-dns`. Leaves the watcher, Web UI, and the DNS forwarder alone. | nothing |
+| `lerd quit` | Everything `lerd stop` does, **plus** the DNS forwarder, Web UI, watcher, and tray. macOS: also stops the Podman Machine VM. | nothing |
 
 `lerd stop` is the everyday "give my laptop back its CPU" command. `lerd quit` is a full shutdown: use it before a reinstall, a system reboot without autostart, or when you really want lerd out of the way.
 
@@ -59,10 +59,11 @@ Both paths skip `Ignored: true` sites — those are explicitly parked by the use
 lerd stop
 ```
 
-Stops everything `lerd start` started **except** the Web UI, watcher, and tray; those keep running so the dashboard stays reachable to bring lerd back up.
+Stops everything `lerd start` started **except** the Web UI, watcher, tray, and the `lerd-dns` forwarder; those keep running so the dashboard stays reachable to bring lerd back up.
 
 A few important details:
 
+- **The DNS forwarder stays up.** `lerd-dns` is treated as install-level plumbing: the system resolver keeps pointing `.test` at it until `lerd uninstall`, so stopping it would leave the resolver aimed at a dead port and make `.test` lookups stall. It is only torn down by `lerd quit` or `lerd uninstall`.
 - **Manually paused services are remembered.** If you stopped Mailpit earlier with `lerd service stop mailpit`, then `lerd stop` + `lerd start` will not bring Mailpit back. The pause flag survives the cycle.
 - **Pinned services start anyway.** A `lerd service pin <name>` overrides auto-stop logic; pinned services are always started by `lerd start` regardless of which sites are active.
 - **Worker state is preserved.** Workers running before `lerd stop` are restarted by the next `lerd start`; workers you manually stopped stay stopped.
@@ -81,7 +82,8 @@ The full off-switch:
 2. Stops `lerd-ui` (Web UI).
 3. Stops `lerd-watcher`.
 4. Kills the system tray process.
-5. **macOS only:** stops the Podman Machine VM.
+5. Stops the `lerd-dns` forwarder. Unlike `lerd stop`, quit is a full teardown, so it takes DNS down too. The watcher is stopped first (step 3) because it is the only thing that would restart `lerd-dns`.
+6. **macOS only:** stops the Podman Machine VM.
 
 After `lerd quit` there are no lerd processes left running. On macOS the Podman Machine VM is also shut down, so `lerd start` will bring it back up on the next run. This is the right command before a reinstall, a system reboot, or before pulling a major update.
 

--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
-# Lerd installer — https://github.com/geodro/lerd
+# Lerd installer — https://lerd.sh
 # Usage:
-#   Install:   curl -fsSL https://raw.githubusercontent.com/geodro/lerd/main/install.sh | bash
-#      or:     wget -qO- https://raw.githubusercontent.com/geodro/lerd/main/install.sh | bash
+#   Install:   curl -fsSL https://lerd.sh/install.sh | bash
+#      or:     wget -qO- https://lerd.sh/install.sh | bash
 #   Update:    lerd-installer --update
 #   Uninstall: lerd-installer --uninstall
 
 set -euo pipefail
 
 # ── Constants ────────────────────────────────────────────────────────────────
-REPO="geodro/lerd"
+# REPO is the GitHub owner/name release assets are fetched from; override with
+# LERD_REPO so a future org move needs no installer change.
+REPO="${LERD_REPO:-geodro/lerd}"
 BINARY="lerd"
 INSTALL_DIR="${LERD_INSTALL_DIR:-$HOME/.local/bin}"
 LERD_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/lerd"
@@ -691,7 +693,7 @@ main() {
   echo "  ╚══════╝╚══════╝╚═╝  ╚═╝╚═════╝ "
   echo -e "${RESET}"
   echo "  Lerd — Podman-powered local PHP dev environment for Linux and macOS"
-  echo "  https://github.com/${REPO}"
+  echo "  https://lerd.sh"
   echo ""
 
   case "${1:-install}" in

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
+	"github.com/geodro/lerd/internal/origin"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
 	"github.com/geodro/lerd/internal/store"
@@ -18,12 +19,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const githubRepo = "geodro/lerd"
-
-// These vars are overridden in tests to point at an httptest server.
-var (
-	githubDownloadBase = "https://github.com/" + githubRepo + "/releases/download"
-)
+// githubDownloadBases returns release-asset download bases in priority order,
+// read live. Overridden in tests to point at an httptest server.
+var githubDownloadBases = origin.ReleaseDownloadBases
 
 // NewUpdateCmd returns the update command.
 func NewUpdateCmd(currentVersion string) *cobra.Command {
@@ -86,7 +84,7 @@ func runUpdate(currentVersion string, beta bool) error {
 			fmt.Println("  " + line)
 		}
 	} else {
-		fmt.Printf("  https://github.com/%s/releases/tag/v%s\n", githubRepo, lat)
+		fmt.Printf("  %s/tag/v%s\n", origin.ReleaseBaseURLs()[0], lat)
 	}
 
 	// A Homebrew-managed binary lives under a Cellar prefix; self-replacing it
@@ -401,7 +399,6 @@ func downloadReleaseBinary(version string) (string, func(), error) {
 	ver := stripV(version)
 
 	filename := fmt.Sprintf("lerd_%s_%s_%s.tar.gz", ver, runtime.GOOS, arch)
-	url := fmt.Sprintf("%s/v%s/%s", githubDownloadBase, ver, filename)
 
 	tmp, err := os.MkdirTemp("", "lerd-update-*")
 	if err != nil {
@@ -410,9 +407,9 @@ func downloadReleaseBinary(version string) (string, func(), error) {
 	cleanup := func() { os.RemoveAll(tmp) }
 
 	archive := filepath.Join(tmp, filename)
-	if err := downloadFile(url, archive, 0644, io.Discard); err != nil {
+	if err := downloadArchive(ver, filename, archive); err != nil {
 		cleanup()
-		return "", func() {}, fmt.Errorf("download failed (%s): %w", url, err)
+		return "", func() {}, err
 	}
 
 	cmd := exec.Command("tar", "--no-same-owner", "-xzf", archive, "-C", tmp)
@@ -426,6 +423,22 @@ func downloadReleaseBinary(version string) (string, func(), error) {
 		return "", func() {}, fmt.Errorf("binary not found in archive")
 	}
 	return tmp, cleanup, nil
+}
+
+// downloadArchive fetches the release archive, trying each download base in
+// order until one succeeds, and returns an aggregated error if none do.
+func downloadArchive(ver, filename, archive string) error {
+	var errs []string
+	for _, base := range githubDownloadBases() {
+		url := fmt.Sprintf("%s/v%s/%s", base, ver, filename)
+		if err := downloadFile(url, archive, 0644, io.Discard); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", url, err))
+			continue
+		}
+		origin.NoteFetched(base)
+		return nil
+	}
+	return fmt.Errorf("download failed: %s", strings.Join(errs, "; "))
 }
 
 // isHomebrewManaged reports whether the resolved binary path lives inside a

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -61,9 +61,9 @@ func TestFetchLatestVersion_success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := lerdUpdate.ReleasesBaseURL
-	lerdUpdate.ReleasesBaseURL = srv.URL
-	defer func() { lerdUpdate.ReleasesBaseURL = orig }()
+	orig := lerdUpdate.ReleaseBaseURLs
+	lerdUpdate.ReleaseBaseURLs = func() []string { return []string{srv.URL} }
+	defer func() { lerdUpdate.ReleaseBaseURLs = orig }()
 
 	got, err := lerdUpdate.FetchLatestVersion()
 	if err != nil {
@@ -80,9 +80,9 @@ func TestFetchLatestVersion_withoutVPrefix(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := lerdUpdate.ReleasesBaseURL
-	lerdUpdate.ReleasesBaseURL = srv.URL
-	defer func() { lerdUpdate.ReleasesBaseURL = orig }()
+	orig := lerdUpdate.ReleaseBaseURLs
+	lerdUpdate.ReleaseBaseURLs = func() []string { return []string{srv.URL} }
+	defer func() { lerdUpdate.ReleaseBaseURLs = orig }()
 
 	got, err := lerdUpdate.FetchLatestVersion()
 	if err != nil {
@@ -99,9 +99,9 @@ func TestFetchLatestVersion_notFound(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := lerdUpdate.ReleasesBaseURL
-	lerdUpdate.ReleasesBaseURL = srv.URL
-	defer func() { lerdUpdate.ReleasesBaseURL = orig }()
+	orig := lerdUpdate.ReleaseBaseURLs
+	lerdUpdate.ReleaseBaseURLs = func() []string { return []string{srv.URL} }
+	defer func() { lerdUpdate.ReleaseBaseURLs = orig }()
 
 	_, err := lerdUpdate.FetchLatestVersion()
 	if err == nil {
@@ -115,9 +115,9 @@ func TestFetchLatestVersion_emptyTag(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := lerdUpdate.ReleasesBaseURL
-	lerdUpdate.ReleasesBaseURL = srv.URL
-	defer func() { lerdUpdate.ReleasesBaseURL = orig }()
+	orig := lerdUpdate.ReleaseBaseURLs
+	lerdUpdate.ReleaseBaseURLs = func() []string { return []string{srv.URL} }
+	defer func() { lerdUpdate.ReleaseBaseURLs = orig }()
 
 	_, err := lerdUpdate.FetchLatestVersion()
 	if err == nil {
@@ -131,9 +131,9 @@ func TestFetchLatestVersion_serverError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := lerdUpdate.ReleasesBaseURL
-	lerdUpdate.ReleasesBaseURL = srv.URL
-	defer func() { lerdUpdate.ReleasesBaseURL = orig }()
+	orig := lerdUpdate.ReleaseBaseURLs
+	lerdUpdate.ReleaseBaseURLs = func() []string { return []string{srv.URL} }
+	defer func() { lerdUpdate.ReleaseBaseURLs = orig }()
 
 	_, err := lerdUpdate.FetchLatestVersion()
 	if err == nil {
@@ -181,9 +181,9 @@ func TestDownloadReleaseBinary_success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := githubDownloadBase
-	githubDownloadBase = srv.URL
-	defer func() { githubDownloadBase = orig }()
+	orig := githubDownloadBases
+	githubDownloadBases = func() []string { return []string{srv.URL} }
+	defer func() { githubDownloadBases = orig }()
 
 	binary, cleanup, err := downloadReleaseBinary("v0.1.0")
 	if err != nil {
@@ -202,9 +202,9 @@ func TestDownloadReleaseBinary_serverError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := githubDownloadBase
-	githubDownloadBase = srv.URL
-	defer func() { githubDownloadBase = orig }()
+	orig := githubDownloadBases
+	githubDownloadBases = func() []string { return []string{srv.URL} }
+	defer func() { githubDownloadBases = orig }()
 
 	_, cleanup, err := downloadReleaseBinary("v0.1.0")
 	cleanup()
@@ -258,9 +258,9 @@ func TestRunUpdate_alreadyLatest(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := lerdUpdate.ReleasesBaseURL
-	lerdUpdate.ReleasesBaseURL = srv.URL
-	defer func() { lerdUpdate.ReleasesBaseURL = orig }()
+	orig := lerdUpdate.ReleaseBaseURLs
+	lerdUpdate.ReleaseBaseURLs = func() []string { return []string{srv.URL} }
+	defer func() { lerdUpdate.ReleaseBaseURLs = orig }()
 
 	// Should return nil without downloading anything
 	err := runUpdate("1.0.0", false)
@@ -335,9 +335,9 @@ func TestFetchLatestPrerelease_success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := lerdUpdate.APIBaseURL
-	lerdUpdate.APIBaseURL = srv.URL
-	defer func() { lerdUpdate.APIBaseURL = orig }()
+	orig := lerdUpdate.APIBaseURLs
+	lerdUpdate.APIBaseURLs = func() []string { return []string{srv.URL} }
+	defer func() { lerdUpdate.APIBaseURLs = orig }()
 
 	got, err := lerdUpdate.FetchLatestPrerelease()
 	if err != nil {
@@ -360,9 +360,9 @@ func TestFetchLatestPrerelease_noPrerelease(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := lerdUpdate.APIBaseURL
-	lerdUpdate.APIBaseURL = srv.URL
-	defer func() { lerdUpdate.APIBaseURL = orig }()
+	orig := lerdUpdate.APIBaseURLs
+	lerdUpdate.APIBaseURLs = func() []string { return []string{srv.URL} }
+	defer func() { lerdUpdate.APIBaseURLs = orig }()
 
 	_, err := lerdUpdate.FetchLatestPrerelease()
 	if err == nil {
@@ -376,9 +376,9 @@ func TestFetchLatestPrerelease_serverError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	orig := lerdUpdate.APIBaseURL
-	lerdUpdate.APIBaseURL = srv.URL
-	defer func() { lerdUpdate.APIBaseURL = orig }()
+	orig := lerdUpdate.APIBaseURLs
+	lerdUpdate.APIBaseURLs = func() []string { return []string{srv.URL} }
+	defer func() { lerdUpdate.APIBaseURLs = orig }()
 
 	_, err := lerdUpdate.FetchLatestPrerelease()
 	if err == nil {

--- a/internal/origin/origin.go
+++ b/internal/origin/origin.go
@@ -1,0 +1,161 @@
+// Package origin centralises every URL lerd fetches its own assets from (release
+// binaries, framework store, changelog, GHCR base images) and owns the
+// geodro->lerd-env move: old org first, new as fallback, flipping on a new-org hit.
+package origin
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+// org holds the repo coordinates for one GitHub owner.
+type org struct {
+	owner          string // GitHub org, also the GHCR namespace
+	mainRepo       string // owner/name for releases, installer, changelog
+	frameworksRepo string // owner/name for the framework store
+}
+
+// Links is the centralized handler for lerd's distribution URLs and the
+// old->new org switch. The zero value is not usable; use New or Default.
+type Links struct {
+	old, new  org
+	mu        sync.RWMutex
+	preferNew bool // when true, the new org is served first
+}
+
+// New builds a Links with the geodro (old) and lerd-env (new) coordinates,
+// preferring old first unless LERD_DISTRIBUTION_ORG says otherwise.
+func New() *Links {
+	l := &Links{
+		// geodro is the current (old) org, served first and kept as the fallback.
+		old: org{owner: "geodro", mainRepo: "geodro/lerd", frameworksRepo: "geodro/lerd-frameworks"},
+		new: org{owner: "lerd-env", mainRepo: "lerd-env/lerd", frameworksRepo: "lerd-env/frameworks"},
+	}
+	switch strings.ToLower(os.Getenv("LERD_DISTRIBUTION_ORG")) {
+	case "lerd-env", "new":
+		l.preferNew = true
+	case "geodro", "old":
+		l.preferNew = false
+	}
+	return l
+}
+
+// Default is the process-wide Links used by the package-level helpers.
+var Default = New()
+
+// PreferNew reports whether the new (lerd-env) org is served first.
+func (l *Links) PreferNew() bool {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.preferNew
+}
+
+// SetPreferNew sets which org is served first.
+func (l *Links) SetPreferNew(v bool) {
+	l.mu.Lock()
+	l.preferNew = v
+	l.mu.Unlock()
+}
+
+// ordered returns [preferred, other] for a function that maps an org to a URL.
+func (l *Links) ordered(of func(org) string) []string {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if l.preferNew {
+		return []string{of(l.new), of(l.old)}
+	}
+	return []string{of(l.old), of(l.new)}
+}
+
+func rawRepo(o org) string  { return "https://raw.githubusercontent.com/" + o.frameworksRepo }
+func rawMain(o org) string  { return "https://raw.githubusercontent.com/" + o.mainRepo }
+func releases(o org) string { return "https://github.com/" + o.mainRepo + "/releases" }
+func apiBase(o org) string  { return "https://api.github.com/repos/" + o.mainRepo }
+
+// StoreBaseURLs lists framework-store bases in priority order.
+func (l *Links) StoreBaseURLs() []string {
+	if list := splitList(os.Getenv("LERD_STORE_BASE_URL")); len(list) > 0 {
+		return list
+	}
+	return l.ordered(func(o org) string { return rawRepo(o) + "/main/frameworks" })
+}
+
+// ReleaseBaseURLs lists GitHub releases bases in priority order.
+func (l *Links) ReleaseBaseURLs() []string {
+	if list := splitList(os.Getenv("LERD_RELEASES_URL")); len(list) > 0 {
+		return list
+	}
+	return l.ordered(releases)
+}
+
+// ReleaseDownloadBases lists release-asset download bases in priority order.
+func (l *Links) ReleaseDownloadBases() []string {
+	if list := splitList(os.Getenv("LERD_RELEASE_DOWNLOAD_URL")); len(list) > 0 {
+		return list
+	}
+	out := l.ReleaseBaseURLs()
+	for i := range out {
+		out[i] += "/download"
+	}
+	return out
+}
+
+// ReleaseAPIBaseURLs lists GitHub API bases in priority order.
+func (l *Links) ReleaseAPIBaseURLs() []string {
+	if list := splitList(os.Getenv("LERD_RELEASES_API_URL")); len(list) > 0 {
+		return list
+	}
+	return l.ordered(apiBase)
+}
+
+// ChangelogURLs lists raw changelog URLs in priority order.
+func (l *Links) ChangelogURLs() []string {
+	if list := splitList(os.Getenv("LERD_CHANGELOG_URL")); len(list) > 0 {
+		return list
+	}
+	return l.ordered(func(o org) string { return rawMain(o) + "/main/CHANGELOG.md" })
+}
+
+// BaseImageRefs lists GHCR refs for a prebuilt PHP-FPM base image in priority
+// order, where phpShort is the dotless version (e.g. "85") and hash pins the
+// image to the embedded Containerfile template.
+func (l *Links) BaseImageRefs(phpShort, hash string) []string {
+	suffix := "/lerd-php" + phpShort + "-fpm-base:" + hash
+	if v := os.Getenv("LERD_BASE_IMAGE_REGISTRY"); v != "" {
+		return []string{v + suffix}
+	}
+	return l.ordered(func(o org) string { return "ghcr.io/" + o.owner + suffix })
+}
+
+// NoteFetched flips to serving the new org first the first time a real request
+// succeeds against a new-org URL (e.g. once the old org is retired). One-way,
+// old->new only; no probe, no timer.
+func (l *Links) NoteFetched(base string) {
+	if base == "" || l.PreferNew() {
+		return
+	}
+	if strings.Contains(base, "/"+l.new.owner+"/") {
+		l.SetPreferNew(true)
+	}
+}
+
+// splitList parses a comma-separated override into trimmed, non-empty entries.
+func splitList(v string) []string {
+	var out []string
+	for _, p := range strings.Split(v, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// Package-level helpers delegate to Default.
+func StoreBaseURLs() []string                      { return Default.StoreBaseURLs() }
+func ReleaseBaseURLs() []string                    { return Default.ReleaseBaseURLs() }
+func ReleaseDownloadBases() []string               { return Default.ReleaseDownloadBases() }
+func ReleaseAPIBaseURLs() []string                 { return Default.ReleaseAPIBaseURLs() }
+func ChangelogURLs() []string                      { return Default.ChangelogURLs() }
+func BaseImageRefs(phpShort, hash string) []string { return Default.BaseImageRefs(phpShort, hash) }
+func NoteFetched(base string)                      { Default.NoteFetched(base) }

--- a/internal/origin/origin_test.go
+++ b/internal/origin/origin_test.go
@@ -1,0 +1,122 @@
+package origin
+
+import (
+	"strings"
+	"testing"
+)
+
+// By default (before the org move) every endpoint must serve the old geodro
+// location first and the new lerd-env location as a fallback.
+func TestDefaultOrderOldFirstNewFallback(t *testing.T) {
+	l := New()
+	lists := map[string][]string{
+		"store":     l.StoreBaseURLs(),
+		"releases":  l.ReleaseBaseURLs(),
+		"downloads": l.ReleaseDownloadBases(),
+		"api":       l.ReleaseAPIBaseURLs(),
+		"changelog": l.ChangelogURLs(),
+		"baseimage": l.BaseImageRefs("85", "h"),
+	}
+	for name, got := range lists {
+		if len(got) != 2 {
+			t.Fatalf("%s: want 2 candidates, got %d (%v)", name, len(got), got)
+		}
+		if !strings.Contains(got[0], "geodro") {
+			t.Errorf("%s: primary %q is not the old geodro location", name, got[0])
+		}
+		if !strings.Contains(got[1], "lerd-env") {
+			t.Errorf("%s: fallback %q is not the new lerd-env location", name, got[1])
+		}
+	}
+}
+
+// After the switch, the new lerd-env location is served first and geodro becomes
+// the fallback.
+func TestSetPreferNewFlipsOrder(t *testing.T) {
+	l := New()
+	l.SetPreferNew(true)
+	if !l.PreferNew() {
+		t.Fatal("PreferNew() should be true after SetPreferNew(true)")
+	}
+	got := l.StoreBaseURLs()
+	if !strings.Contains(got[0], "lerd-env") || !strings.Contains(got[1], "geodro") {
+		t.Errorf("after switch want [lerd-env, geodro], got %v", got)
+	}
+}
+
+func TestDistributionOrgEnvForcesNew(t *testing.T) {
+	t.Setenv("LERD_DISTRIBUTION_ORG", "lerd-env")
+	l := New()
+	if !l.PreferNew() {
+		t.Fatal("LERD_DISTRIBUTION_ORG=lerd-env should prefer the new org")
+	}
+}
+
+// A malformed override (only commas/whitespace) must be ignored and fall back to
+// the defaults, never an empty list that would panic store.NewClient's urls[0].
+func TestEnvOverrideIgnoredWhenEmpty(t *testing.T) {
+	t.Setenv("LERD_STORE_BASE_URL", " , , ")
+	got := New().StoreBaseURLs()
+	if len(got) < 2 || !strings.Contains(got[0], "geodro") {
+		t.Fatalf("empty override must fall back to defaults, got %v", got)
+	}
+}
+
+func TestStoreEnvOverrideReplacesList(t *testing.T) {
+	t.Setenv("LERD_STORE_BASE_URL", "https://store.example/a, https://store.example/b")
+	got := New().StoreBaseURLs()
+	want := []string{"https://store.example/a", "https://store.example/b"}
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("override list = %v, want %v", got, want)
+	}
+}
+
+func TestBaseImageRefFormat(t *testing.T) {
+	refs := New().BaseImageRefs("84", "abc")
+	if refs[0] != "ghcr.io/geodro/lerd-php84-fpm-base:abc" {
+		t.Errorf("primary base ref = %q", refs[0])
+	}
+	if refs[1] != "ghcr.io/lerd-env/lerd-php84-fpm-base:abc" {
+		t.Errorf("fallback base ref = %q", refs[1])
+	}
+}
+
+// A request that succeeds against a new-org URL flips preference to new-first.
+// A request that succeeds against the old org leaves it alone.
+func TestNoteFetchedFlipsOnNewOrgSuccess(t *testing.T) {
+	l := New()
+
+	// A successful old-org fetch keeps us on old.
+	l.NoteFetched(l.StoreBaseURLs()[0]) // geodro (primary while old-first)
+	if l.PreferNew() {
+		t.Fatal("a successful old-org fetch must not flip to new")
+	}
+
+	// A successful new-org fetch (the fallback won) flips to new-first.
+	l.NoteFetched(l.StoreBaseURLs()[1]) // lerd-env (fallback while old-first)
+	if !l.PreferNew() {
+		t.Fatal("a successful new-org fetch must flip to new-first")
+	}
+	if !strings.Contains(l.StoreBaseURLs()[0], "lerd-env") {
+		t.Errorf("after the flip the new org should be served first, got %v", l.StoreBaseURLs())
+	}
+}
+
+// NoteFetched is one-directional and ignores unrelated or empty bases.
+func TestNoteFetchedIgnoresUnrelatedBase(t *testing.T) {
+	l := New()
+	l.NoteFetched("")
+	l.NoteFetched("https://example.com/whatever")
+	if l.PreferNew() {
+		t.Fatal("an empty or unrelated base must not flip preference")
+	}
+}
+
+// A new-org win works for a GHCR base-image ref too, not just raw URLs.
+func TestNoteFetchedMatchesGHCRRef(t *testing.T) {
+	l := New()
+	l.NoteFetched(l.BaseImageRefs("85", "h")[1]) // ghcr.io/lerd-env/...
+	if !l.PreferNew() {
+		t.Fatal("a successful new-org GHCR pull must flip to new-first")
+	}
+}

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/origin"
 )
 
 // WriteContainerUnitFn writes a container unit file for the given name and content.
@@ -306,7 +307,6 @@ func tryPullBaseImage(version string, w io.Writer) string {
 		return ""
 	}
 	short := strings.ReplaceAll(version, ".", "")
-	ref := fmt.Sprintf("ghcr.io/geodro/lerd-php%s-fpm-base:%s", short, hash)
 	fmt.Fprintf(w, "  Pulling pre-built PHP %s base image...\n", version)
 
 	// Use an empty auth file so the pull is always anonymous, regardless of
@@ -320,21 +320,26 @@ func tryPullBaseImage(version string, w io.Writer) string {
 		defer os.Remove(tmpAuth.Name())
 	}
 
-	args := []string{"pull", "--policy=always"}
-	args = append(args, PlatformPullArgs(ref)...)
-	if tmpAuth != nil {
-		args = append(args, "--authfile="+tmpAuth.Name())
-	}
-	args = append(args, ref)
+	// Try each registry in order (old org first, new org fallback) so a binary
+	// keeps pulling across the org move without a rebuild.
+	for _, ref := range origin.BaseImageRefs(short, hash) {
+		args := []string{"pull", "--policy=always"}
+		args = append(args, PlatformPullArgs(ref)...)
+		if tmpAuth != nil {
+			args = append(args, "--authfile="+tmpAuth.Name())
+		}
+		args = append(args, ref)
 
-	cmd := exec.Command(PodmanBin(), args...)
-	cmd.Stdout = w
-	cmd.Stderr = io.Discard
-	if err := cmd.Run(); err != nil {
-		fmt.Fprintf(w, "  Pre-built image unavailable, falling back to local build (may take a few minutes)...\n")
-		return ""
+		cmd := exec.Command(PodmanBin(), args...)
+		cmd.Stdout = w
+		cmd.Stderr = io.Discard
+		if err := cmd.Run(); err == nil {
+			origin.NoteFetched(ref)
+			return ref
+		}
 	}
-	return ref
+	fmt.Fprintf(w, "  Pre-built image unavailable, falling back to local build (may take a few minutes)...\n")
+	return ""
 }
 
 func buildFPMImage(version string, force, local bool, customExts []string, extDeps map[string][]string, packages []string, w io.Writer) error {

--- a/internal/podman/network.go
+++ b/internal/podman/network.go
@@ -455,6 +455,6 @@ func friendlyNetworkCreateError(err error) error {
 	const prose = "podman is too old: `podman network create` does not support --dns " +
 		"(added in podman 4.5). Upgrade podman to 4.5 or newer; several distro " +
 		"releases (Ubuntu 22.04, Zorin 17, Debian 11/12) still ship older builds, see " +
-		"https://geodro.github.io/lerd/getting-started/requirements for options"
+		"https://lerd.sh/getting-started/requirements for options"
 	return fmt.Errorf("%s: %w", prose, err)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -9,17 +9,18 @@ import (
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/origin"
 	"gopkg.in/yaml.v3"
 )
 
-const (
-	defaultBaseURL = "https://raw.githubusercontent.com/geodro/lerd-frameworks/main/frameworks"
-	httpTimeout    = 10 * time.Second
-)
+const httpTimeout = 10 * time.Second
 
-// Client fetches framework definitions from the remote store.
+// Client fetches framework definitions from the remote store. BaseURL is tried
+// first; Fallbacks are tried in order if it fails, so a binary can reach the new
+// store location after an org move and fall back to the old one before it.
 type Client struct {
-	BaseURL string
+	BaseURL   string
+	Fallbacks []string
 }
 
 // Index is the top-level store index listing all available frameworks.
@@ -57,8 +58,10 @@ func autoFetchFramework(name, version string) (*config.Framework, error) {
 
 // NewClient returns a store client with default settings.
 func NewClient() *Client {
+	urls := origin.StoreBaseURLs()
 	return &Client{
-		BaseURL: defaultBaseURL,
+		BaseURL:   urls[0],
+		Fallbacks: urls[1:],
 	}
 }
 
@@ -189,8 +192,20 @@ func (c *Client) findEntry(idx *Index, name string) (*IndexEntry, bool) {
 }
 
 func (c *Client) fetch(path string) ([]byte, error) {
-	url := c.BaseURL + "/" + path
 	client := &http.Client{Timeout: httpTimeout}
+	var errs []string
+	for _, base := range append([]string{c.BaseURL}, c.Fallbacks...) {
+		body, err := fetchOne(client, base+"/"+path)
+		if err == nil {
+			origin.NoteFetched(base)
+			return body, nil
+		}
+		errs = append(errs, err.Error())
+	}
+	return nil, fmt.Errorf("fetching %s: %s", path, strings.Join(errs, "; "))
+}
+
+func fetchOne(client *http.Client, url string) ([]byte, error) {
 	req, err := http.NewRequest(http.MethodGet, url, nil) //nolint:noctx
 	if err != nil {
 		return nil, err

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
@@ -80,6 +81,53 @@ func testClient(t *testing.T, srv *httptest.Server) *Client {
 	t.Helper()
 	return &Client{
 		BaseURL: srv.URL,
+	}
+}
+
+// When the primary base returns a non-200, the client must transparently fetch
+// from the fallback base. This is the geodro->lerd-env transition path.
+func TestFetchIndex_FallsBackWhenPrimaryFails(t *testing.T) {
+	good := testServer(t)
+	defer good.Close()
+
+	c := &Client{
+		BaseURL:   good.URL + "/missing", // /missing/index.json -> 404
+		Fallbacks: []string{good.URL},
+	}
+	idx, err := c.FetchIndex()
+	if err != nil {
+		t.Fatalf("FetchIndex should succeed via fallback: %v", err)
+	}
+	if len(idx.Frameworks) == 0 || idx.Frameworks[0].Name != "laravel" {
+		t.Fatalf("unexpected index from fallback: %+v", idx)
+	}
+}
+
+// When every base fails (e.g. an internet outage), the client returns an error
+// rather than silently changing anything.
+func TestFetchIndex_AllBasesFail(t *testing.T) {
+	good := testServer(t)
+	dead := good.URL
+	good.Close() // now refuses connections
+
+	c := &Client{
+		BaseURL:   dead,
+		Fallbacks: []string{dead + "/also-dead"},
+	}
+	if _, err := c.FetchIndex(); err == nil {
+		t.Fatal("expected an error when all bases are unreachable")
+	}
+}
+
+// NewClient wires the ordered store URLs from origin: the old org first, the new
+// org as the fallback.
+func TestNewClient_OldOrgFirstNewFallback(t *testing.T) {
+	c := NewClient()
+	if !strings.Contains(c.BaseURL, "geodro") {
+		t.Errorf("primary store URL = %q, want geodro first", c.BaseURL)
+	}
+	if len(c.Fallbacks) == 0 || !strings.Contains(c.Fallbacks[0], "lerd-env") {
+		t.Errorf("fallback store URLs = %v, want lerd-env present", c.Fallbacks)
 	}
 }
 

--- a/internal/ui/web/src/stores/dashboard.ts
+++ b/internal/ui/web/src/stores/dashboard.ts
@@ -16,7 +16,7 @@ export const dashboardOpen = writable<DashboardRef | null>(null);
 const DOCS_REF: DashboardRef = {
   name: 'docs',
   label: 'Documentation',
-  dashboard: 'https://geodro.github.io/lerd/'
+  dashboard: 'https://lerd.sh/'
 };
 
 // PROFILER_REF is the synthetic entry for the SPX profiler. The UI is proxied

--- a/internal/ui/wsframe.go
+++ b/internal/ui/wsframe.go
@@ -32,6 +32,14 @@ const (
 	wsOpPong  = 0xA
 )
 
+// maxWSFrameBytes caps a single inbound frame payload: the client declares the
+// length before any data arrives, so without a ceiling a forged length forces a
+// multi-gigabyte allocation. 64 MiB matches the LSP message ceiling.
+const maxWSFrameBytes = 64 << 20
+
+// errFrameTooLarge is returned when a client declares a payload over the cap.
+var errFrameTooLarge = errors.New("ui: websocket frame exceeds size limit")
+
 // wsConn wraps a hijacked net.Conn with the buffered reader from the
 // handshake so WriteText and ReadFrame can share the same underlying stream.
 type wsConn struct {
@@ -185,6 +193,10 @@ func (c *wsConn) ReadFrame() (op byte, payload []byte, err error) {
 			return
 		}
 		plen = int(binary.BigEndian.Uint64(ext[:]))
+	}
+	if plen < 0 || plen > maxWSFrameBytes {
+		err = errFrameTooLarge
+		return
 	}
 	var mask [4]byte
 	if masked {

--- a/internal/ui/wsframe_limit_test.go
+++ b/internal/ui/wsframe_limit_test.go
@@ -1,0 +1,30 @@
+package ui
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+// A client declares the payload length before any data arrives, so a forged
+// 64-bit length must be rejected before ReadFrame allocates — otherwise one
+// frame forces a multi-gigabyte allocation on /api/ws and /api/lsp/php.
+func TestReadFrame_RejectsOversizedDeclaredLength(t *testing.T) {
+	var buf bytes.Buffer
+	buf.WriteByte(wsOpText)   // fin bit unset is fine, opcode is all ReadFrame inspects
+	buf.WriteByte(0x80 | 127) // masked, 64-bit extended length follows
+	var ext [8]byte
+	binary.BigEndian.PutUint64(ext[:], uint64(maxWSFrameBytes)+1)
+	buf.Write(ext[:])
+
+	c := &wsConn{br: bufio.NewReader(&buf)}
+	_, payload, err := c.ReadFrame()
+	if !errors.Is(err, errFrameTooLarge) {
+		t.Fatalf("expected errFrameTooLarge, got %v", err)
+	}
+	if payload != nil {
+		t.Fatalf("expected no payload allocation, got %d bytes", len(payload))
+	}
+}

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -12,9 +12,11 @@ import (
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/origin"
 )
 
-const changelogRawURL = "https://raw.githubusercontent.com/geodro/lerd/main/CHANGELOG.md"
+// changelogURLs returns raw changelog URLs in priority order, read live.
+var changelogURLs = origin.ChangelogURLs
 
 // UpdateInfo holds the result of a successful update check when a newer version exists.
 type UpdateInfo struct {
@@ -102,7 +104,21 @@ func WriteUpdateCache(version string) {
 // Returns an empty string and a non-nil error when the fetch fails.
 func FetchChangelog(currentVersion, latestVersion string) (string, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, changelogRawURL, nil) //nolint:noctx
+	var errs []string
+	for _, url := range changelogURLs() {
+		body, err := fetchChangelogFrom(client, url)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		origin.NoteFetched(url)
+		return extractChangelogSections(body, currentVersion, latestVersion), nil
+	}
+	return "", fmt.Errorf("fetching changelog: %s", strings.Join(errs, "; "))
+}
+
+func fetchChangelogFrom(client *http.Client, url string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil) //nolint:noctx
 	if err != nil {
 		return "", err
 	}
@@ -113,13 +129,13 @@ func FetchChangelog(currentVersion, latestVersion string) (string, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("HTTP %d fetching changelog", resp.StatusCode)
+		return "", fmt.Errorf("HTTP %d fetching changelog from %s", resp.StatusCode, url)
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
-	return extractChangelogSections(string(body), currentVersion, latestVersion), nil
+	return string(body), nil
 }
 
 // extractChangelogSections parses changelog markdown and returns sections where

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -6,17 +6,34 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/geodro/lerd/internal/origin"
 )
 
-// ReleasesBaseURL is the base GitHub releases URL. Overridable in tests.
-var ReleasesBaseURL = "https://github.com/geodro/lerd/releases"
+// ReleaseBaseURLs returns the GitHub releases bases in priority order, read live
+// so a NoteFetched flip reorders them. Overridable in tests.
+var ReleaseBaseURLs = origin.ReleaseBaseURLs
 
-// APIBaseURL is the GitHub API base URL for the repo. Overridable in tests.
-var APIBaseURL = "https://api.github.com/repos/geodro/lerd"
+// APIBaseURLs returns the GitHub API bases in priority order. Overridable in tests.
+var APIBaseURLs = origin.ReleaseAPIBaseURLs
 
-// FetchLatestVersion returns the latest published release tag from GitHub.
+// FetchLatestVersion returns the latest published release tag, trying each
+// release base in order until one answers.
 func FetchLatestVersion() (string, error) {
-	url := ReleasesBaseURL + "/latest"
+	var errs []string
+	for _, base := range ReleaseBaseURLs() {
+		v, err := fetchLatestFrom(base)
+		if err == nil {
+			origin.NoteFetched(base)
+			return v, nil
+		}
+		errs = append(errs, err.Error())
+	}
+	return "", fmt.Errorf("fetching latest version: %s", strings.Join(errs, "; "))
+}
+
+func fetchLatestFrom(base string) (string, error) {
+	url := base + "/latest"
 	client := &http.Client{
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
@@ -63,7 +80,20 @@ type githubRelease struct {
 // Unlike FetchLatestVersion, this calls the GitHub API because the
 // /releases/latest redirect only returns stable releases.
 func FetchLatestPrerelease() (string, error) {
-	url := APIBaseURL + "/releases"
+	var errs []string
+	for _, base := range APIBaseURLs() {
+		v, err := fetchPrereleaseFrom(base)
+		if err == nil {
+			origin.NoteFetched(base)
+			return v, nil
+		}
+		errs = append(errs, err.Error())
+	}
+	return "", fmt.Errorf("fetching latest pre-release: %s", strings.Join(errs, "; "))
+}
+
+func fetchPrereleaseFrom(base string) (string, error) {
+	url := base + "/releases"
 	req, err := http.NewRequest(http.MethodGet, url, nil) //nolint:noctx
 	if err != nil {
 		return "", err
@@ -96,7 +126,7 @@ func FetchLatestPrerelease() (string, error) {
 			return r.TagName, nil
 		}
 	}
-	return "", fmt.Errorf("no pre-release found")
+	return "", fmt.Errorf("no pre-release found from %s", url)
 }
 
 // StripV removes a leading "v" from a version string.


### PR DESCRIPTION
This branch prepares for moving the repos from geodro to a lerd-env org without a flag day. The bulk is a new internal origin package that becomes the single source of truth for every URL lerd fetches its own assets from: the framework store, release binaries, the changelog, and the prebuilt GHCR base images. Each endpoint is served as an ordered list with the current geodro location first and the future lerd-env location as a fallback, so a binary shipped today keeps working and transparently falls through to the new org the moment it exists. The switch is request-driven: the first time a real fetch succeeds against a lerd-env URL the preference flips to new-first for the rest of the process, so installs migrate on their own once geodro is retired, with no probe, no timer, and no second release. A malformed list override falls back to the defaults, so a bad LERD_STORE_BASE_URL can never empty the list and panic. Publish targets stay on geodro because the actual GitHub move has not happened yet, and the installer gains a LERD_REPO override so that step needs no installer change.

Bundled alongside are the pre-release review fixes. ReadFrame now caps an inbound websocket frame's declared payload at 64 MiB before allocating, closing an unbounded-allocation path the new /api/lsp/php endpoint exposes to browser frames. The docs are corrected for the new lerd stop and lerd quit DNS behaviour, the tinker output additions, the automatic network-change healing, and the lerd link init wizard, and the remaining geodro.github.io and raw GitHub doc links now point at lerd.sh.
