### PR TITLE
fix(idle): wake suspended workers on web access on macOS

### DIFF
--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -448,6 +448,27 @@ func AccessSocketPath() string {
 	return filepath.Join(RunDir(), "lerd-access.sock")
 }
 
+// AccessFeedUDPPort is the UDP port the watcher binds on darwin for the nginx
+// access feed: nginx runs in the podman-machine VM where the host unix socket
+// isn't reachable, so the feed travels over gvproxy UDP (like DumpsTCPPort).
+const AccessFeedUDPPort = "9914"
+
+// AccessFeedListenAddr is the host address the watcher binds for the darwin UDP
+// access feed. Loopback matches the gvproxy host.containers.internal forward.
+func AccessFeedListenAddr() string {
+	return "127.0.0.1:" + AccessFeedUDPPort
+}
+
+// AccessLogTarget is the nginx syslog `server=` for the access feed: the
+// bind-mounted unix socket on Linux, or host.containers.internal over gvproxy
+// UDP on macOS where nginx lives in the VM and the host socket isn't reachable.
+func AccessLogTarget() string {
+	if runtime.GOOS == "darwin" {
+		return "host.containers.internal:" + AccessFeedUDPPort
+	}
+	return "unix:" + AccessSocketPath()
+}
+
 // ControlSocketPath is the unix datagram socket the lerd-watcher binds for
 // idle-suspend control messages: "enable"/"disable" from the CLI and dashboard
 // toggle, and "activity <site>" from the CLI shims and MCP.

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -29,6 +29,26 @@ func TestUIClientTransport_matchesOS(t *testing.T) {
 	}
 }
 
