### PR TITLE
Upgrade phpantom_lsp to 0.9.0 with semantic highlighting in tinker

### DIFF
--- a/docs/features/tinker.md
+++ b/docs/features/tinker.md
@@ -75,6 +75,8 @@ Because it analyzes the real project, completions are genuinely project-aware: y
 
 Quick fixes and imports are wired in too: the "Class not found" diagnostic offers an **Import `App\Models\X`** action, and accepting a class from the completion list brings its `use` statement along. Imports land at the top of the buffer with a blank line separating them from your code. Document formatting runs through phpantom on `Shift+Alt+F` and automatically on paste.
 
+Highlighting is semantic, not just grammar-based: the editor colours each token from what phpantom actually resolved it to, so a real method reads differently from an unresolved one and framework magic (facades, Eloquent properties) is coloured like the real symbol it maps to. Monaco falls back to its plain PHP grammar when the server is unavailable.
+
 The browser connects to the server over a WebSocket (`/api/lsp/php`). `lerd-ui` spawns one `phpantom_lsp` process per connection, rooted at the site (or worktree) path, and bridges its stdio LSP traffic to Monaco. Tinker buffers are headerless PHP, so the bridge presents the document to the server with a synthetic leading `<?php` line (and offsets positions accordingly) — you keep typing bare snippets while the server still parses valid PHP.
 
 A small status hint sits in the toolbar while the server is starting, and switches to "Language server unavailable" if it can't be reached. When that happens (offline first-run download, unsupported platform) the editor still works and code still runs — only the live intelligence is missing.

