### PR TITLE
feat(worker-heal): flag a live worker whose server has died as unreachable

### DIFF
--- a/docs/usage/framework-workers.md
+++ b/docs/usage/framework-workers.md
@@ -48,6 +48,19 @@ workers:
 
 Port assignment scans all proxy port env keys across all sites to prevent collisions between different workers and frameworks.
 
+**Server health probe**: A worker whose process can outlive its server (a Vite dev server that dies under `npm` while the Node process lingers) declares a `health` block, so lerd probes reachability rather than mere process liveness:
+
+```yaml
+workers:
+  vite:
+    command: npm run dev
+    host: true
+    health:
+      url_file: public/hot   # a file the server writes on boot, holding its URL
+```
+
+`url_file` names a file the dev server writes when it binds (Vite's `public/hot` holds a URL like `http://[::1]:5173`). While the process is up, lerd reads that file and makes a short TCP dial to its host and port; if nothing is accepting, the worker reports **unreachable** instead of running and [worker-heal](/usage/worker-heal) restarts it. A worker with no `health` block keeps the process-only liveness check. A missing `url_file` is treated as not-probeable, so idle-suspend clearing `public/hot` never trips a false alarm.
+
 **Host workers**: Workers that need to run on the host instead of inside the PHP-FPM container set `host: true`. The command runs via fnm at the project's pinned Node.js version. This is used for tools like Vite that need direct filesystem access for HMR:
 
 ```yaml

--- a/docs/usage/worker-heal.md
+++ b/docs/usage/worker-heal.md
@@ -13,6 +13,12 @@ Two common paths:
 
 The second case requires fixing the underlying error before heal will stick. Heal will start the unit, but if it crashes again it'll burn through the rate limit and re-enter `failed`. The dashboard banner will reappear; check the worker logs (`lerd worker logs <name>` or the dashboard logs pane) for the real cause.
 
+## Workers that run but stop serving
+
+A worker can keep its process alive after its server has died: a Vite dev server whose HTTP server crashes under `npm` while the Node process lingers. systemd still reports the unit active, so process liveness alone reads it as running when nothing is listening.
+
+A worker that declares a [`health` block](/usage/framework-workers) is probed for reachability instead. While its process is up, lerd reads the URL file the server writes on boot (Vite's `public/hot`) and dials its host and port; if nothing is accepting, the worker is reported **unreachable** and heal restarts it (a plain start is a no-op on a still-running unit). Workers with no `health` block keep the process-only check.
+
 ## CLI
 
 ```sh

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -148,6 +148,7 @@ type FrameworkWorker struct {
 	ExcludeCheck   *FrameworkRule `yaml:"exclude_check,omitempty"`  // only show when check FAILS (e.g. queue is hidden when laravel/horizon is installed because horizon supersedes it)
 	ConflictsWith  []string       `yaml:"conflicts_with,omitempty"` // workers to stop before starting this one (e.g. horizon conflicts_with queue)
 	Proxy          *WorkerProxy   `yaml:"proxy,omitempty"`          // WebSocket/HTTP proxy config for nginx
+	Health         *WorkerHealth  `yaml:"health,omitempty"`         // reachability probe: process alive but server not accepting = unhealthy
 	Host           bool           `yaml:"host,omitempty"`           // run on the host via fnm instead of inside the PHP-FPM container
 	// PerWorktree opts the worker into running independently per git worktree
 	// (lerd-<wname>-<site>-<wt>). Defaults to false; set true on workers that
@@ -177,6 +178,17 @@ type WorkerProxy struct {
 	Path        string `yaml:"path"`                   // URL path to proxy (e.g. "/app")
 	PortEnvKey  string `yaml:"port_env_key,omitempty"` // env key holding the port (e.g. "REVERB_SERVER_PORT")
 	DefaultPort int    `yaml:"default_port,omitempty"` // fallback port if env key is missing (default: 8080)
+}
+
+// WorkerHealth declares how to tell whether a worker's server is actually
+// reachable, not merely that its process is alive. A dev server (vite under
+// fnm/npm) can keep its process up after its HTTP server has died, so systemd
+// still reports the unit active while nothing is listening. Where the port lives
+// is declared here, never in Go: URLFile names a file the server writes on boot
+// (vite's public/hot) whose contents carry the URL to probe. A worker with no
+// Health block keeps the process-only liveness check unchanged.
+type WorkerHealth struct {
+	URLFile string `yaml:"url_file,omitempty"` // file (relative to site root) holding the server URL, e.g. "public/hot"
 }
 
 // FrameworkLogSource describes where application log files live for a framework.

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -1910,14 +1910,54 @@ func DetectMajorVersion(projectDir, frameworkName string) string {
 	return ""
 }
 
-func detectVersionFromComposer(projectDir string, rules []FrameworkRule) string {
-	data, err := os.ReadFile(filepath.Join(projectDir, "composer.json"))
-	if err != nil {
-		return ""
+// composerParseCache memoises the parsed top-level sections of a project's
+// composer.json, keyed by path and invalidated by mtime+size. DetectMajorVersion
+// runs on the daemon's hot snapshot path (once per site per tick, and now once
+// per site inside workerheal.Detect), where re-reading and re-unmarshalling
+// composer.json every call showed up as avoidable work. The cached map is only
+// read by callers, so sharing it is safe.
+type composerParseEntry struct {
+	raw   map[string]json.RawMessage
+	mtime time.Time
+	size  int64
+}
+
+var (
+	composerParseCacheMu sync.Mutex
+	composerParseCache   = map[string]composerParseEntry{}
+)
+
+// parseComposerJSON returns the top-level sections of a project's composer.json,
+// mtime-cached. ok is false when the file is missing or unparseable.
+func parseComposerJSON(projectDir string) (raw map[string]json.RawMessage, ok bool) {
+	path := filepath.Join(projectDir, "composer.json")
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		return nil, false
 	}
 
-	var raw map[string]json.RawMessage
-	if json.Unmarshal(data, &raw) != nil {
+	composerParseCacheMu.Lock()
+	if e, hit := composerParseCache[path]; hit && e.mtime.Equal(info.ModTime()) && e.size == info.Size() {
+		composerParseCacheMu.Unlock()
+		return e.raw, e.raw != nil
+	}
+	composerParseCacheMu.Unlock()
+
+	var parsed map[string]json.RawMessage
+	if data, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(data, &parsed) // nil on failure -> cached as a miss
+	}
+
+	composerParseCacheMu.Lock()
+	composerParseCache[path] = composerParseEntry{raw: parsed, mtime: info.ModTime(), size: info.Size()}
+	composerParseCacheMu.Unlock()
+
+	return parsed, parsed != nil
+}
+
+func detectVersionFromComposer(projectDir string, rules []FrameworkRule) string {
+	raw, ok := parseComposerJSON(projectDir)
+	if !ok {
 		return ""
 	}
 

--- a/internal/config/framework_detect_test.go
+++ b/internal/config/framework_detect_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -100,6 +101,31 @@ func TestDetectMajorVersion_SymfonyFromBuiltinRules(t *testing.T) {
 
 	if v := DetectMajorVersion(dir, "symfony"); v != "7" {
 		t.Errorf("expected major 7 from built-in symfony rules, got %q", v)
+	}
+}
+
+func TestParseComposerJSON_MtimeCached(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "composer.json")
+	os.WriteFile(path, []byte(`{"require":{"laravel/framework":"11.0"}}`), 0644) //nolint:errcheck
+
+	first, ok := parseComposerJSON(dir)
+	if !ok {
+		t.Fatal("expected parse ok")
+	}
+	second, _ := parseComposerJSON(dir)
+	if reflect.ValueOf(first).Pointer() != reflect.ValueOf(second).Pointer() {
+		t.Error("unchanged file should return the same cached map, not a reparse")
+	}
+
+	// A changed file (different size) invalidates the cache and reparses.
+	os.WriteFile(path, []byte(`{"require":{"laravel/framework":"12.0","a/b":"1.0"}}`), 0644) //nolint:errcheck
+	third, ok := parseComposerJSON(dir)
+	if !ok {
+		t.Fatal("expected reparse ok")
+	}
+	if reflect.ValueOf(third).Pointer() == reflect.ValueOf(first).Pointer() {
+		t.Error("changed file should reparse, not serve the stale cached map")
 	}
 }
 

--- a/internal/config/framework_health_test.go
+++ b/internal/config/framework_health_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The vite worker's health block (mirrored in the lerd-env/frameworks store)
+// must unmarshal into WorkerHealth so Detect can find where the dev server
+// publishes its port.
+func TestWorkerHealthUnmarshals(t *testing.T) {
+	src := `
+workers:
+  vite:
+    command: npm run dev
+    host: true
+    check:
+      file: node_modules/vite
+    health:
+      url_file: public/hot
+  queue:
+    command: php artisan queue:work
+`
+	var fw Framework
+	if err := yaml.Unmarshal([]byte(src), &fw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	vite, ok := fw.Workers["vite"]
+	if !ok || vite.Health == nil {
+		t.Fatalf("vite health block missing: %+v", fw.Workers["vite"])
+	}
+	if vite.Health.URLFile != "public/hot" {
+		t.Errorf("url_file = %q, want public/hot", vite.Health.URLFile)
+	}
+	// A worker without the block leaves Health nil, so the probe is skipped.
+	if q := fw.Workers["queue"]; q.Health != nil {
+		t.Errorf("queue should have no health block, got %+v", q.Health)
+	}
+}

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -558,11 +558,22 @@ func (e *EnrichedSite) enrichWorkers(fw *config.Framework, hasFw bool) {
 		if label == "" {
 			label = wname
 		}
+		running := unitStatus == "active" || unitStatus == "activating"
+		failing := unitStatus == "failed"
+		// A worker whose process is up but whose server isn't accepting is
+		// unhealthy, not running (a vite dev server that died under npm). Probe
+		// only "active" (a still-activating server may not have bound yet).
+		if unitStatus == "active" && w.Health != nil {
+			if reachable, probed := WorkerServerReachable(e.Path, w.Health); probed && !reachable {
+				running = false
+				failing = true
+			}
+		}
 		e.FrameworkWorkers = append(e.FrameworkWorkers, WorkerInfo{
 			Name:    wname,
 			Label:   label,
-			Running: unitStatus == "active" || unitStatus == "activating",
-			Failing: unitStatus == "failed",
+			Running: running,
+			Failing: failing,
 		})
 	}
 }
@@ -594,11 +605,21 @@ func enrichWorktreeWorkers(siteName, wtPath string, fw *config.Framework) []Work
 		if label == "" {
 			label = wname
 		}
+		running := status == "active" || status == "activating"
+		failing := status == "failed"
+		// Same server-reachability check as enrichWorkers, against this worktree's
+		// own checkout where its dev server writes the URL file.
+		if status == "active" && w.Health != nil {
+			if reachable, probed := WorkerServerReachable(wtPath, w.Health); probed && !reachable {
+				running = false
+				failing = true
+			}
+		}
 		out = append(out, WorkerInfo{
 			Name:    wname,
 			Label:   label,
-			Running: status == "active" || status == "activating",
-			Failing: status == "failed",
+			Running: running,
+			Failing: failing,
 		})
 	}
 	return out

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -40,11 +40,18 @@ const (
 )
 
 // WorkerInfo describes a framework worker and its runtime state.
+//
+// Failing means systemd reports the unit failed. Unreachable is a distinct
+// state: the unit is active (its process is up) but its declared server is not
+// accepting connections — a vite dev server that died under npm. The two are
+// kept apart so a surface never labels an active unit "failed" (which would
+// attach a misleading last-log line); they are mutually exclusive.
 type WorkerInfo struct {
-	Name    string
-	Label   string
-	Running bool
-	Failing bool
+	Name        string
+	Label       string
+	Running     bool
+	Failing     bool
+	Unreachable bool
 }
 
 // WorktreeInfo describes a git worktree associated with a site.
@@ -560,20 +567,23 @@ func (e *EnrichedSite) enrichWorkers(fw *config.Framework, hasFw bool) {
 		}
 		running := unitStatus == "active" || unitStatus == "activating"
 		failing := unitStatus == "failed"
+		unreachable := false
 		// A worker whose process is up but whose server isn't accepting is
 		// unhealthy, not running (a vite dev server that died under npm). Probe
-		// only "active" (a still-activating server may not have bound yet).
+		// only "active" (a still-activating server may not have bound yet). It is
+		// unreachable, not failed: systemd still calls the unit active.
 		if unitStatus == "active" && w.Health != nil {
 			if reachable, probed := WorkerServerReachable(e.Path, w.Health); probed && !reachable {
 				running = false
-				failing = true
+				unreachable = true
 			}
 		}
 		e.FrameworkWorkers = append(e.FrameworkWorkers, WorkerInfo{
-			Name:    wname,
-			Label:   label,
-			Running: running,
-			Failing: failing,
+			Name:        wname,
+			Label:       label,
+			Running:     running,
+			Failing:     failing,
+			Unreachable: unreachable,
 		})
 	}
 }
