### PR TITLE
Remember whether lerd manages Node so the choice survives installs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,11 @@ php:
   default_version: "8.5"
 node:
   default_version: "22"
+  managed: true           # optional. Whether lerd manages Node.js via fnm shims.
+                          # Written by the install prompt and by lerd node:manage
+                          # / node:unmanage; honoured on lerd update so an opt-out
+                          # is not undone. Omitted on configs predating it, which
+                          # fall back to whatever shims are on disk.
 nginx:
   http_port: 80
   https_port: 443

--- a/docs/usage/node.md
+++ b/docs/usage/node.md
@@ -100,6 +100,8 @@ You can flip the choice at any time without re-running the whole installer:
 
 Both also regenerate any host worker units (Vite and other `host: true` workers) so they switch between fnm, your system Node, and bun to match the new state. The dashboard and Settings exposes the same toggle: the Node page shows a **Let lerd manage Node** / **Stop managing** button.
 
+The question is asked once and then remembered in `~/.config/lerd/config.yaml` (`node.managed`). After that, neither `lerd install` nor `lerd update` asks again or undoes your choice, you change it only with `lerd node:manage` / `lerd node:unmanage`. A config predating this adopts whatever lerd is currently doing (shims present means managed) as the remembered choice without prompting, so existing installs are never re-asked.
+
 ---
 
 ## bun

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -251,14 +251,33 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		feedback.Line(fmt.Sprintf("bun detected at %s, lerd will use it automatically for projects that use bun", bunPath))
 	}
 
-	wantLerdNode := true
-	if systemNode := detectSystemNode(); systemNode != "" {
+	// Resolve the Node-management choice from the persisted preference, the
+	// on-disk shim state (for configs predating the preference), and whether a
+	// system node exists. Update runs non-interactively so a prior node:unmanage
+	// survives; a fresh install only prompts when a system node is present.
+	var savedNode *bool
+	if nodeCfg, err := config.LoadGlobal(); err == nil && nodeCfg != nil {
+		if v, set := nodeCfg.NodeManagedPref(); set {
+			savedNode = &v
+		}
+	}
+	systemNode := detectSystemNode()
+	wantLerdNode, promptNode, nodeDefault := nodeManageDecision(fromUpdate, savedNode, systemNode != "", lerdManagesNode())
+	if promptNode {
 		feedback.Line("Node.js detected at " + systemNode)
 		prompt := "Let lerd manage Node.js versions (installs fnm shims, may override system node)?"
 		if bunPath != "" {
 			prompt += " Decline to keep your system Node and use bun."
 		}
-		wantLerdNode = confirmInstallPrompt(prompt)
+		wantLerdNode = confirmInstallPromptDefault(prompt, nodeDefault)
+	}
+	if nodeCfg, err := config.LoadGlobal(); err == nil && nodeCfg != nil {
+		if v, set := nodeCfg.NodeManagedPref(); !set || v != wantLerdNode {
+			nodeCfg.SetNodeManaged(wantLerdNode)
+			if err := config.SaveGlobal(nodeCfg); err != nil {
+				fmt.Printf("    WARN: persist Node-management choice: %v\n", err)
+			}
+		}
 	}
 
 	// Ask whether lerd should manage local DNS. Prompted on every direct
@@ -1230,6 +1249,27 @@ func lerdManagesNode() bool {
 	return err == nil
 }
 
+// nodeManageDecision resolves whether lerd should manage Node.js for this
+// install run. The choice is asked once and then remembered: an explicit saved
+// preference always wins silently, and a config predating the field adopts the
+// current on-disk shim state as that choice without asking. Only a genuine
+// first-time install (no saved preference and no shim) prompts, and then only
+// when a system node exists; with none it defaults to managed. Update never
+// prompts. When needPrompt is true the caller runs the prompt and overrides want
+// with the answer.
+func nodeManageDecision(fromUpdate bool, saved *bool, systemNodeDetected, shimPresent bool) (want, needPrompt, promptDefault bool) {
+	if saved != nil {
+		return *saved, false, *saved
+	}
+	if shimPresent || fromUpdate {
+		return shimPresent, false, shimPresent
+	}
+	if systemNodeDetected {
+		return true, true, true
+	}
+	return true, false, true
+}
+
 // ensureNodeManaged is called by the node:install/use/uninstall commands to
 // guard against running fnm operations while the user has opted out of
 // lerd-managed Node. Prompts for confirmation and writes shims on accept.
@@ -1250,6 +1290,7 @@ func ensureNodeManaged() error {
 	if err := addShellShims(true); err != nil {
 		return fmt.Errorf("writing shims: %w", err)
 	}
+	persistNodeManaged(true)
 	return nil
 }
 

--- a/internal/cli/node_manage.go
+++ b/internal/cli/node_manage.go
@@ -47,6 +47,7 @@ func runNodeManage(_ *cobra.Command, _ []string) error {
 	}
 	step.OK("")
 	ensureDefaultNode()
+	persistNodeManaged(true)
 	// Host workers (Vite etc.) were generated to run directly or via bun while
 	// Node was unmanaged; rewrite them so they route through fnm again.
 	regenerateHostWorkers()
@@ -64,6 +65,24 @@ func NewNodeUnmanageCmd() *cobra.Command {
 		Short: "Stop managing Node.js: remove lerd's node shims and fnm-installed versions",
 		Args:  cobra.NoArgs,
 		RunE:  runNodeUnmanage,
+	}
+}
+
+// persistNodeManaged records the Node-management choice in config.yaml so it
+// survives `lerd update`, which otherwise recomputes the intent and would
+// re-add the shims a node:unmanage removed. Best-effort: a save failure is
+// warned, not fatal, since the shims themselves already reflect the choice.
+func persistNodeManaged(managed bool) {
+	cfg, err := config.LoadGlobal()
+	if err != nil || cfg == nil {
+		return
+	}
+	if v, set := cfg.NodeManagedPref(); set && v == managed {
+		return
+	}
+	cfg.SetNodeManaged(managed)
+	if err := config.SaveGlobal(cfg); err != nil {
+		feedback.Warn("persist Node-management choice: %v", err)
 	}
 }
 
