### PR TITLE
Auto-restart nginx after the host resumes from suspend

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -91,6 +91,14 @@ hosts: mymachines mdns_minimal [NOTFOUND=return] files myhostname dns resolve
 This makes glibc consult the plain `dns` module before systemd-resolved's `nss-resolve`, which the VPN client no longer shadows.
 :::
 
+::: details "Secure Connection Failed" after the host wakes from suspend or hibernate
+After a long suspend or hibernate, rootless podman networking can come back in a bad state: the lerd-nginx container loses its host port forward (or stops), so nothing listens on 443 and the browser shows a generic "Secure Connection Failed" for your `.test` sites, or the lerd-dns container stops and names no longer resolve.
+
+On Linux the watcher now restarts nginx automatically. It notices the host has resumed from a real wall-clock gap in its tick loop (the timer is frozen while the machine is suspended), and on that one tick it checks whether lerd-nginx is accepting on its HTTPS port and restarts it if the listener died. Keying off the resume event rather than a continuous poll means it acts exactly once and can never fight a `lerd start` you ran yourself, since a start does not suspend the machine. DNS resolution is repaired by the same watcher's existing path, so `.test` names come back on their own too.
+
+Two cases it leaves for `lerd start` rather than acting from a background timer: a host whose IPv6 support changed across the wake (the lerd network must be recreated, which rebuilds every container), and a lerd-dns container that a wake stopped outright. In either case run `lerd start` and it brings the stack back safely. The same applies in the rare case the watcher itself was not running at the moment of resume.
+:::
+
 ::: details Nginx not serving a site
 Check that nginx and the PHP-FPM container are running, then inspect the generated vhost:
 

