### PR TITLE
feat: let a framework declare the php.ini its CLI needs

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -16,7 +16,7 @@ Lerd resolves framework definitions from multiple sources. Higher priority wins:
 Workers from the user overlay and project `.lerd.yaml` are merged on top of store or built-in definitions. See [Framework workers](framework-workers.md) for the worker lifecycle and how custom workers are added and managed.
 
 ::: warning Untrusted projects
-A `.lerd.yaml` ships inside a project, so its embedded `framework_def` is treated as untrusted, and lerd strips its host-execution surfaces when restoring it into the store: `command`-type doctor checks, `host: true` workers, the whole `commands:` list, the `nginx:` block, and `requires:` are dropped, because each would otherwise run on your host, rewrite your nginx config, or start containers straight from a cloned repo. Those run only for frameworks that come from the store, a built-in, or your user overlay (`~/.config/lerd/frameworks/`); a definition already installed there is never overwritten by a project's embedded copy. In-container workers, env, symlink, and combo checks are inert and still work from a project definition.
+A `.lerd.yaml` ships inside a project, so its embedded `framework_def` is treated as untrusted, and lerd strips its host-execution surfaces when restoring it into the store: `command`-type doctor checks, `host: true` workers, the whole `commands:` list, the `nginx:` block, `requires:`, and `php.cli_ini` are dropped, because each would otherwise run on your host, rewrite your nginx config, or start containers straight from a cloned repo. Those run only for frameworks that come from the store, a built-in, or your user overlay (`~/.config/lerd/frameworks/`); a definition already installed there is never overwritten by a project's embedded copy. In-container workers, env, symlink, and combo checks are inert and still work from a project definition.
 
 A project's own host extensions still work, just with consent: a `host: true` entry in top-level `custom_workers`, and any top-level `commands:` you run via `lerd run` or the dashboard, prompt once showing the exact command before they run on your host, and the approval is remembered per site. Set `host_commands.skip_confirmation: true` (or `host_commands.disabled: true` to refuse them outright) in the global config to change that.
 :::
@@ -90,6 +90,8 @@ version: "8"                      # framework major version this definition targ
 php:
   min: "8.2"                      # minimum supported PHP version
   max: "8.5"                      # maximum supported PHP version
+  cli_ini:                        # php.ini directives for PHP processes lerd runs (optional)
+    memory_limit: 2G              # bounded: workers get these too
 
 # Detection rules, any match is sufficient
 detect:
@@ -221,6 +223,20 @@ The `{{site}}`, `{{site_testing}}`, `{{bucket}}`, `{{domain}}`, `{{scheme}}`, an
 This is what lets a framework whose bootstrap needs to know where the site lives declare that step as data. Magento 2.4 removed its web installer, so a fresh store is installed with `bin/magento setup:install --base-url=… --db-name=…`; the definition can now express exactly that. A step that creates schema should carry `default: false` so it is opt-in rather than running on every `lerd setup`.
 
 A placeholder whose value is empty, or one lerd does not recognise, is left in the command verbatim rather than being replaced with an empty string, so a half-resolved context can never quietly produce `--base-url=://`.
+
+## PHP ini for the CLI
+
+A project can already raise php.ini settings for its **web** requests by shipping a `.user.ini` in the document root, which PHP-FPM reads per directory. Magento does exactly that, with `memory_limit = 756M`.
+
+The **CLI SAPI never reads `.user.ini`**, not even from inside the document root. So a framework whose commands need more than PHP's 128M default has nowhere to say so, and Magento's `setup:upgrade` and `deploy:mode:set` die with an allocation failure deep inside `symfony/cache` that never mentions memory.
+
+`php.cli_ini` fills that gap. Each directive is passed as `-d name=value` to every PHP process lerd starts for that project: the `php` shim (and therefore `lerd artisan`, `lerd run`, a `vendor/bin` binary, and a `command`-type doctor check), and the `setup:` steps and the workers, which exec in the container directly. Directives are sorted, so the argv is stable, and they are prepended, so a `-d` you type yourself lands later and wins.
+
+Workers get the directives too. They exec their command straight from a systemd unit, and Magento cannot even bootstrap at PHP's 128M default, so a cron or consumer worker without them simply crash-loops. That makes the value a definition author's responsibility: give it a bounded `memory_limit` rather than `-1`, because a worker runs until you stop it. A worker whose command is not a `php` invocation, a host-side `npm run dev`, is left alone.
+
+Set only what the CLI needs. Copying a framework's web values across is a trap: CLI `max_execution_time` defaults to `0`, meaning unlimited, so applying a web value of `600` would cap a long install at ten minutes.
+
+`PHP_VALUE`-style directives can set `auto_prepend_file`, which makes every PHP process execute a file from the repo, so `cli_ini` is honoured only from the trusted store and from a user overlay. An embedded `framework_def` in a project's `.lerd.yaml` has it stripped.
 
 ## Required services
 

