### PR TITLE
feat(ui): render service tools as cards and always show the ports delete

### DIFF
--- a/internal/ui/web/src/components/PortsEditor.svelte
+++ b/internal/ui/web/src/components/PortsEditor.svelte
@@ -60,10 +60,10 @@
         {disabled}
         title={m.common_remove()}
         aria-label={m.common_remove()}
-        class="absolute top-1.5 right-1.5 p-1 rounded-md text-gray-300 hover:text-red-500 hover:bg-red-50 dark:text-gray-600 dark:hover:text-red-400 dark:hover:bg-red-500/10 opacity-0 group-hover:opacity-100 focus:opacity-100 transition disabled:opacity-30"
+        class="absolute top-1.5 right-1.5 p-1 rounded-md text-gray-400 hover:text-red-500 hover:bg-red-50 dark:text-gray-500 dark:hover:text-red-400 dark:hover:bg-red-500/10 transition disabled:opacity-30"
       >
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
         </svg>
       </button>
     </div>

--- a/internal/ui/web/src/tabs/services/ServiceToolsTab.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceToolsTab.svelte
@@ -28,27 +28,31 @@
   {#if shims.length === 0}
     <p class="text-xs text-gray-400">{m.services_tools_none()}</p>
   {:else}
-    <div class="rounded-lg border border-gray-200 dark:border-lerd-border divide-y divide-gray-200 dark:divide-lerd-border">
+    <div class="flex flex-wrap gap-3">
       {#each shims as shim (shim.tool)}
         {@const managedElsewhere = Boolean(shim.owner && shim.owner !== svc.name)}
-        <div class="flex items-center justify-between px-3 py-2.5">
+        <div
+          class="rounded-xl border border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card px-4 py-3 min-w-[150px] flex flex-col gap-2"
+        >
           <div class="min-w-0">
-            <code class="text-xs text-gray-700 dark:text-gray-200">{shim.tool}</code>
+            <code class="block text-sm font-mono font-semibold text-gray-800 dark:text-gray-100 leading-tight truncate">{shim.tool}</code>
             {#if managedElsewhere}
               <p class="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5">{m.services_tools_providedBy({ service: shim.owner ?? '' })}</p>
             {:else if shim.host_has}
               <p class="text-[10px] text-amber-600 dark:text-amber-400 mt-0.5">{m.services_tools_shadow()}</p>
             {/if}
           </div>
-          <Toggle
-            on={shim.enabled}
-            tone={shim.host_has ? 'amber' : 'emerald'}
-            loading={pending[shim.tool]}
-            failing={failed[shim.tool]}
-            disabled={managedElsewhere}
-            title={managedElsewhere ? m.services_tools_providedBy({ service: shim.owner ?? '' }) : shim.tool}
-            onclick={() => toggle(shim.tool, !shim.enabled)}
-          />
+          <div class="flex justify-end">
+            <Toggle
+              on={shim.enabled}
+              tone={shim.host_has ? 'amber' : 'emerald'}
+              loading={pending[shim.tool]}
+              failing={failed[shim.tool]}
+              disabled={managedElsewhere}
+              title={managedElsewhere ? m.services_tools_providedBy({ service: shim.owner ?? '' }) : shim.tool}
+              onclick={() => toggle(shim.tool, !shim.enabled)}
+            />
+          </div>
         </div>
       {/each}
     </div>


### PR DESCRIPTION
The service Tools tab listed each client shim as a plain row with the toggle at the end, which read poorly next to the card based ports section on the same page. It now uses the same card layout as the ports, a wrapping set of bordered cards carrying the tool name, its shadow or provided-by hint, and the toggle kept in each card.

The ports card delete button was only revealed on hover and used a plain cross. It now shows at all times and uses a trash icon, so removing a port is discoverable without hovering.

Closes #764