### PR TITLE
fix(config): write .lerd.yaml atomically and normalise its output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -275,7 +275,7 @@ The config is applied whenever `lerd link` or `lerd init` runs in the project ro
 - **`lerd link`**: framework definition restored, `.node-version` written, PHP version applied, HTTPS toggled, services registered and started.
 - **`lerd init`**: installs PHP FPM if needed, then runs `lerd link` (which applies everything above). Re-runs the wizard if `--fresh` is passed.
 
-Commit `.lerd.yaml` to the repository. On a fresh machine, `lerd link` is sufficient to reproduce the full local environment.
+Commit `.lerd.yaml` to the repository. On a fresh machine, `lerd link` is sufficient to reproduce the full local environment. Lerd writes the file through a temp file and a rename so a crash or two concurrent writers can never leave it half-written, and it normalises the output (two-space indentation, `services` and `workers` sorted), so a worker starting or stopping produces a minimal, stable git diff rather than a reshuffled block.
 
 The Lerd watcher also monitors `.lerd.yaml` for changes. When you switch branches with a different config the PHP and Node versions are re-detected and applied automatically, no manual `lerd link` or `lerd init` needed. See [Automatic version switching](./features/project-setup.md#automatic-version-switching) for details.
 

--- a/internal/cli/idle_test.go
+++ b/internal/cli/idle_test.go
@@ -266,8 +266,9 @@ func TestAppendLostSuspended(t *testing.T) {
 	unitStatesOKFn = func() (map[string]string, bool) { return present, true }
 
 	// All declared+resumable units removed -> all re-marked; the orphan is skipped.
-	if got := appendLostSuspended(site, nil); !slices.Equal(got, []string{"queue", "horizon", "stripe"}) {
-		t.Errorf("all-removed: got %v, want [queue horizon stripe]", got)
+	// Workers persist sorted, so the re-marked list comes back in that order.
+	if got := appendLostSuspended(site, nil); !slices.Equal(got, []string{"horizon", "queue", "stripe"}) {
+		t.Errorf("all-removed: got %v, want [horizon queue stripe]", got)
 	}
 	// A worker whose unit still exists (e.g. crashed/failed) is not re-marked, so
 	// worker-healing still sees it instead of it being masked as sleeping.

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -1,9 +1,11 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -451,15 +453,37 @@ func cloneProjectConfig(in *ProjectConfig) *ProjectConfig {
 	return &out
 }
 
-// SaveProjectConfig writes cfg to .lerd.yaml in dir.
+// SaveProjectConfig writes cfg to .lerd.yaml in dir. The write goes through a
+// temp file and a rename so a crash, a restart mid-write, or a second concurrent
+// writer can never leave the file half-written; the output is two-space indented
+// to match the store YAML and its lists are sorted for stable git diffs.
 func SaveProjectConfig(dir string, cfg *ProjectConfig) error {
-	data, err := yaml.Marshal(cfg)
-	if err != nil {
+	normalizeProjectConfig(cfg)
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(cfg); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), data, 0644); err != nil {
+	if err := enc.Close(); err != nil {
+		return err
+	}
+	if err := writeFileAtomic(filepath.Join(dir, ".lerd.yaml"), buf.Bytes(), 0644); err != nil {
 		return err
 	}
 	invalidateProjectConfigCache(dir)
 	return nil
+}
+
+// normalizeProjectConfig sorts the churn-prone lists into a canonical order so a
+// worker waking or sleeping rewrites .lerd.yaml with a minimal diff instead of a
+// reshuffled block. Order is behaviourally irrelevant here: workers are
+// independent units and each service preset owns a distinct env namespace.
+func normalizeProjectConfig(cfg *ProjectConfig) {
+	if cfg == nil {
+		return
+	}
+	sort.Slice(cfg.Services, func(i, j int) bool { return cfg.Services[i].Name < cfg.Services[j].Name })
+	sort.Strings(cfg.Workers)
+	sort.Strings(cfg.ReloadWorkers)
 }

--- a/internal/config/project_atomic_test.go
+++ b/internal/config/project_atomic_test.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// SaveProjectConfig must emit two-space indentation so .lerd.yaml matches the
+// hand-authored store YAML and stops looking self-inconsistent.
+func TestSaveProjectConfig_TwoSpaceIndent(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &ProjectConfig{
+		Domains:  []string{"acme"},
+		Services: []ProjectService{{Name: "mysql"}},
+	}
+	if err := SaveProjectConfig(dir, cfg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".lerd.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "    - acme") {
+		t.Errorf("output uses four-space indent, want two-space:\n%s", data)
+	}
+	if !strings.Contains(string(data), "\n  - acme") {
+		t.Errorf("domains list not indented two spaces:\n%s", data)
+	}
+}
+
+// Workers and services persist in sorted order so a config change produces a
+// minimal git diff instead of a reshuffled block.
+func TestSaveProjectConfig_SortsWorkersAndServices(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &ProjectConfig{
+		Services:      []ProjectService{{Name: "redis"}, {Name: "mysql"}, {Name: "mailpit"}},
+		Workers:       []string{"vite", "horizon", "schedule"},
+		ReloadWorkers: []string{"vite", "horizon"},
+	}
+	if err := SaveProjectConfig(dir, cfg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	wantSvc := []string{"mailpit", "mysql", "redis"}
+	for i, w := range wantSvc {
+		if got.Services[i].Name != w {
+			t.Errorf("services not sorted: got %v", serviceNames(got.Services))
+			break
+		}
+	}
+	wantWrk := []string{"horizon", "schedule", "vite"}
+	for i, w := range wantWrk {
+		if got.Workers[i] != w {
+			t.Errorf("workers not sorted: got %v", got.Workers)
+			break
+		}
+	}
+	if got.ReloadWorkers[0] != "horizon" || got.ReloadWorkers[1] != "vite" {
+		t.Errorf("reload_workers not sorted: got %v", got.ReloadWorkers)
+	}
+}
+
+// A crash, a restart mid-write, or two concurrent writers must never leave a
+// half-written .lerd.yaml or a stray temp file behind: the atomic write means a
+// reader always sees a complete, parseable file.
+func TestSaveProjectConfig_AtomicNoTempLeftAndAlwaysValid(t *testing.T) {
+	dir := t.TempDir()
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			cfg := &ProjectConfig{
+				Domains: []string{"acme"},
+				Workers: []string{"horizon", "schedule", "vite"},
+			}
+			_ = SaveProjectConfig(dir, cfg)
+			// A reader racing the writers must never see a corrupt file.
+			if _, err := LoadProjectConfig(dir); err != nil {
+				t.Errorf("read during concurrent writes saw corrupt file: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
+	}
+	if _, err := LoadProjectConfig(dir); err != nil {
+		t.Fatalf("final file is not valid: %v", err)
+	}
+}
+
+// AddProjectWorker is the only additive path into the workers list, so it must
+// refuse a whitespace-bearing name that would otherwise land as a single
+// mangled element like "horizon - schedule - vite - stripe".
+func TestAddProjectWorker_RejectsWhitespaceName(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveProjectConfig(dir, &ProjectConfig{Workers: []string{"horizon"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddProjectWorker(dir, "horizon - schedule - vite - stripe"); err == nil {
+		t.Error("expected an error for a whitespace-bearing worker name")
+	}
+	got, err := LoadProjectConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, w := range got.Workers {
+		if strings.ContainsAny(w, " \t\n") {
+			t.Errorf("mangled worker name persisted: %q", w)
+		}
+	}
+	if len(got.Workers) != 1 {
+		t.Errorf("workers list changed: %v", got.Workers)
+	}
+}
+
+func serviceNames(s []ProjectService) []string {
+	out := make([]string, len(s))
+	for i, v := range s {
+		out[i] = v.Name
+	}
+	return out
+}

--- a/internal/config/project_update.go
+++ b/internal/config/project_update.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -73,8 +74,14 @@ func SetProjectWorkers(dir string, workers []string) error {
 }
 
 // AddProjectWorker appends name to the workers list if not already present.
-// No-op if .lerd.yaml does not exist.
+// No-op if .lerd.yaml does not exist. A whitespace-bearing name is rejected so a
+// mangled value like "horizon - schedule - vite - stripe" can never land as a
+// single worker entry; real worker names map to systemd units and have none.
 func AddProjectWorker(dir, name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" || strings.ContainsAny(name, " \t\n\r") {
+		return fmt.Errorf("invalid worker name %q", name)
+	}
 	return updateProjectConfig(dir, func(cfg *ProjectConfig) {
 		for _, w := range cfg.Workers {
 			if w == name {

--- a/internal/config/project_update_test.go
+++ b/internal/config/project_update_test.go
@@ -422,11 +422,12 @@ func TestReplaceProjectDBService_ReplacesExisting(t *testing.T) {
 	if len(cfg.Services) != 2 {
 		t.Fatalf("expected 2 services, got %d: %v", len(cfg.Services), cfg.Services)
 	}
-	if cfg.Services[0].Name != "redis" {
-		t.Errorf("Services[0] = %q, want redis", cfg.Services[0].Name)
+	// Services persist sorted: postgres replaced mysql, redis is preserved.
+	if cfg.Services[0].Name != "postgres" {
+		t.Errorf("Services[0] = %q, want postgres", cfg.Services[0].Name)
 	}
-	if cfg.Services[1].Name != "postgres" {
-		t.Errorf("Services[1] = %q, want postgres", cfg.Services[1].Name)
+	if cfg.Services[1].Name != "redis" {
+		t.Errorf("Services[1] = %q, want redis", cfg.Services[1].Name)
 	}
 }
 


### PR DESCRIPTION
SaveProjectConfig wrote .lerd.yaml with a bare os.WriteFile, which is not crash safe. A process killed mid-write, a full disk, or two of the many callers racing (link, init, worktree overrides, isolate, db-move, stripe, the js-runtime toggle) could leave the file truncated or interleaved, and that invalid YAML then degrades silently: most readers drop the parse error and treat a corrupt file exactly like a missing one, so the site loses its pinned versions, domains, services, workers and everything else and reverts to bare detection with no warning anywhere except lerd check.

The write now goes through the package's existing atomic writer, a uniquely named temp file in the same directory followed by a rename, so a reader always sees a complete file and the last full write wins. The temp lives in the same directory because rename is only atomic within one filesystem and projects can sit on any mount.

While reworking the serialisation, the output is now encoded at two-space indentation to match the hand-authored store YAML, and the services, workers and reload_workers lists are sorted into a canonical order, so a worker starting or stopping rewrites the file with a minimal, stable git diff instead of a reshuffled block. This is safe for anyone updating: reading is untouched since yaml parses any indentation, the reformat only lands when the user actually mutates config rather than on any read or dashboard refresh, worker order is meaningless for independent units, and each service preset owns a distinct env namespace so sorting never changes the generated .env. Domains stay unsorted so the primary keeps its position.

AddProjectWorker, the only path that appends a single worker name, now rejects a name carrying whitespace, so a mangled value can never land as one entry the way a torn write once left "horizon - schedule - vite - stripe" in a real site's workers list. The canonical rewrite also gives an existing mangled entry a self-heal path, since the next worker toggle rebuilds the list from clean live state.

Closes #922
