### PR TITLE
Recover idle-suspended workers whose marking was lost on reinstall

### DIFF
--- a/docs/usage/idle-suspend.md
+++ b/docs/usage/idle-suspend.md
@@ -37,6 +37,8 @@ All of them. When a site goes idle, lerd stops every worker it runs — queue, s
 
 Suspension is graceful: workers receive `SIGTERM` and finish their current job before exiting, and Laravel's job reservation/retry covers anything in flight, so no jobs are lost.
 
+A suspended worker's unit is removed entirely, so the only record that it is asleep (rather than simply off) is the persisted list. If that list is ever lost while the units stay gone, which replacing the lerd binary mid-session can do, the watcher re-marks the affected workers as suspended on its next evaluation, reading the site's declared workers from `.lerd.yaml`, so they show as sleeping again instead of off. It only re-marks a worker whose unit is gone entirely (idle-suspend's own signature); one that merely crashed or stopped keeps its unit and is left to the usual worker-healing, and one you genuinely stopped or removed is dropped from `.lerd.yaml`, so neither is revived this way.
+
 **Vite is a special case.** Stopping the Vite dev server makes Laravel's `@vite` directive fall back to the built asset manifest, so before suspending Vite lerd runs `npm run build` (once, if no usable build exists) and clears `public/hot`. A sleeping site then serves built assets instead of a broken page. If a build can't be produced, Vite is left running for that site.
 
 ## Pinning a site

--- a/internal/cli/idle_engine.go
+++ b/internal/cli/idle_engine.go
@@ -9,17 +9,28 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/siteinfo"
 )
 
+// unitStatesFn snapshots every lerd-* unit's state; a var so tests can pin which
+// units exist. A worker absent from it has had its unit removed entirely, which
+// is idle-suspend's signature (it removes units, not just stops them).
+var unitStatesFn = siteinfo.AllUnitStates
+
 // SuspendWorkersForIdle stops ALL of the site's running workers (queue, Horizon,
-// scheduler, Stripe, vite, ...) and returns the names it stopped, for the caller
-// to persist as Site.IdleSuspendedWorkers. An idle site does no background work.
+// scheduler, Stripe, vite, ...) and returns the names to persist as
+// Site.IdleSuspendedWorkers. An idle site does no background work.
 //
 // Vite is the one special case: stopping it makes Laravel's @vite directive fall
 // back to the built asset manifest, so a site with no build would serve a broken
 // page. So before sleeping we ensure a usable build exists (running `npm run
 // build` if missing) and clear public/hot; if no build can be produced, vite is
 // left running for that site. Idempotent.
+//
+// The returned set also includes declared workers whose unit was removed entirely
+// (see appendLostSuspended), so an idle site whose persisted suspended list was
+// wiped while its units stayed gone (e.g. a reinstall) is re-marked as sleepy
+// rather than left showing as "off" with no way for the engine to recover it.
 func SuspendWorkersForIdle(site *config.Site) []string {
 	running := collectRunningWorkers(site)
 
@@ -43,6 +54,34 @@ func SuspendWorkersForIdle(site *config.Site) []string {
 		}
 		stopWorkerByName(site, w)
 		suspended = append(suspended, w)
+	}
+	return appendLostSuspended(site, suspended)
+}
+
+// appendLostSuspended adds any of the site's declared workers (.lerd.yaml) whose
+// systemd unit is gone entirely and that are resumable. A removed unit is
+// idle-suspend's own signature, so such a worker is one whose persisted
+// "suspended" marking was lost (e.g. a reinstall cleared the list) while its unit
+// stayed gone; re-listing it restores the sleeping state instead of leaving it
+// showing as "off". A worker that merely crashed or stopped still has its unit
+// (active/failed/inactive), so it is left to worker-healing; one the user stopped
+// or removed is dropped from .lerd.yaml entirely, so neither is ever re-marked.
+func appendLostSuspended(site *config.Site, suspended []string) []string {
+	proj, err := config.LoadProjectConfig(site.Path)
+	if err != nil || proj == nil {
+		return suspended
+	}
+	states := unitStatesFn()
+	for _, w := range proj.Workers {
+		if containsString(suspended, w) {
+			continue
+		}
+		if _, unitExists := states["lerd-"+w+"-"+site.Name]; unitExists {
+			continue // unit still present -> not idle-suspend's doing, leave it alone
+		}
+		if idleWorkerResumable(site, w) {
+			suspended = append(suspended, w)
+		}
 	}
 	return suspended
 }

--- a/internal/cli/idle_test.go
+++ b/internal/cli/idle_test.go
@@ -3,11 +3,13 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/siteinfo"
 )
 
 // stubUnitStatus reports the units in active as running and everything else as
