### PR TITLE
fix: stop stale service badges lingering on the site page

### DIFF
--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -202,11 +202,23 @@ func ReferencesContainer(content, serviceName string) bool {
 		if strings.HasPrefix(strings.TrimSpace(line), "#") {
 			continue
 		}
-		if lineReferencesNeedle(line, needle) {
+		if lineReferencesNeedle(stripInlineComment(line), needle) {
 			return true
 		}
 	}
 	return false
+}
+
+// stripInlineComment drops a trailing "# ..." comment from an .env line. A '#'
+// only starts a comment when preceded by whitespace (dotenv convention), so a
+// '#' inside a value (e.g. a password) is preserved.
+func stripInlineComment(line string) string {
+	for i := 1; i < len(line); i++ {
+		if line[i] == '#' && (line[i-1] == ' ' || line[i-1] == '\t') {
+			return line[:i]
+		}
+	}
+	return line
 }
 
 // lineReferencesNeedle reports whether line contains needle as a whole token

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -193,16 +193,32 @@ func ReadValues(path string) map[string]string {
 
 // ReferencesContainer reports whether content references the lerd container
 // hostname "lerd-<serviceName>" as a whole token, so bare "postgres" is not
-// matched by a "lerd-postgres-18" reference (and vice versa).
+// matched by a "lerd-postgres-18" reference (and vice versa). Commented-out
+// lines are ignored so a disabled "#DB_HOST=lerd-mysql" doesn't keep a removed
+// service's badge alive on the site page.
 func ReferencesContainer(content, serviceName string) bool {
 	needle := "lerd-" + serviceName
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		if lineReferencesNeedle(line, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// lineReferencesNeedle reports whether line contains needle as a whole token
+// (the next byte, if any, is not part of a service name).
+func lineReferencesNeedle(line, needle string) bool {
 	for i := 0; ; {
-		j := strings.Index(content[i:], needle)
+		j := strings.Index(line[i:], needle)
 		if j < 0 {
 			return false
 		}
 		end := i + j + len(needle)
-		if end >= len(content) || !isServiceNameByte(content[end]) {
+		if end >= len(line) || !isServiceNameByte(line[end]) {
 			return true
 		}
 		i += j + 1

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -381,6 +381,9 @@ func TestReferencesContainer(t *testing.T) {
 		{"commented reference ignored", "#DB_HOST=lerd-mysql\nDB_HOST=lerd-mariadb-10-11\n", "mysql", false},
 		{"indented comment ignored", "  # DB_HOST=lerd-mysql\n", "mysql", false},
 		{"active wins over commented", "#DB_HOST=lerd-mysql\nDB_HOST=lerd-mysql\n", "mysql", true},
+		{"inline comment ignored", "DB_HOST=lerd-mariadb # was lerd-mysql\n", "mysql", false},
+		{"live token before inline comment matches", "DB_HOST=lerd-mysql # note\n", "mysql", true},
+		{"hash without leading space is not a comment", "DB_HOST=lerd-mysql#x\n", "mysql", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/envfile/envfile_test.go
+++ b/internal/envfile/envfile_test.go
@@ -378,6 +378,9 @@ func TestReferencesContainer(t *testing.T) {
 		{"family alternate matches itself", "DB_HOST=lerd-mysql-5-7\n", "mysql-5-7", true},
 		{"no reference", "DB_HOST=127.0.0.1\n", "postgres", false},
 		{"match at EOF no newline", "DB_HOST=lerd-redis", "redis", true},
+		{"commented reference ignored", "#DB_HOST=lerd-mysql\nDB_HOST=lerd-mariadb-10-11\n", "mysql", false},
+		{"indented comment ignored", "  # DB_HOST=lerd-mysql\n", "mysql", false},
+		{"active wins over commented", "#DB_HOST=lerd-mysql\nDB_HOST=lerd-mysql\n", "mysql", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -668,10 +668,16 @@ func (e *EnrichedSite) enrichServices() {
 	}
 	envStr := string(envData)
 	for _, svcName := range KnownServices() {
-		if !svcSet[svcName] && envfile.ReferencesContainer(envStr, svcName) {
-			e.Services = append(e.Services, svcName)
-			svcSet[svcName] = true
+		if svcSet[svcName] || !envfile.ReferencesContainer(envStr, svcName) {
+			continue
 		}
+		// Skip a referenced-but-uninstalled default preset so a removed service
+		// (quadlet gone) stops ghosting on sites whose .env still points at it.
+		if !podman.QuadletInstalled("lerd-" + svcName) {
+			continue
+		}
+		e.Services = append(e.Services, svcName)
+		svcSet[svcName] = true
 	}
 	if customs, err := config.ListCustomServices(); err == nil {
 		for _, cs := range customs {

--- a/internal/siteinfo/siteinfo_test.go
+++ b/internal/siteinfo/siteinfo_test.go
@@ -592,8 +592,28 @@ func TestLatestLogTime(t *testing.T) {
 
 // ── Service auto-detection ──────────────────────────────────────────────────
 
+// installQuadlets points QuadletDir() at a temp XDG_CONFIG_HOME and writes a
+// quadlet file for each named default preset so enrichServices sees it as
+// installed.
+func installQuadlets(t *testing.T, names ...string) {
+	t.Helper()
+	cfg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	dir := filepath.Join(cfg, "containers", "systemd")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range names {
+		path := filepath.Join(dir, "lerd-"+n+".container")
+		if err := os.WriteFile(path, []byte("[Container]\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func TestEnrichServices(t *testing.T) {
-	t.Run("detects services from .env", func(t *testing.T) {
+	t.Run("detects installed services from .env", func(t *testing.T) {
+		installQuadlets(t, "mysql", "redis")
 		dir := t.TempDir()
 		envContent := "DB_HOST=lerd-mysql\nCACHE_STORE=lerd-redis\n"
 		os.WriteFile(filepath.Join(dir, ".env"), []byte(envContent), 0644)
@@ -613,6 +633,26 @@ func TestEnrichServices(t *testing.T) {
 		}
 		if svcMap["postgres"] {
 			t.Error("expected postgres to NOT be detected")
+		}
+	})
+
+	t.Run("skips a referenced but uninstalled service", func(t *testing.T) {
+		installQuadlets(t, "redis") // mysql intentionally not installed
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, ".env"), []byte("DB_HOST=lerd-mysql\nCACHE_STORE=lerd-redis\n"), 0644)
+
+		e := &EnrichedSite{Path: dir}
+		e.enrichServices()
+
+		svcMap := make(map[string]bool)
+		for _, s := range e.Services {
+			svcMap[s] = true
+		}
+		if svcMap["mysql"] {
+			t.Error("expected removed mysql to be skipped, got a ghost badge")
+		}
+		if !svcMap["redis"] {
+			t.Error("expected installed redis to still be detected")
 		}
 	})
 


### PR DESCRIPTION
A site detail page enumerates its SERVICES badges from container hostname references in the project `.env` (`envfile.ReferencesContainer`), matched against every default preset name. A badge could get stuck as a permanent gray "Stopped" chip that never went away. This fixes three ways that happened:

1. Commented-out references counted as live. The match scanned the whole `.env` as one blob, so a disabled line like `#DB_HOST=lerd-mysql` still counted even when the active `DB_HOST` pointed elsewhere. The `.env` is now scanned line by line and commented-out lines (leading `#`) are skipped. An active reference still wins if both a commented and an uncommented line mention the same service. The whole-token boundary check is unchanged, just moved into a per-line helper.
2. Inline comments on an otherwise live line. A trailing comment like `DB_HOST=lerd-mariadb # was lerd-mysql` still ghosted the commented service. A `#` preceded by whitespace is now stripped before the token match (dotenv convention), so a `#` inside a value (e.g. a password) is preserved.
3. Removed services still enumerated. `enrichServices` inferred default-preset services purely from `.env` references, with no install-state check, so a service whose quadlet had been removed kept ghosting on every site whose `.env` still pointed at it (e.g. a CodeIgniter site with `database.default.hostname=lerd-mysql` after mysql was removed). The `.env`-inferred default presets are now gated on `podman.QuadletInstalled`, matching the `ServiceInstalled` source of truth. An installed-but-stopped service still shows as "Stopped" (a useful signal); only a genuinely absent one is skipped.

Notes:

4. `ReferencesContainer` is also used by the unpause path to decide which services to start for a site, so this also stops unpause from starting a service that is only mentioned on a commented-out `.env` line, which is the intended behaviour.
5. `.lerd.yaml`-declared services are intentionally left ungated: they are an explicit declaration rather than something inferred from `.env`, so they show up whether or not the service happens to be installed.

Tests: `TestReferencesContainer` gains cases for commented, indented-comment, inline-comment, live-token-before-inline-comment, and hash-without-leading-space; a new `TestEnrichServices` case covers a referenced-but-uninstalled service being skipped while an installed one is still detected.

Closes #815
