### PR TITLE
fix(ui): profile localhost routes over http, not https

### DIFF
--- a/internal/ui/web/src/tabs/sites/SiteRequestTiming.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteRequestTiming.svelte
@@ -138,7 +138,7 @@
   let arming = $state(false);
   function routeUrl(r: RouteStat): string {
     if (r.method !== 'GET' || !r.example) return '';
-    return `https://${targetDomain}${r.example}`;
+    return `${site.tls ? 'https' : 'http'}://${targetDomain}${r.example}`;
   }
   async function profileRoute(r: RouteStat) {
     if (arming) return;

--- a/internal/ui/web/src/tabs/sites/SiteRequestTiming.test.ts
+++ b/internal/ui/web/src/tabs/sites/SiteRequestTiming.test.ts
@@ -76,6 +76,7 @@ describe('SiteRequestTiming Recent list', () => {
 describe('SiteRequestTiming on a worktree', () => {
   const site = {
     domain: 'whitewaters.test',
+    tls: true,
     worktrees: [{ branch: 'feature-x', domain: 'feature-x.whitewaters.test' }]
   };
 
@@ -100,6 +101,25 @@ describe('SiteRequestTiming on a worktree', () => {
     await fireEvent.click(await findByRole('button', { name: /GET.*\/reports\/:id/ }));
     await waitFor(() => {
       expect(opened.location.href).toBe('https://feature-x.whitewaters.test/reports/7');
+    });
+  });
+});
+
+// A localhost site is served over plain HTTP (no mkcert cert), so profiling a
+// route must open http://, not https:// which throws a certificate error.
+describe('SiteRequestTiming on a localhost site', () => {
+  const site = { domain: 'whitewaters.localhost' };
+
+  it('profiles routes over http on an unsecured localhost site', async () => {
+    loadSiteAnalytics.mockClear();
+    const opened = { location: { href: '' } };
+    vi.stubGlobal('open', vi.fn(() => opened));
+
+    const { findByRole } = render(SiteRequestTiming, { props: { site } });
+
+    await fireEvent.click(await findByRole('button', { name: /GET.*\/reports\/:id/ }));
+    await waitFor(() => {
+      expect(opened.location.href).toBe('http://whitewaters.localhost/reports/7');
     });
   });
 });


### PR DESCRIPTION
In the per-site request timing overview, profiling a route from the Slowest list built its URL with a hardcoded https scheme. On a localhost site, which lerd serves over plain http with no certificate, that opened https://<name>.localhost and failed with a certificate error instead of loading the route. The scheme now follows the site's TLS state, matching how the rest of the dashboard opens a site, so a localhost site profiles over http and a secured .test site still uses https.

Refs #934