@@ -224,6 +226,106 @@ func TestIdleSuspendStateIsStale(t *testing.T) {
 	site.IdleSuspendedWorkers = nil
 	if IdleSuspendStateIsStale(site) {
 		t.Error("empty suspended set is never stale")
+	}
+}
+
+// appendLostSuspended must re-mark declared workers whose unit was removed
+// entirely (idle-suspend's signature, so their marking was lost while asleep),
+// while never touching a worker whose unit still exists (running, crashed, or
+// merely stopped — left to worker-healing), a duplicate, an orphan with no
+// framework definition, or a worker the user removed from .lerd.yaml.
+func TestAppendLostSuspended(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	dir := filepath.Join(tmp, "site")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	proj, err := config.LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proj.CustomWorkers = map[string]config.FrameworkWorker{
+		"queue":   {Command: "php artisan queue:work"},
+		"horizon": {Command: "php artisan horizon"},
+	}
+	proj.Workers = []string{"queue", "horizon", "stripe", "some-orphan"}
+	if err := config.SaveProjectConfig(dir, proj); err != nil {
+		t.Fatal(err)
+	}
+	site := &config.Site{Name: "site", Framework: "laravel", Path: dir}
+
+	// present pins which units still exist (any state); a worker keyed here is
+	// treated as not idle-suspended and must be left alone.
+	present := map[string]string{}
+	t.Cleanup(func() { unitStatesFn = siteinfo.AllUnitStates })
+	unitStatesFn = func() map[string]string { return present }
+
+	// All declared+resumable units removed -> all re-marked; the orphan is skipped.
+	if got := appendLostSuspended(site, nil); !slices.Equal(got, []string{"queue", "horizon", "stripe"}) {
+		t.Errorf("all-removed: got %v, want [queue horizon stripe]", got)
+	}
+	// A worker whose unit still exists (e.g. crashed/failed) is not re-marked, so
+	// worker-healing still sees it instead of it being masked as sleeping.
+	present = map[string]string{"lerd-queue-site": "failed"}
+	if got := appendLostSuspended(site, nil); !slices.Equal(got, []string{"horizon", "stripe"}) {
+		t.Errorf("queue unit present: got %v, want [horizon stripe]", got)
+	}
+	// An already-listed worker isn't duplicated; the rest are appended.
+	present = map[string]string{}
+	if got := appendLostSuspended(site, []string{"horizon"}); !slices.Equal(got, []string{"horizon", "queue", "stripe"}) {
+		t.Errorf("horizon pre-listed: got %v, want [horizon queue stripe]", got)
+	}
+
+	// A worker the user removed is gone from .lerd.yaml, so it is never re-marked
+	// even though its unit is absent like a sleepy one.
+	proj.Workers = []string{"queue"}
+	if err := config.SaveProjectConfig(dir, proj); err != nil {
+		t.Fatal(err)
+	}
+	if got := appendLostSuspended(site, nil); !slices.Equal(got, []string{"queue"}) {
+		t.Errorf("undeclared worker must not be re-marked: got %v, want [queue]", got)
+	}
+}
+
+// SuspendWorkersForIdle must return declared workers whose unit was removed so an
+// idle site whose persisted list was wiped (units already gone) is re-marked as
+// sleepy rather than stranded showing "off". No worker is running here, so nothing
+// is stopped; the result is purely the recovered set.
+func TestSuspendWorkersForIdle_remarksAbsent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	dir := filepath.Join(tmp, "site")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	proj, err := config.LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proj.CustomWorkers = map[string]config.FrameworkWorker{"queue": {Command: "php artisan queue:work"}}
+	proj.Workers = []string{"queue"}
+	if err := config.SaveProjectConfig(dir, proj); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		podman.UnitLifecycle = nil
+		unitStatesFn = siteinfo.AllUnitStates
+	})
+	podman.UnitLifecycle = stubUnitStatus{active: map[string]bool{}}       // nothing running
+	unitStatesFn = func() map[string]string { return map[string]string{} } // queue unit removed
+
+	site := &config.Site{Name: "site", Framework: "laravel", Path: dir}
+	if got := SuspendWorkersForIdle(site); len(got) != 1 || got[0] != "queue" {
+		t.Errorf("SuspendWorkersForIdle = %v, want [queue] (re-marked from .lerd.yaml)", got)
 	}
 }
 


### PR DESCRIPTION
When idle-suspend puts a worker to sleep it removes the worker's systemd unit entirely, so the only record that the worker is asleep rather than simply off is the per-site `idle_suspended_workers` list. Replacing the lerd binary mid-session can wipe that list while the units stay gone (the watcher's boot reconcile clears a site's whole list as soon as one of its workers drifts back to running). After that the workers show as off in the dashboard, and the engine can never bring them back on its own because it only ever suspends workers that are currently running, so an already-stopped, unmarked worker is invisible to it.

`SuspendWorkersForIdle` now also re-marks any worker declared in the site's `.lerd.yaml` whose unit was removed entirely, which is idle-suspend's own signature. An idle site therefore re-establishes the sleeping state on its next evaluation instead of leaving the workers stranded off, and they resume on the next activity like any other suspended worker.

The recovery is deliberately precise. It keys on the unit being gone, not merely down, so a worker that crashed or stopped keeps its unit and is left to worker-healing rather than being masked as sleeping, and a worker you stopped or removed is dropped from `.lerd.yaml` by those commands, so neither is ever revived this way. Per-worktree workers are out of scope here since they have no `.lerd.yaml` declared-worker manifest to key off.

Refs #632
