### PR TITLE
Make the service YAML the single source of truth for custom services

### DIFF
--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -14,6 +14,7 @@ import (
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/serviceops"
+	"github.com/geodro/lerd/internal/services"
 	"github.com/spf13/cobra"
 )
 
@@ -1136,6 +1137,10 @@ func init() {
 	serviceops.OnPublishedPortShift = func(service string, _ int) {
 		refreshHostProxySitesForService(service)
 	}
+	// Route reconcile's "is the unit installed" check through the platform
+	// service manager (launchd plist on macOS, .container quadlet on Linux) so
+	// it matches `lerd start`'s notion of an installed unit.
+	serviceops.UnitInstalledFn = services.Mgr.ContainerUnitInstalled
 }
 
 // StartServiceDependencies and StopServiceAndDependents are thin wrappers so

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -19,6 +19,7 @@ import (
 	"github.com/geodro/lerd/internal/nginx"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/serviceops"
 	"github.com/geodro/lerd/internal/services"
 	"github.com/spf13/cobra"
 )
@@ -523,6 +524,10 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// uninstall/reinstall cycle. Reads .lerd.yaml from each active site.
 	restoreSiteInfrastructure()
 
+	// Reconcile custom services against their YAMLs (issue #678): regenerate a
+	// missing quadlet, drop an orphan quadlet with no YAML. Data dirs untouched.
+	reconcileCustomServices()
+
 	// If the configured default PHP version has never been installed (no plist /
 	// quadlet / container), install it now so coreUnits() can include it.
 	ensureDefaultPHPInstalled()
