### PR TITLE
fix(cli): warn when a host worker's deps are missing, and route update output through the feedback layer

### DIFF
--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -691,9 +691,15 @@ func startWorkersForSite(site *config.Site, workers []string, phpVersion string)
 		if !ok {
 			continue
 		}
-		// Skip workers whose check doesn't pass.
+		// Skip workers whose check doesn't pass. A host worker (vite et al) the
+		// user opted into but whose deps aren't installed would otherwise drop
+		// silently, reading as "the worker just isn't running"; surface the
+		// reason and remedy instead.
 		if wDef.Check != nil && !config.MatchesRule(site.Path, *wDef.Check) {
 			delete(requested, w)
+			if msg := hostWorkerNotReadyMsg(w, site.Path, wDef); msg != "" {
+				feedback.Warn("%s", msg)
+			}
 			continue
 		}
 		for _, conflict := range wDef.ConflictsWith {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -379,14 +379,16 @@ func restartLerdUserServices() {
 	if len(active) == 0 {
 		return
 	}
-	fmt.Println("\n==> Restarting lerd services to pick up the new binary")
+	feedback.Header("Restarting lerd services to pick up the new binary")
 	for _, u := range active {
-		fmt.Printf("  --> %s ... ", u)
+		s := feedback.Start(u)
 		if err := services.Mgr.Restart(u); err != nil {
-			fmt.Printf("WARN (%v)\n", err)
-		} else {
-			fmt.Println("OK")
+			// Best-effort: the binary swap already succeeded, so a restart that
+			// didn't take is a warning, not a failure of the update itself.
+			s.Warn(err)
+			continue
 		}
+		s.OK("")
 	}
 }
 
@@ -514,7 +516,7 @@ func runRollback() error {
 		return err
 	}
 
-	fmt.Printf("==> Rolling back to v%s\n", prevVersion)
+	feedback.Header(fmt.Sprintf("Rolling back to v%s", prevVersion))
 
 	// Atomically replace lerd.
 	tmp := self + ".tmp"
@@ -548,7 +550,7 @@ func runRollback() error {
 	// `lerd install` starts from a known-good state. The current
 	// binary's probe logic decides v4-only vs dual-stack; the old
 	// binary's EnsureNetwork will accept whatever schema it finds.
-	fmt.Println("  --> Resetting lerd network for rollback")
+	feedback.Line("Resetting lerd network for rollback")
 	if attached, _, err := podman.RecreateNetwork("lerd", nil); err == nil {
 		for _, c := range attached {
 			_ = podman.StartUnit(c)
@@ -561,7 +563,7 @@ func runRollback() error {
 	// the cache picks up Type=simple immediately.
 	prepUserUnitsForRollback("lerd-ui.service", "lerd-watcher.service")
 
-	fmt.Printf("\nRolled back to v%s — applying infrastructure changes...\n\n", prevVersion)
+	feedback.Note(fmt.Sprintf("Rolled back to v%s, applying infrastructure changes...", prevVersion))
 
 	// Re-exec the new binary with `install`, same as a normal update.
 	installCmd := exec.Command(self, "install")

--- a/internal/cli/worker_preflight.go
+++ b/internal/cli/worker_preflight.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/geodro/lerd/internal/config"
@@ -33,6 +34,9 @@ func workerStartPreflight(sitePath, workerName string, w config.FrameworkWorker)
 		return fmt.Errorf("worker %q has an invalid command: must not contain newline or NUL", workerName)
 	}
 	if w.Check != nil && !config.MatchesRule(sitePath, *w.Check) {
+		if msg := hostWorkerNotReadyMsg(workerName, sitePath, w); msg != "" {
+			return errors.New(msg)
+		}
 		return fmt.Errorf(
 			"worker %q skipped: required dependency not satisfied (rule: %s)",
 			workerName, describeRule(*w.Check))
@@ -43,6 +47,19 @@ func workerStartPreflight(sitePath, workerName string, w config.FrameworkWorker)
 			workerName, describeRule(*w.ExcludeCheck))
 	}
 	return nil
+}
+
+// hostWorkerNotReadyMsg returns an actionable message for a host worker (vite et
+// al) that can't start because its dependency check fails. On a node project the
+// cause is almost always JS deps not yet installed on the host, so it names the
+// remedy; `lerd setup` is used rather than a bare `npm ci` so the advice holds
+// for bun/yarn/pnpm projects too. Returns "" when the worker isn't a host node
+// worker, so callers keep their own generic dependency message.
+func hostWorkerNotReadyMsg(workerName, sitePath string, w config.FrameworkWorker) string {
+	if !w.Host || !isNodeProject(sitePath) {
+		return ""
+	}
+	return fmt.Sprintf("%s worker not started: JS dependencies are not installed. Run `lerd setup` to install them, then `lerd worker start %s`.", workerName, workerName)
 }
 
 // describeRule renders a FrameworkRule for an end-user error message.

--- a/internal/cli/worker_test.go
+++ b/internal/cli/worker_test.go
@@ -296,3 +296,73 @@ func TestWorkerRemove_Global(t *testing.T) {
 		t.Error("other should still be present")
 	}
 }
+
+// hostWorkerNotReadyMsg returns a runtime-agnostic JS-deps message only for a
+// host worker on a node project, and "" otherwise so callers fall back to their
+// own generic dependency message.
+func TestHostWorkerNotReadyMsg(t *testing.T) {
+	nodeDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(nodeDir, "package.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	plainDir := t.TempDir()
+
+	hostWorker := config.FrameworkWorker{Host: true, Check: &config.FrameworkRule{File: "node_modules/vite"}}
+
+	msg := hostWorkerNotReadyMsg("vite", nodeDir, hostWorker)
+	for _, want := range []string{"JS dependencies are not installed", "lerd setup", "lerd worker start vite"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("host node-worker message missing %q: %s", want, msg)
+		}
+	}
+	// The remedy must stay runtime-agnostic so it doesn't misdirect bun/yarn/pnpm projects.
+	if strings.Contains(msg, "npm ci") {
+		t.Errorf("message should not hardcode npm ci: %s", msg)
+	}
+
+	// Not a node project: no JS-deps claim, caller keeps its generic message.
+	if got := hostWorkerNotReadyMsg("vite", plainDir, hostWorker); got != "" {
+		t.Errorf("non-node project should yield no host message, got: %s", got)
+	}
+	// Non-host worker: never a JS-deps message even on a node project.
+	containerWorker := config.FrameworkWorker{Check: &config.FrameworkRule{Composer: "vendor/pkg"}}
+	if got := hostWorkerNotReadyMsg("queue", nodeDir, containerWorker); got != "" {
+		t.Errorf("non-host worker should yield no host message, got: %s", got)
+	}
+}
+
+// End-to-end gate: WorkerStartForSite runs workerStartPreflight first and returns
+// its error before touching systemd/podman, so a node project (package.json, no
+// node_modules) with a vite host worker must be refused with the actionable
+// JS-deps message and cause no side effects. This mirrors what a real
+// `lerd worker start vite` surfaces on a freshly linked project.
+func TestWorkerStartForSiteRefusesViteWithoutDeps(t *testing.T) {
+	siteDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(siteDir, "package.json"), []byte(`{"scripts":{"dev":"vite"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	vite := config.FrameworkWorker{
+		Host:    true,
+		Command: "npm run dev",
+		Restart: "on-failure",
+		Check:   &config.FrameworkRule{File: "node_modules/vite"},
+	}
+
+	err := WorkerStartForSite("acme", siteDir, "8.5", "vite", vite, false)
+	if err == nil {
+		t.Fatal("expected WorkerStartForSite to refuse vite without node_modules, got nil")
+	}
+	t.Logf("surfaced message: %s", err)
+	for _, want := range []string{"JS dependencies are not installed", "lerd setup", "lerd worker start vite"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("preflight error missing %q: %s", want, err)
+		}
+	}
+
+	// No unit file should have been written for the refused worker.
+	unit, _ := workerNames("acme", siteDir, "vite")
+	if _, statErr := os.Stat(filepath.Join(os.Getenv("HOME"), ".config", "systemd", "user", unit+".service")); statErr == nil {
+		t.Errorf("a unit file was written for a refused worker: %s", unit)
+	}
+}

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -323,6 +323,18 @@ func (s *Step) Fail(err error) {
 	s.finish(paint(failStyle, "✗"), paint(failStyle, msg))
 }
 
+// Warn collapses the step with an amber warning glyph and message, for a
+// non-fatal hiccup (e.g. a best-effort restart that didn't take) that should be
+// noticed but doesn't mean the command itself failed. Unlike Fail it draws no
+// red cross, so it doesn't read as the whole operation having errored.
+func (s *Step) Warn(err error) {
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	s.finish(paint(warnStyle, GlyphWarn), paint(warnStyle, msg))
+}
+
 // Fail prints a standalone red ✗ line for err to stderr in the same style (and
 // blank-line spacing) as a Live/Step failure. It is for the top-level command
 // handler to render an error a command returned without surfacing it itself, so

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -55,6 +55,28 @@ func TestStepInfoAndFail(t *testing.T) {
 	}
 }
 
+// Warn collapses a step with the amber ⚠ glyph and no red cross, and (unlike
+// Fail) does not mark its error as already-shown, since it is a non-fatal hiccup
+// rather than a failure the command is returning.
+func TestStepWarn(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	warnErr := errors.New("unit not loaded")
+	Start("restarting lerd-ui").Warn(warnErr)
+
+	got := buf.String()
+	if !strings.Contains(got, " → restarting lerd-ui… ⚠ unit not loaded\n") {
+		t.Errorf("missing warn line: %q", got)
+	}
+	if strings.Contains(got, "✗") {
+		t.Errorf("warn must not render a red cross: %q", got)
+	}
+	if AlreadyShown(warnErr) {
+		t.Error("Warn should not mark its error as already-shown")
+	}
+}
+
 // A Step/Live Fail records its error so the top-level handler can tell it was
 // already shown to the user, covering both the bare error returned as-is and a
 // wrapped error that adds context around it. An unrelated error stays unshown.


### PR DESCRIPTION
Two post-1.26.0 CLI fixes.

A freshly linked project that declares a host worker like vite but hasn't installed its JS dependencies used to drop that worker silently, so it just read as vite not running with no clue why. Both the link path and WorkerStartForSite now surface a single shared message through hostWorkerNotReadyMsg, which fires only for a host worker on a node project and points at lerd setup rather than a bare npm ci so the advice still holds for bun, yarn and pnpm projects. The message lives in one place so the preflight gate and the link-time skip read identically, and it stays empty for container workers so they keep their existing dependency note.

The update command's service-restart and rollback output now speaks the same styled feedback vocabulary as the rest of the CLI instead of the old ==> and --> prefixes. A restart that doesn't take is rendered with a new amber Step.Warn rather than a red cross, since the binary swap already succeeded and a stuck restart is a warning, not a failure of the update itself.