### PR TITLE
Make lerd cleanup reclaim service and dangling images by default

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -26,11 +26,11 @@
 | `lerd check` | Validate `.lerd.yaml` syntax, services, and PHP version before setup |
 | `lerd doctor` | Full environment diagnostic: podman, systemd, DNS, ports, PHP images, config validity; also reports how much podman disk is reclaimable |
 | `lerd site:doctor [domain]` | App-level health checks for a single site (env file, env drift, application key, a configured SQLite database that is missing or empty, composer/node dependency install + lock, `composer audit`/`npm audit`, PHP version range, routes running well above the site's typical response time, plus the framework's own checks). A broken database suppresses the framework migration check so the remedy isn't repeated. Defaults to the site in the current directory; pass a domain to target another. Add `--json` for machine-readable output |
-| `lerd cleanup` | Reclaim podman disk from orphaned lerd images: old PHP build images and stale base images a rebuild left behind. Previews the list and confirms before removing. Only ever touches lerd's own images, never your databases, volumes, or other images |
+| `lerd cleanup` | Reclaim podman disk from orphaned lerd images (old PHP build and base images a rebuild left behind), unused service images no installed service references any more (e.g. an old `mysql:8.0` after upgrading, keeping each service's current image and its one-back rollback target), and dangling untagged images. Previews the list and confirms before removing. Never touches a tagged image in use, your databases, or volumes |
 | `lerd cleanup --dry-run` | Show what would be reclaimed and the approximate size, remove nothing |
-| `lerd cleanup --deep` | Also remove unused service images no installed service references any more (e.g. an old `mysql:8.0` after upgrading), keeping each service's current image and its one-back rollback target |
+| `lerd cleanup --safe` | Only reclaim images provably built by lerd, leave unused service and dangling images alone |
 | `lerd cleanup --yes` | Remove without the confirmation prompt |
-| `lerd cleanup auto on` | Enable automatic cleanup (the default): the watcher's daily safe-tier sweep plus immediate reaping after a PHP rebuild or service update/remove |
+| `lerd cleanup auto on` | Enable automatic cleanup (the default): the watcher's daily deep sweep plus immediate reaping after a PHP rebuild or service update/remove |
 | `lerd cleanup auto off` | Disable automatic cleanup; `lerd cleanup` still works on demand |
 | `lerd cleanup auto status` | Show whether automatic cleanup is enabled |
 | `lerd bug-report [-o file] [--log-lines n] [--show-real-names]` | Dump doctor output, config files, unit state, recent logs, network state and env vars to a plain-text file you can attach to a GitHub issue. Site names, domains, parked paths, home paths and the username are anonymized by default; `--show-real-names` keeps raw values |

--- a/docs/usage/cleanup.md
+++ b/docs/usage/cleanup.md
@@ -6,33 +6,39 @@ Local PHP development on podman accumulates reclaimable image data. Every PHP im
 
 ## What it removes
 
-**Safe tier** (the default, and what runs automatically):
+By default (and automatically) cleanup reclaims everything below. Pass `--safe` to drop back to the conservative sweep that removes only images provably built by lerd.
+
+**Orphaned lerd images** (always removed, even with `--safe`):
 
 - **Orphaned PHP build images** — the old `lerd-php<ver>-fpm:local` / `lerd-frankenphp<ver>:local` image a rebuild left dangling when it re-pointed the tag.
 - **Orphaned base images** — a pre-built `lerd-php*-fpm-base` image nothing live is built on: an old Containerfile hash, or a PHP version you no longer have installed. Whether a base is still in use is decided by **layer ancestry** (is its top layer part of any live image?), so a base the current PHP image is built on is always kept, never untagged into a needless re-pull.
 
-**Deep tier** (`--deep`, on demand only):
+**Unused service images** (the deep tier, default):
 
-- **Unused service images** — a service image no installed service references any more, e.g. an old `mysql:8.0` after you upgraded to `8.4`. Each service's **current image and its one-back rollback target are kept**, so a rollback still works.
+- A service image no installed service references any more, e.g. an old `mysql:8.0` after you upgraded to `8.4`. Each service's **current image and its one-back rollback target are kept**, so a rollback still works.
+
+**Dangling images** (the deep tier, default):
+
+- Every untagged `<none>` image left behind by repeated rebuilds and re-pulls, including old upstream images that lost their tag when a newer digest was pulled. A dangling image is unreferenced by definition, so removing it frees disk and strands nothing. This is the bulk of what a long-lived install accumulates.
 
 ## What it never touches
 
-- Any image not provably lerd's. An image qualifies only by a `dev.lerd.*` label or the `lerd-php*-fpm-base` repo name (service images are matched against lerd's own preset catalogue). Your own `mysql:8.0` pulled outside lerd, or any unrelated image, is left alone.
-- Named data volumes — your databases are never in scope.
-- Any image a running container uses, and any image still referenced by an installed service.
+- **Named data volumes** — your databases are never in scope.
+- **Any tagged image in use** — an image a running container uses, and each installed service's current image and one-back rollback target, are always kept.
+- With **`--safe`**, only images provably built by lerd (a `dev.lerd.*` label or the `lerd-php*-fpm-base` repo name) are removed, and nothing else is touched at all.
 
