### PR TITLE
fix: correctness follow-ups from the post-v1.27.1 review

### DIFF
--- a/internal/cli/aiclients.go
+++ b/internal/cli/aiclients.go
@@ -1,12 +1,22 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+// jsonEqual reports whether a and b serialise to the same canonical JSON. Go
+// sorts map keys on marshal, so this compares structure and values regardless of
+// key order or the Go-side slice type ([]string vs the []any a decode produces).
+func jsonEqual(a, b any) bool {
+	ab, err1 := json.Marshal(a)
+	bb, err2 := json.Marshal(b)
+	return err1 == nil && err2 == nil && bytes.Equal(ab, bb)
+}
 
 // mcpFormat selects how a client's MCP server config file is written.
 type mcpFormat int
@@ -283,6 +293,11 @@ func mergeServerJSON(path, serverKey string, entry map[string]any) error {
 	servers, _ := cfg[serverKey].(map[string]any)
 	if servers == nil {
 		servers = map[string]any{}
+	}
+	// Leave a file that already carries an equivalent lerd entry untouched, so a
+	// committed, hand-formatted config isn't reindented on every install/update.
+	if existing, ok := servers["lerd"]; ok && jsonEqual(existing, entry) {
+		return nil
 	}
 	servers["lerd"] = entry
 	cfg[serverKey] = servers

--- a/internal/cli/aiclients_test.go
+++ b/internal/cli/aiclients_test.go
@@ -433,3 +433,52 @@ func TestProjectMCP_isPortable(t *testing.T) {
 		t.Errorf("project entry should not bake in the absolute site dir %s: %s", dir, data)
 	}
 }
+
+// mergeServerJSON must leave a config that already carries an equivalent lerd
+// entry byte-for-byte untouched, so a committed, hand-formatted .mcp.json isn't
+// reindented (a spurious git diff) on every install/update. A differing or
+// missing entry still writes, and unrelated servers are preserved.
+func TestMergeServerJSON_IdempotentOnUnchangedEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".mcp.json")
+
+	original := []byte(`{
+  "mcpServers": {
+    "lerd": {
+      "command": "lerd",
+      "args": ["mcp"]
+    },
+    "other": {
+      "command": "their-tool"
+    }
+  }
+}
+`)
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := map[string]any{"command": "lerd", "args": []string{"mcp"}}
+	if err := mergeServerJSON(path, "mcpServers", entry); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.ReadFile(path)
+	if string(after) != string(original) {
+		t.Errorf("file rewritten though the lerd entry was unchanged:\n--- before ---\n%s\n--- after ---\n%s", original, after)
+	}
+
+	// A genuinely different entry must still be written, preserving other servers.
+	if err := mergeServerJSON(path, "mcpServers", map[string]any{"command": "lerd", "args": []string{"mcp", "--verbose"}}); err != nil {
+		t.Fatal(err)
+	}
+	changed, _ := os.ReadFile(path)
+	if string(changed) == string(original) {
+		t.Fatal("a differing entry should have been written")
+	}
+	if !strings.Contains(string(changed), "their-tool") {
+		t.Fatal("unrelated server must be preserved on write")
+	}
+	if !strings.Contains(string(changed), "--verbose") {
+		t.Fatal("updated lerd entry must be written")
+	}
+}

