### PR TITLE
fix: bring lerd up cleanly on Fedora Silverblue and other atomic images

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -374,6 +374,42 @@ cat "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/containers/networks/aardvark-dns/ler
 ```
 :::
 
+::: details Every container takes 90 seconds to start (Fedora Silverblue and other atomic images)
+Symptom: `lerd start` sits there for a minute and a half per container, and after a reboot nothing is serving until well over a minute in. `systemctl --user list-units --state=failed` shows `podman-user-wait-network-online.service` failed with a timeout, and `lerd doctor` reports the `podman network-online wait` check as a warning.
+
+Cause: podman's quadlet generator makes every rootless container `Wants=` and `After=podman-user-wait-network-online.service`, a unit that polls the system's `network-online.target` until it gives up after 90 seconds. That target is only reached when some unit pulls it in, and on atomic images (Silverblue, Kinoite, Bazzite, CoreOS) nothing does, so the wait can never succeed. Every container start, and the boot itself, pays the full timeout.
+
+Lerd detects this on `lerd start` and `lerd install` and writes a drop-in that turns the wait into a no-op, since lerd publishes on loopback and needs no routable network:
+
+```bash
+lerd start   # writes ~/.config/systemd/user/podman-user-wait-network-online.service.d/10-lerd-no-network-wait.conf
+```
+
+The override only lands on hosts where `network-online.target` is genuinely inactive; on an ordinary distro the wait is left alone. To confirm the target is the one at fault:
+
+```bash
+systemctl is-active network-online.target   # "inactive" here means every quadlet start pays 90s
+```
+
+To go back to podman's stock behaviour, delete the drop-in and run `systemctl --user daemon-reload`.
+:::
+
+::: details System tray missing on Fedora Silverblue and other atomic images
+Symptom: no tray icon, and `systemctl --user is-system-running` reports `degraded` because `lerd-tray.service` failed with status 127.
+
+Cause: `lerd-tray` links `libayatana-appindicator3.so.1`, which these images don't ship, and an immutable OS can't just install it into `/usr` on demand.
+
+Lerd checks the helper's libraries at install time and leaves the tray unit stopped and disabled when one is missing, so the failure no longer drags the systemd user session into `degraded`. Everything else (CLI, dashboard, watcher, containers) is unaffected, the tray is the only thing you lose.
+
+To get the tray back, layer the package and reboot, then re-enable the unit:
+
+```bash
+rpm-ostree install libayatana-appindicator-gtk3
+systemctl reboot
+lerd install   # re-enables the tray now that the library resolves
+```
+:::
+
 ::: details Podman Machine overlay-storage error (macOS)
 Symptom: on macOS, `lerd start` fails and **every** container start reports a graph-driver / overlay error:
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -17,6 +17,7 @@ import (
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/services"
+	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	lerdUpdate "github.com/geodro/lerd/internal/update"
 	"github.com/geodro/lerd/internal/version"
 	"github.com/geodro/lerd/internal/wsl"
@@ -99,6 +100,16 @@ func RunDoctorTo(w io.Writer, useColor bool) (fails, warns int, err error) {
 			}
 		} else {
 			ok("systemd user session")
+		}
+
+		// Podman orders every rootless quadlet after its network-online wait
+		// unit. Where network-online.target is never pulled in (Fedora
+		// Silverblue and other atomic images) that unit can only time out, and
+		// every container start, plus the boot, pays the 90s.
+		if lerdSystemd.NetworkWaitStalls() {
+			warn("podman network-online wait", "network-online.target never activates here, so every container start stalls 90s — fix: lerd start")
+		} else {
+			ok("podman network-online wait")
 		}
 
 		currentUser := os.Getenv("USER")

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -25,8 +25,19 @@ import (
 	"github.com/geodro/lerd/internal/shims"
 	"github.com/geodro/lerd/internal/siteops"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
+	"github.com/geodro/lerd/internal/tray"
 	"github.com/spf13/cobra"
 )
+
+// disableTrayUnit stops the tray and takes it out of the autostart set, then
+// clears any failure it already recorded. A tray whose library is missing exits
+// 127 on every start, and the leftover failed unit is what tips the systemd
+// user session into "degraded".
+func disableTrayUnit() {
+	_ = services.Mgr.Stop("lerd-tray")
+	_ = services.Mgr.Disable("lerd-tray")
+	_ = exec.Command("systemctl", "--user", "reset-failed", "lerd-tray.service").Run()
+}
 
 // healPodmanUpgrade runs the podman-upgrade self-heal, renders its progress,
 // and returns the containers it tore down so the caller can restart them. Both
@@ -199,6 +210,16 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	// failure (#635). Runs before the network step since it recreates it; any
 	// containers it tears down join the unconditional restart loop below.
 	migrated = append(migrated, healPodmanUpgrade(desiredDNS)...)
+
+	// 2b. Podman orders every rootless quadlet after its network-online wait
+	// unit, which can only time out on hosts where network-online.target is
+	// never pulled in (Fedora Silverblue and other atomic images). Left alone
+	// it stalls every container start, and the boot, by 90s.
+	if applied, err := lerdSystemd.EnsureNoNetworkWaitStall(); err != nil {
+		feedback.Note(fmt.Sprintf("could not skip podman's network-online wait: %v", err))
+	} else if applied {
+		feedback.Note("skipping podman's network-online wait (this host never reaches that target)")
+	}
 
 	step("Creating lerd podman network")
 	if err := podman.EnsureNetwork("lerd", desiredDNS); err != nil {
@@ -875,7 +896,14 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		if err := writeUserServiceWithReload("lerd-tray", content); err != nil {
 			return err
 		}
-		if autostartOn {
+		// The helper dies on every start when its appindicator library is
+		// absent, which an immutable image can't install without layering a
+		// package and rebooting. Leave the unit on disk but don't run it, or
+		// the failures drag the whole systemd user session to "degraded".
+		if missing := tray.MissingLibs(tray.HelperPath()); len(missing) > 0 {
+			disableTrayUnit()
+			feedback.Note("system tray unavailable: this host has no " + strings.Join(missing, ", "))
+		} else if autostartOn {
 			if err := services.Mgr.Enable("lerd-tray"); err != nil {
 				fmt.Printf("    WARN: %v\n", err)
 			}

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -22,6 +22,7 @@ import (
 	"github.com/geodro/lerd/internal/serviceops"
 	"github.com/geodro/lerd/internal/services"
 	"github.com/geodro/lerd/internal/shims"
+	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/spf13/cobra"
 )
 
@@ -498,6 +499,16 @@ func runStart(_ *cobra.Command, _ []string) error {
 	}
 	migrateExecWorkerPlists()
 	healMachineRestartIfNeeded(preEnsureLastUp)
+
+	// Podman orders every rootless quadlet after its network-online wait unit.
+	// Where network-online.target never activates (Fedora Silverblue and other
+	// atomic images) that unit only ever times out, so each container start,
+	// and the boot itself, stalls for 90s. Override it before starting anything.
+	if applied, err := lerdSystemd.EnsureNoNetworkWaitStall(); err != nil {
+		fmt.Printf("  WARN: skip podman network-online wait: %v\n", err)
+	} else if applied {
+		fmt.Println("  Skipping podman's network-online wait (this host never reaches that target)")
+	}
 
 	// Self-heal a podman upgrade before touching the network or starting
 	// containers. A major-version or backend change since the last run

--- a/internal/systemd/networkwait.go
+++ b/internal/systemd/networkwait.go
@@ -1,0 +1,98 @@
+package systemd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// podmanNetworkWaitUnit is the unit podman's quadlet generator makes every
+// rootless container Want= and After=. It polls the system's
+// network-online.target and gives up after 90 seconds.
+const podmanNetworkWaitUnit = "podman-user-wait-network-online.service"
+
+const networkWaitDropInFile = "10-lerd-no-network-wait.conf"
+
+// networkWaitDropIn turns podman's wait into a no-op. network-online.target is
+// only reached when some unit pulls it in; on atomic images (Fedora Silverblue
+// and friends) nothing does, so the wait can only ever time out, and it drags
+// every lerd container start, and the boot itself, out by the full 90 seconds.
+// systemd cannot drop an inherited After=, so the wait unit is overridden here
+// rather than removed from the quadlets.
+const networkWaitDropIn = `# Written by lerd.
+# network-online.target never activates on this host, so podman's wait unit can
+# only time out, stalling every container start and boot by 90s. Lerd publishes
+# on loopback and needs no routable network, so the wait is skipped.
+[Service]
+ExecStart=
+ExecStart=/bin/true
+`
+
+// NetworkWaitDropInPath returns the path of lerd's override for podman's
+// network-online wait unit.
+func NetworkWaitDropInPath() string {
+	return filepath.Join(config.SystemdUserDir(), podmanNetworkWaitUnit+".d", networkWaitDropInFile)
+}
+
+// networkWaitStalls decides, from the wait unit's load state, whether lerd has
+// already overridden it, and the current state of network-online.target,
+// whether container starts on this host are paying the 90s timeout.
+func networkWaitStalls(loadState string, dropInPresent bool, targetState string) bool {
+	if loadState != "loaded" || dropInPresent {
+		return false
+	}
+	return targetState == "inactive" || targetState == "failed"
+}
+
+// NetworkWaitStalls reports whether podman's network-online wait unit stalls
+// container starts on this host.
+func NetworkWaitStalls() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	_, err := os.Stat(NetworkWaitDropInPath())
+	return networkWaitStalls(unitLoadState(podmanNetworkWaitUnit), err == nil, networkOnlineTargetState())
+}
+
+// EnsureNoNetworkWaitStall installs the override when podman's wait unit would
+// otherwise stall every container start. Reports whether it wrote the drop-in.
+func EnsureNoNetworkWaitStall() (bool, error) {
+	if !NetworkWaitStalls() {
+		return false, nil
+	}
+
+	path := NetworkWaitDropInPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return false, err
+	}
+	config.GuardRealWrite(path)
+	if err := os.WriteFile(path, []byte(networkWaitDropIn), 0644); err != nil {
+		return false, err
+	}
+
+	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
+	_ = exec.Command("systemctl", "--user", "reset-failed", podmanNetworkWaitUnit).Run()
+	return true, nil
+}
+
+// unitLoadState returns systemd's LoadState for a user unit ("loaded",
+// "not-found", "masked"), or "" when systemctl can't be reached.
+func unitLoadState(unit string) string {
+	out, err := exec.Command("systemctl", "--user", "show", unit, "-p", "LoadState", "--value").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// networkOnlineTargetState returns the ActiveState of the system's
+// network-online.target. systemctl is-active exits non-zero for every state
+// but "active", so the output is what matters, not the exit code.
+func networkOnlineTargetState() string {
+	out, _ := exec.Command("systemctl", "is-active", "network-online.target").Output()
+	return strings.TrimSpace(string(out))
+}

--- a/internal/systemd/networkwait_test.go
+++ b/internal/systemd/networkwait_test.go
@@ -1,0 +1,93 @@
+package systemd
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNetworkWaitStalls(t *testing.T) {
+	tests := []struct {
+		name       string
+		loadState  string
+		dropIn     bool
+		target     string
+		wantStalls bool
+	}{
+		{
+			name:       "atomic image: target never activates",
+			loadState:  "loaded",
+			target:     "inactive",
+			wantStalls: true,
+		},
+		{
+			name:      "ordinary host: target is active",
+			loadState: "loaded",
+			target:    "active",
+		},
+		{
+			name:      "already neutralised by lerd",
+			loadState: "loaded",
+			dropIn:    true,
+			target:    "inactive",
+		},
+		{
+			name:      "podman too old to ship the wait unit",
+			loadState: "not-found",
+			target:    "inactive",
+		},
+		{
+			name:      "user already masked the unit",
+			loadState: "masked",
+			target:    "inactive",
+		},
+		{
+			// Mid-boot the target can still be on its way up. Only act on a
+			// settled "inactive", never on a target that may yet come online.
+			name:      "target still coming up",
+			loadState: "loaded",
+			target:    "activating",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := networkWaitStalls(tt.loadState, tt.dropIn, tt.target); got != tt.wantStalls {
+				t.Errorf("networkWaitStalls(%q, %v, %q) = %v, want %v",
+					tt.loadState, tt.dropIn, tt.target, got, tt.wantStalls)
+			}
+		})
+	}
+}
+
+func TestNetworkWaitDropInOverridesExecStart(t *testing.T) {
+	// Resetting ExecStart before reassigning it is what makes the override
+	// replace podman's poll loop instead of appending a second command.
+	execStarts := 0
+	for _, line := range strings.Split(networkWaitDropIn, "\n") {
+		if strings.HasPrefix(line, "ExecStart=") {
+			execStarts++
+		}
+	}
+	if execStarts != 2 {
+		t.Fatalf("drop-in has %d ExecStart= lines, want 2 (a reset then the no-op)", execStarts)
+	}
+	if !strings.Contains(networkWaitDropIn, "ExecStart=\nExecStart=") {
+		t.Error("drop-in must reset ExecStart= to empty before reassigning it")
+	}
+	if !strings.Contains(networkWaitDropIn, "[Service]") {
+		t.Error("drop-in must carry a [Service] section")
+	}
+}
+
+func TestNetworkWaitDropInPath(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	path := NetworkWaitDropInPath()
+	if got := filepath.Base(filepath.Dir(path)); got != "podman-user-wait-network-online.service.d" {
+		t.Errorf("drop-in parent dir = %q, want the wait unit's .d directory", got)
+	}
+	if got := filepath.Base(path); got != "10-lerd-no-network-wait.conf" {
+		t.Errorf("drop-in file = %q", got)
+	}
+}

--- a/internal/tray/deps.go
+++ b/internal/tray/deps.go
@@ -1,0 +1,90 @@
+package tray
+
+import (
+	"bufio"
+	"bytes"
+	"debug/elf"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// libSearchDirs are the standard locations checked when ldconfig's cache is
+// unavailable (some minimal and immutable images ship no ldconfig binary).
+var libSearchDirs = []string{"/lib64", "/usr/lib64", "/lib", "/usr/lib"}
+
+// HelperPath returns the lerd-tray binary installed alongside lerd, or "" when
+// the running executable can't be located.
+func HelperPath() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(exe), "lerd-tray")
+}
+
+// MissingLibs returns the shared libraries the tray helper links that this host
+// cannot resolve. lerd-tray needs libayatana-appindicator, which an immutable
+// image cannot simply install: without the library the helper exits 127 on
+// every start, so the unit is left restart-looping and the whole systemd user
+// session reports "degraded". Detection is conservative — anything it cannot
+// determine (unreadable binary, no ELF, no library index) reports nothing
+// missing, so a working tray is never disabled by a failed probe.
+func MissingLibs(helper string) []string {
+	needed, err := neededLibs(helper)
+	if err != nil || len(needed) == 0 {
+		return nil
+	}
+	index := hostLibs()
+	if len(index) == 0 {
+		return nil
+	}
+	return missingFrom(needed, index)
+}
+
+// missingFrom returns the needed libraries absent from the host's library index.
+func missingFrom(needed []string, index map[string]struct{}) []string {
+	var missing []string
+	for _, lib := range needed {
+		if _, found := index[lib]; !found {
+			missing = append(missing, lib)
+		}
+	}
+	return missing
+}
+
+// neededLibs reads the DT_NEEDED entries of an ELF binary.
+func neededLibs(path string) ([]string, error) {
+	f, err := elf.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return f.ImportedLibraries()
+}
+
+// hostLibs indexes every shared library the dynamic linker can resolve, from
+// ldconfig's cache when it exists and from the standard directories otherwise.
+func hostLibs() map[string]struct{} {
+	index := map[string]struct{}{}
+	if out, err := exec.Command("ldconfig", "-p").Output(); err == nil {
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		for scanner.Scan() {
+			// "\tlibfoo.so.1 (libc6,x86-64) => /usr/lib64/libfoo.so.1"
+			if name, _, found := strings.Cut(strings.TrimSpace(scanner.Text()), " "); found {
+				index[name] = struct{}{}
+			}
+		}
+	}
+	for _, dir := range libSearchDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			index[filepath.Base(e.Name())] = struct{}{}
+		}
+	}
+	return index
+}

--- a/internal/tray/deps_test.go
+++ b/internal/tray/deps_test.go
@@ -1,0 +1,76 @@
+package tray
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMissingFrom(t *testing.T) {
+	index := map[string]struct{}{
+		"libc.so.6":   {},
+		"libgtk-3.so": {},
+	}
+
+	tests := []struct {
+		name   string
+		needed []string
+		want   []string
+	}{
+		{
+			name:   "atomic image without the appindicator library",
+			needed: []string{"libayatana-appindicator3.so.1", "libc.so.6"},
+			want:   []string{"libayatana-appindicator3.so.1"},
+		},
+		{
+			name:   "everything resolves",
+			needed: []string{"libc.so.6", "libgtk-3.so"},
+		},
+		{
+			name:   "nothing needed",
+			needed: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := missingFrom(tt.needed, index)
+			if len(got) != len(tt.want) {
+				t.Fatalf("missingFrom() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("missingFrom()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// A probe that cannot read the helper must not claim libraries are missing:
+// reporting a false positive would disable a perfectly good tray.
+func TestMissingLibsIsConservative(t *testing.T) {
+	if got := MissingLibs(filepath.Join(t.TempDir(), "no-such-helper")); got != nil {
+		t.Errorf("MissingLibs(absent binary) = %v, want nil", got)
+	}
+
+	notELF := filepath.Join(t.TempDir(), "lerd-tray")
+	if err := os.WriteFile(notELF, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if got := MissingLibs(notELF); got != nil {
+		t.Errorf("MissingLibs(non-ELF) = %v, want nil", got)
+	}
+}
+
+// The running test binary is by definition fully resolvable, so a real ELF read
+// through the real host index must come back clean.
+func TestMissingLibsOnResolvableBinary(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Skip("cannot locate test binary")
+	}
+	if got := MissingLibs(self); got != nil {
+		t.Errorf("MissingLibs(self) = %v, want nil — the running binary resolves", got)
+	}
+}

--- a/internal/tray/stub.go
+++ b/internal/tray/stub.go
@@ -5,7 +5,6 @@ package tray
 import (
 	"os"
 	"os/exec"
-	"path/filepath"
 	"syscall"
 )
 
@@ -13,11 +12,10 @@ import (
 // If the helper is absent or its shared library is missing the error is
 // silently swallowed — the rest of lerd keeps working without a tray.
 func Run(mono bool) error {
-	exe, err := os.Executable()
-	if err != nil {
+	helper := HelperPath()
+	if helper == "" {
 		return nil
 	}
-	helper := filepath.Join(filepath.Dir(exe), "lerd-tray")
 	if _, err := os.Stat(helper); err != nil {
 		return nil // helper not installed
 	}


### PR DESCRIPTION
On atomic images (Fedora Silverblue, Kinoite, Bazzite, CoreOS) podman's quadlet generator makes every rootless container Wants= and After=podman-user-wait-network-online.service. That unit polls network-online.target, which nothing pulls in on these images, so it can only time out after 90 seconds, dragging every container start and the boot itself out by a minute and a half. systemd offers no way to strip an inherited ordering dependency, so lerd now writes a drop-in that turns podman's wait unit into a no-op on hosts where the target never activates, gated so ordinary distributions are untouched. lerd only ever binds loopback, so there is nothing to wait for. Both lerd start and lerd install install the override, and lerd doctor reports the condition.

The tray is the second half. lerd-tray links libayatana-appindicator3.so.1, which these images do not carry and cannot add to /usr without layering a package and rebooting, so the helper exits 127 on every start and the failed unit leaves the whole systemd user session degraded. Install now reads the helper's ELF dependencies and, when a library will not resolve, leaves the tray unit on disk but stopped and disabled instead of enabling it, so the failure no longer poisons the session. The unit is ready to re-enable once the library is present.

Refs #915
