### PR TITLE
fix: apply a changed service config on update, not only on reinstall

### DIFF
--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -821,6 +821,20 @@ func reconcileCustomServices() {
 	if len(res.DefinitionsRefreshed) > 0 {
 		_ = shims.Reconcile(nil)
 	}
+	for _, name := range res.ConfigsApplied {
+		feedback.Warn("applied an updated config to %s and restarted it", name)
+	}
+	// Default-stack services (mysql, postgres, redis…) don't flow through the custom
+	// reconcile above, so apply the same config-drift restart to them: a shipped
+	// preset config bump (e.g. a higher max_allowed_packet) must reach a running
+	// default service on update, not only on an explicit reinstall.
+	for _, name := range config.DefaultPresetNames() {
+		if applied, err := serviceops.RestartIfConfigDrifted(name, name); err != nil {
+			feedback.Warn("applying config for %s: %v", name, err)
+		} else if applied {
+			feedback.Warn("applied an updated config to %s and restarted it", name)
+		}
+	}
 	for _, name := range res.QuadletsRegenerated {
 		feedback.Warn("regenerated missing unit for %s from its config", name)
 	}

--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -389,23 +390,59 @@ func uniqueFamilyHosts(families string) []string {
 // the Go binary is always the source of truth — updating lerd and restarting
 // the service is enough to roll out new file contents.
 func MaterializeServiceFiles(svc *CustomService) error {
+	_, err := MaterializeServiceFilesChanged(svc)
+	return err
+}
+
+// ServiceFilesNewestMtime returns the most recent modification time across svc's
+// materialised preset files, and whether any exist on disk. Because a re-materialise
+// only rewrites a file whose content actually changed, this mod time advances only
+// on a real config change, so comparing it against a container's start time tells
+// whether the running container is on stale config.
+func ServiceFilesNewestMtime(svc *CustomService) (time.Time, bool) {
+	var newest time.Time
+	found := false
+	for _, f := range PresetFiles(svc.Preset) {
+		if f.Target == "" {
+			continue
+		}
+		info, err := os.Stat(ServiceFilePath(svc.Name, f.Target))
+		if err != nil {
+			continue
+		}
+		if info.ModTime().After(newest) {
+			newest = info.ModTime()
+			found = true
+		}
+	}
+	return newest, found
+}
+
+// MaterializeServiceFilesChanged is MaterializeServiceFiles with drift detection:
+// it rewrites a preset file only when its content differs from what is already on
+// disk, and reports whether anything changed. The passive reconcile uses this to
+// roll a shipped preset config bump (e.g. a higher max_allowed_packet) onto an
+// already-installed service on update and to know when a restart is warranted,
+// without churning a service whose config is already current.
+func MaterializeServiceFilesChanged(svc *CustomService) (bool, error) {
 	files := PresetFiles(svc.Preset)
 	if len(files) == 0 {
-		return nil
+		return false, nil
 	}
 	dir := ServiceFilesDir(svc.Name)
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("creating files dir for %s: %w", svc.Name, err)
+		return false, fmt.Errorf("creating files dir for %s: %w", svc.Name, err)
 	}
+	changed := false
 	for _, f := range files {
 		if f.Target == "" {
-			return fmt.Errorf("service %s: file mount missing target", svc.Name)
+			return changed, fmt.Errorf("service %s: file mount missing target", svc.Name)
 		}
 		mode := os.FileMode(0644)
 		if f.Mode != "" {
 			parsed, err := strconv.ParseUint(f.Mode, 8, 32)
 			if err != nil {
-				return fmt.Errorf("service %s: invalid mode %q for %s: %w", svc.Name, f.Mode, f.Target, err)
+				return changed, fmt.Errorf("service %s: invalid mode %q for %s: %w", svc.Name, f.Mode, f.Target, err)
 			}
 			mode = os.FileMode(parsed)
 		}
@@ -414,25 +451,39 @@ func MaterializeServiceFiles(svc *CustomService) error {
 		if f.ContentFn != nil {
 			out, err := f.ContentFn(svc)
 			if err != nil {
-				return fmt.Errorf("generating %s for service %s: %w", path, svc.Name, err)
+				return changed, fmt.Errorf("generating %s for service %s: %w", path, svc.Name, err)
 			}
 			content = out
+		}
+		// A file whose content already matches needs no rewrite; comparing by
+		// content (not ownership) leaves a podman :U-chowned file in place and, most
+		// importantly, avoids a needless service restart when nothing changed. The
+		// mode is still enforced so a re-materialise stays idempotent on permissions,
+		// but a mode-only fixup is not a content change and triggers no restart.
+		if existing, err := os.ReadFile(path); err == nil && string(existing) == content {
+			if info, statErr := os.Stat(path); statErr == nil && info.Mode().Perm() != mode.Perm() {
+				if err := os.Chmod(path, mode); err != nil {
+					return changed, fmt.Errorf("chmod %s: %w", path, err)
+				}
+			}
+			continue
 		}
 		// Unlink first: with chown:true podman's :U flag re-owns the file to a
 		// userns-mapped uid, so a plain rewrite would EACCES. Removing the dir
 		// entry succeeds because the parent dir is owned by us.
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("removing stale %s for service %s: %w", path, svc.Name, err)
+			return changed, fmt.Errorf("removing stale %s for service %s: %w", path, svc.Name, err)
 		}
 		if err := os.WriteFile(path, []byte(content), mode); err != nil {
-			return fmt.Errorf("writing %s for service %s: %w", path, svc.Name, err)
+			return changed, fmt.Errorf("writing %s for service %s: %w", path, svc.Name, err)
 		}
 		// WriteFile honours umask; chmod explicitly so 0600 sticks.
 		if err := os.Chmod(path, mode); err != nil {
-			return fmt.Errorf("chmod %s: %w", path, err)
+			return changed, fmt.Errorf("chmod %s: %w", path, err)
 		}
+		changed = true
 	}
-	return nil
+	return changed, nil
 }
 
 // CustomServicesDependingOn returns the names of all custom services that

--- a/internal/config/custom_service_test.go
+++ b/internal/config/custom_service_test.go
@@ -154,6 +154,41 @@ func TestMaterializeServiceFiles_OverwritesReadOnlyFile(t *testing.T) {
 	}
 }
 
