### PR TITLE
feat: expose database client tools as host shims

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -187,6 +187,8 @@ func main() {
 	root.AddCommand(cli.NewDbRestoreCmd())
 	root.AddCommand(cli.NewDbSnapshotRmCmd())
 	root.AddCommand(cli.NewDbMoveCmd())
+	root.AddCommand(cli.NewClientExecCmd())
+	root.AddCommand(cli.NewShimsCmd())
 	root.AddCommand(cli.NewXdebugCmd())
 	root.AddCommand(cli.NewDumpCmd())
 	root.AddCommand(cli.NewIdleCmd())

--- a/docs/usage/database.md
+++ b/docs/usage/database.md
@@ -191,6 +191,53 @@ lerd db:shell --service postgres --database myapp
 lerd db:shell
 ```
 
+## Client tools for external databases and IDEs
+
+The `db:*` commands work against lerd's own service containers. When you need to dump or query a database that lives **outside** lerd, for example a managed cluster on DigitalOcean, or you want to point an IDE like PhpStorm at a real `mysqldump` executable, lerd exposes the client tools that already ship inside its database images as host shims.
+
+A service declares which tools it exposes in its YAML, so the set grows with the store. Today: mysql and mariadb expose `mysql` and `mysqldump` (mariadb backed by the `mariadb`/`mariadb-dump` binaries); postgres and its pgvector/timescaledb variants expose `psql`, `pg_dump`, `pg_dumpall`, `pg_restore`; redis exposes `redis-cli`; valkey exposes `valkey-cli`; and mongo exposes `mongosh`, `mongodump`, `mongorestore`, `mongoexport`, `mongoimport`. Each becomes a shim on your PATH in `~/.local/share/lerd/bin`.
+
+When you install a service, lerd installs its shims. If you do not already have the tool on your system there is nothing to shadow, so the shim is installed automatically. If you **do** already have the tool installed, lerd asks first (default no) because the shim sits ahead of your own binary on PATH. Removing a service removes its shims. A tool added to a service in the store reaches an already-installed service on the next `lerd update`, without a reinstall.
+
+The shims pass every argument straight through, so targeting an external host is just a matter of supplying your own connection flags:
+
+```bash
+# Dump a managed database to a file in the current directory
+mysqldump -h db.example.com -P 25060 -u doadmin -p yourdb > dump.sql
+
+# Same for postgres
+pg_dump -h db.example.com -p 25060 -U doadmin -d yourdb > dump.sql
+```
+
+Each tool runs in a throwaway container spun from the service's image, so nothing touches your running database container. Your home directory is mounted read-write, so the tool can read a CA cert and write its output anywhere under it, whether you use a shell redirect (`> dump.sql`), the tool's own `--result-file`/`-f` flag, or an IDE that fills one in. Output files are owned by you, not root.
+
+Managed databases usually require TLS. Keep the CA file you pass with a flag like `--ssl-ca` somewhere under your home directory so the tool can read it:
+
+```bash
+mysqldump -h db.example.com -P 25060 -u doadmin -p --ssl-ca=ca.crt yourdb > dump.sql
+```
+
+When you give no host, the tool connects to a local lerd database with its admin credentials, so `pg_dump mydb` or `mysqldump mydb` just works. If you run it from a project directory, it targets that project's own database service, read from the project's `DB_HOST`, so a mariadb-backed project routes to your mariadb container rather than the default mysql one. Outside a project, or when the project's database is a different family than the tool, it falls back to the family's default service. Passing `-h` (an external host) turns all of this off and the shim forwards everything untouched. For scripted local dumps `lerd db:export` is still the tidier option; the raw shim is there for external databases and IDEs.
+
+To point an IDE at a tool, use its shim path, for example `~/.local/share/lerd/bin/mysqldump`.
+
+### Managing shims
+
+List the shims your installed services expose and whether each is installed:
+
+```bash
+lerd shims
+```
+
+Add or remove an individual shim, for example if you declined it at install time and later want it, or you would rather keep your own binary on PATH:
+
+```bash
+lerd shims remove mysqldump   # take lerd's shim off your PATH
+lerd shims add mysqldump      # put it back
+```
+
+The same per-tool toggles are on each database service's Tools tab in the web UI. When two services of the same family are installed (say mysql and mariadb, which both provide `mysqldump`), one owns the shim and runs it; the others show that tool disabled on their Tools tab so it is managed in one place.
+
 ## Recovering after a service reinstall
 
 `lerd service reinstall <name> --reset-data` wipes the database server's data dir (rename-aside, recoverable) and then walks every active site that depends on the service to recreate the database it expects via `CREATE DATABASE IF NOT EXISTS`. Database name resolution is the same as `lerd env`: `.lerd.yaml` `db.database` first, then `.env` `DB_DATABASE`, then a name derived from the site name.

--- a/internal/cli/client_shims.go
+++ b/internal/cli/client_shims.go
@@ -1,0 +1,304 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/geodro/lerd/internal/envfile"
+	"github.com/geodro/lerd/internal/feedback"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/shims"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// clientShimPrompter returns the host-conflict prompter for shim reconciles run
+// from an interactive terminal (install, service install). It asks, defaulting
+// to no, before shadowing a tool the user already has. Non-interactive callers
+// pass nil so the conflict is left for a later interactive run or the web UI.
+func clientShimPrompter() shims.Prompter {
+	if !isInteractive() {
+		return nil
+	}
+	return func(tool string) (bool, bool) {
+		e := confirmInstallPromptDefault(
+			fmt.Sprintf("You already have %s installed; install lerd's %s shim (it shadows yours on PATH)?", tool, tool), false)
+		return e, true
+	}
+}
+
+// NewShimsCmd returns the `shims` command group for managing the client-tool
+// host shims services expose (mysqldump, pg_dump, psql…). With no subcommand it
+// lists the current state.
+func NewShimsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "shims",
+		Short: "Manage the client-tool shims services expose on your PATH",
+		Args:  cobra.NoArgs,
+		RunE:  func(_ *cobra.Command, _ []string) error { return runShimsList() },
+	}
+	cmd.AddCommand(&cobra.Command{
+		Use:   "list",
+		Short: "List client-tool shims and whether each is installed",
+		Args:  cobra.NoArgs,
+		RunE:  func(_ *cobra.Command, _ []string) error { return runShimsList() },
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "add <tool>",
+		Short: "Install the host shim for a client tool (e.g. mysqldump)",
+		Args:  cobra.ExactArgs(1),
+		RunE:  func(_ *cobra.Command, args []string) error { return runShimsSet(args[0], true) },
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "remove <tool>",
+		Short: "Remove the host shim for a client tool",
+		Args:  cobra.ExactArgs(1),
+		RunE:  func(_ *cobra.Command, args []string) error { return runShimsSet(args[0], false) },
+	})
+	return cmd
+}
+
+func runShimsList() error {
+	list := shims.List()
+	if len(list) == 0 {
+		fmt.Println("No installed service exposes client tools.")
+		return nil
+	}
+	for _, s := range list {
+		state := "undecided"
+		if s.Decided {
+			if s.Enabled {
+				state = "installed"
+			} else {
+				state = "removed"
+			}
+		}
+		note := ""
+		if s.HostHas {
+			note = "  (you have your own " + s.Tool + " on PATH)"
+		}
+		fmt.Printf("  %-14s %-12s %-9s%s\n", s.Tool, s.Service, state, note)
+	}
+	return nil
+}
+
+func runShimsSet(tool string, enabled bool) error {
+	if err := shims.Set(tool, enabled); err != nil {
+		return err
+	}
+	feedback.Begin()
+	if enabled {
+		feedback.Done("installed shim " + feedback.Val(tool))
+	} else {
+		feedback.Done("removed shim " + feedback.Val(tool))
+	}
+	return nil
+}
+
+// argsSpecifyHost reports whether the tool arguments already name a host, in
+// which case the shim leaves the connection untouched (an external database).
+// Both the postgres and mysql client families use -h / --host for the host.
+func argsSpecifyHost(args []string) bool {
+	for _, a := range args {
+		if a == "-h" || a == "--host" || strings.HasPrefix(a, "--host=") || (strings.HasPrefix(a, "-h") && len(a) > 2) {
+			return true
+		}
+		// A connection URI or a libpq conninfo string carries its own host, so
+		// the shim must not override it with a local default.
+		if strings.Contains(a, "://") || strings.Contains(a, "host=") {
+			return true
+		}
+	}
+	return false
+}
+
+// hostEnvSet reports whether the caller pointed the tool at a host via the
+// family's environment variable, which also counts as an explicit target.
+func hostEnvSet(tool string) bool {
+	if isPostgresTool(tool) {
+		return os.Getenv("PGHOST") != ""
+	}
+	return os.Getenv("MYSQL_HOST") != ""
+}
+
+// localCredsEnv returns the admin credentials for the backing lerd service so a
+// hostless dump connects to the local server. Postgres needs the superuser name
+// (the container user is root, which is not a role); the mysql families default
+// to root already, so only the password is needed.
+func localCredsEnv(tool string) []string {
+	if isPostgresTool(tool) {
+		return []string{"PGUSER=postgres", "PGPASSWORD=lerd"}
+	}
+	return []string{"MYSQL_PWD=lerd"}
+}
+
+func isPostgresTool(tool string) bool {
+	return tool == "psql" || strings.HasPrefix(tool, "pg_")
+}
+
+// isSQLTool reports whether a tool has a site→service resolver (the SQL
+// families read DB_HOST). Redis, valkey and mongo tools have no such mapping
+// yet, so they keep the global-owner default.
+func isSQLTool(tool string) bool {
+	return isPostgresTool(tool) || tool == "mysql" || tool == "mysqldump"
+}
+
+// siteServiceForTool returns the lerd service the project at cwd points its
+// DB_HOST at, so a bare dump run from a project targets that project's own
+// database service (e.g. a mariadb-backed project routes to lerd-mariadb-<v>
+// rather than the global mysql owner). Returns "" when there is no lerd DB host
+// to adopt; the caller falls back to the owner, and ResolveTarget still ignores
+// a service that does not actually expose the tool (so a Postgres project's
+// lerd-postgres host is not adopted by mysqldump).
+func siteServiceForTool(cwd, tool string) string {
+	if !isSQLTool(tool) {
+		return ""
+	}
+	host := envfile.ReadKey(filepath.Join(siteRootFor(cwd), ".env"), "DB_HOST")
+	svc, ok := strings.CutPrefix(host, "lerd-")
+	if !ok || svc == "" {
+		return ""
+	}
+	return svc
+}
+
+// pathUnder reports whether path is base or nested under it, so a cwd already
+// covered by the home mount isn't mounted a second time.
+func pathUnder(path, base string) bool {
+	return path == base || strings.HasPrefix(path, strings.TrimSuffix(base, "/")+"/")
+}
+
+// NewClientExecCmd returns the hidden `client-exec` command every client shim
+// dispatches to. It resolves the service container backing the tool, starts it
+// if it is down, mounts the working directory so dumps and CA certs on the host
+// are reachable, and execs the tool with all arguments passed straight through.
+func NewClientExecCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:                "client-exec <tool> [args...]",
+		Short:              "Run a service client tool (mysqldump, pg_dump…) in its container",
+		Hidden:             true,
+		DisableFlagParsing: true,
+		SilenceUsage:       true,
+		Args:               cobra.MinimumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runClientExec(args[0], args[1:])
+		},
+	}
+}
+
+func runClientExec(tool string, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	// A hostless dump adopts the current project's own database service, falling
+	// back to the global owner; an explicit -h (external) always uses the owner
+	// and passes straight through.
+	hostGiven := argsSpecifyHost(args) || hostEnvSet(tool)
+	prefer := ""
+	if !hostGiven {
+		prefer = siteServiceForTool(cwd, tool)
+	}
+	target, ok := shims.ResolveTarget(tool, prefer)
+	if !ok {
+		return fmt.Errorf("no installed service exposes the %q client tool", tool)
+	}
+
+	// Autostart the backing service so its image is present and, for a dump
+	// against a local lerd database (-h lerd-<service>), the server is up.
+	if err := ensureServiceRunning(target.Service); err != nil {
+		return fmt.Errorf("could not start %s: %w", target.Service, err)
+	}
+
+	image := podman.InstalledImage("lerd-" + target.Service)
+	if image == "" {
+		return fmt.Errorf("could not resolve the image for service %q", target.Service)
+	}
+
+	// When the caller names no host, default the connection to the resolved lerd
+	// service with its admin credentials, so `pg_dump mydb` / `mysqldump mydb`
+	// work against the local server out of the box. Only for the SQL tools: they
+	// share the -h host flag and have known admin credentials, whereas mongosh
+	// reads -h as --help and redis-cli/mongo tools have their own conventions, so
+	// those pass through and expect an explicit host.
+	var defaultEnv []string
+	if !hostGiven && isSQLTool(tool) {
+		args = append([]string{"-h", "lerd-" + target.Service}, args...)
+		defaultEnv = localCredsEnv(tool)
+	}
+
+	// Resolve the first candidate binary that exists in the image, then exec it
+	// with the shim's args as sh's positional parameters so no quoting is lost.
+	var probe strings.Builder
+	for i, b := range target.Binaries {
+		if i > 0 {
+			probe.WriteString(" || ")
+		}
+		probe.WriteString("command -v " + podman.ShellQuote(b))
+	}
+	shellCmd := "exec $(" + probe.String() + ") \"$@\""
+
+	// Run the tool in a throwaway container from the service image rather than
+	// exec-ing into the long-running service: nothing is mounted into or
+	// restarts the persistent database container. Mount the home dir read-write
+	// so the tool reads a CA cert and writes its output file (an IDE's
+	// --result-file, pg_dump -f) to a host path exactly like a native client;
+	// rootless podman maps container root to the host user, so the file lands
+	// owned by you. A cwd outside home is mounted alongside. Joined to the lerd
+	// network so a local target (-h lerd-<service>) resolves and external hosts
+	// stay reachable.
+	runFlags := []string{"run", "--rm", "-i", "--network", "lerd", "--entrypoint", "sh"}
+	home, _ := os.UserHomeDir()
+	mounted := map[string]bool{}
+	addMount := func(p string) {
+		if p == "" || p == "/" || mounted[p] {
+			return
+		}
+		runFlags = append(runFlags, "-v", p+":"+p)
+		mounted[p] = true
+	}
+	addMount(home)
+	if home == "" || !pathUnder(cwd, home) {
+		addMount(cwd)
+	}
+	runFlags = append(runFlags, "-w", cwd)
+	// Allocate a pty only for a fully interactive run. If stdout is redirected
+	// (mysqldump > dump.sql, pg_dump -Fc > dump.dump), a pty's line discipline
+	// would translate LF to CRLF and corrupt the dump, so both stdin and stdout
+	// must be terminals.
+	if term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd())) {
+		runFlags = append(runFlags, "-t")
+	}
+	// Local-target defaults first, so the caller's own DB-client env (forwarded
+	// next) always wins over them.
+	for _, e := range defaultEnv {
+		runFlags = append(runFlags, "-e", e)
+	}
+	// Forward the caller's DB-client environment (PGPASSWORD, PGSSLMODE,
+	// MYSQL_PWD…) so credentials set on the host reach the tool; podman run
+	// otherwise inherits none of the host env.
+	for _, e := range os.Environ() {
+		k, _, _ := strings.Cut(e, "=")
+		if strings.HasPrefix(k, "PG") || strings.HasPrefix(k, "MYSQL") || strings.HasPrefix(k, "MARIADB") {
+			runFlags = append(runFlags, "-e", e)
+		}
+	}
+	runFlags = append(runFlags, image, "-c", shellCmd, "sh")
+	runFlags = append(runFlags, args...)
+
+	cmd := podman.Cmd(runFlags...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		if exit, ok := err.(*exec.ExitError); ok {
+			os.Exit(exit.ExitCode())
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/cli/client_shims_test.go
+++ b/internal/cli/client_shims_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import "testing"
+
+func TestArgsSpecifyHost(t *testing.T) {
+	cases := []struct {
+		args []string
+		want bool
+	}{
+		{nil, false},
+		{[]string{"mydb"}, false},
+		{[]string{"-U", "postgres", "mydb"}, false},
+		{[]string{"-h", "db.example.com", "mydb"}, true},
+		{[]string{"--host", "db.example.com"}, true},
+		{[]string{"--host=db.example.com"}, true},
+		{[]string{"-hdb.example.com"}, true},
+		{[]string{"--help"}, false},
+		{[]string{"postgresql://user@ext.example.com/db"}, true},
+		{[]string{"host=ext.example.com dbname=prod"}, true},
+		{[]string{"mydb"}, false},
+	}
+	for _, c := range cases {
+		if got := argsSpecifyHost(c.args); got != c.want {
+			t.Errorf("argsSpecifyHost(%v) = %v, want %v", c.args, got, c.want)
+		}
+	}
+}
+
+func TestIsPostgresTool(t *testing.T) {
+	for _, tool := range []string{"psql", "pg_dump", "pg_dumpall", "pg_restore"} {
+		if !isPostgresTool(tool) {
+			t.Errorf("isPostgresTool(%q) = false, want true", tool)
+		}
+	}
+	for _, tool := range []string{"mysql", "mysqldump", "mariadb-dump"} {
+		if isPostgresTool(tool) {
+			t.Errorf("isPostgresTool(%q) = true, want false", tool)
+		}
+	}
+}
+
+func TestIsSQLTool(t *testing.T) {
+	for _, tool := range []string{"mysql", "mysqldump", "psql", "pg_dump", "pg_restore"} {
+		if !isSQLTool(tool) {
+			t.Errorf("isSQLTool(%q) = false, want true", tool)
+		}
+	}
+	for _, tool := range []string{"redis-cli", "valkey-cli", "mongosh", "mongodump"} {
+		if isSQLTool(tool) {
+			t.Errorf("isSQLTool(%q) = true, want false", tool)
+		}
+	}
+}
+
+func TestLocalCredsEnv(t *testing.T) {
+	pg := localCredsEnv("pg_dump")
+	if len(pg) != 2 || pg[0] != "PGUSER=postgres" || pg[1] != "PGPASSWORD=lerd" {
+		t.Errorf("postgres creds = %v", pg)
+	}
+	my := localCredsEnv("mysqldump")
+	if len(my) != 1 || my[0] != "MYSQL_PWD=lerd" {
+		t.Errorf("mysql creds = %v", my)
+	}
+}
+
+func TestPathUnder(t *testing.T) {
+	cases := []struct {
+		path, base string
+		want       bool
+	}{
+		{"/home/u", "/home/u", true},
+		{"/home/u/proj", "/home/u", true},
+		{"/home/u/", "/home/u", true},
+		{"/home/us", "/home/u", false},
+		{"/tmp/x", "/home/u", false},
+		{"/home/u/proj", "/home/u/", true},
+	}
+	for _, c := range cases {
+		if got := pathUnder(c.path, c.base); got != c.want {
+			t.Errorf("pathUnder(%q,%q) = %v, want %v", c.path, c.base, got, c.want)
+		}
+	}
+}
+
+func TestHostEnvSet(t *testing.T) {
+	t.Setenv("PGHOST", "")
+	t.Setenv("MYSQL_HOST", "")
+	if hostEnvSet("pg_dump") || hostEnvSet("mysqldump") {
+		t.Fatal("no host env should read as unset")
+	}
+	t.Setenv("PGHOST", "db.example.com")
+	if !hostEnvSet("pg_dump") {
+		t.Error("PGHOST should count for postgres tools")
+	}
+	if hostEnvSet("mysqldump") {
+		t.Error("PGHOST must not count for mysql tools")
+	}
+	t.Setenv("MYSQL_HOST", "db.example.com")
+	if !hostEnvSet("mysqldump") {
+		t.Error("MYSQL_HOST should count for mysql tools")
+	}
+}

--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -94,6 +94,20 @@ func serviceToDBEnv(name string) *dbEnv {
 	return &dbEnv{service: name, connection: "mysql", username: "root", password: "lerd"}
 }
 
+// lerdServiceFromHost returns the lerd service a DB host of the form
+// "lerd-<service>" points at (e.g. "lerd-mariadb-11-8" -> "mariadb-11-8"), or ""
+// when the host is not a lerd service container (an external host, or the
+// loopback a host-proxy site uses). Lets the db commands target the exact
+// service a site runs on instead of collapsing to the family's canonical
+// service, so a mariadb- or postgres-18-backed site dumps the right server.
+func lerdServiceFromHost(host string) string {
+	svc, ok := strings.CutPrefix(strings.TrimSpace(host), "lerd-")
+	if !ok || svc == "" {
+		return ""
+	}
+	return svc
+}
+
 // resolveDB resolves database connection config using the following priority:
 //  1. --service flag (flagService)
 //  2. .lerd.yaml db: block (present even on unlinked sites)
@@ -171,6 +185,11 @@ func resolveDBFromFramework(cwd string) *dbEnv {
 			continue
 		}
 		env := serviceToDBEnv(svc)
+		// Target the exact service the site points at (an alternate like mariadb
+		// or postgres-18), not just the family's canonical service.
+		if s := lerdServiceFromHost(readKey("DB_HOST")); s != "" {
+			env.service = s
+		}
 		// Resolve database name from the framework's env file.
 		env.database = readKey("DB_DATABASE")
 		if env.database == "" {
@@ -261,8 +280,12 @@ func loadDBEnv(cwd string) (*dbEnv, error) {
 	// DB_PASSWORD avoids authenticating as a role that doesn't exist in the
 	// container (e.g. DB_USERNAME=root against pgsql).
 	svcDefaults := serviceToDBEnv(connToService(conn))
+	service := connToService(conn)
+	if s := lerdServiceFromHost(vals["DB_HOST"]); s != "" {
+		service = s
+	}
 	return &dbEnv{
-		service:    connToService(conn),
+		service:    service,
 		connection: conn,
 		database:   db,
 		username:   svcDefaults.username,
@@ -646,8 +669,12 @@ func loadDBEnvLenient(cwd string) (*dbEnv, error) {
 	}
 
 	svcDefaults := serviceToDBEnv(connToService(conn))
+	service := connToService(conn)
+	if s := lerdServiceFromHost(vals["DB_HOST"]); s != "" {
+		service = s
+	}
 	return &dbEnv{
-		service:    connToService(conn),
+		service:    service,
 		connection: conn,
 		database:   db,
 		username:   svcDefaults.username,

--- a/internal/cli/db_test.go
+++ b/internal/cli/db_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -105,5 +107,69 @@ func TestDbCmdUnsupportedConnection(t *testing.T) {
 	_, err = dbExportCmd(env)
 	if err == nil {
 		t.Error("expected error for unsupported connection")
+	}
+}
+
+func TestLerdServiceFromHost(t *testing.T) {
+	cases := map[string]string{
+		"lerd-mariadb-11-8": "mariadb-11-8",
+		"lerd-mysql":        "mysql",
+		"lerd-postgres-18":  "postgres-18",
+		"  lerd-mysql ":     "mysql",
+		"127.0.0.1":         "",
+		"db.example.com":    "",
+		"":                  "",
+		"lerd-":             "",
+	}
+	for host, want := range cases {
+		if got := lerdServiceFromHost(host); got != want {
+			t.Errorf("lerdServiceFromHost(%q) = %q, want %q", host, got, want)
+		}
+	}
+}
+
+func writeEnvFixture(t *testing.T, lines string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte(lines), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestLoadDBEnvTargetsActualServiceFromHost(t *testing.T) {
+	// A mariadb-backed site: mysql dialect, but the container is the mariadb one.
+	dir := writeEnvFixture(t, "DB_CONNECTION=mysql\nDB_HOST=lerd-mariadb-11-8\nDB_DATABASE=shop\n")
+	env, err := loadDBEnv(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env.service != "mariadb-11-8" {
+		t.Errorf("service = %q, want mariadb-11-8", env.service)
+	}
+	if env.connection != "mysql" {
+		t.Errorf("connection = %q, want mysql", env.connection)
+	}
+}
+
+func TestLoadDBEnvCanonicalHostUnchanged(t *testing.T) {
+	dir := writeEnvFixture(t, "DB_CONNECTION=pgsql\nDB_HOST=lerd-postgres\nDB_DATABASE=shop\n")
+	env, err := loadDBEnv(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env.service != "postgres" {
+		t.Errorf("service = %q, want postgres", env.service)
+	}
+}
+
+func TestLoadDBEnvNonLerdHostFallsBackToCanonical(t *testing.T) {
+	dir := writeEnvFixture(t, "DB_CONNECTION=mysql\nDB_HOST=127.0.0.1\nDB_DATABASE=shop\n")
+	env, err := loadDBEnv(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env.service != "mysql" {
+		t.Errorf("service = %q, want mysql (canonical fallback)", env.service)
 	}
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -23,6 +23,7 @@ import (
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/serviceops"
 	"github.com/geodro/lerd/internal/services"
+	"github.com/geodro/lerd/internal/shims"
 	"github.com/geodro/lerd/internal/siteops"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/spf13/cobra"
@@ -967,6 +968,9 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 
 	step("Adding shell PATH configuration")
 	if err := addShellShims(wantLerdNode); err != nil {
+		fmt.Printf("    WARN: %v\n", err)
+	}
+	if err := shims.Reconcile(clientShimPrompter()); err != nil {
 		fmt.Printf("    WARN: %v\n", err)
 	}
 	ok()

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -16,6 +16,7 @@ import (
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/serviceops"
 	"github.com/geodro/lerd/internal/services"
+	"github.com/geodro/lerd/internal/shims"
 	"github.com/geodro/lerd/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -613,6 +614,9 @@ stopped, removed, exposed, or pinned with the usual service subcommands.`,
 			if len(svc.DependsOn) > 0 {
 				fmt.Printf("Depends on: %s (will be auto-started)\n", strings.Join(svc.DependsOn, ", "))
 			}
+			if err := shims.Reconcile(clientShimPrompter()); err != nil {
+				fmt.Printf("    WARN: client shims: %v\n", err)
+			}
 			return nil
 		},
 	}
