### PR TITLE
fix: keep lerd new's own flags out of the scaffold command, and mount its target

### DIFF
--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -135,6 +135,13 @@ lerd new /path/to/myapp                 # create at an absolute path
 lerd new myapp -- --no-interaction      # pass extra flags to the scaffold command
 ```
 
+`--framework` works before or after the name. Flags belong to lerd wherever they
+appear on the line, so anything meant for the scaffold command itself goes after
+`--`. An absolute target outside your home directory is fine: lerd creates the
+parent directory and mounts it into the PHP container before scaffolding.
+Temporary system directories (`/tmp`, `/var/tmp`, `/run`) are never mounted, so
+scaffolding into one is refused unless you [park](/usage/sites) its parent first.
+
 After creation:
 ```bash
 cd myapp

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -10,7 +10,14 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
+)
+
+var (
+	ensurePathMounted = podman.EnsurePathMounted
+	pathAutoMountable = podman.PathAutoMountable
+	pathVisible       = podman.PathVisible
 )
 
 // NewNewCmd returns the new command — scaffold a new PHP project.
@@ -26,6 +33,9 @@ func NewNewCmd() *cobra.Command {
   lerd new myapp --framework=symfony      # create ./myapp using Symfony
   lerd new /path/to/myapp                 # create at an absolute path
   lerd new myapp -- --no-interaction      # pass extra args to the scaffold command
+
+Flags anywhere on the line belong to lerd; everything after '--' is handed to
+the scaffold command untouched.
 
 For Laravel this runs:
   composer create-project --no-install --no-plugins --no-scripts laravel/laravel <target> [extra args]
@@ -47,9 +57,6 @@ After creation, register the site with:
 		},
 	}
 
-	// Stop flag parsing after the first positional arg so extra flags
-	// (e.g. --no-interaction) are passed through to the scaffold command.
-	cmd.Flags().SetInterspersed(false)
 	cmd.Flags().StringVar(&frameworkName, "framework", "laravel", "Framework to use")
 
 	return cmd
