### PR TITLE
fix(shims): pass a bare version or help query through untouched

### DIFF
--- a/docs/usage/database.md
+++ b/docs/usage/database.md
@@ -258,7 +258,7 @@ When you give no host, the tool connects to a local lerd database with its admin
 
 Run from inside a git worktree, the shim reads that checkout's own env file rather than the parent site's, so a branch with an isolated database dumps from its own schema even when the worktree lives inside the parent's directory. A worktree whose env was never rewritten keeps using the parent site's.
 
-To point an IDE at a tool, use its shim path, for example `~/.local/share/lerd/bin/mysqldump`.
+To point an IDE at a tool, use its shim path, for example `~/.local/share/lerd/bin/mysqldump`. IDEs validate the path by running the tool with `--version` first, and a bare `--version` or `--help` is always forwarded exactly as given, without the local-database default and without starting the service behind it.
 
 ### Managing shims
 

--- a/internal/cli/client_shims.go
+++ b/internal/cli/client_shims.go
@@ -186,6 +186,28 @@ func isSQLTool(tool string) bool {
 	return isPostgresTool(tool) || tool == "mysql" || tool == "mysqldump"
 }
 
+// isVersionProbe reports whether the arguments are a bare version or help query,
+// which is how an IDE validates a client executable before offering it. The
+// postgres tools answer one only as their very first argument.
+func isVersionProbe(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	switch args[0] {
+	case "--version", "-V", "--help", "-?":
+		return true
+	}
+	return false
+}
+
+// wantsLocalDefault reports whether the shim should aim a hostless invocation at
+// the backing lerd service. A version probe is excluded: prepending -h in front
+// of it leaves pg_dump exiting non-zero with no version, and the IDE that asked
+// then rejects the shim path.
+func wantsLocalDefault(tool string, args []string, hostGiven bool) bool {
+	return !hostGiven && isSQLTool(tool) && !isVersionProbe(args)
+}
+
 // siteServiceForTool returns the lerd service the project at cwd points its
 // DB_HOST at, so a bare dump run from a project targets that project's own
 // database service (e.g. a mariadb-backed project routes to lerd-mariadb-<v>
@@ -261,12 +283,15 @@ func runClientExec(tool string, args []string) error {
 	}
 
 	// Autostart the backing service so its image is present and, for a dump
-	// against a local lerd database (-h lerd-<service>), the server is up.
-	if err := ensureServiceRunning(target.Service); err != nil {
-		return fmt.Errorf("could not start %s: %w", target.Service, err)
-	}
-
+	// against a local lerd database (-h lerd-<service>), the server is up. A
+	// version probe needs neither, so it skips the start once the image is there.
 	image := podman.InstalledImage("lerd-" + target.Service)
+	if image == "" || !isVersionProbe(args) {
+		if err := ensureServiceRunning(target.Service); err != nil {
+			return fmt.Errorf("could not start %s: %w", target.Service, err)
+		}
+		image = podman.InstalledImage("lerd-" + target.Service)
+	}
 	if image == "" {
 		return fmt.Errorf("could not resolve the image for service %q", target.Service)
 	}
@@ -278,7 +303,7 @@ func runClientExec(tool string, args []string) error {
 	// reads -h as --help and redis-cli/mongo tools have their own conventions, so
 	// those pass through and expect an explicit host.
 	var defaultEnv []string
-	if !hostGiven && isSQLTool(tool) {
+	if wantsLocalDefault(tool, args, hostGiven) {
 		args = append([]string{"-h", "lerd-" + target.Service}, args...)
 		defaultEnv = localCredsEnv(tool)
 	}

--- a/internal/cli/client_shims_test.go
+++ b/internal/cli/client_shims_test.go
@@ -119,3 +119,51 @@ func TestHostEnvSet(t *testing.T) {
 		t.Error("MYSQL_HOST should count for mysql tools")
 	}
 }
+
+func TestIsVersionProbe(t *testing.T) {
+	cases := []struct {
+		args []string
+		want bool
+	}{
+		{nil, false},
+		{[]string{"--version"}, true},
+		{[]string{"-V"}, true},
+		{[]string{"--help"}, true},
+		{[]string{"-?"}, true},
+		{[]string{"mydb"}, false},
+		{[]string{"-U", "postgres", "mydb"}, false},
+		// Only the leading position counts: that is the one the postgres tools
+		// answer, and anywhere else it is a value, not a query.
+		{[]string{"-c", "--version"}, false},
+		{[]string{"--where=--version"}, false},
+	}
+	for _, c := range cases {
+		if got := isVersionProbe(c.args); got != c.want {
+			t.Errorf("isVersionProbe(%v) = %v, want %v", c.args, got, c.want)
+		}
+	}
+}
+
+func TestWantsLocalDefault(t *testing.T) {
+	cases := []struct {
+		tool      string
+		args      []string
+		hostGiven bool
+		want      bool
+	}{
+		{"pg_dump", []string{"mydb"}, false, true},
+		{"mysqldump", []string{"mydb"}, false, true},
+		{"pg_dump", []string{"mydb"}, true, false},
+		{"mongodump", []string{"mydb"}, false, false},
+		// An IDE validates the executable with a bare --version. Prepending the
+		// local -h in front of it makes pg_dump exit non-zero with no version.
+		{"pg_dump", []string{"--version"}, false, false},
+		{"pg_restore", []string{"--help"}, false, false},
+		{"mysqldump", []string{"-V"}, false, false},
+	}
+	for _, c := range cases {
+		if got := wantsLocalDefault(c.tool, c.args, c.hostGiven); got != c.want {
+			t.Errorf("wantsLocalDefault(%q, %v, %v) = %v, want %v", c.tool, c.args, c.hostGiven, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Pointing PhpStorm at `~/.local/share/lerd/bin/pg_dump` to export an external database was rejected with "Path to executable is wrong", even though the export itself would have worked.

JetBrains validates a client executable by running it with `--version` and reading the output back. With no host on the command line the shim prepends `-h lerd-<service>` so a bare `pg_dump mydb` lands on the local database, so what actually ran was `pg_dump -h lerd-postgres --version`. The postgres tools only answer `--version` and `--help` as their very first argument, so that exited non-zero with nothing on stdout and the IDE refused the path. `pg_restore` and `pg_dumpall` behaved the same way, `psql` happened to tolerate it, which is why connecting worked while exporting did not.

A leading `--version`, `-V`, `--help` or `-?` is now recognised as a probe and forwarded exactly as given, with no local-target default in front of it. The check reads the arguments rather than the tool name, so it holds for every shim a service exposes, present and future.

A probe also no longer starts the service behind the tool when its image is already there. Printing a version string never needed a database to be up, and an IDE runs that check every time the dialog opens.

Closes #1128