@@ -836,6 +840,10 @@ func newServiceRemoveCmd() *cobra.Command {
 
 			if err := serviceops.RemoveService(name, serviceops.RemoveOptions{RemoveData: purge}, emit); err != nil {
 				return err
+			}
+
+			if err := shims.Reconcile(nil); err != nil {
+				fmt.Printf("    WARN: client shims: %v\n", err)
 			}
 
 			if !purge {

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -21,6 +21,7 @@ import (
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/serviceops"
 	"github.com/geodro/lerd/internal/services"
+	"github.com/geodro/lerd/internal/shims"
 	"github.com/spf13/cobra"
 )
 
@@ -814,6 +815,11 @@ func reconcileCustomServices() {
 	res, err := serviceops.ReconcileServices(nil)
 	if err != nil {
 		feedback.Warn("reconciling services: %v", err)
+	}
+	// A refreshed definition may add client tools (client_shims), so bring the
+	// shim dir in line non-interactively.
+	if len(res.DefinitionsRefreshed) > 0 {
+		_ = shims.Reconcile(nil)
 	}
 	for _, name := range res.QuadletsRegenerated {
 		feedback.Warn("regenerated missing unit for %s from its config", name)

--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -148,6 +148,47 @@ type CustomService struct {
 	// handler when it runs as PID 1, which makes podman stop time out and
 	// systemctl restart wedge for ~90s.
 	Init bool `yaml:"init,omitempty" json:"init,omitempty"`
+	// ClientShims lists the client tools this service exposes as host shims
+	// (mysqldump, pg_dump, psql…) so host tools and IDEs can run them against
+	// external databases. Empty for services with nothing to expose.
+	ClientShims []ClientShim `yaml:"client_shims,omitempty" json:"client_shims,omitempty"`
+}
+
+// ClientShim declares a service client tool that lerd exposes as a host shim.
+// Name is the command written onto the host PATH; Binaries are the candidate
+// binaries to resolve inside the service container, tried in order, so a mariadb
+// service can back the mysqldump shim with mariadb-dump. In YAML a bare string
+// is shorthand for a shim whose host name and container binary are identical.
+type ClientShim struct {
+	Name     string   `yaml:"name" json:"name"`
+	Binaries []string `yaml:"binary,omitempty" json:"binary,omitempty"`
+}
+
+// UnmarshalYAML accepts either a bare string (name == binary) or a mapping with
+// an explicit name and one or more candidate binaries.
+func (c *ClientShim) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		c.Name = value.Value
+		c.Binaries = []string{value.Value}
+		return nil
+	case yaml.MappingNode:
+		var raw struct {
+			Name   string   `yaml:"name"`
+			Binary []string `yaml:"binary"`
+		}
+		if err := value.Decode(&raw); err != nil {
+			return err
+		}
+		c.Name = raw.Name
+		c.Binaries = raw.Binary
+		if len(c.Binaries) == 0 {
+			c.Binaries = []string{c.Name}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unexpected YAML node kind %v for client shim", value.Kind)
+	}
 }
 
 // ServiceFilePath returns the deterministic host path for a single FileMount

--- a/internal/config/presets/mysql.yaml
+++ b/internal/config/presets/mysql.yaml
@@ -34,6 +34,9 @@ env_vars:
   - DB_USERNAME=root
   - DB_PASSWORD=lerd
 connection_url: mysql://root:lerd@127.0.0.1:{{host_port}}/lerd
+client_shims:
+  - mysql
+  - mysqldump
 files:
   - target: /etc/mysql/conf.d/lerd.cnf
     content: |

--- a/internal/config/presets/postgres.yaml
+++ b/internal/config/presets/postgres.yaml
@@ -34,3 +34,8 @@ env_vars:
   - DB_USERNAME=postgres
   - DB_PASSWORD=lerd
 connection_url: postgresql://postgres:lerd@127.0.0.1:{{host_port}}/lerd
+client_shims:
+  - psql
+  - pg_dump
+  - pg_dumpall
+  - pg_restore

--- a/internal/config/presets/redis.yaml
+++ b/internal/config/presets/redis.yaml
@@ -16,3 +16,5 @@ env_vars:
   - SESSION_DRIVER=redis
   - QUEUE_CONNECTION=redis
 connection_url: redis://127.0.0.1:6379
+client_shims:
+  - redis-cli

--- a/internal/serviceops/reconcile.go
+++ b/internal/serviceops/reconcile.go
@@ -3,9 +3,11 @@ package serviceops
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
+	"gopkg.in/yaml.v3"
 )
 
 // Seams so tests can drive reconcile without real podman/quadlet work.
@@ -20,6 +22,7 @@ type ReconcileResult struct {
 	QuadletsRegenerated   []string // YAML present, unit was missing and regenerated
 	OrphansRemoved        []string // service quadlet with no YAML, removed
 	RunningOrphansSkipped []string // orphan left in place because its container is up
+	DefinitionsRefreshed  []string // preset-backed YAML re-materialised from the store
 }
 
 // ReconcileServices enforces the issue #678 invariant: regenerate a missing
@@ -40,22 +43,34 @@ func ReconcileServices(emit func(PhaseEvent)) (ReconcileResult, error) {
 		return res, fmt.Errorf("listing custom services: %w", err)
 	}
 	for _, svc := range customs {
-		// Backfill: an add-on preset now lives in the store, not the binary. A
-		// service installed by an older (add-on-embedding) lerd has no cached
-		// preset after upgrade, so its file mounts, family and dashboard would go
-		// missing. Fetch it once into the cache; best-effort, offline just defers
-		// it to the next reconcile. Guarded by PresetExists so it never re-fetches.
-		if svc.Preset != "" && !config.PresetExists(svc.Preset) {
-			_, _ = config.EnsurePreset(svc.Preset)
+		// Re-materialise declarative fields (client_shims, family, dashboard,
+		// env mappings…) from the store preset so a store change reaches an
+		// already-installed service, preserving install-time pins. EnsurePreset
+		// inside also backfills the cache for a service installed by an older
+		// lerd. Best-effort: offline or an unresolvable version leaves the
+		// snapshot untouched.
+		if refreshed, changed := refreshPresetDefinition(svc); changed {
+			if err := config.SaveCustomService(refreshed); err != nil {
+				errs = append(errs, fmt.Errorf("refreshing %s from preset: %w", svc.Name, err))
+			} else {
+				svc = refreshed
+				res.DefinitionsRefreshed = append(res.DefinitionsRefreshed, svc.Name)
+			}
 		}
-		if UnitInstalledFn("lerd-" + svc.Name) {
+		unitInstalled := UnitInstalledFn("lerd-" + svc.Name)
+		if unitInstalled && !slices.Contains(res.DefinitionsRefreshed, svc.Name) {
 			continue
 		}
+		// Regenerate the quadlet when the unit is missing, or when the definition
+		// changed. WriteQuadletDiff is a no-op when the content is identical, so a
+		// client_shims-only change (which never appears in the quadlet) is free.
 		if err := ensureQuadletFn(svc); err != nil {
 			errs = append(errs, fmt.Errorf("regenerating quadlet for %s: %w", svc.Name, err))
 			continue
 		}
-		res.QuadletsRegenerated = append(res.QuadletsRegenerated, svc.Name)
+		if !unitInstalled {
+			res.QuadletsRegenerated = append(res.QuadletsRegenerated, svc.Name)
+		}
 	}
 
 	// Backward: a service quadlet with no YAML is an orphan. Candidates are marked
@@ -80,6 +95,57 @@ func ReconcileServices(emit func(PhaseEvent)) (ReconcileResult, error) {
 		res.OrphansRemoved = append(res.OrphansRemoved, name)
 	}
 	return res, errors.Join(errs...)
+}
+
+// refreshPresetDefinition re-resolves a preset-backed service from the store
+// preset so declarative additions (client_shims, family, dashboard…) reach an
+// already-installed service, while preserving install-time pins: the running
+// image, rollback/migrate state, and identity. Returns the refreshed definition
+// and whether it changed. A non-preset service, an unresolvable preset, or a
+// removed version leaves the snapshot unchanged.
+func refreshPresetDefinition(svc *config.CustomService) (*config.CustomService, bool) {
+	if svc.Preset == "" {
+		return svc, false
+	}
+	preset, err := config.EnsurePreset(svc.Preset)
+	if err != nil {
+		return svc, false
+	}
+	// A canonical install carries the bare preset name; resolve it pinned so a
+	// later canonical-version flip in the store never renames it (which would
+	// rewrite its {{name}}-templated DB_HOST/connection_url to a container that
+	// does not exist). An alternate install keeps its version-suffixed name.
+	var fresh *config.CustomService
+	if svc.Name == preset.Name {
+		fresh, err = preset.ResolvePinned(svc.PresetVersion)
+	} else {
+		fresh, err = preset.Resolve(svc.PresetVersion)
+	}
+	if err != nil {
+		return svc, false
+	}
+	// Preserve install-time pins and state; everything else comes from the
+	// store. Image stays put so a passive reconcile never upgrades the running
+	// container, that remains an explicit `lerd service update`/`migrate`.
+	fresh.Image = svc.Image
+	fresh.PreviousImage = svc.PreviousImage
+	fresh.LastOp = svc.LastOp
+	fresh.PreMigrateBackup = svc.PreMigrateBackup
+	fresh.Name = svc.Name
+	fresh.Preset = svc.Preset
+	fresh.PresetVersion = svc.PresetVersion
+
+	if sameDefinition(fresh, svc) {
+		return svc, false
+	}
+	return fresh, true
+}
+
+// sameDefinition compares two service definitions by their serialised form.
+func sameDefinition(a, b *config.CustomService) bool {
+	ay, err1 := yaml.Marshal(a)
+	by, err2 := yaml.Marshal(b)
+	return err1 == nil && err2 == nil && string(ay) == string(by)
 }
 
 // orphanCandidates is the deduped set of service names worth checking for an

--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -1,0 +1,409 @@
+// Package shims is the single owner of the client-tool host shims that lerd
+// services expose (mysqldump, pg_dump, psql…): the tri-state install decisions,
+// host-conflict detection, script generation, and the reconcile that brings the
+// shim dir in line with the installed services.
+//
+// Scope is deliberately just these service client tools. The php/composer/node
+// shims are a different category (always-on or a single global toggle, exec on
+// the host or into the FPM container) and stay owned by the installer's
+// addShellShims and the shim_sync mirror; they are intentionally not managed
+// here.
+package shims
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/services"
+	"gopkg.in/yaml.v3"
+)
+
+// marker tags every generated shim so the reconcile only ever touches its own
+// files, never a user binary or another shim category.
+const marker = "lerd-managed service client shim"
+
+// Target records which service container a tool shim execs into and the
+// candidate binaries to resolve there (mariadb images ship mariadb-dump in
+// place of mysqldump, so the shim tries each in order).
+type Target struct {
+	Service  string
+	Binaries []string
+}
+
+// Info is the per-tool shim state the CLI and web UI render: which service
+// backs it, whether the host already has the tool (so callers can warn before
+// shadowing it), whether a decision has been recorded, and whether it's on.
+// Owner is the service that actually backs the shim when several same-family
+// services expose the same tool; a service whose name differs from Owner does
+// not manage the shim and its toggle is shown disabled.
+type Info struct {
+	Tool    string `json:"tool"`
+	Service string `json:"service,omitempty"`
+	Owner   string `json:"owner,omitempty"`
+	HostHas bool   `json:"host_has"`
+	Enabled bool   `json:"enabled"`
+	Decided bool   `json:"decided"`
+}
+
+// Prompter resolves a host-conflict when the host already has a tool. It
+// returns whether to enable the shim and whether a decision was actually made.
+// A nil Prompter leaves the conflict undecided so a later interactive run or the
+// web UI can resolve it.
+type Prompter func(tool string) (enable, decided bool)
+
+// script renders the host shim: a trivial pass-through into
+// `lerd client-exec <tool>`, so args, stdin, stdout and exit code all behave
+// exactly like the native binary an IDE would call.
+func script(lerdBin, tool string) string {
+	return "#!/bin/sh\n# " + marker + "\nexec " + lerdBin + " client-exec " + tool + " \"$@\"\n"
+}
+
+// Targets maps every client tool exposed by an installed service to the
+// container and candidate binaries that back it. The first installed service to
+// declare a given tool name wins, so a mysql and a mariadb install both exposing
+// `mysql` resolve deterministically.
+func Targets() map[string]Target {
+	out := map[string]Target{}
+	for _, name := range installedServiceNames() {
+		svc, err := loadServiceDef(name)
+		if err != nil || svc == nil {
+			continue
+		}
+		for _, cs := range svc.ClientShims {
+			if cs.Name == "" {
+				continue
+			}
+			if _, exists := out[cs.Name]; exists {
+				continue
+			}
+			bins := cs.Binaries
+			if len(bins) == 0 {
+				bins = []string{cs.Name}
+			}
+			out[cs.Name] = Target{Service: name, Binaries: bins}
+		}
+	}
+	return out
+}
+
+// installedServiceNames lists every service whose container unit is installed,
+// covering canonical default presets and installed add-ons / alternate versions.
+func installedServiceNames() []string {
+	var names []string
+	for _, n := range config.DefaultPresetNames() {
+		if services.Mgr != nil && services.Mgr.ContainerUnitInstalled("lerd-"+n) {
+			names = append(names, n)
+		}
+	}
+	customs, _ := config.ListCustomServices()
+	for _, c := range customs {
+		if services.Mgr != nil && services.Mgr.ContainerUnitInstalled("lerd-"+c.Name) {
+			names = append(names, c.Name)
+		}
+	}
+	return names
+}
+
+// loadServiceDef resolves a service's definition whether it is a canonical
+// default preset (mysql, postgres) resolved from the embedded YAML or an
+// installed add-on / alternate version stored as a custom service.
+func loadServiceDef(name string) (*config.CustomService, error) {
+	if config.IsDefaultPreset(name) {
+		p, err := config.LoadPreset(name)
+		if err != nil {
+			return nil, err
+		}
+		return p.Resolve("")
+	}
+	return config.LoadCustomService(name)
+}
+
+// ServiceShims returns the client-tool shim state for one installed service,
+// one entry per tool it declares. Owner is filled from the global targets so a
+// service that only shares a same-family tool (not its owner) is marked. Empty
+// when the service exposes none.
+func ServiceShims(name string) []Info {
+	svc, err := loadServiceDef(name)
+	if err != nil || svc == nil {
+		return nil
+	}
+	targets := Targets()
+	var out []Info
+	for _, cs := range svc.ClientShims {
+		if cs.Name == "" {
+			continue
+		}
+		enabled, decided := decision(cs.Name)
+		out = append(out, Info{
+			Tool:    cs.Name,
+			Service: name,
+			Owner:   targets[cs.Name].Service,
+			HostHas: hostHasTool(cs.Name),
+			Enabled: enabled,
+			Decided: decided,
+		})
+	}
+	return out
+}
+
+// ToolOwner returns the installed service that backs the tool's shim, or "" when
+// no installed service exposes it. Used to guard toggles so a shared shim is
+// only managed from its owner.
+func ToolOwner(tool string) string {
+	return Targets()[tool].Service
+}
+
+// ResolveTarget picks the container and binaries to run a tool in. When prefer
+// names an installed service that exposes the tool, it wins (site-aware
+// routing: a dump run from a project targets that project's own database
+// service). Otherwise it falls back to the global owner. The bool is false only
+// when no installed service exposes the tool at all.
+func ResolveTarget(tool, prefer string) (Target, bool) {
+	if prefer != "" {
+		if t, ok := serviceTarget(prefer, tool); ok {
+			return t, true
+		}
+	}
+	t, ok := Targets()[tool]
+	return t, ok
+}
+
+// serviceTarget returns the Target for a tool as declared by a specific
+// installed service, or false when that service does not expose the tool.
+func serviceTarget(service, tool string) (Target, bool) {
+	svc, err := loadServiceDef(service)
+	if err != nil || svc == nil {
+		return Target{}, false
+	}
+	for _, cs := range svc.ClientShims {
+		if cs.Name == tool {
+			bins := cs.Binaries
+			if len(bins) == 0 {
+				bins = []string{tool}
+			}
+			return Target{Service: service, Binaries: bins}, true
+		}
+	}
+	return Target{}, false
+}
+
+// List returns every exposed client tool with its state, sorted by tool name,
+// for the `lerd shims` listing.
+func List() []Info {
+	targets := Targets()
+	tools := make([]string, 0, len(targets))
+	for t := range targets {
+		tools = append(tools, t)
+	}
+	sort.Strings(tools)
+	out := make([]Info, 0, len(tools))
+	for _, t := range tools {
+		enabled, decided := decision(t)
+		out = append(out, Info{
+			Tool:    t,
+			Service: targets[t].Service,
+			HostHas: hostHasTool(t),
+			Enabled: enabled,
+			Decided: decided,
+		})
+	}
+	return out
+}
+
+// Set is the single entry point for an explicit shim decision, shared by the
+// CLI (`lerd shims add/remove`) and the web UI toggle. It validates that an
+// installed service actually exposes the tool, records the decision, and
+// reconciles so the change takes effect at once. It never prompts.
+func Set(tool string, enabled bool) error {
+	if _, ok := Targets()[tool]; !ok {
+		return fmt.Errorf("no installed service exposes the %q client tool", tool)
+	}
+	if err := setDecision(tool, enabled); err != nil {
+		return err
+	}
+	return Reconcile(nil)
+}
+
+// Reconcile brings the host shim dir in line with the tools the installed
+// services expose and the recorded decisions. prompt resolves a host-conflict
+// on first sight; pass nil on non-interactive paths (a removal, an update
+// reconcile) to leave conflicts undecided. Shims for tools no longer exposed by
+// any installed service are pruned.
+func Reconcile(prompt Prompter) error {
+	lerdBin, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	binDir := config.BinDir()
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return err
+	}
+
+	targets := Targets()
+	for tool := range targets {
+		enabled, _ := decide(tool, prompt)
+		shimPath := filepath.Join(binDir, tool)
+		if enabled {
+			_ = os.WriteFile(shimPath, []byte(script(lerdBin, tool)), 0755)
+		} else {
+			removeIfShim(shimPath)
+		}
+	}
+	pruneOrphans(targets)
+	return nil
+}
+
+// decide resolves whether a tool's shim should be installed. A recorded decision
+// wins. Otherwise, when the host lacks the tool there is no conflict so the shim
+// is enabled automatically; when the host already has it, prompt decides (and
+// the answer is recorded). A nil prompt leaves the conflict undecided.
+func decide(tool string, prompt Prompter) (enabled, decided bool) {
+	if e, d := decision(tool); d {
+		return e, true
+	}
+	if !hostHasTool(tool) {
+		_ = setDecision(tool, true)
+		return true, true
+	}
+	if prompt == nil {
+		return false, false
+	}
+	e, d := prompt(tool)
+	if d {
+		_ = setDecision(tool, e)
+	}
+	return e, d
+}
+
+// hostHasTool reports whether the user already has the named tool on their PATH,
+// excluding lerd's own shim dir so a previously-installed lerd shim is never
+// mistaken for a real host binary.
+func hostHasTool(tool string) bool {
+	binDir := config.BinDir()
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" || dir == binDir {
+			continue
+		}
+		cand := filepath.Join(dir, tool)
+		if info, err := os.Stat(cand); err == nil && !info.IsDir() && info.Mode()&0111 != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// removeIfShim deletes path only when it is one of lerd's client shims, so the
+// reconcile never removes a user's own binary of the same name.
+func removeIfShim(path string) {
+	if isShimFile(path) {
+		_ = os.Remove(path)
+	}
+}
+
+// pruneOrphans removes generated shims whose tool is no longer exposed by any
+// installed service and forgets the stale decision so a later reinstall
+// re-decides fresh.
+func pruneOrphans(targets map[string]Target) {
+	binDir := config.BinDir()
+	entries, err := os.ReadDir(binDir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		tool := e.Name()
+		if _, ok := targets[tool]; ok {
+			continue
+		}
+		path := filepath.Join(binDir, tool)
+		if isShimFile(path) {
+			_ = os.Remove(path)
+			_ = forgetDecision(tool)
+		}
+	}
+}
+
+// isShimFile reports whether path is a lerd-managed client shim, matched by the
+// marker comment its generator writes.
+func isShimFile(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), marker)
+}
+
+// ── decision storage ────────────────────────────────────────────────────────
+//
+// Decisions are tri-state: a tool absent from the file is undecided (the
+// reconcile still has to choose), present-true is an installed shim,
+// present-false is a shim the user declined. The set-based service flag files
+// can't express the declined state, so this uses its own map file.
+
+func decisionsFile() string {
+	return filepath.Join(config.DataDir(), "client-shim-decisions.yaml")
+}
+
+// decision returns whether the host shim for the tool is enabled and whether any
+// decision has been recorded.
+func decision(tool string) (enabled, decided bool) {
+	m, err := loadDecisions()
+	if err != nil {
+		return false, false
+	}
+	v, ok := m[tool]
+	return v, ok
+}
+
+func setDecision(tool string, enabled bool) error {
+	m, err := loadDecisions()
+	if err != nil {
+		m = map[string]bool{}
+	}
+	m[tool] = enabled
+	return saveDecisions(m)
+}
+
+func forgetDecision(tool string) error {
+	m, err := loadDecisions()
+	if err != nil || len(m) == 0 {
+		return nil
+	}
+	if _, ok := m[tool]; !ok {
+		return nil
+	}
+	delete(m, tool)
+	return saveDecisions(m)
+}
+
+func loadDecisions() (map[string]bool, error) {
+	data, err := os.ReadFile(decisionsFile())
+	if os.IsNotExist(err) {
+		return map[string]bool{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	m := map[string]bool{}
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func saveDecisions(m map[string]bool) error {
+	if err := os.MkdirAll(filepath.Dir(decisionsFile()), 0755); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(decisionsFile(), data, 0644)
+}

--- a/internal/shims/shims_test.go
+++ b/internal/shims/shims_test.go
@@ -1,0 +1,141 @@
+package shims
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestScript(t *testing.T) {
+	got := script("/home/u/.local/bin/lerd", "mysqldump")
+	for _, want := range []string{"#!/bin/sh", marker, "client-exec mysqldump", "\"$@\""} {
+		if !strings.Contains(got, want) {
+			t.Errorf("script missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestIsShimFile(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "mysqldump")
+	_ = os.WriteFile(shim, []byte(script("lerd", "mysqldump")), 0755)
+	other := filepath.Join(dir, "realtool")
+	_ = os.WriteFile(other, []byte("#!/bin/sh\necho hi\n"), 0755)
+	if !isShimFile(shim) {
+		t.Error("marked shim not detected")
+	}
+	if isShimFile(other) {
+		t.Error("user binary wrongly detected as shim")
+	}
+}
+
+func TestRemoveIfShim(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "psql")
+	user := filepath.Join(dir, "psql-user")
+	_ = os.WriteFile(shim, []byte(script("lerd", "psql")), 0755)
+	_ = os.WriteFile(user, []byte("#!/bin/sh\n"), 0755)
+
+	removeIfShim(shim)
+	removeIfShim(user)
+
+	if _, err := os.Stat(shim); !os.IsNotExist(err) {
+		t.Error("shim should have been removed")
+	}
+	if _, err := os.Stat(user); err != nil {
+		t.Error("user binary must never be removed")
+	}
+}
+
+func TestPruneOrphans(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	binDir := config.BinDir()
+	_ = os.MkdirAll(binDir, 0755)
+	live := filepath.Join(binDir, "mysqldump")
+	orphan := filepath.Join(binDir, "pg_dump")
+	user := filepath.Join(binDir, "sqlite3")
+	_ = os.WriteFile(live, []byte(script("lerd", "mysqldump")), 0755)
+	_ = os.WriteFile(orphan, []byte(script("lerd", "pg_dump")), 0755)
+	_ = os.WriteFile(user, []byte("#!/bin/sh\n"), 0755)
+	_ = setDecision("pg_dump", true)
+
+	pruneOrphans(map[string]Target{"mysqldump": {Service: "mysql", Binaries: []string{"mysqldump"}}})
+
+	if _, err := os.Stat(live); err != nil {
+		t.Error("live shim must be kept")
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Error("orphan shim must be pruned")
+	}
+	if _, err := os.Stat(user); err != nil {
+		t.Error("non-lerd binary must never be pruned")
+	}
+	if _, decided := decision("pg_dump"); decided {
+		t.Error("pruned tool's decision must be forgotten")
+	}
+}
+
+func TestHostHasTool(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	hostDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(hostDir, "mysqldump"), []byte("#!/bin/sh\n"), 0755)
+	binDir := config.BinDir()
+	_ = os.MkdirAll(binDir, 0755)
+	_ = os.WriteFile(filepath.Join(binDir, "pg_dump"), []byte("#!/bin/sh\n"), 0755)
+	t.Setenv("PATH", hostDir+string(os.PathListSeparator)+binDir)
+
+	if !hostHasTool("mysqldump") {
+		t.Error("host tool on PATH should be detected")
+	}
+	if hostHasTool("pg_dump") {
+		t.Error("a tool only in lerd's bin dir must not count as host-installed")
+	}
+	if hostHasTool("nonexistent-tool") {
+		t.Error("absent tool must not be detected")
+	}
+}
+
+func TestDecisionTriState(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	if _, decided := decision("mysqldump"); decided {
+		t.Fatal("fresh tool should be undecided")
+	}
+	_ = setDecision("mysqldump", true)
+	if e, d := decision("mysqldump"); !d || !e {
+		t.Fatalf("want decided+enabled, got decided=%v enabled=%v", d, e)
+	}
+	_ = setDecision("mysqldump", false)
+	if e, d := decision("mysqldump"); !d || e {
+		t.Fatalf("want decided+disabled, got decided=%v enabled=%v", d, e)
+	}
+	_ = forgetDecision("mysqldump")
+	if _, decided := decision("mysqldump"); decided {
+		t.Fatal("forgotten tool should be undecided again")
+	}
+}
+
+func TestDecideAutoEnablesWhenHostLacksTool(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir()) // host has nothing
+
+	enabled, decided := decide("mysqldump", nil)
+	if !enabled || !decided {
+		t.Fatalf("host lacking the tool should auto-enable, got enabled=%v decided=%v", enabled, decided)
+	}
+}
+
+func TestDecideLeavesConflictUndecidedWithoutPrompter(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	hostDir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(hostDir, "mysqldump"), []byte("#!/bin/sh\n"), 0755)
+	t.Setenv("PATH", hostDir)
+
+	enabled, decided := decide("mysqldump", nil)
+	if enabled || decided {
+		t.Fatalf("a host conflict with no prompter must stay undecided, got enabled=%v decided=%v", enabled, decided)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -45,6 +45,7 @@ import (
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/serviceops"
 	"github.com/geodro/lerd/internal/services"
+	"github.com/geodro/lerd/internal/shims"
 	"github.com/geodro/lerd/internal/sitedoctor"
 	"github.com/geodro/lerd/internal/siteinfo"
 	"github.com/geodro/lerd/internal/siteops"
@@ -1078,6 +1079,10 @@ type ServiceResponse struct {
 	MigrationSupported bool           `json:"migration_supported"`
 	CanRollback        bool           `json:"can_rollback"`
 	PortConflicts      []PortConflict `json:"port_conflicts,omitempty"`
+	// ClientShims are the client tools this service exposes as host shims
+	// (mysqldump, pg_dump…), each with whether the host already has the tool and
+	// the user's current decision. The service card renders a toggle per tool.
+	ClientShims []shims.Info `json:"client_shims,omitempty"`
 }
 
 // PortConflict reports a host port lerd wants to bind that is already taken
@@ -1138,45 +1143,102 @@ func loadServicesMap() map[string]config.ServiceConfig {
 }
 
 func buildServiceResponse(name string) ServiceResponse {
-	return buildServiceResponseWithPortList(loadServicesMap(), name, "")
+	return buildServiceResponseWithPortList(loadServicesMap(), name, "", nil)
 }
 
-func buildServiceResponseWithPortList(services map[string]config.ServiceConfig, name, ssOutput string) ServiceResponse {
+// buildServiceResponseWithPortList is the single builder for a service's UI
+// response, covering both built-in default presets and custom/add-on services.
+// The definition source differs (bundled preset helpers vs the stored YAML), so
+// it is resolved once up front; every response field is then set in this one
+// place. Do not add a second builder for a service kind — a field set here must
+// never be silently missing for the other kind (that is exactly how client_shims
+// went missing for add-ons).
+// custom is the already-loaded definition for an add-on service (passed by the
+// list rebuild so it is not re-read and an error cannot blank the card); pass
+// nil for a default preset or to have it loaded by name.
+func buildServiceResponseWithPortList(services map[string]config.ServiceConfig, name, ssOutput string, custom *config.CustomService) ServiceResponse {
 	unit := "lerd-" + name
 	status, _ := podman.UnitStatus(unit)
 	if status == "" {
 		status = "inactive"
 	}
 
-	envMap := map[string]string{}
-	for _, kv := range config.DefaultPresetEnvVars(name) {
-		parts := strings.SplitN(kv, "=", 2)
-		if len(parts) == 2 {
-			envMap[parts[0]] = parts[1]
+	// Resolve the definition source once: a default preset reads from the
+	// bundled preset helpers, a custom/add-on service from its stored YAML.
+	isDefault := config.IsDefaultPreset(name)
+	if !isDefault && custom == nil {
+		custom, _ = config.LoadCustomService(name)
+	}
+
+	var (
+		envKVs       []string
+		presetPorts  []string
+		dashboardRaw string
+		dashExternal bool
+		connURL      string
+		dependsOn    []string
+	)
+	switch {
+	case isDefault:
+		envKVs = config.DefaultPresetEnvVars(name)
+		presetPorts = config.PresetPorts(name)
+		dashboardRaw = config.DefaultPresetDashboard(name)
+		connURL = config.DefaultPresetConnectionURL(name)
+	case custom != nil:
+		envKVs = custom.EnvVars
+		presetPorts = custom.Ports
+		dashboardRaw = custom.Dashboard
+		dashExternal = custom.DashboardExternal
+		connURL = custom.ConnectionURL
+		dependsOn = custom.DependsOn
+		// Bundled dashboards that asked to open externally (cross-origin cookie
+		// trouble) are proxied same-origin under /_svc/<name>/ so they embed in
+		// the iframe overlay; user custom services keep the new tab.
+		if dashProxyEligible(custom) {
+			dashboardRaw, dashExternal = dashProxyPath(name), false
 		}
 	}
 
-	presetPorts := config.PresetPorts(name)
+	handle := "lerd-" + name
+	envMap := map[string]string{}
+	for _, kv := range envKVs {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) == 2 {
+			v := strings.ReplaceAll(parts[1], "{{site}}", handle)
+			v = strings.ReplaceAll(v, "{{site_testing}}", handle+"_testing")
+			envMap[parts[0]] = v
+		}
+	}
+
 	hostPort := effectiveHostPort(services, name, presetPorts)
 	defaultPort := podman.PrimaryHostPort(presetPorts)
 	if sc, ok := services[name]; ok && sc.Port > 0 {
 		defaultPort = sc.Port
 	}
+	// Prefer the installed quadlet's image; fall back to the stored definition so
+	// a custom service whose quadlet is momentarily absent keeps its version.
+	image := podman.InstalledImage(unit)
+	if image == "" && custom != nil {
+		image = custom.Image
+	}
 	resp := ServiceResponse{
-		Name:          name,
-		Status:        status,
-		Version:       podman.ServiceVersionLabel(podman.InstalledImage(unit)),
-		EnvVars:       envMap,
-		Dashboard:     serviceops.WithDashboardPort(config.DefaultPresetDashboard(name), presetPorts, services[name]),
-		ConnectionURL: serviceops.WithURLPort(config.DefaultPresetConnectionURL(name), hostPort),
-		Port:          hostPort,
-		SiteCount:     countSitesUsingService(name),
-		SiteDomains:   sitesUsingService(name),
-		Pinned:        config.ServiceIsPinned(name),
-		Paused:        config.ServiceIsPaused(name),
-		IsDefault:     config.IsDefaultPreset(name),
-		PresetOwned:   config.PresetExists(name),
-		DefaultPort:   defaultPort,
+		Name:              name,
+		Status:            status,
+		Version:           podman.ServiceVersionLabel(image),
+		EnvVars:           envMap,
+		Dashboard:         serviceops.WithDashboardPort(dashboardRaw, presetPorts, services[name]),
+		DashboardExternal: dashExternal,
+		ConnectionURL:     serviceops.WithURLPort(connURL, hostPort),
+		Port:              hostPort,
+		SiteCount:         countSitesUsingService(name),
+		SiteDomains:       sitesUsingService(name),
+		Pinned:            config.ServiceIsPinned(name),
+		Paused:            config.ServiceIsPaused(name),
+		IsDefault:         isDefault,
+		Custom:            custom != nil,
+		PresetOwned:       config.PresetExists(name),
+		DefaultPort:       defaultPort,
+		DependsOn:         dependsOn,
 	}
 	resp.SecondaryPorts = secondaryPortMappings(presetPorts, services[name])
 	if sc, ok := services[name]; ok {
@@ -1197,6 +1259,7 @@ func buildServiceResponseWithPortList(services map[string]config.ServiceConfig, 
 				resp.Tunable = true
 			}
 		}
+		resp.ClientShims = shims.ServiceShims(name)
 	}
 	// Default-preset services advertise update availability so the dashboard
 	// can show an "→ v8.4.3" badge. Stopped services also run the check so the
@@ -1267,65 +1330,14 @@ func buildServicesList() []ServiceResponse {
 	defaultNames := siteinfo.KnownServices()
 	services := make([]ServiceResponse, 0, len(defaultNames))
 	for _, name := range defaultNames {
-		services = append(services, buildServiceResponseWithPortList(svcCfg, name, ssOutput))
+		services = append(services, buildServiceResponseWithPortList(svcCfg, name, ssOutput, nil))
 	}
+	// Optional presets (gotenberg, mongo, …) and user services materialise as
+	// custom services; they go through the SAME builder as the default presets
+	// so every field is populated identically for both kinds.
 	customs, _ := config.ListCustomServices()
 	for _, svc := range customs {
-		unit := "lerd-" + svc.Name
-		status, _ := podman.UnitStatus(unit)
-		if status == "" {
-			status = "inactive"
-		}
-		displayHandle := "lerd-" + svc.Name
-		envMap := map[string]string{}
-		for _, kv := range svc.EnvVars {
-			parts := strings.SplitN(kv, "=", 2)
-			if len(parts) == 2 {
-				v := strings.ReplaceAll(parts[1], "{{site}}", displayHandle)
-				v = strings.ReplaceAll(v, "{{site_testing}}", displayHandle+"_testing")
-				envMap[parts[0]] = v
-			}
-		}
-		var conflicts []PortConflict
-		if status != "active" {
-			conflicts = portConflictsFor(unit, ssOutput)
-		}
-		_, tunable := config.ServiceTuningMount(svc)
-		// Bundled dashboards that asked to open externally (cross-origin cookie
-		// trouble) are instead proxied same-origin under /_svc/<name>/ so they
-		// embed in the iframe overlay; user custom services keep the new tab.
-		dashboard, dashboardExternal := svc.Dashboard, svc.DashboardExternal
-		if dashProxyEligible(svc) {
-			dashboard, dashboardExternal = dashProxyPath(svc.Name), false
-		}
-		hostPort := effectiveHostPort(svcCfg, svc.Name, svc.Ports)
-		// Optional presets (gotenberg, mongo, …) materialise as custom services, so
-		// they land here rather than in the default-preset loop. Surface the same
-		// port fields the ports modal needs: preset ownership drives the extra-ports
-		// affordance, and the declared default host port drives the autofill.
-		services = append(services, ServiceResponse{
-			Name:              svc.Name,
-			Status:            status,
-			Version:           podman.ServiceVersionLabel(svc.Image),
-			EnvVars:           envMap,
-			Dashboard:         serviceops.WithDashboardPort(dashboard, svc.Ports, svcCfg[svc.Name]),
-			DashboardExternal: dashboardExternal,
-			ConnectionURL:     serviceops.WithURLPort(svc.ConnectionURL, hostPort),
-			Port:              hostPort,
-			Custom:            true,
-			PresetOwned:       config.PresetExists(svc.Name),
-			DefaultPort:       podman.PrimaryHostPort(svc.Ports),
-			PublishedPort:     config.ServicePublishedPort(svc.Name),
-			ExtraPorts:        config.ServiceExtraPorts(svc.Name),
-			SecondaryPorts:    secondaryPortMappings(svc.Ports, svcCfg[svc.Name]),
-			Tunable:           tunable,
-			SiteCount:         countSitesUsingService(svc.Name),
-			SiteDomains:       sitesUsingService(svc.Name),
-			Pinned:            config.ServiceIsPinned(svc.Name),
-			Paused:            config.ServiceIsPaused(svc.Name),
-			DependsOn:         svc.DependsOn,
-			PortConflicts:     conflicts,
-		})
+		services = append(services, buildServiceResponseWithPortList(svcCfg, svc.Name, ssOutput, svc))
 	}
 	for _, siteName := range listActiveQueueWorkers() {
 		services = append(services, ServiceResponse{
@@ -2037,6 +2049,11 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if action == "shims" && r.Method == http.MethodPost {
+		handleServiceShims(w, r, name)
+		return
+	}
+
 	if action == "update" && r.Method == http.MethodPost {
 		targetTag := r.URL.Query().Get("tag")
 		var targetImage string
@@ -2447,6 +2464,43 @@ func handleServicePorts(w http.ResponseWriter, r *http.Request, name string) {
 			_ = serviceops.RestorePublishedPorts(name, snapshot)
 		}
 		fail(err)
+		return
+	}
+	writeJSON(w, ServiceActionResponse{
+		ServiceResponse: buildServiceResponse(name),
+		OK:              true,
+	})
+}
+
+// handleServiceShims records the user's decision for one client-tool shim and
+// reconciles the shim dir so it takes effect immediately. Mirrors the ports
+// handler's request/response shape so the frontend refreshes off the returned
+// service state.
+func handleServiceShims(w http.ResponseWriter, r *http.Request, name string) {
+	var body struct {
+		Tool    string `json:"tool"`
+		Enabled bool   `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Tool == "" {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	// A shared same-family tool is managed only from its owning service, so a
+	// toggle from a non-owner is rejected (its toggle is disabled in the UI).
+	if owner := shims.ToolOwner(body.Tool); owner != "" && owner != name {
+		writeJSON(w, ServiceActionResponse{
+			ServiceResponse: buildServiceResponse(name),
+			OK:              false,
+			Error:           fmt.Sprintf("%s is provided by %s; manage it there", body.Tool, owner),
+		})
+		return
+	}
+	if err := shims.Set(body.Tool, body.Enabled); err != nil {
+		writeJSON(w, ServiceActionResponse{
+			ServiceResponse: buildServiceResponse(name),
+			OK:              false,
+			Error:           err.Error(),
+		})
 		return
 	}
 	writeJSON(w, ServiceActionResponse{

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -999,5 +999,21 @@
   "services_cat_other": "Sonstige",
   "services_cat_messaging": "Messaging",
   "tinker_lspConnecting": "Sprachserver startet…",
-  "tinker_lspUnavailable": "Sprachserver nicht verfügbar"
+  "tinker_lspUnavailable": "Sprachserver nicht verfügbar",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "envEditor_proposeReview": "Schlüssel prüfen",
+  "envEditor_proposeModalTitle": "Fehlende Umgebungsschlüssel hinzufügen",
+  "envEditor_proposeModalBody": "Wählen Sie, welche Schlüssel zu {file} hinzugefügt werden sollen. Die Werte werden aus .env.example kopiert, prüfen Sie sie und tragen Sie nach dem Hinzufügen echte Werte ein.",
+  "envEditor_proposeRequiredHeading": "Erforderlich",
+  "envEditor_proposeOptionalHeading": "Optional",
+  "envEditor_proposeSelectAll": "Alle auswählen",
+  "envEditor_proposeSelectNone": "Löschen",
+  "envEditor_proposeAddSelected": "{n} hinzufügen",
+  "envEditor_proposeAddNone": "Auswahl hinzufügen",
+  "services_shimsInstalled": "Client-Tools in deinem PATH",
+  "services_tools_providedBy": "Bereitgestellt von {service}"
 }

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -1008,5 +1008,12 @@
   "services_cat_storage": "Storage",
   "services_cat_testing": "Testing",
   "services_cat_other": "Other",
-  "services_cat_messaging": "Messaging"
+  "services_cat_messaging": "Messaging",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "services_shimsInstalled": "Client tools on your PATH",
+  "services_tools_providedBy": "Provided by {service}"
 }

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -999,5 +999,21 @@
   "services_cat_other": "Otros",
   "services_cat_messaging": "Mensajería",
   "tinker_lspConnecting": "Iniciando servidor de lenguaje…",
-  "tinker_lspUnavailable": "Servidor de lenguaje no disponible"
+  "tinker_lspUnavailable": "Servidor de lenguaje no disponible",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "envEditor_proposeReview": "Revisar claves",
+  "envEditor_proposeModalTitle": "Añadir claves de entorno faltantes",
+  "envEditor_proposeModalBody": "Elige qué claves añadir a {file}. Los valores se copian de .env.example, así que revísalos y completa los reales después de añadirlos.",
+  "envEditor_proposeRequiredHeading": "Obligatorias",
+  "envEditor_proposeOptionalHeading": "Opcionales",
+  "envEditor_proposeSelectAll": "Seleccionar todo",
+  "envEditor_proposeSelectNone": "Borrar",
+  "envEditor_proposeAddSelected": "Añadir {n}",
+  "envEditor_proposeAddNone": "Añadir seleccionadas",
+  "services_shimsInstalled": "Herramientas de cliente en tu PATH",
+  "services_tools_providedBy": "Proporcionado por {service}"
 }

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -999,5 +999,21 @@
   "services_cat_other": "Autres",
   "services_cat_messaging": "Messagerie",
   "tinker_lspConnecting": "Démarrage du serveur de langage…",
-  "tinker_lspUnavailable": "Serveur de langage indisponible"
+  "tinker_lspUnavailable": "Serveur de langage indisponible",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "envEditor_proposeReview": "Vérifier les clés",
+  "envEditor_proposeModalTitle": "Ajouter les clés d’environnement manquantes",
+  "envEditor_proposeModalBody": "Choisissez les clés à ajouter à {file}. Les valeurs sont copiées depuis .env.example, vérifiez-les et renseignez les vraies après l’ajout.",
+  "envEditor_proposeRequiredHeading": "Requises",
+  "envEditor_proposeOptionalHeading": "Facultatives",
+  "envEditor_proposeSelectAll": "Tout sélectionner",
+  "envEditor_proposeSelectNone": "Effacer",
+  "envEditor_proposeAddSelected": "Ajouter {n}",
+  "envEditor_proposeAddNone": "Ajouter la sélection",
+  "services_shimsInstalled": "Outils client sur votre PATH",
+  "services_tools_providedBy": "Fourni par {service}"
 }

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -999,5 +999,21 @@
   "services_cat_other": "Lainnya",
   "services_cat_messaging": "Perpesanan",
   "tinker_lspConnecting": "Memulai server bahasa…",
-  "tinker_lspUnavailable": "Server bahasa tidak tersedia"
+  "tinker_lspUnavailable": "Server bahasa tidak tersedia",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "envEditor_proposeReview": "Tinjau kunci",
+  "envEditor_proposeModalTitle": "Tambahkan kunci env yang hilang",
+  "envEditor_proposeModalBody": "Pilih kunci mana yang akan ditambahkan ke {file}. Nilai disalin dari .env.example, jadi tinjau dan isi nilai sebenarnya setelah menambahkan.",
+  "envEditor_proposeRequiredHeading": "Wajib",
+  "envEditor_proposeOptionalHeading": "Opsional",
+  "envEditor_proposeSelectAll": "Pilih semua",
+  "envEditor_proposeSelectNone": "Hapus",
+  "envEditor_proposeAddSelected": "Tambah {n}",
+  "envEditor_proposeAddNone": "Tambah yang dipilih",
+  "services_shimsInstalled": "Alat klien di PATH Anda",
+  "services_tools_providedBy": "Disediakan oleh {service}"
 }

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -999,5 +999,21 @@
   "services_cat_other": "Altro",
   "services_cat_messaging": "Messaggistica",
   "tinker_lspConnecting": "Avvio del language server…",
-  "tinker_lspUnavailable": "Language server non disponibile"
+  "tinker_lspUnavailable": "Language server non disponibile",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "envEditor_proposeReview": "Rivedi le chiavi",
+  "envEditor_proposeModalTitle": "Aggiungi le chiavi di ambiente mancanti",
+  "envEditor_proposeModalBody": "Scegli quali chiavi aggiungere a {file}. I valori vengono copiati da .env.example, quindi rivedili e inserisci quelli reali dopo l’aggiunta.",
+  "envEditor_proposeRequiredHeading": "Obbligatorie",
+  "envEditor_proposeOptionalHeading": "Facoltative",
+  "envEditor_proposeSelectAll": "Seleziona tutto",
+  "envEditor_proposeSelectNone": "Cancella",
+  "envEditor_proposeAddSelected": "Aggiungi {n}",
+  "envEditor_proposeAddNone": "Aggiungi selezionate",
+  "services_shimsInstalled": "Strumenti client nel tuo PATH",
+  "services_tools_providedBy": "Fornito da {service}"
 }

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -999,5 +999,21 @@
   "services_cat_other": "その他",
   "services_cat_messaging": "メッセージング",
   "tinker_lspConnecting": "言語サーバーを起動中…",
-  "tinker_lspUnavailable": "言語サーバーを利用できません"
+  "tinker_lspUnavailable": "言語サーバーを利用できません",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "envEditor_proposeReview": "キーを確認",
+  "envEditor_proposeModalTitle": "不足している環境変数キーを追加",
+  "envEditor_proposeModalBody": "{file} に追加するキーを選択します。値は .env.example からコピーされるため、追加後に確認して実際の値を入力してください。",
+  "envEditor_proposeRequiredHeading": "必須",
+  "envEditor_proposeOptionalHeading": "任意",
+  "envEditor_proposeSelectAll": "すべて選択",
+  "envEditor_proposeSelectNone": "クリア",
+  "envEditor_proposeAddSelected": "{n} 件追加",
+  "envEditor_proposeAddNone": "選択項目を追加",
+  "services_shimsInstalled": "PATH 上のクライアントツール",
+  "services_tools_providedBy": "{service} が提供"
 }

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -999,5 +999,21 @@
   "services_cat_other": "Overige",
   "services_cat_messaging": "Berichten",
   "tinker_lspConnecting": "Taalserver wordt gestart…",
-  "tinker_lspUnavailable": "Taalserver niet beschikbaar"
+  "tinker_lspUnavailable": "Taalserver niet beschikbaar",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "envEditor_proposeReview": "Sleutels controleren",
+  "envEditor_proposeModalTitle": "Ontbrekende env-sleutels toevoegen",
+  "envEditor_proposeModalBody": "Kies welke sleutels aan {file} worden toegevoegd. Waarden worden gekopieerd uit .env.example, controleer ze en vul na het toevoegen de echte in.",
+  "envEditor_proposeRequiredHeading": "Vereist",
+  "envEditor_proposeOptionalHeading": "Optioneel",
+  "envEditor_proposeSelectAll": "Alles selecteren",
+  "envEditor_proposeSelectNone": "Wissen",
+  "envEditor_proposeAddSelected": "{n} toevoegen",
+  "envEditor_proposeAddNone": "Selectie toevoegen",
+  "services_shimsInstalled": "Clienttools op je PATH",
+  "services_tools_providedBy": "Geleverd door {service}"
 }

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -999,5 +999,21 @@
   "services_cat_other": "Inne",
   "services_cat_messaging": "Komunikaty",
   "tinker_lspConnecting": "Uruchamianie serwera języka…",
-  "tinker_lspUnavailable": "Serwer języka niedostępny"
+  "tinker_lspUnavailable": "Serwer języka niedostępny",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "envEditor_proposeReview": "Przejrzyj klucze",
+  "envEditor_proposeModalTitle": "Dodaj brakujące klucze środowiskowe",
+  "envEditor_proposeModalBody": "Wybierz, które klucze dodać do {file}. Wartości są kopiowane z .env.example, więc sprawdź je i wprowadź prawdziwe po dodaniu.",
+  "envEditor_proposeRequiredHeading": "Wymagane",
+  "envEditor_proposeOptionalHeading": "Opcjonalne",
+  "envEditor_proposeSelectAll": "Zaznacz wszystko",
+  "envEditor_proposeSelectNone": "Wyczyść",
+  "envEditor_proposeAddSelected": "Dodaj {n}",
+  "envEditor_proposeAddNone": "Dodaj zaznaczone",
+  "services_shimsInstalled": "Narzędzia klienta w Twoim PATH",
+  "services_tools_providedBy": "Dostarczane przez {service}"
 }

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -999,5 +999,21 @@
   "services_cat_other": "Outros",
   "services_cat_messaging": "Mensageria",
   "tinker_lspConnecting": "Iniciando servidor de linguagem…",
-  "tinker_lspUnavailable": "Servidor de linguagem indisponível"
+  "tinker_lspUnavailable": "Servidor de linguagem indisponível",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "envEditor_proposeReview": "Revisar chaves",
+  "envEditor_proposeModalTitle": "Adicionar chaves de ambiente ausentes",
+  "envEditor_proposeModalBody": "Escolha quais chaves adicionar a {file}. Os valores são copiados de .env.example, então revise-os e preencha os reais após adicionar.",
+  "envEditor_proposeRequiredHeading": "Obrigatórias",
+  "envEditor_proposeOptionalHeading": "Opcionais",
+  "envEditor_proposeSelectAll": "Selecionar tudo",
+  "envEditor_proposeSelectNone": "Limpar",
+  "envEditor_proposeAddSelected": "Adicionar {n}",
+  "envEditor_proposeAddNone": "Adicionar selecionadas",
+  "services_shimsInstalled": "Ferramentas de cliente no seu PATH",
+  "services_tools_providedBy": "Fornecido por {service}"
 }

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -999,5 +999,21 @@
   "services_cat_other": "Altele",
   "services_cat_messaging": "Mesagerie",
   "tinker_lspConnecting": "Serverul de limbaj pornește…",
-  "tinker_lspUnavailable": "Server de limbaj indisponibil"
+  "tinker_lspUnavailable": "Server de limbaj indisponibil",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "envEditor_proposeReview": "Verifică cheile",
+  "envEditor_proposeModalTitle": "Adaugă cheile de mediu lipsă",
+  "envEditor_proposeModalBody": "Alege ce chei să adaugi în {file}. Valorile sunt copiate din .env.example, așa că verifică-le și completează valorile reale după adăugare.",
+  "envEditor_proposeRequiredHeading": "Obligatorii",
+  "envEditor_proposeOptionalHeading": "Opționale",
+  "envEditor_proposeSelectAll": "Selectează tot",
+  "envEditor_proposeSelectNone": "Șterge",
+  "envEditor_proposeAddSelected": "Adaugă {n}",
+  "envEditor_proposeAddNone": "Adaugă selecția",
+  "services_shimsInstalled": "Instrumente client în PATH-ul tău",
+  "services_tools_providedBy": "Furnizat de {service}"
 }

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -999,5 +999,21 @@
   "services_cat_other": "Diğer",
   "services_cat_messaging": "Mesajlaşma",
   "tinker_lspConnecting": "Dil sunucusu başlatılıyor…",
-  "tinker_lspUnavailable": "Dil sunucusu kullanılamıyor"
+  "tinker_lspUnavailable": "Dil sunucusu kullanılamıyor",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "envEditor_proposeReview": "Anahtarları gözden geçir",
+  "envEditor_proposeModalTitle": "Eksik ortam anahtarlarını ekle",
+  "envEditor_proposeModalBody": "{file} dosyasına eklenecek anahtarları seçin. Değerler .env.example dosyasından kopyalanır, bu yüzden bunları gözden geçirin ve ekledikten sonra gerçek değerleri girin.",
+  "envEditor_proposeRequiredHeading": "Zorunlu",
+  "envEditor_proposeOptionalHeading": "İsteğe bağlı",
+  "envEditor_proposeSelectAll": "Tümünü seç",
+  "envEditor_proposeSelectNone": "Temizle",
+  "envEditor_proposeAddSelected": "{n} ekle",
+  "envEditor_proposeAddNone": "Seçilenleri ekle",
+  "services_shimsInstalled": "PATH’inizdeki istemci araçları",
+  "services_tools_providedBy": "{service} tarafından sağlanıyor"
 }

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -999,5 +999,21 @@
   "services_cat_other": "Khác",
   "services_cat_messaging": "Nhắn tin",
   "tinker_lspConnecting": "Đang khởi động máy chủ ngôn ngữ…",
-  "tinker_lspUnavailable": "Máy chủ ngôn ngữ không khả dụng"
+  "tinker_lspUnavailable": "Máy chủ ngôn ngữ không khả dụng",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "envEditor_proposeReview": "Xem lại các khóa",
+  "envEditor_proposeModalTitle": "Thêm các khóa môi trường bị thiếu",
+  "envEditor_proposeModalBody": "Chọn khóa nào để thêm vào {file}. Giá trị được sao chép từ .env.example, vì vậy hãy xem lại và điền giá trị thực sau khi thêm.",
+  "envEditor_proposeRequiredHeading": "Bắt buộc",
+  "envEditor_proposeOptionalHeading": "Tùy chọn",
+  "envEditor_proposeSelectAll": "Chọn tất cả",
+  "envEditor_proposeSelectNone": "Xóa",
+  "envEditor_proposeAddSelected": "Thêm {n}",
+  "envEditor_proposeAddNone": "Thêm mục đã chọn",
+  "services_shimsInstalled": "Công cụ máy khách trong PATH của bạn",
+  "services_tools_providedBy": "Được cung cấp bởi {service}"
 }

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -999,5 +999,21 @@
   "services_cat_other": "其他",
   "services_cat_messaging": "消息",
   "tinker_lspConnecting": "语言服务器启动中…",
-  "tinker_lspUnavailable": "语言服务器不可用"
+  "tinker_lspUnavailable": "语言服务器不可用",
+  "services_tabs_tools": "Tools",
+  "services_tools_title": "Client tools on your PATH",
+  "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
+  "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",
+  "services_tools_none": "This service exposes no client tools.",
+  "envEditor_proposeReview": "检查键",
+  "envEditor_proposeModalTitle": "添加缺失的环境变量键",
+  "envEditor_proposeModalBody": "选择要添加到 {file} 的键。值从 .env.example 复制，请检查并在添加后填入真实值。",
+  "envEditor_proposeRequiredHeading": "必填",
+  "envEditor_proposeOptionalHeading": "可选",
+  "envEditor_proposeSelectAll": "全选",
+  "envEditor_proposeSelectNone": "清除",
+  "envEditor_proposeAddSelected": "添加 {n} 个",
+  "envEditor_proposeAddNone": "添加所选",
+  "services_shimsInstalled": "PATH 中的客户端工具",
+  "services_tools_providedBy": "由 {service} 提供"
 }

--- a/internal/ui/web/src/stores/services.test.ts
+++ b/internal/ui/web/src/stores/services.test.ts
@@ -53,6 +53,38 @@ describe('services store', () => {
     expect(calls.some((c) => c[0] === '/api/services')).toBe(true);
   });
 
+  it('setServiceShim POSTs the tool decision and reloads', async () => {
+    const calls: Array<[string, RequestInit | undefined]> = [];
+    globalThis.fetch = vi.fn(async (url: unknown, init?: RequestInit) => {
+      calls.push([String(url), init]);
+      if (String(url).endsWith('/mysql/shims'))
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      return new Response('[]', { status: 200 });
+    }) as unknown as typeof fetch;
+    const { setServiceShim } = await import('./services');
+    const res = await setServiceShim('mysql', { tool: 'mysqldump', enabled: true });
+    expect(res.ok).toBe(true);
+    expect(calls[0][0]).toBe('/api/services/mysql/shims');
+    expect(calls[0][1]?.method).toBe('POST');
+    expect(JSON.parse(String(calls[0][1]?.body))).toEqual({ tool: 'mysqldump', enabled: true });
+    expect(calls.some((c) => c[0] === '/api/services')).toBe(true);
+  });
+
+  it('setServiceShim surfaces a server error without reloading', async () => {
+    const calls: string[] = [];
+    globalThis.fetch = vi.fn(async (url: unknown) => {
+      calls.push(String(url));
+      if (String(url).endsWith('/mysql/shims'))
+        return new Response(JSON.stringify({ ok: false, error: 'boom' }), { status: 200 });
+      return new Response('[]', { status: 200 });
+    }) as unknown as typeof fetch;
+    const { setServiceShim } = await import('./services');
+    const res = await setServiceShim('mysql', { tool: 'mysqldump', enabled: true });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('boom');
+    expect(calls.includes('/api/services')).toBe(false);
+  });
+
   it('setServicePorts POSTs the published port and extra ports as JSON', async () => {
     const calls: Array<[string, RequestInit | undefined]> = [];
     globalThis.fetch = vi.fn(async (url: unknown, init?: RequestInit) => {

--- a/internal/ui/web/src/stores/services.ts
+++ b/internal/ui/web/src/stores/services.ts
@@ -58,11 +58,24 @@ export interface Service {
   migration_supported?: boolean;
   can_rollback?: boolean;
   port_conflicts?: PortConflict[];
+  // Client tools this service exposes as host shims (mysqldump, pg_dump…), each
+  // with whether the host already has the tool and the user's current decision.
+  client_shims?: ClientShimInfo[];
 }
 
 export interface PortConflict {
   port: string;
   label?: string;
+}
+
+export interface ClientShimInfo {
+  tool: string;
+  // The service that actually backs the shim. When it differs from the service
+  // being viewed, this row is a same-family duplicate managed elsewhere.
+  owner?: string;
+  host_has: boolean;
+  enabled: boolean;
+  decided: boolean;
 }
 
 export interface PhaseEvent {
@@ -195,6 +208,27 @@ export async function setServicePorts(
 ): Promise<{ ok: boolean; error?: string }> {
   try {
     const res = await apiFetch('/api/services/' + encodeURIComponent(name) + '/ports', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    const data = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+    if (res.ok && data.ok) {
+      await loadServices();
+      return { ok: true };
+    }
+    return { ok: false, error: data.error || 'failed' };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+export async function setServiceShim(
+  name: string,
+  body: { tool: string; enabled: boolean }
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await apiFetch('/api/services/' + encodeURIComponent(name) + '/shims', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body)

--- a/internal/ui/web/src/tabs/ServicesTab.svelte
+++ b/internal/ui/web/src/tabs/ServicesTab.svelte
@@ -73,6 +73,17 @@
             </svg>
           </span>
         {/if}
+        {#if svc.client_shims && svc.client_shims.some((s) => s.enabled)}
+          <span
+            class="shrink-0 text-gray-400 dark:text-gray-500"
+            title={m.services_shimsInstalled() + ': ' + svc.client_shims.filter((s) => s.enabled).map((s) => s.tool).join(', ')}
+          >
+            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="4 17 10 11 4 5"/>
+              <line x1="12" y1="19" x2="20" y2="19"/>
+            </svg>
+          </span>
+        {/if}
         {#if svc.site_count > 0}
           <span class="text-[10px] font-medium tabular-nums shrink-0 {selected === svc.name ? 'text-lerd-red/70' : 'text-gray-400 dark:text-gray-600'}">{svc.site_count}</span>
         {/if}

--- a/internal/ui/web/src/tabs/services/ServiceDetail.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceDetail.svelte
@@ -6,6 +6,7 @@
   import ServiceSiteBadges from './ServiceSiteBadges.svelte';
   import ServiceEnvTab from './ServiceEnvTab.svelte';
   import ServiceTuningTab from './ServiceTuningTab.svelte';
+  import ServiceToolsTab from './ServiceToolsTab.svelte';
   import PresetSuggestionBanner from './PresetSuggestionBanner.svelte';
   import type { Service } from '$stores/services';
   import { m } from '../../paraglide/messages.js';
@@ -15,14 +16,16 @@
   }
   let { svc }: Props = $props();
 
-  type TabId = 'logs' | 'env' | 'config';
+  type TabId = 'logs' | 'env' | 'config' | 'tools';
   let active = $state<TabId>('logs');
 
   const hasEnv = $derived(Boolean(svc.env_vars && Object.keys(svc.env_vars).length > 0));
+  const hasTools = $derived(Boolean(svc.client_shims && svc.client_shims.length > 0));
   const tabs = $derived<TabItem<TabId>[]>([
     { id: 'logs', label: m.services_tabs_logs() },
     { id: 'env', label: m.services_env_title(), hidden: !hasEnv },
-    { id: 'config', label: m.services_tabs_tuning(), hidden: !svc.tunable }
+    { id: 'config', label: m.services_tabs_tuning(), hidden: !svc.tunable },
+    { id: 'tools', label: m.services_tabs_tools(), hidden: !hasTools }
   ]);
 
   // Fall back to logs when the active tab is hidden for the selected service
@@ -30,6 +33,7 @@
   $effect(() => {
     if (active === 'env' && !hasEnv) active = 'logs';
     if (active === 'config' && !svc.tunable) active = 'logs';
+    if (active === 'tools' && !hasTools) active = 'logs';
   });
 
   const logPath = $derived.by(() => {
@@ -67,5 +71,7 @@
     <ServiceEnvTab {svc} />
   {:else if active === 'config'}
     <ServiceTuningTab {svc} />
+  {:else if active === 'tools'}
+    <ServiceToolsTab {svc} />
   {/if}
 </DetailPanel>

--- a/internal/ui/web/src/tabs/services/ServiceToolsTab.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceToolsTab.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import Toggle from '$components/Toggle.svelte';
+  import { setServiceShim, type Service } from '$stores/services';
+  import { m } from '../../paraglide/messages.js';
+
+  interface Props {
+    svc: Service;
+  }
+  let { svc }: Props = $props();
+
+  const shims = $derived(svc.client_shims ?? []);
+
+  let pending = $state<Record<string, boolean>>({});
+  let failed = $state<Record<string, boolean>>({});
+
+  async function toggle(tool: string, enabled: boolean) {
+    pending = { ...pending, [tool]: true };
+    failed = { ...failed, [tool]: false };
+    const res = await setServiceShim(svc.name, { tool, enabled });
+    pending = { ...pending, [tool]: false };
+    if (!res.ok) failed = { ...failed, [tool]: true };
+  }
+</script>
+
+<div class="p-3 sm:p-5 space-y-3 overflow-y-auto">
+  <p class="text-[11px] text-gray-500 dark:text-gray-400">{m.services_tools_hint()}</p>
+
+  {#if shims.length === 0}
+    <p class="text-xs text-gray-400">{m.services_tools_none()}</p>
+  {:else}
+    <div class="rounded-lg border border-gray-200 dark:border-lerd-border divide-y divide-gray-200 dark:divide-lerd-border">
+      {#each shims as shim (shim.tool)}
+        {@const managedElsewhere = Boolean(shim.owner && shim.owner !== svc.name)}
+        <div class="flex items-center justify-between px-3 py-2.5">
+          <div class="min-w-0">
+            <code class="text-xs text-gray-700 dark:text-gray-200">{shim.tool}</code>
+            {#if managedElsewhere}
+              <p class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{m.services_tools_providedBy({ service: shim.owner ?? '' })}</p>
+            {:else if shim.host_has}
+              <p class="text-[10px] text-amber-600 dark:text-amber-400 mt-0.5">{m.services_tools_shadow()}</p>
+            {/if}
+          </div>
+          <Toggle
+            on={shim.enabled}
+            tone={shim.host_has ? 'amber' : 'emerald'}
+            loading={pending[shim.tool]}
+            failing={failed[shim.tool]}
+            disabled={managedElsewhere}
+            title={managedElsewhere ? m.services_tools_providedBy({ service: shim.owner ?? '' }) : shim.tool}
+            onclick={() => toggle(shim.tool, !shim.enabled)}
+          />
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
Surface the client tools that ship inside each database service image (mysqldump, pg_dump, psql, redis-cli, mongodump and friends) as pass-through shims on the host PATH, so you can dump or query a database that lives outside lerd, or point an IDE like PhpStorm at a real client binary, without installing the tool yourself.

A service declares the tools it exposes in its YAML, so the set grows through the store, and a new internal/shims package is the single owner of the decision storage, host-conflict detection, generation and reconcile. Each shim runs the tool in a throwaway container built from the service image with your home directory mounted, so output files and CA certs behave like a native binary and the long running database container is never touched. A hostless dump adopts the current project's own database service, read from its DB_HOST, so a mariadb or postgres-18 backed project routes to its own server, while an explicit host passes straight through for external databases. When several same-family services expose the same tool, one owns the shim and the others show it disabled. The lerd shims command lists and toggles them, and each database service gains a Tools tab in the web UI.

Installed add-on services pick up newly declared tools from the store on the next update, since the service reconcile now re-materialises a preset-backed definition's declarative fields while preserving its pinned image and version. The matching store definitions for mariadb, valkey, mongo and the pgvector and timescaledb variants ship in lerd-env/services.

A second commit fixes an adjacent bug this work uncovered: the db commands resolved the database service from the dialect alone and collapsed to the canonical mysql or postgres container, so a project on an alternate service was dumped or shelled against the wrong server. They now read the exact service the project's DB_HOST names.

Closes #750