### PR TITLE
feat: support pnpm and yarn projects via corepack

### DIFF
--- a/internal/cli/node_exec.go
+++ b/internal/cli/node_exec.go
@@ -141,9 +141,11 @@ func runBun(dir, bun string, args []string, exitOnFail bool) error {
 	return nil
 }
 
-// runJSInstall installs JS dependencies in dir: `bun install` when the project
-// uses bun (frozen adds --frozen-lockfile), otherwise `npm ci`/`npm install`
-// via fnm.
+// runJSInstall installs JS dependencies in dir with the project's package
+// manager: bun when the project uses bun, else pnpm/yarn (via corepack, which
+// ships with Node so neither needs a separate global install) or npm, picked
+// from the lockfile / packageManager field. frozen uses each manager's
+// lockfile-respecting install.
 func runJSInstall(dir string, frozen bool) error {
 	if bun := bunRunnerFor(dir, true); bun != "" {
 		args := []string{"install"}
@@ -157,19 +159,43 @@ func runJSInstall(dir string, frozen bool) error {
 		}
 		return runBun(dir, bun, args, false)
 	}
-	if frozen {
-		return runWithFnm("npm", []string{"ci"}, false)
+	switch nodeDet.PackageManager(dir) {
+	case "pnpm":
+		args := []string{"pnpm", "install"}
+		if frozen {
+			args = append(args, "--frozen-lockfile")
+		}
+		return runWithFnm("corepack", args, false)
+	case "yarn":
+		// --immutable covers yarn berry; classic (v1) ignores it and does a
+		// normal install, which is what we want with a lockfile present.
+		args := []string{"yarn", "install"}
+		if frozen {
+			args = append(args, "--immutable")
+		}
+		return runWithFnm("corepack", args, false)
+	default:
+		if frozen {
+			return runWithFnm("npm", []string{"ci"}, false)
+		}
+		return runWithFnm("npm", []string{"install"}, false)
 	}
-	return runWithFnm("npm", []string{"install"}, false)
 }
 
-// runJSScript runs a package.json script in dir via `bun run <script>` when the
-// project uses bun, otherwise `npm run <script>` via fnm.
+// runJSScript runs a package.json script in dir with the project's package
+// manager (`bun run` / `pnpm run` / `yarn run` / `npm run`).
 func runJSScript(dir, script string) error {
 	if bun := bunRunnerFor(dir, true); bun != "" {
 		return runBun(dir, bun, []string{"run", script}, false)
 	}
-	return runWithFnm("npm", []string{"run", script}, false)
+	switch nodeDet.PackageManager(dir) {
+	case "pnpm":
+		return runWithFnm("corepack", []string{"pnpm", "run", script}, false)
+	case "yarn":
+		return runWithFnm("corepack", []string{"yarn", "run", script}, false)
+	default:
+		return runWithFnm("npm", []string{"run", script}, false)
+	}
 }
 
 // shimLeadingEnv prepends lerd's bin dir (home of the `php` shim) to PATH so
@@ -230,6 +256,11 @@ func runWithFnm(bin string, args []string, exitOnFail bool) error {
 	manageGlobals := bin == "npm" || bin == "npx"
 	prefix := config.NodeGlobalDir()
 	cmd.Env = shimLeadingEnv(os.Environ())
+	if bin == "corepack" {
+		// First use of a manager downloads it; don't block on the interactive
+		// "Corepack is about to download…" prompt in a non-interactive setup.
+		cmd.Env = append(cmd.Env, "COREPACK_ENABLE_DOWNLOAD_PROMPT=0")
+	}
 	if manageGlobals {
 		if err := os.MkdirAll(filepath.Join(prefix, "bin"), 0o755); err == nil {
 			cmd.Env = append(cmd.Env, "npm_config_prefix="+prefix)

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -178,12 +178,13 @@ func runSetup(allSteps, skipOpen bool) error {
 	jsRuntime := "npm"
 	if nodeDet.UsesBun(cwd) && nodeDet.BunPath() != "" {
 		jsRuntime = "bun"
+	} else if pm := nodeDet.PackageManager(cwd); pm == "pnpm" || pm == "yarn" {
+		jsRuntime = pm
 	}
 	installLabel := "npm install/ci"
-	buildLabel := "npm run " + buildScript
-	if jsRuntime == "bun" {
-		installLabel = "bun install"
-		buildLabel = "bun run " + buildScript
+	buildLabel := jsRuntime + " run " + buildScript
+	if jsRuntime != "npm" {
+		installLabel = jsRuntime + " install"
 	}
 	steps = append(steps, []setupStep{
 		{

--- a/internal/node/bun.go
+++ b/internal/node/bun.go
@@ -63,6 +63,41 @@ func UsesBun(dir string) bool {
 	return false
 }
 
+// PackageManager reports the JS package manager a project uses: the
+// package.json "packageManager" field (corepack's pin) wins, then the lockfile.
+// Returns "bun", "pnpm", "yarn", or "npm" (the default). bun is normally
+// resolved earlier via UsesBun/BunPath; it is reported here too for callers
+// that want the raw signal.
+func PackageManager(dir string) string {
+	if data, err := os.ReadFile(filepath.Join(dir, "package.json")); err == nil {
+		var pkg struct {
+			PackageManager string `json:"packageManager"`
+		}
+		if json.Unmarshal(data, &pkg) == nil {
+			name, _, _ := strings.Cut(strings.TrimSpace(pkg.PackageManager), "@")
+			switch name {
+			case "bun", "pnpm", "yarn", "npm":
+				return name
+			}
+		}
+	}
+	switch {
+	case fileInDir(dir, "bun.lockb"), fileInDir(dir, "bun.lock"):
+		return "bun"
+	case fileInDir(dir, "pnpm-lock.yaml"):
+		return "pnpm"
+	case fileInDir(dir, "yarn.lock"):
+		return "yarn"
+	default:
+		return "npm"
+	}
+}
+
+func fileInDir(dir, name string) bool {
+	_, err := os.Stat(filepath.Join(dir, name))
+	return err == nil
+}
+
 // BunPath resolves the host bun binary: the official installer drops it in
 // ~/.bun/bin, which is not on the controlled PATH lerd gives host workers, so
 // check there first and fall back to PATH. Returns "" when bun isn't installed.

--- a/internal/node/package_manager_test.go
+++ b/internal/node/package_manager_test.go
@@ -1,0 +1,51 @@
+package node
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPackageManager_fromLockfile(t *testing.T) {
+	cases := []struct {
+		name string
+		file string
+		want string
+	}{
+		{"pnpm", "pnpm-lock.yaml", "pnpm"},
+		{"yarn", "yarn.lock", "yarn"},
+		{"bun", "bun.lockb", "bun"},
+		{"npm", "package-lock.json", "npm"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, tc.file), []byte("x"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if got := PackageManager(dir); got != tc.want {
+				t.Errorf("PackageManager(%s) = %q, want %q", tc.file, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPackageManager_emptyDirDefaultsToNpm(t *testing.T) {
+	if got := PackageManager(t.TempDir()); got != "npm" {
+		t.Errorf("PackageManager(empty) = %q, want npm", got)
+	}
+}
+
+func TestPackageManager_packageManagerFieldWins(t *testing.T) {
+	// The corepack pin beats a stray lockfile from another manager.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"packageManager":"pnpm@9.1.0"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := PackageManager(dir); got != "pnpm" {
+		t.Errorf("PackageManager(packageManager=pnpm) = %q, want pnpm", got)
+	}
+}


### PR DESCRIPTION
lerd's JS steps only recognised bun or npm, so a pnpm or yarn project got `npm install`/`npm run` regardless of its lockfile. That ignores the real dependency tree and breaks scripts that assume the pinned manager.

This adds a `PackageManager` detector in internal/node that reads the package.json `packageManager` pin first, then falls back to the lockfile, returning bun, pnpm, yarn, or npm. runJSInstall and runJSScript route pnpm and yarn through corepack (bundled with Node, so no extra global install), using each manager's lockfile-respecting flag on the frozen path: `--frozen-lockfile` for pnpm, `--immutable` for yarn berry. The setup wizard's install and build labels follow the detected manager too, and first corepack use is kept non-interactive by disabling its download prompt.

Closes #812