### PR TITLE
fix(ui): stop offering LAN settings that do nothing on a loopback-only install

### DIFF
--- a/docs/usage/remote-development.md
+++ b/docs/usage/remote-development.md
@@ -110,10 +110,16 @@ or `lerd lan:services off` to return all managed services to loopback.
 This option exposes databases and caches without adding authentication. Limit
 their ports with the host firewall and use it only on a trusted network.
 
-The same controls are available on the dashboard **System** tab. Use **LAN
-exposure** for sites and DNS, and **Managed service LAN access** for databases,
-caches, mail, and custom services. The terminal UI exposes both settings in its
-Settings and System views.
+The same controls are available on the dashboard **System** tab. **Managed
+service LAN access** sits inside the **LAN exposure** card, below the expose
+control it depends on, for databases, caches, mail, and custom services. The
+terminal UI exposes both settings in its Settings and System views.
+
+Both `lerd lan:services on` and `lerd remote-control full-access on` refuse to
+run while LAN exposure is off, and the matching dashboard toggles are disabled,
+since neither setting publishes anything while lerd is loopback-only. Turning
+either one off always works, so a setting armed before an unexpose can still be
+cleared.
 
 The dashboard at port 7073 is gated independently. By default it returns 403 to LAN clients even when `lan:expose` is on; set HTTP Basic auth credentials with `lerd remote-control on` (or via the **Remote dashboard access** card in the dashboard) to grant LAN access. The two switches are independent: you can have sites LAN-reachable without exposing the dashboard, or vice versa.
 

--- a/internal/cli/lan.go
+++ b/internal/cli/lan.go
@@ -307,6 +307,13 @@ func newLANServicesCmd() *cobra.Command {
 			}
 
 			enabled := args[0] == "on"
