### PR TITLE
Let every bundled preset publish extra ports and autofill its host port

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -189,7 +189,7 @@ Switch the PHP runtime for the current site between shared PHP-FPM and per-site 
 | `lerd service update <name> [tag]` | Pull a newer image and restart; with no tag applies the safe in-strategy update, with a tag targets an explicit upgrade |
 | `lerd service migrate <name> <target-tag>` | SQL dump + restore for cross-version mysql / postgres moves; old data dir and dump preserved under `~/.local/share/lerd/backups` |
 | `lerd service rollback <name>` | Swap back to the previously-running image; toggles, so a second rollback redoes the update |
-| `lerd service expose <name> <host:container>` | Publish an extra port on a built-in service (persisted, auto-restarts if running) |
+| `lerd service expose <name> <host:container>` | Publish an extra port on any bundled preset service (persisted, auto-restarts if running) |
 | `lerd service expose <name> <host:container> --remove` | Remove a previously exposed port |
 | `lerd service port <name> <port>` | Move a service's published host port without touching its container-internal port; persisted and auto-restarts if running |
 | `lerd service port <name> --reset` | Reset a service to its preset default published port (same as `port <name> 0`) |

--- a/docs/usage/services.md
+++ b/docs/usage/services.md
@@ -40,9 +40,9 @@ Default services are defined as YAML presets with `default: true` in the lerd bi
 
 The Web UI, the TUI, and `lerd status` display the same labels. Services pinned to rolling tags (`latest`, `main`) show the tag verbatim. Services where an update is available show `→ <new-tag>`; cross-strategy upgrades show `⇧ <new-tag>` in amber.
 
-### Exposing extra ports on built-in services
+### Exposing extra ports on bundled services
 
