### PR TITLE
fix: give worktree vhosts the parent framework's config

### DIFF
--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -60,7 +60,7 @@ Whether you use `lerd worktree add` or the bare `git` command, the daemon's watc
 2. Seed `vendor/` and `node_modules/` from the main repo when the worktree's `composer.lock` / JS lockfile matches main's, using reflinks where the filesystem supports them (btrfs, xfs-reflink, APFS) and a plain copy elsewhere.
 3. Sync `.env` from main with `APP_URL` rewritten to the worktree's vhost domain. When `.lerd.yaml` defines `env_overrides`, those templates are resolved instead (see [env overrides](#env-overrides) below).
 4. Run `composer install` (skipped when the marker is at-or-newer than `composer.lock`) and `npm ci` / `pnpm install --frozen-lockfile` / `yarn install --immutable` / `bun install --frozen-lockfile` (skipped under the same marker rule).
-5. Generate the worktree's nginx vhost.
+5. Generate the worktree's nginx vhost. It inherits the parent site's framework, so the document root follows the framework's `public_dir` (`pub` for Magento, `web` for Drupal, `webroot` for CakePHP) rather than assuming `public`, and any [nginx snippet](../usage/framework-definitions.md#framework-nginx-config) the framework declares is spliced in, expanded against the worktree's own checkout.
 
 Frontend build (`npm run build`) is **not** part of the watcher pipeline — it's heavy, project-specific, and can fail silently. `lerd worktree add` runs it interactively after asking; using bare `git worktree add` you run it yourself.
 

--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -264,6 +264,8 @@ Three placeholders are expanded before the config is written:
 
 A snippet that passes requests to PHP should assign `{{fpm}}` to a variable first, `set $myfpm "{{fpm}}";` then `fastcgi_pass $myfpm:9000;`, exactly as the generated vhost does. nginx resolves a literal upstream name once when the config loads and caches it for the life of the process, so a container that comes back on a new address is never picked up.
 
+A git worktree of the site gets the same block, expanded against its own checkout: `{{root}}` and `{{public}}` point at the worktree's directory, not the parent's, so a branch serves its own `setup/`, `/static/` and `/media/` paths.
+
 The snippet must have balanced braces, since an unbalanced one would close the enclosing `server` block and start declaring its own. Balance alone is not enough, because a `}` followed by a `server {` still balances, so the values substituted into the placeholders are rejected too if they contain `{`, `}`, `;`, `#`, or a newline. A snippet failing either check is dropped and the site renders without it, rather than risking an nginx config that fails to load for every site.
 
 Snippets are only honoured from the framework store and from user-defined definitions: an embedded `framework_def` in a project's `.lerd.yaml` is untrusted input, so its `nginx` block is stripped, the same way its host workers and command-type doctor checks are.

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -556,14 +556,28 @@ func GenerateWorktreeVhostFor(domain, path, phpVersion, parentDomain, siteName, 
 	return GenerateWorktreeVhost(domain, path, phpVersion, siteName, branch)
 }
 
