### PR TITLE
fix(watcher): wait for the idle engine's background work

### DIFF
--- a/internal/cli/bug_report_test.go
+++ b/internal/cli/bug_report_test.go
@@ -77,6 +77,11 @@ func TestWriteBugReportHeader_includesVersionAndOS(t *testing.T) {
 }
 
 func TestWriteBugReport_createsFile(t *testing.T) {
+	// The report gathers state through the real config paths, and its update check
+	// caches to the data dir, so without this it writes the developer's own.
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
 	dir := t.TempDir()
 	target := filepath.Join(dir, "report.txt")
 	got, err := writeBugReport(target, 5, false)
@@ -98,6 +103,9 @@ func TestWriteBugReport_createsFile(t *testing.T) {
 }
 
 func TestWriteBugReport_defaultPath(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
 	dir := t.TempDir()
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -482,6 +482,7 @@ func MaterializeServiceFilesChanged(svc *CustomService) (bool, error) {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 			return changed, fmt.Errorf("removing stale %s for service %s: %w", path, svc.Name, err)
 		}
+		guardRealWrite(path)
 		if err := os.WriteFile(path, []byte(content), mode); err != nil {
 			return changed, fmt.Errorf("writing %s for service %s: %w", path, svc.Name, err)
 		}
@@ -545,6 +546,7 @@ func LoadCustomServiceFromFile(path string) (*CustomService, error) {
 	if len(svc.Files) > 0 {
 		svc.Files = nil
 		if migrated, err := yaml.Marshal(&svc); err == nil {
+			guardRealWrite(path)
 			_ = os.WriteFile(path, migrated, 0644)
 		}
 	}
@@ -610,6 +612,7 @@ func SaveCustomService(svc *CustomService) error {
 		return err
 	}
 	path := filepath.Join(dir, svc.Name+".yaml")
+	guardRealWrite(path)
 	return os.WriteFile(path, data, 0644)
 }
 

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -1037,6 +1037,7 @@ func SaveGlobal(cfg *GlobalConfig) error {
 	if err != nil {
 		return err
 	}
+	guardRealWrite(GlobalConfigFile())
 	if err := os.WriteFile(GlobalConfigFile(), data, 0644); err != nil {
 		return err
 	}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -522,6 +522,7 @@ func MarkStopped() error {
 	if err := os.MkdirAll(RunDir(), 0755); err != nil {
 		return err
 	}
+	guardRealWrite(stoppedMarkerPath())
 	return os.WriteFile(stoppedMarkerPath(), []byte("stopped\n"), 0644)
 }
 

--- a/internal/config/preset_source.go
+++ b/internal/config/preset_source.go
@@ -137,6 +137,7 @@ func SaveStorePreset(name string, data []byte) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
+	guardRealWrite(filepath.Join(dir, name+".yaml"))
 	if err := os.WriteFile(filepath.Join(dir, name+".yaml"), data, 0o644); err != nil {
 		return err
 	}

--- a/internal/config/profiler.go
+++ b/internal/config/profiler.go
@@ -31,6 +31,7 @@ func LoadOrGenerateProfilerKey() (string, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return "", err
 	}
+	guardRealWrite(path)
 	if err := os.WriteFile(path, []byte(key+"\n"), 0600); err != nil {
 		return "", fmt.Errorf("writing profiler key: %w", err)
 	}

--- a/internal/config/service_set.go
+++ b/internal/config/service_set.go
@@ -42,6 +42,7 @@ func saveServiceNameSet(path string, m map[string]bool) error {
 	if err != nil {
 		return err
 	}
+	guardRealWrite(path)
 	return os.WriteFile(path, data, 0644)
 }
 

--- a/internal/config/service_tuning.go
+++ b/internal/config/service_tuning.go
@@ -296,6 +296,7 @@ func MaterializeServiceTuning(svc *CustomService) error {
 
 	// Helper file: lerd-managed, always rewritten (not user-editable).
 	if m.AuxTarget != "" {
+		guardRealWrite(ServiceTuningAuxFile(svc.Name))
 		if err := os.WriteFile(ServiceTuningAuxFile(svc.Name), []byte(m.AuxContent), 0644); err != nil {
 			return err
 		}
@@ -308,6 +309,7 @@ func MaterializeServiceTuning(svc *CustomService) error {
 	} else if !os.IsNotExist(err) {
 		return err
 	}
+	guardRealWrite(path)
 	return os.WriteFile(path, []byte(m.Template), 0644)
 }
 

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -399,6 +399,7 @@ func SaveSites(reg *SiteRegistry) error {
 // complete file and the last full write wins. A unique temp name (rather than a
 // fixed path.tmp) keeps two concurrent writers from clobbering each other's temp.
 func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	guardRealWrite(path)
 	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
 	if err != nil {
 		return err

--- a/internal/config/testguard.go
+++ b/internal/config/testguard.go
@@ -63,3 +63,7 @@ func resolveLinks(path string) string {
 	}
 	return path
 }
+
+// UnderTest reports whether this process is a test binary, for packages that must
+// refuse to touch the real system (systemd, podman) when no stub is installed.
+func UnderTest() bool { return underTest }

--- a/internal/config/testguard.go
+++ b/internal/config/testguard.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// realStateDirs are the lerd dirs of whoever is running the process, resolved once
+// at start. XDG_DATA_HOME and XDG_CONFIG_HOME decide them and a test moves those,
+// so resolving later can't tell a test's temp dir from the developer's own. The
+// unit dirs are here too: the bug that started this wrote a real systemd unit.
+var realStateDirs = []string{DataDir(), ConfigDir(), SystemdUserDir(), QuadletDir()}
+
+// underTest reports whether this process is a test binary, read from the command
+// line rather than testing.Testing() so the std testing package stays out of the
+// shipped lerd binary.
+var underTest = func() bool {
+	if strings.HasSuffix(os.Args[0], ".test") || strings.Contains(os.Args[0], "/_test/") {
+		return true
+	}
+	for _, a := range os.Args[1:] {
+		if strings.HasPrefix(a, "-test.") {
+			return true
+		}
+	}
+	return false
+}()
+
+// GuardRealWrite is guardRealWrite for writers in other packages.
+func GuardRealWrite(path string) { guardRealWrite(path) }
+
+// guardRealWrite stops a test writing the state of the developer running it. A
+// test that never isolated XDG_DATA_HOME has emptied a real sites.yaml, so make
+// that a loud failure at the write rather than silent data loss.
+func guardRealWrite(path string) {
+	if !underTest {
+		return
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return
+	}
+	abs = resolveLinks(abs)
+	for _, real := range realStateDirs {
+		if real == "" {
+			continue
+		}
+		real = resolveLinks(real)
+		if abs == real || strings.HasPrefix(abs, real+string(os.PathSeparator)) {
+			panic(fmt.Sprintf("test wrote to the real lerd state at %s: isolate it with "+
+				`t.Setenv("XDG_DATA_HOME", t.TempDir())`+" and "+`t.Setenv("XDG_CONFIG_HOME", t.TempDir())`, abs))
+		}
+	}
+}
+
+// resolveLinks canonicalises what exists of path, so a symlinked state dir can't
+// slip past the prefix comparison.
+func resolveLinks(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
+}

--- a/internal/config/testguard_test.go
+++ b/internal/config/testguard_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The guard is what stands between a forgetful test and the developer's own lerd
+// state, so pin both halves: it fires on a write into the real dirs, and stays out
+// of the way of an isolated one.
+func TestGuardRealWrite(t *testing.T) {
+	if len(realStateDirs) == 0 || realStateDirs[0] == "" {
+		t.Skip("no resolvable state dirs in this environment")
+	}
+
+	t.Run("panics on a write into the real state dir", func(t *testing.T) {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("writing the real sites.yaml from a test must panic, not silently land")
+			}
+			if msg, _ := r.(string); !strings.Contains(msg, "real lerd state") {
+				t.Errorf("panic should name the problem, got %v", r)
+			}
+		}()
+		guardRealWrite(filepath.Join(realStateDirs[0], "sites.yaml"))
+	})
+
+	t.Run("allows an isolated write", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("an isolated temp dir must not trip the guard, got %v", r)
+			}
+		}()
+		guardRealWrite(filepath.Join(t.TempDir(), "lerd", "sites.yaml"))
+	})
+}
+
+// The dirs are captured at process start, because a test relocates XDG_DATA_HOME
+// and a guard that re-resolved them afterwards would compare a temp dir with
+// itself and never fire.
+func TestGuardRealWrite_ignoresRelocatedXDG(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("relocating XDG mid-test must not disarm the guard")
+		}
+	}()
+	guardRealWrite(filepath.Join(realStateDirs[0], "sites.yaml"))
+}

