### PR TITLE
Forward the terminal's colour capability into container execs

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -78,6 +78,12 @@ These run inside the project's PHP-FPM container with the project's working dire
 
 The MCP integration exposes the same surface through two tools, `vendor_bins` (list available binaries) and `vendor_run` (execute one), so AI assistants can discover and run project tooling without per-project configuration.
 
+### Terminal colours
+
+Commands that run in a container get the colour capability of the terminal you started them from. `lerd php`, `lerd composer`, `lerd console`, `lerd shell` and the shell you open from the TUI forward `COLORTERM`, so Symfony Console, laravel/prompts, Pest, the Filament CLI and starship pick the same colour mode inside the container as the same tools do against a host PHP. Without it, podman hands the container a sixteen-colour terminal and anything styled with hex or 256 colours is flattened to the nearest basic colour.
+
+`NO_COLOR` and `FORCE_COLOR` travel with it, so a preference set in your shell holds on both sides of the boundary. `TERM` is deliberately not forwarded: the image only carries terminfo for the xterm family, and a terminal that names itself `foot` or `wezterm` would end up with no colour at all. A terminal that advertises more than sixteen colours gets `TERM=xterm-256color` instead of its own value, which keeps the 256-colour path reachable too. `lerd tinker` is the exception and still runs uncoloured, since its output is captured and rendered by the UI rather than written to your terminal.
+
 ---
 
 ## Version resolution

--- a/internal/cli/console.go
+++ b/internal/cli/console.go
@@ -23,6 +23,19 @@ func NewConsoleCmd() *cobra.Command {
 	}
 }
 
