### PR TITLE
fix(cli): surface npm/bun build failures during setup instead of killing the process

### DIFF
--- a/internal/cli/node_exec.go
+++ b/internal/cli/node_exec.go
@@ -20,7 +20,7 @@ func NewNodeCmd() *cobra.Command {
 		DisableFlagParsing: true,
 		SilenceUsage:       true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runWithFnm("node", args)
+			return runWithFnm("node", args, true)
 		},
 	}
 }
@@ -33,7 +33,7 @@ func NewNpmCmd() *cobra.Command {
 		DisableFlagParsing: true,
 		SilenceUsage:       true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runWithFnm("npm", args)
+			return runWithFnm("npm", args, true)
 		},
 	}
 }
@@ -46,7 +46,7 @@ func NewNpxCmd() *cobra.Command {
 		DisableFlagParsing: true,
 		SilenceUsage:       true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runWithFnm("npx", args)
+			return runWithFnm("npx", args, true)
 		},
 	}
 }
@@ -120,10 +120,12 @@ func systemNodeAvailable() bool {
 	return nodeDet.SystemNodeAvailable()
 }
 
-// runBun execs the host bun binary in dir, streaming to the terminal and
-// os.Exit'ing on failure to mirror runWithFnm's CLI behaviour. bun is
-// self-contained, so unlike node it needs no fnm wrapper or version pin.
-func runBun(dir, bun string, args []string) error {
+// runBun execs the host bun binary in dir, streaming to the terminal. bun is
+// self-contained, so unlike node it needs no fnm wrapper or version pin. When
+// exitOnFail is set it os.Exit's with the child's code to mirror runWithFnm's
+// CLI behaviour; callers that fold the run behind a feedback step (setup) pass
+// false so the non-zero exit is returned and the step loop can report it.
+func runBun(dir, bun string, args []string, exitOnFail bool) error {
 	cmd := exec.Command(bun, args...)
 	cmd.Dir = dir
 	cmd.Stdin = os.Stdin
@@ -131,7 +133,7 @@ func runBun(dir, bun string, args []string) error {
 	cmd.Stderr = os.Stderr
 	cmd.Env = shimLeadingEnv(os.Environ())
 	if err := cmd.Run(); err != nil {
-		if exit, ok := err.(*exec.ExitError); ok {
+		if exit, ok := err.(*exec.ExitError); ok && exitOnFail {
 			os.Exit(exit.ExitCode())
 		}
 		return err
@@ -153,21 +155,21 @@ func runJSInstall(dir string, frozen bool) error {
 				break
 			}
 		}
-		return runBun(dir, bun, args)
+		return runBun(dir, bun, args, false)
 	}
 	if frozen {
-		return runWithFnm("npm", []string{"ci"})
+		return runWithFnm("npm", []string{"ci"}, false)
 	}
-	return runWithFnm("npm", []string{"install"})
+	return runWithFnm("npm", []string{"install"}, false)
 }
 
 // runJSScript runs a package.json script in dir via `bun run <script>` when the
 // project uses bun, otherwise `npm run <script>` via fnm.
 func runJSScript(dir, script string) error {
 	if bun := bunRunnerFor(dir, true); bun != "" {
-		return runBun(dir, bun, []string{"run", script})
+		return runBun(dir, bun, []string{"run", script}, false)
 	}
-	return runWithFnm("npm", []string{"run", script})
+	return runWithFnm("npm", []string{"run", script}, false)
 }
 
 // shimLeadingEnv prepends lerd's bin dir (home of the `php` shim) to PATH so
@@ -191,7 +193,7 @@ func shimLeadingEnv(env []string) []string {
 	return out
 }
 
-func runWithFnm(bin string, args []string) error {
+func runWithFnm(bin string, args []string, exitOnFail bool) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -240,7 +242,7 @@ func runWithFnm(bin string, args []string) error {
 		}
 	}
 	if runErr != nil {
-		if exit, ok := runErr.(*exec.ExitError); ok {
+		if exit, ok := runErr.(*exec.ExitError); ok && exitOnFail {
 			os.Exit(exit.ExitCode())
 		}
 		return runErr

--- a/internal/cli/node_exec_integration_test.go
+++ b/internal/cli/node_exec_integration_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// TestRunWithFnm_FailingScriptReturnsErrorNotExit is the end-to-end guard for the
+// lerd link/setup regression: a failing `npm run <script>` must return an error
+// (so the setup step loop can report it) rather than os.Exit and kill lerd. It
+// drives the real fnm/npm toolchain, so it skips when fnm or a default Node isn't
+// installed. If exitOnFail were still hard-coded true here, this test process
+// would be terminated and the run would fail loudly — which is the point.
+func TestRunWithFnm_FailingScriptReturnsErrorNotExit(t *testing.T) {
+	fnm := filepath.Join(config.BinDir(), "fnm")
+	if _, err := os.Stat(fnm); err != nil {
+		t.Skipf("fnm not installed at %s; skipping integration test", fnm)
+	}
+	// Without a default Node, runWithFnm returns early with the "no Node.js
+	// version available" error and never reaches the failing-script branch this
+	// test guards, so the skip must check for it too — not just fnm's presence.
+	if err := exec.Command(fnm, "exec", "--using=default", "--", "true").Run(); err != nil {
+		t.Skip("no default Node available via fnm; skipping integration test")
+	}
+
+	dir := t.TempDir()
+	pkg := `{"name":"lerd-fail-test","private":true,"scripts":{"production":"node -e \"process.exit(7)\""}}`
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(dir)
+
+	err := runWithFnm("npm", []string{"run", "production"}, false)
+	if err == nil {
+		t.Fatal("expected an error from a failing npm script, got nil (did the process survive but swallow the failure?)")
+	}
+}

--- a/internal/cli/node_exec_test.go
+++ b/internal/cli/node_exec_test.go
@@ -218,3 +218,23 @@ func TestSyncNodeGlobalBins_MissingSourceIsNoOp(t *testing.T) {
 		t.Errorf("expected orphan removed when source missing, err=%v", err)
 	}
 }
+
+// TestRunBun_FailureReturnsErrorWhenNotExiting guards the lerd link/setup
+// regression where a failed `npm run production` / `bun run build` killed the
+// whole process via os.Exit, bypassing the step loop's failure feedback. With
+// exitOnFail false the non-zero child exit must come back as an error so the
+// caller can report it, not terminate lerd.
+func TestRunBun_FailureReturnsErrorWhenNotExiting(t *testing.T) {
+	// /bin/sh stands in for the bun binary; the script exits non-zero.
+	err := runBun(t.TempDir(), "/bin/sh", []string{"-c", "exit 3"}, false)
+	if err == nil {
+		t.Fatal("expected an error from a non-zero child exit, got nil")
+	}
+}
+
+// TestRunBun_SuccessReturnsNil confirms the happy path still returns nil.
+func TestRunBun_SuccessReturnsNil(t *testing.T) {
+	if err := runBun(t.TempDir(), "/bin/sh", []string{"-c", "exit 0"}, false); err != nil {
+		t.Fatalf("expected nil on success, got %v", err)
+	}
+}


### PR DESCRIPTION
A failed `package.json` build script during `lerd link` or `lerd setup` killed the whole `lerd` process on the spot, with a frozen spinner and no error shown. The setup step loop is designed to catch a failed step, mark it failed, print its output, and ask whether to continue, but it never got the chance: `runJSScript` and `runJSInstall` route through `runWithFnm` and `runBun`, and both called `os.Exit` with the child's exit code on any non-zero exit, tearing down the process before the loop could report. Because the step's stdout and stderr were still redirected into the capture pipe at that moment, the real build error never reached the terminal either.

That `os.Exit` is correct for the direct CLI commands, where `lerd` should mirror the child's exit code, but wrong on the setup path, which wants the error returned so the loop can handle it. This threads an `exitOnFail` flag through both helpers: `node`, `npm` and `npx` keep exiting with the child's code, while the setup callers get the error back and feedback flows as designed.

Refs #621