### PR TITLE
fix(macos): keep published ports when lan.exposed is true

### DIFF
--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -351,18 +351,31 @@ func stripPrivilegedIPBind(port string) string {
 	return port
 }
 
-// stripIPv6PublishPorts removes PublishPort= lines that start with a bracketed
-// IPv6 address (e.g. "[::1]:3306:3306"). gvproxy cannot bind both an IPv4 and
-// an IPv6 loopback address on the same port simultaneously.
+// stripIPv6PublishPorts normalises bracketed IPv6 PublishPort= lines for gvproxy,
+// which cannot bind both an IPv4 and an IPv6 address on the same port at once.
+//
+// Loopback IPv6 lines ("[::1]:3306:3306") are dropped: PairIPv6Binds always pairs
+// them with an IPv4 "127.0.0.1:" line that survives, so the published port lives on.
+//
+// Bind-all IPv6 lines ("[::]:80:80") have no IPv4 partner — PairIPv6Binds collapses a
+// bare/0.0.0.0 bind into the "[::]:" form only — so they are rewritten to "0.0.0.0:"
+// rather than dropped. Dropping them left LAN-exposed containers (lan.exposed: true,
+// where every publish ends up as "[::]:") with no published ports at all.
 func stripIPv6PublishPorts(content string) string {
 	lines := strings.Split(content, "\n")
 	out := lines[:0]
 	for _, l := range lines {
-		val := strings.TrimPrefix(strings.TrimSpace(l), "PublishPort=")
-		if val != strings.TrimSpace(l) && strings.HasPrefix(val, "[") {
+		trimmed := strings.TrimSpace(l)
+		val := strings.TrimPrefix(trimmed, "PublishPort=")
+		if val == trimmed || !strings.HasPrefix(val, "[") {
+			out = append(out, l)
 			continue
 		}
-		out = append(out, l)
+		if rest, ok := strings.CutPrefix(val, "[::]:"); ok {
+			out = append(out, "PublishPort=0.0.0.0:"+rest)
+			continue
+		}
+		// Loopback (or any other bracketed) IPv6 line: drop it; its IPv4 partner stays.
 	}
 	return strings.Join(out, "\n")
 }

--- a/internal/services/launchd_test.go
+++ b/internal/services/launchd_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/podman"
 )
 
 // TestHasNonZeroExitCode covers the failure-detection helper for both
@@ -571,6 +573,56 @@ func TestStripPrivilegedIPBind_v6(t *testing.T) {
 	for in, want := range cases {
 		if got := stripPrivilegedIPBind(in); got != want {
 			t.Errorf("stripPrivilegedIPBind(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestStripIPv6PublishPorts(t *testing.T) {
+	cases := map[string]string{
+		// Loopback IPv6 dup is dropped; its IPv4 partner survives.
+		"PublishPort=127.0.0.1:80:80\nPublishPort=[::1]:80:80": "PublishPort=127.0.0.1:80:80",
+		// Bind-all IPv6 has no IPv4 partner: rewrite to 0.0.0.0 rather than drop.
+		"PublishPort=[::]:80:80":   "PublishPort=0.0.0.0:80:80",
+		"PublishPort=[::]:443:443": "PublishPort=0.0.0.0:443:443",
+		// Plain IPv4 lines and non-PublishPort lines pass through untouched.
+		"PublishPort=80:80": "PublishPort=80:80",
+		"Network=lerd":      "Network=lerd",
+		"[Container]":       "[Container]",
+	}
+	for in, want := range cases {
+		if got := stripIPv6PublishPorts(in); got != want {
+			t.Errorf("stripIPv6PublishPorts(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestLANExposedPublishPortsSurvive guards the full macOS transform chain for a
+// LAN-exposed container (lan.exposed: true). The regression: BindForLAN +
+// PairIPv6Binds collapse "PublishPort=80:80" into the "[::]:" bind-all form, and
+// stripIPv6PublishPorts used to drop every bracketed line — leaving lerd-nginx
+// with no -p flags, so nothing reached the host. The published ports must survive
+// as -p entries in the final podman run args.
+func TestLANExposedPublishPortsSurvive(t *testing.T) {
+	content := "[Container]\n" +
+		"Image=docker.io/library/nginx:alpine\n" +
+		"Network=lerd\n" +
+		"PublishPort=80:80\n" +
+		"PublishPort=443:443\n"
+
+	content = podman.BindForLAN(content, true) // lanExposed
+	content = podman.PairIPv6Binds(content)
+	content = stripIPv6PublishPorts(content)
+
+	c := parseSection(content, "Container")
+	args, err := containerToPodmanArgs(c)
+	if err != nil {
+		t.Fatalf("containerToPodmanArgs: %v", err)
+	}
+
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"-p 80:80", "-p 443:443"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected %q in podman args, got: %s", want, joined)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

On macOS with `lan.exposed: true`, all core containers come up with **no published ports**. `lerd doctor` reports everything green (nginx running, ports 80/443, DNS ok), but `.test` domains are unreachable: the host has nothing listening on 80/443.

Inspecting `lerd-nginx` confirmed it launched with zero `-p` flags (`HostConfig.PortBindings: {}`), only the internal `80/tcp` EXPOSE. The generated `~/Library/LaunchAgents/lerd-nginx.plist` had no publish entries in `ProgramArguments`.

## Root cause

On macOS, `WriteContainerUnit` (`internal/services/launchd_darwin.go`) derives the `podman run` args from the quadlet and runs `stripIPv6PublishPorts` so gvproxy never binds an IPv4 and an IPv6 address on the same port.

With `lan.exposed: true`:

1. `BindForLAN(content, true)` leaves bare `PublishPort=80:80` as-is.
2. `PairIPv6Binds` collapses the bare bind into the bind-all **`[::]:80:80`** form only (no IPv4 partner line is kept for bare/`0.0.0.0` binds).
3. `stripIPv6PublishPorts` then dropped **every** bracketed line, removing the only publish lines that existed.

Result: `podman run` with no `-p`. In loopback mode (`lan.exposed: false`) the bug is hidden because `PairIPv6Binds` keeps the IPv4 `127.0.0.1:` line alongside the `[::1]:` one, so the IPv4 publish survives the strip.

## Fix

`stripIPv6PublishPorts` now rewrites bind-all `[::]:PORT` lines to `0.0.0.0:PORT` instead of dropping them; only loopback `[::1]:` duplicates (which always retain a surviving `127.0.0.1:` partner) are removed. `stripPrivilegedIPBind` then collapses `0.0.0.0:80:80` to `80:80` as before, so privileged-port output is unchanged.

## Tests

- `TestStripIPv6PublishPorts`: unit coverage for `[::]:` rewrite, `[::1]:` drop, and IPv4 / non-publish pass-through.
- `TestLANExposedPublishPortsSurvive`: end-to-end regression running the full `BindForLAN(true)` -> `PairIPv6Binds` -> `stripIPv6PublishPorts` -> `containerToPodmanArgs` chain and asserting `-p 80:80` and `-p 443:443` survive. Fails on the old logic.

Full `internal/services` package is green.