### PR TITLE
feat(doctor): add a per-site app-health mode to the doctor command

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -23,16 +23,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewDoctorCmd returns the doctor command.
+// NewDoctorCmd returns the doctor command. With no argument it diagnoses the
+// lerd environment; given a site name it reports that site's app-level health.
 func NewDoctorCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "doctor",
-		Short: "Diagnose your Lerd environment and report issues",
+		Use:   "doctor [site]",
+		Short: "Diagnose your Lerd environment, or a single site's app health",
+		Args:  cobra.MaximumNArgs(1),
 		RunE:  runDoctor,
 	}
 }
 
-func runDoctor(_ *cobra.Command, _ []string) error {
+func runDoctor(_ *cobra.Command, args []string) error {
+	if len(args) == 1 {
+		return RunSiteDoctorTo(os.Stdout, feedback.Animated(), args[0])
+	}
 	_, _, err := RunDoctorTo(os.Stdout, feedback.Animated())
 	return err
 }

--- a/internal/cli/doctor_site.go
+++ b/internal/cli/doctor_site.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
+	"github.com/geodro/lerd/internal/sitedoctor"
+)
+
+// RunSiteDoctorTo resolves the named site and renders its app-level health to w,
+// the same checks the dashboard's Laravel Doctor shows but on the command line
+// (and so reachable to automation, which the web/TUI panels are not).
+func RunSiteDoctorTo(w io.Writer, useColor bool, name string) error {
+	reg, err := config.LoadSites()
+	if err != nil {
+		return err
+	}
+	site, err := findSite(reg.Sites, name)
+	if err != nil {
+		return err
+	}
+	resp := sitedoctor.Run(context.Background(), site.Path)
+	renderSiteDoctor(w, useColor, site, resp)
+	return nil
+}
+
+// findSite looks a site up by its registered name, returning a helpful error
+// that lists the known names when there is no match.
+func findSite(sites []config.Site, name string) (config.Site, error) {
+	known := make([]string, 0, len(sites))
+	for _, s := range sites {
+		if s.Name == name {
+			return s, nil
+		}
+		known = append(known, s.Name)
+	}
+	sort.Strings(known)
+	return config.Site{}, fmt.Errorf("no linked site named %q; known sites: %s", name, strings.Join(known, ", "))
+}
+
+func renderSiteDoctor(w io.Writer, useColor bool, site config.Site, resp sitedoctor.Response) {
+	header := site.Name
+	if len(site.Domains) > 0 {
+		header = fmt.Sprintf("%s (%s)", site.Name, site.Domains[0])
+	}
+	fmt.Fprintf(w, "Site Doctor: %s\n", header)
+	fmt.Fprintln(w, "══════════════════════════════════════════════")
+	fmt.Fprintf(w, "  %-12s %s\n\n", "path", site.Path)
+
+	if len(resp.Checks) == 0 {
+		fmt.Fprintln(w, "  No app-level checks apply to this site (not a Laravel project, or nothing to flag).")
+		return
+	}
+
+	for _, c := range resp.Checks {
+		switch c.Status {
+		case sitedoctor.StatusOK:
+			fmt.Fprintf(w, "  %s %s\n", feedback.GreenIf(useColor, feedback.GlyphOK), c.Name)
+		case sitedoctor.StatusWarn:
+			fmt.Fprintf(w, "  %s %s  %s\n", feedback.AmberIf(useColor, feedback.GlyphWarn), c.Name, c.Detail)
+		case sitedoctor.StatusFail:
+			fmt.Fprintf(w, "  %s %s  %s\n", feedback.RedIf(useColor, feedback.GlyphFail), c.Name, c.Detail)
+			if c.Fix != "" {
+				fmt.Fprintf(w, "    hint: fix command \"%s\"\n", c.Fix)
+			}
+		default:
+			fmt.Fprintf(w, "  - %s  %s\n", c.Name, c.Detail)
+		}
+	}
+
+	fmt.Fprintln(w, "\n══════════════════════════════════════════════")
+	switch {
+	case resp.Failures > 0 && resp.Warnings > 0:
+		fmt.Fprintln(w, feedback.RedIf(useColor, fmt.Sprintf("%d failure(s), %d warning(s) found.", resp.Failures, resp.Warnings)))
+	case resp.Failures > 0:
+		fmt.Fprintln(w, feedback.RedIf(useColor, fmt.Sprintf("%d failure(s) found.", resp.Failures)))
+	case resp.Warnings > 0:
+		fmt.Fprintf(w, "%s  No failures.\n", feedback.AmberIf(useColor, fmt.Sprintf("%d warning(s) found.", resp.Warnings)))
+	default:
+		fmt.Fprintln(w, feedback.GreenIf(useColor, "All app checks passed."))
+	}
+}

