### PR TITLE
feat: polish the web UI for phones and remote LAN dashboards

### DIFF
--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -420,6 +420,7 @@
   "services_unpinTitle": "Lösen, erlaubt Auto-Stopp bei Nichtnutzung",
   "services_removeCustom": "Diesen benutzerdefinierten Dienst entfernen",
   "services_dashboard": "Dashboard",
+  "services_hostOnly": "nur auf dem Host",
   "services_openConnection": "Verbindungs-URL öffnen",
   "services_openAdmin": "{name} öffnen",
   "services_labels_queueWorker": "Queue-Worker",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -401,6 +401,7 @@
   "services_unpinTitle": "Unpin, allow auto-stop when unused",
   "services_removeCustom": "Remove this custom service",
   "services_dashboard": "Dashboard",
+  "services_hostOnly": "host only",
   "services_openConnection": "Open connection URL",
   "services_openAdmin": "Open {name}",
   "services_labels_queueWorker": "Queue worker",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -420,6 +420,7 @@
   "services_unpinTitle": "Desfijar, permitir auto-apagado cuando no se use",
   "services_removeCustom": "Eliminar este servicio personalizado",
   "services_dashboard": "Panel",
+  "services_hostOnly": "solo en el host",
   "services_openConnection": "Abrir URL de conexión",
   "services_openAdmin": "Abrir {name}",
   "services_labels_queueWorker": "Worker de cola",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -420,6 +420,7 @@
   "services_unpinTitle": "Désépingler, autoriser l'arrêt automatique quand inutilisé",
   "services_removeCustom": "Supprimer ce service personnalisé",
   "services_dashboard": "Tableau de bord",
+  "services_hostOnly": "hôte uniquement",
   "services_openConnection": "Ouvrir l'URL de connexion",
   "services_openAdmin": "Ouvrir {name}",
   "services_labels_queueWorker": "Worker de file",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -420,6 +420,7 @@
   "services_unpinTitle": "Lepas sematan, izinkan berhenti otomatis saat tidak digunakan",
   "services_removeCustom": "Hapus layanan kustom ini",
   "services_dashboard": "Dasbor",
+  "services_hostOnly": "hanya di host",
   "services_openConnection": "Buka URL koneksi",
   "services_openAdmin": "Buka {name}",
   "services_labels_queueWorker": "Worker queue",

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -405,6 +405,7 @@
   "services_unpinTitle": "Sblocca, consente l'arresto automatico quando inutilizzato",
   "services_removeCustom": "Rimuovi questo servizio personalizzato",
   "services_dashboard": "Dashboard",
+  "services_hostOnly": "solo sull'host",
   "services_openConnection": "Apri URL di connessione",
   "services_openAdmin": "Apri {name}",
   "services_labels_queueWorker": "Worker della coda",

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -405,6 +405,7 @@
   "services_unpinTitle": "ピン留めを解除して、未使用時の自動停止を許可",
   "services_removeCustom": "このカスタムサービスを削除",
   "services_dashboard": "ダッシュボード",
+  "services_hostOnly": "ホストのみ",
   "services_openConnection": "接続 URL を開く",
   "services_openAdmin": "{name} を開く",
   "services_labels_queueWorker": "キューワーカー",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -420,6 +420,7 @@
   "services_unpinTitle": "Losmaken, staat auto-stop bij inactiviteit toe",
   "services_removeCustom": "Deze aangepaste service verwijderen",
   "services_dashboard": "Dashboard",
+  "services_hostOnly": "alleen op host",
   "services_openConnection": "Verbindings-URL openen",
   "services_openAdmin": "{name} openen",
   "services_labels_queueWorker": "Queue-worker",

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -405,6 +405,7 @@
   "services_unpinTitle": "Odepnij, zezwól na automatyczne zatrzymanie, gdy nieużywane",
   "services_removeCustom": "Usuń tę niestandardową usługę",
   "services_dashboard": "Pulpit",
