### PR TITLE
feat(ide): point a JetBrains project at its lerd database

### DIFF
--- a/docs/usage/database.md
+++ b/docs/usage/database.md
@@ -296,6 +296,22 @@ Run from inside a git worktree, the shim reads that checkout's own env file rath
 
 To point an IDE at a tool, use its shim path, for example `~/.local/share/lerd/bin/mysqldump`. IDEs validate the path by running the tool with `--version` first, and a bare `--version` or `--help` is always forwarded exactly as given, without the local-database default and without starting the service behind it.
 
+### The connection in a JetBrains project
+
+An IDE cannot work out a site's database on its own. The site's `.env` names the container and its internal port, `lerd-postgres-pgvector:5432`, which is correct inside the network and unusable from the machine, where the same engine answers on `127.0.0.1` and whatever port it was published on. No format is shared across IDEs for a project to declare a database either, so the connection normally gets typed by hand, and typed wrong the moment two engines of one family push the second onto a shifted port.
+
+JetBrains keeps its data sources in `<project>/.idea/dataSources.xml`, so lerd maintains one entry there, named `<database> (lerd)`, scoped to the project's own database rather than the whole server, which on a busy machine holds every other project's databases too.
+
+It is written on `lerd link`, refreshed by `lerd env` and by the group commands, and removed by `lerd unlink`. An entry lerd owns whose database the project no longer uses is dropped rather than left behind, which is what keeps a site that moved onto a group's shared database from carrying two connections. The port is read fresh every time, so an engine that moved is picked up rather than remembered wrong.
+
+A grouped secondary sharing the main site's database gets the main's database, because sharing rewrites the secondary's own `DB_DATABASE`, which is what the connection is resolved from.
+
+A project linked before this existed picks it up the next time either command runs there, which is also how a connection catches up with an engine that moved to another port.
+
+lerd only ever touches a project that already has a `.idea` directory, because that directory existing is what says the project is open in a JetBrains IDE; it never creates one. Inside the file it owns exactly one entry, keyed on a stable identifier derived from the project path, so your own data sources are left byte for byte as they were. The user and password ride in the JDBC URL, since JetBrains keeps secrets in its own credential store where lerd cannot write, and they are the fixed local ones the site's `.env` already spells out.
+
+Set `ide_data_source: false` in `~/.config/lerd/config.yaml` to leave IDE files alone entirely. IDEs validate the path by running the tool with `--version` first, and a bare `--version` or `--help` is always forwarded exactly as given, without the local-database default and without starting the service behind it.
+
 ### Managing shims
 
 List the shims your installed services expose and whether each is installed:

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -1088,6 +1088,13 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	// keeps pointing at a host that no longer resolves.
 	alignWorktreeEnvDBConnection(site, envPath, envRelPath, envFormat)
 
+	// The connection a JetBrains project points at is rebuilt from the same
+	// resolution, so a database or an engine that changed here reaches the IDE
+	// rather than leaving it on coordinates that no longer answer.
+	if syncIDEDataSource(site.Path).wrote() {
+		envInfo("  IDE database connection updated in .idea\n")
+	}
+
 	envInfo("Done.\n")
 	return nil
 }

--- a/internal/cli/group.go
+++ b/internal/cli/group.go
@@ -97,6 +97,9 @@ func runGroupAdd(_ *cobra.Command, args []string) error {
 	if groupShareDB {
 		feedback.Note("sharing the " + main.Name + " database")
 	}
+	// Sharing rewrote the secondary's DB_DATABASE, so its IDE connection now
+	// points at a database it no longer uses.
+	syncIDEDataSource(secondary.Path)
 	return nil
 }
 
@@ -123,6 +126,7 @@ func runGroupDB(_ *cobra.Command, args []string) error {
 	} else {
 		feedback.Done("now using a separate database")
 	}
+	syncIDEDataSource(secondary.Path)
 	return nil
 }
 
@@ -136,6 +140,8 @@ func runGroupRemove(_ *cobra.Command, _ []string) error {
 	}
 	feedback.Begin()
 	feedback.Done("ungrouped " + secondary.Name + " → " + feedback.Val(secondary.PrimaryDomain()))
+	// Leaving a group restores the site's own database name.
+	syncIDEDataSource(secondary.Path)
 	return nil
 }
 