@@ -797,6 +802,24 @@ func startRestoredServices() {
 func killTray() {
 	exec.Command("pkill", "-f", "lerd tray").Run()
 	exec.Command("pkill", "-f", "lerd-tray").Run()
+}
+
+// reconcileCustomServices heals custom-service drift on start (issue #678).
+// Failures are non-fatal so one bad service can't block the start sequence.
+func reconcileCustomServices() {
+	res, err := serviceops.ReconcileServices(nil)
+	if err != nil {
+		feedback.Warn("reconciling services: %v", err)
+	}
+	for _, name := range res.QuadletsRegenerated {
+		feedback.Warn("regenerated missing unit for %s from its config", name)
+	}
+	for _, name := range res.OrphansRemoved {
+		feedback.Warn("removed orphan service %s (unit with no config; data left intact)", name)
+	}
+	for _, name := range res.RunningOrphansSkipped {
+		feedback.Warn("orphan service %s has no config but its container is running; left as-is (remove with: lerd service remove %s)", name, name)
+	}
 }
 
 // registeredStripeUnits returns unit names for all lerd-stripe-* service files

--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -525,6 +525,15 @@ func RemoveCustomService(name string) error {
 	return nil
 }
 
+// CustomServiceExists reports whether a custom service's definition YAML exists.
+// The YAML is the authoritative install-state signal for a custom service, so
+// ServiceInstalled and the services list resolve from it and can't drift (#678).
+func CustomServiceExists(name string) bool {
+	path := filepath.Join(CustomServicesDir(), name+".yaml")
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 // ListCustomServices returns all custom services defined in the services directory.
 func ListCustomServices() ([]*CustomService, error) {
 	dir := CustomServicesDir()

--- a/internal/config/custom_service_test.go
+++ b/internal/config/custom_service_test.go
@@ -182,3 +182,26 @@ func TestValidateCustomService_allowsClean(t *testing.T) {
 		t.Errorf("clean service rejected: %v", err)
 	}
 }
+
+func TestCustomServiceExists(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if CustomServiceExists("gotenberg") {
+		t.Fatalf("expected gotenberg to not exist on a clean tree")
+	}
+
+	svc := &CustomService{Name: "gotenberg", Image: "docker.io/gotenberg/gotenberg:8"}
+	if err := SaveCustomService(svc); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if !CustomServiceExists("gotenberg") {
+		t.Fatalf("expected gotenberg to exist after SaveCustomService")
+	}
+
+	if err := RemoveCustomService("gotenberg"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if CustomServiceExists("gotenberg") {
+		t.Fatalf("expected gotenberg to not exist after RemoveCustomService")
+	}
+}

--- a/internal/podman/managed_quadlet_test.go
+++ b/internal/podman/managed_quadlet_test.go
@@ -1,0 +1,49 @@
+package podman
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestGenerateCustomQuadlet_StampsManagedMarker(t *testing.T) {
+	out := GenerateCustomQuadlet(&config.CustomService{Name: "gotenberg", Image: "docker.io/gotenberg/gotenberg:8"})
+	if !strings.Contains(out, CustomServiceQuadletMarker) {
+		t.Fatalf("expected managed-service marker in quadlet, got:\n%s", out)
+	}
+}
+
+func TestListManagedServiceNames(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir := config.QuadletDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	write := func(unit, body string) {
+		if err := os.WriteFile(filepath.Join(dir, unit+".container"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", unit, err)
+		}
+	}
+	// Two marked service quadlets, plus an unmarked site container and a
+	// non-.container file that must be ignored.
+	write("lerd-gotenberg", CustomServiceQuadletMarker+"\n[Container]\nImage=x\n")
+	write("lerd-acme-widget", CustomServiceQuadletMarker+"\n[Container]\nImage=y\n")
+	write("lerd-custom-gonitro", "[Container]\nImage=z\n") // site container, no marker
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte(CustomServiceQuadletMarker), 0o644); err != nil {
+		t.Fatalf("write notes: %v", err)
+	}
+
+	got := ListManagedServiceNames()
+	want := map[string]bool{"gotenberg": true, "acme-widget": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want keys %v", got, want)
+	}
+	for _, n := range got {
+		if !want[n] {
+			t.Fatalf("unexpected managed name %q in %v", n, got)
+		}
+	}
+}

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -1,6 +1,7 @@
 package podman
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"os"
@@ -103,6 +104,26 @@ func QuadletInstalled(name string) bool {
 	path := filepath.Join(config.QuadletDir(), name+".container")
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// ListManagedServiceNames returns the service names (lerd- prefix and .container
+// suffix stripped) of every quadlet carrying CustomServiceQuadletMarker. Used by
+// ReconcileServices to find orphans without misclassifying site/worker quadlets.
+func ListManagedServiceNames() []string {
+	entries, err := filepath.Glob(filepath.Join(config.QuadletDir(), "lerd-*.container"))
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, p := range entries {
+		data, err := os.ReadFile(p)
+		if err != nil || !bytes.Contains(data, []byte(CustomServiceQuadletMarker)) {
+			continue
+		}
+		base := strings.TrimSuffix(filepath.Base(p), ".container")
+		names = append(names, strings.TrimPrefix(base, "lerd-"))
+	}
+	return names
 }
 
 // RemoveQuadlet removes a Podman quadlet container unit file. On macOS it

--- a/internal/podman/quadlet_generate.go
+++ b/internal/podman/quadlet_generate.go
@@ -8,10 +8,16 @@ import (
 	"github.com/geodro/lerd/internal/config"
 )
 
+// CustomServiceQuadletMarker tags quadlets generated for lerd-managed services
+// (custom + default presets) so ReconcileServices finds orphans by content, not
+// by name, sparing site/worker quadlets that lack it (issue #678).
+const CustomServiceQuadletMarker = "# lerd-managed-service"
+
 // GenerateCustomQuadlet builds a quadlet .container file for a custom service.
 func GenerateCustomQuadlet(svc *config.CustomService) string {
 	var b strings.Builder
 
+	b.WriteString(CustomServiceQuadletMarker + "\n")
 	b.WriteString("[Unit]\n")
 	desc := svc.Description
 	if desc == "" {

--- a/internal/serviceops/reconcile.go
+++ b/internal/serviceops/reconcile.go
@@ -1,0 +1,106 @@
+package serviceops
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// Seams so tests can drive reconcile without real podman/quadlet work.
+var (
+	ensureQuadletFn          = EnsureCustomServiceQuadlet
+	listManagedServiceNames  = podman.ListManagedServiceNames
+	orphanContainerRunningFn = podman.ContainerRunningQuiet
+)
+
+// ReconcileResult reports what ReconcileServices changed.
+type ReconcileResult struct {
+	QuadletsRegenerated   []string // YAML present, unit was missing and regenerated
+	OrphansRemoved        []string // service quadlet with no YAML, removed
+	RunningOrphansSkipped []string // orphan left in place because its container is up
+}
+
+// ReconcileServices enforces the issue #678 invariant: regenerate a missing
+// unit from its YAML, remove an orphan service quadlet (no YAML; data left).
+// A running orphan is skipped, not destroyed. Per-item errors are collected so
+// one bad service can't block the rest.
+func ReconcileServices(emit func(PhaseEvent)) (ReconcileResult, error) {
+	if emit == nil {
+		emit = func(PhaseEvent) {}
+	}
+	var res ReconcileResult
+	var errs []error
+
+	// Forward: every defined service must have its unit (EnsureCustomServiceQuadlet
+	// also re-syncs the macOS plist).
+	customs, err := config.ListCustomServices()
+	if err != nil {
+		return res, fmt.Errorf("listing custom services: %w", err)
+	}
+	for _, svc := range customs {
+		if UnitInstalledFn("lerd-" + svc.Name) {
+			continue
+		}
+		if err := ensureQuadletFn(svc); err != nil {
+			errs = append(errs, fmt.Errorf("regenerating quadlet for %s: %w", svc.Name, err))
+			continue
+		}
+		res.QuadletsRegenerated = append(res.QuadletsRegenerated, svc.Name)
+	}
+
+	// Backward: a service quadlet with no YAML is an orphan. Candidates are marked
+	// quadlets (any name, covers user-defined services) plus known non-default
+	// preset names (covers legacy orphans written before the marker existed).
+	for _, name := range orphanCandidates() {
+		if config.IsDefaultPreset(name) || config.CustomServiceExists(name) {
+			continue
+		}
+		if !podman.QuadletInstalled("lerd-" + name) {
+			continue
+		}
+		// Don't destroy a workload that's still up; leave it for explicit removal.
+		if orphanContainerRunningFn("lerd-" + name) {
+			res.RunningOrphansSkipped = append(res.RunningOrphansSkipped, name)
+			continue
+		}
+		if err := RemoveService(name, RemoveOptions{}, emit); err != nil {
+			errs = append(errs, fmt.Errorf("removing orphan service %s: %w", name, err))
+			continue
+		}
+		res.OrphansRemoved = append(res.OrphansRemoved, name)
+	}
+	return res, errors.Join(errs...)
+}
+
+// orphanCandidates is the deduped set of service names worth checking for an
+// orphan quadlet: marked quadlets present on disk, plus every non-default preset
+// name (so legacy pre-marker orphans are still reaped). Preset names never
+// collide with site/worker unit names, so this stays safe.
+func orphanCandidates() []string {
+	seen := map[string]bool{}
+	var names []string
+	add := func(n string) {
+		if !seen[n] {
+			seen[n] = true
+			names = append(names, n)
+		}
+	}
+	for _, n := range listManagedServiceNames() {
+		add(n)
+	}
+	presets, err := config.ListPresets()
+	if err == nil {
+		for _, p := range presets {
+			if config.IsDefaultPreset(p.Name) {
+				continue
+			}
+			add(p.Name)
+			for _, v := range p.Versions {
+				add(config.PresetVersionServiceName(p.Name, v))
+			}
+		}
+	}
+	return names
+}

--- a/internal/serviceops/reconcile_test.go
+++ b/internal/serviceops/reconcile_test.go
@@ -1,0 +1,226 @@
+package serviceops
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// reconcileEnv sets up an isolated HOME/XDG tree and a no-op daemon reload so
+// ReconcileServices can write/read quadlets without touching the real host.
+func reconcileEnv(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+	orig := podman.DaemonReloadFn
+	t.Cleanup(func() { podman.DaemonReloadFn = orig })
+	podman.DaemonReloadFn = func() error { return nil }
+}
+
+// writeQuadlet writes a quadlet for name; marked=true tags it as a managed
+// service (what GenerateCustomQuadlet does), marked=false mimics a site/worker
+// quadlet that reconcile must never touch.
+func writeQuadlet(t *testing.T, name string, marked bool) {
+	t.Helper()
+	dir := config.QuadletDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir quadlet dir: %v", err)
+	}
+	body := "[Container]\nImage=docker.io/example/" + name + ":latest\n"
+	if marked {
+		body = podman.CustomServiceQuadletMarker + "\n" + body
+	}
+	if err := os.WriteFile(filepath.Join(dir, "lerd-"+name+".container"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write quadlet %s: %v", name, err)
+	}
+}
+
+// TestReconcileServices_forwardHealsMissingQuadlet: a service whose YAML exists
+// but whose quadlet is missing gets its quadlet regenerated (issue #678).
+func TestReconcileServices_forwardHealsMissingQuadlet(t *testing.T) {
+	reconcileEnv(t)
+
+	if err := config.SaveCustomService(&config.CustomService{Name: "gotenberg", Image: "docker.io/gotenberg/gotenberg:8"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if podman.QuadletInstalled("lerd-gotenberg") {
+		t.Fatalf("precondition: quadlet should not exist yet")
+	}
+
+	res, err := ReconcileServices(nil)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !slices.Contains(res.QuadletsRegenerated, "gotenberg") {
+		t.Fatalf("expected gotenberg in QuadletsRegenerated, got %+v", res)
+	}
+	if !podman.QuadletInstalled("lerd-gotenberg") {
+		t.Fatalf("expected quadlet regenerated from the YAML")
+	}
+}
+
+// TestReconcileServices_removesMarkedOrphans: a marked service quadlet with no
+// backing YAML is an orphan and is removed, whether or not its name is a preset
+// (covers the user-named orphan gap, issue #678 #4).
+func TestReconcileServices_removesMarkedOrphans(t *testing.T) {
+	reconcileEnv(t)
+	rec := stubPodmanRemove(t)
+	rec.currentStatus = "inactive"
+
+	writeQuadlet(t, "gotenberg", true)   // preset-named orphan
+	writeQuadlet(t, "acme-widget", true) // user-named orphan
+
+	res, err := ReconcileServices(nil)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	for _, want := range []string{"gotenberg", "acme-widget"} {
+		if !slices.Contains(res.OrphansRemoved, want) {
+			t.Fatalf("expected %s in OrphansRemoved, got %+v", want, res)
+		}
+		if !slices.Contains(rec.removedQuadlets, "lerd-"+want) {
+			t.Fatalf("expected RemoveService to drop lerd-%s, recorder: %+v", want, rec.removedQuadlets)
+		}
+	}
+}
+
+// TestReconcileServices_removesLegacyUnmarkedPresetOrphan: an orphan written by
+// an older binary has no marker, but a preset-named quadlet with no YAML is
+// still reaped via the preset-name fallback (the existing-drift migration case).
+func TestReconcileServices_removesLegacyUnmarkedPresetOrphan(t *testing.T) {
+	reconcileEnv(t)
+	rec := stubPodmanRemove(t)
+	rec.currentStatus = "inactive"
+
+	writeQuadlet(t, "gotenberg", false) // legacy orphan, no marker
+
+	res, err := ReconcileServices(nil)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !slices.Contains(res.OrphansRemoved, "gotenberg") {
+		t.Fatalf("expected legacy unmarked preset orphan reaped, got %+v", res)
+	}
+}
+
+// TestReconcileServices_sparesDefaultPreset: built-in default presets carry the
+// marker but have no YAML by design, so they must not be treated as orphans.
+func TestReconcileServices_sparesDefaultPreset(t *testing.T) {
+	reconcileEnv(t)
+	rec := stubPodmanRemove(t)
+
+	if !config.IsDefaultPreset("mysql") {
+		t.Fatalf("test premise broken: mysql must be a default preset")
+	}
+	writeQuadlet(t, "mysql", true)
+
+	res, err := ReconcileServices(nil)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if slices.Contains(res.OrphansRemoved, "mysql") || slices.Contains(rec.removedQuadlets, "lerd-mysql") {
+		t.Fatalf("default preset must never be reaped, res=%+v rec=%+v", res, rec.removedQuadlets)
+	}
+}
+
+// TestReconcileServices_sparesUnmarkedQuadlet: a quadlet without the managed
+// marker (e.g. a site container lerd-custom-<site>) must be left untouched.
+func TestReconcileServices_sparesUnmarkedQuadlet(t *testing.T) {
+	reconcileEnv(t)
+	rec := stubPodmanRemove(t)
+
+	writeQuadlet(t, "custom-gonitro", false) // site custom container, unmarked
+
+	res, err := ReconcileServices(nil)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(res.OrphansRemoved) != 0 || len(rec.removedQuadlets) != 0 {
+		t.Fatalf("unmarked quadlet must not be removed, res=%+v rec=%+v", res, rec.removedQuadlets)
+	}
+}
+
+// TestReconcileServices_skipsRunningOrphan: an orphan whose container is still
+// up must be left in place, not force-stopped and destroyed (issue #678 #2).
+func TestReconcileServices_skipsRunningOrphan(t *testing.T) {
+	reconcileEnv(t)
+	rec := stubPodmanRemove(t)
+
+	prev := orphanContainerRunningFn
+	t.Cleanup(func() { orphanContainerRunningFn = prev })
+	orphanContainerRunningFn = func(string) bool { return true }
+
+	writeQuadlet(t, "gotenberg", true)
+
+	res, err := ReconcileServices(nil)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !slices.Contains(res.RunningOrphansSkipped, "gotenberg") {
+		t.Fatalf("expected gotenberg in RunningOrphansSkipped, got %+v", res)
+	}
+	if len(res.OrphansRemoved) != 0 || len(rec.removedQuadlets) != 0 {
+		t.Fatalf("running orphan must not be removed, res=%+v rec=%+v", res, rec.removedQuadlets)
+	}
+}
+
+// TestReconcileServices_continuesPastForwardError: one service that fails to
+// regenerate must not block the other heals or the orphan-cleanup pass (#1).
+func TestReconcileServices_continuesPastForwardError(t *testing.T) {
+	reconcileEnv(t)
+	rec := stubPodmanRemove(t)
+	rec.currentStatus = "inactive"
+
+	for _, n := range []string{"bad", "good"} {
+		if err := config.SaveCustomService(&config.CustomService{Name: n, Image: "docker.io/example/" + n}); err != nil {
+			t.Fatalf("save %s: %v", n, err)
+		}
+	}
+	writeQuadlet(t, "gotenberg", true) // orphan that must still be reaped despite the error
+
+	prev := ensureQuadletFn
+	t.Cleanup(func() { ensureQuadletFn = prev })
+	ensureQuadletFn = func(svc *config.CustomService) error {
+		if svc.Name == "bad" {
+			return errors.New("boom")
+		}
+		return prev(svc)
+	}
+
+	res, err := ReconcileServices(nil)
+	if err == nil || !contains(err.Error(), "bad") {
+		t.Fatalf("expected aggregated error mentioning bad, got: %v", err)
+	}
+	if !slices.Contains(res.QuadletsRegenerated, "good") {
+		t.Fatalf("good service must still be regenerated despite bad failing, got %+v", res)
+	}
+	if !slices.Contains(res.OrphansRemoved, "gotenberg") {
+		t.Fatalf("orphan cleanup must still run despite a forward error, got %+v", res)
+	}
+}
+
+// TestReconcileServices_steadyStateNoop: a fully-installed service (YAML +
+// marked quadlet) triggers neither a regeneration nor a removal.
+func TestReconcileServices_steadyStateNoop(t *testing.T) {
+	reconcileEnv(t)
+
+	if err := config.SaveCustomService(&config.CustomService{Name: "gotenberg", Image: "docker.io/gotenberg/gotenberg:8"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	writeQuadlet(t, "gotenberg", true)
+
+	res, err := ReconcileServices(nil)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(res.QuadletsRegenerated) != 0 || len(res.OrphansRemoved) != 0 {
+		t.Fatalf("steady state must be a no-op, got %+v", res)
+	}
+}

--- a/internal/serviceops/reinstall_preflight_test.go
+++ b/internal/serviceops/reinstall_preflight_test.go
@@ -404,3 +404,52 @@ func TestRealReinstallInstall_CustomServicePath_CallsStreamingWithPresetName(t *
 		t.Errorf("streaming fn version = %q, want %q", captured.version, "10.11")
 	}
 }
+
+// TestResolvePresetForInstall_partialRemnantsAreHealable: a fully-installed
+// service blocks install, but a YAML-only or quadlet-only remnant from a partial
+// install/remove is reinstallable so install can heal it (issue #678 #3).
+func TestResolvePresetForInstall_partialRemnantsAreHealable(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	const name = "gotenberg" // a non-default bundled preset
+	quadlet := filepath.Join(config.QuadletDir(), "lerd-"+name+".container")
+	mkUnit := func() {
+		if err := os.MkdirAll(config.QuadletDir(), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(quadlet, []byte("[Container]\nImage=x\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mkYAML := func() {
+		if err := config.SaveCustomService(&config.CustomService{Name: name, Image: "docker.io/gotenberg/gotenberg:8"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Clean tree: installable.
+	if _, err := resolvePresetForInstall(name, ""); err != nil {
+		t.Fatalf("clean tree must be installable: %v", err)
+	}
+	// YAML-only remnant: installable (heal forward).
+	mkYAML()
+	if _, err := resolvePresetForInstall(name, ""); err != nil {
+		t.Fatalf("YAML-only remnant must be reinstallable: %v", err)
+	}
+	// Quadlet-only orphan: installable (adopt).
+	if err := config.RemoveCustomService(name); err != nil {
+		t.Fatal(err)
+	}
+	mkUnit()
+	if _, err := resolvePresetForInstall(name, ""); err != nil {
+		t.Fatalf("quadlet-only orphan must be reinstallable: %v", err)
+	}
+	// Fully installed (YAML + unit): blocked.
+	mkYAML()
+	if _, err := resolvePresetForInstall(name, ""); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("fully installed service must be blocked, got: %v", err)
+	}
+}

--- a/internal/serviceops/service_installed_test.go
+++ b/internal/serviceops/service_installed_test.go
@@ -8,11 +8,10 @@ import (
 	"github.com/geodro/lerd/internal/config"
 )
 
-// TestServiceInstalled_quadletIsSourceOfTruth covers the orphan-quadlet case
-// that motivated the helper: a service whose YAML config has been deleted but
-// whose .container quadlet still exists must still report as installed,
-// matching the real runtime state podman sees.
-func TestServiceInstalled_quadletIsSourceOfTruth(t *testing.T) {
+// TestServiceInstalled_defaultPresetQuadletIsTruth: built-in default presets
+// have no services/ YAML, so their quadlet stays the install-state signal even
+// with no YAML present.
+func TestServiceInstalled_defaultPresetQuadletIsTruth(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
@@ -37,5 +36,44 @@ func TestServiceInstalled_quadletIsSourceOfTruth(t *testing.T) {
 
 	if _, err := config.LoadCustomService("mysql"); err == nil {
 		t.Fatalf("test precondition broken: YAML should not exist for this scenario")
+	}
+}
+
+// TestServiceInstalled_customServiceYAMLIsTruth covers the orphan-quadlet bug
+// (issue #678): for a custom service the YAML is the truth, so a leftover
+// quadlet with no backing YAML must report NOT installed.
+func TestServiceInstalled_customServiceYAMLIsTruth(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	if config.IsDefaultPreset("gotenberg") {
+		t.Fatalf("test premise broken: gotenberg must be a non-default preset")
+	}
+
+	if ServiceInstalled("gotenberg") {
+		t.Fatalf("expected gotenberg not installed on a clean tree")
+	}
+
+	// Orphan quadlet with no YAML must NOT count as installed.
+	quadletDir := config.QuadletDir()
+	if err := os.MkdirAll(quadletDir, 0o755); err != nil {
+		t.Fatalf("mkdir quadlet dir: %v", err)
+	}
+	quadletPath := filepath.Join(quadletDir, "lerd-gotenberg.container")
+	if err := os.WriteFile(quadletPath, []byte("[Container]\nImage=docker.io/gotenberg/gotenberg:8\n"), 0o644); err != nil {
+		t.Fatalf("write quadlet: %v", err)
+	}
+	if ServiceInstalled("gotenberg") {
+		t.Fatalf("orphan quadlet with no YAML must report NOT installed for a custom service")
+	}
+
+	// With the YAML present it is installed.
+	if err := config.SaveCustomService(&config.CustomService{Name: "gotenberg", Image: "docker.io/gotenberg/gotenberg:8"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if !ServiceInstalled("gotenberg") {
+		t.Fatalf("expected gotenberg installed once its YAML exists")
 	}
 }

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -25,15 +25,20 @@ import (
 // Kept as a passthrough so callers don't have to import config.
 func IsBuiltin(name string) bool { return config.IsDefaultPreset(name) }
 
-// ServiceInstalled is the single source of truth for whether a lerd service
-// is installed on this host. It checks for the quadlet (lerd-<name>.container)
-// because that's what podman actually uses to run the service, and it can
-// outlive the YAML when the on-disk config drifts (older installs, partial
-// removes, etc.). Use this instead of probing config.LoadCustomService when
-// you only care about install presence.
+// ServiceInstalled is the single source of truth for install state (issue #678):
+// the quadlet for built-in default presets (no YAML by design), the services/
+// YAML for custom services so it agrees with the services list, not the quadlet.
 func ServiceInstalled(name string) bool {
-	return podman.QuadletInstalled("lerd-" + name)
+	if config.IsDefaultPreset(name) {
+		return podman.QuadletInstalled("lerd-" + name)
+	}
+	return config.CustomServiceExists(name)
 }
+
+// UnitInstalledFn reports whether the platform container unit is installed.
+// Defaults to the .container check; the CLI overrides it with the platform-aware
+// services.Mgr.ContainerUnitInstalled (launchd plist on macOS) for reconcile.
+var UnitInstalledFn = func(unit string) bool { return podman.QuadletInstalled(unit) }
 
 // PortAvailable reports whether a TCP port is free to bind on both loopback
 // stacks. It is the exported form of the guard's own bindability test (now the
@@ -241,10 +246,10 @@ func resolvePresetForInstall(name, version string) (*config.CustomService, error
 	if IsBuiltin(svc.Name) {
 		return nil, fmt.Errorf("%q collides with the built-in service of the same name", svc.Name)
 	}
-	// Quadlet presence is the install-state truth (see ServiceInstalled); a
-	// yaml-only remnant from a partial install gets silently rewritten by
-	// registerPreset as the heal path.
-	if ServiceInstalled(svc.Name) {
+	// Only a fully-installed service (YAML and unit both present) blocks install.
+	// A partial remnant (YAML-only after an interrupted install, or a quadlet-only
+	// orphan) is healed by letting registerPreset rewrite both here.
+	if config.CustomServiceExists(svc.Name) && UnitInstalledFn("lerd-"+svc.Name) {
 		return nil, fmt.Errorf("custom service %q already exists; remove it first with: lerd service remove %s", svc.Name, svc.Name)
 	}
 	if missing := MissingPresetDependencies(svc); len(missing) > 0 {


### PR DESCRIPTION
## Problem

A custom service's install state was tracked in two places that could drift apart. `serviceops.ServiceInstalled` (and therefore the preset picker's `installed` flag, the install guard, and dependency checks) keyed off the quadlet file, while the services list, `lerd start`/`stop`, update, tuning, env, pause and host-proxy all read the per-service definition YAML. When a quadlet existed with no backing YAML, the preset picker reported the service as installed while it was invisible in every list, never started, and could not be managed. We found four such orphans on a real install (gotenberg, phpmyadmin, stripe-mock, and a misclassified site container). Fixes #678.

## Change

The service definition YAML is now the single source of truth for custom (non-default) services. `ServiceInstalled` resolves install state from the YAML for them, so the preset flag, the install guard and dependency checks agree with the services list. Built-in default presets keep the quadlet as their signal because their definition lives in the binary and they have no YAML.

A reconciliation pass runs on `lerd start` and enforces the invariant in both directions:

- YAML present but unit missing: regenerate the quadlet/plist from the YAML.
- A service quadlet with no backing YAML: remove the orphan quadlet/plist, leaving the data directory intact.

Orphans are identified by a `# lerd-managed-service` marker stamped into managed quadlets, unioned with the known non-default preset names so orphans written before the marker existed are still reaped. Site containers and per-site workers carry neither, so they are never touched. A running orphan is left in place rather than force-stopped and destroyed, and per-service errors are collected so one bad service can't abort the rest of the pass. The install guard now blocks only a fully installed service (YAML and unit both present), so a partial remnant from an interrupted install or remove can be healed by reinstalling.

Closes #678