### PR TITLE
fix(doctor): check the browser stores for the CA instead of certutil's presence

### DIFF
--- a/docs/features/https.md
+++ b/docs/features/https.md
@@ -27,7 +27,9 @@ Certificates are stored in `~/.local/share/lerd/certs/sites/`.
 
 ## Browser trust (certutil / nss-tools)
 
-mkcert installs the local CA into two places: the system trust store, used by curl, PHP, wget and openssl, and the browser NSS databases used by Firefox and Chrome/Chromium. Writing to the browser stores needs `certutil`, which ships in `nss-tools`. When `certutil` is missing mkcert still trusts the system store, so command-line tools accept `.test` HTTPS, but browsers show a certificate warning. `lerd doctor` reports this under "browser HTTPS trust (certutil)", and `lerd install` / `lerd dns:enable` print a note when it applies.
+mkcert installs the local CA into two places: the system trust store, used by curl, PHP, wget and openssl, and the browser NSS databases used by Firefox and Chrome/Chromium. Writing to the browser stores needs `certutil`, which ships in `nss-tools`. When `certutil` is missing mkcert still trusts the system store, so command-line tools accept `.test` HTTPS, but browsers show a certificate warning. `lerd doctor` reports this under "browser HTTPS trust", and `lerd install` / `lerd dns:enable` print a note when it applies.
+
+That check looks in the stores themselves rather than settling for `certutil` being installed, since the two can disagree: a CA that never reached a browser, or one that was removed from a profile afterwards, leaves every `.test` site warning on a machine that otherwise looks healthy. The certificate found in each store is compared against the CA lerd signs with today, so a CA regenerated after a profile imported the old one is reported rather than accepted for carrying the same name. Any store that comes up short is named in the warning, and `lerd dns:repair` installs the CA there. A machine with no browser store at all has nothing to check and passes.
 
 On ordinary distributions install nss-tools and re-run `lerd dns:repair`:
 

--- a/internal/certs/browser_trust.go
+++ b/internal/certs/browser_trust.go
@@ -1,6 +1,11 @@
 package certs
 
-import "os/exec"
+import (
+	"crypto/x509"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
 
 // certutilLookup reports whether certutil is resolvable on PATH. Seam for tests.
 var certutilLookup = func() bool {
@@ -14,4 +19,100 @@ var certutilLookup = func() bool {
 // openssl trust .test, but Firefox and Chrome are skipped and warn on HTTPS.
 func BrowserTrustAvailable() bool {
 	return certutilLookup()
+}
+
+// nssDBDirs returns the NSS databases on this machine, the same set mkcert
+// installs the root CA into: the store the Chromium family shares and every
+// Firefox profile carrying one. Only directories that actually hold a database
+// are returned, so a machine with no browser reports none rather than reporting
+// browser trust broken. Overridable in tests.
+var nssDBDirs = func() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	var dirs []string
+	for _, dir := range []string{
+		filepath.Join(home, ".pki", "nssdb"),
+		filepath.Join(home, "snap", "chromium", "current", ".pki", "nssdb"),
+		"/etc/pki/nssdb",
+	} {
+		if nssDBPresent(dir) {
+			dirs = append(dirs, dir)
+		}
+	}
+	for _, pattern := range []string{
+		filepath.Join(home, ".mozilla", "firefox", "*"),
+		filepath.Join(home, "snap", "firefox", "common", ".mozilla", "firefox", "*"),
+		filepath.Join(home, ".var", "app", "org.mozilla.firefox", ".mozilla", "firefox", "*"),
+	} {
+		matches, _ := filepath.Glob(pattern)
+		for _, dir := range matches {
+			if nssDBPresent(dir) {
+				dirs = append(dirs, dir)
+			}
+		}
+	}
+	return dirs
+}
+
+// nssDBPresent reports whether dir holds an NSS certificate database. Only the
+// sql-backed cert9.db counts: every browser that still ships has moved to it,
+// and the legacy format needs a different certutil prefix to read at all.
+func nssDBPresent(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, "cert9.db"))
+	return err == nil
+}
+
+// nssCertPEM exports the certificate stored under nickname in the NSS database
+// at dir, or nothing when the store has none. Overridable in tests.
+var nssCertPEM = func(dir, nickname string) []byte {
+	out, err := exec.Command("certutil", "-d", "sql:"+dir, "-L", "-n", nickname, "-a").Output()
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+// caNSSNickname is the nickname mkcert stores the root CA under: its own label
+// followed by the certificate's serial in decimal. Deriving it the way mkcert
+// does is what lets the lookup ask for the CA lerd signs with today rather than
+// for whatever certificate happens to wear the mkcert name.
+func caNSSNickname(der []byte) string {
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return ""
+	}
+	return "mkcert development CA " + cert.SerialNumber.String()
+}
+
+// BrowserStoresMissingCA returns the NSS databases that do not hold the root CA
+// lerd signs with. A browser reading one of those warns on every .test site even
+// though curl, PHP and openssl are happy, which is the state certutil's mere
+// presence on PATH says nothing about.
+//
+// Empty when every store has it, and equally empty when the question could not
+// be asked: no certutil to ask with, no CA generated yet, or no browser store on
+// the machine. An unanswered check is not a finding. The exported certificate is
+// compared as DER rather than trusted for carrying the right nickname, so a CA
+// regenerated after a store imported the old one reports as missing.
+func BrowserStoresMissingCA() []string {
+	if !BrowserTrustAvailable() {
+		return nil
+	}
+	der := rootCADER()
+	if der == nil {
+		return nil
+	}
+	nickname := caNSSNickname(der)
+	if nickname == "" {
+		return nil
+	}
+	var missing []string
+	for _, dir := range nssDBDirs() {
+		if !bundleContainsDER(nssCertPEM(dir, nickname), der) {
+			missing = append(missing, dir)
+		}
+	}
+	return missing
 }

