### PR TITLE
fix(macos): skip the LAN DNS forwarder where lerd-dns binds the LAN port

### DIFF
--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -104,23 +104,50 @@ func EnableLANExposure(progress LANProgressFunc) (lanIP string, err error) {
 			return "", err
 		}
 
-		if err := preflightForwarderPort(lanIP, emit); err != nil {
+		if err := ensureLANForwarder(lanIP, emit); err != nil {
 			return "", err
-		}
-
-		emit("Installing lerd-dns-forwarder.service")
-		if err := installDNSForwarderUnit(lanIP); err != nil {
-			return "", fmt.Errorf("installing dns forwarder: %w", err)
-		}
-
-		emit("Starting lerd-dns-forwarder")
-		if err := reloadAndRestartUnit("lerd-dns-forwarder"); err != nil {
-			return "", fmt.Errorf("starting dns forwarder: %w", err)
 		}
 	}
 
 	emit("Done — lerd is reachable on " + lanIP)
 	return lanIP, nil
+}
+
+// ensureLANForwarder installs the host-side LAN DNS forwarder when the platform
+// needs it. The forwarder is the Linux rootless-pasta workaround: there the
+// lerd-dns container cannot bind the host LAN address, so a forwarder bridges
+// lanIP:5300 → 127.0.0.1:5300. On macOS lerd-dns is a host dnsmasq that already
+// binds all interfaces (including lanIP), so installing a forwarder would
+// double-bind lanIP:5300 and crash lerd-dns; there this is a no-op.
+func ensureLANForwarder(lanIP string, emit func(string)) error {
+	if lerdDNSBindsLANPort {
+		if emit != nil {
+			emit("lerd-dns binds the LAN address directly; no forwarder needed")
+		}
+		return nil
+	}
+	return installLANForwarderFn(lanIP, emit)
+}
+
+// installAndStartForwarder runs the preflight, installs the lerd-dns-forwarder
+// unit, and starts it. Default implementation behind installLANForwarderFn.
+func installAndStartForwarder(lanIP string, emit func(string)) error {
+	if err := preflightForwarderPort(lanIP, emit); err != nil {
+		return err
+	}
+	if emit != nil {
+		emit("Installing lerd-dns-forwarder.service")
+	}
+	if err := installDNSForwarderUnit(lanIP); err != nil {
+		return fmt.Errorf("installing dns forwarder: %w", err)
+	}
+	if emit != nil {
+		emit("Starting lerd-dns-forwarder")
+	}
+	if err := reloadAndRestartUnit("lerd-dns-forwarder"); err != nil {
+		return fmt.Errorf("starting dns forwarder: %w", err)
+	}
+	return nil
 }
 
 // DisableLANExposure flips lerd back to the safe loopback default. Inverts
@@ -231,6 +258,17 @@ var (
 		s, _ := services.Mgr.UnitStatus("lerd-dns-forwarder")
 		return s
 	}
+	// lerdDNSBindsLANPort is true on platforms where the main lerd-dns daemon
+	// binds lanIP:5300 itself (macOS host dnsmasq) instead of via the separate
+	// lerd-dns-forwarder (the Linux rootless-pasta workaround). On such
+	// platforms LAN exposure must NOT install the forwarder: it would
+	// double-bind lanIP:5300 and crash lerd-dns. Seam so both models are
+	// testable from any build host.
+	lerdDNSBindsLANPort = runtime.GOOS == "darwin"
+	// installLANForwarderFn installs and starts the host-side LAN DNS
+	// forwarder. Seam so the macOS skip can be asserted without touching real
+	// units.
+	installLANForwarderFn = installAndStartForwarder
 	forwarderPortFreeFn   = forwarderPortFree
 	forwarderPortHolderFn = forwarderPortHolderLsof
 )

--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -150,6 +150,26 @@ func installAndStartForwarder(lanIP string, emit func(string)) error {
 	return nil
 }
 
