### PR TITLE
Add framework prune and an in-use guard on framework remove

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -277,7 +277,8 @@ Activity-driven worker suspension: lerd gracefully stops each site's suspendable
 |---|---|
 | `lerd framework list` | List all available framework definitions and their workers |
 | `lerd framework add <name>` | Add or update a framework definition (flags or `--from-file`) |
-| `lerd framework remove <name>` | Remove a user-defined framework definition |
+| `lerd framework remove <name>` | Remove a framework definition (confirms if a site still uses it) |
+| `lerd framework prune` | Remove installed definitions no site uses |
 
 ## Stripe
 

--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -20,6 +20,7 @@ Laravel has a built-in definition. Other frameworks (Symfony, WordPress, Drupal,
 | `lerd framework add <name>` | Add or update a user-defined framework definition |
 | `lerd framework remove <name>[@version]` | Remove a framework definition (prompts if multiple versions) |
 | `lerd framework remove <name> --all` | Remove all versions of a framework definition |
+| `lerd framework prune` | Remove installed definitions no site uses |
 
 ---
 
@@ -182,6 +183,21 @@ lerd framework remove symfony --all    # remove all versions
 ```
 
 When multiple versions of a framework are installed, `lerd framework remove` prompts you to choose which version to remove.
+
+If a linked site still uses the framework, `lerd framework remove` lists those sites and asks you to confirm before deleting it. Pass `--force` to skip that confirmation.
+
+### Pruning unused definitions
+
+Installed definitions accumulate over time as you try different frameworks. To clear out the ones no site references:
+
+```bash
+lerd framework prune          # lists unused definitions, then asks to confirm
+lerd framework prune --force  # removes them without confirming
+```
+
+Pruning only touches store-installed and user-defined definitions, never the built-in ones. It is safe to run: lerd re-fetches a definition from the store automatically the moment a site needs one that is no longer present locally, so a pruned framework comes back on its own if you need it again.
+
+When you `lerd unlink` the last site using a framework, lerd offers to remove that framework's definition right then, so you do not have to remember to prune it later. The offer only appears for removable definitions, never the built-in ones.
 
 ---
 

--- a/internal/cli/framework.go
+++ b/internal/cli/framework.go
@@ -27,6 +27,7 @@ func NewFrameworkCmd() *cobra.Command {
 	cmd.AddCommand(newFrameworkSearchCmd())
 	cmd.AddCommand(newFrameworkInstallCmd())
 	cmd.AddCommand(newFrameworkUpdateCmd())
+	cmd.AddCommand(newFrameworkPruneCmd())
 	return cmd
 }
 
@@ -281,18 +282,23 @@ YAML file format:
 
 func newFrameworkRemoveCmd() *cobra.Command {
 	var all bool
+	var force bool
 	cmd := &cobra.Command{
 		Use:   "remove <name>[@version]",
 		Short: "Remove a framework definition (user-defined or store-installed)",
 		Long: `Remove a framework definition. If multiple versions are installed and no
 version is specified, you will be prompted to choose which to remove.
 
-Use --all to remove all versions without prompting.
+If any linked site still uses the framework, you are asked to confirm first.
+
+Use --all to remove all versions without prompting, and --force to skip the
+in-use confirmation.
 
 Examples:
   lerd framework remove symfony          # prompt if multiple versions
   lerd framework remove symfony@7        # remove specific version
-  lerd framework remove symfony --all    # remove all versions`,
+  lerd framework remove symfony --all    # remove all versions
+  lerd framework remove symfony --force  # skip the in-use confirmation`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			name, version := parseNameVersion(args[0])
@@ -313,7 +319,8 @@ Examples:
 				return fmt.Errorf("framework %q not found", name)
 			}
 
