### PR TITLE
fix: swap TLS certs atomically so nginx reload never sees a missing cert

### DIFF
--- a/internal/certs/manager.go
+++ b/internal/certs/manager.go
@@ -3,6 +3,7 @@ package certs
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -113,16 +114,19 @@ func issueCertAtomic(primaryDomain string, allDomains []string, certsDir string)
 		return fmt.Errorf("mkcert for %s: %w\n%s", primaryDomain, err, strings.TrimSpace(mkOut.String()))
 	}
 
-	// Two-phase rename: back up the previous cert (if any), swap in the
-	// new cert, then swap in the new key. If the key rename fails the
-	// cert is rolled back so we don't leave a cert/key mismatch on disk
-	// — nginx with mismatched cert and key refuses to start the site,
-	// which is worse than the transient mkcert failure we're guarding
-	// against in the first place.
+	// Swap the new cert and key in with os.Rename, which atomically replaces
+	// the target in place. Crucially the previous cert is COPIED aside, not
+	// moved: moving it would unlink certFile for the instant between the two
+	// renames, and a concurrent `nginx -s reload` (the watcher or UI reissuing
+	// the same site while the CLI reloads) that lands in that window crashes
+	// with "cannot load certificate ... No such file". Copying keeps a complete
+	// cert at certFile at every moment while still letting us roll back to the
+	// previous cert if the key rename fails (a cert/key mismatch is worse than a
+	// transient issue failure: nginx refuses to start the site).
 	bakCert := certFile + ".bak." + strconv.Itoa(os.Getpid())
 	hadPrevCert := false
 	if _, err := os.Stat(certFile); err == nil {
-		if err := os.Rename(certFile, bakCert); err != nil {
+		if err := copyFile(certFile, bakCert); err != nil {
 			os.Remove(tmpCert) //nolint:errcheck
 			os.Remove(tmpKey)  //nolint:errcheck
 			return fmt.Errorf("backing up cert for %s: %w", primaryDomain, err)
@@ -133,15 +137,16 @@ func issueCertAtomic(primaryDomain string, allDomains []string, certsDir string)
 		os.Remove(tmpCert) //nolint:errcheck
 		os.Remove(tmpKey)  //nolint:errcheck
 		if hadPrevCert {
-			os.Rename(bakCert, certFile) //nolint:errcheck
+			os.Remove(bakCert) //nolint:errcheck
 		}
 		return fmt.Errorf("renaming cert for %s: %w", primaryDomain, err)
 	}
 	if err := os.Rename(tmpKey, keyFile); err != nil {
-		os.Remove(tmpKey)   //nolint:errcheck
-		os.Remove(certFile) //nolint:errcheck
+		os.Remove(tmpKey) //nolint:errcheck
 		if hadPrevCert {
-			os.Rename(bakCert, certFile) //nolint:errcheck
+			os.Rename(bakCert, certFile) //nolint:errcheck — atomic restore of prev cert
+		} else {
+			os.Remove(certFile) //nolint:errcheck
 		}
 		return fmt.Errorf("renaming key for %s: %w", primaryDomain, err)
 	}
@@ -149,6 +154,25 @@ func issueCertAtomic(primaryDomain string, allDomains []string, certsDir string)
 		os.Remove(bakCert) //nolint:errcheck
 	}
 	return nil
+}
+
+// copyFile copies src to dst, creating or truncating dst. Used to back up the
+// previous cert without unlinking it, so the live cert path is never absent.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close() //nolint:errcheck
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close() //nolint:errcheck
+		return err
+	}
+	return out.Close()
 }
 
 // CertExists returns true if the certificate for the domain already exists.

