### PR TITLE
fix: serve sites whose path contains a space

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -279,6 +279,8 @@ Three placeholders are expanded before the config is written:
 | `{{public}}` | the document root (project root joined with `public_dir`) |
 | `{{fpm}}` | the site's PHP-FPM container name |
 
+The two path placeholders expand to nginx variables, `${lerd_root}` and `${lerd_public}`, which lerd declares at the top of the server block with the real paths. A project can live under a path with a space in it, and nginx splits a directive on whitespace: a literal path would turn `root` into three arguments and nginx would reject the whole config, taking every other site on the machine down with it. Quoting the value would fix a standalone `root {{root}};` but not a path used mid-token, as in `alias {{public}}/static/;`, since nginx will not glue a quoted token to a bare one. A variable is resolved after tokenizing, so it works in both positions. Write the placeholders exactly where you would write the path and lerd handles the rest.
+
 A snippet that passes requests to PHP should assign `{{fpm}}` to a variable first, `set $myfpm "{{fpm}}";` then `fastcgi_pass $myfpm:9000;`, exactly as the generated vhost does. nginx resolves a literal upstream name once when the config loads and caches it for the life of the process, so a container that comes back on a new address is never picked up.
 
 A git worktree of the site gets the same block, expanded against its own checkout: `{{root}}` and `{{public}}` point at the worktree's directory, not the parent's, so a branch serves its own `setup/`, `/static/` and `/media/` paths.

--- a/internal/cli/horizon.go
+++ b/internal/cli/horizon.go
@@ -232,7 +232,7 @@ ExecStart=%s exec -w %s %s php artisan horizon
 
 [Install]
 WantedBy=default.target
-`, siteName, fpmUnit, fpmUnit, fpmUnit, podman.PodmanBin(), sitePath, container)
+`, siteName, fpmUnit, fpmUnit, fpmUnit, podman.PodmanBin(), podman.ShellQuote(sitePath), container)
 }
 
 // HorizonStopForSite stops and removes the Horizon unit for the named site.

