### PR TITLE
fix(services): drop a removed default preset from the service list

### DIFF
--- a/internal/cli/service_list_test.go
+++ b/internal/cli/service_list_test.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
+)
+
+// TestServiceList_excludesRemovedDefaultPreset covers the "a removed default
+// preset lingers in the list" bug: `service list` gates default presets on
+// ServiceInstalled (the #678 truth), so a default whose quadlet is gone drops
+// out of the installed list while an installed sibling stays.
+func TestServiceList_excludesRemovedDefaultPreset(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	// Install one default (redis) by writing its quadlet; leave mysql absent
+	// (the removed default).
+	quadletDir := config.QuadletDir()
+	if err := os.MkdirAll(quadletDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	redisQuadlet := filepath.Join(quadletDir, "lerd-redis.container")
+	if err := os.WriteFile(redisQuadlet, []byte("[Container]\nImage=docker.io/library/redis:7\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	restore := feedback.SetTestWriter(&buf)
+	defer restore()
+
+	if err := newServiceListCmd().Execute(); err != nil {
+		t.Fatalf("service list: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "redis") {
+		t.Errorf("installed default 'redis' should be listed; got:\n%s", out)
+	}
+	if strings.Contains(out, "mysql") {
+		t.Errorf("removed default 'mysql' should not appear in the list; got:\n%s", out)
+	}
+}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -421,6 +421,12 @@ func newServiceListCmd() *cobra.Command {
 				return cell
 			}
 			for _, svc := range knownServices() {
+				// A removed default preset (no unit) is not installed; it lives in
+				// the preset picker as installable, so it shouldn't linger here as
+				// "unknown". ServiceInstalled is the #678 single source of truth.
+				if !serviceops.ServiceInstalled(svc) {
+					continue
+				}
 				unit := "lerd-" + svc
 				status, err := podman.UnitStatus(unit)
 				if err != nil {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -1340,6 +1340,12 @@ func buildServicesList() []ServiceResponse {
 	defaultNames := siteinfo.KnownServices()
 	services := make([]ServiceResponse, 0, len(defaultNames))
 	for _, name := range defaultNames {
+		// A removed default preset (no unit) is not installed, so it belongs in
+		// the preset picker as installable, not lingering here as "inactive".
+		// ServiceInstalled is the #678 single source of truth.
+		if !serviceops.ServiceInstalled(name) {
+			continue
+		}
 		services = append(services, buildServiceResponseWithPortList(svcCfg, name, ssOutput, nil))
 	}
 	// Optional presets (gotenberg, mongo, …) and user services materialise as


### PR DESCRIPTION
Removing a default preset stopped and deleted its container, quadlet and plist, but the service list kept showing it. The web UI's buildServicesList and the CLI service list both walked every default preset name and built a row from UnitStatus, so a removed default lingered as an inactive row in the web UI, and an unknown row in the CLI, reading as if the delete had failed.

Both surfaces now gate the default-preset rows on serviceops.ServiceInstalled, the same single source of truth #678 established. A removed default drops out of the installed list and stays reinstallable from the preset picker, which already resolves its installed flag the same way. Custom services were already fine since they come from the YAML listing that the remove path deletes, and lerd status and the MCP update check already gate on unit presence.

Refs #809