### PR TITLE
fix(php): pin a worktree's PHP switch on the checkout, not its parent site

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -37,6 +37,8 @@ Inside a linked site, the commands that run PHP in a container (`lerd php`, `ler
 
 A git worktree resolves ahead of the site it belongs to. A worktree inherits its parent site's version until you pin one with `lerd isolate` from inside the checkout, and from then on the whole toolchain follows that pin: the worktree's own vhost, `lerd php`, `lerd composer`, and everything else that runs PHP in a container. This holds wherever the checkout lives, including inside the parent site's own directory, so a worktree on 8.3 under a site on 8.5 runs composer on 8.3 rather than picking up the parent's version.
 
+When a command needs a version that is not installed and you decline the install, lerd offers to switch to one you already have and pins the choice. Inside a worktree that pin is written on the checkout itself, so the switch travels with the branch and the parent site keeps the version it was on.
+
 So that the project agrees with what actually runs, `lerd link` pins the resolved version into `.php-version`, the same file `lerd isolate` and the dashboard's PHP dropdown write. A pin the framework does not support is rewritten to the version lerd runs, and a version outside the framework's range is clamped rather than accepted, so the file, the site registry and the container can never drift apart. Sites with no lerd-managed PHP version (host-proxy, and custom containers whose version comes from their Containerfile) are left untouched.
 
 ---

--- a/internal/cli/fpm_ensure.go
+++ b/internal/cli/fpm_ensure.go
@@ -7,9 +7,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/siteops"
 	"golang.org/x/term"
 )
 
@@ -207,6 +209,10 @@ func otherInstalledVersions(exclude string) []string {
 // composer's constraint. Best-effort: a write failure or a higher-priority
 // .lerd.yaml override only warns, since the switch still applies to this run.
 func persistPHPVersion(cwd, version string) {
+	if wt, _, ok := phpDet.WorktreeRootFor(cwd); ok {
+		persistWorktreePHPVersion(wt, version)
+		return
+	}
 	root := phpDet.SiteRootFor(cwd)
 	path := root + "/.php-version"
 	if err := os.WriteFile(path, []byte(version+"\n"), 0o644); err != nil {
@@ -217,6 +223,21 @@ func persistPHPVersion(cwd, version string) {
 	if got, err := phpDet.DetectVersion(root); err == nil && got != version {
 		feedback.Warn(".lerd.yaml pins PHP %s, which overrides the .php-version file", got)
 	}
+}
+
+// persistWorktreePHPVersion pins a switch made inside a worktree on the checkout
+// itself, leaving the parent site alone. It writes the same pair a branch-scoped
+// version switch does: the .php-version file for other tooling, and the .lerd.yaml
+// override the worktree's effective version actually comes from.
+func persistWorktreePHPVersion(worktree, version string) {
+	if err := siteops.PinPHPVersionFile(worktree, version); err != nil {
+		feedback.Warn("could not pin PHP %s (%s): %v", version, worktree+"/.php-version", err)
+	}
+	if err := config.SetWorktreePHPVersion(worktree, version); err != nil {
+		feedback.Warn("could not pin PHP %s for this worktree: %v", version, err)
+		return
+	}
+	feedback.Note(fmt.Sprintf("Pinned PHP %s for this worktree (%s)", version, worktree))
 }
 
 // notInstalledErr builds the error returned when a version isn't installed and

--- a/internal/cli/persist_php_version_test.go
+++ b/internal/cli/persist_php_version_test.go
@@ -17,7 +17,7 @@ func TestPersistPHPVersion_NestedWorktreePinsTheWorktree(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)
 
-	site := filepath.Join(t.TempDir(), "app")
+	site := filepath.Join(tempRoot(t), "app")
 	wt := filepath.Join(site, "wt", "feature")
 	makeWorktree(t, site, wt, "feature")
 
@@ -43,7 +43,7 @@ func TestPersistPHPVersion_SiblingWorktreePinsTheWorktree(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)
 
-	root := t.TempDir()
+	root := tempRoot(t)
 	site := filepath.Join(root, "app")
 	wt := filepath.Join(root, "app-feature")
 	makeWorktree(t, site, wt, "feature")
@@ -66,7 +66,7 @@ func TestPersistPHPVersion_SubdirOfWorktreePinsTheWorktreeRoot(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)
 
-	site := filepath.Join(t.TempDir(), "app")
+	site := filepath.Join(tempRoot(t), "app")
 	wt := filepath.Join(site, "wt", "feature")
 	makeWorktree(t, site, wt, "feature")
 	sub := filepath.Join(wt, "app", "Http")
@@ -92,7 +92,7 @@ func TestPersistPHPVersion_PlainSitePinsTheSiteRoot(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)
 
-	site := filepath.Join(t.TempDir(), "app")
+	site := filepath.Join(tempRoot(t), "app")
 	sub := filepath.Join(site, "app", "Http")
 	if err := os.MkdirAll(sub, 0755); err != nil {
 		t.Fatal(err)
@@ -104,6 +104,18 @@ func TestPersistPHPVersion_PlainSitePinsTheSiteRoot(t *testing.T) {
 	persistPHPVersion(sub, "8.3")
 
 	assertPinFile(t, site, "8.3")
+}
+
+// tempRoot is t.TempDir() with symlinks resolved. AddSite canonicalises a site's
+// path, and on macOS the temp dir sits under /var, a symlink to /private/var, so
+// an unresolved path would never prefix-match the registered site.
+func tempRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
 }
 
 func assertPinFile(t *testing.T, dir, want string) {

--- a/internal/cli/persist_php_version_test.go
+++ b/internal/cli/persist_php_version_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// TestPersistPHPVersion_NestedWorktreePinsTheWorktree covers switching version from
+// inside a worktree checked out under its parent site. The parent matches by path
+// prefix, so without resolving the worktree the pin lands at the parent root: the
+// branch keeps its old version and the parent is repinned as a side effect.
+func TestPersistPHPVersion_NestedWorktreePinsTheWorktree(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	site := filepath.Join(t.TempDir(), "app")
+	wt := filepath.Join(site, "wt", "feature")
+	makeWorktree(t, site, wt, "feature")
+
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.5"}); err != nil {
+		t.Fatal(err)
+	}
+
+	persistPHPVersion(wt, "8.3")
+
+	if got, err := phpVersionForDir(wt); err != nil || got != "8.3" {
+		t.Errorf("phpVersionForDir = %q (err %v), want %q", got, err, "8.3")
+	}
+	assertPinFile(t, wt, "8.3")
+	if _, err := os.Stat(filepath.Join(site, ".php-version")); !os.IsNotExist(err) {
+		t.Errorf("parent site was repinned by a switch made in the worktree")
+	}
+}
+
+// TestPersistPHPVersion_SiblingWorktreePinsTheWorktree covers the same switch from a
+// worktree checked out beside its project. It matches no registered site, so the pin
+// file already landed here, but only the .lerd.yaml override actually takes effect.
+func TestPersistPHPVersion_SiblingWorktreePinsTheWorktree(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	root := t.TempDir()
+	site := filepath.Join(root, "app")
+	wt := filepath.Join(root, "app-feature")
+	makeWorktree(t, site, wt, "feature")
+
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.5"}); err != nil {
+		t.Fatal(err)
+	}
+
+	persistPHPVersion(wt, "8.3")
+
+	if got, err := phpVersionForDir(wt); err != nil || got != "8.3" {
+		t.Errorf("phpVersionForDir = %q (err %v), want %q", got, err, "8.3")
+	}
+	assertPinFile(t, wt, "8.3")
+}
+
+// TestPersistPHPVersion_SubdirOfWorktreePinsTheWorktreeRoot resolves the checkout
+// from a directory inside it, since commands run from anywhere in the project.
+func TestPersistPHPVersion_SubdirOfWorktreePinsTheWorktreeRoot(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	site := filepath.Join(t.TempDir(), "app")
+	wt := filepath.Join(site, "wt", "feature")
+	makeWorktree(t, site, wt, "feature")
+	sub := filepath.Join(wt, "app", "Http")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.5"}); err != nil {
+		t.Fatal(err)
+	}
+
+	persistPHPVersion(sub, "8.3")
+
+	assertPinFile(t, wt, "8.3")
+	if _, err := os.Stat(filepath.Join(sub, ".php-version")); !os.IsNotExist(err) {
+		t.Errorf("pin landed in the subdirectory instead of the worktree root")
+	}
+}
+
+// TestPersistPHPVersion_PlainSitePinsTheSiteRoot keeps the ordinary case working:
+// from a subdirectory of a registered site the pin belongs at the project root.
+func TestPersistPHPVersion_PlainSitePinsTheSiteRoot(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	site := filepath.Join(t.TempDir(), "app")
+	sub := filepath.Join(site, "app", "Http")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.5"}); err != nil {
+		t.Fatal(err)
+	}
+
+	persistPHPVersion(sub, "8.3")
+
+	assertPinFile(t, site, "8.3")
+}
+
+func assertPinFile(t *testing.T, dir, want string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, ".php-version"))
+	if err != nil {
+		t.Fatalf("reading .php-version in %s: %v", dir, err)
+	}
+	if got := strings.TrimSpace(string(data)); got != want {
+		t.Errorf(".php-version = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Switching PHP version from inside a worktree pinned the parent site instead of the branch. persistPHPVersion resolved its target with SiteRootFor, which matches registered sites by path prefix, so a worktree checked out under its parent site's directory resolved to the parent. The version the user chose was written to the parent's .php-version and the worktree kept the version it was already on.

It now resolves the checkout through WorktreeRootFor, the resolver version detection and container selection already share, and writes the pin on the worktree. It writes both the .php-version file and the .lerd.yaml override, since a worktree's effective version comes from the override and a lone pin file there is never read. That also covers the sibling layout, which landed the file in the right directory but in a form nothing consumed.

Closes #1002