### PR TITLE
fix(ui): stop serving a cold snapshot cache as an empty sites list

### DIFF
--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -750,7 +750,7 @@ func buildStatus() StatusResponse {
 	}
 }
 
-func buildStatusJSON() []byte { return []byte(mustJSON(buildStatus())) }
+func buildStatusJSON() ([]byte, error) { return []byte(mustJSON(buildStatus())), nil }
 
 // WorktreeResponse is embedded in SiteResponse for each git worktree.
 // PHP/NodeVersion are the effective values; *Override flags signal whether
@@ -916,16 +916,30 @@ type SiteResponse struct {
 }
 
 func handleSites(w http.ResponseWriter, _ *http.Request) {
+	// A nil snapshot means the registry could not be read and there is nothing
+	// cached to fall back on. Saying so beats writing a zero-byte body the
+	// dashboard would render as "you have no sites".
+	body := snapshots.Sites()
+	if body == nil {
+		http.Error(w, "sites are temporarily unavailable, the registry could not be read", http.StatusServiceUnavailable)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write(snapshots.Sites())
+	_, _ = w.Write(body)
 }
 
-func buildSitesJSON() []byte { return []byte(mustJSON(buildSites())) }
+func buildSitesJSON() ([]byte, error) {
+	sites, err := buildSites()
+	if err != nil {
+		return nil, err
+	}
+	return []byte(mustJSON(sites)), nil
+}
 
-func buildSites() []SiteResponse {
+func buildSites() ([]SiteResponse, error) {
 	enriched, err := siteinfo.LoadAll(siteinfo.EnrichUI)
 	if err != nil {
-		return []SiteResponse{}
+		return nil, fmt.Errorf("loading sites: %w", err)
 	}
 	_ = siteinfo.PersistVersionChanges(enriched)
 
@@ -1140,7 +1154,7 @@ func buildSites() []SiteResponse {
 			Workspace:       resolveSiteWorkspace(e, groupMainName, siteWorkspace),
 		})
 	}
-	return sites
+	return sites, nil
 }
 
 // ServicePortMapping describes one published port of a service: its
@@ -1524,7 +1538,7 @@ func handleServices(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write(snapshots.Services())
 }
 