--- a/internal/certs/browser_trust_test.go
+++ b/internal/certs/browser_trust_test.go
@@ -1,6 +1,10 @@
 package certs
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestBrowserTrustAvailable(t *testing.T) {
 	orig := certutilLookup
@@ -14,5 +18,122 @@ func TestBrowserTrustAvailable(t *testing.T) {
 	certutilLookup = func() bool { return false }
 	if BrowserTrustAvailable() {
 		t.Fatal("want unavailable when certutil is missing")
+	}
+}
+
+// browserTrustFixture points the CA and store lookups at a generated CA and
+// returns its directory, so each case only has to say what the stores answer.
+func browserTrustFixture(t *testing.T) (caDir string, pem []byte) {
+	t.Helper()
+	origLookup, origRoot, origDirs, origPEM := certutilLookup, caRootFunc, nssDBDirs, nssCertPEM
+	t.Cleanup(func() {
+		certutilLookup, caRootFunc, nssDBDirs, nssCertPEM = origLookup, origRoot, origDirs, origPEM
+	})
+	certutilLookup = func() bool { return true }
+	caDir = t.TempDir()
+	pem = writeTestCA(t, caDir)
+	caRootFunc = func() (string, error) { return caDir, nil }
+	return caDir, pem
+}
+
+func TestBrowserStoresMissingCANamesTheStoreWithoutIt(t *testing.T) {
+	_, certPEM := browserTrustFixture(t)
+	nssDBDirs = func() []string { return []string{"/home/u/.pki/nssdb", "/home/u/.mozilla/firefox/p"} }
+	nssCertPEM = func(dir, nickname string) []byte {
+		if dir == "/home/u/.pki/nssdb" {
+			return certPEM
+		}
+		return nil
+	}
+
+	missing := BrowserStoresMissingCA()
+	if len(missing) != 1 || missing[0] != "/home/u/.mozilla/firefox/p" {
+		t.Fatalf("BrowserStoresMissingCA() = %v, want only the profile that lacks the CA", missing)
+	}
+}
+
+func TestBrowserStoresMissingCAEmptyWhenEveryStoreHasIt(t *testing.T) {
+	_, certPEM := browserTrustFixture(t)
+	nssDBDirs = func() []string { return []string{"/home/u/.pki/nssdb", "/home/u/.mozilla/firefox/p"} }
+	nssCertPEM = func(dir, nickname string) []byte { return certPEM }
+
+	if missing := BrowserStoresMissingCA(); len(missing) != 0 {
+		t.Fatalf("BrowserStoresMissingCA() = %v, want none", missing)
+	}
+}
+
+// A certificate under the nickname lerd is looking for is not automatically the
+// CA lerd signs with. A CA regenerated after a store imported the old one is
+// exactly this shape, and reporting it trusted is what the presence check did.
+func TestBrowserStoresMissingCARejectsADifferentCertificate(t *testing.T) {
+	browserTrustFixture(t)
+	other := writeTestCA(t, t.TempDir())
+	nssDBDirs = func() []string { return []string{"/home/u/.pki/nssdb"} }
+	nssCertPEM = func(dir, nickname string) []byte { return other }
+
+	if missing := BrowserStoresMissingCA(); len(missing) != 1 {
+		t.Fatalf("BrowserStoresMissingCA() = %v, want the store holding a different certificate", missing)
+	}
+}
+
+// Three ways the question cannot be asked at all. None of them is a finding: a
+// check that could not run has not found anything wrong.
+func TestBrowserStoresMissingCAReportsNothingItCouldNotAsk(t *testing.T) {
+	t.Run("no certutil", func(t *testing.T) {
+		browserTrustFixture(t)
+		certutilLookup = func() bool { return false }
+		nssDBDirs = func() []string { return []string{"/home/u/.pki/nssdb"} }
+		nssCertPEM = func(dir, nickname string) []byte { return nil }
+		if missing := BrowserStoresMissingCA(); len(missing) != 0 {
+			t.Fatalf("BrowserStoresMissingCA() = %v, want none without certutil to ask with", missing)
+		}
+	})
+
+	t.Run("no CA generated", func(t *testing.T) {
+		browserTrustFixture(t)
+		caRootFunc = func() (string, error) { return t.TempDir(), nil }
+		nssDBDirs = func() []string { return []string{"/home/u/.pki/nssdb"} }
+		nssCertPEM = func(dir, nickname string) []byte { return nil }
+		if missing := BrowserStoresMissingCA(); len(missing) != 0 {
+			t.Fatalf("BrowserStoresMissingCA() = %v, want none when there is no CA to look for", missing)
+		}
+	})
+
+	t.Run("no browser store", func(t *testing.T) {
+		browserTrustFixture(t)
+		nssDBDirs = func() []string { return nil }
+		if missing := BrowserStoresMissingCA(); len(missing) != 0 {
+			t.Fatalf("BrowserStoresMissingCA() = %v, want none on a machine with no browser store", missing)
+		}
+	})
+}
+
+// mkcert stores the CA under its own label and the certificate's serial in
+// decimal, and lerd has to ask for that exact nickname to find it.
+func TestCANSSNicknameMatchesMkcert(t *testing.T) {
+	caDir := t.TempDir()
+	writeTestCA(t, caDir)
+	der := firstCertDER(readFileNoErr(filepath.Join(caDir, "rootCA.pem")))
+
+	if got, want := caNSSNickname(der), "mkcert development CA 1"; got != want {
+		t.Fatalf("caNSSNickname() = %q, want %q", got, want)
+	}
+	if got := caNSSNickname([]byte("not a certificate")); got != "" {
+		t.Fatalf("caNSSNickname() = %q for unparseable input, want empty", got)
+	}
+}
+
+// Only a directory holding a database is a store. Naming one that does not
+// exist would report every machine without Firefox as missing browser trust.
+func TestNSSDBPresentRequiresADatabase(t *testing.T) {
+	dir := t.TempDir()
+	if nssDBPresent(dir) {
+		t.Error("an empty directory is not an NSS store")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cert9.db"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !nssDBPresent(dir) {
+		t.Error("a directory with cert9.db is an NSS store")
 	}
 }

--- a/internal/cli/browser_trust.go
+++ b/internal/cli/browser_trust.go
@@ -1,6 +1,10 @@
 package cli
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"strings"
+)
 
 // ostreeBootedFn reports whether the host booted from an ostree/atomic image
 // (Silverblue, Bazzite, Kinoite, CoreOS), where nss-tools can't be added
