### PR TITLE
fix(podman): mount out-of-home site paths into the running containers

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -186,7 +186,14 @@ grep Volume ~/.config/containers/systemd/lerd-nginx.container
 grep Volume ~/.config/containers/systemd/lerd-php*-fpm.container
 ```
 
-You should see your project path listed alongside the `%h:%h` mount.
+You should see your project path listed alongside the `%h:%h` mount. The quadlet is only half the answer though, a container keeps the mounts it booted with, so check the running one too:
+
+```bash
+podman inspect lerd-php84-fpm --format '{{range .Mounts}}{{.Source}}
+{{end}}'
+```
+
+If the path is in the quadlet but not in that output, `lerd restart` picks it up.
 :::
 
 ::: details Permission denied on port 80/443

--- a/internal/podman/build.go
+++ b/internal/podman/build.go
@@ -951,7 +951,10 @@ func RewriteFPMQuadlets() error {
 		if writeErr != nil {
 			continue
 		}
-		if changed {
+		// An unchanged file is not proof the container has the mounts: an
+		// earlier writer in the same run may have written them without ever
+		// restarting the unit (#914).
+		if changed || UnitMissingMounts(unitName, extraPaths) {
 			changedUnits = append(changedUnits, unitName)
 		}
 	}
@@ -959,8 +962,10 @@ func RewriteFPMQuadlets() error {
 	// Also rewrite nginx quadlet with the same extra volumes.
 	if nginxContent, err := GetQuadletTemplate("lerd-nginx.container"); err == nil {
 		nginxContent = InjectExtraVolumes(nginxContent, extraPaths)
-		if changed, err := WriteQuadletDiff("lerd-nginx", nginxContent); err == nil && changed {
-			changedUnits = append(changedUnits, "lerd-nginx")
+		if changed, err := WriteQuadletDiff("lerd-nginx", nginxContent); err == nil {
+			if changed || UnitMissingMounts("lerd-nginx", extraPaths) {
+				changedUnits = append(changedUnits, "lerd-nginx")
+			}
 		}
 	}
 
@@ -1212,6 +1217,17 @@ func EnsurePathMounted(path, phpVersion string) {
 		quadlets = append(quadlets, quadletInfo{unitName, filepath.Join(config.QuadletDir(), unitName+".container")})
 	}
 	quadlets = append(quadlets, quadletInfo{"lerd-nginx", filepath.Join(config.QuadletDir(), "lerd-nginx.container")})
+	// Custom-FPM sites serve from their own container, so an out-of-home path
+	// has to reach that quadlet too, not just the shared per-version ones.
+	if reg, regErr := config.LoadSites(); regErr == nil {
+		for i := range reg.Sites {
+			if !reg.Sites[i].IsCustomFPM() {
+				continue
+			}
+			unitName := CustomFPMContainerName(reg.Sites[i].Name)
+			quadlets = append(quadlets, quadletInfo{unitName, filepath.Join(config.QuadletDir(), unitName+".container")})
+		}
+	}
 
 	var changedUnits []string
 	for _, q := range quadlets {
@@ -1222,6 +1238,12 @@ func EnsurePathMounted(path, phpVersion string) {
 
 		volumePrefix := fmt.Sprintf("Volume=%s:%s:", path, path)
 		if strings.Contains(string(existing), volumePrefix) {
+			// The quadlet is already right, but writing one never touches a
+			// running container: whoever wrote this line may have left the
+			// container running without the mount (#914).
+			if UnitMissingMounts(q.unitName, []string{path}) {
+				changedUnits = append(changedUnits, q.unitName)
+			}
 			continue
 		}
 

--- a/internal/podman/mountdrift.go
+++ b/internal/podman/mountdrift.go
@@ -1,0 +1,68 @@
+package podman
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// containerMounts returns whether the named container is running and the
+// host-side sources of the mounts it is running with. Writing a quadlet does
+// not touch a running container, so this is the only honest answer to "can it
+// reach this path".
+func containerMounts(name string) (bool, []string) {
+	out, err := Run("inspect", "--format={{.State.Running}}#{{range .Mounts}}{{.Source}}|{{end}}", name)
+	if err != nil {
+		return false, nil
+	}
+	state, mounts, _ := strings.Cut(strings.TrimSpace(out), "#")
+	if state != "true" {
+		return false, nil
+	}
+	var sources []string
+	for _, s := range strings.Split(mounts, "|") {
+		if s = strings.TrimSpace(s); s != "" {
+			sources = append(sources, s)
+		}
+	}
+	return true, sources
+}
+
+// UnitMissingMounts reports whether the container behind a unit is running
+// without a bind mount covering one of the given paths, i.e. its quadlet has
+// been updated underneath it and only a restart will make the paths reachable
+// (issue #914). A stopped or unknown container never counts: it picks the
+// quadlet up when it next starts.
+func UnitMissingMounts(unit string, paths []string) bool {
+	if len(paths) == 0 {
+		return false
+	}
+	running, sources := containerMounts(unit)
+	if !running {
+		return false
+	}
+	for _, p := range paths {
+		if !mountCovers(sources, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// mountCovers reports whether one of the mount sources is the path itself or
+// one of its ancestors. Podman may report a source in resolved form, so a
+// symlinked path is compared both ways rather than being reported missing
+// forever, which would restart the containers on every call.
+func mountCovers(sources []string, path string) bool {
+	candidates := []string{path}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil && resolved != path {
+		candidates = append(candidates, resolved)
+	}
+	for _, src := range sources {
+		for _, p := range candidates {
+			if p == src || strings.HasPrefix(p, strings.TrimSuffix(src, "/")+"/") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/podman/mountdrift_test.go
+++ b/internal/podman/mountdrift_test.go
@@ -1,0 +1,196 @@
+package podman
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// fakeInspect stubs `podman inspect` with one canned line, the format
+// containerMounts asks for.
+func fakeInspect(t *testing.T, line string) {
+	t.Helper()
+	prev := execCommand
+	t.Cleanup(func() { execCommand = prev })
+	execCommand = func(_ string, _ ...string) *exec.Cmd {
+		return exec.Command("printf", "%s", line)
+	}
+}
+
+type restartRecorder struct{ restarted []string }
+
+func (r *restartRecorder) Start(string) error { return nil }
+func (r *restartRecorder) Stop(string) error  { return nil }
+func (r *restartRecorder) Restart(name string) error {
+	r.restarted = append(r.restarted, name)
+	return nil
+}
+func (r *restartRecorder) UnitStatus(string) (string, error) { return "active", nil }
+func (r *restartRecorder) AllUnitStates() map[string]string  { return nil }
+
+func TestUnitMissingMounts(t *testing.T) {
+	fakeInspect(t, "true#/home/george|/srv/apps|")
+
+	if UnitMissingMounts("lerd-php84-fpm", []string{"/srv/apps/shop"}) {
+		t.Error("a path under an existing mount source is not missing")
+	}
+	if UnitMissingMounts("lerd-php84-fpm", []string{"/srv/apps"}) {
+		t.Error("the mount source itself is not missing")
+	}
+	if !UnitMissingMounts("lerd-php84-fpm", []string{"/data/Projects/app"}) {
+		t.Error("a path the running container has no mount for is missing")
+	}
+	if !UnitMissingMounts("lerd-php84-fpm", []string{"/srv/appsuite"}) {
+		t.Error("ancestor matching must respect the path separator")
+	}
+	if UnitMissingMounts("lerd-php84-fpm", nil) {
+		t.Error("no paths means nothing is missing")
+	}
+}
+
+// A stopped container picks the quadlet up when it next starts, so it never
+// counts as drifted and must not trigger a restart.
+func TestUnitMissingMountsIgnoresStoppedContainer(t *testing.T) {
+	fakeInspect(t, "false#")
+	if UnitMissingMounts("lerd-php84-fpm", []string{"/data/Projects/app"}) {
+		t.Error("a stopped container must not report drift")
+	}
+}
+
+func TestUnitMissingMountsIgnoresInspectFailure(t *testing.T) {
+	prev := execCommand
+	t.Cleanup(func() { execCommand = prev })
+	execCommand = func(string, ...string) *exec.Cmd { return exec.Command("false") }
+
+	if UnitMissingMounts("lerd-php84-fpm", []string{"/data/Projects/app"}) {
+		t.Error("an unknown container must not report drift")
+	}
+}
+
+// The regression from #914: the quadlet file already carries the Volume line
+// (FinishLink wrote it) but the container is still running without it, so
+// EnsurePathMounted has to restart even though it changes no file.
+func TestEnsurePathMountedRestartsDriftedContainer(t *testing.T) {
+	home := t.TempDir()
+	cfgHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	resetPathMountAttempts()
+
+	quadlets := filepath.Join(cfgHome, "containers", "systemd")
+	if err := os.MkdirAll(quadlets, 0755); err != nil {
+		t.Fatal(err)
+	}
+	fpm := filepath.Join(quadlets, "lerd-php84-fpm.container")
+	content := "[Container]\nVolume=%h:%h:rw\nVolume=/data/Projects/app:/data/Projects/app:rw\n"
+	if err := os.WriteFile(fpm, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(quadlets, "lerd-nginx.container"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeInspect(t, "true#/home/george|")
+	lc := &restartRecorder{}
+	prevLC := UnitLifecycle
+	UnitLifecycle = lc
+	t.Cleanup(func() { UnitLifecycle = prevLC })
+
+	EnsurePathMounted("/data/Projects/app", "8.4")
+
+	if len(lc.restarted) != 2 {
+		t.Fatalf("restarted %v, want both lerd-php84-fpm and lerd-nginx", lc.restarted)
+	}
+	if got, err := os.ReadFile(fpm); err != nil || string(got) != content {
+		t.Error("the quadlet file was already correct and must not be rewritten")
+	}
+}
+
+// FinishLink writes the FPM quadlet and only then calls RewriteFPMQuadlets, so
+// the rewrite finds the file already correct. It still has to restart, which is
+// the second half of #914: the second call here stands in for that rewrite.
+func TestRewriteFPMQuadletsRestartsDriftedContainer(t *testing.T) {
+	home := t.TempDir()
+	cfgHome := t.TempDir()
+	dataHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	t.Setenv("XDG_DATA_HOME", dataHome)
+
+	quadlets := filepath.Join(cfgHome, "containers", "systemd")
+	if err := os.MkdirAll(quadlets, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(quadlets, "lerd-php84-fpm.container"), []byte("[Container]\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveSites(&config.SiteRegistry{Sites: []config.Site{{
+		Name: "shop", Path: "/data/Projects/shop", PHPVersion: "8.4",
+	}}}); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeInspect(t, "true#/home/george|")
+	lc := &restartRecorder{}
+	prevLC := UnitLifecycle
+	UnitLifecycle = lc
+	t.Cleanup(func() { UnitLifecycle = prevLC })
+
+	if err := RewriteFPMQuadlets(); err != nil { // writes the quadlet
+		t.Fatal(err)
+	}
+	lc.restarted = nil
+	if err := RewriteFPMQuadlets(); err != nil { // file already correct, container is not
+		t.Fatal(err)
+	}
+	if len(lc.restarted) == 0 {
+		t.Error("a container running without the site mount must be restarted even when the quadlet is unchanged")
+	}
+}
+
+// A custom-FPM site runs its own container, which EnsurePathMounted used to
+// skip entirely, so an out-of-home path never reached it.
+func TestEnsurePathMountedCoversCustomFPMSites(t *testing.T) {
+	home := t.TempDir()
+	cfgHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+	resetPathMountAttempts()
+
+	quadlets := filepath.Join(cfgHome, "containers", "systemd")
+	if err := os.MkdirAll(quadlets, 0755); err != nil {
+		t.Fatal(err)
+	}
+	custom := filepath.Join(quadlets, "lerd-cfpm-shop.container")
+	if err := os.WriteFile(custom, []byte("[Container]\nVolume=%h:%h:rw\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveSites(&config.SiteRegistry{Sites: []config.Site{{
+		Name: "shop", Path: "/data/Projects/shop", PHPVersion: "8.4", Runtime: "fpm-custom",
+	}}}); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeInspect(t, "true#/home/george|")
+	lc := &restartRecorder{}
+	prevLC := UnitLifecycle
+	UnitLifecycle = lc
+	t.Cleanup(func() { UnitLifecycle = prevLC })
+
+	EnsurePathMounted("/data/Projects/shop", "8.4")
+
+	got, err := os.ReadFile(custom)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "Volume=/data/Projects/shop:/data/Projects/shop:rw"; !strings.Contains(string(got), want) {
+		t.Errorf("custom FPM quadlet missing %q:\n%s", want, got)
+	}
+	if len(lc.restarted) != 1 || lc.restarted[0] != "lerd-cfpm-shop" {
+		t.Errorf("restarted %v, want lerd-cfpm-shop", lc.restarted)
+	}
+}


### PR DESCRIPTION
Linking a project that lives outside the home directory wrote the bind mount into the PHP-FPM and nginx quadlets and then left the containers running with the mount set they booted with. The path did not exist inside them, so the first thing to exec, usually `composer install` during setup, died with `crun: chdir to ...: No such file or directory`.

Three layers each assumed another one had done the work. FinishLink writes the quadlet and only daemon-reloads, then calls the rewrite that does restart, but that one decides by diffing its own render against the file it was just handed, sees no change, and restarts nothing. EnsurePathMounted then finds the Volume line already sitting in the file and skips the restart for the same reason. The quadlets were right the whole time, which is exactly why this looked fine when you checked.

Both paths now ask the running container what it is actually mounted before deciding, so a correct file no longer counts as proof. A stopped container is never treated as drifted, it picks the quadlet up when it next starts, and a symlinked path is compared in resolved form as well so podman reporting a resolved source cannot turn into a restart on every call. EnsurePathMounted also looks at per-site custom-FPM quadlets now, which it never did, leaving those sites with no mount at all outside home.

Projects under the home directory are untouched throughout, the blanket `%h:%h` mount already covers them.

Closes #1053
Refs #914