--- a/internal/cli/ide_datasource.go
+++ b/internal/cli/ide_datasource.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/ide"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// jdbcDialect maps a database family onto what a JetBrains IDE calls its
+// driver. It is the last thing here that knows one engine from another, and
+// belongs in the service store alongside the rest of the per-engine data (see
+// the introspect and extensions fields) once that schema grows a place for it.
+var jdbcDialect = map[string]struct{ driver, class, scheme string }{
+	"postgres": {"postgresql", "org.postgresql.Driver", "postgresql"},
+	"mysql":    {"mysql", "com.mysql.cj.jdbc.Driver", "mysql"},
+	"mariadb":  {"mariadb", "org.mariadb.jdbc.Driver", "mariadb"},
+}
+
+// syncIDEDataSource points a JetBrains project at the site's database, using
+// coordinates that work from the machine rather than the ones in the site's env
+// file, which name the container and are unusable outside the network. Silent
+// when the project is not a JetBrains one or the engine has no JDBC dialect.
+// ideSyncResult says what a sync did, and why when it did nothing, so a command
+// can report the actual reason instead of listing the possibilities.
+type ideSyncResult struct {
+	outcome  ide.Outcome
+	database string
+	reason   string // set when there was nothing lerd could point at
+}
+
+func (r ideSyncResult) wrote() bool { return r.outcome == ide.Written && r.reason == "" }
+
+func syncIDEDataSource(siteRoot string) ideSyncResult {
+	if !config.IDEDataSourceEnabled() {
+		return ideSyncResult{reason: "ide_data_source is off in config.yaml"}
+	}
+	env, err := resolveDB(siteRoot, "", "")
+	if err != nil || env.database == "" {
+		return ideSyncResult{reason: "no database is configured for this project"}
+	}
+	ds, ok := ideDataSourceFor(env)
+	if !ok {
+		return ideSyncResult{reason: "lerd has no IDE driver for " + env.connection + " databases"}
+	}
+	outcomes, err := ide.Sync(siteRoot, []ide.DataSource{ds})
+	if err != nil {
+		return ideSyncResult{reason: err.Error()}
+	}
+	return ideSyncResult{outcome: outcomes[0], database: env.database}
+}
+
+// removeIDEDataSource drops lerd's entry when a site stops being lerd's.
+func removeIDEDataSource(siteRoot string) {
+	_, _ = ide.Remove(siteRoot)
+}
+
+// ideDataSourceFor builds the connection as an IDE stores it. The password is
+// carried in the URL because JetBrains keeps secrets in its own credential
+// store, which lerd cannot write, and it is the fixed local one that the site's
+// env file already spells out next to it.
+func ideDataSourceFor(env *dbEnv) (ide.DataSource, bool) {
+	family := config.FamilyOfName(env.service)
+	dialect, ok := jdbcDialect[family]
+	if !ok {
+		return ide.DataSource{}, false
+	}
+	port := hostPortForService(env.service)
+	if port == 0 || env.database == "" {
+		return ide.DataSource{}, false
+	}
+	return ide.DataSource{
+		Key:    env.database,
+		Name:   env.database + " (lerd)",
+		Driver: dialect.driver,
+		Class:  dialect.class,
+		URL:    fmt.Sprintf("jdbc:%s://127.0.0.1:%d/%s", dialect.scheme, port, env.database),
+		User:   env.username,
+	}, true
+}
+
+// hostPortForService returns the port the engine answers on from the machine,
+// read fresh every time: a second engine of the same family is published on a
+// shifted port, and that shift can happen long after a site was linked.
+func hostPortForService(service string) int {
+	if p := config.ServicePublishedPort(service); p > 0 {
+		return p
+	}
+	if custom, err := config.LoadCustomService(service); err == nil && len(custom.Ports) > 0 {
+		if p := podman.PrimaryHostPort(custom.Ports); p > 0 {
+			return p
+		}
+	}
+	return podman.PrimaryHostPort(config.PresetPorts(service))
+}

--- a/internal/cli/ide_datasource_test.go
+++ b/internal/cli/ide_datasource_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// The env file names the container, which is right inside the network and
+// unusable from the machine, so the IDE has to be given the published port and
+// loopback instead.
+func TestIDEDataSourceUsesHostFacingCoordinates(t *testing.T) {
+	env := &dbEnv{service: "postgres", connection: "pgsql", database: "shop", username: "postgres", password: "lerd"}
+	ds, ok := ideDataSourceFor(env)
+	if !ok {
+		t.Fatal("postgres should have a JDBC dialect")
+	}
+	if strings.Contains(ds.URL, "lerd-postgres") {
+		t.Errorf("URL points at the container: %q", ds.URL)
+	}
+	for _, want := range []string{"jdbc:postgresql://127.0.0.1:", "/shop"} {
+		if !strings.Contains(ds.URL, want) {
+			t.Errorf("URL missing %q: %q", want, ds.URL)
+		}
+	}
+	// The IDE authenticates from its own sidecar, so the user rides there rather
+	// than in the URL.
+	if ds.User != "postgres" {
+		t.Errorf("user = %q", ds.User)
+	}
+	if ds.Name != "shop (lerd)" {
+		t.Errorf("name = %q", ds.Name)
+	}
+	if ds.Class != "org.postgresql.Driver" {
+		t.Errorf("driver class = %q", ds.Class)
+	}
+}
+
+func TestIDEDataSourceDialectPerFamily(t *testing.T) {
+	cases := map[string]string{"mysql": "com.mysql.cj.jdbc.Driver", "postgres": "org.postgresql.Driver"}
+	for service, class := range cases {
+		ds, ok := ideDataSourceFor(&dbEnv{service: service, database: "shop", username: "root", password: "lerd"})
+		if !ok {
+			t.Fatalf("%s should have a dialect", service)
+		}
+		if ds.Class != class {
+			t.Errorf("%s driver = %q, want %q", service, ds.Class, class)
+		}
+	}
+}
+
+// An engine lerd has no JDBC dialect for is left alone rather than written as a
+// connection the IDE cannot open.
+func TestIDEDataSourceSkipsEnginesWithNoDialect(t *testing.T) {
+	if _, ok := ideDataSourceFor(&dbEnv{service: "mongo", database: "shop"}); ok {
+		t.Error("mongo should not produce a JDBC data source")
+	}
+}

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -524,6 +524,10 @@ func printLinkSummary(site config.Site, start time.Time) {
 	// Reached on every successful link path, so this is where we record that the
 	// site is linked for this process (even when the summary itself is deferred).
 	linkApplied = true
+	// A JetBrains project gets its database connection pointed at lerd, using
+	// coordinates that work from the machine rather than the container ones the
+	// site's env file carries.
+	wroteDataSource := syncIDEDataSource(site.Path).wrote()
 	if linkSkipSummary {
 		return
 	}
@@ -554,6 +558,9 @@ func printLinkSummary(site config.Site, start time.Time) {
 			db += " · cache " + cache
 		}
 		sum.Row("DB", db)
+	}
+	if wroteDataSource {
+		sum.Row("IDE", "database connection written to .idea")
 	}
 	sum.Print()
 }

