### PR TITLE
docs: link the v1.28.0 dev digest back to the previous one

### DIFF
--- a/docs/public/digest/v1.28.0.html
+++ b/docs/public/digest/v1.28.0.html
@@ -693,7 +693,7 @@
     </div>
   </div>
   <div class="foot-end">
-    <span>lerd v1.28.0 · 2026-07-08</span>
+    <span>lerd v1.28.0 · 2026-07-08 · <a href="/digest/v1.27.0.html">← v1.27.0 digest</a></span>
     <span><a href="https://github.com/lerd-env/lerd/compare/v1.27.1...v1.28.0">v1.27.1…v1.28.0</a> · <a href="https://lerd.sh/">docs</a> · <a href="https://github.com/lerd-env/lerd">github</a></span>
   </div>
 </footer>


### PR DESCRIPTION
The v1.28.0 dev digest footer was missing the link back to the previous digest that the earlier ones carry, so this adds it pointing at v1.27.0. The SEO and social preview meta already reference the shared social-preview.png asset, so nothing changes there.
