### PR TITLE
feat(queries): copy a captured query with its bindings inlined

### DIFF
--- a/docs/features/queries.md
+++ b/docs/features/queries.md
@@ -21,6 +21,7 @@ Events ship over the **same** Unix socket (Linux) or TCP loopback (macOS) the de
 - **N+1 detection.** Queries whose SQL normalizes to the same fingerprint (literals collapsed) are flagged as duplicates; a request with three or more repeats of one shape is flagged **N+1**.
 - **Slow-query tagging.** Any single query at or over 100ms is tagged **slow**.
 - **Caller, bindings, connection.** Expand a row for the originating `file:line`, the bound parameters, and (when a framework adapter is present) the connection name and read/write type.
+- **Copy runnable SQL.** A copy button next to each query's duration copies the statement with its bindings resolved: positional `?` placeholders are replaced with properly escaped SQL literals (strings quoted, single quotes doubled, `NULL` for nulls, `1`/`0` for booleans), while question marks inside quoted strings are left untouched. Queries with no bindings copy verbatim. Paste it straight into a SQL editor without hand-substituting each parameter.
 
 ## Wire format
 

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -990,6 +990,7 @@
   "queries_show_workers": "Show worker queries",
   "queries_filter_allWorkers": "All workers",
   "queries_worker_badge": "worker",
+  "queries_copySql": "Ausführbares SQL kopieren",
   "queries_trace": "stack trace",
   "queries_details": "Details",
   "queries_hideTrace": "Hide trace",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -735,6 +735,7 @@
   "queries_show_workers": "Show worker queries",
   "queries_filter_allWorkers": "All workers",
   "queries_worker_badge": "worker",
+  "queries_copySql": "Copy runnable SQL",
   "tinker_mode_tinkerTitle": "Bootstraps Laravel via artisan tinker",
   "tinker_mode_phpTitle": "Plain PHP runtime",
   "tinker_clearTitle": "Clear editor and output",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -990,6 +990,7 @@
   "queries_show_workers": "Show worker queries",
   "queries_filter_allWorkers": "All workers",
   "queries_worker_badge": "worker",
+  "queries_copySql": "Copiar SQL ejecutable",
   "queries_trace": "stack trace",
   "queries_details": "Details",
   "queries_hideTrace": "Hide trace",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -990,6 +990,7 @@
   "queries_show_workers": "Show worker queries",
   "queries_filter_allWorkers": "All workers",
   "queries_worker_badge": "worker",
+  "queries_copySql": "Copier le SQL exécutable",
   "queries_trace": "stack trace",
   "queries_details": "Details",
   "queries_hideTrace": "Hide trace",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -990,6 +990,7 @@
   "queries_show_workers": "Show worker queries",
   "queries_filter_allWorkers": "All workers",
   "queries_worker_badge": "worker",
+  "queries_copySql": "Salin SQL yang dapat dijalankan",
   "queries_trace": "stack trace",
   "queries_details": "Details",
   "queries_hideTrace": "Hide trace",

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -727,6 +727,7 @@
   "queries_show_workers": "Mostra query dei worker",
   "queries_filter_allWorkers": "Tutti i worker",
   "queries_worker_badge": "worker",
+  "queries_copySql": "Copia l'SQL eseguibile",
   "tinker_mode_tinkerTitle": "Avvia Laravel tramite artisan tinker",
   "tinker_mode_phpTitle": "Runtime PHP semplice",
   "tinker_clearTitle": "Pulisci editor e output",

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -727,6 +727,7 @@
   "queries_show_workers": "ワーカーのクエリを表示",
   "queries_filter_allWorkers": "すべてのワーカー",
   "queries_worker_badge": "ワーカー",
+  "queries_copySql": "実行可能な SQL をコピー",
   "tinker_mode_tinkerTitle": "artisan tinker 経由で Laravel をブートストラップ",
   "tinker_mode_phpTitle": "プレーンな PHP ランタイム",
   "tinker_clearTitle": "エディタと出力をクリア",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -990,6 +990,7 @@
   "queries_show_workers": "Show worker queries",
   "queries_filter_allWorkers": "All workers",
   "queries_worker_badge": "worker",
+  "queries_copySql": "Uitvoerbare SQL kopiëren",
   "queries_trace": "stack trace",
   "queries_details": "Details",
   "queries_hideTrace": "Hide trace",

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -727,6 +727,7 @@
   "queries_show_workers": "Pokaż zapytania workerów",
   "queries_filter_allWorkers": "Wszystkie workery",
   "queries_worker_badge": "worker",