--- a/internal/cli/queue_test.go
+++ b/internal/cli/queue_test.go
@@ -83,7 +83,7 @@ func TestBuildHorizonUnit_AlwaysDependsOnRedis(t *testing.T) {
 	mustContain(t, unit, "After=network.target lerd-php84-fpm.service lerd-redis.service")
 	mustContain(t, unit, "Wants=lerd-php84-fpm.service lerd-redis.service")
 	mustContain(t, unit, "BindsTo=lerd-php84-fpm.service")
-	mustContain(t, unit, "ExecStart="+podman.PodmanBin()+" exec -w /home/u/example-horizon lerd-php84-fpm php artisan horizon")
+	mustContain(t, unit, "ExecStart="+podman.PodmanBin()+" exec -w '/home/u/example-horizon' lerd-php84-fpm php artisan horizon")
 }
 
 func mustContain(t *testing.T, body, needle string) {

--- a/internal/cli/worker_darwin.go
+++ b/internal/cli/worker_darwin.go
@@ -150,7 +150,7 @@ func writeWorkerExecUnit(unitName, siteName, sitePath, phpVersion, command, rest
 	_ = fpmUnit
 	container := resolveWorkerFPMUnit(siteName, phpVersion)
 
-	podmanExec := fmt.Sprintf("%s exec -w %s %s %s", podman.PodmanBin(), sitePath, container, command)
+	podmanExec := fmt.Sprintf("%s exec -w %s %s %s", podman.PodmanBin(), podman.ShellQuote(sitePath), container, command)
 	script := buildDarwinExecWorkerGuardScript(pidFile, podman.PodmanBin(), container, sitePath, command, podmanExec)
 	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
 		return false, fmt.Errorf("writing worker guard script: %w", err)

--- a/internal/cli/worker_darwin_builder.go
+++ b/internal/cli/worker_darwin_builder.go
@@ -11,9 +11,9 @@ import (
 // buildDarwinExecWorkerService renders the systemd-style service unit that
 // `services.Mgr.WriteServiceUnit` (macOS launchd backend) will translate
 // into a launchd plist. ExecStart points at a pre-written guard script
-// because parseServiceUnit in the launchd translator uses strings.Fields
-// on ExecStart, so an inline multi-line script would not survive the
-// split. scriptPath must contain no whitespace.
+// because the launchd translator splits ExecStart into argv, so an inline
+// multi-line script would not survive the split. The path is quoted, since a
+// data dir with a space in it would otherwise arrive as two arguments.
 func buildDarwinExecWorkerService(scriptPath, restart string) string {
 	return fmt.Sprintf(`[Unit]
 Description=Lerd Worker (exec mode)
@@ -21,7 +21,7 @@ Description=Lerd Worker (exec mode)
 [Service]
 Type=simple
 Restart=%s
-ExecStart=/bin/sh %s
+ExecStart=/bin/sh '%s'
 
 [Install]
 WantedBy=default.target
@@ -54,7 +54,7 @@ Description=Lerd Worker (host mode)
 [Service]
 Type=simple
 Restart=%s
-ExecStart=/bin/sh %s
+ExecStart=/bin/sh '%s'
 
 [Install]
 WantedBy=default.target

--- a/internal/cli/worker_darwin_builder_test.go
+++ b/internal/cli/worker_darwin_builder_test.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/services"
 )
 
 // These builder tests are platform-agnostic — they exercise pure string
@@ -12,7 +15,7 @@ import (
 func TestBuildDarwinExecWorkerService_PointsAtGuardScript(t *testing.T) {
 	serviceUnit := buildDarwinExecWorkerService("/run/workers/lerd-queue-alpha.sh", "always")
 
-	if !strings.Contains(serviceUnit, "ExecStart=/bin/sh /run/workers/lerd-queue-alpha.sh") {
+	if !strings.Contains(serviceUnit, "ExecStart=/bin/sh '/run/workers/lerd-queue-alpha.sh'") {
 		t.Errorf("service unit should call guard script via /bin/sh, got:\n%s", serviceUnit)
 	}
 	if !strings.Contains(serviceUnit, "Restart=always") {
@@ -23,22 +26,19 @@ func TestBuildDarwinExecWorkerService_PointsAtGuardScript(t *testing.T) {
 	}
 }
 
-func TestBuildDarwinExecWorkerService_UnquotedPath(t *testing.T) {
-	// launchd's parseServiceUnit uses strings.Fields on ExecStart, which
-	// splits on whitespace — the path to the guard script must contain
-	// no spaces or quotes. Our constructor should produce a clean
-	// whitespace-free argument.
-	unit := buildDarwinExecWorkerService("/run/workers/lerd-queue-alpha.sh", "always")
+func TestBuildDarwinExecWorkerService_ScriptPathSurvivesTheSplit(t *testing.T) {
+	// The launchd translator splits ExecStart into argv, so a guard script
+	// under a data dir with a space in it has to come back as one argument.
+	script := "/Users/me/My Data/lerd/workers/lerd-queue-alpha.sh"
+	unit := buildDarwinExecWorkerService(script, "always")
 	line := findLine(unit, "ExecStart=")
 	if line == "" {
 		t.Fatalf("no ExecStart= line")
 	}
-	// "ExecStart=/bin/sh /path" should have exactly 3 whitespace-split
-	// fields after the `=`: /bin/sh, /path.
-	rhs := strings.TrimPrefix(line, "ExecStart=")
-	fields := strings.Fields(rhs)
-	if len(fields) != 2 {
-		t.Errorf("ExecStart RHS should have 2 fields, got %d: %q", len(fields), rhs)
+	args := services.SplitExecStart(strings.TrimPrefix(line, "ExecStart="))
+	want := []string{"/bin/sh", script}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("ExecStart argv = %q, want %q", args, want)
 	}
 }
 
@@ -107,7 +107,7 @@ func TestBuildDarwinContainerWorkerUnit_CustomContainerUsesSiteImage(t *testing.
 func TestBuildDarwinHostWorkerService_PointsAtGuardScript(t *testing.T) {
 	unit := buildDarwinHostWorkerService("/run/workers/lerd-vite-alpha.sh", "always")
 
-	if !strings.Contains(unit, "ExecStart=/bin/sh /run/workers/lerd-vite-alpha.sh") {
+	if !strings.Contains(unit, "ExecStart=/bin/sh '/run/workers/lerd-vite-alpha.sh'") {
 		t.Errorf("host worker service unit should /bin/sh the guard, got:\n%s", unit)
 	}
 	if !strings.Contains(unit, "Restart=always") {

--- a/internal/cli/worker_guard.go
+++ b/internal/cli/worker_guard.go
@@ -88,5 +88,5 @@ fi
 echo $$ > %[1]s
 trap 'rm -f %[1]s' EXIT
 exec %[5]s
-`, pidFile, podmanBin, container, podman.ShellQuote(inner), runCmd)
+`, podman.ShellQuote(pidFile), podmanBin, container, podman.ShellQuote(inner), runCmd)
 }

--- a/internal/cli/worker_host_darwin_test.go
+++ b/internal/cli/worker_host_darwin_test.go
@@ -114,7 +114,7 @@ func TestWriteWorkerHostUnit_writesGuardAndServiceUnit(t *testing.T) {
 	if mgr.unitName != "lerd-vite-mysite" {
 		t.Errorf("unit name = %q, want lerd-vite-mysite", mgr.unitName)
 	}
-	if !strings.Contains(mgr.unitBody, "ExecStart=/bin/sh "+scriptPath) {
+	if !strings.Contains(mgr.unitBody, "ExecStart=/bin/sh '"+scriptPath+"'") {
 		t.Errorf("service unit ExecStart missing or wrong:\n%s", mgr.unitBody)
 	}
 	if !strings.Contains(mgr.unitBody, "Restart=always") {

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -52,7 +52,7 @@ BindsTo=%s.service
 [Service]
 Type=oneshot
 ExecStart=%s exec -w %s --env=LERD_SITE=%s %s %s
-`, label, siteName, fpmUnit, fpmUnit, podman.PodmanBin(), sitePath, siteName, container, command)
+`, label, siteName, fpmUnit, fpmUnit, podman.PodmanBin(), podman.ShellQuote(sitePath), siteName, container, command)
 
 		timerUnit := fmt.Sprintf(`[Unit]
 Description=Lerd %s timer (%s)
@@ -91,7 +91,7 @@ ExecStart=%s exec -w %s --env=LERD_SITE=%s %s %s
 
 [Install]
 WantedBy=default.target
-`, label, siteName, fpmUnit, fpmUnit, restart, podman.PodmanBin(), sitePath, siteName, container, command)
+`, label, siteName, fpmUnit, fpmUnit, restart, podman.PodmanBin(), podman.ShellQuote(sitePath), siteName, container, command)
 
 	// A previous run may have written a sibling .timer for this unit
 	// (e.g. before the framework yaml dropped its `schedule:` field).

--- a/internal/cli/worker_spaces_linux_test.go
+++ b/internal/cli/worker_spaces_linux_test.go
@@ -1,0 +1,52 @@
+//go:build linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// systemd splits ExecStart on whitespace, so a site under a path with a space
+// hands podman the second word as the container name: the worker dies with
+// `no container with name or ID "Laravel"` on every restart (#893).
+func TestWriteWorkerUnitFileQuotesSitePathWithSpaces(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	sitePath := filepath.Join(t.TempDir(), "My Laravel CMS", "spatnik")
+	if err := os.MkdirAll(sitePath, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	for _, tc := range []struct{ name, schedule, unitName string }{
+		{"daemon", "", "lerd-queue-spatnik"},
+		{"scheduled", "minutely", "lerd-schedule-spatnik"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := writeWorkerUnitFile(
+				tc.unitName, "Queue Worker", "spatnik",
+				sitePath, "8.5", "php artisan queue:work",
+				"always", tc.schedule, "lerd-php85-fpm", false,
+			); err != nil {
+				t.Fatalf("writeWorkerUnitFile: %v", err)
+			}
+
+			data, err := os.ReadFile(filepath.Join(tmp, "systemd", "user", tc.unitName+".service"))
+			if err != nil {
+				t.Fatalf("read unit: %v", err)
+			}
+			unit := string(data)
+
+			if want := "-w '" + sitePath + "'"; !strings.Contains(unit, want) {
+				t.Errorf("want %q in:\n%s", want, unit)
+			}
+			if bare := "-w " + sitePath + " "; strings.Contains(unit, bare) {
+				t.Errorf("site path passed unquoted, systemd will split it:\n%s", unit)
+			}
+		})
+	}
+}

--- a/internal/nginx/framework_nginx_test.go
+++ b/internal/nginx/framework_nginx_test.go
@@ -42,7 +42,13 @@ func TestExpandNginxSnippet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expand: %v", err)
 	}
-	for _, want := range []string{"root /home/u/shop;", "alias /home/u/shop/pub;", "fastcgi_pass lerd-php84-fpm:9000;"} {
+	for _, want := range []string{
+		`set $lerd_root "/home/u/shop";`,
+		`set $lerd_public "/home/u/shop/pub";`,
+		"root ${lerd_root};",
+		"alias ${lerd_public};",
+		"fastcgi_pass lerd-php84-fpm:9000;",
+	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing %q in:\n%s", want, got)
 		}
@@ -70,8 +76,8 @@ func TestExpandNginxSnippetDotPublicDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expand: %v", err)
 	}
-	if got != "root /home/u/wp;" {
-		t.Fatalf("got %q", got)
+	if want := "set $lerd_public \"/home/u/wp\";"; !strings.Contains(got, want) {
+		t.Fatalf("got %q, want %q in it", got, want)
 	}
 }
 
@@ -168,7 +174,7 @@ func TestVhostRendersFrameworkNginxBeforeGenericLocations(t *testing.T) {
 	out := renderVhostForTest(t, "vhost.conf.tmpl", data)
 
 	iSetup := strings.Index(out, "^/setup($|/)")
-	iRoot := strings.Index(out, "root /home/u/shop/pub;")
+	iRoot := strings.Index(out, `root "/home/u/shop/pub";`)
 	iSlash := strings.Index(out, "location / {")
 	iPHP := strings.Index(out, `location ~ \.php$`)
 	iClose := strings.LastIndex(out, "}")

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -92,6 +92,13 @@ type VhostData struct {
 	FrameworkNginx string
 }
 
+// Root is the document root as the templates render it, quoted so a path with a
+// space stays a single nginx token. Every generator that fills a VhostData goes
+// through it, so the site, worktree, and SSL vhosts are all covered.
+func (d VhostData) Root() string {
+	return nginxQuote(d.Path + "/" + d.PublicDir)
+}
+
 // resolveFrameworkNginx returns the site framework's nginx block, expanded and
 // indented for splicing into the server block. Empty when the framework declares
 // none, when the snippet is unbalanced, or when a substituted value carries
@@ -152,6 +159,30 @@ func frameworkNginxBlock(w io.Writer, framework, domain, snippet, sitePath, publ
 // directive, `#` comments out the rest of the line, newlines do both.
 const nginxValueForbidden = "{};#\n\r\x00"
 
+// nginxQuote renders a filesystem path as a quoted nginx token. nginx splits a
+// directive on whitespace, so a project under a path with a space would give
+// root three arguments and nginx rejects the whole config, taking every other
+// site down with it. Backslash-escaping the spaces parses but does not work:
+// nginx keeps the backslash in the value and realpath() then fails on it.
+func nginxQuote(p string) string {
+	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(p) + `"`
+}
+
+// Variables carrying the site paths for framework snippets to interpolate.
+const (
+	nginxRootVar   = "${lerd_root}"
+	nginxPublicVar = "${lerd_public}"
+)
+
+// nginxPathVars declares the variables a framework snippet interpolates. A
+// snippet may use a path mid-token, as Magento's does with {{public}}/static/,
+// and a quoted token cannot be glued to anything, so the path reaches the
+// snippet as a variable: nginx resolves it after tokenizing, spaces and all.
+func nginxPathVars(sitePath, docRoot string) string {
+	return fmt.Sprintf("set $lerd_root %s;\nset $lerd_public %s;\n\n",
+		nginxQuote(sitePath), nginxQuote(docRoot))
+}
+
 // expandNginxSnippet substitutes the placeholders a framework snippet may use.
 // Plain string replacement, not text/template: the snippet is data rendered into
 // a template, so its braces must never be evaluated as template actions. Values
@@ -168,14 +199,17 @@ func expandNginxSnippet(snippet, sitePath, publicDir, fpmContainer string) (stri
 		}
 	}
 	out := strings.NewReplacer(
-		"{{root}}", sitePath,
-		"{{public}}", docRoot,
+		"{{root}}", nginxRootVar,
+		"{{public}}", nginxPublicVar,
 		"{{fpm}}", fpmContainer,
 	).Replace(snippet)
 	// A misspelled placeholder has balanced braces, so it survives validation and
 	// would reach nginx verbatim, breaking the config for every site.
 	if strings.Contains(out, "{{") {
 		return "", fmt.Errorf("nginx snippet has an unknown {{placeholder}}")
+	}
+	if strings.Contains(out, nginxRootVar) || strings.Contains(out, nginxPublicVar) {
+		out = nginxPathVars(sitePath, docRoot) + out
 	}
 	return out, nil
 }
@@ -730,7 +764,7 @@ server {
         default_type text/html;
     }
 }
