### PR TITLE
fix(watcher): bound source-file watches so an asset dump can't exhaust fds

### DIFF
--- a/internal/watcher/sourcefiles.go
+++ b/internal/watcher/sourcefiles.go
@@ -19,6 +19,23 @@ type SourceTarget struct {
 	Dirs []string
 }
 
+// maxSourceDirEntries caps how many direct entries a directory may have before
+// the source watcher skips it. fsnotify's macOS (kqueue) backend opens a file
+// descriptor per file in every watched directory, so a generated or vendored
+// asset dump checked into a source root (e.g. a Font Awesome icon set with
+// thousands of SVGs) can exhaust the per-process fd limit. Such a directory is
+// not hand-edited source, so skipping it costs nothing for activity detection
+// while keeping fd use bounded. Real source dirs hold tens to a few hundred
+// files; this is far above that and far below an asset dump.
+const maxSourceDirEntries = 2000
+
+// maxWatchedSourceFiles is a hard ceiling on the files the source watcher will
+// register across every target, a backstop under the per-directory cap so no
+// combination of trees can drive the watcher into EMFILE (kern.maxfilesperproc
+// is ~92k on macOS). Once reached, further trees are left to the nginx access
+// feed for activity, which is the primary signal anyway.
+const maxWatchedSourceFiles = 32768
+
 // WatchSourceFiles watches each target's source directories recursively and
 // calls onActivity(key), debounced per key, when a source file under them is
 // written, created, or renamed — i.e. when you save while coding. Heavy or
