### PR TITLE
fix: honour output silent, doctor severity, and confirm on doctor fixes

### DIFF
--- a/docs/features/commands.md
+++ b/docs/features/commands.md
@@ -24,8 +24,8 @@ Some commands include a `check:` rule and only surface when the relevant package
 
 Clicking a command (or pressing Enter on a palette entry, or running `lerd run <name>`) executes the shell command in the project's directory, with stdio routed depending on the command's `output:` value:
 
-- **`silent`** (default) — runs, captures output, shows a brief success or failure indicator in the modal.
-- **`text`** — same as silent but with the captured stdout rendered in a scrollable monospace block. Use for commands whose output you'd want to read (test runs, route lists, config diffs).
+- **`text`** (default) — streams stdout and stderr into the modal as a scrollable monospace block, and leaves it open on the exit code. Use for commands whose output you'd want to read (test runs, route lists, config diffs).
+- **`silent`** — runs without opening the modal and toasts when it's done, so a cache clear doesn't cost you a click. A failure still opens the modal with the captured output, since that's the only thing that explains it.
 - **`url`** — captures stdout, scans it for the first `http(s)://...` URL, and surfaces it with Copy and Open buttons. The killer feature for `drush uli` and similar one-time-login generators.
 - **`terminal`** — spawns the user's terminal emulator (kitty, foot, alacritty, wezterm, ghostty, ptyxis, konsole, gnome-terminal, xterm; on macOS iTerm or Terminal.app) with the command running inside. Use for interactive commands like `php artisan tinker`, `bin/cake bake`, `wp shell` that need a real TTY. The lerd-ui modal stays closed.
 
@@ -75,7 +75,7 @@ commands:
     label: Clear all caches       # UI label
     command: php artisan optimize:clear   # shell, passed to `sh -c`
     description: Clear config, route, view, event, and compiled caches
-    output: silent                # silent | text | url | terminal
+    output: silent                # silent | text | url | terminal (default: text)
     confirm: false                # ask before running
     icon: broom                   # from the known icon set
     cwd: .                        # optional, relative to project root
@@ -86,7 +86,7 @@ commands:
 
 **Known icons**: `broom`, `database`, `refresh`, `link`, `check`, `list`, `key`, `edit`, `arrow-down`, `arrow-up`, `play`, `terminal`. An unknown icon falls back to a generic glyph; `lerd check` warns.
 
-**Output values:** invalid values fail `lerd check`. Defaults to `silent`.
+**Output values:** invalid values fail `lerd check`. Defaults to `text`.
 
 **Check rules**: reuse `FrameworkRule`. The two common forms are `composer: <package>` (the package must be in `composer.json`) and `file: <path>` (the file must exist relative to the project root).
 

--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -216,6 +216,32 @@ logs:
   - path: "var/log/*.log"             # glob relative to project root
     format: raw                       # monolog | raw (plain text, default)
 
+# Custom commands, shown in the dashboard and runnable with `lerd run` (optional)
+commands:
+  - name: cache:clear                 # stable id, unique; the `lerd run` argument
+    label: Clear cache                # display name
+    command: bin/console cache:clear  # shell, run through `sh -c`
+    description: Clear the Symfony cache for the current environment
+    output: silent                    # silent | text | url | terminal (default: text)
+    confirm: false                    # gate behind a confirmation (optional, default: false)
+    icon: broom                       # name from the known icon set (optional)
+    cwd: .                            # working dir relative to project root (optional, default: .)
+    check:                            # hide the command unless the rule matches (optional)
+      composer: symfony/framework-bundle
+
+# Site doctor checks, run after the universal baseline every framework gets (optional)
+doctor:
+  checks:
+    - name: storage_link              # stable id
+      type: symlink                   # env_key_set | env_combo | symlink | command
+      label: Storage Link             # display label
+      link: public/storage            # the path that must be a symlink
+      target: storage/app/public      # skipped unless this dir exists
+      requires_dir: public            # skipped unless this dir exists too (optional)
+      fix: storage:link               # names one of the framework's own commands
+      detail: The public/storage link is missing.   # overrides the generated message (optional)
+      severity: warn                  # warn | fail (optional, per-type default)
+
 # Extra nginx config spliced into the site's server block (optional)
 nginx:
   snippet: |
