### PR TITLE
feat(share): serve a site on your own Cloudflare base domain

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -213,6 +213,7 @@ func main() {
 	}
 	root.AddCommand(cli.NewShareCmd())
 	root.AddCommand(cli.NewShareToolCmd())
+	root.AddCommand(cli.NewShareDomainCmd())
 	root.AddCommand(cli.NewDomainCmd())
 	root.AddCommand(cli.NewGroupCmd())
 	root.AddCommand(cli.NewWorkspaceCmd())

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -71,6 +71,7 @@ Setup steps include common tasks (composer install, npm install, lerd env) plus 
 | `lerd share [name]` | Expose the site publicly via ngrok, cloudflared, or Expose (auto-detected) |
 | `lerd share --domain <hostname>` | Expose the site on your own Cloudflare-managed hostname via a named tunnel (implies Cloudflare Tunnel) |
 | `lerd share:tool [tool]` | Show or set the default tunnel tool for `lerd share` (`auto` restores auto-detection) |
+| `lerd share:domain [domain]` | Show or set the base domain a Cloudflare share is served under, as `<site>.<domain>` (`none` forgets it) |
 | `lerd secure [name]` | Issue a mkcert TLS cert and enable HTTPS, updates `APP_URL` in `.env` |
 | `lerd secure --renew [name]` | Reissue a secured site's TLS cert on demand, resetting its expiry |
 | `lerd unsecure [name]` | Remove TLS and switch back to HTTP, updates `APP_URL` in `.env` |

--- a/docs/usage/sites.md
+++ b/docs/usage/sites.md
@@ -459,10 +459,15 @@ Lerd automatically creates a subdomain for each `git worktree` checkout. See [Gi
 | `lerd share --serveo` | Force serveo.net (SSH, no signup) |
 | `lerd share --domain <hostname>` | Serve on your own Cloudflare-managed hostname (implies Cloudflare Tunnel) |
 | `lerd share:tool [tool]` | Show or set the default tunnel tool (`ngrok`, `cloudflare`, `expose`, `serveo`, `localhost-run`, or `auto`) |
+| `lerd share:domain [domain]` | Show or set the base domain a Cloudflare share is served under (`none` forgets it) |
 
 ### Tunnels from the dashboard
 
 The same tunnels can be started from the [web UI](../features/web-ui.md)'s share menu: hover the wifi button in a site's header and pick a tool (or the auto entry, which follows the same detection order and `share:tool` default as the CLI). The dashboard waits for the tool's public URL and shows it next to the domain with a hover-QR. A tunnel started from the UI belongs to the `lerd-ui` daemon, so it ends when you stop it or when the daemon shuts down, and it is not restored on restart. If the daemon is killed outright rather than asked to stop, the next start reaps whatever tunnel survived, so a public URL never outlives the dashboard that owns it.
+
+A shared site is marked in the sites list too: a violet globe against the row while a public tunnel is up, a teal wifi icon while it is on the LAN, both captioned with the address. A share on one of the site's worktrees counts for the row, since the list has one row per site.
+
+A `lerd share` running in a terminal shows up there as well. The CLI records the share while it runs and clears the record on the way out, so the dashboard reflects it like one of its own, labelled as started from the CLI. Stopping it from the dashboard signals that `lerd share` to exit. A share whose process is killed outright leaves its record behind; the dashboard drops it as soon as it notices the process is gone.
 
 ### Sharing a worktree
 
@@ -486,7 +491,27 @@ lerd share --domain dev.example.com
 
 Custom hostnames are a Cloudflare Tunnel feature, so `--domain` selects that tool on its own. You never need `--cloudflare` alongside it, and it wins over a different default set with `lerd share:tool`. Combining it with another tool flag is rejected rather than silently ignored.
 
-On the first run cloudflared opens a browser window to authorize your Cloudflare account (a one-time login that writes `~/.cloudflared/cert.pem`). lerd then creates a named tunnel called `lerd-<site>`, routes the hostname to it with a CNAME record, and starts the tunnel. Later runs reuse the same tunnel and hostname, so the URL never changes. Re-routing a hostname that already points at the same tunnel is a no-op; if the record exists but points somewhere else, lerd leaves it alone and prints a note asking you to check it.
+#### A base domain, so you never type the hostname
+
+`--domain` takes a full hostname and applies to one run. Set a base domain instead and every Cloudflare share is served under it, with lerd composing the hostname from the site name:
+
+```bash
+lerd share:domain example.com   # myapp.test is shared on myapp.example.com
+lerd share:domain               # show the current one
+lerd share:domain none          # forget it, back to quick tunnels
+```
+
+The hostname follows the site's own domain rather than the folder the project sits in, so a `scorediviner.test` served out of a `score-diviner` directory is shared on `scorediviner.example.com`.
+
+The dashboard asks the first time you pick Cloudflare Tunnel from the share menu: type the base domain, or skip it for a quick tunnel. Tick **Remember this answer** and it stops asking, whichever way you answered. The cog next to the Cloudflare entry reopens that dialog whenever you want to change the domain, or clear it so lerd asks again.
+
+A worktree's subdomain flattens into one label, so `feat-login.myapp.test` is shared on `feat-login-myapp.example.com`: a Cloudflare certificate covers one level of subdomain and no more.
+
+`lerd share --domain` still wins for a single run, and the other tunnel tools ignore the base domain: no other one can hand out a subdomain of a domain you own.
+
+#### How the named tunnel is set up
+
+On the first run cloudflared opens a browser window to authorize your Cloudflare account (a one-time login that writes `~/.cloudflared/cert.pem`). The dashboard has no terminal to run that login in, so a share from the UI stops and tells you to run `cloudflared tunnel login` once. lerd then creates a named tunnel called `lerd-<site>`, routes the hostname to it with a CNAME record, and starts the tunnel. Later runs reuse the same tunnel and hostname, so the URL never changes. Re-routing a hostname that already points at the same tunnel is a no-op; if the record exists but points somewhere else, lerd leaves it alone and prints a note asking you to check it.
 
 A freshly created DNS record takes a moment to become visible. If you open the URL in the first seconds and your resolver caches the miss, it can keep answering NXDOMAIN for up to 30 minutes even though the tunnel is healthy.
 

--- a/internal/cli/share.go
+++ b/internal/cli/share.go
@@ -13,11 +13,15 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
+	"syscall"
 
 	"github.com/geodro/lerd/internal/config"
+	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/hostbin"
 	"github.com/geodro/lerd/internal/siteops"
 	"github.com/spf13/cobra"
@@ -51,7 +55,10 @@ A default tool can be set with "lerd share:tool"; flags override it per run.
 --domain selects Cloudflare Tunnel on its own: a named tunnel is created (or
 reused) and the given hostname is routed to it, so the site is served on your
 own domain instead of a random trycloudflare.com URL. The domain's DNS must be
-managed by Cloudflare.`,
+managed by Cloudflare.
+
+A base domain set with "lerd share:domain" does the same without the flag: a
+Cloudflare share is served on "<site>.<base domain>".`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return runShare(args, useNgrok, useCloudflare, useExpose, useServeo, useLocalhostRun, domain)
@@ -106,13 +113,21 @@ func runShare(args []string, useNgrok, useCloudflare, useExpose, useServeo, useL
 		return err
 	}
 
+	// A configured base domain serves the site on "<site>.<base>" without the
+	// flag, so a bare share matches what the dashboard does.
+	if tool.mode == shareModeCloudflare && tool.domain == "" && cfg.Share.BaseDomain != "" {
+		if tool.domain, err = shareHostname(target.domain, cfg.DNS.TLD, cfg.Share.BaseDomain); err != nil {
+			return err
+		}
+	}
+
 	fmt.Printf("Sharing %s...\n", target.domain)
 	fmt.Println("Press Ctrl+C to stop.")
 	fmt.Println()
 
 	tunnelName := ""
 	if tool.mode == shareModeCloudflare && tool.domain != "" {
-		if tunnelName, err = ensureCloudflareTunnel(target.name, tool.domain); err != nil {
+		if tunnelName, err = ensureCloudflareTunnel(target.name, tool.domain, true); err != nil {
 			return err
 		}
 		fmt.Printf("Public URL: https://%s\n\n", tool.domain)
@@ -128,10 +143,43 @@ func runShare(args []string, useNgrok, useCloudflare, useExpose, useServeo, useL
 	}
 	defer stop()
 
+	// Record the share so the dashboard shows it like one of its own, teeing
+	// the tool's output through the recorder to catch the URL it announces.
+	key := tunnelKey(site.Name, branch)
+	state := tunnelState{Site: site.Name, Branch: branch, Tool: shareToolCanonicalName(tool), PID: os.Getpid()}
+	if tool.domain != "" {
+		state.URL = "https://" + tool.domain
+	}
+	recorder := newTunnelStateWriter(key, state)
+	defer recorder.clear()
+
 	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	cmd.Stdout = io.MultiWriter(os.Stdout, recorder)
+	cmd.Stderr = io.MultiWriter(os.Stderr, recorder)
+
+	// The dashboard stops a CLI share by signalling this process, which the
+	// tool itself never sees, so pass it on and let the run end normally.
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigs)
+	done := make(chan struct{})
+	defer close(done)
+	var signalled atomic.Bool
+	go func() {
+		select {
+		case <-sigs:
+			signalled.Store(true)
+			if cmd.Process != nil {
+				_ = cmd.Process.Signal(syscall.SIGTERM)
+			}
+		case <-done:
+		}
+	}()
+
+	if err := cmd.Run(); err != nil && !signalled.Load() {
+		return err
+	}
+	return nil
 }
 
 // shareTarget is what a tunnel fronts: the domain nginx routes on and whether
@@ -154,9 +202,76 @@ func shareTargetFor(site *config.Site, branch string) (shareTarget, error) {
 	}
 	name := site.Name
 	if branch != "" {
-		name = site.Name + "-" + branch
+		name = site.Name + "-" + gitpkg.SanitizeBranch(branch)
 	}
 	return shareTarget{name: name, domain: domain, secured: site.Secured}, nil
+}
+
+// normalizeBaseDomain cleans up what a user typed for a Cloudflare base domain
+// and rejects anything that is not a bare registrable domain. Empty stays
+// empty: that means "no base domain", not a mistake.
+func normalizeBaseDomain(s string) (string, error) {
+	d := strings.Trim(strings.ToLower(strings.TrimSpace(s)), ".")
+	if d == "" {
+		return "", nil
+	}
+	if strings.ContainsAny(d, "/:@ \t") || strings.HasPrefix(d, "*") {
+		return "", fmt.Errorf("base domain %q must be a bare domain like example.com, without a scheme, port, path or wildcard", s)
+	}
+	if !strings.Contains(d, ".") {
+		return "", fmt.Errorf("base domain %q needs at least one dot, like example.com", s)
+	}
+	for _, label := range strings.Split(d, ".") {
+		if !isDNSLabel(label) {
+			return "", fmt.Errorf("base domain %q is not a valid domain name", s)
+		}
+	}
+	return d, nil
+}
+
+// isDNSLabel reports whether s is usable as one label of a hostname.
+func isDNSLabel(s string) bool {
+	if s == "" || len(s) > 63 || strings.HasPrefix(s, "-") || strings.HasSuffix(s, "-") {
+		return false
+	}
+	for _, r := range s {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+// shareHostLabel is the single label a site is served under on a base domain.
+// It comes from the domain the user picked, not from the folder the project
+// happens to sit in, so scorediviner.test is shared as scorediviner. A
+// worktree's subdomain flattens into that same label, because a Cloudflare
+// certificate covers one level of subdomain and no more.
+func shareHostLabel(domain, tld string) string {
+	d := strings.Trim(strings.ToLower(domain), ".")
+	if tld != "" && strings.HasSuffix(d, "."+tld) {
+		d = strings.TrimSuffix(d, "."+tld)
+	} else if i := strings.LastIndex(d, "."); i > 0 {
+		d = d[:i]
+	}
+	return strings.ReplaceAll(d, ".", "-")
+}
+
+// shareHostname composes the public hostname a site's domain is served on under
+// a base domain.
+func shareHostname(domain, tld, baseDomain string) (string, error) {
+	base, err := normalizeBaseDomain(baseDomain)
+	if err != nil {
+		return "", err
+	}
+	if base == "" {
+		return "", nil
+	}
+	label := shareHostLabel(domain, tld)
+	if !isDNSLabel(label) {
+		return "", fmt.Errorf("domain %q cannot be used as a hostname label under %s", domain, base)
+	}
+	return label + "." + base, nil
 }
 
 // buildTunnelCommand builds the tunnel tool invocation for a target plus a stop
@@ -355,10 +470,15 @@ func cloudflaredCertPath() string {
 }
 
 // ensureCloudflareTunnel makes sure a named tunnel exists for the site and that
-// domain routes to it, logging in interactively first if needed.
+// domain routes to it, logging in interactively first if needed. interactive is
+// false for the dashboard, which has no terminal to run the login in and says so
+// rather than hanging on a prompt nobody can see.
 // Returns the tunnel name to pass to "cloudflared tunnel run".
-func ensureCloudflareTunnel(siteName, domain string) (string, error) {
+func ensureCloudflareTunnel(siteName, domain string, interactive bool) (string, error) {
 	if _, err := os.Stat(cloudflaredCertPath()); err != nil {
+		if !interactive {
+			return "", fmt.Errorf("cloudflared is not authorized for your Cloudflare account yet: run \"cloudflared tunnel login\" in a terminal once, then share again")
+		}
 		fmt.Println("cloudflared is not logged in yet, a browser window will open to authorize it.")
 		login := exec.Command(hostbin.Path("cloudflared"), "tunnel", "login")
 		login.Stdin = os.Stdin
@@ -390,11 +510,13 @@ func ensureCloudflareTunnel(siteName, domain string) (string, error) {
 	out, err = exec.Command(hostbin.Path("cloudflared"), "tunnel", "route", "dns", name, domain).CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(out), "already exists") || strings.Contains(string(out), "already configured") {
-			fmt.Printf("DNS record for %s already exists, make sure it CNAMEs to tunnel %q.\n", domain, name)
+			if interactive {
+				fmt.Printf("DNS record for %s already exists, make sure it CNAMEs to tunnel %q.\n", domain, name)
+			}
 		} else {
 			return "", fmt.Errorf("cloudflared tunnel route dns %s %s: %w\n%s", name, domain, err, out)
 		}
-	} else if strings.Contains(string(out), "Added CNAME") {
+	} else if interactive && strings.Contains(string(out), "Added CNAME") {
 		fmt.Printf("Routed %s to tunnel %q. The record is new, so give it a moment: opening it too early can leave your resolver caching the miss for up to 30 minutes.\n", domain, name)
 	}
 	return name, nil

--- a/internal/cli/share_domain.go
+++ b/internal/cli/share_domain.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
+	"github.com/spf13/cobra"
+)
+
+// NewShareDomainCmd returns the share:domain command.
+func NewShareDomainCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "share:domain [domain|none]",
+		Short: "Show or set the base domain public shares are served under",
+		Long: `Without an argument, prints the base domain "lerd share" serves a site under.
+
+With a domain, every Cloudflare share is served on "<site>.<domain>" through a
+named tunnel, so the public URL stays the same between runs instead of being a
+fresh trycloudflare.com address each time. The domain's DNS must be managed by
+Cloudflare, and cloudflared must be authorized once with "cloudflared tunnel login".
+
+"none" forgets the setting, so quick tunnels come back and the dashboard asks
+again the next time a site is shared through Cloudflare.
+
+"lerd share --domain" still wins for a single run.`,
+		Example: `  lerd share:domain
+  lerd share:domain example.com
+  lerd share:domain none`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runShareDomain,
+	}
+}
+
+func runShareDomain(_ *cobra.Command, args []string) error {
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		switch {
+		case cfg.Share.BaseDomain != "":
+			fmt.Printf("%s (a site is shared on <site>.%s)\n", cfg.Share.BaseDomain, cfg.Share.BaseDomain)
+		case cfg.Share.BaseDomainAnswered:
+			fmt.Println("none (quick tunnels, and the dashboard no longer asks)")
+		default:
+			fmt.Println("none (quick tunnels)")
+		}
+		fmt.Println("\nChange it with: lerd share:domain example.com|none")
+		return nil
+	}
+
+	if strings.EqualFold(args[0], "none") {
+		if err := SetShareBaseDomain("", false); err != nil {
+			return err
+		}
+		feedback.Begin()
+		feedback.Done("share base domain cleared, back to " + feedback.Val("quick tunnels"))
+		return nil
+	}
+
+	domain, err := normalizeBaseDomain(args[0])
+	if err != nil {
+		return err
+	}
+	if err := SetShareBaseDomain(domain, true); err != nil {
+		return err
+	}
+	feedback.Begin()
+	feedback.Done("share base domain set to " + feedback.Val(domain))
+	return nil
+}

