### PR TITLE
feat: show remote dashboard address with QR and keep mobile browsers signed in

### DIFF
--- a/docs/usage/remote-development.md
+++ b/docs/usage/remote-development.md
@@ -317,7 +317,9 @@ lerd lan:unexpose        # flip nginx back to 127.0.0.1, stop forwarder
 
 Check the current state with `lerd remote-control status` and `lerd lan:status`. Both can be run from a loopback shell at any time, even if you've forgotten the password.
 
-The browser handles the Basic auth prompt natively the first time the user visits `http://<server-ip>:7073`; they're prompted once and the credentials are cached for the session. There is no separate UI login screen.
+The browser handles the Basic auth prompt natively the first time the user visits `http://<server-ip>:7073`. On that first success lerd sets a `lerd_session` cookie (HttpOnly, `SameSite=Lax`, one week) and accepts it in place of the Authorization header on later requests, so the device stays signed in across refreshes rather than re-prompting. The cookie is HMAC-signed with the stored password hash, so rotating or clearing the credentials invalidates every outstanding session. This matters on iOS Safari, which otherwise drops cached Basic credentials between page loads and pops the password dialog on every refresh. There is no separate UI login screen.
+
+Once the dashboard is exposed and credentials are set, the **Remote dashboard access** card shows the `http://<server-ip>:7073` address alongside a QR code, so a phone on the same network can scan straight in.
 
 `lerd remote-control on` refuses to run when `lan:expose` is off, since dashboard credentials are meaningless while the dashboard is loopback-only.
 

--- a/internal/ui/remote_control.go
+++ b/internal/ui/remote_control.go
@@ -279,7 +279,19 @@ func withRemoteControlGate(next http.Handler) http.Handler {
 			return
 		}
 
-		// 5. Validate HTTP Basic auth.
+		// 5. A valid session cookie authenticates without re-challenging.
+		// It is issued after a Basic-auth success below and HMAC'd with the
+		// password hash, so changing or clearing credentials invalidates it.
+		// This is what stops iOS Safari, which drops cached Basic
+		// credentials between refreshes, from prompting on every load.
+		now := time.Now()
+		if c, err := r.Cookie(remoteSessionCookie); err == nil &&
+			remoteSessionValid(c.Value, cfg.UI.Username, cfg.UI.PasswordHash, now) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// 6. Validate HTTP Basic auth.
 		user, pass, ok := r.BasicAuth()
 		if !ok {
 			w.Header().Set("WWW-Authenticate", `Basic realm="lerd dashboard"`)
@@ -300,6 +312,9 @@ func withRemoteControlGate(next http.Handler) http.Handler {
 			return
 		}
 
+		// Basic auth cleared — mint a session cookie so the browser skips
+		// the challenge on subsequent requests.
+		setRemoteSessionCookie(w, cfg.UI.Username, cfg.UI.PasswordHash, now)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/ui/remote_control_test.go
+++ b/internal/ui/remote_control_test.go
@@ -171,6 +171,67 @@ func TestRemoteControlGate_lanRequiresAuthWhenEnabled(t *testing.T) {
 	})
 }
 
