### PR TITLE
fix(podman): run postgres native on Apple Silicon via imresamu/postgis rewrite

### DIFF
--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -125,7 +125,7 @@ func ensureImages() {
 			})
 
 		default:
-			label := img
+			label := podman.PlatformImage(img)
 			jobs = append(jobs, BuildJob{
 				Label: "Pulling " + label,
 				Run: func(w io.Writer) error {
@@ -722,7 +722,9 @@ func startRestoredServices() {
 	var pullJobs []BuildJob
 	seen := map[string]bool{}
 	for _, unit := range units {
-		image := quadletImage(unit)
+		// PlatformImage covers a quadlet still on the upstream image from before
+		// the rewrite landed (idempotent once the unit is rewritten on start).
+		image := podman.PlatformImage(quadletImage(unit))
 		if image == "" || seen[image] {
 			continue
 		}

--- a/internal/podman/exec.go
+++ b/internal/podman/exec.go
@@ -106,11 +106,13 @@ func LocalImageDigest(image string) []string {
 	return digests
 }
 
-// pullArgs builds the `podman pull` argv for image, splicing in any
-// host-specific flags (e.g. --platform=linux/amd64 for postgis on Apple
-// Silicon, where the image ships no arm64 manifest). Keeping every pull path
-// on this helper means pull and run never disagree on platform.
+// pullArgs builds the `podman pull` argv for image, first applying the
+// host-specific image rewrite (postgis/postgis -> imresamu/postgis on Apple
+// Silicon) and then splicing in any platform flags (e.g. --platform=linux/amd64
+// for mysql:5.7). Keeping every pull path on this helper means pull and run
+// never disagree on the image or its platform.
 func pullArgs(image string) []string {
+	image = PlatformImage(image)
 	args := append([]string{"pull"}, PlatformPullArgs(image)...)
 	return append(args, image)
 }

--- a/internal/podman/platform.go
+++ b/internal/podman/platform.go
@@ -1,0 +1,27 @@
+package podman
+
+import "strings"
+
+// arm64PostgisImage is the multi-arch (amd64 + arm64) drop-in for the upstream
+// postgis/postgis image, which ships no arm64 manifest. Same tags, same
+// PostgreSQL + PostGIS versions, same on-disk data dir, so swapping to it is
+// transparent. The official postgis README points Apple Silicon users here.
+const arm64PostgisImage = "imresamu/postgis"
+
+// rewriteArm64Image swaps an image that ships no arm64 manifest for a multi-arch
+// drop-in when goarch is arm64, so Apple Silicon runs it natively instead of
+// under Rosetta. Only postgis/postgis -> imresamu/postgis today; the registry
+// prefix and the tag are preserved, and the data dir is unchanged (same
+// PostgreSQL + PostGIS version). Pure (arch is passed in) so the decision is
+// unit-tested off-darwin. Everything else, including mysql:5.7 (legacy, EOL, no
+// arm64 fork adopted), is returned unchanged and keeps its amd64 pin.
+func rewriteArm64Image(image, goarch string) string {
+	if goarch != "arm64" {
+		return image
+	}
+	const upstream = "postgis/postgis"
+	if i := strings.Index(image, upstream); i >= 0 {
+		return image[:i] + arm64PostgisImage + image[i+len(upstream):]
+	}
+	return image
+}

--- a/internal/podman/platform_darwin.go
+++ b/internal/podman/platform_darwin.go
@@ -2,7 +2,20 @@
 
 package podman
 
-import "strings"
+import (
+	"runtime"
+	"strings"
+)
+
+// PlatformImage returns the image to actually pull and run on this host. On
+// Apple Silicon it swaps postgis/postgis (no arm64 manifest) for the multi-arch
+// imresamu/postgis so postgres runs native instead of under Rosetta; every
+// other image is returned unchanged. Applied at the quadlet Image= and every
+// pull path so pull and run never disagree. Intel macs (amd64) keep the upstream
+// image and its linux/amd64 pin, which is native there.
+func PlatformImage(image string) string {
+	return rewriteArm64Image(image, runtime.GOARCH)
+}
 
 // imageLacksArm64 reports whether image is a known upstream tag that ships no
 // arm64 manifest, so Apple Silicon must pull and run it as linux/amd64 under

--- a/internal/podman/platform_linux.go
+++ b/internal/podman/platform_linux.go
@@ -13,3 +13,10 @@ func PlatformPodmanArgs(_, _ string) string {
 func PlatformPullArgs(_ string) []string {
 	return nil
 }
+
+// PlatformImage is a no-op on Linux. linux/amd64 runs postgis natively;
+// linux/arm64 would hit the same gap as Apple Silicon, so add the
+// rewriteArm64Image swap behind a runtime.GOARCH guard then.
+func PlatformImage(image string) string {
+	return image
+}

--- a/internal/podman/platform_test.go
+++ b/internal/podman/platform_test.go
@@ -1,0 +1,27 @@
+package podman
+
+import "testing"
+
+// TestRewriteArm64Image pins the Apple Silicon image swap that fixes #603: only
+// postgis/postgis is rewritten to imresamu/postgis, only on arm64, preserving
+// the registry prefix and tag. Everything else (mysql:5.7, already-imresamu,
+// non-postgis) is left untouched. Pure, so it runs on the Linux CI runner too.
+func TestRewriteArm64Image(t *testing.T) {
+	cases := []struct {
+		name, image, goarch, want string
+	}{
+		{"arm64 postgis with registry", "docker.io/postgis/postgis:16-3.5-alpine", "arm64", "docker.io/imresamu/postgis:16-3.5-alpine"},
+		{"arm64 postgis bare", "postgis/postgis:17-3.6-alpine", "arm64", "imresamu/postgis:17-3.6-alpine"},
+		{"amd64 postgis unchanged", "docker.io/postgis/postgis:16-3.5-alpine", "amd64", "docker.io/postgis/postgis:16-3.5-alpine"},
+		{"arm64 mysql 5.7 unchanged", "docker.io/library/mysql:5.7", "arm64", "docker.io/library/mysql:5.7"},
+		{"arm64 already imresamu unchanged", "docker.io/imresamu/postgis:16-3.5-alpine", "arm64", "docker.io/imresamu/postgis:16-3.5-alpine"},
+		{"arm64 non-postgis unchanged", "docker.io/library/redis:7-alpine", "arm64", "docker.io/library/redis:7-alpine"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rewriteArm64Image(tc.image, tc.goarch); got != tc.want {
+				t.Fatalf("rewriteArm64Image(%q, %q) = %q, want %q", tc.image, tc.goarch, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -68,10 +68,16 @@ func WriteQuadletDiff(name, content string) (changed bool, err error) {
 	content = BindForLAN(content, lanExposed)
 	content = PairIPv6Binds(content)
 	content = StripInstallSection(content, autostartDisabled)
-	// Centralised platform podman-run flags (e.g. --platform=linux/amd64 for
-	// postgis on darwin) so every quadlet writer emits identical units.
+	// Centralised platform image rewrite + podman-run flags so every quadlet
+	// writer emits identical units. On Apple Silicon PlatformImage swaps
+	// postgis/postgis for the multi-arch imresamu/postgis (runs native, no
+	// Rosetta); mysql:5.7 keeps the --platform=linux/amd64 pin.
 	if svc := strings.TrimPrefix(name, "lerd-"); svc != name {
 		if img := CurrentImage(content); img != "" {
+			if rewritten := PlatformImage(img); rewritten != img {
+				content = ApplyImage(content, rewritten)
+				img = rewritten
+			}
 			if arg := PlatformPodmanArgs(svc, img); arg != "" {
 				content = InjectPodmanArgs(content, arg)
 			}


### PR DESCRIPTION
Fixes #603.

## Problem

`postgis/postgis` ships no arm64 manifest for any tag, and the `postgres` preset (default-on, every version) pins it. So every Apple Silicon user runs postgres under Rosetta today. `mysql:5.7` is the other amd64-only image, but it is EOL and legacy pins only (the 8.4/9.7 defaults publish arm64).

Verified on Docker Hub:

```
postgis/postgis   -> amd64 only
imresamu/postgis  -> amd64 + arm64   (same tags, same PG + PostGIS versions)
mysql:5.7         -> amd64 only
mysql:8.4 / 9.7   -> arm64 ok
```

`imresamu/postgis` is a multi-arch drop-in; the official postgis README points ARM users to it.

## Fix (plan B: keep official, rewrite only on arm64)

Rather than change the preset's official image for everyone, rewrite it at the podman boundary. On arm64, `PlatformImage` swaps `postgis/postgis` for `imresamu/postgis`, preserving the registry prefix and tag (so it is the same PostgreSQL + PostGIS version and the data dir is unchanged), so postgres runs native instead of under Rosetta.

- amd64 hosts (Intel macs, Linux) keep the upstream image and its existing `--platform=linux/amd64` pin, which is native there.
- `mysql:5.7` keeps its amd64 pin (no arm64 fork adopted; document migration to 8.4/9.7/mariadb later).
- The rewrite is applied at the quadlet `Image=` line and every pull path, so pull and run never disagree on the image.

The decision lives in a pure `rewriteArm64Image(image, goarch)` helper so it is table-tested off-darwin. Existing arm64 users move off Rosetta on the next service restart, with no config or data migration: same data dir, the container is just recreated on the new image.

## Test

`TestRewriteArm64Image` (pure, runs on the Linux CI runner): postgis is rewritten only on arm64, registry and tag preserved; `mysql:5.7`, an already-`imresamu` image, and non-postgis images are left untouched. `go build`, `go vet`, the podman suite, and the `GOOS=linux -tags nogui` cross-build all pass.

## Notes

- No migration. `imresamu/postgis:{16-3.5,17-3.6,18-3.6}-alpine` (the tags the preset uses) are all multi-arch.
- `PlatformImage` is a no-op on Linux for now; linux/arm64 would hit the same gap and can reuse `rewriteArm64Image` behind a `runtime.GOARCH` guard when lerd ships there.