### PR TITLE
perf(ui): render the debug lenses a page at a time instead of the whole buffer

### DIFF
--- a/docs/features/dumps.md
+++ b/docs/features/dumps.md
@@ -21,7 +21,7 @@ The receiver's transport depends on the host:
 - **Linux** — a per-user Unix socket bound by `lerd-ui` at `~/.local/share/lerd/run/lerd-dumps.sock`. PHP-FPM containers reach it via the existing `%h:%h` bind mount. No host TCP listener, no LAN exposure.
 - **macOS** — TCP loopback `127.0.0.1:9913`. Unix sockets don't traverse the podman-machine virtio-fs boundary as functional sockets, so FPM senders inside the VM reach `lerd-ui` on the host via `host.containers.internal:9913` (gvproxy forwards that upstream).
 
-`lerd-ui` keeps a 500-event in-memory ring as the receiver buffer and replays it to each newly-connecting client; the open dashboard then accumulates the full session on top of that replay, so events stay visible until you refresh the page rather than scrolling out as new traffic arrives. Events fan out to four surfaces:
+`lerd-ui` keeps a 500-event in-memory ring as the receiver buffer and replays it to each newly-connecting client; the open dashboard then accumulates the full session on top of that replay, so events stay visible until you refresh the page rather than scrolling out as new traffic arrives. Because that buffer grows well past what any browser wants to paint at once, every Debug lens renders the newest 100 rows and loads the next 100 as you reach the end of the list, automatically on scroll or via the button at the bottom. Group headers keep reporting the request's real size even when its rows are still partly windowed, and changing a filter or search starts the window over. Events fan out to four surfaces:
 
 - **Web dashboard** — three places:
   - Each site detail pane has a **Dumps** tab next to Overview and Tinker, pre-filtered to that site.

--- a/docs/features/queries.md
+++ b/docs/features/queries.md
@@ -66,7 +66,7 @@ Beyond queries, the same adapter feeds additional Debug sub-tabs:
 - **Events** *(Laravel)* — application and package events dispatched (framework-internal `Illuminate\*` events are filtered out).
 - **HTTP** *(Laravel)* — outgoing requests made via Laravel's HTTP client (method, URL, status), so third-party API calls are visible the way queries are.
 
-Each lens groups per request/job, shows the originating app frame with the stack trace and editor links, and is filterable by site and worker command.
+Each lens groups per request/job, shows the originating app frame with the stack trace and editor links, and is filterable by site and worker command. All of them render the newest 100 rows and load the next 100 as you reach the end, so a worker that has been running all afternoon doesn't put thousands of rows on screen at once.
 
 ## Framework coverage (agnostic seams)
 

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -1023,6 +1023,7 @@
   "debug_enable": "Enable capture",
   "debug_waiting_title": "Waiting…",
   "debug_waiting_body": "Trigger some activity in your app and it will appear here.",
+  "debug_loadMore": "Mehr laden · {shown} von {total}",
   "views_data": "data",
   "debug_tab_http": "HTTP",
   "http_sent": "gesendet",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -719,6 +719,7 @@
   "debug_enable": "Enable capture",
   "debug_waiting_title": "Waiting…",
   "debug_waiting_body": "Trigger some activity in your app and it will appear here.",
+  "debug_loadMore": "Load more · {shown} of {total}",
   "views_data": "data",
   "views_template": "template",
   "queries_searchPlaceholder": "Search SQL, path, or file…",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -1023,6 +1023,7 @@
   "debug_enable": "Enable capture",
   "debug_waiting_title": "Waiting…",
   "debug_waiting_body": "Trigger some activity in your app and it will appear here.",
+  "debug_loadMore": "Cargar más · {shown} de {total}",
   "views_data": "data",
   "debug_tab_http": "HTTP",
   "http_sent": "enviado",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -1023,6 +1023,7 @@
   "debug_enable": "Enable capture",
   "debug_waiting_title": "Waiting…",
   "debug_waiting_body": "Trigger some activity in your app and it will appear here.",
+  "debug_loadMore": "Charger plus · {shown} sur {total}",
   "views_data": "data",
   "debug_tab_http": "HTTP",
   "http_sent": "envoyé",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -1023,6 +1023,7 @@
   "debug_enable": "Enable capture",
   "debug_waiting_title": "Waiting…",
   "debug_waiting_body": "Trigger some activity in your app and it will appear here.",
