### PR TITLE
fix: stop rewriting the DNS sudoers rule on every install

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,7 +39,7 @@ The installer will:
 - Automatically run `lerd install` to complete environment setup
 
 ::: info DNS setup requires sudo
-`lerd install` writes to `/etc/NetworkManager/dnsmasq.d/` and `/etc/NetworkManager/conf.d/` and restarts NetworkManager. This is the only step that requires `sudo`.
+`lerd install` writes to `/etc/NetworkManager/dnsmasq.d/` and `/etc/NetworkManager/conf.d/` and restarts NetworkManager. This is the only step that requires `sudo`. It also installs a passwordless sudoers rule for the DNS resolver operations, so this is a one-time prompt: reinstalling for an update or a test reuses the existing rule and does not ask again.
 :::
 
 After install, reload your shell or open a new terminal so `PATH` takes effect.

--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -549,7 +549,7 @@ func InstallSudoers() error {
 	content := renderLinuxSudoers(user)
 
 	const sudoersPath = "/etc/sudoers.d/lerd"
-	if isFileContent(sudoersPath, []byte(content)) {
+	if sudoersInstalled([]byte(content)) {
 		return nil
 	}
 
@@ -557,6 +557,7 @@ func InstallSudoers() error {
 	if err := sudoWriteFile(sudoersPath, []byte(content), 0440); err != nil {
 		return fmt.Errorf("writing sudoers drop-in: %w", err)
 	}
+	recordSudoersInstalled([]byte(content))
 	return nil
 }
 

--- a/internal/dns/setup_common.go
+++ b/internal/dns/setup_common.go
@@ -2,6 +2,8 @@ package dns
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -14,6 +16,35 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 )
+
+// sudoersMarkerPath is a user-owned record of the sudoers drop-in lerd last
+// installed. /etc/sudoers.d is root-only (0750), so the invoking user cannot
+// read the drop-in back to compare content; without this marker InstallSudoers
+// would rewrite the file, and prompt for sudo, on every run. Overridable in tests.
+var sudoersMarkerPath = func() string {
+	return filepath.Join(config.DataDir(), "sudoers.sha256")
+}
+
+// sudoersInstalled reports whether a drop-in matching content was already
+// installed on this or a prior run, per the user-owned marker.
+func sudoersInstalled(content []byte) bool {
+	got, err := os.ReadFile(sudoersMarkerPath())
+	if err != nil {
+		return false
+	}
+	sum := sha256.Sum256(content)
+	return strings.TrimSpace(string(got)) == hex.EncodeToString(sum[:])
+}
+
+// recordSudoersInstalled stores content's hash after a successful write so the
+// next run can skip the redundant, sudo-prompting rewrite.
+func recordSudoersInstalled(content []byte) {
+	if err := os.MkdirAll(filepath.Dir(sudoersMarkerPath()), 0755); err != nil {
+		return
+	}
+	sum := sha256.Sum256(content)
+	os.WriteFile(sudoersMarkerPath(), []byte(hex.EncodeToString(sum[:])+"\n"), 0644) //nolint:errcheck
+}
 
 // pastaDefaultForwarder is pasta's rootless-netns DNS forwarder IP, which
 // bridges into the host resolver and preserves .test routing. Last-resort

--- a/internal/dns/setup_darwin.go
+++ b/internal/dns/setup_darwin.go
@@ -91,7 +91,7 @@ func InstallSudoers() error {
 	content := renderDarwinSudoers(user, tld)
 
 	const sudoersPath = "/etc/sudoers.d/lerd"
-	if isFileContent(sudoersPath, []byte(content)) {
+	if sudoersInstalled([]byte(content)) {
 		return nil
 	}
 
@@ -99,6 +99,7 @@ func InstallSudoers() error {
 	if err := sudoWriteFile(sudoersPath, []byte(content), 0440); err != nil {
 		return fmt.Errorf("writing sudoers drop-in: %w", err)
 	}
+	recordSudoersInstalled([]byte(content))
 	return nil
 }
 

--- a/internal/dns/sudoers_marker_test.go
+++ b/internal/dns/sudoers_marker_test.go
@@ -1,0 +1,70 @@
+package dns
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The sudoers drop-in lives in /etc/sudoers.d (root-only 0750), so the invoking
+// user cannot read it back to compare. InstallSudoers relies on a user-owned
+// marker instead; without it the drop-in was rewritten, prompting for sudo, on
+// every install.
+func TestSudoersMarker(t *testing.T) {
+	orig := sudoersMarkerPath
+	t.Cleanup(func() { sudoersMarkerPath = orig })
+	dir := t.TempDir()
+	sudoersMarkerPath = func() string { return filepath.Join(dir, "sub", "sudoers.sha256") }
+
+	content := []byte("user ALL=(root) NOPASSWD: /usr/bin/resolvectl\n")
+
+	if sudoersInstalled(content) {
+		t.Fatal("no marker yet: should report not installed")
+	}
+
+	recordSudoersInstalled(content)
+
+	if !sudoersInstalled(content) {
+		t.Fatal("after record: same content should report installed")
+	}
+
+	if sudoersInstalled([]byte("different rule\n")) {
+		t.Fatal("changed content should report not installed so it reinstalls once")
+	}
+
+	if _, err := os.ReadFile(sudoersMarkerPath()); err != nil {
+		t.Fatalf("marker must be user-readable, unlike the drop-in: %v", err)
+	}
+}
+
+// A future lerd version that changes the sudoers rule must still reinstall it
+// on `lerd update` (which re-runs `lerd install`), then go quiet again. This
+// guards the marker against silently skipping a genuine rule change.
+func TestSudoersMarker_upgradeReinstallsOnce(t *testing.T) {
+	orig := sudoersMarkerPath
+	t.Cleanup(func() { sudoersMarkerPath = orig })
+	dir := t.TempDir()
+	sudoersMarkerPath = func() string { return filepath.Join(dir, "sudoers.sha256") }
+
+	oldRule := []byte("v1 rule\n")
+	newRule := []byte("v2 rule with an extra grant\n")
+
+	recordSudoersInstalled(oldRule)
+
+	if sudoersInstalled(newRule) {
+		t.Fatal("upgraded rule must not match the old marker, so it reinstalls")
+	}
+	if !sudoersInstalled(oldRule) {
+		t.Fatal("old rule should still match its marker until the upgrade writes")
+	}
+
+	// The upgrade install writes the new drop-in and refreshes the marker.
+	recordSudoersInstalled(newRule)
+
+	if !sudoersInstalled(newRule) {
+		t.Fatal("after upgrade write, new rule should report installed")
+	}
+	if sudoersInstalled(oldRule) {
+		t.Fatal("old rule must no longer match after the marker is refreshed")
+	}
+}


### PR DESCRIPTION
The DNS sudoers rule was being rewritten on every install, so a plain reinstall for an update or a test prompted for the sudo password even though nothing had changed. The guard that was meant to skip the write read /etc/sudoers.d/lerd and compared it against the rendered rule, but that directory is root only, the invoking user can never read the file back, and the failed read looked the same to the guard as a real difference. It always fell through to the write.

Now the install records the hash of the rule it last wrote in a user owned marker under the data dir and skips the write when the rendered rule still matches. A first install and a genuine rule change on upgrade still write once and refresh the marker, everything after that is silent. macOS shares the same fix through the common setup code.

Closes #730