+// ensureLANForwarderRemoved tears down the LAN DNS forwarder, the mirror of
+// ensureLANForwarder. Unlike the install side it intentionally runs on every
+// platform: macOS no longer installs a forwarder, but a Mac upgrading from an
+// older build (which did) still needs unexpose to clear that stale unit, or it
+// keeps holding lanIP:5300 and breaks .test resolution. Removing a missing unit
+// is ignored, so this is a safe no-op when no forwarder is present.
+func ensureLANForwarderRemoved(emit func(string)) error {
+	if emit != nil {
+		emit("Stopping lerd-dns-forwarder")
+	}
+	_ = services.Mgr.Stop("lerd-dns-forwarder")
+	_ = services.Mgr.Disable("lerd-dns-forwarder")
+	if err := services.Mgr.RemoveServiceUnit("lerd-dns-forwarder"); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing forwarder unit: %w", err)
+	}
+	_ = services.Mgr.DaemonReload()
+
+	return nil
+}
+
 // DisableLANExposure flips lerd back to the safe loopback default. Inverts
 // EnableLANExposure: rewrites every container PublishPort to bind 127.0.0.1,
 // stops the dns-forwarder, reverts dnsmasq to answer with 127.0.0.1, and
@@ -186,13 +206,9 @@ func DisableLANExposure(progress LANProgressFunc) error {
 	}
 
 	if cfg.DNS.Enabled {
-		emit("Stopping lerd-dns-forwarder")
-		_ = services.Mgr.Stop("lerd-dns-forwarder")
-		_ = services.Mgr.Disable("lerd-dns-forwarder")
-		if err := services.Mgr.RemoveServiceUnit("lerd-dns-forwarder"); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("removing forwarder unit: %w", err)
+		if err := ensureLANForwarderRemoved(emit); err != nil {
+			return err
 		}
-		_ = services.Mgr.DaemonReload()
 
 		emit("Reverting dnsmasq to 127.0.0.1")
 		if err := dns.WriteDnsmasqConfigFor(config.DnsmasqDir(), "127.0.0.1"); err != nil {

--- a/internal/cli/dns_preflight_test.go
+++ b/internal/cli/dns_preflight_test.go
@@ -104,6 +104,60 @@ func TestPreflightForwarderPort_PortInUseSurfacesHolder(t *testing.T) {
 	}
 }
 
+func TestEnsureLANForwarder_DarwinSkipsForwarderInstall(t *testing.T) {
+	// macOS model: lerd-dns binds the LAN address directly, so installing the
+	// forwarder would double-bind lanIP:5300 and crash lerd-dns. It must be
+	// skipped entirely.
+	prevBinds := lerdDNSBindsLANPort
+	prevInstall := installLANForwarderFn
+	t.Cleanup(func() {
+		lerdDNSBindsLANPort = prevBinds
+		installLANForwarderFn = prevInstall
+	})
+
+	lerdDNSBindsLANPort = true
+	installLANForwarderFn = func(string, func(string)) error {
+		t.Error("forwarder must not be installed when lerd-dns binds the LAN port directly")
+		return nil
+	}
+
+	var events []string
+	if err := ensureLANForwarder("192.168.1.10", func(s string) { events = append(events, s) }); err != nil {
+		t.Errorf("ensureLANForwarder should be a no-op on the macOS model, got %v", err)
+	}
+	if len(events) == 0 || !strings.Contains(events[0], "no forwarder needed") {
+		t.Errorf("expected a progress line explaining the skip, got %v", events)
+	}
+}
+
+func TestEnsureLANForwarder_NonDarwinInstallsForwarder(t *testing.T) {
+	// Linux model: lerd-dns can't bind the host LAN port, so the forwarder is
+	// required and must be installed.
+	prevBinds := lerdDNSBindsLANPort
+	prevInstall := installLANForwarderFn
+	t.Cleanup(func() {
+		lerdDNSBindsLANPort = prevBinds
+		installLANForwarderFn = prevInstall
+	})
+
+	lerdDNSBindsLANPort = false
+	called := false
+	installLANForwarderFn = func(lanIP string, _ func(string)) error {
+		called = true
+		if lanIP != "192.168.1.10" {
+			t.Errorf("forwarder installed with wrong lanIP %q", lanIP)
+		}
+		return nil
+	}
+
+	if err := ensureLANForwarder("192.168.1.10", nil); err != nil {
+		t.Errorf("ensureLANForwarder should install the forwarder on the Linux model, got %v", err)
+	}
+	if !called {
+		t.Error("expected the forwarder to be installed on the Linux model")
+	}
+}
+
 func TestForwarderPortFree_DetectsBoundUDP(t *testing.T) {
 	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/cli/dns_preflight_test.go
+++ b/internal/cli/dns_preflight_test.go
@@ -1,10 +1,37 @@
 package cli
 
 import (
+	"errors"
 	"net"
+	"os"
 	"strings"
 	"testing"
 )
+
+// forwarderRemoveRecorder records the teardown calls ensureLANForwarderRemoved
+// makes and lets a test inject a RemoveServiceUnit error.
+type forwarderRemoveRecorder struct {
+	fakeServiceMgr
+	calls     []string
+	removeErr error
+}
+
+func (r *forwarderRemoveRecorder) Stop(name string) error {
+	r.calls = append(r.calls, "stop:"+name)
+	return nil
+}
+func (r *forwarderRemoveRecorder) Disable(name string) error {
+	r.calls = append(r.calls, "disable:"+name)
+	return nil
+}
+func (r *forwarderRemoveRecorder) RemoveServiceUnit(name string) error {
+	r.calls = append(r.calls, "remove:"+name)
+	return r.removeErr
+}
+func (r *forwarderRemoveRecorder) DaemonReload() error {
+	r.calls = append(r.calls, "reload")
+	return nil
+}
 
 func TestPreflightForwarderPort_OwnUnitActiveSkipsCheck(t *testing.T) {
 	prevStatus := forwarderUnitStatusFn
@@ -155,6 +182,57 @@ func TestEnsureLANForwarder_NonDarwinInstallsForwarder(t *testing.T) {
 	}
 	if !called {
 		t.Error("expected the forwarder to be installed on the Linux model")
+	}
+}
+
+func TestEnsureLANForwarderRemoved_TearsDownUnit(t *testing.T) {
+	// Teardown stops, disables, removes, then daemon-reloads, naming the
+	// forwarder unit at each step, and emits a progress line.
+	rec := &forwarderRemoveRecorder{}
+	swapMgr(t, rec)
+
+	var events []string
+	if err := ensureLANForwarderRemoved(func(s string) { events = append(events, s) }); err != nil {
+		t.Fatalf("ensureLANForwarderRemoved: unexpected error %v", err)
+	}
+
+	want := []string{
+		"stop:lerd-dns-forwarder",
+		"disable:lerd-dns-forwarder",
+		"remove:lerd-dns-forwarder",
+		"reload",
+	}
+	if !equalStrings(rec.calls, want) {
+		t.Errorf("teardown calls: got %v want %v", rec.calls, want)
+	}
+	if len(events) == 0 || !strings.Contains(events[0], "lerd-dns-forwarder") {
+		t.Errorf("expected a progress line naming the forwarder, got %v", events)
+	}
+}
+
+func TestEnsureLANForwarderRemoved_MissingUnitIgnored(t *testing.T) {
+	// A Mac that never had a forwarder (or any already-clean host) hits a
+	// not-exist on removal; that is the no-op case and must not error.
+	rec := &forwarderRemoveRecorder{removeErr: os.ErrNotExist}
+	swapMgr(t, rec)
+
+	if err := ensureLANForwarderRemoved(nil); err != nil {
+		t.Errorf("a missing forwarder unit must be ignored, got %v", err)
+	}
+}
+
+func TestEnsureLANForwarderRemoved_RealRemoveErrorSurfaces(t *testing.T) {
+	// Any removal error that isn't not-exist is a genuine failure and must
+	// abort the unexpose so the caller doesn't report a clean teardown.
+	rec := &forwarderRemoveRecorder{removeErr: errors.New("permission denied")}
+	swapMgr(t, rec)
+
+	err := ensureLANForwarderRemoved(nil)
+	if err == nil {
+		t.Fatal("expected a real RemoveServiceUnit error to surface")
+	}
+	if !strings.Contains(err.Error(), "removing forwarder unit") {
+		t.Errorf("error should wrap the forwarder removal, got %v", err)
 	}
 }
 

--- a/internal/cli/lan.go
+++ b/internal/cli/lan.go
@@ -91,8 +91,9 @@ func newLANExposeCmd() *cobra.Command {
     become reachable from other devices on the LAN).
   - Restarts each affected container so the new bind takes effect.
   - Rewrites the dnsmasq config to answer *.test queries with the host's
-    auto-detected LAN IP and starts the userspace lerd-dns-forwarder so
-    LAN devices can resolve those names.
+    auto-detected LAN IP so LAN devices can resolve those names. On Linux
+    this is bridged by the userspace lerd-dns-forwarder; on macOS lerd-dns
+    binds the LAN address directly, so no forwarder is installed.
 
 The dashboard at port 7073 is still gated by the remote-control middleware:
 LAN clients get 403 unless you have run 'lerd remote-control on' to set

--- a/internal/cli/remote_setup.go
+++ b/internal/cli/remote_setup.go
@@ -189,7 +189,11 @@ Re-run this command to generate a new code if it expires or is consumed.`,
 				return fmt.Errorf("enabling lan:expose: %w", err)
 			}
 			expose.OK(feedback.Val(lanIP))
-			feedback.Note("lerd-dns-forwarder on " + lanIP + ":5300 (UDP+TCP), answering *.test → " + lanIP)
+			if lerdDNSBindsLANPort {
+				feedback.Note("lerd-dns binds " + lanIP + ":5300 (UDP+TCP) directly, answering *.test → " + lanIP)
+			} else {
+				feedback.Note("lerd-dns-forwarder on " + lanIP + ":5300 (UDP+TCP), answering *.test → " + lanIP)
+			}
 			feedback.Note("allow port 5300 through your firewall from the devices you want to grant access")
 
 			code, err := GenerateRemoteSetupToken(ttl)


### PR DESCRIPTION
## Problem

On macOS, `lerd lan expose` breaks `.test` DNS resolution. It reports success, but afterwards `lerd-dns` is dead and nothing resolves:

- `lerd-dns` (launchd `com.lerd.lerd-dns`) exits with code 2 (`address in use`).
- `lerd-dns-forwarder` is left bound to `lanIP:5300`, forwarding to a dead `127.0.0.1:5300`.
- `dig @127.0.0.1 -p 5300 <site>.test` times out; the browser can't resolve any `.test` site.

A re-`expose` (the common case) previously failed even earlier, at the preflight, with a spurious `lanIP:5300 is already in use` against lerd's **own** `lerd-dns`.

## Root cause

`EnableLANExposure` unconditionally installs and starts `lerd-dns-forwarder`. That forwarder is the **Linux rootless-pasta workaround** (`installDNSForwarderUnit` documents it as such): on Linux the `lerd-dns` container can't bind the host LAN address, so a host-side forwarder bridges `lanIP:5300 → 127.0.0.1:5300`.

On macOS `lerd-dns` is a host dnsmasq that already binds **every** interface, including `lanIP`. Installing the forwarder makes a second process grab `lanIP:5300`, the `lerd-dns` restart then races it and exits `address in use` (exit 2), and the forwarder forwards to a now-dead loopback. DNS is fully broken.

The preflight check (`preflightForwarderPort`) only recognised lerd's own daemon via the `lerd-dns-forwarder` unit. On macOS that unit is `.disabled` and `lerd-dns` itself holds the port, so the preflight read it as a foreign conflict, which accidentally masked the deeper bug by aborting expose.

## Fix

Gate the forwarder install/start on a new `lerdDNSBindsLANPort` seam (`true` on darwin). Where `lerd-dns` binds the LAN port directly, the forwarder is skipped as a no-op (lerd-dns binding all interfaces *is* the LAN exposure). The Linux model is unchanged: there the forwarder is still installed and the existing preflight still guards it.

Extracts the forwarder steps into `ensureLANForwarder` (the gate) + `installAndStartForwarder` (the impl, behind the `installLANForwarderFn` seam).

## Tests

- `TestEnsureLANForwarder_DarwinSkipsForwarderInstall`: macOS model → forwarder not installed, no-op.
- `TestEnsureLANForwarder_NonDarwinInstallsForwarder`: Linux model → forwarder installed with the right lanIP.
- Existing `preflightForwarderPort` / `forwarderPortFree` tests unchanged and green.

Verified end to end on macOS: `lerd lan expose` now reports `lerd-dns binds the LAN address directly; no forwarder needed`, `lerd-dns` stays up, `.test` resolves, and the site is reachable from a LAN device.

`go test ./internal/cli/` green, `go vet` and `gofmt` clean.

---

Note: this supersedes the earlier preflight-only version of this PR (which let expose proceed but did not prevent the forwarder double-bind). Force-pushed.