### PR TITLE
fix(cleanup): reclaim unused catalog images podman auto-pulled

### DIFF
--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -220,7 +220,7 @@ func Inspect(scope Scope) (Plan, error) {
 		repos, repoErr := serviceRepos()
 		prot, protErr := protectedImages()
 		if repoErr == nil && protErr == nil {
-			p.Targets = append(p.Targets, deepTargets(imgs, repos, prot, canonPulled())...)
+			p.Targets = append(p.Targets, deepTargets(imgs, repos, prot, canonPulled(), reapAllDangling)...)
 		}
 	}
 	// podman lists a multi-tag image once per tag, so dedupe by ref/ID to avoid

--- a/internal/cleanup/deep.go
+++ b/internal/cleanup/deep.go
@@ -94,10 +94,14 @@ func realReferencedImages(candidates map[string]bool) map[string]bool {
 // behind after upgrading, while the protected set keeps the live image and the
 // one-back rollback target, and an image carrying any non-catalog tag (one the
 // user added themselves) is left entirely alone.
-func deepTargets(imgs []image, repos, protected, pulled map[string]bool) []Target {
+// ignoreLedger drops the "lerd recorded pulling this" requirement, so the deep
+// tier can recover catalog images pulled outside lerd's explicit pull path
+// (podman auto-pulls a quadlet's Image= on first start, which the ledger never
+// sees). The managed and safe tiers keep the ledger gate.
+func deepTargets(imgs []image, repos, protected, pulled map[string]bool, ignoreLedger bool) []Target {
 	var out []Target
 	for _, img := range imgs {
-		refs := removableServiceRefs(img, repos, protected, pulled)
+		refs := removableServiceRefs(img, repos, protected, pulled, ignoreLedger)
 		// Remove every owned tag so the image actually frees on the last one;
 		// credit the reclaimable bytes once (on that last removal), since
 		// untagging the earlier aliases frees nothing on its own.
@@ -118,7 +122,7 @@ func deepTargets(imgs []image, repos, protected, pulled map[string]bool) []Targe
 // tag (current image or rollback target), a non-catalog tag the user added, or an
 // image lerd never pulled all mean "leave this whole image alone", so cleanup
 // never untags an image the user owns or that something else still relies on.
-func removableServiceRefs(img image, repos, protected, pulled map[string]bool) []string {
+func removableServiceRefs(img image, repos, protected, pulled map[string]bool, ignoreLedger bool) []string {
 	// An image a container still holds can't be removed by podman, so keep it even
 	// when no service config references it (a container running a catalog image the
 	// config no longer names would otherwise be listed forever).
@@ -136,7 +140,7 @@ func removableServiceRefs(img image, repos, protected, pulled map[string]bool) [
 		}
 		refs = append(refs, n)
 	}
-	if !lerdPulled {
+	if !ignoreLedger && !lerdPulled {
 		return nil
 	}
 	return refs

--- a/internal/cleanup/deep_test.go
+++ b/internal/cleanup/deep_test.go
@@ -23,7 +23,7 @@ func TestDeepTargets_ReapsUnusedServiceImagesKeepsProtected(t *testing.T) {
 	}
 	pulled := map[string]bool{"docker.io/library/mysql:5.7": true}
 
-	got := deepTargets(imgs, repos, protected, pulled)
+	got := deepTargets(imgs, repos, protected, pulled, false)
 
 	if len(got) != 1 || got[0].ID != "docker.io/library/mysql:5.7" {
 		t.Fatalf("want only mysql:5.7 reaped, got %+v", got)
@@ -47,7 +47,7 @@ func TestDeepTargets_MultiTagRemovesAllTagsCreditsOnce(t *testing.T) {
 	protected := map[string]bool{}
 	pulled := map[string]bool{"docker.io/library/mysql:5.7": true}
 
-	got := deepTargets(imgs, repos, protected, pulled)
+	got := deepTargets(imgs, repos, protected, pulled, false)
 
 	removed := map[string]int64{}
 	for _, tg := range got {
@@ -78,25 +78,48 @@ func TestDeepTargets_KeepsInUseServiceImage(t *testing.T) {
 	}
 	repos := map[string]bool{"docker.io/library/redis": true}
 
-	got := deepTargets(imgs, repos, map[string]bool{}, map[string]bool{})
+	got := deepTargets(imgs, repos, map[string]bool{}, map[string]bool{}, false)
 
 	if len(got) != 0 {
 		t.Fatalf("an in-use service image must be kept, got %+v", got)
 	}
 }
 
-// An unused catalog image lerd never recorded pulling is kept even by the deep
-// tier: the ledger, not the repo name, is what marks an image as lerd's to reap.
+// With the ledger gate on (managed tier), an unused catalog image lerd never
+// recorded pulling is kept: the ledger, not the repo name, marks it as lerd's.
 func TestDeepTargets_KeepsCatalogImageLerdNeverPulled(t *testing.T) {
 	imgs := []image{
 		{Names: []string{"docker.io/library/redis:6"}, Size: 300},
 	}
 	repos := map[string]bool{"docker.io/library/redis": true}
 
-	got := deepTargets(imgs, repos, map[string]bool{}, map[string]bool{})
+	got := deepTargets(imgs, repos, map[string]bool{}, map[string]bool{}, false)
 
 	if len(got) != 0 {
 		t.Fatalf("a catalog image lerd never pulled must be kept, got %+v", got)
+	}
+}
+
+// With ignoreLedger on (the deep tier), an unused catalog image is reaped even
+// with no ledger entry: this recovers images podman auto-pulled on container
+// start, which the ledger never recorded. Protection and repo scoping still hold.
+func TestDeepTargets_DeepReapsCatalogImageWithoutLedger(t *testing.T) {
+	imgs := []image{
+		{Names: []string{"docker.io/library/mysql:8.0"}, Size: 800},             // unused, no ledger → reap
+		{Names: []string{"docker.io/library/mysql:8.4"}, Size: 500},             // protected → keep
+		{Names: []string{"ubuntu:22.04"}, Size: 700},                            // non-catalog → keep
+		{Names: []string{"docker.io/library/redis:7"}, Size: 40, Containers: 1}, // in use → keep
+	}
+	repos := map[string]bool{"docker.io/library/mysql": true, "docker.io/library/redis": true}
+	protected := map[string]bool{"docker.io/library/mysql:8.4": true}
+
+	got := deepTargets(imgs, repos, protected, map[string]bool{}, true)
+
+	if len(got) != 1 || got[0].ID != "docker.io/library/mysql:8.0" {
+		t.Fatalf("want only mysql:8.0 reaped without ledger, got %+v", got)
+	}
+	if got[0].Bytes != 800 {
+		t.Errorf("bytes = %d, want 800", got[0].Bytes)
 	}
 }
 

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -18,6 +18,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/freeport"
+	"github.com/geodro/lerd/internal/imgledger"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/registry"
 )
@@ -756,6 +757,13 @@ func EnsureCustomServiceQuadlet(svc *config.CustomService) error {
 	changed, err := podman.WriteQuadletDiff(quadletName, content)
 	if err != nil {
 		return fmt.Errorf("writing unit for %s: %w", svc.Name, err)
+	}
+	// Record the image lerd is installing so cleanup can reclaim it later even
+	// though podman, not lerd, pulls the bytes when the quadlet first starts.
+	// Without this the pull ledger only sees images pulled through lerd's own
+	// pull path, and cleanup's managed tier cannot tell this is lerd's to reap.
+	if svc.Image != "" {
+		imgledger.Record(svc.Image)
 	}
 	return podman.DaemonReloadIfNeeded(changed)
 }


### PR DESCRIPTION
lerd cleanup only treated a catalog service image as reclaimable when lerd's pull ledger recorded pulling it, but the ledger is written only in lerd's explicit pull wrapper. When a service quadlet first starts, podman auto-pulls its image without going through that path, so the ledger never sees it. The result was that cleanup could report tens of MiB while several GB of unused old service versions and dropped services sat unreclaimed, visible only to podman system df.

The deep tier now reclaims an unprotected, not-in-use image whose repo is in the service catalog even without a ledger entry, so a deep sweep and the dashboard recover images pulled before this change. The managed and safe tiers keep the ledger gate, so the background auto-sweep still never touches an image lerd cannot prove is its own.

Service installs also record the image at the choke point every service quadlet passes through, so the ledger stays complete going forward and the managed tier can reclaim lerd's own leftovers without needing the deep tier.

Refs #981
