### PR TITLE
feat: move the service ports editor into a tab

### DIFF
--- a/docs/usage/services.md
+++ b/docs/usage/services.md
@@ -67,7 +67,7 @@ services:
 
 Then apply with `lerd service restart mysql`.
 
-You can also manage extra ports from the dashboard: open a service, click the cog button in the action group (between the main button and the dropdown), and add or remove mappings in the **Ports** modal alongside the published port. The CLI, dashboard, MCP and TUI all route through the same logic, so a change made on one surface shows up on the others.
+You can also manage extra ports from the dashboard: open a service and switch to the **Ports** tab, then add or remove mappings alongside the published port. The CLI, dashboard, MCP and TUI all route through the same logic, so a change made on one surface shows up on the others.
 
 ### Moving a service's published host port
 
@@ -99,7 +99,7 @@ The dashboard link for a service always follows the port its dashboard is served
 
 The chosen ports are persisted in `~/.config/lerd/config.yaml` and reapplied on every start: the primary under `services.<name>.published_port`, any other mapping under `services.<name>.published_ports` keyed by container port. Once a port is set, automatically or with `lerd service port`, it sticks: lerd never moves it again on its own, not even back to the default when that frees up later. Change it only with `lerd service port`.
 
-Every published port can also be moved from the dashboard: the cog button on a service opens the **Ports** modal, which lists one editable host-port field per published port (primary and secondary alike), each with a reset-to-default. The TUI shows the current published and extra ports read-only; editing stays in the CLI, dashboard and MCP.
+Every published port can also be moved from the dashboard: a service's **Ports** tab lists one editable host-port field per published port (primary and secondary alike), each with a reset-to-default. The TUI shows the current published and extra ports read-only; editing stays in the CLI, dashboard and MCP.
 
 ::: warning Known limitation
 The shift is decided at quadlet-write time, from whether the port can be bound right then. A host server that is installed but stopped at that moment leaves its port looking free, so lerd may take it and clash when that server next starts (for example at boot). This is the deliberate trade for not inspecting the host: a host database is usually running, and the failure is loud. Recover by moving lerd onto a free port with `lerd service port <name> <port>`.

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -1001,6 +1001,7 @@
   "tinker_lspConnecting": "Sprachserver startet…",
   "tinker_lspUnavailable": "Sprachserver nicht verfügbar",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -1010,6 +1010,7 @@
   "services_cat_other": "Other",
   "services_cat_messaging": "Messaging",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -1001,6 +1001,7 @@
   "tinker_lspConnecting": "Iniciando servidor de lenguaje…",
   "tinker_lspUnavailable": "Servidor de lenguaje no disponible",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -1001,6 +1001,7 @@
   "tinker_lspConnecting": "Démarrage du serveur de langage…",
   "tinker_lspUnavailable": "Serveur de langage indisponible",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -1001,6 +1001,7 @@
   "tinker_lspConnecting": "Memulai server bahasa…",
   "tinker_lspUnavailable": "Server bahasa tidak tersedia",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -1001,6 +1001,7 @@
   "tinker_lspConnecting": "Avvio del language server…",
   "tinker_lspUnavailable": "Language server non disponibile",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -1001,6 +1001,7 @@
   "tinker_lspConnecting": "言語サーバーを起動中…",
   "tinker_lspUnavailable": "言語サーバーを利用できません",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -1001,6 +1001,7 @@
   "tinker_lspConnecting": "Taalserver wordt gestart…",
   "tinker_lspUnavailable": "Taalserver niet beschikbaar",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -1001,6 +1001,7 @@
   "tinker_lspConnecting": "Uruchamianie serwera języka…",
   "tinker_lspUnavailable": "Serwer języka niedostępny",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -1001,6 +1001,7 @@
   "tinker_lspConnecting": "Iniciando servidor de linguagem…",
   "tinker_lspUnavailable": "Servidor de linguagem indisponível",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -1001,6 +1001,7 @@
   "tinker_lspConnecting": "Serverul de limbaj pornește…",
   "tinker_lspUnavailable": "Server de limbaj indisponibil",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -1001,6 +1001,7 @@
   "tinker_lspConnecting": "Dil sunucusu başlatılıyor…",
   "tinker_lspUnavailable": "Dil sunucusu kullanılamıyor",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -1001,6 +1001,7 @@
   "tinker_lspConnecting": "Đang khởi động máy chủ ngôn ngữ…",
   "tinker_lspUnavailable": "Máy chủ ngôn ngữ không khả dụng",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -1001,6 +1001,7 @@
   "tinker_lspConnecting": "语言服务器启动中…",
   "tinker_lspUnavailable": "语言服务器不可用",
   "services_tabs_tools": "Tools",