--- a/internal/cli/unlink.go
+++ b/internal/cli/unlink.go
@@ -110,6 +110,10 @@ func UnlinkSite(name string) error {
 	// the moment another site needs it.
 	offerRemoveOrphanedFramework(site.Framework)
 
+	// The site is no longer lerd's, so neither is the connection lerd wrote into
+	// its IDE configuration.
+	removeIDEDataSource(site.Path)
+
 	autoStopUnusedServices()
 	autoStopUnusedFPMs()
 

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -57,7 +57,11 @@ type GlobalConfig struct {
 	// placeholders; if omitted, lerd appends the file. Empty = autodetect a
 	// known GUI editor (code/cursor/phpstorm/subl/zed), then xdg-open/open.
 	Editor string `yaml:"editor,omitempty" mapstructure:"editor"`
-	PHP    struct {
+	// IDEDataSource keeps a JetBrains project's database connection pointed at
+	// lerd, written only into a project that already has a .idea directory. Set
+	// false to leave every IDE file alone.
+	IDEDataSource *bool `yaml:"ide_data_source,omitempty" mapstructure:"ide_data_source"`
+	PHP           struct {
 		DefaultVersion string            `yaml:"default_version" mapstructure:"default_version"`
 		XdebugEnabled  map[string]bool   `yaml:"xdebug_enabled"  mapstructure:"xdebug_enabled"`
 		XdebugMode     map[string]string `yaml:"xdebug_mode,omitempty" mapstructure:"xdebug_mode"`
@@ -1135,4 +1139,15 @@ func SaveGlobal(cfg *GlobalConfig) error {
 	}
 	invalidateGlobalCache()
 	return nil
+}
+
+// IDEDataSourceEnabled reports whether lerd may maintain a project's JetBrains
+// data source. On by default: it only ever touches a project that already has a
+// .idea directory, and only its own entry in it.
+func IDEDataSourceEnabled() bool {
+	cfg, err := LoadGlobal()
+	if err != nil || cfg == nil || cfg.IDEDataSource == nil {
+		return true
+	}
+	return *cfg.IDEDataSource
 }

--- a/internal/config/ide_datasource_test.go
+++ b/internal/config/ide_datasource_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeGlobal(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	if err := os.MkdirAll(filepath.Join(dir, "lerd"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "lerd", "config.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	invalidateGlobalCache()
+}
+
+// Writing into a project only ever touches a directory the IDE already made,
+// and only lerd's own entry in it, so it is on unless asked otherwise.
+func TestIDEDataSourceEnabledByDefault(t *testing.T) {
+	writeGlobal(t, "editor: code\n")
+	if !IDEDataSourceEnabled() {
+		t.Error("want enabled when the key is absent")
+	}
+}
+
+func TestIDEDataSourceCanBeTurnedOff(t *testing.T) {
+	writeGlobal(t, "ide_data_source: false\n")
+	if IDEDataSourceEnabled() {
+		t.Error("want disabled when the key is false")
+	}
+	writeGlobal(t, "ide_data_source: true\n")
+	if !IDEDataSourceEnabled() {
+		t.Error("want enabled when the key is true")
+	}
+}

--- a/internal/ide/jetbrains.go
+++ b/internal/ide/jetbrains.go
@@ -1,0 +1,371 @@
+// Package ide keeps a project's IDE-side pointers at lerd in sync. An IDE
+// cannot discover a site's database on its own: the site's env file carries the
+// container host and port, which are right inside the network and unusable from
+// the machine, and no format is shared across IDEs for a project to declare one.
+// JetBrains keeps its data sources in a plain XML file, so lerd maintains one
+// entry there with host-facing coordinates.
+package ide
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DataSource is one connection as the IDE stores it. Key identifies it inside a
+// project, so an entry is updated in place across runs, and one whose database
+// the project no longer uses can be told apart from one that is still wanted.
+type DataSource struct {
+	Key    string // stable within a project, e.g. the database name
+	Name   string // shown in the IDE's database tool window
+	Driver string // driver-ref, e.g. "postgresql"
+	Class  string // JDBC driver class
+	URL    string // full jdbc: URL
+	User   string // the IDE authenticates with this, from its own sidecar
+}
+
+// ownedSuffix marks the entries lerd maintains, so one whose database the
+// project has stopped using can be cleaned up without a record of what was
+// written last time.
+const ownedSuffix = " (lerd)"
+
+// Owns reports whether a data source name is one lerd maintains.
+func Owns(name string) bool { return strings.HasSuffix(name, ownedSuffix) }
+
+const (
+	dataSourcesFile = "dataSources.xml"
+	localFile       = "dataSources.local.xml"
+	componentOpen   = `<component name="DataSourceManagerImpl" format="xml" multifile-model="true">`
+	localComponent  = `<component name="dataSourceStorageLocal">`
+)
+
+func skeleton(component string) string {
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  ` + component + `
+  </component>
+</project>
+`
+}
+
+// Outcome says what a sync did, so a caller can tell a user why nothing was
+// written rather than list the reasons it might have been.
+type Outcome int
+
+const (
+	// NotJetBrains means the project has no .idea directory.
+	NotJetBrains Outcome = iota
+	// AlreadyConfigured means a data source already points at the same database.
+	AlreadyConfigured
+	// Written means lerd's entry was added or brought up to date.
+	Written
+)
+
+// Sync writes lerd's data source into the project's JetBrains configuration. A
+// project with no .idea directory is not open in a JetBrains IDE, and lerd
+// creating one would be litter, so it is left alone.
+// Sync brings the project's JetBrains configuration in line with the given set
+// of connections: lerd's own entries are replaced by exactly these, and every
+// other data source in the files is left as it was. The outcome of each source
+// is returned in the order it was given.
+func Sync(projectDir string, sources []DataSource) ([]Outcome, error) {
+	dir := filepath.Join(projectDir, ".idea")
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return repeat(NotJetBrains, len(sources)), nil
+	}
+	body, err := load(dir, dataSourcesFile, componentOpen)
+	if err != nil {
+		return nil, err
+	}
+	local, err := load(dir, localFile, localComponent)
+	if err != nil {
+		return nil, err
+	}
+
+	// Entries lerd wrote before are dropped up front, so one whose database the
+	// project no longer uses does not linger, and the ones still wanted are
+	// written back below.
+	keep := map[string]bool{}
+	for _, ds := range sources {
+		keep[ds.Name] = true
+	}
+	body = dropOwnedExcept(body, keep)
+	local = dropOwnedExcept(local, keep)
+
+	outcomes := make([]Outcome, len(sources))
+	for i, ds := range sources {
+		uuid := dataSourceUUID(projectDir, ds.Key)
+		// Once lerd owns an entry it keeps it current. Until then, a connection
+		// the user already wired to the same database is theirs to keep, and a
+		// second one beside it would be clutter rather than help.
+		if !strings.Contains(body, `uuid="`+uuid+`"`) && hasEquivalent(body, ds.URL) {
+			outcomes[i] = AlreadyConfigured
+			continue
+		}
+		body = dropEntry(body, uuid)
+		if body, err = insert(body, renderEntry(uuid, ds), componentOpen); err != nil {
+			return outcomes, err
+		}
+		// The user belongs in the sidecar the IDE authenticates from: it takes the
+		// user from there, not from the URL, and an entry without one connects as
+		// nobody. The password stays in the IDE's own credential store, which is
+		// beyond reach, so the first connect asks for it once.
+		if ds.User != "" {
+			local = dropEntry(local, uuid)
+			if local, err = insert(local, renderLocalEntry(uuid, ds), localComponent); err != nil {
+				return outcomes, err
+			}
+		}
+		outcomes[i] = Written
+	}
+	if err := write(dir, dataSourcesFile, body); err != nil {
+		return outcomes, err
+	}
+	return outcomes, write(dir, localFile, local)
+}
+
+func repeat(o Outcome, n int) []Outcome {
+	out := make([]Outcome, n)
+	for i := range out {
+		out[i] = o
+	}
+	return out
+}
+
+// dropOwnedExcept removes every entry lerd maintains whose name is not wanted
+// any more, which is how a site that changed database loses the old connection.
+func dropOwnedExcept(body string, keep map[string]bool) string {
+	for {
+		name, uuid, found := nextOwnedEntry(body, keep)
+		if !found {
+			return body
+		}
+		_ = name
+		body = dropEntry(body, uuid)
+	}
+}
+
+// nextOwnedEntry finds the first lerd-owned entry whose name is no longer
+// wanted, returning its name and uuid.
+func nextOwnedEntry(body string, keep map[string]bool) (string, string, bool) {
+	for rest, offset := body, 0; ; {
+		i := strings.Index(rest, "<data-source ")
+		if i < 0 {
+			return "", "", false
+		}
+		rest = rest[i:]
+		offset += i
+		end := strings.Index(rest, ">")
+		if end < 0 {
+			return "", "", false
+		}
+		head := rest[:end]
+		name, uuid := attr(head, "name"), attr(head, "uuid")
+		if Owns(name) && !keep[name] && uuid != "" {
+			return name, uuid, true
+		}
+		rest = rest[len("<data-source "):]
+		offset += len("<data-source ")
+	}
+}
+
+func attr(head, name string) string {
+	marker := name + `="`
+	i := strings.Index(head, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := head[i+len(marker):]
+	j := strings.Index(rest, `"`)
+	if j < 0 {
+		return ""
+	}
+	return unescape(rest[:j])
+}
+
+func renderLocalEntry(uuid string, ds DataSource) string {
+	return fmt.Sprintf(`    <data-source name="%s" uuid="%s">
+      <secret-storage>master_key</secret-storage>
+      <user-name>%s</user-name>
+    </data-source>
+`, escape(ds.Name), uuid, escape(ds.User))
+}
+
+// insert places an entry above the closing tag of the component it belongs to,
+// adding the component when the file has never held one.
+func insert(body, entry, component string) (string, error) {
+	if i := lineStartOf(body, "</component>"); i >= 0 {
+		return body[:i] + entry + body[i:], nil
+	}
+	i := lineStartOf(body, "</project>")
+	if i < 0 {
+		return "", fmt.Errorf("not a JetBrains project file")
+	}
+	return body[:i] + "  " + component + "\n" + entry + "  </component>\n" + body[i:], nil
+}
+
+// Remove drops every entry lerd maintains and leaves everything else as it was.
+func Remove(projectDir string) (bool, error) {
+	dir := filepath.Join(projectDir, ".idea")
+	removed := false
+	for _, name := range []string{dataSourcesFile, localFile} {
+		body, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		trimmed := dropOwnedExcept(string(body), nil)
+		if trimmed == string(body) {
+			continue
+		}
+		if err := write(dir, name, trimmed); err != nil {
+			return removed, err
+		}
+		removed = true
+	}
+	return removed, nil
+}
+
+// hasEquivalent reports whether the file already holds a data source aimed at
+// the same database, however it spells the host.
+func hasEquivalent(body, url string) bool {
+	for _, found := range jdbcURLs(body) {
+		if sameTarget(found, url) {
+			return true
+		}
+	}
+	return false
+}
+
+func jdbcURLs(body string) []string {
+	var out []string
+	for rest := body; ; {
+		i := strings.Index(rest, "<jdbc-url>")
+		if i < 0 {
+			return out
+		}
+		rest = rest[i+len("<jdbc-url>"):]
+		j := strings.Index(rest, "</jdbc-url>")
+		if j < 0 {
+			return out
+		}
+		out = append(out, strings.TrimSpace(rest[:j]))
+		rest = rest[j:]
+	}
+}
+
+// sameTarget compares two JDBC URLs by what they actually connect to: the
+// dialect, the host once loopback is spelled one way, the port and the database.
+// Credentials and other query parameters are not part of the target.
+func sameTarget(a, b string) bool {
+	ah, ap, ad, aok := jdbcTarget(a)
+	bh, bp, bd, bok := jdbcTarget(b)
+	return aok && bok && ah == bh && ap == bp && ad == bd
+}
+
+func jdbcTarget(url string) (dialectHost, port, database string, ok bool) {
+	rest, found := strings.CutPrefix(url, "jdbc:")
+	if !found {
+		return "", "", "", false
+	}
+	dialect, rest, found := strings.Cut(rest, "://")
+	if !found {
+		return "", "", "", false
+	}
+	authority, path, _ := strings.Cut(rest, "/")
+	database, _, _ = strings.Cut(path, "?")
+	host, port, _ := strings.Cut(authority, ":")
+	switch host {
+	case "localhost", "127.0.0.1", "::1", "[::1]":
+		host = "localhost"
+	}
+	return dialect + "://" + host, port, database, true
+}
+
+// lineStartOf returns the index of the start of the line holding tag, so an
+// insertion lands above it and leaves its indentation where it was.
+func lineStartOf(body, tag string) int {
+	i := strings.Index(body, tag)
+	if i < 0 {
+		return -1
+	}
+	for i > 0 && (body[i-1] == ' ' || body[i-1] == '\t') {
+		i--
+	}
+	return i
+}
+
+func load(dir, name, component string) (string, error) {
+	body, err := os.ReadFile(filepath.Join(dir, name))
+	if os.IsNotExist(err) {
+		return skeleton(component), nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func write(dir, name, body string) error {
+	return os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644)
+}
+
+// dropEntry removes the data-source block carrying our uuid. The file is edited
+// as text rather than parsed and re-marshalled, because everything else in it
+// belongs to the user and has to come back byte for byte.
+func dropEntry(body, uuid string) string {
+	marker := `uuid="` + uuid + `"`
+	at := strings.Index(body, marker)
+	if at < 0 {
+		return body
+	}
+	start := strings.LastIndex(body[:at], "<data-source ")
+	if start < 0 {
+		return body
+	}
+	end := strings.Index(body[at:], "</data-source>")
+	if end < 0 {
+		return body
+	}
+	end = at + end + len("</data-source>")
+	for end < len(body) && (body[end] == '\n' || body[end] == '\r') {
+		end++
+	}
+	for start > 0 && (body[start-1] == ' ' || body[start-1] == '\t') {
+		start--
+	}
+	return body[:start] + body[end:]
+}
+
+func renderEntry(uuid string, ds DataSource) string {
+	return fmt.Sprintf(`    <data-source source="LOCAL" name="%s" uuid="%s">
+      <driver-ref>%s</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>%s</jdbc-driver>
+      <jdbc-url>%s</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+`, escape(ds.Name), uuid, escape(ds.Driver), escape(ds.Class), escape(ds.URL))
+}
+
+var (
+	escaper   = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;")
+	unescaper = strings.NewReplacer("&amp;", "&", "&lt;", "<", "&gt;", ">", "&quot;", `"`)
+)
+
+func escape(s string) string   { return escaper.Replace(s) }
+func unescape(s string) string { return unescaper.Replace(s) }
+
+// dataSourceUUID derives a stable identifier from the project and the key, so
+// repeated runs update the same entries instead of piling up, a site and its
+// worktree databases each keep their own, and two projects never collide.
+func dataSourceUUID(projectDir, key string) string {
+	sum := sha1.Sum([]byte("lerd:datasource:" + projectDir + "\x00" + key))
+	b := sum[:16]
+	b[6] = (b[6] & 0x0f) | 0x50 // version 5, as a name-derived uuid
+	b[8] = (b[8] & 0x3f) | 0x80 // RFC 4122 variant
+	h := hex.EncodeToString(b)
+	return strings.Join([]string{h[0:8], h[8:12], h[12:16], h[16:20], h[20:32]}, "-")
+}

--- a/internal/ide/jetbrains_test.go
+++ b/internal/ide/jetbrains_test.go
@@ -1,0 +1,450 @@
+package ide
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func project(t *testing.T, withIdea bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	if withIdea {
+		if err := os.MkdirAll(filepath.Join(dir, ".idea"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func read(t *testing.T, dir string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, ".idea", "dataSources.xml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+var pg = DataSource{
+	Key: "shop", Name: "shop (lerd)", Driver: "postgresql", Class: "org.postgresql.Driver",
+	URL: "jdbc:postgresql://127.0.0.1:5433/shop", User: "postgres",
+}
+
+// sync drives the one-source case the older tests were written around.
+func sync(dir string, ds DataSource) (Outcome, error) {
+	out, err := Sync(dir, []DataSource{ds})
+	if len(out) == 0 {
+		return NotJetBrains, err
+	}
+	return out[0], err
+}
+
+// The .idea directory existing is what says the project is open in a JetBrains
+// IDE. lerd creating one for a project that is not would be litter.
+func TestSyncSkipsAProjectWithoutIdea(t *testing.T) {
+	dir := project(t, false)
+	done, err := sync(dir, pg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if done != NotJetBrains {
+		t.Error("wrote a data source into a project that is not a JetBrains one")
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".idea")); !os.IsNotExist(err) {
+		t.Error(".idea was created")
+	}
+}
+
+func TestSyncWritesAWholeFileWhenThereIsNone(t *testing.T) {
+	dir := project(t, true)
+	if _, err := sync(dir, pg); err != nil {
+		t.Fatal(err)
+	}
+	out := read(t, dir)
+	for _, want := range []string{
+		`<component name="DataSourceManagerImpl"`,
+		`name="shop (lerd)"`,
+		"<driver-ref>postgresql</driver-ref>",
+		"jdbc:postgresql://127.0.0.1:5433/shop",
+		"</project>",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+const existing = `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="production" uuid="0d073425-0b90-47fa-ad3d-859060bb86ac">
+      <driver-ref>postgresql</driver-ref>
+      <jdbc-url>jdbc:postgresql://db.example.com:5432/main</jdbc-url>
+    </data-source>
+  </component>
+</project>
+`
+
+// A user's own sources live in the same file, so lerd owns exactly one entry
+// and leaves every byte of the rest alone.
+func TestSyncLeavesOtherDataSourcesUntouched(t *testing.T) {
+	dir := project(t, true)
+	path := filepath.Join(dir, ".idea", "dataSources.xml")
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sync(dir, pg); err != nil {
+		t.Fatal(err)
+	}
+	out := read(t, dir)
+	if !strings.Contains(out, `name="production"`) || !strings.Contains(out, "db.example.com") {
+		t.Fatalf("the user's own data source was lost:\n%s", out)
+	}
+	if !strings.Contains(out, `name="shop (lerd)"`) {
+		t.Fatalf("lerd's entry was not added:\n%s", out)
+	}
+	if strings.Count(out, "<data-source ") != 2 {
+		t.Errorf("expected two data sources, got:\n%s", out)
+	}
+}
+
+// Run twice, the entry is updated in place rather than accumulating, and a port
+// that moved is picked up.
+func TestSyncUpdatesItsOwnEntryInPlace(t *testing.T) {
+	dir := project(t, true)
+	if _, err := sync(dir, pg); err != nil {
+		t.Fatal(err)
+	}
+	moved := pg
+	moved.URL = "jdbc:postgresql://127.0.0.1:5544/shop"
+	if _, err := sync(dir, moved); err != nil {
+		t.Fatal(err)
+	}
+	out := read(t, dir)
+	if strings.Count(out, "<data-source ") != 1 {
+		t.Errorf("entry duplicated:\n%s", out)
+	}
+	if strings.Contains(out, "5433") || !strings.Contains(out, "5544") {
+		t.Errorf("the moved port was not picked up:\n%s", out)
+	}
+}
+
+func TestRemoveDropsOnlyLerdsEntry(t *testing.T) {
+	dir := project(t, true)
+	path := filepath.Join(dir, ".idea", "dataSources.xml")
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sync(dir, pg); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Remove(dir); err != nil {
+		t.Fatal(err)
+	}
+	out := read(t, dir)
+	if strings.Contains(out, "(lerd)") {
+		t.Errorf("lerd's entry survived:\n%s", out)
+	}
+	if !strings.Contains(out, `name="production"`) {
+		t.Errorf("the user's own data source was removed:\n%s", out)
+	}
+}
+
+// The identifier has to be stable across runs, or every sync would add a second
+// entry, and distinct per project so two sites never fight over one.
+func TestDataSourceUUIDIsStableAndPerProject(t *testing.T) {
+	a, b := dataSourceUUID("/home/u/shop", "db"), dataSourceUUID("/home/u/shop", "db")
+	if a != b {
+		t.Errorf("uuid is not stable: %q vs %q", a, b)
+	}
+	if a == dataSourceUUID("/home/u/other", "db") {
+		t.Error("two projects share one uuid")
+	}
+	if len(a) != 36 || strings.Count(a, "-") != 4 {
+		t.Errorf("not a uuid: %q", a)
+	}
+}
+
+// A name carrying XML metacharacters must not break the file.
+func TestSyncEscapesTheName(t *testing.T) {
+	dir := project(t, true)
+	ds := pg
+	ds.Name = `a & b "c"`
+	if _, err := sync(dir, ds); err != nil {
+		t.Fatal(err)
+	}
+	out := read(t, dir)
+	if strings.Contains(out, `name="a & b "c""`) {
+		t.Errorf("name not escaped:\n%s", out)
+	}
+	if !strings.Contains(out, "&amp;") {
+		t.Errorf("ampersand not escaped:\n%s", out)
+	}
+}
+
+// The file is a user's to read, so the entry lands indented like its siblings
+// and the tag it was inserted above keeps its own indentation.
+func TestSyncKeepsTheFileTidy(t *testing.T) {
+	dir := project(t, true)
+	path := filepath.Join(dir, ".idea", "dataSources.xml")
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sync(dir, pg); err != nil {
+		t.Fatal(err)
+	}
+	out := read(t, dir)
+	if !strings.Contains(out, "\n    <data-source source=\"LOCAL\" name=\"shop (lerd)\"") {
+		t.Errorf("entry is not indented with its siblings:\n%s", out)
+	}
+	if !strings.Contains(out, "\n  </component>") {
+		t.Errorf("the component close lost its indentation:\n%s", out)
+	}
+}
+
+const handWired = `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="postgres:lerd-postgres" uuid="0d073425-0b90-47fa-ad3d-859060bb86ac">
+      <driver-ref>postgresql</driver-ref>
+      <jdbc-url>jdbc:postgresql://localhost:5433/shop</jdbc-url>
+    </data-source>
+  </component>
+</project>
+`
+
+// Someone who already wired the connection by hand does not want a second entry
+// beside it pointing at the same database, however lerd would have spelled it.
+func TestSyncSkipsWhenAnEquivalentConnectionExists(t *testing.T) {
+	dir := project(t, true)
+	path := filepath.Join(dir, ".idea", "dataSources.xml")
+	if err := os.WriteFile(path, []byte(handWired), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wrote, err := sync(dir, pg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wrote != AlreadyConfigured {
+		t.Error("added a duplicate of the user's own data source")
+	}
+	if out := read(t, dir); strings.Contains(out, "(lerd)") {
+		t.Errorf("file was modified:\n%s", out)
+	}
+}
+
+// A hand-wired entry pointing somewhere else is not the same connection, so
+// lerd still adds its own.
+func TestSyncStillWritesWhenTheExistingOnePointsElsewhere(t *testing.T) {
+	dir := project(t, true)
+	path := filepath.Join(dir, ".idea", "dataSources.xml")
+	stale := strings.Replace(handWired, "localhost:5433/shop", "localhost:5432/other", 1)
+	if err := os.WriteFile(path, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wrote, err := sync(dir, pg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wrote != Written {
+		t.Error("a different database should not count as the same connection")
+	}
+}
+
+// Once lerd owns an entry it keeps it current, even if a matching hand-wired
+// one appears later, or the two would fight over every run.
+func TestSyncKeepsUpdatingItsOwnEntryDespiteALookalike(t *testing.T) {
+	dir := project(t, true)
+	if _, err := sync(dir, pg); err != nil {
+		t.Fatal(err)
+	}
+	body := read(t, dir)
+	body = strings.Replace(body, "</component>",
+		"  <data-source source=\"LOCAL\" name=\"mine\" uuid=\"aaaaaaaa-0000-4000-8000-000000000000\">\n"+
+			"      <jdbc-url>jdbc:postgresql://localhost:5433/shop</jdbc-url>\n    </data-source>\n  </component>", 1)
+	if err := os.WriteFile(filepath.Join(dir, ".idea", "dataSources.xml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	moved := pg
+	moved.URL = "jdbc:postgresql://127.0.0.1:5544/shop"
+	if wrote, err := sync(dir, moved); err != nil || wrote != Written {
+		t.Fatalf("wrote=%v err=%v", wrote, err)
+	}
+	if out := read(t, dir); !strings.Contains(out, "5544") {
+		t.Errorf("lerd's own entry stopped being updated:\n%s", out)
+	}
+}
+
+func TestSameTarget(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"jdbc:postgresql://localhost:5433/shop", "jdbc:postgresql://127.0.0.1:5433/shop?user=postgres", true},
+		{"jdbc:mysql://127.0.0.1:3306/shop", "jdbc:mysql://localhost:3306/shop", true},
+		{"jdbc:postgresql://localhost:5433/shop", "jdbc:postgresql://localhost:5432/shop", false},
+		{"jdbc:postgresql://localhost:5433/shop", "jdbc:postgresql://localhost:5433/other", false},
+		{"jdbc:postgresql://localhost:5433/shop", "jdbc:mysql://localhost:5433/shop", false},
+		{"jdbc:redis://lerd-redis:6379/0", "jdbc:postgresql://localhost:5433/shop", false},
+	}
+	for _, c := range cases {
+		if got := sameTarget(c.a, c.b); got != c.want {
+			t.Errorf("sameTarget(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// JetBrains authenticates with the user from its own sidecar, not from the URL,
+// so an entry without one connects as nobody and comes back empty.
+func TestSyncWritesTheUserIntoTheCredentialsSidecar(t *testing.T) {
+	dir := project(t, true)
+	if _, err := sync(dir, pg); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, ".idea", "dataSources.local.xml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(b)
+	for _, want := range []string{
+		`<component name="dataSourceStorageLocal">`,
+		"<user-name>postgres</user-name>",
+		"<secret-storage>master_key</secret-storage>",
+		`name="shop (lerd)"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// The sidecar is the IDE's own bookkeeping for every other data source, so
+// lerd's entry goes in beside them without disturbing any.
+func TestSyncLeavesTheSidecarsOtherEntriesAlone(t *testing.T) {
+	dir := project(t, true)
+	local := `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="dataSourceStorageLocal" created-in="PS-262.8665.325">
+    <data-source name="production" uuid="0d073425-0b90-47fa-ad3d-859060bb86ac">
+      <database-info product="PostgreSQL" version="18.4" />
+      <user-name>deploy</user-name>
+    </data-source>
+  </component>
+</project>
+`
+	path := filepath.Join(dir, ".idea", "dataSources.local.xml")
+	if err := os.WriteFile(path, []byte(local), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sync(dir, pg); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(path)
+	out := string(b)
+	if !strings.Contains(out, "<user-name>deploy</user-name>") || !strings.Contains(out, `created-in="PS-262.8665.325"`) {
+		t.Errorf("the IDE's own bookkeeping was disturbed:\n%s", out)
+	}
+	if strings.Count(out, "<data-source ") != 2 {
+		t.Errorf("expected two entries:\n%s", out)
+	}
+}
+
+func TestRemoveClearsBothFiles(t *testing.T) {
+	dir := project(t, true)
+	if _, err := sync(dir, pg); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Remove(dir); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"dataSources.xml", "dataSources.local.xml"} {
+		b, _ := os.ReadFile(filepath.Join(dir, ".idea", name))
+		if strings.Contains(string(b), "(lerd)") {
+			t.Errorf("%s still holds lerd's entry:\n%s", name, b)
+		}
+	}
+}
+
+// Sync takes the whole set lerd owns, so two databases keep separate entries
+// rather than overwriting each other.
+func TestSyncWritesOneEntryPerDatabase(t *testing.T) {
+	dir := project(t, true)
+	staging := DataSource{Key: "shop_staging", Name: "shop_staging (lerd)", Driver: "postgresql",
+		Class: "org.postgresql.Driver", URL: "jdbc:postgresql://127.0.0.1:5433/shop_staging", User: "postgres"}
+	out, err := Sync(dir, []DataSource{pg, staging})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out[0] != Written || out[1] != Written {
+		t.Fatalf("outcomes = %v", out)
+	}
+	body := read(t, dir)
+	if strings.Count(body, "<data-source ") != 2 {
+		t.Errorf("expected two entries:\n%s", body)
+	}
+	for _, want := range []string{`name="shop (lerd)"`, `name="shop_staging (lerd)"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %s:\n%s", want, body)
+		}
+	}
+}
+
+// A database that is no longer the project's, because grouping moved the site
+// onto the group's shared one, takes its connection with it, without lerd
+// having to remember what it wrote last time.
+func TestSyncDropsAnEntryWhoseDatabaseIsGone(t *testing.T) {
+	dir := project(t, true)
+	staging := DataSource{Key: "shop_staging", Name: "shop_staging (lerd)", Driver: "postgresql",
+		Class: "org.postgresql.Driver", URL: "jdbc:postgresql://127.0.0.1:5433/shop_staging", User: "postgres"}
+	if _, err := Sync(dir, []DataSource{pg, staging}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Sync(dir, []DataSource{pg}); err != nil {
+		t.Fatal(err)
+	}
+	body := read(t, dir)
+	if strings.Contains(body, "shop_staging") {
+		t.Errorf("the connection for a database no longer in the set survived:\n%s", body)
+	}
+	if !strings.Contains(body, `name="shop (lerd)"`) {
+		t.Errorf("the site's own connection was lost:\n%s", body)
+	}
+	local, _ := os.ReadFile(filepath.Join(dir, ".idea", "dataSources.local.xml"))
+	if strings.Contains(string(local), "shop_staging") {
+		t.Errorf("the sidecar kept the removed entry:\n%s", local)
+	}
+}
+
+// Cleaning up lerd's own entries must never reach a user's, whatever they are
+// called.
+func TestSyncCleanupLeavesUserEntriesAlone(t *testing.T) {
+	dir := project(t, true)
+	path := filepath.Join(dir, ".idea", "dataSources.xml")
+	mine := strings.Replace(existing, `name="production"`, `name="@lerd"`, 1)
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Sync(dir, []DataSource{pg}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Sync(dir, []DataSource{pg}); err != nil {
+		t.Fatal(err)
+	}
+	body := read(t, dir)
+	if !strings.Contains(body, `name="@lerd"`) {
+		t.Errorf("a user entry whose name merely mentions lerd was removed:\n%s", body)
+	}
+}
+
+func TestOwns(t *testing.T) {
+	for name, want := range map[string]bool{
+		"shop (lerd)": true, "@lerd": false, "postgres@lerd": false,
+		"lerd": false, "my db (lerd) copy": false,
+	} {
+		if got := Owns(name); got != want {
+			t.Errorf("Owns(%q) = %v, want %v", name, got, want)
+		}
+	}
+}


### PR DESCRIPTION
An IDE cannot work out a site's database on its own, and the reason is ours. The site's env file names the container and its internal port, which is right inside the network and unusable from the machine, where the same engine answers on loopback and whatever port it was published on. There is no format shared across IDEs for a project to declare a database either, so the connection gets typed by hand, and typed wrong the moment a second engine of one family pushes the first onto a shifted port.

JetBrains keeps its data sources in a plain XML file, so lerd maintains one entry there, scoped to the project's own database rather than the whole server, which on a busy machine holds every other project's databases too. It is written on `lerd link`, refreshed by `lerd env` and by the group commands, and removed by `lerd unlink`. The port is read fresh every time rather than remembered.

It detects and never creates. A project with no `.idea` directory is not open in a JetBrains IDE, so it is left alone. Inside the files lerd owns exactly one entry, keyed on the project and the database, and every other data source comes back byte for byte, because they are the user's. An entry lerd owns whose database the project has stopped using is dropped, which is what keeps a site that moved onto a group's shared database from carrying two connections. A connection the user already wired to the same database is theirs to keep, so lerd stands aside rather than adding a duplicate beside it.

A grouped secondary sharing the main site's database resolves the main's database, because sharing rewrites the secondary's own `DB_DATABASE`, which is what the connection is built from. Verified against a real group: main and sharing secondary both resolve the same database, and a site with no database configured writes nothing rather than a URL with no database on it.

The user goes into the credentials sidecar the IDE authenticates from, since it takes the user from there and not from the URL, and an entry without one connects as nobody and comes back empty. The password stays in the IDE's own credential store, which is beyond reach, so the first connect asks once.

Set `ide_data_source: false` in `config.yaml` to leave IDE files alone entirely.

Closes #1134