### PR TITLE
fix(db): validate database names before they reach path and SQL sinks

### DIFF
--- a/docs/usage/database.md
+++ b/docs/usage/database.md
@@ -42,7 +42,7 @@ A named snapshot (`lerd db:snapshot nightly`) gets a UTC timestamp appended to i
 
 Each database engine's detail page in the web UI (Services → pick MySQL, MariaDB, PostgreSQL or MongoDB) opens on a **Databases** tab that shows the databases inside that engine as a grid of cards, each with its on-disk size. It surfaces the same operations as the CLI without leaving the browser:
 
-- **Create** a database inline from the field above the grid.
+- **Create** a database inline from the field above the grid. Names accepted here are limited to letters, digits, underscores and dashes, up to 64 characters, which covers every name lerd generates and keeps the value safe to use as both a path segment and a SQL identifier.
 - **Export** a database to a `.sql` dump, or **import** a dump into one, from the card.
 - **Snapshots** are managed on the card of the database they belong to: take a snapshot, restore one (with a confirmation, since a restore overwrites the current data), delete one (also confirmed), or download one as a plain `.sql` dump. A snapshot is keyed on the engine and database it was taken from, never on a site, so it lives with the database rather than on the site page. A named snapshot gets a UTC timestamp appended (`nightly-20260719-135558`), so repeated snapshots of one name never collide; the list shows the parsed time and sorts newest first.
 - **Copy connection string** builds a ready-to-paste DSN for that specific database, which works whether or not an admin UI is installed.

