### PR TITLE
fix(release): generate the Homebrew formula with Linux support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -133,6 +133,8 @@ archives:
 brews:
   - name: lerd
     ids:
+      - lerd-amd64
+      - lerd-arm64
       - lerd-darwin-amd64
       - lerd-darwin-arm64
     repository:
@@ -143,8 +145,11 @@ brews:
     description: "Local Laravel development environment for Linux and macOS"
     license: "MIT"
     skip_upload: auto
+    # On macOS podman comes from brew; on Linux the distro's podman is the
+    # one lerd integrates with, so no brew dependency there.
     dependencies:
       - name: podman
+        os: mac
     install: |
       bin.install "lerd"
       bin.install "lerd-tray" if File.exist?("lerd-tray")
@@ -207,6 +212,9 @@ release:
     ```bash
     lerd update
     ```
+
+    Also available through apt (PPA), dnf (COPR) and Homebrew, see the
+    [installation docs](https://lerd.sh/getting-started/installation).
 
     ### Install on macOS
 


### PR DESCRIPTION
The brews config only fed the darwin archives to the formula, so GoReleaser emitted depends_on :macos and Homebrew on Linux refused the install with an unsatisfied requirement error. The Linux archives are now included, which makes GoReleaser generate on_macos and on_linux blocks instead.

The podman dependency is scoped to macOS: on Linux lerd integrates with the distribution's podman and its systemd, so a brew-installed one would be the wrong one to pull in. The release notes template now also points Linux users at the apt, dnf and Homebrew options.

The tap formula for 1.31.0 was already regenerated by hand in exactly this shape (lerd-env/homebrew-lerd#2) and verified working on Homebrew for Linux in the homebrew/brew container and on a Fedora VM, so this only has to keep future releases producing the same thing. The config validates with goreleaser check on the same major the release workflow pins.

Refs #1272