### PR TITLE
Add a supported wait for the worktree setup pipeline

### DIFF
--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -14,7 +14,7 @@ Plain `git worktree add` from any tool (CLI, IDE, GitLens) is enough to get a us
 
 ## `lerd worktree add` and `lerd worktree remove`
 
-The wrapper commands mirror `git worktree`'s subcommand layout, every flag passes straight through to git, and add an interactive setup pipeline on top.
+The wrapper commands mirror `git worktree`'s subcommand layout, every flag passes straight through to git, and add an interactive setup pipeline on top. `lerd worktree wait` is the non-interactive companion for scripts and tools that use plain git, see [waiting for the pipeline](#waiting-for-the-pipeline).
 
 ### `lerd worktree add <git args>`
 
@@ -76,6 +76,25 @@ Frontend build (`npm run build`) is **not** part of the watcher pipeline, it's h
 ::: info Why not symlink?
 Earlier lerd versions symlinked `vendor/` to save disk. PHP resolves `__DIR__` through symlinks to the real path, so Composer's `ClassLoader` would initialise against the main repo and silently load stale classes. Real copies (or reflinks) avoid the problem at no meaningful disk cost on modern filesystems.
 :::
+
+### Waiting for the pipeline
+
+A tool that creates a worktree and then wants to act on it, run tests, run a composer script, seed config, has to let the pipeline finish first, or the two write the same tree at once. `lerd worktree wait` blocks until it settles:
+
+```bash
+git worktree add ../myapp-feature feature/auth
+lerd worktree wait ../myapp-feature --timeout 10m
+```
+
+Without a path it waits on the current directory. Nothing is printed on success, the exit status is the contract:
+
+| Status | Meaning |
+|---|---|
+| `0` | Provisioned, and no install is running. |
+| `1` | The timeout elapsed first. |
+| `3` | This path is not a worktree lerd manages, so nothing will ever provision it. |
+
+Do not try to infer this from the tree's contents. Composer's extraction phase fills *existing* `vendor/<org>/` directories, so neither an entry count nor a shallow mtime moves during the longest part of an install, and `node_modules/` exists from the first extracted package. The command watches the pipeline's outputs and its install lock together, which is why it can tell a finished install from one still running. `lerd worktree add` uses the same wait internally.
 
 ---
 

--- a/docs/features/mcp.md
+++ b/docs/features/mcp.md
@@ -130,10 +130,18 @@ The MCP surface is **twelve grouped tools**, each driven by an `action` argument
 | `framework` | `list`, `add`, `remove`, `prune`, `search`, `update`, `project_new`, `setup` |
 | `diag` | `status`, `doctor`, `doctor_fix`, `site_doctor`, `which`, `check`, `dns_diagnose`, `bug_report`, `analyze_queries`, `route_timing`, `optimize_route`, `dumps_recent`, `dumps_status`, `dumps_clear`, `dumps_toggle`, `profiler_toggle`, `profiler_status`, `profiler_clear`, `profiler_report`, `xdebug_on`, `xdebug_off`, `xdebug_status` |
 | `logs` | `sources`, `fetch` |
-| `worktree` | `list`, `add`, `remove`, `db_isolate`, `db_share` |
+| `worktree` | `list`, `add`, `remove`, `wait`, `db_isolate`, `db_share` |
 | `workspace` | `list`, `create`, `rename`, `delete`, `assign`, `move` |
 
 The injected context files document each action's arguments and the key conventions in full.
+
+### Creating a worktree from an assistant
+
+`worktree add` blocks until the watcher's setup pipeline has finished and reports `provisioned: true`, because the pipeline starts the moment git writes the worktree entry, and an action that returned earlier would hand back a tree being written underneath the assistant. Two installers in one tree is how `vendor/` ends up with packages extracted but no `autoload.php`, which then presents as a Composer autoload bug rather than a race.
+
+`wait` is the same check on its own, for a worktree created with plain git or after `add` with `wait=false`. Both accept `timeout_seconds` (default 300) and report `provisioned: false` with a note rather than an error when setup is still running, since an unfinished install is a "not yet", not a failure.
+
+An assistant should never infer readiness from the tree's contents. `node_modules/` exists from the first extracted package, and composer's extraction phase fills *existing* `vendor/<org>/` directories, so neither a file count nor an mtime moves during the longest stretch of an install. Both read as finished mid-install.
 
 ### Workspaces are not site groups
 

--- a/internal/cli/aidocs/lerd-reference.md
+++ b/internal/cli/aidocs/lerd-reference.md
@@ -131,8 +131,9 @@ Actions: `sources`, `fetch`. Debug without opening files by hand.
 - entries come back chronological (oldest first). Raw logs with no timestamps ignore `since`/`level` and just return the last N; a not-running container returns partial output, not an error
 
 #### `worktree` — git worktrees