+// TestRemoteControlGate_sessionCookie verifies that a successful Basic auth
+// mints a session cookie and that the cookie alone authenticates a later LAN
+// request without re-presenting the Authorization header. A tampered cookie
+// falls through to the 401 challenge. This is the iOS Safari fix: Safari drops
+// cached Basic credentials between refreshes, so the cookie carries the
+// session instead.
+func TestRemoteControlGate_sessionCookie(t *testing.T) {
+	setupConfigDir(t, "alice", "s3cret")
+
+	// Basic auth success must set the session cookie.
+	next := &nextHandler{}
+	gate := withRemoteControlGate(next)
+	req := httptest.NewRequest(http.MethodGet, "/api/sites", nil)
+	req.RemoteAddr = "192.168.1.42:54321"
+	req.SetBasicAuth("alice", "s3cret")
+	rec := httptest.NewRecorder()
+	gate.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Basic auth status = %d, want 200", rec.Code)
+	}
+	var session *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == remoteSessionCookie {
+			session = c
+		}
+	}
+	if session == nil {
+		t.Fatal("no session cookie set after successful Basic auth")
+	}
+
+	t.Run("cookie authenticates without Basic header", func(t *testing.T) {
+		next2 := &nextHandler{}
+		gate2 := withRemoteControlGate(next2)
+		req2 := httptest.NewRequest(http.MethodGet, "/api/sites", nil)
+		req2.RemoteAddr = "192.168.1.42:54321"
+		req2.AddCookie(session)
+		rec2 := httptest.NewRecorder()
+		gate2.ServeHTTP(rec2, req2)
+		if !next2.called || rec2.Code != http.StatusOK {
+			t.Errorf("session cookie did not authenticate, status=%d", rec2.Code)
+		}
+	})
+
+	t.Run("tampered cookie falls through to 401", func(t *testing.T) {
+		flip := byte('0')
+		if session.Value[len(session.Value)-1] == '0' {
+			flip = '1'
+		}
+		next2 := &nextHandler{}
+		gate2 := withRemoteControlGate(next2)
+		req2 := httptest.NewRequest(http.MethodGet, "/api/sites", nil)
+		req2.RemoteAddr = "192.168.1.42:54321"
+		req2.AddCookie(&http.Cookie{Name: remoteSessionCookie, Value: session.Value[:len(session.Value)-1] + string(flip)})
+		rec2 := httptest.NewRecorder()
+		gate2.ServeHTTP(rec2, req2)
+		if next2.called || rec2.Code != http.StatusUnauthorized {
+			t.Errorf("tampered cookie status = %d, want 401", rec2.Code)
+		}
+	})
+}
+
 // TestRemoteControlGate_lanOffOverridesCredentials verifies the top-level
 // LAN-exposure gate: when cfg.LAN.Exposed is false, LAN clients are denied
 // even if they present valid Basic auth credentials. This catches the