@@ -37,9 +54,13 @@ func WatchSourceFiles(getTargets func() []SourceTarget, debounce time.Duration, 
 	var mu sync.Mutex
 	dirKey := map[string]string{}      // watched directory → activity key
 	timers := map[string]*time.Timer{} // pending debounce timer per key
+	skipped := map[string]bool{}       // oversized dirs already logged as skipped
+	watchedFiles := 0                  // running estimate of fds the watch set holds
 
-	// addTree recursively watches root and its subdirs (skipping excludes),
-	// tagging each watched directory with key.
+	// addTree recursively watches root and its subdirs (skipping excludes and
+	// oversized asset dumps), tagging each watched directory with key. It bounds
+	// the total files watched so a pathological tree can't exhaust the process fd
+	// limit (see maxSourceDirEntries / maxWatchedSourceFiles).
 	addTree := func(root, key string) {
 		_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
 			if err != nil || !d.IsDir() {
@@ -54,12 +75,43 @@ func WatchSourceFiles(getTargets func() []SourceTarget, debounce time.Duration, 
 			if already {
 				return nil
 			}
+			entries, derr := os.ReadDir(p)
+			if derr != nil {
+				return nil
+			}
+			// A directory dense enough to be a generated/vendored asset dump is
+			// not source: skip it (and its subtree) so kqueue's per-file fds don't
+			// pile up. Log once per dir so 30s rescans don't spam.
+			if len(entries) > maxSourceDirEntries {
+				mu.Lock()
+				if !skipped[p] {
+					skipped[p] = true
+					logger.Warn("source watcher: skipping oversized dir (assets, not source)", "path", p, "entries", len(entries))
+				}
+				mu.Unlock()
+				return filepath.SkipDir
+			}
+			files := 0
+			for _, e := range entries {
+				if !e.IsDir() {
+					files++
+				}
+			}
+			mu.Lock()
+			if watchedFiles+files > maxWatchedSourceFiles {
+				mu.Unlock()
+				// Hard fd budget reached: stop adding trees this pass. The nginx
+				// access feed still drives activity for the unwatched remainder.
+				return filepath.SkipAll
+			}
+			mu.Unlock()
 			if err := w.Add(p); err != nil {
 				logger.Error("failed to watch source dir", "path", p, "err", err)
 				return nil
 			}
 			mu.Lock()
 			dirKey[p] = key
+			watchedFiles += files
 			mu.Unlock()
 			return nil
 		})

--- a/internal/watcher/sourcefiles.go
+++ b/internal/watcher/sourcefiles.go
@@ -71,9 +71,15 @@ func WatchSourceFiles(getTargets func() []SourceTarget, debounce time.Duration, 
 			}
 			mu.Lock()
 			_, already := dirKey[p]
+			wasSkipped := skipped[p]
 			mu.Unlock()
 			if already {
 				return nil
+			}
+			// Already known oversized on a prior pass: skip without re-reading its
+			// (potentially 150k-entry) tree, so rescans stay off it entirely.
+			if wasSkipped {
+				return filepath.SkipDir
 			}
 			entries, derr := os.ReadDir(p)
 			if derr != nil {
@@ -84,11 +90,12 @@ func WatchSourceFiles(getTargets func() []SourceTarget, debounce time.Duration, 
 			// pile up. Log once per dir so 30s rescans don't spam.
 			if len(entries) > maxSourceDirEntries {
 				mu.Lock()
-				if !skipped[p] {
-					skipped[p] = true
+				firstTime := !skipped[p]
+				skipped[p] = true
+				mu.Unlock()
+				if firstTime {
 					logger.Warn("source watcher: skipping oversized dir (assets, not source)", "path", p, "entries", len(entries))
 				}
-				mu.Unlock()
 				return filepath.SkipDir
 			}
 			files := 0

--- a/internal/watcher/sourcefiles_test.go
+++ b/internal/watcher/sourcefiles_test.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -58,5 +59,61 @@ func TestWatchSourceFiles_savesFireActivity(t *testing.T) {
 		t.Errorf("node_modules write reported activity (%q); it must be excluded", key)
 	case <-time.After(600 * time.Millisecond):
 		// no activity — correct
+	}
+}
+
+// TestWatchSourceFiles_skipsOversizedDir asserts a directory dense enough to be
+// an asset dump (more than maxSourceDirEntries files, e.g. a checked-in icon
+// set) is not watched, so kqueue's per-file fds can't exhaust the process limit.
+func TestWatchSourceFiles_skipsOversizedDir(t *testing.T) {
+	root := t.TempDir()
+	srcDir := filepath.Join(root, "src")
+	assets := filepath.Join(root, "src", "icons") // dense asset dump under a source root
+	for _, d := range []string{srcDir, assets} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i <= maxSourceDirEntries; i++ { // > maxSourceDirEntries entries
+		if err := os.WriteFile(filepath.Join(assets, "i"+strconv.Itoa(i)+".svg"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	activity := make(chan string, 8)
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		_ = WatchSourceFiles(
+			func() []SourceTarget { return []SourceTarget{{Key: "mysite", Dirs: []string{root}}} },
+			40*time.Millisecond,
+			func(key string) { activity <- key },
+			stop,
+		)
+	}()
+	time.Sleep(300 * time.Millisecond)
+
+	// A write in the oversized dir must not report activity: it was skipped.
+	if err := os.WriteFile(filepath.Join(assets, "new.svg"), []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case key := <-activity:
+		t.Errorf("oversized-dir write reported activity (%q); it must be skipped", key)
+	case <-time.After(600 * time.Millisecond):
+		// no activity, correct
+	}
+
+	// The normal source root is still watched.
+	if err := os.WriteFile(filepath.Join(srcDir, "App.vue"), []byte("z"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case key := <-activity:
+		if key != "mysite" {
+			t.Errorf("activity key = %q, want mysite", key)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("no activity for a normal source-file save (over-broad skip?)")
 	}
 }


### PR DESCRIPTION
Fixes #674.

## Problem

The idle source-file watcher walks each site's source roots (`app`, `resources`, `routes`, ...) and `fsnotify.Add`s every directory. On macOS fsnotify's kqueue backend opens **one fd per file** in each watched directory, so a generated or vendored asset dump checked into a source root (e.g. a Font Awesome icon set with ~150k SVGs under `resources/`) makes the watcher try to hold hundreds of thousands of fds. It hits `kern.maxfilesperproc` (~92k), and every open after that fails `too many open files`, which then breaks unrelated watcher work, e.g. idle-resume can no longer rewrite a vhost or persist `sites.yaml`:

```
[WARN] idle-resume host-proxy vhost <site>: ... <domain>-ssl.conf: too many open files
[WARN] idle-resume persist <site>: ... sites.yaml: too many open files
```

Live: lerd-watcher held ~92k fds (= `kern.maxfilesperproc`), almost all regular files under one site's `resources/` (a ~187k-file tree dominated by a checked-in icon set).

## Fix

Bound the watch set in `WatchSourceFiles` two ways:

- **Per-directory cap**: skip a directory (and its subtree) with more than `maxSourceDirEntries` (2000) direct entries. That is an asset dump, not hand-edited source, so kqueue's per-file fds don't pile up and activity detection loses nothing. Real source dirs hold tens to a few hundred files, far below the cap, so they stay watched.
- **Global backstop**: cap the total files registered across all targets at `maxWatchedSourceFiles` (32768), well under `kern.maxfilesperproc`, so no combination of trees can drive the watcher into EMFILE. The nginx access feed still drives activity for anything left unwatched (it is the primary signal anyway).

Skips are logged once per directory so the 30s rescans do not spam.

This complements the existing name-based excludes (`node_modules`, `vendor`, hidden dirs); those miss an asset dump sitting under a legitimate source root with an arbitrary name.

## Test

`TestWatchSourceFiles_skipsOversizedDir`: a dir with more than `maxSourceDirEntries` files under a source root reports no activity (skipped), while a normal source-file save in the same target still does (the skip is not over-broad). Existing `TestWatchSourceFiles_savesFireActivity` still passes. `go build`, `go vet`, and the full `internal/watcher` suite (64 tests) pass.