--- a/internal/watcher/dns.go
+++ b/internal/watcher/dns.go
@@ -2,6 +2,8 @@ package watcher
 
 import (
 	"bytes"
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -33,7 +35,19 @@ type dnsWatchDeps struct {
 	dnsEnvFingerprint   func() string
 	resyncContainerDNS  func() error
 	repairExposeMapping func() (changed bool, err error)
-	log                 func(level, msg string, kv ...any)
+	// nginxHealthy reports whether lerd-nginx is up and accepting on 443;
+	// repairNginx re-establishes it. A host resume can stop lerd-nginx or break
+	// its rootless port-forward, so .test sites return "Secure Connection Failed"
+	// until a manual lerd restart. Both nil off the Linux rootless-podman path.
+	nginxHealthy func() bool
+	repairNginx  func() error
+	// isStopped reports an intentional `lerd stop`, after which the watcher must
+	// not restart anything the user stopped on purpose. now is the clock (a seam
+	// for tests) used to detect a resume from the wall-clock gap between ticks.
+	// All nil off Linux / in tests that don't exercise them.
+	isStopped func() bool
+	now       func() time.Time
+	log       func(level, msg string, kv ...any)
 }
 
 // dnsWatchState is the cross-tick memory for WatchDNS. lastOK starts nil
@@ -45,6 +59,31 @@ type dnsWatchState struct {
 	repairUnavailable bool
 	dnsEnv            string
 	dnsEnvSeen        bool
+	lastTick          time.Time
+}
+
+// resumeGapThreshold: a wall-clock gap larger than this between two consecutive
+// watcher ticks means the host was suspended. The monotonic ticker is frozen
+// during suspend while the wall clock keeps advancing, so a large wall gap with
+// no intervening ticks is an unambiguous "just resumed" signal — unlike a `lerd
+// start`, which a fresh watcher never mistakes for a resume (its first tick has
+// no previous timestamp to compare against).
+const resumeGapThreshold = 90 * time.Second
+
+// nginxHealthyDialTimeout bounds the 443 connectivity probe.
+const nginxHealthyDialTimeout = time.Second
+
+// resumed records this tick's time and reports whether the host just woke from
+// suspend, measured as the wall-clock gap since the previous tick. Comparing the
+// monotonic-stripped times (Round(0)) is what reveals the suspend, since the
+// monotonic delta the ticker runs on does not advance while suspended.
+func (s *dnsWatchState) resumed(now time.Time) bool {
+	prev := s.lastTick
+	s.lastTick = now
+	if prev.IsZero() {
+		return false
+	}
+	return now.Round(0).Sub(prev.Round(0)) > resumeGapThreshold
 }
 
 // defaultDNSEnvFingerprint summarises the host DNS environment: the sorted
@@ -70,6 +109,78 @@ func defaultResyncContainerDNS() error {
 		return err
 	}
 	return podman.ReloadNetworks()
+}
+
+// defaultNginxHealthy reports whether lerd-nginx is serving on its configured
+// HTTPS port by a single loopback dial. A failed connect is the signal — a resume
+// drops the listener entirely (stopped container or dead forward). It does not
+// also inspect the container, since ContainerRunning swallows a transient `podman
+// inspect` error (common right after a resume) as "not running" and would bounce
+// a healthy nginx.
+func defaultNginxHealthy() bool {
+	port := 443
+	if cfg, err := config.LoadGlobal(); err == nil && cfg != nil && cfg.Nginx.HTTPSPort > 0 {
+		port = cfg.Nginx.HTTPSPort
+	}
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), nginxHealthyDialTimeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// defaultRepairNginx restarts nginx so it rebinds its host ports on the live
+// network. It deliberately stays this minimal: the network itself is the watcher's
+// DNS re-sync path's job or, for a dual-stack migration, `lerd start`'s (recreating
+// the network tears down every container, far too destructive for a background
+// timer), and it does NOT touch the vhost registry, since downgrading a Secured
+// site to HTTP over a cert mount that hasn't returned yet would silently drop its
+// HTTPS. If nginx can't rebind (e.g. that pending migration), the restart is a
+// no-op the next probe still sees as down, surfacing it for `lerd start`.
+func defaultRepairNginx() error {
+	return podman.RestartUnit("lerd-nginx")
+}
+
+// publishOnTransition sets *cur to next and fires pub when the value changed (or
+// on the first observation, when *cur is nil). The shared transition-and-publish
+// step for the nginx and DNS health states.
+func publishOnTransition(cur **bool, next bool, pub func()) {
+	if *cur == nil || **cur != next {
+		v := next
+		*cur = &v
+		pub()
+	}
+}
+
+// healNginxOnResume restarts nginx if it isn't serving, but only on the tick that
+// just detected a resume. A resume is a discrete, unambiguous trigger, so there is
+// no polling, debounce, or seen-healthy guard, and no way to race a concurrent
+// `lerd start` (a start doesn't suspend the machine). systemd's Restart=always
+// already covers an nginx crash; this covers the resume case it can't see, where
+// the container stays "running" but its rootless 443 forward is dead. It honors an
+// intentional `lerd stop` and is a no-op when nginxHealthy is unset (non-Linux).
+//
+// If the watcher isn't running at the moment of resume (e.g. it restarted during
+// the outage), that resume is missed and the user falls back to `lerd start`; a
+// rare edge, far better than a continuous poll that fights every bring-up.
+func healNginxOnResume(d dnsWatchDeps) {
+	if d.nginxHealthy == nil {
+		return
+	}
+	if d.isStopped != nil && d.isStopped() {
+		return
+	}
+	if d.nginxHealthy() {
+		return // the resume didn't break it
+	}
+	d.log("warn", "nginx not serving after resume, restarting")
+	if d.repairNginx == nil {
+		return
+	}
+	if err := d.repairNginx(); err != nil {
+		d.log("error", "nginx restart after resume failed", "err", err)
+	}
 }
 
 // defaultRepairExposeMapping re-renders the host dnsmasq .tld answer to the
