### PR TITLE
Fix correctness and quality issues from the v1.26 review

### DIFF
--- a/internal/cleanup/deep.go
+++ b/internal/cleanup/deep.go
@@ -16,7 +16,59 @@ import (
 var (
 	serviceRepos    = realServiceRepos
 	protectedImages = realProtectedImages
+
+	// referencedImages is the seam SweepRefs uses to test a handful of specific
+	// refs without materialising the whole protected set: it scans cheap config
+	// sources first and stops as soon as every candidate is accounted for.
+	referencedImages = realReferencedImages
+
+	// installedServiceImages is a seam so the short-circuit (config covers every
+	// candidate, so the per-quadlet image reads are skipped) is assertable.
+	installedServiceImages = realInstalledServiceImages
 )
+
+// realReferencedImages returns the subset of candidates (keyed by canonical ref)
+// still used by a service config entry, a custom service, or an installed service
+// quadlet. It scans config (cheap, cached) before the per-quadlet image reads and
+// short-circuits once all candidates are found, so reaping a couple of refs no
+// longer reads every installed unit's image when config already covers them.
+func realReferencedImages(candidates map[string]bool) map[string]bool {
+	found := map[string]bool{}
+	remaining := len(candidates)
+	mark := func(ref string) {
+		c := canonRef(ref)
+		if candidates[c] && !found[c] {
+			found[c] = true
+			remaining--
+		}
+	}
+	if cfg, err := config.LoadGlobal(); err == nil {
+		for _, s := range cfg.Services {
+			mark(s.Image)
+			mark(s.PreviousImage)
+		}
+	}
+	if remaining > 0 {
+		if customs, err := config.ListCustomServices(); err == nil {
+			for _, s := range customs {
+				mark(s.Image)
+				mark(s.PreviousImage)
+				if remaining == 0 {
+					break
+				}
+			}
+		}
+	}
+	if remaining > 0 {
+		for _, img := range installedServiceImages() {
+			mark(img)
+			if remaining == 0 {
+				break
+			}
+		}
+	}
+	return found
+}
 
 // deepTargets reclaims service images lerd pulled but nothing references any
 // more: an image whose every tag is an unprotected catalog ref. Treating lerd's
@@ -133,7 +185,7 @@ func realProtectedImages() (map[string]bool, error) {
 // installedServiceImages returns the current Image= of every installed service
 // quadlet, so a service that is installed but not running is still protected.
 // PHP-FPM units are skipped: their images are handled by the safe tier.
-func installedServiceImages() []string {
+func realInstalledServiceImages() []string {
 	entries, err := os.ReadDir(config.QuadletDir())
 	if err != nil {
 		return nil

--- a/internal/cleanup/events.go
+++ b/internal/cleanup/events.go
@@ -37,16 +37,26 @@ func SweepRefs(refs ...string) {
 	if !autoEnabled() {
 		return
 	}
-	prot, err := protectedImages()
-	if err != nil {
-		return
-	}
-	seen := map[string]bool{}
+	// De-dup the non-empty refs into canonical candidates, preserving order so a
+	// repeated ref is reaped once.
+	candidates := map[string]bool{}
+	var order []string
 	for _, ref := range refs {
-		if ref == "" || seen[ref] || prot[canonRef(ref)] {
+		c := canonRef(ref)
+		if ref == "" || candidates[c] {
 			continue
 		}
-		seen[ref] = true
+		candidates[c] = true
+		order = append(order, ref)
+	}
+	if len(candidates) == 0 {
+		return
+	}
+	protected := referencedImages(candidates)
+	for _, ref := range order {
+		if protected[canonRef(ref)] {
+			continue
+		}
 		_ = removeImage(ref)
 	}
 }

--- a/internal/cleanup/events_test.go
+++ b/internal/cleanup/events_test.go
@@ -1,20 +1,28 @@
 package cleanup
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
 
 // SweepRefs reaps exactly the refs lerd hands it, skipping any the protected set
 // still holds, and never scans the whole repo (so a user's same-repo image that
 // wasn't passed is untouched).
 func TestSweepRefs_ReapsGivenRefsSkipsProtected(t *testing.T) {
 	autoEnabled = func() bool { return true }
-	protectedImages = func() (map[string]bool, error) {
-		return map[string]bool{"docker.io/library/mysql:8.4": true}, nil
+	referencedImages = func(candidates map[string]bool) map[string]bool {
+		out := map[string]bool{}
+		if candidates[canonRef("docker.io/library/mysql:8.4")] {
+			out[canonRef("docker.io/library/mysql:8.4")] = true
+		}
+		return out
 	}
 	var removed []string
 	removeImage = func(id string) error { removed = append(removed, id); return nil }
 	t.Cleanup(func() {
 		autoEnabled = defaultAutoEnabled
-		protectedImages = realProtectedImages
+		referencedImages = realReferencedImages
 		removeImage = podmanRemoveImage
 	})
 
@@ -54,5 +62,45 @@ func TestSweepSafe_GatedOffNoOp(t *testing.T) {
 	images, bytes, err := SweepSafe()
 	if err != nil || images != 0 || bytes != 0 || scanned {
 		t.Errorf("gated off must no-op without scanning: images=%d bytes=%d err=%v scanned=%v", images, bytes, err, scanned)
+	}
+}
+
+// SweepRefs must skip the per-quadlet image reads when the cheap config sources
+// already account for every candidate ref — the efficiency the short-circuit
+// buys over building the full protected set on each update/remove.
+func TestSweepRefs_shortCircuitsQuadletScanWhenConfigCovers(t *testing.T) {
+	autoEnabled = func() bool { return true }
+	referencedImages = realReferencedImages
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Services["mysql-8.4"] = config.ServiceConfig{Enabled: true, Image: "docker.io/library/mysql:8.4"}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	scanned := false
+	installedServiceImages = func() []string { scanned = true; return nil }
+	var removed []string
+	removeImage = func(id string) error { removed = append(removed, id); return nil }
+	t.Cleanup(func() {
+		autoEnabled = defaultAutoEnabled
+		installedServiceImages = realInstalledServiceImages
+		removeImage = podmanRemoveImage
+	})
+
+	// The only candidate is still in config, so it is protected and the quadlet
+	// scan must never run.
+	SweepRefs("docker.io/library/mysql:8.4")
+
+	if scanned {
+		t.Error("quadlet image reads must be skipped when config already covers every candidate")
+	}
+	if len(removed) != 0 {
+		t.Errorf("a still-referenced ref must not be reaped, got %v", removed)
 	}
 }

--- a/internal/cli/fpm_ensure.go
+++ b/internal/cli/fpm_ensure.go
@@ -21,6 +21,27 @@ func interactiveTTY() bool {
 	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
 }
 
+// Seams for the shared FPM up/installed fast path, swappable in tests.
+var (
+	fpmContainerRunning = podman.ContainerRunning
+	fpmIsInstalled      = phpDet.FPMInstalled
+	fpmStart            = startFPM
+)
+
+// startInstalledFPM handles the two outcomes ensureFPMRunning and ensureFPMStarted
+// share before any human decision: the container is already up, or it is installed
+// but stopped (start it). handled is true when the container is now up and no
+// install prompt is needed; false means the version is not installed.
+func startInstalledFPM(version, container string) (handled bool, err error) {
+	if running, _ := fpmContainerRunning(container); running {
+		return true, nil
+	}
+	if fpmIsInstalled(version, container) {
+		return true, fpmStart(version, container)
+	}
+	return false, nil
+}
+
 // ensureFPMRunning makes sure the FPM container for the detected PHP version is
 // up before lerd execs into it, replacing the old "container is not running"
 // dead end. Behaviour when the container is down:
@@ -35,16 +56,11 @@ func interactiveTTY() bool {
 // which differ from the requested ones when the user switches versions.
 func ensureFPMRunning(cwd, version, container string) (string, string, error) {
 	for {
-		if running, _ := podman.ContainerRunning(container); running {
+		// Already up, or installed-but-stopped (auto-started) — done in both cases.
+		if handled, err := startInstalledFPM(version, container); err != nil {
+			return version, container, err
+		} else if handled {
 			return version, container, nil
-		}
-
-		// Installed but stopped — bring it up automatically.
-		if phpDet.FPMInstalled(version, container) {
-			if err := startFPM(version, container); err != nil {
-				return version, container, err
-			}
-			continue
 		}
 
 		// Not installed — needs a human decision. Only prompt at a real
@@ -79,13 +95,9 @@ func ensureFPMRunning(cwd, version, container string) (string, string, error) {
 // It auto-starts a stopped-but-installed container, offers to install a missing
 // version (same version only — never switches), and otherwise errors.
 func ensureFPMStarted(version, container string) error {
-	if running, _ := podman.ContainerRunning(container); running {
-		return nil
+	if handled, err := startInstalledFPM(version, container); handled || err != nil {
+		return err
 	}
-	if phpDet.FPMInstalled(version, container) {
-		return startFPM(version, container)
-	}
-
 	if !interactiveTTY() {
 		return notInstalledErr(version)
 	}

--- a/internal/cli/fpm_ensure_test.go
+++ b/internal/cli/fpm_ensure_test.go
@@ -1,52 +1,47 @@
 package cli
 
 import (
-	"bufio"
-	"strings"
+	"errors"
 	"testing"
 )
 
-func TestChooseInstalledVersion(t *testing.T) {
-	versions := []string{"8.2", "8.3", "8.4"}
-	cases := []struct {
-		in   string
-		want string
-	}{
-		{"1\n", "8.2"},    // by index
-		{"3\n", "8.4"},    // last index
-		{"8.3\n", "8.3"},  // by literal version
-		{"\n", ""},        // blank cancels
-		{"0\n", ""},       // out of range
-		{"9\n", ""},       // out of range
-		{"abc\n", ""},     // garbage
-		{"  2 \n", "8.3"}, // surrounding space trimmed
-	}
-	for _, c := range cases {
-		r := bufio.NewReader(strings.NewReader(c.in))
-		if got := chooseInstalledVersion(r, versions); got != c.want {
-			t.Errorf("chooseInstalledVersion(%q) = %q, want %q", c.in, got, c.want)
-		}
-	}
-}
+// startInstalledFPM is the fast path ensureFPMRunning and ensureFPMStarted share:
+// it reports the container as handled when it is already up or installed-but-
+// stopped (starting it), and not-handled when the version isn't installed so the
+// caller can prompt. Keeping it shared is what removed the duplicated sequence.
+func TestStartInstalledFPM(t *testing.T) {
+	origRunning, origInstalled, origStart := fpmContainerRunning, fpmIsInstalled, fpmStart
+	t.Cleanup(func() {
+		fpmContainerRunning, fpmIsInstalled, fpmStart = origRunning, origInstalled, origStart
+	})
 
-func TestReadConfirmAnswerReader(t *testing.T) {
-	cases := []struct {
-		in         string
-		defaultYes bool
-		want       bool
-	}{
-		{"\n", true, true},   // blank → default yes
-		{"\n", false, false}, // blank → default no
-		{"y\n", false, true}, // explicit yes overrides default
-		{"yes\n", false, true},
-		{"n\n", true, false}, // explicit no overrides default
-		{"no\n", true, false},
-		{"NO\n", true, false}, // case-insensitive
+	// Already running: handled, nothing started.
+	started := false
+	fpmContainerRunning = func(string) (bool, error) { return true, nil }
+	fpmIsInstalled = func(string, string) bool { return false }
+	fpmStart = func(string, string) error { started = true; return nil }
+	if handled, err := startInstalledFPM("8.4", "lerd-php84-fpm"); !handled || err != nil || started {
+		t.Errorf("running container: handled=%v err=%v started=%v, want true/nil/false", handled, err, started)
 	}
-	for _, c := range cases {
-		r := bufio.NewReader(strings.NewReader(c.in))
-		if got := readConfirmAnswerReader(r, "Install it?", c.defaultYes); got != c.want {
-			t.Errorf("readConfirmAnswerReader(%q, default=%v) = %v, want %v", c.in, c.defaultYes, got, c.want)
-		}
+
+	// Installed but stopped: handled, started once, start error surfaced.
+	started = false
+	fpmContainerRunning = func(string) (bool, error) { return false, nil }
+	fpmIsInstalled = func(string, string) bool { return true }
+	fpmStart = func(string, string) error { started = true; return nil }
+	if handled, err := startInstalledFPM("8.4", "lerd-php84-fpm"); !handled || err != nil || !started {
+		t.Errorf("installed-stopped: handled=%v err=%v started=%v, want true/nil/true", handled, err, started)
+	}
+	wantErr := errors.New("boom")
+	fpmStart = func(string, string) error { return wantErr }
+	if handled, err := startInstalledFPM("8.4", "lerd-php84-fpm"); !handled || !errors.Is(err, wantErr) {
+		t.Errorf("installed-stopped start failure: handled=%v err=%v, want true + boom", handled, err)
+	}
+
+	// Not installed: not handled so the caller prompts; nothing started.
+	started = false
+	fpmIsInstalled = func(string, string) bool { return false }
+	if handled, err := startInstalledFPM("8.4", "lerd-php84-fpm"); handled || err != nil || started {
+		t.Errorf("not-installed: handled=%v err=%v started=%v, want false/nil/false", handled, err, started)
 	}
 }

--- a/internal/cli/hostproxy.go
+++ b/internal/cli/hostproxy.go
@@ -319,17 +319,13 @@ func lerdServiceHostPorts() map[int]bool {
 		}
 	}
 	if cfg, err := config.LoadGlobal(); err == nil {
+		// config.ServiceConfig.HostPorts is the shared source of the host ports a
+		// service entry claims (Port, the PublishedPort override, and ExtraPorts),
+		// so this allocator and the serviceops guard can't drift on it.
 		for _, svc := range cfg.Services {
-			if svc.Port > 0 {
-				out[svc.Port] = true
+			for _, p := range svc.HostPorts() {
+				out[p] = true
 			}
-			// A moved service (guard auto-shift or `lerd service port`) publishes on
-			// PublishedPort, not Port; reserve it too so a dev server isn't handed the
-			// shifted port and then collide when the service restarts.
-			if svc.PublishedPort > 0 {
-				out[svc.PublishedPort] = true
-			}
-			add(svc.ExtraPorts)
 		}
 	}
 	if presets, err := config.ListPresets(); err == nil {

--- a/internal/cli/idle_engine.go
+++ b/internal/cli/idle_engine.go
@@ -12,10 +12,12 @@ import (
 	"github.com/geodro/lerd/internal/siteinfo"
 )
 
-// unitStatesFn snapshots every lerd-* unit's state; a var so tests can pin which
-// units exist. A worker absent from it has had its unit removed entirely, which
-// is idle-suspend's signature (it removes units, not just stops them).
-var unitStatesFn = siteinfo.AllUnitStates
+// unitStatesOKFn snapshots every lerd-* unit's state plus a trust flag; a var so
+// tests can pin which units exist. A worker absent from the map has had its unit
+// removed entirely, which is idle-suspend's signature (it removes units, not just
+// stops them) — but only when the snapshot is trustworthy. The flag is false when
+// the systemctl enumeration failed, in which case every unit looks absent.
+var unitStatesOKFn = siteinfo.AllUnitStatesOK
 
 // SuspendWorkersForIdle stops ALL of the site's running workers (queue, Horizon,
 // scheduler, Stripe, vite, ...) and returns the names to persist as
@@ -71,7 +73,13 @@ func appendLostSuspended(site *config.Site, suspended []string) []string {
 	if err != nil || proj == nil {
 		return suspended
 	}
-	states := unitStatesFn()
+	states, ok := unitStatesOKFn()
+	if !ok {
+		// The systemctl enumeration failed, so absence proves nothing — every unit
+		// looks gone. Infer no lost-suspended workers rather than re-mark every
+		// declared worker and resume ones the user never had running.
+		return suspended
+	}
 	for _, w := range proj.Workers {
 		if containsString(suspended, w) {
 			continue

--- a/internal/cli/idle_test.go
+++ b/internal/cli/idle_test.go
@@ -262,8 +262,8 @@ func TestAppendLostSuspended(t *testing.T) {
 	// present pins which units still exist (any state); a worker keyed here is
 	// treated as not idle-suspended and must be left alone.
 	present := map[string]string{}
-	t.Cleanup(func() { unitStatesFn = siteinfo.AllUnitStates })
-	unitStatesFn = func() map[string]string { return present }
+	t.Cleanup(func() { unitStatesOKFn = siteinfo.AllUnitStatesOK })
+	unitStatesOKFn = func() (map[string]string, bool) { return present, true }
 
 	// All declared+resumable units removed -> all re-marked; the orphan is skipped.
 	if got := appendLostSuspended(site, nil); !slices.Equal(got, []string{"queue", "horizon", "stripe"}) {
@@ -289,6 +289,41 @@ func TestAppendLostSuspended(t *testing.T) {
 	}
 	if got := appendLostSuspended(site, nil); !slices.Equal(got, []string{"queue"}) {
 		t.Errorf("undeclared worker must not be re-marked: got %v, want [queue]", got)
+	}
+}
+
+// TestAppendLostSuspended_ignoresUntrustedSnapshot: when the systemctl
+// enumeration fails the snapshot is empty and untrustworthy. The detector must
+// re-mark nothing — treating every declared worker as removed would later resume
+// workers the user never had running (an opted-out vite/queue).
+func TestAppendLostSuspended_ignoresUntrustedSnapshot(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	dir := filepath.Join(tmp, "site")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: laravel\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	proj, err := config.LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proj.CustomWorkers = map[string]config.FrameworkWorker{"queue": {Command: "php artisan queue:work"}}
+	proj.Workers = []string{"queue", "stripe"}
+	if err := config.SaveProjectConfig(dir, proj); err != nil {
+		t.Fatal(err)
+	}
+	site := &config.Site{Name: "site", Framework: "laravel", Path: dir}
+
+	t.Cleanup(func() { unitStatesOKFn = siteinfo.AllUnitStatesOK })
+	// Empty map with ok=false models a failed enumeration: every unit looks absent.
+	unitStatesOKFn = func() (map[string]string, bool) { return map[string]string{}, false }
+
+	if got := appendLostSuspended(site, nil); len(got) != 0 {
+		t.Errorf("failed enumeration must re-mark nothing, got %v", got)
 	}
 }
 
@@ -318,10 +353,10 @@ func TestSuspendWorkersForIdle_remarksAbsent(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		podman.UnitLifecycle = nil
-		unitStatesFn = siteinfo.AllUnitStates
+		unitStatesOKFn = siteinfo.AllUnitStatesOK
 	})
-	podman.UnitLifecycle = stubUnitStatus{active: map[string]bool{}}       // nothing running
-	unitStatesFn = func() map[string]string { return map[string]string{} } // queue unit removed
+	podman.UnitLifecycle = stubUnitStatus{active: map[string]bool{}}                       // nothing running
+	unitStatesOKFn = func() (map[string]string, bool) { return map[string]string{}, true } // queue unit removed, enum OK
 
 	site := &config.Site{Name: "site", Framework: "laravel", Path: dir}
 	if got := SuspendWorkersForIdle(site); len(got) != 1 || got[0] != "queue" {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -208,7 +208,11 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 				feedback.Note("recreated lerd network as v4-only (IPv6 not available for containers)")
 			}
 			feedback.Note("existing containers on this network were recreated")
-			migrated = restored
+			// Union, don't overwrite: `migrated` already holds the containers the
+			// upgrade heal tore down (line above). Replacing it with `restored`
+			// here dropped those from the restart loop, leaving services stopped
+			// after a run that triggered both heal and a network migration.
+			migrated = mergeMigrationRestarts(migrated, restored)
 			step("Creating lerd podman network")
 		} else {
 			return err

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -700,3 +700,32 @@ func TestParseDNSMode(t *testing.T) {
 		}
 	}
 }
+
+// TestMergeMigrationRestarts_keepsHealTornDownContainers guards the install
+// regression where a run that triggered both the podman-upgrade heal and a
+// network migration overwrote the heal-torn-down container list with the
+// migration's, leaving those services stopped. The merge must keep both sets,
+// de-duplicated.
+func TestMergeMigrationRestarts_keepsHealTornDownContainers(t *testing.T) {
+	healed := []string{"lerd-mysql", "lerd-redis"}
+	recreated := []string{"lerd-redis", "lerd-postgres"}
+
+	got := mergeMigrationRestarts(healed, recreated)
+
+	has := func(s string) bool {
+		for _, c := range got {
+			if c == s {
+				return true
+			}
+		}
+		return false
+	}
+	for _, c := range []string{"lerd-mysql", "lerd-redis", "lerd-postgres"} {
+		if !has(c) {
+			t.Errorf("%s missing from merged restart set %v", c, got)
+		}
+	}
+	if len(got) != 3 {
+		t.Errorf("expected the de-duplicated union of 3 containers, got %v", got)
+	}
+}

--- a/internal/cli/lanshare.go
+++ b/internal/cli/lanshare.go
@@ -578,11 +578,18 @@ func (h *lanShareHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.main.ServeHTTP(w, r)
 }
 
-// isViteHMRSocket reports whether a WebSocket upgrade is Vite's HMR client,
-// which connects to the bare page origin ("/" plus a token query). Application
-// sockets such as Reverb's /app/<key> or noVNC's /websockify carry a real path
-// and must not be hijacked to the Vite dev server.
+// isViteHMRSocket reports whether a WebSocket upgrade is Vite's HMR client.
+// Vite always opens its HMR socket with the "vite-hmr" subprotocol, so we key off
+// that — it survives a custom server.hmr.path or a base-path deployment, which the
+// old bare-root-path check missed. The path check stays as a fallback for the
+// default bare-origin setup. Application sockets such as Reverb's /app/<key> or
+// noVNC's /websockify carry neither signal and must not be hijacked to Vite.
 func isViteHMRSocket(r *http.Request) bool {
+	for _, p := range strings.Split(r.Header.Get("Sec-WebSocket-Protocol"), ",") {
+		if strings.EqualFold(strings.TrimSpace(p), "vite-hmr") {
+			return true
+		}
+	}
 	return r.URL.Path == "" || r.URL.Path == "/"
 }
 

--- a/internal/cli/lanshare_test.go
+++ b/internal/cli/lanshare_test.go
@@ -682,3 +682,33 @@ func TestRewriteLANShareBody_fixesLANIPWithWrongPort(t *testing.T) {
 		t.Errorf("rewriteLANShareBody port-fix:\nGOT:\n%s\nWANT:\n%s", got, want)
 	}
 }
+
+// TestIsViteHMRSocket_matchesViteSubprotocolOnAnyPath: Vite's HMR client always
+// opens its socket with the "vite-hmr" subprotocol regardless of the configured
+// server.hmr.path or base, so the diversion must key off that, not only the bare
+// root path. Application sockets (Reverb's /app/<key>, noVNC's /websockify) carry
+// no such subprotocol and must keep flowing to the main proxy.
+func TestIsViteHMRSocket_matchesViteSubprotocolOnAnyPath(t *testing.T) {
+	mk := func(path, proto string) *http.Request {
+		r := httptest.NewRequest("GET", "http://lan.test"+path, nil)
+		if proto != "" {
+			r.Header.Set("Sec-WebSocket-Protocol", proto)
+		}
+		return r
+	}
+
+	if !isViteHMRSocket(mk("/__vite_hmr", "vite-hmr")) {
+		t.Error("custom server.hmr.path Vite socket (vite-hmr subprotocol) must route to Vite")
+	}
+	if !isViteHMRSocket(mk("/", "vite-hmr")) {
+		t.Error("bare-origin Vite HMR socket must route to Vite")
+	}
+	if !isViteHMRSocket(mk("/", "")) {
+		t.Error("bare-origin socket must still route to Vite via the path fallback")
+	}
+	for _, p := range []string{"/app/local-key", "/websockify"} {
+		if isViteHMRSocket(mk(p, "")) {
+			t.Errorf("app socket %s must flow to the main proxy, not be hijacked to Vite", p)
+		}
+	}
+}

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -1156,6 +1156,15 @@ func collapseTimerSiblings(in []string) []string {
 	return out
 }
 
+// mergeMigrationRestarts unions the containers torn down by the podman-upgrade
+// heal with those recreated by a network migration, de-duplicated and order
+// preserved, so a run that triggers BOTH restarts every affected container
+// exactly once. Overwriting one list with the other left heal-torn-down services
+// stopped after install.
+func mergeMigrationRestarts(healed, recreated []string) []string {
+	return dedupeStrings(append(append([]string(nil), healed...), recreated...))
+}
+
 func dedupeStrings(in []string) []string {
 	seen := make(map[string]struct{}, len(in))
 	out := make([]string, 0, len(in))

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -321,6 +321,41 @@ func defaultConfig() *GlobalConfig {
 	return cfg
 }
 
+// HostPorts returns every host port this service entry claims: its preset-default
+// Port, its PublishedPort override, and the host side of each ExtraPorts mapping.
+// Single source for the serviceops port-ownership guard and the host-proxy dev
+// server allocator, which previously parsed these out separately and drifted (the
+// guard even mis-read the host side of an "ip:host:container" extra mapping).
+func (s ServiceConfig) HostPorts() []int {
+	var ports []int
+	if s.Port > 0 {
+		ports = append(ports, s.Port)
+	}
+	if s.PublishedPort > 0 {
+		ports = append(ports, s.PublishedPort)
+	}
+	for _, ep := range s.ExtraPorts {
+		if n := mappingHostPort(ep); n > 0 {
+			ports = append(ports, n)
+		}
+	}
+	return ports
+}
+
+// mappingHostPort extracts the host port from a podman port mapping: a bare host
+// port "3411", "3411:3306", or "127.0.0.1:3411:3306", with an optional "/tcp"
+// suffix. Returns 0 when no valid host port is present.
+func mappingHostPort(mapping string) int {
+	parts := strings.Split(mapping, ":")
+	host := parts[0]
+	if len(parts) > 1 {
+		host = parts[len(parts)-2]
+	}
+	host = strings.SplitN(host, "/", 2)[0]
+	n, _ := strconv.Atoi(strings.TrimSpace(host))
+	return n
+}
+
 // firstHostPort returns the host-side port number from the first ports entry,
 // e.g. "3306:3306" → 3306. Used by defaultConfig to populate ServiceConfig.Port
 // without mirroring the YAML port literals in code.

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -629,3 +629,28 @@ func TestDNSManaged(t *testing.T) {
 		t.Error("DNSManaged() = true with DNS.Enabled false, want false")
 	}
 }
+
+// TestServiceConfig_HostPorts is the single source both the serviceops port guard
+// and the host-proxy allocator consume, so it must capture Port, the PublishedPort
+// override, and every ExtraPorts mapping form — including "ip:host:container",
+// whose host side the old guard parser dropped.
+func TestServiceConfig_HostPorts(t *testing.T) {
+	svc := ServiceConfig{
+		Port:          3306,
+		PublishedPort: 3307,
+		ExtraPorts:    []string{"8082:8081", "127.0.0.1:9090:9090", "7000", "6379/tcp"},
+	}
+	got := map[int]bool{}
+	for _, p := range svc.HostPorts() {
+		got[p] = true
+	}
+	for _, want := range []int{3306, 3307, 8082, 9090, 7000, 6379} {
+		if !got[want] {
+			t.Errorf("HostPorts missing %d; got %v", want, got)
+		}
+	}
+	// The container-side ports must never be reserved as host ports.
+	if got[8081] {
+		t.Errorf("HostPorts wrongly reserved container-side port 8081: %v", got)
+	}
+}

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -514,6 +514,23 @@ func DefaultPresetDashboard(name string) string {
 	return svc.Dashboard
 }
 
+// DefaultPresetPorts returns the default port mappings for a default preset, or
+// nil for non-defaults. Like DefaultPresetDashboard it reads the cached meta
+// directly instead of through DefaultPresetMeta, which deep-copies the struct and
+// clones its slices — wasteful for the services snapshot, which rebuilds every
+// service every refresh and only reads the ports. The returned slice is the cached
+// instance's own; callers must not mutate it.
+func DefaultPresetPorts(name string) []string {
+	if !IsDefaultPreset(name) {
+		return nil
+	}
+	svc, err := cachedDefaultPresetMeta(name)
+	if err != nil {
+		return nil
+	}
+	return svc.Ports
+}
+
 // DefaultPresetConnectionURL returns the developer-facing connection URL for
 // a default preset, or empty for non-defaults / presets without one.
 func DefaultPresetConnectionURL(name string) string {

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -1189,6 +1189,28 @@ func TestDefaultPresetMeta_Caches(t *testing.T) {
 	}
 }
 
+// DefaultPresetPorts must return the same ports as DefaultPresetMeta without the
+// deep copy, and nil for a non-default preset, so the services snapshot can read
+// a preset's ports without cloning the whole struct on every refresh.
+func TestDefaultPresetPorts(t *testing.T) {
+	meta, err := DefaultPresetMeta("mysql")
+	if err != nil {
+		t.Fatalf("DefaultPresetMeta(mysql): %v", err)
+	}
+	got := DefaultPresetPorts("mysql")
+	if len(got) != len(meta.Ports) {
+		t.Fatalf("DefaultPresetPorts(mysql) = %v, want %v", got, meta.Ports)
+	}
+	for i := range got {
+		if got[i] != meta.Ports[i] {
+			t.Errorf("port %d = %q, want %q", i, got[i], meta.Ports[i])
+		}
+	}
+	if DefaultPresetPorts("sqlite") != nil {
+		t.Error("DefaultPresetPorts(sqlite) must be nil for a non-default preset")
+	}
+}
+
 func TestLoadPreset_DefaultEnvVarsParity(t *testing.T) {
 	// Each default preset must encode the same env_vars that lerd shipped from
 	// the hardcoded cli.serviceEnvVars map. This is the no-regression test for

--- a/internal/mcp/serve_stdout_test.go
+++ b/internal/mcp/serve_stdout_test.go
@@ -1,0 +1,49 @@
+package mcp
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+)
+
+// TestGuardStdout_divertsStrayWritesOffTheProtocolStream proves the Serve-time
+// stdout guard: the JSON-RPC encoder keeps writing to the real stdout, while any
+// in-process diagnostic that still targets os.Stdout is diverted to stderr so it
+// cannot corrupt a protocol frame.
+func TestGuardStdout_divertsStrayWritesOffTheProtocolStream(t *testing.T) {
+	protoR, protoW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	savedOut, savedErr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = protoW, errW
+	t.Cleanup(func() { os.Stdout, os.Stderr = savedOut, savedErr })
+
+	real, restore := guardStdout()
+	fmt.Fprint(os.Stdout, "stray diagnostic") // a handler still printing to stdout
+	fmt.Fprint(real, `{"jsonrpc":"2.0"}`)     // the encoder, on the real stdout
+	restore()
+
+	_ = protoW.Close()
+	_ = errW.Close()
+	var proto, diag bytes.Buffer
+	_, _ = io.Copy(&proto, protoR)
+	_, _ = io.Copy(&diag, errR)
+
+	if proto.String() != `{"jsonrpc":"2.0"}` {
+		t.Errorf("protocol stream = %q, want only the JSON-RPC frame (no stray diagnostics)", proto.String())
+	}
+	if diag.String() != "stray diagnostic" {
+		t.Errorf("stray stdout write landed on %q, want it diverted to stderr as %q", diag.String(), "stray diagnostic")
+	}
+
+	if os.Stdout != real {
+		t.Error("restore must put os.Stdout back to what it was when guardStdout was called")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -116,7 +116,14 @@ type mcpProp struct {
 // Serve runs the MCP server, reading JSON-RPC messages from stdin and writing responses to stdout.
 // All diagnostic output goes to stderr so it never corrupts the JSON-RPC stream on stdout.
 func Serve() error {
-	enc := json.NewEncoder(os.Stdout)
+	// The JSON-RPC encoder owns the real stdout. Repoint os.Stdout at stderr for
+	// the session so any in-process handler that still prints to stdout — a service
+	// port-shift notice, the host-proxy .env refresh, a shelled-out `lerd env` that
+	// inherits os.Stdout — lands on stderr instead of corrupting a protocol frame.
+	stdout, restore := guardStdout()
+	defer restore()
+
+	enc := json.NewEncoder(stdout)
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) // 1 MB — handle large artisan output
 
@@ -150,6 +157,16 @@ func Serve() error {
 		_ = enc.Encode(resp)
 	}
 	return scanner.Err()
+}
+
+// guardStdout repoints os.Stdout at os.Stderr and returns the prior stdout (for
+// the JSON-RPC encoder) plus a restore func. Any in-process diagnostic that still
+// prints to stdout — or a child process that inherits it — then writes to stderr
+// instead of corrupting the protocol stream the server keeps on the real stdout.
+func guardStdout() (real *os.File, restore func()) {
+	real = os.Stdout
+	os.Stdout = os.Stderr
+	return real, func() { os.Stdout = real }
 }
 
 func dispatch(req *rpcRequest) (any, *rpcError) {

--- a/internal/serviceops/ensure_quadlet_test.go
+++ b/internal/serviceops/ensure_quadlet_test.go
@@ -1,6 +1,11 @@
 package serviceops
 
 import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -48,5 +53,58 @@ func TestEnsureCustomServiceQuadlet_reloadsOnlyWhenContentChanges(t *testing.T) 
 	}
 	if count != 2 {
 		t.Errorf("changed image should reload again, got %d total", count)
+	}
+}
+
+// TestEnsureCustomServiceQuadlet_portShiftNoticeAvoidsStdout: when the port guard
+// shifts a service off a busy port it must not write its notice to os.Stdout.
+// EnsureCustomServiceQuadlet is called in-process by the MCP stdio server, which
+// reserves os.Stdout for the JSON-RPC stream — any stray write there corrupts the
+// protocol frame and breaks the client session.
+func TestEnsureCustomServiceQuadlet_portShiftNoticeAvoidsStdout(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	orig := podman.DaemonReloadFn
+	t.Cleanup(func() { podman.DaemonReloadFn = orig })
+	podman.DaemonReloadFn = func() error { return nil }
+
+	// Occupy the service's primary host port so the guard is forced to shift it.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot bind a loopback port: %v", err)
+	}
+	defer ln.Close()
+	busy := ln.Addr().(*net.TCPAddr).Port
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	saved := os.Stdout
+	os.Stdout = w
+
+	svc := &config.CustomService{
+		Name:  "mongo-express",
+		Image: "docker.io/library/mongo-express:latest",
+		Ports: []string{fmt.Sprintf("127.0.0.1:%d:8081", busy)},
+	}
+	ensErr := EnsureCustomServiceQuadlet(svc)
+	_ = w.Close()
+	os.Stdout = saved
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	if ensErr != nil {
+		t.Fatalf("EnsureCustomServiceQuadlet: %v", ensErr)
+	}
+	if config.ServicePublishedPort("mongo-express") == 0 {
+		t.Fatal("expected the guard to shift the busy port and persist a published port")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("port-shift notice leaked to os.Stdout (would corrupt MCP JSON-RPC): %q", buf.String())
 	}
 }

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -45,10 +45,13 @@ func PortAvailable(port int) bool { return freeport.Bindable(port) }
 // OnPublishedPortShift, if set, is invoked when the port-ownership guard moves a
 // service's published port to avoid a host server (service name, new port). The
 // CLI wires this to regenerate host-proxy sites' .env so their loopback DB target
-// follows the moved port; it stays nil in non-CLI contexts (tests, MCP), where
-// serviceops must not reach back into the env writer. Fired from the guard so any
-// quadlet-write path (install, start, reinstall, `service port --reset`) refreshes
-// followers, not just the explicit `lerd service port` command.
+// follows the moved port; it stays nil in pure serviceops tests (which don't
+// import package cli). The MCP server shares the binary, so the CLI init sets it
+// there too — that is fine: the env refresh is still the right thing to do, and
+// the MCP server repoints os.Stdout at stderr so its output can't corrupt the
+// protocol. Fired from the guard so any quadlet-write path (install, start,
+// reinstall, `service port --reset`) refreshes followers, not just the explicit
+// `lerd service port` command.
 var OnPublishedPortShift func(service string, newPort int)
 
 // unitActive reports whether a service's own systemd unit is currently up. The
@@ -92,20 +95,8 @@ func lerdReservedPorts() map[int]bool {
 		return reserved
 	}
 	for _, svc := range cfg.Services {
-		if svc.PublishedPort > 0 {
-			reserved[svc.PublishedPort] = true
-		}
-		if svc.Port > 0 {
-			reserved[svc.Port] = true
-		}
-		for _, ep := range svc.ExtraPorts {
-			host := ep // ExtraPorts are "host:container" (or a bare number); take the host side.
-			if i := strings.IndexByte(ep, ':'); i >= 0 {
-				host = ep[:i]
-			}
-			if n, perr := strconv.Atoi(strings.TrimSpace(host)); perr == nil && n > 0 {
-				reserved[n] = true
-			}
+		for _, p := range svc.HostPorts() {
+			reserved[p] = true
 		}
 	}
 	return reserved
@@ -525,11 +516,12 @@ func EnsureCustomServiceQuadlet(svc *config.CustomService) error {
 				return fmt.Errorf("shifting lerd-%s off in-use port %d: %w", svc.Name, primary, err)
 			}
 			pp = free // use the just-persisted value directly — no second config read to diverge
-			fmt.Printf("Note: 127.0.0.1:%d is in use; publishing lerd-%s on 127.0.0.1:%d instead.\n", primary, svc.Name, free)
-			fmt.Printf("      (override with: lerd service port %s <port>)\n", svc.Name)
+			// Stderr, never stdout: this path runs in-process inside the MCP stdio
+			// server, which reserves stdout for the JSON-RPC stream.
+			fmt.Fprintf(os.Stderr, "Note: 127.0.0.1:%d is in use; publishing lerd-%s on 127.0.0.1:%d instead.\n", primary, svc.Name, free)
+			fmt.Fprintf(os.Stderr, "      (override with: lerd service port %s <port>)\n", svc.Name)
 			// Host-proxy sites reach this service over the published loopback port,
-			// so their .env must follow the shift. The CLI registers the refresh hook;
-			// it stays nil elsewhere (tests, MCP).
+			// so their .env must follow the shift. The CLI registers the refresh hook.
 			if OnPublishedPortShift != nil {
 				OnPublishedPortShift(svc.Name, free)
 			}

--- a/internal/siteinfo/unitcache.go
+++ b/internal/siteinfo/unitcache.go
@@ -77,6 +77,30 @@ func AllUnitStates() map[string]string {
 	return out
 }
 
+// AllUnitStatesOK is AllUnitStates plus a trust signal: ok is false when the
+// batched systemctl enumeration was attempted this call and failed, leaving the
+// snapshot empty or stale. Callers that infer "unit absent -> removed" must check
+// ok first, since a failed enumeration makes every unit look absent. On the
+// non-systemd override path (darwin) ok is always true.
+func AllUnitStatesOK() (map[string]string, bool) {
+	if allUnitStatesFn != nil {
+		return allUnitStatesFn(), true
+	}
+	globalUnitCache.mu.Lock()
+	defer globalUnitCache.mu.Unlock()
+	ok := true
+	if globalUnitCache.states == nil || time.Since(globalUnitCache.at) > unitCacheTTL {
+		if err := globalUnitCache.refreshLocked(); err != nil {
+			ok = false
+		}
+	}
+	out := make(map[string]string, len(globalUnitCache.states))
+	for k, v := range globalUnitCache.states {
+		out[k] = v
+	}
+	return out, ok
+}
+
 // unitStatusCached returns the active state of a lerd-* unit, consulting a
 // short-lived batched snapshot. One systemctl call populates ~all lerd units
 // instead of one subprocess per worker.

--- a/internal/ui/effective_host_port_test.go
+++ b/internal/ui/effective_host_port_test.go
@@ -1,0 +1,32 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// effectiveHostPort takes the caller's already-loaded services map (so a whole
+// services-list rebuild loads the global config once, not once per service) and
+// must keep the published-port > configured-port > default-mapping precedence.
+func TestEffectiveHostPort_precedenceFromSharedMap(t *testing.T) {
+	services := map[string]config.ServiceConfig{
+		"mysql":    {PublishedPort: 3307, Port: 3306},
+		"postgres": {Port: 5418},
+	}
+
+	if got := effectiveHostPort(services, "mysql", []string{"3306:3306"}); got != 3307 {
+		t.Errorf("published port override must win: got %d, want 3307", got)
+	}
+	if got := effectiveHostPort(services, "postgres", []string{"5432:5432"}); got != 5418 {
+		t.Errorf("configured port: got %d, want 5418", got)
+	}
+	// Absent from the map -> the default mapping's primary host port.
+	if got := effectiveHostPort(services, "redis", []string{"6379:6379"}); got != 6379 {
+		t.Errorf("default mapping fallback: got %d, want 6379", got)
+	}
+	// A nil map (config load failed) still falls back cleanly.
+	if got := effectiveHostPort(nil, "redis", []string{"6379:6379"}); got != 6379 {
+		t.Errorf("nil services map must fall back to the default mapping: got %d, want 6379", got)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1061,26 +1061,35 @@ func portConflictsFor(unit, ssOutput string) []PortConflict {
 // connection URL all agree: the published-port override, else the configured
 // port (which a non-canonical preset version seeds to its own host port, e.g.
 // postgres 18 → 5418), else the primary host port from the default mappings.
-// 0 when none applies (no host port published, e.g. a worker).
-func effectiveHostPort(name string, defaultPorts []string) int {
-	if cfg, err := config.LoadGlobal(); err == nil && cfg != nil {
-		if sc, ok := cfg.Services[name]; ok {
-			if sc.PublishedPort > 0 {
-				return sc.PublishedPort
-			}
-			if sc.Port > 0 {
-				return sc.Port
-			}
+// 0 when none applies (no host port published, e.g. a worker). services is the
+// caller's already-loaded cfg.Services map so a full services-list rebuild loads
+// (and deep-clones) the global config once rather than once per service.
+func effectiveHostPort(services map[string]config.ServiceConfig, name string, defaultPorts []string) int {
+	if sc, ok := services[name]; ok {
+		if sc.PublishedPort > 0 {
+			return sc.PublishedPort
+		}
+		if sc.Port > 0 {
+			return sc.Port
 		}
 	}
 	return podman.PrimaryHostPort(defaultPorts)
 }
 
-func buildServiceResponse(name string) ServiceResponse {
-	return buildServiceResponseWithPortList(name, "")
+// loadServicesMap returns cfg.Services, or nil when the global config can't be
+// loaded — the single load behind a one-off buildServiceResponse.
+func loadServicesMap() map[string]config.ServiceConfig {
+	if cfg, err := config.LoadGlobal(); err == nil && cfg != nil {
+		return cfg.Services
+	}
+	return nil
 }
 
-func buildServiceResponseWithPortList(name, ssOutput string) ServiceResponse {
+func buildServiceResponse(name string) ServiceResponse {
+	return buildServiceResponseWithPortList(loadServicesMap(), name, "")
+}
+
+func buildServiceResponseWithPortList(services map[string]config.ServiceConfig, name, ssOutput string) ServiceResponse {
 	unit := "lerd-" + name
 	status, _ := podman.UnitStatus(unit)
 	if status == "" {
@@ -1095,11 +1104,8 @@ func buildServiceResponseWithPortList(name, ssOutput string) ServiceResponse {
 		}
 	}
 
-	var presetPorts []string
-	if meta, err := config.DefaultPresetMeta(name); err == nil {
-		presetPorts = meta.Ports
-	}
-	hostPort := effectiveHostPort(name, presetPorts)
+	presetPorts := config.DefaultPresetPorts(name)
+	hostPort := effectiveHostPort(services, name, presetPorts)
 	resp := ServiceResponse{
 		Name:          name,
 		Status:        status,
@@ -1191,10 +1197,14 @@ func buildServicesList() []ServiceResponse {
 	// this rebuild; portConflictsFor is a no-op when ssOutput is empty.
 	ssOutput := cli.PortListOutput()
 
+	// Load the global config once for the whole rebuild; effectiveHostPort reads
+	// the shared Services map instead of re-loading (and deep-cloning) it per service.
+	svcCfg := loadServicesMap()
+
 	defaultNames := siteinfo.KnownServices()
 	services := make([]ServiceResponse, 0, len(defaultNames))
 	for _, name := range defaultNames {
-		services = append(services, buildServiceResponseWithPortList(name, ssOutput))
+		services = append(services, buildServiceResponseWithPortList(svcCfg, name, ssOutput))
 	}
 	customs, _ := config.ListCustomServices()
 	for _, svc := range customs {
@@ -1225,7 +1235,7 @@ func buildServicesList() []ServiceResponse {
 		if dashProxyEligible(svc) {
 			dashboard, dashboardExternal = dashProxyPath(svc.Name), false
 		}
-		hostPort := effectiveHostPort(svc.Name, svc.Ports)
+		hostPort := effectiveHostPort(svcCfg, svc.Name, svc.Ports)
 		services = append(services, ServiceResponse{
 			Name:              svc.Name,
 			Status:            status,


### PR DESCRIPTION
Reviewing everything merged since v1.26 turned up four real defects plus some duplication worth tidying.

The worst were on the MCP path. The service port-ownership guard printed its shift notice to stdout and fired the host-proxy refresh hook there too, corrupting the JSON-RPC stream the MCP server reserves for responses. The guard now writes to stderr, and the server repoints stdout at stderr for the whole session so no in-process diagnostic, or a child process that inherits stdout, can break a protocol frame. The LAN-share Vite HMR diversion only matched the bare root path, so a project with a custom server.hmr.path or a base path lost hot reload over a share; it now keys off the vite-hmr subprotocol, which survives either. A podman install run that triggered both the upgrade heal and a network migration overwrote one torn-down container list with the other and left services stopped; the two are now merged. Idle-suspend treated an empty systemctl snapshot as proof every worker unit had been removed, so a transient enumeration failure could re-mark and later resume workers the user never had running; it now ignores an untrusted snapshot via a new trust flag.

The remainder are cleanups. The reserved-port set the service guard and the host-proxy allocator each computed separately is now one shared accessor on ServiceConfig, which also corrects the guard mis-reading the host side of an ip:host:container mapping. SweepRefs short-circuits the cheap config sources instead of rebuilding the whole protected set on every reclaim. The UI services list loads the global config once rather than once per service and reads a preset port list without deep-copying the whole struct. The FPM up-or-installed fast path is now shared between the two ensure-FPM callers instead of duplicated.

Closes #667