### PR TITLE
feat(cli): render list views as responsive tables and unify error output

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -66,6 +66,16 @@ func main() {
 		// failure through the feedback UI (a red ✗ line) is suppressed here so
 		// cobra doesn't reprint the same message as a second "Error: …" line.
 		SilenceErrors: true,
+		// Cobra validates flags and args before PersistentPreRunE runs, so by the
+		// time we get here the invocation is well-formed and any failure is a
+		// runtime error, not misuse. Silencing usage now keeps the clean ✗ line
+		// for runtime errors while still printing the usage block for a wrong
+		// flag or arg count. No subcommand defines its own persistent hook, so
+		// this runs for every command.
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+			return nil
+		},
 	}
 
 	// Register all subcommands
@@ -209,7 +219,7 @@ func main() {
 		// Only print errors the command didn't already show the user via a
 		// feedback Fail line, so the same failure never appears twice.
 		if !feedback.AlreadyShown(err) {
-			fmt.Fprintf(os.Stderr, "\nError: %s\n\n", err.Error())
+			feedback.Fail(err)
 		}
 		os.Exit(1)
 	}

--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -34,14 +34,16 @@ lerd framework search
 ```
 
 ```
-Name            Label           Latest       Versions
-───────────────────────────────────────────────────────
-laravel         Laravel         13           13, 12, 11, 10
-symfony         Symfony         8            8, 7
-wordpress       WordPress       6            6, 5
-drupal          Drupal          11           11, 10
-cakephp         CakePHP         5            5, 4
-statamic        Statamic        6            6, 5
+╭───────────┬───────────┬────────┬────────────────╮
+│ Name      │ Label     │ Latest │ Versions       │
+├───────────┼───────────┼────────┼────────────────┤
+│ laravel   │ Laravel   │ 13     │ 13, 12, 11, 10 │
+│ symfony   │ Symfony   │ 8      │ 8, 7           │
+│ wordpress │ WordPress │ 6      │ 6, 5           │
+│ drupal    │ Drupal    │ 11     │ 11, 10         │
+│ cakephp   │ CakePHP   │ 5      │ 5, 4           │
+│ statamic  │ Statamic  │ 6      │ 6, 5           │
+╰───────────┴───────────┴────────┴────────────────╯
 ```
 
 ### Installing from the store

--- a/docs/usage/services.md
+++ b/docs/usage/services.md
@@ -24,14 +24,16 @@ Default services are defined as YAML presets with `default: true` in the lerd bi
 `lerd service list` shows the version (derived from the image tag) and an Update column with green / amber / violet badges:
 
 ```
-Service              Version    Status     Update
-────────────────────────────────────────────────────────────
-mailpit              latest     active
-meilisearch          v1.42.1    active
-mysql                v8.4.9     active
-postgres             v16        active
-redis                v7.4.8     active
-rustfs               latest     active
+╭─────────────┬─────────┬────────┬────────╮
+│ Service     │ Version │ Status │ Update │
+├─────────────┼─────────┼────────┼────────┤
+│ mailpit     │ latest  │ active │        │
+│ meilisearch │ v1.42.1 │ active │        │
+│ mysql       │ v8.4.9  │ active │        │
+│ postgres    │ v16     │ active │        │
+│ redis       │ v7.4.8  │ active │        │
+│ rustfs      │ latest  │ active │        │
+╰─────────────┴─────────┴────────┴────────╯
 ```
 
 The Web UI, the TUI, and `lerd status` display the same labels. Services pinned to rolling tags (`latest`, `main`) show the tag verbatim. Services where an update is available show `→ <new-tag>`; cross-strategy upgrades show `⇧ <new-tag>` in amber.

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/getlantern/systray v1.2.2
 	github.com/godbus/dbus/v5 v5.2.2
+	github.com/lrstanley/bubblezone v1.0.0
 	github.com/pelletier/go-toml/v2 v2.1.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
@@ -50,7 +51,6 @@ require (
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/lrstanley/bubblezone v1.0.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 h1:JFgG/x
 github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7/go.mod h1:ISC1gtLcVilLOf23wvTfoQuYbW2q0JevFxPfUzZ9Ybw=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
-github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=
-github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc/go.mod h1:X4/0JoqgTIPSFcRA/P6INZzIuyqdFY5rm8tb41s9okk=
 github.com/charmbracelet/colorprofile v0.3.1 h1:k8dTHMd7fgw4bnFd7jXTLZrSU/CQrKnL3m+AxCzDz40=
 github.com/charmbracelet/colorprofile v0.3.1/go.mod h1:/GkGusxNs8VB/RSOh3fu0TJmQ4ICMMPApIIVn0KszZ0=
 github.com/charmbracelet/glamour v1.0.0 h1:AWMLOVFHTsysl4WV8T8QgkQ0s/ZNZo7CiE4WKhk8l08=

--- a/internal/cli/db_snapshot.go
+++ b/internal/cli/db_snapshot.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
@@ -269,8 +268,7 @@ func snapshotGitBranch(cwd string) string {
 }
 
 func printSnapshotTable(snaps []serviceops.Snapshot) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tCREATED\tDATABASE\tSIZE\tBRANCH")
+	rows := make([][]string, 0, len(snaps))
 	for _, s := range snaps {
 		db := s.Database
 		if s.AllDatabases {
@@ -280,10 +278,11 @@ func printSnapshotTable(snaps []serviceops.Snapshot) {
 		if branch == "" {
 			branch = "-"
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-			s.Name, s.Created.Local().Format("2006-01-02 15:04"), db, humanSize(s.SizeBytes), branch)
+		rows = append(rows, []string{
+			s.Name, s.Created.Local().Format("2006-01-02 15:04"), db, humanSize(s.SizeBytes), branch,
+		})
 	}
-	_ = w.Flush()
+	feedback.Table([]string{"NAME", "CREATED", "DATABASE", "SIZE", "BRANCH"}, rows)
 }
 
 // humanSize renders a byte count in binary units.

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -171,10 +171,11 @@ func NewEnvCmd() *cobra.Command {
   - Sets APP_URL to the registered .test domain`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// --verbose (and any non-animated output, e.g. the MCP server or a
+			// --verbose (and any non-interactive output, e.g. the MCP server or a
 			// pipe) prints the full per-step detail. An interactive terminal gets