@@ -607,19 +617,22 @@ func enrichWorktreeWorkers(siteName, wtPath string, fw *config.Framework) []Work
 		}
 		running := status == "active" || status == "activating"
 		failing := status == "failed"
+		unreachable := false
 		// Same server-reachability check as enrichWorkers, against this worktree's
-		// own checkout where its dev server writes the URL file.
+		// own checkout where its dev server writes the URL file. Active-but-unbound
+		// is unreachable, not failed.
 		if status == "active" && w.Health != nil {
 			if reachable, probed := WorkerServerReachable(wtPath, w.Health); probed && !reachable {
 				running = false
-				failing = true
+				unreachable = true
 			}
 		}
 		out = append(out, WorkerInfo{
-			Name:    wname,
-			Label:   label,
-			Running: running,
-			Failing: failing,
+			Name:        wname,
+			Label:       label,
+			Running:     running,
+			Failing:     failing,
+			Unreachable: unreachable,
 		})
 	}
 	return out

--- a/internal/siteinfo/workerhealth.go
+++ b/internal/siteinfo/workerhealth.go
@@ -1,0 +1,71 @@
+package siteinfo
+
+import (
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// healthDialTimeout bounds one reachability probe so a hung dev server can't
+// stall the snapshot. Short because the server is on the same host.
+const healthDialTimeout = 300 * time.Millisecond
+
+// dialProbe opens and closes a TCP connection; a var so tests probe without a
+// real socket.
+var dialProbe = func(address string) error {
+	c, err := net.DialTimeout("tcp", address, healthDialTimeout)
+	if err != nil {
+		return err
+	}
+	return c.Close()
+}
+
+// WorkerServerReachable reports whether a worker's declared server is accepting
+// connections. probed is false when the worker declares no usable health source
+// (no block, a URL file that isn't there yet, or a file with no host:port), in
+// which case the caller keeps the process-only liveness check. A missing URL
+// file is treated as not-probeable rather than a failure: idle-suspend clears
+// vite's public/hot while the unit is briefly still up, and the real failure the
+// block catches is a stale file whose advertised port is refused. When probed is
+// true, reachable is the result of a short TCP dial.
+func WorkerServerReachable(sitePath string, h *config.WorkerHealth) (reachable, probed bool) {
+	if h == nil || h.URLFile == "" {
+		return false, false
+	}
+	data, err := os.ReadFile(filepath.Join(sitePath, h.URLFile))
+	if err != nil {
+		return false, false
+	}
+	addr := hostPortFromURL(strings.TrimSpace(string(data)))
+	if addr == "" {
+		return false, false
+	}
+	if err := dialProbe(addr); err != nil {
+		return false, true
+	}
+	return true, true
+}
+
+// hostPortFromURL pulls a dialable host:port out of a server URL like
+// "http://[::1]:5173" or "http://localhost:5173". Returns "" when there is no
+// port, since then there is nothing to probe. A host-less URL defaults to
+// localhost, which is where a same-host dev server binds.
+func hostPortFromURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Port() == "" {
+		return ""
+	}
+	host := u.Hostname()
+	if host == "" {
+		host = "localhost"
+	}
+	return net.JoinHostPort(host, u.Port())
+}

