### PR TITLE
fix: harden the macOS machine heal, DNS teardown, and CA trust check

### DIFF
--- a/internal/certs/ca_trust.go
+++ b/internal/certs/ca_trust.go
@@ -20,6 +20,11 @@ var caTrustPaths = []string{
 	"/etc/ssl/cert.pem",                  // openSUSE and others
 }
 
+// platformTrustCheck reports whether der is trusted through a non-bundle store.
+// The darwin build wires it to a keychain lookup (mkcert installs its root
+// there, not in a PEM bundle); nil on Linux, where caTrustPaths is authoritative.
+var platformTrustCheck func(der []byte) bool
+
 // caRootFunc resolves mkcert's CAROOT directory. Overridable in tests.
 var caRootFunc = func() (string, error) {
 	out, err := exec.Command(MkcertPath(), "-CAROOT").Output()
@@ -45,6 +50,9 @@ func CATrusted() bool {
 		if bundleContainsDER(readFileNoErr(p), der) {
 			return true
 		}
+	}
+	if platformTrustCheck != nil {
+		return platformTrustCheck(der)
 	}
 	return false
 }

--- a/internal/certs/ca_trust_darwin.go
+++ b/internal/certs/ca_trust_darwin.go
@@ -1,0 +1,21 @@
+//go:build darwin
+
+package certs
+
+import "os/exec"
+
+// keychainCertsPEM dumps every certificate in the keychain search list as
+// concatenated PEM. Overridable in tests.
+var keychainCertsPEM = func() []byte {
+	out, _ := exec.Command("security", "find-certificate", "-a", "-p").Output()
+	return out
+}
+
+// mkcert installs its root into the keychain, not the PEM bundles caTrustPaths
+// scans, so on macOS the trust check runs against the keychain dump. The same
+// DER-equality match as the bundle path handles the headers `security` prints.
+func init() {
+	platformTrustCheck = func(der []byte) bool {
+		return bundleContainsDER(keychainCertsPEM(), der)
+	}
+}

--- a/internal/certs/ca_trust_darwin_test.go
+++ b/internal/certs/ca_trust_darwin_test.go
@@ -1,0 +1,35 @@
+//go:build darwin
+
+package certs
+
+import "testing"
+
+// On macOS the trust check must consult the keychain, since mkcert never writes
+// into the Linux PEM bundles caTrustPaths lists.
+func TestCATrustedDarwinKeychain(t *testing.T) {
+	origRoot, origPaths, origKC, origPlat := caRootFunc, caTrustPaths, keychainCertsPEM, platformTrustCheck
+	t.Cleanup(func() {
+		caRootFunc, caTrustPaths, keychainCertsPEM, platformTrustCheck = origRoot, origPaths, origKC, origPlat
+	})
+	platformTrustCheck = func(der []byte) bool { return bundleContainsDER(keychainCertsPEM(), der) }
+
+	caDir := t.TempDir()
+	certPEM := writeTestCA(t, caDir)
+	caRootFunc = func() (string, error) { return caDir, nil }
+	caTrustPaths = nil // no Linux bundles: the keychain is the only trust source
+
+	t.Run("present in keychain", func(t *testing.T) {
+		keychainCertsPEM = func() []byte { return append([]byte("# anchor\n"), certPEM...) }
+		if !CATrusted() {
+			t.Fatal("expected CA reported trusted when present in the keychain")
+		}
+	})
+
+	t.Run("absent from keychain", func(t *testing.T) {
+		other := writeTestCA(t, t.TempDir()) // a different CA
+		keychainCertsPEM = func() []byte { return other }
+		if CATrusted() {
+			t.Fatal("expected CA reported not trusted when absent from the keychain")
+		}
+	})
+}

