### PR TITLE
Unify install/start CLI output on the feedback vocabulary

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -273,7 +273,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 
 	if wantDNS {
 		// 4. mkcert CA, interactive (may prompt for sudo)
-		feedback.Line("installing mkcert CA")
+		feedback.Sudo("Installing mkcert CA")
 		mkcertCmd := exec.Command(certs.MkcertPath(), "-install")
 		mkcertCmd.Stdin = os.Stdin
 		mkcertCmd.Stdout = os.Stdout
@@ -292,7 +292,8 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		dnsChanged = dnsChanged || confChanged
 		ok()
 
-		feedback.Line("installing DNS sudoers rule")
+		// InstallSudoers prints its own gold "🔒 Installing DNS sudoers rule"
+		// line when it actually writes the drop-in, so no header is printed here.
 		dns.InstallSudoers() //nolint:errcheck
 	} else {
 		feedback.Line("DNS disabled, skipping mkcert CA, dnsmasq and sudoers")

--- a/internal/cli/install_autostart_darwin.go
+++ b/internal/cli/install_autostart_darwin.go
@@ -3,9 +3,9 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/services"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 )
@@ -16,14 +16,14 @@ import (
 func installAutostart() {
 	content, err := lerdSystemd.GetUnit("lerd-autostart")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "  WARN: autostart unit: %v\n", err)
+		feedback.WarnOn(os.Stderr, "autostart unit: %v", err)
 		return
 	}
 	if err := services.Mgr.WriteServiceUnit("lerd-autostart", content); err != nil {
-		fmt.Fprintf(os.Stderr, "  WARN: writing autostart service: %v\n", err)
+		feedback.WarnOn(os.Stderr, "writing autostart service: %v", err)
 		return
 	}
 	if err := services.Mgr.Enable("lerd-autostart"); err != nil {
-		fmt.Fprintf(os.Stderr, "  WARN: enabling autostart: %v\n", err)
+		feedback.WarnOn(os.Stderr, "enabling autostart: %v", err)
 	}
 }

