### PR TITLE
Fix ERR_SSL_PROTOCOL_ERROR on LAN-shared sites that force https

### DIFF
--- a/internal/cli/lanshare.go
+++ b/internal/cli/lanshare.go
@@ -452,10 +452,14 @@ func startLANShareProxy(domain string, port, httpPort, httpsPort int, secured bo
 		}
 
 		// Rewrite Location headers: replace both http:// and https:// variants
-		// of the origin domain with the plain-HTTP LAN address.
+		// of the origin domain with the plain-HTTP LAN address. The third pass
+		// collapses https://<lanHost> redirects the app emitted itself (it
+		// honored X-Forwarded-Host but forced an https scheme) so the browser
+		// doesn't TLS-handshake the plain-HTTP proxy (ERR_SSL_PROTOCOL_ERROR).
 		if loc := resp.Header.Get("Location"); loc != "" {
 			loc = strings.ReplaceAll(loc, "https://"+domain, scheme+"://"+lanHost)
 			loc = strings.ReplaceAll(loc, "http://"+domain, scheme+"://"+lanHost)
+			loc = strings.ReplaceAll(loc, "https://"+lanHost, scheme+"://"+lanHost)
 			resp.Header.Set("Location", loc)
 		}
 

--- a/internal/cli/lanshare_test.go
+++ b/internal/cli/lanshare_test.go
@@ -610,6 +610,60 @@ func mustExtractPort(t *testing.T, rawURL string) int {
 	return p
 }
 
+func TestLANShareProxy_rewritesHTTPSLocationRedirects(t *testing.T) {
+	// Upstream stands in for nginx/the app. It builds a redirect Location from
+	// the path: /to-domain uses the origin domain, /to-lanhost uses the
+	// forwarded LAN host with a forced https scheme (the case Laravel hits when
+	// it honors X-Forwarded-Host but forces https from APP_URL).
+	const domain = "laravel.test"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var loc string
+		switch r.URL.Path {
+		case "/to-domain":
+			loc = "https://" + domain + "/dashboard"
+		case "/to-lanhost":
+			loc = "https://" + r.Header.Get("X-Forwarded-Host") + "/dashboard"
+		}
+		w.Header().Set("Location", loc)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer upstream.Close()
+	upstreamPort := mustExtractPort(t, upstream.URL)
+
+	// Reserve a free port for the proxy, then hand it to startLANShareProxy.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	proxyPort := probe.Addr().(*net.TCPAddr).Port
+	probe.Close()
+
+	srv, err := startLANShareProxy(domain, proxyPort, upstreamPort, 0, false)
+	if err != nil {
+		t.Fatalf("startLANShareProxy: %v", err)
+	}
+	defer srv.Close()
+
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}}
+	lanHost := fmt.Sprintf("127.0.0.1:%d", proxyPort)
+	wantLoc := "http://" + lanHost + "/dashboard"
+
+	for _, path := range []string{"/to-domain", "/to-lanhost"} {
+		t.Run(path, func(t *testing.T) {
+			resp, err := client.Get("http://" + lanHost + path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", path, err)
+			}
+			resp.Body.Close()
+			if got := resp.Header.Get("Location"); got != wantLoc {
+				t.Errorf("Location = %q, want %q", got, wantLoc)
+			}
+		})
+	}
+}
+
 func TestRewriteLANShareBody_fixesLANIPWithWrongPort(t *testing.T) {
 	// Laravel/Symfony can emit URLs with the LAN IP but SERVER_PORT (443 from
 	// the nginx HTTPS vhost) when X-Forwarded-Port isn't honored — those must


### PR DESCRIPTION
On Linux (and any platform), accessing a LAN-shared site over its `http://<lan-ip>:9100` link could redirect to HTTPS and fail with `ERR_SSL_PROTOCOL_ERROR`, forcing users to hand-edit the URL back to `http://`.

## Cause

The LAN share proxy serves plain HTTP. When the upstream app honors `X-Forwarded-Host` but forces an https scheme (e.g. a Laravel app with `APP_URL=https://...` or `URL::forceScheme(.https.)`), it emits redirects like `Location: https://<lan-ip>:9100/dashboard`. The proxy `ModifyResponse` Location rewriter only collapsed the origin-domain variants (`https://<domain>` and `http://<domain>`), so this self-referential `https://<lanHost>` redirect passed through untouched. The browser followed it to HTTPS, and the HTTP-only proxy failed the TLS handshake.

The response-body rewriter (`rewriteLANShareBody`) already handled this exact case for URLs embedded in HTML/JS; the `Location` header path was simply missing the equivalent pass.

## Fix

Add a third `Location` rewrite pass that collapses `https://<lanHost>` to `http://<lanHost>`, mirroring `rewriteLANShareBody`.

A new integration test (`TestLANShareProxy_rewritesHTTPSLocationRedirects`) stands up the real proxy against a redirecting upstream and asserts both the origin-domain and forwarded-LAN-host redirect forms come back as `http://<lanHost>`. It fails on the forwarded-host case without the fix.

Addresses the remaining symptom reported in #620 (the original `ERR_CONNECTION_REFUSED` was already fixed in 1.26.2).