### PR TITLE
Point the docs rail icon at the documentation

### DIFF
--- a/internal/ui/web/src/stores/dashboard.test.ts
+++ b/internal/ui/web/src/stores/dashboard.test.ts
@@ -52,6 +52,17 @@ describe('dashboard store', () => {
     open.mockRestore();
   });
 
+  it('openDocs embeds the docs landing page in the overlay', async () => {
+    const { openDocs, dashboardOpen } = await import('./dashboard');
+
+    dashboardOpen.set(null);
+    openDocs();
+    const cur = get(dashboardOpen);
+    expect(cur?.name).toBe('docs');
+    expect(cur?.dashboard).toBe('https://lerd.sh/getting-started/requirements');
+    expect(location.hash).toBe('#docs');
+  });
+
   it('openMailpitMessage opens overlay with extraPath when mailpit is present', async () => {
     const { services } = await import('./services');
     const { openMailpitMessage, dashboardOpen } = await import('./dashboard');

--- a/internal/ui/web/src/stores/dashboard.ts
+++ b/internal/ui/web/src/stores/dashboard.ts
@@ -16,7 +16,7 @@ export const dashboardOpen = writable<DashboardRef | null>(null);
 const DOCS_REF: DashboardRef = {
   name: 'docs',
   label: 'Documentation',
-  dashboard: 'https://lerd.sh/'
+  dashboard: 'https://lerd.sh/getting-started/requirements'
 };
 
 // PROFILER_REF is the synthetic entry for the SPX profiler. The UI is proxied


### PR DESCRIPTION
The docs icon in the left navigation rail opened the overlay at https://lerd.sh/, which is the marketing landing page rather than the documentation. lerd.sh is a VitePress site whose actual docs pages live under /getting-started and other sections, so clicking the docs icon dropped people on the hero page instead of anything readable.

This repoints the docs overlay at https://lerd.sh/getting-started/requirements, the first page in the getting-started section, so the icon lands on real documentation.