### PR TITLE
Surface the real reason when a service fails to start

### DIFF
--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -313,14 +313,22 @@ func (s *Step) OK(result string) { s.finish(paint(okStyle, "✓"), result) }
 // Info collapses the step with a plain result and no mark.
 func (s *Step) Info(result string) { s.finish("", result) }
 
+// failText is the message rendered next to a ✗. A cross must never appear
+// without a reason, so a nil or empty-string error falls back to a placeholder
+// instead of leaving the user staring at a bare red mark.
+func failText(err error) string {
+	if err != nil {
+		if msg := err.Error(); msg != "" {
+			return msg
+		}
+	}
+	return "failed (no error detail reported)"
+}
+
 // Fail collapses the step with a red cross and the error text.
 func (s *Step) Fail(err error) {
 	markReported(err)
-	msg := ""
-	if err != nil {
-		msg = err.Error()
-	}
-	s.finish(paint(failStyle, "✗"), paint(failStyle, msg))
+	s.finish(paint(failStyle, "✗"), paint(failStyle, failText(err)))
 }
 
 // Warn collapses the step with an amber warning glyph and message, for a
@@ -354,7 +362,7 @@ func FailOn(w io.Writer, err error) {
 	on := colorEnabledFor(w)
 	mu.Lock()
 	defer mu.Unlock()
-	fmt.Fprintf(w, "\n%s%s %s\n\n", pad, paintIf(on, failStyle, GlyphFail), paintIf(on, failStyle, err.Error()))
+	fmt.Fprintf(w, "\n%s%s %s\n\n", pad, paintIf(on, failStyle, GlyphFail), paintIf(on, failStyle, failText(err)))
 }
 
 // Line prints a standalone step (arrow prefix, no trailing ellipsis) for an
@@ -832,10 +840,7 @@ func (l *Live) Fail(err error) {
 	if l.animated {
 		fmt.Fprint(target(), "\r\033[2K")
 	}
-	msg := ""
-	if err != nil {
-		msg = err.Error()
-	}
+	msg := failText(err)
 	// A live line fails the whole operation, so give the cross some breathing
 	// room with a blank line above and below, matching the top-level handler.
 	fmt.Fprintf(target(), "\n%s%s %s\n\n", pad, paint(failStyle, "✗"), paint(failStyle, msg))

--- a/internal/feedback/feedback_test.go
+++ b/internal/feedback/feedback_test.go
@@ -355,3 +355,38 @@ func TestStartLive_TracksActiveAcrossNesting(t *testing.T) {
 		t.Fatal("outer Fail did not restore the baseline active line")
 	}
 }
+
+func TestFailTextNeverEmpty(t *testing.T) {
+	if got := failText(nil); got == "" {
+		t.Error("failText(nil) must not be empty — a ✗ needs a reason")
+	}
+	if got := failText(errors.New("")); got == "" {
+		t.Error("failText of an empty-message error must not be empty")
+	}
+	if got := failText(errors.New("boom")); got != "boom" {
+		t.Errorf("failText = %q, want %q", got, "boom")
+	}
+}
+
+// End-to-end: every ✗-rendering path must route through failText so a cross is
+// never drawn without a reason, even when handed a nil or empty error.
+func TestFailPathsAlwaysShowReason(t *testing.T) {
+	render := func(run func()) string {
+		var buf bytes.Buffer
+		restore := SetTestWriter(&buf)
+		run()
+		restore()
+		return buf.String()
+	}
+	cases := map[string]func(){
+		"Step.Fail(nil)":      func() { Start("starting lerd-dns").Fail(nil) },
+		"Step.Fail(emptyErr)": func() { Start("starting lerd-redis").Fail(errors.New("")) },
+		"Live.Fail(nil)":      func() { StartLive("pulling image").Fail(nil) },
+	}
+	for name, run := range cases {
+		out := render(run)
+		if !strings.Contains(out, "✗") || !strings.Contains(out, "no error detail") {
+			t.Errorf("%s drew a ✗ without a reason: %q", name, out)
+		}
+	}
+}

--- a/internal/systemd/dbus_linux.go
+++ b/internal/systemd/dbus_linux.go
@@ -101,7 +101,7 @@ func dbusUnitOp(op, verb, name string) error {
 		return fmt.Errorf("%s %s failed: %w", verb, name, err)
 	}
 	if result != "done" {
-		return fmt.Errorf("%s %s failed: %s", verb, name, result)
+		return fmt.Errorf("%s %s failed: %s%s", verb, name, result, unitFailureDetail(conn, name))
 	}
 	return nil
 }

