### PR TITLE
fix: probe rustfs readiness on its published host port

### DIFF
--- a/internal/config/service_manual.go
+++ b/internal/config/service_manual.go
@@ -116,6 +116,18 @@ func ServicePublishedPort(name string) int {
 	return 0
 }
 
+// ServiceConfigFor returns the global config entry for a service (its ports,
+// image pin and enabled flag), or the zero ServiceConfig when the service isn't
+// configured. Callers that need the effective host ports read HostPorts() off it
+// so the preset default and any override resolve from the one registry.
+func ServiceConfigFor(name string) ServiceConfig {
+	cfg, err := LoadGlobal()
+	if err != nil {
+		return ServiceConfig{}
+	}
+	return cfg.Services[name]
+}
+
 // ServicePublishedPorts returns the per-container-port host overrides for a
 // service's secondary mappings (nil when none). The primary override lives in
 // ServicePublishedPort; these cover the extra ports a multi-port service exposes.

--- a/internal/podman/quadlet.go
+++ b/internal/podman/quadlet.go
@@ -340,6 +340,22 @@ var mariadbReadyArgs = []string{"mariadb-admin", "ping", "-h127.0.0.1", "-P3306"
 // catastrophic failures for the bare-name presets — versioned ones
 // fall through to the systemd-active probe which can report "active"
 // for a few seconds even when the container is crashlooping.
+// rustfsProbeAddr is the host address WaitReady dials to test rustfs readiness.
+// rustfs is probed over TCP from the host rather than via podman exec (the image
+// ships no shell), so the probe must follow the port rustfs is actually published
+// on. HostPorts() is the registry's effective primary: the PublishedPort override
+// the port-ownership guard sets when a host server owns 9000, else the preset
+// default seeded into Port. Without this the dial targets a port nothing is on and
+// WaitReady burns its full timeout on every php/composer call. Empty (rustfs not
+// configured, so not something WaitReady is starting) resolves to nothing to dial.
+func rustfsProbeAddr(svc config.ServiceConfig) string {
+	hp := svc.HostPorts()
+	if len(hp) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("localhost:%d", hp[0])
+}
+
 func readyFamily(service string) string {
 	for _, fam := range []string{"mariadb", "mysql", "postgres", "redis", "rustfs"} {
 		if service == fam || strings.HasPrefix(service, fam+"-") {
@@ -384,8 +400,12 @@ func WaitReady(service string, timeout time.Duration) error {
 			return cmd.Run() == nil
 		}
 	case "rustfs":
+		addr := rustfsProbeAddr(config.ServiceConfigFor(service))
 		probe = func() bool {
-			conn, err := net.DialTimeout("tcp", "localhost:9000", time.Second)
+			if addr == "" {
+				return false
+			}
+			conn, err := net.DialTimeout("tcp", addr, time.Second)
 			if err != nil {
 				return false
 			}

--- a/internal/podman/quadlet_waitready_test.go
+++ b/internal/podman/quadlet_waitready_test.go
@@ -3,6 +3,8 @@ package podman
 import (
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 func TestMySQLReadinessProbeForcesTCP(t *testing.T) {
@@ -35,6 +37,24 @@ func TestMariaDBReadinessProbeUsesMariaDBAdmin(t *testing.T) {
 	}
 	if !strings.Contains(joined, "-h127.0.0.1") {
 		t.Errorf("mariadb readiness probe must force TCP via -h127.0.0.1, got: %s", joined)
+	}
+}
+
+func TestRustFSProbeAddrFollowsPublishedPort(t *testing.T) {
+	// rustfs is the one service probed by a host-side TCP dial rather than an
+	// in-container exec, so its probe must target the port rustfs is actually
+	// published on, read from the registry's effective host port. When the
+	// port-ownership guard or `lerd service port` moves rustfs off 9000 (a host
+	// server owns it), a dial to a hardcoded 9000 never connects and WaitReady
+	// burns its full timeout on every php/composer call.
+	if got := rustfsProbeAddr(config.ServiceConfig{Port: 9000}); got != "localhost:9000" {
+		t.Errorf("preset default: rustfsProbeAddr = %q, want localhost:9000", got)
+	}
+	if got := rustfsProbeAddr(config.ServiceConfig{Port: 9000, PublishedPort: 9002}); got != "localhost:9002" {
+		t.Errorf("moved published port: rustfsProbeAddr = %q, want localhost:9002", got)
+	}
+	if got := rustfsProbeAddr(config.ServiceConfig{}); got != "" {
+		t.Errorf("unconfigured: rustfsProbeAddr = %q, want empty (nothing to dial)", got)
 	}
 }
 


### PR DESCRIPTION
rustfs is the one service WaitReady tests by dialing the S3 API over TCP from the host rather than by an in container exec, because the image ships no shell. That dial targeted a hardcoded localhost:9000, so once the port ownership guard shifted rustfs off 9000 to avoid a host server already sitting on it, or the port was moved with lerd service port, the probe connected to nothing and ran out its full timeout on every php and composer call. The command proceeded anyway, so the only visible symptom was a thirty second stall and a warning that read like a rustfs health problem when rustfs was actually fine.

It also broke the site doctor panel. The per check timeout is shorter than the readiness wait, so the migrations, composer dependencies and composer audit checks were cancelled mid probe and fell back to the generic could not run message, while the filesystem based checks passed.

The probe now reads the effective primary host port from the service registry, which already carries the preset default in Port and any override in PublishedPort, and dials that instead of assuming 9000.

Refs #881