### PR TITLE
feat(dashboard): reclaimable disk in the resources widget with a cleanup modal

### DIFF
--- a/docs/usage/cleanup.md
+++ b/docs/usage/cleanup.md
@@ -41,7 +41,7 @@ lerd cleanup --yes        # skip the confirmation prompt (for scripts)
 
 Reported sizes are an estimate of the disk each removal frees. An image a live image is still built on is never listed (removing it is impossible and would free nothing), so cleanup never promises space it can't reclaim, though images that share layers with each other can add up to less than their sizes suggest. `lerd doctor` shows the reclaimable total as a read-only line so you discover the bloat early.
 
-The destructive command is CLI-only by design, consistent with keeping destructive operations out of the dashboard and TUI.
+The dashboard surfaces this too. The resources widget shows the reclaimable total alongside live CPU and memory, and a **Clean up** button opens a confirmation modal that lists the images that would be removed and the space they would return, mirroring the preview above, before it runs the deep reclaim. Confirming re-inspects the host and applies that fresh plan, so a modal left open across a rebuild never asks podman to remove an image that has since become live. Cleanup only ever reclaims images and never touches a named data volume, and the watcher already runs it unattended every day, so it does not sit in the same class as migrate, remove, or reinstall, which stay CLI-only. The TUI stays informative only.
 
 ## Automatic cleanup
 

--- a/internal/ui/cleanup.go
+++ b/internal/ui/cleanup.go
@@ -1,0 +1,126 @@
+package ui
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/geodro/lerd/internal/cleanup"
+)
+
+// diskCacheTTL bounds how often the dashboard triggers a full podman image
+// scan. Computing the reclaimable total inspects every image's layers, which
+// is heavier than the per-container stats poll, so the disk widget refreshes
+// on its own slower cadence and this short cache collapses concurrent tabs
+// into a single scan.
+const diskCacheTTL = 20 * time.Second
+
+// inspectDisk and applyDisk are the seams tests override. The dashboard button
+// runs the deep scope, matching the interactive CLI default, so both the
+// preview and the reclaim work off ScopeDeep.
+var (
+	inspectDisk = func() (cleanup.Plan, error) { return cleanup.Inspect(cleanup.ScopeDeep) }
+	applyDisk   = cleanup.Apply
+)
+
+// diskImage is one reclaimable image in the preview the modal lists.
+type diskImage struct {
+	ID    string `json:"id"`
+	Desc  string `json:"desc"`
+	Bytes int64  `json:"bytes"`
+}
+
+// diskSnapshot is the reclaimable-disk preview the widget polls and the modal
+// itemizes. Held is disk locked behind running containers that a restart, not
+// this cleanup, would release.
+type diskSnapshot struct {
+	Available        bool        `json:"available"`
+	ReclaimableBytes int64       `json:"reclaimable_bytes"`
+	Images           []diskImage `json:"images"`
+	HeldBytes        int64       `json:"held_bytes"`
+	HeldCount        int         `json:"held_count"`
+}
+
+var (
+	diskMu   sync.Mutex
+	diskSnap *diskSnapshot
+	diskAt   time.Time
+)
+
+// cachedDisk returns the reclaimable-disk preview, running a full scan at most
+// once per diskCacheTTL. Holding the lock across the scan serializes the rare
+// concurrent callers, which then read the fresh value, so multiple open tabs
+// never fan out into parallel podman scans.
+func cachedDisk() diskSnapshot {
+	diskMu.Lock()
+	defer diskMu.Unlock()
+	if diskSnap != nil && time.Since(diskAt) < diskCacheTTL {
+		return *diskSnap
+	}
+	snap := scanDisk()
+	diskSnap = &snap
+	diskAt = time.Now()
+	return snap
+}
+
+// scanDisk builds the preview from a fresh deep-scope inspection. A scan error
+// (podman down) reports as unavailable rather than an empty reclaim, so the
+// widget can distinguish "nothing to reclaim" from "couldn't look".
+func scanDisk() diskSnapshot {
+	plan, err := inspectDisk()
+	if err != nil {
+		return diskSnapshot{Available: false}
+	}
+	imgs := make([]diskImage, 0, len(plan.Targets))
+	for _, t := range plan.Targets {
+		imgs = append(imgs, diskImage{ID: t.ID, Desc: t.Desc, Bytes: t.Bytes})
+	}
+	return diskSnapshot{
+		Available:        true,
+		ReclaimableBytes: plan.ReclaimBytes(),
+		Images:           imgs,
+		HeldBytes:        plan.Held.Bytes,
+		HeldCount:        plan.Held.Count,
+	}
+}
+
+// invalidateDiskCache drops the cached preview so the next poll reflects a
+// reclaim that just ran instead of serving a stale total for up to a TTL.
+func invalidateDiskCache() {
+	diskMu.Lock()
+	diskSnap = nil
+	diskMu.Unlock()
+}
+
+// handleDisk serves the reclaimable-disk preview (GET) and runs the reclaim
+// (POST). The POST is loopback-only: the deep scope removes images on the host,
+// including dangling ones from other podman workloads, so it stays off the LAN
+// even when remote control is on.
+func handleDisk(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, cachedDisk())
+	case http.MethodPost:
+		if !isLoopbackRequest(r) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		handleDiskCleanup(w)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleDiskCleanup re-inspects the host and applies that fresh plan rather
+// than trusting anything the client posted, so a modal left open across a
+// rebuild can't ask podman to remove an image that has since become live.
+func handleDiskCleanup(w http.ResponseWriter) {
+	plan, err := inspectDisk()
+	if err != nil {
+		writeJSON(w, map[string]any{"ok": false, "error": err.Error()})
+		return
+	}
+	removed, reclaimed := applyDisk(plan)
+	invalidateDiskCache()
+	writeJSON(w, map[string]any{"ok": true, "removed": removed, "reclaimed_bytes": reclaimed})
+}

