### PR TITLE
fix(doctor): accept the LAN IP in DNS checks when lan:expose is on

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -108,10 +108,10 @@ The chain in order:
 | `lerd-dns container` | The dnsmasq container is running. | `lerd start` (or `podman logs lerd-dns` to see why it crashed). |
 | `dnsmasq config` | `~/.local/share/lerd/dnsmasq/lerd.conf` exists with `port=5300` and `address=/.<tld>/`. | `lerd start` regenerates the config from your registered TLD. |
 | `port 5300 listening` | TCP/UDP 5300 is reachable on 127.0.0.1. | Another process owns the port. Find it with `ss -tlnp sport = :5300` on Linux, or `lsof -nP -iTCP:5300 -sTCP:LISTEN` on macOS. |
-| `dig @127.0.0.1 -p 5300` | A direct query at port 5300 returns 127.0.0.1 for `lerd-probe.<tld>`. | dnsmasq is up but its config drifted. `systemctl --user restart lerd-dns`. |
+| `dig @127.0.0.1 -p 5300` | A direct query at port 5300 returns 127.0.0.1 for `lerd-probe.<tld>`, or the host's LAN IP when [`lan:expose`](usage/lan-sharing.md) is on. | dnsmasq is up but its config drifted. `lerd dns:repair`. |
 | `resolver hookup` | The NetworkManager dispatcher script or systemd-resolved drop-in is installed. | Rerun `lerd install`. |
 | `interface routes .test to 5300` | `resolvectl status` shows `127.0.0.1:5300` and `~<tld>` on the active interface. | `sudo systemctl restart NetworkManager`, or set the routing manually with `sudo resolvectl domain <iface> ~test ~.`. |
-| `system DNS lookup` | `host lerd-probe.test` (the system resolver) returns 127.0.0.1. | The drop-in is installed but resolved isn't honouring it. Check whether cloud-init or another tool wrote a higher-priority resolver config. Common on EC2 / cloud images. With a VPN connected this rung is reported as a warning rather than a failure, see the VPN section below. |
+| `system DNS lookup` | `host lerd-probe.test` (the system resolver) returns 127.0.0.1, or the host's LAN IP under `lan:expose`. | The drop-in is installed but resolved isn't honouring it. Check whether cloud-init or another tool wrote a higher-priority resolver config. Common on EC2 / cloud images. With a VPN connected this rung is reported as a warning rather than a failure, see the VPN section below. |
 
 You can also call this programmatically over MCP via the `diag` tool's `dns_diagnose` action, useful for AI-driven troubleshooting:
 

--- a/internal/dns/diagnose.go
+++ b/internal/dns/diagnose.go
@@ -60,6 +60,35 @@ type probeFns struct {
 	dummyLinkRouting func(tld string) (present bool, routed bool)
 	systemLookup     func(tld string) (addrs []string, err error)
 	vpnActive        func() bool
+	// lanExposedIP is the LAN IP dnsmasq hands out under lan:expose, or "" when
+	// off, so the answer checks accept it as legitimate (see probe.go Check).
+	lanExposedIP func() string
+}
+
+// exposedIP is the LAN IP dnsmasq publishes under lan:expose, or "" when the
+// probe left the hook unset (older callers and tests predating the field).
+func (p probeFns) exposedIP() string {
+	if p.lanExposedIP == nil {
+		return ""
+	}
+	return p.lanExposedIP()
+}
+
+// answerAccepted reports whether a DNS answer is one lerd would legitimately
+// return: loopback always, plus the host LAN IP when lan:expose is on.
+func answerAccepted(answer, lanIP string) bool {
+	return answer == "127.0.0.1" || (lanIP != "" && answer == lanIP)
+}
+
+// acceptedAnswer returns the first address in addrs that lerd would legitimately
+// hand out, or "" if none qualifies.
+func acceptedAnswer(addrs []string, lanIP string) string {
+	for _, a := range addrs {
+		if answerAccepted(a, lanIP) {
+			return a
+		}
+	}
+	return ""
 }
 
 // resolverHookup kinds. Both systemd-resolved paths rely on the lerd0 link;
@@ -170,23 +199,30 @@ func diagnose(tld string, p probeFns) Diagnostic {
 		return finalize(d)
 	}
 
-	// Rung 4 — direct DNS query at port 5300.
+	// Rung 4 — direct DNS query at port 5300. Under lan:expose dnsmasq answers
+	// the host LAN IP, not loopback, so accept that too rather than red-flag a
+	// healthy exposed setup.
 	answer, err := p.dnsmasqAnswer(tld)
