### PR TITLE
fix(ui): leave the desktop to the daemon under the native sink

### DIFF
--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -9,7 +9,7 @@ The first time you open the dashboard a small banner offers to enable browser no
 Notifications have a single delivery **sink**, chosen per install and mutually exclusive so you never get the same alert twice:
 
 - **Browser** — the WebSocket fan-out to open dashboards plus Web Push to subscribed browsers (the paths described under [How it works](#how-it-works)). Needs a browser permission grant, works cross-machine over the LAN, and delivers to a closed PWA.
-- **Native desktop** — the `lerd-ui` daemon posts straight to the desktop notification service (`org.freedesktop.Notifications` over the session bus, using the DBus library lerd already ships). No browser, no permission prompt, and notifications appear even with nothing open. Web Push is suppressed in this mode. Linux only for now; macOS follows later.
+- **Native desktop** — the `lerd-ui` daemon posts straight to the desktop notification service (`org.freedesktop.Notifications` over the session bus, using the DBus library lerd already ships). No browser, no permission prompt, and notifications appear even with nothing open. Web Push is suppressed in this mode, and so is the popup an open dashboard would otherwise raise itself, so the daemon's is the only copy and clicking it opens the desktop app. Linux only for now; macOS follows later.
 
 Switch under **System → Notifications** with the *Delivery* control, or from the CLI:
 

--- a/internal/ui/web/src/lib/notify.test.ts
+++ b/internal/ui/web/src/lib/notify.test.ts
@@ -119,6 +119,43 @@ describe('notify dispatcher', () => {
     hasFocus.mockRestore();
   });
 
+  // With the native sink the daemon posts its own desktop popup, so a page
+  // raising a second one duplicates it and steals the click from the desktop
+  // app (#1042). The bell still records the event.
+  it('leaves the desktop to the daemon when delivery is native', async () => {
+    const { initNotify, notifyDelivery, notificationHistory } = await import('./notify');
+    const { wsMessage } = await import('./ws');
+
+    initNotify();
+    notifyDelivery.set('native');
+    wsMessage.set({
+      type: 'notification',
+      notification: { kind: 'mail', title: 'New email: Welcome' }
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(swShows).toHaveLength(0);
+    expect(MockNotification.instances).toHaveLength(0);
+    expect(get(notificationHistory)).toHaveLength(1);
+  });
+
+  it('still raises it on the desktop under the browser sink', async () => {
+    const { initNotify, notifyDelivery } = await import('./notify');
+    const { wsMessage } = await import('./ws');
+
+    initNotify();
+    notifyDelivery.set('browser');
+    wsMessage.set({
+      type: 'notification',
+      notification: { kind: 'mail', title: 'New email: Welcome' }
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(swShows).toHaveLength(1);
+  });
+
   it('suppresses notifications for kinds the user has disabled', async () => {
     const { initNotify, setNotifyPref } = await import('./notify');
     const { wsMessage } = await import('./ws');

--- a/internal/ui/web/src/lib/notify.ts
+++ b/internal/ui/web/src/lib/notify.ts
@@ -316,6 +316,10 @@ async function fireNotification(evt: NotificationEvent) {
       pushInApp(entry);
     }
     if (windowFocused()) return;
+    // Under the native sink the daemon has already posted this to the desktop.
+    // A second popup from the page duplicates it and takes the click away from
+    // the desktop app, which the daemon's copy opens through lerd://.
+    if (get(notifyDelivery) === 'native') return;
   }
   if (typeof Notification === 'undefined') return;
   if (Notification.permission !== 'granted') return;


### PR DESCRIPTION
With the native sink selected, one event produced two desktop popups whenever a dashboard window was open but not focused. The daemon broadcasts the payload over the websocket so open pages can file it in the bell, then posts to the notification service itself, and the page went on to raise its own copy through the browser because nothing told it the desktop had already been served.

The duplicate was more than visual noise. The daemon's copy opens the desktop app through its lerd:// scheme while the browser's focuses the browser, and a compositor stacking two identical popups makes it luck which one gets clicked, so the app the user installed was bypassed half the time.

The page already tracks the sink for the enable banner and the settings pane, so the dispatcher now consults it and stops before the OS-level call when delivery is native. The bell and the in-page toast are untouched, and the daemon's popup becomes the single clickable copy.

Closes #1042