### PR TITLE
cleanup: lerd-aware command to reclaim orphaned podman disk

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"bytes"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/geodro/lerd/internal/activityping"
 	"github.com/geodro/lerd/internal/certs"
+	"github.com/geodro/lerd/internal/cleanup"
 	"github.com/geodro/lerd/internal/cli"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
@@ -58,6 +60,12 @@ func main() {
 	// publish; in the CLI/MCP processes we HTTP-POST to the dashboard.
 	podman.AfterUnitChange = notifyLerdUI
 
+	// A PHP image (re)build orphans the previous image. Flag it here and reclaim
+	// once when the command finishes, so a multi-version install/update coalesces
+	// into a single safe-tier sweep instead of one per built version.
+	var imageRebuilt atomic.Bool
+	podman.OnImageRebuilt = func() { imageRebuilt.Store(true) }
+
 	root := &cobra.Command{
 		Use:     "lerd",
 		Short:   "Lerd — Podman-powered local PHP dev environment for Linux and macOS",
@@ -76,6 +84,13 @@ func main() {
 			cmd.SilenceUsage = true
 			return nil
 		},
+		// After any command that rebuilt a PHP image, reclaim the now-orphaned
+		// image (safe tier, gated by auto_cleanup). Runs once per command.
+		PersistentPostRun: func(_ *cobra.Command, _ []string) {
+			if imageRebuilt.Load() {
+				cleanup.SweepSafe()
+			}
+		},
 	}
 
 	// Register all subcommands
@@ -85,6 +100,7 @@ func main() {
 	root.AddCommand(cli.NewQuitCmd())
 	root.AddCommand(cli.NewUpdateCmd(version.Version))
 	root.AddCommand(cli.NewUninstallCmd())
+	root.AddCommand(cli.NewCleanupCmd())
 	root.AddCommand(cli.NewParkCmd())
 	root.AddCommand(cli.NewInitCmd())
 	root.AddCommand(cli.NewLinkCmd())
@@ -495,6 +511,11 @@ func newWatchCmd() *cobra.Command {
 			// under launchd that can be left orphaned by an interrupted
 			// migration or sleep/wake bridge churn. No-op on Linux.
 			go watcher.WatchExecWorkers(60 * time.Second)
+
+			// Reclaim orphaned lerd images (safe tier) on a slow daily cadence,
+			// so rebuild leftovers and stale base images don't pile up. Gated by
+			// the auto_cleanup config; never touches service images (--deep).
+			go watcher.WatchCleanup(time.Hour)
 
 			// Idle-suspend: suspends/resumes workers by activity. The whole session,
 			// including the source-file watcher passed here, only runs while the

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -165,6 +165,7 @@ export default defineConfig({
             { text: 'Service presets', link: '/usage/service-presets' },
             { text: 'Custom services', link: '/usage/custom-services' },
             { text: 'Database', link: '/usage/database' },
+            { text: 'Disk cleanup', link: '/usage/cleanup' },
           ],
         },
         {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,15 @@ host_proxy:
                           # "start this command on your host?" confirmation.
                           # Default false so a command from a cloned repo is
                           # never run unconfirmed. See usage/host-proxy.md.
+auto_cleanup: true      # when true (default), lerd reclaims its own orphaned
+                        # podman images on its own: the lerd-watcher runs a safe
+                        # daily sweep, and a PHP rebuild or a service update/remove
+                        # reclaims the image it just superseded. Only ever removes
+                        # lerd's own images (old PHP build and base images,
+                        # superseded service versions), never data volumes or
+                        # images in use. Toggle with `lerd cleanup auto on/off`
+                        # (or set this key); `lerd cleanup` still works on demand
+                        # when off. See reference/commands.md.
 parked_directories:
   - ~/Lerd
 services:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -24,7 +24,14 @@
 | `lerd man [page]` | Browse the built-in documentation in the terminal; pass a page name to jump directly (e.g. `lerd man sites`) |
 | `lerd tui` | Open a btop-style terminal dashboard with live site / service / worker status, per-site detail pane, inline domain and version editing, shell drop-in, log tailing, filter + sort, and global settings |
 | `lerd check` | Validate `.lerd.yaml` syntax, services, and PHP version before setup |
-| `lerd doctor` | Full environment diagnostic: podman, systemd, DNS, ports, PHP images, config validity |
+| `lerd doctor` | Full environment diagnostic: podman, systemd, DNS, ports, PHP images, config validity; also reports how much podman disk is reclaimable |
+| `lerd cleanup` | Reclaim podman disk from orphaned lerd images: old PHP build images and stale base images a rebuild left behind. Previews the list and confirms before removing. Only ever touches lerd's own images, never your databases, volumes, or other images |
+| `lerd cleanup --dry-run` | Show what would be reclaimed and the approximate size, remove nothing |
+| `lerd cleanup --deep` | Also remove unused service images no installed service references any more (e.g. an old `mysql:8.0` after upgrading), keeping each service's current image and its one-back rollback target |
+| `lerd cleanup --yes` | Remove without the confirmation prompt |
+| `lerd cleanup auto on` | Enable automatic cleanup (the default): the watcher's daily safe-tier sweep plus immediate reaping after a PHP rebuild or service update/remove |
+| `lerd cleanup auto off` | Disable automatic cleanup; `lerd cleanup` still works on demand |
+| `lerd cleanup auto status` | Show whether automatic cleanup is enabled |
 | `lerd bug-report [-o file] [--log-lines n] [--show-real-names]` | Dump doctor output, config files, unit state, recent logs, network state and env vars to a plain-text file you can attach to a GitHub issue. Site names, domains, parked paths, home paths and the username are anonymized by default; `--show-real-names` keeps raw values |
 | `lerd logs [-f] [target]` | Show logs for the current project's FPM container, `nginx`, a service name, or a PHP version |
 

--- a/docs/usage/cleanup.md
+++ b/docs/usage/cleanup.md
@@ -1,0 +1,52 @@
+# Disk cleanup
+
+Local PHP development on podman accumulates reclaimable image data. Every PHP image rebuild re-points the fixed `:local` tag and leaves the old image dangling, every Containerfile hash bump (from a lerd update) strands the previous base image, and every service upgrade leaves the old version's image behind. Left alone, a machine that only ever kicked the tyres can end up tens of gigabytes deep.
+
+`lerd cleanup` reclaims that space. Unlike a blunt `podman system prune -a`, it knows which images are load-bearing and only ever removes lerd's own, so it can never eat a database or another tool's images.
+
+## What it removes
+
+**Safe tier** (the default, and what runs automatically):
+
+- **Orphaned PHP build images** — the old `lerd-php<ver>-fpm:local` / `lerd-frankenphp<ver>:local` image a rebuild left dangling when it re-pointed the tag.
+- **Orphaned base images** — a pre-built `lerd-php*-fpm-base` image nothing live is built on: an old Containerfile hash, or a PHP version you no longer have installed. Whether a base is still in use is decided by **layer ancestry** (is its top layer part of any live image?), so a base the current PHP image is built on is always kept, never untagged into a needless re-pull.
+
+**Deep tier** (`--deep`, on demand only):
+
+- **Unused service images** — a service image no installed service references any more, e.g. an old `mysql:8.0` after you upgraded to `8.4`. Each service's **current image and its one-back rollback target are kept**, so a rollback still works.
+
+## What it never touches
+
+- Any image not provably lerd's. An image qualifies only by a `dev.lerd.*` label or the `lerd-php*-fpm-base` repo name (service images are matched against lerd's own preset catalogue). Your own `mysql:8.0` pulled outside lerd, or any unrelated image, is left alone.
+- Named data volumes — your databases are never in scope.
+- Any image a running container uses, and any image still referenced by an installed service.
+
+Removal is reference-count safe: layers an image still shares with a live image stay on disk, and an image that turns out to be in use is skipped rather than forced.
+
+## Commands
+
+```bash
+lerd cleanup              # preview, confirm, then reclaim the safe tier
+lerd cleanup --dry-run    # show what would be reclaimed and the size, remove nothing
+lerd cleanup --deep       # also reclaim unused service images (keeps current + rollback)
+lerd cleanup --yes        # skip the confirmation prompt (for scripts)
+```
+
+Reported sizes are the disk actually freed (an image's unique layers, not its full size), so the figure is honest even when images share base layers. `lerd doctor` shows the reclaimable total as a read-only line so you discover the bloat early.
+
+The destructive command is CLI-only by design, consistent with keeping destructive operations out of the dashboard and TUI.
+
+## Automatic cleanup
+
+Cleanup is on by default and safe, so the disk doesn't grow on its own:
+
+- **On rebuild / service change** — a PHP rebuild (`lerd use`, `lerd php:rebuild`, `lerd php:ext`/`php:pkg`, a `lerd update` that bumps the Containerfile) reclaims the image it just superseded immediately. A `lerd service update` or `lerd service remove` reclaims that service's now-unused versions, scoped to that one service.
+- **Daily backstop** — the `lerd-watcher` runs a safe-tier sweep about once a day (throttled by a timestamp so a restarting watcher can't sweep more often), catching anything an interrupted operation left behind.
+
+The automatic path only ever runs the **safe tier**, never `--deep`. Toggle it with `lerd cleanup auto on` / `lerd cleanup auto off` (or set `auto_cleanup` in [`~/.config/lerd/config.yaml`](../configuration.md)); `lerd cleanup auto status` shows the current state. When off, `lerd cleanup` stays available on demand.
+
+```bash
+lerd cleanup auto off       # disable the automatic sweep and event-driven reaping
+lerd cleanup auto on        # re-enable (the default)
+lerd cleanup auto status    # show whether automatic cleanup is on
+```

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -1,0 +1,309 @@
+// Package cleanup reclaims podman disk that lerd itself created — the orphaned
+// PHP/FrankenPHP images that rebuilds leave behind — and nothing else. An image
+// is only ever eligible when it is provably lerd's: a dev.lerd.* label, or the
+// lerd-php*-fpm-base repo name only lerd's pre-built base images use. So it can
+// never touch images, containers, or volumes belonging to anything else.
+package cleanup
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// lerdLabelPrefix is stamped (as a hash label) on every image lerd builds. Its
+// presence is the single proof that an image is lerd's, and the only gate for
+// considering a built image for removal.
+const lerdLabelPrefix = "dev.lerd."
+
+// baseImageRe matches a lerd pre-built PHP base image ref. These are pulled from
+// a registry and carry no dev.lerd.* label, so the repo name (which only lerd's
+// base images use) is the ownership signal.
+var baseImageRe = regexp.MustCompile(`/lerd-php\d+-fpm-base:`)
+
+// Target is one reclaimable resource.
+type Target struct {
+	Kind  string // "image"
+	ID    string // short image ID
+	Desc  string // human description for the plan output
+	Bytes int64
+}
+
+// Plan is the set of lerd-owned resources that are safe to reclaim.
+type Plan struct {
+	Targets []Target
+}
+
+// ReclaimBytes is the total disk the plan would free.
+func (p Plan) ReclaimBytes() int64 {
+	var total int64
+	for _, t := range p.Targets {
+		total += t.Bytes
+	}
+	return total
+}
+
+// image mirrors the fields lerd needs from `podman images --format json`.
+// SharedSize is the bytes of layers this image shares with others; subtracting
+// it from Size gives the disk actually freed by removing the image, since shared
+// base layers stay behind for the live images that still reference them.
+type image struct {
+	ID         string            `json:"Id"`
+	Names      []string          `json:"Names"`
+	Size       int64             `json:"Size"`
+	SharedSize int64             `json:"SharedSize"`
+	Labels     map[string]string `json:"Labels"`
+}
+
+// reclaimable is the disk removing img would actually free: its layers that no
+// other image shares. Never negative.
+func reclaimable(img image) int64 {
+	if u := img.Size - img.SharedSize; u > 0 {
+		return u
+	}
+	return 0
+}
+
+// scanImages and imageLayers are the seams tests override; they read local
+// image state via podman. imageLayers inspects in one batched call, keyed by the
+// IDs passed in (podman returns one result line per arg, in order).
+var (
+	scanImages  = podmanImages
+	imageLayers = podmanImageLayers
+)
+
+func podmanImages() ([]image, error) {
+	out, err := podman.Run("images", "--format", "json")
+	if err != nil {
+		return nil, err
+	}
+	var imgs []image
+	if err := json.Unmarshal([]byte(out), &imgs); err != nil {
+		return nil, fmt.Errorf("parsing podman images: %w", err)
+	}
+	return imgs, nil
+}
+
+func podmanImageLayers(ids []string) (map[string][]string, error) {
+	if len(ids) == 0 {
+		return map[string][]string{}, nil
+	}
+	args := append([]string{"image", "inspect", "--format", "{{json .RootFS.Layers}}"}, ids...)
+	out, err := podman.Run(args...)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != len(ids) {
+		return nil, fmt.Errorf("layer inspect: %d results for %d ids", len(lines), len(ids))
+	}
+	m := make(map[string][]string, len(ids))
+	for i, line := range lines {
+		var layers []string
+		if err := json.Unmarshal([]byte(line), &layers); err != nil {
+			return nil, fmt.Errorf("parsing layers for %s: %w", ids[i], err)
+		}
+		m[ids[i]] = layers
+	}
+	return m, nil
+}
+
+// Inspect returns the safe-tier cleanup plan. It reclaims two kinds of lerd
+// image a rebuild leaves behind:
+//   - derived images lerd built and then orphaned: lerd tags every live build
+//     with a fixed :local tag, so a rebuild re-points the tag and leaves the old
+//     image dangling — the unambiguous "superseded" signal.
+//   - pre-built base images nothing live is built on: a base for an old
+//     Containerfile hash, or for a PHP version no longer installed.
+//
+// Both removals are refcount-safe: layers a live image still shares are kept.
+//
+// When deep is true it also reclaims the more aggressive tier: catalog service
+// images no service references any more (see deepTargets). If the protected set
+// can't be built, the deep tier is skipped rather than risk a wrong removal.
+func Inspect(deep bool) (Plan, error) {
+	imgs, err := scanImages()
+	if err != nil {
+		return Plan{}, err
+	}
+
+	var p Plan
+	add := func(id, desc string, bytes int64) {
+		p.Targets = append(p.Targets, Target{Kind: "image", ID: id, Desc: desc, Bytes: bytes})
+	}
+	var baseCandidates []image
+	for _, img := range imgs {
+		switch {
+		case isLerd(img) && isOrphaned(img):
+			add(shortID(img.ID), describe(img.Labels), reclaimable(img))
+		default:
+			if baseName(img) != "" {
+				baseCandidates = append(baseCandidates, img)
+			}
+		}
+	}
+
+	// Only inspect layers when there is a base image whose in-use status must be
+	// decided; with none, skip the podman inspect calls entirely. If either the
+	// live-image set or the base layers can't be fully read, keep every base
+	// (an inspect failure must never make an in-use base look orphaned).
+	if len(baseCandidates) > 0 {
+		if live, ok := liveLayers(imgs); ok {
+			if baseLayers, err := imageLayers(imageIDs(baseCandidates)); err == nil {
+				for _, img := range baseCandidates {
+					if !builtUpon(baseLayers[img.ID], live) {
+						add(baseName(img), "orphaned PHP base image", reclaimable(img))
+					}
+				}
+			}
+		}
+	}
+
+	if deep {
+		repos, repoErr := serviceRepos()
+		prot, protErr := protectedImages()
+		if repoErr == nil && protErr == nil {
+			p.Targets = append(p.Targets, deepTargets(imgs, repos, prot)...)
+		}
+	}
+	// podman lists a multi-tag image once per tag, so dedupe by ref/ID to avoid
+	// counting or trying to remove the same target twice.
+	p.Targets = dedupTargets(p.Targets)
+	return p, nil
+}
+
+// dedupTargets drops repeated targets, keeping the first of each ID/ref.
+func dedupTargets(ts []Target) []Target {
+	seen := make(map[string]bool, len(ts))
+	out := make([]Target, 0, len(ts))
+	for _, t := range ts {
+		if seen[t.ID] {
+			continue
+		}
+		seen[t.ID] = true
+		out = append(out, t)
+	}
+	return out
+}
+
+// imageIDs returns the IDs of the given images, for a batched layer inspect.
+func imageIDs(imgs []image) []string {
+	ids := make([]string, len(imgs))
+	for i, img := range imgs {
+		ids[i] = img.ID
+	}
+	return ids
+}
+
+// liveLayers collects every layer belonging to a live (still-tagged) lerd-built
+// image, so a base image can be told apart from one nothing is built on. The
+// bool is false when any live image's layers couldn't be read, so the caller
+// can refuse to reap bases against an incomplete live set.
+func liveLayers(imgs []image) (map[string]bool, bool) {
+	var ids []string
+	for _, img := range imgs {
+		if isLerd(img) && !isOrphaned(img) {
+			ids = append(ids, img.ID)
+		}
+	}
+	set := map[string]bool{}
+	if len(ids) == 0 {
+		return set, true
+	}
+	byID, err := imageLayers(ids)
+	if err != nil {
+		return set, false
+	}
+	for _, layers := range byID {
+		for _, l := range layers {
+			set[l] = true
+		}
+	}
+	return set, true
+}
+
+// builtUpon reports whether a live image is built on a base, given the base's
+// layers: true when the base's top layer appears in some live image. Unknown
+// (empty) layers return true, so a base we cannot place is kept.
+func builtUpon(layers []string, live map[string]bool) bool {
+	if len(layers) == 0 {
+		return true
+	}
+	return live[layers[len(layers)-1]]
+}
+
+// baseName returns the image's lerd base-image ref, or "" if it isn't one.
+func baseName(img image) string {
+	for _, n := range img.Names {
+		if baseImageRe.MatchString(n) {
+			return n
+		}
+	}
+	return ""
+}
+
+// removeImage is the seam tests override; it deletes one image by ID.
+var removeImage = podmanRemoveImage
+
+func podmanRemoveImage(id string) error {
+	return podman.RunSilent("image", "rm", id)
+}
+
+// Apply removes every target in the plan and returns the disk reclaimed. A
+// target that fails to remove (e.g. it became referenced since Inspect) is
+// skipped, so one stuck image can't abort the whole sweep.
+func Apply(p Plan) (reclaimed int64) {
+	for _, t := range p.Targets {
+		if err := removeImage(t.ID); err != nil {
+			continue
+		}
+		reclaimed += t.Bytes
+	}
+	return reclaimed
+}
+
+// isLerd reports whether the image was built by lerd, proven by a dev.lerd.*
+// label. Only images that pass this are ever eligible for removal.
+func isLerd(img image) bool {
+	for k := range img.Labels {
+		if strings.HasPrefix(k, lerdLabelPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// isOrphaned reports whether a lerd image has lost its tag (no names, or only
+// the placeholder <none>:<none>), meaning a newer build superseded it.
+func isOrphaned(img image) bool {
+	for _, n := range img.Names {
+		if n != "" && n != "<none>:<none>" {
+			return false
+		}
+	}
+	return true
+}
+
+// describe names the kind of orphaned derived image for the plan output, by its
+// build label (FPM or FrankenPHP). Pre-built base images are described
+// separately at their call site.
+func describe(labels map[string]string) string {
+	for k := range labels {
+		if strings.Contains(k, "frankenphp") {
+			return "orphaned FrankenPHP image"
+		}
+	}
+	return "orphaned PHP image"
+}
+
+// shortID trims a sha256: prefix and truncates to podman's 12-char short form.
+func shortID(id string) string {
+	id = strings.TrimPrefix(id, "sha256:")
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -1,0 +1,158 @@
+package cleanup
+
+import (
+	"errors"
+	"testing"
+)
+
+// withImages swaps the image-scan and layer-inspect seams for fixtures and
+// restores them after. layers maps an image ID to its RootFS layers.
+func withImages(t *testing.T, imgs []image, layers map[string][]string) {
+	t.Helper()
+	scanImages = func() ([]image, error) { return imgs, nil }
+	imageLayers = func(ids []string) (map[string][]string, error) {
+		m := map[string][]string{}
+		for _, id := range ids {
+			if l, ok := layers[id]; ok {
+				m[id] = l
+			}
+		}
+		return m, nil
+	}
+	t.Cleanup(func() {
+		scanImages = podmanImages
+		imageLayers = podmanImageLayers
+	})
+}
+
+func TestInspect_ReclaimsOnlyOrphanedLerdImages(t *testing.T) {
+	withImages(t, []image{
+		// orphaned lerd FPM base (tag moved away on rebuild) → reclaim
+		{ID: "sha256:aaa", Names: nil, Size: 100, Labels: map[string]string{"dev.lerd.fpm.containerfile-hash": "h1"}},
+		// live lerd image (still tagged) → keep
+		{ID: "sha256:bbb", Names: []string{"lerd-php84-fpm:local"}, Size: 200, Labels: map[string]string{"dev.lerd.fpm.containerfile-hash": "h2"}},
+		// dangling but not lerd → keep (only touch lerd)
+		{ID: "sha256:ccc", Names: nil, Size: 400, Labels: nil},
+		// tagged non-lerd image → keep
+		{ID: "sha256:ddd", Names: []string{"mysql:8.4"}, Size: 800, Labels: nil},
+		// orphaned lerd FrankenPHP image; 600 of its 1600 bytes are shared layers,
+		// so only the 1000 unique bytes are actually reclaimable → reclaim
+		{ID: "sha256:eee", Names: []string{"<none>:<none>"}, Size: 1600, SharedSize: 600, Labels: map[string]string{"dev.lerd.frankenphp.containerfile-hash": "h3"}},
+	}, nil)
+
+	p, err := Inspect(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]bool{}
+	for _, tg := range p.Targets {
+		got[tg.ID] = true
+	}
+	if len(got) != 2 || !got["aaa"] || !got["eee"] {
+		t.Fatalf("want exactly orphaned lerd images {aaa,eee}, got %+v", p.Targets)
+	}
+	// aaa contributes its full 100 (no shared layers); eee contributes 1000
+	// (1600 size minus 600 shared) — shared layers are not counted as reclaimed.
+	if want := int64(1100); p.ReclaimBytes() != want {
+		t.Errorf("ReclaimBytes = %d, want %d", p.ReclaimBytes(), want)
+	}
+}
+
+// The "only touch lerd" contract: with nothing lerd-built present, the plan is
+// empty even when the host is full of other reclaimable podman images.
+func TestInspect_NeverTargetsNonLerd(t *testing.T) {
+	withImages(t, []image{
+		{ID: "sha256:111", Names: nil, Size: 999, Labels: nil},                                                        // dangling non-lerd
+		{ID: "sha256:222", Names: []string{"redis:7"}, Size: 999, Labels: nil},                                        // tagged non-lerd
+		{ID: "sha256:333", Names: []string{"<none>:<none>"}, Size: 999, Labels: map[string]string{"maintainer": "x"}}, // dangling, foreign label
+	}, nil)
+
+	p, err := Inspect(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Targets) != 0 {
+		t.Fatalf("non-lerd images must never be targeted, got %+v", p.Targets)
+	}
+}
+
+// A base image is reaped only when nothing live is built on it — covering both
+// an old Containerfile hash for an installed version and a base for a PHP
+// version no longer installed. The base whose layers the live image shares is
+// kept (untagging it would force a needless re-pull and free nothing).
+func TestInspect_ReclaimsOrphanBasesKeepsInUse(t *testing.T) {
+	withImages(t,
+		[]image{
+			// live derived image, built on the current php84 base
+			{ID: "local84", Names: []string{"localhost/lerd-php84-fpm:local"}, Size: 700, Labels: map[string]string{"dev.lerd.fpm.containerfile-hash": "h"}},
+			// current php84 base: its top layer is in the live image → keep
+			{ID: "baseCur", Names: []string{"ghcr.io/geodro/lerd-php84-fpm-base:cur"}, Size: 500},
+			// old-hash php84 base: top layer used by nothing live → reclaim
+			{ID: "baseOld", Names: []string{"ghcr.io/geodro/lerd-php84-fpm-base:old"}, Size: 500},
+			// base for php82, a version no longer installed → reclaim
+			{ID: "base82", Names: []string{"ghcr.io/geodro/lerd-php82-fpm-base:cur"}, Size: 500},
+		},
+		map[string][]string{
+			"local84": {"L1", "L2", "L3", "Lcustom"}, // built on current base + custom layer
+			"baseCur": {"L1", "L2", "L3"},            // top L3 ∈ live → in use
+			"baseOld": {"L1", "L2", "Lold"},          // top Lold ∉ live → orphan
+			"base82":  {"L1", "P82a", "P82b"},        // top P82b ∉ live → orphan
+		},
+	)
+
+	p, err := Inspect(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]bool{}
+	for _, tg := range p.Targets {
+		got[tg.ID] = true
+	}
+	want := map[string]bool{
+		"ghcr.io/geodro/lerd-php84-fpm-base:old": true,
+		"ghcr.io/geodro/lerd-php82-fpm-base:cur": true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("want the two orphan bases reaped, got %+v", p.Targets)
+	}
+	for ref := range want {
+		if !got[ref] {
+			t.Errorf("expected %q reaped, missing", ref)
+		}
+	}
+}
+
+func TestApply_RemovesTargetsAndSumsReclaimed(t *testing.T) {
+	var removed []string
+	removeImage = func(id string) error { removed = append(removed, id); return nil }
+	t.Cleanup(func() { removeImage = podmanRemoveImage })
+
+	got := Apply(Plan{Targets: []Target{{ID: "aaa", Bytes: 100}, {ID: "bbb", Bytes: 250}}})
+
+	if got != 350 {
+		t.Errorf("reclaimed = %d, want 350", got)
+	}
+	if len(removed) != 2 || removed[0] != "aaa" || removed[1] != "bbb" {
+		t.Errorf("removed = %v, want [aaa bbb]", removed)
+	}
+}
+
+// A removal that fails (e.g. the image became referenced since Inspect) is
+// skipped so one stuck image can't abort the sweep, and its bytes aren't counted.
+func TestApply_SkipsFailedRemovalsButContinues(t *testing.T) {
+	removeImage = func(id string) error {
+		if id == "bad" {
+			return errors.New("image is in use")
+		}
+		return nil
+	}
+	t.Cleanup(func() { removeImage = podmanRemoveImage })
+
+	got := Apply(Plan{Targets: []Target{{ID: "bad", Bytes: 100}, {ID: "good", Bytes: 50}}})
+
+	if got != 50 {
+		t.Errorf("reclaimed = %d, want 50 (only the successful removal)", got)
+	}
+}

--- a/internal/cleanup/deep.go
+++ b/internal/cleanup/deep.go
@@ -1,0 +1,156 @@
+package cleanup
+
+import (
+	"os"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/registry"
+)
+
+// serviceRepos and protectedImages are the seams tests override. serviceRepos
+// is the set of normalized image repos lerd's preset catalog manages (mysql,
+// redis, ...); protectedImages is every image a service currently uses or holds
+// as a rollback target, which --deep must never remove.
+var (
+	serviceRepos    = realServiceRepos
+	protectedImages = realProtectedImages
+)
+
+// deepTargets reclaims service images lerd pulled but nothing references any
+// more: an image whose every tag is an unprotected catalog ref. Treating lerd's
+// managed service images as lerd's own, this catches an old mysql:5.7 left
+// behind after upgrading, while the protected set keeps the live image and the
+// one-back rollback target, and an image carrying any non-catalog tag (one the
+// user added themselves) is left entirely alone.
+func deepTargets(imgs []image, repos, protected map[string]bool) []Target {
+	var out []Target
+	for _, img := range imgs {
+		refs := removableServiceRefs(img, repos, protected)
+		// Remove every owned tag so the image actually frees on the last one;
+		// credit the reclaimable bytes once (on that last removal), since
+		// untagging the earlier aliases frees nothing on its own.
+		for i, ref := range refs {
+			bytes := int64(0)
+			if i == len(refs)-1 {
+				bytes = reclaimable(img)
+			}
+			out = append(out, Target{Kind: "image", ID: ref, Desc: "unused service image", Bytes: bytes})
+		}
+	}
+	return out
+}
+
+// removableServiceRefs returns the tags to remove for an unused service image,
+// or nil to keep it. An image is removable only when EVERY one of its tags is an
+// unprotected catalog ref: a protected tag (current image or rollback target) or
+// a non-catalog tag the user added both mean "leave this whole image alone", so
+// cleanup never untags an image something else still relies on.
+func removableServiceRefs(img image, repos, protected map[string]bool) []string {
+	if len(img.Names) == 0 {
+		return nil
+	}
+	refs := make([]string, 0, len(img.Names))
+	for _, n := range img.Names {
+		if protected[canonRef(n)] || !repos[canonRepo(n)] {
+			return nil
+		}
+		refs = append(refs, n)
+	}
+	return refs
+}
+
+// canonRef / canonRepo canonicalise an image reference through the shared
+// registry parser, so a fully-qualified ref and its short form (mysql:8.4 ==
+// docker.io/library/mysql:8.4) compare equal on both sides of every lookup.
+func canonRef(ref string) string {
+	r, err := registry.ParseImage(ref)
+	if err != nil {
+		return ref
+	}
+	return r.Registry + "/" + r.Repo + ":" + r.Tag
+}
+
+func canonRepo(ref string) string {
+	r, err := registry.ParseImage(ref)
+	if err != nil {
+		return ref
+	}
+	return r.Registry + "/" + r.Repo
+}
+
+func realServiceRepos() (map[string]bool, error) {
+	presets, err := config.ListPresets()
+	if err != nil {
+		return nil, err
+	}
+	repos := map[string]bool{}
+	add := func(image string) {
+		if image != "" {
+			repos[canonRepo(image)] = true
+		}
+	}
+	for _, p := range presets {
+		add(p.Image)
+		for _, v := range p.Versions {
+			add(v.Image)
+		}
+	}
+	return repos, nil
+}
+
+func realProtectedImages() (map[string]bool, error) {
+	prot := map[string]bool{}
+	add := func(ref string) {
+		if ref != "" {
+			prot[canonRef(ref)] = true
+		}
+	}
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range cfg.Services {
+		add(s.Image)
+		add(s.PreviousImage)
+	}
+	customs, err := config.ListCustomServices()
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range customs {
+		add(s.Image)
+		add(s.PreviousImage)
+	}
+	for _, ref := range installedServiceImages() {
+		add(ref)
+	}
+	return prot, nil
+}
+
+// installedServiceImages returns the current Image= of every installed service
+// quadlet, so a service that is installed but not running is still protected.
+// PHP-FPM units are skipped: their images are handled by the safe tier.
+func installedServiceImages() []string {
+	entries, err := os.ReadDir(config.QuadletDir())
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "lerd-") || !strings.HasSuffix(name, ".container") {
+			continue
+		}
+		unit := strings.TrimSuffix(name, ".container")
+		if strings.HasPrefix(unit, "lerd-php") && strings.HasSuffix(unit, "-fpm") {
+			continue
+		}
+		if img := podman.InstalledImage(unit); img != "" {
+			out = append(out, img)
+		}
+	}
+	return out
+}

--- a/internal/cleanup/deep_test.go
+++ b/internal/cleanup/deep_test.go
@@ -1,0 +1,120 @@
+package cleanup
+
+import "testing"
+
+// Catalog repos and protected refs are keyed by canonical form (the same
+// registry.ParseImage canonicalisation deepTargets applies to image names).
+func TestDeepTargets_ReapsUnusedServiceImagesKeepsProtected(t *testing.T) {
+	imgs := []image{
+		{Names: []string{"docker.io/library/mysql:8.4"}, Size: 500},   // current → protected
+		{Names: []string{"docker.io/library/mysql:5.7"}, Size: 400},   // unused old → reap
+		{Names: []string{"docker.io/library/redis:7"}, Size: 100},     // one-back rollback → protected
+		{Names: []string{"docker.io/library/postgres:16"}, Size: 900}, // repo not in catalog → keep
+		{Names: []string{"ubuntu:22.04"}, Size: 700},                  // user's own image → keep
+		// multi-tag image: the rolling alias is unprotected but the pinned tag is
+		// in use, so the whole image must be kept (per-image protection)
+		{Names: []string{"docker.io/library/redis:7-alpine", "docker.io/library/redis:7.4.9-alpine"}, Size: 40},
+	}
+	repos := map[string]bool{"docker.io/library/mysql": true, "docker.io/library/redis": true}
+	protected := map[string]bool{
+		"docker.io/library/mysql:8.4":          true,
+		"docker.io/library/redis:7":            true,
+		"docker.io/library/redis:7.4.9-alpine": true,
+	}
+
+	got := deepTargets(imgs, repos, protected)
+
+	if len(got) != 1 || got[0].ID != "docker.io/library/mysql:5.7" {
+		t.Fatalf("want only mysql:5.7 reaped, got %+v", got)
+	}
+	if got[0].Bytes != 400 {
+		t.Errorf("bytes = %d, want 400", got[0].Bytes)
+	}
+}
+
+// A multi-tag image whose tags are ALL unprotected catalog refs must have every
+// tag removed (so the image actually frees), with the reclaimable bytes credited
+// exactly once. An image carrying a non-catalog tag is left entirely alone.
+func TestDeepTargets_MultiTagRemovesAllTagsCreditsOnce(t *testing.T) {
+	imgs := []image{
+		// both tags catalog + unprotected → remove both, count bytes once
+		{Names: []string{"docker.io/library/mysql:5.7", "docker.io/library/mysql:5.7.40"}, Size: 400},
+		// catalog tag + a user's own tag → keep the whole image
+		{Names: []string{"docker.io/library/mysql:8.0", "myown:tag"}, Size: 999},
+	}
+	repos := map[string]bool{"docker.io/library/mysql": true}
+	protected := map[string]bool{}
+
+	got := deepTargets(imgs, repos, protected)
+
+	removed := map[string]int64{}
+	for _, tg := range got {
+		removed[tg.ID] = tg.Bytes
+	}
+	if len(removed) != 2 ||
+		!hasKey(removed, "docker.io/library/mysql:5.7") ||
+		!hasKey(removed, "docker.io/library/mysql:5.7.40") {
+		t.Fatalf("want both mysql:5.7 tags removed, none from the user-tagged image, got %+v", got)
+	}
+	var total int64
+	for _, b := range removed {
+		total += b
+	}
+	if total != 400 {
+		t.Errorf("reclaimable credited = %d, want 400 (once for the image)", total)
+	}
+}
+
+func hasKey(m map[string]int64, k string) bool { _, ok := m[k]; return ok }
+
+// The deep tier is additive: the safe tier never touches service images, and
+// only --deep reaps the unused one, leaving the current image alone.
+func TestInspect_DeepAppendsUnusedServiceImages(t *testing.T) {
+	withImages(t, []image{
+		{ID: "m57", Names: []string{"docker.io/library/mysql:5.7"}, Size: 400}, // unused → deep reap
+		{ID: "m84", Names: []string{"docker.io/library/mysql:8.4"}, Size: 500}, // current → keep
+	}, nil)
+	serviceRepos = func() (map[string]bool, error) {
+		return map[string]bool{"docker.io/library/mysql": true}, nil
+	}
+	protectedImages = func() (map[string]bool, error) {
+		return map[string]bool{"docker.io/library/mysql:8.4": true}, nil
+	}
+	t.Cleanup(func() {
+		serviceRepos = realServiceRepos
+		protectedImages = realProtectedImages
+	})
+
+	safe, err := Inspect(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(safe.Targets) != 0 {
+		t.Fatalf("safe tier must not touch service images, got %+v", safe.Targets)
+	}
+
+	deep, err := Inspect(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deep.Targets) != 1 || deep.Targets[0].ID != "docker.io/library/mysql:5.7" {
+		t.Fatalf("deep tier should reap only mysql:5.7, got %+v", deep.Targets)
+	}
+}
+
+func TestCanonRefAndRepo(t *testing.T) {
+	refCases := map[string]string{
+		"mysql:8.4":                   "docker.io/library/mysql:8.4",
+		"docker.io/library/mysql:8.4": "docker.io/library/mysql:8.4",
+		"getmeili/meilisearch:v1.7":   "docker.io/getmeili/meilisearch:v1.7",
+		"ghcr.io/x/y:tag":             "ghcr.io/x/y:tag",
+	}
+	for in, want := range refCases {
+		if got := canonRef(in); got != want {
+			t.Errorf("canonRef(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if got := canonRepo("docker.io/library/mysql:8.4"); got != "docker.io/library/mysql" {
+		t.Errorf("canonRepo = %q, want docker.io/library/mysql", got)
+	}
+}

--- a/internal/cleanup/events.go
+++ b/internal/cleanup/events.go
@@ -1,0 +1,52 @@
+package cleanup
+
+import "github.com/geodro/lerd/internal/config"
+
+// autoEnabled reports whether automatic cleanup is on. Seam for tests.
+var autoEnabled = defaultAutoEnabled
+
+func defaultAutoEnabled() bool {
+	cfg, err := config.LoadGlobal()
+	return err == nil && cfg.AutoCleanupEnabled()
+}
+
+// SweepSafe runs the safe-tier cleanup immediately when auto_cleanup is on. It
+// is the event hook for the moment a PHP image rebuild orphans the old image,
+// reaping it at once instead of waiting for the daily watcher. Returns the
+// number of images reaped and bytes freed; err is non-nil only when the image
+// scan itself failed, so the watcher can tell a transient failure (retry) from
+// "nothing to do" (throttle). All-zero with nil err when disabled or clean.
+func SweepSafe() (images int, bytes int64, err error) {
+	if !autoEnabled() {
+		return 0, 0, nil
+	}
+	plan, err := Inspect(false)
+	if err != nil {
+		return 0, 0, err
+	}
+	return len(plan.Targets), Apply(plan), nil
+}
+
+// SweepRefs reaps the exact image references lerd is dropping (the superseded
+// version after a service update, the removed service's images after a remove).
+// Each ref is one lerd itself recorded, so it is provably lerd's; a ref another
+// service still references (in the protected set) is skipped. Reaping precise
+// refs rather than a whole repo means a user's own same-repo image is never
+// touched. Gated by auto_cleanup.
+func SweepRefs(refs ...string) {
+	if !autoEnabled() {
+		return
+	}
+	prot, err := protectedImages()
+	if err != nil {
+		return
+	}
+	seen := map[string]bool{}
+	for _, ref := range refs {
+		if ref == "" || seen[ref] || prot[canonRef(ref)] {
+			continue
+		}
+		seen[ref] = true
+		_ = removeImage(ref)
+	}
+}

--- a/internal/cleanup/events_test.go
+++ b/internal/cleanup/events_test.go
@@ -1,0 +1,58 @@
+package cleanup
+
+import "testing"
+
+// SweepRefs reaps exactly the refs lerd hands it, skipping any the protected set
+// still holds, and never scans the whole repo (so a user's same-repo image that
+// wasn't passed is untouched).
+func TestSweepRefs_ReapsGivenRefsSkipsProtected(t *testing.T) {
+	autoEnabled = func() bool { return true }
+	protectedImages = func() (map[string]bool, error) {
+		return map[string]bool{"docker.io/library/mysql:8.4": true}, nil
+	}
+	var removed []string
+	removeImage = func(id string) error { removed = append(removed, id); return nil }
+	t.Cleanup(func() {
+		autoEnabled = defaultAutoEnabled
+		protectedImages = realProtectedImages
+		removeImage = podmanRemoveImage
+	})
+
+	// 5.7 is the superseded ref → removed; 8.4 is still current → protected, skipped;
+	// "" is ignored; the duplicate is collapsed.
+	SweepRefs("docker.io/library/mysql:5.7", "docker.io/library/mysql:8.4", "", "docker.io/library/mysql:5.7")
+
+	if len(removed) != 1 || removed[0] != "docker.io/library/mysql:5.7" {
+		t.Fatalf("want only the superseded mysql:5.7 removed, got %v", removed)
+	}
+}
+
+func TestSweepRefs_GatedOffNoOp(t *testing.T) {
+	autoEnabled = func() bool { return false }
+	called := false
+	removeImage = func(string) error { called = true; return nil }
+	t.Cleanup(func() {
+		autoEnabled = defaultAutoEnabled
+		removeImage = podmanRemoveImage
+	})
+
+	SweepRefs("docker.io/library/mysql:5.7")
+	if called {
+		t.Error("gated off must not remove anything")
+	}
+}
+
+func TestSweepSafe_GatedOffNoOp(t *testing.T) {
+	autoEnabled = func() bool { return false }
+	scanned := false
+	scanImages = func() ([]image, error) { scanned = true; return nil, nil }
+	t.Cleanup(func() {
+		autoEnabled = defaultAutoEnabled
+		scanImages = podmanImages
+	})
+
+	images, bytes, err := SweepSafe()
+	if err != nil || images != 0 || bytes != 0 || scanned {
+		t.Errorf("gated off must no-op without scanning: images=%d bytes=%d err=%v scanned=%v", images, bytes, err, scanned)
+	}
+}

--- a/internal/cli/cleanup.go
+++ b/internal/cli/cleanup.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/geodro/lerd/internal/cleanup"
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
+	"github.com/spf13/cobra"
+)
+
+// NewCleanupCmd returns the cleanup command: reclaim podman disk that lerd's
+// own image rebuilds have orphaned, without ever touching a non-lerd resource.
+func NewCleanupCmd() *cobra.Command {
+	var dryRun, yes, deep bool
+	cmd := &cobra.Command{
+		Use:   "cleanup",
+		Short: "Reclaim podman disk from orphaned lerd images",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runCleanup(dryRun, yes, deep)
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be reclaimed without removing anything")
+	cmd.Flags().BoolVar(&yes, "yes", false, "Remove without confirming")
+	cmd.Flags().BoolVar(&deep, "deep", false, "Also remove unused service images no service references any more")
+	cmd.AddCommand(newCleanupAutoCmd())
+	return cmd
+}
+
+// newCleanupAutoCmd toggles automatic cleanup (the watcher's daily safe-tier
+// sweep and the post-rebuild / post-service-change reaping), so users don't have
+// to hand-edit config.yaml. Matches the on/off/status shape of lerd idle/notify.
+func newCleanupAutoCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auto",
+		Short: "Enable, disable, or show automatic cleanup",
+		Long: `Toggle automatic cleanup: the lerd-watcher's daily safe-tier sweep and
+the immediate reaping after a PHP rebuild or a service update/remove. On by
+default. Only ever runs the safe tier, never --deep.`,
+	}
+	cmd.AddCommand(
+		&cobra.Command{Use: "on", Short: "Enable automatic cleanup", Args: cobra.NoArgs,
+			RunE: func(_ *cobra.Command, _ []string) error { return runCleanupAutoToggle(true) }},
+		&cobra.Command{Use: "off", Short: "Disable automatic cleanup", Args: cobra.NoArgs,
+			RunE: func(_ *cobra.Command, _ []string) error { return runCleanupAutoToggle(false) }},
+		&cobra.Command{Use: "status", Short: "Show whether automatic cleanup is on", Args: cobra.NoArgs,
+			RunE: func(_ *cobra.Command, _ []string) error { return runCleanupAutoStatus() }},
+	)
+	return cmd
+}
+
+func runCleanupAutoToggle(enable bool) error {
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+	if cfg.AutoCleanupEnabled() == enable {
+		feedback.Line(fmt.Sprintf("Automatic cleanup already %s.", autoStateWord(enable)))
+		return nil
+	}
+	cfg.AutoCleanup = enable
+	if err := config.SaveGlobal(cfg); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+	feedback.Done(fmt.Sprintf("Automatic cleanup %s.", autoStateWord(enable)))
+	return nil
+}
+
+func runCleanupAutoStatus() error {
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return err
+	}
+	state := feedback.Amber("disabled")
+	if cfg.AutoCleanupEnabled() {
+		state = feedback.Green("enabled")
+	}
+	fmt.Printf("Automatic cleanup: %s\n", state)
+	return nil
+}
+
+func autoStateWord(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}
+
+func runCleanup(dryRun, yes, deep bool) error {
+	plan, err := cleanup.Inspect(deep)
+	if err != nil {
+		return err
+	}
+	if len(plan.Targets) == 0 {
+		feedback.Line("Nothing to clean up. No orphaned lerd images.")
+		return nil
+	}
+
+	// Sizes are per-image reclaimable (unique layers only); shared base layers
+	// stay behind for the live images that still reference them.
+	rows := make([][]string, 0, len(plan.Targets))
+	for _, t := range plan.Targets {
+		rows = append(rows, []string{t.ID, t.Desc, humanSize(t.Bytes)})
+	}
+	feedback.Header("Reclaimable lerd images")
+	feedback.Table([]string{"IMAGE", "KIND", "RECLAIMABLE"}, rows)
+	feedback.Note(fmt.Sprintf("About %s across %d image(s).", humanSize(plan.ReclaimBytes()), len(plan.Targets)))
+
+	if dryRun {
+		return nil
+	}
+	if !yes && !feedback.Confirm("Remove these images?", false) {
+		return nil
+	}
+
+	feedback.Done(fmt.Sprintf("Freed about %s.", humanSize(cleanup.Apply(plan))))
+	return nil
+}

--- a/internal/cli/cleanup_auto_test.go
+++ b/internal/cli/cleanup_auto_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// runCleanupAutoToggle persists the auto_cleanup flag so the watcher and event
+// hooks read it back. Default is on; off then on must round-trip through config.
+func TestCleanupAutoToggle_PersistsFlag(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.AutoCleanupEnabled() {
+		t.Fatal("auto cleanup should start enabled by default")
+	}
+
+	if err := runCleanupAutoToggle(false); err != nil {
+		t.Fatalf("toggle off: %v", err)
+	}
+	if cfg, _ := config.LoadGlobal(); cfg.AutoCleanupEnabled() {
+		t.Error("expected disabled after toggle off")
+	}
+
+	if err := runCleanupAutoToggle(true); err != nil {
+		t.Fatalf("toggle on: %v", err)
+	}
+	if cfg, _ := config.LoadGlobal(); !cfg.AutoCleanupEnabled() {
+		t.Error("expected enabled after toggle on")
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/geodro/lerd/internal/cleanup"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
 	"github.com/geodro/lerd/internal/feedback"
@@ -335,6 +336,10 @@ func RunDoctorTo(w io.Writer, useColor bool) (fails, warns int, err error) {
 		} else {
 			ok(fmt.Sprintf("PHP %s image", v))
 		}
+	}
+
+	if plan, planErr := cleanup.Inspect(false); planErr == nil && plan.ReclaimBytes() > 0 {
+		info("Reclaimable disk", fmt.Sprintf("about %s (run: lerd cleanup)", humanSize(plan.ReclaimBytes())))
 	}
 
 	// ── Container → Host Connectivity ────────────────────────────────────────

--- a/internal/config/auto_cleanup_test.go
+++ b/internal/config/auto_cleanup_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestAutoCleanupEnabled_NilAndExplicit(t *testing.T) {
+	var nilCfg *GlobalConfig
+	if !nilCfg.AutoCleanupEnabled() {
+		t.Error("nil config should report auto-cleanup on")
+	}
+	if (&GlobalConfig{AutoCleanup: true}).AutoCleanupEnabled() != true {
+		t.Error("AutoCleanup=true should report on")
+	}
+	if (&GlobalConfig{AutoCleanup: false}).AutoCleanupEnabled() != false {
+		t.Error("AutoCleanup=false should report off")
+	}
+}
+
+// An existing config that predates the auto_cleanup key must default on, which
+// relies on defaultConfig seeding true and viper merging only present keys.
+func TestLoadGlobal_AutoCleanupDefaultsOnWhenKeyAbsent(t *testing.T) {
+	setConfigDir(t)
+	if err := os.MkdirAll(ConfigDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(GlobalConfigFile(), []byte("php:\n  default_version: \"8.4\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	invalidateGlobalCache()
+
+	cfg, err := LoadGlobal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.AutoCleanupEnabled() {
+		t.Error("auto_cleanup absent from config should default on")
+	}
+}
+
+func TestLoadGlobal_AutoCleanupHonoursDisable(t *testing.T) {
+	setConfigDir(t)
+	if err := os.MkdirAll(ConfigDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(GlobalConfigFile(), []byte("auto_cleanup: false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	invalidateGlobalCache()
+
+	cfg, err := LoadGlobal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AutoCleanupEnabled() {
+		t.Error("auto_cleanup: false should disable the sweep")
+	}
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -206,8 +206,19 @@ type GlobalConfig struct {
 		// DefaultIdleSuspendTimeout; read it via IdleSuspendTimeout.
 		Timeout string `yaml:"timeout,omitempty" mapstructure:"timeout"`
 	} `yaml:"idle_suspend,omitempty" mapstructure:"idle_suspend"`
+	// AutoCleanup lets the watcher periodically reclaim orphaned lerd images
+	// (safe tier only, never service images). On by default; set false to turn
+	// off the daily sweep. Read it via AutoCleanupEnabled for nil-safety.
+	AutoCleanup       bool                     `yaml:"auto_cleanup"       mapstructure:"auto_cleanup"`
 	ParkedDirectories []string                 `yaml:"parked_directories" mapstructure:"parked_directories"`
 	Services          map[string]ServiceConfig `yaml:"services"           mapstructure:"services"`
+}
+
+// AutoCleanupEnabled reports whether the watcher's periodic image cleanup is on.
+// Nil-safe and defaults on, matching defaultConfig, so an unconfigured install
+// reclaims orphaned images on its own.
+func (c *GlobalConfig) AutoCleanupEnabled() bool {
+	return c == nil || c.AutoCleanup
 }
 
 // DefaultIdleSuspendTimeout is how long a site stays idle before its
@@ -274,6 +285,7 @@ func defaultConfig() *GlobalConfig {
 	cfg.Nginx.HTTPSPort = 443
 	cfg.DNS.Enabled = true
 	cfg.DNS.TLD = "test"
+	cfg.AutoCleanup = true
 
 	home, _ := os.UserHomeDir()
 	cfg.ParkedDirectories = []string{home + "/Lerd"}

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -32,6 +32,12 @@ var DaemonReloadFn func() error = DaemonReload
 // Set to true on macOS where the unit file is a launchd plist, not a quadlet.
 var SkipQuadletUpToDateCheck bool
 
+// OnImageRebuilt, when set, is invoked after a PHP FPM/FrankenPHP image is
+// actually (re)built — the moment the old image of that version is orphaned. A
+// higher layer wires it to reclaim that orphan at once (event-driven cleanup);
+// it is injected here because podman must not import the cleanup package.
+var OnImageRebuilt func()
+
 // ExtraVolumePaths returns absolute paths that need to be bind-mounted into the
 // PHP-FPM container because they are outside the user's home directory. It
 // collects parked directories and linked site paths, deduplicates them, and
@@ -469,6 +475,9 @@ build:
 	}
 
 	fmt.Fprintf(w, "  PHP %s image built successfully.\n", version)
+	if OnImageRebuilt != nil {
+		OnImageRebuilt()
+	}
 	return nil
 }
 

--- a/internal/podman/frankenphp_build.go
+++ b/internal/podman/frankenphp_build.go
@@ -184,6 +184,9 @@ func buildFrankenPHPImage(version string, force bool, customExts, packages []str
 		return fmt.Errorf("building FrankenPHP PHP %s image: %w", version, err)
 	}
 	fmt.Fprintf(w, "  FrankenPHP PHP %s image built successfully.\n", version)
+	if OnImageRebuilt != nil {
+		OnImageRebuilt()
+	}
 	return nil
 }
 

--- a/internal/serviceops/remove.go
+++ b/internal/serviceops/remove.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/geodro/lerd/internal/cleanup"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
 )
@@ -71,6 +72,10 @@ func RemoveService(name string, opts RemoveOptions, emit func(PhaseEvent)) error
 	}
 	unit := "lerd-" + name
 
+	// Capture the service's images before its config/quadlet are removed, so
+	// cleanup can reclaim exactly those once nothing references them.
+	removedImage, removedPrev := serviceImageRefs(name)
+
 	var family string
 	if existing, err := config.LoadCustomService(name); err == nil {
 		family = existing.Family
@@ -121,6 +126,10 @@ func RemoveService(name string, opts RemoveOptions, emit func(PhaseEvent)) error
 	}
 
 	emit(PhaseEvent{Phase: "done"})
+	// The service is gone from config now, so its current and rollback images are
+	// unreferenced unless another service shares them. Reclaim exactly those refs
+	// (auto_cleanup gated); the protected set keeps any another service still holds.
+	cleanup.SweepRefs(removedImage, removedPrev)
 	return nil
 }
 

--- a/internal/serviceops/update.go
+++ b/internal/serviceops/update.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/geodro/lerd/internal/cleanup"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/registry"
@@ -154,6 +155,11 @@ func UpdateServiceStreaming(name, targetImage string, emit func(PhaseEvent)) err
 	unlock := lockService(name)
 	defer unlock()
 
+	// The image currently held as the rollback target becomes unreferenced once
+	// this update sets PreviousImage to the outgoing current. Capture it now so
+	// we can reclaim exactly that superseded image afterwards.
+	_, superseded := serviceImageRefs(name)
+
 	emit(PhaseEvent{Phase: "checking_registry"})
 	chosenImage := targetImage
 	if chosenImage == "" {
@@ -188,7 +194,32 @@ func UpdateServiceStreaming(name, targetImage string, emit func(PhaseEvent)) err
 		return err
 	}
 	emit(PhaseEvent{Phase: "done", Image: chosenImage, Unit: unit})
+	// Reclaim exactly the image this update superseded (the old rollback target),
+	// not the whole repo, so a user's own same-repo image is never touched. The
+	// protected set still guards against removing an image another service holds.
+	cleanup.SweepRefs(superseded)
 	return nil
+}
+
+// serviceImageRefs returns the image refs lerd records for a service: its
+// current image and the one-back rollback target. For a default preset the
+// current image lives in the installed quadlet (config may leave it empty), so
+// that is preferred; for a custom service both come from its config.
+func serviceImageRefs(name string) (current, previous string) {
+	if config.IsDefaultPreset(name) {
+		if cfg, err := config.LoadGlobal(); err == nil {
+			s := cfg.Services[name]
+			current, previous = s.Image, s.PreviousImage
+		}
+		if img := podman.InstalledImage("lerd-" + name); img != "" {
+			current = img
+		}
+		return current, previous
+	}
+	if svc, err := config.LoadCustomService(name); err == nil && svc != nil {
+		return svc.Image, svc.PreviousImage
+	}
+	return current, previous
 }
 
 // restartWithRetry handles the "unit not found" race after writing a fresh

--- a/internal/watcher/cleanup.go
+++ b/internal/watcher/cleanup.go
@@ -1,0 +1,90 @@
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/geodro/lerd/internal/cleanup"
+	"github.com/geodro/lerd/internal/config"
+)
+
+// autoCleanupInterval is the minimum gap between automatic safe-tier sweeps.
+// Orphaned images aren't urgent, so a slow daily cadence reclaims rebuild
+// leftovers on its own while keeping the watcher quiet.
+const autoCleanupInterval = 24 * time.Hour
+
+// WatchCleanup periodically reclaims orphaned lerd images (the safe tier only,
+// never the --deep service-image tier). It ticks at interval but acts at most
+// once per autoCleanupInterval, throttled by a persisted timestamp so a
+// restarting watcher can't sweep more often. The auto_cleanup config gate turns
+// it off.
+func WatchCleanup(interval time.Duration) {
+	// Check once at startup too: the daily stamp throttles it, but a watcher
+	// that restarts more often than interval would otherwise never sweep, and a
+	// fresh post-install start has rebuild orphans worth reaping promptly.
+	runAutoCleanup(time.Now())
+
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for range t.C {
+		runAutoCleanup(time.Now())
+	}
+}
+
+// runAutoCleanup performs one throttled, gated safe-tier sweep. Split from the
+// ticker so its decision points are unit-testable with an injected clock. The
+// actual reclaim is delegated to cleanup.SweepSafe so the watcher only adds the
+// throttle and the log line on top of the shared pipeline.
+func runAutoCleanup(now time.Time) {
+	cfg, err := config.LoadGlobal()
+	if err != nil || !cfg.AutoCleanupEnabled() {
+		return
+	}
+	if !cleanupDue(now, lastAutoCleanup()) {
+		return
+	}
+
+	images, freed, err := cleanup.SweepSafe()
+	if err != nil {
+		// Transient podman failure: don't stamp, so the next tick retries
+		// instead of being throttled out for a full interval.
+		return
+	}
+	stampAutoCleanup(now)
+	if images > 0 {
+		logger.Info("auto-cleanup reclaimed orphaned images", "images", images, "bytes", freed)
+	}
+}
+
+// cleanupDue reports whether a full interval has elapsed since the last sweep.
+func cleanupDue(now, last time.Time) bool {
+	return now.Sub(last) >= autoCleanupInterval
+}
+
+// stampPathFn is the seam tests override to redirect the timestamp file.
+var stampPathFn = defaultStampPath
+
+func defaultStampPath() string {
+	return filepath.Join(config.DataDir(), "auto-cleanup.stamp")
+}
+
+// lastAutoCleanup reads the last sweep time, or the zero time when the stamp is
+// missing or unreadable (so the first sweep is always due).
+func lastAutoCleanup() time.Time {
+	b, err := os.ReadFile(stampPathFn())
+	if err != nil {
+		return time.Time{}
+	}
+	secs, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(secs, 0)
+}
+
+func stampAutoCleanup(now time.Time) {
+	_ = os.WriteFile(stampPathFn(), []byte(strconv.FormatInt(now.Unix(), 10)), 0o644)
+}

--- a/internal/watcher/cleanup_test.go
+++ b/internal/watcher/cleanup_test.go
@@ -1,0 +1,43 @@
+package watcher
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCleanupDue(t *testing.T) {
+	now := time.Unix(1_000_000_000, 0)
+	cases := []struct {
+		name string
+		last time.Time
+		want bool
+	}{
+		{"never run (zero time)", time.Time{}, true},
+		{"ran 25h ago", now.Add(-25 * time.Hour), true},
+		{"ran exactly at interval", now.Add(-autoCleanupInterval), true},
+		{"ran 1h ago", now.Add(-1 * time.Hour), false},
+		{"ran just now", now, false},
+	}
+	for _, c := range cases {
+		if got := cleanupDue(now, c.last); got != c.want {
+			t.Errorf("%s: cleanupDue = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestAutoCleanupStampRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	stampPathFn = func() string { return dir + "/auto-cleanup.stamp" }
+	t.Cleanup(func() { stampPathFn = defaultStampPath })
+
+	// No stamp yet → zero time (so a first sweep is always due).
+	if !lastAutoCleanup().IsZero() {
+		t.Fatalf("expected zero time before any stamp, got %v", lastAutoCleanup())
+	}
+
+	now := time.Unix(1_700_000_000, 0)
+	stampAutoCleanup(now)
+	if got := lastAutoCleanup(); !got.Equal(now) {
+		t.Errorf("round-trip = %v, want %v", got, now)
+	}
+}


### PR DESCRIPTION
## What

Adds `lerd cleanup`, a lerd-aware command to reclaim the podman disk that lerd's own image rebuilds leave behind. Testing lerd accumulates gigabytes of reclaimable image data that nothing reaps today: every PHP rebuild orphans the previous `:local` image, every base-image hash bump strands the old base, and every service upgrade leaves the old version behind. Unlike a blunt `podman system prune -a`, this only ever touches images that are provably lerd's, so it can never remove a database, a named volume, or another tool's images.

## Behaviour

**Safe tier** (the default, and what runs automatically):
- Orphaned PHP/FrankenPHP build images a rebuild left dangling.
- Pre-built base images nothing live is built on: an old Containerfile hash, or a PHP version no longer installed. In-use vs orphaned is decided by layer ancestry, so the base the current PHP image is built on is always kept (never untagged into a needless re-pull).

**Deep tier** (`--deep`, on demand only):
- Service images no installed service references any more (e.g. an old `mysql:8.0` after upgrading), keeping each service's current image and its one-back rollback target. An image carrying any tag the user added themselves is left entirely alone.

Ownership is enforced structurally: the safe tier requires a `dev.lerd.*` label or the `lerd-php*-fpm-base` repo name; the deep tier matches lerd's own preset catalogue. Reported sizes count an image's unique layers only (`Size - SharedSize`), so the "reclaimable" figure reflects disk that is actually freed rather than double-counting shared base layers.

## Commands

```
lerd cleanup                 # preview, confirm, reclaim the safe tier
lerd cleanup --dry-run       # show what would be reclaimed and the size
lerd cleanup --deep          # also reclaim unused service images
lerd cleanup --yes           # skip the confirmation prompt
lerd cleanup auto on|off|status   # toggle automatic cleanup (auto_cleanup, default on)
```

`lerd doctor` reports the reclaimable total as a read-only line. The destructive command is CLI-only, consistent with keeping destructive operations out of the dashboard and TUI.

## Automatic cleanup

On by default and safe:
- The `lerd-watcher` runs the safe tier about once a day, throttled by a persisted timestamp so a restarting watcher cannot sweep more often.
- A PHP rebuild (`lerd use`, `php:rebuild`, `php:ext`/`pkg`, a `lerd update` that bumps the Containerfile) reclaims the image it just orphaned immediately, coalesced into one sweep per command.
- A `lerd service update`/`remove` reclaims the exact image it superseded. The event path reaps only the precise refs lerd recorded (the superseded rollback target on update, the removed service's images on remove), never a whole repo, so a user's own same-repo image is never touched.

Set `auto_cleanup: false` (or `lerd cleanup auto off`) to disable the automatic path; the command stays available on demand.

Closes #637
