### PR TITLE
Resolve a worktree to its parent so directory commands work

### DIFF
--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -186,7 +186,13 @@ The same toggle is available on the dashboard for already-active worktrees: flip
 
 ### Per-worktree LAN share
 
-LAN share has a separate toggle that's worktree-aware: when a worktree is active in the dashboard, the toggle controls a proxy bound to a per-worktree port (next free `>= 9100` across all sites and worktrees). The proxy targets the worktree's vhost domain so devices on your network reach the worktree's URL directly — no DNS setup on the client. Removing the worktree releases the port via the watcher's cleanup pass; the dashboard QR-code popover honours `?branch=` so the QR encodes the worktree's URL.
+LAN share has a separate toggle that's worktree-aware: when a worktree is active in the dashboard, the toggle controls a proxy bound to a per-worktree port (next free `>= 9100` across all sites and worktrees). The proxy targets the worktree's vhost domain so devices on your network reach the worktree's URL directly — no DNS setup on the client. Removing the worktree releases the port via the watcher's cleanup pass; the dashboard QR-code popover honours `?branch=` so the QR encodes the worktree's URL. Running `lerd lan:share` from inside the checkout does the same thing from the CLI.
+
+### Per-worktree public tunnel
+
+Public tunnels are worktree-scoped too. `lerd share` run from inside a checkout tunnels `<branch>.<site>.test`, and the dashboard's share menu acts on whichever branch tab is active. A worktree's tunnel is a process of its own: it can run alongside the parent site's, each with its own public URL, and stopping one does not touch the other. Under `--domain`, the Cloudflare named tunnel is keyed to the branch as well, so routing a hostname to a worktree never takes over the one the parent site is using.
+
+Commands that act on a directory resolve a worktree to its parent site automatically. `lerd share`, `lerd open`, `lerd domain`, `lerd env`, `lerd worker`, `lerd runtime` and the rest run from inside a checkout without linking it as a site of its own.
 
 ---
 

--- a/docs/usage/sites.md
+++ b/docs/usage/sites.md
@@ -464,6 +464,14 @@ Lerd automatically creates a subdomain for each `git worktree` checkout. See [Gi
 
 The same tunnels can be started from the [web UI](../features/web-ui.md)'s share menu: hover the wifi button in a site's header and pick a tool (or the auto entry, which follows the same detection order and `share:tool` default as the CLI). The dashboard waits for the tool's public URL and shows it next to the domain with a hover-QR. A tunnel started from the UI belongs to the `lerd-ui` daemon, so it ends when you stop it or when the daemon shuts down, and it is not restored on restart.
 
+### Sharing a worktree
+
+Run `lerd share` from inside a git worktree and lerd tunnels that branch's own domain (`<branch>.<site>.test`), not the parent checkout's. The worktree inherits the parent's registration, so there is nothing to link first: the command resolves the parent site and the branch you are standing in. The same is true of `lerd lan:share`, which assigns the branch its own LAN port, and of `lerd open`, which opens the branch domain.
+
+A worktree tunnel is independent of the parent's. Both can run at once, each on its own public URL, and stopping one leaves the other alone. In the dashboard, switch to the worktree's tab and the share menu acts on that branch.
+
+Naming a site explicitly (`lerd share myapp`) always means the site itself, never one of its branches.
+
 ### Default tunnel tool
 
 Auto-detection picks the first installed tool, which may not be the one you want. `lerd share:tool cloudflare` pins the default; from then on a bare `lerd share` uses Cloudflare Tunnel even with ngrok installed. A tool flag still overrides the default per run, and `lerd share:tool auto` restores auto-detection.

--- a/internal/cli/lan.go
+++ b/internal/cli/lan.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 	"net/http"
-	"os"
+	"net/url"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
@@ -188,31 +188,37 @@ the LAN address instead of the .test domain.
 The assigned port is stored in sites.yaml and reused across restarts.
 Run 'lerd lan:unshare' to stop sharing and release the port.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			cwd, err := os.Getwd()
+			// A worktree resolves to its parent plus the branch, so running this
+			// inside one shares that branch's own domain rather than assigning a
+			// port to a site name derived from the checkout directory.
+			site, branch, err := ensureSiteAndBranchForCwd()
 			if err != nil {
 				return err
 			}
-			siteName, err := queueSiteName(cwd)
-			if err != nil {
-				return err
-			}
+			siteName := site.Name
+			label := siteName
 			// Persist the port assignment (daemon will start the proxy).
-			port, err := LANShareEnsurePort(siteName)
+			port := 0
+			action := "lan:share"
+			if branch != "" {
+				port, err = LANShareEnsureWorktreePort(siteName, branch)
+				action += "?branch=" + url.QueryEscape(branch)
+				label = branch + "." + site.PrimaryDomain()
+			} else {
+				port, err = LANShareEnsurePort(siteName)
+			}
 			if err != nil {
 				return err
 			}
 			// Tell the running daemon to start the proxy now.
-			site, _ := config.FindSite(siteName)
-			if site != nil {
-				notifyDaemon(site.PrimaryDomain(), "lan:share") //nolint:errcheck
-			}
+			notifyDaemon(site.PrimaryDomain(), action) //nolint:errcheck
 			ip, _ := detectPrimaryLANIP()
 			if ip == "" {
 				ip = "<your-LAN-IP>"
 			}
 			shareURL := fmt.Sprintf("http://%s:%d", ip, port)
 			feedback.Begin()
-			feedback.Done("sharing " + siteName + " at " + feedback.Val(shareURL))
+			feedback.Done("sharing " + label + " at " + feedback.Val(shareURL))
 			feedback.Note("other devices on the network can use that URL directly — no DNS setup needed")
 			fmt.Println()
 			PrintLANShareQR(shareURL)
@@ -228,27 +234,29 @@ func newLANUnshareCmd() *cobra.Command {
 		Use:   "unshare",
 		Short: "Stop LAN sharing for the current site",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			cwd, err := os.Getwd()
+			site, branch, err := ensureSiteAndBranchForCwd()
 			if err != nil {
 				return err
 			}
-			siteName, err := queueSiteName(cwd)
-			if err != nil {
-				return err
-			}
-			site, err := config.FindSite(siteName)
-			if err != nil {
-				return err
+			label := site.Name
+			action := "lan:unshare"
+			if branch != "" {
+				action += "?branch=" + url.QueryEscape(branch)
+				label = branch + "." + site.PrimaryDomain()
 			}
 			// Tell the running daemon to stop the proxy and clear the port.
 			// If the daemon is not reachable, clear the port directly so the
 			// proxy is not restored on next daemon start.
-			if nErr := notifyDaemon(site.PrimaryDomain(), "lan:unshare"); nErr != nil {
-				site.LANPort = 0
-				_ = config.AddSite(*site)
+			if nErr := notifyDaemon(site.PrimaryDomain(), action); nErr != nil {
+				if branch != "" {
+					_, _, _ = config.RemoveWorktreeLAN(site.Name, branch)
+				} else {
+					site.LANPort = 0
+					_ = config.AddSite(*site)
+				}
 			}
 			feedback.Begin()
-			feedback.Done("LAN sharing stopped for " + siteName)
+			feedback.Done("LAN sharing stopped for " + label)
 			return nil
 		},
 	}

--- a/internal/cli/lanshare.go
+++ b/internal/cli/lanshare.go
@@ -45,6 +45,21 @@ func LANShareEnsurePort(siteName string) (int, error) {
 	return port, nil
 }
 
+// LANShareEnsureWorktreePort is LANShareEnsurePort for a worktree branch,
+// persisting the entry the daemon's proxy reads without starting anything.
+func LANShareEnsureWorktreePort(siteName, branch string) (int, error) {
+	if entry, found, err := config.FindWorktreeLAN(siteName, branch); err == nil && found && entry.Port != 0 {
+		return entry.Port, nil
+	}
+	port := assignWorktreeLANPort(siteName, branch)
+	if err := config.AddWorktreeLAN(config.WorktreeLANEntry{
+		Site: siteName, Branch: branch, Port: port,
+	}); err != nil {
+		return 0, fmt.Errorf("saving worktree LAN port: %w", err)
+	}
+	return port, nil
+}
+
 // LANShareStart starts the in-process reverse proxy for the site. It is
 // intended to be called from the daemon (UI server) only — the proxy goroutine
 // lives in the daemon process. CLI commands should notify the daemon via its

--- a/internal/cli/lanshare_test.go
+++ b/internal/cli/lanshare_test.go
@@ -712,3 +712,72 @@ func TestIsViteHMRSocket_matchesViteSubprotocolOnAnyPath(t *testing.T) {
 		}
 	}
 }