-func buildServicesJSON() []byte { return []byte(mustJSON(buildServicesList())) }
+func buildServicesJSON() ([]byte, error) { return []byte(mustJSON(buildServicesList())), nil }
 
 func buildServicesList() []ServiceResponse {
 	// One ss/lsof call shared across all installed-but-stopped services in

--- a/internal/ui/snapshot.go
+++ b/internal/ui/snapshot.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"log"
 	"sync"
 	"time"
 
@@ -29,188 +30,128 @@ func currentSnapshotTTL() time.Duration {
 	return snapshotTTLIdle
 }
 
-// snapshotCache holds cached JSON bytes of the last /api/sites, /api/services,
+// snapshotSlot caches one kind's JSON bytes behind its own build mutex, so
+// that when podman inspect is slow the callers queue behind a single in-flight
+// rebuild rather than each spawning their own batch of subprocesses.
+//
+// get returns nil only when there is nothing truthful to say: no cached value
+// and a build that failed. Callers must treat nil as "unavailable" rather than
+// as an empty result, because presenting it as data is how a cold cache turned
+// into a dashboard with no sites on it.
+type snapshotSlot struct {
+	mu    sync.Mutex
+	build sync.Mutex
+
+	data []byte
+	at   time.Time
+
+	fn func() ([]byte, error)
+}
+
+func (s *snapshotSlot) get() []byte {
+	s.mu.Lock()
+	if s.data != nil && time.Since(s.at) < currentSnapshotTTL() {
+		b := s.data
+		s.mu.Unlock()
+		return b
+	}
+	stale := s.data
+	s.mu.Unlock()
+
+	// A caller holding a usable value never waits on a slow rebuild. A caller
+	// with nothing has to, or it answers with the cold cache's nil and the
+	// dashboard renders that as an empty list.
+	if stale != nil {
+		if !s.build.TryLock() {
+			return stale
+		}
+	} else {
+		s.build.Lock()
+	}
+	defer s.build.Unlock()
+
+	s.mu.Lock()
+	if s.data != nil && time.Since(s.at) < currentSnapshotTTL() {
+		b := s.data
+		s.mu.Unlock()
+		return b
+	}
+	s.mu.Unlock()
+
+	b, err := s.fn()
+	if err != nil {
+		// Storing this would serve one transient failure as the truth for a
+		// whole TTL, up to five minutes when no tab is counted visible.
+		log.Printf("[snapshot] rebuild failed, keeping previous value: %v", err)
+		return stale
+	}
+
+	s.mu.Lock()
+	s.data = b
+	s.at = time.Now()
+	s.mu.Unlock()
+	return b
+}
+
+// invalidate drops the cached value's freshness so the next read rebuilds.
+func (s *snapshotSlot) invalidate() {
+	s.mu.Lock()
+	s.at = time.Time{}
+	s.mu.Unlock()
+}
+
+// snapshotCache holds the cached JSON of the last /api/sites, /api/services,
 // and /api/status responses. Handlers read from here instead of rebuilding
 // from scratch on every poll; /api/ws broadcasts the same bytes to every
 // connected browser.
 type snapshotCache struct {
-	mu sync.Mutex
+	sites, services, status snapshotSlot
 
-	sites, services, status       []byte
-	sitesAt, servicesAt, statusAt time.Time
-
-	// Unhealthy-workers JSON shadows the sites cycle: it is derived from
-	// the same batched unit-state cache and invalidated alongside KindSites,
-	// so callers don't pay any extra subprocess cost.
-	unhealthy   []byte
-	unhealthyAt time.Time
-
-	// One build-mutex per kind serialises concurrent rebuilds so that when
-	// podman inspect is slow, goroutines queue behind one in-flight rebuild
-	// rather than each spawning their own batch of subprocesses.
-	sitesBuild, servicesBuild, statusBuild, unhealthyBuild sync.Mutex
+	// Worker health shadows the sites cycle: it is derived from the same
+	// batched unit-state cache and invalidated alongside KindSites, so callers
+	// don't pay any extra subprocess cost.
+	unhealthy snapshotSlot
 }
 
-var snapshots = &snapshotCache{}
-
-// Sites returns cached /api/sites JSON, rebuilding if stale.
-// If a rebuild is already in progress, returns the stale value immediately
-// rather than queuing behind the in-flight build.
-func (c *snapshotCache) Sites() []byte {
-	c.mu.Lock()
-	if c.sites != nil && time.Since(c.sitesAt) < currentSnapshotTTL() {
-		b := c.sites
-		c.mu.Unlock()
-		return b
-	}
-	stale := c.sites
-	c.mu.Unlock()
-
-	if !c.sitesBuild.TryLock() {
-		return stale
-	}
-	defer c.sitesBuild.Unlock()
-
-	c.mu.Lock()
-	if c.sites != nil && time.Since(c.sitesAt) < currentSnapshotTTL() {
-		b := c.sites
-		c.mu.Unlock()
-		return b
-	}
-	c.mu.Unlock()
-
-	b := buildSitesJSON()
-	c.mu.Lock()
-	c.sites = b
-	c.sitesAt = time.Now()
-	c.mu.Unlock()
-	return b
+var snapshots = &snapshotCache{
+	sites:     snapshotSlot{fn: buildSitesJSON},
+	services:  snapshotSlot{fn: buildServicesJSON},
+	status:    snapshotSlot{fn: buildStatusJSON},
+	unhealthy: snapshotSlot{fn: buildUnhealthyWorkersJSON},
 }
+
+// Sites returns cached /api/sites JSON, rebuilding if stale. nil means no
+// snapshot could be produced.
+func (c *snapshotCache) Sites() []byte { return c.sites.get() }
 
 // Services returns cached /api/services JSON, rebuilding if stale.
-// If a rebuild is already in progress, returns the stale value immediately
-// rather than queuing behind the in-flight build.
-func (c *snapshotCache) Services() []byte {
-	c.mu.Lock()
-	if c.services != nil && time.Since(c.servicesAt) < currentSnapshotTTL() {
-		b := c.services
-		c.mu.Unlock()
-		return b
-	}
-	stale := c.services
-	c.mu.Unlock()
-
-	if !c.servicesBuild.TryLock() {
-		return stale
-	}
-	defer c.servicesBuild.Unlock()
-
-	c.mu.Lock()
-	if c.services != nil && time.Since(c.servicesAt) < currentSnapshotTTL() {
-		b := c.services
-		c.mu.Unlock()
-		return b
-	}
-	c.mu.Unlock()
-
-	b := buildServicesJSON()
-	c.mu.Lock()
-	c.services = b
-	c.servicesAt = time.Now()
-	c.mu.Unlock()
-	return b
-}
+func (c *snapshotCache) Services() []byte { return c.services.get() }
 
 // Status returns cached /api/status JSON, rebuilding if stale.
-// If a rebuild is already in progress, returns the stale value immediately
-// rather than queuing behind the in-flight build.
-func (c *snapshotCache) Status() []byte {
-	c.mu.Lock()
-	if c.status != nil && time.Since(c.statusAt) < currentSnapshotTTL() {
-		b := c.status
-		c.mu.Unlock()
-		return b
-	}
-	stale := c.status
-	c.mu.Unlock()
-
-	if !c.statusBuild.TryLock() {
-		return stale
-	}
-	defer c.statusBuild.Unlock()
-
-	c.mu.Lock()
-	if c.status != nil && time.Since(c.statusAt) < currentSnapshotTTL() {
-		b := c.status
-		c.mu.Unlock()
-		return b
-	}
-	c.mu.Unlock()
-
-	b := buildStatusJSON()
-	c.mu.Lock()
-	c.status = b
-	c.statusAt = time.Now()
-	c.mu.Unlock()
-	return b
-}
+func (c *snapshotCache) Status() []byte { return c.status.get() }
 
 // UnhealthyWorkers returns cached worker-health JSON, rebuilding if stale.
 // Pinned to the KindSites lifecycle: same source cache, same invalidation
 // signal, no extra polling.
-func (c *snapshotCache) UnhealthyWorkers() []byte {
-	c.mu.Lock()
-	if c.unhealthy != nil && time.Since(c.unhealthyAt) < currentSnapshotTTL() {
-		b := c.unhealthy
-		c.mu.Unlock()
-		return b
-	}
-	stale := c.unhealthy
-	c.mu.Unlock()
-
-	if !c.unhealthyBuild.TryLock() {
-		return stale
-	}
-	defer c.unhealthyBuild.Unlock()
-
-	c.mu.Lock()
-	if c.unhealthy != nil && time.Since(c.unhealthyAt) < currentSnapshotTTL() {
-		b := c.unhealthy
-		c.mu.Unlock()
-		return b
-	}
-	c.mu.Unlock()
-
-	b := buildUnhealthyWorkersJSON()
-	c.mu.Lock()
-	c.unhealthy = b
-	c.unhealthyAt = time.Now()
-	c.mu.Unlock()
-	return b
-}
+func (c *snapshotCache) UnhealthyWorkers() []byte { return c.unhealthy.get() }
 
 // Invalidate drops the cached bytes for one kind so the next read rebuilds.
 func (c *snapshotCache) Invalidate(kind string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	switch kind {
 	case eventbus.KindSites:
-		c.sitesAt = time.Time{}
-		// Worker health shares the sites lifecycle.
-		c.unhealthyAt = time.Time{}
+		c.sites.invalidate()
+		c.unhealthy.invalidate()
 	case eventbus.KindServices:
-		c.servicesAt = time.Time{}
+		c.services.invalidate()
 	case eventbus.KindStatus:
-		c.statusAt = time.Time{}
+		c.status.invalidate()
 	}
 }
 
-// InvalidateAll drops all three cached snapshots.
+// InvalidateAll drops all cached snapshots.
 func (c *snapshotCache) InvalidateAll() {
-	c.mu.Lock()
-	c.sitesAt = time.Time{}
-	c.servicesAt = time.Time{}
-	c.statusAt = time.Time{}
-	c.unhealthyAt = time.Time{}
-	c.mu.Unlock()
+	c.sites.invalidate()
+	c.services.invalidate()
+	c.status.invalidate()
+	c.unhealthy.invalidate()
 }

--- a/internal/ui/snapshot_test.go
+++ b/internal/ui/snapshot_test.go
@@ -1,0 +1,133 @@
+package ui
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// A browser opening the dashboard fires several requests at once. On a cold
+// cache the losers used to be handed the nil they found there, which the
+// handler wrote out as a zero-byte body and the dashboard read as "no sites".
+func TestSnapshotColdCacheServesEveryConcurrentCaller(t *testing.T) {
+	var builds int
+	slot := &snapshotSlot{fn: func() ([]byte, error) {
+		builds++
+		time.Sleep(20 * time.Millisecond)
+		return []byte(`[{"name":"acme"}]`), nil
+	}}
+
+	const callers = 25
+	var wg sync.WaitGroup
+	results := make([][]byte, callers)
+	for i := range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[i] = slot.get()
+		}()
+	}
+	wg.Wait()
+
+	for i, got := range results {
+		if len(got) == 0 {
+			t.Fatalf("caller %d got an empty snapshot on a cold cache", i)
+		}
+	}
+	if builds != 1 {
+		t.Errorf("builds = %d, want 1: callers must queue behind one rebuild", builds)
+	}
+}
+
+// The reason the losers returned early in the first place: a caller holding a
+// usable value should not wait on a slow podman inspect.
+func TestSnapshotWarmCacheServesStaleWithoutWaiting(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	slot := &snapshotSlot{data: []byte(`["stale"]`), at: time.Now().Add(-time.Hour)}
+	slot.fn = func() ([]byte, error) {
+		entered <- struct{}{}
+		<-release
+		return []byte(`["fresh"]`), nil
+	}
+
+	go slot.get()
+	<-entered // the rebuild is in flight and holding the build lock
+
+	done := make(chan []byte, 1)
+	go func() { done <- slot.get() }()
+	select {
+	case got := <-done:
+		if string(got) != `["stale"]` {
+			t.Errorf("got %s, want the stale value", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("a caller holding a stale value queued behind the in-flight rebuild")
+	}
+	close(release)
+}
+
+// A transient failure to read the registry must not be stored with a fresh
+// timestamp, or it is served as a legitimate empty list for a whole TTL.
+func TestSnapshotDoesNotCacheAFailedBuild(t *testing.T) {
+	fail := true
+	slot := &snapshotSlot{fn: func() ([]byte, error) {
+		if fail {
+			return nil, errors.New("reading sites.yaml: permission denied")
+		}
+		return []byte(`[{"name":"acme"}]`), nil
+	}}
+
+	if got := slot.get(); got != nil {
+		t.Fatalf("failed build returned %s, want nil so the handler can say so", got)
+	}
+
+	fail = false
+	if got := slot.get(); string(got) != `[{"name":"acme"}]` {
+		t.Fatalf("got %s, want the rebuilt value: the failure was cached", got)
+	}
+}
+
+// With something cached, a failed rebuild is better answered with the stale
+// value than with nothing.
+func TestSnapshotKeepsStaleWhenRebuildFails(t *testing.T) {
+	slot := &snapshotSlot{data: []byte(`["stale"]`), at: time.Now().Add(-time.Hour)}
+	slot.fn = func() ([]byte, error) { return nil, errors.New("registry unreadable") }
+
+	if got := slot.get(); string(got) != `["stale"]` {
+		t.Fatalf("got %s, want the stale value kept through a failed rebuild", got)
+	}
+	// The stale timestamp must not be refreshed, so the next call retries.
+	var attempts int
+	slot.fn = func() ([]byte, error) {
+		attempts++
+		return []byte(`["fresh"]`), nil
+	}
+	if got := slot.get(); string(got) != `["fresh"]` {
+		t.Fatalf("got %s, want a retry after the failure", got)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestSnapshotServesCachedValueWithinTTL(t *testing.T) {
+	var builds int
+	slot := &snapshotSlot{fn: func() ([]byte, error) {
+		builds++
+		return []byte(`["v"]`), nil
+	}}
+
+	slot.get()
+	slot.get()
+	if builds != 1 {
+		t.Errorf("builds = %d, want 1 within the TTL", builds)
+	}
+
+	slot.invalidate()
+	slot.get()
+	if builds != 2 {
+		t.Errorf("builds = %d after invalidate, want 2", builds)
+	}
+}

--- a/internal/ui/web/src/stores/sites.ts
+++ b/internal/ui/web/src/stores/sites.ts
@@ -118,13 +118,24 @@ export interface Site {
 export const sites = writable<Site[]>([]);
 export const sitesLoaded = writable<boolean>(false);
 
-export async function loadSites() {
+// Nothing polls the sites list on a timer, so a load that fails before the
+// first success leaves the dashboard empty until some unrelated mutation
+// publishes a sites payload over the websocket, which on an idle machine can
+// be minutes. Retry until we have a list to show, backing off as we go.
+const sitesRetryDelays = [500, 1500, 4000];
+
+export async function loadSites(attempt = 0): Promise<boolean> {
   try {
     const list = await apiJson<Site[]>('/api/sites');
     sites.set(Array.isArray(list) ? list : []);
     sitesLoaded.set(true);
+    return true;
   } catch {
-    /* keep previous */
+    // A later failure keeps whatever is already on screen; only the cold case
+    // is worth chasing, since there the alternative is showing nothing.
+    if (get(sitesLoaded) || attempt >= sitesRetryDelays.length) return false;
+    setTimeout(() => loadSites(attempt + 1), sitesRetryDelays[attempt]);
+    return false;
   }
 }
 

--- a/internal/ui/web/src/stores/sitesLoad.test.ts
+++ b/internal/ui/web/src/stores/sitesLoad.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { get } from 'svelte/store';
+import { sites, sitesLoaded, loadSites } from './sites';
+
+describe('loadSites recovery', () => {
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sites.set([]);
+    sitesLoaded.set(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    globalThis.fetch = realFetch;
+  });
+
+  function respond(...responses: Array<() => Response>) {
+    let i = 0;
+    const mock = vi.fn(async () => responses[Math.min(i++, responses.length - 1)]());
+    globalThis.fetch = mock as unknown as typeof fetch;
+    return mock;
+  }
+
+  const ok = () =>
+    new Response(JSON.stringify([{ name: 'acme' }]), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  const unavailable = () => new Response('sites are temporarily unavailable', { status: 503 });
+
+  // The cold-cache window is short, so a retry is all it takes. Without one the
+  // list stays empty until an unrelated websocket event arrives.
+  it('retries until it has a list to show', async () => {
+    const mock = respond(unavailable, ok);
+
+    await loadSites();
+    expect(get(sitesLoaded)).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(600);
+    expect(mock).toHaveBeenCalledTimes(2);
+    expect(get(sitesLoaded)).toBe(true);
+    expect(get(sites)).toHaveLength(1);
+  });
+
+  it('gives up after the last delay instead of retrying forever', async () => {
+    const mock = respond(unavailable);
+
+    await loadSites();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(mock).toHaveBeenCalledTimes(4); // initial attempt plus three retries
+    expect(get(sitesLoaded)).toBe(false);
+  });
+
+  // Once a list has been shown, a later blip must not blank it or start
+  // chasing the endpoint.
+  it('leaves an already loaded list alone when a refresh fails', async () => {
+    respond(ok);
+    await loadSites();
+    expect(get(sites)).toHaveLength(1);
+
+    const mock = respond(unavailable);
+    await loadSites();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(get(sites)).toHaveLength(1);
+    expect(get(sitesLoaded)).toBe(true);
+  });
+});

--- a/internal/ui/worker_health_watcher.go
+++ b/internal/ui/worker_health_watcher.go
@@ -173,15 +173,18 @@ func healthSignature(ws []workerheal.UnhealthyWorker) string {
 // degrade to an empty array so the dashboard never sees a malformed frame.
 // Each entry is enriched with the last journal line so the dashboard can
 // surface "why did this fail?" without a drill-down.
-func buildUnhealthyWorkersJSON() []byte {
+// buildUnhealthyWorkersJSON reports an empty list rather than an error when
+// detection fails: "no unhealthy workers" is the safe reading of a failed
+// health probe, unlike "no sites", which is a claim about the registry.
+func buildUnhealthyWorkersJSON() ([]byte, error) {
 	out, err := workerheal.Detect()
 	if err != nil || len(out) == 0 {
-		return []byte("[]")
+		return []byte("[]"), nil
 	}
 	out = workerheal.Enrich(out)
 	b, err := json.Marshal(out)
 	if err != nil {
-		return []byte("[]")
+		return []byte("[]"), nil
 	}
-	return b
+	return b, nil
 }


### PR DESCRIPTION
The snapshot cache handed a caller that lost the build lock whatever it already held, and on a cold cache that is nil. The handler wrote it out as a zero-byte body, so a browser opening the dashboard just after a restart lost the race on most of the requests it fires at once, and the client's parse failure left the store at the empty array it was initialised with, with nothing scheduled to try again.

A caller holding a usable stale value still returns immediately rather than queuing behind a slow podman inspect, which is what the early return was for. A caller with nothing waits for the build already in flight instead, because answering from a cold cache is making a claim about the registry that nobody checked. All four kinds carried their own copy of that pattern with the same flaw, so they are one type now with the rule stated once.

The second path in the report is fixed the same way. A failure to read the registry is reported rather than turned into an empty slice, a failed build is never cached, and the handler answers 503 instead of a body the dashboard would render as "you have no sites". Where something is already cached, a failed rebuild keeps serving it and leaves the timestamp untouched so the next read retries. Worker health still reports an empty list when its probe fails, since no unhealthy workers is a safe reading of a failed health check in a way that no sites is not.

On the client, loadSites retries at 500ms, 1.5s and 4s while it has never managed to load. Once a list is on screen a later blip leaves it alone.

Verified against the repro in the report, on a machine with twenty sites. Restarting lerd-ui and firing twenty five concurrent reads of /api/sites returned an empty body to twenty four of them beforehand, and the full payload to all twenty five afterwards, holding at forty concurrent across repeated restarts.

Closes #1248.