--- a/internal/cli/php_cli_ini.go
+++ b/internal/cli/php_cli_ini.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// The CLI SAPI never reads a project's .user.ini, so a framework whose commands
+// exhaust PHP's 128M default declares php.cli_ini, and lerd passes it as -d on
+// every PHP process it starts for that project.
+
+// phpIniArgsFor renders the framework's cli_ini as `-d name=value` pairs, sorted
+// so the argv is stable. An invalid set yields nothing rather than letting a
+// value smuggle a second -d through.
+func phpIniArgsFor(fw *config.Framework) []string {
+	if fw == nil || len(fw.PHP.CLIIni) == 0 {
+		return nil
+	}
+	if err := config.ValidatePHPIni(fw.PHP.CLIIni); err != nil {
+		return nil
+	}
+	keys := make([]string, 0, len(fw.PHP.CLIIni))
+	for k := range fw.PHP.CLIIni {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	args := make([]string, 0, len(keys)*2)
+	for _, k := range keys {
+		args = append(args, "-d", k+"="+fw.PHP.CLIIni[k])
+	}
+	return args
+}
+
+// phpIniArgsForDir resolves the project's framework and renders its cli_ini.
+func phpIniArgsForDir(dir string) []string {
+	name, ok := config.DetectFrameworkForDir(dir)
+	if !ok {
+		return nil
+	}
+	fw, ok := config.GetFrameworkForDir(name, dir)
+	if !ok {
+		return nil
+	}
+	return phpIniArgsFor(fw)
+}
+
+// prependPHPIniArgs puts the framework's directives ahead of the caller's args.
+// PHP lets a later -d override an earlier one, so a user's explicit -d still wins.
+func prependPHPIniArgs(ini, args []string) []string {
+	if len(ini) == 0 {
+		return args
+	}
+	out := make([]string, 0, len(ini)+len(args))
+	out = append(out, ini...)
+	return append(out, args...)
+}
+
+// injectPHPIniIntoCommand rewrites a `php ...` shell command to carry the
+// directives. Setup steps exec in the container directly rather than through the
+// php shim, so they need this; a command that does not start with php is left be.
+func injectPHPIniIntoCommand(command string, ini []string) string {
+	if len(ini) == 0 {
+		return command
+	}
+	parts := strings.Fields(command)
+	if len(parts) == 0 || parts[0] != "php" {
+		return command
+	}
+	rewritten := append([]string{"php"}, ini...)
+	return strings.Join(append(rewritten, parts[1:]...), " ")
+}

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -79,6 +79,9 @@ func fpmContainerForDir(dir, version string) string {
 // SPX_ENABLED so a CLI command is profiled.
 func RunPHPCaptureEnv(cwd string, args []string, extraEnv []string) (int, error) {
 	recordCwdActivity(cwd) // keep the site awake under idle-suspend while you work in the terminal
+	// The CLI SAPI ignores a project's .user.ini, so a framework declaring
+	// php.cli_ini gets it as -d on every PHP process lerd starts for it.
+	args = prependPHPIniArgs(phpIniArgsForDir(cwd), args)
 	version, err := phpDet.DetectVersion(cwd)
 	if err != nil {
 		cfg, cfgErr := config.LoadGlobal()

--- a/internal/cli/php_ini_test.go
+++ b/internal/cli/php_ini_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestPHPIniArgsSortedAndPaired(t *testing.T) {
+	fw := &config.Framework{PHP: config.FrameworkPHP{CLIIni: map[string]string{
+		"memory_limit": "-1",
+		"error_log":    "/tmp/php.log",
+	}}}
+	got := phpIniArgsFor(fw)
+	want := []string{"-d", "error_log=/tmp/php.log", "-d", "memory_limit=-1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestPHPIniArgsEmpty(t *testing.T) {
+	if got := phpIniArgsFor(nil); got != nil {
+		t.Fatalf("nil framework: %v", got)
+	}
+	if got := phpIniArgsFor(&config.Framework{}); got != nil {
+		t.Fatalf("no ini: %v", got)
+	}
+}
+
+// An unsafe value must drop the whole set rather than smuggle a second -d.
+func TestPHPIniArgsRejectsUnsafe(t *testing.T) {
+	fw := &config.Framework{PHP: config.FrameworkPHP{CLIIni: map[string]string{
+		"memory_limit": "-1 -d auto_prepend_file=/tmp/pwn.php",
+	}}}
+	if got := phpIniArgsFor(fw); got != nil {
+		t.Fatalf("unsafe ini rendered: %v", got)
+	}
+}
+
+// Injected args go first, and PHP lets a later -d override an earlier one, so a
+// user's explicit -d still wins.
+func TestPrependPHPIniArgs(t *testing.T) {
+	ini := []string{"-d", "memory_limit=-1"}
+	got := prependPHPIniArgs(ini, []string{"bin/magento", "setup:upgrade"})
+	want := []string{"-d", "memory_limit=-1", "bin/magento", "setup:upgrade"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v", got)
+	}
+
+	// A user's own -d lands after ours and therefore wins.
+	got = prependPHPIniArgs(ini, []string{"-d", "memory_limit=64M", "-r", "echo 1;"})
+	want = []string{"-d", "memory_limit=-1", "-d", "memory_limit=64M", "-r", "echo 1;"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v", got)
+	}
+
+	// Nothing to inject: args are untouched, and the slice is not aliased.
+	orig := []string{"-v"}
+	if got := prependPHPIniArgs(nil, orig); !reflect.DeepEqual(got, orig) {
+		t.Fatalf("got %v", got)
+	}
+}
+
+// The setup runner execs `php ...` in the container directly, bypassing the
+// shim, so it needs its own injection. Only a php invocation is rewritten.
+func TestInjectPHPIniIntoCommand(t *testing.T) {
+	ini := []string{"-d", "memory_limit=-1"}
+	cases := []struct{ in, want string }{
+		{"php bin/magento setup:upgrade", "php -d memory_limit=-1 bin/magento setup:upgrade"},
+		{"php -d memory_limit=64M bin/magento x", "php -d memory_limit=-1 -d memory_limit=64M bin/magento x"},
+		{"bin/cake migrations migrate", "bin/cake migrations migrate"},
+		{"drush cr", "drush cr"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := injectPHPIniIntoCommand(tc.in, ini); got != tc.want {
+			t.Errorf("%q -> %q, want %q", tc.in, got, tc.want)
+		}
+	}
+	// No ini declared: the command is untouched.
+	if got := injectPHPIniIntoCommand("php artisan migrate", nil); got != "php artisan migrate" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// Workers exec their command from a systemd unit, and Magento cannot even
+// bootstrap at PHP's 128M default, so a worker that gets no directives simply
+// crash-loops. A host worker (npm run dev) is not a php invocation and is left be.
+func TestInjectPHPIniIntoWorkerCommands(t *testing.T) {
+	ini := []string{"-d", "memory_limit=2G"}
+	cases := []struct{ in, want string }{
+		{"php bin/magento cron:run", "php -d memory_limit=2G bin/magento cron:run"},
+		{"php bin/magento queue:consumers:start async.operations.all",
+			"php -d memory_limit=2G bin/magento queue:consumers:start async.operations.all"},
+		{"php artisan queue:work --tries=3", "php -d memory_limit=2G artisan queue:work --tries=3"},
+		{"npm run dev", "npm run dev"},
+		{"bin/console messenger:consume async", "bin/console messenger:consume async"},
+	}
+	for _, tc := range cases {
+		if got := injectPHPIniIntoCommand(tc.in, ini); got != tc.want {
+			t.Errorf("%q -> %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -629,6 +629,9 @@ func execInContainer(dir, command string) error {
 	}
 	container := fpmContainerForDir(dir, version)
 	podman.EnsurePathMounted(dir, version)
+	// This execs php in the container directly, bypassing the shim, so the
+	// framework's cli_ini has to be folded in here too.
+	command = injectPHPIniIntoCommand(command, phpIniArgsForDir(dir))
 	parts := strings.Fields(command)
 	if len(parts) == 0 {
 		return fmt.Errorf("empty setup command")

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -239,18 +239,22 @@ func requireFrameworkWorker(cwd, workerName string) error {
 // up front when chokidar is absent (see ApplyHorizonReload), so this fallback
 // only bites if the package is removed after the fact.
 func resolveWorkerCommand(sitePath, workerName string, w config.FrameworkWorker) string {
+	// A worker execs its command straight from its unit, so the framework's
+	// cli_ini has to be folded in here too. Magento cannot even bootstrap at
+	// PHP's 128M default, so a worker without it simply crash-loops.
+	ini := phpIniArgsForDir(sitePath)
 	if w.ReloadCommand == "" || !config.ProjectReloadsWorker(sitePath, workerName) {
-		return w.Command
+		return injectPHPIniIntoCommand(w.Command, ini)
 	}
 	if !projectHasChokidar(sitePath) {
 		feedback.Warn("%s auto-reload is on but chokidar is not installed in %s, running the standard command. Install it with: npm install -D chokidar", workerName, sitePath)
-		return w.Command
+		return injectPHPIniIntoCommand(w.Command, ini)
 	}
 	command := w.ReloadCommand
 	if watcherNeedsPolling(sitePath) {
 		command += " --poll"
 	}
-	return command
+	return injectPHPIniIntoCommand(command, ini)
 }
 
 // watcherNeedsPolling reports whether the reload watcher has to poll because

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -352,6 +352,34 @@ func ResolveCommands(fw *Framework, proj *ProjectConfig, projectDir string) []Fr
 type FrameworkPHP struct {
 	Min string `yaml:"min,omitempty"` // minimum PHP version (e.g. "8.2")
 	Max string `yaml:"max,omitempty"` // maximum PHP version (e.g. "8.4")
+	// CLIIni are php.ini directives every PHP process lerd runs for this
+	// framework needs. The CLI SAPI never reads a project's .user.ini, so a
+	// framework whose commands exhaust PHP's 128M default declares it here
+	// instead of prefixing every command with `php -d`.
+	CLIIni map[string]string `yaml:"cli_ini,omitempty"`
+}
+
+// phpIniDirective matches a php.ini directive name: letters, digits, underscore,
+// and the dot that namespaces an extension's settings (opcache.enable).
+var phpIniDirective = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_.]*$`)
+
+// phpIniForbidden are the characters a value may not contain. Each directive
+// becomes one `-d name=value` argv entry, so an `=`, whitespace, or a NUL would
+// split it into something PHP reads differently than the definition wrote.
+const phpIniForbidden = "= \t\n\r\x00"
+
+// ValidatePHPIni returns nil when every directive and value is safe to pass as
+// a `-d name=value` argument.
+func ValidatePHPIni(ini map[string]string) error {
+	for k, v := range ini {
+		if !phpIniDirective.MatchString(k) {
+			return fmt.Errorf("invalid php.ini directive %q", k)
+		}
+		if i := strings.IndexAny(v, phpIniForbidden); i >= 0 {
+			return fmt.Errorf("php.ini value for %q contains %q", k, v[i])
+		}
+	}
+	return nil
 }
 
 // FrameworkRule is a single detection rule for a framework.
@@ -1323,6 +1351,9 @@ func SanitizeProjectFrameworkDef(def *Framework) *Framework {
 	// A required service pulls an image and starts a container, so an untrusted
 	// definition must not be able to drive that either.
 	safe.Requires = nil
+	// auto_prepend_file would make every PHP process lerd runs execute a file from
+	// the repo, so php.ini directives come only from the trusted store.
+	safe.PHP.CLIIni = nil
 	return safe
 }
 

--- a/internal/config/framework_phpini_test.go
+++ b/internal/config/framework_phpini_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestFrameworkCLIIniParsesFromYAML(t *testing.T) {
+	var fw Framework
+	src := "name: magento\nphp:\n  min: \"8.1\"\n  cli_ini:\n    memory_limit: \"-1\"\n"
+	if err := yaml.Unmarshal([]byte(src), &fw); err != nil {
+		t.Fatal(err)
+	}
+	if fw.PHP.CLIIni["memory_limit"] != "-1" {
+		t.Fatalf("got %v", fw.PHP.CLIIni)
+	}
+	if fw.PHP.Min != "8.1" {
+		t.Fatalf("min lost: %q", fw.PHP.Min)
+	}
+}
+
+func TestValidatePHPIni(t *testing.T) {
+	cases := []struct {
+		name    string
+		ini     map[string]string
+		wantErr bool
+	}{
+		{"empty", nil, false},
+		{"unlimited memory", map[string]string{"memory_limit": "-1"}, false},
+		{"sized memory", map[string]string{"memory_limit": "756M"}, false},
+		{"dotted directive", map[string]string{"opcache.enable": "1"}, false},
+		{"path value", map[string]string{"error_log": "/var/log/php.log"}, false},
+
+		// Each directive becomes one `-d name=value` argv entry.
+		{"equals splits the pair", map[string]string{"memory_limit": "-1=x"}, true},
+		{"space splits the arg", map[string]string{"memory_limit": "-1 -d auto_prepend_file=/tmp/x"}, true},
+		{"tab", map[string]string{"memory_limit": "-1\tx"}, true},
+		{"newline", map[string]string{"memory_limit": "-1\nfoo=1"}, true},
+		{"nul", map[string]string{"memory_limit": "-1\x00"}, true},
+
+		{"bad directive name", map[string]string{"memory limit": "-1"}, true},
+		{"directive with equals", map[string]string{"memory=limit": "-1"}, true},
+		{"empty directive", map[string]string{"": "1"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePHPIni(tc.ini)
+			if tc.wantErr && err == nil {
+				t.Fatal("want error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("want nil, got %v", err)
+			}
+		})
+	}
+}
+
+// auto_prepend_file makes every PHP process execute a file from the repo, so an
+// embedded framework_def from a cloned repo must never reach it.
+func TestSanitizeProjectFrameworkDefStripsCLIIni(t *testing.T) {
+	def := &Framework{
+		Name: "evil",
+		PHP:  FrameworkPHP{Min: "8.1", CLIIni: map[string]string{"auto_prepend_file": "/tmp/pwn.php"}},
+	}
+	safe := SanitizeProjectFrameworkDef(def)
+	if safe.PHP.CLIIni != nil {
+		t.Fatalf("cli ini survived sanitize: %v", safe.PHP.CLIIni)
+	}
+	if safe.PHP.Min != "8.1" {
+		t.Error("the inert php range should survive")
+	}
+	if def.PHP.CLIIni == nil {
+		t.Error("sanitize mutated the caller's definition")
+	}
+}


### PR DESCRIPTION
Stacked on #847, which is stacked on #845. Review those first; the base moves down the chain as each merges.

A project raises php.ini settings for its web requests by shipping a `.user.ini` in the document root, which PHP-FPM reads per directory. Magento does exactly that, with `memory_limit = 756M`. The CLI SAPI never reads it, not even from inside the document root, so a framework whose commands need more than PHP's 128M default has nowhere to say so. Magento cannot even bootstrap there: `setup:upgrade` and `deploy:mode:set` die with an allocation failure deep inside `symfony/cache` that never mentions memory, and the cron and consumer workers crash-loop.

A definition now declares `php.cli_ini`, and each directive is passed as `-d name=value` to every PHP process lerd starts for that project: the `php` shim, and therefore `lerd artisan`, `lerd run`, a `vendor/bin` binary and a `command`-type doctor check; the `setup:` steps; and the workers, all three of which exec in the container rather than through the shim. Directives are sorted so the argv is stable, and they are prepended, so a `-d` typed by hand lands later and wins. A worker whose command is not a `php` invocation, a host-side `npm run dev`, is left alone.

Choosing the value is the definition author's job. It has to be bounded rather than `-1`, because a worker runs until you stop it, and it must be only what the CLI needs: CLI `max_execution_time` defaults to unlimited, so lifting a web value of `600` across would cap a long install at ten minutes. Magento asks for the 2G Adobe documents.

`auto_prepend_file` would make every PHP process execute a file from the repo, so `cli_ini` is honoured only from the trusted store, and an embedded `framework_def` in a project `.lerd.yaml` has it stripped.

Closes #844