### PR TITLE
fix(php): give the fast path a toolchain to build custom extensions in

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -302,6 +302,8 @@ $ lerd isolate 8.3
 
 An extension that genuinely cannot build on that version is reported differently, because no rebuild will fix it.
 
+One that loaded on **no version at all** is reported differently again. A version boundary shows up on some versions and not others, so an extension missing from every one of them is usually the build failing rather than the versions refusing it, and `lerd php:ext list` says so instead of reading it as a capability gap.
+
 Some extensions need extra Alpine packages to compile. lerd already knows the ones for `imap` (`imap-dev krb5-dev openssl-dev c-client`); for anything else, pass them with `--apk-deps`:
 
 ```bash

--- a/internal/cli/php_sets_report.go
+++ b/internal/cli/php_sets_report.go
@@ -16,7 +16,8 @@ import (
 // advertised what those images do not load, which is what #856 exists to
 // prevent. The three states are kept apart because the answer to each differs:
 // rebuild, give up, or nothing to do.
-func printPerVersionStatus(cfg *config.GlobalConfig, pick func(phpsets.Report) phpsets.SetState) {
+func printPerVersionStatus(cfg *config.GlobalConfig, kind declaredKind) {
+	pick := kind.pick
 	reports := phpsets.StatusAll(cfg, config.SupportedPHPVersions)
 
 	var lines []string
@@ -52,8 +53,30 @@ func printPerVersionStatus(cfg *config.GlobalConfig, pick func(phpsets.Report) p
 	if unbuildable {
 		fmt.Println("\nWhat an image cannot load did not build on that version; a rebuild will not change that.")
 	}
+	// Landing on no version at all is a different problem from a version
+	// boundary: nowhere to build is usually the build environment, not the
+	// versions, and saying so is what would have surfaced #1013 without
+	// anyone reading a build log.
+	if nowhere := phpsets.NowhereBuilt(reports, pick); len(nowhere) > 0 {
+		fmt.Printf("\n%s built on no version at all, which usually means the build failed rather than\nthe versions cannot have it.%s\n", strings.Join(nowhere, ", "), kind.nowhereHint(nowhere[0]))
+	}
 }
 
-// extensionsOf and packagesOf name which declared set a report line is about.
-func extensionsOf(r phpsets.Report) phpsets.SetState { return r.Extensions }
-func packagesOf(r phpsets.Report) phpsets.SetState   { return r.Packages }
+// declaredKind names which declared set a report is about, along with what to
+// suggest when an entry of that kind landed on no version.
+type declaredKind struct {
+	pick        func(phpsets.Report) phpsets.SetState
+	nowhereHint func(entry string) string
+}
+
+var extensionsOf = declaredKind{
+	pick: func(r phpsets.Report) phpsets.SetState { return r.Extensions },
+	nowhereHint: func(e string) string {
+		return " Re-add it with the Alpine packages its\nbuild needs: lerd php:ext add " + e + " --apk-deps \"<pkg>-dev\""
+	},
+}
+
+var packagesOf = declaredKind{
+	pick:        func(r phpsets.Report) phpsets.SetState { return r.Packages },
+	nowhereHint: func(e string) string { return " Check the package name exists on Alpine." },
+}

--- a/internal/phpsets/phpsets.go
+++ b/internal/phpsets/phpsets.go
@@ -83,6 +83,37 @@ func StatusAll(cfg *config.GlobalConfig, versions []string) []Report {
 	return out
 }
 
+// NowhereBuilt returns the declared entries that no built, current image
+// carries. A version-specific capability gap shows up on some versions and not
+// others; an entry missing from every one of them points at the build
+// environment instead, which is a different problem with a different answer.
+// Empty when no version has a current image to judge from.
+func NowhereBuilt(reports []Report, pick func(Report) SetState) []string {
+	var judged []Report
+	for _, r := range reports {
+		if r.Built && !r.NeedsRebuild {
+			judged = append(judged, r)
+		}
+	}
+	if len(judged) == 0 {
+		return nil
+	}
+	var out []string
+	for _, e := range pick(judged[0]).Declared {
+		missing := true
+		for _, r := range judged {
+			if slices.Contains(pick(r).Has, e) {
+				missing = false
+				break
+			}
+		}
+		if missing {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 // split partitions the declared set into what the image has and what it could
 // not load, from the record written when it was built.
 func split(cfg *config.GlobalConfig, version string, declared []string) (has, cannot []string) {

--- a/internal/phpsets/phpsets_test.go
+++ b/internal/phpsets/phpsets_test.go
@@ -152,3 +152,33 @@ func TestModules_unbuiltVersion(t *testing.T) {
 		t.Errorf("Modules = %v, want empty for an unbuilt version", got)
 	}
 }
+
+// An entry that landed nowhere is a broken build environment, not a version
+// boundary, and the realised set already holds what tells those apart.
+func TestNowhereBuilt(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.AddExtension("mongodb")
+	cfg.AddExtension("yaml")
+	cfg.SetRealised("8.5", config.RealisedPHPSet{Extensions: []string{"mongodb"}})
+	cfg.SetRealised("7.4", config.RealisedPHPSet{})
+	stubImages(t, func(v string) bool { return v == "8.5" || v == "7.4" }, func(string) bool { return false })
+
+	reports := StatusAll(cfg, []string{"8.5", "8.1", "7.4"})
+	got := NowhereBuilt(reports, func(r Report) SetState { return r.Extensions })
+	if !reflect.DeepEqual(got, []string{"yaml"}) {
+		t.Errorf("NowhereBuilt = %v, want [yaml]: mongodb built on 8.5, yaml built nowhere", got)
+	}
+}
+
+// With no current image anywhere there is nothing to conclude, so nothing is
+// claimed: an unbuilt version is not evidence that an entry failed.
+func TestNowhereBuilt_noJudgeableImage(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.AddExtension("yaml")
+	stubImages(t, func(string) bool { return true }, func(string) bool { return true })
+
+	reports := StatusAll(cfg, []string{"8.5", "8.4"})
+	if got := NowhereBuilt(reports, func(r Report) SetState { return r.Extensions }); got != nil {
+		t.Errorf("NowhereBuilt = %v, want nil when every image is stale", got)
+	}
+}

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -471,7 +471,7 @@ func buildFPMImage(version string, force, local bool, customExts []string, extDe
 		if baseRef := tryPullBaseImage(version, w); baseRef != "" {
 			containerfile = "FROM " + baseRef + "\n" +
 				"RUN mkdir -p /etc/my.cnf.d && printf '[client]\\nssl=0\\n' > /etc/my.cnf.d/lerd-no-ssl.cnf\n" +
-				buildCustomExtBlock(customExts, extDeps) +
+				buildCustomExtBlockWithToolchain(customExts, extDeps) +
 				buildCustomPackagesBlock(packages) +
 				mkcertCABlock(tmp)
 			goto build
@@ -602,24 +602,48 @@ func buildCustomExtRuntimeDeps(exts []string, userDeps map[string][]string) stri
 	return "RUN apk add --no-cache " + strings.Join(deps, " ") + " && rm -rf /var/cache/apk/*\n"
 }
 
+// phpizeToolchain is what a PECL build needs beyond the runtime image: the same
+// compilers the Containerfile's builder stage apk-adds. Without them `pecl
+// install` stops at phpize ("Cannot find autoconf").
+var phpizeToolchain = []string{"autoconf", "make", "g++", "linux-headers"}
+
 // buildCustomExtBlock generates Dockerfile RUN blocks for user-configured
 // extensions, apk-adding any extra build deps (built-in map ∪ userDeps) first.
