### PR TITLE
feat(databases): let an engine declare its extensions, and create them when needed

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -190,6 +190,7 @@ func main() {
 	root.AddCommand(cli.NewDbRestoreCmd())
 	root.AddCommand(cli.NewDbSnapshotRmCmd())
 	root.AddCommand(cli.NewDbMoveCmd())
+	root.AddCommand(cli.NewDbExtensionCmd())
 	root.AddCommand(cli.NewClientExecCmd())
 	root.AddCommand(cli.NewShimsCmd())
 	root.AddCommand(cli.NewXdebugCmd())

--- a/docs/usage/database.md
+++ b/docs/usage/database.md
@@ -10,6 +10,7 @@ Database commands work with any project type: Laravel, Symfony, NestJS, Next.js,
 | `lerd db:import [-s service] [-d name] [--fresh] <file.sql>` | Import a SQL dump |
 | `lerd db:export [-s service] [-d name] [-o file.sql]` | Export a database to a SQL dump |
 | `lerd db:shell [-s service] [-d name]` | Open an interactive MySQL or PostgreSQL shell |
+| `lerd db:extension list\|add <name>` | List or create the extensions an engine offers |
 | `lerd db:snapshot [name] [-A]` | Create a named, restorable snapshot of a database |
 | `lerd db:snapshots [--all]` | List stored snapshots |
 | `lerd db:restore <name> [-A] [-f]` | Restore a database from a stored snapshot |
@@ -159,6 +160,16 @@ A dump taken from a hosted Postgres or MySQL carries statements about that host'
 lerd filters those out on the way in, which is what `--no-owner --no-privileges` does at dump time, except you do not have to have thought of it when you took the dump. What it skipped is reported next to the errors, since a dump lerd quietly rewrote should never read as one that arrived clean. Row data is never touched: a postgres `COPY` block is passed through byte for byte between its header and its closing `\.`, and on mysql only DDL lines are rewritten, so a value that happens to contain the word survives.
 
 Ownership is the smaller half of what goes wrong. The rest comes from loading into a database that already has the objects, which no filter can fix: the schema, tables, sequences, indexes and constraints all collide, and then the rows land on populated tables as duplicate keys and foreign key violations. Tick **Empty the database first** in the import dialog, or pass `--fresh` on the CLI, and the database is dropped and recreated before the dump loads, so it replaces what was there rather than fighting it.
+
+### Extensions
+
+A postgres engine declares in its [service preset](service-presets.md) which extensions its image can create and which types each provides, so lerd never carries a list of extension names in its own code. Two things follow from that declaration.
+
+An extension marked as always-on is created wherever lerd creates a database, so a project on `postgres-pgvector` gets `vector` in both its app and `_testing` databases, and a database that is dropped and recreated, by an import with **Empty the database first** or by a snapshot restore, comes back with it rather than missing what the site was built on. A database that already exists is topped up the same way, so a site set up before its engine declared an extension picks it up rather than staying behind.
+
+The rest are created only when an imported dump reaches for one, matched on the type names the preset declares. That is how a dump holding a `public.geometry` column brings PostGIS with it on the default engine without every database on the machine paying for it: an empty postgres database is about 7.5 MB, and PostGIS doubles it, while `vector` costs a third of a megabyte, which is why one waits and the other does not. What was created is reported next to the import, since a database should never gain something without saying so.
+
+`lerd db:extension list` shows what the engine offers against what the database already has, and `lerd db:extension add <name>` creates one when you want it before any dump arrives.
 
 ### Compressed and custom-format dumps
 

--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -32,6 +32,7 @@ func NewDbCmd() *cobra.Command {
 	cmd.AddCommand(newDbRestoreCmd("restore"))
 	cmd.AddCommand(newDbSnapshotRmCmd("snapshot:rm"))
 	cmd.AddCommand(newDbMoveCmd("move"))
+	cmd.AddCommand(newDbExtensionCmd("extension"))
 	return cmd
 }
 
@@ -325,7 +326,10 @@ func runDbImport(file, service, database string, fresh bool) error {
 	if err != nil {
 		return err
 	}
-	src, skipped := serviceops.SanitizeDump(config.FamilyOfName(env.service), src)
+	src, notes := serviceops.SanitizeDump(serviceops.DumpTarget{
+		Service: env.service, Family: config.FamilyOfName(env.service), Database: env.database,
+		Extensions: serviceops.DeclaredExtensions(env.service),
+	}, src)
 	// psql exits 0 even when every statement failed, so the output is tallied on
 	// its way to the terminal and the result reported at the end.
 	var tally serviceops.ImportTally
@@ -345,9 +349,12 @@ func runDbImport(file, service, database string, fresh bool) error {
 		return fmt.Errorf("import failed: %w", err)
 	}
 	rep := tally.Report()
-	rep.Skipped = skipped()
-	if note := rep.SkippedSummary(); note != "" {
-		feedback.Line(note)
+	n := notes()
+	rep.Skipped, rep.Created = n.Skipped, n.Created
+	for _, note := range []string{rep.CreatedSummary(), rep.SkippedSummary()} {
+		if note != "" {
+			feedback.Line(note)
+		}
 	}
 	if rep.Errors > 0 {
 		feedback.Warn("import finished but %s", rep.Summary())

--- a/internal/cli/db_extension.go
+++ b/internal/cli/db_extension.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/geodro/lerd/internal/feedback"
+	"github.com/geodro/lerd/internal/serviceops"
+	"github.com/spf13/cobra"
+)
+
+// NewDbExtensionCmd returns the standalone db:extension command.
+func NewDbExtensionCmd() *cobra.Command { return newDbExtensionCmd("db:extension") }
+
+// newDbExtensionCmd manages the database extensions an engine's image can
+// create. lerd creates one automatically when an imported dump reaches for it,
+// so this is for the times you want one before any dump arrives.
+func newDbExtensionCmd(use string) *cobra.Command {
+	var database, service string
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: "List or add database extensions the engine can create",
+		Args:  cobra.NoArgs,
+		RunE:  func(_ *cobra.Command, _ []string) error { return runDbExtensionList(service, database) },
+	}
+	list := &cobra.Command{
+		Use:   "list",
+		Short: "Show which extensions the engine offers and which the database has",
+		Args:  cobra.NoArgs,
+		RunE:  func(_ *cobra.Command, _ []string) error { return runDbExtensionList(service, database) },
+	}
+	add := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Create an extension in the database",
+		Args:  cobra.ExactArgs(1),
+		RunE:  func(_ *cobra.Command, args []string) error { return runDbExtensionAdd(args[0], service, database) },
+	}
+	for _, c := range []*cobra.Command{cmd, list, add} {
+		c.Flags().StringVarP(&database, "database", "d", "", "Database name (default: from .env or .lerd.yaml)")
+		c.Flags().StringVarP(&service, "service", "s", "", "Lerd DB service to target (e.g. postgres)")
+	}
+	cmd.AddCommand(list, add)
+	return cmd
+}
+
+// resolveExtensionTarget resolves the engine and database the same way every
+// other db command does, and rejects engines that have no extensions at all.
+func resolveExtensionTarget(service, database string) (*dbEnv, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	env, err := resolveDB(cwd, service, database)
+	if err != nil {
+		return nil, err
+	}
+	if env.connection != "pgsql" && env.connection != "postgres" {
+		return nil, fmt.Errorf("%s databases have no extensions", env.connection)
+	}
+	if err := ensureServiceRunning(env.service); err != nil {
+		return nil, fmt.Errorf("could not start %s: %w", env.service, err)
+	}
+	return env, nil
+}
+
+func runDbExtensionList(service, database string) error {
+	env, err := resolveExtensionTarget(service, database)
+	if err != nil {
+		return err
+	}
+	installed, err := serviceops.InstalledExtensions(env.service, env.database)
+	if err != nil {
+		return err
+	}
+	have := map[string]bool{}
+	for _, name := range installed {
+		have[name] = true
+	}
+	declared := serviceops.DeclaredExtensions(env.service)
+	fmt.Printf("Extensions in %s on %s:\n", env.database, env.service)
+	for _, name := range installed {
+		fmt.Printf("  %-20s installed\n", name)
+	}
+	for _, e := range declared {
+		if have[e.Name] {
+			continue
+		}
+		types := ""
+		if len(e.Types) > 0 {
+			types = "  (" + strings.Join(e.Types, ", ") + ")"
+		}
+		fmt.Printf("  %-20s available%s\n", e.Name, types)
+	}
+	if len(declared) == 0 {
+		fmt.Println("  the engine declares none beyond what is already there")
+	}
+	return nil
+}
+
+func runDbExtensionAdd(name, service, database string) error {
+	env, err := resolveExtensionTarget(service, database)
+	if err != nil {
+		return err
+	}
+	feedback.Begin()
+	if err := serviceops.CreateExtension(env.service, env.database, name); err != nil {
+		return err
+	}
+	feedback.Done("extension " + feedback.Val(name) + " ready in " + feedback.Val(env.database))
+	return nil
+}

--- a/internal/config/custom_service.go
+++ b/internal/config/custom_service.go
@@ -180,6 +180,22 @@ type CustomService struct {
 	// Introspect, when set, lets the databases UI enumerate the databases inside
 	// this engine and read their sizes. Only database-engine presets declare it.
 	Introspect *Introspect `yaml:"introspect,omitempty" json:"introspect,omitempty"`
+	// Extensions lists the database extensions this engine's image can create.
+	// Only engines that ship any declare them, and lerd creates one only when a
+	// dump reaches for it, since some cost several megabytes per database.
+	Extensions []Extension `yaml:"extensions,omitempty" json:"extensions,omitempty"`
+}
+
+// Extension is a database extension an engine's image ships, with the type
+// names it provides. The types are what let an import tell that a dump needs it,
+// so no Go code has to know what postgis or pgvector are.
+type Extension struct {
+	Name  string   `yaml:"name" json:"name"`
+	Types []string `yaml:"types,omitempty" json:"types,omitempty"`
+	// Always creates the extension wherever lerd creates a database, for the ones
+	// that are cheap or that provide no distinctive type to match a dump against.
+	// The rest wait until a dump reaches for one of their types.
+	Always bool `yaml:"always,omitempty" json:"always,omitempty"`
 }
 
 // ClientShim declares a service client tool that lerd exposes as a host shim.

--- a/internal/config/presets/postgres.yaml
+++ b/internal/config/presets/postgres.yaml
@@ -47,3 +47,10 @@ introspect:
     "SELECT datname || chr(9) || GREATEST(pg_database_size(datname)
     - (SELECT pg_database_size('template1')), 0) FROM pg_database
     WHERE datistemplate = false AND datname <> 'postgres' ORDER BY datname"
