### PR TITLE
fix: retry podman machine start once before failing the install

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -85,7 +85,9 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	// Sample LastUp before ensure so an internal stop+start isn't mistaken
 	// for an external machine restart by healMachineRestartIfNeeded below.
 	preEnsureLastUp := currentMachineLastUp()
-	ensurePodmanMachineRunning()
+	if err := ensurePodmanMachineRunning(); err != nil {
+		return err
+	}
 	healMachineRestartIfNeeded(preEnsureLastUp)
 
 	if err := ensureUnprivilegedPorts(); err != nil {

--- a/internal/cli/machine_reset_darwin.go
+++ b/internal/cli/machine_reset_darwin.go
@@ -57,7 +57,7 @@ func runMachineReset(assumeYes bool) error {
 
 	// ensurePodmanMachineRunning re-inits a rootful machine when none exists
 	// and waits for the API socket to be ready.
-	ensurePodmanMachineRunning()
+	_ = ensurePodmanMachineRunning()
 	recordMachineLastUp()
 
 	fmt.Println()

--- a/internal/cli/overlay_heal_darwin.go
+++ b/internal/cli/overlay_heal_darwin.go
@@ -45,7 +45,7 @@ func restartPodmanMachineForHeal() {
 		feedback.Warn("podman machine stop: %v", err)
 	}
 	// ensurePodmanMachineRunning starts the VM and waits for the API socket.
-	ensurePodmanMachineRunning()
+	_ = ensurePodmanMachineRunning()
 	recordMachineLastUp()
 }
 

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -485,7 +485,9 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// external podman-machine restart (which orphans gvproxy port forwards)
 	// from a stop+start the ensure itself performs. No-op on Linux.
 	preEnsureLastUp := currentMachineLastUp()
-	ensurePodmanMachineRunning()
+	if err := ensurePodmanMachineRunning(); err != nil {
+		return err
+	}
 	migrateExecWorkerPlists()
 	healMachineRestartIfNeeded(preEnsureLastUp)
 

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -365,12 +365,17 @@ func startPodmanMachineWithRetry() error {
 
 	feedback.Warn("podman machine start: %v", err)
 	feedback.Line("Retrying Podman Machine start once…")
+	// Brief settle before retrying: when vfkit crashes it can take a moment to
+	// fully exit and release the SSH port it grabbed. Retrying instantly can
+	// race that release; a short pause lets podman reassign the port cleanly.
+	time.Sleep(3 * time.Second)
 	err = run()
 	if err == nil {
 		return nil
 	}
 
-	feedback.Warn("podman machine start: %v", err)
+	// The error itself is surfaced once by main as the command's exit error, so
+	// we only add the actionable guidance here rather than re-Warn the same text.
 	feedback.Note("The Podman Machine VM would not boot. On new macOS releases this is often a vfkit issue that leaves a stale SSH port behind.")
 	feedback.Note("Try: podman machine stop && podman machine start. If it keeps failing, run `lerd machine reset` to recreate the VM, then `lerd install` again.")
 	return fmt.Errorf("podman machine start: %w", err)

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -172,8 +172,11 @@ func recreateBrokenMachine(name string, running bool, targetMemoryMiB int64) {
 // ensurePodmanMachineRunning ensures a Podman Machine VM exists, is rootful,
 // and is running. If no machine exists it initialises one with --rootful.
 // If an existing machine is rootless it is stopped, switched, and restarted.
-// On macOS all container operations require the VM to be up.
-func ensurePodmanMachineRunning() {
+// On macOS all container operations require the VM to be up. It returns an
+// error only when the VM cannot be started, so callers (install, start) can
+// halt instead of cascading into a wall of confusing podman "exit status 125"
+// failures from every command that follows.
+func ensurePodmanMachineRunning() error {
 	// machine list only exposes Name and Running; use inspect for Rootful.
 	listOut, _ := exec.Command(podman.PodmanBin(), "machine", "list", "--format", "{{.Name}}\t{{.Running}}").Output()
 
@@ -238,7 +241,7 @@ func ensurePodmanMachineRunning() {
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
 			feedback.Warn("podman machine init: %v", err)
-			return
+			return fmt.Errorf("podman machine init: %w", err)
 		}
 	} else {
 		m := machines[0]
@@ -309,18 +312,14 @@ func ensurePodmanMachineRunning() {
 					}
 				}
 			} else if m.running {
-				return // already running and correctly configured
+				return nil // already running and correctly configured
 			}
 		}
 	}
 
 	feedback.Line("Starting Podman Machine…")
-	cmd := exec.Command(podman.PodmanBin(), "machine", "start")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		feedback.Warn("podman machine start: %v", err)
-		return
+	if err := startPodmanMachineWithRetry(); err != nil {
+		return err
 	}
 
 	// `podman machine start` exits before the API socket is ready to handle
@@ -336,12 +335,45 @@ func ensurePodmanMachineRunning() {
 		if err := exec.Command(podman.PodmanBin(), "ps", "-q").Run(); err == nil {
 			time.Sleep(3 * time.Second) // grace period before container ops
 			fmt.Println(" " + feedback.Green("ready"))
-			return
+			return nil
 		}
 		time.Sleep(500 * time.Millisecond)
 		fmt.Print(feedback.Dim("."))
 	}
 	fmt.Println(" " + feedback.Amber("timed out (proceeding anyway)"))
+	return nil
+}
+
+// startPodmanMachineWithRetry runs `podman machine start`, retrying once if the
+// first attempt fails. On new macOS (e.g. Tahoe 26.x) vfkit can crash on the
+// first boot and leave its SSH port unreleased; a second start makes podman
+// notice the stale port, reassign it, and boot cleanly. If the retry also
+// fails we stop with an actionable message instead of letting every later
+// podman command cascade into confusing "exit status 125" errors.
+func startPodmanMachineWithRetry() error {
+	run := func() error {
+		cmd := exec.Command(podman.PodmanBin(), "machine", "start")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+
+	err := run()
+	if err == nil {
+		return nil
+	}
+
+	feedback.Warn("podman machine start: %v", err)
+	feedback.Line("Retrying Podman Machine start once…")
+	err = run()
+	if err == nil {
+		return nil
+	}
+
+	feedback.Warn("podman machine start: %v", err)
+	feedback.Note("The Podman Machine VM would not boot. On new macOS releases this is often a vfkit issue that leaves a stale SSH port behind.")
+	feedback.Note("Try: podman machine stop && podman machine start. If it keeps failing, run `lerd machine reset` to recreate the VM, then `lerd install` again.")
+	return fmt.Errorf("podman machine start: %w", err)
 }
 
 // stopPodmanMachine stops the running Podman Machine VM. Called by runQuit so

--- a/internal/cli/startstop_linux.go
+++ b/internal/cli/startstop_linux.go
@@ -4,7 +4,7 @@ package cli
 
 // ensurePodmanMachineRunning is a no-op on Linux — Podman runs natively
 // without a VM, so no machine needs to be started before running containers.
-func ensurePodmanMachineRunning() {}
+func ensurePodmanMachineRunning() error { return nil }
 
 // migrateExecWorkerPlists is a no-op on Linux — exec-based plists only existed
 // in the macOS-specific alpha.2/alpha.3 launchd plist implementation.

--- a/internal/cli/startstop_retry_darwin_test.go
+++ b/internal/cli/startstop_retry_darwin_test.go
@@ -1,0 +1,67 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFakePodman drops an executable `podman` shim into dir that runs the given
+// shell body, and returns dir so it can be prepended to PATH.
+func writeFakePodman(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" + body
+	if err := os.WriteFile(filepath.Join(dir, "podman"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake podman: %v", err)
+	}
+	return dir
+}
+
+func withPATH(t *testing.T, dir string) {
+	t.Helper()
+	orig := os.Getenv("PATH")
+	t.Cleanup(func() { os.Setenv("PATH", orig) })
+	os.Setenv("PATH", dir+":"+orig)
+}
+
+// On new macOS (e.g. Tahoe) vfkit can crash on the first `machine start`, leaving
+// a stale SSH port behind; a second start reassigns it and boots. The helper must
+// retry once and report success without surfacing the first failure as fatal.
+func TestStartPodmanMachineWithRetry_RecoversOnSecondAttempt(t *testing.T) {
+	counter := filepath.Join(t.TempDir(), "n")
+	dir := writeFakePodman(t, `
+if [ "$1" = "machine" ] && [ "$2" = "start" ]; then
+  n=$(cat "`+counter+`" 2>/dev/null || echo 0); n=$((n+1)); echo "$n" > "`+counter+`"
+  [ "$n" -eq 1 ] && { echo "vfkit exited unexpectedly with exit code 1" >&2; exit 125; }
+  exit 0
+fi
+exit 0
+`)
+	withPATH(t, dir)
+
+	if err := startPodmanMachineWithRetry(); err != nil {
+		t.Fatalf("expected recovery on retry, got %v", err)
+	}
+	if b, _ := os.ReadFile(counter); string(b) != "2\n" {
+		t.Fatalf("expected exactly 2 start attempts, got %q", b)
+	}
+}
+
+// When the VM never boots, the helper returns an error so install/start halt
+// instead of cascading into a wall of confusing "exit status 125" failures.
+func TestStartPodmanMachineWithRetry_FailsAfterRetry(t *testing.T) {
+	dir := writeFakePodman(t, `
+if [ "$1" = "machine" ] && [ "$2" = "start" ]; then
+  echo "vfkit exited unexpectedly with exit code 1" >&2; exit 125
+fi
+exit 0
+`)
+	withPATH(t, dir)
+
+	if err := startPodmanMachineWithRetry(); err == nil {
+		t.Fatal("expected an error when the VM never boots, got nil")
+	}
+}

--- a/internal/cli/startstop_test.go
+++ b/internal/cli/startstop_test.go
@@ -178,7 +178,7 @@ func TestIsPortConflict(t *testing.T) {
 
 func TestEnsurePodmanMachineRunning_linux(t *testing.T) {
 	// On Linux this is a no-op — should not panic
-	ensurePodmanMachineRunning()
+	_ = ensurePodmanMachineRunning()
 }
 
 func TestMigrateExecWorkerPlists_linux(t *testing.T) {


### PR DESCRIPTION
## Background

From #601: a fresh install on macOS Tahoe 26.5.1 failed the first `lerd install` with `vfkit exited unexpectedly with exit code 1`, followed by a wall of `exit status 125` errors and an SSH `handshake failed ... connection reset by peer`. Running install a second time printed `detected port conflict on machine ssh port [...], reassigning` and then succeeded.

The root cause is vfkit crashing on the first `podman machine start` (very new macOS). When it crashed, the SSH port it had grabbed was never released, so every podman command afterwards failed with `125`. The second run worked only because podman noticed the stale port and reassigned it.

## Change

Retry `podman machine start` once when the first attempt fails. That single retry is exactly what recovered the install manually, since podman reassigns the stale port on the second attempt.

If the retry also fails, stop with an actionable message (vfkit/stale-port hint plus the recovery commands) instead of letting `lerd install` and `lerd start` proceed into the confusing `125` cascade. `ensurePodmanMachineRunning` now returns an error so install and start halt cleanly; the overlay-heal and machine-reset paths keep their previous best-effort behaviour.

The Rosetta prompt in the report is expected and unrelated (podman enables Rosetta by default in the VM on Apple Silicon), so it is not touched here.

Fixes #601