### PR TITLE
fix: restore HTTPS on sites when DNS is re-enabled

### DIFF
--- a/docs/features/dns.md
+++ b/docs/features/dns.md
@@ -56,6 +56,8 @@ The DNS question is asked once, at your first `lerd install`, and then remembere
 - git-worktree vhosts and per-worktree `.env` files
 - stale primary vhost confs and (when disabling) the previous TLS cert and key
 
+The round trip is lossless for HTTPS. Disabling flips a site to plain `http` because there is no trusted CA on `*.localhost`, but the project's committed HTTPS intent in `.lerd.yaml` is left untouched. Re-enabling reads that intent back and re-secures every site that wanted HTTPS, reissuing the cert and syncing `.env` back to `https://`, so a site served over HTTPS before a `dns:disable` comes back to HTTPS on `dns:enable`. Sites you deliberately kept on plain HTTP stay that way.
+
 The lerd-dns service itself is torn down on the disable transition, `systemctl stop` plus quadlet remove on Linux, `launchctl bootout` plus plist remove on macOS. NetworkManager / `/etc/resolver` entries from the previous run are left in place because removing them needs sudo and they are inert when dnsmasq is no longer running. Run `lerd-cleanup` (macOS) or remove the dropins manually if you want a fully clean system. Running `dns:enable` while DNS is already on simply repairs the setup, the same as `dns:repair`.
 
 Custom TLDs (anything other than `test` or `localhost`) are preserved across toggles, lerd only flips the canonical defaults.

--- a/internal/cli/migrate_tld.go
+++ b/internal/cli/migrate_tld.go
@@ -38,12 +38,26 @@ func sitesWithTLD(oldTLD string) []string {
 	return names
 }
 
+// projectWantsHTTPS reports whether the site's committed .lerd.yaml records
+// HTTPS intent. It is the record the DNS re-enable migration restores from; a
+// missing or unreadable file means no intent, so the site stays plain HTTP.
+func projectWantsHTTPS(dir string) bool {
+	cfg, err := config.LoadProjectConfig(dir)
+	if err != nil || cfg == nil {
+		return false
+	}
+	return cfg.Secured
+}
+
 // migrateSiteTLD rewrites every site's domain suffix from oldTLD to newTLD,
 // removes stale nginx vhost confs at the previous primary-domain paths, and
 // updates each site's .env APP_URL (plus Vite/Reverb keys) via
 // envfile.SyncPrimaryDomain. When forceUnsecure is true (DNS being disabled,
-// so HTTPS is unavailable) the site's Secured flag is also flipped off so the
-// regen pass writes plain HTTP vhosts.
+// so HTTPS is unavailable) the site's registry Secured flag is flipped off so
+// the regen pass writes plain HTTP vhosts, but the project's committed HTTPS
+// intent in .lerd.yaml is left intact. When forceUnsecure is false (DNS being
+// enabled) each site's Secured flag is restored from that intent, so a
+// disable/enable round trip returns previously secured sites to https.
 //
 // Returns the list of sites that were actually mutated. Errors on individual
 // sites are printed but do not stop the migration: a partial rename is still
