### PR TITLE
fix(host-proxy): show proxy-only sites as running when their port is listening

### DIFF
--- a/docs/usage/host-proxy.md
+++ b/docs/usage/host-proxy.md
@@ -81,6 +81,8 @@ The dev server is the site's main process, not a togglable worker. Its health dr
 
 If it dies it is restarted automatically (`Restart=always`), and lerd's worker-heal pass recovers it if it ever gets stuck, while leaving paused sites alone. Because pause already stops it, there is deliberately no separate start/stop toggle for the dev server in the dashboard.
 
+For a proxy-only site, which has no command for lerd to run, there is no unit to reflect, so the running indicator instead follows the proxied port: it is green while the dev server you start yourself is listening on it, and grey otherwise.
+
 The dashboard shows a **Proxy** badge with the port (mirroring the container badge custom-container sites get), and the dev server's journal is available under a read-only **Dev Server** logs tab. The site header carries a reload button that restarts the dev server, the same thing `lerd restart` does; proxy-only sites, which have no command for lerd to run, do not get it. From the CLI:
 
 ```bash

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -446,9 +446,15 @@ func (e *EnrichedSite) enrichVersions(s config.Site, fw *config.Framework, hasFw
 
 func (e *EnrichedSite) enrichFPM() {
 	if e.HostPort > 0 {
-		// Host-proxy sites have no container; "running" reflects the
-		// supervised dev-server worker. Proxy-only sites (no worker) stay
-		// false. Match the activating-state handling used for worker rows.
+		// Host-proxy sites have no container. When lerd supervises the dev
+		// server, "running" reflects that worker unit. Proxy-only sites have no
+		// worker, so their liveness is whether the user's own dev server is
+		// listening on the proxied port.
+		if e.HostCommand == "" {
+			e.FPMRunning = proxyPortListening(e.HostPort)
+			return
+		}
+		// Match the activating-state handling used for worker rows.
 		st, _ := unitStatusFn(config.HostProxyWorkerUnit(e.Name))
 		e.FPMRunning = st == "active" || st == "activating"
 		return

--- a/internal/siteinfo/siteinfo_test.go
+++ b/internal/siteinfo/siteinfo_test.go
@@ -1,6 +1,7 @@
 package siteinfo
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1078,6 +1079,57 @@ func TestEnrichFPM(t *testing.T) {
 		e.enrichFPM()
 		if e.FPMRunning {
 			t.Error("expected FPMRunning = false for stopped custom container")
+		}
+	})
+
+	t.Run("proxy-only site is running when its host port is listening", func(t *testing.T) {
+		prev := dialProbe
+		var dialed string
+		dialProbe = func(addr string) error { dialed = addr; return nil }
+		defer func() { dialProbe = prev }()
+
+		e := &EnrichedSite{Name: "vite", HostPort: 5173}
+		e.enrichFPM()
+		if dialed != "127.0.0.1:5173" {
+			t.Errorf("dialed %q, want 127.0.0.1:5173", dialed)
+		}
+		if !e.FPMRunning {
+			t.Error("expected FPMRunning = true when the proxied dev server is listening")
+		}
+	})
+
+	t.Run("proxy-only site is not running when its host port refuses", func(t *testing.T) {
+		prev := dialProbe
+		dialProbe = func(string) error { return errors.New("connection refused") }
+		defer func() { dialProbe = prev }()
+
+		e := &EnrichedSite{Name: "vite", HostPort: 5173}
+		e.enrichFPM()
+		if e.FPMRunning {
+			t.Error("expected FPMRunning = false when the proxied port refuses")
+		}
+	})
+
+	t.Run("supervised host proxy reflects its worker unit, not the port", func(t *testing.T) {
+		prev := dialProbe
+		dialProbe = func(string) error {
+			t.Fatal("supervised host-proxy site should not be port-probed")
+			return nil
+		}
+		defer func() { dialProbe = prev }()
+		origUnit := unitStatusFn
+		unitStatusFn = func(name string) (string, error) {
+			if name == config.HostProxyWorkerUnit("nestapp") {
+				return "active", nil
+			}
+			return "", nil
+		}
+		defer func() { unitStatusFn = origUnit }()
+
+		e := &EnrichedSite{Name: "nestapp", HostPort: 3100, HostCommand: "npm run start:dev"}
+		e.enrichFPM()
+		if !e.FPMRunning {
+			t.Error("expected FPMRunning = true from the active worker unit")
 		}
 	})
 }

--- a/internal/siteinfo/workerhealth.go
+++ b/internal/siteinfo/workerhealth.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -63,6 +64,16 @@ func WorkerServerReachable(sitePath string, h *config.WorkerHealth, activeEnter 
 		return false, true
 	}
 	return true, true
+}
+
+// proxyPortListening reports whether a proxy-only host site's dev server is
+// accepting connections on its proxied port. Such sites have no worker unit to
+// reflect, so their liveness is the port itself: the user starts the server.
+func proxyPortListening(port int) bool {
+	if port <= 0 {
+		return false
+	}
+	return dialProbe(net.JoinHostPort("127.0.0.1", strconv.Itoa(port))) == nil
 }
 
 // hostPortFromURL pulls a dialable host:port out of a server URL like


### PR DESCRIPTION
The site status dot in the sites list and dashboard is driven by fpm_running, which for a host-proxy site was computed only from its supervised dev-server unit. Proxy-only sites, where you start the dev server yourself and lerd only wires the proxy, have no such unit, so fpm_running was always false and the dot stayed grey even while the server was up and serving.

For proxy-only sites the running state now follows the proxied port: a short TCP probe of the host port, reusing the same dial seam the worker health checks already use. A green dot means your dev server is listening on the port lerd proxies to. Supervised host-proxy sites keep reflecting their worker unit exactly as before.

Refs #1108