### PR TITLE
feat(install): unattended setup for package-manager installs

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -96,6 +96,7 @@ func main() {
 
 	// Register all subcommands
 	root.AddCommand(cli.NewInstallCmd())
+	root.AddCommand(cli.NewBootstrapCmd())
 	root.AddCommand(cli.NewStartCmd())
 	root.AddCommand(cli.NewStopCmd())
 	root.AddCommand(cli.NewQuitCmd())

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -72,6 +72,28 @@ bash install.sh --local ./build/lerd
 
 ---
 
+### Install via apt (Ubuntu/Debian)
+
+Lerd is published to a Launchpad PPA, so you can install and update it with your package manager:
+
+```bash
+sudo add-apt-repository ppa:lerd/lerd
+sudo apt update
+sudo apt install lerd
+```
+
+The package installs the binary to `/usr/bin/lerd` and finishes setup automatically: its maintainer script enables the unprivileged-port sysctl and systemd linger, then runs `lerd install` for your user, so the stack comes up straight away and again at every boot. `.test` DNS and HTTPS are configured with no prompt because the package sets up the sudoers rule and trusts the mkcert CA as root.
+
+Updates come through apt like any other package:
+
+```bash
+sudo apt upgrade
+```
+
+An apt-installed lerd lives under `/usr`, so `lerd update` (which self-replaces a `~/.local/bin` install) detects it and defers to `sudo apt upgrade` instead of fighting the package manager.
+
+---
+
 ### Update
 
 ```bash

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -90,7 +90,9 @@ Updates come through apt like any other package:
 sudo apt upgrade
 ```
 
-An apt-installed lerd lives under `/usr`, so `lerd update` (which self-replaces a `~/.local/bin` install) detects it and defers to `sudo apt upgrade` instead of fighting the package manager.
+A package-installed lerd lives under `/usr`, so `lerd update` (which self-replaces a `~/.local/bin` install) detects it and defers to your package manager instead of fighting it.
+
+The setup steps behind the package are not Debian-specific: `lerd bootstrap` recognises the Debian, Fedora, Arch and openSUSE trust store layouts and picks whichever the system uses, so the same flow will serve future rpm and AUR packages. On distros with no writable system trust store (NixOS), it prints where the CA lives so you can trust it declaratively.
 
 ---
 

--- a/internal/certs/system_trust_linux.go
+++ b/internal/certs/system_trust_linux.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package certs
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// systemStoreCAFile is where the mkcert root CA is dropped for the system trust
+// store; update-ca-certificates picks up .crt files under this directory. A var
+// so tests can point it at a temp path.
+var systemStoreCAFile = "/usr/local/share/ca-certificates/lerd-mkcert-rootCA.crt"
+
+// updateSystemTrust refreshes the aggregated trust bundle. A var so tests can
+// stub out the real command.
+var updateSystemTrust = func() error {
+	return exec.Command("update-ca-certificates").Run()
+}
+
+// TrustCAInSystemStore installs the given mkcert root CA PEM into the system
+// trust store. The caller must be root. Idempotent: a byte-identical CA already
+// in place is a no-op, so re-running on every package upgrade is cheap.
+//
+// mkcert normally does this itself via an interactive sudo, which a package
+// maintainer script cannot answer. `lerd bootstrap --trust-ca` runs as root and
+// installs the user-generated CA directly instead.
+func TrustCAInSystemStore(caPEM []byte) error {
+	if existing, err := os.ReadFile(systemStoreCAFile); err == nil && bytes.Equal(existing, caPEM) {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(systemStoreCAFile), 0755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(systemStoreCAFile, caPEM, 0644); err != nil {
+		return err
+	}
+	return updateSystemTrust()
+}

--- a/internal/certs/system_trust_linux.go
+++ b/internal/certs/system_trust_linux.go
@@ -4,38 +4,61 @@ package certs
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 )
 
-// systemStoreCAFile is where the mkcert root CA is dropped for the system trust
-// store; update-ca-certificates picks up .crt files under this directory. A var
-// so tests can point it at a temp path.
-var systemStoreCAFile = "/usr/local/share/ca-certificates/lerd-mkcert-rootCA.crt"
+// ErrNoSystemTrustStore reports that no known CA anchor directory exists on
+// this system, as on NixOS and other distros where trust is declarative.
+var ErrNoSystemTrustStore = errors.New("no system CA trust store found")
+
+// systemTrustStore is one distro family's CA anchor directory and the command
+// that rebuilds the aggregated trust bundle from it.
+type systemTrustStore struct {
+	dir      string
+	filename string
+	command  []string
+}
+
+// systemTrustStores lists the anchor layouts mkcert recognises, in the same
+// order; the first whose directory exists wins. A var so tests can substitute
+// temp paths.
+var systemTrustStores = []systemTrustStore{
+	{"/etc/pki/ca-trust/source/anchors", "lerd-mkcert-rootCA.pem", []string{"update-ca-trust", "extract"}},       // Fedora/RHEL
+	{"/usr/local/share/ca-certificates", "lerd-mkcert-rootCA.crt", []string{"update-ca-certificates"}},           // Debian/Ubuntu
+	{"/etc/ca-certificates/trust-source/anchors", "lerd-mkcert-rootCA.crt", []string{"trust", "extract-compat"}}, // Arch
+	{"/usr/share/pki/trust/anchors", "lerd-mkcert-rootCA.crt", []string{"update-ca-certificates"}},               // openSUSE
+}
 
 // updateSystemTrust refreshes the aggregated trust bundle. A var so tests can
 // stub out the real command.
-var updateSystemTrust = func() error {
-	return exec.Command("update-ca-certificates").Run()
+var updateSystemTrust = func(command []string) error {
+	return exec.Command(command[0], command[1:]...).Run()
 }
 
-// TrustCAInSystemStore installs the given mkcert root CA PEM into the system
-// trust store. The caller must be root. Idempotent: a byte-identical CA already
-// in place is a no-op, so re-running on every package upgrade is cheap.
+// TrustCAInSystemStore installs the given mkcert root CA PEM into whichever
+// system trust store this distro uses. The caller must be root. Idempotent: a
+// byte-identical CA already in place is a no-op, so re-running on every package
+// upgrade is cheap.
 //
 // mkcert normally does this itself via an interactive sudo, which a package
 // maintainer script cannot answer. `lerd bootstrap --trust-ca` runs as root and
 // installs the user-generated CA directly instead.
 func TrustCAInSystemStore(caPEM []byte) error {
-	if existing, err := os.ReadFile(systemStoreCAFile); err == nil && bytes.Equal(existing, caPEM) {
-		return nil
+	for _, store := range systemTrustStores {
+		if info, err := os.Stat(store.dir); err != nil || !info.IsDir() {
+			continue
+		}
+		caFile := filepath.Join(store.dir, store.filename)
+		if existing, err := os.ReadFile(caFile); err == nil && bytes.Equal(existing, caPEM) {
+			return nil
+		}
+		if err := os.WriteFile(caFile, caPEM, 0644); err != nil {
+			return err
+		}
+		return updateSystemTrust(store.command)
 	}
-	if err := os.MkdirAll(filepath.Dir(systemStoreCAFile), 0755); err != nil {
-		return err
-	}
-	if err := os.WriteFile(systemStoreCAFile, caPEM, 0644); err != nil {
-		return err
-	}
-	return updateSystemTrust()
+	return ErrNoSystemTrustStore
 }

--- a/internal/certs/system_trust_linux_test.go
+++ b/internal/certs/system_trust_linux_test.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package certs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTrustCAInSystemStore(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lerd-mkcert-rootCA.crt")
+
+	origPath, origUpdate := systemStoreCAFile, updateSystemTrust
+	t.Cleanup(func() { systemStoreCAFile, updateSystemTrust = origPath, origUpdate })
+	systemStoreCAFile = path
+
+	var updates int
+	updateSystemTrust = func() error { updates++; return nil }
+
+	ca := []byte("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n")
+	if err := TrustCAInSystemStore(ca); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != string(ca) {
+		t.Fatalf("CA not written: got %q err %v", got, err)
+	}
+	if updates != 1 {
+		t.Errorf("update-ca-certificates called %d times, want 1", updates)
+	}
+
+	// Idempotent: same CA already in place must not rewrite or re-run update.
+	if err := TrustCAInSystemStore(ca); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if updates != 1 {
+		t.Errorf("idempotent install re-ran update (%d times)", updates)
+	}
+}

--- a/internal/certs/system_trust_linux_test.go
+++ b/internal/certs/system_trust_linux_test.go
@@ -3,39 +3,72 @@
 package certs
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
+func stubTrustStores(t *testing.T, stores []systemTrustStore) *[][]string {
+	t.Helper()
+	origStores, origUpdate := systemTrustStores, updateSystemTrust
+	t.Cleanup(func() { systemTrustStores, updateSystemTrust = origStores, origUpdate })
+	systemTrustStores = stores
+
+	var commands [][]string
+	updateSystemTrust = func(command []string) error {
+		commands = append(commands, command)
+		return nil
+	}
+	return &commands
+}
+
 func TestTrustCAInSystemStore(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "lerd-mkcert-rootCA.crt")
-
-	origPath, origUpdate := systemStoreCAFile, updateSystemTrust
-	t.Cleanup(func() { systemStoreCAFile, updateSystemTrust = origPath, origUpdate })
-	systemStoreCAFile = path
-
-	var updates int
-	updateSystemTrust = func() error { updates++; return nil }
+	present := filepath.Join(dir, "anchors")
+	if err := os.MkdirAll(present, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// The first candidate's directory does not exist, so detection must fall
+	// through to the second.
+	commands := stubTrustStores(t, []systemTrustStore{
+		{filepath.Join(dir, "missing"), "lerd-mkcert-rootCA.pem", []string{"update-ca-trust", "extract"}},
+		{present, "lerd-mkcert-rootCA.crt", []string{"update-ca-certificates"}},
+	})
 
 	ca := []byte("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n")
 	if err := TrustCAInSystemStore(ca); err != nil {
 		t.Fatalf("first install: %v", err)
 	}
-	got, err := os.ReadFile(path)
+	got, err := os.ReadFile(filepath.Join(present, "lerd-mkcert-rootCA.crt"))
 	if err != nil || string(got) != string(ca) {
 		t.Fatalf("CA not written: got %q err %v", got, err)
 	}
-	if updates != 1 {
-		t.Errorf("update-ca-certificates called %d times, want 1", updates)
+	if len(*commands) != 1 || (*commands)[0][0] != "update-ca-certificates" {
+		t.Errorf("trust command runs = %v, want one update-ca-certificates", *commands)
 	}
 
 	// Idempotent: same CA already in place must not rewrite or re-run update.
 	if err := TrustCAInSystemStore(ca); err != nil {
 		t.Fatalf("second install: %v", err)
 	}
-	if updates != 1 {
-		t.Errorf("idempotent install re-ran update (%d times)", updates)
+	if len(*commands) != 1 {
+		t.Errorf("idempotent install re-ran the trust command (%d runs)", len(*commands))
+	}
+}
+
+func TestTrustCAInSystemStoreNoStore(t *testing.T) {
+	dir := t.TempDir()
+	commands := stubTrustStores(t, []systemTrustStore{
+		{filepath.Join(dir, "missing-a"), "a.pem", []string{"update-ca-trust", "extract"}},
+		{filepath.Join(dir, "missing-b"), "b.crt", []string{"update-ca-certificates"}},
+	})
+
+	err := TrustCAInSystemStore([]byte("ca"))
+	if !errors.Is(err, ErrNoSystemTrustStore) {
+		t.Fatalf("err = %v, want ErrNoSystemTrustStore", err)
+	}
+	if len(*commands) != 0 {
+		t.Errorf("trust command ran with no store present: %v", *commands)
 	}
 }

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+// The machine-global, user-independent steps that `lerd install` would
+// otherwise perform through interactive sudo. A package maintainer script runs
+// as root but cannot prompt, so it calls `lerd bootstrap --system` for the
+// prerequisites and `lerd bootstrap --trust-ca` after the per-user install, so
+// `lerd install --unattended` in between needs no sudo. See lerd-env/lerd#979.
+const (
+	unprivPortDropIn  = "/etc/sysctl.d/99-lerd-ports.conf"
+	unprivPortSetting = "net.ipv4.ip_unprivileged_port_start=80"
+)
+
+// cmdRunner runs an external command. A seam so the bootstrap steps can be
+// tested without touching the real system.
+type cmdRunner func(name string, args ...string) error
+
+func execRunner(name string, args ...string) error {
+	c := exec.Command(name, args...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}
+
+// writePortDropIn lets rootless Podman bind 80/443 by lowering
+// ip_unprivileged_port_start, both live (sysctl -w) and persistently (a
+// sysctl.d drop-in). Idempotent.
+func writePortDropIn(path string, run cmdRunner) error {
+	if err := os.WriteFile(path, []byte(unprivPortSetting+"\n"), 0644); err != nil {
+		return err
+	}
+	return run("sysctl", "-w", unprivPortSetting)
+}
+
+// enableLinger keeps the user's rootless containers alive across screen blank,
+// lock, and logout. A blank user is a no-op.
+func enableLinger(user string, run cmdRunner) error {
+	if user == "" {
+		return nil
+	}
+	return run("loginctl", "enable-linger", user)
+}
+
+// bootstrapTargetUser resolves whose session the per-user half of setup belongs
+// to. An explicit --user wins; otherwise SUDO_USER (the human who invoked the
+// package manager) is preferred over the ambient USER, and a root SUDO_USER is
+// ignored since it carries no per-user meaning.
+func bootstrapTargetUser(flagUser string) string {
+	if flagUser != "" {
+		return flagUser
+	}
+	if u := os.Getenv("SUDO_USER"); u != "" && u != "root" {
+		return u
+	}
+	if u := os.Getenv("USER"); u != "" {
+		return u
+	}
+	return os.Getenv("LOGNAME")
+}
+
+// NewBootstrapCmd returns the bootstrap command. It performs the root-level,
+// non-interactive halves of setup so a deb/rpm postinst can finish the install
+// without prompting, pairing with `lerd install --unattended`.
+func NewBootstrapCmd() *cobra.Command {
+	var system, trustCA bool
+	var user string
+	cmd := &cobra.Command{
+		Use:   "bootstrap",
+		Short: "Apply the root-level system setup (for package maintainer scripts)",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if !system && !trustCA {
+				return fmt.Errorf("nothing to do: pass --system or --trust-ca")
+			}
+			if os.Geteuid() != 0 {
+				return fmt.Errorf("lerd bootstrap configures system-level settings and must run as root")
+			}
+			target := bootstrapTargetUser(user)
+			if trustCA {
+				return runBootstrapTrustCA(target)
+			}
+			return runBootstrapSystem(target)
+		},
+	}
+	cmd.Flags().BoolVar(&system, "system", false, "Apply root-level setup: unprivileged ports, linger, DNS sudoers")
+	cmd.Flags().BoolVar(&trustCA, "trust-ca", false, "Trust the user's mkcert CA in the system store (run after install)")
+	cmd.Flags().StringVar(&user, "user", "", "Target user for per-user settings (defaults to SUDO_USER)")
+	return cmd
+}

--- a/internal/cli/bootstrap_linux.go
+++ b/internal/cli/bootstrap_linux.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"github.com/geodro/lerd/internal/certs"
+	"github.com/geodro/lerd/internal/dns"
+	"github.com/geodro/lerd/internal/feedback"
+)
+
+// runBootstrapSystem performs the root prerequisites a later unattended install
+// relies on: the unprivileged-port sysctl, systemd linger, and the DNS sudoers
+// rule that lets the install configure the resolver without prompting.
+func runBootstrapSystem(target string) error {
+	feedback.Header("Bootstrapping system for lerd")
+
+	if err := writePortDropIn(unprivPortDropIn, execRunner); err != nil {
+		feedback.Warn("enabling unprivileged ports: %v", err)
+	} else {
+		feedback.Done("unprivileged ports enabled for 80/443")
+	}
+
+	if target == "" {
+		return nil
+	}
+	if err := enableLinger(target, execRunner); err != nil {
+		feedback.Warn("enabling linger for %s: %v", target, err)
+	} else {
+		feedback.Done("systemd linger enabled for " + target)
+	}
+	if err := dns.WriteSudoersForUser(target); err != nil {
+		feedback.Warn("installing DNS sudoers rule: %v", err)
+	} else {
+		feedback.Done("DNS sudoers rule installed for " + target)
+	}
+	return nil
+}
+
+// runBootstrapTrustCA installs the user-generated mkcert root CA into the system
+// trust store, the one managed-DNS step the per-user install cannot do without
+// an interactive sudo. Run after `lerd install --unattended` has generated the
+// CA. A missing CA is not an error (localhost-mode installs have none).
+func runBootstrapTrustCA(target string) error {
+	if target == "" {
+		return fmt.Errorf("--trust-ca needs a target user (pass --user)")
+	}
+	u, err := user.Lookup(target)
+	if err != nil {
+		return fmt.Errorf("looking up user %s: %w", target, err)
+	}
+	caPath := filepath.Join(u.HomeDir, ".local", "share", "mkcert", "rootCA.pem")
+	pem, err := os.ReadFile(caPath)
+	if err != nil {
+		feedback.Note("no mkcert CA at " + caPath + " yet, skipping system trust")
+		return nil
+	}
+	if err := certs.TrustCAInSystemStore(pem); err != nil {
+		return fmt.Errorf("trusting CA in system store: %w", err)
+	}
+	feedback.Done("mkcert CA trusted in the system store")
+	return nil
+}

--- a/internal/cli/bootstrap_linux.go
+++ b/internal/cli/bootstrap_linux.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -60,6 +61,10 @@ func runBootstrapTrustCA(target string) error {
 		return nil
 	}
 	if err := certs.TrustCAInSystemStore(pem); err != nil {
+		if errors.Is(err, certs.ErrNoSystemTrustStore) {
+			feedback.Note("no system CA trust store on this distro; trust " + caPath + " through your system configuration (NixOS: security.pki.certificateFiles)")
+			return nil
+		}
 		return fmt.Errorf("trusting CA in system store: %w", err)
 	}
 	feedback.Done("mkcert CA trusted in the system store")

--- a/internal/cli/bootstrap_other.go
+++ b/internal/cli/bootstrap_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package cli
+
+import "fmt"
+
+func runBootstrapSystem(string) error {
+	return fmt.Errorf("lerd bootstrap is only supported on Linux")
+}
+
+func runBootstrapTrustCA(string) error {
+	return fmt.Errorf("lerd bootstrap is only supported on Linux")
+}

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWritePortDropIn(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "99-lerd-ports.conf")
+
+	var gotName string
+	var gotArgs []string
+	run := func(name string, args ...string) error {
+		gotName = name
+		gotArgs = args
+		return nil
+	}
+
+	if err := writePortDropIn(path, run); err != nil {
+		t.Fatalf("writePortDropIn: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("drop-in not written: %v", err)
+	}
+	if string(data) != unprivPortSetting+"\n" {
+		t.Errorf("drop-in content = %q, want %q", string(data), unprivPortSetting+"\n")
+	}
+	if gotName != "sysctl" || len(gotArgs) != 2 || gotArgs[0] != "-w" || gotArgs[1] != unprivPortSetting {
+		t.Errorf("runner called with %q %v, want sysctl -w %s", gotName, gotArgs, unprivPortSetting)
+	}
+}
+
+func TestEnableLinger(t *testing.T) {
+	var gotArgs []string
+	run := func(_ string, args ...string) error {
+		gotArgs = args
+		return nil
+	}
+
+	// A blank user is a no-op: nothing to enable, no runner call.
+	if err := enableLinger("", run); err != nil {
+		t.Fatalf("enableLinger blank: %v", err)
+	}
+	if gotArgs != nil {
+		t.Errorf("blank user still called runner: %v", gotArgs)
+	}
+
+	if err := enableLinger("george", run); err != nil {
+		t.Fatalf("enableLinger: %v", err)
+	}
+	if len(gotArgs) != 2 || gotArgs[0] != "enable-linger" || gotArgs[1] != "george" {
+		t.Errorf("runner args = %v, want enable-linger george", gotArgs)
+	}
+}
+
+func TestBootstrapTargetUser(t *testing.T) {
+	t.Setenv("SUDO_USER", "sudoer")
+	t.Setenv("USER", "current")
+
+	if got := bootstrapTargetUser("explicit"); got != "explicit" {
+		t.Errorf("flag user ignored: got %q", got)
+	}
+	if got := bootstrapTargetUser(""); got != "sudoer" {
+		t.Errorf("SUDO_USER not preferred: got %q", got)
+	}
+
+	// root as SUDO_USER is meaningless (it means apt was run by root directly),
+	// so fall back to USER.
+	t.Setenv("SUDO_USER", "root")
+	if got := bootstrapTargetUser(""); got != "current" {
+		t.Errorf("root SUDO_USER not skipped: got %q", got)
+	}
+}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -66,6 +66,8 @@ func NewInstallCmd() *cobra.Command {
 		"Preselect the DNS mode and skip the prompt: 'managed' (.test + HTTPS) or 'localhost' (.localhost, plain HTTP)")
 	cmd.Flags().Bool("from-update", false, "")
 	_ = cmd.Flags().MarkHidden("from-update")
+	cmd.Flags().Bool("unattended", false,
+		"Run non-interactively for package installs: no prompts, and skip the sudo-gated system steps that `lerd bootstrap` handles")
 	return cmd
 }
 
@@ -140,6 +142,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		noIPv6 = true
 	}
 	fromUpdate, _ := cmd.Flags().GetBool("from-update")
+	unattended, _ := cmd.Flags().GetBool("unattended")
 	dnsFlag, _ := cmd.Flags().GetString("dns")
 	// Captured before any step writes config: a missing file means this is a
 	// first install, the only time the DNS question is asked. Every later run
@@ -147,6 +150,14 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	// dns:disable rather than by re-prompting.
 	_, cfgStatErr := os.Stat(config.GlobalConfigFile())
 	configExisted := cfgStatErr == nil
+	// Unattended runs are driven by a package maintainer script: reuse the
+	// non-interactive update path for prompts. The sudo-gated system steps are
+	// skipped here because `lerd bootstrap --system` performs them as root
+	// beforehand, and the mkcert CA's system-trust is done afterward by
+	// `lerd bootstrap --trust-ca`, so managed .test DNS works with no prompts.
+	if unattended {
+		fromUpdate = true
+	}
 	if noIPv6 {
 		podman.MarkIPv6Disabled("lerd")
 		feedback.Line("IPv6 disabled by user, lerd network will be v4-only")
@@ -163,8 +174,13 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 
 	ensurePortsAvailable()
 
-	if err := ensureUnprivilegedPorts(); err != nil {
-		return err
+	// Skipped under --unattended: these prompt for sudo, which a package
+	// maintainer script cannot answer. `lerd bootstrap --system` set the
+	// unprivileged-port sysctl and enabled linger as root beforehand.
+	if !unattended {
+		if err := ensureUnprivilegedPorts(); err != nil {
+			return err
+		}
 	}
 	if err := ensurePortForwarding(); err != nil {
 		return err
@@ -194,8 +210,10 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	// the session goes inactive and lerd appears to "stop working" until
 	// the next manual `lerd install`. This is the single biggest source of
 	// "DNS just stopped" issues reported in the wild — see #153.
-	if err := ensureSystemdLinger(); err != nil {
-		fmt.Printf("    WARN: %v\n", err)
+	if !unattended {
+		if err := ensureSystemdLinger(); err != nil {
+			fmt.Printf("    WARN: %v\n", err)
+		}
 	}
 
 	// 2. Podman network
@@ -403,10 +421,18 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		// gold sudo header and swallow its "already installed" banner. Only a
 		// genuine first install announces the sudo step and runs interactively.
 		mkcertCmd := exec.Command(certs.MkcertPath(), "-install")
-		if certs.CATrusted() {
+		switch {
+		case unattended:
+			// No sudo available: generate the CA and trust it only in the user's
+			// NSS store (TRUST_STORES=nss skips the system store). The system
+			// store is handled afterward by `lerd bootstrap --trust-ca` as root.
+			mkcertCmd.Env = append(os.Environ(), "TRUST_STORES=nss")
 			mkcertCmd.Stdout = io.Discard
 			mkcertCmd.Stderr = io.Discard
-		} else {
+		case certs.CATrusted():
+			mkcertCmd.Stdout = io.Discard
+			mkcertCmd.Stderr = io.Discard
+		default:
 			feedback.Sudo("Installing mkcert CA")
 			mkcertCmd.Stdin = os.Stdin
 			mkcertCmd.Stdout = os.Stdout
@@ -436,7 +462,11 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 
 		// InstallSudoers prints its own gold "🔒 Installing DNS sudoers rule"
 		// line when it actually writes the drop-in, so no header is printed here.
-		dns.InstallSudoers() //nolint:errcheck
+		// Skipped under --unattended: `lerd bootstrap --system` already wrote the
+		// rule as root, and InstallSudoers would prompt for a password here.
+		if !unattended {
+			dns.InstallSudoers() //nolint:errcheck
+		}
 	} else {
 		feedback.Line("DNS disabled, skipping mkcert CA, dnsmasq and sudoers")
 	}

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -147,10 +148,15 @@ func runUninstall(force bool) error {
 	ok()
 
 	step("Removing lerd binary")
-	if self, err := selfPath(); err == nil {
-		os.Remove(self) //nolint:errcheck
+	if self, err := selfPath(); err == nil && isSystemPackageManaged(self) {
+		fmt.Println(feedback.Dim("kept, package-managed"))
+		feedback.Note("remove the binary with your package manager, e.g. " + packageManagerRemoveHint(self))
+	} else {
+		if err == nil {
+			os.Remove(self) //nolint:errcheck
+		}
+		ok()
 	}
-	ok()
 
 	if removeData {
 		step("Removing config and data directories")

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -98,6 +98,13 @@ func runUpdate(currentVersion string, beta bool) error {
 		}
 	}
 
+	// A deb/rpm install lives under /usr and is owned by the package manager;
+	// self-replacing it would fight apt/dnf, so defer to them.
+	if self, err := selfPath(); err == nil && isSystemPackageManaged(self) {
+		fmt.Printf("\nThis lerd is managed by your system package manager (%s).\nUpdate it with:\n\n  sudo apt upgrade\n\n", self)
+		return nil
+	}
+
 	// Ask for confirmation.
 	if !feedback.Confirm("Update to v"+lat+"?", true) {
 		feedback.Line("update cancelled")
@@ -485,6 +492,14 @@ func downloadArchive(ver, filename, archive string) error {
 // than self-replacing files brew owns.
 func isHomebrewManaged(path string) bool {
 	return strings.Contains(path, "/Cellar/")
+}
+
+// isSystemPackageManaged reports whether the binary lives under a system prefix
+// owned by a package manager. lerd's own installers use ~/.local/bin, so a
+// binary under /usr came from the deb/rpm and must be updated with apt/dnf, not
+// by self-replacing files the package manager owns.
+func isSystemPackageManaged(path string) bool {
+	return strings.HasPrefix(path, "/usr/")
 }
 
 func selfPath() (string, error) {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -101,7 +101,7 @@ func runUpdate(currentVersion string, beta bool) error {
 	// A deb/rpm install lives under /usr and is owned by the package manager;
 	// self-replacing it would fight apt/dnf, so defer to them.
 	if self, err := selfPath(); err == nil && isSystemPackageManaged(self) {
-		fmt.Printf("\nThis lerd is managed by your system package manager (%s).\nUpdate it with:\n\n  sudo apt upgrade\n\n", self)
+		fmt.Printf("\nThis lerd is managed by your system package manager (%s).\nUpdate it with:\n\n  %s\n\n", self, packageManagerUpdateHint(self))
 		return nil
 	}
 
@@ -496,10 +496,59 @@ func isHomebrewManaged(path string) bool {
 
 // isSystemPackageManaged reports whether the binary lives under a system prefix
 // owned by a package manager. lerd's own installers use ~/.local/bin, so a
-// binary under /usr came from the deb/rpm and must be updated with apt/dnf, not
-// by self-replacing files the package manager owns.
+// binary under /usr came from a deb/rpm/pacman package and one under /nix/store
+// from Nix; those are updated by their manager, not by self-replacing files it
+// owns.
 func isSystemPackageManaged(path string) bool {
-	return strings.HasPrefix(path, "/usr/")
+	// /var/usrlocal is what /usr/local resolves to on ostree systems
+	// (Silverblue), where selfPath's symlink resolution hides the /usr prefix.
+	return strings.HasPrefix(path, "/usr/") ||
+		strings.HasPrefix(path, "/var/usrlocal/") ||
+		strings.HasPrefix(path, "/nix/store/")
+}
+
+// lookPath is a seam for tests.
+var lookPath = exec.LookPath
+
+// systemPackageManagers maps a package manager binary to the commands that
+// update and remove a packaged lerd, in detection order.
+var systemPackageManagers = []struct{ bin, update, remove string }{
+	{"apt", "sudo apt upgrade", "sudo apt remove lerd"},
+	// Before dnf: atomic Fedora ships both, and layered packages are managed
+	// by rpm-ostree there, not dnf.
+	{"rpm-ostree", "rpm-ostree upgrade", "rpm-ostree uninstall lerd"},
+	{"dnf", "sudo dnf upgrade lerd", "sudo dnf remove lerd"},
+	{"pacman", "sudo pacman -Syu lerd", "sudo pacman -R lerd"},
+	{"zypper", "sudo zypper update lerd", "sudo zypper remove lerd"},
+}
+
+// packageManagerUpdateHint names the command that updates a package-managed
+// lerd: Nix is recognised by the binary path, everything else by the first
+// known package manager present on the system.
+func packageManagerUpdateHint(self string) string {
+	if strings.HasPrefix(self, "/nix/store/") {
+		return "nix profile upgrade lerd    (or rebuild your NixOS configuration)"
+	}
+	for _, pm := range systemPackageManagers {
+		if _, err := lookPath(pm.bin); err == nil {
+			return pm.update
+		}
+	}
+	return "your system package manager's upgrade command"
+}
+
+// packageManagerRemoveHint is the removal counterpart of
+// packageManagerUpdateHint.
+func packageManagerRemoveHint(self string) string {
+	if strings.HasPrefix(self, "/nix/store/") {
+		return "nix profile remove lerd    (or your NixOS configuration)"
+	}
+	for _, pm := range systemPackageManagers {
+		if _, err := lookPath(pm.bin); err == nil {
+			return pm.remove
+		}
+	}
+	return "your system package manager"
 }
 
 func selfPath() (string, error) {

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -13,6 +13,26 @@ import (
 	lerdUpdate "github.com/geodro/lerd/internal/update"
 )
 
+// ── package-managed detection ─────────────────────────────────────────────────
+
+func TestIsSystemPackageManaged(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/usr/bin/lerd", true},
+		{"/usr/local/bin/lerd", true},
+		{"/home/george/.local/bin/lerd", false},
+		{"/opt/lerd/lerd", false},
+		{"/tmp/lerd", false},
+	}
+	for _, c := range cases {
+		if got := isSystemPackageManaged(c.path); got != c.want {
+			t.Errorf("isSystemPackageManaged(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
 // ── stripV ───────────────────────────────────────────────────────────────────
 
 func TestStripV(t *testing.T) {

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	lerdUpdate "github.com/geodro/lerd/internal/update"
@@ -22,6 +23,8 @@ func TestIsSystemPackageManaged(t *testing.T) {
 	}{
 		{"/usr/bin/lerd", true},
 		{"/usr/local/bin/lerd", true},
+		{"/nix/store/abc123-lerd-1.30.0/bin/lerd", true},
+		{"/var/usrlocal/bin/lerd", true},
 		{"/home/george/.local/bin/lerd", false},
 		{"/opt/lerd/lerd", false},
 		{"/tmp/lerd", false},
@@ -30,6 +33,53 @@ func TestIsSystemPackageManaged(t *testing.T) {
 		if got := isSystemPackageManaged(c.path); got != c.want {
 			t.Errorf("isSystemPackageManaged(%q) = %v, want %v", c.path, got, c.want)
 		}
+	}
+}
+
+func TestPackageManagerHints(t *testing.T) {
+	orig := lookPath
+	t.Cleanup(func() { lookPath = orig })
+
+	stub := func(present ...string) {
+		lookPath = func(bin string) (string, error) {
+			for _, p := range present {
+				if bin == p {
+					return "/usr/bin/" + bin, nil
+				}
+			}
+			return "", os.ErrNotExist
+		}
+	}
+
+	stub("dnf")
+	if got := packageManagerUpdateHint("/usr/bin/lerd"); got != "sudo dnf upgrade lerd" {
+		t.Errorf("dnf update hint = %q", got)
+	}
+	if got := packageManagerRemoveHint("/usr/bin/lerd"); got != "sudo dnf remove lerd" {
+		t.Errorf("dnf remove hint = %q", got)
+	}
+
+	stub("pacman")
+	if got := packageManagerUpdateHint("/usr/bin/lerd"); got != "sudo pacman -Syu lerd" {
+		t.Errorf("pacman update hint = %q", got)
+	}
+
+	// Atomic Fedora has both; rpm-ostree owns layered packages, so it wins.
+	stub("rpm-ostree", "dnf")
+	if got := packageManagerUpdateHint("/usr/bin/lerd"); got != "rpm-ostree upgrade" {
+		t.Errorf("rpm-ostree update hint = %q", got)
+	}
+
+	// A Nix store path decides by itself, whatever is on PATH.
+	stub("apt")
+	if got := packageManagerUpdateHint("/nix/store/abc-lerd/bin/lerd"); !strings.Contains(got, "nix profile upgrade") {
+		t.Errorf("nix update hint = %q", got)
+	}
+
+	// No known package manager present falls back to a generic sentence.
+	stub("")
+	if got := packageManagerUpdateHint("/usr/bin/lerd"); !strings.Contains(got, "package manager") {
+		t.Errorf("fallback update hint = %q", got)
 	}
 }
 

--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -959,6 +959,27 @@ func removeSudoersGrant() bool {
 // InstallSudoers writes a sudoers drop-in granting the current user passwordless
 // access to resolvectl commands. This is required for the autostart service which
 // runs non-interactively and cannot prompt for a sudo password.
+// WriteSudoersForUser writes the DNS sudoers drop-in directly, without the
+// interactive `sudo tee` that InstallSudoers uses. The caller must already be
+// root. `lerd bootstrap --system` calls this so a package maintainer script can
+// grant the passwordless DNS rules up front, letting a later unattended install
+// configure the resolver without a prompt. Idempotent.
+func WriteSudoersForUser(user string) error {
+	if user == "" {
+		return fmt.Errorf("cannot determine target user")
+	}
+	content := renderLinuxSudoers(user)
+	if sudoersInstalled([]byte(content)) {
+		return nil
+	}
+	const sudoersPath = "/etc/sudoers.d/lerd"
+	if err := os.WriteFile(sudoersPath, []byte(content), 0440); err != nil {
+		return fmt.Errorf("writing sudoers drop-in: %w", err)
+	}
+	recordSudoersInstalled([]byte(content))
+	return nil
+}
+
 func InstallSudoers() error {
 	user := os.Getenv("USER")
 	if user == "" {

--- a/internal/systemd/embed.go
+++ b/internal/systemd/embed.go
@@ -3,13 +3,35 @@ package systemd
 import (
 	"embed"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
 //go:embed units
 var unitsFS embed.FS
 
-// GetUnit returns the content of an embedded systemd unit file.
+// lerdBinaryPath resolves the absolute path to the running lerd binary so unit
+// ExecStart lines point at wherever lerd is actually installed: ~/.local/bin
+// for curl/brew, /usr/bin for the deb. A var so tests can override it; returns
+// "" when the path can't be resolved, in which case GetUnit leaves the template
+// default in place.
+var lerdBinaryPath = func() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	if resolved, rErr := filepath.EvalSymlinks(exe); rErr == nil {
+		exe = resolved
+	}
+	return exe
+}
+
+// GetUnit returns the content of an embedded systemd unit file with the lerd
+// binary path resolved. The templates ship with ExecStart=%h/.local/bin/lerd,
+// which only works for a ~/.local/bin install; substituting the real path lets
+// the daemon units run from any install location (notably /usr/bin under the
+// Debian package).
 func GetUnit(name string) (string, error) {
 	// name may or may not have .service suffix
 	filename := name
@@ -20,5 +42,19 @@ func GetUnit(name string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("systemd unit %q not found: %w", name, err)
 	}
-	return string(data), nil
+	return resolveUnitBinaryPath(string(data)), nil
+}
+
+// resolveUnitBinaryPath swaps the hardcoded ~/.local/bin templates for the
+// running binary's real location. lerd-tray is replaced first because its name
+// has lerd as a prefix.
+func resolveUnitBinaryPath(content string) string {
+	bin := lerdBinaryPath()
+	if bin == "" {
+		return content
+	}
+	tray := filepath.Join(filepath.Dir(bin), "lerd-tray")
+	content = strings.ReplaceAll(content, "%h/.local/bin/lerd-tray", tray)
+	content = strings.ReplaceAll(content, "%h/.local/bin/lerd", bin)
+	return content
 }

--- a/internal/systemd/embed_test.go
+++ b/internal/systemd/embed_test.go
@@ -1,0 +1,47 @@
+package systemd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetUnitResolvesBinaryPath(t *testing.T) {
+	orig := lerdBinaryPath
+	t.Cleanup(func() { lerdBinaryPath = orig })
+	lerdBinaryPath = func() string { return "/usr/bin/lerd" }
+
+	ui, err := GetUnit("lerd-ui")
+	if err != nil {
+		t.Fatalf("GetUnit: %v", err)
+	}
+	if !strings.Contains(ui, "ExecStart=/usr/bin/lerd serve-ui") {
+		t.Errorf("lerd-ui ExecStart not resolved:\n%s", ui)
+	}
+	if strings.Contains(ui, "%h/.local/bin/lerd") {
+		t.Errorf("lerd-ui still has the template path:\n%s", ui)
+	}
+
+	tray, err := GetUnit("lerd-tray")
+	if err != nil {
+		t.Fatalf("GetUnit tray: %v", err)
+	}
+	if !strings.Contains(tray, "ExecStart=/usr/bin/lerd-tray") {
+		t.Errorf("lerd-tray ExecStart not resolved:\n%s", tray)
+	}
+}
+
+// When the binary path can't be resolved, the template default is left intact
+// rather than producing a broken ExecStart.
+func TestGetUnitKeepsTemplateWhenUnresolved(t *testing.T) {
+	orig := lerdBinaryPath
+	t.Cleanup(func() { lerdBinaryPath = orig })
+	lerdBinaryPath = func() string { return "" }
+
+	ui, err := GetUnit("lerd-ui")
+	if err != nil {
+		t.Fatalf("GetUnit: %v", err)
+	}
+	if !strings.Contains(ui, "%h/.local/bin/lerd serve-ui") {
+		t.Errorf("expected template default, got:\n%s", ui)
+	}
+}


### PR DESCRIPTION
Debian and Ubuntu users install lerd from a Launchpad PPA (ppa:lerd/lerd), where a maintainer script runs as root and cannot answer the interactive sudo prompts a normal lerd install relies on. This adds the pieces that let a package finish setup without prompting, and teaches lerd to cooperate with a system-managed binary, while leaving the interactive install untouched.

lerd bootstrap --system does the root-level machine-global steps, the unprivileged-port sysctl, systemd linger, and the DNS sudoers rule. lerd install --unattended runs the rest non-interactively, defaults to managed .test, and generates the mkcert CA with TRUST_STORES=nss so it needs no sudo. lerd bootstrap --trust-ca installs that CA into the system trust store as root afterward. The companion lerd-deb package runs bootstrap --system, the per-user install, then bootstrap --trust-ca, so managed DNS and HTTPS come up with no password. Every unattended-only branch is gated behind the flag, so an ordinary lerd install behaves exactly as before.

The systemd unit templates hardcoded ~/.local/bin/lerd, which cannot resolve for a package that installs the binary to /usr/bin, so the unit ExecStart now carries the running binary's real path.

lerd update self-replaces a ~/.local/bin binary, which would fight apt on a packaged install, so it now recognises a binary under /usr and defers to the package manager.

Closes #979