+  "services_hostOnly": "tylko na hoście",
   "services_openConnection": "Otwórz URL połączenia",
   "services_openAdmin": "Otwórz {name}",
   "services_labels_queueWorker": "Worker kolejki",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -420,6 +420,7 @@
   "services_unpinTitle": "Desfixar, permitir auto-parada quando não usado",
   "services_removeCustom": "Remover este serviço personalizado",
   "services_dashboard": "Painel",
+  "services_hostOnly": "apenas no host",
   "services_openConnection": "Abrir URL de conexão",
   "services_openAdmin": "Abrir {name}",
   "services_labels_queueWorker": "Worker de fila",

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -405,6 +405,7 @@
   "services_unpinTitle": "Anulează fixarea, permite oprirea automată când nu este folosit",
   "services_removeCustom": "Elimină acest serviciu personalizat",
   "services_dashboard": "Tablou de bord",
+  "services_hostOnly": "doar pe gazdă",
   "services_openConnection": "Deschide URL-ul de conexiune",
   "services_openAdmin": "Deschide {name}",
   "services_labels_queueWorker": "Worker de coadă",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -420,6 +420,7 @@
   "services_unpinTitle": "Sabitlemeyi kaldır, kullanılmadığında otomatik durdurmaya izin ver",
   "services_removeCustom": "Bu özel servisi kaldır",
   "services_dashboard": "Pano",
+  "services_hostOnly": "yalnızca ana makinede",
   "services_openConnection": "Bağlantı URL'sini aç",
   "services_openAdmin": "{name} aç",
   "services_labels_queueWorker": "Kuyruk worker'ı",

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -405,6 +405,7 @@
   "services_unpinTitle": "Bỏ ghim, cho phép tự động dừng khi không dùng",
   "services_removeCustom": "Gỡ dịch vụ tùy chỉnh này",
   "services_dashboard": "Bảng điều khiển",
+  "services_hostOnly": "chỉ trên máy chủ",
   "services_openConnection": "Mở URL kết nối",
   "services_openAdmin": "Mở {name}",
   "services_labels_queueWorker": "Queue worker",

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -405,6 +405,7 @@
   "services_unpinTitle": "取消固定，闲置时允许自动停止",
   "services_removeCustom": "移除此自定义服务",
   "services_dashboard": "仪表盘",
+  "services_hostOnly": "仅限主机",
   "services_openConnection": "打开连接 URL",
   "services_openAdmin": "打开 {name}",
   "services_labels_queueWorker": "队列 worker",

--- a/internal/ui/web/src/app.css
+++ b/internal/ui/web/src/app.css
@@ -78,3 +78,15 @@ button {
   width: 3px !important;
   margin-left: 3px;
 }
+
+/* iOS Safari zooms into any focused field whose font is under 16px. Monaco's
+   keystroke capture is a hidden textarea that inherits the 12px editor font, so
+   focusing the Tinker editor zooms the page and throws the fixed-position
+   suggest widget off-screen. The textarea is invisible (Monaco paints text in
+   its own view layers) so bumping it to 16px stops the zoom with no visual
+   change. Scoped to touch pointers so desktop is untouched. */
+@media (pointer: coarse) {
+  .monaco-editor .inputarea {
+    font-size: 16px !important;
+  }
+}

--- a/internal/ui/web/src/components/MobileBackBar.svelte
+++ b/internal/ui/web/src/components/MobileBackBar.svelte
@@ -9,10 +9,10 @@
   const title = $derived($routeRest || $tab);
 </script>
 
-<div class="flex items-center gap-3 px-3 py-3 border-b border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card shrink-0 sticky top-0 z-10">
+<div class="flex items-center gap-2 px-3 py-1.5 border-b border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card shrink-0 sticky top-0 z-10">
   <button
     onclick={back}
