### PR TITLE
fix(dns): actually remove the passwordless sudoers grant on teardown

### DIFF
--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -926,14 +926,34 @@ func Teardown() {
 	// Left behind, it is a standing NOPASSWD root grant (a root-run dispatcher
 	// script, resolvectl, NetworkManager restart) for a tool that is being
 	// removed, which is exactly what the teardown exists to undo.
-	if _, err := os.Stat(lerdSudoersPath); err == nil {
-		rmCmd := exec.Command("sudo", "rm", "-f", lerdSudoersPath)
-		rmCmd.Stdin = os.Stdin
-		rmCmd.Stdout = os.Stdout
-		rmCmd.Stderr = os.Stderr
-		rmCmd.Run() //nolint:errcheck
-		ForgetSudoersMarker()
+	removeSudoersGrant()
+}
+
+// runSudoersRemoval is the seam tests override.
+var runSudoersRemoval = defaultRunSudoersRemoval
+
+func defaultRunSudoersRemoval(path string) {
+	rmCmd := exec.Command("sudo", "rm", "-f", path)
+	rmCmd.Stdin = os.Stdin
+	rmCmd.Stdout = os.Stdout
+	rmCmd.Stderr = os.Stderr
+	rmCmd.Run() //nolint:errcheck
+}
+
+// removeSudoersGrant deletes the passwordless drop-in, reporting whether it
+// tried. It keys on the user-owned marker rather than stat'ing the drop-in:
+// /etc/sudoers.d is 0750 root-only on Fedora and Arch, so the stat fails with
+// EACCES there and the removal never ran. The marker is the same record
+// InstallSudoers already keeps for exactly this reason, and its absence means
+// lerd never installed a drop-in, so there is nothing to remove and no grant
+// that would make the sudo passwordless.
+func removeSudoersGrant() bool {
+	if _, err := os.Stat(sudoersMarkerPath()); err != nil {
+		return false
 	}
+	runSudoersRemoval(lerdSudoersPath)
+	ForgetSudoersMarker()
+	return true
 }
 
 // InstallSudoers writes a sudoers drop-in granting the current user passwordless
@@ -1020,7 +1040,10 @@ func renderLinuxSudoers(user string) string {
 			"%s ALL=(root) NOPASSWD: /usr/bin/rm -f /etc/NetworkManager/conf.d/lerd-dns-link.conf\n"+
 			"%s ALL=(root) NOPASSWD: /usr/bin/rm -f /etc/NetworkManager/conf.d/lerd.conf\n"+
 			"%s ALL=(root) NOPASSWD: /usr/bin/rm -f /etc/NetworkManager/dnsmasq.d/lerd.conf\n"+
-			"%s ALL=(root) NOPASSWD: /usr/bin/rm -f /etc/NetworkManager/dispatcher.d/99-lerd-dns\n",
-		user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user,
+			"%s ALL=(root) NOPASSWD: /usr/bin/rm -f /etc/NetworkManager/dispatcher.d/99-lerd-dns\n"+
+			// The drop-in permits its own removal, so teardown can revoke the
+			// grant without a password prompt an unattended uninstall cannot answer.
+			"%s ALL=(root) NOPASSWD: /usr/bin/rm -f "+lerdSudoersPath+"\n",
+		user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user, user,
 	)
 }