-			// the single live "configuring .env" line instead.
-			if verbose || !feedback.Animated() {
+			// the single live "configuring .env" line instead, even under NO_COLOR
+			// where it degrades to a plain condensed line rather than verbose.
+			if verbose || !feedback.Interactive() {
 				return runEnv(cmd, args)
 			}
 			feedback.Begin()
@@ -869,9 +870,10 @@ func alignWorktreeEnvDBConnection(site *config.Site, mainEnvPath, envRelPath, en
 	if err != nil || len(worktrees) == 0 {
 		return
 	}
+	mainVals := envfile.ReadValues(mainEnvPath)
 	coords := map[string]string{}
 	for _, k := range worktreeDBConnectionKeys {
-		if v := envfile.ReadKey(mainEnvPath, k); v != "" {
+		if v := mainVals[k]; v != "" {
 			coords[k] = v
 		}
 	}
@@ -884,10 +886,12 @@ func alignWorktreeEnvDBConnection(site *config.Site, mainEnvPath, envRelPath, en
 			continue
 		}
 		// Only touch worktrees whose coordinates actually drifted, so a steady
-		// state stays silent and the file's mtime is left alone.
+		// state stays silent and the file's mtime is left alone. One read of the
+		// worktree env covers every key compared.
+		wtVals := envfile.ReadValues(wtEnv)
 		drifted := false
 		for k, v := range coords {
-			if envfile.ReadKey(wtEnv, k) != v {
+			if wtVals[k] != v {
 				drifted = true
 				break
 			}

--- a/internal/cli/env_check.go
+++ b/internal/cli/env_check.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/spf13/cobra"
 )
 
@@ -163,60 +164,22 @@ func runEnvCheck(_ *cobra.Command, _ []string) error {
 	}
 	sort.Strings(sortedKeys)
 
-	// Compute column widths.
-	keyWidth := len("KEY")
+	// Build the matrix: one column per env source, a ✓/✗ cell per key.
+	headers := make([]string, 0, len(files)+2)
+	headers = append(headers, "KEY", ".env.example")
+	for _, f := range files {
+		headers = append(headers, f.name)
+	}
+	rows := make([][]string, 0, len(sortedKeys))
 	for _, k := range sortedKeys {
-		if len(k) > keyWidth {
-			keyWidth = len(k)
+		row := make([]string, 0, len(files)+2)
+		row = append(row, k, envMark(exampleSet[k]))
+		for _, f := range files {
+			row = append(row, envMark(f.keySet[k]))
 		}
+		rows = append(rows, row)
 	}
-
-	colWidths := make([]int, len(files)+1)
-	colWidths[0] = len(".env.example")
-	for i, f := range files {
-		colWidths[i+1] = len(f.name)
-		if colWidths[i+1] < 4 {
-			colWidths[i+1] = 4
-		}
-	}
-
-	// Print header.
-	fmt.Printf("  %-*s", keyWidth, "KEY")
-	fmt.Printf("  %-*s", colWidths[0], ".env.example")
-	for i, f := range files {
-		fmt.Printf("  %-*s", colWidths[i+1], f.name)
-	}
-	fmt.Println()
-
-	// Print separator.
-	fmt.Printf("  %s", dashes(keyWidth))
-	fmt.Printf("  %s", dashes(colWidths[0]))
-	for i := range files {
-		fmt.Printf("  %s", dashes(colWidths[i+1]))
-	}
-	fmt.Println()
-
-	// Print rows.
-	totalMissing := 0
-	for _, k := range sortedKeys {
-		fmt.Printf("  %-*s", keyWidth, k)
-		if exampleSet[k] {
-			fmt.Printf("  %s", center("✓", colWidths[0]))
-		} else {
-			fmt.Printf("  %s", center("✗", colWidths[0]))
-		}
-		for i, f := range files {
-			if f.keySet[k] {
-				fmt.Printf("  %s", center("✓", colWidths[i+1]))
-			} else {
-				fmt.Printf("  %s", center("✗", colWidths[i+1]))
-				if exampleSet[k] {
-					totalMissing++
-				}
-			}
-		}
-		fmt.Println()
-	}
+	feedback.Table(headers, rows)
 
 	fmt.Println()
 	fmt.Printf("  %d key(s) out of sync\n", len(sortedKeys))
@@ -224,17 +187,9 @@ func runEnvCheck(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func dashes(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = '-'
+func envMark(present bool) string {
+	if present {
+		return feedback.Green("✓")
 	}
-	return string(b)
-}
-
-func center(s string, width int) string {
-	pad := width - 1
-	left := pad / 2
-	right := pad - left
-	return fmt.Sprintf("%*s%s%*s", left, "", s, right, "")
+	return feedback.Red("✗")
 }

--- a/internal/cli/env_reentrant_test.go
+++ b/internal/cli/env_reentrant_test.go
@@ -43,6 +43,7 @@ func TestEnvCmd_AnimatedFailureIsMarkedAlreadyShown(t *testing.T) {
 	var buf bytes.Buffer
 	defer feedback.SetTestWriter(&buf)()
 	defer feedback.SetAnimated(true)()
+	defer feedback.SetInteractive(true)()
 
 	cmd := NewEnvCmd()
 	err := cmd.RunE(cmd, nil)

--- a/internal/cli/framework.go
+++ b/internal/cli/framework.go
@@ -65,16 +65,14 @@ func runFrameworkList(check bool) error {
 		}
 	}
 
+	var headers []string
 	if check {
-		fmt.Printf("%-15s %-8s %-10s %-10s %s\n", "Name", "Version", "Source", "Latest", "Status")
-		fmt.Printf("%-15s %-8s %-10s %-10s %s\n",
-			"───────────────", "────────", "──────────", "──────────", "──────────────────────")
+		headers = []string{"Name", "Version", "Source", "Latest", "Status"}
 	} else {
-		fmt.Printf("%-15s %-8s %-10s %-10s %s\n", "Name", "Version", "Source", "PublicDir", "Workers")
-		fmt.Printf("%-15s %-8s %-10s %-10s %s\n",
-			"───────────────", "────────", "──────────", "──────────", "──────────────────────")
+		headers = []string{"Name", "Version", "Source", "PublicDir", "Workers"}
 	}
 
+	rows := make([][]string, 0, len(frameworks))
 	for _, info := range frameworks {
 		version := info.Version
 		if version == "" && cwd != "" {
@@ -86,8 +84,7 @@ func runFrameworkList(check bool) error {
 
 		if check {
 			latest, status := storeStatus(info, storeIndex)
-			fmt.Printf("%-15s %-8s %-10s %-10s %s\n",
-				info.Name, version, info.Source, latest, status)
+			rows = append(rows, []string{info.Name, version, string(info.Source), latest, status})
 		} else {
 			var workerNames []string
 			for name := range info.Workers {
@@ -98,10 +95,10 @@ func runFrameworkList(check bool) error {
 			if workers == "" {
 				workers = "—"
 			}
-			fmt.Printf("%-15s %-8s %-10s %-10s %s\n",
-				info.Name, version, info.Source, info.PublicDir, workers)
+			rows = append(rows, []string{info.Name, version, string(info.Source), info.PublicDir, workers})
 		}
 	}
+	feedback.Table(headers, rows)
 	return nil
 }
 
@@ -412,13 +409,13 @@ Examples:
 				return nil
 			}
 
-			fmt.Printf("%-15s %-15s %-12s %s\n", "Name", "Label", "Latest", "Versions")
-			fmt.Printf("%-15s %-15s %-12s %s\n",
-				"───────────────", "───────────────", "────────────", "──────────────────────")
+			rows := make([][]string, 0, len(results))
 			for _, entry := range results {
-				fmt.Printf("%-15s %-15s %-12s %s\n",
-					entry.Name, entry.Label, entry.Latest, strings.Join(entry.Versions, ", "))
+				rows = append(rows, []string{
+					entry.Name, entry.Label, entry.Latest, strings.Join(entry.Versions, ", "),
+				})
 			}
+			feedback.Table([]string{"Name", "Label", "Latest", "Versions"}, rows)
 			return nil
 		},
 	}

--- a/internal/cli/idle.go
+++ b/internal/cli/idle.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -179,20 +177,23 @@ func runIdleStatus() error {
 
 	timeout := cfg.IdleSuspendTimeout()
 	now := time.Now()
-	tw := tabwriter.NewWriter(os.Stdout, 0, 2, 3, ' ', 0)
+	var rows [][]string
 	for _, s := range reg.Sites {
 		if s.Ignored {
 			continue
 		}
-		fmt.Fprintf(tw, "  %s\t%s\n", s.Name, idleSiteStatus(s, lastActive, uiErr, timeout, now))
+		rows = append(rows, []string{s.Name, idleSiteStatus(s, lastActive, uiErr, timeout, now)})
 		// A worktree idles independently, so list each under its site. The site's
 		// pause/pin still applies (the engine skips a paused or pinned site whole).
 		for _, wt := range worktrees[s.Name] {
-			label := "  " + s.Name + "/" + wt.Branch
-			fmt.Fprintf(tw, "  %s\t%s\n", label, idleWorktreeStatus(s, wt, uiErr, timeout, now))
+			label := "↳ " + s.Name + "/" + wt.Branch
+			rows = append(rows, []string{label, idleWorktreeStatus(s, wt, uiErr, timeout, now)})
 		}
 	}
-	return tw.Flush()
+	if len(rows) > 0 {
+		feedback.Table([]string{"Site", "Status"}, rows)
+	}
+	return nil
 }
 
 // idleSiteStatus renders a single unambiguous state for a site: paused sites are

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1342,7 +1342,7 @@ func applyProjectConfig(cwd string) error {
 // per-service output.
 func applyEnvStep(cwd string) {
 	envApplied = true
-	if !feedback.Animated() {
+	if !feedback.Interactive() {
 		if err := runEnv(nil, nil); err != nil {
 			feedback.Warn("lerd env: %v", err)
 		}

--- a/internal/cli/man.go
+++ b/internal/cli/man.go
@@ -60,8 +60,7 @@ func runManPlain(args []string) error {
 				return nil
 			}
 		}
-		fmt.Fprintf(os.Stderr, "No documentation page found for %q\n", query)
-		os.Exit(1)
+		return fmt.Errorf("no documentation page found for %q", query)
 	}
 
 	// Print table of contents

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -402,8 +402,16 @@ func newServiceListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List all services and their status",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			fmt.Printf("%-20s %-10s %-10s %s\n", "Service", "Version", "Status", "Update")
-			fmt.Printf("%s\n", strings.Repeat("─", 60))
+			var rows [][]string
+			statusCell := func(name, status string) string {
+				cell := colorStatus(status)
+				if status == "inactive" {
+					if reason := serviceInactiveReason(name); reason != "" {
+						cell += feedback.Dim(reason)
+					}
+				}
+				return cell
+			}
 			for _, svc := range knownServices() {
 				unit := "lerd-" + svc
 				status, err := podman.UnitStatus(unit)
@@ -411,12 +419,7 @@ func newServiceListCmd() *cobra.Command {
 					status = "unknown"
 				}
 				ver := podman.ServiceVersionLabel(podman.InstalledImage(unit))
-				fmt.Printf("%-20s %-10s %-10s %s\n", svc, ver, colorStatus(status), serviceUpdateHint(svc, status))
-				if status == "inactive" {
-					if reason := serviceInactiveReason(svc); reason != "" {
-						fmt.Printf("  %s\n", strings.TrimSpace(reason))
-					}
-				}
+				rows = append(rows, []string{svc, ver, statusCell(svc, status), serviceUpdateHint(svc, status)})
 			}
 			customs, _ := config.ListCustomServices()
 			for _, svc := range customs {
@@ -426,16 +429,13 @@ func newServiceListCmd() *cobra.Command {
 					status = "unknown"
 				}
 				ver := podman.ServiceVersionLabel(svc.Image)
-				fmt.Printf("%-20s %-10s %-10s %s  [custom]\n", svc.Name, ver, colorStatus(status), serviceUpdateHint(svc.Name, status))
-				if status == "inactive" {
-					if reason := serviceInactiveReason(svc.Name); reason != "" {
-						fmt.Printf("  %s\n", strings.TrimSpace(reason))
-					}
-				}
+				name := svc.Name + " " + feedback.Dim("[custom]")
+				rows = append(rows, []string{name, ver, statusCell(svc.Name, status), serviceUpdateHint(svc.Name, status)})
 				if len(svc.DependsOn) > 0 {
-					fmt.Printf("  depends on: %s\n", strings.Join(svc.DependsOn, ", "))
+					rows = append(rows, []string{feedback.Dim("↳ depends on: " + strings.Join(svc.DependsOn, ", ")), "", "", ""})
 				}
 			}
+			feedback.Table([]string{"Service", "Version", "Status", "Update"}, rows)
 			return nil
 		},
 	}
@@ -655,8 +655,7 @@ func printPresetList() error {
 		fmt.Println("No presets bundled with this build.")
 		return nil
 	}
-	fmt.Printf("%-14s %-10s %s\n", "Preset", "Status", "Description")
-	fmt.Printf("%s\n", strings.Repeat("─", 60))
+	var rows [][]string
 	for _, p := range presets {
 		status := "available"
 		if len(p.Versions) == 0 {
@@ -664,23 +663,19 @@ func printPresetList() error {
 				status = "installed"
 			}
 		} else {
-			anyInstalled := false
 			for _, v := range p.Versions {
 				if serviceops.ServiceInstalled(config.PresetVersionServiceName(p.Name, v)) {
-					anyInstalled = true
+					status = "installed"
 					break
 				}
 			}
-			if anyInstalled {
-				status = "installed"
-			}
 		}
-		fmt.Printf("%-14s %-10s %s\n", p.Name, status, p.Description)
+		rows = append(rows, []string{p.Name, status, p.Description})
 		if len(p.DependsOn) > 0 {
-			fmt.Printf("%-14s %-10s depends on: %s\n", "", "", strings.Join(p.DependsOn, ", "))
+			rows = append(rows, []string{"", "", feedback.Dim("depends on: " + strings.Join(p.DependsOn, ", "))})
 		}
 		if p.Dashboard != "" {
-			fmt.Printf("%-14s %-10s dashboard:  %s\n", "", "", p.Dashboard)
+			rows = append(rows, []string{"", "", feedback.Dim("dashboard: " + p.Dashboard)})
 		}
 		for _, v := range p.Versions {
 			versionStatus := "available"
@@ -691,13 +686,14 @@ func printPresetList() error {
 			if serviceops.ServiceInstalled(config.PresetVersionServiceName(p.Name, v)) {
 				versionStatus = "installed"
 			}
-			marker := " "
+			name := "↳ " + v.Tag
 			if v.Tag == p.DefaultVersion {
-				marker = "*"
+				name = "↳ * " + v.Tag
 			}
-			fmt.Printf("%-14s %-10s %s %-9s %-13s %s\n", "", "", marker, versionStatus, v.Tag, label)
+			rows = append(rows, []string{name, versionStatus, label})
 		}
 	}
+	feedback.Table([]string{"Preset", "Status", "Description"}, rows)
 	fmt.Println("\n* = default version")
 	fmt.Println("Install with: lerd service preset <name> [--version <tag>]")
 	return nil

--- a/internal/cli/sites.go
+++ b/internal/cli/sites.go
@@ -3,9 +3,8 @@ package cli
 import (
 	"fmt"
 	"os"
-	"strings"
+	"unicode/utf8"
 
-	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/siteinfo"
 	"github.com/spf13/cobra"
@@ -42,193 +41,112 @@ func runSites(_ *cobra.Command, _ []string) error {
 
 	width := termWidth()
 
-	// Print each main/standalone site, immediately followed by its group
-	// secondaries (a secondary occupies <label>.<main-domain> and reads as a
-	// child of the main, like aliases and worktrees do).
+	// Order sites: each main/standalone followed by its group secondaries (a
+	// secondary occupies <label>.<main-domain> and reads as a child of the main,
+	// like aliases and worktrees do).
 	secondariesByGroup := map[string][]siteinfo.EnrichedSite{}
 	for _, s := range sites {
 		if s.Group != "" && s.GroupSubdomain != "" {
 			secondariesByGroup[s.Group] = append(secondariesByGroup[s.Group], s)
 		}
 	}
+	var ordered []orderedSite
 	seen := map[string]bool{}
 	for _, s := range sites {
 		if s.GroupSubdomain != "" {
 			continue // printed under its main
 		}
-		printEnrichedSite(s, width, false)
+		ordered = append(ordered, orderedSite{s, false})
 		seen[s.Name] = true
 		for _, sec := range secondariesByGroup[s.Group] {
-			printEnrichedSite(sec, width, true)
+			ordered = append(ordered, orderedSite{sec, true})
 			seen[sec.Name] = true
 		}
 	}
 	// Any secondary whose main isn't listed (shouldn't happen, but never hide a site).
 	for _, s := range sites {
 		if s.GroupSubdomain != "" && !seen[s.Name] {
-			printEnrichedSite(s, width, true)
+			ordered = append(ordered, orderedSite{s, true})
 		}
 	}
 
+	// Narrow terminals keep the two-line compact layout; a bordered grid can't
+	// fit that width. Wider terminals get the styled table.
+	if width < 80 {
+		for _, o := range ordered {
+			printSiteCompact(o.site, o.grouped)
+		}
+		return nil
+	}
+
+	wide := width >= 120
+	headers := []string{"Domain", "PHP", "TLS", "Framework", "Status", "Path"}
+	if wide {
+		headers = []string{"Name", "Domain", "PHP", "Node", "TLS", "Framework", "Status", "Path"}
+	}
+	var rows [][]string
+	for _, o := range ordered {
+		rows = append(rows, siteRows(o.site, o.grouped, wide)...)
+	}
+	feedback.Table(headers, rows)
 	return nil
 }
 
-// printEnrichedSite prints one site row (plus its alias domains and worktrees)
-// at the right layout for the terminal width. When grouped is true the site is
-// a group secondary and is rendered indented beneath its main.
-func printEnrichedSite(s siteinfo.EnrichedSite, width int, grouped bool) {
-	site := config.Site{
-		Name:           s.Name,
-		Domains:        s.Domains,
-		Path:           s.Path,
-		PHPVersion:     s.PHPVersion,
-		NodeVersion:    s.NodeVersion,
-		Secured:        s.Secured,
-		Paused:         s.Paused,
-		Group:          s.Group,
-		GroupSubdomain: s.GroupSubdomain,
-	}
-
-	switch {
-	case width >= 120:
-		if grouped {
-			printGroupSecondaryWide(site, s.FrameworkLabel)
-		} else {
-			printSiteWide(site, s.FrameworkLabel)
-		}
-		for _, d := range s.Domains[1:] {
-			printAliasDomainWide(d)
-		}
-		for _, wt := range s.Worktrees {
-			printWorktreeWide(wt, site)
-		}
-	case width >= 80:
-		if grouped {
-			printGroupSecondaryMedium(site, s.FrameworkLabel)
-		} else {
-			printSiteMedium(site, s.FrameworkLabel)
-		}
-		for _, d := range s.Domains[1:] {
-			printAliasDomainMedium(d)
-		}
-		for _, wt := range s.Worktrees {
-			printWorktreeMedium(wt, site)
-		}
-	default:
-		if grouped {
-			printGroupSecondaryCompact(site, s.FrameworkLabel)
-		} else {
-			printSiteCompact(site, s.FrameworkLabel)
-		}
-		for _, d := range s.Domains[1:] {
-			printAliasDomainCompact(d)
-		}
-		for _, wt := range s.Worktrees {
-			printWorktreeCompact(wt, site)
-		}
-	}
+type orderedSite struct {
+	site    siteinfo.EnrichedSite
+	grouped bool
 }
 
 func pausedTag() string { return feedback.Amber("paused") }
 
-// Wide layout: Name Domain PHP Node TLS Framework Status Path  (≥120 cols)
-func printSiteWide(s config.Site, fwLabel string) {
-	if !siteWideHeaderPrinted {
-		fmt.Printf("%-22s %-32s %-6s %-6s %-4s %-10s %-8s %s\n",
-			"Name", "Domain", "PHP", "Node", "TLS", "Framework", "Status", "Path")
-		fmt.Printf("%s %s %s %s %s %s %s %s\n",
-			strings.Repeat("─", 22), strings.Repeat("─", 32),
-			strings.Repeat("─", 6), strings.Repeat("─", 6),
-			strings.Repeat("─", 4), strings.Repeat("─", 10),
-			strings.Repeat("─", 8), strings.Repeat("─", 28))
-		siteWideHeaderPrinted = true
-	}
+// siteRows renders a site as one main row plus a child row per alias domain and
+// worktree, the nested rows indented inside the first column so the grid keeps
+// its parent/child shape. wide adds the Name and Node columns (≥120 cols);
+// otherwise the domain leads (80–119 cols).
+func siteRows(s siteinfo.EnrichedSite, grouped, wide bool) [][]string {
 	tls := "No"
 	if s.Secured {
 		tls = "Yes"
 	}
-	statusCol := fmt.Sprintf("%-8s", "")
+	status := ""
 	if s.Paused {
-		statusCol = pausedTag() + "  "
+		status = pausedTag()
 	}
-	fmt.Printf("%-22s %-32s %-6s %-6s %-4s %-10s %s %s\n",
-		truncate(s.Name, 22), truncate(s.PrimaryDomain(), 32),
-		s.PHPVersion, s.NodeVersion, tls, fwLabel, statusCol, s.Path)
+
+	var rows [][]string
+	if wide {
+		name := truncate(s.Name, 22)
+		if grouped {
+			name = "↳ grp " + truncate(s.Name, 14)
+		}
+		rows = append(rows, []string{name, truncate(s.PrimaryDomain(), 32), s.PHPVersion, s.NodeVersion, tls, s.FrameworkLabel, status, s.Path})
+		for _, d := range s.Domains[1:] {
+			rows = append(rows, []string{"↳ alias", truncate(d, 32), "", "", "", "", "", ""})
+		}
+		for _, wt := range s.Worktrees {
+			rows = append(rows, []string{"↳ " + truncate(wt.Branch, 18), truncate(wt.Domain, 32), s.PHPVersion, s.NodeVersion, "—", "", "", wt.Path})
+		}
+		return rows
+	}
+
+	dom := truncate(s.PrimaryDomain(), 28)
+	if grouped {
+		dom = "↳ grp " + truncate(s.PrimaryDomain(), 20)
+	}
+	rows = append(rows, []string{dom, s.PHPVersion, tls, s.FrameworkLabel, status, s.Path})
+	for _, d := range s.Domains[1:] {
+		rows = append(rows, []string{"↳ " + truncate(d, 24), "", "", "", "", ""})
+	}
+	for _, wt := range s.Worktrees {
+		rows = append(rows, []string{"↳ " + truncate(wt.Domain, 24), s.PHPVersion, "—", "", "", wt.Path})
+	}
+	return rows
 }
 
-func printAliasDomainWide(domain string) {
-	fmt.Printf("  %-20s %-32s\n",
-		"↳ alias", truncate(domain, 32))
-}
-
-func printWorktreeWide(wt siteinfo.WorktreeInfo, s config.Site) {
-	fmt.Printf("  %-20s %-32s %-6s %-6s %-4s %-10s %-8s %s\n",
-		"↳ "+truncate(wt.Branch, 18), truncate(wt.Domain, 32),
-		s.PHPVersion, s.NodeVersion, "—", "", "", wt.Path)
-}
-
-func printGroupSecondaryWide(s config.Site, fwLabel string) {
-	tls := "No"
-	if s.Secured {
-		tls = "Yes"
-	}
-	statusCol := fmt.Sprintf("%-8s", "")
-	if s.Paused {
-		statusCol = pausedTag() + "  "
-	}
-	fmt.Printf("  %-20s %-32s %-6s %-6s %-4s %-10s %s %s\n",
-		"↳ grp "+truncate(s.Name, 14), truncate(s.PrimaryDomain(), 32),
-		s.PHPVersion, s.NodeVersion, tls, fwLabel, statusCol, s.Path)
-}
-
-// Medium layout: Domain PHP TLS Framework Status Path  (80–119 cols, no Node, shorter Name)
-func printSiteMedium(s config.Site, fwLabel string) {
-	if !siteMediumHeaderPrinted {
-		fmt.Printf("%-28s %-6s %-4s %-10s %-8s %s\n",
-			"Domain", "PHP", "TLS", "Framework", "Status", "Path")
-		fmt.Printf("%s %s %s %s %s %s\n",
-			strings.Repeat("─", 28), strings.Repeat("─", 6),
-			strings.Repeat("─", 4), strings.Repeat("─", 10),
-			strings.Repeat("─", 8), strings.Repeat("─", 22))
-		siteMediumHeaderPrinted = true
-	}
-	tls := "No"
-	if s.Secured {
-		tls = "Yes"
-	}
-	statusCol := fmt.Sprintf("%-8s", "")
-	if s.Paused {
-		statusCol = pausedTag() + "  "
-	}
-	fmt.Printf("%-28s %-6s %-4s %-10s %s %s\n",
-		truncate(s.PrimaryDomain(), 28), s.PHPVersion, tls, fwLabel, statusCol, s.Path)
-}
-
-func printAliasDomainMedium(domain string) {
-	fmt.Printf("  %-26s\n",
-		"↳ "+truncate(domain, 24))
-}
-
-func printWorktreeMedium(wt siteinfo.WorktreeInfo, s config.Site) {
-	fmt.Printf("  %-26s %-6s %-4s %-10s %-8s %s\n",
-		"↳ "+truncate(wt.Domain, 24), s.PHPVersion, "—", "", "", wt.Path)
-}
-
-func printGroupSecondaryMedium(s config.Site, fwLabel string) {
-	tls := "No"
-	if s.Secured {
-		tls = "Yes"
-	}
-	statusCol := fmt.Sprintf("%-8s", "")
-	if s.Paused {
-		statusCol = pausedTag() + "  "
-	}
-	fmt.Printf("  %-26s %-6s %-4s %-10s %s %s\n",
-		"↳ grp "+truncate(s.PrimaryDomain(), 20), s.PHPVersion, tls, fwLabel, statusCol, s.Path)
-}
-
-// Compact layout: two lines per site  (<80 cols)
-func printSiteCompact(s config.Site, fwLabel string) {
+// printSiteCompact prints a site as two indented lines (plus its aliases and
+// worktrees) for terminals too narrow for the table. grouped renders a group
+// secondary nested beneath its main.
+func printSiteCompact(s siteinfo.EnrichedSite, grouped bool) {
 	status := ""
 	if s.Paused {
 		status = " [" + pausedTag() + "]"
@@ -238,54 +156,37 @@ func printSiteCompact(s config.Site, fwLabel string) {
 		tls = " 🔒"
 	}
 	meta := s.PHPVersion
-	if fwLabel != "" {
-		meta += " · " + fwLabel
+	if s.FrameworkLabel != "" {
+		meta += " · " + s.FrameworkLabel
 	}
-	fmt.Printf("%s%s%s\n", s.PrimaryDomain(), tls, status)
-	fmt.Printf("  %s\n", truncate(s.Path, 76))
-	if meta != "" {
-		fmt.Printf("  %s\n", feedback.Dim(meta))
+
+	if grouped {
+		fmt.Printf("  ↳ grp %s%s%s\n", s.PrimaryDomain(), tls, status)
+		fmt.Printf("    %s\n", truncate(s.Path, 74))
+		if meta != "" {
+			fmt.Printf("    %s\n", feedback.Dim(meta))
+		}
+	} else {
+		fmt.Printf("%s%s%s\n", s.PrimaryDomain(), tls, status)
+		fmt.Printf("  %s\n", truncate(s.Path, 76))
+		if meta != "" {
+			fmt.Printf("  %s\n", feedback.Dim(meta))
+		}
+	}
+
+	for _, d := range s.Domains[1:] {
+		fmt.Printf("  ↳ %s\n", d)
+	}
+	for _, wt := range s.Worktrees {
+		fmt.Printf("  ↳ %s\n", wt.Domain)
+		fmt.Printf("    %s\n", truncate(wt.Path, 74))
 	}
 }
-
-func printAliasDomainCompact(domain string) {
-	fmt.Printf("  ↳ %s\n", domain)
-}
-
-func printWorktreeCompact(wt siteinfo.WorktreeInfo, _ config.Site) {
-	fmt.Printf("  ↳ %s\n", wt.Domain)
-	fmt.Printf("    %s\n", truncate(wt.Path, 74))
-}
-
-func printGroupSecondaryCompact(s config.Site, fwLabel string) {
-	status := ""
-	if s.Paused {
-		status = " [" + pausedTag() + "]"
-	}
-	tls := ""
-	if s.Secured {
-		tls = " 🔒"
-	}
-	meta := s.PHPVersion
-	if fwLabel != "" {
-		meta += " · " + fwLabel
-	}
-	fmt.Printf("  ↳ grp %s%s%s\n", s.PrimaryDomain(), tls, status)
-	fmt.Printf("    %s\n", truncate(s.Path, 74))
-	if meta != "" {
-		fmt.Printf("    %s\n", feedback.Dim(meta))
-	}
-}
-
-// package-level header guards so headers print once per run
-var (
-	siteWideHeaderPrinted   bool
-	siteMediumHeaderPrinted bool
-)
 
 func truncate(s string, max int) string {
-	if len(s) <= max {
+	if utf8.RuneCountInString(s) <= max {
 		return s
 	}
-	return s[:max-3] + "..."
+	r := []rune(s)
+	return string(r[:max-3]) + "..."
 }

--- a/internal/cli/xdebug.go
+++ b/internal/cli/xdebug.go
@@ -154,15 +154,15 @@ func runXdebugStatus(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	fmt.Printf("%-10s %-10s %s\n", "Version", "Xdebug", "Mode")
-	fmt.Printf("%-10s %-10s %s\n", "─────────", "──────────", "────")
+	rows := make([][]string, 0, len(versions))
 	for _, v := range versions {
 		mode := cfg.GetXdebugMode(v)
-		state := feedback.Amber(fmt.Sprintf("%-10s", "disabled"))
+		state := feedback.Amber("disabled")
 		if mode != "" {
-			state = feedback.Green(fmt.Sprintf("%-10s", "enabled"))
+			state = feedback.Green("enabled")
 		}
-		fmt.Printf("%-10s %s %s\n", v, state, mode)
+		rows = append(rows, []string{v, state, mode})
 	}
+	feedback.Table([]string{"Version", "Xdebug", "Mode"}, rows)
 	return nil
 }

--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -545,6 +545,7 @@ func InstallSudoers() error {
 		return nil
 	}
 
+	feedback.Sudo("Installing DNS sudoers rule")
 	if err := sudoWriteFile(sudoersPath, []byte(content), 0440); err != nil {
 		return fmt.Errorf("writing sudoers drop-in: %w", err)
 	}

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -159,6 +159,38 @@ func ReadKey(path, key string) string {
 	return ""
 }
 
+// ReadValues reads path once and returns all non-comment key/value pairs, with
+// each value unquoted the same way ReadKey unquotes a single key. On a duplicate
+// key the first occurrence wins, matching ReadKey, which returns its first
+// match. Returns an empty (non-nil) map when the file is missing, so callers can
+// range freely. Prefer this over repeated ReadKey calls when checking several
+// keys from one file: ReadKey re-opens and rescans the whole file on every call.
+func ReadValues(path string) map[string]string {
+	out := map[string]string{}
+	f, err := os.Open(path)
+	if err != nil {
+		return out
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if k = strings.TrimSpace(k); k != "" {
+			if _, seen := out[k]; !seen {
+				out[k] = strings.Trim(strings.TrimSpace(v), `"'`)
+			}
+		}
+	}
+	return out
+}
+
 // ReferencesContainer reports whether content references the lerd container
 // hostname "lerd-<serviceName>" as a whole token, so bare "postgres" is not
 // matched by a "lerd-postgres-18" reference (and vice versa).

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -387,3 +387,39 @@ func TestReferencesContainer(t *testing.T) {
 		})
 	}
 }
+
+// ── ReadValues ───────────────────────────────────────────────────────────────
+
+func TestReadValues_parsesUnquotesSkipsComments(t *testing.T) {
+	f := writeEnv(t, "# comment\nDB_HOST=lerd-postgres\nDB_PORT=\"5432\"\nEMPTY=\nbroken line\n")
+	got := ReadValues(f)
+	if got["DB_HOST"] != "lerd-postgres" {
+		t.Errorf("DB_HOST = %q, want lerd-postgres", got["DB_HOST"])
+	}
+	if got["DB_PORT"] != "5432" {
+		t.Errorf("DB_PORT = %q, want 5432 (quotes stripped)", got["DB_PORT"])
+	}
+	if v, ok := got["EMPTY"]; !ok || v != "" {
+		t.Errorf("EMPTY should be present and empty, got %q present=%v", v, ok)
+	}
+	if _, ok := got["# comment"]; ok {
+		t.Error("comment line must not become a key")
+	}
+}
+
+func TestReadValues_missingFileReturnsEmptyMap(t *testing.T) {
+	got := ReadValues(filepath.Join(t.TempDir(), "nope.env"))
+	if got == nil || len(got) != 0 {
+		t.Errorf("missing file should yield empty non-nil map, got %v", got)
+	}
+}
+
+func TestReadValues_firstOccurrenceWinsLikeReadKey(t *testing.T) {
+	f := writeEnv(t, "DB_HOST=first\nDB_HOST=second\n")
+	if got := ReadValues(f)["DB_HOST"]; got != "first" {
+		t.Errorf("ReadValues DB_HOST = %q, want first (parity with ReadKey)", got)
+	}
+	if got := ReadKey(f, "DB_HOST"); got != "first" {
+		t.Errorf("ReadKey DB_HOST = %q, want first", got)
+	}
+}

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"github.com/charmbracelet/x/ansi"
 	"golang.org/x/term"
 )
 
@@ -321,6 +323,28 @@ func (s *Step) Fail(err error) {
 	s.finish(paint(failStyle, "✗"), paint(failStyle, msg))
 }
 
+// Fail prints a standalone red ✗ line for err to stderr in the same style (and
+// blank-line spacing) as a Live/Step failure. It is for the top-level command
+// handler to render an error a command returned without surfacing it itself, so
+// every failure reads the same whether it came up through a spinner or bubbled
+// out raw. Errors go to stderr so stdout stays clean for piped data. It records
+// err as shown so nothing reprints it.
+func Fail(err error) { FailOn(os.Stderr, err) }
+
+// FailOn is Fail targeted at an explicit writer, colouring only when that writer
+// is a terminal. Lets the top-level handler send errors to stderr and tests
+// capture them in a buffer.
+func FailOn(w io.Writer, err error) {
+	if err == nil {
+		return
+	}
+	markReported(err)
+	on := colorEnabledFor(w)
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintf(w, "\n%s%s %s\n\n", pad, paintIf(on, failStyle, GlyphFail), paintIf(on, failStyle, err.Error()))
+}
+
 // Line prints a standalone step (arrow prefix, no trailing ellipsis) for an
 // already-known fact, e.g. "php 8.4 · node 22 · nginx vhost written".
 func Line(msg string) {
@@ -393,6 +417,156 @@ func WarnOn(w io.Writer, format string, a ...any) {
 	mu.Lock()
 	defer mu.Unlock()
 	fmt.Fprintf(w, "%s%s %s\n", pad, paintIf(on, warnStyle, "⚠"), paintIf(on, warnStyle, msg))
+}
+
+// Table prints headers + rows as a single aligned table in the lerd palette so
+// every `lerd … list`/`search` view shares one look instead of hand-rolled
+// printf columns. See RenderTable for the styling and plain-mode fallback.
+func Table(headers []string, rows [][]string) {
+	mu.Lock()
+	defer mu.Unlock()
+	fmt.Fprintln(target(), RenderTable(headers, rows))
+}
+
+// tableWidth reports the column budget a rendered table must fit within: the
+// terminal width, or 0 when it can't be determined (piped/redirected) so the
+// table renders at its natural width. A package var so tests can pin a width.
+var tableWidth = func() int {
+	if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
+		return w
+	}
+	return 0
+}
+
+// RenderTable returns the table as a string without printing it, for callers
+// that compose it into other output. On a colour TTY it draws a rounded grid
+// with a bold brand-red header and dim borders; with colour off (NO_COLOR or a
+// pipe) it falls back to plain space-aligned columns so scripted output stays
+// parseable. When the natural grid is wider than the terminal the widest
+// columns are truncated with an ellipsis so every row stays on one line and the
+// grid fits the screen whenever the column count leaves room for it.
+func RenderTable(headers []string, rows [][]string) string {
+	if !colorOn.Load() {
+		return plainTable(headers, rows)
+	}
+	if w := tableWidth(); w > 0 {
+		headers, rows = fitColumns(headers, rows, w)
+	}
+	header := lipgloss.NewStyle().Bold(true).Foreground(ColTitle).Padding(0, 1)
+	cell := lipgloss.NewStyle().Padding(0, 1)
+	t := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(ColDivider)).
+		Headers(headers...).
+		Rows(rows...).
+		StyleFunc(func(row, _ int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return header
+			}
+			return cell
+		})
+	return t.String()
+}
+
+// fitColumns shrinks a table to fit budget columns wide by repeatedly trimming
+// the widest column and ellipsis-truncating its cells, so rows stay single-line.
+// Rounded borders cost one cell per separator (N+1) plus two padding cells per
+// column, so the content budget is budget-(3N+1). Truncation is ANSI-aware so
+// pre-coloured cells keep their styling.
+func fitColumns(headers []string, rows [][]string, budget int) ([]string, [][]string) {
+	n := len(headers)
+	if n == 0 {
+		return headers, rows
+	}
+	widths := make([]int, n)
+	for i, h := range headers {
+		widths[i] = ansi.StringWidth(h)
+	}
+	for _, r := range rows {
+		for i := 0; i < n && i < len(r); i++ {
+			if w := ansi.StringWidth(r[i]); w > widths[i] {
+				widths[i] = w
+			}
+		}
+	}
+
+	total := 0
+	for _, w := range widths {
+		total += w
+	}
+	avail := budget - (3*n + 1)
+	if total <= avail {
+		return headers, rows // already fits
+	}
+	// On a terminal too narrow even for the per-column floor, shrink everything
+	// to the floor anyway: the grid may still exceed the screen, but clamped to
+	// the minimum it can be rather than spilling at full natural width.
+	const minCol = 6
+
+	for total > avail {
+		maxI, maxW := -1, minCol
+		for i, w := range widths {
+			if w > maxW {
+				maxI, maxW = i, w
+			}
+		}
+		if maxI < 0 {
+			break // every column already at the floor
+		}
+		widths[maxI]--
+		total--
+	}
+
+	outHeaders := make([]string, n)
+	for i, h := range headers {
+		outHeaders[i] = ansi.Truncate(h, widths[i], "…")
+	}
+	outRows := make([][]string, len(rows))
+	for ri, r := range rows {
+		nr := make([]string, len(r))
+		copy(nr, r)
+		for i := 0; i < n && i < len(nr); i++ {
+			nr[i] = ansi.Truncate(nr[i], widths[i], "…")
+		}
+		outRows[ri] = nr
+	}
+	return outHeaders, outRows
+}
+
+// plainTable lays the same data out as space-aligned columns with a two-space
+// gutter and no borders or colour, for piped/NO_COLOR output. Widths are
+// measured with lipgloss.Width so any pre-styled cells still align.
+func plainTable(headers []string, rows [][]string) string {
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = lipgloss.Width(h)
+	}
+	for _, r := range rows {
+		for i := 0; i < len(widths) && i < len(r); i++ {
+			if w := lipgloss.Width(r[i]); w > widths[i] {
+				widths[i] = w
+			}
+		}
+	}
+	var b strings.Builder
+	writeRow := func(cells []string) {
+		for i := range widths {
+			val := ""
+			if i < len(cells) {
+				val = cells[i]
+			}
+			b.WriteString(val)
+			if i < len(widths)-1 {
+				b.WriteString(strings.Repeat(" ", widths[i]-lipgloss.Width(val)+2))
+			}
+		}
+		b.WriteString("\n")
+	}
+	writeRow(headers)
+	for _, r := range rows {
+		writeRow(r)
+	}
+	return strings.TrimRight(b.String(), "\n")
 }
 
 // interruptible is anything that animates a spinner line and can pause it so a
@@ -479,6 +653,24 @@ func Prompt(question string, defaultYes bool) {
 // Animated reports whether output supports in-place animation (a colour TTY).
 // When false, Live degrades to a header line plus one plain line per item.
 func Animated() bool { return colorOn.Load() }
+
+// interactiveFn is the swappable backing for Interactive so tests can pin it
+// via SetInteractive without exposing a mutable public symbol.
+var interactiveFn = func() bool { return term.IsTerminal(int(os.Stdout.Fd())) }
+
+// Interactive reports whether stdout is a terminal, independent of colour. Use
+// it to choose a condensed single-line view over full verbose output: a user
+// who only disabled colour (NO_COLOR) still gets the interactive view rather
+// than the pipe/MCP verbose path. Animated() is the wrong gate for that, since
+// NO_COLOR forces it false even on a real terminal.
+func Interactive() bool { return interactiveFn() }
+
+// SetInteractive overrides Interactive for a test and returns a restore func.
+func SetInteractive(on bool) func() {
+	prev := interactiveFn
+	interactiveFn = func() bool { return on }
+	return func() { interactiveFn = prev }
+}
 
 // Live is a single in-place progress line with a trailing spinner that
 // accumulates completed items, e.g. "→ configuring .env… ✓ a · b · c ⠙". When

--- a/internal/feedback/table_test.go
+++ b/internal/feedback/table_test.go
@@ -1,0 +1,114 @@
+package feedback
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestTablePlainAligns(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)() // forces plain mode (no colour, no borders)
+
+	Table(
+		[]string{"Name", "Latest", "Versions"},
+		[][]string{
+			{"laravel", "13", "13, 12, 11"},
+			{"symfony", "8", "8, 7"},
+		},
+	)
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 lines (header + 2 rows), got %d: %q", len(lines), buf.String())
+	}
+	// Plain mode must not draw borders or ANSI escapes.
+	if strings.ContainsAny(buf.String(), "│─╭╮╰╯\x1b") {
+		t.Fatalf("plain table leaked borders/escapes: %q", buf.String())
+	}
+	// The "Latest" column header and the longer "Versions" value must start at
+	// the same offset on every line, proving alignment.
+	col := strings.Index(lines[0], "Latest")
+	for i, ln := range lines[1:] {
+		if got := strings.Index(ln, strings.Fields(ln)[1]); got != col {
+			t.Errorf("row %d second column at %d, want %d: %q", i, got, col, ln)
+		}
+	}
+}
+
+func TestTableRaggedRowsNoPanic(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	// A row shorter than the header must pad, not panic or drop columns.
+	Table([]string{"A", "B", "C"}, [][]string{{"x"}, {"y", "z", "w"}})
+	if !strings.Contains(buf.String(), "x") || !strings.Contains(buf.String(), "w") {
+		t.Fatalf("ragged rows mangled: %q", buf.String())
+	}
+}
+
+func TestRenderTableFitsTerminalWidth(t *testing.T) {
+	mu.Lock()
+	prevColor, prevWidth := colorOn.Load(), tableWidth
+	colorOn.Store(true)
+	tableWidth = func() int { return 60 }
+	mu.Unlock()
+	defer func() {
+		mu.Lock()
+		colorOn.Store(prevColor)
+		tableWidth = prevWidth
+		mu.Unlock()
+	}()
+
+	out := RenderTable(
+		[]string{"Name", "Path"},
+		[][]string{{"app", "/very/long/path/that/keeps/going/and/going/well/past/sixty/columns/wide"}},
+	)
+	for _, ln := range strings.Split(out, "\n") {
+		if w := lipgloss.Width(ln); w > 60 {
+			t.Errorf("line width %d exceeds budget 60: %q", w, ln)
+		}
+	}
+	if !strings.Contains(out, "…") {
+		t.Errorf("expected an ellipsis from truncating the long path: %q", out)
+	}
+}
+
+func TestRenderTableColouredHasBorders(t *testing.T) {
+	mu.Lock()
+	prev := colorOn.Load()
+	colorOn.Store(true)
+	mu.Unlock()
+	defer func() {
+		mu.Lock()
+		colorOn.Store(prev)
+		mu.Unlock()
+	}()
+
+	out := RenderTable([]string{"Name"}, [][]string{{"laravel"}})
+	if !strings.ContainsAny(out, "╭─│") {
+		t.Fatalf("coloured table missing rounded border: %q", out)
+	}
+}
+
+func TestFailPrintsCrossAndMarksShown(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	err := errTest("boom")
+	FailOn(&buf, err)
+
+	out := buf.String()
+	if !strings.Contains(out, "✗") || !strings.Contains(out, "boom") {
+		t.Fatalf("Fail output missing cross or message: %q", out)
+	}
+	if !AlreadyShown(err) {
+		t.Errorf("Fail should mark the error as already shown")
+	}
+}
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }


### PR DESCRIPTION
Every lerd list and search view now renders through a single shared feedback.Table helper instead of hand-rolled printf columns, so sites, services, presets, db snapshots, framework list and search, env check, idle, and xdebug share one bordered look. The helper shrinks its widest columns with an ellipsis to fit the terminal width and falls back to plain aligned columns when output is piped or NO_COLOR is set, and the sites view keeps its worktree, alias, and group-secondary rows indented inside the grid rather than as separate hand-formatted lines.

Command failures are now uniform. The top-level handler renders a returned error as a single red cross line on stderr instead of cobra's raw Error prefix followed by a usage dump, and usage is suppressed only after flags and arguments validate, so mistyping a flag or passing the wrong number of arguments still prints the usage block.

This also restores the lock-glyph header that was missing on the Linux DNS sudoers step, keeps lerd env and lerd init on the condensed live view when only colour is disabled instead of dropping to verbose output, and reads each worktree .env once during database realignment rather than five times.

Closes #609