### PR TITLE
feat(ui): link the site name in a debug group header to that site

### DIFF
--- a/docs/features/dumps.md
+++ b/docs/features/dumps.md
@@ -25,7 +25,7 @@ The receiver's transport depends on the host:
 
 - **Web dashboard** — three places:
   - Each site detail pane has a **Dumps** tab next to Overview and Tinker, pre-filtered to that site.
-  - **System > Debug bridge** opens a global view with the listener address, the buffered count, an Enable/Disable button, and every dump across every project.
+  - **System > Debug bridge** opens a global view with the listener address, the buffered count, an Enable/Disable button, and every dump across every project. The site name that leads each group header links to that site's own Debug tab, so an event you spot in the global view takes you straight to where it came from; a name that matches no linked site stays plain text.
 
     ![System Debug bridge detail](/assets/screenshots/system-dump-bridge.png)
 
@@ -59,7 +59,7 @@ Each event is one line of JSON. The shape is stable from v1 of the protocol:
 }
 ```
 
-`ctx.branch` is set when the dump came from a worktree, so a request to `feat-a.acme.test` carries `branch: "feat-a"` alongside the parent `site: "acme"`. It is plumbed end-to-end via the `LERD_SITE` and `LERD_BRANCH` fastcgi params on the worktree vhost. Because every worktree shares the parent's `site`, the branch is what separates a worktree's events from the parent's: request grouping keys on it (a worktree request never merges into the parent's group), every group is labelled `[site@branch]` in the dashboard and the TUI, the CLI tail prints `site@branch` in each event header, and the search box matches the branch name. To isolate a single worktree, filter by branch: `lerd dump tail --branch feat-a`, the `branch` query param on `/api/dumps`, or the `branch` argument to the `dumps_recent` MCP tool. Parent-site requests leave the field empty and render as plain `[site]`.
+`ctx.branch` is set when the dump came from a worktree, so a request to `feat-a.acme.test` carries `branch: "feat-a"` alongside the parent `site: "acme"`. It is plumbed end-to-end via the `LERD_SITE` and `LERD_BRANCH` fastcgi params on the worktree vhost. Because every worktree shares the parent's `site`, the branch is what separates a worktree's events from the parent's: request grouping keys on it (a worktree request never merges into the parent's group), every group is labelled `[site@branch]` in the dashboard and the TUI, the CLI tail prints `site@branch` in each event header, and the search box matches the branch name. To isolate a single worktree, filter by branch: `lerd dump tail --branch feat-a`, the `branch` query param on `/api/dumps`, or the `branch` argument to the `dumps_recent` MCP tool. Parent-site requests leave the field empty and render as plain `[site]`. Inside a site's own Debug tab the site name is dropped and only `[branch]` is shown, unlinked, since you are already on that site.
 
 `ctx.site` is set on terminal runs too: `lerd php` (and everything shimmed through it, `artisan` included) passes `LERD_SITE` into the container, so an event from an artisan command carries the registered site name rather than the directory it happened to run in, and a run inside a worktree checkout reports the parent site.
 

--- a/internal/ui/web/src/components/KindLens.svelte
+++ b/internal/ui/web/src/components/KindLens.svelte
@@ -18,6 +18,7 @@
   import Dropdown from '$components/Dropdown.svelte';
   import TraceBlock from '$components/TraceBlock.svelte';
   import LensLoadMore from '$components/LensLoadMore.svelte';
+  import LensGroupLabel from '$components/LensGroupLabel.svelte';
   import { windowGroups, LENS_PAGE } from '$lib/lensWindow';
   import { openInEditor } from '$lib/editor';
   import { m } from '../paraglide/messages.js';
@@ -172,7 +173,7 @@
         <section class="mb-4">
           <header class="flex items-center gap-2 mb-1 sticky top-0 bg-gray-50 dark:bg-lerd-bg py-1 -mx-3 px-3 z-1">
             {#if group.worker}<span class="text-[10px] font-semibold uppercase tracking-wide rounded-sm px-1.5 py-0.5 bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 shrink-0">{m.queries_worker_badge()}</span>{/if}
-            <span class="text-sm truncate">{group.label}</span>
+            <LensGroupLabel label={group.label} />
             <span class="text-xs text-gray-400 ml-auto whitespace-nowrap font-mono">{localTime(group.ts)}</span>
             <span class="text-xs text-gray-400 whitespace-nowrap">{page.total}</span>
           </header>

--- a/internal/ui/web/src/components/LensGroupLabel.svelte
+++ b/internal/ui/web/src/components/LensGroupLabel.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import type { GroupLabel } from '$lib/eventGroup';
+  import { sites, siteDomainForName } from '$stores/sites';
+
+  interface Props {
+    label: GroupLabel;
+  }
+  let { label }: Props = $props();
+
+  // A site name that resolves to a linked site opens that site's Debug tab;
+  // anything else (an unregistered name, the empty "(unknown)" case, and the
+  // branch shown on its own inside a site) stays plain text.
+  const domain = $derived(siteDomainForName($sites, label.site));
+  const suffix = $derived(label.site && label.branch ? '@' + label.branch : '');
+</script>
+
+<span class="text-sm truncate">
+  {#if label.site || label.branch}<span
+      >[{#if label.site && domain}<a
+          href="#sites/{domain}/dumps"
+          class="underline decoration-dotted underline-offset-2 hover:text-lerd-red">{label.site}</a
+        >{:else if label.site}{label.site}{:else}{label.branch}{/if}{suffix}]
+    </span>{/if}{label.text}
+</span>

--- a/internal/ui/web/src/components/LensGroupLabel.test.ts
+++ b/internal/ui/web/src/components/LensGroupLabel.test.ts
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect, beforeEach } from 'vitest';
+import LensGroupLabel from './LensGroupLabel.svelte';
+import { sites } from '$stores/sites';
+
+describe('LensGroupLabel', () => {
+  beforeEach(() => {
+    sites.set([{ domain: 'admin-astrolov.test', name: 'admin-astrolov' }]);
+  });
+
+  it('links a known site name to that site Debug tab', () => {
+    render(LensGroupLabel, { props: { label: { site: 'admin-astrolov', branch: '', text: 'GET /caffeine/drip' } } });
+    const link = screen.getByText('admin-astrolov');
+    expect(link.tagName.toLowerCase()).toBe('a');
+    expect(link.getAttribute('href')).toBe('#sites/admin-astrolov.test/dumps');
+  });
+
+  it('keeps the branch inside the brackets and out of the link', () => {
+    const { container } = render(LensGroupLabel, {
+      props: { label: { site: 'admin-astrolov', branch: 'feature-x', text: 'GET /' } }
+    });
+    expect(screen.getByText('admin-astrolov').tagName.toLowerCase()).toBe('a');
+    expect(container.textContent).toContain('[admin-astrolov@feature-x]');
+    expect(container.querySelector('a')?.textContent).toBe('admin-astrolov');
+  });
+
+  it('leaves an unregistered site name as plain text', () => {
+    const { container } = render(LensGroupLabel, {
+      props: { label: { site: 'mystery', branch: '', text: 'GET /' } }
+    });
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.textContent).toContain('[mystery]');
+  });
+
+  it('renders a lone branch unlinked, as the per-site tab shows it', () => {
+    const { container } = render(LensGroupLabel, {
+      props: { label: { site: '', branch: 'feature-x', text: 'GET /' } }
+    });
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.textContent).toContain('[feature-x]');
+    expect(container.textContent).toContain('GET /');
+  });
+
+  it('renders the label text alone when there is no site or branch', () => {
+    const { container } = render(LensGroupLabel, {
+      props: { label: { site: '', branch: '', text: 'cli (pid 7)' } }
+    });
+    expect(container.textContent?.trim()).toBe('cli (pid 7)');
+  });
+});

--- a/internal/ui/web/src/components/QueriesLens.svelte
+++ b/internal/ui/web/src/components/QueriesLens.svelte
@@ -20,6 +20,7 @@
   import Dropdown from '$components/Dropdown.svelte';
   import TraceBlock from '$components/TraceBlock.svelte';
   import LensLoadMore from '$components/LensLoadMore.svelte';
+  import LensGroupLabel from '$components/LensGroupLabel.svelte';
   import { windowGroups, LENS_PAGE } from '$lib/lensWindow';
   import { inlineBindings } from '$lib/sqlInline';
   import type { QueryRow } from '$stores/queries';
@@ -217,7 +218,7 @@
             {#if group.worker}
               <span class="text-[10px] font-semibold uppercase tracking-wide rounded-sm px-1.5 py-0.5 bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 shrink-0">{m.queries_worker_badge()}</span>
             {/if}
-            <span class="text-sm truncate">{group.label}</span>
+            <LensGroupLabel label={group.label} />
             {#if group.nPlusOne}
               <span class="text-[10px] font-semibold uppercase tracking-wide rounded-sm px-1.5 py-0.5 bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">{m.queries_nplusone_badge()}</span>
             {/if}

--- a/internal/ui/web/src/lib/eventGroup.test.ts
+++ b/internal/ui/web/src/lib/eventGroup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { groupKey, sitePrefix } from './eventGroup';
+import { groupKey, groupLabel, labelString } from './eventGroup';
 import type { DumpEvent } from '$lib/dumpsStream';
 
 function ev(over: Partial<DumpEvent['ctx']> & { ts?: string } = {}): DumpEvent {
@@ -41,17 +41,35 @@ describe('groupKey', () => {
   });
 });
 
-describe('sitePrefix', () => {
-  it('tags the branch alongside the site', () => {
-    expect(sitePrefix(ev({ branch: 'feature-x' }), false)).toBe('[acme@feature-x] ');
+describe('groupLabel', () => {
+  it('returns site and branch as separate parts', () => {
+    expect(groupLabel(ev({ branch: 'feature-x' }), false)).toEqual({
+      site: 'acme',
+      branch: 'feature-x',
+      text: 'GET /checkout'
+    });
   });
 
-  it('is plain [site] with no branch', () => {
-    expect(sitePrefix(ev({ branch: '' }), false)).toBe('[acme] ');
+  it('drops the site but keeps the branch when the site prefix is hidden', () => {
+    expect(groupLabel(ev({ branch: 'feature-x' }), true)).toEqual({
+      site: '',
+      branch: 'feature-x',
+      text: 'GET /checkout'
+    });
   });
 
-  it('keeps the branch but drops the site when the site prefix is hidden', () => {
-    expect(sitePrefix(ev({ branch: 'feature-x' }), true)).toBe('[feature-x] ');
-    expect(sitePrefix(ev({ branch: '' }), true)).toBe('');
+  it('names the worker command when the event came from a worker process', () => {
+    expect(groupLabel(ev({ worker: 'queue:work' }), false).text).toBe('queue:work');
+  });
+
+  it('falls back to the pid for cli invocations', () => {
+    expect(groupLabel(ev({ type: 'cli', request: '' }), false).text).toBe('cli (pid 7)');
+  });
+
+  it('flattens back to the bracketed single-string form', () => {
+    expect(labelString(groupLabel(ev({ branch: 'feature-x' }), false))).toBe('[acme@feature-x] GET /checkout');
+    expect(labelString(groupLabel(ev({ branch: '' }), false))).toBe('[acme] GET /checkout');
+    expect(labelString(groupLabel(ev({ branch: 'feature-x' }), true))).toBe('[feature-x] GET /checkout');
+    expect(labelString(groupLabel(ev({ branch: '', site: '' }), false))).toBe('GET /checkout');
   });
 });

--- a/internal/ui/web/src/lib/eventGroup.ts
+++ b/internal/ui/web/src/lib/eventGroup.ts
@@ -27,17 +27,37 @@ export function groupKey(ev: DumpEvent): string {
   return `cli:${site}:${branch}:${ev.ctx.pid ?? ''}:${bucket}`;
 }
 
-// sitePrefix renders the bracketed chunk that leads a group label. With both
-// site and branch it reads `[site@branch] `; plain site is `[site] `.
-// hideSitePrefix drops the site name (the surrounding UI already establishes
-// it) but keeps the branch as `[branch] `, since within one site the branch is
-// the only thing telling worktree events apart from the parent.
-export function sitePrefix(ev: DumpEvent, hideSitePrefix: boolean): string {
-  const branch = ev.ctx.branch ?? '';
-  if (hideSitePrefix) {
-    return branch ? `[${branch}] ` : '';
-  }
-  const site = ev.ctx.site ?? '';
-  if (!site) return '';
-  return branch ? `[${site}@${branch}] ` : `[${site}] `;
+// GroupLabel is a group header split into its parts rather than one string,
+// so the renderer can turn the site name into a link to that site's Debug tab
+// while the rest stays plain text. site is empty when the surrounding UI
+// already establishes it, or when the event carried no site at all.
+export interface GroupLabel {
+  site: string;
+  branch: string;
+  text: string;
+}
+
+// groupLabel describes the header of one request group. The bracketed chunk
+// reads `[site@branch]`, or `[site]`, or `[branch]` alone when hideSitePrefix
+// drops the site (within one site the branch is the only thing telling
+// worktree events apart from the parent).
+export function groupLabel(ev: DumpEvent, hideSitePrefix: boolean): GroupLabel {
+  return {
+    site: hideSitePrefix ? '' : (ev.ctx.site ?? ''),
+    branch: ev.ctx.branch ?? '',
+    text: labelText(ev)
+  };
+}
+
+function labelText(ev: DumpEvent): string {
+  if (ev.ctx.worker) return ev.ctx.worker;
+  if (ev.ctx.type === 'fpm') return ev.ctx.request || '(request)';
+  return `cli (pid ${ev.ctx.pid ?? '?'})`;
+}
+
+// labelString flattens a GroupLabel back to the single-string form, for
+// callers that need one string rather than the rendered parts.
+export function labelString(l: GroupLabel): string {
+  const inner = l.site ? (l.branch ? `${l.site}@${l.branch}` : l.site) : l.branch;
+  return inner ? `[${inner}] ${l.text}` : l.text;
 }

--- a/internal/ui/web/src/stores/debugEvents.ts
+++ b/internal/ui/web/src/stores/debugEvents.ts
@@ -1,6 +1,6 @@
 import { derived, type Readable } from 'svelte/store';
 import type { DumpEvent } from '$lib/dumpsStream';
-import { groupKey, sitePrefix } from '$lib/eventGroup';
+import { groupKey, groupLabel, type GroupLabel } from '$lib/eventGroup';
 import { dumps } from '$stores/dumps';
 
 // Generic per-request grouping shared by the non-dump/non-query Debug lenses
@@ -8,17 +8,10 @@ import { dumps } from '$stores/dumps';
 // per-request id, then method+path+pid, then a 5s CLI bucket.
 export interface DebugGroup {
   key: string;
-  label: string;
+  label: GroupLabel;
   ts: string;
   events: DumpEvent[];
   worker: string;
-}
-
-function groupLabel(ev: DumpEvent, hideSitePrefix: boolean): string {
-  const prefix = sitePrefix(ev, hideSitePrefix);
-  if (ev.ctx.worker) return prefix + ev.ctx.worker;
-  if (ev.ctx.type === 'fpm') return prefix + (ev.ctx.request || '(request)');
-  return `${prefix}cli (pid ${ev.ctx.pid ?? '?'})`;
 }
 
 // buildKindGroups filters the shared event stream to one kind and groups it by

--- a/internal/ui/web/src/stores/dumps.test.ts
+++ b/internal/ui/web/src/stores/dumps.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
 import { dumpGroups, dumps, filterSite, filterCtx, filterText, buildDumpGroups, status } from './dumps';
+import { labelString } from '$lib/eventGroup';
 import { wsMessage } from '$lib/ws';
 import type { DumpEvent } from '$lib/dumpsStream';
 
@@ -35,7 +36,7 @@ describe('dumpGroups', () => {
       ev({ id: 'c', ts: '2026-05-10T12:00:10.000Z', ctx: { type: 'fpm', site: 's', request: 'GET /a' } })
     ]);
     const groups = get(dumpGroups);
-    expect(groups.map((g) => g.label)).toEqual(['[s] GET /a', '[s] GET /b']);
+    expect(groups.map((g) => labelString(g.label))).toEqual(['[s] GET /a', '[s] GET /b']);
   });
 
   it('excludes non-dump kinds (queries share the same ring)', () => {
@@ -96,7 +97,7 @@ describe('dumpGroups', () => {
     ]);
     const groups = get(dumpGroups);
     expect(groups.length).toBe(2);
-    const labels = groups.map((g) => g.label);
+    const labels = groups.map((g) => labelString(g.label));
     expect(labels).toContain('[acme] GET /checkout');
     expect(labels).toContain('[acme@feature-x] GET /checkout');
   });
@@ -122,8 +123,8 @@ describe('dumpGroups', () => {
       '',
       true
     );
-    expect(groups[0].label).toBe('GET /x');
-    expect(groups[0].label).not.toContain('whitewaters');
+    expect(groups[0].label.site).toBe('');
+    expect(labelString(groups[0].label)).toBe('GET /x');
   });
 
   it('keeps [site] prefix when hideSitePrefix is false', () => {
@@ -134,7 +135,7 @@ describe('dumpGroups', () => {
       '',
       false
     );
-    expect(groups[0].label).toContain('[whitewaters]');
+    expect(groups[0].label.site).toBe('whitewaters');
   });
 
   it('applies free-text search across label, text, file', () => {

--- a/internal/ui/web/src/stores/dumps.ts
+++ b/internal/ui/web/src/stores/dumps.ts
@@ -1,7 +1,7 @@
 import { derived, writable, get, type Readable } from 'svelte/store';
 import { apiFetch, apiJson } from '$lib/api';
 import { createDumpsStream, type DumpEvent } from '$lib/dumpsStream';
-import { groupKey, sitePrefix } from '$lib/eventGroup';
+import { groupKey, groupLabel, type GroupLabel } from '$lib/eventGroup';
 import { wsMessage } from '$lib/ws';
 
 export interface DumpsStatus {
@@ -28,7 +28,7 @@ export const filterText = writable<string>('');
 // Web tab can render one card per group.
 export interface DumpGroup {
   key: string;
-  label: string;
+  label: GroupLabel;
   events: DumpEvent[];
   ts: string;
 }
@@ -94,14 +94,6 @@ export const dumpGroups: Readable<DumpGroup[]> = derived(
   [dumps, filterSite, filterCtx, filterText],
   ([$dumps, $site, $ctx, $text]) => buildDumpGroups($dumps, $site, $ctx, $text)
 );
-
-function groupLabel(ev: DumpEvent, hideSitePrefix = false): string {
-  const prefix = sitePrefix(ev, hideSitePrefix);
-  if (ev.ctx.type === 'fpm') {
-    return prefix + (ev.ctx.request || '(request)');
-  }
-  return `${prefix}cli (pid ${ev.ctx.pid ?? '?'})`;
-}
 
 // lastFlashId tracks the most recent event arriving over the live socket
 // (post-initial-replay) so DumpEntry can paint a one-shot highlight ring

--- a/internal/ui/web/src/stores/queries.test.ts
+++ b/internal/ui/web/src/stores/queries.test.ts
@@ -101,7 +101,7 @@ describe('buildQueryGroups', () => {
     const all = buildQueryGroups(events);
     const wq = all.find((g) => g.rows[0].event.id === 'w1');
     expect(wq?.worker).toBe('queue:work');
-    expect(wq?.label).toContain('queue:work');
+    expect(wq?.label.text).toBe('queue:work');
 
     // Filter to one worker command.
     const onlyScrape = buildQueryGroups(events, '', '', false, 'scrape:rtb-data');

--- a/internal/ui/web/src/stores/queries.ts
+++ b/internal/ui/web/src/stores/queries.ts
@@ -1,7 +1,7 @@
 import { derived, writable, type Readable } from 'svelte/store';
 import { apiFetch, apiJson } from '$lib/api';
 import type { DumpEvent, QueryData } from '$lib/dumpsStream';
-import { groupKey, sitePrefix } from '$lib/eventGroup';
+import { groupKey, groupLabel, type GroupLabel } from '$lib/eventGroup';
 import { dumps, toggleDumps, status as dumpsStatus, type DumpsStatus } from '$stores/dumps';
 import { wsMessage } from '$lib/ws';
 
@@ -37,7 +37,7 @@ export interface QueryRow {
 
 export interface QueryGroup {
   key: string;
-  label: string;
+  label: GroupLabel;
   ts: string;
   rows: QueryRow[];
   count: number;
@@ -61,15 +61,6 @@ export function normalizeSql(sql: string): string {
     .replace(/\s+/g, ' ')
     .trim()
     .toLowerCase();
-}
-
-function groupLabel(ev: DumpEvent, hideSitePrefix: boolean): string {
-  const prefix = sitePrefix(ev, hideSitePrefix);
-  if (ev.ctx.worker) return prefix + ev.ctx.worker;
-  if (ev.ctx.type === 'fpm') {
-    return prefix + (ev.ctx.request || '(request)');
-  }
-  return `${prefix}cli (pid ${ev.ctx.pid ?? '?'})`;
 }
 
 function queryData(ev: DumpEvent): QueryData | null {

--- a/internal/ui/web/src/stores/sites.test.ts
+++ b/internal/ui/web/src/stores/sites.test.ts
@@ -45,6 +45,17 @@ describe('sites store', () => {
     expect(activeWorktreeDomain(s, 'mystery')).toBe('acme.test');
   });
 
+  it('siteDomainForName maps a site name back to its domain', async () => {
+    const { siteDomainForName } = await import('./sites');
+    const list = [
+      { domain: 'acme.test', name: 'acme' },
+      { domain: 'admin-astrolov.test', name: 'admin-astrolov' }
+    ];
+    expect(siteDomainForName(list, 'admin-astrolov')).toBe('admin-astrolov.test');
+    expect(siteDomainForName(list, 'mystery')).toBe('');
+    expect(siteDomainForName(list, '')).toBe('');
+  });
+
   it('saveSiteEnv PUTs JSON body to the site env endpoint', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ ok: true, backup_path: '.env.20260528-103045' }), {

--- a/internal/ui/web/src/stores/sites.ts
+++ b/internal/ui/web/src/stores/sites.ts
@@ -155,6 +155,15 @@ export function findSite(domain: string): Site | undefined {
   return get(sites).find((s) => s.domain === domain);
 }
 
+// siteDomainForName resolves a registered site name to the domain the hash
+// router keys sites by, mirroring siteDomainForRoute on the backend. Returns
+// '' when nothing matches, so callers can fall back to plain text instead of
+// linking to a route that doesn't exist.
+export function siteDomainForName(list: Site[], name: string): string {
+  if (!name) return '';
+  return list.find((s) => s.name === name)?.domain ?? '';
+}
+
 export function isGroupSecondary(s: Site): boolean {
   return Boolean(s.group) && Boolean(s.group_subdomain);
 }

--- a/internal/ui/web/src/tabs/DumpsTab.svelte
+++ b/internal/ui/web/src/tabs/DumpsTab.svelte
@@ -20,6 +20,7 @@
   import EmptyState from '$components/EmptyState.svelte';
   import Dropdown from '$components/Dropdown.svelte';
   import LensLoadMore from '$components/LensLoadMore.svelte';
+  import LensGroupLabel from '$components/LensGroupLabel.svelte';
   import { windowGroups, LENS_PAGE } from '$lib/lensWindow';
   import { m } from '../paraglide/messages.js';
 
@@ -175,7 +176,7 @@
       {#each win.pages as page (page.group.key)}
         <section class="mb-4">
           <header class="flex items-center gap-2 mb-1 sticky top-0 bg-gray-50 dark:bg-lerd-bg py-1 -mx-3 px-3 z-1">
-            <span class="text-sm">{page.group.label}</span>
+            <LensGroupLabel label={page.group.label} />
             <span class="text-xs text-gray-400 ml-auto">{m.dumps_groupCount({ count: page.total })}</span>
           </header>
           {#each page.rows as ev (ev.id)}


### PR DESCRIPTION
Each group header in the system Debug window leads with the site the request came from, and spotting something interesting there meant going back to the Sites list and finding that site by hand. The bracketed name is now a link to that site's own Debug tab.

The name was not a field at render time. The label was built as one string by three near-identical copies of the same function, one per lens, and rendered as a single span, so nothing downstream could tell the site from the request. The builder now lives once in eventGroup.ts and returns the site, the branch and the trailing text as parts, and one shared component renders them for the dumps, queries and kind lenses.

The label carries a site name while the hash router keys sites by domain, so this needed the lookup the other way round from the one the sites store offered, mirroring siteDomainForRoute on the backend. A name that matches no linked site, which includes the empty case the filter dropdown shows as "(unknown)", stays plain text rather than becoming a dead link. Inside a site's own Debug tab the lone branch tag stays unlinked, since you are already on that site.

Closes #1014