--- a/internal/config/worktree_db_registry.go
+++ b/internal/config/worktree_db_registry.go
@@ -58,12 +58,14 @@ func saveWorktreeDBRegistryLocked(entries []WorktreeDBEntry) error {
 		return err
 	}
 	if len(entries) == 0 {
+		guardRealWrite(path)
 		return os.WriteFile(path, []byte("worktree_dbs: []\n"), 0644)
 	}
 	data, err := yaml.Marshal(worktreeDBRegistry{Entries: entries})
 	if err != nil {
 		return err
 	}
+	guardRealWrite(path)
 	return os.WriteFile(path, data, 0644)
 }
 

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -293,6 +293,7 @@ func GenerateVhost(site config.Site, phpVersion string) error {
 		return err
 	}
 	confPath := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
+	config.GuardRealWrite(confPath)
 	return os.WriteFile(confPath, buf.Bytes(), 0644)
 }
 
@@ -340,6 +341,7 @@ func GenerateSSLVhost(site config.Site, phpVersion string) error {
 		return err
 	}
 	confPath := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
+	config.GuardRealWrite(confPath)
 	return os.WriteFile(confPath, buf.Bytes(), 0644)
 }
 
@@ -372,6 +374,7 @@ func GenerateFrankenPHPVhost(site config.Site) error {
 		return err
 	}
 	confPath := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
+	config.GuardRealWrite(confPath)
 	return os.WriteFile(confPath, buf.Bytes(), 0644)
 }
 
@@ -403,6 +406,7 @@ func GenerateFrankenPHPSSLVhost(site config.Site) error {
 		return err
 	}
 	confPath := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
+	config.GuardRealWrite(confPath)
 	return os.WriteFile(confPath, buf.Bytes(), 0644)
 }
 
@@ -438,6 +442,7 @@ func GenerateCustomVhost(site config.Site) error {
 		return err
 	}
 	confPath := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
+	config.GuardRealWrite(confPath)
 	return os.WriteFile(confPath, buf.Bytes(), 0644)
 }
 
@@ -473,6 +478,7 @@ func GenerateCustomSSLVhost(site config.Site) error {
 		return err
 	}
 	confPath := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+"-ssl.conf")
+	config.GuardRealWrite(confPath)
 	return os.WriteFile(confPath, buf.Bytes(), 0644)
 }
 
@@ -533,6 +539,7 @@ func generateHostProxyVhost(site config.Site, tmplName, confName string, ssl boo
 		return err
 	}
 	confPath := filepath.Join(config.NginxConfD(), confName)
+	config.GuardRealWrite(confPath)
 	return os.WriteFile(confPath, buf.Bytes(), 0644)
 }
 
