### PR TITLE
fix(mcp): honor host-proxy sites in site link

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2437,7 +2437,12 @@ func execSiteLink(args map[string]any) (any, *rpcError) {
 	// proceeds, while an unapproved command in this non-interactive context is
 	// refused with guidance rather than run blindly.
 	if proj != nil && proj.Proxy != nil && proj.Proxy.Port > 0 {
-		out, err := runIn(projectPath, "lerd", "link", name)
+		// No positional name: a positional is treated by runLink as an explicit
+		// primary domain to prepend, which would register the directory-derived
+		// name alongside the .lerd.yaml domains (and SyncProjectDomains would then
+		// persist the spurious entry). Plain `lerd link` honors proj.Domains
+		// verbatim, matching the container and PHP branches above.
+		out, err := runIn(projectPath, "lerd", "link")
 		if err != nil {
 			msg := strings.TrimSpace(out)
 			if msg == "" {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2427,6 +2427,27 @@ func execSiteLink(args map[string]any) (any, *rpcError) {
 		return toolOK(fmt.Sprintf("Linked %s -> %s (custom container, port %d)", name, strings.Join(domains, ", "), proj.Container.Port)), nil
 	}
 
+	// Host-proxy path: .lerd.yaml has a proxy section, so the site runs a dev
+	// server on the host that nginx reverse-proxies to. Supervising that command
+	// needs the consent gating and worker-start logic that live in the cli
+	// package, so delegate to `lerd link` (the same shell-out pattern as worker
+	// start) instead of falling through to the PHP path, which would downgrade
+	// the site to plain FPM and drop the proxy vhost. The consent gate still
+	// applies: an already-approved command (or host_proxy.skip_confirmation)
+	// proceeds, while an unapproved command in this non-interactive context is
+	// refused with guidance rather than run blindly.
+	if proj != nil && proj.Proxy != nil && proj.Proxy.Port > 0 {
+		out, err := runIn(projectPath, "lerd", "link", name)
+		if err != nil {
+			msg := strings.TrimSpace(out)
+			if msg == "" {
+				msg = err.Error()
+			}
+			return toolErr(msg), nil
+		}
+		return toolOK(strings.TrimSpace(out)), nil
+	}
+
 	// PHP / framework path.
 	framework := ""
 	if fname, ok := config.DetectFrameworkForDir(projectPath); ok {


### PR DESCRIPTION
Fixes #642

## Problem

The MCP `site link` handler (`execSiteLink` in `internal/mcp/server.go`) only branches on two cases: custom-container (`proj.Container`) and PHP/framework. A `.lerd.yaml` carrying a `proxy:` section has neither, so it falls through to the **PHP path**.

The result is that calling `site link` (via MCP) on a host-proxy site silently downgrades it:

- the registry entry loses `host_port` / `host_command` and gains `php_version`,
- the generated vhost loses `proxy_pass` and becomes a plain FPM vhost serving `public/`,
- the site starts returning 403 (and `site restart` then reports it as "static").

The CLI `lerd link` (`internal/cli/link.go`) handles host-proxy correctly; only the MCP handler was missing the branch. Reproduced on a Nuxt dev site (`pnpm dev` on a host port): one MCP `site link` turned a working host-proxy site into a broken FPM site.

## Fix

Add a host-proxy branch to `execSiteLink` that delegates to `lerd link`, mirroring the shell-out pattern worker start (`execWorkerStart`) already uses. Delegating reuses the cli package's consent gating and dev-server supervision rather than reimplementing them in the MCP package (which can't import `cli`).

Consent is preserved, not bypassed: the subprocess `lerd link` is non-interactive, so the existing `hostProxyGate` lets an already-approved command (or `host_proxy.skip_confirmation`) proceed, while an unapproved command is refused with the usual guidance instead of run blindly. The MCP deliberately does not pass `--yes`.

## Notes

- No new test: the branch is a guard + shell-out (same shape as `execWorkerStart`, which is likewise not unit-tested for the shell-out), and the consent policy itself is already covered by the `hostProxyGate` unit tests. Mocking `runIn` here would test the mock, not behavior. Happy to add one if you'd prefer a specific shape.
- `go vet` / `go build` / `go test ./internal/mcp/` (59 pass) all green with `-tags nogui`.