-`, serverNames, serverNames, site.PrimaryDomain(), site.PrimaryDomain(), pausedDir, htmlFile)
+`, serverNames, serverNames, site.PrimaryDomain(), site.PrimaryDomain(), nginxQuote(pausedDir), htmlFile)
 	}
 	return fmt.Sprintf(`server {
     listen 80;
@@ -742,7 +776,7 @@ server {
         default_type text/html;
     }
 }
-`, serverNames, pausedDir, htmlFile)
+`, serverNames, nginxQuote(pausedDir), htmlFile)
 }
 
 // writeLandingVhost writes site's static-page vhost (serving htmlFile) to
@@ -807,7 +841,7 @@ server {
         default_type text/html;
     }
 }
-`, domain, domain, certDomain, certDomain, pausedDir)
+`, domain, domain, certDomain, certDomain, nginxQuote(pausedDir))
 	} else {
 		conf = fmt.Sprintf(`server {
     listen 80;
@@ -819,7 +853,7 @@ server {
         default_type text/html;
     }
 }
-`, domain, pausedDir)
+`, domain, nginxQuote(pausedDir))
 	}
 
 	confPath := filepath.Join(config.NginxConfD(), domain+".conf")
@@ -1199,7 +1233,7 @@ server {
     listen [::]:443 default_server ssl;
     ssl_reject_handshake on;
 }
