### PR TITLE
fix(workers): follow a site's scheme and domains into its dev server

### DIFF
--- a/docs/usage/framework-workers.md
+++ b/docs/usage/framework-workers.md
@@ -98,6 +98,10 @@ Nothing in the project is edited. lerd writes a generated config to `node_module
 
 The port is pinned, because the vhost proxies to it and the tool would otherwise drift to the next free one whenever several sites run. It is kept clear of other sites, of the site's own worktrees, and of whatever else the machine is holding, and a pin something has since taken is re-picked rather than left to fail. Each worktree pins its own port and takes its origin from its own subdomain.
 
+The tool reads those addresses once, when it starts, so lerd writes them back and restarts the dev server whenever they move: `lerd secure` and `lerd unsecure`, `lerd domain add` and `lerd domain remove`, and grouping a site under a main. A dev server that is not running is left down, and a change that leaves the addresses exactly as they were restarts nothing.
+
+A site with more than one domain serves its assets from the primary one, since a dev server can advertise only a single origin. The generated config lists every domain, both as a host the server answers for (along with its subdomains, matching the vhost's wildcard) and as an origin allowed to fetch from it, so a page opened on a second domain loads normally instead of having its assets refused.
+
 Some plugin middleware registers itself ahead of the tool's own base handling and only answers unprefixed, which would 404 on URLs it advertised itself. nginx retries any 404 under the prefix once with the prefix removed, so those routes work without anything having to name them.
 
 When [idle-suspend](/usage/idle-suspend) is enabled it stops every one of a site's workers once the site has been idle, so workers carry no special configuration for it. A worker marked `per_worktree: true` (Vite is the only one by default) is suspended per worktree, on each worktree's own idle timer.

--- a/internal/cli/devserver.go
+++ b/internal/cli/devserver.go
@@ -11,10 +11,12 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
 	"github.com/geodro/lerd/internal/freeport"
 	gitpkg "github.com/geodro/lerd/internal/git"
 	"github.com/geodro/lerd/internal/nginx"
 	phpDet "github.com/geodro/lerd/internal/php"
+	"github.com/geodro/lerd/internal/podman"
 )
 
 // A host dev server normally advertises its own address, so everything it
@@ -73,21 +75,21 @@ func jsLiterals(values ...any) ([]any, error) {
 	return out, nil
 }
 
-// writeDevServerWrapper generates the config that puts the dev server on the
-// site's origin and returns its site-relative path. An empty path means the
-// mechanism does not apply here and the caller must leave the command alone.
-func writeDevServerWrapper(sitePath string, tool *config.DevServerTool, origin string, domains []string) (string, error) {
+// devServerWrapperBody renders the config that puts the dev server on the site's
+// origin, returning its site-relative path and its contents. An empty path means
+// the mechanism does not apply here and the caller must leave the command alone.
+func devServerWrapperBody(sitePath string, tool *config.DevServerTool, addr devServerAddr) (string, string, error) {
 	projectConfig := devServerProjectConfig(sitePath, tool)
 	if projectConfig == "" {
-		return "", nil
+		return "", "", nil
 	}
 	if !pathIsIgnored(sitePath, tool.WrapperPath) {
-		return "", nil
+		return "", "", nil
 	}
 
 	importPath, err := filepath.Rel(filepath.Dir(tool.WrapperPath), projectConfig)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	importPath = filepath.ToSlash(importPath)
 	if !strings.HasPrefix(importPath, ".") {
@@ -96,54 +98,70 @@ func writeDevServerWrapper(sitePath string, tool *config.DevServerTool, origin s
 	// The wrapper is JavaScript the dev server executes and a project's own
 	// .lerd.yaml supplies its domains, so every value is encoded into a literal
 	// rather than quoted by the template.
-	literals, err := jsLiterals(importPath, tool.Base, origin, domains)
+	literals, err := jsLiterals(importPath, tool.Base, addr.Origin, addr.Hosts, addr.Origins)
 	if err != nil {
+		return "", "", err
+	}
+	return tool.WrapperPath, fmt.Sprintf(tool.Wrapper, literals...), nil
+}
+
+// writeDevServerWrapper generates the config and returns its site-relative path.
+func writeDevServerWrapper(sitePath string, tool *config.DevServerTool, addr devServerAddr) (string, error) {
+	rel, body, err := devServerWrapperBody(sitePath, tool, addr)
+	if err != nil || rel == "" {
 		return "", err
 	}
-
-	full := filepath.Join(sitePath, tool.WrapperPath)
+	full := filepath.Join(sitePath, rel)
 	if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
 		return "", err
 	}
-	body := fmt.Sprintf(tool.Wrapper, literals...)
 	if err := os.WriteFile(full, []byte(body), 0644); err != nil {
 		return "", err
 	}
-	return tool.WrapperPath, nil
+	return rel, nil
 }
 
-// devServerOrigin returns the URL the dev server should advertise and the
-// hostnames it must accept, which is the site's own address rather than the
-// tool's localhost guess.
-func devServerOrigin(site *config.Site) (string, []string) {
+// devServerAddr is every address the site answers on, in the shape the generated
+// config needs: the one origin asset URLs resolve to, the hosts the server may
+// answer for, and the page origins allowed to fetch from it.
+type devServerAddr struct {
+	Origin  string
+	Hosts   []string
+	Origins []string
+}
+
+// devServerAddrFor mirrors what the vhost serves. Assets resolve to the primary
+// domain, since a dev server can only advertise one; each domain answers along
+// with its subdomains, matching the vhost's wildcard (a leading dot is how the
+// tool spells that); and a page on any of those domains may fetch from it.
+func devServerAddrFor(secured bool, primary string, domains []string) devServerAddr {
 	scheme := "http"
-	if site.Secured {
+	if secured {
 		scheme = "https"
 	}
-	domains := site.Domains
-	if len(domains) == 0 {
-		domains = []string{site.PrimaryDomain()}
+	addr := devServerAddr{Origin: scheme + "://" + primary}
+	for _, d := range domains {
+		addr.Hosts = append(addr.Hosts, "."+d)
+		addr.Origins = append(addr.Origins, scheme+"://"+d)
 	}
-	return scheme + "://" + site.PrimaryDomain(), domains
+	return addr
 }
 
-// devServerAddress returns the origin and accepted hostnames for whichever
-// checkout is starting: the site itself, or one of its worktrees on its own
-// subdomain.
-func devServerAddress(site *config.Site, sitePath string) (string, []string, error) {
+// devServerAddress returns the addresses for whichever checkout is starting: the
+// site itself, or one of its worktrees on its own subdomain.
+func devServerAddress(site *config.Site, sitePath string) (devServerAddr, error) {
 	if isSiteItself(site, sitePath) {
-		origin, domains := devServerOrigin(site)
-		return origin, domains, nil
+		domains := site.Domains
+		if len(domains) == 0 {
+			domains = []string{site.PrimaryDomain()}
+		}
+		return devServerAddrFor(site.Secured, site.PrimaryDomain(), domains), nil
 	}
 	wt, ok := worktreeForPath(site, sitePath)
 	if !ok {
-		return "", nil, fmt.Errorf("no worktree registered for %s", sitePath)
+		return devServerAddr{}, fmt.Errorf("no worktree registered for %s", sitePath)
 	}
-	scheme := "http"
-	if site.Secured {
-		scheme = "https"
-	}
-	return scheme + "://" + wt.Domain, []string{wt.Domain}, nil
+	return devServerAddrFor(site.Secured, wt.Domain, []string{wt.Domain}), nil
 }
 
 func isSiteItself(site *config.Site, sitePath string) bool {
@@ -263,11 +281,11 @@ func devServerSetup(siteName, sitePath string, tool *config.DevServerTool) (stri
 	}
 	// A worktree fronts its own domain and runs its own dev server, so it gets
 	// its own origin and its own pinned port rather than the parent's.
-	origin, domains, err := devServerAddress(site, sitePath)
+	addr, err := devServerAddress(site, sitePath)
 	if err != nil {
 		return "", err
 	}
-	wrapper, err := writeDevServerWrapper(sitePath, tool, origin, domains)
+	wrapper, err := writeDevServerWrapper(sitePath, tool, addr)
 	if err != nil || wrapper == "" {
 		return "", err
 	}
@@ -287,4 +305,85 @@ func devServerArgs(tool *config.DevServerTool, wrapperPath string, port int) str
 	}
 	args := strings.ReplaceAll(tool.Args, "{config}", wrapperPath)
 	return strings.ReplaceAll(args, "{port}", strconv.Itoa(port))
+}
+
+// RefreshDevServers brings the generated config back in line with the addresses
+// the site now answers on, for the site and for each of its worktrees, and
+// restarts a dev server still running on the old ones. The tool reads those
+// values once, at start, so every path that moves a site's scheme or its domains
+// has to come through here. Nothing changed means nothing is restarted.
+func RefreshDevServers(site *config.Site) {
+	if site == nil || site.Path == "" {
+		return
+	}
+	refreshDevServersAt(site, site.Path)
+	// A worktree pins its own port the first time its dev server runs, so an
+	// empty set means none of them has one to realign.
+	if len(site.WorktreeDevPorts) == 0 {
+		return
+	}
+	if wts, err := gitpkg.DetectWorktrees(site.Path, site.PrimaryDomain()); err == nil {
+		for _, wt := range wts {
+			refreshDevServersAt(site, wt.Path)
+		}
+	}
+}
+
+// refreshDevServersAt rewrites one checkout's generated config when the addresses
+// in it have moved, and restarts the worker holding the stale copy. The port is
+// left alone: it lives in the unit, nginx already proxies to it, and a plain
+// restart re-reads the config the unit is pointed at. A config that was never
+// generated here settles it in two stats, since this runs from every path that
+// regenerates a vhost.
+func refreshDevServersAt(site *config.Site, sitePath string) {
+	tool := config.DevServerToolInstalled(sitePath)
+	if tool == nil {
+		return
+	}
+	if _, err := os.Stat(filepath.Join(sitePath, tool.WrapperPath)); err != nil {
+		return
+	}
+	addr, err := devServerAddress(site, sitePath)
+	if err != nil {
+		return
+	}
+	fw, ok := config.GetFrameworkForDir(site.Framework, sitePath)
+	if !ok || fw == nil {
+		return
+	}
+	if !rewriteDevServerWrapper(sitePath, tool, addr) {
+		return
+	}
+	for name, w := range fw.Workers {
+		if !w.Host || config.DevServerToolFor(sitePath, resolveWorkerCommand(sitePath, name, w)) == nil {
+			continue
+		}
+		unit := WorkerUnitName(site.Name, sitePath, name)
+		if !unitIsActiveOrActivating(unit) {
+			continue
+		}
+		if err := podman.RestartUnit(unit); err != nil {
+			feedback.Warn("restarting %s so it serves %s: %v", name, addr.Origin, err)
+		}
+	}
+}
+
+// rewriteDevServerWrapper updates an already generated config in place and
+// reports whether it had drifted. A config this mechanism never generated here
+// is left absent rather than created: no unit is pointed at it.
+func rewriteDevServerWrapper(sitePath string, tool *config.DevServerTool, addr devServerAddr) bool {
+	rel, body, err := devServerWrapperBody(sitePath, tool, addr)
+	if err != nil || rel == "" {
+		return false
+	}
+	full := filepath.Join(sitePath, rel)
+	current, err := os.ReadFile(full)
+	if err != nil || string(current) == body {
+		return false
+	}
+	if err := os.WriteFile(full, []byte(body), 0644); err != nil {
+		feedback.Warn("updating the generated dev server config: %v", err)
+		return false
+	}
+	return true
 }

--- a/internal/cli/devserver_refresh_test.go
+++ b/internal/cli/devserver_refresh_test.go
@@ -1,0 +1,229 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/podman"
+)
+
+// devServerSite registers a site whose framework declares a host worker that
+// starts vite, with the project shaped the way the mechanism requires, and
+// returns the project directory.
+func devServerSite(t *testing.T, secured bool) string {
+	t.Helper()
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("XDG_DATA_HOME", xdg)
+	if err := os.MkdirAll(filepath.Join(xdg, "lerd", "frameworks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveFramework(&config.Framework{
+		Name: "testfw",
+		Workers: map[string]config.FrameworkWorker{
+			"vite":  {Command: "npm run dev", Host: true},
+			"queue": {Command: "php artisan queue:work"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := gitRepo(t, "/node_modules\n")
+	if err := os.WriteFile(filepath.Join(dir, "vite.config.js"), []byte("export default {}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"scripts":{"dev":"vite"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules", "vite"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.AddSite(config.Site{
+		Name:      "myapp",
+		Path:      dir,
+		Domains:   []string{"myapp.test"},
+		Framework: "testfw",
+		Secured:   secured,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// addWorktree checks out a branch of the site as a git worktree beside it, with
+// the same project shape (a worktree seeds node_modules from its parent), and
+// returns its path.
+func addWorktree(t *testing.T, sitePath, branch string) string {
+	t.Helper()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = sitePath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	run("add", "-A")
+	run("commit", "-qm", "initial")
+	path := filepath.Join(filepath.Dir(sitePath), filepath.Base(sitePath)+"-"+branch)
+	run("worktree", "add", "-q", "-b", branch, path)
+	if err := os.MkdirAll(filepath.Join(path, "node_modules", "vite"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// Unsecuring a site leaves its dev server advertising https, so every asset URL
+// on the page names a scheme nothing serves any more and the page arrives
+// unstyled. The config has to be rewritten and the server put back on it.
+func TestRefreshDevServersRestartsAfterTheSchemeChanges(t *testing.T) {
+	dir := devServerSite(t, true)
+	tool := config.DevServerToolInstalled(dir)
+	if tool == nil {
+		t.Fatal("vite not resolved from node_modules")
+	}
+	if _, err := writeDevServerWrapper(dir, tool, securedAddr("myapp.test")); err != nil {
+		t.Fatal(err)
+	}
+
+	site, err := config.FindSite("myapp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	site.Secured = false
+	if err := config.AddSite(*site); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &fakeUnitLifecycle{}
+	podman.UnitLifecycle = fake
+	defer func() { podman.UnitLifecycle = nil }()
+
+	RefreshDevServers(site)
+
+	body, err := os.ReadFile(filepath.Join(dir, tool.WrapperPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `"http://myapp.test"`) {
+		t.Errorf("generated config still does not carry the site's plain origin:\n%s", body)
+	}
+	if fake.restartedUnit != "lerd-vite-myapp" {
+		t.Errorf("restarted unit = %q, want lerd-vite-myapp", fake.restartedUnit)
+	}
+}
+
+// Adding a domain has to reach the running server too: it answers only for the
+// hosts it was started with and refuses the new one outright.
+func TestRefreshDevServersFollowsAnAddedDomain(t *testing.T) {
+	dir := devServerSite(t, false)
+	tool := config.DevServerToolInstalled(dir)
+	if tool == nil {
+		t.Fatal("vite not resolved from node_modules")
+	}
+	plain := devServerAddrFor(false, "myapp.test", []string{"myapp.test"})
+	if _, err := writeDevServerWrapper(dir, tool, plain); err != nil {
+		t.Fatal(err)
+	}
+
+	site, err := config.FindSite("myapp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	site.Domains = append(site.Domains, "alias.test")
+	if err := config.AddSite(*site); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &fakeUnitLifecycle{}
+	podman.UnitLifecycle = fake
+	defer func() { podman.UnitLifecycle = nil }()
+
+	RefreshDevServers(site)
+
+	body, err := os.ReadFile(filepath.Join(dir, tool.WrapperPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `".alias.test"`) {
+		t.Errorf("generated config does not answer for the new domain:\n%s", body)
+	}
+	if !strings.Contains(string(body), `"http://alias.test"`) {
+		t.Errorf("generated config does not let a page on the new domain fetch assets:\n%s", body)
+	}
+	if fake.restartedUnit != "lerd-vite-myapp" {
+		t.Errorf("restarted unit = %q, want lerd-vite-myapp", fake.restartedUnit)
+	}
+}
+
+// A worktree fronts its own subdomain of the site, so it has to be realigned
+// against that rather than against the parent's domain.
+func TestRefreshDevServersFollowsAWorktreeSubdomain(t *testing.T) {
+	dir := devServerSite(t, false)
+	wt := addWorktree(t, dir, "feature")
+	tool := config.DevServerToolInstalled(wt)
+	if tool == nil {
+		t.Fatal("vite not resolved from the worktree's node_modules")
+	}
+	stale := devServerAddrFor(false, "feature.old.test", []string{"feature.old.test"})
+	if _, err := writeDevServerWrapper(wt, tool, stale); err != nil {
+		t.Fatal(err)
+	}
+
+	site, err := config.FindSite("myapp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	site.WorktreeDevPorts = map[string]int{filepath.Base(wt): 5174}
+	if err := config.AddSite(*site); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &fakeUnitLifecycle{}
+	podman.UnitLifecycle = fake
+	defer func() { podman.UnitLifecycle = nil }()
+
+	RefreshDevServers(site)
+
+	body, err := os.ReadFile(filepath.Join(wt, tool.WrapperPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `"http://feature.myapp.test"`) {
+		t.Errorf("worktree config does not carry its own subdomain:\n%s", body)
+	}
+	if fake.restartedUnit != "lerd-vite-myapp-"+config.WorktreeUnitSlug(filepath.Base(wt)) {
+		t.Errorf("restarted unit = %q, want the worktree's own unit", fake.restartedUnit)
+	}
+}
+
+// Nothing moved means nothing is bounced: the refresh runs from every path that
+// regenerates a vhost, including ones that leave the addresses exactly as they
+// were.
+func TestRefreshDevServersLeavesAnUnchangedSiteRunning(t *testing.T) {
+	dir := devServerSite(t, true)
+	tool := config.DevServerToolInstalled(dir)
+	if tool == nil {
+		t.Fatal("vite not resolved from node_modules")
+	}
+	if _, err := writeDevServerWrapper(dir, tool, securedAddr("myapp.test")); err != nil {
+		t.Fatal(err)
+	}
+	site, err := config.FindSite("myapp")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &fakeUnitLifecycle{}
+	podman.UnitLifecycle = fake
+	defer func() { podman.UnitLifecycle = nil }()
+
+	RefreshDevServers(site)
+
+	if fake.restartedUnit != "" {
+		t.Errorf("restarted unit = %q, want no restart", fake.restartedUnit)
+	}
+}

--- a/internal/cli/devserver_test.go
+++ b/internal/cli/devserver_test.go
@@ -22,10 +22,15 @@ func viteDevServer() *config.DevServerTool {
 		DefaultPort:   5173,
 		Wrapper: `import { mergeConfig } from 'vite';
 import projectConfig from %s;
