### PR TITLE
fix(services): start a stopped engine before migrating it

### DIFF
--- a/docs/usage/service-updates.md
+++ b/docs/usage/service-updates.md
@@ -29,6 +29,7 @@ Cross-major boundaries (e.g. mysql 8 → 9, postgres 16 → 17) are not surfaced
 For mysql, mariadb, and postgres, the violet **Migrate → \<tag\>** button runs the full SQL migration:
 
 ```
+0. Start the engine if it is not running (a service no site uses is auto-stopped)
 1. Dump current data via the running container's native tool
    (mysqldump --all-databases / pg_dumpall) → ~/.local/share/lerd/backups/<svc>-<ts>.sql
 2. Stop the unit

--- a/internal/serviceops/migrate.go
+++ b/internal/serviceops/migrate.go
@@ -58,7 +58,37 @@ func MigrateService(name, targetImage string, emit func(PhaseEvent)) error {
 	if err := os.MkdirAll(config.BackupsDir(), 0700); err != nil {
 		return fmt.Errorf("creating backups dir: %w", err)
 	}
+	if err := startEngineForMigrate(name, fam, emit); err != nil {
+		return err
+	}
 	return fn(name, targetImage, emit)
+}
+
+// migrateProbe returns the in-container command that answers once the family's
+// engine is accepting connections.
+func migrateProbe(family string) string {
+	switch family {
+	case "mysql", "mariadb":
+		return mysqlMigrateProbeCommand()
+	case "postgres":
+		return pgMigrateProbeCommand()
+	}
+	return ""
+}
+
+// startEngineForMigrate brings the engine up before the dump. A service that no
+// site uses is auto-stopped, and the dump execs into its container, so migrating
+// one in that state failed on "no such container" before anything had run.
+func startEngineForMigrate(name, family string, emit func(PhaseEvent)) error {
+	unit := "lerd-" + name
+	if status, _ := podman.UnitStatus(unit); status == "active" {
+		return nil
+	}
+	emit(PhaseEvent{Phase: "waiting_ready", Unit: unit, Message: "starting the engine to dump from"})
+	if err := podman.StartUnit(unit); err != nil {
+		return fmt.Errorf("starting %s to dump from: %w", unit, err)
+	}
+	return waitContainerReady(unit, migrateProbe(family), snapshotEnv(family), 90*time.Second)
 }
 
 // familyOf returns the service family for a default preset or installed
@@ -407,6 +437,10 @@ func migrateMysql(name, targetImage string, emit func(PhaseEvent)) error {
 
 // ---- postgres --------------------------------------------------------------
 
+func pgMigrateProbeCommand() string {
+	return "psql -h 127.0.0.1 -U postgres -c 'SELECT 1' >/dev/null 2>&1"
+}
+
 func migratePostgres(name, targetImage string, emit func(PhaseEvent)) error {
 	unit := "lerd-" + name
 	snapshot, err := captureServiceConfig(name)
@@ -445,8 +479,7 @@ func migratePostgres(name, targetImage string, emit func(PhaseEvent)) error {
 	}
 
 	emit(PhaseEvent{Phase: "waiting_ready", Unit: unit})
-	probe := "psql -h 127.0.0.1 -U postgres -c 'SELECT 1' >/dev/null 2>&1"
-	if err := waitContainerReady(unit, probe, pgEnv, 90*time.Second); err != nil {
+	if err := waitContainerReady(unit, pgMigrateProbeCommand(), pgEnv, 90*time.Second); err != nil {
 		return fmt.Errorf("%w. Dump preserved at %s; old data dir at %s", err, dump, backup)
 	}
 

--- a/internal/serviceops/migrate_test.go
+++ b/internal/serviceops/migrate_test.go
@@ -197,3 +197,17 @@ func TestMysqlMigrateCommands_ResolveMariadbBinaries(t *testing.T) {
 		}
 	}
 }
+
+// A service that was auto-stopped for being unused is the normal state to start
+// a migrate from, so every migratable family needs a readiness probe to bring
+// its engine up before the dump. Without one the dump execs into no container.
+func TestMigrateProbe_CoversEveryMigratableFamily(t *testing.T) {
+	for family := range migrators {
+		if migrateProbe(family) == "" {
+			t.Errorf("family %q has a migrator but no readiness probe", family)
+		}
+	}
+	if migrateProbe("mongo") != "" {
+		t.Error("a family with no migrator should have no probe")
+	}
+}


### PR DESCRIPTION
A service no site uses is auto-stopped, and that is the normal state to reach for the Migrate button from. The migrate went straight to dumping, which execs into the service container, so it failed on "no such container" before anything had been touched. The notification reported a failed migration for what was really a service that simply was not running.

MigrateService now brings the unit up first and waits on the family readiness probe, so the dump runs against a live engine. The probe each family already used after the image switch is what answers here too, rather than a second spelling of the same check.

Based on the branch for #1023, so it can go in once that merges.

Refs #1026