### PR TITLE
fix: provision/realign worktree databases and unify service-stop output

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -709,6 +709,14 @@ func scanWorktrees() bool {
 				gitpkg.EnsureWorktreeDeps(s.Path, wt.Path, wt.Domain, s.Secured, nil)
 				release()
 			}
+			// Provision the isolated DB for a worktree that committed
+			// db_isolated: true but was never run through `lerd worktree add`
+			// (e.g. linked with the worktree already present). No-op otherwise.
+			if created, err := cli.EnsureWorktreeIsolatedDB(&site, wt.Branch, wt.Path); err != nil {
+				fmt.Printf("[WARN] isolated DB for worktree %s: %v\n", wt.Branch, err)
+			} else if created {
+				fmt.Printf("Worktree DB: created isolated database for %s\n", wt.Branch)
+			}
 			// Host-proxy sites mirror the parent dev command on a per-worktree
 			// port behind the worktree domain; no PHP vhost or framework workers.
 			if site.IsHostProxy() {
@@ -801,6 +809,19 @@ func syncWorktree(sitePath, worktreeName, action string, pruneStale bool) bool {
 			gitpkg.EnsureWorktreeDeps(sitePath, wt.Path, wt.Domain, site.Secured, nil)
 			release()
 		}
+		// Provision the isolated DB for a worktree that committed
+		// db_isolated: true but was never run through `lerd worktree add`.
+		// Gated to genuine creation like the worker/nginx seeding below: on
+		// "changed" (a commit/checkout) an already-provisioned worktree would
+		// no-op anyway, and a misconfigured one would re-warn on every HEAD
+		// write. The boot rescan catches worktrees that opt in while offline.
+		if shouldProvisionWorktreeDBOnSync(action) {
+			if created, err := cli.EnsureWorktreeIsolatedDB(site, wt.Branch, wt.Path); err != nil {
+				fmt.Printf("[WARN] isolated DB for worktree %s: %v\n", wt.Branch, err)
+			} else if created {
+				fmt.Printf("Worktree DB: created isolated database for %s\n", wt.Branch)
+			}
+		}
 		// Host-proxy worktrees run their own dev server behind the worktree
 		// domain; wire that instead of a PHP vhost + framework workers.
 		if site.IsHostProxy() {
@@ -848,6 +869,15 @@ func syncWorktree(sitePath, worktreeName, action string, pruneStale bool) bool {
 // worktree path is stable so existing units need no kick. Resurrecting
 // them clobbered user stops — issue #375.
 func shouldAutoStartWorkersOnSync(action string) bool {
+	return action == "added"
+}
+
+// shouldProvisionWorktreeDBOnSync gates isolated-DB creation to genuine
+// worktree creation. On "changed" an already-isolated worktree is a registry
+// no-op, and a worktree that can't isolate (no lerd-managed parent DB) would
+// otherwise log a warning on every commit/checkout. The boot rescan still
+// picks up worktrees that opted in while the watcher was offline.
+func shouldProvisionWorktreeDBOnSync(action string) bool {
 	return action == "added"
 }
 

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -20,6 +20,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
 	"github.com/geodro/lerd/internal/feedback"
+	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/grouping"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
@@ -833,8 +834,73 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		}
 	}
 
+	// 7. Worktrees share the parent site's database SERVER (only DB_DATABASE
+	// differs, and only when isolated). Their .env was copied once at creation,
+	// so after this run realigned the parent to the selected services, mirror
+	// the connection coordinates into each worktree .env too — otherwise a
+	// worktree captured before a service switch (e.g. postgres -> postgres-18)
+	// keeps pointing at a host that no longer resolves.
+	alignWorktreeEnvDBConnection(site, envPath, envRelPath, envFormat)
+
 	envInfo("Done.\n")
 	return nil
+}
+
+// worktreeDBConnectionKeys are the shared database SERVER coordinates a worktree
+// inherits from its parent. DB_DATABASE is deliberately excluded: it is owned by
+// the isolated-DB logic (or the parent value for a non-isolated worktree).
+var worktreeDBConnectionKeys = []string{"DB_CONNECTION", "DB_HOST", "DB_PORT", "DB_USERNAME", "DB_PASSWORD"}
+
+// alignWorktreeEnvDBConnection mirrors the parent's (just-aligned) DB connection
+// coordinates into each existing worktree env file. It is the worktree arm of
+// `lerd env`'s "make the env match the selected services" guarantee. Best
+// effort: a worktree without an env file yet is skipped (it'll be seeded on its
+// next sync), and ApplyUpdates no-ops when nothing changed.
+//
+// Scoped to the dotenv format: the connection keys are Laravel-style and
+// php-const frameworks use a different writer and key set, so they are left to
+// their own env detection. envRelPath is the framework-resolved env file path so
+// a worktree of a framework whose env file isn't ".env" is still targeted.
+func alignWorktreeEnvDBConnection(site *config.Site, mainEnvPath, envRelPath, envFormat string) {
+	if site == nil || envFormat == "php-const" {
+		return
+	}
+	worktrees, err := gitpkg.DetectWorktrees(site.Path, site.PrimaryDomain())
+	if err != nil || len(worktrees) == 0 {
+		return
+	}
+	coords := map[string]string{}
+	for _, k := range worktreeDBConnectionKeys {
+		if v := envfile.ReadKey(mainEnvPath, k); v != "" {
+			coords[k] = v
+		}
+	}
+	if len(coords) == 0 {
+		return
+	}
+	for _, wt := range worktrees {
+		wtEnv := filepath.Join(wt.Path, envRelPath)
+		if _, statErr := os.Stat(wtEnv); statErr != nil {
+			continue
+		}
+		// Only touch worktrees whose coordinates actually drifted, so a steady
+		// state stays silent and the file's mtime is left alone.
+		drifted := false
+		for k, v := range coords {
+			if envfile.ReadKey(wtEnv, k) != v {
+				drifted = true
+				break
+			}
+		}
+		if !drifted {
+			continue
+		}
+		if err := envfile.ApplyUpdates(wtEnv, coords); err != nil {
+			feedback.Warn("aligning worktree %s .env: %v", wt.Branch, err)
+			continue
+		}
+		envInfo("  Aligned worktree %s DB connection\n", wt.Branch)
+	}
 }
 
 // frameworkServiceDetected returns true if any detect rule in def matches the env map.