@@ -20,4 +24,13 @@ func browserTrustGuidance(atomic bool) string {
 		return base + "For browser trust run rpm-ostree install nss-tools, reboot, then lerd dns:repair. Or run lerd dns:disable to serve plain http on .localhost."
 	}
 	return base + "For browser trust install nss-tools (dnf install nss-tools, apt install libnss3-tools, or pacman -S nss) then lerd dns:repair. Or run lerd dns:disable to serve plain http on .localhost."
+}
+
+// browserTrustStoreGuidance returns the message shown when certutil is there to
+// install the CA and the store does not have it: the browsers reading that store
+// warn on .test even though the command-line tools accept it. Naming the stores
+// keeps the difference visible between one stale Firefox profile and a machine
+// where the CA never reached a browser at all.
+func browserTrustStoreGuidance(stores []string) string {
+	return fmt.Sprintf("the mkcert root CA is missing from %s, so browsers reading it warn on .test even though curl, PHP and openssl trust it. Run lerd dns:repair to install it there.", strings.Join(stores, ", "))
 }

--- a/internal/cli/browser_trust_test.go
+++ b/internal/cli/browser_trust_test.go
@@ -28,3 +28,18 @@ func TestBrowserTrustGuidance_ordinary(t *testing.T) {
 		t.Errorf("ordinary guidance should not tell the user to layer with rpm-ostree: %s", msg)
 	}
 }