-Built-in services publish a fixed set of ports by default. Use `lerd service expose` to bind additional host ports without recompiling or replacing the service:
+Bundled services publish a fixed set of ports by default. Use `lerd service expose` to bind additional host ports without recompiling or replacing the service. This works for any service lerd ships as a preset, both the default-stack ones (MySQL, PostgreSQL, Redis) and the optional ones you install on demand (Gotenberg, MongoDB, Elasticsearch, and so on). Only genuinely custom services you define yourself are excluded, since those declare their ports in their own YAML.
 
 ```bash
 # Expose MySQL on an extra port (e.g. for a second GUI client using a different port)

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -514,14 +514,17 @@ func DefaultPresetDashboard(name string) string {
 	return svc.Dashboard
 }
 
-// DefaultPresetPorts returns the default port mappings for a default preset, or
-// nil for non-defaults. Like DefaultPresetDashboard it reads the cached meta
-// directly instead of through DefaultPresetMeta, which deep-copies the struct and
-// clones its slices — wasteful for the services snapshot, which rebuilds every
+// PresetPorts returns the resolved default host port mappings for any bundled
+// preset — default-stack (mysql, redis) or optional (gotenberg, mongo) alike —
+// or nil when name isn't a preset we ship. The ports live in the preset YAML the
+// same way regardless of the default flag, so the ports UI keys off ownership,
+// not default-stack membership. Like DefaultPresetDashboard it reads the cached
+// meta directly instead of through DefaultPresetMeta, which deep-copies the struct
+// and clones its slices — wasteful for the services snapshot, which rebuilds every
 // service every refresh and only reads the ports. The returned slice is the cached
 // instance's own; callers must not mutate it.
-func DefaultPresetPorts(name string) []string {
-	if !IsDefaultPreset(name) {
+func PresetPorts(name string) []string {
+	if !PresetExists(name) {
 		return nil
 	}
 	svc, err := cachedDefaultPresetMeta(name)

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -1189,25 +1189,29 @@ func TestDefaultPresetMeta_Caches(t *testing.T) {
 	}
 }
 
-// DefaultPresetPorts must return the same ports as DefaultPresetMeta without the
-// deep copy, and nil for a non-default preset, so the services snapshot can read
-// a preset's ports without cloning the whole struct on every refresh.
-func TestDefaultPresetPorts(t *testing.T) {
+// PresetPorts must return the same ports as DefaultPresetMeta without the deep
+// copy for a default-stack preset, the declared ports for an optional preset
+// (gotenberg), and nil for a name we don't ship, so the services snapshot can
+// read any preset's ports without cloning the whole struct on every refresh.
+func TestPresetPorts(t *testing.T) {
 	meta, err := DefaultPresetMeta("mysql")
 	if err != nil {
 		t.Fatalf("DefaultPresetMeta(mysql): %v", err)
 	}
-	got := DefaultPresetPorts("mysql")
+	got := PresetPorts("mysql")
 	if len(got) != len(meta.Ports) {
-		t.Fatalf("DefaultPresetPorts(mysql) = %v, want %v", got, meta.Ports)
+		t.Fatalf("PresetPorts(mysql) = %v, want %v", got, meta.Ports)
 	}
 	for i := range got {
 		if got[i] != meta.Ports[i] {
 			t.Errorf("port %d = %q, want %q", i, got[i], meta.Ports[i])
 		}
 	}
-	if DefaultPresetPorts("sqlite") != nil {
-		t.Error("DefaultPresetPorts(sqlite) must be nil for a non-default preset")
+	if goten := PresetPorts("gotenberg"); len(goten) != 1 || goten[0] != "3000:3000" {
+		t.Errorf("PresetPorts(gotenberg) = %v, want [3000:3000] for an optional preset", goten)
+	}
+	if PresetPorts("sqlite") != nil {
+		t.Error("PresetPorts(sqlite) must be nil for a name we don't ship as a preset")
 	}
 }
 

--- a/internal/config/service_manual.go
+++ b/internal/config/service_manual.go
@@ -115,3 +115,18 @@ func ServicePublishedPort(name string) int {
 	}
 	return 0
 }
+
+// ServiceExtraPorts returns the extra published port mappings recorded for a
+// service (set via `lerd service expose` or the Web UI ports modal), or nil when
+// none. Applied at the quadlet choke point so every preset-backed service, not
+// just the default-stack ones, honours the same extra-port overrides.
+func ServiceExtraPorts(name string) []string {
+	cfg, err := LoadGlobal()
+	if err != nil {
+		return nil
+	}
+	if sc, ok := cfg.Services[name]; ok {
+		return sc.ExtraPorts
+	}
+	return nil
+}

--- a/internal/serviceops/ports.go
+++ b/internal/serviceops/ports.go
@@ -164,15 +164,16 @@ func SetPublishedPort(name string, port int) (PortChange, error) {
 	return res, nil
 }
 
-// SetExtraPorts replaces a built-in service's extra published ports with ports
+// SetExtraPorts replaces a bundled preset's extra published ports with ports
 // (each a bare "host", "host:container", or "ip:host:container" mapping),
 // de-duplicating and validating, then re-rendering and restarting the unit when
 // it is running. Shared by the CLI `service expose`, MCP service:expose, and the
-// Web UI ports endpoint. Custom services declare their ports in their own YAML,
-// so this is preset-only.
+// Web UI ports endpoint. Any preset lerd ships qualifies (default-stack or
+// optional like gotenberg); genuinely custom services declare their ports in
+// their own YAML, so they're excluded.
 func SetExtraPorts(name string, ports []string) error {
-	if !config.IsDefaultPreset(name) {
-		return fmt.Errorf("%q is not a built-in service", name)
+	if !config.PresetExists(name) {
+		return fmt.Errorf("%q is not a bundled service", name)
 	}
 	cfg, err := config.LoadGlobal()
 	if err != nil {
@@ -217,7 +218,7 @@ func SetExtraPorts(name string, ports []string) error {
 	if !ServiceInstalled(name) {
 		return nil
 	}
-	if err := EnsureDefaultPresetQuadlet(name); err != nil {
+	if err := rerenderServiceQuadlet(name); err != nil {
 		return err
 	}
 	if status, _ := podman.UnitStatus("lerd-" + name); status == "active" {

--- a/internal/serviceops/ports_test.go
+++ b/internal/serviceops/ports_test.go
@@ -146,6 +146,25 @@ func TestSetExtraPortsRejectsCustomName(t *testing.T) {
 	}
 }
 
+// TestSetExtraPortsOptionalPreset persists extra ports for an optional (non
+// default-stack) preset like gotenberg: it's a service we ship, so the gate is
+// preset ownership, not the default flag.
+func TestSetExtraPortsOptionalPreset(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := SetExtraPorts("gotenberg", []string{"39580:80"}); err != nil {
+		t.Fatalf("SetExtraPorts(gotenberg): %v", err)
+	}
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Services["gotenberg"].ExtraPorts; len(got) != 1 || got[0] != "39580:80" {
+		t.Errorf("gotenberg ExtraPorts = %v, want [39580:80]", got)
+	}
+}
+
 // TestSetPublishedPortRejectsSiblingPort refuses a port another lerd service
 // already claims (postgres's default 5432) even while that sibling is stopped.
 func TestSetPublishedPortRejectsSiblingPort(t *testing.T) {

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -360,18 +360,17 @@ func EnsureDefaultPresetQuadletPinned(name, pinnedImage string) error {
 	}
 	canonicalPin := ""
 	pinnedUserImage := ""
-	var extraPorts []string
 	if cfg, loadErr := config.LoadGlobal(); loadErr == nil {
 		if svcCfg, ok := cfg.Services[name]; ok {
 			canonicalPin = svcCfg.CanonicalVersion
 			pinnedUserImage = svcCfg.Image
-			extraPorts = svcCfg.ExtraPorts
 		}
 	}
-	// The published-port override and the generic port-availability guard are now
-	// applied once, downstream, in EnsureCustomServiceQuadlet (the choke point every
-	// service quadlet passes through), so this preset path just resolves the default
-	// ports and hands the service off.
+	// The published-port override, the extra published ports, and the generic
+	// port-availability guard are all applied once, downstream, in
+	// EnsureCustomServiceQuadlet (the choke point every service quadlet passes
+	// through), so this preset path just resolves the default ports and hands the
+	// service off.
 	hasUserPin := pinnedUserImage != ""
 	// Backfill for pre-existing installs that pre-date this feature: if no
 	// pin is recorded but a container is running, derive the major from the
@@ -398,9 +397,6 @@ func EnsureDefaultPresetQuadletPinned(name, pinnedImage string) error {
 	}
 	if hasUserPin {
 		svc.Image = pinnedUserImage
-	}
-	if len(extraPorts) > 0 {
-		svc.Ports = append(svc.Ports, extraPorts...)
 	}
 	// First-install / backfill pin: persist the canonical tag so future YAML
 	// canonical flips don't silently major-jump this install.
@@ -531,6 +527,14 @@ func EnsureCustomServiceQuadlet(svc *config.CustomService) error {
 	if pp > 0 {
 		svc.Ports = podman.SetPrimaryHostPort(svc.Ports, pp)
 		svc.ConnectionURL = WithURLPort(svc.ConnectionURL, pp)
+	}
+	// Extra published ports (set via `lerd service expose` / the Web UI ports
+	// modal) apply to any bundled preset, not just default-stack ones. Appended
+	// here at the shared choke point — after the primary-port guard reads the
+	// unpolluted mapping — so the preset and materialised-preset paths behave
+	// identically.
+	if extra := config.ServiceExtraPorts(svc.Name); len(extra) > 0 {
+		svc.Ports = append(svc.Ports, extra...)
 	}
 	if svc.DataDir != "" {
 		if err := os.MkdirAll(config.DataSubDir(svc.Name), 0755); err != nil {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1002,6 +1002,11 @@ type ServiceResponse struct {
 	ExtraPorts    []string `json:"extra_ports,omitempty"`
 	Custom        bool     `json:"custom,omitempty"`
 	IsDefault     bool     `json:"is_default,omitempty"`
+	// PresetOwned is true when lerd ships this service as a bundled preset
+	// (default-stack or optional like gotenberg). The ports modal keys the
+	// extra-ports affordance off this, not is_default, so every service we
+	// provide can publish extra ports while genuinely custom services can't.
+	PresetOwned bool `json:"preset_owned,omitempty"`
 	// Tunable is true when the service exposes a user-editable runtime config
 	// override (see config.ServiceTuningMount), so the UI can show a Tuning tab.
 	Tunable            bool     `json:"tunable,omitempty"`
@@ -1111,7 +1116,7 @@ func buildServiceResponseWithPortList(services map[string]config.ServiceConfig, 
 		}
 	}
 
-	presetPorts := config.DefaultPresetPorts(name)
+	presetPorts := config.PresetPorts(name)
 	hostPort := effectiveHostPort(services, name, presetPorts)
 	defaultPort := podman.PrimaryHostPort(presetPorts)
 	if sc, ok := services[name]; ok && sc.Port > 0 {
@@ -1130,6 +1135,7 @@ func buildServiceResponseWithPortList(services map[string]config.ServiceConfig, 
 		Pinned:        config.ServiceIsPinned(name),
 		Paused:        config.ServiceIsPaused(name),
 		IsDefault:     config.IsDefaultPreset(name),
+		PresetOwned:   config.PresetExists(name),
 		DefaultPort:   defaultPort,
 	}
 	if sc, ok := services[name]; ok {
@@ -1252,6 +1258,10 @@ func buildServicesList() []ServiceResponse {
 			dashboard, dashboardExternal = dashProxyPath(svc.Name), false
 		}
 		hostPort := effectiveHostPort(svcCfg, svc.Name, svc.Ports)
+		// Optional presets (gotenberg, mongo, …) materialise as custom services, so
+		// they land here rather than in the default-preset loop. Surface the same
+		// port fields the ports modal needs: preset ownership drives the extra-ports
+		// affordance, and the declared default host port drives the autofill.
 		services = append(services, ServiceResponse{
 			Name:              svc.Name,
 			Status:            status,
@@ -1262,6 +1272,10 @@ func buildServicesList() []ServiceResponse {
 			ConnectionURL:     serviceops.WithURLPort(svc.ConnectionURL, hostPort),
 			Port:              hostPort,
 			Custom:            true,
+			PresetOwned:       config.PresetExists(svc.Name),
+			DefaultPort:       podman.PrimaryHostPort(svc.Ports),
+			PublishedPort:     config.ServicePublishedPort(svc.Name),
+			ExtraPorts:        config.ServiceExtraPorts(svc.Name),
 			Tunable:           tunable,
 			SiteCount:         countSitesUsingService(svc.Name),
 			SiteDomains:       sitesUsingService(svc.Name),
@@ -2361,9 +2375,9 @@ func handleServicePorts(w http.ResponseWriter, r *http.Request, name string) {
 		fail(err)
 		return
 	}
-	// Extra ports apply to built-in services only; custom services declare ports
-	// in their own YAML.
-	if config.IsDefaultPreset(name) {
+	// Extra ports apply to any preset lerd ships; genuinely custom services
+	// declare their ports in their own YAML.
+	if config.PresetExists(name) {
 		if err := serviceops.SetExtraPorts(name, body.ExtraPorts); err != nil {
 			fail(err)
 			return

--- a/internal/ui/web/src/stores/services.ts
+++ b/internal/ui/web/src/stores/services.ts
@@ -20,6 +20,9 @@ export interface Service {
   extra_ports?: string[];
   custom?: boolean;
   is_default?: boolean;
+  // True when lerd ships this service as a bundled preset (default-stack or
+  // optional). Drives the ports modal's extra-ports affordance.
+  preset_owned?: boolean;
   tunable?: boolean;
   site_count: number;
   site_domains?: string[];

--- a/internal/ui/web/src/tabs/services/ServicePortsModal.svelte
+++ b/internal/ui/web/src/tabs/services/ServicePortsModal.svelte
@@ -11,7 +11,7 @@
   }
   let { open, svc, onclose }: Props = $props();
 
-  const isBuiltin = $derived(Boolean(svc.is_default));
+  const isBuiltin = $derived(Boolean(svc.preset_owned));
 
   // Shared with the domains modal's add inputs so the two read identically.
   const inputCls =


### PR DESCRIPTION
The ports manager treated a service as built-in only when its preset carried default: true, but that flag means part of the default stack we start automatically, not provided by lerd. Optional presets we also ship, gotenberg being the obvious one, fell outside the gate, so their ports modal showed an empty published-port field and refused to add extra ports even though we own them.

The gate now keys off preset ownership rather than default-stack membership. PresetPorts resolves the declared ports for any bundled preset, ServiceExtraPorts exposes the recorded extra mappings, and the extra-ports application moved into EnsureCustomServiceQuadlet, the single choke point every service quadlet passes through, so the default-preset and materialised-preset paths behave identically instead of the preset path appending them itself. SetExtraPorts and the Web UI expose handler both gate on PresetExists now, and the services API surfaces a preset_owned flag plus the port fields for optional presets, which materialise as custom services and so are built through the custom-services path rather than the default-preset one. The modal reads preset_owned for the extra-ports affordance and leaves is_default to the delete and reinstall confirmations that legitimately mean default stack.

Refs #707