### PR TITLE
feat: let a framework definition declare the services it cannot run without

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -16,7 +16,7 @@ Lerd resolves framework definitions from multiple sources. Higher priority wins:
 Workers from the user overlay and project `.lerd.yaml` are merged on top of store or built-in definitions. See [Framework workers](framework-workers.md) for the worker lifecycle and how custom workers are added and managed.
 
 ::: warning Untrusted projects
-A `.lerd.yaml` ships inside a project, so its embedded `framework_def` is treated as untrusted, and lerd strips its host-execution surfaces when restoring it into the store: `command`-type doctor checks, `host: true` workers, and the whole `commands:` list are dropped, because each would otherwise run on your host straight from a cloned repo. Those run only for frameworks that come from the store, a built-in, or your user overlay (`~/.config/lerd/frameworks/`); a definition already installed there is never overwritten by a project's embedded copy. In-container workers, env, symlink, and combo checks are inert and still work from a project definition.
+A `.lerd.yaml` ships inside a project, so its embedded `framework_def` is treated as untrusted, and lerd strips its host-execution surfaces when restoring it into the store: `command`-type doctor checks, `host: true` workers, the whole `commands:` list, the `nginx:` block, and `requires:` are dropped, because each would otherwise run on your host, rewrite your nginx config, or start containers straight from a cloned repo. Those run only for frameworks that come from the store, a built-in, or your user overlay (`~/.config/lerd/frameworks/`); a definition already installed there is never overwritten by a project's embedded copy. In-container workers, env, symlink, and combo checks are inert and still work from a project definition.
 
 A project's own host extensions still work, just with consent: a `host: true` entry in top-level `custom_workers`, and any top-level `commands:` you run via `lerd run` or the dashboard, prompt once showing the exact command before they run on your host, and the approval is remembered per site. Set `host_commands.skip_confirmation: true` (or `host_commands.disabled: true` to refuse them outright) in the global config to change that.
 :::
@@ -136,6 +136,12 @@ env:
 # Scaffold command for "lerd new"
 create: composer create-project symfony/skeleton
 
+# Service presets the framework cannot run without (optional). Link installs and
+# starts them and records them in .lerd.yaml, so a teammate cloning the repo gets
+# them too. The doctor fails when one is missing and warns when it is stopped.
+requires:
+  - opensearch
+
 # Dependency installation. `false` means the framework never uses that package
 # manager, and `lerd setup` does not offer its steps at all. Magento and Drupal
 # set npm: false; WordPress sets both to false.
@@ -215,6 +221,16 @@ The `{{site}}`, `{{site_testing}}`, `{{bucket}}`, `{{domain}}`, `{{scheme}}`, an
 This is what lets a framework whose bootstrap needs to know where the site lives declare that step as data. Magento 2.4 removed its web installer, so a fresh store is installed with `bin/magento setup:install --base-url=… --db-name=…`; the definition can now express exactly that. A step that creates schema should carry `default: false` so it is opt-in rather than running on every `lerd setup`.
 
 A placeholder whose value is empty, or one lerd does not recognise, is left in the command verbatim rather than being replaced with an empty string, so a half-resolved context can never quietly produce `--base-url=://`.
+
+## Required services
+
+Most frameworks run against whatever services the project happens to reference. A few cannot start at all without one. Magento 2.4 removed the MySQL catalog search engine, so a store without OpenSearch or Elasticsearch fails partway through `setup:install` with a stack trace that never mentions the search engine.
+
+A definition lists those in `requires:`, naming service presets. On `lerd link` each one is resolved from the service store, installed if it is not already, started, and appended to the project's `.lerd.yaml` so the requirement travels with the repo. Re-linking does not duplicate an entry, and a name the service store does not know is reported and skipped rather than written into the project's committed config.
+
+The site doctor reports the same thing after the fact: a required service that is not installed is a failure, since the app cannot boot, and one that is installed but stopped is a warning, since starting it is a single command.
+
+A required service pulls an image and runs a container, so, like host workers and `nginx.snippet`, `requires:` is honoured only from the trusted store and from a user overlay. An embedded `framework_def` in a project's `.lerd.yaml` has it stripped.
 
 ## Framework nginx config
 

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -455,6 +455,9 @@ func runLink(args []string) error {
 			}
 		}
 
