### PR TITLE
fix(mcp): bound podman hot-path calls and self-heal a stalled machine

### DIFF
--- a/internal/cli/machineheal_wire_darwin.go
+++ b/internal/cli/machineheal_wire_darwin.go
@@ -1,0 +1,10 @@
+//go:build darwin
+
+package cli
+
+import "github.com/geodro/lerd/internal/podman"
+
+// Wire the MCP/exec hot-path self-heal to the same machine restart the service
+// start pass uses. On a post-sleep stall, podman.EnsureMachineResponsive calls
+// this to stop+restart the VM and wait for its API socket, then retries once.
+func init() { podman.MachineHeal = restartPodmanMachineForHeal }

--- a/internal/php/fpm_start.go
+++ b/internal/php/fpm_start.go
@@ -29,6 +29,12 @@ func FPMInstalled(version, container string) bool {
 // callers add any user-facing progress. Shared by the CLI php/artisan/shell
 // commands and the MCP exec handlers so both auto-start the same way.
 func StartFPM(version, container string) error {
+	// Gate on a bounded machine probe so a post-sleep stall surfaces (and self-
+	// heals) fast instead of hanging the caller on the untimed inspect below.
+	// Once this passes the VM is responsive, so the exec that follows won't hang.
+	if err := podman.EnsureMachineResponsive(); err != nil {
+		return err
+	}
 	if running, _ := podman.ContainerRunning(container); running {
 		return nil
 	}

--- a/internal/podman/cache.go
+++ b/internal/podman/cache.go
@@ -49,10 +49,20 @@ func (c *ContainerCache) SetOnChange(fn func()) {
 	c.onChangeMu.Unlock()
 }
 
+// pollTimeout bounds the non-started fallback podman calls so a stalled VM
+// (macOS post-sleep) yields a fast empty snapshot instead of hanging the caller.
+const pollTimeout = 10 * time.Second
+
 func defaultPollFn() (string, error) {
-	return Run("ps", "-a",
+	ctx, cancel := context.WithTimeout(context.Background(), pollTimeout)
+	defer cancel()
+	out, err := CmdContext(ctx, "ps", "-a",
 		"--filter", "name=lerd-",
-		"--format", "{{.Names}}\t{{.State}}")
+		"--format", "{{.Names}}\t{{.State}}").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 // Cache is the process-wide container state store. Start it once from serve-ui;
@@ -84,10 +94,21 @@ func (c *ContainerCache) Running(name string) bool {
 	c.mu.RUnlock()
 
 	if !started {
-		running, _ := ContainerRunning(name)
-		return running
+		return containerRunningBounded(name)
 	}
 	return v
+}
+
+// containerRunningBounded is the non-started fallback's container check, bounded
+// by pollTimeout so a stalled VM returns fast (false) instead of hanging.
+func containerRunningBounded(name string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), pollTimeout)
+	defer cancel()
+	out, err := CmdContext(ctx, "inspect", "--format={{.State.Running}}", name).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
 }
 
 // Snapshot returns a copy of the cached container map. When the cache has not

--- a/internal/podman/machineheal.go
+++ b/internal/podman/machineheal.go
@@ -29,10 +29,13 @@ var (
 // stall it heals once (cooldown-guarded) and re-probes, turning a post-sleep
 // freeze into a self-healed retry or a fast error instead of an unbounded hang.
 func EnsureMachineResponsive() error {
+	if MachineHeal == nil {
+		return nil // no machine VM to stall or heal (Linux, tests): skip the probe
+	}
 	if machineResponds() {
 		return nil
 	}
-	if MachineHeal == nil || !healOnceWithinCooldown() {
+	if !healOnceWithinCooldown() {
 		return fmt.Errorf("podman machine is not responding (try: lerd start)")
 	}
 	if machineResponds() {
@@ -45,9 +48,6 @@ func EnsureMachineResponsive() error {
 // returning whether a heal actually ran. Guards against stop-start loops when
 // the machine stays dead across successive calls.
 func healOnceWithinCooldown() bool {
-	if MachineHeal == nil {
-		return false
-	}
 	healMu.Lock()
 	if !lastHealAt.IsZero() && time.Since(lastHealAt) < healCooldown {
 		healMu.Unlock()

--- a/internal/podman/machineheal.go
+++ b/internal/podman/machineheal.go
@@ -1,0 +1,73 @@
+package podman
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// MachineHeal recovers a stalled Podman Machine (e.g. macOS post-sleep, when the
+// VM and its gvproxy networking are suspended and every podman call blocks
+// forever). Wired by the darwin CLI to restartPodmanMachineForHeal; nil on
+// Linux and in tests, where there is no machine VM to restart.
+var MachineHeal func()
+
+// machineProbeTimeout bounds the "is the VM responsive" probe. A healthy machine
+// answers `podman ps -q` in well under a second, so this only fires on a stall.
+const machineProbeTimeout = 10 * time.Second
+
+// healCooldown suppresses repeated stop/start cycles when the machine is
+// genuinely dead, so a burst of MCP calls does not stop-start it in a loop.
+const healCooldown = 2 * time.Minute
+
+var (
+	healMu     sync.Mutex
+	lastHealAt time.Time
+)
+
+// EnsureMachineResponsive verifies the Podman Machine answers a cheap query
+// within a timeout before an MCP handler shells out for real. On a stall it
+// heals the VM once (subject to a cooldown) and re-probes, turning a post-sleep
+// freeze into a self-healed retry or, if the machine is truly dead, a fast
+// surfaced error instead of an unbounded hang. Fast no-op on a healthy machine
+// and on Linux (no machine VM, MachineHeal nil).
+func EnsureMachineResponsive() error {
+	if machineResponds() {
+		return nil
+	}
+	if MachineHeal == nil || !healOnceWithinCooldown() {
+		return fmt.Errorf("podman machine is not responding (try: lerd start)")
+	}
+	if machineResponds() {
+		return nil
+	}
+	return fmt.Errorf("podman machine did not recover after a restart (try: lerd machine reset)")
+}
+
+// healOnceWithinCooldown runs MachineHeal unless one ran within healCooldown,
+// returning whether a heal actually ran. Guards against stop-start loops when
+// the machine stays dead across successive calls.
+func healOnceWithinCooldown() bool {
+	if MachineHeal == nil {
+		return false
+	}
+	healMu.Lock()
+	if !lastHealAt.IsZero() && time.Since(lastHealAt) < healCooldown {
+		healMu.Unlock()
+		return false
+	}
+	lastHealAt = time.Now()
+	healMu.Unlock()
+	MachineHeal()
+	return true
+}
+
+// machineResponds reports whether `podman ps -q` returns within the probe
+// timeout. Any failure (deadline, dead socket, missing machine) counts as
+// unresponsive, which is exactly when a heal is warranted.
+func machineResponds() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), machineProbeTimeout)
+	defer cancel()
+	return CmdContext(ctx, "ps", "-q").Run() == nil
+}

--- a/internal/podman/machineheal.go
+++ b/internal/podman/machineheal.go
@@ -7,9 +7,8 @@ import (
 	"time"
 )
 
-// MachineHeal recovers a stalled Podman Machine (e.g. macOS post-sleep, when the
-// VM and its gvproxy networking are suspended and every podman call blocks
-// forever). Wired by the darwin CLI to restartPodmanMachineForHeal; nil on
+// MachineHeal recovers a stalled Podman Machine (macOS post-sleep: VM+gvproxy
+// suspended, so podman calls block forever). Wired by the darwin CLI; nil on
 // Linux and in tests, where there is no machine VM to restart.
 var MachineHeal func()
 
@@ -26,12 +25,9 @@ var (
 	lastHealAt time.Time
 )
 
-// EnsureMachineResponsive verifies the Podman Machine answers a cheap query
-// within a timeout before an MCP handler shells out for real. On a stall it
-// heals the VM once (subject to a cooldown) and re-probes, turning a post-sleep
-// freeze into a self-healed retry or, if the machine is truly dead, a fast
-// surfaced error instead of an unbounded hang. Fast no-op on a healthy machine
-// and on Linux (no machine VM, MachineHeal nil).
+// EnsureMachineResponsive probes the VM before an MCP handler shells out. On a
+// stall it heals once (cooldown-guarded) and re-probes, turning a post-sleep
+// freeze into a self-healed retry or a fast error instead of an unbounded hang.
 func EnsureMachineResponsive() error {
 	if machineResponds() {
 		return nil

--- a/internal/podman/machineheal_test.go
+++ b/internal/podman/machineheal_test.go
@@ -106,12 +106,16 @@ func TestEnsureMachineResponsiveCooldownBlocksSecondHeal(t *testing.T) {
 	}
 }
 
-func TestEnsureMachineResponsiveNoHealHookErrors(t *testing.T) {
+func TestEnsureMachineResponsiveNoHealHookIsNoop(t *testing.T) {
 	resetHealState(t)
-	execCommandContext = fakeExecContextExit(func() int { return 1 })
-	MachineHeal = nil
+	probed := 0
+	execCommandContext = fakeExecContextExit(func() int { probed++; return 1 })
+	MachineHeal = nil // Linux: no machine VM
 
-	if err := EnsureMachineResponsive(); err == nil {
-		t.Fatal("no heal hook (Linux): want error, got nil")
+	if err := EnsureMachineResponsive(); err != nil {
+		t.Fatalf("no heal hook (Linux): want nil no-op, got %v", err)
+	}
+	if probed != 0 {
+		t.Errorf("no heal hook must skip the probe, probed %d times", probed)
 	}
 }

--- a/internal/podman/machineheal_test.go
+++ b/internal/podman/machineheal_test.go
@@ -1,0 +1,117 @@
+package podman
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// fakeExecContextExit returns an execCommandContext drop-in whose child exits
+// with exitFn()'s code each call, so probe responsiveness can be toggled over
+// successive calls without a real podman.
+func fakeExecContextExit(exitFn func() int) func(context.Context, string, ...string) *exec.Cmd {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cs := append([]string{"-test.run=TestHelperProcess", "--", name}, args...)
+		cmd := exec.CommandContext(ctx, os.Args[0], cs...)
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_HELPER_PROCESS=1",
+			"HELPER_EXIT="+strconv.Itoa(exitFn()),
+		)
+		return cmd
+	}
+}
+
+// resetHealState restores the package heal globals so tests don't leak into
+// each other through lastHealAt / MachineHeal / execCommandContext.
+func resetHealState(t *testing.T) {
+	t.Helper()
+	prevCtx := execCommandContext
+	prevHeal := MachineHeal
+	t.Cleanup(func() {
+		execCommandContext = prevCtx
+		MachineHeal = prevHeal
+		healMu.Lock()
+		lastHealAt = time.Time{}
+		healMu.Unlock()
+	})
+	healMu.Lock()
+	lastHealAt = time.Time{}
+	healMu.Unlock()
+}
+
+func TestEnsureMachineResponsiveHealthy(t *testing.T) {
+	resetHealState(t)
+	execCommandContext = fakeExecContextExit(func() int { return 0 })
+	healed := 0
+	MachineHeal = func() { healed++ }
+
+	if err := EnsureMachineResponsive(); err != nil {
+		t.Fatalf("healthy machine: got error %v", err)
+	}
+	if healed != 0 {
+		t.Errorf("healthy machine healed %d times, want 0", healed)
+	}
+}
+
+func TestEnsureMachineResponsiveHealsThenRecovers(t *testing.T) {
+	resetHealState(t)
+	// First probe fails; the heal "fixes" it so the second probe succeeds.
+	stalled := true
+	execCommandContext = fakeExecContextExit(func() int {
+		if stalled {
+			return 1
+		}
+		return 0
+	})
+	healed := 0
+	MachineHeal = func() { healed++; stalled = false }
+
+	if err := EnsureMachineResponsive(); err != nil {
+		t.Fatalf("post-heal recovery: got error %v", err)
+	}
+	if healed != 1 {
+		t.Errorf("healed %d times, want 1", healed)
+	}
+}
+
+func TestEnsureMachineResponsiveDeadMachineErrors(t *testing.T) {
+	resetHealState(t)
+	execCommandContext = fakeExecContextExit(func() int { return 1 })
+	healed := 0
+	MachineHeal = func() { healed++ } // heal doesn't fix it
+
+	if err := EnsureMachineResponsive(); err == nil {
+		t.Fatal("dead machine: want error, got nil")
+	}
+	if healed != 1 {
+		t.Errorf("healed %d times, want 1 (retry-once)", healed)
+	}
+}
+
+func TestEnsureMachineResponsiveCooldownBlocksSecondHeal(t *testing.T) {
+	resetHealState(t)
+	execCommandContext = fakeExecContextExit(func() int { return 1 })
+	healed := 0
+	MachineHeal = func() { healed++ }
+
+	_ = EnsureMachineResponsive() // heals once, still dead
+	if err := EnsureMachineResponsive(); err == nil {
+		t.Fatal("second call: want error, got nil")
+	}
+	if healed != 1 {
+		t.Errorf("healed %d times across two calls, want 1 (cooldown)", healed)
+	}
+}
+
+func TestEnsureMachineResponsiveNoHealHookErrors(t *testing.T) {
+	resetHealState(t)
+	execCommandContext = fakeExecContextExit(func() int { return 1 })
+	MachineHeal = nil
+
+	if err := EnsureMachineResponsive(); err == nil {
+		t.Fatal("no heal hook (Linux): want error, got nil")
+	}
+}

--- a/internal/watcher/dns.go
+++ b/internal/watcher/dns.go
@@ -41,6 +41,10 @@ type dnsWatchDeps struct {
 	// until a manual lerd restart. Both nil off the Linux rootless-podman path.
 	nginxHealthy func() bool
 	repairNginx  func() error
+	// healMachine restarts the shared podman machine VM if a host suspend left it
+	// stalled, healing the MCP/exec path on wake before the next call. macOS only
+	// (nil elsewhere: Linux has no machine VM).
+	healMachine func()
 	// isStopped reports an intentional `lerd stop`, after which the watcher must
 	// not restart anything the user stopped on purpose. now is the clock (a seam
 	// for tests) used to detect a resume from the wall-clock gap between ticks.
@@ -179,6 +183,29 @@ func publishOnTransition(cur **bool, next bool, pub func()) {
 // If the watcher isn't running at the moment of resume (e.g. it restarted during
 // the outage), that resume is missed and the user falls back to `lerd start`; a
 // rare edge, far better than a continuous poll that fights every bring-up.
+// defaultHealMachine un-stalls the podman machine VM after a host resume, so the
+// MCP/exec path recovers proactively before the next agent call. It reuses the
+// reactive probe+heal (podman.EnsureMachineResponsive) so both share one
+// cooldown and it only restarts the VM when a bounded probe actually fails.
+func defaultHealMachine() {
+	if err := podman.EnsureMachineResponsive(); err != nil {
+		logger.Warn("podman machine heal after resume failed", "err", err)
+	}
+}
+
+// healMachineOnResume restarts the podman machine VM on the tick that detected a
+// resume, mirroring healNginxOnResume. No-op when healMachine is unset (Linux,
+// tests) or the stack was intentionally stopped.
+func healMachineOnResume(d dnsWatchDeps) {
+	if d.healMachine == nil {
+		return
+	}
+	if d.isStopped != nil && d.isStopped() {
+		return
+	}
+	d.healMachine()
+}
+
 func healNginxOnResume(d dnsWatchDeps) {
 	if d.nginxHealthy == nil {
 		return
@@ -323,6 +350,14 @@ func WatchDNS(interval time.Duration, tld string) {
 		// lerd restart (issue #665). DNS resolution is already repaired below.
 		deps.nginxHealthy = defaultNginxHealthy
 		deps.repairNginx = defaultRepairNginx
+		deps.isStopped = config.IsStopped
+	}
+
+	// A host suspend can stall the shared podman machine VM (issue #715); the
+	// resume tick restarts it so the MCP/exec path is healed before the next
+	// agent call. isStopped keeps a deliberate `lerd stop` from resurrecting it.
+	if runtime.GOOS == "darwin" {
+		deps.healMachine = defaultHealMachine
 		deps.isStopped = config.IsStopped
 	}
 
@@ -473,9 +508,11 @@ func tickDNS(d dnsWatchDeps, s *dnsWatchState, tld string, linkTriggered bool) {
 		s.dnsEnvSeen = true
 	}
 
-	// Recover nginx after a resume, once the container DNS above has re-synced the
-	// network it will rebind onto.
+	// Recover after a resume: on macOS un-stall the podman machine VM first (the
+	// shared VM everything runs in), then on Linux rebind nginx's host forward
+	// once the container DNS above has re-synced the network.
 	if resumed {
+		healMachineOnResume(d)
 		healNginxOnResume(d)
 	}
 

--- a/internal/watcher/dns_test.go
+++ b/internal/watcher/dns_test.go
@@ -817,6 +817,55 @@ func TestTickDNS_resumeTriggersNginxHeal(t *testing.T) {
 	}
 }
 
+// TestTickDNS_resumeTriggersMachineHeal: the podman machine VM is healed only on
+// the tick that detects a resume, never on the first or a normal-cadence tick.
+func TestTickDNS_resumeTriggersMachineHeal(t *testing.T) {
+	c := &fakeClock{t: time.Unix(1_000_000, 0)}
+	heals := 0
+	deps := dnsWatchDeps{
+		check:         func(string) (bool, error) { return true, nil },
+		idleOrLocked:  func() bool { return false },
+		publishStatus: func() {},
+		now:           c.now,
+		monoSince:     c.since,
+		healMachine:   func() { heals++ },
+		log:           func(string, string, ...any) {},
+	}
+	s := &dnsWatchState{}
+
+	tickDNS(deps, s, "test", false) // first tick: not a resume
+	c.advance(30 * time.Second)
+	tickDNS(deps, s, "test", false) // normal gap: not a resume
+	if heals != 0 {
+		t.Fatalf("non-resume ticks must not heal the machine, got %d", heals)
+	}
+
+	c.suspend(2 * time.Hour)
+	tickDNS(deps, s, "test", false) // suspend gap: resume -> heal
+	if heals != 1 {
+		t.Fatalf("resume must heal the machine once, got %d", heals)
+	}
+}
+
+// TestHealMachineOnResume: heals when set, no-ops on an unset hook or a
+// deliberately stopped stack.
+func TestHealMachineOnResume(t *testing.T) {
+	heals := 0
+	d := dnsWatchDeps{healMachine: func() { heals++ }}
+	healMachineOnResume(d)
+	if heals != 1 {
+		t.Fatalf("resume must heal, got %d", heals)
+	}
+
+	d.isStopped = func() bool { return true }
+	healMachineOnResume(d)
+	if heals != 1 {
+		t.Fatalf("stopped stack must not heal, got %d", heals)
+	}
+
+	healMachineOnResume(dnsWatchDeps{}) // nil hook: no panic, no-op
+}
+
 // TestTickDNS_resumeHealsEvenWhenIdle: an idle/locked poll tick backs off the DNS
 // probe, but a detected resume must still heal nginx.
 func TestTickDNS_resumeHealsEvenWhenIdle(t *testing.T) {


### PR DESCRIPTION
## Problem

On macOS, when the host sleeps and wakes, the podman machine VM and its gvproxy networking are left suspended. The MCP server is a single-threaded stdio loop that runs each request to completion with no per-call timeout, and every core handler shells out to podman through the untimed `exec.Command` seam. So after a wake the first `podman exec`/`inspect` on the request path blocks forever, the serve loop never advances, and lerd goes unresponsive to the agent driving it.

The activity/idle-suspend path and the Linux-only battery optimisations are not involved here; the cause is purely the untimed podman shell-out on the request path.

## Fix

**Piece 1: bound the hot path.**
- New `podman.EnsureMachineResponsive` runs a bounded `podman ps -q` probe (10s) before an MCP handler shells out for real, and gates `StartFPM` (the first podman call on both `exec:artisan` and `exec:composer`). A healthy machine answers in well under a second, so this only fires on a real stall. Once it passes the VM is responsive, so the artisan/composer exec that follows won't hang, and legitimately slow commands (composer install, migrations) keep no artificial timeout.
- The `ContainerCache` non-started fallback (`defaultPollFn` and the `Running` check) is now bounded too, so status reads surface a fast empty snapshot instead of hanging.

**Piece 2: self-heal the stall.**
- On a failed probe, `EnsureMachineResponsive` restarts the machine once and re-probes, so a post-sleep freeze becomes a self-healed retry, or a fast surfaced error if the VM is truly dead. It carries a cooldown so a burst of calls against a genuinely dead machine doesn't stop-start it in a loop.
- The darwin heal is wired to the existing `restartPodmanMachineForHeal` (stop + `ensurePodmanMachineRunning`, the same recovery the service start pass uses). `MachineHeal` is nil on Linux, where there is no machine VM. Its feedback lands on stderr under the MCP server's existing `guardStdout`, so it never corrupts the JSON-RPC stream.

**Piece 3: proactive heal on resume.**
- The DNS watcher's resume tick (the existing wall-clock-vs-monotonic gap detection) also un-stalls the machine on macOS: `healMachineOnResume` → `defaultHealMachine` → the same `podman.EnsureMachineResponsive`, so the MCP/exec path is recovered before the next agent call rather than on it. Reusing the reactive probe+heal means both share one cooldown, and it only restarts the VM when the bounded probe actually fails, so it doesn't spin the VM on every laptop open. It's guarded by `isStopped`, so a deliberate `lerd stop` is never resurrected, and it's macOS-only (nil elsewhere).

## Tests

- `internal/podman/machineheal_test.go` covers healthy (no heal), stall→heal→recover, dead-machine retry-once error, cooldown blocks the second heal, and the nil-hook (Linux) path.
- `internal/watcher/dns_test.go` covers healing the machine only on the tick that detects a resume, never on the first or a normal-cadence tick.

All `internal/podman` + `internal/php` + `internal/watcher` tests pass.

Closes #715