+
+// The stores are named because one stale Firefox profile and a CA that never
+// reached any browser are the same warning otherwise, and they need different
+// things from the reader.
+func TestBrowserTrustStoreGuidanceNamesEveryStore(t *testing.T) {
+	msg := browserTrustStoreGuidance([]string{"/home/u/.pki/nssdb", "/home/u/.mozilla/firefox/p"})
+	for _, want := range []string{"/home/u/.pki/nssdb", "/home/u/.mozilla/firefox/p", "lerd dns:repair"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("store guidance missing %q: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "nss-tools") {
+		t.Errorf("certutil is installed in this state, so the guidance should not ask for it: %s", msg)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -155,11 +155,18 @@ func runDoctorInto(w io.Writer, useColor bool) (DoctorReport, error) {
 		// store only, so curl and PHP trust it but Firefox and Chrome warn, and
 		// the mkcert warning is swallowed. Only relevant when DNS/HTTPS is managed.
 		if cfg, cfgErr := config.LoadGlobal(); cfgErr == nil && cfg.DNSManaged() {
-			if certs.BrowserTrustAvailable() {
-				ok("browser HTTPS trust (certutil)")
-			} else {
-				warn("browser HTTPS trust (certutil)", browserTrustGuidance(ostreeBootedFn()))
+			// certutil being installed says nothing about the store it writes
+			// into, so the CA itself has to be found there.
+			missing := certs.BrowserStoresMissingCA()
+			switch {
+			case !certs.BrowserTrustAvailable():
+				warn("browser HTTPS trust", browserTrustGuidance(ostreeBootedFn()))
 				rep.fixLast(manualFix)
+			case len(missing) > 0:
+				warn("browser HTTPS trust", browserTrustStoreGuidance(missing))
+				rep.fixLast(manualFix)
+			default:
+				ok("browser HTTPS trust")
 			}
 		}
 


### PR DESCRIPTION
The browser HTTPS trust check reported a pass whenever certutil resolved on PATH, so it answered a question about the tool rather than about the store it is named for. A machine where nss-tools is installed but the root CA never reached the NSS store, or was removed from a profile afterwards, got a clean bill of health while every browser refused the certificates lerd signs, which is the one symptom the check exists to catch.

The check now looks for the CA in the databases mkcert installs into, the store the Chromium family shares and every Firefox profile carrying one, and compares what it exports against the CA lerd signs with rather than accepting any certificate wearing the mkcert name, so a CA regenerated after a profile imported the old one is reported instead of passing. A store that comes up short is named in the warning and repaired by lerd dns:repair, and missing certutil keeps the guidance it already had.

Nothing to ask with, no CA yet, or no browser store on the machine all report nothing rather than a warning, matching how the system trust checks already treat a question they could not put. The doctor line loses its certutil suffix, since it no longer reports on certutil.

Refs #1251