### PR TITLE
fix: skip podman-mac-helper sudo prompt when already installed

### DIFF
--- a/internal/cli/install_darwin.go
+++ b/internal/cli/install_darwin.go
@@ -86,10 +86,9 @@ func downloadBinaries(w io.Writer) error {
 //
 // If the helper is not found or already installed, this is a no-op.
 func ensurePortForwarding() error {
-	// Check whether the LaunchDaemon is already installed.
-	const daemonPlist = "/Library/LaunchDaemons/com.github.containers.podman.helper.plist"
-	if _, err := os.Stat(daemonPlist); err == nil {
-		return nil // already installed
+	// Skip (and avoid the sudo prompt) if the LaunchDaemon is already installed.
+	if podmanHelperInstalled("/Library/LaunchDaemons", currentUsername(os.Getenv("HOME"))) {
+		return nil
 	}
 
 	// Locate the podman-mac-helper binary.
@@ -110,6 +109,24 @@ func ensurePortForwarding() error {
 		feedback.Note(fmt.Sprintf("Ports 80/443 may not work — run manually: sudo %s install", helperPath))
 	}
 	return nil
+}
+
+// podmanHelperInstalled reports whether the podman-mac-helper LaunchDaemon is
+// already present. Recent Podman names the plist per-user
+// (com.github.containers.podman.helper-<user>.plist); older releases used an
+// unsuffixed name. Checking both lets us skip the sudo prompt when the helper
+// is already installed.
+func podmanHelperInstalled(daemonDir, username string) bool {
+	candidates := []string{
+		"com.github.containers.podman.helper-" + username + ".plist",
+		"com.github.containers.podman.helper.plist",
+	}
+	for _, name := range candidates {
+		if _, err := os.Stat(filepath.Join(daemonDir, name)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // findPodmanMacHelper returns the path to podman-mac-helper if found.

--- a/internal/cli/install_darwin_test.go
+++ b/internal/cli/install_darwin_test.go
@@ -1,0 +1,36 @@
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPodmanHelperInstalled(t *testing.T) {
+	tests := []struct {
+		name     string
+		plist    string
+		username string
+		want     bool
+	}{
+		{"per-user plist", "com.github.containers.podman.helper-george.plist", "george", true},
+		{"unsuffixed plist", "com.github.containers.podman.helper.plist", "george", true},
+		{"other user's plist", "com.github.containers.podman.helper-alice.plist", "george", false},
+		{"not installed", "", "george", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.plist != "" {
+				if err := os.WriteFile(filepath.Join(dir, tc.plist), nil, 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := podmanHelperInstalled(dir, tc.username); got != tc.want {
+				t.Errorf("podmanHelperInstalled = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
On macOS the port forwarding step asked for the sudo password on every lerd install, even when podman-mac-helper was already set up. The existing skip check looked for an unsuffixed LaunchDaemon plist, but recent Podman names the plist per user (com.github.containers.podman.helper-<user>.plist), so the check never matched and we always ran sudo just for the helper to report it was already installed.

The install now checks for the per-user plist, falling back to the legacy unsuffixed name for older Podman, and skips the sudo prompt entirely when either is present.

Refs #760