### PR TITLE
fix(notify): bound the notification D-Bus calls and stop announcing workers that already recovered

### DIFF
--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -51,6 +51,8 @@ The dashboard's System health card also carries a bell toggle, next to the debug
 
 Clicking a notification focuses the dashboard (or launches the PWA if closed) and deep-links to the relevant view: the captured email in the Mailpit overlay, the failing worker's site detail, the finished service's tile, the Dumps tab.
 
+`worker_failed` waits before it speaks. Worker units restart themselves five seconds after a crash, so most failures clear on their own, and a notification sent the moment one is spotted usually describes a worker that is running again by the time you reach the dashboard. Instead the watcher holds new failures for thirty seconds, groups anything else that trips in that window into one notification, then re-checks health and drops the workers that recovered. You only hear about a worker that is still down after systemd has had several attempts at it, and the notification reflects its state at that point rather than when it first tripped. The dashboard banner is unaffected and still appears immediately, clearing itself when the worker comes back.
+
 ## How it works
 
 With the **native** sink selected the daemon skips everything below and posts once to `org.freedesktop.Notifications`. With the **browser** sink (the default), two delivery paths run in parallel:

--- a/internal/desktopnotify/notify_linux.go
+++ b/internal/desktopnotify/notify_linux.go
@@ -4,8 +4,10 @@ package desktopnotify
 
 import (
 	"bytes"
+	"context"
 	"os/exec"
 	"sync"
+	"time"
 
 	"github.com/godbus/dbus/v5"
 )
