### PR TITLE
fix(podman): enable git+ssh in PHP runtime images (FPM + FrankenPHP)

### DIFF
--- a/internal/podman/quadlets/lerd-frankenphp.Containerfile
+++ b/internal/podman/quadlets/lerd-frankenphp.Containerfile
@@ -31,8 +31,10 @@ RUN install-php-extensions {{.CoreExtensions}} \
     && rm -rf /tmp/* /var/cache/apk/*
 
 # nodejs+npm so the Octane file-watcher (lerd octane:reload on) and JS tooling
-# work without an apk add at container start, matching the FPM image.
-RUN apk add --no-cache nodejs npm && rm -rf /var/cache/apk/*
+# work without an apk add at container start; git + openssh-client so git over
+# SSH (private composer packages, source installs run inside this container)
+# works without auth failures. All matching the FPM image.
+RUN apk add --no-cache nodejs npm git openssh-client && rm -rf /var/cache/apk/*
 
 # lerd_devtools: lerd's engine-level Debug-window capture (queries, mail, views,
 # events, jobs, http), compiled here for the ZTS base since install-php-extensions

--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -122,6 +122,7 @@ RUN apk update && apk add --no-cache \
         libgomp \
         ffmpeg \
         git \
+        openssh-client \
         mysql-client \
         nodejs \
         npm \


### PR DESCRIPTION
Fixes #644

## Problem

lerd's PHP runtime images can't do git over SSH, so `lerd composer install` of a private package fetched over `git+ssh` fails with an auth error:

- **FPM image** (`lerd-php-fpm.Containerfile`, all PHP versions + custom-FPM + worktrees): ships `git` but no SSH client.
- **FrankenPHP image** (`lerd-frankenphp.Containerfile`): ships neither `git` nor an SSH client.

Confirmed on a live FPM container:

```
$ podman exec lerd-php85-fpm sh -c 'for b in ssh ssh-agent ssh-add git; do command -v $b || echo "$b MISSING"; done'
ssh MISSING
ssh-agent MISSING
ssh-add MISSING
/usr/bin/git
```

## Fix

- FPM image: add `openssh-client` (it already had `git`).
- FrankenPHP image: add `git` + `openssh-client` for parity.

Since `$HOME` is already bind-mounted into the containers, on-disk keys without a passphrase plus the user's `~/.ssh/known_hosts` then work for `lerd composer install` with no further config. Takes effect after an image rebuild.

Note: `lerd composer` / `lerd php` for a FrankenPHP site already exec into the shared FPM container, so the FPM half alone covers composer. The FrankenPHP change is for git+ssh run **inside** the FrankenPHP container directly (and keeps the two runtime images at parity).

## Scope

Foundational half of #643. Sharing an `ssh-agent` for passphrase-protected keys (the `ddev auth ssh` equivalent) builds on this and will be a separate PR against #643.

`go build` / `go test ./internal/podman/` (263 pass) green with `-tags nogui`.
