### PR TITLE
feat(ui): group the services list by service type

### DIFF
--- a/docs/features/web-ui.md
+++ b/docs/features/web-ui.md
@@ -127,7 +127,7 @@ Selecting a site opens the detail panel with:
 
 ![Services tab](/assets/screenshots/services-list.png)
 
-The middle panel lists core infrastructure services (MySQL, Redis, PostgreSQL, Meilisearch, RustFS, Mailpit), any installed preset alternates (e.g. MySQL 5.7, MariaDB 11, MongoDB) and admin UIs (phpMyAdmin, pgAdmin, Mongo Express), plus grouped per-site workers (Queues, Horizon, Schedules, Workers, Stripe, Reverb).
+The middle panel lists core infrastructure services (MySQL, Redis, PostgreSQL, Meilisearch, RustFS, Mailpit), any installed preset alternates (e.g. MySQL 5.7, MariaDB 11, MongoDB) and admin UIs (phpMyAdmin, pgAdmin, Mongo Express), grouped by service type under labelled sections (Databases, Cache, Messaging, Search, Mail & PDF, Admin UIs, Storage, Testing) in the same order the discovery grid uses, plus grouped per-site workers (Queues, Horizon, Schedules, Workers, Stripe, Reverb) below them.
 
 The header has a **+** button that opens the **preset picker modal**: a one-click installer for the bundled service presets. A search box at the top filters the list by name, description, or image as you type. Multi-version presets like `mysql` and `mariadb` show a version dropdown next to the **Add** button. Already-installed entries are filtered out.
 

--- a/internal/ui/web/src/components/ListGroupHeader.svelte
+++ b/internal/ui/web/src/components/ListGroupHeader.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  // A section label inside a list panel. `divider` draws the top border that
+  // separates one group from the one above; the first group in a panel omits
+  // it so it doesn't double up with the panel header's bottom border.
+  let { label, divider = true }: { label: string; divider?: boolean } = $props();
+</script>
+
+<div
+  class="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 {divider
+    ? 'border-t border-gray-100 dark:border-lerd-border'
+    : ''}"
+>
+  {label}
+</div>

--- a/internal/ui/web/src/components/ListGroupHeader.test.ts
+++ b/internal/ui/web/src/components/ListGroupHeader.test.ts
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import ListGroupHeader from './ListGroupHeader.svelte';
+
+describe('ListGroupHeader', () => {
+  it('renders the label', () => {
+    const { getByText } = render(ListGroupHeader, { props: { label: 'Databases' } });
+    expect(getByText('Databases')).toBeTruthy();
+  });
+
+  it('draws the top divider by default', () => {
+    const { container } = render(ListGroupHeader, { props: { label: 'Cache' } });
+    expect(container.querySelector('div')!.className).toMatch(/border-t/);
+  });
+
+  it('omits the divider when divider=false', () => {
+    const { container } = render(ListGroupHeader, { props: { label: 'Cache', divider: false } });
+    expect(container.querySelector('div')!.className).not.toMatch(/border-t/);
+  });
+});

--- a/internal/ui/web/src/lib/presetCategories.test.ts
+++ b/internal/ui/web/src/lib/presetCategories.test.ts
@@ -46,7 +46,7 @@ describe('groupByCategory', () => {
       p('mailpit', 'mail')
     ]);
     expect(groups.map((g) => g.key)).toEqual(['databases', 'cache', 'mail']);