--- a/internal/cli/env_worktree_align_test.go
+++ b/internal/cli/env_worktree_align_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// alignWorktreeEnvDBConnection mirrors the parent's DB connection coordinates
+// into each worktree .env (the worktree arm of `lerd env`), while leaving the
+// worktree-specific DB_DATABASE alone.
+func TestAlignWorktreeEnvDBConnection_realignsHostKeepsDatabase(t *testing.T) {
+	main := t.TempDir()
+	checkout := t.TempDir()
+
+	// Main repo .git dir so IsMainRepo is true, plus the worktree metadata that
+	// DetectWorktrees reads (HEAD for the branch, gitdir for the checkout path).
+	wtMeta := filepath.Join(main, ".git", "worktrees", "feat")
+	if err := os.MkdirAll(wtMeta, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtMeta, "HEAD"), []byte("ref: refs/heads/feat/add-social-logins\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtMeta, "gitdir"), []byte(filepath.Join(checkout, ".git")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Parent .env already aligned to the current service; worktree .env is stale.
+	mainEnv := "DB_CONNECTION=pgsql\nDB_HOST=lerd-postgres-18\nDB_PORT=5432\nDB_DATABASE=acme\n"
+	if err := os.WriteFile(filepath.Join(main, ".env"), []byte(mainEnv), 0644); err != nil {
+		t.Fatal(err)
+	}
+	wtEnv := "DB_CONNECTION=pgsql\nDB_HOST=lerd-postgres\nDB_PORT=5432\nDB_DATABASE=acme_feat_add_social_logins\n"
+	if err := os.WriteFile(filepath.Join(checkout, ".env"), []byte(wtEnv), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	site := &config.Site{Name: "acme", Path: main, Domains: []string{"acme.test"}}
+	alignWorktreeEnvDBConnection(site, filepath.Join(main, ".env"), ".env", "")
+
+	got, err := os.ReadFile(filepath.Join(checkout, ".env"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(got)
+	if !strings.Contains(s, "DB_HOST=lerd-postgres-18") {
+		t.Errorf("worktree DB_HOST not realigned to parent:\n%s", s)
+	}
+	if strings.Contains(s, "DB_HOST=lerd-postgres\n") {
+		t.Errorf("stale worktree DB_HOST still present:\n%s", s)
+	}
+	if !strings.Contains(s, "DB_DATABASE=acme_feat_add_social_logins") {
+		t.Errorf("worktree-specific DB_DATABASE must be left untouched:\n%s", s)
+	}
+}
+
+// A worktree that has no .env yet is skipped without error.
+func TestAlignWorktreeEnvDBConnection_skipsWorktreeWithoutEnv(t *testing.T) {
+	main := t.TempDir()
+	checkout := t.TempDir()
+
+	wtMeta := filepath.Join(main, ".git", "worktrees", "feat")
+	if err := os.MkdirAll(wtMeta, 0755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(wtMeta, "HEAD"), []byte("ref: refs/heads/feat\n"), 0644)
+	os.WriteFile(filepath.Join(wtMeta, "gitdir"), []byte(filepath.Join(checkout, ".git")+"\n"), 0644)
+	os.WriteFile(filepath.Join(main, ".env"), []byte("DB_HOST=lerd-postgres-18\n"), 0644)
+
+	site := &config.Site{Name: "acme", Path: main, Domains: []string{"acme.test"}}
+	// No worktree .env: must be a no-op, no panic, no file created.
+	alignWorktreeEnvDBConnection(site, filepath.Join(main, ".env"), ".env", "")
+
+	if _, err := os.Stat(filepath.Join(checkout, ".env")); !os.IsNotExist(err) {
+		t.Error("worktree .env should not have been created")
+	}
+}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -146,9 +146,9 @@ func newServiceStopCmd() *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			name := args[0]
 			feedback.Begin()
-			step := feedback.Start("stopping " + name)
+			// StopServiceAndDependents emits its own "stopping <service>" step
+			// (per service in the dependency cascade), so don't wrap it here.
 			StopServiceAndDependents(name)
-			step.OK("")
 			_ = config.SetServicePaused(name, true)
 			_ = config.SetServiceManuallyStarted(name, false)
 			if fam := serviceops.ServiceFamily(name); fam != "" {

--- a/internal/cli/worktree_db.go
+++ b/internal/cli/worktree_db.go
@@ -143,6 +143,31 @@ func SetWorktreeDBIsolated(site *config.Site, branch string, isolated bool, sour
 	return nil
 }
 
+// EnsureWorktreeIsolatedDB provisions the isolated database for a worktree that
+// committed `db_isolated: true` in its .lerd.yaml but has no database yet. This
+// is the case when a site is linked with a pre-existing worktree (or one is
+// materialised on a daemon that was offline): the interactive add-time prompt
+// that normally creates the DB never ran, so the worktree's vhost and workers
+// come up but its .env points at a database that was never created.
+//
+// It is a no-op when the worktree didn't opt in or its DB is already in the
+// registry, so it is safe to call on every scan. The database is seeded empty
+// (the worktree's own migrations populate it); cloning from the parent stays an
+// explicit `lerd db:isolate` / `lerd worktree add` choice. Returns true only
+// when it created the database this call.
+func EnsureWorktreeIsolatedDB(site *config.Site, branch, worktreePath string) (bool, error) {
+	if !config.WorktreeDBIsolated(worktreePath) {
+		return false, nil
+	}
+	if _, found, _ := config.FindWorktreeDB(site.Name, branch); found {
+		return false, nil
+	}
+	if err := SetWorktreeDBIsolated(site, branch, true, "empty"); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // WorktreeDBName mirrors the projectDBName convention so a parent named
 // "acme_app" with branch "feat-x" becomes "acme_app_feat_x".
 func WorktreeDBName(parentDB, branch string) string {

--- a/internal/cli/worktree_db_ensure_test.go
+++ b/internal/cli/worktree_db_ensure_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// writeWorktreeLerdYAML writes a minimal worktree .lerd.yaml at dir with the
+// given db_isolated value.
+func writeWorktreeLerdYAML(t *testing.T, dir string, isolated bool) {
+	t.Helper()
+	body := "workers:\n    - vite\n"
+	if isolated {
+		body += "db_isolated: true\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureWorktreeIsolatedDB_NoopWhenNotOptedIn(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	wt := t.TempDir()
+	writeWorktreeLerdYAML(t, wt, false) // no db_isolated
+
+	site := &config.Site{Name: "parkapp"}
+	created, err := EnsureWorktreeIsolatedDB(site, "feat/x", wt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if created {
+		t.Fatal("expected no provisioning when the worktree did not opt in")
+	}
+}
+
+func TestEnsureWorktreeIsolatedDB_NoopWhenAlreadyRegistered(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	wt := t.TempDir()
+	writeWorktreeLerdYAML(t, wt, true) // db_isolated: true
+
+	// A registry entry already exists for this site+branch, so the helper must
+	// short-circuit before attempting to create the DB (which would need podman).
+	if err := config.AddWorktreeDB(config.WorktreeDBEntry{
+		Site:    "parkapp",
+		Branch:  "feat/x",
+		Service: "postgres",
+		DBName:  "parkapp_feat_x",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	site := &config.Site{Name: "parkapp"}
+	created, err := EnsureWorktreeIsolatedDB(site, "feat/x", wt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if created {
+		t.Fatal("expected no provisioning when the worktree DB is already registered")
+	}
+}

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/registry"
 )
@@ -471,8 +472,12 @@ func StopWithDependents(name string) {
 	unit := "lerd-" + name
 	status, _ := podman.UnitStatus(unit)
 	if status == "active" || status == "activating" {
-		fmt.Printf("Stopping %s...\n", unit)
+		// Show the service name (not the lerd- unit) in the shared feedback
+		// vocabulary, so `lerd unlink`/`lerd stop` read as "stopping meilisearch"
+		// rather than the old "Stopping lerd-meilisearch...".
+		step := feedback.Start("stopping " + name)
 		_ = podman.StopUnit(unit)
+		step.OK("")
 	}
 }
 


### PR DESCRIPTION
Three fixes that surfaced while re-linking a site (`parkapp`) that already contained a git worktree.

## Isolated DB not provisioned for a pre-existing worktree

A worktree that committed `db_isolated: true` in its `.lerd.yaml` never got its database. The daemon's worktree provisioning (`scanWorktrees` / `syncWorktree`) generated the vhost and started workers but never read the isolation flag, and `SetWorktreeDBIsolated` (the only thing that creates and registers an isolated DB) was reachable only from `lerd worktree add`, the dashboard, and `lerd db:isolate`. The worktree's `.env` pointed at a database that was never created.

`EnsureWorktreeIsolatedDB` now provisions the database (empty schema) and registers it when a worktree opted into isolation but has no registry entry yet. It's called from both daemon worktree-provisioning paths, idempotently (guarded by the registry, and `CreateDatabase` is `IF NOT EXISTS`).

## Worktree `.env` not realigned after a DB service switch

A worktree `.env` is copied once at creation and never realigned. After the parent site switched DB service (`postgres` to `postgres-18`, so `DB_HOST` went `lerd-postgres` to `lerd-postgres-18`), the worktree kept pointing at a host that no longer resolves:

```
SQLSTATE[08006] could not translate host name "lerd-postgres" to address: Name does not resolve
```

`lerd env` now mirrors the parent's connection coordinates (`DB_CONNECTION/HOST/PORT/USERNAME/PASSWORD`) into each worktree `.env`, only when they drifted, leaving the isolated `DB_DATABASE` untouched. `lerd setup`, `lerd init`, and `lerd db set` all route through `lerd env`, so a service switch realigns worktrees automatically. Scoped to the dotenv format.

## Service stop used the old output style

`StopWithDependents` printed `Stopping lerd-meilisearch...` while the worker stops in the same `lerd unlink` flow already used the feedback steps. It now emits the shared feedback step with the service name (`stopping meilisearch`), and `lerd service stop` drops its redundant outer step so a single service no longer renders twice.

Tests cover the isolated-DB guards, the worktree env realignment, and the existing service/cli suites pass.