### PR TITLE
fix: keep the out-of-home mounts when the nginx quadlet is rewritten

### DIFF
--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -1652,5 +1652,9 @@ func RewriteNginxQuadlet() (changed bool, err error) {
 	if err != nil {
 		return false, fmt.Errorf("reading bundled nginx quadlet template: %w", err)
 	}
+	// The template carries only the lerd-owned mounts, so a site or parked
+	// directory outside $HOME must have its Volume= line re-injected here, the
+	// same way RewriteFPMQuadlets does, or nginx restarts without the docroot.
+	content = podman.InjectExtraVolumes(content, podman.ExtraVolumePaths())
 	return podman.WriteQuadletDiff("lerd-nginx", content)
 }

--- a/internal/nginx/quadlet_volumes_test.go
+++ b/internal/nginx/quadlet_volumes_test.go
@@ -1,0 +1,76 @@
+package nginx
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// RewriteNginxQuadlet must preserve the Volume= lines for paths outside $HOME.
+// It renders the bundled template, which carries no site mounts, so without
+// re-injecting them a site parked outside home loses its bind mount from nginx
+// and its docroot becomes unreadable inside the container.
+func TestRewriteNginxQuadlet_keepsExtraVolumes(t *testing.T) {
+	sandbox := t.TempDir()
+	home := filepath.Join(sandbox, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(sandbox, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(sandbox, "data"))
+
+	cfgDir := filepath.Join(sandbox, "config", "lerd")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A project parked outside $HOME: the case ExtraVolumePaths exists for.
+	const outside = "/srv/apps"
+	cfg := "parked_directories:\n    - " + outside + "\n"
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(sandbox, "config", "containers", "systemd"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	paths := podman.ExtraVolumePaths()
+	if len(paths) != 1 || paths[0] != outside {
+		t.Fatalf("ExtraVolumePaths() = %v, want [%s]", paths, outside)
+	}
+
+	// Seed the quadlet the way RewriteFPMQuadlets does: template + extra mounts.
+	tmpl, err := podman.GetQuadletTemplate("lerd-nginx.container")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := podman.WriteQuadletDiff("lerd-nginx", podman.InjectExtraVolumes(tmpl, paths)); err != nil {
+		t.Fatal(err)
+	}
+
+	quadlet := filepath.Join(sandbox, "config", "containers", "systemd", "lerd-nginx.container")
+	want := "Volume=" + outside + ":" + outside + ":rw"
+	before, err := os.ReadFile(quadlet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(before), want) {
+		t.Fatalf("seeded quadlet is missing %q:\n%s", want, before)
+	}
+
+	// Saving a global nginx http config rewrites the quadlet (internal/ui/nginx_global.go).
+	if _, err := RewriteNginxQuadlet(); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := os.ReadFile(quadlet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(after), want) {
+		t.Errorf("RewriteNginxQuadlet dropped the out-of-home mount %q; nginx can no longer read the site:\n%s", want, after)
+	}
+}


### PR DESCRIPTION
RewriteNginxQuadlet rendered lerd-nginx.container straight from the bundled template and, unlike RewriteFPMQuadlets, never re-injected the extra volume paths. The template carries only the lerd-owned mounts, so any project living outside $HOME lost its bind mount from nginx.

The dashboard global nginx config editor calls that rewrite on every save. The rewrite reported a change precisely because it had dropped the line, and that return value is what gates the restart, so nginx was reloaded and restarted into the stripped quadlet and the site document root was no longer visible inside the container. The save still reported success, because the container comes up fine and nginx does not check that a root directory exists, so the site started failing with nothing pointing at the cause.

The rewrite now goes through the same extra volume injection the FPM rewrite uses. An install that already lost a mount gets it back on the next save.

Refs #902