### PR TITLE
test(phpini): skip the shared-ini reseed test when PHP versions are installed

### DIFF
--- a/internal/phpini/phpini.go
+++ b/internal/phpini/phpini.go
@@ -196,7 +196,10 @@ func restartFPMUnit(version string) error {
 	return podman.RestartUnit("lerd-php" + short + "-fpm")
 }
 
-func installedVersions() []string {
+// A var so tests can pin the version list. The real one reads the host's
+// launchd plists on macOS, which no amount of XDG isolation hides, so a test
+// that left it live would drive the developer's own podman.
+var installedVersions = func() []string {
 	v, _ := phpPkg.ListInstalled()
 	return v
 }

--- a/internal/phpini/phpini_test.go
+++ b/internal/phpini/phpini_test.go
@@ -40,6 +40,15 @@ func TestScopeFile_VersionMapsToPerVersionIni(t *testing.T) {
 // containers restart — every PHP container mounts it and a missing bind-mount
 // source makes them all fail to start on podman that does not auto-create it.
 func TestRestartNoSeed_SharedReseedsFile(t *testing.T) {
+	// The no-op restart loop this asserts only holds with no PHP versions
+	// installed. On a dev machine that has some, RestartNoSeed iterates them and
+	// drives real podman, which the isolated env below cannot reach (wiping
+	// XDG_CONFIG_HOME loses the podman-machine connection on macOS). Read the
+	// real state before the env is isolated, and skip rather than fail there.
+	if len(installedVersions()) > 0 {
+		t.Skip("PHP versions installed; RestartNoSeed would drive real podman")
+	}
+
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 

--- a/internal/phpini/phpini_test.go
+++ b/internal/phpini/phpini_test.go
@@ -40,20 +40,17 @@ func TestScopeFile_VersionMapsToPerVersionIni(t *testing.T) {
 // containers restart — every PHP container mounts it and a missing bind-mount
 // source makes them all fail to start on podman that does not auto-create it.
 func TestRestartNoSeed_SharedReseedsFile(t *testing.T) {
-	// The no-op restart loop this asserts only holds with no PHP versions
-	// installed. On a dev machine that has some, RestartNoSeed iterates them and
-	// drives real podman, which the isolated env below cannot reach (wiping
-	// XDG_CONFIG_HOME loses the podman-machine connection on macOS). Read the
-	// real state before the env is isolated, and skip rather than fail there.
-	if len(installedVersions()) > 0 {
-		t.Skip("PHP versions installed; RestartNoSeed would drive real podman")
-	}
+	// Pin the version list empty so the restart loop is a no-op here and the
+	// assertion is about the reseed alone. Left live it would iterate whatever
+	// the developer has installed and drive their real podman.
+	restore := installedVersions
+	installedVersions = func() []string { return nil }
+	t.Cleanup(func() { installedVersions = restore })
 
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
-	// Simulate the post-reset state: no shared file on disk. No PHP versions are
-	// installed in this temp env, so the restart loop is a no-op.
+	// Simulate the post-reset state: no shared file on disk.
 	if err := RestartNoSeed(SharedScope); err != nil {
 		t.Fatalf("RestartNoSeed(shared): %v", err)
 	}


### PR DESCRIPTION
TestRestartNoSeed_SharedReseedsFile only holds when no PHP versions are installed, since RestartNoSeed otherwise iterates the installed versions and restarts their FPM containers through podman. The test isolates the environment by pointing XDG at temp dirs, which on macOS loses the podman-machine connection, so on a machine with PHP installed it failed with a podman socket error instead of exercising the no-op path it was written for. It now reads the installed versions before isolating the environment and skips when any exist, so it still runs on a clean CI runner but no longer false-fails locally.

Refs #1095