### PR TITLE
fix: address regressions found in the v1.30 release review

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -708,6 +708,7 @@ cmd_uninstall_macos() {
 # and only the binary can take them back out, so the uninstaller uses this list
 # both to detect the setup and to tell the user how to clear it by hand.
 LERD_DNS_FILES=(
+  /etc/sudoers.d/lerd
   /etc/systemd/system/lerd-dns-link.service
   /etc/systemd/resolved.conf.d/lerd-fallback.conf
   /etc/systemd/resolved.conf.d/lerd.conf

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -169,7 +169,7 @@ func runDoctorInto(w io.Writer, useColor bool) (DoctorReport, error) {
 		// every container start, plus the boot, pays the 90s.
 		if lerdSystemd.NetworkWaitStalls() {
 			warn("podman network-online wait", "network-online.target never activates here, so every container start stalls 90s — fix: lerd start")
-			rep.fixLast(autoFix(fixStart, "", "install the network-online drop-in and restart (lerd start)"))
+			rep.fixLast(autoFix(fixNetworkWait, "", "install the podman network-online drop-in"))
 		} else {
 			ok("podman network-online wait")
 		}

--- a/internal/cli/doctor_fix.go
+++ b/internal/cli/doctor_fix.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/geodro/lerd/internal/feedback"
+	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 )
 
 // Automatic fix keys. Each is attached to a finding by the doctor and dispatched
@@ -16,7 +17,7 @@ const (
 	fixMkdir        = "mkdir"
 	fixEnableLinger = "enable-linger"
 	fixPhpRebuild   = "php-rebuild"
-	fixStart        = "start"
+	fixNetworkWait  = "network-wait"
 	fixInstall      = "install"
 	fixCleanup      = "cleanup"
 )
@@ -40,6 +41,11 @@ var heavyFixKeys = map[string]bool{
 // reCheckReport re-runs the diagnosis after fixes are applied; a package var so
 // tests can stub it instead of probing the live system.
 var reCheckReport = RunDoctorReport
+
+// ensureNoNetworkWaitStallFn installs the podman network-online drop-in; a seam
+// tests override so the network-wait fix can be exercised without touching the
+// host's systemd, and to prove it routes here rather than into `lerd start`.
+var ensureNoNetworkWaitStallFn = lerdSystemd.EnsureNoNetworkWaitStall
 
 // IsHeavyFix reports whether a fix always warrants an extra confirmation.
 func IsHeavyFix(fix *DoctorFix) bool {
@@ -157,8 +163,13 @@ func ApplyDoctorFix(fix *DoctorFix, out io.Writer) error {
 			return fmt.Errorf("php-rebuild fix: no version")
 		}
 		return runSelf(out, "php:rebuild", fix.Arg)
-	case fixStart:
-		return runSelf(out, "start")
+	case fixNetworkWait:
+		// A user-level drop-in and `systemctl --user` only; deliberately not
+		// `lerd start`, which would drag the privileged resolver reconfiguration
+		// into the auto tier that promises never to touch sudo.
+		fmt.Fprintln(out, "installing the podman network-online drop-in")
+		_, err := ensureNoNetworkWaitStallFn()
+		return err
 	case fixInstall:
 		return runSelf(out, "install")
 	case fixCleanup:

--- a/internal/cli/doctor_fix_test.go
+++ b/internal/cli/doctor_fix_test.go
@@ -67,3 +67,32 @@ func TestHeavyFixClassification(t *testing.T) {
 		t.Fatal("mkdir should not be heavy")
 	}
 }
+
+// The network-online repair used to re-enter `lerd start`, which reconfigures
+// the resolver through sudo, elevating unattended under `doctor --fix --yes`.
+// It now installs a user-level drop-in in-process; assert it routes there and
+// never touches privilege, and that "start" is no longer a dispatchable key.
+func TestApplyDoctorFixNetworkWaitStaysUnprivileged(t *testing.T) {
+	called := false
+	orig := ensureNoNetworkWaitStallFn
+	ensureNoNetworkWaitStallFn = func() (bool, error) { called = true; return false, nil }
+	t.Cleanup(func() { ensureNoNetworkWaitStallFn = orig })
+
+	fix := autoFix(fixNetworkWait, "", "install the podman network-online drop-in")
+	var buf bytes.Buffer
+	if err := ApplyDoctorFix(fix, &buf); err != nil {
+		t.Fatalf("network-wait fix failed: %v", err)
+	}
+	if !called {
+		t.Error("network-wait fix did not route to the in-process drop-in installer")
+	}
+	if IsHeavyFix(fix) {
+		t.Error("network-wait fix should not be heavy")
+	}
+
+	// The privileged `start` fix is gone: a doctor that re-adds it lands in the
+	// unknown-key default rather than silently running sudo from the auto tier.
+	if err := ApplyDoctorFix(&DoctorFix{Tier: FixAuto, Key: "start"}, &buf); err == nil {
+		t.Error(`"start" is dispatchable from the auto tier again but it runs lerd start (sudo)`)
+	}
+}

--- a/internal/cli/doctor_report.go
+++ b/internal/cli/doctor_report.go
@@ -75,18 +75,24 @@ func (r *DoctorReport) fixLast(fx *DoctorFix) {
 }
 
 // AutoFixes returns the findings carrying an applicable automatic fix, in report
-// order, one per distinct key. Several failing findings can attach the same
+// order, one per distinct fix. Several failing findings can attach the same
 // repair (a broken DNS chain fails at more than one rung), and running that
-// repair once per finding would repeat the whole sequence. Callers filter
-// further (heavy fixes always re-confirm).
+// repair once per finding would repeat the whole sequence. The identity is the
+// key plus its argument: mkdir and php-rebuild reuse one key across findings
+// that each target a different directory or PHP version, and those must all
+// survive. Callers filter further (heavy fixes always re-confirm).
 func (r *DoctorReport) AutoFixes() []Finding {
 	var out []Finding
 	seen := map[string]bool{}
 	for _, f := range r.Findings {
-		if f.Fix == nil || f.Fix.Tier != FixAuto || seen[f.Fix.Key] {
+		if f.Fix == nil || f.Fix.Tier != FixAuto {
 			continue
 		}
-		seen[f.Fix.Key] = true
+		id := f.Fix.Key + "\x00" + f.Fix.Arg
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
 		out = append(out, f)
 	}
 	return out

--- a/internal/cli/doctor_report_test.go
+++ b/internal/cli/doctor_report_test.go
@@ -72,7 +72,7 @@ func TestAutoFixesDedupesByKey(t *testing.T) {
 	rep := &DoctorReport{}
 	for _, name := range []string{"resolver hookup", "interface routing", "system lookup"} {
 		rep.add(Finding{Name: name, Status: "fail"})
-		rep.fixLast(autoFix(fixStart, "", "start the stack"))
+		rep.fixLast(autoFix(fixNetworkWait, "", "install the drop-in"))
 	}
 	rep.add(Finding{Name: "data dir", Status: "fail"})
 	rep.fixLast(autoFix(fixMkdir, "/x", "create it"))
@@ -81,11 +81,40 @@ func TestAutoFixesDedupesByKey(t *testing.T) {
 	if len(autos) != 2 {
 		t.Fatalf("got %d auto fixes, want 2 (one per distinct key): %+v", len(autos), autos)
 	}
-	if autos[0].Fix.Key != fixStart || autos[1].Fix.Key != fixMkdir {
+	if autos[0].Fix.Key != fixNetworkWait || autos[1].Fix.Key != fixMkdir {
 		t.Errorf("report order not preserved: %q then %q", autos[0].Fix.Key, autos[1].Fix.Key)
 	}
 	if autos[0].Name != "resolver hookup" {
 		t.Errorf("first occurrence should win, got %q", autos[0].Name)
+	}
+}
+
+// mkdir and php-rebuild reuse one key across findings that each target a
+// different directory or version; those are distinct fixes and every one must
+// survive the dedupe, or --fix silently repairs only the first.
+func TestAutoFixesKeepsSameKeyWithDistinctArgs(t *testing.T) {
+	rep := &DoctorReport{}
+	for _, dir := range []string{"/a", "/b", "/c"} {
+		rep.add(Finding{Name: "parked dir: " + dir, Status: "warn"})
+		rep.fixLast(autoFix(fixMkdir, dir, "create the parked directory"))
+	}
+	for _, v := range []string{"8.3", "8.4"} {
+		rep.add(Finding{Name: "PHP " + v + " image", Status: "fail"})
+		rep.fixLast(autoFix(fixPhpRebuild, v, "rebuild the image"))
+	}
+
+	autos := rep.AutoFixes()
+	if len(autos) != 5 {
+		t.Fatalf("got %d auto fixes, want 5 (one per distinct arg): %+v", len(autos), autos)
+	}
+	args := map[string]bool{}
+	for _, f := range autos {
+		args[f.Fix.Key+" "+f.Fix.Arg] = true
+	}
+	for _, want := range []string{"mkdir /a", "mkdir /b", "mkdir /c", "php-rebuild 8.3", "php-rebuild 8.4"} {
+		if !args[want] {
+			t.Errorf("missing fix %q from %v", want, args)
+		}
 	}
 }
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1095,6 +1095,10 @@ func startPerSiteContainers() {
 // refreshUnreferencedCustomQuadlets rewrites quadlets for globally installed
 // custom services, per-site custom containers, and per-site FrankenPHP
 // containers the earlier per-site walk would skip, so schema changes reach every managed container.
+// writeCustomFPMQuadletFn is the seam tests override to assert the refresh
+// routes a custom-FPM site to its writer without spawning podman.
+var writeCustomFPMQuadletFn = podman.WriteCustomFPMQuadlet
+
 func refreshUnreferencedCustomQuadlets(seenSvc map[string]bool, reg *config.SiteRegistry) {
 	if customs, err := config.ListCustomServices(); err == nil {
 		for _, svc := range customs {
@@ -1132,6 +1136,14 @@ func refreshUnreferencedCustomQuadlets(seenSvc map[string]bool, reg *config.Site
 			entrypoint, env := s.FrankenPHPQuadletSpec()
 			if err := podman.WriteFrankenPHPQuadlet(s.Name, s.Path, s.PHPVersion, entrypoint, env); err != nil {
 				fmt.Printf("  WARN: refreshing %s quadlet: %v\n", podman.FrankenPHPContainerName(s.Name), err)
+			}
+		case s.IsCustomFPM():
+			// Without this branch a custom-FPM site's quadlet is only rewritten on
+			// link, so an upgrade never back-fills additions to the FPM template
+			// (the shared php.ini mount from #944), and `php:ini shared` reports
+			// success while the setting silently never reaches the container.
+			if err := writeCustomFPMQuadletFn(s.Name, s.PHPVersion); err != nil {
+				fmt.Printf("  WARN: refreshing %s quadlet: %v\n", podman.CustomFPMContainerName(s.Name), err)
 			}
 		}
 	}

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -174,6 +174,33 @@ func TestFileChangedBy(t *testing.T) {
 	}
 }
 
+// An upgrade that only refreshes quadlets must rewrite a custom-FPM site's
+// quadlet too, or additions to the shared FPM template (the shared php.ini
+// mount from #944) never back-fill and `php:ini shared` silently no-ops for it.
+func TestRefreshUnreferencedCustomQuadlets_RoutesCustomFPM(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	var got []string
+	orig := writeCustomFPMQuadletFn
+	writeCustomFPMQuadletFn = func(name, version string) error {
+		got = append(got, name+"@"+version)
+		return nil
+	}
+	t.Cleanup(func() { writeCustomFPMQuadletFn = orig })
+
+	reg := &config.SiteRegistry{Sites: []config.Site{
+		{Name: "shop", Path: t.TempDir(), Runtime: "fpm-custom", PHPVersion: "8.4"},
+		{Name: "paused", Path: t.TempDir(), Runtime: "fpm-custom", PHPVersion: "8.4", Paused: true},
+	}}
+
+	refreshUnreferencedCustomQuadlets(map[string]bool{}, reg)
+
+	if len(got) != 1 || got[0] != "shop@8.4" {
+		t.Errorf("custom-FPM refresh routing = %v, want only [shop@8.4]", got)
+	}
+}
+
 func TestInstallAutostart(t *testing.T) {
 	installAutostart()
 }

--- a/internal/cli/php_shell.go
+++ b/internal/cli/php_shell.go
@@ -19,6 +19,19 @@ func NewPhpShellCmd() *cobra.Command {
 	}
 }
 
+// shellWorkDir resolves the directory the shell opens in: the worktree checkout
+// when cwd is inside one, otherwise the registered site root, otherwise cwd. A
+// worktree nested under its parent path-prefix-matches the parent in
+// SiteRootFor, so without the worktree check the shell would open the parent
+// tree while running the worktree's own PHP version and FPM image, mixing two
+// sites in one session. It resolves the site the same way version detection does.
+func shellWorkDir(cwd string) string {
+	if wt, _, ok := phpDet.WorktreeRootFor(cwd); ok {
+		return wt
+	}
+	return phpDet.SiteRootFor(cwd)
+}
+
 func runPhpShell(_ *cobra.Command, _ []string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -37,9 +50,7 @@ func runPhpShell(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	// Use the registered site root as the working directory if cwd is inside one,
-	// otherwise fall back to cwd.
-	workDir := phpDet.SiteRootFor(cwd)
+	workDir := shellWorkDir(cwd)
 
 	podman.EnsurePathMounted(workDir, version)
 	ensureServicesForCwd(workDir)

--- a/internal/cli/php_shell_test.go
+++ b/internal/cli/php_shell_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// A worktree checked out inside its parent site path-prefix-matches the parent
+// in SiteRootFor, so the shell must resolve the worktree checkout itself, or it
+// opens the parent tree while running the worktree's own PHP and FPM.
+func TestShellWorkDir_NestedWorktreeOpensTheWorktree(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	site := filepath.Join(t.TempDir(), "app")
+	wt := filepath.Join(site, "wt", "feature")
+	makeWorktree(t, site, wt, "feature")
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.5"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := shellWorkDir(wt); got != wt {
+		t.Errorf("shellWorkDir = %q, want the worktree root %q", got, wt)
+	}
+}
+
+// From inside a plain registered site the shell opens the site root, wherever in
+// the tree the command was run.
+func TestShellWorkDir_PlainSiteOpensTheSiteRoot(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	site := filepath.Join(t.TempDir(), "app")
+	sub := filepath.Join(site, "app", "Http")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.5"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := shellWorkDir(sub); got != site {
+		t.Errorf("shellWorkDir = %q, want the site root %q", got, site)
+	}
+}

--- a/internal/cli/php_shell_test.go
+++ b/internal/cli/php_shell_test.go
@@ -8,13 +8,26 @@ import (
 	"github.com/geodro/lerd/internal/config"
 )
 
+// canonicalTempDir returns a temp dir with symlinks resolved. On macOS /var is a
+// symlink to /private/var, and the site registry stores canonical paths, so a
+// raw t.TempDir() would not prefix-match the stored site path (the shape
+// os.Getwd already returns in production).
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
 // A worktree checked out inside its parent site path-prefix-matches the parent
 // in SiteRootFor, so the shell must resolve the worktree checkout itself, or it
 // opens the parent tree while running the worktree's own PHP and FPM.
 func TestShellWorkDir_NestedWorktreeOpensTheWorktree(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
-	site := filepath.Join(t.TempDir(), "app")
+	site := filepath.Join(canonicalTempDir(t), "app")
 	wt := filepath.Join(site, "wt", "feature")
 	makeWorktree(t, site, wt, "feature")
 	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.5"}); err != nil {
@@ -31,7 +44,7 @@ func TestShellWorkDir_NestedWorktreeOpensTheWorktree(t *testing.T) {
 func TestShellWorkDir_PlainSiteOpensTheSiteRoot(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
-	site := filepath.Join(t.TempDir(), "app")
+	site := filepath.Join(canonicalTempDir(t), "app")
 	sub := filepath.Join(site, "app", "Http")
 	if err := os.MkdirAll(sub, 0755); err != nil {
 		t.Fatal(err)

--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -45,6 +45,10 @@ func resolvedDropinFor(tld string) string {
 // never re-pushes DNS over the link, so the resolvectl route it carries stays put.
 const lerdNMUnmanaged = "/etc/NetworkManager/conf.d/lerd-dns-link.conf"
 
+// lerdSudoersPath is the passwordless DNS grant lerd installs. Teardown removes
+// it, so this is a package const both sides share.
+const lerdSudoersPath = "/etc/sudoers.d/lerd"
+
 // Pre-1.30 builds shipped lerd0 as an NM keyfile connection. Kept so setup can
 // migrate those hosts off it and Teardown can clean it up.
 const (
@@ -483,6 +487,12 @@ func dummyLinkNMRuleNeeded(withNM bool) bool {
 // tree on a host that has no NetworkManager at all.
 func setupDummyLink(withNM bool, tld string) error {
 	if !dummyLinkGrantsLive() {
+		// Same reasoning as the ensureDummyLinkRunning failure below: a host that
+		// once set lerd0 up still carries the fallback drop-in, and lerd0 down with
+		// fallbacks off is the exact state the guard exists to prevent. An upgrade
+		// that adds a grant lands here until `lerd install` runs, so hand the
+		// fallbacks back rather than leaving offline lookups hanging every run.
+		restoreResolvedFallbacks()
 		return fmt.Errorf("sudoers drop-in is out of date, run `lerd install` to refresh it")
 	}
 	// Migrate hosts that got lerd0 as an NM keyfile connection from a pre-release
@@ -911,6 +921,19 @@ func Teardown() {
 	} else if isSystemdResolvedActive() {
 		exec.Command("sudo", "systemctl", "restart", "systemd-resolved").Run() //nolint:errcheck
 	}
+
+	// The passwordless grant goes last, once nothing above still depends on it.
+	// Left behind, it is a standing NOPASSWD root grant (a root-run dispatcher
+	// script, resolvectl, NetworkManager restart) for a tool that is being
+	// removed, which is exactly what the teardown exists to undo.
+	if _, err := os.Stat(lerdSudoersPath); err == nil {
+		rmCmd := exec.Command("sudo", "rm", "-f", lerdSudoersPath)
+		rmCmd.Stdin = os.Stdin
+		rmCmd.Stdout = os.Stdout
+		rmCmd.Stderr = os.Stderr
+		rmCmd.Run() //nolint:errcheck
+		ForgetSudoersMarker()
+	}
 }
 
 // InstallSudoers writes a sudoers drop-in granting the current user passwordless
@@ -927,13 +950,12 @@ func InstallSudoers() error {
 
 	content := renderLinuxSudoers(user)
 
-	const sudoersPath = "/etc/sudoers.d/lerd"
 	if sudoersInstalled([]byte(content)) {
 		return nil
 	}
 
 	feedback.Sudo("Installing DNS sudoers rule")
-	if err := sudoWriteFile(sudoersPath, []byte(content), 0440); err != nil {
+	if err := sudoWriteFile(lerdSudoersPath, []byte(content), 0440); err != nil {
 		return fmt.Errorf("writing sudoers drop-in: %w", err)
 	}
 	recordSudoersInstalled([]byte(content))

--- a/internal/dns/setup_test.go
+++ b/internal/dns/setup_test.go
@@ -615,6 +615,34 @@ func TestTeardown_removesFallbackDropin(t *testing.T) {
 	}
 }
 
+// Left behind, /etc/sudoers.d/lerd is a standing NOPASSWD root grant (resolvectl,
+// a root-run NM dispatcher script, restarting NetworkManager) for a tool being
+// removed, so Teardown must delete it. It has to go last, once nothing above
+// still depends on the grants it provides.
+func TestTeardown_removesTheSudoersGrant(t *testing.T) {
+	src, err := os.ReadFile("setup.go")
+	if err != nil {
+		t.Fatalf("reading setup.go: %v", err)
+	}
+	_, teardown, found := strings.Cut(string(src), "func Teardown()")
+	if !found {
+		t.Fatal("Teardown not found in setup.go")
+	}
+	if !strings.Contains(teardown, "lerdSudoersPath") {
+		t.Fatal("Teardown must remove /etc/sudoers.d/lerd, or uninstalling lerd leaves a passwordless root grant behind")
+	}
+	sudoersAt := strings.Index(teardown, "lerdSudoersPath")
+	resolverAt := strings.LastIndex(teardown, `"restart", "systemd-resolved"`)
+	nmAt := strings.LastIndex(teardown, `"restart", "NetworkManager"`)
+	last := resolverAt
+	if nmAt > last {
+		last = nmAt
+	}
+	if last >= 0 && sudoersAt < last {
+		t.Error("the sudoers removal must come after the granted resolver/NetworkManager restarts, or it revokes the grants those steps still need")
+	}
+}
+
 // The write is guarded on the link coming up, but nothing ever walked it back. A
 // host that had lerd0 and lost it (dummy module dropped by a kernel update, unit
 // removed by hand) keeps the drop-in from the run that worked, and is left with
@@ -649,6 +677,26 @@ func TestSetupDummyLink_handsTheFallbacksBackWhenTheLinkStopsWorking(t *testing.
 	sudoers := renderLinuxSudoers("alice")
 	assertContains(t, sudoers, "/usr/bin/rm -f /etc/systemd/resolved.conf.d/lerd-fallback.conf")
 	assertContains(t, sudoers, "/usr/bin/systemctl restart systemd-resolved")
+}
+
+// The grants-out-of-date early return must hand the fallbacks back too. An
+// upgrade that adds a required grant lands here until `lerd install` runs, and a
+// host that already had lerd0 still carries the fallback drop-in, so bailing
+// without restoring leaves resolved's fallbacks off with no lerd0, hanging every
+// offline lookup, with no later run repairing it because each takes the same
+// early return.
+func TestSetupDummyLink_handsTheFallbacksBackWhenTheGrantsAreStale(t *testing.T) {
+	src, err := os.ReadFile("setup.go")
+	if err != nil {
+		t.Fatalf("reading setup.go: %v", err)
+	}
+	guard := section(t, string(src), "if !dummyLinkGrantsLive() {", "// Migrate hosts")
+	assertContains(t, guard, "restoreResolvedFallbacks()")
+	restoreAt := strings.Index(guard, "restoreResolvedFallbacks()")
+	returnAt := strings.Index(guard, "return fmt.Errorf")
+	if returnAt < 0 || restoreAt > returnAt {
+		t.Error("the restore must run before the early return, not after it")
+	}
 }
 
 // The link and everything that reads it must agree on the TLD. lerd supports a

--- a/internal/podman/mountprune.go
+++ b/internal/podman/mountprune.go
@@ -60,10 +60,12 @@ func staleSelfMount(line string) (string, bool) {
 	return src, true
 }
 
-// RepairMissingMounts drops stale bind mounts from every quadlet on disk before
+// RepairMissingMounts drops stale bind mounts from lerd's own quadlets before
 // the units are started, and reports what was removed so the caller can name the
-// project responsible. Containers already running keep their mounts until their
-// next restart, which is when the quadlet is read again.
+// project responsible. Only lerd- prefixed units are touched: the quadlet
+// directory is shared with whatever else the user runs there, and a foreign
+// quadlet's mount is not lerd's to rewrite. Containers already running keep their
+// mounts until their next restart, which is when the quadlet is read again.
 func RepairMissingMounts() []MountRepair {
 	dir := config.QuadletDir()
 	entries, err := os.ReadDir(dir)
@@ -73,7 +75,7 @@ func RepairMissingMounts() []MountRepair {
 	var repairs []MountRepair
 	for _, e := range entries {
 		name := e.Name()
-		if e.IsDir() || !strings.HasSuffix(name, ".container") {
+		if e.IsDir() || !strings.HasPrefix(name, "lerd-") || !strings.HasSuffix(name, ".container") {
 			continue
 		}
 		path := filepath.Join(dir, name)

--- a/internal/podman/mountprune_test.go
+++ b/internal/podman/mountprune_test.go
@@ -84,10 +84,14 @@ func TestRepairMissingMounts(t *testing.T) {
 	}
 	stale := "[Container]\nVolume=%h:%h:ro\nVolume=" + missing + ":" + missing + ":rw\n"
 	healthy := "[Container]\nVolume=%h:%h:ro\nVolume=" + site + ":" + site + ":rw\n"
+	// A user's own quadlet in the shared directory carries a stale mount too; it
+	// is not lerd's to rewrite, so the sweep must leave it exactly as found.
+	foreign := "[Container]\nVolume=" + missing + ":" + missing + ":rw\n"
 	for name, content := range map[string]string{
 		"lerd-nginx.container":     stale,
 		"lerd-php85-fpm.container": stale,
 		"lerd-mysql.container":     healthy,
+		"backup.container":         foreign,
 	} {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
 			t.Fatal(err)
@@ -127,6 +131,13 @@ func TestRepairMissingMounts(t *testing.T) {
 	}
 	if string(got) != healthy {
 		t.Errorf("healthy quadlet was rewritten:\n%s", got)
+	}
+	gotForeign, err := os.ReadFile(filepath.Join(dir, "backup.container"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotForeign) != foreign {
+		t.Errorf("foreign quadlet was rewritten:\n%s", gotForeign)
 	}
 	if reloads != 1 {
 		t.Errorf("daemon reloads = %d, want 1", reloads)

--- a/internal/podman/quadlet_embed_test.go
+++ b/internal/podman/quadlet_embed_test.go
@@ -789,4 +789,11 @@ func TestDNSQuadletHasNoStartRateLimit(t *testing.T) {
 	if !strings.Contains(tpl, "StartLimitIntervalSec=0") {
 		t.Errorf("lerd-dns must disable the start rate limit:\n%s", tpl)
 	}
+	// The directive only works in [Unit]; systemd ignores it under [Service],
+	// which is exactly how #1087 shipped broken. Assert its section, not just
+	// its presence.
+	unit, _, found := strings.Cut(tpl, "[Container]")
+	if !found || !strings.Contains(unit, "StartLimitIntervalSec=0") {
+		t.Errorf("StartLimitIntervalSec must sit in [Unit], not a later section:\n%s", tpl)
+	}
 }

--- a/internal/podman/quadlets/lerd-dns.container
+++ b/internal/podman/quadlets/lerd-dns.container
@@ -1,6 +1,11 @@
 [Unit]
 Description=Lerd DNS (dnsmasq)
 After=network.target
+# The NetworkManager dispatcher restarts this unit on every interface event, so a
+# resume that brings several links back at once outruns systemd's default start
+# rate limit and parks lerd-dns in failed until the user runs `lerd start`. This
+# only takes effect in [Unit]; systemd ignores it under [Service].
+StartLimitIntervalSec=0
 
 [Container]
 Image=lerd-dnsmasq:local
@@ -13,10 +18,6 @@ Exec=dnsmasq --no-daemon --conf-dir=/etc/dnsmasq.d
 [Service]
 Restart=always
 TimeoutStartSec=300
-# The NetworkManager dispatcher restarts this unit on every interface event, so a
-# resume that brings several links back at once outruns systemd's default start
-# rate limit and parks lerd-dns in failed until the user runs `lerd start`.
-StartLimitIntervalSec=0
 
 [Install]
 WantedBy=default.target

--- a/internal/ui/web/src/lib/notify.test.ts
+++ b/internal/ui/web/src/lib/notify.test.ts
@@ -140,6 +140,49 @@ describe('notify dispatcher', () => {
     expect(get(notificationHistory)).toHaveLength(1);
   });
 
+  // Under the native sink the browser prefs have no UI, so they must not gate
+  // the bell: a kind the browser prefs default off (or the user turned off
+  // before switching to native) still reaches the notification centre when the
+  // daemon delivers it natively (#968 regression).
+  it('records to the bell under the native sink even when browser prefs are off', async () => {
+    const { initNotify, notifyDelivery, notifyNativeKinds, setNotifyPref, notificationHistory } =
+      await import('./notify');
+    const { wsMessage } = await import('./ws');
+
+    initNotify();
+    notifyDelivery.set('native');
+    notifyNativeKinds.set({ mail: true });
+    setNotifyPref('mail', false); // browser pref off, unreachable in native mode
+
+    wsMessage.set({
+      type: 'notification',
+      notification: { kind: 'mail', title: 'New email: Welcome' }
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(get(notificationHistory)).toHaveLength(1);
+  });
+
+  it('drops a kind the daemon suppresses natively', async () => {
+    const { initNotify, notifyDelivery, notifyNativeKinds, notificationHistory } =
+      await import('./notify');
+    const { wsMessage } = await import('./ws');
+
+    initNotify();
+    notifyDelivery.set('native');
+    notifyNativeKinds.set({ dump: false });
+
+    wsMessage.set({
+      type: 'notification',
+      notification: { kind: 'dump', title: 'ray()' }
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(get(notificationHistory)).toHaveLength(0);
+  });
+
   it('still raises it on the desktop under the browser sink', async () => {
     const { initNotify, notifyDelivery } = await import('./notify');
     const { wsMessage } = await import('./ws');

--- a/internal/ui/web/src/lib/notify.ts
+++ b/internal/ui/web/src/lib/notify.ts
@@ -284,9 +284,20 @@ function isFailure(evt: NotificationEvent): boolean {
 
 async function fireNotification(evt: NotificationEvent) {
   const prefs = get(notifyPrefs);
+  const native = get(notifyDelivery) === 'native';
   const failed = isFailure(evt);
-  if (!failed && !prefs.enabled) return;
-  if (!failed && prefs.kinds[evt.kind as NotifyKind] === false) return;
+  // A failure is always delivered. Otherwise the gate follows the active sink:
+  // under native the daemon's resolved per-kind prefs decide, and the browser
+  // prefs (which have no UI in native mode) must not act as a phantom filter
+  // that keeps the desktop popup but silently empties the bell.
+  if (!failed) {
+    if (native) {
+      if (get(notifyNativeKinds)[evt.kind] === false) return;
+    } else {
+      if (!prefs.enabled) return;
+      if (prefs.kinds[evt.kind as NotifyKind] === false) return;
+    }
+  }
   if (evt.tag) {
     const key = evt.kind + ' ' + evt.tag;
     const now = Date.now();
@@ -352,13 +363,24 @@ export const notifyDelivery = writable<'browser' | 'native'>('browser');
 // the lerd:// handler, so the web UI can offer "Open in app".
 export const desktopAppInstalled = writable<boolean>(false);
 
+// notifyNativeKinds mirrors the daemon's resolved per-kind native prefs. Under
+// the native sink the browser prefs are hidden, so the bell and toasts must
+// follow these instead: a kind the daemon posts to the desktop is one the bell
+// should keep, and one it suppresses is one the bell should drop.
+export const notifyNativeKinds = writable<Record<string, boolean>>({});
+
 export async function loadNotifyDelivery() {
   try {
     const r = await apiFetch('/api/notifications/target');
     if (r.ok) {
-      const d = (await r.json()) as { target?: string; app_installed?: boolean };
+      const d = (await r.json()) as {
+        target?: string;
+        app_installed?: boolean;
+        kinds?: Record<string, boolean>;
+      };
       notifyDelivery.set(d.target === 'native' ? 'native' : 'browser');
       desktopAppInstalled.set(!!d.app_installed);
+      notifyNativeKinds.set(d.kinds ?? {});
     }
   } catch {
     /* keep browser default */

--- a/internal/ui/web/src/tabs/services/ServiceDetail.stub.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceDetail.stub.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  // Generic stand-in for ServiceDetail's heavy children (log SSE, database
+  // fetches) so the tab-visibility tests mount without their IO.
+  const {} = $props();
+</script>
+
+<div data-testid="child-stub"></div>

--- a/internal/ui/web/src/tabs/services/ServiceDetail.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceDetail.svelte
@@ -11,6 +11,7 @@
   import ServiceDatabasesTab from './ServiceDatabasesTab.svelte';
   import PresetSuggestionBanner from './PresetSuggestionBanner.svelte';
   import { isServiceWorker, type Service } from '$stores/services';
+  import { accessMode } from '$stores/accessMode';
   import { m } from '../../paraglide/messages.js';
 
   interface Props {
@@ -30,8 +31,12 @@
   const hasTools = $derived(Boolean(svc.client_shims && svc.client_shims.length > 0));
   // Workers publish nothing, so the ports tab tracks the header gear's old guard.
   const hasPorts = $derived(!isServiceWorker(svc));
+  // The whole databases surface (the /api/databases subtree) is loopback-only,
+  // so on a LAN-exposed dashboard the tab would report a running engine as
+  // stopped and silently 403 every action. Hide it off the lerd host entirely.
+  const hasDatabases = $derived(svc.is_database && $accessMode.loopback);
   const tabs = $derived<TabItem<TabId>[]>([
-    { id: 'databases', label: m.databases_title(), hidden: !svc.is_database },
+    { id: 'databases', label: m.databases_title(), hidden: !hasDatabases },
     { id: 'logs', label: m.services_tabs_logs() },
     { id: 'env', label: m.services_env_title(), hidden: !hasEnv },
     { id: 'config', label: m.services_tabs_tuning(), hidden: !svc.tunable },
@@ -42,13 +47,13 @@
   // Selecting a different service resets to its default tab; within one service
   // the user's tab choice sticks, falling back off any tab hidden for it.
   $effect(() => {
-    const fallback: TabId = svc.is_database ? 'databases' : 'logs';
+    const fallback: TabId = hasDatabases ? 'databases' : 'logs';
     if (svc.name !== shownService) {
       shownService = svc.name;
       active = fallback;
       return;
     }
-    if (active === 'databases' && !svc.is_database) active = fallback;
+    if (active === 'databases' && !hasDatabases) active = fallback;
     if (active === 'env' && !hasEnv) active = fallback;
     if (active === 'config' && !svc.tunable) active = fallback;
     if (active === 'tools' && !hasTools) active = fallback;

--- a/internal/ui/web/src/tabs/services/ServiceDetail.test.ts
+++ b/internal/ui/web/src/tabs/services/ServiceDetail.test.ts
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// The children do IO on mount (log SSE, the loopback-only databases fetch);
+// swap them for stubs so these tests stay on the tab-visibility logic.
+import { vi } from 'vitest';
+vi.mock('./ServiceHeader.svelte', () => import('./ServiceDetail.stub.svelte'));
+vi.mock('./ServiceSiteBadges.svelte', () => import('./ServiceDetail.stub.svelte'));
+vi.mock('./PresetSuggestionBanner.svelte', () => import('./ServiceDetail.stub.svelte'));
+vi.mock('./ServiceDatabasesTab.svelte', () => import('./ServiceDetail.stub.svelte'));
+vi.mock('$components/LogViewer.svelte', () => import('./ServiceDetail.stub.svelte'));
+
+import ServiceDetail from './ServiceDetail.svelte';
+import { accessMode } from '$stores/accessMode';
+import type { Service } from '$stores/services';
+
+function dbService(): Service {
+  return {
+    name: 'mysql',
+    status: 'active',
+    site_count: 0,
+    preset_owned: true,
+    is_database: true
+  } as Service;
+}
+
+describe('ServiceDetail databases tab', () => {
+  beforeEach(() => accessMode.set({ loopback: true, lanExposed: false, checked: true }));
+
+  it('shows the Databases tab on the loopback host', () => {
+    const { getByRole } = render(ServiceDetail, { props: { svc: dbService() } });
+    expect(getByRole('button', { name: 'Databases' })).toBeInTheDocument();
+  });
+
+  // The whole /api/databases subtree is loopback-only, so on a LAN-exposed
+  // dashboard the tab would report a running engine as stopped and 403 every
+  // action. It must be hidden there instead.
+  it('hides the Databases tab on a LAN-exposed dashboard', () => {
+    accessMode.set({ loopback: false, lanExposed: true, checked: true });
+    const { queryByRole } = render(ServiceDetail, { props: { svc: dbService() } });
+    expect(queryByRole('button', { name: 'Databases' })).toBeNull();
+  });
+});

--- a/internal/ui/web/src/tabs/system/NotificationsDetail.svelte
+++ b/internal/ui/web/src/tabs/system/NotificationsDetail.svelte
@@ -15,6 +15,7 @@
     autoSubscribeDisabled,
     detectBrowserFamily,
     notifyDelivery,
+    notifyNativeKinds,
     ALL_KINDS,
     type NotifyKind
   } from '$lib/notify';
@@ -71,6 +72,7 @@
         nativeSupported = !!d.native_supported;
         nativeKinds = d.kinds ?? {};
         notifyDelivery.set(deliveryTarget);
+        notifyNativeKinds.set(nativeKinds);
       }
     } catch {
       /* keep browser default */
@@ -95,6 +97,7 @@
     } catch {
       nativeKinds = { ...nativeKinds, [kind]: prev };
     }
+    notifyNativeKinds.set(nativeKinds);
   }
 
   async function setDelivery(target: 'browser' | 'native') {

--- a/internal/ui/ws.go
+++ b/internal/ui/ws.go
@@ -112,7 +112,9 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	defer ws.Close()
+	// The socket is closed by the reader-coordinating cleanup below, once the
+	// reader goroutine exists; until then there is no return path that leaves it
+	// open, so there is nothing to defer here.
 
 	// All frame writes funnel through these helpers: the reader goroutine
 	// writes pong/close frames while the main loop writes snapshots and pings,
@@ -152,45 +154,22 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 	snapshots.Invalidate(eventbus.KindServices)
 	snapshots.Invalidate(eventbus.KindStatus)
 
-	// Initial snapshot: assemble one JSON object containing all kinds.
-	initial := assembleSnapshot(
-		snapshots.Sites(),
-		snapshots.Services(),
-		snapshots.Status(),
-		snapshots.UnhealthyWorkers(),
-		buildDumpsStatusJSON(),
-		buildDevtoolsStatusJSON(),
-		buildProfilerStatusJSON(),
-		nil,
-		[]string{"snapshot"},
-	)
-	if err := sendText(initial); err != nil {
-		return
-	}
-
 	// connVisible tracks whether THIS connection is currently counted as
-	// visible. Only the reader goroutine writes it; the deferred cleanup
-	// reads it after the reader has exited (close(done) happens-before the
-	// <-done branch), so there is no data race.
+	// visible. Only the reader goroutine writes connVisible/connFocused; the
+	// cleanup below reads them only after closing the socket and waiting for the
+	// reader to exit, so there is no data race and no lost decrement.
 	connVisible := true
 	noteVisibility(true)
 	// Focus starts false: a freshly opened connection has not told us yet, and
 	// assuming focus would silence desktop notifications for a window that is
 	// merely open. The client sends its state right after the socket opens.
 	connFocused := false
-	defer func() {
-		if connVisible {
-			noteVisibility(false)
-		}
-		if connFocused {
-			noteFocus(false)
-		}
-	}()
 
 	// Reader goroutine: handle ping/pong/close/visibility frames. The read
 	// deadline is reset before every frame; if the client falls silent
 	// (suspended tab, half-open TCP), ReadFrame returns a timeout error and
-	// the goroutine exits, which triggers the deferred cleanup below.
+	// the goroutine exits, which triggers the deferred cleanup below. Started
+	// before the initial snapshot so every return path can join it.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -232,6 +211,38 @@ func handleWS(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}()
+
+	// Close the socket to unblock the reader's ReadFrame, wait for it to exit,
+	// then decrement. Closing first is what guarantees the reader is done
+	// touching connVisible/connFocused before this reads them, on every return
+	// path (broker channel closed, a failed write, a ping error), not only the
+	// main loop's done branch.
+	defer func() {
+		ws.Close()
+		<-done
+		if connVisible {
+			noteVisibility(false)
+		}
+		if connFocused {
+			noteFocus(false)
+		}
+	}()
+
+	// Initial snapshot: assemble one JSON object containing all kinds.
+	initial := assembleSnapshot(
+		snapshots.Sites(),
+		snapshots.Services(),
+		snapshots.Status(),
+		snapshots.UnhealthyWorkers(),
+		buildDumpsStatusJSON(),
+		buildDevtoolsStatusJSON(),
+		buildProfilerStatusJSON(),
+		nil,
+		[]string{"snapshot"},
+	)
+	if err := sendText(initial); err != nil {
+		return
+	}
 
 	pingTicker := time.NewTicker(wsPingInterval)
 	defer pingTicker.Stop()

--- a/internal/ui/ws_focus_cleanup_test.go
+++ b/internal/ui/ws_focus_cleanup_test.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The focus/visibility decrement in handleWS reads connFocused/connVisible,
+// which only the reader goroutine writes. If the cleanup runs while the reader
+// is still live, a lost focus decrement leaves focusedClients above zero for the
+// life of the process and silences every native notification and web push. The
+// cleanup therefore has to close the socket (to unblock ReadFrame) and join the
+// reader (<-done) before it reads the flags. This pins that ordering so a
+// refactor that reintroduces the race fails here rather than in the field.
+func TestHandleWS_cleanupJoinsReaderBeforeReadingFocusFlags(t *testing.T) {
+	src, err := os.ReadFile("ws.go")
+	if err != nil {
+		t.Fatalf("reading ws.go: %v", err)
+	}
+	body := string(src)
+
+	closeAt := strings.Index(body, "ws.Close()")
+	// The join after the close, so the match is the code and not the comment
+	// above the cleanup that mentions the reader's done channel in prose.
+	joinAt := -1
+	if closeAt >= 0 {
+		if rel := strings.Index(body[closeAt:], "<-done"); rel >= 0 {
+			joinAt = closeAt + rel
+		}
+	}
+	focusAt := strings.Index(body, "noteFocus(false)")
+	visibleAt := strings.Index(body, "noteVisibility(false)")
+
+	if closeAt < 0 || joinAt < 0 || focusAt < 0 || visibleAt < 0 {
+		t.Fatal("handleWS cleanup must close the socket, join the reader, then decrement focus and visibility")
+	}
+	if !(closeAt < joinAt && joinAt < focusAt && joinAt < visibleAt) {
+		t.Errorf("cleanup order is wrong: close=%d join=%d focus=%d visible=%d; the join must sit after the close and before both decrements",
+			closeAt, joinAt, focusAt, visibleAt)
+	}
+	// A standalone `defer ws.Close()` up top would run last and defeat the join,
+	// so the socket close must live inside the coordinated cleanup, not on its own.
+	if strings.Contains(body, "\tdefer ws.Close()") {
+		t.Error("ws.Close must run inside the reader-joining cleanup, not as a standalone top-level defer")
+	}
+}

--- a/tests/installer/installer.bats
+++ b/tests/installer/installer.bats
@@ -501,6 +501,14 @@ _stub_dns_files() {
   [[ "$output" == *"only root can remove it"* ]]
 }
 
+@test "lerd_dns_cleanup_hint lists the sudoers grant for hand removal" {
+  # The passwordless DNS grant is a root-owned file the setup writes; left
+  # behind it is a standing NOPASSWD root grant for a tool being removed.
+  [[ " ${LERD_DNS_FILES[*]} " == *" /etc/sudoers.d/lerd "* ]]
+  run lerd_dns_cleanup_hint
+  [[ "$output" == *"/etc/sudoers.d/lerd"* ]]
+}
+
 @test "uninstall_linux_dns stays quiet when lerd never configured DNS" {
   local d; d="$(_fake_lerd_dir)"
   PATH="$d:$PATH"


### PR DESCRIPTION
Podman start no longer rewrites quadlets lerd does not own. The missing-mount sweep walked every container file in the shared user quadlet directory and dropped any self bind mount whose host source had gone, so a start could permanently edit a container file another tool owns and never restore it. It scopes to lerd- prefixed units now, matching the cleanup scan, and still prunes lerd own stale mounts.

The DNS unit start rate-limit override takes effect now. StartLimitIntervalSec sat in the Service section, where systemd ignores it, so a resume that restarted lerd-dns several times in a few seconds still exhausted the default limit and parked the unit in failed with .test dark. It moves to the Unit section where the directive belongs.

Uninstall removes the passwordless DNS sudoers grant. The teardown and the installer left the drop-in behind, a standing NOPASSWD root grant for a tool being removed. Teardown deletes it last, once nothing above still needs it, and the installer lists it in the by-hand cleanup path.

doctor fix applies every automatic fix rather than one per key. The dedupe keyed on the fix key alone and collapsed the per-directory mkdir and per-version rebuild fixes to a single entry, so several missing directories or images needed the command run again. It keys on the fix and its argument now.

The doctor network-online repair stays in the no-privilege tier. It re-entered lerd start, which reconfigures the resolver through sudo, so under the non-interactive fix path it could rewrite systemd-resolved unattended. It installs the user drop-in directly, and the start fix that carried the privilege is gone.

The offline .test fallback is handed back on the grants-out-of-date path too, so a host that loses a grant after an upgrade is not left with resolved fallbacks off and no lerd0, hanging every offline lookup.

An upgraded custom-FPM site quadlet is refreshed on install. The refresh had no custom-FPM branch, so an addition to the shared template never back-filled and the shared php.ini reported success while never reaching the container.

lerd shell in a nested worktree opens the worktree, not its parent. The working directory resolved to the parent site root while the PHP version resolved to the worktree own pin, so the shell sat in one project running another PHP.

The dashboard websocket no longer loses a focus decrement. A client dropped in the middle of a focus change could leave the focused count above zero for the life of the process, silencing every native notification and web push. Cleanup closes the socket and joins the reader before reading the flags.

Under the native notification sink the bell records what the daemon delivers. Page-side delivery was gated on the browser prefs, which native mode hides, so a category the daemon posted to the desktop never reached the notification centre. It follows the daemon resolved per-kind prefs now.

The Databases tab is hidden on a LAN-exposed dashboard, where its loopback-only endpoints returned a forbidden response and made a running engine read as stopped with every action silently failing.

Closes #1093