### PR TITLE
doctor: add rootless podman build preflight checks

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/geodro/lerd/internal/cleanup"
@@ -70,6 +71,18 @@ func RunDoctorTo(w io.Writer, useColor bool) (fails, warns int, err error) {
 		ok("podman")
 	}
 
+	// podman 4.5 is lerd's minimum on every platform: older clients reject the
+	// quadlet units lerd emits and hit build regressions (#636). Probes the
+	// binary directly, so it reports even when the daemon/machine is down.
+	if meetsMin, ver, verErr := podman.VersionAtLeast(4, 5); verErr == nil {
+		if meetsMin {
+			ok(fmt.Sprintf("podman version (%s)", ver))
+		} else {
+			fail("podman version", "podman "+ver+" is older than the 4.5 minimum",
+				"upgrade podman to 4.5 or newer: https://podman.io/docs/installation")
+		}
+	}
+
 	if runtime.GOOS == "linux" {
 		if _, lookErr := exec.LookPath("crun"); lookErr != nil {
 			warn("OCI runtime", "crun not found — recommended for rootless podman (install: sudo pacman -S crun / sudo apt install crun / sudo dnf install crun)")
@@ -99,6 +112,30 @@ func RunDoctorTo(w io.Writer, useColor bool) (fails, warns int, err error) {
 			} else {
 				ok("linger enabled")
 			}
+		}
+
+		// Rootless podman build preflight: a missing subuid/subgid range or a
+		// missing fuse-overlayfs surface as the same opaque tar "Operation not
+		// permitted" failure during image builds (#636). Both are Linux-host
+		// concerns; on macOS the uid mapping and storage live inside the podman
+		// machine VM. Diagnose each so the user gets a real pointer.
+		if currentUser != "" {
+			uid := strconv.Itoa(os.Getuid())
+			for _, path := range []string{"/etc/subuid", "/etc/subgid"} {
+				b, readErr := os.ReadFile(path)
+				if readErr != nil || !hasSubIDRange(string(b), currentUser, uid) {
+					fail(path+" range", "no sub-id range for "+currentUser+" (rootless podman builds will fail)",
+						"add one: echo "+currentUser+":100000:65536 | sudo tee -a "+path+" && podman system migrate")
+				} else {
+					ok(path + " range")
+				}
+			}
+		}
+
+		if _, lookErr := exec.LookPath("fuse-overlayfs"); lookErr != nil {
+			warn("fuse-overlayfs", "not found — recommended for rootless overlay storage (install: sudo apt install fuse-overlayfs / sudo dnf install fuse-overlayfs / sudo pacman -S fuse-overlayfs)")
+		} else {
+			ok("fuse-overlayfs")
 		}
 	}
 

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -1,0 +1,25 @@
+package cli
+
+import "strings"
+
+// hasSubIDRange reports whether the /etc/subuid or /etc/subgid content grants
+// a range to the given username or uid. Lines are "owner:start:count"; blanks
+// and #comments are ignored. Rootless podman needs such a range to build
+// images, and its absence shows up only as an opaque tar "Operation not
+// permitted" failure (#636).
+func hasSubIDRange(content, username, uid string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		owner, _, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		if owner == username || (uid != "" && owner == uid) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/preflight_test.go
+++ b/internal/cli/preflight_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import "testing"
+
+func TestHasSubIDRange(t *testing.T) {
+	const content = "alice:100000:65536\n# comment\n\nbob:165536:65536\n1001:231072:65536\n"
+	tests := []struct {
+		name          string
+		username, uid string
+		want          bool
+	}{
+		{"by username", "alice", "1000", true},
+		{"second entry", "bob", "1000", true},
+		{"by uid", "carol", "1001", true},
+		{"missing", "dave", "9999", false},
+		{"empty username falls back to uid", "", "1001", true},
+		{"comment line not matched", "#", "0", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasSubIDRange(content, tt.username, tt.uid); got != tt.want {
+				t.Errorf("hasSubIDRange(%q, %q): got %v, want %v", tt.username, tt.uid, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasSubIDRange_empty(t *testing.T) {
+	if hasSubIDRange("", "alice", "1000") {
+		t.Error("empty content should yield no range")
+	}
+}

--- a/internal/podman/version.go
+++ b/internal/podman/version.go
@@ -42,12 +42,34 @@ func splitMajorMinor(v string) (int, int, error) {
 	return major, minor, nil
 }
 
+// versionAtLeast reports whether major.minor >= wantMajor.wantMinor.
+func versionAtLeast(major, minor, wantMajor, wantMinor int) bool {
+	if major != wantMajor {
+		return major > wantMajor
+	}
+	return minor >= wantMinor
+}
+
 // podmanVersionSupportsStopTimeout reports whether the StopTimeout= key in
 // quadlet [Container] sections is recognised. Added in Podman 5.0; Ubuntu
 // 24.04 ships 4.9.3 which rejects the unit and emits no service files.
 func podmanVersionSupportsStopTimeout(major, minor int) bool {
-	_ = minor
-	return major >= 5
+	return versionAtLeast(major, minor, 5, 0)
+}
+
+// VersionAtLeast probes the local podman and reports whether its version meets
+// the given minimum. It returns the parsed "major.minor" for messaging. An
+// error means the binary could not be run or its version could not be parsed.
+func VersionAtLeast(wantMajor, wantMinor int) (ok bool, version string, err error) {
+	out, err := execCommand(PodmanBin(), "--version").Output()
+	if err != nil {
+		return false, "", err
+	}
+	major, minor, err := parsePodmanVersion(string(out))
+	if err != nil {
+		return false, "", err
+	}
+	return versionAtLeast(major, minor, wantMajor, wantMinor), fmt.Sprintf("%d.%d", major, minor), nil
 }
 
 // supportsContainerStopTimeoutKey is the runtime test seam used by the

--- a/internal/podman/version_test.go
+++ b/internal/podman/version_test.go
@@ -37,6 +37,28 @@ func TestParsePodmanVersion(t *testing.T) {
 	}
 }
 
+func TestVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		major, minor       int
+		wantMajor, wantMin int
+		want               bool
+	}{
+		{4, 5, 4, 5, true},   // exact match
+		{4, 4, 4, 5, false},  // one minor short
+		{4, 9, 4, 5, true},   // newer minor
+		{5, 0, 4, 5, true},   // newer major beats lower minor
+		{3, 99, 4, 5, false}, // older major
+		{4, 10, 4, 5, true},  // double-digit minor
+	}
+	for _, tt := range tests {
+		got := versionAtLeast(tt.major, tt.minor, tt.wantMajor, tt.wantMin)
+		if got != tt.want {
+			t.Errorf("versionAtLeast(%d.%d >= %d.%d): got %v, want %v",
+				tt.major, tt.minor, tt.wantMajor, tt.wantMin, got, tt.want)
+		}
+	}
+}
+
 func TestSupportsContainerStopTimeoutBoundary(t *testing.T) {
 	// StopTimeout= in [Container] was added in Podman 5.0. Anything below
 	// must fall back to PodmanArgs=--stop-timeout=5.


### PR DESCRIPTION
Surfaced by #635, where an Ubuntu 22 user hit a PHP image build failure with `tar Cannot change mode Operation not permitted`. That is a rootless podman storage or uid-mapping problem, not a lerd bug, but `lerd doctor` gave no pointer to the real cause. It checked crun, the systemd user session, linger and ports, but none of the three conditions that produce that opaque failure.

This adds three preflight checks to `RunDoctorTo`:

- **podman version**: fails when the client is older than the 4.5 minimum, with an upgrade hint. Runs on every platform (the client minimum applies on macOS too) and probes the binary directly, so it reports even when the daemon or podman machine is down.
- **/etc/subuid and /etc/subgid**: fails when the current user has no sub-id range, with a hint to add one and run `podman system migrate`. Linux only, since on macOS the uid mapping lives inside the podman machine VM.
- **fuse-overlayfs**: warns when missing. Linux only.

The version comparison reuses the existing `parsePodmanVersion` through a new `versionAtLeast` helper, which also de-duplicates the existing StopTimeout probe. The subuid/subgid parsing is a pure `hasSubIDRange` helper. Both have unit tests.

Closes #636.