### PR TITLE
fix(watcher): signal readiness before the boot provisioning

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -401,42 +401,6 @@ func newWatchCmd() *cobra.Command {
 				fmt.Printf("[WARN] default vhost: %v\n", err)
 			}
 
-			// Initial scan: register new projects.
-			reloadNeeded := false
-			for _, dir := range cfg.ParkedDirectories {
-				entries, err := os.ReadDir(dir)
-				if err != nil {
-					continue
-				}
-				for _, entry := range entries {
-					if !entry.IsDir() {
-						continue
-					}
-					registered, err := cli.RegisterProject(filepath.Join(dir, entry.Name()), cfg)
-					if err != nil {
-						fmt.Printf("[WARN] %s: %v\n", entry.Name(), err)
-					} else if registered {
-						reloadNeeded = true
-					}
-				}
-			}
-
-			// Remove stale sites (deleted while we were offline or during the scan above).
-			if removeStale(cfg) {
-				reloadNeeded = true
-			}
-
-			// Startup scan: generate vhosts for any existing worktrees.
-			if scanWorktrees() {
-				reloadNeeded = true
-			}
-
-			if reloadNeeded {
-				if err := nginx.Reload(); err != nil {
-					fmt.Printf("[WARN] nginx reload: %v\n", err)
-				}
-			}
-
 			// Periodically catch deletions that happen while the watcher is busy.
 			go func() {
 				for range time.Tick(30 * time.Second) {
@@ -680,10 +644,10 @@ func newWatchCmd() *cobra.Command {
 				}
 			}()
 
-			// Initial setup and goroutines are live; tell systemd we're
-			// ready so Type=notify unit starts unblock for any dependent
-			// startup sequence (lerd-ui, lerd-tray, test harnesses).
-			lerdSystemd.NotifyReady()
+			// Goroutines are live; tell systemd we're ready so Type=notify
+			// unit starts unblock for any dependent startup sequence
+			// (lerd-ui, lerd-tray, test harnesses), then reconcile.
+			notifyReadyThenScan(lerdSystemd.NotifyReady, func() { bootScan(cfg) })
 
 			return watcher.Watch(cfg.ParkedDirectories, func(projectPath string) {
 				fmt.Printf("New project detected: %s\n", projectPath)
@@ -740,6 +704,58 @@ func mainRepoSitePaths() []string {
 		}
 	}
 	return paths
+}
+
+// notifyReadyThenScan signals watcher readiness and then runs the boot scan in
+// the background. The order matters: the scan provisions worktrees, composer
+// install included, and that has no duration worth guessing at, while `lerd
+// watch` runs under a Type=notify unit with a start timeout. Signalling first
+// leaves a slow install as a slow install, instead of a SIGTERM before
+// readiness and a restart that begins the same install from scratch.
+func notifyReadyThenScan(notifyReady, scan func()) {
+	notifyReady()
+	go scan()
+}
+
+// bootScan is the watcher's one-shot reconciliation: register projects parked
+// while it was down, drop sites whose directory has gone, and provision the
+// worktrees found on disk. Nothing here is a precondition for serving, so it
+// runs off the startup path; the periodic passes cover whatever it misses.
+func bootScan(cfg *config.GlobalConfig) {
+	reloadNeeded := false
+	for _, dir := range cfg.ParkedDirectories {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			registered, err := cli.RegisterProject(filepath.Join(dir, entry.Name()), cfg)
+			if err != nil {
+				fmt.Printf("[WARN] %s: %v\n", entry.Name(), err)
+			} else if registered {
+				reloadNeeded = true
+			}
+		}
+	}
+
+	// Remove stale sites (deleted while we were offline or during the scan above).
+	if removeStale(cfg) {
+		reloadNeeded = true
+	}
+
+	// Generate vhosts for any existing worktrees.
+	if scanWorktrees() {
+		reloadNeeded = true
+	}
+
+	if reloadNeeded {
+		if err := nginx.Reload(); err != nil {
+			fmt.Printf("[WARN] nginx reload: %v\n", err)
+		}
+	}
 }
 
 // scanWorktrees generates vhosts for all existing worktrees across all main-repo sites.

