### PR TITLE
Recover ghost containers on start

### DIFF
--- a/internal/cli/ghost_heal.go
+++ b/internal/cli/ghost_heal.go
@@ -1,0 +1,20 @@
+package cli
+
+import "strings"
+
+// isGhostContainerError reports whether err is the "ghost container" failure:
+// a container whose libpod DB entry survives (typically stuck Created) but whose
+// c/storage layer is gone, a DB/storage desync an unclean Podman Machine
+// shutdown can cause. `podman run --replace` then fails trying to swap the
+// dead record, surfacing as `getting container from store "<id>": container not
+// known`. Both substrings are required so an ordinary "container not known" (a
+// genuinely absent container) does not trip the heal. Distinct from
+// isOverlayStorageError, which matches corrupt overlay layers.
+func isGhostContainerError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "from store") &&
+		strings.Contains(msg, "container not known")
+}

--- a/internal/cli/ghost_heal_darwin.go
+++ b/internal/cli/ghost_heal_darwin.go
@@ -1,0 +1,46 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+
+	"github.com/geodro/lerd/internal/feedback"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// healGhostContainersIfNeeded recovers from a ghost container (see
+// isGhostContainerError) on the service start pass, then asks the caller to
+// retry once. The host podman client cannot purge the ghost: lerd's containers
+// live in the VM's rootful storage, and `podman rm -f` from the host returns
+// "container not known" against the missing storage layer. Removing it inside
+// the VM, where the rootful podman tolerates the dead record, clears it so the
+// retry's `podman run --replace` recreates the container on fresh storage.
+// Site data is host bind-mounted, so the purge loses nothing. Returns true when
+// recovery ran and the caller should retry the start pass.
+func healGhostContainersIfNeeded(err error) bool {
+	if !isGhostContainerError(err) {
+		return false
+	}
+	purgeGhostLerdContainers()
+	return true
+}
+
+// purgeGhostLerdContainers force-removes the stuck-Created lerd-* containers
+// inside the Podman Machine's rootful scope, the only place the removal
+// succeeds. It targets `status=created` so healthy running services are left
+// alone; `xargs -r` makes the remove a no-op when nothing matches.
+func purgeGhostLerdContainers() {
+	name := selectedMachineName()
+	if name == "" {
+		return
+	}
+	feedback.Line("A container's storage was orphaned (likely an unclean Podman Machine shutdown); purging the ghost inside the VM so it can be recreated…")
+	const script = `sudo podman ps -a --filter name=^lerd- --filter status=created -q | xargs -r sudo podman rm -f`
+	cmd := podman.Cmd("machine", "ssh", name, script)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		feedback.Warn("purge ghost containers: %v", err)
+	}
+}

--- a/internal/cli/ghost_heal_other.go
+++ b/internal/cli/ghost_heal_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package cli
+
+// healGhostContainersIfNeeded is a no-op on non-darwin platforms. The ghost is
+// recoverable on the host there: native podman runs in the same scope as the
+// containers, so a plain `podman rm -f` (already on the existing heal paths)
+// reaches the dead record without going through a VM.
+func healGhostContainersIfNeeded(_ error) bool { return false }

--- a/internal/cli/ghost_heal_test.go
+++ b/internal/cli/ghost_heal_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsGhostContainerError(t *testing.T) {
+	// The exact wrapping a unit start produces: the podman stderr is wrapped by
+	// the run step. Captured from a user whose lerd-redis was stuck Created with
+	// a libpod DB entry but a missing storage layer (DB/storage desync after an
+	// unclean Podman Machine shutdown), so `podman run --replace` failed.
+	runErr := fmt.Errorf("podman run lerd-redis: %w",
+		errors.New(`exit status 125: Error: getting container from store "21ed4c91893d12b7d48773d004b7b0149c9c4b440b08ad3503d22f420ea2ab1d": container not known`))
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"ghost container", runErr, true},
+		{"bare from-store wording", errors.New(`getting container from store "abc": container not known`), true},
+		{"nil error", nil, false},
+		{"overlay corruption is a different heal", errors.New(`getting graph driver info "b77": readlink /var/lib/containers/storage/overlay: invalid argument`), false},
+		{"container not known without store context", errors.New("no container with name lerd-redis: container not known"), false},
+		{"port conflict", errors.New("rootlessport cannot expose privileged port 80, bind: address already in use"), false},
+		{"missing image", errors.New(`short-name "lerd-php85-fpm:local" did not resolve to an alias`), false},
+		{"generic failure", errors.New("some other failure"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isGhostContainerError(tc.err); got != tc.want {
+				t.Fatalf("isGhostContainerError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -635,8 +635,10 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// When the Podman Machine's container storage is left corrupt after an
 	// unclean host shutdown, every container start fails. Remount storage and
 	// rebuild the stale containers (data is host bind-mounted, so this is safe),
-	// then retry the start pass once.
-	if healOverlayCorruptionIfNeeded(serviceErr) {
+	// then retry the start pass once. A ghost container (libpod DB entry intact
+	// but its storage layer gone) is the other unclean-shutdown failure; purge it
+	// inside the VM and retry the same way. The two signatures are exclusive.
+	if healOverlayCorruptionIfNeeded(serviceErr) || healGhostContainersIfNeeded(serviceErr) {
 		serviceErr = RunParallel(makeJobs(serviceUnits))
 	}
 	// If the storage is still corrupt the heal couldn't fix it; every worker


### PR DESCRIPTION
Fixes #698.

## Problem

An unclean Podman Machine shutdown can desync libpod and c/storage: a container's DB entry survives (stuck `Created`) while its storage layer is gone, a "ghost". `podman run --replace` then fails and the unit never starts:

```
✗ redis: podman run lerd-redis: exit status 125: Error: getting container from store "<id>": container not known
```

The host podman client can't clear it (`container not known` against the missing layer), and `lerd service reinstall` doesn't help because its stop step uses the same host-side `podman rm -f`. The removal only succeeds inside the VM's rootful scope.

## Change

On the service start pass, detect the `getting container from store ...: container not known` signature and purge the stuck-`Created` lerd-* containers inside the VM via `podman machine ssh ... podman rm -f`, then retry the start once. The purge is filtered to `status=created`, so running services are left alone; site data is host bind-mounted, so nothing is lost.

This mirrors the existing overlay-corruption heal. It is darwin-only (`ghost_heal_darwin.go`), with a no-op on Linux where native podman shares the container scope and a plain `podman rm -f` already reaches the record.

## Notes

Not Podman version specific: the failure persisted across a 6 to 5 downgrade. The trigger is unclean VM shutdowns (host sleep/reboot without `lerd quit`).

The filter selectivity was verified live against a stuck-`Created` stand-in container: the heal targeted only that container and excluded all running services.