-Actions: `list`, `add`, `remove`, `db_isolate`, `db_share`.
-- `add` installs deps and offers an asset-worker / build-step prompt; secured sites get `*.<branch>.<site>.test` wildcard cert SANs + nginx `server_name` automatically
+Actions: `list`, `add`, `remove`, `wait`, `db_isolate`, `db_share`.
+- `add` installs deps and offers an asset-worker / build-step prompt; secured sites get `*.<branch>.<site>.test` wildcard cert SANs + nginx `server_name` automatically. It waits for setup and reports `provisioned` (`false` + note means still running, not failed; `timeout_seconds` default 300)
+- `wait` is that readiness check alone, for a worktree made with plain `git worktree add`. **Never** judge readiness from the tree: `node_modules/` exists from the first extracted package and composer fills *existing* `vendor/<org>/` dirs, so both read as finished mid-install, and racing the watcher is how `vendor/` ends up with no `autoload.php`
 - `db_isolate` gives a worktree its own database (seed via `source`: empty|main|<branch>); `db_share` points it back at the main; `remove` keeps an isolated DB unless `keep_db: false`
 - a framework definition can declare what its worktrees need (an isolated database, what it is cloned from, console commands to run once it is in place), so `add` does that work rather than leaving it to be run by hand
 - request timing is recorded per worktree; pass `branch` to `route_timing`, `optimize_route` and `dumps_recent` to read one branch's traffic

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -580,9 +580,12 @@ func TestIsLerdBuiltImage_matchers(t *testing.T) {
 // `doctor_fix` action, then 28700 → 29400 for the runtime `ini_*` php.ini
 // actions and the shared-vs-per-version guidance, then 29400 → 29700 for the
 // fnm/nvm version-manager choice (`node.manager`), then 29700 → 30300 for the
-// db `import` provider-dump handling and the `php_list` base-image update flag.
+// db `import` provider-dump handling and the `php_list` base-image update flag,
+// then 30300 → 30800 for the worktree `wait` action and the readiness rule it
+// exists to replace: an assistant that guesses from the tree's contents races
+// the watcher's installer, and no amount of probing files can tell it apart.
 func TestLerdReference_underSizeCeiling(t *testing.T) {
-	const ceiling = 30300
+	const ceiling = 30800
 	if got := len(lerdReference); got > ceiling {
 		t.Errorf("lerd-reference.md is %d bytes, ceiling is %d — trim before raising", got, ceiling)
 	}

--- a/internal/cli/worktree_add.go
+++ b/internal/cli/worktree_add.go
@@ -28,6 +28,7 @@ func NewWorktreeCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newWorktreeAddCmd())
 	cmd.AddCommand(newWorktreeRemoveCmd())
+	cmd.AddCommand(newWorktreeWaitCmd())
 	return cmd
 }
 