@@ -59,6 +66,24 @@ After creation, register the site with:
 // typed (filepath.Base would drop the parent dirs of a nested target).
 func newNextStep(typedTarget string) string {
 	return "cd " + typedTarget + " && lerd link && lerd setup"
+}
+
+// prepareScaffoldParent creates the target's parent directory and makes it
+// visible inside the PHP container. The scaffold shells out to composer, which
+// is a container shim, so an unmounted parent leaves crun with nothing to chdir
+// into and it exits 127 before composer ever runs.
+func prepareScaffoldParent(target string) error {
+	parent := filepath.Dir(target)
+	if err := os.MkdirAll(parent, 0755); err != nil {
+		return fmt.Errorf("cannot create %s: %w", parent, err)
+	}
+	cfg, _ := config.LoadGlobal()
+	version := cfg.PHP.DefaultVersion
+	if !pathVisible(parent, version) && !pathAutoMountable(parent) {
+		return fmt.Errorf("cannot scaffold into %s: lerd does not mount temporary system directories (/tmp, /var/tmp, /run) into containers, so composer would have no such directory to run in. Pick a path under your home directory, or park the parent first with 'lerd park %s'", parent, parent)
+	}
+	ensurePathMounted(parent, version)
+	return nil
 }
 
 func runNew(target, frameworkName string, extraArgs []string) error {
@@ -81,6 +106,10 @@ func runNew(target, frameworkName string, extraArgs []string) error {
 	}
 	if fw.Create == "" {
 		return fmt.Errorf("framework %q has no create command — add a 'create' field to its YAML definition", frameworkName)
+	}
+
+	if err := prepareScaffoldParent(target); err != nil {
+		return err
 	}
 
 	// Build the full command: <create command parts> <target> [extra args]

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -1,6 +1,15 @@
 package cli
 
-import "testing"
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
 
 // The "Next" hint must cd into the path the user actually typed. Using only the
 // base name breaks for nested targets (lerd new apps/myapp → cd myapp).
@@ -17,5 +26,159 @@ func TestNewNextStep(t *testing.T) {
 		if got := newNextStep(tc.target); got != tc.want {
 			t.Errorf("newNextStep(%q) = %q, want %q", tc.target, got, tc.want)
 		}
+	}
+}
+
+// runNewCmd parses args through the real command, stubbing out the scaffold so
+// the test only observes what flag parsing produced.
+func runNewCmd(t *testing.T, args ...string) (target, framework string, extra []string, err error) {
+	t.Helper()
+	cmd := NewNewCmd()
+	cmd.RunE = func(c *cobra.Command, positional []string) error {
+		target = positional[0]
+		extra = positional[1:]
+		framework, _ = c.Flags().GetString("framework")
+		return nil
+	}
+	cmd.SetArgs(args)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err = cmd.Execute()
+	return
+}
+
+// The help text advertises `lerd new myapp --framework=symfony`, so a flag after
+// the positional must be lerd's own, not forwarded to composer.
+func TestNewCmdParsesFrameworkAfterTarget(t *testing.T) {
+	target, framework, extra, err := runNewCmd(t, "magento-real", "--framework=magento")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if target != "magento-real" {
+		t.Errorf("target = %q, want magento-real", target)
+	}
+	if framework != "magento" {
+		t.Errorf("framework = %q, want magento", framework)
+	}
+	if len(extra) != 0 {
+		t.Errorf("extra args = %v, want none", extra)
+	}
+}
+
+func TestNewCmdParsesFrameworkBeforeTarget(t *testing.T) {
+	target, framework, _, err := runNewCmd(t, "--framework=magento", "magento-real")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if target != "magento-real" || framework != "magento" {
+		t.Errorf("target = %q, framework = %q, want magento-real/magento", target, framework)
+	}
+}
+
+// Everything after -- still belongs to the scaffold command, flags included.
+func TestNewCmdForwardsArgsAfterDash(t *testing.T) {
+	target, framework, extra, err := runNewCmd(t, "myapp", "--", "--no-interaction", "--dev")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if target != "myapp" {
+		t.Errorf("target = %q, want myapp", target)
+	}
+	if framework != "laravel" {
+		t.Errorf("framework = %q, want laravel", framework)
+	}
+	if want := []string{"--no-interaction", "--dev"}; !reflect.DeepEqual(extra, want) {
+		t.Errorf("extra args = %v, want %v", extra, want)
+	}
+}
+
+// An unknown flag before -- is a mistake, not scaffold input: forwarding it is
+// what made composer die with `The "--framework" option does not exist`.
+func TestNewCmdRejectsUnknownFlagBeforeDash(t *testing.T) {
+	_, _, _, err := runNewCmd(t, "myapp", "--no-interaction")
+	if err == nil {
+		t.Fatal("expected an error for an unconsumed flag, got none")
+	}
+	if !strings.Contains(err.Error(), "--no-interaction") {
+		t.Errorf("error = %v, want it to name the offending flag", err)
+	}
+}
+
+// stubMountSeams swaps the podman lookups for fixed answers and records the
+// mount call, so the scaffold guard can be driven without touching quadlets.
+func stubMountSeams(t *testing.T, autoMountable, visible bool) *string {
+	t.Helper()
+	mounted := new(string)
+	origMount, origAuto, origVisible := ensurePathMounted, pathAutoMountable, pathVisible
+	ensurePathMounted = func(path, phpVersion string) { *mounted = path }
+	pathAutoMountable = func(path string) bool { return autoMountable }
+	pathVisible = func(path, phpVersion string) bool { return visible }
+	t.Cleanup(func() {
+		ensurePathMounted, pathAutoMountable, pathVisible = origMount, origAuto, origVisible
+	})
+	return mounted
+}
+
+// The scaffold runs composer through the container shim, so the target's parent
+// has to exist on the host and be bind-mounted before the container starts.
+func TestPrepareScaffoldParentMountsParent(t *testing.T) {
+	mounted := stubMountSeams(t, true, false)
+
+	parent := filepath.Join(t.TempDir(), "out", "of", "home")
+	if err := prepareScaffoldParent(filepath.Join(parent, "oobtest")); err != nil {
+		t.Fatalf("prepareScaffoldParent: %v", err)
+	}
+	if *mounted != parent {
+		t.Errorf("mounted %q, want %q", *mounted, parent)
+	}
+	if info, err := os.Stat(parent); err != nil || !info.IsDir() {
+		t.Errorf("parent %q was not created: %v", parent, err)
+	}
+}
+
+// A parent lerd will never bind-mount (a temp dir) and that no parked volume
+// covers must fail up front, not as a crun exit 127 out of composer.
+func TestPrepareScaffoldParentRejectsUnmountableParent(t *testing.T) {
+	mounted := stubMountSeams(t, false, false)
+
+	err := prepareScaffoldParent(filepath.Join(t.TempDir(), "oob", "app"))
+	if err == nil {
+		t.Fatal("expected an error for a parent lerd cannot mount")
+	}
+	if !strings.Contains(err.Error(), "lerd park") {
+		t.Errorf("error = %v, want it to suggest parking the parent", err)
+	}
+	if *mounted != "" {
+		t.Errorf("mounted %q, want no mount attempt", *mounted)
+	}
+}
+
+// Parking a temp dir is how you opt in, so an already-visible parent scaffolds.
+func TestPrepareScaffoldParentAcceptsVisibleParent(t *testing.T) {
+	stubMountSeams(t, false, true)
+
+	if err := prepareScaffoldParent(filepath.Join(t.TempDir(), "parked", "app")); err != nil {
+		t.Fatalf("prepareScaffoldParent: %v", err)
+	}
+}
+
+// A parent we cannot create must fail before composer runs, with a message that
+// points at the directory rather than a crun exit 127.
+func TestPrepareScaffoldParentFailsOnUncreatableParent(t *testing.T) {
+	mounted := stubMountSeams(t, true, false)
+
+	blocker := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(blocker, []byte("not a dir"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := prepareScaffoldParent(filepath.Join(blocker, "sub", "app"))
+	if err == nil {
+		t.Fatal("expected an error when the parent cannot be created")
+	}
+	if !strings.Contains(err.Error(), filepath.Join(blocker, "sub")) {
+		t.Errorf("error = %v, want it to name the parent directory", err)
+	}
+	if *mounted != "" {
+		t.Error("must not try to mount a parent that does not exist")
 	}
 }

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -1036,16 +1036,61 @@ var (
 
 const pathMountDebounce = 60 * time.Second
 
+// PathAutoMountable reports whether EnsurePathMounted would bind-mount the
+// given path on demand. The filesystem root is refused (issue #884) and so are
+// the ephemeral system trees above; callers that need such a path inside a
+// container have to say so explicitly, by parking it.
+func PathAutoMountable(path string) bool {
+	if !bindMountable(path) {
+		return false
+	}
+	for _, p := range ephemeralPathPrefixes {
+		if strings.HasPrefix(path, p) {
+			return false
+		}
+	}
+	return true
+}
+
+// PathVisible reports whether a path can already be reached inside the PHP-FPM
+// container for the given version, either because it lives under $HOME or
+// because a Volume line (its own, or an ancestor's) already covers it.
+func PathVisible(path, phpVersion string) bool {
+	if !bindMountable(path) {
+		return false
+	}
+	if home, _ := os.UserHomeDir(); home != "" && (path == home || strings.HasPrefix(path, strings.TrimSuffix(home, "/")+"/")) {
+		return true
+	}
+	short := strings.ReplaceAll(phpVersion, ".", "")
+	content, err := os.ReadFile(filepath.Join(config.QuadletDir(), "lerd-php"+short+"-fpm.container"))
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		spec, ok := strings.CutPrefix(strings.TrimSpace(line), "Volume=")
+		if !ok {
+			continue
+		}
+		src, _, found := strings.Cut(spec, ":")
+		if !found || !filepath.IsAbs(src) {
+			continue
+		}
+		if path == src || strings.HasPrefix(path, strings.TrimSuffix(src, "/")+"/") {
+			return true
+		}
+	}
+	return false
+}
+
 // EnsurePathMounted checks whether the given path is accessible inside the
 // PHP-FPM and nginx containers. If the path is outside $HOME and not already
 // volume-mounted, the quadlets are updated and containers restarted
 // transparently before returning.
 func EnsurePathMounted(path, phpVersion string) {
-	// Never bind-mount the filesystem root (or an empty/relative path): it would
-	// inject Volume=/:/:rw into the nginx and FPM quadlets and restart them into
-	// a crun exit 127 (issue #884). This path is reached from `lerd php`, console,
-	// tinker, shell and setup, so a command run from / must not brick nginx.
-	if !bindMountable(path) {
+	// Reached from `lerd php`, console, tinker, shell, setup and new, so a
+	// command run from / or from a temp dir must not rewrite the quadlets.
+	if !PathAutoMountable(path) {
 		return
 	}
 	home, _ := os.UserHomeDir()
@@ -1058,11 +1103,6 @@ func EnsurePathMounted(path, phpVersion string) {
 	}
 	if path == home || strings.HasPrefix(path, homePrefix) {
 		return
-	}
-	for _, p := range ephemeralPathPrefixes {
-		if strings.HasPrefix(path, p) {
-			return // ephemeral system dir, never bind-mount
-		}
 	}
 
 	pathMountAttemptsMu.Lock()

--- a/internal/podman/path_mount_test.go
+++ b/internal/podman/path_mount_test.go
@@ -1,6 +1,8 @@
 package podman
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -33,6 +35,61 @@ func TestEphemeralPathsAreSkipped(t *testing.T) {
 		if !matched {
 			t.Errorf("%s should be classified as ephemeral", p)
 		}
+	}
+}
+
+func TestPathAutoMountable(t *testing.T) {
+	cases := map[string]bool{
+		"/srv/projects":    true,
+		"/mnt/data/apps":   true,
+		"/":                false,
+		"":                 false,
+		"relative/path":    false,
+		"/var/tmp/lerd":    false,
+		"/tmp/lerd":        false,
+		"/run/user/1000/x": false,
+	}
+	for path, want := range cases {
+		if got := PathAutoMountable(path); got != want {
+			t.Errorf("PathAutoMountable(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+// A path lerd refuses to auto-mount can still be reachable inside the container
+// because it was parked: the Volume line is already in the FPM quadlet.
+func TestPathVisible(t *testing.T) {
+	home := t.TempDir()
+	cfgHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+
+	quadlets := filepath.Join(cfgHome, "containers", "systemd")
+	if err := os.MkdirAll(quadlets, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := "[Container]\nVolume=/var/tmp/parked:/var/tmp/parked:rw\nVolume=/srv/apps:/srv/apps:rw\n"
+	if err := os.WriteFile(filepath.Join(quadlets, "lerd-php84-fpm.container"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := map[string]bool{
+		filepath.Join(home, "Code", "app"): true,  // under $HOME
+		"/var/tmp/parked":                  true,  // parked, mounted verbatim
+		"/var/tmp/parked/nested":           true,  // covered by the parked ancestor
+		"/var/tmp/other":                   false, // never mounted
+		"/srv/apps/shop":                   true,
+		"/srv/appsuite":                    false, // ancestor match must respect the separator
+		"/opt/elsewhere":                   false,
+	}
+	for path, want := range cases {
+		if got := PathVisible(path, "8.4"); got != want {
+			t.Errorf("PathVisible(%q) = %v, want %v", path, got, want)
+		}
+	}
+
+	if PathVisible("/srv/apps/shop", "8.1") {
+		t.Error("PathVisible should report false when the version's quadlet does not exist")
 	}
 }
 


### PR DESCRIPTION
lerd new stopped parsing flags at the first positional argument, so the invocation its own help advertises, lerd new myapp --framework=symfony, scaffolded Laravel and then handed --framework=symfony to composer, which died on an option it does not have. Flags are now parsed wherever they sit on the line and only what follows -- reaches the scaffold command, which also stops the separator itself from being forwarded along with the arguments after it. An unknown flag before the separator is now rejected rather than passed on for composer to choke on.

The scaffold shells out to composer, which on PATH is a container shim, so a target outside the home directory left crun with no such directory to chdir into and it exited 127 before composer ever ran. lerd new now creates the target's parent and mounts it into the containers the way php, console, tinker, shell and setup already do.

Temporary system trees are deliberately never auto-mounted, since php and composer get invoked from whatever working directory an IDE happens to be in, and a mount there would cascade FPM restarts. A target under one of them is therefore refused up front, with a pointer at lerd park, which is the explicit opt-in that already mounts such a path.

Refs #876
Refs #895