+// This is the builder stage's block, which already has a toolchain to build in.
 func buildCustomExtBlock(exts []string, userDeps map[string][]string) string {
+	return customExtBlock(exts, userDeps, false)
+}
+
+// buildCustomExtBlockWithToolchain is the same block for the fast path, which
+// layers straight onto the pre-built runtime image and so has no toolchain to
+// build against. It installs one virtually and purges it inside the same layer,
+// leaving the runtime image the size it was.
+func buildCustomExtBlockWithToolchain(exts []string, userDeps map[string][]string) string {
+	return customExtBlock(exts, userDeps, true)
+}
+
+func customExtBlock(exts []string, userDeps map[string][]string, withToolchain bool) string {
 	if len(exts) == 0 {
 		return ""
 	}
 	var sb strings.Builder
 	sb.WriteString("# User-configured extensions\n")
 	for _, ext := range exts {
-		prefix := ""
+		prefix, purge := "", ""
+		if withToolchain {
+			prefix = "apk add --no-cache --virtual .lerd-ext-build " + strings.Join(phpizeToolchain, " ") + " && "
+			purge = " \\\n    && { apk del .lerd-ext-build 2>/dev/null || true; }"
+		}
+		// The extension's own deps outlive the purge: the compiled .so dlopens
+		// against them at runtime, the way the local path's runtime block does.
 		if deps := apkDepsForExt(ext, userDeps); len(deps) > 0 {
-			prefix = "apk add --no-cache " + strings.Join(deps, " ") + " && "
+			prefix += "apk add --no-cache " + strings.Join(deps, " ") + " && "
 		}
 		// `yes ''` feeds default answers to interactive PECL prompts (imap asks
 		// for kerberos / c-client paths); harmless for extensions that don't ask.
 		sb.WriteString(fmt.Sprintf(
-			"RUN { %s(yes '' | pecl install %s && docker-php-ext-enable %s) || docker-php-ext-install %s || true; } \\\n    && rm -rf /tmp/pear /var/cache/apk/*\n",
-			prefix, ext, ext, ext,
+			"RUN { %s(yes '' | pecl install %s && docker-php-ext-enable %s) || docker-php-ext-install %s || true; }%s \\\n    && rm -rf /tmp/pear /var/cache/apk/*\n",
+			prefix, ext, ext, ext, purge,
 		))
 	}
 	return sb.String()

--- a/internal/podman/build_test.go
+++ b/internal/podman/build_test.go
@@ -157,6 +157,45 @@ func TestBuildCustomExtBlock_UserDepsUnionedWithBuiltin(t *testing.T) {
 	}
 }
 
