### PR TITLE
fix: correctness and safety follow-ups from the v1.27 review

### DIFF
--- a/docs/usage/cleanup.md
+++ b/docs/usage/cleanup.md
@@ -15,7 +15,7 @@ By default (and automatically) cleanup reclaims everything below. Pass `--safe` 
 
 **Unused service images** (the deep tier, default):
 
-- A service image no installed service references any more, e.g. an old `mysql:8.0` after you upgraded to `8.4`. Each service's **current image and its one-back rollback target are kept**, so a rollback still works.
+- A service image **lerd itself pulled** that no installed service references any more, e.g. an old `mysql:8.0` after you upgraded to `8.4`. Each service's **current image and its one-back rollback target are kept**, so a rollback still works. lerd records every image it pulls, so a catalog image you pulled yourself for another project (a `redis` or `postgres` for a non-lerd stack) is never in scope, even though it shares a repo with a lerd service.
 
 **Dangling images** (the deep tier, default):
 
@@ -25,9 +25,10 @@ By default (and automatically) cleanup reclaims everything below. Pass `--safe` 
 
 - **Named data volumes** — your databases are never in scope.
 - **Any tagged image in use** — an image a running container uses, and each installed service's current image and one-back rollback target, are always kept.
+- **A tagged image lerd didn't pull** — a `mysql`, `redis`, `postgres` (or any catalog repo) you pulled yourself is kept, because the reap only removes service images lerd's own pull recorded. Sharing a repo with a lerd service is not enough to make it a target.
 - With **`--safe`**, only images provably built by lerd (a `dev.lerd.*` label or the `lerd-php*-fpm-base` repo name) are removed, and nothing else is touched at all.
 
-The default reaches further than `--safe` in one place: it also removes **dangling** (untagged) images. That is deliberately safe, a dangling image is unreferenced by definition, so nothing depends on it. On a machine that also runs podman for non-lerd projects, that means the default reclaims their untagged leftovers too; use `--safe` there if you want cleanup scoped strictly to lerd. Removal is reference-count safe throughout: shared layers stay on disk, and an image that turns out to be in use is skipped rather than forced.
+The default reaches further than `--safe` in one place: it also removes **dangling** (untagged) images. That is deliberately safe, a dangling image is unreferenced by definition, so nothing depends on it. On a machine that also runs podman for non-lerd projects, that means the interactive `lerd cleanup` reclaims their untagged leftovers too (the unattended daily sweep never does); use `--safe` there if you want cleanup scoped strictly to lerd. Tagged images are unaffected either way, only lerd's own pulls are in scope. Removal is reference-count safe throughout: shared layers stay on disk, and an image that turns out to be in use is skipped rather than forced.
 
 ## Commands
 

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -220,7 +220,7 @@ func Inspect(scope Scope) (Plan, error) {
 		repos, repoErr := serviceRepos()
 		prot, protErr := protectedImages()
 		if repoErr == nil && protErr == nil {
-			p.Targets = append(p.Targets, deepTargets(imgs, repos, prot)...)
+			p.Targets = append(p.Targets, deepTargets(imgs, repos, prot, canonPulled())...)
 		}
 	}
 	// podman lists a multi-tag image once per tag, so dedupe by ref/ID to avoid

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -3,6 +3,8 @@ package cleanup
 import (
 	"errors"
 	"testing"
+
+	"github.com/geodro/lerd/internal/imgledger"
 )
 
 // withImages swaps the image-scan and layer-inspect seams for fixtures and
@@ -19,9 +21,13 @@ func withImages(t *testing.T, imgs []image, layers map[string][]string) {
 		}
 		return m, nil
 	}
+	// Default to an empty ledger so a test that doesn't care never reads the real
+	// on-disk file; catalog-reap tests override this after calling withImages.
+	loadPulledImages = func() map[string]bool { return map[string]bool{} }
 	t.Cleanup(func() {
 		scanImages = podmanImages
 		imageLayers = podmanImageLayers
+		loadPulledImages = imgledger.Load
 	})
 }
 
