### PR TITLE
release: v1.26.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,18 @@ Lerd uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.26.1] - 2026-06-26
+
+A patch release fixing a silent fallback that made most Linux hosts rebuild every PHP image from source, alongside cherry-picked fixes for macOS LAN exposure, setup feedback, and host-worker reporting.
+
+### Fixed
+
+- **Prebuilt PHP base images are pulled on podman below 5.0 instead of silently building from source** (#638). lerd pulled the base with `podman pull --policy=always`, but `--policy` only exists on podman 5.0+, so on Ubuntu 24.04 (4.9.3), 22.04 (3.4.4) and Debian 12 (4.3.1) the flag was rejected; the pull's stderr was discarded, so the failure was invisible and lerd quietly fell back to the full local build even when a matching prebuilt base was published. The flag is now gated behind a podman 5.0 check and the pull error surfaces in the fallback message.
+- **`lerd setup` reports npm and bun build failures instead of killing the process** (#622). A failed install returns through the feedback step rather than calling `os.Exit`, so the failure shows in context.
+- **Host workers whose dependencies aren't installed surface a remedy instead of dropping silently** (#616), and `lerd update`'s service restarts route through the feedback layer, warning rather than erroring when a best-effort restart doesn't take.
+- **macOS LAN exposure keeps published ports and no longer double-binds the DNS forwarder** (#618, #619). Bind-all IPv6 publish lines are rewritten to `0.0.0.0` rather than dropped so `lan.exposed` containers keep their ports, and the LAN DNS forwarder is skipped where the host dnsmasq already binds the LAN address.
+- **Docs: the host database override example uses `host.containers.internal`** (#626).
+
 ## [1.26.0] - 2026-06-24
 
 This release brings lerd's one-line installer to macOS, rebuilds the dashboard's editors on Monaco with a real PHP language server behind Tinker, reshapes the terminal UI into a clickable tabbed dashboard, and gives the whole CLI a styled feedback layer. The same `curl … | install.sh` one-liner that installs on Linux now installs on macOS, and `lerd update` self-updates there too. Every in-browser editor moves from CodeMirror to Monaco, and Tinker's autocomplete, diagnostics, hover, quick fixes and formatting now come from phpantom_lsp analysing the real project rather than static lists, with each statement's executed SQL captured inline and results tagged to the line that produced them. `lerd tui` becomes a mouse-driven, tabbed Dashboard/Sites/Services interface that mirrors the web UI, and the CLI routes through a shared feedback palette with spinners, aligned summaries, responsive tables and a unified error style that all degrade to plain text when piped. Linking is smarter, an unlinked project is offered the init wizard rather than dead-ending and non-PHP projects are handled, DNS gains pinnable upstream servers and heals across host network changes, postgres-timescaledb joins the presets, and the website moves to its lerd.sh home with a rebuilt landing page. Alongside the features, a focused security pass closes name-injection, root-write and websocket-rebinding holes, and DNS healing, TLS cert swaps, podman startup and MCP output get hardened.

--- a/docs/features/env-setup.md
+++ b/docs/features/env-setup.md
@@ -87,14 +87,16 @@ lerd env
 The one reserved key, `LERD_EXTERNAL_SERVICES`, lists services lerd should treat as externally managed (you run your own instance). For each named service lerd still writes its connection variables into `.env`, but it does **not** start the container and does **not** create the project database or S3 bucket. Combine it with the connection overrides that point at your own instance:
 
 ```dotenv
-# .env.lerd_override — point this project at my host postgres
-DB_HOST=127.0.0.1
+# .env.lerd_override: point this project at a host (system) database
+DB_HOST=host.containers.internal
 DB_PORT=5432
 DB_USERNAME=postgres
 DB_PASSWORD=mysecret
 
 LERD_EXTERNAL_SERVICES=postgres
 ```
+
+Use `host.containers.internal` for the host rather than `127.0.0.1`. The override is read inside the PHP-FPM container, where `127.0.0.1` is the container's own loopback, not your machine. lerd keeps a `host.containers.internal` entry in the container that resolves to the host, so a containerized app reaches a host MySQL, MariaDB or Postgres over it with no extra setup. For MySQL use `DB_PORT=3306`.
 
 The value is comma or space separated, so `LERD_EXTERNAL_SERVICES=postgres, redis` opts both out. The reserved key is consumed by lerd and is never written into `.env`.
 

--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -104,23 +104,70 @@ func EnableLANExposure(progress LANProgressFunc) (lanIP string, err error) {
 			return "", err
 		}
 
-		if err := preflightForwarderPort(lanIP, emit); err != nil {
+		if err := ensureLANForwarder(lanIP, emit); err != nil {
 			return "", err
-		}
-
-		emit("Installing lerd-dns-forwarder.service")
-		if err := installDNSForwarderUnit(lanIP); err != nil {
-			return "", fmt.Errorf("installing dns forwarder: %w", err)
-		}
-
-		emit("Starting lerd-dns-forwarder")
-		if err := reloadAndRestartUnit("lerd-dns-forwarder"); err != nil {
-			return "", fmt.Errorf("starting dns forwarder: %w", err)
 		}
 	}
 
 	emit("Done — lerd is reachable on " + lanIP)
 	return lanIP, nil
+}
+
+// ensureLANForwarder installs the host-side LAN DNS forwarder when the platform
+// needs it. The forwarder is the Linux rootless-pasta workaround: there the
+// lerd-dns container cannot bind the host LAN address, so a forwarder bridges
+// lanIP:5300 → 127.0.0.1:5300. On macOS lerd-dns is a host dnsmasq that already
+// binds all interfaces (including lanIP), so installing a forwarder would
+// double-bind lanIP:5300 and crash lerd-dns; there this is a no-op.
+func ensureLANForwarder(lanIP string, emit func(string)) error {
+	if lerdDNSBindsLANPort {
+		if emit != nil {
+			emit("lerd-dns binds the LAN address directly; no forwarder needed")
+		}
+		return nil
+	}
+	return installLANForwarderFn(lanIP, emit)
+}
+
+// installAndStartForwarder runs the preflight, installs the lerd-dns-forwarder
+// unit, and starts it. Default implementation behind installLANForwarderFn.
+func installAndStartForwarder(lanIP string, emit func(string)) error {
+	if err := preflightForwarderPort(lanIP, emit); err != nil {
+		return err
+	}
+	if emit != nil {
+		emit("Installing lerd-dns-forwarder.service")
+	}
+	if err := installDNSForwarderUnit(lanIP); err != nil {
+		return fmt.Errorf("installing dns forwarder: %w", err)
+	}
+	if emit != nil {
+		emit("Starting lerd-dns-forwarder")
+	}
+	if err := reloadAndRestartUnit("lerd-dns-forwarder"); err != nil {
+		return fmt.Errorf("starting dns forwarder: %w", err)
+	}
+	return nil
+}
+
+// ensureLANForwarderRemoved tears down the LAN DNS forwarder, the mirror of
+// ensureLANForwarder. Unlike the install side it intentionally runs on every
+// platform: macOS no longer installs a forwarder, but a Mac upgrading from an
+// older build (which did) still needs unexpose to clear that stale unit, or it
+// keeps holding lanIP:5300 and breaks .test resolution. Removing a missing unit
+// is ignored, so this is a safe no-op when no forwarder is present.
+func ensureLANForwarderRemoved(emit func(string)) error {
+	if emit != nil {
+		emit("Stopping lerd-dns-forwarder")
+	}
+	_ = services.Mgr.Stop("lerd-dns-forwarder")
+	_ = services.Mgr.Disable("lerd-dns-forwarder")
+	if err := services.Mgr.RemoveServiceUnit("lerd-dns-forwarder"); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing forwarder unit: %w", err)
+	}
+	_ = services.Mgr.DaemonReload()
+
+	return nil
 }
 
 // DisableLANExposure flips lerd back to the safe loopback default. Inverts
@@ -159,13 +206,9 @@ func DisableLANExposure(progress LANProgressFunc) error {
 	}
 
 	if cfg.DNS.Enabled {
-		emit("Stopping lerd-dns-forwarder")
-		_ = services.Mgr.Stop("lerd-dns-forwarder")
-		_ = services.Mgr.Disable("lerd-dns-forwarder")
-		if err := services.Mgr.RemoveServiceUnit("lerd-dns-forwarder"); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("removing forwarder unit: %w", err)
+		if err := ensureLANForwarderRemoved(emit); err != nil {
+			return err
 		}
-		_ = services.Mgr.DaemonReload()
 
 		emit("Reverting dnsmasq to 127.0.0.1")
 		if err := dns.WriteDnsmasqConfigFor(config.DnsmasqDir(), "127.0.0.1"); err != nil {
@@ -231,6 +274,17 @@ var (
 		s, _ := services.Mgr.UnitStatus("lerd-dns-forwarder")
 		return s
 	}
+	// lerdDNSBindsLANPort is true on platforms where the main lerd-dns daemon
+	// binds lanIP:5300 itself (macOS host dnsmasq) instead of via the separate
+	// lerd-dns-forwarder (the Linux rootless-pasta workaround). On such
+	// platforms LAN exposure must NOT install the forwarder: it would
+	// double-bind lanIP:5300 and crash lerd-dns. Seam so both models are
+	// testable from any build host.
+	lerdDNSBindsLANPort = runtime.GOOS == "darwin"
+	// installLANForwarderFn installs and starts the host-side LAN DNS
+	// forwarder. Seam so the macOS skip can be asserted without touching real
+	// units.
+	installLANForwarderFn = installAndStartForwarder
 	forwarderPortFreeFn   = forwarderPortFree
 	forwarderPortHolderFn = forwarderPortHolderLsof
 )

--- a/internal/cli/dns_preflight_test.go
+++ b/internal/cli/dns_preflight_test.go
@@ -1,10 +1,37 @@
 package cli
 
 import (
+	"errors"
 	"net"
+	"os"
 	"strings"
 	"testing"
 )
+
+// forwarderRemoveRecorder records the teardown calls ensureLANForwarderRemoved
+// makes and lets a test inject a RemoveServiceUnit error.
+type forwarderRemoveRecorder struct {
+	fakeServiceMgr
+	calls     []string
+	removeErr error
+}
+
+func (r *forwarderRemoveRecorder) Stop(name string) error {
+	r.calls = append(r.calls, "stop:"+name)
+	return nil
+}
+func (r *forwarderRemoveRecorder) Disable(name string) error {
+	r.calls = append(r.calls, "disable:"+name)
+	return nil
+}
+func (r *forwarderRemoveRecorder) RemoveServiceUnit(name string) error {
+	r.calls = append(r.calls, "remove:"+name)
+	return r.removeErr
+}
+func (r *forwarderRemoveRecorder) DaemonReload() error {
+	r.calls = append(r.calls, "reload")
+	return nil
+}
 
 func TestPreflightForwarderPort_OwnUnitActiveSkipsCheck(t *testing.T) {
 	prevStatus := forwarderUnitStatusFn
@@ -101,6 +128,111 @@ func TestPreflightForwarderPort_PortInUseSurfacesHolder(t *testing.T) {
 		if !strings.Contains(msg, want) {
 			t.Errorf("error message missing %q\nfull message: %s", want, msg)
 		}
+	}
+}
+
+func TestEnsureLANForwarder_DarwinSkipsForwarderInstall(t *testing.T) {
+	// macOS model: lerd-dns binds the LAN address directly, so installing the
+	// forwarder would double-bind lanIP:5300 and crash lerd-dns. It must be
+	// skipped entirely.
+	prevBinds := lerdDNSBindsLANPort
+	prevInstall := installLANForwarderFn
+	t.Cleanup(func() {
+		lerdDNSBindsLANPort = prevBinds
+		installLANForwarderFn = prevInstall
+	})
+
+	lerdDNSBindsLANPort = true
+	installLANForwarderFn = func(string, func(string)) error {
+		t.Error("forwarder must not be installed when lerd-dns binds the LAN port directly")
+		return nil
+	}
+
+	var events []string
+	if err := ensureLANForwarder("192.168.1.10", func(s string) { events = append(events, s) }); err != nil {
+		t.Errorf("ensureLANForwarder should be a no-op on the macOS model, got %v", err)
+	}
+	if len(events) == 0 || !strings.Contains(events[0], "no forwarder needed") {
+		t.Errorf("expected a progress line explaining the skip, got %v", events)
+	}
+}
+
+func TestEnsureLANForwarder_NonDarwinInstallsForwarder(t *testing.T) {
+	// Linux model: lerd-dns can't bind the host LAN port, so the forwarder is
+	// required and must be installed.
+	prevBinds := lerdDNSBindsLANPort
+	prevInstall := installLANForwarderFn
+	t.Cleanup(func() {
+		lerdDNSBindsLANPort = prevBinds
+		installLANForwarderFn = prevInstall
+	})
+
+	lerdDNSBindsLANPort = false
+	called := false
+	installLANForwarderFn = func(lanIP string, _ func(string)) error {
+		called = true
+		if lanIP != "192.168.1.10" {
+			t.Errorf("forwarder installed with wrong lanIP %q", lanIP)
+		}
+		return nil
+	}
+
+	if err := ensureLANForwarder("192.168.1.10", nil); err != nil {
+		t.Errorf("ensureLANForwarder should install the forwarder on the Linux model, got %v", err)
+	}
+	if !called {
+		t.Error("expected the forwarder to be installed on the Linux model")
+	}
+}
+
+func TestEnsureLANForwarderRemoved_TearsDownUnit(t *testing.T) {
+	// Teardown stops, disables, removes, then daemon-reloads, naming the
+	// forwarder unit at each step, and emits a progress line.
+	rec := &forwarderRemoveRecorder{}
+	swapMgr(t, rec)
+
+	var events []string
+	if err := ensureLANForwarderRemoved(func(s string) { events = append(events, s) }); err != nil {
+		t.Fatalf("ensureLANForwarderRemoved: unexpected error %v", err)
+	}
+
+	want := []string{
+		"stop:lerd-dns-forwarder",
+		"disable:lerd-dns-forwarder",
+		"remove:lerd-dns-forwarder",
+		"reload",
+	}
+	if !equalStrings(rec.calls, want) {
+		t.Errorf("teardown calls: got %v want %v", rec.calls, want)
+	}
+	if len(events) == 0 || !strings.Contains(events[0], "lerd-dns-forwarder") {
+		t.Errorf("expected a progress line naming the forwarder, got %v", events)
+	}
+}
+
+func TestEnsureLANForwarderRemoved_MissingUnitIgnored(t *testing.T) {
+	// A Mac that never had a forwarder (or any already-clean host) hits a
+	// not-exist on removal; that is the no-op case and must not error.
+	rec := &forwarderRemoveRecorder{removeErr: os.ErrNotExist}
+	swapMgr(t, rec)
+
+	if err := ensureLANForwarderRemoved(nil); err != nil {
+		t.Errorf("a missing forwarder unit must be ignored, got %v", err)
+	}
+}
+
+func TestEnsureLANForwarderRemoved_RealRemoveErrorSurfaces(t *testing.T) {
+	// Any removal error that isn't not-exist is a genuine failure and must
+	// abort the unexpose so the caller doesn't report a clean teardown.
+	rec := &forwarderRemoveRecorder{removeErr: errors.New("permission denied")}
+	swapMgr(t, rec)
+
+	err := ensureLANForwarderRemoved(nil)
+	if err == nil {
+		t.Fatal("expected a real RemoveServiceUnit error to surface")
+	}
+	if !strings.Contains(err.Error(), "removing forwarder unit") {
+		t.Errorf("error should wrap the forwarder removal, got %v", err)
 	}
 }
 

--- a/internal/cli/lan.go
+++ b/internal/cli/lan.go
@@ -91,8 +91,9 @@ func newLANExposeCmd() *cobra.Command {
     become reachable from other devices on the LAN).
   - Restarts each affected container so the new bind takes effect.
   - Rewrites the dnsmasq config to answer *.test queries with the host's
-    auto-detected LAN IP and starts the userspace lerd-dns-forwarder so
-    LAN devices can resolve those names.
+    auto-detected LAN IP so LAN devices can resolve those names. On Linux
+    this is bridged by the userspace lerd-dns-forwarder; on macOS lerd-dns
+    binds the LAN address directly, so no forwarder is installed.
 
 The dashboard at port 7073 is still gated by the remote-control middleware:
 LAN clients get 403 unless you have run 'lerd remote-control on' to set

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -691,9 +691,15 @@ func startWorkersForSite(site *config.Site, workers []string, phpVersion string)
 		if !ok {
 			continue
 		}
-		// Skip workers whose check doesn't pass.
+		// Skip workers whose check doesn't pass. A host worker (vite et al) the
+		// user opted into but whose deps aren't installed would otherwise drop
+		// silently, reading as "the worker just isn't running"; surface the
+		// reason and remedy instead.
 		if wDef.Check != nil && !config.MatchesRule(site.Path, *wDef.Check) {
 			delete(requested, w)
+			if msg := hostWorkerNotReadyMsg(w, site.Path, wDef); msg != "" {
+				feedback.Warn("%s", msg)
+			}
 			continue
 		}
 		for _, conflict := range wDef.ConflictsWith {

--- a/internal/cli/node_exec.go
+++ b/internal/cli/node_exec.go
@@ -20,7 +20,7 @@ func NewNodeCmd() *cobra.Command {
 		DisableFlagParsing: true,
 		SilenceUsage:       true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runWithFnm("node", args)
+			return runWithFnm("node", args, true)
 		},
 	}
 }
@@ -33,7 +33,7 @@ func NewNpmCmd() *cobra.Command {
 		DisableFlagParsing: true,
 		SilenceUsage:       true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runWithFnm("npm", args)
+			return runWithFnm("npm", args, true)
 		},
 	}
 }
