### PR TITLE
fix(idle): serve an auto-refreshing waking page for suspended host-proxy sites

### DIFF
--- a/internal/cli/idle_engine.go
+++ b/internal/cli/idle_engine.go
@@ -2,14 +2,19 @@ package cli
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"sync"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/nginx"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/siteinfo"
+	"github.com/geodro/lerd/internal/siteops"
 )
 
 // unitStatesOKFn snapshots every lerd-* unit's state plus a trust flag; a var so
@@ -57,7 +62,11 @@ func SuspendWorkersForIdle(site *config.Site) []string {
 		stopWorkerByName(site, w)
 		suspended = append(suspended, w)
 	}
-	return appendLostSuspended(site, suspended)
+	final := appendLostSuspended(site, suspended)
+	// A host-proxy site's dev server is its only request-serving process, so once
+	// idle-suspend stops it the proxy vhost 502s. Swap to the waking page instead.
+	swapHostProxyVhostToWaking(site, final)
+	return final
 }
 
 // appendLostSuspended adds any of the site's declared workers (.lerd.yaml) whose
@@ -127,6 +136,67 @@ func ResumeWorkersForIdle(site *config.Site, workers []string) {
 	}
 	for _, w := range workers {
 		resumeWorkerByName(site, w, phpVersion)
+	}
+	// Restore the host-proxy proxy vhost the suspend swapped to the waking page,
+	// once the dev server is listening again.
+	restoreHostProxyVhostAfterIdle(site, workers)
+}
+
+// swapHostProxyVhostToWaking swaps a host-proxy site's proxy vhost to the
+// auto-refreshing waking page when idle-suspend stops its dev server, so a
+// request to the sleeping site serves a "starting back up" page (the access hit
+// drives the resume) instead of a 502 from nginx proxying to the dead port.
+// No-op unless the site is host-proxy and its app worker is among the suspended
+// set.
+func swapHostProxyVhostToWaking(site *config.Site, suspended []string) {
+	if !site.IsHostProxy() || !containsString(suspended, hostProxyWorkerName) {
+		return
+	}
+	if err := writeWakingHTML(site); err != nil {
+		fmt.Printf("[WARN] idle-suspend waking page %s: %v\n", site.Name, err)
+		return
+	}
+	if err := nginx.GenerateWakingVhost(*site); err != nil {
+		fmt.Printf("[WARN] idle-suspend waking vhost %s: %v\n", site.Name, err)
+		return
+	}
+	nginx.ReloadOrWarn("")
+}
+
+// restoreHostProxyVhostAfterIdle restores a host-proxy site's proxy vhost after
+// idle-resume restarts its dev server. It waits for the dev server to be
+// listening again first so the waking page's auto-refresh keeps serving until the
+// app can answer, rather than flashing nginx's own 502 (which carries no refresh
+// and would break the reload loop) during the dev server's warmup.
+func restoreHostProxyVhostAfterIdle(site *config.Site, workers []string) {
+	if !site.IsHostProxy() || !containsString(workers, hostProxyWorkerName) {
+		return
+	}
+	// ponytail: poll the dev-server port, bounded to 60s. Vite/Nuxt can take many
+	// seconds to bind after launch; with no fixed proxy port we skip the wait and
+	// restore immediately (the worst case is a brief 502 flash on warmup).
+	if proxy := parentProxyConfig(*site); proxy != nil && proxy.Port > 0 {
+		waitForHostPort(proxy.Port, 60*time.Second)
+	}
+	if err := siteops.RegenerateSiteVhost(site, site.PrimaryDomain()); err != nil {
+		fmt.Printf("[WARN] idle-resume host-proxy vhost %s: %v\n", site.Name, err)
+		return
+	}
+	nginx.ReloadOrWarn("")
+}
+
+// waitForHostPort blocks until a TCP connection to the host port succeeds or the
+// timeout elapses, polling cheaply. Gates the host-proxy proxy-vhost restore on
+// the dev server actually accepting connections again.
+func waitForHostPort(port int, timeout time.Duration) {
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if conn, err := net.DialTimeout("tcp", addr, time.Second); err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(250 * time.Millisecond)
 	}
 }
 