+// AccessLogTarget must give nginx a syslog server it can reach: macOS ships the
+// feed to host.containers.internal over gvproxy UDP (nginx is in the VM), Linux
+// stays on the bind-mounted unix socket. The watcher's listen addr must pair.
+func TestAccessLogTarget_matchesOS(t *testing.T) {
+	target := AccessLogTarget()
+	if runtime.GOOS == "darwin" {
+		want := "host.containers.internal:" + AccessFeedUDPPort
+		if target != want {
+			t.Errorf("AccessLogTarget() = %q on darwin, want %q", target, want)
+		}
+		if addr := AccessFeedListenAddr(); addr != "127.0.0.1:"+AccessFeedUDPPort {
+			t.Errorf("AccessFeedListenAddr() = %q on darwin, want 127.0.0.1:%s", addr, AccessFeedUDPPort)
+		}
+		return
+	}
+	if want := "unix:" + AccessSocketPath(); target != want {
+		t.Errorf("AccessLogTarget() = %q on %s, want %q", target, runtime.GOOS, want)
+	}
+}
+
 // ── XDG overrides ─────────────────────────────────────────────────────────────
 
 func TestConfigDir_UsesXDGConfigHome(t *testing.T) {

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -46,8 +46,8 @@ func detectSiteProxy(site config.Site) (path string, port int, ok bool) {
 }
 
 type nginxConfData struct {
-	Resolver     string
-	AccessSocket string
+	Resolver        string
+	AccessLogTarget string
 }
 
 // VhostData is the data passed to vhost templates.
@@ -1328,8 +1328,8 @@ func EnsureNginxConfig() error {
 	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, nginxConfData{
-		Resolver:     podman.NetworkGateway("lerd"),
-		AccessSocket: config.AccessSocketPath(),
+		Resolver:        podman.NetworkGateway("lerd"),
+		AccessLogTarget: config.AccessLogTarget(),
 	}); err != nil {
 		return fmt.Errorf("rendering nginx.conf: %w", err)
 	}

--- a/internal/nginx/templates/nginx.conf
+++ b/internal/nginx/templates/nginx.conf
@@ -24,14 +24,11 @@ http {
     # Use Podman network DNS so upstream hostnames are re-resolved dynamically
     resolver {{.Resolver}} valid=5s ipv6=off;
 
-    # Activity feed for idle-suspend. Log only the request host to a unix
-    # datagram socket lerd-ui owns; it maps host -> site -> last-active to
-    # decide when a quiet site's workers can suspend. This is the http-level
-    # default, so every vhost inherits it (none set their own access_log).
-    # If lerd-ui isn't listening yet, nginx drops the datagrams and keeps
-    # serving — losing an activity tick is harmless, the grace window covers it.
+    # Activity feed for idle-suspend: log the request host to the watcher (unix
+    # socket on Linux, host.containers.internal UDP on macOS). It's an http-level
+    # default every vhost inherits; a dropped datagram is harmless (grace covers).
     log_format lerd_access '$host';
-    access_log syslog:server=unix:{{.AccessSocket}},nohostname,tag=lerdaccess lerd_access;
+    access_log syslog:server={{.AccessLogTarget}},nohostname,tag=lerdaccess lerd_access;
 
     # User http-level overrides (gzip, proxy buffers, client_max_body_size…).
     # Lerd never writes here; loaded last so user values win.

--- a/internal/watcher/idle_feed.go
+++ b/internal/watcher/idle_feed.go
@@ -71,13 +71,12 @@ func enableIdle() {
 
 	go idleEng.run(ctx)
 
-	// macOS skips the access feed: lerd-nginx runs in the podman-machine VM where
-	// a host unix socket isn't reachable. Source-file saves are the macOS signal.
-	if runtime.GOOS != "darwin" {
-		if conn, ok := listenDatagram(config.AccessSocketPath()); ok {
-			go func() { <-ctx.Done(); conn.Close() }()
-			go readDatagrams(conn, handleAccessDatagram)
-		}
+	// The nginx access feed turns a plain web request into activity, so browsing
+	// a quiet site wakes it. Best-effort: on a bind failure the source-file
+	// watcher and control-socket pings still feed activity.
+	if conn, ok := accessFeedConn(); ok {
+		go func() { <-ctx.Done(); conn.Close() }()
+		go readDatagrams(conn, handleAccessDatagram)
 	}
 	if idleStartSrc != nil {
 		go func() { _ = idleStartSrc(ctx.Done()) }()
@@ -106,6 +105,26 @@ func handleAccessDatagram(b []byte) {
 			idleEng.OnActivity(site)
 		}
 	}
+}
+
+// accessFeedConn binds the nginx access feed listener per platform: a unix
+// datagram socket on Linux (bind-mounted into the rootless nginx container), or
+// UDP on macOS where nginx is in the VM and the host socket isn't reachable.
+func accessFeedConn() (net.PacketConn, bool) {
+	if runtime.GOOS == "darwin" {
+		return listenUDP(config.AccessFeedListenAddr())
+	}
+	return listenDatagram(config.AccessSocketPath())
+}
+
+// listenUDP binds a UDP socket at addr for the macOS access feed. ok=false on
+// failure, matching listenDatagram so callers skip the feed the same way.
+func listenUDP(addr string) (net.PacketConn, bool) {
+	conn, err := net.ListenPacket("udp", addr)
+	if err != nil {
+		return nil, false
+	}
+	return conn, true
 }
 
 // listenDatagram binds a unix datagram socket at path under RunDir, replacing any

--- a/internal/watcher/idle_feed_test.go
+++ b/internal/watcher/idle_feed_test.go
@@ -58,6 +58,45 @@ func TestReadAccessFeed_recordsTouch(t *testing.T) {
 	t.Fatal("access datagram was not recorded as a site touch within 2s")
 }
 
+// TestReadAccessFeed_overUDP drives the macOS transport: nginx in the VM ships
+// the feed as UDP syslog, so the watcher must read the same "$host" datagrams
+// off a UDP socket. Ephemeral port so it never collides with a live daemon's.
+func TestReadAccessFeed_overUDP(t *testing.T) {
+	prev := activityTracker
+	t.Cleanup(func() { activityTracker = prev })
+	activityTracker = idle.NewTracker(func(h string) (string, bool) {
+		if h == "myapp.test" {
+			return "myapp", true
+		}
+		return "", false
+	})
+
+	conn, ok := listenUDP("127.0.0.1:0")
+	if !ok {
+		t.Fatal("listenUDP failed")
+	}
+	t.Cleanup(func() { conn.Close() })
+	go readDatagrams(conn, handleAccessDatagram)
+
+	sender, err := net.Dial("udp", conn.LocalAddr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer sender.Close()
+	if _, err := sender.Write([]byte("<190>Jun 12 10:00:00 lerdaccess: myapp.test")); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := activityTracker.LastActive("myapp"); ok {
+			return // recorded as expected
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("UDP access datagram was not recorded as a site touch within 2s")
+}
+
 // TestReadAccessFeed_ignoresUnmatched confirms a datagram for an unknown host
 // never creates a phantom record.
 func TestReadAccessFeed_ignoresUnmatched(t *testing.T) {


### PR DESCRIPTION
## Problem

On macOS, idle-suspended background workers (horizon, schedule, vite, stripe) never resumed when their site was accessed in a browser. The site kept serving, but its workers stayed stopped until a source-file edit or a terminal artisan/composer/npm command touched the site.

Idle-suspend resumes a site's workers when activity arrives via the nginx access feed (nginx logs each request host, the watcher reads it and calls `OnActivity`). That feed was bound on Linux only. On macOS nginx runs inside the podman-machine VM, where the host unix socket isn't reachable, so the watcher skipped binding it (`if runtime.GOOS != "darwin"`). With no feed, a browser request produced zero activity and the engine never resumed the workers. The site sat at "idle Nh" with a frozen last-active, and the watcher log showed it suspended repeatedly and never resumed.

## Fix

Deliver the feed over a transport that crosses the VM boundary on macOS. nginx ships each request host as UDP syslog to `host.containers.internal:9914`, and the watcher binds `127.0.0.1:9914` to receive it, the same gvproxy-forwarded path the dump receiver already uses on 9913. From there it reuses the existing `OnActivity` to resume flow. Linux is byte-for-byte unchanged: `AccessLogTarget()` still returns the bind-mounted unix socket and the watcher binds the same unix datagram socket.

## Verification

- `go test ./...` passes, including new `TestAccessLogTarget_matchesOS` and `TestReadAccessFeed_overUDP`.
- Live on macOS: with a site suspended, a single `curl https://pickrightsports.test/` produced `[idle] resumed pickrightsports: [horizon schedule vite stripe]` within 3s. Before the change the watcher log only ever recorded suspends, never a resume.

Fixes #680