--- a/internal/dns/setup_common.go
+++ b/internal/dns/setup_common.go
@@ -62,7 +62,7 @@ var sudoProbe = defaultSudoProbe
 // to the content marker so a working setup is never needlessly reinstalled.
 func defaultSudoProbe() (permitted, conclusive bool) {
 	var stderr bytes.Buffer
-	cmd := exec.Command("sudo", "-n", "-l", sudoersProbeCommand)
+	cmd := sudoProbeCmd()
 	cmd.Stderr = &stderr
 	if cmd.Run() == nil {
 		return true, true
@@ -71,6 +71,35 @@ func defaultSudoProbe() (permitted, conclusive bool) {
 		return false, true
 	}
 	return false, false
+}
+
+// sudoProbeCmd builds the probe. It runs the granted command rather than listing
+// it with `sudo -l`, because listing reports whether the command is permitted at
+// all, which is true for anyone carrying a broader password-requiring rule like
+// ALL=(ALL) ALL, so the listing succeeded while running it still prompted.
+// Running the command is the only thing that answers the question being asked.
+// resolvectl --version touches nothing.
+func sudoProbeCmd() *exec.Cmd {
+	cmd := exec.Command("sudo", "-n", sudoersProbeCommand, "--version")
+	cmd.Env = cLocaleEnv(os.Environ())
+	return cmd
+}
+
+// cLocaleEnv returns environ with the locale pinned to C, so sudo's refusal is
+// the English text the parser expects rather than a translation. The inherited
+// locale variables are dropped rather than overridden, because glibc's getenv
+// returns the first match and an appended value would be shadowed by the one
+// already there.
+func cLocaleEnv(environ []string) []string {
+	out := make([]string, 0, len(environ)+2)
+	for _, kv := range environ {
+		name, _, ok := strings.Cut(kv, "=")
+		if ok && (name == "LANG" || name == "LANGUAGE" || strings.HasPrefix(name, "LC_")) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "LC_ALL=C", "LANG=C")
 }
 
 // sudoRefusalIsConclusive reports whether sudo's refusal proves the passwordless

--- a/internal/dns/setup_common.go
+++ b/internal/dns/setup_common.go
@@ -57,9 +57,9 @@ var sudoProbe = defaultSudoProbe
 
 // defaultSudoProbe asks sudo, without prompting, whether the invoking user may
 // run the granted command passwordless. Exit 0 means the grant is live (from the
-// drop-in or a broader rule); a "password is required" refusal means it is gone;
-// anything else (no sudo, an unsupported flag) is inconclusive and defers to the
-// content marker so a working setup is never needlessly reinstalled.
+// drop-in or a broader rule); a refusal that asks for credentials means it is
+// gone; anything else (no sudo, an unsupported flag) is inconclusive and defers
+// to the content marker so a working setup is never needlessly reinstalled.
 func defaultSudoProbe() (permitted, conclusive bool) {
 	var stderr bytes.Buffer
 	cmd := exec.Command("sudo", "-n", "-l", sudoersProbeCommand)
@@ -67,10 +67,22 @@ func defaultSudoProbe() (permitted, conclusive bool) {
 	if cmd.Run() == nil {
 		return true, true
 	}
-	if strings.Contains(strings.ToLower(stderr.String()), "password is required") {
+	if sudoRefusalIsConclusive(stderr.String()) {
 		return false, true
 	}
 	return false, false
+}
+
+// sudoRefusalIsConclusive reports whether sudo's refusal proves the passwordless
+// grant is gone, rather than merely failing to answer. The two implementations
+// word it differently: classic sudo asks for a password, while sudo-rs, which
+// Ubuntu 26.04 ships, asks for interactive authentication. Matching only the
+// former read every sudo-rs refusal as inconclusive, so the stale marker won and
+// a deleted drop-in was never rewritten.
+func sudoRefusalIsConclusive(stderr string) bool {
+	s := strings.ToLower(stderr)
+	return strings.Contains(s, "password is required") ||
+		strings.Contains(s, "authentication is required")
 }
 
 // ForgetSudoersMarker deletes the user-owned marker so the next InstallSudoers

--- a/internal/dns/setup_test.go
+++ b/internal/dns/setup_test.go
@@ -628,10 +628,10 @@ func TestTeardown_removesTheSudoersGrant(t *testing.T) {
 	if !found {
 		t.Fatal("Teardown not found in setup.go")
 	}
-	if !strings.Contains(teardown, "lerdSudoersPath") {
+	if !strings.Contains(teardown, "removeSudoersGrant()") {
 		t.Fatal("Teardown must remove /etc/sudoers.d/lerd, or uninstalling lerd leaves a passwordless root grant behind")
 	}
-	sudoersAt := strings.Index(teardown, "lerdSudoersPath")
+	sudoersAt := strings.Index(teardown, "removeSudoersGrant()")
 	resolverAt := strings.LastIndex(teardown, `"restart", "systemd-resolved"`)
 	nmAt := strings.LastIndex(teardown, `"restart", "NetworkManager"`)
 	last := resolverAt

--- a/internal/dns/sudo_probe_test.go
+++ b/internal/dns/sudo_probe_test.go
@@ -1,0 +1,55 @@
+package dns
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// `sudo -l CMD` answers whether CMD is permitted, not whether it can run without
+// a password, so it exits 0 for any user carrying a broader rule, which is most
+// admin accounts. The probe has to actually run the command to learn the answer.
+func TestSudoProbeCmd_RunsTheCommandRatherThanListingIt(t *testing.T) {
+	args := sudoProbeCmd().Args
+
+	if slices.Contains(args, "-l") {
+		t.Errorf("probe must not use `sudo -l`, which reports authorization rather than passwordless access: %v", args)
+	}
+	if !slices.Contains(args, "-n") {
+		t.Errorf("probe must stay non-interactive so it can never hang on a prompt: %v", args)
+	}
+	if !slices.Contains(args, sudoersProbeCommand) {
+		t.Errorf("probe must invoke the granted command %q: %v", sudoersProbeCommand, args)
+	}
+}
+
+// sudo translates its refusal, so the parser only ever sees English if the probe
+// pins the locale. A Romanian host reports "o parolă este necesară".
+func TestCLocaleEnv_PinsTheLocale(t *testing.T) {
+	got := cLocaleEnv([]string{
+		"PATH=/usr/bin",
+		"LANG=ro_RO.UTF-8",
+		"LC_ALL=ro_RO.UTF-8",
+		"LC_MESSAGES=ro_RO.UTF-8",
+		"LANGUAGE=ro",
+		"HOME=/home/george",
+	})
+
+	// glibc's getenv returns the first match, so a stale entry left earlier in
+	// the slice would win over one appended after it.
+	for _, kv := range got {
+		for _, stale := range []string{"LANG=ro", "LC_ALL=ro", "LC_MESSAGES=ro", "LANGUAGE=ro"} {
+			if strings.HasPrefix(kv, stale) {
+				t.Errorf("inherited locale %q must be dropped, not shadowed", kv)
+			}
+		}
+	}
+	if !slices.Contains(got, "LC_ALL=C") {
+		t.Errorf("probe environment must pin LC_ALL=C, got %v", got)
+	}
+	for _, want := range []string{"PATH=/usr/bin", "HOME=/home/george"} {
+		if !slices.Contains(got, want) {
+			t.Errorf("unrelated variable %q must be preserved, got %v", want, got)
+		}
+	}
+}

--- a/internal/dns/sudo_refusal_test.go
+++ b/internal/dns/sudo_refusal_test.go
@@ -1,0 +1,52 @@
+package dns
+
+import "testing"
+
+// The probe cannot read the root-only drop-in, so it decides whether the grant
+// is gone from how sudo words its refusal. Classic sudo and sudo-rs word it
+// differently, and matching only the classic wording made every sudo-rs refusal
+// read as inconclusive, so a deleted drop-in was never rewritten.
+func TestSudoRefusalIsConclusive(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		stderr string
+		want   bool
+	}{
+		{
+			name:   "classic sudo",
+			stderr: "sudo: a password is required\n",
+			want:   true,
+		},
+		{
+			name:   "sudo-rs, shipped on Ubuntu 26.04",
+			stderr: "sudo: interactive authentication is required\n",
+			want:   true,
+		},
+		{
+			name:   "mixed case is still a refusal",
+			stderr: "sudo: A Password Is Required\n",
+			want:   true,
+		},
+		{
+			name:   "no sudo on the host says nothing about the grant",
+			stderr: "sudo: command not found\n",
+			want:   false,
+		},
+		{
+			name:   "an unsupported flag is not evidence either way",
+			stderr: "sudo: invalid option -- 'n'\n",
+			want:   false,
+		},
+		{
+			name:   "silence is inconclusive",
+			stderr: "",
+			want:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sudoRefusalIsConclusive(tc.stderr); got != tc.want {
+				t.Errorf("sudoRefusalIsConclusive(%q) = %v, want %v", tc.stderr, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/dns/sudoers_teardown_test.go
+++ b/internal/dns/sudoers_teardown_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package dns
 
 import (

--- a/internal/dns/sudoers_teardown_test.go
+++ b/internal/dns/sudoers_teardown_test.go
@@ -1,0 +1,79 @@
+package dns
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The previous cover for this was a source-text grep over Teardown, which a
+// permanently-false guard and a missing sudoers rule both passed. These exercise
+// the decision instead.
+
+func withMarker(t *testing.T, present bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig := sudoersMarkerPath
+	t.Cleanup(func() { sudoersMarkerPath = orig })
+	path := filepath.Join(dir, "sudoers.sha256")
+	sudoersMarkerPath = func() string { return path }
+	if present {
+		if err := os.WriteFile(path, []byte("deadbeef\n"), 0644); err != nil {
+			t.Fatalf("seeding marker: %v", err)
+		}
+	}
+	return path
+}
+
+func captureRemoval(t *testing.T) *[]string {
+	t.Helper()
+	orig := runSudoersRemoval
+	t.Cleanup(func() { runSudoersRemoval = orig })
+	var got []string
+	runSudoersRemoval = func(path string) { got = append(got, path) }
+	return &got
+}
+
+// /etc/sudoers.d is 0750 root-only on Fedora and Arch, so the invoking user
+// cannot stat the drop-in. Gating removal on that stat meant the grant was never
+// removed there, which is the whole of issue #1094.
+func TestRemoveSudoersGrant_DoesNotDependOnReadingTheRootOnlyPath(t *testing.T) {
+	marker := withMarker(t, true)
+	removed := captureRemoval(t)
+
+	if !removeSudoersGrant() {
+		t.Fatal("removal must be attempted whenever lerd recorded installing a drop-in")
+	}
+	if len(*removed) != 1 || (*removed)[0] != lerdSudoersPath {
+		t.Fatalf("expected one removal of %s, got %v", lerdSudoersPath, *removed)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Error("the marker must be forgotten alongside the grant, or a later install skips rewriting it")
+	}
+}
+
+// Without the marker lerd never installed a drop-in, and the grant that would
+// make the removal passwordless is absent, so a blind sudo would prompt.
+func TestRemoveSudoersGrant_SkippedWhenLerdNeverInstalledOne(t *testing.T) {
+	withMarker(t, false)
+	removed := captureRemoval(t)
+
+	if removeSudoersGrant() {
+		t.Error("removal must not be attempted when no drop-in was ever recorded")
+	}
+	if len(*removed) != 0 {
+		t.Errorf("expected no removal, got %v", *removed)
+	}
+}
+
+// The drop-in has to permit its own removal. Without this rule the teardown's
+// `sudo rm` prompts for a password, which a non-interactive `uninstall --force`
+// cannot answer, so the grant survives even once the removal is reached.
+func TestLinuxSudoers_GrantsItsOwnRemoval(t *testing.T) {
+	content := renderLinuxSudoers("tester")
+	want := "tester ALL=(root) NOPASSWD: /usr/bin/rm -f " + lerdSudoersPath
+	if !strings.Contains(content, want) {
+		t.Fatalf("drop-in must grant its own removal.\nwant a line: %s\ngot:\n%s", want, content)
+	}
+}


### PR DESCRIPTION
Uninstalling was meant to delete `/etc/sudoers.d/lerd`, so a standing NOPASSWD root grant does not outlive the tool it was installed for. It never did, and it failed two independent ways.

The removal was guarded on stat'ing the drop-in, but `/etc/sudoers.d` is 0750 root-only on Fedora and Arch, so the invoking user cannot traverse it, the stat fails with EACCES, and the branch was unreachable. Ubuntu ships that directory 0755, which is the only reason the code was ever entered there. The guard now keys on the user-owned marker that InstallSudoers already maintains for exactly this problem, the drop-in being unreadable to the user who wrote it, and its absence means lerd never installed one.

Reaching the removal was not enough either. The drop-in granted `rm` only for the resolver and NetworkManager files, never for itself, so the sudo prompted for a password that an unattended uninstall cannot answer. It now permits its own removal, and the rule parses under the strict sudo parsers.

Because the drop-in's content changes, the marker no longer matches and an existing install rewrites it on the next run, which is how the self-removal rule reaches machines that already have one.

The cover for this read Teardown as source text and grepped it for a constant name, so a permanently unreachable branch and a missing grant both passed. The decision is a seam now.

Verified on the Fedora VM that showed it: the grant is present before the uninstall and gone after, the rule lands in the real drop-in, and visudo accepts it.

Closes #1098