+  "queries_copySql": "Kopiuj wykonywalny SQL",
   "tinker_mode_tinkerTitle": "Inicjalizuje Laravel przez artisan tinker",
   "tinker_mode_phpTitle": "Zwykłe środowisko PHP",
   "tinker_clearTitle": "Wyczyść edytor i wynik",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -990,6 +990,7 @@
   "queries_show_workers": "Show worker queries",
   "queries_filter_allWorkers": "All workers",
   "queries_worker_badge": "worker",
+  "queries_copySql": "Copiar SQL executável",
   "queries_trace": "stack trace",
   "queries_details": "Details",
   "queries_hideTrace": "Hide trace",

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -727,6 +727,7 @@
   "queries_show_workers": "Afișează interogările workerilor",
   "queries_filter_allWorkers": "Toți workerii",
   "queries_worker_badge": "worker",
+  "queries_copySql": "Copiază SQL-ul executabil",
   "tinker_mode_tinkerTitle": "Inițializează Laravel prin artisan tinker",
   "tinker_mode_phpTitle": "Runtime PHP simplu",
   "tinker_clearTitle": "Golește editorul și rezultatul",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -990,6 +990,7 @@
   "queries_show_workers": "Show worker queries",
   "queries_filter_allWorkers": "All workers",
   "queries_worker_badge": "worker",
+  "queries_copySql": "Çalıştırılabilir SQL'i kopyala",
   "queries_trace": "stack trace",
   "queries_details": "Details",
   "queries_hideTrace": "Hide trace",

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -727,6 +727,7 @@
   "queries_show_workers": "Hiện truy vấn của worker",
   "queries_filter_allWorkers": "Tất cả workers",
   "queries_worker_badge": "worker",
+  "queries_copySql": "Sao chép SQL có thể chạy",
   "tinker_mode_tinkerTitle": "Khởi động Laravel qua artisan tinker",
   "tinker_mode_phpTitle": "Runtime PHP thuần",
   "tinker_clearTitle": "Xóa trình soạn thảo và kết quả",

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -727,6 +727,7 @@
   "queries_show_workers": "显示 worker 查询",
   "queries_filter_allWorkers": "所有 workers",
   "queries_worker_badge": "worker",
+  "queries_copySql": "复制可执行的 SQL",
   "tinker_mode_tinkerTitle": "通过 artisan tinker 引导 Laravel",
   "tinker_mode_phpTitle": "纯 PHP 运行时",
   "tinker_clearTitle": "清空编辑器和输出",

--- a/internal/ui/web/src/components/QueriesLens.svelte
+++ b/internal/ui/web/src/components/QueriesLens.svelte
@@ -19,6 +19,8 @@
   import EmptyState from '$components/EmptyState.svelte';
   import Dropdown from '$components/Dropdown.svelte';
   import TraceBlock from '$components/TraceBlock.svelte';
+  import { inlineBindings } from '$lib/sqlInline';
+  import type { QueryRow } from '$stores/queries';
   import { m } from '../paraglide/messages.js';
 
   interface Props {
@@ -41,7 +43,10 @@
     // timing view's Inspect queries seeds; mirror it into the input on open.
     if (scoped) textInput = get(debugSearch);
   });
-  onDestroy(() => stopDumpsStream());
+  onDestroy(() => {
+    stopDumpsStream();
+    for (const t of Object.values(copyTimers)) clearTimeout(t);
+  });
 
   const groups = $derived(
     buildQueryGroups($dumps, scoped ? siteScope : $queryFilterSite, scoped ? $debugSearch : $queryFilterText, scoped, $queryFilterWorker, Boolean($devtoolsStatus?.workers))
@@ -91,6 +96,21 @@
   }
   let expanded = $state<Record<string, boolean>>({});
   const toggleRow = (id: string) => (expanded[id] = !expanded[id]);
+
+  // Copy the query with its bindings inlined so it pastes straight into a SQL
+  // editor. Feedback is per-row (keyed by event id) and clears after 1.5s.
+  let copied = $state<Record<string, boolean>>({});
+  const copyTimers: Record<string, ReturnType<typeof setTimeout>> = {};
+  async function copyRow(row: QueryRow) {
+    try {
+      await navigator.clipboard.writeText(inlineBindings(row.data.sql, row.data.bindings));
+      copied[row.event.id] = true;
+      if (copyTimers[row.event.id]) clearTimeout(copyTimers[row.event.id]);
+      copyTimers[row.event.id] = setTimeout(() => (copied[row.event.id] = false), 1500);
+    } catch {
+      /* clipboard unavailable; leave the row untouched */
+    }
+  }
 </script>
 
 <div class="flex flex-col h-full overflow-hidden">
