### PR TITLE
feat(mcp): let the db tool list the databases an engine holds

### DIFF
--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -122,7 +122,7 @@ The MCP surface is **twelve grouped tools**, each driven by an `action` argument
 |---|---|
 | `site` | `list` (discover sites — call first), `link`, `unlink`, `domain_add`, `domain_remove`, `group_assign`, `group_unassign`, `group_label`, `group_db`, `group_list`, `tls_enable`, `tls_disable`, `tls_renew`, `php`, `node`, `pause`, `unpause`, `restart`, `rebuild`, `runtime`, `nginx_read`, `nginx_write`, `nginx_reset`, `park`, `unpark` |
 | `service` | `start`, `stop`, `restart`, `pin`, `unpin`, `update`, `rollback`, `migrate`, `remove`, `reinstall`, `add`, `expose`, `port`, `env`, `config_read`, `config_write`, `config_restore`, `config_reset`, `config_list_backups`, `preset_list`, `preset_search`, `preset_install`, `check_updates` |
-| `db` | `set`, `move`, `create`, `export`, `import`, `snapshot`, `snapshots`, `restore`, `snapshot_delete` |
+| `db` | `list`, `set`, `move`, `create`, `export`, `import`, `snapshot`, `snapshots`, `restore`, `snapshot_delete` |
 | `env` | `setup`, `check`, `override` |
 | `runtime` | `versions`, `node_install`, `node_uninstall`, `php_list`, `ext_list`, `ext_add`, `ext_remove`, `ports_list`, `ports_add`, `ports_remove`, `ini_read`, `ini_write`, `ini_reset` |
 | `worker` | `list` (call first), `start`, `stop`, `add`, `remove`, `health`, `heal`, `mode_get`, `mode_set`, `queue_start`, `queue_stop`, `horizon_start`, `horizon_stop`, `reverb_start`, `reverb_stop`, `schedule_start`, `schedule_stop`, `stripe_start`, `stripe_stop`, `stripe_config` |

--- a/internal/cli/aidocs/lerd-reference.md
+++ b/internal/cli/aidocs/lerd-reference.md
@@ -53,7 +53,8 @@ Actions: `start`, `stop`, `restart`, `pin`, `unpin`, `update`, `rollback`, `migr
 - `config_*` read/write/restore/reset a service's runtime tuning override
 
 #### `db` — databases
-Actions: `set`, `move`, `create`, `export`, `import`, `snapshot`, `snapshots`, `restore`, `snapshot_delete`.
+Actions: `list`, `set`, `move`, `create`, `export`, `import`, `snapshot`, `snapshots`, `restore`, `snapshot_delete`.
+- `list` reports the databases an engine holds, with their sizes; pass `service` to pick the engine, otherwise it resolves from the project the same way the other actions do. An engine whose preset declares no introspection reports nothing
 - `set` picks the project DB (`database`: sqlite, mysql, postgres, or a family alternate like mariadb / postgres-pgvector / postgres-timescaledb / mysql-5-7); persists to `.lerd.yaml`, rewrites `DB_` keys, starts the service, creates the DB + `_testing`
 - `move` migrates sites between two installed same-family services (`from`/`to`, `sites: [...]` or `all: true`) and repoints each `.env`; source data is left intact
 - `create`/`export`/`import` auto-detect service and database; pass `service` to override

--- a/internal/cli/aidocs/lerd-reference.md
+++ b/internal/cli/aidocs/lerd-reference.md
@@ -54,7 +54,7 @@ Actions: `start`, `stop`, `restart`, `pin`, `unpin`, `update`, `rollback`, `migr
 
 #### `db` — databases
 Actions: `list`, `set`, `move`, `create`, `export`, `import`, `snapshot`, `snapshots`, `restore`, `snapshot_delete`.
-- `list` reports the databases an engine holds, with their sizes; pass `service` to pick the engine, otherwise it resolves from the project the same way the other actions do. An engine whose preset declares no introspection reports nothing
+- `list` reports an engine's databases with sizes; `service` picks the engine, else it resolves from the project. No introspect command, nothing to report
 - `set` picks the project DB (`database`: sqlite, mysql, postgres, or a family alternate like mariadb / postgres-pgvector / postgres-timescaledb / mysql-5-7); persists to `.lerd.yaml`, rewrites `DB_` keys, starts the service, creates the DB + `_testing`
 - `move` migrates sites between two installed same-family services (`from`/`to`, `sites: [...]` or `all: true`) and repoints each `.env`; source data is left intact
 - `create`/`export`/`import` auto-detect service and database; pass `service` to override

