### PR TITLE
fix(php-ini): keep FPM alive through a reset, and surface the restart in the editor

### DIFF
--- a/internal/cfgedit/cfgedit.go
+++ b/internal/cfgedit/cfgedit.go
@@ -192,23 +192,37 @@ func (f File) Save(content string, opt SaveOpts) (SaveResult, error) {
 
 // Reset deletes the live file (its include glob then expands to nothing) and
 // runs apply. Backups are kept. Apply is skipped when nothing was removed.
+// An apply failure puts the file back and re-applies, the same rollback the save
+// path performs, so a container that will not come back up is never left behind
+// a reset the user cannot undo.
 func (f File) Reset(apply func() error) error {
 	Mu.Lock()
 	defer Mu.Unlock()
 
-	removeErr := os.Remove(f.Path)
-	if removeErr != nil {
-		if os.IsNotExist(removeErr) {
+	snap, snapErr := ReadSnapshot(f.Path)
+	if err := os.Remove(f.Path); err != nil {
+		if os.IsNotExist(err) {
 			return nil
 		}
-		return removeErr
+		return err
 	}
-	if apply != nil {
-		if err := apply(); err != nil {
-			return fmt.Errorf("reset, but apply failed: %w", err)
-		}
+	if apply == nil {
+		return nil
 	}
-	return nil
+	applyErr := apply()
+	if applyErr == nil {
+		return nil
+	}
+	if snapErr != nil {
+		return fmt.Errorf("reset, but apply failed and the previous contents could not be read back: %v (apply error: %w)", snapErr, applyErr)
+	}
+	if rbErr := RestoreSnapshot(f.Path, snap); rbErr != nil {
+		return fmt.Errorf("reset, apply failed and rollback failed: %v (apply error: %w)", rbErr, applyErr)
+	}
+	if rb2Err := apply(); rb2Err != nil {
+		return fmt.Errorf("reset rolled back, but the restart still failed: %v (original: %w)", rb2Err, applyErr)
+	}
+	return fmt.Errorf("reset rolled back: %w", applyErr)
 }
 
 // Restore swaps a backup over the live file, applies, and only then drops the

--- a/internal/cfgedit/cfgedit_test.go
+++ b/internal/cfgedit/cfgedit_test.go
@@ -175,6 +175,44 @@ func TestReset_removesFile(t *testing.T) {
 	}
 }
 
+// A reset whose restart fails must not leave the file deleted: the container is
+// already down, and without the contents back the user has no way to undo it.
+func TestReset_restoresFileWhenApplyFails(t *testing.T) {
+	f := tmpFile(t)
+	if err := os.MkdirAll(filepath.Dir(f.Path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const original = "; keep me\nmemory_limit = 512M\n"
+	if err := os.WriteFile(f.Path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	applies := 0
+	err := f.Reset(func() error {
+		applies++
+		if applies == 1 {
+			return errors.New("fpm did not come back")
+		}
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected the apply failure to surface, got nil")
+	}
+	if !strings.Contains(err.Error(), "rolled back") {
+		t.Errorf("error = %v, want it to say the reset was rolled back", err)
+	}
+	if applies != 2 {
+		t.Errorf("apply ran %d times, want 2 (once to fail, once after the rollback)", applies)
+	}
+	got, readErr := os.ReadFile(f.Path)
+	if readErr != nil {
+		t.Fatalf("file must be restored after a failed apply: %v", readErr)
+	}
+	if string(got) != original {
+		t.Errorf("restored contents = %q, want %q", got, original)
+	}
+}
+
 func TestValidBackupName_rejectsForeignAndTraversal(t *testing.T) {
 	f := tmpFile(t)
 	for _, bad := range []string{"../etc/passwd", "other.conf.bkp.20260101-101010", "x_acme.test.conf.bkp.20260101-101010"} {

--- a/internal/phpini/phpini.go
+++ b/internal/phpini/phpini.go
@@ -126,13 +126,12 @@ func Restart(scope string) error {
 	return restartVersion(scope)
 }
 
-// RestartNoSeed restarts a scope's container(s) after a reset. The per-version
-// file is not re-seeded (the shared FPM tolerates its absence: only that one
-// version's container mounts it, and the reset means "no per-version override").
-// The shared file IS re-seeded first, because every PHP container mounts it and
-// a missing bind-mount source makes them all fail to start; re-seeding the
-// commented template is functionally "no shared override" while keeping the
-// mount valid. A FrankenPHP site is re-seeded for the same bind-mount reason.
+// RestartNoSeed restarts a scope's container(s) after a reset. Every scope is
+// re-seeded first: the quadlets bind-mount each ini path unconditionally, so a
+// missing source makes podman refuse to start the container (statfs, exit 125)
+// and systemd restart-loops it. Re-seeding the commented template is what "no
+// override" means on disk while keeping the mount valid. NoSeed refers to
+// skipping the quadlet rewrite, not the file itself.
 func RestartNoSeed(scope string) error {
 	if scope == SharedScope {
 		_ = podman.EnsureSharedIni()
@@ -153,6 +152,7 @@ func RestartNoSeed(scope string) error {
 		_ = podman.EnsureSitePHPUserIni(name)
 		return podman.RestartUnit(podman.FrankenPHPContainerName(site.Name))
 	}
+	_ = podman.EnsureUserIni(scope)
 	return restartFPMUnit(scope)
 }
 
@@ -191,7 +191,9 @@ func restartFrankenPHPSite(name string) error {
 	return podman.RestartUnit(podman.FrankenPHPContainerName(site.Name))
 }
 
-func restartFPMUnit(version string) error {
+// A var for the same reason as installedVersions below: a test that left it live
+// would restart the developer's own FPM containers.
+var restartFPMUnit = func(version string) error {
 	short := strings.ReplaceAll(version, ".", "")
 	return podman.RestartUnit("lerd-php" + short + "-fpm")
 }

--- a/internal/phpini/phpini_test.go
+++ b/internal/phpini/phpini_test.go
@@ -63,6 +63,30 @@ func TestRestartNoSeed_SharedReseedsFile(t *testing.T) {
 	}
 }
 
+// The per-version file is bind-mounted into that version's FPM unconditionally,
+// so a reset that leaves it deleted makes podman refuse to start the container
+// (statfs, exit 125) and systemd restart-loop it until the start limit is hit.
+func TestRestartNoSeed_VersionReseedsFile(t *testing.T) {
+	restore := restartFPMUnit
+	restartFPMUnit = func(string) error { return nil }
+	t.Cleanup(func() { restartFPMUnit = restore })
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	// Simulate the post-reset state: no per-version file on disk.
+	if err := RestartNoSeed("8.4"); err != nil {
+		t.Fatalf("RestartNoSeed(8.4): %v", err)
+	}
+	got, err := ScopeFile("8.4").Read()
+	if err != nil {
+		t.Fatalf("reading per-version ini: %v", err)
+	}
+	if !got.Exists {
+		t.Errorf("per-version ini must be re-seeded after a reset, but it is missing")
+	}
+}
+
 func TestEnsure_SharedCreatesFile(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	if err := Ensure(SharedScope); err != nil {

--- a/internal/ui/php_ini.go
+++ b/internal/ui/php_ini.go
@@ -23,7 +23,8 @@ func phpIniScopeFile(scope string) cfgedit.File { return phpini.ScopeFile(scope)
 func phpIniRestart(scope string) error { return phpini.Restart(scope) }
 
 // phpIniRestartNoSeed restarts a scope's container(s) after a reset without
-// re-seeding a per-version/shared file.
+// rewriting the quadlet. The ini file itself is re-seeded to keep the bind mount
+// valid.
 func phpIniRestartNoSeed(scope string) error { return phpini.RestartNoSeed(scope) }
 
 // PhpIniReadResponse mirrors SiteNginxReadResponse. Exists distinguishes a
@@ -190,9 +191,9 @@ func handlePhpIniReset(w http.ResponseWriter, r *http.Request, version string) {
 		http.NotFound(w, r)
 		return
 	}
-	// RestartNoSeed, not Restart: the latter re-seeds via EnsureUserIni, which
-	// would recreate the file we just deleted. cfgedit.Reset skips the restart
-	// when nothing was removed.
+	// RestartNoSeed, not Restart: it restarts without rewriting the quadlet. The
+	// file is still re-seeded to its commented template, which is what "no
+	// override" looks like on disk and keeps the bind mount valid.
 	if err := phpIniScopeFile(version).Reset(func() error { return phpIniRestartNoSeed(version) }); err != nil {
 		writeJSON(w, PhpIniResetResponse{OK: false, Error: "removed, but FPM restart failed: " + err.Error()})
 		return

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "Diese Änderungen an der php.ini für {scope} speichern und FPM neu starten?",
   "phpIniEditor_resetTitle": "php.ini zurücksetzen",
   "phpIniEditor_resetBody": "Die gespeicherte php.ini für {scope} löschen und FPM neu starten? Dann gelten die mitgelieferten Standardwerte. Backups bleiben erhalten und können später wiederhergestellt werden.",
+  "phpIniEditor_restarting": "PHP-FPM wird neu gestartet…",
+  "phpIniEditor_restartFailed": "Neustart von PHP-FPM für {scope} fehlgeschlagen",
   "phpIniEditor_restoreTitle": "php.ini aus Backup wiederherstellen",
   "phpIniEditor_restoreBody": "Die aktuelle php.ini für {scope} durch {name} ersetzen. Das Backup wird nach der Wiederherstellung entfernt.",
   "services_dash_overview": "Übersicht",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "Save these changes to {scope}'s php.ini and restart FPM?",
   "phpIniEditor_resetTitle": "Reset php.ini",
   "phpIniEditor_resetBody": "Delete the saved php.ini for {scope} and restart FPM? The bundled defaults will apply. Backups are kept and can be restored later.",
+  "phpIniEditor_restarting": "Restarting PHP-FPM…",
+  "phpIniEditor_restartFailed": "PHP-FPM restart failed for {scope}",
   "phpIniEditor_restoreTitle": "Restore php.ini from backup",
   "phpIniEditor_restoreBody": "Replace the current php.ini for {scope} with {name}. The backup will be removed after the restore completes.",
   "services_dash_overview": "Overview",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "¿Guardar estos cambios en el php.ini de {scope} y reiniciar FPM?",
   "phpIniEditor_resetTitle": "Restablecer php.ini",
   "phpIniEditor_resetBody": "¿Eliminar el php.ini guardado de {scope} y reiniciar FPM? Se aplicarán los valores incluidos por defecto. Las copias de seguridad se conservan y pueden restaurarse más tarde.",
+  "phpIniEditor_restarting": "Reiniciando PHP-FPM…",
+  "phpIniEditor_restartFailed": "Error al reiniciar PHP-FPM para {scope}",
   "phpIniEditor_restoreTitle": "Restaurar php.ini desde una copia",
   "phpIniEditor_restoreBody": "Sustituye el php.ini actual de {scope} por {name}. La copia se eliminará cuando termine la restauración.",
   "services_dash_overview": "Resumen",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "Enregistrer ces modifications du php.ini pour {scope} et redémarrer FPM ?",
   "phpIniEditor_resetTitle": "Réinitialiser php.ini",
   "phpIniEditor_resetBody": "Supprimer le php.ini enregistré pour {scope} et redémarrer FPM ? Les valeurs par défaut fournies s'appliqueront. Les sauvegardes sont conservées et peuvent être restaurées plus tard.",
+  "phpIniEditor_restarting": "Redémarrage de PHP-FPM…",
+  "phpIniEditor_restartFailed": "Échec du redémarrage de PHP-FPM pour {scope}",
   "phpIniEditor_restoreTitle": "Restaurer php.ini depuis une sauvegarde",
   "phpIniEditor_restoreBody": "Remplacer le php.ini actuel pour {scope} par {name}. La sauvegarde sera supprimée une fois la restauration terminée.",
   "services_dash_overview": "Aperçu",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "Simpan perubahan ini ke php.ini milik {scope} dan mulai ulang FPM?",
   "phpIniEditor_resetTitle": "Setel ulang php.ini",
   "phpIniEditor_resetBody": "Hapus php.ini yang tersimpan untuk {scope} dan mulai ulang FPM? Bawaan bundel akan berlaku. Cadangan tetap disimpan dan dapat dipulihkan nanti.",
+  "phpIniEditor_restarting": "Memulai ulang PHP-FPM…",
+  "phpIniEditor_restartFailed": "Gagal memulai ulang PHP-FPM untuk {scope}",
   "phpIniEditor_restoreTitle": "Pulihkan php.ini dari cadangan",
   "phpIniEditor_restoreBody": "Ganti php.ini saat ini untuk {scope} dengan {name}. Cadangan akan dihapus setelah pemulihan selesai.",
   "services_dash_overview": "Ikhtisar",

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "Salvare queste modifiche al php.ini di {scope} e riavviare FPM?",
   "phpIniEditor_resetTitle": "Reimposta php.ini",
   "phpIniEditor_resetBody": "Eliminare il php.ini salvato per {scope} e riavviare FPM? Verranno applicate le impostazioni predefinite incluse. I backup vengono conservati e possono essere ripristinati in seguito.",
+  "phpIniEditor_restarting": "Riavvio di PHP-FPM…",
+  "phpIniEditor_restartFailed": "Riavvio di PHP-FPM non riuscito per {scope}",
   "phpIniEditor_restoreTitle": "Ripristina php.ini da backup",
   "phpIniEditor_restoreBody": "Sostituire il php.ini corrente per {scope} con {name}. Il backup verrà rimosso al completamento del ripristino.",
   "services_dash_overview": "Panoramica",

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "これらの変更を {scope} の php.ini に保存して FPM を再起動しますか？",
   "phpIniEditor_resetTitle": "php.ini をリセット",
   "phpIniEditor_resetBody": "{scope} の保存済み php.ini を削除して FPM を再起動しますか？ 同梱のデフォルトが適用されます。バックアップは保持され、後で復元できます。",
+  "phpIniEditor_restarting": "PHP-FPM を再起動しています…",
+  "phpIniEditor_restartFailed": "{scope} の PHP-FPM の再起動に失敗しました",
   "phpIniEditor_restoreTitle": "バックアップから php.ini を復元",
   "phpIniEditor_restoreBody": "{scope} の現在の php.ini を {name} で置き換えます。復元完了後にバックアップは削除されます。",
   "services_dash_overview": "概要",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "Deze wijzigingen opslaan in de php.ini van {scope} en FPM herstarten?",
   "phpIniEditor_resetTitle": "php.ini resetten",
   "phpIniEditor_resetBody": "De opgeslagen php.ini voor {scope} verwijderen en FPM herstarten? De meegeleverde standaardwaarden gaan dan gelden. Back-ups blijven bewaard en kunnen later worden hersteld.",
+  "phpIniEditor_restarting": "PHP-FPM opnieuw starten…",
+  "phpIniEditor_restartFailed": "PHP-FPM opnieuw starten mislukt voor {scope}",
   "phpIniEditor_restoreTitle": "php.ini uit back-up herstellen",
   "phpIniEditor_restoreBody": "Vervang de huidige php.ini voor {scope} door {name}. De back-up wordt verwijderd zodra het herstellen is voltooid.",
   "services_dash_overview": "Overzicht",

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "Zapisać te zmiany do php.ini {scope} i uruchomić ponownie FPM?",
   "phpIniEditor_resetTitle": "Resetuj php.ini",
   "phpIniEditor_resetBody": "Usunąć zapisany php.ini dla {scope} i uruchomić ponownie FPM? Zastosowane zostaną dołączone wartości domyślne. Kopie zapasowe są zachowywane i można je później odtworzyć.",
+  "phpIniEditor_restarting": "Ponowne uruchamianie PHP-FPM…",
+  "phpIniEditor_restartFailed": "Nie udało się ponownie uruchomić PHP-FPM dla {scope}",
   "phpIniEditor_restoreTitle": "Odtwórz php.ini z kopii zapasowej",
   "phpIniEditor_restoreBody": "Zastąp bieżący php.ini dla {scope} kopią {name}. Kopia zapasowa zostanie usunięta po zakończeniu odtwarzania.",
   "services_dash_overview": "Przegląd",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "Salvar estas alterações no php.ini de {scope} e reiniciar o FPM?",
   "phpIniEditor_resetTitle": "Redefinir o php.ini",
   "phpIniEditor_resetBody": "Excluir o php.ini salvo de {scope} e reiniciar o FPM? Os padrões integrados passam a valer. Os backups são mantidos e podem ser restaurados depois.",
+  "phpIniEditor_restarting": "Reiniciando o PHP-FPM…",
+  "phpIniEditor_restartFailed": "Falha ao reiniciar o PHP-FPM para {scope}",
   "phpIniEditor_restoreTitle": "Restaurar o php.ini a partir de um backup",
   "phpIniEditor_restoreBody": "Substituir o php.ini atual de {scope} por {name}. O backup será removido após a restauração ser concluída.",
   "services_dash_overview": "Visão geral",

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "Salvezi aceste modificări la php.ini al {scope} și repornești FPM?",
   "phpIniEditor_resetTitle": "Resetează php.ini",
   "phpIniEditor_resetBody": "Ștergi php.ini salvat pentru {scope} și repornești FPM? Se vor aplica valorile implicite incluse. Copiile de rezervă sunt păstrate și pot fi restaurate ulterior.",
+  "phpIniEditor_restarting": "Se repornește PHP-FPM…",
+  "phpIniEditor_restartFailed": "Repornirea PHP-FPM pentru {scope} a eșuat",
   "phpIniEditor_restoreTitle": "Restaurează php.ini din copia de rezervă",
   "phpIniEditor_restoreBody": "Înlocuiește php.ini curent pentru {scope} cu {name}. Copia de rezervă va fi eliminată după finalizarea restaurării.",
   "services_dash_overview": "Prezentare generală",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "Bu değişiklikler {scope} için php.ini dosyasına kaydedilip FPM yeniden başlatılsın mı?",
   "phpIniEditor_resetTitle": "php.ini'yi sıfırla",
   "phpIniEditor_resetBody": "{scope} için kaydedilmiş php.ini silinip FPM yeniden başlatılsın mı? Pakete dahil varsayılanlar geçerli olacak. Yedekler saklanır ve daha sonra geri yüklenebilir.",
+  "phpIniEditor_restarting": "PHP-FPM yeniden başlatılıyor…",
+  "phpIniEditor_restartFailed": "{scope} için PHP-FPM yeniden başlatılamadı",
   "phpIniEditor_restoreTitle": "php.ini'yi yedekten geri yükle",
   "phpIniEditor_restoreBody": "{scope} için mevcut php.ini, {name} ile değiştirilecek. Geri yükleme tamamlandıktan sonra yedek kaldırılacak.",
   "services_dash_overview": "Genel bakış",

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "Lưu các thay đổi này vào php.ini của {scope} và khởi động lại FPM?",
   "phpIniEditor_resetTitle": "Đặt lại php.ini",
   "phpIniEditor_resetBody": "Xóa php.ini đã lưu cho {scope} và khởi động lại FPM? Các giá trị mặc định đi kèm sẽ áp dụng. Bản sao lưu được giữ lại và có thể khôi phục sau.",
+  "phpIniEditor_restarting": "Đang khởi động lại PHP-FPM…",
+  "phpIniEditor_restartFailed": "Không thể khởi động lại PHP-FPM cho {scope}",
   "phpIniEditor_restoreTitle": "Khôi phục php.ini từ bản sao lưu",
   "phpIniEditor_restoreBody": "Thay php.ini hiện tại cho {scope} bằng {name}. Bản sao lưu sẽ bị gỡ sau khi khôi phục hoàn tất.",
   "services_dash_overview": "Tổng quan",

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -1044,6 +1044,8 @@
   "phpIniEditor_confirmBody": "将这些更改保存到 {scope} 的 php.ini 并重启 FPM？",
   "phpIniEditor_resetTitle": "重置 php.ini",
   "phpIniEditor_resetBody": "删除为 {scope} 保存的 php.ini 并重启 FPM？将应用内置默认配置。备份会保留，可在之后恢复。",
+  "phpIniEditor_restarting": "正在重启 PHP-FPM…",
+  "phpIniEditor_restartFailed": "{scope} 的 PHP-FPM 重启失败",
   "phpIniEditor_restoreTitle": "从备份恢复 php.ini",
   "phpIniEditor_restoreBody": "用 {name} 替换 {scope} 的当前 php.ini。恢复完成后该备份将被移除。",
   "services_dash_overview": "概览",

--- a/internal/ui/web/src/lib/notify.test.ts
+++ b/internal/ui/web/src/lib/notify.test.ts
@@ -791,3 +791,35 @@ describe('notification severity', () => {
     expect(notificationSeverity('nplusone', true)).toBe('failure');
   });
 });
+
+describe('notifyLocalFailure', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('puts a page-detected failure on the in-app surface and in the history', async () => {
+    const { notifyLocalFailure, inAppNotifications, notificationHistory } = await import('./notify');
+
+    notifyLocalFailure('php_ini', 'PHP-FPM restart failed for PHP 8.4', 'unit did not come back');
+
+    const inApp = get(inAppNotifications);
+    expect(inApp).toHaveLength(1);
+    expect(inApp[0].title).toBe('PHP-FPM restart failed for PHP 8.4');
+    expect(inApp[0].body).toBe('unit did not come back');
+    // failed entries are the ones NotificationToasts refuses to auto-dismiss.
+    expect(inApp[0].failed).toBe(true);
+
+    expect(get(notificationHistory)[0].title).toBe('PHP-FPM restart failed for PHP 8.4');
+  });
+
+  it('does not depend on the window having focus, unlike pushed events', async () => {
+    const hasFocus = vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+    const { notifyLocalFailure, inAppNotifications } = await import('./notify');
+
+    notifyLocalFailure('php_ini', 'title', 'body');
+
+    expect(get(inAppNotifications)).toHaveLength(1);
+    hasFocus.mockRestore();
+  });
+});

--- a/internal/ui/web/src/lib/notify.ts
+++ b/internal/ui/web/src/lib/notify.ts
@@ -263,6 +263,16 @@ export function dismissInApp(id: number) {
   inAppNotifications.update((list) => list.filter((n) => n.id !== id));
 }
 
+// notifyLocalFailure raises a failure the page itself detected, rather than one
+// the daemon pushed. It takes the same in-app surface and history as a pushed
+// event, so a container that will not come back up is still on screen after the
+// modal is closed. Failures never auto-dismiss.
+export function notifyLocalFailure(kind: string, title: string, body: string) {
+  const entry = { kind, title, body, url: '', failed: true };
+  record(entry);
+  pushInApp(entry);
+}
+
 // dedupeWindowMs scopes the tag dedupe to a short window so an immediate
 // retry of the same payload collapses but a same-tag send seconds later
 // (Send-test double-click, two identical mail webhooks) still fires.

--- a/internal/ui/web/src/modals/ConfirmPhpIniResetModal.svelte
+++ b/internal/ui/web/src/modals/ConfirmPhpIniResetModal.svelte
@@ -3,6 +3,7 @@
   import DetailButton from '$components/DetailButton.svelte';
   import { closeModal, modal } from '$stores/modals';
   import { resetPhpIni } from '$stores/phpVersions';
+  import { notifyLocalFailure } from '$lib/notify';
   import { m } from '../paraglide/messages.js';
 
   const target = $derived($modal.phpIniReset);
@@ -24,6 +25,9 @@
       const res = await resetPhpIni(target.version);
       if (!res.ok) {
         error = res.error || m.nginxEditor_resetFailed();
+        // A reset that cannot restart FPM leaves the version down, so say so
+        // somewhere that outlives this modal.
+        notifyLocalFailure('php_ini', m.phpIniEditor_restartFailed({ scope: target.label }), error);
         return;
       }
       closeModal();
@@ -60,7 +64,7 @@
     <DetailButton onclick={safeClose} disabled={busy}>{m.common_cancel()}</DetailButton>
     {#if target}
       <DetailButton tone="primary" onclick={confirm} loading={busy} disabled={busy}>
-        {busy ? m.nginxEditor_resetting() : m.nginxEditor_resetAccept()}
+        {busy ? m.phpIniEditor_restarting() : m.nginxEditor_resetAccept()}
       </DetailButton>
     {/if}
   {/snippet}

--- a/internal/ui/web/src/modals/ConfirmPhpIniSaveModal.svelte
+++ b/internal/ui/web/src/modals/ConfirmPhpIniSaveModal.svelte
@@ -3,6 +3,7 @@
   import DetailButton from '$components/DetailButton.svelte';
   import { closeModal, modal } from '$stores/modals';
   import { savePhpIni } from '$stores/phpVersions';
+  import { notifyLocalFailure } from '$lib/notify';
   import { m } from '../paraglide/messages.js';
 
   const target = $derived($modal.phpIniSave);
@@ -25,6 +26,9 @@
       const res = await savePhpIni(target.version, target.content, backup);
       if (!res.ok) {
         error = res.error || m.nginxEditor_saveFailed();
+        // The restart is the slow, failure-prone half, and the error otherwise
+        // lives only in a modal the user is about to close.
+        notifyLocalFailure('php_ini', m.phpIniEditor_restartFailed({ scope: target.label }), error);
         return;
       }
       closeModal();
@@ -75,7 +79,7 @@
     <DetailButton onclick={safeClose} disabled={busy}>{m.common_cancel()}</DetailButton>
     {#if target}
       <DetailButton tone="primary" onclick={confirm} loading={busy} disabled={busy}>
-        {busy ? m.nginxEditor_saving() : m.common_save()}
+        {busy ? m.phpIniEditor_restarting() : m.common_save()}
       </DetailButton>
     {/if}
   {/snippet}

--- a/internal/ui/web/src/tabs/system/PhpIniTab.svelte
+++ b/internal/ui/web/src/tabs/system/PhpIniTab.svelte
@@ -33,13 +33,17 @@
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
   let backups = $state<SiteNginxBackup[]>([]);
   let restoring = $state(false);
+  // True from the moment an action's request goes out until the tab has reloaded
+  // the file, so the editor cannot take a second write against state it has not
+  // caught up with yet.
+  let applying = $state(false);
 
   const dirty = $derived(text !== original);
   const latestBackup = $derived(backups[0]);
   const hasBackup = $derived(backups.length > 0 && !loading && !error);
-  const canRevert = $derived(dirty && !loading && !error);
-  const canReset = $derived(exists && !loading && !error);
-  const canSave = $derived(dirty && !loading && !error);
+  const canRevert = $derived(dirty && !loading && !error && !applying);
+  const canReset = $derived(exists && !loading && !error && !applying);
+  const canSave = $derived(dirty && !loading && !error && !applying);
 
   // The php.ini scope: this version's own file, or the shared file applied to
   // every version. The API keys on this token ("shared" or a bare version).
@@ -111,6 +115,7 @@
   });
 
   async function refreshAfterAction(v: string) {
+    applying = true;
     try {
       const [cfgRes, listRes] = await Promise.allSettled([getPhpIni(v), loadPhpIniBackups(v)]);
       if (currentScope !== v) return;
@@ -135,6 +140,8 @@
     } catch (e: unknown) {
       if (currentScope !== v) return;
       actionError = e instanceof Error ? e.message : String(e);
+    } finally {
+      applying = false;
     }
   }
 
@@ -222,7 +229,7 @@
     {canReset}
     {canSave}
     {hasBackup}
-    {restoring}
+    restoring={restoring || applying}
     {copied}
     onCopy={copy}
     onRevert={revert}


### PR DESCRIPTION
Resetting a non-default PHP version's `php.ini` from the dashboard left that version's FPM unable to start at all, and nothing said so. The container failed with a podman `statfs` error rather than anything mentioning lerd, and systemd restart-looped it until the start limit was hit. Hit locally on 8.3 and 8.4 while 8.5, the default, kept working.

Every FPM quadlet bind-mounts the per-version user ini unconditionally, so deleting that file is enough to make the container unstartable. `RestartNoSeed` skipped re-seeding it deliberately, on the reasoning that a version's own container tolerates its absence, while the same function already re-seeded the shared and FrankenPHP site files precisely because a missing bind-mount source stops them starting. The per-version case now behaves like the other two: the commented template is what "no override" looks like on disk and it keeps the mount valid. The default version hid this, because `lerd start` rewrites its quadlet and that path re-seeds on the way through.

Around that, two things about the editor itself. The restart runs synchronously inside the save request and takes several seconds, rewriting the quadlet, restarting the unit and then every per-site container on that version, but the button only said "Saving". It now names the restart. The editor also went live again the moment the modal closed, while the tab was still reloading the file, so it would accept a second write against state it had not caught up with. The action guards now wait for that reload.

And a failed restart is no longer quiet or unrecoverable. Reset snapshots before deleting and, if the restart fails, restores the contents and restarts again, which is the rollback the save path already performed, with the error distinguishing a clean rollback from one that failed too. Both dialogs raise the failure through the in-app notification surface so it is recorded in the notification centre and stays on screen instead of vanishing with the modal.

The reset path was verified end to end against a live install by driving the handler's own code path: the reset returns clean, the file comes back, and the container stays up.

Closes #1124
Closes #1125
Closes #1126