+extensions:
+  - name: postgis
+    types: [geometry, geography]
+  - name: postgis_raster
+    types: [raster]
+  - name: postgis_topology
+    types: [topogeometry]

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4233,7 +4233,10 @@ func execDBImport(args map[string]any) (any, *rpcError) {
 	if err != nil {
 		return toolErr(err.Error()), nil
 	}
-	src, skipped := serviceops.SanitizeDump(config.FamilyOfName(svc), src)
+	src, notes := serviceops.SanitizeDump(serviceops.DumpTarget{
+		Service: svc, Family: config.FamilyOfName(svc), Database: env.database,
+		Extensions: serviceops.DeclaredExtensions(svc),
+	}, src)
 	var stderr bytes.Buffer
 	cmd.Stdin = src
 	cmd.Stderr = &stderr
@@ -4241,8 +4244,12 @@ func execDBImport(args map[string]any) (any, *rpcError) {
 		return toolErr(fmt.Sprintf("import failed (%v):\n%s", err, stripANSI(stderr.String()))), nil
 	}
 	msg := fmt.Sprintf("Imported %s into %s (%s)", file, env.database, env.connection)
-	if note := (serviceops.ImportReport{Skipped: skipped()}).SkippedSummary(); note != "" {
-		msg += ", " + note
+	n := notes()
+	rep := serviceops.ImportReport{Skipped: n.Skipped, Created: n.Created}
+	for _, note := range []string{rep.CreatedSummary(), rep.SkippedSummary()} {
+		if note != "" {
+			msg += ", " + note
+		}
 	}
 	return toolOK(msg), nil
 }

--- a/internal/presetfixtures/testdata/postgres-pgvector.yaml
+++ b/internal/presetfixtures/testdata/postgres-pgvector.yaml
@@ -33,3 +33,7 @@ env_vars:
 connection_url: postgresql://postgres:lerd@127.0.0.1:{{host_port}}/lerd
 category: databases
 icon: elephant
+extensions:
+  - name: vector
+    always: true
+    types: [vector, halfvec, sparsevec]

--- a/internal/presetfixtures/testdata/postgres-timescaledb.yaml
+++ b/internal/presetfixtures/testdata/postgres-timescaledb.yaml
@@ -31,3 +31,6 @@ site_init:
   exec: psql -U postgres -d {{site}} -c "CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE"
 category: databases
 icon: elephant
+extensions:
+  - name: timescaledb
+    always: true

--- a/internal/serviceops/databases.go
+++ b/internal/serviceops/databases.go
@@ -218,6 +218,7 @@ type ImportReport struct {
 	Issues  []ImportIssue `json:"issues,omitempty"`
 	Omitted int           `json:"omitted,omitempty"`
 	Skipped []ImportIssue `json:"skipped,omitempty"`
+	Created []ImportIssue `json:"created,omitempty"`
 }
 
 // Summary renders the report as one line for the CLI and the phase stream.
@@ -251,6 +252,19 @@ func (r ImportReport) SkippedSummary() string {
 		parts = append(parts, fmt.Sprintf("%d× %s", s.Count, s.Message))
 	}
 	return "skipped " + strings.Join(parts, "; ")
+}
+
+// CreatedSummary renders the extensions the load needed and lerd created, or
+// could not, for the same reason.
+func (r ImportReport) CreatedSummary() string {
+	if len(r.Created) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(r.Created))
+	for _, c := range r.Created {
+		parts = append(parts, c.Message)
+	}
+	return strings.Join(parts, "; ")
 }
 
 // ImportTally counts an engine's complaints as its output streams past, so a