--- a/internal/phpantom/phpantom.go
+++ b/internal/phpantom/phpantom.go
@@ -27,7 +27,7 @@ import (
 
 // Version pins the phpantom_lsp release lerd installs. Bump alongside a
 // tested upgrade; the binary is re-fetched when the on-disk copy is missing.
-const Version = "0.8.0"
+const Version = "0.9.0"
 
 const binName = "phpantom_lsp"
 

--- a/internal/ui/web/src/lib/lsp.test.ts
+++ b/internal/ui/web/src/lib/lsp.test.ts
@@ -3,7 +3,8 @@ import {
   lspWorkspaceEditToMonaco,
   isBlankCompletionPrefix,
   stripSyntheticHeader,
-  withImportBlankLine
+  withImportBlankLine,
+  lspSemanticTokensToMonaco
 } from '$lib/lsp';
 
 // Mirrors the production fromLspRange: LSP 0-based -> Monaco 1-based, line 0
@@ -128,5 +129,48 @@ describe('stripSyntheticHeader', () => {
 
   it('leaves headerless text untouched', () => {
     expect(stripSyntheticHeader('$x = 1;\n')).toBe('$x = 1;\n');
+  });
+});
+
+describe('lspSemanticTokensToMonaco', () => {
+  // Decode a Monaco token stream back to absolute [line, char, len, type, mods]
+  // tuples so assertions read in editor coordinates, not deltas.
+  const decode = (data: Uint32Array) => {
+    const out: number[][] = [];
+    let line = 0, char = 0;
+    for (let i = 0; i + 4 < data.length; i += 5) {
+      if (data[i] === 0) char += data[i + 1];
+      else { line += data[i]; char = data[i + 1]; }
+      out.push([line, char, data[i + 2], data[i + 3], data[i + 4]]);
+    }
+    return out;
+  };
+
+  it('returns an empty array for missing or short data', () => {
+    expect(lspSemanticTokensToMonaco(undefined)).toEqual(new Uint32Array(0));
+    expect(lspSemanticTokensToMonaco([])).toEqual(new Uint32Array(0));
+    expect(lspSemanticTokensToMonaco([0, 1, 2, 3])).toEqual(new Uint32Array(0));
+  });
+
+  it('shifts every token up one line out of synthetic-header space', () => {
+    // One token on LSP line 1 (the user's first line), char 4, len 3.
+    const out = lspSemanticTokensToMonaco([1, 4, 3, 8, 0]);
+    expect(decode(out)).toEqual([[0, 4, 3, 8, 0]]);
+  });
+
+  it('drops tokens the server pins to the synthetic <?php line (LSP line 0)', () => {
+    // First token on line 0 (synthetic), second on line 2 at char 6.
+    const out = lspSemanticTokensToMonaco([0, 0, 5, 15, 0, 2, 6, 3, 8, 0]);
+    expect(decode(out)).toEqual([[1, 6, 3, 8, 0]]);
+  });
+
+  it('preserves same-line char deltas and re-bases across lines', () => {
+    // LSP: line 1 char 0 (len 3), line 1 char 8 (len 4), line 3 char 2 (len 5).
+    const out = lspSemanticTokensToMonaco([1, 0, 3, 8, 0, 0, 8, 4, 8, 0, 2, 2, 5, 8, 0]);
+    expect(decode(out)).toEqual([
+      [0, 0, 3, 8, 0],
+      [0, 8, 4, 8, 0],
+      [2, 2, 5, 8, 0]
+    ]);
   });
 });

--- a/internal/ui/web/src/lib/lsp.ts
+++ b/internal/ui/web/src/lib/lsp.ts
@@ -27,6 +27,21 @@ const LSP_COMPLETION_KIND = [
   'Constant', 'Struct', 'Event', 'Operator', 'TypeParameter'
 ] as const;
 
+// The standard LSP 3.16 semantic token legend we advertise. phpantom returns
+// its own legend in the initialize response, which we forward to Monaco
+// verbatim; these just declare which types/modifiers we understand so the
+// server doesn't withhold tokens.
+const SEMANTIC_TOKEN_TYPES = [
+  'namespace', 'type', 'class', 'enum', 'interface', 'struct', 'typeParameter',
+  'parameter', 'variable', 'property', 'enumMember', 'event', 'function',
+  'method', 'macro', 'keyword', 'modifier', 'comment', 'string', 'number',
+  'regexp', 'operator', 'decorator'
+];
+const SEMANTIC_TOKEN_MODIFIERS = [
+  'declaration', 'definition', 'readonly', 'static', 'deprecated', 'abstract',
+  'async', 'modification', 'documentation', 'defaultLibrary'
+];
+
 export interface PhpLspHandle {
   dispose(): void;
 }
@@ -102,6 +117,31 @@ export function stripSyntheticHeader(text: string): string {
   if (lines.length && lines[0].trim() === '<?php') lines.shift();
   if (lines.length && lines[0].trim() === '') lines.shift();
   return lines.join('\n');
+}
+
+// Re-base an LSP semantic-token stream into the headerless tinker buffer.
+// The data is a flat run of 5-tuples [deltaLine, deltaStartChar, length,
+// tokenType, tokenModifiers], delta-encoded against the previous token with
+// the first relative to line 0. Our document carries a synthetic `<?php` on
+// LSP line 0, so every token sits one line below where Monaco should paint it:
+// we decode to absolute positions, drop anything on the synthetic header line,
+// shift the rest up one line, and re-encode the deltas Monaco expects.
+export function lspSemanticTokensToMonaco(data: readonly number[] | undefined): Uint32Array {
+  if (!data || data.length < 5) return new Uint32Array(0);
+  const out: number[] = [];
+  let absLine = 0, absChar = 0;
+  let lastLine = 0, lastChar = 0;
+  for (let i = 0; i + 4 < data.length; i += 5) {
+    if (data[i] === 0) absChar += data[i + 1];
+    else { absLine += data[i]; absChar = data[i + 1]; }
+    if (absLine < 1) continue; // synthetic <?php header (LSP line 0)
+    const line = absLine - 1;
+    const deltaLine = line - lastLine;
+    out.push(deltaLine, deltaLine === 0 ? absChar - lastChar : absChar, data[i + 2], data[i + 3], data[i + 4]);
+    lastLine = line;
+    lastChar = absChar;
+  }
+  return new Uint32Array(out);
 }
 
 interface Pending {
@@ -507,9 +547,43 @@ export function attachPhpLsp(opts: {
       }
     })
   );
