### PR TITLE
fix(doctor): size the reclaimable disk finding with the scope its fix applies

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,6 +21,8 @@ lerd doctor --fix --dry-run   # list what would be repaired, change nothing
 
 The fixes fall into three groups. lerd applies the safe ones itself, creating a missing data or config directory, enabling linger so services survive logout, installing the network-online drop-in, rebuilding a missing PHP image, and, after you confirm the heavier ones, reinstalling the services or reclaiming podman disk. Anything that needs `sudo` lerd never runs for you; it prints the exact command to copy. That covers installing podman, crun, fuse-overlayfs, the rootless network helpers or adding a subuid range, and also `lerd dns:repair` and `lerd wsl:setup`, which rewrite the resolver and podman configuration through `sudo` and so are yours to run even though lerd knows the command. Findings that are external state, a foreign process already holding port 80, a config file with a syntax error, are left untouched with their hint. The same safe, non-heavy repairs are available to AI assistants through the MCP `diag` tool's `doctor_fix` action, which therefore never elevates on your behalf.
 
+Reclaimable disk is listed separately as optional, because nothing is wrong when there is disk to reclaim. It runs the same interactive reclaim as `lerd cleanup`, so it takes the deep scope and can remove an unreferenced catalog image whoever pulled it, and the size doctor quotes is that same deep scope. If you run other podman workloads on the machine, run [`lerd cleanup --safe`](usage/cleanup.md) yourself instead. Optional fixes never count towards what a re-check reports as still outstanding.
+
 ## Filing a bug report
 
 If you need help on the [issue tracker](https://github.com/lerd-env/lerd/issues), run:

--- a/internal/cli/cleanup.go
+++ b/internal/cli/cleanup.go
@@ -17,7 +17,7 @@ func NewCleanupCmd() *cobra.Command {
 		Use:   "cleanup",
 		Short: "Reclaim podman disk from orphaned lerd images, unused service images, and dangling leftovers",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return runCleanup(dryRun, yes, !safe)
+			return runCleanup(dryRun, yes, safe)
 		},
 	}
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be reclaimed without removing anything")
@@ -93,12 +93,18 @@ func autoStateWord(enabled bool) string {
 	return "disabled"
 }
 