--- a/internal/ui/cleanup_test.go
+++ b/internal/ui/cleanup_test.go
@@ -1,0 +1,131 @@
+package ui
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/geodro/lerd/internal/cleanup"
+)
+
+func stubDisk(t *testing.T, inspect func() (cleanup.Plan, error), apply func(cleanup.Plan) (int, int64)) {
+	t.Helper()
+	origInspect, origApply := inspectDisk, applyDisk
+	inspectDisk, applyDisk = inspect, apply
+	invalidateDiskCache()
+	t.Cleanup(func() {
+		inspectDisk, applyDisk = origInspect, origApply
+		invalidateDiskCache()
+	})
+}
+
+func TestScanDiskReportsPlan(t *testing.T) {
+	plan := cleanup.Plan{
+		Targets: []cleanup.Target{
+			{Kind: "image", ID: "aaa", Desc: "orphaned build", Bytes: 100},
+			{Kind: "image", ID: "bbb", Desc: "dangling image", Bytes: 250},
+		},
+		Held: cleanup.HeldByContainers{Count: 1, Bytes: 40},
+	}
+	stubDisk(t, func() (cleanup.Plan, error) { return plan, nil }, nil)
+
+	snap := scanDisk()
+	if !snap.Available {
+		t.Fatal("Available: got false want true")
+	}
+	if snap.ReclaimableBytes != 350 {
+		t.Errorf("ReclaimableBytes: got %d want 350", snap.ReclaimableBytes)
+	}
+	if len(snap.Images) != 2 || snap.Images[1].Desc != "dangling image" {
+		t.Errorf("Images: got %+v", snap.Images)
+	}
+	if snap.HeldBytes != 40 || snap.HeldCount != 1 {
+		t.Errorf("held: got %d/%d want 40/1", snap.HeldBytes, snap.HeldCount)
+	}
+}
+
+func TestScanDiskUnavailableOnError(t *testing.T) {
+	stubDisk(t, func() (cleanup.Plan, error) { return cleanup.Plan{}, errors.New("podman down") }, nil)
+	snap := scanDisk()
+	if snap.Available {
+		t.Error("a scan error must report Available=false, not an empty reclaim")
+	}
+}
+
+// The apply path must re-inspect server-side and reclaim that fresh plan rather
+// than trusting the client, so an image that became live since the modal opened
+// is never posted for removal.
+func TestDiskCleanupReinspects(t *testing.T) {
+	fresh := cleanup.Plan{Targets: []cleanup.Target{{Kind: "image", ID: "live-now", Bytes: 500}}}
+	var applied cleanup.Plan
+	stubDisk(t,
+		func() (cleanup.Plan, error) { return fresh, nil },
+		func(p cleanup.Plan) (int, int64) { applied = p; return len(p.Targets), 500 },
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/disk", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	rec := httptest.NewRecorder()
+	handleDisk(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", rec.Code)
+	}
+	if len(applied.Targets) != 1 || applied.Targets[0].ID != "live-now" {
+		t.Errorf("apply got the client list, not the server re-inspection: %+v", applied.Targets)
+	}
+	var resp struct {
+		OK             bool  `json:"ok"`
+		Removed        int   `json:"removed"`
+		ReclaimedBytes int64 `json:"reclaimed_bytes"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK || resp.Removed != 1 || resp.ReclaimedBytes != 500 {
+		t.Errorf("resp: got %+v", resp)
+	}
+}
+
+func TestDiskCleanupRejectsNonLoopback(t *testing.T) {
+	called := false
+	stubDisk(t,
+		func() (cleanup.Plan, error) { called = true; return cleanup.Plan{}, nil },
+		func(p cleanup.Plan) (int, int64) { called = true; return 0, 0 },
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/disk", nil)
+	req.RemoteAddr = "192.168.1.50:5555"
+	rec := httptest.NewRecorder()
+	handleDisk(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status: got %d want 403", rec.Code)
+	}
+	if called {
+		t.Error("a non-loopback POST must never reach inspect/apply")
+	}
+}
+
+func TestDiskGetServesPreview(t *testing.T) {
+	stubDisk(t, func() (cleanup.Plan, error) {
+		return cleanup.Plan{Targets: []cleanup.Target{{ID: "x", Bytes: 7}}}, nil
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/disk", nil)
+	rec := httptest.NewRecorder()
+	handleDisk(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200", rec.Code)
+	}
+	var snap diskSnapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &snap); err != nil {
+		t.Fatal(err)
+	}
+	if !snap.Available || snap.ReclaimableBytes != 7 {
+		t.Errorf("snapshot: got %+v", snap)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -265,6 +265,7 @@ func Start(currentVersion string) error {
 	mux.HandleFunc("/api/workers/health", withCORS(handleWorkersHealth))
 	mux.HandleFunc("/api/workers/heal", withCORS(handleWorkersHeal))
 	mux.HandleFunc("/api/stats", withCORS(handleStats))
+	mux.HandleFunc("/api/disk", withCORS(handleDisk))
 	mux.HandleFunc("/api/xdebug/", withCORS(publishAfter(handleXdebugAction, eventbus.KindStatus)))
 	mux.HandleFunc("/api/lerd/start", withCORS(handleLerdStart))
 	mux.HandleFunc("/api/lerd/stop", withCORS(handleLerdStop))

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "\"{name}\" löschen?",
   "workspaces_deleteBody": "Der Arbeitsbereich wird entfernt. Seine Sites bleiben verknüpft und sind nicht mehr gruppiert.",
   "workspaces_deleteSiteCount": "Betroffene Sites: {count}",
-  "dashboard_sites_pausedCount": "{count} pausiert"
+  "dashboard_sites_pausedCount": "{count} pausiert",
+  "dashboard_disk_reclaimable": "Freigebbarer Speicher",
+  "dashboard_disk_cleanup": "Aufräumen",
+  "dashboard_disk_held": "{size} weitere von laufenden Containern belegt, werden beim Neustart frei",
+  "dashboard_disk_modalTitle": "Speicher freigeben",
+  "dashboard_disk_modalBody": "Diese Images können entfernt werden, um etwa {size} freizugeben:",
+  "dashboard_disk_modalDeepNote": "Diese gründliche Bereinigung entfernt auch ungetaggte, verwaiste Images anderer Podman-Workloads auf diesem Rechner. Benannte Datenvolumes werden nie angetastet.",
+  "dashboard_disk_modalConfirm": "Freigeben",
+  "dashboard_disk_cleaning": "Wird freigegeben…"
 }

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "Delete \"{name}\"?",
   "workspaces_deleteBody": "The workspace is removed. Its sites stay linked and become ungrouped.",
   "workspaces_deleteSiteCount": "Sites affected: {count}",
-  "dashboard_sites_pausedCount": "{count} paused"
+  "dashboard_sites_pausedCount": "{count} paused",
+  "dashboard_disk_reclaimable": "Reclaimable disk",
+  "dashboard_disk_cleanup": "Clean up",
+  "dashboard_disk_held": "{size} more held by running containers, freed on restart",
+  "dashboard_disk_modalTitle": "Reclaim disk",
+  "dashboard_disk_modalBody": "These images can be removed to free about {size}:",
+  "dashboard_disk_modalDeepNote": "This deep clean also removes dangling untagged images left by other podman workloads on this machine. It never touches named data volumes.",
+  "dashboard_disk_modalConfirm": "Reclaim",
+  "dashboard_disk_cleaning": "Reclaiming…"
 }

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "¿Eliminar \"{name}\"?",
   "workspaces_deleteBody": "Se elimina el espacio de trabajo. Sus sitios siguen vinculados y quedan sin agrupar.",
   "workspaces_deleteSiteCount": "Sitios afectados: {count}",
-  "dashboard_sites_pausedCount": "{count} pausados"
+  "dashboard_sites_pausedCount": "{count} pausados",
+  "dashboard_disk_reclaimable": "Disco recuperable",
+  "dashboard_disk_cleanup": "Limpiar",
+  "dashboard_disk_held": "{size} más retenidos por contenedores en ejecución, se liberan al reiniciar",
+  "dashboard_disk_modalTitle": "Recuperar disco",
+  "dashboard_disk_modalBody": "Estas imágenes se pueden eliminar para liberar unos {size}:",
+  "dashboard_disk_modalDeepNote": "Esta limpieza profunda también elimina imágenes colgantes sin etiqueta dejadas por otras cargas de trabajo de podman en esta máquina. Nunca toca los volúmenes de datos con nombre.",
+  "dashboard_disk_modalConfirm": "Recuperar",
+  "dashboard_disk_cleaning": "Recuperando…"
 }

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "Supprimer \"{name}\" ?",
   "workspaces_deleteBody": "L'espace de travail est supprimé. Ses sites restent liés et ne sont plus regroupés.",
   "workspaces_deleteSiteCount": "Sites concernés : {count}",
-  "dashboard_sites_pausedCount": "{count} en pause"
+  "dashboard_sites_pausedCount": "{count} en pause",
+  "dashboard_disk_reclaimable": "Disque récupérable",
+  "dashboard_disk_cleanup": "Nettoyer",
+  "dashboard_disk_held": "{size} de plus retenus par des conteneurs en cours d'exécution, libérés au redémarrage",
+  "dashboard_disk_modalTitle": "Récupérer de l'espace disque",
+  "dashboard_disk_modalBody": "Ces images peuvent être supprimées pour libérer environ {size} :",
+  "dashboard_disk_modalDeepNote": "Ce nettoyage profond supprime aussi les images sans étiquette laissées par d'autres charges de travail podman sur cette machine. Il ne touche jamais aux volumes de données nommés.",
+  "dashboard_disk_modalConfirm": "Récupérer",
+  "dashboard_disk_cleaning": "Récupération…"
 }

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "Hapus \"{name}\"?",
   "workspaces_deleteBody": "Ruang kerja dihapus. Situsnya tetap tertaut dan menjadi tidak dikelompokkan.",
   "workspaces_deleteSiteCount": "Situs yang terpengaruh: {count}",
-  "dashboard_sites_pausedCount": "{count} dijeda"
+  "dashboard_sites_pausedCount": "{count} dijeda",
+  "dashboard_disk_reclaimable": "Disk yang bisa direklamasi",
+  "dashboard_disk_cleanup": "Bersihkan",
+  "dashboard_disk_held": "{size} lagi ditahan oleh kontainer yang berjalan, dibebaskan saat mulai ulang",
+  "dashboard_disk_modalTitle": "Reklamasi disk",
+  "dashboard_disk_modalBody": "Image ini dapat dihapus untuk membebaskan sekitar {size}:",
+  "dashboard_disk_modalDeepNote": "Pembersihan mendalam ini juga menghapus image menggantung tanpa tag milik beban kerja podman lain di mesin ini. Volume data bernama tidak pernah disentuh.",
+  "dashboard_disk_modalConfirm": "Reklamasi",
+  "dashboard_disk_cleaning": "Mereklamasi…"
 }

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "Eliminare \"{name}\"?",
   "workspaces_deleteBody": "Lo spazio di lavoro viene rimosso. I suoi siti restano collegati e non sono più raggruppati.",
   "workspaces_deleteSiteCount": "Siti interessati: {count}",
-  "dashboard_sites_pausedCount": "{count} in pausa"
+  "dashboard_sites_pausedCount": "{count} in pausa",
+  "dashboard_disk_reclaimable": "Disco recuperabile",
+  "dashboard_disk_cleanup": "Pulisci",
+  "dashboard_disk_held": "{size} in più trattenuti dai container in esecuzione, liberati al riavvio",
+  "dashboard_disk_modalTitle": "Recupera spazio su disco",
+  "dashboard_disk_modalBody": "Queste immagini possono essere rimosse per liberare circa {size}:",
+  "dashboard_disk_modalDeepNote": "Questa pulizia profonda rimuove anche le immagini penzolanti senza tag lasciate da altri carichi di lavoro podman su questa macchina. Non tocca mai i volumi di dati denominati.",
+  "dashboard_disk_modalConfirm": "Recupera",
+  "dashboard_disk_cleaning": "Recupero in corso…"
 }

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "「{name}」を削除しますか？",
   "workspaces_deleteBody": "ワークスペースを削除します。サイトはリンクされたまま、グループ解除されます。",
   "workspaces_deleteSiteCount": "影響を受けるサイト: {count}",
-  "dashboard_sites_pausedCount": "{count} 個一時停止中"
+  "dashboard_sites_pausedCount": "{count} 個一時停止中",
+  "dashboard_disk_reclaimable": "回収可能なディスク",
+  "dashboard_disk_cleanup": "クリーンアップ",
+  "dashboard_disk_held": "実行中のコンテナがさらに {size} を保持しています。再起動で解放されます",
+  "dashboard_disk_modalTitle": "ディスクを回収",
+  "dashboard_disk_modalBody": "これらのイメージを削除すると約 {size} を解放できます:",
+  "dashboard_disk_modalDeepNote": "このディープクリーンは、このマシン上の他の podman ワークロードが残した未タグのダングリングイメージも削除します。名前付きデータボリュームには一切触れません。",
+  "dashboard_disk_modalConfirm": "回収",
+  "dashboard_disk_cleaning": "回収中…"
 }

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "\"{name}\" verwijderen?",
   "workspaces_deleteBody": "De werkruimte wordt verwijderd. De sites blijven gekoppeld en zijn niet langer gegroepeerd.",
   "workspaces_deleteSiteCount": "Betrokken sites: {count}",
-  "dashboard_sites_pausedCount": "{count} gepauzeerd"
+  "dashboard_sites_pausedCount": "{count} gepauzeerd",
+  "dashboard_disk_reclaimable": "Vrijmaakbare schijf",
+  "dashboard_disk_cleanup": "Opruimen",
+  "dashboard_disk_held": "{size} meer vastgehouden door draaiende containers, vrijgemaakt bij herstart",
+  "dashboard_disk_modalTitle": "Schijfruimte vrijmaken",
+  "dashboard_disk_modalBody": "Deze images kunnen worden verwijderd om ongeveer {size} vrij te maken:",
+  "dashboard_disk_modalDeepNote": "Deze grondige opschoning verwijdert ook ongetagde losse images van andere podman-workloads op deze machine. Benoemde datavolumes worden nooit aangeraakt.",
+  "dashboard_disk_modalConfirm": "Vrijmaken",
+  "dashboard_disk_cleaning": "Bezig met vrijmaken…"
 }

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "Usunąć „{name}”?",
   "workspaces_deleteBody": "Przestrzeń robocza zostanie usunięta. Jej witryny pozostaną połączone i nie będą pogrupowane.",
   "workspaces_deleteSiteCount": "Witryny, których to dotyczy: {count}",
-  "dashboard_sites_pausedCount": "{count} wstrzymane"
+  "dashboard_sites_pausedCount": "{count} wstrzymane",
+  "dashboard_disk_reclaimable": "Odzyskiwalny dysk",
+  "dashboard_disk_cleanup": "Wyczyść",
+  "dashboard_disk_held": "{size} więcej zajęte przez działające kontenery, zwalniane po restarcie",
+  "dashboard_disk_modalTitle": "Odzyskaj miejsce na dysku",
+  "dashboard_disk_modalBody": "Te obrazy można usunąć, aby zwolnić około {size}:",
+  "dashboard_disk_modalDeepNote": "To głębokie czyszczenie usuwa również nieoznaczone wiszące obrazy pozostawione przez inne zadania podman na tej maszynie. Nigdy nie narusza nazwanych woluminów danych.",
+  "dashboard_disk_modalConfirm": "Odzyskaj",
+  "dashboard_disk_cleaning": "Odzyskiwanie…"
 }

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "Excluir \"{name}\"?",
   "workspaces_deleteBody": "O espaço de trabalho é removido. Seus sites continuam vinculados e ficam sem agrupamento.",
   "workspaces_deleteSiteCount": "Sites afetados: {count}",
-  "dashboard_sites_pausedCount": "{count} pausados"
+  "dashboard_sites_pausedCount": "{count} pausados",
+  "dashboard_disk_reclaimable": "Disco recuperável",
+  "dashboard_disk_cleanup": "Limpar",
+  "dashboard_disk_held": "{size} a mais retidos por contêineres em execução, liberados ao reiniciar",
+  "dashboard_disk_modalTitle": "Recuperar disco",
+  "dashboard_disk_modalBody": "Estas imagens podem ser removidas para liberar cerca de {size}:",
+  "dashboard_disk_modalDeepNote": "Esta limpeza profunda também remove imagens pendentes sem tag deixadas por outras cargas de trabalho do podman nesta máquina. Nunca toca em volumes de dados nomeados.",
+  "dashboard_disk_modalConfirm": "Recuperar",
+  "dashboard_disk_cleaning": "Recuperando…"
 }

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "Ștergi „{name}”?",
   "workspaces_deleteBody": "Spațiul de lucru este eliminat. Site-urile rămân conectate și devin negrupate.",
   "workspaces_deleteSiteCount": "Site-uri afectate: {count}",
-  "dashboard_sites_pausedCount": "{count} întrerupte"
+  "dashboard_sites_pausedCount": "{count} întrerupte",
+  "dashboard_disk_reclaimable": "Disc recuperabil",
+  "dashboard_disk_cleanup": "Curăță",
+  "dashboard_disk_held": "încă {size} ocupați de containere active, eliberați la repornire",
+  "dashboard_disk_modalTitle": "Recuperează spațiu pe disc",
+  "dashboard_disk_modalBody": "Aceste imagini pot fi șterse pentru a elibera aproximativ {size}:",
+  "dashboard_disk_modalDeepNote": "Această curățare profundă șterge și imaginile fără etichetă rămase de la alte sarcini podman de pe această mașină. Nu atinge niciodată volumele de date denumite.",
+  "dashboard_disk_modalConfirm": "Recuperează",
+  "dashboard_disk_cleaning": "Se recuperează…"
 }

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "\"{name}\" silinsin mi?",
   "workspaces_deleteBody": "Çalışma alanı kaldırılır. Siteleri bağlı kalır ve gruplanmamış duruma geçer.",
   "workspaces_deleteSiteCount": "Etkilenen siteler: {count}",
-  "dashboard_sites_pausedCount": "{count} duraklatıldı"
+  "dashboard_sites_pausedCount": "{count} duraklatıldı",
+  "dashboard_disk_reclaimable": "Geri kazanılabilir disk",
+  "dashboard_disk_cleanup": "Temizle",
+  "dashboard_disk_held": "Çalışan kapsayıcılar {size} daha tutuyor, yeniden başlatınca boşalır",
+  "dashboard_disk_modalTitle": "Disk alanı geri kazan",
+  "dashboard_disk_modalBody": "Bu görüntüler yaklaşık {size} boşaltmak için kaldırılabilir:",
+  "dashboard_disk_modalDeepNote": "Bu derin temizlik, bu makinedeki diğer podman iş yüklerinden kalan etiketsiz sarkan görüntüleri de kaldırır. Adlandırılmış veri birimlerine asla dokunmaz.",
+  "dashboard_disk_modalConfirm": "Geri kazan",
+  "dashboard_disk_cleaning": "Geri kazanılıyor…"
 }

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "Xóa \"{name}\"?",
   "workspaces_deleteBody": "Không gian làm việc sẽ bị xóa. Các trang vẫn được liên kết và trở thành chưa nhóm.",
   "workspaces_deleteSiteCount": "Số trang bị ảnh hưởng: {count}",
-  "dashboard_sites_pausedCount": "{count} tạm dừng"
+  "dashboard_sites_pausedCount": "{count} tạm dừng",
+  "dashboard_disk_reclaimable": "Đĩa có thể thu hồi",
+  "dashboard_disk_cleanup": "Dọn dẹp",
+  "dashboard_disk_held": "{size} nữa đang bị các container đang chạy giữ, được giải phóng khi khởi động lại",
+  "dashboard_disk_modalTitle": "Thu hồi dung lượng đĩa",
+  "dashboard_disk_modalBody": "Có thể xóa các image này để giải phóng khoảng {size}:",
+  "dashboard_disk_modalDeepNote": "Việc dọn dẹp sâu này cũng xóa các image lơ lửng không gắn thẻ do các tải công việc podman khác trên máy này để lại. Nó không bao giờ đụng đến các volume dữ liệu có tên.",
+  "dashboard_disk_modalConfirm": "Thu hồi",
+  "dashboard_disk_cleaning": "Đang thu hồi…"
 }

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -1055,5 +1055,13 @@
   "workspaces_deleteTitle": "删除“{name}”？",
   "workspaces_deleteBody": "工作区将被移除。其中的站点仍保持链接，只是不再分组。",
   "workspaces_deleteSiteCount": "受影响的站点：{count}",
-  "dashboard_sites_pausedCount": "{count} 个已暂停"
+  "dashboard_sites_pausedCount": "{count} 个已暂停",
+  "dashboard_disk_reclaimable": "可回收磁盘",
+  "dashboard_disk_cleanup": "清理",
+  "dashboard_disk_held": "运行中的容器还占用 {size}，重启后释放",
+  "dashboard_disk_modalTitle": "回收磁盘空间",
+  "dashboard_disk_modalBody": "删除这些镜像可释放约 {size}：",
+  "dashboard_disk_modalDeepNote": "此深度清理还会删除本机上其他 podman 工作负载遗留的未标记悬空镜像。它绝不会触及命名数据卷。",
+  "dashboard_disk_modalConfirm": "回收",
+  "dashboard_disk_cleaning": "正在回收…"
 }

--- a/internal/ui/web/src/stores/disk.test.ts
+++ b/internal/ui/web/src/stores/disk.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('disk store', () => {
+  const realFetch = globalThis.fetch;
+  let calls: { url: string; method: string }[];
+
+  beforeEach(() => {
+    vi.resetModules();
+    calls = [];
+    globalThis.fetch = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, method: (init?.method ?? 'GET').toUpperCase() });
+      const body =
+        (init?.method ?? 'GET').toUpperCase() === 'POST'
+          ? { ok: true, removed: 3, reclaimed_bytes: 4096 }
+          : { available: true, reclaimable_bytes: 512, images: [], held_bytes: 0, held_count: 0 };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('loadDisk fetches the preview and marks it loaded', async () => {
+    const { loadDisk, disk, diskLoaded, get } = await importDisk();
+    await loadDisk();
+    expect(calls[0].url).toContain('/api/disk');
+    expect(calls[0].method).toBe('GET');
+    expect(get(disk).reclaimable_bytes).toBe(512);
+    expect(get(diskLoaded)).toBe(true);
+  });
+
+  it('runCleanup POSTs, reports freed space, then refreshes the preview', async () => {
+    const { runCleanup } = await importDisk();
+    const res = await runCleanup();
+    expect(res.ok).toBe(true);
+    expect(res.removed).toBe(3);
+    expect(res.reclaimedBytes).toBe(4096);
+    // A POST to reclaim, then a follow-up GET to refresh the snapshot.
+    expect(calls[0].method).toBe('POST');
+    expect(calls[1].method).toBe('GET');
+  });
+});
+
+async function importDisk() {
+  const mod = await import('./disk');
+  const { get } = await import('svelte/store');
+  return { ...mod, get };
+}

--- a/internal/ui/web/src/stores/disk.ts
+++ b/internal/ui/web/src/stores/disk.ts
@@ -1,0 +1,116 @@
+import { writable } from 'svelte/store';
+import { apiJson, apiFetch } from '$lib/api';
+
+export interface DiskImage {
+  id: string;
+  desc: string;
+  bytes: number;
+}
+
+export interface DiskSnapshot {
+  available: boolean;
+  reclaimable_bytes: number;
+  images: DiskImage[];
+  held_bytes: number;
+  held_count: number;
+}
+
+const empty: DiskSnapshot = {
+  available: false,
+  reclaimable_bytes: 0,
+  images: [],
+  held_bytes: 0,
+  held_count: 0
+};
+
+export const disk = writable<DiskSnapshot>(empty);
+export const diskLoaded = writable<boolean>(false);
+
+// Reclaimable disk comes from a full podman image scan, far heavier than the
+// per-container stats poll, so it refreshes on its own slower cadence.
+const POLL_INTERVAL_MS = 30000;
+
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let inflight = false;
+
+export async function loadDisk(): Promise<void> {
+  if (inflight) return;
+  inflight = true;
+  try {
+    const res = await apiJson<DiskSnapshot>('/api/disk');
+    disk.set({ ...empty, ...res });
+    diskLoaded.set(true);
+  } catch {
+    /* keep previous */
+  } finally {
+    inflight = false;
+  }
+}
+
+// startDiskPolling mirrors the stats loop: an immediate fetch, then a slow poll
+// gated by the Page Visibility API so a backgrounded tab stops scanning images.
+export function startDiskPolling(): () => void {
+  let stopped = false;
+  function tick() {
+    if (stopped) return;
+    if (typeof document !== 'undefined' && document.hidden) return;
+    void loadDisk();
+  }
+  tick();
+  pollTimer = setInterval(tick, POLL_INTERVAL_MS);
+
+  const onVisibility = () => {
+    if (typeof document === 'undefined') return;
+    if (!document.hidden) tick();
+  };
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', onVisibility);
+  }
+
+  return () => {
+    stopped = true;
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', onVisibility);
+    }
+  };
+}
+
+export interface CleanupResult {
+  ok: boolean;
+  removed: number;
+  reclaimedBytes: number;
+  error?: string;
+}
+
+// runCleanup reclaims the reclaimable disk. The daemon re-inspects and applies
+// its own fresh plan, so the client never sends a target list. A successful run
+// refreshes the snapshot so the widget reflects the freed space at once.
+export async function runCleanup(): Promise<CleanupResult> {
+  try {
+    const res = await apiFetch('/api/disk', { method: 'POST' });
+    const data = (await res.json()) as {
+      ok?: boolean;
+      removed?: number;
+      reclaimed_bytes?: number;
+      error?: string;
+    };
+    if (data.ok) await loadDisk();
+    return {
+      ok: Boolean(data.ok),
+      removed: data.removed ?? 0,
+      reclaimedBytes: data.reclaimed_bytes ?? 0,
+      error: data.error
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      removed: 0,
+      reclaimedBytes: 0,
+      error: e instanceof Error ? e.message : 'Request failed'
+    };
+  }
+}

--- a/internal/ui/web/src/tabs/dashboard/CleanupModal.svelte
+++ b/internal/ui/web/src/tabs/dashboard/CleanupModal.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import Modal from '$components/Modal.svelte';
+  import DetailButton from '$components/DetailButton.svelte';
+  import { formatBytes } from '$stores/stats';
+  import type { DiskImage } from '$stores/disk';
+  import { m } from '../../paraglide/messages.js';
+
+  interface Props {
+    open: boolean;
+    images: DiskImage[];
+    reclaimableBytes: number;
+    loading?: boolean;
+    error?: string;
+    onconfirm: () => void;
+    onclose: () => void;
+  }
+  let { open, images, reclaimableBytes, loading = false, error, onconfirm, onclose }: Props =
+    $props();
+</script>
+
+<Modal {open} title={m.dashboard_disk_modalTitle()} onclose={onclose} size="md">
+  <div class="px-5 py-4 space-y-3">
+    <p class="text-sm text-gray-700 dark:text-gray-300">
+      {m.dashboard_disk_modalBody({ size: formatBytes(reclaimableBytes) })}
+    </p>
+
+    {#if images.length > 0}
+      <div class="rounded-lg border border-gray-200 dark:border-lerd-border divide-y divide-gray-100 dark:divide-lerd-border max-h-56 overflow-y-auto">
+        {#each images as img (img.id)}
+          <div class="flex items-center gap-2 px-3 py-1.5 text-xs">
+            <span class="flex-1 truncate text-gray-600 dark:text-gray-300">{img.desc}</span>
+            <span class="shrink-0 font-mono tabular-nums text-gray-500 dark:text-gray-400">{formatBytes(img.bytes)}</span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    <p class="text-xs text-gray-500 dark:text-gray-400">{m.dashboard_disk_modalDeepNote()}</p>
+
+    {#if error}
+      <p class="text-xs text-red-600 dark:text-red-400">{error}</p>
+    {/if}
+  </div>
+
+  {#snippet footer()}
+    <DetailButton onclick={onclose} disabled={loading}>{m.common_cancel()}</DetailButton>
+    <DetailButton tone="danger" onclick={onconfirm} loading={loading} disabled={loading}>
+      {loading ? m.dashboard_disk_cleaning() : m.dashboard_disk_modalConfirm()}
+    </DetailButton>
+  {/snippet}
+</Modal>

--- a/internal/ui/web/src/tabs/dashboard/ResourcesWidget.svelte
+++ b/internal/ui/web/src/tabs/dashboard/ResourcesWidget.svelte
@@ -1,17 +1,43 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import DashboardCard from './DashboardCard.svelte';
+  import DetailButton from '$components/DetailButton.svelte';
+  import CleanupModal from './CleanupModal.svelte';
   import { stats, statsLoaded, startStatsPolling, formatBytes } from '$stores/stats';
-  import { serviceLabel } from '$stores/services';
+  import { disk, startDiskPolling, runCleanup } from '$stores/disk';
   import { m } from '../../paraglide/messages.js';
 
   let stop: (() => void) | null = null;
+  let stopDisk: (() => void) | null = null;
   onMount(() => {
     stop = startStatsPolling();
+    stopDisk = startDiskPolling();
   });
   onDestroy(() => {
     if (stop) stop();
+    if (stopDisk) stopDisk();
   });
+
+  let modalOpen = $state(false);
+  let cleaning = $state(false);
+  let cleanupError = $state<string | undefined>(undefined);
+
+  function openModal() {
+    cleanupError = undefined;
+    modalOpen = true;
+  }
+
+  async function doCleanup() {
+    cleaning = true;
+    cleanupError = undefined;
+    const res = await runCleanup();
+    cleaning = false;
+    if (res.ok) {
+      modalOpen = false;
+    } else {
+      cleanupError = res.error ?? 'Cleanup failed';
+    }
+  }
 
   const rows = $derived($stats.containers);
   const memPercentOfHost = $derived(
@@ -58,6 +84,23 @@
       </div>
     </div>
 
+    {#if $disk.available && $disk.reclaimable_bytes > 0}
+      <div class="pt-2 mt-2 border-t border-gray-100 dark:border-lerd-border">
+        <div class="flex items-center justify-between gap-2">
+          <div>
+            <div class="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500">{m.dashboard_disk_reclaimable()}</div>
+            <div class="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">{formatBytes($disk.reclaimable_bytes)}</div>
+          </div>
+          <DetailButton tone="warn" onclick={openModal}>{m.dashboard_disk_cleanup()}</DetailButton>
+        </div>
+        {#if $disk.held_bytes > 0}
+          <div class="text-[10px] text-gray-400 dark:text-gray-500 mt-1">
+            {m.dashboard_disk_held({ size: formatBytes($disk.held_bytes) })}
+          </div>
+        {/if}
+      </div>
+    {/if}
+
     {#if rows.length > 0}
       <div class="pt-2 border-t border-gray-100 dark:border-lerd-border space-y-1">
         <div class="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide">{m.dashboard_resources_top()}</div>
@@ -74,3 +117,15 @@
     {/if}
   {/if}
 </DashboardCard>
+
+<CleanupModal
+  open={modalOpen}
+  images={$disk.images}
+  reclaimableBytes={$disk.reclaimable_bytes}
+  loading={cleaning}
+  error={cleanupError}
+  onconfirm={doCleanup}
+  onclose={() => {
+    if (!cleaning) modalOpen = false;
+  }}
+/>


### PR DESCRIPTION
The dashboard resources widget shows live CPU and memory but says nothing about disk, which is the resource that actually grows unbounded on a long-lived install. This adds the reclaimable total next to CPU and memory and lets you act on it without dropping to a terminal.

Clicking Clean up opens a confirmation modal that lists the images that would be removed and the space that would come back, mirroring the preview lerd cleanup prints, and confirming runs the deep reclaim. Deep scope matches the interactive CLI default, so it can also reap dangling untagged images belonging to other podman workloads on the machine, which is exactly why it sits behind a modal that names what it will remove rather than firing on one click. The reclaimable figure comes from a full podman image scan, so it fetches on its own slower cadence rather than riding the per-container stats poll, and the apply path re-inspects the host server-side instead of trusting the target list the client posts back.

This supersedes the note in the cleanup docs that the command is CLI-only by design. Cleanup only ever reclaims images and never touches named data volumes, and the watcher already runs it unattended every day, so it does not belong in the same class as migrate, remove, or reinstall, which stay CLI-only. The TUI scope rule is unaffected.

Closes #814