### PR TITLE
fix: normalize PHP version input before it is stored or used

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -33,6 +33,8 @@
 
 If no version is given, the version is resolved from the current directory (`.php-version` or `composer.json`, falling back to the global default).
 
+Versions are written as `major.minor`, but common spellings are accepted everywhere a version is typed: `php8.4`, `84` and `8.4.7` all normalize to `8.4`. Anything that does not resolve to a supported version is rejected up front, so a typo can never end up as the stored default and break image names.
+
 Inside a linked site, the commands that run PHP in a container (`lerd php`, `lerd composer`, `lerd console`, `lerd php:shell`) use the version the site is registered on, which is the version its FPM container serves. That matters when a framework clamps the version at link time: a Laravel 13 project pinning `.php-version` to 8.1 is linked on 8.5, because Laravel 13 supports 8.3 to 8.5, and composer then runs on 8.5 too rather than resolving 8.1 from the file and quietly using a different PHP than the site itself.
 
 A git worktree resolves ahead of the site it belongs to. A worktree inherits its parent site's version until you pin one with `lerd isolate` from inside the checkout, and from then on the whole toolchain follows that pin: the worktree's own vhost, `lerd php`, `lerd composer`, and everything else that runs PHP in a container. This holds wherever the checkout lives, including inside the parent site's own directory, so a worktree on 8.3 under a site on 8.5 runs composer on 8.3 rather than picking up the parent's version.