+// consoleCmdArgs builds the podman exec that runs a framework console command
+// in the project's container, carrying the terminal's colour capability so
+// styled console output keeps the fidelity it has on the host.
+func consoleCmdArgs(cwd, container, consoleCmd string, tty bool, args []string) []string {
+	execFlags := []string{"exec", "-i"}
+	if tty {
+		execFlags = append(execFlags, "-t")
+	}
+	cmdArgs := append(execFlags, terminalColorEnvArgs()...)
+	cmdArgs = append(cmdArgs, "-w", cwd, container, "php", consoleCmd)
+	return append(cmdArgs, args...)
+}
+
 func runConsole(_ *cobra.Command, args []string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -50,14 +63,7 @@ func runConsole(_ *cobra.Command, args []string) error {
 	podman.EnsurePathMounted(cwd, version)
 	ensureServicesForCwd(cwd)
 
-	execFlags := []string{"exec", "-i"}
-	if term.IsTerminal(int(os.Stdin.Fd())) {
-		execFlags = append(execFlags, "-t")
-	}
-	cmdArgs := append(execFlags, "-w", cwd, container, "php", consoleCmd)
-	cmdArgs = append(cmdArgs, args...)
-
-	cmd := podman.Cmd(cmdArgs...)
+	cmd := podman.Cmd(consoleCmdArgs(cwd, container, consoleCmd, term.IsTerminal(int(os.Stdin.Fd())), args)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/cli/exec_color_test.go
+++ b/internal/cli/exec_color_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// truecolorHost points the process environment at a terminal that can do more
+// than sixteen colours, the case podman's pinned TERM=xterm otherwise hides
+// from everything running in the container (#1276).
+func truecolorHost(t *testing.T) {
+	t.Helper()
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("FORCE_COLOR", "")
+	t.Setenv("TERM", "foot")
+	t.Setenv("COLORTERM", "truecolor")
+}
+
+func TestConsoleCmdArgs(t *testing.T) {
+	truecolorHost(t)
+	got := consoleCmdArgs("/proj", "lerd-php84-fpm", "artisan", true, []string{"migrate"})
+	want := "exec -i -t --env=COLORTERM=truecolor --env=TERM=xterm-256color " +
+		"-w /proj lerd-php84-fpm php artisan migrate"
+	if strings.Join(got, " ") != want {
+		t.Errorf("consoleCmdArgs() = %v, want %v", got, strings.Split(want, " "))
+	}
+
+	if got := consoleCmdArgs("/proj", "lerd-php84-fpm", "spark", false, nil); strings.Contains(strings.Join(got, " "), " -t ") {
+		t.Errorf("consoleCmdArgs() = %v, want no pty without a terminal", got)
+	}
+
+	t.Setenv("NO_COLOR", "1")
+	got = consoleCmdArgs("/proj", "lerd-php84-fpm", "artisan", true, nil)
+	if line := strings.Join(got, " "); !strings.Contains(line, "--env=NO_COLOR=1") || strings.Contains(line, "COLORTERM") {
+		t.Errorf("consoleCmdArgs() = %q, want the opt-out forwarded on its own", line)
+	}
+}
+
+func TestPhpShellExecArgs(t *testing.T) {
+	truecolorHost(t)
+	got := strings.Join(phpShellExecArgs("lerd-php84-fpm", "/proj"), " ")
+	if !strings.HasPrefix(got, "exec -it ") {
+		t.Errorf("phpShellExecArgs() = %q, want an interactive exec", got)
+	}
+	if !strings.Contains(got, "--env=COLORTERM=truecolor") {
+		t.Errorf("phpShellExecArgs() = %q, missing the terminal colour environment", got)
+	}
+	if !strings.Contains(got, "/root/.bun/bin") {
+		t.Errorf("phpShellExecArgs() = %q, missing the bun PATH export", got)
+	}
+}

--- a/internal/cli/php_exec.go
+++ b/internal/cli/php_exec.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/geodro/lerd/internal/agentenv"
 	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/logcolor"
 	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
@@ -97,6 +98,14 @@ func debugSiteEnvArgs(dir string) []string {
 	return nil
 }
 
+// terminalColorEnvArgs carries the attached terminal's colour capability into
+// the container. Every exec path the user watches needs it: podman forwards no
+// host environment, so without COLORTERM the tools inside see a sixteen-colour
+// terminal and style themselves down to match.
+func terminalColorEnvArgs() []string {
+	return logcolor.PodmanExecTerminalArgs(os.Environ())
+}
+
 // RunPHPCaptureEnv is RunPHPCapture with extra KEY=VALUE environment entries
 // injected into the container exec — used by `lerd profile run` to set
 // SPX_ENABLED so a CLI command is profiled.
@@ -178,6 +187,7 @@ func RunPHPVersionCaptureEnv(cwd, version string, args []string, extraEnv []stri
 		"--env", "PATH="+projectVendorBin+":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:"+composerBin,
 	)
 	cmdArgs = append(cmdArgs, debugSiteEnvArgs(cwd)...)
+	cmdArgs = append(cmdArgs, terminalColorEnvArgs()...)
 	// Forward SPX_* profiler vars from the host so `SPX_ENABLED=1 php ...` (or
 	// any shim'd tool like composer) reaches SPX inside the container. extraEnv
 	// is applied after, so an explicit caller like `lerd profile run` wins.

--- a/internal/cli/php_shell.go
+++ b/internal/cli/php_shell.go
@@ -32,6 +32,17 @@ func shellWorkDir(cwd string) string {
 	return phpDet.SiteRootFor(cwd)
 }
 
+// phpShellExecArgs builds the interactive shell exec. It puts the opt-in
+// in-container bun (lerd php:bun install) on PATH so a bare `bun` resolves,
+// harmless when bun isn't installed, and forwards the terminal's colour
+// capability so starship and the tools run in the session render as they do
+// on the host.
+func phpShellExecArgs(container, workDir string) []string {
+	args := append([]string{"exec", "-it"}, terminalColorEnvArgs()...)
+	return append(args, "-w", workDir, container,
+		"sh", "-c", `export PATH="/root/.bun/bin:$PATH"; `+podman.InteractiveShellScript())
+}
+
 func runPhpShell(_ *cobra.Command, _ []string) error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -55,10 +66,7 @@ func runPhpShell(_ *cobra.Command, _ []string) error {
 	podman.EnsurePathMounted(workDir, version)
 	ensureServicesForCwd(workDir)
 
-	// Put the opt-in in-container bun (lerd php:bun install) on PATH so a bare
-	// `bun` resolves in the shell. Harmless no-op when bun isn't installed.
-	cmd := podman.Cmd("exec", "-it", "-w", workDir, container,
-		"sh", "-c", `export PATH="/root/.bun/bin:$PATH"; `+podman.InteractiveShellScript())
+	cmd := podman.Cmd(phpShellExecArgs(container, workDir)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/logcolor/logcolor.go
+++ b/internal/logcolor/logcolor.go
@@ -25,6 +25,65 @@ func Vars() []string {
 	return append([]string(nil), forced...)
 }
 
+// TerminalPassthrough returns the colour environment an attached terminal
+// implies for a container exec. podman forwards none of the host environment,
+// so COLORTERM has to travel explicitly: Symfony Console and laravel/prompts
+// read it first when they pick a colour mode, and without it hex and 256-colour
+// styling is flattened to one of sixteen colours. NO_COLOR and FORCE_COLOR ride
+// along so a choice made on the host holds inside the container, with NO_COLOR
+// winning outright.
+//
+// TERM is not forwarded. The images carry terminfo for the xterm family only,
+// and Symfony matches TERM against a fixed pattern that foot, wezterm and
+// friends fail, so the host value would turn colour off for exactly the
+// terminals podman's pinned "xterm" keeps working today. A terminal that
+// advertises more than sixteen colours gets xterm-256color instead, an entry
+// every image has, which puts the eight-bit path back in reach as well.
+func TerminalPassthrough(environ []string) []string {
+	env := map[string]string{}
+	for _, e := range environ {
+		if k, v, ok := strings.Cut(e, "="); ok {
+			env[k] = v
+		}
+	}
+	if env["NO_COLOR"] != "" {
+		return []string{"NO_COLOR=" + env["NO_COLOR"]}
+	}
+	var out []string
+	if v := env["FORCE_COLOR"]; v != "" {
+		out = append(out, "FORCE_COLOR="+v)
+	}
+	if env["TERM"] == "dumb" {
+		return out
+	}
+	if v := env["COLORTERM"]; v != "" {
+		out = append(out, "COLORTERM="+v)
+	}
+	if wideColorTerminal(env["TERM"], env["COLORTERM"]) {
+		out = append(out, "TERM=xterm-256color")
+	}
+	return out
+}
+
+// wideColorTerminal reports whether the attached terminal claims more than the
+// sixteen colours podman's pinned TERM leaves room for.
+func wideColorTerminal(term, colorterm string) bool {
+	if colorterm != "" {
+		return true
+	}
+	return strings.Contains(term, "256color") || strings.Contains(term, "direct")
+}
+
+// PodmanExecTerminalArgs returns TerminalPassthrough as `podman exec` flags.
+func PodmanExecTerminalArgs(environ []string) []string {
+	vars := TerminalPassthrough(environ)
+	args := make([]string, 0, len(vars))
+	for _, v := range vars {
+		args = append(args, "--env="+v)
+	}
+	return args
+}
+
 // PodmanExecArgs returns the flags to add to a `podman exec` invocation.
 func PodmanExecArgs() []string {
 	vars := Vars()

--- a/internal/logcolor/logcolor_test.go
+++ b/internal/logcolor/logcolor_test.go
@@ -76,6 +76,68 @@ func TestShellExports(t *testing.T) {
 	}
 }
 
+func TestTerminalPassthrough(t *testing.T) {
+	tests := []struct {
+		name    string
+		environ []string
+		want    []string
+	}{
+		{
+			name:    "truecolor terminal carries COLORTERM and a 256-colour TERM",
+			environ: []string{"TERM=foot", "COLORTERM=truecolor", "PATH=/bin"},
+			want:    []string{"COLORTERM=truecolor", "TERM=xterm-256color"},
+		},
+		{
+			name:    "256-colour TERM alone still lifts the pinned xterm",
+			environ: []string{"TERM=screen-256color"},
+			want:    []string{"TERM=xterm-256color"},
+		},
+		{
+			name:    "a plain terminal is left to podman's own pin",
+			environ: []string{"TERM=xterm"},
+			want:    nil,
+		},
+		{
+			name:    "NO_COLOR travels alone",
+			environ: []string{"TERM=wezterm", "COLORTERM=truecolor", "FORCE_COLOR=1", "NO_COLOR=1"},
+			want:    []string{"NO_COLOR=1"},
+		},
+		{
+			name:    "an empty NO_COLOR is not an opt-out",
+			environ: []string{"NO_COLOR=", "COLORTERM=24bit"},
+			want:    []string{"COLORTERM=24bit", "TERM=xterm-256color"},
+		},
+		{
+			name:    "FORCE_COLOR is forwarded verbatim, zero included",
+			environ: []string{"TERM=xterm", "FORCE_COLOR=0"},
+			want:    []string{"FORCE_COLOR=0"},
+		},
+		{
+			name:    "an empty FORCE_COLOR is nothing to forward",
+			environ: []string{"TERM=xterm", "FORCE_COLOR="},
+			want:    nil,
+		},
+		{
+			name:    "a dumb terminal is told nothing about colour",
+			environ: []string{"TERM=dumb", "COLORTERM=truecolor"},
+			want:    nil,
+		},
+		{
+			name:    "nothing to say about a terminal-less environment",
+			environ: []string{"PATH=/bin"},
+			want:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TerminalPassthrough(tt.environ)
+			if strings.Join(got, " ") != strings.Join(tt.want, " ") {
+				t.Errorf("TerminalPassthrough(%v) = %v, want %v", tt.environ, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEnviron(t *testing.T) {
 	colourOn(t)
 	base := []string{"PATH=/bin"}

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/geodro/lerd/internal/logcolor"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/geodro/lerd/internal/siteinfo"
 )
@@ -21,18 +22,24 @@ type ActionResult struct {
 	Detail  string
 }
 
+// shellExecArgs builds the exec that opens the session, forwarding the colour
+// capability of the terminal the TUI is running in so prompt and tool output
+// inside the container match what the same tools render on the host.
+func shellExecArgs(container, workDir string) []string {
+	args := append([]string{"exec", "-it"}, logcolor.PodmanExecTerminalArgs(os.Environ())...)
+	if workDir != "" {
+		args = append(args, "-w", workDir)
+	}
+	return append(args, container, "sh", "-c", podman.InteractiveShellScript())
+}
+
 // runShellIn suspends bubbletea, opens an interactive shell inside the
 // chosen container (FPM for PHP sites, the custom container for Node/Go/etc.
 // sites, and the service's own container for services), then resumes. The
 // shell fallback chain prefers the host user's shell (fish or zsh) when the
 // image has it, falling back through bash to sh for minimal images.
 func runShellIn(container, workDir string) tea.Cmd {
-	args := []string{"exec", "-it"}
-	if workDir != "" {
-		args = append(args, "-w", workDir)
-	}
-	args = append(args, container, "sh", "-c", podman.InteractiveShellScript())
-	cmd := podman.Cmd(args...)
+	cmd := podman.Cmd(shellExecArgs(container, workDir)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/tui/actions_shell_test.go
+++ b/internal/tui/actions_shell_test.go
@@ -1,0 +1,29 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// A shell opened from the TUI runs in the same terminal as the TUI itself, so
+// it gets the same colour capability the host tools see (#1276).
+func TestShellExecArgs(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("FORCE_COLOR", "")
+	t.Setenv("TERM", "wezterm")
+	t.Setenv("COLORTERM", "truecolor")
+
+	got := strings.Join(shellExecArgs("lerd-php84-fpm", "/proj"), " ")
+	for _, want := range []string{"exec -it", "--env=COLORTERM=truecolor", "--env=TERM=xterm-256color", "-w /proj"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("shellExecArgs() = %q, missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "TERM=wezterm") {
+		t.Errorf("shellExecArgs() = %q, the image has no terminfo for the host TERM", got)
+	}
+
+	if got := strings.Join(shellExecArgs("lerd-mysql", ""), " "); strings.Contains(got, "-w") {
+		t.Errorf("shellExecArgs() = %q, want no working directory for a service container", got)
+	}
+}


### PR DESCRIPTION
Commands lerd runs in the PHP container were styled as if the terminal could only do sixteen colours. podman forwards none of the host environment, so Symfony Console and laravel/prompts never saw COLORTERM and resolved their colour mode from the TERM podman pins to xterm, which flattened hex and 256 colour styling while the identical code against a host php rendered exactly. Artisan output, Pest, the Filament CLI and starship in lerd shell all lost fidelity that way.

The exec paths with a real terminal attached now carry COLORTERM across, together with NO_COLOR and FORCE_COLOR so a preference set on the host holds on both sides of the boundary. That covers lerd php and everything routed through it, composer and the vendor/bin shortcuts included, the framework console, lerd shell, and the shell opened from the TUI.

TERM stays out of it. The images only carry terminfo for the xterm family, and Symfony matches TERM against a fixed pattern that foot and wezterm fail, so forwarding the host value would turn colour off for exactly the terminals the pinned xterm keeps working today. A terminal that advertises more than sixteen colours gets xterm-256color instead, which puts the eight bit path back in reach as well, and a dumb terminal is told nothing about colour at all.

lerd tinker keeps its deliberate NO_COLOR and TERM=dumb, since its output is captured and rendered by the UI rather than written to a terminal.

Closes #1276
