### PR TITLE
fix(link): build the PHP version a link selects so the site can serve

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -138,6 +138,8 @@ Lerd automatically manages which PHP-FPM containers are running based on which v
 
 **Auto-start**: FPM is started automatically when you link a site (`lerd link`, `lerd park`, `lerd isolate`) or change the global default (`lerd use`). When unpausing a site, lerd also ensures the required FPM container is running before restoring the nginx vhost.
 
+**Build on first use**: when a link lands on a PHP version this machine has never built (an older framework clamps to a version below the ones you have, say), `lerd link` builds that version's image before starting it, so the site serves rather than answering 502. The build streams its progress as a link step. If the build cannot run (an unattended `lerd park` sweep withholds builds) or fails, the site is still registered and lerd names the one command that finishes the job, `lerd php:rebuild <version>`.
+
 **Manual control**: unused PHP versions (no active sites) can be started and stopped manually from the dashboard (System > PHP > Start / Stop). From the CLI:
 
 ```bash

--- a/internal/linker/apply.go
+++ b/internal/linker/apply.go
@@ -7,8 +7,15 @@ import (
 	"github.com/geodro/lerd/internal/certs"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/nginx"
+	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteops"
 )
+
+// fpmImageExists is a seam so tests can decide a version's image is present
+// without a podman image tree. It answers "can this version serve a request",
+// which writing a quadlet does not: several paths write one for a version whose
+// image was never built.
+var fpmImageExists = podman.FPMImageExists
 
 // Deps are the side effects a link needs that live above this package. A nil
 // field means the caller cannot do that thing, and the step is skipped.
@@ -93,7 +100,7 @@ func Apply(plan *Plan, p Policy, d Deps, r Reporter) (*Result, error) {
 		}
 	}
 
-	if err := provision(plan, site, p, r); err != nil {
+	if err := provision(plan, site, p, d, r); err != nil {
 		return res, err
 	}
 
@@ -109,7 +116,9 @@ func Apply(plan *Plan, p Policy, d Deps, r Reporter) (*Result, error) {
 // provision writes the vhost and runtime units for the site's mode, then issues
 // its certificate. The certificate is a separate step from the runtime so
 // mkcert's work gets its own line rather than being buried in the runtime's.
-func provision(plan *Plan, site config.Site, p Policy, r Reporter) error {
+func provision(plan *Plan, site config.Site, p Policy, d Deps, r Reporter) error {
+	ensureServableFPMImage(plan, site, p, d, r)
+
 	label, detail := provisionLabels(plan, site, r)
 
 	unsecured := site
@@ -168,6 +177,33 @@ func finish(plan *Plan, site config.Site, p Policy) error {
 		}
 		return siteops.FinishLink(site, site.PHPVersion)
 	}
+}
+
+// ensureServableFPMImage makes the selected version's image exist before the
+// shared FPM unit is (re)started, so a link onto a version this machine never
+// built serves instead of answering 502. The other modes build their own
+// per-site image in their finisher. On a build lerd cannot run here, or one that
+// fails, the site stays registered and the user is told the single command that
+// makes it serve, rather than being left on a silent 502.
+func ensureServableFPMImage(plan *Plan, site config.Site, p Policy, d Deps, r Reporter) {
+	if plan.Mode != ModeFPM || fpmImageExists(site.PHPVersion) {
+		return
+	}
+	rebuildHint := fmt.Sprintf("PHP %s is not built, so %s will answer 502 until you run 'lerd php:rebuild %s'",
+		site.PHPVersion, site.Name, site.PHPVersion)
+	// The watcher's unattended sweep withholds image builds; naming the command
+	// keeps it honest rather than silently registering a 502.
+	if !p.ImageBuild || d.EnsureFPMQuadlet == nil {
+		r.Warn("%s", rebuildHint)
+		return
+	}
+	step := r.Step("building PHP " + site.PHPVersion + " image (first use)")
+	if err := d.EnsureFPMQuadlet(site.PHPVersion); err != nil {
+		step.Fail(err)
+		r.Warn("%s", rebuildHint)
+		return
+	}
+	step.OK("")
 }
 
 // provisionLabels names the provisioning step and its result for a mode.

--- a/internal/linker/apply_test.go
+++ b/internal/linker/apply_test.go
@@ -147,6 +147,100 @@ func TestOfferBetterPHP_saysNothingWhenTheVersionIsUnconstrained(t *testing.T) {
 	}
 }
 
+// withFPMImageExists swaps the image-existence seam for one test.
+func withFPMImageExists(t *testing.T, exists bool) {
+	t.Helper()
+	prev := fpmImageExists
+	fpmImageExists = func(string) bool { return exists }
+	t.Cleanup(func() { fpmImageExists = prev })
+}
+
+func fpmSite() config.Site {
+	return config.Site{Name: "myapp", PHPVersion: "8.1"}
+}
+
+// Linking onto a version whose image was never built must build it, so the site
+// serves instead of answering 502. This is the core of issue #1164.
+func TestEnsureServableFPMImage_buildsAMissingVersion(t *testing.T) {
+	withFPMImageExists(t, false)
+	built := ""
+	d := Deps{EnsureFPMQuadlet: func(v string) error { built = v; return nil }}
+	r := &recorder{}
+
+	ensureServableFPMImage(&Plan{Mode: ModeFPM}, fpmSite(), Policy{ImageBuild: true}, d, r)
+
+	if built != "8.1" {
+		t.Errorf("built %q, want the selected version 8.1", built)
+	}
+	if !r.saw(r.steps, "building PHP 8.1 image") {
+		t.Errorf("the build was not reported as a step, steps = %v", r.steps)
+	}
+	if len(r.warns) != 0 {
+		t.Errorf("a successful build must not warn, warns = %v", r.warns)
+	}
+}
+
+// An already-built version is left alone: no build, no warning.
+func TestEnsureServableFPMImage_skipsAnExistingImage(t *testing.T) {
+	withFPMImageExists(t, true)
+	d := Deps{EnsureFPMQuadlet: func(string) error { t.Fatal("must not build an image that exists"); return nil }}
+	r := &recorder{}
+
+	ensureServableFPMImage(&Plan{Mode: ModeFPM}, fpmSite(), Policy{ImageBuild: true}, d, r)
+
+	if len(r.steps) != 0 || len(r.warns) != 0 {
+		t.Errorf("an existing image needs no work, steps = %v warns = %v", r.steps, r.warns)
+	}
+}
+
+// A failed build keeps the site registered and names the command that fixes it,
+// rather than aborting the link.
+func TestEnsureServableFPMImage_warnsWhenTheBuildFails(t *testing.T) {
+	withFPMImageExists(t, false)
+	d := Deps{EnsureFPMQuadlet: func(string) error { return errors.New("no network") }}
+	r := &recorder{}
+
+	ensureServableFPMImage(&Plan{Mode: ModeFPM}, fpmSite(), Policy{ImageBuild: true}, d, r)
+
+	if len(r.fails) == 0 {
+		t.Error("the failed build was not reported")
+	}
+	if !r.saw(r.warns, "lerd php:rebuild 8.1") {
+		t.Errorf("the warning must name the rebuild command, warns = %v", r.warns)
+	}
+}
+
+// A caller that cannot build (the watcher, or no builder wired) warns plainly
+// instead of registering a silent 502.
+func TestEnsureServableFPMImage_warnsWhenBuildsAreWithheld(t *testing.T) {
+	withFPMImageExists(t, false)
+	r := &recorder{}
+
+	ensureServableFPMImage(&Plan{Mode: ModeFPM}, fpmSite(), Policy{ImageBuild: false},
+		Deps{EnsureFPMQuadlet: func(string) error { t.Fatal("must not build when withheld"); return nil }}, r)
+
+	if !r.saw(r.warns, "lerd php:rebuild 8.1") {
+		t.Errorf("the warning must name the rebuild command, warns = %v", r.warns)
+	}
+	if len(r.steps) != 0 {
+		t.Errorf("nothing should be built, steps = %v", r.steps)
+	}
+}
+
+// Per-site runtimes build their own image in their finisher, so this check only
+// governs the shared FPM mode.
+func TestEnsureServableFPMImage_ignoresNonFPMModes(t *testing.T) {
+	withFPMImageExists(t, false)
+	for _, mode := range []Mode{ModeFrankenPHP, ModeCustomFPM, ModeCustomContainer, ModeHostProxy} {
+		r := &recorder{}
+		ensureServableFPMImage(&Plan{Mode: mode}, fpmSite(), Policy{ImageBuild: true},
+			Deps{EnsureFPMQuadlet: func(string) error { t.Fatalf("must not build for %s", mode); return nil }}, r)
+		if len(r.steps) != 0 || len(r.warns) != 0 {
+			t.Errorf("%s should be untouched, steps = %v warns = %v", mode, r.steps, r.warns)
+		}
+	}
+}
+
 func proxyPlan(command string) *Plan {
 	return &Plan{
 		Mode:         ModeHostProxy,


### PR DESCRIPTION
Linking a project whose framework pinned it to a PHP version this machine had never built registered the site, reported that version in lerd sites, and then answered every request with 502. The link wrote the version's FPM quadlet but never built its image or started a container behind it, and because lerd php:list reads quadlets it even showed the version as installed. An older framework clamping to the top of an older supported range reaches this without anything unusual.

Every link funnels through the linker, so the fix lives there. When a link settles on a shared-FPM version whose image is missing, it now builds that image the way the install path does, as its own reported step, before the unit is started, so the site serves immediately. When the build is withheld (an unattended park sweep does not build) or fails, the site stays registered and lerd names the command that finishes it, lerd php:rebuild <version>, rather than leaving a silent 502. Per-site runtimes are unaffected since they already build their own image.

Closes #1164