### PR TITLE
fix(php): restart a version's container onto the image just rebuilt

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -259,9 +259,11 @@ lerd php:ext add swoole
 
 Extensions belong to you, not to a PHP version. One declared set applies to every PHP image lerd builds, so a site that changes version keeps them. The version you are on is rebuilt and verified straight away; other installed versions carry the old set until they are rebuilt, and lerd says which ones those are.
 
+Those deferred versions are rebuilt by the next command that touches them, which is usually `lerd use`, `lerd link`, `lerd fetch`, `lerd unpause` or `lerd start`. When that happens to a version whose container is already running, lerd restarts the container onto the image it just built, so the running PHP always matches what `lerd php:ext list` and the dashboard report for it.
+
 Extensions are persisted in `~/.config/lerd/config.yaml` under `php.extensions`, so they survive `lerd php:rebuild`.
 
-After the rebuild, lerd checks that the extension actually loaded (`php -m`); if the PECL build failed, `lerd php:ext add` exits with an error and removes the extension from the config again, rather than reporting success for an extension that isn't there.
+After the rebuild, lerd checks that the extension actually loaded (`php -m`); if the PECL build failed, `lerd php:ext add` exits with an error and removes the extension from the config again, rather than reporting success for an extension that isn't there. A rebuild that fails outright is reverted the same way, so a name that cannot build is not left declared and retried by every command after it.
 
 #### What each version actually loaded
 

--- a/internal/cli/fetch.go
+++ b/internal/cli/fetch.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"fmt"
 	"io"
+	"strings"
+	"sync"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
@@ -72,18 +74,47 @@ func runFetch(cmd *cobra.Command, args []string) error {
 		versions = SupportedPHPVersions
 	}
 
+	var rebuiltMu sync.Mutex
+	var rebuilt []string
 	jobs := make([]BuildJob, len(versions))
 	for i, v := range versions {
 		ver := v
 		jobs[i] = BuildJob{
 			Label: "PHP " + ver,
-			Run:   func(w io.Writer) error { return podman.BuildFPMImageTo(ver, local, w) },
+			Run: func(w io.Writer) error {
+				changed, err := podman.BuildFPMImageTo(ver, local, w)
+				if changed {
+					rebuiltMu.Lock()
+					rebuilt = append(rebuilt, ver)
+					rebuiltMu.Unlock()
+				}
+				return err
+			},
 		}
 	}
 
 	if err := RunParallel(jobs); err != nil {
 		feedback.Warn("some images failed to build: %v", err)
 	}
+	restartRebuiltFPMUnits(rebuilt)
 	feedback.Done("all requested PHP images ready")
 	return nil
+}
+
+// restartRebuiltFPMUnits bounces the containers of versions whose image this run
+// replaced, so a fetch that quietly rebuilt a stale image doesn't leave the
+// running container on the image it superseded. Versions that aren't up are left
+// alone: fetch pre-builds images and is not a reason to start anything.
+func restartRebuiltFPMUnits(versions []string) {
+	for _, v := range versions {
+		unit := "lerd-php" + strings.ReplaceAll(v, ".", "") + "-fpm"
+		if running, _ := fpmContainerRunning(unit); !running {
+			continue
+		}
+		if err := restartUnitFn(unit); err != nil {
+			feedback.Warn("restart %s: %v", unit, err)
+		} else {
+			feedback.Note("restarted " + unit)
+		}
+	}
 }

--- a/internal/cli/fpm_restart_test.go
+++ b/internal/cli/fpm_restart_test.go
@@ -2,24 +2,37 @@ package cli
 
 import (
 	"io"
+	"path/filepath"
 	"reflect"
 	"testing"
-
-	"github.com/geodro/lerd/internal/podman"
 )