+func TestMaterializeServiceFilesChanged_DetectsContentDrift(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	svc := &CustomService{Name: "pgadmin", Image: "docker.io/dpage/pgadmin4:latest", Preset: "pgadmin"}
+
+	changed, err := MaterializeServiceFilesChanged(svc)
+	if err != nil {
+		t.Fatalf("first materialize: %v", err)
+	}
+	if !changed {
+		t.Fatal("first materialize must report a change (files did not exist yet)")
+	}
+
+	changed, err = MaterializeServiceFilesChanged(svc)
+	if err != nil {
+		t.Fatalf("second materialize: %v", err)
+	}
+	if changed {
+		t.Fatal("re-materialize with identical content must report no change, so no restart is triggered")
+	}
+
+	// A drifted file (what a shipped preset config bump looks like) must be detected.
+	path := ServiceFilePath(svc.Name, "/pgpass")
+	if err := os.WriteFile(path, []byte("stale-content\n"), 0o600); err != nil {
+		t.Fatalf("simulate drift: %v", err)
+	}
+	changed, err = MaterializeServiceFilesChanged(svc)
+	if err != nil {
+		t.Fatalf("drift materialize: %v", err)
+	}
+	if !changed {
+		t.Fatal("a drifted preset file must report a change so the service is restarted")
+	}
+}
+
 func TestValidateCustomService_rejectsEnvInjection(t *testing.T) {
 	svc := &CustomService{Name: "evil", Image: "alpine",
 		Environment: map[string]string{"X": "ok\nPodmanArgs=--privileged"}}

--- a/internal/podman/exec.go
+++ b/internal/podman/exec.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/imgledger"
@@ -295,6 +296,29 @@ func ContainerRunning(name string) (bool, error) {
 		return false, nil
 	}
 	return strings.TrimSpace(out) == "true", nil
+}
+
+// ContainerStartedAt returns the running container's last start time and whether
+// it is currently running. A stopped or missing container reports (zero, false).
+// Used to tell whether a bind-mounted config file has been rewritten since the
+// container booted, i.e. whether it is running stale config.
+func ContainerStartedAt(name string) (time.Time, bool) {
+	// Render StartedAt via its .Format method: the bare {{.State.StartedAt}} emits
+	// Go's time.String() ("2006-01-02 15:04:05 -0700 MST"), not RFC3339, which does
+	// not round-trip through time.Parse.
+	out, err := Run("inspect", `--format={{.State.Running}}|{{.State.StartedAt.Format "2006-01-02T15:04:05.999999999Z07:00"}}`, name)
+	if err != nil {
+		return time.Time{}, false
+	}
+	parts := strings.SplitN(strings.TrimSpace(out), "|", 2)
+	if len(parts) != 2 || parts[0] != "true" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339Nano, parts[1])
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
 }
 
 // ContainerExists returns true if the named container exists (running or not).

