### PR TITLE
feat(auth): lerd auth ssh — shared ssh-agent for composer git over SSH

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -124,6 +124,7 @@ func main() {
 	root.AddCommand(cli.NewNpmCmd())
 	root.AddCommand(cli.NewNpxCmd())
 	root.AddCommand(cli.NewComposerCmd())
+	root.AddCommand(cli.NewAuthCmd())
 	root.AddCommand(cli.NewServiceCmd())
 	root.AddCommand(cli.NewStatusCmd())
 	root.AddCommand(cli.NewTuiCmd())

--- a/internal/cli/auth_ssh.go
+++ b/internal/cli/auth_ssh.go
@@ -1,0 +1,192 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// NewAuthCmd returns the `auth` command group: sharing host credentials with the
+// project containers.
+func NewAuthCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Share host credentials (SSH keys) with the project containers",
+	}
+	cmd.AddCommand(newAuthSSHCmd())
+	return cmd
+}
+
+func newAuthSSHCmd() *cobra.Command {
+	var list, remove bool
+	c := &cobra.Command{
+		Use:   "ssh [key...]",
+		Short: "Load SSH keys into a shared agent so composer can use git over SSH",
+		Long: "Start a shared ssh-agent container and load your SSH keys into it, so " +
+			"`lerd composer` can authenticate to private git repositories with " +
+			"passphrase-protected keys. With no arguments it loads ~/.ssh/id_* ; pass " +
+			"key paths (under ~/.ssh) to load specific keys. Keys live only in the " +
+			"agent's memory and are cleared when it stops or the machine restarts.",
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			switch {
+			case remove:
+				return authSSHRemove()
+			case list:
+				return authSSHList()
+			default:
+				return authSSHAdd(args)
+			}
+		},
+	}
+	c.Flags().BoolVar(&list, "list", false, "List the keys currently loaded in the agent")
+	c.Flags().BoolVar(&remove, "remove", false, "Flush all keys and stop the agent")
+	return c
+}
+
+// authSSHAdd ensures the agent sidecar is up and loads the requested keys.
+func authSSHAdd(keys []string) error {
+	resolved, err := resolveSSHKeys(keys)
+	if err != nil {
+		return err
+	}
+	if len(resolved) == 0 {
+		return fmt.Errorf("no SSH keys found in ~/.ssh (looked for id_*); pass a key path explicitly, e.g. lerd auth ssh ~/.ssh/mykey")
+	}
+	if err := ensureSSHAgent(); err != nil {
+		return err
+	}
+
+	// Allocate a TTY only when we have one, so a passphrase prompt works
+	// interactively while a passphraseless add (or a scripted run) still works
+	// without a terminal.
+	execArgs := []string{"exec", "-i"}
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		execArgs = append(execArgs, "-t")
+	}
+	execArgs = append(execArgs, "--env", "SSH_AUTH_SOCK="+podman.SSHAgentSocket,
+		podman.SSHAgentContainer, "ssh-add")
+	execArgs = append(execArgs, resolved...)
+	cmd := podman.Cmd(execArgs...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("ssh-add: %w", err)
+	}
+	fmt.Println("Keys loaded. `lerd composer` can now use git over SSH for private packages.")
+	return nil
+}
+
+// authSSHList prints the keys currently held by the agent.
+func authSSHList() error {
+	if !podman.ContainerRunningQuiet(podman.SSHAgentContainer) {
+		return fmt.Errorf("ssh-agent is not running; run `lerd auth ssh` first")
+	}
+	cmd := podman.Cmd("exec", "--env", "SSH_AUTH_SOCK="+podman.SSHAgentSocket,
+		podman.SSHAgentContainer, "ssh-add", "-l")
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	return cmd.Run()
+}
+
+// authSSHRemove flushes the loaded keys and stops the agent sidecar.
+func authSSHRemove() error {
+	if podman.ContainerRunningQuiet(podman.SSHAgentContainer) {
+		flush := podman.Cmd("exec", "--env", "SSH_AUTH_SOCK="+podman.SSHAgentSocket,
+			podman.SSHAgentContainer, "ssh-add", "-D")
+		flush.Stdout, flush.Stderr = os.Stdout, os.Stderr
+		_ = flush.Run()
+	}
+	if err := podman.StopUnit(podman.SSHAgentUnit); err != nil {
+		return fmt.Errorf("stopping ssh-agent: %w", err)
+	}
+	fmt.Println("SSH agent stopped and keys flushed.")
+	return nil
+}
+
+// ensureSSHAgent makes the FPM containers mount the agent volume, writes and
+// starts the agent sidecar quadlet, and waits until the socket is ready.
+func ensureSSHAgent() error {
+	// Regenerate FPM quadlets so they mount the agent volume, restarting any
+	// whose unit changed. No-op once the mount is already in place.
+	if err := podman.RewriteFPMQuadlets(); err != nil {
+		return fmt.Errorf("updating FPM containers for the agent mount: %w", err)
+	}
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return err
+	}
+	version := cfg.PHP.DefaultVersion
+	image := fmt.Sprintf("lerd-php%s-fpm:local", strings.ReplaceAll(version, ".", ""))
+
+	changed, err := podman.WriteQuadletDiff(podman.SSHAgentUnit, podman.GenerateSSHAgentQuadlet(image))
+	if err != nil {
+		return fmt.Errorf("writing ssh-agent unit: %w", err)
+	}
+	if err := podman.DaemonReloadIfNeeded(changed); err != nil {
+		return err
+	}
+	if err := podman.StartUnit(podman.SSHAgentUnit); err != nil {
+		return fmt.Errorf("starting ssh-agent (is the PHP %s image built? try `lerd php rebuild`): %w", version, err)
+	}
+
+	// Give the sidecar a moment to come up and create the socket before ssh-add.
+	for i := 0; i < 50; i++ {
+		if podman.ContainerRunningQuiet(podman.SSHAgentContainer) {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("ssh-agent container did not start in time")
+}
+
+// resolveSSHKeys turns the user's key arguments (or the ~/.ssh/id_* default)
+// into absolute paths under ~/.ssh. Keys must live under ~/.ssh because that is
+// the only host directory mounted into the agent container.
+func resolveSSHKeys(keys []string) ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	sshDir := filepath.Join(home, ".ssh")
+
+	if len(keys) > 0 {
+		var out []string
+		for _, k := range keys {
+			if !filepath.IsAbs(k) {
+				k = filepath.Join(sshDir, k)
+			}
+			abs, err := filepath.Abs(k)
+			if err != nil {
+				return nil, err
+			}
+			if rel, err := filepath.Rel(sshDir, abs); err != nil || strings.HasPrefix(rel, "..") {
+				return nil, fmt.Errorf("key must be under ~/.ssh (the only directory shared with the agent): %s", k)
+			}
+			if _, err := os.Stat(abs); err != nil {
+				return nil, fmt.Errorf("key not found: %s", abs)
+			}
+			out = append(out, abs)
+		}
+		return out, nil
+	}
+
+	// Default: every ~/.ssh/id_* private key (skip the .pub counterparts).
+	matches, _ := filepath.Glob(filepath.Join(sshDir, "id_*"))
+	var out []string
+	for _, m := range matches {
+		if strings.HasSuffix(m, ".pub") {
+			continue
+		}
+		out = append(out, m)
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -151,6 +151,10 @@ func RunPHPCaptureEnv(cwd string, args []string, extraEnv []string) (int, error)
 	for _, e := range extraEnv {
 		cmdArgs = append(cmdArgs, "--env", e)
 	}
+	// Point composer/git at the shared ssh-agent when it's running, so private
+	// packages with passphrase-protected keys authenticate over SSH. No-op when
+	// the agent isn't up (falls back to the bind-mounted on-disk keys).
+	cmdArgs = append(cmdArgs, podman.SSHAuthSockEnv()...)
 	cmdArgs = append(cmdArgs, container, "php")
 	cmdArgs = append(cmdArgs, args...)
 

--- a/internal/podman/quadlets/lerd-frankenphp.Containerfile
+++ b/internal/podman/quadlets/lerd-frankenphp.Containerfile
@@ -31,8 +31,10 @@ RUN install-php-extensions {{.CoreExtensions}} \
     && rm -rf /tmp/* /var/cache/apk/*
 
 # nodejs+npm so the Octane file-watcher (lerd octane:reload on) and JS tooling
-# work without an apk add at container start, matching the FPM image.
-RUN apk add --no-cache nodejs npm && rm -rf /var/cache/apk/*
+# work without an apk add at container start; git + openssh-client so git over
+# SSH (private composer packages, source installs run inside this container)
+# works without auth failures. All matching the FPM image.
+RUN apk add --no-cache nodejs npm git openssh-client && rm -rf /var/cache/apk/*
 
 # lerd_devtools: lerd's engine-level Debug-window capture (queries, mail, views,
 # events, jobs, http), compiled here for the ZTS base since install-php-extensions

--- a/internal/podman/quadlets/lerd-php-fpm.Containerfile
+++ b/internal/podman/quadlets/lerd-php-fpm.Containerfile
@@ -122,6 +122,7 @@ RUN apk update && apk add --no-cache \
         libgomp \
         ffmpeg \
         git \
+        openssh-client \
         mysql-client \
         nodejs \
         npm \

--- a/internal/podman/quadlets/lerd-php-fpm.container.tmpl
+++ b/internal/podman/quadlets/lerd-php-fpm.container.tmpl
@@ -17,6 +17,10 @@ ContainerName=lerd-php{{.VersionShort}}-fpm
 Network=lerd
 Volume=%h/.local/share/lerd/hosts:/etc/hosts:ro,z
 Volume=%h:%h:rw
+# Shared ssh-agent socket (lerd auth ssh) so composer's git-over-SSH can reach
+# the user's passphrase-protected keys. Named volume, auto-created by podman;
+# empty until `lerd auth ssh` starts the agent sidecar.
+Volume=lerd-ssh-agent:/ssh-agent
 Volume={{.XdebugIniPath}}:/usr/local/etc/php/conf.d/99-xdebug.ini:ro
 Volume={{.UserIniPath}}:/usr/local/etc/php/conf.d/98-lerd-user.ini:ro
 Volume={{.DumpsDir}}:/usr/local/etc/lerd:ro

--- a/internal/podman/sshagent.go
+++ b/internal/podman/sshagent.go
@@ -1,0 +1,73 @@
+package podman
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Shared ssh-agent sidecar. It holds the user's unlocked SSH keys in memory and
+// exposes its socket on the lerd-ssh-agent named volume, which is also mounted
+// into the FPM containers (see lerd-php-fpm.container.tmpl) so composer's
+// git-over-SSH can reach the agent for private packages with passphrase keys.
+// Keys without a passphrase already work through the bind-mounted ~/.ssh, so the
+// agent is only needed for passphrase-protected keys.
+const (
+	// SSHAgentContainer is the podman container name of the sidecar.
+	SSHAgentContainer = "lerd-ssh-agent"
+	// SSHAgentUnit is the quadlet/systemd unit name (matches the container).
+	SSHAgentUnit = "lerd-ssh-agent"
+	// SSHAgentVolume is the named volume that carries the agent socket. Podman
+	// auto-creates it on first container start; it lives inside the podman
+	// machine on macOS, so the socket never crosses the host-VM boundary.
+	SSHAgentVolume = "lerd-ssh-agent"
+	// SSHAgentMountDir is where the named volume is mounted in every container.
+	SSHAgentMountDir = "/ssh-agent"
+	// SSHAgentSocket is the agent socket path, shared via the named volume.
+	SSHAgentSocket = "/ssh-agent/agent.sock"
+)
+
+// GenerateSSHAgentQuadlet renders the quadlet for the shared ssh-agent sidecar.
+// image is the FPM image to reuse: it ships openssh-client (so ssh-agent and
+// ssh-add are present), which avoids pulling or building a dedicated image. The
+// agent reads key files from the read-only ~/.ssh bind mount; the unlocked key
+// material stays in the agent's memory only.
+func GenerateSSHAgentQuadlet(image string) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, "[Unit]")
+	fmt.Fprintln(&b, "Description=Lerd shared ssh-agent")
+	fmt.Fprintln(&b, "After=network.target")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "[Container]")
+	fmt.Fprintf(&b, "Image=%s\n", image)
+	fmt.Fprintf(&b, "ContainerName=%s\n", SSHAgentContainer)
+	fmt.Fprintln(&b, "Network=lerd")
+	fmt.Fprintf(&b, "Volume=%s:%s\n", SSHAgentVolume, SSHAgentMountDir)
+	fmt.Fprintln(&b, "Volume=%h/.ssh:%h/.ssh:ro")
+	fmt.Fprintf(&b, "Environment=SSH_AUTH_SOCK=%s\n", SSHAgentSocket)
+	fmt.Fprintln(&b, "PodmanArgs=--security-opt=label=disable")
+	fmt.Fprintf(&b, "Exec=ssh-agent -D -a %s\n", SSHAgentSocket)
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "[Service]")
+	fmt.Fprintln(&b, "Restart=always")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "[Install]")
+	fmt.Fprintln(&b, "WantedBy=default.target")
+	return b.String()
+}
+
+// SSHAuthSockEnv returns the `podman exec` --env arguments that point
+// composer/php at the shared ssh-agent, but only when the agent container is
+// running. When it is not, it returns nil so ssh falls back to the on-disk keys
+// instead of failing against a dead socket.
+func SSHAuthSockEnv() []string {
+	return sshAuthSockEnv(ContainerRunningQuiet(SSHAgentContainer))
+}
+
+// sshAuthSockEnv is the pure decision behind SSHAuthSockEnv, split out so it can
+// be unit-tested without a running container.
+func sshAuthSockEnv(agentRunning bool) []string {
+	if !agentRunning {
+		return nil
+	}
+	return []string{"--env", "SSH_AUTH_SOCK=" + SSHAgentSocket}
+}

--- a/internal/podman/sshagent_test.go
+++ b/internal/podman/sshagent_test.go
@@ -1,0 +1,48 @@
+package podman
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSSHAuthSockEnv_RunningInjectsSocket(t *testing.T) {
+	got := sshAuthSockEnv(true)
+	want := []string{"--env", "SSH_AUTH_SOCK=" + SSHAgentSocket}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("sshAuthSockEnv(true) = %v, want %v", got, want)
+	}
+}
+
+func TestSSHAuthSockEnv_StoppedReturnsNil(t *testing.T) {
+	if got := sshAuthSockEnv(false); got != nil {
+		t.Errorf("sshAuthSockEnv(false) = %v, want nil (must fall back to on-disk keys)", got)
+	}
+}
+
+func TestGenerateSSHAgentQuadlet(t *testing.T) {
+	content := GenerateSSHAgentQuadlet("lerd-php85-fpm:local")
+	for _, want := range []string{
+		"Image=lerd-php85-fpm:local",
+		"ContainerName=" + SSHAgentContainer,
+		"Volume=" + SSHAgentVolume + ":" + SSHAgentMountDir,
+		"Volume=%h/.ssh:%h/.ssh:ro",
+		"Exec=ssh-agent -D -a " + SSHAgentSocket,
+		"Restart=always",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("quadlet missing %q in:\n%s", want, content)
+		}
+	}
+}
+
+// The FPM container template must mount the agent volume, otherwise composer in
+// the FPM container can't reach the shared agent socket.
+func TestFPMTemplateMountsAgentVolume(t *testing.T) {
+	tmpl, err := GetQuadletTemplate("lerd-php-fpm.container.tmpl")
+	if err != nil {
+		t.Fatalf("reading FPM template: %v", err)
+	}
+	if !strings.Contains(string(tmpl), "Volume="+SSHAgentVolume+":"+SSHAgentMountDir) {
+		t.Errorf("FPM template must mount %s:%s", SSHAgentVolume, SSHAgentMountDir)
+	}
+}


### PR DESCRIPTION
Fixes #643

> **Stacked on #645.** This branch carries the two openssh image commits from #645 so the agent sidecar can reuse the ssh-capable FPM image. Please merge #645 first; the only commit to review here is `feat(auth): lerd auth ssh …`. I'll rebase onto `main` to drop the #645 commits once it merges.

## What

`lerd auth ssh`, mirroring `ddev auth ssh`: load SSH keys into a shared ssh-agent so `lerd composer` can authenticate to private git repositories, including passphrase-protected keys.

Keys without a passphrase already work via the bind-mounted `~/.ssh` once the image has an SSH client (#645). The agent covers passphrase-protected keys, which need an agent the FPM container can reach. On macOS the host agent socket can't cross the podman-machine VM boundary, so the agent runs inside podman.

## How

- A shared `lerd-ssh-agent` sidecar container runs `ssh-agent` and holds the unlocked keys in memory. It reuses the FPM image (the openssh-client added in #645 provides `ssh-agent`/`ssh-add`), so no extra image is pulled or built.
- Its socket lives on the `lerd-ssh-agent` named volume, which is also mounted into the FPM containers, so the socket never crosses the host-VM boundary on macOS.
- `lerd composer` / `lerd php` inject `SSH_AUTH_SOCK` into the container exec only when the agent is running, so they fall back to on-disk keys otherwise.
- Consent/security: the sidecar mounts `~/.ssh` read-only; unlocked key material stays in the agent's memory; keys clear when the agent stops or the machine restarts.

Commands: `lerd auth ssh [key...]` (default `~/.ssh/id_*`), `--list`, `--remove`.

## Verified end-to-end (local macOS, podman machine)

1. `php:rebuild 8.5 --local` → image ships `ssh`/`ssh-agent`/`ssh-add`.
2. `lerd auth ssh <key>` → sidecar up, key loaded (`Identity added`).
3. From inside the FPM container: `SSH_AUTH_SOCK=/ssh-agent/agent.sock ssh-add -l` lists the key, proving the socket is shared across containers via the named volume.
4. `lerd php -r 'echo getenv("SSH_AUTH_SOCK")'` → `/ssh-agent/agent.sock`, the composer/php path injects it.

`go build ./...`, `go vet`, `go test ./internal/cli/ ./internal/podman/` (1229 pass) all green with `-tags nogui`.
