### PR TITLE
fix(php): resolve a worktree's own PHP version for container commands

### DIFF
--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -159,7 +159,7 @@ php_version: "8.4"
 node_version: "24"
 ```
 
-The override is honoured wherever lerd materialises worktree state on disk: vhost generation on add, rename, pause/unpause, and `lerd secure`/`lerd unsecure`. Worktrees with no override inherit the parent's pinned version (not the highest-installed satisfier of `composer.json`/`package.json` constraints — that detection only kicks in for unregistered directories).
+The override is honoured wherever lerd materialises worktree state on disk: vhost generation on add, rename, pause/unpause, and `lerd secure`/`lerd unsecure`. The commands that run PHP in a container follow it too, so `lerd php` and `lerd composer` from inside the checkout use the worktree's version rather than the parent's, whether the worktree sits beside the project or inside it. Switching a worktree's version writes the target version's FPM quadlet the same way a site switch does, so the vhost it generates always has a container behind it. Worktrees with no override inherit the parent's pinned version (not the highest-installed satisfier of `composer.json`/`package.json` constraints — that detection only kicks in for unregistered directories).
 
 Site-level resources stay shared and cannot be overridden per worktree: domain (derived from the parent), TLS certificate (parent's wildcard cert), LAN share port (worktree-scoped LAN share is a separate toggle), workers, and any custom container settings.
 

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -35,6 +35,8 @@ If no version is given, the version is resolved from the current directory (`.ph
 
 Inside a linked site, the commands that run PHP in a container (`lerd php`, `lerd composer`, `lerd console`, `lerd php:shell`) use the version the site is registered on, which is the version its FPM container serves. That matters when a framework clamps the version at link time: a Laravel 13 project pinning `.php-version` to 8.1 is linked on 8.5, because Laravel 13 supports 8.3 to 8.5, and composer then runs on 8.5 too rather than resolving 8.1 from the file and quietly using a different PHP than the site itself.
 
+A git worktree resolves ahead of the site it belongs to. A worktree inherits its parent site's version until you pin one with `lerd isolate` from inside the checkout, and from then on the whole toolchain follows that pin: the worktree's own vhost, `lerd php`, `lerd composer`, and everything else that runs PHP in a container. This holds wherever the checkout lives, including inside the parent site's own directory, so a worktree on 8.3 under a site on 8.5 runs composer on 8.3 rather than picking up the parent's version.
+
 So that the project agrees with what actually runs, `lerd link` pins the resolved version into `.php-version`, the same file `lerd isolate` and the dashboard's PHP dropdown write. A pin the framework does not support is rewritten to the version lerd runs, and a version outside the framework's range is clamped rather than accepted, so the file, the site registry and the container can never drift apart. Sites with no lerd-managed PHP version (host-proxy, and custom containers whose version comes from their Containerfile) are left untouched.
 
 ---

--- a/internal/cli/client_shims.go
+++ b/internal/cli/client_shims.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/geodro/lerd/internal/envfile"
 	"github.com/geodro/lerd/internal/feedback"
+	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/shims"
 	"github.com/spf13/cobra"