@@ -595,6 +602,7 @@ func GenerateWorktreeVhost(domain, path, phpVersion, siteName, branch string) er
 		return err
 	}
 	confPath := filepath.Join(config.NginxConfD(), domain+".conf")
+	config.GuardRealWrite(confPath)
 	return os.WriteFile(confPath, buf.Bytes(), 0644)
 }
 
@@ -635,6 +643,7 @@ func GenerateWorktreeSSLVhost(domain, path, phpVersion, parentDomain, siteName, 
 		return err
 	}
 	confPath := filepath.Join(config.NginxConfD(), domain+".conf")
+	config.GuardRealWrite(confPath)
 	return os.WriteFile(confPath, buf.Bytes(), 0644)
 }
 
@@ -673,6 +682,7 @@ func GenerateWorktreeHostProxyVhostFor(domain, path, parentDomain string, upstre
 	if err := os.MkdirAll(config.NginxConfD(), 0755); err != nil {
 		return err
 	}
+	config.GuardRealWrite(filepath.Join(config.NginxConfD(), domain+".conf"))
 	return os.WriteFile(filepath.Join(config.NginxConfD(), domain+".conf"), buf.Bytes(), 0644)
 }
 
@@ -726,6 +736,7 @@ func writeLandingVhost(site config.Site, htmlFile string) error {
 	}
 	conf := landingVhostConf(site, config.PausedDir(), htmlFile)
 	confPath := filepath.Join(config.NginxConfD(), site.PrimaryDomain()+".conf")
+	config.GuardRealWrite(confPath)
 	if err := os.WriteFile(confPath, []byte(conf), 0644); err != nil {
 		return err
 	}
@@ -794,6 +805,7 @@ server {
 	}
 
 	confPath := filepath.Join(config.NginxConfD(), domain+".conf")
+	config.GuardRealWrite(confPath)
 	return os.WriteFile(confPath, []byte(conf), 0644)
 }
 
@@ -845,6 +857,7 @@ func GenerateProxyVhost(domain, upstreamHost string, upstreamPort int) error {
 		return err
 	}
 	confPath := filepath.Join(config.NginxConfD(), domain+".conf")
+	config.GuardRealWrite(confPath)
 	return os.WriteFile(confPath, buf.Bytes(), 0644)
 }
 
@@ -1134,6 +1147,7 @@ func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
 		effective = info.Mode().Perm()
 	}
 	tmp := path + ".tmp"
+	config.GuardRealWrite(tmp)
 	if err := os.WriteFile(tmp, data, effective); err != nil {
 		return err
 	}
@@ -1287,6 +1301,7 @@ func writeErrorPages() error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
+	config.GuardRealWrite(filepath.Join(dir, "404.html"))
 	return os.WriteFile(filepath.Join(dir, "404.html"), []byte(errorPageHTML), 0644)
 }
 
@@ -1429,6 +1444,7 @@ func EnsureLerdVhost() error {
 }
 `, config.UISocketPath())
 	}
+	config.GuardRealWrite(filepath.Join(config.NginxConfD(), "lerd.localhost.conf"))
 	return os.WriteFile(filepath.Join(config.NginxConfD(), "lerd.localhost.conf"), []byte(content), 0644)
 }
 
@@ -1467,6 +1483,7 @@ func EnsureNginxConfig() error {
 	}); err != nil {
 		return fmt.Errorf("rendering nginx.conf: %w", err)
 	}
+	config.GuardRealWrite(destPath)
 	return os.WriteFile(destPath, buf.Bytes(), 0644)
 }
 
@@ -1506,6 +1523,7 @@ func EnsureForwardedConf() error {
 		return err
 	}
 	content := forwardedConf + spxKeyMap(key)
+	config.GuardRealWrite(filepath.Join(config.NginxConfD(), "_forwarded.conf"))
 	return os.WriteFile(
 		filepath.Join(config.NginxConfD(), "_forwarded.conf"),
 		[]byte(content),
@@ -1552,6 +1570,7 @@ func EnsureProfilerVhost() error {
     }
 }
 `, phpShort(cfg.PHP.DefaultVersion))
+	config.GuardRealWrite(filepath.Join(config.NginxConfD(), "_profiler.conf"))
 	return os.WriteFile(filepath.Join(config.NginxConfD(), "_profiler.conf"), []byte(content), 0644)
 }
 

--- a/internal/nginx/trust_token.go
+++ b/internal/nginx/trust_token.go
@@ -75,6 +75,7 @@ func LoadOrGenerateTrustToken() (string, error) {
 	if err := os.MkdirAll(config.DataDir(), 0o755); err != nil {
 		return "", err
 	}
+	config.GuardRealWrite(path)
 	if err := os.WriteFile(path, []byte(token+"\n"), 0o600); err != nil {
 		return "", fmt.Errorf("writing trust token: %w", err)
 	}

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -2,6 +2,7 @@ package podman
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -242,8 +243,19 @@ func unitOpCaller() string {
 	}
 }
 
