### PR TITLE
Warn about busy host ports before lerd install runs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -46,13 +46,18 @@ After install, reload your shell or open a new terminal so `PATH` takes effect.
 
 `lerd install` will:
 
-1. Create XDG config and data directories
-2. Create the `lerd` Podman network
-3. Download static binaries: Composer, fnm, mkcert
-4. Install the mkcert CA into your system trust store
-5. Write and start the `lerd-dns` and `lerd-nginx` Podman Quadlet containers
-6. Enable the `lerd-watcher` background service (auto-discovers new projects)
-7. Add `~/.local/share/lerd/bin` to your shell's `PATH`
+1. Check that the host ports lerd binds first (HTTP 80, HTTPS 443, DNS 5300) are free
+2. Create XDG config and data directories
+3. Create the `lerd` Podman network
+4. Download static binaries: Composer, fnm, mkcert
+5. Install the mkcert CA into your system trust store
+6. Write and start the `lerd-dns` and `lerd-nginx` Podman Quadlet containers
+7. Enable the `lerd-watcher` background service (auto-discovers new projects)
+8. Add `~/.local/share/lerd/bin` to your shell's `PATH`
+
+::: info Running alongside Laravel Herd or another local stack
+If another tool is already serving sites on ports 80/443 (Laravel Herd, a system nginx/Apache) or holding the DNS port, install prints a warning naming each busy port and how to find the process. Install still continues, so stop the other stack to free the ports first, otherwise `lerd-nginx` and `lerd-dns` will fail to start.
+:::
 
 ---
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -67,6 +67,46 @@ func fileChangedBy(path string, mutate func() error) (bool, error) {
 	return string(after) != string(before), nil
 }
 
+// portPreflightConflicts returns the core host ports lerd needs to bind first
+// (nginx HTTP/HTTPS and DNS) that are already held by a foreign process.
+// portList is the host listener dump from PortListOutput; the seams mirror
+// checkPortConflicts so lerd's own running container, an already-answering
+// dnsmasq, and the macOS gvproxy forward are not reported as conflicts.
+func portPreflightConflicts(portList string, containerRunning func(string) bool, dnsAnswering func() bool) []PortCheck {
+	var conflicts []PortCheck
+	for _, c := range CollectPortChecks([]string{"lerd-nginx", "lerd-dns"}) {
+		if isPortConflict(c, portList, containerRunning, dnsAnswering) {
+			conflicts = append(conflicts, c)
+		}
+	}
+	return conflicts
+}
+
+// ensurePortsAvailable warns, before any setup work runs, when a core port lerd
+// needs is already taken by a foreign process. The usual culprit is a parallel
+// local-dev stack such as Laravel Herd or a system nginx/Apache holding 80/443.
+// It is advisory only: install continues so a user who knows the conflict (or
+// plans to remap lerd's ports) isn't blocked.
+func ensurePortsAvailable() {
+	step("Checking required host ports")
+	portList := PortListOutput()
+	if portList == "" {
+		ok()
+		return
+	}
+	conflicts := portPreflightConflicts(portList, podmanContainerRunning, lerdDNSAnswering)
+	if len(conflicts) == 0 {
+		ok()
+		return
+	}
+	fmt.Println()
+	for _, c := range conflicts {
+		feedback.Warn("port %s (%s) is already in use, %s may fail to start", c.Port, c.Label, c.Container)
+		feedback.Note("find it: " + FindListenerCmd(c.Port))
+	}
+	feedback.Note("another local stack such as Laravel Herd may be hosting sites; stop it to free these ports, then re-run lerd install")
+}
+
 func runInstall(cmd *cobra.Command, _ []string) error {
 	feedback.Header("Installing Lerd")
 
@@ -89,6 +129,8 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	healMachineRestartIfNeeded(preEnsureLastUp)
+
+	ensurePortsAvailable()
 
 	if err := ensureUnprivilegedPorts(); err != nil {
 		return err

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -37,6 +37,60 @@ func TestIsShell_empty(t *testing.T) {
 	}
 }
 
+func TestPortPreflightConflicts(t *testing.T) {
+	// Isolate config so nginx ports fall back to the 80/443 defaults and the
+	// DNS check is the fixed 5300, making CollectPortChecks deterministic.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	notRunning := func(string) bool { return false }
+	running := func(string) bool { return true }
+	dnsDown := func() bool { return false }
+	dnsUp := func() bool { return true }
+
+	hasPort := func(cs []PortCheck, port string) bool {
+		for _, c := range cs {
+			if c.Port == port {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("foreign listener on 80 is a conflict", func(t *testing.T) {
+		list := "herd-nginx 1234 herd 6u IPv4 TCP 0.0.0.0:80 (LISTEN)"
+		got := portPreflightConflicts(list, notRunning, dnsDown)
+		if !hasPort(got, "80") {
+			t.Fatalf("expected port 80 conflict, got %+v", got)
+		}
+	})
+
+	t.Run("lerd-nginx already running is not a conflict", func(t *testing.T) {
+		list := "conmon 1234 sdp 6u IPv4 TCP 0.0.0.0:80 (LISTEN)"
+		got := portPreflightConflicts(list, running, dnsUp)
+		if len(got) != 0 {
+			t.Fatalf("expected no conflicts when lerd owns the ports, got %+v", got)
+		}
+	})
+
+	t.Run("answering dnsmasq holding 5300 is not a conflict", func(t *testing.T) {
+		list := "dnsmasq 60498 sdp 5u IPv4 TCP 127.0.0.1:5300 (LISTEN)"
+		got := portPreflightConflicts(list, notRunning, dnsUp)
+		if hasPort(got, "5300") {
+			t.Fatalf("expected 5300 suppressed when dns is answering, got %+v", got)
+		}
+	})
+
+	t.Run("all ports free yields no conflicts", func(t *testing.T) {
+		got := portPreflightConflicts("", notRunning, dnsDown)
+		if len(got) != 0 {
+			t.Fatalf("expected no conflicts on an empty listener list, got %+v", got)
+		}
+	})
+}
+
 func TestEnsurePortForwarding(t *testing.T) {
 	// Should not error on any platform
 	if err := ensurePortForwarding(); err != nil {


### PR DESCRIPTION
lerd install only checked that prerequisite packages were present, never that the ports it needs to bind first were actually free. Anyone installing alongside Laravel Herd or a system nginx only found out about the clash once lerd-nginx or lerd-dns failed to start.

It now runs a port preflight right after the podman machine is up, before any setup work. It reuses the existing conflict toolkit so it flags a foreign listener on HTTP 80, HTTPS 443, or DNS 5300 while ignoring lerd's own running containers and the macOS gvproxy forward. The warning names each busy port and the command to find the process holding it, and it is advisory so the user is never hard-blocked.

Closes #627