--- a/internal/cli/doctor_site_test.go
+++ b/internal/cli/doctor_site_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/sitedoctor"
+)
+
+func TestFindSite_ByName(t *testing.T) {
+	sites := []config.Site{{Name: "alpha"}, {Name: "beta", Path: "/p/beta"}}
+	got, err := findSite(sites, "beta")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Path != "/p/beta" {
+		t.Errorf("findSite returned the wrong site: %+v", got)
+	}
+}
+
+func TestFindSite_NotFoundListsKnown(t *testing.T) {
+	sites := []config.Site{{Name: "alpha"}, {Name: "beta"}}
+	_, err := findSite(sites, "missing")
+	if err == nil {
+		t.Fatal("expected an error for an unknown site")
+	}
+	for _, want := range []string{"missing", "alpha", "beta"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err.Error(), want)
+		}
+	}
+}
+
+func TestRenderSiteDoctor_ShowsChecksAndSummary(t *testing.T) {
+	site := config.Site{Name: "shop", Domains: []string{"shop.test"}, Path: "/www/shop"}
+	resp := sitedoctor.Response{
+		Checks: []sitedoctor.Check{
+			{Name: "app_key", Status: sitedoctor.StatusOK},
+			{Name: "env_drift", Status: sitedoctor.StatusWarn, Detail: "FOO missing"},
+			{Name: "migrations", Status: sitedoctor.StatusFail, Detail: "2 pending", Fix: "migrate"},
+		},
+		Failures: 1,
+		Warnings: 1,
+	}
+	var buf bytes.Buffer
+	renderSiteDoctor(&buf, false, site, resp)
+	out := buf.String()
+
+	for _, want := range []string{
+		"shop (shop.test)", "/www/shop",
+		"app_key", "env_drift", "FOO missing",
+		"migrations", "2 pending", "migrate",
+		"1 failure(s), 1 warning(s) found.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderSiteDoctor_AllPassed(t *testing.T) {
+	site := config.Site{Name: "shop", Path: "/www/shop"}
+	resp := sitedoctor.Response{Checks: []sitedoctor.Check{{Name: "app_key", Status: sitedoctor.StatusOK}}}
+	var buf bytes.Buffer
+	renderSiteDoctor(&buf, false, site, resp)
+	if !strings.Contains(buf.String(), "All app checks passed.") {
+		t.Errorf("expected an all-passed summary, got:\n%s", buf.String())
+	}
+}
+
+func TestRenderSiteDoctor_NoApplicableChecks(t *testing.T) {
+	site := config.Site{Name: "static", Path: "/www/static"}
+	var buf bytes.Buffer
+	renderSiteDoctor(&buf, false, site, sitedoctor.Response{})
+	if !strings.Contains(buf.String(), "No app-level checks apply") {
+		t.Errorf("expected the no-checks note, got:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
## Why

The site doctor (app_key, env drift, app debug, storage link, pending migrations) already exists in `internal/sitedoctor` and is surfaced by the dashboard's Laravel Doctor panel and the TUI. But there is no CLI entry point, so terminal users and automation (scripts, AI agents) cannot run it. `lerd doctor` today only diagnoses the environment.

## What

Give `lerd doctor` an optional site argument:

- `lerd doctor` -> environment diagnostics, exactly as before.
- `lerd doctor <site>` -> resolves the site and renders `sitedoctor.Run` for it, in the same ok/warn/fail glyph + summary style as the environment doctor.

```
$ lerd doctor <site>
Site Doctor: <site> (<site>.test)
══════════════════════════════════════════════
  path         /path/to/<site>

  ✓ app_key
  ✓ env_drift
  ✓ app_debug
  ✓ storage_link
  ✓ migrations

══════════════════════════════════════════════
All app checks passed.
```

An unknown name errors with the list of known sites.

## Notes

- Reuses the existing `sitedoctor` package unchanged; no new mutation paths, no change to the web/TUI callers.
- Lookup (`findSite`) and rendering (`renderSiteDoctor`) are unit-tested; `go test ./internal/cli/` is green (998 pass). Verified live against a Laravel project (the migrations check runs in the FPM container) and that the no-arg environment doctor is untouched.
- Natural follow-up: fold infra checks (FPM up, TLS reachable, queue/horizon/reverb running) into `sitedoctor` so the dashboard, TUI and CLI all gain them at once. Left out here to keep this focused on closing the CLI gap.