### PR TITLE
fix(cli): bring uninstall output onto the feedback vocabulary

### DIFF
--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"bufio"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -49,8 +47,9 @@ func runUninstall(force bool) error {
 	removeMkcertCA := force || confirmRemoveMkcertCA()
 	purgeImages := force || confirmPurgeLerdImages()
 
-	// DNS teardown runs outside the step runner because it may prompt for sudo.
-	fmt.Println("  --> Removing DNS configuration")
+	// DNS teardown runs outside the step runner because it may prompt for sudo;
+	// the lock glyph warns that the password prompt below is expected.
+	feedback.Sudo("Removing DNS configuration")
 	dns.Teardown()
 
 	step("Stopping containers and services")
@@ -115,12 +114,12 @@ func runUninstall(force bool) error {
 	ok()
 
 	if purgeImages {
-		fmt.Println("  --> Purging lerd-built container images")
+		feedback.Line("purging lerd-built container images")
 		removeLerdImages()
 	}
 
 	if removeMkcertCA {
-		fmt.Println("  --> Uninstalling mkcert CA from system trust stores")
+		feedback.Sudo("Uninstalling mkcert CA from system trust stores")
 		cmd := exec.Command(certs.MkcertPath(), "-uninstall")
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
@@ -129,15 +128,15 @@ func runUninstall(force bool) error {
 	}
 
 	if removeMCP {
-		fmt.Println("  --> Removing MCP integration (global)")
+		feedback.Line("removing MCP integration (global)")
 		if home, err := os.UserHomeDir(); err == nil {
 			_ = RemoveGlobalAISkills(home, true)
 		}
-		fmt.Println("  --> Removing MCP integration (registered sites)")
+		feedback.Line("removing MCP integration (registered sites)")
 		if reg, err := config.LoadSites(); err == nil {
 			for _, s := range reg.Sites {
 				if err := RemoveProjectAISkills(s.Path, false); err == nil {
-					fmt.Printf("    cleaned %s\n", s.Path)
+					feedback.Note("cleaned " + s.Path)
 				}
 			}
 		}
@@ -153,12 +152,11 @@ func runUninstall(force bool) error {
 	}
 	ok()
 
-	fmt.Println()
 	if removeData {
-		fmt.Print("  --> Removing config and data directories ... ")
+		step("Removing config and data directories")
 		os.RemoveAll(config.ConfigDir())
 		os.RemoveAll(config.DataDir())
-		fmt.Println("OK")
+		ok()
 	} else {
 		feedback.Note("config kept at " + config.ConfigDir())
 		feedback.Note("data kept at " + config.DataDir())
@@ -169,18 +167,15 @@ func runUninstall(force bool) error {
 }
 
 func confirmRemoveMCPIntegration() bool {
-	fmt.Print("  Remove MCP integration (global skills + per-site .mcp/.claude/.cursor/.junie files)? [y/N] ")
-	return readYes()
+	return feedback.Confirm("Remove MCP integration (global skills + per-site .mcp/.claude/.cursor/.junie files)?", false)
 }
 
 func confirmRemoveMkcertCA() bool {
-	fmt.Print("  Uninstall mkcert CA from system trust stores? [y/N] ")
-	return readYes()
+	return feedback.Confirm("Uninstall mkcert CA from system trust stores?", false)
 }
 
 func confirmPurgeLerdImages() bool {
-	fmt.Print("  Purge lerd-built container images (lerd-php*-fpm, lerd-custom-*, lerd-dnsmasq)? Databases and app files are unaffected. [y/N] ")
-	return readYes()
+	return feedback.Confirm("Purge lerd-built container images (lerd-php*-fpm, lerd-custom-*, lerd-dnsmasq)? Databases and app files are unaffected.", false)
 }
 
 // removeLerdImages removes locally-built lerd images. Upstream pulls
@@ -189,7 +184,7 @@ func confirmPurgeLerdImages() bool {
 func removeLerdImages() {
 	out, err := exec.Command(podman.PodmanBin(), "images", "--format", "{{.Repository}}:{{.Tag}}").Output()
 	if err != nil {
-		fmt.Printf("    WARN: listing images: %v\n", err)
+		feedback.Warn("listing images: %v", err)
 		return
 	}
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
@@ -201,10 +196,10 @@ func removeLerdImages() {
 			continue
 		}
 		if err := exec.Command(podman.PodmanBin(), "image", "rm", "-f", line).Run(); err != nil {
-			fmt.Printf("    WARN: removing %s: %v\n", line, err)
+			feedback.Warn("removing %s: %v", line, err)
 			continue
 		}
-		fmt.Printf("    removed %s\n", line)
+		feedback.Note("removed " + line)
 	}
 }
 
@@ -222,15 +217,7 @@ func isLerdBuiltImage(ref string) bool {
 }
 
 func confirmRemoveData() bool {
-	fmt.Print("  Remove all config and data (~/.config/lerd, ~/.local/share/lerd)? [y/N] ")
-	return readYes()
-}
-
-func readYes() bool {
-	scanner := bufio.NewScanner(os.Stdin)
-	scanner.Scan()
-	ans := strings.TrimSpace(scanner.Text())
-	return strings.EqualFold(ans, "y") || strings.EqualFold(ans, "yes")
+	return feedback.Confirm("Remove all config and data (~/.config/lerd, ~/.local/share/lerd)?", false)
 }
 
 // shellRCMarkers lists every marker comment lerd's install pipelines

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -87,45 +87,6 @@ func TestRemoveMarkedBlock_onlyMarker(t *testing.T) {
 	}
 }
 
-// ── readYes ──────────────────────────────────────────────────────────────────
-
-func TestReadYes(t *testing.T) {
-	cases := []struct {
-		input string
-		want  bool
-	}{
-		{"y\n", true},
-		{"Y\n", true},
-		{"yes\n", true},
-		{"YES\n", true},
-		{"n\n", false},
-		{"N\n", false},
-		{"no\n", false},
-		{"\n", false},
-		{"maybe\n", false},
-	}
-
-	for _, c := range cases {
-		// Redirect stdin to a pipe containing the test input.
-		r, w, err := os.Pipe()
-		if err != nil {
-			t.Fatal(err)
-		}
-		w.WriteString(c.input)
-		w.Close()
-
-		oldStdin := os.Stdin
-		os.Stdin = r
-		got := readYes()
-		os.Stdin = oldStdin
-		r.Close()
-
-		if got != c.want {
-			t.Errorf("readYes(%q) = %v, want %v", c.input, got, c.want)
-		}
-	}
-}
-
 // ── removeShellEntry ─────────────────────────────────────────────────────────
 
 func TestRemoveShellEntry_bashrc(t *testing.T) {


### PR DESCRIPTION
The uninstall flow was half-converted: the main confirmation, the progress steps, and the final result already spoke the feedback vocabulary, but the data, MCP, mkcert, and image prompts still used raw fmt prints with bracket hints, the intermediate notices used a --> prefix, and the DNS teardown's sudo prompt arrived with no lock-glyph header to warn the password request was coming.

The four sub-prompts now go through feedback.Confirm so they render with the same gold question glyph as the top-level one, the DNS and mkcert steps that may ask for a password are introduced with feedback.Sudo so the lock glyph appears first, the config and data removal is a proper progress step, and the per-image and per-site results report through feedback.Note and feedback.Warn. The prompts still run before the step runner takes over stdin, so the ordering that keeps their input from being swallowed is preserved.

Closes #611