### PR TITLE
Let the dashboard cards fill the viewport height

### DIFF
--- a/internal/ui/web/src/tabs/DashboardTab.svelte
+++ b/internal/ui/web/src/tabs/DashboardTab.svelte
@@ -32,8 +32,8 @@
   );
 </script>
 
-<div class="flex-1 overflow-y-auto">
-  <div class="flex flex-wrap items-center justify-between gap-y-2 px-3 py-3 border-b border-gray-100 dark:border-lerd-border">
+<div class="flex-1 min-h-0 flex flex-col overflow-y-auto">
+  <div class="shrink-0 flex flex-wrap items-center justify-between gap-y-2 px-3 py-3 border-b border-gray-100 dark:border-lerd-border">
     <div class="min-w-0">
       <h1 class="font-semibold text-gray-900 dark:text-white text-xl tracking-tight">{m.dashboard_title()}</h1>
       {#if everythingHealthy}
@@ -62,12 +62,12 @@
     </button>
   </div>
 
-  <div class="p-3 space-y-3">
+  <div class="p-3 space-y-3 xl:flex-1 xl:min-h-0 xl:flex xl:flex-col">
     <OnboardingPanel />
     {#if !everythingHealthy}
       <HeroStatus />
     {/if}
-    <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3">
+    <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3 xl:flex-1 xl:min-h-0 xl:auto-rows-fr">
       <SitesWidget />
       <ServicesWidget />
       <WorkersWidget />

--- a/internal/ui/web/src/tabs/dashboard/DashboardCard.svelte
+++ b/internal/ui/web/src/tabs/dashboard/DashboardCard.svelte
@@ -21,7 +21,10 @@
   };
 </script>
 
-<div class="flex flex-col max-h-[340px] bg-white dark:bg-lerd-card border border-gray-100 dark:border-lerd-border rounded-xl overflow-hidden {accent[tone]}">
+<!-- Below xl the grid stacks into many rows and the page scrolls, so the card
+     keeps a readable band of its own. At xl it stretches to fill its grid row
+     instead, and min-h-0 lets it shrink with that row rather than overflow. -->
+<div class="flex flex-col min-h-[280px] max-h-[340px] xl:min-h-0 xl:max-h-none bg-white dark:bg-lerd-card border border-gray-100 dark:border-lerd-border rounded-xl overflow-hidden {accent[tone]}">
   <div class="shrink-0 flex items-center justify-between gap-3 px-3 py-2.5 border-b border-gray-100 dark:border-lerd-border">
     <span class="text-sm font-semibold text-gray-700 dark:text-gray-200">{title}</span>
     {#if badge}{@render badge()}{/if}

--- a/internal/ui/web/src/tabs/dashboard/DashboardCard.test.ts
+++ b/internal/ui/web/src/tabs/dashboard/DashboardCard.test.ts
@@ -51,4 +51,23 @@ describe('DashboardCard', () => {
     const root = container.querySelector('div');
     expect(root!.className).not.toMatch(/border-l-4/);
   });
+
+  it('caps height on narrow layouts but stretches to fill the row at xl', () => {
+    const { container } = render(Harness, { props: { title: 'Sites' } });
+    const root = container.querySelector('div');
+    // Narrow layouts stack into many rows, so the cap stays; at xl the card
+    // fills its share instead of leaving dead space.
+    expect(root!.className).toMatch(/max-h-\[340px\]/);
+    expect(root!.className).toMatch(/xl:max-h-none/);
+  });
+
+  it('keeps a height floor below xl and drops it where it stretches', () => {
+    const { container } = render(Harness, { props: { title: 'Sites' } });
+    const root = container.querySelector('div');
+    // Narrow layouts stack and scroll, so a floor keeps each card readable.
+    // At xl the floor would push the rows past a short viewport and clip
+    // them, so the card shrinks with its row and its body scrolls instead.
+    expect(root!.className).toMatch(/min-h-\[280px\]/);
+    expect(root!.className).toMatch(/xl:min-h-0/);
+  });
 });

--- a/internal/ui/web/src/tabs/dashboard/ResourcesWidget.svelte
+++ b/internal/ui/web/src/tabs/dashboard/ResourcesWidget.svelte
@@ -104,7 +104,7 @@
     {#if rows.length > 0}
       <div class="pt-2 border-t border-gray-100 dark:border-lerd-border space-y-1">
         <div class="text-[10px] font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide">{m.dashboard_resources_top()}</div>
-        <div class="space-y-1 max-h-44 overflow-y-auto pr-1">
+        <div class="space-y-1 max-h-44 xl:max-h-none overflow-y-auto pr-1">
           {#each rows as c (c.name)}
             <div class="flex items-center gap-2 text-xs">
               <span class="flex-1 truncate text-gray-600 dark:text-gray-300">{shortName(c.name)}</span>


### PR DESCRIPTION
The dashboard cards were pinned to a 340px ceiling while the grid rows sized themselves to their content, so on a tall window the six cards stopped short and left a band of dead space under the second row.

At xl the grid now claims the height left below the header and splits it evenly between its two rows, with the ceiling lifted so each card stretches into its share. The cards drop their floor there too, so a short window shrinks the rows instead of overflowing and clipping them, and each card body scrolls as it already did. Below xl the grid stacks into many rows and the page scrolls, where filling the viewport would only squash things, so the cards keep a floor of their own instead. The resources card also drops the cap on its consumer list at xl so a taller card is not left half empty.

Closes #983