@@ -240,6 +266,83 @@ The `{{site}}`, `{{site_testing}}`, `{{bucket}}`, `{{domain}}`, `{{scheme}}`, an
 This is what lets a framework whose bootstrap needs to know where the site lives declare that step as data. Magento 2.4 removed its web installer, so a fresh store is installed with `bin/magento setup:install --base-url=… --db-name=…`; the definition can now express exactly that. A step that creates schema should carry `default: false` so it is opt-in rather than running on every `lerd setup`.
 
 A placeholder whose value is empty, or one lerd does not recognise, is left in the command verbatim rather than being replaced with an empty string, so a half-resolved context can never quietly produce `--base-url=://`.
+
+## Custom commands
+
+The `commands:` list is the framework's own verbs: the things you would otherwise type into a console by hand. Each entry shows up on the site's dashboard, in the command palette, and as an argument to `lerd run`, and can be named as the `fix:` of a doctor check.
+
+`name` and `command` are the only required keys. The name is a stable identifier, unique within the definition, and is what `lerd run <name>` and a doctor `fix:` both refer to, so treat it as API and don't rename it casually. The command is a shell string handed to `sh -c`, with the [site placeholders](#site-placeholders) expanded first. It runs in the site's PHP-FPM container, from the project root unless `cwd` moves it; `cwd` is a path relative to that root, and `.` and an empty value both mean the root itself. When a command is run against a git worktree, the root is the worktree's own checkout.
+
+`output` decides where the command's output goes, and the four values are genuinely different surfaces:
+
+| Value | What happens |
+|---|---|
+| `text` | Streams stdout and stderr into the run modal as they arrive, and the modal stays open afterwards showing the exit code and duration. This is what you get when `output` is omitted. |
+| `silent` | Runs without opening the modal at all, and shows a toast when it finishes. A non-zero exit is the exception: the modal opens after all, carrying the captured output, because that output is the only thing that explains the failure. Use it for commands whose output nobody reads, like a cache clear. |
+| `url` | Streams like `text`, and additionally lifts the first `http://` or `https://` URL out of the output into a copy-and-open panel on the finished modal. This exists for one-time login links, like Drupal's `drush uli`. |
+| `terminal` | Spawns the user's terminal emulator running the command, instead of streaming it anywhere. Nothing is captured, so there is no output pane, no exit code, and no run history. Use it for commands that are interactive or long-lived enough that a modal is the wrong container. It is rejected over MCP, which has no terminal to open. |
+
+`confirm: true` puts the command behind a confirmation showing the exact command line before anything runs, and the dashboard, `lerd run` (unless you pass `--yes`) and MCP (unless the caller forces it) all honour it. This is what lets a genuinely destructive command ship as a command rather than as a setup step: Laravel's `migrate:fresh` drops every table, and Magento ships `setup:install` this way.
+
+`check` takes the same rule shape as a worker's or a setup step's, so `composer: <package>` or `file: <path>`, and a command whose check fails is dropped from the resolved set rather than merely hidden, which means it also disappears from `lerd run` and from any doctor `fix:` pointing at it. Use it for commands that only make sense when an optional package is installed.
+
+`icon` is drawn from a fixed vocabulary, and a name outside it renders a generic fallback rather than failing. The set is:
+
+`broom`, `database`, `refresh`, `link`, `check`, `list`, `key`, `edit`, `arrow-down`, `arrow-up`, `play`, `terminal`
+
+`lerd check` validates a definition's commands, and it is the fastest way to catch a typo: an unknown `output` is an error, and an unknown `icon` is a warning.
+
+## Doctor checks
+
+The `doctor:` section adds framework-specific health checks to the ones every site gets for free (env file present, dependencies installed and locked, audit clean, PHP version in range). They run on `lerd site:doctor` and in the dashboard's doctor panel. Keeping them declarative is what stops the doctor from growing a Go branch per framework.
+
+Each check carries a `name` (a stable id), a `type` that selects the evaluator, an optional `label` for display, an optional `detail` that overrides the generated message, an optional `severity`, and an optional `fix`.
+
+`fix` names one of the framework's own `commands:` entries, by `name`. That indirection is the whole design: the doctor never grows its own mutation endpoints, it just points at a command the framework already exposes, and the UI renders a Fix button that runs it. A `fix` naming a command that does not exist, or one whose `check` rule failed, simply renders no button, and nothing validates the reference, so check your spelling. Four universal keys are also accepted, for the fixes that are not framework-specific: `composer_install`, `composer_update`, `npm_install` and `npm_audit_fix`.
+
+The Fix button runs the command through the same gate as everywhere else, so a fix pointing at a `confirm: true` command still asks first, and the doctor re-checks only once the command has actually run.
+
+There are four check types, each with its own fields.
+
+`env_key_set` fails when a single env key is empty. It takes `env_key`, the key to read.
+
+```yaml
+- name: mailer_dsn
+  type: env_key_set
+  label: Mailer
+  env_key: MAILER_DSN
+  detail: MAILER_DSN is empty, so no mail will be sent.
+```
+
+`env_combo` catches a combination of env values that is individually legal but collectively a footgun, the classic being debug mode left on in production. It takes `when` and `warn_if`, both maps of key to expected value, and only triggers when every pair in both maps matches. Values are compared truthily, so a `warn_if` of `true` matches `1`, `on` and `yes` as well.
+
+```yaml
+- name: app_debug
+  type: env_combo
+  label: Debug Mode
+  when: { APP_ENV: production }
+  warn_if: { APP_DEBUG: true }
+  detail: APP_DEBUG is on in production, which leaks stack traces.
+```
+
+`symlink` checks that a path is a symlink, for the likes of Laravel's `public/storage`. It takes `link`, the path that should be one, and `target`, the directory it should point into. The check skips itself entirely when `target` does not exist, since the link is meaningless then, and `requires_dir` adds a second directory that must exist for the check to apply at all.
+
+`command` runs a console command inside the site's container and judges the result. It takes `command`, and `fail_if_output_contains`, a plain substring that marks the finding as triggered when it appears in the output. `timeout` caps the run in seconds, defaulting to 25. `unknown_on_error: true` is the important one: when the command cannot run at all, because the app is wedged or the database is unreachable, the check reports "unknown" instead of failing, so a down app does not turn the whole panel red with checks that never actually ran.
+
+```yaml
+- name: migrations
+  type: command
+  label: Migrations
+  command: php artisan migrate:status
+  fail_if_output_contains: "Pending"
+  unknown_on_error: true
+  timeout: 30
+  fix: migrate
+```
+
+`severity` overrides the status a triggered check reports, and takes `warn` or `fail`. The default differs by type, which is not something you would guess: a `command` check defaults to `fail`, and the other three default to `warn`. So a pending-migrations check is a failure unless you say otherwise, while a missing symlink is a warning. An unrecognised severity is ignored rather than rejected, falling back to the type default.
+
+An unknown `type` is skipped rather than treated as an error, so a definition using a check type a newer lerd added still loads on an older binary; the new check just does not run.
 
 ## PHP ini for the CLI
 

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -280,7 +280,7 @@ type FrameworkCommand struct {
 	Label       string         `yaml:"label" json:"label"`                                 // human label shown in the UI
 	Command     string         `yaml:"command" json:"command"`                             // shell command, passed to `sh -c`
 	Description string         `yaml:"description,omitempty" json:"description,omitempty"` // one-line description for tooltips
-	Output      string         `yaml:"output,omitempty" json:"output,omitempty"`           // silent | text | url | terminal (default: silent)
+	Output      string         `yaml:"output,omitempty" json:"output,omitempty"`           // silent | text | url | terminal (default: text)
 	Confirm     bool           `yaml:"confirm,omitempty" json:"confirm,omitempty"`         // gate behind a confirm modal before running
 	Icon        string         `yaml:"icon,omitempty" json:"icon,omitempty"`               // icon name from the known set
 	Check       *FrameworkRule `yaml:"check,omitempty" json:"check,omitempty"`             // hide the command when this rule fails

--- a/internal/sitedoctor/sitedoctor.go
+++ b/internal/sitedoctor/sitedoctor.go
@@ -258,7 +258,7 @@ func runDeclaredCheck(ctx context.Context, path, envPath, envFormat string, spec
 	var ok bool
 	switch spec.Type {
 	case "env_key_set":
-		c, ok = checkEnvKeySet(read, spec.Name, spec.EnvKey, spec.Fix, spec.Detail), true
+		c, ok = checkEnvKeySet(read, spec), true
 	case "env_combo":
 		c, ok = checkEnvCombo(read, spec), true
 	case "symlink":
@@ -344,8 +344,13 @@ func checkAppKey(envPath string, fw *config.Framework) (Check, bool) {
 		return Check{}, false
 	}
 	kg := fw.Env.KeyGeneration
-	detail := fmt.Sprintf("%s is empty, so encryption, signed URLs, and sessions won't work until it's set.", kg.EnvKey)
-	return checkEnvKeySet(envfile.Reader(envPath, "dotenv"), "app_key", kg.EnvKey, kg.Command, detail), true
+	// An empty app key breaks encryption, signed URLs and sessions, so this one
+	// fails rather than taking the declared-check default of warn.
+	spec := config.DoctorCheck{
+		Name: "app_key", EnvKey: kg.EnvKey, Fix: kg.Command, Severity: StatusFail,
+		Detail: fmt.Sprintf("%s is empty, so encryption, signed URLs, and sessions won't work until it's set.", kg.EnvKey),
+	}
+	return checkEnvKeySet(envfile.Reader(envPath, "dotenv"), spec), true
 }
 
 // checkSQLiteDatabase fails when the env file selects the sqlite driver but the
@@ -407,15 +412,17 @@ func frameworkHasCommand(fw *config.Framework, name string) bool {
 	return false
 }
 
-// checkEnvKeySet fails when key is empty in the env file.
-func checkEnvKeySet(read func(string) string, name, key, fix, detail string) Check {
-	if strings.TrimSpace(read(key)) == "" {
+// checkEnvKeySet warns when key is empty in the env file. A check that considers
+// the key mandatory escalates with severity: fail.
+func checkEnvKeySet(read func(string) string, spec config.DoctorCheck) Check {
+	if strings.TrimSpace(read(spec.EnvKey)) == "" {
+		detail := spec.Detail
 		if detail == "" {
-			detail = fmt.Sprintf("%s is empty.", key)
+			detail = fmt.Sprintf("%s is empty.", spec.EnvKey)
 		}
-		return Check{Name: name, Status: StatusFail, Detail: detail, Fix: fix}
+		return Check{Name: spec.Name, Status: triggeredStatus(spec, StatusWarn), Detail: detail, Fix: spec.Fix}
 	}
-	return Check{Name: name, Status: StatusOK}
+	return Check{Name: spec.Name, Status: StatusOK}
 }
 
 // checkEnvDrift warns when .env.example declares keys the project's .env is

--- a/internal/sitedoctor/sitedoctor_test.go
+++ b/internal/sitedoctor/sitedoctor_test.go
@@ -248,6 +248,37 @@ func TestCheckEnvCombo(t *testing.T) {
 	}
 }
 
+// TestCheckEnvKeySet pins that an empty key warns by default and that a check
+// can override the status to fail, the same as the other declared types.
+func TestCheckEnvKeySet(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	spec := config.DoctorCheck{
+		Name: "mailer_dsn", Type: "env_key_set",
+		EnvKey: "MAILER_DSN", Detail: "mail is unconfigured", Fix: "mail:setup",
+	}
+
+	// Key set → ok.
+	writeEnv(t, dir, ".env", "MAILER_DSN=smtp://localhost\n")
+	if c := checkEnvKeySet(envfile.Reader(envPath, "dotenv"), spec); c.Status != StatusOK {
+		t.Errorf("key set: got %q, want ok", c.Status)
+	}
+
+	// Empty (whitespace-only) key → warn, carrying the detail and fix.
+	writeEnv(t, dir, ".env", "MAILER_DSN=   \n")
+	c := checkEnvKeySet(envfile.Reader(envPath, "dotenv"), spec)
+	if c.Status != StatusWarn || c.Detail != "mail is unconfigured" || c.Fix != "mail:setup" {
+		t.Errorf("empty key: got status=%q detail=%q fix=%q, want warn/mail is unconfigured/mail:setup", c.Status, c.Detail, c.Fix)
+	}
+
+	// severity: fail escalates the same finding.
+	strict := spec
+	strict.Severity = "fail"
+	if c := checkEnvKeySet(envfile.Reader(envPath, "dotenv"), strict); c.Status != StatusFail {
+		t.Errorf("severity fail: got %q, want fail", c.Status)
+	}
+}
+
 // TestCheckSymlink covers the public/storage link, expressed declaratively.
 func TestCheckSymlink(t *testing.T) {
 	spec := config.DoctorCheck{

--- a/internal/ui/web/src/stores/commands.test.ts
+++ b/internal/ui/web/src/stores/commands.test.ts
@@ -6,6 +6,8 @@ import {
   closeRun,
   currentRun,
   runningName,
+  runToast,
+  runSettled,
   type Command
 } from './commands';
 
@@ -183,6 +185,76 @@ describe('history', () => {
     localStorage.setItem('lerd-commands-history-v1', 'not json');
     const { lastRunFor } = await import('./commands');
     expect(lastRunFor('a', 'b')).toBeNull();
+  });
+});
+
+describe('output: silent', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('runs without opening the modal and toasts when it succeeds', async () => {
+    mockSSE(['event: stdout\ndata: cache cleared\n\n', 'event: done\ndata: {"exit":0,"durationMs":8}\n\n']);
+    launchCommand('acme.test', { name: 'optimize:clear', label: 'Clear all caches', command: 'php artisan optimize:clear', output: 'silent' });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(get(currentRun).kind).toBe('idle');
+    expect(get(runToast)).toBe('Clear all caches finished');
+  });
+
+  // The output is the only thing that explains a failure, so a silent command
+  // that exits non-zero still surfaces the modal.
+  it('opens the modal with the output when it fails', async () => {
+    mockSSE(['event: stderr\ndata: boom\n\n', 'event: done\ndata: {"exit":1,"durationMs":8}\n\n']);
+    launchCommand('acme.test', { name: 'migrate', label: 'Run migrations', command: 'php artisan migrate', output: 'silent' });
+    await new Promise((r) => setTimeout(r, 50));
+    const s = get(currentRun);
+    expect(s.kind).toBe('done');
+    if (s.kind !== 'done') return;
+    expect(s.exit).toBe(1);
+    expect(s.lines).toEqual([{ stream: 'stderr', text: 'boom' }]);
+  });
+
+  it('still records run history', async () => {
+    const { lastRunFor } = await import('./commands');
+    mockSSE(['event: stdout\ndata: done\n\n', 'event: done\ndata: {"exit":0,"durationMs":9}\n\n']);
+    launchCommand('acme.test', { name: 'key:generate', label: 'Generate key', command: 'php artisan key:generate', output: 'silent' });
+    await new Promise((r) => setTimeout(r, 50));
+    const prev = lastRunFor('acme.test', 'key:generate');
+    expect(prev).not.toBeNull();
+    expect(prev!.exit).toBe(0);
+    expect(prev!.lines).toEqual([{ stream: 'stdout', text: 'done' }]);
+  });
+});
+
+describe('runSettled', () => {
+  it('resolves immediately when nothing is pending', async () => {
+    await expect(runSettled()).resolves.toBeUndefined();
+  });
+
+  // The doctor's Fix button launches through the confirm gate, so it must not
+  // re-check while the prompt is still on screen waiting for the user.
+  it('stays pending while a confirmation is waiting, and resolves once the run finishes', async () => {
+    mockSSE(['event: done\ndata: {"exit":0,"durationMs":3}\n\n']);
+    const cmd: Command = { name: 'migrate:fresh', label: 'Fresh', command: 'php artisan migrate:fresh', confirm: true };
+    launchCommand('acme.test', cmd);
+    expect(get(currentRun).kind).toBe('confirm');
+
+    let settled = false;
+    const pending = runSettled().then(() => (settled = true));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(settled).toBe(false);
+
+    // The user confirms; the run goes through and settles.
+    const { executeCommand } = await import('./commands');
+    void executeCommand('acme.test', cmd, '', true);
+    await pending;
+    expect(settled).toBe(true);
+  });
+
+  it('resolves when the user cancels the confirmation', async () => {
+    launchCommand('acme.test', { name: 'x', label: 'X', command: 'true', confirm: true });
+    expect(get(currentRun).kind).toBe('confirm');
+    const pending = runSettled();
+    closeRun();
+    await expect(pending).resolves.toBeUndefined();
   });
 });
 

--- a/internal/ui/web/src/stores/commands.ts
+++ b/internal/ui/web/src/stores/commands.ts
@@ -251,61 +251,85 @@ export async function executeDoctorFix(domain: string, key: string, label: strin
 
 // runInModal drives the shared CommandRunModal state for any streaming runner,
 // folding stdout/stderr/done/error into currentRun and persisting history.
+// A silent command runs without the modal and toasts instead, the way a
+// terminal one does; a terminal command streams nowhere at all.
 async function runInModal(domain: string, cmd: Command, branch: string, run: (cb: RunCallbacks) => Promise<void>) {
   const started = Date.now();
+  const quiet = cmd.output === 'silent' || cmd.output === 'terminal';
   runningName.set(cmd.name);
-  if (cmd.output === 'terminal') {
-    currentRun.set({ kind: 'idle' });
-  } else {
-    currentRun.set({ kind: 'running', domain, cmd, lines: [], started });
-  }
-  abortCtrl = new AbortController();
+  currentRun.set(quiet ? { kind: 'idle' } : { kind: 'running', domain, cmd, lines: [], started });
+  const ctrl = new AbortController();
+  abortCtrl = ctrl;
+
+  // Buffered independently of currentRun, since a silent run never enters the
+  // running state but still needs its output for history and for a failure.
+  const lines: RunLine[] = [];
+  // Stale once the user closed the modal (which aborts) or another run took over.
+  const live = () => abortCtrl === ctrl;
 
   const append = (stream: 'stdout' | 'stderr', text: string) => {
-    currentRun.update((s) => {
-      if (s.kind !== 'running') return s;
-      return { ...s, lines: [...s.lines, { stream, text }] };
-    });
+    lines.push({ stream, text });
+    currentRun.update((s) => (s.kind === 'running' ? { ...s, lines: [...lines] } : s));
   };
 
   try {
     await run({
-      signal: abortCtrl.signal,
+      signal: ctrl.signal,
       onStdout: (l) => append('stdout', l),
       onStderr: (l) => append('stderr', l),
       onDone: ({ exit, durationMs, url }) => {
-        currentRun.update((s) => {
-          if (s.kind !== 'running') return s;
-          const done = { kind: 'done' as const, domain, cmd, lines: s.lines, exit, durationMs, url };
-          saveHistory(domain, cmd.name, done);
-          maybeNotifyDone(cmd, domain, exit, durationMs);
-          return done;
-        });
+        if (!live()) return;
+        const done = { kind: 'done' as const, domain, cmd, lines, exit, durationMs, url };
+        saveHistory(domain, cmd.name, done);
+        maybeNotifyDone(cmd, domain, exit, durationMs);
+        // A silent command that worked stays out of the way. A failure is the
+        // one case where its output is the only thing that explains itself, so
+        // the modal opens after all.
+        if (cmd.output === 'silent' && exit === 0) {
+          setToast((cmd.label || cmd.name) + ' finished');
+          return;
+        }
+        currentRun.set(done);
       },
       onTerminal: () => {
         setToast('Opened ' + (cmd.label || cmd.name) + ' in terminal');
       },
       onError: (msg) => {
-        currentRun.update((s) => {
-          if (s.kind === 'running') {
-            return {
-              kind: 'done',
-              domain,
-              cmd,
-              lines: [...s.lines, { stream: 'meta', text: '[error] ' + msg }],
-              exit: -1,
-              durationMs: Date.now() - started
-            };
-          }
+        if (!live()) return;
+        if (cmd.output === 'terminal') {
           setToast('Error: ' + msg, 3000);
-          return s;
-        });
+          return;
+        }
+        lines.push({ stream: 'meta', text: '[error] ' + msg });
+        currentRun.set({ kind: 'done', domain, cmd, lines, exit: -1, durationMs: Date.now() - started });
       }
     });
   } finally {
     runningName.set(null);
-    abortCtrl = null;
+    if (abortCtrl === ctrl) abortCtrl = null;
   }
+}
+
+// runSettled resolves once nothing is pending: no confirmation waiting on the
+// user and no run in flight. It lets a caller launch through the confirm gate
+// (rather than bypassing it) and still act once the command really finished,
+// which a plain await can't do while the run is parked at a prompt. Resolves
+// straight away if the user cancels.
+export function runSettled(): Promise<void> {
+  const settled = () => get(currentRun).kind !== 'confirm' && get(runningName) === null;
+  if (settled()) return Promise.resolve();
+  return new Promise((resolve) => {
+    let done = false;
+    const unsubs: Array<() => void> = [];
+    const check = () => {
+      if (done || !settled()) return;
+      done = true;
+      // Deferred: a subscriber fires during subscribe(), before unsubs is filled.
+      queueMicrotask(() => unsubs.forEach((u) => u()));
+      resolve();
+    };
+    unsubs.push(currentRun.subscribe(check), runningName.subscribe(check));
+  });
 }
 
 export function closeRun() {

--- a/internal/ui/web/src/tabs/sites/SiteDoctorModal.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteDoctorModal.svelte
@@ -67,7 +67,7 @@
 <script lang="ts">
   import Modal from '$components/Modal.svelte';
   import { loadDoctor, type DoctorCheck, type DoctorReport } from '$stores/doctor';
-  import { loadCommands, executeCommand, executeDoctorFix, type Command } from '$stores/commands';
+  import { loadCommands, launchCommand, runSettled, executeDoctorFix, type Command } from '$stores/commands';
   import { goToTab } from '$stores/route';
   import { activeWorktreeDomain, type Site } from '$stores/sites';
   import { m } from '../../paraglide/messages.js';
@@ -140,7 +140,10 @@
       } else {
         const cmd = commands.find((c) => c.name === check.fix);
         if (!cmd) return;
-        await executeCommand(site.domain, cmd, branch);
+        // Launched, not executed: a fix naming a confirm: true command must
+        // still prompt, and runSettled waits out that prompt before re-checking.
+        launchCommand(site.domain, cmd, { branch });
+        await runSettled();
       }
       await reload();
     } finally {

--- a/internal/ui/web/src/tabs/sites/SiteDoctorModal.test.ts
+++ b/internal/ui/web/src/tabs/sites/SiteDoctorModal.test.ts
@@ -1,16 +1,20 @@
-import { render, screen, cleanup } from '@testing-library/svelte';
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
 const loadDoctor = vi.fn();
 const loadCommands = vi.fn();
-const executeCommand = vi.fn();
+const launchCommand = vi.fn();
+const executeDoctorFix = vi.fn();
+const runSettled = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('$stores/doctor', () => ({
   loadDoctor: (...a: unknown[]) => loadDoctor(...a)
 }));
 vi.mock('$stores/commands', () => ({
   loadCommands: (...a: unknown[]) => loadCommands(...a),
-  executeCommand: (...a: unknown[]) => executeCommand(...a)
+  launchCommand: (...a: unknown[]) => launchCommand(...a),
+  executeDoctorFix: (...a: unknown[]) => executeDoctorFix(...a),
+  runSettled: (...a: unknown[]) => runSettled(...a)
 }));
 
 import SiteDoctorModal from './SiteDoctorModal.svelte';
@@ -52,6 +56,25 @@ describe('SiteDoctorModal', () => {
     expect(screen.getByText('Debug mode')).toBeTruthy();
     expect(screen.getByText('APP_KEY is empty')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Fix' })).toBeTruthy();
+  });
+
+  // A fix naming a destructive command (migrate:fresh drops every table) must
+  // still go through the confirm gate, so Fix launches rather than executing.
+  it('launches the fix command so a confirm: true fix still prompts', async () => {
+    loadDoctor.mockResolvedValue({
+      checks: [{ name: 'migrations', status: 'fail', detail: 'pending migrations', fix: 'migrate:fresh' }],
+      failures: 1,
+      warnings: 0
+    });
+    const cmd = { name: 'migrate:fresh', label: 'Drop and re-migrate', command: 'php artisan migrate:fresh', confirm: true };
+    loadCommands.mockResolvedValue([cmd]);
+
+    render(SiteDoctorModal, { props: { open: true, site: site(), branch: 'feat-x', onclose: () => {} } });
+
+    await fireEvent.click(await screen.findByRole('button', { name: 'Fix' }));
+
+    expect(launchCommand).toHaveBeenCalledWith('acme.test', cmd, { branch: 'feat-x' });
+    expect(runSettled).toHaveBeenCalled();
   });
 
   it('omits the Fix button when no matching command is available', async () => {


### PR DESCRIPTION
The framework schema documented two whole sections that the reference never covered, the custom commands list and the doctor checks, so anyone copying Laravel or Symfony as a starting point had to read the Go structs to find out what the keys meant. Writing that reference turned up three places where the code did not actually do what the schema said, so this fixes those first and documents the result rather than writing down the warts.

A command declaring output silent still opened the run modal, because nothing branched on the value: only terminal and url were ever consumed, which made silent and text the same thing. Silent now runs without the modal and toasts when it finishes, which is the whole point of the mode for the cache clears and key generations that make up most of the store. A non zero exit still opens the modal, since the output is the only thing that explains a failure, and the run history and the completion notification now work for a silent run too, which they did not when it never entered the running state. This is the most visible change here, most commands in the store are silent and they all stop popping a modal.

An env_key_set doctor check ignored its severity and always reported a failure, because the dispatch passed five loose fields instead of the spec and the evaluator had no way to see it. It now routes through triggeredStatus like the other three types, so it warns by default and an author can escalate. The app key check shares that evaluator and genuinely must fail, since an empty key breaks encryption and sessions, so it now says so explicitly rather than leaning on the hardcoded status. No framework in the store uses the type yet, so nothing changes for an existing site.

The doctor Fix button ran its target through the path that skips the confirmation, so a check whose fix named a destructive command would have run it on a single click with no prompt. Nothing in the store does that today, but fix: migrate:fresh on a pending migrations check is exactly the shape an author would reach for, and it would drop every table. Fix now launches through the same gate as the dashboard, the CLI and MCP. That means a fix can park at a prompt, and a silent one never reaches the modal at all, so the doctor waits on the run settling rather than on the launch before it re-checks.

The reference now covers both sections properly: the four output modes and how each differs, confirm, check, cwd, the icon vocabulary an author would otherwise guess at, and every doctor check type with its own fields, its fix target, and the per type severity default, which differs by type and is not something anyone would guess. The default for an unset output is text, not silent as the struct comment claimed and the features page repeated, so both are corrected.

Closes #894
Closes #898
Closes #899
Closes #900