### PR TITLE
Fold a site's _testing database into its parent card on the Databases tab

### DIFF
--- a/docs/usage/database.md
+++ b/docs/usage/database.md
@@ -48,6 +48,7 @@ Each database engine's detail page in the web UI (Services → pick MySQL, Maria
 - **Copy connection string** builds a ready-to-paste DSN for that specific database, which works whether or not an admin UI is installed.
 - **Open in the admin UI** appears on the card when an admin tool is installed for the engine, and opens it straight to this database when the tool supports a per-database URL (phpMyAdmin and Adminer for MySQL/MariaDB, Mongo Express for MongoDB). pgAdmin has no such URL, so it opens at its root.
 - **The linked site**, when a site owns the database, is shown as a link on the card that jumps to that site. A `<name>_testing` database links to the same site as `<name>`.
+- **A `<name>_testing` database shares the card of the `<name>` database it tests**, rather than taking a second card of its own for what is usually an empty database. The card header carries an App/Testing segment, and the name, size, linked site and every action below it act on whichever half is selected, so an export, an import, a snapshot or a drop always applies to the database currently shown. Dropping one half leaves the other in place. A `_testing` database whose matching database does not exist keeps an ordinary card of its own.
 
 The same "open in the admin tool" affordance is on the database service card in a site's own overview (a database-icon button), so from a site you can jump straight into that site's database in phpMyAdmin, Adminer or Mongo Express.
 

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "App",
+  "databases_targetTesting": "Test",
+  "databases_targetLabel": "Auf welche Datenbank sich diese Aktionen beziehen",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "App",
+  "databases_targetTesting": "Testing",
+  "databases_targetLabel": "Which database these controls act on",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "App",
+  "databases_targetTesting": "Pruebas",
+  "databases_targetLabel": "Sobre qué base de datos actúan estos controles",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "App",
+  "databases_targetTesting": "Test",
+  "databases_targetLabel": "Base de données sur laquelle agissent ces actions",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "Aplikasi",
+  "databases_targetTesting": "Pengujian",
+  "databases_targetLabel": "Basis data yang dikenai kontrol ini",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "App",
+  "databases_targetTesting": "Test",
+  "databases_targetLabel": "Su quale database agiscono questi controlli",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "アプリ",
+  "databases_targetTesting": "テスト",
+  "databases_targetLabel": "これらの操作の対象となるデータベース",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "App",
+  "databases_targetTesting": "Test",
+  "databases_targetLabel": "Op welke database deze acties werken",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "Aplikacja",
+  "databases_targetTesting": "Testowa",
+  "databases_targetLabel": "Na której bazie danych działają te akcje",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "App",
+  "databases_targetTesting": "Testes",
+  "databases_targetLabel": "Sobre qual base de dados estas ações atuam",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "Aplicație",
+  "databases_targetTesting": "Testare",
+  "databases_targetLabel": "Pe care bază de date acționează aceste comenzi",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "Uygulama",
+  "databases_targetTesting": "Test",
+  "databases_targetLabel": "Bu denetimlerin etkilediği veritabanı",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "Ứng dụng",
+  "databases_targetTesting": "Kiểm thử",
+  "databases_targetLabel": "Các thao tác này áp dụng cho cơ sở dữ liệu nào",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -1116,6 +1116,9 @@
   "databases_delete": "Delete",
   "databases_noSnapshots": "No snapshots yet.",
   "databases_openIn": "Open in {name}",
+  "databases_targetApp": "应用",
+  "databases_targetTesting": "测试",
+  "databases_targetLabel": "这些操作作用于哪个数据库",
   "databases_deleteConfirm": "Confirm delete",
   "databases_count": "{count} databases"
 }

