### PR TITLE
fix: stop sites listing twice on ostree hosts where /home links to /var/home

### DIFF
--- a/docs/usage/sites.md
+++ b/docs/usage/sites.md
@@ -263,6 +263,8 @@ When a directory is parked or linked and another site is already registered with
 - **Same path**: treated as a re-link of the same site. The existing registration is updated and the TLS state is preserved.
 - **Different path**: the new site is registered with a numeric suffix (`myapp-2`, `myapp-3`, etc.) so both sites can coexist.
 
+Paths are compared after resolving symlinks, and the resolved path is what gets stored. On atomic images (Fedora Silverblue, Bazzite, and other ostree systems) `/home` is a symlink to `/var/home`, so linking a project through either spelling maps to the one site instead of registering it twice.
+
 ---
 
 ## Linking from the web UI

--- a/internal/cli/park.go
+++ b/internal/cli/park.go
@@ -209,8 +209,8 @@ func freeSiteName(desired, path string) string {
 		if err != nil || existing == nil {
 			return candidate // name is free
 		}
-		if existing.Path == path {
-			return candidate // same site being re-registered
+		if config.CanonicalPath(existing.Path) == config.CanonicalPath(path) {
+			return candidate // same site being re-registered (symlink spellings included, #930)
 		}
 	}
 }

--- a/internal/cli/park_canonical_test.go
+++ b/internal/cli/park_canonical_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestFreeSiteName_reusesNameForSymlinkedSpelling(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "home")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	appReal := filepath.Join(real, "app")
+	appLink := filepath.Join(link, "app")
+	if err := os.MkdirAll(appReal, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{Name: "app", Path: appReal}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Linking the same directory through the symlinked spelling must reuse the
+	// existing name, not disambiguate it to app-2 (#930).
+	if got := freeSiteName("app", appLink); got != "app" {
+		t.Errorf("freeSiteName(app, symlinked spelling) = %q, want app", got)
+	}
+}

--- a/internal/config/canonical_path_test.go
+++ b/internal/config/canonical_path_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCanonicalPath_resolvesSymlinkSpellings(t *testing.T) {
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	if CanonicalPath(link) != CanonicalPath(real) {
+		t.Errorf("CanonicalPath(%q)=%q, want it to match CanonicalPath(%q)=%q",
+			link, CanonicalPath(link), real, CanonicalPath(real))
+	}
+}
+
+func TestCanonicalPath_fallsBackWhenUnresolvable(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does", "..", "nope")
+	if got := CanonicalPath(missing); got != filepath.Clean(missing) {
+		t.Errorf("CanonicalPath(%q)=%q, want cleaned %q", missing, got, filepath.Clean(missing))
+	}
+	if CanonicalPath("") != "" {
+		t.Error(`CanonicalPath("") should return ""`)
+	}
+}
+
+func TestAddSiteStoresCanonicalPathAndFindsBothSpellings(t *testing.T) {
+	setDataDir(t)
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "home")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	appReal := filepath.Join(real, "app")
+	appLink := filepath.Join(link, "app")
+	if err := os.MkdirAll(appReal, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Register through the symlinked spelling; the stored path must be canonical.
+	if err := AddSite(Site{Name: "app", Path: appLink}); err != nil {
+		t.Fatal(err)
+	}
+	s, err := FindSite("app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Path != CanonicalPath(appReal) {
+		t.Errorf("stored path = %q, want canonical %q", s.Path, CanonicalPath(appReal))
+	}
+
+	// The same directory is found through the real spelling too.
+	if _, err := FindSiteByPath(appReal); err != nil {
+		t.Errorf("FindSiteByPath(real spelling) should find the symlink-registered site: %v", err)
+	}
+}

--- a/internal/config/site.go
+++ b/internal/config/site.go
@@ -434,6 +434,10 @@ func AddSite(site Site) error {
 	if ContainsUnitInjectionChars(site.Name) || strings.ContainsRune(site.Name, '/') {
 		return fmt.Errorf("invalid site name %q: must not contain newline, NUL, or slash", site.Name)
 	}
+	// Store the resolved path so two spellings of one directory (on ostree hosts
+	// /home is a symlink to /var/home, and os.Getwd can return either) register
+	// and de-duplicate as a single site rather than two (#930).
+	site.Path = CanonicalPath(site.Path)
 	// The filesystem root can never be a site: lerd bind-mounts a site's path into
 	// its containers, and mounting / over a container's own rootfs shadows its
 	// entrypoint so it cannot start (issue #884).
@@ -702,13 +706,29 @@ func FindSiteByPath(path string) (*Site, error) {
 		return nil, err
 	}
 
+	target := CanonicalPath(path)
 	for _, s := range reg.Sites {
-		if s.Path == path {
+		if CanonicalPath(s.Path) == target {
 			s := s
 			return &s, nil
 		}
 	}
 	return nil, fmt.Errorf("site with path %q not found", path)
+}
+
+// CanonicalPath resolves symlinks in p so two spellings of the same directory
+// compare equal. On ostree hosts /home is a symlink to /var/home, so os.Getwd
+// can hand back either form for one project, which otherwise registers and
+// lists twice (#930). Falls back to a cleaned path when the target can't be
+// resolved, e.g. it no longer exists, so callers always get a usable value.
+func CanonicalPath(p string) string {
+	if p == "" {
+		return p
+	}
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	return filepath.Clean(p)
 }
 
 // FindSiteByDomain returns the site that has the given domain (checks all domains),


### PR DESCRIPTION
On atomic images /home is a symlink to /var/home, so os.Getwd can hand back either spelling for one project directory. lerd stored and compared site paths as raw strings, so linking a project through /home and again through /var/home registered it as two separate sites, the second disambiguated with a numeric suffix, and both showed up in lerd sites and the dashboard. Linking a directory lerd already had, once through the ~ spelling and once through /var/home, was enough to mint the duplicate.

Paths are now resolved before they are stored and compared. AddSite writes the symlink-resolved path, and the re-link and lookup checks compare resolved paths, so the two spellings collapse to a single site. A directory reached through either form maps to the same registration, and an entry left over under the unresolved spelling from an earlier link still matches.

Refs #930
