### PR TITLE
docs(cleanup): describe the deep tier reaping any unreferenced catalog image

### DIFF
--- a/docs/usage/cleanup.md
+++ b/docs/usage/cleanup.md
@@ -2,7 +2,7 @@
 
 Local PHP development on podman accumulates reclaimable image data. Every PHP image rebuild re-points the fixed `:local` tag and leaves the old image dangling, every Containerfile hash bump (from a lerd update) strands the previous base image, and every service upgrade leaves the old version's image behind. Left alone, a machine that only ever kicked the tyres can end up tens of gigabytes deep.
 
-`lerd cleanup` reclaims that space. Unlike a blunt `podman system prune -a`, it knows which images are load-bearing and only ever removes lerd's own, so it can never eat a database or another tool's images.
+`lerd cleanup` reclaims that space. Unlike a blunt `podman system prune -a`, it knows which images are load-bearing, so it can never eat a database or an image something still depends on. The default tier does reach beyond lerd's own images to unused catalog images and dangling leftovers on the host; `--safe` scopes it strictly to images lerd built.
 
 ## What it removes
 
@@ -15,7 +15,8 @@ By default (and automatically) cleanup reclaims everything below. Pass `--safe` 
 
 **Unused service images** (the deep tier, default):
 
-- A service image **lerd itself pulled** that no installed service references any more, e.g. an old `mysql:8.0` after you upgraded to `8.4`. Each service's **current image and its one-back rollback target are kept**, so a rollback still works. lerd records every image it pulls, so a catalog image you pulled yourself for another project (a `redis` or `postgres` for a non-lerd stack) is never in scope, even though it shares a repo with a lerd service.
+- A **catalog service image** that no installed service references any more and that no container currently holds, e.g. an old `mysql:8.0` after you upgraded to `8.4`. Each service's **current image and its one-back rollback target are kept**, so a rollback still works.
+- This tier does **not** require that lerd pulled the image. Any image whose repo appears in the service catalog (`postgres`, `mysql`, `mariadb`, `redis`, `mongo`, `elasticsearch`, `valkey` and the rest) is in scope once nothing references it, including a copy you pulled yourself for a non-lerd project. That is deliberate: an unreferenced catalog image is the single largest thing a mixed-workload machine accumulates. If you park stopped containers' images for other stacks, run `--safe` instead; anything reclaimed here comes back with a `podman pull`.
 
 **Dangling images** (the deep tier, default):
 
@@ -25,10 +26,12 @@ By default (and automatically) cleanup reclaims everything below. Pass `--safe` 
 
 - **Named data volumes** — your databases are never in scope.
 - **Any tagged image in use** — an image a running container uses, and each installed service's current image and one-back rollback target, are always kept.
-- **A tagged image lerd didn't pull** — a `mysql`, `redis`, `postgres` (or any catalog repo) you pulled yourself is kept, because the reap only removes service images lerd's own pull recorded. Sharing a repo with a lerd service is not enough to make it a target.
+- **A tagged image outside the service catalog** — your own application images, another tool's base images, anything still carrying a tag whose repo lerd doesn't recognise as a service. (Untagged leftovers are a different matter, the deep tier reaps those wherever they came from.)
 - With **`--safe`**, only images provably built by lerd (a `dev.lerd.*` label or the `lerd-php*-fpm-base` repo name) are removed, and nothing else is touched at all.
 
-The default reaches further than `--safe` in one place: it also removes **dangling** (untagged) images. That is deliberately safe, a dangling image is unreferenced by definition, so nothing depends on it. On a machine that also runs podman for non-lerd projects, that means the interactive `lerd cleanup` reclaims their untagged leftovers too (the unattended daily sweep never does); use `--safe` there if you want cleanup scoped strictly to lerd. Tagged images are unaffected either way, only lerd's own pulls are in scope. Removal is reference-count safe throughout: shared layers stay on disk, and an image that turns out to be in use is skipped rather than forced.
+The default reaches further than `--safe` in two places: it also removes **dangling** (untagged) images, and **unreferenced catalog images regardless of who pulled them**. On a machine that also runs podman for non-lerd projects, that means the interactive `lerd cleanup` can reclaim a `postgres` or `redis` you pulled for another stack once its containers are gone. The unattended daily sweep never does either of these, it stays strictly on images lerd pulled. Use `--safe` if you want cleanup scoped to lerd alone. Removal is reference-count safe throughout: shared layers stay on disk, and an image that turns out to be in use is skipped rather than forced.
+
+Both the CLI preview and the dashboard modal itemise every image before anything is removed, so you always see a catalog image of your own listed by name and size before confirming.
 
 ## Commands
 