@@ -126,6 +132,9 @@ func TestInspect_ManagedReapsCatalogNotForeignDangling(t *testing.T) {
 	protectedImages = func() (map[string]bool, error) {
 		return map[string]bool{"docker.io/library/mysql:8.4": true}, nil
 	}
+	loadPulledImages = func() map[string]bool {
+		return map[string]bool{"docker.io/library/mysql:5.7": true}
+	}
 	t.Cleanup(func() {
 		serviceRepos = realServiceRepos
 		protectedImages = realProtectedImages
@@ -156,6 +165,43 @@ func TestInspect_ManagedReapsCatalogNotForeignDangling(t *testing.T) {
 	}
 	if !deepGot["docker.io/library/mysql:5.7"] || !deepGot["foreign"] {
 		t.Errorf("deep tier should reap both the catalog leftover and the foreign dangling image, got %+v", deep.Targets)
+	}
+}
+
+// A tagged catalog image lerd never pulled (the user pulled it themselves for an
+// unrelated project) must be left alone even though its repo is in the catalog and
+// nothing lerd runs references it. The ledger is what separates lerd's own
+// leftovers from the user's own images sharing a catalog repo.
+func TestInspect_ManagedSparesCatalogImageLerdNeverPulled(t *testing.T) {
+	withImages(t, []image{
+		{ID: "r6", Names: []string{"docker.io/library/redis:6"}, Size: 300}, // user's own pull
+		{ID: "r7", Names: []string{"docker.io/library/redis:7"}, Size: 300}, // lerd's leftover
+	}, nil)
+	serviceRepos = func() (map[string]bool, error) {
+		return map[string]bool{"docker.io/library/redis": true}, nil
+	}
+	protectedImages = func() (map[string]bool, error) { return map[string]bool{}, nil }
+	loadPulledImages = func() map[string]bool {
+		return map[string]bool{"docker.io/library/redis:7": true}
+	}
+	t.Cleanup(func() {
+		serviceRepos = realServiceRepos
+		protectedImages = realProtectedImages
+	})
+
+	managed, err := Inspect(ScopeManaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, tg := range managed.Targets {
+		got[tg.ID] = true
+	}
+	if got["docker.io/library/redis:6"] {
+		t.Errorf("must not reap the user's own redis:6 that lerd never pulled, got %+v", managed.Targets)
+	}
+	if !got["docker.io/library/redis:7"] {
+		t.Errorf("should reap lerd's own recorded redis:7 leftover, got %+v", managed.Targets)
 	}
 }
 

--- a/internal/cleanup/deep.go
+++ b/internal/cleanup/deep.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/imgledger"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/registry"
 )
@@ -25,7 +26,24 @@ var (
 	// installedServiceImages is a seam so the short-circuit (config covers every
 	// candidate, so the per-quadlet image reads are skipped) is assertable.
 	installedServiceImages = realInstalledServiceImages
+
+	// loadPulledImages is the seam onto lerd's pull ledger: the catalog reap only
+	// removes a tagged image whose ref lerd recorded pulling, so a user's own copy
+	// of a catalog image lerd never touched is left alone.
+	loadPulledImages = imgledger.Load
 )
+
+// canonPulled canonicalises the ledger refs so they compare equal to the
+// canonicalised image names the reap inspects, regardless of short vs
+// fully-qualified form.
+func canonPulled() map[string]bool {
+	raw := loadPulledImages()
+	out := make(map[string]bool, len(raw))
+	for r := range raw {
+		out[canonRef(r)] = true
+	}
+	return out
+}
 
 // realReferencedImages returns the subset of candidates (keyed by canonical ref)
 // still used by a service config entry, a custom service, or an installed service
@@ -76,10 +94,10 @@ func realReferencedImages(candidates map[string]bool) map[string]bool {
 // behind after upgrading, while the protected set keeps the live image and the
 // one-back rollback target, and an image carrying any non-catalog tag (one the
 // user added themselves) is left entirely alone.
-func deepTargets(imgs []image, repos, protected map[string]bool) []Target {
+func deepTargets(imgs []image, repos, protected, pulled map[string]bool) []Target {
 	var out []Target
 	for _, img := range imgs {
-		refs := removableServiceRefs(img, repos, protected)
+		refs := removableServiceRefs(img, repos, protected, pulled)
 		// Remove every owned tag so the image actually frees on the last one;
 		// credit the reclaimable bytes once (on that last removal), since
 		// untagging the earlier aliases frees nothing on its own.
@@ -96,10 +114,11 @@ func deepTargets(imgs []image, repos, protected map[string]bool) []Target {
 
 // removableServiceRefs returns the tags to remove for an unused service image,
 // or nil to keep it. An image is removable only when EVERY one of its tags is an
-// unprotected catalog ref: a protected tag (current image or rollback target) or
-// a non-catalog tag the user added both mean "leave this whole image alone", so
-// cleanup never untags an image something else still relies on.
-func removableServiceRefs(img image, repos, protected map[string]bool) []string {
+// unprotected catalog ref AND lerd's ledger records having pulled it: a protected
+// tag (current image or rollback target), a non-catalog tag the user added, or an
+// image lerd never pulled all mean "leave this whole image alone", so cleanup
+// never untags an image the user owns or that something else still relies on.
+func removableServiceRefs(img image, repos, protected, pulled map[string]bool) []string {
 	// An image a container still holds can't be removed by podman, so keep it even
 	// when no service config references it (a container running a catalog image the
 	// config no longer names would otherwise be listed forever).
@@ -107,11 +126,18 @@ func removableServiceRefs(img image, repos, protected map[string]bool) []string 
 		return nil
 	}
 	refs := make([]string, 0, len(img.Names))
+	lerdPulled := false
 	for _, n := range img.Names {
 		if protected[canonRef(n)] || !repos[canonRepo(n)] {
 			return nil
 		}
+		if pulled[canonRef(n)] {
+			lerdPulled = true
+		}
 		refs = append(refs, n)
+	}
+	if !lerdPulled {
+		return nil
 	}
 	return refs
 }

--- a/internal/cleanup/deep_test.go
+++ b/internal/cleanup/deep_test.go
@@ -21,8 +21,9 @@ func TestDeepTargets_ReapsUnusedServiceImagesKeepsProtected(t *testing.T) {
 		"docker.io/library/redis:7":            true,
 		"docker.io/library/redis:7.4.9-alpine": true,
 	}
+	pulled := map[string]bool{"docker.io/library/mysql:5.7": true}
 
-	got := deepTargets(imgs, repos, protected)
+	got := deepTargets(imgs, repos, protected, pulled)
 
 	if len(got) != 1 || got[0].ID != "docker.io/library/mysql:5.7" {
 		t.Fatalf("want only mysql:5.7 reaped, got %+v", got)
@@ -44,8 +45,9 @@ func TestDeepTargets_MultiTagRemovesAllTagsCreditsOnce(t *testing.T) {
 	}
 	repos := map[string]bool{"docker.io/library/mysql": true}
 	protected := map[string]bool{}
+	pulled := map[string]bool{"docker.io/library/mysql:5.7": true}
 
-	got := deepTargets(imgs, repos, protected)
+	got := deepTargets(imgs, repos, protected, pulled)
 
 	removed := map[string]int64{}
 	for _, tg := range got {
@@ -76,10 +78,25 @@ func TestDeepTargets_KeepsInUseServiceImage(t *testing.T) {
 	}
 	repos := map[string]bool{"docker.io/library/redis": true}
 
-	got := deepTargets(imgs, repos, map[string]bool{})
+	got := deepTargets(imgs, repos, map[string]bool{}, map[string]bool{})
 
 	if len(got) != 0 {
 		t.Fatalf("an in-use service image must be kept, got %+v", got)
+	}
+}
+
+// An unused catalog image lerd never recorded pulling is kept even by the deep
+// tier: the ledger, not the repo name, is what marks an image as lerd's to reap.
+func TestDeepTargets_KeepsCatalogImageLerdNeverPulled(t *testing.T) {
+	imgs := []image{
+		{Names: []string{"docker.io/library/redis:6"}, Size: 300},
+	}
+	repos := map[string]bool{"docker.io/library/redis": true}
+
+	got := deepTargets(imgs, repos, map[string]bool{}, map[string]bool{})
+
+	if len(got) != 0 {
+		t.Fatalf("a catalog image lerd never pulled must be kept, got %+v", got)
 	}
 }
 
@@ -95,6 +112,9 @@ func TestInspect_DeepAppendsUnusedServiceImages(t *testing.T) {
 	}
 	protectedImages = func() (map[string]bool, error) {
 		return map[string]bool{"docker.io/library/mysql:8.4": true}, nil
+	}
+	loadPulledImages = func() map[string]bool {
+		return map[string]bool{"docker.io/library/mysql:5.7": true}
 	}
 	t.Cleanup(func() {
 		serviceRepos = realServiceRepos

--- a/internal/cleanup/events_test.go
+++ b/internal/cleanup/events_test.go
@@ -64,6 +64,9 @@ func TestSweepDeep_ReapsUnusedServiceImages(t *testing.T) {
 	protectedImages = func() (map[string]bool, error) {
 		return map[string]bool{"docker.io/library/mysql:8.4": true}, nil
 	}
+	loadPulledImages = func() map[string]bool {
+		return map[string]bool{"docker.io/library/mysql:5.7": true}
+	}
 	var removed []string
 	removeImage = func(id string) error { removed = append(removed, id); return nil }
 	t.Cleanup(func() {

--- a/internal/cli/client_shims.go
+++ b/internal/cli/client_shims.go
@@ -103,14 +103,16 @@ func runShimsSet(tool string, enabled bool) error {
 // Both the postgres and mysql client families use -h / --host for the host.
 func argsSpecifyHost(args []string) bool {
 	for _, a := range args {
-		if a == "-h" || a == "--host" || strings.HasPrefix(a, "--host=") || (strings.HasPrefix(a, "-h") && len(a) > 2) {
+		// The glued short form is "-hHOST" with no whitespace; "-h note" (a space)
+		// is a -c/-e body that happens to start with -h, not a host flag.
+		gluedHost := strings.HasPrefix(a, "-h") && len(a) > 2 && !strings.ContainsAny(a, " \t")
+		if a == "-h" || a == "--host" || strings.HasPrefix(a, "--host=") || gluedHost {
 			return true
 		}
 		// A connection URI (scheme://…) or a libpq conninfo string carries its own
-		// host. A "host=" is only read as a conninfo key when the whole arg is
-		// key=value pairs, so a host= inside a SQL body (passed via -c/-e, whether
-		// spaced or inline) is never mistaken for one.
-		if isConnURI(a) || (strings.Contains(a, "host=") && looksLikeConninfo(a)) {
+		// host. Conninfo detection requires an actual "host" key, so a host= inside a
+		// SQL body (via -c/-e) or a "--where=host=x" filter is never mistaken for one.
+		if isConnURI(a) || looksLikeConninfo(a) {
 			return true
 		}
 	}
@@ -129,21 +131,27 @@ func isConnURI(a string) bool {
 	return false
 }
 
-// looksLikeConninfo reports whether a is a libpq conninfo string: every
-// whitespace-separated token is a key=value pair. A SQL query fails this on its
-// first bare word (SELECT, WHERE…), so it separates "host=db port=5432" from a
-// "WHERE host='x'" predicate without knowing the tool or its flags.
+// looksLikeConninfo reports whether a is a libpq conninfo string that names a
+// host: every whitespace-separated token is a key=value pair AND one token's key
+// is exactly "host". A SQL query fails the first test on its first bare word
+// (SELECT, WHERE…); a spaceless "--where=host=x" filter passes that but fails the
+// host-key test, since its only key is "--where". So neither is read as a host.
 func looksLikeConninfo(a string) bool {
 	fields := strings.Fields(a)
 	if len(fields) == 0 {
 		return false
 	}
+	hasHost := false
 	for _, f := range fields {
-		if i := strings.IndexByte(f, '='); i <= 0 {
+		i := strings.IndexByte(f, '=')
+		if i <= 0 {
 			return false
 		}
+		if f[:i] == "host" {
+			hasHost = true
+		}
 	}
-	return true
+	return hasHost
 }
 
 // hostEnvSet reports whether the caller pointed the tool at a host via the

--- a/internal/cli/client_shims_test.go
+++ b/internal/cli/client_shims_test.go
@@ -31,6 +31,12 @@ func TestArgsSpecifyHost(t *testing.T) {
 		// so a following -h is a real host and must still be detected.
 		{[]string{"-c", "-h", "prod.example.com", "mydb"}, true},
 		{[]string{"-e", "-h", "prod.example.com"}, true},
+		// A spaceless "--where=host=x" filter: its only key is --where, not host, so
+		// it must not be read as a conninfo host and suppress the local default.
+		{[]string{"mysqldump", "db", "t", "--where=host=x"}, false},
+		// A -c/-e body that merely starts with "-h" is not a glued host flag: the
+		// real glued form ("-hHOST") carries no whitespace.
+		{[]string{"-c", "-h note"}, false},
 	}
 	for _, c := range cases {
 		if got := argsSpecifyHost(c.args); got != c.want {

--- a/internal/imgledger/imgledger.go
+++ b/internal/imgledger/imgledger.go
@@ -1,0 +1,88 @@
+// Package imgledger records the container image refs lerd itself pulled. Podman
+// has no way to label an image in place, so the ledger is lerd's provenance
+// marker: cleanup reclaims lerd's own catalog leftovers while leaving an image
+// the user pulled independently that happens to share a catalog repo untouched.
+package imgledger
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+var mu sync.Mutex
+
+// pathFn is the seam tests override to redirect the ledger file.
+var pathFn = defaultPath
+
+func defaultPath() string {
+	return filepath.Join(config.DataDir(), "pulled-images.json")
+}
+
+// Record notes that lerd has pulled ref. Best-effort: a write failure only keeps
+// cleanup conservative (an unrecorded image is never reaped as lerd's), so the
+// pull path ignores the outcome.
+func Record(ref string) {
+	if ref == "" {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	set := load()
+	if set[ref] {
+		return
+	}
+	set[ref] = true
+	save(set)
+}
+
+// Load returns the set of refs lerd has recorded pulling. A missing or unreadable
+// ledger yields an empty set, so cleanup reaps nothing it can't prove is lerd's.
+func Load() map[string]bool {
+	mu.Lock()
+	defer mu.Unlock()
+	return load()
+}
+
+func load() map[string]bool {
+	set := map[string]bool{}
+	b, err := os.ReadFile(pathFn())
+	if err != nil {
+		return set
+	}
+	var refs []string
+	if json.Unmarshal(b, &refs) != nil {
+		return set
+	}
+	for _, r := range refs {
+		set[r] = true
+	}
+	return set
+}
+
+// save writes the ledger atomically (temp then rename) so a concurrent reader or
+// a mid-write crash can never see a truncated file.
+func save(set map[string]bool) {
+	refs := make([]string, 0, len(set))
+	for r := range set {
+		refs = append(refs, r)
+	}
+	sort.Strings(refs)
+	b, err := json.Marshal(refs)
+	if err != nil {
+		return
+	}
+	path := pathFn()
+	if os.MkdirAll(filepath.Dir(path), 0o755) != nil {
+		return
+	}
+	tmp := path + ".tmp"
+	if os.WriteFile(tmp, b, 0o644) != nil {
+		return
+	}
+	_ = os.Rename(tmp, path)
+}

--- a/internal/imgledger/imgledger_test.go
+++ b/internal/imgledger/imgledger_test.go
@@ -1,0 +1,58 @@
+package imgledger
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withTempLedger points the ledger at a throwaway file for the test.
+func withTempLedger(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pulled-images.json")
+	pathFn = func() string { return path }
+	t.Cleanup(func() { pathFn = defaultPath })
+	return path
+}
+
+func TestRecordAndLoad(t *testing.T) {
+	withTempLedger(t)
+
+	if got := Load(); len(got) != 0 {
+		t.Fatalf("fresh ledger should be empty, got %v", got)
+	}
+
+	Record("docker.io/library/mysql:8.4")
+	Record("docker.io/library/redis:7")
+	Record("docker.io/library/mysql:8.4") // duplicate is a no-op
+
+	got := Load()
+	if len(got) != 2 || !got["docker.io/library/mysql:8.4"] || !got["docker.io/library/redis:7"] {
+		t.Fatalf("want the two distinct refs, got %v", got)
+	}
+}
+
+// An empty ref is ignored, and a missing ledger file loads as empty rather than
+// erroring, so cleanup stays conservative when nothing has been recorded.
+func TestRecordEmptyAndMissingFile(t *testing.T) {
+	path := withTempLedger(t)
+
+	Record("")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("recording an empty ref must not create the ledger file")
+	}
+	if got := Load(); len(got) != 0 {
+		t.Errorf("missing ledger should load empty, got %v", got)
+	}
+}
+
+// A corrupt ledger loads as empty instead of propagating a parse error.
+func TestLoadCorruptFile(t *testing.T) {
+	path := withTempLedger(t)
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := Load(); len(got) != 0 {
+		t.Errorf("corrupt ledger should load empty, got %v", got)
+	}
+}

--- a/internal/podman/exec.go
+++ b/internal/podman/exec.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/imgledger"
 )
 
 // execCommand and execCommandContext are the single seam every podman
@@ -131,6 +132,9 @@ func runPull(image string, stdout, stderr io.Writer) error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("pulling %s: %w", image, err)
 	}
+	// Record the ref lerd pulled (platform-resolved, matching the stored image)
+	// so cleanup can tell its own catalog leftovers from images the user pulled.
+	imgledger.Record(PlatformImage(image))
 	return nil
 }
 

--- a/internal/podman/fpmports.go
+++ b/internal/podman/fpmports.go
@@ -9,8 +9,33 @@ import (
 )
 
 // fpmPortsBindable is the port-bindability probe, swapped in tests so the shift
-// guard can be exercised without binding real sockets.
-var fpmPortsBindable = freeport.Bindable
+// guard can be exercised without binding real sockets. The unit lifecycle calls
+// are seams for the same reason: the restart-rollback path is exercised without a
+// live podman.
+var (
+	fpmPortsBindable    = freeport.Bindable
+	fpmQuadletInstalled = QuadletInstalled
+	fpmUnitStatus       = UnitStatus
+	fpmWriteQuadlet     = WriteFPMQuadlet
+	fpmRestartUnit      = RestartUnit
+)
+
+// setVersionFPMPorts writes (or clears) a version's FPM port overrides on cfg,
+// pruning the map to nil when the last version is removed. Shared by the save and
+// its rollback so both persist the port list the same way.
+func setVersionFPMPorts(cfg *config.GlobalConfig, version string, ports []string) {
+	if len(ports) == 0 {
+		delete(cfg.PHP.FPMPorts, version)
+		if len(cfg.PHP.FPMPorts) == 0 {
+			cfg.PHP.FPMPorts = nil
+		}
+		return
+	}
+	if cfg.PHP.FPMPorts == nil {
+		cfg.PHP.FPMPorts = map[string][]string{}
+	}
+	cfg.PHP.FPMPorts[version] = ports
+}
 
 // SetFPMPorts replaces the extra published ports for a PHP version's shared FPM
 // container with the given "host:container" specs, shifting any requested host
@@ -25,6 +50,9 @@ func SetFPMPorts(version string, specs []string) ([]string, error) {
 	if err != nil || cfg == nil {
 		return nil, fmt.Errorf("loading global config: %w", err)
 	}
+	// Prior ports for this version, so a failed restart can roll the whole change
+	// back to the mapping that was actually serving.
+	prevPorts := append([]string(nil), cfg.PHP.FPMPorts[version]...)
 
 	// A port this version already publishes is not a collision with itself: the
 	// running container holds it now but frees it on the restart below, so a probe
@@ -87,17 +115,7 @@ func SetFPMPorts(version string, specs []string) ([]string, error) {
 		resolved = append(resolved, mapping)
 	}
 
-	if len(resolved) == 0 {
-		delete(cfg.PHP.FPMPorts, version)
-		if len(cfg.PHP.FPMPorts) == 0 {
-			cfg.PHP.FPMPorts = nil
-		}
-	} else {
-		if cfg.PHP.FPMPorts == nil {
-			cfg.PHP.FPMPorts = map[string][]string{}
-		}
-		cfg.PHP.FPMPorts[version] = resolved
-	}
+	setVersionFPMPorts(cfg, version, resolved)
 	if err := config.SaveGlobal(cfg); err != nil {
 		return nil, err
 	}
@@ -106,16 +124,34 @@ func SetFPMPorts(version string, specs []string) ([]string, error) {
 	// version whose FPM quadlet actually exists, so a save for a not-yet-installed
 	// version doesn't resurrect a unit that would grab a host port at boot.
 	unit := "lerd-php" + strings.ReplaceAll(version, ".", "") + "-fpm"
-	if !QuadletInstalled(unit) {
+	if !fpmQuadletInstalled(unit) {
 		return resolved, nil
 	}
-	if err := WriteFPMQuadlet(version); err != nil {
+	if err := fpmWriteQuadlet(version); err != nil {
 		return resolved, err
 	}
-	if status, _ := UnitStatus(unit); status == "active" || status == "activating" {
-		_ = RestartUnit(unit)
+	if status, _ := fpmUnitStatus(unit); status == "active" || status == "activating" {
+		if err := fpmRestartUnit(unit); err != nil {
+			return rollbackFPMPorts(version, unit, prevPorts, resolved, err)
+		}
 	}
 	return resolved, nil
+}
+
+// rollbackFPMPorts restores a version's previous FPM ports after a restart on the
+// new mapping failed (a port grabbed between the bindability probe and the restart
+// can leave the shared FPM down). On a clean restore it returns the previous ports
+// with an explanatory error; if the restore itself fails the unit may be down and
+// the operator is told to run `lerd start`.
+func rollbackFPMPorts(version, unit string, prevPorts, resolved []string, cause error) ([]string, error) {
+	cfg, err := config.LoadGlobal()
+	if err == nil && cfg != nil {
+		setVersionFPMPorts(cfg, version, prevPorts)
+		if config.SaveGlobal(cfg) == nil && fpmWriteQuadlet(version) == nil && fpmRestartUnit(unit) == nil {
+			return prevPorts, fmt.Errorf("could not restart %s on the new ports, restored the previous ports: %w", unit, cause)
+		}
+	}
+	return resolved, fmt.Errorf("could not restart %s and could not restore the previous ports, run `lerd start`: %w", unit, cause)
 }
 
 // AddFPMPort appends a single "host:container" mapping to a version's FPM ports,

--- a/internal/podman/fpmports_test.go
+++ b/internal/podman/fpmports_test.go
@@ -1,11 +1,36 @@
 package podman
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
 )
+
+// stubFPMUnit makes the FPM unit look installed and active, with a no-op quadlet
+// write and a restart whose failures follow the given sequence (one bool per call,
+// true = fail). It returns a pointer to the live call count.
+func stubFPMUnit(t *testing.T, restartFails ...bool) *int {
+	t.Helper()
+	oInstalled, oStatus, oWrite, oRestart := fpmQuadletInstalled, fpmUnitStatus, fpmWriteQuadlet, fpmRestartUnit
+	t.Cleanup(func() {
+		fpmQuadletInstalled, fpmUnitStatus, fpmWriteQuadlet, fpmRestartUnit = oInstalled, oStatus, oWrite, oRestart
+	})
+	fpmQuadletInstalled = func(string) bool { return true }
+	fpmUnitStatus = func(string) (string, error) { return "active", nil }
+	fpmWriteQuadlet = func(string) error { return nil }
+	calls := 0
+	fpmRestartUnit = func(string) error {
+		i := calls
+		calls++
+		if i < len(restartFails) && restartFails[i] {
+			return fmt.Errorf("restart %d failed", i)
+		}
+		return nil
+	}
+	return &calls
+}
 
 // fpmTestEnv points config at a temp dir and stubs bindability so the shift
 // guard is driven by an explicit busy-port set rather than real sockets.
@@ -118,6 +143,33 @@ func TestSetFPMPorts_EmptyClearsVersion(t *testing.T) {
 	}
 	if got := config.FPMPortsFor("8.3"); got != nil {
 		t.Errorf("after clear, FPMPortsFor(8.3) = %v, want nil", got)
+	}
+}
+
+// A restart that fails on the new mapping (a port grabbed between the probe and
+// the restart) rolls the version's ports back to what was serving before, and the
+// persisted config and returned list both reflect the restored ports.
+func TestSetFPMPorts_RestartFailureRestoresPreviousPorts(t *testing.T) {
+	fpmTestEnv(t)
+	seeded, err := SetFPMPorts("8.4", []string{"41000:9003"})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	calls := stubFPMUnit(t, true, false) // new-port restart fails, rollback restart succeeds
+
+	resolved, err := SetFPMPorts("8.4", []string{"41100:9003"})
+	if err == nil {
+		t.Fatal("expected an error surfacing the failed restart")
+	}
+	if strings.Join(resolved, ",") != strings.Join(seeded, ",") {
+		t.Fatalf("resolved = %v, want the restored previous ports %v", resolved, seeded)
+	}
+	cfg, _ := config.LoadGlobal()
+	if got := strings.Join(cfg.PHP.FPMPorts["8.4"], ","); got != strings.Join(seeded, ",") {
+		t.Fatalf("persisted ports = %v, want %v restored", got, seeded)
+	}
+	if *calls != 2 {
+		t.Errorf("restart calls = %d, want 2 (new port fails, rollback succeeds)", *calls)
 	}
 }
 

--- a/internal/serviceops/port_guard_test.go
+++ b/internal/serviceops/port_guard_test.go
@@ -143,6 +143,40 @@ func TestPortClaimedByOtherInstalled(t *testing.T) {
 	}
 }
 
+// A multi-port service reserves its un-overridden SECONDARY default too, not just
+// the ports HostPorts() records. Without this, two installed services defaulting a
+// secondary mapping to the same host port both pass the boot guard and collide.
+func TestPortClaimedByOtherInstalled_SecondaryDefault(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	svc := &config.CustomService{Name: "twoport", Image: "example/x:1", Ports: []string{"33061:3306", "8025:8025"}}
+	if err := config.SaveCustomService(svc); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+	// A config entry with only the primary set, so HostPorts() omits the 8025
+	// secondary default (the gap this guards against).
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	cfg.Services["twoport"] = config.ServiceConfig{Enabled: true, Port: 33061}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	if !portClaimedByOtherInstalled("other", 8025) {
+		t.Error("the un-overridden secondary default 8025 must count as claimed")
+	}
+	if !portClaimedByOtherInstalled("other", 33061) {
+		t.Error("the primary default 33061 must count as claimed")
+	}
+	if portClaimedByOtherInstalled("other", 9999) {
+		t.Error("an unrelated port must not be claimed")
+	}
+}
+
 // Issue #704: the guard keeps a bindable canonical port when only a phantom
 // (uninstalled) preset holds it, and shifts when an installed sibling does.
 func TestGenericGuard_704CanonicalSharing(t *testing.T) {

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -158,14 +158,25 @@ func portClaimedByOtherInstalled(self string, p int) bool {
 	if err != nil || cfg == nil {
 		return false
 	}
+	// serviceEffectiveHostPorts includes a multi-port service's un-overridden
+	// secondary defaults (mailpit's 8025, rustfs' 9001), which HostPorts() omits,
+	// so a stopped sibling still reserves them and two units can't collide at boot.
+	claims := func(name string, sc config.ServiceConfig) bool {
+		for _, hp := range serviceEffectiveHostPorts(name, sc) {
+			if hp == p {
+				return true
+			}
+		}
+		return false
+	}
+	seen := map[string]bool{}
 	for name, sc := range cfg.Services {
 		if name == self || !ServiceInstalled(name) {
 			continue
 		}
-		for _, hp := range sc.HostPorts() {
-			if hp == p {
-				return true
-			}
+		seen[name] = true
+		if claims(name, sc) {
+			return true
 		}
 	}
 	customs, err := config.ListCustomServices()
@@ -173,16 +184,11 @@ func portClaimedByOtherInstalled(self string, p int) bool {
 		return false
 	}
 	for _, c := range customs {
-		if c.Name == self || !ServiceInstalled(c.Name) {
-			continue
+		if c.Name == self || seen[c.Name] || !ServiceInstalled(c.Name) {
+			continue // seen entries were fully covered by the cfg.Services loop
 		}
-		if sc, ok := cfg.Services[c.Name]; ok && len(sc.HostPorts()) > 0 {
-			continue // already counted from cfg.Services above
-		}
-		for _, m := range c.Ports {
-			if config.MappingHostPort(m) == p {
-				return true
-			}
+		if claims(c.Name, cfg.Services[c.Name]) { // zero config when unconfigured
+			return true
 		}
 	}
 	return false

--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -38,6 +38,21 @@ func validShimName(name string) bool {
 	return shimNamePattern.MatchString(name)
 }
 
+// reservedShimNames are the host-shim filenames the installer owns (addShellShims
+// and the fnm node mirror). They share BinDir with the client shims but carry no
+// marker, so a store-declared client tool must never claim one, else a preset
+// could repoint the host php or composer at a database client container.
+var reservedShimNames = map[string]bool{
+	"php": true, "composer": true, "composer.phar": true, "laravel": true,
+	"node": true, "npm": true, "npx": true, "fnm": true,
+}
+
+// isReservedShimName reports whether name is an installer-owned shim the client
+// reconcile must not generate over.
+func isReservedShimName(name string) bool {
+	return reservedShimNames[name]
+}
+
 // validBinaries keeps only the candidate binary names safe to pass to
 // client-exec, dropping any a malformed or hostile store entry slipped in.
 func validBinaries(bins []string) []string {
@@ -98,7 +113,7 @@ func Targets() map[string]Target {
 			continue
 		}
 		for _, cs := range svc.ClientShims {
-			if !validShimName(cs.Name) {
+			if !validShimName(cs.Name) || isReservedShimName(cs.Name) {
 				continue
 			}
 			if _, exists := out[cs.Name]; exists {
@@ -277,7 +292,9 @@ func Reconcile(prompt Prompter) error {
 		enabled, _ := decide(tool, prompt)
 		shimPath := filepath.Join(binDir, tool)
 		if enabled {
-			_ = os.WriteFile(shimPath, []byte(script(lerdBin, tool)), 0755)
+			if canWriteShim(shimPath) {
+				_ = os.WriteFile(shimPath, []byte(script(lerdBin, tool)), 0755)
+			}
 		} else {
 			removeIfShim(shimPath)
 		}
@@ -323,6 +340,17 @@ func hostHasTool(tool string) bool {
 		}
 	}
 	return false
+}
+
+// canWriteShim reports whether the reconcile may write path: only when it is
+// absent or already one of lerd's client shims. An existing non-shim file (the
+// installer's php/composer, or a user binary sharing a tool name) is left intact,
+// mirroring removeIfShim so the write and remove sides guard the same set.
+func canWriteShim(path string) bool {
+	if _, err := os.Lstat(path); os.IsNotExist(err) {
+		return true
+	}
+	return isShimFile(path)
 }
 
 // removeIfShim deletes path only when it is one of lerd's client shims, so the

--- a/internal/shims/shims_test.go
+++ b/internal/shims/shims_test.go
@@ -76,6 +76,46 @@ func TestRemoveIfShim(t *testing.T) {
 	}
 }
 
+// The installer-owned shim names (php, composer, node…) are reserved: a store
+// preset can't have the client reconcile generate over them, so it can never
+// repoint the host php or composer at a database client container.
+func TestReservedShimNames(t *testing.T) {
+	for _, name := range []string{"php", "composer", "composer.phar", "laravel", "node", "npm", "npx", "fnm"} {
+		if !isReservedShimName(name) {
+			t.Errorf("%q should be reserved for the installer", name)
+		}
+	}
+	for _, name := range []string{"mysqldump", "psql", "pg_dump", "redis-cli", "mongosh"} {
+		if isReservedShimName(name) {
+			t.Errorf("%q is a real client tool and must not be reserved", name)
+		}
+	}
+}
+
+// canWriteShim guards the reconcile's write side the way removeIfShim guards its
+// remove side: an absent path or an existing lerd client shim is writable, but a
+// non-shim file (an installer shim, or a user binary of the same name) is not, so
+// the reconcile can never clobber it.
+func TestCanWriteShim(t *testing.T) {
+	dir := t.TempDir()
+	absent := filepath.Join(dir, "mysqldump")
+	if !canWriteShim(absent) {
+		t.Error("an absent path must be writable")
+	}
+
+	ours := filepath.Join(dir, "psql")
+	_ = os.WriteFile(ours, []byte(script("lerd", "psql")), 0755)
+	if !canWriteShim(ours) {
+		t.Error("our own client shim must be overwritable")
+	}
+
+	installer := filepath.Join(dir, "php")
+	_ = os.WriteFile(installer, []byte("#!/bin/sh\nexec lerd php \"$@\"\n"), 0755)
+	if canWriteShim(installer) {
+		t.Error("an installer shim (no marker) must never be overwritten")
+	}
+}
+
 func TestPruneOrphans(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	binDir := config.BinDir()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -125,14 +125,22 @@ func loadCachedIndex() (*Index, error) {
 	return &idx, nil
 }
 
-// writeCachedIndex persists the raw index bytes to the local cache. Best effort:
-// a cache we cannot write just means the next read falls back to the network.
+// writeCachedIndex persists the raw index bytes to the local cache atomically
+// (temp then rename) so an offline reader in another process, or a crash
+// mid-write, never sees a truncated file. Best effort: a cache we cannot write
+// just means the next read falls back to the network.
 func writeCachedIndex(data []byte) {
 	path := config.StoreIndexFile()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return
 	}
-	_ = os.WriteFile(path, data, 0o644)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+	}
 }
 
 // FetchFramework downloads a framework definition from the store.

--- a/internal/ui/openfolder.go
+++ b/internal/ui/openfolder.go
@@ -35,7 +35,20 @@ func handleOpenFolder(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "path must be absolute", http.StatusBadRequest)
 		return
 	}
+	// Resolve symlinks before the home check so a symlink under home that points
+	// outside home can't slip a foreign path past the prefix guard. Home is
+	// resolved the same way in case it is itself a symlink.
+	path, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		http.Error(w, "folder not found", http.StatusNotFound)
+		return
+	}
 	home, _ := os.UserHomeDir()
+	if home != "" {
+		if h, err := filepath.EvalSymlinks(home); err == nil {
+			home = h
+		}
+	}
 	if home == "" || (path != home && !strings.HasPrefix(path, home+string(os.PathSeparator))) {
 		http.Error(w, "path outside home", http.StatusForbidden)
 		return

--- a/internal/ui/openfolder_test.go
+++ b/internal/ui/openfolder_test.go
@@ -59,6 +59,18 @@ func TestHandleOpenFolderRejects(t *testing.T) {
 		}
 	})
 
+	t.Run("symlink under home pointing outside home is 403", func(t *testing.T) {
+		link := filepath.Join(home, "escape")
+		if err := os.Symlink("/etc", link); err != nil {
+			t.Skipf("cannot create symlink: %v", err)
+		}
+		defer os.Remove(link)
+		rr := postFolder(t, "127.0.0.1:5000", `{"path":"`+link+`"}`)
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403 (symlink must not escape home)", rr.Code)
+		}
+	})
+
 	t.Run("a file (not a dir) is 404", func(t *testing.T) {
 		f := filepath.Join(home, "notadir.txt")
 		if err := os.WriteFile(f, []byte("x"), 0644); err != nil {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -2420,6 +2420,10 @@ func handleServiceAction(w http.ResponseWriter, r *http.Request) {
 // shared serviceops layer so the Web UI enforces the same validation, guard and
 // host-proxy refresh as the CLI and MCP. A nil/zero published_port resets to the
 // preset default.
+// servicePortsMu serializes port-modal saves so their snapshot/apply/restore
+// sequences can't interleave across concurrent requests.
+var servicePortsMu sync.Mutex
+
 func handleServicePorts(w http.ResponseWriter, r *http.Request, name string) {
 	var body struct {
 		PublishedPort  *int           `json:"published_port"`
@@ -2441,10 +2445,6 @@ func handleServicePorts(w http.ResponseWriter, r *http.Request, name string) {
 	if body.PublishedPort != nil {
 		port = *body.PublishedPort
 	}
-	// A modal save applies the primary, secondaries, and extras in sequence.
-	// Snapshot first so a failure partway through rolls the whole save back to a
-	// consistent state instead of leaving some ports moved while reporting failure.
-	snapshot, canRestore := serviceops.SnapshotPublishedPorts(name)
 	apply := func() error {
 		if _, err := serviceops.SetPublishedPort(name, port); err != nil {
 			return err
@@ -2469,10 +2469,18 @@ func handleServicePorts(w http.ResponseWriter, r *http.Request, name string) {
 		}
 		return nil
 	}
-	if err := apply(); err != nil {
-		if canRestore {
-			_ = serviceops.RestorePublishedPorts(name, snapshot)
-		}
+	// A modal save applies the primary, secondaries, and extras in sequence.
+	// Snapshot first so a failure partway through rolls the whole save back to a
+	// consistent state. The lock spans snapshot, apply and restore so two
+	// concurrent saves can't interleave and restore each other's wrong baseline.
+	servicePortsMu.Lock()
+	snapshot, canRestore := serviceops.SnapshotPublishedPorts(name)
+	err := apply()
+	if err != nil && canRestore {
+		_ = serviceops.RestorePublishedPorts(name, snapshot)
+	}
+	servicePortsMu.Unlock()
+	if err != nil {
 		fail(err)
 		return
 	}

--- a/internal/ui/site_analytics.go
+++ b/internal/ui/site_analytics.go
@@ -13,16 +13,26 @@ import (
 // writes. Opened once, lazily, since lerd-ui and the watcher are separate
 // processes sharing the SQLite file (WAL, so the reader never blocks the writer).
 var (
-	analyticsStore     *reqstats.Store
-	analyticsStoreErr  error
-	analyticsStoreOnce sync.Once
+	analyticsStore   *reqstats.Store
+	analyticsStoreMu sync.Mutex
 )
 
+// getAnalyticsStore opens the durable request store lazily, caching only a
+// successful handle. A transient open failure is retried on the next call rather
+// than memoised, so analytics recovers once the file is reachable without a
+// lerd-ui restart.
 func getAnalyticsStore() (*reqstats.Store, error) {
-	analyticsStoreOnce.Do(func() {
-		analyticsStore, analyticsStoreErr = reqstats.OpenStore(config.RequestStatsDB())
-	})
-	return analyticsStore, analyticsStoreErr
+	analyticsStoreMu.Lock()
+	defer analyticsStoreMu.Unlock()
+	if analyticsStore != nil {
+		return analyticsStore, nil
+	}
+	st, err := reqstats.OpenStore(config.RequestStatsDB())
+	if err != nil {
+		return nil, err
+	}
+	analyticsStore = st
+	return analyticsStore, nil
 }
 
 // recentRequest is one row of the recent-requests list: enough to render it

--- a/internal/watcher/idle_feed.go
+++ b/internal/watcher/idle_feed.go
@@ -153,23 +153,7 @@ func disableIdle() {
 func handleAccessDatagram(b []byte) {
 	if reqAggregator != nil {
 		if rec, ok := reqstats.ParseAccessRecord(b); ok {
-			reqAggregator.Record(rec)
-			// Skip requests nginx served without the app: a static-asset extension,
-			// or a zero request time, which is nginx answering a static file directly
-			// (manifest.json, robots.txt, service workers) rather than PHP.
-			if reqStore != nil && !reqstats.IsStaticAsset(rec.URI) && rec.SecondsToMillis() > 0 {
-				if site, ok := resolveHostToSite(rec.Host); ok {
-					now := time.Now()
-					sr := reqstats.RecordFrom(rec, site, now)
-					reqBufMu.Lock()
-					// Cold start: first request after the site sat idle past coldGap.
-					last, seen := reqLastSeen[site]
-					sr.Cold = reqstats.IsColdStart(last, seen, now, coldGap)
-					reqLastSeen[site] = now
-					reqBuf = append(reqBuf, sr)
-					reqBufMu.Unlock()
-				}
-			}
+			ingestAccessRecord(rec)
 		}
 	}
 	if !idleActive.Load() {
@@ -179,6 +163,40 @@ func handleAccessDatagram(b []byte) {
 		if site := activityTracker.TouchHost(host, time.Now()); site != "" {
 			idleEng.OnActivity(site)
 		}
+	}
+}
+
+// siteForHost is the seam the request-stats fan-out resolves through; a var so a
+// test can inject a resolver without a live site registry.
+var siteForHost = resolveHostToSite
+
+// ingestAccessRecord fans one parsed access record out to the durable store and
+// the live aggregator. It flags a cold start (the first request after the site
+// sat idle past coldGap) and keeps it out of the aggregator, whose snapshot feeds
+// the slow-route notifier and the doctor: a wake's inflated time must not trip
+// them, while the store still records it (marked cold, excluded from its timing).
+func ingestAccessRecord(rec reqstats.AccessRecord) {
+	// Skip requests nginx served without the app: a static-asset extension, or a
+	// zero request time, which is nginx answering a static file directly
+	// (manifest.json, robots.txt, service workers) rather than PHP.
+	appServed := !reqstats.IsStaticAsset(rec.URI) && rec.SecondsToMillis() > 0
+	site, resolved := siteForHost(rec.Host)
+	cold := false
+	if appServed && resolved {
+		now := time.Now()
+		reqBufMu.Lock()
+		last, seen := reqLastSeen[site]
+		cold = reqstats.IsColdStart(last, seen, now, coldGap)
+		reqLastSeen[site] = now
+		if reqStore != nil {
+			sr := reqstats.RecordFrom(rec, site, now)
+			sr.Cold = cold
+			reqBuf = append(reqBuf, sr)
+		}
+		reqBufMu.Unlock()
+	}
+	if !cold {
+		reqAggregator.Record(rec)
 	}
 }
 

--- a/internal/watcher/reqstats_ingest_test.go
+++ b/internal/watcher/reqstats_ingest_test.go
@@ -1,0 +1,46 @@
+package watcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/geodro/lerd/internal/reqstats"
+)
+
+// A cold start (the first request after the site sat idle past coldGap) must not
+// reach the live aggregator, so the slow-route notifier and the doctor never fire
+// on a wake's inflated time. A warm request still counts.
+func TestIngestAccessRecord_ColdStartExcludedFromAggregator(t *testing.T) {
+	resolve := func(h string) (string, bool) {
+		if h == "app.test" {
+			return "app", true
+		}
+		return "", false
+	}
+	prevAgg, prevResolve, prevStore := reqAggregator, siteForHost, reqStore
+	prevLastSeen, prevGap := reqLastSeen, coldGap
+	t.Cleanup(func() {
+		reqAggregator, siteForHost, reqStore = prevAgg, prevResolve, prevStore
+		reqLastSeen, coldGap = prevLastSeen, prevGap
+	})
+	siteForHost = resolve
+	reqAggregator = reqstats.New(resolve)
+	reqStore = nil
+	reqLastSeen = map[string]time.Time{}
+	coldGap = 30 * time.Minute
+
+	rec := reqstats.AccessRecord{Host: "app.test", Method: "GET", URI: "/dash", RequestTime: 1.5, Status: 200}
+
+	ingestAccessRecord(rec) // warm: first ever request, not a cold start
+	// Back-date the site's last-seen so the next request lands past coldGap.
+	reqLastSeen["app"] = time.Now().Add(-time.Hour)
+	ingestAccessRecord(rec) // cold: must be dropped from the aggregator
+
+	snap, ok := reqAggregator.SiteSnapshot("app")
+	if !ok {
+		t.Fatal("aggregator should have the warm sample")
+	}
+	if snap.Samples != 1 {
+		t.Fatalf("aggregator samples = %d, want 1 (the cold start excluded)", snap.Samples)
+	}
+}


### PR DESCRIPTION
Everything that landed since v1.27.0 got a pass and this fixes what it turned up, headlined by the unattended cleanup sweep.

That sweep moved to the managed tier and could delete a tagged catalog image, a mysql or redis or postgres, only because it shared a repo with a lerd service, even one the user had pulled themselves for a project that has nothing to do with lerd. Since podman cant label an image in place, lerd now keeps a small ledger of the refs it pulls and the catalog reap only removes a tagged image the ledger recorded pulling. A foreign copy is always kept, lerd own leftovers are still reclaimed, and on an existing install the ledger fills as lerd pulls, so the sweep simply stays conservative until then.

The client-shim reconcile had a matching ownership gap and could overwrite the installer php or composer shim if a store preset declared a colliding tool name, so those names are reserved and the reconcile never writes over a file that isnt one of its own shims. The remaining changes are smaller: cold starts after an idle wake no longer trip false slow-route alerts, the store-index cache is written atomically, the boot port guard counts secondary default ports, the analytics store retries a transient open, the client-tool host detection drops two false positives, open-folder resolves symlinks before the home check, port-modal saves are serialised, and a failed FPM shell-port restart rolls back.

Closes #798