@@ -196,7 +197,7 @@ func siteServiceForTool(cwd, tool string) string {
 	if !isSQLTool(tool) {
 		return ""
 	}
-	host := envfile.ReadKey(filepath.Join(siteRootFor(cwd), ".env"), "DB_HOST")
+	host := envfile.ReadKey(filepath.Join(phpDet.SiteRootFor(cwd), ".env"), "DB_HOST")
 	svc, ok := strings.CutPrefix(host, "lerd-")
 	if !ok || svc == "" {
 		return ""

--- a/internal/cli/fpm_ensure.go
+++ b/internal/cli/fpm_ensure.go
@@ -207,7 +207,7 @@ func otherInstalledVersions(exclude string) []string {
 // composer's constraint. Best-effort: a write failure or a higher-priority
 // .lerd.yaml override only warns, since the switch still applies to this run.
 func persistPHPVersion(cwd, version string) {
-	root := siteRootFor(cwd)
+	root := phpDet.SiteRootFor(cwd)
 	path := root + "/.php-version"
 	if err := os.WriteFile(path, []byte(version+"\n"), 0o644); err != nil {
 		feedback.Warn("could not pin PHP %s (%s): %v", version, path, err)

--- a/internal/cli/idle_activity.go
+++ b/internal/cli/idle_activity.go
@@ -7,6 +7,7 @@ import (
 	"github.com/geodro/lerd/internal/activityping"
 	"github.com/geodro/lerd/internal/config"
 	gitpkg "github.com/geodro/lerd/internal/git"
+	phpDet "github.com/geodro/lerd/internal/php"
 )
 
 // recordCwdActivity tells lerd-ui that the site containing dir is being worked
@@ -18,7 +19,7 @@ func recordCwdActivity(dir string) {
 	if dir == "" {
 		return
 	}
-	site, _ := config.FindSiteByPath(siteRootFor(dir))
+	site, _ := config.FindSiteByPath(phpDet.SiteRootFor(dir))
 	if site == nil {
 		return
 	}

--- a/internal/cli/php_bun.go
+++ b/internal/cli/php_bun.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
+	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
@@ -129,7 +130,7 @@ func bunFPMSite() *config.Site {
 	if err != nil {
 		return nil
 	}
-	s, err := config.FindSiteByPath(siteRootFor(cwd))
+	s, err := config.FindSiteByPath(phpDet.SiteRootFor(cwd))
 	if err != nil || s == nil || !s.IsCustomFPM() {
 		return nil
 	}

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -62,22 +62,9 @@ func RunPHPCapture(cwd string, args []string) (int, error) {
 }
 
 // phpVersionForDir resolves the PHP version a directory's commands must run on.
-// A registered site's version wins: lerd link clamps to the framework's supported
-// range, so re-detecting here would run composer, console and php:shell on a
-// different PHP than the FPM container serving the site.
+// The rules live in internal/php so the CLI and the MCP server cannot drift.
 func phpVersionForDir(dir string) (string, error) {
-	if site, _ := config.FindSiteByPath(siteRootFor(dir)); site != nil && site.PHPVersion != "" {
-		return site.PHPVersion, nil
-	}
-	version, err := phpDet.DetectVersion(dir)
-	if err == nil {
-		return version, nil
-	}
-	cfg, cfgErr := config.LoadGlobal()
-	if cfgErr != nil {
-		return "", fmt.Errorf("cannot detect PHP version: %w", err)
-	}
-	return cfg.PHP.DefaultVersion, nil
+	return phpDet.VersionForDir(dir)
 }
 
 // fpmContainerForDir resolves the FPM container an exec in dir should target:
@@ -87,7 +74,7 @@ func phpVersionForDir(dir string) (string, error) {
 // also walks up), otherwise a custom-FPM exec from a subdir would wrongly hit
 // the shared container.
 func fpmContainerForDir(dir, version string) string {
-	if site, _ := config.FindSiteByPath(siteRootFor(dir)); site != nil {
+	if site, _ := config.FindSiteByPath(phpDet.SiteRootFor(dir)); site != nil {
 		return podman.FPMContainerName(*site, version)
 	}
 	return "lerd-php" + strings.ReplaceAll(version, ".", "") + "-fpm"

--- a/internal/cli/php_shell.go
+++ b/internal/cli/php_shell.go
@@ -3,10 +3,8 @@ package cli
 import (
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 
-	"github.com/geodro/lerd/internal/config"
+	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
@@ -41,7 +39,7 @@ func runPhpShell(_ *cobra.Command, _ []string) error {
 
 	// Use the registered site root as the working directory if cwd is inside one,
 	// otherwise fall back to cwd.
-	workDir := siteRootFor(cwd)
+	workDir := phpDet.SiteRootFor(cwd)
 
 	podman.EnsurePathMounted(workDir, version)
 	ensureServicesForCwd(workDir)
@@ -60,30 +58,4 @@ func runPhpShell(_ *cobra.Command, _ []string) error {
 		return err
 	}
 	return nil
-}
-
-// siteRootFor returns the registered site path that contains dir, or dir itself
-// if no registered site matches.
-func siteRootFor(dir string) string {
-	reg, err := config.LoadSites()
-	if err != nil {
-		return dir
-	}
-	// Normalise to clean absolute path for prefix matching.
-	dir = filepath.Clean(dir)
-	best := ""
-	for _, s := range reg.Sites {
-		sitePath := filepath.Clean(s.Path)
-		// dir == sitePath or dir is underneath sitePath
-		if dir == sitePath || strings.HasPrefix(dir, sitePath+string(filepath.Separator)) {
-			// Prefer the longest (most-specific) match.
-			if len(sitePath) > len(best) {
-				best = sitePath
-			}
-		}
-	}
-	if best != "" {
-		return best
-	}
-	return dir
 }

--- a/internal/cli/php_version_for_dir_test.go
+++ b/internal/cli/php_version_for_dir_test.go
@@ -37,6 +37,107 @@ func TestPHPVersionForDir_PrefersTheRegisteredSite(t *testing.T) {
 	}
 }
 
+// makeWorktree wires up the .git bookkeeping git itself writes for a worktree:
+// a .git file in the checkout and a gitdir pointer under the parent's
+// .git/worktrees, which is what ParentSiteForWorktreeDir reads.
+func makeWorktree(t *testing.T, sitePath, wtPath, branch string) {
+	t.Helper()
+	book := filepath.Join(sitePath, ".git", "worktrees", branch)
+	if err := os.MkdirAll(book, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(wtPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(book, "gitdir"), []byte(filepath.Join(wtPath, ".git")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtPath, ".git"), []byte("gitdir: "+book+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestPHPVersionForDir_NestedWorktreeOverride covers a worktree checked out inside
+// its parent site's directory. The site path matches by prefix, so without the
+// worktree check the parent's registry version wins and the CLI runs a different
+// PHP than the worktree's own vhost points at.
+func TestPHPVersionForDir_NestedWorktreeOverride(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	site := filepath.Join(t.TempDir(), "app")
+	wt := filepath.Join(site, "wt", "feature")
+	makeWorktree(t, site, wt, "feature")
+
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.5"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SetWorktreePHPVersion(wt, "8.3"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := phpVersionForDir(wt)
+	if err != nil {
+		t.Fatalf("phpVersionForDir: %v", err)
+	}
+	if got != "8.3" {
+		t.Errorf("phpVersionForDir = %q, want %q (the worktree's own pin)", got, "8.3")
+	}
+}
+
+// TestPHPVersionForDir_WorktreeSubdirOverride resolves from a directory inside the
+// worktree, since commands run from anywhere in the checkout.
+func TestPHPVersionForDir_WorktreeSubdirOverride(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	site := filepath.Join(t.TempDir(), "app")
+	wt := filepath.Join(site, "wt", "feature")
+	makeWorktree(t, site, wt, "feature")
+
+	sub := filepath.Join(wt, "app", "Http")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.5"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SetWorktreePHPVersion(wt, "8.3"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := phpVersionForDir(sub)
+	if err != nil {
+		t.Fatalf("phpVersionForDir: %v", err)
+	}
+	if got != "8.3" {
+		t.Errorf("phpVersionForDir = %q, want %q (the worktree's own pin)", got, "8.3")
+	}
+}
+
+// TestPHPVersionForDir_WorktreeInheritsParent keeps inherit-by-default working: a
+// worktree with no override of its own runs the parent site's version.
+func TestPHPVersionForDir_WorktreeInheritsParent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	site := filepath.Join(t.TempDir(), "app")
+	wt := filepath.Join(site, "wt", "feature")
+	makeWorktree(t, site, wt, "feature")
+
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.5"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := phpVersionForDir(wt)
+	if err != nil {
+		t.Fatalf("phpVersionForDir: %v", err)
+	}
+	if got != "8.5" {
+		t.Errorf("phpVersionForDir = %q, want %q (inherited from the parent site)", got, "8.5")
+	}
+}
+
 // TestPHPVersionForDir_FallsBackToDetection keeps the unlinked case working: a
 // directory that is not a registered site still resolves from the project itself.
 func TestPHPVersionForDir_FallsBackToDetection(t *testing.T) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4640,7 +4640,7 @@ func resolvePHPVersion(args map[string]any) (string, error) {
 		return v, nil
 	}
 	if defaultSitePath != "" {
-		if v, err := phpDet.DetectVersion(defaultSitePath); err == nil {
+		if v, err := phpDet.VersionForDir(defaultSitePath); err == nil {
 			return v, nil
 		}
 	}

--- a/internal/php/resolve.go
+++ b/internal/php/resolve.go
@@ -1,0 +1,87 @@
+package php
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// VersionForDir resolves the PHP version a directory's commands must run on.
+// This is the single answer the CLI, the MCP server and the version-scoped
+// tools all use, so a command can never exec into a different PHP than the
+// container serving the same directory.
+//
+// A worktree's own pin wins first: a worktree checked out inside its parent
+// site matches that site by path, so resolving the site first would ignore the
+// pin its vhost was generated from. A registered site's version comes next,
+// because lerd link clamps to the framework's supported range and re-detecting
+// would undo the clamp. Only then does the project's own configuration apply.
+func VersionForDir(dir string) (string, error) {
+	if wt, parent, ok := WorktreeRootFor(dir); ok {
+		return config.WorktreePHPVersion(wt, parent.PHPVersion), nil
+	}
+	if site, _ := config.FindSiteByPath(SiteRootFor(dir)); site != nil && site.PHPVersion != "" {
+		return site.PHPVersion, nil
+	}
+	version, err := DetectVersion(dir)
+	if err == nil {
+		return version, nil
+	}
+	cfg, cfgErr := config.LoadGlobal()
+	if cfgErr != nil {
+		return "", fmt.Errorf("cannot detect PHP version: %w", err)
+	}
+	return cfg.PHP.DefaultVersion, nil
+}
+
+// WorktreeRootFor returns the worktree checkout containing dir and the site it
+// belongs to. Git writes .git as a file in a worktree and as a directory in the
+// main checkout, so the walk stops at the first .git either way.
+func WorktreeRootFor(dir string) (string, *config.Site, bool) {
+	cur := filepath.Clean(dir)
+	for {
+		fi, err := os.Stat(filepath.Join(cur, ".git"))
+		if err == nil {
+			if fi.IsDir() {
+				return "", nil, false
+			}
+			if site, ok := config.ParentSiteForWorktreeDir(cur); ok {
+				return cur, site, true
+			}
+			return "", nil, false
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return "", nil, false
+		}
+		cur = parent
+	}
+}
+
+// SiteRootFor returns the registered site path that contains dir, or dir itself
+// if no registered site matches. Commands run from anywhere in a project, so
+// this walks up to the project root the site was registered at.
+func SiteRootFor(dir string) string {
+	reg, err := config.LoadSites()
+	if err != nil {
+		return dir
+	}
+	dir = filepath.Clean(dir)
+	best := ""
+	for _, s := range reg.Sites {
+		sitePath := filepath.Clean(s.Path)
+		if dir == sitePath || strings.HasPrefix(dir, sitePath+string(filepath.Separator)) {
+			// Prefer the longest (most-specific) match.
+			if len(sitePath) > len(best) {
+				best = sitePath
+			}
+		}
+	}
+	if best != "" {
+		return best
+	}
+	return dir
+}

--- a/internal/siteops/phpversion.go
+++ b/internal/siteops/phpversion.go
@@ -21,6 +21,7 @@ var (
 	imageGapFn         = imageGap
 	imageStaleFn       = podman.FPMImageStale
 	imageExistsFn      = podman.FPMImageExists
+	detectWorktreesFn  = gitpkg.DetectWorktrees
 
 	frameworkPHPRange = func(site *config.Site) (string, string) {
 		if site.Framework == "" {
@@ -209,7 +210,7 @@ func regenerateSiteVhost(site *config.Site, version string) error {
 // just that worktree's vhost, so the next request lands on the new FPM upstream.
 // The parent site's own version is untouched.
 func setWorktreePHPVersion(site *config.Site, branch, version string) error {
-	worktrees, err := gitpkg.DetectWorktrees(site.Path, site.PrimaryDomain())
+	worktrees, err := detectWorktreesFn(site.Path, site.PrimaryDomain())
 	if err != nil {
 		return fmt.Errorf("detecting worktrees: %w", err)
 	}
@@ -223,6 +224,12 @@ func setWorktreePHPVersion(site *config.Site, branch, version string) error {
 		if err := config.SetWorktreePHPVersion(wt.Path, version); err != nil {
 			return fmt.Errorf("updating .lerd.yaml: %w", err)
 		}
+		// Same runtime setup the site path does: the vhost below points at the
+		// version's FPM container, which need not exist on this machine yet.
+		if err := podman.WriteFPMQuadlet(version); err == nil {
+			_ = podman.DaemonReloadFn()
+		}
+		_ = podman.EnsureXdebugIni(version)
 		if site.Secured {
 			err = nginx.GenerateWorktreeSSLVhost(wt.Domain, wt.Path, version, site.PrimaryDomain(), site.Name, wt.Branch)
 		} else {
@@ -231,8 +238,13 @@ func setWorktreePHPVersion(site *config.Site, branch, version string) error {
 		if err != nil {
 			return fmt.Errorf("regenerating worktree vhost: %w", err)
 		}
+		_ = podman.RewriteFPMQuadlets()
+		_ = podman.WriteContainerHosts()
 		if err := nginxReloadFn(); err != nil {
 			return fmt.Errorf("reloading nginx: %w", err)
+		}
+		if podman.AfterUnitChange != nil {
+			podman.AfterUnitChange("site:" + site.Name)
 		}
 		return nil
 	}

--- a/internal/siteops/phpversion_test.go
+++ b/internal/siteops/phpversion_test.go
@@ -4,10 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
+	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/podman"
 )
 
@@ -352,5 +354,59 @@ func TestSetSitePHPVersion_keepsFrankenPHPOnSupportedVersion(t *testing.T) {
 	}
 	if site.Runtime != "frankenphp" {
 		t.Errorf("site.Runtime = %q, want frankenphp", site.Runtime)
+	}
+}
+
+// A worktree switch generates a vhost pointing at the target version's FPM
+// container, so it has to write that version's quadlet and notify open
+// dashboards exactly like the site path does. Without it the vhost can point at
+// a container that was never created on this machine.
+func TestSetSitePHPVersion_worktreeDoesTheSameRuntimeSetup(t *testing.T) {
+	site := phpVersionTestSite(t, asFPM)
+	stubPHPVersionDeps(t, "", "")
+
+	wtPath := filepath.Join(site.Path, "wt", "feature")
+	if err := os.MkdirAll(wtPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origDetect := detectWorktreesFn
+	origDR := podman.DaemonReloadFn
+	origNotify := podman.AfterUnitChange
+	t.Cleanup(func() {
+		detectWorktreesFn = origDetect
+		podman.DaemonReloadFn = origDR
+		podman.AfterUnitChange = origNotify
+	})
+
+	detectWorktreesFn = func(string, string) ([]gitpkg.Worktree, error) {
+		return []gitpkg.Worktree{{Name: "feature", Branch: "feature", Path: wtPath, Domain: "feature.app.test"}}, nil
+	}
+	reloaded := 0
+	podman.DaemonReloadFn = func() error { reloaded++; return nil }
+	var notified []string
+	podman.AfterUnitChange = func(name string) { notified = append(notified, name) }
+
+	if _, err := SetSitePHPVersion(site, "8.3", PHPVersionOpts{Branch: "feature"}); err != nil {
+		t.Fatalf("SetSitePHPVersion: %v", err)
+	}
+
+	if reloaded == 0 {
+		t.Error("worktree switch did not write the target version's FPM quadlet")
+	}
+	if !slices.Contains(notified, "site:app") {
+		t.Errorf("AfterUnitChange notifications = %v, want one for site:app", notified)
+	}
+
+	// The parent site keeps its own version; the override travels with the branch.
+	stored, err := config.FindSite("app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.PHPVersion != "8.4" {
+		t.Errorf("parent site PHPVersion = %q, want 8.4 (unchanged)", stored.PHPVersion)
+	}
+	if got := config.WorktreePHPVersion(wtPath, stored.PHPVersion); got != "8.3" {
+		t.Errorf("worktree version = %q, want 8.3", got)
 	}
 }


### PR DESCRIPTION
A git worktree checked out inside its parent site's directory matched that site by path prefix, so the CLI resolved the parent's registry version and never looked at the worktree's own pin. The worktree's nginx vhost was generated from the pin, so the browser served the branch on one PHP version while `lerd php` and `lerd composer` in that same directory ran another. Sibling checkouts outside the site path were unaffected, which is why this went unnoticed for so long.

Worktrees now resolve ahead of the containing site, from anywhere inside the checkout. Inherit-by-default is unchanged: a worktree with no pin of its own still follows the parent, and a registered site still wins over its own dotfiles, so the framework clamp applied at link time is never undone.

Switching a worktree's version also runs the same runtime setup a site switch does. It previously wrote only the pins and the vhost, so moving a branch onto a version with no quadlet on the machine produced a vhost pointing at a container that was never created, no xdebug ini for that version, and no notification to open dashboards.

The rules now live in `internal/php` as `VersionForDir`, with `SiteRootFor` and `WorktreeRootFor` alongside. The CLI and the MCP server both delegate to it, so the version a command runs on and the version its container serves cannot drift apart again. The MCP resolver in particular never consulted the site registry before, so its version scoped tools could disagree with the CLI on a site whose registry version had been clamped away from its `.php-version`.

Refs #988
Refs #989
Closes #990