@@ -82,8 +96,12 @@ func migrateSiteTLD(oldTLD, newTLD string, forceUnsecure bool) []string {
 		worktrees, _ := gitpkg.DetectWorktrees(s.Path, oldPrimary)
 
 		s.Domains = newDomains
+		// Registry flag off while DNS is down; on re-enable restore HTTPS from
+		// the committed .lerd.yaml intent so the round trip is lossless.
 		if forceUnsecure {
 			s.Secured = false
+		} else {
+			s.Secured = projectWantsHTTPS(s.Path)
 		}
 		if err := config.AddSite(s); err != nil {
 			fmt.Printf("    WARN: %s: persist domains: %v\n", s.Name, err)
@@ -132,7 +150,6 @@ func migrateSiteTLD(oldTLD, newTLD string, forceUnsecure bool) []string {
 		if err := envfile.SyncPrimaryDomain(s.Path, newPrimary, s.Secured); err != nil {
 			fmt.Printf("    WARN: %s: update .env: %v\n", s.Name, err)
 		}
-		_ = config.SetProjectSecured(s.Path, s.Secured)
 		_ = config.SyncProjectDomains(s.Path, s.Domains, newTLD)
 
 		feedback.Note(fmt.Sprintf("%s: %s → %s://%s", s.Name, oldPrimary, scheme, newPrimary))

--- a/internal/cli/migrate_tld_test.go
+++ b/internal/cli/migrate_tld_test.go
@@ -50,6 +50,10 @@ func TestMigrateSiteTLD_RewritesDomainsAndEnv(t *testing.T) {
 	if err := os.WriteFile(envPath, []byte("APP_URL=http://alpha.test\n"), 0644); err != nil {
 		t.Fatalf("write .env: %v", err)
 	}
+	// The project committed HTTPS intent; disabling DNS must leave it intact.
+	if err := config.SaveProjectConfig(siteDir, &config.ProjectConfig{Secured: true}); err != nil {
+		t.Fatalf("save .lerd.yaml: %v", err)
+	}
 
 	staleVhost := filepath.Join(config.NginxConfD(), "alpha.test.conf")
 	if err := os.WriteFile(staleVhost, []byte("server {}\n"), 0644); err != nil {
@@ -91,6 +95,14 @@ func TestMigrateSiteTLD_RewritesDomainsAndEnv(t *testing.T) {
 	}
 	if site.Secured {
 		t.Errorf("Secured should be false after forceUnsecure")
+	}
+
+	proj, err := config.LoadProjectConfig(siteDir)
+	if err != nil {
+		t.Fatalf("LoadProjectConfig: %v", err)
+	}
+	if !proj.Secured {
+		t.Errorf(".lerd.yaml secured intent should survive DNS disable; got false")
 	}
 
 	envBytes, _ := os.ReadFile(envPath)
@@ -246,6 +258,10 @@ echo "FAKE-KEY" > "$KEY"
 	if err := os.WriteFile(filepath.Join(checkout, ".env"), []byte("APP_URL=https://feat-x.alpha.test\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
+	// The enable path restores HTTPS from the committed .lerd.yaml intent.
+	if err := config.SaveProjectConfig(siteDir, &config.ProjectConfig{Secured: true}); err != nil {
+		t.Fatalf("save .lerd.yaml: %v", err)
+	}
 
 	if err := config.AddSite(config.Site{
 		Name:       "alpha",
@@ -292,6 +308,142 @@ echo "FAKE-KEY" > "$KEY"
 	}
 	if _, err := os.Stat(filepath.Join(certsDir, "alpha.test.key")); !os.IsNotExist(err) {
 		t.Errorf("old key should be removed after migration; stat err = %v", err)
+	}
+}
+
+// TestMigrateSiteTLD_DNSRoundTripRestoresHTTPS pins the fix for #749: disabling
+// then re-enabling DNS must be lossless. A site secured on .test falls back to
+// plain .localhost http on disable (registry flag off) but keeps its committed
+// HTTPS intent in .lerd.yaml; re-enabling reads that intent and re-secures the
+// site on .test, reissuing the cert and syncing the .env back to https.
+func TestMigrateSiteTLD_DNSRoundTripRestoresHTTPS(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	binDir := filepath.Join(tmp, "lerd", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	fakeMkcert := `#!/bin/sh
+CRT=""
+KEY=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -cert-file) shift; CRT="$1" ;;
+    -key-file) shift; KEY="$1" ;;
+  esac
+  shift
+done
+echo "CERT" > "$CRT"
+echo "KEY" > "$KEY"
+`
+	if err := os.WriteFile(filepath.Join(binDir, "mkcert"), []byte(fakeMkcert), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	siteDir := filepath.Join(tmp, "alpha")
+	if err := os.MkdirAll(siteDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	envPath := filepath.Join(siteDir, ".env")
+	if err := os.WriteFile(envPath, []byte("APP_URL=https://alpha.test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveProjectConfig(siteDir, &config.ProjectConfig{Secured: true}); err != nil {
+		t.Fatalf("save .lerd.yaml: %v", err)
+	}
+	if err := config.AddSite(config.Site{
+		Name:       "alpha",
+		Path:       siteDir,
+		Domains:    []string{"alpha.test"},
+		PHPVersion: "8.4",
+		Secured:    true,
+	}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	// Disable DNS: site falls back to plain-http .localhost.
+	if changed := migrateSiteTLD("test", "localhost", true); !slices.Equal(changed, []string{"alpha"}) {
+		t.Fatalf("disable changed = %v, want [alpha]", changed)
+	}
+	site, err := config.FindSite("alpha")
+	if err != nil {
+		t.Fatalf("FindSite after disable: %v", err)
+	}
+	if site.PrimaryDomain() != "alpha.localhost" || site.Secured {
+		t.Fatalf("after disable: domain=%q secured=%v, want alpha.localhost/false", site.PrimaryDomain(), site.Secured)
+	}
+	if envBytes, _ := os.ReadFile(envPath); !contains(envBytes, "APP_URL=http://alpha.localhost") {
+		t.Errorf("after disable .env = %q, want http://alpha.localhost", envBytes)
+	}
+	if proj, _ := config.LoadProjectConfig(siteDir); !proj.Secured {
+		t.Fatalf("after disable: .lerd.yaml secured intent lost")
+	}
+
+	// Re-enable DNS: site returns to .test and HTTPS is restored from intent.
+	if changed := migrateSiteTLD("localhost", "test", false); !slices.Equal(changed, []string{"alpha"}) {
+		t.Fatalf("enable changed = %v, want [alpha]", changed)
+	}
+	site, err = config.FindSite("alpha")
+	if err != nil {
+		t.Fatalf("FindSite after enable: %v", err)
+	}
+	if site.PrimaryDomain() != "alpha.test" || !site.Secured {
+		t.Fatalf("after enable: domain=%q secured=%v, want alpha.test/true", site.PrimaryDomain(), site.Secured)
+	}
+	if envBytes, _ := os.ReadFile(envPath); !contains(envBytes, "APP_URL=https://alpha.test") {
+		t.Errorf("after enable .env = %q, want https://alpha.test", envBytes)
+	}
+	certPath := filepath.Join(config.CertsDir(), "sites", "alpha.test.crt")
+	if _, err := os.Stat(certPath); err != nil {
+		t.Errorf("expected reissued cert at %s: %v", certPath, err)
+	}
+}
+
+// TestMigrateSiteTLD_EnableLeavesPlainSiteHTTP confirms a site the user
+// intentionally kept on plain http (no .lerd.yaml secured intent) is not
+// promoted to HTTPS when DNS is enabled.
+func TestMigrateSiteTLD_EnableLeavesPlainSiteHTTP(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
+		t.Fatal(err)
+	}
+	siteDir := filepath.Join(tmp, "beta")
+	if err := os.MkdirAll(siteDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	envPath := filepath.Join(siteDir, ".env")
+	if err := os.WriteFile(envPath, []byte("APP_URL=http://beta.localhost\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveProjectConfig(siteDir, &config.ProjectConfig{Secured: false}); err != nil {
+		t.Fatalf("save .lerd.yaml: %v", err)
+	}
+	if err := config.AddSite(config.Site{
+		Name: "beta", Path: siteDir, Domains: []string{"beta.localhost"}, PHPVersion: "8.4",
+	}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	if changed := migrateSiteTLD("localhost", "test", false); !slices.Equal(changed, []string{"beta"}) {
+		t.Fatalf("changed = %v, want [beta]", changed)
+	}
+	site, err := config.FindSite("beta")
+	if err != nil {
+		t.Fatalf("FindSite: %v", err)
+	}
+	if site.Secured {
+		t.Errorf("plain-http site should stay unsecured after DNS enable")
+	}
+	if envBytes, _ := os.ReadFile(envPath); !contains(envBytes, "APP_URL=http://beta.test") {
+		t.Errorf(".env = %q, want http://beta.test", envBytes)
 	}
 }
 


### PR DESCRIPTION
Disabling and re-enabling lerd-managed DNS left every previously secured site on plain HTTP. The TLD migration the toggle drives wrote secured: false back into each project's .lerd.yaml on disable, erasing the only record that the site wanted HTTPS, and the reverse migration on enable only renamed domains back to .test without re-securing anything, so there was nothing left to restore from.

The project .lerd.yaml is now the source of truth for HTTPS intent. Disabling still flips the registry secured flag off so nothing serves HTTPS while .test is down, but it leaves the committed intent in .lerd.yaml untouched. Enabling reads that intent back and re-secures the sites that wanted HTTPS, which reissues the cert, writes the SSL vhost through the install reconcile, and syncs the .env back to https. Sites intentionally kept on plain HTTP record that in their project file and stay HTTP.

The disabled-DNS paths that consult the project secured flag already gate on whether lerd manages DNS, so preserving the flag cannot cause anything to serve HTTPS on a .localhost domain.

Refs #749