### PR TITLE
fix(cli): isolate the config dir in the host-proxy preset-port test

### DIFF
--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -374,6 +374,9 @@ func TestApplyHostProxyEnv_leavesNonConnectionKeysAlone(t *testing.T) {
 func TestRewriteEnvForHostProxy_usesPresetPorts(t *testing.T) {
 	// postgres + redis are default presets resolvable from the embedded YAML,
 	// so the full path (preset lookup -> port map -> rewrite) works offline.
+	// Isolate the config dir so a real install's published-port override (e.g.
+	// redis shifted to 6380 when the host owns 6379) cannot leak into the lookup.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	updates := map[string]string{
 		"DB_HOST":    "lerd-postgres",
 		"DB_PORT":    "5432",


### PR DESCRIPTION
TestRewriteEnvForHostProxy_usesPresetPorts asserted a fixed redis port of 6379, but the rewrite path it exercises reads the live install's published-port override through config.ServicePublishedPort. On a machine where redis was moved to 6380 at install because the host already held 6379, that override leaked in and failed the test, on a plain checkout and at the last release tag alike, so it was never a product regression, only a non-hermetic test that broke for contributors whose service ports had been relocated.

This points XDG_CONFIG_HOME at a temp dir for the duration of the test, matching how the other config-touching tests isolate themselves, so the lookup finds no override and the embedded preset defaults hold.

Refs #907