--- a/internal/serviceops/reconcile.go
+++ b/internal/serviceops/reconcile.go
@@ -15,6 +15,10 @@ var (
 	ensureQuadletFn          = EnsureCustomServiceQuadlet
 	listManagedServiceNames  = podman.ListManagedServiceNames
 	orphanContainerRunningFn = podman.ContainerRunningQuiet
+	materializeFilesFn       = config.MaterializeServiceFiles
+	newestFileMtimeFn        = config.ServiceFilesNewestMtime
+	containerStartedAtFn     = podman.ContainerStartedAt
+	restartUnitFn            = podman.RestartUnit
 )
 
 // ReconcileResult reports what ReconcileServices changed.
@@ -23,6 +27,7 @@ type ReconcileResult struct {
 	OrphansRemoved        []string // service quadlet with no YAML, removed
 	RunningOrphansSkipped []string // orphan left in place because its container is up
 	DefinitionsRefreshed  []string // preset-backed YAML re-materialised from the store
+	ConfigsApplied        []string // preset config file drifted; rewritten and the running service restarted
 }
 
 // ReconcileServices enforces the issue #678 invariant: regenerate a missing
@@ -58,8 +63,15 @@ func ReconcileServices(emit func(PhaseEvent)) (ReconcileResult, error) {
 			}
 		}
 		unitInstalled := UnitInstalledFn("lerd-" + svc.Name)
-		if unitInstalled && !slices.Contains(res.DefinitionsRefreshed, svc.Name) {
-			continue
+		if unitInstalled {
+			if applied, err := RestartIfConfigDrifted(svc.Name, svc.Preset); err != nil {
+				errs = append(errs, err)
+			} else if applied {
+				res.ConfigsApplied = append(res.ConfigsApplied, svc.Name)
+			}
+			if !slices.Contains(res.DefinitionsRefreshed, svc.Name) {
+				continue
+			}
 		}
 		// Regenerate the quadlet when the unit is missing, or when the definition
 		// changed. WriteQuadletDiff is a no-op when the content is identical, so a
@@ -95,6 +107,33 @@ func ReconcileServices(emit func(PhaseEvent)) (ReconcileResult, error) {
 		res.OrphansRemoved = append(res.OrphansRemoved, name)
 	}
 	return res, errors.Join(errs...)
+}
+
+// RestartIfConfigDrifted re-materialises a running service's preset config files
+// and, when the config file is newer than the container's boot (i.e. the container
+// is on stale config after a shipped preset change like a higher max_allowed_packet),
+// restarts it, returning whether it did. It is the single seam both the custom
+// reconcile and the default-stack start pass use, since those flow through separate
+// install paths. A stopped or missing container, or a preset with no config files,
+// is a no-op; the mtime only advances on a real content change, so a steady state
+// never restarts anything.
+func RestartIfConfigDrifted(name, preset string) (bool, error) {
+	started, running := containerStartedAtFn("lerd-" + name)
+	if !running {
+		return false, nil
+	}
+	probe := &config.CustomService{Name: name, Preset: preset}
+	if err := materializeFilesFn(probe); err != nil {
+		return false, fmt.Errorf("materialising files for %s: %w", name, err)
+	}
+	mtime, ok := newestFileMtimeFn(probe)
+	if !ok || !mtime.After(started) {
+		return false, nil
+	}
+	if err := restartUnitFn("lerd-" + name); err != nil {
+		return false, fmt.Errorf("restarting %s after a config change: %w", name, err)
+	}
+	return true, nil
 }
 
 // refreshPresetDefinition re-resolves a preset-backed service from the store