@@ -308,15 +309,36 @@ func WaitForWorktreeReady(worktreePath string, deadline time.Duration) error {
 	hasComposer := fileExistsAt(filepath.Join(worktreePath, "composer.json"))
 	hasJS := fileExistsAt(filepath.Join(worktreePath, "package.json"))
 	for time.Now().Before(end) {
-		envOk := fileExistsAt(filepath.Join(worktreePath, ".env"))
-		composerOk := !hasComposer || fileExistsAt(filepath.Join(worktreePath, "vendor", "autoload.php"))
-		jsOk := !hasJS || fileExistsAt(filepath.Join(worktreePath, "node_modules"))
-		if envOk && composerOk && jsOk {
+		if worktreeArtifactsPresent(worktreePath, hasComposer, hasJS) && !installInFlight(worktreePath) {
 			return nil
 		}
 		time.Sleep(2 * time.Second)
 	}
 	return fmt.Errorf("timed out after %s waiting for worktree setup", deadline)
+}
+
+// worktreeArtifactsPresent reports whether the pipeline's outputs are on disk.
+// Necessary but not sufficient on its own: node_modules exists as soon as the
+// first package is extracted, so a live npm ci already satisfies it.
+func worktreeArtifactsPresent(worktreePath string, hasComposer, hasJS bool) bool {
+	if !fileExistsAt(filepath.Join(worktreePath, ".env")) {
+		return false
+	}
+	if hasComposer && !fileExistsAt(filepath.Join(worktreePath, "vendor", "autoload.php")) {
+		return false
+	}
+	if hasJS && !fileExistsAt(filepath.Join(worktreePath, "node_modules")) {
+		return false
+	}
+	return true
+}
+
+// installInFlight reports whether an installer holds the worktree's install
+// lock. A probe that fails outright counts as idle so an unreadable lock dir
+// degrades to the old artifact-only behaviour instead of waiting forever.
+func installInFlight(worktreePath string) bool {
+	held, err := gitpkg.InstallInFlight(worktreePath)
+	return err == nil && held
 }
 
 func fileExistsAt(path string) bool {

--- a/internal/cli/worktree_wait.go
+++ b/internal/cli/worktree_wait.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
+	"github.com/spf13/cobra"
+)
+
+// ErrNotLerdWorktree marks a path lerd does not manage as a worktree, which
+// callers have to tell apart from a timeout: one means "ask someone else", the
+// other means "still going".
+var ErrNotLerdWorktree = errors.New("not a worktree lerd manages")
+
+// exitNotLerdWorktree is the distinct status for ErrNotLerdWorktree. 1 stays
+// the timeout, and 2 is left alone because cobra spends it on usage errors.
+const exitNotLerdWorktree = 3
+
+// newWorktreeWaitCmd is the non-interactive half of `lerd worktree add`'s wait,
+// for tools that create a worktree with plain git and need to know when lerd has
+// finished provisioning it before they touch the tree themselves.
+func newWorktreeWaitCmd() *cobra.Command {
+	var timeout time.Duration
+	cmd := &cobra.Command{
+		Use:   "wait [path]",
+		Short: "Block until lerd's setup pipeline has finished for a worktree",
+		Long: `Block until lerd's watcher-driven setup pipeline has finished for a worktree,
+so a tool that created one with plain git can wait before acting on the tree.
+
+Without a path, the current directory is used. Nothing is printed on success;
+the exit status is the contract:
+
+  0  the worktree is provisioned and no install is running
+  1  the timeout elapsed first
+  3  this path is not a worktree lerd manages
+
+Waiting covers both the pipeline's outputs (.env, vendor/autoload.php,
+node_modules) and its install lock, because node_modules exists from the first
+extracted package and would otherwise read as finished mid-install.`,
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			path := ""
+			if len(args) == 1 {
+				path = args[0]
+			}
+			err := WaitForManagedWorktree(path, timeout)
+			if errors.Is(err, ErrNotLerdWorktree) {
+				feedback.Fail(err)
+				os.Exit(exitNotLerdWorktree)
+			}
+			return err
+		},
+	}
+	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Minute, "How long to wait before giving up")
+	return cmd
+}
+
+// WaitForManagedWorktree resolves path (empty means the current directory),
+// confirms lerd manages it as a worktree, then blocks until its setup pipeline
+// has settled. Rejecting an unmanaged path up front matters: nothing would ever
+// provision it, so waiting could only ever end in a timeout.
+func WaitForManagedWorktree(path string, timeout time.Duration) error {
+	if path == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		path = cwd
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	if _, ok := config.ParentSiteForWorktreeDir(abs); !ok {
+		return fmt.Errorf("%w: %s", ErrNotLerdWorktree, abs)
+	}
+	return WaitForWorktreeReady(abs, timeout)
+}