--- a/internal/ui/remote_session.go
+++ b/internal/ui/remote_session.go
@@ -1,0 +1,82 @@
+package ui
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/hex"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// remoteSessionCookie authenticates LAN dashboard requests without a fresh
+// HTTP Basic challenge. iOS Safari drops cached Basic credentials between
+// refreshes, so relying on the browser to re-send Authorization means the
+// native password dialog pops on every page load. Once the user has cleared
+// the Basic gate once, we hand them this cookie and accept it in lieu of the
+// header on later requests.
+const remoteSessionCookie = "lerd_session"
+
+// remoteSessionTTL is how long a session cookie stays valid. A week keeps a
+// phone signed in across a normal working stretch while still expiring if a
+// device is lost.
+const remoteSessionTTL = 7 * 24 * time.Hour
+
+// remoteSessionMAC authenticates the encoded username and expiry with the
+// bcrypt password hash as the key. The hash never leaves the server, so a
+// client cannot forge a value, and changing or clearing credentials rotates
+// the key and invalidates every outstanding cookie.
+func remoteSessionMAC(passwordHash, encUser, exp string) string {
+	h := hmac.New(sha256.New, []byte(passwordHash))
+	h.Write([]byte(encUser + "|" + exp))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// remoteSessionSign returns the cookie value binding username to expiry.
+func remoteSessionSign(username, passwordHash string, expiry time.Time) string {
+	encUser := base64.RawURLEncoding.EncodeToString([]byte(username))
+	exp := strconv.FormatInt(expiry.Unix(), 10)
+	return encUser + "." + exp + "." + remoteSessionMAC(passwordHash, encUser, exp)
+}
+
+// remoteSessionValid reports whether cookieVal authenticates as the configured
+// user. Tampered, expired, or prior-password values all fail.
+func remoteSessionValid(cookieVal, username, passwordHash string, now time.Time) bool {
+	if passwordHash == "" {
+		return false
+	}
+	parts := strings.Split(cookieVal, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	encUser, exp, mac := parts[0], parts[1], parts[2]
+	raw, err := base64.RawURLEncoding.DecodeString(encUser)
+	if err != nil || string(raw) != username {
+		return false
+	}
+	ts, err := strconv.ParseInt(exp, 10, 64)
+	if err != nil || now.After(time.Unix(ts, 0)) {
+		return false
+	}
+	want := remoteSessionMAC(passwordHash, encUser, exp)
+	return subtle.ConstantTimeCompare([]byte(mac), []byte(want)) == 1
+}
+
+// setRemoteSessionCookie writes a fresh session cookie. HttpOnly and
+// SameSite=Lax; not Secure because the LAN dashboard is served over plain
+// HTTP at http://<lan-ip>:7073 with no certificate.
+func setRemoteSessionCookie(w http.ResponseWriter, username, passwordHash string, now time.Time) {
+	exp := now.Add(remoteSessionTTL)
+	http.SetCookie(w, &http.Cookie{
+		Name:     remoteSessionCookie,
+		Value:    remoteSessionSign(username, passwordHash, exp),
+		Path:     "/",
+		Expires:  exp,
+		MaxAge:   int(remoteSessionTTL / time.Second),
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}

--- a/internal/ui/remote_session_test.go
+++ b/internal/ui/remote_session_test.go
@@ -1,0 +1,64 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestRemoteSession_signValidatesRoundTrip(t *testing.T) {
+	hash, err := bcrypt.GenerateFromPassword([]byte("s3cret"), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+	now := time.Unix(1_700_000_000, 0)
+	val := remoteSessionSign("alice", string(hash), now.Add(remoteSessionTTL))
+
+	if !remoteSessionValid(val, "alice", string(hash), now) {
+		t.Error("freshly signed cookie failed to validate")
+	}
+}
+
+func TestRemoteSession_rejectsTamperedAndStale(t *testing.T) {
+	hash, err := bcrypt.GenerateFromPassword([]byte("s3cret"), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+	h := string(hash)
+	now := time.Unix(1_700_000_000, 0)
+	val := remoteSessionSign("alice", h, now.Add(remoteSessionTTL))
+
+	otherHash, _ := bcrypt.GenerateFromPassword([]byte("different"), bcrypt.MinCost)
+
+	// Flip the final MAC character to a definitely-different hex digit.
+	flip := byte('0')
+	if val[len(val)-1] == '0' {
+		flip = '1'
+	}
+	tampered := val[:len(val)-1] + string(flip)
+
+	cases := []struct {
+		name string
+		val  string
+		user string
+		hash string
+		now  time.Time
+		want bool
+	}{
+		{"valid", val, "alice", h, now, true},
+		{"wrong user", val, "bob", h, now, false},
+		{"password changed", val, "alice", string(otherHash), now, false},
+		{"expired", val, "alice", h, now.Add(remoteSessionTTL + time.Minute), false},
+		{"tampered mac", tampered, "alice", h, now, false},
+		{"empty hash", val, "alice", "", now, false},
+		{"malformed", "not-a-cookie", "alice", h, now, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := remoteSessionValid(c.val, c.user, c.hash, c.now); got != c.want {
+				t.Errorf("remoteSessionValid = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -190,6 +190,7 @@ func Start(currentVersion string) error {
 	mux.HandleFunc("/api/push/devices", withCORS(handlePushDevices))
 	mux.HandleFunc("/api/push/test", withCORS(handlePushTest))
 	mux.HandleFunc("/api/lan-qr/", withCORS(handleLANQR))
+	mux.HandleFunc("/api/dashboard-qr", withCORS(handleDashboardQR))
 
 	// Cross-process notifier for CLI/MCP. Loopback-only. PollNow in a
 	// goroutine so the handler returns under the CLI's 500 ms POST
@@ -3093,6 +3094,30 @@ func handleLANQR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	png, err := qrcode.Encode(shareURL, qrcode.Medium, 160)
+	if err != nil {
+		http.Error(w, "qr encode: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "image/png")
+	w.Header().Set("Cache-Control", "no-cache")
+	http.ServeContent(w, r, "qr.png", time.Time{}, bytes.NewReader(png))
+}
+
+// handleDashboardQR serves a QR code PNG encoding the dashboard's own LAN URL
+// (http://<lan-ip>:7073) so a phone can scan straight into the remote
+// dashboard. Only meaningful while LAN exposure is on; 404 otherwise.
+func handleDashboardQR(w http.ResponseWriter, r *http.Request) {
+	cfg, _ := config.LoadGlobal()
+	if cfg == nil || !cfg.LAN.Exposed {
+		http.NotFound(w, r)
+		return
+	}
+	ip := uiPrimaryLANIP()
+	if ip == "" {
+		http.NotFound(w, r)
+		return
+	}
+	png, err := qrcode.Encode("http://"+ip+":7073", qrcode.Medium, 160)
 	if err != nil {
 		http.Error(w, "qr encode: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -609,6 +609,7 @@
   "system_lan_remote_copyTooltip_copied": "Kopiert!",
   "system_lan_remote_footer": "Der Endpunkt ist auf RFC-1918-Quell-IPs beschränkt und der Code ist einmalig nutzbar. Klicke erneut auf {generate} für einen neuen Code.",
   "system_remote_title": "Entfernter Dashboard-Zugriff",
+  "system_remote_address": "Dashboard-Adresse",
   "system_remote_status_active": "aktiv",
   "system_remote_status_inert": "inaktiv",
   "system_remote_status_disabled": "deaktiviert",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -602,6 +602,7 @@
   "system_lan_remote_copyTooltip_copied": "Copied!",
   "system_lan_remote_footer": "The endpoint is restricted to RFC 1918 source IPs and the code is single-use. Click {generate} again for a fresh code.",
   "system_remote_title": "Remote dashboard access",
+  "system_remote_address": "Dashboard address",
   "system_remote_status_active": "active",
   "system_remote_status_inert": "inert",
   "system_remote_status_disabled": "disabled",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -609,6 +609,7 @@
   "system_lan_remote_copyTooltip_copied": "¡Copiado!",
   "system_lan_remote_footer": "El endpoint está restringido a IPs origen RFC 1918 y el código es de un solo uso. Pulsa {generate} de nuevo para un código nuevo.",
   "system_remote_title": "Acceso remoto al panel",
+  "system_remote_address": "Dirección del panel",
   "system_remote_status_active": "activo",
   "system_remote_status_inert": "inerte",
   "system_remote_status_disabled": "desactivado",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -609,6 +609,7 @@
   "system_lan_remote_copyTooltip_copied": "Copié !",
   "system_lan_remote_footer": "Le endpoint est restreint aux IPs source RFC 1918 et le code est à usage unique. Cliquez {generate} à nouveau pour un code frais.",
   "system_remote_title": "Accès distant au tableau de bord",
+  "system_remote_address": "Adresse du tableau de bord",
   "system_remote_status_active": "actif",
   "system_remote_status_inert": "inerte",
   "system_remote_status_disabled": "désactivé",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -609,6 +609,7 @@
   "system_lan_remote_copyTooltip_copied": "Tersalin!",
   "system_lan_remote_footer": "Endpoint dibatasi ke IP sumber RFC 1918 dan kode hanya sekali pakai. Klik {generate} lagi untuk kode baru.",
   "system_remote_title": "Akses dasbor jarak jauh",
+  "system_remote_address": "Alamat dasbor",
   "system_remote_status_active": "aktif",
   "system_remote_status_inert": "inert",
   "system_remote_status_disabled": "nonaktif",

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -594,6 +594,7 @@
   "system_lan_remote_copyTooltip_copied": "Copiato!",
   "system_lan_remote_footer": "L'endpoint è limitato agli IP sorgente RFC 1918 e il codice è monouso. Clicca di nuovo {generate} per un codice nuovo.",
   "system_remote_title": "Accesso remoto alla dashboard",
+  "system_remote_address": "Indirizzo della dashboard",
   "system_remote_status_active": "attivo",
   "system_remote_status_inert": "inerte",
   "system_remote_status_disabled": "disabilitato",

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -594,6 +594,7 @@
   "system_lan_remote_copyTooltip_copied": "コピーしました！",
   "system_lan_remote_footer": "エンドポイントは RFC 1918 の送信元 IP に制限され、コードは 1 回限りです。新しいコードが必要なら再度 {generate} をクリックしてください。",
   "system_remote_title": "リモートダッシュボードアクセス",
+  "system_remote_address": "ダッシュボードのアドレス",
   "system_remote_status_active": "アクティブ",
   "system_remote_status_inert": "不活性",
   "system_remote_status_disabled": "無効",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -609,6 +609,7 @@
   "system_lan_remote_copyTooltip_copied": "Gekopieerd!",
   "system_lan_remote_footer": "Het eindpunt is beperkt tot RFC 1918-bron-IP's en de code is eenmalig bruikbaar. Klik opnieuw op {generate} voor een nieuwe code.",
   "system_remote_title": "Externe dashboardtoegang",
+  "system_remote_address": "Dashboardadres",
   "system_remote_status_active": "actief",
   "system_remote_status_inert": "inert",
   "system_remote_status_disabled": "uitgeschakeld",

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -594,6 +594,7 @@
   "system_lan_remote_copyTooltip_copied": "Skopiowano!",
   "system_lan_remote_footer": "Punkt końcowy jest ograniczony do źródłowych adresów IP z RFC 1918, a kod jest jednorazowy. Kliknij {generate} ponownie, aby uzyskać świeży kod.",
   "system_remote_title": "Zdalny dostęp do pulpitu",
+  "system_remote_address": "Adres panelu",
   "system_remote_status_active": "aktywny",
   "system_remote_status_inert": "nieaktywny",
   "system_remote_status_disabled": "wyłączony",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -609,6 +609,7 @@
   "system_lan_remote_copyTooltip_copied": "Copiado!",
   "system_lan_remote_footer": "O endpoint é restrito a IPs de origem RFC 1918 e o código é de uso único. Clique {generate} novamente para um código novo.",
   "system_remote_title": "Acesso remoto ao painel",
+  "system_remote_address": "Endereço do painel",
   "system_remote_status_active": "ativo",
   "system_remote_status_inert": "inerte",
   "system_remote_status_disabled": "desativado",

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -594,6 +594,7 @@
   "system_lan_remote_copyTooltip_copied": "Copiat!",
   "system_lan_remote_footer": "Endpoint-ul este restricționat la IP-uri sursă RFC 1918, iar codul este de unică folosință. Apasă {generate} din nou pentru un cod nou.",
   "system_remote_title": "Acces la tabloul de bord la distanță",
+  "system_remote_address": "Adresa panoului",
   "system_remote_status_active": "activ",
   "system_remote_status_inert": "inert",
   "system_remote_status_disabled": "dezactivat",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -609,6 +609,7 @@
   "system_lan_remote_copyTooltip_copied": "Kopyalandı!",
   "system_lan_remote_footer": "Uç nokta RFC 1918 kaynak IP'leriyle kısıtlıdır ve kod tek kullanımlıktır. Yeni bir kod için tekrar {generate}'a tıklayın.",
   "system_remote_title": "Uzak pano erişimi",
+  "system_remote_address": "Pano adresi",
   "system_remote_status_active": "aktif",
   "system_remote_status_inert": "atıl",
   "system_remote_status_disabled": "devre dışı",

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -594,6 +594,7 @@
   "system_lan_remote_copyTooltip_copied": "Đã sao chép!",
   "system_lan_remote_footer": "Endpoint bị giới hạn cho các IP nguồn RFC 1918 và mã chỉ dùng một lần. Nhấp {generate} lần nữa để có mã mới.",
   "system_remote_title": "Truy cập bảng điều khiển từ xa",
+  "system_remote_address": "Địa chỉ bảng điều khiển",
   "system_remote_status_active": "đang hoạt động",
   "system_remote_status_inert": "không hoạt động",
   "system_remote_status_disabled": "đã tắt",

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -594,6 +594,7 @@
   "system_lan_remote_copyTooltip_copied": "已复制！",
   "system_lan_remote_footer": "该端点仅限 RFC 1918 源 IP，且代码为一次性使用。再次点击 {generate} 获取新代码。",
   "system_remote_title": "远程仪表盘访问",
+  "system_remote_address": "仪表板地址",
   "system_remote_status_active": "活动",
   "system_remote_status_inert": "未生效",
   "system_remote_status_disabled": "已禁用",

--- a/internal/ui/web/src/tabs/system/LerdDetail.svelte
+++ b/internal/ui/web/src/tabs/system/LerdDetail.svelte
@@ -15,8 +15,13 @@
   import Toggle from '$components/Toggle.svelte';
   import SettingsCard from '$components/SettingsCard.svelte';
   import LanguageSwitcher from '$components/LanguageSwitcher.svelte';
-  import { apiFetch } from '$lib/api';
+  import { apiFetch, apiBase } from '$lib/api';
   import { m } from '../../paraglide/messages.js';
+
+  // The remote dashboard always binds :7073; when LAN-exposed we surface the
+  // address plus a scannable QR so a phone can jump straight in.
+  const dashboardURL = $derived('http://' + $lan.lanIP + ':7073');
+  const dashboardQRSrc = $derived(apiBase + '/api/dashboard-qr?v=' + encodeURIComponent($lan.lanIP));
 
   onMount(() => {
     loadLANStatus();
@@ -393,6 +398,15 @@
 
       {#if $remoteControl.enabled}
         <div class="space-y-2">
+          {#if $lan.exposed}
+            <div class="flex items-center justify-between gap-3 p-3 rounded-lg bg-gray-50 dark:bg-white/3 border border-gray-100 dark:border-lerd-border">
+              <div class="min-w-0">
+                <p class="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">{m.system_remote_address()}</p>
+                <a href={dashboardURL} target="_blank" rel="noopener" class="text-sm text-teal-600 dark:text-teal-400 font-mono hover:underline break-all">{dashboardURL}</a>
+              </div>
+              <img src={dashboardQRSrc} width="112" height="112" alt={m.lanShare_qrAlt()} class="shrink-0 rounded-sm bg-white p-1" />
+            </div>
+          {/if}
           <p class="text-xs text-gray-600 dark:text-gray-400">
             {@html m.system_remote_usernameRow({ username: '<code class="bg-gray-100 dark:bg-white/10 px-1.5 py-0.5 rounded-sm font-mono">' + $remoteControl.username + '</code>' })}
           </p>


### PR DESCRIPTION
The Remote dashboard access card now surfaces where the dashboard is actually reachable. Once LAN exposure is on and credentials are set, it shows the `http://<lan-ip>:7073` address next to a scannable QR of the same URL, rendered server side the same way the per-site LAN share links are, so a phone on the network can jump straight in.

It also fixes the credential re-prompt on mobile. Remote access was pure HTTP Basic auth with no session layer, so every request relied on the browser re-sending the Authorization header, and iOS Safari drops those between refreshes, popping the native password dialog on every page load. On the first successful Basic auth the gate now sets a `lerd_session` cookie, HttpOnly and SameSite Lax, valid for a week, and accepts it in place of the header on later requests. The cookie is HMAC signed with the bcrypt password hash, which never leaves the server, so rotating or clearing the credentials invalidates every outstanding session, and it is checked only after the existing LAN exposure and cross origin gates so none of the current protections weaken.

Closes #782