+		if fw, ok := config.GetFrameworkForDir(framework, cwd); ok {
+			proj = ensureRequiredServices(cwd, proj, fw, presetResolvable)
+		}
 		if err := linkApplyServices(cwd, proj); err != nil {
 			return err
 		}
@@ -550,6 +553,68 @@ func linkRuntimeLabel(site config.Site) string {
 	default:
 		return "FPM"
 	}
+}
+
+// ensureRequiredServices folds the framework's required service presets into the
+// project's service list, so linkApplyServices installs and starts them like any
+// other declared service and a teammate cloning the repo gets them too. A name
+// the service store does not know is reported and skipped rather than written
+// into the project's committed config. resolvePreset is a seam for tests; the
+// real one fetches a store-only preset, since a required service is precisely
+// the one that is not installed yet.
+func ensureRequiredServices(cwd string, proj *config.ProjectConfig, fw *config.Framework, resolvePreset func(string) bool) *config.ProjectConfig {
+	if fw == nil || len(fw.Requires) == 0 {
+		return proj
+	}
+	if proj == nil {
+		proj = &config.ProjectConfig{}
+	}
+	have := make(map[string]bool, len(proj.Services))
+	for _, s := range proj.Services {
+		have[s.Name] = true
+	}
+	added := false
+	for _, name := range fw.Requires {
+		if have[name] {
+			continue
+		}
+		if !resolvePreset(name) {
+			feedback.Warn("%s requires the %q service, which the service store does not have", frameworkLabelOf(fw), name)
+			continue
+		}
+		svc := config.ProjectService{Name: name}
+		if !config.IsDefaultPreset(name) {
+			svc.Preset = name
+		}
+		proj.Services = append(proj.Services, svc)
+		have[name] = true
+		added = true
+	}
+	if added {
+		if err := config.SaveProjectConfig(cwd, proj); err != nil {
+			feedback.Warn("could not save .lerd.yaml: %v", err)
+		}
+	}
+	return proj
+}
+
+// presetResolvable reports whether a preset name can be served, fetching a
+// store-only preset into the local cache on the way. PresetExists alone would
+// reject any preset not already installed, which is the whole point of requires.
+func presetResolvable(name string) bool {
+	if config.PresetExists(name) {
+		return true
+	}
+	_, err := config.EnsurePreset(name)
+	return err == nil
+}
+
+// frameworkLabelOf prefers the display label, falling back to the slug.
+func frameworkLabelOf(fw *config.Framework) string {
+	if fw.Label != "" {
+		return fw.Label
+	}
+	return fw.Name
 }
 
 // linkApplyServices installs and starts services declared in .lerd.yaml.

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -388,6 +388,13 @@ func runLink(args []string) error {
 
 	_ = config.SyncProjectDomains(cwd, site.Domains, cfg.DNS.TLD)
 
+	// Fold in the framework's required services before any runtime path applies
+	// them, so a custom-FPM or FrankenPHP site gets them too, not only the
+	// standard PHP-FPM path below.
+	if fw, ok := config.GetFrameworkForDir(framework, cwd); ok {
+		proj = ensureRequiredServices(cwd, proj, fw, presetResolvable)
+	}
+
 	if site.IsCustomFPM() {
 		result := "php " + feedback.Val(phpVersion) + " · nginx vhost written"
 		if err := provisionAndSecure("building custom FPM image", result, site,
@@ -455,9 +462,6 @@ func runLink(args []string) error {
 			}
 		}
 
-		if fw, ok := config.GetFrameworkForDir(framework, cwd); ok {
-			proj = ensureRequiredServices(cwd, proj, fw, presetResolvable)
-		}
 		if err := linkApplyServices(cwd, proj); err != nil {
 			return err
 		}

--- a/internal/cli/link_requires_test.go
+++ b/internal/cli/link_requires_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func names(proj *config.ProjectConfig) []string {
+	out := []string{}
+	for _, s := range proj.Services {
+		out = append(out, s.Name)
+	}
+	return out
+}
+
+func TestEnsureRequiredServicesAddsMissingPreset(t *testing.T) {
+	dir := t.TempDir()
+	proj := &config.ProjectConfig{Services: []config.ProjectService{{Name: "mysql"}}}
+	fw := &config.Framework{Label: "Magento", Requires: []string{"opensearch"}}
+
+	got := ensureRequiredServices(dir, proj, fw, func(string) bool { return true })
+
+	if len(got.Services) != 2 {
+		t.Fatalf("services = %v", names(got))
+	}
+	added := got.Services[1]
+	if added.Name != "opensearch" || added.Preset != "opensearch" {
+		t.Fatalf("added = %+v, want a preset reference", added)
+	}
+	// Persisted, so a teammate cloning the repo gets the same service.
+	reloaded, err := config.LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatalf("project config not saved: %v", err)
+	}
+	if len(reloaded.Services) != 2 {
+		t.Fatalf("saved services = %v", names(reloaded))
+	}
+}
+
+func TestEnsureRequiredServicesIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	proj := &config.ProjectConfig{Services: []config.ProjectService{
+		{Name: "opensearch", Preset: "opensearch"},
+	}}
+	fw := &config.Framework{Requires: []string{"opensearch"}}
+
+	got := ensureRequiredServices(dir, proj, fw, func(string) bool { return true })
+	if len(got.Services) != 1 {
+		t.Fatalf("duplicated the service: %v", names(got))
+	}
+}
+
+// A default preset (mysql, redis) is referenced by bare name, not as a preset
+// reference, matching what the init wizard writes.
+func TestEnsureRequiredServicesDefaultPresetIsBareName(t *testing.T) {
+	dir := t.TempDir()
+	fw := &config.Framework{Requires: []string{"mysql"}}
+	got := ensureRequiredServices(dir, &config.ProjectConfig{}, fw, func(string) bool { return true })
+	if len(got.Services) != 1 || got.Services[0].Preset != "" {
+		t.Fatalf("got %+v, want a bare name", got.Services)
+	}
+}
+
+// A definition naming a service the store has never heard of must not write a
+// broken entry into the project's committed config.
+func TestEnsureRequiredServicesSkipsUnknownPreset(t *testing.T) {
+	dir := t.TempDir()
+	fw := &config.Framework{Requires: []string{"nonexistent-engine"}}
+	got := ensureRequiredServices(dir, &config.ProjectConfig{}, fw, func(string) bool { return false })
+	if len(got.Services) != 0 {
+		t.Fatalf("wrote an unknown service: %v", names(got))
+	}
+}
+
+func TestEnsureRequiredServicesNoRequiresIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	proj := &config.ProjectConfig{}
+	if got := ensureRequiredServices(dir, proj, &config.Framework{}, func(string) bool { return true }); len(got.Services) != 0 {
+		t.Fatal("added services for a framework that requires none")
+	}
+	if got := ensureRequiredServices(dir, proj, nil, func(string) bool { return true }); got != proj {
+		t.Fatal("nil framework should return the project untouched")
+	}
+	// Nothing to save, so no .lerd.yaml should appear on disk.
+	if _, err := os.Stat(filepath.Join(dir, ".lerd.yaml")); err == nil {
+		t.Error("wrote .lerd.yaml with nothing to add")
+	}
+}
+
+func TestEnsureRequiredServicesNilProject(t *testing.T) {
+	dir := t.TempDir()
+	fw := &config.Framework{Requires: []string{"opensearch"}}
+	got := ensureRequiredServices(dir, nil, fw, func(string) bool { return true })
+	if got == nil || len(got.Services) != 1 {
+		t.Fatalf("got %+v", got)
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -88,6 +88,10 @@ type Framework struct {
 	// Nginx, when set, declares extra server-block config the framework needs
 	// (Magento's /setup, /static, and /media handling). See FrameworkNginx.
 	Nginx *FrameworkNginx `yaml:"nginx,omitempty"`
+	// Requires names the service presets the framework cannot run without
+	// (Magento 2.4 has no MySQL catalog search engine, so it needs opensearch).
+	// Link installs and starts them; the doctor reports one that goes missing.
+	Requires []string `yaml:"requires,omitempty"`
 }
 
 // FrameworkNginx carries a raw nginx block spliced into the site's server block
@@ -1316,6 +1320,9 @@ func SanitizeProjectFrameworkDef(def *Framework) *Framework {
 	// An nginx snippet is spliced into the site's server block, so it is a
 	// config-injection surface: only the trusted store may declare one.
 	safe.Nginx = nil
+	// A required service pulls an image and starts a container, so an untrusted
+	// definition must not be able to drive that either.
+	safe.Requires = nil
 	return safe
 }
 

--- a/internal/config/framework_requires_test.go
+++ b/internal/config/framework_requires_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestFrameworkRequiresParsesFromYAML(t *testing.T) {
+	var fw Framework
+	src := "name: magento\nversion: \"2\"\nrequires:\n  - opensearch\n"
+	if err := yaml.Unmarshal([]byte(src), &fw); err != nil {
+		t.Fatal(err)
+	}
+	if len(fw.Requires) != 1 || fw.Requires[0] != "opensearch" {
+		t.Fatalf("got %v", fw.Requires)
+	}
+}
+
+func TestFrameworkRequiresAbsentIsNil(t *testing.T) {
+	var fw Framework
+	if err := yaml.Unmarshal([]byte("name: laravel\n"), &fw); err != nil {
+		t.Fatal(err)
+	}
+	if fw.Requires != nil {
+		t.Fatalf("got %v, want nil", fw.Requires)
+	}
+}
+
+// A .lerd.yaml is untrusted. A required service pulls a container image and
+// starts it, so an embedded framework_def must not be able to drive that, the
+// same way it cannot drive host workers, commands, or nginx config.
+func TestSanitizeProjectFrameworkDefStripsRequires(t *testing.T) {
+	def := &Framework{Name: "evil", Requires: []string{"opensearch"}}
+	safe := SanitizeProjectFrameworkDef(def)
+	if safe.Requires != nil {
+		t.Fatalf("requires survived sanitize: %v", safe.Requires)
+	}
+	if def.Requires == nil {
+		t.Fatal("sanitize mutated the caller's definition")
+	}
+}

--- a/internal/sitedoctor/required_services_test.go
+++ b/internal/sitedoctor/required_services_test.go
@@ -1,0 +1,74 @@
+package sitedoctor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func withStubs(t *testing.T, installed map[string]bool, status map[string]string) {
+	t.Helper()
+	origInstalled, origStatus := quadletInstalledFn, unitStatusFn
+	quadletInstalledFn = func(unit string) bool { return installed[unit] }
+	unitStatusFn = func(unit string) (string, error) { return status[unit], nil }
+	t.Cleanup(func() { quadletInstalledFn, unitStatusFn = origInstalled, origStatus })
+}
+
+func TestRequiredServicesSkippedWhenNoneDeclared(t *testing.T) {
+	withStubs(t, nil, nil)
+	if _, ok := checkRequiredServices(&config.Framework{}); ok {
+		t.Error("a framework requiring nothing should produce no check")
+	}
+	if _, ok := checkRequiredServices(nil); ok {
+		t.Error("nil framework should produce no check")
+	}
+}
+
+func TestRequiredServicesOKWhenInstalledAndActive(t *testing.T) {
+	withStubs(t, map[string]bool{"lerd-opensearch": true}, map[string]string{"lerd-opensearch": "active"})
+	c, ok := checkRequiredServices(&config.Framework{Requires: []string{"opensearch"}})
+	if !ok || c.Status != StatusOK {
+		t.Fatalf("got %+v", c)
+	}
+}
+
+// Not installed is a hard failure: the app cannot boot without it.
+func TestRequiredServicesFailsWhenNotInstalled(t *testing.T) {
+	withStubs(t, nil, nil)
+	c, ok := checkRequiredServices(&config.Framework{Label: "Magento", Requires: []string{"opensearch"}})
+	if !ok || c.Status != StatusFail {
+		t.Fatalf("got %+v", c)
+	}
+	if !strings.Contains(c.Detail, "opensearch") || !strings.Contains(c.Detail, "lerd service preset") {
+		t.Errorf("detail should name the service and the remedy: %q", c.Detail)
+	}
+}
+
+// Installed but stopped is a warning, not a failure: starting it is one command
+// and lerd starts it on the next link anyway.
+func TestRequiredServicesWarnsWhenStopped(t *testing.T) {
+	withStubs(t, map[string]bool{"lerd-opensearch": true}, map[string]string{"lerd-opensearch": "inactive"})
+	c, ok := checkRequiredServices(&config.Framework{Requires: []string{"opensearch"}})
+	if !ok || c.Status != StatusWarn {
+		t.Fatalf("got %+v", c)
+	}
+	if !strings.Contains(c.Detail, "lerd service start") {
+		t.Errorf("detail should name the remedy: %q", c.Detail)
+	}
+}
+
+// A missing service outranks a stopped one, since it is the more severe finding.
+func TestRequiredServicesMissingOutranksStopped(t *testing.T) {
+	withStubs(t,
+		map[string]bool{"lerd-redis": true},
+		map[string]string{"lerd-redis": "inactive"},
+	)
+	c, _ := checkRequiredServices(&config.Framework{Requires: []string{"redis", "opensearch"}})
+	if c.Status != StatusFail {
+		t.Fatalf("got %s, want fail: %+v", c.Status, c)
+	}
+	if !strings.Contains(c.Detail, "opensearch") {
+		t.Errorf("detail should name the missing service: %q", c.Detail)
+	}
+}

--- a/internal/sitedoctor/sitedoctor.go
+++ b/internal/sitedoctor/sitedoctor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
 	phpkg "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
 )
 
 // Check statuses, mirroring the MCP doctor's check shape so the diagnostics
@@ -107,6 +108,9 @@ func Run(ctx context.Context, path string, fw *config.Framework) Response {
 	envFile, envFormat, exampleFile := envSetup(fw, path)
 	envPath := filepath.Join(path, envFile)
 
+	if c, ok := checkRequiredServices(fw); ok {
+		resp.add(c)
+	}
 	if hasEnvConfig(fw) {
 		if c, ok := checkEnvPresent(path, envFile, fwExampleFile(fw)); ok {
 			resp.add(c)
@@ -184,6 +188,57 @@ func fwExampleFile(fw *config.Framework) string {
 	return fw.Env.ExampleFile
 }
 
+// Seams so the required-service check can be tested without podman.
+var (
+	quadletInstalledFn = podman.QuadletInstalled
+	unitStatusFn       = podman.UnitStatus
+)
+
+// checkRequiredServices reports the framework's declared required services that
+// are absent or stopped. Absent is a failure, since the app cannot boot without
+// it; stopped is a warning, since starting it is one command.
+func checkRequiredServices(fw *config.Framework) (Check, bool) {
+	if fw == nil || len(fw.Requires) == 0 {
+		return Check{}, false
+	}
+	var missing, stopped []string
+	for _, name := range fw.Requires {
+		unit := "lerd-" + name
+		if !quadletInstalledFn(unit) {
+			missing = append(missing, name)
+			continue
+		}
+		if status, _ := unitStatusFn(unit); status != "active" {
+			stopped = append(stopped, name)
+		}
+	}
+	switch {
+	case len(missing) > 0:
+		return Check{
+			Name:   "required_services",
+			Status: StatusFail,
+			Detail: fmt.Sprintf("%s cannot run without %s. Install it with 'lerd service preset %s'.",
+				frameworkLabel(fw), strings.Join(missing, ", "), missing[0]),
+		}, true
+	case len(stopped) > 0:
+		return Check{
+			Name:   "required_services",
+			Status: StatusWarn,
+			Detail: fmt.Sprintf("%s is required but not running. Start it with 'lerd service start %s'.",
+				strings.Join(stopped, ", "), stopped[0]),
+		}, true
+	}
+	return Check{Name: "required_services", Status: StatusOK}, true
+}
+
+// frameworkLabel prefers the display label, falling back to the slug.
+func frameworkLabel(fw *config.Framework) string {
+	if fw.Label != "" {
+		return fw.Label
+	}
+	return fw.Name
+}
+
 // frameworkChecks returns the framework's declarative doctor checks, or nil.
 func frameworkChecks(fw *config.Framework) []config.DoctorCheck {
 	if fw == nil || fw.Doctor == nil {
@@ -222,16 +277,17 @@ func runDeclaredCheck(ctx context.Context, path, envPath, envFormat string, spec
 // universalLabels maps the built-in check names to their display labels. The
 // declared framework checks carry their own labels from the store.
 var universalLabels = map[string]string{
-	"env_present":     "Env File",
-	"app_key":         "App Key",
-	"env_drift":       "Env Drift",
-	"sqlite_database": "Database",
-	"composer_deps":   "Composer Dependencies",
-	"composer_audit":  "Composer Audit",
-	"node_deps":       "Node Dependencies",
-	"node_audit":      "Node Audit",
-	"php_version":     "PHP Version",
-	"slow_routes":     "Response Time",
+	"required_services": "Required Services",
+	"env_present":       "Env File",
+	"app_key":           "App Key",
+	"env_drift":         "Env Drift",
+	"sqlite_database":   "Database",
+	"composer_deps":     "Composer Dependencies",
+	"composer_audit":    "Composer Audit",
+	"node_deps":         "Node Dependencies",
+	"node_audit":        "Node Audit",
+	"php_version":       "PHP Version",
+	"slow_routes":       "Response Time",
 }
 
 // humanize turns a snake_case check name into a Title Case fallback label.


### PR DESCRIPTION
Stacked on #845. Review that one first; the base will move to `main` once it merges.

A definition could describe how to wire a service the project already referenced, and a `check:` rule could test for a file or a composer package, but nothing could say that a framework does not run at all without a given service. Magento 2.4 removed the MySQL catalog search engine, so linking a store produced a site with no search engine, and the first `setup:install` died partway through the schema install with a stack trace that never mentioned it.

A definition now lists those in `requires:`, naming service presets. Link resolves each one from the service store, fetching a preset that is not cached yet, since a required service is precisely the one that is not installed, then installs and starts it and records it in the project's `.lerd.yaml` so the requirement travels with the repo. Re-linking does not duplicate the entry, and a name the store does not know is reported and skipped rather than written into a project's committed config.

The site doctor reports the same state after the fact. A required service that is not installed fails, since the app cannot boot without it, and one that is installed but stopped warns, since starting it is a single command.

Starting a container from a definition is a side effect on the host, so `requires:` is honoured only from the trusted store and from a user overlay, and an embedded `framework_def` in a project `.lerd.yaml` has it stripped alongside its host workers, commands, and nginx config.

Closes #843