### PR TITLE
fix(cli): stop lerd check flagging stripe and the host-proxy worker

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -111,7 +111,7 @@ func runCheck(_ *cobra.Command, _ []string) error {
 		if cfg.Container != nil {
 			// Custom container site: workers must be defined in custom_workers.
 			for _, w := range cfg.Workers {
-				if _, ok := cfg.CustomWorkers[w]; ok {
+				if _, ok := cfg.CustomWorkers[w]; ok || config.IsBuiltinWorker(w) {
 					ckOK("worker: %s\n", w)
 				} else {
 					ckFail("worker: %q is not defined in custom_workers\n", w)
@@ -130,6 +130,13 @@ func runCheck(_ *cobra.Command, _ []string) error {
 				}
 				if w == "horizon" {
 					hasHorizon = true
+				}
+
+				// Stripe and the host-proxy app worker are lerd built-ins, run
+				// through their own units and never declared by a framework.
+				if config.IsBuiltinWorker(w) {
+					ckOK("worker: %s\n", w)
+					continue
 				}
 
 				if !hasFw || fw.Workers == nil {

--- a/internal/config/builtin_worker_test.go
+++ b/internal/config/builtin_worker_test.go
@@ -1,0 +1,18 @@
+package config
+
+import "testing"
+
+// IsBuiltinWorker must recognise the lerd-managed workers that live outside any
+// framework's worker definitions, so a validator does not flag them as undefined.
+func TestIsBuiltinWorker(t *testing.T) {
+	for _, name := range []string{StripeWorkerName, HostProxyWorkerName} {
+		if !IsBuiltinWorker(name) {
+			t.Errorf("IsBuiltinWorker(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"queue", "horizon", "schedule", "vite", "reverb", ""} {
+		if IsBuiltinWorker(name) {
+			t.Errorf("IsBuiltinWorker(%q) = true, want false", name)
+		}
+	}
+}

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -137,6 +137,19 @@ func (s *Site) IsHostProxy() bool {
 // dev server. There is exactly one per site.
 const HostProxyWorkerName = "app"
 
+// StripeWorkerName is the Stripe webhook listener, run through its own unit
+// (lerd-stripe-<site>) rather than declared by any framework.
+const StripeWorkerName = "stripe"
+
+// IsBuiltinWorker reports whether name is a lerd-managed worker that lives
+// outside a framework's worker definitions: the Stripe listener and the
+// host-proxy dev server. A validator checking a site's workers against its
+// framework must treat these as valid rather than undefined, the same way the
+// running-worker collector and the orphan scan already special-case them.
+func IsBuiltinWorker(name string) bool {
+	return name == StripeWorkerName || name == HostProxyWorkerName
+}
+
 // HostProxyWorkerUnit returns the worker unit name for a host-proxy site's dev
 // server (lerd-app-<site>). Single source of truth for the cli (which starts
 // and stops it) and siteinfo (which reports its health).


### PR DESCRIPTION
lerd check validated each entry in a site's workers list against the framework's worker definitions and its custom_workers, and failed with "worker is not defined" for anything in neither. That was wrong for the workers that legitimately live outside a framework: the Stripe listener and the host-proxy app dev server both run through their own units and land in the workers list, so a healthy site reported a red error and printed validation failed, the same false positive that turned up while looking at a real site's config.

Every other path already treats these as valid. The running-worker collector checks stripe and the host-proxy worker separately from the framework roster, and the orphan scan skips stripe, so check was the one place that never got told. This teaches it the same thing through a shared IsBuiltinWorker helper rather than another magic string. Stripe is framework-agnostic and the host-proxy worker is its own site type, so nothing here hardcodes a framework name, and a genuinely undefined worker still fails as before.

Verified against real sites of each shape: a framework site carrying stripe, a host-proxy site carrying stripe and app, and a custom-container site with a custom worker all pass, while a bogus worker name still reports the error and fails validation.

Closes #926