--- a/internal/cli/install_cleanup_darwin.go
+++ b/internal/cli/install_cleanup_darwin.go
@@ -3,9 +3,10 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/geodro/lerd/internal/feedback"
 )
 
 const lerdCleanupScript = `#!/bin/sh
@@ -75,11 +76,11 @@ echo "Run 'brew uninstall lerd' if you haven't already."
 func installCleanupScript() {
 	binDir := filepath.Join(os.Getenv("HOME"), ".local", "bin")
 	if err := os.MkdirAll(binDir, 0755); err != nil {
-		fmt.Printf("    WARN: could not create %s: %v\n", binDir, err)
+		feedback.Warn("could not create %s: %v", binDir, err)
 		return
 	}
 	dest := filepath.Join(binDir, "lerd-cleanup")
 	if err := os.WriteFile(dest, []byte(lerdCleanupScript), 0755); err != nil {
-		fmt.Printf("    WARN: could not write lerd-cleanup script: %v\n", err)
+		feedback.Warn("could not write lerd-cleanup script: %v", err)
 	}
 }

--- a/internal/cli/install_darwin.go
+++ b/internal/cli/install_darwin.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/phpantom"
 )
 
@@ -69,7 +70,7 @@ func downloadBinaries(w io.Writer) error {
 	// here (offline install, unsupported arch) must not abort setup.
 	if !phpantom.Installed() {
 		if err := phpantom.EnsureBinary(context.Background(), w); err != nil {
-			fmt.Fprintf(w, "      Warning: phpantom_lsp download failed (%v); tinker autocomplete loads on first use instead\n", err)
+			feedback.WarnOn(w, "phpantom_lsp download failed (%v); tinker autocomplete loads on first use instead", err)
 		}
 	}
 
@@ -94,19 +95,19 @@ func ensurePortForwarding() error {
 	// Locate the podman-mac-helper binary.
 	helperPath, err := findPodmanMacHelper()
 	if err != nil {
-		fmt.Printf("    WARN: podman-mac-helper not found — ports 80/443 may not work.\n")
-		fmt.Printf("    Install Podman via Homebrew and re-run 'lerd install'.\n")
+		feedback.Warn("podman-mac-helper not found — ports 80/443 may not work.")
+		feedback.Note("Install Podman via Homebrew and re-run 'lerd install'.")
 		return nil // not fatal; containers still work on non-privileged ports
 	}
 
-	fmt.Println("  [sudo required] Installing podman-mac-helper for ports 80/443")
+	feedback.Sudo("Installing podman-mac-helper for ports 80/443")
 	cmd := exec.Command("sudo", helperPath, "install")
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		fmt.Printf("    WARN: podman-mac-helper install: %v\n", err)
-		fmt.Printf("    Ports 80/443 may not work — run manually: sudo %s install\n", helperPath)
+		feedback.Warn("podman-mac-helper install: %v", err)
+		feedback.Note(fmt.Sprintf("Ports 80/443 may not work — run manually: sudo %s install", helperPath))
 	}
 	return nil
 }

--- a/internal/cli/install_dns_darwin.go
+++ b/internal/cli/install_dns_darwin.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
 )
@@ -25,7 +26,7 @@ func installDNSService(w io.Writer) error {
 		if _, berr := exec.LookPath("brew"); berr != nil {
 			return fmt.Errorf("dnsmasq not found and Homebrew not available — install dnsmasq manually")
 		}
-		fmt.Fprintln(w, "==> Installing dnsmasq via Homebrew")
+		feedback.LineOn(w, "Installing dnsmasq via Homebrew…")
 		cmd := exec.Command("brew", "install", "dnsmasq")
 		cmd.Stdout = w
 		cmd.Stderr = w
@@ -148,7 +149,7 @@ func writeDNSUnit(_ io.Writer) error {
 // container-based approach, migrating to native dnsmasq automatically.
 func ensureDNSServiceUpdated(w io.Writer) error {
 	if needsDNSServiceInstall() {
-		fmt.Fprintln(w, "  --> Migrating DNS from container to native dnsmasq ...")
+		feedback.LineOn(w, "Migrating DNS from container to native dnsmasq…")
 		return installDNSService(w)
 	}
 	return nil

--- a/internal/cli/machine_reset_darwin.go
+++ b/internal/cli/machine_reset_darwin.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 )
 
@@ -40,13 +41,13 @@ func runMachineReset(assumeYes bool) error {
 		}
 	}
 
-	fmt.Printf("  --> Stopping Podman Machine %q ...\n", name)
+	feedback.Line(fmt.Sprintf("Stopping Podman Machine %q…", name))
 	stop := exec.Command(podman.PodmanBin(), "machine", "stop", name)
 	stop.Stdout = os.Stdout
 	stop.Stderr = os.Stderr
 	_ = stop.Run() // a stopped machine still removes fine
 
-	fmt.Printf("  --> Removing Podman Machine %q ...\n", name)
+	feedback.Line(fmt.Sprintf("Removing Podman Machine %q…", name))
 	rm := exec.Command(podman.PodmanBin(), "machine", "rm", "-f", name)
 	rm.Stdout = os.Stdout
 	rm.Stderr = os.Stderr

--- a/internal/cli/machine_restart_heal_darwin.go
+++ b/internal/cli/machine_restart_heal_darwin.go
@@ -3,13 +3,13 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 )
 
@@ -115,7 +115,7 @@ func healMachineRestartIfNeeded(preEnsureLastUp string) {
 // the host and gvproxy re-registers the host port forwards.
 func removeLerdContainersForGvproxyHeal() {
 	forceRemoveLerdContainers(false,
-		"  --> Podman Machine was restarted; recreating containers to restore host port forwards ...")
+		"Podman Machine was restarted; recreating containers to restore host port forwards…")
 }
 
 // forceRemoveLerdContainers force-removes lerd-* containers so the next
@@ -141,9 +141,12 @@ func forceRemoveLerdContainers(includeStopped bool, announce string) {
 	if len(names) == 0 {
 		return
 	}
-	fmt.Println(announce)
+	feedback.Line(announce)
 	args := append([]string{"rm", "-f"}, names...)
 	if out, err := exec.Command(podman.PodmanBin(), args...).CombinedOutput(); err != nil {
-		fmt.Printf("       WARN: podman rm -f failed: %v\n%s\n", err, strings.TrimSpace(string(out)))
+		feedback.Warn("podman rm -f failed: %v", err)
+		if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+			feedback.Note(trimmed)
+		}
 	}
 }

--- a/internal/cli/overlay_heal_darwin.go
+++ b/internal/cli/overlay_heal_darwin.go
@@ -3,10 +3,10 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 )
 
@@ -25,7 +25,7 @@ func healOverlayCorruptionIfNeeded(err error) bool {
 	}
 	restartPodmanMachineForHeal()
 	forceRemoveLerdContainers(true,
-		"  --> Clearing stale lerd containers so they rebuild on fresh storage ...")
+		"Clearing stale lerd containers so they rebuild on fresh storage…")
 	return true
 }
 
@@ -37,12 +37,12 @@ func restartPodmanMachineForHeal() {
 	if name == "" {
 		return
 	}
-	fmt.Println("  --> Container storage looks stale after an unclean shutdown; restarting the Podman Machine to remount it ...")
+	feedback.Line("Container storage looks stale after an unclean shutdown; restarting the Podman Machine to remount it…")
 	stop := exec.Command(podman.PodmanBin(), "machine", "stop", name)
 	stop.Stdout = os.Stdout
 	stop.Stderr = os.Stderr
 	if err := stop.Run(); err != nil {
-		fmt.Printf("  WARN: podman machine stop: %v\n", err)
+		feedback.Warn("podman machine stop: %v", err)
 	}
 	// ensurePodmanMachineRunning starts the VM and waits for the API socket.
 	ensurePodmanMachineRunning()
@@ -57,11 +57,11 @@ func reportOverlayHealOutcome(err error) bool {
 	if !isOverlayStorageError(err) {
 		return false
 	}
-	fmt.Println()
-	fmt.Println("  Podman Machine container storage is still corrupted after a restart.")
-	fmt.Println("  This happens when the host shuts down while the VM is running.")
-	fmt.Println("  Your databases and site data are safe; they live on the host, not in the VM.")
-	fmt.Println("  Recreate the VM to fix it (images are rebuilt automatically on the next start):")
-	fmt.Println("      lerd machine reset")
+	feedback.Begin()
+	feedback.Warn("Podman Machine container storage is still corrupted after a restart.")
+	feedback.Note("This happens when the host shuts down while the VM is running.")
+	feedback.Note("Your databases and site data are safe; they live on the host, not in the VM.")
+	feedback.Note("Recreate the VM to fix it (images are rebuilt automatically on the next start):")
+	feedback.Note("    lerd machine reset")
 	return true
 }

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 )
 
@@ -145,9 +146,8 @@ func machineMissingHomeMount(name string) bool {
 // (every bind mount fails), so nothing of value is lost. The caller starts the
 // freshly-initialised machine.
 func recreateBrokenMachine(name string, running bool, targetMemoryMiB int64) {
-	fmt.Println("  --> Podman Machine is missing the host home mount and can't be repaired")
-	fmt.Println("      in place; recreating it. No running containers are affected (a")
-	fmt.Println("      machine in this state can't start any).")
+	feedback.Line("Podman Machine is missing the host home mount; recreating it (can't be repaired in place)…")
+	feedback.Note("No running containers are affected; a machine in this state can't start any.")
 	if running {
 		stopCmd := exec.Command(podman.PodmanBin(), "machine", "stop", name)
 		stopCmd.Stdout = os.Stdout
@@ -158,14 +158,14 @@ func recreateBrokenMachine(name string, running bool, targetMemoryMiB int64) {
 	rmCmd.Stdout = os.Stdout
 	rmCmd.Stderr = os.Stderr
 	if err := rmCmd.Run(); err != nil {
-		fmt.Printf("  WARN: podman machine rm: %v\n", err)
+		feedback.Warn("podman machine rm: %v", err)
 		return
 	}
 	initCmd := exec.Command(podman.PodmanBin(), machineInitArgs(name, targetMemoryMiB)...)
 	initCmd.Stdout = os.Stdout
 	initCmd.Stderr = os.Stderr
 	if err := initCmd.Run(); err != nil {
-		fmt.Printf("  WARN: podman machine init: %v\n", err)
+		feedback.Warn("podman machine init: %v", err)
 	}
 }
 
@@ -225,7 +225,7 @@ func ensurePodmanMachineRunning() {
 	}
 
 	if len(machines) == 0 {
-		fmt.Println("  --> Initialising Podman Machine (first run, this may take a minute) ...")
+		feedback.Line("Initialising Podman Machine (first run, this may take a minute)…")
 		// Size memory at init so a fresh VM (first run, or one recreated by
 		// `lerd machine reset`) boots at the host-scaled target rather than
 		// podman's stock default. The existing-machine branch below only
@@ -237,7 +237,7 @@ func ensurePodmanMachineRunning() {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
-			fmt.Printf("  WARN: podman machine init: %v\n", err)
+			feedback.Warn("podman machine init: %v", err)
 			return
 		}
 	} else {
@@ -278,34 +278,34 @@ func ensurePodmanMachineRunning() {
 						parts = append(parts, fmt.Sprintf("increase memory to %d MB", targetMemoryMiB))
 					}
 					reason := strings.Join(parts, " and ")
-					fmt.Printf("  --> Stopping Podman Machine to %s ...\n", reason)
+					feedback.Line(fmt.Sprintf("Stopping Podman Machine to %s…", reason))
 					stopCmd := exec.Command(podman.PodmanBin(), "machine", "stop", m.name)
 					stopCmd.Stdout = os.Stdout
 					stopCmd.Stderr = os.Stderr
 					stopCmd.Run() //nolint:errcheck
 				}
 				if needsRootful {
-					fmt.Println("  --> Enabling rootful mode for Podman Machine (required for ports 80/443) ...")
+					feedback.Line("Enabling rootful mode for Podman Machine (required for ports 80/443)…")
 					setCmd := exec.Command(podman.PodmanBin(), "machine", "set", "--rootful", m.name)
 					setCmd.Stdout = os.Stdout
 					setCmd.Stderr = os.Stderr
 					if err := setCmd.Run(); err != nil {
-						fmt.Printf("  WARN: podman machine set --rootful: %v\n", err)
+						feedback.Warn("podman machine set --rootful: %v", err)
 					}
 				}
 				if needsMemory {
 					if hostGiB > 0 && hostGiB <= 8 {
-						fmt.Printf("  --> Host has %d GB RAM; setting Podman Machine to %d MB (tight but workable) ...\n", hostGiB, targetMemoryMiB)
-						fmt.Println("       If sites slow down under load, run: podman machine set --memory 4096")
+						feedback.Line(fmt.Sprintf("Host has %d GB RAM; setting Podman Machine to %d MB (tight but workable)…", hostGiB, targetMemoryMiB))
+						feedback.Note("If sites slow down under load, run: podman machine set --memory 4096")
 					} else {
-						fmt.Printf("  --> Setting Podman Machine memory to %d MB ...\n", targetMemoryMiB)
+						feedback.Line(fmt.Sprintf("Setting Podman Machine memory to %d MB…", targetMemoryMiB))
 					}
 					setCmd := exec.Command(podman.PodmanBin(), "machine", "set",
 						"--memory", strconv.FormatInt(targetMemoryMiB, 10), m.name)
 					setCmd.Stdout = os.Stdout
 					setCmd.Stderr = os.Stderr
 					if err := setCmd.Run(); err != nil {
-						fmt.Printf("  WARN: podman machine set --memory: %v\n", err)
+						feedback.Warn("podman machine set --memory: %v", err)
 					}
 				}
 			} else if m.running {
@@ -314,12 +314,12 @@ func ensurePodmanMachineRunning() {
 		}
 	}
 
-	fmt.Println("  --> Starting Podman Machine ...")
+	feedback.Line("Starting Podman Machine…")
 	cmd := exec.Command(podman.PodmanBin(), "machine", "start")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		fmt.Printf("  WARN: podman machine start: %v\n", err)
+		feedback.Warn("podman machine start: %v", err)
 		return
 	}
 
@@ -327,18 +327,21 @@ func ensurePodmanMachineRunning() {
 	// container operations. Poll `podman ps` (which exercises the full
 	// container stack, not just the info endpoint) until it succeeds, then
 	// wait a few extra seconds for the socket to fully settle.
-	fmt.Print("  --> Waiting for Podman Machine to be ready ...")
+	// Printed in place (no feedback.Line) so the polling dots and the final
+	// "ready" land on the same line; the leading pad + dim arrow still match
+	// the surrounding feedback vocabulary.
+	fmt.Printf(" %s %s", feedback.Dim("→"), feedback.Dim("Waiting for Podman Machine to be ready…"))
 	deadline := time.Now().Add(120 * time.Second)
 	for time.Now().Before(deadline) {
 		if err := exec.Command(podman.PodmanBin(), "ps", "-q").Run(); err == nil {
 			time.Sleep(3 * time.Second) // grace period before container ops
-			fmt.Println(" ready")
+			fmt.Println(" " + feedback.Green("ready"))
 			return
 		}
 		time.Sleep(500 * time.Millisecond)
-		fmt.Print(".")
+		fmt.Print(feedback.Dim("."))
 	}
-	fmt.Println(" timed out (proceeding anyway)")
+	fmt.Println(" " + feedback.Amber("timed out (proceeding anyway)"))
 }
 
 // stopPodmanMachine stops the running Podman Machine VM. Called by runQuit so
@@ -357,12 +360,12 @@ func stopPodmanMachine() {
 			continue
 		}
 		name := strings.TrimSuffix(fields[0], "*")
-		fmt.Printf("  --> Stopping Podman Machine (%s) ...\n", name)
+		feedback.Line(fmt.Sprintf("Stopping Podman Machine (%s)…", name))
 		cmd := exec.Command(podman.PodmanBin(), "machine", "stop", name)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
-			fmt.Printf("  WARN: podman machine stop: %v\n", err)
+			feedback.Warn("podman machine stop: %v", err)
 		}
 	}
 }

--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 )
 
 const nmDnsConf = `[main]
