### PR TITLE
fix: correctness and cleanup fixes from the v1.27 review

### DIFF
--- a/internal/certs/secure.go
+++ b/internal/certs/secure.go
@@ -92,17 +92,22 @@ func ReissueCertForWorktree(site config.Site) error {
 // never forces, so it is cheap to call on every boot/watcher pass as the routine
 // self-heal that keeps a long-lived secured site's leaf cert from expiring.
 func EnsureCert(site config.Site) error {
-	certsDir := filepath.Join(config.CertsDir(), "sites")
+	certsDir, domains := siteCertDomains(site)
+	return IssueCert(site.PrimaryDomain(), domains, certsDir)
+}
 
+// siteCertDomains assembles the cert output directory and the full SAN list (the
+// site's own domains plus every current worktree domain) shared by the reuse and
+// force reissue paths so they cannot drift.
+func siteCertDomains(site config.Site) (certsDir string, domains []string) {
+	certsDir = filepath.Join(config.CertsDir(), "sites")
 	var wtDomains []string
 	if worktrees, err := gitpkg.ServableWorktrees(site.Path, site.PrimaryDomain()); err == nil {
 		for _, wt := range worktrees {
 			wtDomains = append(wtDomains, wt.Domain)
 		}
 	}
-	domains := WorktreeCertDomains(site.Domains, wtDomains)
-
-	return IssueCert(site.PrimaryDomain(), domains, certsDir)
+	return certsDir, WorktreeCertDomains(site.Domains, wtDomains)
 }
 
 // issueCertWithWorktrees detects all worktrees for the site and issues a
@@ -111,16 +116,7 @@ func EnsureCert(site config.Site) error {
 // reissue is atomic: a transient mkcert failure leaves the existing cert
 // intact rather than tripping RepairVhosts into flipping the site to HTTP.
 func issueCertWithWorktrees(site config.Site) error {
-	certsDir := filepath.Join(config.CertsDir(), "sites")
-
-	var wtDomains []string
-	if worktrees, err := gitpkg.ServableWorktrees(site.Path, site.PrimaryDomain()); err == nil {
-		for _, wt := range worktrees {
-			wtDomains = append(wtDomains, wt.Domain)
-		}
-	}
-	domains := WorktreeCertDomains(site.Domains, wtDomains)
-
+	certsDir, domains := siteCertDomains(site)
 	return IssueCertForce(site.PrimaryDomain(), domains, certsDir)
 }
 

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -290,13 +290,14 @@ func podmanRemoveImage(id string) error {
 	return podman.RunSilent("image", "rm", id)
 }
 
-// Apply removes every target in the plan and returns the disk reclaimed. It
-// sweeps in repeated passes, retrying targets that failed until a full pass
+// Apply removes every target in the plan and returns how many images were
+// actually removed and the disk reclaimed (a skipped target counts toward
+// neither). It sweeps in repeated passes, retrying targets that failed until a full pass
 // frees nothing new: podman refuses a parent image while a child is still
 // present, so removing a dangling build chain listed parent-first needs the
 // children gone first. A target that never succeeds (e.g. it became referenced
 // since Inspect) is simply left, so one stuck image can't abort the sweep.
-func Apply(p Plan) (reclaimed int64) {
+func Apply(p Plan) (removed int, reclaimed int64) {
 	remaining := p.Targets
 	for len(remaining) > 0 {
 		var stuck []Target
@@ -306,6 +307,7 @@ func Apply(p Plan) (reclaimed int64) {
 				stuck = append(stuck, t)
 				continue
 			}
+			removed++
 			reclaimed += t.Bytes
 			progress = true
 		}
@@ -314,7 +316,7 @@ func Apply(p Plan) (reclaimed int64) {
 		}
 		remaining = stuck
 	}
-	return reclaimed
+	return removed, reclaimed
 }
 
 // isLerd reports whether the image was built by lerd, proven by a dev.lerd.*

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -197,10 +197,13 @@ func TestApply_RemovesTargetsAndSumsReclaimed(t *testing.T) {
 	removeImage = func(id string) error { removed = append(removed, id); return nil }
 	t.Cleanup(func() { removeImage = podmanRemoveImage })
 
-	got := Apply(Plan{Targets: []Target{{ID: "aaa", Bytes: 100}, {ID: "bbb", Bytes: 250}}})
+	gotN, got := Apply(Plan{Targets: []Target{{ID: "aaa", Bytes: 100}, {ID: "bbb", Bytes: 250}}})
 
 	if got != 350 {
 		t.Errorf("reclaimed = %d, want 350", got)
+	}
+	if gotN != 2 {
+		t.Errorf("removed count = %d, want 2", gotN)
 	}
 	if len(removed) != 2 || removed[0] != "aaa" || removed[1] != "bbb" {
 		t.Errorf("removed = %v, want [aaa bbb]", removed)
@@ -221,10 +224,13 @@ func TestApply_RetriesUntilDependentsFreed(t *testing.T) {
 	}
 	t.Cleanup(func() { removeImage = podmanRemoveImage })
 
-	got := Apply(Plan{Targets: []Target{{ID: "parent", Bytes: 500}, {ID: "child", Bytes: 100}}})
+	gotN, got := Apply(Plan{Targets: []Target{{ID: "parent", Bytes: 500}, {ID: "child", Bytes: 100}}})
 
 	if got != 600 {
 		t.Errorf("reclaimed = %d, want 600 (both freed across passes)", got)
+	}
+	if gotN != 2 {
+		t.Errorf("removed count = %d, want 2", gotN)
 	}
 	if present["parent"] {
 		t.Error("parent should be removed once the child is gone")
@@ -242,9 +248,12 @@ func TestApply_SkipsFailedRemovalsButContinues(t *testing.T) {
 	}
 	t.Cleanup(func() { removeImage = podmanRemoveImage })
 
-	got := Apply(Plan{Targets: []Target{{ID: "bad", Bytes: 100}, {ID: "good", Bytes: 50}}})
+	gotN, got := Apply(Plan{Targets: []Target{{ID: "bad", Bytes: 100}, {ID: "good", Bytes: 50}}})
 
 	if got != 50 {
 		t.Errorf("reclaimed = %d, want 50 (only the successful removal)", got)
+	}
+	if gotN != 1 {
+		t.Errorf("removed count = %d, want 1 (only the successful removal)", gotN)
 	}
 }

--- a/internal/cleanup/events.go
+++ b/internal/cleanup/events.go
@@ -1,6 +1,9 @@
 package cleanup
 
-import "github.com/geodro/lerd/internal/config"
+import (
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
 
 // autoEnabled reports whether automatic cleanup is on. Seam for tests.
 var autoEnabled = defaultAutoEnabled
@@ -35,7 +38,11 @@ func sweep(deep bool) (images int, bytes int64, err error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	return len(plan.Targets), Apply(plan), nil
+	// Report what Apply actually removed, not the planned count: a target that
+	// became referenced again since Inspect is skipped, so the plan can overstate
+	// the reclaim.
+	removed, bytesFreed := Apply(plan)
+	return removed, bytesFreed, nil
 }
 
 // SweepRefs reaps the exact image references lerd is dropping (the superseded
@@ -49,12 +56,18 @@ func SweepRefs(refs ...string) {
 		return
 	}
 	// De-dup the non-empty refs into canonical candidates, preserving order so a
-	// repeated ref is reaped once.
+	// repeated ref is reaped once. Apply the host image rewrite first
+	// (postgis/postgis -> imresamu/postgis on Apple Silicon) so the ref matches the
+	// name actually stored, otherwise the superseded image is never reclaimed.
 	candidates := map[string]bool{}
 	var order []string
 	for _, ref := range refs {
+		if ref == "" {
+			continue
+		}
+		ref = podman.PlatformImage(ref)
 		c := canonRef(ref)
-		if ref == "" || candidates[c] {
+		if candidates[c] {
 			continue
 		}
 		candidates[c] = true

--- a/internal/cli/cleanup.go
+++ b/internal/cli/cleanup.go
@@ -120,7 +120,8 @@ func runCleanup(dryRun, yes, deep bool) error {
 		return nil
 	}
 
-	feedback.Done(fmt.Sprintf("Freed about %s.", humanSize(cleanup.Apply(plan))))
+	_, freed := cleanup.Apply(plan)
+	feedback.Done(fmt.Sprintf("Freed about %s.", humanSize(freed)))
 	showHeldHint(plan)
 	return nil
 }

--- a/internal/cli/queue_test.go
+++ b/internal/cli/queue_test.go
@@ -1,12 +1,54 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
+	"gopkg.in/yaml.v3"
 )
+
+// The store-fetched Laravel definitions must keep declaring restart_command and
+// tune_command on the queue worker: without them QueueRestartForSite no-ops and
+// queue:start drops its tuned flags, since no Go merger backfills the fields.
+func TestLaravelStoreQueueWorker_HasRestartAndTuneCommands(t *testing.T) {
+	dir := filepath.Join("..", "..", "lerd-frameworks", "frameworks", "laravel")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Skipf("laravel store checkout not present: %v", err)
+	}
+	checked := 0
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		var fw config.Framework
+		if err := yaml.Unmarshal(b, &fw); err != nil {
+			t.Fatalf("unmarshal %s: %v", e.Name(), err)
+		}
+		q, ok := fw.Workers["queue"]
+		if !ok {
+			continue
+		}
+		checked++
+		if q.RestartCommand == "" {
+			t.Errorf("%s: queue worker missing restart_command", e.Name())
+		}
+		if q.TuneCommand == "" {
+			t.Errorf("%s: queue worker missing tune_command", e.Name())
+		}
+	}
+	if checked == 0 {
+		t.Skip("no laravel version declares a queue worker")
+	}
+}
 
 func TestRenderQueueCommand(t *testing.T) {
 	// Laravel declares --queue=/--tries=/--timeout= flags.

--- a/internal/cli/secure.go
+++ b/internal/cli/secure.go
@@ -52,8 +52,10 @@ func resolveSiteName(args []string) (string, error) {
 }
 
 func runSecure(cmd *cobra.Command, args []string) error {
-	if renew, _ := cmd.Flags().GetBool("renew"); renew {
-		return renewCert(args)
+	if cmd != nil {
+		if renew, _ := cmd.Flags().GetBool("renew"); renew {
+			return renewCert(args)
+		}
 	}
 	return toggleSecureCmd(args, true)
 }

--- a/internal/cli/secure_test.go
+++ b/internal/cli/secure_test.go
@@ -1,0 +1,15 @@
+package cli
+
+import "testing"
+
+// lerd link (secured project) and lerd setup call runSecure with a nil
+// *cobra.Command, so it must not panic reading the --renew flag; it should just
+// proceed to the secure toggle, which errors cleanly on an unknown site.
+func TestRunSecure_NilCommandDoesNotPanic(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	if err := runSecure(nil, []string{"nonexistent-site-xyz"}); err == nil {
+		t.Fatal("expected an error for an unknown site, got nil")
+	}
+}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -958,7 +958,7 @@ func newServiceExposeCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&remove, "remove", false, "Remove the port mapping instead of adding it")
+	cmd.Flags().BoolVar(&remove, "remove", false, "Remove the port mapping instead of adding it (accepts the host port or the full host:container spec)")
 	return cmd
 }
 

--- a/internal/cli/site_doctor.go
+++ b/internal/cli/site_doctor.go
@@ -41,8 +41,7 @@ func runSiteDoctor(domain string, asJSON bool) error {
 	if err != nil {
 		return err
 	}
-	fw, _ := config.GetFrameworkForDir(fwName, path)
-	resp := sitedoctor.Run(context.Background(), path, fw)
+	resp := sitedoctor.RunForPath(context.Background(), path, fwName)
 
 	if asJSON {
 		enc := json.NewEncoder(os.Stdout)
@@ -71,8 +70,8 @@ func resolveSiteDoctorTarget(domain string) (path, fwName, label string, err err
 	if err != nil {
 		return "", "", "", err
 	}
-	name, _ := config.DetectFrameworkForDir(cwd)
-	return cwd, name, cwd, nil
+	// Leave fwName empty; sitedoctor.RunForPath detects it from the path.
+	return cwd, "", cwd, nil
 }
 
 func printSiteDoctor(resp sitedoctor.Response, label string) {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -437,7 +437,6 @@ func downloadArchive(ver, filename, archive string) error {
 			errs = append(errs, fmt.Sprintf("%s: %v", url, err))
 			continue
 		}
-		origin.NoteFetched(base)
 		return nil
 	}
 	return fmt.Errorf("download failed: %s", strings.Join(errs, "; "))

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -376,7 +376,7 @@ func (s ServiceConfig) HostPorts() []int {
 		}
 	}
 	for _, ep := range s.ExtraPorts {
-		if n := mappingHostPort(ep); n > 0 {
+		if n := MappingHostPort(ep); n > 0 {
 			ports = append(ports, n)
 		}
 	}
@@ -398,10 +398,10 @@ func (s ServiceConfig) HostPortFor(containerPort, defaultHost int, isPrimary boo
 	return defaultHost
 }
 
-// mappingHostPort extracts the host port from a podman port mapping: a bare host
+// MappingHostPort extracts the host port from a podman port mapping: a bare host
 // port "3411", "3411:3306", or "127.0.0.1:3411:3306", with an optional "/tcp"
 // suffix. Returns 0 when no valid host port is present.
-func mappingHostPort(mapping string) int {
+func MappingHostPort(mapping string) int {
 	parts := strings.Split(mapping, ":")
 	host := parts[0]
 	if len(parts) > 1 {
@@ -409,6 +409,16 @@ func mappingHostPort(mapping string) int {
 	}
 	host = strings.SplitN(host, "/", 2)[0]
 	n, _ := strconv.Atoi(strings.TrimSpace(host))
+	return n
+}
+
+// mappingContainerPort extracts the container (internal) port from a podman port
+// mapping — the last numeric segment after stripping an optional "/proto" suffix.
+// A bare "3411" reports 3411, matching podman's host==container publish.
+func mappingContainerPort(mapping string) int {
+	body := strings.SplitN(mapping, "/", 2)[0]
+	parts := strings.Split(body, ":")
+	n, _ := strconv.Atoi(strings.TrimSpace(parts[len(parts)-1]))
 	return n
 }
 
@@ -423,33 +433,56 @@ func mappingHostPort(mapping string) int {
 // and customs.
 func ReservedHostPorts() map[int]bool {
 	reserved := map[int]bool{}
-	addMappings := func(mappings []string) {
-		for _, m := range mappings {
-			if n := mappingHostPort(m); n > 0 {
-				reserved[n] = true
-			}
+	cfg, _ := LoadGlobal()
+	add := func(n int) {
+		if n > 0 {
+			reserved[n] = true
 		}
 	}
-	if cfg, err := LoadGlobal(); err == nil && cfg != nil {
+	// reserveDefaults reserves a service's default mappings, resolving each through
+	// the service's recorded published override so a moved primary or secondary port
+	// reserves its NEW port and frees the default, instead of pinning the vacated
+	// default reserved forever (which would keep the guard and the host-proxy
+	// allocator from ever reusing it). Matches HostPorts()'s freed-default contract.
+	reserveDefaults := func(name string, mappings []string) {
+		var svc ServiceConfig
+		configured := false
+		if cfg != nil {
+			svc, configured = cfg.Services[name]
+		}
+		for i, m := range mappings {
+			host := MappingHostPort(m)
+			if host <= 0 {
+				continue
+			}
+			if configured {
+				host = svc.HostPortFor(mappingContainerPort(m), host, i == 0)
+			}
+			add(host)
+		}
+	}
+	if cfg != nil {
 		for _, svc := range cfg.Services {
 			for _, p := range svc.HostPorts() {
-				reserved[p] = true
+				add(p)
 			}
 		}
 		for _, specs := range cfg.PHP.FPMPorts {
-			addMappings(specs)
+			for _, m := range specs {
+				add(MappingHostPort(m))
+			}
 		}
 	}
 	if presets, err := ListPresets(); err == nil {
 		for _, meta := range presets {
 			if p, err := LoadPreset(meta.Name); err == nil {
-				addMappings(p.Ports)
+				reserveDefaults(meta.Name, p.Ports)
 			}
 		}
 	}
 	if customs, err := ListCustomServices(); err == nil {
 		for _, svc := range customs {
-			addMappings(svc.Ports)
+			reserveDefaults(svc.Name, svc.Ports)
 		}
 	}
 	return reserved
@@ -634,6 +667,12 @@ func cloneGlobalConfig(in *GlobalConfig) *GlobalConfig {
 			cp := v
 			if v.ExtraPorts != nil {
 				cp.ExtraPorts = append([]string(nil), v.ExtraPorts...)
+			}
+			if v.PublishedPorts != nil {
+				cp.PublishedPorts = make(map[int]int, len(v.PublishedPorts))
+				for pk, pv := range v.PublishedPorts {
+					cp.PublishedPorts[pk] = pv
+				}
 			}
 			out.Services[k] = cp
 		}

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -407,6 +407,22 @@ func TestExtApkDeps_DeepCopied(t *testing.T) {
 	}
 }
 
+// A clone's per-service PublishedPorts map must not alias the original's, or a
+// secondary-port override written into a loaded config would mutate the shared
+// cache (risking a concurrent map read/write in lerd-ui).
+func TestCloneGlobalConfig_PublishedPortsDeepCopied(t *testing.T) {
+	cfg := &GlobalConfig{
+		Services: map[string]ServiceConfig{
+			"mailpit": {PublishedPorts: map[int]int{8025: 8025}},
+		},
+	}
+	clone := cloneGlobalConfig(cfg)
+	clone.Services["mailpit"].PublishedPorts[8025] = 9025
+	if got := cfg.Services["mailpit"].PublishedPorts[8025]; got != 8025 {
+		t.Errorf("mutating the clone must not affect the original: got %d, want 8025", got)
+	}
+}
+
 func TestExtensions_AddIdempotent(t *testing.T) {
 	cfg := &GlobalConfig{}
 	cfg.AddExtension("8.3", "redis")
@@ -753,5 +769,31 @@ func TestReservedHostPorts_IncludesFPMPorts(t *testing.T) {
 	}
 	if !ReservedHostPorts()[3000] {
 		t.Errorf("ReservedHostPorts must reserve an FPM port 3000; got %v", ReservedHostPorts())
+	}
+}
+
+// A published-port override that moves a service off its preset default must free
+// that default for reuse: the preset's own default port loop must not keep it
+// reserved, matching HostPorts()'s freed-default contract.
+func TestReservedHostPorts_FreesDefaultWhenPublishedOverrideMovesIt(t *testing.T) {
+	setConfigDir(t)
+	cfg, _ := LoadGlobal()
+	svc := cfg.Services["mysql"]
+	def := svc.Port
+	if def == 0 {
+		t.Skip("mysql preset has no default port in this build")
+	}
+	moved := def + 1000
+	svc.PublishedPort = moved
+	cfg.Services["mysql"] = svc
+	if err := SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+	reserved := ReservedHostPorts()
+	if reserved[def] {
+		t.Errorf("moved-off default port %d must be freed, but it is still reserved", def)
+	}
+	if !reserved[moved] {
+		t.Errorf("the new published port %d must be reserved; got %v", moved, reserved)
 	}
 }

--- a/internal/mcp/site_doctor.go
+++ b/internal/mcp/site_doctor.go
@@ -27,8 +27,6 @@ func execSiteDoctor(args map[string]any) (any, *rpcError) {
 			}
 			path = cwd
 		}
-		fwName, _ = config.DetectFrameworkForDir(path)
 	}
-	fw, _ := config.GetFrameworkForDir(fwName, path)
-	return toolJSON(sitedoctor.Run(context.Background(), path, fw)), nil
+	return toolJSON(sitedoctor.RunForPath(context.Background(), path, fwName)), nil
 }

--- a/internal/origin/origin.go
+++ b/internal/origin/origin.go
@@ -1,157 +1,85 @@
-// Package origin centralises every URL lerd fetches its own assets from (release
-// binaries, framework store, changelog, GHCR base images) and owns the
-// geodro->lerd-env move: old org first, new as fallback, flipping on a new-org hit.
+// Package origin centralises every URL lerd fetches its own assets from: release
+// binaries, the framework and service stores, the changelog, and the GHCR base
+// images. Everything is served from the lerd-env org (the geodro->lerd-env move
+// is complete), and each endpoint is overridable via its environment variable
+// for tests and mirrors.
 package origin
 
 import (
 	"os"
 	"strings"
-	"sync"
 )
 
-// org holds the repo coordinates for one GitHub owner.
-type org struct {
-	owner          string // GitHub org, also the GHCR namespace
-	mainRepo       string // owner/name for releases, installer, changelog
-	frameworksRepo string // owner/name for the framework store
-	servicesRepo   string // owner/name for the service-preset store
-}
+const (
+	owner          = "lerd-env"      // GitHub org, also the GHCR namespace
+	mainRepo       = "lerd-env/lerd" // releases, installer, changelog
+	frameworksRepo = "lerd-env/frameworks"
+	servicesRepo   = "lerd-env/services"
+)
 
-// Links is the centralized handler for lerd's distribution URLs and the
-// old->new org switch. The zero value is not usable; use New or Default.
-type Links struct {
-	old, new  org
-	mu        sync.RWMutex
-	preferNew bool // when true, the new org is served first
-}
-
-// New builds a Links with the geodro (old) and lerd-env (new) coordinates,
-// preferring old first unless LERD_DISTRIBUTION_ORG says otherwise.
-func New() *Links {
-	l := &Links{
-		// geodro is the current (old) org, served first and kept as the fallback.
-		old: org{owner: "geodro", mainRepo: "geodro/lerd", frameworksRepo: "geodro/lerd-frameworks", servicesRepo: "geodro/lerd-services"},
-		new: org{owner: "lerd-env", mainRepo: "lerd-env/lerd", frameworksRepo: "lerd-env/frameworks", servicesRepo: "lerd-env/services"},
-	}
-	switch strings.ToLower(os.Getenv("LERD_DISTRIBUTION_ORG")) {
-	case "lerd-env", "new":
-		l.preferNew = true
-	case "geodro", "old":
-		l.preferNew = false
-	}
-	return l
-}
-
-// Default is the process-wide Links used by the package-level helpers.
-var Default = New()
-
-// PreferNew reports whether the new (lerd-env) org is served first.
-func (l *Links) PreferNew() bool {
-	l.mu.RLock()
-	defer l.mu.RUnlock()
-	return l.preferNew
-}
-
-// SetPreferNew sets which org is served first.
-func (l *Links) SetPreferNew(v bool) {
-	l.mu.Lock()
-	l.preferNew = v
-	l.mu.Unlock()
-}
-
-// ordered returns [preferred, other] for a function that maps an org to a URL.
-func (l *Links) ordered(of func(org) string) []string {
-	l.mu.RLock()
-	defer l.mu.RUnlock()
-	if l.preferNew {
-		return []string{of(l.new), of(l.old)}
-	}
-	return []string{of(l.old), of(l.new)}
-}
-
-func rawRepo(o org) string     { return "https://raw.githubusercontent.com/" + o.frameworksRepo }
-func rawServices(o org) string { return "https://raw.githubusercontent.com/" + o.servicesRepo }
-func rawMain(o org) string     { return "https://raw.githubusercontent.com/" + o.mainRepo }
-func releases(o org) string    { return "https://github.com/" + o.mainRepo + "/releases" }
-func apiBase(o org) string     { return "https://api.github.com/repos/" + o.mainRepo }
-
-// StoreBaseURLs returns the framework-store base. The store content lives in the
-// new lerd-env org, so it is served directly without the geodro fallback the
-// binary-distribution endpoints still carry through the org move.
-func (l *Links) StoreBaseURLs() []string {
+// StoreBaseURLs returns the framework-store base. The definitions live under a
+// frameworks/ subdir (index.json + <name>.yaml), not at the repo root.
+func StoreBaseURLs() []string {
 	if list := splitList(os.Getenv("LERD_STORE_BASE_URL")); len(list) > 0 {
 		return list
 	}
-	return []string{rawRepo(l.new) + "/main/frameworks"}
+	return []string{"https://raw.githubusercontent.com/" + frameworksRepo + "/main/frameworks"}
 }
 
-// ServiceStoreBaseURLs returns the service-preset-store base. Like the framework
-// store it targets the new lerd-env org directly and nests the definitions under
-// a services/ subdir (index.json + <name>.yaml live there, not at the repo root).
-func (l *Links) ServiceStoreBaseURLs() []string {
+// ServiceStoreBaseURLs returns the service-preset-store base, nested under a
+// services/ subdir.
+func ServiceStoreBaseURLs() []string {
 	if list := splitList(os.Getenv("LERD_SERVICES_BASE_URL")); len(list) > 0 {
 		return list
 	}
-	return []string{rawServices(l.new) + "/main/services"}
+	return []string{"https://raw.githubusercontent.com/" + servicesRepo + "/main/services"}
 }
 
-// ReleaseBaseURLs lists GitHub releases bases in priority order.
-func (l *Links) ReleaseBaseURLs() []string {
+// ReleaseBaseURLs lists GitHub releases bases.
+func ReleaseBaseURLs() []string {
 	if list := splitList(os.Getenv("LERD_RELEASES_URL")); len(list) > 0 {
 		return list
 	}
-	return l.ordered(releases)
+	return []string{"https://github.com/" + mainRepo + "/releases"}
 }
 
-// ReleaseDownloadBases lists release-asset download bases in priority order.
-func (l *Links) ReleaseDownloadBases() []string {
+// ReleaseDownloadBases lists release-asset download bases.
+func ReleaseDownloadBases() []string {
 	if list := splitList(os.Getenv("LERD_RELEASE_DOWNLOAD_URL")); len(list) > 0 {
 		return list
 	}
-	out := l.ReleaseBaseURLs()
+	out := ReleaseBaseURLs()
 	for i := range out {
 		out[i] += "/download"
 	}
 	return out
 }
 
-// ReleaseAPIBaseURLs lists GitHub API bases in priority order.
-func (l *Links) ReleaseAPIBaseURLs() []string {
+// ReleaseAPIBaseURLs lists GitHub API bases.
+func ReleaseAPIBaseURLs() []string {
 	if list := splitList(os.Getenv("LERD_RELEASES_API_URL")); len(list) > 0 {
 		return list
 	}
-	return l.ordered(apiBase)
+	return []string{"https://api.github.com/repos/" + mainRepo}
 }
 
-// ChangelogURLs lists raw changelog URLs in priority order.
-func (l *Links) ChangelogURLs() []string {
+// ChangelogURLs lists raw changelog URLs.
+func ChangelogURLs() []string {
 	if list := splitList(os.Getenv("LERD_CHANGELOG_URL")); len(list) > 0 {
 		return list
 	}
-	return l.ordered(func(o org) string { return rawMain(o) + "/main/CHANGELOG.md" })
+	return []string{"https://raw.githubusercontent.com/" + mainRepo + "/main/CHANGELOG.md"}
 }
 
-// BaseImageRefs lists GHCR refs for a prebuilt PHP-FPM base image in priority
-// order, where phpShort is the dotless version (e.g. "85") and hash pins the
-// image to the embedded Containerfile template.
-func (l *Links) BaseImageRefs(phpShort, hash string) []string {
+// BaseImageRefs lists GHCR refs for a prebuilt PHP-FPM base image, where phpShort
+// is the dotless version (e.g. "85") and hash pins the image to the embedded
+// Containerfile template.
+func BaseImageRefs(phpShort, hash string) []string {
 	suffix := "/lerd-php" + phpShort + "-fpm-base:" + hash
 	if v := os.Getenv("LERD_BASE_IMAGE_REGISTRY"); v != "" {
 		return []string{v + suffix}
 	}
-	return l.ordered(func(o org) string { return "ghcr.io/" + o.owner + suffix })
-}
-
-// NoteFetched flips to serving the new org first the first time a real request
-// succeeds against a new-org URL (e.g. once the old org is retired). One-way,
-// old->new only; no probe, no timer.
-func (l *Links) NoteFetched(base string) {
-	if base == "" || l.PreferNew() {
-		return
-	}
-	if strings.Contains(base, "/"+l.new.owner+"/") {
-		l.SetPreferNew(true)
-	}
+	return []string{"ghcr.io/" + owner + suffix}
 }
 
 // splitList parses a comma-separated override into trimmed, non-empty entries.
@@ -164,13 +92,3 @@ func splitList(v string) []string {
 	}
 	return out
 }
-
-// Package-level helpers delegate to Default.
-func StoreBaseURLs() []string                      { return Default.StoreBaseURLs() }
-func ServiceStoreBaseURLs() []string               { return Default.ServiceStoreBaseURLs() }
-func ReleaseBaseURLs() []string                    { return Default.ReleaseBaseURLs() }
-func ReleaseDownloadBases() []string               { return Default.ReleaseDownloadBases() }
-func ReleaseAPIBaseURLs() []string                 { return Default.ReleaseAPIBaseURLs() }
-func ChangelogURLs() []string                      { return Default.ChangelogURLs() }
-func BaseImageRefs(phpShort, hash string) []string { return Default.BaseImageRefs(phpShort, hash) }
-func NoteFetched(base string)                      { Default.NoteFetched(base) }

--- a/internal/origin/origin_test.go
+++ b/internal/origin/origin_test.go
@@ -5,40 +5,19 @@ import (
 	"testing"
 )
 
-// The binary-distribution endpoints still carry the org move: geodro first,
-// lerd-env as the fallback. The framework and service stores are excluded here
-// because their content lives on lerd-env and is served directly (see
-// TestStoresUseNewOrgDirectly).
-func TestDefaultOrderOldFirstNewFallback(t *testing.T) {
-	l := New()
+// Every endpoint serves the lerd-env org directly (the geodro move is complete)
+// and never returns an empty list that would panic store.NewClient's urls[0].
+func TestAllEndpointsServeLerdEnv(t *testing.T) {
 	lists := map[string][]string{
-		"releases":  l.ReleaseBaseURLs(),
-		"downloads": l.ReleaseDownloadBases(),
-		"api":       l.ReleaseAPIBaseURLs(),
-		"changelog": l.ChangelogURLs(),
-		"baseimage": l.BaseImageRefs("85", "h"),
+		"framework-store": StoreBaseURLs(),
+		"service-store":   ServiceStoreBaseURLs(),
+		"releases":        ReleaseBaseURLs(),
+		"downloads":       ReleaseDownloadBases(),
+		"api":             ReleaseAPIBaseURLs(),
+		"changelog":       ChangelogURLs(),
+		"baseimage":       BaseImageRefs("85", "h"),
 	}
 	for name, got := range lists {
-		if len(got) != 2 {
-			t.Fatalf("%s: want 2 candidates, got %d (%v)", name, len(got), got)
-		}
-		if !strings.Contains(got[0], "geodro") {
-			t.Errorf("%s: primary %q is not the old geodro location", name, got[0])
-		}
-		if !strings.Contains(got[1], "lerd-env") {
-			t.Errorf("%s: fallback %q is not the new lerd-env location", name, got[1])
-		}
-	}
-}
-
-// Both stores serve the lerd-env org directly with no geodro fallback, and never
-// return an empty list that would panic store.NewClient's urls[0].
-func TestStoresUseNewOrgDirectly(t *testing.T) {
-	l := New()
-	for name, got := range map[string][]string{
-		"framework-store": l.StoreBaseURLs(),
-		"service-store":   l.ServiceStoreBaseURLs(),
-	} {
 		if len(got) == 0 {
 			t.Fatalf("%s: empty base list", name)
 		}
@@ -47,45 +26,42 @@ func TestStoresUseNewOrgDirectly(t *testing.T) {
 		}
 		for _, u := range got {
 			if strings.Contains(u, "geodro") {
-				t.Errorf("%s: must not rely on geodro, got %q", name, u)
+				t.Errorf("%s: must not reference geodro, got %q", name, u)
 			}
 		}
 	}
-	// The switch must hold even after a new-org flip (already new-first).
-	l.SetPreferNew(true)
-	if strings.Contains(l.StoreBaseURLs()[0], "geodro") || strings.Contains(l.ServiceStoreBaseURLs()[0], "geodro") {
-		t.Error("stores must never serve geodro regardless of preference")
+}
+
+func TestBaseImageRefFormat(t *testing.T) {
+	refs := BaseImageRefs("84", "abc")
+	if len(refs) != 1 || refs[0] != "ghcr.io/lerd-env/lerd-php84-fpm-base:abc" {
+		t.Errorf("base ref = %v, want [ghcr.io/lerd-env/lerd-php84-fpm-base:abc]", refs)
+	}
+}
+
+func TestBaseImageRegistryOverride(t *testing.T) {
+	t.Setenv("LERD_BASE_IMAGE_REGISTRY", "registry.example/mirror")
+	refs := BaseImageRefs("85", "h")
+	if len(refs) != 1 || refs[0] != "registry.example/mirror/lerd-php85-fpm-base:h" {
+		t.Errorf("override base ref = %v", refs)
+	}
+}
+
+func TestStoreEnvOverrideReplacesList(t *testing.T) {
+	t.Setenv("LERD_STORE_BASE_URL", "https://store.example/a, https://store.example/b")
+	got := StoreBaseURLs()
+	want := []string{"https://store.example/a", "https://store.example/b"}
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("override list = %v, want %v", got, want)
 	}
 }
 
 func TestServiceStoreEnvOverride(t *testing.T) {
 	t.Setenv("LERD_SERVICES_BASE_URL", "https://svc.example/a, https://svc.example/b")
-	got := New().ServiceStoreBaseURLs()
+	got := ServiceStoreBaseURLs()
 	want := []string{"https://svc.example/a", "https://svc.example/b"}
 	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
 		t.Errorf("service override list = %v, want %v", got, want)
-	}
-}
-
-// After the switch, the new lerd-env location is served first and geodro becomes
-// the fallback.
-func TestSetPreferNewFlipsOrder(t *testing.T) {
-	l := New()
-	l.SetPreferNew(true)
-	if !l.PreferNew() {
-		t.Fatal("PreferNew() should be true after SetPreferNew(true)")
-	}
-	got := l.ReleaseBaseURLs()
-	if !strings.Contains(got[0], "lerd-env") || !strings.Contains(got[1], "geodro") {
-		t.Errorf("after switch want [lerd-env, geodro], got %v", got)
-	}
-}
-
-func TestDistributionOrgEnvForcesNew(t *testing.T) {
-	t.Setenv("LERD_DISTRIBUTION_ORG", "lerd-env")
-	l := New()
-	if !l.PreferNew() {
-		t.Fatal("LERD_DISTRIBUTION_ORG=lerd-env should prefer the new org")
 	}
 }
 
@@ -93,67 +69,8 @@ func TestDistributionOrgEnvForcesNew(t *testing.T) {
 // the default, never an empty list that would panic store.NewClient's urls[0].
 func TestEnvOverrideIgnoredWhenEmpty(t *testing.T) {
 	t.Setenv("LERD_STORE_BASE_URL", " , , ")
-	got := New().StoreBaseURLs()
+	got := StoreBaseURLs()
 	if len(got) == 0 || !strings.Contains(got[0], "lerd-env") {
 		t.Fatalf("empty override must fall back to the lerd-env default, got %v", got)
-	}
-}
-
-func TestStoreEnvOverrideReplacesList(t *testing.T) {
-	t.Setenv("LERD_STORE_BASE_URL", "https://store.example/a, https://store.example/b")
-	got := New().StoreBaseURLs()
-	want := []string{"https://store.example/a", "https://store.example/b"}
-	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
-		t.Errorf("override list = %v, want %v", got, want)
-	}
-}
-
-func TestBaseImageRefFormat(t *testing.T) {
-	refs := New().BaseImageRefs("84", "abc")
-	if refs[0] != "ghcr.io/geodro/lerd-php84-fpm-base:abc" {
-		t.Errorf("primary base ref = %q", refs[0])
-	}
-	if refs[1] != "ghcr.io/lerd-env/lerd-php84-fpm-base:abc" {
-		t.Errorf("fallback base ref = %q", refs[1])
-	}
-}
-
-// A request that succeeds against a new-org URL flips preference to new-first.
-// A request that succeeds against the old org leaves it alone.
-func TestNoteFetchedFlipsOnNewOrgSuccess(t *testing.T) {
-	l := New()
-
-	// A successful old-org fetch keeps us on old.
-	l.NoteFetched(l.ReleaseBaseURLs()[0]) // geodro (primary while old-first)
-	if l.PreferNew() {
-		t.Fatal("a successful old-org fetch must not flip to new")
-	}
-
-	// A successful new-org fetch (the fallback won) flips to new-first.
-	l.NoteFetched(l.ReleaseBaseURLs()[1]) // lerd-env (fallback while old-first)
-	if !l.PreferNew() {
-		t.Fatal("a successful new-org fetch must flip to new-first")
-	}
-	if !strings.Contains(l.ReleaseBaseURLs()[0], "lerd-env") {
-		t.Errorf("after the flip the new org should be served first, got %v", l.ReleaseBaseURLs())
-	}
-}
-
-// NoteFetched is one-directional and ignores unrelated or empty bases.
-func TestNoteFetchedIgnoresUnrelatedBase(t *testing.T) {
-	l := New()
-	l.NoteFetched("")
-	l.NoteFetched("https://example.com/whatever")
-	if l.PreferNew() {
-		t.Fatal("an empty or unrelated base must not flip preference")
-	}
-}
-
-// A new-org win works for a GHCR base-image ref too, not just raw URLs.
-func TestNoteFetchedMatchesGHCRRef(t *testing.T) {
-	l := New()
-	l.NoteFetched(l.BaseImageRefs("85", "h")[1]) // ghcr.io/lerd-env/...
-	if !l.PreferNew() {
-		t.Fatal("a successful new-org GHCR pull must flip to new-first")
 	}
 }

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -355,7 +355,6 @@ func tryPullBaseImage(version string, w io.Writer) string {
 		var stderr strings.Builder
 		cmd.Stderr = &stderr
 		if err := cmd.Run(); err == nil {
-			origin.NoteFetched(ref)
 			return ref
 		} else if s := strings.TrimSpace(stderr.String()); s != "" {
 			lastErr = pullErrLine(s)

--- a/internal/podman/build_test.go
+++ b/internal/podman/build_test.go
@@ -3,6 +3,7 @@ package podman
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"reflect"
 	"slices"
 	"strings"
@@ -35,6 +36,33 @@ func TestBasePullArgs(t *testing.T) {
 		if strings.HasPrefix(a, "--authfile=") {
 			t.Errorf("empty authFile must omit --authfile, got %v", noAuth)
 		}
+	}
+}
+
+// TestBaseImagePullResolvesFromRegistry guards the FPM base-image pull: as long
+// as the published ref (ghcr.io/lerd-env) is pullable, it must return that ref
+// rather than collapsing to a slow full local build.
+func TestBaseImagePullResolvesFromRegistry(t *testing.T) {
+	prevExec := execCommand
+	t.Cleanup(func() { execCommand = prevExec })
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		ref := args[len(args)-1]
+		if strings.Contains(ref, "ghcr.io/lerd-env/") {
+			return fakeExec("", "", 0)(name, args...)
+		}
+		return fakeExec("", "Error: manifest unknown", 1)(name, args...)
+	}
+
+	var buf strings.Builder
+	got := tryPullBaseImage("8.5", &buf)
+	if got == "" {
+		t.Fatalf("pull returned empty (would force a full local build); log:\n%s", buf.String())
+	}
+	if !strings.Contains(got, "ghcr.io/lerd-env/") {
+		t.Errorf("pulled %q, want a ref under ghcr.io/lerd-env/", got)
+	}
+	if !strings.Contains(got, "lerd-php85-fpm-base") {
+		t.Errorf("pulled %q, not the php 8.5 base image", got)
 	}
 }
 

--- a/internal/podman/exec.go
+++ b/internal/podman/exec.go
@@ -76,9 +76,13 @@ func RunSilent(args ...string) error {
 	return err
 }
 
-// ImageExists returns true if the named image is present in the local store.
+// ImageExists returns true if the named image is present in the local store. It
+// applies the same host rewrite as the pull path (postgis/postgis ->
+// imresamu/postgis on Apple Silicon), so the check tests the name actually
+// stored and doesn't force a needless re-pull. PlatformImage is identity for
+// every other image and platform.
 func ImageExists(image string) bool {
-	return RunSilent("image", "exists", image) == nil
+	return RunSilent("image", "exists", PlatformImage(image)) == nil
 }
 
 // LocalImageDigest returns every known digest for the locally-stored image,

--- a/internal/podman/fpmports.go
+++ b/internal/podman/fpmports.go
@@ -2,7 +2,6 @@ package podman
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
@@ -55,6 +54,7 @@ func SetFPMPorts(version string, specs []string) ([]string, error) {
 
 	resolved := make([]string, 0, len(specs))
 	seen := map[string]bool{}
+	requested := map[string]bool{}
 	for _, spec := range specs {
 		spec = strings.TrimSpace(spec)
 		if spec == "" {
@@ -64,6 +64,14 @@ func SetFPMPorts(version string, specs []string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Collapse an exact-duplicate request before the shift, so re-adding a
+		// mapping the batch already carries is a no-op rather than being pushed
+		// onto a redundant extra host port.
+		reqKey := fmt.Sprintf("%d:%d", host, container)
+		if requested[reqKey] {
+			continue
+		}
+		requested[reqKey] = true
 		if taken(host) {
 			host = freeport.FirstFree(host+1, taken)
 			if host == 0 {
@@ -166,13 +174,8 @@ func parseFPMPortSpec(spec string) (host, container int, err error) {
 }
 
 // specHostPort returns the host-side port of a "host:container" or
-// "ip:host:container" mapping (an optional /proto suffix is ignored), or 0.
+// "ip:host:container" mapping (an optional /proto suffix is ignored), or 0. It
+// reuses PrimaryHostPort so there is a single host-port parser for FPM specs.
 func specHostPort(spec string) int {
-	parts := strings.Split(strings.SplitN(spec, "/", 2)[0], ":")
-	host := parts[0]
-	if len(parts) > 1 {
-		host = parts[len(parts)-2]
-	}
-	n, _ := strconv.Atoi(strings.TrimSpace(host))
-	return n
+	return PrimaryHostPort([]string{spec})
 }

--- a/internal/podman/fpmports_test.go
+++ b/internal/podman/fpmports_test.go
@@ -95,6 +95,19 @@ func TestSetFPMPorts_ShiftsDuplicateWithinBatch(t *testing.T) {
 	}
 }
 
+// An exact-duplicate host:container spec in the batch collapses to a single
+// mapping rather than being shifted onto a redundant extra host port.
+func TestSetFPMPorts_CollapsesExactDuplicate(t *testing.T) {
+	fpmTestEnv(t)
+	got, err := SetFPMPorts("8.3", []string{"3000:3000", "3000:3000"})
+	if err != nil {
+		t.Fatalf("SetFPMPorts: %v", err)
+	}
+	if len(got) != 1 || got[0] != "3000:3000" {
+		t.Errorf("resolved = %v, want [3000:3000] (duplicate collapsed)", got)
+	}
+}
+
 func TestSetFPMPorts_EmptyClearsVersion(t *testing.T) {
 	fpmTestEnv(t)
 	if _, err := SetFPMPorts("8.3", []string{"3000:3000"}); err != nil {

--- a/internal/reqstats/persist.go
+++ b/internal/reqstats/persist.go
@@ -10,7 +10,13 @@ import (
 // file and rename so a reader never sees a half-written file. The watcher calls
 // this on its tick; lerd-ui reads it with Load.
 func (a *Aggregator) Save(path string) error {
-	snap := a.Snapshot()
+	return SaveSnapshot(a.Snapshot(), path)
+}
+
+// SaveSnapshot persists an already-computed snapshot, so a caller that also needs
+// the snapshot (e.g. to feed slow-route notifications) can build it once and
+// avoid recomputing it inside Save.
+func SaveSnapshot(snap []SiteStats, path string) error {
 	b, err := json.Marshal(snap)
 	if err != nil {
 		return err

--- a/internal/serviceops/ports.go
+++ b/internal/serviceops/ports.go
@@ -60,9 +60,7 @@ func SetPublishedPort(name string, port int) (PortChange, error) {
 	// Silence the guard's shift hook during our own quadlet write; we fire it
 	// once at the end with the actual resulting port, so a --reset that the guard
 	// re-shifts off a host-owned default never refreshes followers twice.
-	savedHook := OnPublishedPortShift
-	OnPublishedPortShift = nil
-	defer func() { OnPublishedPortShift = savedHook }()
+	defer suppressPublishedPortShift()()
 
 	cfg, err := config.LoadGlobal()
 	if err != nil {
@@ -87,7 +85,7 @@ func SetPublishedPort(name string, port int) (PortChange, error) {
 	// A published port can't double as one of this service's own extra ports.
 	if port > 0 {
 		for _, ep := range svcCfg.ExtraPorts {
-			if extraHostPort(ep) == port {
+			if config.MappingHostPort(ep) == port {
 				return res, fmt.Errorf("%w: %d", ErrPortInUse, port)
 			}
 		}
@@ -136,10 +134,9 @@ func SetPublishedPort(name string, port int) (PortChange, error) {
 		return res, err
 	}
 	// Host-proxy sites reach the service over the published loopback port, so
-	// refresh their .env to follow the change (no-op when none use it).
-	if savedHook != nil {
-		savedHook(name, res.Actual)
-	}
+	// refresh their .env to follow the change (no-op when none use it). Fired
+	// once here with the final port, bypassing our own suppression window.
+	firePublishedPortShiftForced(name, res.Actual)
 	return res, nil
 }
 
@@ -253,7 +250,7 @@ func SetPublishedPortFor(name string, containerPort, hostPort int) (PortChange, 
 			}
 		}
 		for _, ep := range svcCfg.ExtraPorts {
-			if extraHostPort(ep) == hostPort {
+			if config.MappingHostPort(ep) == hostPort {
 				return res, fmt.Errorf("%w: %d", ErrPortInUse, hostPort)
 			}
 		}
@@ -323,6 +320,14 @@ func persistSecondaryOverride(name string, containerPort, port int) error {
 // optional like gotenberg); genuinely custom services declare their ports in
 // their own YAML, so they're excluded.
 func SetExtraPorts(name string, ports []string) error {
+	return updateExtraPorts(name, func(_ []string) []string { return ports })
+}
+
+// updateExtraPorts loads the global config once, derives the new extra-port list
+// from the current one via mutate, then validates, persists, and re-renders.
+// SetExtraPorts/AddExtraPort/RemoveExtraPort all funnel through here so a single
+// mutation reads the config file once, not twice.
+func updateExtraPorts(name string, mutate func(current []string) []string) error {
 	if !config.PresetExists(name) {
 		return fmt.Errorf("%q is not a bundled service", name)
 	}
@@ -331,6 +336,7 @@ func SetExtraPorts(name string, ports []string) error {
 		return err
 	}
 	svcCfg := cfg.Services[name]
+	ports := mutate(svcCfg.ExtraPorts)
 	// The service's own main host port (published override, else preset default)
 	// is reserved — an extra mapping must not republish it.
 	mainHost := svcCfg.Port
@@ -348,7 +354,7 @@ func SetExtraPorts(name string, ports []string) error {
 		if err := ValidateExtraPort(p); err != nil {
 			return err
 		}
-		host := extraHostPort(p)
+		host := config.MappingHostPort(p)
 		if host > 0 {
 			if host == mainHost || seenHost[host] {
 				return fmt.Errorf("%w: %d", ErrPortInUse, host)
@@ -372,30 +378,27 @@ func SetExtraPorts(name string, ports []string) error {
 	if err := rerenderServiceQuadlet(name); err != nil {
 		return err
 	}
-	if status, _ := podman.UnitStatus("lerd-" + name); status == "active" {
+	// Treat "activating" as running too (a slow-booting unit), matching
+	// applyServicePortRestart, so a port exposed mid-boot still takes effect.
+	if status, _ := podman.UnitStatus("lerd-" + name); status == "active" || status == "activating" {
 		_ = podman.RestartUnit("lerd-" + name)
 	}
 	return nil
 }
 
 // AddExtraPort adds a single extra published port to a built-in service. Adding a
-// mapping already present is a harmless re-render (SetExtraPorts de-duplicates).
+// mapping already present is a harmless re-render (updateExtraPorts de-duplicates).
 func AddExtraPort(name, spec string) error {
-	cfg, err := config.LoadGlobal()
-	if err != nil {
-		return err
-	}
-	cur := cfg.Services[name].ExtraPorts
-	return SetExtraPorts(name, append(append([]string{}, cur...), spec))
+	return updateExtraPorts(name, func(cur []string) []string {
+		return append(append([]string{}, cur...), spec)
+	})
 }
 
 // RemoveExtraPort removes a single extra published port from a built-in service.
 func RemoveExtraPort(name, spec string) error {
-	cfg, err := config.LoadGlobal()
-	if err != nil {
-		return err
-	}
-	return SetExtraPorts(name, removePort(append([]string{}, cfg.Services[name].ExtraPorts...), spec))
+	return updateExtraPorts(name, func(cur []string) []string {
+		return removePort(append([]string{}, cur...), spec)
+	})
 }
 
 // ValidateExtraPort checks that spec is a usable podman port mapping: a bare host
@@ -484,23 +487,16 @@ func serviceEffectiveHostPorts(name string, cfg config.ServiceConfig) []int {
 	return ports
 }
 
-// extraHostPort returns the host-side port of a "host", "host:container", or
-// "ip:host:container" mapping (an optional /proto suffix is ignored), or 0 when
-// none is parseable.
-func extraHostPort(spec string) int {
-	parts := strings.Split(strings.SplitN(spec, "/", 2)[0], ":")
-	host := parts[0]
-	if len(parts) > 1 {
-		host = parts[len(parts)-2]
-	}
-	n, _ := strconv.Atoi(strings.TrimSpace(host))
-	return n
-}
-
-func removePort(ports []string, port string) []string {
+// removePort drops the mapping whose host port matches target, which may be a
+// bare host port ("39996") or a full "host:container" spec. Matching on the host
+// port lets `service expose --remove <hostport>` work without echoing the exact
+// spec back; a host port uniquely identifies an extra mapping, so this can't drop
+// the wrong one. An unparseable target removes nothing.
+func removePort(ports []string, target string) []string {
+	want := config.MappingHostPort(target)
 	out := ports[:0]
 	for _, p := range ports {
-		if p != port {
+		if want == 0 || config.MappingHostPort(p) != want {
 			out = append(out, p)
 		}
 	}

--- a/internal/serviceops/ports_test.go
+++ b/internal/serviceops/ports_test.go
@@ -2,11 +2,37 @@ package serviceops
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
 )
+
+// The guard's shift hook is silenced only while a SetPublishedPort window is
+// open, counted so overlapping windows both hold it, while the forced fire
+// (SetPublishedPort's own end-of-change refresh) always runs. This is the
+// non-racy replacement for nil-swapping the package-global hook.
+func TestPublishedPortShiftSuppression(t *testing.T) {
+	var fired []int
+	prev := OnPublishedPortShift
+	OnPublishedPortShift = func(_ string, port int) { fired = append(fired, port) }
+	t.Cleanup(func() { OnPublishedPortShift = prev })
+
+	firePublishedPortShift("mysql", 1) // not suppressed: fires
+	unsuppress := suppressPublishedPortShift()
+	firePublishedPortShift("mysql", 2)       // suppressed: silenced
+	firePublishedPortShiftForced("mysql", 3) // forced: fires despite suppression
+	un2 := suppressPublishedPortShift()      // nested window
+	unsuppress()                             // one window closed, still suppressed
+	firePublishedPortShift("mysql", 4)       // silenced
+	un2()                                    // all windows closed
+	firePublishedPortShift("mysql", 5)       // fires again
+
+	if want := []int{1, 3, 5}; !reflect.DeepEqual(fired, want) {
+		t.Errorf("fired = %v, want %v", fired, want)
+	}
+}
 
 func TestValidateExtraPort(t *testing.T) {
 	cases := []struct {
@@ -37,9 +63,19 @@ func TestValidateExtraPort(t *testing.T) {
 }
 
 func TestRemovePort(t *testing.T) {
+	// Full spec removes every mapping on that host port.
 	got := removePort([]string{"3411:3306", "39580:80", "3411:3306"}, "3411:3306")
 	if len(got) != 1 || got[0] != "39580:80" {
-		t.Errorf("removePort dropped wrong entries: %v", got)
+		t.Errorf("removePort(full spec) dropped wrong entries: %v", got)
+	}
+	// A bare host port removes the mapping too, so `expose --remove 39580` works.
+	got = removePort([]string{"3411:3306", "39580:80"}, "39580")
+	if len(got) != 1 || got[0] != "3411:3306" {
+		t.Errorf("removePort(host only) should drop 39580:80: %v", got)
+	}
+	// An unparseable target removes nothing.
+	if got := removePort([]string{"39580:80"}, ""); len(got) != 1 {
+		t.Errorf("removePort(empty) should keep everything: %v", got)
 	}
 }
 

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
@@ -58,6 +59,55 @@ func PortAvailable(port int) bool { return freeport.Bindable(port) }
 // reinstall, `service port --reset`) refreshes followers, not just the explicit
 // `lerd service port` command.
 var OnPublishedPortShift func(service string, newPort int)
+
+// shiftHookMu guards OnPublishedPortShift and shiftSuppressN. SetPublishedPort
+// runs in the long-lived lerd-ui process where HTTP handlers are concurrent, so
+// the hook must never be read or mutated without the lock, and suppression uses
+// a counter rather than nil-swapping the global (a nil-swap could race two
+// callers and leave the hook permanently nil for the process).
+var (
+	shiftHookMu    sync.Mutex
+	shiftSuppressN int
+)
+
+// suppressPublishedPortShift silences the guard's own shift-fire for the caller's
+// quadlet write (which fires it once itself with the final port) and returns the
+// restore func. Overlapping windows are counted, so one caller exiting doesn't
+// unsuppress another still mid-write.
+func suppressPublishedPortShift() func() {
+	shiftHookMu.Lock()
+	shiftSuppressN++
+	shiftHookMu.Unlock()
+	return func() {
+		shiftHookMu.Lock()
+		shiftSuppressN--
+		shiftHookMu.Unlock()
+	}
+}
+
+// firePublishedPortShift invokes the hook from the guard unless a caller has
+// suppressed it, reading both under the lock so a concurrent SetPublishedPort
+// can't race the func value.
+func firePublishedPortShift(service string, newPort int) {
+	shiftHookMu.Lock()
+	hook := OnPublishedPortShift
+	suppressed := shiftSuppressN > 0
+	shiftHookMu.Unlock()
+	if hook != nil && !suppressed {
+		hook(service, newPort)
+	}
+}
+
+// firePublishedPortShiftForced invokes the hook ignoring suppression, for the
+// deliberate end-of-change fire in SetPublishedPort.
+func firePublishedPortShiftForced(service string, newPort int) {
+	shiftHookMu.Lock()
+	hook := OnPublishedPortShift
+	shiftHookMu.Unlock()
+	if hook != nil {
+		hook(service, newPort)
+	}
+}
 
 // unitActive reports whether a service's own systemd unit is currently up. The
 // generic port guard uses it to avoid treating the service's *own* published
@@ -130,7 +180,7 @@ func portClaimedByOtherInstalled(self string, p int) bool {
 			continue // already counted from cfg.Services above
 		}
 		for _, m := range c.Ports {
-			if extraHostPort(m) == p {
+			if config.MappingHostPort(m) == p {
 				return true
 			}
 		}
@@ -621,9 +671,7 @@ func EnsureCustomServiceQuadlet(svc *config.CustomService) error {
 			fmt.Fprintf(os.Stderr, "      (override with: lerd service port %s <port>)\n", svc.Name)
 			// Host-proxy sites reach this service over the published loopback port,
 			// so their .env must follow the shift. The CLI registers the refresh hook.
-			if OnPublishedPortShift != nil {
-				OnPublishedPortShift(svc.Name, free)
-			}
+			firePublishedPortShift(svc.Name, free)
 		}
 	}
 	// Apply the recorded published port (guard-shifted or set via `lerd service

--- a/internal/sitedoctor/sitedoctor.go
+++ b/internal/sitedoctor/sitedoctor.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/geodro/lerd/internal/config"
@@ -89,6 +90,18 @@ func (d *Response) add(c Check) {
 // the universal baseline and the framework's declarative checks. fw may be nil
 // (an unknown framework) — only the file/dependency baseline runs then. The
 // cheap checks read files; command and audit checks touch the container.
+// RunForPath resolves the framework definition for a project path and runs the
+// doctor, so the CLI, MCP, and Web UI share one path -> framework -> Run chain
+// instead of re-deriving it three ways. fwName is the site's recorded framework
+// when known; pass "" to detect it from the path.
+func RunForPath(ctx context.Context, path, fwName string) Response {
+	if fwName == "" {
+		fwName, _ = config.DetectFrameworkForDir(path)
+	}
+	fw, _ := config.GetFrameworkForDir(fwName, path)
+	return Run(ctx, path, fw)
+}
+
 func Run(ctx context.Context, path string, fw *config.Framework) Response {
 	resp := Response{Checks: []Check{}}
 	envFile, envFormat, exampleFile := envSetup(fw, path)
@@ -115,19 +128,23 @@ func Run(ctx context.Context, path string, fw *config.Framework) Response {
 		}
 	}
 
+	// The framework command checks and the composer/node dependency + audit checks
+	// each block on an independent container-exec timeout. Run them concurrently
+	// (results collected in order) so a down app caps the panel at roughly one
+	// timeout instead of the sum of them all.
+	var tasks []func() (Check, bool)
 	for _, spec := range frameworkChecks(fw) {
+		spec := spec
 		// A known-broken database turns a migration check into "couldn't run" noise
 		// that just repeats the database finding's remedy, so skip a command check
 		// whose fix is the same migrate command; unrelated command checks still run.
 		if dbBroken && spec.Type == "command" && spec.Fix == sqliteFixCommand {
 			continue
 		}
-		if c, ok := runDeclaredCheck(ctx, path, envPath, spec); ok {
-			resp.add(c)
-		}
+		tasks = append(tasks, func() (Check, bool) { return runDeclaredCheck(ctx, path, envPath, spec) })
 	}
-
-	for _, c := range dependencyChecks(ctx, path, fw) {
+	tasks = append(tasks, dependencyCheckTasks(ctx, path, fw)...)
+	for _, c := range runChecksConcurrently(tasks) {
 		resp.add(c)
 	}
 	if c, ok := checkPHPVersion(path, fw); ok {
@@ -649,20 +666,58 @@ func checkCommand(ctx context.Context, path string, spec config.DoctorCheck) Che
 	return Check{Name: spec.Name, Status: StatusOK}
 }
 
-// dependencyChecks runs the universal package-manager checks: composer and node
-// dependency install + lock state, plus their security audits. Each is skipped
-// when its manifest is absent.
-func dependencyChecks(ctx context.Context, path string, fw *config.Framework) []Check {
-	var checks []Check
+// maxDoctorConcurrency bounds how many checks (mostly container execs) run at
+// once, so the panel's latency is capped near a single timeout without spawning
+// an unbounded number of concurrent podman execs.
+const maxDoctorConcurrency = 6
+
+// runChecksConcurrently runs each task in its own goroutine, bounded by
+// maxDoctorConcurrency, and returns the checks that fired in the original task
+// order, so independent container-exec checks no longer add up their timeouts.
+func runChecksConcurrently(tasks []func() (Check, bool)) []Check {
+	results := make([]struct {
+		c  Check
+		ok bool
+	}, len(tasks))
+	sem := make(chan struct{}, maxDoctorConcurrency)
+	var wg sync.WaitGroup
+	for i, t := range tasks {
+		wg.Add(1)
+		go func(i int, t func() (Check, bool)) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			results[i].c, results[i].ok = t()
+		}(i, t)
+	}
+	wg.Wait()
+	var out []Check
+	for _, r := range results {
+		if r.ok {
+			out = append(out, r.c)
+		}
+	}
+	return out
+}
+
+// dependencyCheckTasks builds the universal package-manager checks (composer and
+// node dependency install + lock state, plus their security audits) as deferred
+// tasks. Each is skipped when its manifest is absent, and the composer audit is
+// skipped when vendor/ is missing (checkComposerDeps already flags that, and the
+// audit can only degrade to "unknown" without installed packages).
+func dependencyCheckTasks(ctx context.Context, path string, fw *config.Framework) []func() (Check, bool) {
+	var tasks []func() (Check, bool)
 	if fileExists(filepath.Join(path, "composer.json")) && !composerDisabled(fw) {
-		checks = append(checks, checkComposerDeps(ctx, path))
-		checks = append(checks, checkComposerAudit(ctx, path))
+		tasks = append(tasks, func() (Check, bool) { return checkComposerDeps(ctx, path), true })
+		if dirExists(filepath.Join(path, "vendor")) {
+			tasks = append(tasks, func() (Check, bool) { return checkComposerAudit(ctx, path), true })
+		}
 	}
 	if fileExists(filepath.Join(path, "package.json")) {
-		checks = append(checks, checkNodeDeps(path))
-		checks = append(checks, checkNodeAudit(ctx, path))
+		tasks = append(tasks, func() (Check, bool) { return checkNodeDeps(path), true })
+		tasks = append(tasks, func() (Check, bool) { return checkNodeAudit(ctx, path), true })
 	}
-	return checks
+	return tasks
 }
 
 // composerDisabled reports whether the framework explicitly opts out of composer

--- a/internal/sitedoctor/sitedoctor_test.go
+++ b/internal/sitedoctor/sitedoctor_test.go
@@ -642,3 +642,25 @@ func TestCheckSQLiteDatabase(t *testing.T) {
 		}
 	})
 }
+
+// dependencyCheckTasks skips the composer audit when vendor/ is absent (the deps
+// check already flags that, and the audit could only burn a container-exec
+// timeout to reach "unknown").
+func TestDependencyCheckTasks_SkipsComposerAuditWithoutVendor(t *testing.T) {
+	t.Run("composer.json without vendor: deps only, no audit", func(t *testing.T) {
+		dir := t.TempDir()
+		writeEnv(t, dir, "composer.json", "{}")
+		if got := len(dependencyCheckTasks(context.Background(), dir, nil)); got != 1 {
+			t.Errorf("want 1 task (deps only), got %d", got)
+		}
+	})
+
+	t.Run("composer.json with vendor: deps and audit", func(t *testing.T) {
+		dir := t.TempDir()
+		writeEnv(t, dir, "composer.json", "{}")
+		mustMkdir(t, filepath.Join(dir, "vendor"))
+		if got := len(dependencyCheckTasks(context.Background(), dir, nil)); got != 2 {
+			t.Errorf("want 2 tasks (deps + audit), got %d", got)
+		}
+	})
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -197,7 +197,6 @@ func (c *Client) fetch(path string) ([]byte, error) {
 	for _, base := range append([]string{c.BaseURL}, c.Fallbacks...) {
 		body, err := fetchOne(client, base+"/"+path)
 		if err == nil {
-			origin.NoteFetched(base)
 			return body, nil
 		}
 		errs = append(errs, err.Error())

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -40,6 +40,19 @@ func tryAcquireRun(domain, name string) (release func(), busyWith string, ok boo
 	}, "", true
 }
 
+// siteRunLockKey derives the per-site run-lock key: prefer the name, fall back to
+// the first domain, then the project path, so every site has a unique key shared
+// by the command runner and the doctor-fix runner (they must exclude each other).
+func siteRunLockKey(site *config.Site) string {
+	if site.Name != "" {
+		return site.Name
+	}
+	if len(site.Domains) > 0 {
+		return site.Domains[0]
+	}
+	return site.Path
+}
+
 // commandRoute dispatches the two commands subroutes:
 //
 //	GET  /api/sites/{domain}/commands              → list
@@ -159,16 +172,8 @@ func handleCommandRun(w http.ResponseWriter, r *http.Request, site *config.Site,
 
 	// Per-site mutex: refuse if another command is already running on this
 	// site. Prevents two tabs (or palette + dropdown) from concurrently
-	// hammering migrate:fresh, etc. Prefer site.Name, fall back to the
-	// first domain, then the project path so we always have a unique key.
-	lockKey := site.Name
-	if lockKey == "" && len(site.Domains) > 0 {
-		lockKey = site.Domains[0]
-	}
-	if lockKey == "" {
-		lockKey = site.Path
-	}
-	release, busyWith, ok := tryAcquireRun(lockKey, target.Name)
+	// hammering migrate:fresh, etc.
+	release, busyWith, ok := tryAcquireRun(siteRunLockKey(site), target.Name)
 	if !ok {
 		w.WriteHeader(http.StatusConflict)
 		writeJSON(w, map[string]any{"error": "another command is already running on this site: " + busyWith})

--- a/internal/ui/site_doctor.go
+++ b/internal/ui/site_doctor.go
@@ -48,8 +48,7 @@ func handleDoctorRun(w http.ResponseWriter, r *http.Request, site *config.Site) 
 	// it first — otherwise every file check reads a missing .env and reports a
 	// healthy worktree as broken. No-op for the parent and idempotent.
 	ensureWorktreeEnvIfBranch(site, branch)
-	fw, _ := config.GetFrameworkForDir(site.Framework, path)
-	writeJSON(w, sitedoctor.Run(r.Context(), path, fw))
+	writeJSON(w, sitedoctor.RunForPath(r.Context(), path, site.Framework))
 }
 
 // handleDoctorFixRun runs an allowlisted package-manager fix (composer
@@ -66,14 +65,7 @@ func handleDoctorFixRun(w http.ResponseWriter, r *http.Request, site *config.Sit
 	if !ok {
 		return
 	}
-	lockKey := site.Name
-	if lockKey == "" && len(site.Domains) > 0 {
-		lockKey = site.Domains[0]
-	}
-	if lockKey == "" {
-		lockKey = site.Path
-	}
-	release, busyWith, ok := tryAcquireRun(lockKey, key)
+	release, busyWith, ok := tryAcquireRun(siteRunLockKey(site), key)
 	if !ok {
 		w.WriteHeader(http.StatusConflict)
 		writeJSON(w, map[string]any{"error": "another command is already running on this site: " + busyWith})

--- a/internal/ui/web/src/components/CommandRunModal.branch.test.ts
+++ b/internal/ui/web/src/components/CommandRunModal.branch.test.ts
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Spy on executeCommand while keeping the rest of the store real, so clicking
+// Run Anyway exercises the real component wiring end to end. vi.hoisted lets the
+// hoisted vi.mock factory reference the spy without a temporal-dead-zone error.
+const { executeCommand } = vi.hoisted(() => ({ executeCommand: vi.fn() }));
+vi.mock('$stores/commands', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$stores/commands')>();
+  return { ...actual, executeCommand };
+});
+
+import { currentRun, closeRun } from '$stores/commands';
+import Harness from './CommandRunModal.test.svelte';
+
+afterEach(() => {
+  closeRun();
+  executeCommand.mockClear();
+});
+
+describe('CommandRunModal Run Anyway', () => {
+  // Regression for the wrong-database bug: clicking Run Anyway on a worktree
+  // must forward that worktree's branch, not an empty branch that resolves to
+  // the parent checkout.
+  it('forwards the worktree branch to executeCommand', async () => {
+    render(Harness);
+    currentRun.set({
+      kind: 'confirm',
+      domain: 'acme.test',
+      cmd: { name: 'migrate:fresh', label: 'Fresh migrate', command: 'php artisan migrate:fresh --force', confirm: true },
+      branch: 'feat-x'
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    screen.getByText(/Run anyway/i).click();
+    expect(executeCommand).toHaveBeenCalledWith(
+      'acme.test',
+      expect.objectContaining({ name: 'migrate:fresh' }),
+      'feat-x',
+      true
+    );
+  });
+
+  it('passes an empty branch for a parent-site run', async () => {
+    render(Harness);
+    currentRun.set({
+      kind: 'confirm',
+      domain: 'acme.test',
+      cmd: { name: 'x', label: 'X', command: 'true', confirm: true },
+      branch: ''
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    screen.getByText(/Run anyway/i).click();
+    expect(executeCommand).toHaveBeenCalledWith('acme.test', expect.anything(), '', true);
+  });
+});

--- a/internal/ui/web/src/components/CommandRunModal.svelte
+++ b/internal/ui/web/src/components/CommandRunModal.svelte
@@ -109,7 +109,7 @@
       <div class="mt-5 flex items-center justify-end gap-2">
         <button onclick={closeRun} class="px-3 py-1.5 rounded-md text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5">{m.common_cancel()}</button>
         <button
-          onclick={() => $currentRun.kind === 'confirm' && executeCommand($currentRun.domain, cmd, '', true)}
+          onclick={() => $currentRun.kind === 'confirm' && executeCommand($currentRun.domain, cmd, $currentRun.branch, true)}
           class="px-3 py-1.5 rounded-md text-xs font-medium bg-lerd-red hover:bg-lerd-redhov text-white"
         >{m.cmdrun_runAnyway()}</button>
       </div>

--- a/internal/ui/web/src/components/CommandRunModal.test.ts
+++ b/internal/ui/web/src/components/CommandRunModal.test.ts
@@ -24,7 +24,8 @@ describe('CommandRunModal', () => {
     currentRun.set({
       kind: 'confirm',
       domain: 'acme.test',
-      cmd: { name: 'migrate:fresh', label: 'Fresh migrate', command: 'php artisan migrate:fresh --force', confirm: true }
+      cmd: { name: 'migrate:fresh', label: 'Fresh migrate', command: 'php artisan migrate:fresh --force', confirm: true },
+      branch: ''
     });
     await new Promise((r) => setTimeout(r, 0));
     expect(screen.getByText(/Run Fresh migrate/)).toBeInTheDocument();
@@ -104,7 +105,8 @@ describe('CommandRunModal', () => {
     currentRun.set({
       kind: 'confirm',
       domain: 'acme.test',
-      cmd: { name: 'x', label: 'X', command: 'true', confirm: true }
+      cmd: { name: 'x', label: 'X', command: 'true', confirm: true },
+      branch: ''
     });
     await new Promise((r) => setTimeout(r, 0));
     // Two buttons match "Cancel" (backdrop has aria-label and the footer Cancel

--- a/internal/ui/web/src/components/NotificationsToggle.test.ts
+++ b/internal/ui/web/src/components/NotificationsToggle.test.ts
@@ -10,7 +10,8 @@ const allKinds: Record<NotifyKind, boolean> = {
   op_done: true,
   update_available: true,
   nplusone: true,
-  dump: false
+  dump: false,
+  slow_route: false
 };
 
 describe('NotificationsToggle', () => {

--- a/internal/ui/web/src/stores/commands.test.ts
+++ b/internal/ui/web/src/stores/commands.test.ts
@@ -129,6 +129,16 @@ describe('launchCommand', () => {
     expect(s.cmd.name).toBe('echo');
   });
 
+  // Regression: the confirm state must carry the branch so Run Anyway targets the
+  // worktree the command was launched for, not the parent checkout.
+  it('carries the worktree branch into the confirm state', () => {
+    launchCommand('acme.test', cmd({ confirm: true }), { branch: 'feat-x' });
+    const s = get(currentRun);
+    expect(s.kind).toBe('confirm');
+    if (s.kind !== 'confirm') return;
+    expect(s.branch).toBe('feat-x');
+  });
+
   it('skips confirm when skipConfirm: true', async () => {
     mockSSE(['event: done\ndata: {"exit":0,"durationMs":1}\n\n']);
     launchCommand('acme.test', cmd({ confirm: true }), { skipConfirm: true });

--- a/internal/ui/web/src/stores/commands.ts
+++ b/internal/ui/web/src/stores/commands.ts
@@ -165,7 +165,7 @@ export type RunLine = { stream: 'stdout' | 'stderr' | 'meta'; text: string };
 
 export type CurrentRun =
   | { kind: 'idle' }
-  | { kind: 'confirm'; domain: string; cmd: Command }
+  | { kind: 'confirm'; domain: string; cmd: Command; branch: string }
   | { kind: 'running'; domain: string; cmd: Command; lines: RunLine[]; started: number }
   | {
       kind: 'done';
@@ -202,7 +202,9 @@ export function launchCommand(domain: string, cmd: Command, opts: { skipConfirm?
     return;
   }
   if (cmd.confirm && !opts.skipConfirm) {
-    currentRun.set({ kind: 'confirm', domain, cmd });
+    // Carry the branch into the confirm state so Run Anyway targets the same
+    // worktree the command was launched for, not the parent checkout.
+    currentRun.set({ kind: 'confirm', domain, cmd, branch: opts.branch ?? '' });
     return;
   }
   void executeCommand(domain, cmd, opts.branch);

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -111,7 +111,6 @@ func FetchChangelog(currentVersion, latestVersion string) (string, error) {
 			errs = append(errs, err.Error())
 			continue
 		}
-		origin.NoteFetched(url)
 		return extractChangelogSections(body, currentVersion, latestVersion), nil
 	}
 	return "", fmt.Errorf("fetching changelog: %s", strings.Join(errs, "; "))

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -24,7 +24,6 @@ func FetchLatestVersion() (string, error) {
 	for _, base := range ReleaseBaseURLs() {
 		v, err := fetchLatestFrom(base)
 		if err == nil {
-			origin.NoteFetched(base)
 			return v, nil
 		}
 		errs = append(errs, err.Error())
@@ -84,7 +83,6 @@ func FetchLatestPrerelease() (string, error) {
 	for _, base := range APIBaseURLs() {
 		v, err := fetchPrereleaseFrom(base)
 		if err == nil {
-			origin.NoteFetched(base)
 			return v, nil
 		}
 		errs = append(errs, err.Error())

--- a/internal/watcher/dns.go
+++ b/internal/watcher/dns.go
@@ -141,12 +141,44 @@ func defaultNginxHealthy() bool {
 	if cfg, err := config.LoadGlobal(); err == nil && cfg != nil && cfg.Nginx.HTTPSPort > 0 {
 		port = cfg.Nginx.HTTPSPort
 	}
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), nginxHealthyDialTimeout)
+	if !loopbackServing(fmt.Sprintf("127.0.0.1:%d", port)) {
+		return false
+	}
+	// A resume can drop only the IPv6 (::1) forward while the IPv4 one survives,
+	// leaving sites a browser resolves to ::1 unreachable while this probe would
+	// otherwise call nginx healthy. Require the ::1 forward too, but only when the
+	// host actually has an IPv6 loopback, so an IPv4-only host isn't bounced on a
+	// ::1 that never existed.
+	if hasIPv6Loopback() && !loopbackServing(fmt.Sprintf("[::1]:%d", port)) {
+		return false
+	}
+	return true
+}
+
+// loopbackServing reports whether a loopback dial to addr connects within the
+// health-probe timeout.
+func loopbackServing(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, nginxHealthyDialTimeout)
 	if err != nil {
 		return false
 	}
 	_ = conn.Close()
 	return true
+}
+
+// hasIPv6Loopback reports whether the host has the ::1 loopback address, so the
+// health probe only requires an IPv6 forward on hosts that actually run IPv6.
+func hasIPv6Loopback() bool {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return false
+	}
+	for _, a := range addrs {
+		if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.Equal(net.IPv6loopback) {
+			return true
+		}
+	}
+	return false
 }
 
 // defaultRepairNginx restarts nginx so it rebinds its host ports on the live

--- a/internal/watcher/idle_feed.go
+++ b/internal/watcher/idle_feed.go
@@ -61,11 +61,8 @@ func StartIdle(notify func(), sourceWatcher func(stop <-chan struct{}) error) {
 	// The access feed is bound once, for the daemon's life, and fans out to both
 	// request stats (always) and idle activity (only while enabled). Idle used to
 	// bind it inside its session, but timing stats must run even with idle off, so
-	// there is a single always-on reader here. Best-effort: a bind failure loses
-	// the feed, and both consumers degrade to their other signals.
-	if conn, ok := accessFeedConn(); ok {
-		go readDatagrams(conn, handleAccessDatagram)
-	}
+	// there is a single always-on reader here.
+	startAccessFeed()
 	go runReqStatsSaver()
 
 	// Boot memory is the persisted config flag, not the ephemeral socket. When
@@ -151,12 +148,37 @@ func runReqStatsSaver() {
 			continue
 		}
 		snap := reqAggregator.Snapshot()
-		_ = reqAggregator.Save(config.RequestStatsFile())
+		_ = reqstats.SaveSnapshot(snap, config.RequestStatsFile())
 		domainOf := siteDomainResolver()
 		for _, n := range slowNotifier.notifications(snap, domainOf) {
 			_ = push.Send(n)
 		}
 	}
+}
+
+// accessFeedRetryInterval is how often startAccessFeed retries a failed bind so
+// a transient boot-time failure recovers without a full daemon restart.
+const accessFeedRetryInterval = 30 * time.Second
+
+// startAccessFeed binds the always-on access-feed reader. A bind that fails at
+// boot (a transient FS/permission hiccup on the socket path) is retried in the
+// background so the feed and its consumers recover on their own; until it binds
+// both consumers degrade to their other signals.
+func startAccessFeed() {
+	if conn, ok := accessFeedConn(); ok {
+		go readDatagrams(conn, handleAccessDatagram)
+		return
+	}
+	go func() {
+		t := time.NewTicker(accessFeedRetryInterval)
+		defer t.Stop()
+		for range t.C {
+			if conn, ok := accessFeedConn(); ok {
+				go readDatagrams(conn, handleAccessDatagram)
+				return
+			}
+		}
+	}()
 }
 
 // accessFeedConn binds the nginx access feed listener per platform: a unix


### PR DESCRIPTION
The global config clone shared each service's published ports map with the cached value, so a Web UI secondary port remap could mutate the cache and race the dashboard status poll into a concurrent map read and write. lerd link and lerd setup passed a nil command into the secure path, which then dereferenced a flag and panicked. The FPM port editor shifted an exact duplicate host mapping onto a new port instead of collapsing it. A service moved off its preset default left the freed default reserved so nothing could reuse it. The auto cleanup reclaim report counted the planned targets rather than the images actually removed. The nginx resume health probe only dialed 127.0.0.1, so a dead IPv6 forward went unnoticed. The service ports guard nil swapped a package global hook without locking, which could drop a host proxy env refresh or leave the hook nil for the process.

On Apple Silicon lerd rewrites postgis/postgis to the multi arch imresamu/postgis at pull and quadlet time, but the image exists check and the update sweep still used the upstream name, so the cached image was never found and re pulled on every start while superseded images were never reclaimed. Both now apply the same rewrite.

The Web UI confirm modal did not carry the worktree branch, so Run Anyway ran a confirm command against the parent checkout instead of the worktree it was launched for, which could hit the wrong database. The branch now travels with the confirm state.

With the geodro to lerd-env move complete and the base images published under the new org, the origin package collapses from the old first with fallback machinery to the single lerd-env source, keeping its environment overrides. Alongside these, duplicated host port parsing, certificate domain assembly, the per site run lock key, and the doctor's site to framework resolution move behind shared helpers, and the doctor's independent container checks now run concurrently so a down or offline site is capped near a single timeout.

Closes #771