-Removal is reference-count safe: layers an image still shares with a live image stay on disk, and an image that turns out to be in use is skipped rather than forced.
+The default reaches further than `--safe` in one place: it also removes **dangling** (untagged) images. That is deliberately safe, a dangling image is unreferenced by definition, so nothing depends on it. On a machine that also runs podman for non-lerd projects, that means the default reclaims their untagged leftovers too; use `--safe` there if you want cleanup scoped strictly to lerd. Removal is reference-count safe throughout: shared layers stay on disk, and an image that turns out to be in use is skipped rather than forced.
 
 ## Commands
 
 ```bash
-lerd cleanup              # preview, confirm, then reclaim the safe tier
+lerd cleanup              # preview, confirm, then reclaim orphaned lerd, unused service, and dangling images
 lerd cleanup --dry-run    # show what would be reclaimed and the size, remove nothing
-lerd cleanup --deep       # also reclaim unused service images (keeps current + rollback)
+lerd cleanup --safe       # only reclaim images provably built by lerd, keep unused service and dangling images
 lerd cleanup --yes        # skip the confirmation prompt (for scripts)
 ```
 
-Reported sizes are the disk actually freed (an image's unique layers, not its full size), so the figure is honest even when images share base layers. `lerd doctor` shows the reclaimable total as a read-only line so you discover the bloat early.
+Reported sizes are an estimate of the disk each removal frees. An image a live image is still built on is never listed (removing it is impossible and would free nothing), so cleanup never promises space it can't reclaim, though images that share layers with each other can add up to less than their sizes suggest. `lerd doctor` shows the reclaimable total as a read-only line so you discover the bloat early.
 
 The destructive command is CLI-only by design, consistent with keeping destructive operations out of the dashboard and TUI.
 
@@ -41,9 +47,9 @@ The destructive command is CLI-only by design, consistent with keeping destructi
 Cleanup is on by default and safe, so the disk doesn't grow on its own:
 
 - **On rebuild / service change** — a PHP rebuild (`lerd use`, `lerd php:rebuild`, `lerd php:ext`/`php:pkg`, a `lerd update` that bumps the Containerfile) reclaims the image it just superseded immediately. A `lerd service update` or `lerd service remove` reclaims that service's now-unused versions, scoped to that one service.
-- **Daily backstop** — the `lerd-watcher` runs a safe-tier sweep about once a day (throttled by a timestamp so a restarting watcher can't sweep more often), catching anything an interrupted operation left behind.
+- **Daily backstop** — the `lerd-watcher` runs a deep sweep about once a day (throttled by a timestamp so a restarting watcher can't sweep more often), catching anything an interrupted operation left behind, old service versions that fell out of the one-back rollback window, and accumulated dangling images. It keeps every tagged image in use (the current image and the rollback target), and dangling images it removes are unreferenced by definition, so it stays safe unattended.
 
-The automatic path only ever runs the **safe tier**, never `--deep`. Toggle it with `lerd cleanup auto on` / `lerd cleanup auto off` (or set `auto_cleanup` in [`~/.config/lerd/config.yaml`](../configuration.md)); `lerd cleanup auto status` shows the current state. When off, `lerd cleanup` stays available on demand.
+Toggle automatic cleanup with `lerd cleanup auto on` / `lerd cleanup auto off` (or set `auto_cleanup` in [`~/.config/lerd/config.yaml`](../configuration.md)); `lerd cleanup auto status` shows the current state. When off, `lerd cleanup` stays available on demand.
 
 ```bash
 lerd cleanup auto off       # disable the automatic sweep and event-driven reaping

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -1,8 +1,10 @@
-// Package cleanup reclaims podman disk that lerd itself created — the orphaned
-// PHP/FrankenPHP images that rebuilds leave behind — and nothing else. An image
-// is only ever eligible when it is provably lerd's: a dev.lerd.* label, or the
-// lerd-php*-fpm-base repo name only lerd's pre-built base images use. So it can
-// never touch images, containers, or volumes belonging to anything else.
+// Package cleanup reclaims podman disk lerd's own image rebuilds leave behind.
+// The safe tier only ever removes what is provably lerd's: an image with a
+// dev.lerd.* label, or the lerd-php*-fpm-base repo name only lerd's pre-built
+// base images use. The deep tier additionally reaps every dangling image, which
+// is untagged and unreferenced by definition so removing it strands nothing, and
+// catalog service images no service references any more. Neither tier ever
+// touches a tagged image in use, a container, or a named volume.
 package cleanup
 
 import (
@@ -35,6 +37,16 @@ type Target struct {
 // Plan is the set of lerd-owned resources that are safe to reclaim.
 type Plan struct {
 	Targets []Target
+	// Held counts dangling images a running container still holds that would
+	// otherwise be reaped. They can't be removed now, but a restart recreates the
+	// container on the current image and releases them, so the caller can hint it.
+	Held HeldByContainers
+}
+
+// HeldByContainers tallies reclaimable disk a restart would free.
+type HeldByContainers struct {
+	Count int
+	Bytes int64
 }
 
 // ReclaimBytes is the total disk the plan would free.
@@ -56,7 +68,15 @@ type image struct {
 	Size       int64             `json:"Size"`
 	SharedSize int64             `json:"SharedSize"`
 	Labels     map[string]string `json:"Labels"`
+	// Containers is how many containers still reference this image. Any non-zero
+	// count means podman refuses to remove it, so it must never be listed.
+	Containers int `json:"Containers"`
 }
+
+// inUse reports whether a container still holds the image, which makes it
+// unremovable: podman errors "image is in use by a container". Listing such an
+// image would show it as reclaimable forever while freeing nothing.
+func inUse(img image) bool { return img.Containers > 0 }
 
 // reclaimable is the disk removing img would actually free: its layers that no
 // other image shares. Never negative.
@@ -111,8 +131,8 @@ func podmanImageLayers(ids []string) (map[string][]string, error) {
 	return m, nil
 }
 
-// Inspect returns the safe-tier cleanup plan. It reclaims two kinds of lerd
-// image a rebuild leaves behind:
+// Inspect returns the cleanup plan. The always-safe tier reclaims what is
+// provably lerd's:
 //   - derived images lerd built and then orphaned: lerd tags every live build
 //     with a fixed :local tag, so a rebuild re-points the tag and leaves the old
 //     image dangling — the unambiguous "superseded" signal.
@@ -121,9 +141,12 @@ func podmanImageLayers(ids []string) (map[string][]string, error) {
 //
 // Both removals are refcount-safe: layers a live image still shares are kept.
 //
-// When deep is true it also reclaims the more aggressive tier: catalog service
-// images no service references any more (see deepTargets). If the protected set
-// can't be built, the deep tier is skipped rather than risk a wrong removal.
+// When deep is true it also reclaims the aggressive tier: every remaining
+// dangling image (untagged and unreferenced, so removing it strands nothing),
+// plus catalog service images no service references any more (see deepTargets).
+// An image a container still holds is skipped everywhere, since podman can't
+// remove it. If the protected set can't be built the service reap is skipped
+// rather than risk a wrong removal.
 func Inspect(deep bool) (Plan, error) {
 	imgs, err := scanImages()
 	if err != nil {
@@ -137,8 +160,23 @@ func Inspect(deep bool) (Plan, error) {
 	var baseCandidates []image
 	for _, img := range imgs {
 		switch {
-		case isLerd(img) && isOrphaned(img):
-			add(shortID(img.ID), describe(img.Labels), reclaimable(img))
+		case inUse(img):
+			// A container still holds this image; podman can't remove it, so skip
+			// it. If it is a dangling image this tier would otherwise reap (an old
+			// build the container hasn't been recreated off yet), tally it so the
+			// caller can hint that a restart would release the space.
+			if isOrphaned(img) && (isLerd(img) || deep) {
+				p.Held.Count++
+				p.Held.Bytes += reclaimable(img)
+			}
+			continue
+		case isOrphaned(img):
+			// A dangling image is untagged and unreferenced, so removing it frees
+			// disk and strands nothing. Provable lerd orphans go in every tier;
+			// other dangling leftovers only when the deep tier is on.
+			if isLerd(img) || deep {
+				add(shortID(img.ID), describeOrphan(img), reclaimable(img))
+			}
 		default:
 			if baseName(img) != "" {
 				baseCandidates = append(baseCandidates, img)
@@ -252,15 +290,29 @@ func podmanRemoveImage(id string) error {
 	return podman.RunSilent("image", "rm", id)
 }
 
-// Apply removes every target in the plan and returns the disk reclaimed. A
-// target that fails to remove (e.g. it became referenced since Inspect) is
-// skipped, so one stuck image can't abort the whole sweep.
+// Apply removes every target in the plan and returns the disk reclaimed. It
+// sweeps in repeated passes, retrying targets that failed until a full pass
+// frees nothing new: podman refuses a parent image while a child is still
+// present, so removing a dangling build chain listed parent-first needs the
+// children gone first. A target that never succeeds (e.g. it became referenced
+// since Inspect) is simply left, so one stuck image can't abort the sweep.
 func Apply(p Plan) (reclaimed int64) {
-	for _, t := range p.Targets {
-		if err := removeImage(t.ID); err != nil {
-			continue
+	remaining := p.Targets
+	for len(remaining) > 0 {
+		var stuck []Target
+		progress := false
+		for _, t := range remaining {
+			if err := removeImage(t.ID); err != nil {
+				stuck = append(stuck, t)
+				continue
+			}
+			reclaimed += t.Bytes
+			progress = true
 		}
-		reclaimed += t.Bytes
+		if !progress {
+			break
+		}
+		remaining = stuck
 	}
 	return reclaimed
 }
@@ -285,6 +337,15 @@ func isOrphaned(img image) bool {
 		}
 	}
 	return true
+}
+
+// describeOrphan names a dangling image for the plan: its lerd build kind when
+// the image is labelled, or a generic dangling leftover otherwise.
+func describeOrphan(img image) string {
+	if isLerd(img) {
+		return describe(img.Labels)
+	}
+	return "dangling image"
 }
 
 // describe names the kind of orphaned derived image for the plan output, by its

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -77,6 +77,74 @@ func TestInspect_NeverTargetsNonLerd(t *testing.T) {
 	}
 }
 
+// The deep tier reaps every dangling image, lerd's own labelled orphans and
+// unlabelled upstream leftovers alike, since a dangling image is unreferenced by
+// definition. The safe tier still keeps non-lerd dangling images (proven by
+// TestInspect_NeverTargetsNonLerd), so the aggressive reap is opt-out via --safe.
+func TestInspect_DeepReapsAllDanglingImages(t *testing.T) {
+	withImages(t, []image{
+		{ID: "sha256:lerd", Names: nil, Size: 100, Labels: map[string]string{"dev.lerd.fpm.containerfile-hash": "h"}}, // lerd orphan
+		{ID: "sha256:mysql", Names: nil, Size: 800}, // old upstream image that lost its tag
+		{ID: "sha256:live", Names: []string{"lerd-php84-fpm:local"}, Size: 200, Labels: map[string]string{"dev.lerd.fpm.containerfile-hash": "h2"}},
+		{ID: "sha256:tag", Names: []string{"mysql:8.4"}, Size: 900}, // tagged, not dangling → keep
+	}, nil)
+	serviceRepos = func() (map[string]bool, error) { return map[string]bool{}, nil }
+	protectedImages = func() (map[string]bool, error) { return map[string]bool{}, nil }
+	t.Cleanup(func() {
+		serviceRepos = realServiceRepos
+		protectedImages = realProtectedImages
+	})
+
+	p, err := Inspect(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, tg := range p.Targets {
+		got[tg.ID] = true
+	}
+	if !got["lerd"] || !got["mysql"] {
+		t.Fatalf("deep tier should reap both the lerd orphan and the untagged upstream image, got %+v", p.Targets)
+	}
+	if got["live"] || got["tag"] {
+		t.Errorf("a tagged image must never be reaped, got %+v", p.Targets)
+	}
+}
+
+// A dangling image a container still holds cannot be removed (podman refuses),
+// so it must be kept out of the plan rather than listed forever as "Freed 0 B".
+func TestInspect_SkipsInUseDanglingImages(t *testing.T) {
+	withImages(t, []image{
+		{ID: "sha256:free", Names: nil, Size: 400},                // no container → reap
+		{ID: "sha256:held", Names: nil, Size: 500, Containers: 1}, // a container holds it → keep
+	}, nil)
+	serviceRepos = func() (map[string]bool, error) { return map[string]bool{}, nil }
+	protectedImages = func() (map[string]bool, error) { return map[string]bool{}, nil }
+	t.Cleanup(func() {
+		serviceRepos = realServiceRepos
+		protectedImages = realProtectedImages
+	})
+
+	p, err := Inspect(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, tg := range p.Targets {
+		got[tg.ID] = true
+	}
+	if got["held"] {
+		t.Error("an image a container holds must be kept (unremovable)")
+	}
+	if !got["free"] {
+		t.Error("a free dangling image should still be reaped")
+	}
+	// The held dangling image is tallied so the caller can hint a restart frees it.
+	if p.Held.Count != 1 || p.Held.Bytes != 500 {
+		t.Errorf("Held = %+v, want {Count:1 Bytes:500}", p.Held)
+	}
+}
+
 // A base image is reaped only when nothing live is built on it — covering both
 // an old Containerfile hash for an installed version and a base for a PHP
 // version no longer installed. The base whose layers the live image shares is
@@ -136,6 +204,30 @@ func TestApply_RemovesTargetsAndSumsReclaimed(t *testing.T) {
 	}
 	if len(removed) != 2 || removed[0] != "aaa" || removed[1] != "bbb" {
 		t.Errorf("removed = %v, want [aaa bbb]", removed)
+	}
+}
+
+// A parent image podman refuses while its child is still present is retried on
+// a later pass once the child is gone, so a single Apply reclaims the whole
+// dangling build chain even when the parent is listed first.
+func TestApply_RetriesUntilDependentsFreed(t *testing.T) {
+	present := map[string]bool{"child": true, "parent": true}
+	removeImage = func(id string) error {
+		if id == "parent" && present["child"] {
+			return errors.New("image has dependent child images")
+		}
+		delete(present, id)
+		return nil
+	}
+	t.Cleanup(func() { removeImage = podmanRemoveImage })
+
+	got := Apply(Plan{Targets: []Target{{ID: "parent", Bytes: 500}, {ID: "child", Bytes: 100}}})
+
+	if got != 600 {
+		t.Errorf("reclaimed = %d, want 600 (both freed across passes)", got)
+	}
+	if present["parent"] {
+		t.Error("parent should be removed once the child is gone")
 	}
 }
 

--- a/internal/cleanup/deep.go
+++ b/internal/cleanup/deep.go
@@ -100,7 +100,10 @@ func deepTargets(imgs []image, repos, protected map[string]bool) []Target {
 // a non-catalog tag the user added both mean "leave this whole image alone", so
 // cleanup never untags an image something else still relies on.
 func removableServiceRefs(img image, repos, protected map[string]bool) []string {
-	if len(img.Names) == 0 {
+	// An image a container still holds can't be removed by podman, so keep it even
+	// when no service config references it (a container running a catalog image the
+	// config no longer names would otherwise be listed forever).
+	if len(img.Names) == 0 || inUse(img) {
 		return nil
 	}
 	refs := make([]string, 0, len(img.Names))

--- a/internal/cleanup/deep_test.go
+++ b/internal/cleanup/deep_test.go
@@ -67,6 +67,22 @@ func TestDeepTargets_MultiTagRemovesAllTagsCreditsOnce(t *testing.T) {
 
 func hasKey(m map[string]int64, k string) bool { _, ok := m[k]; return ok }
 
+// A catalog image a container still holds is kept even when no service config
+// references it: podman can't remove an in-use image, so listing it would just
+// report "Freed 0 B" every run.
+func TestDeepTargets_KeepsInUseServiceImage(t *testing.T) {
+	imgs := []image{
+		{Names: []string{"docker.io/library/redis:7-alpine"}, Size: 40, Containers: 1},
+	}
+	repos := map[string]bool{"docker.io/library/redis": true}
+
+	got := deepTargets(imgs, repos, map[string]bool{})
+
+	if len(got) != 0 {
+		t.Fatalf("an in-use service image must be kept, got %+v", got)
+	}
+}
+
 // The deep tier is additive: the safe tier never touches service images, and
 // only --deep reaps the unused one, leaving the current image alone.
 func TestInspect_DeepAppendsUnusedServiceImages(t *testing.T) {

--- a/internal/cleanup/events.go
+++ b/internal/cleanup/events.go
@@ -12,15 +12,26 @@ func defaultAutoEnabled() bool {
 
 // SweepSafe runs the safe-tier cleanup immediately when auto_cleanup is on. It
 // is the event hook for the moment a PHP image rebuild orphans the old image,
-// reaping it at once instead of waiting for the daily watcher. Returns the
-// number of images reaped and bytes freed; err is non-nil only when the image
-// scan itself failed, so the watcher can tell a transient failure (retry) from
-// "nothing to do" (throttle). All-zero with nil err when disabled or clean.
-func SweepSafe() (images int, bytes int64, err error) {
+// reaping it at once instead of waiting for the daily watcher.
+func SweepSafe() (images int, bytes int64, err error) { return sweep(false) }
+
+// SweepDeep runs the deep tier: the safe-tier orphans plus service catalog
+// images no service references any more. This is the daily watcher's sweep, so
+// old service versions left by an upgrade get reclaimed unattended. Protected
+// images (the current one and the one-back rollback) and user-added tags are
+// always kept, and the deep tier degrades to safe when the preset store can't
+// be read, so the unattended path stays safe.
+func SweepDeep() (images int, bytes int64, err error) { return sweep(true) }
+
+// sweep runs a cleanup tier when auto_cleanup is on. Returns the number of
+// images reaped and bytes freed; err is non-nil only when the image scan itself
+// failed, so the watcher can tell a transient failure (retry) from "nothing to
+// do" (throttle). All-zero with nil err when disabled or clean.
+func sweep(deep bool) (images int, bytes int64, err error) {
 	if !autoEnabled() {
 		return 0, 0, nil
 	}
-	plan, err := Inspect(false)
+	plan, err := Inspect(deep)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/internal/cleanup/events_test.go
+++ b/internal/cleanup/events_test.go
@@ -50,6 +50,56 @@ func TestSweepRefs_GatedOffNoOp(t *testing.T) {
 	}
 }
 
+// SweepDeep runs the deep tier, reaping a service image no service references
+// any more where the safe tier would leave it, and crediting its bytes.
+func TestSweepDeep_ReapsUnusedServiceImages(t *testing.T) {
+	autoEnabled = func() bool { return true }
+	withImages(t, []image{
+		{ID: "m57", Names: []string{"docker.io/library/mysql:5.7"}, Size: 400}, // unused → reap
+		{ID: "m84", Names: []string{"docker.io/library/mysql:8.4"}, Size: 500}, // current → keep
+	}, nil)
+	serviceRepos = func() (map[string]bool, error) {
+		return map[string]bool{"docker.io/library/mysql": true}, nil
+	}
+	protectedImages = func() (map[string]bool, error) {
+		return map[string]bool{"docker.io/library/mysql:8.4": true}, nil
+	}
+	var removed []string
+	removeImage = func(id string) error { removed = append(removed, id); return nil }
+	t.Cleanup(func() {
+		autoEnabled = defaultAutoEnabled
+		serviceRepos = realServiceRepos
+		protectedImages = realProtectedImages
+		removeImage = podmanRemoveImage
+	})
+
+	images, bytes, err := SweepDeep()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 1 || removed[0] != "docker.io/library/mysql:5.7" {
+		t.Fatalf("want only the unused mysql:5.7 reaped, got %v", removed)
+	}
+	if images != 1 || bytes != 400 {
+		t.Errorf("images=%d bytes=%d, want 1 and 400", images, bytes)
+	}
+}
+
+func TestSweepDeep_GatedOffNoOp(t *testing.T) {
+	autoEnabled = func() bool { return false }
+	scanned := false
+	scanImages = func() ([]image, error) { scanned = true; return nil, nil }
+	t.Cleanup(func() {
+		autoEnabled = defaultAutoEnabled
+		scanImages = podmanImages
+	})
+
+	images, bytes, err := SweepDeep()
+	if err != nil || images != 0 || bytes != 0 || scanned {
+		t.Errorf("gated off must no-op without scanning: images=%d bytes=%d err=%v scanned=%v", images, bytes, err, scanned)
+	}
+}
+
 func TestSweepSafe_GatedOffNoOp(t *testing.T) {
 	autoEnabled = func() bool { return false }
 	scanned := false

--- a/internal/cli/cleanup.go
+++ b/internal/cli/cleanup.go
@@ -12,17 +12,21 @@ import (
 // NewCleanupCmd returns the cleanup command: reclaim podman disk that lerd's
 // own image rebuilds have orphaned, without ever touching a non-lerd resource.
 func NewCleanupCmd() *cobra.Command {
-	var dryRun, yes, deep bool
+	var dryRun, yes, safe, deep bool
 	cmd := &cobra.Command{
 		Use:   "cleanup",
-		Short: "Reclaim podman disk from orphaned lerd images",
+		Short: "Reclaim podman disk from orphaned lerd images, unused service images, and dangling leftovers",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return runCleanup(dryRun, yes, deep)
+			return runCleanup(dryRun, yes, !safe)
 		},
 	}
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be reclaimed without removing anything")
 	cmd.Flags().BoolVar(&yes, "yes", false, "Remove without confirming")
-	cmd.Flags().BoolVar(&deep, "deep", false, "Also remove unused service images no service references any more")
+	cmd.Flags().BoolVar(&safe, "safe", false, "Only reclaim images provably built by lerd, keep unused service and dangling images")
+	// --deep is now the default; kept as a hidden no-op so existing muscle memory
+	// and scripts don't break.
+	cmd.Flags().BoolVar(&deep, "deep", false, "")
+	_ = cmd.Flags().MarkHidden("deep")
 	cmd.AddCommand(newCleanupAutoCmd())
 	return cmd
 }
@@ -34,9 +38,10 @@ func newCleanupAutoCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auto",
 		Short: "Enable, disable, or show automatic cleanup",
-		Long: `Toggle automatic cleanup: the lerd-watcher's daily safe-tier sweep and
-the immediate reaping after a PHP rebuild or a service update/remove. On by
-default. Only ever runs the safe tier, never --deep.`,
+		Long: `Toggle automatic cleanup: the lerd-watcher's daily deep sweep and the
+immediate reaping after a PHP rebuild or a service update/remove. On by
+default. The deep sweep always keeps the current image and the one-back
+rollback target, and never touches images lerd didn't pull.`,
 	}
 	cmd.AddCommand(
 		&cobra.Command{Use: "on", Short: "Enable automatic cleanup", Args: cobra.NoArgs,
@@ -92,7 +97,8 @@ func runCleanup(dryRun, yes, deep bool) error {
 		return err
 	}
 	if len(plan.Targets) == 0 {
-		feedback.Line("Nothing to clean up. No orphaned lerd images.")
+		feedback.Line("Nothing to reclaim right now.")
+		showHeldHint(plan)
 		return nil
 	}
 
@@ -107,6 +113,7 @@ func runCleanup(dryRun, yes, deep bool) error {
 	feedback.Note(fmt.Sprintf("About %s across %d image(s).", humanSize(plan.ReclaimBytes()), len(plan.Targets)))
 
 	if dryRun {
+		showHeldHint(plan)
 		return nil
 	}
 	if !yes && !feedback.Confirm("Remove these images?", false) {
@@ -114,5 +121,23 @@ func runCleanup(dryRun, yes, deep bool) error {
 	}
 
 	feedback.Done(fmt.Sprintf("Freed about %s.", humanSize(cleanup.Apply(plan))))
+	showHeldHint(plan)
 	return nil
+}
+
+// showHeldHint tells the user when reclaimable disk is locked behind running
+// containers: those images can't be removed now, but a restart recreates the
+// containers on the current images and releases the old ones. Silent otherwise.
+func showHeldHint(plan cleanup.Plan) {
+	if h := heldHint(plan); h != "" {
+		feedback.Note(h)
+	}
+}
+
+func heldHint(plan cleanup.Plan) string {
+	if plan.Held.Count == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s across %d image(s) is held by running containers. Run `lerd restart` to release it, then cleanup again.",
+		humanSize(plan.Held.Bytes), plan.Held.Count)
 }

--- a/internal/cli/cleanup_auto_test.go
+++ b/internal/cli/cleanup_auto_test.go
@@ -1,10 +1,41 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/geodro/lerd/internal/cleanup"
 	"github.com/geodro/lerd/internal/config"
 )
+
+// The held-by-containers hint is silent when nothing is held, and otherwise
+// names the size and points at restart as the way to release it.
+func TestHeldHint(t *testing.T) {
+	if got := heldHint(cleanup.Plan{}); got != "" {
+		t.Errorf("no held images should give an empty hint, got %q", got)
+	}
+	got := heldHint(cleanup.Plan{Held: cleanup.HeldByContainers{Count: 8, Bytes: 2 << 30}})
+	if !strings.Contains(got, "8 image") || !strings.Contains(got, "lerd restart") {
+		t.Errorf("hint should mention the count and restart, got %q", got)
+	}
+}
+
+// cleanup runs the deep tier by default; --safe opts back down to the
+// conservative sweep, and the old --deep flag stays as a hidden no-op.
+func TestNewCleanupCmd_DeepByDefaultSafeOptOut(t *testing.T) {
+	cmd := NewCleanupCmd()
+	safe := cmd.Flags().Lookup("safe")
+	if safe == nil {
+		t.Fatal("expected a --safe opt-out flag")
+	}
+	if safe.DefValue != "false" {
+		t.Errorf("--safe should default false so deep is on by default, got %q", safe.DefValue)
+	}
+	deep := cmd.Flags().Lookup("deep")
+	if deep == nil || !deep.Hidden {
+		t.Error("--deep should remain as a hidden deprecated no-op")
+	}
+}
 
 // runCleanupAutoToggle persists the auto_cleanup flag so the watcher and event
 // hooks read it back. Default is on; off then on must round-trip through config.

--- a/internal/watcher/cleanup.go
+++ b/internal/watcher/cleanup.go
@@ -11,16 +11,19 @@ import (
 	"github.com/geodro/lerd/internal/config"
 )
 
-// autoCleanupInterval is the minimum gap between automatic safe-tier sweeps.
-// Orphaned images aren't urgent, so a slow daily cadence reclaims rebuild
-// leftovers on its own while keeping the watcher quiet.
+// autoCleanupInterval is the minimum gap between automatic sweeps. Orphaned and
+// unused images aren't urgent, so a slow daily cadence reclaims them on its own
+// while keeping the watcher quiet.
 const autoCleanupInterval = 24 * time.Hour
 
-// WatchCleanup periodically reclaims orphaned lerd images (the safe tier only,
-// never the --deep service-image tier). It ticks at interval but acts at most
-// once per autoCleanupInterval, throttled by a persisted timestamp so a
-// restarting watcher can't sweep more often. The auto_cleanup config gate turns
-// it off.
+// autoSweep is the sweep the watcher runs; the deep tier so upgraded service
+// images left behind get reclaimed unattended. Seam for tests.
+var autoSweep = cleanup.SweepDeep
+
+// WatchCleanup periodically reclaims orphaned lerd images and unused service
+// images (the deep tier). It ticks at interval but acts at most once per
+// autoCleanupInterval, throttled by a persisted timestamp so a restarting
+// watcher can't sweep more often. The auto_cleanup config gate turns it off.
 func WatchCleanup(interval time.Duration) {
 	// Check once at startup too: the daily stamp throttles it, but a watcher
 	// that restarts more often than interval would otherwise never sweep, and a
@@ -34,10 +37,10 @@ func WatchCleanup(interval time.Duration) {
 	}
 }
 
-// runAutoCleanup performs one throttled, gated safe-tier sweep. Split from the
+// runAutoCleanup performs one throttled, gated deep-tier sweep. Split from the
 // ticker so its decision points are unit-testable with an injected clock. The
-// actual reclaim is delegated to cleanup.SweepSafe so the watcher only adds the
-// throttle and the log line on top of the shared pipeline.
+// actual reclaim is delegated to autoSweep so the watcher only adds the throttle
+// and the log line on top of the shared pipeline.
 func runAutoCleanup(now time.Time) {
 	cfg, err := config.LoadGlobal()
 	if err != nil || !cfg.AutoCleanupEnabled() {
@@ -47,7 +50,7 @@ func runAutoCleanup(now time.Time) {
 		return
 	}
 
-	images, freed, err := cleanup.SweepSafe()
+	images, freed, err := autoSweep()
 	if err != nil {
 		// Transient podman failure: don't stamp, so the next tick retries
 		// instead of being throttled out for a full interval.
@@ -55,7 +58,7 @@ func runAutoCleanup(now time.Time) {
 	}
 	stampAutoCleanup(now)
 	if images > 0 {
-		logger.Info("auto-cleanup reclaimed orphaned images", "images", images, "bytes", freed)
+		logger.Info("auto-cleanup reclaimed unused images", "images", images, "bytes", freed)
 	}
 }
 

--- a/internal/watcher/cleanup_test.go
+++ b/internal/watcher/cleanup_test.go
@@ -3,7 +3,29 @@ package watcher
 import (
 	"testing"
 	"time"
+
+	"github.com/geodro/lerd/internal/cleanup"
 )
+
+// The daily sweep must run the deep tier so upgraded service images are
+// reclaimed unattended, not just the safe-tier orphans.
+func TestRunAutoCleanup_UsesDeepSweep(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	stampPathFn = func() string { return tmp + "/auto-cleanup.stamp" }
+	called := false
+	autoSweep = func() (int, int64, error) { called = true; return 0, 0, nil }
+	t.Cleanup(func() {
+		stampPathFn = defaultStampPath
+		autoSweep = cleanup.SweepDeep
+	})
+
+	runAutoCleanup(time.Unix(2_000_000_000, 0))
+	if !called {
+		t.Error("auto cleanup should invoke the deep sweep")
+	}
+}
 
 func TestCleanupDue(t *testing.T) {
 	now := time.Unix(1_000_000_000, 0)


### PR DESCRIPTION
lerd cleanup only reaped provably-lerd orphaned images by default, and the daily automatic sweep was limited to that same tier. Upgraded service versions and the dangling leftovers that repeated image rebuilds pile up were never touched unless someone remembered to pass --deep by hand, so a long-lived install let podman grow tens of gigabytes while cleanup reported nothing to do.

Deep is now the default, for the command and the watcher's daily sweep, with a --safe flag to drop back to the conservative provably-lerd pass. The deep tier reaps catalog service images no service references any more and every dangling image, since a dangling image is untagged and unreferenced so removing it strands nothing.

An image a container still holds is skipped everywhere, because podman refuses to remove one and it would otherwise show as reclaimable on every run while freeing nothing. Removal retries across passes so a dangling build chain reclaims in a single run, and when everything reclaimable is locked behind running containers cleanup reports how much a restart would release instead of a bare nothing to do.

Closes #739.