@@ -46,7 +46,7 @@ func NewNpxCmd() *cobra.Command {
 		DisableFlagParsing: true,
 		SilenceUsage:       true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runWithFnm("npx", args)
+			return runWithFnm("npx", args, true)
 		},
 	}
 }
@@ -120,10 +120,12 @@ func systemNodeAvailable() bool {
 	return nodeDet.SystemNodeAvailable()
 }
 
-// runBun execs the host bun binary in dir, streaming to the terminal and
-// os.Exit'ing on failure to mirror runWithFnm's CLI behaviour. bun is
-// self-contained, so unlike node it needs no fnm wrapper or version pin.
-func runBun(dir, bun string, args []string) error {
+// runBun execs the host bun binary in dir, streaming to the terminal. bun is
+// self-contained, so unlike node it needs no fnm wrapper or version pin. When
+// exitOnFail is set it os.Exit's with the child's code to mirror runWithFnm's
+// CLI behaviour; callers that fold the run behind a feedback step (setup) pass
+// false so the non-zero exit is returned and the step loop can report it.
+func runBun(dir, bun string, args []string, exitOnFail bool) error {
 	cmd := exec.Command(bun, args...)
 	cmd.Dir = dir
 	cmd.Stdin = os.Stdin
@@ -131,7 +133,7 @@ func runBun(dir, bun string, args []string) error {
 	cmd.Stderr = os.Stderr
 	cmd.Env = shimLeadingEnv(os.Environ())
 	if err := cmd.Run(); err != nil {
-		if exit, ok := err.(*exec.ExitError); ok {
+		if exit, ok := err.(*exec.ExitError); ok && exitOnFail {
 			os.Exit(exit.ExitCode())
 		}
 		return err
@@ -153,21 +155,21 @@ func runJSInstall(dir string, frozen bool) error {
 				break
 			}
 		}
-		return runBun(dir, bun, args)
+		return runBun(dir, bun, args, false)
 	}
 	if frozen {
-		return runWithFnm("npm", []string{"ci"})
+		return runWithFnm("npm", []string{"ci"}, false)
 	}
-	return runWithFnm("npm", []string{"install"})
+	return runWithFnm("npm", []string{"install"}, false)
 }
 
 // runJSScript runs a package.json script in dir via `bun run <script>` when the
 // project uses bun, otherwise `npm run <script>` via fnm.
 func runJSScript(dir, script string) error {
 	if bun := bunRunnerFor(dir, true); bun != "" {
-		return runBun(dir, bun, []string{"run", script})
+		return runBun(dir, bun, []string{"run", script}, false)
 	}
-	return runWithFnm("npm", []string{"run", script})
+	return runWithFnm("npm", []string{"run", script}, false)
 }
 
 // shimLeadingEnv prepends lerd's bin dir (home of the `php` shim) to PATH so
@@ -191,7 +193,7 @@ func shimLeadingEnv(env []string) []string {
 	return out
 }
 
-func runWithFnm(bin string, args []string) error {
+func runWithFnm(bin string, args []string, exitOnFail bool) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -240,7 +242,7 @@ func runWithFnm(bin string, args []string) error {
 		}
 	}
 	if runErr != nil {
-		if exit, ok := runErr.(*exec.ExitError); ok {
+		if exit, ok := runErr.(*exec.ExitError); ok && exitOnFail {
 			os.Exit(exit.ExitCode())
 		}
 		return runErr

--- a/internal/cli/node_exec_integration_test.go
+++ b/internal/cli/node_exec_integration_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// TestRunWithFnm_FailingScriptReturnsErrorNotExit is the end-to-end guard for the
+// lerd link/setup regression: a failing `npm run <script>` must return an error
+// (so the setup step loop can report it) rather than os.Exit and kill lerd. It
+// drives the real fnm/npm toolchain, so it skips when fnm or a default Node isn't
+// installed. If exitOnFail were still hard-coded true here, this test process
+// would be terminated and the run would fail loudly — which is the point.
+func TestRunWithFnm_FailingScriptReturnsErrorNotExit(t *testing.T) {
+	fnm := filepath.Join(config.BinDir(), "fnm")
+	if _, err := os.Stat(fnm); err != nil {
+		t.Skipf("fnm not installed at %s; skipping integration test", fnm)
+	}
+	// Without a default Node, runWithFnm returns early with the "no Node.js
+	// version available" error and never reaches the failing-script branch this
+	// test guards, so the skip must check for it too — not just fnm's presence.
+	if err := exec.Command(fnm, "exec", "--using=default", "--", "true").Run(); err != nil {
+		t.Skip("no default Node available via fnm; skipping integration test")
+	}
+
+	dir := t.TempDir()
+	pkg := `{"name":"lerd-fail-test","private":true,"scripts":{"production":"node -e \"process.exit(7)\""}}`
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(dir)
+
+	err := runWithFnm("npm", []string{"run", "production"}, false)
+	if err == nil {
+		t.Fatal("expected an error from a failing npm script, got nil (did the process survive but swallow the failure?)")
+	}
+}

--- a/internal/cli/node_exec_test.go
+++ b/internal/cli/node_exec_test.go
@@ -218,3 +218,23 @@ func TestSyncNodeGlobalBins_MissingSourceIsNoOp(t *testing.T) {
 		t.Errorf("expected orphan removed when source missing, err=%v", err)
 	}
 }
+
+// TestRunBun_FailureReturnsErrorWhenNotExiting guards the lerd link/setup
+// regression where a failed `npm run production` / `bun run build` killed the
+// whole process via os.Exit, bypassing the step loop's failure feedback. With
+// exitOnFail false the non-zero child exit must come back as an error so the
+// caller can report it, not terminate lerd.
+func TestRunBun_FailureReturnsErrorWhenNotExiting(t *testing.T) {
+	// /bin/sh stands in for the bun binary; the script exits non-zero.
+	err := runBun(t.TempDir(), "/bin/sh", []string{"-c", "exit 3"}, false)
+	if err == nil {
+		t.Fatal("expected an error from a non-zero child exit, got nil")
+	}
+}
+
+// TestRunBun_SuccessReturnsNil confirms the happy path still returns nil.
+func TestRunBun_SuccessReturnsNil(t *testing.T) {
+	if err := runBun(t.TempDir(), "/bin/sh", []string{"-c", "exit 0"}, false); err != nil {
+		t.Fatalf("expected nil on success, got %v", err)
+	}
+}

--- a/internal/cli/remote_setup.go
+++ b/internal/cli/remote_setup.go
@@ -189,7 +189,11 @@ Re-run this command to generate a new code if it expires or is consumed.`,
 				return fmt.Errorf("enabling lan:expose: %w", err)
 			}
 			expose.OK(feedback.Val(lanIP))
-			feedback.Note("lerd-dns-forwarder on " + lanIP + ":5300 (UDP+TCP), answering *.test → " + lanIP)
+			if lerdDNSBindsLANPort {
+				feedback.Note("lerd-dns binds " + lanIP + ":5300 (UDP+TCP) directly, answering *.test → " + lanIP)
+			} else {
+				feedback.Note("lerd-dns-forwarder on " + lanIP + ":5300 (UDP+TCP), answering *.test → " + lanIP)
+			}
 			feedback.Note("allow port 5300 through your firewall from the devices you want to grant access")
 
 			code, err := GenerateRemoteSetupToken(ttl)

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -379,14 +379,16 @@ func restartLerdUserServices() {
 	if len(active) == 0 {
 		return
 	}
-	fmt.Println("\n==> Restarting lerd services to pick up the new binary")
+	feedback.Header("Restarting lerd services to pick up the new binary")
 	for _, u := range active {
-		fmt.Printf("  --> %s ... ", u)
+		s := feedback.Start(u)
 		if err := services.Mgr.Restart(u); err != nil {
-			fmt.Printf("WARN (%v)\n", err)
-		} else {
-			fmt.Println("OK")
+			// Best-effort: the binary swap already succeeded, so a restart that
+			// didn't take is a warning, not a failure of the update itself.
+			s.Warn(err)
+			continue
 		}
+		s.OK("")
 	}
 }
 
@@ -514,7 +516,7 @@ func runRollback() error {
 		return err
 	}
 
-	fmt.Printf("==> Rolling back to v%s\n", prevVersion)
+	feedback.Header(fmt.Sprintf("Rolling back to v%s", prevVersion))
 
 	// Atomically replace lerd.
 	tmp := self + ".tmp"
@@ -548,7 +550,7 @@ func runRollback() error {
 	// `lerd install` starts from a known-good state. The current
 	// binary's probe logic decides v4-only vs dual-stack; the old
 	// binary's EnsureNetwork will accept whatever schema it finds.
-	fmt.Println("  --> Resetting lerd network for rollback")
+	feedback.Line("Resetting lerd network for rollback")
 	if attached, _, err := podman.RecreateNetwork("lerd", nil); err == nil {
 		for _, c := range attached {
 			_ = podman.StartUnit(c)
@@ -561,7 +563,7 @@ func runRollback() error {
 	// the cache picks up Type=simple immediately.
 	prepUserUnitsForRollback("lerd-ui.service", "lerd-watcher.service")
 
-	fmt.Printf("\nRolled back to v%s — applying infrastructure changes...\n\n", prevVersion)
+	feedback.Note(fmt.Sprintf("Rolled back to v%s, applying infrastructure changes...", prevVersion))
 
 	// Re-exec the new binary with `install`, same as a normal update.
 	installCmd := exec.Command(self, "install")

--- a/internal/cli/worker_preflight.go
+++ b/internal/cli/worker_preflight.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/geodro/lerd/internal/config"
@@ -33,6 +34,9 @@ func workerStartPreflight(sitePath, workerName string, w config.FrameworkWorker)
 		return fmt.Errorf("worker %q has an invalid command: must not contain newline or NUL", workerName)
 	}
 	if w.Check != nil && !config.MatchesRule(sitePath, *w.Check) {
+		if msg := hostWorkerNotReadyMsg(workerName, sitePath, w); msg != "" {
+			return errors.New(msg)
+		}
 		return fmt.Errorf(
 			"worker %q skipped: required dependency not satisfied (rule: %s)",
 			workerName, describeRule(*w.Check))
@@ -43,6 +47,19 @@ func workerStartPreflight(sitePath, workerName string, w config.FrameworkWorker)
 			workerName, describeRule(*w.ExcludeCheck))
 	}
 	return nil
+}
+
+// hostWorkerNotReadyMsg returns an actionable message for a host worker (vite et
+// al) that can't start because its dependency check fails. On a node project the
+// cause is almost always JS deps not yet installed on the host, so it names the
+// remedy; `lerd setup` is used rather than a bare `npm ci` so the advice holds
+// for bun/yarn/pnpm projects too. Returns "" when the worker isn't a host node
+// worker, so callers keep their own generic dependency message.
+func hostWorkerNotReadyMsg(workerName, sitePath string, w config.FrameworkWorker) string {
+	if !w.Host || !isNodeProject(sitePath) {
+		return ""
+	}
+	return fmt.Sprintf("%s worker not started: JS dependencies are not installed. Run `lerd setup` to install them, then `lerd worker start %s`.", workerName, workerName)
 }
 
 // describeRule renders a FrameworkRule for an end-user error message.

--- a/internal/cli/worker_test.go
+++ b/internal/cli/worker_test.go
@@ -296,3 +296,73 @@ func TestWorkerRemove_Global(t *testing.T) {
 		t.Error("other should still be present")
 	}
 }
+
+// hostWorkerNotReadyMsg returns a runtime-agnostic JS-deps message only for a
+// host worker on a node project, and "" otherwise so callers fall back to their
+// own generic dependency message.
+func TestHostWorkerNotReadyMsg(t *testing.T) {
+	nodeDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(nodeDir, "package.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	plainDir := t.TempDir()
+
+	hostWorker := config.FrameworkWorker{Host: true, Check: &config.FrameworkRule{File: "node_modules/vite"}}
+
+	msg := hostWorkerNotReadyMsg("vite", nodeDir, hostWorker)
+	for _, want := range []string{"JS dependencies are not installed", "lerd setup", "lerd worker start vite"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("host node-worker message missing %q: %s", want, msg)
+		}
+	}
+	// The remedy must stay runtime-agnostic so it doesn't misdirect bun/yarn/pnpm projects.
+	if strings.Contains(msg, "npm ci") {
+		t.Errorf("message should not hardcode npm ci: %s", msg)
+	}
+
+	// Not a node project: no JS-deps claim, caller keeps its generic message.
+	if got := hostWorkerNotReadyMsg("vite", plainDir, hostWorker); got != "" {
+		t.Errorf("non-node project should yield no host message, got: %s", got)
+	}
+	// Non-host worker: never a JS-deps message even on a node project.
+	containerWorker := config.FrameworkWorker{Check: &config.FrameworkRule{Composer: "vendor/pkg"}}
+	if got := hostWorkerNotReadyMsg("queue", nodeDir, containerWorker); got != "" {
+		t.Errorf("non-host worker should yield no host message, got: %s", got)
+	}
+}
+
+// End-to-end gate: WorkerStartForSite runs workerStartPreflight first and returns
+// its error before touching systemd/podman, so a node project (package.json, no
+// node_modules) with a vite host worker must be refused with the actionable
+// JS-deps message and cause no side effects. This mirrors what a real
+// `lerd worker start vite` surfaces on a freshly linked project.
+func TestWorkerStartForSiteRefusesViteWithoutDeps(t *testing.T) {
+	siteDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(siteDir, "package.json"), []byte(`{"scripts":{"dev":"vite"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	vite := config.FrameworkWorker{
+		Host:    true,
+		Command: "npm run dev",
+		Restart: "on-failure",
+		Check:   &config.FrameworkRule{File: "node_modules/vite"},
+	}
+
+	err := WorkerStartForSite("acme", siteDir, "8.5", "vite", vite, false)
+	if err == nil {
+		t.Fatal("expected WorkerStartForSite to refuse vite without node_modules, got nil")
+	}
+	t.Logf("surfaced message: %s", err)
+	for _, want := range []string{"JS dependencies are not installed", "lerd setup", "lerd worker start vite"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("preflight error missing %q: %s", want, err)
+		}
+	}
+
+	// No unit file should have been written for the refused worker.
+	unit, _ := workerNames("acme", siteDir, "vite")
+	if _, statErr := os.Stat(filepath.Join(os.Getenv("HOME"), ".config", "systemd", "user", unit+".service")); statErr == nil {
+		t.Errorf("a unit file was written for a refused worker: %s", unit)
+	}
+}

--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -323,6 +323,18 @@ func (s *Step) Fail(err error) {
 	s.finish(paint(failStyle, "✗"), paint(failStyle, msg))
 }
 
+// Warn collapses the step with an amber warning glyph and message, for a
+// non-fatal hiccup (e.g. a best-effort restart that didn't take) that should be
+// noticed but doesn't mean the command itself failed. Unlike Fail it draws no
+// red cross, so it doesn't read as the whole operation having errored.
+func (s *Step) Warn(err error) {
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	s.finish(paint(warnStyle, GlyphWarn), paint(warnStyle, msg))
+}
+
 // Fail prints a standalone red ✗ line for err to stderr in the same style (and
 // blank-line spacing) as a Live/Step failure. It is for the top-level command
 // handler to render an error a command returned without surfacing it itself, so

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -55,6 +55,28 @@ func TestStepInfoAndFail(t *testing.T) {
 	}
 }
 
+// Warn collapses a step with the amber ⚠ glyph and no red cross, and (unlike
+// Fail) does not mark its error as already-shown, since it is a non-fatal hiccup
+// rather than a failure the command is returning.
+func TestStepWarn(t *testing.T) {
+	var buf bytes.Buffer
+	defer SetTestWriter(&buf)()
+
+	warnErr := errors.New("unit not loaded")
+	Start("restarting lerd-ui").Warn(warnErr)
+
+	got := buf.String()
+	if !strings.Contains(got, " → restarting lerd-ui… ⚠ unit not loaded\n") {
+		t.Errorf("missing warn line: %q", got)
+	}
+	if strings.Contains(got, "✗") {
+		t.Errorf("warn must not render a red cross: %q", got)
+	}
+	if AlreadyShown(warnErr) {
+		t.Error("Warn should not mark its error as already-shown")
+	}
+}
+
 // A Step/Live Fail records its error so the top-level handler can tell it was
 // already shown to the user, covering both the bare error returned as-is and a
 // wrapped error that adds context around it. An unrelated error stays unshown.

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -299,6 +299,23 @@ func baseContainerfileHash() (string, error) {
 	return fmt.Sprintf("%x", sum)[:12], nil
 }
 
+// basePullArgs builds the `podman pull` args for a base image ref. The
+// --policy=always flag is podman 5.0+ only (older podman rejects it with
+// "unknown flag: --policy"), so withPolicy gates it; without the flag a plain
+// pull still fetches the hash-pinned tag. authFile is the anonymous authfile
+// path, omitted when empty. Extracted so the version-gated flag has test cover.
+func basePullArgs(ref, authFile string, withPolicy bool) []string {
+	args := []string{"pull"}
+	if withPolicy {
+		args = append(args, "--policy=always")
+	}
+	args = append(args, PlatformPullArgs(ref)...)
+	if authFile != "" {
+		args = append(args, "--authfile="+authFile)
+	}
+	return append(args, ref)
+}
+
 // tryPullBaseImage attempts to pull the pre-built base image from ghcr.io.
 // Returns the image reference on success, or "" if unavailable.
 func tryPullBaseImage(version string, w io.Writer) string {
@@ -314,31 +331,53 @@ func tryPullBaseImage(version string, w io.Writer) string {
 	// expired or mismatched credentials would otherwise cause a 401 for this
 	// public image and force a slow local build.
 	tmpAuth, err := os.CreateTemp("", "lerd-auth-*.json")
+	authFile := ""
 	if err == nil {
 		tmpAuth.WriteString("{}")
 		tmpAuth.Close()
+		authFile = tmpAuth.Name()
 		defer os.Remove(tmpAuth.Name())
 	}
 
+	// --policy=always (podman 5.0+) re-pulls a republished base on rebuild; on
+	// older podman it's an unknown flag that would fail the pull, so gate it.
+	withPolicy := supportsPullPolicy()
+
 	// Try each registry in order (old org first, new org fallback) so a binary
 	// keeps pulling across the org move without a rebuild.
+	var lastErr string
 	for _, ref := range origin.BaseImageRefs(short, hash) {
-		args := []string{"pull", "--policy=always"}
-		args = append(args, PlatformPullArgs(ref)...)
-		if tmpAuth != nil {
-			args = append(args, "--authfile="+tmpAuth.Name())
-		}
-		args = append(args, ref)
-
-		cmd := exec.Command(PodmanBin(), args...)
+		cmd := exec.Command(PodmanBin(), basePullArgs(ref, authFile, withPolicy)...)
 		cmd.Stdout = w
-		cmd.Stderr = io.Discard
+		// Capture stderr instead of discarding it: a swallowed pull failure
+		// (an unknown flag, a 404, a network or storage error) used to surface
+		// only as a confusing full local build with no reason given.
+		var stderr strings.Builder
+		cmd.Stderr = &stderr
 		if err := cmd.Run(); err == nil {
 			origin.NoteFetched(ref)
 			return ref
+		} else if s := strings.TrimSpace(stderr.String()); s != "" {
+			lastErr = lastLine(s)
 		}
 	}
-	fmt.Fprintf(w, "  Pre-built image unavailable, falling back to local build (may take a few minutes)...\n")
+	if lastErr != "" {
+		fmt.Fprintf(w, "  Pre-built image unavailable (%s), falling back to local build (may take a few minutes)...\n", lastErr)
+	} else {
+		fmt.Fprintf(w, "  Pre-built image unavailable, falling back to local build (may take a few minutes)...\n")
+	}
+	return ""
+}
+
+// lastLine returns the last non-empty line of s, the most useful part of a
+// podman error (the trailing "Error: ..." rather than progress noise).
+func lastLine(s string) string {
+	lines := strings.Split(s, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if t := strings.TrimSpace(lines[i]); t != "" {
+			return t
+		}
+	}
 	return ""
 }
 

--- a/internal/podman/build_test.go
+++ b/internal/podman/build_test.go
@@ -4,11 +4,43 @@ import (
 	"errors"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
 )
+
+func TestBasePullArgs(t *testing.T) {
+	ref := "ghcr.io/geodro/lerd-php85-fpm-base:abc123def456"
+
+	withPolicy := basePullArgs(ref, "/tmp/auth.json", true)
+	if withPolicy[0] != "pull" {
+		t.Errorf("first arg must be pull, got %v", withPolicy)
+	}
+	if !slices.Contains(withPolicy, "--policy=always") {
+		t.Errorf("withPolicy=true must include --policy=always, got %v", withPolicy)
+	}
+	if !slices.Contains(withPolicy, "--authfile=/tmp/auth.json") {
+		t.Errorf("must include the authfile, got %v", withPolicy)
+	}
+	if withPolicy[len(withPolicy)-1] != ref {
+		t.Errorf("ref must be the last arg, got %v", withPolicy)
+	}
+
+	// podman < 5.0 rejects --policy with "unknown flag", so it must be omitted.
+	noPolicy := basePullArgs(ref, "/tmp/auth.json", false)
+	if slices.Contains(noPolicy, "--policy=always") {
+		t.Errorf("withPolicy=false must omit --policy, got %v", noPolicy)
+	}
+
+	noAuth := basePullArgs(ref, "", true)
+	for _, a := range noAuth {
+		if strings.HasPrefix(a, "--authfile=") {
+			t.Errorf("empty authFile must omit --authfile, got %v", noAuth)
+		}
+	}
+}
 
 func TestBuildCustomExtBlock_Empty(t *testing.T) {
 	if got := buildCustomExtBlock(nil, nil); got != "" {

--- a/internal/podman/version.go
+++ b/internal/podman/version.go
@@ -82,3 +82,42 @@ func defaultSupportsContainerStopTimeoutKey() bool {
 	})
 	return stopTimeoutResult
 }
+
+// podmanVersionSupportsPullPolicy reports whether `podman pull` accepts the
+// --policy flag. Added in Podman 5.0; older podman (Ubuntu 24.04 ships 4.9.3,
+// 22.04 ships 3.4.4) rejects it with "unknown flag: --policy", which silently
+// forced a full local image build instead of pulling the prebuilt base.
+func podmanVersionSupportsPullPolicy(major, minor int) bool {
+	_ = minor
+	return major >= 5
+}
+
+// supportsPullPolicy is the runtime test seam used by the base-image pull.
+// Tests override it to exercise both branches without shelling out. The
+// default lazily probes the local podman once.
+var supportsPullPolicy = defaultSupportsPullPolicy
+
+var (
+	pullPolicyOnce   sync.Once
+	pullPolicyResult bool
+)
+
+func defaultSupportsPullPolicy() bool {
+	pullPolicyOnce.Do(func() {
+		out, err := exec.Command(PodmanBin(), "--version").Output()
+		if err != nil {
+			// Probe failed: omit the flag. A plain `podman pull` works on every
+			// version, so dropping --policy is safer than risking the unknown-flag
+			// rejection that would force a slow local build.
+			pullPolicyResult = false
+			return
+		}
+		major, minor, err := parsePodmanVersion(string(out))
+		if err != nil {
+			pullPolicyResult = false
+			return
+		}
+		pullPolicyResult = podmanVersionSupportsPullPolicy(major, minor)
+	})
+	return pullPolicyResult
+}

--- a/internal/podman/version_test.go
+++ b/internal/podman/version_test.go
@@ -57,3 +57,25 @@ func TestSupportsContainerStopTimeoutBoundary(t *testing.T) {
 		}
 	}
 }
+
+func TestSupportsPullPolicyBoundary(t *testing.T) {
+	// `podman pull --policy` was added in Podman 5.0. On anything below the
+	// flag is unknown and the pull must omit it (Ubuntu 24.04 ships 4.9.3).
+	tests := []struct {
+		major, minor int
+		want         bool
+	}{
+		{3, 4, false},
+		{4, 9, false},
+		{4, 99, false},
+		{5, 0, true},
+		{5, 8, true},
+		{6, 0, true},
+	}
+	for _, tt := range tests {
+		got := podmanVersionSupportsPullPolicy(tt.major, tt.minor)
+		if got != tt.want {
+			t.Errorf("%d.%d: got %v, want %v", tt.major, tt.minor, got, tt.want)
+		}
+	}
+}

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -351,18 +351,31 @@ func stripPrivilegedIPBind(port string) string {
 	return port
 }
 
-// stripIPv6PublishPorts removes PublishPort= lines that start with a bracketed
-// IPv6 address (e.g. "[::1]:3306:3306"). gvproxy cannot bind both an IPv4 and
-// an IPv6 loopback address on the same port simultaneously.
+// stripIPv6PublishPorts normalises bracketed IPv6 PublishPort= lines for gvproxy,
+// which cannot bind both an IPv4 and an IPv6 address on the same port at once.
+//
+// Loopback IPv6 lines ("[::1]:3306:3306") are dropped: PairIPv6Binds always pairs
+// them with an IPv4 "127.0.0.1:" line that survives, so the published port lives on.
+//
+// Bind-all IPv6 lines ("[::]:80:80") have no IPv4 partner — PairIPv6Binds collapses a
+// bare/0.0.0.0 bind into the "[::]:" form only — so they are rewritten to "0.0.0.0:"
+// rather than dropped. Dropping them left LAN-exposed containers (lan.exposed: true,
+// where every publish ends up as "[::]:") with no published ports at all.
 func stripIPv6PublishPorts(content string) string {
 	lines := strings.Split(content, "\n")
 	out := lines[:0]
 	for _, l := range lines {
-		val := strings.TrimPrefix(strings.TrimSpace(l), "PublishPort=")
-		if val != strings.TrimSpace(l) && strings.HasPrefix(val, "[") {
+		trimmed := strings.TrimSpace(l)
+		val := strings.TrimPrefix(trimmed, "PublishPort=")
+		if val == trimmed || !strings.HasPrefix(val, "[") {
+			out = append(out, l)
 			continue
 		}
-		out = append(out, l)
+		if rest, ok := strings.CutPrefix(val, "[::]:"); ok {
+			out = append(out, "PublishPort=0.0.0.0:"+rest)
+			continue
+		}
+		// Loopback (or any other bracketed) IPv6 line: drop it; its IPv4 partner stays.
 	}
 	return strings.Join(out, "\n")
 }

--- a/internal/services/launchd_test.go
+++ b/internal/services/launchd_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/podman"
 )
 
 // TestHasNonZeroExitCode covers the failure-detection helper for both
@@ -571,6 +573,56 @@ func TestStripPrivilegedIPBind_v6(t *testing.T) {
 	for in, want := range cases {
 		if got := stripPrivilegedIPBind(in); got != want {
 			t.Errorf("stripPrivilegedIPBind(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestStripIPv6PublishPorts(t *testing.T) {
+	cases := map[string]string{
+		// Loopback IPv6 dup is dropped; its IPv4 partner survives.
+		"PublishPort=127.0.0.1:80:80\nPublishPort=[::1]:80:80": "PublishPort=127.0.0.1:80:80",
+		// Bind-all IPv6 has no IPv4 partner: rewrite to 0.0.0.0 rather than drop.
+		"PublishPort=[::]:80:80":   "PublishPort=0.0.0.0:80:80",
+		"PublishPort=[::]:443:443": "PublishPort=0.0.0.0:443:443",
+		// Plain IPv4 lines and non-PublishPort lines pass through untouched.
+		"PublishPort=80:80": "PublishPort=80:80",
+		"Network=lerd":      "Network=lerd",
+		"[Container]":       "[Container]",
+	}
+	for in, want := range cases {
+		if got := stripIPv6PublishPorts(in); got != want {
+			t.Errorf("stripIPv6PublishPorts(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestLANExposedPublishPortsSurvive guards the full macOS transform chain for a
+// LAN-exposed container (lan.exposed: true). The regression: BindForLAN +
+// PairIPv6Binds collapse "PublishPort=80:80" into the "[::]:" bind-all form, and
+// stripIPv6PublishPorts used to drop every bracketed line — leaving lerd-nginx
+// with no -p flags, so nothing reached the host. The published ports must survive
+// as -p entries in the final podman run args.
+func TestLANExposedPublishPortsSurvive(t *testing.T) {
+	content := "[Container]\n" +
+		"Image=docker.io/library/nginx:alpine\n" +
+		"Network=lerd\n" +
+		"PublishPort=80:80\n" +
+		"PublishPort=443:443\n"
+
+	content = podman.BindForLAN(content, true) // lanExposed
+	content = podman.PairIPv6Binds(content)
+	content = stripIPv6PublishPorts(content)
+
+	c := parseSection(content, "Container")
+	args, err := containerToPodmanArgs(c)
+	if err != nil {
+		t.Fatalf("containerToPodmanArgs: %v", err)
+	}
+
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"-p 80:80", "-p 443:443"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected %q in podman args, got: %s", want, joined)
 		}
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -9,7 +9,7 @@ import "fmt"
 //	-X github.com/geodro/lerd/internal/version.Commit=<sha>
 //	-X github.com/geodro/lerd/internal/version.Date=<iso8601>
 var (
-	Version = "1.26.0"
+	Version = "1.26.1"
 	Commit  = "none"
 	Date    = "unknown"
 )


### PR DESCRIPTION
This is the v1.26.1 patch release. The headline fix is that lerd was silently rebuilding every PHP image from source on most Linux hosts: it pulled the prebuilt base with `podman pull --policy=always`, but `--policy` only exists on podman 5.0, so on Ubuntu 24.04 (4.9.3), 22.04 (3.4.4) and Debian 12 (4.3.1) the flag was rejected, and because the pull's stderr was discarded the failure was invisible and lerd fell back to the full local build even when a matching prebuilt base was published. The flag is now gated behind a podman 5.0 probe and the pull error surfaces in the fallback message.

Alongside that it cherry-picks five already-merged fixes from main worth shipping now rather than waiting for the next feature release: setup reports npm and bun build failures instead of killing the process, host workers whose deps aren't installed surface a remedy instead of dropping silently and update's restarts route through the feedback layer, macOS LAN exposure keeps its published ports and stops double-binding the DNS forwarder, and the host database override docs example is corrected.

Refs #638.