--- a/internal/cli/worktree_wait_test.go
+++ b/internal/cli/worktree_wait_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/geodro/lerd/internal/config"
+	gitpkg "github.com/geodro/lerd/internal/git"
+)
+
+// registerWorktreeSite wires a registered site plus one worktree checkout, the
+// shape ParentSiteForWorktreeDir recognises, and returns the checkout path.
+func registerWorktreeSite(t *testing.T, branch string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	site := filepath.Join(t.TempDir(), "app")
+	wt := filepath.Join(site, "wt", branch)
+	makeWorktree(t, site, wt, branch)
+	if err := config.AddSite(config.Site{Name: "app", Path: site, PHPVersion: "8.4"}); err != nil {
+		t.Fatal(err)
+	}
+	return wt
+}
+
+// A path lerd does not manage has to be rejected outright. Callers need "not
+// mine" to be distinguishable from "gave up", and burning the whole timeout on
+// a path that will never be provisioned would make the command useless in a hook.
+func TestWaitForManagedWorktree_rejectsUnmanagedPathWithoutWaiting(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmp, "data"))
+
+	start := time.Now()
+	err := WaitForManagedWorktree(t.TempDir(), 30*time.Second)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrNotLerdWorktree) {
+		t.Fatalf("err = %v, want ErrNotLerdWorktree", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("took %s, must fail fast rather than wait out the timeout", elapsed)
+	}
+}
+
+// The parent site's own path is not a worktree, so it gets the same rejection
+// rather than a wait that can never be satisfied.
+func TestWaitForManagedWorktree_rejectsTheParentSitePath(t *testing.T) {
+	wt := registerWorktreeSite(t, "feature")
+	sitePath := filepath.Dir(filepath.Dir(wt))
+
+	if err := WaitForManagedWorktree(sitePath, 2*time.Second); !errors.Is(err, ErrNotLerdWorktree) {
+		t.Errorf("err = %v, want ErrNotLerdWorktree for the parent checkout", err)
+	}
+}
+
+func TestWaitForManagedWorktree_returnsOnceSettled(t *testing.T) {
+	wt := registerWorktreeSite(t, "feature")
+	if err := os.WriteFile(filepath.Join(wt, ".env"), []byte("APP_ENV=local\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WaitForManagedWorktree(wt, 10*time.Second); err != nil {
+		t.Errorf("WaitForManagedWorktree: %v", err)
+	}
+}
+
+// The regression this command exists for. node_modules/ appears with the first
+// extracted package, so the artifact checks alone call a mid-flight npm ci
+// finished; while an installer holds the lock the wait must not report ready.
+func TestWaitForWorktreeReady_waitsOutAnInstallHoldingTheLock(t *testing.T) {
+	wt := registerWorktreeSite(t, "feature")
+	for name, body := range map[string]string{
+		".env":                "APP_ENV=local\n",
+		"composer.json":       "{}\n",
+		"package.json":        "{}\n",
+		"vendor/autoload.php": "<?php\n",
+	} {
+		p := filepath.Join(wt, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Present but mid-install, the state every content heuristic misreads.
+	if err := os.MkdirAll(filepath.Join(wt, "node_modules", "lodash"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	release, err := gitpkg.LockInstall(wt, 5*time.Second)
+	if err != nil {
+		t.Fatalf("LockInstall: %v", err)
+	}
+	if err := WaitForWorktreeReady(wt, 3*time.Second); err == nil {
+		release()
+		t.Fatal("reported ready while an installer still held the lock")
+	}
+
+	release()
+	if err := WaitForWorktreeReady(wt, 10*time.Second); err != nil {
+		t.Errorf("after the install released the lock: %v", err)
+	}
+}
+
+func TestWaitForWorktreeReady_timesOutWhenArtifactsNeverAppear(t *testing.T) {
+	wt := registerWorktreeSite(t, "feature")
+
+	if err := WaitForWorktreeReady(wt, 2*time.Second); err == nil {
+		t.Error("want a timeout error when .env never lands")
+	}
+}

--- a/internal/git/install_lock.go
+++ b/internal/git/install_lock.go
@@ -114,6 +114,35 @@ func TryLockInstall(worktreePath string) (func(), bool, error) {
 	}, true, nil
 }
 
+// InstallInFlight reports whether an installer currently holds worktreePath's
+// install lock, the one signal about install progress that cannot lie. It
+// probes with a shared non-blocking flock rather than TryLockInstall so it
+// neither overwrites the pid the real holder recorded nor takes an exclusive
+// lock an installer would then have to poll for.
+//
+// A missing lock file means no install has ever started for the path, so it is
+// reported as idle. The file deliberately outlives the install that created it,
+// which is why its presence, and the pid inside it, mean nothing on their own.
+func InstallInFlight(worktreePath string) (bool, error) {
+	path, err := installLockFile(worktreePath)
+	if err != nil {
+		return false, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer f.Close() //nolint:errcheck
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_SH|syscall.LOCK_NB); err != nil {
+		return true, nil
+	}
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return false, nil
+}
+
 // lockWithDeadline polls TryLock until success or deadline.
 func lockWithDeadline(mu *sync.Mutex, deadline time.Time) bool {
 	for {

--- a/internal/git/install_lock_test.go
+++ b/internal/git/install_lock_test.go
@@ -62,3 +62,55 @@ func TestLockInstall_serializesInProcess(t *testing.T) {
 		t.Errorf("max concurrent holders = %d, want 1", got)
 	}
 }
+
+// InstallInFlight is the signal external tools need in place of guessing from
+// directory contents. It must report a running install, go quiet once that
+// install finishes, and never be fooled by the lock file left behind, which is
+// exactly the trap that makes existence and pid checks useless.
+func TestInstallInFlight(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	dir := t.TempDir()
+
+	if held, err := InstallInFlight(dir); err != nil || held {
+		t.Fatalf("before any install: held=%v err=%v, want held=false", held, err)
+	}
+
+	release, err := LockInstall(dir, 5*time.Second)
+	if err != nil {
+		t.Fatalf("LockInstall: %v", err)
+	}
+	held, err := InstallInFlight(dir)
+	if err != nil {
+		t.Fatalf("InstallInFlight while lock held: %v", err)
+	}
+	if !held {
+		t.Error("must report in flight while an installer holds the lock")
+	}
+	release()
+
+	if held, err := InstallInFlight(dir); err != nil || held {
+		t.Errorf("after release, with the lock file still on disk: held=%v err=%v, want held=false", held, err)
+	}
+}
+
+// The probe must not disturb a real installer: it may not take the exclusive
+// lock, so an install starting immediately after a probe still acquires at once.
+func TestInstallInFlight_leavesLockAcquirable(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	dir := t.TempDir()
+
+	release, err := LockInstall(dir, 5*time.Second)
+	if err != nil {
+		t.Fatalf("seed lock: %v", err)
+	}
+	release()
+
+	if _, err := InstallInFlight(dir); err != nil {
+		t.Fatalf("InstallInFlight: %v", err)
+	}
+	release2, err := LockInstall(dir, 2*time.Second)
+	if err != nil {
+		t.Fatalf("an installer must still acquire right after a probe: %v", err)
+	}
+	release2()
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -257,8 +257,12 @@ func TestToolList_underSizeCeiling(t *testing.T) {
 	// surface at all: db `extension_list`/`extension_add`, service `entities`/
 	// `entity_action` (everything a preset declares that is not a database), and
 	// runtime `node_manager`. Description verbosity in the same three tools was
-	// trimmed to pay for part of it.
-	const ceiling = 22100
+	// trimmed to pay for part of it, then 22100 → 22450 for the worktree `wait`
+	// action and its `wait` / `timeout_seconds` properties, another capability
+	// with no MCP surface at all: without it an assistant cannot tell a finished
+	// install from a running one and races the watcher inside the tree. The
+	// worktree description was merged and trimmed to pay for half of it.
+	const ceiling = 22450
 	got, err := json.Marshal(toolList())
 	if err != nil {
 		t.Fatalf("marshal tool list: %v", err)

--- a/internal/mcp/worktree.go
+++ b/internal/mcp/worktree.go
@@ -1,11 +1,13 @@
 package mcp
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
 	gitpkg "github.com/geodro/lerd/internal/git"
@@ -19,17 +21,19 @@ import (
 func worktreeTool() mcpTool {
 	return mcpTool{
 		Name:        "worktree",
-		Description: "Manage git worktrees. list / add / remove / db_isolate (empty|main|<branch>) / db_share. Watcher auto-installs deps on add and presents a unified asset-worker / npm-build prompt (workers with replaces_build+per_worktree appear alongside npm scripts; picked workers start ad-hoc with persist=false). Worktrees on secured sites get *.branch.domain.test wildcard cert SANs and nginx server_name automatically. .lerd.yaml env_overrides ({{domain}}/{{scheme}}/{{site}} placeholders) layers per-worktree env vars on top of the APP_URL rewrite. Workers with per_worktree:true run under lerd-<wname>-<site>-<wt> units. Remove keeps isolated DB unless keep_db=false.",
+		Description: "Manage git worktrees. list / add / remove / wait / db_isolate (empty|main|<branch>) / db_share. Watcher auto-installs deps on add; add waits for that and reports provisioned, and wait does the same for a worktree made with plain git. Never judge readiness from tree contents, they read as finished mid-install. add also presents a unified asset-worker / npm-build prompt (replaces_build+per_worktree workers alongside npm scripts; picks start with persist=false). Worktrees on secured sites get *.branch.domain.test wildcard cert SANs and nginx server_name automatically. .lerd.yaml env_overrides ({{domain}}/{{scheme}}/{{site}} placeholders) layers per-worktree env vars on top of the APP_URL rewrite. Workers with per_worktree:true run under lerd-<wname>-<site>-<wt> units. Remove keeps isolated DB unless keep_db=false.",
 		InputSchema: mcpSchema{
 			Type: "object",
 			Properties: map[string]mcpProp{
-				"action":   {Type: "string", Enum: []string{"list", "add", "remove", "db_isolate", "db_share"}},
-				"site":     {Type: "string", Description: "Defaults to cwd's site."},
-				"branch":   {Type: "string"},
-				"git_args": {Type: "array", Description: "Forwarded to git worktree."},
-				"force":    {Type: "boolean", Description: "remove: --force."},
-				"keep_db":  {Type: "boolean", Description: "remove: preserve DB (default true)."},
-				"source":   {Type: "string", Description: "db_isolate seed."},
+				"action":          {Type: "string", Enum: []string{"list", "add", "remove", "wait", "db_isolate", "db_share"}},
+				"site":            {Type: "string", Description: "Defaults to cwd's site."},
+				"branch":          {Type: "string"},
+				"git_args":        {Type: "array", Description: "Forwarded to git worktree."},
+				"force":           {Type: "boolean", Description: "remove: --force."},
+				"keep_db":         {Type: "boolean", Description: "remove: preserve DB (default true)."},
+				"source":          {Type: "string", Description: "db_isolate seed."},
+				"wait":            {Type: "boolean", Description: "add: wait for setup (default true)."},
+				"timeout_seconds": {Type: "integer", Description: "add/wait: seconds, default 300."},
 			},
 			Required: []string{"action"},
 		},
@@ -44,6 +48,8 @@ func dispatchWorktree(args map[string]any) (any, *rpcError) {
 		return execWorktreeAdd(args)
 	case "remove":
 		return execWorktreeRemove(args)
+	case "wait":
+		return execWorktreeWait(args)
 	case "db_isolate":
 		return execWorktreeDBIsolate(args)
 	case "db_share":
@@ -147,11 +153,63 @@ func execWorktreeAdd(args map[string]any) (any, *rpcError) {
 			gitArgs = append(gitArgs, fmt.Sprint(v))
 		}
 	}
+	before := worktreePaths(site)
 	out, err := runIn(site.Path, "git", gitArgs...)
 	if err != nil {
 		return toolErr("git " + strings.Join(gitArgs, " ") + ": " + out), nil
 	}
-	return toolJSON(map[string]any{"ok": true, "site": site.Name, "output": out}), nil
+	resp := map[string]any{"ok": true, "site": site.Name, "output": out}
+	// The watcher starts installing the moment git writes the worktree entry, so
+	// returning here would hand back a tree being written underneath the caller.
+	// Waiting is the default because acting on the tree is the whole point of
+	// creating it; wait=false is for a caller that only wants the checkout.
+	if path := addedWorktreePath(site, before); path != "" {
+		resp["path"] = path
+		if wantsWorktreeWait(args) {
+			code, waitOut := worktreeWaitFn(path, worktreeWaitTimeout(args))
+			resp["provisioned"] = code == 0
+			if code != 0 {
+				resp["note"] = "setup has not finished; call action=wait before writing to this tree"
+				if waitOut != "" {
+					resp["wait_output"] = waitOut
+				}
+			}
+		}
+	}
+	return toolJSON(resp), nil
+}
+
+// execWorktreeWait blocks until lerd's setup pipeline has settled for a
+// worktree, so an assistant that created one with plain git (or declined the
+// wait on add) can tell "safe to touch" from "still installing" instead of
+// guessing from directory contents.
+func execWorktreeWait(args map[string]any) (any, *rpcError) {
+	site, errResp := resolveSiteForWorktree(args)
+	if errResp != nil {
+		return errResp, nil
+	}
+	branch := branchFromArgs(args, site)
+	if branch == "" {
+		return toolErr("branch required (or run from inside the worktree's checkout)"), nil
+	}
+	wtPath := worktreePathFor(site, branch)
+	if wtPath == "" {
+		return toolErr("worktree path for branch " + branch + " not on disk"), nil
+	}
+	code, out := worktreeWaitFn(wtPath, worktreeWaitTimeout(args))
+	resp := map[string]any{
+		"site":        site.Name,
+		"branch":      branch,
+		"path":        wtPath,
+		"provisioned": code == 0,
+	}
+	if out != "" {
+		resp["output"] = out
+	}
+	if code != 0 {
+		resp["note"] = "setup has not finished; do not write to this tree yet"
+	}
+	return toolJSON(resp), nil
 }
 
 func execWorktreeRemove(args map[string]any) (any, *rpcError) {
@@ -264,6 +322,69 @@ func runIn(dir, name string, args ...string) (string, error) {
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
+}
+
+// worktreeWaitFn is the seam the wait goes through, so tests need neither a
+// lerd binary on PATH nor a running watcher.
+var worktreeWaitFn = shellWorktreeWait
+
+// shellWorktreeWait defers to `lerd worktree wait`, which is the only check that
+// accounts for the install lock and not just the pipeline's outputs. Shelling
+// out keeps cli the single source of truth for the lifecycle; importing it here
+// would be an import cycle. Returns the exit status: 0 settled, 1 timed out,
+// 3 not a worktree lerd manages.
+func shellWorktreeWait(worktreePath string, timeout time.Duration) (int, string) {
+	out, err := runIn(worktreePath, lerdSelf(), "worktree", "wait", "--timeout", timeout.String())
+	if err == nil {
+		return 0, out
+	}
+	var exit *exec.ExitError
+	if errors.As(err, &exit) {
+		return exit.ExitCode(), out
+	}
+	return -1, out
+}
+
+// wantsWorktreeWait reports whether add should block on setup. Absent means
+// yes: a caller that did not think about it is better served waiting.
+func wantsWorktreeWait(args map[string]any) bool {
+	if v, ok := args["wait"].(bool); ok {
+		return v
+	}
+	return true
+}
+
+func worktreeWaitTimeout(args map[string]any) time.Duration {
+	return time.Duration(intArg(args, "timeout_seconds", 300)) * time.Second
+}
+
+// worktreePaths returns the checkout paths currently on disk, so the caller can
+// diff before and after a git call instead of re-parsing git_args to guess where
+// the new worktree landed.
+func worktreePaths(site *config.Site) map[string]bool {
+	out := map[string]bool{}
+	wts, err := gitpkg.DetectWorktrees(site.Path, site.PrimaryDomain())
+	if err != nil {
+		return out
+	}
+	for _, wt := range wts {
+		out[wt.Path] = true
+	}
+	return out
+}
+
+// addedWorktreePath returns the one checkout that appeared since before.
+func addedWorktreePath(site *config.Site, before map[string]bool) string {
+	wts, err := gitpkg.DetectWorktrees(site.Path, site.PrimaryDomain())
+	if err != nil {
+		return ""
+	}
+	for _, wt := range wts {
+		if !before[wt.Path] {
+			return wt.Path
+		}
+	}
+	return ""
 }
 
 func worktreePathFor(site *config.Site, sanitizedBranch string) string {

--- a/internal/mcp/worktree_test.go
+++ b/internal/mcp/worktree_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
 )
@@ -79,5 +80,174 @@ func gitRun(t *testing.T, dir string, args ...string) {
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// initRepoSite builds a real git repo registered as a lerd site, the fixture
+// the worktree actions run against.
+func initRepoSite(t *testing.T, name string) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", filepath.Join(root, "data"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
+
+	repo := filepath.Join(root, name)
+	if err := os.MkdirAll(repo, 0755); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "init")
+	gitRun(t, repo, "config", "user.email", "test@example.com")
+	gitRun(t, repo, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hi\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, repo, "add", "README.md")
+	gitRun(t, repo, "commit", "-m", "init")
+	if err := config.AddSite(config.Site{Name: name, Domains: []string{name + ".test"}, Path: repo}); err != nil {
+		t.Fatal("add site:", err)
+	}
+	return repo
+}
+
+// stubWorktreeWait swaps the wait seam so tests need neither a lerd binary on
+// PATH nor a running watcher, and records the path it was asked about.
+func stubWorktreeWait(t *testing.T, code int) *string {
+	t.Helper()
+	var gotPath string
+	orig := worktreeWaitFn
+	t.Cleanup(func() { worktreeWaitFn = orig })
+	worktreeWaitFn = func(path string, _ time.Duration) (int, string) {
+		gotPath = path
+		return code, ""
+	}
+	return &gotPath
+}
+
+func TestWorktreeTool_advertisesWait(t *testing.T) {
+	enum := worktreeTool().InputSchema.Properties["action"].Enum
+	for _, a := range enum {
+		if a == "wait" {
+			return
+		}
+	}
+	t.Errorf("action enum %v must offer wait, or no assistant can discover it", enum)
+}
+
+// The race this closes: the watcher starts installing the moment git writes the
+// worktree entry, so an add that returns immediately hands back a tree being
+// written underneath the caller.
+func TestExecWorktreeAdd_waitsForThePipeline(t *testing.T) {
+	repo := initRepoSite(t, "demo")
+	gotPath := stubWorktreeWait(t, 0)
+
+	result, rpcErr := execWorktreeAdd(map[string]any{
+		"site":     "demo",
+		"git_args": []any{filepath.Join(repo, "feature"), "-b", "feature"},
+	})
+	if rpcErr != nil {
+		t.Fatal("unexpected rpc error:", rpcErr.Message)
+	}
+	var parsed struct {
+		OK          bool   `json:"ok"`
+		Path        string `json:"path"`
+		Provisioned bool   `json:"provisioned"`
+	}
+	decodeContent(t, result, &parsed)
+	if !parsed.OK || !parsed.Provisioned {
+		t.Errorf("ok=%v provisioned=%v, want both true", parsed.OK, parsed.Provisioned)
+	}
+	if *gotPath == "" {
+		t.Fatal("add returned without waiting for the pipeline")
+	}
+	if filepath.Base(*gotPath) != "feature" {
+		t.Errorf("waited on %q, want the newly created worktree", *gotPath)
+	}
+	if parsed.Path == "" {
+		t.Error("response must report the new worktree path")
+	}
+}
+
+// A pipeline still running is not an error, the tree just is not safe to touch
+// yet, so the caller is told rather than handed a failure.
+func TestExecWorktreeAdd_reportsAnUnfinishedPipeline(t *testing.T) {
+	repo := initRepoSite(t, "demo")
+	stubWorktreeWait(t, 1)
+
+	result, rpcErr := execWorktreeAdd(map[string]any{
+		"site":     "demo",
+		"git_args": []any{filepath.Join(repo, "feature"), "-b", "feature"},
+	})
+	if rpcErr != nil {
+		t.Fatal("unexpected rpc error:", rpcErr.Message)
+	}
+	var parsed struct {
+		OK          bool   `json:"ok"`
+		Provisioned bool   `json:"provisioned"`
+		Note        string `json:"note"`
+	}
+	decodeContent(t, result, &parsed)
+	if !parsed.OK {
+		t.Error("git succeeded, so ok must stay true")
+	}
+	if parsed.Provisioned {
+		t.Error("provisioned must be false while setup is still running")
+	}
+	if parsed.Note == "" {
+		t.Error("an unfinished pipeline needs a note telling the caller to wait")
+	}
+}
+
+func TestExecWorktreeAdd_waitCanBeDeclined(t *testing.T) {
+	repo := initRepoSite(t, "demo")
+	gotPath := stubWorktreeWait(t, 0)
+
+	if _, rpcErr := execWorktreeAdd(map[string]any{
+		"site":     "demo",
+		"git_args": []any{filepath.Join(repo, "feature"), "-b", "feature"},
+		"wait":     false,
+	}); rpcErr != nil {
+		t.Fatal("unexpected rpc error:", rpcErr.Message)
+	}
+	if *gotPath != "" {
+		t.Errorf("wait=false must not block, but it waited on %q", *gotPath)
+	}
+}
+
+func TestExecWorktreeWait_reportsSettled(t *testing.T) {
+	repo := initRepoSite(t, "demo")
+	gitRun(t, repo, "worktree", "add", filepath.Join(repo, "feature"), "-b", "feature")
+	stubWorktreeWait(t, 0)
+
+	result, rpcErr := execWorktreeWait(map[string]any{"site": "demo", "branch": "feature"})
+	if rpcErr != nil {
+		t.Fatal("unexpected rpc error:", rpcErr.Message)
+	}
+	var parsed struct {
+		Provisioned bool `json:"provisioned"`
+	}
+	decodeContent(t, result, &parsed)
+	if !parsed.Provisioned {
+		t.Error("provisioned must be true when the wait exits 0")
+	}
+}
+
+func TestExecWorktreeWait_timeoutIsNotSuccess(t *testing.T) {
+	repo := initRepoSite(t, "demo")
+	gitRun(t, repo, "worktree", "add", filepath.Join(repo, "feature"), "-b", "feature")
+	stubWorktreeWait(t, 1)
+
+	result, rpcErr := execWorktreeWait(map[string]any{"site": "demo", "branch": "feature"})
+	if rpcErr != nil {
+		t.Fatal("unexpected rpc error:", rpcErr.Message)
+	}
+	var parsed struct {
+		Provisioned bool `json:"provisioned"`
+	}
+	decodeContent(t, result, &parsed)
+	if parsed.Provisioned {
+		t.Error("a timeout must not be reported as provisioned")
 	}
 }


### PR DESCRIPTION
The watcher's auto-setup pipeline is what makes a bare `git worktree add` from any tool a first-class flow, but a tool that then wants to act on the new tree had no supported way to ask whether that pipeline had finished. The wait existed only inside the interactive `lerd worktree add` wrapper, so everyone else was left probing the tree's contents or reverse-engineering the install lock.

Both of those are traps. Composer's extraction phase fills *existing* `vendor/<org>/` directories, and `node_modules/` exists from the very first extracted package, so neither a file count nor an mtime moves during the longest stretch of an install, and the tree reads as finished while it is being written. Two installers in one tree is how `vendor/` ends up holding packages but no `autoload.php`, which then presents as a Composer autoload bug rather than as the race it is.

`lerd worktree wait [path]` blocks until the pipeline settles, defaulting to the current directory. It exits 0 once the tree is safe to touch, 1 on timeout, and 3 when the path is not a worktree lerd manages, so a caller can tell "ask someone else" apart from "still going" instead of waiting out a timeout nothing could ever satisfy.

Readiness now consults the install lock alongside the pipeline's outputs, which closes the same false-ready window in `lerd worktree add`'s own wait, since `node_modules/` alone was never enough to call an `npm ci` finished. The probe takes a shared non-blocking flock rather than the existing try-lock, so it neither overwrites the pid the real holder recorded nor claims an exclusive lock a starting installer would then have to poll for. A probe that fails outright counts as idle, so an unreadable lock directory degrades to the previous behaviour rather than blocking forever.

The MCP worktree tool carried the identical race in its `add` action, which ran bare git and handed the tree straight back to the assistant, so that is fixed here too rather than left for later. `add` now waits by default and reports whether the tree is provisioned, `wait: false` opts out, and a `wait` action covers a worktree created outside the tool. An install still running is reported as not-yet rather than as a failure. The reference injected into every assistant session now states that readiness must never be inferred from the tree's contents, which is the part an assistant would otherwise get wrong on its own.

Both size ceilings that guard the assistant-facing manifests fired on the additions. Each is raised only by the remainder that survived merging the new text into the sentences it supersedes, in the way the ceiling comments describe.

While smoke-testing this I hit an unrelated startup bug in the watcher and filed it as #1255.

Refs #1246
