### PR TITLE
feat: skip the mkcert CA announcement when the CA is already trusted

### DIFF
--- a/internal/certs/ca_trust.go
+++ b/internal/certs/ca_trust.go
@@ -1,0 +1,87 @@
+package certs
+
+import (
+	"bytes"
+	"encoding/pem"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// caTrustPaths lists the aggregated system trust bundles searched for the
+// mkcert root CA. These are the files mkcert's `-install` ultimately writes
+// into (via update-ca-certificates / update-ca-trust / trust extract), so a
+// hit here means the CA is already system-trusted and reinstalling would be a
+// no-op that never prompts for sudo. Overridable in tests.
+var caTrustPaths = []string{
+	"/etc/ssl/certs/ca-certificates.crt", // Debian, Ubuntu, Arch, CachyOS
+	"/etc/pki/tls/certs/ca-bundle.crt",   // Fedora, RHEL
+	"/etc/ssl/cert.pem",                  // openSUSE and others
+}
+
+// caRootFunc resolves mkcert's CAROOT directory. Overridable in tests.
+var caRootFunc = func() (string, error) {
+	out, err := exec.Command(MkcertPath(), "-CAROOT").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// CATrusted reports whether mkcert's root CA is already present in the system
+// trust store. Callers use it to skip the sudo announcement (and mkcert's
+// chatty banner) on a reinstall where the CA is already installed.
+func CATrusted() bool {
+	root, err := caRootFunc()
+	if err != nil || root == "" {
+		return false
+	}
+	der := firstCertDER(readFileNoErr(filepath.Join(root, "rootCA.pem")))
+	if der == nil {
+		return false
+	}
+	for _, p := range caTrustPaths {
+		if bundleContainsDER(readFileNoErr(p), der) {
+			return true
+		}
+	}
+	return false
+}
+
+func readFileNoErr(path string) []byte {
+	data, _ := os.ReadFile(path)
+	return data
+}
+
+// firstCertDER returns the DER bytes of the first CERTIFICATE block in pemBytes.
+func firstCertDER(pemBytes []byte) []byte {
+	for len(pemBytes) > 0 {
+		block, rest := pem.Decode(pemBytes)
+		if block == nil {
+			return nil
+		}
+		if block.Type == "CERTIFICATE" {
+			return block.Bytes
+		}
+		pemBytes = rest
+	}
+	return nil
+}
+
+// bundleContainsDER reports whether any CERTIFICATE block in pemBytes matches
+// der. Comparing decoded DER makes the check robust to header comments and
+// whitespace that trust extractors add around the same certificate.
+func bundleContainsDER(pemBytes, der []byte) bool {
+	for len(pemBytes) > 0 {
+		block, rest := pem.Decode(pemBytes)
+		if block == nil {
+			return false
+		}
+		if block.Type == "CERTIFICATE" && bytes.Equal(block.Bytes, der) {
+			return true
+		}
+		pemBytes = rest
+	}
+	return false
+}

--- a/internal/certs/ca_trust_test.go
+++ b/internal/certs/ca_trust_test.go
@@ -1,0 +1,91 @@
+package certs
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeTestCA generates a self-signed cert, writes its PEM to <dir>/rootCA.pem,
+// and returns the PEM bytes so tests can plant it in (or omit it from) a bundle.
+func writeTestCA(t *testing.T, dir string) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "mkcert test CA"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("cert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(filepath.Join(dir, "rootCA.pem"), certPEM, 0644); err != nil {
+		t.Fatalf("write rootCA: %v", err)
+	}
+	return certPEM
+}
+
+func TestCATrusted(t *testing.T) {
+	origRoot, origPaths := caRootFunc, caTrustPaths
+	t.Cleanup(func() { caRootFunc, caTrustPaths = origRoot, origPaths })
+
+	caDir := t.TempDir()
+	certPEM := writeTestCA(t, caDir)
+	caRootFunc = func() (string, error) { return caDir, nil }
+
+	bundleDir := t.TempDir()
+
+	t.Run("present in bundle", func(t *testing.T) {
+		bundle := filepath.Join(bundleDir, "present.crt")
+		body := append([]byte("# some other anchor\n"), certPEM...)
+		if err := os.WriteFile(bundle, body, 0644); err != nil {
+			t.Fatal(err)
+		}
+		caTrustPaths = []string{bundle}
+		if !CATrusted() {
+			t.Fatal("expected CA to be reported as trusted")
+		}
+	})
+
+	t.Run("absent from bundle", func(t *testing.T) {
+		bundle := filepath.Join(bundleDir, "absent.crt")
+		other := writeTestCA(t, t.TempDir()) // a different cert
+		if err := os.WriteFile(bundle, other, 0644); err != nil {
+			t.Fatal(err)
+		}
+		caTrustPaths = []string{bundle}
+		if CATrusted() {
+			t.Fatal("expected CA to be reported as not trusted")
+		}
+	})
+
+	t.Run("no bundle files", func(t *testing.T) {
+		caTrustPaths = []string{filepath.Join(bundleDir, "does-not-exist.crt")}
+		if CATrusted() {
+			t.Fatal("expected not trusted when no bundle is readable")
+		}
+	})
+
+	t.Run("no rootCA", func(t *testing.T) {
+		caRootFunc = func() (string, error) { return t.TempDir(), nil }
+		caTrustPaths = []string{filepath.Join(bundleDir, "present.crt")}
+		if CATrusted() {
+			t.Fatal("expected not trusted when rootCA.pem is missing")
+		}
+	})
+}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -342,12 +342,20 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	dnsChanged := false
 
 	if wantDNS {
-		// 4. mkcert CA, interactive (may prompt for sudo)
-		feedback.Sudo("Installing mkcert CA")
+		// 4. mkcert CA. When the CA is already in the system trust store,
+		// mkcert -install is a silent no-op that never prompts, so skip the
+		// gold sudo header and swallow its "already installed" banner. Only a
+		// genuine first install announces the sudo step and runs interactively.
 		mkcertCmd := exec.Command(certs.MkcertPath(), "-install")
-		mkcertCmd.Stdin = os.Stdin
-		mkcertCmd.Stdout = os.Stdout
-		mkcertCmd.Stderr = os.Stderr
+		if certs.CATrusted() {
+			mkcertCmd.Stdout = io.Discard
+			mkcertCmd.Stderr = io.Discard
+		} else {
+			feedback.Sudo("Installing mkcert CA")
+			mkcertCmd.Stdin = os.Stdin
+			mkcertCmd.Stdout = os.Stdout
+			mkcertCmd.Stderr = os.Stderr
+		}
 		mkcertCmd.Run() //nolint:errcheck
 
 		// 5. DNS config + sudoers


### PR DESCRIPTION
Every install printed a gold "Installing mkcert CA" line and ran `mkcert -install`, even on a reinstall where the local CA was already in the system trust store, where mkcert does nothing and never prompts. The announcement implied a sudo step that was not happening on a repeat install, and mkcert's "already installed" banner spilled into the otherwise clean install output.

Install now checks whether the root CA is already present in the system trust store and only prints the announcement and runs the interactive install when it is not. When the CA is already trusted `mkcert -install` still runs as a silent no-op with its output discarded, so nothing is lost. The detection reads mkcert's own rootCA and looks for it in the aggregated system trust bundles, so it stays distro agnostic.

Closes #732