--- a/internal/certs/ca_trust_test.go
+++ b/internal/certs/ca_trust_test.go
@@ -41,8 +41,10 @@ func writeTestCA(t *testing.T, dir string) []byte {
 }
 
 func TestCATrusted(t *testing.T) {
-	origRoot, origPaths := caRootFunc, caTrustPaths
-	t.Cleanup(func() { caRootFunc, caTrustPaths = origRoot, origPaths })
+	origRoot, origPaths, origPlat := caRootFunc, caTrustPaths, platformTrustCheck
+	t.Cleanup(func() { caRootFunc, caTrustPaths, platformTrustCheck = origRoot, origPaths, origPlat })
+	// Exercise the bundle logic in isolation; the keychain path has its own test.
+	platformTrustCheck = nil
 
 	caDir := t.TempDir()
 	certPEM := writeTestCA(t, caDir)

--- a/internal/cli/install_dns_darwin.go
+++ b/internal/cli/install_dns_darwin.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/dns"
 	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
@@ -176,4 +177,7 @@ func teardownDNS() {
 	_ = services.Mgr.RemoveServiceUnit("lerd-dns")
 	// Defensive: if a legacy container plist is still around, clear that too.
 	_ = services.Mgr.RemoveContainerUnit("lerd-dns")
+	// Remove the /etc/resolver files lerd wrote so a disabled setup doesn't leave
+	// a resolver pointing at the dnsmasq we just tore down.
+	dns.Teardown()
 }

--- a/internal/cli/machine_bounded_darwin.go
+++ b/internal/cli/machine_bounded_darwin.go
@@ -1,0 +1,48 @@
+//go:build darwin
+
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// A podman machine subcommand blocks forever when the VM is wedged (post-sleep
+// freeze). The self-heal runs on the hot path (FPM start, DNS watcher), so each
+// subcommand is context-bounded to kill the child at its deadline. init and set
+// stay unbounded: a first-run image pull is long and a config edit is instant.
+const (
+	machineQueryTimeout = 30 * time.Second // list, inspect
+	machineStopTimeout  = 90 * time.Second
+	machineStartTimeout = 3 * time.Minute
+)
+
+// machineCmdContext builds a context-bound podman command. A package var so
+// darwin tests can substitute a fake process to exercise the timeout path.
+var machineCmdContext = func(ctx context.Context, args ...string) *exec.Cmd {
+	return podman.CmdContext(ctx, args...)
+}
+
+// machineQuery runs a read-only podman machine query (list, inspect), bounded by
+// machineQueryTimeout, and returns its stdout.
+func machineQuery(args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), machineQueryTimeout)
+	defer cancel()
+	return machineCmdContext(ctx, args...).Output()
+}
+
+// runMachineStreaming runs a podman machine subcommand (stop, start) bounded by
+// timeout, streaming its output. On timeout the context terminates the process
+// so a wedged VM can't hang the caller.
+func runMachineStreaming(timeout time.Duration, args ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := machineCmdContext(ctx, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/cli/machine_bounded_darwin_test.go
+++ b/internal/cli/machine_bounded_darwin_test.go
@@ -1,0 +1,47 @@
+//go:build darwin
+
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestMachineHelperProcess is the child spawned by the fake machineCmdContext.
+// It sleeps far longer than any test timeout so the parent's context deadline is
+// what ends it, proving the bound terminates a wedged command.
+func TestMachineHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_MACHINE_HELPER") != "1" {
+		return
+	}
+	time.Sleep(30 * time.Second)
+	os.Exit(0)
+}
+
+func fakeHungMachineCmd(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestMachineHelperProcess", "--")
+	cmd.Env = append(os.Environ(), "GO_WANT_MACHINE_HELPER=1")
+	return cmd
+}
+
+// runMachineStreaming must return promptly when the underlying command hangs,
+// instead of blocking the hot path (FPM start, DNS watcher) on a wedged VM.
+func TestRunMachineStreamingBoundsAHungCommand(t *testing.T) {
+	prev := machineCmdContext
+	t.Cleanup(func() { machineCmdContext = prev })
+	machineCmdContext = fakeHungMachineCmd
+
+	start := time.Now()
+	err := runMachineStreaming(200*time.Millisecond, "machine", "stop", "x")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error when the machine command is killed by the deadline")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("runMachineStreaming took %v; expected it to return near the 200ms bound", elapsed)
+	}
+}