@@ -323,7 +324,7 @@ func setupNMWithResolved() error {
 	dispatcherScript := "/etc/NetworkManager/dispatcher.d/99-lerd-dns"
 
 	if !isFileContent(dispatcherScript, []byte(nmDispatcherScript)) {
-		fmt.Println("  [sudo required] Configuring NetworkManager dispatcher for .test DNS resolution")
+		feedback.Sudo("Configuring NetworkManager dispatcher for .test DNS resolution")
 
 		if err := sudoWriteFile(dispatcherScript, []byte(nmDispatcherScript), 0755); err != nil {
 			return fmt.Errorf("writing NM dispatcher script: %w", err)
@@ -404,7 +405,7 @@ func setupSystemdResolved() error {
 		}
 	}
 
-	fmt.Println("  [sudo required] Configuring systemd-resolved for .test DNS resolution")
+	feedback.Sudo("Configuring systemd-resolved for .test DNS resolution")
 
 	if err := sudoWriteFile(dropin, []byte(resolvedDropin), 0644); err != nil {
 		return fmt.Errorf("writing resolved drop-in: %w", err)
@@ -429,7 +430,7 @@ func setupNetworkManager() error {
 		return nil
 	}
 
-	fmt.Println("  [sudo required] Configuring NetworkManager for .test DNS resolution")
+	feedback.Sudo("Configuring NetworkManager for .test DNS resolution")
 
 	if err := sudoWriteFile(nmConfFile, []byte(nmDnsConf), 0644); err != nil {
 		return fmt.Errorf("writing NetworkManager conf: %w", err)
@@ -499,7 +500,7 @@ func Teardown() {
 
 	// Restart the resolver to apply the removal and re-establish upstream DNS.
 	if isNetworkManagerActive() {
-		fmt.Println("  Restarting NetworkManager (may take a moment)...")
+		feedback.Line("Restarting NetworkManager (may take a moment)…")
 		cmd := exec.Command("sudo", "systemctl", "restart", "NetworkManager")
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout

--- a/internal/dns/setup_darwin.go
+++ b/internal/dns/setup_darwin.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 )
 
 // readUpstreamDNS reads upstream DNS servers from /etc/resolv.conf.
@@ -47,7 +48,7 @@ func ConfigureResolver() error {
 		return nil
 	}
 
-	fmt.Println("  [sudo required] Configuring /etc/resolver for ." + tld + " DNS resolution")
+	feedback.Sudo("Configuring /etc/resolver for ." + tld + " DNS resolution")
 	return sudoWriteFile(resolverFile, content, 0644)
 }
 
@@ -94,7 +95,7 @@ func InstallSudoers() error {
 		return nil
 	}
 
-	fmt.Println("  [sudo required] Installing DNS sudoers rule")
+	feedback.Sudo("Installing DNS sudoers rule")
 	if err := sudoWriteFile(sudoersPath, []byte(content), 0440); err != nil {
 		return fmt.Errorf("writing sudoers drop-in: %w", err)
 	}

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -26,7 +26,8 @@ var (
 	ColRunning = lipgloss.Color("#10b981") // emerald-500
 	ColStopped = lipgloss.Color("#6b7280") // gray-500
 	ColFailing = lipgloss.Color("#ef4444") // red-500
-	ColPaused  = lipgloss.Color("#f59e0b") // amber-400
+	ColPaused  = lipgloss.Color("#f59e0b") // amber-500
+	ColGold    = lipgloss.Color("#fbbf24") // amber-400 (brighter gold for sudo prompts)
 	// Interactive accent is the brand red so the TUI, CLI feedback, and the web
 	// UI all share one accent rather than diverging on a separate hue.
 	ColAccent = lipgloss.Color("#FF2D20") // lerd red
@@ -42,6 +43,7 @@ var (
 	warnStyle   = lipgloss.NewStyle().Foreground(ColPaused)
 	redStyle    = lipgloss.NewStyle().Foreground(ColFailing)
 	titleStyle  = lipgloss.NewStyle().Bold(true).Foreground(ColTitle)
+	goldStyle   = lipgloss.NewStyle().Bold(true).Foreground(ColGold)
 )
 
 // Status glyphs for query/report output that renders its own layout rather than
@@ -50,6 +52,7 @@ const (
 	GlyphOK   = "✓"
 	GlyphFail = "✗"
 	GlyphWarn = "⚠"
+	GlyphLock = "🔒"
 )
 
 // Title styles a fragment as the bold lerd-red wordmark colour.
@@ -147,6 +150,18 @@ func detectColor() bool {
 		return false
 	}
 	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// colorEnabledFor reports whether coloured output should be written to w: only
+// when NO_COLOR is unset and w is itself a terminal. Writer-targeted helpers
+// (LineOn/WarnOn) gate on it so ANSI codes never leak into a captured buffer or
+// a discarded/redirected writer, regardless of os.Stdout's TTY state.
+func colorEnabledFor(w io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	f, ok := w.(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
 }
 
 // paint applies a style only when colour is enabled, so plain-mode output (and
@@ -314,6 +329,16 @@ func Line(msg string) {
 	fmt.Fprintf(target(), "%s%s %s\n", pad, paint(dimStyle, "→"), msg)
 }
 
+// LineOn is Line targeted at an explicit writer — for an install step that
+// captures or discards its sub-output (e.g. via io.Discard) rather than writing
+// to the live stdout. Mirrors Line's styling so captured output reads the same.
+func LineOn(w io.Writer, msg string) {
+	on := colorEnabledFor(w)
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintf(w, "%s%s %s\n", pad, paintIf(on, dimStyle, "→"), msg)
+}
+
 // Header prints a section header — a brand-red "▸ title" with a blank line
 // above and below — to delimit the major phases of a long multi-step command
 // (install, update) so the step lines beneath read as a group instead of one
@@ -337,6 +362,19 @@ func Note(msg string) {
 	})
 }
 
+// Sudo prints a privileged-step line: a gold lock glyph and gold message, so
+// the password prompt the next command (mkcert, a sudo write) raises reads as
+// expected rather than a surprise. Use it in place of a bare "[sudo required] …"
+// print so every privileged step looks the same. Routed through emit so it
+// lands cleanly above any live spinner.
+func Sudo(msg string) {
+	emit(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		fmt.Fprintf(target(), "%s%s %s\n", pad, paint(goldStyle, GlyphLock), paint(goldStyle, msg))
+	})
+}
+
 // Warn prints a warning line: an amber warning glyph and amber message. Use in
 // place of a plain "[WARN] …" print.
 func Warn(format string, a ...any) {
@@ -345,6 +383,16 @@ func Warn(format string, a ...any) {
 		defer mu.Unlock()
 		fmt.Fprintf(target(), "%s%s %s\n", pad, paint(warnStyle, "⚠"), paint(warnStyle, fmt.Sprintf(format, a...)))
 	})
+}
+
+// WarnOn is Warn targeted at an explicit writer rather than the live stdout,
+// for callers that capture or discard their sub-output. Mirrors Warn's styling.
+func WarnOn(w io.Writer, format string, a ...any) {
+	on := colorEnabledFor(w)
+	msg := fmt.Sprintf(format, a...)
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintf(w, "%s%s %s\n", pad, paintIf(on, warnStyle, "⚠"), paintIf(on, warnStyle, msg))
 }
 
 // interruptible is anything that animates a spinner line and can pause it so a


### PR DESCRIPTION
The macOS install and Podman Machine output had drifted into several different styles: `-->` for some steps, `→` for others, a bare `[sudo required]` tag, `==>` for the dnsmasq install, and raw `WARN:` lines. This routes them all through the shared `feedback` package so the CLI reads consistently.

## What changed

A new `feedback.Sudo()` helper prints a gold `🔒` lock line for privileged steps (mkcert CA, podman-mac-helper, the DNS resolver/sudoers writes) so the password prompt that follows reads as expected instead of as a surprise. It replaces the old `[sudo required]` prefix.

The Podman Machine status lines in the darwin CLI now use `feedback.Line` (dim `→`), continuation detail uses `feedback.Note`, and every `WARN:` print uses `feedback.Warn` (amber `⚠`). The "waiting for the machine" line keeps its in-place polling dots but leads with the same dim arrow and ends with a green `ready` or amber `timed out`.

The install path no longer prints the DNS sudoers header twice on a first install: the header now comes only from `InstallSudoers()` when it actually writes the drop-in. The mkcert and lowercase step labels were tidied to match.

Two writer-targeted helpers, `feedback.LineOn` and `feedback.WarnOn`, cover install steps that capture or discard their sub-output (for example the brew dnsmasq install, which writes to `io.Discard`). They decide colour per-writer, so ANSI codes are never written into a non-terminal writer. The autostart warnings keep writing to stderr via `WarnOn(os.Stderr, ...)`.