--- a/internal/ui/web/src/components/SegmentedControl.svelte
+++ b/internal/ui/web/src/components/SegmentedControl.svelte
@@ -1,0 +1,37 @@
+<script lang="ts" module>
+  export interface SegmentOption<T extends string = string> {
+    value: T;
+    label: string;
+    title?: string;
+  }
+</script>
+
+<script lang="ts" generics="T extends string">
+  import { tooltip } from '$lib/tooltip';
+
+  interface Props {
+    options: SegmentOption<T>[];
+    value: T;
+    label?: string;
+    onchange: (value: T) => void;
+  }
+  let { options, value, label = '', onchange }: Props = $props();
+</script>
+
+<div
+  role="group"
+  aria-label={label}
+  class="inline-flex shrink-0 gap-0.5 p-0.5 rounded-lg border border-gray-200 dark:border-lerd-border bg-gray-100 dark:bg-white/5"
+>
+  {#each options as opt (opt.value)}
+    <button
+      type="button"
+      aria-pressed={opt.value === value}
+      use:tooltip={opt.title ?? ''}
+      onclick={() => opt.value !== value && onchange(opt.value)}
+      class="px-2 py-0.5 rounded-md text-[10px] font-semibold transition-colors {opt.value === value
+        ? 'bg-white dark:bg-lerd-card text-gray-800 dark:text-gray-100 shadow-xs'
+        : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'}"
+    >{opt.label}</button>
+  {/each}
+</div>

--- a/internal/ui/web/src/components/SegmentedControl.test.svelte
+++ b/internal/ui/web/src/components/SegmentedControl.test.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import SegmentedControl, { type SegmentOption } from './SegmentedControl.svelte';
+
+  interface Props {
+    options: SegmentOption[];
+    value: string;
+    label?: string;
+    onchange?: (value: string) => void;
+  }
+  let { options, value, label = '', onchange = () => {} }: Props = $props();
+</script>
+
+<SegmentedControl {options} {value} {label} {onchange} />

--- a/internal/ui/web/src/components/SegmentedControl.test.ts
+++ b/internal/ui/web/src/components/SegmentedControl.test.ts
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect, vi } from 'vitest';
+import Harness from './SegmentedControl.test.svelte';
+
+const options = [
+  { value: 'app', label: 'App' },
+  { value: 'testing', label: 'Testing' }
+];
+
+describe('SegmentedControl', () => {
+  it('renders one button per option', () => {
+    render(Harness, { props: { options, value: 'app' } });
+    expect(screen.getByRole('button', { name: 'App' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Testing' })).toBeInTheDocument();
+  });
+
+  it('marks only the selected option as pressed', () => {
+    render(Harness, { props: { options, value: 'testing' } });
+    expect(screen.getByRole('button', { name: 'App' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: 'Testing' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('reports the value when another option is clicked', () => {
+    const onchange = vi.fn();
+    render(Harness, { props: { options, value: 'app', onchange } });
+    screen.getByRole('button', { name: 'Testing' }).click();
+    expect(onchange).toHaveBeenCalledWith('testing');
+  });
+
+  it('stays quiet when the selected option is clicked again', () => {
+    const onchange = vi.fn();
+    render(Harness, { props: { options, value: 'app', onchange } });
+    screen.getByRole('button', { name: 'App' }).click();
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it('labels the group for assistive tech', () => {
+    render(Harness, { props: { options, value: 'app', label: 'Target database' } });
+    expect(screen.getByRole('group', { name: 'Target database' })).toBeInTheDocument();
+  });
+});

--- a/internal/ui/web/src/lib/databasePairs.test.ts
+++ b/internal/ui/web/src/lib/databasePairs.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { pairDatabases } from './databasePairs';
+import type { DatabaseEntry } from '$stores/databases';
+
+function db(name: string, size = 0, site?: string): DatabaseEntry {
+  return { name, size_bytes: size, site, snapshots: [] };
+}
+
+describe('pairDatabases', () => {
+  it('folds a testing database into the parent it belongs to', () => {
+    const pairs = pairDatabases([db('havenly', 4096, 'havenly.test'), db('havenly_testing')]);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].entry.name).toBe('havenly');
+    expect(pairs[0].testing?.name).toBe('havenly_testing');
+  });
+
+  it('pairs regardless of the order the engine returned them in', () => {
+    const pairs = pairDatabases([db('havenly_testing'), db('havenly')]);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].entry.name).toBe('havenly');
+    expect(pairs[0].testing?.name).toBe('havenly_testing');
+  });
+
+  it('keeps a testing database standalone when its parent is absent', () => {
+    const pairs = pairDatabases([db('scratch_testing'), db('ledgerly')]);
+    expect(pairs.map((p) => p.entry.name)).toEqual(['scratch_testing', 'ledgerly']);
+    expect(pairs.every((p) => p.testing === undefined)).toBe(true);
+  });
+
+  it('leaves a parent without a testing sibling as a plain entry', () => {
+    const pairs = pairDatabases([db('ledgerly', 8192)]);
+    expect(pairs).toEqual([{ entry: db('ledgerly', 8192) }]);
+  });
+
+  it('preserves the order the engine returned, taking each pair at the parent position', () => {
+    const pairs = pairDatabases([
+      db('alpha'),
+      db('beta_testing'),
+      db('beta'),
+      db('gamma_testing')
+    ]);
+    expect(pairs.map((p) => p.entry.name)).toEqual(['alpha', 'beta', 'gamma_testing']);
+  });
+
+  it('does not treat the bare suffix as a testing database of an empty name', () => {
+    const pairs = pairDatabases([db('_testing')]);
+    expect(pairs).toEqual([{ entry: db('_testing') }]);
+  });
+
+  it('does not chain a doubly suffixed name past its direct parent', () => {
+    const pairs = pairDatabases([db('havenly_testing'), db('havenly_testing_testing')]);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].entry.name).toBe('havenly_testing');
+    expect(pairs[0].testing?.name).toBe('havenly_testing_testing');
+  });
+
+  it('returns nothing for an empty engine', () => {
+    expect(pairDatabases([])).toEqual([]);
+  });
+});

--- a/internal/ui/web/src/lib/databasePairs.ts
+++ b/internal/ui/web/src/lib/databasePairs.ts
@@ -1,0 +1,35 @@
+import type { DatabaseEntry } from '$stores/databases';
+
+const SUFFIX = '_testing';
+
+export interface DatabasePair {
+  entry: DatabaseEntry;
+  // The <name>_testing sibling, present only when this entry's own database exists.
+  testing?: DatabaseEntry;
+}
+
+// pairDatabases folds each "<name>_testing" database into the card of the database
+// it tests. A testing database whose parent isn't there keeps its own entry, so
+// nothing an engine reported ever disappears from the grid.
+export function pairDatabases(list: DatabaseEntry[]): DatabasePair[] {
+  const names = new Set(list.map((e) => e.name));
+  const parentOf = (name: string): string | null => {
+    if (!name.endsWith(SUFFIX)) return null;
+    const parent = name.slice(0, -SUFFIX.length);
+    return parent !== '' && names.has(parent) ? parent : null;
+  };
+
+  const pairs: DatabasePair[] = [];
+  const index = new Map<string, DatabasePair>();
+  for (const entry of list) {
+    if (parentOf(entry.name)) continue;
+    const pair: DatabasePair = { entry };
+    pairs.push(pair);
+    index.set(entry.name, pair);
+  }
+  for (const entry of list) {
+    const parent = parentOf(entry.name);
+    if (parent) index.get(parent)!.testing = entry;
+  }
+  return pairs;
+}

--- a/internal/ui/web/src/tabs/databases/DatabaseCard.svelte
+++ b/internal/ui/web/src/tabs/databases/DatabaseCard.svelte
@@ -16,13 +16,21 @@
   import { databaseAdminFor, openDatabaseAdmin } from '$stores/dashboard';
   import { goToTab } from '$stores/route';
   import DatabaseSnapshotsModal from './DatabaseSnapshotsModal.svelte';
+  import SegmentedControl from '$components/SegmentedControl.svelte';
   import { m } from '../../paraglide/messages.js';
 
   interface Props {
     engine: DatabaseEngine;
     entry: DatabaseEntry;
+    // The entry's "<name>_testing" sibling, folded into this card when it exists.
+    testing?: DatabaseEntry;
   }
-  let { engine, entry }: Props = $props();
+  let { engine, entry, testing }: Props = $props();
+
+  let target = $state<'app' | 'testing'>('app');
+  // Everything below acts on the half the segment points at, and falls back to
+  // the parent so dropping the testing database can't leave the card orphaned.
+  const active = $derived(target === 'testing' && testing ? testing : entry);
 
   let copied = $state(false);
   let showSnapshots = $state(false);
@@ -33,7 +41,7 @@
   let fileInput = $state<HTMLInputElement | null>(null);
 
   const sqlOps = $derived(engine.supports_snapshot);
-  const snapshotCount = $derived(entry.snapshots?.length ?? 0);
+  const snapshotCount = $derived(active.snapshots?.length ?? 0);
   // The installed admin tool that can open this specific database (phpMyAdmin,
   // Adminer, Mongo Express); null when none is installed or can't deep-link.
   const admin = $derived.by(() => {
@@ -42,7 +50,7 @@
   });
 
   async function copyDsn() {
-    const dsn = dsnFor(engine, entry.name);
+    const dsn = dsnFor(engine, active.name);
     if (!dsn) return;
     await navigator.clipboard.writeText(dsn);
     copied = true;
@@ -55,14 +63,14 @@
     input.value = '';
     if (!file) return;
     importBusy = true;
-    await importDatabase(engine.service, entry.name, file);
+    await importDatabase(engine.service, active.name, file);
     importBusy = false;
   }
 
   async function confirmDrop() {
     dropBusy = true;
     dropError = '';
-    const res = await dropDatabase(engine.service, entry.name);
+    const res = await dropDatabase(engine.service, active.name);
     dropBusy = false;
     if (!res.ok) {
       dropError = res.error || m.common_failed();
@@ -76,20 +84,31 @@
   <div class="flex items-start gap-2">
     <Icon name="database" class="w-4 h-4 mt-0.5 shrink-0 text-gray-300 dark:text-gray-600" />
     <div class="min-w-0 flex-1">
-      <p class="truncate text-sm font-semibold text-gray-800 dark:text-gray-100" title={entry.name}>{entry.name}</p>
+      <p class="truncate text-sm font-semibold text-gray-800 dark:text-gray-100" title={active.name}>{active.name}</p>
       <p class="flex items-center gap-1.5 text-xs text-gray-400 dark:text-gray-500">
-        <span class="tabular-nums">{formatBytes(entry.size_bytes)}</span>
-        {#if entry.site}
+        <span class="tabular-nums">{formatBytes(active.size_bytes)}</span>
+        {#if active.site}
           <span aria-hidden="true">·</span>
           <button
             type="button"
-            onclick={() => goToTab('sites', entry.site ?? '')}
+            onclick={() => goToTab('sites', active.site ?? '')}
             class="min-w-0 truncate text-sky-600 dark:text-sky-400 hover:underline"
-            title={entry.site}
-          >{entry.site}</button>
+            title={active.site}
+          >{active.site}</button>
         {/if}
       </p>
     </div>
+    {#if testing}
+      <SegmentedControl
+        label={m.databases_targetLabel()}
+        value={target}
+        options={[
+          { value: 'app', label: m.databases_targetApp(), title: entry.name },
+          { value: 'testing', label: m.databases_targetTesting(), title: testing.name }
+        ]}
+        onchange={(v) => (target = v)}
+      />
+    {/if}
   </div>
 
   <div class="flex items-center gap-0.5 mt-2 pt-2 border-t border-gray-100 dark:border-lerd-border/60">
@@ -98,7 +117,7 @@
         type="button"
         use:tooltip={m.databases_openIn({ name: serviceLabel(admin.name) })}
         aria-label={m.databases_openIn({ name: serviceLabel(admin.name) })}
-        onclick={() => openDatabaseAdmin(engine.service, entry.name)}
+        onclick={() => openDatabaseAdmin(engine.service, active.name)}
         class="flex items-center justify-center w-7 h-7 rounded-md text-gray-400 dark:text-gray-500 hover:text-lerd-red hover:bg-gray-100 dark:hover:bg-white/5 transition-colors"
       >
         <Icon name="external" class="w-3.5 h-3.5" />
@@ -116,7 +135,7 @@
 
     {#if sqlOps}
       <a
-        href={exportUrl(engine.service, entry.name)}
+        href={exportUrl(engine.service, active.name)}
         use:tooltip={m.databases_export()}
         aria-label={m.databases_export()}
         class="flex items-center justify-center w-7 h-7 rounded-md text-gray-400 dark:text-gray-500 hover:text-lerd-red hover:bg-gray-100 dark:hover:bg-white/5 transition-colors"
@@ -164,11 +183,11 @@
 </div>
 
 {#if showSnapshots}
-  <DatabaseSnapshotsModal {engine} {entry} onclose={() => (showSnapshots = false)} />
+  <DatabaseSnapshotsModal {engine} entry={active} onclose={() => (showSnapshots = false)} />
 {/if}
 
 {#if showDrop}
-  <Modal open title={m.databases_dropTitle({ name: entry.name })} onclose={() => !dropBusy && (showDrop = false)} size="sm">
+  <Modal open title={m.databases_dropTitle({ name: active.name })} onclose={() => !dropBusy && (showDrop = false)} size="sm">
     <div class="px-5 py-4 space-y-2">
       <p class="text-sm text-gray-700 dark:text-gray-300">{m.databases_dropBody()}</p>
       {#if dropError}

--- a/internal/ui/web/src/tabs/databases/DatabaseCard.test.ts
+++ b/internal/ui/web/src/tabs/databases/DatabaseCard.test.ts
@@ -1,0 +1,85 @@
+import { render, fireEvent, within } from '@testing-library/svelte';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import DatabaseCard from './DatabaseCard.svelte';
+import type { DatabaseEngine, DatabaseEntry } from '$stores/databases';
+
+const { dropDatabase, exportUrl } = vi.hoisted(() => ({
+  dropDatabase: vi.fn(async () => ({ ok: true })),
+  exportUrl: vi.fn((service: string, database: string) => `/api/${service}/export?database=${database}`)
+}));
+vi.mock('$stores/databases', async (orig) => {
+  const actual = (await orig()) as object;
+  return { ...actual, dropDatabase, exportUrl };
+});
+
+const engine: DatabaseEngine = {
+  service: 'mysql',
+  family: 'mysql',
+  status: 'active',
+  supports_create: true,
+  supports_snapshot: true,
+  databases: []
+};
+
+function db(name: string, size = 0, site?: string): DatabaseEntry {
+  return { name, size_bytes: size, site, snapshots: [] };
+}
+
+const parent = db('havenly', 4096, 'havenly.test');
+const testing = db('havenly_testing', 0, 'havenly.test');
+
+describe('DatabaseCard', () => {
+  beforeEach(() => {
+    dropDatabase.mockClear();
+    exportUrl.mockClear();
+  });
+
+  it('shows no segment when the entry has no testing sibling', () => {
+    const { queryByRole } = render(DatabaseCard, { props: { engine, entry: parent } });
+    expect(queryByRole('group')).not.toBeInTheDocument();
+  });
+
+  it('opens on the parent database when paired', () => {
+    const { getByText, getByRole } = render(DatabaseCard, {
+      props: { engine, entry: parent, testing }
+    });
+    expect(getByText('havenly')).toBeInTheDocument();
+    expect(within(getByRole('group')).getByRole('button', { name: 'App' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+
+  it('retargets the name, size and site link to the testing database', async () => {
+    const { getByRole, getByText, queryByText } = render(DatabaseCard, {
+      props: { engine, entry: db('havenly', 4096, 'havenly.test'), testing: db('havenly_testing', 16384, 'havenly.test') }
+    });
+    await fireEvent.click(within(getByRole('group')).getByRole('button', { name: 'Testing' }));
+    expect(getByText('havenly_testing')).toBeInTheDocument();
+    expect(queryByText('havenly')).not.toBeInTheDocument();
+    expect(getByText('16.0 KB')).toBeInTheDocument();
+    expect(getByText('havenly.test')).toBeInTheDocument();
+  });
+
+  it('drops only the half the segment points at', async () => {
+    const { getByRole, getByLabelText, getAllByRole } = render(DatabaseCard, {
+      props: { engine, entry: parent, testing }
+    });
+    await fireEvent.click(within(getByRole('group')).getByRole('button', { name: 'Testing' }));
+    await fireEvent.click(getByLabelText('Drop'));
+    const confirm = getAllByRole('button', { name: 'Drop' }).at(-1)!;
+    await fireEvent.click(confirm);
+    expect(dropDatabase).toHaveBeenCalledWith('mysql', 'havenly_testing');
+  });
+
+  it('points export at the selected half', async () => {
+    const { getByRole, getByLabelText } = render(DatabaseCard, {
+      props: { engine, entry: parent, testing }
+    });
+    await fireEvent.click(within(getByRole('group')).getByRole('button', { name: 'Testing' }));
+    expect(getByLabelText('Export')).toHaveAttribute(
+      'href',
+      expect.stringContaining('havenly_testing')
+    );
+  });
+});

--- a/internal/ui/web/src/tabs/services/ServiceDatabasesTab.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceDatabasesTab.svelte
@@ -3,6 +3,7 @@
   import DetailButton from '$components/DetailButton.svelte';
   import { databases, loadEngine, createDatabase } from '$stores/databases';
   import type { Service } from '$stores/services';
+  import { pairDatabases } from '$lib/databasePairs';
   import DatabaseCard from '../databases/DatabaseCard.svelte';
   import { m } from '../../paraglide/messages.js';
 
@@ -19,6 +20,7 @@
 
   const engine = $derived($databases.find((e) => e.service === svc.name));
   const active = $derived(engine?.status === 'active');
+  const pairs = $derived(pairDatabases(engine?.databases ?? []));
 
   let newName = $state('');
   let creating = $state(false);
@@ -68,8 +70,8 @@
       <p class="text-sm text-gray-400 dark:text-gray-500">{m.databases_noDatabases()}</p>
     {:else}
       <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-        {#each engine.databases as entry (entry.name)}
-          <DatabaseCard {engine} {entry} />
+        {#each pairs as pair (pair.entry.name)}
+          <DatabaseCard {engine} entry={pair.entry} testing={pair.testing} />
         {/each}
       </div>
     {/if}


### PR DESCRIPTION
The Databases tab listed every database the engine reported, so a site with a testing database took two identical cards and the second one was almost always empty. On a real MySQL install that meant 35 cards where 19 carry anything worth reading.

A _testing database now shares the card of the database it tests. The header carries an App/Testing segment, and the name, size, linked site and every action below it act on whichever half is selected, so an export, an import, a snapshot or a drop always applies to the database currently on screen. Dropping one half leaves the other in place.

Grouping only happens when a database exists whose name is the _testing name without the suffix. A testing database with no matching parent keeps an ordinary card of its own, so nothing an engine reports can disappear from the grid.

The segment itself is a new SegmentedControl component, since nothing in components/ covered a two-state switch of this shape.

Closes #1019