### PR TITLE
fix: resolve worktree env sync through the framework definition

### DIFF
--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -58,7 +58,7 @@ Whether you use `lerd worktree add` or the bare `git` command, the daemon's watc
 
 1. Wait for `HEAD` to be a final ref or SHA — git writes `gitdir`/`HEAD` over multiple steps and the watcher must avoid acting on a half-written detached state.
 2. Seed `vendor/` and `node_modules/` from the main repo when the worktree's `composer.lock` / JS lockfile matches main's, using reflinks where the filesystem supports them (btrfs, xfs-reflink, APFS) and a plain copy elsewhere.
-3. Sync `.env` from main with `APP_URL` rewritten to the worktree's vhost domain. When `.lerd.yaml` defines `env_overrides`, those templates are resolved instead (see [env overrides](#env-overrides) below).
+3. Sync the framework's env file from main with its base-URL key rewritten to the worktree's vhost domain. The file, its format and the key all come from the framework definition, so Laravel gets `.env` / `APP_URL`, Symfony `.env.local` / `DEFAULT_URI`, CodeIgniter `config/.env` / `app.baseURL`, and the PHP-config frameworks are seeded through their own writers: WordPress's `wp-config.php` (rewriting `WP_HOME`) and Magento's `app/etc/env.php` (carried across for its database credentials; Magento keeps its base URL in the database, so it declares no key and the file is otherwise left intact). When `.lerd.yaml` defines `env_overrides`, those dotenv templates are resolved on top (see [env overrides](#env-overrides) below).
 4. Run `composer install` (skipped when the marker is at-or-newer than `composer.lock`) and `npm ci` / `pnpm install --frozen-lockfile` / `yarn install --immutable` / `bun install --frozen-lockfile` (skipped under the same marker rule).
 5. Generate the worktree's nginx vhost. It inherits the parent site's framework, so the document root follows the framework's `public_dir` (`pub` for Magento, `web` for Drupal, `webroot` for CakePHP) rather than assuming `public`, and any [nginx snippet](../usage/framework-definitions.md#framework-nginx-config) the framework declares is spliced in, expanded against the worktree's own checkout.
 
@@ -71,7 +71,7 @@ Frontend build (`npm run build`) is **not** part of the watcher pipeline — it'
 | `vendor/` | Reflink/copy from main when `composer.lock` matches; otherwise skip and let `composer install` build from scratch (no stale autoload entries). |
 | `node_modules/` | Same lockfile-match guard against `pnpm-lock.yaml` / `yarn.lock` / `bun.lock*` / `package-lock.json` / `npm-shrinkwrap.json` (whichever exists). |
 | `public/build/` | Not seeded. Run `npm run dev` (Vite dev server, hot reload) or `npm run build` (static manifest) inside the worktree. |
-| `.env` | Copied from main; `APP_URL` rewritten to `http(s)://<branch>.<site>.test` (or resolved via `env_overrides` when defined). Realigned on every subsequent watcher pass so a branch rename keeps the value current. |
+| env file | The framework's env file (Laravel `.env`, Symfony `.env.local`, CakePHP `config/.env`) copied from main; the framework's base-URL key (`APP_URL`, `DEFAULT_URI`, `app.baseURL`) rewritten to `http(s)://<branch>.<site>.test` (or resolved via `env_overrides` when defined). Realigned on every subsequent watcher pass so a branch rename keeps the value current. |
 
 ::: info Why not symlink?
 Earlier lerd versions symlinked `vendor/` to save disk. PHP resolves `__DIR__` through symlinks to the real path, so Composer's `ClassLoader` would initialise against the main repo and silently load stale classes. Real copies (or reflinks) avoid the problem at no meaningful disk cost on modern filesystems.
@@ -90,11 +90,11 @@ lerd secure myapp
 # app.feature-auth.myapp.test         → https  (wildcard SAN)
 ```
 
-`APP_URL` in each worktree's `.env` is rewritten to `https://` when you secure the parent (and back to `http://` on `lerd unsecure`).
+The framework's base-URL key in each worktree's env file (`APP_URL` for Laravel, `DEFAULT_URI` for Symfony) is rewritten to `https://` when you secure the parent (and back to `http://` on `lerd unsecure`).
 
 ## Env overrides
 
-By default lerd only rewrites `APP_URL` in worktree `.env` files. Multi-tenant apps and other projects that derive multiple env variables from the site domain can define `env_overrides` in `.lerd.yaml`:
+By default lerd only rewrites the framework's base-URL key in worktree env files. Multi-tenant apps and other projects that derive multiple env variables from the site domain can define `env_overrides` in `.lerd.yaml`:
 
 ```yaml
 env_overrides:
@@ -165,7 +165,7 @@ Site-level resources stay shared and cannot be overridden per worktree: domain (
 
 ### Per-worktree database
 
-By default every worktree shares the parent site's database. The dashboard's **Isolated DB** toggle and the `lerd worktree add` prompt opt the worktree into its own schema, named `<parent_db>_<sanitized_branch>` in the same service the parent uses (mysql, mariadb, or postgres). The worktree's `.env` is rewritten so `DB_DATABASE` points at the new schema, and `db_isolated: true` is persisted to the worktree's `.lerd.yaml` so the choice travels with the branch.
+By default every worktree shares the parent site's database. The dashboard's **Isolated DB** toggle and the `lerd worktree add` prompt opt the worktree into its own schema, named `<parent_db>_<sanitized_branch>` in the same service the parent uses (mysql, mariadb, or postgres). The worktree's env file is rewritten so its database-name key points at the new schema, and `db_isolated: true` is persisted to the worktree's `.lerd.yaml` so the choice travels with the branch. The env file, its format and the host/name keys are resolved from the framework definition, so Laravel's `DB_DATABASE` in `.env` and Magento's `db.connection.default.dbname` in `app/etc/env.php` are rewritten the same way.
 
 When isolation is enabled lerd asks where the new schema should start from:
 
@@ -180,7 +180,7 @@ The isolated database survives `lerd worktree remove` by default — the wrapper
 - **Reuse preserved isolated DB** — reconnects the worktree to the same data with no schema changes.
 - **Reset preserved DB to a fresh empty schema** — drops the existing DB, recreates it empty, then offers to run migrations.
 
-The same toggle is available on the dashboard for already-active worktrees: flipping **Isolated DB** off opens a confirmation modal naming the database that is about to go, and on confirm it drops the database and restores the parent's `DB_DATABASE` value in `.env`. The toggle only appears when the parent uses a lerd-managed mysql/mariadb/postgres service. Sqlite is naturally file-based and isolated per checkout, no opt-in needed.
+The same toggle is available on the dashboard for already-active worktrees: flipping **Isolated DB** off opens a confirmation modal naming the database that is about to go, and on confirm it drops the database and restores the parent's database-name value in the worktree's env file. The toggle only appears when the parent uses a lerd-managed mysql/mariadb/postgres service. Sqlite is naturally file-based and isolated per checkout, no opt-in needed.
 
 ### Per-worktree LAN share
 

--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -42,7 +42,10 @@ env:
   format: dotenv                    # dotenv | php-const | php-array
   fallback_file: wp-config.php      # used when file doesn't exist
   fallback_format: php-const        # format for fallback_file
-  url_key: APP_URL                  # env key holding the app URL
+  url_key: APP_URL                  # env key holding the app URL (or "none")
+  worktree_url_keys:                # keys set to a worktree's own base URL
+    - system.default.web.unsecure.base_url
+    - system.default.web.secure.base_url
 
   # Application key generation
   key_generation:
@@ -108,6 +111,11 @@ env:
   url_key: DEFAULT_URI            # env key holding the app URL (default: APP_URL;
                                   # `none` opts out for frameworks that keep the
                                   # base URL elsewhere, e.g. Magento's database)
+  worktree_url_keys:              # keys set to a worktree's own base URL, even
+    - web.unsecure.base_url       # when url_key is `none` — lets a worktree whose
+    - web.secure.base_url         # canonical base URL is database-hosted (Magento)
+                                  # override it in env.php and serve on its own
+                                  # domain instead of redirecting to the parent
   vars:                           # unconditional env defaults, always applied (optional)
     - "CI_ENVIRONMENT=development" # e.g. force CodeIgniter into dev mode for local work
   key_generation:                 # application key generation (optional)

--- a/internal/cli/worktree_db.go
+++ b/internal/cli/worktree_db.go
@@ -46,9 +46,11 @@ func liveWorktreeBranches(site *config.Site) map[string]bool {
 // handler and the `lerd db:isolate` / `lerd db:share` CLI commands. On enable
 // it creates `<parent_db>_<sanitized_branch>` in the same service the parent
 // uses, optionally clones from `source` (empty / "main" / another isolated
-// branch), records the worktree-DB pair in the registry, and rewrites
-// DB_DATABASE in the worktree's .env. On disable it drops the DB and restores
-// the parent's value. Idempotent.
+// branch), records the worktree-DB pair in the registry, and rewrites the
+// database-name key in the worktree's env file. The file, format and key are
+// resolved from the framework definition (see resolveDBEnvBinding), so Laravel's
+// DB_DATABASE and Magento's db.connection.default.dbname are handled alike. On
+// disable it drops the DB and restores the parent's value. Idempotent.
 // resolveDBService returns the lerd service backing the parent site's database.
 // Container/PHP sites name it directly in DB_HOST (lerd-postgres -> postgres);
 // host-proxy sites rewrite DB_HOST to loopback, so the service is recovered from
@@ -71,6 +73,72 @@ func resolveDBService(site *config.Site, parentHost string) string {
 	return ""
 }
 
+// dbEnvBinding describes how a framework's env file addresses its primary
+// database: the file and format to read and write, and the keys holding the DB
+// host (a lerd-<service> container name) and the database name. It is resolved
+// from the framework definition's mysql/mariadb/postgres service vars, so a
+// Laravel site (DB_HOST / DB_DATABASE), a Magento site
+// (db.connection.default.host / .dbname) and any future framework are addressed
+// the same way. A framework that encodes its database in a single DSN (Symfony's
+// DATABASE_URL) has no standalone name key, so it falls back to the Laravel-shaped
+// default and db:isolate reports it as unmanaged, exactly as before.
+type dbEnvBinding struct {
+	file    string
+	format  string
+	hostKey string
+	nameKey string
+}
+
+func resolveDBEnvBinding(sitePath string) dbEnvBinding {
+	def := dbEnvBinding{file: ".env", format: "dotenv", hostKey: "DB_HOST", nameKey: "DB_DATABASE"}
+	fwName, ok := config.DetectFrameworkForDir(sitePath)
+	if !ok {
+		return def
+	}
+	fw, ok := config.GetFrameworkForDir(fwName, sitePath)
+	if !ok {
+		return def
+	}
+	file, format := fw.Env.Resolve(sitePath)
+	for _, family := range []string{"mysql", "mariadb", "postgres"} {
+		svc, ok := fw.Env.Services[family]
+		if !ok {
+			continue
+		}
+		b := dbEnvBinding{file: file, format: format}
+		for _, v := range svc.Vars {
+			key, val, found := strings.Cut(v, "=")
+			if !found {
+				continue
+			}
+			switch {
+			case val == "{{site}}":
+				b.nameKey = key
+			case strings.HasPrefix(val, "lerd-"):
+				b.hostKey = key
+			}
+		}
+		if b.nameKey != "" && b.hostKey != "" {
+			return b
+		}
+	}
+	return def
+}
+
+// applyDBEnvUpdate writes updates to a worktree env file through the writer that
+// matches its format, so php-array (Magento) and php-const (WordPress) files are
+// rewritten correctly rather than corrupted by the dotenv writer.
+func applyDBEnvUpdate(path, format string, updates map[string]string) error {
+	switch format {
+	case "php-const":
+		return envfile.ApplyPhpConstUpdates(path, updates)
+	case "php-array":
+		return envfile.ApplyPhpArrayUpdates(path, updates)
+	default:
+		return envfile.ApplyUpdates(path, updates)
+	}
+}
+
 func SetWorktreeDBIsolated(site *config.Site, branch string, isolated bool, source string) error {
 	worktrees, err := gitpkg.DetectWorktrees(site.Path, site.PrimaryDomain())
 	if err != nil {
@@ -89,14 +157,16 @@ func SetWorktreeDBIsolated(site *config.Site, branch string, isolated bool, sour
 		return fmt.Errorf("unknown worktree branch %q", branch)
 	}
 
-	parentEnv := filepath.Join(site.Path, ".env")
-	parentDB := envfile.ReadKey(parentEnv, "DB_DATABASE")
-	parentHost := envfile.ReadKey(parentEnv, "DB_HOST")
+	binding := resolveDBEnvBinding(site.Path)
+	readParent := envfile.Reader(filepath.Join(site.Path, binding.file), binding.format)
+	parentDB := readParent(binding.nameKey)
+	parentHost := readParent(binding.hostKey)
 	service := resolveDBService(site, parentHost)
 	if parentDB == "" || service == "" {
-		return fmt.Errorf("parent site does not use a lerd-managed mysql/postgres (DB_HOST=%q, DB_DATABASE=%q)", parentHost, parentDB)
+		return fmt.Errorf("parent site does not use a lerd-managed mysql/postgres (%s=%q, %s=%q)", binding.hostKey, parentHost, binding.nameKey, parentDB)
 	}
 	dbName := WorktreeDBName(parentDB, branch)
+	wtEnv := filepath.Join(wt.Path, binding.file)
 
 	if isolated {
 		if _, err := CreateDatabase(service, dbName); err != nil {
@@ -119,10 +189,8 @@ func SetWorktreeDBIsolated(site *config.Site, branch string, isolated bool, sour
 		if err := config.SetWorktreeDBIsolated(wt.Path, true); err != nil {
 			return fmt.Errorf("updating .lerd.yaml: %w", err)
 		}
-		if err := envfile.ApplyUpdates(filepath.Join(wt.Path, ".env"), map[string]string{
-			"DB_DATABASE": dbName,
-		}); err != nil {
-			return fmt.Errorf("rewriting worktree .env: %w", err)
+		if err := applyDBEnvUpdate(wtEnv, binding.format, map[string]string{binding.nameKey: dbName}); err != nil {
+			return fmt.Errorf("rewriting worktree env: %w", err)
 		}
 		return nil
 	}
@@ -133,11 +201,9 @@ func SetWorktreeDBIsolated(site *config.Site, branch string, isolated bool, sour
 	if err := config.SetWorktreeDBIsolated(wt.Path, false); err != nil {
 		return fmt.Errorf("updating .lerd.yaml: %w", err)
 	}
-	if _, err := os.Stat(filepath.Join(wt.Path, ".env")); err == nil {
-		if err := envfile.ApplyUpdates(filepath.Join(wt.Path, ".env"), map[string]string{
-			"DB_DATABASE": parentDB,
-		}); err != nil {
-			return fmt.Errorf("restoring worktree .env: %w", err)
+	if _, err := os.Stat(wtEnv); err == nil {
+		if err := applyDBEnvUpdate(wtEnv, binding.format, map[string]string{binding.nameKey: parentDB}); err != nil {
+			return fmt.Errorf("restoring worktree env: %w", err)
 		}
 	}
 	return nil

--- a/internal/cli/worktree_db_binding_test.go
+++ b/internal/cli/worktree_db_binding_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// resolveDBEnvBinding must derive the env file, format and DB host/name keys from
+// the framework definition, so db:isolate addresses each framework's database the
+// way that framework actually stores it.
+func TestResolveDBEnvBinding(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	storeDir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A Magento-shaped php-array framework: env under app/etc/env.php, database
+	// addressed by dotted keys.
+	magDef := "name: magish\nlabel: Magish\nenv:\n  file: app/etc/env.php\n  format: php-array\n  url_key: none\n  services:\n    mysql:\n      vars:\n        - db.connection.default.host=lerd-mysql\n        - db.connection.default.dbname={{site}}\n"
+	if err := os.WriteFile(filepath.Join(storeDir, "magish.yaml"), []byte(magDef), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name                     string
+		framework                string
+		wantFile, wantFmt        string
+		wantHostKey, wantNameKey string
+	}{
+		{"laravel", "laravel", ".env", "dotenv", "DB_HOST", "DB_DATABASE"},
+		{"magento", "magish", "app/etc/env.php", "php-array", "db.connection.default.host", "db.connection.default.dbname"},
+		// Symfony encodes the database in a single DATABASE_URL DSN, so there is no
+		// standalone name key; the binding falls back to the Laravel-shaped default.
+		{"symfony-dsn-fallback", "symfony", ".env", "dotenv", "DB_HOST", "DB_DATABASE"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: "+tc.framework+"\n"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			b := resolveDBEnvBinding(dir)
+			if b.file != tc.wantFile || b.format != tc.wantFmt {
+				t.Errorf("file/format = %q/%q, want %q/%q", b.file, b.format, tc.wantFile, tc.wantFmt)
+			}
+			if b.hostKey != tc.wantHostKey || b.nameKey != tc.wantNameKey {
+				t.Errorf("hostKey/nameKey = %q/%q, want %q/%q", b.hostKey, b.nameKey, tc.wantHostKey, tc.wantNameKey)
+			}
+		})
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -404,6 +404,14 @@ type FrameworkEnvConf struct {
 	// URLKey is the env key that holds the application URL (default: APP_URL).
 	URLKey string `yaml:"url_key,omitempty"`
 
+	// WorktreeURLKeys are env keys set to the worktree's own base URL
+	// ("<scheme>://<domain>/") on every worktree. They exist for frameworks
+	// whose canonical base URL lives outside the env file — Magento keeps its in
+	// the database, so url_key is "none", but env.php's web.*.base_url overrides
+	// the database and is what lets a worktree serve on its own domain instead of
+	// redirecting to the parent. Written verbatim through the env format's writer.
+	WorktreeURLKeys []string `yaml:"worktree_url_keys,omitempty"`
+
 	// Vars are unconditional KEY=VALUE env defaults the framework always wants
 	// applied during `lerd env`, regardless of which services are detected
 	// (e.g. CodeIgniter's CI_ENVIRONMENT=development for local dev). They
@@ -747,9 +755,11 @@ var symfonyFramework = &Framework{
 	Env: FrameworkEnvConf{
 		// Symfony commits .env and gitignores .env.local as the local override,
 		// so lerd writes its connection values into .env.local, seeded from .env.
+		// Symfony's base URL lives under DEFAULT_URI, not APP_URL.
 		File:        ".env.local",
 		ExampleFile: ".env",
 		Format:      "dotenv",
+		URLKey:      "DEFAULT_URI",
 		Services: map[string]FrameworkServiceDef{
 			"mysql": {
 				Detect: []FrameworkServiceDetect{{Key: "DATABASE_URL", ValuePrefix: "mysql"}},

--- a/internal/config/framework_test.go
+++ b/internal/config/framework_test.go
@@ -147,6 +147,9 @@ func TestGetFrameworkSymfony_BuiltinEnvTargetsEnvLocal(t *testing.T) {
 	if fw.Env.ExampleFile != ".env" {
 		t.Errorf("Env.ExampleFile = %q, want .env", fw.Env.ExampleFile)
 	}
+	if fw.Env.URLKey != "DEFAULT_URI" {
+		t.Errorf("Env.URLKey = %q, want DEFAULT_URI", fw.Env.URLKey)
+	}
 }
 
 func TestGetFrameworkCustom_WithoutLogs(t *testing.T) {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -269,64 +269,115 @@ func lockfilesMatch(mainRepoPath, worktreePath string, lockfiles []string) bool 
 	return true
 }
 
-// EnsureWorktreeEnv copies .env from the main repo when missing (gitignored,
-// so `git worktree add` never carries it across) and rewrites APP_URL to the
-// worktree domain. When the main repo's .lerd.yaml defines env_overrides,
-// those values are resolved and layered on top — only keys declared in
+// EnsureWorktreeEnv seeds the worktree's env file from the main repo when
+// missing (gitignored, so `git worktree add` never carries it across) and
+// rewrites the framework's url_key to the worktree domain. The env file, its
+// format and url_key all come from the framework definition, so every framework
+// is seeded where it actually reads: Symfony's .env.local / DEFAULT_URI,
+// CodeIgniter's config/.env / app.baseURL, WordPress's wp-config.php / WP_HOME,
+// Magento's app/etc/env.php (php-array, whose base URL lives in the database so
+// it declares no url_key and only the file is carried across for its database
+// credentials). When the main repo's .lerd.yaml defines env_overrides, those
+// dotenv templates are resolved and layered on top — only keys declared in
 // env_overrides are touched, so partial overrides (e.g. SESSION_DOMAIN only)
-// don't suppress the default APP_URL rewrite. Idempotent and cheap; safe to
-// call on every request.
+// don't suppress the url_key rewrite. Idempotent and cheap; safe to call on
+// every request.
 func EnsureWorktreeEnv(mainRepoPath, worktreePath, worktreeDomain string, secured bool) {
 	scheme := "http"
 	if secured {
 		scheme = "https"
 	}
-	worktreeEnv := filepath.Join(worktreePath, ".env")
+
+	// Resolve the env file, its format and url_key through the framework
+	// definition, the same resolver the Env tab, doctor and env wiring use.
+	envFile, urlKey, format := ".env", "APP_URL", "dotenv"
+	var worktreeURLKeys []string
+	if fwName, ok := config.DetectFrameworkForDir(mainRepoPath); ok {
+		if fw, ok := config.GetFrameworkForDir(fwName, mainRepoPath); ok {
+			file, f := fw.Env.Resolve(mainRepoPath)
+			if !filepath.IsLocal(file) {
+				return
+			}
+			envFile, format = file, f
+			if k := fw.Env.URLKey; k != "" {
+				urlKey = k
+			}
+			worktreeURLKeys = fw.Env.WorktreeURLKeys
+		}
+	}
+
+	worktreeEnv := filepath.Join(worktreePath, envFile)
 	if _, err := os.Lstat(worktreeEnv); err != nil {
-		mainEnv := filepath.Join(mainRepoPath, ".env")
+		mainEnv := filepath.Join(mainRepoPath, envFile)
+		if err := os.MkdirAll(filepath.Dir(worktreeEnv), 0o755); err != nil {
+			return
+		}
 		if err := copyFile(mainEnv, worktreeEnv); err != nil {
 			return
 		}
 	}
 
-	updates := map[string]string{
-		"APP_URL": scheme + "://" + worktreeDomain,
+	updates := map[string]string{}
+	// url_key: none opts out (Magento keeps its base URL in the database), so the
+	// seeded file is left as copied and only its database credentials carry over.
+	if !strings.EqualFold(urlKey, "none") {
+		updates[urlKey] = scheme + "://" + worktreeDomain
+	}
+	// worktree_url_keys point the seeded file at the worktree's own domain even
+	// when url_key is none, so a database-hosted base URL (Magento) is overridden
+	// and the worktree serves itself instead of redirecting to the parent.
+	for _, k := range worktreeURLKeys {
+		updates[k] = scheme + "://" + worktreeDomain + "/"
 	}
 
-	cfg, _ := config.LoadProjectConfig(mainRepoPath)
-	if cfg != nil && len(cfg.EnvOverrides) > 0 {
-		// {{site}}: legacy DB-safe slug of the FULL worktree domain, e.g.
-		// feat_a_acme_test. Kept for backward compatibility — new templates
-		// should prefer {{branch}} or {{parent}} which match user intent.
-		// {{branch}}: first segment of the worktree domain, e.g. "feat-a".
-		// {{parent}}: parent site name slug (DB-safe), e.g. "acme".
-		site := config.SiteSlug(worktreeDomain)
-		branch := worktreeDomain
-		if i := strings.IndexByte(worktreeDomain, '.'); i > 0 {
-			branch = worktreeDomain[:i]
-		}
-		parent := ""
-		if s, err := config.FindSiteByPath(mainRepoPath); err == nil && s != nil {
-			parent = config.SiteSlug(s.Name)
-		}
-		// When the user opted into an isolated worktree DB, DB_DATABASE is
-		// owned by SetWorktreeDBIsolated and any env_overrides template for
-		// the same key would clobber it on the next watcher tick.
-		dbIsolated := config.WorktreeDBIsolated(worktreePath)
-		for k, v := range cfg.EnvOverrides {
-			if dbIsolated && k == "DB_DATABASE" {
-				continue
+	// env_overrides are dotenv KEY=VALUE templates (Laravel multi-tenancy and
+	// similar); they don't apply to the php-config formats.
+	if format == "dotenv" {
+		cfg, _ := config.LoadProjectConfig(mainRepoPath)
+		if cfg != nil && len(cfg.EnvOverrides) > 0 {
+			// {{site}}: legacy DB-safe slug of the FULL worktree domain, e.g.
+			// feat_a_acme_test. Kept for backward compatibility — new templates
+			// should prefer {{branch}} or {{parent}} which match user intent.
+			// {{branch}}: first segment of the worktree domain, e.g. "feat-a".
+			// {{parent}}: parent site name slug (DB-safe), e.g. "acme".
+			site := config.SiteSlug(worktreeDomain)
+			branch := worktreeDomain
+			if i := strings.IndexByte(worktreeDomain, '.'); i > 0 {
+				branch = worktreeDomain[:i]
 			}
-			v = strings.ReplaceAll(v, "{{domain}}", worktreeDomain)
-			v = strings.ReplaceAll(v, "{{scheme}}", scheme)
-			v = strings.ReplaceAll(v, "{{site}}", site)
-			v = strings.ReplaceAll(v, "{{branch}}", branch)
-			v = strings.ReplaceAll(v, "{{parent}}", parent)
-			updates[k] = v
+			parent := ""
+			if s, err := config.FindSiteByPath(mainRepoPath); err == nil && s != nil {
+				parent = config.SiteSlug(s.Name)
+			}
+			// When the user opted into an isolated worktree DB, DB_DATABASE is
+			// owned by SetWorktreeDBIsolated and any env_overrides template for
+			// the same key would clobber it on the next watcher tick.
+			dbIsolated := config.WorktreeDBIsolated(worktreePath)
+			for k, v := range cfg.EnvOverrides {
+				if dbIsolated && k == "DB_DATABASE" {
+					continue
+				}
+				v = strings.ReplaceAll(v, "{{domain}}", worktreeDomain)
+				v = strings.ReplaceAll(v, "{{scheme}}", scheme)
+				v = strings.ReplaceAll(v, "{{site}}", site)
+				v = strings.ReplaceAll(v, "{{branch}}", branch)
+				v = strings.ReplaceAll(v, "{{parent}}", parent)
+				updates[k] = v
+			}
 		}
 	}
 
-	_ = envfile.ApplyUpdates(worktreeEnv, updates)
+	if len(updates) == 0 {
+		return
+	}
+	switch format {
+	case "php-const":
+		_ = envfile.ApplyPhpConstUpdates(worktreeEnv, updates)
+	case "php-array":
+		_ = envfile.ApplyPhpArrayUpdates(worktreeEnv, updates)
+	default:
+		_ = envfile.ApplyUpdates(worktreeEnv, updates)
+	}
 }
 
 func copyFile(src, dst string) error {

--- a/internal/git/worktree_env_test.go
+++ b/internal/git/worktree_env_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/envfile"
 )
 
 // EnsureWorktreeEnv must materialise .env in a fresh worktree (git worktree
@@ -367,5 +368,237 @@ func TestEnsureWorktreeEnv_noopWhenMainHasNoEnv(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(wt, ".env")); !os.IsNotExist(err) {
 		t.Errorf("expected no .env in worktree, got err=%v", err)
+	}
+}
+
+// Symfony commits .env and gitignores .env.local as the local override, so lerd
+// writes its connection values into .env.local and its base URL under DEFAULT_URI.
+// A worktree must seed that file and rewrite that key, not a hardcoded root .env
+// with APP_URL, which the app never reads.
+func TestEnsureWorktreeEnv_symfonySeedsEnvLocalAndDefaultURI(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	main := t.TempDir()
+	wt := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(main, ".lerd.yaml"), []byte("framework: symfony\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	envLocal := "DEFAULT_URI=https://acme.test\nDATABASE_URL=mysql://root:lerd@lerd-mysql:3306/acme\n"
+	if err := os.WriteFile(filepath.Join(main, ".env.local"), []byte(envLocal), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureWorktreeEnv(main, wt, "feat-a.acme.test", true)
+
+	got, err := os.ReadFile(filepath.Join(wt, ".env.local"))
+	if err != nil {
+		t.Fatalf("worktree .env.local not seeded: %v", err)
+	}
+	s := string(got)
+	if !strings.Contains(s, "DEFAULT_URI=https://feat-a.acme.test") {
+		t.Errorf("DEFAULT_URI not rewritten to worktree domain:\n%s", s)
+	}
+	if !strings.Contains(s, "DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/acme") {
+		t.Errorf(".env.local not seeded in full:\n%s", s)
+	}
+	if _, err := os.Stat(filepath.Join(wt, ".env")); !os.IsNotExist(err) {
+		t.Errorf("a root .env was wrongly created for a Symfony worktree")
+	}
+}
+
+// The env file and url_key are resolved from the framework definition, so a
+// framework serving its env from config/.env under app.baseURL (CodeIgniter's
+// shape) is addressed through the store def, not the hardcoded .env / APP_URL.
+func TestEnsureWorktreeEnv_resolvesStoreFileAndURLKey(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	storeDir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	def := "name: igniter\nlabel: Igniter\nenv:\n  file: config/.env\n  url_key: app.baseURL\n  format: dotenv\n"
+	if err := os.WriteFile(filepath.Join(storeDir, "igniter.yaml"), []byte(def), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	main := t.TempDir()
+	wt := t.TempDir()
+	if err := os.WriteFile(filepath.Join(main, ".lerd.yaml"), []byte("framework: igniter\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(main, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(main, "config", ".env"), []byte("app.baseURL='http://acme.test'\nKEEP=1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// The committed config/ dir exists in the checkout; only the env is gitignored.
+	if err := os.MkdirAll(filepath.Join(wt, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureWorktreeEnv(main, wt, "feat-a.acme.test", false)
+
+	got, err := os.ReadFile(filepath.Join(wt, "config", ".env"))
+	if err != nil {
+		t.Fatalf("worktree config/.env not seeded: %v", err)
+	}
+	s := string(got)
+	if !strings.Contains(s, "app.baseURL=http://feat-a.acme.test") {
+		t.Errorf("app.baseURL not rewritten:\n%s", s)
+	}
+	if !strings.Contains(s, "KEEP=1") {
+		t.Errorf("config/.env not seeded in full:\n%s", s)
+	}
+	if _, err := os.Stat(filepath.Join(wt, ".env")); !os.IsNotExist(err) {
+		t.Errorf("a root .env was wrongly created")
+	}
+}
+
+// Magento's env is a php-array file (app/etc/env.php) nested under app/etc, and
+// its base URL lives in the database so it declares no url_key. The worktree must
+// seed that file so its database credentials carry across, write no root .env,
+// and leave the file's values otherwise intact (no url rewrite).
+func TestEnsureWorktreeEnv_seedsPhpArrayEnvFile(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	storeDir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	def := "name: magish\nlabel: Magish\npublic_dir: pub\nenv:\n  file: app/etc/env.php\n  format: php-array\n  url_key: none\n"
+	if err := os.WriteFile(filepath.Join(storeDir, "magish.yaml"), []byte(def), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	main := t.TempDir()
+	wt := t.TempDir()
+	if err := os.WriteFile(filepath.Join(main, ".lerd.yaml"), []byte("framework: magish\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(main, "app", "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	envPhp := "<?php\nreturn [\n    'db' => ['connection' => ['default' => ['host' => 'lerd-mysql', 'dbname' => 'shop']]],\n];\n"
+	if err := os.WriteFile(filepath.Join(main, "app", "etc", "env.php"), []byte(envPhp), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// A stray root .env in main must not be copied across for a php-format site.
+	if err := os.WriteFile(filepath.Join(main, ".env"), []byte("STRAY=1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(wt, "app", "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureWorktreeEnv(main, wt, "feat.shop.test", false)
+
+	vals, err := envfile.ReadPhpArray(filepath.Join(wt, "app", "etc", "env.php"))
+	if err != nil {
+		t.Fatalf("worktree app/etc/env.php not seeded: %v", err)
+	}
+	if vals["db.connection.default.host"] != "lerd-mysql" || vals["db.connection.default.dbname"] != "shop" {
+		t.Errorf("database credentials not carried across: %+v", vals)
+	}
+	if _, err := os.Stat(filepath.Join(wt, ".env")); !os.IsNotExist(err) {
+		t.Errorf("a root .env was wrongly created for a php-array site")
+	}
+}
+
+// A framework whose url_key is none but which declares worktree_url_keys (Magento
+// overriding its database-hosted base URL through env.php) must have each of those
+// keys pointed at the worktree's own domain so it serves itself instead of
+// redirecting to the parent.
+func TestEnsureWorktreeEnv_writesWorktreeURLKeys(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	storeDir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	def := "name: magish\nlabel: Magish\nenv:\n  file: app/etc/env.php\n  format: php-array\n  url_key: none\n  worktree_url_keys:\n    - system.default.web.unsecure.base_url\n    - system.default.web.secure.base_url\n"
+	if err := os.WriteFile(filepath.Join(storeDir, "magish.yaml"), []byte(def), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	main := t.TempDir()
+	wt := t.TempDir()
+	if err := os.WriteFile(filepath.Join(main, ".lerd.yaml"), []byte("framework: magish\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(main, "app", "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	envPhp := "<?php\nreturn [\n    'db' => ['connection' => ['default' => ['host' => 'lerd-mysql', 'dbname' => 'shop']]],\n];\n"
+	if err := os.WriteFile(filepath.Join(main, "app", "etc", "env.php"), []byte(envPhp), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(wt, "app", "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureWorktreeEnv(main, wt, "feat.shop.test", true)
+
+	vals, err := envfile.ReadPhpArray(filepath.Join(wt, "app", "etc", "env.php"))
+	if err != nil {
+		t.Fatalf("worktree app/etc/env.php not seeded: %v", err)
+	}
+	if got := vals["system.default.web.unsecure.base_url"]; got != "https://feat.shop.test/" {
+		t.Errorf("unsecure base_url = %q, want https://feat.shop.test/", got)
+	}
+	if got := vals["system.default.web.secure.base_url"]; got != "https://feat.shop.test/" {
+		t.Errorf("secure base_url = %q, want https://feat.shop.test/", got)
+	}
+	// DB credentials still carry across alongside the base URL override.
+	if vals["db.connection.default.dbname"] != "shop" {
+		t.Errorf("database credentials not preserved: %+v", vals)
+	}
+}
+
+// WordPress's env is a php-const file (wp-config.php) whose base URL key is
+// WP_HOME. The worktree must seed the file and rewrite WP_HOME through the
+// php-const writer, not the dotenv one.
+func TestEnsureWorktreeEnv_seedsPhpConstAndRewritesURLKey(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	storeDir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	def := "name: wpish\nlabel: WPish\nenv:\n  file: wp-config.php\n  url_key: WP_HOME\n  format: php-const\n"
+	if err := os.WriteFile(filepath.Join(storeDir, "wpish.yaml"), []byte(def), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	main := t.TempDir()
+	wt := t.TempDir()
+	if err := os.WriteFile(filepath.Join(main, ".lerd.yaml"), []byte("framework: wpish\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	wpConfig := "<?php\ndefine('WP_HOME','http://acme.test');\ndefine('DB_NAME','wp');\n"
+	if err := os.WriteFile(filepath.Join(main, "wp-config.php"), []byte(wpConfig), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureWorktreeEnv(main, wt, "feat.acme.test", true)
+
+	vals, err := envfile.ReadPhpConst(filepath.Join(wt, "wp-config.php"))
+	if err != nil {
+		t.Fatalf("worktree wp-config.php not seeded: %v", err)
+	}
+	if vals["WP_HOME"] != "https://feat.acme.test" {
+		t.Errorf("WP_HOME not rewritten to worktree domain: %q", vals["WP_HOME"])
+	}
+	if vals["DB_NAME"] != "wp" {
+		t.Errorf("DB_NAME not carried across: %q", vals["DB_NAME"])
+	}
+	if _, err := os.Stat(filepath.Join(wt, ".env")); !os.IsNotExist(err) {
+		t.Errorf("a root .env was wrongly created for a php-const site")
 	}
 }


### PR DESCRIPTION
The worktree env sync joined the worktree path with a literal .env and rewrote only APP_URL, so any framework whose environment lives elsewhere got a broken worktree. Symfony's .env.local and DEFAULT_URI were never touched, CodeIgniter and Tempest had the wrong base URL key written, and the two php-config frameworks fared worst: WordPress and Magento seed no env at all, so a Magento worktree came up with no database credentials and every request redirected to /setup/.

EnsureWorktreeEnv now resolves the env file, its format and the url_key from the framework definition, the same resolver the Env tab, the doctor and lerd env already use, and seeds through the writer that matches the format. dotenv frameworks get their real file and key, WordPress's wp-config.php has WP_HOME rewritten through the php-const writer, and Magento's app/etc/env.php is carried across for its database credentials through the php-array writer. The built-in Symfony definition gains url_key DEFAULT_URI so its offline fallback matches the store definition.

db:isolate gets the same treatment. It read DB_HOST and DB_DATABASE out of a literal .env, which a Magento site does not have. A binding now derives the env file, format and the host and database-name keys from the definition's service vars, so Laravel's DB_DATABASE and Magento's db.connection.default.dbname are rewritten alike, and a framework that keeps its database in a single DSN falls back to the previous behaviour.

Magento keeps its base URL in the database rather than in env.php, so it declares no url_key and a worktree would redirect straight back to the parent domain. A new worktree_url_keys env field lets a definition name the keys that should carry the worktree's own base URL, which env.php overrides the database with, so the worktree serves on its own domain. Magento's own keys belong in its store definition.

Refs #877