### PR TITLE
feat(tui): lay the site overview out as a responsive grid

### DIFF
--- a/docs/features/tui.md
+++ b/docs/features/tui.md
@@ -41,6 +41,7 @@ Dots follow the same convention everywhere: green `●` running, grey `○` stop
 | click | Click a tab to switch screens, or a site / service row to select it |
 | `tab` / `shift+tab` | Cycle focus between the list and the detail pane on the current tab |
 | `↑` `↓` / `j` `k` | Move selection in the focused pane (scrolls the grid on the Dashboard tab) |
+| `←` `→` | Cross between the two columns of the site Overview grid (Domains and Toggles) when the pane is wide enough to pair them |
 | `pgup` `pgdn` | Jump by 10 rows |
 | `home` `g` | Jump to first row |
 | `end` `G` | Jump to last row |
@@ -137,13 +138,21 @@ The site detail pane is split into read-side tabs the user can jump between with
 
 | Key | Tab | Contents |
 | --- | --- | --- |
-| `1` | Overview | The default — domains, services used, workers, worktrees, toggles (HTTPS / LAN / PHP / Node), and the [request-timing panel](#request-timing) |
+| `1` | Overview | The default: domains, toggles (HTTPS / LAN / PHP / Node), services used, workers, worktrees, and the [request-timing panel](#request-timing), laid out as a [responsive grid](#overview-layout) |
 | `2` | Logs | A live tail of any of the site's log sources: the FPM or custom container, every worker unit, and each of the framework's app-log files. `[` / `]` cycle the source, `{` / `}` scroll back through the buffer, `f` finds within it. `l` is a shortcut to this tab from anywhere on the Sites tab |
 | `3` | Env | Read-only display of the site's `.env` file (read up to 256 KB so a runaway file can't wedge the render loop) |
 | `4` | Debug | This site's slice of the Debug window: the active lens (Dumps · Queries · Jobs · Views · Mail · Cache · Events · HTTP) scoped to the focused site, with `[` / `]` to switch lens and `w` to toggle worker capture. Rows show their detail inline; press `D` for the full cross-site window |
 | `5` | Doctor | The same framework-agnostic app-level health checks the web dashboard runs: a universal baseline (env file present, env drift warning only on keys the code reads without a default, application key set, composer and node dependencies installed with lockfiles in step, `composer audit` and `npm audit` clean, PHP version in range) plus each framework's own checks from its store definition (for Laravel, the `APP_DEBUG`-in-production footgun, the `public/storage` symlink, and pending migrations). Some checks exec in the container, so the run is on-demand: press `5` to run and again to re-run. The panel is read-only and names the suggested fix (e.g. `key:generate`, `migrate`) rather than running it, so a status view can never migrate a database |
 
 Switching tabs resets the detail-pane scroll so the user lands at the top of the new tab. Picker overlays (PHP / Node version) only show in Overview; selecting a different tab dismisses them.
+
+## Overview layout
+
+The Overview is a grid, not a column. Each section says whether it wants the whole pane or half of it, and half-width sections pair up: **Domains** sits beside **Toggles**, and **Services used** beside **Workers**. The identity header, worktrees and request timing take the full width, and the timing panel subdivides internally into its distribution, slowest-routes and recent columns.
+
+A column has a floor of 44 characters. When the pane can't give two columns that much, every section goes full width and the grid collapses to the single column it has always been, so a narrow terminal loses nothing. The same rule applies inside the timing panel, which drops from three blocks to two to one rather than truncating every row to a stub.
+
+Because sections sit side by side, `left` and `right` cross between the two columns of a grid row (Domains and Toggles), keeping the cursor's offset within the section, while `up` and `down` walk a single column as before.
 
 ## Request timing
 

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -67,8 +67,11 @@ const (
 	kindWorktreeNode
 )
 
-// detailRows returns the ordered rows the detail view draws. Built on each
-// render so worker lists stay in sync with live state.
+// detailRows returns the rows the detail view draws, in the order the Overview
+// renders them: Domains, Toggles, Workers, then the worktrees. Cursor movement
+// walks this slice, so the order has to match the layout or `down` teleports the
+// cursor to a block somewhere else on screen. Built on each render so worker
+// lists stay in sync with live state.
 func detailRows(s *siteinfo.EnrichedSite) []detailRow {
 	var rows []detailRow
 	rows = append(rows, detailRow{kind: kindInfo}) // header placeholder drawn separately
@@ -76,6 +79,16 @@ func detailRows(s *siteinfo.EnrichedSite) []detailRow {
 		rows = append(rows, detailRow{kind: kindDomain, domain: d})
 	}
 	rows = append(rows, detailRow{kind: kindDomainAdd})
+	if s.ContainerPort == 0 && s.PHPVersion != "" {
+		rows = append(rows, detailRow{kind: kindPHP})
+	}
+	if s.NodeVersion != "" {
+		rows = append(rows, detailRow{kind: kindNode})
+	}
+	if cfg, _ := config.LoadGlobal(); cfg == nil || cfg.DNS.Enabled {
+		rows = append(rows, detailRow{kind: kindHTTPS})
+	}
+	rows = append(rows, detailRow{kind: kindLANShare})
 	if s.HasQueueWorker {
 		rows = append(rows, detailRow{kind: kindWorker, workerName: "queue"})
 	}
@@ -95,16 +108,6 @@ func detailRows(s *siteinfo.EnrichedSite) []detailRow {
 		}
 		rows = append(rows, detailRow{kind: kindWorker, workerName: fw.Name})
 	}
-	if s.ContainerPort == 0 && s.PHPVersion != "" {
-		rows = append(rows, detailRow{kind: kindPHP})
-	}
-	if s.NodeVersion != "" {
-		rows = append(rows, detailRow{kind: kindNode})
-	}
-	if cfg, _ := config.LoadGlobal(); cfg == nil || cfg.DNS.Enabled {
-		rows = append(rows, detailRow{kind: kindHTTPS})
-	}
-	rows = append(rows, detailRow{kind: kindLANShare})
 	dbCapable := siteHasManagedDB(s)
 	for _, wt := range s.Worktrees {
 		rows = append(rows, detailRow{kind: kindWorktreeHeader, branch: wt.Branch, branchPath: wt.Path})
@@ -156,9 +159,13 @@ func findWorktree(s *siteinfo.EnrichedSite, branch string) *siteinfo.WorktreeInf
 func navigableRows(rows []detailRow) []int {
 	var idx []int
 	for i, r := range rows {
-		if r.kind != kindInfo {
-			idx = append(idx, i)
+		// The worktree header is a caption, not a control: it has no toggle and
+		// renders no cursor, so leaving it navigable made the cursor vanish for a
+		// keypress as it passed through.
+		if r.kind == kindInfo || r.kind == kindWorktreeHeader {
+			continue
 		}
+		idx = append(idx, i)
 	}
 	return idx
 }
@@ -554,8 +561,11 @@ func settingsContentLines(m *Model, focused bool, innerW int) []string {
 	return out
 }
 
-// detailContentLines returns the rendered lines for the site detail pane and
-// the line index of the currently selected row (for viewport scrolling).
+// detailContentLines renders the site Overview and returns the line index of the
+// selected row (for viewport scrolling). The Overview is a grid: sections declare
+// whether they want the whole pane or half of it, and half-width sections pair up
+// so Domains sits beside Toggles and Services beside Workers. A narrow pane
+// collapses every section to full width and the grid becomes a single column.
 func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, innerW int) ([]string, int) {
 	rows := detailRows(site)
 	nav := navigableRows(rows)
@@ -567,114 +577,112 @@ func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, inn
 		}
 		return -1
 	}
+	sel := func(i int) bool { return focused && navPos(i) == m.detailCursor }
 
-	out := renderSiteTabHeader(tabSiteOverview, innerW, availableSiteTabs(site))
-	cursorLine := 0
-	add := func(s string, selected bool) {
-		if selected && len(out) > 0 {
-			cursorLine = len(out)
-		}
-		out = append(out, padToWidth(clipLine(s, innerW), innerW))
-	}
-	addPlain := func(s string) { add(s, false) }
-
-	// Lead with the primary domain (what users see in the browser). The
-	// internal registry name is still surfaced as the "name:" line below,
-	// since commands and filters still accept it.
-	header := site.PrimaryDomain()
-	if header == "" {
-		header = site.Name
-	}
-	addPlain(sectionStyle.Render(header))
-	if site.AppName != "" {
-		addPlain(dimStyle.Render("  app: ") + site.AppName)
-	}
-	if site.Name != header {
-		addPlain(dimStyle.Render("  name: ") + site.Name)
-	}
-	if site.Path != "" {
-		addPlain(dimStyle.Render("  path: ") + site.Path)
-	}
-	if site.Group != "" {
-		if site.GroupSubdomain != "" {
-			// Resolve the main from the registry rather than trimming the label
-			// off this site's own domain, which breaks if the primary isn't
-			// literally <label>.<main> (e.g. an alias was promoted to primary).
-			mainDomain := ""
-			for _, s := range m.snap.Sites {
-				if s.Group == site.Group && s.GroupSubdomain == "" {
-					mainDomain = s.PrimaryDomain()
-					break
-				}
-			}
-			if mainDomain == "" {
-				mainDomain = strings.TrimPrefix(site.PrimaryDomain(), site.GroupSubdomain+".")
-			}
-			line := "  group: secondary of " + mainDomain
-			if site.GroupSharedDB {
-				line += " · shared db"
-			}
-			addPlain(dimStyle.Render(line))
-		} else {
-			n := 0
-			for _, s := range m.snap.Sites {
-				if s.Group == site.Group && s.GroupSubdomain != "" {
-					n++
-				}
-			}
-			noun := "secondaries"
-			if n == 1 {
-				noun = "secondary"
-			}
-			addPlain(dimStyle.Render(fmt.Sprintf("  group: main · %d %s", n, noun)))
-		}
-	}
-
+	colW := overviewColWidth(innerW)
 	scheme := "http"
 	if site.Secured {
 		scheme = "https"
 	}
 
-	addPlain("")
-	addPlain(sectionStyle.Render("Domains"))
-	if len(site.Domains) == 0 {
-		addPlain(dimStyle.Render("  (no domain)"))
-	}
-	for i, row := range rows {
-		if row.kind != kindDomain {
-			continue
-		}
-		selected := focused && navPos(i) == m.detailCursor
-		domain := row.domain
-		label := scheme + "://" + domain
-		add(renderDetailRow(selected, accentStyle.Render("⊙"), label, dimStyle.Render(domainRole(site, domain))), selected)
-	}
-	for i, row := range rows {
-		if row.kind != kindDomainAdd {
-			continue
-		}
-		selected := focused && navPos(i) == m.detailCursor
-		prefix := "  "
-		if selected {
-			prefix = " " + accentStyle.Render("▸")
-		}
-		if m.domainInputActive {
-			label := "add domain: "
-			if m.domainInputEditing != "" {
-				label = "rename " + m.domainInputEditing + " → "
-			}
-			add(prefix+" "+accentStyle.Render("+")+" "+selectedStyle.Render(label)+m.domainInput+"▌", selected)
-		} else {
-			add(prefix+" "+accentStyle.Render("+")+" "+dimStyle.Render("add domain (space or a)"), selected)
-		}
-	}
-	addPlain("")
+	var secs []ovSection
+	secs = append(secs, overviewIdentity(m, site, innerW)...)
+	secs = append(secs, overviewDomains(m, site, rows, sel, scheme, colW)...)
+	secs = append(secs, overviewToggles(site, rows, sel, colW)...)
+	secs = append(secs, overviewServices(m, site, colW)...)
+	secs = append(secs, overviewWorkers(site, rows, sel, colW)...)
+	secs = append(secs, overviewWorktrees(site, rows, sel, scheme, innerW)...)
+	secs = append(secs, overviewTiming(m, site, innerW)...)
 
+	body, cursorLine := composeOverview(secs, innerW)
+	out := renderSiteTabHeader(tabSiteOverview, innerW, availableSiteTabs(site))
+	if cursorLine >= 0 {
+		cursorLine += len(out)
+	} else {
+		cursorLine = 0
+	}
+	return append(out, body...), cursorLine
+}
+
+// overviewIdentity is the header: primary domain, then the facts about the site
+// packed onto as few lines as the pane allows.
+func overviewIdentity(m *Model, site *siteinfo.EnrichedSite, innerW int) []ovSection {
+	b := newOvBuilder(innerW)
+
+	// Lead with the primary domain (what users see in the browser). The internal
+	// registry name is still surfaced below, since commands and filters take it.
+	header := site.PrimaryDomain()
+	if header == "" {
+		header = site.Name
+	}
+	b.plain(sectionStyle.Render(header))
+
+	var facts []string
+	if site.AppName != "" {
+		facts = append(facts, dimStyle.Render("app: ")+site.AppName)
+	}
+	if site.Name != header {
+		facts = append(facts, dimStyle.Render("name: ")+site.Name)
+	}
+	if g := siteGroupLine(m, site); g != "" {
+		facts = append(facts, dimStyle.Render(g))
+	}
+	for _, ln := range joinInfo(facts, innerW-2) {
+		b.plain("  " + ln)
+	}
+	if site.Path != "" {
+		b.plain(dimStyle.Render("  path: ") + site.Path)
+	}
+	b.plain("  " + siteRuntimeLine(site))
+	b.plain("")
+	return b.section(ovFull)
+}
+
+// siteGroupLine describes the site's place in a group, or "" when it isn't in one.
+func siteGroupLine(m *Model, site *siteinfo.EnrichedSite) string {
+	if site.Group == "" {
+		return ""
+	}
+	if site.GroupSubdomain != "" {
+		// Resolve the main from the registry rather than trimming the label off
+		// this site's own domain, which breaks if the primary isn't literally
+		// <label>.<main> (e.g. an alias was promoted to primary).
+		mainDomain := ""
+		for _, s := range m.snap.Sites {
+			if s.Group == site.Group && s.GroupSubdomain == "" {
+				mainDomain = s.PrimaryDomain()
+				break
+			}
+		}
+		if mainDomain == "" {
+			mainDomain = strings.TrimPrefix(site.PrimaryDomain(), site.GroupSubdomain+".")
+		}
+		line := "group: secondary of " + mainDomain
+		if site.GroupSharedDB {
+			line += " · shared db"
+		}
+		return line
+	}
+	n := 0
+	for _, s := range m.snap.Sites {
+		if s.Group == site.Group && s.GroupSubdomain != "" {
+			n++
+		}
+	}
+	noun := "secondaries"
+	if n == 1 {
+		noun = "secondary"
+	}
+	return fmt.Sprintf("group: main · %d %s", n, noun)
+}
+
+// siteRuntimeLine is the one-liner of versions: PHP, Node, framework, runtime, branch.
+func siteRuntimeLine(site *siteinfo.EnrichedSite) string {
 	php := site.PHPVersion
 	if php == "" && site.ContainerPort > 0 {
 		php = "custom"
 	}
-	info := dimStyle.Render("  php: ") + php
+	info := dimStyle.Render("php: ") + php
 	if site.NodeVersion != "" {
 		info += dimStyle.Render("  node: ") + site.NodeVersion
 	}
@@ -691,133 +699,159 @@ func detailContentLines(m *Model, site *siteinfo.EnrichedSite, focused bool, inn
 	if site.Branch != "" {
 		info += dimStyle.Render("  git: ") + site.Branch
 	}
-	addPlain(info)
-	addPlain("")
-	if len(site.Services) > 0 {
-		addPlain(sectionStyle.Render("Services used"))
-		states := m.serviceStatesByName()
-		for _, svc := range site.Services {
-			addPlain(renderSiteServiceRow(svc, states[svc]))
-		}
-		addPlain("")
-	}
+	return info
+}
 
-	hasWorkers := false
-	for _, row := range rows {
-		if row.kind == kindWorker {
-			hasWorkers = true
-			break
-		}
+func overviewDomains(m *Model, site *siteinfo.EnrichedSite, rows []detailRow, sel func(int) bool, scheme string, w int) []ovSection {
+	b := newOvBuilder(w)
+	b.plain(sectionStyle.Render("Domains"))
+	if len(site.Domains) == 0 {
+		b.plain(dimStyle.Render("  (no domain)"))
 	}
-	if hasWorkers {
-		addPlain(sectionStyle.Render("Workers"))
-		for i, row := range rows {
-			if row.kind != kindWorker {
-				continue
-			}
-			selected := focused && navPos(i) == m.detailCursor
-			add(renderDetailRow(selected,
-				workerGlyphFor(site, row.workerName),
-				workerLabel(site, row.workerName),
-				workerStateText(site, row.workerName)), selected)
-		}
-		addPlain("")
-	}
-
-	if len(site.Worktrees) > 0 {
-		addPlain(sectionStyle.Render("Worktrees"))
-		for _, wt := range site.Worktrees {
-			head := "  " + accentStyle.Render(wt.Branch)
-			if wt.Domain != "" {
-				head += "  " + dimStyle.Render(scheme+"://"+wt.Domain)
-			}
-			if wt.Path != "" {
-				head += "  " + dimStyle.Render(wt.Path)
-			}
-			addPlain(head)
-			renderedAny := false
-			for i, row := range rows {
-				if row.kind == kindWorktreeWorker && row.branch == wt.Branch {
-					renderedAny = true
-					selected := focused && navPos(i) == m.detailCursor
-					add(renderDetailRow(selected,
-						worktreeWorkerGlyph(&wt, row.workerName),
-						"    "+worktreeWorkerLabel(&wt, row.workerName),
-						worktreeWorkerStateText(&wt, row.workerName)), selected)
-				}
-			}
-			for i, row := range rows {
-				if row.kind == kindWorktreeDB && row.branch == wt.Branch {
-					renderedAny = true
-					selected := focused && navPos(i) == m.detailCursor
-					add(renderDetailRow(selected,
-						onOffGlyph(wt.DBIsolated),
-						"    "+"Isolated DB",
-						worktreeDBStateText(wt)), selected)
-				}
-			}
-			for i, row := range rows {
-				if row.kind == kindWorktreeLAN && row.branch == wt.Branch {
-					renderedAny = true
-					selected := focused && navPos(i) == m.detailCursor
-					add(renderDetailRow(selected,
-						onOffGlyph(wt.LANPort > 0),
-						"    "+"LAN share",
-						lanShareText(wt.LANPort)), selected)
-				}
-			}
-			for i, row := range rows {
-				if row.kind == kindWorktreePHP && row.branch == wt.Branch {
-					renderedAny = true
-					selected := focused && navPos(i) == m.detailCursor
-					add(renderDetailRow(selected,
-						accentStyle.Render("λ"),
-						"    "+"PHP",
-						worktreeVersionText(wt.PHPVersion, wt.PHPVersionOverride)), selected)
-				}
-				if row.kind == kindWorktreeNode && row.branch == wt.Branch {
-					renderedAny = true
-					selected := focused && navPos(i) == m.detailCursor
-					add(renderDetailRow(selected,
-						accentStyle.Render("⬢"),
-						"    "+"Node",
-						worktreeVersionText(wt.NodeVersion, wt.NodeVersionOverride)), selected)
-				}
-			}
-			if !renderedAny {
-				addPlain(dimStyle.Render("    (no per-worktree controls)"))
-			}
-		}
-		addPlain("")
-	}
-
-	addPlain(sectionStyle.Render("Toggles"))
 	for i, row := range rows {
-		selected := focused && navPos(i) == m.detailCursor
+		switch row.kind {
+		case kindDomain:
+			s := sel(i)
+			label := scheme + "://" + row.domain
+			b.add(renderDetailRow(s, accentStyle.Render("⊙"), label, dimStyle.Render(domainRole(site, row.domain))), s)
+		case kindDomainAdd:
+			s := sel(i)
+			prefix := "  "
+			if s {
+				prefix = " " + accentStyle.Render("▸")
+			}
+			if m.domainInputActive {
+				label := "add domain: "
+				if m.domainInputEditing != "" {
+					label = "rename " + m.domainInputEditing + " → "
+				}
+				b.add(prefix+" "+accentStyle.Render("+")+" "+selectedStyle.Render(label)+m.domainInput+"▌", s)
+			} else {
+				b.add(prefix+" "+accentStyle.Render("+")+" "+dimStyle.Render("add domain (space or a)"), s)
+			}
+		}
+	}
+	b.plain("")
+	return b.section(ovHalf)
+}
+
+func overviewToggles(site *siteinfo.EnrichedSite, rows []detailRow, sel func(int) bool, w int) []ovSection {
+	b := newOvBuilder(w)
+	b.plain(sectionStyle.Render("Toggles"))
+	for i, row := range rows {
+		s := sel(i)
 		switch row.kind {
 		case kindPHP:
-			add(renderDetailRow(selected,
-				accentStyle.Render("λ"), "PHP", dimStyle.Render(site.PHPVersion)), selected)
+			b.add(renderDetailRow(s, accentStyle.Render("λ"), "PHP", dimStyle.Render(site.PHPVersion)), s)
 		case kindNode:
-			add(renderDetailRow(selected,
-				accentStyle.Render("⬢"), "Node", dimStyle.Render(site.NodeVersion)), selected)
+			b.add(renderDetailRow(s, accentStyle.Render("⬢"), "Node", dimStyle.Render(site.NodeVersion)), s)
 		case kindHTTPS:
-			add(renderDetailRow(selected,
-				onOffGlyph(site.Secured), "HTTPS", onOffText(site.Secured)), selected)
+			b.add(renderDetailRow(s, onOffGlyph(site.Secured), "HTTPS", onOffText(site.Secured)), s)
 		case kindLANShare:
-			add(renderDetailRow(selected,
-				onOffGlyph(site.LANPort > 0), "LAN share", lanShareText(site.LANPort)), selected)
+			b.add(renderDetailRow(s, onOffGlyph(site.LANPort > 0), "LAN share", lanShareText(site.LANPort)), s)
 		}
 	}
+	b.plain("")
+	return b.section(ovHalf)
+}
 
-	// The request-timing panel closes the Overview, in the space the app-logs
-	// sub-pane used to take. Read-only, so it sits below the navigable rows and
-	// never enters the cursor cycle.
-	if timing := timingSectionLines(m, site, innerW); len(timing) > 0 {
-		out = append(out, "")
-		out = append(out, timing...)
+func overviewServices(m *Model, site *siteinfo.EnrichedSite, w int) []ovSection {
+	if len(site.Services) == 0 {
+		return nil
 	}
-	return out, cursorLine
+	b := newOvBuilder(w)
+	b.plain(sectionStyle.Render("Services used"))
+	states := m.serviceStatesByName()
+	for _, svc := range site.Services {
+		b.plain(renderSiteServiceRow(svc, states[svc]))
+	}
+	b.plain("")
+	return b.section(ovHalf)
+}
+
+func overviewWorkers(site *siteinfo.EnrichedSite, rows []detailRow, sel func(int) bool, w int) []ovSection {
+	b := newOvBuilder(w)
+	for i, row := range rows {
+		if row.kind != kindWorker {
+			continue
+		}
+		if b.empty() {
+			b.plain(sectionStyle.Render("Workers"))
+		}
+		s := sel(i)
+		b.add(renderDetailRow(s,
+			workerGlyphFor(site, row.workerName),
+			workerLabel(site, row.workerName),
+			workerStateText(site, row.workerName)), s)
+	}
+	if b.empty() {
+		return nil
+	}
+	b.plain("")
+	return b.section(ovHalf)
+}
+
+func overviewWorktrees(site *siteinfo.EnrichedSite, rows []detailRow, sel func(int) bool, scheme string, w int) []ovSection {
+	if len(site.Worktrees) == 0 {
+		return nil
+	}
+	b := newOvBuilder(w)
+	b.plain(sectionStyle.Render("Worktrees"))
+	for _, wt := range site.Worktrees {
+		head := "  " + accentStyle.Render(wt.Branch)
+		if wt.Domain != "" {
+			head += "  " + dimStyle.Render(scheme+"://"+wt.Domain)
+		}
+		if wt.Path != "" {
+			head += "  " + dimStyle.Render(wt.Path)
+		}
+		b.plain(head)
+		renderedAny := false
+		for i, row := range rows {
+			if row.branch != wt.Branch {
+				continue
+			}
+			s := sel(i)
+			switch row.kind {
+			case kindWorktreeWorker:
+				renderedAny = true
+				b.add(renderDetailRow(s, worktreeWorkerGlyph(&wt, row.workerName),
+					"    "+worktreeWorkerLabel(&wt, row.workerName),
+					worktreeWorkerStateText(&wt, row.workerName)), s)
+			case kindWorktreeDB:
+				renderedAny = true
+				b.add(renderDetailRow(s, onOffGlyph(wt.DBIsolated),
+					"    Isolated DB", worktreeDBStateText(wt)), s)
+			case kindWorktreeLAN:
+				renderedAny = true
+				b.add(renderDetailRow(s, onOffGlyph(wt.LANPort > 0),
+					"    LAN share", lanShareText(wt.LANPort)), s)
+			case kindWorktreePHP:
+				renderedAny = true
+				b.add(renderDetailRow(s, accentStyle.Render("λ"),
+					"    PHP", worktreeVersionText(wt.PHPVersion, wt.PHPVersionOverride)), s)
+			case kindWorktreeNode:
+				renderedAny = true
+				b.add(renderDetailRow(s, accentStyle.Render("⬢"),
+					"    Node", worktreeVersionText(wt.NodeVersion, wt.NodeVersionOverride)), s)
+			}
+		}
+		if !renderedAny {
+			b.plain(dimStyle.Render("    (no per-worktree controls)"))
+		}
+	}
+	b.plain("")
+	return b.section(ovFull)
+}
+
+// overviewTiming wraps the request-timing panel as a full-width section. It's
+// read-only, so it holds no cursor.
+func overviewTiming(m *Model, site *siteinfo.EnrichedSite, innerW int) []ovSection {
+	lines := timingSectionLines(m, site, innerW)
+	if len(lines) == 0 {
+		return nil
+	}
+	return []ovSection{{lines: lines, span: ovFull, cursor: -1}}
 }
 
 func renderDetailRow(selected bool, glyph, label, state string) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -562,6 +562,17 @@ func (m *Model) handleMainKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.switchTab(m.nextTab(-1))
 		return m, m.afterNav()
 
+	case "left", "right":
+		// The Overview lays Domains beside Toggles when the pane is wide enough;
+		// left and right cross between those columns while up and down walk one.
+		if m.timingActive() && m.focus == paneDetail {
+			site := m.currentSite()
+			rows := detailRows(site)
+			m.detailCursor = hopDetailColumn(rows, navigableRows(rows), m.detailCursor, m.detailInnerWidth())
+			m.followCursor = true
+		}
+		return m, nil
+
 	case "tab":
 		// On the Dashboard tab there are no list panes; tab moves focus
 		// between the grid cards so j/k and the wheel scroll the right one.

--- a/internal/tui/overview.go
+++ b/internal/tui/overview.go
@@ -1,0 +1,275 @@
+package tui
+
+import "github.com/charmbracelet/x/ansi"
+
+// The site Overview lays out as a grid. A section either takes the whole pane
+// width or pairs with the next half-width section, so Services sits beside
+// Workers and Domains beside Toggles rather than stacking into a column twice as
+// tall as the terminal. Below the breakpoint every section goes full-width and
+// the grid degrades to the single column it has always been.
+const (
+	// overviewMinColWidth is the narrowest a paired column can get and still hold
+	// a label, its state, and a glyph without truncating everything interesting.
+	overviewMinColWidth = 44
+	overviewGutter      = 2
+)
+
+// ovSpan says whether a section wants the whole pane width or shares a grid row.
+type ovSpan int
+
+const (
+	ovHalf ovSpan = iota
+	ovFull
+)
+
+// ovSection is one block of the Overview: the lines it renders, how wide it wants
+// to be, and which of its lines carries the cursor (-1 when the cursor is
+// elsewhere), so the grid can offset that line once the section lands in a row.
+type ovSection struct {
+	lines  []string
+	span   ovSpan
+	cursor int
+}
+
+// ovBuilder accumulates one section's lines at a fixed width, remembering the
+// selected line as it goes.
+type ovBuilder struct {
+	lines  []string
+	cursor int
+	w      int
+}
+
+func newOvBuilder(w int) *ovBuilder { return &ovBuilder{cursor: -1, w: w} }
+
+func (b *ovBuilder) add(s string, selected bool) {
+	if selected {
+		b.cursor = len(b.lines)
+	}
+	b.lines = append(b.lines, padToWidth(clipLine(s, b.w), b.w))
+}
+
+func (b *ovBuilder) plain(s string) { b.add(s, false) }
+
+func (b *ovBuilder) empty() bool { return len(b.lines) == 0 }
+
+// section freezes the builder into a section of the given span. Returns nothing
+// for an empty builder, so a site with no worktrees doesn't leave a hole in the
+// grid.
+func (b *ovBuilder) section(span ovSpan) []ovSection {
+	if b.empty() {
+		return nil
+	}
+	return []ovSection{{lines: b.lines, span: span, cursor: b.cursor}}
+}
+
+// overviewCols reports how many columns the pane can carry. Two only when each
+// would still clear overviewMinColWidth, so a narrow terminal keeps the single
+// column rather than shredding both halves.
+func overviewCols(innerW int) int {
+	if (innerW-overviewGutter)/2 >= overviewMinColWidth {
+		return 2
+	}
+	return 1
+}
+
+// overviewColWidth is the width a half-span section builds at: half the pane when
+// the grid is two columns wide, the whole pane when it has collapsed to one.
+func overviewColWidth(innerW int) int {
+	if overviewCols(innerW) == 1 {
+		return innerW
+	}
+	return (innerW - overviewGutter) / 2
+}
+
+// composeOverview lays the sections into the grid and returns the composed block
+// plus the line carrying the cursor (-1 when no section holds it). Full-span
+// sections take a row to themselves; a half-span section pairs with the next one,
+// and falls back to full width when it has no partner or the grid is one column.
+func composeOverview(secs []ovSection, innerW int) ([]string, int) {
+	colW := overviewColWidth(innerW)
+	paired := overviewCols(innerW) > 1
+
+	var out []string
+	cursorLine := -1
+	// The right column takes whatever the split left over, so an odd pane width
+	// still spans the full pane rather than leaving a ragged edge.
+	rightW := innerW - colW - overviewGutter
+
+	for i := 0; i < len(secs); i++ {
+		left := secs[i]
+		start := len(out)
+
+		if paired && left.span == ovHalf && i+1 < len(secs) && secs[i+1].span == ovHalf {
+			right := secs[i+1]
+			h := len(left.lines)
+			if len(right.lines) > h {
+				h = len(right.lines)
+			}
+			for j := 0; j < h; j++ {
+				l := spaces(colW)
+				if j < len(left.lines) {
+					l = padToWidth(clipLine(left.lines[j], colW), colW)
+				}
+				r := ""
+				if j < len(right.lines) {
+					r = clipLine(right.lines[j], rightW)
+				}
+				out = append(out, padToWidth(l+spaces(overviewGutter)+r, innerW))
+			}
+			if left.cursor >= 0 {
+				cursorLine = start + left.cursor
+			}
+			if right.cursor >= 0 {
+				cursorLine = start + right.cursor
+			}
+			i++ // the partner is consumed
+			continue
+		}
+
+		for _, ln := range left.lines {
+			out = append(out, padToWidth(clipLine(ln, innerW), innerW))
+		}
+		if left.cursor >= 0 {
+			cursorLine = start + left.cursor
+		}
+	}
+	return out, cursorLine
+}
+
+// detailInnerWidth is the content width the detail pane renders at, mirroring the
+// split renderBody does. Key handlers need it to know whether the Overview grid
+// is one column or two, since layout decides whether `left`/`right` mean anything.
+func (m *Model) detailInnerWidth() int {
+	w := m.width
+	if m.width >= narrowWidth {
+		leftW := m.width / 4
+		leftW = clamp(leftW, 28, 46)
+		if leftW > m.width-30 {
+			leftW = m.width - 30
+		}
+		w = m.width - leftW
+	}
+	innerW, _ := innerSize(paneStyle(true), w, m.height)
+	return innerW - 1 // the detail pane reserves a cell for the scrollbar
+}
+
+// ovCell names the grid cell a navigable row renders in. Only Domains and Toggles
+// share a grid row with nav rows on both sides, so they're the only pair `left`
+// and `right` can cross between.
+type ovCell int
+
+const (
+	ovCellNone ovCell = iota
+	ovCellDomains
+	ovCellToggles
+)
+
+// ovCellOf classifies a row into its grid cell.
+func ovCellOf(k detailKind) ovCell {
+	switch k {
+	case kindDomain, kindDomainAdd:
+		return ovCellDomains
+	case kindPHP, kindNode, kindHTTPS, kindLANShare:
+		return ovCellToggles
+	}
+	return ovCellNone
+}
+
+// hopDetailColumn moves the cursor across the Domains/Toggles grid row, keeping
+// its offset within the cell so `right` from the second domain lands on the
+// second toggle. Returns the new cursor, or the old one when there's nowhere to
+// hop: a one-column grid, or a row that isn't part of the pair.
+func hopDetailColumn(rows []detailRow, nav []int, cursor int, innerW int) int {
+	if overviewCols(innerW) == 1 || cursor < 0 || cursor >= len(nav) {
+		return cursor
+	}
+	from := ovCellOf(rows[nav[cursor]].kind)
+	if from == ovCellNone {
+		return cursor
+	}
+	to := ovCellToggles
+	if from == ovCellToggles {
+		to = ovCellDomains
+	}
+
+	offset, first, count := 0, -1, 0
+	for i, rowIdx := range nav {
+		switch ovCellOf(rows[rowIdx].kind) {
+		case from:
+			if i < cursor {
+				offset++
+			}
+		case to:
+			if first < 0 {
+				first = i
+			}
+			count++
+		}
+	}
+	if first < 0 {
+		return cursor
+	}
+	if offset >= count {
+		offset = count - 1
+	}
+	return first + offset
+}
+
+// columnize lays blocks side by side, splitting innerW evenly between them and
+// padding every row to the full width so the result spans the pane. Used inside a
+// full-width section that wants to subdivide, like the timing panel's
+// distribution / routes / recent trio.
+func columnize(blocks [][]string, innerW int) []string {
+	n := len(blocks)
+	if n == 0 {
+		return nil
+	}
+	colW := (innerW - overviewGutter*(n-1)) / n
+	h := 0
+	for _, b := range blocks {
+		if len(b) > h {
+			h = len(b)
+		}
+	}
+	out := make([]string, 0, h)
+	for i := 0; i < h; i++ {
+		row := ""
+		for j, b := range blocks {
+			cell := ""
+			if i < len(b) {
+				cell = b[i]
+			}
+			if j > 0 {
+				row += spaces(overviewGutter)
+			}
+			row += padToWidth(clipLine(cell, colW), colW)
+		}
+		out = append(out, padToWidth(row, innerW))
+	}
+	return out
+}
+
+// joinInfo packs the identity facts onto as few lines as the width allows, so a
+// wide pane doesn't spend five rows on one fact each.
+func joinInfo(parts []string, w int) []string {
+	var out []string
+	cur := ""
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		switch {
+		case cur == "":
+			cur = p
+		case ansi.StringWidth(cur)+ansi.StringWidth(p)+3 <= w:
+			cur += "   " + p
+		default:
+			out = append(out, cur)
+			cur = p
+		}
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}

--- a/internal/tui/overview_test.go
+++ b/internal/tui/overview_test.go
@@ -1,0 +1,191 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/siteinfo"
+)
+
+func gridSite() *siteinfo.EnrichedSite {
+	return &siteinfo.EnrichedSite{
+		Name: "alpha", PHPVersion: "8.3", NodeVersion: "22",
+		Domains:        []string{"alpha.test", "alt.test"},
+		Services:       []string{"mysql"},
+		HasQueueWorker: true,
+		Worktrees: []siteinfo.WorktreeInfo{
+			{Branch: "feat", Path: "/tmp/wt", PHPVersion: "8.3", NodeVersion: "22"},
+		},
+	}
+}
+
+// The cursor walks detailRows, so that order has to match the order the Overview
+// draws its sections. When they drifted apart, `down` from a worker teleported the
+// cursor to the Toggles block at the bottom of the pane, and `down` again threw it
+// backwards into Worktrees.
+func TestDetailRows_NavOrderMatchesRenderOrder(t *testing.T) {
+	rows := detailRows(gridSite())
+	nav := navigableRows(rows)
+
+	var got []detailKind
+	for _, i := range nav {
+		got = append(got, rows[i].kind)
+	}
+	want := []detailKind{
+		kindDomain, kindDomain, kindDomainAdd, // Domains
+		kindPHP, kindNode, kindHTTPS, kindLANShare, // Toggles
+		kindWorker,                      // Workers
+		kindWorktreeDB, kindWorktreeLAN, // Worktrees
+		kindWorktreePHP, kindWorktreeNode, //
+	}
+	if len(got) != len(want) {
+		t.Fatalf("nav order\n got %v\nwant %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("nav[%d] = %v, want %v\n got %v\nwant %v", i, got[i], want[i], got, want)
+		}
+	}
+}
+
+// The worktree header is a caption with no toggle, and it renders no cursor, so
+// leaving it navigable made the cursor vanish for one keypress as it passed by.
+func TestNavigableRows_SkipsTheWorktreeHeader(t *testing.T) {
+	rows := detailRows(gridSite())
+	for _, i := range navigableRows(rows) {
+		if rows[i].kind == kindWorktreeHeader {
+			t.Fatal("the worktree header should not be a cursor stop")
+		}
+	}
+}
+
+func TestOverviewCols_CollapsesBelowTheBreakpoint(t *testing.T) {
+	if got := overviewCols(2*overviewMinColWidth + overviewGutter); got != 2 {
+		t.Errorf("a pane exactly wide enough for two columns should use them, got %d", got)
+	}
+	if got := overviewCols(2*overviewMinColWidth + overviewGutter - 1); got != 1 {
+		t.Errorf("one cell short of the breakpoint should collapse to one column, got %d", got)
+	}
+	if got := overviewColWidth(60); got != 60 {
+		t.Errorf("a collapsed grid builds sections at the full pane width, got %d", got)
+	}
+}
+
+func TestComposeOverview_PairsHalvesAndTracksTheCursor(t *testing.T) {
+	left := ovSection{lines: []string{"L0", "L1", "L2"}, span: ovHalf, cursor: 2}
+	right := ovSection{lines: []string{"R0"}, span: ovHalf, cursor: -1}
+	full := ovSection{lines: []string{"F0"}, span: ovFull, cursor: -1}
+
+	out, cursor := composeOverview([]ovSection{left, right, full}, 100)
+	if len(out) != 4 {
+		t.Fatalf("two paired sections plus a full one should be 4 rows, got %d:\n%v", len(out), out)
+	}
+	if !strings.Contains(out[0], "L0") || !strings.Contains(out[0], "R0") {
+		t.Errorf("paired sections should share a row, got %q", out[0])
+	}
+	// The taller section keeps its rows; the shorter one just runs out.
+	if !strings.Contains(out[2], "L2") {
+		t.Errorf("the taller section should keep its remaining rows, got %q", out[2])
+	}
+	if cursor != 2 {
+		t.Errorf("the cursor line should be offset into the composed block, got %d", cursor)
+	}
+	for i, ln := range out {
+		if lipglossWidth(ln) != 100 {
+			t.Errorf("row %d should span the pane, got width %d", i, lipglossWidth(ln))
+		}
+	}
+}
+
+func TestComposeOverview_NarrowStacksEverything(t *testing.T) {
+	a := ovSection{lines: []string{"A"}, span: ovHalf, cursor: -1}
+	b := ovSection{lines: []string{"B"}, span: ovHalf, cursor: -1}
+
+	out, _ := composeOverview([]ovSection{a, b}, 40) // below the breakpoint
+	if len(out) != 2 {
+		t.Fatalf("a collapsed grid stacks its sections, got %d rows:\n%v", len(out), out)
+	}
+	if strings.Contains(out[0], "B") {
+		t.Errorf("a collapsed grid must not pair sections, got %q", out[0])
+	}
+}
+
+func TestHopDetailColumn_CrossesBetweenDomainsAndToggles(t *testing.T) {
+	rows := detailRows(gridSite())
+	nav := navigableRows(rows)
+	wide := 2*overviewMinColWidth + overviewGutter
+
+	// From the first domain, right lands on the first toggle.
+	got := hopDetailColumn(rows, nav, 0, wide)
+	if rows[nav[got]].kind != kindPHP {
+		t.Fatalf("right from the first domain should reach the first toggle, got %v", rows[nav[got]].kind)
+	}
+	// The offset within the cell carries across, so the second domain reaches the
+	// second toggle and back again.
+	got = hopDetailColumn(rows, nav, 1, wide)
+	if rows[nav[got]].kind != kindNode {
+		t.Fatalf("the offset within the cell should carry across, got %v", rows[nav[got]].kind)
+	}
+	if back := hopDetailColumn(rows, nav, got, wide); back != 1 {
+		t.Fatalf("hopping back should return to where it came from, got %d", back)
+	}
+}
+
+func TestHopDetailColumn_ClampsAndNoOps(t *testing.T) {
+	rows := detailRows(gridSite())
+	nav := navigableRows(rows)
+	wide := 2*overviewMinColWidth + overviewGutter
+
+	// Domains has 3 rows, Toggles has 4: hopping from the last domain clamps into
+	// the toggles rather than running off the end.
+	got := hopDetailColumn(rows, nav, 2, wide)
+	if k := rows[nav[got]].kind; k != kindHTTPS {
+		t.Fatalf("the third domain should clamp onto the third toggle, got %v", k)
+	}
+
+	// A worker isn't part of the paired grid row, so there's nowhere to hop.
+	worker := -1
+	for i, idx := range nav {
+		if rows[idx].kind == kindWorker {
+			worker = i
+			break
+		}
+	}
+	if got := hopDetailColumn(rows, nav, worker, wide); got != worker {
+		t.Errorf("a row outside the pair should not move, got %d want %d", got, worker)
+	}
+
+	// A one-column grid has no second column to reach.
+	if got := hopDetailColumn(rows, nav, 0, 50); got != 0 {
+		t.Errorf("a collapsed grid should not hop, got %d", got)
+	}
+}
+
+func TestJoinInfo_PacksFactsUntilTheyStopFitting(t *testing.T) {
+	got := joinInfo([]string{"aaa", "bbb", "ccc"}, 100)
+	if len(got) != 1 {
+		t.Fatalf("facts that fit should share one line, got %v", got)
+	}
+	got = joinInfo([]string{"aaa", "bbb", "ccc"}, 8)
+	if len(got) < 2 {
+		t.Fatalf("facts that don't fit should wrap, got %v", got)
+	}
+	if len(joinInfo([]string{"", ""}, 40)) != 0 {
+		t.Error("empty facts should produce no lines")
+	}
+}
+
+func TestTimingCols_DropsAColumnRatherThanStarveTheBlocks(t *testing.T) {
+	if got := timingCols(3*timingMinBlockWidth + 2*overviewGutter); got != 3 {
+		t.Errorf("a pane wide enough for three blocks should use three, got %d", got)
+	}
+	if got := timingCols(2*timingMinBlockWidth + overviewGutter); got != 2 {
+		t.Errorf("expected two columns at the two-block width, got %d", got)
+	}
+	if got := timingCols(40); got != 1 {
+		t.Errorf("a narrow pane stacks the blocks, got %d", got)
+	}
+}
+
+// lipglossWidth is the display width of a rendered row.
+func lipglossWidth(s string) int { return len([]rune(stripANSI(s))) }

--- a/internal/tui/timing.go
+++ b/internal/tui/timing.go
@@ -31,6 +31,10 @@ const (
 	timingRecentLimit  = 6
 	timingRouteLimit   = 5
 	timingBarWidth     = 18
+	// timingMinBlockWidth is the narrowest a side-by-side block can get and still
+	// show a route or a URI worth reading next to its figures. Below it the panel
+	// drops a column rather than truncating every row to a stub.
+	timingMinBlockWidth = 38
 )
 
 // timingScope is one entry in the branch cycle. key is the reqstats identity the
@@ -200,44 +204,61 @@ func timingSectionLines(m *Model, site *siteinfo.EnrichedSite, innerW int) []str
 	if a.ColdStarts > 0 {
 		line += fmt.Sprintf(" · %d cold", a.ColdStarts)
 	}
-	add(line)
-	add("  " + statusMix(a.Status))
+	add(line + "     " + statusMix(a.Status))
 	add("")
 
-	add("  " + sectionStyle.Render("Response times"))
-	for _, row := range distributionRows(a.Distribution) {
-		add(row)
-	}
-	add("")
+	// The three blocks sit side by side when the pane can carry them, which is
+	// what turns the panel from twenty rows into nine.
+	blocks := [][]string{}
+	cols := timingCols(innerW)
+	blockW := (innerW - overviewGutter*(cols-1)) / cols
 
-	if routes := topRoutes(a.Routes); len(routes) > 0 {
-		add("  " + sectionStyle.Render("Slowest routes"))
-		for _, r := range routes {
-			// Route already carries the method ("GET /products/:id"), so it isn't
-			// repeated as its own column.
-			add(fmt.Sprintf("    %-44s %8s  %4d×",
-				clipLine(r.Route, 44), ms(r.RecentP95Millis), r.Samples))
-		}
-		add("")
+	blocks = append(blocks, distributionBlock(a.Distribution, blockW))
+	if r := routesBlock(a.Routes, blockW); len(r) > 0 {
+		blocks = append(blocks, r)
+	}
+	if r := recentBlock(m.timingRecent, blockW); len(r) > 0 {
+		blocks = append(blocks, r)
 	}
 
-	if len(m.timingRecent) > 0 {
-		add("  " + sectionStyle.Render("Recent"))
-		for _, r := range m.timingRecent {
-			uri := r.URI
-			if uri == "" {
-				uri = r.Route
+	if cols == 1 {
+		for _, b := range blocks {
+			for _, ln := range b {
+				add(ln)
 			}
-			add(fmt.Sprintf("    %s  %-6s %s %-30s %8s",
-				r.At.Format("15:04:05"), r.Method, statusGlyph(r.Status), clipLine(uri, 30), ms(r.Millis)))
+			add("")
 		}
+		return out
+	}
+	// Pack the blocks into rows of at most cols, so a two-column pane stacks the
+	// third block beneath the first two rather than shredding all three.
+	for i := 0; i < len(blocks); i += cols {
+		end := i + cols
+		if end > len(blocks) {
+			end = len(blocks)
+		}
+		out = append(out, columnize(blocks[i:end], innerW)...)
+		add("")
 	}
 	return out
 }
 
-// distributionRows renders the latency histogram as one bar per bucket, scaled
-// against the busiest bucket so the shape reads at any request volume.
-func distributionRows(buckets []reqstats.LatencyBucket) []string {
+// timingCols is how many of the panel's blocks fit side by side. Each needs room
+// for a label, a bar or a route, and a figure.
+func timingCols(innerW int) int {
+	switch {
+	case innerW >= 3*timingMinBlockWidth+2*overviewGutter:
+		return 3
+	case innerW >= 2*timingMinBlockWidth+overviewGutter:
+		return 2
+	}
+	return 1
+}
+
+// distributionBlock renders the latency histogram, scaling the bars against both
+// the busiest bucket and the width on offer.
+func distributionBlock(buckets []reqstats.LatencyBucket, w int) []string {
+	out := []string{"  " + sectionStyle.Render("Response times")}
 	peak := 0
 	for _, b := range buckets {
 		if b.Count > peak {
@@ -245,22 +266,74 @@ func distributionRows(buckets []reqstats.LatencyBucket) []string {
 		}
 	}
 	if peak == 0 {
-		return nil
+		return append(out, dimStyle.Render("    (no timed requests)"))
 	}
-	rows := make([]string, 0, len(buckets))
+	// Label and count take a fixed slice; the bar gets whatever's left.
+	barW := w - 18
+	if barW < 4 {
+		barW = 4
+	}
+	if barW > timingBarWidth {
+		barW = timingBarWidth
+	}
 	for _, b := range buckets {
 		label := "≥1s"
 		if b.UpperMillis > 0 {
 			label = bucketLabel(b.UpperMillis)
 		}
-		width := b.Count * timingBarWidth / peak
+		width := b.Count * barW / peak
 		bar := strings.Repeat("▇", width)
 		if b.Count > 0 && width == 0 {
 			bar = "▏" // a bucket with traffic never renders as empty
 		}
-		rows = append(rows, fmt.Sprintf("    %-8s %-*s %4d", label, timingBarWidth, bar, b.Count))
+		out = append(out, fmt.Sprintf("    %-7s %-*s %4d", label, barW, bar, b.Count))
 	}
-	return rows
+	return out
+}
+
+// routesBlock ranks by recent p95, the same recency-aware figure the web UI sorts
+// on, so a route that's been fixed drops off as newer, faster samples arrive.
+func routesBlock(routes []reqstats.RouteStat, w int) []string {
+	top := topRoutes(routes)
+	if len(top) == 0 {
+		return nil
+	}
+	out := []string{"  " + sectionStyle.Render("Slowest routes")}
+	// Route already carries the method ("GET /products/:id"), so it isn't repeated.
+	// The row is 4 indent + name + 1 + 8 (time) + 1 + 4 + 1 ("×"), so the name gets
+	// what's left of w after those 19 cells.
+	nameW := w - 19
+	if nameW < 10 {
+		nameW = 10
+	}
+	for _, r := range top {
+		out = append(out, fmt.Sprintf("    %-*s %8s %4d×",
+			nameW, clipLine(r.Route, nameW), ms(r.RecentP95Millis), r.Samples))
+	}
+	return out
+}
+
+// recentBlock is the tail of requests as they arrived, newest first.
+func recentBlock(recent []reqstats.Record, w int) []string {
+	if len(recent) == 0 {
+		return nil
+	}
+	out := []string{"  " + sectionStyle.Render("Recent")}
+	// 4 indent + 8 (clock) + 1 + 4 (method) + 1 + 3 (status) + 1 + uri + 1 + 8 (time).
+	uriW := w - 31
+	if uriW < 8 {
+		uriW = 8
+	}
+	for _, r := range recent {
+		uri := r.URI
+		if uri == "" {
+			uri = r.Route
+		}
+		out = append(out, fmt.Sprintf("    %s %-4s %s %-*s %8s",
+			r.At.Format("15:04:05"), r.Method, statusGlyph(r.Status),
+			uriW, clipLine(uri, uriW), ms(r.Millis)))
+	}
+	return out
 }
 
 // topRoutes ranks by recent p95, the same recency-aware figure the web UI sorts


### PR DESCRIPTION
The site Overview rendered as one long column in a detail pane far wider than its content. At 150 columns the pane was about 111 wide while the widest line was 65, so roughly 40 percent of the horizontal space sat empty, and the content still ran 58 rows deep, which meant scrolling past domains, services and workers to reach the request timing at the bottom. It managed to be too tall and too narrow at once.

Sections now declare whether they want the whole pane or half of it, and half-width sections pair up: Domains sits beside Toggles, Services beside Workers. The identity header, worktrees and request timing keep the full width, and the timing panel subdivides internally into its distribution, slowest-routes and recent columns. The same site now comes in at roughly half the height.

A column has a floor of 44 characters. When the pane cannot give two columns that much, every section goes full width and the grid collapses to the single column it has always been, so a narrow terminal loses nothing. The timing panel follows the same rule, dropping from three blocks to two to one rather than truncating every row to a stub.

Cursor movement walks detailRows, and that order had drifted away from the order the Overview draws. Pressing down from a worker jumped the cursor to the Toggles block at the foot of the pane, and pressing down again threw it backwards into the worktrees above. The worktree header was navigable as well, despite being a caption that draws no cursor, so the cursor vanished entirely for a keypress as it passed through. Both are gone: the rows are emitted in the order they render, and the header is no longer a stop.

Left and right now cross between the two columns of a grid row, holding the cursor's offset within the section, while up and down walk a single column as before.

Closes #869