@@ -197,21 +217,36 @@
                 ? 'border-amber-300 dark:border-amber-700/50 bg-amber-50 dark:bg-amber-900/10'
                 : 'border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card'}"
             >
-              <button
-                type="button"
-                class="w-full text-left px-2.5 py-1.5 flex items-start gap-2 hover:bg-gray-50 dark:hover:bg-white/5"
-                onclick={() => toggleRow(row.event.id)}
-              >
-                <code class="text-xs flex-1 break-all text-gray-800 dark:text-gray-200">{row.data.sql}</code>
-                <span class="flex items-center gap-1 shrink-0">
-                  {#if row.duplicate}
-                    <span class="text-[10px] rounded-sm px-1 py-0.5 bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-300" title="duplicate query in this request">{m.queries_dup_badge({ count: row.dupCount })}</span>
+              <div class="flex items-stretch">
+                <button
+                  type="button"
+                  class="flex-1 min-w-0 text-left px-2.5 py-1.5 flex items-start gap-2 hover:bg-gray-50 dark:hover:bg-white/5"
+                  onclick={() => toggleRow(row.event.id)}
+                >
+                  <code class="text-xs flex-1 break-all text-gray-800 dark:text-gray-200">{row.data.sql}</code>
+                  <span class="flex items-center gap-1 shrink-0">
+                    {#if row.duplicate}
+                      <span class="text-[10px] rounded-sm px-1 py-0.5 bg-rose-100 dark:bg-rose-900/40 text-rose-700 dark:text-rose-300" title="duplicate query in this request">{m.queries_dup_badge({ count: row.dupCount })}</span>
+                    {/if}
+                    <span
+                      class="text-[11px] tabular-nums rounded-sm px-1 py-0.5 {row.slow ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300' : 'text-gray-400'}"
+                    >{fmtMs(row.data.time_ms)} ms{#if row.slow}&nbsp;{m.queries_slow_badge()}{/if}</span>
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  class="shrink-0 px-2 flex items-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-white/5 border-l border-gray-100 dark:border-lerd-border/50 {copied[row.event.id] ? 'text-emerald-600 dark:text-emerald-500' : ''}"
+                  onclick={() => copyRow(row)}
+                  title={m.queries_copySql()}
+                  aria-label={m.queries_copySql()}
+                >
+                  {#if copied[row.event.id]}
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5" /></svg>
+                  {:else}
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></svg>
                   {/if}
-                  <span
-                    class="text-[11px] tabular-nums rounded-sm px-1 py-0.5 {row.slow ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300' : 'text-gray-400'}"
-                  >{fmtMs(row.data.time_ms)} ms{#if row.slow}&nbsp;{m.queries_slow_badge()}{/if}</span>
-                </span>
-              </button>
+                </button>
+              </div>
               {#if expanded[row.event.id]}
                 <div class="px-2.5 pb-2 pt-1 border-t border-gray-100 dark:border-lerd-border/50 text-[11px] space-y-1.5">
                   {#if row.data.connection}

--- a/internal/ui/web/src/lib/sqlInline.test.ts
+++ b/internal/ui/web/src/lib/sqlInline.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { inlineBindings } from './sqlInline';
+
+describe('inlineBindings', () => {
+  it('returns the SQL untouched when there are no bindings', () => {
+    const sql = 'select * from users where id = ?';
+    expect(inlineBindings(sql, [])).toBe(sql);
+    expect(inlineBindings(sql, undefined)).toBe(sql);
+  });
+
+  it('substitutes positional placeholders in order', () => {
+    expect(inlineBindings('select * from users where id = ? and team = ?', [7, 3])).toBe(
+      'select * from users where id = 7 and team = 3'
+    );
+  });
+
+  it('quotes strings and doubles embedded single quotes', () => {
+    expect(inlineBindings('where name = ?', ["O'Brien"])).toBe("where name = 'O''Brien'");
+  });
+
+  it('renders null bindings as NULL', () => {
+    expect(inlineBindings('where deleted_at = ?', [null])).toBe('where deleted_at = NULL');
+  });
+
+  it('renders booleans as 1 and 0', () => {
+    expect(inlineBindings('where active = ? and banned = ?', [true, false])).toBe(
+      'where active = 1 and banned = 0'
+    );
+  });
+
+  it('leaves question marks inside single-quoted strings alone', () => {
+    expect(inlineBindings("where label = 'why?' and id = ?", [5])).toBe(
+      "where label = 'why?' and id = 5"
+    );
+  });
+
+  it('leaves question marks inside double-quoted strings and backtick identifiers alone', () => {
+    expect(inlineBindings('where "col?" = ? and `weird?col` = ?', [1, 2])).toBe(
+      'where "col?" = 1 and `weird?col` = 2'
+    );
+  });
+
+  it('handles doubled quotes inside a string literal without ending it early', () => {
+    expect(inlineBindings("where note = 'it''s ok?' and id = ?", [9])).toBe(
+      "where note = 'it''s ok?' and id = 9"
+    );
+  });
+
+  it('handles backslash-escaped quotes inside a string literal', () => {
+    expect(inlineBindings("where note = 'a\\'? b' and id = ?", [4])).toBe(
+      "where note = 'a\\'? b' and id = 4"
+    );
+  });
+
+  it('serializes objects and arrays as JSON string literals', () => {
+    expect(inlineBindings('where meta = ?', [{ a: 1 }])).toBe('where meta = \'{"a":1}\'');
+  });
+
+  it('leaves surplus placeholders untouched when bindings run out', () => {
+    expect(inlineBindings('where a = ? and b = ?', [1])).toBe('where a = 1 and b = ?');
+  });
+});

--- a/internal/ui/web/src/lib/sqlInline.ts
+++ b/internal/ui/web/src/lib/sqlInline.ts
@@ -1,0 +1,63 @@
+// inlineBindings resolves a captured query's positional `?` placeholders into a
+// runnable statement, escaping each binding as a SQL literal. Placeholders that
+// sit inside quoted strings or backtick identifiers are left alone, and any
+// question mark past the last binding stays as-is. With no bindings the SQL is
+// returned untouched.
+
+function quoteString(s: string): string {
+  return "'" + s.replace(/'/g, "''") + "'";
+}
+
+function toSqlLiteral(v: unknown): string {
+  if (v === null || v === undefined) return 'NULL';
+  if (typeof v === 'boolean') return v ? '1' : '0';
+  if (typeof v === 'number') return Number.isFinite(v) ? String(v) : quoteString(String(v));
+  if (typeof v === 'bigint') return v.toString();
+  if (typeof v === 'string') return quoteString(v);
+  return quoteString(JSON.stringify(v));
+}
+
+export function inlineBindings(sql: string, bindings?: unknown[]): string {
+  if (!bindings || bindings.length === 0) return sql;
+
+  let out = '';
+  let bindIdx = 0;
+  // quote holds the character that opened the current string/identifier, or
+  // null when we are in ordinary SQL where a `?` is a real placeholder.
+  let quote: string | null = null;
+
+  for (let i = 0; i < sql.length; i++) {
+    const ch = sql[i];
+
+    if (quote) {
+      out += ch;
+      if (ch === '\\' && i + 1 < sql.length) {
+        out += sql[i + 1];
+        i++;
+      } else if (ch === quote) {
+        if (sql[i + 1] === quote) {
+          out += sql[i + 1];
+          i++;
+        } else {
+          quote = null;
+        }
+      }
+      continue;
+    }
+
+    if (ch === "'" || ch === '"' || ch === '`') {
+      quote = ch;
+      out += ch;
+      continue;
+    }
+
+    if (ch === '?' && bindIdx < bindings.length) {
+      out += toSqlLiteral(bindings[bindIdx++]);
+      continue;
+    }
+
+    out += ch;
+  }
+
+  return out;
+}


### PR DESCRIPTION
The Queries lens displays a captured statement and its bindings separately, so copying the SQL on its own gives you a query full of unresolved ? placeholders that each have to be replaced by hand before it will run.

This adds a copy button next to each query's execution time. When there are no bindings it copies the SQL as is, and when there are it substitutes the positional placeholders with properly escaped SQL literals, quoting strings and doubling their single quotes, NULL for nulls, 1 and 0 for booleans, and JSON for structured values. Question marks that live inside quoted strings are preserved. The button flashes a checkmark once the query is on the clipboard and fails quietly if the clipboard is not available, and expanding a row still works exactly as before.

Closes #923