### PR TITLE
Follow live system light/dark changes in the auto theme

### DIFF
--- a/internal/ui/web/src/stores/theme.test.ts
+++ b/internal/ui/web/src/stores/theme.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Controllable matchMedia mock: setDark flips the preference and fires 'change'.
+function mockMatchMedia(initialDark: boolean) {
+  let dark = initialDark;
+  const listeners: Array<() => void> = [];
+  const mql = {
+    get matches() {
+      return dark;
+    },
+    addEventListener: (_: string, cb: () => void) => listeners.push(cb),
+    removeEventListener: () => {}
+  };
+  (window as unknown as { matchMedia: unknown }).matchMedia = vi.fn(() => mql);
+  return {
+    setDark(v: boolean) {
+      dark = v;
+      listeners.forEach((cb) => cb());
+    }
+  };
+}
+
+describe('theme store', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+    vi.resetModules();
+  });
+
+  it('auto follows a live system light/dark change', async () => {
+    const media = mockMatchMedia(false);
+    localStorage.setItem('lerd-theme', 'auto');
+    const { initTheme } = await import('./theme');
+    initTheme();
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+    media.setDark(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    media.setDark(false);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('explicit dark ignores the system preference', async () => {
+    const media = mockMatchMedia(false);
+    localStorage.setItem('lerd-theme', 'dark');
+    const { initTheme } = await import('./theme');
+    initTheme();
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    media.setDark(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});

--- a/internal/ui/web/src/stores/theme.ts
+++ b/internal/ui/web/src/stores/theme.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 
 export type Theme = 'light' | 'dark' | 'auto';
 
@@ -25,7 +25,10 @@ export function initTheme() {
     localStorage.setItem(KEY, t);
     apply(t);
   });
+  // On a system light/dark change, re-apply the current theme so 'auto' follows
+  // live. Re-applying directly (not theme.update) because setting the store to
+  // its current value is a no-op that never notifies subscribers.
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-    theme.update((t) => t);
+    apply(get(theme));
   });
 }


### PR DESCRIPTION
The dashboard's auto theme only picked up a desktop light and dark switch on a full reload. The prefers-color-scheme change listener re-set the theme store to its current value, which Svelte treats as a no-op and never notifies subscribers, so the step that toggles the dark class never ran. It now re-applies the current theme directly on the media change, so auto follows the desktop live, in the browser and in the desktop app.

Refs #971
