### PR TITLE
fix(shims): read a nested worktree's own env when routing a database client tool

### DIFF
--- a/docs/usage/database.md
+++ b/docs/usage/database.md
@@ -250,6 +250,8 @@ mysqldump -h db.example.com -P 25060 -u doadmin -p --ssl-ca=ca.crt yourdb > dump
 
 When you give no host, the tool connects to a local lerd database with its admin credentials, so `pg_dump mydb` or `mysqldump mydb` just works. If you run it from a project directory, it targets that project's own database service, read from the project's `DB_HOST`, so a mariadb-backed project routes to your mariadb container rather than the default mysql one. Outside a project, or when the project's database is a different family than the tool, it falls back to the family's default service. Passing `-h` (an external host) turns all of this off and the shim forwards everything untouched. For scripted local dumps `lerd db:export` is still the tidier option; the raw shim is there for external databases and IDEs.
 
+Run from inside a git worktree, the shim reads that checkout's own env file rather than the parent site's, so a branch with an isolated database dumps from its own schema even when the worktree lives inside the parent's directory. A worktree whose env was never rewritten keeps using the parent site's.
+
 To point an IDE at a tool, use its shim path, for example `~/.local/share/lerd/bin/mysqldump`.
 
 ### Managing shims

--- a/internal/cli/client_shims.go
+++ b/internal/cli/client_shims.go
@@ -197,12 +197,24 @@ func siteServiceForTool(cwd, tool string) string {
 	if !isSQLTool(tool) {
 		return ""
 	}
-	host := envfile.ReadKey(filepath.Join(phpDet.SiteRootFor(cwd), ".env"), "DB_HOST")
+	host := envfile.ReadKey(filepath.Join(dbEnvRootFor(cwd), ".env"), "DB_HOST")
 	svc, ok := strings.CutPrefix(host, "lerd-")
 	if !ok || svc == "" {
 		return ""
 	}
 	return svc
+}
+
+// dbEnvRootFor returns the directory whose .env describes the database a command
+// run from cwd talks to. A worktree nested inside its parent site matches that
+// site by path, so reading the site root would route a branch at the parent's DB.
+func dbEnvRootFor(cwd string) string {
+	if wt, _, ok := phpDet.WorktreeRootFor(cwd); ok {
+		if _, err := os.Stat(filepath.Join(wt, ".env")); err == nil {
+			return wt
+		}
+	}
+	return phpDet.SiteRootFor(cwd)
 }
 
 // pathUnder reports whether path is base or nested under it, so a cwd already

--- a/internal/cli/client_shims_worktree_test.go
+++ b/internal/cli/client_shims_worktree_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func writeEnv(t *testing.T, dir, host string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("DB_HOST="+host+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSiteServiceForTool_NestedWorktreeUsesItsOwnEnv covers a dump run from a
+// worktree checked out inside its parent site. The parent matches by path prefix,
+// so without resolving the worktree the shim reads the parent's DB_HOST and a
+// branch dump silently comes from the parent's database.
+func TestSiteServiceForTool_NestedWorktreeUsesItsOwnEnv(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	site := filepath.Join(tempRoot(t), "app")
+	wt := filepath.Join(site, "wt", "feature")
+	makeWorktree(t, site, wt, "feature")
+	writeEnv(t, site, "lerd-mysql-8.4")
+	writeEnv(t, wt, "lerd-postgres-17")
+
+	if err := config.AddSite(config.Site{Name: "app", Path: site}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := siteServiceForTool(wt, "psql"); got != "postgres-17" {
+		t.Errorf("siteServiceForTool = %q, want %q", got, "postgres-17")
+	}
+}
+
+// TestSiteServiceForTool_SubdirOfWorktreeUsesTheWorktreeEnv resolves the checkout
+// from a directory inside it, since dumps run from anywhere in the project.
+func TestSiteServiceForTool_SubdirOfWorktreeUsesTheWorktreeEnv(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	site := filepath.Join(tempRoot(t), "app")
+	wt := filepath.Join(site, "wt", "feature")
+	makeWorktree(t, site, wt, "feature")
+	writeEnv(t, site, "lerd-mysql-8.4")
+	writeEnv(t, wt, "lerd-postgres-17")
+	sub := filepath.Join(wt, "database", "dumps")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := config.AddSite(config.Site{Name: "app", Path: site}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := siteServiceForTool(sub, "pg_dump"); got != "postgres-17" {
+		t.Errorf("siteServiceForTool = %q, want %q", got, "postgres-17")
+	}
+}
+
+// TestSiteServiceForTool_WorktreeWithoutEnvFallsBackToTheSite keeps a worktree
+// that never had its env rewritten on the parent's service.
+func TestSiteServiceForTool_WorktreeWithoutEnvFallsBackToTheSite(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	site := filepath.Join(tempRoot(t), "app")
+	wt := filepath.Join(site, "wt", "feature")
+	makeWorktree(t, site, wt, "feature")
+	writeEnv(t, site, "lerd-mysql-8.4")
+
+	if err := config.AddSite(config.Site{Name: "app", Path: site}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := siteServiceForTool(wt, "mysqldump"); got != "mysql-8.4" {
+		t.Errorf("siteServiceForTool = %q, want %q", got, "mysql-8.4")
+	}
+}
+
+// TestSiteServiceForTool_PlainSiteUsesTheSiteRoot keeps the ordinary case: from a
+// subdirectory of a registered site the project root's env is the one to read.
+func TestSiteServiceForTool_PlainSiteUsesTheSiteRoot(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	site := filepath.Join(tempRoot(t), "app")
+	sub := filepath.Join(site, "database", "dumps")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeEnv(t, site, "lerd-mariadb-11.4")
+
+	if err := config.AddSite(config.Site{Name: "app", Path: site}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := siteServiceForTool(sub, "mysqldump"); got != "mariadb-11.4" {
+		t.Errorf("siteServiceForTool = %q, want %q", got, "mariadb-11.4")
+	}
+}


### PR DESCRIPTION
siteServiceForTool decided which lerd service a database client shim should talk to by reading DB_HOST from the site root SiteRootFor returns, and that does path-prefix matching over registered sites. A worktree checked out inside its parent site's directory matches the parent, so the worktree's own env was skipped and the shim adopted the parent's service. A branch with an isolated database could therefore be dumped from the parent's data, and a branch on a different engine than its parent targeted the wrong container outright.

It now resolves the checkout through WorktreeRootFor, the same view of what a directory belongs to that version detection and the PHP pin already use, and reads that checkout's env when it has one. A worktree whose env was never rewritten still falls back to the site root, so a shared-database branch is unaffected.

Refs #1003