+
+// stubEnsurePath isolates lerd state and replaces every step of the ensure path
+// that shells out to podman, so these exercise the start/restart decision and
+// nothing else. Without the stubs the path really does invoke podman, which
+// builds a container storage tree under the test's temp dir to get there.
+func stubEnsurePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, "data"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+
+	origWrite, origBuild := writeFPMQuadlet, buildFPMImageTo
+	origXdebug, origStart, origRestart := ensureXdebugIni, startUnitFn, restartUnitFn
+	t.Cleanup(func() {
+		writeFPMQuadlet, buildFPMImageTo = origWrite, origBuild
+		ensureXdebugIni, startUnitFn, restartUnitFn = origXdebug, origStart, origRestart
+	})
+	writeFPMQuadlet = func(string) error { return nil }
+	ensureXdebugIni = func(string) error { return nil }
+}
 
 // A version whose image ensureFPMQuadletTo just rebuilt must have its container
 // bounced onto it. StartUnit is a no-op on an active unit, so before this the
 // deferred half of a php:ext / php:pkg change left the container serving the
 // image it had superseded while every status surface reported the new set.
 func TestEnsureFPMQuadletTo_restartsOnlyWhenTheImageWasRebuilt(t *testing.T) {
-	origBuild, origStart, origRestart := buildFPMImageTo, startUnitFn, restartUnitFn
-	origWrite := podman.WriteContainerUnitFn
-	t.Cleanup(func() {
-		buildFPMImageTo, startUnitFn, restartUnitFn = origBuild, origStart, origRestart
-		podman.WriteContainerUnitFn = origWrite
-	})
-	podman.WriteContainerUnitFn = func(_, _ string) error { return nil }
+	stubEnsurePath(t)
 
 	var started, restarted []string
 	startUnitFn = func(name string) error { started = append(started, name); return nil }
@@ -53,13 +66,7 @@ func TestEnsureFPMQuadletTo_restartsOnlyWhenTheImageWasRebuilt(t *testing.T) {
 
 // A build that fails never reaches the unit at all.
 func TestEnsureFPMQuadletTo_failedBuildTouchesNoUnit(t *testing.T) {
-	origBuild, origStart, origRestart := buildFPMImageTo, startUnitFn, restartUnitFn
-	origWrite := podman.WriteContainerUnitFn
-	t.Cleanup(func() {
-		buildFPMImageTo, startUnitFn, restartUnitFn = origBuild, origStart, origRestart
-		podman.WriteContainerUnitFn = origWrite
-	})
-	podman.WriteContainerUnitFn = func(_, _ string) error { return nil }
+	stubEnsurePath(t)
 
 	touched := 0
 	startUnitFn = func(string) error { touched++; return nil }

--- a/internal/cli/fpm_restart_test.go
+++ b/internal/cli/fpm_restart_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// A version whose image ensureFPMQuadletTo just rebuilt must have its container
+// bounced onto it. StartUnit is a no-op on an active unit, so before this the
+// deferred half of a php:ext / php:pkg change left the container serving the
+// image it had superseded while every status surface reported the new set.
+func TestEnsureFPMQuadletTo_restartsOnlyWhenTheImageWasRebuilt(t *testing.T) {
+	origBuild, origStart, origRestart := buildFPMImageTo, startUnitFn, restartUnitFn
+	origWrite := podman.WriteContainerUnitFn
+	t.Cleanup(func() {
+		buildFPMImageTo, startUnitFn, restartUnitFn = origBuild, origStart, origRestart
+		podman.WriteContainerUnitFn = origWrite
+	})
+	podman.WriteContainerUnitFn = func(_, _ string) error { return nil }
+
+	var started, restarted []string
+	startUnitFn = func(name string) error { started = append(started, name); return nil }
+	restartUnitFn = func(name string) error { restarted = append(restarted, name); return nil }
+
+	rebuilt := false
+	buildFPMImageTo = func(_ string, _ bool, _ io.Writer) (bool, error) { return rebuilt, nil }
+
+	if err := ensureFPMQuadletTo("8.3", io.Discard); err != nil {
+		t.Fatalf("ensureFPMQuadletTo: %v", err)
+	}
+	if len(restarted) != 0 {
+		t.Errorf("an unchanged image must not bounce a running container, restarted %v", restarted)
+	}
+	if len(started) != 1 || started[0] != "lerd-php83-fpm" {
+		t.Errorf("started = %v, want [lerd-php83-fpm]", started)
+	}
+
+	rebuilt = true
+	started, restarted = nil, nil
+	if err := ensureFPMQuadletTo("8.3", io.Discard); err != nil {
+		t.Fatalf("ensureFPMQuadletTo: %v", err)
+	}
+	if len(started) != 0 {
+		t.Errorf("a rebuilt image must not be left to a no-op start, started %v", started)
+	}
+	if len(restarted) != 1 || restarted[0] != "lerd-php83-fpm" {
+		t.Errorf("restarted = %v, want [lerd-php83-fpm]", restarted)
+	}
+}
+
+// A build that fails never reaches the unit at all.
+func TestEnsureFPMQuadletTo_failedBuildTouchesNoUnit(t *testing.T) {
+	origBuild, origStart, origRestart := buildFPMImageTo, startUnitFn, restartUnitFn
+	origWrite := podman.WriteContainerUnitFn
+	t.Cleanup(func() {
+		buildFPMImageTo, startUnitFn, restartUnitFn = origBuild, origStart, origRestart
+		podman.WriteContainerUnitFn = origWrite
+	})
+	podman.WriteContainerUnitFn = func(_, _ string) error { return nil }
+
+	touched := 0
+	startUnitFn = func(string) error { touched++; return nil }
+	restartUnitFn = func(string) error { touched++; return nil }
+	buildFPMImageTo = func(_ string, _ bool, _ io.Writer) (bool, error) {
+		return false, io.ErrUnexpectedEOF
+	}
+
+	if err := ensureFPMQuadletTo("8.3", io.Discard); err == nil {
+		t.Fatal("a failed build must surface an error")
+	}
+	if touched != 0 {
+		t.Errorf("a failed build must not start or restart the unit, touched %d times", touched)
+	}
+}
+
+// fetch rebuilds a stale image without going near the unit, so it needs the
+// same bounce ensureFPMQuadletTo does. It must not start anything that was
+// down: pre-building images is not a reason to bring a version up.
+func TestRestartRebuiltFPMUnits_bouncesOnlyRunningRebuiltVersions(t *testing.T) {
+	origRunning, origRestart := fpmContainerRunning, restartUnitFn
+	t.Cleanup(func() { fpmContainerRunning, restartUnitFn = origRunning, origRestart })
+
+	up := map[string]bool{"lerd-php83-fpm": true, "lerd-php85-fpm": true}
+	fpmContainerRunning = func(name string) (bool, error) { return up[name], nil }
+
+	var restarted []string
+	restartUnitFn = func(name string) error { restarted = append(restarted, name); return nil }
+
+	// 8.4 was rebuilt but is down; 8.2 is down and was not rebuilt either.
+	restartRebuiltFPMUnits([]string{"8.3", "8.4"})
+
+	if !reflect.DeepEqual(restarted, []string{"lerd-php83-fpm"}) {
+		t.Errorf("restarted = %v, want [lerd-php83-fpm]: only a running version this run rebuilt", restarted)
+	}
+}
+
+// A run that rebuilt nothing must leave every container alone.
+func TestRestartRebuiltFPMUnits_nothingRebuiltBouncesNothing(t *testing.T) {
+	origRunning, origRestart := fpmContainerRunning, restartUnitFn
+	t.Cleanup(func() { fpmContainerRunning, restartUnitFn = origRunning, origRestart })
+
+	fpmContainerRunning = func(string) (bool, error) { return true, nil }
+	restarted := 0
+	restartUnitFn = func(string) error { restarted++; return nil }
+
+	restartRebuiltFPMUnits(nil)
+
+	if restarted != 0 {
+		t.Errorf("restarted %d units for a fetch that rebuilt nothing", restarted)
+	}
+}

--- a/internal/cli/park.go
+++ b/internal/cli/park.go
@@ -336,9 +336,13 @@ func ensureFPMQuadlet(phpVersion string) error {
 	return ensureFPMQuadletTo(phpVersion, os.Stdout)
 }
 
-// Seams for the ensure path's unit lifecycle, swappable in tests.
+// Seams for the ensure path, swappable in tests. Every step shells out to
+// podman or writes real state, so a test of the start/restart decision alone
+// would otherwise build a container storage tree to reach it.
 var (
+	writeFPMQuadlet = podman.WriteFPMQuadlet
 	buildFPMImageTo = podman.BuildFPMImageTo
+	ensureXdebugIni = podman.EnsureXdebugIni
 	startUnitFn     = podman.StartUnit
 	restartUnitFn   = podman.RestartUnit
 )
@@ -350,7 +354,7 @@ func ensureFPMQuadletTo(phpVersion string, w io.Writer) error {
 
 	// Write the unit file first so the version is registered in lerd status even
 	// if the image build fails — lerd start will rebuild the image on the next run.
-	if err := podman.WriteFPMQuadlet(phpVersion); err != nil {
+	if err := writeFPMQuadlet(phpVersion); err != nil {
 		return err
 	}
 
@@ -359,7 +363,7 @@ func ensureFPMQuadletTo(phpVersion string, w io.Writer) error {
 		return fmt.Errorf("building FPM image for PHP %s: %w", phpVersion, err)
 	}
 
-	_ = podman.EnsureXdebugIni(phpVersion)
+	_ = ensureXdebugIni(phpVersion)
 
 	// A start is a no-op on an already-active unit, so a version whose image was
 	// just rebuilt here (the deferred half of a php:ext / php:pkg change) would

--- a/internal/cli/park.go
+++ b/internal/cli/park.go
@@ -336,6 +336,13 @@ func ensureFPMQuadlet(phpVersion string) error {
 	return ensureFPMQuadletTo(phpVersion, os.Stdout)
 }
 
+// Seams for the ensure path's unit lifecycle, swappable in tests.
+var (
+	buildFPMImageTo = podman.BuildFPMImageTo
+	startUnitFn     = podman.StartUnit
+	restartUnitFn   = podman.RestartUnit
+)
+
 // ensureFPMQuadletTo is like ensureFPMQuadlet but writes build output to w.
 func ensureFPMQuadletTo(phpVersion string, w io.Writer) error {
 	versionShort := strings.ReplaceAll(phpVersion, ".", "")
@@ -347,11 +354,18 @@ func ensureFPMQuadletTo(phpVersion string, w io.Writer) error {
 		return err
 	}
 
-	if err := podman.BuildFPMImageTo(phpVersion, false, w); err != nil {
+	rebuilt, err := buildFPMImageTo(phpVersion, false, w)
+	if err != nil {
 		return fmt.Errorf("building FPM image for PHP %s: %w", phpVersion, err)
 	}
 
 	_ = podman.EnsureXdebugIni(phpVersion)
 
-	return podman.StartUnit(unitName)
+	// A start is a no-op on an already-active unit, so a version whose image was
+	// just rebuilt here (the deferred half of a php:ext / php:pkg change) would
+	// keep serving the old image while every status surface reported the new set.
+	if rebuilt {
+		return restartUnitFn(unitName)
+	}
+	return startUnitFn(unitName)
 }

--- a/internal/cli/php_ext.go
+++ b/internal/cli/php_ext.go
@@ -16,6 +16,10 @@ import (
 
 var validExtNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
+// rebuildFPMImage is a seam so the add path's revert-on-failure can be tested
+// without building an image.
+var rebuildFPMImage = podman.RebuildFPMImage
+
 // NewPhpExtCmd returns the php:ext parent command.
 func NewPhpExtCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -71,19 +75,33 @@ func newPhpExtAddCmd() *cobra.Command {
 			if len(deps) > 0 {
 				feedback.Note("alpine packages: " + strings.Join(deps, " "))
 			}
-			if err := podman.RebuildFPMImage(version, false); err != nil {
-				return err
-			}
-
 			// The build records what this version realised, so the revert
 			// re-reads rather than saving a copy loaded before the build.
+			revert := func() {
+				if saveErr := config.UpdateGlobal(func(c *config.GlobalConfig) {
+					c.RemoveExtension(ext)
+					c.SetExtApkDeps(ext, nil)
+				}); saveErr != nil {
+					feedback.Warn("reverting config: %v", saveErr)
+				}
+			}
+
+			// A failed rebuild has to revert too, or the extension stays declared,
+			// every version's image reads as stale, and the build that cannot
+			// succeed is retried on every command that follows.
+			if err := rebuildFPMImage(version, false); err != nil {
+				if alreadyDeclared {
+					return err
+				}
+				revert()
+				return fmt.Errorf("rebuild failed (config reverted): %w", err)
+			}
+
 			if err := podman.VerifyExtensionLoaded(version, ext); err != nil {
 				if alreadyDeclared {
 					return fmt.Errorf("extension %q did not load on PHP %s: %w", ext, version, err)
 				}
-				if saveErr := config.UpdateGlobal(func(c *config.GlobalConfig) { c.RemoveExtension(ext) }); saveErr != nil {
-					feedback.Warn("reverting config: %v", saveErr)
-				}
+				revert()
 				return fmt.Errorf("extension %q was not installed (config reverted): %w", ext, err)
 			}
 

--- a/internal/cli/php_ext_test.go
+++ b/internal/cli/php_ext_test.go
@@ -1,6 +1,14 @@
 package cli
 
-import "testing"
+import (
+	"errors"
+	"io"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
 
 func TestValidExtName(t *testing.T) {
 	valid := []string{
@@ -36,5 +44,71 @@ func TestValidExtName(t *testing.T) {
 		if validExtNameRe.MatchString(name) {
 			t.Errorf("expected %q to be invalid", name)
 		}
+	}
+}
+
+// A rebuild that fails must not leave the extension declared. Left in, it
+// stales every version's image, so the build that cannot succeed is retried by
+// every command that follows. php:pkg already reverted; php:ext did not.
+func TestPhpExtAdd_revertsTheConfigWhenTheRebuildFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+
+	orig := rebuildFPMImage
+	t.Cleanup(func() { rebuildFPMImage = orig })
+	rebuildFPMImage = func(string, bool) error { return errors.New("pecl install failed") }
+
+	cmd := newPhpExtAddCmd()
+	cmd.SetArgs([]string{"leveldb", "--apk-deps", "leveldb-dev"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("a failed rebuild must surface an error")
+	}
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if slices.Contains(cfg.GetExtensions(), "leveldb") {
+		t.Errorf("extension still declared after a failed rebuild: %v", cfg.GetExtensions())
+	}
+	if deps := cfg.GetExtApkDeps("leveldb"); len(deps) > 0 {
+		t.Errorf("apk deps outlived the reverted extension: %v", deps)
+	}
+}
+
+// Re-adding an already-declared extension must keep it when the rebuild fails:
+// the revert would rip out a working declaration this run did not make.
+func TestPhpExtAdd_keepsAnAlreadyDeclaredExtensionWhenTheRebuildFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+
+	if err := config.UpdateGlobal(func(c *config.GlobalConfig) { c.AddExtension("leveldb") }); err != nil {
+		t.Fatalf("seeding config: %v", err)
+	}
+
+	orig := rebuildFPMImage
+	t.Cleanup(func() { rebuildFPMImage = orig })
+	rebuildFPMImage = func(string, bool) error { return errors.New("pecl install failed") }
+
+	cmd := newPhpExtAddCmd()
+	cmd.SetArgs([]string{"leveldb"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("a failed rebuild must surface an error")
+	}
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if !slices.Contains(cfg.GetExtensions(), "leveldb") {
+		t.Error("a failed re-add removed the extension that was already declared and working")
 	}
 }

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -93,7 +93,10 @@ func ensureImages() {
 			v := ver
 			jobs = append(jobs, BuildJob{
 				Label: "PHP " + v,
-				Run:   func(w io.Writer) error { return podman.BuildFPMImageTo(v, false, w) },
+				Run: func(w io.Writer) error {
+					_, err := podman.BuildFPMImageTo(v, false, w)
+					return err
+				},
 			})
 
 		case strings.HasPrefix(img, "localhost/lerd-frankenphp") && strings.HasSuffix(img, ":local"):

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -298,15 +298,19 @@ func BuildFPMImage(version string, local bool) error {
 	if err != nil {
 		return err
 	}
-	return buildFPMImage(version, false, local, cfg.GetExtensions(), cfg.AllExtApkDeps(), cfg.GetPackages(), os.Stdout)
+	_, err = buildFPMImage(version, false, local, cfg.GetExtensions(), cfg.AllExtApkDeps(), cfg.GetPackages(), os.Stdout)
+	return err
 }
 
-// BuildFPMImageTo builds the PHP-FPM image writing output to w.
+// BuildFPMImageTo builds the PHP-FPM image writing output to w, reporting
+// whether an image was actually produced. Callers need that answer: a rebuild
+// leaves any container already running on the old image, and starting an active
+// unit is a no-op, so only a caller that knows the image changed can bounce it.
 // When local is false, it attempts to pull a pre-built base image from ghcr.io first.
-func BuildFPMImageTo(version string, local bool, w io.Writer) error {
+func BuildFPMImageTo(version string, local bool, w io.Writer) (bool, error) {
 	cfg, err := config.LoadGlobal()
 	if err != nil {
-		return err
+		return false, err
 	}
 	return buildFPMImage(version, false, local, cfg.GetExtensions(), cfg.AllExtApkDeps(), cfg.GetPackages(), w)
 }
@@ -318,7 +322,8 @@ func RebuildFPMImage(version string, local bool) error {
 	if err != nil {
 		return err
 	}
-	return buildFPMImage(version, true, local, cfg.GetExtensions(), cfg.AllExtApkDeps(), cfg.GetPackages(), os.Stdout)
+	_, err = buildFPMImage(version, true, local, cfg.GetExtensions(), cfg.AllExtApkDeps(), cfg.GetPackages(), os.Stdout)
+	return err
 }
 
 // RebuildFPMImageTo force-rebuilds the PHP-FPM image writing output to w.
@@ -328,7 +333,8 @@ func RebuildFPMImageTo(version string, local bool, w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	return buildFPMImage(version, true, local, cfg.GetExtensions(), cfg.AllExtApkDeps(), cfg.GetPackages(), w)
+	_, err = buildFPMImage(version, true, local, cfg.GetExtensions(), cfg.AllExtApkDeps(), cfg.GetPackages(), w)
+	return err
 }
 
 // baseContainerfileHash returns a 12-character SHA-256 prefix of the Containerfile
@@ -433,7 +439,7 @@ func pullErrLine(s string) string {
 	return last
 }
 
-func buildFPMImage(version string, force, local bool, customExts []string, extDeps map[string][]string, packages []string, w io.Writer) error {
+func buildFPMImage(version string, force, local bool, customExts []string, extDeps map[string][]string, packages []string, w io.Writer) (bool, error) {
 	imageName := FPMImageName(version)
 
 	// Stamp the Containerfile hash as an image label so NeedsFPMRebuild
@@ -441,19 +447,19 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 	// pre-v1.22.0 poisoning bug). Both build paths inherit the same args.
 	canonicalHash, hashErr := ContainerfileHash()
 	if hashErr != nil {
-		return fmt.Errorf("computing Containerfile hash for label: %w", hashErr)
+		return false, fmt.Errorf("computing Containerfile hash for label: %w", hashErr)
 	}
 	customHash := customSetHash(customExts, extDeps, packages)
 
 	if !force && fpmImageCurrent(imageName, canonicalHash, customHash) {
-		return nil
+		return false, nil
 	}
 
 	fmt.Fprintf(w, "\n  Building PHP %s image...\n", version)
 
 	tmp, err := os.MkdirTemp("", "lerd-php-build-*")
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer os.RemoveAll(tmp)
 
@@ -479,11 +485,11 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 	// doesn't need it).
 	{
 		if err := writeDevtoolsSource(tmp); err != nil {
-			return fmt.Errorf("staging devtools source: %w", err)
+			return false, fmt.Errorf("staging devtools source: %w", err)
 		}
 		tmpl, tmplErr := GetQuadletTemplate("lerd-php-fpm.Containerfile")
 		if tmplErr != nil {
-			return tmplErr
+			return false, tmplErr
 		}
 		containerfile = strings.ReplaceAll(tmpl, "{{.Version}}", version)
 		containerfile = strings.ReplaceAll(containerfile, "{{.CustomExtensions}}", buildCustomExtBlock(customExts, extDeps))
@@ -495,7 +501,7 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 build:
 	cfPath := filepath.Join(tmp, "Containerfile")
 	if err := os.WriteFile(cfPath, []byte(containerfile), 0644); err != nil {
-		return err
+		return false, err
 	}
 
 	buildArgs = append(buildArgs, "-f", cfPath, tmp)
@@ -503,7 +509,7 @@ build:
 	cmd.Stdout = w
 	cmd.Stderr = w
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("building PHP %s image: %w", version, err)
+		return false, fmt.Errorf("building PHP %s image: %w", version, err)
 	}
 
 	// Stamp the hash only after a real build — callers that no-op when the
@@ -518,7 +524,7 @@ build:
 	if OnImageRebuilt != nil {
 		OnImageRebuilt()
 	}
-	return nil
+	return true, nil
 }
 
 // extApkDeps maps a custom PHP extension to the Alpine packages its build needs.

--- a/internal/podman/custom_set.go
+++ b/internal/podman/custom_set.go
@@ -138,23 +138,23 @@ func FPMImageStale(version string) bool {
 var realisedSetMu sync.Mutex
 
 // RecordRealisedSet asks a freshly built image what it actually carries and
-// records it against the version. Best-effort: a version whose image can't be
-// inspected simply has no record, which callers read as "nothing known yet"
-// rather than "nothing installed".
+// records it against the version.
+//
+// A build that cannot be inspected still records, as an empty set. The build
+// has already stamped the current declared-set label on the image, so it reads
+// as fresh from that moment on; leaving no record would have MissingFromImage
+// return nothing for it and the whole declared set be reported as present. That
+// is the #952 false success reached through the absent record instead of the
+// empty one, so the two are closed the same way: erring towards "not in this
+// image" is a warning, erring the other way advertises what isn't there.
 func RecordRealisedSet(version string, declaredExts, declaredPkgs []string) {
 	if len(declaredExts) == 0 && len(declaredPkgs) == 0 {
 		clearRealisedSet(version)
 		return
 	}
-	image := FPMImageName(version)
-	modules, err := execCommand(PodmanBin(), "run", "--rm", image, "php", "-m").Output()
-	if err != nil {
-		return
-	}
-	// `apk info` needs no network: it reads the image's own installed database.
-	apkInfo, err := execCommand(PodmanBin(), "run", "--rm", image, "apk", "info").Output()
-	if err != nil {
-		return
+	var set config.RealisedPHPSet
+	if modules, apkInfo, err := inspectFPMImageSets(version); err == nil {
+		set = realisedSet(declaredExts, declaredPkgs, modules, apkInfo)
 	}
 
 	realisedSetMu.Lock()
@@ -163,10 +163,24 @@ func RecordRealisedSet(version string, declaredExts, declaredPkgs []string) {
 	if err != nil {
 		return
 	}
-	set := realisedSet(declaredExts, declaredPkgs, string(modules), string(apkInfo))
 	set.Hash = customSetHash(declaredExts, cfg.AllExtApkDeps(), declaredPkgs)
 	cfg.SetRealised(version, set)
 	_ = config.SaveGlobal(cfg)
+}
+
+// inspectFPMImageSets reads a version's image for what it loaded and installed.
+// `apk info` needs no network: it reads the image's own installed database.
+func inspectFPMImageSets(version string) (modules, apkInfo string, err error) {
+	image := FPMImageName(version)
+	mods, err := execCommand(PodmanBin(), "run", "--rm", image, "php", "-m").Output()
+	if err != nil {
+		return "", "", fmt.Errorf("reading modules from %s: %w", image, err)
+	}
+	pkgs, err := execCommand(PodmanBin(), "run", "--rm", image, "apk", "info").Output()
+	if err != nil {
+		return "", "", fmt.Errorf("reading packages from %s: %w", image, err)
+	}
+	return string(mods), string(pkgs), nil
 }
 
 // clearRealisedSet drops a version's record once nothing is declared, so a

--- a/internal/podman/custom_set_test.go
+++ b/internal/podman/custom_set_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 // The declared set is what drives a version's image content, so its fingerprint
@@ -168,5 +170,54 @@ func TestFPMImageCurrent(t *testing.T) {
 	}
 	if fpmImageCurrent("img", "recipe1", "cust1") {
 		t.Error("an unlabelled image must rebuild once something is declared")
+	}
+}
+
+// The build stamps the current declared-set label on the image before this
+// runs, so the image reads as fresh from that moment. Returning without a
+// record then had MissingFromImage answer "nothing missing" for a version that
+// was never measured, reporting the whole declared set as present — the #952
+// false success reached through the absent record instead of the empty one.
+func TestRecordRealisedSet_recordsAnEmptySetWhenTheImageCannotBeInspected(t *testing.T) {
+	withTempXDG(t)
+	origExec := execCommand
+	t.Cleanup(func() { execCommand = origExec })
+	execCommand = func(string, ...string) *exec.Cmd { return exec.Command("false") }
+
+	RecordRealisedSet("8.0", []string{"mongodb"}, []string{"chromium"})
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	missing := cfg.MissingFromImage("8.0", []string{"mongodb", "chromium"})
+	if !reflect.DeepEqual(missing, []string{"mongodb", "chromium"}) {
+		t.Errorf("MissingFromImage = %v, want [mongodb chromium]: an uninspectable build must not read as carrying the declared set", missing)
+	}
+	if cfg.GetRealised("8.0").Hash == "" {
+		t.Error("the record must carry its hash, or it serializes away and reads back as no record at all")
+	}
+}
+
+// The normal path still records exactly what the image reported.
+func TestRecordRealisedSet_recordsWhatTheImageReports(t *testing.T) {
+	withTempXDG(t)
+	origExec := execCommand
+	t.Cleanup(func() { execCommand = origExec })
+	execCommand = func(_ string, arg ...string) *exec.Cmd {
+		if len(arg) > 0 && arg[len(arg)-1] == "-m" {
+			return exec.Command("printf", "%s\\n", "mongodb")
+		}
+		return exec.Command("printf", "%s\\n", "chromium")
+	}
+
+	RecordRealisedSet("8.4", []string{"mongodb", "imagick"}, []string{"chromium"})
+
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if missing := cfg.MissingFromImage("8.4", []string{"mongodb", "imagick", "chromium"}); !reflect.DeepEqual(missing, []string{"imagick"}) {
+		t.Errorf("MissingFromImage = %v, want [imagick]", missing)
 	}
 }

--- a/internal/tui/php_extras.go
+++ b/internal/tui/php_extras.go
@@ -30,10 +30,17 @@ func phpExtrasSummary(cfg *config.GlobalConfig, version string) string {
 		return ""
 	}
 
+	// A record is always written with its hash, so an empty hash is the only
+	// "never measured" case and the only one a rebuild answers. A record that
+	// measured nothing means this version's image carries none of the declared
+	// set, which rebuilding it cannot change.
 	realised := cfg.GetRealised(version)
 	have := append(slices.Clone(realised.Extensions), realised.Packages...)
 	if len(have) == 0 {
-		return "not in this image yet · lerd php:rebuild " + version
+		if realised.Hash == "" {
+			return "not in this image yet · lerd php:rebuild " + version
+		}
+		return "none of the declared set is in this image"
 	}
 
 	summary := strings.Join(have, ", ")

--- a/internal/tui/php_extras_test.go
+++ b/internal/tui/php_extras_test.go
@@ -39,4 +39,12 @@ func TestPHPExtrasSummary(t *testing.T) {
 	if got := phpExtrasSummary(cfg, "7.4"); got != "chromium · not in this image: mongodb" {
 		t.Errorf("partial version = %q, want the gap named without a cause", got)
 	}
+
+	// A version that was measured and carried none of the set is not the same
+	// as one that was never measured. It has been rebuilt already, so pointing
+	// at php:rebuild sends the user round a loop that cannot change the answer.
+	cfg.SetRealised("8.0", config.RealisedPHPSet{Hash: "measured"})
+	if got := phpExtrasSummary(cfg, "8.0"); got != "none of the declared set is in this image" {
+		t.Errorf("measured-but-empty version = %q, want no rebuild hint", got)
+	}
 }


### PR DESCRIPTION
Before the custom set hash landed, the FPM build returned early whenever the image existed, so the ensure path never rebuilt anything and its StartUnit call was enough. The build now rebuilds whenever the declared set has moved, but a systemd start is a no op on an already active unit. With a site on 8.4 and one on 8.3 running, php:ext add rebuilds and restarts 8.4 and defers 8.3, and the next lerd use, link, fetch, init, unpause or start rebuilds the 8.3 image without anything bouncing the container onto it. php:ext list, the PHP page and the doctor all report the new set as present while lerd-php83-fpm keeps serving the image it superseded.

The build now reports whether it actually produced an image, so the ensure path can restart the unit when it did and start it otherwise. lerd fetch never went near the units at all, so it collects the versions it replaced and bounces the ones that are running, leaving anything that is down alone, since pre-building images is not a reason to bring a version up.

There was a second route to the same false success. RecordRealisedSet returned without writing a record when the post build inspection failed, but the build had already stamped the current declared set label, so the image read as fresh while MissingFromImage answered nothing for the absent record and the entire declared set was reported as present. That is the empty set bug from #952 reached through the absent record instead of the empty one, so it closes the same way: a record is always written, empty when the image cannot be inspected. Erring towards naming a gap is a warning, erring the other way advertises what an image does not have.

Two smaller things in the same area. php:ext add now reverts its config change when the rebuild fails, matching its php:pkg sibling, so a name that cannot build is not left declared with every version's image reading stale and the failing build retried on every command that follows. And the TUI no longer points at php:rebuild for a version whose record measured nothing, since an empty record is precisely the case a rebuild cannot help.

Refs #995
