### PR TITLE
Route all podman execution through a single seam

### DIFF
--- a/internal/cli/bug_report.go
+++ b/internal/cli/bug_report.go
@@ -186,12 +186,12 @@ func dumpConfigFiles(w io.Writer) {
 }
 
 func dumpRuntimes(w io.Writer) {
-	if out, err := exec.Command("podman", "--version").Output(); err == nil {
+	if out, err := podman.Cmd("--version").Output(); err == nil {
 		fmt.Fprintf(w, "podman:    %s", string(out))
 	} else {
 		fmt.Fprintln(w, "podman:    (not found)")
 	}
-	if out, err := exec.Command("podman", "info", "--format", "{{.Host.OCIRuntime.Name}} {{.Host.OCIRuntime.Version}}").Output(); err == nil {
+	if out, err := podman.Cmd("info", "--format", "{{.Host.OCIRuntime.Name}} {{.Host.OCIRuntime.Version}}").Output(); err == nil {
 		fmt.Fprintf(w, "OCI:       %s", string(out))
 	}
 	if cfg, err := config.LoadGlobal(); err == nil {

--- a/internal/cli/install_dns_linux.go
+++ b/internal/cli/install_dns_linux.go
@@ -4,7 +4,6 @@ package cli
 
 import (
 	"io"
-	"os/exec"
 	"strings"
 
 	"github.com/geodro/lerd/internal/podman"
@@ -25,8 +24,8 @@ func ensureDNSImageForStart() {
 	// Build the dnsmasq image if it doesn't exist. Ignore errors — the image
 	// will be pulled/built during RunParallel if missing.
 	containerfile := "FROM docker.io/library/alpine:latest\nRUN apk add --no-cache dnsmasq\n"
-	if exec.Command("podman", "image", "exists", "lerd-dnsmasq:local").Run() != nil {
-		cmd := exec.Command("podman", "build", "-t", "lerd-dnsmasq:local", "-")
+	if !podman.ImageExists("lerd-dnsmasq:local") {
+		cmd := podman.Cmd("build", "-t", "lerd-dnsmasq:local", "-")
 		cmd.Stdin = strings.NewReader(containerfile)
 		cmd.Run() //nolint:errcheck
 	}
@@ -38,7 +37,7 @@ func pullDNSImages() []BuildJob {
 		{
 			Label: "Pulling alpine:latest",
 			Run: func(w io.Writer) error {
-				cmd := exec.Command("podman", "pull", "docker.io/library/alpine:latest")
+				cmd := podman.Cmd("pull", "docker.io/library/alpine:latest")
 				cmd.Stdout = w
 				cmd.Stderr = w
 				return cmd.Run()
@@ -48,7 +47,7 @@ func pullDNSImages() []BuildJob {
 			Label: "Building dnsmasq image",
 			Run: func(w io.Writer) error {
 				containerfile := "FROM docker.io/library/alpine:latest\nRUN apk add --no-cache dnsmasq\n"
-				cmd := exec.Command("podman", "build", "-t", "lerd-dnsmasq:local", "-")
+				cmd := podman.Cmd("build", "-t", "lerd-dnsmasq:local", "-")
 				cmd.Stdin = strings.NewReader(containerfile)
 				cmd.Stdout = w
 				cmd.Stderr = w

--- a/internal/cli/machine_reset_darwin.go
+++ b/internal/cli/machine_reset_darwin.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/geodro/lerd/internal/feedback"
@@ -42,13 +41,13 @@ func runMachineReset(assumeYes bool) error {
 	}
 
 	feedback.Line(fmt.Sprintf("Stopping Podman Machine %q…", name))
-	stop := exec.Command(podman.PodmanBin(), "machine", "stop", name)
+	stop := podman.Cmd("machine", "stop", name)
 	stop.Stdout = os.Stdout
 	stop.Stderr = os.Stderr
 	_ = stop.Run() // a stopped machine still removes fine
 
 	feedback.Line(fmt.Sprintf("Removing Podman Machine %q…", name))
-	rm := exec.Command(podman.PodmanBin(), "machine", "rm", "-f", name)
+	rm := podman.Cmd("machine", "rm", "-f", name)
 	rm.Stdout = os.Stdout
 	rm.Stderr = os.Stderr
 	if err := rm.Run(); err != nil {

--- a/internal/cli/machine_restart_heal_darwin.go
+++ b/internal/cli/machine_restart_heal_darwin.go
@@ -4,7 +4,6 @@ package cli
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -24,7 +23,7 @@ func machineLastUpFile() string {
 // (default-marked, else first) so inspect targets the VM lerd actually
 // uses. Returns "" when no machine exists yet.
 func selectedMachineName() string {
-	out, err := exec.Command(podman.PodmanBin(), "machine", "list",
+	out, err := podman.Cmd("machine", "list",
 		"--format", "{{.Name}}").Output()
 	if err != nil {
 		return ""
@@ -58,7 +57,7 @@ func currentMachineLastUp() string {
 	if name == "" {
 		return ""
 	}
-	out, err := exec.Command(podman.PodmanBin(), "machine", "inspect",
+	out, err := podman.Cmd("machine", "inspect",
 		"--format", "{{.LastUp}}", name).Output()
 	if err != nil {
 		return ""
@@ -143,7 +142,7 @@ func forceRemoveLerdContainers(includeStopped bool, announce string) {
 	}
 	feedback.Line(announce)
 	args := append([]string{"rm", "-f"}, names...)
-	if out, err := exec.Command(podman.PodmanBin(), args...).CombinedOutput(); err != nil {
+	if out, err := podman.Cmd(args...).CombinedOutput(); err != nil {
 		feedback.Warn("podman rm -f failed: %v", err)
 		if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
 			feedback.Note(trimmed)

--- a/internal/cli/overlay_heal_darwin.go
+++ b/internal/cli/overlay_heal_darwin.go
@@ -4,7 +4,6 @@ package cli
 
 import (
 	"os"
-	"os/exec"
 
 	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
@@ -38,7 +37,7 @@ func restartPodmanMachineForHeal() {
 		return
 	}
 	feedback.Line("Container storage looks stale after an unclean shutdown; restarting the Podman Machine to remount it…")
-	stop := exec.Command(podman.PodmanBin(), "machine", "stop", name)
+	stop := podman.Cmd("machine", "stop", name)
 	stop.Stdout = os.Stdout
 	stop.Stderr = os.Stderr
 	if err := stop.Run(); err != nil {

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -149,19 +149,19 @@ func recreateBrokenMachine(name string, running bool, targetMemoryMiB int64) {
 	feedback.Line("Podman Machine is missing the host home mount; recreating it (can't be repaired in place)…")
 	feedback.Note("No running containers are affected; a machine in this state can't start any.")
 	if running {
-		stopCmd := exec.Command(podman.PodmanBin(), "machine", "stop", name)
+		stopCmd := podman.Cmd("machine", "stop", name)
 		stopCmd.Stdout = os.Stdout
 		stopCmd.Stderr = os.Stderr
 		stopCmd.Run() //nolint:errcheck
 	}
-	rmCmd := exec.Command(podman.PodmanBin(), "machine", "rm", "-f", name)
+	rmCmd := podman.Cmd("machine", "rm", "-f", name)
 	rmCmd.Stdout = os.Stdout
 	rmCmd.Stderr = os.Stderr
 	if err := rmCmd.Run(); err != nil {
 		feedback.Warn("podman machine rm: %v", err)
 		return
 	}
-	initCmd := exec.Command(podman.PodmanBin(), machineInitArgs(name, targetMemoryMiB)...)
+	initCmd := podman.Cmd(machineInitArgs(name, targetMemoryMiB)...)
 	initCmd.Stdout = os.Stdout
 	initCmd.Stderr = os.Stderr
 	if err := initCmd.Run(); err != nil {
@@ -178,7 +178,7 @@ func recreateBrokenMachine(name string, running bool, targetMemoryMiB int64) {
 // failures from every command that follows.
 func ensurePodmanMachineRunning() error {
 	// machine list only exposes Name and Running; use inspect for Rootful.
-	listOut, _ := exec.Command(podman.PodmanBin(), "machine", "list", "--format", "{{.Name}}\t{{.Running}}").Output()
+	listOut, _ := podman.Cmd("machine", "list", "--format", "{{.Name}}\t{{.Running}}").Output()
 
 	type machineInfo struct {
 		name    string
@@ -207,7 +207,7 @@ func ensurePodmanMachineRunning() error {
 
 		// Inspect to get Rootful status.
 		rootful := false
-		inspectOut, err := exec.Command(podman.PodmanBin(), "machine", "inspect", "--format", "{{.Rootful}}", name).Output()
+		inspectOut, err := podman.Cmd("machine", "inspect", "--format", "{{.Rootful}}", name).Output()
 		if err == nil {
 			rootful = strings.TrimSpace(string(inspectOut)) == "true"
 		}
@@ -236,7 +236,7 @@ func ensurePodmanMachineRunning() error {
 		cfg, _ := config.LoadGlobal()
 		execMode := cfg != nil && cfg.WorkerExecMode() != config.WorkerExecModeContainer
 		targetMemoryMiB := recommendedVMMemoryMiB(hostMemoryGiB(), execMode)
-		cmd := exec.Command(podman.PodmanBin(), machineInitArgs("", targetMemoryMiB)...)
+		cmd := podman.Cmd(machineInitArgs("", targetMemoryMiB)...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
@@ -262,7 +262,7 @@ func ensurePodmanMachineRunning() error {
 		} else {
 			needsRootful := !m.rootful
 			needsMemory := false
-			if inspectMem, err := exec.Command(podman.PodmanBin(), "machine", "inspect",
+			if inspectMem, err := podman.Cmd("machine", "inspect",
 				"--format", "{{.Resources.Memory}}", m.name).Output(); err == nil {
 				if memMiB, parseErr := strconv.ParseInt(strings.TrimSpace(string(inspectMem)), 10, 64); parseErr == nil && memMiB > 0 {
 					if memMiB < targetMemoryMiB {
@@ -282,14 +282,14 @@ func ensurePodmanMachineRunning() error {
 					}
 					reason := strings.Join(parts, " and ")
 					feedback.Line(fmt.Sprintf("Stopping Podman Machine to %s…", reason))
-					stopCmd := exec.Command(podman.PodmanBin(), "machine", "stop", m.name)
+					stopCmd := podman.Cmd("machine", "stop", m.name)
 					stopCmd.Stdout = os.Stdout
 					stopCmd.Stderr = os.Stderr
 					stopCmd.Run() //nolint:errcheck
 				}
 				if needsRootful {
 					feedback.Line("Enabling rootful mode for Podman Machine (required for ports 80/443)…")
-					setCmd := exec.Command(podman.PodmanBin(), "machine", "set", "--rootful", m.name)
+					setCmd := podman.Cmd("machine", "set", "--rootful", m.name)
 					setCmd.Stdout = os.Stdout
 					setCmd.Stderr = os.Stderr
 					if err := setCmd.Run(); err != nil {
@@ -303,7 +303,7 @@ func ensurePodmanMachineRunning() error {
 					} else {
 						feedback.Line(fmt.Sprintf("Setting Podman Machine memory to %d MB…", targetMemoryMiB))
 					}
-					setCmd := exec.Command(podman.PodmanBin(), "machine", "set",
+					setCmd := podman.Cmd("machine", "set",
 						"--memory", strconv.FormatInt(targetMemoryMiB, 10), m.name)
 					setCmd.Stdout = os.Stdout
 					setCmd.Stderr = os.Stderr
@@ -332,7 +332,7 @@ func ensurePodmanMachineRunning() error {
 	fmt.Printf(" %s %s", feedback.Dim("→"), feedback.Dim("Waiting for Podman Machine to be ready…"))
 	deadline := time.Now().Add(120 * time.Second)
 	for time.Now().Before(deadline) {
-		if err := exec.Command(podman.PodmanBin(), "ps", "-q").Run(); err == nil {
+		if err := podman.Cmd("ps", "-q").Run(); err == nil {
 			time.Sleep(3 * time.Second) // grace period before container ops
 			fmt.Println(" " + feedback.Green("ready"))
 			return nil
@@ -352,7 +352,7 @@ func ensurePodmanMachineRunning() error {
 // podman command cascade into confusing "exit status 125" errors.
 func startPodmanMachineWithRetry() error {
 	run := func() error {
-		cmd := exec.Command(podman.PodmanBin(), "machine", "start")
+		cmd := podman.Cmd("machine", "start")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		return cmd.Run()
@@ -384,7 +384,7 @@ func startPodmanMachineWithRetry() error {
 // stopPodmanMachine stops the running Podman Machine VM. Called by runQuit so
 // the VM is cleanly shut down when the user quits Lerd entirely.
 func stopPodmanMachine() {
-	out, err := exec.Command(podman.PodmanBin(), "machine", "list", "--format", "{{.Name}}\t{{.Running}}").Output()
+	out, err := podman.Cmd("machine", "list", "--format", "{{.Name}}\t{{.Running}}").Output()
 	if err != nil {
 		return
 	}
@@ -398,7 +398,7 @@ func stopPodmanMachine() {
 		}
 		name := strings.TrimSuffix(fields[0], "*")
 		feedback.Line(fmt.Sprintf("Stopping Podman Machine (%s)…", name))
-		cmd := exec.Command(podman.PodmanBin(), "machine", "stop", name)
+		cmd := podman.Cmd("machine", "stop", name)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {

--- a/internal/cli/tinker.go
+++ b/internal/cli/tinker.go
@@ -163,7 +163,7 @@ func RunTinker(ctx context.Context, sitePath, siteName, branch, code string) (Ti
 	}
 
 	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, podman.PodmanBin(), argv...)
+	cmd := podman.CmdContext(ctx, argv...)
 	if stdinPipe != "" {
 		cmd.Stdin = strings.NewReader(stdinPipe)
 	}

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -182,7 +182,7 @@ func confirmPurgeLerdImages() bool {
 // (mysql/redis/postgres/etc.) are left alone since they're expensive to
 // re-pull and not lerd-owned.
 func removeLerdImages() {
-	out, err := exec.Command(podman.PodmanBin(), "images", "--format", "{{.Repository}}:{{.Tag}}").Output()
+	out, err := podman.Cmd("images", "--format", "{{.Repository}}:{{.Tag}}").Output()
 	if err != nil {
 		feedback.Warn("listing images: %v", err)
 		return
@@ -195,7 +195,7 @@ func removeLerdImages() {
 		if !isLerdBuiltImage(line) {
 			continue
 		}
-		if err := exec.Command(podman.PodmanBin(), "image", "rm", "-f", line).Run(); err != nil {
+		if err := podman.Cmd("image", "rm", "-f", line).Run(); err != nil {
 			feedback.Warn("removing %s: %v", line, err)
 			continue
 		}

--- a/internal/cli/worker_migrate_darwin.go
+++ b/internal/cli/worker_migrate_darwin.go
@@ -4,7 +4,6 @@ package cli
 
 import (
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -124,7 +123,7 @@ func sweepOrphanWorkerContainers() {
 	if len(prefixes) == 0 {
 		return
 	}
-	out, err := exec.Command(podman.PodmanBin(), "ps", "-a", "--format", "{{.Names}}").Output()
+	out, err := podman.Cmd("ps", "-a", "--format", "{{.Names}}").Output()
 	if err != nil {
 		return
 	}

--- a/internal/dns/diagnose.go
+++ b/internal/dns/diagnose.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
 )
 
 // StepStatus is the outcome of a single rung in the layered DNS check.
@@ -308,7 +309,7 @@ func defaultContainerRunning() bool {
 	if err == nil && strings.TrimSpace(string(out)) == "active" {
 		return true
 	}
-	cmd := exec.Command("podman", "ps", "--filter", "name=^lerd-dns$", "--format", "{{.Names}}")
+	cmd := podman.Cmd("ps", "--filter", "name=^lerd-dns$", "--format", "{{.Names}}")
 	out, err = cmd.Output()
 	return err == nil && strings.TrimSpace(string(out)) == "lerd-dns"
 }

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -770,7 +769,7 @@ func reloadWithRetry(reload func() error, timeout time.Duration) error {
 func Test() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, podman.PodmanBin(), "exec", "lerd-nginx", "nginx", "-t")
+	cmd := podman.CmdContext(ctx, "exec", "lerd-nginx", "nginx", "-t")
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -196,7 +196,7 @@ func NeedsFPMRebuild(activeVersions []string) bool {
 // error (image missing, podman unreachable, label absent) so callers
 // treat that as "doesn't match" and fall back to a rebuild.
 func imageLabel(image, key string) string {
-	out, err := exec.Command(PodmanBin(), "inspect",
+	out, err := execCommand(PodmanBin(), "inspect",
 		"--format", "{{index .Config.Labels \""+key+"\"}}",
 		image,
 	).Output()
@@ -330,7 +330,7 @@ func tryPullBaseImage(version string, w io.Writer) string {
 		}
 		args = append(args, ref)
 
-		cmd := exec.Command(PodmanBin(), args...)
+		cmd := execCommand(PodmanBin(), args...)
 		cmd.Stdout = w
 		cmd.Stderr = io.Discard
 		if err := cmd.Run(); err == nil {
@@ -347,7 +347,7 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 
 	if !force {
 		// Skip if image already exists
-		if exec.Command(PodmanBin(), "image", "exists", imageName).Run() == nil {
+		if execCommand(PodmanBin(), "image", "exists", imageName).Run() == nil {
 			return nil
 		}
 	}
@@ -410,7 +410,7 @@ build:
 	}
 
 	buildArgs = append(buildArgs, "-f", cfPath, tmp)
-	cmd := exec.Command(PodmanBin(), buildArgs...)
+	cmd := execCommand(PodmanBin(), buildArgs...)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	if err := cmd.Run(); err != nil {
@@ -579,7 +579,7 @@ func phpExtensionLoaded(moduleOutput, ext string) bool {
 // in the custom-extension RUN block).
 func VerifyExtensionLoaded(version, ext string) error {
 	imageName := FPMImageName(version)
-	out, err := exec.Command(PodmanBin(), "run", "--rm", imageName, "php", "-m").CombinedOutput()
+	out, err := execCommand(PodmanBin(), "run", "--rm", imageName, "php", "-m").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("inspecting extensions in %s: %w\n%s", imageName, err, out)
 	}

--- a/internal/podman/custom_container.go
+++ b/internal/podman/custom_container.go
@@ -5,7 +5,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -139,7 +138,7 @@ func BuildCustomImage(siteName, projectPath string, cfg *config.ContainerConfig)
 	buildCtx := ResolveBuildContext(projectPath, cfg)
 	imageName := CustomImageName(siteName)
 
-	cmd := exec.Command(PodmanBin(), buildCustomImageArgs(imageName, containerfile, buildCtx, cfg)...)
+	cmd := execCommand(PodmanBin(), buildCustomImageArgs(imageName, containerfile, buildCtx, cfg)...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -158,7 +157,7 @@ func BuildCustomImageTo(siteName, projectPath string, cfg *config.ContainerConfi
 	buildCtx := ResolveBuildContext(projectPath, cfg)
 	imageName := CustomImageName(siteName)
 
-	cmd := exec.Command(PodmanBin(), buildCustomImageArgs(imageName, containerfile, buildCtx, cfg)...)
+	cmd := execCommand(PodmanBin(), buildCustomImageArgs(imageName, containerfile, buildCtx, cfg)...)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	if err := cmd.Run(); err != nil {
@@ -170,7 +169,7 @@ func BuildCustomImageTo(siteName, projectPath string, cfg *config.ContainerConfi
 // RemoveCustomImage removes the local image for a site's custom container.
 func RemoveCustomImage(siteName string) error {
 	imageName := CustomImageName(siteName)
-	_ = exec.Command(PodmanBin(), "rmi", "-f", imageName).Run()
+	_ = execCommand(PodmanBin(), "rmi", "-f", imageName).Run()
 	return nil
 }
 
@@ -206,5 +205,5 @@ func ContainerBaseImage(projectPath string, cfg *config.ContainerConfig) string 
 // container (force-remove to handle edge cases).
 func RemoveCustomContainer(siteName string) {
 	name := CustomContainerName(siteName)
-	_ = exec.Command(PodmanBin(), "rm", "-f", name).Run()
+	_ = execCommand(PodmanBin(), "rm", "-f", name).Run()
 }

--- a/internal/podman/exec.go
+++ b/internal/podman/exec.go
@@ -2,6 +2,7 @@ package podman
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,14 @@ import (
 	"github.com/geodro/lerd/internal/config"
 )
 
+// execCommand and execCommandContext are the single seam every podman
+// invocation in this package is built on. Tests override them to fake the
+// shell-out; the no-direct-exec guard keeps callers outside from bypassing it.
+var (
+	execCommand        = exec.Command
+	execCommandContext = exec.CommandContext
+)
+
 // ShellQuote single-quotes s so it is safe as one argument inside an
 // `sh -c` command string. Embedded single quotes are closed, escaped, reopened.
 func ShellQuote(s string) string {
@@ -20,6 +29,7 @@ func ShellQuote(s string) string {
 
 // PodmanBin returns the full path to the podman binary. On macOS it searches
 // well-known Homebrew locations when PATH is restricted (e.g. launchd services).
+// Resolved fresh each call: tests override PATH per-case to force a fake binary.
 func PodmanBin() string {
 	if p, err := exec.LookPath("podman"); err == nil {
 		return p
@@ -38,12 +48,18 @@ func PodmanBin() string {
 // Cmd returns an exec.Cmd for podman with the given arguments, using PodmanBin()
 // so the binary is found even under launchd's restricted PATH.
 func Cmd(args ...string) *exec.Cmd {
-	return exec.Command(PodmanBin(), args...)
+	return execCommand(PodmanBin(), args...)
+}
+
+// CmdContext is Cmd bound to a context, for callers that stream output or need
+// cancellation (log tailing, nginx -t with a timeout, container migration).
+func CmdContext(ctx context.Context, args ...string) *exec.Cmd {
+	return execCommandContext(ctx, PodmanBin(), args...)
 }
 
 // Run executes podman with the given arguments and returns stdout.
 func Run(args ...string) (string, error) {
-	cmd := exec.Command(PodmanBin(), args...)
+	cmd := execCommand(PodmanBin(), args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -99,15 +115,22 @@ func pullArgs(image string) []string {
 	return append(args, image)
 }
 
-// PullImageTo pulls the named image, writing progress output to w.
-func PullImageTo(image string, w io.Writer) error {
-	cmd := exec.Command(PodmanBin(), pullArgs(image)...)
-	cmd.Stdout = w
-	cmd.Stderr = w
+// runPull builds and runs `podman pull image`, sending podman's stdout and
+// stderr to the given writers so the three entry points share one error-wrap
+// and one platform-aware argv (pullArgs).
+func runPull(image string, stdout, stderr io.Writer) error {
+	cmd := Cmd(pullArgs(image)...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("pulling %s: %w", image, err)
 	}
 	return nil
+}
+
+// PullImageTo pulls the named image, writing progress output to w.
+func PullImageTo(image string, w io.Writer) error {
+	return runPull(image, w, w)
 }
 
 // PullImageWithProgress pulls the named image and invokes onLine for each
@@ -116,12 +139,9 @@ func PullImageWithProgress(image string, onLine func(string)) error {
 	if onLine == nil {
 		return PullImageIfMissing(image)
 	}
-	cmd := exec.Command(PodmanBin(), pullArgs(image)...)
 	w := &lineWriter{onLine: onLine}
-	cmd.Stdout = w
-	cmd.Stderr = w
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("pulling %s: %w", image, err)
+	if err := runPull(image, w, w); err != nil {
+		return err
 	}
 	w.flush()
 	return nil
@@ -164,13 +184,7 @@ func PullImageIfMissing(image string) error {
 	if ImageExists(image) {
 		return nil
 	}
-	cmd := exec.Command(PodmanBin(), pullArgs(image)...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("pulling %s: %w", image, err)
-	}
-	return nil
+	return runPull(image, os.Stdout, os.Stderr)
 }
 
 // ServiceImage returns the OCI image name embedded in a named quadlet template.

--- a/internal/podman/exec_test.go
+++ b/internal/podman/exec_test.go
@@ -1,6 +1,14 @@
 package podman
 
-import "testing"
+import (
+	"context"
+	"os"
+	"os/exec"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
 
 func TestShellQuote(t *testing.T) {
 	cases := []struct {
@@ -41,5 +49,116 @@ func TestServiceVersionLabel(t *testing.T) {
 				t.Errorf("ServiceVersionLabel(%q) = %q, want %q", tt.image, got, tt.want)
 			}
 		})
+	}
+}
+
+// fakeExec returns a drop-in for execCommand that re-executes the test binary
+// as a helper process emitting the given stdout/stderr and exit code, so the
+// exec helpers can be exercised without a real podman on the host.
+func fakeExec(stdout, stderr string, exit int) func(string, ...string) *exec.Cmd {
+	return func(name string, args ...string) *exec.Cmd {
+		cs := append([]string{"-test.run=TestHelperProcess", "--", name}, args...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_HELPER_PROCESS=1",
+			"HELPER_STDOUT="+stdout,
+			"HELPER_STDERR="+stderr,
+			"HELPER_EXIT="+strconv.Itoa(exit),
+		)
+		return cmd
+	}
+}
+
+// TestHelperProcess is not a real test; it's the child process spawned by
+// fakeExec. It echoes the configured streams and exits with the wanted code.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	if s := os.Getenv("HELPER_STDOUT"); s != "" {
+		os.Stdout.WriteString(s)
+	}
+	if s := os.Getenv("HELPER_STDERR"); s != "" {
+		os.Stderr.WriteString(s)
+	}
+	code, _ := strconv.Atoi(os.Getenv("HELPER_EXIT"))
+	os.Exit(code)
+}
+
+func TestCmdUsesPodmanBinAndArgs(t *testing.T) {
+	cmd := Cmd("machine", "stop", "lerd")
+	want := []string{PodmanBin(), "machine", "stop", "lerd"}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Errorf("Cmd args = %v, want %v", cmd.Args, want)
+	}
+}
+
+func TestCmdContextPassesContextAndArgs(t *testing.T) {
+	type ctxKey struct{}
+	var gotCtx context.Context
+	var gotName string
+	var gotArgs []string
+
+	prev := execCommandContext
+	t.Cleanup(func() { execCommandContext = prev })
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		gotCtx, gotName, gotArgs = ctx, name, args
+		return prev(ctx, name, args...)
+	}
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, "v")
+	_ = CmdContext(ctx, "logs", "-f", "lerd-nginx")
+
+	if gotCtx == nil || gotCtx.Value(ctxKey{}) != "v" {
+		t.Error("CmdContext did not pass the context through")
+	}
+	if gotName != PodmanBin() {
+		t.Errorf("CmdContext binary = %q, want %q", gotName, PodmanBin())
+	}
+	if want := []string{"logs", "-f", "lerd-nginx"}; !reflect.DeepEqual(gotArgs, want) {
+		t.Errorf("CmdContext args = %v, want %v", gotArgs, want)
+	}
+}
+
+func TestRunTrimsStdout(t *testing.T) {
+	prev := execCommand
+	t.Cleanup(func() { execCommand = prev })
+	execCommand = fakeExec("  hello world \n", "", 0)
+
+	got, err := Run("ps")
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got != "hello world" {
+		t.Errorf("Run = %q, want %q", got, "hello world")
+	}
+}
+
+func TestRunWrapsErrorWithStderr(t *testing.T) {
+	prev := execCommand
+	t.Cleanup(func() { execCommand = prev })
+	execCommand = fakeExec("", "boom: no such container", 1)
+
+	_, err := Run("inspect", "nope")
+	if err == nil {
+		t.Fatal("Run expected an error, got nil")
+	}
+	if msg := err.Error(); !strings.Contains(msg, "boom: no such container") || !strings.Contains(msg, "inspect nope") {
+		t.Errorf("Run error = %q, want it to mention args and stderr", msg)
+	}
+}
+
+func TestRunSilentReturnsExecErrors(t *testing.T) {
+	prev := execCommand
+	t.Cleanup(func() { execCommand = prev })
+
+	execCommand = fakeExec("", "", 0)
+	if err := RunSilent("ok"); err != nil {
+		t.Errorf("RunSilent on exit 0 = %v, want nil", err)
+	}
+
+	execCommand = fakeExec("", "fail", 2)
+	if err := RunSilent("bad"); err == nil {
+		t.Error("RunSilent on exit 2 = nil, want error")
 	}
 }

--- a/internal/podman/frankenphp_build.go
+++ b/internal/podman/frankenphp_build.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -142,7 +141,7 @@ func buildFrankenPHPImage(version string, force bool, customExts, packages []str
 		return fmt.Errorf("hashing FrankenPHP Containerfile: %w", err)
 	}
 	if !force {
-		if exec.Command(PodmanBin(), "image", "exists", imageName).Run() == nil &&
+		if execCommand(PodmanBin(), "image", "exists", imageName).Run() == nil &&
 			imageLabelFn(imageName, frankenPHPContainerfileHashLabel) == hash {
 			return nil // image exists and is current
 		}
@@ -178,7 +177,7 @@ func buildFrankenPHPImage(version string, force bool, customExts, packages []str
 		args = append(args, "--no-cache")
 	}
 	args = append(args, "-f", cfPath, tmp)
-	cmd := exec.Command(PodmanBin(), args...)
+	cmd := execCommand(PodmanBin(), args...)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	if err := cmd.Run(); err != nil {

--- a/internal/podman/hosts.go
+++ b/internal/podman/hosts.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -207,7 +206,7 @@ func ReadHostGatewayFromFile() string {
 // probeHostFromNginx returns true if lerd-nginx can open a TCP connection to
 // ip:port within 2 seconds. Uses busybox nc (-z = scan only, -w = timeout).
 func probeHostFromNginx(ip, port string) bool {
-	cmd := exec.Command(PodmanBin(), "exec", "lerd-nginx", "nc", "-z", "-w", "2", ip, port)
+	cmd := execCommand(PodmanBin(), "exec", "lerd-nginx", "nc", "-z", "-w", "2", ip, port)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	// Cap total wall time so a hung exec doesn't block lerd start.
@@ -233,7 +232,7 @@ func ContainerRunningQuiet(name string) bool {
 }
 
 func parseHostGatewayFromExec(container string) string {
-	out, err := exec.Command(PodmanBin(), "exec", container,
+	out, err := execCommand(PodmanBin(), "exec", container,
 		"getent", "hosts", "host.containers.internal").Output()
 	if err != nil {
 		return ""
@@ -242,7 +241,7 @@ func parseHostGatewayFromExec(container string) string {
 }
 
 func parseHostGatewayFromProbe() string {
-	out, err := exec.Command(PodmanBin(), "run", "--rm", "--network", "lerd",
+	out, err := execCommand(PodmanBin(), "run", "--rm", "--network", "lerd",
 		"docker.io/library/alpine", "getent", "hosts", "host.containers.internal").Output()
 	if err != nil {
 		return ""
@@ -263,7 +262,7 @@ func firstField(s string) string {
 // nginxContainerIP returns the IP address of lerd-nginx on the lerd Podman
 // network. Falls back to 127.0.0.1 if the container isn't running.
 func nginxContainerIP() string {
-	out, err := exec.Command(PodmanBin(), "inspect", "lerd-nginx",
+	out, err := execCommand(PodmanBin(), "inspect", "lerd-nginx",
 		"--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}").Output()
 	if err != nil {
 		return "127.0.0.1"

--- a/internal/podman/network.go
+++ b/internal/podman/network.go
@@ -68,11 +68,11 @@ func HostHasUsableIPv6() bool {
 // both v4 and v6 subnets, returns the v4 gateway (which most callers expect
 // for backwards compatibility).
 func NetworkGateway(name string) string {
-	out, err := exec.Command(PodmanBin(), "network", "inspect", name,
+	out, err := execCommand(PodmanBin(), "network", "inspect", name,
 		"--format", "{{range .Subnets}}{{if (.Gateway).To4}}{{.Gateway}}{{end}}{{end}}").Output()
 	if err != nil || strings.TrimSpace(string(out)) == "" {
 		// Fallback for older podman that doesn't expose .To4 in the template.
-		out, err = exec.Command(PodmanBin(), "network", "inspect", name,
+		out, err = execCommand(PodmanBin(), "network", "inspect", name,
 			"--format", "{{range .Subnets}}{{.Gateway}} {{end}}").Output()
 		if err != nil {
 			return "127.0.0.1"
@@ -90,7 +90,7 @@ func NetworkGateway(name string) string {
 // NetworkHasIPv6 reports whether the named podman network has at least one
 // IPv6 subnet configured.
 func NetworkHasIPv6(name string) bool {
-	out, err := exec.Command(PodmanBin(), "network", "inspect", name,
+	out, err := execCommand(PodmanBin(), "network", "inspect", name,
 		"--format", "{{range .Subnets}}{{.Subnet}} {{end}}").Output()
 	if err != nil {
 		return false
@@ -262,7 +262,7 @@ const probeNetworkIPv6Timeout = 30 * time.Second
 func probeNetworkIPv6(name string) (ok, timedOut bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), probeNetworkIPv6Timeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, PodmanBin(), "run", "--rm", "--network", name,
+	cmd := execCommandContext(ctx, PodmanBin(), "run", "--rm", "--network", name,
 		"--pull", "never", "alpine:latest", "true")
 	out, err := cmd.CombinedOutput()
 	if err == nil {

--- a/internal/podman/no_direct_exec_test.go
+++ b/internal/podman/no_direct_exec_test.go
@@ -1,0 +1,188 @@
+package podman
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestNoDirectPodmanExec enforces the single-seam invariant: outside this
+// package nothing may build a podman exec directly. Every call must go through
+// podman.Cmd/CmdContext/Run/RunSilent. Systemd ExecStart and launchd plist
+// argv are fine (systemd/launchd runs those, not Go), so only exec.Command and
+// exec.CommandContext calls whose binary argument denotes podman are flagged.
+func TestNoDirectPodmanExec(t *testing.T) {
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("resolving repo root: %v", err)
+	}
+
+	var offenders []string
+	fset := token.NewFileSet()
+	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() {
+			if shouldSkipDir(root, path, info) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			// Unparseable scratch files aren't ours to police.
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		offenders = append(offenders, scanFileForDirectPodmanExec(fset, file, rel)...)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+
+	if len(offenders) > 0 {
+		t.Errorf("found %d direct podman exec(s) outside internal/podman; route them through podman.Cmd/CmdContext/Run/RunSilent:\n  %s",
+			len(offenders), strings.Join(offenders, "\n  "))
+	}
+}
+
+// shouldSkipDir prunes the walk: the seam package itself, VCS/build/dependency
+// trees, hidden and testdata dirs, and any nested module (its own go.mod) so a
+// stray sibling checkout at the repo root can't fail this package's tests.
+func shouldSkipDir(root, path string, info os.FileInfo) bool {
+	if path == root {
+		return false
+	}
+	base := info.Name()
+	switch base {
+	case ".git", "node_modules", "vendor", "worktrees", "build", "testdata":
+		return true
+	}
+	if strings.HasPrefix(base, ".") {
+		return true
+	}
+	if path == filepath.Join(root, "internal", "podman") {
+		return true
+	}
+	if _, err := os.Stat(filepath.Join(path, "go.mod")); err == nil {
+		return true
+	}
+	return false
+}
+
+// scanFileForDirectPodmanExec returns "<rel>:<line>" for every exec.Command /
+// exec.CommandContext call whose binary argument is a podman binary (a "podman"
+// literal, a PodmanBin()/podmanBinPath() call, or a local var bound to either).
+func scanFileForDirectPodmanExec(fset *token.FileSet, file *ast.File, rel string) []string {
+	binVars := podmanBinVars(file)
+	var out []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		kind := execCallKind(call.Fun)
+		if kind == "" {
+			return true
+		}
+		binIdx := 0
+		if kind == "CommandContext" {
+			binIdx = 1
+		}
+		if binIdx >= len(call.Args) {
+			return true
+		}
+		if isPodmanBinExpr(call.Args[binIdx], binVars) {
+			line := fset.Position(call.Pos()).Line
+			out = append(out, rel+":"+strconv.Itoa(line))
+		}
+		return true
+	})
+	return out
+}
+
+// execCallKind returns "Command" or "CommandContext" when fun is exec.Command /
+// exec.CommandContext, else "".
+func execCallKind(fun ast.Expr) string {
+	sel, ok := fun.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "exec" {
+		return ""
+	}
+	if sel.Sel.Name == "Command" || sel.Sel.Name == "CommandContext" {
+		return sel.Sel.Name
+	}
+	return ""
+}
+
+// podmanBinVars collects local identifiers assigned a podman binary expression
+// (bin := PodmanBin(), p := "podman", …) so indirected execs are still caught.
+func podmanBinVars(file *ast.File) map[string]bool {
+	vars := map[string]bool{}
+	record := func(lhs []ast.Expr, rhs []ast.Expr) {
+		if len(lhs) != len(rhs) {
+			return
+		}
+		for i, l := range lhs {
+			id, ok := l.(*ast.Ident)
+			if !ok || id.Name == "_" {
+				continue
+			}
+			if isPodmanBinExpr(rhs[i], nil) {
+				vars[id.Name] = true
+			}
+		}
+	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch s := n.(type) {
+		case *ast.AssignStmt:
+			record(s.Lhs, s.Rhs)
+		case *ast.ValueSpec:
+			lhs := make([]ast.Expr, len(s.Names))
+			for i, nm := range s.Names {
+				lhs[i] = nm
+			}
+			record(lhs, s.Values)
+		}
+		return true
+	})
+	return vars
+}
+
+// isPodmanBinExpr reports whether expr denotes the podman binary: the "podman"
+// string literal, a PodmanBin()/podmanBinPath() call, or a var in binVars.
+func isPodmanBinExpr(expr ast.Expr, binVars map[string]bool) bool {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		return e.Kind == token.STRING && e.Value == `"podman"`
+	case *ast.CallExpr:
+		return isPodmanBinFunc(e.Fun)
+	case *ast.Ident:
+		return binVars[e.Name]
+	}
+	return false
+}
+
+func isPodmanBinFunc(fun ast.Expr) bool {
+	name := ""
+	switch f := fun.(type) {
+	case *ast.Ident:
+		name = f.Name
+	case *ast.SelectorExpr:
+		name = f.Sel.Name
+	}
+	return name == "PodmanBin" || name == "podmanBinPath"
+}

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -124,7 +124,7 @@ func RemoveQuadlet(name string) error {
 // RemoveContainer removes a stopped Podman container by name, ignoring errors
 // if the container does not exist.
 func RemoveContainer(name string) {
-	_ = exec.Command(PodmanBin(), "rm", "-f", name).Run()
+	_ = execCommand(PodmanBin(), "rm", "-f", name).Run()
 }
 
 // AfterQuadletWriteFn, if non-nil, is called by WriteQuadletDiff after
@@ -318,22 +318,22 @@ func WaitReady(service string, timeout time.Duration) error {
 	case "mysql":
 		args := append([]string{"exec", unit}, mysqlReadyArgs...)
 		probe = func() bool {
-			return exec.Command(PodmanBin(), args...).Run() == nil
+			return execCommand(PodmanBin(), args...).Run() == nil
 		}
 	case "mariadb":
 		args := append([]string{"exec", unit}, mariadbReadyArgs...)
 		probe = func() bool {
-			return exec.Command(PodmanBin(), args...).Run() == nil
+			return execCommand(PodmanBin(), args...).Run() == nil
 		}
 	case "postgres":
 		probe = func() bool {
-			cmd := exec.Command(PodmanBin(), "exec", unit,
+			cmd := execCommand(PodmanBin(), "exec", unit,
 				"pg_isready", "-U", "postgres")
 			return cmd.Run() == nil
 		}
 	case "redis":
 		probe = func() bool {
-			cmd := exec.Command(PodmanBin(), "exec", unit,
+			cmd := execCommand(PodmanBin(), "exec", unit,
 				"redis-cli", "ping")
 			return cmd.Run() == nil
 		}

--- a/internal/podman/quadlet_embed.go
+++ b/internal/podman/quadlet_embed.go
@@ -3,7 +3,6 @@ package podman
 import (
 	"embed"
 	"fmt"
-	"os/exec"
 	"strings"
 )
 
@@ -166,7 +165,7 @@ func InjectExtraVolumes(content string, paths []string) string {
 
 // OCIRuntime returns the name of the OCI runtime podman is currently configured to use.
 func OCIRuntime() string {
-	out, err := exec.Command(PodmanBin(), "info", "--format", "{{.Host.OCIRuntime.Name}}").Output()
+	out, err := execCommand(PodmanBin(), "info", "--format", "{{.Host.OCIRuntime.Name}}").Output()
 	if err != nil {
 		return ""
 	}

--- a/internal/podman/version.go
+++ b/internal/podman/version.go
@@ -2,7 +2,6 @@ package podman
 
 import (
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 	"sync"
@@ -65,7 +64,7 @@ func defaultSupportsContainerStopTimeoutKey() bool {
 	stopTimeoutOnce.Do(func() {
 		// Use PodmanBin() so the probe still resolves under launchd's
 		// restricted PATH on macOS, where "podman" alone misses Homebrew.
-		out, err := exec.Command(PodmanBin(), "--version").Output()
+		out, err := execCommand(PodmanBin(), "--version").Output()
 		if err != nil {
 			// Conservative fallback: PodmanArgs= works on every quadlet
 			// version, while StopTimeout= breaks <5.0. Better to use the

--- a/internal/serviceops/migrate.go
+++ b/internal/serviceops/migrate.go
@@ -130,7 +130,7 @@ func containerExec(container, shellCmd string, envPairs []string, stdin *os.File
 		args = append(args, "--env", kv)
 	}
 	args = append(args, container, "sh", "-c", shellCmd)
-	cmd := exec.CommandContext(ctx, podman.PodmanBin(), args...)
+	cmd := podman.CmdContext(ctx, args...)
 	if stdin != nil {
 		cmd.Stdin = stdin
 	}
@@ -153,7 +153,7 @@ func dumpToHost(container, shellCmd string, envPairs []string, hostPath string, 
 		args = append(args, "--env", kv)
 	}
 	args = append(args, container, "sh", "-c", shellCmd)
-	cmd := exec.CommandContext(ctx, podman.PodmanBin(), args...)
+	cmd := podman.CmdContext(ctx, args...)
 	if err := runStreaming(cmd, out); err != nil {
 		return fmt.Errorf("dump command failed: %w", err)
 	}
@@ -187,7 +187,7 @@ func restoreFromHost(container, shellCmd string, envPairs []string, hostPath str
 		args = append(args, "--env", kv)
 	}
 	args = append(args, container, "sh", "-c", shellCmd)
-	cmd := exec.CommandContext(ctx, podman.PodmanBin(), args...)
+	cmd := podman.CmdContext(ctx, args...)
 	cmd.Stdin = in
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -279,20 +279,6 @@ func expandSpecifiers(s string) string {
 	return strings.ReplaceAll(s, "%h", home)
 }
 
-// podmanBinPath returns the path to the podman binary.
-func podmanBinPath() string {
-	if p, err := exec.LookPath("podman"); err == nil {
-		return p
-	}
-	// Homebrew default locations
-	for _, candidate := range []string{"/opt/homebrew/bin/podman", "/usr/local/bin/podman"} {
-		if _, err := os.Stat(candidate); err == nil {
-			return candidate
-		}
-	}
-	return "podman"
-}
-
 // stripSELinuxVolOpts removes SELinux relabelling flags (:z, :Z) from a
 // volume mount spec. On macOS with Podman Machine the source path is a
 // virtiofs mount and SELinux relabelling is unsupported; passing :z causes
@@ -384,7 +370,7 @@ func stripIPv6PublishPorts(content string) string {
 // On macOS we run detached (-d) so that launchctl bootstrap sees an immediate
 // exit 0 (success); podman's own --restart=always policy handles crash recovery.
 func containerToPodmanArgs(c map[string][]string) ([]string, error) {
-	args := []string{podmanBinPath(), "run", "-d", "--restart=always"}
+	args := []string{podman.PodmanBin(), "run", "-d", "--restart=always"}
 
 	if names := c["ContainerName"]; len(names) > 0 {
 		// --replace removes any stale container with this name before starting.
@@ -751,8 +737,8 @@ func (m *darwinServiceManager) Stop(name string) error {
 	// Skipping the podman calls when the container is absent avoids flooding the
 	// Podman Machine SSH socket with N parallel no-op requests during lerd stop.
 	if running, _ := podman.ContainerRunning(name); running {
-		exec.Command(podmanBinPath(), "stop", "-t", "5", name).Run() //nolint:errcheck
-		exec.Command(podmanBinPath(), "rm", "-f", name).Run()        //nolint:errcheck
+		podman.Cmd("stop", "-t", "5", name).Run() //nolint:errcheck
+		podman.Cmd("rm", "-f", name).Run()        //nolint:errcheck
 	}
 
 	domain := uidDomain()
@@ -777,8 +763,8 @@ func (m *darwinServiceManager) Restart(name string) error {
 	// of launchd. Stop it explicitly so the restart is clean even if
 	// --replace is ever removed from the podman run args.
 	if running, _ := podman.ContainerRunning(name); running {
-		exec.Command(podmanBinPath(), "stop", "-t", "5", name).Run() //nolint:errcheck
-		exec.Command(podmanBinPath(), "rm", "-f", name).Run()        //nolint:errcheck
+		podman.Cmd("stop", "-t", "5", name).Run() //nolint:errcheck
+		podman.Cmd("rm", "-f", name).Run()        //nolint:errcheck
 	}
 
 	domain := uidDomain()

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -7,7 +7,6 @@ package stats
 import (
 	"bufio"
 	"context"
-	"os/exec"
 	"runtime"
 	"sort"
 	"strconv"
@@ -212,9 +211,9 @@ func SetHostReader(fn func() ([]ContainerStat, error)) (restore func()) {
 func readPodmanStats() ([]ContainerStat, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), readTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(
+	cmd := podman.CmdContext(
 		ctx,
-		podman.PodmanBin(), "stats", "--interval", "1",
+		"stats", "--interval", "1",
 		"--format", "{{.Name}}|{{.CPU}}|{{.MemUsage}}|{{.MemPerc}}",
 	)
 	stdout, err := cmd.StdoutPipe()

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -31,7 +31,7 @@ func runShellIn(container, workDir string) tea.Cmd {
 		args = append(args, "-w", workDir)
 	}
 	args = append(args, container, "sh", "-c", podman.InteractiveShellScript())
-	cmd := exec.Command(podman.PodmanBin(), args...)
+	cmd := podman.Cmd(args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/tui/log_tail.go
+++ b/internal/tui/log_tail.go
@@ -130,7 +130,7 @@ func (t *logTail) run(ctx context.Context, target LogTarget, ch chan<- string) {
 		// the same scrollback as the podman/journal variants.
 		cmd = exec.CommandContext(ctx, "tail", "-n", "200", "-F", target.ID)
 	default:
-		cmd = exec.CommandContext(ctx, podman.PodmanBin(), "logs", "-f", "--tail", "200", target.ID)
+		cmd = podman.CmdContext(ctx, "logs", "-f", "--tail", "200", target.ID)
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/ui/logs_darwin.go
+++ b/internal/ui/logs_darwin.go
@@ -23,7 +23,7 @@ func isContainerUnit(unit string) bool { return unitlog.IsContainerUnit(unit) }
 
 func serviceRecentLogs(unit string) string {
 	if isContainerUnit(unit) {
-		out, err := exec.Command(podman.PodmanBin(), "logs", "--tail", "20", unit).CombinedOutput()
+		out, err := podman.Cmd("logs", "--tail", "20", unit).CombinedOutput()
 		if err != nil {
 			return ""
 		}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -4224,7 +4224,7 @@ func handleLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pr, pw := io.Pipe()
-	cmd := exec.CommandContext(streamCtx, podman.PodmanBin(), "logs", "-f", "--tail", tail, container)
+	cmd := podman.CmdContext(streamCtx, "logs", "-f", "--tail", tail, container)
 	cmd.Stdout = pw
 	cmd.Stderr = pw
 


### PR DESCRIPTION
lerd talked to podman from around 145 call sites with no common chokepoint for the binary path or error formatting, and a handful hardcoded the literal "podman" string, which skips the macOS Homebrew and launchd PATH resolution that PodmanBin() provides. This makes internal/podman the single component that executes podman.

Cmd, Run and RunSilent now funnel through one private execCommand seam, and a new CmdContext covers the callers that stream output or need cancellation like log tailing, the nginx -t probe and container migration. Every stray call site across cli, dns, nginx, serviceops, services, stats, tui and ui is migrated onto those helpers. The systemd ExecStart and launchd argv interpolations are left as they are since systemd and launchd run those, not Go.

A guard keeps any file outside the package from building a podman exec directly and bypassing the seam.

Closes #630