### PR TITLE
fix: stop install prompts swallowing typed-ahead input

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -1450,13 +1449,34 @@ func promptSource() (io.Reader, io.Closer, bool) {
 
 func readConfirmAnswer(r io.Reader, question string, defaultYes bool) bool {
 	feedback.Prompt(question, defaultYes)
-	reader := bufio.NewReader(r)
-	answer, _ := reader.ReadString('\n')
-	answer = strings.TrimSpace(strings.ToLower(answer))
+	answer := strings.TrimSpace(strings.ToLower(readLine(r)))
 	if answer == "" {
 		return defaultYes
 	}
 	return answer != "n" && answer != "no"
+}
+
+// readLine reads a single line, one byte at a time, stopping after the first
+// newline. Reading unbuffered is deliberate: successive prompts share the
+// terminal, so a buffered reader would pull typed-ahead input past this line and
+// discard it, making the next prompt block. Byte-at-a-time leaves the rest in
+// the terminal buffer for the following prompt.
+func readLine(r io.Reader) string {
+	var b strings.Builder
+	buf := make([]byte, 1)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			if buf[0] == '\n' {
+				break
+			}
+			b.WriteByte(buf[0])
+		}
+		if err != nil {
+			break
+		}
+	}
+	return b.String()
 }
 
 // downloadFile downloads a URL to a local file, printing a progress bar to w.

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -644,6 +644,25 @@ func TestReadConfirmAnswer(t *testing.T) {
 	}
 }
 
+// Successive prompts share one input source (reconcile asks per tool), so a
+// single answer must consume exactly its own line. Reading ahead past the
+// newline swallows a user's typed-ahead Enter and makes the next prompt appear
+// to hang until they press Enter again.
+func TestReadConfirmAnswerConsumesSingleLine(t *testing.T) {
+	r := strings.NewReader("\ny\n")
+	var first, second bool
+	withSilencedStdout(t, func() {
+		first = readConfirmAnswer(r, "one?", false)
+		second = readConfirmAnswer(r, "two?", false)
+	})
+	if first {
+		t.Fatalf("first answer = true, want false (empty line keeps the no default)")
+	}
+	if !second {
+		t.Fatalf("second answer = false, want true; the first read consumed past its own line")
+	}
+}
+
 // When stdin is a pipe (not a TTY) and /dev/tty isn't accessible either,
 // promptSource must report no terminal so confirmInstallPromptDefault can
 // fall back to the default rather than reading EOF from the pipe.


### PR DESCRIPTION
The install confirm prompts share one terminal source but each question built its own buffered reader. A buffered read pulls every byte already waiting in the terminal, returns just the current line, then discards the reader when the answer returns, taking any typed-ahead Enter with it. On a host that already has mysql and mysqldump the two shim prompts run back to back, so an Enter meant for the second question got eaten and that prompt sat looking frozen until you pressed Enter again.

readConfirmAnswer now reads a single line one byte at a time and stops at the newline, leaving the rest in the terminal buffer for the next prompt. Every install confirmation flows through this path, so the DNS and Node questions get the same fix.

Refs #758