### PR TITLE
fix(lan-share): carry app WebSockets, only divert Vite's HMR socket

### DIFF
--- a/internal/cli/lanshare.go
+++ b/internal/cli/lanshare.go
@@ -549,10 +549,13 @@ func (h *lanShareHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.viteProxy(port).ServeHTTP(w, r)
 		return
 	}
-	// Vite's HMR client opens a WebSocket to the page origin with no
-	// distinguishing path (just "/?token=..."). When we know the active
-	// Vite port, forward any WS upgrade there so HMR can connect.
-	if isWebSocketUpgrade(r) {
+	// Vite's HMR client opens a WebSocket to the bare page origin (just
+	// "/?token=..."). Divert only that socket to the active Vite port.
+	// Application sockets carry a real path (Reverb's /app/<key>, noVNC's
+	// /websockify, Vite HMR is the exception) and must flow to the main proxy
+	// so nginx upgrades them like its own vhost does — httputil.ReverseProxy
+	// carries WebSockets natively.
+	if isWebSocketUpgrade(r) && isViteHMRSocket(r) {
 		if port := h.getActiveVitePort(); port > 0 {
 			h.viteProxy(port).ServeHTTP(w, r)
 			return
@@ -573,6 +576,14 @@ func (h *lanShareHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	h.main.ServeHTTP(w, r)
+}
+
+// isViteHMRSocket reports whether a WebSocket upgrade is Vite's HMR client,
+// which connects to the bare page origin ("/" plus a token query). Application
+// sockets such as Reverb's /app/<key> or noVNC's /websockify carry a real path
+// and must not be hijacked to the Vite dev server.
+func isViteHMRSocket(r *http.Request) bool {
+	return r.URL.Path == "" || r.URL.Path == "/"
 }
 
 // isWebSocketUpgrade reports whether r is an HTTP upgrade to WebSocket.

--- a/internal/cli/lanshare_ws_e2e_test.go
+++ b/internal/cli/lanshare_ws_e2e_test.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// wsEchoBackend performs a raw WebSocket-style 101 upgrade and echoes one line,
+// standing in for nginx->reverb / nginx->noVNC.
+func wsEchoBackend(tag string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			conn, brw, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+			io.WriteString(conn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n")
+			brw.Flush()
+			line, _ := brw.ReadString('\n')
+			io.WriteString(conn, tag+":"+line)
+			return
+		}
+		fmt.Fprint(w, "plain")
+	}))
+}
+
+// dialWS sends a raw WS handshake to host on path and returns the status line
+// plus the post-handshake echo (or an error on hang/timeout).
+func dialWS(host, path string) (status, echo string, err error) {
+	conn, err := net.DialTimeout("tcp", host, 3*time.Second)
+	if err != nil {
+		return "", "", err
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+	io.WriteString(conn, "GET "+path+" HTTP/1.1\r\nHost: "+host+"\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: x\r\nSec-WebSocket-Version: 13\r\n\r\n")
+	br := bufio.NewReader(conn)
+	status, err = br.ReadString('\n')
+	if err != nil {
+		return "", "", err
+	}
+	for {
+		l, e := br.ReadString('\n')
+		if e != nil || l == "\r\n" || l == "" {
+			break
+		}
+	}
+	io.WriteString(conn, "hello\n")
+	echo, _ = br.ReadString('\n')
+	return status, echo, nil
+}
+
+// realMainProxy mirrors the production main proxy built in startLANShareProxy:
+// a single-host reverse proxy to the (nginx) upstream with the same Director
+// header rewrites.
+func realMainProxy(t *testing.T, upstream string) *httputil.ReverseProxy {
+	t.Helper()
+	tu, _ := url.Parse(upstream)
+	p := httputil.NewSingleHostReverseProxy(tu)
+	orig := p.Director
+	p.Director = func(req *http.Request) {
+		lanHost := req.Host
+		orig(req)
+		req.Header.Set("X-Forwarded-Host", lanHost)
+		req.Header.Set("X-Forwarded-Proto", "http")
+		req.Host = tu.Host
+		req.Header.Set("Accept-Encoding", "identity")
+	}
+	return p
+}
+
+// No Vite active: an app WS through the real lanShareHandler must upgrade
+// end-to-end via the main proxy.
+func TestLANShareE2E_appWebsocket_noVite(t *testing.T) {
+	be := wsEchoBackend("nginx")
+	defer be.Close()
+
+	h := newLANShareHandler(realMainProxy(t, be.URL))
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	host := mustHost(t, srv.URL)
+
+	status, echo, err := dialWS(host, "/app/local-key?protocol=7")
+	if err != nil {
+		t.Fatalf("WS dial failed (HANG): %v", err)
+	}
+	if !strings.Contains(status, "101") {
+		t.Fatalf("status = %q, want 101", status)
+	}
+	if !strings.HasPrefix(echo, "nginx:") {
+		t.Fatalf("echo = %q, want nginx: prefix", echo)
+	}
+}
+
+// Vite active: an app WS (real path) must still reach the main proxy, not get
+// hijacked to the Vite dev server. This is the #656 regression.
+func TestLANShareE2E_appWebsocket_viteActive(t *testing.T) {
+	be := wsEchoBackend("nginx")
+	defer be.Close()
+	// A Vite stand-in that does NOT speak the app's WS protocol — if the app
+	// socket were routed here it would hang on the echo read.
+	vite := wsEchoBackend("vite")
+	defer vite.Close()
+	vitePort := mustExtractPort(t, vite.URL)
+
+	h := newLANShareHandler(realMainProxy(t, be.URL))
+	h.setActiveVitePort(vitePort)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	host := mustHost(t, srv.URL)
+
+	for _, path := range []string{"/app/local-key?protocol=7", "/websockify"} {
+		status, echo, err := dialWS(host, path)
+		if err != nil {
+			t.Fatalf("[%s] WS dial failed (HANG): %v", path, err)
+		}
+		if !strings.Contains(status, "101") {
+			t.Fatalf("[%s] status = %q, want 101", path, status)
+		}
+		if !strings.HasPrefix(echo, "nginx:") {
+			t.Fatalf("[%s] echo = %q, want nginx: (app WS hijacked to Vite)", path, echo)
+		}
+	}
+}
+
+func mustHost(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u.Host
+}


### PR DESCRIPTION
## Problem

`lerd lan:share` forwarded plain HTTP fine but dropped WebSocket upgrades for LAN clients: a WS handshake hung (`curl http_code=000`, full timeout) while the identical request straight to the site's nginx vhost returned `101 Switching Protocols`. Reverb's `/app/<key>` and a noVNC `/websockify` endpoint both reproduced it (#656).

## Root cause

The share handler diverted **every** WebSocket upgrade to the active Vite dev server whenever one was known:

```go
if isWebSocketUpgrade(r) {
    if port := h.getActiveVitePort(); port > 0 {
        h.viteProxy(port).ServeHTTP(w, r)
        return
    }
}
```

During a normal Laravel dev session (`npm run dev` running for HMR), `activeVitePort` is set, so application sockets were hijacked to Vite. Vite does not speak Reverb's or noVNC's protocol, so the handshake hangs. The main proxy path (`httputil.ReverseProxy` to nginx) carries WebSockets natively and was never the problem, it just never got the chance to run.

## Fix

Only Vite's HMR client connects to the bare origin (`/?token=...`). Gate the diversion on that, so application sockets (which carry a real path) fall through to the main proxy and get upgraded by nginx exactly like its own vhost.

```go
if isWebSocketUpgrade(r) && isViteHMRSocket(r) { /* divert to Vite */ }
```

## Verification

Added an end-to-end test (`lanshare_ws_e2e_test.go`) that runs the real `lanShareHandler` + `httputil.ReverseProxy` and performs a raw WS handshake:

- **no Vite active**: app WS reaches the main proxy and upgrades (`101`), confirming that path was always WS-capable.
- **Vite active**: `/app/<key>` and `/websockify` still reach the main proxy and upgrade, while Vite's HMR socket (`/`) still routes to Vite.

The Vite-active test fails on `main` (the app socket is answered by the Vite stand-in) and passes with this change. Full `internal/cli` lan-share suite green; `go vet` clean.

## Note / out of scope

The secured share builds its upstream transport from `http.DefaultTransport.Clone()` (`ForceAttemptHTTP2=true`). This is safe today because lerd's nginx never enables HTTP/2, so ALPN always settles on HTTP/1.1 and the h1 WS upgrade passes through. If HTTP/2 is ever enabled on a vhost (e.g. via a `custom.d` include), the secured share could negotiate h2 and break the upgrade. Pinning the secured transport to `http/1.1` would harden against that, but it is not needed for #656 and is left out here.

Fixes #656.