### PR TITLE
fix(php): keep an empty realised set from vanishing on config load

### DIFF
--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -654,6 +654,7 @@ func cloneGlobalConfig(in *GlobalConfig) *GlobalConfig {
 		out.PHP.Realised = make(map[string]RealisedPHPSet, len(in.PHP.Realised))
 		for k, v := range in.PHP.Realised {
 			out.PHP.Realised[k] = RealisedPHPSet{
+				Hash:       v.Hash,
 				Extensions: slices.Clone(v.Extensions),
 				Packages:   slices.Clone(v.Packages),
 			}

--- a/internal/config/php_sets.go
+++ b/internal/config/php_sets.go
@@ -38,6 +38,14 @@ func UpdateGlobal(fn func(*GlobalConfig)) error {
 // names and availability differ. Recording the truth per version is what lets
 // lerd warn about a gap instead of advertising what an image does not have.
 type RealisedPHPSet struct {
+	// Hash is the declared-set fingerprint the image was measured against. It is
+	// always set, which is also what keeps a record from serializing as an empty
+	// map: a version that loaded nothing of the declared set (mongodb on the
+	// Alpine 3.16 8.0 image) records empty Extensions and Packages, and viper
+	// drops an empty-map entry on load. Without a leaf the "8.0" key vanishes,
+	// MissingFromImage reads it back as "no record", and the whole declared set
+	// is then reported as loaded, the false success this record exists to prevent.
+	Hash       string   `yaml:"hash" mapstructure:"hash"`
 	Extensions []string `yaml:"extensions,omitempty" mapstructure:"extensions"`
 	Packages   []string `yaml:"packages,omitempty" mapstructure:"packages"`
 }

--- a/internal/config/php_sets_test.go
+++ b/internal/config/php_sets_test.go
@@ -265,3 +265,40 @@ func TestRealisedSetRoundTrips(t *testing.T) {
 		t.Errorf("MissingFromImage on an unbuilt version = %v, want none", missing)
 	}
 }
+
+// A version whose image loaded nothing of the declared set (mongodb on the
+// Alpine 3.16 8.0 image) records an otherwise empty realised entry. It must
+// survive a save/load round-trip through viper, which drops an empty-map entry.
+// When it was dropped the version read back as "no record" and was reported as
+// carrying the whole declared set it could not build, the false success #950
+// exists to prevent.
+func TestRealisedSet_emptyRecordSurvivesRoundTrip(t *testing.T) {
+	writeGlobalConfig(t, `
+php:
+  extensions: [mongodb]
+`)
+
+	cfg, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	// The build succeeded but mongodb did not load, so Extensions and Packages
+	// are both empty. The always-emitted hash key (even zero-valued here) is the
+	// leaf that keeps the whole record from serializing as an empty map.
+	cfg.SetRealised("8.0", RealisedPHPSet{})
+	if err := SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	invalidateGlobalCache()
+	reloaded, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal (reload): %v", err)
+	}
+	if _, ok := reloaded.PHP.Realised["8.0"]; !ok {
+		t.Fatal("empty realised record for 8.0 was dropped on load")
+	}
+	if missing := reloaded.MissingFromImage("8.0", []string{"mongodb"}); !reflect.DeepEqual(missing, []string{"mongodb"}) {
+		t.Errorf("MissingFromImage(8.0) = %v, want [mongodb]: an image that loaded nothing must report the declared set as missing", missing)
+	}
+}

--- a/internal/podman/custom_set.go
+++ b/internal/podman/custom_set.go
@@ -163,7 +163,9 @@ func RecordRealisedSet(version string, declaredExts, declaredPkgs []string) {
 	if err != nil {
 		return
 	}
-	cfg.SetRealised(version, realisedSet(declaredExts, declaredPkgs, string(modules), string(apkInfo)))
+	set := realisedSet(declaredExts, declaredPkgs, string(modules), string(apkInfo))
+	set.Hash = customSetHash(declaredExts, cfg.AllExtApkDeps(), declaredPkgs)
+	cfg.SetRealised(version, set)
 	_ = config.SaveGlobal(cfg)
 }
 


### PR DESCRIPTION
A version whose image loaded nothing of the declared set records an otherwise empty realised entry. `SaveGlobal` writes it as `"8.0": {}` through yaml, but `LoadGlobal` reads the config with viper (`KeyDelimiter("::")`), which drops an empty-map entry on load. The `"8.0"` key then vanishes, `MissingFromImage` reads it back as "no record" (`ok == false`), and every surface reports the whole declared set as loaded on a version that could not build it, the exact false success the realised set exists to prevent.

### Repro
1. `lerd fetch 8.0` (Alpine 3.16).
2. `lerd php:ext add mongodb` (does not build < 8.1).
3. `lerd php:rebuild 8.0` builds fine without mongodb (correct, graceful).
4. `lerd php:ext list` prints `PHP 8.0  mongodb`, though `php -m` on the 8.0 image has no mongodb.

Causal proof: hand-editing `realised["8.0"]` from `{}` to any non-empty set without mongodb flips the output to the correct `PHP 8.0  cannot load: mongodb`.

### Fix
Give `RealisedPHPSet` an always-emitted `hash` of the declared set the image was measured against. The record is no longer an empty map, so it survives the round-trip, and the hash is meaningful rather than a bare sentinel: it names the set the realisation describes. `RecordRealisedSet` fills it in.

This fixes the data layer, so all five `MissingFromImage` callers (the CLI list, the TUI, the version switch, MCP, and park) become correct at once rather than each guarding for the dropped record.

### Test
`TestRealisedSet_emptyRecordSurvivesRoundTrip` saves an empty realised record, reloads through viper, and asserts the key survives and the declared entry is reported missing. It fails if the hash tag ever regains `omitempty` (empty map returns, entry drops). Verified: fails on the pre-fix shape, passes with the fix.

### Note
Existing on-disk `{}` records written before this change stay dropped until the version is rebuilt, which rewrites them with a hash. No migration needed; it self-heals on the next `lerd php:rebuild`.

Found while testing #943 on macOS.

Closes #950