+  "services_tabs_ports": "Ports",
   "services_tools_title": "Client tools on your PATH",
   "services_tools_hint": "Expose this service’s client tools on your host so you can run them against an external database or from an IDE like PhpStorm.",
   "services_tools_shadow": "You already have this installed; enabling the shim shadows it on your PATH.",

--- a/internal/ui/web/src/tabs/services/ServiceDetail.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceDetail.svelte
@@ -7,8 +7,9 @@
   import ServiceEnvTab from './ServiceEnvTab.svelte';
   import ServiceTuningTab from './ServiceTuningTab.svelte';
   import ServiceToolsTab from './ServiceToolsTab.svelte';
+  import ServicePortsTab from './ServicePortsTab.svelte';
   import PresetSuggestionBanner from './PresetSuggestionBanner.svelte';
-  import type { Service } from '$stores/services';
+  import { isServiceWorker, type Service } from '$stores/services';
   import { m } from '../../paraglide/messages.js';
 
   interface Props {
@@ -16,16 +17,19 @@
   }
   let { svc }: Props = $props();
 
-  type TabId = 'logs' | 'env' | 'config' | 'tools';
+  type TabId = 'logs' | 'env' | 'config' | 'tools' | 'ports';
   let active = $state<TabId>('logs');
 
   const hasEnv = $derived(Boolean(svc.env_vars && Object.keys(svc.env_vars).length > 0));
   const hasTools = $derived(Boolean(svc.client_shims && svc.client_shims.length > 0));
+  // Workers publish nothing, so the ports tab tracks the header gear's old guard.
+  const hasPorts = $derived(!isServiceWorker(svc));
   const tabs = $derived<TabItem<TabId>[]>([
     { id: 'logs', label: m.services_tabs_logs() },
     { id: 'env', label: m.services_env_title(), hidden: !hasEnv },
     { id: 'config', label: m.services_tabs_tuning(), hidden: !svc.tunable },
-    { id: 'tools', label: m.services_tabs_tools(), hidden: !hasTools }
+    { id: 'tools', label: m.services_tabs_tools(), hidden: !hasTools },
+    { id: 'ports', label: m.services_tabs_ports(), hidden: !hasPorts }
   ]);
 
   // Fall back to logs when the active tab is hidden for the selected service
@@ -34,6 +38,7 @@
     if (active === 'env' && !hasEnv) active = 'logs';
     if (active === 'config' && !svc.tunable) active = 'logs';
     if (active === 'tools' && !hasTools) active = 'logs';
+    if (active === 'ports' && !hasPorts) active = 'logs';
   });
 
   const logPath = $derived.by(() => {
@@ -73,5 +78,7 @@
     <ServiceTuningTab {svc} />
   {:else if active === 'tools'}
     <ServiceToolsTab {svc} />
+  {:else if active === 'ports'}
+    <ServicePortsTab {svc} />
   {/if}
 </DetailPanel>

--- a/internal/ui/web/src/tabs/services/ServiceHeader.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceHeader.svelte
@@ -5,7 +5,6 @@
   import ServiceDependencies from './ServiceDependencies.svelte';
   import ServiceDeleteModal from './ServiceDeleteModal.svelte';
   import ServiceReinstallModal from './ServiceReinstallModal.svelte';
-  import ServicePortsModal from './ServicePortsModal.svelte';
   import {
     type Service,
     services as allServices,
@@ -90,7 +89,6 @@
   let localBusy = $state(false);
   let deleteOpen = $state(false);
   let reinstallOpen = $state(false);
-  let portsOpen = $state(false);
   let checking = $state(false);
   let checkMessage = $state<{ text: string; tone: 'ok' | 'info' | 'error' } | null>(null);
   let checkMessageTimer: ReturnType<typeof setTimeout> | null = null;
@@ -467,8 +465,6 @@
         checkUpdates: checkUpdatesIcon
       })}
       {busy}
