### PR TITLE
fix(cli): resolve env and db framework defs through the store

### DIFF
--- a/docs/getting-started/symfony.md
+++ b/docs/getting-started/symfony.md
@@ -27,8 +27,8 @@ public_dir: public
 create: composer create-project symfony/skeleton
 console: bin/console
 env:
-  file: .env
-  example_file: .env.dist
+  file: .env.local
+  example_file: .env
   format: dotenv
   url_key: DEFAULT_URI
   services:
@@ -197,7 +197,7 @@ App logs (anything in `var/log/*.log`) show up in the [Web UI](../features/web-u
 | `lerd framework add symfony` | Registered the YAML so Symfony projects are auto-detected |
 | `lerd link` | Assigned `myapp.test`, set document root to `public/` |
 | `lerd init` | Wrote `.lerd.yaml` with PHP, Node, MySQL, Mailpit, messenger |
-| `lerd env` (via setup) | Wrote `DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/myapp?serverVersion=8.0` and `MAILER_DSN=smtp://lerd-mailpit:1025` into `.env` |
+| `lerd env` (via setup) | Wrote `DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/myapp?serverVersion=8.0` and `MAILER_DSN=smtp://lerd-mailpit:1025` into `.env.local`, seeded from the committed `.env` |
 | `lerd secure` (via setup) | Issued mkcert cert, set `DEFAULT_URI=https://myapp.test` |
 | Doctrine migrations + cache:clear | Ran via the framework's `setup:` block |
 | `lerd worker start messenger` (via setup) | Launched `lerd-messenger-myapp` |

--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -160,7 +160,7 @@ func resolveDBFromFramework(cwd string) *dbEnv {
 	if !ok {
 		return nil
 	}
-	fw, ok := config.GetFramework(fwName)
+	fw, ok := config.GetFrameworkForDir(fwName, cwd)
 	if !ok || len(fw.Env.Services) == 0 {
 		return nil
 	}

--- a/internal/cli/db_framework_resolve_test.go
+++ b/internal/cli/db_framework_resolve_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// resolveDBFromFramework must read the framework's env file through the
+// version-aware store definition (GetFrameworkForDir), not the Go built-in
+// (GetFramework). For Symfony the store def targets .env.local while the
+// built-in targets .env, so a DATABASE_URL that lives only in .env.local is
+// invisible unless the store def is consulted.
+func TestResolveDBFromFramework_ReadsStoreEnvFile(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	storeDir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	storeDef := "name: symfony\nlabel: Symfony\nenv:\n  file: .env.local\n  format: dotenv\n  services:\n    mysql:\n      detect:\n        - key: DATABASE_URL\n          value_prefix: mysql\n"
+	if err := os.WriteFile(filepath.Join(storeDir, "symfony.yaml"), []byte(storeDef), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: symfony\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The committed .env carries no DATABASE_URL; the real value lives in the
+	// gitignored .env.local, exactly as Symfony's convention prescribes.
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_ENV=dev\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env.local"), []byte("DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/shop\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := resolveDBFromFramework(dir)
+	if env == nil {
+		t.Fatal("resolveDBFromFramework read the built-in .env and found no service; it must resolve the store def's .env.local")
+	}
+	if env.connection != "mysql" {
+		t.Errorf("connection = %q, want mysql", env.connection)
+	}
+	if env.database != "shop" {
+		t.Errorf("database = %q, want shop (parsed from DATABASE_URL in .env.local)", env.database)
+	}
+}

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -375,7 +375,7 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("no framework detected for this site\nDefine one with 'lerd framework add' or add a framework YAML to %s", config.FrameworksDir())
 	}
 
-	fw, ok := config.GetFramework(fwName)
+	fw, ok := config.GetFrameworkForDir(fwName, cwd)
 	if !ok {
 		return fmt.Errorf("framework %q is not defined\nDefine it with 'lerd framework add'", fwName)
 	}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -745,8 +745,10 @@ var symfonyFramework = &Framework{
 		{Composer: "symfony/framework-bundle"},
 	},
 	Env: FrameworkEnvConf{
-		File:        ".env",
-		ExampleFile: ".env.example",
+		// Symfony commits .env and gitignores .env.local as the local override,
+		// so lerd writes its connection values into .env.local, seeded from .env.
+		File:        ".env.local",
+		ExampleFile: ".env",
 		Format:      "dotenv",
 		Services: map[string]FrameworkServiceDef{
 			"mysql": {

--- a/internal/config/framework_test.go
+++ b/internal/config/framework_test.go
@@ -130,6 +130,25 @@ func TestGetFrameworkCustom_WithLogs(t *testing.T) {
 	}
 }
 
+// The built-in Symfony def must follow Symfony's env convention: lerd writes its
+// connection values into .env.local (the gitignored local override), seeded from
+// the committed .env. Keeping the built-in aligned with the store def stops the
+// two from contradicting each other on the offline fallback path.
+func TestGetFrameworkSymfony_BuiltinEnvTargetsEnvLocal(t *testing.T) {
+	setConfigDir(t)
+
+	fw, ok := GetFramework("symfony")
+	if !ok {
+		t.Fatal("GetFramework(symfony): not found")
+	}
+	if fw.Env.File != ".env.local" {
+		t.Errorf("Env.File = %q, want .env.local", fw.Env.File)
+	}
+	if fw.Env.ExampleFile != ".env" {
+		t.Errorf("Env.ExampleFile = %q, want .env", fw.Env.ExampleFile)
+	}
+}
+
 func TestGetFrameworkCustom_WithoutLogs(t *testing.T) {
 	setConfigDir(t)
 


### PR DESCRIPTION
The env wiring in lerd env and the service detection behind the db commands were still reading the Go built-in framework definition, while the doctor, the Env tab, and the rest of the UI had already moved to the version aware, store first resolver. For the two built-in frameworks the built-in shadows the store, so no store def change could reach the env wiring at all.

For Symfony the two definitions disagreed. The built-in declared .env with .env.example, but Symfony commits .env and gitignores .env.local as the local override. So lerd setup wrote DATABASE_URL and the service credentials into the committed .env and never created .env.local, while the Env tab and doctor looked for .env.local and came up empty. Laravel was unaffected because its built-in and store def agree.

This points both call sites at the store first resolver so they see the same definition as everything else, and aligns the Symfony built-in env block to .env.local seeded from .env so the offline fallback follows the same convention and the two cannot drift apart again. Existing Symfony sites set up under the old behaviour keep their values in the committed .env, and the next lerd env creates .env.local from it.

Refs #873