--- a/internal/siteinfo/workerhealth_test.go
+++ b/internal/siteinfo/workerhealth_test.go
@@ -1,0 +1,76 @@
+package siteinfo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestHostPortFromURL(t *testing.T) {
+	cases := map[string]string{
+		"http://[::1]:5173":       "[::1]:5173",
+		"http://localhost:5173":   "localhost:5173",
+		"https://127.0.0.1:443/x": "127.0.0.1:443",
+		"//host:8080":             "host:8080",
+		"http://localhost":        "", // no port, nothing to probe
+		"not a url":               "",
+		"":                        "",
+	}
+	for in, want := range cases {
+		if got := hostPortFromURL(in); got != want {
+			t.Errorf("hostPortFromURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestWorkerServerReachable(t *testing.T) {
+	prev := dialProbe
+	t.Cleanup(func() { dialProbe = prev })
+
+	dir := t.TempDir()
+	hot := filepath.Join(dir, "public", "hot")
+	if err := os.MkdirAll(filepath.Dir(hot), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	h := &config.WorkerHealth{URLFile: "public/hot"}
+
+	// No block / empty URLFile: not probeable.
+	if _, probed := WorkerServerReachable(dir, nil); probed {
+		t.Error("nil health should not be probed")
+	}
+	if _, probed := WorkerServerReachable(dir, &config.WorkerHealth{}); probed {
+		t.Error("empty url_file should not be probed")
+	}
+
+	// File missing: not a failure (idle-suspend clears it while briefly up).
+	dialProbe = func(string) error { t.Fatal("should not dial when file is absent"); return nil }
+	if reachable, probed := WorkerServerReachable(dir, h); probed || reachable {
+		t.Errorf("missing hot file: got reachable=%v probed=%v, want false/false", reachable, probed)
+	}
+
+	// File present, server accepting: reachable.
+	os.WriteFile(hot, []byte("http://[::1]:5173\n"), 0o644)
+	var dialed string
+	dialProbe = func(addr string) error { dialed = addr; return nil }
+	if reachable, probed := WorkerServerReachable(dir, h); !reachable || !probed {
+		t.Errorf("reachable server: got reachable=%v probed=%v, want true/true", reachable, probed)
+	}
+	if dialed != "[::1]:5173" {
+		t.Errorf("dialed %q, want [::1]:5173", dialed)
+	}
+
+	// File present (stale port), server refusing: unhealthy.
+	dialProbe = func(string) error { return os.ErrDeadlineExceeded }
+	if reachable, probed := WorkerServerReachable(dir, h); reachable || !probed {
+		t.Errorf("dead server: got reachable=%v probed=%v, want false/true", reachable, probed)
+	}
+
+	// File present but no port: not probeable.
+	os.WriteFile(hot, []byte("http://localhost\n"), 0o644)
+	dialProbe = func(string) error { t.Fatal("should not dial an unparseable URL"); return nil }
+	if reachable, probed := WorkerServerReachable(dir, h); probed || reachable {
+		t.Errorf("portless url: got reachable=%v probed=%v, want false/false", reachable, probed)
+	}
+}

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -14,14 +14,16 @@ import (
 
 // workerVisual is the single source for how a worker's live state renders: its
 // style, dot glyph, and one-word label, applying the one precedence used
-// everywhere — failing > running > suspended > stopped. The five render sites
+// everywhere — failing > unreachable > running > suspended > stopped. The five render sites
 // (site rows, detail rows, worktree rows) all route through this so the
 // orderings and colours can't drift apart. stoppedStyle and dimStyle share a
 // colour, so the stopped word looks identical to the old dimStyle rendering.
-func workerVisual(failing, running, suspended bool) (style lipgloss.Style, glyph, word string) {
+func workerVisual(failing, unreachable, running, suspended bool) (style lipgloss.Style, glyph, word string) {
 	switch {
 	case failing:
 		return failingStyle, glyphFailing, "failing"
+	case unreachable:
+		return unreachableStyle, glyphUnreachable, "unreachable"
 	case running:
 		return runningStyle, glyphRunning, "running"
 	case suspended:
@@ -278,6 +280,18 @@ func worktreeWorkerFailing(wt *siteinfo.WorktreeInfo, name string) bool {
 	return false
 }
 
+func worktreeWorkerUnreachable(wt *siteinfo.WorktreeInfo, name string) bool {
+	if wt == nil {
+		return false
+	}
+	for _, fw := range wt.FrameworkWorkers {
+		if fw.Name == name {
+			return fw.Unreachable
+		}
+	}
+	return false
+}
+
 func worktreeWorkerSuspended(wt *siteinfo.WorktreeInfo, name string) bool {
 	if wt == nil {
 		return false
@@ -411,6 +425,18 @@ func workerFailing(s *siteinfo.EnrichedSite, name string) bool {
 	for _, fw := range s.FrameworkWorkers {
 		if fw.Name == name {
 			return fw.Failing
+		}
+	}
+	return false
+}
+
+// workerUnreachable reports whether the worker's process is up but its server
+// isn't accepting. Only health-probed framework workers (e.g. vite) can be
+// unreachable; q/s/r/h have no health block.
+func workerUnreachable(s *siteinfo.EnrichedSite, name string) bool {
+	for _, fw := range s.FrameworkWorkers {
+		if fw.Name == name {
+			return fw.Unreachable
 		}
 	}
 	return false
@@ -853,12 +879,12 @@ func domainRole(s *siteinfo.EnrichedSite, domain string) string {
 }
 
 func worktreeWorkerGlyph(wt *siteinfo.WorktreeInfo, name string) string {
-	st, glyph, _ := workerVisual(worktreeWorkerFailing(wt, name), worktreeWorkerRunning(wt, name), worktreeWorkerSuspended(wt, name))
+	st, glyph, _ := workerVisual(worktreeWorkerFailing(wt, name), worktreeWorkerUnreachable(wt, name), worktreeWorkerRunning(wt, name), worktreeWorkerSuspended(wt, name))
 	return st.Render(glyph)
 }
 
 func worktreeWorkerStateText(wt *siteinfo.WorktreeInfo, name string) string {
-	st, _, word := workerVisual(worktreeWorkerFailing(wt, name), worktreeWorkerRunning(wt, name), worktreeWorkerSuspended(wt, name))
+	st, _, word := workerVisual(worktreeWorkerFailing(wt, name), worktreeWorkerUnreachable(wt, name), worktreeWorkerRunning(wt, name), worktreeWorkerSuspended(wt, name))
 	return st.Render(word)
 }
 
@@ -887,12 +913,12 @@ func worktreeVersionText(version string, override bool) string {
 }
 
 func workerGlyphFor(s *siteinfo.EnrichedSite, name string) string {
-	st, glyph, _ := workerVisual(workerFailing(s, name), workerRunning(s, name), workerSuspended(s, name))
+	st, glyph, _ := workerVisual(workerFailing(s, name), workerUnreachable(s, name), workerRunning(s, name), workerSuspended(s, name))
 	return st.Render(glyph)
 }
 
 func workerStateText(s *siteinfo.EnrichedSite, name string) string {
-	st, _, word := workerVisual(workerFailing(s, name), workerRunning(s, name), workerSuspended(s, name))
+	st, _, word := workerVisual(workerFailing(s, name), workerUnreachable(s, name), workerRunning(s, name), workerSuspended(s, name))
 	return st.Render(word)
 }
 

--- a/internal/tui/panes.go
+++ b/internal/tui/panes.go
@@ -565,19 +565,19 @@ func fpmGlyph(s siteinfo.EnrichedSite) string {
 
 func workerGlyphs(s siteinfo.EnrichedSite) string {
 	var out []string
-	add := func(has, running, failing, suspended bool, label string) {
+	add := func(has, running, failing, unreachable, suspended bool, label string) {
 		if !has {
 			return
 		}
-		st, _, _ := workerVisual(failing, running, suspended)
+		st, _, _ := workerVisual(failing, unreachable, running, suspended)
 		out = append(out, st.Render(label))
 	}
-	add(s.HasQueueWorker, s.QueueRunning, s.QueueFailing, workerSuspended(&s, "queue"), "q")
-	add(s.HasScheduleWorker, s.ScheduleRunning, s.ScheduleFailing, workerSuspended(&s, "schedule"), "s")
-	add(s.HasReverb, s.ReverbRunning, s.ReverbFailing, workerSuspended(&s, "reverb"), "v")
-	add(s.HasHorizon, s.HorizonRunning, s.HorizonFailing, workerSuspended(&s, "horizon"), "h")
+	add(s.HasQueueWorker, s.QueueRunning, s.QueueFailing, false, workerSuspended(&s, "queue"), "q")
+	add(s.HasScheduleWorker, s.ScheduleRunning, s.ScheduleFailing, false, workerSuspended(&s, "schedule"), "s")
+	add(s.HasReverb, s.ReverbRunning, s.ReverbFailing, false, workerSuspended(&s, "reverb"), "v")
+	add(s.HasHorizon, s.HorizonRunning, s.HorizonFailing, false, workerSuspended(&s, "horizon"), "h")
 	for _, fw := range s.FrameworkWorkers {
-		add(true, fw.Running, fw.Failing, workerSuspended(&s, fw.Name), "•")
+		add(true, fw.Running, fw.Failing, fw.Unreachable, workerSuspended(&s, fw.Name), "•")
 	}
 	return strings.Join(out, " ")
 }

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -20,19 +20,22 @@ var (
 )
 
 var (
-	titleStyle     = lipgloss.NewStyle().Bold(true).Foreground(colTitle)
-	sectionStyle   = lipgloss.NewStyle().Bold(true).Foreground(colDim)
-	dimStyle       = lipgloss.NewStyle().Foreground(colDim)
-	selectedStyle  = lipgloss.NewStyle().Bold(true).Foreground(colSelected)
-	focusedPane    = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(colAccent).Padding(0, 1)
-	unfocusedPane  = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(colDivider).Padding(0, 1)
-	runningStyle   = lipgloss.NewStyle().Foreground(colRunning)
-	stoppedStyle   = lipgloss.NewStyle().Foreground(colStopped)
-	failingStyle   = lipgloss.NewStyle().Foreground(colFailing).Bold(true)
-	pausedStyle    = lipgloss.NewStyle().Foreground(colPaused)
-	suspendedStyle = lipgloss.NewStyle().Foreground(colPaused)
-	accentStyle    = lipgloss.NewStyle().Foreground(colAccent)
-	helpStyle      = lipgloss.NewStyle().Foreground(colDim)
+	titleStyle    = lipgloss.NewStyle().Bold(true).Foreground(colTitle)
+	sectionStyle  = lipgloss.NewStyle().Bold(true).Foreground(colDim)
+	dimStyle      = lipgloss.NewStyle().Foreground(colDim)
+	selectedStyle = lipgloss.NewStyle().Bold(true).Foreground(colSelected)
+	focusedPane   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(colAccent).Padding(0, 1)
+	unfocusedPane = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(colDivider).Padding(0, 1)
+	runningStyle  = lipgloss.NewStyle().Foreground(colRunning)
+	stoppedStyle  = lipgloss.NewStyle().Foreground(colStopped)
+	failingStyle  = lipgloss.NewStyle().Foreground(colFailing).Bold(true)
+	// Active-but-unreachable: same problem colour as failing, but not bold and a
+	// distinct glyph, so it reads as its own state rather than a systemd failure.
+	unreachableStyle = lipgloss.NewStyle().Foreground(colFailing)
+	pausedStyle      = lipgloss.NewStyle().Foreground(colPaused)
+	suspendedStyle   = lipgloss.NewStyle().Foreground(colPaused)
+	accentStyle      = lipgloss.NewStyle().Foreground(colAccent)
+	helpStyle        = lipgloss.NewStyle().Foreground(colDim)
 )
 
 // Footer key-hint styles. Navigation/view keys stay in the main accent colour
@@ -62,11 +65,12 @@ var (
 var cardStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(colDivider).Padding(0, 1)
 
 const (
-	glyphRunning   = "●"
-	glyphStopped   = "○"
-	glyphFailing   = "✖"
-	glyphPaused    = "◐"
-	glyphSuspended = "◔"
+	glyphRunning     = "●"
+	glyphStopped     = "○"
+	glyphFailing     = "✖"
+	glyphUnreachable = "⊘"
+	glyphPaused      = "◐"
+	glyphSuspended   = "◔"
 )
 
 // keyChipStyle wraps a single keybinding name (e.g. " y ", " esc ") in a

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -711,6 +711,9 @@ type WorkerStatus struct {
 	Label   string `json:"label"`
 	Running bool   `json:"running"`
 	Failing bool   `json:"failing,omitempty"`
+	// Unreachable: the unit is active but its server isn't accepting connections.
+	// Distinct from Failing (systemd failed) so the row shows its own state.
+	Unreachable bool `json:"unreachable,omitempty"`
 }
 
 // ConflictingDomain describes a domain declared in .lerd.yaml that wasn't
@@ -883,10 +886,11 @@ func buildSites() []SiteResponse {
 		var fwWorkers []WorkerStatus
 		for _, fw := range e.FrameworkWorkers {
 			fwWorkers = append(fwWorkers, WorkerStatus{
-				Name:    fw.Name,
-				Label:   fw.Label,
-				Running: fw.Running,
-				Failing: fw.Failing,
+				Name:        fw.Name,
+				Label:       fw.Label,
+				Running:     fw.Running,
+				Failing:     fw.Failing,
+				Unreachable: fw.Unreachable,
 			})
 		}
 
@@ -909,10 +913,11 @@ func buildSites() []SiteResponse {
 			var wtWorkers []WorkerStatus
 			for _, fw := range wt.FrameworkWorkers {
 				wtWorkers = append(wtWorkers, WorkerStatus{
-					Name:    fw.Name,
-					Label:   fw.Label,
-					Running: fw.Running,
-					Failing: fw.Failing,
+					Name:        fw.Name,
+					Label:       fw.Label,
+					Running:     fw.Running,
+					Failing:     fw.Failing,
+					Unreachable: fw.Unreachable,
 				})
 			}
 			wtKeyStr := wtKey(e.Name, config.WorktreeUnitSlug(filepath.Base(wt.Path)))

--- a/internal/ui/web/src/components/ToggleButton.svelte
+++ b/internal/ui/web/src/components/ToggleButton.svelte
@@ -6,6 +6,11 @@
     label: string;
     on: boolean;
     failing?: boolean;
+    // unreachable marks a worker whose process is up but whose server isn't
+    // accepting connections (a dev server that died under its runner). Its own
+    // amber ringed dot, distinct from failing's solid red, so an active unit is
+    // never shown as a systemd failure. Clicking it restarts (rebinds) the server.
+    unreachable?: boolean;
     loading?: boolean;
     disabled?: boolean;
     // asleep marks a worker that idle-suspend has intentionally stopped: shown
@@ -24,6 +29,7 @@
     label,
     on,
     failing = false,
+    unreachable = false,
     loading = false,
     disabled = false,
     asleep = false,
@@ -34,7 +40,17 @@
   }: Props = $props();
 
   const state = $derived(
-    loading ? 'loading' : failing ? 'failing' : asleep ? 'asleep' : on ? 'on' : 'off'
+    loading
+      ? 'loading'
+      : failing
+        ? 'failing'
+        : unreachable
+          ? 'unreachable'
+          : asleep
+            ? 'asleep'
+            : on
+              ? 'on'
+              : 'off'
   );
 
   const dotClass = $derived(
@@ -42,9 +58,11 @@
       ? 'bg-emerald-500'
       : state === 'failing'
         ? 'bg-red-500'
-        : state === 'loading'
-          ? 'bg-amber-400'
-          : 'border border-gray-300 dark:border-gray-600 bg-transparent'
+        : state === 'unreachable'
+          ? 'bg-amber-500 ring-2 ring-amber-500/30'
+          : state === 'loading'
+            ? 'bg-amber-400'
+            : 'border border-gray-300 dark:border-gray-600 bg-transparent'
   );
 
   const tintClass = $derived(
@@ -52,9 +70,11 @@
       ? 'bg-emerald-50/60 dark:bg-emerald-900/15 hover:bg-emerald-50 dark:hover:bg-emerald-900/25'
       : state === 'failing'
         ? 'bg-red-50/60 dark:bg-red-900/15 hover:bg-red-50 dark:hover:bg-red-900/25'
-        : state === 'asleep'
-          ? 'bg-sky-50/60 dark:bg-sky-900/15 hover:bg-sky-50 dark:hover:bg-sky-900/25'
-          : 'bg-white dark:bg-lerd-card hover:bg-gray-50 dark:hover:bg-white/5'
+        : state === 'unreachable'
+          ? 'bg-amber-50/60 dark:bg-amber-900/15 hover:bg-amber-50 dark:hover:bg-amber-900/25'
+          : state === 'asleep'
+            ? 'bg-sky-50/60 dark:bg-sky-900/15 hover:bg-sky-50 dark:hover:bg-sky-900/25'
+            : 'bg-white dark:bg-lerd-card hover:bg-gray-50 dark:hover:bg-white/5'
   );
 </script>
 

--- a/internal/ui/web/src/stores/sites.ts
+++ b/internal/ui/web/src/stores/sites.ts
@@ -7,6 +7,9 @@ export interface FrameworkWorker {
   label?: string;
   running?: boolean;
   failing?: boolean;
+  // Process is up but its server isn't accepting connections. Distinct from
+  // failing (systemd failed); rendered as its own state, not folded into it.
+  unreachable?: boolean;
 }
 
 export interface Site {

--- a/internal/ui/web/src/tabs/sites/SiteControls.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteControls.svelte
@@ -369,6 +369,7 @@
             label={w.label || w.name}
             on={Boolean(w.running)}
             failing={Boolean(w.failing)}
+            unreachable={Boolean(w.unreachable)}
             loading={isPending('worker:' + w.name)}
             disabled={isPending('worker:' + w.name)}
             onclick={() => transition('worker:' + w.name, !w.running, () => toggleWorker(site, w, activeWorktreeBranch))}
@@ -448,6 +449,7 @@
           on={Boolean(w.running)}
           asleep={asleepWorkers.has(w.name)}
           failing={Boolean(w.failing)}
+          unreachable={Boolean(w.unreachable)}
           loading={isPending('worker:' + w.name)}
           disabled={isPending('worker:' + w.name)}
           onclick={() => transition('worker:' + w.name, !w.running, () => toggleWorker(site, w))}

--- a/internal/workerheal/workerheal.go
+++ b/internal/workerheal/workerheal.go
@@ -21,7 +21,7 @@ type UnhealthyWorker struct {
 	Site      string `json:"site"`
 	Worker    string `json:"worker"`
 	Unit      string `json:"unit"`
-	State     string `json:"state"` // "failed" today; reserve for future "start-limit-hit", "expected-but-stopped"
+	State     string `json:"state"` // "failed" | "expected-but-stopped" | "unreachable" (process up, server not accepting)
 	LastError string `json:"last_error,omitempty"`
 }
 
@@ -58,12 +58,30 @@ var nonWorkerPerSitePrefixes = map[string]bool{
 // Swappable for tests so the detector can be exercised without touching the
 // real systemd unit-state cache or starting real units.
 var (
-	unitStatesFn  = siteinfo.AllUnitStates
-	unitEnabledFn = isUnitEnabled
-	healFn        = podman.StartUnit
-	lastErrorFn   = readLastError
-	isStoppedFn   = config.IsStopped
+	unitStatesFn      = siteinfo.AllUnitStates
+	unitEnabledFn     = isUnitEnabled
+	healFn            = podman.StartUnit
+	restartFn         = podman.RestartUnit
+	lastErrorFn       = readLastError
+	isStoppedFn       = config.IsStopped
+	workerReachableFn = defaultWorkerReachable
 )
+
+// defaultWorkerReachable probes a running worker that declares a health block.
+// probed is false (keep process-only liveness) when the worker has no health
+// block or its framework can't be resolved. The framework read is cached, so the
+// cost lands once per site that has active workers, not per worker.
+func defaultWorkerReachable(sitePath, framework, worker string) (reachable, probed bool) {
+	fw, ok := config.GetFrameworkForDir(framework, sitePath)
+	if !ok {
+		return false, false
+	}
+	w, ok := fw.Workers[worker]
+	if !ok || w.Health == nil {
+		return false, false
+	}
+	return siteinfo.WorkerServerReachable(sitePath, w.Health)
+}
 
 // HumanState renders an UnhealthyWorker.State for end-user copy. The machine
 // values ("failed", "expected-but-stopped") read awkwardly in a sentence.
@@ -154,6 +172,9 @@ func Detect() ([]UnhealthyWorker, error) {
 		return nil, err
 	}
 	siteSet := make(map[string]bool, len(reg.Sites))
+	// path + framework per site, for resolving a health-probed worker's block.
+	type siteMeta struct{ path, framework string }
+	meta := make(map[string]siteMeta, len(reg.Sites))
 	// Workers a site has intentionally idle-suspended must never be reported as
 	// failing or drifted — they are asleep on purpose and resume on the next
 	// request, so flagging or healing them would be noise (and a heal would wake
@@ -164,6 +185,7 @@ func Detect() ([]UnhealthyWorker, error) {
 			continue
 		}
 		siteSet[s.Name] = true
+		meta[s.Name] = siteMeta{path: s.Path, framework: s.Framework}
 		if len(s.IdleSuspendedWorkers) > 0 {
 			set := make(map[string]bool, len(s.IdleSuspendedWorkers))
 			for _, w := range s.IdleSuspendedWorkers {
@@ -187,6 +209,31 @@ func Detect() ([]UnhealthyWorker, error) {
 		if !strings.HasSuffix(unit, ".service") {
 			continue
 		}
+		// Only these states can be unhealthy; skip the rest before the
+		// site-name resolution below so the hot path stays cheap.
+		if state != "failed" && state != "inactive" && state != "active" {
+			continue
+		}
+		body := strings.TrimPrefix(unit, "lerd-")
+		body = strings.TrimSuffix(body, ".service")
+		// Find the longest site-name suffix match so worker names with
+		// embedded hyphens (e.g. emit-events) survive intact.
+		var site, worker string
+		for s := range siteSet {
+			if strings.HasSuffix(body, "-"+s) && len(s) > len(site) {
+				site = s
+				worker = strings.TrimSuffix(body, "-"+s)
+			}
+		}
+		if site == "" || worker == "" {
+			continue
+		}
+		if nonWorkerPerSitePrefixes[worker] {
+			continue
+		}
+		if suspended[site][worker] {
+			continue // intentionally idle-suspended, not a failure
+		}
 		var detected string
 		switch state {
 		case "failed":
@@ -202,30 +249,13 @@ func Detect() ([]UnhealthyWorker, error) {
 				continue
 			}
 			detected = "expected-but-stopped"
-		default:
-			continue
-		}
-		body := strings.TrimPrefix(unit, "lerd-")
-		body = strings.TrimSuffix(body, ".service")
-		// Find the longest site-name suffix match so worker names with
-		// embedded hyphens (e.g. emit-events) survive intact.
-		var site, worker string
-		for s := range siteSet {
-			if strings.HasSuffix(body, "-"+s) {
-				if len(s) > len(site) {
-					site = s
-					worker = strings.TrimSuffix(body, "-"+s)
-				}
+		default: // "active": up, but a health-probed server may have died under it.
+			m := meta[site]
+			reachable, probed := workerReachableFn(m.path, m.framework, worker)
+			if !probed || reachable {
+				continue // no health probe declared, or the server is serving
 			}
-		}
-		if site == "" || worker == "" {
-			continue
-		}
-		if nonWorkerPerSitePrefixes[worker] {
-			continue
-		}
-		if suspended[site][worker] {
-			continue // intentionally idle-suspended, not a failure
+			detected = "unreachable"
 		}
 		out = append(out, UnhealthyWorker{
 			Site:   site,
@@ -264,7 +294,13 @@ func HealAll(emit func(Event)) (Result, error) {
 	report := Result{}
 	for _, u := range unhealthy {
 		emit(Event{Phase: "starting", Site: u.Site, Unit: u.Unit})
-		if err := HealUnit(u.Unit); err != nil {
+		// An unreachable worker's process is still up, so a plain start is a no-op;
+		// restart to rebind its server. Failed/stopped workers just start.
+		heal := HealUnit
+		if u.State == "unreachable" {
+			heal = restartFn
+		}
+		if err := heal(u.Unit); err != nil {
 			report.Failed = append(report.Failed, Failure{Worker: u, Err: err.Error()})
 			emit(Event{Phase: "failed", Site: u.Site, Unit: u.Unit, Error: err.Error()})
 			continue

--- a/internal/workerheal/workerheal.go
+++ b/internal/workerheal/workerheal.go
@@ -68,12 +68,12 @@ var (
 )
 
 // defaultWorkerReachable probes a running worker that declares a health block.
-// probed is false (keep process-only liveness) when the worker has no health
-// block or its framework can't be resolved. The framework read is cached, so the
-// cost lands once per site that has active workers, not per worker.
-func defaultWorkerReachable(sitePath, framework, worker string) (reachable, probed bool) {
-	fw, ok := config.GetFrameworkForDir(framework, sitePath)
-	if !ok {
+// probed is false (keep process-only liveness) when the site has no resolvable
+// framework or the worker has no health block. The framework is resolved once
+// per site by Detect and passed in, so the store is touched at most once per
+// site per tick, never per worker.
+func defaultWorkerReachable(sitePath string, fw *config.Framework, worker string) (reachable, probed bool) {
+	if fw == nil {
 		return false, false
 	}
 	w, ok := fw.Workers[worker]
@@ -136,6 +136,15 @@ func Enrich(in []UnhealthyWorker) []UnhealthyWorker {
 		if in[i].State == "expected-but-stopped" {
 			continue
 		}
+		// An unreachable worker's process is still active, so its last journal line
+		// is whatever the live server last logged (often a harmless info line) and
+		// would read as a false cause. State the real problem instead of the journal.
+		// Framework-agnostic on purpose: which file/port carries the URL lives in the
+		// store, not here.
+		if in[i].State == "unreachable" {
+			in[i].LastError = "process is up but its server is not accepting connections"
+			continue
+		}
 		if time.Now().After(deadline) {
 			break
 		}
@@ -147,8 +156,10 @@ func Enrich(in []UnhealthyWorker) []UnhealthyWorker {
 // Detect returns every worker unit systemd considers "failed". Cheap by
 // design: it reads only the existing batched unit-state cache (one
 // systemctl call per 3s, shared with the dashboard's enrichment path) plus
-// sites.yaml. No per-site .lerd.yaml or composer.json reads, no extra
-// subprocess calls. Safe to invoke from a hot endpoint.
+// sites.yaml. For a site that has an active health-probed worker it resolves
+// the framework once per site, memoised by composer.json mtime, so a steady
+// tick reparses nothing. No extra subprocess calls; safe to invoke from a
+// hot endpoint.
 //
 // Two health problems are detected. "failed" — units that hit Restart= rate
 // limits or crash repeatedly and stay stuck until reset. "expected-but-stopped"
@@ -199,6 +210,11 @@ func Detect() ([]UnhealthyWorker, error) {
 	}
 
 	states := unitStatesFn()
+	// Framework resolved lazily, at most once per site with an active worker.
+	// GetFrameworkForDir is not a plain lookup (it can trigger an unthrottled
+	// store fetch), so it must never run per worker inside the loop.
+	resolvedFw := make(map[string]*config.Framework)
+	resolvedSet := make(map[string]bool)
 	var out []UnhealthyWorker
 	for unit, state := range states {
 		// The unit-state cache aliases each .service unit under both
@@ -251,7 +267,11 @@ func Detect() ([]UnhealthyWorker, error) {
 			detected = "expected-but-stopped"
 		default: // "active": up, but a health-probed server may have died under it.
 			m := meta[site]
-			reachable, probed := workerReachableFn(m.path, m.framework, worker)
+			if !resolvedSet[site] {
+				resolvedFw[site], _ = config.GetFrameworkForDir(m.framework, m.path)
+				resolvedSet[site] = true
+			}
+			reachable, probed := workerReachableFn(m.path, resolvedFw[site], worker)
 			if !probed || reachable {
 				continue // no health probe declared, or the server is serving
 			}

--- a/internal/workerheal/workerheal_test.go
+++ b/internal/workerheal/workerheal_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 // stubEnv stages a sites.yaml with the given names in a temp XDG_DATA_HOME
@@ -413,6 +415,22 @@ func TestEnrich_KeepsPreSetErrorAndSkipsCall(t *testing.T) {
 	}
 }
 
+func TestEnrich_UnreachableGetsDedicatedLineNotJournal(t *testing.T) {
+	prev := lastErrorFn
+	t.Cleanup(func() { lastErrorFn = prev })
+	// The journal line for an active server would read as a false cause; Enrich
+	// must not call it for an unreachable worker.
+	lastErrorFn = func(string) string {
+		t.Fatal("readLastError must not be called for an unreachable worker")
+		return ""
+	}
+
+	out := Enrich([]UnhealthyWorker{{Unit: "lerd-vite-foo", Site: "foo", Worker: "vite", State: "unreachable"}})
+	if out[0].LastError == "" || out[0].LastError == "boom" {
+		t.Errorf("unreachable last_error = %q, want the dedicated not-accepting line", out[0].LastError)
+	}
+}
+
 func TestEnrich_NilAndEmpty(t *testing.T) {
 	if got := Enrich(nil); got != nil {
 		t.Errorf("Enrich(nil) = %v, want nil", got)
@@ -434,7 +452,7 @@ func TestDetect_UnreachableActiveWorkerFlagged(t *testing.T) {
 		nil,
 	)
 	prev := workerReachableFn
-	workerReachableFn = func(_, _, worker string) (reachable, probed bool) {
+	workerReachableFn = func(_ string, _ *config.Framework, worker string) (reachable, probed bool) {
 		if worker == "vite" {
 			return false, true // process up, server not accepting
 		}
@@ -461,7 +479,7 @@ func TestDetect_ReachableActiveWorkerNotFlagged(t *testing.T) {
 		nil,
 	)
 	prev := workerReachableFn
-	workerReachableFn = func(_, _, _ string) (bool, bool) { return true, true } // serving
+	workerReachableFn = func(_ string, _ *config.Framework, _ string) (bool, bool) { return true, true } // serving
 	t.Cleanup(func() { workerReachableFn = prev })
 
 	got, err := Detect()
@@ -482,7 +500,7 @@ func TestHealAll_RestartsUnreachableWorker(t *testing.T) {
 		func(string) error { t.Fatal("unreachable worker must be restarted, not started"); return nil },
 	)
 	prevReach, prevRestart := workerReachableFn, restartFn
-	workerReachableFn = func(_, _, _ string) (bool, bool) { return false, true }
+	workerReachableFn = func(_ string, _ *config.Framework, _ string) (bool, bool) { return false, true }
 	var restarted string
 	restartFn = func(unit string) error { restarted = unit; return nil }
 	t.Cleanup(func() { workerReachableFn = prevReach; restartFn = prevRestart })

--- a/internal/workerheal/workerheal_test.go
+++ b/internal/workerheal/workerheal_test.go
@@ -421,3 +421,80 @@ func TestEnrich_NilAndEmpty(t *testing.T) {
 		t.Errorf("Enrich(empty) = %v, want empty", got)
 	}
 }
+
+// An active worker whose declared server has died (process up, port refused) is
+// flagged "unreachable"; a plain active worker with no health probe is not.
+func TestDetect_UnreachableActiveWorkerFlagged(t *testing.T) {
+	stubEnv(t,
+		[]string{"myapp"}, nil,
+		map[string]string{
+			"lerd-vite-myapp.service":  "active",
+			"lerd-queue-myapp.service": "active",
+		},
+		nil,
+	)
+	prev := workerReachableFn
+	workerReachableFn = func(_, _, worker string) (reachable, probed bool) {
+		if worker == "vite" {
+			return false, true // process up, server not accepting
+		}
+		return false, false // no health probe for other workers
+	}
+	t.Cleanup(func() { workerReachableFn = prev })
+
+	got, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(got) != 1 || got[0].Unit != "lerd-vite-myapp" {
+		t.Fatalf("got %v, want [lerd-vite-myapp]", unitNames(got))
+	}
+	if got[0].State != "unreachable" {
+		t.Errorf("state = %q, want unreachable", got[0].State)
+	}
+}
+
+func TestDetect_ReachableActiveWorkerNotFlagged(t *testing.T) {
+	stubEnv(t,
+		[]string{"myapp"}, nil,
+		map[string]string{"lerd-vite-myapp.service": "active"},
+		nil,
+	)
+	prev := workerReachableFn
+	workerReachableFn = func(_, _, _ string) (bool, bool) { return true, true } // serving
+	t.Cleanup(func() { workerReachableFn = prev })
+
+	got, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("a reachable server must not be flagged, got %v", unitNames(got))
+	}
+}
+
+// An unreachable worker's process is still up, so heal must restart it (a start
+// is a no-op on an active unit), while failed/stopped workers still start.
+func TestHealAll_RestartsUnreachableWorker(t *testing.T) {
+	stubEnv(t,
+		[]string{"myapp"}, nil,
+		map[string]string{"lerd-vite-myapp.service": "active"},
+		func(string) error { t.Fatal("unreachable worker must be restarted, not started"); return nil },
+	)
+	prevReach, prevRestart := workerReachableFn, restartFn
+	workerReachableFn = func(_, _, _ string) (bool, bool) { return false, true }
+	var restarted string
+	restartFn = func(unit string) error { restarted = unit; return nil }
+	t.Cleanup(func() { workerReachableFn = prevReach; restartFn = prevRestart })
+
+	res, err := HealAll(nil)
+	if err != nil {
+		t.Fatalf("HealAll: %v", err)
+	}
+	if restarted != "lerd-vite-myapp" {
+		t.Errorf("restarted %q, want lerd-vite-myapp", restarted)
+	}
+	if len(res.Healed) != 1 {
+		t.Errorf("healed %d, want 1", len(res.Healed))
+	}
+}


### PR DESCRIPTION
Worker health only looked at systemd's failed state, so a worker that keeps its process alive after its server has died (a vite dev server that crashes under npm while the node process lingers) stayed `active`, and lerd reported it as running while nothing was listening. The reported state was the opposite of the truth and the failure was silent.

A worker can now declare a `health` block naming a file its server writes on boot (vite's `public/hot`, which holds the dev-server URL). While the unit is active, `Detect` reads that file and makes a short TCP dial to its host and port. Process-alive-but-unreachable is reported as a new `unreachable` state, and `HealAll` restarts the unit (a plain start is a no-op on a running unit) rather than starting it. Where the port lives stays in the framework store, never in Go, so it is framework-agnostic. A worker with no `health` block keeps the process-only liveness check. A missing `url_file` is treated as not-probeable, so idle-suspend clearing `public/hot` never trips a false alarm.

The framework resolves once per site inside `Detect` (never per worker), backed by an mtime-cached `composer.json` parse so `DetectMajorVersion` stops reparsing on a steady tick and `Detect`'s hot-endpoint contract stays honest. `Unreachable` is a distinct `WorkerInfo` state, not folded into `Failing` (which keeps meaning systemd failed): the dashboard and TUI worker rows render it as its own state with its own badge, and `Enrich` gives it a dedicated not-accepting line instead of reading the journal off an active unit.

The companion `health` block for the vite worker ships in a paired lerd-env/frameworks PR.

Per-worktree worker heal and gating the probe on `ActiveEnterTimestamp` (plus the grace rule) are split into #853 as a fast-follow, since both need the batched unit-state cache extended to carry `ActiveEnterTimestamp` + `WorkingDirectory`, the one source that feeds both in a single call per tick.

Refs #839