### PR TITLE
fix: Symfony store links, cached store index, and framework command cleanup

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -27,6 +27,7 @@ import (
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteops"
+	"github.com/geodro/lerd/internal/store"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/geodro/lerd/internal/ui"
 	"github.com/geodro/lerd/internal/version"
@@ -523,6 +524,10 @@ func newWatchCmd() *cobra.Command {
 			// so rebuild leftovers and stale base images don't pile up. Gated by
 			// the auto_cleanup config; never touches service images (--deep).
 			go watcher.WatchCleanup(time.Hour)
+
+			// Keep the cached framework store index fresh so offline detection and
+			// listing resolve the full catalogue without a network round trip.
+			go store.WatchIndex(6 * time.Hour)
 
 			// Idle-suspend: suspends/resumes workers by activity. The whole session,
 			// including the source-file watcher passed here, only runs while the

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -124,7 +124,7 @@ The MCP surface is **eleven grouped tools**, each driven by an `action` argument
 | `runtime` | `versions`, `node_install`, `node_uninstall`, `php_list`, `ext_list`, `ext_add`, `ext_remove`, `ports_list`, `ports_add`, `ports_remove` |
 | `worker` | `list` (call first), `start`, `stop`, `add`, `remove`, `health`, `heal`, `mode_get`, `mode_set`, `queue_start`, `queue_stop`, `horizon_start`, `horizon_stop`, `reverb_start`, `reverb_stop`, `schedule_start`, `schedule_stop`, `stripe_start`, `stripe_stop`, `stripe_config` |
 | `exec` | `artisan`, `console`, `composer`, `vendor_bins`, `vendor_run`, `commands_list`, `commands_run`, `command_add`, `command_remove` |
-| `framework` | `list`, `add`, `remove`, `prune`, `search`, `install`, `project_new`, `setup` |
+| `framework` | `list`, `add`, `remove`, `prune`, `search`, `update`, `project_new`, `setup` |
 | `diag` | `status`, `doctor`, `site_doctor`, `which`, `check`, `dns_diagnose`, `bug_report`, `analyze_queries`, `route_timing`, `optimize_route`, `dumps_recent`, `dumps_status`, `dumps_clear`, `dumps_toggle`, `profiler_toggle`, `profiler_status`, `profiler_clear`, `profiler_report`, `xdebug_on`, `xdebug_off`, `xdebug_status` |
 | `logs` | `sources`, `fetch` |
 | `worktree` | `list`, `add`, `remove`, `db_isolate`, `db_share` |

--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -14,8 +14,7 @@ Laravel has a built-in definition. Other frameworks (Symfony, WordPress, Drupal,
 | `lerd framework list` | List all framework definitions with source and workers |
 | `lerd framework list --check` | Compare local definitions against the store |
 | `lerd framework search [query]` | Search the community store for available definitions |
-| `lerd framework install <name>[@version]` | Install a framework definition from the store |
-| `lerd framework update [name[@version]]` | Update installed definitions from the store |
+| `lerd framework update [name[@version]]` | Refresh definitions from the store (definitions otherwise auto-fetch on link) |
 | `lerd framework update --diff` | Preview changes before applying updates |
 | `lerd framework add <name>` | Add or update a user-defined framework definition |
 | `lerd framework remove <name>[@version]` | Remove a framework definition (prompts if multiple versions) |
@@ -47,17 +46,22 @@ lerd framework search
 ╰───────────┴───────────┴────────┴────────────────╯
 ```
 
-### Installing from the store
+### Getting definitions from the store
+
+Definitions arrive automatically. Linking a project detects its framework and version and fetches the matching definition from the store, and the cached catalogue refreshes on its own in the background, so there is no install step to run.
+
+To refresh manually, `lerd framework update`. With no arguments it refreshes the cached catalogue and re-fetches every installed definition; with a name it fetches that one, installing it if it isn't cached yet:
 
 ```bash
-lerd framework install symfony          # auto-detects version from composer.lock
-lerd framework install laravel@12       # explicit version
-lerd framework install wordpress        # latest version
+lerd framework update                   # refresh catalogue + all installed definitions
+lerd framework update symfony           # fetch/update symfony (auto-detects version from composer.lock)
+lerd framework update laravel@12        # explicit version
+lerd framework update --diff            # preview changes before applying
 ```
 
 When no version is specified, lerd reads `composer.lock` to detect the installed major version. If the version can't be determined, it falls back to the latest available.
 
-Store-installed definitions are saved to `~/.local/share/lerd/frameworks/<name>@<version>.yaml`, separate from user-defined frameworks.
+Store definitions are saved to `~/.local/share/lerd/frameworks/<name>@<version>.yaml`, separate from user-defined frameworks.
 
 ### Checking for updates
 

--- a/internal/cli/aidocs/lerd-reference.md
+++ b/internal/cli/aidocs/lerd-reference.md
@@ -88,10 +88,10 @@ Actions: `artisan` (Laravel), `console` (other frameworks), `composer`, `vendor_
 - **composer over git SSH (CLI-only)**: when `composer` needs a private repo reachable only over SSH, `lerd auth ssh` starts a shared ssh-agent container and loads the host's `~/.ssh/id_*` (or named keys) so passphrase-protected keys work in the FPM container; `lerd auth ssh --list` shows loaded keys, `--remove` flushes them. Keys live only in agent memory and clear on machine restart
 
 #### `framework` — framework definitions & scaffolding
-Actions: `list`, `add`, `remove`, `prune`, `search`, `install`, `project_new`, `setup`.
+Actions: `list`, `add`, `remove`, `prune`, `search`, `update`, `project_new`, `setup`.
 - `add` with `name: "laravel"` merges custom workers/setup into the built-in framework
 - `remove` refuses to drop a definition a linked site still uses (pass `force: true` to override); `prune` removes every framework definition no site uses
-- `search`/`install` use the community store (install auto-detects version from `composer.lock`)
+- `search`/`update` use the community store; definitions auto-fetch on link, so `update` is the manual refresh (no `name` refreshes the catalogue and all installed definitions; with `name` it fetches that one, auto-detecting version from `composer.lock`)
 - `project_new` scaffolds a new project (requires absolute `path`, default framework laravel); follow with `site` `link` + `env` `setup`
 - `setup` runs the framework's post-install steps (migrations, storage:link…) — MANDATORY after `env setup` on new/cloned projects; idempotent
 

--- a/internal/cli/framework.go
+++ b/internal/cli/framework.go
@@ -25,7 +25,6 @@ func NewFrameworkCmd() *cobra.Command {
 	cmd.AddCommand(newFrameworkAddCmd())
 	cmd.AddCommand(newFrameworkRemoveCmd())
 	cmd.AddCommand(newFrameworkSearchCmd())
-	cmd.AddCommand(newFrameworkInstallCmd())
 	cmd.AddCommand(newFrameworkUpdateCmd())
 	cmd.AddCommand(newFrameworkPruneCmd())
 	return cmd
@@ -517,82 +516,21 @@ Examples:
 	}
 }
 
-func newFrameworkInstallCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "install <name>[@version]",
-		Short: "Install a framework definition from the store",
-		Long: `Download and install a framework definition from the community store.
-
-If no version is specified, the version is auto-detected from composer.lock
-in the current directory, falling back to the latest available version.
-
-Examples:
-  lerd framework install symfony
-  lerd framework install laravel@11
-  lerd framework install wordpress@6`,
-		Args: cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			name, version := parseNameVersion(args[0])
-
-			client := store.NewClient()
-
-			// Auto-detect version from cwd if not specified
-			if version == "" {
-				cwd, _ := os.Getwd()
-				if cwd != "" {
-					if idx, err := client.FetchIndex(); err == nil {
-						for _, entry := range idx.Frameworks {
-							if entry.Name == name {
-								version = store.ResolveVersion(cwd, entry.Detect, entry.Versions, "")
-								break
-							}
-						}
-					}
-				}
-			}
-
-			fw, err := client.FetchFramework(name, version)
-			if err != nil {
-				return err
-			}
-
-			// Check if already exists locally
-			if _, ok := config.GetFramework(name); ok {
-				fmt.Printf("Framework %q already exists locally. Overwriting with store definition.\n", name)
-			}
-
-			if err := config.SaveStoreFramework(fw); err != nil {
-				return fmt.Errorf("saving framework: %w", err)
-			}
-			// Remove old user-defined file so the store version takes effect.
-			config.RemoveUserFramework(name)
-
-			versionStr := fw.Version
-			if versionStr == "" {
-				versionStr = "latest"
-			}
-			filename := fw.Name + ".yaml"
-			if fw.Version != "" {
-				filename = fw.Name + "@" + fw.Version + ".yaml"
-			}
-			feedback.Done(fmt.Sprintf("installed %s@%s (%s)", fw.Name, versionStr, fw.Label))
-			feedback.Note("saved to " + config.StoreFrameworksDir() + "/" + filename)
-			return nil
-		},
-	}
-}
-
 func newFrameworkUpdateCmd() *cobra.Command {
 	var diff bool
 	cmd := &cobra.Command{
 		Use:   "update [name[@version]]",
-		Short: "Update installed framework definitions from the store",
+		Short: "Update framework definitions from the store",
 		Long: `Re-fetch framework definitions from the store.
 
-If a name is given, only that framework is updated.
-If no name is given, every cached version of every installed framework is
-re-fetched (e.g. laravel@10, @11, @12, @13 are all refreshed individually,
-not just the latest).
+Definitions normally auto-fetch when you link a project and refresh on their own
+in the background; this is the manual trigger.
+
+If a name is given, only that framework is fetched (installing it if it isn't
+cached yet).
+If no name is given, the cached store catalogue is refreshed and every cached
+version of every installed framework is re-fetched (e.g. laravel@10, @11, @12,
+@13 are all refreshed individually, not just the latest).
 Use --diff to preview changes before applying.
 
 Examples:
@@ -647,7 +585,9 @@ func updateSingleFramework(client *store.Client, name, version string, showDiff 
 }
 
 func updateAllFrameworks(client *store.Client, showDiff bool) error {
-	idx, err := client.FetchIndex()
+	// Refresh the cached catalogue first, so the manual update also pulls newly
+	// published frameworks and versions even on a machine with nothing installed.
+	idx, err := client.RefreshIndex()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/framework_command_test.go
+++ b/internal/cli/framework_command_test.go
@@ -1,0 +1,19 @@
+package cli
+
+import "testing"
+
+// install was removed: definitions auto-fetch on link and refresh in the
+// background, so a manual install has no job. update is the sole manual
+// store-refresh command.
+func TestFrameworkCmd_InstallRemovedUpdateKept(t *testing.T) {
+	names := map[string]bool{}
+	for _, c := range NewFrameworkCmd().Commands() {
+		names[c.Name()] = true
+	}
+	if names["install"] {
+		t.Error("framework install should be removed")
+	}
+	if !names["update"] {
+		t.Error("framework update should remain as the manual refresh command")
+	}
+}

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -580,6 +580,11 @@ func linkApplyServices(cwd string, proj *config.ProjectConfig) error {
 		return nil
 	}
 	for _, svc := range proj.Services {
+		// SQLite is a per-project file, not a container: env setup writes its vars
+		// and creates the db file. There is nothing to install or start here.
+		if svc.Name == "sqlite" {
+			continue
+		}
 		// A bare entry whose name is a bundled tool preset (e.g. phpmyadmin from a
 		// detected docker-compose, or an older .lerd.yaml written before this was
 		// normalised) has no Preset/Custom set; resolve it to its preset so it

--- a/internal/cli/link_service_test.go
+++ b/internal/cli/link_service_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
+)
+
+// SQLite is a per-project file, not a container. linkApplyServices must skip it
+// rather than route it through ensureServiceRunning, which looks for a preset or
+// custom service YAML and warns "custom service sqlite not found" when neither
+// exists (there is no sqlite preset by design).
+func TestLinkApplyServices_SkipsSQLite(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	var buf bytes.Buffer
+	defer feedback.SetTestWriter(&buf)()
+
+	proj := &config.ProjectConfig{Services: []config.ProjectService{{Name: "sqlite"}}}
+	if err := linkApplyServices(t.TempDir(), proj); err != nil {
+		t.Fatalf("linkApplyServices: %v", err)
+	}
+	if strings.Contains(buf.String(), "sqlite") {
+		t.Errorf("sqlite should be skipped silently, got output: %q", buf.String())
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -431,7 +431,7 @@ func (e FrameworkEnvConf) Resolve(projectDir string) (file, format string) {
 	return primary, primaryFmt
 }
 
-// laravelFramework is the only built-in framework definition.
+// laravelFramework is the built-in Laravel adapter, the default shipped stack.
 var laravelFramework = &Framework{
 	Name:      "laravel",
 	Label:     "Laravel",
@@ -1386,7 +1386,7 @@ type FrameworkInfo struct {
 func ListFrameworksDetailed() []FrameworkInfo {
 	var result []FrameworkInfo
 	seenNameVersion := map[string]bool{}
-	hasStoreLaravel := false
+	storeNames := map[string]bool{}
 
 	key := func(name, version string) string { return name + "@" + version }
 
@@ -1405,20 +1405,15 @@ func ListFrameworksDetailed() []FrameworkInfo {
 		seenNameVersion[k] = true
 		merged := mergeUserOverlay(fw)
 		result = append(result, FrameworkInfo{Framework: merged, Source: SourceStore})
-		if fw.Name == "laravel" {
-			hasStoreLaravel = true
-		}
+		storeNames[fw.Name] = true
 	}
 
-	// Built-in Laravel (only if no store-installed version exists).
-	if !hasStoreLaravel {
-		if fw, ok := GetFramework("laravel"); ok {
-			result = append(result, FrameworkInfo{Framework: fw, Source: SourceBuiltIn})
+	// Built-in adapters, only when no store-installed version supersedes them.
+	for _, b := range builtinFrameworks() {
+		if storeNames[b.Name] {
+			continue
 		}
-	}
-	// Built-in Symfony.
-	if !seenNameVersion[key("symfony", "")] {
-		if fw, ok := GetFramework("symfony"); ok {
+		if fw, ok := GetFramework(b.Name); ok {
 			result = append(result, FrameworkInfo{Framework: fw, Source: SourceBuiltIn})
 		}
 	}
@@ -1860,6 +1855,15 @@ func DetectMajorVersion(projectDir, frameworkName string) string {
 				rules = fw.Detect
 				break
 			}
+		}
+	}
+
+	// No store definition installed yet: fall back to the built-in adapter's
+	// detect rules so a first-time link can resolve a version and auto-fetch the
+	// store definition, instead of silently serving the built-in.
+	if len(rules) == 0 {
+		if b := builtinFramework(frameworkName); b != nil {
+			rules = b.Detect
 		}
 	}
 

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -297,12 +297,12 @@ type FrameworkPHP struct {
 // FrameworkRule is a single detection rule for a framework.
 // Any matching rule is sufficient to identify the framework.
 type FrameworkRule struct {
-	File             string   `yaml:"file,omitempty"`              // file must exist in project root
-	Composer         string   `yaml:"composer,omitempty"`          // package must be in composer.json require/require-dev
-	ComposerSections []string `yaml:"composer_sections,omitempty"` // extra composer.json keys to search (e.g. flex-require)
-	VersionKey       string   `yaml:"version_key,omitempty"`       // dot-path to version in composer.json (e.g. extra.symfony.require)
-	VersionFile      string   `yaml:"version_file,omitempty"`      // file to read version from (relative to project root)
-	VersionPattern   string   `yaml:"version_pattern,omitempty"`   // regex with capture group for version (e.g. "\\$wp_version = '([^']+)'")
+	File             string   `yaml:"file,omitempty" json:"file,omitempty"`                           // file must exist in project root
+	Composer         string   `yaml:"composer,omitempty" json:"composer,omitempty"`                   // package must be in composer.json require/require-dev
+	ComposerSections []string `yaml:"composer_sections,omitempty" json:"composer_sections,omitempty"` // extra composer.json keys to search (e.g. flex-require)
+	VersionKey       string   `yaml:"version_key,omitempty" json:"version_key,omitempty"`             // dot-path to version in composer.json (e.g. extra.symfony.require)
+	VersionFile      string   `yaml:"version_file,omitempty" json:"version_file,omitempty"`           // file to read version from (relative to project root)
+	VersionPattern   string   `yaml:"version_pattern,omitempty" json:"version_pattern,omitempty"`     // regex with capture group for version (e.g. "\\$wp_version = '([^']+)'")
 }
 
 // FrameworkEnvConf describes how the framework manages its env file.

--- a/internal/config/framework_detect_test.go
+++ b/internal/config/framework_detect_test.go
@@ -88,6 +88,44 @@ func TestDetectFrameworkForDir_LerdYAMLTakesPriority(t *testing.T) {
 	}
 }
 
+func TestDetectMajorVersion_SymfonyFromBuiltinRules(t *testing.T) {
+	setConfigDir(t)
+	dir := t.TempDir()
+
+	// No symfony store definition installed yet, only a composer.json. Detection
+	// must fall back to the built-in adapter's rules so a version resolves and the
+	// store auto-fetch can trigger (previously this returned "" and served built-in).
+	composer := `{"require":{"symfony/framework-bundle":"7.1.*"}}`
+	os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0644) //nolint:errcheck
+
+	if v := DetectMajorVersion(dir, "symfony"); v != "7" {
+		t.Errorf("expected major 7 from built-in symfony rules, got %q", v)
+	}
+}
+
+func TestListFrameworksDetailed_SymfonyStoreNoDuplicate(t *testing.T) {
+	setConfigDir(t)
+
+	storeDir := StoreFrameworksDir()
+	os.MkdirAll(storeDir, 0755) //nolint:errcheck
+	fw := &Framework{Name: "symfony", Version: "8", Label: "Symfony"}
+	fwData, _ := yaml.Marshal(fw)
+	os.WriteFile(filepath.Join(storeDir, "symfony@8.yaml"), fwData, 0644) //nolint:errcheck
+
+	var symfony []FrameworkInfo
+	for _, info := range ListFrameworksDetailed() {
+		if info.Name == "symfony" {
+			symfony = append(symfony, info)
+		}
+	}
+	if len(symfony) != 1 {
+		t.Fatalf("expected a single symfony entry, got %d", len(symfony))
+	}
+	if symfony[0].Source != SourceStore {
+		t.Errorf("expected store source, got %q", symfony[0].Source)
+	}
+}
+
 func TestDetectFrameworkForDir_EmbeddedDefRestored(t *testing.T) {
 	setConfigDir(t)
 	dir := t.TempDir()

--- a/internal/config/framework_rule_test.go
+++ b/internal/config/framework_rule_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The store index is JSON with snake_case keys. FrameworkRule needs json tags,
+// not just yaml, or "composer_sections" and "version_key" silently fail to bind
+// (Go's case-insensitive fallback does not cross underscores), which drops
+// Symfony's flex-require / extra.symfony.require version detection.
+func TestFrameworkRule_JSONSnakeCaseTags(t *testing.T) {
+	data := []byte(`{"composer":"symfony/framework-bundle","composer_sections":["flex-require"],"version_key":"extra.symfony.require"}`)
+	var r FrameworkRule
+	if err := json.Unmarshal(data, &r); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if r.VersionKey != "extra.symfony.require" {
+		t.Errorf("version_key not bound: %q", r.VersionKey)
+	}
+	if len(r.ComposerSections) != 1 || r.ComposerSections[0] != "flex-require" {
+		t.Errorf("composer_sections not bound: %+v", r.ComposerSections)
+	}
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -367,6 +367,14 @@ func StoreFrameworksDir() string {
 	return filepath.Join(DataDir(), "frameworks")
 }
 
+// StoreIndexFile returns the path to the locally cached framework store index.
+// The store package refreshes it in the background; offline detection and
+// listing read it so a fresh machine can resolve any framework without a
+// definition already on disk.
+func StoreIndexFile() string {
+	return filepath.Join(StoreFrameworksDir(), "index.json")
+}
+
 // StorePresetsDir returns the directory for store-installed service-preset YAML
 // files, fetched from the external service store. It sits under the preset-source
 // seam as a layer above the embedded bundle: a valid preset here is served in

--- a/internal/mcp/framework_update_test.go
+++ b/internal/mcp/framework_update_test.go
@@ -1,0 +1,15 @@
+package mcp
+
+import "testing"
+
+// The framework MCP tool mirrors the CLI: install was dropped in favour of
+// update as the single manual store-refresh action.
+func TestFrameworkGroup_InstallReplacedByUpdate(t *testing.T) {
+	fw := groupDispatch["framework"]
+	if _, ok := fw["install"]; ok {
+		t.Error("framework install action should be removed")
+	}
+	if _, ok := fw["update"]; !ok {
+		t.Error("framework update action should be registered")
+	}
+}

--- a/internal/mcp/groups.go
+++ b/internal/mcp/groups.go
@@ -186,7 +186,7 @@ var groupDispatch = map[string]map[string]handlerFn{
 		"add":         execFrameworkAdd,
 		"remove":      execFrameworkRemove,
 		"search":      execFrameworkSearch,
-		"install":     execFrameworkInstall,
+		"update":      execFrameworkUpdate,
 		"prune":       func(a map[string]any) (any, *rpcError) { return execFrameworkPrune(a) },
 		"project_new": execProjectNew,
 		"setup":       execSetup,
@@ -472,8 +472,8 @@ func frameworkTool() mcpTool {
 		InputSchema: mcpSchema{
 			Type: "object",
 			Properties: map[string]mcpProp{
-				"action":              {Type: "string", Enum: []string{"list", "add", "remove", "prune", "search", "install", "project_new", "setup"}},
-				"name":                {Type: "string", Description: "add/remove/install: framework slug."},
+				"action":              {Type: "string", Enum: []string{"list", "add", "remove", "prune", "search", "update", "project_new", "setup"}},
+				"name":                {Type: "string", Description: "add/remove/update: framework slug."},
 				"force":               {Type: "boolean", Description: "remove: delete even if a site uses it."},
 				"label":               {Type: "string", Description: "add: human-readable name."},
 				"public_dir":          {Type: "string", Description: "add: document root."},

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3787,16 +3787,46 @@ func execFrameworkSearch(args map[string]any) (any, *rpcError) {
 	return toolOK(string(data)), nil
 }
 
-func execFrameworkInstall(args map[string]any) (any, *rpcError) {
-	name := strArg(args, "name")
-	if name == "" {
-		return toolErr("name is required"), nil
-	}
-	version := strArg(args, "version")
-
+func execFrameworkUpdate(args map[string]any) (any, *rpcError) {
 	client := store.NewClient()
+	name := strArg(args, "name")
 
-	// Auto-detect version from site path if not specified
+	// No name: refresh the cached catalogue and re-fetch every installed
+	// definition. Definitions otherwise auto-fetch on link and self-refresh, so
+	// this is the manual trigger.
+	if name == "" {
+		idx, err := client.RefreshIndex()
+		if err != nil {
+			return toolErr(fmt.Sprintf("refreshing store index: %v", err)), nil
+		}
+		updated := 0
+		for _, info := range config.ListFrameworksDetailed() {
+			if info.Source == config.SourceBuiltIn {
+				continue
+			}
+			inIndex := false
+			for _, entry := range idx.Frameworks {
+				if entry.Name == info.Name {
+					inIndex = true
+					break
+				}
+			}
+			if !inIndex {
+				continue
+			}
+			remote, ferr := client.FetchFramework(info.Name, info.Version)
+			if ferr != nil {
+				continue
+			}
+			if config.SaveStoreFramework(remote) == nil {
+				config.RemoveUserFramework(info.Name)
+				updated++
+			}
+		}
+		return toolOK(fmt.Sprintf("Refreshed store catalogue and updated %d framework definition(s).", updated)), nil
+	}
+
+	version := strArg(args, "version")
 	if version == "" {
 		sitePath := defaultSitePath
 		if sitePath != "" {
@@ -3815,20 +3845,16 @@ func execFrameworkInstall(args map[string]any) (any, *rpcError) {
 	if err != nil {
 		return toolErr(fmt.Sprintf("fetching framework: %v", err)), nil
 	}
-
 	if err := config.SaveStoreFramework(fw); err != nil {
 		return toolErr(fmt.Sprintf("saving framework: %v", err)), nil
 	}
+	config.RemoveUserFramework(name)
 
 	versionStr := fw.Version
 	if versionStr == "" {
 		versionStr = "latest"
 	}
-	filename := fw.Name + ".yaml"
-	if fw.Version != "" {
-		filename = fw.Name + "@" + fw.Version + ".yaml"
-	}
-	return toolOK(fmt.Sprintf("Installed %s@%s (%s). Saved to %s/%s", fw.Name, versionStr, fw.Label, config.StoreFrameworksDir(), filename)), nil
+	return toolOK(fmt.Sprintf("Updated %s@%s (%s).", fw.Name, versionStr, fw.Label)), nil
 }
 
 func execProjectNew(args map[string]any) (any, *rpcError) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -67,17 +69,70 @@ func NewClient() *Client {
 
 // FetchIndex downloads the store index.
 func (c *Client) FetchIndex() (*Index, error) {
+	idx, _, err := c.fetchIndex()
+	return idx, err
+}
+
+// fetchIndex downloads and parses the store index, returning the raw bytes too so
+// callers can persist them to the on-disk cache verbatim.
+func (c *Client) fetchIndex() (*Index, []byte, error) {
 	data, err := c.fetch("index.json")
 	if err != nil {
-		return nil, fmt.Errorf("fetching store index: %w", err)
+		return nil, nil, fmt.Errorf("fetching store index: %w", err)
 	}
 
 	var idx Index
 	if err := json.Unmarshal(data, &idx); err != nil {
-		return nil, fmt.Errorf("parsing store index: %w", err)
+		return nil, nil, fmt.Errorf("parsing store index: %w", err)
 	}
 
+	return &idx, data, nil
+}
+
+// RefreshIndex downloads the store index, updates the local cache, and returns
+// it, so offline detection and listing can read the full catalogue without a
+// network round trip.
+func (c *Client) RefreshIndex() (*Index, error) {
+	idx, data, err := c.fetchIndex()
+	if err != nil {
+		return nil, err
+	}
+	writeCachedIndex(data)
+	return idx, nil
+}
+
+// WatchIndex refreshes the cached store index once at startup and then on every
+// interval tick. Meant to run as a goroutine from the long-running watcher.
+func WatchIndex(interval time.Duration) {
+	_, _ = NewClient().RefreshIndex()
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for range t.C {
+		_, _ = NewClient().RefreshIndex()
+	}
+}
+
+// loadCachedIndex reads and parses the locally cached store index.
+func loadCachedIndex() (*Index, error) {
+	data, err := os.ReadFile(config.StoreIndexFile())
+	if err != nil {
+		return nil, err
+	}
+	var idx Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, err
+	}
 	return &idx, nil
+}
+
+// writeCachedIndex persists the raw index bytes to the local cache. Best effort:
+// a cache we cannot write just means the next read falls back to the network.
+func writeCachedIndex(data []byte) {
+	path := config.StoreIndexFile()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o644)
 }
 
 // FetchFramework downloads a framework definition from the store.

--- a/internal/store/store_index_cache_test.go
+++ b/internal/store/store_index_cache_test.go
@@ -1,0 +1,33 @@
+package store
+
+import (
+	"os"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// RefreshIndex must persist the fetched index to config.StoreIndexFile() so the
+// offline detection and listing paths can read the full catalogue without a
+// network round trip. loadCachedIndex reads that same file back.
+func TestRefreshIndex_CachesToDisk(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	if _, err := c.RefreshIndex(); err != nil {
+		t.Fatalf("RefreshIndex: %v", err)
+	}
+	if _, err := os.Stat(config.StoreIndexFile()); err != nil {
+		t.Fatalf("expected cached index at %s: %v", config.StoreIndexFile(), err)
+	}
+
+	idx, err := loadCachedIndex()
+	if err != nil {
+		t.Fatalf("loadCachedIndex: %v", err)
+	}
+	if len(idx.Frameworks) != 2 || idx.Frameworks[1].Name != "symfony" {
+		t.Fatalf("unexpected cached index: %+v", idx)
+	}
+}


### PR DESCRIPTION
Linking a Symfony project on a machine that had not fetched the Symfony definition yet served it from the built-in Go adapter instead of the store, because version detection only read detect rules from store YAML already on disk and so resolved no version, which disabled the store auto-fetch. Detection now falls back to the built-in adapter's own detect rules when nothing is installed, so the fetch fires and Symfony links from the store the same way Laravel already did. The framework list no longer shows Symfony twice once a store version is installed, and lerd setup no longer warns about a missing sqlite service, since sqlite is a per-project file the link path now skips rather than trying to start as a container.

The store index is now cached locally and refreshed in the background, instead of being fetched on every call and never persisted, which is the foundation for resolving any framework offline. The framework rule struct also gained json tags so the index's snake_case keys parse correctly.

The redundant framework install command is gone from the CLI and the MCP tool, since definitions auto-fetch on link, and update becomes the single manual store refresh, which now also refreshes the cached catalogue.

Refs #775
Refs #774
