### PR TITLE
feat: resolve framework detection offline from the cached store index

### DIFF
--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -48,7 +48,7 @@ lerd framework search
 
 ### Getting definitions from the store
 
-Definitions arrive automatically. Linking a project detects its framework and version and fetches the matching definition from the store, and the cached catalogue refreshes on its own in the background, so there is no install step to run.
+Definitions arrive automatically. Linking a project detects its framework and version and fetches the matching definition from the store, and the cached catalogue refreshes on its own in the background, so there is no install step to run. Because the catalogue is cached locally, detection resolves the right framework and version even offline and for frameworks you have not linked before.
 
 To refresh manually, `lerd framework update`. With no arguments it refreshes the cached catalogue and re-fetches every installed definition; with a name it fetches that one, installing it if it isn't cached yet:
 

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -1306,6 +1306,18 @@ func DetectFramework(dir string) (string, bool) {
 		}
 	}
 
+	// Cached store catalogue: lets any store framework be detected offline, not
+	// just the ones already fetched to disk or built into the binary.
+	for _, e := range loadCachedStoreEntries() {
+		if seen[e.Name] {
+			continue
+		}
+		seen[e.Name] = true
+		if matchesFramework(dir, &Framework{Name: e.Name, Detect: e.Detect}) {
+			matches = append(matches, e.Name)
+		}
+	}
+
 	// Built-in Laravel and Symfony as fallbacks.
 	for _, fw := range builtinFrameworks() {
 		if !seen[fw.Name] && matchesFramework(dir, fw) {
@@ -1838,35 +1850,33 @@ func matchesFramework(dir string, fw *Framework) bool {
 
 // DetectMajorVersion detects the major version of a framework from the project directory.
 // It tries composer.json constraints first, then falls back to version_file regex matching.
+// frameworkDetectRules resolves the detect rules for a framework offline,
+// preferring an installed store definition, then the cached store index (which
+// covers every framework in the catalogue, not just the built-ins), then the
+// built-in adapter as the no-network fallback.
+func frameworkDetectRules(frameworkName string) []FrameworkRule {
+	matches, _ := filepath.Glob(filepath.Join(StoreFrameworksDir(), frameworkName+"@*.yaml"))
+	matches = append(matches, filepath.Join(StoreFrameworksDir(), frameworkName+".yaml"))
+	for _, path := range matches {
+		if fw := loadFrameworkYAML(path); fw != nil && len(fw.Detect) > 0 {
+			return fw.Detect
+		}
+	}
+	if e := cachedStoreEntryByName(frameworkName); e != nil && len(e.Detect) > 0 {
+		return e.Detect
+	}
+	if b := builtinFramework(frameworkName); b != nil {
+		return b.Detect
+	}
+	return nil
+}
+
 func DetectMajorVersion(projectDir, frameworkName string) string {
 	if projectDir == "" {
 		return ""
 	}
 
-	var rules []FrameworkRule
-	if frameworkName == "laravel" {
-		rules = []FrameworkRule{{Composer: "laravel/framework"}}
-	} else {
-		pattern := filepath.Join(StoreFrameworksDir(), frameworkName+"@*.yaml")
-		matches, _ := filepath.Glob(pattern)
-		matches = append(matches, filepath.Join(StoreFrameworksDir(), frameworkName+".yaml"))
-		for _, path := range matches {
-			if fw := loadFrameworkYAML(path); fw != nil {
-				rules = fw.Detect
-				break
-			}
-		}
-	}
-
-	// No store definition installed yet: fall back to the built-in adapter's
-	// detect rules so a first-time link can resolve a version and auto-fetch the
-	// store definition, instead of silently serving the built-in.
-	if len(rules) == 0 {
-		if b := builtinFramework(frameworkName); b != nil {
-			rules = b.Detect
-		}
-	}
-
+	rules := frameworkDetectRules(frameworkName)
 	if len(rules) == 0 {
 		return ""
 	}

--- a/internal/config/store_index.go
+++ b/internal/config/store_index.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// cachedStoreEntry mirrors the framework store index fields that offline
+// detection needs. The config package cannot import the store package (store
+// imports config), so it reads the store-maintained cache file directly. The
+// store package writes and refreshes StoreIndexFile(); this is the read side.
+type cachedStoreEntry struct {
+	Name     string          `json:"name"`
+	Label    string          `json:"label"`
+	Versions []string        `json:"versions"`
+	Latest   string          `json:"latest"`
+	Detect   []FrameworkRule `json:"detect"`
+}
+
+// loadCachedStoreEntries reads the locally cached framework store index. Returns
+// nil when the cache is absent or unreadable (e.g. a fresh machine that has not
+// reached the store yet), so callers fall back to the built-in adapters.
+func loadCachedStoreEntries() []cachedStoreEntry {
+	data, err := os.ReadFile(StoreIndexFile())
+	if err != nil {
+		return nil
+	}
+	var idx struct {
+		Frameworks []cachedStoreEntry `json:"frameworks"`
+	}
+	if json.Unmarshal(data, &idx) != nil {
+		return nil
+	}
+	return idx.Frameworks
+}
+
+// cachedStoreEntryByName returns the cached index entry for name, or nil.
+func cachedStoreEntryByName(name string) *cachedStoreEntry {
+	entries := loadCachedStoreEntries()
+	for i := range entries {
+		if entries[i].Name == name {
+			return &entries[i]
+		}
+	}
+	return nil
+}

--- a/internal/config/store_index_detect_test.go
+++ b/internal/config/store_index_detect_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A framework with no built-in Go adapter and no store YAML on disk must still
+// be detected, by name and version, from the locally cached store index alone.
+// This is the offline case that the built-in fallback can't cover (Drupal,
+// Statamic, CakePHP, Tempest, etc.).
+func TestDetection_FromCachedStoreIndex(t *testing.T) {
+	setConfigDir(t)
+	dir := t.TempDir()
+
+	os.WriteFile(filepath.Join(dir, "composer.json"), //nolint:errcheck
+		[]byte(`{"require":{"drupal/core-recommended":"^11.0"}}`), 0644)
+
+	os.MkdirAll(StoreFrameworksDir(), 0755) //nolint:errcheck
+	index := `{"frameworks":[{"name":"drupal","label":"Drupal","versions":["11","10"],"latest":"11","detect":[{"composer":"drupal/core-recommended"},{"composer":"drupal/core"}]}]}`
+	os.WriteFile(StoreIndexFile(), []byte(index), 0644) //nolint:errcheck
+
+	if name, ok := DetectFramework(dir); !ok || name != "drupal" {
+		t.Errorf("DetectFramework = %q, %v; want drupal, true", name, ok)
+	}
+	if v := DetectMajorVersion(dir, "drupal"); v != "11" {
+		t.Errorf("DetectMajorVersion = %q; want 11", v)
+	}
+}


### PR DESCRIPTION
Framework detection resolved its name and version rules only from framework YAML already on disk plus the two built-in Go adapters, so on a machine that had not fetched a definition yet only Laravel and Symfony worked offline and every other store framework fell through. This is the same gap that made Symfony fall back before, just narrowed to the frameworks with no Go adapter.

Detection now layers its sources: an installed store definition first, then the locally cached store catalogue, then the built-in adapter as the no-network fallback. Because the cached index carries detect rules and version lists for the whole catalogue, any framework resolves by name and version offline, not just the two built into the binary. The config package reads the cached index file directly, since it cannot import the store package that writes it.

Closes #774
