### PR TITLE
fix: key host-worker consent on the command that actually runs

### DIFF
--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -310,11 +310,16 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 		return nil
 	}
 
+	command := resolveWorkerCommand(sitePath, workerName, w)
+
 	// A host worker from an untrusted project .lerd.yaml (custom_workers) runs its
-	// command on the host, so require consent before starting it. Trusted workers
-	// (store/built-in/overlay) and in-container workers are unaffected.
+	// command on the host, so require consent before starting it. Consent is keyed
+	// on the resolved command actually executed (the reload variant when the
+	// project opts in), not w.Command, so a reload_command can't run unshown behind
+	// an approved plain command. Trusted workers (store/built-in/overlay) and
+	// in-container workers are unaffected.
 	if w.Host && w.ProjectOrigin {
-		if err := approveHostCommand(siteName, w.Command, fmt.Sprintf("worker %q", workerName)); err != nil {
+		if err := approveHostCommand(siteName, command, fmt.Sprintf("worker %q", workerName)); err != nil {
 			return err
 		}
 	}
@@ -325,8 +330,6 @@ func WorkerStartForSite(siteName, sitePath, phpVersion, workerName string, w con
 	for _, conflict := range w.ConflictsWith {
 		WorkerStopForSite(siteName, sitePath, conflict) //nolint:errcheck
 	}
-
-	command := resolveWorkerCommand(sitePath, workerName, w)
 
 	// Handle proxy port assignment and command augmentation.
 	if w.Proxy != nil && w.Proxy.PortEnvKey != "" {

--- a/internal/cli/worker_consent_test.go
+++ b/internal/cli/worker_consent_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// Regression for the host-worker consent bypass: the gate must authorize the
+// resolved command that actually runs (the reload variant when a project opts
+// in), not the plain w.Command, so approving the shown command can never let an
+// unshown reload_command execute on the host. Runs non-interactive (test env has
+// no tty), where an unapproved command is denied rather than prompted.
+func TestHostWorkerConsent_KeyedOnResolvedCommand(t *testing.T) {
+	site := siteWithReload(t, true, true) // reload on, chokidar present
+	if err := config.SaveSites(&config.SiteRegistry{Sites: []config.Site{
+		{Name: "app", Path: site},
+	}}); err != nil {
+		t.Fatalf("SaveSites: %v", err)
+	}
+
+	// Named "horizon" so siteWithReload's reload opt-in applies to it.
+	worker := config.FrameworkWorker{
+		Command:       "npm run dev",
+		ReloadCommand: "touch /tmp/pwned",
+		Host:          true,
+		ProjectOrigin: true,
+	}
+	resolved := resolveWorkerCommand(site, "horizon", worker)
+	if resolved == worker.Command {
+		t.Fatalf("precondition: reload should resolve to the reload command, got %q", resolved)
+	}
+
+	// Approving only the shown plain command must NOT authorize the reload command.
+	if err := config.ApproveSiteCommand("app", worker.Command); err != nil {
+		t.Fatalf("ApproveSiteCommand: %v", err)
+	}
+	if err := approveHostCommand("app", resolved, "worker \"horizon\""); err == nil {
+		t.Error("approving only the plain command must not authorize the reload command")
+	}
+
+	// Approving the resolved command authorizes exactly what runs.
+	if err := config.ApproveSiteCommand("app", resolved); err != nil {
+		t.Fatalf("ApproveSiteCommand(resolved): %v", err)
+	}
+	if err := approveHostCommand("app", resolved, "worker \"horizon\""); err != nil {
+		t.Errorf("approving the resolved command should authorize it: %v", err)
+	}
+}

--- a/internal/cli/worker_darwin.go
+++ b/internal/cli/worker_darwin.go
@@ -261,11 +261,15 @@ func reapInContainerWorker(reapPath string) {
 // phase 2 of runStart so we don't saturate the Podman Machine SSH connection
 // before containers are ready.
 func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.FrameworkWorker) {
+	// Resolve the same way WorkerStartForSite does so a project opted into
+	// auto-reload keeps its reload command across lerd start and reboots.
+	command := resolveWorkerCommand(sitePath, workerName, w)
 	// A project-supplied host worker only restores on boot if the user already
-	// approved its command; otherwise skip silently so a cloned repo's host worker
-	// can't run unattended on reboot.
+	// approved the resolved command it will actually run; otherwise skip silently
+	// so a cloned repo's host worker (or an unapproved reload command) can't run
+	// unattended on reboot.
 	if w.Host && w.ProjectOrigin {
-		if allowed, _ := config.HostCommandAllowed(siteName, w.Command); !allowed {
+		if allowed, _ := config.HostCommandAllowed(siteName, command); !allowed {
 			return
 		}
 	}
@@ -279,8 +283,5 @@ func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.F
 	if label == "" {
 		label = workerName
 	}
-	// Resolve the same way WorkerStartForSite does so a project opted into
-	// auto-reload keeps its reload command across lerd start and reboots.
-	command := resolveWorkerCommand(sitePath, workerName, w)
 	writeWorkerUnitFile(unitName, label, displaySite, sitePath, phpVersion, command, restart, w.Schedule, fpmUnit, w.Host) //nolint:errcheck
 }

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -187,18 +187,19 @@ func workerLogHint(unitName string, host bool) string {
 // other infra containers are up. Starting here would race against container
 // readiness and cause errors like "lerd-redis: name does not resolve".
 func restoreWorker(siteName, sitePath, phpVersion, workerName string, w config.FrameworkWorker) {
-	// A project-supplied host worker only restores on boot if the user already
-	// approved its command; otherwise skip silently so a cloned repo's host worker
-	// can't run unattended on reboot.
-	if w.Host && w.ProjectOrigin {
-		if allowed, _ := config.HostCommandAllowed(siteName, w.Command); !allowed {
-			return
-		}
-	}
 	// Resolve the same way WorkerStartForSite does so a project opted into
 	// auto-reload keeps its reload command across lerd start and reboots,
 	// instead of silently coming back in standard mode.
 	command := resolveWorkerCommand(sitePath, workerName, w)
+	// A project-supplied host worker only restores on boot if the user already
+	// approved the resolved command it will actually run; otherwise skip silently
+	// so a cloned repo's host worker (or an unapproved reload command) can't run
+	// unattended on reboot.
+	if w.Host && w.ProjectOrigin {
+		if allowed, _ := config.HostCommandAllowed(siteName, command); !allowed {
+			return
+		}
+	}
 	if w.Proxy != nil && w.Proxy.PortEnvKey != "" {
 		envPath := filepath.Join(sitePath, ".env")
 		port := envfile.ReadKey(envPath, w.Proxy.PortEnvKey)


### PR DESCRIPTION
A project supplied host worker asks the user to approve its command before running it on the host, but the gate approved the worker's base command while a reload enabled worker runs its reload_command instead, plus a polling flag where the container cannot see host file changes. A cloned project could show an innocuous command for approval while an arbitrary reload_command executed on the host, and the Linux and macOS restore paths repeated the same mismatch on every reboot because they also checked the base command. WorkerStartForSite and both restore paths now resolve the command first and key consent on the resolved command, so nothing runs on the host that the user was not shown and did not approve.

Closes #770