--- a/internal/serviceops/reconcile_test.go
+++ b/internal/serviceops/reconcile_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
@@ -349,6 +350,77 @@ func TestReconcileServices_continuesPastForwardError(t *testing.T) {
 
 // TestReconcileServices_steadyStateNoop: a fully-installed service (YAML +
 // marked quadlet) triggers neither a regeneration nor a removal.
+// A shipped preset config-file change (e.g. a higher max_allowed_packet) must
+// reach an already-installed, running service on reconcile: when the config file
+// is newer than the container's boot, the service is restarted, so the fix lands
+// on `lerd update` rather than only on an explicit reinstall.
+func TestReconcileServices_appliesDriftedConfigAndRestarts(t *testing.T) {
+	reconcileEnv(t)
+	if err := config.SaveCustomService(&config.CustomService{Name: "mysql", Image: "docker.io/library/mysql:8.4"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	writeQuadlet(t, "mysql", true)
+
+	boot := time.Unix(1_000_000, 0)
+	restore := swapDriftSeams(t,
+		func(*config.CustomService) error { return nil },
+		func(*config.CustomService) (time.Time, bool) { return boot.Add(time.Hour), true }, // file newer than boot
+		func(string) (time.Time, bool) { return boot, true },
+		func(unit string) error { return nil },
+		func(string) bool { return true },
+	)
+	defer restore()
+
+	res, err := ReconcileServices(nil)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !slices.Contains(res.ConfigsApplied, "mysql") {
+		t.Fatalf("expected mysql in ConfigsApplied, got %+v", res)
+	}
+}
+
+func TestReconcileServices_noRestartWhenConfigCurrent(t *testing.T) {
+	reconcileEnv(t)
+	if err := config.SaveCustomService(&config.CustomService{Name: "mysql", Image: "docker.io/library/mysql:8.4"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	writeQuadlet(t, "mysql", true)
+
+	boot := time.Unix(1_000_000, 0)
+	restarted := false
+	restore := swapDriftSeams(t,
+		func(*config.CustomService) error { return nil },
+		func(*config.CustomService) (time.Time, bool) { return boot.Add(-time.Hour), true }, // file older than boot
+		func(string) (time.Time, bool) { return boot, true },
+		func(unit string) error { restarted = true; return nil },
+		func(string) bool { return true },
+	)
+	defer restore()
+
+	res, err := ReconcileServices(nil)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if restarted {
+		t.Fatal("a service booted after its config was written must not be restarted")
+	}
+	if len(res.ConfigsApplied) != 0 {
+		t.Fatalf("expected no ConfigsApplied, got %+v", res)
+	}
+}
+
+// swapDriftSeams overrides the reconcile config-drift seams for a test, restoring
+// them on cleanup.
+func swapDriftSeams(t *testing.T, mat func(*config.CustomService) error, mtime func(*config.CustomService) (time.Time, bool), started func(string) (time.Time, bool), restart func(string) error, installed func(string) bool) func() {
+	t.Helper()
+	pm, pmt, ps, pr, pi := materializeFilesFn, newestFileMtimeFn, containerStartedAtFn, restartUnitFn, UnitInstalledFn
+	materializeFilesFn, newestFileMtimeFn, containerStartedAtFn, restartUnitFn, UnitInstalledFn = mat, mtime, started, restart, installed
+	return func() {
+		materializeFilesFn, newestFileMtimeFn, containerStartedAtFn, restartUnitFn, UnitInstalledFn = pm, pmt, ps, pr, pi
+	}
+}
+
 func TestReconcileServices_steadyStateNoop(t *testing.T) {
 	reconcileEnv(t)
 


### PR DESCRIPTION
A shipped preset config change never reached an already-installed service on a plain lerd update, which is why telling a user to update and try again changed nothing. The reconcile pass only regenerated a service's config files when its unit was missing, and for a running service it refreshed the declarative definition but left the mounted config file alone and never restarted the container, so a higher bundled max_allowed_packet, or any preset config bump, only landed after an explicit lerd service reinstall.

Reconcile now re-materialises a running service's preset files and restarts the container when its config file is newer than the container's boot, meaning the config genuinely drifted since it last started. The file mod time only advances on a real content change, so a steady state restarts nothing, verified by running start three times where the first applies the change and the next two are no-ops. The same drift check covers both custom services and the default stack, which install through separate paths, so it reaches the default mysql as well as a store mariadb. The materialiser gained content-diff detection so an identical file is never rewritten, and podman gained a container start-time reader for the comparison.

This is the delivery fix for the v1.28.0 max_allowed_packet change, and it applies to any future preset config change too.