--- a/internal/cli/dns_tld_decline_test.go
+++ b/internal/cli/dns_tld_decline_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// Disabling DNS with the default TLD renames sites test -> localhost. When the
+// user declines the domain rewrite, the sites keep their .test domains, but
+// HTTPS still tracks DNS: they must be unsecured so the torn-down resolver
+// doesn't leave an HTTPS-only vhost nginx serves unreachably. Regression guard
+// for the canonical-rename decline branch, which previously only logged a note.
+func TestApplyDNSTLDMigration_DeclinedDisableUnsecuresSites(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	orig := confirmTLDRewrite
+	t.Cleanup(func() { confirmTLDRewrite = orig })
+	confirmTLDRewrite = func(string, bool) bool { return false } // decline the rewrite
+
+	siteDir := filepath.Join(tmp, "alpha")
+	if err := os.MkdirAll(siteDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{
+		Name:    "alpha",
+		Path:    siteDir,
+		Domains: []string{"alpha.test"},
+		Secured: true,
+	}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	if got := applyDNSTLDMigration("test", false); got != "localhost" {
+		t.Fatalf("new TLD = %q, want localhost", got)
+	}
+
+	reg, err := config.LoadSites()
+	if err != nil {
+		t.Fatal(err)
+	}
+	site := reg.Sites[0]
+	if site.Secured {
+		t.Errorf("declined disable must unsecure the site; Secured still true (domain %s)", site.PrimaryDomain())
+	}
+	if site.PrimaryDomain() != "alpha.test" {
+		t.Errorf("declined rewrite must keep the .test domain, got %s", site.PrimaryDomain())
+	}
+	if !site.SecuredBeforeDNSOff {
+		t.Error("pre-disable HTTPS state should be recorded for a lossless re-enable")
+	}
+}
+
+// Accepting the rewrite still migrates domains and unsecures, so the decline fix
+// doesn't alter the accepted path.
+func TestApplyDNSTLDMigration_AcceptedDisableMigratesAndUnsecures(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	orig := confirmTLDRewrite
+	t.Cleanup(func() { confirmTLDRewrite = orig })
+	confirmTLDRewrite = func(string, bool) bool { return true }
+
+	siteDir := filepath.Join(tmp, "beta")
+	if err := os.MkdirAll(siteDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{
+		Name:    "beta",
+		Path:    siteDir,
+		Domains: []string{"beta.test"},
+		Secured: true,
+	}); err != nil {
+		t.Fatalf("AddSite: %v", err)
+	}
+
+	applyDNSTLDMigration("test", false)
+
+	reg, _ := config.LoadSites()
+	site := reg.Sites[0]
+	if site.PrimaryDomain() != "beta.localhost" || site.Secured {
+		t.Fatalf("accepted disable: domain=%s secured=%v, want beta.localhost/false", site.PrimaryDomain(), site.Secured)
+	}
+}

--- a/internal/cli/dns_toggle.go
+++ b/internal/cli/dns_toggle.go
@@ -118,6 +118,10 @@ func toggledCanonicalTLD(prevTLD string, enabling bool) string {
 	return prevTLD
 }
 
+// confirmTLDRewrite is the prompt seam for the TLD-rewrite decision, overridden
+// in tests to exercise the accept and decline branches without a terminal.
+var confirmTLDRewrite = confirmInstallPromptDefault
+
 // applyDNSTLDMigration computes the new canonical TLD for a mode flip and, when
 // it changes and sites still carry the old TLD, offers to rewrite their domains,
 // .env APP_URL and vhosts (mirroring the installer's TLD-migration prompt).
@@ -133,10 +137,14 @@ func applyDNSTLDMigration(prevTLD string, enabling bool) string {
 		if affected := sitesWithTLD(prevTLD); len(affected) > 0 {
 			feedback.Line(fmt.Sprintf("TLD change: %d site(s) currently on .%s -> .%s", len(affected), prevTLD, newTLD))
 			feedback.Note(strings.Join(affected, ", "))
-			if confirmInstallPromptDefault(fmt.Sprintf("Rewrite domains, .env APP_URL, and vhosts to .%s?", newTLD), true) {
+			if confirmTLDRewrite(fmt.Sprintf("Rewrite domains, .env APP_URL, and vhosts to .%s?", newTLD), true) {
 				migrateSiteTLD(prevTLD, newTLD, !enabling)
 			} else {
 				feedback.Note("skipped, sites still reference ." + prevTLD)
+				// Domains stay on the old TLD, but HTTPS tracks DNS: unsecure them
+				// on disable (restore on enable) so a declined rewrite never leaves
+				// an HTTPS-only vhost the torn-down resolver can no longer reach.
+				adjustSitesSecuredForDNS(prevTLD, enabling)
 			}
 		}
 		return newTLD

--- a/internal/dns/setup_common.go
+++ b/internal/dns/setup_common.go
@@ -26,14 +26,50 @@ var sudoersMarkerPath = func() string {
 }
 
 // sudoersInstalled reports whether a drop-in matching content was already
-// installed on this or a prior run, per the user-owned marker.
+// installed on this or a prior run, per the user-owned marker. The marker alone
+// can't tell a deleted drop-in from an intact one (the root-only file is
+// unreadable), so a matching marker is additionally checked against a live
+// passwordless probe: only a conclusive "the grant is gone" answer forces a
+// reinstall, an inconclusive probe leaves the marker's verdict standing.
 func sudoersInstalled(content []byte) bool {
 	got, err := os.ReadFile(sudoersMarkerPath())
 	if err != nil {
 		return false
 	}
 	sum := sha256.Sum256(content)
-	return strings.TrimSpace(string(got)) == hex.EncodeToString(sum[:])
+	if strings.TrimSpace(string(got)) != hex.EncodeToString(sum[:]) {
+		return false
+	}
+	if permitted, conclusive := sudoProbe(); conclusive && !permitted {
+		return false
+	}
+	return true
+}
+
+// sudoersProbeCommand is one of the commands the drop-in grants passwordless;
+// used only to probe whether that grant is still live.
+const sudoersProbeCommand = "/usr/bin/resolvectl"
+
+// sudoProbe is the seam tests override. It reports whether the drop-in's
+// passwordless grant is currently live and whether the answer is conclusive.
+var sudoProbe = defaultSudoProbe
+
+// defaultSudoProbe asks sudo, without prompting, whether the invoking user may
+// run the granted command passwordless. Exit 0 means the grant is live (from the
+// drop-in or a broader rule); a "password is required" refusal means it is gone;
+// anything else (no sudo, an unsupported flag) is inconclusive and defers to the
+// content marker so a working setup is never needlessly reinstalled.
+func defaultSudoProbe() (permitted, conclusive bool) {
+	var stderr bytes.Buffer
+	cmd := exec.Command("sudo", "-n", "-l", sudoersProbeCommand)
+	cmd.Stderr = &stderr
+	if cmd.Run() == nil {
+		return true, true
+	}
+	if strings.Contains(strings.ToLower(stderr.String()), "password is required") {
+		return false, true
+	}
+	return false, false
 }
 
 // ForgetSudoersMarker deletes the user-owned marker so the next InstallSudoers

--- a/internal/dns/sudoers_marker_test.go
+++ b/internal/dns/sudoers_marker_test.go
@@ -6,6 +6,16 @@ import (
 	"testing"
 )
 
+// stubSudoProbe pins the passwordless-grant probe so marker tests are isolated
+// from the host's real sudo configuration. Inconclusive by default so the marker
+// verdict stands.
+func stubSudoProbe(t *testing.T, permitted, conclusive bool) {
+	t.Helper()
+	orig := sudoProbe
+	t.Cleanup(func() { sudoProbe = orig })
+	sudoProbe = func() (bool, bool) { return permitted, conclusive }
+}
+
 // The sudoers drop-in lives in /etc/sudoers.d (root-only 0750), so the invoking
 // user cannot read it back to compare. InstallSudoers relies on a user-owned
 // marker instead; without it the drop-in was rewritten, prompting for sudo, on
@@ -15,6 +25,7 @@ func TestSudoersMarker(t *testing.T) {
 	t.Cleanup(func() { sudoersMarkerPath = orig })
 	dir := t.TempDir()
 	sudoersMarkerPath = func() string { return filepath.Join(dir, "sub", "sudoers.sha256") }
+	stubSudoProbe(t, false, false)
 
 	content := []byte("user ALL=(root) NOPASSWD: /usr/bin/resolvectl\n")
 
@@ -47,6 +58,7 @@ func TestForgetSudoersMarker_ForcesRewrite(t *testing.T) {
 	t.Cleanup(func() { sudoersMarkerPath = orig })
 	dir := t.TempDir()
 	sudoersMarkerPath = func() string { return filepath.Join(dir, "sudoers.sha256") }
+	stubSudoProbe(t, false, false)
 
 	content := []byte("user ALL=(root) NOPASSWD: /usr/bin/resolvectl\n")
 	recordSudoersInstalled(content)
@@ -69,6 +81,7 @@ func TestSudoersMarker_upgradeReinstallsOnce(t *testing.T) {
 	t.Cleanup(func() { sudoersMarkerPath = orig })
 	dir := t.TempDir()
 	sudoersMarkerPath = func() string { return filepath.Join(dir, "sudoers.sha256") }
+	stubSudoProbe(t, false, false)
 
 	oldRule := []byte("v1 rule\n")
 	newRule := []byte("v2 rule with an extra grant\n")
@@ -90,5 +103,38 @@ func TestSudoersMarker_upgradeReinstallsOnce(t *testing.T) {
 	}
 	if sudoersInstalled(oldRule) {
 		t.Fatal("old rule must no longer match after the marker is refreshed")
+	}
+}
+
+// The content marker can't tell a deleted drop-in from an intact one. When the
+// passwordless probe conclusively reports the grant is gone, sudoersInstalled
+// must report not-installed so an ordinary install/update restores it, without
+// needing dns:repair. An inconclusive or affirmative probe leaves a working
+// setup alone.
+func TestSudoersInstalled_ProbeInvalidatesDeletedDropIn(t *testing.T) {
+	orig := sudoersMarkerPath
+	t.Cleanup(func() { sudoersMarkerPath = orig })
+	dir := t.TempDir()
+	sudoersMarkerPath = func() string { return filepath.Join(dir, "sudoers.sha256") }
+
+	content := []byte("user ALL=(root) NOPASSWD: /usr/bin/resolvectl\n")
+	recordSudoersInstalled(content)
+
+	// Grant conclusively gone: force a reinstall despite the matching marker.
+	stubSudoProbe(t, false, true)
+	if sudoersInstalled(content) {
+		t.Fatal("a conclusive gone-grant probe must force reinstall (report not installed)")
+	}
+
+	// Grant live: the marker's verdict stands.
+	stubSudoProbe(t, true, true)
+	if !sudoersInstalled(content) {
+		t.Fatal("a live grant with a matching marker should report installed")
+	}
+
+	// Inconclusive (no sudo, unsupported flag): never regress marker-only behaviour.
+	stubSudoProbe(t, false, false)
+	if !sudoersInstalled(content) {
+		t.Fatal("an inconclusive probe must defer to the marker (report installed)")
 	}
 }

--- a/internal/serviceops/ports.go
+++ b/internal/serviceops/ports.go
@@ -555,6 +555,12 @@ func RestorePublishedPorts(name string, snap PublishedPortSnapshot) error {
 	if !ServiceInstalled(name) {
 		return nil
 	}
+	// Silence the guard's shift hook during our own quadlet rewrite and fire it
+	// once at the end with the restored port, mirroring SetPublishedPort. Without
+	// this a partially-applied save that moved the port (and refreshed host-proxy
+	// .env to follow it) would roll the port back but leave host-proxy sites
+	// pointing at the port the service no longer publishes.
+	defer suppressPublishedPortShift()()
 	unit := "lerd-" + name
 	wasActive := unitActive(name)
 	if wasActive {
@@ -569,5 +575,6 @@ func RestorePublishedPorts(name string, snap PublishedPortSnapshot) error {
 		}
 		_ = portsWaitReady(name, 30*time.Second)
 	}
+	firePublishedPortShiftForced(name, snap.PublishedPort)
 	return nil
 }

--- a/internal/serviceops/ports_test.go
+++ b/internal/serviceops/ports_test.go
@@ -527,3 +527,55 @@ func TestErrPortInUseSentinel(t *testing.T) {
 		t.Error("ErrPortInUse not matchable via errors.Is")
 	}
 }
+
+// A ports-modal save that fails partway through rolls back with RestorePublishedPorts.
+// The forward path fired the host-proxy .env refresh to the new port, so the
+// rollback must re-fire it to the restored port, or host-proxy sites are left
+// pointing at a port the service no longer publishes.
+func TestRestorePublishedPorts_RefreshesHostProxyToRestoredPort(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	fakeQuadletOnDisk(t, "mysql") // ServiceInstalled -> true
+
+	prevStatus, prevStop, prevStart := portsUnitStatus, portsStopUnit, portsStartUnit
+	prevWait, prevRerender := portsWaitReady, portsRerender
+	t.Cleanup(func() {
+		portsUnitStatus, portsStopUnit, portsStartUnit = prevStatus, prevStop, prevStart
+		portsWaitReady, portsRerender = prevWait, prevRerender
+	})
+	portsUnitStatus = func(string) (string, error) { return "active", nil }
+	portsStopUnit = func(string) error { return nil }
+	portsStartUnit = func(string) error { return nil }
+	portsWaitReady = func(string, time.Duration) error { return nil }
+	portsRerender = func(string) error { return nil }
+
+	var fired []int
+	prevHook := OnPublishedPortShift
+	OnPublishedPortShift = func(_ string, port int) { fired = append(fired, port) }
+	t.Cleanup(func() { OnPublishedPortShift = prevHook })
+
+	if _, err := SetPublishedPort("mysql", 33061); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	snap, ok := SnapshotPublishedPorts("mysql")
+	if !ok {
+		t.Fatal("snapshot !ok")
+	}
+	// The apply moved the primary and refreshed host-proxy .env to 33072.
+	if _, err := SetPublishedPort("mysql", 33072); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	fired = nil
+	if err := RestorePublishedPorts("mysql", snap); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if got := config.ServicePublishedPort("mysql"); got != 33061 {
+		t.Fatalf("port not restored, got %d want 33061", got)
+	}
+	// Exactly one refresh, carrying the restored port, so host-proxy .env follows.
+	if len(fired) != 1 || fired[0] != 33061 {
+		t.Errorf("rollback must refresh host-proxy sites to the restored port; fired=%v want [33061]", fired)
+	}
+}

--- a/internal/serviceops/reconcile.go
+++ b/internal/serviceops/reconcile.go
@@ -116,7 +116,10 @@ func refreshPresetDefinition(svc *config.CustomService) (*config.CustomService, 
 	// rewrite its {{name}}-templated DB_HOST/connection_url to a container that
 	// does not exist). An alternate install keeps its version-suffixed name.
 	var fresh *config.CustomService
-	if svc.Name == preset.Name {
+	// ResolvePinned pins the canonical instance to its version's port, but only a
+	// multi-version preset has versions to pin; a single-version preset (no
+	// versions list) must go through Resolve or it never receives store refreshes.
+	if svc.Name == preset.Name && len(preset.Versions) > 0 {
 		fresh, err = preset.ResolvePinned(svc.PresetVersion)
 	} else {
 		fresh, err = preset.Resolve(svc.PresetVersion)
@@ -134,6 +137,17 @@ func refreshPresetDefinition(svc *config.CustomService) (*config.CustomService, 
 	fresh.Name = svc.Name
 	fresh.Preset = svc.Preset
 	fresh.PresetVersion = svc.PresetVersion
+	// Ports and the connection URL carry the host-port allocation chosen at
+	// quadlet generation (shifted when the preset default collided), not store
+	// intent, so preserve them like the image. Otherwise reconcile resets a
+	// shifted service to the default port on every start, churning the snapshot
+	// and re-running shim reconciliation for no real change.
+	if len(svc.Ports) > 0 {
+		fresh.Ports = svc.Ports
+	}
+	if svc.ConnectionURL != "" {
+		fresh.ConnectionURL = svc.ConnectionURL
+	}
 
 	if sameDefinition(fresh, svc) {
 		return svc, false

--- a/internal/serviceops/reconcile_test.go
+++ b/internal/serviceops/reconcile_test.go
@@ -96,6 +96,93 @@ func TestRefreshPresetDefinition_RefreshesDeclarativePreservesPins(t *testing.T)
 	}
 }
 
+// A single-version preset (no versions list) installs under its bare canonical
+// name, so refreshPresetDefinition must resolve it too; routing it through
+// ResolvePinned would error and silently skip every store refresh for it.
+func TestRefreshPresetDefinition_SingleVersionPresetRefreshes(t *testing.T) {
+	reconcileEnv(t)
+
+	presetDir := config.StorePresetsDir()
+	if err := os.MkdirAll(presetDir, 0o755); err != nil {
+		t.Fatalf("mkdir preset dir: %v", err)
+	}
+	presetYAML := "name: pdfsvc\n" +
+		"image: docker.io/gotenberg/gotenberg:8\n" +
+		"description: PDF service\n" +
+		"dashboard: http://localhost:3000\n"
+	if err := os.WriteFile(filepath.Join(presetDir, "pdfsvc.yaml"), []byte(presetYAML), 0o644); err != nil {
+		t.Fatalf("write preset: %v", err)
+	}
+
+	installed := &config.CustomService{
+		Name:   "pdfsvc",
+		Preset: "pdfsvc",
+		Image:  "docker.io/gotenberg/gotenberg:8",
+		LastOp: "install",
+		// dashboard missing: a store addition that reconcile must now deliver.
+	}
+	fresh, changed := refreshPresetDefinition(installed)
+	if !changed {
+		t.Fatal("single-version preset should refresh from the store, got changed=false")
+	}
+	if fresh.Dashboard != "http://localhost:3000" || fresh.Description != "PDF service" {
+		t.Errorf("declarative fields not refreshed: %+v", fresh)
+	}
+}
+
+// A service whose host port was shifted off the preset default (a collision at
+// quadlet generation) must not be seen as changed on every reconcile, or the
+// snapshot churns and shim reconciliation reruns each start.
+func TestRefreshPresetDefinition_PreservesShiftedPortNoChurn(t *testing.T) {
+	reconcileEnv(t)
+
+	presetDir := config.StorePresetsDir()
+	if err := os.MkdirAll(presetDir, 0o755); err != nil {
+		t.Fatalf("mkdir preset dir: %v", err)
+	}
+	presetYAML := "name: mydb\n" +
+		"description: db\n" +
+		"ports:\n" +
+		"  - \"{{host_port}}:3306\"\n" +
+		"connection_url: mysql://root:lerd@127.0.0.1:{{host_port}}/lerd\n" +
+		"versions:\n" +
+		"  - tag: \"11.8\"\n" +
+		"    image: docker.io/library/mariadb:11.8\n" +
+		"    canonical: true\n" +
+		"    host_port: 3306\n"
+	if err := os.WriteFile(filepath.Join(presetDir, "mydb.yaml"), []byte(presetYAML), 0o644); err != nil {
+		t.Fatalf("write preset: %v", err)
+	}
+
+	installed := &config.CustomService{
+		Name:          "mydb",
+		Preset:        "mydb",
+		PresetVersion: "11.8",
+		Image:         "docker.io/library/mariadb:11.8",
+		Description:   "db",
+		Ports:         []string{"3399:3306"}, // shifted host port
+		ConnectionURL: "mysql://root:lerd@127.0.0.1:3399/lerd",
+	}
+	fresh, changed := refreshPresetDefinition(installed)
+	if changed {
+		t.Errorf("a store-identical, port-shifted service should not churn; got changed=true (fresh=%+v)", fresh)
+	}
+
+	// The shift is preserved (not reset to the preset default), and a real
+	// declarative change is still detected.
+	installed.Description = "stale"
+	fresh, changed = refreshPresetDefinition(installed)
+	if !changed {
+		t.Fatal("a genuine declarative change should still report changed")
+	}
+	if len(fresh.Ports) == 0 || fresh.Ports[0] != "3399:3306" {
+		t.Errorf("shifted host port not preserved through a refresh: %v", fresh.Ports)
+	}
+	if fresh.ConnectionURL != "mysql://root:lerd@127.0.0.1:3399/lerd" {
+		t.Errorf("shifted connection URL not preserved: %q", fresh.ConnectionURL)
+	}
+}
+
 // TestReconcileServices_forwardHealsMissingQuadlet: a service whose YAML exists
 // but whose quadlet is missing gets its quadlet regenerated (issue #678).
 func TestReconcileServices_forwardHealsMissingQuadlet(t *testing.T) {

--- a/internal/ui/web/src/tabs/sites/SiteRequestTiming.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteRequestTiming.svelte
@@ -330,7 +330,7 @@
         </div>
       {:else}
         <div class="divide-y divide-gray-100 dark:divide-lerd-border">
-          {#each data.recent as r (r.at_millis + r.uri)}
+          {#each data.recent as r, i (r.at_millis + '-' + r.uri + '-' + i)}
             <div class="flex items-center gap-3 px-3 py-2 text-xs">
               <span class="shrink-0 font-mono text-[11px] tabular-nums text-gray-400 dark:text-gray-500">{fmtTime(r.at_millis)}</span>
               <span class="shrink-0 font-mono text-[9px] font-semibold px-1 py-0.5 rounded {methClass(r.method)}">{r.method}</span>

--- a/internal/ui/web/src/tabs/sites/SiteRequestTiming.test.ts
+++ b/internal/ui/web/src/tabs/sites/SiteRequestTiming.test.ts
@@ -1,0 +1,49 @@
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import { describe, it, expect, vi } from 'vitest';
+import type { Analytics } from '$stores/analytics';
+
+// Two requests to the same URI in the same millisecond are real (Reverb/websocket
+// bursts) and the durable store has no unique constraint, so the Recent list can
+// receive rows that share (at_millis, uri). Its {#each} key must stay unique or
+// Svelte 5 throws a duplicate-key error at render and blanks the tab.
+const analytics: Analytics = {
+  site: 'whitewaters',
+  range: '1h',
+  samples: 2,
+  cold_starts: 0,
+  median_millis: 5,
+  p95_millis: 9,
+  status: { c2xx: 2, c3xx: 0, c4xx: 0, c5xx: 0 },
+  distribution: [],
+  throughput: [],
+  routes: [],
+  recent: [
+    { at_millis: 1783501663287, method: 'POST', route: 'POST /broadcasting/auth', uri: '/broadcasting/auth', status: 200, millis: 4, cold: false },
+    { at_millis: 1783501663287, method: 'POST', route: 'POST /broadcasting/auth', uri: '/broadcasting/auth', status: 200, millis: 6, cold: false }
+  ]
+};
+
+vi.mock('$stores/analytics', () => ({
+  loadSiteAnalytics: vi.fn(async () => analytics),
+  TIME_RANGES: ['15m', '1h', '24h', '7d']
+}));
+
+import SiteRequestTiming from './SiteRequestTiming.svelte';
+import { m } from '../../paraglide/messages.js';
+
+describe('SiteRequestTiming Recent list', () => {
+  it('renders same-millisecond, same-URI rows without a duplicate-key crash', async () => {
+    const { getByRole, findByText, getAllByText } = render(SiteRequestTiming, {
+      props: { site: { domain: 'whitewaters' } }
+    });
+
+    // Wait for the loaded view, then switch to the Recent tab.
+    await findByText(m.sites_timing_recent());
+    await fireEvent.click(getByRole('button', { name: m.sites_timing_recent() }));
+
+    // Both colliding rows render; without a unique key the keyed each throws.
+    await waitFor(() => {
+      expect(getAllByText('/broadcasting/auth').length).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
Disabling DNS with the default TLD and declining the domain rewrite left sites on their .test domains but still marked secured, so the torn down resolver stranded them behind an HTTPS only vhost nginx served unreachably. The declined branch now unsecures them the same way the custom TLD path already does.

The sudoers content marker could not tell a deleted drop in from an intact one, so an ordinary install or update silently skipped restoring a rule removed out of band, and only dns:repair recovered it. A matching marker is now confirmed against a live passwordless probe, and only a conclusive gone grant forces the reinstall while an inconclusive probe defers to the marker.

Service reconcile routed canonical single version presets through the pinned resolver, which errored and skipped every store refresh for them, and it reset a shifted host port back to the preset default on every start. Single version presets now resolve, and the ports and connection url are preserved as install time allocation.

The AI client config merge rewrote a committed mcp.json on every install or update even when the lerd entry was unchanged, reindenting a hand formatted file that a teammate had committed. It now leaves an already equivalent entry untouched.

The request timing Recent list keyed its rows on timestamp plus path, which collide for two requests that complete in the same millisecond and blanked the tab. The key now stays unique per row.

Restoring a partially applied service port save rolled the port back but never re pointed host proxy sites, leaving their .env on a port the service no longer publishes. The rollback now refreshes them to the restored port, mirroring the forward path.

Refs #801
