### PR TITLE
fix(dns): stop re-prompting for the DNS sudoers rule on macOS

### DIFF
--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -982,6 +982,14 @@ func InstallSudoers() error {
 	return nil
 }
 
+// sudoersProbeCommand / sudoProbeArgs are the passwordless-liveness probe on
+// Linux: resolvectl is granted by renderLinuxSudoers and `--version` touches
+// nothing.
+var (
+	sudoersProbeCommand = "/usr/bin/resolvectl"
+	sudoProbeArgs       = []string{"--version"}
+)
+
 // renderLinuxSudoers returns the sudoers drop-in content for the given user.
 // Every rule uses a fully qualified command argument so modern strict
 // parsers (sudo-rs on Ubuntu 26.04+, C sudo >= 1.9.16 on Fedora 41+ /

--- a/internal/dns/setup_common.go
+++ b/internal/dns/setup_common.go
@@ -47,9 +47,11 @@ func sudoersInstalled(content []byte) bool {
 	return true
 }
 
-// sudoersProbeCommand is one of the commands the drop-in grants passwordless;
-// used only to probe whether that grant is still live.
-const sudoersProbeCommand = "/usr/bin/resolvectl"
+// sudoersProbeCommand and sudoProbeArgs name a command the platform's drop-in
+// grants passwordless, invoked only to probe whether that grant is still live.
+// They are platform-specific (see setup.go / setup_darwin.go): the macOS drop-in
+// never grants resolvectl, so a shared Linux probe could never succeed there and
+// forced a sudoers rewrite on every run (issue #1101).
 
 // sudoProbe is the seam tests override. It reports whether the drop-in's
 // passwordless grant is currently live and whether the answer is conclusive.
@@ -78,9 +80,11 @@ func defaultSudoProbe() (permitted, conclusive bool) {
 // all, which is true for anyone carrying a broader password-requiring rule like
 // ALL=(ALL) ALL, so the listing succeeded while running it still prompted.
 // Running the command is the only thing that answers the question being asked.
-// resolvectl --version touches nothing.
+// The chosen invocation touches nothing: resolvectl --version on Linux, an
+// idempotent `mkdir -p /etc/resolver` on macOS.
 func sudoProbeCmd() *exec.Cmd {
-	cmd := exec.Command("sudo", "-n", sudoersProbeCommand, "--version")
+	args := append([]string{"-n", sudoersProbeCommand}, sudoProbeArgs...)
+	cmd := exec.Command("sudo", args...)
 	cmd.Env = cLocaleEnv(os.Environ())
 	return cmd
 }

--- a/internal/dns/setup_darwin.go
+++ b/internal/dns/setup_darwin.go
@@ -137,6 +137,17 @@ func InstallSudoers() error {
 	return nil
 }
 
+// sudoersProbeCommand / sudoProbeArgs are the passwordless-liveness probe on
+// macOS. It must exercise a command renderDarwinSudoers actually grants, or the
+// probe can never succeed: `mkdir -p /etc/resolver` matches the granted rule
+// verbatim and is idempotent (a no-op once the directory exists). resolvectl,
+// the Linux probe, is never granted here, which forced a sudoers rewrite on
+// every run (issue #1101).
+var (
+	sudoersProbeCommand = "/bin/mkdir"
+	sudoProbeArgs       = []string{"-p", "/etc/resolver"}
+)
+
 // renderDarwinSudoers returns the macOS sudoers content for user + the
 // configured TLD. Every command argument is fully qualified — no
 // wildcards — so the rules pass modern strict sudo parsers (sudo-rs on

--- a/internal/dns/sudo_probe_darwin_test.go
+++ b/internal/dns/sudo_probe_darwin_test.go
@@ -1,0 +1,25 @@
+//go:build darwin
+
+package dns
+
+import (
+	"strings"
+	"testing"
+)
+
+// The passwordless probe must exercise a command the macOS drop-in actually
+// grants, or it can never succeed: sudo refuses the ungranted command, the
+// refusal reads as a conclusive "grant is gone", and lerd rewrites the sudoers
+// rule (prompting for sudo) on every run. resolvectl is a Linux-only grant that
+// never lands in the macOS drop-in, which is what broke issue #1101.
+func TestSudoProbe_ExercisesACommandTheDarwinDropInGrants(t *testing.T) {
+	grant := renderDarwinSudoers("kdonaldson", "test")
+
+	probe := sudoersProbeCommand
+	if len(sudoProbeArgs) > 0 {
+		probe += " " + strings.Join(sudoProbeArgs, " ")
+	}
+	if !strings.Contains(grant, "NOPASSWD: "+probe) {
+		t.Errorf("probe %q is not granted passwordless by the macOS sudoers drop-in:\n%s", probe, grant)
+	}
+}


### PR DESCRIPTION
On macOS `lerd start` prompted to reinstall the DNS sudoers rule on every run, even when the installed `/etc/sudoers.d/lerd` was byte identical to the recorded hash.

The cause is the passwordless-liveness probe that decides whether the drop-in is still active. It lived in the platform-shared setup code and was hardcoded to resolvectl, a systemd tool that only exists on Linux. On macOS the drop-in never grants resolvectl, so `sudo -n` always refused with "a password is required", which the probe read as a conclusive "the grant is gone", forcing a rewrite and a sudo prompt every time.

This makes the probe command platform specific. Linux keeps resolvectl. macOS probes with `mkdir -p /etc/resolver`, a command the drop-in already grants verbatim and which is idempotent, so it succeeds silently when the grant is live and only reports it gone when sudo genuinely refuses.

Refs #1101