--- a/internal/certs/manager_race_test.go
+++ b/internal/certs/manager_race_test.go
@@ -1,0 +1,86 @@
+package certs
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+// TestIssueCertForce_certNeverAbsentDuringReissue is the regression test for the
+// "cannot load certificate ... No such file" crash: issueCertAtomic must swap
+// the cert in without ever unlinking the live path, so a concurrent reader (an
+// nginx reload mid-reissue) always finds a complete cert. An observer stats the
+// cert in a tight loop while the issuer reissues many times; any absence fails.
+//
+// Against the old move-the-old-cert-aside implementation this records absences;
+// against the copy-then-atomic-rename implementation it records zero.
+func TestIssueCertForce_certNeverAbsentDuringReissue(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	binDir := filepath.Join(tmp, "lerd", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	fakeMkcert := `#!/bin/sh
+CRT=""
+KEY=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -cert-file) shift; CRT="$1" ;;
+    -key-file)  shift; KEY="$1" ;;
+  esac
+  shift
+done
+printf 'CERT' > "$CRT"
+printf 'KEY' > "$KEY"
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(binDir, "mkcert"), []byte(fakeMkcert), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	certsDir := filepath.Join(tmp, "lerd", "certs", "sites")
+	if err := os.MkdirAll(certsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	certPath := filepath.Join(certsDir, "myapp.test.crt")
+	// Seed an initial cert/key so every reissue hits the "previous cert exists"
+	// branch, the one that used to move the live cert out of the way.
+	if err := os.WriteFile(certPath, []byte("CERT"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(certsDir, "myapp.test.key"), []byte("KEY"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var absent int64
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				if _, err := os.Stat(certPath); os.IsNotExist(err) {
+					atomic.AddInt64(&absent, 1)
+				}
+			}
+		}
+	}()
+
+	for i := 0; i < 400; i++ {
+		if err := IssueCertForce("myapp.test", []string{"myapp.test"}, certsDir); err != nil {
+			t.Fatalf("reissue %d: %v", i, err)
+		}
+	}
+	close(done)
+	<-stopped
+
+	if n := atomic.LoadInt64(&absent); n > 0 {
+		t.Fatalf("cert path was absent %d times during reissue; the swap unlinks the live cert", n)
+	}
+}

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -482,7 +482,10 @@ func provisionAndSecure(label, result string, site config.Site, finish func(conf
 		// the finisher above only reloaded it for the plain-HTTP config, so
 		// without this the site keeps serving the now-deleted HTTP vhost from
 		// nginx's memory and HTTPS never comes up until an unrelated reload.
-		if err := nginx.Reload(); err != nil {
+		// Retry the reload: a concurrent cert reissue (the watcher or UI
+		// reacting to the same new site) can briefly race the cert swap and
+		// make a single reload fail with "cannot load certificate".
+		if err := nginx.ReloadWithRetry(10 * time.Second); err != nil {
 			cert.Fail(err)
 			return err
 		}

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -731,6 +731,31 @@ func Reload() error {
 	return err
 }
 
+// ReloadWithRetry reloads nginx, retrying on failure for up to timeout. The cert
+// file is now swapped in atomically, but the cert and key are still two separate
+// renames, so a concurrent reissue (the watcher or UI reacting to the same site
+// change) can momentarily pair a new cert with the old key. A reload that lands
+// in that window crashes with "cannot load certificate"; retrying a beat later,
+// once the swap has settled, succeeds. nginx keeps serving its previous config
+// across a rejected reload, so retrying is safe.
+func ReloadWithRetry(timeout time.Duration) error {
+	return reloadWithRetry(Reload, timeout)
+}
+
+func reloadWithRetry(reload func() error, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		err := reload()
+		if err == nil {
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			return err
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
 // Test runs `nginx -t` inside the lerd-nginx container and returns the
 // combined stdout+stderr output along with the exit error. nginx writes its
 // per-directive validation diagnostics to stderr, so the output is the

--- a/internal/nginx/reload_retry_test.go
+++ b/internal/nginx/reload_retry_test.go
@@ -1,0 +1,40 @@
+package nginx
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestReloadWithRetry_SucceedsAfterTransientFailures(t *testing.T) {
+	n := 0
+	err := reloadWithRetry(func() error {
+		n++
+		if n < 3 {
+			return errors.New("cannot load certificate: No such file")
+		}
+		return nil
+	}, 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected success once the reload settles, got %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("expected 3 attempts, got %d", n)
+	}
+}
+
+func TestReloadWithRetry_ReturnsLastErrorOnTimeout(t *testing.T) {
+	want := errors.New("persistent config error")
+	err := reloadWithRetry(func() error { return want }, 300*time.Millisecond)
+	if !errors.Is(err, want) {
+		t.Fatalf("expected the last reload error, got %v", err)
+	}
+}
+
+func TestReloadWithRetry_SucceedsFirstTry(t *testing.T) {
+	n := 0
+	err := reloadWithRetry(func() error { n++; return nil }, time.Second)
+	if err != nil || n != 1 {
+		t.Fatalf("expected one successful attempt, got n=%d err=%v", n, err)
+	}
+}

--- a/internal/siteops/link.go
+++ b/internal/siteops/link.go
@@ -3,6 +3,7 @@ package siteops
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
@@ -159,7 +160,7 @@ func FinishLink(site config.Site, phpVersion string) error {
 	_ = podman.RewriteFPMQuadlets()
 	_ = podman.WriteContainerHosts()
 
-	if err := nginx.Reload(); err != nil {
+	if err := nginx.ReloadWithRetry(10 * time.Second); err != nil {
 		return fmt.Errorf("nginx reload: %w", err)
 	}
 
@@ -225,7 +226,7 @@ func FinishFrankenPHPLink(site config.Site) error {
 
 	_ = podman.WriteContainerHosts()
 
-	if err := nginx.Reload(); err != nil {
+	if err := nginx.ReloadWithRetry(10 * time.Second); err != nil {
 		return fmt.Errorf("nginx reload: %w", err)
 	}
 
@@ -278,7 +279,7 @@ func DemoteFrankenPHPToFPM(site *config.Site) error {
 		return fmt.Errorf("regenerating vhost: %w", err)
 	}
 
-	if err := nginx.Reload(); err != nil {
+	if err := nginx.ReloadWithRetry(10 * time.Second); err != nil {
 		return fmt.Errorf("nginx reload: %w", err)
 	}
 
@@ -325,7 +326,7 @@ func FinishCustomFPMLink(site config.Site, containerCfg *config.ContainerConfig)
 	}
 
 	_ = podman.WriteContainerHosts()
-	if err := nginx.Reload(); err != nil {
+	if err := nginx.ReloadWithRetry(10 * time.Second); err != nil {
 		return fmt.Errorf("nginx reload: %w", err)
 	}
 	if podman.AfterUnitChange != nil {
@@ -352,7 +353,7 @@ func FinishHostProxyLink(site config.Site) error {
 		}
 	}
 
-	if err := nginx.Reload(); err != nil {
+	if err := nginx.ReloadWithRetry(10 * time.Second); err != nil {
 		return fmt.Errorf("nginx reload: %w", err)
 	}
 
@@ -404,7 +405,7 @@ func FinishCustomLink(site config.Site, containerCfg *config.ContainerConfig) er
 
 	_ = podman.WriteContainerHosts()
 
-	if err := nginx.Reload(); err != nil {
+	if err := nginx.ReloadWithRetry(10 * time.Second); err != nil {
 		return fmt.Errorf("nginx reload: %w", err)
 	}
 


### PR DESCRIPTION
## Symptom

`lerd init` / `lerd link` on a secured site could crash the nginx reload:

```
generating certificate… ✗ podman exec lerd-nginx nginx -s reload: exit status 1
[emerg] cannot load certificate "/etc/nginx/certs/<domain>.crt": ...
No such file or directory ... calling fopen(...) error: no such file
```

Running again usually "worked", which pointed at a race rather than a real missing file.

## Root cause

`certs.issueCertAtomic` swapped the new cert in by first moving the existing cert out of the way (`rename(certFile -> .bak)`) and only then renaming the new cert into place. Between those two renames the cert path does not exist.

When a second process reissues the same cert concurrently (the watcher or UI reacting to the same site change) at the moment the CLI reloads nginx, the reload lands in that window and fails. The init flow reliably hit this because writing `.lerd.yaml` triggers a concurrent reissue.

Reproduced directly against the live container: with the move-aside swap, a concurrent reader saw the cert missing in 3/120 probes; with an atomic rename-replace, 0/120.

## Fix

- Back the previous cert up by **copying** it instead of moving it, then `os.Rename` the new cert over the target, which replaces it atomically. The live cert path now always holds a complete cert. Rollback on key-rename failure is preserved (a cert/key mismatch is worse than a transient issue failure).
- Cert and key are still two separate renames, so a concurrent reissue can briefly pair a new cert with an old key. The link/secure flows now reload via a new `nginx.ReloadWithRetry`, so a reload caught in that much smaller window retries once the swap settles. nginx keeps serving its previous config across a rejected reload, so retrying is safe.

## Tests

New regression test reissues a cert in a loop while an observer stats the live path and counts any absence:

- old move-aside swap: ~15k absences (fails)
- copy + atomic rename: 0 absences (passes)

`certs`, `nginx`, `cli`, and `siteops` suites pass; build and vet clean.