### PR TITLE
fix(php): guard an unreachable cwd instead of leaking a crun error

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -70,3 +70,12 @@ Binding symmetry is preserved across stacks: `127.0.0.1` maps to `[::1]` and `0.
 **Per-version PHP-FPM**: each PHP version gets its own container built from a local `Containerfile`. The image includes all extensions needed for Laravel out of the box: `pdo_mysql`, `pdo_pgsql`, `bcmath`, `mbstring`, `xml`, `zip`, `gd`, `intl`, `opcache`, `pcntl`, `exif`, `sockets`, `redis`, `imagick`.
 
 **Automatic volume mounts**: the PHP-FPM and nginx containers bind-mount `$HOME` by default. When a project lives outside the home directory (e.g. `/var/www`, `/opt/projects`), lerd automatically adds the extra volume mount to both containers and restarts them. This happens transparently during `lerd link`, `lerd park`, or the first `lerd php` / `composer` / `laravel new` invocation from the outside path.
+
+Ephemeral system trees (`/tmp`, `/var/tmp`, `/run`, `/proc`, `/sys`, `/dev`) are deliberately excluded from auto-mounting: they vanish on reboot and would leave containers with dead mounts, and IDEs dropping randomly named temp files there would otherwise cascade container restarts. Running `lerd php` from such a path is refused with a clear message rather than an opaque runtime error. To opt a specific scratch root in anyway (common for AI coding agents whose session files live under `/tmp`), list it under `mounts:` in `~/.config/lerd/config.yaml`:
+
+```yaml
+mounts:
+  - /tmp/claude
+```
+
+Each entry is bind-mounted at the same location in the PHP-FPM and nginx containers, on the next `lerd start` or on the first `lerd php` invocation from a path it covers. Paths are mounted verbatim (host path equals container path), so a script's working directory and file arguments resolve unchanged.

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -126,22 +126,31 @@ func RunPHPCaptureEnv(cwd string, args []string, extraEnv []string) (int, error)
 	composerBin := filepath.Join(composerHome, "vendor", "bin")
 	projectVendorBin := filepath.Join(cwd, "vendor", "bin")
 
+	// A cwd the container can't reach (an ephemeral /tmp path, not parked and not
+	// listed under mounts:) makes `podman exec -w <cwd>` fail with an opaque crun
+	// chdir error. Refuse with a clear message instead (issue #949).
+	if !podman.PathVisible(cwd, version) && !podman.PathAutoMountable(cwd) {
+		return 0, fmt.Errorf("cannot run php from %s: lerd does not mount temporary system directories (/tmp, /var/tmp, /run) into the PHP container. Run from a path under your home directory or a parked directory, or add the path to mounts: in %s", cwd, config.GlobalConfigFile())
+	}
+
 	podman.EnsurePathMounted(cwd, version)
 	ensureServicesForCwd(cwd)
 
-	// If any positional arg is an absolute path to a file that exists on the
-	// host but outside $HOME (e.g. /tmp/ide-phpinfo.php written by PhpStorm),
-	// the container won't be able to read it since only $HOME is volume-mounted.
-	// Stream the file through stdin and replace the arg with /dev/stdin.
+	// PHP runs the first non-option operand as its script. When that script is an
+	// absolute path the container can't read (e.g. /tmp/ide-phpinfo.php written by
+	// an IDE), stream it through stdin as /dev/stdin. Only the script is eligible:
+	// a later path is the script's own argument (a data file), and rewriting that
+	// to /dev/stdin silently breaks is_file() checks and any script taking more
+	// than one file (issue #949).
 	var stdinReader io.Reader = os.Stdin
 	useTTY := term.IsTerminal(int(os.Stdin.Fd()))
-	for i, arg := range args {
-		if filepath.IsAbs(arg) && !strings.HasPrefix(arg, home+"/") && arg != home {
+	if i := phpScriptArgIndex(args); i >= 0 && i < len(args) {
+		arg := args[i]
+		if filepath.IsAbs(arg) && !strings.HasPrefix(arg, home+"/") && arg != home && !podman.PathVisible(arg, version) {
 			if data, err := os.ReadFile(arg); err == nil {
 				args[i] = "/dev/stdin"
 				stdinReader = bytes.NewReader(data)
 				useTTY = false
-				break
 			}
 		}
 	}
@@ -188,6 +197,34 @@ func RunPHPCaptureEnv(cwd string, args []string, extraEnv []string) (int, error)
 		return 0, err
 	}
 	return 0, nil
+}
+
+// phpScriptArgIndex returns the index of the script operand in a `php` argument
+// list — the first token that is not an option (nor an option's separate value),
+// which is the file PHP executes. Returns -1 when the invocation runs no file
+// (php -r '...', php -v). Flag parsing is disabled on the php command, so this
+// mirrors just enough of PHP's CLI getopt to tell a script path from a flag.
+func phpScriptArgIndex(args []string) int {
+	// Single-letter options that consume the following token as their value; the
+	// glued forms (-dfoo=bar) carry their own value and pass through as one token.
+	valueFlags := map[string]bool{
+		"-c": true, "-d": true, "-r": true, "-B": true, "-R": true,
+		"-F": true, "-E": true, "-S": true, "-t": true, "-z": true,
+	}
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "-f" {
+			return i + 1 // php -f <file>: the value is the script
+		}
+		if strings.HasPrefix(a, "-") {
+			if valueFlags[a] {
+				i++ // skip its separate value token
+			}
+			continue
+		}
+		return i
+	}
+	return -1
 }
 
 // spxPassthroughEnv picks the SPX_* profiler vars out of environ. When SPX is

--- a/internal/cli/php_exec_test.go
+++ b/internal/cli/php_exec_test.go
@@ -5,6 +5,31 @@ import (
 	"testing"
 )
 
+func TestPhpScriptArgIndex(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"bare script", []string{"artisan", "migrate"}, 0},
+		{"absolute script", []string{"/tmp/ide-phpinfo.php"}, 0},
+		{"glued -d before script", []string{"-dmemory_limit=-1", "/tmp/x.php"}, 1},
+		{"separated -d before script", []string{"-d", "memory_limit=-1", "script.php"}, 2},
+		{"script then data file arg", []string{"check.php", "/tmp/input.xml"}, 0},
+		{"-r runs no file", []string{"-r", "echo 1;"}, -1},
+		{"-v runs no file", []string{"-v"}, -1},
+		{"-f names the script", []string{"-f", "/tmp/x.php"}, 1},
+		{"empty", nil, -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := phpScriptArgIndex(tt.args); got != tt.want {
+				t.Errorf("phpScriptArgIndex(%v) = %d, want %d", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSpxPassthroughEnv(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -267,9 +267,17 @@ type GlobalConfig struct {
 	// AutoCleanup lets the watcher periodically reclaim orphaned lerd images
 	// (safe tier only, never service images). On by default; set false to turn
 	// off the daily sweep. Read it via AutoCleanupEnabled for nil-safety.
-	AutoCleanup       bool                     `yaml:"auto_cleanup"       mapstructure:"auto_cleanup"`
-	ParkedDirectories []string                 `yaml:"parked_directories" mapstructure:"parked_directories"`
-	Services          map[string]ServiceConfig `yaml:"services"           mapstructure:"services"`
+	AutoCleanup       bool     `yaml:"auto_cleanup"       mapstructure:"auto_cleanup"`
+	ParkedDirectories []string `yaml:"parked_directories" mapstructure:"parked_directories"`
+	// Mounts are extra host paths the user opts in to bind-mounting into the
+	// PHP-FPM and nginx containers at the same location, on top of $HOME and the
+	// parked/linked-site paths. Unlike those, a mount may point at a normally
+	// excluded system tree (e.g. a scratch root under /tmp for agent workflows):
+	// listing it here is the explicit "yes, mount this" the ephemeral denylist
+	// otherwise withholds. Same-location only, so an in-container path matches its
+	// host path and `lerd php` can chdir into it.
+	Mounts   []string                 `yaml:"mounts,omitempty"   mapstructure:"mounts"`
+	Services map[string]ServiceConfig `yaml:"services"           mapstructure:"services"`
 	// Workspaces group sites for display only, in the web UI and the TUI. See
 	// workspaces.go; they never affect how a site is served.
 	Workspaces []Workspace `yaml:"workspaces,omitempty" mapstructure:"workspaces"`
@@ -678,6 +686,9 @@ func cloneGlobalConfig(in *GlobalConfig) *GlobalConfig {
 	}
 	if in.ParkedDirectories != nil {
 		out.ParkedDirectories = append([]string(nil), in.ParkedDirectories...)
+	}
+	if in.Mounts != nil {
+		out.Mounts = append([]string(nil), in.Mounts...)
 	}
 	if in.DNS.Upstream != nil {
 		out.DNS.Upstream = append([]string(nil), in.DNS.Upstream...)

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -51,6 +51,7 @@ func ExtraVolumePaths() []string {
 	var candidates []string
 	if cfg, err := config.LoadGlobal(); err == nil {
 		candidates = append(candidates, cfg.ParkedDirectories...)
+		candidates = append(candidates, cfg.Mounts...)
 	}
 	if reg, err := config.LoadSites(); err == nil {
 		for _, site := range reg.Sites {
@@ -1056,13 +1057,37 @@ var (
 
 const pathMountDebounce = 60 * time.Second
 
+// configuredMountRoot returns the config `mounts:` entry that covers path (the
+// path itself or an ancestor), if any. It is the user's explicit opt-in to
+// bind-mount a tree the ephemeral denylist would otherwise withhold.
+func configuredMountRoot(path string) (string, bool) {
+	cfg, err := config.LoadGlobal()
+	if err != nil || cfg == nil {
+		return "", false
+	}
+	for _, m := range cfg.Mounts {
+		if !bindMountable(m) {
+			continue
+		}
+		m = filepath.Clean(m)
+		if path == m || strings.HasPrefix(path, strings.TrimSuffix(m, "/")+"/") {
+			return m, true
+		}
+	}
+	return "", false
+}
+
 // PathAutoMountable reports whether EnsurePathMounted would bind-mount the
 // given path on demand. The filesystem root is refused (issue #884) and so are
 // the ephemeral system trees above; callers that need such a path inside a
-// container have to say so explicitly, by parking it.
+// container have to say so explicitly, by parking it or listing it under
+// `mounts:` in config.yaml (which overrides the ephemeral denylist).
 func PathAutoMountable(path string) bool {
 	if !bindMountable(path) {
 		return false
+	}
+	if _, ok := configuredMountRoot(path); ok {
+		return true
 	}
 	for _, p := range ephemeralPathPrefixes {
 		if strings.HasPrefix(path, p) {
@@ -1112,6 +1137,12 @@ func EnsurePathMounted(path, phpVersion string) {
 	// command run from / or from a temp dir must not rewrite the quadlets.
 	if !PathAutoMountable(path) {
 		return
+	}
+	// A cwd under a configured mount mounts the mount root, not the deep
+	// (often session-scoped) subdirectory, so the quadlet gains one stable line
+	// instead of churning a new one per scratch path.
+	if root, ok := configuredMountRoot(path); ok {
+		path = root
 	}
 	home, _ := os.UserHomeDir()
 	if home == "" {

--- a/internal/podman/path_mount_test.go
+++ b/internal/podman/path_mount_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 // resetPathMountAttempts clears the debounce cache so tests can drive the
@@ -90,6 +92,42 @@ func TestPathVisible(t *testing.T) {
 
 	if PathVisible("/srv/apps/shop", "8.1") {
 		t.Error("PathVisible should report false when the version's quadlet does not exist")
+	}
+}
+
+// A path listed under config `mounts:` is auto-mountable even though it lives
+// under an ephemeral prefix the denylist would otherwise refuse, and it flows
+// into ExtraVolumePaths so a quadlet rebuild picks it up (issue #949).
+func TestConfiguredMountOverridesEphemeralDenylist(t *testing.T) {
+	home := t.TempDir()
+	cfgHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+
+	cfg := &config.GlobalConfig{Mounts: []string{"/tmp/claude"}}
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if !PathAutoMountable("/tmp/claude/session-123") {
+		t.Error("a path under a configured mount should be auto-mountable despite /tmp")
+	}
+	if PathAutoMountable("/tmp/other/session") {
+		t.Error("an unconfigured /tmp path must stay refused")
+	}
+	if root, ok := configuredMountRoot("/tmp/claude/session-123"); !ok || root != "/tmp/claude" {
+		t.Errorf("configuredMountRoot = %q,%v; want /tmp/claude,true", root, ok)
+	}
+
+	got := ExtraVolumePaths()
+	found := false
+	for _, p := range got {
+		if p == "/tmp/claude" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ExtraVolumePaths() = %v; want it to include /tmp/claude", got)
 	}
 }
 


### PR DESCRIPTION
Running lerd php from a directory the PHP container cannot reach, most often a scratch path under /tmp, passed the working directory straight to podman exec -w and let crun fail with an opaque chdir error. The shim now checks the directory is reachable first and refuses with a message that points at the fix, the same guard lerd new already applies before it scaffolds.

A file argument that lives outside the mounted paths was being rewritten to /dev/stdin, which only makes sense for the script PHP actually executes. A plain data-file argument turned into /dev/stdin too, so a script that checked it with is_file, or took more than one file, broke silently. Only the first script operand is eligible for streaming now, and a real path argument reaches the script unchanged.

A new mounts key in config.yaml lets a specific host path be bind-mounted into the PHP and nginx containers on top of the home and parked directories, overriding the denylist that keeps temporary system trees out by default. That gives agent workflows a way to opt a scratch root under /tmp into the containers without lerd mounting every random temp path, and a path it covers resolves both as a working directory and as a file argument.

Refs #949