### PR TITLE
test(serviceops): stop the port-shift guard test reading live systemd

### DIFF
--- a/internal/serviceops/ensure_quadlet_test.go
+++ b/internal/serviceops/ensure_quadlet_test.go
@@ -125,6 +125,12 @@ func TestEnsureCustomServiceQuadlet_portShiftNoticeAvoidsStdout(t *testing.T) {
 	t.Cleanup(func() { podman.DaemonReloadFn = orig })
 	podman.DaemonReloadFn = func() error { return nil }
 
+	// The guard leaves the port alone while the service's own unit is up, so pin
+	// the unit down: otherwise a developer running lerd-mongo-express fails here.
+	origStatus := ensureUnitStatus
+	t.Cleanup(func() { ensureUnitStatus = origStatus })
+	ensureUnitStatus = func(string) (string, error) { return "inactive", nil }
+
 	// Occupy the service's primary host port so the guard is forced to shift it.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/serviceops/serviceops.go
+++ b/internal/serviceops/serviceops.go
@@ -110,11 +110,15 @@ func firePublishedPortShiftForced(service string, newPort int) {
 	}
 }
 
+// ensureUnitStatus is the seam the port guard reads unit state through, so tests
+// can decide it instead of inheriting whatever the developer happens to be running.
+var ensureUnitStatus = podman.UnitStatus
+
 // unitActive reports whether a service's own systemd unit is currently up. The
 // generic port guard uses it to avoid treating the service's *own* published
 // listener as a foreign owner of the port (see maybeShiftPublishedPort).
 func unitActive(name string) bool {
-	status, _ := podman.UnitStatus("lerd-" + name)
+	status, _ := ensureUnitStatus("lerd-" + name)
 	return status == "active" || status == "activating"
 }
 


### PR DESCRIPTION
The generic port guard leaves a service's published port alone while that service's own unit is up, and it read that unit state straight from the session systemd. The port-shift test names its fixture service `mongo-express`, so on a machine actually running `lerd-mongo-express` the guard saw a live unit, skipped the shift, and the assertion about the persisted published port failed. The test already isolates `HOME` and the XDG directories, but neither of those redirects the session bus, so that isolation could never cover this.

Unit state now goes through a package-level seam in front of `podman.UnitStatus`, matching what `ports.go` and `remove.go` already do, and the test pins it. Nothing about the guard's behaviour changes: the same call reaches the same function everywhere outside the test.

Closes #1122
