### PR TITLE
Auto-start FPM, or offer to install/switch the PHP version

### DIFF
--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -48,8 +48,9 @@ func runConsole(_ *cobra.Command, args []string) error {
 
 	container := fpmContainerForDir(cwd, version)
 
-	if running, _ := podman.ContainerRunning(container); !running {
-		return fmt.Errorf("PHP %s FPM container is not running — start it with: systemctl --user start %s", version, container)
+	version, container, err = ensureFPMRunning(cwd, version, container)
+	if err != nil {
+		return err
 	}
 
 	podman.EnsurePathMounted(cwd, version)

--- a/internal/cli/fpm_ensure.go
+++ b/internal/cli/fpm_ensure.go
@@ -1,0 +1,218 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/geodro/lerd/internal/feedback"
+	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
+	"golang.org/x/term"
+)
+
+// interactiveTTY reports whether both stdin and stdout are real terminals, so a
+// prompt would actually reach a human who can answer it. It deliberately does
+// not fall back to /dev/tty (unlike the installer's promptSource): the php/shell
+// shims must not steal a piped stdin or block when run from a script or agent.
+func interactiveTTY() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// ensureFPMRunning makes sure the FPM container for the detected PHP version is
+// up before lerd execs into it, replacing the old "container is not running"
+// dead end. Behaviour when the container is down:
+//
+//   - version installed but stopped → start the unit and wait for it.
+//   - version not installed, on a TTY → offer to install it; if the user
+//     declines, offer to switch to an already-installed version (persisted to
+//     the project's .php-version pin).
+//   - version not installed, no TTY → return a clear error.
+//
+// It returns the version and container the caller should actually exec against,
+// which differ from the requested ones when the user switches versions.
+func ensureFPMRunning(cwd, version, container string) (string, string, error) {
+	for {
+		if running, _ := podman.ContainerRunning(container); running {
+			return version, container, nil
+		}
+
+		// Installed but stopped — bring it up automatically.
+		if phpDet.FPMInstalled(version, container) {
+			if err := startFPM(version, container); err != nil {
+				return version, container, err
+			}
+			continue
+		}
+
+		// Not installed — needs a human decision. Only prompt at a real
+		// interactive terminal: when stdin is piped (a script feeding `php`) or
+		// there's no TTY (agent/CI), prompting would steal stdin or block, and
+		// silently building an image is too heavy a side effect to assume.
+		if !interactiveTTY() {
+			return version, container, notInstalledErr(version)
+		}
+		newVersion, install, err := resolveUninstalledFPM(bufio.NewReader(os.Stdin), cwd, version)
+		if err != nil {
+			return version, container, err
+		}
+
+		if install {
+			if err := ensureFPMQuadletTo(version, os.Stderr); err != nil {
+				return version, container, fmt.Errorf("installing PHP %s: %w", version, err)
+			}
+			container = fpmContainerForDir(cwd, version)
+			continue
+		}
+
+		// User switched to an installed version; loop will auto-start it.
+		version = newVersion
+		container = fpmContainerForDir(cwd, version)
+	}
+}
+
+// ensureFPMStarted is the no-switch variant of ensureFPMRunning for callers that
+// operate on an explicit, already-chosen PHP version (tinker eval, pest-browser
+// and php:bun installs) and have done version-specific work around this check.
+// It auto-starts a stopped-but-installed container, offers to install a missing
+// version (same version only — never switches), and otherwise errors.
+func ensureFPMStarted(version, container string) error {
+	if running, _ := podman.ContainerRunning(container); running {
+		return nil
+	}
+	if phpDet.FPMInstalled(version, container) {
+		return startFPM(version, container)
+	}
+
+	if !interactiveTTY() {
+		return notInstalledErr(version)
+	}
+	reader := bufio.NewReader(os.Stdin)
+	if !readConfirmAnswerReader(reader, fmt.Sprintf("PHP %s is not installed. Install it now?", version), true) {
+		return notInstalledErr(version)
+	}
+	if err := ensureFPMQuadletTo(version, os.Stderr); err != nil {
+		return fmt.Errorf("installing PHP %s: %w", version, err)
+	}
+	return startFPM(version, container)
+}
+
+// startFPM starts a stopped-but-installed FPM container, with a progress spinner.
+// The start/wait itself is shared with the MCP exec path via phpDet.StartFPM; the
+// spinner goes to stderr so the transparent `php` shim's stdout stays clean.
+func startFPM(version, container string) error {
+	step := feedback.StartOn(os.Stderr, fmt.Sprintf("Starting PHP %s FPM", version))
+	if err := phpDet.StartFPM(version, container); err != nil {
+		step.Fail(err)
+		return fmt.Errorf("%w (try: %s)", err, serviceStartHint(container))
+	}
+	step.OK("running")
+	return nil
+}
+
+// resolveUninstalledFPM drives the prompt for a version that isn't installed.
+// It first offers to install the requested version; only if the user declines
+// does it list the installed versions to switch to. Returns (chosenVersion,
+// installRequested, error): install=true means build the requested version;
+// otherwise chosenVersion is an already-installed version to switch to.
+func resolveUninstalledFPM(reader *bufio.Reader, cwd, version string) (string, bool, error) {
+	if readConfirmAnswerReader(reader, fmt.Sprintf("PHP %s is not installed. Install it now?", version), true) {
+		return version, true, nil
+	}
+
+	installed := otherInstalledVersions(version)
+	if len(installed) == 0 {
+		return version, false, notInstalledErr(version)
+	}
+
+	chosen := chooseInstalledVersion(reader, installed)
+	if chosen == "" {
+		return version, false, fmt.Errorf("PHP %s is not installed", version)
+	}
+
+	persistPHPVersion(cwd, chosen)
+	return chosen, false, nil
+}
+
+// readConfirmAnswerReader is readConfirmAnswer over an existing *bufio.Reader so
+// the install prompt and the version menu share one buffered reader instead of
+// each wrapping /dev/tty separately and racing over buffered bytes.
+func readConfirmAnswerReader(reader *bufio.Reader, question string, defaultYes bool) bool {
+	feedback.Prompt(question, defaultYes)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer == "" {
+		return defaultYes
+	}
+	return answer != "n" && answer != "no"
+}
+
+// chooseInstalledVersion shows a numbered menu of installed versions and reads
+// the user's pick. A number or the literal version both work; blank cancels.
+func chooseInstalledVersion(reader *bufio.Reader, versions []string) string {
+	feedback.Note("Installed PHP versions you can switch to:")
+	for i, v := range versions {
+		fmt.Printf("        %d) PHP %s\n", i+1, v)
+	}
+	fmt.Printf("\n      %s Choose a version %s ",
+		feedback.Dim("?"), feedback.Dim(fmt.Sprintf("[1-%d, blank to cancel]", len(versions))))
+
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(answer)
+	if answer == "" {
+		return ""
+	}
+	if n, err := strconv.Atoi(answer); err == nil && n >= 1 && n <= len(versions) {
+		return versions[n-1]
+	}
+	for _, v := range versions {
+		if v == answer {
+			return v
+		}
+	}
+	return ""
+}
+
+// otherInstalledVersions lists installed PHP versions excluding the requested one.
+func otherInstalledVersions(exclude string) []string {
+	installed, err := phpDet.ListInstalled()
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(installed))
+	for _, v := range installed {
+		if v != exclude {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// persistPHPVersion pins the chosen version for the project by writing the site
+// root's .php-version file, the dedicated per-project pin lerd reads before
+// composer's constraint. Best-effort: a write failure or a higher-priority
+// .lerd.yaml override only warns, since the switch still applies to this run.
+func persistPHPVersion(cwd, version string) {
+	root := siteRootFor(cwd)
+	path := root + "/.php-version"
+	if err := os.WriteFile(path, []byte(version+"\n"), 0o644); err != nil {
+		feedback.Warn("could not pin PHP %s (%s): %v", version, path, err)
+		return
+	}
+	feedback.Note(fmt.Sprintf("Pinned PHP %s for this project (%s)", version, path))
+	if got, err := phpDet.DetectVersion(root); err == nil && got != version {
+		feedback.Warn(".lerd.yaml pins PHP %s, which overrides the .php-version file", got)
+	}
+}
+
+// notInstalledErr builds the error returned when a version isn't installed and
+// we can't prompt (no TTY) or have nothing to switch to.
+func notInstalledErr(version string) error {
+	if installed := otherInstalledVersions(version); len(installed) > 0 {
+		return fmt.Errorf("PHP %s is not installed (installed: %s) — pin one with a .php-version file, or run 'lerd install' to add %s",
+			version, strings.Join(installed, ", "), version)
+	}
+	return fmt.Errorf("PHP %s is not installed — run 'lerd install' to add it", version)
+}

--- a/internal/cli/fpm_ensure_test.go
+++ b/internal/cli/fpm_ensure_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func TestChooseInstalledVersion(t *testing.T) {
+	versions := []string{"8.2", "8.3", "8.4"}
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"1\n", "8.2"},    // by index
+		{"3\n", "8.4"},    // last index
+		{"8.3\n", "8.3"},  // by literal version
+		{"\n", ""},        // blank cancels
+		{"0\n", ""},       // out of range
+		{"9\n", ""},       // out of range
+		{"abc\n", ""},     // garbage
+		{"  2 \n", "8.3"}, // surrounding space trimmed
+	}
+	for _, c := range cases {
+		r := bufio.NewReader(strings.NewReader(c.in))
+		if got := chooseInstalledVersion(r, versions); got != c.want {
+			t.Errorf("chooseInstalledVersion(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestReadConfirmAnswerReader(t *testing.T) {
+	cases := []struct {
+		in         string
+		defaultYes bool
+		want       bool
+	}{
+		{"\n", true, true},   // blank → default yes
+		{"\n", false, false}, // blank → default no
+		{"y\n", false, true}, // explicit yes overrides default
+		{"yes\n", false, true},
+		{"n\n", true, false}, // explicit no overrides default
+		{"no\n", true, false},
+		{"NO\n", true, false}, // case-insensitive
+	}
+	for _, c := range cases {
+		r := bufio.NewReader(strings.NewReader(c.in))
+		if got := readConfirmAnswerReader(r, "Install it?", c.defaultYes); got != c.want {
+			t.Errorf("readConfirmAnswerReader(%q, default=%v) = %v, want %v", c.in, c.defaultYes, got, c.want)
+		}
+	}
+}

--- a/internal/cli/pest_browser.go
+++ b/internal/cli/pest_browser.go
@@ -166,8 +166,8 @@ func installPestBrowser(version string, w io.Writer) error {
 		return fmt.Errorf("updating FPM quadlet: %w", err)
 	}
 
-	if running, _ := podman.ContainerRunning(container); !running {
-		return fmt.Errorf("PHP %s FPM container is not running — start it with: %s", version, serviceStartHint(container))
+	if err := ensureFPMStarted(version, container); err != nil {
+		return err
 	}
 
 	// Rebuild when chromium was just opted in, or when an image from an older

--- a/internal/cli/php_bun.go
+++ b/internal/cli/php_bun.go
@@ -41,8 +41,8 @@ func newPhpBunUpdateCmd() *cobra.Command {
 				return err
 			}
 			container := bunFPMContainer(version)
-			if running, _ := podman.ContainerRunning(container); !running {
-				return fmt.Errorf("PHP %s FPM container is not running — start it with: %s", version, serviceStartHint(container))
+			if err := ensureFPMStarted(version, container); err != nil {
+				return err
 			}
 			if !bunInstalledInContainer(version) {
 				return fmt.Errorf("bun is not installed in the PHP %s container — run: lerd php:bun install", version)
@@ -214,8 +214,8 @@ func installContainerBun(version, pin string, w io.Writer) error {
 	} else if err := podman.WriteFPMQuadlet(version); err != nil {
 		return fmt.Errorf("updating FPM quadlet: %w", err)
 	}
-	if running, _ := podman.ContainerRunning(container); !running {
-		return fmt.Errorf("PHP %s FPM container is not running — start it with: %s", version, serviceStartHint(container))
+	if err := ensureFPMStarted(version, container); err != nil {
+		return err
 	}
 	if !bunVolumeMounted(container) {
 		fmt.Fprintf(w, "Preparing PHP %s container for bun...\n", version)
@@ -255,8 +255,8 @@ func newPhpBunVersionCmd() *cobra.Command {
 				return err
 			}
 			container := bunFPMContainer(version)
-			if running, _ := podman.ContainerRunning(container); !running {
-				return fmt.Errorf("PHP %s FPM container is not running — start it with: %s", version, serviceStartHint(container))
+			if err := ensureFPMStarted(version, container); err != nil {
+				return err
 			}
 			out, err := podman.Cmd("exec", container, "/root/.bun/bin/bun", "--version").CombinedOutput()
 			feedback.Begin()

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -90,6 +90,11 @@ func RunPHPCaptureEnv(cwd string, args []string, extraEnv []string) (int, error)
 
 	container := fpmContainerForDir(cwd, version)
 
+	version, container, err = ensureFPMRunning(cwd, version, container)
+	if err != nil {
+		return 0, err
+	}
+
 	home := os.Getenv("HOME")
 	composerHome := os.Getenv("COMPOSER_HOME")
 	if composerHome == "" {
@@ -102,10 +107,6 @@ func RunPHPCaptureEnv(cwd string, args []string, extraEnv []string) (int, error)
 	}
 	composerBin := filepath.Join(composerHome, "vendor", "bin")
 	projectVendorBin := filepath.Join(cwd, "vendor", "bin")
-
-	if running, _ := podman.ContainerRunning(container); !running {
-		return 0, fmt.Errorf("PHP %s FPM container is not running — start it with: systemctl --user start %s", version, container)
-	}
 
 	podman.EnsurePathMounted(cwd, version)
 	ensureServicesForCwd(cwd)

--- a/internal/cli/php_shell.go
+++ b/internal/cli/php_shell.go
@@ -40,8 +40,9 @@ func runPhpShell(_ *cobra.Command, _ []string) error {
 
 	container := fpmContainerForDir(cwd, version)
 
-	if running, _ := podman.ContainerRunning(container); !running {
-		return fmt.Errorf("PHP %s FPM container is not running — start it with: %s", version, serviceStartHint(container))
+	version, container, err = ensureFPMRunning(cwd, version, container)
+	if err != nil {
+		return err
 	}
 
 	// Use the registered site root as the working directory if cwd is inside one,

--- a/internal/cli/tinker.go
+++ b/internal/cli/tinker.go
@@ -86,8 +86,8 @@ func RunTinker(ctx context.Context, sitePath, siteName, branch, code string) (Ti
 	}
 	container := fpmContainerForDir(sitePath, version)
 
-	if running, _ := podman.ContainerRunning(container); !running {
-		return res, fmt.Errorf("PHP %s FPM container is not running", version)
+	if err := ensureFPMStarted(version, container); err != nil {
+		return res, err
 	}
 
 	podman.EnsurePathMounted(sitePath, version)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -264,6 +265,23 @@ func isKnownService(name string) bool { return config.IsDefaultPreset(name) }
 
 // ---- Tool implementations ----
 
+// ensureFPMStartedMCP auto-starts a stopped FPM container before an exec, the
+// MCP-side equivalent of the CLI's ensureFPMStarted. It shares phpDet.StartFPM
+// with the CLI so both auto-start identically. On a TTY-less MCP connection it
+// never prompts: it starts an installed-but-stopped container, or returns a
+// tool-error body (install hint / start failure) for the caller to hand back to
+// the client. Returns nil when the container is already running or just started.
+func ensureFPMStartedMCP(phpVersion, short, container string) map[string]any {
+	err := phpDet.StartFPM(phpVersion, container)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, phpDet.ErrFPMNotInstalled) {
+		return toolErr(fmt.Sprintf("PHP %s is not installed — install it with `lerd install`, or start it with service_start(name: \"php%s\")", phpVersion, short))
+	}
+	return toolErr(fmt.Sprintf("could not start the PHP %s FPM container: %v", phpVersion, err))
+}
+
 func execArtisan(args map[string]any) (any, *rpcError) {
 	projectPath := resolvedPath(args)
 	if projectPath == "" {
@@ -285,6 +303,9 @@ func execArtisan(args map[string]any) (any, *rpcError) {
 
 	short := strings.ReplaceAll(phpVersion, ".", "")
 	container := "lerd-php" + short + "-fpm"
+	if errBody := ensureFPMStartedMCP(phpVersion, short, container); errBody != nil {
+		return errBody, nil
+	}
 
 	consoleCmd, err := config.GetConsoleCommand(projectPath)
 	if err != nil {
@@ -937,6 +958,9 @@ func execComposer(args map[string]any) (any, *rpcError) {
 
 	short := strings.ReplaceAll(phpVersion, ".", "")
 	container := "lerd-php" + short + "-fpm"
+	if errBody := ensureFPMStartedMCP(phpVersion, short, container); errBody != nil {
+		return errBody, nil
+	}
 
 	cmdArgs := []string{"exec", "-w", projectPath, "--env", composer.ProcessTimeoutEnv()}
 	for _, e := range agentenv.MCPInject(os.Environ()) {
@@ -1013,6 +1037,9 @@ func execVendorRun(args map[string]any) (any, *rpcError) {
 
 	short := strings.ReplaceAll(phpVersion, ".", "")
 	container := "lerd-php" + short + "-fpm"
+	if errBody := ensureFPMStartedMCP(phpVersion, short, container); errBody != nil {
+		return errBody, nil
+	}
 
 	cmdArgs := []string{"exec", "-w", projectPath}
 	for _, e := range agentenv.MCPInject(os.Environ()) {
@@ -3889,6 +3916,9 @@ func execSetup(args map[string]any) (any, *rpcError) {
 		phpVersion = cfg.PHP.DefaultVersion
 	}
 	container := "lerd-php" + strings.ReplaceAll(phpVersion, ".", "") + "-fpm"
+	if errBody := ensureFPMStartedMCP(phpVersion, strings.ReplaceAll(phpVersion, ".", ""), container); errBody != nil {
+		return errBody, nil
+	}
 
 	var out bytes.Buffer
 	ran, skipped, failed := 0, 0, 0

--- a/internal/php/fpm_start.go
+++ b/internal/php/fpm_start.go
@@ -1,0 +1,51 @@
+package php
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/services"
+)
+
+// ErrFPMNotInstalled is returned (wrapped) by StartFPM when the requested
+// version's FPM container does not exist yet, so the caller knows the fix is to
+// install it rather than just start it. Test with errors.Is.
+var ErrFPMNotInstalled = errors.New("FPM container is not installed")
+
+// FPMInstalled reports whether the FPM container already exists (so it only
+// needs starting) rather than needing a fresh build. It checks both the shared
+// per-version units and the specific container's unit, so a custom-FPM container
+// (lerd-cfpm-<site>, whose version isn't in the shared list) is recognised too.
+func FPMInstalled(version, container string) bool {
+	return IsInstalled(version) || services.Mgr.ContainerUnitInstalled(container)
+}
+
+// StartFPM brings up a stopped-but-installed FPM container and waits for it to
+// report running, so an exec right after doesn't race the boot. It is a no-op
+// when the container is already running and returns ErrFPMNotInstalled (wrapped
+// with the version) when the container doesn't exist yet. It produces no output;
+// callers add any user-facing progress. Shared by the CLI php/artisan/shell
+// commands and the MCP exec handlers so both auto-start the same way.
+func StartFPM(version, container string) error {
+	if running, _ := podman.ContainerRunning(container); running {
+		return nil
+	}
+	if !FPMInstalled(version, container) {
+		return fmt.Errorf("PHP %s: %w", version, ErrFPMNotInstalled)
+	}
+	if err := podman.StartUnit(container); err != nil {
+		return fmt.Errorf("starting PHP %s FPM: %w", version, err)
+	}
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		if running, _ := podman.ContainerRunning(container); running {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for %s to start", container)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
Closes #651.

Running `php`, `php artisan`, `lerd shell`, tinker, or the `php:bun` / `pest:browser` commands when the project's PHP-FPM container was stopped used to fail with a dead-end error, and the hint it printed (`systemctl --user start ...`) is wrong on macOS. The same gap existed over MCP, where the `exec` tool handlers surfaced a raw podman error when the container was down.

## Behavior

When the FPM container for the detected PHP version is not running:

- Installed but stopped: start it automatically and wait for it to come up.
- Not installed, on a real terminal: offer to install it. Only if the user declines, list the already installed versions to switch to, and persist that choice to the project's `.php-version`.
- No interactive terminal (piped input, agent, MCP): do not prompt and do not silently build an image. Return a clear error listing the installed versions and how to add the requested one.

## How it fits together

The shared start core is `php.StartFPM(version, container)`, reused by both the CLI and the MCP exec handlers so they auto-start identically. It produces no output, so it cannot corrupt the MCP JSON-RPC stream on stdout. CLI progress (the start spinner) goes to stderr so the transparent `php` shim stays pipe-clean.

The macOS hint bug is fixed by routing errors through the platform-aware `serviceStartHint` instead of the two hardcoded `systemctl` strings.

Custom-FPM sites (`lerd-cfpm-<site>`) are recognised as installed via their own unit, not only the shared per-version list.

## Call sites

- Interactive project commands (`php_exec.go`, `console.go`, `php_shell.go`) use the full flow with install and version-switch.
- Callers that operate on an explicit, already-chosen version (`tinker.go`, the `php:bun` and `pest:browser` installs) get start-or-install only, never a switch, since switching would run against the wrong PHP or corrupt a half-done install.
- MCP `exec` handlers (`artisan`, `console`, `composer`, `vendor_run`, `setup`) auto-start via a small `ensureFPMStartedMCP` wrapper that returns a tool-error body with a `service_start` hint when the version is missing.

Verified end to end against the installed binary: CLI auto-start and clean not-installed error, plus MCP auto-start and clean not-installed tool result with no stdout corruption.