-    expect(groups[0].presets.map((x) => x.name)).toEqual(['mongo', 'mysql']);
+    expect(groups[0].items.map((x) => x.name)).toEqual(['mongo', 'mysql']);
   });
 
   it('sorts presets alphabetically within a category', () => {
@@ -55,7 +55,7 @@ describe('groupByCategory', () => {
       p('memcached', 'cache'),
       p('redis', 'cache')
     ]);
-    expect(groups[0].presets.map((x) => x.name)).toEqual(['memcached', 'redis', 'valkey']);
+    expect(groups[0].items.map((x) => x.name)).toEqual(['memcached', 'redis', 'valkey']);
   });
 
   it('keeps the global category order regardless of input order', () => {

--- a/internal/ui/web/src/lib/presetCategories.ts
+++ b/internal/ui/web/src/lib/presetCategories.ts
@@ -69,21 +69,27 @@ export function categoryOf(preset: Pick<Preset, 'category'>): CategoryKey {
   return asCategory(preset.category);
 }
 
-export interface CategoryGroup {
+export interface CategoryGroup<T = Preset> {
   key: CategoryKey;
-  presets: Preset[];
+  items: T[];
 }
 
-export function groupByCategory(presets: Preset[]): CategoryGroup[] {
-  const buckets = new Map<CategoryKey, Preset[]>();
-  for (const p of presets) {
-    const k = categoryOf(p);
+// Bucket anything carrying a name and a category (presets in the discovery
+// grid, installed services in the list) into the shared category taxonomy,
+// keeping only non-empty categories in CATEGORY_ORDER and sorting each bucket
+// by name.
+export function groupByCategory<T extends { name: string; category?: string }>(
+  items: T[]
+): CategoryGroup<T>[] {
+  const buckets = new Map<CategoryKey, T[]>();
+  for (const it of items) {
+    const k = asCategory(it.category);
     const arr = buckets.get(k) || [];
-    arr.push(p);
+    arr.push(it);
     buckets.set(k, arr);
   }
   return CATEGORY_ORDER.filter((k) => buckets.has(k)).map((k) => ({
     key: k,
-    presets: buckets.get(k)!.slice().sort((a, b) => a.name.localeCompare(b.name))
+    items: buckets.get(k)!.slice().sort((a, b) => a.name.localeCompare(b.name))
   }));
 }

--- a/internal/ui/web/src/stores/services.test.ts
+++ b/internal/ui/web/src/stores/services.test.ts
@@ -29,6 +29,36 @@ describe('services store', () => {
     expect(groups.find((g) => g.key === 'schedule')).toBeUndefined();
   });
 
+  it('groups core services by category in CATEGORY_ORDER, sorted by name', async () => {
+    const { services, coreServiceGroups } = await import('./services');
+    services.set([
+      { name: 'valkey', status: 'active', site_count: 0, category: 'cache' },
+      { name: 'mariadb', status: 'active', site_count: 0, category: 'databases' },
+      { name: 'memcached', status: 'active', site_count: 0, category: 'cache' },
+      { name: 'mailpit', status: 'active', site_count: 0, category: 'mail' }
+    ]);
+    const groups = get(coreServiceGroups);
+    expect(groups.map((g) => g.key)).toEqual(['databases', 'cache', 'mail']);
+    expect(groups[1].items.map((s) => s.name)).toEqual(['memcached', 'valkey']);
+  });
+
+  it('excludes worker-lens services from the category groups', async () => {
+    const { services, coreServiceGroups } = await import('./services');
+    services.set([
+      { name: 'mariadb', status: 'active', site_count: 0, category: 'databases' },
+      { name: 'queue-blog', status: 'active', site_count: 0, category: 'other', queue_site: 'blog' }
+    ]);
+    const groups = get(coreServiceGroups);
+    expect(groups.map((g) => g.key)).toEqual(['databases']);
+    expect(groups.flatMap((g) => g.items.map((s) => s.name))).toEqual(['mariadb']);
+  });
+
+  it('buckets a service with no category into other', async () => {
+    const { services, coreServiceGroups } = await import('./services');
+    services.set([{ name: 'mystery', status: 'active', site_count: 0 }]);
+    expect(get(coreServiceGroups).map((g) => g.key)).toEqual(['other']);
+  });
+
   it('applies ws service frames', async () => {
     const { wsMessage } = await import('$lib/ws');
     const { services, servicesLoaded } = await import('./services');

--- a/internal/ui/web/src/stores/services.ts
+++ b/internal/ui/web/src/stores/services.ts
@@ -2,6 +2,7 @@ import { writable, derived, get } from 'svelte/store';
 import { apiJson, apiFetch } from '$lib/api';
 import { wsMessage } from '$lib/ws';
 import { sites } from './sites';
+import { groupByCategory, type CategoryGroup } from '$lib/presetCategories';
 
 // One published port of a service: its container-internal port, its preset
 // default host port, and the current host override (0/undefined = on default).
@@ -139,6 +140,14 @@ function isWorker(s: Service): boolean {
 }
 
 export const coreServices = derived(services, ($s) => $s.filter((x) => !isWorker(x)));
+
+// The core services list bucketed by the service's category (databases, cache,
+// messaging…) so the middle panel shows one labelled section per type instead
+// of a flat list. Reuses the same taxonomy the discovery grid groups by.
+export const coreServiceGroups = derived(
+  coreServices,
+  ($core): CategoryGroup<Service>[] => groupByCategory($core)
+);
 
 export interface WorkerGroup {
   key: string;

--- a/internal/ui/web/src/tabs/ServicesTab.svelte
+++ b/internal/ui/web/src/tabs/ServicesTab.svelte
@@ -4,17 +4,19 @@
   import EmptyState from '$components/EmptyState.svelte';
   import Icon from '$components/Icon.svelte';
   import ListRow from '$components/ListRow.svelte';
+  import ListGroupHeader from '$components/ListGroupHeader.svelte';
   import StatusDot from '$components/StatusDot.svelte';
   import LoadingRow from '$components/LoadingRow.svelte';
   import { accessMode } from '$stores/accessMode';
   import { routeRest, goToTab } from '$stores/route';
   import {
-    coreServices,
+    coreServiceGroups,
     workerGroups,
     servicesLoaded,
     serviceLabel,
     workerSiteName
   } from '$stores/services';
+  import { CATEGORY_LABELS } from '$lib/presetCategories';
   import { openPresetModal } from '$stores/modals';
   import { m } from '../paraglide/messages.js';
 
@@ -46,72 +48,73 @@
 <ListPanel title={m.services_title()} {actions}>
   {#if !$servicesLoaded}
     <LoadingRow />
-  {:else if $coreServices.length === 0 && $workerGroups.length === 0}
+  {:else if $coreServiceGroups.length === 0 && $workerGroups.length === 0}
     <EmptyState title={m.services_empty()} size="sm" />
   {:else}
-    {#each $coreServices as svc (svc.name)}
-      {#snippet leading()}<StatusDot color={svc.status === 'active' ? 'green' : 'gray'} />{/snippet}
-      {#snippet trailing()}
-        {#if svc.status !== 'active' && svc.port_conflicts && svc.port_conflicts.length > 0}
-          <span
-            class="shrink-0 text-amber-500 dark:text-amber-400"
-            title={'Port ' + svc.port_conflicts.map((c) => c.port).join(', ') + ' already in use on the host. Start may fail until you stop the conflicting process.'}
-            aria-label={m.services_ariaPortConflict()}
-          >
-            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
-              <line x1="12" y1="9" x2="12" y2="13"/>
-              <line x1="12" y1="17" x2="12.01" y2="17"/>
-            </svg>
-          </span>
-        {/if}
-        {#if svc.depends_on && svc.depends_on.length > 0}
-          <span class="shrink-0 text-gray-300 dark:text-gray-600" title={m.services_hasDependencies()}>
-            <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/>
-              <path d="M8.59 13.51l6.83 3.98M15.41 6.51l-6.82 3.98"/>
-            </svg>
-          </span>
-        {/if}
-        {#if svc.client_shims && svc.client_shims.some((s) => s.enabled)}
-          <span
-            class="shrink-0 text-gray-400 dark:text-gray-500"
-            title={m.services_shimsInstalled() + ': ' + svc.client_shims.filter((s) => s.enabled).map((s) => s.tool).join(', ')}
-          >
-            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="4 17 10 11 4 5"/>
-              <line x1="12" y1="19" x2="20" y2="19"/>
-            </svg>
-          </span>
-        {/if}
-        {#if svc.site_count > 0}
-          <span class="text-[10px] font-medium tabular-nums shrink-0 {selected === svc.name ? 'text-lerd-red/70' : 'text-gray-400 dark:text-gray-600'}">{svc.site_count}</span>
-        {/if}
-      {/snippet}
-      <ListRow active={selected === svc.name} onclick={() => select(svc.name)} {leading} {trailing}>
-        {serviceLabel(svc.name)}
-        {#if svc.version}
-          <span class="ml-1 text-[10px] font-normal tabular-nums text-gray-400 dark:text-gray-500">{svc.version}</span>
-        {/if}
-        {#if svc.update_available}
-          <span
-            class="ml-1 text-[10px] font-medium text-emerald-600 dark:text-emerald-400"
-            title={svc.latest_version ? m.services_updateAvailableTo({ tag: svc.latest_version }) : m.services_updateAvailable()}
-          >↑</span>
-        {/if}
-      </ListRow>
+    {#each $coreServiceGroups as group, gi (group.key)}
+      <ListGroupHeader label={CATEGORY_LABELS[group.key]()} divider={gi > 0} />
+      {#each group.items as svc (svc.name)}
+        {#snippet leading()}<StatusDot color={svc.status === 'active' ? 'green' : 'gray'} />{/snippet}
+        {#snippet trailing()}
+          {#if svc.status !== 'active' && svc.port_conflicts && svc.port_conflicts.length > 0}
+            <span
+              class="shrink-0 text-amber-500 dark:text-amber-400"
+              title={'Port ' + svc.port_conflicts.map((c) => c.port).join(', ') + ' already in use on the host. Start may fail until you stop the conflicting process.'}
+              aria-label={m.services_ariaPortConflict()}
+            >
+              <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+                <line x1="12" y1="9" x2="12" y2="13"/>
+                <line x1="12" y1="17" x2="12.01" y2="17"/>
+              </svg>
+            </span>
+          {/if}
+          {#if svc.depends_on && svc.depends_on.length > 0}
+            <span class="shrink-0 text-gray-300 dark:text-gray-600" title={m.services_hasDependencies()}>
+              <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/>
+                <path d="M8.59 13.51l6.83 3.98M15.41 6.51l-6.82 3.98"/>
+              </svg>
+            </span>
+          {/if}
+          {#if svc.client_shims && svc.client_shims.some((s) => s.enabled)}
+            <span
+              class="shrink-0 text-gray-400 dark:text-gray-500"
+              title={m.services_shimsInstalled() + ': ' + svc.client_shims.filter((s) => s.enabled).map((s) => s.tool).join(', ')}
+            >
+              <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="4 17 10 11 4 5"/>
+                <line x1="12" y1="19" x2="20" y2="19"/>
+              </svg>
+            </span>
+          {/if}
+          {#if svc.site_count > 0}
+            <span class="text-[10px] font-medium tabular-nums shrink-0 {selected === svc.name ? 'text-lerd-red/70' : 'text-gray-400 dark:text-gray-600'}">{svc.site_count}</span>
+          {/if}
+        {/snippet}
+        <ListRow active={selected === svc.name} onclick={() => select(svc.name)} {leading} {trailing}>
+          {serviceLabel(svc.name)}
+          {#if svc.version}
+            <span class="ml-1 text-[10px] font-normal tabular-nums text-gray-400 dark:text-gray-500">{svc.version}</span>
+          {/if}
+          {#if svc.update_available}
+            <span
+              class="ml-1 text-[10px] font-medium text-emerald-600 dark:text-emerald-400"
+              title={svc.latest_version ? m.services_updateAvailableTo({ tag: svc.latest_version }) : m.services_updateAvailable()}
+            >↑</span>
+          {/if}
+        </ListRow>
+      {/each}
     {/each}
 
-    {#each $workerGroups as group (group.key)}
-      <div class="border-t border-gray-100 dark:border-lerd-border">
-        <div class="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">{groupLabel(group.key)}</div>
-        {#each group.items as svc (svc.name)}
-          {#snippet workerLeading()}<StatusDot color={svc.status === 'active' ? 'green' : 'gray'} size="xs" />{/snippet}
-          <ListRow active={selected === svc.name} onclick={() => select(svc.name)} leading={workerLeading}>
-            {workerSiteName(svc)}
-          </ListRow>
-        {/each}
-      </div>
+    {#each $workerGroups as group, wi (group.key)}
+      <ListGroupHeader label={groupLabel(group.key)} divider={wi > 0 || $coreServiceGroups.length > 0} />
+      {#each group.items as svc (svc.name)}
+        {#snippet workerLeading()}<StatusDot color={svc.status === 'active' ? 'green' : 'gray'} size="xs" />{/snippet}
+        <ListRow active={selected === svc.name} onclick={() => select(svc.name)} leading={workerLeading}>
+          {workerSiteName(svc)}
+        </ListRow>
+      {/each}
     {/each}
   {/if}
 </ListPanel>

--- a/internal/ui/web/src/tabs/services/ServicesDashboard.svelte
+++ b/internal/ui/web/src/tabs/services/ServicesDashboard.svelte
@@ -64,7 +64,7 @@
           <div class="space-y-4">
             {#each groups as group (group.key)}
               <DashboardSection label={CATEGORY_LABELS[group.key]()} sub>
-                {#each group.presets as preset (preset.name)}
+                {#each group.items as preset (preset.name)}
                   <PresetCard {preset} category={group.key} />
                 {/each}
               </DashboardSection>


### PR DESCRIPTION
The middle Services panel rendered every core service as one flat list, which grew long once a project pulled in databases, caches, search and mail presets side by side. It now buckets those services into labelled sections by their category, Databases, Cache, Messaging and the rest, in the same order the discovery grid already uses, with the per site worker groups still listed below them.

The grouping reuses the same category taxonomy the discovery grid buckets by, driven entirely by each service's category as resolved from its preset, so no service names are hardcoded. The section header the worker groups already drew is now a small shared component so both blocks render through it.

Closes #964