@@ -13,13 +15,59 @@ import (
 const (
 	notifyDest = "org.freedesktop.Notifications"
 	notifyPath = "/org/freedesktop/Notifications"
+	// dbusTimeout bounds every bus call. Callers are synchronous request
+	// handlers in a long-lived daemon, so a wedged notification daemon would
+	// otherwise pin one goroutine per event with no bound on how many pile up.
+	dbusTimeout = 3 * time.Second
+	// maxTrackedRoutes caps the click-route map. A daemon that shows popups
+	// without ever emitting ActionInvoked or NotificationClosed would grow it
+	// without limit over the process lifetime.
+	maxTrackedRoutes = 256
 )
 
 var (
-	routeMu      sync.Mutex
-	routes       = map[uint32]string{}
-	listenerOnce sync.Once
+	busMu   sync.Mutex
+	busConn *dbus.Conn
+
+	routeMu        sync.Mutex
+	routes         = map[uint32]string{}
+	routeOrder     []uint32
+	listenerActive bool
 )
+
+// sessionBus returns a cached connection to the session bus. Autostart is
+// deliberately off: godbus falls back to a bare dbus-launch, which spawns a
+// dbus-daemon that outlives lerd, so `lerd start` over SSH would leave an
+// orphan behind on every host that has dbus installed but no session.
+func sessionBus() (*dbus.Conn, error) {
+	busMu.Lock()
+	defer busMu.Unlock()
+	if busConn != nil && busConn.Connected() {
+		return busConn, nil
+	}
+	conn, err := dbus.SessionBusPrivateNoAutoStartup()
+	if err != nil {
+		return nil, err
+	}
+	if err := conn.Auth(nil); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if err := conn.Hello(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	busConn = conn
+	return conn, nil
+}
+
+// call issues a bus call that gives up after dbusTimeout instead of blocking
+// on context.Background() the way a zero-flag Call does.
+func call(obj dbus.BusObject, method string, args ...any) *dbus.Call {
+	ctx, cancel := context.WithTimeout(context.Background(), dbusTimeout)
+	defer cancel()
+	return obj.CallWithContext(ctx, method, 0, args...)
+}
 
 // Supported reports whether native notifications can be delivered on this host.
 // True when a daemon already owns the well-known name (GNOME, KDE, which run it
@@ -27,19 +75,19 @@ var (
 // xfce4-notifyd, which auto-start on the first Notify). False on a headless host
 // with no session bus and no daemon, so callers fall back to the browser sink.
 func Supported() bool {
-	conn, err := dbus.SessionBus()
+	conn, err := sessionBus()
 	if err != nil {
 		return false
 	}
 	bus := conn.BusObject()
 
 	var has bool
-	if err := bus.Call("org.freedesktop.DBus.NameHasOwner", 0, notifyDest).Store(&has); err == nil && has {
+	if err := call(bus, "org.freedesktop.DBus.NameHasOwner", notifyDest).Store(&has); err == nil && has {
 		return true
 	}
 
 	var activatable []string
-	if err := bus.Call("org.freedesktop.DBus.ListActivatableNames", 0).Store(&activatable); err == nil {
+	if err := call(bus, "org.freedesktop.DBus.ListActivatableNames").Store(&activatable); err == nil {
 		for _, name := range activatable {
 			if name == notifyDest {
 				return true
@@ -51,7 +99,7 @@ func Supported() bool {
 
 // Emit shows a native notification and returns the daemon-assigned id.
 func Emit(req Request) (uint32, error) {
-	conn, err := dbus.SessionBus()
+	conn, err := sessionBus()
 	if err != nil {
 		return 0, err
 	}
@@ -69,7 +117,7 @@ func Emit(req Request) (uint32, error) {
 	if req.Route != "" {
 		actions = []string{"default", "", "open", "Open Lerd"}
 	}
-	call := obj.Call(notifyDest+".Notify", 0,
+	c := call(obj, notifyDest+".Notify",
 		req.AppName, // app_name
 		uint32(0),   // replaces_id
 		icon,        // app_icon
@@ -79,11 +127,11 @@ func Emit(req Request) (uint32, error) {
 		hints,       // hints
 		int32(-1),   // expire_timeout, -1 = daemon default
 	)
-	if call.Err != nil {
-		return 0, call.Err
+	if c.Err != nil {
+		return 0, c.Err
 	}
 	var id uint32
-	if err := call.Store(&id); err != nil {
+	if err := c.Store(&id); err != nil {
 		return 0, err
 	}
 	if req.Route != "" {
@@ -92,27 +140,40 @@ func Emit(req Request) (uint32, error) {
 	return id, nil
 }
 
-// trackRoute records the route to open for a notification id and starts the
-// ActionInvoked listener on first use.
+// trackRoute records the route to open for a notification id, starting the
+// ActionInvoked listener on first use. A failed start is not latched, so a bus
+// that was briefly unavailable doesn't leave clicks dead for the rest of the
+// process; without a listener the route is dropped rather than tracked forever.
 func trackRoute(id uint32, route string) {
 	routeMu.Lock()
+	defer routeMu.Unlock()
+	if !listenerActive {
+		if !startActionListener() {
+			return
+		}
+		listenerActive = true
+	}
 	routes[id] = route
-	routeMu.Unlock()
-	listenerOnce.Do(startActionListener)
+	routeOrder = append(routeOrder, id)
+	for len(routeOrder) > maxTrackedRoutes {
+		delete(routes, routeOrder[0])
+		routeOrder = routeOrder[1:]
+	}
 }
 
 // startActionListener subscribes to the notification daemon's signals and opens
-// the tracked route when the user clicks a lerd notification.
-func startActionListener() {
-	conn, err := dbus.SessionBus()
+// the tracked route when the user clicks a lerd notification. Reports whether
+// the subscription is live. Swappable for tests.
+var startActionListener = func() bool {
+	conn, err := sessionBus()
 	if err != nil {
-		return
+		return false
 	}
 	if err := conn.AddMatchSignal(
 		dbus.WithMatchObjectPath(notifyPath),
 		dbus.WithMatchInterface(notifyDest),
 	); err != nil {
-		return
+		return false
 	}
 	ch := make(chan *dbus.Signal, 16)
 	conn.Signal(ch)
@@ -141,6 +202,7 @@ func startActionListener() {
 			}
 		}
 	}()
+	return true
 }
 
 // openRoute sends the click to the best available target: the desktop app via
@@ -171,7 +233,8 @@ func AppInstalled() bool {
 }
 
 // OpenApp focuses (or launches) the desktop app at the given dashboard route via
-// its lerd:// scheme.
+// its lerd:// scheme. Start, not Run: xdg-open can outlive the handoff, which
+// would block `lerd dashboard` and freeze the tray's Dashboard item behind it.
 func OpenApp(route string) error {
-	return exec.Command("xdg-open", appSchemeURL(route)).Run()
+	return exec.Command("xdg-open", appSchemeURL(route)).Start()
 }

--- a/internal/desktopnotify/notify_linux_test.go
+++ b/internal/desktopnotify/notify_linux_test.go
@@ -1,0 +1,101 @@
+//go:build linux
+
+package desktopnotify
+
+import "testing"
+
+// resetRouteState clears the package-level click-route tracking between cases.
+func resetRouteState(t *testing.T) {
+	t.Helper()
+	routeMu.Lock()
+	routes = map[uint32]string{}
+	routeOrder = nil
+	listenerActive = false
+	routeMu.Unlock()
+	t.Cleanup(func() {
+		routeMu.Lock()
+		routes = map[uint32]string{}
+		routeOrder = nil
+		listenerActive = false
+		routeMu.Unlock()
+	})
+}
+
+func withListener(t *testing.T, ok bool, calls *int) {
+	t.Helper()
+	orig := startActionListener
+	startActionListener = func() bool {
+		if calls != nil {
+			*calls++
+		}
+		return ok
+	}
+	t.Cleanup(func() { startActionListener = orig })
+}
+
+// A listener that never started cannot deliver clicks, so tracking a route
+// would grow the map forever with entries nothing will ever consume.
+func TestTrackRouteDropsWhenListenerFails(t *testing.T) {
+	resetRouteState(t)
+	calls := 0
+	withListener(t, false, &calls)
+
+	trackRoute(1, "#system")
+	trackRoute(2, "#sites")
+
+	routeMu.Lock()
+	n := len(routes)
+	routeMu.Unlock()
+	if n != 0 {
+		t.Fatalf("tracked %d routes with no listener, want 0", n)
+	}
+	if calls != 2 {
+		t.Fatalf("listener start attempted %d times, want 2 (a failure must not be latched)", calls)
+	}
+}
+
+func TestTrackRouteStartsListenerOnce(t *testing.T) {
+	resetRouteState(t)
+	calls := 0
+	withListener(t, true, &calls)
+
+	trackRoute(1, "#system")
+	trackRoute(2, "#sites")
+
+	if calls != 1 {
+		t.Fatalf("listener started %d times, want 1", calls)
+	}
+	routeMu.Lock()
+	n := len(routes)
+	routeMu.Unlock()
+	if n != 2 {
+		t.Fatalf("tracked %d routes, want 2", n)
+	}
+}
+
+// Popups the user never clicks and whose daemon sends no close signal would
+// otherwise accumulate for the life of the daemon.
+func TestTrackRouteEvictsOldest(t *testing.T) {
+	resetRouteState(t)
+	withListener(t, true, nil)
+
+	for i := 0; i < maxTrackedRoutes+50; i++ {
+		trackRoute(uint32(i), "#system")
+	}
+
+	routeMu.Lock()
+	n := len(routes)
+	_, oldestKept := routes[0]
+	_, newestKept := routes[uint32(maxTrackedRoutes+49)]
+	routeMu.Unlock()
+
+	if n > maxTrackedRoutes {
+		t.Fatalf("routes grew to %d, want at most %d", n, maxTrackedRoutes)
+	}
+	if oldestKept {
+		t.Error("oldest route survived eviction")
+	}
+	if !newestKept {
+		t.Error("newest route was evicted")
+	}
+}

--- a/internal/ui/notifier.go
+++ b/internal/ui/notifier.go
@@ -21,12 +21,15 @@ const (
 
 // notifySink resolves where a notification goes. Native is only chosen when the
 // config selects it and a daemon is actually present, so an unsupported host
-// transparently falls back to the browser sink instead of dropping alerts.
-func notifySink(cfg *config.GlobalConfig, nativeSupported bool) sink {
+// transparently falls back to the browser sink instead of dropping alerts. The
+// support probe is a function because it costs a D-Bus round trip: an eagerly
+// evaluated argument would run it for every delivery, including notifications
+// switched off entirely and the browser sink that never touches the bus.
+func notifySink(cfg *config.GlobalConfig, nativeSupported func() bool) sink {
 	if cfg == nil || !cfg.IsNotificationsEnabled() {
 		return sinkOff
 	}
-	if cfg.NotificationTarget() == config.NotifyTargetNative && nativeSupported {
+	if cfg.NotificationTarget() == config.NotifyTargetNative && nativeSupported() {
 		return sinkNative
 	}
 	return sinkBrowser
@@ -54,7 +57,7 @@ func dispatchNotification(n push.Notification) {
 	if err != nil {
 		return
 	}
-	switch notifySink(cfg, desktopnotify.Supported()) {
+	switch notifySink(cfg, desktopnotify.Supported) {
 	case sinkOff:
 		return
 	case sinkNative:

--- a/internal/ui/notifier_test.go
+++ b/internal/ui/notifier_test.go
@@ -31,8 +31,31 @@ func TestNotifySink(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := notifySink(tc.cfg, tc.supported); got != tc.want {
+			if got := notifySink(tc.cfg, func() bool { return tc.supported }); got != tc.want {
 				t.Fatalf("notifySink()=%d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// The probe talks to D-Bus, so it must not run for a sink that will never
+// deliver natively — notifications off, or the browser target.
+func TestNotifySinkProbesOnlyForNativeTarget(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *config.GlobalConfig
+	}{
+		{"nil config", nil},
+		{"globally disabled", cfgWith(true, config.NotifyTargetNative)},
+		{"browser target", cfgWith(false, config.NotifyTargetBrowser)},
+		{"unset target", cfgWith(false, "")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			probed := false
+			notifySink(tc.cfg, func() bool { probed = true; return true })
+			if probed {
+				t.Fatal("native support probe ran for a non-native sink")
 			}
 		})
 	}

--- a/internal/ui/worker_failure_batcher.go
+++ b/internal/ui/worker_failure_batcher.go
@@ -7,17 +7,49 @@ import (
 	"github.com/geodro/lerd/internal/workerheal"
 )
 
-// workerFailureBatchDelay is the quiet window between the first new failure
-// in a burst and the grouped dispatch. Five seconds collapses systemd
-// cascades (start-limit storms, OOM kills hitting several queues at once)
-// into one notification while still feeling immediate for a single failure.
-var workerFailureBatchDelay = 5 * time.Second
+// workerFailureBatchDelay is the settle window between the first new failure
+// in a burst and the grouped dispatch. It collapses systemd cascades
+// (start-limit storms, OOM kills hitting several queues at once) into one
+// notification, and it gives the units time to come back on their own: worker
+// units carry RestartSec=5, so a worker that crashed once is usually active
+// again within a cycle or two. Notifying at five seconds meant most alerts
+// described a worker that had already recovered by the time anyone opened the
+// dashboard, so the window is long enough for several restart attempts to play
+// out and only what is still broken at the end of it gets announced.
+var workerFailureBatchDelay = 30 * time.Second
 
 // workerFailureDispatch is the sink used by the batcher. Production wires it
 // to dispatchNotification; tests override it to observe the grouped payload
 // without exercising the push subsystem.
 var workerFailureDispatch = func(ws []workerheal.UnhealthyWorker) {
 	dispatchNotification(notificationForWorkerFailures(ws))
+}
+
+// workerFailureDetect re-reads current worker health at flush time. Swappable
+// for tests.
+var workerFailureDetect = workerheal.Detect
+
+// stillUnhealthy drops queued failures that recovered during the settle window
+// and refreshes the state of those that did not, so the notification describes
+// the workers as they are when it is sent rather than when they first tripped.
+// A detector error keeps the whole batch: failing to confirm is not evidence of
+// recovery, and staying silent would be the worse mistake.
+func stillUnhealthy(queued []workerheal.UnhealthyWorker) []workerheal.UnhealthyWorker {
+	current, err := workerFailureDetect()
+	if err != nil {
+		return queued
+	}
+	byUnit := make(map[string]workerheal.UnhealthyWorker, len(current))
+	for _, w := range current {
+		byUnit[w.Unit] = w
+	}
+	out := make([]workerheal.UnhealthyWorker, 0, len(queued))
+	for _, q := range queued {
+		if w, ok := byUnit[q.Unit]; ok {
+			out = append(out, w)
+		}
+	}
+	return out
 }
 
 var (
@@ -55,6 +87,9 @@ func flushPendingWorkerFailures() {
 	workerFailureFlushTimer = nil
 	workerFailureBatchMu.Unlock()
 	if len(ws) == 0 {
+		return
+	}
+	if ws = stillUnhealthy(ws); len(ws) == 0 {
 		return
 	}
 	workerFailureDispatch(ws)

--- a/internal/ui/worker_failure_batcher_test.go
+++ b/internal/ui/worker_failure_batcher_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"errors"
 	"sort"
 	"sync"
 	"testing"
@@ -50,8 +51,22 @@ func installBatchTestSink(t *testing.T, delay time.Duration) (wait func() [][]wo
 	}
 }
 
+// confirmUnits stubs the flush-time re-check so the listed units still read as
+// unhealthy and everything else reads as recovered.
+func confirmUnits(t *testing.T, units ...workerheal.UnhealthyWorker) {
+	t.Helper()
+	orig := workerFailureDetect
+	workerFailureDetect = func() ([]workerheal.UnhealthyWorker, error) { return units, nil }
+	t.Cleanup(func() { workerFailureDetect = orig })
+}
+
 func TestQueueWorkerFailureNotifications_BatchesWithinWindow(t *testing.T) {
 	wait := installBatchTestSink(t, 200*time.Millisecond)
+	confirmUnits(t,
+		uw("lerd-queue-a.service", "a.test", "queue", "failed"),
+		uw("lerd-horizon-a.service", "a.test", "horizon", "failed"),
+		uw("lerd-scheduler-b.service", "b.test", "scheduler", "failed"),
+	)
 	queueWorkerFailureNotifications([]workerheal.UnhealthyWorker{
 		uw("lerd-queue-a.service", "a.test", "queue", "failed"),
 	})
@@ -86,6 +101,7 @@ func TestQueueWorkerFailureNotifications_BatchesWithinWindow(t *testing.T) {
 
 func TestQueueWorkerFailureNotifications_DedupesByUnit(t *testing.T) {
 	wait := installBatchTestSink(t, 200*time.Millisecond)
+	confirmUnits(t, uw("lerd-queue-a.service", "a.test", "queue", "start-limit-hit"))
 	queueWorkerFailureNotifications([]workerheal.UnhealthyWorker{
 		uw("lerd-queue-a.service", "a.test", "queue", "failed"),
 	})
@@ -103,6 +119,10 @@ func TestQueueWorkerFailureNotifications_DedupesByUnit(t *testing.T) {
 
 func TestQueueWorkerFailureNotifications_SecondBurstArmsFreshWindow(t *testing.T) {
 	wait := installBatchTestSink(t, 100*time.Millisecond)
+	confirmUnits(t,
+		uw("lerd-queue-a.service", "a.test", "queue", "failed"),
+		uw("lerd-horizon-b.service", "b.test", "horizon", "failed"),
+	)
 	queueWorkerFailureNotifications([]workerheal.UnhealthyWorker{
 		uw("lerd-queue-a.service", "a.test", "queue", "failed"),
 	})
@@ -122,6 +142,71 @@ func TestQueueWorkerFailureNotifications_SecondBurstArmsFreshWindow(t *testing.T
 	}
 	if len(second[1]) != 1 || second[1][0].Unit != "lerd-horizon-b.service" {
 		t.Errorf("second burst payload wrong: %+v", second[1])
+	}
+}
+
+// systemd restarts worker units on its own (RestartSec=5), so a worker that
+// tripped once is often active again before the window closes. Announcing it
+// then sends the user to a dashboard showing nothing wrong.
+func TestFlush_SkipsWorkersThatRecoveredDuringWindow(t *testing.T) {
+	origDispatch := workerFailureDispatch
+	origDelay := workerFailureBatchDelay
+	t.Cleanup(func() {
+		workerFailureDispatch = origDispatch
+		workerFailureBatchDelay = origDelay
+	})
+	var fired bool
+	workerFailureDispatch = func([]workerheal.UnhealthyWorker) { fired = true }
+	workerFailureBatchDelay = 50 * time.Millisecond
+	confirmUnits(t) // everything came back on its own
+
+	queueWorkerFailureNotifications([]workerheal.UnhealthyWorker{
+		uw("lerd-queue-a.service", "a.test", "queue", "failed"),
+	})
+	time.Sleep(200 * time.Millisecond)
+	if fired {
+		t.Error("dispatched a notification for a worker that had already recovered")
+	}
+}
+
+func TestFlush_KeepsWorkersStillDownAndRefreshesState(t *testing.T) {
+	wait := installBatchTestSink(t, 50*time.Millisecond)
+	// One recovered, the other is still down and has since gone from a crash
+	// loop to plain stopped.
+	confirmUnits(t, uw("lerd-horizon-b.service", "b.test", "horizon", "expected-but-stopped"))
+
+	queueWorkerFailureNotifications([]workerheal.UnhealthyWorker{
+		uw("lerd-queue-a.service", "a.test", "queue", "failed"),
+		uw("lerd-horizon-b.service", "b.test", "horizon", "failed"),
+	})
+	calls := wait()
+	if len(calls) != 1 || len(calls[0]) != 1 {
+		t.Fatalf("expected one dispatch carrying one worker, got %+v", calls)
+	}
+	if calls[0][0].Unit != "lerd-horizon-b.service" {
+		t.Errorf("dispatched %q, want the worker that stayed down", calls[0][0].Unit)
+	}
+	if calls[0][0].State != "expected-but-stopped" {
+		t.Errorf("State=%q, want the state re-read at flush time", calls[0][0].State)
+	}
+}
+
+// Failing to confirm is not evidence of recovery, so a broken detector must
+// not turn into silence.
+func TestFlush_KeepsBatchWhenRecheckFails(t *testing.T) {
+	wait := installBatchTestSink(t, 50*time.Millisecond)
+	orig := workerFailureDetect
+	workerFailureDetect = func() ([]workerheal.UnhealthyWorker, error) {
+		return nil, errors.New("systemctl unavailable")
+	}
+	t.Cleanup(func() { workerFailureDetect = orig })
+
+	queueWorkerFailureNotifications([]workerheal.UnhealthyWorker{
+		uw("lerd-queue-a.service", "a.test", "queue", "failed"),
+	})
+	calls := wait()
+	if len(calls) != 1 || len(calls[0]) != 1 {
+		t.Fatalf("expected the unconfirmed batch to still dispatch, got %+v", calls)
 	}
 }
 


### PR DESCRIPTION
Two problems in the notification path, both of which end with the user either waiting on something that never returns or reading an alert about a worker that is fine.

The desktop notification package called D-Bus with godbus's zero flag everywhere, which is context.Background() with no deadline, so a wedged notification daemon blocked the calling goroutine indefinitely. The callers are synchronous, so that reaches the mailpit webhook and the service install, migrate and reinstall handlers at one stuck goroutine per event with nothing bounding how many pile up, and the PHP install handler dispatches before its in-flight defer runs, so a blocked call held that lock and the version could not be reinstalled without restarting lerd-ui. Every call is bounded at three seconds now.

Supported() reached the bus on every delivery because it was an eagerly evaluated argument, including with notifications switched off and on the browser sink that never talks to D-Bus at all. Session bus discovery no longer falls through to dbus-launch, which was starting a daemon that outlived lerd and leaving an orphan behind after lerd start over SSH, and the connection is cached instead of rediscovered per notification. The click listener no longer burns its sync.Once on a failed start, which used to leave the routes map growing unbounded and notification clicks dead for the rest of the process, and that map is capped with oldest first eviction. OpenApp uses Start like the tray and CLI launchers rather than Run, which was blocking lerd dashboard and freezing the tray's Dashboard item behind it.

The second problem is the one you notice daily. Worker units carry Restart=always with RestartSec=5, so a worker that crashes once is usually back on its own within a cycle or two, and the batcher was dispatching about ten seconds after a failure, right in the middle of the window systemd uses to fix it. Most worker_failed notifications described a worker that had already recovered, so you would open the dashboard to a cleared banner and everything green. The batcher now holds a new failure for thirty seconds, still grouping a cascade into one notification, then re-reads health and drops whatever came back. What is left carries the state read at flush time, so a unit that went from a crash loop to plain stopped is described as it actually is, and a detector error keeps the batch rather than turning into silence. The dashboard banner is unaffected and still appears immediately.

Refs #996
Refs #1017