### PR TITLE
fix(cli): only offer the Sail import when Sail is initialized

### DIFF
--- a/internal/cli/import_sail.go
+++ b/internal/cli/import_sail.go
@@ -10,11 +10,33 @@ import (
 	"strings"
 	"time"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
+
+// sailInitialized reports whether a project is actually set up to run Laravel
+// Sail, rather than merely carrying the laravel/sail dev dependency that ships
+// in every fresh Laravel app's require-dev. `sail:install` writes a
+// docker-compose.yml whose app service builds from the package runtime dir, so
+// the gate requires both the dependency and a compose file carrying that Sail
+// marker; a project's unrelated hand-written compose file is not enough.
+func sailInitialized(dir string) bool {
+	if !config.ComposerHasPackage(dir, "laravel/sail") {
+		return false
+	}
+	composePath, err := sailFindComposeFile(dir)
+	if err != nil {
+		return false
+	}
+	data, err := os.ReadFile(composePath)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), "vendor/laravel/sail")
+}
 
 // NewImportCmd returns the import parent command with source subcommands.
 func NewImportCmd() *cobra.Command {

--- a/internal/cli/import_sail_test.go
+++ b/internal/cli/import_sail_test.go
@@ -860,3 +860,48 @@ func containsArg(args []string, want string) bool {
 	}
 	return false
 }
+
+// ── sailInitialized ───────────────────────────────────────────────────────────
+
+func TestSailInitialized(t *testing.T) {
+	// laravel/sail in require-dev ships with every fresh Laravel app, so the
+	// package alone must not count as initialized: a Sail compose file must
+	// exist, and an unrelated hand-written compose file must not satisfy it.
+	const composerWithSail = `{"require-dev":{"laravel/sail":"^1.0"}}`
+	const composerNoSail = `{"require-dev":{"phpunit/phpunit":"^11.0"}}`
+	// Trimmed shape of what `sail:install` generates: the app service builds
+	// from the package runtime dir.
+	const sailCompose = "services:\n  laravel.test:\n    build:\n      context: ./vendor/laravel/sail/runtimes/8.4\n"
+	const otherCompose = "services:\n  redis:\n    image: redis:7\n"
+
+	cases := []struct {
+		name     string
+		composer string // "" means no composer.json
+		compose  string // "" means no compose file
+		want     bool
+	}{
+		{"fresh app: sail dep but no compose file", composerWithSail, "", false},
+		{"sail dep but unrelated compose file", composerWithSail, otherCompose, false},
+		{"initialized sail: dep plus sail compose file", composerWithSail, sailCompose, true},
+		{"no sail dependency", composerNoSail, sailCompose, false},
+		{"no composer.json", "", sailCompose, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.composer != "" {
+				if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte(tc.composer), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.compose != "" {
+				if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(tc.compose), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := sailInitialized(dir); got != tc.want {
+				t.Fatalf("sailInitialized = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -412,8 +412,10 @@ func runLink(args []string) error {
 	printLinkSummary(site, start)
 
 	// Sail detection — offer to import data before setup so lerd's DB is
-	// populated from the existing Sail environment.
-	if linkShouldImportSail(isInteractive(), linkSkipDataImport, config.ComposerHasPackage(cwd, "laravel/sail")) {
+	// populated from the existing Sail environment. Gate on Sail actually being
+	// initialized (a compose file), not just the laravel/sail dev dependency
+	// that every fresh Laravel app ships, which would prompt on a new project.
+	if linkShouldImportSail(isInteractive(), linkSkipDataImport, sailInitialized(cwd)) {
 		sailDBName := sailLinkDetectDBName(cwd)
 		if feedback.Confirm("This project uses Laravel Sail. Import database (and S3 files) from Sail into lerd?", false) {
 			if err := runImportSail(false, false, "sail", "password", sailDBName, sailDBName != "", false, false); err != nil {


### PR DESCRIPTION
A new project tripped the "This project uses Laravel Sail. Import database...?" prompt during `lerd link` even though it had no Sail environment. The trigger was just `laravel/sail` appearing in `composer.json`, but that dependency ships in every fresh Laravel app's `require-dev`, so the prompt fired on day-one projects, and confirming it failed anyway because the import needs a compose file the project doesn't have.

The prompt now gates on Sail actually being initialized: the `laravel/sail` dependency plus a docker-compose file that carries Sail's own runtime build context (`vendor/laravel/sail`), which is what `sail:install` writes and what the import itself requires. A fresh app no longer prompts, and an unrelated hand-written compose file sitting alongside the dependency no longer counts either.