+
+// ── worktree LAN port ─────────────────────────────────────────────────────────
+
+// lerd lan:share inside a worktree persists a port for that branch, not for
+// the parent site, so the daemon starts the branch's own proxy.
+func TestLANShareEnsureWorktreePort_persistsPerBranch(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	parent, _ := makeWorktreeLayout(t, "rapids", "feature")
+	writeSitesYAML(t, []config.Site{{Name: "rapids", Path: parent}})
+
+	port, err := LANShareEnsureWorktreePort("rapids", "feature")
+	if err != nil {
+		t.Fatalf("LANShareEnsureWorktreePort: %v", err)
+	}
+	if port == 0 {
+		t.Fatal("expected a port to be assigned")
+	}
+	entry, found, err := config.FindWorktreeLAN("rapids", "feature")
+	if err != nil || !found {
+		t.Fatalf("worktree entry not persisted: found=%v err=%v", found, err)
+	}
+	if entry.Port != port {
+		t.Errorf("persisted port = %d, want %d", entry.Port, port)
+	}
+	site, err := config.FindSite("rapids")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if site.LANPort != 0 {
+		t.Errorf("parent site LANPort = %d, want it left alone", site.LANPort)
+	}
+}
+
+func TestLANShareEnsureWorktreePort_isIdempotent(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	parent, _ := makeWorktreeLayout(t, "rapids", "feature")
+	writeSitesYAML(t, []config.Site{{Name: "rapids", Path: parent}})
+
+	first, err := LANShareEnsureWorktreePort("rapids", "feature")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := LANShareEnsureWorktreePort("rapids", "feature")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Errorf("port moved between calls: %d then %d", first, second)
+	}
+}
+
+// Two branches of one site are two listeners, so they must not collide.
+func TestLANShareEnsureWorktreePort_branchesGetDistinctPorts(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	parent, _ := makeWorktreeLayout(t, "rapids", "feature")
+	writeSitesYAML(t, []config.Site{{Name: "rapids", Path: parent}})
+
+	a, err := LANShareEnsureWorktreePort("rapids", "feature")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := LANShareEnsureWorktreePort("rapids", "other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Errorf("both branches got port %d", a)
+	}
+}

--- a/internal/cli/link_worktree_test.go
+++ b/internal/cli/link_worktree_test.go
@@ -84,3 +84,52 @@ func TestFindOwningWorktree_skipsParentItself(t *testing.T) {
 		t.Error("the parent path itself must not register as one of its own worktrees")
 	}
 }