+			// Turning it on while lerd is loopback-only would persist a
+			// setting that publishes nothing, so refuse rather than store an
+			// inert preference. Turning it off always works, so a setting
+			// armed before an unexpose can still be cleared.
+			if enabled && !cfg.LAN.Exposed {
+				return fmt.Errorf("LAN exposure is off — run `lerd lan:expose` first. Managed services can only reach the LAN while lerd itself does")
+			}
 			feedback.Begin()
 			update := feedback.Start("updating managed service LAN access")
 			if err := SetManagedServiceLANExposure(enabled, nil); err != nil {
@@ -316,9 +323,6 @@ func newLANServicesCmd() *cobra.Command {
 			if enabled {
 				update.OK(feedback.Val("enabled"))
 				feedback.Note("development services may use weak or empty credentials; restrict their ports with the host firewall and use only on a trusted network")
-				if !cfg.LAN.Exposed {
-					feedback.Note("services remain loopback-only until `lerd lan:expose`")
-				}
 			} else {
 				update.OK(feedback.Val("loopback-only"))
 			}

--- a/internal/cli/lan_services_test.go
+++ b/internal/cli/lan_services_test.go
@@ -8,13 +8,21 @@ import (
 
 func TestLANServicesCommandPersistsExplicitOptIn(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	cfg.LAN.Exposed = true
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
 
 	cmd := newLANServicesCmd()
 	cmd.SetArgs([]string{"on"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("services on: %v", err)
 	}
-	cfg, err := config.LoadGlobal()
+	cfg, err = config.LoadGlobal()
 	if err != nil {
 		t.Fatalf("LoadGlobal after on: %v", err)
 	}
@@ -50,5 +58,50 @@ func TestLANServicesCommandRejectsUnknownState(t *testing.T) {
 	}
 	if cfg.LAN.ServicesExposed {
 		t.Fatal("invalid state changed lan.services_exposed")
+	}
+}
+
+// Opting in while lerd is loopback only would store a preference that
+// publishes nothing, so the command refuses rather than pretending.
+func TestLANServicesRefusesToEnableWhileLoopbackOnly(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd := newLANServicesCmd()
+	cmd.SetArgs([]string{"on"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("services on succeeded while LAN exposure was off")
+	}
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.LAN.ServicesExposed {
+		t.Fatal("refused command still persisted lan.services_exposed")
+	}
+}
+
+// Clearing a setting armed before an unexpose must stay possible.
+func TestLANServicesStillDisablesWhileLoopbackOnly(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	cfg.LAN.ServicesExposed = true
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	cmd := newLANServicesCmd()
+	cmd.SetArgs([]string{"off"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("services off: %v", err)
+	}
+	cfg, err = config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.LAN.ServicesExposed {
+		t.Fatal("services off did not clear the setting")
 	}
 }

--- a/internal/cli/remote_control.go
+++ b/internal/cli/remote_control.go
@@ -200,6 +200,9 @@ the local dashboard or a local shell can change it.`,
 			}
 
 			enabled := args[0] == "on"
+			if enabled && !cfg.LAN.Exposed {
+				return fmt.Errorf("LAN exposure is off — run `lerd lan:expose` first. There are no remote sessions to widen while the dashboard is loopback-only")
+			}
 			if enabled && cfg.UI.PasswordHash == "" {
 				return fmt.Errorf("dashboard credentials are not configured — run `lerd remote-control on` first")
 			}

--- a/internal/cli/remote_control_full_access_test.go
+++ b/internal/cli/remote_control_full_access_test.go
@@ -15,6 +15,7 @@ func withCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadGlobal: %v", err)
 	}
+	cfg.LAN.Exposed = true
 	cfg.UI.Username = "alice"
 	cfg.UI.PasswordHash = "$2a$04$abcdefghijklmnopqrstuv"
 	if err := config.SaveGlobal(cfg); err != nil {
@@ -109,5 +110,33 @@ func TestRemoteControlOffClearsFullAccess(t *testing.T) {
 	}
 	if cfg.UI.RemoteFullAccess {
 		t.Fatal("remote-control off left ui.remote_full_access set")
+	}
+}
+
+// Widening remote authority while the dashboard is loopback only would set a
+// preference with no remote session to apply it to.
+func TestFullAccessRefusesToEnableWhileLoopbackOnly(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cfg, err := config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	cfg.UI.Username = "alice"
+	cfg.UI.PasswordHash = "$2a$04$abcdefghijklmnopqrstuv"
+	if err := config.SaveGlobal(cfg); err != nil {
+		t.Fatalf("SaveGlobal: %v", err)
+	}
+
+	cmd := newRemoteControlFullAccessCmd()
+	cmd.SetArgs([]string{"on"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("full-access on succeeded while LAN exposure was off")
+	}
+	cfg, err = config.LoadGlobal()
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.UI.RemoteFullAccess {
+		t.Fatal("refused command still persisted ui.remote_full_access")
 	}
 }

--- a/internal/ui/lan_gate_test.go
+++ b/internal/ui/lan_gate_test.go
@@ -1,0 +1,74 @@
+package ui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func localPost(path, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Host = "localhost:7073"
+	req.Header.Set("X-Lerd-CSRF", "1")
+	return req
+}
+
+// Opting managed services in while lerd is loopback only would persist a
+// setting that publishes nothing, which reads as exposure that never happened.
+func TestServicesOnRefusedWhileLoopbackOnly(t *testing.T) {
+	setupConfigDirRaw(t, "", "", false)
+
+	rec := httptest.NewRecorder()
+	handleLANStatus(rec, localPost("/api/lan/status", `{"action":"services_on"}`))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	cfg, _ := config.LoadGlobal()
+	if cfg != nil && cfg.LAN.ServicesExposed {
+		t.Fatal("refused request still persisted lan.services_exposed")
+	}
+}
+
+// Opting out has to keep working, or a setting armed before an unexpose can
+// never be cleared from the dashboard.
+func TestServicesOffAllowedWhileLoopbackOnly(t *testing.T) {
+	setupConfigDirRaw(t, "", "", false)
+
+	rec := httptest.NewRecorder()
+	handleLANStatus(rec, localPost("/api/lan/status", `{"action":"services_off"}`))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestFullAccessRefusedWhileLoopbackOnly(t *testing.T) {
+	setupConfigDirRaw(t, "alice", "s3cret", false)
+
+	rec := httptest.NewRecorder()
+	handleRemoteControl(rec, localPost("/api/remote-control", `{"action":"full-access","enabled":true}`))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d (%s)", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	cfg, _ := config.LoadGlobal()
+	if cfg != nil && cfg.UI.RemoteFullAccess {
+		t.Fatal("refused request still persisted ui.remote_full_access")
+	}
+}
+
+func TestFullAccessOffAllowedWhileLoopbackOnly(t *testing.T) {
+	setupConfigDirRaw(t, "alice", "s3cret", false)
+
+	rec := httptest.NewRecorder()
+	handleRemoteControl(rec, localPost("/api/remote-control", `{"action":"full-access","enabled":false}`))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/ui/lan_status_test.go
+++ b/internal/ui/lan_status_test.go
@@ -42,7 +42,9 @@ func TestLANStatusIncludesManagedServiceExposure(t *testing.T) {
 
 func TestLANStatusCanToggleManagedServiceExposureFromLoopback(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	if err := config.SaveGlobal(&config.GlobalConfig{}); err != nil {
+	exposed := &config.GlobalConfig{}
+	exposed.LAN.Exposed = true
+	if err := config.SaveGlobal(exposed); err != nil {
 		t.Fatalf("SaveGlobal: %v", err)
 	}
 
@@ -82,8 +84,8 @@ func TestLANStatusCanToggleManagedServiceExposureFromLoopback(t *testing.T) {
 	if final.Result != "ok" || !final.ServicesEnabled {
 		t.Fatalf("final event = %+v", final)
 	}
-	if final.ServicesReachable {
-		t.Fatalf("services must remain unreachable while LAN exposure is off: %+v", final)
+	if !final.ServicesReachable {
+		t.Fatalf("services must be reachable once both settings are on: %+v", final)
 	}
 }
 

--- a/internal/ui/remote_control.go
+++ b/internal/ui/remote_control.go
@@ -405,6 +405,16 @@ func handleLANStatus(w http.ResponseWriter, r *http.Request) {
 		}
 		switch body.Action {
 		case "expose", "unexpose", "services_on", "services_off":
+			// Managed services can only reach the LAN while lerd itself does,
+			// so opting in beforehand would persist a setting that publishes
+			// nothing. Opting out stays available so a setting armed before an
+			// unexpose can still be cleared.
+			if body.Action == "services_on" {
+				if cfg, _ := config.LoadGlobal(); cfg == nil || !cfg.LAN.Exposed {
+					http.Error(w, "LAN exposure is off — managed services can only reach the LAN while lerd itself does.", http.StatusBadRequest)
+					return
+				}
+			}
 		default:
 			http.Error(w, "unknown action — expected 'expose', 'unexpose', 'services_on', or 'services_off'", http.StatusBadRequest)
 			return
@@ -599,6 +609,10 @@ func handleRemoteControl(w http.ResponseWriter, r *http.Request) {
 			// remote session can never grant itself host actions.
 			if !isLocalControlRequest(r) {
 				http.Error(w, "Forbidden — remote full access can only be changed from the lerd host.", http.StatusForbidden)
+				return
+			}
+			if body.Enabled && !cfg.LAN.Exposed {
+				http.Error(w, "LAN exposure is off — there are no remote sessions to widen while the dashboard is loopback-only.", http.StatusBadRequest)
 				return
 			}
 			if body.Enabled && cfg.UI.PasswordHash == "" {

--- a/internal/ui/web/src/tabs/system/LANServicesSetting.svelte
+++ b/internal/ui/web/src/tabs/system/LANServicesSetting.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import { lan, toggleLANServices } from '$stores/lan';
+  import { accessMode } from '$stores/accessMode';
+  import Toggle from '$components/Toggle.svelte';
+  import SettingsCard from '$components/SettingsCard.svelte';
+  import { m } from '../../paraglide/messages.js';
+
+  // nested renders the setting as a sub-section of the LAN exposure card, with
+  // a rule separating it from the exposure controls above. Standalone brings
+  // its own card, for disabled-DNS mode where there is no LAN card to sit in.
+  interface Props {
+    nested?: boolean;
+  }
+
+  let { nested = false }: Props = $props();
+
+  // The setting publishes nothing while lerd is loopback-only, so it stays out
+  // of the way entirely. An already enabled setting keeps showing, so that
+  // re-exposing does not silently republish databases nobody remembered.
+  const hidden = $derived(!$lan.exposed && !$lan.servicesEnabled);
+</script>
+
+{#snippet body()}
+  <div class="flex items-center justify-between gap-3 mb-2">
+    <span class="text-sm font-semibold text-gray-700 dark:text-gray-300">{m.system_lan_services_title()}</span>
+    {#if $accessMode.localControl}
+      <Toggle
+        on={$lan.servicesEnabled}
+        loading={$lan.servicesLoading}
+        disabled={!$lan.loaded}
+        title={m.system_lan_services_title()}
+        onclick={() => toggleLANServices(!$lan.servicesEnabled)}
+      />
+    {:else}
+      <span class="inline-flex items-center gap-1.5 text-[10px] font-medium px-2 py-0.5 rounded-full {$lan.servicesReachable
+        ? 'bg-emerald-100 dark:bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
+        : $lan.servicesEnabled
+          ? 'bg-amber-100 dark:bg-amber-500/15 text-amber-700 dark:text-amber-400'
+          : 'bg-gray-100 dark:bg-white/5 text-gray-500 dark:text-gray-400'}">
+        <span class="w-1.5 h-1.5 rounded-full {$lan.servicesReachable
+          ? 'bg-emerald-500'
+          : $lan.servicesEnabled
+            ? 'bg-amber-500'
+            : 'bg-gray-400'}"></span>
+        {$lan.servicesReachable
+          ? m.system_lan_services_enabled()
+          : $lan.servicesEnabled
+            ? m.system_remote_status_inert()
+            : m.system_lan_loopback()}
+      </span>
+    {/if}
+  </div>
+  <p class="text-xs text-gray-500 dark:text-gray-400">
+    {m.system_lan_services_description()}
+  </p>
+  {#if $lan.servicesEnabled && !$lan.servicesReachable}
+    <p class="text-xs text-amber-600 dark:text-amber-400 mt-2">
+      {m.system_lan_services_inactive()}
+    </p>
+  {/if}
+  {#if $lan.servicesError}
+    <p class="text-xs text-red-500 mt-2">{$lan.servicesError}</p>
+  {/if}
+  {#if $lan.servicesEnabled}
+    <p class="text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/30 rounded-lg px-3 py-2 mt-3">
+      {m.system_lan_services_warning()}
+    </p>
+  {/if}
+{/snippet}
+
+{#if !hidden}
+  {#if nested}
+    <div class="mt-4 pt-4 border-t border-gray-100 dark:border-lerd-border">
+      {@render body()}
+    </div>
+  {:else}
+    <SettingsCard>
+      {@render body()}
+    </SettingsCard>
+  {/if}
+{/if}

--- a/internal/ui/web/src/tabs/system/LANServicesSetting.test.ts
+++ b/internal/ui/web/src/tabs/system/LANServicesSetting.test.ts
@@ -1,0 +1,88 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import LANServicesSetting from './LANServicesSetting.svelte';
+import { lan } from '$stores/lan';
+import { accessMode } from '$stores/accessMode';
+
+function setLAN(over: Partial<{ exposed: boolean; servicesEnabled: boolean; servicesReachable: boolean }>) {
+  lan.update((v) => ({
+    ...v,
+    loaded: true,
+    exposed: false,
+    servicesEnabled: false,
+    servicesReachable: false,
+    servicesLoading: false,
+    servicesError: '',
+    ...over
+  }));
+}
+
+describe('LANServicesSetting', () => {
+  beforeEach(() => {
+    accessMode.set({ localControl: true, lanExposed: false, checked: true });
+    setLAN({});
+  });
+
+  // The setting is what tells you managed services stay private even while
+  // sites are exposed, so it has to be readable before you expose anything.
+  it('renders its control once lerd is exposed', () => {
+    setLAN({ exposed: true });
+    const { getByRole, container } = render(LANServicesSetting);
+    expect(getByRole('button')).toBeInTheDocument();
+    expect(container.textContent).toContain('Managed service LAN access');
+  });
+
+  it('explains that an opted-in setting is not in effect yet', () => {
+    setLAN({ exposed: false, servicesEnabled: true, servicesReachable: false });
+    const { container } = render(LANServicesSetting);
+    expect(container.textContent).toContain('services remain on loopback until LAN exposure is enabled');
+  });
+
+  it('warns about weak credentials once services are reachable', () => {
+    setLAN({ exposed: true, servicesEnabled: true, servicesReachable: true });
+    const { container } = render(LANServicesSetting);
+    expect(container.textContent).toContain('trusted network');
+  });
+
+  it('shows read-only state instead of a toggle without dashboard-control authority', () => {
+    accessMode.set({ localControl: false, lanExposed: true, checked: true });
+    setLAN({ exposed: true });
+    const { queryByTitle, container } = render(LANServicesSetting);
+    expect(queryByTitle('Managed service LAN access')).toBeNull();
+    expect(container.textContent).toContain('loopback only');
+  });
+
+  it('separates itself from the exposure controls when nested', () => {
+    setLAN({ exposed: true });
+    const { container } = render(LANServicesSetting, { props: { nested: true } });
+    expect(container.querySelector('div')?.className).toContain('border-t');
+  });
+});
+
+describe('LANServicesSetting while lerd is loopback only', () => {
+  beforeEach(() => {
+    accessMode.set({ localControl: true, lanExposed: false, checked: true });
+    setLAN({ exposed: false, servicesEnabled: false });
+  });
+
+  // The setting publishes nothing in this state, so it is not shown at all.
+  it('renders nothing', () => {
+    const { container } = render(LANServicesSetting);
+    expect(container.textContent?.trim()).toBe('');
+  });
+
+  // Re-exposing would otherwise republish databases nobody remembered arming.
+  it('keeps showing an already enabled setting so it can be cleared', () => {
+    setLAN({ exposed: false, servicesEnabled: true });
+    const { getByRole, container } = render(LANServicesSetting);
+    expect(getByRole('button')).not.toBeDisabled();
+    expect(container.textContent).toContain('Managed service LAN access');
+  });
+
+  it('reappears once lerd is exposed', () => {
+    setLAN({ exposed: true, servicesEnabled: false });
+    const { getByRole } = render(LANServicesSetting);
+    expect(getByRole('button')).not.toBeDisabled();
+  });
+});

--- a/internal/ui/web/src/tabs/system/LerdDetail.svelte
+++ b/internal/ui/web/src/tabs/system/LerdDetail.svelte
@@ -3,7 +3,7 @@
   import CheckUpdatesButton from '$components/CheckUpdatesButton.svelte';
   import { version, loadVersion } from '$stores/version';
   import { accessMode } from '$stores/accessMode';
-  import { lan, loadLANStatus, toggleLAN, toggleLANServices, generateRemoteSetupCode, copySetupCurl } from '$stores/lan';
+  import { lan, loadLANStatus, toggleLAN, generateRemoteSetupCode, copySetupCurl } from '$stores/lan';
   import { status } from '$stores/status';
   import {
     remoteControl,
@@ -16,6 +16,7 @@
   import { idleEnabled, idleTimeoutMinutes, loadIdle, saveIdle } from '$stores/idle';
   import Toggle from '$components/Toggle.svelte';
   import SettingsCard from '$components/SettingsCard.svelte';
+  import LANServicesSetting from './LANServicesSetting.svelte';
   import LanguageSwitcher from '$components/LanguageSwitcher.svelte';
   import { apiFetch, apiBase } from '$lib/api';
   import { escapeHtml } from '$lib/html';
@@ -84,6 +85,19 @@
 
   let updateTerminalLoading = $state(false);
   let updateTerminalError = $state('');
+
+  // There is no remote session to widen while lerd is loopback-only, so the
+  // setting stays out of the way. An already enabled setting keeps showing, so
+  // that re-exposing does not silently hand host access back out.
+  const fullAccessHidden = $derived(!$lan.exposed && !$remoteControl.fullAccess);
+
+  // Dashboard credentials are equally inert while lerd is loopback-only, so the
+  // card goes too. Configured credentials keep it visible so they can be
+  // rotated or cleared, and disabled-DNS mode keeps it as its only route to
+  // LAN exposure at all.
+  const remoteCardHidden = $derived(
+    !$lan.exposed && !$remoteControl.enabled && $status.dns?.enabled !== false
+  );
   async function openUpdateTerminal() {
     updateTerminalLoading = true;
     updateTerminalError = '';
@@ -371,57 +385,13 @@
           </div>
         </div>
       {/if}
+      <LANServicesSetting nested />
     </SettingsCard>
+    {:else}
+    <LANServicesSetting />
     {/if}
 
-    <SettingsCard>
-      <div class="flex items-center justify-between gap-3 mb-2">
-        <span class="text-sm font-semibold text-gray-700 dark:text-gray-300">{m.system_lan_services_title()}</span>
-        {#if $accessMode.localControl}
-          <Toggle
-            on={$lan.servicesEnabled}
-            loading={$lan.servicesLoading}
-            disabled={!$lan.loaded}
-            title={m.system_lan_services_title()}
-            onclick={() => toggleLANServices(!$lan.servicesEnabled)}
-          />
-        {:else}
-          <span class="inline-flex items-center gap-1.5 text-[10px] font-medium px-2 py-0.5 rounded-full {$lan.servicesReachable
-            ? 'bg-emerald-100 dark:bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
-            : $lan.servicesEnabled
-              ? 'bg-amber-100 dark:bg-amber-500/15 text-amber-700 dark:text-amber-400'
-              : 'bg-gray-100 dark:bg-white/5 text-gray-500 dark:text-gray-400'}">
-            <span class="w-1.5 h-1.5 rounded-full {$lan.servicesReachable
-              ? 'bg-emerald-500'
-              : $lan.servicesEnabled
-                ? 'bg-amber-500'
-                : 'bg-gray-400'}"></span>
-            {$lan.servicesReachable
-              ? m.system_lan_services_enabled()
-              : $lan.servicesEnabled
-                ? m.system_remote_status_inert()
-                : m.system_lan_loopback()}
-          </span>
-        {/if}
-      </div>
-      <p class="text-xs text-gray-500 dark:text-gray-400">
-        {m.system_lan_services_description()}
-      </p>
-      {#if $lan.servicesEnabled && !$lan.servicesReachable}
-        <p class="text-xs text-amber-600 dark:text-amber-400 mt-2">
-          {m.system_lan_services_inactive()}
-        </p>
-      {/if}
-      {#if $lan.servicesError}
-        <p class="text-xs text-red-500 mt-2">{$lan.servicesError}</p>
-      {/if}
-      {#if $lan.servicesEnabled}
-        <p class="text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/30 rounded-lg px-3 py-2 mt-3">
-          {m.system_lan_services_warning()}
-        </p>
-      {/if}
-    </SettingsCard>
-
+    {#if !remoteCardHidden}
     <SettingsCard>
       <div class="flex items-center justify-between mb-2">
         <span class="text-sm font-semibold text-gray-700 dark:text-gray-300">{m.system_remote_title()}</span>
@@ -471,6 +441,7 @@
               {@html m.system_remote_inertWarning({ cmd: '<code class="font-mono">lerd lan:expose</code>', btn: '<em>' + m.system_lan_expose() + '</em>' })}
             </p>
           {/if}
+          {#if !fullAccessHidden}
           <div class="pt-1">
             <div class="flex items-center justify-between gap-3">
               <span class="text-xs font-semibold text-gray-700 dark:text-gray-300">{m.system_remote_fullAccess_title()}</span>
@@ -489,6 +460,7 @@
               </p>
             {/if}
           </div>
+          {/if}
           <div class="flex flex-wrap gap-2">
             <button
               onclick={() => openRemoteControlModal()}
@@ -526,5 +498,6 @@
       {/if}
       {#if $remoteControl.error}<p class="text-xs text-red-500 mt-2">{$remoteControl.error}</p>{/if}
     </SettingsCard>
+    {/if}
   </div>
 </div>


### PR DESCRIPTION
Managed service LAN access shipped as its own card below LAN exposure, and it could be switched on while lerd was still bound to loopback. That put a card reading "loopback only, LAN devices cannot reach it" directly above a switch offering those same devices access to every database, and flipping it published nothing at all, it only stored a preference for a later expose.

The setting now sits inside the LAN exposure card, under the control it depends on, so the relationship is visible rather than implied by ordering. While lerd is loopback-only it is not shown, and neither is the host actions switch in the remote dashboard access card. Enabling either one is also refused by the CLI and the API, so hiding a control in the dashboard is not the only thing holding the line.

Two states stay visible on purpose. A setting that is already on keeps showing after an unexpose, because otherwise re-exposing would silently republish databases or hand host access back out with nobody having asked for it in that session, and turning either setting off always works so an armed preference can still be cleared. The remote dashboard access card likewise stays when credentials are configured, so they can be rotated or cleared, and in disabled-DNS mode where that card is the only route to LAN exposure at all.

The managed service block moved into its own component so it can render nested inside the LAN card or standalone in disabled-DNS mode without the markup existing twice.

Refs #1247.