@@ -48,7 +51,7 @@ The dashboard surfaces this too. The resources widget shows the reclaimable tota
 Cleanup is on by default and safe, so the disk doesn't grow on its own:
 
 - **On rebuild / service change** — a PHP rebuild (`lerd use`, `lerd php:rebuild`, `lerd php:ext`/`php:pkg`, a `lerd update` that bumps the Containerfile) reclaims the image it just superseded immediately. A `lerd service update` or `lerd service remove` reclaims that service's now-unused versions, scoped to that one service.
-- **Daily backstop** — the `lerd-watcher` runs a managed sweep about once a day (throttled by a timestamp so a restarting watcher can't sweep more often), catching lerd's own orphaned build images and old service versions that fell out of the one-back rollback window. It keeps every tagged image in use (the current image and the rollback target) and never removes an image lerd didn't pull, so it stays safe unattended. The wider dangling-image reap that also clears foreign untagged leftovers is left to the interactive `lerd cleanup`, so nothing running another podman workload is surprised by an unattended prune.
+- **Daily backstop** — the `lerd-watcher` runs a managed sweep about once a day (throttled by a timestamp so a restarting watcher can't sweep more often), catching lerd's own orphaned build images and old service versions that fell out of the one-back rollback window. It keeps every tagged image in use (the current image and the rollback target) and never removes an image lerd didn't pull, so it stays safe unattended. The wider reap that also clears foreign untagged leftovers and unreferenced catalog images you pulled yourself is left to the interactive `lerd cleanup`, so nothing running another podman workload is surprised by an unattended prune.
 
 Toggle automatic cleanup with `lerd cleanup auto on` / `lerd cleanup auto off` (or set `auto_cleanup` in [`~/.config/lerd/config.yaml`](../configuration.md)); `lerd cleanup auto status` shows the current state. When off, `lerd cleanup` stays available on demand.
 

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -143,8 +143,9 @@ const (
 	// references any more (upgrade leftovers). Still lerd-scoped, so it is safe to
 	// run unattended; this is the daily watcher's tier.
 	ScopeManaged
-	// ScopeDeep additionally reclaims every remaining dangling image on the host,
-	// foreign ones included. Interactive only (`lerd cleanup --deep`).
+	// ScopeDeep additionally reclaims every remaining dangling image on the host
+	// and every unreferenced catalog image regardless of who pulled it, foreign
+	// ones included. Interactive only, and the default for `lerd cleanup`.
 	ScopeDeep
 )
 

--- a/internal/cleanup/deep.go
+++ b/internal/cleanup/deep.go
@@ -27,9 +27,9 @@ var (
 	// candidate, so the per-quadlet image reads are skipped) is assertable.
 	installedServiceImages = realInstalledServiceImages
 
-	// loadPulledImages is the seam onto lerd's pull ledger: the catalog reap only
-	// removes a tagged image whose ref lerd recorded pulling, so a user's own copy
-	// of a catalog image lerd never touched is left alone.
+	// loadPulledImages is the seam onto lerd's pull ledger. The managed tier gates
+	// the catalog reap on it; the deep tier passes ignoreLedger and reaps any
+	// unreferenced catalog image, a user's own copy included.
 	loadPulledImages = imgledger.Load
 )
 


### PR DESCRIPTION
The deep tier stopped requiring a pull ledger entry when it gained `ignoreLedger`, so an unreferenced catalog image is reclaimed now regardless of who pulled it. That is what we want from an interactive cleanup, an unreferenced catalog image is the largest thing a mixed-workload machine accumulates, and both the CLI preview and the dashboard modal itemise every image by name and size before anything goes.

The documentation never caught up. It promised in three places that a catalog image you pulled yourself is never in scope, that a tagged image lerd did not pull is kept because the reap only removes what lerd's own pull recorded, and that tagged images are unaffected by the way the default reaches past `--safe`. All three now describe what the code actually does, and anyone running a second podman workload is pointed at `--safe`.

The never-touched list needed narrowing to tagged images outside the catalog. The dangling reap has always taken foreign untagged leftovers, so the old blanket wording was wrong in that direction too.

Two comments carried the same stale guarantee, the seam on `loadPulledImages` and the one on `ScopeDeep`. The latter also still pointed at `lerd cleanup --deep`, which became a hidden no-op once deep turned into the default.

Closes #992