--- a/internal/cli/idle_engine.go
+++ b/internal/cli/idle_engine.go
@@ -142,6 +142,14 @@ func ResumeWorkersForIdle(site *config.Site, workers []string) {
 	restoreHostProxyVhostAfterIdle(site, workers)
 }
 
+// hostProxyVhostSwapApplies reports whether idle suspend/resume should swap a
+// site's vhost: only for a host-proxy site whose suspended (or resumed) worker
+// set includes the app dev server. Every other site or worker set leaves the
+// vhost untouched.
+func hostProxyVhostSwapApplies(isHostProxy bool, workers []string) bool {
+	return isHostProxy && containsString(workers, hostProxyWorkerName)
+}
+
 // swapHostProxyVhostToWaking swaps a host-proxy site's proxy vhost to the
 // auto-refreshing waking page when idle-suspend stops its dev server, so a
 // request to the sleeping site serves a "starting back up" page (the access hit
@@ -149,7 +157,7 @@ func ResumeWorkersForIdle(site *config.Site, workers []string) {
 // No-op unless the site is host-proxy and its app worker is among the suspended
 // set.
 func swapHostProxyVhostToWaking(site *config.Site, suspended []string) {
-	if !site.IsHostProxy() || !containsString(suspended, hostProxyWorkerName) {
+	if !hostProxyVhostSwapApplies(site.IsHostProxy(), suspended) {
 		return
 	}
 	if err := writeWakingHTML(site); err != nil {
@@ -169,12 +177,12 @@ func swapHostProxyVhostToWaking(site *config.Site, suspended []string) {
 // app can answer, rather than flashing nginx's own 502 (which carries no refresh
 // and would break the reload loop) during the dev server's warmup.
 func restoreHostProxyVhostAfterIdle(site *config.Site, workers []string) {
-	if !site.IsHostProxy() || !containsString(workers, hostProxyWorkerName) {
+	if !hostProxyVhostSwapApplies(site.IsHostProxy(), workers) {
 		return
 	}
-	// ponytail: poll the dev-server port, bounded to 60s. Vite/Nuxt can take many
-	// seconds to bind after launch; with no fixed proxy port we skip the wait and
-	// restore immediately (the worst case is a brief 502 flash on warmup).
+	// Poll the dev-server port, bounded to 60s. Vite/Nuxt can take many seconds
+	// to bind after launch; with no fixed proxy port we skip the wait and restore
+	// immediately (the worst case is a brief 502 flash on warmup).
 	if proxy := parentProxyConfig(*site); proxy != nil && proxy.Port > 0 {
 		waitForHostPort(proxy.Port, 60*time.Second)
 	}

--- a/internal/cli/idle_hostproxy_test.go
+++ b/internal/cli/idle_hostproxy_test.go
@@ -14,3 +14,32 @@ func TestWakingPageHTML_autoRefreshes(t *testing.T) {
 		t.Error("waking page must carry a meta refresh so a resumed site reloads on its own")
 	}
 }
+
+// TestHostProxyVhostSwapApplies pins the gate the idle suspend/resume vhost swap
+// rides on: only a host-proxy site whose worker set includes the app dev server
+// swaps to (or restores from) the waking page; every other site or worker set is
+// left alone.
+func TestHostProxyVhostSwapApplies(t *testing.T) {
+	app := hostProxyWorkerName
+	cases := []struct {
+		name        string
+		isHostProxy bool
+		workers     []string
+		want        bool
+	}{
+		{"host-proxy with app", true, []string{app}, true},
+		{"host-proxy with app among others", true, []string{"queue", app}, true},
+		{"host-proxy without app", true, []string{"queue", "schedule"}, false},
+		{"host-proxy empty set", true, nil, false},
+		{"non-host-proxy with app", false, []string{app}, false},
+		{"non-host-proxy without app", false, []string{"queue"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hostProxyVhostSwapApplies(tc.isHostProxy, tc.workers); got != tc.want {
+				t.Fatalf("hostProxyVhostSwapApplies(%v, %v) = %v, want %v",
+					tc.isHostProxy, tc.workers, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/idle_hostproxy_test.go
+++ b/internal/cli/idle_hostproxy_test.go
@@ -1,0 +1,16 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWakingPageHTML_autoRefreshes guards the wake mechanism: the page a sleeping
+// host-proxy site serves must auto-refresh, so once the access hit drives resume
+// and the proxy vhost is restored, the browser reloads onto the live app without
+// the user touching anything.
+func TestWakingPageHTML_autoRefreshes(t *testing.T) {
+	if !strings.Contains(wakingPageHTML, `http-equiv="refresh"`) {
+		t.Error("waking page must carry a meta refresh so a resumed site reloads on its own")
+	}
+}

--- a/internal/cli/pause.go
+++ b/internal/cli/pause.go
@@ -648,6 +648,82 @@ func writePausedHTML(_ *config.Site) error {
 	return os.WriteFile(filepath.Join(dir, "paused.html"), []byte(pausedPageHTML), 0644)
 }
 
+// wakingPageHTML is the static landing page served while an idle-suspended
+// host-proxy site's dev server is starting back up. Unlike the paused page it
+// has no Resume button: the request that loaded it already drove idle-resume, so
+// it just auto-refreshes (native meta refresh) until the proxy vhost is restored
+// and the reload lands on the live app.
+const wakingPageHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="refresh" content="3">
+  <title>Waking up</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      background: #0f1117;
+      color: #e5e7eb;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+    }
+    .card {
+      background: #1a1d27;
+      border: 1px solid #2d3142;
+      border-radius: 14px;
+      padding: 2.5rem 3rem;
+      max-width: 420px;
+      width: calc(100% - 2rem);
+      text-align: center;
+    }
+    .spinner {
+      width: 40px;
+      height: 40px;
+      margin: 0 auto 1.25rem;
+      border: 3px solid #2d3142;
+      border-top-color: #FF2D20;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    h1 { font-size: 1.2rem; font-weight: 600; margin: 0 0 0.5rem; }
+    .host {
+      font-size: 0.85rem;
+      color: #FF2D20;
+      font-family: ui-monospace, 'Cascadia Code', monospace;
+      margin: 0 0 1rem;
+      word-break: break-all;
+    }
+    p { font-size: 0.85rem; color: #9ca3af; margin: 0; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="spinner"></div>
+    <h1>Waking the dev server</h1>
+    <p class="host" id="host"></p>
+    <p>This site was idle and is starting back up. This page refreshes automatically.</p>
+  </div>
+  <script>document.getElementById('host').textContent = location.hostname;</script>
+</body>
+</html>
+`
+
+// writeWakingHTML ensures the shared idle-waking landing page exists in the same
+// directory as the paused page.
+func writeWakingHTML(_ *config.Site) error {
+	dir := config.PausedDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "waking.html"), []byte(wakingPageHTML), 0644)
+}
+
 // pauseWorktrees generates paused HTML and nginx vhosts for every worktree of
 // a site that is being paused. The resume button on each worktree page unpauses
 // the parent site (which restores all worktree vhosts as well).

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -567,20 +567,14 @@ func GenerateWorktreeHostProxyVhostFor(domain, path, parentDomain string, upstre
 	return os.WriteFile(filepath.Join(config.NginxConfD(), domain+".conf"), buf.Bytes(), 0644)
 }
 
-// GeneratePausedVhost writes a minimal nginx vhost that serves the static paused
-// landing page for the given site. For secured sites it also adds the HTTPS block
-// so the redirect and TLS still work while the site is paused.
-func GeneratePausedVhost(site config.Site) error {
-	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
-		return err
-	}
-
-	pausedDir := config.PausedDir()
+// landingVhostConf renders a minimal vhost for site that serves htmlFile (read
+// from pausedDir) for every path. Shared by the paused and the idle-waking
+// landing pages. Secured sites get an 80->443 redirect plus a TLS server block;
+// plain sites a single 80 server.
+func landingVhostConf(site config.Site, pausedDir, htmlFile string) string {
 	serverNames := serverNamesWithWildcards(site.Domains)
-
-	var conf string
 	if site.Secured {
-		conf = fmt.Sprintf(`server {
+		return fmt.Sprintf(`server {
     listen 80;
     listen [::]:80;
     server_name %s;
@@ -595,35 +589,56 @@ server {
     ssl_certificate_key /etc/nginx/certs/%s.key;
     root %s;
     location / {
-        try_files /paused.html =503;
+        try_files /%s =503;
         default_type text/html;
     }
 }
-`, serverNames, serverNames, site.PrimaryDomain(), site.PrimaryDomain(), pausedDir)
-	} else {
-		conf = fmt.Sprintf(`server {
+`, serverNames, serverNames, site.PrimaryDomain(), site.PrimaryDomain(), pausedDir, htmlFile)
+	}
+	return fmt.Sprintf(`server {
     listen 80;
     listen [::]:80;
     server_name %s;
     root %s;
     location / {
-        try_files /paused.html =503;
+        try_files /%s =503;
         default_type text/html;
     }
 }
-`, serverNames, pausedDir)
-	}
+`, serverNames, pausedDir, htmlFile)
+}
 
+// writeLandingVhost writes site's static-page vhost (serving htmlFile) to
+// conf.d/<domain>.conf and, for secured sites, removes the separate -ssl.conf so
+// nginx stops routing HTTPS to the real backend while the page is up.
+func writeLandingVhost(site config.Site, htmlFile string) error {
+	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
+		return err
+	}
+	conf := landingVhostConf(site, config.PausedDir(), htmlFile)
 	confPath := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
 	if err := os.WriteFile(confPath, []byte(conf), 0644); err != nil {
 		return err
 	}
-	// For secured sites the SSL vhost lives in a separate file; remove it so
-	// nginx doesn't still route HTTPS requests to PHP-FPM while the site is paused.
 	if site.Secured {
 		_ = os.Remove(filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf"))
 	}
 	return nil
+}
+
+// GeneratePausedVhost writes a minimal nginx vhost that serves the static paused
+// landing page for the given site. For secured sites it also adds the HTTPS block
+// so the redirect and TLS still work while the site is paused.
+func GeneratePausedVhost(site config.Site) error {
+	return writeLandingVhost(site, "paused.html")
+}
+
+// GenerateWakingVhost swaps an idle-suspended host-proxy site's vhost to the
+// auto-refreshing "waking up" page. A request to a sleeping site then wakes its
+// dev server (the access hit drives idle-resume) and the page reloads onto the
+// live app, instead of nginx returning 502 from proxying to the stopped server.
+func GenerateWakingVhost(site config.Site) error {
+	return writeLandingVhost(site, "waking.html")
 }
 
 // GeneratePausedWorktreeVhost writes a paused nginx vhost for a worktree domain.

--- a/internal/nginx/waking_vhost_test.go
+++ b/internal/nginx/waking_vhost_test.go
@@ -1,0 +1,63 @@
+package nginx
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestGenerateWakingVhost_servesWakingPageNotProxy(t *testing.T) {
+	confD := setupConfD(t)
+	site := config.Site{Name: "rr", Domains: []string{"rr.test"}, Path: "/srv/rr"}
+	if err := GenerateWakingVhost(site); err != nil {
+		t.Fatalf("GenerateWakingVhost: %v", err)
+	}
+	conf := readConf(t, filepath.Join(confD, "rr.test.conf"))
+	if !strings.Contains(conf, "try_files /waking.html =503") {
+		t.Errorf("waking vhost should serve waking.html, got:\n%s", conf)
+	}
+	if strings.Contains(conf, "proxy_pass") {
+		t.Errorf("waking vhost must not proxy to the stopped dev server, got:\n%s", conf)
+	}
+}
+
+func TestGenerateWakingVhost_securedRemovesSeparateSSLConf(t *testing.T) {
+	confD := setupConfD(t)
+	if err := os.MkdirAll(confD, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// A secured host-proxy site's real backend lives in a separate -ssl.conf; the
+	// waking swap must delete it so HTTPS stops routing to the dead dev server.
+	sslPath := filepath.Join(confD, "rr.test-ssl.conf")
+	if err := os.WriteFile(sslPath, []byte("server { listen 443 ssl; }\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	site := config.Site{Name: "rr", Domains: []string{"rr.test"}, Path: "/srv/rr", Secured: true}
+	if err := GenerateWakingVhost(site); err != nil {
+		t.Fatalf("GenerateWakingVhost: %v", err)
+	}
+	if _, err := os.Stat(sslPath); !os.IsNotExist(err) {
+		t.Errorf("secured waking swap should remove %s", sslPath)
+	}
+	conf := readConf(t, filepath.Join(confD, "rr.test.conf"))
+	if !strings.Contains(conf, "listen 443 ssl") || !strings.Contains(conf, "try_files /waking.html") {
+		t.Errorf("secured waking vhost wrong:\n%s", conf)
+	}
+}
+
+// TestGeneratePausedVhost_stillServesPausedPage guards the refactor: the paused
+// vhost must keep serving paused.html after sharing code with the waking vhost.
+func TestGeneratePausedVhost_stillServesPausedPage(t *testing.T) {
+	confD := setupConfD(t)
+	site := config.Site{Name: "app", Domains: []string{"app.test"}, Path: "/srv/app"}
+	if err := GeneratePausedVhost(site); err != nil {
+		t.Fatalf("GeneratePausedVhost: %v", err)
+	}
+	conf := readConf(t, filepath.Join(confD, "app.test.conf"))
+	if !strings.Contains(conf, "try_files /paused.html =503") {
+		t.Errorf("paused vhost should serve paused.html, got:\n%s", conf)
+	}
+}


### PR DESCRIPTION
Fixes #672.

## Problem

When idle-suspend sleeps a host-proxy site, the site returns **502 Bad Gateway** and does not recover gracefully on the next request.

A PHP site keeps serving while idle-suspended: the engine stops only its background workers (queue, horizon) and FPM stays up. A host-proxy site has no FPM, the dev server (the `app` worker) is its only request-serving process. Stopping it leaves the proxy vhost pointing at a dead port, so nginx 502s.

"Resume on next request" can't recover it cleanly either: the request 502s at nginx before the dev server (often a slow Vite/Nuxt warmup) is back, and nginx's 502 page carries no auto-refresh, so the reload loop never lands on the live app.

## Fix

On suspend of a host-proxy site, swap its proxy vhost to an auto-refreshing "waking up" landing page instead of leaving the dead proxy:

- `SuspendWorkersForIdle`: when the suspended set includes the host-proxy `app` worker, write `waking.html` and swap to the waking vhost (`GenerateWakingVhost`) + reload.
- `ResumeWorkersForIdle`: after restarting the dev server, wait (bounded, 60s) for its port to accept connections, then restore the proxy vhost via `siteops.RegenerateSiteVhost` + reload. The wait keeps the auto-refreshing page serving through the dev server's warmup so the reload lands on the live app rather than flashing nginx's refresh-less 502.

The access-log hit that loads the waking page already drives idle-resume (the existing `OnActivity` path), so no extra wake wiring is needed. PHP sites are unaffected.

The paused and waking vhosts now share `landingVhostConf` / `writeLandingVhost`, so `GeneratePausedVhost` is output-identical to before.

## Test

- `internal/nginx`: `GenerateWakingVhost` serves `waking.html` (not a proxy_pass), and on a secured site removes the separate `-ssl.conf`; a regression test pins `GeneratePausedVhost` still serving `paused.html` after the refactor.
- `internal/cli`: the waking page carries a `meta http-equiv="refresh"` so a resumed site reloads on its own.
- `go build`, `go vet ./internal/cli ./internal/nginx`, and the `nginx` + `cli` + `watcher` suites pass.

## Notes

The port-wait is bounded to 60s and skipped when the proxy has no fixed port (worst case a brief 502 flash on warmup). Scope is the parent host-proxy site; worktree host-proxy dev servers are out of scope here.