### PR TITLE
fix(workers): loosen the reload watcher poll interval and follow the power state

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -528,6 +528,13 @@ func newWatchCmd() *cobra.Command {
 			// migration or sleep/wake bridge churn. No-op on Linux.
 			go watcher.WatchExecWorkers(60 * time.Second)
 
+			// Re-apply the reload watcher's poll cadence when the machine is
+			// plugged in or unplugged. The interval is baked into a worker's
+			// unit and read once at watcher startup, so an unplugged laptop
+			// would otherwise keep polling at the mains rate. No-op where the
+			// reload watcher doesn't have to poll.
+			go watcher.WatchPower(30 * time.Second)
+
 			// Reclaim orphaned lerd images (safe tier) on a slow daily cadence,
 			// so rebuild leftovers and stale base images don't pile up. Gated by
 			// the auto_cleanup config; never touches service images (--deep).

--- a/docs/usage/queue-workers.md
+++ b/docs/usage/queue-workers.md
@@ -52,10 +52,11 @@ lerd horizon:reload       # show the current state
 
 Auto-reload is off by default. The preference is per project, stored as `reload_workers` in the project's `.lerd.yaml` (a list of worker names opted into reload mode, currently just `horizon`), so one project can develop with auto-reload while another stays in standard mode. In the dashboard the Horizon toggle and the reload toggle sit together as one grouped control, and the reload toggle only appears while Horizon is running, since reload is a property of a live worker. Either way, the running Horizon worker for the project is restarted so the change applies immediately, and the new state is pushed to every open dashboard over the websocket.
 
-Two notes:
+Three notes:
 
 - The watcher shells out to Node and resolves [`chokidar`](https://www.npmjs.com/package/chokidar) from your project's `node_modules`. Horizon ships the watcher script but not chokidar itself, so the project has to provide it. It used to arrive for free as a transitive dependency of Vite, but Vite 8 dropped it, so a plain `npm install` is no longer enough. If chokidar is missing, the toggle never silently reads as on: from the dashboard, enabling pops a modal that offers a one-click `npm install --save-dev chokidar` and then turns reload on once the watcher is present; from the CLI, `lerd horizon:reload on` refuses with the same `npm install -D chokidar` hint.
 - lerd adds `--poll` where the container can't see host filesystem events: on macOS, where workers run in the podman virtual machine, and under WSL2, where projects on `/mnt` (9p) mounts get no inotify delivery. On native Linux the container shares the host filesystem directly and inotify works, so polling is left off to avoid the wasted CPU.
+- Where the watcher does poll, lerd re-stats watched files once a second rather than at chokidar's default of ten times a second, which is the difference between a busy virtiofs mount and an idle one. On a laptop the interval also follows how the machine is powered: running from the battery doubles it, and asking for less background work outright (macOS Low Power Mode, the power-saver profile on Linux, read from UPower and power-profiles-daemon) doubles it again. Unplugging mid-session restarts the affected reload workers so the new cadence applies straight away, at most once every five minutes.
 
 ## Generic workers (`lerd worker`)
 

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -1060,7 +1060,7 @@ func restoreSiteInfrastructure() {
 				if worktreeWorkerIdleSuspended(&s, wt.Path, w) {
 					continue
 				}
-				if services.Mgr.IsEnabled(workerUnitName(s.Name, wt.Path, w)) {
+				if services.Mgr.IsEnabled(WorkerUnitName(s.Name, wt.Path, w)) {
 					continue
 				}
 				wtPHP := config.WorktreePHPVersion(wt.Path, phpVersion)

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -264,6 +264,30 @@ func watcherNeedsPolling(sitePath string) bool {
 	return config.WatcherNeedsPolling(sitePath)
 }
 
+// workerExecEnvArgs returns the `--env=` flags a worker's `podman exec` needs.
+// Currently that is the reload watcher's poll interval, which only applies where
+// the watcher has to poll; everywhere else this is empty and the command is
+// unchanged. Setting it unconditionally on the polling hosts is harmless for
+// workers that run no watcher, since nothing else reads the variable.
+func workerExecEnvArgs(sitePath string) []string {
+	env := config.WatcherPollEnv(sitePath)
+	if env == "" {
+		return nil
+	}
+	return []string{"--env=" + env}
+}
+
+// workerExecEnvFlags is workerExecEnvArgs rendered for the unit templates, with
+// a leading space so it can be interpolated straight into the command. Mirrors
+// workerColorArgs, which splices the same way for the colour flags.
+func workerExecEnvFlags(sitePath string) string {
+	args := workerExecEnvArgs(sitePath)
+	if len(args) == 0 {
+		return ""
+	}
+	return " " + strings.Join(args, " ")
+}
+
 // projectHasChokidar reports whether the chokidar package, required by the
 // reload command's file watcher, is installed in the project. Delegates to
 // config.ProjectHasChokidar.

--- a/internal/cli/worker.go
+++ b/internal/cli/worker.go
@@ -575,7 +575,7 @@ func newWorkerRemoveCmd() *cobra.Command {
 				}
 			}
 			for _, p := range paths {
-				unit := workerUnitName(site.Name, p, name)
+				unit := WorkerUnitName(site.Name, p, name)
 				if isServiceActiveOrRestarting(unit) {
 					_ = WorkerStopForSite(site.Name, p, name)
 				}
@@ -645,9 +645,10 @@ func workerNames(siteName, sitePath, workerName string) (unit, display string) {
 	return unit + "-" + config.WorktreeUnitSlug(wtBase), display + "/" + wtBase
 }
 
-// workerUnitName is a thin wrapper around workerNames for callers that only
-// need the unit name (legacy callers, mostly).
-func workerUnitName(siteName, sitePath, workerName string) string {
+// WorkerUnitName is a thin wrapper around workerNames for callers that only
+// need the unit name, including callers outside this package, so the naming
+// rule (and its worktree suffix) is never re-spelled by hand.
+func WorkerUnitName(siteName, sitePath, workerName string) string {
 	unit, _ := workerNames(siteName, sitePath, workerName)
 	return unit
 }

--- a/internal/cli/worker_darwin.go
+++ b/internal/cli/worker_darwin.go
@@ -150,7 +150,7 @@ func writeWorkerExecUnit(unitName, siteName, sitePath, phpVersion, command, rest
 	_ = fpmUnit
 	container := resolveWorkerFPMUnit(siteName, phpVersion)
 
-	podmanExec := buildWorkerExecCommand(podman.PodmanBin(), podman.ShellQuote(sitePath), container, command)
+	podmanExec := buildWorkerExecCommand(podman.PodmanBin(), podman.ShellQuote(sitePath), container, command, workerExecEnvArgs(sitePath))
 	script := buildDarwinExecWorkerGuardScript(pidFile, podman.PodmanBin(), container, sitePath, command, podmanExec)
 	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
 		return false, fmt.Errorf("writing worker guard script: %w", err)

--- a/internal/cli/worker_darwin_builder.go
+++ b/internal/cli/worker_darwin_builder.go
@@ -46,9 +46,11 @@ func buildDarwinExecWorkerGuardScript(pidFile, podmanBin, container, sitePath, w
 
 // buildWorkerExecCommand renders the `podman exec` invocation an exec-mode
 // worker runs. The colour vars are passed through so the worker's output keeps
-// its ANSI escapes on the way to the launchd log file.
-func buildWorkerExecCommand(podmanBin, sitePath, container, command string) string {
+// its ANSI escapes on the way to the launchd log file, and envArgs carries any
+// `--env=` the worker itself needs (the reload watcher's poll interval).
+func buildWorkerExecCommand(podmanBin, sitePath, container, command string, envArgs []string) string {
 	parts := []string{podmanBin, "exec", "-w", sitePath}
+	parts = append(parts, envArgs...)
 	parts = append(parts, logcolor.PodmanExecArgs()...)
 	parts = append(parts, container, command)
 	return strings.Join(parts, " ")

--- a/internal/cli/worker_darwin_builder_test.go
+++ b/internal/cli/worker_darwin_builder_test.go
@@ -209,9 +209,26 @@ func TestWorkerBuilders_ForceColour(t *testing.T) {
 		t.Errorf("host worker guard should export the colour vars:\n%s", guard)
 	}
 
-	exec := buildWorkerExecCommand("/usr/bin/podman", "/site", "lerd-php84-fpm", "php artisan queue:work")
+	exec := buildWorkerExecCommand("/usr/bin/podman", "/site", "lerd-php84-fpm", "php artisan queue:work", nil)
 	if !strings.Contains(exec, "--env=FORCE_COLOR=1") {
 		t.Errorf("exec worker command should pass the colour vars:\n%s", exec)
+	}
+	if !strings.HasSuffix(exec, "lerd-php84-fpm php artisan queue:work") {
+		t.Errorf("exec worker command should end with container and command:\n%s", exec)
+	}
+}
+
+// The worker's own env has to land before the container name, or podman reads
+// it as part of the command instead of as a flag.
+func TestBuildWorkerExecCommand_EnvArgsPrecedeContainer(t *testing.T) {
+	exec := buildWorkerExecCommand("/usr/bin/podman", "/site", "lerd-php84-fpm", "php artisan queue:work",
+		[]string{"--env=CHOKIDAR_INTERVAL=2000"})
+
+	if !strings.Contains(exec, "--env=CHOKIDAR_INTERVAL=2000") {
+		t.Fatalf("exec worker command should carry the env args:\n%s", exec)
+	}
+	if strings.Index(exec, "--env=CHOKIDAR_INTERVAL=2000") > strings.Index(exec, "lerd-php84-fpm") {
+		t.Errorf("env args must come before the container name:\n%s", exec)
 	}
 	if !strings.HasSuffix(exec, "lerd-php84-fpm php artisan queue:work") {
 		t.Errorf("exec worker command should end with container and command:\n%s", exec)

--- a/internal/cli/worker_exec_env_test.go
+++ b/internal/cli/worker_exec_env_test.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// The flag has to be interpolatable straight into the exec command, so it
+// carries its own leading space and stays empty when nothing needs setting.
+func TestWorkerExecEnvFlags(t *testing.T) {
+	dir := t.TempDir()
+	got := workerExecEnvFlags(dir)
+
+	if !config.WatcherNeedsPolling(dir) {
+		if got != "" {
+			t.Fatalf("host does not poll, want no env flags, got %q", got)
+		}
+		return
+	}
+
+	if !strings.HasPrefix(got, " --env=CHOKIDAR_INTERVAL=") {
+		t.Fatalf("polling host must pass the interval to the container, got %q", got)
+	}
+	if strings.Contains(strings.TrimPrefix(got, " "), " ") {
+		t.Errorf("flag must be a single argument, got %q", got)
+	}
+}

--- a/internal/cli/worker_linux.go
+++ b/internal/cli/worker_linux.go
@@ -88,11 +88,11 @@ Type=simple
 Restart=%s
 RestartSec=5
 SuccessExitStatus=1 130 143
-ExecStart=%s exec -w %s --env=LERD_SITE=%s %s%s %s
+ExecStart=%s exec -w %s --env=LERD_SITE=%s%s %s%s %s
 
 [Install]
 WantedBy=default.target
-`, label, siteName, fpmUnit, fpmUnit, restart, podman.PodmanBin(), podman.ShellQuote(sitePath), siteName, workerColorArgs(), container, command)
+`, label, siteName, fpmUnit, fpmUnit, restart, podman.PodmanBin(), podman.ShellQuote(sitePath), siteName, workerExecEnvFlags(sitePath), workerColorArgs(), container, command)
 
 	// A previous run may have written a sibling .timer for this unit
 	// (e.g. before the framework yaml dropped its `schedule:` field).

--- a/internal/cli/worker_stop_worktree_test.go
+++ b/internal/cli/worker_stop_worktree_test.go
@@ -79,7 +79,7 @@ func registerSite(t *testing.T, name, path string) {
 // worktree suffix when sitePath equals the registered site path.
 func TestWorkerUnitName_parentPath(t *testing.T) {
 	registerSite(t, "ws", "/p/ws")
-	got := workerUnitName("ws", "/p/ws", "vite")
+	got := WorkerUnitName("ws", "/p/ws", "vite")
 	if got != "lerd-vite-ws" {
 		t.Errorf("got %q, want %q", got, "lerd-vite-ws")
 	}
@@ -89,7 +89,7 @@ func TestWorkerUnitName_parentPath(t *testing.T) {
 // suffixed unit name format used by per-worktree worker units.
 func TestWorkerUnitName_worktreePath(t *testing.T) {
 	registerSite(t, "ws", "/p/ws")
-	got := workerUnitName("ws", "/p/ws/feat-x", "vite")
+	got := WorkerUnitName("ws", "/p/ws/feat-x", "vite")
 	if got != "lerd-vite-ws-feat-x" {
 		t.Errorf("got %q, want %q", got, "lerd-vite-ws-feat-x")
 	}
@@ -99,7 +99,7 @@ func TestWorkerUnitName_worktreePath(t *testing.T) {
 // know the path get the parent unit name, matching pre-refactor behaviour.
 func TestWorkerUnitName_emptyPath(t *testing.T) {
 	registerSite(t, "ws", "/p/ws")
-	got := workerUnitName("ws", "", "vite")
+	got := WorkerUnitName("ws", "", "vite")
 	if got != "lerd-vite-ws" {
 		t.Errorf("got %q, want %q", got, "lerd-vite-ws")
 	}

--- a/internal/config/frankenphp_reload.go
+++ b/internal/config/frankenphp_reload.go
@@ -24,6 +24,15 @@ func WatcherNeedsPolling(sitePath string) bool {
 	return wsl.IsWSL() && strings.HasPrefix(sitePath, "/mnt/")
 }
 
+// HostCanPollWatchers reports whether any site on this host could need a
+// polling watcher, which is the host half of WatcherNeedsPolling with the path
+// test dropped. Native Linux never polls whatever the site path, so background
+// work that exists only to maintain the poll cadence can stand down entirely
+// rather than waking to find nothing to do.
+func HostCanPollWatchers() bool {
+	return runtime.GOOS == "darwin" || wsl.IsWSL()
+}
+
 // watcherPollIntervalMS is how often a polling reload watcher re-stats each
 // watched file while the machine is plugged in. chokidar's own default is
 // 100ms, which is fine on a local disk and ruinous on a shared one: every

--- a/internal/config/frankenphp_reload.go
+++ b/internal/config/frankenphp_reload.go
@@ -4,8 +4,10 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
+	"github.com/geodro/lerd/internal/power"
 	"github.com/geodro/lerd/internal/wsl"
 )
 
@@ -20,6 +22,50 @@ func WatcherNeedsPolling(sitePath string) bool {
 		return true
 	}
 	return wsl.IsWSL() && strings.HasPrefix(sitePath, "/mnt/")
+}
+
+// watcherPollIntervalMS is how often a polling reload watcher re-stats each
+// watched file while the machine is plugged in. chokidar's own default is
+// 100ms, which is fine on a local disk and ruinous on a shared one: every
+// watched file becomes ten host round trips a second. On macOS that traffic
+// crosses virtiofs and is served by the VM process, which is where the cost
+// lands (measured at roughly 280 virtiofs requests per second for a single
+// site, holding the VM process near 30% CPU on an otherwise idle machine). A
+// second between passes keeps reload feeling immediate for a worker that takes
+// longer than that to restart anyway.
+const watcherPollIntervalMS = 1000
+
+// watcherPollIntervalFor scales the base interval by how much the host has
+// asked lerd to hold back. Waking the disk to stat a few hundred files is
+// exactly the kind of background work a laptop on battery can do without, and
+// Low Power Mode is an explicit request for less of it, so it backs off twice
+// as far again.
+func watcherPollIntervalFor(state power.State) int {
+	switch state {
+	case power.LowPower:
+		return watcherPollIntervalMS * 4
+	case power.Battery:
+		return watcherPollIntervalMS * 2
+	default:
+		return watcherPollIntervalMS
+	}
+}
+
+// WatcherPollEnv returns the KEY=VALUE environment assignment that loosens a
+// polling reload watcher, or an empty string when the watcher is not polling
+// and the default event-driven path applies. chokidar honours CHOKIDAR_INTERVAL
+// as a global override no matter how polling was switched on, so this tunes the
+// vendored Octane and Horizon watcher scripts without patching them.
+//
+// The value is resolved when the worker's unit is written, so a machine that
+// changes power state picks up the new cadence on the next worker start rather
+// than immediately: the interval is baked into the running watcher's
+// environment and chokidar reads it only once, at startup.
+func WatcherPollEnv(sitePath string) string {
+	if !WatcherNeedsPolling(sitePath) {
+		return ""
+	}
+	return "CHOKIDAR_INTERVAL=" + strconv.Itoa(watcherPollIntervalFor(power.Current()))
 }
 
 // ProjectHasChokidar reports whether the chokidar npm package, required by the

--- a/internal/config/frankenphp_reload_test.go
+++ b/internal/config/frankenphp_reload_test.go
@@ -177,6 +177,20 @@ func TestWatcherPollEnv_TracksPollingDecision(t *testing.T) {
 	}
 }
 
+// The host gate exists to let cadence upkeep stand down, so it may only be
+// false where no site path polls either. A host that says it never polls while
+// some path does would silently strand those watchers on a stale interval.
+func TestHostCanPollWatchers_NeverSuppressesAPollingPath(t *testing.T) {
+	if HostCanPollWatchers() {
+		return
+	}
+	for _, path := range []string{"/mnt/c/Users/dev/app", "/home/dev/Code/app", t.TempDir()} {
+		if WatcherNeedsPolling(path) {
+			t.Errorf("host reports no polling, but %s polls", path)
+		}
+	}
+}
+
 // The ladder: a laptop on battery backs off, and Low Power Mode, an explicit
 // request for less background work, backs off twice as far again.
 func TestWatcherPollIntervalFor(t *testing.T) {

--- a/internal/config/frankenphp_reload_test.go
+++ b/internal/config/frankenphp_reload_test.go
@@ -3,8 +3,11 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/power"
 )
 
 // fwWithOctane builds a minimal Laravel-like framework with a FrankenPHP worker
@@ -145,4 +148,49 @@ func TestAppendPollFlag(t *testing.T) {
 			t.Fatalf("got %v", got)
 		}
 	})
+}
+
+// chokidar's own default is 100ms, which is what made a polling watcher stat
+// every watched file ten times a second across the VM boundary. The point of
+// the override is to be materially slower than that.
+func TestWatcherPollEnv_TracksPollingDecision(t *testing.T) {
+	dir := t.TempDir()
+	got := WatcherPollEnv(dir)
+
+	if !WatcherNeedsPolling(dir) {
+		if got != "" {
+			t.Fatalf("no polling on this host, want no env override, got %q", got)
+		}
+		return
+	}
+
+	const prefix = "CHOKIDAR_INTERVAL="
+	if !strings.HasPrefix(got, prefix) {
+		t.Fatalf("polling host must set the interval override, got %q", got)
+	}
+	ms, err := strconv.Atoi(strings.TrimPrefix(got, prefix))
+	if err != nil {
+		t.Fatalf("interval must be a plain integer of milliseconds, got %q", got)
+	}
+	if ms <= 100 {
+		t.Errorf("interval %dms is not looser than chokidar's 100ms default", ms)
+	}
+}
+
+// The ladder: a laptop on battery backs off, and Low Power Mode, an explicit
+// request for less background work, backs off twice as far again.
+func TestWatcherPollIntervalFor(t *testing.T) {
+	mains := watcherPollIntervalFor(power.Mains)
+	battery := watcherPollIntervalFor(power.Battery)
+	low := watcherPollIntervalFor(power.LowPower)
+
+	if battery != mains*2 {
+		t.Errorf("battery interval = %d, want double mains (%d)", battery, mains*2)
+	}
+	if low != mains*4 {
+		t.Errorf("low power interval = %d, want quadruple mains (%d)", low, mains*4)
+	}
+	if mains <= 100 {
+		t.Errorf("mains interval %dms is not looser than chokidar's 100ms default", mains)
+	}
 }

--- a/internal/power/power.go
+++ b/internal/power/power.go
@@ -1,0 +1,72 @@
+// Package power reports the host's power state so lerd can back off work that
+// is cheap on mains and expensive on a laptop running from its battery.
+package power
+
+import (
+	"sync"
+	"time"
+)
+
+// State is how the host is currently powered, ordered by how much lerd should
+// hold back.
+type State int
+
+const (
+	// Mains is plugged in with no energy-saving mode engaged.
+	Mains State = iota
+	// Battery is running from the battery.
+	Battery
+	// LowPower is an explicit user request to conserve energy (macOS Low Power
+	// Mode, the low-power ACPI platform profile). It outranks Battery: the
+	// setting can be switched on while plugged in, and when it is, the user has
+	// asked for less background work regardless of the power source.
+	LowPower
+)
+
+func (s State) String() string {
+	switch s {
+	case LowPower:
+		return "low-power"
+	case Battery:
+		return "battery"
+	default:
+		return "mains"
+	}
+}
+
+// probeTTL caches the answer briefly. The probe shells out on macOS and callers
+// arrive in bursts (a `lerd start` writes one unit per worker per site), so a
+// short window collapses a dozen probes into one without letting the answer go
+// stale enough to matter for the cadences that read it.
+const probeTTL = 10 * time.Second
+
+// probeFn is the platform detector, swappable in tests.
+var probeFn = detectState
+
+var (
+	mu       sync.Mutex
+	cached   State
+	cachedAt time.Time
+)
+
+// Current reports how the host is powered. Anything undeterminable reports
+// Mains: the conservative answer keeps the normal cadence rather than degrading
+// behaviour on a desktop, a VM, or a container that never had a battery.
+func Current() State {
+	mu.Lock()
+	defer mu.Unlock()
+	if !cachedAt.IsZero() && time.Since(cachedAt) < probeTTL {
+		return cached
+	}
+	cached = probeFn()
+	cachedAt = time.Now()
+	return cached
+}
+
+// reset clears the cache; used by tests.
+func reset() {
+	mu.Lock()
+	cached = Mains
+	cachedAt = time.Time{}
+	mu.Unlock()
+}

--- a/internal/power/power.go
+++ b/internal/power/power.go
@@ -17,7 +17,7 @@ const (
 	// Battery is running from the battery.
 	Battery
 	// LowPower is an explicit user request to conserve energy (macOS Low Power
-	// Mode, the low-power ACPI platform profile). It outranks Battery: the
+	// Mode, the power-saver profile on Linux). It outranks Battery: the
 	// setting can be switched on while plugged in, and when it is, the user has
 	// asked for less background work regardless of the power source.
 	LowPower
@@ -34,10 +34,11 @@ func (s State) String() string {
 	}
 }
 
-// probeTTL caches the answer briefly. The probe shells out on macOS and callers
-// arrive in bursts (a `lerd start` writes one unit per worker per site), so a
-// short window collapses a dozen probes into one without letting the answer go
-// stale enough to matter for the cadences that read it.
+// probeTTL caches the answer briefly. The probe shells out on macOS and crosses
+// the system bus on Linux, and callers arrive in bursts (a `lerd start` writes
+// one unit per worker per site), so a short window collapses a dozen probes
+// into one without letting the answer go stale enough to matter for the
+// cadences that read it.
 const probeTTL = 10 * time.Second
 
 // probeFn is the platform detector, swappable in tests.

--- a/internal/power/power_darwin.go
+++ b/internal/power/power_darwin.go
@@ -1,0 +1,61 @@
+//go:build darwin
+
+package power
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// pmset runs a pmset query, bounded so a wedged pmset can never stall a worker
+// write. A var so tests can drive the parsing without real hardware.
+var pmset = func(args ...string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "pmset", args...).Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
+// detectState asks pmset for the power source and, separately, whether Low
+// Power Mode is engaged. Low Power Mode can be on while plugged in, so it is
+// checked first and wins.
+func detectState() State {
+	if lowPowerFromPmset(pmset("-g")) {
+		return LowPower
+	}
+	if onBatteryFromPmset(pmset("-g", "batt")) {
+		return Battery
+	}
+	return Mains
+}
+
+// onBatteryFromPmset reads pmset's "Now drawing from 'X Power'" line.
+func onBatteryFromPmset(out string) bool {
+	return strings.Contains(out, "'Battery Power'")
+}
+
+// lowPowerFromPmset reads Low Power Mode out of `pmset -g`, whose lines are a
+// name and value separated by whitespace.
+//
+// The key was renamed across releases: older macOS reports "lowpowermode",
+// current macOS reports "powermode". Both are accepted, since a machine only
+// prints one of them and reading the wrong name means the mode silently never
+// registers. "powermode" is tri-state (0 normal, 1 low, 2 high), so only an
+// explicit 1 counts: high power mode must not be mistaken for low.
+func lowPowerFromPmset(out string) bool {
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if fields[0] == "lowpowermode" || fields[0] == "powermode" {
+			return fields[1] == "1"
+		}
+	}
+	return false
+}

--- a/internal/power/power_darwin_test.go
+++ b/internal/power/power_darwin_test.go
@@ -1,0 +1,77 @@
+//go:build darwin
+
+package power
+
+import "testing"
+
+func TestOnBatteryFromPmset(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{"plugged in", "Now drawing from 'AC Power'\n -InternalBattery-0 (id=1)\t100%; charged; 0:00 remaining present: true\n", false},
+		{"on battery", "Now drawing from 'Battery Power'\n -InternalBattery-0 (id=1)\t87%; discharging; 4:41 remaining present: true\n", true},
+		{"pmset unavailable", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := onBatteryFromPmset(tc.out); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLowPowerFromPmset(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{"legacy key engaged", "System-wide power settings:\n lowpowermode         1\n", true},
+		{"legacy key off", "System-wide power settings:\n lowpowermode         0\n", false},
+		{"current key engaged", "Currently in use:\n powermode            1\n womp                 1\n", true},
+		{"current key off", "Currently in use:\n powermode            0\n womp                 1\n", false},
+		{"high power mode is not low power", "Currently in use:\n powermode            2\n", false},
+		{"key absent entirely", "Currently in use:\n hibernatemode        3\n", false},
+		{"pmset unavailable", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lowPowerFromPmset(tc.out); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Low Power Mode can be switched on while plugged in, and when it is the user
+// has asked for less background work regardless of the power source.
+func TestDetectState_LowPowerOutranksSource(t *testing.T) {
+	prev := pmset
+	pmset = func(args ...string) string {
+		if len(args) == 1 && args[0] == "-g" {
+			return " lowpowermode         1\n"
+		}
+		return "Now drawing from 'AC Power'\n"
+	}
+	t.Cleanup(func() { pmset = prev })
+
+	if got := detectState(); got != LowPower {
+		t.Errorf("low power while on AC = %v, want low-power", got)
+	}
+}
+
+func TestDetectState_BatteryWithoutLowPower(t *testing.T) {
+	prev := pmset
+	pmset = func(args ...string) string {
+		if len(args) == 1 && args[0] == "-g" {
+			return " lowpowermode         0\n"
+		}
+		return "Now drawing from 'Battery Power'\n"
+	}
+	t.Cleanup(func() { pmset = prev })
+
+	if got := detectState(); got != Battery {
+		t.Errorf("got %v, want battery", got)
+	}
+}

--- a/internal/power/power_linux.go
+++ b/internal/power/power_linux.go
@@ -1,0 +1,53 @@
+//go:build linux
+
+package power
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// sysfs roots, vars so tests can point them at a fixture tree.
+var (
+	powerSupplyRoot = "/sys/class/power_supply"
+	platformProfile = "/sys/firmware/acpi/platform_profile"
+)
+
+// detectState reads sysfs. The ACPI platform profile is the closest analogue to
+// macOS Low Power Mode and, like it, can be selected while plugged in, so it is
+// checked first.
+func detectState() State {
+	if profile, err := os.ReadFile(platformProfile); err == nil {
+		if strings.TrimSpace(string(profile)) == "low-power" {
+			return LowPower
+		}
+	}
+	if onBatterySysfs() {
+		return Battery
+	}
+	return Mains
+}
+
+// onBatterySysfs reports true only when a mains adapter exists and none is
+// online. A host with no adapter at all (desktop, VM, container) reports false
+// rather than guessing.
+func onBatterySysfs() bool {
+	entries, err := filepath.Glob(filepath.Join(powerSupplyRoot, "*"))
+	if err != nil {
+		return false
+	}
+	sawMains := false
+	for _, dir := range entries {
+		kind, err := os.ReadFile(filepath.Join(dir, "type"))
+		if err != nil || strings.TrimSpace(string(kind)) != "Mains" {
+			continue
+		}
+		sawMains = true
+		online, err := os.ReadFile(filepath.Join(dir, "online"))
+		if err == nil && strings.TrimSpace(string(online)) == "1" {
+			return false
+		}
+	}
+	return sawMains
+}

--- a/internal/power/power_linux.go
+++ b/internal/power/power_linux.go
@@ -3,9 +3,13 @@
 package power
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"github.com/godbus/dbus/v5"
 )
 
 // sysfs roots, vars so tests can point them at a fixture tree.
@@ -14,24 +18,101 @@ var (
 	platformProfile = "/sys/firmware/acpi/platform_profile"
 )
 
-// detectState reads sysfs. The ACPI platform profile is the closest analogue to
-// macOS Low Power Mode and, like it, can be selected while plugged in, so it is
-// checked first.
-func detectState() State {
-	if profile, err := os.ReadFile(platformProfile); err == nil {
-		if strings.TrimSpace(string(profile)) == "low-power" {
-			return LowPower
-		}
+// dbusTimeout bounds every bus call so a wedged UPower can never stall a worker
+// write.
+const dbusTimeout = 2 * time.Second
+
+// upowerDest, upowerPath and upowerIface own the power source. UPower is on
+// every desktop Linux install and answers where sysfs cannot: it knows which
+// supplies are real adapters rather than a wireless mouse reporting a battery.
+const (
+	upowerDest  = "org.freedesktop.UPower"
+	upowerPath  = "/org/freedesktop/UPower"
+	upowerIface = "org.freedesktop.UPower"
+)
+
+// powerProfileServices are the buses that own the power-saver toggle the
+// desktops expose, newest name first. power-profiles-daemon moved under the
+// UPower name at 0.20 and still claims the old one, so both are tried and the
+// first that answers wins.
+var powerProfileServices = []struct{ dest, path, iface string }{
+	{"org.freedesktop.UPower.PowerProfiles", "/org/freedesktop/UPower/PowerProfiles", "org.freedesktop.UPower.PowerProfiles"},
+	{"net.hadess.PowerProfiles", "/net/hadess/PowerProfiles", "net.hadess.PowerProfiles"},
+}
+
+// systemBusProperty reads one property off the system bus. A var so tests can
+// answer for services this machine may not run.
+var systemBusProperty = func(dest, path, iface, prop string) (dbus.Variant, error) {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return dbus.Variant{}, err
 	}
-	if onBatterySysfs() {
+	ctx, cancel := context.WithTimeout(context.Background(), dbusTimeout)
+	defer cancel()
+	var v dbus.Variant
+	err = conn.Object(dest, dbus.ObjectPath(path)).
+		CallWithContext(ctx, "org.freedesktop.DBus.Properties.Get", 0, iface, prop).Store(&v)
+	return v, err
+}
+
+// detectState prefers the system bus and falls back to sysfs. The power-saver
+// profile is the closest analogue to macOS Low Power Mode and, like it, can be
+// selected while plugged in, so it is checked first.
+func detectState() State {
+	if busElseFile(lowPowerDBus, lowPowerSysfs) {
+		return LowPower
+	}
+	if busElseFile(onBatteryDBus, onBatterySysfs) {
 		return Battery
 	}
 	return Mains
 }
 
+// busElseFile takes the bus answer when a service replied and reads sysfs
+// otherwise, so a host with no UPower (a container, a headless box, a minimal
+// install) still gets an answer instead of defaulting blind.
+func busElseFile(bus func() (bool, bool), sysfs func() bool) bool {
+	if v, answered := bus(); answered {
+		return v
+	}
+	return sysfs()
+}
+
+// lowPowerDBus asks power-profiles-daemon which profile is active.
+func lowPowerDBus() (low, answered bool) {
+	for _, svc := range powerProfileServices {
+		v, err := systemBusProperty(svc.dest, svc.path, svc.iface, "ActiveProfile")
+		if err != nil {
+			continue
+		}
+		if profile, ok := v.Value().(string); ok {
+			return profile == "power-saver", true
+		}
+	}
+	return false, false
+}
+
+// onBatteryDBus asks UPower for the power source.
+func onBatteryDBus() (battery, answered bool) {
+	v, err := systemBusProperty(upowerDest, upowerPath, upowerIface, "OnBattery")
+	if err != nil {
+		return false, false
+	}
+	b, ok := v.Value().(bool)
+	return b, ok
+}
+
+// lowPowerSysfs reads the ACPI platform profile, which only some hardware
+// exposes; power-profiles-daemon drives it there and uses the CPU driver
+// elsewhere, which is why the bus is asked first.
+func lowPowerSysfs() bool {
+	profile, err := os.ReadFile(platformProfile)
+	return err == nil && strings.TrimSpace(string(profile)) == "low-power"
+}
+
 // onBatterySysfs reports true only when a mains adapter exists and none is
 // online. A host with no adapter at all (desktop, VM, container) reports false
-// rather than guessing.
+// rather than guessing, and a peripheral reporting its own battery is ignored.
 func onBatterySysfs() bool {
 	entries, err := filepath.Glob(filepath.Join(powerSupplyRoot, "*"))
 	if err != nil {

--- a/internal/power/power_linux_test.go
+++ b/internal/power/power_linux_test.go
@@ -1,0 +1,174 @@
+//go:build linux
+
+package power
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// supply is one entry in a fake /sys/class/power_supply.
+type supply struct {
+	name   string
+	kind   string
+	online string
+}
+
+// fakeSysfs points the sysfs readers at a fixture tree. profile is written only
+// when non-empty, so the common case of hardware without an ACPI platform
+// profile is covered too.
+func fakeSysfs(t *testing.T, profile string, supplies ...supply) {
+	t.Helper()
+	root := t.TempDir()
+
+	supplyRoot := filepath.Join(root, "power_supply")
+	if err := os.MkdirAll(supplyRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range supplies {
+		dir := filepath.Join(supplyRoot, s.name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "type"), []byte(s.kind+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if s.online != "" {
+			if err := os.WriteFile(filepath.Join(dir, "online"), []byte(s.online+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	profilePath := filepath.Join(root, "platform_profile")
+	if profile != "" {
+		if err := os.WriteFile(profilePath, []byte(profile+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	prevSupply, prevProfile := powerSupplyRoot, platformProfile
+	powerSupplyRoot, platformProfile = supplyRoot, profilePath
+	t.Cleanup(func() { powerSupplyRoot, platformProfile = prevSupply, prevProfile })
+}
+
+// noBus makes every property read fail, which is what a container, a headless
+// box, or an install without UPower looks like.
+func noBus(t *testing.T) {
+	t.Helper()
+	stubBus(t, func(dest, path, iface, prop string) (dbus.Variant, error) {
+		return dbus.Variant{}, errors.New("no such service")
+	})
+}
+
+func stubBus(t *testing.T, fn func(dest, path, iface, prop string) (dbus.Variant, error)) {
+	t.Helper()
+	prev := systemBusProperty
+	systemBusProperty = fn
+	t.Cleanup(func() { systemBusProperty = prev })
+}
+
+// bus answers OnBattery and ActiveProfile for the named service only, so the
+// tests can model a host running UPower without power-profiles-daemon and the
+// two spellings of the profiles service independently.
+func bus(t *testing.T, onBattery bool, profileDest, profile string) {
+	t.Helper()
+	stubBus(t, func(dest, path, iface, prop string) (dbus.Variant, error) {
+		switch {
+		case dest == upowerDest && prop == "OnBattery":
+			return dbus.MakeVariant(onBattery), nil
+		case dest == profileDest && prop == "ActiveProfile":
+			return dbus.MakeVariant(profile), nil
+		}
+		return dbus.Variant{}, errors.New("no such service")
+	})
+}
+
+const (
+	ppdModern = "org.freedesktop.UPower.PowerProfiles"
+	ppdLegacy = "net.hadess.PowerProfiles"
+)
+
+func TestDetectStateFromSysfs(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		profile  string
+		supplies []supply
+		want     State
+	}{
+		{"desktop with no supplies at all", "", nil, Mains},
+		{"laptop plugged in", "", []supply{{"AC", "Mains", "1"}, {"BAT0", "Battery", ""}}, Mains},
+		{"laptop unplugged", "", []supply{{"AC", "Mains", "0"}, {"BAT0", "Battery", ""}}, Battery},
+		// A wireless mouse or keyboard registers as a Battery supply on a
+		// mains-powered desktop; treating that as "on battery" would loosen
+		// the cadence on a machine that is plugged into the wall.
+		{"desktop with a peripheral battery", "", []supply{{"hidpp_battery_0", "Battery", "1"}}, Mains},
+		{"power-saver platform profile", "low-power", []supply{{"AC", "Mains", "1"}}, LowPower},
+		{"balanced platform profile", "balanced", []supply{{"AC", "Mains", "1"}}, Mains},
+		// The profile can be selected while plugged in, and when it is the
+		// user has asked for less background work regardless of the source.
+		{"platform profile outranks the source", "low-power", []supply{{"AC", "Mains", "0"}}, LowPower},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			noBus(t)
+			fakeSysfs(t, tc.profile, tc.supplies...)
+			if got := detectState(); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectStateFromBus(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		onBattery   bool
+		profileDest string
+		profile     string
+		want        State
+	}{
+		{"plugged in, balanced", false, ppdModern, "balanced", Mains},
+		{"on battery, balanced", true, ppdModern, "balanced", Battery},
+		{"power-saver on the current service name", false, ppdModern, "power-saver", LowPower},
+		{"power-saver on the legacy service name", false, ppdLegacy, "power-saver", LowPower},
+		{"performance profile is not low power", true, ppdModern, "performance", Battery},
+		// No power-profiles-daemon on the bus at all: the source still decides.
+		{"upower only", true, "", "", Battery},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bus(t, tc.onBattery, tc.profileDest, tc.profile)
+			fakeSysfs(t, "", supply{"AC", "Mains", "1"})
+			if got := detectState(); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// UPower knows the real adapters; sysfs is only the fallback for hosts that
+// don't run it, so a bus answer must not be second-guessed by the fixture tree.
+func TestBusOutranksSysfs(t *testing.T) {
+	bus(t, false, ppdModern, "balanced")
+	fakeSysfs(t, "", supply{"AC", "Mains", "0"})
+
+	if got := detectState(); got != Mains {
+		t.Errorf("bus says plugged in, sysfs says unplugged: got %v, want mains", got)
+	}
+}
+
+// A daemon that answers with the wrong type must not be read as an answer, or
+// a malformed reply would mask the sysfs fallback.
+func TestNonBoolOnBatteryFallsBackToSysfs(t *testing.T) {
+	stubBus(t, func(dest, path, iface, prop string) (dbus.Variant, error) {
+		return dbus.MakeVariant("yes"), nil
+	})
+	fakeSysfs(t, "", supply{"AC", "Mains", "0"})
+
+	if got := detectState(); got != Battery {
+		t.Errorf("got %v, want battery from the sysfs fallback", got)
+	}
+}

--- a/internal/power/power_other.go
+++ b/internal/power/power_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !linux
+
+package power
+
+// detectState has no implementation on other platforms; reporting Mains keeps
+// the normal cadence rather than degrading behaviour blindly.
+func detectState() State { return Mains }

--- a/internal/power/power_test.go
+++ b/internal/power/power_test.go
@@ -1,0 +1,57 @@
+package power
+
+import "testing"
+
+// Callers arrive in bursts (one worker unit per worker per site), and on macOS
+// each probe is a subprocess, so repeat calls must collapse into one.
+func TestCurrent_CachesWithinTTL(t *testing.T) {
+	t.Cleanup(reset)
+	reset()
+
+	probes := 0
+	prev := probeFn
+	probeFn = func() State {
+		probes++
+		return Battery
+	}
+	t.Cleanup(func() { probeFn = prev })
+
+	for i := 0; i < 5; i++ {
+		if Current() != Battery {
+			t.Fatal("expected the stubbed probe's answer")
+		}
+	}
+	if probes != 1 {
+		t.Errorf("probed %d times for five calls inside the TTL, want 1", probes)
+	}
+}
+
+// An undeterminable power source must read as mains, so a desktop or a host
+// without sysfs keeps the normal cadence instead of being treated as a laptop.
+func TestCurrent_DefaultsToMains(t *testing.T) {
+	t.Cleanup(reset)
+	reset()
+
+	prev := probeFn
+	probeFn = func() State { return Mains }
+	t.Cleanup(func() { probeFn = prev })
+
+	if got := Current(); got != Mains {
+		t.Errorf("unknown power source = %v, want mains", got)
+	}
+}
+
+func TestStateString(t *testing.T) {
+	for _, tc := range []struct {
+		s    State
+		want string
+	}{
+		{Mains, "mains"},
+		{Battery, "battery"},
+		{LowPower, "low-power"},
+	} {
+		if got := tc.s.String(); got != tc.want {
+			t.Errorf("State(%d).String() = %q, want %q", tc.s, got, tc.want)
+		}
+	}
+}

--- a/internal/watcher/power.go
+++ b/internal/watcher/power.go
@@ -1,0 +1,138 @@
+package watcher
+
+import (
+	"time"
+
+	"github.com/geodro/lerd/internal/cli"
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+	"github.com/geodro/lerd/internal/power"
+)
+
+// powerRestartCooldown is the shortest gap between two power-driven restart
+// rounds. Unplugging and replugging a laptop in quick succession should not
+// bounce every reload worker each time, and the cadence being corrected is a
+// background nicety, not something worth a restart storm over.
+const powerRestartCooldown = 5 * time.Minute
+
+// powerWatchState tracks the last observed power state and when workers were
+// last bounced for it. Split out from the loop so the transition and cooldown
+// rules can be tested without a battery to unplug.
+type powerWatchState struct {
+	last        power.State
+	lastRestart time.Time
+	cooldown    time.Duration
+}
+
+// shouldRestart reports whether a transition to cur warrants restarting the
+// polling reload workers. A change suppressed by the cooldown deliberately
+// leaves `last` untouched so the next tick retries it: the workers are still
+// running the previous state's interval, and dropping the transition would
+// strand them there until the power source changed again.
+func (s *powerWatchState) shouldRestart(cur power.State, now time.Time) bool {
+	if cur == s.last {
+		return false
+	}
+	if !s.lastRestart.IsZero() && now.Sub(s.lastRestart) < s.cooldown {
+		return false
+	}
+	s.last = cur
+	s.lastRestart = now
+	return true
+}
+
+// Seams for tests, so the loop can be driven without real hardware or workers.
+var (
+	powerCurrentFn = power.Current
+	powerRestartFn = restartPollingReloadWorkers
+)
+
+// WatchPower re-applies the reload watcher's poll interval when the machine's
+// power source changes. The interval is baked into a worker's unit when it is
+// written and chokidar reads it once at startup, so without this an unplugged
+// laptop would keep polling at the mains cadence until something else happened
+// to restart the worker.
+func WatchPower(interval time.Duration) {
+	state := &powerWatchState{last: powerCurrentFn(), cooldown: powerRestartCooldown}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for range ticker.C {
+		cur := powerCurrentFn()
+		if !state.shouldRestart(cur, time.Now()) {
+			continue
+		}
+		logger.Info("power state changed, re-applying reload watcher cadence", "state", cur.String())
+		powerRestartFn(cur)
+	}
+}
+
+// restartPollingReloadWorkers rewrites and restarts every worker whose reload
+// watcher is polling, so it picks up the interval for the new power state.
+//
+// Only workers that are currently active are touched: this must never
+// resurrect a worker the user deliberately stopped, and a worker that is down
+// will pick up the new interval whenever it is next started anyway.
+func restartPollingReloadWorkers(state power.State) {
+	if config.IsStopped() || cli.WorkerMigrationActive() {
+		return
+	}
+	reg, err := config.LoadSites()
+	if err != nil || reg == nil {
+		return
+	}
+	cfg, _ := config.LoadGlobal()
+	defaultPHP := ""
+	if cfg != nil {
+		defaultPHP = cfg.PHP.DefaultVersion
+	}
+
+	for _, s := range reg.Sites {
+		if s.Ignored || s.Paused {
+			continue
+		}
+		// Where the watcher can see host events it never polls, so there is
+		// no interval to re-apply and nothing to restart.
+		if !config.WatcherNeedsPolling(s.Path) || !config.ProjectHasChokidar(s.Path) {
+			continue
+		}
+		proj, _ := config.LoadProjectConfig(s.Path)
+		if proj == nil || len(proj.ReloadWorkers) == 0 {
+			continue
+		}
+		fw, ok := config.GetFrameworkForDir(s.Framework, s.Path)
+		if !ok || fw == nil {
+			continue
+		}
+		paused := make(map[string]bool, len(s.PausedWorkers))
+		for _, name := range s.PausedWorkers {
+			paused[name] = true
+		}
+		php := s.PHPVersion
+		if php == "" {
+			php = defaultPHP
+		}
+
+		for _, name := range proj.ReloadWorkers {
+			if paused[name] {
+				continue
+			}
+			def, ok := fw.Workers[name]
+			if !ok || def.ReloadCommand == "" {
+				continue
+			}
+			if supported, _ := cli.WorkerSupportedOnPlatform(def); !supported {
+				continue
+			}
+			unit := "lerd-" + name + "-" + s.Name
+			if status, _ := podman.UnitStatus(unit); status != "active" {
+				continue
+			}
+			logger.Info("restarting reload worker for new power state",
+				"unit", unit, "state", state.String())
+			if err := cli.WorkerStartForSite(s.Name, s.Path, php, name, def, true); err != nil {
+				logger.Error("power-driven worker restart failed", "unit", unit, "err", err)
+			}
+		}
+	}
+}

--- a/internal/watcher/power.go
+++ b/internal/watcher/power.go
@@ -45,6 +45,7 @@ func (s *powerWatchState) shouldRestart(cur power.State, now time.Time) bool {
 var (
 	powerCurrentFn = power.Current
 	powerRestartFn = restartPollingReloadWorkers
+	hostCanPollFn  = config.HostCanPollWatchers
 )
 
 // WatchPower re-applies the reload watcher's poll interval when the machine's
@@ -52,7 +53,14 @@ var (
 // written and chokidar reads it once at startup, so without this an unplugged
 // laptop would keep polling at the mains cadence until something else happened
 // to restart the worker.
+//
+// Hosts where no watcher can ever poll return immediately: there would be no
+// interval to re-apply, and ticking anyway costs a probe every interval and
+// logs a power transition that changed nothing.
 func WatchPower(interval time.Duration) {
+	if !hostCanPollFn() {
+		return
+	}
 	state := &powerWatchState{last: powerCurrentFn(), cooldown: powerRestartCooldown}
 
 	ticker := time.NewTicker(interval)
@@ -124,7 +132,7 @@ func restartPollingReloadWorkers(state power.State) {
 			if supported, _ := cli.WorkerSupportedOnPlatform(def); !supported {
 				continue
 			}
-			unit := "lerd-" + name + "-" + s.Name
+			unit := cli.WorkerUnitName(s.Name, s.Path, name)
 			if status, _ := podman.UnitStatus(unit); status != "active" {
 				continue
 			}

--- a/internal/watcher/power_test.go
+++ b/internal/watcher/power_test.go
@@ -1,0 +1,73 @@
+package watcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/geodro/lerd/internal/power"
+)
+
+func TestPowerWatchState_NoRestartWithoutAChange(t *testing.T) {
+	s := &powerWatchState{last: power.Mains, cooldown: powerRestartCooldown}
+	now := time.Now()
+
+	if s.shouldRestart(power.Mains, now) {
+		t.Error("steady mains must not restart anything")
+	}
+	if s.shouldRestart(power.Mains, now.Add(time.Hour)) {
+		t.Error("still steady an hour later must not restart anything")
+	}
+}
+
+func TestPowerWatchState_RestartsOnTransition(t *testing.T) {
+	s := &powerWatchState{last: power.Mains, cooldown: powerRestartCooldown}
+	now := time.Now()
+
+	if !s.shouldRestart(power.Battery, now) {
+		t.Fatal("unplugging must re-apply the cadence")
+	}
+	if s.shouldRestart(power.Battery, now.Add(time.Second)) {
+		t.Error("no further restart while the state holds")
+	}
+}
+
+// Unplugging and replugging in quick succession should not bounce every reload
+// worker each time.
+func TestPowerWatchState_CooldownSuppressesFlapping(t *testing.T) {
+	s := &powerWatchState{last: power.Mains, cooldown: 5 * time.Minute}
+	now := time.Now()
+
+	if !s.shouldRestart(power.Battery, now) {
+		t.Fatal("first transition should restart")
+	}
+	if s.shouldRestart(power.Mains, now.Add(10*time.Second)) {
+		t.Error("a transition inside the cooldown must be suppressed")
+	}
+}
+
+// A transition suppressed by the cooldown must be retried once the window
+// passes: the workers are still running the old interval, and dropping the
+// change would strand them there until the power source moved again.
+func TestPowerWatchState_SuppressedTransitionIsRetried(t *testing.T) {
+	s := &powerWatchState{last: power.Mains, cooldown: 5 * time.Minute}
+	now := time.Now()
+
+	s.shouldRestart(power.Battery, now)                     // restarts, starts the cooldown
+	if s.shouldRestart(power.Mains, now.Add(time.Minute)) { // suppressed
+		t.Fatal("expected suppression inside the cooldown")
+	}
+	if !s.shouldRestart(power.Mains, now.Add(6*time.Minute)) {
+		t.Error("the suppressed transition must be retried after the cooldown")
+	}
+}
+
+// Every state carries a distinct interval, so each transition is worth acting
+// on rather than being collapsed.
+func TestPowerWatchState_LowPowerIsItsOwnTransition(t *testing.T) {
+	s := &powerWatchState{last: power.Battery, cooldown: 0}
+	now := time.Now()
+
+	if !s.shouldRestart(power.LowPower, now) {
+		t.Error("battery to low power changes the interval and must re-apply")
+	}
+}

--- a/internal/watcher/power_test.go
+++ b/internal/watcher/power_test.go
@@ -61,6 +61,35 @@ func TestPowerWatchState_SuppressedTransitionIsRetried(t *testing.T) {
 	}
 }
 
+// A host where no watcher can poll has no cadence to maintain, so the loop must
+// not start at all: it would probe the power state forever and log transitions
+// that restart nothing.
+func TestWatchPower_StandsDownWhereNothingPolls(t *testing.T) {
+	prevHost, prevCurrent := hostCanPollFn, powerCurrentFn
+	probes := 0
+	hostCanPollFn = func() bool { return false }
+	powerCurrentFn = func() power.State {
+		probes++
+		return power.Mains
+	}
+	t.Cleanup(func() { hostCanPollFn, powerCurrentFn = prevHost, prevCurrent })
+
+	done := make(chan struct{})
+	go func() {
+		WatchPower(time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WatchPower kept ticking on a host that never polls")
+	}
+	if probes != 0 {
+		t.Errorf("probed the power state %d times with nothing to maintain, want 0", probes)
+	}
+}
+
 // Every state carries a distinct interval, so each transition is worth acting
 // on rather than being collapsed.
 func TestPowerWatchState_LowPowerIsItsOwnTransition(t *testing.T) {


### PR DESCRIPTION
A worker opted into auto-reload runs its file watcher in polling mode wherever the container cannot see host filesystem events, which is always the case on macOS and on WSL2 for projects under /mnt. chokidar's default polling interval is 100ms, so every watched file was re-stat'd ten times a second for as long as the worker ran. On macOS each of those stats crosses virtiofs and is served by the host VM process, which is where the cost lands: a single site with a few hundred watched files held that process near 30% CPU on an otherwise idle machine, and a user has reported it at 161%.

The watcher now gets CHOKIDAR_INTERVAL on its exec. chokidar honours it as a global override however polling was switched on, so the vendored Octane and Horizon watcher scripts are tuned without being patched. A second between passes is imperceptible for a worker that takes longer than that to restart.

The interval also tracks how the machine is powered, since re-stat'ing a few hundred files is exactly the background work a laptop can do without. Battery doubles it, and Low Power Mode, an explicit request for less background work, doubles it again. Low Power Mode can be switched on while plugged in, so it outranks the power source. It is read from either spelling pmset uses, because older releases report lowpowermode and current ones report powermode, and reading only one name means the mode silently never registers. powermode is tri-state, so only an explicit 1 counts and high power mode is not mistaken for low.

Because the interval is baked into a worker's unit and chokidar reads it once at startup, a laptop unplugged mid-session would otherwise keep polling at the mains cadence. The watcher now notices the transition and restarts the affected workers. Only workers that are actually polling and currently active are touched: restarting a stopped worker would resurrect something the user deliberately stopped, and it picks up the new interval whenever it is next started anyway. Restart rounds are held to one per five minutes so plugging in and out repeatedly cannot bounce every worker, and a transition suppressed by that window is retried rather than dropped.

Measured on one site: virtiofs requests fall from roughly 280 per second at the old default to 180 at the mains interval and 72 in low power, verified end to end by unplugging the machine and watching the worker come back with the new value. Stopping the watcher altogether reaches 14, so this reduces the traffic rather than removing it, and the watcher still wants moving out of the container.

Refs #1077