+  "debug_loadMore": "Muat lebih banyak · {shown} dari {total}",
   "views_data": "data",
   "debug_tab_http": "HTTP",
   "http_sent": "terkirim",

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -713,6 +713,7 @@
   "debug_enable": "Abilita cattura",
   "debug_waiting_title": "In attesa…",
   "debug_waiting_body": "Attiva qualche attività nella tua app e comparirà qui.",
+  "debug_loadMore": "Carica altri · {shown} di {total}",
   "views_data": "dati",
   "views_template": "template",
   "queries_searchPlaceholder": "Cerca SQL, percorso o file…",

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -713,6 +713,7 @@
   "debug_enable": "キャプチャを有効化",
   "debug_waiting_title": "待機中…",
   "debug_waiting_body": "アプリで何らかのアクティビティを発生させるとここに表示されます。",
+  "debug_loadMore": "さらに読み込む · {total} 件中 {shown} 件",
   "views_data": "データ",
   "views_template": "テンプレート",
   "queries_searchPlaceholder": "SQL、パス、ファイルを検索…",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -1023,6 +1023,7 @@
   "debug_enable": "Enable capture",
   "debug_waiting_title": "Waiting…",
   "debug_waiting_body": "Trigger some activity in your app and it will appear here.",
+  "debug_loadMore": "Meer laden · {shown} van {total}",
   "views_data": "data",
   "debug_tab_http": "HTTP",
   "http_sent": "verzonden",

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -713,6 +713,7 @@
   "debug_enable": "Włącz przechwytywanie",
   "debug_waiting_title": "Oczekiwanie…",
   "debug_waiting_body": "Wywołaj jakąś aktywność w swojej aplikacji, a pojawi się tutaj.",
+  "debug_loadMore": "Załaduj więcej · {shown} z {total}",
   "views_data": "dane",
   "views_template": "szablon",
   "queries_searchPlaceholder": "Szukaj SQL, ścieżki lub pliku…",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -1023,6 +1023,7 @@
   "debug_enable": "Enable capture",
   "debug_waiting_title": "Waiting…",
   "debug_waiting_body": "Trigger some activity in your app and it will appear here.",
+  "debug_loadMore": "Carregar mais · {shown} de {total}",
   "views_data": "data",
   "debug_tab_http": "HTTP",
   "http_sent": "enviado",

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -713,6 +713,7 @@
   "debug_enable": "Activează captura",
   "debug_waiting_title": "Se așteaptă…",
   "debug_waiting_body": "Declanșează ceva activitate în aplicația ta și va apărea aici.",
+  "debug_loadMore": "Încarcă mai multe · {shown} din {total}",
   "views_data": "date",
   "views_template": "șablon",
   "queries_searchPlaceholder": "Caută SQL, cale sau fișier…",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -1023,6 +1023,7 @@
   "debug_enable": "Enable capture",
   "debug_waiting_title": "Waiting…",
   "debug_waiting_body": "Trigger some activity in your app and it will appear here.",
+  "debug_loadMore": "Daha fazla yükle · {total} kayıttan {shown} tanesi",
   "views_data": "data",
   "debug_tab_http": "HTTP",
   "http_sent": "gönderildi",

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -713,6 +713,7 @@
   "debug_enable": "Bật bắt giữ",
   "debug_waiting_title": "Đang chờ…",
   "debug_waiting_body": "Kích hoạt một số hoạt động trong ứng dụng của bạn và nó sẽ xuất hiện ở đây.",
+  "debug_loadMore": "Tải thêm · {shown} trên {total}",
   "views_data": "dữ liệu",
   "views_template": "mẫu",
   "queries_searchPlaceholder": "Tìm SQL, đường dẫn hoặc tệp…",

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -713,6 +713,7 @@
   "debug_enable": "启用捕获",
   "debug_waiting_title": "等待中…",
   "debug_waiting_body": "在你的应用中触发一些活动，它就会显示在这里。",
+  "debug_loadMore": "加载更多 · 共 {total} 条，已显示 {shown} 条",
   "views_data": "数据",
   "views_template": "模板",
   "queries_searchPlaceholder": "搜索 SQL、路径或文件…",