-  // Format-on-paste leans on the range provider above. Scoped to this editor,
-  // which is only ever the tinker surface.
-  editor.updateOptions({ formatOnPaste: true });
+  // Format-on-paste leans on the range provider above; semantic highlighting
+  // turns on the project-aware colouring our token provider feeds. Both are
+  // scoped to this editor, which is only ever the tinker surface.
+  editor.updateOptions({ formatOnPaste: true, 'semanticHighlighting.enabled': true });
+
+  // ---- semantic highlighting ----
+  // Registered only after initialize, once we have the server's token legend.
+  // Monaco re-requests on every model change; each response is re-based out of
+  // synthetic-header space before Monaco paints it.
+  function registerSemanticTokens(provider: any) {
+    const legend = provider && typeof provider === 'object' ? provider.legend : undefined;
+    const supportsFull =
+      provider && (provider.full === true || (provider.full && typeof provider.full === 'object'));
+    if (disposed || !legend?.tokenTypes || !supportsFull) return;
+    disposables.push(
+      monaco.languages.registerDocumentSemanticTokensProvider('php', {
+        getLegend: () => ({
+          tokenTypes: legend.tokenTypes,
+          tokenModifiers: legend.tokenModifiers ?? []
+        }),
+        async provideDocumentSemanticTokens(model) {
+          if (!isOurModel(model)) return null;
+          let res: any;
+          try {
+            res = await request('textDocument/semanticTokens/full', {
+              textDocument: { uri: documentUri }
+            });
+          } catch {
+            return null;
+          }
+          if (!res?.data) return null;
+          return { data: lspSemanticTokensToMonaco(res.data), resultId: res.resultId };
+        },
+        releaseDocumentSemanticTokens() {}
+      })
+    );
+  }
 
   // ---- handshake + initialize ----
   void (async () => {
@@ -517,8 +591,9 @@ export function attachPhpLsp(opts: {
     if (disposed) return;
     const rootUri = 'file://' + root.split('/').map(encodeURIComponent).join('/');
     documentUri = `${rootUri}/.lerd-tinker.php`;
+    let initResult: any;
     try {
-      await request('initialize', {
+      initResult = await request('initialize', {
         processId: null,
         rootUri,
         workspaceFolders: [{ uri: rootUri, name: 'tinker' }],
@@ -539,6 +614,13 @@ export function attachPhpLsp(opts: {
               resolveSupport: { properties: ['edit'] }
             },
             formatting: { dynamicRegistration: false },
+            semanticTokens: {
+              dynamicRegistration: false,
+              requests: { full: true },
+              tokenTypes: SEMANTIC_TOKEN_TYPES,
+              tokenModifiers: SEMANTIC_TOKEN_MODIFIERS,
+              formats: ['relative']
+            },
             publishDiagnostics: {}
           }
         }
@@ -548,6 +630,7 @@ export function attachPhpLsp(opts: {
       return;
     }
     if (disposed) return;
+    registerSemanticTokens(initResult?.capabilities?.semanticTokensProvider);
     notify('initialized', {});
     notify('textDocument/didOpen', {
       textDocument: { uri: documentUri, languageId: 'php', version: docVersion, text: fullText() }


### PR DESCRIPTION
phpantom_lsp 0.9.0 brings a big batch of language server improvements to the tinker editor, and almost all of it arrives just by moving the pinned binary forward, tighter type checking, far better Laravel resolution for Eloquent builders, relations, macros and facades, new refactorings in the lightbulb, smarter completion ranking, and mago.toml aware formatting. The asset names are unchanged so the download path still resolves, and the binary re-fetches on the next tinker connect.

The one genuinely new client capability is semantic highlighting. 0.9.0 advertises a semantic tokens provider, so the editor now colours each token from what phpantom resolved it to instead of from the static PHP grammar. A resolved method looks different from an unresolved one, and framework magic like facades and Eloquent properties is coloured like the real symbol behind it. The server sees the tinker buffer with a synthetic leading php tag, so its tokens sit one line below where Monaco paints, we re-base the delta encoded stream out of that synthetic line space before handing it over. It only turns on when the server actually offers a legend and full document support, and falls back to the plain grammar when the language server is unavailable.

Closes #973