### PR TITLE
fix(ui): keep the star card sentence flowing when a translation wraps

### DIFF
--- a/internal/ui/web/src/tabs/system/LerdDetail.svelte
+++ b/internal/ui/web/src/tabs/system/LerdDetail.svelte
@@ -184,13 +184,15 @@
         </div>
       {/if}
 
-      <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 mt-3">
-        <svg class="w-3.5 h-3.5 shrink-0 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">
+      <div class="flex items-start gap-2 text-xs text-gray-500 dark:text-gray-400 mt-3">
+        <svg class="w-3.5 h-3.5 shrink-0 mt-0.5 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">
           <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.286 3.957a1 1 0 00.95.69h4.162c.969 0 1.371 1.24.588 1.81l-3.367 2.446a1 1 0 00-.364 1.118l1.287 3.957c.3.922-.755 1.688-1.54 1.118l-3.366-2.446a1 1 0 00-1.176 0l-3.366 2.446c-.784.57-1.838-.196-1.54-1.118l1.287-3.957a1 1 0 00-.364-1.118L2.098 9.384c-.783-.57-.38-1.81.588-1.81h4.162a1 1 0 00.95-.69l1.286-3.957z"/>
         </svg>
-        <span>{m.system_lerd_starBlurb()}</span>
-        <a href="https://github.com/lerd-env/lerd" target="_blank" rel="noopener" class="font-medium text-lerd-red hover:text-lerd-redhov underline-offset-2 hover:underline">{m.system_lerd_starCta()}</a>
-        <span>{m.system_lerd_starAfter()}</span>
+        <p class="leading-relaxed">
+          {m.system_lerd_starBlurb()}
+          <a href="https://github.com/lerd-env/lerd" target="_blank" rel="noopener" class="font-medium text-lerd-red hover:text-lerd-redhov underline-offset-2 hover:underline">{m.system_lerd_starCta()}</a>
+          {m.system_lerd_starAfter()}
+        </p>
       </div>
     </SettingsCard>
 


### PR DESCRIPTION
The System tab's star-on-GitHub card assembled its sentence from three separate children of a centred flex row, so a longer translation like Romanian pushed the middle piece, the GitHub link, onto a second line, where the centred alignment left it floating out of line with the surrounding text.

This renders the blurb, link, and closing text as a single paragraph that wraps as ordinary prose, and aligns the row on its first line so the star sits beside the opening word rather than the vertical centre.

Refs #909