--- a/internal/cli/share_domain_test.go
+++ b/internal/cli/share_domain_test.go
@@ -1,0 +1,255 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func TestNormalizeBaseDomain_cleansUpWhatIsTyped(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"   ", ""},
+		{"example.com", "example.com"},
+		{"  Example.COM  ", "example.com"},
+		{"example.com.", "example.com"},
+		{".example.com", "example.com"},
+		{"dev.example.co.uk", "dev.example.co.uk"},
+	}
+	for _, c := range cases {
+		got, err := normalizeBaseDomain(c.in)
+		if err != nil {
+			t.Errorf("normalizeBaseDomain(%q) errored: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("normalizeBaseDomain(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeBaseDomain_rejectsAnythingThatIsNotABareDomain(t *testing.T) {
+	for _, in := range []string{
+		"https://example.com",
+		"example.com/app",
+		"example.com:8080",
+		"*.example.com",
+		"example",
+		"exa mple.com",
+		"-example.com",
+		"example-.com",
+		"exa_mple.com",
+	} {
+		if got, err := normalizeBaseDomain(in); err == nil {
+			t.Errorf("normalizeBaseDomain(%q) = %q, want an error", in, got)
+		}
+	}
+}
+
+func TestShareHostname_composesTheSiteDomainUnderTheBase(t *testing.T) {
+	got, err := shareHostname("acme.test", "test", "example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "acme.example.com" {
+		t.Errorf("hostname = %q, want acme.example.com", got)
+	}
+}
+
+// The label follows the domain the user picked, not the folder the project sits
+// in, so a scorediviner.test served out of a score-diviner directory is shared
+// as scorediviner.
+func TestShareHostLabel_followsTheDomainNotTheFolder(t *testing.T) {
+	if got := shareHostLabel("scorediviner.test", "test"); got != "scorediviner" {
+		t.Errorf("label = %q, want scorediviner", got)
+	}
+}
+
+// A worktree's subdomain flattens into one label: a Cloudflare certificate
+// covers one level of subdomain, so feat-acme.example.com works where
+// feat.acme.example.com would not.
+func TestShareHostLabel_flattensAWorktreeSubdomain(t *testing.T) {
+	if got := shareHostLabel("feat-login.acme.test", "test"); got != "feat-login-acme" {
+		t.Errorf("label = %q, want feat-login-acme", got)
+	}
+}
+
+func TestShareHostLabel_honoursACustomTLD(t *testing.T) {
+	if got := shareHostLabel("acme.localhost", "localhost"); got != "acme" {
+		t.Errorf("label = %q, want acme", got)
+	}
+	// Unknown TLD: drop the last label rather than keeping the whole domain.
+	if got := shareHostLabel("acme.dev", "test"); got != "acme" {
+		t.Errorf("label = %q, want acme", got)
+	}
+}
+
+func TestShareHostname_emptyBaseMeansNoHostname(t *testing.T) {
+	got, err := shareHostname("acme.test", "test", "")
+	if err != nil || got != "" {
+		t.Errorf("shareHostname with no base = (%q, %v), want (\"\", nil)", got, err)
+	}
+}
+
+func TestShareHostname_rejectsADomainThatCannotBeALabel(t *testing.T) {
+	if _, err := shareHostname("my site.test", "test", "example.com"); err == nil {
+		t.Error("expected an error for a domain that cannot be a hostname label")
+	}
+}
+
+func TestResolveShareBaseDomain_prefersTheRequestedOverTheConfigured(t *testing.T) {
+	got, err := resolveShareBaseDomain(&shareTool{mode: shareModeCloudflare}, "run.example.com", "saved.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "run.example.com" {
+		t.Errorf("base = %q, want run.example.com", got)
+	}
+}
+
+func TestResolveShareBaseDomain_fallsBackToTheConfigured(t *testing.T) {
+	got, err := resolveShareBaseDomain(&shareTool{mode: shareModeCloudflare}, "", "saved.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "saved.example.com" {
+		t.Errorf("base = %q, want saved.example.com", got)
+	}
+}
+
+// The configured domain is a standing preference, not a per-run flag, so a tool
+// that cannot serve a custom hostname just ignores it.
+func TestResolveShareBaseDomain_otherToolsIgnoreTheConfiguredOne(t *testing.T) {
+	got, err := resolveShareBaseDomain(&shareTool{mode: shareModeNgrok}, "", "saved.example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("base = %q, want it dropped for ngrok", got)
+	}
+}
+
+func TestResolveShareBaseDomain_rejectsARequestedOneOnAnotherTool(t *testing.T) {
+	_, err := resolveShareBaseDomain(&shareTool{mode: shareModeNgrok}, "run.example.com", "")
+	if err == nil || !strings.Contains(err.Error(), "Cloudflare") {
+		t.Errorf("error = %v, want it to name Cloudflare Tunnel", err)
+	}
+}
+
+func TestSetShareBaseDomain_remembersAndForgets(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := SetShareBaseDomain("Example.COM", true); err != nil {
+		t.Fatalf("saving: %v", err)
+	}
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	if cfg.Share.BaseDomain != "example.com" || !cfg.Share.BaseDomainAnswered {
+		t.Fatalf("stored (%q, %v), want (example.com, true)", cfg.Share.BaseDomain, cfg.Share.BaseDomainAnswered)
+	}
+
+	if err := SetShareBaseDomain("example.com", false); err != nil {
+		t.Fatalf("forgetting: %v", err)
+	}
+	cfg, err = config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	if cfg.Share.BaseDomain != "" || cfg.Share.BaseDomainAnswered {
+		t.Errorf("stored (%q, %v), want it forgotten", cfg.Share.BaseDomain, cfg.Share.BaseDomainAnswered)
+	}
+}
+
+// Skipping is an answer too: nothing is served under a domain, but the share
+// menu has to stop asking.
+func TestSetShareBaseDomain_rememberedSkipIsAnAnswer(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := SetShareBaseDomain("", true); err != nil {
+		t.Fatalf("saving: %v", err)
+	}
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	if cfg.Share.BaseDomain != "" || !cfg.Share.BaseDomainAnswered {
+		t.Errorf("stored (%q, %v), want (\"\", true)", cfg.Share.BaseDomain, cfg.Share.BaseDomainAnswered)
+	}
+}
+
+func TestSetShareBaseDomain_rejectsAnInvalidDomain(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := SetShareBaseDomain("https://example.com/app", true); err == nil {
+		t.Error("expected an error for a domain that is not bare")
+	}
+}
+
+func TestShareTools_reportsTheBaseDomain(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := SetShareBaseDomain("example.com", true); err != nil {
+		t.Fatalf("saving: %v", err)
+	}
+
+	info := ShareTools()
+	if info.BaseDomain != "example.com" || !info.BaseDomainAnswered {
+		t.Errorf("ShareTools reported (%q, %v), want (example.com, true)", info.BaseDomain, info.BaseDomainAnswered)
+	}
+}
+
+func TestRunShareDomain_setShowClear(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	if err := runShareDomain(nil, []string{"example.com"}); err != nil {
+		t.Fatalf("setting: %v", err)
+	}
+	out := captureStdout(t, func() {
+		if err := runShareDomain(nil, nil); err != nil {
+			t.Errorf("showing: %v", err)
+		}
+	})
+	if !strings.Contains(out, "example.com") {
+		t.Errorf("show output %q does not report the base domain", out)
+	}
+	if !strings.Contains(out, "lerd share:domain") {
+		t.Errorf("show output %q does not say how to change it", out)
+	}
+
+	if err := runShareDomain(nil, []string{"none"}); err != nil {
+		t.Fatalf("clearing: %v", err)
+	}
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("loading config: %v", err)
+	}
+	if cfg.Share.BaseDomain != "" || cfg.Share.BaseDomainAnswered {
+		t.Errorf("stored (%q, %v) after none, want it cleared", cfg.Share.BaseDomain, cfg.Share.BaseDomainAnswered)
+	}
+}
+
+func TestRunShareDomain_rejectsAnInvalidDomain(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := runShareDomain(nil, []string{"not a domain"}); err == nil {
+		t.Error("expected an error for a domain that is not bare")
+	}
+}
+
+// The dashboard has no terminal to run the browser login in, so it has to say
+// what to run rather than block on a prompt nobody can answer.
+func TestEnsureCloudflareTunnel_headlessRefusesToLogIn(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("TUNNEL_ORIGIN_CERT", "")
+	logFile := fakeCloudflared(t, "created", 0, "routed", 0)
+
+	_, err := ensureCloudflareTunnel("mysite", "mysite.example.com", false)
+	if err == nil || !strings.Contains(err.Error(), "cloudflared tunnel login") {
+		t.Fatalf("error = %v, want it to name the login command", err)
+	}
+	if strings.Contains(readCalls(t, logFile), "tunnel login") {
+		t.Error("a headless caller must not start an interactive login")
+	}
+}

--- a/internal/cli/share_test.go
+++ b/internal/cli/share_test.go
@@ -449,7 +449,7 @@ func TestEnsureCloudflareTunnel_happyPath_logsInWhenNoCert(t *testing.T) {
 	}
 	logFile := fakeCloudflared(t, "created", 0, "routed", 0)
 
-	name, err := ensureCloudflareTunnel("mysite", "dev.example.com")
+	name, err := ensureCloudflareTunnel("mysite", "dev.example.com", true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -472,7 +472,7 @@ func TestEnsureCloudflareTunnel_skipsLoginWhenCertExists(t *testing.T) {
 	t.Setenv("TUNNEL_ORIGIN_CERT", cert)
 	logFile := fakeCloudflared(t, "created", 0, "routed", 0)
 
-	if _, err := ensureCloudflareTunnel("mysite", "dev.example.com"); err != nil {
+	if _, err := ensureCloudflareTunnel("mysite", "dev.example.com", true); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if strings.Contains(readCalls(t, logFile), "tunnel login") {
@@ -486,7 +486,7 @@ func TestEnsureCloudflareTunnel_toleratesExistingTunnelAndRoute(t *testing.T) {
 
 	var name string
 	var err error
-	out := captureStdout(t, func() { name, err = ensureCloudflareTunnel("mysite", "dev.example.com") })
+	out := captureStdout(t, func() { name, err = ensureCloudflareTunnel("mysite", "dev.example.com", true) })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -502,7 +502,7 @@ func TestEnsureCloudflareTunnel_existingTunnelMissingCredentials(t *testing.T) {
 	certWithoutTunnelCredentials(t)
 	fakeCloudflared(t, "tunnel with name already exists", 1, "routed", 0)
 
-	_, err := ensureCloudflareTunnel("mysite", "dev.example.com")
+	_, err := ensureCloudflareTunnel("mysite", "dev.example.com", true)
 	if err == nil {
 		t.Fatal("expected an error, got nil")
 	}
@@ -519,7 +519,7 @@ func TestEnsureCloudflareTunnel_freshRouteWarnsAboutPropagation(t *testing.T) {
 	fakeCloudflared(t, "created", 0, "Added CNAME dev.example.com which will route to this tunnel", 0)
 
 	out := captureStdout(t, func() {
-		if _, err := ensureCloudflareTunnel("mysite", "dev.example.com"); err != nil {
+		if _, err := ensureCloudflareTunnel("mysite", "dev.example.com", true); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
@@ -533,7 +533,7 @@ func TestEnsureCloudflareTunnel_reusedRouteStaysQuiet(t *testing.T) {
 	fakeCloudflared(t, "created", 0, "", 0)
 
 	out := captureStdout(t, func() {
-		if _, err := ensureCloudflareTunnel("mysite", "dev.example.com"); err != nil {
+		if _, err := ensureCloudflareTunnel("mysite", "dev.example.com", true); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
@@ -550,7 +550,7 @@ func TestEnsureCloudflareTunnel_createFailurePropagates(t *testing.T) {
 	t.Setenv("TUNNEL_ORIGIN_CERT", cert)
 	fakeCloudflared(t, "auth error", 1, "routed", 0)
 
-	_, err := ensureCloudflareTunnel("mysite", "dev.example.com")
+	_, err := ensureCloudflareTunnel("mysite", "dev.example.com", true)
 	if err == nil || !strings.Contains(err.Error(), "tunnel create") {
 		t.Errorf("error = %v, want tunnel create failure", err)
 	}
@@ -564,7 +564,7 @@ func TestEnsureCloudflareTunnel_routeFailurePropagates(t *testing.T) {
 	t.Setenv("TUNNEL_ORIGIN_CERT", cert)
 	fakeCloudflared(t, "created", 0, "zone not found", 1)
 
-	_, err := ensureCloudflareTunnel("mysite", "dev.example.com")
+	_, err := ensureCloudflareTunnel("mysite", "dev.example.com", true)
 	if err == nil || !strings.Contains(err.Error(), "route dns") {
 		t.Errorf("error = %v, want route dns failure", err)
 	}

--- a/internal/cli/tunnelshare.go
+++ b/internal/cli/tunnelshare.go
@@ -22,10 +22,12 @@ import (
 // shutdown handler and anything that outlived a SIGKILL is reaped at the next
 // start (see tunnel_reap.go).
 
-// TunnelInfo describes a running tunnel for the sites payload.
+// TunnelInfo describes a running tunnel for the sites payload. External marks
+// one started by "lerd share" in a terminal rather than from the dashboard.
 type TunnelInfo struct {
-	Tool string `json:"tool"`
-	URL  string `json:"url"`
+	Tool     string `json:"tool"`
+	URL      string `json:"url"`
+	External bool   `json:"external,omitempty"`
 }
 
 type tunnelProc struct {
@@ -57,6 +59,11 @@ type ShareToolsInfo struct {
 	Tools   []ShareToolStatus `json:"tools"`
 	Auto    string            `json:"auto,omitempty"`
 	Default string            `json:"default,omitempty"`
+	// BaseDomain is the Cloudflare-managed domain a share is served under, and
+	// BaseDomainAnswered says whether that answer was remembered, so the share
+	// menu knows whether it still has to ask.
+	BaseDomain         string `json:"base_domain,omitempty"`
+	BaseDomainAnswered bool   `json:"base_domain_answered,omitempty"`
 }
 
 var shareToolMeta = map[string]struct{ label, installURL string }{
@@ -70,11 +77,17 @@ var shareToolMeta = map[string]struct{ label, installURL string }{
 // ShareTools reports every supported tunnel tool, which ones are installed,
 // and what the auto pick would use right now.
 func ShareTools() ShareToolsInfo {
-	defaultTool := ""
+	defaultTool, baseDomain, answered := "", "", false
 	if cfg, err := config.LoadGlobal(); err == nil {
 		defaultTool = cfg.Share.DefaultTool
+		baseDomain, answered = cfg.Share.BaseDomain, cfg.Share.BaseDomainAnswered
 	}
-	info := ShareToolsInfo{Default: defaultTool, Auto: autoShareToolName(defaultTool)}
+	info := ShareToolsInfo{
+		Default:            defaultTool,
+		Auto:               autoShareToolName(defaultTool),
+		BaseDomain:         baseDomain,
+		BaseDomainAnswered: answered,
+	}
 	for _, t := range shareTools {
 		meta := shareToolMeta[t.name]
 		_, found := hostbin.Look(t.binary)
@@ -169,6 +182,20 @@ func parseTunnelURL(tool, line string) (string, bool) {
 	return "", false
 }
 
+// cloudflareConnected matches the line a named tunnel logs once it is carrying
+// traffic. Both spellings cloudflared has used are accepted.
+var cloudflareConnected = regexp.MustCompile(`(?i)(registered tunnel connection|connection [0-9a-f-]+ registered)`)
+
+// tunnelURLFromLine reports the public URL a line of output announces. A named
+// Cloudflare tunnel serves a hostname that is known before it starts, so there
+// the scan waits for the connection to register and reports that hostname.
+func tunnelURLFromLine(tool, known, line string) (string, bool) {
+	if known != "" {
+		return known, cloudflareConnected.MatchString(line)
+	}
+	return parseTunnelURL(tool, line)
+}
+
 // tunnelKey identifies a running tunnel. A worktree fronts its own domain, so
 // it gets a key of its own rather than replacing the parent site's tunnel. The
 // bare site name is kept as the key for the site itself.
@@ -179,15 +206,16 @@ func tunnelKey(siteName, branch string) string {
 	return siteName + "@" + branch
 }
 
-// tunnelStatusByKey returns the running tunnel registered under key.
+// tunnelStatusByKey returns the running tunnel registered under key, falling
+// back to one a "lerd share" in a terminal recorded for us.
 func tunnelStatusByKey(key string) (TunnelInfo, bool) {
 	tunnelsMu.Lock()
-	defer tunnelsMu.Unlock()
 	p := tunnels[key]
-	if p == nil || p.url == "" {
-		return TunnelInfo{}, false
+	tunnelsMu.Unlock()
+	if p != nil && p.url != "" {
+		return TunnelInfo{Tool: p.tool, URL: p.url}, true
 	}
-	return TunnelInfo{Tool: p.tool, URL: p.url}, true
+	return cliTunnelStatus(key)
 }
 
 // TunnelStatus returns the running tunnel for a site, or for one of its
@@ -196,10 +224,53 @@ func TunnelStatus(siteName, branch string) (TunnelInfo, bool) {
 	return tunnelStatusByKey(tunnelKey(siteName, branch))
 }
 
+// resolveShareBaseDomain settles which base domain a start serves under. One
+// given for this run only works with Cloudflare Tunnel, the same way --domain
+// does; the configured one simply does not apply to the other tools.
+func resolveShareBaseDomain(tool *shareTool, requested, configured string) (string, error) {
+	d, err := normalizeBaseDomain(requested)
+	if err != nil {
+		return "", err
+	}
+	if tool.mode != shareModeCloudflare {
+		if d != "" {
+			return "", fmt.Errorf("a base domain only works with Cloudflare Tunnel, pick that tool instead")
+		}
+		return "", nil
+	}
+	if d == "" {
+		d = configured
+	}
+	return d, nil
+}
+
+// SetShareBaseDomain records the answer to the base-domain question. remember
+// false forgets it, so the next share asks again.
+func SetShareBaseDomain(baseDomain string, remember bool) error {
+	domain, err := normalizeBaseDomain(baseDomain)
+	if err != nil {
+		return err
+	}
+	if !remember {
+		domain = ""
+	}
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		return err
+	}
+	if cfg.Share.BaseDomain == domain && cfg.Share.BaseDomainAnswered == remember {
+		return nil
+	}
+	cfg.Share.BaseDomain, cfg.Share.BaseDomainAnswered = domain, remember
+	return config.SaveGlobal(cfg)
+}
+
 // TunnelStart starts a public tunnel for the site, or for one of its worktrees
-// when branch is set, and blocks until the tool prints its public URL. An empty
-// toolName auto-picks like the CLI does.
-func TunnelStart(siteName, branch, toolName string) (string, error) {
+// when branch is set, and blocks until the tool reports its public URL. An empty
+// toolName auto-picks like the CLI does. baseDomain serves the site on
+// "<site>.<base domain>" through a Cloudflare named tunnel for this run;
+// empty falls back to the configured one.
+func TunnelStart(siteName, branch, toolName, baseDomain string) (string, error) {
 	site, err := config.FindSite(siteName)
 	if err != nil {
 		return "", err
@@ -224,17 +295,36 @@ func TunnelStart(siteName, branch, toolName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cmd, stopProxy, err := buildTunnelCommand(tool, "", target, httpPort, httpsPort, true)
+	base, err := resolveShareBaseDomain(tool, baseDomain, cfg.Share.BaseDomain)
 	if err != nil {
 		return "", err
 	}
-	return startTunnelProcess(tunnelKey(siteName, branch), shareToolCanonicalName(tool), cmd, stopProxy, tunnelStartTimeout)
+
+	// A named tunnel serves a hostname known before it starts, so the scan has
+	// nothing to parse out of the output and waits for the connection instead.
+	tunnelName, known := "", ""
+	if base != "" {
+		hostname, hErr := shareHostname(target.domain, cfg.DNS.TLD, base)
+		if hErr != nil {
+			return "", hErr
+		}
+		if tunnelName, err = ensureCloudflareTunnel(target.name, hostname, false); err != nil {
+			return "", err
+		}
+		known = "https://" + hostname
+	}
+
+	cmd, stopProxy, err := buildTunnelCommand(tool, tunnelName, target, httpPort, httpsPort, true)
+	if err != nil {
+		return "", err
+	}
+	return startTunnelProcess(tunnelKey(siteName, branch), shareToolCanonicalName(tool), cmd, stopProxy, tunnelStartTimeout, known)
 }
 
 // startTunnelProcess runs the tool, scans its output for the public URL, and
 // registers the tunnel under key. It replaces any tunnel already running for
 // that key. After a successful Start the exit watcher owns stopProxy.
-func startTunnelProcess(key, toolName string, cmd *exec.Cmd, stopProxy func(), timeout time.Duration) (string, error) {
+func startTunnelProcess(key, toolName string, cmd *exec.Cmd, stopProxy func(), timeout time.Duration, known string) (string, error) {
 	stopTunnelByKey(key)
 	if stopProxy == nil {
 		stopProxy = func() {}
@@ -277,7 +367,7 @@ func startTunnelProcess(key, toolName string, cmd *exec.Cmd, stopProxy func(), t
 				tail = tail[1:]
 			}
 			tailMu.Unlock()
-			if u, ok := parseTunnelURL(toolName, line); ok {
+			if u, ok := tunnelURLFromLine(toolName, known, line); ok {
 				select {
 				case urlCh <- u:
 				default:
@@ -324,22 +414,30 @@ func startTunnelProcess(key, toolName string, cmd *exec.Cmd, stopProxy func(), t
 }
 
 // TunnelStop stops the tunnel for a site, or for one of its worktrees when
-// branch is set. A no-op when none is running.
+// branch is set, wherever it was started from. A no-op when none is running.
+// Our own tunnel is the one the dashboard is showing when both exist, so that
+// is the one a stop acts on; the CLI share behind it stays up and takes over
+// the display.
 func TunnelStop(siteName, branch string) error {
-	stopTunnelByKey(tunnelKey(siteName, branch))
+	key := tunnelKey(siteName, branch)
+	if !stopTunnelByKey(key) {
+		stopCLITunnel(key)
+	}
 	return nil
 }
 
-// stopTunnelByKey kills the tunnel registered under key, if any.
-func stopTunnelByKey(key string) {
+// stopTunnelByKey kills the tunnel registered under key and reports whether
+// there was one.
+func stopTunnelByKey(key string) bool {
 	tunnelsMu.Lock()
 	p := tunnels[key]
 	delete(tunnels, key)
 	tunnelsMu.Unlock()
 	if p == nil {
-		return
+		return false
 	}
 	killTunnel(p)
+	return true
 }
 
 // StopAllTunnels kills every running tunnel.

--- a/internal/cli/tunnelshare_test.go
+++ b/internal/cli/tunnelshare_test.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -146,9 +148,10 @@ func waitTunnelGone(t *testing.T, key string) {
 }
 
 func TestStartTunnelProcess_returnsURLAndTracksTunnel(t *testing.T) {
+	tunnelStateHome(t)
 	site := "tunnel-test-a"
 	cmd := shellTunnel(`echo "Forwarding HTTP traffic from https://abc123.serveo.net"; sleep 30`)
-	url, err := startTunnelProcess(site, "serveo", cmd, nil, 5*time.Second)
+	url, err := startTunnelProcess(site, "serveo", cmd, nil, 5*time.Second, "")
 	t.Cleanup(func() { _ = TunnelStop(site, "") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -167,9 +170,10 @@ func TestStartTunnelProcess_returnsURLAndTracksTunnel(t *testing.T) {
 }
 
 func TestStartTunnelProcess_readsStderrToo(t *testing.T) {
+	tunnelStateHome(t)
 	site := "tunnel-test-stderr"
 	cmd := shellTunnel(`echo "INF |  https://plum-lakes-agree.trycloudflare.com  |" >&2; sleep 30`)
-	url, err := startTunnelProcess(site, "cloudflare", cmd, nil, 5*time.Second)
+	url, err := startTunnelProcess(site, "cloudflare", cmd, nil, 5*time.Second, "")
 	t.Cleanup(func() { _ = TunnelStop(site, "") })
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -182,9 +186,10 @@ func TestStartTunnelProcess_readsStderrToo(t *testing.T) {
 }
 
 func TestStartTunnelProcess_exitBeforeURLReportsOutput(t *testing.T) {
+	tunnelStateHome(t)
 	site := "tunnel-test-fail"
 	cmd := shellTunnel(`echo "ERR authentication failed: install your authtoken" >&2; exit 1`)
-	_, err := startTunnelProcess(site, "ngrok", cmd, nil, 5*time.Second)
+	_, err := startTunnelProcess(site, "ngrok", cmd, nil, 5*time.Second, "")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -195,9 +200,10 @@ func TestStartTunnelProcess_exitBeforeURLReportsOutput(t *testing.T) {
 }
 
 func TestStartTunnelProcess_timesOut(t *testing.T) {
+	tunnelStateHome(t)
 	site := "tunnel-test-slow"
 	cmd := shellTunnel(`sleep 30`)
-	_, err := startTunnelProcess(site, "serveo", cmd, nil, 300*time.Millisecond)
+	_, err := startTunnelProcess(site, "serveo", cmd, nil, 300*time.Millisecond, "")
 	if err == nil || !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("expected timeout error, got %v", err)
 	}
@@ -205,14 +211,15 @@ func TestStartTunnelProcess_timesOut(t *testing.T) {
 }
 
 func TestStartTunnelProcess_replacesExistingTunnel(t *testing.T) {
+	tunnelStateHome(t)
 	site := "tunnel-test-replace"
 	t.Cleanup(func() { _ = TunnelStop(site, "") })
 	first := shellTunnel(`echo "Forwarding HTTP traffic from https://first.serveo.net"; sleep 30`)
-	if _, err := startTunnelProcess(site, "serveo", first, nil, 5*time.Second); err != nil {
+	if _, err := startTunnelProcess(site, "serveo", first, nil, 5*time.Second, ""); err != nil {
 		t.Fatalf("first start: %v", err)
 	}
 	second := shellTunnel(`echo "Forwarding HTTP traffic from https://second.serveo.net"; sleep 30`)
-	url, err := startTunnelProcess(site, "serveo", second, nil, 5*time.Second)
+	url, err := startTunnelProcess(site, "serveo", second, nil, 5*time.Second, "")
 	if err != nil {
 		t.Fatalf("second start: %v", err)
 	}
@@ -226,10 +233,11 @@ func TestStartTunnelProcess_replacesExistingTunnel(t *testing.T) {
 }
 
 func TestStartTunnelProcess_stopProxyRunsWhenProcessDies(t *testing.T) {
+	tunnelStateHome(t)
 	site := "tunnel-test-proxy"
 	stopped := make(chan struct{})
 	cmd := shellTunnel(`echo "Forwarding HTTP traffic from https://p.serveo.net"; sleep 30`)
-	if _, err := startTunnelProcess(site, "serveo", cmd, func() { close(stopped) }, 5*time.Second); err != nil {
+	if _, err := startTunnelProcess(site, "serveo", cmd, func() { close(stopped) }, 5*time.Second, ""); err != nil {
 		t.Fatalf("start: %v", err)
 	}
 	if err := TunnelStop(site, ""); err != nil {
@@ -243,10 +251,11 @@ func TestStartTunnelProcess_stopProxyRunsWhenProcessDies(t *testing.T) {
 }
 
 func TestStopAllTunnels(t *testing.T) {
+	tunnelStateHome(t)
 	sites := []string{"tunnel-test-all-1", "tunnel-test-all-2"}
 	for _, s := range sites {
 		cmd := shellTunnel(`echo "Forwarding HTTP traffic from https://` + s + `.serveo.net"; sleep 30`)
-		if _, err := startTunnelProcess(s, "serveo", cmd, nil, 5*time.Second); err != nil {
+		if _, err := startTunnelProcess(s, "serveo", cmd, nil, 5*time.Second, ""); err != nil {
 			t.Fatalf("start %s: %v", s, err)
 		}
 	}
@@ -257,6 +266,7 @@ func TestStopAllTunnels(t *testing.T) {
 }
 
 func TestTunnelStop_noopWhenNotRunning(t *testing.T) {
+	tunnelStateHome(t)
 	if err := TunnelStop("tunnel-test-none", ""); err != nil {
 		t.Fatalf("expected no-op, got %v", err)
 	}
@@ -279,17 +289,18 @@ func TestTunnelKey_separatesWorktreeFromSite(t *testing.T) {
 // A worktree fronts its own domain, so its tunnel is a separate process that
 // neither replaces the parent's nor is stopped along with it.
 func TestStartTunnelProcess_worktreeTunnelIsIndependentOfTheSite(t *testing.T) {
+	tunnelStateHome(t)
 	site := "tunnel-test-wt"
 	siteKey := tunnelKey(site, "")
 	wtKey := tunnelKey(site, "feature")
 	t.Cleanup(func() { _ = TunnelStop(site, ""); _ = TunnelStop(site, "feature") })
 
 	parent := shellTunnel(`echo "Forwarding HTTP traffic from https://parent.serveo.net"; sleep 30`)
-	if _, err := startTunnelProcess(siteKey, "serveo", parent, nil, 5*time.Second); err != nil {
+	if _, err := startTunnelProcess(siteKey, "serveo", parent, nil, 5*time.Second, ""); err != nil {
 		t.Fatalf("parent start: %v", err)
 	}
 	wt := shellTunnel(`echo "Forwarding HTTP traffic from https://branch.serveo.net"; sleep 30`)
-	if _, err := startTunnelProcess(wtKey, "serveo", wt, nil, 5*time.Second); err != nil {
+	if _, err := startTunnelProcess(wtKey, "serveo", wt, nil, 5*time.Second, ""); err != nil {
 		t.Fatalf("worktree start: %v", err)
 	}
 
@@ -308,5 +319,157 @@ func TestStartTunnelProcess_worktreeTunnelIsIndependentOfTheSite(t *testing.T) {
 	waitTunnelGone(t, wtKey)
 	if _, ok := TunnelStatus(site, ""); !ok {
 		t.Error("stopping the worktree tunnel also stopped the site's")
+	}
+}
+
+// ── named Cloudflare tunnels ─────────────────────────────────────────────────
+
+func TestTunnelURLFromLine_parsesTheOutputWhenNothingIsKnown(t *testing.T) {
+	got, ok := tunnelURLFromLine("serveo", "", "Forwarding from https://abc.serveo.net")
+	if !ok || got != "https://abc.serveo.net" {
+		t.Errorf("got (%q, %v), want the serveo URL", got, ok)
+	}
+}
+
+// A named tunnel prints no URL at all, so the scan waits for the line that says
+// it is carrying traffic and reports the hostname it already knew.
+func TestTunnelURLFromLine_knownURLWaitsForTheConnection(t *testing.T) {
+	known := "https://acme.example.com"
+	if _, ok := tunnelURLFromLine("cloudflare", known, "INF Starting tunnel tunnelID=abc"); ok {
+		t.Error("the hostname was reported before the tunnel connected")
+	}
+	got, ok := tunnelURLFromLine("cloudflare", known, "INF Registered tunnel connection connIndex=0 protocol=quic")
+	if !ok || got != known {
+		t.Errorf("got (%q, %v), want %q once the connection registered", got, ok, known)
+	}
+}
+
+func TestTunnelURLFromLine_knownURLAcceptsTheOlderWording(t *testing.T) {
+	known := "https://acme.example.com"
+	line := "INF Connection 0e8b1c4a-1111-2222-3333-444455556666 registered"
+	if got, ok := tunnelURLFromLine("cloudflare", known, line); !ok || got != known {
+		t.Errorf("got (%q, %v), want %q", got, ok, known)
+	}
+}
+
+func TestStartTunnelProcess_namedTunnelReportsItsOwnHostname(t *testing.T) {
+	tunnelStateHome(t)
+	site := "tunnel-test-named"
+	known := "https://acme.example.com"
+	cmd := shellTunnel(`echo "INF Registered tunnel connection connIndex=0"; sleep 30`)
+	url, err := startTunnelProcess(site, "cloudflare", cmd, nil, 5*time.Second, known)
+	t.Cleanup(func() { _ = TunnelStop(site, "") })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if url != known {
+		t.Errorf("url = %q, want %q", url, known)
+	}
+	if err := TunnelStop(site, ""); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	waitTunnelGone(t, site)
+}
+
+// A share started in a terminal is invisible to the daemon's own registry, so
+// the status has to fall through to what the CLI recorded on disk.
+func TestTunnelStatus_reportsAShareStartedFromTheCLI(t *testing.T) {
+	tunnelStateHome(t)
+	st := tunnelState{Site: "acme", Tool: "ngrok", URL: "https://abc.ngrok.io", PID: os.Getpid()}
+	if err := writeTunnelState(tunnelKey("acme", ""), st); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+
+	info, ok := TunnelStatus("acme", "")
+	if !ok || info.URL != st.URL || !info.External {
+		t.Errorf("TunnelStatus = %+v, %v; want the CLI tunnel marked external", info, ok)
+	}
+}
+
+// The daemon's own tunnel is the live one; a leftover CLI entry for the same
+// site must not shadow it.
+func TestTunnelStatus_prefersTheDaemonsOwnTunnel(t *testing.T) {
+	tunnelStateHome(t)
+	site := "tunnel-test-both"
+	if err := writeTunnelState(tunnelKey(site, ""), tunnelState{
+		Site: site, Tool: "ngrok", URL: "https://stale.ngrok.io", PID: os.Getpid(),
+	}); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+	cmd := shellTunnel(`echo "Forwarding HTTP traffic from https://live.serveo.net"; sleep 30`)
+	if _, err := startTunnelProcess(site, "serveo", cmd, nil, 5*time.Second, ""); err != nil {
+		t.Fatalf("starting: %v", err)
+	}
+	t.Cleanup(func() { _ = TunnelStop(site, "") })
+
+	info, ok := TunnelStatus(site, "")
+	if !ok || info.URL != "https://live.serveo.net" || info.External {
+		t.Errorf("TunnelStatus = %+v, %v; want the daemon's own tunnel", info, ok)
+	}
+}
+
+// startSleeper runs a real process to stand in for a "lerd share" in a
+// terminal, so a stop has something it can actually signal.
+func startSleeper(t *testing.T) *exec.Cmd {
+	t.Helper()
+	c := exec.Command("/bin/sh", "-c", "sleep 30")
+	if err := c.Start(); err != nil {
+		t.Fatalf("starting the stand-in share: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = c.Process.Kill()
+		_ = c.Wait()
+	})
+	return c
+}
+
+// A stop acts on the tunnel the dashboard is showing. With both kinds up that
+// is the daemon's own, and the CLI share behind it takes over the display.
+func TestTunnelStop_leavesTheCLIShareWhenWeOwnTheLiveTunnel(t *testing.T) {
+	tunnelStateHome(t)
+	site := "tunnel-test-stop-both"
+	sleeper := startSleeper(t)
+	if err := writeTunnelState(tunnelKey(site, ""), tunnelState{
+		Site: site, Tool: "ngrok", URL: "https://cli.ngrok.io", PID: sleeper.Process.Pid,
+	}); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+	cmd := shellTunnel(`echo "Forwarding HTTP traffic from https://live.serveo.net"; sleep 30`)
+	if _, err := startTunnelProcess(site, "serveo", cmd, nil, 5*time.Second, ""); err != nil {
+		t.Fatalf("starting: %v", err)
+	}
+	t.Cleanup(func() { _ = TunnelStop(site, "") })
+
+	if err := TunnelStop(site, ""); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	info, ok := TunnelStatus(site, "")
+	if !ok || info.URL != "https://cli.ngrok.io" || !info.External {
+		t.Errorf("after the stop TunnelStatus = %+v, %v; want the CLI share still up", info, ok)
+	}
+	if err := sleeper.Process.Signal(syscall.Signal(0)); err != nil {
+		t.Error("the CLI share was signalled even though we owned the live tunnel")
+	}
+}
+
+func TestTunnelStop_signalsACLIShareWhenItIsTheOnlyOne(t *testing.T) {
+	tunnelStateHome(t)
+	site := "tunnel-test-stop-cli"
+	sleeper := startSleeper(t)
+	if err := writeTunnelState(tunnelKey(site, ""), tunnelState{
+		Site: site, Tool: "ngrok", URL: "https://cli.ngrok.io", PID: sleeper.Process.Pid,
+	}); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+
+	if err := TunnelStop(site, ""); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- sleeper.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the CLI share was never signalled")
 	}
 }

--- a/internal/cli/tunnelstate.go
+++ b/internal/cli/tunnelstate.go
@@ -1,0 +1,213 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// A tunnel started by "lerd share" runs in the user's own terminal, where the
+// dashboard's in-process registry cannot see it. Each CLI share drops a small
+// file under the run dir for as long as it is up, and the dashboard folds those
+// in so a share looks the same wherever it was started from.
+
+// tunnelState is one CLI-owned tunnel, as recorded on disk.
+type tunnelState struct {
+	Site   string `json:"site"`
+	Branch string `json:"branch,omitempty"`
+	Tool   string `json:"tool"`
+	URL    string `json:"url"`
+	PID    int    `json:"pid"`
+}
+
+func tunnelStateDir() string {
+	return filepath.Join(config.RunDir(), "tunnels")
+}
+
+// tunnelStateFile maps a tunnel key to its file. The key is only storage here,
+// so anything a path cannot carry becomes an underscore; the entry itself names
+// the site and branch it belongs to.
+func tunnelStateFile(key string) string {
+	safe := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '-', r == '.', r == '@':
+			return r
+		}
+		return '_'
+	}, key)
+	return filepath.Join(tunnelStateDir(), safe+".json")
+}
+
+func writeTunnelState(key string, st tunnelState) error {
+	defer invalidateTunnelStates()
+	if err := os.MkdirAll(tunnelStateDir(), 0755); err != nil {
+		return err
+	}
+	b, err := json.Marshal(st)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(tunnelStateFile(key), b, 0644)
+}
+
+func removeTunnelState(key string) {
+	defer invalidateTunnelStates()
+	_ = os.Remove(tunnelStateFile(key))
+}
+
+// pidAlive reports whether a process is still around. Signal 0 only checks, and
+// the CLI share runs as the same user as the daemon reading this.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}
+
+// A status build asks about every site in turn and the answer is one directory
+// either way, so the scan is held briefly. Writes from this process drop it,
+// and the directory is part of the key so a change of data dir is a miss.
+var (
+	statesMu   sync.Mutex
+	statesDir  string
+	statesAt   time.Time
+	statesSeen map[string]tunnelState
+)
+
+const tunnelStateTTL = 750 * time.Millisecond
+
+// readTunnelStates returns every live CLI tunnel keyed the same way the
+// in-process registry is.
+func readTunnelStates() map[string]tunnelState {
+	statesMu.Lock()
+	defer statesMu.Unlock()
+	dir := tunnelStateDir()
+	if statesSeen != nil && statesDir == dir && time.Since(statesAt) < tunnelStateTTL {
+		return statesSeen
+	}
+	statesSeen, statesDir, statesAt = scanTunnelStates(), dir, time.Now()
+	return statesSeen
+}
+
+func invalidateTunnelStates() {
+	statesMu.Lock()
+	statesSeen = nil
+	statesMu.Unlock()
+}
+
+// scanTunnelStates reads the run dir, deleting the entries whose process is
+// gone. A share killed outright never gets to clean up after itself, so this is
+// where those files go.
+func scanTunnelStates() map[string]tunnelState {
+	live := map[string]tunnelState{}
+	entries, err := os.ReadDir(tunnelStateDir())
+	if err != nil {
+		return live
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(tunnelStateDir(), e.Name())
+		b, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var st tunnelState
+		if err := json.Unmarshal(b, &st); err != nil || st.Site == "" || st.URL == "" {
+			_ = os.Remove(path)
+			continue
+		}
+		if !pidAlive(st.PID) {
+			_ = os.Remove(path)
+			continue
+		}
+		live[tunnelKey(st.Site, st.Branch)] = st
+	}
+	return live
+}
+
+// cliTunnelStatus reports the CLI-started tunnel registered under key.
+func cliTunnelStatus(key string) (TunnelInfo, bool) {
+	st, ok := readTunnelStates()[key]
+	if !ok {
+		return TunnelInfo{}, false
+	}
+	return TunnelInfo{Tool: st.Tool, URL: st.URL, External: true}, true
+}
+
+// stopCLITunnel terminates the "lerd share" process behind a CLI tunnel. The
+// entry goes now rather than when that share gets around to clearing it, so the
+// dashboard never keeps showing a tunnel it just stopped.
+func stopCLITunnel(key string) bool {
+	st, ok := readTunnelStates()[key]
+	if !ok {
+		return false
+	}
+	_ = syscall.Kill(st.PID, syscall.SIGTERM)
+	removeTunnelState(key)
+	return true
+}
+
+// tunnelStateWriter records a CLI share for the dashboard while it runs. It
+// doubles as the writer the tool's output is teed through, so a tunnel whose
+// URL is only announced in that output gets recorded the moment it appears.
+type tunnelStateWriter struct {
+	key   string
+	mu    sync.Mutex
+	state tunnelState
+	buf   []byte
+	found bool
+}
+
+// newTunnelStateWriter starts recording st. A tunnel whose URL is already known,
+// as a named Cloudflare tunnel's is, is published straight away.
+func newTunnelStateWriter(key string, st tunnelState) *tunnelStateWriter {
+	w := &tunnelStateWriter{key: key, state: st}
+	if st.URL != "" {
+		w.found = true
+		_ = writeTunnelState(key, st)
+	}
+	return w
+}
+
+func (w *tunnelStateWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.found {
+		return len(p), nil
+	}
+	w.buf = append(w.buf, p...)
+	for {
+		i := strings.IndexByte(string(w.buf), '\n')
+		if i < 0 {
+			break
+		}
+		line := string(w.buf[:i])
+		w.buf = w.buf[i+1:]
+		if u, ok := parseTunnelURL(w.state.Tool, line); ok {
+			w.state.URL = u
+			w.found = true
+			_ = writeTunnelState(w.key, w.state)
+			w.buf = nil
+			break
+		}
+	}
+	// A tool that never prints a newline must not grow the buffer forever.
+	if len(w.buf) > 64*1024 {
+		w.buf = w.buf[len(w.buf)-4096:]
+	}
+	return len(p), nil
+}
+
+func (w *tunnelStateWriter) clear() {
+	removeTunnelState(w.key)
+}

--- a/internal/cli/tunnelstate_test.go
+++ b/internal/cli/tunnelstate_test.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+// Every test here writes under the run dir, so point the data dir at a temp one.
+func tunnelStateHome(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+}
+
+func TestTunnelState_roundTrip(t *testing.T) {
+	tunnelStateHome(t)
+
+	st := tunnelState{Site: "acme", Tool: "cloudflare", URL: "https://x.trycloudflare.com", PID: os.Getpid()}
+	if err := writeTunnelState("acme", st); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+
+	info, ok := cliTunnelStatus("acme")
+	if !ok {
+		t.Fatal("a live CLI tunnel was not reported")
+	}
+	if info.URL != st.URL || info.Tool != st.Tool {
+		t.Errorf("info = %+v, want the recorded tool and URL", info)
+	}
+	if !info.External {
+		t.Error("a CLI tunnel must be marked external so the UI can say where it came from")
+	}
+
+	removeTunnelState("acme")
+	if _, ok := cliTunnelStatus("acme"); ok {
+		t.Error("the entry is still reported after being removed")
+	}
+}
+
+// A share killed outright never gets to clean up, so the reader is what clears
+// the entry rather than leaving a dead tunnel on the dashboard forever.
+func TestReadTunnelStates_dropsEntriesWhoseProcessIsGone(t *testing.T) {
+	tunnelStateHome(t)
+
+	dead := tunnelState{Site: "acme", Tool: "serveo", URL: "https://x.serveo.net", PID: 2 << 30}
+	if err := writeTunnelState("acme", dead); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+
+	if _, ok := cliTunnelStatus("acme"); ok {
+		t.Error("an entry whose process is gone must not be reported")
+	}
+	if _, err := os.Stat(tunnelStateFile("acme")); !os.IsNotExist(err) {
+		t.Error("the stale file should have been removed")
+	}
+}
+
+func TestReadTunnelStates_keysAWorktreeSeparately(t *testing.T) {
+	tunnelStateHome(t)
+
+	site := tunnelState{Site: "acme", Tool: "serveo", URL: "https://site.serveo.net", PID: os.Getpid()}
+	branch := tunnelState{Site: "acme", Branch: "feat", Tool: "serveo", URL: "https://branch.serveo.net", PID: os.Getpid()}
+	if err := writeTunnelState(tunnelKey("acme", ""), site); err != nil {
+		t.Fatalf("writing site: %v", err)
+	}
+	if err := writeTunnelState(tunnelKey("acme", "feat"), branch); err != nil {
+		t.Fatalf("writing branch: %v", err)
+	}
+
+	got, ok := cliTunnelStatus(tunnelKey("acme", "feat"))
+	if !ok || got.URL != branch.URL {
+		t.Errorf("branch tunnel = %+v, want %q", got, branch.URL)
+	}
+	got, ok = cliTunnelStatus(tunnelKey("acme", ""))
+	if !ok || got.URL != site.URL {
+		t.Errorf("site tunnel = %+v, want %q", got, site.URL)
+	}
+}
+
+// A branch name a path cannot carry still has to land in a file of its own.
+func TestTunnelStateFile_survivesASlashInTheBranch(t *testing.T) {
+	tunnelStateHome(t)
+
+	st := tunnelState{Site: "acme", Branch: "feat/login", Tool: "serveo", URL: "https://x.serveo.net", PID: os.Getpid()}
+	if err := writeTunnelState(tunnelKey("acme", "feat/login"), st); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+	if _, ok := cliTunnelStatus(tunnelKey("acme", "feat/login")); !ok {
+		t.Error("a branch with a slash in it was not readable back")
+	}
+}
+
+func TestTunnelStateWriter_publishesTheURLItSeesInTheOutput(t *testing.T) {
+	tunnelStateHome(t)
+
+	w := newTunnelStateWriter("acme", tunnelState{Site: "acme", Tool: "serveo", PID: os.Getpid()})
+	if _, ok := cliTunnelStatus("acme"); ok {
+		t.Fatal("nothing should be published before a URL is known")
+	}
+
+	if _, err := w.Write([]byte("Forwarding HTTP traffic from https://abc.serveo.net\n")); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+	info, ok := cliTunnelStatus("acme")
+	if !ok || info.URL != "https://abc.serveo.net" {
+		t.Errorf("published %+v, want the URL from the output", info)
+	}
+
+	w.clear()
+	if _, ok := cliTunnelStatus("acme"); ok {
+		t.Error("the entry outlived the share")
+	}
+}
+
+// The URL rarely arrives in one write, so the scan has to work across chunks.
+func TestTunnelStateWriter_joinsSplitWrites(t *testing.T) {
+	tunnelStateHome(t)
+
+	w := newTunnelStateWriter("acme", tunnelState{Site: "acme", Tool: "serveo", PID: os.Getpid()})
+	for _, chunk := range []string{"Forwarding from ", "https://abc.serveo", ".net\n"} {
+		if _, err := w.Write([]byte(chunk)); err != nil {
+			t.Fatalf("writing %q: %v", chunk, err)
+		}
+	}
+	info, ok := cliTunnelStatus("acme")
+	if !ok || info.URL != "https://abc.serveo.net" {
+		t.Errorf("published %+v, want the URL assembled from both writes", info)
+	}
+}
+
+// A named Cloudflare tunnel knows its hostname up front, so the dashboard sees
+// it without anything having to be parsed out of cloudflared's logs.
+func TestTunnelStateWriter_publishesAKnownURLImmediately(t *testing.T) {
+	tunnelStateHome(t)
+
+	newTunnelStateWriter("acme", tunnelState{
+		Site: "acme", Tool: "cloudflare", URL: "https://acme.example.com", PID: os.Getpid(),
+	})
+	info, ok := cliTunnelStatus("acme")
+	if !ok || info.URL != "https://acme.example.com" {
+		t.Errorf("published %+v, want the hostname it already knew", info)
+	}
+}
+
+func TestStopCLITunnel_reportsWhetherThereWasOne(t *testing.T) {
+	tunnelStateHome(t)
+
+	if stopCLITunnel("acme") {
+		t.Error("stopping a tunnel that is not running should report nothing was there")
+	}
+}
+
+// A branch share must not be reported against the parent site, or the
+// dashboard would show the site itself as shared.
+func TestCliTunnelStatus_branchShareIsNotTheSiteShare(t *testing.T) {
+	tunnelStateHome(t)
+
+	st := tunnelState{
+		Site: "acme", Branch: "feat", Tool: "cloudflare",
+		URL: "https://feat-acme.example.com", PID: os.Getpid(),
+	}
+	if err := writeTunnelState(tunnelKey("acme", "feat"), st); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+
+	if _, ok := cliTunnelStatus(tunnelKey("acme", "")); ok {
+		t.Error("a branch share was reported against the site itself")
+	}
+	if got, ok := cliTunnelStatus(tunnelKey("acme", "feat")); !ok || got.URL != st.URL {
+		t.Errorf("branch share = %+v, %v; want %q", got, ok, st.URL)
+	}
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -120,6 +120,14 @@ type GlobalConfig struct {
 		// given: ngrok | cloudflare | expose | serveo | localhost-run.
 		// Empty = auto-detect. Set via "lerd share:tool".
 		DefaultTool string `yaml:"default_tool,omitempty" mapstructure:"default_tool"`
+		// BaseDomain is a Cloudflare-managed domain a share is served under:
+		// lerd routes "<site>.<base domain>" to a named tunnel instead of
+		// handing out a random trycloudflare.com URL.
+		BaseDomain string `yaml:"base_domain,omitempty" mapstructure:"base_domain"`
+		// BaseDomainAnswered records that the base-domain question has an
+		// answer worth reusing, so the dashboard stops asking. Answered with
+		// an empty BaseDomain means "always use a quick tunnel".
+		BaseDomainAnswered bool `yaml:"base_domain_answered,omitempty" mapstructure:"base_domain_answered"`
 	} `yaml:"share,omitempty" mapstructure:"share"`
 	Nginx struct {
 		HTTPPort  int `yaml:"http_port"  mapstructure:"http_port"`

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -769,6 +769,7 @@ type WorktreeResponse struct {
 	LANShareURL         string         `json:"lan_share_url,omitempty"`
 	TunnelURL           string         `json:"tunnel_url,omitempty"`
 	TunnelTool          string         `json:"tunnel_tool,omitempty"`
+	TunnelExternal      bool           `json:"tunnel_external,omitempty"`
 	FrameworkWorkers    []WorkerStatus `json:"framework_workers,omitempty"`
 	// Idle-suspend state for the worktree, which idles on its own timer.
 	LastActive           int64    `json:"last_active,omitempty"`
@@ -877,6 +878,7 @@ type SiteResponse struct {
 	LANShareURL      string `json:"lan_share_url,omitempty"`
 	TunnelURL        string `json:"tunnel_url,omitempty"`
 	TunnelTool       string `json:"tunnel_tool,omitempty"`
+	TunnelExternal   bool   `json:"tunnel_external,omitempty"`
 	CustomContainer  bool   `json:"custom_container,omitempty"`
 	ContainerPort    int    `json:"container_port,omitempty"`
 	ContainerImage   string `json:"container_image,omitempty"`
@@ -1043,6 +1045,7 @@ func buildSites() []SiteResponse {
 				LANShareURL:          lanURL,
 				TunnelURL:            wtTunnel.URL,
 				TunnelTool:           wtTunnel.Tool,
+				TunnelExternal:       wtTunnel.External,
 				FrameworkWorkers:     wtWorkers,
 				LastActive:           idleActivity[wtKeyStr],
 				Idle:                 idleSiteIsIdle(idleActivity, wtKeyStr, e.Paused, idleExempt, idleOn, idleTimeout, idleNow),
@@ -1112,6 +1115,7 @@ func buildSites() []SiteResponse {
 			LANShareURL:          cli.LANShareURL(e.LANPort),
 			TunnelURL:            tunnel.URL,
 			TunnelTool:           tunnel.Tool,
+			TunnelExternal:       tunnel.External,
 			CustomContainer:      e.ContainerPort > 0,
 			ContainerPort:        e.ContainerPort,
 			ContainerImage:       e.ContainerImage,
@@ -3246,7 +3250,24 @@ func handleLANQR(w http.ResponseWriter, r *http.Request) {
 
 // handleShareTools reports the supported tunnel tools, which are installed,
 // and what the auto pick would use, so the share menu can render its entries.
+// A POST records the answer to the base-domain question.
 func handleShareTools(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost {
+		var body struct {
+			BaseDomain string `json:"base_domain"`
+			Remember   bool   `json:"remember"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeJSON(w, SiteActionResponse{Error: "invalid request body"})
+			return
+		}
+		if err := cli.SetShareBaseDomain(body.BaseDomain, body.Remember); err != nil {
+			writeJSON(w, SiteActionResponse{Error: err.Error()})
+			return
+		}
+		writeJSON(w, SiteActionResponse{OK: true})
+		return
+	}
 	writeJSON(w, cli.ShareTools())
 }
 
@@ -4011,7 +4032,7 @@ func handleSiteAction(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, SiteActionResponse{OK: true})
 		return
 	case "tunnel:start":
-		if _, err := cli.TunnelStart(site.Name, r.URL.Query().Get("branch"), r.URL.Query().Get("tool")); err != nil {
+		if _, err := cli.TunnelStart(site.Name, r.URL.Query().Get("branch"), r.URL.Query().Get("tool"), r.URL.Query().Get("domain")); err != nil {
 			writeJSON(w, SiteActionResponse{Error: err.Error()})
 			return
 		}

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -1227,5 +1227,18 @@
   "share_stop": "Stopp",
   "share_stopTunnel": "Tunnel stoppen",
   "share_tunnelVia": "Tunnel über {tool}",
-  "share_startFailed": "{tool} konnte nicht starten"
+  "share_startFailed": "{tool} konnte nicht starten",
+  "shareDomain_title": "Diese Website unter deiner eigenen Domain ausliefern?",
+  "shareDomain_body": "Cloudflare Tunnel kann die Website unter einer Domain ausliefern, die dir gehört, sodass die öffentliche Adresse jedes Mal gleich bleibt. Leer lassen für eine kurzlebige trycloudflare.com-URL.",
+  "shareDomain_label": "Basis-Domain",
+  "shareDomain_preview": "Ausgeliefert unter",
+  "shareDomain_previewEmpty": "Ihr DNS muss von Cloudflare verwaltet werden.",
+  "shareDomain_remember": "Diese Antwort merken",
+  "shareDomain_rememberHint": "Beim nächsten Mal ohne Nachfrage direkt teilen.",
+  "shareDomain_skip": "Überspringen",
+  "shareDomain_use": "Diese Domain verwenden",
+  "shareDomain_configure": "Domain konfigurieren",
+  "share_tunnelViaCli": "Tunnel über {tool}, aus der CLI",
+  "sites_sharedPublicly": "Öffentlich geteilt unter {url}",
+  "sites_sharedOnLan": "Im Netzwerk geteilt unter {url}"
 }

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -1227,5 +1227,18 @@
   "share_stop": "Stop",
   "share_stopTunnel": "Stop tunnel",
   "share_tunnelVia": "Tunnel via {tool}",
-  "share_startFailed": "{tool} failed to start"
+  "share_startFailed": "{tool} failed to start",
+  "shareDomain_title": "Serve this site on your own domain?",
+  "shareDomain_body": "Cloudflare Tunnel can serve the site on a domain you own, so the public address stays the same every time. Leave it empty for a throwaway trycloudflare.com URL.",
+  "shareDomain_label": "Base domain",
+  "shareDomain_preview": "Served on",
+  "shareDomain_previewEmpty": "Its DNS has to be managed by Cloudflare.",
+  "shareDomain_remember": "Remember this answer",
+  "shareDomain_rememberHint": "Share straight away next time, without asking.",
+  "shareDomain_skip": "Skip",
+  "shareDomain_use": "Use this domain",
+  "shareDomain_configure": "Configure the domain",
+  "share_tunnelViaCli": "Tunnel via {tool}, from the CLI",
+  "sites_sharedPublicly": "Shared publicly on {url}",
+  "sites_sharedOnLan": "Shared on your network at {url}"
 }

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -1227,5 +1227,18 @@
   "share_stop": "Detener",
   "share_stopTunnel": "Detener túnel",
   "share_tunnelVia": "Túnel vía {tool}",
-  "share_startFailed": "{tool} no pudo iniciarse"
+  "share_startFailed": "{tool} no pudo iniciarse",
+  "shareDomain_title": "¿Servir este sitio en tu propio dominio?",
+  "shareDomain_body": "Cloudflare Tunnel puede servir el sitio en un dominio tuyo, de modo que la dirección pública sea siempre la misma. Déjalo vacío para una URL desechable de trycloudflare.com.",
+  "shareDomain_label": "Dominio base",
+  "shareDomain_preview": "Servido en",
+  "shareDomain_previewEmpty": "Su DNS tiene que estar gestionado por Cloudflare.",
+  "shareDomain_remember": "Recordar esta respuesta",
+  "shareDomain_rememberHint": "La próxima vez comparte directamente, sin preguntar.",
+  "shareDomain_skip": "Omitir",
+  "shareDomain_use": "Usar este dominio",
+  "shareDomain_configure": "Configurar el dominio",
+  "share_tunnelViaCli": "Túnel vía {tool}, desde la CLI",
+  "sites_sharedPublicly": "Compartido públicamente en {url}",
+  "sites_sharedOnLan": "Compartido en tu red en {url}"
 }

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -1227,5 +1227,18 @@
   "share_stop": "Arrêter",
   "share_stopTunnel": "Arrêter le tunnel",
   "share_tunnelVia": "Tunnel via {tool}",
-  "share_startFailed": "{tool} n'a pas pu démarrer"
+  "share_startFailed": "{tool} n'a pas pu démarrer",
+  "shareDomain_title": "Servir ce site sur votre propre domaine ?",
+  "shareDomain_body": "Cloudflare Tunnel peut servir le site sur un domaine qui vous appartient, pour que l'adresse publique reste la même à chaque fois. Laissez vide pour une URL trycloudflare.com jetable.",
+  "shareDomain_label": "Domaine de base",
+  "shareDomain_preview": "Servi sur",
+  "shareDomain_previewEmpty": "Son DNS doit être géré par Cloudflare.",
+  "shareDomain_remember": "Retenir cette réponse",
+  "shareDomain_rememberHint": "Partager directement la prochaine fois, sans demander.",
+  "shareDomain_skip": "Ignorer",
+  "shareDomain_use": "Utiliser ce domaine",
+  "shareDomain_configure": "Configurer le domaine",
+  "share_tunnelViaCli": "Tunnel via {tool}, depuis la CLI",
+  "sites_sharedPublicly": "Partagé publiquement sur {url}",
+  "sites_sharedOnLan": "Partagé sur votre réseau à {url}"
 }

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -1227,5 +1227,18 @@
   "share_stop": "Hentikan",
   "share_stopTunnel": "Hentikan tunnel",
   "share_tunnelVia": "Tunnel via {tool}",
-  "share_startFailed": "{tool} gagal dimulai"
+  "share_startFailed": "{tool} gagal dimulai",
+  "shareDomain_title": "Sajikan situs ini di domain Anda sendiri?",
+  "shareDomain_body": "Cloudflare Tunnel bisa menyajikan situs di domain milik Anda, sehingga alamat publiknya selalu sama. Biarkan kosong untuk URL trycloudflare.com sekali pakai.",
+  "shareDomain_label": "Domain dasar",
+  "shareDomain_preview": "Disajikan di",
+  "shareDomain_previewEmpty": "DNS-nya harus dikelola oleh Cloudflare.",
+  "shareDomain_remember": "Ingat jawaban ini",
+  "shareDomain_rememberHint": "Lain kali langsung bagikan, tanpa bertanya.",
+  "shareDomain_skip": "Lewati",
+  "shareDomain_use": "Gunakan domain ini",
+  "shareDomain_configure": "Konfigurasikan domain",
+  "share_tunnelViaCli": "Tunnel via {tool}, dari CLI",
+  "sites_sharedPublicly": "Dibagikan publik di {url}",
+  "sites_sharedOnLan": "Dibagikan di jaringan Anda di {url}"
 }

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -1227,5 +1227,18 @@
   "share_stop": "Ferma",
   "share_stopTunnel": "Ferma il tunnel",
   "share_tunnelVia": "Tunnel via {tool}",
-  "share_startFailed": "{tool} non è riuscito ad avviarsi"
+  "share_startFailed": "{tool} non è riuscito ad avviarsi",
+  "shareDomain_title": "Servire questo sito sul tuo dominio?",
+  "shareDomain_body": "Cloudflare Tunnel può servire il sito su un dominio tuo, così l'indirizzo pubblico resta sempre lo stesso. Lascia vuoto per un URL trycloudflare.com usa e getta.",
+  "shareDomain_label": "Dominio di base",
+  "shareDomain_preview": "Servito su",
+  "shareDomain_previewEmpty": "Il suo DNS deve essere gestito da Cloudflare.",
+  "shareDomain_remember": "Ricorda questa risposta",
+  "shareDomain_rememberHint": "La prossima volta condividi subito, senza chiedere.",
+  "shareDomain_skip": "Salta",
+  "shareDomain_use": "Usa questo dominio",
+  "shareDomain_configure": "Configura il dominio",
+  "share_tunnelViaCli": "Tunnel via {tool}, dalla CLI",
+  "sites_sharedPublicly": "Condiviso pubblicamente su {url}",
+  "sites_sharedOnLan": "Condiviso sulla tua rete su {url}"
 }

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -1227,5 +1227,18 @@
   "share_stop": "停止",
   "share_stopTunnel": "トンネルを停止",
   "share_tunnelVia": "{tool} のトンネル",
-  "share_startFailed": "{tool} を起動できませんでした"
+  "share_startFailed": "{tool} を起動できませんでした",
+  "shareDomain_title": "このサイトを自分のドメインで公開しますか？",
+  "shareDomain_body": "Cloudflare Tunnel は所有しているドメインでサイトを配信できるため、公開アドレスが毎回同じになります。空のままにすると使い捨ての trycloudflare.com URL になります。",
+  "shareDomain_label": "ベースドメイン",
+  "shareDomain_preview": "配信先",
+  "shareDomain_previewEmpty": "DNS が Cloudflare で管理されている必要があります。",
+  "shareDomain_remember": "この回答を記憶する",
+  "shareDomain_rememberHint": "次回からは確認せずにそのまま共有します。",
+  "shareDomain_skip": "スキップ",
+  "shareDomain_use": "このドメインを使う",
+  "shareDomain_configure": "ドメインを設定",
+  "share_tunnelViaCli": "{tool} 経由のトンネル、CLI から",
+  "sites_sharedPublicly": "{url} で公開共有中",
+  "sites_sharedOnLan": "ネットワーク上の {url} で共有中"
 }

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -1227,5 +1227,18 @@
   "share_stop": "Stoppen",
   "share_stopTunnel": "Tunnel stoppen",
   "share_tunnelVia": "Tunnel via {tool}",
-  "share_startFailed": "{tool} kon niet starten"
+  "share_startFailed": "{tool} kon niet starten",
+  "shareDomain_title": "Deze site op je eigen domein serveren?",
+  "shareDomain_body": "Cloudflare Tunnel kan de site serveren op een domein van jezelf, zodat het publieke adres elke keer hetzelfde blijft. Laat leeg voor een wegwerp-URL van trycloudflare.com.",
+  "shareDomain_label": "Basisdomein",
+  "shareDomain_preview": "Geserveerd op",
+  "shareDomain_previewEmpty": "De DNS moet door Cloudflare beheerd worden.",
+  "shareDomain_remember": "Dit antwoord onthouden",
+  "shareDomain_rememberHint": "Volgende keer meteen delen, zonder te vragen.",
+  "shareDomain_skip": "Overslaan",
+  "shareDomain_use": "Dit domein gebruiken",
+  "shareDomain_configure": "Domein instellen",
+  "share_tunnelViaCli": "Tunnel via {tool}, vanaf de CLI",
+  "sites_sharedPublicly": "Publiek gedeeld op {url}",
+  "sites_sharedOnLan": "Gedeeld op je netwerk op {url}"
 }

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -1227,5 +1227,18 @@
   "share_stop": "Zatrzymaj",
   "share_stopTunnel": "Zatrzymaj tunel",
   "share_tunnelVia": "Tunel przez {tool}",
-  "share_startFailed": "Nie udało się uruchomić {tool}"
+  "share_startFailed": "Nie udało się uruchomić {tool}",
+  "shareDomain_title": "Serwować tę stronę na twojej własnej domenie?",
+  "shareDomain_body": "Cloudflare Tunnel może serwować stronę na domenie, którą posiadasz, więc publiczny adres pozostaje za każdym razem taki sam. Zostaw puste, aby dostać jednorazowy adres trycloudflare.com.",
+  "shareDomain_label": "Domena bazowa",
+  "shareDomain_preview": "Serwowane na",
+  "shareDomain_previewEmpty": "Jej DNS musi być zarządzany przez Cloudflare.",
+  "shareDomain_remember": "Zapamiętaj tę odpowiedź",
+  "shareDomain_rememberHint": "Następnym razem udostępnij od razu, bez pytania.",
+  "shareDomain_skip": "Pomiń",
+  "shareDomain_use": "Użyj tej domeny",
+  "shareDomain_configure": "Skonfiguruj domenę",
+  "share_tunnelViaCli": "Tunel przez {tool}, z CLI",
+  "sites_sharedPublicly": "Udostępnione publicznie pod {url}",
+  "sites_sharedOnLan": "Udostępnione w twojej sieci pod {url}"
 }

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -1227,5 +1227,18 @@
   "share_stop": "Parar",
   "share_stopTunnel": "Parar túnel",
   "share_tunnelVia": "Túnel via {tool}",
-  "share_startFailed": "{tool} não conseguiu iniciar"
+  "share_startFailed": "{tool} não conseguiu iniciar",
+  "shareDomain_title": "Servir este site no teu próprio domínio?",
+  "shareDomain_body": "O Cloudflare Tunnel pode servir o site num domínio teu, para que o endereço público seja sempre o mesmo. Deixa vazio para um URL descartável do trycloudflare.com.",
+  "shareDomain_label": "Domínio base",
+  "shareDomain_preview": "Servido em",
+  "shareDomain_previewEmpty": "O DNS tem de ser gerido pela Cloudflare.",
+  "shareDomain_remember": "Lembrar esta resposta",
+  "shareDomain_rememberHint": "Da próxima vez partilha logo, sem perguntar.",
+  "shareDomain_skip": "Ignorar",
+  "shareDomain_use": "Usar este domínio",
+  "shareDomain_configure": "Configurar o domínio",
+  "share_tunnelViaCli": "Túnel via {tool}, a partir da CLI",
+  "sites_sharedPublicly": "Partilhado publicamente em {url}",
+  "sites_sharedOnLan": "Partilhado na tua rede em {url}"
 }

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -1227,5 +1227,18 @@
   "share_stop": "Oprește",
   "share_stopTunnel": "Oprește tunelul",
   "share_tunnelVia": "Tunel prin {tool}",
-  "share_startFailed": "{tool} nu a putut porni"
+  "share_startFailed": "{tool} nu a putut porni",
+  "shareDomain_title": "Servim acest site pe domeniul tău?",
+  "shareDomain_body": "Cloudflare Tunnel poate servi site-ul pe un domeniu al tău, astfel încât adresa publică să rămână aceeași de fiecare dată. Lasă gol pentru un URL trycloudflare.com de unică folosință.",
+  "shareDomain_label": "Domeniu de bază",
+  "shareDomain_preview": "Servit pe",
+  "shareDomain_previewEmpty": "DNS-ul lui trebuie gestionat de Cloudflare.",
+  "shareDomain_remember": "Ține minte răspunsul",
+  "shareDomain_rememberHint": "Data viitoare partajează direct, fără să întrebe.",
+  "shareDomain_skip": "Sari peste",
+  "shareDomain_use": "Folosește acest domeniu",
+  "shareDomain_configure": "Configurează domeniul",
+  "share_tunnelViaCli": "Tunel prin {tool}, din CLI",
+  "sites_sharedPublicly": "Partajat public pe {url}",
+  "sites_sharedOnLan": "Partajat în rețeaua ta la {url}"
 }

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -1227,5 +1227,18 @@
   "share_stop": "Durdur",
   "share_stopTunnel": "Tüneli durdur",
   "share_tunnelVia": "{tool} üzerinden tünel",
-  "share_startFailed": "{tool} başlatılamadı"
+  "share_startFailed": "{tool} başlatılamadı",
+  "shareDomain_title": "Bu site kendi alan adınızda sunulsun mu?",
+  "shareDomain_body": "Cloudflare Tunnel siteyi sahip olduğunuz bir alan adında sunabilir, böylece genel adres her seferinde aynı kalır. Tek kullanımlık bir trycloudflare.com adresi için boş bırakın.",
+  "shareDomain_label": "Temel alan adı",
+  "shareDomain_preview": "Şurada sunuluyor",
+  "shareDomain_previewEmpty": "DNS'inin Cloudflare tarafından yönetilmesi gerekir.",
+  "shareDomain_remember": "Bu yanıtı hatırla",
+  "shareDomain_rememberHint": "Bir dahaki sefere sormadan doğrudan paylaş.",
+  "shareDomain_skip": "Atla",
+  "shareDomain_use": "Bu alan adını kullan",
+  "shareDomain_configure": "Alan adını yapılandır",
+  "share_tunnelViaCli": "{tool} üzerinden tünel, CLI'dan",
+  "sites_sharedPublicly": "{url} adresinde herkese açık paylaşıldı",
+  "sites_sharedOnLan": "Ağınızda {url} adresinde paylaşıldı"
 }

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -1227,5 +1227,18 @@
   "share_stop": "Dừng",
   "share_stopTunnel": "Dừng tunnel",
   "share_tunnelVia": "Tunnel qua {tool}",
-  "share_startFailed": "{tool} không khởi động được"
+  "share_startFailed": "{tool} không khởi động được",
+  "shareDomain_title": "Phục vụ trang này trên tên miền của bạn?",
+  "shareDomain_body": "Cloudflare Tunnel có thể phục vụ trang trên tên miền bạn sở hữu, để địa chỉ công khai luôn giữ nguyên. Để trống nếu muốn một URL trycloudflare.com dùng một lần.",
+  "shareDomain_label": "Tên miền gốc",
+  "shareDomain_preview": "Phục vụ tại",
+  "shareDomain_previewEmpty": "DNS của nó phải do Cloudflare quản lý.",
+  "shareDomain_remember": "Ghi nhớ câu trả lời này",
+  "shareDomain_rememberHint": "Lần sau chia sẻ ngay, không hỏi lại.",
+  "shareDomain_skip": "Bỏ qua",
+  "shareDomain_use": "Dùng tên miền này",
+  "shareDomain_configure": "Cấu hình tên miền",
+  "share_tunnelViaCli": "Tunnel qua {tool}, từ CLI",
+  "sites_sharedPublicly": "Đang chia sẻ công khai tại {url}",
+  "sites_sharedOnLan": "Đang chia sẻ trong mạng của bạn tại {url}"
 }

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -1227,5 +1227,18 @@
   "share_stop": "停止",
   "share_stopTunnel": "停止隧道",
   "share_tunnelVia": "通过 {tool} 的隧道",
-  "share_startFailed": "{tool} 启动失败"
+  "share_startFailed": "{tool} 启动失败",
+  "shareDomain_title": "用你自己的域名提供这个站点？",
+  "shareDomain_body": "Cloudflare Tunnel 可以在你拥有的域名上提供站点，这样公开地址每次都一样。留空则使用一次性的 trycloudflare.com 地址。",
+  "shareDomain_label": "基础域名",
+  "shareDomain_preview": "提供于",
+  "shareDomain_previewEmpty": "它的 DNS 必须由 Cloudflare 托管。",
+  "shareDomain_remember": "记住这个选择",
+  "shareDomain_rememberHint": "下次直接分享，不再询问。",
+  "shareDomain_skip": "跳过",
+  "shareDomain_use": "使用该域名",
+  "shareDomain_configure": "配置域名",
+  "share_tunnelViaCli": "通过 {tool} 的隧道，来自 CLI",
+  "sites_sharedPublicly": "已公开分享于 {url}",
+  "sites_sharedOnLan": "已在你的网络中分享于 {url}"
 }

--- a/internal/ui/web/src/components/SiteIndicators.svelte
+++ b/internal/ui/web/src/components/SiteIndicators.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Icon from '$components/Icon.svelte';
   import StatusDot from '$components/StatusDot.svelte';
   import { runningWorkerColors, idleWorkerColors, siteWorkerFailing, siteHasWorkers, type Site } from '$stores/sites';
   import { m } from '../paraglide/messages.js';
@@ -12,7 +13,26 @@
   // While asleep, keep showing the suspended workers' dots (dimmed) so the site
   // doesn't look like it lost its workers.
   const idleDots = $derived(idleWorkerColors(site));
+
+  // A share on a branch counts for the row: the list shows one row per site,
+  // and a shared worktree is still that site reachable from outside.
+  const worktrees = $derived(site.worktrees ?? []);
+  const tunnelUrl = $derived(site.tunnel_url || worktrees.find((w) => w.tunnel_url)?.tunnel_url || '');
+  const lanUrl = $derived(
+    site.lan_share_url || worktrees.find((w) => w.lan_share_url)?.lan_share_url || ''
+  );
 </script>
+
+{#if tunnelUrl}
+  <span title={m.sites_sharedPublicly({ url: tunnelUrl })} class="inline-flex shrink-0 text-violet-500 dark:text-violet-400">
+    <Icon name="globe" class="w-3 h-3" />
+  </span>
+{/if}
+{#if lanUrl}
+  <span title={m.sites_sharedOnLan({ url: lanUrl })} class="inline-flex shrink-0 text-teal-500 dark:text-teal-400">
+    <Icon name="wifi" class="w-3 h-3" />
+  </span>
+{/if}
 
 {#if site.worktrees && site.worktrees.length > 0}
   <span title={m.sites_gitWorktrees()} class="inline-flex shrink-0">

--- a/internal/ui/web/src/components/SiteIndicators.test.ts
+++ b/internal/ui/web/src/components/SiteIndicators.test.ts
@@ -41,3 +41,37 @@ describe('SiteIndicators sleep moon', () => {
     expect(hasMoon(container)).toBe(false);
   });
 });
+
+describe('SiteIndicators share badges', () => {
+  it('marks a site that is shared through a public tunnel', () => {
+    const { getByTitle } = render(SiteIndicators, {
+      props: { site: site({ tunnel_url: 'https://abc.trycloudflare.com' }) }
+    });
+    expect(getByTitle('Shared publicly on https://abc.trycloudflare.com')).toBeInTheDocument();
+  });
+
+  it('marks a site that is shared on the local network', () => {
+    const { getByTitle } = render(SiteIndicators, {
+      props: { site: site({ lan_share_url: 'http://192.168.1.10:8080' }) }
+    });
+    expect(getByTitle('Shared on your network at http://192.168.1.10:8080')).toBeInTheDocument();
+  });
+
+  // The list has one row per site, so a share on a branch still has to show up
+  // against the site it belongs to.
+  it('counts a share on one of the site worktrees', () => {
+    const { getByTitle } = render(SiteIndicators, {
+      props: {
+        site: site({
+          worktrees: [{ branch: 'feat', tunnel_url: 'https://branch.serveo.net' }]
+        } as Partial<Site>)
+      }
+    });
+    expect(getByTitle('Shared publicly on https://branch.serveo.net')).toBeInTheDocument();
+  });
+
+  it('shows nothing for a site that is not shared', () => {
+    const { queryByTitle } = render(SiteIndicators, { props: { site: site({}) } });
+    expect(queryByTitle(/^Shared/)).not.toBeInTheDocument();
+  });
+});

--- a/internal/ui/web/src/stores/sites.ts
+++ b/internal/ui/web/src/stores/sites.ts
@@ -79,6 +79,7 @@ export interface Site {
     lan_share_url?: string;
     tunnel_url?: string;
     tunnel_tool?: string;
+    tunnel_external?: boolean;
     framework_workers?: FrameworkWorker[];
     idle_suspended_workers?: string[];
   }>;
@@ -107,6 +108,7 @@ export interface Site {
   lan_share_url?: string;
   tunnel_url?: string;
   tunnel_tool?: string;
+  tunnel_external?: boolean;
   framework_workers?: FrameworkWorker[];
   last_request_at?: number;
   request_count?: number;
@@ -616,15 +618,36 @@ export interface ShareToolsInfo {
   tools: ShareToolStatus[];
   auto?: string;
   default?: string;
+  base_domain?: string;
+  base_domain_answered?: boolean;
 }
 export const loadShareTools = () => apiJson<ShareToolsInfo>('/api/share-tools');
-export const startTunnel = (s: Site, tool: string = '', branch: string = '') => {
+export const startTunnel = (s: Site, tool: string = '', branch: string = '', domain: string = '') => {
   const params = new URLSearchParams();
   if (tool) params.set('tool', tool);
   if (branch) params.set('branch', branch);
+  if (domain) params.set('domain', domain);
   const qs = params.toString();
   return postAction(site(s.domain, 'tunnel:start') + (qs ? `?${qs}` : ''));
 };
+// Records the answer to the base-domain question. remember false forgets it, so
+// the share menu asks again next time.
+export async function saveShareDomain(
+  domain: string,
+  remember: boolean
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await apiFetch('/api/share-tools', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ base_domain: domain, remember })
+    });
+    const data = (await res.json()) as { ok?: boolean; error?: string };
+    return { ok: Boolean(data.ok), error: data.error };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : m.common_requestFailed() };
+  }
+}
 export const stopTunnel = (s: Site, branch: string = '') =>
   postAction(site(s.domain, 'tunnel:stop') + (branch ? `?branch=${encodeURIComponent(branch)}` : ''));
 export const toggleQueue = (s: Site) =>

--- a/internal/ui/web/src/tabs/sites/ShareDomainModal.svelte
+++ b/internal/ui/web/src/tabs/sites/ShareDomainModal.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import Modal from '$components/Modal.svelte';
+  import { m } from '../../paraglide/messages.js';
+
+  interface Props {
+    open: boolean;
+    // "start" asks on the way to a tunnel and offers to skip; "configure" is
+    // the cog, which only records the answer.
+    mode: 'start' | 'configure';
+    label: string;
+    baseDomain?: string;
+    remembered?: boolean;
+    error?: string;
+    busy?: boolean;
+    onclose: () => void;
+    onsubmit: (domain: string, remember: boolean) => void;
+  }
+  let {
+    open,
+    mode,
+    label,
+    baseDomain = '',
+    remembered = false,
+    error = '',
+    busy = false,
+    onclose,
+    onsubmit
+  }: Props = $props();
+
+  let domain = $state('');
+  let remember = $state(false);
+
+  // Reopening starts from what is stored, so the cog shows the current answer
+  // and the ask starts empty rather than from a half-typed previous attempt.
+  $effect(() => {
+    if (open) {
+      domain = baseDomain;
+      remember = remembered || mode === 'configure';
+    }
+  });
+
+  const clean = $derived(domain.trim().replace(/^\.+|\.+$/g, '').toLowerCase());
+  const preview = $derived(clean ? `${label}.${clean}` : '');
+  const btnBase =
+    'px-3 py-1.5 text-xs font-medium rounded-md transition-colors disabled:opacity-50';
+</script>
+
+<Modal {open} title={m.shareDomain_title()} {onclose} size="md">
+  <div class="px-5 py-4 space-y-3">
+    <p class="text-sm text-gray-600 dark:text-gray-300">{m.shareDomain_body()}</p>
+
+    <div>
+      <label for="share-base-domain" class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+        {m.shareDomain_label()}
+      </label>
+      <input
+        id="share-base-domain"
+        bind:value={domain}
+        onkeydown={(e) => e.key === 'Enter' && clean && !busy && onsubmit(clean, remember)}
+        placeholder="example.com"
+        autocomplete="off"
+        spellcheck="false"
+        class="w-full px-2.5 py-1.5 text-sm font-mono rounded-md border border-gray-200 dark:border-lerd-border bg-white dark:bg-lerd-bg text-gray-800 dark:text-gray-200 focus:outline-none focus:border-lerd-red"
+      />
+      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        {#if preview}
+          {m.shareDomain_preview()}
+          <span class="font-mono text-violet-600 dark:text-violet-400">{preview}</span>
+        {:else}
+          {m.shareDomain_previewEmpty()}
+        {/if}
+      </p>
+    </div>
+
+    <div class="flex items-start gap-2 text-xs">
+      <input id="share-remember" type="checkbox" bind:checked={remember} class="mt-0.5 accent-lerd-red" />
+      <span>
+        <label for="share-remember" class="text-gray-600 dark:text-gray-300 cursor-pointer"
+          >{m.shareDomain_remember()}</label
+        >
+        <span class="block text-gray-500 dark:text-gray-400">{m.shareDomain_rememberHint()}</span>
+      </span>
+    </div>
+
+    {#if error}
+      <p class="text-xs text-red-600 dark:text-red-400 break-words">{error}</p>
+    {/if}
+  </div>
+
+  {#snippet footer()}
+    {#if mode === 'start'}
+      <button
+        type="button"
+        disabled={busy}
+        onclick={() => onsubmit('', remember)}
+        class="{btnBase} border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/5"
+        >{m.shareDomain_skip()}</button
+      >
+      <button
+        type="button"
+        disabled={busy || !clean}
+        onclick={() => onsubmit(clean, remember)}
+        class="{btnBase} bg-lerd-red hover:bg-lerd-redhov text-white">{m.shareDomain_use()}</button
+      >
+    {:else}
+      <button
+        type="button"
+        disabled={busy}
+        onclick={onclose}
+        class="{btnBase} border border-gray-200 dark:border-lerd-border text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-white/5"
+        >{m.common_cancel()}</button
+      >
+      <button
+        type="button"
+        disabled={busy}
+        onclick={() => onsubmit(clean, remember)}
+        class="{btnBase} bg-lerd-red hover:bg-lerd-redhov text-white">{m.common_save()}</button
+      >
+    {/if}
+  {/snippet}
+</Modal>

--- a/internal/ui/web/src/tabs/sites/ShareMenu.svelte
+++ b/internal/ui/web/src/tabs/sites/ShareMenu.svelte
@@ -4,10 +4,12 @@
     type ShareToolsInfo,
     loadShareTools,
     loadSites,
+    saveShareDomain,
     startTunnel,
     stopTunnel
   } from '$stores/sites';
   import Icon from '$components/Icon.svelte';
+  import ShareDomainModal from './ShareDomainModal.svelte';
   import { m } from '../../paraglide/messages.js';
 
   interface Props {
@@ -61,7 +63,22 @@
     (activeWorktreeBranch ? activeWorktree?.tunnel_tool : site.tunnel_tool) ?? ''
   );
   const tunnelOn = $derived(Boolean(tunnelUrl));
+  const tunnelExternal = $derived(
+    Boolean(activeWorktreeBranch ? activeWorktree?.tunnel_external : site.tunnel_external)
+  );
   const autoTool = $derived(toolsInfo?.tools.find((t) => t.name === toolsInfo?.auto));
+
+  // The label a Cloudflare named tunnel serves the site on, mirroring the
+  // hostname the backend composes: the site's own domain without the TLD, so
+  // it follows the domain the user picked rather than the project folder.
+  const hostLabel = $derived(
+    labelFor((activeWorktreeBranch ? activeWorktree?.domain : site.domain) || site.domain)
+  );
+
+  function labelFor(domain: string): string {
+    const parts = domain.toLowerCase().split('.').filter(Boolean);
+    return (parts.length > 1 ? parts.slice(0, -1) : parts).join('-');
+  }
 
   function toolLabel(name: string): string {
     return toolsInfo?.tools.find((t) => t.name === name)?.label || name;
@@ -108,14 +125,49 @@
     if (e.key === 'Escape') closeNow();
   }
 
-  async function startTool(tool: string, label: string) {
+  // Cloudflare is the only tool that can serve a site on your own domain, so
+  // picking it asks for one first, until the answer has been remembered.
+  const CLOUDFLARE = 'cloudflare';
+  let domainModal = $state<'start' | 'configure' | ''>('');
+  let domainError = $state('');
+  let domainBusy = $state(false);
+
+  function pickTool(tool: string, label: string) {
+    if (tool === CLOUDFLARE && !toolsInfo?.base_domain_answered) {
+      startingLabel = label;
+      domainError = '';
+      domainModal = 'start';
+      return;
+    }
+    startTool(tool, label);
+  }
+
+  async function submitDomain(domain: string, remember: boolean) {
+    const starting = domainModal === 'start';
+    domainBusy = true;
+    domainError = '';
+    try {
+      const res = await saveShareDomain(domain, remember);
+      if (!res.ok) {
+        domainError = res.error || m.common_requestFailed();
+        return;
+      }
+      toolsInfo = await loadShareTools().catch(() => toolsInfo);
+      domainModal = '';
+      if (starting) await startTool(CLOUDFLARE, startingLabel, domain);
+    } finally {
+      domainBusy = false;
+    }
+  }
+
+  async function startTool(tool: string, label: string, domain: string = '') {
     if (tunnelBusy) return;
     tunnelBusy = true;
     startingLabel = label;
     tunnelError = '';
     cancelRequested = false;
     try {
-      const res = await startTunnel(site, tool, activeWorktreeBranch);
+      const res = await startTunnel(site, tool, activeWorktreeBranch, domain);
       if (!res.ok && !cancelRequested) {
         tunnelError = res.error || m.common_requestFailed();
         errorTool = label;
@@ -258,7 +310,11 @@
         <div class="{itemClass} border-l-2 border-violet-500 bg-violet-50/60 dark:bg-violet-900/15">
           <Icon name="globe" class="w-3.5 h-3.5 shrink-0 text-violet-600 dark:text-violet-400" />
           <span class="flex-1 min-w-0">
-            <span class="block font-medium text-gray-700 dark:text-gray-200">{m.share_tunnelVia({ tool: toolLabel(tunnelTool) })}</span>
+            <span class="block font-medium text-gray-700 dark:text-gray-200">
+              {tunnelExternal
+                ? m.share_tunnelViaCli({ tool: toolLabel(tunnelTool) })
+                : m.share_tunnelVia({ tool: toolLabel(tunnelTool) })}
+            </span>
             <a href={tunnelUrl} target="_blank" rel="noopener" class="block font-mono text-[10px] text-violet-600 dark:text-violet-400 truncate hover:underline">{tunnelUrl}</a>
           </span>
           <button
@@ -292,7 +348,7 @@
             type="button"
             role="menuitem"
             disabled={!autoTool}
-            onclick={() => startTool('', m.share_autoLabel())}
+            onclick={() => pickTool(autoTool?.name === CLOUDFLARE ? CLOUDFLARE : '', m.share_autoLabel())}
             class="{itemClass} {autoTool ? itemIdle : 'text-gray-400 dark:text-gray-600'}"
           >
             <Icon name="external" class="w-3.5 h-3.5 shrink-0" />
@@ -304,24 +360,57 @@
             </span>
           </button>
           {#each toolsInfo.tools as tool (tool.name)}
-            <button
-              type="button"
-              role="menuitem"
-              disabled={!tool.installed}
-              onclick={() => startTool(tool.name, tool.label)}
-              class="{itemClass} {tool.installed ? itemIdle : 'text-gray-400 dark:text-gray-600'}"
-            >
-              <Icon name="globe" class="w-3.5 h-3.5 shrink-0" />
-              <span class="flex-1 min-w-0 text-left">
-                <span class="block font-medium">{tool.label}</span>
-                <span class="block text-[10px] {tool.installed ? 'text-gray-500 dark:text-gray-400' : ''}">
-                  {tool.installed ? tool.binary : installHint(tool)}
+            <div class="flex items-stretch">
+              <button
+                type="button"
+                role="menuitem"
+                disabled={!tool.installed}
+                onclick={() => pickTool(tool.name, tool.label)}
+                class="{itemClass} {tool.installed ? itemIdle : 'text-gray-400 dark:text-gray-600'}"
+              >
+                <Icon name="globe" class="w-3.5 h-3.5 shrink-0" />
+                <span class="flex-1 min-w-0 text-left">
+                  <span class="block font-medium">{tool.label}</span>
+                  <span class="block text-[10px] {tool.installed ? 'text-gray-500 dark:text-gray-400' : ''}">
+                    {!tool.installed
+                      ? installHint(tool)
+                      : tool.name === CLOUDFLARE && toolsInfo.base_domain
+                        ? hostLabel + '.' + toolsInfo.base_domain
+                        : tool.binary}
+                  </span>
                 </span>
-              </span>
-            </button>
+              </button>
+              {#if tool.name === CLOUDFLARE && tool.installed}
+                <button
+                  type="button"
+                  role="menuitem"
+                  title={m.shareDomain_configure()}
+                  aria-label={m.shareDomain_configure()}
+                  data-testid="share-domain-cog"
+                  onclick={() => ((domainError = ''), (domainModal = 'configure'))}
+                  class="shrink-0 px-2.5 flex items-center text-gray-400 hover:text-lerd-red dark:text-gray-500 dark:hover:text-lerd-red transition-colors"
+                >
+                  <Icon name="system" class="w-3.5 h-3.5" />
+                </button>
+              {/if}
+            </div>
           {/each}
         {/if}
       {/if}
     </div>
   {/if}
 </div>
+
+<!-- Outside the menu: moving the pointer onto the modal closes the hover menu,
+     which would take the modal with it. -->
+<ShareDomainModal
+  open={domainModal !== ''}
+  mode={domainModal === 'configure' ? 'configure' : 'start'}
+  label={hostLabel}
+  baseDomain={toolsInfo?.base_domain ?? ''}
+  remembered={toolsInfo?.base_domain_answered ?? false}
+  error={domainError}
+  busy={domainBusy}
+  onclose={() => (domainModal = '')}
+  onsubmit={submitDomain}
+/>

--- a/internal/ui/web/src/tabs/sites/ShareMenu.test.ts
+++ b/internal/ui/web/src/tabs/sites/ShareMenu.test.ts
@@ -25,7 +25,8 @@ const toolsPayload = {
     { name: 'cloudflare', label: 'Cloudflare Tunnel', binary: 'cloudflared', installed: true },
     { name: 'serveo', label: 'Serveo', binary: 'ssh', installed: true }
   ],
-  auto: 'cloudflare'
+  auto: 'cloudflare',
+  base_domain_answered: true
 };
 
 let fetchCalls: string[];
@@ -148,5 +149,181 @@ describe('ShareMenu', () => {
     await openMenu(container);
     await fireEvent.keyDown(window, { key: 'Escape' });
     expect(screen.queryByTestId('share-menu')).not.toBeInTheDocument();
+  });
+});
+
+// A fetch that answers each endpoint properly, so the save → start sequence
+// actually gets past the save.
+function mockShareFetch(tools: Record<string, unknown>) {
+  fetchCalls = [];
+  const bodies: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      fetchCalls.push(url);
+      if (init?.method === 'POST') {
+        if (init.body) bodies.push(String(init.body));
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(JSON.stringify(tools), { status: 200 });
+    })
+  );
+  return bodies;
+}
+
+const unanswered = { ...toolsPayload, base_domain_answered: false };
+
+async function openCloudflare(container: HTMLElement) {
+  await openMenu(container);
+  await waitFor(() => expect(screen.getByText('Cloudflare Tunnel')).toBeInTheDocument());
+  await fireEvent.click(screen.getByText('Cloudflare Tunnel').closest('button')!);
+}
+
+describe('ShareMenu base domain', () => {
+  it('asks for a base domain before the first Cloudflare share', async () => {
+    mockShareFetch(unanswered);
+    const { container } = render(Harness, { props: { site } });
+    await openCloudflare(container);
+    expect(screen.getByText('Serve this site on your own domain?')).toBeInTheDocument();
+    expect(fetchCalls.some((u) => u.includes('tunnel:start'))).toBe(false);
+  });
+
+  it('previews the hostname the site would be served on', async () => {
+    mockShareFetch(unanswered);
+    const { container } = render(Harness, { props: { site } });
+    await openCloudflare(container);
+    await fireEvent.input(screen.getByLabelText('Base domain'), { target: { value: 'example.com' } });
+    expect(screen.getByText('app.example.com')).toBeInTheDocument();
+  });
+
+  it('starts on the given domain and remembers the answer', async () => {
+    const bodies = mockShareFetch(unanswered);
+    const { container } = render(Harness, { props: { site } });
+    await openCloudflare(container);
+    await fireEvent.input(screen.getByLabelText('Base domain'), { target: { value: 'example.com' } });
+    await fireEvent.click(screen.getByLabelText('Remember this answer'));
+    await fireEvent.click(screen.getByText('Use this domain'));
+
+    await waitFor(() =>
+      expect(
+        fetchCalls.some((u) => u.includes('tunnel:start?tool=cloudflare&domain=example.com'))
+      ).toBe(true)
+    );
+    expect(bodies.some((b) => JSON.parse(b).base_domain === 'example.com')).toBe(true);
+    expect(bodies.some((b) => JSON.parse(b).remember === true)).toBe(true);
+  });
+
+  it('skips straight to a quick tunnel, carrying the remember choice', async () => {
+    const bodies = mockShareFetch(unanswered);
+    const { container } = render(Harness, { props: { site } });
+    await openCloudflare(container);
+    await fireEvent.click(screen.getByLabelText('Remember this answer'));
+    await fireEvent.click(screen.getByText('Skip'));
+
+    await waitFor(() =>
+      expect(fetchCalls.some((u) => u.includes('tunnel:start?tool=cloudflare'))).toBe(true)
+    );
+    expect(fetchCalls.some((u) => u.includes('domain='))).toBe(false);
+    const saved = bodies.map((b) => JSON.parse(b)).find((b) => 'remember' in b);
+    expect(saved).toEqual({ base_domain: '', remember: true });
+  });
+
+  it('stops asking once the answer has been remembered', async () => {
+    mockShareFetch({ ...toolsPayload, base_domain_answered: true, base_domain: 'example.com' });
+    const { container } = render(Harness, { props: { site } });
+    await openCloudflare(container);
+    expect(screen.queryByText('Serve this site on your own domain?')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(fetchCalls.some((u) => u.includes('tunnel:start?tool=cloudflare'))).toBe(true)
+    );
+  });
+
+  it('shows the hostname a remembered domain will serve the site on', async () => {
+    mockShareFetch({ ...toolsPayload, base_domain_answered: true, base_domain: 'example.com' });
+    const { container } = render(Harness, { props: { site } });
+    await openMenu(container);
+    await waitFor(() => expect(screen.getByText('app.example.com')).toBeInTheDocument());
+  });
+
+  it('reconfigures the domain from the cog without starting anything', async () => {
+    const bodies = mockShareFetch({ ...toolsPayload, base_domain_answered: true, base_domain: 'old.example' });
+    const { container } = render(Harness, { props: { site } });
+    await openMenu(container);
+    await waitFor(() => expect(screen.getByTestId('share-domain-cog')).toBeInTheDocument());
+    await fireEvent.click(screen.getByTestId('share-domain-cog'));
+
+    const input = screen.getByLabelText('Base domain') as HTMLInputElement;
+    expect(input.value).toBe('old.example');
+    await fireEvent.input(input, { target: { value: 'new.example' } });
+    await fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(bodies.some((b) => JSON.parse(b).base_domain === 'new.example')).toBe(true));
+    expect(fetchCalls.some((u) => u.includes('tunnel:start'))).toBe(false);
+  });
+
+  it('reports a rejected domain instead of starting', async () => {
+    fetchCalls = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        fetchCalls.push(String(input));
+        if (init?.method === 'POST') {
+          return new Response(JSON.stringify({ error: 'base domain "nope" needs at least one dot' }), { status: 200 });
+        }
+        return new Response(JSON.stringify(unanswered), { status: 200 });
+      })
+    );
+    const { container } = render(Harness, { props: { site } });
+    await openCloudflare(container);
+    await fireEvent.input(screen.getByLabelText('Base domain'), { target: { value: 'nope' } });
+    await fireEvent.click(screen.getByText('Use this domain'));
+
+    await waitFor(() => expect(screen.getByText(/needs at least one dot/)).toBeInTheDocument());
+    expect(fetchCalls.some((u) => u.includes('tunnel:start'))).toBe(false);
+  });
+
+  // A worktree is served on its own subdomain, and the hostname follows that
+  // domain flattened into one label.
+  it('previews the worktree hostname on a branch tab', async () => {
+    mockShareFetch(unanswered);
+    const { container } = render(Harness, {
+      props: { site: withWorktree(), activeWorktreeBranch: 'feat' }
+    });
+    await openCloudflare(container);
+    await fireEvent.input(screen.getByLabelText('Base domain'), { target: { value: 'example.com' } });
+    expect(screen.getByText('feat-app.example.com')).toBeInTheDocument();
+  });
+
+  it('starts a worktree share on the given domain, against its branch', async () => {
+    mockShareFetch(unanswered);
+    const { container } = render(Harness, {
+      props: { site: withWorktree(), activeWorktreeBranch: 'feat' }
+    });
+    await openCloudflare(container);
+    await fireEvent.input(screen.getByLabelText('Base domain'), { target: { value: 'example.com' } });
+    await fireEvent.click(screen.getByText('Use this domain'));
+    await waitFor(() =>
+      expect(
+        fetchCalls.some((u) =>
+          u.includes('tunnel:start?tool=cloudflare&branch=feat&domain=example.com')
+        )
+      ).toBe(true)
+    );
+  });
+
+  it('says when the running tunnel was started from the CLI', async () => {
+    mockShareFetch(toolsPayload);
+    const running = {
+      ...site,
+      tunnel_url: 'https://x.trycloudflare.com',
+      tunnel_tool: 'cloudflare',
+      tunnel_external: true
+    } as unknown as Site;
+    const { container } = render(Harness, { props: { site: running } });
+    await openMenu(container);
+    await waitFor(() =>
+      expect(screen.getByText('Tunnel via Cloudflare Tunnel, from the CLI')).toBeInTheDocument()
+    );
   });
 });


### PR DESCRIPTION
A quick tunnel hands out a fresh trycloudflare.com URL on every run, so the address you sent someone yesterday is dead today. `lerd share --domain` already fixed that for a single run, at the cost of typing the whole hostname every time. A base domain settles it once: set one and every Cloudflare share is served on `<site>.<base domain>` through a named tunnel, with the label taken from the site's own domain rather than the folder the project happens to sit in, so a scorediviner.test living in a score-diviner directory is shared as scorediviner.

The dashboard asks the first time you pick Cloudflare Tunnel from the share menu. Type a base domain, or skip it for a quick tunnel, and tick remember to have it stop asking, whichever way you answered. The cog beside the Cloudflare entry reopens that dialog to change the domain later, or to clear it so the question comes back. `lerd share:domain` is the terminal equivalent, and `--domain` still wins for a single run.

A worktree's subdomain flattens into one label, so a branch is served on feat-login-myapp.example.com. A Cloudflare certificate covers one level of subdomain and no more, and feat-login.myapp.example.com would fail TLS before it ever reached the tunnel.

Named tunnels need cloudflared authorized once, which the dashboard cannot do for you because it has no terminal to run the browser login in. It says what to run instead of hanging on a prompt nobody can see.

The other half of this is that a share was only ever visible where it was started. A `lerd share` running in a terminal now records itself for as long as it is up and clears the record on the way out, so the dashboard reflects it like one of its own and can stop it. A share killed outright leaves its record behind, and the dashboard drops it once it notices the process is gone. Sites carry an icon in the list while they are shared, publicly or on the LAN, including when the share belongs to one of their worktrees.

Closes #1215