+func TestBuildCustomExtBlockWithToolchain(t *testing.T) {
+	if got := buildCustomExtBlockWithToolchain(nil, nil); got != "" {
+		t.Errorf("expected empty block for no extensions, got:\n%s", got)
+	}
+	// The prebuilt base is the runtime image, so phpize has no toolchain there.
+	block := buildCustomExtBlockWithToolchain([]string{"yaml"}, map[string][]string{"yaml": {"yaml-dev"}})
+	for _, pkg := range phpizeToolchain {
+		if !strings.Contains(block, pkg) {
+			t.Errorf("fast-path block must install %q for phpize:\n%s", pkg, block)
+		}
+	}
+	if !strings.Contains(block, "--virtual .lerd-ext-build") {
+		t.Errorf("toolchain must install as a virtual package so it can be purged:\n%s", block)
+	}
+	if !strings.Contains(block, "apk del .lerd-ext-build") {
+		t.Errorf("toolchain must be purged in the same layer so the runtime image does not grow:\n%s", block)
+	}
+	// The extension's own deps still install, and outlive the purge: the
+	// compiled .so dlopens against them at runtime.
+	if !strings.Contains(block, "apk add --no-cache yaml-dev && ") {
+		t.Errorf("extension deps must still install:\n%s", block)
+	}
+	if strings.Count(block, "\nRUN ") > 1 {
+		t.Errorf("one extension should produce one RUN layer:\n%s", block)
+	}
+	if !strings.Contains(block, "|| true; }") {
+		t.Errorf("block must keep the `|| true` resilience guard:\n%s", block)
+	}
+}
+
+// The builder stage already carries the toolchain, so the local path must not
+// install or purge it: purging there would take the stage's own compilers out.
+func TestBuildCustomExtBlock_NoToolchainOnLocalPath(t *testing.T) {
+	block := buildCustomExtBlock([]string{"yaml"}, nil)
+	if strings.Contains(block, ".lerd-ext-build") {
+		t.Errorf("builder-stage block must not manage the toolchain:\n%s", block)
+	}
+}
+
 func TestBuildCustomExtRuntimeDeps_Empty(t *testing.T) {
 	if got := buildCustomExtRuntimeDeps(nil, nil); got != "" {
 		t.Errorf("empty input should produce empty runtime block, got: %q", got)


### PR DESCRIPTION
lerd php:ext add failed for every extension on the default path. The fast path is FROM the pre-built base with the custom extension block layered straight onto it, and that base is the runtime image, which carries no compilers, so pecl install got as far as phpize and stopped on "Cannot find autoconf". The same block on the local path sits in the builder stage, where autoconf, make and g++ are already installed, which is why --local worked and the default did not.

The fast path now installs those compilers as a virtual package, builds, and purges them inside the same layer, so the two paths agree and the runtime image stays the size it was. An extension's own apk deps still install for good, since the compiled .so dlopens against them at runtime, the way the local path's runtime block already handles them. In practice that means `lerd php:ext add yaml --apk-deps "yaml-dev"` is all that is needed now, where the workaround also had to list the whole toolchain.

Nothing surfaced this, because each extension step ends in || true so that one entry a version genuinely cannot have does not fail the image for the versions that can. That absorbed a total failure with machinery meant for a partial one, and the version by version report read it back as a capability boundary. An entry that landed on no version at all is now reported as the build failing rather than the versions refusing it, which is a different problem with a different answer.

Refs #1013