### PR TITLE
feat(host-proxy): bind dev server to all interfaces so the proxy container can reach it

### DIFF
--- a/docs/usage/host-proxy.md
+++ b/docs/usage/host-proxy.md
@@ -49,6 +49,7 @@ The `proxy` section in `.lerd.yaml` is mutually exclusive with `container:` (a s
 | `port` | yes | | Port the dev server listens on. lerd injects this and proxies to it. |
 | `ssl` | no | `false` | Set to `true` if the dev server serves HTTPS on its port (nginx proxies via `https://` with `proxy_ssl_verify off`). |
 | `port_env_key` | no | `PORT` | Environment variable the port is injected as. Most servers read `PORT`; set this if yours uses a different name. |
+| `host_env_key` | no | `HOST` | Environment variable the bind address (`0.0.0.0`) is injected as. Most servers read `HOST`; set this if yours uses a different name, e.g. `HOSTNAME` for a Next.js standalone server. |
 
 ## Ports
 
@@ -56,9 +57,15 @@ For Node projects the port is auto-assigned: `lerd init` starts from a default a
 
 Lerd sets both sides of the contract: it injects the chosen port via `PORT` (or `port_env_key`) so a server that honours it binds there, and points nginx at the same port. It does not probe the live socket, so a server that ignores the env var and hardcodes a different port will not be reached. For those, name the port directly in the command (for example `vite --port 5173 --strictPort`, or `runserver 0.0.0.0:8000`) so both sides agree.
 
+## Binding
+
+nginx runs inside a container and reaches your dev server over the host gateway, not loopback. A server bound to `127.0.0.1` (the common dev default) is therefore unreachable through the proxy: depending on the framework it surfaces as a connection error, or as a stray all-interfaces HMR socket answering every request with `426 Upgrade Required` (the symptom seen with Nuxt).
+
+To avoid this, lerd injects `HOST=0.0.0.0` (or `host_env_key`) alongside the port, which Nuxt, NestJS, and most Node servers honour to bind all interfaces. A `HOST` you set yourself later in the command still wins. Servers that ignore the env var (notably the raw Vite CLI, which reads a flag) must bind explicitly: name `--host` in the command, for example `vite --host --port 5173 --strictPort`.
+
 ## Vite
 
-Vite checks the request's `Host` header against its `allowedHosts` list and answers anything else with `403 Blocked request`. Because nginx proxies with the site domain as the `Host`, a default Vite project returns 403 through the lerd proxy until you allow the domain. Add it to `server.allowedHosts` in `vite.config` (or set `allowedHosts: true`). `lerd init` prints this reminder when it detects a Vite dev command.
+Vite checks the request's `Host` header against its `allowedHosts` list and answers anything else with `403 Blocked request`. Because nginx proxies with the site domain as the `Host`, a default Vite project returns 403 through the lerd proxy until you allow the domain. Add it to `server.allowedHosts` in `vite.config` (or set `allowedHosts: true`). The raw Vite CLI also ignores `HOST` (see [Binding](#binding)), so add `--host` to the command. `lerd init` prints these reminders when it detects a Vite dev command.
 
 ## Lifecycle
 

--- a/docs/usage/host-proxy.md
+++ b/docs/usage/host-proxy.md
@@ -50,7 +50,7 @@ The `proxy` section in `.lerd.yaml` is mutually exclusive with `container:` (a s
 | `ssl` | no | `false` | Set to `true` if the dev server serves HTTPS on its port (nginx proxies via `https://` with `proxy_ssl_verify off`). |
 | `port_env_key` | no | `PORT` | Environment variable the port is injected as. Most servers read `PORT`; set this if yours uses a different name. |
 | `host_env_key` | no | `HOST` | Environment variable the bind address (`0.0.0.0`) is injected as. Most servers read `HOST`; set this if yours uses a different name, e.g. `HOSTNAME` for a Next.js standalone server. |
-| `bind` | no | `true` | Whether lerd injects the bind-address env (see [Binding](#binding)). Set `false` to opt out entirely, for a server that reads `HOST` for something else or manages its own bind. The port injection is unaffected. |
+| `inject_host` | no | `true` | Whether lerd injects the bind-address env (see [Binding](#binding)). Set `false` to opt out entirely, for a server that reads `HOST` for something else or manages its own bind. The port injection is unaffected. |
 
 ## Ports
 
@@ -64,7 +64,7 @@ nginx runs inside a container and reaches your dev server over the host gateway,
 
 To avoid this, lerd injects `HOST=0.0.0.0` (or `host_env_key`) alongside the port, which Nuxt, NestJS, and most Node servers honour to bind all interfaces. A `HOST` you set yourself later in the command still wins. Servers that ignore the env var (notably the raw Vite CLI, which reads a flag) must bind explicitly: name `--host` in the command, for example `vite --host --port 5173 --strictPort`.
 
-If a server reads `HOST` for something else, or you already set it in your `.env` (dotenv won't override a variable already in the environment, so the injected `0.0.0.0` would win), set `bind: false` to suppress the injection and manage binding yourself. The port injection is unaffected.
+If a server reads `HOST` for something else, or you already set it in your `.env` (dotenv won't override a variable already in the environment, so the injected `0.0.0.0` would win), set `inject_host: false` to suppress the injection and manage binding yourself. The port injection is unaffected.
 
 ## Vite
 

--- a/docs/usage/host-proxy.md
+++ b/docs/usage/host-proxy.md
@@ -50,6 +50,7 @@ The `proxy` section in `.lerd.yaml` is mutually exclusive with `container:` (a s
 | `ssl` | no | `false` | Set to `true` if the dev server serves HTTPS on its port (nginx proxies via `https://` with `proxy_ssl_verify off`). |
 | `port_env_key` | no | `PORT` | Environment variable the port is injected as. Most servers read `PORT`; set this if yours uses a different name. |
 | `host_env_key` | no | `HOST` | Environment variable the bind address (`0.0.0.0`) is injected as. Most servers read `HOST`; set this if yours uses a different name, e.g. `HOSTNAME` for a Next.js standalone server. |
+| `bind` | no | `true` | Whether lerd injects the bind-address env (see [Binding](#binding)). Set `false` to opt out entirely, for a server that reads `HOST` for something else or manages its own bind. The port injection is unaffected. |
 
 ## Ports
 
@@ -62,6 +63,8 @@ Lerd sets both sides of the contract: it injects the chosen port via `PORT` (or 
 nginx runs inside a container and reaches your dev server over the host gateway, not loopback. A server bound to `127.0.0.1` (the common dev default) is therefore unreachable through the proxy: depending on the framework it surfaces as a connection error, or as a stray all-interfaces HMR socket answering every request with `426 Upgrade Required` (the symptom seen with Nuxt).
 
 To avoid this, lerd injects `HOST=0.0.0.0` (or `host_env_key`) alongside the port, which Nuxt, NestJS, and most Node servers honour to bind all interfaces. A `HOST` you set yourself later in the command still wins. Servers that ignore the env var (notably the raw Vite CLI, which reads a flag) must bind explicitly: name `--host` in the command, for example `vite --host --port 5173 --strictPort`.
+
+If a server reads `HOST` for something else, or you already set it in your `.env` (dotenv won't override a variable already in the environment, so the injected `0.0.0.0` would win), set `bind: false` to suppress the injection and manage binding yourself. The port injection is unaffected.
 
 ## Vite
 

--- a/internal/cli/hostproxy.go
+++ b/internal/cli/hostproxy.go
@@ -97,11 +97,11 @@ func hostProxyHostEnvKey(proxy *config.ProxyConfig) string {
 }
 
 // hostProxyShouldBind reports whether lerd injects the bind-address env
-// (e.g. HOST=0.0.0.0). Defaults to true; a project sets `bind: false` to opt
-// out entirely, for a dev server that reads HOST for something else or manages
-// its own bind. The port injection is unaffected.
+// (e.g. HOST=0.0.0.0). Defaults to true; a project sets `inject_host: false` to
+// opt out entirely, for a dev server that reads HOST for something else or
+// manages its own bind. The port injection is unaffected.
 func hostProxyShouldBind(proxy *config.ProxyConfig) bool {
-	return proxy.Bind == nil || *proxy.Bind
+	return proxy.InjectHost == nil || *proxy.InjectHost
 }
 
 // hostProxyBindAddr is the address the dev server must bind so the in-container
@@ -119,7 +119,7 @@ const hostProxyBindAddr = "0.0.0.0"
 // shell (macOS) and directly via `fnm exec --` (Linux); `env` is a real
 // executable that works in both. A HOST the user sets later in their own
 // command still wins (env evaluates left to right). The bind injection is
-// suppressed when `bind: false`, leaving only the port. Returns "" in
+// suppressed when `inject_host: false`, leaving only the port. Returns "" in
 // proxy-only mode (no command).
 func buildHostProxyCommandPort(proxy *config.ProxyConfig, port int) string {
 	if proxy.Command == "" {

--- a/internal/cli/hostproxy.go
+++ b/internal/cli/hostproxy.go
@@ -86,16 +86,40 @@ func hostProxyPortEnvKey(proxy *config.ProxyConfig) string {
 	return "PORT"
 }
 
-// buildHostProxyCommandPort prefixes the dev command with `env KEY=port` so the
-// app binds the port nginx proxies to. The `env` utility (not a bare `KEY=value`
+// hostProxyHostEnvKey returns the environment variable the bind address is
+// injected as, defaulting to HOST (honoured by Nuxt, NestJS, and most Node
+// servers). Set host_env_key to e.g. HOSTNAME for a Next.js standalone server.
+func hostProxyHostEnvKey(proxy *config.ProxyConfig) string {
+	if proxy.HostEnvKey != "" {
+		return proxy.HostEnvKey
+	}
+	return "HOST"
+}
+
+// hostProxyBindAddr is the address the dev server must bind so the in-container
+// nginx can reach it. nginx proxies to the host over the gateway IP, so a dev
+// server that binds loopback (the common default) is unreachable: it surfaces
+// as a connection error, or as a stray all-interfaces HMR socket answering
+// every plain request with 426 Upgrade Required. Binding all interfaces fixes
+// both. Note: env-only; pure Vite reads --host, not this env var.
+const hostProxyBindAddr = "0.0.0.0"
+
+// buildHostProxyCommandPort prefixes the dev command with `env PORT=port
+// HOST=0.0.0.0` so the app binds the port nginx proxies to, on an interface the
+// proxy container can reach. The `env` utility (not a bare `KEY=value`
 // assignment) is used because host workers exec the command both through a
 // shell (macOS) and directly via `fnm exec --` (Linux); `env` is a real
-// executable that works in both. Returns "" in proxy-only mode (no command).
+// executable that works in both. A HOST the user sets later in their own
+// command still wins (env evaluates left to right). Returns "" in proxy-only
+// mode (no command).
 func buildHostProxyCommandPort(proxy *config.ProxyConfig, port int) string {
 	if proxy.Command == "" {
 		return ""
 	}
-	return fmt.Sprintf("env %s=%d %s", hostProxyPortEnvKey(proxy), port, proxy.Command)
+	return fmt.Sprintf("env %s=%d %s=%s %s",
+		hostProxyPortEnvKey(proxy), port,
+		hostProxyHostEnvKey(proxy), hostProxyBindAddr,
+		proxy.Command)
 }
 
 func buildHostProxyCommand(proxy *config.ProxyConfig) string {

--- a/internal/cli/hostproxy.go
+++ b/internal/cli/hostproxy.go
@@ -96,6 +96,14 @@ func hostProxyHostEnvKey(proxy *config.ProxyConfig) string {
 	return "HOST"
 }
 
+// hostProxyShouldBind reports whether lerd injects the bind-address env
+// (e.g. HOST=0.0.0.0). Defaults to true; a project sets `bind: false` to opt
+// out entirely, for a dev server that reads HOST for something else or manages
+// its own bind. The port injection is unaffected.
+func hostProxyShouldBind(proxy *config.ProxyConfig) bool {
+	return proxy.Bind == nil || *proxy.Bind
+}
+
 // hostProxyBindAddr is the address the dev server must bind so the in-container
 // nginx can reach it. nginx proxies to the host over the gateway IP, so a dev
 // server that binds loopback (the common default) is unreachable: it surfaces
@@ -110,11 +118,16 @@ const hostProxyBindAddr = "0.0.0.0"
 // assignment) is used because host workers exec the command both through a
 // shell (macOS) and directly via `fnm exec --` (Linux); `env` is a real
 // executable that works in both. A HOST the user sets later in their own
-// command still wins (env evaluates left to right). Returns "" in proxy-only
-// mode (no command).
+// command still wins (env evaluates left to right). The bind injection is
+// suppressed when `bind: false`, leaving only the port. Returns "" in
+// proxy-only mode (no command).
 func buildHostProxyCommandPort(proxy *config.ProxyConfig, port int) string {
 	if proxy.Command == "" {
 		return ""
+	}
+	if !hostProxyShouldBind(proxy) {
+		return fmt.Sprintf("env %s=%d %s",
+			hostProxyPortEnvKey(proxy), port, proxy.Command)
 	}
 	return fmt.Sprintf("env %s=%d %s=%s %s",
 		hostProxyPortEnvKey(proxy), port,

--- a/internal/cli/hostproxy_test.go
+++ b/internal/cli/hostproxy_test.go
@@ -139,17 +139,17 @@ func TestBuildProjectServices_builtins(t *testing.T) {
 	}
 }
 
-func TestBuildHostProxyCommand_injectsPort(t *testing.T) {
+func TestBuildHostProxyCommand_injectsPortAndHost(t *testing.T) {
 	got := buildHostProxyCommand(&config.ProxyConfig{Command: "npm run start:dev", Port: 3000})
-	want := "env PORT=3000 npm run start:dev"
+	want := "env PORT=3000 HOST=0.0.0.0 npm run start:dev"
 	if got != want {
 		t.Errorf("buildHostProxyCommand = %q, want %q", got, want)
 	}
 }
 
-func TestBuildHostProxyCommand_customEnvKey(t *testing.T) {
-	got := buildHostProxyCommand(&config.ProxyConfig{Command: "node server.js", Port: 4000, PortEnvKey: "APP_PORT"})
-	want := "env APP_PORT=4000 node server.js"
+func TestBuildHostProxyCommand_customEnvKeys(t *testing.T) {
+	got := buildHostProxyCommand(&config.ProxyConfig{Command: "node server.js", Port: 4000, PortEnvKey: "APP_PORT", HostEnvKey: "HOSTNAME"})
+	want := "env APP_PORT=4000 HOSTNAME=0.0.0.0 node server.js"
 	if got != want {
 		t.Errorf("buildHostProxyCommand = %q, want %q", got, want)
 	}
@@ -184,7 +184,7 @@ func TestHostProxyWorkerForPort_usesGivenPort(t *testing.T) {
 	if !ok {
 		t.Fatal("expected a worker for a non-empty command")
 	}
-	if w.Command != "env PORT=3101 npm run start:dev" {
+	if w.Command != "env PORT=3101 HOST=0.0.0.0 npm run start:dev" {
 		t.Errorf("worker command = %q, want the worktree port 3101 injected", w.Command)
 	}
 	if !w.Host || w.Restart != "always" {

--- a/internal/cli/hostproxy_test.go
+++ b/internal/cli/hostproxy_test.go
@@ -155,20 +155,20 @@ func TestBuildHostProxyCommand_customEnvKeys(t *testing.T) {
 	}
 }
 
-func TestBuildHostProxyCommand_bindFalseOptsOut(t *testing.T) {
-	// bind: false suppresses the HOST injection but keeps the port.
-	bind := false
-	got := buildHostProxyCommand(&config.ProxyConfig{Command: "npm run dev", Port: 3000, Bind: &bind})
+func TestBuildHostProxyCommand_injectHostFalseOptsOut(t *testing.T) {
+	// inject_host: false suppresses the HOST injection but keeps the port.
+	injectHost := false
+	got := buildHostProxyCommand(&config.ProxyConfig{Command: "npm run dev", Port: 3000, InjectHost: &injectHost})
 	want := "env PORT=3000 npm run dev"
 	if got != want {
 		t.Errorf("buildHostProxyCommand = %q, want %q", got, want)
 	}
 }
 
-func TestBuildHostProxyCommand_bindTrueExplicitInjects(t *testing.T) {
-	// bind: true is the same as the default: HOST is injected.
-	bind := true
-	got := buildHostProxyCommand(&config.ProxyConfig{Command: "npm run dev", Port: 3000, Bind: &bind})
+func TestBuildHostProxyCommand_injectHostTrueExplicitInjects(t *testing.T) {
+	// inject_host: true is the same as the default: HOST is injected.
+	injectHost := true
+	got := buildHostProxyCommand(&config.ProxyConfig{Command: "npm run dev", Port: 3000, InjectHost: &injectHost})
 	want := "env PORT=3000 HOST=0.0.0.0 npm run dev"
 	if got != want {
 		t.Errorf("buildHostProxyCommand = %q, want %q", got, want)

--- a/internal/cli/hostproxy_test.go
+++ b/internal/cli/hostproxy_test.go
@@ -155,6 +155,26 @@ func TestBuildHostProxyCommand_customEnvKeys(t *testing.T) {
 	}
 }
 
+func TestBuildHostProxyCommand_bindFalseOptsOut(t *testing.T) {
+	// bind: false suppresses the HOST injection but keeps the port.
+	bind := false
+	got := buildHostProxyCommand(&config.ProxyConfig{Command: "npm run dev", Port: 3000, Bind: &bind})
+	want := "env PORT=3000 npm run dev"
+	if got != want {
+		t.Errorf("buildHostProxyCommand = %q, want %q", got, want)
+	}
+}
+
+func TestBuildHostProxyCommand_bindTrueExplicitInjects(t *testing.T) {
+	// bind: true is the same as the default: HOST is injected.
+	bind := true
+	got := buildHostProxyCommand(&config.ProxyConfig{Command: "npm run dev", Port: 3000, Bind: &bind})
+	want := "env PORT=3000 HOST=0.0.0.0 npm run dev"
+	if got != want {
+		t.Errorf("buildHostProxyCommand = %q, want %q", got, want)
+	}
+}
+
 func TestBuildHostProxyCommand_proxyOnlyMode(t *testing.T) {
 	// No command means proxy-only: lerd supervises nothing.
 	if got := buildHostProxyCommand(&config.ProxyConfig{Port: 3000}); got != "" {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -819,10 +819,14 @@ func runHostProxyWizard(cwd string, defaults *config.ProjectConfig, gcfg *config
 	// Vite rejects requests whose Host header isn't localhost/an IP (its
 	// allowedHosts check). nginx proxies with the site domain as Host, so the
 	// user has to allow it in vite.config or every request fails with a 403.
+	// The raw Vite CLI also ignores the injected HOST env and binds loopback,
+	// which the proxy container cannot reach, so it needs an explicit --host.
 	if manifest.runsVite(command) {
 		fmt.Println("\nNote: Vite blocks proxied requests by their Host header. Add your site")
 		fmt.Println("domain to server.allowedHosts in vite.config (or set allowedHosts: true),")
 		fmt.Println("or requests through the lerd proxy fail with \"host not allowed\".")
+		fmt.Println("Vite also ignores the HOST env; add --host to the command so it binds")
+		fmt.Println("all interfaces, otherwise the proxy can't reach it.")
 	}
 
 	return &config.ProjectConfig{

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -38,6 +38,7 @@ type ProxyConfig struct {
 	Port       int    `yaml:"port"`                   // host port the app binds (required)
 	SSL        bool   `yaml:"ssl,omitempty"`          // app serves TLS on its port; proxy via https
 	PortEnvKey string `yaml:"port_env_key,omitempty"` // env var the port is injected as (default "PORT")
+	HostEnvKey string `yaml:"host_env_key,omitempty"` // env var the bind address is injected as (default "HOST")
 }
 
 // ProjectConfig holds per-project configuration stored in .lerd.yaml.

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -39,7 +39,7 @@ type ProxyConfig struct {
 	SSL        bool   `yaml:"ssl,omitempty"`          // app serves TLS on its port; proxy via https
 	PortEnvKey string `yaml:"port_env_key,omitempty"` // env var the port is injected as (default "PORT")
 	HostEnvKey string `yaml:"host_env_key,omitempty"` // env var the bind address is injected as (default "HOST")
-	Bind       *bool  `yaml:"bind,omitempty"`         // inject the bind-address env so the server listens on all interfaces; nil/unset = true, set false to opt out
+	InjectHost *bool  `yaml:"inject_host,omitempty"`  // inject the bind-address env (HOST=0.0.0.0) so the server listens on all interfaces; nil/unset = true, set false to opt out
 }
 
 // ProjectConfig holds per-project configuration stored in .lerd.yaml.

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -39,6 +39,7 @@ type ProxyConfig struct {
 	SSL        bool   `yaml:"ssl,omitempty"`          // app serves TLS on its port; proxy via https
 	PortEnvKey string `yaml:"port_env_key,omitempty"` // env var the port is injected as (default "PORT")
 	HostEnvKey string `yaml:"host_env_key,omitempty"` // env var the bind address is injected as (default "HOST")
+	Bind       *bool  `yaml:"bind,omitempty"`         // inject the bind-address env so the server listens on all interfaces; nil/unset = true, set false to opt out
 }
 
 // ProjectConfig holds per-project configuration stored in .lerd.yaml.

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -441,6 +441,43 @@ func TestProjectConfig_Proxy_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestProjectConfig_Proxy_InjectHost(t *testing.T) {
+	// Guards the inject_host struct tag: a typo would leave the field nil
+	// even though the key is present, and every Go-level test would still pass.
+	cases := map[string]struct {
+		input   string
+		wantSet bool
+		wantVal bool
+	}{
+		"opt out":      {"proxy:\n  port: 3000\n  inject_host: false\n", true, false},
+		"explicit on":  {"proxy:\n  port: 3000\n  inject_host: true\n", true, true},
+		"unset is nil": {"proxy:\n  port: 3000\n", false, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var cfg ProjectConfig
+			if err := yaml.Unmarshal([]byte(tc.input), &cfg); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if cfg.Proxy == nil {
+				t.Fatal("Proxy is nil")
+			}
+			if !tc.wantSet {
+				if cfg.Proxy.InjectHost != nil {
+					t.Errorf("InjectHost = %v, want nil (unset = default true)", *cfg.Proxy.InjectHost)
+				}
+				return
+			}
+			if cfg.Proxy.InjectHost == nil {
+				t.Fatal("InjectHost = nil, want non-nil (inject_host struct tag mismatch?)")
+			}
+			if *cfg.Proxy.InjectHost != tc.wantVal {
+				t.Errorf("InjectHost = %v, want %v", *cfg.Proxy.InjectHost, tc.wantVal)
+			}
+		})
+	}
+}
+
 func TestProjectConfig_Proxy_IsEmpty(t *testing.T) {
 	cfg := &ProjectConfig{}
 	if !cfg.IsEmpty() {


### PR DESCRIPTION
## Problem

nginx runs inside a container and reaches host-proxy dev servers over the host **gateway IP**, never loopback. A dev server bound to `127.0.0.1` (the common dev default) is unreachable through the lerd proxy.

How it surfaces depends on the framework:
- generic Node server on loopback → connection error / 502 through the proxy
- **Nuxt** → the main app binds loopback but Vite's HMR socket binds all interfaces on the same port, so the container hits the HMR socket, which answers every plain HTTP request with `426 Upgrade Required`. In the browser this reads as a misleading **"Update required"** page even though the app is perfectly healthy.

Repro: link a Nuxt 4 dev app as a host-proxy site, open the domain → `426`. Direct `curl localhost:<port>` → `200`. The only difference is loopback vs the gateway interface.

## Fix

Mirror the existing `PORT` injection. `buildHostProxyCommandPort` now prefixes the supervised dev command with `HOST=0.0.0.0` alongside the port, so Nuxt, NestJS, and most Node servers bind all interfaces out of the box. The bind env var is configurable via a new `host_env_key` field (default `HOST`, mirroring `port_env_key`) for servers that use a different name, e.g. `HOSTNAME` for a Next.js standalone server.

A `HOST` the user sets later in their own command still wins, because `env` evaluates left to right.

The raw **Vite CLI** ignores the `HOST` env (it reads `--host`), so the `lerd init` Vite reminder and the host-proxy docs are extended to tell those users to add `--host` explicitly.

## Changes
- `internal/config/project.go` — new `host_env_key` field on `ProxyConfig`.
- `internal/cli/hostproxy.go` — `hostProxyHostEnvKey` helper + inject `HOST=0.0.0.0` in `buildHostProxyCommandPort`.
- `internal/cli/init.go` — extend the Vite reminder with the `--host` note.
- `docs/usage/host-proxy.md` — new **Binding** section, `host_env_key` table row, Vite `--host` note.
- `internal/cli/hostproxy_test.go` — updated assertions + custom-env-keys case.

## Test
`go test ./internal/cli/ ./internal/config/` green; `go vet` and `gofmt` clean. Verified end to end against a real Nuxt 4 host-proxy site: domain went from `426` to `200` once the dev server bound all interfaces.