### PR TITLE
fix: handle missing certutil on atomic images for browser HTTPS trust

### DIFF
--- a/docs/features/https.md
+++ b/docs/features/https.md
@@ -25,6 +25,34 @@ Certificates are stored in `~/.local/share/lerd/certs/sites/`.
 
 ---
 
+## Browser trust (certutil / nss-tools)
+
+mkcert installs the local CA into two places: the system trust store, used by curl, PHP, wget and openssl, and the browser NSS databases used by Firefox and Chrome/Chromium. Writing to the browser stores needs `certutil`, which ships in `nss-tools`. When `certutil` is missing mkcert still trusts the system store, so command-line tools accept `.test` HTTPS, but browsers show a certificate warning. `lerd doctor` reports this under "browser HTTPS trust (certutil)", and `lerd install` / `lerd dns:enable` print a note when it applies.
+
+On ordinary distributions install nss-tools and re-run `lerd dns:repair`:
+
+```bash
+sudo dnf install nss-tools        # Fedora
+sudo apt install libnss3-tools    # Debian / Ubuntu
+sudo pacman -S nss                # Arch
+lerd dns:repair
+```
+
+On atomic images (Fedora Silverblue, Bazzite, Kinoite, CoreOS) the package has to be layered and the machine rebooted first:
+
+```bash
+rpm-ostree install nss-tools
+systemctl reboot
+lerd dns:repair
+```
+
+If you would rather not install a package at all, run `lerd dns:disable` to serve your sites over plain http on `*.localhost`, which needs no certificate.
+
+> [!NOTE]
+> On atomic desktops a Flatpak Firefox or Chrome keeps its own trust store inside the sandbox, which mkcert cannot reach even once certutil is installed. A native (non-Flatpak) browser, or Chrome using the shared `~/.pki/nssdb`, picks up the CA normally.
+
+---
+
 ## Automatic renewal
 
 mkcert issues each leaf certificate with a lifetime of a little over two years. Lerd renews a secured site's certificate on its own before it lapses: whenever a certificate is within roughly 30 days of its `NotAfter` (or has already expired, gone missing, or been corrupted), the next ordinary `lerd start` or watcher pass reissues it in place. A still-valid certificate comfortably clear of that window is left untouched, so the renewal check is cheap and silent. `lerd status` continues to surface the same 30-day expiry warning under `[TLS Certificates]`, but you no longer need to act on it manually; a long-lived site that just keeps running self-heals its own certificate.

--- a/install.sh
+++ b/install.sh
@@ -67,15 +67,41 @@ detect_distro() {
   fi
 }
 
+# detect_distro_like returns the ID_LIKE field from /etc/os-release, the space
+# separated list of parent distros a derivative declares (e.g. bazzite -> fedora).
+detect_distro_like() {
+  if [ -f /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    echo "${ID_LIKE:-}"
+  fi
+}
+
+# is_atomic reports whether this host booted from an ostree image (Fedora
+# Silverblue, Bazzite, Kinoite, CoreOS). On these, packages are layered with
+# rpm-ostree and a reboot, not installed into the running system.
+is_atomic() {
+  [ -f /run/ostree-booted ]
+}
+
 distro_family() {
   local distro; distro="$(detect_distro)"
   case "$distro" in
-    arch|manjaro|endeavouros|garuda) echo "arch" ;;
-    debian|ubuntu|pop|linuxmint|elementary|zorin) echo "debian" ;;
-    fedora|rhel|centos|rocky|alma) echo "fedora" ;;
-    opensuse*|sles) echo "suse" ;;
-    *) echo "unknown" ;;
+    arch|manjaro|endeavouros|garuda) echo "arch"; return ;;
+    debian|ubuntu|pop|linuxmint|elementary|zorin) echo "debian"; return ;;
+    fedora|rhel|centos|rocky|alma) echo "fedora"; return ;;
+    opensuse*|sles) echo "suse"; return ;;
   esac
