### PR TITLE
fix: harden php-array env parsing and surface dropped framework nginx snippets

### DIFF
--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -179,9 +179,8 @@ func emptyEnvFile(envFormat string) []byte {
 }
 
 // frameworkManagesEnv reports whether the project's framework declares an env
-// section. Link and setup call `lerd env` unconditionally; for a framework that
-// keeps its config elsewhere (Magento) that is an expected no-op, not a failure
-// worth printing twice.
+// section. For a framework with no env section (a static or host-proxy app) the
+// unconditional `lerd env` in link and setup is an expected no-op, not a failure.
 func frameworkManagesEnv(cwd string) bool {
 	name, ok := config.DetectFrameworkForDir(cwd)
 	if !ok {

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -389,8 +389,8 @@ type FrameworkEnvConf struct {
 }
 
 // HasEnvConfig reports whether the framework manages an env file at all. A
-// framework that keeps its config elsewhere (Magento's app/etc/env.php) declares
-// no env section, so `lerd env` and the doctor's env checks must skip it.
+// framework with no env section (a static or host-proxy app) is skipped by
+// `lerd env` and the doctor's env checks, not flagged for a file it never had.
 func (f *Framework) HasEnvConfig() bool {
 	if f == nil {
 		return false

--- a/internal/envfile/phparray.go
+++ b/internal/envfile/phparray.go
@@ -242,7 +242,15 @@ func parsePhpReturn(src string) (*phpValue, error) {
 			p.skipTrivia()
 			return p.parseValue()
 		}
-		p.pos++
+		// Step over a string literal whole, so a `return` sitting inside one is
+		// never mistaken for the statement. skipTrivia already ate comments.
+		if c := p.src[p.pos]; c == '\'' || c == '"' {
+			if _, err := p.parseString(); err != nil {
+				return nil, err
+			}
+		} else {
+			p.pos++
+		}
 		p.skipTrivia()
 	}
 	return nil, nil

--- a/internal/envfile/phparray_test.go
+++ b/internal/envfile/phparray_test.go
@@ -107,6 +107,24 @@ return array(
 	}
 }
 
+// A `return` sitting inside a string literal before the real return statement
+// must not be mistaken for it, or the scanner parses the wrong value.
+func TestReadPhpArraySkipsReturnInsideString(t *testing.T) {
+	src := `<?php
+$note = 'remember to return the array';
+return [
+    'db' => ['host' => 'localhost'],
+];
+`
+	got, err := ReadPhpArray(writeTemp(t, src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["db.host"] != "localhost" {
+		t.Fatalf("scanner matched a return inside a string: %v", got)
+	}
+}
+
 func TestReadPhpArrayMissingOrEmptyFile(t *testing.T) {
 	if _, err := ReadPhpArray(filepath.Join(t.TempDir(), "nope.php")); err == nil {
 		t.Error("missing file should error")

--- a/internal/nginx/framework_nginx_test.go
+++ b/internal/nginx/framework_nginx_test.go
@@ -106,6 +106,52 @@ func TestExpandNginxSnippetRejectsHostileValues(t *testing.T) {
 	}
 }
 
+// A snippet dropped because a substituted value carries nginx syntax (here a
+// project path with a metacharacter) must warn, not vanish silently.
+func TestFrameworkNginxBlockWarnsOnDrop(t *testing.T) {
+	snippet := "location /a/ {\n    root {{root}};\n}"
+
+	var buf bytes.Buffer
+	if got := frameworkNginxBlock(&buf, "magento", "shop.test", snippet, "/home/u/a;b", "pub", "fpm"); got != "" {
+		t.Fatalf("hostile path should be dropped, got %q", got)
+	}
+	if !strings.Contains(buf.String(), "[WARN]") || !strings.Contains(buf.String(), "shop.test") {
+		t.Fatalf("drop was silent: %q", buf.String())
+	}
+
+	// A clean snippet expands and stays quiet.
+	buf.Reset()
+	if got := frameworkNginxBlock(&buf, "magento", "shop.test", snippet, "/home/u/a", "pub", "fpm"); got == "" {
+		t.Fatal("valid snippet was dropped")
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("valid snippet warned: %q", buf.String())
+	}
+	// An empty snippet is the common case: no output, no block.
+	buf.Reset()
+	if got := frameworkNginxBlock(&buf, "laravel", "app.test", "  ", "/p", "public", "fpm"); got != "" || buf.Len() != 0 {
+		t.Fatalf("empty snippet: got %q, warned %q", got, buf.String())
+	}
+}
+
+// A dropped-snippet warning reaches the user once per process, so `lerd link`
+// shows the reason while the watcher does not repeat it on every regeneration.
+func TestEmitOnceDedupes(t *testing.T) {
+	var buf bytes.Buffer
+	msg := "[WARN] dropping magento nginx config for emitonce-unique.test: bad\n"
+	emitOnce(&buf, msg)
+	emitOnce(&buf, msg)
+	if strings.Count(buf.String(), "emitonce-unique.test") != 1 {
+		t.Fatalf("want one emission, got %q", buf.String())
+	}
+	// A different reason still surfaces; an empty message never emits.
+	emitOnce(&buf, "[WARN] dropping magento nginx config for emitonce-unique.test: other\n")
+	emitOnce(&buf, "")
+	if strings.Count(buf.String(), "emitonce-unique.test") != 2 {
+		t.Fatalf("distinct reason or empty msg mishandled: %q", buf.String())
+	}
+}
+
 // The framework block must land inside the server block and BEFORE the generic
 // `location /` and `location ~ \.php$`, since nginx picks the first matching
 // regex location in declaration order.

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -7,11 +7,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -96,14 +98,50 @@ type VhostData struct {
 // nginx syntax of its own.
 func resolveFrameworkNginx(site config.Site, publicDir, fpmContainer string) string {
 	fw, ok := config.GetFrameworkForDir(site.Framework, site.Path)
-	if !ok || fw.Nginx == nil || strings.TrimSpace(fw.Nginx.Snippet) == "" {
+	if !ok || fw.Nginx == nil {
 		return ""
 	}
-	if err := config.ValidateNginxSnippet(fw.Nginx.Snippet); err != nil {
+	var warn bytes.Buffer
+	block := frameworkNginxBlock(&warn, site.Framework, site.PrimaryDomain(), fw.Nginx.Snippet, site.Path, publicDir, fpmContainer)
+	emitOnce(os.Stdout, warn.String())
+	return block
+}
+
+var (
+	frameworkNginxWarnMu   sync.Mutex
+	frameworkNginxWarnSeen = map[string]bool{}
+)
+
+// emitOnce writes msg to w only the first time this process sees it. A dropped
+// snippet then surfaces on `lerd link` without the watcher repeating it on every
+// vhost regeneration, and the http/ssl pair for one site collapses to one line.
+func emitOnce(w io.Writer, msg string) {
+	if msg == "" {
+		return
+	}
+	frameworkNginxWarnMu.Lock()
+	defer frameworkNginxWarnMu.Unlock()
+	if frameworkNginxWarnSeen[msg] {
+		return
+	}
+	frameworkNginxWarnSeen[msg] = true
+	fmt.Fprint(w, msg)
+}
+
+// frameworkNginxBlock validates and expands a framework snippet into an indented
+// server-block fragment, "" when it declares none. A drop writes a warning to w
+// rather than vanishing silently (the caller rate-limits it, see emitOnce).
+func frameworkNginxBlock(w io.Writer, framework, domain, snippet, sitePath, publicDir, fpmContainer string) string {
+	if strings.TrimSpace(snippet) == "" {
 		return ""
 	}
-	expanded, err := expandNginxSnippet(fw.Nginx.Snippet, site.Path, publicDir, fpmContainer)
+	if err := config.ValidateNginxSnippet(snippet); err != nil {
+		fmt.Fprintf(w, "[WARN] dropping %s nginx config for %s: %v\n", framework, domain, err)
+		return ""
+	}
+	expanded, err := expandNginxSnippet(snippet, sitePath, publicDir, fpmContainer)
 	if err != nil {
+		fmt.Fprintf(w, "[WARN] dropping %s nginx config for %s: %v\n", framework, domain, err)
 		return ""
 	}
 	return indentBlock(strings.TrimRight(expanded, "\n"), "    ")


### PR DESCRIPTION
Two follow-ups to the framework-definition work merged in #845.

The php-array env reader scanned for the top-level return statement byte by byte without stepping over string literals, so a return sitting inside a string ahead of the real one could be mistaken for it and the wrong value parsed. Magento's env.php is machine generated and never hits this, but a hand-authored php-array file could, so the scanner now steps over a string whole.

A framework nginx snippet dropped for an unbalanced brace or a substituted value carrying nginx syntax used to vanish with no output, so a project path containing an nginx metacharacter would make the framework's asset routes silently disappear. The drop now warns, once per process, so lerd link surfaces the reason while the long running watcher does not repeat it on every vhost regeneration.