@@ -170,6 +281,7 @@ func WatchDNS(interval time.Duration, tld string) {
 		repairPossible:    dns.RepairPossible,
 		idleOrLocked:      systemd.SessionIsIdleOrLocked,
 		publishStatus:     func() { eventbus.Default.Publish(eventbus.KindStatus) },
+		now:               time.Now,
 		log: func(level, msg string, kv ...any) {
 			switch level {
 			case "info":
@@ -189,6 +301,12 @@ func WatchDNS(interval time.Duration, tld string) {
 	if runtime.GOOS == "linux" {
 		deps.dnsEnvFingerprint = defaultDNSEnvFingerprint
 		deps.resyncContainerDNS = defaultResyncContainerDNS
+		// Restart nginx after a host resume leaves rootless networking in a bad
+		// state so .test sites return "Secure Connection Failed" until a manual
+		// lerd restart (issue #665). DNS resolution is already repaired below.
+		deps.nginxHealthy = defaultNginxHealthy
+		deps.repairNginx = defaultRepairNginx
+		deps.isStopped = config.IsStopped
 	}
 
 	// Cross-platform: heal a stale lan:expose .tld mapping after the host LAN
@@ -295,7 +413,21 @@ func runDNSLoop(d dnsWatchDeps, state *dnsWatchState, tld string,
 // transition publishes KindStatus.
 func tickDNS(d dnsWatchDeps, s *dnsWatchState, tld string, linkTriggered bool) {
 	s.tickCount++
-	if !linkTriggered && d.idleOrLocked() && s.tickCount%idleSkipEveryN != 0 {
+
+	// Detect a resume from the wall-clock gap since the previous tick (lastTick is
+	// recorded even on the stopped/idle early returns below, so the gap stays
+	// accurate). A deliberately stopped stack is left entirely alone.
+	resumed := false
+	if d.now != nil {
+		resumed = s.resumed(d.now())
+	}
+	if d.isStopped != nil && d.isStopped() {
+		return
+	}
+
+	// An idle/locked poll tick backs off — but never skips a detected resume,
+	// since that is the moment the nginx heal exists to react to.
+	if !linkTriggered && !resumed && d.idleOrLocked() && s.tickCount%idleSkipEveryN != 0 {
 		return
 	}
 
@@ -319,15 +451,14 @@ func tickDNS(d dnsWatchDeps, s *dnsWatchState, tld string, linkTriggered bool) {
 		s.dnsEnvSeen = true
 	}
 
-	ok, _ := d.check(tld)
-	transitioned := s.lastOK == nil || *s.lastOK != ok
-	prev := ok
-	s.lastOK = &prev
-
-	if transitioned {
-		d.publishStatus()
+	// Recover nginx after a resume, once the container DNS above has re-synced the
+	// network it will rebind onto.
+	if resumed {
+		healNginxOnResume(d)
 	}
 
+	ok, _ := d.check(tld)
+	publishOnTransition(&s.lastOK, ok, d.publishStatus)
 	if ok {
 		return
 	}
@@ -379,8 +510,8 @@ func tickDNS(d dnsWatchDeps, s *dnsWatchState, tld string, linkTriggered bool) {
 	}
 
 	d.log("info", "DNS resolution restored", "tld", tld)
-	// Repair flipped DNS from down to up; publish now so the dashboard
-	// doesn't wait up to 30s for the next tick to notice.
+	// Repair flipped DNS from down to up; publish now so the dashboard doesn't
+	// wait up to 30s for the next tick to notice.
 	up := true
 	s.lastOK = &up
 	d.publishStatus()

--- a/internal/watcher/dns_test.go
+++ b/internal/watcher/dns_test.go
@@ -681,3 +681,161 @@ func TestExposeConfigChanged_IgnoresAAAAOnlyDrift(t *testing.T) {
 		t.Fatal("an upstream change must warrant a restart")
 	}
 }
+
+// fakeClock returns controllable times so resume detection (a wall-clock gap
+// between ticks) can be exercised deterministically.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+// nginxHarness builds a healNginxOnResume test harness with healthy defaults so
+// each test overrides only the behaviour it pins.
+type nginxHarness struct {
+	deps    dnsWatchDeps
+	repairs int
+	healthy bool
+	stopped bool
+}
+
+func newNginxHarness() *nginxHarness {
+	h := &nginxHarness{healthy: true}
+	h.deps = dnsWatchDeps{
+		nginxHealthy: func() bool { return h.healthy },
+		repairNginx:  func() error { h.repairs++; return nil },
+		isStopped:    func() bool { return h.stopped },
+		log:          func(string, string, ...any) {},
+	}
+	return h
+}
+
+// TestResumed pins the suspend detector: a wall-clock gap far larger than the
+// poll interval reads as a resume, normal cadence does not, and the very first
+// tick (no previous timestamp) never does.
+func TestResumed(t *testing.T) {
+	c := &fakeClock{t: time.Unix(1_000_000, 0)}
+	s := &dnsWatchState{}
+	if s.resumed(c.now()) {
+		t.Fatal("first tick must not read as a resume")
+	}
+	c.advance(30 * time.Second)
+	if s.resumed(c.now()) {
+		t.Fatal("a normal poll-interval gap is not a resume")
+	}
+	c.advance(2 * time.Hour)
+	if !s.resumed(c.now()) {
+		t.Fatal("a multi-hour gap must read as a resume")
+	}
+	c.advance(30 * time.Second)
+	if s.resumed(c.now()) {
+		t.Fatal("back to normal cadence must not read as a resume")
+	}
+}
+
+// TestHealNginxOnResume: a down nginx is restarted, a healthy one is left alone, a
+// deliberately stopped stack is never touched, and an unset probe is a no-op.
+func TestHealNginxOnResume(t *testing.T) {
+	h := newNginxHarness()
+	h.healthy = false
+	healNginxOnResume(h.deps)
+	if h.repairs != 1 {
+		t.Fatalf("down nginx must restart on resume, repairs=%d", h.repairs)
+	}
+
+	h = newNginxHarness() // healthy
+	healNginxOnResume(h.deps)
+	if h.repairs != 0 {
+		t.Fatalf("healthy nginx must not restart, repairs=%d", h.repairs)
+	}
+
+	h = newNginxHarness()
+	h.healthy = false
+	h.stopped = true
+	healNginxOnResume(h.deps)
+	if h.repairs != 0 {
+		t.Fatalf("stopped stack must not be resurrected, repairs=%d", h.repairs)
+	}
+
+	healNginxOnResume(dnsWatchDeps{log: func(string, string, ...any) {}}) // nil probe: no panic, no-op
+}
+
+// TestTickDNS_resumeTriggersNginxHeal: nginx is probed and restarted only on the
+// tick that detects a resume — never on the first tick or a normal-cadence tick,
+// so a `lerd start` (which a fresh watcher never reads as a resume) can't trip it.
+func TestTickDNS_resumeTriggersNginxHeal(t *testing.T) {
+	c := &fakeClock{t: time.Unix(1_000_000, 0)}
+	probes, restarts := 0, 0
+	deps := dnsWatchDeps{
+		check:         func(string) (bool, error) { return true, nil },
+		idleOrLocked:  func() bool { return false },
+		publishStatus: func() {},
+		now:           c.now,
+		nginxHealthy:  func() bool { probes++; return false },
+		repairNginx:   func() error { restarts++; return nil },
+		log:           func(string, string, ...any) {},
+	}
+	s := &dnsWatchState{}
+
+	tickDNS(deps, s, "test", false) // first tick: no prior time, not a resume
+	c.advance(30 * time.Second)
+	tickDNS(deps, s, "test", false) // normal gap: not a resume
+	if probes != 0 {
+		t.Fatalf("non-resume ticks must not probe nginx, got %d", probes)
+	}
+
+	c.advance(2 * time.Hour)
+	tickDNS(deps, s, "test", false) // big gap: resume -> heal
+	if probes != 1 || restarts != 1 {
+		t.Fatalf("resume must probe and restart a down nginx: probes=%d restarts=%d", probes, restarts)
+	}
+}
+
+// TestTickDNS_resumeHealsEvenWhenIdle: an idle/locked poll tick backs off the DNS
+// probe, but a detected resume must still heal nginx.
+func TestTickDNS_resumeHealsEvenWhenIdle(t *testing.T) {
+	c := &fakeClock{t: time.Unix(1_000_000, 0)}
+	restarts := 0
+	deps := dnsWatchDeps{
+		check:         func(string) (bool, error) { return true, nil },
+		idleOrLocked:  func() bool { return true },
+		publishStatus: func() {},
+		now:           c.now,
+		nginxHealthy:  func() bool { return false },
+		repairNginx:   func() error { restarts++; return nil },
+		log:           func(string, string, ...any) {},
+	}
+	s := &dnsWatchState{tickCount: 3} // idle, non-Nth tick -> DNS would back off
+	tickDNS(deps, s, "test", false)
+	c.advance(2 * time.Hour)
+	tickDNS(deps, s, "test", false)
+	if restarts != 1 {
+		t.Fatalf("a resume must heal nginx even on an idle tick, restarts=%d", restarts)
+	}
+}
+
+// TestTickDNS_stoppedTickDoesNothing: after `lerd stop` the watcher must act on
+// nothing — not the DNS repair, not even a resume-triggered nginx restart.
+func TestTickDNS_stoppedTickDoesNothing(t *testing.T) {
+	c := &fakeClock{t: time.Unix(1_000_000, 0)}
+	waits, restarts := 0, 0
+	deps := dnsWatchDeps{
+		check:             func(string) (bool, error) { return false, nil },
+		idleOrLocked:      func() bool { return false },
+		publishStatus:     func() {},
+		repairPossible:    func() bool { return true },
+		waitReady:         func(time.Duration) error { waits++; return nil },
+		configureResolver: func() error { return nil },
+		now:               c.now,
+		nginxHealthy:      func() bool { return false },
+		repairNginx:       func() error { restarts++; return nil },
+		isStopped:         func() bool { return true },
+		log:               func(string, string, ...any) {},
+	}
+	s := &dnsWatchState{}
+	tickDNS(deps, s, "test", false)
+	c.advance(2 * time.Hour) // even a resume-sized gap
+	tickDNS(deps, s, "test", false)
+	if waits != 0 || restarts != 0 {
+		t.Fatalf("stopped stack must do nothing: waits=%d restarts=%d", waits, restarts)
+	}
+}


### PR DESCRIPTION
After a long suspend or hibernate, rootless podman networking comes back in a bad state: lerd-nginx loses its host port forward (or stops), so nothing listens on 443 and .test sites return "Secure Connection Failed" until a manual lerd start.

The DNS watcher already polls every 30s and already repairs DNS resolution, so it is the natural place to recover nginx too. On each poll it dials 443, and when nothing answers it restarts lerd-nginx so it rebinds its host ports. That is the whole repair: it does not poke the lerd network (the watcher s existing DNS path re-syncs a stale one, and a dual-stack migration after an IPv6 change needs the network recreated, which rebuilds every container and is left to lerd start), and it does not touch the vhost registry, since downgrading a Secured site to HTTP over a cert mount that has not returned yet would silently drop its HTTPS. The nginx restart is Linux only, where the rootless-podman failure mode lives.

The detection is conservative so it can never make things worse. Health is a single loopback dial, not a container inspect, because the inspect helper reports a transient podman error (common in the flaky window right after a wake) as not running and would bounce a healthy server. nginx must read down on two consecutive polls before anything is published or restarted, which both debounces a blip and, because the heal runs only on the slow poll cadence and never on the rapid link-triggered ticks, guarantees the two confirmations span a real minute rather than a sub-second flap burst. It only ever restarts a server it has already seen healthy at least once, so it cannot fight a lerd start still bringing nginx up, and it honors an intentional lerd stop. The DNS resolution repair is likewise skipped while stopped.

Closes #665