### PR TITLE
dns: recognise launchd-managed lerd-dns in the doctor diagnostic

### DIFF
--- a/internal/dns/diagnose.go
+++ b/internal/dns/diagnose.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/services"
 )
 
 // StepStatus is the outcome of a single rung in the layered DNS check.
@@ -304,13 +305,20 @@ func defaultProbes() probeFns {
 	}
 }
 
+// serviceActive reports whether the lerd-dns service unit is active. It is a
+// var so tests can stub it; production resolves to the platform service
+// manager, which uses launchd on macOS and systemd on linux.
+var serviceActive = func(name string) bool { return services.Mgr.IsActive(name) }
+
 func defaultContainerRunning() bool {
-	out, err := exec.Command("systemctl", "--user", "is-active", "lerd-dns").Output()
-	if err == nil && strings.TrimSpace(string(out)) == "active" {
+	// Consult the service manager first so a launchd-managed host dnsmasq on
+	// macOS (no container, no systemctl) isn't misreported as a foreign
+	// resolver. Falls back to a direct container probe for the podman case.
+	if serviceActive("lerd-dns") {
 		return true
 	}
 	cmd := podman.Cmd("ps", "--filter", "name=^lerd-dns$", "--format", "{{.Names}}")
-	out, err = cmd.Output()
+	out, err := cmd.Output()
 	return err == nil && strings.TrimSpace(string(out)) == "lerd-dns"
 }
 

--- a/internal/dns/diagnose_probe_test.go
+++ b/internal/dns/diagnose_probe_test.go
@@ -1,0 +1,17 @@
+package dns
+
+import "testing"
+
+// Regression for the macOS false "lerd-dns container not running" warning:
+// defaultContainerRunning must treat the lerd-dns service unit as running
+// when the platform service manager reports it active (launchd on macOS,
+// systemd on linux), instead of only checking systemctl + podman ps.
+func TestDefaultContainerRunning_serviceActiveShortCircuits(t *testing.T) {
+	prev := serviceActive
+	t.Cleanup(func() { serviceActive = prev })
+
+	serviceActive = func(name string) bool { return name == "lerd-dns" }
+	if !defaultContainerRunning() {
+		t.Error("expected true when the service manager reports lerd-dns active")
+	}
+}


### PR DESCRIPTION
On macOS, `lerd doctor` printed a false warning under `[DNS]`:

```
[DNS]
  ✓ DNS TLD (.test)
  ⚠   lerd-dns container  not running; a host-side resolver on :5300 is answering .test with 127.0.0.1
```

DNS was actually working and lerd-managed. On macOS lerd runs DNS as a launchd-supervised host dnsmasq (`com.lerd.lerd-dns`, reading lerd's own conf-dir), not a podman container. The diagnostic's container probe (`defaultContainerRunning` in `internal/dns/diagnose.go`) only checked `systemctl --user is-active` (a no-op on macOS) and `podman ps` (no container on macOS), so it always returned false and the chain fell into the "a host-side resolver is answering, lerd is not managing DNS" branch.

This consults the cross-platform `services.Mgr.IsActive` first, which resolves to launchd on macOS and systemd on linux, keeping the direct podman container probe as a fallback. The lookup goes through a `serviceActive` var so it can be stubbed in a regression test. No import cycle: `internal/services` does not import `internal/dns`.

After the fix the chain reports the container as running and walks the rest of the DNS rungs:

```
[DNS]
  ✓ DNS TLD (.test)
    lerd-dns container               running
    dnsmasq config                   address=/.test/127.0.0.1, port=5300
    port 5300 listening              127.0.0.1:5300
    dig @127.0.0.1 -p 5300           127.0.0.1
    resolver hookup                  macOS native dnsmasq: /usr/local/etc/dnsmasq.d/lerd.conf
    system DNS lookup                127.0.0.1
```

Closes #649.