### PR TITLE
fix(ui): open the site's Debug tab from a debug notification

### DIFF
--- a/docs/features/dumps.md
+++ b/docs/features/dumps.md
@@ -61,6 +61,8 @@ Each event is one line of JSON. The shape is stable from v1 of the protocol:
 
 `ctx.branch` is set when the dump came from a worktree, so a request to `feat-a.acme.test` carries `branch: "feat-a"` alongside the parent `site: "acme"`. It is plumbed end-to-end via the `LERD_SITE` and `LERD_BRANCH` fastcgi params on the worktree vhost. Because every worktree shares the parent's `site`, the branch is what separates a worktree's events from the parent's: request grouping keys on it (a worktree request never merges into the parent's group), every group is labelled `[site@branch]` in the dashboard and the TUI, the CLI tail prints `site@branch` in each event header, and the search box matches the branch name. To isolate a single worktree, filter by branch: `lerd dump tail --branch feat-a`, the `branch` query param on `/api/dumps`, or the `branch` argument to the `dumps_recent` MCP tool. Parent-site requests leave the field empty and render as plain `[site]`.
 
+`ctx.site` is set on terminal runs too: `lerd php` (and everything shimmed through it, `artisan` included) passes `LERD_SITE` into the container, so an event from an artisan command carries the registered site name rather than the directory it happened to run in, and a run inside a worktree checkout reports the parent site.
+
 Reserved fields: `tree` (structured cloner output, populated in a future revision) and `trunc` (set to `true` when the cloner output exceeded the per-event cap).
 
 ## CLI

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -45,6 +45,10 @@ In native mode, clicking a notification opens the [Lerd desktop app](https://ler
 | `update_available` | The registry has a newer image tag for an installed service | on | low |
 | `dump` | A `ray()` / `dump()` / var-dump packet arrives | **off** | low |
 
+The diagnostic categories (`nplusone`, `slow_route`) report a problem lerd found in your app rather than an action that completed, so the toast and the notification centre draw them as amber warnings, between the blue informational entries and the red failures.
+
+Clicking a debug notification (`dump`, `nplusone`, `slow_route`) opens the originating site's **Debug** tab, where the event and its surrounding context are. The site is resolved from the event's site name, or from the request domain when the bridge never saw one; if neither resolves, the click lands on the sites list rather than the global debug bridge view.
+
 Each category can be toggled individually under **System → Notifications**, along with a master switch that turns every category off in one click. Preferences are stored client-side in `localStorage` and mirrored to the server via the push subscription — closed-PWA push respects the toggles even when the dashboard isn't running.
 
 The dashboard's System health card also carries a bell toggle, next to the debug bridge and profiler ones, that flips the master switch and prompts for browser permission on first use. It dims when the browser has blocked notifications, in which case the recovery flow lives under **System → Notifications**.

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -82,6 +82,21 @@ func fpmContainerForDir(dir, version string) string {
 	return "lerd-php" + strings.ReplaceAll(version, ".", "") + "-fpm"
 }
 
+// debugSiteEnvArgs returns the LERD_SITE exec flag for a CLI run in dir, so the
+// debug bridge and the devtools extension tag every event with the registered
+// site name. Without it the bridge falls back to the directory basename and the
+// extension emits no site at all, which strands the notification (#1005). A
+// worktree checkout reports its parent site, like tinker and the worktree vhost.
+func debugSiteEnvArgs(dir string) []string {
+	if _, parent, ok := phpDet.WorktreeRootFor(dir); ok && parent != nil && parent.Name != "" {
+		return []string{"--env", "LERD_SITE=" + parent.Name}
+	}
+	if site, _ := config.FindSiteByPath(phpDet.SiteRootFor(dir)); site != nil && site.Name != "" {
+		return []string{"--env", "LERD_SITE=" + site.Name}
+	}
+	return nil
+}
+
 // RunPHPCaptureEnv is RunPHPCapture with extra KEY=VALUE environment entries
 // injected into the container exec — used by `lerd profile run` to set
 // SPX_ENABLED so a CLI command is profiled.
@@ -154,6 +169,7 @@ func RunPHPCaptureEnv(cwd string, args []string, extraEnv []string) (int, error)
 		"--env", "COMPOSER_HOME="+composerHome,
 		"--env", "PATH="+projectVendorBin+":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:"+composerBin,
 	)