+
+// A path can be spelled two ways when a parent directory is a symlink: macOS
+// resolves /var to /private/var and ostree hosts resolve /home to /var/home,
+// so the registry and git's own metadata can hold one spelling while os.Getwd
+// hands back the other. The lookup has to compare canonical paths or a
+// worktree is never matched to its parent on those hosts.
+func TestFindOwningWorktree_matchesThroughASymlinkedPath(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	root := t.TempDir()
+	real := filepath.Join(root, "real")
+	if err := os.MkdirAll(real, 0755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	// Register the site and write git's metadata using the symlinked spelling.
+	parent := filepath.Join(link, "rapids")
+	wtPath := filepath.Join(parent, "feature")
+	meta := filepath.Join(parent, ".git", "worktrees", "feature")
+	if err := os.MkdirAll(meta, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(wtPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(meta, "HEAD"), []byte("ref: refs/heads/feature\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(meta, "gitdir"), []byte(filepath.Join(wtPath, ".git")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeSitesYAML(t, []config.Site{{Name: "rapids", Path: parent}})
+
+	// The resolved spelling is what os.Getwd reports from inside the checkout.
+	resolved, err := filepath.EvalSymlinks(wtPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner, branch, ok := findOwningWorktree(resolved)
+	if !ok {
+		t.Fatal("worktree not matched to its parent through the symlinked path")
+	}
+	if owner.Name != "rapids" || branch != "feature" {
+		t.Errorf("got %s/%s, want rapids/feature", owner.Name, branch)
+	}
+}

--- a/internal/cli/open.go
+++ b/internal/cli/open.go
@@ -20,6 +20,20 @@ func NewOpenCmd() *cobra.Command {
 	}
 }
 
+// worktreeURL is the address a branch is served on, under the parent's scheme.
+// Empty when the branch has no worktree.
+func worktreeURL(site *config.Site, branch string) string {
+	domain, err := siteops.WorktreeDomain(site, branch)
+	if err != nil {
+		return ""
+	}
+	scheme := "http"
+	if site.Secured {
+		scheme = "https"
+	}
+	return scheme + "://" + domain
+}
+
 func runOpen(_ *cobra.Command, args []string) error {
 	var url string
 
@@ -37,6 +51,13 @@ func runOpen(_ *cobra.Command, args []string) error {
 			return err
 		}
 		url = siteURL(cwd)
+		if url == "" {
+			// A worktree is served on its own subdomain, so open that rather
+			// than the parent site it inherits its registration from.
+			if parent, branch, ok := findOwningWorktree(cwd); ok {
+				url = worktreeURL(parent, branch)
+			}
+		}
 		if url == "" {
 			// Fall back: maybe cwd is named like a site.
 			name, _ := siteops.SiteNameAndDomain(filepath.Base(cwd), "test")

--- a/internal/cli/open_test.go
+++ b/internal/cli/open_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// lerd open inside a worktree opens the branch's own domain, not the parent's.
+func TestWorktreeURL_usesTheBranchDomainAndParentScheme(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	parent, _ := makeWorktreeLayout(t, "rapids", "feature")
+	site := &config.Site{Name: "rapids", Path: parent, Domains: []string{"rapids.test"}, Secured: true}
+
+	if got := worktreeURL(site, "feature"); got != "https://feature.rapids.test" {
+		t.Errorf("worktreeURL = %q, want https://feature.rapids.test", got)
+	}
+	site.Secured = false
+	if got := worktreeURL(site, "feature"); got != "http://feature.rapids.test" {
+		t.Errorf("worktreeURL = %q, want the http form", got)
+	}
+	if got := worktreeURL(site, "nope"); got != "" {
+		t.Errorf("worktreeURL for an unknown branch = %q, want empty", got)
+	}
+}

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -14,19 +14,34 @@ func errNotLinked() error {
 	return fmt.Errorf("no site registered for this directory — run 'lerd link' first")
 }
 
-// ensureSiteForCwd resolves the site for the current working directory, using
-// os.Getwd for both lookup and link so they can't diverge. On a miss in an
-// interactive terminal it offers to link (cascading into init) and re-resolves.
+// ensureSiteForCwd resolves the site for the current working directory. A
+// worktree resolves to its parent; callers that act on the branch itself want
+// ensureSiteAndBranchForCwd.
 func ensureSiteForCwd() (*config.Site, error) {
+	site, _, err := ensureSiteAndBranchForCwd()
+	return site, err
+}
+
+// ensureSiteAndBranchForCwd resolves the site for the current working
+// directory, using os.Getwd for both lookup and link so they can't diverge. On
+// a miss in an interactive terminal it offers to link (cascading into init) and
+// re-resolves. The branch is empty unless the directory is a worktree.
+func ensureSiteAndBranchForCwd() (*config.Site, string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if site, err := config.FindSiteByPath(cwd); err == nil {
-		return site, nil
+		return site, "", nil
+	}
+	// A worktree inherits the parent's registration, so an exact lookup always
+	// misses. Resolve it ahead of the link prompt, which only leads to link
+	// refusing it and the caller advising a command that cannot work.
+	if parent, branch, ok := findOwningWorktree(cwd); ok {
+		return parent, branch, nil
 	}
 	if !isInteractive() {
-		return nil, errNotLinked()
+		return nil, "", errNotLinked()
 	}
 
 	// Wrap the prompt and link in envInterrupt so, when reached from `lerd env`
@@ -46,11 +61,11 @@ func ensureSiteForCwd() (*config.Site, error) {
 		linkErr = runLinkOrInit(nil)
 	})
 	if linkErr != nil {
-		return nil, linkErr
+		return nil, "", linkErr
 	}
 	site, err := config.FindSiteByPath(cwd)
 	if err != nil {
-		return nil, errNotLinked()
+		return nil, "", errNotLinked()
 	}
-	return site, nil
+	return site, "", nil
 }

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 func TestErrNotLinkedMentionsLink(t *testing.T) {
@@ -22,5 +25,76 @@ func TestEnsureSiteForCwdNonInteractiveErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "lerd link") {
 		t.Errorf("error should point the user at lerd link, got: %v", err)
+	}
+}
+
+// chdir moves into dir for the test and restores the old cwd afterwards.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(prev) }) //nolint:errcheck
+}
+
+// A worktree is never registered as a site of its own, so an exact path lookup
+// always misses and every directory-scoped command used to dead-end on "run
+// lerd link first", advice that can never work because link refuses a worktree.
+func TestEnsureSiteAndBranchForCwd_resolvesWorktreeToParent(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	parent, wtPath := makeWorktreeLayout(t, "rapids", "feature")
+	writeSitesYAML(t, []config.Site{{Name: "rapids", Path: parent}})
+	chdir(t, wtPath)
+
+	site, branch, err := ensureSiteAndBranchForCwd()
+	if err != nil {
+		t.Fatalf("ensureSiteAndBranchForCwd: %v", err)
+	}
+	if site.Name != "rapids" {
+		t.Errorf("site = %q, want rapids", site.Name)
+	}
+	if branch != "feature" {
+		t.Errorf("branch = %q, want feature", branch)
+	}
+}
+
+// The registered site itself keeps resolving with no branch, so nothing that
+// already worked starts behaving like a worktree.
+func TestEnsureSiteAndBranchForCwd_registeredSiteHasNoBranch(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	parent, _ := makeWorktreeLayout(t, "rapids", "feature")
+	writeSitesYAML(t, []config.Site{{Name: "rapids", Path: parent}})
+	chdir(t, parent)
+
+	site, branch, err := ensureSiteAndBranchForCwd()
+	if err != nil {
+		t.Fatalf("ensureSiteAndBranchForCwd: %v", err)
+	}
+	if site.Name != "rapids" {
+		t.Errorf("site = %q, want rapids", site.Name)
+	}
+	if branch != "" {
+		t.Errorf("branch = %q, want empty for the parent checkout", branch)
+	}
+}
+
+// The worktree fallback must be reached before the link prompt, so a worktree
+// resolves in a non-interactive process instead of erroring.
+func TestEnsureSiteForCwd_worktreeResolvesWithoutPrompting(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	parent, wtPath := makeWorktreeLayout(t, "rapids", "feature")
+	writeSitesYAML(t, []config.Site{{Name: "rapids", Path: parent}})
+	chdir(t, wtPath)
+
+	site, err := ensureSiteForCwd()
+	if err != nil {
+		t.Fatalf("ensureSiteForCwd: %v", err)
+	}
+	if site.Name != "rapids" {
+		t.Errorf("site = %q, want rapids", site.Name)
 	}
 }

--- a/internal/cli/share.go
+++ b/internal/cli/share.go
@@ -82,7 +82,11 @@ type shareTool struct {
 }
 
 func runShare(args []string, useNgrok, useCloudflare, useExpose, useServeo, useLocalhostRun bool, domain string) error {
-	site, err := resolveShareSite(args)
+	site, branch, err := resolveShareSite(args)
+	if err != nil {
+		return err
+	}
+	target, err := shareTargetFor(site, branch)
 	if err != nil {
 		return err
 	}
@@ -101,13 +105,13 @@ func runShare(args []string, useNgrok, useCloudflare, useExpose, useServeo, useL
 		return err
 	}
 
-	fmt.Printf("Sharing %s...\n", site.PrimaryDomain())
+	fmt.Printf("Sharing %s...\n", target.domain)
 	fmt.Println("Press Ctrl+C to stop.")
 	fmt.Println()
 
 	tunnelName := ""
 	if tool.mode == shareModeCloudflare && tool.domain != "" {
-		if tunnelName, err = ensureCloudflareTunnel(site.Name, tool.domain); err != nil {
+		if tunnelName, err = ensureCloudflareTunnel(target.name, tool.domain); err != nil {
 			return err
 		}
 		fmt.Printf("Public URL: https://%s\n\n", tool.domain)
@@ -117,7 +121,7 @@ func runShare(args []string, useNgrok, useCloudflare, useExpose, useServeo, useL
 	if httpsPort == 0 {
 		httpsPort = 443
 	}
-	cmd, stop, err := buildTunnelCommand(tool, tunnelName, site, port, httpsPort, false)
+	cmd, stop, err := buildTunnelCommand(tool, tunnelName, target, port, httpsPort, false)
 	if err != nil {
 		return err
 	}
@@ -129,28 +133,53 @@ func runShare(args []string, useNgrok, useCloudflare, useExpose, useServeo, useL
 	return cmd.Run()
 }
 
-// buildTunnelCommand builds the tunnel tool invocation for a site plus a stop
+// shareTarget is what a tunnel fronts: the domain nginx routes on and whether
+// that vhost is served over HTTPS. A worktree resolves to its own subdomain
+// under the parent's TLS state, the same way the LAN share proxy does.
+type shareTarget struct {
+	// name identifies the target when a tool needs a stable handle for it,
+	// which today is the Cloudflare named tunnel.
+	name    string
+	domain  string
+	secured bool
+}
+
+// shareTargetFor resolves a site, and optionally one of its worktree branches,
+// to the domain a tunnel should front.
+func shareTargetFor(site *config.Site, branch string) (shareTarget, error) {
+	domain, err := siteops.WorktreeDomain(site, branch)
+	if err != nil {
+		return shareTarget{}, err
+	}
+	name := site.Name
+	if branch != "" {
+		name = site.Name + "-" + branch
+	}
+	return shareTarget{name: name, domain: domain, secured: site.Secured}, nil
+}
+
+// buildTunnelCommand builds the tunnel tool invocation for a target plus a stop
 // func for the local helper proxy the cloudflare/ssh modes need. headless
 // swaps interactive output for parseable logs so a caller can scrape the
 // public URL.
-func buildTunnelCommand(tool *shareTool, tunnelName string, site *config.Site, httpPort, httpsPort int, headless bool) (*exec.Cmd, func(), error) {
+func buildTunnelCommand(tool *shareTool, tunnelName string, target shareTarget, httpPort, httpsPort int, headless bool) (*exec.Cmd, func(), error) {
 	stop := func() {}
 	var cmd *exec.Cmd
 	switch tool.mode {
 	case shareModeNgrok:
-		args := []string{"http", fmt.Sprintf("%d", httpPort), "--host-header=" + site.PrimaryDomain()}
+		args := []string{"http", fmt.Sprintf("%d", httpPort), "--host-header=" + target.domain}
 		if headless {
 			args = append(args, "--log", "stdout", "--log-format", "json")
 		}
 		cmd = exec.Command("ngrok", args...)
 	case shareModeExpose:
-		shareURL := fmt.Sprintf("http://%s", site.PrimaryDomain())
+		shareURL := fmt.Sprintf("http://%s", target.domain)
 		if httpPort != 80 {
-			shareURL = fmt.Sprintf("http://%s:%d", site.PrimaryDomain(), httpPort)
+			shareURL = fmt.Sprintf("http://%s:%d", target.domain, httpPort)
 		}
 		cmd = exec.Command("expose", "share", shareURL)
 	case shareModeCloudflare:
-		proxyPort, stopProxy, err := startHostProxy(site.PrimaryDomain(), httpPort, httpsPort, site.Secured)
+		proxyPort, stopProxy, err := startHostProxy(target.domain, httpPort, httpsPort, target.secured)
 		if err != nil {
 			return nil, nil, fmt.Errorf("starting local proxy: %w", err)
 		}
@@ -164,13 +193,13 @@ func buildTunnelCommand(tool *shareTool, tunnelName string, site *config.Site, h
 		}
 	case shareModeSSH:
 		// Start a local reverse proxy that rewrites Host so nginx routes correctly.
-		proxyPort, stopProxy, err := startHostProxy(site.PrimaryDomain(), httpPort, httpsPort, site.Secured)
+		proxyPort, stopProxy, err := startHostProxy(target.domain, httpPort, httpsPort, target.secured)
 		if err != nil {
 			return nil, nil, fmt.Errorf("starting local proxy: %w", err)
 		}
 		stop = stopProxy
 		if !headless {
-			fmt.Printf("Local proxy started on port %d (Host: %s → nginx:%d)\n\n", proxyPort, site.PrimaryDomain(), httpPort)
+			fmt.Printf("Local proxy started on port %d (Host: %s → nginx:%d)\n\n", proxyPort, target.domain, httpPort)
 		}
 		cmd = exec.Command("ssh",
 			"-o", "StrictHostKeyChecking=no",
@@ -182,32 +211,37 @@ func buildTunnelCommand(tool *shareTool, tunnelName string, site *config.Site, h
 	return cmd, stop, nil
 }
 
-// resolveShareSite finds the site for the given name arg (or CWD if no arg).
-func resolveShareSite(args []string) (*config.Site, error) {
+// resolveShareSite finds the site for the given name arg (or CWD if no arg),
+// plus the worktree branch when the CWD is one. Naming a site explicitly always
+// means the site itself, never a branch of it.
+func resolveShareSite(args []string) (*config.Site, string, error) {
 	if len(args) == 1 {
 		site, err := config.FindSite(args[0])
 		if err != nil {
-			return nil, fmt.Errorf("site %q not found — run 'lerd sites' to list registered sites", args[0])
+			return nil, "", fmt.Errorf("site %q not found — run 'lerd sites' to list registered sites", args[0])
 		}
-		return site, nil
+		return site, "", nil
 	}
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	site, err := config.FindSiteByPath(cwd)
 	if err == nil {
-		return site, nil
+		return site, "", nil
+	}
+	if parent, branch, ok := findOwningWorktree(cwd); ok {
+		return parent, branch, nil
 	}
 
 	// Fall back: treat the directory name as a site name.
 	name, _ := siteops.SiteNameAndDomain(filepath.Base(cwd), "test")
 	if site, err = config.FindSite(name); err == nil {
-		return site, nil
+		return site, "", nil
 	}
-	return ensureSiteForCwd()
+	return ensureSiteAndBranchForCwd()
 }
 
 func pickShareTool(useNgrok, useCloudflare, useExpose, useServeo, useLocalhostRun bool, domain, defaultTool string) (*shareTool, error) {

--- a/internal/cli/share_test.go
+++ b/internal/cli/share_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+
+	"github.com/geodro/lerd/internal/config"
 	"strings"
 	"testing"
 )
@@ -851,5 +853,76 @@ func TestStartHostProxy_stopClosesListener(t *testing.T) {
 	_, err = http.Get(fmt.Sprintf("http://127.0.0.1:%d/", port))
 	if err == nil {
 		t.Error("expected connection error after stop, got nil")
+	}
+}
+
+// ── share target ──────────────────────────────────────────────────────────────
+
+// A worktree is served on its own subdomain, so a tunnel started from one must
+// front that domain rather than the parent site's.
+func TestShareTargetFor_worktreeUsesTheBranchDomain(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	parent, _ := makeWorktreeLayout(t, "rapids", "feature")
+	site := &config.Site{Name: "rapids", Path: parent, Domains: []string{"rapids.test"}, Secured: true}
+
+	target, err := shareTargetFor(site, "feature")
+	if err != nil {
+		t.Fatalf("shareTargetFor: %v", err)
+	}
+	if target.domain != "feature.rapids.test" {
+		t.Errorf("domain = %q, want feature.rapids.test", target.domain)
+	}
+	if !target.secured {
+		t.Error("a worktree inherits the parent's TLS state")
+	}
+	// The Cloudflare named tunnel is keyed off this, so a branch must not
+	// reuse the parent's tunnel and take over its hostname.
+	if target.name == site.Name {
+		t.Errorf("name = %q, want a name distinct from the site's", target.name)
+	}
+}
+
+func TestShareTargetFor_siteUsesItsPrimaryDomain(t *testing.T) {
+	site := &config.Site{Name: "rapids", Domains: []string{"rapids.test"}}
+	target, err := shareTargetFor(site, "")
+	if err != nil {
+		t.Fatalf("shareTargetFor: %v", err)
+	}
+	if target.domain != "rapids.test" || target.name != "rapids" {
+		t.Errorf("target = %+v, want the site's own domain and name", target)
+	}
+}
+
+func TestShareTargetFor_unknownBranchErrors(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	parent, _ := makeWorktreeLayout(t, "rapids", "feature")
+	site := &config.Site{Name: "rapids", Path: parent, Domains: []string{"rapids.test"}}
+
+	if _, err := shareTargetFor(site, "nope"); err == nil {
+		t.Fatal("expected an error for a branch with no worktree")
+	}
+}
+
+func TestBuildTunnelCommand_ngrokRoutesTheTargetDomain(t *testing.T) {
+	target := shareTarget{name: "rapids-feature", domain: "feature.rapids.test"}
+	cmd, stop, err := buildTunnelCommand(&shareTool{mode: shareModeNgrok}, "", target, 80, 443, true)
+	if err != nil {
+		t.Fatalf("buildTunnelCommand: %v", err)
+	}
+	defer stop()
+	if !strings.Contains(strings.Join(cmd.Args, " "), "--host-header=feature.rapids.test") {
+		t.Errorf("args = %v, want the worktree domain as the host header", cmd.Args)
+	}
+}
+
+func TestBuildTunnelCommand_exposeSharesTheTargetDomain(t *testing.T) {
+	target := shareTarget{name: "rapids-feature", domain: "feature.rapids.test"}
+	cmd, stop, err := buildTunnelCommand(&shareTool{mode: shareModeExpose}, "", target, 80, 443, true)
+	if err != nil {
+		t.Fatalf("buildTunnelCommand: %v", err)
+	}
+	defer stop()
+	if !strings.Contains(strings.Join(cmd.Args, " "), "http://feature.rapids.test") {
+		t.Errorf("args = %v, want the worktree domain shared", cmd.Args)
 	}
 }

--- a/internal/cli/tunnelshare.go
+++ b/internal/cli/tunnelshare.go
@@ -165,21 +165,42 @@ func parseTunnelURL(tool, line string) (string, bool) {
 	return "", false
 }
 
-// TunnelStatus returns the running tunnel for a site, if one has a URL yet.
-func TunnelStatus(siteName string) (TunnelInfo, bool) {
+// tunnelKey identifies a running tunnel. A worktree fronts its own domain, so
+// it gets a key of its own rather than replacing the parent site's tunnel. The
+// bare site name is kept as the key for the site itself.
+func tunnelKey(siteName, branch string) string {
+	if branch == "" {
+		return siteName
+	}
+	return siteName + "@" + branch
+}
+
+// tunnelStatusByKey returns the running tunnel registered under key.
+func tunnelStatusByKey(key string) (TunnelInfo, bool) {
 	tunnelsMu.Lock()
 	defer tunnelsMu.Unlock()
-	p := tunnels[siteName]
+	p := tunnels[key]
 	if p == nil || p.url == "" {
 		return TunnelInfo{}, false
 	}
 	return TunnelInfo{Tool: p.tool, URL: p.url}, true
 }
 
-// TunnelStart starts a public tunnel for the site and blocks until the tool
-// prints its public URL. An empty toolName auto-picks like the CLI does.
-func TunnelStart(siteName, toolName string) (string, error) {
+// TunnelStatus returns the running tunnel for a site, or for one of its
+// worktrees when branch is set, if one has a URL yet.
+func TunnelStatus(siteName, branch string) (TunnelInfo, bool) {
+	return tunnelStatusByKey(tunnelKey(siteName, branch))
+}
+
+// TunnelStart starts a public tunnel for the site, or for one of its worktrees
+// when branch is set, and blocks until the tool prints its public URL. An empty
+// toolName auto-picks like the CLI does.
+func TunnelStart(siteName, branch, toolName string) (string, error) {
 	site, err := config.FindSite(siteName)
+	if err != nil {
+		return "", err
+	}
+	target, err := shareTargetFor(site, branch)
 	if err != nil {
 		return "", err
 	}
@@ -199,18 +220,18 @@ func TunnelStart(siteName, toolName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cmd, stopProxy, err := buildTunnelCommand(tool, "", site, httpPort, httpsPort, true)
+	cmd, stopProxy, err := buildTunnelCommand(tool, "", target, httpPort, httpsPort, true)
 	if err != nil {
 		return "", err
 	}
-	return startTunnelProcess(siteName, shareToolCanonicalName(tool), cmd, stopProxy, tunnelStartTimeout)
+	return startTunnelProcess(tunnelKey(siteName, branch), shareToolCanonicalName(tool), cmd, stopProxy, tunnelStartTimeout)
 }
 
 // startTunnelProcess runs the tool, scans its output for the public URL, and
-// registers the tunnel. It replaces any tunnel already running for the site.
-// After a successful Start the exit watcher owns stopProxy.
-func startTunnelProcess(siteName, toolName string, cmd *exec.Cmd, stopProxy func(), timeout time.Duration) (string, error) {
-	_ = TunnelStop(siteName)
+// registers the tunnel under key. It replaces any tunnel already running for
+// that key. After a successful Start the exit watcher owns stopProxy.
+func startTunnelProcess(key, toolName string, cmd *exec.Cmd, stopProxy func(), timeout time.Duration) (string, error) {
+	stopTunnelByKey(key)
 	if stopProxy == nil {
 		stopProxy = func() {}
 	}
@@ -233,7 +254,7 @@ func startTunnelProcess(siteName, toolName string, cmd *exec.Cmd, stopProxy func
 
 	p := &tunnelProc{tool: toolName, cmd: cmd, stopProxy: stopProxy, done: make(chan struct{})}
 	tunnelsMu.Lock()
-	tunnels[siteName] = p
+	tunnels[key] = p
 	tunnelsMu.Unlock()
 
 	urlCh := make(chan string, 1)
@@ -268,8 +289,8 @@ func startTunnelProcess(siteName, toolName string, cmd *exec.Cmd, stopProxy func
 		stopProxy()
 		close(p.done)
 		tunnelsMu.Lock()
-		if tunnels[siteName] == p {
-			delete(tunnels, siteName)
+		if tunnels[key] == p {
+			delete(tunnels, key)
 		}
 		tunnelsMu.Unlock()
 	}()
@@ -287,8 +308,8 @@ func startTunnelProcess(siteName, toolName string, cmd *exec.Cmd, stopProxy func
 		return "", fmt.Errorf("%s exited before printing a public URL: %s", toolName, out)
 	case <-time.After(timeout):
 		tunnelsMu.Lock()
-		if tunnels[siteName] == p {
-			delete(tunnels, siteName)
+		if tunnels[key] == p {
+			delete(tunnels, key)
 		}
 		tunnelsMu.Unlock()
 		killTunnel(p)
@@ -296,17 +317,23 @@ func startTunnelProcess(siteName, toolName string, cmd *exec.Cmd, stopProxy func
 	}
 }
 
-// TunnelStop stops the site's tunnel. A no-op when none is running.
-func TunnelStop(siteName string) error {
+// TunnelStop stops the tunnel for a site, or for one of its worktrees when
+// branch is set. A no-op when none is running.
+func TunnelStop(siteName, branch string) error {
+	stopTunnelByKey(tunnelKey(siteName, branch))
+	return nil
+}
+
+// stopTunnelByKey kills the tunnel registered under key, if any.
+func stopTunnelByKey(key string) {
 	tunnelsMu.Lock()
-	p := tunnels[siteName]
-	delete(tunnels, siteName)
+	p := tunnels[key]
+	delete(tunnels, key)
 	tunnelsMu.Unlock()
 	if p == nil {
-		return nil
+		return
 	}
 	killTunnel(p)
-	return nil
 }
 
 // StopAllTunnels kills every running tunnel.

--- a/internal/cli/tunnelshare_test.go
+++ b/internal/cli/tunnelshare_test.go
@@ -134,33 +134,33 @@ func shellTunnel(script string) *exec.Cmd {
 	return exec.Command("/bin/sh", "-c", script)
 }
 
-func waitTunnelGone(t *testing.T, site string) {
+func waitTunnelGone(t *testing.T, key string) {
 	t.Helper()
 	for range 100 {
-		if _, ok := TunnelStatus(site); !ok {
+		if _, ok := tunnelStatusByKey(key); !ok {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Fatalf("tunnel for %s still reported after waiting", site)
+	t.Fatalf("tunnel for %s still reported after waiting", key)
 }
 
 func TestStartTunnelProcess_returnsURLAndTracksTunnel(t *testing.T) {
 	site := "tunnel-test-a"
 	cmd := shellTunnel(`echo "Forwarding HTTP traffic from https://abc123.serveo.net"; sleep 30`)
 	url, err := startTunnelProcess(site, "serveo", cmd, nil, 5*time.Second)
-	t.Cleanup(func() { _ = TunnelStop(site) })
+	t.Cleanup(func() { _ = TunnelStop(site, "") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if url != "https://abc123.serveo.net" {
 		t.Errorf("url = %q, want the serveo URL", url)
 	}
-	info, ok := TunnelStatus(site)
+	info, ok := TunnelStatus(site, "")
 	if !ok || info.URL != url || info.Tool != "serveo" {
 		t.Errorf("TunnelStatus = %+v, %v; want running serveo tunnel", info, ok)
 	}
-	if err := TunnelStop(site); err != nil {
+	if err := TunnelStop(site, ""); err != nil {
 		t.Fatalf("stop: %v", err)
 	}
 	waitTunnelGone(t, site)
@@ -170,14 +170,14 @@ func TestStartTunnelProcess_readsStderrToo(t *testing.T) {
 	site := "tunnel-test-stderr"
 	cmd := shellTunnel(`echo "INF |  https://plum-lakes-agree.trycloudflare.com  |" >&2; sleep 30`)
 	url, err := startTunnelProcess(site, "cloudflare", cmd, nil, 5*time.Second)
-	t.Cleanup(func() { _ = TunnelStop(site) })
+	t.Cleanup(func() { _ = TunnelStop(site, "") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if url != "https://plum-lakes-agree.trycloudflare.com" {
 		t.Errorf("url = %q, want the trycloudflare URL", url)
 	}
-	_ = TunnelStop(site)
+	_ = TunnelStop(site, "")
 	waitTunnelGone(t, site)
 }
 
@@ -206,7 +206,7 @@ func TestStartTunnelProcess_timesOut(t *testing.T) {
 
 func TestStartTunnelProcess_replacesExistingTunnel(t *testing.T) {
 	site := "tunnel-test-replace"
-	t.Cleanup(func() { _ = TunnelStop(site) })
+	t.Cleanup(func() { _ = TunnelStop(site, "") })
 	first := shellTunnel(`echo "Forwarding HTTP traffic from https://first.serveo.net"; sleep 30`)
 	if _, err := startTunnelProcess(site, "serveo", first, nil, 5*time.Second); err != nil {
 		t.Fatalf("first start: %v", err)
@@ -219,7 +219,7 @@ func TestStartTunnelProcess_replacesExistingTunnel(t *testing.T) {
 	if url != "https://second.serveo.net" {
 		t.Errorf("url = %q, want the second tunnel's URL", url)
 	}
-	info, ok := TunnelStatus(site)
+	info, ok := TunnelStatus(site, "")
 	if !ok || info.URL != "https://second.serveo.net" {
 		t.Errorf("TunnelStatus = %+v, %v; want the second tunnel", info, ok)
 	}
@@ -232,7 +232,7 @@ func TestStartTunnelProcess_stopProxyRunsWhenProcessDies(t *testing.T) {
 	if _, err := startTunnelProcess(site, "serveo", cmd, func() { close(stopped) }, 5*time.Second); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	if err := TunnelStop(site); err != nil {
+	if err := TunnelStop(site, ""); err != nil {
 		t.Fatalf("stop: %v", err)
 	}
 	select {
@@ -257,7 +257,56 @@ func TestStopAllTunnels(t *testing.T) {
 }
 
 func TestTunnelStop_noopWhenNotRunning(t *testing.T) {
-	if err := TunnelStop("tunnel-test-none"); err != nil {
+	if err := TunnelStop("tunnel-test-none", ""); err != nil {
 		t.Fatalf("expected no-op, got %v", err)
+	}
+}
+
+// ── worktree tunnels ──────────────────────────────────────────────────────────
+
+func TestTunnelKey_separatesWorktreeFromSite(t *testing.T) {
+	if got := tunnelKey("rapids", ""); got != "rapids" {
+		t.Errorf("tunnelKey with no branch = %q, want the bare site name", got)
+	}
+	if tunnelKey("rapids", "feature") == tunnelKey("rapids", "") {
+		t.Error("a worktree tunnel must not share the site's key")
+	}
+	if tunnelKey("rapids", "feature") == tunnelKey("rapids", "other") {
+		t.Error("two branches of one site must not share a key")
+	}
+}
+
+// A worktree fronts its own domain, so its tunnel is a separate process that
+// neither replaces the parent's nor is stopped along with it.
+func TestStartTunnelProcess_worktreeTunnelIsIndependentOfTheSite(t *testing.T) {
+	site := "tunnel-test-wt"
+	siteKey := tunnelKey(site, "")
+	wtKey := tunnelKey(site, "feature")
+	t.Cleanup(func() { _ = TunnelStop(site, ""); _ = TunnelStop(site, "feature") })
+
+	parent := shellTunnel(`echo "Forwarding HTTP traffic from https://parent.serveo.net"; sleep 30`)
+	if _, err := startTunnelProcess(siteKey, "serveo", parent, nil, 5*time.Second); err != nil {
+		t.Fatalf("parent start: %v", err)
+	}
+	wt := shellTunnel(`echo "Forwarding HTTP traffic from https://branch.serveo.net"; sleep 30`)
+	if _, err := startTunnelProcess(wtKey, "serveo", wt, nil, 5*time.Second); err != nil {
+		t.Fatalf("worktree start: %v", err)
+	}
+
+	pInfo, ok := TunnelStatus(site, "")
+	if !ok || pInfo.URL != "https://parent.serveo.net" {
+		t.Errorf("site tunnel = %+v, %v; want the parent URL still running", pInfo, ok)
+	}
+	wInfo, ok := TunnelStatus(site, "feature")
+	if !ok || wInfo.URL != "https://branch.serveo.net" {
+		t.Errorf("worktree tunnel = %+v, %v; want the branch URL", wInfo, ok)
+	}
+
+	if err := TunnelStop(site, "feature"); err != nil {
+		t.Fatalf("stop worktree: %v", err)
+	}
+	waitTunnelGone(t, wtKey)
+	if _, ok := TunnelStatus(site, ""); !ok {
+		t.Error("stopping the worktree tunnel also stopped the site's")
 	}
 }

--- a/internal/linker/resolve.go
+++ b/internal/linker/resolve.go
@@ -221,14 +221,18 @@ func OwningWorktree(dir string) (*config.Site, string, bool) {
 	if err != nil {
 		return nil, "", false
 	}
+	// Compare canonical paths, as the registry lookup does: a checkout under a
+	// symlinked parent (/var on macOS, /home on ostree) is spelled one way in
+	// the registry and git's metadata and another by os.Getwd.
+	target := config.CanonicalPath(dir)
 	for i := range reg.Sites {
 		s := &reg.Sites[i]
-		if s.Ignored || s.Path == dir {
+		if s.Ignored || config.CanonicalPath(s.Path) == target {
 			continue
 		}
 		wts, _ := gitpkg.DetectWorktrees(s.Path, s.PrimaryDomain())
 		for _, wt := range wts {
-			if wt.Path == dir {
+			if config.CanonicalPath(wt.Path) == target {
 				return s, wt.Branch, true
 			}
 		}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -760,6 +760,8 @@ type WorktreeResponse struct {
 	DBDatabase          string         `json:"db_database,omitempty"`
 	LANPort             int            `json:"lan_port,omitempty"`
 	LANShareURL         string         `json:"lan_share_url,omitempty"`
+	TunnelURL           string         `json:"tunnel_url,omitempty"`
+	TunnelTool          string         `json:"tunnel_tool,omitempty"`
 	FrameworkWorkers    []WorkerStatus `json:"framework_workers,omitempty"`
 	// Idle-suspend state for the worktree, which idles on its own timer.
 	LastActive           int64    `json:"last_active,omitempty"`
@@ -1015,6 +1017,7 @@ func buildSites() []SiteResponse {
 			// timing API share). Same worktree, two key schemes.
 			wtKeyStr := wtKey(e.Name, config.WorktreeUnitSlug(filepath.Base(wt.Path)))
 			usage = addUsage(usage, siteUsage[reqstats.Key(e.Name, wt.Branch)])
+			wtTunnel, _ := cli.TunnelStatus(e.Name, wt.Branch)
 			worktreeResponses = append(worktreeResponses, WorktreeResponse{
 				Branch:               wt.Branch,
 				Domain:               wt.Domain,
@@ -1031,6 +1034,8 @@ func buildSites() []SiteResponse {
 				DBDatabase:           wt.DBDatabase,
 				LANPort:              lanPort,
 				LANShareURL:          lanURL,
+				TunnelURL:            wtTunnel.URL,
+				TunnelTool:           wtTunnel.Tool,
 				FrameworkWorkers:     wtWorkers,
 				LastActive:           idleActivity[wtKeyStr],
 				Idle:                 idleSiteIsIdle(idleActivity, wtKeyStr, e.Paused, idleExempt, idleOn, idleTimeout, idleNow),
@@ -1041,7 +1046,7 @@ func buildSites() []SiteResponse {
 			worktreeResponses = []WorktreeResponse{}
 		}
 
-		tunnel, _ := cli.TunnelStatus(e.Name)
+		tunnel, _ := cli.TunnelStatus(e.Name, "")
 
 		sites = append(sites, SiteResponse{
 			Name:                 e.Name,
@@ -3247,7 +3252,7 @@ func handleTunnelQR(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	tunnel, ok := cli.TunnelStatus(site.Name)
+	tunnel, ok := cli.TunnelStatus(site.Name, r.URL.Query().Get("branch"))
 	if !ok {
 		http.NotFound(w, r)
 		return
@@ -3999,14 +4004,14 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
 	case "tunnel:start":
-		if _, err := cli.TunnelStart(site.Name, r.URL.Query().Get("tool")); err != nil {
+		if _, err := cli.TunnelStart(site.Name, r.URL.Query().Get("branch"), r.URL.Query().Get("tool")); err != nil {
 			writeJSON(w, SiteActionResponse{Error: err.Error()})
 			return
 		}
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
 	case "tunnel:stop":
-		if err := cli.TunnelStop(site.Name); err != nil {
+		if err := cli.TunnelStop(site.Name, r.URL.Query().Get("branch")); err != nil {
 			writeJSON(w, SiteActionResponse{Error: err.Error()})
 			return
 		}

--- a/internal/ui/web/src/stores/sites.ts
+++ b/internal/ui/web/src/stores/sites.ts
@@ -77,6 +77,8 @@ export interface Site {
     db_database?: string;
     lan_port?: number;
     lan_share_url?: string;
+    tunnel_url?: string;
+    tunnel_tool?: string;
     framework_workers?: FrameworkWorker[];
     idle_suspended_workers?: string[];
   }>;
@@ -616,9 +618,15 @@ export interface ShareToolsInfo {
   default?: string;
 }
 export const loadShareTools = () => apiJson<ShareToolsInfo>('/api/share-tools');
-export const startTunnel = (s: Site, tool: string = '') =>
-  postAction(site(s.domain, 'tunnel:start') + (tool ? `?tool=${encodeURIComponent(tool)}` : ''));
-export const stopTunnel = (s: Site) => postAction(site(s.domain, 'tunnel:stop'));
+export const startTunnel = (s: Site, tool: string = '', branch: string = '') => {
+  const params = new URLSearchParams();
+  if (tool) params.set('tool', tool);
+  if (branch) params.set('branch', branch);
+  const qs = params.toString();
+  return postAction(site(s.domain, 'tunnel:start') + (qs ? `?${qs}` : ''));
+};
+export const stopTunnel = (s: Site, branch: string = '') =>
+  postAction(site(s.domain, 'tunnel:stop') + (branch ? `?branch=${encodeURIComponent(branch)}` : ''));
 export const toggleQueue = (s: Site) =>
   postAction(site(s.domain, s.queue_running ? 'queue:stop' : 'queue:start'));
 export const toggleHorizon = (s: Site) =>

--- a/internal/ui/web/src/tabs/sites/ShareMenu.svelte
+++ b/internal/ui/web/src/tabs/sites/ShareMenu.svelte
@@ -47,12 +47,20 @@
   let errorTool = $state('');
   let cancelRequested = false;
 
-  const tunnelUrl = $derived(site.tunnel_url ?? '');
-  const tunnelTool = $derived(site.tunnel_tool ?? '');
+  // A worktree is served on its own subdomain and tunnels it separately, so
+  // the section reads and acts on the active branch's tunnel, not the site's.
+  const activeWorktree = $derived(
+    activeWorktreeBranch
+      ? (site.worktrees || []).find((w) => w.branch === activeWorktreeBranch)
+      : undefined
+  );
+  const tunnelUrl = $derived(
+    (activeWorktreeBranch ? activeWorktree?.tunnel_url : site.tunnel_url) ?? ''
+  );
+  const tunnelTool = $derived(
+    (activeWorktreeBranch ? activeWorktree?.tunnel_tool : site.tunnel_tool) ?? ''
+  );
   const tunnelOn = $derived(Boolean(tunnelUrl));
-  // Tunnels are site-level (they front the primary domain), so the section
-  // hides while a worktree is the active view.
-  const showTunnelSection = $derived(!activeWorktreeBranch);
   const autoTool = $derived(toolsInfo?.tools.find((t) => t.name === toolsInfo?.auto));
 
   function toolLabel(name: string): string {
@@ -107,7 +115,7 @@
     tunnelError = '';
     cancelRequested = false;
     try {
-      const res = await startTunnel(site, tool);
+      const res = await startTunnel(site, tool, activeWorktreeBranch);
       if (!res.ok && !cancelRequested) {
         tunnelError = res.error || m.common_requestFailed();
         errorTool = label;
@@ -120,7 +128,7 @@
 
   async function cancelStart() {
     cancelRequested = true;
-    await stopTunnel(site);
+    await stopTunnel(site, activeWorktreeBranch);
   }
 
   let stopBusy = $state(false);
@@ -129,7 +137,7 @@
     if (stopBusy) return;
     stopBusy = true;
     try {
-      await stopTunnel(site);
+      await stopTunnel(site, activeWorktreeBranch);
       await loadSites();
     } finally {
       stopBusy = false;
@@ -227,93 +235,91 @@
         </button>
       {/if}
 
-      {#if showTunnelSection}
-        <div class="my-1 border-t border-gray-100 dark:border-lerd-border"></div>
-        <div class="px-3 pt-0.5 pb-0.5 text-[9px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
-          {m.share_publicTunnel()}
-        </div>
+      <div class="my-1 border-t border-gray-100 dark:border-lerd-border"></div>
+      <div class="px-3 pt-0.5 pb-0.5 text-[9px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+        {m.share_publicTunnel()}
+      </div>
 
-        {#if tunnelBusy}
-          <div class="{itemClass} text-gray-700 dark:text-gray-200">
+      {#if tunnelBusy}
+        <div class="{itemClass} text-gray-700 dark:text-gray-200">
+          <Icon name="spinner" class="w-3.5 h-3.5 shrink-0 animate-spin" />
+          <span class="flex-1 min-w-0">
+            <span class="block font-medium">{m.share_starting({ tool: startingLabel })}</span>
+            <span class="block text-[10px] text-gray-500 dark:text-gray-400">{m.share_waitingURL()}</span>
+          </span>
+          <button
+            type="button"
+            role="menuitem"
+            onclick={cancelStart}
+            class="shrink-0 text-[10px] font-medium px-2 py-0.5 rounded border border-gray-200 dark:border-lerd-border text-gray-500 dark:text-gray-400 hover:text-red-600 hover:border-red-400 dark:hover:text-red-400 transition-colors"
+          >{m.common_cancel()}</button>
+        </div>
+      {:else if tunnelOn}
+        <div class="{itemClass} border-l-2 border-violet-500 bg-violet-50/60 dark:bg-violet-900/15">
+          <Icon name="globe" class="w-3.5 h-3.5 shrink-0 text-violet-600 dark:text-violet-400" />
+          <span class="flex-1 min-w-0">
+            <span class="block font-medium text-gray-700 dark:text-gray-200">{m.share_tunnelVia({ tool: toolLabel(tunnelTool) })}</span>
+            <a href={tunnelUrl} target="_blank" rel="noopener" class="block font-mono text-[10px] text-violet-600 dark:text-violet-400 truncate hover:underline">{tunnelUrl}</a>
+          </span>
+          <button
+            type="button"
+            role="menuitem"
+            onclick={stopT}
+            class="shrink-0 text-[10px] font-medium px-2 py-0.5 rounded border border-gray-200 dark:border-lerd-border text-gray-500 dark:text-gray-400 hover:text-red-600 hover:border-red-400 dark:hover:text-red-400 transition-colors"
+          >{m.share_stop()}</button>
+        </div>
+      {:else}
+        {#if tunnelError}
+          <button
+            type="button"
+            role="menuitem"
+            onclick={() => (tunnelError = '')}
+            class="{itemClass} text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20"
+          >
+            <Icon name="alert" class="w-3.5 h-3.5 shrink-0" />
+            <span class="flex-1 min-w-0">
+              <span class="block font-medium">{m.share_startFailed({ tool: errorTool })}</span>
+              <span class="block text-[10px] break-words">{tunnelError}</span>
+            </span>
+          </button>
+        {/if}
+        {#if toolsLoading}
+          <div class="{itemClass} text-gray-500 dark:text-gray-400">
             <Icon name="spinner" class="w-3.5 h-3.5 shrink-0 animate-spin" />
-            <span class="flex-1 min-w-0">
-              <span class="block font-medium">{m.share_starting({ tool: startingLabel })}</span>
-              <span class="block text-[10px] text-gray-500 dark:text-gray-400">{m.share_waitingURL()}</span>
-            </span>
-            <button
-              type="button"
-              role="menuitem"
-              onclick={cancelStart}
-              class="shrink-0 text-[10px] font-medium px-2 py-0.5 rounded border border-gray-200 dark:border-lerd-border text-gray-500 dark:text-gray-400 hover:text-red-600 hover:border-red-400 dark:hover:text-red-400 transition-colors"
-            >{m.common_cancel()}</button>
           </div>
-        {:else if tunnelOn}
-          <div class="{itemClass} border-l-2 border-violet-500 bg-violet-50/60 dark:bg-violet-900/15">
-            <Icon name="globe" class="w-3.5 h-3.5 shrink-0 text-violet-600 dark:text-violet-400" />
-            <span class="flex-1 min-w-0">
-              <span class="block font-medium text-gray-700 dark:text-gray-200">{m.share_tunnelVia({ tool: toolLabel(tunnelTool) })}</span>
-              <a href={tunnelUrl} target="_blank" rel="noopener" class="block font-mono text-[10px] text-violet-600 dark:text-violet-400 truncate hover:underline">{tunnelUrl}</a>
-            </span>
-            <button
-              type="button"
-              role="menuitem"
-              onclick={stopT}
-              class="shrink-0 text-[10px] font-medium px-2 py-0.5 rounded border border-gray-200 dark:border-lerd-border text-gray-500 dark:text-gray-400 hover:text-red-600 hover:border-red-400 dark:hover:text-red-400 transition-colors"
-            >{m.share_stop()}</button>
-          </div>
-        {:else}
-          {#if tunnelError}
-            <button
-              type="button"
-              role="menuitem"
-              onclick={() => (tunnelError = '')}
-              class="{itemClass} text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20"
-            >
-              <Icon name="alert" class="w-3.5 h-3.5 shrink-0" />
-              <span class="flex-1 min-w-0">
-                <span class="block font-medium">{m.share_startFailed({ tool: errorTool })}</span>
-                <span class="block text-[10px] break-words">{tunnelError}</span>
+        {:else if toolsInfo}
+          <button
+            type="button"
+            role="menuitem"
+            disabled={!autoTool}
+            onclick={() => startTool('', m.share_autoLabel())}
+            class="{itemClass} {autoTool ? itemIdle : 'text-gray-400 dark:text-gray-600'}"
+          >
+            <Icon name="external" class="w-3.5 h-3.5 shrink-0" />
+            <span class="flex-1 min-w-0 text-left">
+              <span class="block font-medium">{m.share_viaTunnel()}</span>
+              <span class="block text-[10px] {autoTool ? 'text-gray-500 dark:text-gray-400' : ''}">
+                {autoTool ? m.share_autoPicks({ tool: autoTool.label }) : m.share_noTools()}
               </span>
-            </button>
-          {/if}
-          {#if toolsLoading}
-            <div class="{itemClass} text-gray-500 dark:text-gray-400">
-              <Icon name="spinner" class="w-3.5 h-3.5 shrink-0 animate-spin" />
-            </div>
-          {:else if toolsInfo}
+            </span>
+          </button>
+          {#each toolsInfo.tools as tool (tool.name)}
             <button
               type="button"
               role="menuitem"
-              disabled={!autoTool}
-              onclick={() => startTool('', m.share_autoLabel())}
-              class="{itemClass} {autoTool ? itemIdle : 'text-gray-400 dark:text-gray-600'}"
+              disabled={!tool.installed}
+              onclick={() => startTool(tool.name, tool.label)}
+              class="{itemClass} {tool.installed ? itemIdle : 'text-gray-400 dark:text-gray-600'}"
             >
-              <Icon name="external" class="w-3.5 h-3.5 shrink-0" />
+              <Icon name="globe" class="w-3.5 h-3.5 shrink-0" />
               <span class="flex-1 min-w-0 text-left">
-                <span class="block font-medium">{m.share_viaTunnel()}</span>
-                <span class="block text-[10px] {autoTool ? 'text-gray-500 dark:text-gray-400' : ''}">
-                  {autoTool ? m.share_autoPicks({ tool: autoTool.label }) : m.share_noTools()}
+                <span class="block font-medium">{tool.label}</span>
+                <span class="block text-[10px] {tool.installed ? 'text-gray-500 dark:text-gray-400' : ''}">
+                  {tool.installed ? tool.binary : installHint(tool)}
                 </span>
               </span>
             </button>
-            {#each toolsInfo.tools as tool (tool.name)}
-              <button
-                type="button"
-                role="menuitem"
-                disabled={!tool.installed}
-                onclick={() => startTool(tool.name, tool.label)}
-                class="{itemClass} {tool.installed ? itemIdle : 'text-gray-400 dark:text-gray-600'}"
-              >
-                <Icon name="globe" class="w-3.5 h-3.5 shrink-0" />
-                <span class="flex-1 min-w-0 text-left">
-                  <span class="block font-medium">{tool.label}</span>
-                  <span class="block text-[10px] {tool.installed ? 'text-gray-500 dark:text-gray-400' : ''}">
-                    {tool.installed ? tool.binary : installHint(tool)}
-                  </span>
-                </span>
-              </button>
-            {/each}
-          {/if}
+          {/each}
         {/if}
       {/if}
     </div>

--- a/internal/ui/web/src/tabs/sites/ShareMenu.test.ts
+++ b/internal/ui/web/src/tabs/sites/ShareMenu.test.ts
@@ -10,6 +10,15 @@ const site = {
   worktrees: []
 } as unknown as Site;
 
+// A site whose "feat" worktree is the active view, carrying whatever tunnel
+// state the test needs on the worktree itself.
+function withWorktree(wt: Record<string, unknown> = {}): Site {
+  return {
+    ...site,
+    worktrees: [{ branch: 'feat', domain: 'feat.app.test', path: '/home/u/Code/app/wt/feat', ...wt }]
+  } as unknown as Site;
+}
+
 const toolsPayload = {
   tools: [
     { name: 'ngrok', label: 'ngrok', binary: 'ngrok', installed: false, install_url: 'https://ngrok.com/download' },
@@ -94,11 +103,44 @@ describe('ShareMenu', () => {
     await waitFor(() => expect(fetchCalls.some((u) => u.includes('/api/sites/app.test/tunnel:stop'))).toBe(true));
   });
 
-  it('hides the tunnel section on a worktree view', async () => {
-    const { container } = render(Harness, { props: { site, activeWorktreeBranch: 'feat' } });
+  it('offers the tunnel section on a worktree view', async () => {
+    const { container } = render(Harness, { props: { site: withWorktree(), activeWorktreeBranch: 'feat' } });
     await openMenu(container);
-    expect(screen.queryByText('Public tunnel')).not.toBeInTheDocument();
+    expect(screen.getByText('Public tunnel')).toBeInTheDocument();
     expect(screen.getByText('Local network')).toBeInTheDocument();
+  });
+
+  it('starts a worktree tunnel against its branch', async () => {
+    const { container } = render(Harness, { props: { site: withWorktree(), activeWorktreeBranch: 'feat' } });
+    await openMenu(container);
+    await waitFor(() => expect(screen.getByText('Serveo')).toBeInTheDocument());
+    await fireEvent.click(screen.getByText('Serveo').closest('button')!);
+    await waitFor(() =>
+      expect(
+        fetchCalls.some((u) => u.includes('tunnel:start?tool=serveo&branch=feat'))
+      ).toBe(true)
+    );
+  });
+
+  // The branch has a tunnel of its own, so the menu must show that one rather
+  // than whatever the parent site happens to be running.
+  it('shows the worktree tunnel, not the site tunnel', async () => {
+    const s = withWorktree({ tunnel_url: 'https://branch.serveo.net', tunnel_tool: 'serveo' });
+    (s as unknown as { tunnel_url: string }).tunnel_url = 'https://parent.trycloudflare.com';
+    const { container } = render(Harness, { props: { site: s, activeWorktreeBranch: 'feat' } });
+    await openMenu(container);
+    expect(screen.getByText('https://branch.serveo.net')).toBeInTheDocument();
+    expect(screen.queryByText('https://parent.trycloudflare.com')).not.toBeInTheDocument();
+  });
+
+  it('stops a worktree tunnel against its branch', async () => {
+    const s = withWorktree({ tunnel_url: 'https://branch.serveo.net', tunnel_tool: 'serveo' });
+    const { container } = render(Harness, { props: { site: s, activeWorktreeBranch: 'feat' } });
+    await openMenu(container);
+    await fireEvent.click(screen.getByText('Stop'));
+    await waitFor(() =>
+      expect(fetchCalls.some((u) => u.includes('tunnel:stop?branch=feat'))).toBe(true)
+    );
   });
 
   it('closes on Escape', async () => {

--- a/internal/ui/web/src/tabs/sites/SiteHeader.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteHeader.svelte
@@ -135,16 +135,19 @@
   const lanQrSrc = $derived(
     apiBase + '/api/lan-qr/' + site.domain + (activeWorktreeBranch ? '?branch=' + encodeURIComponent(activeWorktreeBranch) : '')
   );
-  // Tunnels are site-level, so the chip only shows on the main site view.
-  const tunnelURL = $derived(activeWorktreeBranch ? '' : site.tunnel_url ?? '');
-  const tunnelQrSrc = $derived(apiBase + '/api/tunnel-qr/' + site.domain);
+  // A worktree tunnels its own subdomain, so the chip follows the active view
+  // the same way the LAN one does.
+  const tunnelURL = $derived(activeWorktree ? activeWorktree.tunnel_url ?? '' : site.tunnel_url ?? '');
+  const tunnelQrSrc = $derived(
+    apiBase + '/api/tunnel-qr/' + site.domain + (activeWorktreeBranch ? '?branch=' + encodeURIComponent(activeWorktreeBranch) : '')
+  );
   let tunnelBusy = $state(false);
 
   async function startTunnelAuto() {
     if (tunnelBusy) return;
     tunnelBusy = true;
     try {
-      const res = await startTunnel(site);
+      const res = await startTunnel(site, '', activeWorktreeBranch);
       if (!res.ok) openErrorModal(res.error || m.common_requestFailed());
       await loadSites();
     } finally {
@@ -153,7 +156,7 @@
   }
 
   async function stopTunnelNow() {
-    await stopTunnel(site);
+    await stopTunnel(site, activeWorktreeBranch);
     await loadSites();
   }
 
@@ -754,7 +757,7 @@
                 {lanOn ? m.sites_controls_lanToggle_on() : m.sites_controls_lanToggle_off()}
               </button>
             {/if}
-            {#if !site.paused && !activeWorktreeBranch}
+            {#if !site.paused}
               <button
                 type="button"
                 role="menuitem"


### PR DESCRIPTION
A worktree inherits its parent's registration and is deliberately never registered as a site of its own, but the shared resolver behind every directory scoped command looked a directory up by exact registry path. Inside a checkout that always missed, so the command offered to link the directory, link correctly refused because it is a worktree, and the caller then reported no site registered for this directory, run lerd link first. That is advice that can never succeed no matter how many times it is followed, and it took out share, open, domain, env, worker, runtime, stripe and xdebug pause all at once.

The resolver now falls back to the owning parent and the branch the checkout is on, ahead of the link prompt, so a worktree resolves silently instead of prompting for something that cannot be done.

Commands that address a domain act on the branch rather than the parent. lerd share tunnels the worktree's own subdomain, which would otherwise have been a quietly wrong site rather than an error. That needs a branch dimension on the tunnel registry, which was keyed by site name, so a worktree tunnel neither replaces the parent's nor is stopped along with it, and the Cloudflare named tunnel is keyed to the branch too so routing a hostname to a worktree cannot take over the one the parent site uses. The tunnel command builds against a target now, one domain and its TLS state, instead of reaching into the site for both. lerd open opens the branch domain for the same reason.

The dashboard share menu used to hide its whole public tunnel section while a worktree tab was active. It offers it now, reading and acting on that branch's tunnel, with the sites payload carrying the tunnel per worktree the way it already carries the LAN port, and the QR endpoint honouring the branch. Both tunnels can run at once, each on its own public URL, and stopping one leaves the other alone.

lerd lan:share and lan:unshare resolved the current directory through the queue site helper, whose fallback treats the directory basename as a site name, so inside a worktree they assigned a LAN port to a site that does not exist. Both route through the same resolver now and drive the per branch proxy that was already implemented and reachable from the dashboard.

Closes #1199