### PR TITLE
fix(test): isolate HOME in the PHP version switch tests

### DIFF
--- a/internal/siteops/phpversion_test.go
+++ b/internal/siteops/phpversion_test.go
@@ -17,6 +17,12 @@ import (
 func phpVersionTestSite(t *testing.T, tweak func(*config.Site)) *config.Site {
 	t.Helper()
 	tmp := t.TempDir()
+	// HOME too, not just XDG: the launchd/systemd unit for the fpm service is
+	// written under os.UserHomeDir() (~/Library/LaunchAgents on macOS), which
+	// reads $HOME rather than the XDG dirs. Without this the version switch
+	// clobbers the real service files with a fake-podman path from this temp
+	// tree, breaking the developer's own lerd install once the tree is cleaned up.
+	t.Setenv("HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	fakePodmanOnPath(t)


### PR DESCRIPTION
`SetSitePHPVersion` writes the fpm service unit under `os.UserHomeDir()` (`~/Library/LaunchAgents` on macOS), which reads `$HOME` rather than the XDG dirs `phpVersionTestSite` already overrides. Running the suite on macOS therefore overwrote the developer's real service plists with a fake-podman path from the test's temp tree. Once `go test` cleaned the tree up, nginx and the `php*-fpm` services pointed at a binary that no longer existed and could not start. A shared macOS runner would hit the same on every run.

### Evidence
After a run, `~/Library/LaunchAgents/lerd-{nginx,php81,php82,php83,php85}-fpm.plist` carried `ProgramArguments` like:

```
/var/folders/.../T/TestSetSitePHPVersion_clampsToFrameworkRange<N>/002/podman run ...
--hostname starsetid.local ...
```

Each corrupted plist named a distinct subtest, so `TestSetSitePHPVersion` was the writer.

### Fix
Point `HOME` at the temp dir in the shared helper alongside the XDG dirs, so the unit is written into the tree and torn down with it. Every `SetSitePHPVersion` test routes through the helper; `TestImageGap` drives `imageGap` directly and writes no unit.

### Verified
- Full suite green.
- Real `~/Library/LaunchAgents` mtime unchanged across a suite run with the fix, so nothing leaks out any more (confirmed by comparing before/after).

Surfaced while testing #943 on macOS.

Closes #951