--- a/internal/serviceops/databases.go
+++ b/internal/serviceops/databases.go
@@ -132,10 +132,17 @@ func ExportDatabase(service, database string, w io.Writer) error {
 // ExportSnapshot streams a snapshot's stored dump to w, decompressed, so it
 // downloads as a plain .sql the same as a live export rather than a .gz.
 func ExportSnapshot(service, database, name string, w io.Writer) error {
-	dumpPath := filepath.Join(snapshotDir(service, database, name, false), snapshotDumpFile)
-	f, err := os.Open(dumpPath)
+	if err := ValidateDatabaseName(database); err != nil {
+		return err
+	}
+	clean, err := sanitizeSnapshotName(name)
 	if err != nil {
-		return fmt.Errorf("opening snapshot: %w", err)
+		return err
+	}
+	dumpPath := filepath.Join(snapshotDir(service, database, clean, false), snapshotDumpFile)
+	f, openErr := os.Open(dumpPath)
+	if openErr != nil {
+		return fmt.Errorf("opening snapshot: %w", openErr)
 	}
 	defer f.Close()
 	gz, err := gzip.NewReader(f)

--- a/internal/serviceops/provision.go
+++ b/internal/serviceops/provision.go
@@ -3,6 +3,7 @@ package serviceops
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -18,6 +19,39 @@ import (
 func escapeIdentBacktick(name string) string { return strings.ReplaceAll(name, "`", "``") }
 func escapeIdentDQuote(name string) string   { return strings.ReplaceAll(name, `"`, `""`) }
 func escapeSQLLiteral(v string) string       { return strings.ReplaceAll(v, "'", "''") }
+
+// escapeMySQLLiteral is escapeSQLLiteral for MySQL and MariaDB, which treat a
+// backslash as an escape character unless NO_BACKSLASH_ESCAPES is set. Doubling
+// the backslash first stops `\'` from escaping the doubled quote and ending the
+// literal. PostgreSQL keeps escapeSQLLiteral: standard_conforming_strings makes
+// a backslash ordinary, so doubling it there would corrupt the value.
+func escapeMySQLLiteral(v string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(v, `\`, `\\`), "'", "''")
+}
+
+// databaseNamePattern is the strict shape a database name must have to reach a
+// path or SQL sink: it must start with a letter, digit or underscore and carry
+// only those plus dashes, which covers every name lerd generates while excluding
+// path separators, dot segments and every SQL metacharacter.
+var databaseNamePattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_-]*$`)
+
+// maxDatabaseNameLen is MySQL's identifier limit, the tighter of the two engines.
+const maxDatabaseNameLen = 64
+
+// ValidateDatabaseName guards the sinks that assume a slugged name: the snapshot
+// paths built with filepath.Join and the information_schema lookups built by
+// string interpolation.
+func ValidateDatabaseName(name string) error {
+	switch {
+	case name == "":
+		return fmt.Errorf("a database name is required")
+	case len(name) > maxDatabaseNameLen:
+		return fmt.Errorf("database name is longer than %d characters", maxDatabaseNameLen)
+	case !databaseNamePattern.MatchString(name):
+		return fmt.Errorf("invalid database name %q: use letters, digits, underscores and dashes only", name)
+	}
+	return nil
+}
 
 // CreateDatabase creates dbName inside the named service container if it does
 // not already exist. svc is the service name (e.g. "mysql", "mysql-5-6",
@@ -40,7 +74,7 @@ func CreateDatabase(svc, name string) (bool, error) {
 		var lastErr error
 		for _, bin := range binaries {
 			check := podman.Cmd("exec", container, bin, "-uroot", "-plerd",
-				"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", escapeSQLLiteral(name)))
+				"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", escapeMySQLLiteral(name)))
 			out, err := check.Output()
 			if err != nil {
 				lastErr = err
@@ -95,7 +129,7 @@ func DropDatabase(svc, name string) (bool, error) {
 		var lastErr error
 		for _, bin := range binaries {
 			check := podman.Cmd("exec", container, bin, "-uroot", "-plerd",
-				"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", escapeSQLLiteral(name)))
+				"-sNe", fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name='%s';", escapeMySQLLiteral(name)))
 			out, err := check.Output()
 			if err != nil {
 				lastErr = err

--- a/internal/serviceops/provision_test.go
+++ b/internal/serviceops/provision_test.go
@@ -1,6 +1,9 @@
 package serviceops
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // These guard the DB identifier/literal quoting used by CreateDatabase and
 // DropDatabase. A worktree DB name derives from a git branch, and git allows
@@ -43,5 +46,53 @@ func TestEscapeSQLLiteral(t *testing.T) {
 		if got := escapeSQLLiteral(tc.in); got != tc.want {
 			t.Errorf("escapeSQLLiteral(%q) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+// MySQL treats a backslash as an escape character unless NO_BACKSLASH_ESCAPES is
+// set, so doubling only the quote lets `\'` slip a quote through and end the
+// literal. The backslash has to be doubled first.
+func TestEscapeMySQLLiteral(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"acme_app", "acme_app"},
+		{"a'b", "a''b"},
+		{`a\b`, `a\\b`},
+		{`\' UNION SELECT 1; -- `, `\\'' UNION SELECT 1; -- `},
+	}
+	for _, tc := range cases {
+		if got := escapeMySQLLiteral(tc.in); got != tc.want {
+			t.Errorf("escapeMySQLLiteral(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestValidateDatabaseName(t *testing.T) {
+	valid := []string{"acme_app", "acme_app_testing", "app2", "_private", "my-db", "A1"}
+	for _, name := range valid {
+		if err := ValidateDatabaseName(name); err != nil {
+			t.Errorf("ValidateDatabaseName(%q) = %v, want nil", name, err)
+		}
+	}
+
+	// Traversal segments, path separators and every SQL metacharacter must be
+	// rejected before they reach filepath.Join or an interpolated statement.
+	invalid := []string{
+		"", "..", ".", ".hidden",
+		"../../../../../../home/george/Code",
+		"a/b", `a\b`, "a'b", "a\"b", "a`b", "a;b", "a b", "a.b",
+		"-leading-dash", "naÏve", "app$", "app%",
+	}
+	for _, name := range invalid {
+		if err := ValidateDatabaseName(name); err == nil {
+			t.Errorf("ValidateDatabaseName(%q) = nil, want an error", name)
+		}
+	}
+
+	// MySQL caps identifiers at 64 characters.
+	if err := ValidateDatabaseName(strings.Repeat("a", 64)); err != nil {
+		t.Errorf("64 characters should be accepted: %v", err)
+	}
+	if err := ValidateDatabaseName(strings.Repeat("a", 65)); err == nil {
+		t.Error("65 characters should be rejected")
 	}
 }

--- a/internal/serviceops/snapshot.go
+++ b/internal/serviceops/snapshot.go
@@ -247,6 +247,11 @@ func ListSnapshots(service, database string, includeAll bool) ([]Snapshot, error
 // DeleteSnapshot removes a stored snapshot, erroring when it does not exist so
 // callers can report the miss clearly.
 func DeleteSnapshot(service, database, name string, allDatabases bool) error {
+	if !allDatabases {
+		if err := ValidateDatabaseName(database); err != nil {
+			return err
+		}
+	}
 	clean, err := sanitizeSnapshotName(name)
 	if err != nil {
 		return err
@@ -267,6 +272,11 @@ func DeleteSnapshot(service, database, name string, allDatabases bool) error {
 func CreateSnapshot(t SnapshotTarget, name string, ctx SnapshotMeta, emit func(PhaseEvent)) (*Snapshot, error) {
 	if emit == nil {
 		emit = func(PhaseEvent) {}
+	}
+	if !t.AllDatabases {
+		if err := ValidateDatabaseName(t.Database); err != nil {
+			return nil, err
+		}
 	}
 	dumpCmd, err := snapshotDumpCommand(t)
 	if err != nil {
@@ -345,6 +355,11 @@ func CreateSnapshot(t SnapshotTarget, name string, ctx SnapshotMeta, emit func(P
 func RestoreSnapshot(t SnapshotTarget, name string, emit func(PhaseEvent)) error {
 	if emit == nil {
 		emit = func(PhaseEvent) {}
+	}
+	if !t.AllDatabases {
+		if err := ValidateDatabaseName(t.Database); err != nil {
+			return err
+		}
 	}
 	restoreCmd, err := snapshotRestoreCommand(t)
 	if err != nil {

--- a/internal/serviceops/snapshot_test.go
+++ b/internal/serviceops/snapshot_test.go
@@ -214,6 +214,31 @@ func TestDeleteSnapshot(t *testing.T) {
 	}
 }
 
+// TestDeleteSnapshotRejectsTraversalDatabase pins the path-traversal fix: the
+// database segment is joined straight into the snapshot path, so a traversing
+// value would resolve outside the snapshot root and hand a real project
+// directory to os.RemoveAll.
+func TestDeleteSnapshotRejectsTraversalDatabase(t *testing.T) {
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+
+	victim := filepath.Join(data, "precious")
+	if err := os.MkdirAll(filepath.Join(victim, "src"), 0o755); err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+
+	rel, err := filepath.Rel(filepath.Join(config.SnapshotsDir(), "postgres", "databases"), victim)
+	if err != nil {
+		t.Fatalf("rel: %v", err)
+	}
+	if err := DeleteSnapshot("postgres", rel, "src", false); err == nil {
+		t.Error("traversing database name was accepted")
+	}
+	if _, err := os.Stat(filepath.Join(victim, "src")); err != nil {
+		t.Errorf("victim directory was removed: %v", err)
+	}
+}
+
 func TestSnapshotDumpCommand(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/ui/databases.go
+++ b/internal/ui/databases.go
@@ -270,10 +270,19 @@ func decodeDBBody(r *http.Request) (database, name string, ok bool) {
 	return strings.TrimSpace(body.Database), strings.TrimSpace(body.Name), true
 }
 
+// requireDatabaseName rejects a database name that could escape its snapshot
+// path or its SQL quoting, so nothing unvalidated reaches serviceops.
+func requireDatabaseName(w http.ResponseWriter, database string) bool {
+	if err := serviceops.ValidateDatabaseName(database); err != nil {
+		writeDBError(w, err.Error())
+		return false
+	}
+	return true
+}
+
 func handleDatabaseCreate(w http.ResponseWriter, r *http.Request, service string) {
 	_, name, ok := decodeDBBody(r)
-	if !ok || name == "" {
-		writeDBError(w, "a database name is required")
+	if !ok || !requireDatabaseName(w, name) {
 		return
 	}
 	created, err := serviceops.CreateDatabase(service, name)
@@ -290,8 +299,7 @@ func handleDatabaseCreate(w http.ResponseWriter, r *http.Request, service string
 
 func handleDatabaseDrop(w http.ResponseWriter, r *http.Request, service string) {
 	_, name, ok := decodeDBBody(r)
-	if !ok || name == "" {
-		writeDBError(w, "a database name is required")
+	if !ok || !requireDatabaseName(w, name) {
 		return
 	}
 	if _, err := serviceops.DropDatabase(service, name); err != nil {
@@ -303,8 +311,7 @@ func handleDatabaseDrop(w http.ResponseWriter, r *http.Request, service string) 
 
 func handleSnapshotCreate(w http.ResponseWriter, r *http.Request, service string) {
 	database, name, ok := decodeDBBody(r)
-	if !ok || database == "" {
-		writeDBError(w, "a database is required")
+	if !ok || !requireDatabaseName(w, database) {
 		return
 	}
 	target := serviceops.SnapshotTarget{Service: service, Family: config.FamilyOfName(service), Database: database}
@@ -317,8 +324,11 @@ func handleSnapshotCreate(w http.ResponseWriter, r *http.Request, service string
 
 func handleSnapshotRestore(w http.ResponseWriter, r *http.Request, service string) {
 	database, name, ok := decodeDBBody(r)
-	if !ok || database == "" || name == "" {
+	if !ok || name == "" {
 		writeDBError(w, "a database and snapshot name are required")
+		return
+	}
+	if !requireDatabaseName(w, database) {
 		return
 	}
 	target := serviceops.SnapshotTarget{Service: service, Family: config.FamilyOfName(service), Database: database}
@@ -331,8 +341,11 @@ func handleSnapshotRestore(w http.ResponseWriter, r *http.Request, service strin
 
 func handleSnapshotDelete(w http.ResponseWriter, r *http.Request, service string) {
 	database, name, ok := decodeDBBody(r)
-	if !ok || database == "" || name == "" {
+	if !ok || name == "" {
 		writeDBError(w, "a database and snapshot name are required")
+		return
+	}
+	if !requireDatabaseName(w, database) {
 		return
 	}
 	if err := serviceops.DeleteSnapshot(service, database, name, false); err != nil {
@@ -346,8 +359,8 @@ func handleSnapshotDelete(w http.ResponseWriter, r *http.Request, service string
 // downloadable file.
 func handleDatabaseExport(w http.ResponseWriter, r *http.Request, service string) {
 	database := strings.TrimSpace(r.URL.Query().Get("database"))
-	if database == "" {
-		http.Error(w, "a database is required", http.StatusBadRequest)
+	if err := serviceops.ValidateDatabaseName(database); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	if status, _ := podman.UnitStatus("lerd-" + service); status != "active" {
@@ -367,8 +380,12 @@ func handleDatabaseExport(w http.ResponseWriter, r *http.Request, service string
 func handleSnapshotExport(w http.ResponseWriter, r *http.Request, service string) {
 	database := strings.TrimSpace(r.URL.Query().Get("database"))
 	name := strings.TrimSpace(r.URL.Query().Get("name"))
-	if database == "" || name == "" {
+	if name == "" {
 		http.Error(w, "a database and snapshot name are required", http.StatusBadRequest)
+		return
+	}
+	if err := serviceops.ValidateDatabaseName(database); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	w.Header().Set("Content-Type", "application/sql")
@@ -382,8 +399,7 @@ func handleSnapshotExport(w http.ResponseWriter, r *http.Request, service string
 // upload is streamed into the engine, so a large dump never buffers on disk.
 func handleDatabaseImport(w http.ResponseWriter, r *http.Request, service string) {
 	database := strings.TrimSpace(r.FormValue("database"))
-	if database == "" {
-		writeDBError(w, "a database is required")
+	if !requireDatabaseName(w, database) {
 		return
 	}
 	file, _, err := r.FormFile("file")

--- a/internal/ui/databases_validation_test.go
+++ b/internal/ui/databases_validation_test.go
@@ -1,0 +1,92 @@
+package ui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const traversalDB = "../../../../../../home/george/Code"
+
+// decodeDBAction reads the {ok,error} envelope the mutating endpoints return.
+func decodeDBAction(t *testing.T, rec *httptest.ResponseRecorder) dbActionResponse {
+	t.Helper()
+	var got dbActionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding %q: %v", rec.Body.String(), err)
+	}
+	return got
+}
+
+// The JSON-body handlers must reject a traversing database name before it
+// reaches serviceops, where it would be joined straight into a snapshot path.
+func TestDatabaseBodyHandlersRejectTraversal(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler func(http.ResponseWriter, *http.Request, string)
+		body    string
+	}{
+		{"snapshot delete", handleSnapshotDelete, `{"database":"` + traversalDB + `","name":"src"}`},
+		{"snapshot restore", handleSnapshotRestore, `{"database":"` + traversalDB + `","name":"src"}`},
+		{"snapshot create", handleSnapshotCreate, `{"database":"` + traversalDB + `"}`},
+		{"drop", handleDatabaseDrop, `{"name":"a'b"}`},
+		{"create", handleDatabaseCreate, `{"name":"a` + "`" + `b"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/api/databases/postgres/x", strings.NewReader(tc.body))
+			tc.handler(rec, req, "postgres")
+
+			got := decodeDBAction(t, rec)
+			if got.OK {
+				t.Fatal("handler accepted an invalid database name")
+			}
+			if !strings.Contains(got.Error, "invalid database name") {
+				t.Errorf("error = %q, want a rejection naming the invalid database", got.Error)
+			}
+		})
+	}
+}
+
+// The export endpoints read straight off disk without the engine running, so
+// they must reject before opening a path.
+func TestDatabaseExportHandlersRejectTraversal(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler func(http.ResponseWriter, *http.Request, string)
+		query   string
+	}{
+		{"database export", handleDatabaseExport, "?database=" + traversalDB},
+		{"snapshot export", handleSnapshotExport, "?database=" + traversalDB + "&name=src"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/databases/postgres/export"+tc.query, nil)
+			tc.handler(rec, req, "postgres")
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+			}
+			if !strings.Contains(rec.Body.String(), "invalid database name") {
+				t.Errorf("body = %q, want a rejection naming the invalid database", rec.Body.String())
+			}
+		})
+	}
+}
+
+// An empty database name still reports the missing-value message rather than
+// the pattern rejection, so the browser copy does not regress.
+func TestDatabaseHandlersRejectEmptyName(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/databases/postgres/create", strings.NewReader(`{"name":""}`))
+	handleDatabaseCreate(rec, req, "postgres")
+
+	got := decodeDBAction(t, rec)
+	if got.OK || !strings.Contains(got.Error, "required") {
+		t.Errorf("error = %q, want a required-field message", got.Error)
+	}
+}


### PR DESCRIPTION
The database management endpoints added in #967 took the database and name values straight from the request with no validation beyond trimming, and two sinks downstream assumed those values had already been slugged. The snapshot handlers joined database into the snapshot path, so a value of ../../../../../../home/george/Code resolved outside the snapshot root and reached os.RemoveAll on a real project directory. The same parameter gave directory creation on snapshot create and arbitrary reads of any dump.sql.gz through snapshot export.

Names are now validated against a strict pattern, letters, digits, underscores and dashes up to 64 characters, which covers every name lerd generates through SiteSlug while excluding path separators, dot segments and every SQL metacharacter. The check sits at the HTTP boundary so the browser gets a clear rejection, and also inside the snapshot entry points so the MCP and CLI callers reach the same guard.

Snapshot export turned out to pass its snapshot name straight into the path too, unlike the other snapshot operations, so it now runs through the same sanitiser.

The MySQL and MariaDB existence lookup interpolated the name through an escape that doubled the quote but left the backslash alone, and MySQL treats a backslash as an escape character unless NO_BACKSLASH_ESCAPES is set, so a backslash escaped the doubled quote and the remainder ran as a second statement under the root client. Those sinks now double the backslash first. PostgreSQL is unaffected and keeps the existing escape, since standard_conforming_strings makes a backslash ordinary.

One deliberate tradeoff: the pattern rejects dots and spaces, so a pre-existing database whose name carries one would be refused for snapshot and export operations. Every name lerd generates passes, and the rule is documented on the database page.

Closes #991