### PR TITLE
fix(php): exec a worktree into its site's own FPM image

### DIFF
--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -163,6 +163,8 @@ The override is honoured wherever lerd materialises worktree state on disk: vhos
 
 Site-level resources stay shared and cannot be overridden per worktree: domain (derived from the parent), TLS certificate (parent's wildcard cert), LAN share port (worktree-scoped LAN share is a separate toggle), workers, and any custom container settings.
 
+On a site running its own per-site image (`runtime: fpm-custom`, built from a project Containerfile), a worktree is served from that image rather than the shared per-version container, and `lerd php` and `lerd composer` inside the checkout exec into it too. Whatever the Containerfile adds is therefore present on the branch exactly as it is on the parent, wherever the checkout lives.
+
 ### Per-worktree database
 
 By default every worktree shares the parent site's database. The dashboard's **Isolated DB** toggle and the `lerd worktree add` prompt opt the worktree into its own schema, named `<parent_db>_<sanitized_branch>` in the same service the parent uses (mysql, mariadb, or postgres). The worktree's env file is rewritten so its database-name key points at the new schema, and `db_isolated: true` is persisted to the worktree's `.lerd.yaml` so the choice travels with the branch. The env file, its format and the host/name keys are resolved from the framework definition, so Laravel's `DB_DATABASE` in `.env` and Magento's `db.connection.default.dbname` in `app/etc/env.php` are rewritten the same way.

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -69,11 +69,13 @@ func phpVersionForDir(dir string) (string, error) {
 
 // fpmContainerForDir resolves the FPM container an exec in dir should target:
 // the per-site container for custom-FPM sites, otherwise the shared
-// lerd-php<version>-fpm container. dir may be a subdirectory of the project, so
-// it resolves the containing site root first (matching version detection, which
-// also walks up), otherwise a custom-FPM exec from a subdir would wrongly hit
-// the shared container.
+// lerd-php<version>-fpm container. It resolves the site the same way version
+// detection does, so a worktree beside its project reaches the parent's custom
+// image rather than falling through to the shared container its vhost never uses.
 func fpmContainerForDir(dir, version string) string {
+	if _, parent, ok := phpDet.WorktreeRootFor(dir); ok {
+		return podman.FPMContainerName(*parent, version)
+	}
 	if site, _ := config.FindSiteByPath(phpDet.SiteRootFor(dir)); site != nil {
 		return podman.FPMContainerName(*site, version)
 	}

--- a/internal/cli/php_version_for_dir_test.go
+++ b/internal/cli/php_version_for_dir_test.go
@@ -160,3 +160,47 @@ func TestPHPVersionForDir_FallsBackToDetection(t *testing.T) {
 		t.Errorf("phpVersionForDir = %q, want %q", got, "8.1")
 	}
 }
+
+// TestFPMContainerForDir_SiblingWorktreeOfCustomFPMSite covers a worktree checked
+// out beside its project rather than inside it. It matches no registered site
+// path, so without resolving the worktree's parent the exec falls back to the
+// shared container and loses the per-site image the site is actually served from.
+func TestFPMContainerForDir_SiblingWorktreeOfCustomFPMSite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	root := t.TempDir()
+	site := filepath.Join(root, "app")
+	wt := filepath.Join(root, "app-feature")
+	makeWorktree(t, site, wt, "feature")
+
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.4", Runtime: "fpm-custom"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := fpmContainerForDir(wt, "8.4")
+	if want := "lerd-cfpm-app"; got != want {
+		t.Errorf("fpmContainerForDir = %q, want %q (the site's own image, which its vhost uses)", got, want)
+	}
+}
+
+// TestFPMContainerForDir_SiblingWorktreeOfSharedFPMSite keeps the ordinary case
+// on the shared per-version container.
+func TestFPMContainerForDir_SiblingWorktreeOfSharedFPMSite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	root := t.TempDir()
+	site := filepath.Join(root, "app")
+	wt := filepath.Join(root, "app-feature")
+	makeWorktree(t, site, wt, "feature")
+
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.4"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := fpmContainerForDir(wt, "8.4")
+	if want := "lerd-php84-fpm"; got != want {
+		t.Errorf("fpmContainerForDir = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
A worktree checked out beside its project matches no registered site path, so the container lookup missed and fell back to the shared per-version container. On a site running its own image built from a project Containerfile that is the wrong runtime, since nothing the Containerfile adds is present there. Commands that depend on it failed in the branch while working fine in the parent checkout.

The worktree's vhost never had this problem. It resolves the parent through `config.FindSite` by name and hands the full site to `podman.FPMContainerName`, so it correctly selects the per-site container. The browser therefore served the branch from the site's own image while the terminal ran against the shared one.

A worktree nested inside the project happened to work, because the path prefix found the parent and carried its runtime along. That asymmetry is what pointed at the lookup being wrong rather than the fallback, so the container is now resolved from the worktree's parent, the same view of the directory the version resolution already uses.

Validated against a Laravel site linked as `fpm-custom` whose Containerfile stamps a marker into the per-site image, with a sibling worktree. Before, the worktree's vhost pointed at `lerd-cfpm-<site>` while the CLI reported the marker missing; after, both agree. A nested worktree on an ordinary shared-FPM site still resolves to the shared container.

Closes #1000
