### PR TITLE
fix(new): scaffold under a PHP version the framework supports

### DIFF
--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -151,6 +151,12 @@ Every framework's create command starts with composer, and it is lerd's own
 composer that runs it, inside the project's PHP container. You do not need
 composer, or any PHP, installed on the host.
 
+The scaffold runs under a PHP version the framework supports, not whatever the
+machine defaults to. The framework definition declares a PHP range, so a
+framework whose current release tops out below your default PHP is scaffolded on
+a version inside that range instead, and composer resolves against a PHP the
+framework actually supports rather than rejecting every candidate.
+
 After creation:
 ```bash
 cd myapp

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -11,6 +11,7 @@ import (
 	"github.com/geodro/lerd/internal/composer"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
+	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
 )
@@ -117,10 +118,36 @@ func scaffoldPlan(create, target string, extraArgs []string) scaffold {
 	}
 }
 
-// runScaffold executes a scaffold plan from the target's parent directory.
-func runScaffold(plan scaffold, workDir string) error {
+// scaffoldPHPVersion returns the PHP version the scaffold should run under: the
+// machine default clamped into the framework's declared range, so composer
+// resolves against a PHP the framework supports rather than whatever the parent
+// directory (empty, so the default) would pick. Returns "" when the framework
+// declares no range, leaving the caller on the default as before.
+func scaffoldPHPVersion(fw *config.Framework) string {
+	if fw.PHP.Min == "" && fw.PHP.Max == "" {
+		return ""
+	}
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return ""
+	}
+	return phpDet.ClampToRange(cfg.PHP.DefaultVersion, fw.PHP.Min, fw.PHP.Max)
+}
+
+// runScaffold executes a scaffold plan from the target's parent directory. When
+// version is set, the containerized create command runs under that PHP rather
+// than the one the parent directory resolves to.
+func runScaffold(plan scaffold, workDir, version string) error {
 	if plan.inContainer {
-		code, err := RunPHPCaptureEnv(workDir, plan.args, []string{composer.ProcessTimeoutEnv()})
+		var (
+			code int
+			err  error
+		)
+		if version != "" {
+			code, err = RunPHPVersionCaptureEnv(workDir, version, plan.args, []string{composer.ProcessTimeoutEnv()})
+		} else {
+			code, err = RunPHPCaptureEnv(workDir, plan.args, []string{composer.ProcessTimeoutEnv()})
+		}
 		if err != nil {
 			return err
 		}
@@ -171,12 +198,18 @@ func runNew(target, frameworkName string, extraArgs []string) error {
 		return fmt.Errorf("framework %q has an empty create command", frameworkName)
 	}
 
+	scaffoldVersion := scaffoldPHPVersion(fw)
+
 	start := time.Now()
 	feedback.Begin()
-	feedback.Line("scaffolding " + feedback.Val(fw.Label) + " · " + strings.Join(strings.Fields(fw.Create), " ") + " " + target)
+	line := "scaffolding " + feedback.Val(fw.Label) + " · " + strings.Join(strings.Fields(fw.Create), " ") + " " + target
+	if plan.inContainer && scaffoldVersion != "" {
+		line += " · php " + feedback.Val(scaffoldVersion)
+	}
+	feedback.Line(line)
 	fmt.Println()
 
-	if err := runScaffold(plan, filepath.Dir(target)); err != nil {
+	if err := runScaffold(plan, filepath.Dir(target), scaffoldVersion); err != nil {
 		return fmt.Errorf("scaffold command failed: %w", err)
 	}
 

--- a/internal/cli/new_php_version_test.go
+++ b/internal/cli/new_php_version_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// setDefaultPHP persists a global config whose default PHP version is v.
+func setDefaultPHP(t *testing.T, v string) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	cfg := &config.GlobalConfig{}
+	cfg.DNS.TLD = "test"
+	cfg.PHP.DefaultVersion = v
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+}
+
+func fwWithRange(min, max string) *config.Framework {
+	return &config.Framework{Name: "fw", Label: "FW", PHP: config.FrameworkPHP{Min: min, Max: max}}
+}
+
+// A framework whose supported max is below the machine default must scaffold
+// under a version inside its range, not the default — the core of issue #1165.
+func TestScaffoldPHPVersion_clampsDefaultAboveTheRange(t *testing.T) {
+	setDefaultPHP(t, "8.5")
+
+	// No in-range version is installed in the temp home, so the clamp falls back
+	// to the framework minimum, which is still inside the supported range.
+	got := scaffoldPHPVersion(fwWithRange("8.1", "8.3"))
+	if got != "8.1" {
+		t.Errorf("scaffoldPHPVersion = %q, want 8.1 (clamped into 8.1-8.3, not the 8.5 default)", got)
+	}
+}
+
+// A default already inside the framework's range is left as-is.
+func TestScaffoldPHPVersion_keepsAnInRangeDefault(t *testing.T) {
+	setDefaultPHP(t, "8.3")
+
+	if got := scaffoldPHPVersion(fwWithRange("8.1", "8.4")); got != "8.3" {
+		t.Errorf("scaffoldPHPVersion = %q, want the in-range default 8.3", got)
+	}
+}
+
+// A framework that declares no range leaves the scaffold on the default, so the
+// version stays empty and the caller runs the existing default path.
+func TestScaffoldPHPVersion_emptyWhenNoRange(t *testing.T) {
+	setDefaultPHP(t, "8.5")
+
+	if got := scaffoldPHPVersion(fwWithRange("", "")); got != "" {
+		t.Errorf("scaffoldPHPVersion = %q, want empty when the framework declares no range", got)
+	}
+}

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -101,18 +101,26 @@ func debugSiteEnvArgs(dir string) []string {
 // injected into the container exec — used by `lerd profile run` to set
 // SPX_ENABLED so a CLI command is profiled.
 func RunPHPCaptureEnv(cwd string, args []string, extraEnv []string) (int, error) {
-	recordCwdActivity(cwd) // keep the site awake under idle-suspend while you work in the terminal
-	// The CLI SAPI ignores a project's .user.ini, so a framework declaring
-	// php.cli_ini gets it as -d on every PHP process lerd starts for it.
-	args = prependPHPIniArgs(phpIniArgsForDir(cwd), args)
 	version, err := phpVersionForDir(cwd)
 	if err != nil {
 		return 0, err
 	}
+	return RunPHPVersionCaptureEnv(cwd, version, args, extraEnv)
+}
+
+// RunPHPVersionCaptureEnv runs php in a specific version's container rather than
+// the one cwd resolves to. `lerd new` uses it to scaffold under a version the
+// framework supports, since the empty parent directory would otherwise resolve
+// to the machine default and break composer's platform check.
+func RunPHPVersionCaptureEnv(cwd, version string, args []string, extraEnv []string) (int, error) {
+	recordCwdActivity(cwd) // keep the site awake under idle-suspend while you work in the terminal
+	// The CLI SAPI ignores a project's .user.ini, so a framework declaring
+	// php.cli_ini gets it as -d on every PHP process lerd starts for it.
+	args = prependPHPIniArgs(phpIniArgsForDir(cwd), args)
 
 	container := fpmContainerForDir(cwd, version)
 
-	version, container, err = ensureFPMRunning(cwd, version, container)
+	version, container, err := ensureFPMRunning(cwd, version, container)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
lerd new ran the scaffold's composer against the machine default PHP rather than one the framework supports. The create command runs from the new project's parent directory, which is empty, so version resolution fell through to the global default. Scaffolding a framework whose supported range tops out below that default left composer rejecting every candidate for requiring a PHP the run did not have. A create command that installs at scaffold time failed outright, while a no-install one reported success and left an empty vendor that only showed up as a 500 once the site was linked and served.

The framework definition already declares its supported range and the framework is resolved before the scaffold runs, so the scaffold now runs under the default clamped into that range, and composer resolves against a PHP the framework actually supports. A framework that declares no range stays on the default. The chosen version goes through the same start-or-prompt path every other containerized command uses, so a version that cannot run surfaces plainly rather than a scaffold that reports success on nothing.

Closes #1165