### PR TITLE
fix(ci): publish base image manifests per version so installs pull instead of building

### DIFF
--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -140,6 +140,11 @@ jobs:
     name: Manifest PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     needs: build
+    # Run per version even when a sibling build cell failed: a single arch/version
+    # failure must not skip manifest creation for every other version, or the
+    # pullable multi-arch tag never publishes and every install falls back to a
+    # slow from-source build. fail-fast:false keeps the versions independent.
+    if: ${{ !cancelled() }}
     permissions:
       packages: write
     strategy:
@@ -175,6 +180,19 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify both arch images exist
+        run: |
+          BASE="ghcr.io/lerd-env/lerd-php${{ steps.tag.outputs.php_short }}-fpm-base"
+          TAG="${{ steps.tag.outputs.tag }}"
+          MISSING=""
+          for a in amd64 arm64; do
+            docker manifest inspect "${BASE}:${TAG}-${a}" > /dev/null 2>&1 || MISSING="$MISSING ${a}"
+          done
+          if [ -n "$MISSING" ]; then
+            echo "::error::PHP ${{ matrix.php }} base build did not publish:$MISSING; manifest not created (this version will build from source on install until it is rebuilt)"
+            exit 1
+          fi
 
       - name: Check if manifest already exists
         id: check


### PR DESCRIPTION
The base-images manifest job ran only when the entire build matrix succeeded, so a single arch or version failure skipped manifest creation for all seven PHP versions. The manifest job publishes the arch-less tag that lerd pulls at install time, so with it skipped there was no prebuilt base for the current Containerfile hash and every install fell back to a slow from-source build.

The manifest job now runs per version regardless of a sibling cell's outcome, and verifies both arch images exist before assembling the manifest so a version missing an arch fails its own cell with a clear message instead of quietly leaving the pull tag unpublished. Merging this republishes the manifests for the versions whose arch builds already succeeded.

Closes #879