### PR TITLE
fix(services): resolve the client binary when migrating a mariadb service

### DIFF
--- a/internal/serviceops/databases.go
+++ b/internal/serviceops/databases.go
@@ -104,7 +104,7 @@ func exportShellCommand(family, database string) (string, bool) {
 	q := podman.ShellQuote(database)
 	switch family {
 	case "mysql", "mariadb":
-		return "$(command -v mysqldump || command -v mariadb-dump) -uroot " + q, true
+		return mysqlDumpBin + " -uroot " + q, true
 	case "postgres":
 		return "pg_dump -U postgres " + q, true
 	default:
@@ -116,7 +116,7 @@ func importShellCommand(family, database string) (string, bool) {
 	q := podman.ShellQuote(database)
 	switch family {
 	case "mysql", "mariadb":
-		return "$(command -v mysql || command -v mariadb) --max-allowed-packet=1G -uroot " + q, true
+		return mysqlClientBin + " --max-allowed-packet=1G -uroot " + q, true
 	case "postgres":
 		return "psql -U postgres -d " + q, true
 	default:

--- a/internal/serviceops/migrate.go
+++ b/internal/serviceops/migrate.go
@@ -337,6 +337,21 @@ func abortMigrate(unit, name, backup string, snapshot *serviceConfigSnapshot, ca
 
 // ---- mysql / mariadb -------------------------------------------------------
 
+// The three in-container commands a mysql-family migrate runs. They resolve the
+// client binary at runtime because the mariadb images carry only the mariadb
+// names, and a literal `mysqldump` aborts the migrate before it dumps anything.
+func mysqlMigrateDumpCommand() string {
+	return mysqlDumpBin + " -h 127.0.0.1 -uroot --all-databases " + mysqldumpFlags
+}
+
+func mysqlMigrateProbeCommand() string {
+	return mysqlClientBin + " -h 127.0.0.1 -uroot -e 'SELECT 1' >/dev/null 2>&1"
+}
+
+func mysqlMigrateRestoreCommand() string {
+	return mysqlClientBin + " --max-allowed-packet=" + config.MySQLImportMaxPacket + " -h 127.0.0.1 -uroot 2>&1"
+}
+
 func migrateMysql(name, targetImage string, emit func(PhaseEvent)) error {
 	unit := "lerd-" + name
 	snapshot, err := captureServiceConfig(name)
@@ -347,8 +362,7 @@ func migrateMysql(name, targetImage string, emit func(PhaseEvent)) error {
 	rootEnv := []string{"MYSQL_PWD=lerd"}
 
 	emit(PhaseEvent{Phase: "dumping_data", Message: "mysqldump → " + dump})
-	dumpCmd := "mysqldump -h 127.0.0.1 -uroot --all-databases --single-transaction --routines --triggers --events --quick"
-	if err := dumpToHost(unit, dumpCmd, rootEnv, dump, dumpRestoreTimeout); err != nil {
+	if err := dumpToHost(unit, mysqlMigrateDumpCommand(), rootEnv, dump, dumpRestoreTimeout); err != nil {
 		return fmt.Errorf("mysqldump: %w", err)
 	}
 
@@ -375,15 +389,12 @@ func migrateMysql(name, targetImage string, emit func(PhaseEvent)) error {
 	}
 
 	emit(PhaseEvent{Phase: "waiting_ready", Unit: unit})
-	probe := "mysql -h 127.0.0.1 -uroot -e 'SELECT 1' >/dev/null 2>&1 || mariadb -h 127.0.0.1 -uroot -e 'SELECT 1' >/dev/null 2>&1"
-	if err := waitContainerReady(unit, probe, rootEnv, 90*time.Second); err != nil {
+	if err := waitContainerReady(unit, mysqlMigrateProbeCommand(), rootEnv, 90*time.Second); err != nil {
 		return fmt.Errorf("%w. Dump preserved at %s; old data dir at %s", err, dump, backup)
 	}
 
 	emit(PhaseEvent{Phase: "restoring_data", Message: dump})
-	packet := "--max-allowed-packet=" + config.MySQLImportMaxPacket
-	restoreCmd := "mysql " + packet + " -h 127.0.0.1 -uroot 2>&1 || mariadb " + packet + " -h 127.0.0.1 -uroot 2>&1"
-	if err := restoreFromHost(unit, restoreCmd, rootEnv, dump, dumpRestoreTimeout); err != nil {
+	if err := restoreFromHost(unit, mysqlMigrateRestoreCommand(), rootEnv, dump, dumpRestoreTimeout); err != nil {
 		return fmt.Errorf("restore: %w. Dump preserved at %s; old data dir at %s", err, dump, backup)
 	}
 

--- a/internal/serviceops/migrate_test.go
+++ b/internal/serviceops/migrate_test.go
@@ -179,3 +179,21 @@ func TestServiceConfigSnapshot_RevertsImage(t *testing.T) {
 		t.Errorf("PreviousImage = %q, want cleared", entry.PreviousImage)
 	}
 }
+
+// The mariadb images drop the mysql-named client binaries, so a migrate that
+// spells the tools literally fails with "mysqldump: not found" before it has
+// dumped anything. Every mysql-family command must resolve the binary at runtime.
+func TestMysqlMigrateCommands_ResolveMariadbBinaries(t *testing.T) {
+	for name, cmd := range map[string]string{
+		"dump":    mysqlMigrateDumpCommand(),
+		"probe":   mysqlMigrateProbeCommand(),
+		"restore": mysqlMigrateRestoreCommand(),
+	} {
+		if !strings.Contains(cmd, "command -v") {
+			t.Errorf("%s command does not resolve its binary: %s", name, cmd)
+		}
+		if !strings.Contains(cmd, "mariadb") {
+			t.Errorf("%s command has no mariadb fallback: %s", name, cmd)
+		}
+	}
+}

--- a/internal/serviceops/snapshot.go
+++ b/internal/serviceops/snapshot.go
@@ -52,6 +52,14 @@ const (
 	mysqldumpFlags   = "--single-transaction --quick --no-tablespaces --routines --triggers --events"
 )
 
+// The mariadb images ship mariadb/mariadb-dump and no mysql-named binaries, so
+// every mysql-family command resolves its tool in the container rather than
+// spelling one of the two names.
+const (
+	mysqlDumpBin   = "$(command -v mysqldump || command -v mariadb-dump)"
+	mysqlClientBin = "$(command -v mysql || command -v mariadb)"
+)
+
 // reservedSnapshotName flags snapshot names that collide with command verbs,
 // catching mistakes like `lerd db snapshot list` (which would otherwise create
 // a snapshot literally named "list" instead of listing).
@@ -135,7 +143,7 @@ func snapshotEnv(family string) []string {
 func snapshotDumpCommand(t SnapshotTarget) (string, error) {
 	switch t.Family {
 	case "mysql", "mariadb":
-		bin := "$(command -v mysqldump || command -v mariadb-dump)"
+		bin := mysqlDumpBin
 		args := "-uroot " + mysqldumpFlags
 		if t.AllDatabases {
 			// --add-drop-database makes the dump self-cleaning so an
@@ -160,7 +168,7 @@ func snapshotDumpCommand(t SnapshotTarget) (string, error) {
 func snapshotRestoreCommand(t SnapshotTarget) (string, error) {
 	switch t.Family {
 	case "mysql", "mariadb":
-		bin := "$(command -v mysql || command -v mariadb) --max-allowed-packet=" + config.MySQLImportMaxPacket
+		bin := mysqlClientBin + " --max-allowed-packet=" + config.MySQLImportMaxPacket
 		if t.AllDatabases {
 			return "gunzip -c | " + bin + " -uroot", nil
 		}


### PR DESCRIPTION
A mysql-family migrate spelled its dump command as a literal mysqldump and its probe and restore as a mysql invocation with a mariadb fallback behind ||. The mariadb images carry only the mariadb-named binaries, so migrating a mariadb service failed immediately on the dump with "mysqldump: not found", before the data dir was touched.

The three in-container commands now resolve their tool at runtime the way the snapshot and import/export paths already did, and that substitution lives in one pair of constants the whole package shares rather than being written out at each call site.

Refs #1023