-			// Specific version requested.
+			// Specific version requested: this removes one cached definition, not
+			// the framework, so the name-level in-use guard does not apply.
 			if version != "" {
 				for _, f := range files {
 					if f.Version == version {
@@ -327,12 +334,31 @@ Examples:
 				return fmt.Errorf("framework %q version %q not found", name, version)
 			}
 
+			// Removing every definition for the name. Confirm if an active site
+			// still uses it, unless it is built-in (the binary definition remains,
+			// so a site never breaks) or --force is given.
+			if !force && !config.IsBuiltinFramework(name) {
+				if sites := config.SitesUsingFramework(name); len(sites) > 0 {
+					fmt.Printf("Framework %q is still used by %s: %s\n",
+						name, pluralizeSites(len(sites)), strings.Join(sites, ", "))
+					if !promptConfirm("Remove it anyway?") {
+						feedback.Note("aborted")
+						return nil
+					}
+				}
+			}
+
+			builtinNote := ""
+			if config.IsBuiltinFramework(name) {
+				builtinNote = " (built-in definition remains)"
+			}
+
 			// Single file or --all: remove everything.
 			if len(files) == 1 || all {
 				if err := config.RemoveFramework(name); err != nil {
 					return err
 				}
-				feedback.Done(fmt.Sprintf("framework %q removed", name))
+				feedback.Done(fmt.Sprintf("framework %q removed%s", name, builtinNote))
 				return nil
 			}
 
@@ -360,7 +386,7 @@ Examples:
 				if err := config.RemoveFramework(name); err != nil {
 					return err
 				}
-				feedback.Done(fmt.Sprintf("framework %q removed (all versions)", name))
+				feedback.Done(fmt.Sprintf("framework %q removed (all versions)%s", name, builtinNote))
 				return nil
 			}
 
@@ -381,7 +407,77 @@ Examples:
 		},
 	}
 	cmd.Flags().BoolVar(&all, "all", false, "Remove all versions without prompting")
+	cmd.Flags().BoolVar(&force, "force", false, "Skip the confirmation when a site still uses the framework")
 	return cmd
