### PR TITLE
Auto-heal rootless podman after a major upgrade

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -137,6 +137,43 @@ func RunDoctorTo(w io.Writer, useColor bool) (fails, warns int, err error) {
 		} else {
 			ok("fuse-overlayfs")
 		}
+
+		// Rootless network helpers. lerd's containers run on a custom bridge
+		// network, which on rootless podman requires netavark + aardvark-dns
+		// plus a rootless network tool (pasta or slirp4netns). Missing any of
+		// these is the "failed to mount runtime directory for rootless netns"
+		// container start failure from #635 — a fresh, minimal host can lack
+		// them entirely. They need sudo to install, so flag with the command.
+		//
+		// netavark/aardvark-dns live in libexec, not on $PATH, so ask podman
+		// for the paths it actually resolved rather than LookPath (which would
+		// false-fail on a healthy host). Skip the check when podman can't report
+		// them (older podman without the field).
+		if netavark, aardvark, probed := podman.NetworkHelpers(); probed {
+			if netavark == "" {
+				fail("rootless network (netavark)", "podman cannot find netavark — containers on the lerd bridge cannot start",
+					"sudo apt install netavark  (or dnf/pacman); then: lerd install")
+			} else {
+				ok("rootless network (netavark)")
+			}
+			if aardvark == "" {
+				fail("rootless network (aardvark-dns)", "podman cannot find aardvark-dns — container DNS will not resolve",
+					"sudo apt install aardvark-dns  (or dnf/pacman); then: lerd install")
+			} else {
+				ok("rootless network (aardvark-dns)")
+			}
+		}
+		// pasta/slirp4netns are user-PATH tools, so LookPath is reliable here.
+		if _, p := exec.LookPath("pasta"); p != nil {
+			if _, s := exec.LookPath("slirp4netns"); s != nil {
+				fail("rootless network (pasta/slirp4netns)", "neither pasta nor slirp4netns found — rootless containers have no network",
+					"sudo apt install passt  (provides pasta), or: sudo apt install slirp4netns; then: lerd install")
+			} else {
+				ok("rootless network (slirp4netns)")
+			}
+		} else {
+			ok("rootless network (pasta)")
+		}
 	}
 
 	quadletDir := config.QuadletDir()

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -28,6 +28,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// healPodmanUpgrade runs the podman-upgrade self-heal, renders its progress,
+// and returns the containers it tore down so the caller can restart them. Both
+// install and start enter the heal through here so the wording and error
+// handling stay identical regardless of entry point.
+func healPodmanUpgrade(containerDNS []string) []string {
+	healed, restart, err := podman.HealPodmanUpgrade(containerDNS, func(msg string) { feedback.Note(msg) })
+	if err != nil {
+		feedback.Warn("podman upgrade heal: %v", err)
+	} else if healed {
+		feedback.Note("podman upgrade detected — migrated storage and rebuilt the lerd network")
+	}
+	return restart
+}
+
 // NewInstallCmd returns the install command.
 func NewInstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -171,8 +185,16 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	// Containers removed by recreate are restarted AFTER the quadlet refresh
 	// phase below so they come up on the freshly written quadlets.
 	var migrated []string
-	step("Creating lerd podman network")
 	desiredDNS := dns.ReadContainerDNS()
