### PR TITLE
fix(ui): pause host-proxy site when its dev-server worker is stopped (502 fix)

### DIFF
--- a/internal/ui/host_proxy_worker_lifecycle_test.go
+++ b/internal/ui/host_proxy_worker_lifecycle_test.go
@@ -1,0 +1,38 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// TestHostProxyAppLifecycleOp pins the routing that fixes the host-proxy 502:
+// stopping/starting the parent "app" worker must become a site pause/unpause
+// (which swaps the proxy vhost), while every other case keeps the plain
+// per-worker path.
+func TestHostProxyAppLifecycleOp(t *testing.T) {
+	app := config.HostProxyWorkerName
+	cases := []struct {
+		name               string
+		isHostProxy        bool
+		worker, branch, op string
+		wantOp             string
+		wantOK             bool
+	}{
+		{"host-proxy app stop -> pause", true, app, "", "stop", "pause", true},
+		{"host-proxy app start -> unpause", true, app, "", "start", "unpause", true},
+		{"non-host-proxy app untouched", false, app, "", "stop", "", false},
+		{"other worker on host-proxy untouched", true, "queue", "", "stop", "", false},
+		{"worktree app untouched", true, app, "feature", "stop", "", false},
+		{"unknown op untouched", true, app, "", "restart", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotOp, gotOK := hostProxyAppLifecycleOp(tc.isHostProxy, tc.worker, tc.branch, tc.op)
+			if gotOp != tc.wantOp || gotOK != tc.wantOK {
+				t.Fatalf("hostProxyAppLifecycleOp(%v, %q, %q, %q) = (%q, %v), want (%q, %v)",
+					tc.isHostProxy, tc.worker, tc.branch, tc.op, gotOp, gotOK, tc.wantOp, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -3805,6 +3805,28 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 			if len(parts) == 3 && (parts[2] == "start" || parts[2] == "stop") {
 				workerName := parts[1]
 				branch := r.URL.Query().Get("branch")
+				// A host-proxy site's dev server (the "app" worker) IS the site:
+				// nothing runs behind the proxy vhost but the dev command itself.
+				// Stopping just its unit leaves the vhost proxying to a now-dead
+				// port, so every request 502s. Route the parent app worker's
+				// start/stop through pause/unpause, which swap the vhost to the
+				// paused page (and back) and keep registry state consistent so the
+				// paused page's Resume button works. Worktree dev servers keep the
+				// plain worker path; their vhosts are handled by (un)pauseWorktrees.
+				if lifecycle, ok := hostProxyAppLifecycleOp(site.IsHostProxy(), workerName, branch, parts[2]); ok {
+					var opErr error
+					if lifecycle == "pause" {
+						opErr = cli.PauseSite(site.Name)
+					} else {
+						opErr = cli.UnpauseSite(site.Name)
+					}
+					if opErr != nil {
+						writeJSON(w, SiteActionResponse{Error: opErr.Error()})
+						return
+					}
+					writeJSON(w, SiteActionResponse{OK: true})
+					return
+				}
 				targetPath := site.Path
 				if branch != "" {
 					wtPath := resolveSitePath(site, branch)
@@ -3865,6 +3887,26 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, SiteActionResponse{OK: true})
+}
+
+// hostProxyAppLifecycleOp maps a worker start/stop on a host-proxy site's parent
+// dev-server worker ("app") to the site-level lifecycle op that also swaps the
+// proxy vhost: "stop" -> "pause", "start" -> "unpause". It returns ok=false for
+// anything that must take the normal per-worker path — a different worker, a
+// worktree target (branch set), or a non-host-proxy site — so only the parent
+// app worker is rerouted. Without this, stopping the app worker leaves the proxy
+// vhost pointing at the dead dev-server port and every request to the site 502s.
+func hostProxyAppLifecycleOp(isHostProxy bool, workerName, branch, op string) (string, bool) {
+	if !isHostProxy || workerName != config.HostProxyWorkerName || branch != "" {
+		return "", false
+	}
+	switch op {
+	case "stop":
+		return "pause", true
+	case "start":
+		return "unpause", true
+	}
+	return "", false
 }
 
 func handlePHPVersionAction(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes #671.

## Problem

Stopping a host-proxy site's dev server from the dashboard leaves the site returning **502 Bad Gateway** for every request. Reproduced on a secured host-proxy site running a dev server (e.g. `pnpm dev`): after stopping its `app` worker the dev-server port is no longer listening, yet a request to the site returns `502`.

The vhost is still the live proxy, pointing at the now-dead port:

```
location / {
    proxy_pass http://host.containers.internal:<dev-port>;
    ...
}
```

## Root cause

A host-proxy site's dev server is the synthesized `app` worker (`config.HostProxyWorkerName`), not a framework worker. The dashboard's `worker:app:stop` action calls `WorkerStopForSite`, which tears down only the `lerd-app-<site>` unit. Nothing swaps the proxy vhost, so nginx keeps proxying to the dead port and 502s.

It is also asymmetric: because `app` is not in any framework's `Workers` map, the `worker:app:start` path bails with "worker app not defined", so once stopped there is no per-worker way to bring it back, only `lerd start` or pause/unpause.

`PauseSite` already does the right thing for host-proxy sites (`GeneratePausedVhost` swaps the secured vhost to the paused page and removes the stale `-ssl.conf`, then reloads), and `UnpauseSite` restores the proxy vhost and restarts the dev server. Stopping the only thing a host-proxy site runs is, semantically, pausing the site.

## Fix

Route the parent `app` worker's start/stop through `PauseSite` / `UnpauseSite` at the dashboard handler (so there is no recursion through `WorkerStopForSite`):

- `worker:app:stop` (parent, host-proxy) -> `PauseSite`: swaps the vhost to the paused landing page, stops the dev server, marks the site paused. The paused page's Resume button then works because the registry state is consistent.
- `worker:app:start` (parent, host-proxy) -> `UnpauseSite`: restores the proxy vhost and dev server.
- Other workers, worktree targets (`branch` set), and non-host-proxy sites keep the plain per-worker path untouched.

The decision is factored into a pure `hostProxyAppLifecycleOp` helper so the routing is unit-testable without standing up the HTTP handler.

Worktree host-proxy dev servers (`worker:app:stop?branch=...`) have the same class of issue but no single-worktree pause primitive exists; left for a follow-up and explicitly excluded here (they keep the normal worker path).

## Test

`TestHostProxyAppLifecycleOp` (table-driven) pins the routing: parent app stop -> pause, start -> unpause, and untouched for non-host-proxy sites, other workers, worktree targets, and unknown ops. `go build` + `go vet ./internal/ui` clean.