-`, errorDir))
+`, nginxQuote(errorDir)))
 }
 
 // contentHashHex is sha256 → hex, used as the managed-file sentinel value.

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -109,7 +109,7 @@ func TestGenerateVhost_honoursSitePublicDir(t *testing.T) {
 		t.Fatalf("GenerateVhost: %v", err)
 	}
 	content := readConf(t, filepath.Join(confD, "myapp.test.conf"))
-	if !strings.Contains(content, "root /srv/myapp/public_html") {
+	if !strings.Contains(content, `root "/srv/myapp/public_html`) {
 		t.Errorf("expected custom public_html doc root in:\n%s", content)
 	}
 }
@@ -365,7 +365,7 @@ func TestGenerateVhost_createsConfFile(t *testing.T) {
 	if !strings.Contains(content, "server_name myapp.test") {
 		t.Errorf("expected server_name myapp.test in:\n%s", content)
 	}
-	if !strings.Contains(content, "root /srv/myapp/public") {
+	if !strings.Contains(content, `root "/srv/myapp/public`) {
 		t.Errorf("expected root path in:\n%s", content)
 	}
 	if !strings.Contains(content, "lerd-php83-fpm") {
@@ -477,7 +477,7 @@ func TestGenerateWorktreeVhost_createsConfFile(t *testing.T) {
 	if !strings.Contains(content, "*.feat-x.myapp.test") {
 		t.Errorf("expected wildcard server_name for worktree subdomains in:\n%s", content)
 	}
-	if !strings.Contains(content, "root /srv/myapp-feat/public") {
+	if !strings.Contains(content, `root "/srv/myapp-feat/public`) {
 		t.Errorf("expected worktree path in:\n%s", content)
 	}
 }

--- a/internal/nginx/templates/vhost-ssl.conf.tmpl
+++ b/internal/nginx/templates/vhost-ssl.conf.tmpl
@@ -9,7 +9,7 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
     server_name {{.ServerNames}};
-    root {{.Path}}/{{.PublicDir}};
+    root {{.Root}};
     index index.php index.html;
 
     ssl_certificate /etc/nginx/certs/{{.CertDomain}}.crt;

--- a/internal/nginx/templates/vhost.conf.tmpl
+++ b/internal/nginx/templates/vhost.conf.tmpl
@@ -2,7 +2,7 @@ server {
     listen 80;
     listen [::]:80;
     server_name {{.ServerNames}};
-    root {{.Path}}/{{.PublicDir}};
+    root {{.Root}};
     index index.php index.html;
 {{if .FrameworkNginx}}
 {{.FrameworkNginx}}

--- a/internal/nginx/vhost_spaces_test.go
+++ b/internal/nginx/vhost_spaces_test.go
@@ -1,0 +1,99 @@
+package nginx
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// A project under a path with a space renders a `root` directive with three
+// arguments, which nginx refuses to parse. It rejects the whole config, so one
+// such site takes every other site down with it (#893).
+func TestVhostQuotesDocumentRootWithSpaces(t *testing.T) {
+	for _, name := range []string{"vhost.conf.tmpl", "vhost-ssl.conf.tmpl"} {
+		out := renderVhostForTest(t, name, VhostData{
+			Domain:         "spatnik.test",
+			ServerNames:    "spatnik.test *.spatnik.test",
+			Path:           "/media/tim/DriveX/My Laravel CMS/Spatnik",
+			PublicDir:      "public",
+			FPMContainer:   "lerd-php85-fpm",
+			CertDomain:     "spatnik.test",
+			RequestTimeout: 60,
+		})
+		want := `root "/media/tim/DriveX/My Laravel CMS/Spatnik/public";`
+		if !strings.Contains(out, want) {
+			t.Errorf("%s: want %q in:\n%s", name, want, out)
+		}
+	}
+}
+
+// Backslash-escaping the spaces would pass `nginx -t` and then 404 every
+// request: nginx keeps the backslash in the value and realpath() fails on it.
+func TestVhostRootIsQuotedNotBackslashEscaped(t *testing.T) {
+	out := renderVhostForTest(t, "vhost.conf.tmpl", VhostData{
+		Domain:       "spatnik.test",
+		Path:         "/media/My Laravel CMS/Spatnik",
+		PublicDir:    "public",
+		FPMContainer: "lerd-php85-fpm",
+	})
+	if strings.Contains(out, `My\ Laravel`) {
+		t.Errorf("root backslash-escaped, which nginx does not resolve:\n%s", out)
+	}
+}
+
+// A framework snippet interpolates the paths mid-token, as Magento's does with
+// {{public}}/static/, and a quoted token cannot be glued to a bare one. The
+// paths reach the snippet as variables, which nginx resolves after tokenizing.
+func TestExpandNginxSnippetUsesPathVariables(t *testing.T) {
+	got, err := expandNginxSnippet(
+		"root {{root}};\nalias {{public}}/static/;\nfastcgi_pass {{fpm}}:9000;",
+		"/media/tim/My Laravel CMS/shop", "pub", "lerd-php84-fpm",
+	)
+	if err != nil {
+		t.Fatalf("expandNginxSnippet: %v", err)
+	}
+	want := "set $lerd_root \"/media/tim/My Laravel CMS/shop\";\n" +
+		"set $lerd_public \"/media/tim/My Laravel CMS/shop/pub\";\n\n" +
+		"root ${lerd_root};\n" +
+		"alias ${lerd_public}/static/;\n" +
+		"fastcgi_pass lerd-php84-fpm:9000;"
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// A snippet that names no path gets no variables: nothing would read them.
+func TestExpandNginxSnippetWithoutPathsDeclaresNoVariables(t *testing.T) {
+	got, err := expandNginxSnippet("fastcgi_pass {{fpm}}:9000;", "/home/u/shop", "public", "lerd-php84-fpm")
+	if err != nil {
+		t.Fatalf("expandNginxSnippet: %v", err)
+	}
+	if strings.Contains(got, "set $lerd_") {
+		t.Errorf("declared unused path variables:\n%s", got)
+	}
+}
+
+// The paused and idle-waking landing pages are served from lerd's own data dir,
+// which sits under $HOME and inherits a space from the user's home directory.
+func TestLandingVhostQuotesRoot(t *testing.T) {
+	site := config.Site{Name: "shop", Domains: []string{"shop.test"}}
+	out := landingVhostConf(site, "/home/My User/.local/share/lerd/paused", "shop.test.html")
+	if want := `root "/home/My User/.local/share/lerd/paused";`; !strings.Contains(out, want) {
+		t.Errorf("want %q in:\n%s", want, out)
+	}
+}
+
+func TestNginxQuote(t *testing.T) {
+	cases := map[string]string{
+		"/home/u/shop":          `"/home/u/shop"`,
+		"/media/My Laravel CMS": `"/media/My Laravel CMS"`,
+		`/media/back\slash`:     `"/media/back\\slash"`,
+		`/media/qu"ote`:         `"/media/qu\"ote"`,
+	}
+	for in, want := range cases {
+		if got := nginxQuote(in); got != want {
+			t.Errorf("nginxQuote(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/nginx/worktree_vhost_test.go
+++ b/internal/nginx/worktree_vhost_test.go
@@ -85,10 +85,10 @@ func TestGenerateWorktreeVhostUsesFrameworkPublicDir(t *testing.T) {
 	}
 	out := readWorktreeConf(t, "feature.shop.test")
 
-	if want := "root " + wt + "/pub;"; !strings.Contains(out, want) {
+	if want := `root "` + wt + `/pub";`; !strings.Contains(out, want) {
 		t.Errorf("missing %q in:\n%s", want, out)
 	}
-	if bad := "root " + wt + "/public;"; strings.Contains(out, bad) {
+	if bad := `root "` + wt + `/public";`; strings.Contains(out, bad) {
 		t.Errorf("worktree rooted at the hardcoded public dir:\n%s", out)
 	}
 }
@@ -106,10 +106,10 @@ func TestGenerateWorktreeVhostRendersFrameworkNginx(t *testing.T) {
 	if !strings.Contains(out, `location ~* ^/(setup|update)($|/) {`) {
 		t.Fatalf("framework snippet missing from worktree vhost:\n%s", out)
 	}
-	if want := "root " + wt + ";"; !strings.Contains(out, want) {
+	if want := `set $lerd_root "` + wt + `";`; !strings.Contains(out, want) {
 		t.Errorf("snippet {{root}} should expand to the worktree, want %q in:\n%s", want, out)
 	}
-	if bad := "root " + parent + ";"; strings.Contains(out, bad) {
+	if bad := `set $lerd_root "` + parent + `";`; strings.Contains(out, bad) {
 		t.Errorf("snippet {{root}} expanded to the parent checkout:\n%s", out)
 	}
 	if !strings.Contains(out, "fastcgi_pass lerd-php84-fpm:9000;") {
@@ -127,7 +127,7 @@ func TestGenerateWorktreeSSLVhostUsesFrameworkConfig(t *testing.T) {
 	}
 	out := readWorktreeConf(t, "feature.shop.test")
 
-	if want := "root " + wt + "/pub;"; !strings.Contains(out, want) {
+	if want := `root "` + wt + `/pub";`; !strings.Contains(out, want) {
 		t.Errorf("missing %q in:\n%s", want, out)
 	}
 	if !strings.Contains(out, `location ~* ^/(setup|update)($|/) {`) {
@@ -148,7 +148,7 @@ func TestGenerateWorktreeVhostHonoursSitePublicDir(t *testing.T) {
 	}
 	out := readWorktreeConf(t, "feature.shop.test")
 
-	if want := "root " + wt + "/web;"; !strings.Contains(out, want) {
+	if want := `root "` + wt + `/web";`; !strings.Contains(out, want) {
 		t.Errorf("missing %q in:\n%s", want, out)
 	}
 }
@@ -163,7 +163,7 @@ func TestGenerateWorktreeVhostUnknownParentFallsBack(t *testing.T) {
 	}
 	out := readWorktreeConf(t, "feature.ghost.test")
 
-	if want := "root " + wt + "/public;"; !strings.Contains(out, want) {
+	if want := `root "` + wt + `/public";`; !strings.Contains(out, want) {
 		t.Errorf("missing fallback %q in:\n%s", want, out)
 	}
 	if strings.Contains(out, "^/(setup|update)") {

--- a/internal/services/execline.go
+++ b/internal/services/execline.go
@@ -1,0 +1,54 @@
+package services
+
+import "strings"
+
+// SplitExecStart splits a systemd ExecStart= line into argv the way systemd
+// does, honouring single and double quotes so an argument may contain spaces.
+// The launchd backend translates the same unit files systemd reads on Linux, so
+// it has to agree on the quoting: a site under a path with a space passes its
+// working directory as `-w '/Users/me/My Projects/shop'`, and splitting that on
+// whitespace alone would hand podman `Projects/shop'` as the container name.
+func SplitExecStart(line string) []string {
+	var (
+		args    []string
+		cur     strings.Builder
+		inArg   bool
+		quote   rune // 0 when unquoted, else the open quote
+		escaped bool
+	)
+	for _, r := range line {
+		switch {
+		case escaped:
+			cur.WriteRune(r)
+			escaped = false
+		case r == '\\' && quote != '\'':
+			// Escapes work outside quotes and inside double quotes, as they do
+			// in systemd and the shell. ShellQuote writes an apostrophe in a
+			// path as '\'', which only reassembles if this is honoured.
+			escaped = true
+			inArg = true
+		case quote != 0:
+			if r == quote {
+				quote = 0
+			} else {
+				cur.WriteRune(r)
+			}
+		case r == '\'' || r == '"':
+			quote = r
+			inArg = true
+		case r == ' ' || r == '\t':
+			if inArg {
+				args = append(args, cur.String())
+				cur.Reset()
+				inArg = false
+			}
+		default:
+			cur.WriteRune(r)
+			inArg = true
+		}
+	}
+	if inArg {
+		args = append(args, cur.String())
+	}
+	return args
+}

--- a/internal/services/execline_test.go
+++ b/internal/services/execline_test.go
@@ -1,0 +1,62 @@
+package services
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitExecStart(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{
+			name: "plain command",
+			line: "/usr/bin/podman exec -w /Users/me/shop lerd-php84-fpm php artisan queue:work",
+			want: []string{"/usr/bin/podman", "exec", "-w", "/Users/me/shop", "lerd-php84-fpm", "php", "artisan", "queue:work"},
+		},
+		{
+			// Without quote handling podman is handed "Projects/shop'" as the
+			// container name and the worker never starts (#893).
+			name: "single-quoted path with spaces",
+			line: "/usr/bin/podman exec -w '/Users/me/My Projects/shop' lerd-php84-fpm php artisan horizon",
+			want: []string{"/usr/bin/podman", "exec", "-w", "/Users/me/My Projects/shop", "lerd-php84-fpm", "php", "artisan", "horizon"},
+		},
+		{
+			name: "double-quoted path with spaces",
+			line: `/bin/sh "/Users/me/My Data/lerd/workers/queue.sh"`,
+			want: []string{"/bin/sh", "/Users/me/My Data/lerd/workers/queue.sh"},
+		},
+		{
+			name: "escaped quote inside double quotes",
+			line: `/bin/echo "a \"b\" c"`,
+			want: []string{"/bin/echo", `a "b" c`},
+		},
+		{
+			name: "runs of whitespace collapse",
+			line: "  /bin/echo   a\tb  ",
+			want: []string{"/bin/echo", "a", "b"},
+		},
+		{
+			name: "empty quoted argument is kept",
+			line: "/bin/echo '' x",
+			want: []string{"/bin/echo", "", "x"},
+		},
+		{
+			// ShellQuote renders an apostrophe as '\'', which only survives the
+			// round trip if an escape outside quotes is honoured. Folders like
+			// "Tim's Projects" are ordinary on macOS.
+			name: "apostrophe in path, as ShellQuote writes it",
+			line: `/usr/bin/podman exec -w '/Users/tim/Tim'\''s Projects/shop' lerd-php84-fpm php artisan queue:work`,
+			want: []string{"/usr/bin/podman", "exec", "-w", "/Users/tim/Tim's Projects/shop", "lerd-php84-fpm", "php", "artisan", "queue:work"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SplitExecStart(tc.line); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("SplitExecStart(%q)\n got %q\nwant %q", tc.line, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -446,7 +446,7 @@ func parseServiceUnit(name, content string) (args []string, keepAlive keepAliveP
 	if len(execStarts) == 0 {
 		return nil, keepAliveNever, fmt.Errorf("no ExecStart= found in service unit %s", name)
 	}
-	args = strings.Fields(expandSpecifiers(execStarts[0]))
+	args = SplitExecStart(expandSpecifiers(execStarts[0]))
 	if len(args) == 0 {
 		return nil, keepAliveNever, fmt.Errorf("empty ExecStart in service unit %s", name)
 	}


### PR DESCRIPTION
A project under a path with a space in it, say /media/tim/DriveX/My Laravel CMS/Spatnik, breaks nginx outright. nginx splits a directive on whitespace, so the generated root came out with three arguments, and nginx rejects the whole config rather than the offending server block. Linking one such site therefore takes every other site on the machine down with it, which is what the reporter hit.

The document root is quoted now. Backslash escaping is the obvious alternative and it is a trap worth naming: it passes nginx -t cleanly and then 404s every request, because nginx keeps the backslash in the value and realpath fails on it. Quoting is also not enough on its own, because a framework snippet can interpolate a path mid-token, as Magento does with alias {{public}}/static/, and nginx will not glue a quoted token to a bare one. So {{root}} and {{public}} expand to nginx variables that lerd declares at the top of the server block, which nginx resolves after tokenizing and which work standalone or concatenated.

The path reaches systemd too, as the worker's working directory. An unquoted ExecStart argument meant podman read the second word as the container name, so the queue worker died with `no container with name or ID "Laravel"` and restart-looped. macOS has no systemd to parse the unit: lerd translates it into a launchd plist itself, and that translator was splitting ExecStart on whitespace with no notion of quoting, so it would have mangled the fix rather than benefited from it. It now parses the quoting the way systemd does, including the apostrophe form that a folder like Tim's Projects produces, so systemd, launchd and the shell all agree on one quoting mechanism.

A path containing a dollar sign is still not supported, and cannot be: nginx has no escape for it inside a value.

Refs #893