### PR TITLE
Show the idle moon in real time on resume

### DIFF
--- a/internal/ui/web/src/components/SiteIndicators.svelte
+++ b/internal/ui/web/src/components/SiteIndicators.svelte
@@ -24,9 +24,13 @@
 {#if siteWorkerFailing(site)}
   <span title={m.sites_workerFailing()} class="shrink-0"><StatusDot color="red" size="xs" pulse /></span>
 {/if}
-{#if site.idle && siteHasWorkers(site)}
+{#if site.idle_suspended && siteHasWorkers(site)}
   <!-- Asleep: keep the worker dots (dimmed) and float a moon above them. A site
-       with no workers never sleeps, so it gets no moon at all. -->
+       with no workers never sleeps, so it gets no moon at all. We key off
+       idle_suspended (the engine's actual stopped-workers state, cleared the
+       instant resume publishes) rather than idle (the timeout prediction read
+       from the watcher's activity file, only re-saved every tick) so the moon
+       drops in real time on resume instead of lingering until the next poll. -->
   {#if idleDots.length > 0}
     <span class="relative inline-flex items-center shrink-0" title={m.sites_idleHint()}>
       <span class="absolute -top-2.5 left-1/2 -translate-x-1/2 text-sky-500 dark:text-sky-400">

--- a/internal/ui/web/src/components/SiteIndicators.test.ts
+++ b/internal/ui/web/src/components/SiteIndicators.test.ts
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import SiteIndicators from './SiteIndicators.svelte';
+import type { Site } from '$stores/sites';
+
+// The moon path is distinctive enough to detect "is the sleep indicator shown".
+const MOON_PATH = 'M21.752 15.002';
+
+function hasMoon(container: HTMLElement): boolean {
+  return Array.from(container.querySelectorAll('path')).some((p) =>
+    (p.getAttribute('d') || '').startsWith(MOON_PATH)
+  );
+}
+
+function site(overrides: Partial<Site>): Site {
+  return { domain: 'app.test', name: 'app', has_queue_worker: true, ...overrides } as Site;
+}
+
+describe('SiteIndicators sleep moon', () => {
+  it('shows the moon when workers are actually suspended', () => {
+    const { container } = render(SiteIndicators, {
+      props: { site: site({ idle_suspended: true, idle_suspended_workers: ['queue'] }) }
+    });
+    expect(hasMoon(container)).toBe(true);
+  });
+
+  it('hides the moon the instant workers resume, even while the idle timeout flag is still stale', () => {
+    // This is the bug: on resume the engine clears idle_suspended and publishes
+    // immediately, but `idle` (read from the watcher's activity file) stays true
+    // for up to a tick. The moon must follow idle_suspended, not idle.
+    const { container } = render(SiteIndicators, {
+      props: { site: site({ idle: true, idle_suspended: false, idle_suspended_workers: [] }) }
+    });
+    expect(hasMoon(container)).toBe(false);
+  });
+
+  it('shows no moon for a fully running site', () => {
+    const { container } = render(SiteIndicators, {
+      props: { site: site({ idle: false, idle_suspended: false, queue_running: true }) }
+    });
+    expect(hasMoon(container)).toBe(false);
+  });
+});


### PR DESCRIPTION
The sleep moon in the sites list and the dashboard tiles was keyed off the site's idle flag, which the UI derives from the watcher's persisted activity file. The watcher only re-saves that file on its 30 second tick, so when workers resumed the moon kept showing for up to half a minute even though the worker dots had already gone green over the socket. The two indicators were reading different signals, one live and one polled.

The moon now keys off idle_suspended, the engine's actual stopped-workers state, which resume clears and publishes on the same socket cycle as the worker dots. The moon now appears exactly when the workers are suspended and clears the instant they resume, fully in sync with the dots and with no polling lag.

Refs #702