--- a/internal/cli/overlay_heal_darwin.go
+++ b/internal/cli/overlay_heal_darwin.go
@@ -3,10 +3,7 @@
 package cli
 
 import (
-	"os"
-
 	"github.com/geodro/lerd/internal/feedback"
-	"github.com/geodro/lerd/internal/podman"
 )
 
 // healOverlayCorruptionIfNeeded recovers from the overlay-storage error (see
@@ -37,10 +34,7 @@ func restartPodmanMachineForHeal() {
 		return
 	}
 	feedback.Line("Container storage looks stale after an unclean shutdown; restarting the Podman Machine to remount it…")
-	stop := podman.Cmd("machine", "stop", name)
-	stop.Stdout = os.Stdout
-	stop.Stderr = os.Stderr
-	if err := stop.Run(); err != nil {
+	if err := runMachineStreaming(machineStopTimeout, "machine", "stop", name); err != nil {
 		feedback.Warn("podman machine stop: %v", err)
 	}
 	// ensurePodmanMachineRunning starts the VM and waits for the API socket.

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -196,7 +196,7 @@ func recreateBrokenMachine(name string, running bool, targetMemoryMiB int64) {
 // failures from every command that follows.
 func ensurePodmanMachineRunning() error {
 	// machine list only exposes Name and Running; use inspect for Rootful.
-	listOut, _ := podman.Cmd("machine", "list", "--format", "{{.Name}}\t{{.Running}}").Output()
+	listOut, _ := machineQuery("machine", "list", "--format", "{{.Name}}\t{{.Running}}")
 
 	type machineInfo struct {
 		name    string
@@ -225,7 +225,7 @@ func ensurePodmanMachineRunning() error {
 
 		// Inspect to get Rootful status.
 		rootful := false
-		inspectOut, err := podman.Cmd("machine", "inspect", "--format", "{{.Rootful}}", name).Output()
+		inspectOut, err := machineQuery("machine", "inspect", "--format", "{{.Rootful}}", name)
 		if err == nil {
 			rootful = strings.TrimSpace(string(inspectOut)) == "true"
 		}
@@ -280,8 +280,8 @@ func ensurePodmanMachineRunning() error {
 		} else {
 			needsRootful := !m.rootful
 			needsMemory := false
-			if inspectMem, err := podman.Cmd("machine", "inspect",
-				"--format", "{{.Resources.Memory}}", m.name).Output(); err == nil {
+			if inspectMem, err := machineQuery("machine", "inspect",
+				"--format", "{{.Resources.Memory}}", m.name); err == nil {
 				if memMiB, parseErr := strconv.ParseInt(strings.TrimSpace(string(inspectMem)), 10, 64); parseErr == nil && memMiB > 0 {
 					if memMiB < targetMemoryMiB {
 						needsMemory = true
@@ -300,10 +300,7 @@ func ensurePodmanMachineRunning() error {
 					}
 					reason := strings.Join(parts, " and ")
 					feedback.Line(fmt.Sprintf("Stopping Podman Machine to %s…", reason))
-					stopCmd := podman.Cmd("machine", "stop", m.name)
-					stopCmd.Stdout = os.Stdout
-					stopCmd.Stderr = os.Stderr
-					stopCmd.Run() //nolint:errcheck
+					_ = runMachineStreaming(machineStopTimeout, "machine", "stop", m.name)
 				}
 				if needsRootful {
 					feedback.Line("Enabling rootful mode for Podman Machine (required for ports 80/443)…")
@@ -370,10 +367,7 @@ func ensurePodmanMachineRunning() error {
 // podman command cascade into confusing "exit status 125" errors.
 func startPodmanMachineWithRetry() error {
 	run := func() error {
-		cmd := podman.Cmd("machine", "start")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		return cmd.Run()
+		return runMachineStreaming(machineStartTimeout, "machine", "start")
 	}
 
 	err := run()

--- a/internal/dns/setup_darwin.go
+++ b/internal/dns/setup_darwin.go
@@ -3,6 +3,7 @@
 package dns
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,15 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
 )
+
+// resolverDir is the macOS per-TLD resolver directory. A var so tests can point
+// the stale-file scan at a fixture.
+var resolverDir = "/etc/resolver"
+
+// resolverContent is what ConfigureResolver writes into /etc/resolver/<tld>: it
+// routes .<tld> queries at the lerd-dns dnsmasq container. Teardown matches on it
+// so it removes exactly the resolver files lerd created.
+var resolverContent = []byte("nameserver 127.0.0.1\nport 5300\n")
 
 // readUpstreamDNS reads upstream DNS servers from /etc/resolv.conf.
 // On macOS the OS keeps /etc/resolv.conf up-to-date with DHCP-assigned DNS servers,
@@ -41,8 +51,8 @@ func ConfigureResolver() error {
 		tld = "test"
 	}
 
-	resolverFile := filepath.Join("/etc/resolver", tld)
-	content := []byte("nameserver 127.0.0.1\nport 5300\n")
+	resolverFile := filepath.Join(resolverDir, tld)
+	content := resolverContent
 
 	if isFileContent(resolverFile, content) {
 		return nil
@@ -52,22 +62,42 @@ func ConfigureResolver() error {
 	return sudoWriteFile(resolverFile, content, 0644)
 }
 
-// Teardown removes the /etc/resolver/<tld> file written by ConfigureResolver.
+// Teardown removes every /etc/resolver file lerd wrote (matched by content) so
+// disabling DNS never orphans a resolver pointing at the torn-down dnsmasq.
+// Content-matching beats the config TLD: disable flips cfg.DNS.TLD first, so it
+// no longer names the file to remove, and a custom TLD leaves its own to clean.
 func Teardown() {
-	cfg, _ := config.LoadGlobal()
-	tld := "test"
-	if cfg != nil && cfg.DNS.TLD != "" {
-		tld = cfg.DNS.TLD
+	stale := staleResolverFiles(resolverDir)
+	if len(stale) == 0 {
+		return
 	}
+	rmCmd := exec.Command("sudo", append([]string{"rm", "-f"}, stale...)...)
+	rmCmd.Stdin = os.Stdin
+	rmCmd.Stdout = os.Stdout
+	rmCmd.Stderr = os.Stderr
+	rmCmd.Run() //nolint:errcheck
+}
 
-	resolverFile := filepath.Join("/etc/resolver", tld)
-	if _, err := os.Stat(resolverFile); err == nil {
-		rmCmd := exec.Command("sudo", "rm", "-f", resolverFile)
-		rmCmd.Stdin = os.Stdin
-		rmCmd.Stdout = os.Stdout
-		rmCmd.Stderr = os.Stderr
-		rmCmd.Run() //nolint:errcheck
+// staleResolverFiles returns the resolver files under dir whose content matches
+// what ConfigureResolver writes, so Teardown removes exactly those and leaves a
+// user's or another tool's resolver files untouched.
+func staleResolverFiles(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
 	}
+	want := bytes.TrimSpace(resolverContent)
+	var stale []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		if body, rerr := os.ReadFile(path); rerr == nil && bytes.Equal(bytes.TrimSpace(body), want) {
+			stale = append(stale, path)
+		}
+	}
+	return stale
 }
 
 // InstallSudoers writes a sudoers drop-in granting the current user passwordless

--- a/internal/dns/setup_darwin_test.go
+++ b/internal/dns/setup_darwin_test.go
@@ -1,0 +1,55 @@
+//go:build darwin
+
+package dns
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// staleResolverFiles must return exactly the resolver files lerd wrote (matched
+// by content, across TLDs) and leave a user's or another tool's resolver files
+// and subdirectories alone.
+func TestStaleResolverFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name string, body []byte) {
+		if err := os.WriteFile(filepath.Join(dir, name), body, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("test", resolverContent)                           // canonical lerd TLD
+	write("app", resolverContent)                            // preserved custom lerd TLD
+	write("test-trailing", append(resolverContent, '\n'))    // lerd content + stray newline
+	write("corp", []byte("nameserver 10.0.0.53\nport 53\n")) // foreign, must survive
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := staleResolverFiles(dir)
+	sort.Strings(got)
+
+	want := []string{
+		filepath.Join(dir, "app"),
+		filepath.Join(dir, "test"),
+		filepath.Join(dir, "test-trailing"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("staleResolverFiles = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("staleResolverFiles = %v, want %v", got, want)
+		}
+	}
+}
+
+// A missing resolver directory is not an error: Teardown on a host that never
+// configured DNS must be a no-op.
+func TestStaleResolverFilesMissingDir(t *testing.T) {
+	if got := staleResolverFiles(filepath.Join(t.TempDir(), "does-not-exist")); got != nil {
+		t.Fatalf("expected nil for a missing dir, got %v", got)
+	}
+}

--- a/internal/freeport/freeport_test.go
+++ b/internal/freeport/freeport_test.go
@@ -20,12 +20,12 @@ func TestBindable_falseForBoundPort(t *testing.T) {
 }
 
 // TestBindable_falseForAllInterfacesBoundPort: a server listening on all
-// interfaces must read as not bindable. Go binds every wildcard string
-// ("0.0.0.0:0", ":0", "[::]:0") as a dual-stack [::] socket — the shape gvproxy
-// uses to publish a container's port on macOS and that a DB configured to listen
-// on all interfaces (bind-address *, listen_addresses '*') takes. A
-// specific-loopback probe alone slips past it under SO_REUSEADDR on macOS and
-// lets lerd publish a container on the same port; the wildcard probe catches it.
+// interfaces must read as not bindable. Go binds "0.0.0.0:0" as an IPv4
+// all-interfaces (AF_INET) socket and "[::]:0" as a dual-stack [::] socket; a DB
+// configured to listen on all interfaces (bind-address *, listen_addresses '*')
+// or gvproxy publishing a container's port on macOS takes one of these shapes. A
+// specific-loopback probe alone slips past them under SO_REUSEADDR on macOS and
+// lets lerd publish a container on the same port; the wildcard probes catch it.
 // Both wildcard spellings are exercised so the coverage is explicit.
 func TestBindable_falseForAllInterfacesBoundPort(t *testing.T) {
 	for _, spec := range []string{"0.0.0.0:0", "[::]:0"} {


### PR DESCRIPTION
On macOS a wedged Podman Machine (the classic post-sleep freeze where the VM and gvproxy are suspended) could hang the caller because the self-heal shelled podman machine stop and start with no timeout, and that heal now runs on the hot path through EnsureMachineResponsive. Every wedge-prone machine subcommand is now bounded by a context deadline, so a stalled VM fails fast instead of freezing the FPM start pass or the DNS watcher.

Disabling DNS left an orphaned /etc/resolver file pointing at the dnsmasq that was just torn down, because the darwin teardown never removed it and the removal that did exist keyed on a TLD the disable flow had already flipped away. Teardown now removes every resolver file lerd wrote, matched by its content rather than the configured TLD, so it cleans the right files across a canonical or custom TLD, and the darwin teardown path actually invokes it.

The mkcert CA trust check only scanned the Linux trust bundles, so on macOS it always reported the CA as untrusted even when it was installed in the keychain, and the install and update flows kept reprinting the mkcert announcement on every run. The check now consults the keychain on macOS.

Refs #790