### PR TITLE
fix(databases): count the COPY cascade on postgres 18

### DIFF
--- a/docs/usage/database.md
+++ b/docs/usage/database.md
@@ -179,7 +179,7 @@ A custom-format archive (`pg_dump -Fc`) is not a SQL file at all, and `psql` say
 
 ### Imports that finish with errors
 
-`psql` exits 0 whether a dump loaded cleanly or every statement in it failed, so `lerd db:import`, `lerd db:restore` and a cross-version `service migrate` count what the engine wrote and end on a warning instead of "import complete" when it complained. On the terminal the warning spells out the first few complaints with their counts and folds the rest into a tally, which is usually enough to name the cause on sight; the web UI lists them all: a flood of `invalid command \N` means a `COPY` block had no table to load into, so the failure is further up in whatever stopped that table from being created.
+`psql` exits 0 whether a dump loaded cleanly or every statement in it failed, so `lerd db:import`, `lerd db:restore` and a cross-version `service migrate` count what the engine wrote and end on a warning instead of "import complete" when it complained. On the terminal the warning spells out the first few complaints with their counts and folds the rest into a tally, which is usually enough to name the cause on sight; the web UI lists them all: a flood of `invalid command \N`, or of `backslash commands are restricted` on PostgreSQL 18, means a `COPY` block had no table to load into, so the failure is further up in whatever stopped that table from being created. Both phrasings are the same thing and both fold into a single line in the report, so the cascade never crowds out its cause.
 
 ### Large dumps and `max_allowed_packet`
 

--- a/internal/serviceops/databases.go
+++ b/internal/serviceops/databases.go
@@ -347,7 +347,7 @@ func (t *ImportTally) Report() ImportReport {
 	}
 	loudestNoise := ""
 	for _, msg := range t.order {
-		if strings.HasPrefix(msg, "invalid command") && (loudestNoise == "" || t.seen[msg] > t.seen[loudestNoise]) {
+		if isCopyCascadeLine(msg) && (loudestNoise == "" || t.seen[msg] > t.seen[loudestNoise]) {
 			loudestNoise = msg
 		}
 	}
@@ -357,7 +357,7 @@ func (t *ImportTally) Report() ImportReport {
 	}
 	rep := ImportReport{Errors: t.errors}
 	for _, msg := range t.order {
-		if strings.HasPrefix(msg, "invalid command") {
+		if isCopyCascadeLine(msg) {
 			continue
 		}
 		if len(rep.Issues) == room {
@@ -384,7 +384,7 @@ func trimImportPrefix(line string) string {
 	if !strings.HasPrefix(line, "psql:") {
 		return line
 	}
-	for _, marker := range []string{": ERROR", ": invalid command"} {
+	for _, marker := range []string{": ERROR", ": invalid command", ": backslash commands are restricted"} {
 		if i := strings.Index(line, marker); i >= 0 {
 			return line[i+2:]
 		}
@@ -393,7 +393,16 @@ func trimImportPrefix(line string) string {
 }
 
 func isImportErrorLine(line string) bool {
-	return strings.HasPrefix(line, "ERROR") || strings.HasPrefix(line, "invalid command")
+	return strings.HasPrefix(line, "ERROR") || isCopyCascadeLine(line)
+}
+
+// isCopyCascadeLine reports whether a complaint is COPY data being read as SQL,
+// which is what follows a table the dump failed to create. Postgres 18 dumps
+// open with \restrict, and in that mode psql refuses backslash commands, so the
+// rows that used to read "invalid command \N" now say so differently.
+func isCopyCascadeLine(msg string) bool {
+	return strings.HasPrefix(msg, "invalid command") ||
+		strings.HasPrefix(msg, "backslash commands are restricted")
 }
 
 // DumpReader unwraps a gzipped dump so a .sql.gz loads like a .sql. The engine

--- a/internal/serviceops/import_report_test.go
+++ b/internal/serviceops/import_report_test.go
@@ -185,3 +185,58 @@ func TestImportTallyBoundsPartialLine(t *testing.T) {
 		t.Fatalf("partial = %d bytes, want at most %d", got, maxPartialLine)
 	}
 }
+
+// pg_dump 18 opens its dumps with \restrict, and in that mode psql refuses
+// backslash commands. So the COPY data that spills out after a missing table,
+// which used to read "invalid command \N", now reads this instead, and the
+// tally never saw it.
+func TestParseImportOutputCountsThePostgres18Cascade(t *testing.T) {
+	out := `ERROR:  type "public.vector" does not exist
+ERROR:  relation "public.embeddings" does not exist
+backslash commands are restricted; only \unrestrict is allowed
+backslash commands are restricted; only \unrestrict is allowed
+backslash commands are restricted; only \unrestrict is allowed
+ERROR:  syntax error at or near "1"
+`
+	rep := parseImportOutput(out)
+	if rep.Errors != 6 {
+		t.Fatalf("errors = %d, want 6", rep.Errors)
+	}
+	// The cascade folds into one entry, at the end, so it cannot crowd out the
+	// failure that caused it.
+	last := rep.Issues[len(rep.Issues)-1]
+	if !strings.Contains(last.Message, "backslash commands are restricted") || last.Count != 3 {
+		t.Fatalf("last issue = %+v", last)
+	}
+	if rep.Issues[0].Message != `ERROR:  type "public.vector" does not exist` {
+		t.Errorf("the cause is no longer first: %+v", rep.Issues[0])
+	}
+	if len(rep.Issues) != 4 {
+		t.Errorf("issues = %+v", rep.Issues)
+	}
+}
+
+// Both phrasings are the same cascade, and a dump that somehow produced both
+// must still leave room for the statements that matter.
+func TestParseImportOutputFoldsEitherCascadePhrasing(t *testing.T) {
+	out := "invalid command \\N\ninvalid command \\N\n" +
+		"backslash commands are restricted; only \\unrestrict is allowed\n" +
+		"ERROR:  relation \"t\" does not exist\n"
+	rep := parseImportOutput(out)
+	noise := 0
+	for _, i := range rep.Issues {
+		if strings.HasPrefix(i.Message, "invalid command") || strings.HasPrefix(i.Message, "backslash commands") {
+			noise++
+		}
+	}
+	if noise != 1 {
+		t.Errorf("both phrasings should fold to one entry: %+v", rep.Issues)
+	}
+}
+
+func TestTrimImportPrefixHandlesTheRestrictedLine(t *testing.T) {
+	got := trimImportPrefix(`psql:<stdin>:4412: backslash commands are restricted; only \unrestrict is allowed`)
+	if got != `backslash commands are restricted; only \unrestrict is allowed` {
+		t.Errorf("trim = %q", got)
+	}
+}


### PR DESCRIPTION
When a `COPY` block has no table to load into, its rows are read as SQL and the engine complains once per line. That flood is how the shape of a failed import is recognised, so the report counts it and folds it into one entry that cannot crowd out the statement that caused it.

None of that happened on PostgreSQL 18. Dumps written by `pg_dump` 18 open with a `\restrict` line, and in that mode `psql` refuses backslash commands, so the rows that used to read `invalid command \N` now say `backslash commands are restricted` instead, and the tally recognised only the older phrasing.

Measured on a dump whose table type is missing on the target, before and after:

```
before:  the engine reported 6 errors: ... 2x syntax error at or near "1"
after:   the engine reported 48 errors: ... 2x syntax error ...; and 1 more
```

42 complaints had been going past uncounted, and they are the ones carrying the shape of the failure. Both phrasings are now the same cascade, counted, folded together and left at the end of the list so the cause stays first.

Closes #1138