--- a/internal/cli/fetch.go
+++ b/internal/cli/fetch.go
@@ -41,8 +41,9 @@ func IsLegacyPHPVersion(v string) bool {
 // quadlet and starts the service, streaming build output to w. It is the
 // programmatic entry point behind the UI's "add PHP version" flow.
 func InstallPHPVersion(version string, w io.Writer) error {
-	if !IsSupportedPHPVersion(version) {
-		return fmt.Errorf("unsupported PHP version %q", version)
+	version, err := config.NormalizePHPVersion(version)
+	if err != nil {
+		return err
 	}
 	// Always emit a line so a streamed install shows progress even when the
 	// image is already built and the build step produces no output.
@@ -69,7 +70,14 @@ func NewFetchCmd() *cobra.Command {
 func runFetch(cmd *cobra.Command, args []string) error {
 	local, _ := cmd.Flags().GetBool("local")
 
-	versions := args
+	versions := make([]string, 0, len(args))
+	for _, a := range args {
+		v, err := config.NormalizePHPVersion(a)
+		if err != nil {
+			return err
+		}
+		versions = append(versions, v)
+	}
 	if len(versions) == 0 {
 		versions = SupportedPHPVersions
 	}

--- a/internal/cli/isolate.go
+++ b/internal/cli/isolate.go
@@ -22,7 +22,10 @@ func NewIsolateCmd() *cobra.Command {
 }
 
 func runIsolate(_ *cobra.Command, args []string) error {
-	version := args[0]
+	version, err := config.NormalizePHPVersion(args[0])
+	if err != nil {
+		return err
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -48,9 +51,6 @@ func runIsolate(_ *cobra.Command, args []string) error {
 	// to write. link picks it up when the directory is eventually linked.
 	site, err := config.FindSiteByPath(cwd)
 	if err != nil {
-		if !config.IsSupportedPHPVersion(version) {
-			return fmt.Errorf("unsupported PHP version %q (supported: %s)", version, strings.Join(config.SupportedPHPVersions, ", "))
-		}
 		if err := siteops.PinPHPVersionFile(cwd, version); err != nil {
 			return fmt.Errorf("writing .php-version: %w", err)
 		}

--- a/internal/cli/php_rebuild.go
+++ b/internal/cli/php_rebuild.go
@@ -121,7 +121,11 @@ func runPhpRebuild(cmd *cobra.Command, args []string) error {
 	var versions []string
 
 	if len(args) == 1 {
-		versions = []string{args[0]}
+		v, err := config.NormalizePHPVersion(args[0])
+		if err != nil {
+			return err
+		}
+		versions = []string{v}
 	} else {
 		var err error
 		versions, err = phpPkg.ListInstalled()

--- a/internal/cli/use.go
+++ b/internal/cli/use.go
@@ -19,7 +19,10 @@ func NewUseCmd() *cobra.Command {
 }
 
 func runUse(_ *cobra.Command, args []string) error {
-	version := args[0]
+	version, err := config.NormalizePHPVersion(args[0])
+	if err != nil {
+		return err
+	}
 
 	cfg, err := config.LoadGlobal()
 	if err != nil {

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -652,6 +652,7 @@ func LoadGlobal() (*GlobalConfig, error) {
 		return nil, err
 	}
 	migrateStaleServiceImages(cfg)
+	normalizeDefaultPHPVersion(cfg)
 
 	if statErr == nil {
 		globalCacheMu.Lock()
@@ -661,6 +662,15 @@ func LoadGlobal() (*GlobalConfig, error) {
 		globalCacheMu.Unlock()
 	}
 	return cfg, nil
+}
+
+// normalizeDefaultPHPVersion repairs a default version stored raw by an older
+// `lerd use` (e.g. "php84"), which broke every derived image name. Values that
+// don't resolve to a supported version are left for callers to reject.
+func normalizeDefaultPHPVersion(cfg *GlobalConfig) {
+	if v, err := NormalizePHPVersion(cfg.PHP.DefaultVersion); err == nil {
+		cfg.PHP.DefaultVersion = v
+	}
 }
 
 // cloneGlobalConfig returns a deep copy. Maps and slices are duplicated so

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -38,6 +38,30 @@ func TestLoadGlobal_Defaults(t *testing.T) {
 	}
 }
 
+// A default version stored with a "php" prefix by an older `lerd use` produced
+// image names like lerd-phpphp84-fpm-base. Loading must repair it in memory so
+// a wedged install self-heals without the user re-running `lerd use`.
+func TestLoadGlobal_NormalizesStoredDefaultVersion(t *testing.T) {
+	setConfigDir(t)
+
+	seed, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	seed.PHP.DefaultVersion = "php84"
+	if err := SaveGlobal(seed); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	cfg, err := LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.PHP.DefaultVersion != "8.4" {
+		t.Errorf("PHP.DefaultVersion = %q, want 8.4", cfg.PHP.DefaultVersion)
+	}
+}
+
 // A config returned by LoadGlobal must not share its PHP.Packages map with the
 // cache: php:pkg's AddPackage/RemovePackage mutate the loaded copy in place
 // before SaveGlobal, and that must not corrupt what later LoadGlobal calls see.

--- a/internal/config/php_versions.go
+++ b/internal/config/php_versions.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -22,6 +23,24 @@ func IsSupportedPHPVersion(v string) bool {
 		}
 	}
 	return false
+}
+
+// NormalizePHPVersion reduces user input to a supported "major.minor" version:
+// "php8.4", "PHP 8.4", "84" and "8.4.7" all become "8.4". Anything that does
+// not resolve to a supported version is an error naming the supported list.
+func NormalizePHPVersion(input string) (string, error) {
+	v := strings.ToLower(strings.TrimSpace(input))
+	v = strings.TrimSpace(strings.TrimPrefix(v, "php"))
+	if !strings.Contains(v, ".") && len(v) == 2 {
+		v = v[:1] + "." + v[1:]
+	}
+	if parts := strings.SplitN(v, ".", 3); len(parts) >= 2 {
+		v = parts[0] + "." + parts[1]
+	}
+	if !IsSupportedPHPVersion(v) {
+		return "", fmt.Errorf("unsupported PHP version %q (supported: %s)", input, strings.Join(SupportedPHPVersions, ", "))
+	}
+	return v, nil
 }
 
 // FrankenPHPVersions returns the subset of SupportedPHPVersions that

--- a/internal/config/php_versions_test.go
+++ b/internal/config/php_versions_test.go
@@ -18,6 +18,38 @@ func TestIsSupportedPHPVersion(t *testing.T) {
 	}
 }
 
+func TestNormalizePHPVersion(t *testing.T) {
+	valid := map[string]string{
+		"8.4":     "8.4",
+		"php8.4":  "8.4",
+		"PHP8.4":  "8.4",
+		"php 8.4": "8.4",
+		"84":      "8.4",
+		"php84":   "8.4",
+		"8.4.7":   "8.4",
+		" 8.4 ":   "8.4",
+		"74":      "7.4",
+		"8.0":     "8.0",
+	}
+	for in, want := range valid {
+		got, err := NormalizePHPVersion(in)
+		if err != nil {
+			t.Errorf("NormalizePHPVersion(%q) error: %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("NormalizePHPVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+	for _, in := range []string{"", "php", "9.9", "5.6", "8", "845", "banana", "8.x"} {
+		if got, err := NormalizePHPVersion(in); err == nil {
+			t.Errorf("NormalizePHPVersion(%q) = %q, want error", in, got)
+		} else if !strings.Contains(err.Error(), "supported:") {
+			t.Errorf("NormalizePHPVersion(%q) error %q does not list supported versions", in, err)
+		}
+	}
+}
+
 func TestFrankenPHPVersions(t *testing.T) {
 	got := FrankenPHPVersions()
 	want := []string{"8.2", "8.3", "8.4", "8.5"}

--- a/internal/siteops/phpversion.go
+++ b/internal/siteops/phpversion.go
@@ -80,9 +80,12 @@ type PHPVersionResult struct {
 func SetSitePHPVersion(site *config.Site, version string, opts PHPVersionOpts) (PHPVersionResult, error) {
 	res := PHPVersionResult{Requested: version, Version: version}
 
-	if !config.IsSupportedPHPVersion(version) {
-		return res, fmt.Errorf("unsupported PHP version %q (supported: %s)", version, strings.Join(config.SupportedPHPVersions, ", "))
+	norm, err := config.NormalizePHPVersion(version)
+	if err != nil {
+		return res, err
 	}
+	version = norm
+	res.Version = version
 	if site.IsCustomContainer() {
 		return res, fmt.Errorf("site %q runs a custom container, which defines its own PHP runtime", site.Name)
 	}

--- a/internal/siteops/phpversion_test.go
+++ b/internal/siteops/phpversion_test.go
@@ -140,6 +140,27 @@ func TestSetSitePHPVersion_clampsToFrameworkRange(t *testing.T) {
 	}
 }
 
+// Input like "php8.2" must reduce to "8.2" before anything is derived from it;
+// stored raw it produces image names like lerd-phpphp82-fpm-base (#1173).
+func TestSetSitePHPVersion_normalizesPrefixedInput(t *testing.T) {
+	site := phpVersionTestSite(t, asFPM)
+	stubPHPVersionDeps(t, "", "")
+
+	res, err := SetSitePHPVersion(site, "php8.2", PHPVersionOpts{})
+	if err != nil {
+		t.Fatalf("SetSitePHPVersion: %v", err)
+	}
+	if res.Version != "8.2" {
+		t.Errorf("res.Version = %q, want 8.2", res.Version)
+	}
+	if got := readPHPVersionFile(t, site.Path); got != "8.2" {
+		t.Errorf(".php-version = %q, want 8.2", got)
+	}
+	if site.PHPVersion != "8.2" {
+		t.Errorf("site.PHPVersion = %q, want 8.2", site.PHPVersion)
+	}
+}
+
 func TestSetSitePHPVersion_rejectsUnsupportedVersion(t *testing.T) {
 	site := phpVersionTestSite(t, asFPM)
 	stubPHPVersionDeps(t, "", "")


### PR DESCRIPTION
A PHP version typed as php84 or php8.4 was accepted verbatim by lerd use and written straight into the global config. Every name derived from it then broke: the pre-built base became ghcr.io/lerd-env/lerd-phpphp84-fpm-base, which GHCR answers with 403 Forbidden even though the real problem is that the repository does not exist, and the local fallback tried to pull php:php8.4-fpm-alpine, which is not a real tag either. The command still reported success, so the install looked fine until the next image build failed with errors that pointed at the registry instead of the input.

Version input now goes through a single normalizer in the config package that reduces common spellings to major.minor, so php8.4, 84 and 8.4.7 all become 8.4, and anything that does not resolve to a supported version is rejected up front with the supported list in the error. It applies everywhere a version enters: use, isolate, php:rebuild, fetch, the UI's add version flow, and the site switch funnel shared by the CLI, dashboard and MCP.

Loading the global config also repairs an already stored bad default in memory, so an install that is already wedged, like the one in the report, self-heals on the next command instead of requiring the user to know to run lerd use again with the right spelling.

Refs #1173