--- a/internal/ui/web/src/components/KindLens.svelte
+++ b/internal/ui/web/src/components/KindLens.svelte
@@ -17,6 +17,8 @@
   import EmptyState from '$components/EmptyState.svelte';
   import Dropdown from '$components/Dropdown.svelte';
   import TraceBlock from '$components/TraceBlock.svelte';
+  import LensLoadMore from '$components/LensLoadMore.svelte';
+  import { windowGroups, LENS_PAGE } from '$lib/lensWindow';
   import { openInEditor } from '$lib/editor';
   import { m } from '../paraglide/messages.js';
 
@@ -54,6 +56,16 @@
   const groups = $derived(
     buildKindGroups($dumps, wireKind, scoped ? siteScope : $queryFilterSite, effectiveText, scoped, $queryFilterWorker, Boolean($devtoolsStatus?.workers))
   );
+
+  // Only the newest LENS_PAGE rows render; the rest arrive as the user
+  // reaches the end. Changing a filter or tab starts the window over.
+  let limit = $state(LENS_PAGE);
+  const win = $derived(windowGroups(groups, (g) => g.events, limit));
+  const filterKey = $derived(`${wireKind}|${scoped ? siteScope : $queryFilterSite}|${effectiveText}|${$queryFilterWorker}`);
+  $effect(() => {
+    filterKey;
+    limit = LENS_PAGE;
+  });
 
   let enabling = $state(false);
   async function onEnable() {
@@ -155,15 +167,16 @@
         </EmptyState>
       {/if}
     {:else}
-      {#each groups as group (group.key)}
+      {#each win.pages as page (page.group.key)}
+        {@const group = page.group}
         <section class="mb-4">
           <header class="flex items-center gap-2 mb-1 sticky top-0 bg-gray-50 dark:bg-lerd-bg py-1 -mx-3 px-3 z-1">
             {#if group.worker}<span class="text-[10px] font-semibold uppercase tracking-wide rounded-sm px-1.5 py-0.5 bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 shrink-0">{m.queries_worker_badge()}</span>{/if}
             <span class="text-sm truncate">{group.label}</span>
             <span class="text-xs text-gray-400 ml-auto whitespace-nowrap font-mono">{localTime(group.ts)}</span>
-            <span class="text-xs text-gray-400 whitespace-nowrap">{group.events.length}</span>
+            <span class="text-xs text-gray-400 whitespace-nowrap">{page.total}</span>
           </header>
-          {#each group.events as ev (ev.id)}
+          {#each page.rows as ev (ev.id)}
             {@const d = (ev.data ?? {}) as Record<string, any>}
             <div class="rounded-sm border border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-card mb-1.5 overflow-hidden">
               <button type="button" class="w-full text-left px-2.5 py-1.5 flex items-start gap-2 hover:bg-gray-50 dark:hover:bg-white/5" onclick={() => toggleRow(ev.id)}>
@@ -208,6 +221,7 @@
           {/each}
         </section>
       {/each}
+      <LensLoadMore shown={win.shown} total={win.total} onmore={() => (limit += LENS_PAGE)} />
     {/if}
   </div>
 </div>

--- a/internal/ui/web/src/components/LensLoadMore.svelte
+++ b/internal/ui/web/src/components/LensLoadMore.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { m } from '../paraglide/messages.js';
+
+  interface Props {
+    shown: number;
+    total: number;
+    onmore: () => void;
+  }
+  let { shown, total, onmore }: Props = $props();
+
+  let sentinel = $state<HTMLDivElement | null>(null);
+
+  // Auto-advance when the footer scrolls into view; the button stays as the
+  // fallback for environments without IntersectionObserver.
+  $effect(() => {
+    if (!sentinel || shown >= total || typeof IntersectionObserver === 'undefined') return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) onmore();
+      },
+      { rootMargin: '300px' }
+    );
+    io.observe(sentinel);
+    return () => io.disconnect();
+  });
+</script>
+
+{#if shown < total}
+  <div bind:this={sentinel} class="py-3 flex justify-center">
+    <button
+      type="button"
+      class="text-xs rounded-sm border border-gray-300 dark:border-lerd-border px-3 py-1 text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-white/5"
+      onclick={onmore}
+    >
+      {m.debug_loadMore({ shown, total })}
+    </button>
+  </div>
+{/if}

--- a/internal/ui/web/src/components/QueriesLens.svelte
+++ b/internal/ui/web/src/components/QueriesLens.svelte
@@ -19,6 +19,8 @@
   import EmptyState from '$components/EmptyState.svelte';
   import Dropdown from '$components/Dropdown.svelte';
   import TraceBlock from '$components/TraceBlock.svelte';
+  import LensLoadMore from '$components/LensLoadMore.svelte';
+  import { windowGroups, LENS_PAGE } from '$lib/lensWindow';
   import { inlineBindings } from '$lib/sqlInline';
   import type { QueryRow } from '$stores/queries';
   import { m } from '../paraglide/messages.js';
@@ -51,6 +53,18 @@
   const groups = $derived(
     buildQueryGroups($dumps, scoped ? siteScope : $queryFilterSite, scoped ? $debugSearch : $queryFilterText, scoped, $queryFilterWorker, Boolean($devtoolsStatus?.workers))
   );
+
+  // Only the newest LENS_PAGE rows render; the rest arrive as the user
+  // reaches the end. Changing a filter starts the window over.
+  let limit = $state(LENS_PAGE);
+  const win = $derived(windowGroups(groups, (g) => g.rows, limit));
+  const filterKey = $derived(
+    `${scoped ? siteScope : $queryFilterSite}|${scoped ? $debugSearch : $queryFilterText}|${$queryFilterWorker}`
+  );
+  $effect(() => {
+    filterKey;
+    limit = LENS_PAGE;
+  });
 
   let togglingWorkers = $state(false);
   async function onToggleWorkers(e: Event) {
@@ -196,7 +210,8 @@
         </EmptyState>
       {/if}
     {:else}
-      {#each groups as group (group.key)}
+      {#each win.pages as page (page.group.key)}
+        {@const group = page.group}
         <section class="mb-4">
           <header class="flex items-center gap-2 mb-1 sticky top-0 bg-gray-50 dark:bg-lerd-bg py-1 -mx-3 px-3 z-1">
             {#if group.worker}
@@ -211,7 +226,7 @@
               {m.queries_rollup({ count: group.count, ms: fmtMs(group.totalMs) })}
             </span>
           </header>
-          {#each group.rows as row (row.event.id)}
+          {#each page.rows as row (row.event.id)}
             <div
               class="rounded-sm border mb-1.5 overflow-hidden {row.duplicate
                 ? 'border-amber-300 dark:border-amber-700/50 bg-amber-50 dark:bg-amber-900/10'
@@ -265,6 +280,7 @@
           {/each}
         </section>
       {/each}
+      <LensLoadMore shown={win.shown} total={win.total} onmore={() => (limit += LENS_PAGE)} />
     {/if}
   </div>
 </div>

--- a/internal/ui/web/src/lib/lensWindow.test.ts
+++ b/internal/ui/web/src/lib/lensWindow.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { windowGroups, LENS_PAGE } from './lensWindow';
+
+interface G {
+  key: string;
+  rows: number[];
+}
+
+const g = (key: string, n: number): G => ({ key, rows: Array.from({ length: n }, (_, i) => i) });
+const rowsOf = (x: G) => x.rows;
+
+describe('windowGroups', () => {
+  it('keeps every group when the budget covers them all', () => {
+    const w = windowGroups([g('a', 3), g('b', 2)], rowsOf, LENS_PAGE);
+    expect(w.pages.map((p) => p.group.key)).toEqual(['a', 'b']);
+    expect(w.shown).toBe(5);
+    expect(w.total).toBe(5);
+  });
+
+  it('drops groups past the budget but still counts their rows', () => {
+    const w = windowGroups([g('a', 4), g('b', 4), g('c', 4)], rowsOf, 4);
+    expect(w.pages.map((p) => p.group.key)).toEqual(['a']);
+    expect(w.shown).toBe(4);
+    expect(w.total).toBe(12);
+  });
+
+  it('truncates the group straddling the budget and reports its real size', () => {
+    const w = windowGroups([g('a', 3), g('b', 10)], rowsOf, 5);
+    expect(w.pages[1].rows).toHaveLength(2);
+    expect(w.pages[1].total).toBe(10);
+    expect(w.shown).toBe(5);
+    expect(w.total).toBe(13);
+  });
+
+  it('does not copy rows when a group fits whole', () => {
+    const group = g('a', 3);
+    const w = windowGroups([group], rowsOf, 5);
+    expect(w.pages[0].rows).toBe(group.rows);
+  });
+
+  it('handles an empty group list', () => {
+    const w = windowGroups<G, number>([], rowsOf, LENS_PAGE);
+    expect(w.pages).toEqual([]);
+    expect(w.shown).toBe(0);
+    expect(w.total).toBe(0);
+  });
+
+  it('skips empty groups without spending budget', () => {
+    const w = windowGroups([g('a', 0), g('b', 2)], rowsOf, 2);
+    expect(w.pages.map((p) => p.group.key)).toEqual(['a', 'b']);
+    expect(w.shown).toBe(2);
+  });
+});

--- a/internal/ui/web/src/lib/lensWindow.ts
+++ b/internal/ui/web/src/lib/lensWindow.ts
@@ -1,0 +1,36 @@
+// Shared row windowing for the Debug lenses. Every lens renders request
+// groups whose rows come off one unbounded client buffer, so each of them
+// slices the same way: fill a row budget group by group, truncating the
+// group that straddles the edge.
+
+// LENS_PAGE is both the initial window and the step each "load more" adds.
+export const LENS_PAGE = 100;
+
+export interface LensPage<G, R> {
+  group: G;
+  rows: R[];
+  // total is the group's row count before truncation, so headers keep
+  // reporting the real size of a request.
+  total: number;
+}
+
+export interface LensWindow<G, R> {
+  pages: LensPage<G, R>[];
+  shown: number;
+  total: number;
+}
+
+export function windowGroups<G, R>(groups: G[], rowsOf: (g: G) => R[], limit: number): LensWindow<G, R> {
+  const pages: LensPage<G, R>[] = [];
+  let shown = 0;
+  let total = 0;
+  for (const group of groups) {
+    const rows = rowsOf(group);
+    total += rows.length;
+    if (shown >= limit) continue;
+    const take = Math.min(rows.length, limit - shown);
+    pages.push({ group, rows: take === rows.length ? rows : rows.slice(0, take), total: rows.length });
+    shown += take;
+  }
+  return { pages, shown, total };
+}

--- a/internal/ui/web/src/tabs/DumpsTab.svelte
+++ b/internal/ui/web/src/tabs/DumpsTab.svelte
@@ -19,6 +19,8 @@
   import DumpEntry from '$components/DumpEntry.svelte';
   import EmptyState from '$components/EmptyState.svelte';
   import Dropdown from '$components/Dropdown.svelte';
+  import LensLoadMore from '$components/LensLoadMore.svelte';
+  import { windowGroups, LENS_PAGE } from '$lib/lensWindow';
   import { m } from '../paraglide/messages.js';
 
   interface Props {
@@ -45,6 +47,16 @@
   const groups = $derived(
     buildDumpGroups($dumps, scoped ? siteScope : $filterSite, effectiveCtx, effectiveText, scoped)
   );
+
+  // Only the newest LENS_PAGE rows render; the rest arrive as the user
+  // reaches the end. Changing a filter starts the window over.
+  let limit = $state(LENS_PAGE);
+  const win = $derived(windowGroups(groups, (g) => g.events, limit));
+  const filterKey = $derived(`${scoped ? siteScope : $filterSite}|${effectiveCtx}|${effectiveText}`);
+  $effect(() => {
+    filterKey;
+    limit = LENS_PAGE;
+  });
 
   let textInput = $state('');
 
@@ -160,17 +172,18 @@
         </EmptyState>
       {/if}
     {:else}
-      {#each groups as group (group.key)}
+      {#each win.pages as page (page.group.key)}
         <section class="mb-4">
           <header class="flex items-center gap-2 mb-1 sticky top-0 bg-gray-50 dark:bg-lerd-bg py-1 -mx-3 px-3 z-1">
-            <span class="text-sm">{group.label}</span>
-            <span class="text-xs text-gray-400 ml-auto">{m.dumps_groupCount({ count: group.events.length })}</span>
+            <span class="text-sm">{page.group.label}</span>
+            <span class="text-xs text-gray-400 ml-auto">{m.dumps_groupCount({ count: page.total })}</span>
           </header>
-          {#each group.events as ev (ev.id)}
+          {#each page.rows as ev (ev.id)}
             <DumpEntry event={ev} />
           {/each}
         </section>
       {/each}
+      <LensLoadMore shown={win.shown} total={win.total} onmore={() => (limit += LENS_PAGE)} />
     {/if}
   </div>
 </div>

--- a/internal/ui/web/src/tabs/DumpsTab.test.ts
+++ b/internal/ui/web/src/tabs/DumpsTab.test.ts
@@ -9,6 +9,7 @@ import {
   filterText,
   status
 } from '../stores/dumps';
+import { debugSearch } from '../stores/debugLens';
 import type { DumpEvent } from '../lib/dumpsStream';
 
 function ev(over: Partial<DumpEvent> & { id: string }): DumpEvent {
@@ -49,6 +50,7 @@ describe('DumpsTab', () => {
     filterSite.set('');
     filterCtx.set('');
     filterText.set('');
+    debugSearch.set('');
     status.set({
       enabled: true,
       passthrough: false,
@@ -118,6 +120,41 @@ describe('DumpsTab', () => {
       expect(container.textContent).toMatch(/Enable debug bridge/);
     });
     expect(container.textContent).toMatch(/Debug bridge is disabled/);
+  });
+
+  it('renders only the first page of rows and grows on load more', async () => {
+    dumps.set(
+      Array.from({ length: 250 }, (_, i) =>
+        ev({
+          id: `e${i}`,
+          ts: `2026-05-10T12:00:${String(i % 60).padStart(2, '0')}.000Z`,
+          ctx: { type: 'fpm', site: 'whitewaters', request: `GET /r${i}`, rid: `r${i}` }
+        })
+      )
+    );
+    const { container, getByRole } = render(DumpsTab, { siteScope: 'whitewaters' });
+    await waitFor(() => {
+      expect(container.querySelectorAll('section').length).toBe(100);
+    });
+    getByRole('button', { name: /Load more/ }).click();
+    await waitFor(() => {
+      expect(container.querySelectorAll('section').length).toBe(200);
+    });
+  });
+
+  it('resets the window when the search filter changes', async () => {
+    dumps.set(
+      Array.from({ length: 150 }, (_, i) =>
+        ev({ id: `e${i}`, ctx: { type: 'fpm', site: 'whitewaters', request: `GET /r${i}`, rid: `r${i}` } })
+      )
+    );
+    const { container, getByRole } = render(DumpsTab, { siteScope: 'whitewaters' });
+    await waitFor(() => expect(container.querySelectorAll('section').length).toBe(100));
+    getByRole('button', { name: /Load more/ }).click();
+    await waitFor(() => expect(container.querySelectorAll('section').length).toBe(150));
+
+    debugSearch.set('GET /r');
+    await waitFor(() => expect(container.querySelectorAll('section').length).toBe(100));
   });
 
   it('reacts to new events pushed into the dumps store', async () => {


### PR DESCRIPTION
Every lens in the Debug view painted its entire filtered array in one go. The client store holds up to 10000 events and a fresh connection replays 3000 of them, so a busy request or a worker that has been running all afternoon could put thousands of rows on screen and the view got slow to render and to scroll.

All three lens components now render the newest 100 rows and load the next 100 as you reach the end of the list, automatically on scroll or from the button at the bottom. Because the lenses are shared, this covers the system Debug detail and the per-site Debug tab across all eight tabs at once.

The windowing itself lives in one place, a small pure helper that fills a row budget group by group and truncates whichever group straddles the edge, plus a footer component that watches for the end of the list. Group headers keep reporting the request's real size even while its rows are still partly windowed, so a request card still says how many queries it ran, and changing a filter or a search starts the window over.

The two related things the issue mentioned are deliberately not in here. The group derivations still re-run over the whole array on every event, and the per-site view still subscribes to the stream unscoped and filters client-side. Both want their own change: the first is an incremental-append redesign of the builders, the second touches the reference-counted store lifecycle that the system view and every site tab share.

Closes #1004