### PR TITLE
fix: make the shared ssh-agent restart-safe

### DIFF
--- a/internal/podman/sshagent.go
+++ b/internal/podman/sshagent.go
@@ -45,7 +45,10 @@ func GenerateSSHAgentQuadlet(image string) string {
 	fmt.Fprintln(&b, "Volume=%h/.ssh:%h/.ssh:ro")
 	fmt.Fprintf(&b, "Environment=SSH_AUTH_SOCK=%s\n", SSHAgentSocket)
 	fmt.Fprintln(&b, "PodmanArgs=--security-opt=label=disable")
-	fmt.Fprintf(&b, "Exec=ssh-agent -D -a %s\n", SSHAgentSocket)
+	// ssh-agent refuses to bind an existing socket path, and it only unlinks the
+	// socket on SIGINT/SIGTERM/SIGHUP, not on the php image's SIGQUIT stop signal.
+	// Clearing the stale socket first keeps restarts from crash-looping.
+	fmt.Fprintf(&b, "Exec=sh -c \"rm -f %s && exec ssh-agent -D -a %s\"\n", SSHAgentSocket, SSHAgentSocket)
 	fmt.Fprintln(&b)
 	fmt.Fprintln(&b, "[Service]")
 	fmt.Fprintln(&b, "Restart=always")

--- a/internal/podman/sshagent_test.go
+++ b/internal/podman/sshagent_test.go
@@ -26,7 +26,7 @@ func TestGenerateSSHAgentQuadlet(t *testing.T) {
 		"ContainerName=" + SSHAgentContainer,
 		"Volume=" + SSHAgentVolume + ":" + SSHAgentMountDir,
 		"Volume=%h/.ssh:%h/.ssh:ro",
-		"Exec=ssh-agent -D -a " + SSHAgentSocket,
+		`Exec=sh -c "rm -f ` + SSHAgentSocket + ` && exec ssh-agent -D -a ` + SSHAgentSocket + `"`,
 		"Restart=always",
 	} {
 		if !strings.Contains(content, want) {

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -79,7 +79,7 @@ func plistArgs(path string) ([]string, error) {
 		if open < 0 || close < 0 {
 			break
 		}
-		args = append(args, block[open+len("<string>"):close])
+		args = append(args, xmlUnescStr(block[open+len("<string>"):close]))
 		block = block[close+len("</string>"):]
 	}
 	return args, nil
@@ -130,6 +130,15 @@ func xmlEscStr(s string) string {
 		}
 	}
 	return buf.String()
+}
+
+// xmlUnescStr reverses xmlEscStr, so args read back out of a plist reach podman
+// as they were written. &amp; is decoded last, otherwise an escaped "&amp;lt;"
+// would collapse into a literal "<".
+func xmlUnescStr(s string) string {
+	s = strings.ReplaceAll(s, "&lt;", "<")
+	s = strings.ReplaceAll(s, "&gt;", ">")
+	return strings.ReplaceAll(s, "&amp;", "&")
 }
 
 // keepAlivePolicy mirrors the subset of systemd Restart= values we care

--- a/internal/services/launchd_test.go
+++ b/internal/services/launchd_test.go
@@ -258,6 +258,31 @@ func TestSSHAgentQuadletExecSurvivesTranslation(t *testing.T) {
 	}
 }
 
+// Container units are started by reading the argv back out of the plist, so an
+// arg holding XML-special characters (any `sh -c` script with && or a
+// redirection) has to survive the escape/unescape round trip verbatim.
+func TestPlistArgsRoundTripsXMLSpecials(t *testing.T) {
+	script := "rm -f /ssh-agent/agent.sock && exec ssh-agent -D -a /ssh-agent/agent.sock 2>/dev/null"
+	want := []string{"podman", "run", "sh", "-c", script}
+	dir := t.TempDir()
+	p := filepath.Join(dir, "unit.plist")
+	if err := os.WriteFile(p, []byte(buildPlist("com.lerd.unit", want, false, keepAliveAlways, "", "")), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := plistArgs(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("plistArgs = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("arg[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestParseSectionMultipleValues(t *testing.T) {
 	content := `[Container]
 Volume=/home:/home:z

--- a/internal/services/launchd_test.go
+++ b/internal/services/launchd_test.go
@@ -241,6 +241,23 @@ Exec=sh -c "install-php-extensions pcntl >/dev/null && exec php artisan octane:s
 	}
 }
 
+// The ssh-agent quadlet clears its stale socket via `sh -c` before exec'ing the
+// agent; that script must reach podman as one argv element on macOS too.
+func TestSSHAgentQuadletExecSurvivesTranslation(t *testing.T) {
+	args, err := containerToPodmanArgs(parseSection(podman.GenerateSSHAgentQuadlet("lerd-php85-fpm:local"), "Container"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotTail := args[len(args)-3:]
+	wantTail := []string{"sh", "-c",
+		"rm -f " + podman.SSHAgentSocket + " && exec ssh-agent -D -a " + podman.SSHAgentSocket}
+	for i := range wantTail {
+		if gotTail[i] != wantTail[i] {
+			t.Fatalf("tail arg[%d] = %q, want %q (full: %v)", i, gotTail[i], wantTail[i], args)
+		}
+	}
+}
+
 func TestParseSectionMultipleValues(t *testing.T) {
 	content := `[Container]
 Volume=/home:/home:z


### PR DESCRIPTION
The shared ssh-agent sidecar binds its socket on the persistent `lerd-ssh-agent` volume. `ssh-agent` refuses to bind a path that already exists, and it only unlinks the socket in its `SIGINT`/`SIGTERM`/`SIGHUP` handler, never on the php image's `SIGQUIT` stop signal. The socket therefore survives every stop, every later start fails instantly, and `Restart=always` respawns it into a crash loop. Because `lerd auth ssh` recreates the container, the command that needs the agent is the same one that re-orphans the socket, so it ends up racing a sub-100ms alive window and failing with "cannot exec in a container that is not running". This wraps the agent command in `sh -c` so the stale socket is removed before exec, which makes the container restart-safe regardless of how it was stopped, including `SIGKILL` and host crashes. The socket stays on the named volume rather than moving to tmpfs because the FPM containers mount it to reach the agent.

Smoke-testing that on macOS surfaced a second bug underneath it, fixed in the follow-up commit. Container units are not started by launchctl: lerd reads the argv back out of the plist and runs podman itself so it can gate concurrent starts on a semaphore. The write path escapes `&`, `<` and `>` for XML, but the read path pulled each `<string>` out verbatim, so any argument carrying one of those characters reached podman still escaped. The new `sh -c` script arrived as `rm -f sock &amp;&amp; exec ssh-agent` and the shell died with "syntax error: unexpected &". The same corruption applies to the FrankenPHP worker Exec, which both redirects with `>` and chains with `&&`. Parsing now reverses the escaping, decoding `&amp;` last so an escaped `&amp;lt;` does not collapse into a literal `<`.

Refs #1062
