### PR TITLE
fix(security): close name injection, root-write, and WS rebinding holes

### DIFF
--- a/internal/cli/worktree_db_test.go
+++ b/internal/cli/worktree_db_test.go
@@ -77,7 +77,7 @@ func TestFindParentSiteForWorktree_unregisteredDir(t *testing.T) {
 func TestWorktreeDBName_underscoreSlug(t *testing.T) {
 	cases := map[[2]string]string{
 		{"acme", "feat-a"}:       "acme_feat_a",
-		{"my_app", "feature/x"}:  "my_app_feature/x", // sanitization happens at branch detection time, not here
+		{"my_app", "feature/x"}:  "my_app_feature_x", // SiteSlug maps the slash to _ along with every other non-[a-z0-9_] char
 		{"acme_app", "feat-x-y"}: "acme_app_feat_x_y",
 		{"acme", "RELEASE-1"}:    "acme_release_1",
 	}

--- a/internal/config/slug.go
+++ b/internal/config/slug.go
@@ -3,13 +3,24 @@ package config
 import "strings"
 
 // SiteSlug converts a name (site name, branch, directory basename, or domain)
-// to a database-safe, underscore-separated slug. Hyphens and dots are replaced
-// with underscores and the result is lowercased.
+// to a database-safe, underscore-separated slug. It lowercases and maps every
+// character outside [a-z0-9_] to an underscore, extending the long-standing
+// hyphen/dot-to-underscore convention to all separators. The mapping matters
+// for security: slugs flow into shell-run site_init commands and SQL
+// identifiers, so a name carrying a backtick, quote, semicolon, or $(...) must
+// not survive into those sinks. Mapping (rather than dropping) keeps slashed
+// branches like "feature/x" collision-free as "feature_x".
 func SiteSlug(name string) string {
-	s := strings.ToLower(name)
-	s = strings.ReplaceAll(s, "-", "_")
-	s = strings.ReplaceAll(s, ".", "_")
-	return s
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range strings.ToLower(name) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
 }
 
 // WorktreeUnitSlug sanitizes a worktree directory basename for use inside a

--- a/internal/config/slug_test.go
+++ b/internal/config/slug_test.go
@@ -16,6 +16,16 @@ func TestSiteSlug(t *testing.T) {
 		{"mixed.dots-and-hyphens", "mixed_dots_and_hyphens"},
 		{"simple", "simple"},
 		{"", ""},
+		// Security: shell/SQL metacharacters must be neutralised so a hostile
+		// directory or branch name cannot reach a site_init `sh -c` or a
+		// CREATE DATABASE identifier carrying an injection payload. They map to
+		// underscores, so the output is always [a-z0-9_].
+		{"app`id`x", "app_id_x"},
+		{`app"x`, "app_x"},
+		{"a b;c", "a_b_c"},
+		{"feature/x", "feature_x"},
+		{"drop`whoami`", "drop_whoami_"},
+		{`x";DROP`, "x__drop"},
 	}
 	for _, tc := range cases {
 		if got := SiteSlug(tc.in); got != tc.want {

--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -56,9 +56,11 @@ else
     exit 0
 fi
 
-# Sync lerd-dns config and restart for any user running it. systemctl --user
-# runs via runuser as the real user (XDG_RUNTIME_DIR/DBUS from the root
-# dispatcher alone is not enough); the > rewrite keeps the file's user ownership.
+# Sync lerd-dns config and restart for any user running it. The dispatcher runs
+# as root, so the config rewrite is piped through runuser ($as_user) and written
+# by the owning user, never by root: a user who symlinks their lerd.conf at a
+# root-owned path then can only write where they already could, closing the
+# arbitrary-file-write escalation. systemctl --user likewise runs via runuser.
 for uid_dir in /run/user/[0-9]*/; do
     [ -d "$uid_dir" ] || continue
     bus="${uid_dir}bus"
@@ -88,10 +90,16 @@ for uid_dir in /run/user/[0-9]*/; do
     {
         printf '# Lerd DNS configuration\nport=5300\nno-resolv\n'
         for dns_ip in $dns_servers; do
+            # Defensive filter: emit only tokens shaped like an IP with an
+            # optional #port. The Go side validates dns.upstream, but the awk
+            # re-parse above does not, so reject anything outside IP/port chars.
+            case "$dns_ip" in
+                ''|*[!0-9A-Fa-f:.#]*) continue ;;
+            esac
             printf 'server=%s\n' "$dns_ip"
         done
         printf 'address=/.%s/127.0.0.1\n' "$tld"
-    } > "$config_file"
+    } | $as_user tee "$config_file" >/dev/null
     $as_user systemctl --user restart lerd-dns 2>/dev/null || true
 done
 `

--- a/internal/dns/setup_test.go
+++ b/internal/dns/setup_test.go
@@ -191,6 +191,23 @@ func TestNMDispatcherScript_prefersPinnedUpstream(t *testing.T) {
 	assertContains(t, nmDispatcherScript, "dns_servers=\"$LERD_DNS\"")
 }
 
+// The dispatcher runs as root, so writing the per-user lerd.conf with a plain
+// root `> "$config_file"` redirect lets a user symlink that path at a root-owned
+// file and have root truncate it (CWE-59 privesc). The write must go through
+// runuser ($as_user) so it happens with the owning user's privileges.
+func TestNMDispatcherScript_writesConfigAsUser(t *testing.T) {
+	assertContains(t, nmDispatcherScript, `| $as_user tee "$config_file"`)
+	if strings.Contains(nmDispatcherScript, `} > "$config_file"`) {
+		t.Error("dispatcher still writes lerd.conf via a root redirect; must pipe through $as_user")
+	}
+}
+
+// The awk re-parse of dns.upstream applies no validation, so the server-entry
+// loop must filter to IP/port-shaped tokens before emitting server= lines.
+func TestNMDispatcherScript_filtersUpstreamEntries(t *testing.T) {
+	assertContains(t, nmDispatcherScript, "*[!0-9A-Fa-f:.#]*) continue")
+}
+
 // --- WriteDnsmasqConfigFor ---
 
 func TestWriteDnsmasqConfigFor_customTarget(t *testing.T) {

--- a/internal/serviceops/provision.go
+++ b/internal/serviceops/provision.go
@@ -10,6 +10,15 @@ import (
 	"github.com/geodro/lerd/internal/podman"
 )
 
+// escapeIdentBacktick makes name safe inside a MySQL/MariaDB `...` identifier
+// by doubling embedded backticks; escapeIdentDQuote does the same for a
+// PostgreSQL "..." identifier, and escapeSQLLiteral for a '...' string literal.
+// Callers already pass slugged names, but these guard the SQL sinks directly so
+// a name that ever reaches here unsanitised cannot break out of its quoting.
+func escapeIdentBacktick(name string) string { return strings.ReplaceAll(name, "`", "``") }
+func escapeIdentDQuote(name string) string   { return strings.ReplaceAll(name, `"`, `""`) }
+func escapeSQLLiteral(v string) string       { return strings.ReplaceAll(v, "'", "''") }
+
 // CreateDatabase creates dbName inside the named service container if it does
 // not already exist. svc is the service name (e.g. "mysql", "mysql-5-6",
 // "mariadb-11", "postgres-14"); the container is always "lerd-<svc>". The
@@ -31,7 +40,7 @@ func CreateDatabase(svc, name string) (bool, error) {
 		var lastErr error
 		for _, bin := range binaries {
 			check := podman.Cmd("exec", container, bin, "-uroot", "-plerd",
-				"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", name))
+				"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", escapeSQLLiteral(name)))
 			out, err := check.Output()
 			if err != nil {
 				lastErr = err
@@ -41,7 +50,7 @@ func CreateDatabase(svc, name string) (bool, error) {
 				return false, nil
 			}
 			cmd := podman.Cmd("exec", container, bin, "-uroot", "-plerd",
-				"-e", fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`;", name))
+				"-e", fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`;", escapeIdentBacktick(name)))
 			// Capture stderr rather than inheriting it: mysql prints a noisy
 			// "[Warning] Using a password on the command line interface" that would
 			// otherwise clobber the live "configuring .env" spinner. Surface it only
@@ -54,7 +63,7 @@ func CreateDatabase(svc, name string) (bool, error) {
 		return false, lastErr
 	case "postgres":
 		cmd := podman.Cmd("exec", container, "psql", "-U", "postgres",
-			"-c", fmt.Sprintf(`CREATE DATABASE "%s";`, name))
+			"-c", fmt.Sprintf(`CREATE DATABASE "%s";`, escapeIdentDQuote(name)))
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			if strings.Contains(string(out), "already exists") {
@@ -86,7 +95,7 @@ func DropDatabase(svc, name string) (bool, error) {
 		var lastErr error
 		for _, bin := range binaries {
 			check := podman.Cmd("exec", container, bin, "-uroot", "-plerd",
-				"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", name))
+				"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", escapeSQLLiteral(name)))
 			out, err := check.Output()
 			if err != nil {
 				lastErr = err
@@ -96,7 +105,7 @@ func DropDatabase(svc, name string) (bool, error) {
 				return false, nil
 			}
 			cmd := podman.Cmd("exec", container, bin, "-uroot", "-plerd",
-				"-e", fmt.Sprintf("DROP DATABASE IF EXISTS `%s`;", name))
+				"-e", fmt.Sprintf("DROP DATABASE IF EXISTS `%s`;", escapeIdentBacktick(name)))
 			cmd.Stderr = os.Stderr
 			return true, cmd.Run()
 		}
@@ -105,9 +114,9 @@ func DropDatabase(svc, name string) (bool, error) {
 		// Postgres refuses DROP if any session has the DB open, so terminate
 		// stragglers (queue workers, lingering psql shells) first.
 		_ = podman.Cmd("exec", container, "psql", "-U", "postgres",
-			"-c", fmt.Sprintf(`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid();`, name)).Run()
+			"-c", fmt.Sprintf(`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid();`, escapeSQLLiteral(name))).Run()
 		cmd := podman.Cmd("exec", container, "psql", "-U", "postgres",
-			"-c", fmt.Sprintf(`DROP DATABASE IF EXISTS "%s";`, name))
+			"-c", fmt.Sprintf(`DROP DATABASE IF EXISTS "%s";`, escapeIdentDQuote(name)))
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			if strings.Contains(string(out), "does not exist") {

--- a/internal/serviceops/provision_test.go
+++ b/internal/serviceops/provision_test.go
@@ -1,0 +1,47 @@
+package serviceops
+
+import "testing"
+
+// These guard the DB identifier/literal quoting used by CreateDatabase and
+// DropDatabase. A worktree DB name derives from a git branch, and git allows
+// quotes and backticks in branch names, so a name reaching these sinks must not
+// be able to terminate its quoting and inject SQL.
+func TestEscapeIdentBacktick(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"acme_app", "acme_app"},
+		{"a`b", "a``b"},
+		{"`; DROP DATABASE x; --", "``; DROP DATABASE x; --"},
+		{"plain", "plain"},
+	}
+	for _, tc := range cases {
+		if got := escapeIdentBacktick(tc.in); got != tc.want {
+			t.Errorf("escapeIdentBacktick(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestEscapeIdentDQuote(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"acme_app", "acme_app"},
+		{`a"b`, `a""b`},
+		{`x"; DROP DATABASE other; --`, `x""; DROP DATABASE other; --`},
+	}
+	for _, tc := range cases {
+		if got := escapeIdentDQuote(tc.in); got != tc.want {
+			t.Errorf("escapeIdentDQuote(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestEscapeSQLLiteral(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"acme_app", "acme_app"},
+		{"a'b", "a''b"},
+		{"' OR '1'='1", "'' OR ''1''=''1"},
+	}
+	for _, tc := range cases {
+		if got := escapeSQLLiteral(tc.in); got != tc.want {
+			t.Errorf("escapeSQLLiteral(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/ui/ws_origin_test.go
+++ b/internal/ui/ws_origin_test.go
@@ -21,6 +21,13 @@ func TestWSOriginAllowed(t *testing.T) {
 		{"cross-site hijack attempt", "localhost:7073", "http://evil.example", false},
 		{"foreign origin same path", "myapp.test", "https://attacker.test", false},
 		{"malformed origin", "localhost:7073", "::::not a url", false},
+		// DNS rebinding: a public domain rebound to a local address sends
+		// matching Origin and Host, so a bare same-origin test would accept it.
+		// The local-host requirement rejects it because the domain is neither an
+		// IP literal nor under a reserved local TLD.
+		{"rebinding public domain", "evil.example", "http://evil.example", false},
+		{"rebinding public domain with port", "attacker.com:7073", "http://attacker.com:7073", false},
+		{"mdns .local same-origin", "my-mac.local:7073", "http://my-mac.local:7073", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/ui/wsframe.go
+++ b/internal/ui/wsframe.go
@@ -51,8 +51,9 @@ type wsConn struct {
 // don't apply CORS to the WS handshake, so without this an arbitrary page
 // could open a socket to the dashboard. A missing Origin means a non-browser
 // client (lerd's own tools, curl), which isn't a hijack vector. Otherwise the
-// Origin must be in the CORS allowlist or be same-origin with the request Host,
-// which keeps custom-domain and LAN access working.
+// Origin must be in the CORS allowlist, or be same-origin with the request Host
+// AND target a local-network host, which keeps custom-domain and LAN access
+// working while closing the DNS-rebinding hole (see isLocalNetworkHost).
 func wsOriginAllowed(r *http.Request) bool {
 	origin := r.Header.Get("Origin")
 	if origin == "" {
@@ -67,7 +68,40 @@ func wsOriginAllowed(r *http.Request) bool {
 	}
 	// Hostnames are case-insensitive (RFC 3986), and r.Host casing isn't
 	// guaranteed to match the browser-normalised Origin, so compare case-folded.
-	return strings.EqualFold(u.Host, r.Host)
+	if !strings.EqualFold(u.Host, r.Host) {
+		return false
+	}
+	return isLocalNetworkHost(u.Host)
+}
+
+// isLocalNetworkHost reports whether hostport (host or host:port) names a
+// machine on the local network. The same-origin check above is not enough on
+// its own: under DNS rebinding a page on http://evil.example whose A record is
+// rebound to a loopback or LAN address sends Origin and Host both equal to
+// evil.example, so a bare same-origin test passes and the socket opens.
+//
+// Rebinding fundamentally needs a DNS name (an IP-literal Host can't be
+// rebound), so the rule is: any IP literal is fine (it's a host the user
+// pointed a browser at directly: loopback, a LAN address, or an explicit
+// public bind that is already gated by remote-control auth), while a hostname
+// is accepted only under localhost or one of the reserved local TLDs. .test and
+// .localhost are lerd's own managed TLDs (resolved to loopback by lerd-dns,
+// never publicly resolvable per RFC 6761) and .local is mDNS, so none can be
+// pointed at an attacker's server. An attacker's public domain is rejected.
+func isLocalNetworkHost(hostport string) bool {
+	host := hostport
+	if h, _, err := net.SplitHostPort(hostport); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]") // strip IPv6 literal brackets
+	if net.ParseIP(host) != nil {
+		return true
+	}
+	h := strings.ToLower(host)
+	return h == "localhost" ||
+		strings.HasSuffix(h, ".localhost") ||
+		strings.HasSuffix(h, ".test") ||
+		strings.HasSuffix(h, ".local")
 }
 
 // wsUpgrade performs the RFC6455 handshake and returns a wsConn ready for

--- a/internal/ui/wsframe_test.go
+++ b/internal/ui/wsframe_test.go
@@ -1,0 +1,31 @@
+package ui
+
+import "testing"
+
+// isLocalNetworkHost gates the same-origin fallback in wsOriginAllowed against
+// DNS rebinding: an IP literal can't be rebound, and only the reserved local
+// TLDs (.localhost/.test) and mDNS .local are accepted for hostnames.
+func TestIsLocalNetworkHost(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"localhost:7073", true},
+		{"127.0.0.1:7073", true},
+		{"[::1]:7073", true},
+		{"192.168.1.50:7073", true},
+		{"10.0.0.5", true},
+		{"lerd.localhost", true},
+		{"myapp.test", true},
+		{"foo.local:7073", true},
+		{"evil.example", false},
+		{"attacker.com:7073", false},
+		{"localhostx.evil.com", false},
+		{"nottest.eviltest", false},
+	}
+	for _, tc := range cases {
+		if got := isLocalNetworkHost(tc.in); got != tc.want {
+			t.Errorf("isLocalNetworkHost(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
This is a focused security pass over the changes since v1.25.0, covering three issues that a hostile linked project, a local user, or a malicious site open in the developer's browser could each exploit.

Site and worktree-branch names flow into shell-run site_init commands and into CREATE DATABASE identifiers, so a project whose directory or branch name carried a shell or SQL payload could reach a lerd-managed service container that every site shares. SiteSlug now lowercases and maps every character outside [a-z0-9_] to an underscore, extending the existing hyphen and dot convention to all separators, so those names can no longer break out, and CreateDatabase and DropDatabase escape the identifiers and literals they interpolate as a second layer.

The NetworkManager dispatcher runs as root and rewrote each user's lerd.conf with a plain redirect, so a user could point that path at a root-owned file with a symlink and have root truncate it on the next network change. The rewrite now runs through runuser as the owning user, so the write only lands where that user already has access, and the upstream list is filtered to IP and port shaped tokens first.

The dashboard's websocket handshake accepted any Origin whose host matched the request Host, which a DNS-rebinding page satisfies because it controls both. The same-origin fallback now also requires the host to be an IP literal or one of the reserved local TLDs lerd serves, so a public domain rebound to loopback is rejected while loopback, LAN, lerd.localhost, and .test access are unchanged.