-// worktreeFPMContainer resolves the FPM container a worktree vhost points at:
-// the parent site's per-site container for custom-FPM sites, otherwise the
-// shared lerd-php<ver>-fpm.
-func worktreeFPMContainer(siteName, phpVersion string) string {
-	if site, _ := config.FindSite(siteName); site != nil {
-		return podman.FPMContainerName(*site, phpVersion)
+// worktreeSite rebases the parent site onto the worktree checkout: same
+// framework and public_dir, but rooted at the worktree's path and domain, so
+// everything derived from it (document root, framework nginx block) resolves
+// against the branch's own files. An unregistered parent yields a bare site,
+// which falls back to the shared FPM container and a "public" root.
+func worktreeSite(domain, path, siteName string) config.Site {
+	site := config.Site{Name: siteName, Domains: []string{domain}, Path: path}
+	if parent, _ := config.FindSite(siteName); parent != nil {
+		site = *parent
+		site.Path = path
+		site.Domains = []string{domain}
 	}
-	return "lerd-php" + phpShort(phpVersion) + "-fpm"
+	return site
+}
+
+// worktreeVhostConfig resolves the framework-dependent parts of a worktree
+// vhost, the same three the main-site generators resolve for the parent.
+func worktreeVhostConfig(domain, path, phpVersion, siteName string) (publicDir, fpmContainer, frameworkNginx string) {
+	site := worktreeSite(domain, path, siteName)
+	publicDir = resolvePublicDir(site)
+	fpmContainer = podman.FPMContainerName(site, phpVersion)
+	return publicDir, fpmContainer, resolveFrameworkNginx(site, publicDir, fpmContainer)
 }
 
 // GenerateWorktreeVhost renders the HTTP vhost template for a worktree checkout
@@ -579,18 +593,20 @@ func GenerateWorktreeVhost(domain, path, phpVersion, siteName, branch string) er
 		return err
 	}
 
+	publicDir, fpmContainer, frameworkNginx := worktreeVhostConfig(domain, path, phpVersion, siteName)
 	data := VhostData{
 		Domain:          domain,
 		ServerNames:     domain + " *." + domain,
 		Path:            path,
 		PHPVersion:      phpVersion,
 		PHPVersionShort: phpShort(phpVersion),
-		FPMContainer:    worktreeFPMContainer(siteName, phpVersion),
-		PublicDir:       "public",
+		FPMContainer:    fpmContainer,
+		PublicDir:       publicDir,
 		LerdSite:        siteName,
 		LerdBranch:      branch,
 		Profiling:       profilerEnabled(),
 		RequestTimeout:  resolveRequestTimeout(path),
+		FrameworkNginx:  frameworkNginx,
 	}
 
 	var buf bytes.Buffer
@@ -619,19 +635,21 @@ func GenerateWorktreeSSLVhost(domain, path, phpVersion, parentDomain, siteName, 
 		return err
 	}
 
+	publicDir, fpmContainer, frameworkNginx := worktreeVhostConfig(domain, path, phpVersion, siteName)
 	data := VhostData{
 		Domain:          domain,
 		ServerNames:     domain + " *." + domain,
 		Path:            path,
 		PHPVersion:      phpVersion,
 		PHPVersionShort: phpShort(phpVersion),
-		FPMContainer:    worktreeFPMContainer(siteName, phpVersion),
+		FPMContainer:    fpmContainer,
 		CertDomain:      parentDomain,
-		PublicDir:       "public",
+		PublicDir:       publicDir,
 		LerdSite:        siteName,
 		LerdBranch:      branch,
 		Profiling:       profilerEnabled(),
 		RequestTimeout:  resolveRequestTimeout(path),
+		FrameworkNginx:  frameworkNginx,
 	}
 
 	var buf bytes.Buffer

--- a/internal/nginx/worktree_vhost_test.go
+++ b/internal/nginx/worktree_vhost_test.go
@@ -1,0 +1,175 @@
+package nginx
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupWorktreeEnv registers a parent site whose framework serves from a
+// non-default public dir and declares an nginx block, then returns the parent
+// and worktree checkout paths. The worktree lives beside the parent, the way
+// `lerd worktree add` creates it.
+func setupWorktreeEnv(t *testing.T, sitePublicDir string) (parentPath, worktreePath string) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	parentPath = filepath.Join(tmp, "shop")
+	worktreePath = filepath.Join(tmp, "shop-feature")
+	for _, p := range []string{parentPath, worktreePath} {
+		if err := os.MkdirAll(filepath.Join(p, "pub"), 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+
+	store := filepath.Join(tmp, "lerd", "frameworks")
+	if err := os.MkdirAll(store, 0755); err != nil {
+		t.Fatalf("mkdir store: %v", err)
+	}
+	fw := `name: magento
+label: Magento
+public_dir: pub
+nginx:
+  snippet: |
+    location ~* ^/(setup|update)($|/) {
+        root {{root}};
+        fastcgi_pass {{fpm}}:9000;
+    }
+`
+	if err := os.WriteFile(filepath.Join(store, "magento.yaml"), []byte(fw), 0644); err != nil {
+		t.Fatalf("write framework: %v", err)
+	}
+
+	publicDir := ""
+	if sitePublicDir != "" {
+		publicDir = "\n  public_dir: " + sitePublicDir
+	}
+	sites := `sites:
+- name: shop
+  domains:
+    - shop.test
+  path: ` + parentPath + `
+  php_version: "8.4"
+  framework: magento` + publicDir + "\n"
+
+	lerdDir := filepath.Join(tmp, "lerd")
+	if err := os.MkdirAll(lerdDir, 0755); err != nil {
+		t.Fatalf("mkdir lerd: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(lerdDir, "sites.yaml"), []byte(sites), 0644); err != nil {
+		t.Fatalf("write sites.yaml: %v", err)
+	}
+	return parentPath, worktreePath
+}
+
+func readWorktreeConf(t *testing.T, domain string) string {
+	t.Helper()
+	conf := filepath.Join(os.Getenv("XDG_DATA_HOME"), "lerd", "nginx", "conf.d", domain+".conf")
+	b, err := os.ReadFile(conf)
+	if err != nil {
+		t.Fatalf("read %s: %v", conf, err)
+	}
+	return string(b)
+}
+
+// A worktree of a site whose framework serves from "pub" must not get a
+// document root of "public": nothing lives there, so every request 404s.
+func TestGenerateWorktreeVhostUsesFrameworkPublicDir(t *testing.T) {
+	_, wt := setupWorktreeEnv(t, "")
+
+	if err := GenerateWorktreeVhost("feature.shop.test", wt, "8.4", "shop", "feature"); err != nil {
+		t.Fatalf("GenerateWorktreeVhost: %v", err)
+	}
+	out := readWorktreeConf(t, "feature.shop.test")
+
+	if want := "root " + wt + "/pub;"; !strings.Contains(out, want) {
+		t.Errorf("missing %q in:\n%s", want, out)
+	}
+	if bad := "root " + wt + "/public;"; strings.Contains(out, bad) {
+		t.Errorf("worktree rooted at the hardcoded public dir:\n%s", out)
+	}
+}
+
+// The framework's nginx block must reach the worktree vhost too, expanded
+// against the worktree's own checkout rather than the parent's.
+func TestGenerateWorktreeVhostRendersFrameworkNginx(t *testing.T) {
+	parent, wt := setupWorktreeEnv(t, "")
+
+	if err := GenerateWorktreeVhost("feature.shop.test", wt, "8.4", "shop", "feature"); err != nil {
+		t.Fatalf("GenerateWorktreeVhost: %v", err)
+	}
+	out := readWorktreeConf(t, "feature.shop.test")
+
+	if !strings.Contains(out, `location ~* ^/(setup|update)($|/) {`) {
+		t.Fatalf("framework snippet missing from worktree vhost:\n%s", out)
+	}
+	if want := "root " + wt + ";"; !strings.Contains(out, want) {
+		t.Errorf("snippet {{root}} should expand to the worktree, want %q in:\n%s", want, out)
+	}
+	if bad := "root " + parent + ";"; strings.Contains(out, bad) {
+		t.Errorf("snippet {{root}} expanded to the parent checkout:\n%s", out)
+	}
+	if !strings.Contains(out, "fastcgi_pass lerd-php84-fpm:9000;") {
+		t.Errorf("snippet {{fpm}} unexpanded in:\n%s", out)
+	}
+}
+
+// The SSL path renders from a different template and generator, so it needs the
+// same coverage: a secured worktree must not lose the root or the snippet.
+func TestGenerateWorktreeSSLVhostUsesFrameworkConfig(t *testing.T) {
+	_, wt := setupWorktreeEnv(t, "")
+
+	if err := GenerateWorktreeSSLVhost("feature.shop.test", wt, "8.4", "shop.test", "shop", "feature"); err != nil {
+		t.Fatalf("GenerateWorktreeSSLVhost: %v", err)
+	}
+	out := readWorktreeConf(t, "feature.shop.test")
+
+	if want := "root " + wt + "/pub;"; !strings.Contains(out, want) {
+		t.Errorf("missing %q in:\n%s", want, out)
+	}
+	if !strings.Contains(out, `location ~* ^/(setup|update)($|/) {`) {
+		t.Errorf("framework snippet missing from SSL worktree vhost:\n%s", out)
+	}
+	if !strings.Contains(out, "ssl_certificate") {
+		t.Errorf("not an SSL vhost:\n%s", out)
+	}
+}
+
+// A site-level public_dir (from .lerd.yaml) outranks the framework's, on the
+// worktree exactly as it does on the parent.
+func TestGenerateWorktreeVhostHonoursSitePublicDir(t *testing.T) {
+	_, wt := setupWorktreeEnv(t, "web")
+
+	if err := GenerateWorktreeVhost("feature.shop.test", wt, "8.4", "shop", "feature"); err != nil {
+		t.Fatalf("GenerateWorktreeVhost: %v", err)
+	}
+	out := readWorktreeConf(t, "feature.shop.test")
+
+	if want := "root " + wt + "/web;"; !strings.Contains(out, want) {
+		t.Errorf("missing %q in:\n%s", want, out)
+	}
+}
+
+// An unregistered parent (a worktree scanned before its site lands in the
+// registry) keeps the old behaviour rather than erroring: public root, no block.
+func TestGenerateWorktreeVhostUnknownParentFallsBack(t *testing.T) {
+	_, wt := setupWorktreeEnv(t, "")
+
+	if err := GenerateWorktreeVhost("feature.ghost.test", wt, "8.4", "ghost", "feature"); err != nil {
+		t.Fatalf("GenerateWorktreeVhost: %v", err)
+	}
+	out := readWorktreeConf(t, "feature.ghost.test")
+
+	if want := "root " + wt + "/public;"; !strings.Contains(out, want) {
+		t.Errorf("missing fallback %q in:\n%s", want, out)
+	}
+	if strings.Contains(out, "^/(setup|update)") {
+		t.Errorf("unknown parent should carry no framework block:\n%s", out)
+	}
+	if !strings.Contains(out, "fastcgi_pass $fpm:9000;") {
+		t.Errorf("missing shared FPM pass in:\n%s", out)
+	}
+}


### PR DESCRIPTION
A worktree vhost was rendered with its document root hardcoded to `public` and without the framework's nginx block. Any site whose framework serves from somewhere else, Magento's `pub`, Drupal's `web`, CakePHP's `webroot` or WordPress's project root, answered every request into the worktree with a 404, since nothing lives at that root. A Magento worktree additionally lost the `setup`, `/static/` and `/media/` handling its definition declares, so an uninstalled store would redirect to `/setup/` forever and developer-mode assets would never resolve.

The main site generators already resolve both of these, the document root through `resolvePublicDir` and the framework block through `resolveFrameworkNginx`. The worktree generators simply did not. They now rebase the parent site onto the worktree checkout, same framework and public_dir but rooted at the branch's path and domain, and run it through those same resolvers. The snippet's `{{root}}` and `{{public}}` therefore expand against the worktree's own files rather than the parent's. An unregistered parent keeps the old behaviour, a `public` root and no snippet, so a worktree scanned before its site lands in the registry does not error.

Every caller reaches these through `GenerateWorktreeVhostFor`, so the scan, sync and migrate paths are all covered.

The public dir half has been broken since the framework definitions landed, affecting Drupal, CakePHP and WordPress worktrees; Magento is just the first framework to also want an nginx block, which is what made it visible.

Worth knowing before this closes out Magento: a Magento worktree still cannot boot after this, because the worktree env sync hardcodes `.env` and never seeds `app/etc/env.php`. That is #877.

Refs #874
Refs #875