### PR TITLE
Pin applehv provider for podman machine init on podman 6

### DIFF
--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -87,11 +87,29 @@ var requiredMachineMounts = []string{"/Users", "/private", "/var/folders", "/Vol
 // can start.
 const homeMachineMount = "/Users"
 
+// machineProvider returns the machine provider to pin for `podman machine
+// init`, or "" to accept podman's default. Podman 6 switched the macOS
+// Apple-Silicon default to libkrun, which needs a `krunkit` binary that is not
+// in Homebrew core, so an unpinned init fails with "krunkit: executable file
+// not found". Pin applehv (the vfkit backend bundled with podman, which lerd
+// has always used) so init works with no extra dependency. Empty on podman <6,
+// where applehv is already the default and --provider may be unsupported.
+func machineProvider() string {
+	if ok, _, err := podman.VersionAtLeast(6, 0); err == nil && ok {
+		return "applehv"
+	}
+	return ""
+}
+
 // machineInitArgs builds `podman machine init` arguments with every required
 // mount and the host-scaled memory. name re-creates a specific machine
-// (preserving a custom name); "" creates Podman's default.
-func machineInitArgs(name string, targetMemoryMiB int64) []string {
+// (preserving a custom name); "" creates Podman's default. provider pins the
+// VM backend ("" leaves podman's default); see machineProvider.
+func machineInitArgs(name string, targetMemoryMiB int64, provider string) []string {
 	args := []string{"machine", "init", "--rootful"}
+	if provider != "" {
+		args = append(args, "--provider", provider)
+	}
 	for _, m := range requiredMachineMounts {
 		args = append(args, "-v", m+":"+m)
 	}
@@ -161,7 +179,7 @@ func recreateBrokenMachine(name string, running bool, targetMemoryMiB int64) {
 		feedback.Warn("podman machine rm: %v", err)
 		return
 	}
-	initCmd := podman.Cmd(machineInitArgs(name, targetMemoryMiB)...)
+	initCmd := podman.Cmd(machineInitArgs(name, targetMemoryMiB, machineProvider())...)
 	initCmd.Stdout = os.Stdout
 	initCmd.Stderr = os.Stderr
 	if err := initCmd.Run(); err != nil {
@@ -236,7 +254,7 @@ func ensurePodmanMachineRunning() error {
 		cfg, _ := config.LoadGlobal()
 		execMode := cfg != nil && cfg.WorkerExecMode() != config.WorkerExecModeContainer
 		targetMemoryMiB := recommendedVMMemoryMiB(hostMemoryGiB(), execMode)
-		cmd := podman.Cmd(machineInitArgs("", targetMemoryMiB)...)
+		cmd := podman.Cmd(machineInitArgs("", targetMemoryMiB, machineProvider())...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {

--- a/internal/cli/startstop_darwin_test.go
+++ b/internal/cli/startstop_darwin_test.go
@@ -13,7 +13,7 @@ import (
 func TestMachineInitArgs(t *testing.T) {
 	// Every required mount must be passed explicitly, or Podman's stringArray
 	// --volume drops the defaults (the lerd <= 1.24.0 bug).
-	args := machineInitArgs("", 4096)
+	args := machineInitArgs("", 4096, "")
 	joined := strings.Join(args, " ")
 	for _, m := range requiredMachineMounts {
 		if !strings.Contains(joined, "-v "+m+":"+m) {
@@ -26,13 +26,27 @@ func TestMachineInitArgs(t *testing.T) {
 	if !strings.Contains(joined, "--memory 4096") {
 		t.Errorf("init args missing memory: %v", args)
 	}
+	// An empty provider must not emit --provider (older podman where applehv is
+	// the default and the flag may not exist).
+	if strings.Contains(joined, "--provider") {
+		t.Errorf("empty provider should omit --provider: %v", args)
+	}
 	// A name (recreate path) must be the trailing positional arg.
-	named := machineInitArgs("podman-machine-default", 0)
+	named := machineInitArgs("podman-machine-default", 0, "")
 	if named[len(named)-1] != "podman-machine-default" {
 		t.Errorf("named init args should end with the machine name: %v", named)
 	}
 	if strings.Contains(strings.Join(named, " "), "--memory") {
 		t.Errorf("zero memory should omit --memory: %v", named)
+	}
+	// Pinning a provider (podman 6: avoid the libkrun/krunkit default) emits
+	// --provider, with the name still trailing.
+	pinned := machineInitArgs("podman-machine-default", 0, "applehv")
+	if !strings.Contains(strings.Join(pinned, " "), "--provider applehv") {
+		t.Errorf("pinned provider should emit --provider applehv: %v", pinned)
+	}
+	if pinned[len(pinned)-1] != "podman-machine-default" {
+		t.Errorf("pinned init args should still end with the machine name: %v", pinned)
 	}
 }
 


### PR DESCRIPTION
Fixes #700.

## Problem

Podman 6 changed the default macOS Apple Silicon machine provider from `applehv` (vfkit) to `libkrun` (krunkit). `krunkit` is not bundled with podman and not in Homebrew core, so an unpinned `podman machine init` builds a VM that cannot start:

```
 → Starting Podman Machine…
Error: exec: "krunkit": executable file not found in $PATH
 ⚠ podman machine start: exit status 125
```

This breaks `lerd machine reset` and every fresh `lerd install` on Podman 6 + Apple Silicon, since lerd's init passed no `--provider` and inherited the new default.

## Change

Pin `--provider applehv` in `machineInitArgs` when podman is 6.0 or newer (the version where both the libkrun default and the `--provider` flag exist). On podman <6, applehv is already the default and the flag is omitted, so older podman is unaffected.

applehv (vfkit) is bundled with the podman Homebrew formula and is the backend lerd has always used. libkrun's advantage is GPU/Vulkan passthrough, which lerd's PHP/nginx/database containers do not need, so it stays an opt-in rather than a silent, dependency-adding default.

## Recovery for users already broken

```
CONTAINERS_MACHINE_PROVIDER=applehv lerd machine reset -y
lerd start
```