@@ -433,7 +447,9 @@ func ImportDatabase(service, database string, r io.Reader, opt ImportOptions) (I
 	if err != nil {
 		return ImportReport{}, err
 	}
-	src, skipped := SanitizeDump(family, src)
+	src, notes := SanitizeDump(DumpTarget{
+		Service: service, Family: family, Database: database, Extensions: DeclaredExtensions(service),
+	}, src)
 	cmd := podman.CmdContext(ctx, args...)
 	cmd.Stdin = src
 	out, err := cmd.CombinedOutput()
@@ -441,7 +457,8 @@ func ImportDatabase(service, database string, r io.Reader, opt ImportOptions) (I
 		return ImportReport{}, fmt.Errorf("import failed: %w\n%s", err, strings.TrimSpace(string(out)))
 	}
 	rep := parseImportOutput(string(out))
-	rep.Skipped = skipped()
+	n := notes()
+	rep.Skipped, rep.Created = n.Skipped, n.Created
 	return rep, nil
 }
 

--- a/internal/serviceops/extensions.go
+++ b/internal/serviceops/extensions.go
@@ -1,0 +1,154 @@
+package serviceops
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// Extension is an engine's declared extension, aliased so callers work in one
+// package without the store type leaking a second definition.
+type Extension = config.Extension
+
+// DeclaredExtensions returns what an engine's image can create, preferring the
+// preset the service was installed from so an engine installed before the field
+// existed still gets it, the same resolution IntrospectCommand uses.
+func DeclaredExtensions(service string) []Extension {
+	presetName := service
+	if custom, err := config.LoadCustomService(service); err == nil {
+		if len(custom.Extensions) > 0 {
+			return custom.Extensions
+		}
+		if custom.Preset != "" {
+			presetName = custom.Preset
+		}
+	}
+	if p, err := config.LoadPreset(presetName); err == nil {
+		return p.Extensions
+	}
+	return nil
+}
+
+// alwaysExtensions returns the declared extensions created up front rather than
+// when a dump reaches for one of their types.
+func alwaysExtensions(exts []Extension) []Extension {
+	var out []Extension
+	for _, e := range exts {
+		if e.Always {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// ensureAlwaysExtensions creates an engine's up-front extensions in a database.
+// Every path that makes a database calls it, so one that gets dropped and
+// recreated, by a fresh import or a snapshot restore, comes back whole.
+func ensureAlwaysExtensions(service, database string, exts []Extension) error {
+	for _, e := range alwaysExtensions(exts) {
+		if err := createExtensionFn(service, database, e.Name); err != nil {
+			return fmt.Errorf("extension %s in %s: %w", e.Name, database, err)
+		}
+	}
+	return nil
+}
+
+// EnsureExtensions applies an engine's up-front extensions to a database it has
+// just created.
+func EnsureExtensions(service, database string) error {
+	return ensureAlwaysExtensions(service, database, DeclaredExtensions(service))
+}
+
+// typePattern matches a declared type where a dump would name one: as a column
+// type, schema qualified or not, and never as part of a longer identifier.
+var (
+	patternCache sync.Map
+	typeWord     = regexp.MustCompile(`\W`)
+)
+
+func typePattern(name string) *regexp.Regexp {
+	if re, ok := patternCache.Load(name); ok {
+		return re.(*regexp.Regexp)
+	}
+	re := regexp.MustCompile(`(?i)(^|[^\w.])(\w+\.)?` + regexp.QuoteMeta(name) + `\b`)
+	patternCache.Store(name, re)
+	return re
+}
+
+// ddlLine matches where a type may legitimately be named: the head of a CREATE
+// or ALTER, or an indented continuation of one, which is how pg_dump and
+// mysqldump both write column definitions. It deliberately excludes INSERT and
+// the rest, so the word inside a row value is never read as a type.
+var ddlLine = regexp.MustCompile(`(?i)^(\s+|\s*(CREATE|ALTER)\b)`)
+
+// extensionForLine returns the extension a dump line reaches for, or nil.
+func extensionForLine(exts []Extension, line string) *Extension {
+	if len(exts) == 0 || !ddlLine.MatchString(line) {
+		return nil
+	}
+	for i := range exts {
+		for _, t := range exts[i].Types {
+			if m := typePattern(t).FindStringIndex(line); m != nil && !typeFollowedByWord(line, m[1]) {
+				return &exts[i]
+			}
+		}
+	}
+	return nil
+}
+
+// typeFollowedByWord reports whether the match runs into more identifier, so
+// "vectorized" never counts as a reference to "vector".
+func typeFollowedByWord(line string, end int) bool {
+	if end >= len(line) {
+		return false
+	}
+	return !typeWord.MatchString(string(line[end]))
+}
+
+// CreateExtension creates one extension in a database, idempotently, so a dump
+// that carries its own CREATE EXTENSION and lerd's own call cannot collide.
+func CreateExtension(service, database, name string) error {
+	if err := ValidateDatabaseName(database); err != nil {
+		return err
+	}
+	if !validExtensionName(name) {
+		return fmt.Errorf("invalid extension name %q", name)
+	}
+	sql := fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS %q", name)
+	out, err := containerExec("lerd-"+service,
+		"psql -U postgres -v ON_ERROR_STOP=1 -d "+podman.ShellQuote(database)+" -c "+podman.ShellQuote(sql),
+		[]string{"PGPASSWORD=lerd"}, nil, introspectTimeout)
+	if err != nil {
+		return fmt.Errorf("creating extension %s in %s: %w\n%s", name, database, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// InstalledExtensions returns the extensions already present in a database.
+func InstalledExtensions(service, database string) ([]string, error) {
+	if err := ValidateDatabaseName(database); err != nil {
+		return nil, err
+	}
+	out, err := containerExec("lerd-"+service,
+		"psql -U postgres -At -d "+podman.ShellQuote(database)+" -c "+
+			podman.ShellQuote("SELECT extname FROM pg_extension ORDER BY extname"),
+		[]string{"PGPASSWORD=lerd"}, nil, introspectTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("listing extensions in %s: %w\n%s", database, err, strings.TrimSpace(string(out)))
+	}
+	var names []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if name := strings.TrimSpace(line); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+var extensionName = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
+
+func validExtensionName(name string) bool { return extensionName.MatchString(name) }

--- a/internal/serviceops/extensions_test.go
+++ b/internal/serviceops/extensions_test.go
@@ -1,0 +1,126 @@
+package serviceops
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The engine declares what it can offer, so lerd never carries a list of
+// extension names in Go. The bundled postgres preset runs the PostGIS image and
+// says so.
+func TestDeclaredExtensionsComeFromThePreset(t *testing.T) {
+	exts := DeclaredExtensions("postgres")
+	if len(exts) == 0 {
+		t.Fatal("the bundled postgres preset should declare what its image ships")
+	}
+	var postgis *Extension
+	for i, e := range exts {
+		if e.Name == "postgis" {
+			postgis = &exts[i]
+		}
+	}
+	if postgis == nil {
+		t.Fatalf("postgis not declared: %+v", exts)
+	}
+	if len(postgis.Types) == 0 {
+		t.Error("an extension with no types can never be matched to a dump that needs it")
+	}
+}
+
+func TestDeclaredExtensionsEmptyForEnginesWithNone(t *testing.T) {
+	if got := DeclaredExtensions("mysql"); len(got) != 0 {
+		t.Errorf("mysql declared %+v", got)
+	}
+	if got := DeclaredExtensions("nosuchengine"); len(got) != 0 {
+		t.Errorf("unknown engine declared %+v", got)
+	}
+}
+
+// A dump reaches for an extension by naming one of its types in a column
+// definition. Matching is on the type name, whether or not it is schema
+// qualified, and never on a word that merely contains it.
+func TestExtensionForLine(t *testing.T) {
+	exts := []Extension{
+		{Name: "vector", Types: []string{"vector", "halfvec"}},
+		{Name: "postgis", Types: []string{"geometry", "geography"}},
+	}
+	cases := []struct {
+		line string
+		want string
+	}{
+		{"    embedding public.vector(1536),", "vector"},
+		{"    embedding vector(1536),", "vector"},
+		{"    shape public.geometry(Point,4326),", "postgis"},
+		{"    half public.halfvec(4),", "vector"},
+		{"CREATE TABLE public.users (id integer);", ""},
+		{"INSERT INTO t VALUES ('a vector of values');", ""},
+		{"    name text,", ""},
+		// A column whose name embeds a type name is not a reference to it.
+		{"    vectorized boolean,", ""},
+		{"    geometry_id integer,", ""},
+	}
+	for _, c := range cases {
+		got := ""
+		if e := extensionForLine(exts, c.line); e != nil {
+			got = e.Name
+		}
+		if got != c.want {
+			t.Errorf("extensionForLine(%q) = %q, want %q", c.line, got, c.want)
+		}
+	}
+}
+
+// An extension with no distinctive type cannot be matched against a dump, so it
+// says so instead, and lerd creates it wherever it creates a database.
+func TestAlwaysExtensionsAreTheOnesCreatedUpFront(t *testing.T) {
+	exts := []Extension{
+		{Name: "postgis", Types: []string{"geometry"}},
+		{Name: "timescaledb", Always: true},
+		{Name: "vector", Types: []string{"vector"}, Always: true},
+	}
+	got := alwaysExtensions(exts)
+	if len(got) != 2 || got[0].Name != "timescaledb" || got[1].Name != "vector" {
+		t.Fatalf("always = %+v", got)
+	}
+}
+
+// Every path that creates a database goes through here, so db:create, a fresh
+// import and a snapshot restore all leave the engine's extensions in place.
+func TestEnsureAlwaysExtensionsCreatesEachDeclaredOne(t *testing.T) {
+	var calls []string
+	defer stubExtensionCreate(func(service, database, name string) error {
+		calls = append(calls, service+"/"+database+"/"+name)
+		return nil
+	})()
+	exts := []Extension{{Name: "timescaledb", Always: true}, {Name: "postgis", Types: []string{"geometry"}}}
+	if err := ensureAlwaysExtensions("postgres-timescaledb", "shop", exts); err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 1 || calls[0] != "postgres-timescaledb/shop/timescaledb" {
+		t.Fatalf("calls = %v", calls)
+	}
+}
+
+// A database that cannot get the extension its engine promises is not the
+// database it claims to be, so the failure is not swallowed.
+func TestEnsureAlwaysExtensionsSurfacesAFailure(t *testing.T) {
+	defer stubExtensionCreate(func(_, _, _ string) error { return errors.New("no such extension") })()
+	err := ensureAlwaysExtensions("pg", "shop", []Extension{{Name: "timescaledb", Always: true}})
+	if err == nil || !strings.Contains(err.Error(), "timescaledb") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// A site created before its engine declared an extension has to pick it up, or
+// the declaration only ever reaches databases made after the upgrade.
+func TestEnsureExtensionsAppliesToAnExistingDatabase(t *testing.T) {
+	var calls int
+	defer stubExtensionCreate(func(_, _, _ string) error { calls++; return nil })()
+	if err := ensureAlwaysExtensions("pg", "already_there", []Extension{{Name: "vector", Always: true}}); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1", calls)
+	}
+}

--- a/internal/serviceops/import_sanitize.go
+++ b/internal/serviceops/import_sanitize.go
@@ -27,22 +27,45 @@ var (
 // row data until a lone "\.", so nothing between them may be rewritten.
 var copyStart = regexp.MustCompile(`(?i)^\s*COPY\s.*\sFROM\s+stdin;\s*$`)
 
+// DumpTarget is where a dump is going, so the filter knows which statements can
+// never apply and which extensions the engine could create for it.
+type DumpTarget struct {
+	Service    string
+	Family     string
+	Database   string
+	Extensions []Extension
+}
+
+// ImportNotes is what the filter did on the way in, reported beside the errors
+// so a dump lerd changed never reads as one that arrived untouched.
+type ImportNotes struct {
+	Skipped []ImportIssue
+	Created []ImportIssue
+}
+
+// createExtensionFn is the container call, swapped out in tests.
+var createExtensionFn = CreateExtension
+
 // SanitizeDump filters a dump on its way to the engine so statements that name
-// roles the local engine does not have never reach it. It returns the filtered
-// stream and a function reporting what was dropped, valid once the stream has
-// been read to the end.
-func SanitizeDump(family string, r io.Reader) (io.Reader, func() []ImportIssue) {
-	s := &dumpSanitizer{postgres: family == "postgres"}
+// roles the local engine does not have never reach it, and creates a declared
+// extension the moment a statement reaches for one of its types. It returns the
+// filtered stream and a function reporting what it did, valid once the stream
+// has been read to the end.
+func SanitizeDump(t DumpTarget, r io.Reader) (io.Reader, func() ImportNotes) {
+	s := &dumpSanitizer{target: t, postgres: t.Family == "postgres"}
 	pr, pw := io.Pipe()
 	go func() { pw.CloseWithError(s.copy(r, pw)) }()
-	return pr, s.report
+	return pr, s.notes
 }
 
 type dumpSanitizer struct {
+	target   DumpTarget
 	postgres bool
+	ensured  map[string]bool
 	mu       sync.Mutex
 	counts   map[string]int
 	order    []string
+	created  []ImportIssue
 }
 
 func (s *dumpSanitizer) note(kind string) {
@@ -57,14 +80,38 @@ func (s *dumpSanitizer) note(kind string) {
 	s.counts[kind]++
 }
 
-func (s *dumpSanitizer) report() []ImportIssue {
+func (s *dumpSanitizer) notes() ImportNotes {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	out := make([]ImportIssue, 0, len(s.order))
+	out := ImportNotes{Created: s.created}
 	for _, kind := range s.order {
-		out = append(out, ImportIssue{Message: kind, Count: s.counts[kind]})
+		out.Skipped = append(out.Skipped, ImportIssue{Message: kind, Count: s.counts[kind]})
 	}
 	return out
+}
+
+// ensureExtension creates the extension a line reaches for, before that line is
+// forwarded, so the statement needing it cannot run first. Each is attempted
+// once, whether or not it worked, so a dump full of one type costs one exec.
+func (s *dumpSanitizer) ensureExtension(line string) {
+	if !s.postgres || len(s.target.Extensions) == 0 || s.target.Database == "" {
+		return
+	}
+	e := extensionForLine(s.target.Extensions, line)
+	if e == nil || s.ensured[e.Name] {
+		return
+	}
+	if s.ensured == nil {
+		s.ensured = map[string]bool{}
+	}
+	s.ensured[e.Name] = true
+	msg := "created extension " + e.Name + ", which the dump needs and did not carry"
+	if err := createExtensionFn(s.target.Service, s.target.Database, e.Name); err != nil {
+		msg = "could not create extension " + e.Name + ", which the dump needs: " + err.Error()
+	}
+	s.mu.Lock()
+	s.created = append(s.created, ImportIssue{Message: msg, Count: 1})
+	s.mu.Unlock()
 }
 
 // copy streams r to w a line at a time. ReadString rather than a Scanner: a
@@ -85,6 +132,9 @@ func (s *dumpSanitizer) copy(r io.Reader, w io.Writer) error {
 				inCopy = true
 			default:
 				out = s.filter(line)
+				if out != "" {
+					s.ensureExtension(out)
+				}
 			}
 			if out != "" {
 				if _, werr := io.WriteString(w, out); werr != nil {

--- a/internal/serviceops/import_sanitize_test.go
+++ b/internal/serviceops/import_sanitize_test.go
@@ -1,19 +1,27 @@
 package serviceops
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"testing"
 )
 
+// stubExtensionCreate swaps the container call out for the duration of a test.
+func stubExtensionCreate(fn func(service, database, name string) error) func() {
+	prev := createExtensionFn
+	createExtensionFn = fn
+	return func() { createExtensionFn = prev }
+}
+
 func sanitized(t *testing.T, family, dump string) (string, []ImportIssue) {
 	t.Helper()
-	r, skipped := SanitizeDump(family, strings.NewReader(dump))
+	r, notes := SanitizeDump(DumpTarget{Family: family}, strings.NewReader(dump))
 	out, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return string(out), skipped()
+	return string(out), notes().Skipped
 }
 
 // A dump from a managed provider assigns ownership to roles that only exist
@@ -119,4 +127,91 @@ func total(issues []ImportIssue) int {
 		n += i.Count
 	}
 	return n
+}
+
+// A dump reaches for an extension by naming one of its types, and the statement
+// that needs it must not be forwarded until the extension exists, or it fails
+// exactly as it does today.
+func TestSanitizeDumpCreatesADeclaredExtensionBeforeTheLineNeedingIt(t *testing.T) {
+	var created []string
+	var orderOK bool
+	seen := ""
+	restore := stubExtensionCreate(func(service, database, name string) error {
+		created = append(created, service+"/"+database+"/"+name)
+		orderOK = !strings.Contains(seen, "vector(1536)")
+		return nil
+	})
+	defer restore()
+
+	dump := "CREATE TABLE public.embeddings (\n    id bigint NOT NULL,\n    embedding public.vector(1536)\n);\n"
+	target := DumpTarget{Service: "postgres-pgvector", Family: "postgres", Database: "shop",
+		Extensions: []Extension{{Name: "vector", Types: []string{"vector"}}}}
+	r, notes := SanitizeDump(target, strings.NewReader(dump))
+	buf := make([]byte, 1)
+	out := ""
+	for {
+		n, err := r.Read(buf)
+		out += string(buf[:n])
+		seen = out
+		if err != nil {
+			break
+		}
+	}
+	if out != dump {
+		t.Errorf("dump was rewritten:\n%q", out)
+	}
+	if len(created) != 1 || created[0] != "postgres-pgvector/shop/vector" {
+		t.Fatalf("created = %v", created)
+	}
+	if !orderOK {
+		t.Error("the extension was created after the line that needs it went out")
+	}
+	if n := notes(); len(n.Created) != 1 || n.Created[0].Count != 1 {
+		t.Errorf("notes = %+v", n)
+	}
+}
+
+// Two tables of the same type must not each pay for a container exec.
+func TestSanitizeDumpCreatesEachExtensionOnce(t *testing.T) {
+	calls := 0
+	defer stubExtensionCreate(func(_, _, _ string) error { calls++; return nil })()
+	dump := "CREATE TABLE a (\n    e public.vector(3)\n);\nCREATE TABLE b (\n    e public.vector(3)\n);\n"
+	target := DumpTarget{Service: "pg", Family: "postgres", Database: "shop",
+		Extensions: []Extension{{Name: "vector", Types: []string{"vector"}}}}
+	r, _ := SanitizeDump(target, strings.NewReader(dump))
+	_, _ = io.ReadAll(r)
+	if calls != 1 {
+		t.Errorf("created the extension %d times", calls)
+	}
+}
+
+// An extension the image does not ship has to be named in the report, since the
+// type error the engine raises afterwards cannot be mapped back to it.
+func TestSanitizeDumpReportsAnExtensionItCouldNotCreate(t *testing.T) {
+	defer stubExtensionCreate(func(_, _, _ string) error { return errors.New("not available") })()
+	target := DumpTarget{Service: "pg", Family: "postgres", Database: "shop",
+		Extensions: []Extension{{Name: "postgis", Types: []string{"geometry"}}}}
+	r, notes := SanitizeDump(target, strings.NewReader("CREATE TABLE t (\n    shape public.geometry(Point)\n);\n"))
+	_, _ = io.ReadAll(r)
+	n := notes()
+	if len(n.Created) != 1 || !strings.Contains(n.Created[0].Message, "postgis") {
+		t.Fatalf("notes = %+v", n)
+	}
+	if !strings.Contains(n.Created[0].Message, "could not") {
+		t.Errorf("a failure must not read as a success: %q", n.Created[0].Message)
+	}
+}
+
+// The mysql families have no extensions, and a dump into one must never trigger
+// a lookup for them.
+func TestSanitizeDumpNeverCreatesOnMysql(t *testing.T) {
+	calls := 0
+	defer stubExtensionCreate(func(_, _, _ string) error { calls++; return nil })()
+	target := DumpTarget{Service: "mysql", Family: "mysql", Database: "shop",
+		Extensions: []Extension{{Name: "vector", Types: []string{"vector"}}}}
+	r, _ := SanitizeDump(target, strings.NewReader("CREATE TABLE t (\n    e vector(3)\n);\n"))
+	_, _ = io.ReadAll(r)
+	if calls != 0 {
+		t.Errorf("mysql import created %d extensions", calls)
+	}
 }

--- a/internal/serviceops/provision.go
+++ b/internal/serviceops/provision.go
@@ -101,11 +101,17 @@ func CreateDatabase(svc, name string) (bool, error) {
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			if strings.Contains(string(out), "already exists") {
-				return false, nil
+				// Applied to a database that was already there too, so a site created
+				// before its engine declared an extension picks it up on the next run
+				// rather than only ever on a new database.
+				return false, EnsureExtensions(svc, name)
 			}
 			return false, fmt.Errorf("%s", strings.TrimSpace(string(out)))
 		}
-		return true, nil
+		// The engine's up-front extensions belong to every database it holds, so a
+		// dropped and recreated one comes back whole rather than missing what the
+		// site was built on.
+		return true, EnsureExtensions(svc, name)
 	default:
 		return false, nil
 	}

--- a/internal/ui/databases.go
+++ b/internal/ui/databases.go
@@ -264,12 +264,13 @@ type dbActionResponse struct {
 	Issues  []serviceops.ImportIssue `json:"issues,omitempty"`
 	Omitted int                      `json:"omitted,omitempty"`
 	Skipped []serviceops.ImportIssue `json:"skipped,omitempty"`
+	Created []serviceops.ImportIssue `json:"created,omitempty"`
 }
 
 func writeDBOK(w http.ResponseWriter) { writeJSON(w, dbActionResponse{OK: true}) }
 
 func writeDBReport(w http.ResponseWriter, rep serviceops.ImportReport) {
-	writeJSON(w, dbActionResponse{OK: true, Errors: rep.Errors, Issues: rep.Issues, Omitted: rep.Omitted, Skipped: rep.Skipped})
+	writeJSON(w, dbActionResponse{OK: true, Errors: rep.Errors, Issues: rep.Issues, Omitted: rep.Omitted, Skipped: rep.Skipped, Created: rep.Created})
 }
 func writeDBError(w http.ResponseWriter, m string) {
 	writeJSON(w, dbActionResponse{OK: false, Error: m})

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "{name} wird gelöscht…",
   "databases_snapshotDeleted": "{name} gelöscht",
   "databases_importedWithErrors": "{file} importiert, aber die Engine meldete {count} Fehler",
+  "databases_importedWithExtensions": "{file} importiert und {names} erstellt",
   "databases_restoredWithErrors": "{name} wiederhergestellt, aber die Engine meldete {count} Fehler",
   "databases_importIssuesLink": "Ansehen, was die Engine gemeldet hat",
   "databases_importIssuesBody": "Der Dump wurde geladen, aber die Engine hat diese Anweisungen abgelehnt.",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "Deleting {name}…",
   "databases_snapshotDeleted": "Deleted {name}",
   "databases_importedWithErrors": "Imported {file}, but the engine reported {count} errors",
+  "databases_importedWithExtensions": "Imported {file}, and created {names}",
   "databases_restoredWithErrors": "Restored {name}, but the engine reported {count} errors",
   "databases_importIssuesLink": "See what the engine reported",
   "databases_importIssuesBody": "The dump loaded, but the engine rejected these statements.",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "Eliminando {name}…",
   "databases_snapshotDeleted": "{name} eliminada",
   "databases_importedWithErrors": "{file} importado, pero el motor informó de {count} errores",
+  "databases_importedWithExtensions": "Importado {file}, y creado {names}",
   "databases_restoredWithErrors": "{name} restaurada, pero el motor informó de {count} errores",
   "databases_importIssuesLink": "Ver lo que informó el motor",
   "databases_importIssuesBody": "El volcado se cargó, pero el motor rechazó estas sentencias.",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "Suppression de {name}…",
   "databases_snapshotDeleted": "{name} supprimé",
   "databases_importedWithErrors": "{file} importé, mais le moteur a signalé {count} erreurs",
+  "databases_importedWithExtensions": "{file} importé, et {names} créé",
   "databases_restoredWithErrors": "{name} restauré, mais le moteur a signalé {count} erreurs",
   "databases_importIssuesLink": "Voir ce que le moteur a signalé",
   "databases_importIssuesBody": "Le dump s'est chargé, mais le moteur a rejeté ces instructions.",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "Menghapus {name}…",
   "databases_snapshotDeleted": "{name} dihapus",
   "databases_importedWithErrors": "{file} diimpor, tetapi engine melaporkan {count} kesalahan",
+  "databases_importedWithExtensions": "Mengimpor {file}, dan membuat {names}",
   "databases_restoredWithErrors": "{name} dipulihkan, tetapi engine melaporkan {count} kesalahan",
   "databases_importIssuesLink": "Lihat apa yang dilaporkan engine",
   "databases_importIssuesBody": "Dump berhasil dimuat, tetapi mesin menolak pernyataan ini.",

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "Eliminazione di {name}…",
   "databases_snapshotDeleted": "{name} eliminato",
   "databases_importedWithErrors": "{file} importato, ma il motore ha segnalato {count} errori",
+  "databases_importedWithExtensions": "Importato {file}, e creato {names}",
   "databases_restoredWithErrors": "{name} ripristinato, ma il motore ha segnalato {count} errori",
   "databases_importIssuesLink": "Vedi cosa ha segnalato il motore",
   "databases_importIssuesBody": "Il dump è stato caricato, ma il motore ha rifiutato queste istruzioni.",

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "{name} を削除中…",
   "databases_snapshotDeleted": "{name} を削除しました",
   "databases_importedWithErrors": "{file} をインポートしましたが、エンジンが {count} 件のエラーを報告しました",
+  "databases_importedWithExtensions": "{file} をインポートし、{names} を作成しました",
   "databases_restoredWithErrors": "{name} を復元しましたが、エンジンが {count} 件のエラーを報告しました",
   "databases_importIssuesLink": "エンジンの報告内容を見る",
   "databases_importIssuesBody": "ダンプは読み込まれましたが、エンジンはこれらの文を拒否しました。",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "{name} verwijderen…",
   "databases_snapshotDeleted": "{name} verwijderd",
   "databases_importedWithErrors": "{file} geïmporteerd, maar de engine meldde {count} fouten",
+  "databases_importedWithExtensions": "{file} geïmporteerd en {names} aangemaakt",
   "databases_restoredWithErrors": "{name} hersteld, maar de engine meldde {count} fouten",
   "databases_importIssuesLink": "Bekijk wat de engine meldde",
   "databases_importIssuesBody": "De dump is geladen, maar de engine heeft deze statements geweigerd.",

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "Usuwanie {name}…",
   "databases_snapshotDeleted": "Usunięto {name}",
   "databases_importedWithErrors": "Zaimportowano {file}, ale silnik zgłosił błędy: {count}",
+  "databases_importedWithExtensions": "Zaimportowano {file} i utworzono {names}",
   "databases_restoredWithErrors": "Przywrócono {name}, ale silnik zgłosił błędy: {count}",
   "databases_importIssuesLink": "Zobacz, co zgłosił silnik",
   "databases_importIssuesBody": "Zrzut się wczytał, ale silnik odrzucił te instrukcje.",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "Excluindo {name}…",
   "databases_snapshotDeleted": "{name} excluído",
   "databases_importedWithErrors": "{file} importado, mas o engine reportou {count} erros",
+  "databases_importedWithExtensions": "Importado {file}, e criado {names}",
   "databases_restoredWithErrors": "{name} restaurado, mas o engine reportou {count} erros",
   "databases_importIssuesLink": "Veja o que o engine reportou",
   "databases_importIssuesBody": "O dump foi carregado, mas o motor rejeitou estas instruções.",

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "Se șterge {name}…",
   "databases_snapshotDeleted": "S-a șters {name}",
   "databases_importedWithErrors": "S-a importat {file}, dar motorul a raportat {count} erori",
+  "databases_importedWithExtensions": "S-a importat {file} și s-a creat {names}",
   "databases_restoredWithErrors": "S-a restaurat {name}, dar motorul a raportat {count} erori",
   "databases_importIssuesLink": "Vezi ce a raportat motorul",
   "databases_importIssuesBody": "Dump-ul s-a încărcat, dar motorul a respins aceste instrucțiuni.",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "{name} siliniyor…",
   "databases_snapshotDeleted": "{name} silindi",
   "databases_importedWithErrors": "{file} içe aktarıldı, ancak motor {count} hata bildirdi",
+  "databases_importedWithExtensions": "{file} içe aktarıldı ve {names} oluşturuldu",
   "databases_restoredWithErrors": "{name} geri yüklendi, ancak motor {count} hata bildirdi",
   "databases_importIssuesLink": "Motorun bildirdiklerine bakın",
   "databases_importIssuesBody": "Döküm yüklendi, ancak motor bu ifadeleri reddetti.",

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "Đang xóa {name}…",
   "databases_snapshotDeleted": "Đã xóa {name}",
   "databases_importedWithErrors": "Đã nhập {file}, nhưng engine báo {count} lỗi",
+  "databases_importedWithExtensions": "Đã nhập {file} và tạo {names}",
   "databases_restoredWithErrors": "Đã khôi phục {name}, nhưng engine báo {count} lỗi",
   "databases_importIssuesLink": "Xem những gì engine báo lại",
   "databases_importIssuesBody": "Bản kết xuất đã được tải, nhưng engine từ chối các câu lệnh này.",

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -1140,6 +1140,7 @@
   "databases_deletingSnapshot": "正在删除 {name}…",
   "databases_snapshotDeleted": "已删除 {name}",
   "databases_importedWithErrors": "已导入 {file}，但引擎报告了 {count} 个错误",
+  "databases_importedWithExtensions": "已导入 {file}，并创建了 {names}",
   "databases_restoredWithErrors": "已恢复 {name}，但引擎报告了 {count} 个错误",
   "databases_importIssuesLink": "查看引擎报告的内容",
   "databases_importIssuesBody": "转储已载入，但引擎拒绝了这些语句。",

--- a/internal/ui/web/src/stores/databases.ts
+++ b/internal/ui/web/src/stores/databases.ts
@@ -74,6 +74,9 @@ type Result = {
   // What the daemon held back on the way in, so a load that came out clean
   // because lerd filtered it says so rather than looking untouched.
   skipped?: ImportIssue[];
+  // Extensions the load needed and the daemon created, so a database that
+  // gained one is never changed without a word.
+  created?: ImportIssue[];
 };
 
 async function post(service: string, path: string, body: unknown): Promise<Result> {

--- a/internal/ui/web/src/tabs/databases/DatabaseCard.svelte
+++ b/internal/ui/web/src/tabs/databases/DatabaseCard.svelte
@@ -52,6 +52,7 @@
     issues?: ImportIssue[];
     omitted?: number;
     skipped?: ImportIssue[];
+    created?: ImportIssue[];
   } | null>(null);
   // The dump waiting on the confirmation, and whether to empty the database
   // before it loads.
@@ -68,7 +69,13 @@
     if (importOp.tone === 'error') return m.databases_importFailed({ error: importOp.error ?? '' });
     if (importOp.tone === 'warn')
       return m.databases_importedWithErrors({ file: importOp.file, count: importOp.errors ?? 0 });
-    if (importOp.tone === 'done') return m.databases_imported({ file: importOp.file });
+    if (importOp.tone === 'done')
+      return importOp.created?.length
+        ? m.databases_importedWithExtensions({
+            file: importOp.file,
+            names: importOp.created.map((c) => c.message).join(', ')
+          })
+        : m.databases_imported({ file: importOp.file });
     return importOp.percent === null
       ? m.databases_importing({ file: importOp.file })
       : m.databases_importingPercent({
@@ -132,12 +139,13 @@
         errors: res.errors,
         issues: res.issues,
         omitted: res.omitted,
-        skipped: res.skipped
+        skipped: res.skipped,
+        created: res.created
       };
       showIssues = (res.issues ?? []).length > 0;
       return;
     }
-    importOp = { tone: 'done', file: file.name, percent: null };
+    importOp = { tone: 'done', file: file.name, percent: null, created: res.created };
     clearTimeout(clearDone);
     clearDone = setTimeout(() => {
       if (importOp?.tone === 'done') importOp = null;

--- a/internal/ui/web/src/tabs/databases/DatabaseCard.test.ts
+++ b/internal/ui/web/src/tabs/databases/DatabaseCard.test.ts
@@ -17,6 +17,8 @@ const { dropDatabase, exportUrl, importDatabase } = vi.hoisted(() => ({
       error?: string;
       errors?: number;
       issues?: { message: string; count: number }[];
+      skipped?: { message: string; count: number }[];
+      created?: { message: string; count: number }[];
     }> => ({ ok: true })
   )
 }));
@@ -176,6 +178,16 @@ describe('DatabaseCard', () => {
     await pickDump(container);
     expect(await findByText(/ownership and privilege statements/)).toBeInTheDocument();
     expect(getByText('80×')).toBeInTheDocument();
+  });
+
+  it('names an extension it created for the dump, so nothing changes silently', async () => {
+    importDatabase.mockResolvedValueOnce({
+      ok: true,
+      created: [{ message: 'vector', count: 1 }]
+    });
+    const { container, findByText } = render(DatabaseCard, { props: { engine, entry: parent } });
+    await pickDump(container);
+    expect(await findByText('Imported shop.sql, and created vector')).toBeInTheDocument();
   });
 
   it('surfaces the engine error when an import fails', async () => {


### PR DESCRIPTION
A dump from a managed provider usually does not carry its extensions, because `pg_dump` skips the ones the connecting user does not own. The one that prompted this holds a `vector` column and no `CREATE EXTENSION` anywhere, so the table was rejected, everything depending on it failed, and nothing in the load said which extension would have fixed it.

A postgres engine now declares what its image can create, with the types each extension provides, so no extension name lives in Go. Two things read that declaration.

An entry marked `always` is created wherever lerd creates a database. That fixes a hole that predates this: `postgres-timescaledb` created its extension from a `site_init` exec, which fires once per project at `lerd env` and names only `{{site}}`, so the `_testing` database never got it, and a snapshot restore, which drops and recreates, took it away. `postgres-pgvector` had no such line at all, so `vector` was only ever created by hand.

The rest wait until a dump names one of their types, which is how a `geometry` column brings PostGIS with it without every database on the machine paying for it. Measured: an empty postgres database is 7521 kB and PostGIS takes it to 15 MB, while `vector` costs 333 kB. That difference is the whole reason for the two modes.

The same declaration backs `lerd db:extension list` and `lerd db:extension add`, for when an extension is wanted before any dump arrives. What was created rides back on the import report and shows on the card, since a database must never gain something without saying so.

On the dump that prompted this, all 45 tables now land and one harmless complaint is left, down from 90 errors and a missing table.

The `vector` and `timescaledb` declarations live in the store and need a companion change in lerd-env/services; `postgis` ships here because `postgres` is the bundled default stack. Until that lands, the fixtures under `internal/presetfixtures/testdata` carry them so the tests resolve.

Closes #1137