### PR TITLE
fix: correctness issues found reviewing the v1.26 changes

### DIFF
--- a/internal/cli/hostproxy.go
+++ b/internal/cli/hostproxy.go
@@ -305,42 +305,12 @@ func reservedHostPorts(exceptSite string) map[int]bool {
 // lerdServiceHostPorts returns every host port a lerd service may publish:
 // installed/default services (with their resolved ports), all bundled presets
 // (including optional ones like gotenberg that aren't in the default set), and
-// installed custom services. Used so a host-proxy dev server is never assigned a
-// port a service will reclaim.
+// installed custom services. It delegates to config.ReservedHostPorts, the single
+// shared definition the serviceops port-ownership guard consumes too, so a
+// host-proxy dev server is never assigned a port a service will reclaim and the
+// two reserved sets can't drift.
 func lerdServiceHostPorts() map[int]bool {
-	out := map[int]bool{}
-	add := func(mappings []string) {
-		for _, m := range mappings {
-			if host, _, ok := splitHostContainerPort(m); ok {
-				if n, _ := strconv.Atoi(host); n > 0 {
-					out[n] = true
-				}
-			}
-		}
-	}
-	if cfg, err := config.LoadGlobal(); err == nil {
-		// config.ServiceConfig.HostPorts is the shared source of the host ports a
-		// service entry claims (Port, the PublishedPort override, and ExtraPorts),
-		// so this allocator and the serviceops guard can't drift on it.
-		for _, svc := range cfg.Services {
-			for _, p := range svc.HostPorts() {
-				out[p] = true
-			}
-		}
-	}
-	if presets, err := config.ListPresets(); err == nil {
-		for _, p := range presets {
-			if pr, err := config.LoadPreset(p.Name); err == nil {
-				add(pr.Ports)
-			}
-		}
-	}
-	if customs, err := config.ListCustomServices(); err == nil {
-		for _, svc := range customs {
-			add(svc.Ports)
-		}
-	}
-	return out
+	return config.ReservedHostPorts()
 }
 
 // allocateHostPort picks a free host port for a dev server, starting from the

--- a/internal/cli/idle_engine.go
+++ b/internal/cli/idle_engine.go
@@ -180,17 +180,32 @@ func restoreHostProxyVhostAfterIdle(site *config.Site, workers []string) {
 	if !hostProxyVhostSwapApplies(site.IsHostProxy(), workers) {
 		return
 	}
-	// Poll the dev-server port, bounded to 60s. Vite/Nuxt can take many seconds
-	// to bind after launch; with no fixed proxy port we skip the wait and restore
-	// immediately (the worst case is a brief 502 flash on warmup).
-	if proxy := parentProxyConfig(*site); proxy != nil && proxy.Port > 0 {
-		waitForHostPort(proxy.Port, 60*time.Second)
+	// Poll the dev-server port, bounded to 60s. Vite/Nuxt can take many seconds to
+	// bind after launch. Wait on the site's registered proxied port — always set
+	// for a host-proxy site — rather than only the committed proxy block's port,
+	// which is unset for an auto-allocated dev server and used to skip the wait and
+	// flash a bare 502 on warmup.
+	if port := hostProxyResumeWaitPort(site); port > 0 {
+		waitForHostPort(port, 60*time.Second)
 	}
 	if err := siteops.RegenerateSiteVhost(site, site.PrimaryDomain()); err != nil {
 		fmt.Printf("[WARN] idle-resume host-proxy vhost %s: %v\n", site.Name, err)
 		return
 	}
 	nginx.ReloadOrWarn("")
+}
+
+// hostProxyResumeWaitPort returns the host port idle-resume waits on before
+// restoring a host-proxy site's proxy vhost: the committed proxy block's port when
+// it carries one, else the site's registered proxied port (HostPort, always >0 for
+// a host-proxy site). The fallback is what stops an auto-allocated dev server —
+// whose committed proxy block has no fixed port — from skipping the wait and
+// flashing a bare 502 during warmup.
+func hostProxyResumeWaitPort(site *config.Site) int {
+	if proxy := parentProxyConfig(*site); proxy != nil && proxy.Port > 0 {
+		return proxy.Port
+	}
+	return site.HostPort
 }
 
 // waitForHostPort blocks until a TCP connection to the host port succeeds or the

--- a/internal/cli/idle_hostproxy_test.go
+++ b/internal/cli/idle_hostproxy_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 // TestWakingPageHTML_autoRefreshes guards the wake mechanism: the page a sleeping
@@ -12,6 +14,30 @@ import (
 func TestWakingPageHTML_autoRefreshes(t *testing.T) {
 	if !strings.Contains(wakingPageHTML, `http-equiv="refresh"`) {
 		t.Error("waking page must carry a meta refresh so a resumed site reloads on its own")
+	}
+}
+
+// TestHostProxyResumeWaitPort pins finding #8: idle-resume must wait for the dev
+// server to rebind before restoring the proxy vhost, on a non-zero port, so it
+// never skips the wait and flashes a bare 502. The committed proxy block's port is
+// preferred, but when it carries none (an auto-allocated dev server) the wait falls
+// back to the site's registered HostPort instead of 0.
+func TestHostProxyResumeWaitPort(t *testing.T) {
+	dir := t.TempDir()
+	site := &config.Site{Name: "node-app", Domains: []string{"node-app.test"}, Path: dir, HostPort: 3000, HostCommand: "npm run dev"}
+
+	if got := hostProxyResumeWaitPort(site); got != 3000 {
+		t.Fatalf("with no committed proxy block, wait port = %d, want 3000 (HostPort)", got)
+	}
+
+	// Committed proxy block omits the port (auto-allocated dev server).
+	if err := config.SaveProjectConfig(dir, &config.ProjectConfig{
+		Proxy: &config.ProxyConfig{Command: "npm run dev"}, // Port left 0
+	}); err != nil {
+		t.Fatalf("SaveProjectConfig: %v", err)
+	}
+	if got := hostProxyResumeWaitPort(site); got != 3000 {
+		t.Fatalf("with a port-less committed proxy block, wait port = %d, want 3000 (HostPort fallback, never 0)", got)
 	}
 }
 

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -786,6 +786,23 @@ func mergeBuiltinTinker(fw *Framework) *Framework {
 	return fw
 }
 
+// mergeBuiltinDoctor backfills the framework's site-doctor checks from a built-in
+// when a store yaml predates the doctor block (or its on-disk cache does), so a
+// Laravel/Symfony site never silently loses its prod-debug, storage-symlink, and
+// pending-migration checks. Same shape as mergeBuiltinFrankenPHP.
+func mergeBuiltinDoctor(fw *Framework) *Framework {
+	if fw == nil || fw.Doctor != nil {
+		return fw
+	}
+	src := builtinFramework(fw.Name)
+	if src == nil || src.Doctor == nil {
+		return fw
+	}
+	cp := *src.Doctor
+	fw.Doctor = &cp
+	return fw
+}
+
 // mergeUserOverlay checks for a user-defined overlay file in FrameworksDir()
 // and merges its workers and setup commands on top of base.
 // User additions/overrides win. If no overlay exists, base is returned as-is.
@@ -902,6 +919,7 @@ func GetFrameworkForDir(name, projectDir string) (*Framework, bool) {
 		base = mergeUserOverlay(base)
 		base = mergeBuiltinFrankenPHP(base)
 		base = mergeBuiltinTinker(base)
+		base = mergeBuiltinDoctor(base)
 		return mergeProjectWorkers(base, projectDir), true
 	}
 

--- a/internal/config/framework_doctor_test.go
+++ b/internal/config/framework_doctor_test.go
@@ -54,3 +54,25 @@ doctor:
 		t.Errorf("command not parsed: %+v", cmd)
 	}
 }
+
+// TestMergeBuiltinDoctor pins finding #1: a Laravel/Symfony definition whose store
+// yaml predates the doctor block (or whose on-disk cache does) must inherit the
+// builtin checks, so the prod-debug, storage-symlink, and pending-migration checks
+// aren't silently dropped, while an existing doctor section is left untouched and a
+// framework with no builtin stays doctor-less.
+func TestMergeBuiltinDoctor(t *testing.T) {
+	missing := mergeBuiltinDoctor(&Framework{Name: "laravel"})
+	if missing.Doctor == nil || len(missing.Doctor.Checks) == 0 {
+		t.Fatal("a Laravel definition with no doctor section must inherit the builtin checks")
+	}
+
+	own := &FrameworkDoctor{Checks: []DoctorCheck{{Name: "only_mine"}}}
+	kept := mergeBuiltinDoctor(&Framework{Name: "laravel", Doctor: own})
+	if kept.Doctor != own {
+		t.Error("an existing doctor section must be left untouched")
+	}
+
+	if got := mergeBuiltinDoctor(&Framework{Name: "cakephp"}); got.Doctor != nil {
+		t.Error("a framework with no builtin must stay doctor-less, not gain checks")
+	}
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -321,18 +321,22 @@ func defaultConfig() *GlobalConfig {
 	return cfg
 }
 
-// HostPorts returns every host port this service entry claims: its preset-default
-// Port, its PublishedPort override, and the host side of each ExtraPorts mapping.
-// Single source for the serviceops port-ownership guard and the host-proxy dev
-// server allocator, which previously parsed these out separately and drifted (the
-// guard even mis-read the host side of an "ip:host:container" extra mapping).
+// HostPorts returns every host port this service entry actually binds: its
+// effective primary (the PublishedPort override when set, else the preset-default
+// Port) plus the host side of each ExtraPorts mapping. Single source for the
+// serviceops port-ownership guard and the host-proxy dev server allocator, which
+// previously parsed these out separately and drifted (the guard even mis-read the
+// host side of an "ip:host:container" extra mapping). The default Port is NOT
+// reported once an override moves the service off it: the quadlet publishes only
+// the override, so the freed default must be reassignable to another service.
 func (s ServiceConfig) HostPorts() []int {
 	var ports []int
-	if s.Port > 0 {
-		ports = append(ports, s.Port)
-	}
+	primary := s.Port
 	if s.PublishedPort > 0 {
-		ports = append(ports, s.PublishedPort)
+		primary = s.PublishedPort
+	}
+	if primary > 0 {
+		ports = append(ports, primary)
 	}
 	for _, ep := range s.ExtraPorts {
 		if n := mappingHostPort(ep); n > 0 {
@@ -354,6 +358,46 @@ func mappingHostPort(mapping string) int {
 	host = strings.SplitN(host, "/", 2)[0]
 	n, _ := strconv.Atoi(strings.TrimSpace(host))
 	return n
+}
+
+// ReservedHostPorts returns every host port a lerd service may bind: each
+// configured service entry's effective ports (HostPorts), every bundled preset's
+// default ports (including optional presets not in the default set), and every
+// installed custom service's ports. It is the single shared definition consumed
+// by both the serviceops port-ownership guard and the host-proxy dev-server
+// allocator so the two can never drift — the divergence that previously let the
+// guard shift a built-in onto a stopped custom service's port and collide at boot,
+// since the guard read only cfg.Services while the allocator also covered presets
+// and customs.
+func ReservedHostPorts() map[int]bool {
+	reserved := map[int]bool{}
+	addMappings := func(mappings []string) {
+		for _, m := range mappings {
+			if n := mappingHostPort(m); n > 0 {
+				reserved[n] = true
+			}
+		}
+	}
+	if cfg, err := LoadGlobal(); err == nil && cfg != nil {
+		for _, svc := range cfg.Services {
+			for _, p := range svc.HostPorts() {
+				reserved[p] = true
+			}
+		}
+	}
+	if presets, err := ListPresets(); err == nil {
+		for _, meta := range presets {
+			if p, err := LoadPreset(meta.Name); err == nil {
+				addMappings(p.Ports)
+			}
+		}
+	}
+	if customs, err := ListCustomServices(); err == nil {
+		for _, svc := range customs {
+			addMappings(svc.Ports)
+		}
+	}
+	return reserved
 }
 
 // firstHostPort returns the host-side port number from the first ports entry,

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -631,9 +631,10 @@ func TestDNSManaged(t *testing.T) {
 }
 
 // TestServiceConfig_HostPorts is the single source both the serviceops port guard
-// and the host-proxy allocator consume, so it must capture Port, the PublishedPort
-// override, and every ExtraPorts mapping form — including "ip:host:container",
-// whose host side the old guard parser dropped.
+// and the host-proxy allocator consume, so it must capture the effective primary
+// (the PublishedPort override when set, else the preset-default Port) and every
+// ExtraPorts mapping form — including "ip:host:container", whose host side the old
+// guard parser dropped.
 func TestServiceConfig_HostPorts(t *testing.T) {
 	svc := ServiceConfig{
 		Port:          3306,
@@ -644,13 +645,29 @@ func TestServiceConfig_HostPorts(t *testing.T) {
 	for _, p := range svc.HostPorts() {
 		got[p] = true
 	}
-	for _, want := range []int{3306, 3307, 8082, 9090, 7000, 6379} {
+	for _, want := range []int{3307, 8082, 9090, 7000, 6379} {
 		if !got[want] {
 			t.Errorf("HostPorts missing %d; got %v", want, got)
 		}
 	}
+	// Once an override moves the service off its default, the quadlet publishes
+	// only the override, so the freed default must NOT stay reserved — otherwise
+	// it can never be reassigned to another service.
+	if got[3306] {
+		t.Errorf("HostPorts still reserved the freed default 3306 after an override: %v", got)
+	}
 	// The container-side ports must never be reserved as host ports.
 	if got[8081] {
 		t.Errorf("HostPorts wrongly reserved container-side port 8081: %v", got)
+	}
+}
+
+// TestServiceConfig_HostPorts_defaultWhenNoOverride reports the preset-default
+// Port when no PublishedPort override is set.
+func TestServiceConfig_HostPorts_defaultWhenNoOverride(t *testing.T) {
+	svc := ServiceConfig{Port: 5432}
+	got := svc.HostPorts()
+	if len(got) != 1 || got[0] != 5432 {
+		t.Errorf("HostPorts = %v, want [5432]", got)
 	}
 }

--- a/internal/serviceops/port_guard_test.go
+++ b/internal/serviceops/port_guard_test.go
@@ -36,6 +36,26 @@ func TestLerdReservedPorts_includesPresetPort(t *testing.T) {
 	}
 }
 
+// TestLerdReservedPorts_includesInstalledCustomService pins finding #6: an
+// installed custom service's ports live in its own YAML, never in cfg.Services.
+// The guard previously read only cfg.Services and so was blind to them, free to
+// shift a built-in onto a stopped custom service's port and collide at boot. With
+// the unified config.ReservedHostPorts the guard now sees them.
+func TestLerdReservedPorts_includesInstalledCustomService(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	svc := &config.CustomService{Name: "my-thing", Image: "example/my-thing:1", Ports: []string{"34567:80"}}
+	if err := config.SaveCustomService(svc); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+
+	if !lerdReservedPorts()[34567] {
+		t.Errorf("the guard must reserve an installed custom service's host port 34567; got %v", lerdReservedPorts())
+	}
+}
+
 func TestPersistPublishedPort_persists(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/internal/serviceops/ports.go
+++ b/internal/serviceops/ports.go
@@ -32,6 +32,17 @@ type PortChange struct {
 	NoOp      bool // the requested port already matched the current override
 }
 
+// podman/quadlet seams for SetPublishedPort, swapped in tests so the
+// stop/rewrite/start sequence — and its rollback when the start fails — can be
+// exercised without a live container runtime.
+var (
+	portsUnitStatus = podman.UnitStatus
+	portsStopUnit   = podman.StopUnit
+	portsStartUnit  = podman.StartUnit
+	portsWaitReady  = podman.WaitReady
+	portsRerender   = rerenderServiceQuadlet
+)
+
 // SetPublishedPort moves a service's published host port (port > 0) or resets it
 // to the preset default (port == 0), persisting the override and re-rendering and
 // restarting the unit as needed. It is the single entry point shared by the CLI
@@ -58,6 +69,15 @@ func SetPublishedPort(name string, port int) (PortChange, error) {
 		return res, err
 	}
 	svcCfg := cfg.Services[name]
+	prevPublished := svcCfg.PublishedPort
+	// Requesting the preset default is the same as resetting to it: normalise to 0
+	// so we don't store a redundant override and, crucially, skip the bind probe
+	// below — a running service holds its own default port, so probing it would
+	// otherwise reject `lerd service port mysql 3306` while mysql legitimately owns
+	// 3306 (the Web UI already converts the default to null client-side).
+	if port > 0 && port == svcCfg.Port {
+		port = 0
+	}
 	if port == svcCfg.PublishedPort {
 		res.NoOp = true
 		res.Actual = svcCfg.PublishedPort
@@ -97,17 +117,17 @@ func SetPublishedPort(name string, port int) (PortChange, error) {
 	}
 	res.Installed = true
 	unit := "lerd-" + name
-	status, _ := podman.UnitStatus(unit)
+	status, _ := portsUnitStatus(unit)
 	res.WasActive = status == "active" || status == "activating"
 	// Stop a running unit before the write: its own live listener would look
 	// like a foreign owner to the guard and suppress a needed shift, leaving it
 	// unable to bind on restart. Stopped, the write/guard/start see the true state.
 	if res.WasActive {
-		if err := podman.StopUnit(unit); err != nil {
+		if err := portsStopUnit(unit); err != nil {
 			return res, fmt.Errorf("stopping %s: %w", unit, err)
 		}
 	}
-	if err := rerenderServiceQuadlet(name); err != nil {
+	if err := portsRerender(name); err != nil {
 		return res, err
 	}
 	// The guard inside the write may have overridden the request, so report the
@@ -119,10 +139,22 @@ func SetPublishedPort(name string, port int) (PortChange, error) {
 		}
 	}
 	if res.WasActive {
-		if err := podman.StartUnit(unit); err != nil {
-			return res, fmt.Errorf("starting %s: %w", unit, err)
+		if startErr := portsStartUnit(unit); startErr != nil {
+			// The new port wouldn't bind (a TOCTOU grab between the pre-flight and the
+			// start, or the guard landing on a host-owned port). Don't leave the
+			// service down with the config already moved: restore the previous
+			// published port, re-render, and bring it back up on the port it had.
+			res.Actual = prevPublished
+			restored := persistPublishedPort(name, prevPublished) == nil &&
+				portsRerender(name) == nil &&
+				portsStartUnit(unit) == nil
+			if restored {
+				_ = portsWaitReady(name, 30*time.Second)
+				return res, fmt.Errorf("could not start %s on port %d, restored the previous port %d: %w", unit, port, prevPublished, startErr)
+			}
+			return res, fmt.Errorf("could not start %s and could not restore the previous port, run `lerd start`: %w", unit, startErr)
 		}
-		_ = podman.WaitReady(name, 30*time.Second)
+		_ = portsWaitReady(name, 30*time.Second)
 	}
 	// Host-proxy sites reach the service over the published loopback port, so
 	// refresh their .env to follow the change (no-op when none use it).

--- a/internal/serviceops/ports_test.go
+++ b/internal/serviceops/ports_test.go
@@ -3,6 +3,7 @@ package serviceops
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
 )
@@ -191,6 +192,84 @@ func TestSetExtraPortsRejectsSiblingPort(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", tmp)
 	if err := SetExtraPorts("mysql", []string{"5432:5432"}); !errors.Is(err, ErrPortReserved) {
 		t.Fatalf("SetExtraPorts onto postgres's port err = %v, want ErrPortReserved", err)
+	}
+}
+
+// TestSetPublishedPortDefaultResetsNotCollides pins finding #4: asking for the
+// preset default normalises to a reset (override 0) instead of erroring as
+// "port already in use" — a running service holds its own default port, so the
+// old bind probe rejected `lerd service port mysql 3306` while mysql owned 3306.
+func TestSetPublishedPortDefaultResetsNotCollides(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if _, err := SetPublishedPort("mysql", 33071); err != nil {
+		t.Fatalf("move off default: %v", err)
+	}
+	res, err := SetPublishedPort("mysql", 3306) // mysql's preset default
+	if err != nil {
+		t.Fatalf("requesting the preset default must not error, got %v", err)
+	}
+	if got := config.ServicePublishedPort("mysql"); got != 0 {
+		t.Errorf("requesting the default must reset the override to 0, got %d", got)
+	}
+	_ = res
+}
+
+// TestSetPublishedPortDefaultNoOpWhenAlreadyDefault: a service already on its
+// default reports NoOp when asked for that same default port, never an error.
+func TestSetPublishedPortDefaultNoOpWhenAlreadyDefault(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	res, err := SetPublishedPort("mysql", 3306)
+	if err != nil {
+		t.Fatalf("requesting the default on a default service must not error, got %v", err)
+	}
+	if !res.NoOp {
+		t.Error("requesting the current default must be a NoOp")
+	}
+}
+
+// TestSetPublishedPortRollsBackOnStartFailure pins finding #3: when the restart
+// on the new port fails, the service is brought back up on its previous port and
+// the config is rolled back, instead of left down with the override already moved.
+func TestSetPublishedPortRollsBackOnStartFailure(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	fakeQuadletOnDisk(t, "mysql") // ServiceInstalled -> true
+
+	prevStatus, prevStop, prevStart := portsUnitStatus, portsStopUnit, portsStartUnit
+	prevWait, prevRerender := portsWaitReady, portsRerender
+	t.Cleanup(func() {
+		portsUnitStatus, portsStopUnit, portsStartUnit = prevStatus, prevStop, prevStart
+		portsWaitReady, portsRerender = prevWait, prevRerender
+	})
+
+	startCalls := 0
+	portsUnitStatus = func(string) (string, error) { return "active", nil }
+	portsStopUnit = func(string) error { return nil }
+	portsRerender = func(string) error { return nil }
+	portsWaitReady = func(string, time.Duration) error { return nil }
+	portsStartUnit = func(string) error {
+		startCalls++
+		if startCalls == 1 {
+			return errors.New("address already in use")
+		}
+		return nil // the rollback restart on the previous port succeeds
+	}
+
+	if _, err := SetPublishedPort("mysql", 33072); err == nil {
+		t.Fatal("a failed start must surface an error so the caller knows the change didn't take")
+	}
+	if startCalls != 2 {
+		t.Fatalf("expected a rollback restart attempt after the failed start, startCalls=%d", startCalls)
+	}
+	if got := config.ServicePublishedPort("mysql"); got != 0 {
+		t.Errorf("config must roll back to the previous port (0=default), got %d", got)
 	}
 }
 

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -87,24 +87,16 @@ func maybeShiftPublishedPort(primary int, active bool) int {
 	})
 }
 
-// lerdReservedPorts collects the host ports already claimed by lerd's own services in
-// global config — each service's published port, its preset-default port, and any extra
-// published ports — so the port-ownership guard never auto-picks a port another lerd
-// service will bind. The preset-default Port matters even for a STOPPED service: nothing
-// is listening, so freeport.Bindable() would report it free, and handing it out would
-// collide when both units start at boot (the failure this guard exists to prevent).
+// lerdReservedPorts collects the host ports already claimed by lerd's own services
+// so the port-ownership guard never auto-picks a port another lerd service will
+// bind. It delegates to config.ReservedHostPorts, the single shared definition the
+// host-proxy dev-server allocator consumes too: configured services' effective
+// ports, every bundled preset's defaults, and installed customs. A preset default
+// matters even for a STOPPED service — nothing is listening, so freeport.Bindable()
+// would report it free, and handing it out would collide when both units start at
+// boot (the failure this guard exists to prevent).
 func lerdReservedPorts() map[int]bool {
-	reserved := map[int]bool{}
-	cfg, err := config.LoadGlobal()
-	if err != nil || cfg == nil {
-		return reserved
-	}
-	for _, svc := range cfg.Services {
-		for _, p := range svc.HostPorts() {
-			reserved[p] = true
-		}
-	}
-	return reserved
+	return config.ReservedHostPorts()
 }
 
 // persistPublishedPort records port as service name's published port in global

--- a/internal/sitedoctor/sitedoctor.go
+++ b/internal/sitedoctor/sitedoctor.go
@@ -603,7 +603,10 @@ func parseComposerAudit(output string) int {
 	var parsed struct {
 		Advisories json.RawMessage `json:"advisories"`
 	}
-	if err := json.Unmarshal([]byte(output[start:]), &parsed); err != nil {
+	// Decode only the first JSON object: composer can print warning/deprecation
+	// lines after the payload, which json.Unmarshal rejects as trailing data and
+	// would otherwise degrade a real advisory count to "unknown".
+	if err := json.NewDecoder(strings.NewReader(output[start:])).Decode(&parsed); err != nil {
 		return -1
 	}
 	if len(parsed.Advisories) == 0 {
@@ -658,20 +661,29 @@ func checkNodeAudit(ctx context.Context, path string) Check {
 }
 
 // parseNpmAudit returns the total vulnerability count in `npm audit --json`
-// output, or -1 when the JSON can't be read.
+// output, or -1 when the audit couldn't actually run or its JSON can't be read.
 func parseNpmAudit(output string) int {
 	start := strings.IndexByte(output, '{')
 	if start < 0 {
 		return -1
 	}
 	var parsed struct {
+		Error    json.RawMessage `json:"error"`
 		Metadata struct {
 			Vulnerabilities struct {
 				Total int `json:"total"`
 			} `json:"vulnerabilities"`
 		} `json:"metadata"`
 	}
-	if err := json.Unmarshal([]byte(output[start:]), &parsed); err != nil {
+	// Decode only the first JSON object: npm can print warning lines after the
+	// payload, which json.Unmarshal rejects as trailing data.
+	if err := json.NewDecoder(strings.NewReader(output[start:])).Decode(&parsed); err != nil {
+		return -1
+	}
+	// On a pnpm/yarn/bun project (no package-lock.json) npm audit errors with
+	// {"error":{"code":"ENOLOCK",...}} and no metadata block. Total would default
+	// to 0, falsely reporting a clean audit, so report "unknown" instead.
+	if len(parsed.Error) > 0 {
 		return -1
 	}
 	return parsed.Metadata.Vulnerabilities.Total

--- a/internal/sitedoctor/sitedoctor_test.go
+++ b/internal/sitedoctor/sitedoctor_test.go
@@ -338,6 +338,11 @@ func TestParseComposerAudit(t *testing.T) {
 	if n := parseComposerAudit("not json"); n != -1 {
 		t.Errorf("garbage: got %d, want -1", n)
 	}
+	// Finding #10: a warning printed AFTER the JSON payload must not degrade a real
+	// count to "unknown" (json.Unmarshal rejects trailing data; the decoder ignores it).
+	if n := parseComposerAudit("{\"advisories\":{\"pkg/a\":[{}]}}\nDeprecation: something\n"); n != 1 {
+		t.Errorf("trailing warning after JSON: got %d, want 1", n)
+	}
 }
 
 func TestParseNpmAudit(t *testing.T) {
@@ -349,6 +354,15 @@ func TestParseNpmAudit(t *testing.T) {
 	}
 	if n := parseNpmAudit("oops"); n != -1 {
 		t.Errorf("garbage: got %d, want -1", n)
+	}
+	// Finding #2: npm audit on a pnpm/yarn/bun project errors with no metadata
+	// block. That must read as "unknown" (-1), never a false clean (0).
+	if n := parseNpmAudit(`{"error":{"code":"ENOLOCK","summary":"This command requires an existing lockfile."}}`); n != -1 {
+		t.Errorf("ENOLOCK error JSON: got %d, want -1 (unknown), a 0 would be a false all-clear", n)
+	}
+	// Finding #10: a warning line after the JSON payload must still parse.
+	if n := parseNpmAudit("{\"metadata\":{\"vulnerabilities\":{\"total\":2}}}\nnpm warn deprecated foo\n"); n != 2 {
+		t.Errorf("trailing warning after JSON: got %d, want 2", n)
 	}
 }
 

--- a/internal/watcher/dns.go
+++ b/internal/watcher/dns.go
@@ -47,6 +47,11 @@ type dnsWatchDeps struct {
 	// All nil off Linux / in tests that don't exercise them.
 	isStopped func() bool
 	now       func() time.Time
+	// monoSince returns monotonic elapsed time since the watcher started; paired
+	// with now (wall clock) it lets resumed() tell a real suspend (monotonic frozen,
+	// wall advanced) from a tick merely delayed by load (both advanced). Nil off the
+	// Linux path, where resumed() falls back to the bare wall gap.
+	monoSince func() time.Duration
 	log       func(level, msg string, kv ...any)
 }
 
@@ -60,30 +65,40 @@ type dnsWatchState struct {
 	dnsEnv            string
 	dnsEnvSeen        bool
 	lastTick          time.Time
+	lastMono          time.Duration
 }
 
-// resumeGapThreshold: a wall-clock gap larger than this between two consecutive
-// watcher ticks means the host was suspended. The monotonic ticker is frozen
-// during suspend while the wall clock keeps advancing, so a large wall gap with
-// no intervening ticks is an unambiguous "just resumed" signal — unlike a `lerd
-// start`, which a fresh watcher never mistakes for a resume (its first tick has
-// no previous timestamp to compare against).
+// resumeGapThreshold: when the wall clock advances more than this beyond the
+// monotonic clock between two consecutive ticks, the host was suspended (the
+// monotonic clock freezes during suspend while the wall clock keeps advancing).
+// Comparing the two gaps — not the bare wall gap — is what distinguishes a real
+// resume from a tick merely delayed past the threshold by CPU pressure or a long
+// pause, where wall and monotonic advance together and the difference stays near
+// zero. A fresh watcher never mistakes its first tick for a resume (no previous
+// timestamp to compare against).
 const resumeGapThreshold = 90 * time.Second
 
 // nginxHealthyDialTimeout bounds the 443 connectivity probe.
 const nginxHealthyDialTimeout = time.Second
 
-// resumed records this tick's time and reports whether the host just woke from
-// suspend, measured as the wall-clock gap since the previous tick. Comparing the
-// monotonic-stripped times (Round(0)) is what reveals the suspend, since the
-// monotonic delta the ticker runs on does not advance while suspended.
-func (s *dnsWatchState) resumed(now time.Time) bool {
-	prev := s.lastTick
-	s.lastTick = now
+// resumed records this tick's wall and monotonic readings and reports whether the
+// host just woke from suspend. now is wall-clock; mono is a monotonic elapsed
+// counter (haveMono=false when no monotonic source is wired, off the Linux path,
+// where it falls back to the bare wall gap). A suspend freezes the monotonic clock
+// while the wall clock keeps advancing, so the wall gap exceeds the monotonic gap
+// by ~the suspend duration; a tick merely delayed by CPU pressure advances both
+// equally, leaving the difference near zero, so it does NOT read as a resume.
+func (s *dnsWatchState) resumed(now time.Time, mono time.Duration, haveMono bool) bool {
+	prev, prevMono := s.lastTick, s.lastMono
+	s.lastTick, s.lastMono = now, mono
 	if prev.IsZero() {
 		return false
 	}
-	return now.Round(0).Sub(prev.Round(0)) > resumeGapThreshold
+	wallGap := now.Round(0).Sub(prev.Round(0))
+	if !haveMono {
+		return wallGap > resumeGapThreshold
+	}
+	return wallGap-(mono-prevMono) > resumeGapThreshold
 }
 
 // defaultDNSEnvFingerprint summarises the host DNS environment: the sorted
@@ -274,6 +289,7 @@ const linkChangeDebounce = 750 * time.Millisecond
 // eventbus.KindStatus so the dashboard reflects the live state via the
 // WebSocket without a manual refresh.
 func WatchDNS(interval time.Duration, tld string) {
+	start := time.Now()
 	deps := dnsWatchDeps{
 		check:             dns.Check,
 		waitReady:         dns.WaitReady,
@@ -282,6 +298,7 @@ func WatchDNS(interval time.Duration, tld string) {
 		idleOrLocked:      systemd.SessionIsIdleOrLocked,
 		publishStatus:     func() { eventbus.Default.Publish(eventbus.KindStatus) },
 		now:               time.Now,
+		monoSince:         func() time.Duration { return time.Since(start) },
 		log: func(level, msg string, kv ...any) {
 			switch level {
 			case "info":
@@ -419,7 +436,12 @@ func tickDNS(d dnsWatchDeps, s *dnsWatchState, tld string, linkTriggered bool) {
 	// accurate). A deliberately stopped stack is left entirely alone.
 	resumed := false
 	if d.now != nil {
-		resumed = s.resumed(d.now())
+		haveMono := d.monoSince != nil
+		var mono time.Duration
+		if haveMono {
+			mono = d.monoSince()
+		}
+		resumed = s.resumed(d.now(), mono, haveMono)
 	}
 	if d.isStopped != nil && d.isStopped() {
 		return

--- a/internal/watcher/dns_test.go
+++ b/internal/watcher/dns_test.go
@@ -682,12 +682,19 @@ func TestExposeConfigChanged_IgnoresAAAAOnlyDrift(t *testing.T) {
 	}
 }
 
-// fakeClock returns controllable times so resume detection (a wall-clock gap
-// between ticks) can be exercised deterministically.
-type fakeClock struct{ t time.Time }
+// fakeClock returns controllable wall and monotonic readings so resume detection
+// can be exercised deterministically. advance moves both clocks (normal time
+// passing); suspend moves only the wall clock, modelling a host suspend where the
+// monotonic clock freezes — the signal that tells a real resume from a slow tick.
+type fakeClock struct {
+	t    time.Time
+	mono time.Duration
+}
 
 func (c *fakeClock) now() time.Time          { return c.t }
-func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+func (c *fakeClock) since() time.Duration    { return c.mono }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d); c.mono += d }
+func (c *fakeClock) suspend(d time.Duration) { c.t = c.t.Add(d) }
 
 // nginxHarness builds a healNginxOnResume test harness with healthy defaults so
 // each test overrides only the behaviour it pins.
@@ -709,26 +716,45 @@ func newNginxHarness() *nginxHarness {
 	return h
 }
 
-// TestResumed pins the suspend detector: a wall-clock gap far larger than the
-// poll interval reads as a resume, normal cadence does not, and the very first
-// tick (no previous timestamp) never does.
+// TestResumed pins the suspend detector: a wall-clock gap that outruns the
+// monotonic clock (a real suspend) reads as a resume; normal cadence does not; the
+// first tick never does; and — finding #9 — a multi-hour tick delay where the
+// monotonic clock advanced too (CPU pressure, a long pause) must NOT read as a
+// resume, since nothing actually suspended.
 func TestResumed(t *testing.T) {
 	c := &fakeClock{t: time.Unix(1_000_000, 0)}
 	s := &dnsWatchState{}
-	if s.resumed(c.now()) {
+	if s.resumed(c.now(), c.since(), true) {
 		t.Fatal("first tick must not read as a resume")
 	}
 	c.advance(30 * time.Second)
-	if s.resumed(c.now()) {
+	if s.resumed(c.now(), c.since(), true) {
 		t.Fatal("a normal poll-interval gap is not a resume")
 	}
-	c.advance(2 * time.Hour)
-	if !s.resumed(c.now()) {
-		t.Fatal("a multi-hour gap must read as a resume")
+	c.suspend(2 * time.Hour) // wall jumps, monotonic frozen: a real suspend
+	if !s.resumed(c.now(), c.since(), true) {
+		t.Fatal("a wall gap that outruns the monotonic clock must read as a resume")
 	}
 	c.advance(30 * time.Second)
-	if s.resumed(c.now()) {
+	if s.resumed(c.now(), c.since(), true) {
 		t.Fatal("back to normal cadence must not read as a resume")
+	}
+	// A long delay where BOTH clocks advanced is a stalled/slow tick, not a suspend.
+	c.advance(2 * time.Hour)
+	if s.resumed(c.now(), c.since(), true) {
+		t.Fatal("a slow tick (monotonic advanced with the wall clock) must not read as a resume")
+	}
+}
+
+// TestResumed_noMonotonicFallback: without a monotonic source (off the Linux
+// path) resumed falls back to the bare wall gap.
+func TestResumed_noMonotonicFallback(t *testing.T) {
+	c := &fakeClock{t: time.Unix(1_000_000, 0)}
+	s := &dnsWatchState{}
+	_ = s.resumed(c.now(), 0, false)
+	c.advance(2 * time.Hour)
+	if !s.resumed(c.now(), 0, false) {
+		t.Fatal("with no monotonic source a multi-hour wall gap must read as a resume")
 	}
 }
 
@@ -770,6 +796,7 @@ func TestTickDNS_resumeTriggersNginxHeal(t *testing.T) {
 		idleOrLocked:  func() bool { return false },
 		publishStatus: func() {},
 		now:           c.now,
+		monoSince:     c.since,
 		nginxHealthy:  func() bool { probes++; return false },
 		repairNginx:   func() error { restarts++; return nil },
 		log:           func(string, string, ...any) {},
@@ -783,8 +810,8 @@ func TestTickDNS_resumeTriggersNginxHeal(t *testing.T) {
 		t.Fatalf("non-resume ticks must not probe nginx, got %d", probes)
 	}
 
-	c.advance(2 * time.Hour)
-	tickDNS(deps, s, "test", false) // big gap: resume -> heal
+	c.suspend(2 * time.Hour)
+	tickDNS(deps, s, "test", false) // suspend gap: resume -> heal
 	if probes != 1 || restarts != 1 {
 		t.Fatalf("resume must probe and restart a down nginx: probes=%d restarts=%d", probes, restarts)
 	}
@@ -800,13 +827,14 @@ func TestTickDNS_resumeHealsEvenWhenIdle(t *testing.T) {
 		idleOrLocked:  func() bool { return true },
 		publishStatus: func() {},
 		now:           c.now,
+		monoSince:     c.since,
 		nginxHealthy:  func() bool { return false },
 		repairNginx:   func() error { restarts++; return nil },
 		log:           func(string, string, ...any) {},
 	}
 	s := &dnsWatchState{tickCount: 3} // idle, non-Nth tick -> DNS would back off
 	tickDNS(deps, s, "test", false)
-	c.advance(2 * time.Hour)
+	c.suspend(2 * time.Hour)
 	tickDNS(deps, s, "test", false)
 	if restarts != 1 {
 		t.Fatalf("a resume must heal nginx even on an idle tick, restarts=%d", restarts)
@@ -826,6 +854,7 @@ func TestTickDNS_stoppedTickDoesNothing(t *testing.T) {
 		waitReady:         func(time.Duration) error { waits++; return nil },
 		configureResolver: func() error { return nil },
 		now:               c.now,
+		monoSince:         c.since,
 		nginxHealthy:      func() bool { return false },
 		repairNginx:       func() error { restarts++; return nil },
 		isStopped:         func() bool { return true },
@@ -833,7 +862,7 @@ func TestTickDNS_stoppedTickDoesNothing(t *testing.T) {
 	}
 	s := &dnsWatchState{}
 	tickDNS(deps, s, "test", false)
-	c.advance(2 * time.Hour) // even a resume-sized gap
+	c.suspend(2 * time.Hour) // even a resume-sized gap
 	tickDNS(deps, s, "test", false)
 	if waits != 0 || restarts != 0 {
 		t.Fatalf("stopped stack must do nothing: waits=%d restarts=%d", waits, restarts)


### PR DESCRIPTION
A review of everything since v1.26 surfaced a cluster of correctness issues in the new service-ports management and the framework-agnostic site doctor.

In the site doctor, a Laravel or Symfony site whose store definition predates the doctor block now inherits the built-in production-debug, storage-symlink and pending-migration checks instead of silently reporting healthy. npm audit on a pnpm, yarn or bun project reports unknown rather than a false all-clear when it errors out with no metadata block, and both audit parsers tolerate warning lines printed after the JSON payload.

In service ports, requesting a service's preset default now resets to it rather than colliding with the running service's own listener, a freed default port is no longer reported as still claimed so it can be reassigned to another service, a failed restart after a port move rolls the service back onto its previous port instead of leaving it down, and the port-ownership guard and the host-proxy allocator now share a single reserved-port set so they can no longer drift into a boot collision.

The host-proxy idle-resume now waits on the site's registered port before restoring the proxy vhost, so an auto-allocated dev server no longer flashes a bare 502 during warmup. The watcher distinguishes a real host resume from a tick merely delayed under load by comparing the wall clock against the monotonic clock, so it no longer restarts nginx spuriously.