### PR TITLE
fix: resolve composer's ext-zend-opcache against the bundled opcache

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -392,3 +392,11 @@ When you run `lerd park` or `lerd link`, Lerd reads `composer.json` and warns if
 [!] my-app requires PHP extensions not in the image: swoole
     Run: lerd php:ext add swoole
 ```
+
+A requirement can also fail even though the extension is in the image, because composer names a few extensions differently from the name they are installed under. Composer builds its `ext-*` names from the module name PHP reports, and OPcache reports itself as `Zend OPcache`, so composer publishes `ext-zend-opcache` and never `ext-opcache`. A `composer.json` asking for `ext-opcache` therefore fails its platform check on `composer install` even though OPcache is loaded, and `lerd php:ext add opcache` will not help because nothing is actually missing. Lerd recognises both spellings and tells you which one composer wants:
+
+```
+[!] my-app requires ext-opcache, which composer publishes as ext-zend-opcache
+    The extension is in the image; composer install will still fail its platform check.
+    Require ext-zend-opcache in composer.json instead.
+```

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -422,6 +422,10 @@ func runLink(args []string) error {
 	}
 	printLinkSummary(site, start)
 
+	// Warn before the setup prompt below: an ext-* requirement the image cannot
+	// satisfy fails composer install, which is the first thing setup runs.
+	warnMissingExtensions(cwd, site.Name, phpVersion, cfg)
+
 	// Sail detection — offer to import data before setup so lerd's DB is
 	// populated from the existing Sail environment. Gate on Sail actually being
 	// initialized (a compose file), not just the laravel/sail dev dependency

--- a/internal/cli/park.go
+++ b/internal/cli/park.go
@@ -16,19 +16,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// warnMissingExtensions checks composer.json for ext-* requirements and warns if any are
-// not covered by the bundled image or the user's custom extension list.
-func warnMissingExtensions(dir, name, phpVersion string, cfg *config.GlobalConfig) {
-	detected := phpDet.DetectExtensions(dir)
-	if len(detected) == 0 {
-		return
-	}
-	bundled := podman.BundledExtensions()
-	installed := cfg.GetExtensions(phpVersion)
+// extMismatch is a composer.json requirement whose extension is in the image but
+// under a different platform name, so composer install still fails its check.
+type extMismatch struct {
+	Required string // the ext-* name composer.json asks for
+	Platform string // the ext-* name composer actually publishes
+}
 
+// checkExtensions compares composer's ext-* requirements against the image, folding
+// both spellings of an extension onto one name so ext-opcache and ext-zend-opcache
+// resolve to the same module.
+func checkExtensions(detected, bundled, installed []string) ([]string, []extMismatch) {
 	inSet := func(ext string, set []string) bool {
 		for _, e := range set {
-			if e == ext {
+			if podman.CanonicalExtension(e) == ext {
 				return true
 			}
 		}
@@ -36,14 +37,37 @@ func warnMissingExtensions(dir, name, phpVersion string, cfg *config.GlobalConfi
 	}
 
 	var missing []string
+	var misnamed []extMismatch
 	for _, ext := range detected {
-		if !inSet(ext, bundled) && !inSet(ext, installed) {
+		canonical := podman.CanonicalExtension(ext)
+		if !inSet(canonical, bundled) && !inSet(canonical, installed) {
 			missing = append(missing, ext)
+			continue
+		}
+		if platform := podman.ComposerPlatformName(canonical); platform != strings.ToLower(ext) {
+			misnamed = append(misnamed, extMismatch{Required: ext, Platform: platform})
 		}
 	}
+	return missing, misnamed
+}
+
+// warnMissingExtensions checks composer.json for ext-* requirements and warns if any are
+// not covered by the bundled image or the user's custom extension list.
+func warnMissingExtensions(dir, name, phpVersion string, cfg *config.GlobalConfig) {
+	detected := phpDet.DetectExtensions(dir)
+	if len(detected) == 0 {
+		return
+	}
+	missing, misnamed := checkExtensions(detected, podman.BundledExtensions(), cfg.GetExtensions(phpVersion))
+
 	if len(missing) > 0 {
 		fmt.Printf("  [!] %s requires PHP extensions not in the image: %s\n", name, strings.Join(missing, ", "))
 		fmt.Printf("      Run: lerd php:ext add %s\n", strings.Join(missing, " "))
+	}
+	for _, m := range misnamed {
+		fmt.Printf("  [!] %s requires ext-%s, which composer publishes as ext-%s\n", name, m.Required, m.Platform)
+		fmt.Printf("      The extension is in the image; composer install will still fail its platform check.\n")
+		fmt.Printf("      Require ext-%s in composer.json instead.\n", m.Platform)
 	}
 }
 

--- a/internal/cli/park_test.go
+++ b/internal/cli/park_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
@@ -129,6 +130,57 @@ func TestFreeSiteName_legacyDomainField(t *testing.T) {
 	got := freeSiteName("myapp", "/projects/new")
 	if got != "myapp-2" {
 		t.Errorf("got %q, want %q", got, "myapp-2")
+	}
+}
+
+// ── checkExtensions ──────────────────────────────────────────────────────────
+
+func TestCheckExtensions(t *testing.T) {
+	bundled := []string{"opcache", "redis", "mbstring"}
+	installed := []string{"imap"}
+
+	cases := []struct {
+		name         string
+		detected     []string
+		wantMissing  []string
+		wantMisnamed []extMismatch
+	}{
+		{
+			// #842: the extension is in the image, but composer publishes it as
+			// ext-zend-opcache, so composer install fails its platform check.
+			name:         "ext-opcache is present but misnamed",
+			detected:     []string{"opcache"},
+			wantMisnamed: []extMismatch{{Required: "opcache", Platform: "zend-opcache"}},
+		},
+		{
+			name:     "ext-zend-opcache resolves against the bundled opcache",
+			detected: []string{"zend-opcache"},
+		},
+		{
+			name:        "a genuinely absent extension is still reported",
+			detected:    []string{"snmp"},
+			wantMissing: []string{"snmp"},
+		},
+		{
+			name:     "a custom-installed extension is not missing",
+			detected: []string{"imap"},
+		},
+		{
+			name:     "a plainly bundled extension is silent",
+			detected: []string{"redis", "mbstring"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			missing, misnamed := checkExtensions(c.detected, bundled, installed)
+			if !reflect.DeepEqual(missing, c.wantMissing) {
+				t.Errorf("missing = %v, want %v", missing, c.wantMissing)
+			}
+			if !reflect.DeepEqual(misnamed, c.wantMisnamed) {
+				t.Errorf("misnamed = %v, want %v", misnamed, c.wantMisnamed)
+			}
+		})
 	}
 }
 

--- a/internal/podman/extensions.go
+++ b/internal/podman/extensions.go
@@ -1,13 +1,15 @@
 package podman
 
+import "strings"
+
 // BundledExtensions returns the set of PHP extensions included in the default lerd FPM image.
 func BundledExtensions() []string {
 	return []string{
 		// always-compiled PHP core
-		"ctype", "dom", "fileinfo", "filter", "hash", "iconv",
-		"json", "libxml", "openssl", "pcre", "pdo", "phar", "posix",
-		"readline", "session", "simplexml", "sodium", "spl", "tokenizer",
-		"xml", "xmlreader", "xmlwriter", "zlib",
+		"ctype", "date", "dom", "fileinfo", "filter", "hash", "iconv",
+		"json", "libxml", "mysqlnd", "openssl", "pcre", "pdo", "phar", "posix",
+		"random", "readline", "reflection", "session", "simplexml", "sodium",
+		"spl", "tokenizer", "xml", "xmlreader", "xmlwriter", "zlib",
 		// docker-php-ext-install
 		"bcmath", "bz2", "calendar", "curl", "dba", "exif", "ftp", "gd", "gmp",
 		"intl", "ldap", "mbstring", "mysqli", "opcache", "pcntl",
@@ -16,4 +18,32 @@ func BundledExtensions() []string {
 		// PECL
 		"redis", "imagick", "igbinary", "mongodb", "pcov", "xdebug",
 	}
+}
+
+// composerPlatformNames maps an extension's install name to the name composer's
+// platform repository publishes it under. Composer derives ext-* names from the
+// module name PHP reports, which for OPcache is "Zend OPcache", never "opcache".
+var composerPlatformNames = map[string]string{
+	"opcache": "zend-opcache",
+}
+
+// ComposerPlatformName returns the ext-* name (without the prefix) that composer
+// publishes for a bundled extension. Most extensions are published as-is.
+func ComposerPlatformName(ext string) string {
+	if name, ok := composerPlatformNames[strings.ToLower(ext)]; ok {
+		return name
+	}
+	return ext
+}
+
+// CanonicalExtension folds a composer ext-* name back onto the install name
+// BundledExtensions uses, so both spellings resolve to the same extension.
+func CanonicalExtension(name string) string {
+	name = strings.ToLower(name)
+	for install, platform := range composerPlatformNames {
+		if platform == name {
+			return install
+		}
+	}
+	return name
 }

--- a/internal/podman/extensions_test.go
+++ b/internal/podman/extensions_test.go
@@ -2,6 +2,47 @@ package podman
 
 import "testing"
 
+// TestComposerPlatformNameRoundTrips checks both directions of the name folding:
+// composer publishes OPcache as ext-zend-opcache (the module is "Zend OPcache",
+// so extension_loaded("opcache") is false), while the image installs it as
+// opcache. Both spellings must agree with BundledExtensions.
+func TestComposerPlatformNameRoundTrips(t *testing.T) {
+	cases := []struct{ bundled, platform string }{
+		{"opcache", "zend-opcache"},
+		{"redis", "redis"},
+		{"pdo_mysql", "pdo_mysql"},
+	}
+	for _, c := range cases {
+		if got := ComposerPlatformName(c.bundled); got != c.platform {
+			t.Errorf("ComposerPlatformName(%q) = %q, want %q", c.bundled, got, c.platform)
+		}
+		if got := CanonicalExtension(c.platform); got != c.bundled {
+			t.Errorf("CanonicalExtension(%q) = %q, want %q", c.platform, got, c.bundled)
+		}
+	}
+}
+
+func TestCanonicalExtensionIsCaseInsensitive(t *testing.T) {
+	if got := CanonicalExtension("Zend-OPcache"); got != "opcache" {
+		t.Errorf("CanonicalExtension(%q) = %q, want %q", "Zend-OPcache", got, "opcache")
+	}
+}
+
+// TestBundledExtensionsUseInstallNames guards the mapping's premise: every alias
+// key is a name BundledExtensions actually lists, so a rename in the list cannot
+// silently orphan its composer counterpart.
+func TestBundledExtensionsUseInstallNames(t *testing.T) {
+	bundled := map[string]bool{}
+	for _, e := range BundledExtensions() {
+		bundled[e] = true
+	}
+	for install := range composerPlatformNames {
+		if !bundled[install] {
+			t.Errorf("composerPlatformNames maps %q, but BundledExtensions does not list it", install)
+		}
+	}
+}
+
 // TestBundledExtensionsCoverContainerfile checks one direction: every extension
 // the FPM Containerfile installs or enables (docker-php-ext-install + the pecl
 // docker-php-ext-enable names) is listed in BundledExtensions, so adding one to


### PR DESCRIPTION
Composer builds its platform names from the module name PHP reports, and OPcache reports itself as Zend OPcache, so composer publishes ext-zend-opcache and never ext-opcache. park compared composer's ext-* names against the bundled list as plain strings, so a project requiring ext-opcache looked satisfied and then failed its platform check on composer install, while one requiring ext-zend-opcache was reported as missing from an image that has it. Neither spelling worked, in opposite ways.

Extension names now fold onto the install name in both directions. A requirement whose extension is present under a different platform name gets its own warning naming the spelling composer actually wants, rather than a php:ext add suggestion that would not help, since nothing is missing.

Auditing the rest of the bundled names for the same problem turned up several always-compiled modules composer publishes that the list omitted, date, random, reflection and mysqlnd, each of which produced the same false missing warning against an image that has them.

lerd link never ran the extension check at all, despite the docs promising it did, so a project registered the usual way got no warning for any unsatisfiable extension. The check now runs there too, right before link offers to run setup, which is where composer install would fail.

Refs #842