### PR TITLE
fix: resolve the framework in worktrees so console commands run

### DIFF
--- a/internal/config/console_worktree_test.go
+++ b/internal/config/console_worktree_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A worktree checkout isn't a registered site of its own, so `lerd artisan`
+// (via GetConsoleCommand) must inherit the parent site's framework instead of
+// failing with "no framework assigned".
+func TestGetConsoleCommand_worktreeInheritsParent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	installLaravelVersions(t, map[string][2]string{"12": {"8.2", "8.4"}})
+	// installLaravelVersions omits the console field, so add a definition that
+	// carries one for the resolver to return.
+	body := "name: laravel\nlabel: Laravel\nversion: \"12\"\n" +
+		"public_dir: public\nconsole: artisan\n" +
+		"php:\n  min: \"8.2\"\n  max: \"8.4\"\n" +
+		"detect:\n  - composer: laravel/framework\n"
+	if err := os.WriteFile(filepath.Join(StoreFrameworksDir(), "laravel@12.yaml"), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sitePath := filepath.Join(tmp, "acme")
+	if err := os.MkdirAll(filepath.Join(sitePath, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	checkout := filepath.Join(t.TempDir(), "feat-a")
+	if err := os.MkdirAll(checkout, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeComposer(t, checkout, "^12.0")
+	writeWorktreeMeta(t, sitePath, "feat-a", checkout)
+
+	if err := AddSite(Site{Name: "acme", Path: sitePath, Domains: []string{"acme.test"}, Framework: "laravel", PHPVersion: "8.4"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := GetConsoleCommand(checkout)
+	if err != nil {
+		t.Fatalf("GetConsoleCommand(worktree) = error %v, want nil", err)
+	}
+	if got != "artisan" {
+		t.Errorf("console = %q, want %q", got, "artisan")
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -1683,14 +1683,24 @@ func GetTinkerForDir(projectDir string) *FrameworkTinker {
 // the framework detected in projectDir. It checks the site registry first, then
 // falls back to auto-detection. For Laravel the default is "artisan".
 func GetConsoleCommand(projectDir string) (string, error) {
-	site, err := FindSiteByPath(projectDir)
-	if err != nil || site.Framework == "" {
+	frameworkName := ""
+	if site, err := FindSiteByPath(projectDir); err == nil {
+		frameworkName = site.Framework
+	}
+	if frameworkName == "" {
+		// Worktree checkouts aren't registered as their own site; inherit the
+		// parent site's framework so console commands run inside them too.
+		if parent, ok := ParentSiteForWorktreeDir(projectDir); ok {
+			frameworkName = parent.Framework
+		}
+	}
+	if frameworkName == "" {
 		return "", fmt.Errorf("no framework assigned — run 'lerd link' first")
 	}
 
-	fw, ok := GetFrameworkForDir(site.Framework, projectDir)
+	fw, ok := GetFrameworkForDir(frameworkName, projectDir)
 	if !ok {
-		return "", fmt.Errorf("framework %q not found", site.Framework)
+		return "", fmt.Errorf("framework %q not found", frameworkName)
 	}
 
 	if fw.Console == "" {


### PR DESCRIPTION
Running lerd artisan or lerd console from inside a git worktree checkout failed with "no framework assigned run 'lerd link' first", even when the worktree was served and its parent site was linked. Console resolved the framework by an exact path match against the site registry, and a worktree checkout is never registered as its own site, so the lookup missed.

It now inherits the parent site's framework for worktree paths, the same way the worker commands and lerd tinker already resolve them. The MCP console tool routes through the same resolver, so it is covered too.

Refs #920