### PR TITLE
fix(cli): follow the terminal theme so the accent stops reading as an error

### DIFF
--- a/internal/feedback/feedback.go
+++ b/internal/feedback/feedback.go
@@ -19,20 +19,29 @@ import (
 	"golang.org/x/term"
 )
 
-// Canonical lerd palette (Tailwind hex values). The TUI theme aliases these so
-// CLI feedback and the dashboard share one set of colours.
+// Canonical lerd palette. The TUI theme aliases these so CLI feedback and the
+// dashboard share one set of colours. The signal colours are ANSI 16-colour
+// codes rather than fixed hex, so the CLI and TUI follow the user's terminal
+// theme (like `php artisan about`) instead of hardcoding a look. This also keeps
+// the accent off red, which reads as an error, and off the brand red the web UI
+// still owns. Greys stay hex because ANSI's single grey can't express the
+// two-tone dim-vs-divider hierarchy, but they are adaptive so they invert on a
+// light terminal (a hairline divider stays light on light, dark on dark)
+// instead of assuming a dark background. Dark values are unchanged from the
+// fixed palette so a dark terminal looks exactly as before.
 var (
-	ColTitle   = lipgloss.Color("#FF2D20") // lerd red (Laravel brand)
-	ColDim     = lipgloss.Color("#6b7280") // gray-500
-	ColDivider = lipgloss.Color("#374151") // gray-700
-	ColRunning = lipgloss.Color("#10b981") // emerald-500
-	ColStopped = lipgloss.Color("#6b7280") // gray-500
-	ColFailing = lipgloss.Color("#ef4444") // red-500
-	ColPaused  = lipgloss.Color("#f59e0b") // amber-500
-	ColGold    = lipgloss.Color("#fbbf24") // amber-400 (brighter gold for sudo prompts)
-	// Interactive accent is the brand red so the TUI, CLI feedback, and the web
-	// UI all share one accent rather than diverging on a separate hue.
-	ColAccent = lipgloss.Color("#FF2D20") // lerd red
+	ColTitle   = lipgloss.Color("2")                                       // terminal green
+	ColDim     = lipgloss.AdaptiveColor{Light: "#4b5563", Dark: "#6b7280"} // gray-600 / gray-500
+	ColDivider = lipgloss.AdaptiveColor{Light: "#d1d5db", Dark: "#374151"} // gray-300 / gray-700
+	ColRunning = lipgloss.Color("2")                                       // terminal green
+	ColStopped = lipgloss.AdaptiveColor{Light: "#4b5563", Dark: "#6b7280"} // gray-600 / gray-500
+	ColFailing = lipgloss.Color("1")                                       // terminal red
+	ColPaused  = lipgloss.Color("3")                                       // terminal yellow
+	ColGold    = lipgloss.Color("11")                                      // terminal bright yellow (sudo prompts)
+	// Accent shares the terminal green with titles and running status so borders,
+	// tabs, key chips, the spinner, and value fragments all read as the same
+	// theme colour rather than as an error.
+	ColAccent = lipgloss.Color("2") // terminal green
 )
 
 var (
@@ -57,7 +66,7 @@ const (
 	GlyphLock = "🔒"
 )
 
-// Title styles a fragment as the bold lerd-red wordmark colour.
+// Title styles a fragment as the bold accent (terminal-green) title colour.
 func Title(s string) string { return paint(titleStyle, s) }
 
 // Green, Red, Amber, and Dim colour a one-off fragment for status reports,
@@ -184,7 +193,8 @@ func paintIf(on bool, st lipgloss.Style, s string) string {
 	return paint(st, s)
 }
 
-// Val styles a value fragment (violet) for embedding inside a step or summary.
+// Val styles a value fragment in the accent colour for embedding inside a step
+// or summary.
 func Val(s string) string { return paint(valueStyle, s) }
 
 // Begin prints a single blank line to separate a feedback block from whatever
@@ -637,7 +647,7 @@ func Success(msg string, d time.Duration) {
 
 // Confirm prints a styled yes/no prompt (preceded by a blank line) and reads
 // the answer from stdin, returning defaultYes on an empty response. The prompt
-// matches the step styling: a violet "?" lead-in and a dim "[Y/n]" hint.
+// matches the step styling: an accent "?" lead-in and a dim "[Y/n]" hint.
 func Confirm(question string, defaultYes bool) bool {
 	hint := "[Y/n]"
 	if !defaultYes {
@@ -656,7 +666,7 @@ func Confirm(question string, defaultYes bool) bool {
 	return answer[0] == 'y'
 }
 
-// Prompt renders a styled yes/no question (violet "?", dim "[Y/n]" hint),
+// Prompt renders a styled yes/no question (accent "?", dim "[Y/n]" hint),
 // preceded by a blank line, WITHOUT reading the answer — for callers that read
 // from a custom source (e.g. /dev/tty so `curl … | bash` prompts still work)
 // instead of stdin. Mirrors Confirm's styling so every prompt looks the same.

--- a/internal/feedback/palette_test.go
+++ b/internal/feedback/palette_test.go
@@ -1,0 +1,45 @@
+package feedback
+
+import "testing"
+
+// The accent, titles, and running status share the terminal's green (ANSI "2")
+// so the CLI and TUI follow the user's terminal theme rather than a fixed brand
+// red, which users read as an error. Guard against a regression back to a
+// hardcoded red accent.
+func TestAccentFollowsTerminalTheme(t *testing.T) {
+	green := "2"
+	for name, got := range map[string]string{
+		"ColTitle":   string(ColTitle),
+		"ColAccent":  string(ColAccent),
+		"ColRunning": string(ColRunning),
+	} {
+		if got != green {
+			t.Errorf("%s = %q, want terminal green %q", name, got, green)
+		}
+	}
+	if string(ColFailing) != "1" {
+		t.Errorf("ColFailing = %q, want terminal red %q", string(ColFailing), "1")
+	}
+	if ColAccent == ColFailing {
+		t.Error("accent shares the failure colour, so accented UI reads as an error")
+	}
+}
+
+// The greys can't follow the terminal theme (ANSI has one grey), so they stay
+// hex but adapt to a light vs dark terminal. The dark value must be unchanged
+// from the old fixed palette so a dark terminal looks identical, and the light
+// value must differ so a light terminal actually inverts.
+func TestGreysAdaptToTerminalBackground(t *testing.T) {
+	if ColDivider.Dark != "#374151" {
+		t.Errorf("ColDivider dark = %q, want the unchanged gray-700 %q", ColDivider.Dark, "#374151")
+	}
+	if ColDivider.Light == ColDivider.Dark {
+		t.Error("ColDivider light and dark are identical, so it does not adapt on a light terminal")
+	}
+	if ColDim.Dark != "#6b7280" {
+		t.Errorf("ColDim dark = %q, want the unchanged gray-500 %q", ColDim.Dark, "#6b7280")
+	}
+	if ColDim.Light == ColDim.Dark {
+		t.Error("ColDim light and dark are identical, so it does not adapt on a light terminal")
+	}
+}

--- a/internal/tui/logs_render.go
+++ b/internal/tui/logs_render.go
@@ -26,7 +26,7 @@ var (
 var (
 	logErrorStyle  = lipgloss.NewStyle().Foreground(colFailing)
 	logWarnStyle   = lipgloss.NewStyle().Foreground(colPaused)
-	logMatchStyle  = lipgloss.NewStyle().Background(colAccent).Foreground(lipgloss.Color("#000000"))
+	logMatchStyle  = lipgloss.NewStyle().Background(colAccent).Foreground(onAccent)
 	logDimNonMatch = lipgloss.NewStyle().Foreground(colDim)
 )
 

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -17,6 +17,11 @@ var (
 	colPaused   = feedback.ColPaused
 	colAccent   = feedback.ColAccent
 	colSelected = feedback.ColTitle
+	// onAccent is the foreground for a label sitting on an accent-filled
+	// background (active tab pill, key chip, log search match). It follows the
+	// terminal's light/dark mode so the text stays legible on the themed accent
+	// instead of assuming a bright one, which black text would need.
+	onAccent = lipgloss.AdaptiveColor{Light: "#f5f5f5", Dark: "#0b0b0b"}
 )
 
 var (
@@ -52,7 +57,7 @@ var (
 // stands out as the current screen; inactive tabs sit dim until hovered or
 // clicked. Both keep the same padding so the bar's hit regions line up.
 var (
-	tabActiveStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#0b0b0b")).Background(colAccent).Padding(0, 2)
+	tabActiveStyle   = lipgloss.NewStyle().Bold(true).Foreground(onAccent).Background(colAccent).Padding(0, 2)
 	tabInactiveStyle = lipgloss.NewStyle().Foreground(colDim).Padding(0, 2)
 	// A blank row above the tabs keeps the active pill off the terminal's own
 	// top chrome (tmux/term tab line) instead of butting right against it.
@@ -80,7 +85,7 @@ const (
 var (
 	keyChipStyle = lipgloss.NewStyle().
 			Background(colAccent).
-			Foreground(lipgloss.Color("#0b0b0b")).
+			Foreground(onAccent).
 			Bold(true).
 			Padding(0, 1)
 	keyChipLabelStyle = lipgloss.NewStyle().Foreground(colDim)


### PR DESCRIPTION
lerd's CLI feedback and TUI shared one palette whose interactive accent was the brand red, the same red family as the failure colour, so a running spinner, an accented value, a focused border, or the active tab pill all read as an error. This moves the signal colours off fixed hex and onto ANSI terminal-theme codes, so the accent, titles, and running status render as the terminal's green, failures as its red, and warnings as its yellow, following whatever theme the user runs the same way `php artisan about` does. The accent is no longer a red competing with errors.

The greys can't follow the theme since ANSI only has one, so they stay hex but are now adaptive: a divider is a light hairline on a light terminal and a dark one on a dark terminal, and dim text darkens for contrast on a light background. The foregrounds sitting on the accent, the active tab pill, key chips, and the log search match, are adaptive too so the label stays legible on the themed accent rather than assuming a bright one. Dark terminals look exactly as before.

The web UI keeps its brand red, this change is scoped to the terminal and TUI.

Closes #918