+
+	// 2a. Self-heal a podman upgrade. A major-version or backend change since
+	// the last install reshuffles rootless storage and networking, which
+	// otherwise surfaces as the cryptic "rootless netns" container start
+	// failure (#635). Runs before the network step since it recreates it; any
+	// containers it tears down join the unconditional restart loop below.
+	migrated = append(migrated, healPodmanUpgrade(desiredDNS)...)
+
+	step("Creating lerd podman network")
 	if err := podman.EnsureNetwork("lerd", desiredDNS); err != nil {
 		if errors.Is(err, podman.ErrNetworkNeedsMigration) {
 			fmt.Println()

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -491,11 +491,21 @@ func runStart(_ *cobra.Command, _ []string) error {
 	migrateExecWorkerPlists()
 	healMachineRestartIfNeeded(preEnsureLastUp)
 
+	// Self-heal a podman upgrade before touching the network or starting
+	// containers. A major-version or backend change since the last run
+	// reshuffles rootless storage/networking and otherwise surfaces as the
+	// cryptic "rootless netns" container start failure (#635). No-op unless
+	// drift is detected. The heal force-removes the lerd containers; the start
+	// sequence below brings them back up, so the returned list is not needed
+	// here.
+	containerDNS := dns.ReadContainerDNS()
+	_ = healPodmanUpgrade(containerDNS)
+
 	// Ensure the lerd bridge network exists. On macOS the network is stored
 	// inside the Podman Machine VM; it may be absent after a fresh machine
 	// init or if it was pruned. All service containers use --network lerd so
 	// this must succeed before any container is started.
-	if err := podman.EnsureNetwork("lerd", dns.ReadContainerDNS()); err != nil {
+	if err := podman.EnsureNetwork("lerd", containerDNS); err != nil {
 		if errors.Is(err, podman.ErrNetworkNeedsMigration) {
 			fmt.Println("  WARN: lerd network schema doesn't match host IPv6 support; run 'lerd install' to recreate")
 		} else {

--- a/internal/podman/upgradeheal.go
+++ b/internal/podman/upgradeheal.go
@@ -1,0 +1,195 @@
+package podman
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// PodmanEnv fingerprints the host podman that lerd last installed against.
+// Stored at install/start so the next run can detect a podman upgrade (which on
+// rootless Linux silently reshuffles storage and networking) and self-heal
+// before the user hits the cryptic "failed to mount runtime directory for
+// rootless netns" wall that motivated this (#635).
+type PodmanEnv struct {
+	Version        string `json:"version"` // full token, e.g. "4.6.2"
+	Major          int    `json:"major"`
+	Minor          int    `json:"minor"`
+	NetworkBackend string `json:"networkBackend"` // "netavark" | "cni" | ""
+}
+
+func podmanEnvPath() string {
+	return filepath.Join(config.DataDir(), "podman-env.json")
+}
+
+// LoadPodmanEnv returns the last recorded fingerprint, or the zero value when
+// none has been written yet (a fresh install, or a pre-fingerprint lerd).
+func LoadPodmanEnv() PodmanEnv {
+	data, err := os.ReadFile(podmanEnvPath())
+	if err != nil {
+		return PodmanEnv{}
+	}
+	var env PodmanEnv
+	if err := json.Unmarshal(data, &env); err != nil {
+		return PodmanEnv{}
+	}
+	return env
+}
+
+// SavePodmanEnv records the current fingerprint for the next run to compare.
+func SavePodmanEnv(env PodmanEnv) error {
+	data, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(config.DataDir(), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(podmanEnvPath(), data, 0o644)
+}
+
+// CurrentPodmanEnv probes the live podman for its version and network backend
+// in a single `podman info` call (the server-side values, which on rootless
+// Linux are the runtime that actually matters).
+func CurrentPodmanEnv() (PodmanEnv, error) {
+	out, err := execCommand(PodmanBin(), "info", "--format",
+		"{{.Version.Version}}|{{.Host.NetworkBackend}}").Output()
+	if err != nil {
+		return PodmanEnv{}, err
+	}
+	ver, backend, _ := strings.Cut(strings.TrimSpace(string(out)), "|")
+	major, minor, err := splitMajorMinor(ver)
+	if err != nil {
+		return PodmanEnv{}, err
+	}
+	return PodmanEnv{
+		Version:        cleanVersionToken(strings.TrimSpace(ver)),
+		Major:          major,
+		Minor:          minor,
+		NetworkBackend: strings.TrimSpace(backend),
+	}, nil
+}
+
+// NetworkHelpers reports the filesystem paths podman resolves for its rootless
+// network helpers (netavark, aardvark-dns). These live in libexec, not on
+// $PATH, so podman's own resolution is the only reliable probe. An empty path
+// means podman cannot find that helper; probed is false when podman could not
+// be queried (e.g. an older podman without the template field), so callers skip
+// the check rather than report a false failure.
+func NetworkHelpers() (netavark, aardvark string, probed bool) {
+	out, err := execCommand(PodmanBin(), "info", "--format",
+		"{{.Host.NetworkBackendInfo.Path}}|{{.Host.NetworkBackendInfo.DNS.Path}}").Output()
+	if err != nil {
+		return "", "", false
+	}
+	nv, ad, ok := strings.Cut(strings.TrimSpace(string(out)), "|")
+	if !ok {
+		return "", "", false
+	}
+	return strings.TrimSpace(nv), strings.TrimSpace(ad), true
+}
+
+// upgradeNeedsHeal decides whether a podman change since the last install
+// warrants the migrate/netns/network heal. A major-version change or a
+// network-backend switch both reshuffle rootless storage and networking; a
+// minor/patch bump does not. Pure, so the policy is unit-testable.
+func upgradeNeedsHeal(prev, cur PodmanEnv) (bool, string) {
+	if prev.Version == "" {
+		return false, "" // first install — nothing to compare against
+	}
+	if prev.Major != cur.Major {
+		return true, fmt.Sprintf("podman %s → %s", prev.Version, cur.Version)
+	}
+	if prev.NetworkBackend != "" && cur.NetworkBackend != "" &&
+		prev.NetworkBackend != cur.NetworkBackend {
+		return true, fmt.Sprintf("network backend %s → %s", prev.NetworkBackend, cur.NetworkBackend)
+	}
+	return false, ""
+}
+
+// rootlessNetnsDir is the stale shared rootless network namespace a podman major
+// upgrade leaves behind; mounting it is what fails after the upgrade. Empty on
+// hosts without XDG_RUNTIME_DIR, making the clear a natural no-op.
+func rootlessNetnsDir() string {
+	dir := os.Getenv("XDG_RUNTIME_DIR")
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "containers", "networks", "rootless-netns")
+}
+
+func clearRootlessNetns() error {
+	p := rootlessNetnsDir()
+	if p == "" {
+		return nil
+	}
+	if _, err := os.Stat(p); err != nil {
+		return nil // not present — nothing to clear
+	}
+	return os.RemoveAll(p)
+}
+
+func systemMigrate() error {
+	return execCommand(PodmanBin(), "system", "migrate").Run()
+}
+
+// HealPodmanUpgrade detects a podman upgrade since the last install and, when
+// found, runs the remediation that unblocked #635: rebuild the lerd bridge in
+// the new backend's format, migrate rootless storage, and clear the stale
+// rootless-netns. emit, when non-nil, narrates each step.
+//
+// restart lists the containers torn down by the network rebuild so the caller
+// can bring them back up; it is returned even on a partial failure so nothing
+// is left stopped. The current fingerprint is recorded up front, so a failed
+// heal warns and points at manual steps rather than re-running its destructive
+// steps on every subsequent invocation. Linux-only: on macOS the runtime lives
+// in a VM and the rootless-netns failure mode does not exist.
+func HealPodmanUpgrade(dns []string, emit func(string)) (healed bool, restart []string, err error) {
+	if runtime.GOOS != "linux" {
+		return false, nil, nil
+	}
+	cur, perr := CurrentPodmanEnv()
+	if perr != nil {
+		return false, nil, nil // can't probe podman — don't block install over it
+	}
+	prev := LoadPodmanEnv()
+	heal, reason := upgradeNeedsHeal(prev, cur)
+
+	// Record the new fingerprint before doing anything destructive. The heal is
+	// best-effort; persisting up front makes it at-most-once per podman version
+	// so a mid-heal failure can't re-tear-down containers on every later run.
+	_ = SavePodmanEnv(cur)
+	if !heal {
+		return false, nil, nil
+	}
+
+	if emit != nil {
+		emit(reason)
+		emit("recreating lerd network")
+	}
+	// Rebuild the bridge first: RecreateNetwork stops and force-removes the lerd
+	// containers, so `podman system migrate` below runs with them down (its
+	// documented precondition), and attached tells the caller what to restart.
+	attached, _, rErr := RecreateNetwork("lerd", dns)
+	if rErr != nil {
+		return false, attached, fmt.Errorf("recreate lerd network: %w", rErr)
+	}
+	if emit != nil {
+		emit("podman system migrate")
+	}
+	if mErr := systemMigrate(); mErr != nil {
+		return false, attached, fmt.Errorf("podman system migrate: %w", mErr)
+	}
+	if emit != nil {
+		emit("clearing stale rootless-netns")
+	}
+	if cErr := clearRootlessNetns(); cErr != nil {
+		return false, attached, fmt.Errorf("clear rootless-netns: %w", cErr)
+	}
+	return true, attached, nil
+}

--- a/internal/podman/upgradeheal_test.go
+++ b/internal/podman/upgradeheal_test.go
@@ -1,0 +1,88 @@
+package podman
+
+import "testing"
+
+func TestUpgradeNeedsHeal(t *testing.T) {
+	cases := []struct {
+		name     string
+		prev     PodmanEnv
+		cur      PodmanEnv
+		wantHeal bool
+	}{
+		{
+			name:     "first install, no prior fingerprint",
+			prev:     PodmanEnv{},
+			cur:      PodmanEnv{Version: "4.6.2", Major: 4, Minor: 6, NetworkBackend: "netavark"},
+			wantHeal: false,
+		},
+		{
+			name:     "major upgrade 3 to 4",
+			prev:     PodmanEnv{Version: "3.4.4", Major: 3, Minor: 4, NetworkBackend: "cni"},
+			cur:      PodmanEnv{Version: "4.6.2", Major: 4, Minor: 6, NetworkBackend: "netavark"},
+			wantHeal: true,
+		},
+		{
+			name:     "major downgrade also heals",
+			prev:     PodmanEnv{Version: "4.6.2", Major: 4, Minor: 6, NetworkBackend: "netavark"},
+			cur:      PodmanEnv{Version: "3.4.4", Major: 3, Minor: 4, NetworkBackend: "cni"},
+			wantHeal: true,
+		},
+		{
+			name:     "minor bump within same major does not heal",
+			prev:     PodmanEnv{Version: "4.6.2", Major: 4, Minor: 6, NetworkBackend: "netavark"},
+			cur:      PodmanEnv{Version: "4.9.3", Major: 4, Minor: 9, NetworkBackend: "netavark"},
+			wantHeal: false,
+		},
+		{
+			name:     "backend switch within same major heals",
+			prev:     PodmanEnv{Version: "4.6.2", Major: 4, Minor: 6, NetworkBackend: "cni"},
+			cur:      PodmanEnv{Version: "4.6.2", Major: 4, Minor: 6, NetworkBackend: "netavark"},
+			wantHeal: true,
+		},
+		{
+			name:     "unknown backend on either side never triggers a backend heal",
+			prev:     PodmanEnv{Version: "4.6.2", Major: 4, Minor: 6, NetworkBackend: ""},
+			cur:      PodmanEnv{Version: "4.6.2", Major: 4, Minor: 6, NetworkBackend: "netavark"},
+			wantHeal: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := upgradeNeedsHeal(tc.prev, tc.cur)
+			if got != tc.wantHeal {
+				t.Fatalf("upgradeNeedsHeal = %v (%q), want %v", got, reason, tc.wantHeal)
+			}
+			if got && reason == "" {
+				t.Error("heal needed but reason was empty")
+			}
+		})
+	}
+}
+
+func TestCleanVersionToken(t *testing.T) {
+	cases := map[string]string{
+		"4.6.2":     "4.6.2",
+		"4.9.3+ds1": "4.9.3",
+		"5.8.2-rc1": "5.8.2",
+		"3.4":       "3.4",
+	}
+	for in, want := range cases {
+		if got := cleanVersionToken(in); got != want {
+			t.Errorf("cleanVersionToken(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestPodmanEnvRoundTrip(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if got := LoadPodmanEnv(); got.Version != "" {
+		t.Fatalf("expected zero env before any save, got %+v", got)
+	}
+	want := PodmanEnv{Version: "4.6.2", Major: 4, Minor: 6, NetworkBackend: "netavark"}
+	if err := SavePodmanEnv(want); err != nil {
+		t.Fatalf("SavePodmanEnv: %v", err)
+	}
+	if got := LoadPodmanEnv(); got != want {
+		t.Errorf("round-trip = %+v, want %+v", got, want)
+	}
+}

--- a/internal/podman/version.go
+++ b/internal/podman/version.go
@@ -20,13 +20,19 @@ func parsePodmanVersion(out string) (int, int, error) {
 	return 0, 0, fmt.Errorf("podman version: no version token in %q", out)
 }
 
-func splitMajorMinor(v string) (int, int, error) {
-	// Strip distro/build suffixes like "+ds1" or "-rc1".
+// cleanVersionToken strips distro/build suffixes like "+ds1", "-rc1", or "~"
+// from a bare version string, leaving "major.minor.patch".
+func cleanVersionToken(v string) string {
 	for _, sep := range []string{"+", "-", "~"} {
 		if idx := strings.Index(v, sep); idx > 0 {
 			v = v[:idx]
 		}
 	}
+	return v
+}
+
+func splitMajorMinor(v string) (int, int, error) {
+	v = cleanVersionToken(v)
 	parts := strings.Split(v, ".")
 	if len(parts) < 2 {
 		return 0, 0, fmt.Errorf("podman version %q: not enough components", v)


### PR DESCRIPTION
## Problem

A podman major-version or network-backend change silently reshuffles rootless storage and networking. Containers on lerd's custom bridge then fail to start with the opaque "failed to mount runtime directory for rootless netns" error, which took a long manual diagnosis in #635 (install missing network helpers, `podman system migrate`, clear the stale rootless-netns, recreate the lerd network). podman 4→5 makes this worse: CNI is removed and old network configs are not auto-migrated, a common cause of broken networking after the jump.

## Change

Fingerprint the host podman (version + network backend) in `podman-env.json` at install and start. When the next run detects a major-version or backend change, run the remediation before bringing containers up:

1. rebuild the lerd bridge in the new backend's format (its stopped containers are handed back for the caller to restart)
2. `podman system migrate`
3. clear the stale rootless-netns

The fingerprint is recorded up front, so a mid-heal failure cannot re-run the destructive steps on every later invocation. Linux-only: the failure mode does not exist on the macOS podman-machine VM, and probing the server version via `podman info` avoids a client-only `brew upgrade` triggering a false heal.

A fresh, minimal host can lack the rootless network helpers entirely, which the upgrade heal cannot fix since there is no prior fingerprint. That was the actual root cause in #635, so `lerd doctor` now also checks for them: netavark and aardvark-dns via podman-resolved libexec paths (not `exec.LookPath`, which false-fails since they are off `$PATH`), and pasta/slirp4netns on `$PATH`.

## Notes

Healing fires on every major bump by design. With CNI removed and not auto-migrated in 5.0, even a 4→5 where both sides report netavark benefits from the network recreate plus migrate plus rootless-netns clear; the cost is brief, properly-restarted downtime.

Related to #635.