-const lerd = { base: %s, server: { origin: %s, allowedHosts: %s } };
+const lerd = { base: %s, server: { origin: %s, allowedHosts: %s, cors: { origin: %s } } };
 export default projectConfig;
 `,
 	}
+}
+
+// securedAddr is the addresses a secured single-domain site hands the generator.
+func securedAddr(domain string) devServerAddr {
+	return devServerAddrFor(true, domain, []string{domain})
 }
 
 func gitRepo(t *testing.T, ignore string) string {
@@ -76,7 +81,7 @@ func TestWriteDevServerWrapperMergesBaseAndOrigin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rel, err := writeDevServerWrapper(dir, viteDevServer(), "https://myapp.test", []string{"myapp.test"})
+	rel, err := writeDevServerWrapper(dir, viteDevServer(), securedAddr("myapp.test"))
 	if err != nil {
 		t.Fatalf("writeDevServerWrapper() error: %v", err)
 	}
@@ -91,13 +96,127 @@ func TestWriteDevServerWrapperMergesBaseAndOrigin(t *testing.T) {
 	for _, want := range []string{
 		`"/@lerd-vite/"`,
 		`"https://myapp.test"`,
-		`"myapp.test"`,
+		`".myapp.test"`,
 		`"../../vite.config.js"`,
 		"mergeConfig",
 	} {
 		if !strings.Contains(string(body), want) {
 			t.Errorf("wrapper missing %s:\n%s", want, body)
 		}
+	}
+}
+
+// The vhost answers on every domain of the site and on each one's wildcard, so
+// the generated config has to name the same set: the hosts the server may answer
+// for, and the origins a page loaded on any of them fetches its assets from.
+func TestDevServerAddrCoversEveryDomainAndItsSubdomains(t *testing.T) {
+	addr := devServerAddrFor(true, "myapp.test", []string{"myapp.test", "alias.test"})
+
+	if addr.Origin != "https://myapp.test" {
+		t.Errorf("origin = %q, want https://myapp.test", addr.Origin)
+	}
+	if got, want := strings.Join(addr.Hosts, " "), ".myapp.test .alias.test"; got != want {
+		t.Errorf("hosts = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(addr.Origins, " "), "https://myapp.test https://alias.test"; got != want {
+		t.Errorf("cors origins = %q, want %q", got, want)
+	}
+}
+
+// A site served over plain HTTP has to be described that way, or the page ends
+// up asking for its assets over a scheme nothing is listening on.
+func TestDevServerAddrFollowsAPlainSite(t *testing.T) {
+	addr := devServerAddrFor(false, "myapp.test", []string{"myapp.test"})
+
+	if addr.Origin != "http://myapp.test" {
+		t.Errorf("origin = %q, want http://myapp.test", addr.Origin)
+	}
+	if got, want := strings.Join(addr.Origins, " "), "http://myapp.test"; got != want {
+		t.Errorf("cors origins = %q, want %q", got, want)
+	}
+}
+
+// Naming an origin makes some framework plugins use it as their whole CORS
+// allowlist, so a second domain of the same site has to be listed explicitly or
+// the browser refuses every asset the page just asked for.
+func TestWriteDevServerWrapperDeclaresCorsForEveryDomain(t *testing.T) {
+	dir := gitRepo(t, "/node_modules\n")
+	if err := os.WriteFile(filepath.Join(dir, "vite.config.js"), []byte("export default {}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	addr := devServerAddrFor(false, "myapp.test", []string{"myapp.test", "alias.test"})
+	rel, err := writeDevServerWrapper(dir, viteDevServer(), addr)
+	if err != nil {
+		t.Fatalf("writeDevServerWrapper() error: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, rel))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `cors: { origin: ["http://myapp.test","http://alias.test"] }`) {
+		t.Errorf("wrapper does not allow both domains to fetch from the server:\n%s", body)
+	}
+}
+
+// The tool reads the config once, at start, so a scheme that moved underneath a
+// running dev server has to be written back before it can be restarted onto it.
+func TestRewriteDevServerWrapperFollowsASchemeChange(t *testing.T) {
+	dir := gitRepo(t, "/node_modules\n")
+	if err := os.WriteFile(filepath.Join(dir, "vite.config.js"), []byte("export default {}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rel, err := writeDevServerWrapper(dir, viteDevServer(), securedAddr("myapp.test"))
+	if err != nil {
+		t.Fatalf("writeDevServerWrapper() error: %v", err)
+	}
+
+	plain := devServerAddrFor(false, "myapp.test", []string{"myapp.test"})
+	if !rewriteDevServerWrapper(dir, viteDevServer(), plain) {
+		t.Fatal("rewriteDevServerWrapper() = false, want the unsecured site to be written back")
+	}
+	body, err := os.ReadFile(filepath.Join(dir, rel))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "https://myapp.test") {
+		t.Errorf("config still advertises https:\n%s", body)
+	}
+	if !strings.Contains(string(body), `"http://myapp.test"`) {
+		t.Errorf("config does not advertise the site's plain origin:\n%s", body)
+	}
+}
+
+// Regeneration runs from every path that touches a vhost, most of which change
+// nothing here, and a needless rewrite would bounce a dev server someone is
+// working against.
+func TestRewriteDevServerWrapperLeavesAnUnchangedConfigAlone(t *testing.T) {
+	dir := gitRepo(t, "/node_modules\n")
+	if err := os.WriteFile(filepath.Join(dir, "vite.config.js"), []byte("export default {}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeDevServerWrapper(dir, viteDevServer(), securedAddr("myapp.test")); err != nil {
+		t.Fatalf("writeDevServerWrapper() error: %v", err)
+	}
+
+	if rewriteDevServerWrapper(dir, viteDevServer(), securedAddr("myapp.test")) {
+		t.Error("rewriteDevServerWrapper() = true for addresses that did not move")
+	}
+}
+
+// A project whose dev server has never run here has no generated config and
+// nothing pointed at one, so refreshing must not conjure one up.
+func TestRewriteDevServerWrapperSkipsAConfigItNeverWrote(t *testing.T) {
+	dir := gitRepo(t, "/node_modules\n")
+	if err := os.WriteFile(filepath.Join(dir, "vite.config.js"), []byte("export default {}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if rewriteDevServerWrapper(dir, viteDevServer(), securedAddr("myapp.test")) {
+		t.Error("rewriteDevServerWrapper() = true with no generated config on disk")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "node_modules/.lerd/vite.config.mjs")); err == nil {
+		t.Error("a config was generated for a dev server that has never started here")
 	}
 }
 
@@ -116,7 +235,7 @@ func TestWriteDevServerWrapperOverwritesInheritedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rel, err := writeDevServerWrapper(dir, viteDevServer(), "https://feature.myapp.test", []string{"feature.myapp.test"})
+	rel, err := writeDevServerWrapper(dir, viteDevServer(), securedAddr("feature.myapp.test"))
 	if err != nil {
 		t.Fatalf("writeDevServerWrapper() error: %v", err)
 	}
@@ -140,7 +259,7 @@ func TestWriteDevServerWrapperSkipsWhenPathIsTracked(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rel, err := writeDevServerWrapper(dir, viteDevServer(), "https://myapp.test", []string{"myapp.test"})
+	rel, err := writeDevServerWrapper(dir, viteDevServer(), securedAddr("myapp.test"))
 	if err != nil {
 		t.Fatalf("writeDevServerWrapper() error: %v", err)
 	}
@@ -172,7 +291,7 @@ func TestWriteDevServerWrapperSkipsWhenPathIsCommitted(t *testing.T) {
 		t.Fatalf("git add: %v (%s)", err, out)
 	}
 
-	rel, err := writeDevServerWrapper(dir, viteDevServer(), "https://myapp.test", []string{"myapp.test"})
+	rel, err := writeDevServerWrapper(dir, viteDevServer(), securedAddr("myapp.test"))
 	if err != nil {
 		t.Fatalf("writeDevServerWrapper() error: %v", err)
 	}
@@ -223,7 +342,7 @@ func TestWriteDevServerWrapperEscapesAHostileOrigin(t *testing.T) {
 
 	payload := "x'+process.env.AWS_SECRET_ACCESS_KEY+'"
 	origin := "https://" + payload
-	rel, err := writeDevServerWrapper(dir, tool, origin, []string{payload})
+	rel, err := writeDevServerWrapper(dir, tool, securedAddr(payload))
 	if err != nil {
 		t.Fatalf("writeDevServerWrapper() error: %v", err)
 	}
@@ -253,7 +372,7 @@ func TestWriteDevServerWrapperAppliesOutsideGit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rel, err := writeDevServerWrapper(dir, viteDevServer(), "https://myapp.test", []string{"myapp.test"})
+	rel, err := writeDevServerWrapper(dir, viteDevServer(), securedAddr("myapp.test"))
 	if err != nil {
 		t.Fatalf("writeDevServerWrapper() error: %v", err)
 	}

--- a/internal/cli/devserver_wire.go
+++ b/internal/cli/devserver_wire.go
@@ -1,0 +1,8 @@
+package cli
+
+import "github.com/geodro/lerd/internal/siteops"
+
+// Wire the dev server refresh to the siteops paths that move a site's addresses,
+// securing it and changing its domains, which the CLI, the UI and MCP all share.
+// The mechanism lives in this package, so the hook is filled in from here.
+func init() { siteops.RefreshDevServers = RefreshDevServers }

--- a/internal/config/devserver.go
+++ b/internal/config/devserver.go
@@ -24,9 +24,10 @@ type DevServerTool struct {
 	WrapperPath string
 	// Args is appended to the worker command, with {config} and {port} filled in.
 	Args string
-	// Wrapper is the generated config, taking the import path, base, origin and
-	// allowed hosts. Every placeholder is filled with an encoded JavaScript
-	// literal, so none of them carries its own quotes.
+	// Wrapper is the generated config, taking the import path, base, origin,
+	// allowed hosts and the origins allowed to fetch from the server. Every
+	// placeholder is filled with an encoded JavaScript literal, so none of them
+	// carries its own quotes.
 	Wrapper     string
 	DefaultPort int
 }
@@ -49,6 +50,10 @@ const lerd = {
         host: true,
         origin: %s,
         allowedHosts: %s,
+        // Naming an origin makes some framework plugins treat it as the whole
+        // CORS allowlist, so a page on any other domain of the site would be
+        // refused the assets it just asked for. Declare them all.
+        cors: { origin: %s },
     },
 };
 

--- a/internal/siteops/devserver.go
+++ b/internal/siteops/devserver.go
@@ -1,0 +1,13 @@
+package siteops
+
+import "github.com/geodro/lerd/internal/config"
+
+// RefreshDevServers realigns a site's generated dev server config, and the dev
+// server running on it, with the addresses the site now answers on. A dev server
+// reads its origin and its allowed hosts once, at start, so securing a site or
+// moving its domains leaves it serving an address that has gone.
+//
+// The mechanism lives in the cli package, which wires the real implementation in
+// (see internal/cli/devserver_wire.go); the default is a no-op so a binary that
+// does not link it, and every test in this package, behaves as before.
+var RefreshDevServers = func(*config.Site) {}

--- a/internal/siteops/devserver_test.go
+++ b/internal/siteops/devserver_test.go
@@ -1,0 +1,65 @@
+package siteops
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// recordDevServerRefresh captures the sites handed to the dev server refresh, so
+// a test can assert that a path which moves a site's addresses reaches it.
+func recordDevServerRefresh(t *testing.T) *[]string {
+	t.Helper()
+	var seen []string
+	orig := RefreshDevServers
+	RefreshDevServers = func(site *config.Site) {
+		if site != nil {
+			seen = append(seen, site.Name)
+		}
+	}
+	t.Cleanup(func() { RefreshDevServers = orig })
+	return &seen
+}
+
+// A dev server reads the site's scheme once, at start, so unsecuring a site has
+// to reach it or every asset URL on the page keeps naming https.
+func TestSetSecuredRefreshesTheDevServer(t *testing.T) {
+	stubSecureDeps(t)
+	projectDir := withTempEnv(t)
+	seen := recordDevServerRefresh(t)
+
+	site := &config.Site{Name: "myapp", Domains: []string{"myapp.test"}, Path: projectDir, Secured: true}
+	if err := config.AddSite(*site); err != nil {
+		t.Fatalf("seed site: %v", err)
+	}
+
+	if err := SetSecured(site, false); err != nil {
+		t.Fatalf("SetSecured: %v", err)
+	}
+
+	if len(*seen) != 1 || (*seen)[0] != "myapp" {
+		t.Errorf("dev server refreshed for %v, want [myapp]", *seen)
+	}
+}
+
+// Every caller that changes a site's domains regenerates its vhost, so that is
+// where the dev server's allowed hosts are brought along.
+func TestRegenerateSiteVhostRefreshesTheDevServer(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	seen := recordDevServerRefresh(t)
+
+	site := &config.Site{
+		Name:       "myapp",
+		Domains:    []string{"myapp.test", "alias.test"},
+		Path:       t.TempDir(),
+		PHPVersion: "8.4",
+	}
+	if err := RegenerateSiteVhost(site, "myapp.test"); err != nil {
+		t.Fatalf("RegenerateSiteVhost: %v", err)
+	}
+
+	if len(*seen) != 1 || (*seen)[0] != "myapp" {
+		t.Errorf("dev server refreshed for %v, want [myapp]", *seen)
+	}
+}

--- a/internal/siteops/secure.go
+++ b/internal/siteops/secure.go
@@ -58,7 +58,9 @@ func defaultNotifyDaemon(domain, action string) error {
 //     for these, so even callers running inside the daemon hit the same
 //     HTTP endpoints; a tiny loopback roundtrip is the cost of having one
 //     identical post-toggle path.
-//  7. Cascade to the group secondaries when the site is a secured group main,
+//  7. Realign the generated dev server config, and any dev server running on
+//     the old scheme, with the site's new one.
+//  8. Cascade to the group secondaries when the site is a secured group main,
 //     and refuse to unsecure a secondary whose main is secured (see #811).
 func SetSecured(site *config.Site, secured bool) error {
 	_, err := SetSecuredCascade(site, secured)
@@ -101,6 +103,7 @@ func SetSecuredCascade(site *config.Site, secured bool) ([]string, error) {
 	}
 	_ = notifyDaemonFn(site.PrimaryDomain(), "stripe:refresh")
 	_ = notifyDaemonFn(site.PrimaryDomain(), "lan:refresh")
+	RefreshDevServers(site)
 	if secured && site.IsGroupMain() {
 		return cascadeGroupSecondaries(site)
 	}

--- a/internal/siteops/vhost.go
+++ b/internal/siteops/vhost.go
@@ -13,7 +13,9 @@ import (
 
 // RegenerateSiteVhost regenerates the nginx vhost for a site after domain changes.
 // If the primary domain changed, the old vhost file is removed. For secured sites
-// the SSL vhost is generated and renamed to the main .conf path.
+// the SSL vhost is generated and renamed to the main .conf path. Every caller that
+// changes a site's domains comes through here, so it is also where a running dev
+// server is realigned with them.
 func RegenerateSiteVhost(site *config.Site, oldPrimary string) error {
 	newPrimary := site.PrimaryDomain()
 
@@ -71,6 +73,9 @@ func RegenerateSiteVhost(site *config.Site, oldPrimary string) error {
 			return fmt.Errorf("generating vhost: %w", err)
 		}
 	}
+	// A dev server serving under this vhost has the site's domains baked into the
+	// config it was started with, so it follows the vhost that just moved.
+	RefreshDevServers(site)
 	if podman.AfterUnitChange != nil {
 		podman.AfterUnitChange("site:" + site.Name)
 	}


### PR DESCRIPTION
A dev server reads the origin and the allowed hosts lerd generates for it once, when it starts, and nothing revisited them afterwards. Unsecuring a site left the server still advertising https, so every asset URL on the page named a scheme the site no longer serves and it arrived unstyled, which is the very thing the base prefix exists to prevent. Securing a running site failed the same way in reverse, with the plain URLs refused as mixed content, and moving a domain surfaced as the server rejecting the host outright.

The generated config, and the server running on it, now follow from the two places every caller already shares: the HTTPS toggle, and the vhost regeneration that every domain change goes through. The CLI, the UI, MCP and the group cascade all reach it without any of them naming it. What gets rewritten is decided from the contents of the config rather than from the event, so the many paths that regenerate a vhost without moving an address never bounce a dev server somebody is working against, and one that is not running is left down. The port never moves, since the unit holds it and nginx already proxies there.

Multiple domains needed more than regeneration. An origin can name only one domain, so assets always resolve to the primary, which is inherent. What was not inherent is that naming an origin at all makes some framework plugins adopt it as their entire CORS allowlist, in place of a default that accepted any domain of the site, so a page opened on a second domain had every module script refused. The generated config declares those origins itself now.

The allowed hosts mirror the vhost as well. It answers on each domain and on that domain's wildcard, which is how a worktree subdomain reaches the dev server, and listing only the bare domains left the server blocking everything else that arrived.

Closes #1240