-func runCleanup(dryRun, yes, deep bool) error {
-	scope := cleanup.ScopeSafe
-	if deep {
-		scope = cleanup.ScopeDeep
+// cleanupScope maps the --safe flag to the scope the reclaim runs at. The doctor
+// sizes its reclaimable-disk finding through the same helper, so the estimate it
+// shows is the one its fix acts on.
+func cleanupScope(safe bool) cleanup.Scope {
+	if safe {
+		return cleanup.ScopeSafe
 	}
-	plan, err := cleanup.Inspect(scope)
+	return cleanup.ScopeDeep
+}
+
+func runCleanup(dryRun, yes, safe bool) error {
+	plan, err := cleanup.Inspect(cleanupScope(safe))
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cleanup_scope_test.go
+++ b/internal/cli/cleanup_scope_test.go
@@ -1,0 +1,16 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/cleanup"
+)
+
+func TestCleanupScopeFollowsSafeFlag(t *testing.T) {
+	if got := cleanupScope(false); got != cleanup.ScopeDeep {
+		t.Fatalf("default scope = %v, want ScopeDeep", got)
+	}
+	if got := cleanupScope(true); got != cleanup.ScopeSafe {
+		t.Fatalf("--safe scope = %v, want ScopeSafe", got)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -508,7 +508,7 @@ func runDoctorInto(w io.Writer, useColor bool) (DoctorReport, error) {
 		}
 	}
 
-	if plan, planErr := cleanup.Inspect(cleanup.ScopeSafe); planErr == nil && plan.ReclaimBytes() > 0 {
+	if plan, planErr := cleanup.Inspect(cleanupScope(false)); planErr == nil && plan.ReclaimBytes() > 0 {
 		info("Reclaimable disk", fmt.Sprintf("about %s (run: lerd cleanup)", humanSize(plan.ReclaimBytes())))
 		rep.fixLast(autoFix(fixCleanup, "", "reclaim disk space (lerd cleanup)"))
 	}

--- a/internal/cli/doctor_fix.go
+++ b/internal/cli/doctor_fix.go
@@ -50,7 +50,9 @@ func IsHeavyFix(fix *DoctorFix) bool {
 // each automatic fix (confirming per fix, heavy ones even under yes), lists the
 // sudo commands the user must run themselves, then re-checks.
 func runDoctorFix(w io.Writer, rep DoctorReport, yes, dryRun bool) error {
-	autos := rep.AutoFixes()
+	required := rep.RequiredAutoFixes()
+	optional := rep.OptionalAutoFixes()
+	autos := append(append([]Finding{}, required...), optional...)
 	manuals := rep.ManualFixes()
 
 	if len(autos) == 0 && len(manuals) == 0 {
@@ -58,12 +60,8 @@ func runDoctorFix(w io.Writer, rep DoctorReport, yes, dryRun bool) error {
 		return nil
 	}
 
-	if len(autos) > 0 {
-		fmt.Fprintln(w, "\nAutomatic fixes available:")
-		for _, f := range autos {
-			fmt.Fprintf(w, "  • %s: %s\n", f.Name, f.Fix.Label)
-		}
-	}
+	listFixes(w, "Automatic fixes available:", required)
+	listFixes(w, "Optional, nothing is wrong with these:", optional)
 
 	if dryRun {
 		printManualFixes(w, manuals)
@@ -107,8 +105,8 @@ func runDoctorFix(w io.Writer, rep DoctorReport, yes, dryRun bool) error {
 
 	if applied > 0 {
 		if after, err := reCheckReport(); err == nil {
-			if remaining := len(after.AutoFixes()); remaining == 0 {
-				fmt.Fprintln(w, "Re-checked: no automatic fixes remain.")
+			if remaining := len(after.RequiredAutoFixes()); remaining == 0 {
+				fmt.Fprintln(w, "Re-checked: nothing left to repair.")
 			} else {
 				fmt.Fprintf(w, "Re-checked: %d automatic fix(es) still needed, run `lerd doctor --fix` again.\n", remaining)
 			}
@@ -167,6 +165,16 @@ func ApplyDoctorFix(fix *DoctorFix, out io.Writer) error {
 		return runSelf(out, "cleanup", "--yes")
 	default:
 		return fmt.Errorf("unknown fix %q", fix.Key)
+	}
+}
+
+func listFixes(w io.Writer, heading string, fs []Finding) {
+	if len(fs) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "\n%s\n", heading)
+	for _, f := range fs {
+		fmt.Fprintf(w, "  • %s: %s\n", f.Name, f.Fix.Label)
 	}
 }
 

--- a/internal/cli/doctor_fix_flow_test.go
+++ b/internal/cli/doctor_fix_flow_test.go
@@ -106,10 +106,55 @@ func TestRunDoctorFixAppliesAndReChecks(t *testing.T) {
 	if !strings.Contains(out, "Applied 1 fix") {
 		t.Fatalf("expected applied summary, got: %q", out)
 	}
-	if !strings.Contains(out, "no automatic fixes remain") {
+	if !strings.Contains(out, "nothing left to repair") {
 		t.Fatalf("expected clean re-check, got: %q", out)
 	}
 	if !strings.Contains(out, "sudo apt install netavark") {
 		t.Fatalf("manual fixes should still be listed, got: %q", out)
+	}
+}
+
+func TestRunDoctorFixListsInfoFindingsAsOptional(t *testing.T) {
+	var buf bytes.Buffer
+	rep := reportWith(
+		Finding{Name: "data dir", Status: "fail", Fix: autoFix(fixMkdir, "/x", "create the data directory")},
+		Finding{Name: "Reclaimable disk", Status: "info", Fix: autoFix(fixCleanup, "", "reclaim disk space (lerd cleanup)")},
+	)
+	if err := runDoctorFix(&buf, rep, false, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	req := strings.Index(out, "create the data directory")
+	opt := strings.Index(out, "Optional")
+	disk := strings.Index(out, "reclaim disk space")
+	if req < 0 || opt < 0 || disk < 0 {
+		t.Fatalf("expected required and optional sections, got: %q", out)
+	}
+	if !(req < opt && opt < disk) {
+		t.Fatalf("optional fixes should come after the required ones, got: %q", out)
+	}
+}
+
+func TestRunDoctorFixReCheckIgnoresOptionalFixes(t *testing.T) {
+	// A leftover info finding is not a repair the user still owes, so the
+	// re-check must not report it as outstanding on every run.
+	orig := reCheckReport
+	reCheckReport = func() (DoctorReport, error) {
+		return reportWith(Finding{Name: "Reclaimable disk", Status: "info", Fix: autoFix(fixCleanup, "", "reclaim disk space")}), nil
+	}
+	defer func() { reCheckReport = orig }()
+
+	dir := filepath.Join(t.TempDir(), "quadlets")
+	var buf bytes.Buffer
+	rep := reportWith(Finding{Name: "service config dir", Status: "fail", Fix: autoFix(fixMkdir, dir, "create the service config directory")})
+	if err := runDoctorFix(&buf, rep, true, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "still needed") {
+		t.Fatalf("info finding must not count as an outstanding fix, got: %q", out)
+	}
+	if !strings.Contains(out, "nothing left to repair") {
+		t.Fatalf("expected a clean re-check, got: %q", out)
 	}
 }

--- a/internal/cli/doctor_report.go
+++ b/internal/cli/doctor_report.go
@@ -92,6 +92,24 @@ func (r *DoctorReport) AutoFixes() []Finding {
 	return out
 }
 
+// RequiredAutoFixes returns the automatic fixes attached to a real problem, and
+// OptionalAutoFixes those hanging off an informational finding. An info finding
+// is a standing offer, never a repair the user still owes.
+func (r *DoctorReport) RequiredAutoFixes() []Finding { return r.autoFixes(false) }
+
+// OptionalAutoFixes returns the automatic fixes attached to info findings.
+func (r *DoctorReport) OptionalAutoFixes() []Finding { return r.autoFixes(true) }
+
+func (r *DoctorReport) autoFixes(info bool) []Finding {
+	var out []Finding
+	for _, f := range r.AutoFixes() {
+		if (f.Status == "info") == info {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
 // ManualFixes returns the findings whose repair needs sudo, so the CLI can list
 // their commands for the user to run.
 func (r *DoctorReport) ManualFixes() []Finding {

--- a/internal/cli/doctor_report_test.go
+++ b/internal/cli/doctor_report_test.go
@@ -108,6 +108,23 @@ func TestDoctorReportPartitionsFixesByTier(t *testing.T) {
 	}
 }
 
+func TestDoctorReportSplitsRequiredFromOptionalAutoFixes(t *testing.T) {
+	rep := &DoctorReport{}
+	rep.add(Finding{Name: "data dir", Status: "fail"})
+	rep.fixLast(autoFix(fixMkdir, "/x", "create the data directory"))
+	rep.add(Finding{Name: "Reclaimable disk", Status: "info"})
+	rep.fixLast(autoFix(fixCleanup, "", "reclaim disk space (lerd cleanup)"))
+
+	req := rep.RequiredAutoFixes()
+	if len(req) != 1 || req[0].Name != "data dir" {
+		t.Fatalf("RequiredAutoFixes returned %+v, want only data dir", req)
+	}
+	opt := rep.OptionalAutoFixes()
+	if len(opt) != 1 || opt[0].Name != "Reclaimable disk" {
+		t.Fatalf("OptionalAutoFixes returned %+v, want only Reclaimable disk", opt)
+	}
+}
+
 func TestManualFixTier(t *testing.T) {
 	if manualFix.Tier != FixManual {
 		t.Fatalf("manualFix tier = %d, want FixManual", manualFix.Tier)


### PR DESCRIPTION
The doctor sized its reclaimable disk finding with the safe scope while the fix behind it ran `lerd cleanup --yes`, which takes the deep scope. The user consented to a number the safe scope produced and got the deep reclaim, so an unreferenced catalog image could go against an estimate that never counted it. Both sites resolve their scope through one `cleanupScope` helper now, and `runCleanup` takes the safe flag directly instead of the inverted deep, so the size doctor quotes is the size the reclaim acts on.

The deep default stays as it is. A stronger interactive cleanup is the point of that tier, and the reclaim still itemises every image by name and size before anything goes.

The same fix hung off an informational finding while the auto fix filter looked only at the tier, so a healthy install opened `lerd doctor --fix` with an offer to reclaim disk, and the re-check counted that finding as a repair still owed, reporting one fix still needed on every run for as long as anything was reclaimable. Automatic fixes split into required and optional now, informational findings land in the optional group and apply after the real repairs, and the re-check counts only the required ones.

Closes #994