+  # A derivative not listed above (bazzite, nobara, cachyos, ...) still declares
+  # its parents in ID_LIKE, so fall back to that before giving up as unknown.
+  local like; like=" $(detect_distro_like) "
+  case "$like" in
+    *" arch "*)                           echo "arch"; return ;;
+    *" debian "*|*" ubuntu "*)            echo "debian"; return ;;
+    *" fedora "*|*" rhel "*|*" centos "*) echo "fedora"; return ;;
+    *" suse "*|*" opensuse "*)            echo "suse"; return ;;
+  esac
+  echo "unknown"
 }
 
 # ── Prerequisite checks ──────────────────────────────────────────────────────
@@ -153,6 +179,15 @@ check_certutil() {
     suse)   pkg="mozilla-nss-tools" ;;
     *)      pkg="nss-tools" ;;
   esac
+  if is_atomic; then
+    # nss-tools can't be layered inline (rpm-ostree needs a reboot), so don't
+    # queue it for the package installer, which would die or fail on ostree.
+    # Guide instead, and leave localhost as the no-package alternative.
+    warn "certutil not found — mkcert can't trust HTTPS certs in Chrome/Firefox on this atomic image"
+    info "For browser trust: rpm-ostree install $pkg, reboot, then run 'lerd dns:repair'"
+    info "Or re-run and choose localhost DNS to serve plain http with no certificates"
+    return
+  fi
   warn "certutil not found — mkcert won't be able to trust HTTPS certs in Chrome/Firefox"
   MISSING_PKGS+=("$pkg")
 }
@@ -253,6 +288,12 @@ install_packages() {
   fi
 
   local family; family="$(distro_family)"
+
+  if is_atomic; then
+    warn "atomic image detected — packages are layered with rpm-ostree, not installed into the running system"
+    info "Run:  rpm-ostree install ${pkgs[*]}  then reboot and re-run the installer"
+    return
+  fi
 
   case "$family" in
     arch)

--- a/internal/certs/browser_trust.go
+++ b/internal/certs/browser_trust.go
@@ -1,0 +1,17 @@
+package certs
+
+import "os/exec"
+
+// certutilLookup reports whether certutil is resolvable on PATH. Seam for tests.
+var certutilLookup = func() bool {
+	_, err := exec.LookPath("certutil")
+	return err == nil
+}
+
+// BrowserTrustAvailable reports whether mkcert can install the root CA into the
+// browser NSS trust stores. That needs certutil, shipped in nss-tools. Without
+// it mkcert still writes the CA to the system trust store, so curl, PHP and
+// openssl trust .test, but Firefox and Chrome are skipped and warn on HTTPS.
+func BrowserTrustAvailable() bool {
+	return certutilLookup()
+}

--- a/internal/certs/browser_trust_test.go
+++ b/internal/certs/browser_trust_test.go
@@ -1,0 +1,18 @@
+package certs
+
+import "testing"
+
+func TestBrowserTrustAvailable(t *testing.T) {
+	orig := certutilLookup
+	defer func() { certutilLookup = orig }()
+
+	certutilLookup = func() bool { return true }
+	if !BrowserTrustAvailable() {
+		t.Fatal("want available when certutil is present")
+	}
+
+	certutilLookup = func() bool { return false }
+	if BrowserTrustAvailable() {
+		t.Fatal("want unavailable when certutil is missing")
+	}
+}