+}
+
+func pluralizeSites(n int) string {
+	if n == 1 {
+		return "1 site"
+	}
+	return fmt.Sprintf("%d sites", n)
+}
+
+func newFrameworkPruneCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Remove installed framework definitions no site uses",
+		Long: `Remove store-installed and user-defined framework definitions that no linked
+site references. Built-in definitions are never touched.
+
+This is safe: lerd re-fetches a definition from the store automatically the
+moment a site needs one that is no longer present locally, so a pruned
+framework comes back on its own if it is needed again.
+
+Examples:
+  lerd framework prune          # list unused, then confirm
+  lerd framework prune --force  # remove without confirming`,
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			unused := config.UnusedInstalledFrameworks()
+			if len(unused) == 0 {
+				feedback.Done("no unused frameworks to prune")
+				return nil
+			}
+
+			fmt.Printf("The following %s used by any site:\n", pruneSubject(len(unused)))
+			for _, name := range unused {
+				fmt.Printf("  %s\n", name)
+			}
+
+			if !force && !promptConfirm("Remove them?") {
+				feedback.Note("aborted")
+				return nil
+			}
+
+			removed, failed := config.RemoveFrameworks(unused)
+			for _, name := range failed {
+				feedback.Warn("could not remove %q", name)
+			}
+			if len(removed) == 0 {
+				return fmt.Errorf("could not prune any frameworks")
+			}
+			feedback.Done(fmt.Sprintf("pruned %s", pluralizeFrameworks(len(removed))))
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "Remove without confirming")
+	return cmd
+}
+
+func pruneSubject(n int) string {
+	if n == 1 {
+		return "framework is not"
+	}
+	return "frameworks are not"
+}
+
+func pluralizeFrameworks(n int) string {
+	if n == 1 {
+		return "1 framework"
+	}
+	return fmt.Sprintf("%d frameworks", n)
 }
 
 func newFrameworkSearchCmd() *cobra.Command {

--- a/internal/cli/framework_prune_test.go
+++ b/internal/cli/framework_prune_test.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func setFrameworkTestDirs(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+}
+
+func seedStoreFramework(t *testing.T, name string) string {
+	t.Helper()
+	dir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name+".yaml")
+	if err := os.WriteFile(path, []byte("name: "+name+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestFrameworkPrune_RemovesUnusedKeepsUsed(t *testing.T) {
+	setFrameworkTestDirs(t)
+
+	usedPath := seedStoreFramework(t, "wordpress")
+	unusedPath := seedStoreFramework(t, "drupal")
+
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "shop", Framework: "wordpress"},
+	}}
+	if err := config.SaveSites(reg); err != nil {
+		t.Fatalf("SaveSites: %v", err)
+	}
+
+	cmd := newFrameworkPruneCmd()
+	cmd.SetArgs([]string{"--force"})
+	cmd.SetOut(os.NewFile(0, os.DevNull))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+
+	if _, err := os.Stat(unusedPath); !os.IsNotExist(err) {
+		t.Error("expected unused framework to be pruned")
+	}
+	if _, err := os.Stat(usedPath); err != nil {
+		t.Errorf("expected used framework to remain, got: %v", err)
+	}
+}
+
+func TestFrameworkPrune_NothingToPrune(t *testing.T) {
+	setFrameworkTestDirs(t)
+
+	usedPath := seedStoreFramework(t, "wordpress")
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "shop", Framework: "wordpress"},
+	}}
+	if err := config.SaveSites(reg); err != nil {
+		t.Fatalf("SaveSites: %v", err)
+	}
+
+	cmd := newFrameworkPruneCmd()
+	cmd.SetArgs([]string{})
+	cmd.SetOut(os.NewFile(0, os.DevNull))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+
+	if _, err := os.Stat(usedPath); err != nil {
+		t.Errorf("expected used framework to remain, got: %v", err)
+	}
+}
+
+func TestFrameworkRemove_ForceSkipsInUseConfirm(t *testing.T) {
+	setFrameworkTestDirs(t)
+
+	path := seedStoreFramework(t, "wordpress")
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "blog", Framework: "wordpress"},
+	}}
+	if err := config.SaveSites(reg); err != nil {
+		t.Fatalf("SaveSites: %v", err)
+	}
+
+	cmd := newFrameworkRemoveCmd()
+	cmd.SetArgs([]string{"wordpress", "--force"})
+	cmd.SetOut(os.NewFile(0, os.DevNull))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("remove --force: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("expected framework to be removed with --force despite being in use")
+	}
+}
+
+func TestFrameworkIsOrphaned(t *testing.T) {
+	setFrameworkTestDirs(t)
+
+	seedStoreFramework(t, "wordpress") // still used
+	seedStoreFramework(t, "drupal")    // orphaned
+	seedStoreFramework(t, "symfony")   // built-in overlay, never orphaned
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "shop", Framework: "wordpress"},
+	}}
+	if err := config.SaveSites(reg); err != nil {
+		t.Fatalf("SaveSites: %v", err)
+	}
+
+	if frameworkIsOrphaned("wordpress") {
+		t.Error("wordpress is still used, should not be orphaned")
+	}
+	if !frameworkIsOrphaned("drupal") {
+		t.Error("drupal has no site, should be orphaned")
+	}
+	if frameworkIsOrphaned("symfony") {
+		t.Error("symfony is built-in, should never be orphaned")
+	}
+	if frameworkIsOrphaned("") {
+		t.Error("empty framework should not be orphaned")
+	}
+}
+
+func TestFrameworkRemove_VersionSpecificNotBlockedByInUse(t *testing.T) {
+	setFrameworkTestDirs(t)
+
+	dir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	v5 := filepath.Join(dir, "drupal@5.yaml")
+	v7 := filepath.Join(dir, "drupal@7.yaml")
+	os.WriteFile(v5, []byte("name: drupal\nversion: \"5\"\n"), 0644)
+	os.WriteFile(v7, []byte("name: drupal\nversion: \"7\"\n"), 0644)
+
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "site", Framework: "drupal"},
+	}}
+	if err := config.SaveSites(reg); err != nil {
+		t.Fatalf("SaveSites: %v", err)
+	}
+
+	cmd := newFrameworkRemoveCmd()
+	cmd.SetArgs([]string{"drupal@5"})
+	cmd.SetOut(os.NewFile(0, os.DevNull))
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("remove drupal@5: %v", err)
+	}
+
+	if _, err := os.Stat(v5); !os.IsNotExist(err) {
+		t.Error("expected drupal@5 to be removed without the in-use guard")
+	}
+	if _, err := os.Stat(v7); err != nil {
+		t.Errorf("expected drupal@7 to remain, got: %v", err)
+	}
+}

--- a/internal/cli/framework_prune_test.go
+++ b/internal/cli/framework_prune_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,7 +44,7 @@ func TestFrameworkPrune_RemovesUnusedKeepsUsed(t *testing.T) {
 
 	cmd := newFrameworkPruneCmd()
 	cmd.SetArgs([]string{"--force"})
-	cmd.SetOut(os.NewFile(0, os.DevNull))
+	cmd.SetOut(io.Discard)
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("prune: %v", err)
 	}
