### PR TITLE
fix(sites): stop a link damaging what it finds, and report what it skipped

### DIFF
--- a/docs/usage/sites.md
+++ b/docs/usage/sites.md
@@ -315,6 +315,16 @@ Paths are compared after resolving symlinks, and the resolved path is what gets 
 
 You can link a new site directly from the dashboard by clicking the **+** button in the sites panel header. A directory browser modal lets you navigate to the project folder and click **Link This Directory**. After linking, the site's `.env` is auto-configured and the UI switches to the new site's settings.
 
+Clicking **Link This Directory** is the consent a terminal link would ask for, so
+a project that declares a host-proxy dev command has that command started for
+you. The command is printed in the modal's output, so what lerd runs on your host
+is on screen either way.
+
+The environment step can fail on its own — a project with no framework, or a
+framework that declares no env file, has nothing to configure. The site is still
+linked, and the modal says what went wrong instead of closing on a clean
+success.
+
 ---
 
 ## Unlinked domains

--- a/internal/cli/confirm_replace.go
+++ b/internal/cli/confirm_replace.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/geodro/lerd/internal/linker"
 	"github.com/pmezard/go-difflib/difflib"
 	"gopkg.in/yaml.v3"
 )
@@ -25,11 +25,32 @@ const (
 	replaceFromDisk                         // apply disk → .lerd.yaml
 )
 