--- a/internal/systemd/diag_linux.go
+++ b/internal/systemd/diag_linux.go
@@ -1,0 +1,87 @@
+//go:build linux
+
+package systemd
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+)
+
+// unitFailureDetail turns systemd's opaque job result (usually the bare word
+// "failed") into something a user can act on. It pulls the service Result
+// property and the last few journal lines for the unit, so a quadlet that
+// dies on "container name is already in use" or an OCI runtime error reports
+// the real reason instead of just "failed: failed". Best-effort: any lookup
+// that errors is skipped and an empty string means "no detail available".
+func unitFailureDetail(conn *dbus.Conn, name string) string {
+	unit := withServiceSuffix(name)
+	return formatUnitFailureDetail(serviceResult(conn, unit), journalTail(unit, 8))
+}
+
+// formatUnitFailureDetail assembles the trailing detail appended to a unit-op
+// error from the service-result summary and the journal tail. Pure (no DBus or
+// exec) so the formatting is unit-testable; returns "" when neither is present.
+func formatUnitFailureDetail(header, logs string) string {
+	if header == "" && logs == "" {
+		return ""
+	}
+	var b strings.Builder
+	if header != "" {
+		fmt.Fprintf(&b, " (%s)", header)
+	}
+	if logs != "" {
+		b.WriteString("\n")
+		b.WriteString(logs)
+	}
+	return b.String()
+}
+
+// serviceResult reads the Service-type Result property (e.g. "exit-code",
+// "timeout", "resources", "oom-kill") plus the main process exit status when
+// present, summarising why the unit's process failed. Empty on any error or
+// when the result is the unremarkable "success".
+func serviceResult(conn *dbus.Conn, unit string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	props, err := conn.GetUnitTypePropertiesContext(ctx, unit, "Service")
+	if err != nil {
+		return ""
+	}
+	result, _ := props["Result"].(string)
+	if result == "" || result == "success" {
+		return ""
+	}
+	out := "result: " + result
+	if code, ok := props["ExecMainStatus"].(int32); ok && code != 0 {
+		out += fmt.Sprintf(", exit status %d", code)
+	}
+	return out
+}
+
+// journalTail returns the last n journal lines for the unit's most recent
+// invocation, message-only, trimmed and indented for display. Empty if
+// journalctl is unavailable or produced nothing.
+func journalTail(unit string, n int) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "journalctl", "--user",
+		"-u", unit, "-n", fmt.Sprintf("%d", n), "--no-pager", "-o", "cat")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	var lines []string
+	for _, ln := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		ln = strings.TrimSpace(ln)
+		if ln == "" || ln == "-- No entries --" {
+			continue
+		}
+		lines = append(lines, "    "+ln)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/systemd/diag_linux_test.go
+++ b/internal/systemd/diag_linux_test.go
@@ -1,0 +1,55 @@
+//go:build linux
+
+package systemd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatUnitFailureDetail(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		logs   string
+		want   string
+	}{
+		{"empty", "", "", ""},
+		{"header only", "result: exit-code, exit status 125", "",
+			" (result: exit-code, exit status 125)"},
+		{"logs only", "", "    lerd-nginx: name is already in use",
+			"\n    lerd-nginx: name is already in use"},
+		{"both", "result: exit-code", "    boom",
+			" (result: exit-code)\n    boom"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatUnitFailureDetail(tc.header, tc.logs); got != tc.want {
+				t.Errorf("formatUnitFailureDetail(%q, %q) = %q, want %q",
+					tc.header, tc.logs, got, tc.want)
+			}
+		})
+	}
+}
+
+// journalTail must degrade to "" rather than panic or surface noise when the
+// unit has no journal (or journalctl is missing entirely, e.g. a container
+// without systemd) — the enrichment is best-effort and never the failure path.
+func TestJournalTailNoEntries(t *testing.T) {
+	got := journalTail("lerd-nonexistent-unit-xyz.service", 5)
+	if got != "" {
+		t.Errorf("journalTail for a unit with no journal = %q, want empty", got)
+	}
+}
+
+// Every emitted journal line is indented so it reads as a nested detail block
+// under the one-line error, never flush against the left margin.
+func TestJournalTailIndents(t *testing.T) {
+	if out := journalTail("init.scope", 3); out != "" {
+		for _, ln := range strings.Split(out, "\n") {
+			if !strings.HasPrefix(ln, "    ") {
+				t.Errorf("journal line not indented: %q", ln)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Problem

When a Podman service fails to start on Linux, lerd printed systemd's job result verbatim, which is almost always the single word "failed":

```
start lerd-php85-fpm failed: failed
restart lerd-dns failed: failed
```

That gave the user nothing to act on and made #635 a dead end: every container failed and the only signal was "failed: failed". The actual cause (image missing, container name already in use, OCI runtime error, port collision) was available but never shown.

## Change

**Linux unit-op enrichment** (`internal/systemd/diag_linux.go`). On a failed start/restart/stop, append the real reason pulled from two sources:
- the service `Result` property and main exit status over DBus (exit-code, timeout, oom-kill, resources, plus the process exit code such as podman's 125)
- the last few journal lines for the unit, indented, which is where the actionable line lives (for example `the container name "lerd-nginx" is already in use`)

Both lookups are timeout-bounded (5s) and best-effort: any error degrades to the old message, so the enrichment never becomes the failure path. A failure now reads:

```
restart lerd-nginx failed: failed (result: exit-code, exit status 125)
    Error: creating container storage: the container name "lerd-nginx" is already in use by ...
```

macOS already surfaces podman stderr through `runPodmanWithError`, so this is Linux-only.

**Framework guarantee** (`internal/feedback/feedback.go`). A red cross was not guaranteed to carry a reason: `Fail(nil)` or an error with an empty message would draw a bare cross. Every cross now routes through a single `failText` helper that falls back to a placeholder, so a reasonless mark is impossible regardless of caller discipline.

## Verification

The message assembly and graceful degradation are unit-tested. The systemd tests run under Linux (the enrichment is build-tagged linux); the feedback render paths are exercised end-to-end on every platform, asserting that each Fail path emits both the cross and a reason for nil and empty-string errors.

Closes #654