@@ -69,7 +70,7 @@ func TestFrameworkPrune_NothingToPrune(t *testing.T) {
 
 	cmd := newFrameworkPruneCmd()
 	cmd.SetArgs([]string{})
-	cmd.SetOut(os.NewFile(0, os.DevNull))
+	cmd.SetOut(io.Discard)
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("prune: %v", err)
 	}
@@ -92,7 +93,7 @@ func TestFrameworkRemove_ForceSkipsInUseConfirm(t *testing.T) {
 
 	cmd := newFrameworkRemoveCmd()
 	cmd.SetArgs([]string{"wordpress", "--force"})
-	cmd.SetOut(os.NewFile(0, os.DevNull))
+	cmd.SetOut(io.Discard)
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("remove --force: %v", err)
 	}
@@ -150,7 +151,7 @@ func TestFrameworkRemove_VersionSpecificNotBlockedByInUse(t *testing.T) {
 
 	cmd := newFrameworkRemoveCmd()
 	cmd.SetArgs([]string{"drupal@5"})
-	cmd.SetOut(os.NewFile(0, os.DevNull))
+	cmd.SetOut(io.Discard)
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("remove drupal@5: %v", err)
 	}

--- a/internal/cli/unlink.go
+++ b/internal/cli/unlink.go
@@ -104,8 +104,44 @@ func UnlinkSite(name string) error {
 		}
 	}
 
+	// Offer to remove the framework definition when this was the last site
+	// using it and the definition is removable (store-installed or user-defined,
+	// never a built-in). It is safe to remove: lerd re-fetches it from the store
+	// the moment another site needs it.
+	offerRemoveOrphanedFramework(site.Framework)
+
 	autoStopUnusedServices()
 	autoStopUnusedFPMs()
 
 	return nil