-// confirmReplace compares existing (on disk) and replacement (from .lerd.yaml)
-// by marshalling both to YAML. If they are identical it returns replaceSkip
-// immediately. Otherwise it prints a unified diff and asks the user which
-// direction to sync, or to skip.
+// replaceOptions are the resolutions offered, in the order they are presented.
+// The index the user picks maps onto the action at the same position.
+var replaceOptions = []struct {
+	label  string
+	action replaceAction
+}{
+	{"Use version from .lerd.yaml (update local definition)", replaceFromProject},
+	{"Use local definition (update .lerd.yaml)", replaceFromDisk},
+	{"Skip (keep both as-is)", replaceSkip},
+}
+
+// confirmReplace resolves a conflict between a definition on disk and the one a
+// project committed, asking at the terminal when there is one.
 func confirmReplace(kind, name string, existing, replacement interface{}) (replaceAction, error) {
+	return confirmReplaceWith(linkPrompter(), kind, name, existing, replacement)
+}
+
+// confirmReplaceWith compares existing (on disk) and replacement (from
+// .lerd.yaml) by marshalling both to YAML. Identical definitions resolve to
+// replaceSkip without a word. Otherwise it prints a unified diff and asks which
+// direction to sync.
+//
+// A nil prompter means nobody can answer — a link from the dashboard, an
+// assistant, or a script. That keeps both sides as they are rather than failing
+// the link, which is what driving a TUI form with no terminal used to do.
+func confirmReplaceWith(prompt linker.Prompter, kind, name string, existing, replacement interface{}) (replaceAction, error) {
 	oldYAML, err := yaml.Marshal(existing)
 	if err != nil {
 		return replaceSkip, err
@@ -41,6 +62,15 @@ func confirmReplace(kind, name string, existing, replacement interface{}) (repla
 
 	if string(oldYAML) == string(newYAML) {
 		return replaceSkip, nil // identical — nothing to do
+	}
+
+	if prompt == nil {
+		// Unstyled: this branch is reached exactly when there is no terminal (the
+		// dashboard, an assistant, a script), and lipgloss emits colour into a
+		// pipe regardless, which would land as escape codes in their output.
+		fmt.Printf("\n  ~ %s/%s differs from the one this project commits; keeping both as they are.\n", kind, name)
+		fmt.Printf("    Run 'lerd link' in a terminal to choose which to keep.\n")
+		return replaceSkip, nil
 	}
 
 	diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
@@ -69,21 +99,16 @@ func confirmReplace(kind, name string, existing, replacement interface{}) (repla
 	}
 	fmt.Println()
 
-	choice := 0
-	if err := huh.NewForm(
-		huh.NewGroup(
-			huh.NewSelect[int]().
-				Title(fmt.Sprintf("How to resolve %s/%s?", kind, name)).
-				Options(
-					huh.NewOption("Use version from .lerd.yaml (update local definition)", int(replaceFromProject)),
-					huh.NewOption("Use local definition (update .lerd.yaml)", int(replaceFromDisk)),
-					huh.NewOption("Skip (keep both as-is)", int(replaceSkip)),
-				).
-				Value(&choice),
-		),
-	).WithTheme(huh.ThemeFunc(huh.ThemeCatppuccin)).Run(); err != nil {
+	labels := make([]string, 0, len(replaceOptions))
+	for _, o := range replaceOptions {
+		labels = append(labels, o.label)
+	}
+	choice, err := prompt.Choose(fmt.Sprintf("How to resolve %s/%s?", kind, name), labels)
+	if err != nil {
 		return replaceSkip, err
 	}
-
-	return replaceAction(choice), nil
+	if choice < 0 || choice >= len(replaceOptions) {
+		return replaceSkip, nil
+	}
+	return replaceOptions[choice].action, nil
 }

--- a/internal/cli/confirm_replace_ansi_test.go
+++ b/internal/cli/confirm_replace_ansi_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// The no-prompter branch is reached exactly when the caller has no terminal, so
+// it must not emit styling. lipgloss colours its output even when stdout is a
+// pipe, unlike the feedback layer, and the escape codes ended up verbatim in the
+// MCP tool result and the dashboard's link log.
+func TestConfirmReplace_withoutAPrompterEmitsNoEscapeCodes(t *testing.T) {
+	out := captureStdout(t, func() {
+		if _, err := confirmReplaceWith(nil, "framework", "laravel", def{Label: "A"}, def{Label: "B"}); err != nil {
+			t.Error(err)
+		}
+	})
+
+	if strings.Contains(out, "\x1b") {
+		t.Errorf("output carries ANSI escape codes: %q", out)
+	}
+	if !strings.Contains(out, "framework/laravel differs") {
+		t.Errorf("the conflict was not reported: %q", out)
+	}
+}

--- a/internal/cli/confirm_replace_test.go
+++ b/internal/cli/confirm_replace_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/linker"
+)
+
+type def struct {
+	Label string `yaml:"label"`
+	Min   string `yaml:"min,omitempty"`
+}
+
+// choosePrompter answers a Choose with a fixed index and records the options.
+type choosePrompter struct {
+	pick    int
+	err     error
+	title   string
+	options []string
+	asked   bool
+}
+
+func (c *choosePrompter) Confirm(string, bool) bool { return false }
+
+func (c *choosePrompter) Choose(title string, options []string) (int, error) {
+	c.asked = true
+	c.title, c.options = title, options
+	return c.pick, c.err
+}
+
+func TestConfirmReplace_identicalDefinitionsAskNothing(t *testing.T) {
+	p := &choosePrompter{}
+	action, err := confirmReplaceWith(p, "framework", "laravel", def{Label: "Laravel"}, def{Label: "Laravel"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if action != replaceSkip {
+		t.Errorf("action = %v, want replaceSkip", action)
+	}
+	if p.asked {
+		t.Error("identical definitions must not ask the user anything")
+	}
+}
+
+// Without a terminal there is nobody to resolve the conflict, so the link keeps
+// both sides as they are instead of failing. Driving a TUI form here used to
+// abort the whole link with "could not open TTY", which made a project that
+// commits its own framework_def impossible to link from the dashboard or an
+// assistant.
+func TestConfirmReplace_withoutAPrompterKeepsBothAndDoesNotFail(t *testing.T) {
+	action, err := confirmReplaceWith(nil, "framework", "laravel", def{Label: "Laravel"}, def{Label: "Other"})
+	if err != nil {
+		t.Fatalf("a conflict with nobody to ask must not fail the link: %v", err)
+	}
+	if action != replaceSkip {
+		t.Errorf("action = %v, want replaceSkip", action)
+	}
+}
+
+func TestConfirmReplace_mapsTheChoiceOntoTheAction(t *testing.T) {
+	cases := []struct {
+		pick int
+		want replaceAction
+	}{
+		{0, replaceFromProject},
+		{1, replaceFromDisk},
+		{2, replaceSkip},
+		{9, replaceSkip}, // out of range is the conservative branch
+		{-1, replaceSkip},
+	}
+	for _, c := range cases {
+		p := &choosePrompter{pick: c.pick}
+		action, err := confirmReplaceWith(p, "service", "mysql", def{Label: "a"}, def{Label: "b"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if action != c.want {
+			t.Errorf("pick %d → %v, want %v", c.pick, action, c.want)
+		}
+	}
+}
+
+func TestConfirmReplace_offersAllThreeResolutions(t *testing.T) {
+	p := &choosePrompter{}
+	if _, err := confirmReplaceWith(p, "framework", "laravel", def{Label: "a"}, def{Label: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(p.options) != 3 {
+		t.Fatalf("options = %v, want three resolutions", p.options)
+	}
+	if p.title == "" {
+		t.Error("the question needs a title naming the conflict")
+	}
+}
+
+// The prompter is the seam; a real one is what the CLI supplies.
+var _ linker.Prompter = (*choosePrompter)(nil)

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -246,19 +246,9 @@ func runLink(args []string) error {
 		}
 	}
 
-	// Apply remaining .lerd.yaml settings: HTTPS and services. The site's secured
-	// state already folds in the DNS-managed gate, so a secured: true project on a
-	// localhost install lands here unsecured and is left on http rather than
-	// triggering a runSecure that the cert layer would only reject.
-	if proj != nil {
-		if proj.Secured && !site.Secured && cfg.DNSManaged() {
-			if err := runSecure(nil, []string{}); err != nil {
-				feedback.Warn("securing site: %v", err)
-			}
-		} else if !proj.Secured && site.Secured {
-			if err := runUnsecure(nil, []string{}); err != nil {
-				feedback.Warn("disabling HTTPS: %v", err)
-			}
+	if proj != nil && shouldSecureOnLink(proj.Secured, site.Secured, cfg.DNSManaged()) {
+		if err := runSecure(nil, []string{}); err != nil {
+			feedback.Warn("securing site: %v", err)
 		}
 	}
 
@@ -295,9 +285,9 @@ func printLinkSummary(site config.Site, start time.Time, wroteDataSource bool) {
 	if site.Framework != "" {
 		sum.Row("Framework", site.Framework)
 	}
-	if env := sailReadRawEnv(site.Path); env["DB_CONNECTION"] != "" {
-		db := env["DB_CONNECTION"]
-		if cache := env["CACHE_STORE"]; cache != "" {
+	readEnv := summaryEnvReader(site)
+	if db := strings.TrimSpace(readEnv("DB_CONNECTION")); db != "" {
+		if cache := strings.TrimSpace(readEnv("CACHE_STORE")); cache != "" {
 			db += " · cache " + cache
 		}
 		sum.Row("DB", db)
@@ -306,6 +296,35 @@ func printLinkSummary(site config.Site, start time.Time, wroteDataSource bool) {
 		sum.Row("IDE", "database connection written to .idea")
 	}
 	sum.Print()
+}
+
+// shouldSecureOnLink reports whether a link should turn HTTPS on because the
+// project asks for it. A link only ever turns HTTPS on: it is turned off with
+// `lerd unsecure`, never as a side effect of linking. secured is a plain bool,
+// so an absent .lerd.yaml, an empty one, and one that omits the field all read
+// as false — and treating that as "turn HTTPS off" silently dropped a secured
+// site back to HTTP every time it was re-linked, undoing the carry-over
+// CleanupRelink had just performed. The DNS gate is folded in so a secured:
+// true project on a localhost install stays on http rather than triggering a
+// runSecure the cert layer would only reject.
+func shouldSecureOnLink(projSecured, siteSecured, dnsManaged bool) bool {
+	return projSecured && !siteSecured && dnsManaged
+}
+
+// summaryEnvReader reads the site's live env file, resolved through the
+// framework's env config so a project in a non-dotenv format is parsed in its
+// own. Deliberately not sailReadRawEnv, which prefers the .env.before_lerd
+// backup the first link has just written, so the summary reported the database
+// lerd had replaced rather than the one it configured (#1144).
+func summaryEnvReader(site config.Site) func(key string) string {
+	envPath := filepath.Join(site.Path, ".env")
+	format := "dotenv"
+	if fw, ok := config.GetFrameworkForDir(site.Framework, site.Path); ok {
+		file, f := fw.Env.Resolve(site.Path)
+		envPath = filepath.Join(site.Path, file)
+		format = f
+	}
+	return makeEnvReader(envExampleFallback(envPath), format)
 }
 
 // linkRuntimeLabel names the serving runtime for the link summary's PHP row.

--- a/internal/cli/link_https_test.go
+++ b/internal/cli/link_https_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import "testing"
+
+func TestShouldSecureOnLink(t *testing.T) {
+	cases := []struct {
+		name                                 string
+		projSecured, siteSecured, dnsManaged bool
+		want                                 bool
+	}{
+		{"a project asking for HTTPS gets it", true, false, true, true},
+		{"already secured needs nothing", true, true, true, false},
+		{"a localhost install cannot issue a certificate", true, false, false, false},
+		// The bug: an absent .lerd.yaml reads as secured:false, and treating
+		// that as intent dropped a secured site to HTTP on every re-link.
+		{"a project with no opinion never turns HTTPS off", false, true, true, false},
+		{"no opinion and no HTTPS stays put", false, false, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldSecureOnLink(c.projSecured, c.siteSecured, c.dnsManaged); got != c.want {
+				t.Errorf("shouldSecureOnLink(%v, %v, %v) = %v, want %v",
+					c.projSecured, c.siteSecured, c.dnsManaged, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/cli/link_summary_env_test.go
+++ b/internal/cli/link_summary_env_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// The first link of a project is exactly when .env.before_lerd is written, so a
+// summary that preferred the backup reported the database lerd had just
+// replaced rather than the one it configured (#1144).
+func TestSummaryEnvReader_readsTheLiveEnvNotTheBackup(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".env", "DB_CONNECTION=mysql\nCACHE_STORE=redis\n")
+	writeFile(t, dir, ".env.before_lerd", "DB_CONNECTION=sqlite\nCACHE_STORE=database\n")
+
+	read := summaryEnvReader(config.Site{Path: dir})
+	if got := read("DB_CONNECTION"); got != "mysql" {
+		t.Errorf("DB_CONNECTION = %q, want mysql (the live env, not the pre-lerd backup)", got)
+	}
+	if got := read("CACHE_STORE"); got != "redis" {
+		t.Errorf("CACHE_STORE = %q, want redis", got)
+	}
+}
+
+func TestSummaryEnvReader_fallsBackToTheExampleBeforeTheEnvExists(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".env.example", "DB_CONNECTION=pgsql\n")
+
+	if got := summaryEnvReader(config.Site{Path: dir})("DB_CONNECTION"); got != "pgsql" {
+		t.Errorf("DB_CONNECTION = %q, want pgsql from the example file", got)
+	}
+}
+
+func TestSummaryEnvReader_emptyWhenThereIsNoEnvAtAll(t *testing.T) {
+	if got := summaryEnvReader(config.Site{Path: t.TempDir()})("DB_CONNECTION"); got != "" {
+		t.Errorf("DB_CONNECTION = %q, want empty", got)
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -1404,7 +1404,7 @@ func DetectFrameworkForDir(dir string) (string, bool) {
 		// Restore the embedded definition from .lerd.yaml (the committed source of
 		// truth, so inert edits propagate), sanitised so an untrusted .lerd.yaml
 		// can't seed host-executing doctor checks into the store.
-		if proj.FrameworkDef != nil {
+		if proj.FrameworkDef != nil && projectOwnsFramework(name) {
 			safe := SanitizeProjectFrameworkDef(proj.FrameworkDef)
 			safe.Name = name
 			_ = SaveStoreFramework(safe)

--- a/internal/config/framework_detect_write_test.go
+++ b/internal/config/framework_detect_write_test.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// storeSandbox points the framework store and config at temp dirs.
+func storeSandbox(t *testing.T) string {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+	store := filepath.Join(data, "lerd", "frameworks")
+	if err := os.MkdirAll(store, 0755); err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func projectWithEmbeddedDef(t *testing.T, label string) string {
+	t.Helper()
+	dir := t.TempDir()
+	yaml := "framework: acme\nframework_def:\n  name: acme\n  label: " + label + "\n  public_dir: public\n"
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// A project carrying its own framework definition installs it when the machine
+// has none, so cloning such a repo brings the framework along.
+func TestDetectFrameworkForDir_installsAnEmbeddedDefinitionWhenAbsent(t *testing.T) {
+	store := storeSandbox(t)
+	dir := projectWithEmbeddedDef(t, "Acme")
+
+	name, ok := DetectFrameworkForDir(dir)
+	if !ok || name != "acme" {
+		t.Fatalf("DetectFrameworkForDir = (%q, %v), want (acme, true)", name, ok)
+	}
+	if _, err := os.Stat(filepath.Join(store, "acme.yaml")); err != nil {
+		t.Errorf("the embedded definition was not installed: %v", err)
+	}
+}
+
+// A store-published framework belongs to every project on the machine, so one
+// project's embedded copy must not replace it. This used to happen on a mere
+// detection call: the copy overwrote the store entry, and when it omitted the
+// detect rules the store carried, detection broke for every project of that
+// framework. Differences against a published definition are the link flow's
+// conflict prompt to resolve.
+func TestDetectFrameworkForDir_doesNotOverwriteAStorePublishedDefinition(t *testing.T) {
+	store := storeSandbox(t)
+	installed := "name: acme\nlabel: Acme Proper\npublic_dir: public\ndetect:\n    - file: acme.json\n"
+	if err := os.WriteFile(filepath.Join(store, "acme.yaml"), []byte(installed), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// The store index is what makes the name store-owned rather than the
+	// project's to define.
+	index := `{"frameworks":[{"name":"acme","label":"Acme Proper","versions":["1"],"latest":"1","detect":[{"file":"acme.json"}]}]}`
+	if err := os.WriteFile(filepath.Join(store, "index.json"), []byte(index), 0644); err != nil {
+		t.Fatal(err)
+	}
+	dir := projectWithEmbeddedDef(t, "Hijacked")
+
+	if _, ok := DetectFrameworkForDir(dir); !ok {
+		t.Fatal("DetectFrameworkForDir did not resolve the installed definition")
+	}
+
+	after, err := os.ReadFile(filepath.Join(store, "acme.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != installed {
+		t.Errorf("a published definition was rewritten by a project's copy:\n%s", after)
+	}
+}
+
+// A framework the store does not publish belongs to the projects that use it, so
+// an edit to the committed definition still propagates.
+func TestDetectFrameworkForDir_propagatesAnEditToAProjectOwnedDefinition(t *testing.T) {
+	store := storeSandbox(t)
+	stale := "name: acme\nlabel: Stale\npublic_dir: public\ndetect:\n    - file: acme.json\n"
+	if err := os.WriteFile(filepath.Join(store, "acme.yaml"), []byte(stale), 0644); err != nil {
+		t.Fatal(err)
+	}
+	dir := projectWithEmbeddedDef(t, "Edited")
+
+	if _, ok := DetectFrameworkForDir(dir); !ok {
+		t.Fatal("DetectFrameworkForDir did not resolve the definition")
+	}
+
+	after, err := os.ReadFile(filepath.Join(store, "acme.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(after), "Edited") {
+		t.Errorf("an edit to a project-owned definition should propagate:\n%s", after)
+	}
+}

--- a/internal/config/store_index.go
+++ b/internal/config/store_index.go
@@ -34,6 +34,22 @@ func loadCachedStoreEntries() []cachedStoreEntry {
 	return idx.Frameworks
 }
 
+// projectOwnsFramework reports whether a framework name belongs to the projects
+// that use it rather than to the published store. A project carrying its own
+// definition for its own framework is the source of truth for it, so the copy in
+// .lerd.yaml is installed and kept current.
+//
+// A store-published name (laravel, symfony, …) is not: the store owns it and
+// every project on the machine shares it. Letting one project's embedded copy
+// replace it would rewrite a machine-wide definition from a single repository,
+// silently, on nothing more than a detection call. When that copy omitted the
+// detect rules the store entry carried, detection then failed for every project
+// of that framework. Resolving a difference against a published definition is
+// what the link flow's conflict prompt is for.
+func projectOwnsFramework(name string) bool {
+	return cachedStoreEntryByName(name) == nil
+}
+
 // cachedStoreEntryByName returns the cached index entry for name, or nil.
 func cachedStoreEntryByName(name string) *cachedStoreEntry {
 	entries := loadCachedStoreEntries()

--- a/internal/ui/link_failure_message_test.go
+++ b/internal/ui/link_failure_message_test.go
@@ -1,0 +1,63 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFailureMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{
+			// What `lerd env` actually prints for a project with no framework:
+			// the reason on the ✗ line, then the guidance under it. Taking only
+			// the last line dropped the reason and kept the guidance.
+			name: "a failure marker carries the reason and its guidance",
+			out: " ✗ no framework detected for this site\n" +
+				"Define one with 'lerd framework add' or add a framework YAML to /home/me/.config/lerd/frameworks\n",
+			want: "no framework detected for this site — Define one with 'lerd framework add' " +
+				"or add a framework YAML to /home/me/.config/lerd/frameworks",
+		},
+		{
+			name: "progress output above the failure is left out",
+			out:  " → configuring .env…\n → detecting services…\n ✗ reading .env: permission denied\n",
+			want: "reading .env: permission denied",
+		},
+		{
+			name: "without a marker the last line is the best available",
+			out:  "some output\nfinal problem\n",
+			want: "final problem",
+		},
+		{
+			name: "a single line with no marker is used as is",
+			out:  "exit status 1",
+			want: "exit status 1",
+		},
+		{
+			name: "empty output yields nothing rather than a stray separator",
+			out:  "\n\n",
+			want: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := failureMessage(c.out); got != c.want {
+				t.Errorf("failureMessage() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestFailureMessage_trimsAWallOfOutput(t *testing.T) {
+	got := failureMessage(" ✗ " + strings.Repeat("x", 500))
+	if len([]rune(got)) > 301 {
+		t.Errorf("message is %d runes, want it trimmed", len([]rune(got)))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("a trimmed message must say so, got %q", got[len(got)-10:])
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -5536,6 +5536,46 @@ func handleBrowse(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]any{"current": dir, "dirs": dirs})
 }
 
+// failureMessage extracts why a lerd command failed from its output. A failure
+// is printed as a "✗" line followed by any guidance, so everything from that
+// marker on is the message; without one, the last non-empty line is the best
+// available. Trimmed so the modal shows a sentence rather than a wall of output.
+func failureMessage(out string) string {
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+
+	from := -1
+	for i, line := range lines {
+		if strings.Contains(line, "✗") {
+			from = i
+		}
+	}
+
+	var parts []string
+	if from >= 0 {
+		for _, line := range lines[from:] {
+			if t := strings.TrimSpace(strings.ReplaceAll(line, "✗", "")); t != "" {
+				parts = append(parts, t)
+			}
+		}
+	} else {
+		for i := len(lines) - 1; i >= 0; i-- {
+			if t := strings.TrimSpace(lines[i]); t != "" {
+				parts = append(parts, t)
+				break
+			}
+		}
+	}
+
+	msg := strings.Join(parts, " — ")
+	if msg == "" {
+		msg = strings.TrimSpace(out)
+	}
+	if len(msg) > 300 {
+		return strings.TrimSpace(msg[:300]) + "…"
+	}
+	return msg
+}
+
 // handleSiteLink links a directory as a site via POST /api/sites/link.
 // It streams command output as SSE events and sends a final "done" event.
 // SiteReorderRequest is the JSON body for POST /api/sites/reorder.
@@ -5644,19 +5684,23 @@ func handleSiteLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Run env setup (non-fatal).
+	// Run env setup. The site is linked either way, so a failure here is a
+	// warning rather than an error — but it must reach the modal: a project with
+	// no framework, or a framework whose YAML declares no env section, leaves the
+	// .env untouched, and silently reporting success hid that entirely.
 	fmt.Fprintf(w, "data: → Setting up environment...\n\n")
 	flusher.Flush()
-	streamCmd(self, "env") //nolint:errcheck
+	envOut, envFailed := streamCmd(self, "env")
 
-	// Find the newly linked site to return its domain.
-	site, err := config.FindSiteByPath(path)
-	if err != nil {
-		fmt.Fprintf(w, "event: done\ndata: %s\n\n", mustJSON(map[string]any{"ok": true}))
-		flusher.Flush()
-		return
+	done := map[string]any{"ok": true}
+	if envFailed {
+		done["warning"] = "environment setup failed: " + failureMessage(envOut)
 	}
-	fmt.Fprintf(w, "event: done\ndata: %s\n\n", mustJSON(map[string]any{"ok": true, "domain": site.PrimaryDomain()}))
+	// Find the newly linked site to return its domain.
+	if site, err := config.FindSiteByPath(path); err == nil {
+		done["domain"] = site.PrimaryDomain()
+	}
+	fmt.Fprintf(w, "event: done\ndata: %s\n\n", mustJSON(done))
 	flusher.Flush()
 }
 

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "Dieses Verzeichnis verknüpfen",
   "link_waitingOutput": "Warte auf Ausgabe...",
   "link_failed": "Verknüpfen fehlgeschlagen",
+  "link_envWarning": "Die Site ist verknüpft, aber die Einrichtung der Umgebung wurde nicht abgeschlossen.",
+  "link_continueToSite": "Weiter zur Site",
   "workers_health_banner_title": "{count} Worker brauchen Reparatur",
   "workers_health_banner_starting": "{unit} wird gestartet…",
   "workers_health_banner_heal": "Reparieren",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "Link This Directory",
   "link_waitingOutput": "Waiting for output...",
   "link_failed": "Link failed",
+  "link_envWarning": "The site is linked, but its environment setup did not finish.",
+  "link_continueToSite": "Continue to site",
   "workers_health_banner_title": "{count} worker(s) need healing",
   "workers_health_banner_starting": "Starting {unit}…",
   "workers_health_banner_heal": "Heal",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "Enlazar este directorio",
   "link_waitingOutput": "Esperando salida...",
   "link_failed": "Enlace fallido",
+  "link_envWarning": "El sitio está enlazado, pero la configuración de su entorno no se completó.",
+  "link_continueToSite": "Ir al sitio",
   "workers_health_banner_title": "{count} worker(s) necesitan reparación",
   "workers_health_banner_starting": "Iniciando {unit}…",
   "workers_health_banner_heal": "Reparar",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "Lier ce répertoire",
   "link_waitingOutput": "En attente de sortie...",
   "link_failed": "Échec de la liaison",
+  "link_envWarning": "Le site est lié, mais la configuration de son environnement n'a pas abouti.",
+  "link_continueToSite": "Aller au site",
   "workers_health_banner_title": "{count} worker(s) à réparer",
   "workers_health_banner_starting": "Démarrage de {unit}…",
   "workers_health_banner_heal": "Réparer",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "Tautkan Direktori Ini",
   "link_waitingOutput": "Menunggu keluaran...",
   "link_failed": "Gagal menautkan",
+  "link_envWarning": "Situs sudah ditautkan, tetapi penyiapan lingkungannya tidak selesai.",
+  "link_continueToSite": "Lanjut ke situs",
   "workers_health_banner_title": "{count} worker perlu diperbaiki",
   "workers_health_banner_starting": "Memulai {unit}…",
   "workers_health_banner_heal": "Perbaiki",

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "Collega questa directory",
   "link_waitingOutput": "In attesa di output...",
   "link_failed": "Collegamento fallito",
+  "link_envWarning": "Il sito è collegato, ma la configurazione dell'ambiente non è stata completata.",
+  "link_continueToSite": "Vai al sito",
   "workers_health_banner_title": "{count} worker necessitano di ripristino",
   "workers_health_banner_starting": "Avvio di {unit}…",
   "workers_health_banner_heal": "Ripristina",

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "このディレクトリをリンク",
   "link_waitingOutput": "出力を待機中...",
   "link_failed": "リンクに失敗しました",
+  "link_envWarning": "サイトはリンクされましたが、環境のセットアップは完了しませんでした。",
+  "link_continueToSite": "サイトへ移動",
   "workers_health_banner_title": "{count} 個のワーカーに修復が必要です",
   "workers_health_banner_starting": "{unit} を起動中…",
   "workers_health_banner_heal": "修復",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "Deze map koppelen",
   "link_waitingOutput": "Wachten op uitvoer...",
   "link_failed": "Koppelen mislukt",
+  "link_envWarning": "De site is gekoppeld, maar het instellen van de omgeving is niet voltooid.",
+  "link_continueToSite": "Doorgaan naar site",
   "workers_health_banner_title": "{count} worker(s) hebben herstel nodig",
   "workers_health_banner_starting": "{unit} starten…",
   "workers_health_banner_heal": "Herstellen",

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "Połącz ten katalog",
   "link_waitingOutput": "Oczekiwanie na wynik...",
   "link_failed": "Łączenie nie powiodło się",
+  "link_envWarning": "Witryna została połączona, ale konfiguracja jej środowiska nie została ukończona.",
+  "link_continueToSite": "Przejdź do witryny",
   "workers_health_banner_title": "{count} workerów wymaga naprawy",
   "workers_health_banner_starting": "Uruchamianie {unit}…",
   "workers_health_banner_heal": "Napraw",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "Vincular este diretório",
   "link_waitingOutput": "Aguardando saída...",
   "link_failed": "Vinculação falhou",
+  "link_envWarning": "O site está vinculado, mas a configuração do ambiente não foi concluída.",
+  "link_continueToSite": "Ir para o site",
   "workers_health_banner_title": "{count} worker(s) precisam de reparo",
   "workers_health_banner_starting": "Iniciando {unit}…",
   "workers_health_banner_heal": "Reparar",

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "Conectează acest director",
   "link_waitingOutput": "Se așteaptă rezultatul...",
   "link_failed": "Conectare eșuată",
+  "link_envWarning": "Site-ul este legat, dar configurarea mediului nu s-a finalizat.",
+  "link_continueToSite": "Mergi la site",
   "workers_health_banner_title": "{count} worker(i) necesită reparare",
   "workers_health_banner_starting": "Se pornește {unit}…",
   "workers_health_banner_heal": "Repară",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "Bu Dizini Bağla",
   "link_waitingOutput": "Çıktı bekleniyor...",
   "link_failed": "Bağlama başarısız",
+  "link_envWarning": "Site bağlandı, ancak ortam kurulumu tamamlanmadı.",
+  "link_continueToSite": "Siteye git",
   "workers_health_banner_title": "{count} worker onarılmalı",
   "workers_health_banner_starting": "{unit} başlatılıyor…",
   "workers_health_banner_heal": "Onar",

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "Liên kết thư mục này",
   "link_waitingOutput": "Đang chờ kết quả...",
   "link_failed": "Liên kết thất bại",
+  "link_envWarning": "Trang đã được liên kết, nhưng thiết lập môi trường chưa hoàn tất.",
+  "link_continueToSite": "Đến trang",
   "workers_health_banner_title": "{count} worker cần khôi phục",
   "workers_health_banner_starting": "Đang khởi động {unit}…",
   "workers_health_banner_heal": "Khôi phục",

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -668,6 +668,8 @@
   "link_linkThisDir": "链接此目录",
   "link_waitingOutput": "等待输出...",
   "link_failed": "链接失败",
+  "link_envWarning": "站点已链接，但其环境设置未完成。",
+  "link_continueToSite": "前往站点",
   "workers_health_banner_title": "{count} 个 worker 需要修复",
   "workers_health_banner_starting": "启动 {unit} 中…",
   "workers_health_banner_heal": "修复",

--- a/internal/ui/web/src/modals/LinkModal.svelte
+++ b/internal/ui/web/src/modals/LinkModal.svelte
@@ -14,6 +14,8 @@
   let loading = $state(false);
   let linking = $state(false);
   let error = $state('');
+  let warning = $state('');
+  let linkedDomain = $state('');
   let logs = $state<string[]>([]);
   let scrollEl: HTMLDivElement | null = $state(null);
 
@@ -33,9 +35,15 @@
     }
   }
 
+  function openLinkedSite() {
+    closeModal();
+    if (linkedDomain) goToTab('sites', linkedDomain);
+  }
+
   async function link() {
     linking = true;
     error = '';
+    warning = '';
     logs = [];
     try {
       const box: { result: { ok?: boolean; domain?: string; error?: string } | null } = { result: null };
@@ -57,8 +65,14 @@
         return;
       }
       await loadSites();
-      closeModal();
-      if (result.domain) goToTab('sites', result.domain);
+      linkedDomain = result.domain ?? '';
+      // The site is linked, but something it needs did not finish. Stay open so
+      // the reason is read rather than scrolling past as the modal closes.
+      if (result.warning) {
+        warning = result.warning;
+        return;
+      }
+      openLinkedSite();
     } catch (e) {
       error = e instanceof Error ? e.message : m.common_failed();
     } finally {
@@ -120,12 +134,23 @@
     </div>
   {/if}
 
+  {#if warning}
+    <div class="px-5 py-2">
+      <p class="text-xs text-amber-600 dark:text-amber-500">{m.link_envWarning()}</p>
+      <p class="text-xs text-gray-500 dark:text-gray-400 mt-1 font-mono break-words">{warning}</p>
+    </div>
+  {/if}
+
   {#snippet footer()}
-    {#if !linking}
-      <DetailButton onclick={closeModal}>{m.common_cancel()}</DetailButton>
+    {#if warning}
+      <DetailButton tone="primary" onclick={openLinkedSite}>{m.link_continueToSite()}</DetailButton>
+    {:else}
+      {#if !linking}
+        <DetailButton onclick={closeModal}>{m.common_cancel()}</DetailButton>
+      {/if}
+      <DetailButton tone="primary" onclick={link} disabled={linking || loading} loading={linking}>
+        {m.link_linkThisDir()}
+      </DetailButton>
     {/if}
-    <DetailButton tone="primary" onclick={link} disabled={linking || loading} loading={linking}>
-      {m.link_linkThisDir()}
-    </DetailButton>
   {/snippet}
 </Modal>

--- a/internal/ui/web/src/stores/link.ts
+++ b/internal/ui/web/src/stores/link.ts
@@ -7,6 +7,9 @@ export interface LinkEvent {
   ok?: boolean;
   domain?: string;
   error?: string;
+  // Set when the site linked but its environment setup did not, so the modal
+  // can say so instead of reporting a clean success.
+  warning?: string;
 }
 
 export async function streamLinkSite(path: string, onEvent: (e: LinkEvent) => void): Promise<void> {
@@ -14,8 +17,19 @@ export async function streamLinkSite(path: string, onEvent: (e: LinkEvent) => vo
   await readSSE(res, (event, data) => {
     if (event === 'done') {
       try {
-        const result = JSON.parse(data) as { ok?: boolean; domain?: string; error?: string };
-        onEvent({ done: true, ok: Boolean(result.ok), domain: result.domain, error: result.error });
+        const result = JSON.parse(data) as {
+          ok?: boolean;
+          domain?: string;
+          error?: string;
+          warning?: string;
+        };
+        onEvent({
+          done: true,
+          ok: Boolean(result.ok),
+          domain: result.domain,
+          error: result.error,
+          warning: result.warning,
+        });
       } catch {
         onEvent({ done: true, ok: false, error: 'bad done payload' });
       }


### PR DESCRIPTION
Five defects in linking, all found while exercising the paths the previous change unified. Based on #1159, so review that one first.

A project committing its own framework definition could not be linked from anywhere without a terminal. The prompt asking which definition to keep drove a TUI form with no fallback, so it failed with "could not open TTY" and registered nothing, which took out the dashboard and the MCP action for any such project. The question already had a conservative answer, keeping both sides as they are, so that is what a caller with nobody to ask now gets, along with a line saying a link run in a terminal can resolve it.

Worse, detecting a framework wrote to the store. A project's committed definition was saved over the installed one on any call, including calls that were only reading, and a project commits only the fields it cares about. A copy carrying no detection rules left the shared definition with none, and from then on nothing detected that framework for any project on the machine. Propagating an edit is right for a framework a project defines itself and wrong for a name the store publishes and every project shares, so a published definition is left alone and its differences stay the conflict prompt's to resolve.

Re-linking a secured project that has no `.lerd.yaml` dropped it back to HTTP. The secured state is deliberately carried over so a re-link keeps HTTPS, then the project's committed intent was applied on top, where an absent file reads exactly like a file asking for HTTP. A link now only ever turns HTTPS on, and turning it off stays with the command that says so.

The dashboard reported a link as a clean success when the environment step failed, leaving an untouched `.env` behind and the reason scrolling past in the log. The site is linked either way, so it stays a warning, but the modal shows it and waits rather than closing.

The database row in the link summary read the backup taken moments earlier rather than the file just written, so a project configured for one database was reported as using the one it replaced.

Closes #1154
Closes #1155
Closes #1156
Closes #1157
Closes #1144