+	lanIP := p.exposedIP()
+	want := "127.0.0.1"
+	if lanIP != "" {
+		want += " or " + lanIP
+	}
 	switch {
 	case err != nil:
 		d.Steps = append(d.Steps, Step{
 			Name:   "dig @127.0.0.1 -p 5300",
 			Status: StepFail,
 			Detail: err.Error(),
-			Hint:   "lerd-dns config probably stale, restart with: systemctl --user restart lerd-dns",
+			Hint:   "lerd-dns config probably stale, repair with: lerd dns:repair",
 		})
 		return finalize(d)
-	case answer != "127.0.0.1":
+	case !answerAccepted(answer, lanIP):
 		d.Steps = append(d.Steps, Step{
 			Name:   "dig @127.0.0.1 -p 5300",
 			Status: StepFail,
-			Detail: fmt.Sprintf("got %q, want 127.0.0.1", answer),
-			Hint:   "lerd-dns address rule missing, restart with: systemctl --user restart lerd-dns",
+			Detail: fmt.Sprintf("got %q, want %s", answer, want),
+			Hint:   "lerd-dns address rule missing, repair with: lerd dns:repair",
 		})
 		return finalize(d)
 	default:
@@ -273,14 +309,15 @@ func diagnose(tld string, p probeFns) Diagnostic {
 	// Rung 7 — end to end resolution at port 53.
 	addrs, err := p.systemLookup(tld)
 	vpn := p.vpnActive != nil && p.vpnActive()
+	accepted := acceptedAnswer(addrs, lanIP)
 	switch {
 	case err != nil:
 		d.Steps = append(d.Steps, systemLookupFailStep(err.Error(), vpn))
-	case !contains(addrs, "127.0.0.1"):
+	case accepted == "":
 		d.Steps = append(d.Steps, systemLookupFailStep(
-			fmt.Sprintf("got %v, want one entry to be 127.0.0.1", addrs), vpn))
+			fmt.Sprintf("got %v, want one entry to be %s", addrs, want), vpn))
 	default:
-		d.Steps = append(d.Steps, Step{Name: "system DNS lookup", Status: StepOK, Detail: "127.0.0.1"})
+		d.Steps = append(d.Steps, Step{Name: "system DNS lookup", Status: StepOK, Detail: accepted})
 	}
 
 	return finalize(d)
@@ -321,15 +358,6 @@ func finalize(d Diagnostic) Diagnostic {
 	return d
 }
 
-func contains(haystack []string, needle string) bool {
-	for _, h := range haystack {
-		if h == needle {
-			return true
-		}
-	}
-	return false
-}
-
 // findListenerCmd returns the shell command the user can run to identify
 // the process bound to a TCP port. macOS lacks ss(8), so we point users at
 // lsof which ships with the OS; everywhere else we assume iproute2 ss.
@@ -352,7 +380,19 @@ func defaultProbes() probeFns {
 		dummyLinkRouting: defaultDummyLinkRouting,
 		systemLookup:     defaultSystemLookup,
 		vpnActive:        VPNActive,
+		lanExposedIP:     defaultLanExposedIP,
 	}
+}
+
+// defaultLanExposedIP returns the host's primary LAN IP when lan:expose is on,
+// or "" otherwise. Mirrors probe.go's Check so the doctor accepts the same
+// answers the resolver legitimately hands out.
+func defaultLanExposedIP() string {
+	cfg, _ := config.LoadGlobal()
+	if cfg != nil && cfg.LAN.Exposed {
+		return primaryLANIP()
+	}
+	return ""
 }
 
 // defaultDummyLinkRouting reports whether lerd0 exists and still carries the

--- a/internal/dns/diagnose_test.go
+++ b/internal/dns/diagnose_test.go
@@ -21,6 +21,7 @@ func fakeProbes() probeFns {
 		dummyLinkRouting: func(string) (bool, bool) { return true, true },
 		systemLookup:     func(string) ([]string, error) { return []string{"127.0.0.1"}, nil },
 		vpnActive:        func() bool { return false },
+		lanExposedIP:     func() string { return "" },
 	}
 }
 
@@ -171,6 +172,38 @@ func TestDiagnose_wrongAnswerSurfaceConfigDrift(t *testing.T) {
 	}
 	if !strings.Contains(d.Steps[3].Detail, "1.2.3.4") {
 		t.Errorf("detail should include the wrong answer, got %q", d.Steps[3].Detail)
+	}
+}
+
+// Under lan:expose dnsmasq answers the host LAN IP, not loopback, and the
+// system resolver returns it too. The doctor must accept that as healthy
+// instead of red-flagging a working setup.
+func TestDiagnose_lanExposedAcceptsLANIP(t *testing.T) {
+	const lanIP = "192.168.1.50"
+	p := fakeProbes()
+	p.lanExposedIP = func() string { return lanIP }
+	p.dnsmasqAnswer = func(string) (string, error) { return lanIP, nil }
+	p.systemLookup = func(string) ([]string, error) { return []string{lanIP}, nil }
+	d := diagnose("test", p)
+	if d.FirstFailure != -1 {
+		t.Errorf("FirstFailure = %d, want -1 (LAN IP is valid under lan:expose)", d.FirstFailure)
+	}
+	if got := d.Steps[3].Detail; got != lanIP {
+		t.Errorf("dig rung detail = %q, want the LAN IP %q", got, lanIP)
+	}
+}
+
+// The dig-rung hint must point at a cross-platform command. systemctl is
+// Linux-only and used to leak into the hint shown on macOS.
+func TestDiagnose_digHintUsesDnsRepairNotSystemctl(t *testing.T) {
+	p := fakeProbes()
+	p.dnsmasqAnswer = func(string) (string, error) { return "1.2.3.4", nil }
+	hint := diagnose("test", p).Steps[3].Hint
+	if !strings.Contains(hint, "lerd dns:repair") {
+		t.Errorf("hint %q should suggest `lerd dns:repair`", hint)
+	}
+	if strings.Contains(hint, "systemctl") {
+		t.Errorf("hint %q must not suggest systemctl (Linux-only)", hint)
 	}
 }
 


### PR DESCRIPTION
lerd doctor treated 127.0.0.1 as the only valid DNS answer, so a lan:expose setup where dnsmasq legitimately hands out the host LAN IP was reported as broken even though the TLD resolves and sites serve. The direct dnsmasq query and the end to end system lookup now accept the LAN IP as well when lan:expose is on, deriving it the same way probe.go already does, so the check matches the answers the resolver actually returns in both modes.

The two dig-rung hints suggested restarting lerd-dns with systemctl, which is not present on macOS. They now point at lerd dns:repair, which works on both platforms.

Refs #1091