### PR TITLE
fix: report a scheduled worker as running when its timer is armed

### DIFF
--- a/internal/siteinfo/scheduled_worker_test.go
+++ b/internal/siteinfo/scheduled_worker_test.go
@@ -1,0 +1,37 @@
+package siteinfo
+
+import "testing"
+
+// A scheduled worker is Type=oneshot driven by a .timer: its .service is
+// inactive between ticks, so liveness is the timer's state, not the service's.
+func TestWorkerUnitLiveness(t *testing.T) {
+	cases := []struct {
+		name         string
+		schedule     string
+		serviceState string
+		timerState   string
+		wantRunning  bool
+		wantFailing  bool
+	}{
+		{"daemon running", "", "active", "", true, false},
+		{"daemon stopped", "", "inactive", "", false, false},
+		{"daemon failed", "", "failed", "", false, true},
+		{"daemon starting", "", "activating", "", true, false},
+
+		// The case the UI got wrong: armed timer, idle service.
+		{"scheduled armed between ticks", "minutely", "inactive", "active", true, false},
+		{"scheduled firing right now", "minutely", "activating", "active", true, false},
+		{"scheduled timer stopped", "minutely", "inactive", "inactive", false, false},
+		// A failed last run still surfaces, even though the timer is armed.
+		{"scheduled last run failed", "minutely", "failed", "active", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			running, failing := workerLiveness(tc.schedule, tc.serviceState, tc.timerState)
+			if running != tc.wantRunning || failing != tc.wantFailing {
+				t.Fatalf("running=%v failing=%v, want running=%v failing=%v",
+					running, failing, tc.wantRunning, tc.wantFailing)
+			}
+		})
+	}
+}

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -560,19 +560,23 @@ func (e *EnrichedSite) enrichWorkers(fw *config.Framework, hasFw bool) {
 	sort.Strings(names)
 	for _, wname := range names {
 		w := fw.Workers[wname]
-		unitStatus, _ := unitStatusFn("lerd-" + wname + "-" + e.Name)
+		unit := "lerd-" + wname + "-" + e.Name
+		serviceState, _ := unitStatusFn(unit)
+		timerState := ""
+		if w.Schedule != "" {
+			timerState, _ = unitStatusFn(unit + ".timer")
+		}
+		running, failing := workerLiveness(w.Schedule, serviceState, timerState)
 		label := w.Label
 		if label == "" {
 			label = wname
 		}
-		running := unitStatus == "active" || unitStatus == "activating"
-		failing := unitStatus == "failed"
 		unreachable := false
 		// A worker whose process is up but whose server isn't accepting is
 		// unhealthy, not running (a vite dev server that died under npm). Probe
 		// only "active" (a still-activating server may not have bound yet). It is
 		// unreachable, not failed: systemd still calls the unit active.
-		if unitStatus == "active" && w.Health != nil {
+		if serviceState == "active" && w.Health != nil {
 			if reachable, probed := WorkerServerReachable(e.Path, w.Health); probed && !reachable {
 				running = false
 				unreachable = true
@@ -586,6 +590,18 @@ func (e *EnrichedSite) enrichWorkers(fw *config.Framework, hasFw bool) {
 			Unreachable: unreachable,
 		})
 	}
+}
+
+// workerLiveness maps a worker's unit states to what a UI should show. A daemon
+// is alive when its service is. A scheduled worker is a Type=oneshot triggered
+// by a .timer, so its service is inactive between ticks and the timer carries
+// the liveness; a failed last run still surfaces.
+func workerLiveness(schedule, serviceState, timerState string) (running, failing bool) {
+	failing = serviceState == "failed"
+	if schedule != "" {
+		return timerState == "active" || timerState == "activating", failing
+	}
+	return serviceState == "active" || serviceState == "activating", failing
 }
 
 // enrichWorktreeWorkers returns running state for framework workers that the
@@ -610,18 +626,21 @@ func enrichWorktreeWorkers(siteName, wtPath string, fw *config.Framework) []Work
 	for _, wname := range names {
 		w := fw.Workers[wname]
 		unit := "lerd-" + wname + "-" + siteName + "-" + wtBase
-		status, _ := unitStatusFn(unit)
+		serviceState, _ := unitStatusFn(unit)
+		timerState := ""
+		if w.Schedule != "" {
+			timerState, _ = unitStatusFn(unit + ".timer")
+		}
+		running, failing := workerLiveness(w.Schedule, serviceState, timerState)
 		label := w.Label
 		if label == "" {
 			label = wname
 		}
-		running := status == "active" || status == "activating"
-		failing := status == "failed"
 		unreachable := false
 		// Same server-reachability check as enrichWorkers, against this worktree's
 		// own checkout where its dev server writes the URL file. Active-but-unbound
 		// is unreachable, not failed.
-		if status == "active" && w.Health != nil {
+		if serviceState == "active" && w.Health != nil {
 			if reachable, probed := WorkerServerReachable(wtPath, w.Health); probed && !reachable {
 				running = false
 				unreachable = true


### PR DESCRIPTION
A worker with a `schedule:` is written as a `Type=oneshot` service triggered by a sibling `.timer`, so its service unit is inactive between ticks. That is how it is supposed to look. Worker status read the service, so a perfectly healthy scheduled worker was reported as stopped, and clicking it in the dashboard appeared to do nothing.

Liveness for a scheduled worker is the timer's state, while a failed last run still surfaces from the service, so an errored tick is not hidden behind an armed timer. The site view and the worktree view resolve it through the same helper.

Three shipped definitions declare one: Laravel 10's `schedule`, Tempest 3's `schedule`, and Magento 2's `cron`. All three have been drawn as stopped for as long as they have existed.

Closes #849