### PR TITLE
fix: stop versioned DB alternates from leaking the bare canonical service

### DIFF
--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/envfile"
 	"github.com/geodro/lerd/internal/feedback"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/nginx"
@@ -344,7 +345,7 @@ func startServicesForSiteNoticed(sitePath, siteName string) {
 
 	headerPrinted := false
 	for _, name := range candidates {
-		if !strings.Contains(envContent, "lerd-"+name) {
+		if !envfile.ReferencesContainer(envContent, name) {
 			continue
 		}
 		if siteName != "" && !headerPrinted && !lerdSystemd.IsServiceActive("lerd-"+name) {

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -159,6 +159,33 @@ func ReadKey(path, key string) string {
 	return ""
 }
 
+// ReferencesContainer reports whether content references the lerd container
+// hostname "lerd-<serviceName>" as a whole token, so bare "postgres" is not
+// matched by a "lerd-postgres-18" reference (and vice versa).
+func ReferencesContainer(content, serviceName string) bool {
+	needle := "lerd-" + serviceName
+	for i := 0; ; {
+		j := strings.Index(content[i:], needle)
+		if j < 0 {
+			return false
+		}
+		end := i + j + len(needle)
+		if end >= len(content) || !isServiceNameByte(content[end]) {
+			return true
+		}
+		i += j + 1
+	}
+}
+
+// isServiceNameByte reports whether b can be part of a service name following
+// the "lerd-" prefix (alphanumerics and '-', as in postgres-18 or mysql-5-7).
+func isServiceNameByte(b byte) bool {
+	return b == '-' ||
+		(b >= '0' && b <= '9') ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z')
+}
+
 // ReadKeys returns all non-comment key names from the .env file at path,
 // in the order they appear.
 func ReadKeys(path string) ([]string, error) {

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -359,3 +359,31 @@ func TestApplyUpdates_deterministicAppendOrder(t *testing.T) {
 		}
 	}
 }
+
+func TestReferencesContainer(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		service string
+		want    bool
+	}{
+		{"bare host match", "DB_HOST=lerd-postgres\n", "postgres", true},
+		{"host with port", "DB_HOST=lerd-postgres:5432\n", "postgres", true},
+		{"host in url", "DB_URL=pgsql://u@lerd-postgres:5432/app\n", "postgres", true},
+		{"bare not matched by versioned ref", "DB_HOST=lerd-postgres-18\n", "postgres", false},
+		{"versioned matches itself", "DB_HOST=lerd-postgres-18\n", "postgres-18", true},
+		{"versioned with port", "DB_HOST=lerd-postgres-18:5432\n", "postgres-18", true},
+		{"bare not matched by suffix alternate", "DB_HOST=lerd-postgres-pgvector\n", "postgres", false},
+		{"family alternate not matched by mismatch", "DB_HOST=lerd-mysql-5-7\n", "mysql", false},
+		{"family alternate matches itself", "DB_HOST=lerd-mysql-5-7\n", "mysql-5-7", true},
+		{"no reference", "DB_HOST=127.0.0.1\n", "postgres", false},
+		{"match at EOF no newline", "DB_HOST=lerd-redis", "redis", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ReferencesContainer(tc.content, tc.service); got != tc.want {
+				t.Errorf("ReferencesContainer(%q, %q) = %v, want %v", tc.content, tc.service, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -668,14 +668,14 @@ func (e *EnrichedSite) enrichServices() {
 	}
 	envStr := string(envData)
 	for _, svcName := range KnownServices() {
-		if !svcSet[svcName] && strings.Contains(envStr, "lerd-"+svcName) {
+		if !svcSet[svcName] && envfile.ReferencesContainer(envStr, svcName) {
 			e.Services = append(e.Services, svcName)
 			svcSet[svcName] = true
 		}
 	}
 	if customs, err := config.ListCustomServices(); err == nil {
 		for _, cs := range customs {
-			if !svcSet[cs.Name] && strings.Contains(envStr, "lerd-"+cs.Name) {
+			if !svcSet[cs.Name] && envfile.ReferencesContainer(envStr, cs.Name) {
 				e.Services = append(e.Services, cs.Name)
 				svcSet[cs.Name] = true
 			}


### PR DESCRIPTION
## Problem

A site that uses a versioned database alternate (e.g. `postgres-18`) would also surface and auto-start the bare canonical service (`postgres`, i.e. pg16).

Reported symptoms:
- The site was "still considered a pg16 project" even after removing the pg16 reference from `.lerd.yaml`.
- The UI showed both postgres versions.
- Stopping the pg18 container and running an artisan command auto-started the pg16 container.

## Root cause

Two places checked service membership with `strings.Contains(env, "lerd-"+name)`. Since `"lerd-postgres"` is a prefix of `"lerd-postgres-18"`, the bare canonical `postgres` candidate falsely matched a `lerd-postgres-18` reference in `.env`:

- `internal/cli/pause.go` (`startServicesForSiteNoticed`, run before every `lerd php artisan` via `console.go`) started the canonical pg16 container alongside pg18.
- `internal/siteinfo/siteinfo.go` (`enrichServices`, the UI's per-site service list) added bare `postgres` on top of `postgres-18`.

The `lerd env` setup loop was already guarded via `userPickedDBFromYAML`, so it was not a contributor.

## Fix

Add `envfile.ReferencesContainer`, a boundary-aware match that only treats `lerd-<name>` as a reference when the following byte is not part of a service name. `lerd-postgres` matches `lerd-postgres` or `lerd-postgres:5432`, but not `lerd-postgres-18` or `lerd-postgres-pgvector`, and vice versa. Both call sites now use it.

## Verification

Reproduced on a machine running both `lerd-postgres` (pg16) and `lerd-postgres-18`, against the reporter's exact config.

On-demand path (the artisan symptom), pg16 stopped first:
- Before: prints `Starting postgres...` and pg16 comes back up.
- After: pg16 stays down, only pg18 runs.

UI service list (`enrichServices`):
- Before: `[mailpit redis rustfs postgres-18 postgres]`.
- After: `[mailpit redis rustfs postgres-18]`.

Added a unit test for `ReferencesContainer` covering pg16/pg18, `mysql-5-7`, and `postgres-pgvector`.