+// errNoRealSystemd is what the unit lifecycle returns when a test drives it with
+// no stub installed. Falling through to the real user bus would start, stop and
+// enable units on the machine running the suite, which it has already done once.
+var errNoRealSystemd = errors.New("podman: refusing the real systemd from a test; set podman.UnitLifecycle")
+
+// realSystemdBlocked reports whether this call must not reach the real user bus.
+func realSystemdBlocked() bool { return UnitLifecycle == nil && config.UnderTest() }
+
 func StartUnit(name string) error {
 	logUnitOp("start", name)
+	if realSystemdBlocked() {
+		return errNoRealSystemd
+	}
 	if UnitLifecycle != nil {
 		err := UnitLifecycle.Start(name)
 		if err == nil {
@@ -261,6 +273,9 @@ func StartUnit(name string) error {
 // StopUnit stops a service unit.
 func StopUnit(name string) error {
 	logUnitOp("stop", name)
+	if realSystemdBlocked() {
+		return errNoRealSystemd
+	}
 	if UnitLifecycle != nil {
 		err := UnitLifecycle.Stop(name)
 		if err == nil {
@@ -281,7 +296,7 @@ func StopUnit(name string) error {
 // DBusStartUnit does. On macOS launchd has no separate failed state (the
 // bootstrap path replaces the job), so this is a no-op. Best-effort.
 func ResetFailedUnit(name string) {
-	if UnitLifecycle != nil {
+	if UnitLifecycle != nil || realSystemdBlocked() {
 		return
 	}
 	_ = systemd.DBusResetFailed(name)
@@ -290,6 +305,9 @@ func ResetFailedUnit(name string) {
 // RestartUnit restarts a service unit.
 func RestartUnit(name string) error {
 	logUnitOp("restart", name)
+	if realSystemdBlocked() {
+		return errNoRealSystemd
+	}
 	if UnitLifecycle != nil {
 		err := UnitLifecycle.Restart(name)
 		if err == nil {

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -90,6 +90,7 @@ func WriteQuadletDiff(name, content string) (changed bool, err error) {
 		fileChanged = false
 	}
 	if fileChanged {
+		config.GuardRealWrite(path)
 		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 			return false, err
 		}

--- a/internal/podman/testguard_test.go
+++ b/internal/podman/testguard_test.go
@@ -1,0 +1,55 @@
+package podman
+
+import (
+	"errors"
+	"testing"
+)
+
+// A test that drives the unit lifecycle without installing a stub used to fall
+// through to the real user bus and start, stop and enable units on the machine
+// running the suite. That is how a crash-looping lerd-queue unit ended up on a
+// developer's machine. It must refuse instead.
+func TestUnitLifecycle_refusesRealSystemdUnderTest(t *testing.T) {
+	prev := UnitLifecycle
+	UnitLifecycle = nil
+	t.Cleanup(func() { UnitLifecycle = prev })
+
+	for _, tc := range []struct {
+		name string
+		call func(string) error
+	}{
+		{"start", StartUnit},
+		{"stop", StopUnit},
+		{"restart", RestartUnit},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.call("lerd-queue-myapp"); !errors.Is(err, errNoRealSystemd) {
+				t.Errorf("%s reached the real systemd from a test (err = %v)", tc.name, err)
+			}
+		})
+	}
+}
+
+// With a stub installed the lifecycle still works, so the refusal only covers the
+// unstubbed path and doesn't disarm the tests that do drive it.
+func TestUnitLifecycle_stubStillDrivesTheLifecycle(t *testing.T) {
+	stub := &recordingLifecycle{}
+	prev := UnitLifecycle
+	UnitLifecycle = stub
+	t.Cleanup(func() { UnitLifecycle = prev })
+
+	if err := StartUnit("lerd-queue-myapp"); err != nil {
+		t.Fatalf("start with a stub: %v", err)
+	}
+	if stub.started != "lerd-queue-myapp" {
+		t.Errorf("stub should have seen the start, got %q", stub.started)
+	}
+}
+
+type recordingLifecycle struct{ started string }
+
+func (r *recordingLifecycle) Start(name string) error           { r.started = name; return nil }
+func (r *recordingLifecycle) Stop(string) error                 { return nil }
+func (r *recordingLifecycle) Restart(string) error              { return nil }
+func (r *recordingLifecycle) UnitStatus(string) (string, error) { return "inactive", nil }
+func (r *recordingLifecycle) AllUnitStates() map[string]string  { return nil }

--- a/internal/systemd/user.go
+++ b/internal/systemd/user.go
@@ -17,6 +17,7 @@ func WriteService(name, content string) error {
 		return err
 	}
 	path := filepath.Join(dir, name+".service")
+	config.GuardRealWrite(path)
 	return os.WriteFile(path, []byte(content), 0644)
 }
 
@@ -32,6 +33,7 @@ func WriteServiceIfChanged(name, content string) (bool, error) {
 	if existing, err := os.ReadFile(path); err == nil && string(existing) == content {
 		return false, nil
 	}
+	config.GuardRealWrite(path)
 	return true, os.WriteFile(path, []byte(content), 0644)
 }
 
@@ -47,6 +49,7 @@ func WriteTimerIfChanged(name, content string) (bool, error) {
 	if existing, err := os.ReadFile(path); err == nil && string(existing) == content {
 		return false, nil
 	}
+	config.GuardRealWrite(path)
 	return true, os.WriteFile(path, []byte(content), 0644)
 }
 

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"os/exec"
 	"strings"
@@ -63,6 +64,9 @@ func containerForSite(s *siteinfo.EnrichedSite) string {
 // This avoids drifting when ensureQuadlet / dependency logic moves around.
 func runLerd(dir string, args ...string) tea.Cmd {
 	return func() tea.Msg {
+		if !subprocessesAllowed {
+			return ActionResult{Summary: "lerd " + strings.Join(args, " "), Err: errNoSubprocess}
+		}
 		self, err := os.Executable()
 		if err != nil {
 			self = "lerd"
@@ -82,3 +86,11 @@ func runLerd(dir string, args ...string) tea.Cmd {
 		}
 	}
 }
+
+// subprocessesAllowed gates the TUI's two self-exec paths. The test harness turns
+// it off: under test os.Executable() is the test binary, so shelling out to it
+// re-runs the package's own tests against the developer's real environment.
+var subprocessesAllowed = true
+
+// errNoSubprocess is what an action reports when self-exec is off.
+var errNoSubprocess = errors.New("lerd subprocess not run under test")

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -76,21 +77,40 @@ func runBatchUntil[T any](t *testing.T, cmd tea.Cmd, d time.Duration) *T {
 	if cmd == nil {
 		return nil
 	}
-	out := make(chan tea.Msg, 8)
+	// A command runs the real TUI load path, which touches the site registry, so
+	// don't return while the rest of the batch is still in it. The wait is bounded:
+	// some commands (busCmd) park until a cleanup registered before this one closes
+	// their channel, and cleanups run last-registered-first, so an unbounded wait
+	// here would hang the package instead of failing a test.
+	var wg sync.WaitGroup
+	t.Cleanup(func() { waitBounded(&wg, 5*time.Second) })
+
+	out := make(chan tea.Msg, 64)
+	send := func(m tea.Msg) { // never block a goroutine nobody is reading any more
+		select {
+		case out <- m:
+		default:
+		}
+	}
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		msg := cmd()
 		if msg == nil {
-			out <- nil
+			send(nil)
 			return
 		}
 		switch v := msg.(type) {
 		case tea.BatchMsg:
 			for _, c := range v {
-				c := c
-				go func() { out <- c() }()
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					send(c())
+				}()
 			}
 		default:
-			out <- v
+			send(v)
 		}
 	}()
 	deadline := time.After(d)
@@ -103,5 +123,16 @@ func runBatchUntil[T any](t *testing.T, cmd tea.Cmd, d time.Duration) *T {
 		case <-deadline:
 			return nil
 		}
+	}
+}
+
+// waitBounded waits for wg, giving up after d. A command parked on a channel that
+// only a later cleanup closes must not hang the whole package.
+func waitBounded(wg *sync.WaitGroup, d time.Duration) {
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(d):
 	}
 }

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -245,6 +245,9 @@ func longestCommonPrefix(in []string) string {
 // records a one-line summary so the user has lasting feedback even if
 // they want to refer back to the most recent action.
 func runPaletteCommand(raw string, args []string) tea.Cmd {
+	if !subprocessesAllowed {
+		return func() tea.Msg { return ActionResult{Summary: raw, Err: errNoSubprocess} }
+	}
 	self, err := os.Executable()
 	if err != nil {
 		self = "lerd"

--- a/internal/tui/tabs_test.go
+++ b/internal/tui/tabs_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -13,10 +14,24 @@ import (
 )
 
 // TestMain initialises the global bubblezone manager so View() (which marks
-// clickable regions) doesn't panic outside of Run.
+// clickable regions) doesn't panic outside of Run, and points the whole package at
+// a temp XDG root. The TUI's load path reads and writes the site registry, and a
+// test driving it without isolation writes the developer's own sites.yaml; that
+// has already emptied one. Isolating here covers every test in the package rather
+// than relying on each to remember.
 func TestMain(m *testing.M) {
 	zone.NewGlobal()
-	os.Exit(m.Run())
+	subprocessesAllowed = false
+	dir, err := os.MkdirTemp("", "lerd-tui-test-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "tui tests: temp XDG root:", err)
+		os.Exit(1)
+	}
+	os.Setenv("XDG_DATA_HOME", filepath.Join(dir, "data"))
+	os.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
 }
 
 // waitZone polls for a zone to register. zone.Scan hands positions to a

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -104,6 +104,7 @@ func freshLatest() string {
 
 func writeCache(path string, state updateCheckState) {
 	data, _ := json.Marshal(state)
+	config.GuardRealWrite(path)
 	os.WriteFile(path, data, 0o644) //nolint:errcheck
 }
 

--- a/internal/watcher/idle_control_test.go
+++ b/internal/watcher/idle_control_test.go
@@ -41,6 +41,7 @@ func TestEnableDisableIdle_lifecycle(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Cleanup(func() {
 		disableIdle()
+		idleEng.wait() // the tick loop and the disable drain must not outlive the test
 		idleStartSrc = nil
 		activityTracker = nil
 		idleEng = nil
@@ -110,6 +111,8 @@ func TestResumeUntilClear_exitsWhenClean(t *testing.T) {
 // TestResumeUntilClear_bailsWhenReenabled proves the drain bails the moment the
 // feature is re-enabled, so it never fights a fresh session's suspends.
 func TestResumeUntilClear_bailsWhenReenabled(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	prev := activityTracker
 	t.Cleanup(func() { activityTracker = prev; idleEng = nil; idleActive.Store(false) })
 	activityTracker = idle.NewTracker(nil)

--- a/internal/watcher/idle_engine.go
+++ b/internal/watcher/idle_engine.go
@@ -74,6 +74,16 @@ var idleEng *idleEngine
 // stand in fake worktrees without a real git checkout.
 var detectWorktrees = gitpkg.DetectWorktrees
 
+// The slow worker operations the engine backgrounds, vars for the same reason as
+// detectWorktrees: a test can stand in for one and hold it open, which is how it
+// observes that the goroutine running it is waited on.
+var (
+	suspendWorkers         = cli.SuspendWorkersForIdle
+	resumeWorkers          = cli.ResumeWorkersForIdle
+	suspendWorktreeWorkers = cli.SuspendWorktreeWorkersForIdle
+	resumeWorktreeWorkers  = cli.ResumeWorktreeWorkersForIdle
+)
+
 // idleEngine suspends a site's suspendable workers once it has been idle past
 // its timeout and resumes them on activity. It holds an in-memory mirror of
 // which sites are currently suspended (also persisted in Site.IdleSuspendedWorkers)
@@ -86,6 +96,32 @@ type idleEngine struct {
 	// (a suspend may run a slow one-time `npm run build`), so the tick and other
 	// sites' wakes never block on it and the same site isn't worked twice at once.
 	inFlight map[string]bool
+	// wg counts every goroutine the engine has started, so wait() can block on them.
+	wg sync.WaitGroup
+}
+
+// spawn runs one of the engine's background jobs in a goroutine wait() covers.
+// Every goroutine the engine starts goes through here.
+func (e *idleEngine) spawn(what string, fn func()) {
+	if e == nil {
+		return
+	}
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+		defer recoverEngine(what)
+		fn()
+	}()
+}
+
+// wait blocks until the goroutines the engine started have returned, so none of
+// them outlives the caller. A session's tick loop only ends on cancel, so cancel
+// first. Wakes must be quiet too: a WaitGroup grown while Wait runs panics.
+func (e *idleEngine) wait() {
+	if e == nil {
+		return
+	}
+	e.wg.Wait()
 }
 
 func newIdleEngine(t *idle.Tracker) *idleEngine {
@@ -129,11 +165,15 @@ func newIdleEngine(t *idle.Tracker) *idleEngine {
 	return e
 }
 
+// start runs the tick loop for a session, tracked so wait() covers it.
+func (e *idleEngine) start(ctx context.Context) {
+	e.spawn("ticker", func() { e.run(ctx) })
+}
+
 // run drives the suspend evaluation until the session is cancelled. It evaluates
 // once immediately so enabling idle-suspend sleeps already-idle sites at once
 // rather than waiting a full tick interval, then re-evaluates periodically.
 func (e *idleEngine) run(ctx context.Context) {
-	defer recoverEngine("ticker")
 	t := time.NewTicker(idleTickInterval)
 	defer t.Stop()
 	for {
@@ -344,6 +384,11 @@ func (e *idleEngine) OnActivity(key string) {
 	e.resume(key) // resume runs its own goroutine
 }
 
+// startResumeUntilClear runs the disable-path drain, tracked so wait() covers it.
+func (e *idleEngine) startResumeUntilClear() {
+	e.spawn("drain", func() { e.resumeUntilClear() })
+}
+
 // resumeUntilClear is the disable path's safety net (replacing the tick that used
 // to re-resume disabled-but-suspended sites): it retries until nothing is left
 // suspended, catching a site whose slow mid-flight suspend resume() had skipped.
@@ -483,14 +528,13 @@ func (e *idleEngine) suspend(siteName string) {
 	e.inFlight[siteName] = true
 	e.mu.Unlock()
 
-	go func() {
-		defer recoverEngine("suspend")
+	e.spawn("suspend", func() {
 		defer e.clearInFlight(siteName)
 		site, err := config.FindSite(siteName)
 		if err != nil {
 			return
 		}
-		workers := cli.SuspendWorkersForIdle(site)
+		workers := suspendWorkers(site)
 		if len(workers) == 0 {
 			return // nothing stoppable (e.g. only vite, no build yet)
 		}
@@ -502,7 +546,7 @@ func (e *idleEngine) suspend(siteName string) {
 		e.mu.Unlock()
 		fmt.Printf("[idle] suspended %s: %v\n", siteName, workers)
 		publishSitesChanged()
-	}()
+	})
 }
 
 // resume restarts a suspended site's workers in the background.
@@ -515,15 +559,14 @@ func (e *idleEngine) resume(siteName string) {
 	e.inFlight[siteName] = true
 	e.mu.Unlock()
 
-	go func() {
-		defer recoverEngine("resume")
+	e.spawn("resume", func() {
 		defer e.clearInFlight(siteName)
 		site, err := config.FindSite(siteName)
 		if err != nil {
 			return
 		}
 		workers := site.IdleSuspendedWorkers
-		cli.ResumeWorkersForIdle(site, workers)
+		resumeWorkers(site, workers)
 		if err := config.SetSiteIdleSuspendedWorkers(siteName, nil); err != nil {
 			fmt.Printf("[WARN] idle-resume persist %s: %v\n", siteName, err)
 		}
@@ -532,7 +575,7 @@ func (e *idleEngine) resume(siteName string) {
 		e.mu.Unlock()
 		fmt.Printf("[idle] resumed %s: %v\n", siteName, workers)
 		publishSitesChanged()
-	}()
+	})
 }
 
 // suspendWorktree stops a worktree's own workers in the background, mirroring
@@ -548,14 +591,13 @@ func (e *idleEngine) suspendWorktree(siteName, wtBase, wtPath string) {
 	e.inFlight[key] = true
 	e.mu.Unlock()
 
-	go func() {
-		defer recoverEngine("suspend-wt")
+	e.spawn("suspend-wt", func() {
 		defer e.clearInFlight(key)
 		site, err := config.FindSite(siteName)
 		if err != nil {
 			return
 		}
-		workers := cli.SuspendWorktreeWorkersForIdle(site, wtPath)
+		workers := suspendWorktreeWorkers(site, wtPath)
 		if len(workers) == 0 {
 			return
 		}
@@ -567,7 +609,7 @@ func (e *idleEngine) suspendWorktree(siteName, wtBase, wtPath string) {
 		e.mu.Unlock()
 		fmt.Printf("[idle] suspended %s (worktree %s): %v\n", siteName, wtBase, workers)
 		publishSitesChanged()
-	}()
+	})
 }
 
 // resumeWorktree restarts a worktree's previously suspended workers.
@@ -581,8 +623,7 @@ func (e *idleEngine) resumeWorktree(siteName, wtBase, wtPath string) {
 	e.inFlight[key] = true
 	e.mu.Unlock()
 
-	go func() {
-		defer recoverEngine("resume-wt")
+	e.spawn("resume-wt", func() {
 		defer e.clearInFlight(key)
 		site, err := config.FindSite(siteName)
 		if err != nil {
@@ -592,7 +633,7 @@ func (e *idleEngine) resumeWorktree(siteName, wtBase, wtPath string) {
 		if site.WorktreeIdleSuspended != nil {
 			workers = site.WorktreeIdleSuspended[wtBase]
 		}
-		cli.ResumeWorktreeWorkersForIdle(site, wtPath, workers)
+		resumeWorktreeWorkers(site, wtPath, workers)
 		if err := config.SetWorktreeIdleSuspendedWorkers(siteName, wtBase, nil); err != nil {
 			fmt.Printf("[WARN] idle-resume persist %s worktree %s: %v\n", siteName, wtBase, err)
 		}
@@ -601,7 +642,7 @@ func (e *idleEngine) resumeWorktree(siteName, wtBase, wtPath string) {
 		e.mu.Unlock()
 		fmt.Printf("[idle] resumed %s (worktree %s): %v\n", siteName, wtBase, workers)
 		publishSitesChanged()
-	}()
+	})
 }
 
 func (e *idleEngine) clearInFlight(siteName string) {

--- a/internal/watcher/idle_engine_test.go
+++ b/internal/watcher/idle_engine_test.go
@@ -1,9 +1,11 @@
 package watcher
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
 	gitpkg "github.com/geodro/lerd/internal/git"
@@ -56,6 +58,7 @@ func TestTick_pinnedSiteStillTicksWorktrees(t *testing.T) {
 
 	e := newIdleEngine(idle.NewTracker(nil))
 	e.tick()
+	e.wait() // a tick that does decide to act must not outlive this env
 
 	reg, err := config.LoadSites()
 	if err != nil {
@@ -146,6 +149,7 @@ func TestTick_reconcilesStaleSuspendedCache(t *testing.T) {
 	e.suspended["myapp"] = true // stale cache the install couldn't clear
 
 	e.tick()
+	e.wait()
 
 	if e.suspended["myapp"] {
 		t.Error("stale suspended cache should be reconciled to false against the empty persisted list")
@@ -198,6 +202,7 @@ func TestTick_reconcilesStaleSuspendedListAgainstReality(t *testing.T) {
 	e.suspended["myapp"] = true
 
 	e.tick()
+	e.wait()
 
 	if e.suspended["myapp"] {
 		t.Error("stale suspended list with a running worker must reconcile to not-suspended")
@@ -261,6 +266,7 @@ func TestTickWorktrees_reconcilesStaleSuspendedCache(t *testing.T) {
 	e.suspended[key] = true // stale: persisted WorktreeIdleSuspended has no entry
 
 	e.tick()
+	e.wait()
 
 	if e.suspended[key] {
 		t.Error("stale worktree suspended cache should be reconciled to false")
@@ -297,6 +303,129 @@ func TestResumeAllSuspended_preservesInFlightList(t *testing.T) {
 	}
 	if len(site.IdleSuspendedWorkers) == 0 {
 		t.Error("cleared an in-flight suspend's list, stranding it")
+	}
+}
+
+// Every slow worker operation the engine backgrounds must run in a goroutine that
+// wait() covers. One that doesn't goes on resolving systemd paths and shelling out
+// after whatever started it has returned, which in a test is once the temp XDG
+// environment is gone, so its units land in the developer's real home. Each case
+// holds its operation open and proves wait() blocks until it is let go; revert any
+// of the four to a bare `go` and wait() returns early and the case fails.
+func TestSpawnedWork_isTrackedByWait(t *testing.T) {
+	const wtBase = "feature-x"
+	wtPath := "/srv/myapp/" + wtBase
+
+	cases := []struct {
+		name    string
+		hold    func(t *testing.T, entered, release chan struct{})
+		trigger func(e *idleEngine)
+	}{
+		{
+			name: "suspend",
+			hold: func(t *testing.T, entered, release chan struct{}) {
+				prev := suspendWorkers
+				suspendWorkers = func(*config.Site) []string { close(entered); <-release; return nil }
+				t.Cleanup(func() { suspendWorkers = prev })
+			},
+			trigger: func(e *idleEngine) { e.suspend("myapp") },
+		},
+		{
+			name: "resume",
+			hold: func(t *testing.T, entered, release chan struct{}) {
+				prev := resumeWorkers
+				resumeWorkers = func(*config.Site, []string) { close(entered); <-release }
+				t.Cleanup(func() { resumeWorkers = prev })
+			},
+			trigger: func(e *idleEngine) {
+				e.suspended["myapp"] = true
+				e.resume("myapp")
+			},
+		},
+		{
+			name: "suspend worktree",
+			hold: func(t *testing.T, entered, release chan struct{}) {
+				prev := suspendWorktreeWorkers
+				suspendWorktreeWorkers = func(*config.Site, string) []string { close(entered); <-release; return nil }
+				t.Cleanup(func() { suspendWorktreeWorkers = prev })
+			},
+			trigger: func(e *idleEngine) { e.suspendWorktree("myapp", wtBase, wtPath) },
+		},
+		{
+			name: "resume worktree",
+			hold: func(t *testing.T, entered, release chan struct{}) {
+				prev := resumeWorktreeWorkers
+				resumeWorktreeWorkers = func(*config.Site, string, []string) { close(entered); <-release }
+				t.Cleanup(func() { resumeWorktreeWorkers = prev })
+			},
+			trigger: func(e *idleEngine) {
+				e.suspended[wtKey("myapp", wtBase)] = true
+				e.resumeWorktree("myapp", wtBase, wtPath)
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("XDG_DATA_HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			if err := config.AddSite(config.Site{
+				Name: "myapp", Path: "/srv/myapp", PHPVersion: "8.4", Domains: []string{"myapp.test"},
+			}); err != nil {
+				t.Fatalf("seed site: %v", err)
+			}
+			entered, release := make(chan struct{}), make(chan struct{})
+			c.hold(t, entered, release)
+
+			e := newIdleEngine(idle.NewTracker(nil))
+			c.trigger(e)
+			<-entered // the goroutine is now inside the operation we hold open
+
+			returned := make(chan struct{})
+			go func() { e.wait(); close(returned) }()
+			select {
+			case <-returned:
+				t.Fatal("wait returned while the work was still running, so its goroutine is untracked")
+			case <-time.After(50 * time.Millisecond):
+			}
+
+			close(release)
+			select {
+			case <-returned:
+			case <-time.After(2 * time.Second):
+				t.Fatal("wait did not return once the work finished")
+			}
+		})
+	}
+}
+
+// The tick loop is waited on too, so a session's evaluations can't run on into a
+// torn-down environment either. It ends only when the session is cancelled, which
+// is what makes wait() the basis of a clean shutdown and not just a test aid.
+func TestStart_tickLoopIsTrackedUntilCancelled(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	prev := detectWorktrees
+	detectWorktrees = func(string, string) ([]gitpkg.Worktree, error) { return nil, nil }
+	t.Cleanup(func() { detectWorktrees = prev })
+
+	e := newIdleEngine(idle.NewTracker(nil))
+	ctx, cancel := context.WithCancel(context.Background())
+	e.start(ctx)
+
+	returned := make(chan struct{})
+	go func() { e.wait(); close(returned) }()
+	select {
+	case <-returned:
+		t.Fatal("wait returned while the tick loop was still running, so it is untracked")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("wait did not return once the session was cancelled")
 	}
 }
 

--- a/internal/watcher/idle_feed.go
+++ b/internal/watcher/idle_feed.go
@@ -109,7 +109,7 @@ func StartIdle(notify func(), sourceWatcher func(stop <-chan struct{}) error) {
 	if cfg, err := config.LoadGlobal(); err == nil && cfg.IdleSuspend.Enabled {
 		enableIdle()
 	} else {
-		go idleEng.resumeUntilClear()
+		idleEng.startResumeUntilClear()
 	}
 }
 
@@ -130,13 +130,13 @@ func enableIdle() {
 	_ = os.MkdirAll(config.RunDir(), 0755)
 	_ = activityTracker.Save(config.IdleActivityFile())
 
-	go idleEng.run(ctx)
+	idleEng.start(ctx)
 
 	// The access feed is bound once in StartIdle and gated on idleActive, so
 	// enabling just flips the gate: browsing a quiet site now wakes it. The
 	// source-file watcher is the only thing this session still starts.
 	if idleStartSrc != nil {
-		go func() { _ = idleStartSrc(ctx.Done()) }()
+		idleEng.spawn("source-watcher", func() { _ = idleStartSrc(ctx.Done()) })
 	}
 }
 
@@ -151,7 +151,7 @@ func disableIdle() {
 		idleCancel = nil
 	}
 	idleMu.Unlock()
-	go idleEng.resumeUntilClear()
+	idleEng.startResumeUntilClear()
 }
 
 // handleAccessDatagram fans one nginx access datagram out to both consumers:


### PR DESCRIPTION
The idle engine hands its slow work to goroutines. Suspend, resume and their worktree variants each spawn one, and so do the tick loop, the source-file watcher and the disable-path drain, and nothing ever waited for any of them. In the daemon that is the point, a slow worker stop must not block a tick or another site's wake, but it also means the work outlives whatever set it up.

That is how a real systemd unit ended up written and enabled on a machine, crash-looping on an ExecStart pointing at a directory that had already been deleted. A goroutine still in flight once its caller returned resolved the systemd user directory against the real home rather than the isolated one it had started under. The drain widens the window a long way, since it reloads the site registry every 500 milliseconds for up to five minutes and keeps reading whichever configuration directory happens to be current at the time.

Every goroutine the engine starts now goes through a single spawner backed by a WaitGroup, and wait blocks until all of them have returned. The four slow worker operations move behind package vars, the same seam the worktree detector already uses, so one can be held open to observe that the goroutine running it is genuinely waited on.

Chasing that turned up the same bug doing far more damage elsewhere, so the second commit fixes it. The TUI tests drive the real load path, which reads and writes the site registry, and the helper that runs a batched tea.Cmd returned on the first message it wanted and left the rest of the batch running into a later test, with the earlier one's temp XDG dirs already restored. Nothing pointed those tests at a temp XDG root either, so whatever was ambient is what they wrote. Running the suite could empty a developer's sites.yaml, and did: every site gone, replaced by an empty list.

That package now takes a temp XDG root in TestMain and its batch helper waits, bounded, for the goroutines it starts. Two bug-report tests in the CLI package get the same isolation, since their update check was caching into the real data dir. Behind all of it, writing lerd state from a test that resolved it to the state of whoever is running the suite now panics with the offending path instead of silently destroying data. It covers the registry, the global config, the rest of the config package's writers, nginx vhosts, certs, quadlets and systemd units, and the directories it protects are resolved once at process start, because XDG_DATA_HOME is what decides them and a test moves it.

The TUI's two subprocess paths no longer run under test. There os.Executable() is the test binary, so shelling out to it re-ran the package's own tests against the real environment with their output swallowed into a buffer, which is a large part of why this stayed hidden.



The last piece is the one that produced the original artifact. A test that drives the unit lifecycle without installing a podman.UnitLifecycle stub falls through to the real user bus and starts, stops and restarts units on the machine running the suite, and the unit files it writes land in the real systemd user directory. That path is now refused from a test binary when no stub is installed, and the unit writes go through the same guard as the rest of lerd state. The whole suite passes with the real bus blocked, so nothing was relying on it.

Refs #830