--- a/cmd/lerd/main_test.go
+++ b/cmd/lerd/main_test.go
@@ -5,7 +5,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dns"
@@ -290,6 +293,37 @@ func TestShouldInheritNginxOnSync(t *testing.T) {
 			t.Errorf("shouldInheritNginxOnSync(%q) = %v, want %v", action, got, want)
 		}
 	}
+}
+
+// The boot scan provisions worktrees, and a composer install there can take
+// longer than the Type=notify unit's start timeout. Readiness must be signalled
+// without waiting for it, or systemd terminates the process before it is ever
+// ready and the restart begins the same install again, forever.
+func TestNotifyReadyThenScan_readinessDoesNotWaitOnTheScan(t *testing.T) {
+	release := make(chan struct{})
+	// A scan run synchronously would block on release forever, so it is let go
+	// on a timer as well and the assertions below report the ordering.
+	releaseScan := sync.OnceFunc(func() { close(release) })
+	time.AfterFunc(5*time.Second, releaseScan)
+
+	var ready atomic.Bool
+	scanDone := make(chan struct{})
+	notifyReadyThenScan(
+		func() { ready.Store(true) },
+		func() { <-release; close(scanDone) },
+	)
+
+	if !ready.Load() {
+		t.Error("readiness was not signalled before the watcher moved on")
+	}
+	select {
+	case <-scanDone:
+		t.Error("readiness waited for the boot scan to finish")
+	default:
+	}
+
+	releaseScan()
+	<-scanDone
 }
 
 func TestShouldAutoStartWorkersOnSync(t *testing.T) {

--- a/docs/features/git-worktrees.md
+++ b/docs/features/git-worktrees.md
@@ -226,6 +226,8 @@ When a worktree is removed (via `git worktree remove` directly or `lerd worktree
 
 The startup sweep also catches any registry entries whose worktree directory disappeared while the watcher was offline, restarting `lerd-watcher` reconciles state.
 
+The sweep runs in the background, after the watcher has reported itself ready. It provisions worktrees it finds unprovisioned, which can mean a full `composer install`, and that has no duration worth waiting on: the watcher is up and watching from the first moment either way, so a long install shows up as a worktree that finishes setting itself up a few minutes in, not as a daemon that refuses to start. Use [`lerd worktree wait`](#waiting-for-the-pipeline) when you need to block until a specific worktree is actually ready.
+
 ### A checkout deleted without git
 
 That ordering hangs off git's own `.git/worktrees/` entry disappearing, which is what `git worktree remove` deletes. Deleting the checkout directory on its own leaves that entry behind, so the watcher never hears about it and the worker units keep retrying against a `WorkingDirectory` that has gone, failing at `CHDIR` before the command runs and restarting every `RestartSec` indefinitely. This is no longer unusual: coding agents create and destroy their own worktrees, and they have no reason to know lerd exists.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -262,6 +262,8 @@ systemctl --user start lerd-watcher   # start it from the terminal
 # or use the Start button in the UI under System > Watcher
 ```
 
+The watcher reports itself ready as soon as its watch loops are live and does its boot reconciliation (registering parked projects, provisioning worktrees) after that, in the background. A worktree install that takes minutes therefore delays only that worktree; it can't hold the unit below its start timeout and put systemd in a restart loop.
+
 To see what the watcher is doing:
 
 ```bash


### PR DESCRIPTION
The watcher is a Type=notify unit that signalled readiness after its boot work rather than before it. That work provisions any worktree that needs it, which includes a synchronous composer install, so a boot install slower than the unit's start timeout got the process terminated before readiness was ever signalled. systemd restarted it, the fresh process began the same install from the beginning, and it died at the same point, restart counter climbing and nothing converging on its own. The shape the user sees is a watcher that is simply down, so nothing provisions worktrees and nothing reacts to new projects, and recovering by hand means working out that you have to stop the unit, run the install outside it, then start it again.

Readiness now goes first and the boot scan runs in the background, the way the later periodic passes already do. Nothing in that scan is a precondition for serving, the watch loops and goroutines are live well before the first install completes, and that is what readiness means here. A long install is a long install again, with the watcher up and watching from the first moment either way. Raising the start timeout was the alternative and it only moves the cliff, since an install has no duration worth guessing at.

macOS carries no readiness contract and no start timeout in its plists, so it never had the cliff, but the change is platform neutral and holds there too.

Refs #1255