-      onSettings={isWorker ? undefined : () => (portsOpen = true)}
-      settingsTitle={m.services_ports_settingsTitle()}
     />
     {#if updating}
       <span
@@ -507,5 +503,3 @@
   onclose={() => (reinstallOpen = false)}
   onconfirm={confirmReinstall}
 />
-
-<ServicePortsModal open={portsOpen} {svc} onclose={() => (portsOpen = false)} />

--- a/internal/ui/web/src/tabs/services/ServicePortsTab.svelte
+++ b/internal/ui/web/src/tabs/services/ServicePortsTab.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
-  import Modal from '$components/Modal.svelte';
   import DetailButton from '$components/DetailButton.svelte';
   import PortRow from './PortRow.svelte';
   import { type Service, setServicePorts } from '$stores/services';
   import { m } from '../../paraglide/messages.js';
 
   interface Props {
-    open: boolean;
     svc: Service;
-    onclose: () => void;
   }
-  let { open, svc, onclose }: Props = $props();
+  let { svc }: Props = $props();
 
   const isBuiltin = $derived(Boolean(svc.preset_owned));
 
@@ -21,7 +18,6 @@
   // Number inputs bound with bind:value yield number | null (null when empty),
   // so these stay numeric — never strings.
   let publishedInput = $state<number | null>(null);
-  // Secondary published ports (a multi-port service), keyed by container port.
   let secondaryInputs = $state<Record<number, number | null>>({});
   let extraPorts = $state<string[]>([]);
   let newHost = $state<number | null>(null);
@@ -29,24 +25,46 @@
   let saving = $state(false);
   let error = $state('');
 
-  // Reseed from the service every time the modal opens so a reopen never shows
-  // stale edits from a cancelled session.
+  // The seed a service would produce. `published` mirrors the modal's fallback
+  // chain so an unset override reads as the preset default, not a blank field.
+  function seed(s: Service) {
+    const secondary: Record<number, number | null> = {};
+    for (const p of s.secondary_ports ?? []) secondary[p.container] = p.published || p.default;
+    return {
+      published: s.published_port || s.default_port || null,
+      secondary,
+      extra: [...(s.extra_ports ?? [])]
+    };
+  }
+
+  // Pin the reseed to the service name only. Every services WebSocket broadcast
+  // passes a fresh svc object even when the name is unchanged; reseeding on the
+  // object would clobber in-progress edits on every push.
+  const currentName = $derived(svc.name);
   $effect(() => {
-    if (open) {
-      publishedInput = svc.published_port || svc.default_port || null;
-      // Build the seed locally and assign once — mutating secondaryInputs in place
-      // here would make this effect read and write the same state and loop.
-      const seeded: Record<number, number | null> = {};
-      for (const p of svc.secondary_ports ?? []) {
-        seeded[p.container] = p.published || p.default;
-      }
-      secondaryInputs = seeded;
-      extraPorts = [...(svc.extra_ports ?? [])];
-      newHost = null;
-      newContainer = null;
-      saving = false;
-      error = '';
+    currentName;
+    const s = seed(svc);
+    publishedInput = s.published;
+    secondaryInputs = s.secondary;
+    extraPorts = [...s.extra];
+    newHost = null;
+    newContainer = null;
+    saving = false;
+    error = '';
+  });
+
+  // Live baseline off the current svc so a successful save (which updates svc
+  // via the broadcast) settles dirty back to false without an extra reseed.
+  const baseline = $derived(seed(svc));
+  const dirty = $derived.by(() => {
+    if ((publishedInput ?? null) !== (baseline.published ?? null)) return true;
+    for (const p of svc.secondary_ports ?? []) {
+      if ((secondaryInputs[p.container] ?? null) !== (baseline.secondary[p.container] ?? null)) return true;
     }
+    const cur = [...extraPorts].sort();
+    const base = [...baseline.extra].sort();
+    if (cur.length !== base.length) return true;
+    return cur.some((v, i) => v !== base[i]);
   });
 
   function validPort(n: number | null): n is number {
@@ -69,6 +87,16 @@
 
   function removeExtra(spec: string) {
     extraPorts = extraPorts.filter((p) => p !== spec);
+  }
+
+  function revert() {
+    const s = seed(svc);
+    publishedInput = s.published;
+    secondaryInputs = s.secondary;
+    extraPorts = [...s.extra];
+    newHost = null;
+    newContainer = null;
+    error = '';
   }
 
   async function save() {
@@ -106,15 +134,44 @@
         error = res.error || m.common_failed();
         return;
       }
-      onclose();
     } finally {
       saving = false;
     }
   }
 </script>
 
-<Modal {open} {onclose} title={m.services_ports_title({ name: svc.name })} size="md">
-  <div class="px-5 py-4 space-y-5">
+<div class="flex flex-col h-full">
+  <div class="sticky top-0 z-10">
+    <div class="flex items-center justify-between bg-gray-50 dark:bg-white/3 px-3 py-1.5 border-b border-gray-200 dark:border-lerd-border">
+      <div class="flex items-center gap-2 min-w-0">
+        {#if dirty && !saving}
+          <span class="text-[10px] font-medium text-amber-600 dark:text-amber-400">{m.tuningEditor_unsaved()}</span>
+        {/if}
+      </div>
+      <div class="flex items-center gap-2 shrink-0">
+        {#if dirty}
+          <button
+            type="button"
+            onclick={revert}
+            disabled={saving}
+            class="text-xs px-2 py-1 rounded-sm border border-gray-300 dark:border-lerd-border text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/5 disabled:opacity-40"
+          >
+            {m.tuningEditor_revert()}
+          </button>
+          <button
+            type="button"
+            onclick={save}
+            disabled={saving}
+            class="text-xs px-3 py-1 rounded-sm bg-lerd-red hover:bg-lerd-redhov text-white transition-colors disabled:opacity-40"
+          >
+            {saving ? m.services_ports_applying() : m.common_save()}
+          </button>
+        {/if}
+      </div>
+    </div>
+  </div>
+
+  <div class="flex-1 overflow-y-auto p-3 sm:p-5 space-y-5">
     <div class="space-y-2">
       <div>
         <span class="text-sm font-medium text-gray-800 dark:text-gray-200">
@@ -199,17 +256,4 @@
       <p class="text-xs text-red-500">{error}</p>
     {/if}
   </div>
-  {#snippet footer()}
-    <button
-      type="button"
-      onclick={onclose}
-      class="text-xs px-3 py-1.5 rounded-sm border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors"
-    >{m.common_cancel()}</button>
-    <button
-      type="button"
-      onclick={save}
-      disabled={saving}
-      class="text-xs px-3 py-1.5 rounded-sm bg-lerd-red hover:bg-lerd-redhov text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-    >{saving ? m.services_ports_applying() : m.common_save()}</button>
-  {/snippet}
-</Modal>
+</div>

--- a/internal/ui/web/src/tabs/services/ServicePortsTab.test.ts
+++ b/internal/ui/web/src/tabs/services/ServicePortsTab.test.ts
@@ -1,6 +1,6 @@
 import { render, fireEvent } from '@testing-library/svelte';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import ServicePortsModal from './ServicePortsModal.svelte';
+import ServicePortsTab from './ServicePortsTab.svelte';
 import type { Service } from '$stores/services';
 
 const { setServicePorts } = vi.hoisted(() => ({ setServicePorts: vi.fn(async () => ({ ok: true })) }));
@@ -21,13 +21,11 @@ function svc(over: Partial<Service> = {}): Service {
   } as Service;
 }
 
-describe('ServicePortsModal', () => {
+describe('ServicePortsTab', () => {
   beforeEach(() => setServicePorts.mockClear());
 
   it('saves a changed primary port', async () => {
-    const { container, getByText } = render(ServicePortsModal, {
-      props: { open: true, svc: svc(), onclose: () => {} }
-    });
+    const { container, getByText } = render(ServicePortsTab, { props: { svc: svc() } });
     const input = container.querySelector('input[type="number"]') as HTMLInputElement;
     await fireEvent.input(input, { target: { value: '1026' } });
     await fireEvent.click(getByText('Save'));
@@ -40,9 +38,7 @@ describe('ServicePortsModal', () => {
 
   it('clears a secondary override when its field is blanked', async () => {
     const s = svc({ secondary_ports: [{ container: 8025, default: 8025, published: 38026 }] });
-    const { container, getByText } = render(ServicePortsModal, {
-      props: { open: true, svc: s, onclose: () => {} }
-    });
+    const { container, getByText } = render(ServicePortsTab, { props: { svc: s } });
     const inputs = container.querySelectorAll('input[type="number"]');
     // Blank the seeded 38026 override: an empty field means reset to default, so
     // the default is sent and the backend clears the override.
@@ -56,9 +52,7 @@ describe('ServicePortsModal', () => {
   });
 
   it('saves a changed secondary port keyed by container port', async () => {
-    const { container, getByText } = render(ServicePortsModal, {
-      props: { open: true, svc: svc(), onclose: () => {} }
-    });
+    const { container, getByText } = render(ServicePortsTab, { props: { svc: svc() } });
     const inputs = container.querySelectorAll('input[type="number"]');
     // Second published-port field is the 8025 secondary mapping.
     await fireEvent.input(inputs[1], { target: { value: '8026' } });
@@ -68,5 +62,13 @@ describe('ServicePortsModal', () => {
       published_ports: { '8025': 8026 },
       extra_ports: []
     });
+  });
+
+  it('shows the save action only once a field is edited', async () => {
+    const { container, queryByText } = render(ServicePortsTab, { props: { svc: svc() } });
+    expect(queryByText('Save')).toBeNull();
+    const input = container.querySelector('input[type="number"]') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: '1026' } });
+    expect(queryByText('Save')).not.toBeNull();
   });
 });


### PR DESCRIPTION
The services detail view groups its configuration surfaces as tabs now, logs, env, tuning, and the recently added tools tab. Port mappings were the odd one out, reachable only through the cog button in the header as a modal, which was both an arbitrary split and a weaker discovery point than a labelled tab.

Ports becomes a tab following the Tuning tab's shape, a dirty indicator with revert and save that appear only once a field is edited, settling back to clean on a successful save through the normal services broadcast. It hides itself for workers exactly as the cog was suppressed for them, and the published, secondary, and extra port logic is carried over unchanged.

Closes #753