-    class="flex items-center justify-center w-8 h-8 rounded-sm text-gray-400 hover:text-lerd-red hover:bg-gray-100 dark:hover:bg-white/5 transition-colors"
+    class="flex items-center justify-center w-7 h-7 -ml-1 rounded-sm text-gray-400 hover:text-lerd-red hover:bg-gray-100 dark:hover:bg-white/5 transition-colors"
     title={m.common_back()}
     aria-label={m.common_back()}
   >

--- a/internal/ui/web/src/components/MobileNav.svelte
+++ b/internal/ui/web/src/components/MobileNav.svelte
@@ -3,7 +3,12 @@
   import Icon, { type IconName } from './Icon.svelte';
   import { dashboardOpen } from '$stores/dashboard';
   import { mobileView, goToApps } from '$stores/mobileView';
+  import { accessMode } from '$stores/accessMode';
   import { m } from '../paraglide/messages.js';
+
+  // The Apps view only launches loopback-only service dashboards, dead from a
+  // remote (LAN) dashboard, so drop the tab there.
+  const remote = $derived(!$accessMode.loopback);
 
   const labels = $derived<Record<TabId, string>>({
     dashboard: m.nav_dashboard(),
@@ -36,15 +41,17 @@
       <span class="text-[10px] font-medium">{labels[t]}</span>
     </button>
   {/each}
-  <button
-    onclick={goToApps}
-    class="grow basis-0 min-w-0 flex flex-col items-center justify-center gap-0.5 transition-colors {$mobileView === 'apps'
-      ? 'text-lerd-red'
-      : 'text-gray-400 dark:text-gray-500'}"
-  >
-    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6a2 2 0 012-2h4a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h4a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4zM14 6a2 2 0 012-2h4a2 2 0 012 2v4a2 2 0 01-2 2h-4a2 2 0 01-2-2V6zM14 16a2 2 0 012-2h4a2 2 0 012 2v4a2 2 0 01-2 2h-4a2 2 0 01-2-2v-4z"/>
-    </svg>
-    <span class="text-[10px] font-medium">{m.nav_apps()}</span>
-  </button>
+  {#if !remote}
+    <button
+      onclick={goToApps}
+      class="grow basis-0 min-w-0 flex flex-col items-center justify-center gap-0.5 transition-colors {$mobileView === 'apps'
+        ? 'text-lerd-red'
+        : 'text-gray-400 dark:text-gray-500'}"
+    >
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6a2 2 0 012-2h4a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h4a2 2 0 012 2v4a2 2 0 01-2 2H6a2 2 0 01-2-2v-4zM14 6a2 2 0 012-2h4a2 2 0 012 2v4a2 2 0 01-2 2h-4a2 2 0 01-2-2V6zM14 16a2 2 0 012-2h4a2 2 0 012 2v4a2 2 0 01-2 2h-4a2 2 0 01-2-2v-4z"/>
+      </svg>
+      <span class="text-[10px] font-medium">{m.nav_apps()}</span>
+    </button>
+  {/if}
 </nav>

--- a/internal/ui/web/src/components/MonacoEditor.svelte
+++ b/internal/ui/web/src/components/MonacoEditor.svelte
@@ -46,10 +46,22 @@
 
   onMount(() => {
     let unsubTheme: (() => void) | undefined;
+    let vvCleanup: (() => void) | undefined;
     void (async () => {
       const monaco = await loadMonaco();
       if (disposed || !container) return;
       monacoRef = monaco;
+
+      // On touch the soft keyboard shrinks the visible area but Monaco still
+      // lays out to the full container height, so with the caret near the top it
+      // decides there's no room below and flips the suggest popup above,
+      // off-screen. We constrain the editor to the visual viewport below so its
+      // geometry matches what's actually visible and the popup lands by the
+      // caret. Widgets stay fixed-positioned so they clear the overflow-hidden card.
+      const coarse =
+        typeof window !== 'undefined' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(pointer: coarse)').matches;
 
       const ed = monaco.editor.create(container, {
         value,
@@ -73,6 +85,29 @@
       });
       editor = ed;
 
+      // Keyboard-aware sizing on touch (see the note above the create call):
+      // cap the editor at the gap between its top and the visual viewport
+      // bottom (the keyboard), and refit as the keyboard shows or hides.
+      // automaticLayout picks up the max-height change and Monaco then places
+      // the suggest popup within the visible area.
+      if (coarse && typeof window !== 'undefined' && window.visualViewport && container) {
+        const host = container;
+        const vv = window.visualViewport;
+        const fit = () => {
+          const top = host.getBoundingClientRect().top;
+          const avail = vv.offsetTop + vv.height - top - 8;
+          host.style.maxHeight = avail > 120 ? `${avail}px` : '';
+        };
+        fit();
+        vv.addEventListener('resize', fit);
+        vv.addEventListener('scroll', fit);
+        vvCleanup = () => {
+          vv.removeEventListener('resize', fit);
+          vv.removeEventListener('scroll', fit);
+          host.style.maxHeight = '';
+        };
+      }
+
       ed.onDidChangeModelContent(() => {
         if (internalUpdate) return;
         const next = ed.getValue();
@@ -90,6 +125,7 @@
     return () => {
       disposed = true;
       unsubTheme?.();
+      vvCleanup?.();
       editor?.dispose();
       editor = undefined;
     };

--- a/internal/ui/web/src/components/NavRail.svelte
+++ b/internal/ui/web/src/components/NavRail.svelte
@@ -16,11 +16,16 @@
   import { dashboardIconSvg } from '$lib/dashboardIcons';
   import { profilerEnabled, loadProfilerStatus } from '$stores/profiler';
   import { serviceLabel } from '$stores/services';
+  import { accessMode } from '$stores/accessMode';
   import { m } from '../paraglide/messages.js';
 
   onMount(() => {
     void loadProfilerStatus();
   });
+
+  // The profiler and service dashboards are loopback-only localhost web UIs, so
+  // their launch icons are dead from a remote (LAN) dashboard. Hide them there.
+  const remote = $derived(!$accessMode.loopback);
 
   const labels = $derived<Record<TabId, string>>({
     dashboard: m.nav_dashboard(),
@@ -54,36 +59,38 @@
     {/each}
   </div>
 
-  <div class="flex flex-col items-center gap-1 mt-3 pt-3 border-t border-gray-200 dark:border-lerd-border w-8">
-    <IconButton
-      title={m.nav_profiler()}
-      active={$dashboardOpen?.name === 'profiler'}
-      onclick={openProfiler}
-    >
-      <span class="relative flex items-center justify-center">
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          {@html dashboardIconSvg('profiler')}
-        </svg>
-        {#if $profilerEnabled}
-          <span
-            title={m.profiler_toggle_on()}
-            class="absolute -top-1 -right-1.5 w-2 h-2 rounded-full bg-emerald-500 ring-2 ring-white dark:ring-lerd-card"
-          ></span>
-        {/if}
-      </span>
-    </IconButton>
-    {#each $dashboardServices as svc (svc.name)}
+  {#if !remote}
+    <div class="flex flex-col items-center gap-1 mt-3 pt-3 border-t border-gray-200 dark:border-lerd-border w-8">
       <IconButton
-        title={serviceLabel(svc.name) + ' ' + m.services_dashboard().toLowerCase()}
-        active={$dashboardOpen?.name === svc.name}
-        onclick={() => openDashboard(svc)}
+        title={m.nav_profiler()}
+        active={$dashboardOpen?.name === 'profiler'}
+        onclick={openProfiler}
       >
-        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          {@html dashboardIconSvg(svc.name)}
-        </svg>
+        <span class="relative flex items-center justify-center">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            {@html dashboardIconSvg('profiler')}
+          </svg>
+          {#if $profilerEnabled}
+            <span
+              title={m.profiler_toggle_on()}
+              class="absolute -top-1 -right-1.5 w-2 h-2 rounded-full bg-emerald-500 ring-2 ring-white dark:ring-lerd-card"
+            ></span>
+          {/if}
+        </span>
       </IconButton>
-    {/each}
-  </div>
+      {#each $dashboardServices as svc (svc.name)}
+        <IconButton
+          title={serviceLabel(svc.name) + ' ' + m.services_dashboard().toLowerCase()}
+          active={$dashboardOpen?.name === svc.name}
+          onclick={() => openDashboard(svc)}
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            {@html dashboardIconSvg(svc.name)}
+          </svg>
+        </IconButton>
+      {/each}
+    </div>
+  {/if}
 
   <div class="mt-auto flex flex-col items-center gap-2">
     <IconButton

--- a/internal/ui/web/src/stores/sites.actions.test.ts
+++ b/internal/ui/web/src/stores/sites.actions.test.ts
@@ -234,4 +234,22 @@ describe('sites actions', () => {
     expect(siteWorkerFailing({ domain: 'a', framework_workers: [{ name: 'x', failing: true }] })).toBe(true);
     expect(siteWorkerFailing({ domain: 'a' })).toBe(false);
   });
+
+  it('openSiteInBrowser opens the .test domain by default', async () => {
+    const opened: string[] = [];
+    vi.stubGlobal('open', (url: string) => opened.push(url));
+    const { openSiteInBrowser } = await import('./sites');
+    openSiteInBrowser({ domain: 'a.test', name: 'a', tls: true });
+    expect(opened).toEqual(['https://a.test']);
+    vi.unstubAllGlobals();
+  });
+
+  it('openSiteInBrowser prefers an explicit url override (remote LAN open)', async () => {
+    const opened: string[] = [];
+    vi.stubGlobal('open', (url: string) => opened.push(url));
+    const { openSiteInBrowser } = await import('./sites');
+    openSiteInBrowser({ domain: 'a.test', name: 'a', tls: true }, '', 'http://192.168.0.200:8080');
+    expect(opened).toEqual(['http://192.168.0.200:8080']);
+    vi.unstubAllGlobals();
+  });
 });

--- a/internal/ui/web/src/stores/sites.ts
+++ b/internal/ui/web/src/stores/sites.ts
@@ -207,10 +207,13 @@ export function siteHasWorkers(s: Site): boolean {
   );
 }
 
-export function openSiteInBrowser(s: Site, branch: string = '') {
+export function openSiteInBrowser(s: Site, branch: string = '', urlOverride?: string) {
   const target = activeWorktreeDomain(s, branch);
   const useTLS = Boolean(s.tls);
-  const url = (useTLS ? 'https://' : 'http://') + target;
+  // urlOverride carries the LAN share URL when a remote dashboard viewer opens
+  // the site: the .test domain only resolves on the host, so off-host we open
+  // http://<lan-ip>:<port> instead.
+  const url = urlOverride || (useTLS ? 'https://' : 'http://') + target;
   // Opening the site loads it, which wakes it via the activity feed. Clear the
   // idle marker optimistically so the sleep indicator drops immediately rather
   // than lingering until the next poll confirms the activity.

--- a/internal/ui/web/src/tabs/services/ServiceHeader.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceHeader.svelte
@@ -19,7 +19,13 @@
   } from '$stores/services';
   import { adminServiceFor } from '$stores/presetSuggestions';
   import { openDashboard } from '$stores/dashboard';
+  import { accessMode } from '$stores/accessMode';
   import { m } from '../../paraglide/messages.js';
+
+  // Service ports and their web UIs bind to loopback on the host, so their
+  // localhost links are dead from a remote (LAN) dashboard. Disable the open
+  // actions with a "host only" hint rather than offering links that can't work.
+  const remote = $derived(!$accessMode.loopback);
 
   function localDetailLabel(s: Service): string {
     if (s.queue_site) return m.services_labels_queueWorker();
@@ -214,32 +220,39 @@
       });
     }
 
+    // Strip the click/link and grey out an open action when the dashboard is
+    // viewed remotely: the target is a loopback-only localhost URL.
+    const openAct = (a: ButtonMenuAction): ButtonMenuAction =>
+      remote
+        ? { id: a.id, tone: a.tone, icon: a.icon, disabled: true, label: `${a.label} · ${m.services_hostOnly()}`, title: m.services_hostOnly() }
+        : a;
+
     if (active && admin) {
       const adminLabel = m.services_openAdmin({ name: serviceLabel(admin.name) });
-      rest.push({
+      rest.push(openAct({
         id: 'admin',
         tone: 'info',
         icon: icons.external,
         label: adminLabel,
         title: adminLabel,
         onclick: openAdmin
-      });
+      }));
     } else if (active && svc.dashboard) {
-      rest.push({
+      rest.push(openAct({
         id: 'dashboard',
         icon: icons.external,
         label: m.services_dashboard(),
         title: m.services_dashboard(),
         onclick: () => openDashboard(svc)
-      });
+      }));
     } else if (active && svc.connection_url) {
-      rest.push({
+      rest.push(openAct({
         id: 'connection',
         icon: icons.external,
         label: m.services_openConnection(),
         title: svc.connection_url,
         href: svc.connection_url
-      });
+      }));
     }
 
     if (!isWorker && !active && !updating) {

--- a/internal/ui/web/src/tabs/sites/AppLogsTab.svelte
+++ b/internal/ui/web/src/tabs/sites/AppLogsTab.svelte
@@ -127,7 +127,7 @@
 </script>
 
 <div class="flex-1 flex flex-col overflow-hidden min-h-0">
-  <div class="flex items-center gap-2 px-3 py-2 shrink-0 border-b border-gray-100 dark:border-lerd-border">
+  <div class="flex flex-wrap items-center gap-2 px-3 py-2 shrink-0 border-b border-gray-100 dark:border-lerd-border">
     {#if files.length > 0}
       <Dropdown
         value={selectedFile}
@@ -164,7 +164,7 @@
       </svg>
     {/if}
 
-    <div class="relative flex-1">
+    <div class="relative flex-1 min-w-[7rem]">
       <svg class="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
       </svg>

--- a/internal/ui/web/src/tabs/sites/SiteHeader.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteHeader.svelte
@@ -128,6 +128,18 @@
   const useTLS = $derived(Boolean(site.tls));
   const scheme = $derived(useTLS ? 'https://' : 'http://');
 
+  // On a remote (non-loopback) dashboard the site's .test domain doesn't
+  // resolve, so the open action targets the LAN share URL instead. When the
+  // site isn't shared yet the primary button flips to a share action, since
+  // there is nothing openable off-host until it is. Loopback is unchanged.
+  const remoteView = $derived(!$accessMode.loopback);
+  const primaryShare = $derived(remoteView && !lanOn && !site.paused);
+  const showLanToggle = $derived(!site.paused && ($accessMode.loopback || lanOn));
+
+  function openTarget() {
+    openSiteInBrowser(site, activeWorktreeBranch, remoteView && lanOn && lanURL ? lanURL : undefined);
+  }
+
   async function togglePause() {
     pauseBusy = true;
     try {
@@ -208,8 +220,8 @@
 
 <div class="border-b border-gray-100 dark:border-lerd-border shrink-0 @container flex flex-col">
   {#if showWorktreeTabs}
-    <div class="flex items-end bg-gray-50/60 dark:bg-white/[0.02]">
-      <div class="flex items-center gap-0.5 px-3 pt-3 overflow-x-auto flex-1 min-w-0">
+    <div class="flex flex-col-reverse @md:flex-row @md:items-end bg-gray-50/60 dark:bg-white/[0.02]">
+      <div class="flex items-center gap-0.5 px-3 pt-3 overflow-x-auto @md:flex-1 min-w-0">
       {#each tabEntries as e (e.isMain ? '__main__' : e.branch)}
         {@const isActive = e.isMain ? activeWorktreeBranch === '' : e.branch === activeWorktreeBranch}
         <div
@@ -286,8 +298,8 @@
       {/if}
       </div>
       {#if activePath}
-        <div class="shrink-0 pl-2 pr-3 pb-2 flex items-center text-[11px] leading-none text-gray-500 dark:text-gray-400 min-w-0">
-          <span class="font-mono leading-none truncate max-w-[22rem]" title={activePath}>{activePath}</span>
+        <div class="@md:shrink-0 px-3 pt-2 pb-1 @md:pt-0 @md:pb-2 @md:pl-2 @md:pr-3 flex items-center text-[11px] leading-none text-gray-500 dark:text-gray-400 min-w-0">
+          <span class="font-mono leading-none truncate max-w-full @md:max-w-[22rem]" title={activePath}>{activePath}</span>
         </div>
       {/if}
     </div>
@@ -436,7 +448,7 @@
 
       <span class="flex items-center gap-1.5 shrink-0">
         {#if activeFrameworkLabel}
-          <Badge tone="framework">{activeFrameworkLabel}</Badge>
+          <span class="hidden @md:inline-flex"><Badge tone="framework">{activeFrameworkLabel}</Badge></span>
         {/if}
         {#if lanOn && lanURL}
           <span class="hidden @md:inline-flex items-center gap-1 text-[10px] text-teal-600 dark:text-teal-400">
@@ -479,24 +491,46 @@
     </div>
 
     <div class="flex items-center shrink-0">
-      <button
-        type="button"
-        onclick={() => openSiteInBrowser(site, activeWorktreeBranch)}
-        aria-label={m.common_open()}
-        use:tooltip={m.common_open() + ' — ' + activeDomain}
-        class="w-8 h-8 flex items-center justify-center rounded-md text-gray-500 dark:text-gray-400 hover:text-lerd-red hover:bg-gray-100 dark:hover:bg-white/5 transition-colors"
-      >
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-          />
-        </svg>
-      </button>
+      {#if primaryShare}
+        <button
+          type="button"
+          onclick={flipLAN}
+          disabled={lanBusy}
+          aria-label={m.sites_controls_lanToggle_off()}
+          use:tooltip={m.sites_controls_lanToggle_off()}
+          class="w-8 h-8 flex items-center justify-center rounded-md text-gray-500 dark:text-gray-400 hover:text-lerd-red hover:bg-gray-100 dark:hover:bg-white/5 transition-colors disabled:opacity-50"
+        >
+          {#if lanBusy}
+            <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+            </svg>
+          {:else}
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+              <path d="M5 12.55a11 11 0 0114 0M8.5 16.5a5 5 0 017 0M2 8.82a15 15 0 0120 0M12 20h.01" />
+            </svg>
+          {/if}
+        </button>
+      {:else}
+        <button
+          type="button"
+          onclick={openTarget}
+          aria-label={m.common_open()}
+          use:tooltip={m.common_open() + ' — ' + (remoteView && lanOn && lanURL ? lanURL : activeDomain)}
+          class="w-8 h-8 flex items-center justify-center rounded-md text-gray-500 dark:text-gray-400 hover:text-lerd-red hover:bg-gray-100 dark:hover:bg-white/5 transition-colors"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+            />
+          </svg>
+        </button>
+      {/if}
 
-      {#if !site.paused}
+      {#if showLanToggle}
         <button
           type="button"
           onclick={flipLAN}
@@ -689,7 +723,7 @@
                 {m.sites_manageDomains()}
               </button>
             {/if}
-            {#if !site.paused}
+            {#if showLanToggle}
               <button
                 type="button"
                 role="menuitem"
@@ -704,6 +738,25 @@
                   <path d="M5 12.55a11 11 0 0114 0M8.5 16.5a5 5 0 017 0M2 8.82a15 15 0 0120 0M12 20h.01" />
                 </svg>
                 {lanOn ? m.sites_controls_lanToggle_on() : m.sites_controls_lanToggle_off()}
+              </button>
+            {/if}
+            {#if showXdebug && !site.paused}
+              <button
+                type="button"
+                role="menuitem"
+                onclick={() => {
+                  overflowOpen = false;
+                  toggleXdebug();
+                }}
+                disabled={xdebugBusy}
+                class="@md:hidden w-full px-3 py-1.5 text-xs text-left flex items-center gap-2 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors disabled:opacity-50 {xdebugEnabled ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-700 dark:text-gray-200'}"
+              >
+                <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+                  <path d="m8 2 1.88 1.88M14.12 3.88 16 2M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" />
+                  <path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6zM12 20v-9" />
+                  <path d="M6.53 9C4.6 8.8 3 7.1 3 5M6 13H2M3 21c0-2.1 1.7-3.9 3.8-4M20.97 5c0 2.1-1.6 3.8-3.5 4M22 13h-4M17.2 17c2.1.1 3.8 1.9 3.8 4" />
+                </svg>
+                {xdebugEnabled ? m.sites_badges_xdebugOn({ mode: xdebugMode }) : m.sites_badges_xdebugDisabled()}
               </button>
             {/if}
             {#if !site.paused || !activeWorktreeBranch}
@@ -734,6 +787,15 @@
       </div>
     </div>
   </div>
+
+  {#if lanOn && lanURL}
+    <div class="@md:hidden px-3 pb-2 flex items-center gap-1.5 text-[11px] text-teal-600 dark:text-teal-400 min-w-0">
+      <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
+        <path d="M5 12.55a11 11 0 0114 0M8.5 16.5a5 5 0 017 0M2 8.82a15 15 0 0120 0M12 20h.01" />
+      </svg>
+      <LANShareLink domain={lanDomain} url={lanURL} siteDomain={site.domain} branch={activeWorktreeBranch} />
+    </div>
+  {/if}
 
   {#if activePath && !showWorktreeTabs}
     <div class="px-2 pb-2 flex items-center text-[11px] text-gray-500 dark:text-gray-400 min-w-0">


### PR DESCRIPTION
The dashboard picked up a set of rough edges once it was driven from a phone or over a shared LAN dashboard rather than on the host, and this smooths them over.

On mobile the app log toolbar now wraps so its refresh and clear buttons stop being clipped off the right edge, the back bar is slimmer, and the worktree tabs no longer fight the project path for width, the path moves to its own line above them. The address bar hides the framework badge on narrow screens so the site domain actually has room to show, and when a site is shared it surfaces the LAN URL on its own row. Xdebug, which had no room left in the bar, now lives in the overflow menu alongside the other folded actions.

The site open action is aware of where it is opened from. On a remote dashboard the site's .test domain does not resolve, so open now targets the LAN share URL when the site is shared and turns into a share over LAN action when it is not. On the host it is unchanged and still opens the .test domain.

Tinker no longer zooms the page when the editor is focused on iOS, the hidden input that captures keystrokes is bumped to sixteen pixels on touch so Safari leaves the viewport alone, and the editor now sizes itself to the visual viewport above the on screen keyboard so the autocomplete popup tracks the caret instead of floating off the top.

Finally the remote dashboard stops surfacing things that only work on the host. Service dashboard links, which point at loopback localhost URLs, are disabled with a host only hint instead of being dead links, and the loopback-only launchers for the profiler and the per-service dashboards drop out of the left rail and the mobile apps view when the dashboard is viewed remotely.

Closes #784