@@ -100,6 +119,7 @@ func runNodeUnmanage(_ *cobra.Command, _ []string) error {
 	// Existing host worker units still reference `fnm exec --using=… -- npm …`,
 	// which now has no Node to run; rewrite them so they use bun (when present)
 	// or the user's system Node directly.
+	persistNodeManaged(false)
 	feedback.Begin()
 	regen := feedback.Start("regenerating host worker units")
 	regenerateHostWorkers()

--- a/internal/cli/node_manage_decision_test.go
+++ b/internal/cli/node_manage_decision_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import "testing"
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestNodeManageDecision(t *testing.T) {
+	cases := []struct {
+		name        string
+		fromUpdate  bool
+		saved       *bool
+		systemNode  bool
+		shimPresent bool
+		wantWant    bool
+		wantPrompt  bool
+		wantDefault bool
+	}{
+		// An explicit saved choice always wins silently, on install and update.
+		{"saved opt-out honoured on install", false, boolPtr(false), true, true, false, false, false},
+		{"saved opt-out honoured on update", true, boolPtr(false), true, true, false, false, false},
+		{"saved opt-in honoured on install", false, boolPtr(true), false, false, true, false, true},
+		{"saved opt-in honoured on update", true, boolPtr(true), false, false, true, false, true},
+
+		// No saved choice yet but lerd is already managing (shim present): adopt
+		// that as the remembered choice without asking, so an existing user is
+		// never re-prompted on a rerun.
+		{"install adopts existing managed silently", false, nil, true, true, true, false, true},
+		{"update adopts existing managed silently", true, nil, true, true, true, false, true},
+
+		// No saved choice and no shim on update: preserve the unmanaged state.
+		{"update legacy preserves unmanaged", true, nil, true, false, false, false, false},
+
+		// Genuine first-time install (no saved choice, no shim): prompt only when
+		// a system node exists, otherwise default to managed with no prompt.
+		{"first install system node prompts", false, nil, true, false, false, true, true},
+		{"first install no system node defaults on", false, nil, false, false, true, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want, prompt, def := nodeManageDecision(tc.fromUpdate, tc.saved, tc.systemNode, tc.shimPresent)
+			if prompt != tc.wantPrompt {
+				t.Errorf("needPrompt = %v, want %v", prompt, tc.wantPrompt)
+			}
+			if def != tc.wantDefault {
+				t.Errorf("promptDefault = %v, want %v", def, tc.wantDefault)
+			}
+			// want is only meaningful when the caller does not prompt; when it
+			// prompts it overrides want with the answer, so only assert otherwise.
+			if !prompt && want != tc.wantWant {
+				t.Errorf("want = %v, want %v", want, tc.wantWant)
+			}
+		})
+	}
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -77,6 +77,11 @@ type GlobalConfig struct {
 	} `yaml:"php" mapstructure:"php"`
 	Node struct {
 		DefaultVersion string `yaml:"default_version" mapstructure:"default_version"`
+		// Managed records whether lerd manages Node.js via fnm shims. A pointer
+		// so a config predating the field (nil) keeps the historical
+		// shim-presence behaviour, while an explicit false survives updates that
+		// would otherwise re-add the shims a `node:unmanage` removed.
+		Managed *bool `yaml:"managed,omitempty" mapstructure:"managed"`
 	} `yaml:"node" mapstructure:"node"`
 	Nginx struct {
 		HTTPPort  int `yaml:"http_port"  mapstructure:"http_port"`
@@ -921,6 +926,22 @@ func (c *GlobalConfig) IsNotificationsEnabled() bool {
 // SaveGlobal; dispatchNotification re-reads the flag on every event.
 func (c *GlobalConfig) SetNotificationsEnabled(enabled bool) {
 	c.Notifications.Disabled = !enabled
+}
+
+// NodeManagedPref returns the persisted Node-management choice. set is false
+// when the config predates the field, so callers fall back to the on-disk shim
+// state instead of assuming a default.
+func (c *GlobalConfig) NodeManagedPref() (val bool, set bool) {
+	if c.Node.Managed == nil {
+		return false, false
+	}
+	return *c.Node.Managed, true
+}
+
+// SetNodeManaged records the Node-management choice. Persist via SaveGlobal;
+// the install/update flow reads it to keep the choice across updates.
+func (c *GlobalConfig) SetNodeManaged(managed bool) {
+	c.Node.Managed = &managed
 }
 
 // SaveGlobal writes the configuration to config.yaml.

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -105,6 +105,37 @@ func TestSaveLoadGlobal_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestNodeManagedPref(t *testing.T) {
+	setConfigDir(t)
+
+	cfg, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	// A fresh config predates the field, so the preference is unset and callers
+	// fall back to the on-disk shim state.
+	if _, set := cfg.NodeManagedPref(); set {
+		t.Fatal("expected NodeManagedPref unset on a fresh config")
+	}
+
+	cfg.SetNodeManaged(false)
+	if err := SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	got, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal after save: %v", err)
+	}
+	val, set := got.NodeManagedPref()
+	if !set {
+		t.Fatal("expected NodeManagedPref set after SetNodeManaged")
+	}
+	if val {
+		t.Errorf("NodeManagedPref = true, want false (the opt-out must survive a round-trip)")
+	}
+}
+
 // ── RequestTimeoutSeconds ─────────────────────────────────────────────────────
 
 func TestRequestTimeoutSeconds_DefaultsTo60WhenUnset(t *testing.T) {


### PR DESCRIPTION
lerd asks at install time whether it should manage Node.js via fnm shims, and node:manage / node:unmanage flip that later, but the answer was only ever inferred from whether the node shim existed on disk. Because lerd update re-execs install and recomputed the intent as managed, an update would silently re-add the shims a node:unmanage had removed, and every rerun of lerd install asked the question again.

The choice is now persisted to node.managed in config.yaml, the same way DNS remembers its enabled flag. An explicit saved choice always wins silently on both install and update, node:manage and node:unmanage write it, and a config predating the field adopts whatever lerd is currently doing as the remembered choice without prompting. Only a genuine first install, with no saved choice and no shim present, asks, and then only when a system node is detected. Existing installs are never re-asked and a prior opt-out is no longer undone by an update.

Closes #742