--- a/internal/cli/browser_trust.go
+++ b/internal/cli/browser_trust.go
@@ -1,0 +1,23 @@
+package cli
+
+import "os"
+
+// ostreeBootedFn reports whether the host booted from an ostree/atomic image
+// (Silverblue, Bazzite, Kinoite, CoreOS), where nss-tools can't be added
+// without layering a package and rebooting. Seam for tests.
+var ostreeBootedFn = func() bool {
+	_, err := os.Stat("/run/ostree-booted")
+	return err == nil
+}
+
+// browserTrustGuidance returns the message shown when managed DNS is on but
+// certutil is missing, so .test HTTPS is trusted by curl, PHP and openssl yet
+// browsers warn. The route to browser trust differs on atomic images, which
+// can only gain nss-tools by layering it and rebooting.
+func browserTrustGuidance(atomic bool) string {
+	base := "certutil (nss-tools) not found, so .test certificates are trusted by curl, PHP and openssl but browsers will warn. "
+	if atomic {
+		return base + "For browser trust run rpm-ostree install nss-tools, reboot, then lerd dns:repair. Or run lerd dns:disable to serve plain http on .localhost."
+	}
+	return base + "For browser trust install nss-tools (dnf install nss-tools, apt install libnss3-tools, or pacman -S nss) then lerd dns:repair. Or run lerd dns:disable to serve plain http on .localhost."
+}