+	cmdArgs = append(cmdArgs, debugSiteEnvArgs(cwd)...)
 	// Forward SPX_* profiler vars from the host so `SPX_ENABLED=1 php ...` (or
 	// any shim'd tool like composer) reaches SPX inside the container. extraEnv
 	// is applied after, so an explicit caller like `lerd profile run` wins.

--- a/internal/cli/php_exec_test.go
+++ b/internal/cli/php_exec_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"reflect"
 	"testing"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 func TestPhpScriptArgIndex(t *testing.T) {
@@ -69,5 +71,29 @@ func TestSpxPassthroughEnv(t *testing.T) {
 				t.Errorf("spxPassthroughEnv(%v) = %v, want %v", tt.environ, got, tt.want)
 			}
 		})
+	}
+}
+
+// A CLI exec must tag the container with the registered site name so debug
+// events (queries included) resolve to a site rather than falling back to the
+// working-directory basename, or to nothing at all (#1005).
+func TestDebugSiteEnvArgs(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	dir := t.TempDir()
+	if err := config.AddSite(config.Site{
+		Name:    "rapids",
+		Domains: []string{"harborlist.test"},
+		Path:    dir,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := debugSiteEnvArgs(dir)
+	want := []string{"--env", "LERD_SITE=rapids"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("args = %v, want %v", got, want)
+	}
+	if got := debugSiteEnvArgs(t.TempDir()); got != nil {
+		t.Errorf("unregistered dir args = %v, want none", got)
 	}
 }

--- a/internal/ui/notify_dumps.go
+++ b/internal/ui/notify_dumps.go
@@ -90,7 +90,7 @@ func notificationForDump(evt dumps.Event) push.Notification {
 			"text": body,
 		},
 		Tag:     "lerd-dump-" + site,
-		URL:     "#sites/" + siteDomainForRoute(site) + "/dumps",
+		URL:     debugRouteForContext(evt.Ctx),
 		Data:    map[string]string{"site": site, "id": evt.ID},
 		Urgency: "low",
 		TTL:     60,

--- a/internal/ui/notify_nplusone.go
+++ b/internal/ui/notify_nplusone.go
@@ -124,16 +124,12 @@ func notificationForNPlusOne(ev dumps.Event, count int) push.Notification {
 	if where != "" {
 		body = fmt.Sprintf("%s ran a similar query %d×", where, count)
 	}
-	url := "#system/dump-bridge"
-	if ev.Ctx.Site != "" {
-		url = "#sites/" + siteDomainForRoute(ev.Ctx.Site) + "/dumps"
-	}
 	return push.Notification{
 		Kind:  "nplusone",
 		Title: "Possible N+1 query on " + site,
 		Body:  body,
 		Tag:   "lerd-nplusone-" + routeKeyForQuery(ev),
-		URL:   url,
+		URL:   debugRouteForContext(ev.Ctx),
 		Data: map[string]string{
 			"site":   ev.Ctx.Site,
 			"worker": ev.Ctx.Worker,

--- a/internal/ui/notify_route.go
+++ b/internal/ui/notify_route.go
@@ -1,0 +1,32 @@
+package ui
+
+import (
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/dumps"
+)
+
+// debugRouteForContext returns the dashboard route a debug notification opens.
+// Debug events belong to a site, so they land on that site's Debug tab; when no
+// site can be resolved the sites list is the honest destination, since the
+// global bridge view says nothing about the event that was clicked.
+func debugRouteForContext(ctx dumps.Context) string {
+	if domain := debugSiteDomain(ctx); domain != "" {
+		return "#sites/" + domain + "/dumps"
+	}
+	return "#sites"
+}
+
+// debugSiteDomain resolves an event context to the primary domain the Sites tab
+// is keyed by, preferring the site the bridge tagged and falling back to the
+// request domain, which survives even when LERD_SITE never reached the process.
+func debugSiteDomain(ctx dumps.Context) string {
+	if ctx.Site != "" {
+		return siteDomainForRoute(ctx.Site)
+	}
+	if ctx.Domain != "" {
+		if s, err := config.FindSiteByDomain(ctx.Domain); err == nil && s != nil {
+			return s.PrimaryDomain()
+		}
+	}
+	return ""
+}

--- a/internal/ui/notify_route_test.go
+++ b/internal/ui/notify_route_test.go
@@ -1,0 +1,87 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/dumps"
+)
+
+func TestDebugRouteForContext_ResolvesNameToDomain(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := config.AddSite(config.Site{
+		Name:    "rapids",
+		Domains: []string{"harborlist.test"},
+		Path:    t.TempDir(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := debugRouteForContext(dumps.Context{Site: "rapids"}); got != "#sites/harborlist.test/dumps" {
+		t.Errorf("route = %q", got)
+	}
+}
+
+// An event that reaches the notifier without LERD_SITE still carries the
+// request domain, which is enough to land on the right site's Debug tab.
+func TestDebugRouteForContext_ResolvesSiteFromDomain(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := config.AddSite(config.Site{
+		Name:    "rapids",
+		Domains: []string{"harborlist.test", "admin.harborlist.test"},
+		Path:    t.TempDir(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := debugRouteForContext(dumps.Context{Domain: "admin.harborlist.test"}); got != "#sites/harborlist.test/dumps" {
+		t.Errorf("route = %q", got)
+	}
+}
+
+func TestDebugRouteForContext_FallsBackToSitesList(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if got := debugRouteForContext(dumps.Context{Type: "cli"}); got != "#sites" {
+		t.Errorf("route = %q, want #sites", got)
+	}
+	if got := debugRouteForContext(dumps.Context{Domain: "gone.test"}); got != "#sites" {
+		t.Errorf("unregistered domain route = %q, want #sites", got)
+	}
+}
+
+func TestNotificationForDump_NoSiteFallsBackToSitesList(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	n := notificationForDump(dumps.Event{ID: "z", Kind: "dump", Ctx: dumps.Context{Type: "cli"}})
+	if n.URL != "#sites" {
+		t.Errorf("URL = %q, want #sites", n.URL)
+	}
+}
+
+func TestNotificationForNPlusOne_RoutesToSiteDebugTab(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := config.AddSite(config.Site{
+		Name:    "rapids",
+		Domains: []string{"harborlist.test"},
+		Path:    t.TempDir(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	n := notificationForNPlusOne(dumps.Event{Ctx: dumps.Context{Site: "rapids", Request: "GET /users"}}, 4)
+	if n.URL != "#sites/harborlist.test/dumps" {
+		t.Errorf("URL = %q", n.URL)
+	}
+}
+
+// Without a site the N+1 warning used to land on the global bridge view, which
+// says nothing about the event that was clicked (#1005).
+func TestNotificationForNPlusOne_NoSiteFallsBackToSitesList(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	n := notificationForNPlusOne(dumps.Event{Ctx: dumps.Context{Worker: "queue:work"}}, 4)
+	if n.URL != "#sites" {
+		t.Errorf("URL = %q, want #sites", n.URL)
+	}
+}

--- a/internal/ui/web/src/components/NotificationCenter.svelte
+++ b/internal/ui/web/src/components/NotificationCenter.svelte
@@ -6,6 +6,7 @@
     unreadNotifications,
     markNotificationsRead,
     clearNotificationHistory,
+    notificationSeverity,
     type NotificationRecord
   } from '$lib/notify';
   import { m } from '../paraglide/messages.js';
@@ -63,6 +64,7 @@
     {:else}
       <ul class="max-h-[60vh] overflow-y-auto divide-y divide-gray-100 dark:divide-lerd-border/60">
         {#each $notificationHistory as n (n.id)}
+          {@const severity = notificationSeverity(n.kind, n.failed)}
           <li>
             <button
               type="button"
@@ -70,10 +72,12 @@
               class="flex w-full items-start gap-2 px-3 py-2 text-left hover:bg-gray-50 dark:hover:bg-white/5 transition-colors"
             >
               <Icon
-                name={n.failed ? 'alert' : 'check'}
-                class="mt-0.5 h-3.5 w-3.5 shrink-0 {n.failed
+                name={severity === 'info' ? 'check' : 'alert'}
+                class="mt-0.5 h-3.5 w-3.5 shrink-0 {severity === 'failure'
                   ? 'text-red-500'
-                  : 'text-gray-300 dark:text-gray-600'}"
+                  : severity === 'warning'
+                    ? 'text-amber-500'
+                    : 'text-gray-300 dark:text-gray-600'}"
               />
               <span class="min-w-0 flex-1">
                 <span class="block truncate text-xs font-medium text-gray-800 dark:text-gray-100"

--- a/internal/ui/web/src/components/NotificationCenter.test.ts
+++ b/internal/ui/web/src/components/NotificationCenter.test.ts
@@ -48,3 +48,18 @@ describe('NotificationCenter', () => {
     expect(get(notificationHistory)).toHaveLength(0);
   });
 });
+
+describe('NotificationCenter severity', () => {
+  beforeEach(() => {
+    notificationHistory.set([]);
+  });
+
+  it('marks a detected problem as a warning in the list', async () => {
+    notificationHistory.set([
+      rec({ kind: 'nplusone', title: 'Possible N+1 query on acme', failed: false })
+    ]);
+    const { getByLabelText, container } = render(NotificationCenter);
+    await fireEvent.click(getByLabelText('Notifications'));
+    expect(container.querySelector('.text-amber-500')).toBeTruthy();
+  });
+});

--- a/internal/ui/web/src/components/NotificationToasts.svelte
+++ b/internal/ui/web/src/components/NotificationToasts.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import Icon from '$components/Icon.svelte';
-  import { inAppNotifications, dismissInApp, type InAppNotification } from '$lib/notify';
+  import {
+    inAppNotifications,
+    dismissInApp,
+    notificationSeverity,
+    type InAppNotification
+  } from '$lib/notify';
   import { m } from '../paraglide/messages.js';
 
   // A failure stays until it is dismissed; anything else is informational and
@@ -34,18 +39,24 @@
 {#if $inAppNotifications.length > 0}
   <div class="fixed bottom-3 right-3 z-60 flex w-[min(92vw,380px)] flex-col gap-2">
     {#each $inAppNotifications as n (n.id)}
+      {@const severity = notificationSeverity(n.kind, n.failed)}
       <div
-        role={n.failed ? 'alert' : 'status'}
-        class="rounded-lg border border-l-4 bg-white/90 dark:bg-lerd-card/90 backdrop-blur-md shadow-2xl {n.failed
+        role={severity === 'info' ? 'status' : 'alert'}
+        class="rounded-lg border border-l-4 bg-white/90 dark:bg-lerd-card/90 backdrop-blur-md shadow-2xl {severity ===
+        'failure'
           ? 'border-red-300 dark:border-red-500/40 border-l-red-500'
-          : 'border-gray-200 dark:border-lerd-border border-l-sky-500'}"
+          : severity === 'warning'
+            ? 'border-amber-300 dark:border-amber-500/40 border-l-amber-500'
+            : 'border-gray-200 dark:border-lerd-border border-l-sky-500'}"
       >
         <div class="flex items-start gap-2.5 px-3 py-2.5">
           <Icon
-            name={n.failed ? 'alert' : 'check'}
-            class="mt-0.5 h-4 w-4 shrink-0 {n.failed
+            name={severity === 'info' ? 'check' : 'alert'}
+            class="mt-0.5 h-4 w-4 shrink-0 {severity === 'failure'
               ? 'text-red-500'
-              : 'text-sky-600 dark:text-sky-400'}"
+              : severity === 'warning'
+                ? 'text-amber-500'
+                : 'text-sky-600 dark:text-sky-400'}"
           />
           <div class="min-w-0 flex-1">
             <p class="text-xs font-semibold text-gray-800 dark:text-gray-100">{n.title}</p>

--- a/internal/ui/web/src/components/NotificationToasts.test.ts
+++ b/internal/ui/web/src/components/NotificationToasts.test.ts
@@ -47,3 +47,20 @@ describe('NotificationToasts', () => {
     expect(get(inAppNotifications)).toHaveLength(0);
   });
 });
+
+describe('NotificationToasts severity', () => {
+  beforeEach(() => {
+    inAppNotifications.set([]);
+    vi.useRealTimers();
+  });
+
+  it('draws a detected problem as a warning rather than a completed action', async () => {
+    const { getByRole, container } = render(NotificationToasts);
+    push({ kind: 'nplusone', title: 'Possible N+1 query on acme', body: 'GET /users ran a similar query 3x' });
+    await tick();
+
+    expect(getByRole('alert')).toHaveTextContent('Possible N+1 query on acme');
+    expect(container.querySelector('.text-amber-500')).toBeTruthy();
+    expect(container.querySelector('.text-sky-600')).toBeNull();
+  });
+});

--- a/internal/ui/web/src/lib/notify.test.ts
+++ b/internal/ui/web/src/lib/notify.test.ts
@@ -680,4 +680,34 @@ describe('stored notification history', () => {
     const { notificationHistory } = await import('./notify');
     expect(get(notificationHistory)).toHaveLength(0);
   });
+
+  // Entries written before debug notifications learned to open the site they
+  // came from still point at the global bridge view, and the list outlives the
+  // build that wrote it, so the stale route is rewritten on load (#1005).
+  it('retargets a stored debug notification away from the bridge view', async () => {
+    localStorage.setItem(
+      'lerd:notify:history',
+      JSON.stringify([
+        { id: 1, kind: 'nplusone', title: 'Possible N+1 query on acme', body: '', url: '#system/dump-bridge', failed: false, at: 1, read: false },
+        { id: 2, kind: 'op_done', title: 'Update finished', body: '', url: '#services/mysql', failed: false, at: 2, read: true }
+      ])
+    );
+
+    const { notificationHistory } = await import('./notify');
+    const urls = get(notificationHistory).map((r) => r.url);
+    expect(urls).toEqual(['#sites', '#services/mysql']);
+  });
+});
+
+describe('notification severity', () => {
+  it('reads a detected problem as a warning, not a completed action', async () => {
+    const { notificationSeverity } = await import('./notify');
+    expect(notificationSeverity('nplusone', false)).toBe('warning');
+    expect(notificationSeverity('slow_route', false)).toBe('warning');
+    expect(notificationSeverity('op_done', false)).toBe('info');
+    expect(notificationSeverity('mail', false)).toBe('info');
+    expect(notificationSeverity('op_failed', true)).toBe('failure');
+    // A failed operation outranks its category.
+    expect(notificationSeverity('nplusone', true)).toBe('failure');
+  });
 });

--- a/internal/ui/web/src/lib/notify.ts
+++ b/internal/ui/web/src/lib/notify.ts
@@ -165,6 +165,18 @@ export interface InAppNotification {
 
 export const inAppNotifications = writable<InAppNotification[]>([]);
 
+// Severity drives how a notification is drawn on the in-page surfaces. The
+// diagnostic kinds report a problem lerd found in the user's app, so they read
+// as warnings rather than as a completed action.
+export type NotifySeverity = 'failure' | 'warning' | 'info';
+
+const WARNING_KINDS = new Set<string>(['nplusone', 'slow_route']);
+
+export function notificationSeverity(kind: string, failed: boolean): NotifySeverity {
+  if (failed) return 'failure';
+  return WARNING_KINDS.has(kind) ? 'warning' : 'info';
+}
+
 // HISTORY_KEY holds the notification centre's list. It is persisted because the
 // point of the centre is catching up on what happened while the user was
 // elsewhere, including before a reload.
@@ -174,6 +186,13 @@ const historyLimit = 50;
 export interface NotificationRecord extends InAppNotification {
   at: number;
   read: boolean;
+}
+
+// Debug notifications used to open the global bridge view, which says nothing
+// about the event that was clicked. Stored entries outlive the build that wrote
+// them, so an old one is retargeted at the sites list on load.
+function retargetStoredURL(url: string): string {
+  return url === '#system/dump-bridge' ? '#sites' : (url ?? '');
 }
 
 // Stored ids are renumbered on the way in. The list outlives the code that
@@ -188,7 +207,7 @@ function loadHistory(): NotificationRecord[] {
     return list
       .filter((r) => r && typeof r === 'object' && typeof r.title === 'string')
       .slice(0, historyLimit)
-      .map((r, i) => ({ ...r, id: i + 1 }));
+      .map((r, i) => ({ ...r, id: i + 1, url: retargetStoredURL(r.url) }));
   } catch {
     return [];
   }

--- a/internal/watcher/reqstats_notify.go
+++ b/internal/watcher/reqstats_notify.go
@@ -65,12 +65,16 @@ func notificationForSlowRoute(site, domain string, r reqstats.RouteStat) push.No
 	if r.Multiplier > 0 {
 		body = fmt.Sprintf("%s is %gx slower than usual (%gms)", r.Route, r.Multiplier, r.P95Millis)
 	}
+	url := "#sites"
+	if domain != "" {
+		url = "#sites/" + domain + "/dumps"
+	}
 	return push.Notification{
 		Kind:    "slow_route",
 		Title:   "Slow route on " + site,
 		Body:    body,
 		Tag:     "lerd-slowroute-" + site + "-" + r.Route,
-		URL:     "#sites/" + domain + "/dumps",
+		URL:     url,
 		Data:    map[string]string{"site": site, "route": r.Route},
 		Urgency: "normal",
 		TTL:     120,
@@ -78,13 +82,14 @@ func notificationForSlowRoute(site, domain string, r reqstats.RouteStat) push.No
 }
 
 // siteDomainResolver loads the site registry once and returns a key->domain
-// lookup, falling back to the key when it has no domain. A worktree key resolves
-// to the worktree's own domain, so the notification deep-links to the branch that
-// went slow rather than to its parent.
+// lookup, returning "" when the key has no domain so the caller can fall back to
+// the sites list rather than deep-link a route that resolves to nothing. A
+// worktree key resolves to the worktree's own domain, so the notification
+// deep-links to the branch that went slow rather than to its parent.
 func siteDomainResolver() func(string) string {
 	reg, err := config.LoadSites()
 	if err != nil {
-		return func(s string) string { return s }
+		return func(string) string { return "" }
 	}
 	m := make(map[string]string, len(reg.Sites))
 	for _, s := range reg.Sites {
@@ -99,9 +104,6 @@ func siteDomainResolver() func(string) string {
 				return d
 			}
 		}
-		if d, ok := m[site]; ok {
-			return d
-		}
-		return key
+		return m[site]
 	}
 }

--- a/internal/watcher/reqstats_notify_test.go
+++ b/internal/watcher/reqstats_notify_test.go
@@ -95,3 +95,12 @@ func TestNotificationForSlowRoute_zeroMultiplierUsesAbsolute(t *testing.T) {
 		t.Errorf("with a real multiplier the body should use the slower-than-usual phrasing, got %q", body)
 	}
 }
+
+// An unresolvable site key must land on the sites list, not on a deep link that
+// resolves to no site at all (#1005).
+func TestNotificationForSlowRoute_unresolvedDomainFallsBackToSitesList(t *testing.T) {
+	r := reqstats.RouteStat{Route: "GET /export", Method: "GET", P95Millis: 1200, Multiplier: 5}
+	if url := notificationForSlowRoute("acme", "", r).URL; url != "#sites" {
+		t.Errorf("URL = %q, want #sites", url)
+	}
+}


### PR DESCRIPTION
A debug notification should land on the site the event came from, where the event and its surrounding context are, rather than on the global bridge view. The N+1 warning was the one kind that started from the system Debug detail and only rewrote itself to a site route when the event carried one, so anything reaching the notifier without a resolved site sent the user somewhere that told them nothing about what they had just clicked.

Every debug notification now resolves its route the same way: the site the bridge tagged, then the request domain, and the sites list when neither resolves. That also fixes a dump with no site producing a route with the literal placeholder in it, and the slow-route warning deep-linking a domain the resolver never found.

Driving this against a real site showed the fallback was not rare at all. The devtools extension reads LERD_SITE from the environment and lerd php never passed it, so every query, job and event from a terminal command arrived with no site while dumps quietly guessed one from the directory name. lerd php now forwards the registered site name, with a worktree checkout reporting its parent like tinker and the worktree vhost already do.

The in-page surfaces gained a warning tier between informational and failure, since an N+1 or a slow route is a problem lerd found in your app, not an action that completed, and a green check read as the opposite. Entries already stored in the notification centre still point at the bridge view, so they are retargeted when the history loads.

Closes #1005