+}
+
+// offerRemoveOrphanedFramework prompts, in interactive sessions only, to delete
+// a framework definition once no remaining active site references it. Built-in
+// frameworks are never offered.
+func offerRemoveOrphanedFramework(fw string) {
+	if !isInteractive() || !frameworkIsOrphaned(fw) {
+		return
+	}
+	if feedback.Confirm(fmt.Sprintf("No sites use the %q framework anymore. Remove its definition?", fw), false) {
+		if err := config.RemoveFramework(fw); err != nil {
+			feedback.Warn("could not remove framework %q: %v", fw, err)
+			return
+		}
+		feedback.Line("framework definition removed")
+	}
+}
+
+// frameworkIsOrphaned reports whether fw has a removable definition (store or
+// user, never built-in) that no remaining active site references.
+func frameworkIsOrphaned(fw string) bool {
+	if fw == "" {
+		return false
+	}
+	for _, name := range config.UnusedInstalledFrameworks() {
+		if name == fw {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -1447,7 +1447,12 @@ func ListFrameworkFiles(name string) []FrameworkFile {
 		files = append(files, FrameworkFile{Path: path, Version: version, Source: source})
 	}
 
-	add(filepath.Join(FrameworksDir(), name+".yaml"), SourceUser)
+	userDir := FrameworksDir()
+	add(filepath.Join(userDir, name+".yaml"), SourceUser)
+	userMatches, _ := filepath.Glob(filepath.Join(userDir, name+"@*.yaml"))
+	for _, m := range userMatches {
+		add(m, SourceUser)
+	}
 
 	storeDir := StoreFrameworksDir()
 	add(filepath.Join(storeDir, name+".yaml"), SourceStore)
@@ -1457,6 +1462,106 @@ func ListFrameworkFiles(name string) []FrameworkFile {
 	}
 
 	return files
+}
+
+// IsBuiltinFramework reports whether name is one of lerd's built-in frameworks
+// (laravel, symfony). Their definitions ship in the binary, so their store or
+// user files are overlays that prune and the unlink offer leave alone.
+func IsBuiltinFramework(name string) bool {
+	return builtinFramework(name) != nil
+}
+
+// SitesUsingFramework returns the names of active sites whose framework field
+// matches name. Ignored entries (parked directories that were unlinked) are not
+// served, so they do not count as usage. It is the basis for the remove
+// confirmation and prune.
+func SitesUsingFramework(name string) []string {
+	reg, err := LoadSites()
+	if err != nil || reg == nil {
+		return nil
+	}
+	var out []string
+	for _, s := range reg.Sites {
+		if s.Ignored {
+			continue
+		}
+		if s.Framework == name {
+			out = append(out, s.Name)
+		}
+	}
+	return out
+}
+
+// activeFrameworkSet returns the set of framework names referenced by at least
+// one active (non-ignored) site, loading the registry once.
+func activeFrameworkSet() map[string]bool {
+	set := make(map[string]bool)
+	reg, err := LoadSites()
+	if err != nil || reg == nil {
+		return set
+	}
+	for _, s := range reg.Sites {
+		if s.Ignored || s.Framework == "" {
+			continue
+		}
+		set[s.Framework] = true
+	}
+	return set
+}
+
+// UnusedInstalledFrameworks returns installed framework names that no active
+// site references, sorted. Built-in frameworks are never included.
+func UnusedInstalledFrameworks() []string {
+	inUse := activeFrameworkSet()
+	var out []string
+	for _, name := range InstalledFrameworkNames() {
+		if !inUse[name] {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// RemoveFrameworks removes each named framework definition, returning the names
+// that were removed and the names that failed so callers can report accurately.
+func RemoveFrameworks(names []string) (removed, failed []string) {
+	for _, name := range names {
+		if err := RemoveFramework(name); err != nil {
+			failed = append(failed, name)
+			continue
+		}
+		removed = append(removed, name)
+	}
+	return removed, failed
+}
+
+// InstalledFrameworkNames returns the unique names of frameworks that have a
+// removable definition file on disk (user-defined or store-installed). Built-in
+// frameworks are excluded: their definitions live in the binary, so what is on
+// disk is only an overlay we never prune away.
+func InstalledFrameworkNames() []string {
+	seen := make(map[string]bool)
+	var names []string
+
+	collect := func(dir string) {
+		matches, _ := filepath.Glob(filepath.Join(dir, "*.yaml"))
+		for _, m := range matches {
+			base := strings.TrimSuffix(filepath.Base(m), ".yaml")
+			if i := strings.IndexByte(base, '@'); i != -1 {
+				base = base[:i]
+			}
+			if base == "" || seen[base] || IsBuiltinFramework(base) {
+				continue
+			}
+			seen[base] = true
+			names = append(names, base)
+		}
+	}
+
+	collect(FrameworksDir())
+	collect(StoreFrameworksDir())
+	sort.Strings(names)
+	return names
 }
 
 // RemoveFrameworkFile removes a single framework definition file.

--- a/internal/config/framework_test.go
+++ b/internal/config/framework_test.go
@@ -337,3 +337,113 @@ func TestValidatePublicDir(t *testing.T) {
 		}
 	}
 }
+
+// ── SitesUsingFramework / InstalledFrameworkNames ────────────────────────────
+
+func TestSitesUsingFramework(t *testing.T) {
+	setConfigDir(t)
+
+	reg := &SiteRegistry{Sites: []Site{
+		{Name: "shop", Framework: "laravel"},
+		{Name: "blog", Framework: "wordpress"},
+		{Name: "api", Framework: "laravel"},
+		{Name: "static", Framework: ""},
+	}}
+	if err := SaveSites(reg); err != nil {
+		t.Fatalf("SaveSites: %v", err)
+	}
+
+	got := SitesUsingFramework("laravel")
+	if len(got) != 2 || got[0] != "shop" || got[1] != "api" {
+		t.Errorf("SitesUsingFramework(laravel) = %v, want [shop api]", got)
+	}
+	if got := SitesUsingFramework("symfony"); len(got) != 0 {
+		t.Errorf("SitesUsingFramework(symfony) = %v, want empty", got)
+	}
+}
+
+func TestSitesUsingFramework_IgnoresUnlinkedParkedEntries(t *testing.T) {
+	setConfigDir(t)
+
+	reg := &SiteRegistry{Sites: []Site{
+		{Name: "served", Framework: "wordpress"},
+		{Name: "parked", Framework: "wordpress", Ignored: true},
+	}}
+	if err := SaveSites(reg); err != nil {
+		t.Fatalf("SaveSites: %v", err)
+	}
+
+	got := SitesUsingFramework("wordpress")
+	if len(got) != 1 || got[0] != "served" {
+		t.Errorf("SitesUsingFramework(wordpress) = %v, want [served]", got)
+	}
+}
+
+func TestInstalledFrameworkNames_ExcludesBuiltins(t *testing.T) {
+	setConfigDir(t)
+
+	user := FrameworksDir()
+	os.MkdirAll(user, 0755)
+	os.WriteFile(filepath.Join(user, "custom.yaml"), []byte("name: custom\n"), 0644)
+	os.WriteFile(filepath.Join(user, "laravel.yaml"), []byte("name: laravel\n"), 0644)
+
+	store := StoreFrameworksDir()
+	os.MkdirAll(store, 0755)
+	os.WriteFile(filepath.Join(store, "symfony.yaml"), []byte("name: symfony\n"), 0644)
+	os.WriteFile(filepath.Join(store, "symfony@7.yaml"), []byte("name: symfony\nversion: \"7\"\n"), 0644)
+	os.WriteFile(filepath.Join(store, "wordpress@6.yaml"), []byte("name: wordpress\n"), 0644)
+
+	got := InstalledFrameworkNames()
+	want := []string{"custom", "wordpress"}
+	if len(got) != len(want) {
+		t.Fatalf("InstalledFrameworkNames() = %v, want %v (built-ins laravel/symfony must be excluded)", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("InstalledFrameworkNames()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestUnusedInstalledFrameworks(t *testing.T) {
+	setConfigDir(t)
+
+	store := StoreFrameworksDir()
+	os.MkdirAll(store, 0755)
+	os.WriteFile(filepath.Join(store, "wordpress.yaml"), []byte("name: wordpress\n"), 0644)
+	os.WriteFile(filepath.Join(store, "drupal.yaml"), []byte("name: drupal\n"), 0644)
+
+	reg := &SiteRegistry{Sites: []Site{
+		{Name: "blog", Framework: "wordpress"},
+		{Name: "old", Framework: "drupal", Ignored: true},
+	}}
+	if err := SaveSites(reg); err != nil {
+		t.Fatalf("SaveSites: %v", err)
+	}
+
+	got := UnusedInstalledFrameworks()
+	if len(got) != 1 || got[0] != "drupal" {
+		t.Errorf("UnusedInstalledFrameworks() = %v, want [drupal]", got)
+	}
+}
+
+func TestListFrameworkFiles_IncludesUserVersioned(t *testing.T) {
+	setConfigDir(t)
+
+	user := FrameworksDir()
+	os.MkdirAll(user, 0755)
+	versioned := filepath.Join(user, "drupal@10.yaml")
+	os.WriteFile(versioned, []byte("name: drupal\nversion: \"10\"\n"), 0644)
+
+	files := ListFrameworkFiles("drupal")
+	if len(files) != 1 || files[0].Path != versioned || files[0].Version != "10" {
+		t.Fatalf("ListFrameworkFiles(drupal) = %+v, want the user-dir drupal@10 file", files)
+	}
+
+	if err := RemoveFramework("drupal"); err != nil {
+		t.Fatalf("RemoveFramework: %v", err)
+	}
+	if _, err := os.Stat(versioned); !os.IsNotExist(err) {
+		t.Error("expected user-dir versioned file to be removed")
+	}
+}

--- a/internal/mcp/groups.go
+++ b/internal/mcp/groups.go
@@ -181,6 +181,7 @@ var groupDispatch = map[string]map[string]handlerFn{
 		"remove":      execFrameworkRemove,
 		"search":      execFrameworkSearch,
 		"install":     execFrameworkInstall,
+		"prune":       func(a map[string]any) (any, *rpcError) { return execFrameworkPrune(a) },
 		"project_new": execProjectNew,
 		"setup":       execSetup,
 	},
@@ -444,12 +445,13 @@ func execTool() mcpTool {
 func frameworkTool() mcpTool {
 	return mcpTool{
 		Name:        "framework",
-		Description: "Framework definitions and scaffolding. action: list, add (name=laravel merges into built-in), remove, search (community store), install, project_new (scaffold), setup (run post-install steps — MANDATORY after env setup).",
+		Description: "Framework definitions and scaffolding. action: list, add (name=laravel merges into built-in), remove (force=true overrides in-use guard), prune (remove unused defs), search (store), install, project_new (scaffold), setup (post-install steps, MANDATORY after env setup).",
 		InputSchema: mcpSchema{
 			Type: "object",
 			Properties: map[string]mcpProp{
-				"action":              {Type: "string", Enum: []string{"list", "add", "remove", "search", "install", "project_new", "setup"}},
+				"action":              {Type: "string", Enum: []string{"list", "add", "remove", "prune", "search", "install", "project_new", "setup"}},
 				"name":                {Type: "string", Description: "add/remove/install: framework slug."},
+				"force":               {Type: "boolean", Description: "remove: delete even if a site uses it."},
 				"label":               {Type: "string", Description: "add: human-readable name."},
 				"public_dir":          {Type: "string", Description: "add: document root."},
 				"detect_files":        {Type: "array", Description: "add: filenames that signal this framework."},

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3628,6 +3628,8 @@ func execFrameworkRemove(args map[string]any) (any, *rpcError) {
 		return toolOK("Custom Laravel worker additions removed. Built-in queue/schedule/reverb workers remain."), nil
 	}
 
+	// Version-specific removal deletes one cached definition, not the framework,
+	// so the name-level in-use guard does not apply.
 	if version != "" {
 		files := config.ListFrameworkFiles(name)
 		for _, f := range files {
@@ -3641,13 +3643,43 @@ func execFrameworkRemove(args map[string]any) (any, *rpcError) {
 		return toolErr(fmt.Sprintf("framework %q version %q not found", name, version)), nil
 	}
 
+	// Built-in frameworks keep working from the binary definition after their
+	// overlay is removed, so only third-party definitions need the guard.
+	if !boolArg(args, "force") && !config.IsBuiltinFramework(name) {
+		if sites := config.SitesUsingFramework(name); len(sites) > 0 {
+			return toolErr(fmt.Sprintf("framework %q is still used by: %s. Pass force=true to remove it anyway.",
+				name, strings.Join(sites, ", "))), nil
+		}
+	}
+
 	if err := config.RemoveFramework(name); err != nil {
 		if os.IsNotExist(err) {
 			return toolErr(fmt.Sprintf("framework %q not found", name)), nil
 		}
 		return toolErr(fmt.Sprintf("removing framework: %v", err)), nil
 	}
-	return toolOK(fmt.Sprintf("Framework %q removed.", name)), nil
+	note := ""
+	if config.IsBuiltinFramework(name) {
+		note = " (built-in definition remains)"
+	}
+	return toolOK(fmt.Sprintf("Framework %q removed%s.", name, note)), nil
+}
+
+func execFrameworkPrune(_ map[string]any) (any, *rpcError) {
+	unused := config.UnusedInstalledFrameworks()
+	if len(unused) == 0 {
+		return toolOK("No unused frameworks to prune."), nil
+	}
+
+	removed, failed := config.RemoveFrameworks(unused)
+	if len(removed) == 0 {
+		return toolErr(fmt.Sprintf("could not prune any of: %s", strings.Join(failed, ", "))), nil
+	}
+	msg := fmt.Sprintf("Pruned %d unused framework(s): %s.", len(removed), strings.Join(removed, ", "))
+	if len(failed) > 0 {
+		msg += fmt.Sprintf(" Failed: %s.", strings.Join(failed, ", "))
+	}
+	return toolOK(msg), nil
 }
 
 func execFrameworkSearch(args map[string]any) (any, *rpcError) {


### PR DESCRIPTION
Installed framework definitions pile up in the store as you try things out, and there was no way to clear out the ones nothing references. This adds lerd framework prune, which lists the installed definitions no active site uses and removes them after you confirm, with --force to skip the prompt. Pruning is safe because lerd re-fetches a definition from the store the moment a site needs one that is missing locally, so anything pruned comes back on its own.

Removing a framework that a site still depends on used to happen silently. Now lerd framework remove names the sites still using it and asks before deleting, again with --force to override. Built-in frameworks skip the guard since their binary definition keeps a site working after an overlay is removed, and the message says so. Version-specific removals are left unguarded because they only drop one cached definition rather than the framework itself. Unlinking the last site that used a framework now also offers to remove its definition right then.

Usage is read from the active sites in the registry, ignoring parked entries that were unlinked, and built-in definitions are never offered for removal. The CLI and the MCP framework tool share the same prune and guard logic, and the registry is loaded once per prune rather than once per framework.

Closes #623