--- a/internal/mcp/db_list_test.go
+++ b/internal/mcp/db_list_test.go
@@ -1,0 +1,33 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestExecDBList_noIntrospectCommand asserts an engine whose preset declares no
+// introspection reports that rather than erroring or reaching for a container.
+func TestExecDBList_noIntrospectCommand(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	res, rpcErr := execDBList(map[string]any{"service": "nosuchengine"})
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	text := resultText(t, res)
+	if !strings.Contains(text, "no database introspection") {
+		t.Errorf("got %q, want a no-introspection report", text)
+	}
+}
+
+// TestExecDBList_requiresATarget asserts list refuses to guess when neither a
+// service nor a resolvable project is given.
+func TestExecDBList_requiresATarget(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	res, rpcErr := execDBList(map[string]any{"path": t.TempDir()})
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+	if text := resultText(t, res); !strings.Contains(text, "service") {
+		t.Errorf("got %q, want guidance to pass a service", text)
+	}
+}

--- a/internal/mcp/groups.go
+++ b/internal/mcp/groups.go
@@ -130,6 +130,7 @@ var groupDispatch = map[string]map[string]handlerFn{
 		"check_updates":       execServiceCheckUpdates,
 	},
 	"db": {
+		"list":            execDBList,
 		"set":             execDbSet,
 		"move":            execDbMove,
 		"create":          execDBCreate,
@@ -365,11 +366,11 @@ func serviceTool() mcpTool {
 func dbTool() mcpTool {
 	return mcpTool{
 		Name:        "db",
-		Description: "Database operations. action: set (pick sqlite/mysql/postgres/family alternate), move (between same-family services), create, export, import, snapshot, snapshots, restore (destructive), snapshot_delete.",
+		Description: "Database operations. action: list (an engine's databases), set (pick sqlite/mysql/postgres/family alternate), move (between same-family services), create, export, import, snapshot, snapshots, restore (destructive), snapshot_delete.",
 		InputSchema: mcpSchema{
 			Type: "object",
 			Properties: map[string]mcpProp{
-				"action":        {Type: "string", Enum: []string{"set", "move", "create", "export", "import", "snapshot", "snapshots", "restore", "snapshot_delete"}},
+				"action":        {Type: "string", Enum: []string{"list", "set", "move", "create", "export", "import", "snapshot", "snapshots", "restore", "snapshot_delete"}},
 				"path":          {Type: "string", Description: "Project root. Defaults to cwd."},
 				"database":      {Type: "string", Description: "set: target db engine. Others: db name (defaults DB_DATABASE)."},
 				"from":          {Type: "string", Description: "move: source service."},
@@ -379,7 +380,7 @@ func dbTool() mcpTool {
 				"file":          {Type: "string", Description: "import: SQL dump path."},
 				"output":        {Type: "string", Description: "export: output file (default <database>.sql)."},
 				"name":          {Type: "string", Description: "snapshot/restore/snapshot_delete: snapshot name. create: db name."},
-				"service":       {Type: "string", Description: "snapshot ops: DB service override."},
+				"service":       {Type: "string", Description: "list/snapshot: DB service override."},
 				"all_databases": {Type: "boolean", Description: "snapshot ops: cover whole service."},
 			},
 			Required: []string{"action"},

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4302,6 +4302,26 @@ func execDBSnapshots(args map[string]any) (any, *rpcError) {
 	return toolOK(string(data)), nil
 }
 
+func execDBList(args map[string]any) (any, *rpcError) {
+	target, err := mcpSnapshotTarget(args)
+	if err != nil {
+		return toolErr(err.Error()), nil
+	}
+	command := serviceops.IntrospectCommand(target.Service)
+	if command == "" {
+		return toolOK(fmt.Sprintf("%s declares no database introspection, so its databases cannot be listed", target.Service)), nil
+	}
+	dbs, err := serviceops.ListDatabases(target.Service, command)
+	if err != nil {
+		return toolErr(err.Error()), nil
+	}
+	if len(dbs) == 0 {
+		return toolOK(fmt.Sprintf("%s holds no user databases", target.Service)), nil
+	}
+	data, _ := json.MarshalIndent(dbs, "", "  ")
+	return toolOK(string(data)), nil
+}
+
 func execDBRestore(args map[string]any) (any, *rpcError) {
 	name := strArg(args, "name")
 	if name == "" {

--- a/internal/serviceops/databases.go
+++ b/internal/serviceops/databases.go
@@ -31,6 +31,26 @@ type DatabaseInfo struct {
 // picks whichever variable applies and ignores the rest.
 func introspectEnv() []string { return []string{"MYSQL_PWD=lerd", "PGPASSWORD=lerd"} }
 
+// IntrospectCommand resolves an engine's list-databases query, preferring the
+// preset it was installed from so an engine installed before the introspect
+// field existed still gets it from the current preset. Falls back to the stored
+// definition for a genuinely user-defined engine.
+func IntrospectCommand(service string) string {
+	presetName := service
+	if custom, err := config.LoadCustomService(service); err == nil {
+		if custom.Introspect != nil {
+			return custom.Introspect.ListDatabases
+		}
+		if custom.Preset != "" {
+			presetName = custom.Preset
+		}
+	}
+	if p, err := config.LoadPreset(presetName); err == nil && p.Introspect != nil {
+		return p.Introspect.ListDatabases
+	}
+	return ""
+}
+
 // ListDatabases runs the preset-declared introspection command inside the
 // service container and parses its "name<TAB>size_bytes" rows. The command is
 // engine-specific and lives in the service store, so this stays framework

--- a/internal/serviceops/databases_test.go
+++ b/internal/serviceops/databases_test.go
@@ -1,6 +1,10 @@
 package serviceops
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestParseDatabaseRows(t *testing.T) {
 	out := "laravel_app\t25690112\nwordpress\t18979224\nempty\t0\n"
@@ -38,6 +42,44 @@ func TestParseDatabaseRowsNameOnly(t *testing.T) {
 	got := parseDatabaseRows([]byte("analytics\nmetrics\n"))
 	if len(got) != 2 || got[0].Name != "analytics" || got[0].SizeBytes != 0 {
 		t.Fatalf("unexpected parse: %+v", got)
+	}
+}
+
+// writeCustomService drops a service YAML into an isolated config dir so
+// introspect resolution can be exercised without touching the real install.
+func writeCustomService(t *testing.T, name, body string) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	dir := filepath.Join(tmp, "lerd", "services")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".yaml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestIntrospectCommandFromCustomService(t *testing.T) {
+	writeCustomService(t, "myengine", "name: myengine\nimage: example/engine:1\nintrospect:\n  list_databases: echo hi\n")
+	if got := IntrospectCommand("myengine"); got != "echo hi" {
+		t.Fatalf("got %q, want %q", got, "echo hi")
+	}
+}
+
+func TestIntrospectCommandFallsBackToPreset(t *testing.T) {
+	// An engine installed before the introspect field existed carries no
+	// introspect block of its own, so the preset it came from supplies it.
+	writeCustomService(t, "mysql", "name: mysql\nimage: docker.io/library/mysql:8\npreset: mysql\n")
+	if IntrospectCommand("mysql") == "" {
+		t.Fatal("want the bundled mysql preset command, got none")
+	}
+}
+
+func TestIntrospectCommandUnknownEngine(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if got := IntrospectCommand("nosuchengine"); got != "" {
+		t.Fatalf("want empty, got %q", got)
 	}
 }
 

--- a/internal/ui/databases.go
+++ b/internal/ui/databases.go
@@ -131,7 +131,7 @@ func databaseEngine(name string) dbEngineResponse {
 	if base.Status != "active" {
 		return eng
 	}
-	command := introspectCommand(name)
+	command := serviceops.IntrospectCommand(name)
 	if command == "" {
 		return eng
 	}
@@ -156,26 +156,6 @@ func databaseEngine(name string) dbEngineResponse {
 		eng.Databases = append(eng.Databases, entry)
 	}
 	return eng
-}
-
-// introspectCommand resolves the engine's list-databases query, preferring the
-// preset it was installed from so an engine installed before the introspect
-// field existed still gets it from the current preset. Falls back to the stored
-// definition for a genuinely user-defined engine.
-func introspectCommand(name string) string {
-	presetName := name
-	if custom, err := config.LoadCustomService(name); err == nil {
-		if custom.Introspect != nil {
-			return custom.Introspect.ListDatabases
-		}
-		if custom.Preset != "" {
-			presetName = custom.Preset
-		}
-	}
-	if p, err := config.LoadPreset(presetName); err == nil && p.Introspect != nil {
-		return p.Introspect.ListDatabases
-	}
-	return ""
 }
 
 // handleDatabases lists every installed database engine and its databases.


### PR DESCRIPTION
The dashboard gained database introspection in #966, so an engine's service page lists what is inside the running container, driven by an introspect.list_databases command declared in the engine's service preset. The MCP db tool never picked that capability up, so an assistant could act on a database whose name it already knew but could not ask what an engine actually holds. It was the one database operation the browser could do that an agent could not.

The new list action reuses that introspection rather than growing a second path. It resolves the engine the same way the snapshot actions already do, so service picks one explicitly and omitting it falls back to the project's own database. An engine whose preset declares no introspect command reports nothing instead of erroring, so coverage grows as the field ships to the store engines.

The command resolver moved out of the ui package into serviceops so the dashboard and the tool share it. The MCP reference and the mcp docs page both carry the action list, so they move with it.

Closes #986