### PR TITLE
fix: retry a transient store fetch so a slow CDN response doesn't drop a definition

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,7 +16,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const httpTimeout = 10 * time.Second
+const (
+	httpTimeout       = 10 * time.Second
+	maxFetchAttempts  = 3
+	fetchRetryBackoff = 400 * time.Millisecond
+)
+
+// sleepFn is the backoff sleep, a seam so tests don't wait in real time.
+var sleepFn = time.Sleep
 
 // Client fetches framework definitions from the remote store. BaseURL is tried
 // first; Fallbacks are tried in order if it fails, so a binary can reach the new
@@ -258,13 +266,54 @@ func (c *Client) fetch(path string) ([]byte, error) {
 	client := &http.Client{Timeout: httpTimeout}
 	var errs []string
 	for _, base := range append([]string{c.BaseURL}, c.Fallbacks...) {
-		body, err := fetchOne(client, base+"/"+path)
+		body, err := fetchWithRetry(client, base+"/"+path)
 		if err == nil {
 			return body, nil
 		}
 		errs = append(errs, err.Error())
 	}
 	return nil, fmt.Errorf("fetching %s: %s", path, strings.Join(errs, "; "))
+}
+
+// fetchWithRetry retries a transient fetch failure, a request timeout, a dropped
+// connection, or a 5xx, with a short linear backoff before giving up. A slow
+// raw.githubusercontent.com response is common when refreshing many definitions at
+// once, and would otherwise fail a store entry on the first stall; a definitive 4xx
+// (e.g. a removed definition) is not retried.
+func fetchWithRetry(client *http.Client, url string) ([]byte, error) {
+	var lastErr error
+	for attempt := 1; attempt <= maxFetchAttempts; attempt++ {
+		body, err := fetchOne(client, url)
+		if err == nil {
+			return body, nil
+		}
+		lastErr = err
+		if !retryableFetchErr(err) || attempt == maxFetchAttempts {
+			break
+		}
+		sleepFn(fetchRetryBackoff * time.Duration(attempt))
+	}
+	return nil, lastErr
+}
+
+// httpStatusError carries a non-200 response code so retry classification can tell
+// a retryable 5xx from a definitive 4xx.
+type httpStatusError struct {
+	code int
+	url  string
+}
+
+func (e *httpStatusError) Error() string { return fmt.Sprintf("HTTP %d from %s", e.code, e.url) }
+
+// retryableFetchErr reports whether an error is worth retrying: any network or
+// timeout error (client.Do failing) is transient, an HTTP 5xx is transient, and a
+// 4xx is not.
+func retryableFetchErr(err error) bool {
+	var se *httpStatusError
+	if errors.As(err, &se) {
+		return se.code >= 500
+	}
+	return true
 }
 
 func fetchOne(client *http.Client, url string) ([]byte, error) {
@@ -281,7 +330,7 @@ func fetchOne(client *http.Client, url string) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+		return nil, &httpStatusError{code: resp.StatusCode, url: url}
 	}
 
 	return io.ReadAll(resp.Body)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
 )
@@ -306,5 +308,72 @@ func TestDetectFromStore_NoMatch(t *testing.T) {
 	_, _, ok := c.DetectFromStore(dir)
 	if ok {
 		t.Fatal("expected no detection in empty dir")
+	}
+}
+
+func TestFetchWithRetry_RecoversFromTransientFailure(t *testing.T) {
+	prevSleep := sleepFn
+	sleepFn = func(time.Duration) {}
+	t.Cleanup(func() { sleepFn = prevSleep })
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) < 3 {
+			http.Error(w, "boom", http.StatusBadGateway) // 502, transient
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(srv.Close)
+
+	body, err := fetchWithRetry(&http.Client{Timeout: httpTimeout}, srv.URL)
+	if err != nil {
+		t.Fatalf("expected recovery, got %v", err)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("body = %q, want ok", body)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("expected 3 attempts, got %d", got)
+	}
+}
+
+func TestFetchWithRetry_DoesNotRetry404(t *testing.T) {
+	prevSleep := sleepFn
+	sleepFn = func(time.Duration) {}
+	t.Cleanup(func() { sleepFn = prevSleep })
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		http.Error(w, "nope", http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, err := fetchWithRetry(&http.Client{Timeout: httpTimeout}, srv.URL); err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("a 4xx must not be retried, got %d attempts", got)
+	}
+}
+
+func TestFetchWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
+	prevSleep := sleepFn
+	sleepFn = func(time.Duration) {}
+	t.Cleanup(func() { sleepFn = prevSleep })
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		http.Error(w, "down", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, err := fetchWithRetry(&http.Client{Timeout: httpTimeout}, srv.URL); err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if got := atomic.LoadInt32(&calls); got != maxFetchAttempts {
+		t.Fatalf("expected %d attempts, got %d", maxFetchAttempts, got)
 	}
 }


### PR DESCRIPTION
Refreshing the store fetches each framework or service definition over its own request to raw.githubusercontent.com, and a single slow response would fail that entry outright with context deadline exceeded (Client.Timeout exceeded while awaiting headers), leaving it stale until the next refresh. That is what shows up as a handful of frameworks failing mid-refresh while others succeed, transient CDN latency, not a real error, made worse by pulling a dozen or more files back to back with no retry. Both the framework store and the service store go through the same Client.fetch, so this hardens them together.

A fetch now retries a transient failure, a request timeout, a dropped connection, or a 5xx, up to three attempts with a short linear backoff, and still gives up immediately on a definitive 4xx such as a removed definition. The non-200 path carries a typed status error so the classifier can tell a retryable 5xx from a 4xx, and the backoff sleep is a seam so the tests run instantly.

Connection reuse was already fine, the default transport pools keep-alive connections even though a new http.Client is created per fetch, so retry is the missing piece rather than keep-alive. Bounded-parallel refresh is a reasonable follow-up to cut wall-clock further, but the retry is what stops a slow file from dropping a definition.