--- a/internal/cli/browser_trust_test.go
+++ b/internal/cli/browser_trust_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBrowserTrustGuidance_atomic(t *testing.T) {
+	msg := browserTrustGuidance(true)
+	for _, want := range []string{"certutil", "rpm-ostree install nss-tools", "reboot", "lerd dns:repair", "lerd dns:disable"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("atomic guidance missing %q: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "apt install") || strings.Contains(msg, "pacman") {
+		t.Errorf("atomic guidance should not offer non-atomic package managers: %s", msg)
+	}
+}
+
+func TestBrowserTrustGuidance_ordinary(t *testing.T) {
+	msg := browserTrustGuidance(false)
+	for _, want := range []string{"certutil", "nss-tools", "lerd dns:repair", "lerd dns:disable"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("guidance missing %q: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "rpm-ostree") {
+		t.Errorf("ordinary guidance should not tell the user to layer with rpm-ostree: %s", msg)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/cleanup"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
@@ -99,6 +100,18 @@ func RunDoctorTo(w io.Writer, useColor bool) (fails, warns int, err error) {
 			}
 		} else {
 			ok("systemd user session")
+		}
+
+		// mkcert can only trust .test in the browser when certutil (nss-tools) is
+		// present. Without it lerd's mkcert step installs the CA to the system
+		// store only, so curl and PHP trust it but Firefox and Chrome warn, and
+		// the mkcert warning is swallowed. Only relevant when DNS/HTTPS is managed.
+		if cfg, cfgErr := config.LoadGlobal(); cfgErr == nil && cfg != nil && cfg.DNS.Enabled {
+			if certs.BrowserTrustAvailable() {
+				ok("browser HTTPS trust (certutil)")
+			} else {
+				warn("browser HTTPS trust (certutil)", browserTrustGuidance(ostreeBootedFn()))
+			}
 		}
 
 		currentUser := os.Getenv("USER")

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -106,7 +106,7 @@ func RunDoctorTo(w io.Writer, useColor bool) (fails, warns int, err error) {
 		// present. Without it lerd's mkcert step installs the CA to the system
 		// store only, so curl and PHP trust it but Firefox and Chrome warn, and
 		// the mkcert warning is swallowed. Only relevant when DNS/HTTPS is managed.
-		if cfg, cfgErr := config.LoadGlobal(); cfgErr == nil && cfg != nil && cfg.DNS.Enabled {
+		if cfg, cfgErr := config.LoadGlobal(); cfgErr == nil && cfg.DNSManaged() {
 			if certs.BrowserTrustAvailable() {
 				ok("browser HTTPS trust (certutil)")
 			} else {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -393,6 +393,14 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		}
 		mkcertCmd.Run() //nolint:errcheck
 
+		// mkcert only adds the CA to the browser NSS stores when certutil is
+		// present, and it exits 0 with a warning otherwise (which the discard
+		// path above hides). Surface it ourselves so the user knows .test HTTPS
+		// works for tooling but not the browser, and how to fix or side-step it.
+		if !certs.BrowserTrustAvailable() {
+			feedback.Note(browserTrustGuidance(ostreeBootedFn()))
+		}
+
 		// 5. DNS config + sudoers
 		step("Writing DNS configuration")
 		dnsConfPath := filepath.Join(config.DnsmasqDir(), "lerd.conf")

--- a/tests/installer/installer.bats
+++ b/tests/installer/installer.bats
@@ -87,9 +87,61 @@ teardown() {
 @test "distro_family returns unknown for unrecognised distro" {
   function detect_distro() { echo "slackware"; }
   export -f detect_distro
+  function detect_distro_like() { echo ""; }
+  export -f detect_distro_like
 
   run distro_family
   [ "$output" = "unknown" ]
+}
+
+@test "distro_family falls back to ID_LIKE for derivatives (bazzite -> fedora)" {
+  function detect_distro() { echo "bazzite"; }
+  export -f detect_distro
+  function detect_distro_like() { echo "fedora"; }
+  export -f detect_distro_like
+
+  run distro_family
+  [ "$output" = "fedora" ]
+}
+
+@test "distro_family reads a multi-value ID_LIKE" {
+  function detect_distro() { echo "somespin"; }
+  export -f detect_distro
+  function detect_distro_like() { echo "rhel fedora"; }
+  export -f detect_distro_like
+
+  run distro_family
+  [ "$output" = "fedora" ]
+}
+
+# ── check_certutil ────────────────────────────────────────────────────────────
+
+@test "check_certutil guides without queuing nss-tools on atomic images" {
+  function command() { if [ "$1" = "-v" ] && [ "$2" = "certutil" ]; then return 1; fi; builtin command "$@"; }
+  export -f command
+  function distro_family() { echo "fedora"; }
+  export -f distro_family
+  function is_atomic() { return 0; }
+  export -f is_atomic
+
+  MISSING_PKGS=()
+  check_certutil >"$BATS_TMPDIR/cc-$$.out" 2>&1
+  [ "${#MISSING_PKGS[@]}" -eq 0 ]
+  grep -q "rpm-ostree install nss-tools" "$BATS_TMPDIR/cc-$$.out"
+}
+
+@test "check_certutil queues nss-tools on ordinary distros" {
+  function command() { if [ "$1" = "-v" ] && [ "$2" = "certutil" ]; then return 1; fi; builtin command "$@"; }
+  export -f command
+  function distro_family() { echo "fedora"; }
+  export -f distro_family
+  function is_atomic() { return 1; }
+  export -f is_atomic
+
+  MISSING_PKGS=()
+  check_certutil >/dev/null 2>&1
+  [ "${#MISSING_PKGS[@]}" -eq 1 ]
+  [ "${MISSING_PKGS[0]}" = "nss-tools" ]
 }
 
 # ── _download_tool ────────────────────────────────────────────────────────────


### PR DESCRIPTION
On atomic images (Fedora Silverblue, Bazzite, Kinoite, CoreOS) certutil, which ships in nss-tools, can't be installed without layering a package and rebooting. mkcert still trusts the local CA in the system store, so curl, PHP and openssl accept .test HTTPS, but it skips the browser NSS databases and only prints a warning, which lerd swallowed. The result was .test certificates that work on the command line but throw warnings in the browser, with nothing in lerd explaining why.

lerd now detects a missing certutil when managed DNS is enabled and surfaces it rather than hiding it. The mkcert step in install and dns:enable prints the guidance, and lerd doctor reports a browser HTTPS trust rung. The guidance points at either layering nss-tools and rerunning dns:repair, or dns:disable to serve plain http on localhost, and it is honest that a Flatpak browser keeps its own sandboxed trust store that mkcert cannot reach even after nss-tools is installed.

The bootstrap installer had the matching gap. distro_family only recognised base distribution IDs and ignored ID_LIKE, so a spin like bazzite fell through to unknown and install.sh died when it tried to install nss-tools, and even a Fedora atomic cannot dnf install into an ostree base. distro_family now consults ID_LIKE, and on atomic images the certutil check guides toward rpm-ostree or localhost instead of offering a package install that cannot succeed.

Refs #929
