### PR TITLE
docs: add a Drupal walkthrough

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -142,6 +142,7 @@ export default defineConfig({
             { text: 'Laravel', link: '/getting-started/laravel' },
             { text: 'Symfony', link: '/getting-started/symfony' },
             { text: 'WordPress', link: '/getting-started/wordpress' },
+            { text: 'Drupal', link: '/getting-started/drupal' },
             { text: 'Containers (Node, Python, Go, …)', link: '/getting-started/containers' },
           ],
         },

--- a/docs/getting-started/drupal.md
+++ b/docs/getting-started/drupal.md
@@ -1,0 +1,220 @@
+# Drupal walkthrough
+
+End-to-end: from `lerd install` to a Drupal 11 site running on `https://mysite.test` with MySQL, Redis, Mailpit and a cron worker.
+
+::: info Prerequisites
+You've already run `lerd install` once on this machine. If not, see [Installation](installation.md).
+:::
+
+::: tip Drive it from your AI assistant
+Run `lerd mcp:enable-global` once and your AI assistant (Claude Code, Cursor, Junie, Codex, Gemini, Copilot, Antigravity, Windsurf) can call every command below through the grouped MCP tools: `framework` `action: "project_new"`, `site` `action: "link"`, `env` `action: "setup"`, `framework` `action: "setup"`, `db` `action: "create"`, `worker`, etc. See [AI Integration](../features/mcp.md).
+:::
+
+---
+
+## 1. Create the project
+
+::: code-group
+
+```bash [lerd new]
+cd ~/Lerd
+lerd new mysite --framework=drupal
+# runs: composer create-project drupal/recommended-project ./mysite
+```
+
+```bash [composer]
+cd ~/Lerd
+composer create-project drupal/recommended-project mysite
+```
+
+```bash [existing repo]
+cd ~/Lerd
+git clone git@github.com:you/mysite.git
+```
+
+:::
+
+---
+
+## 2. Register the site
+
+```bash
+cd mysite
+lerd link
+```
+
+```
+ → detecting framework… ✓ drupal
+ → provisioning PHP-FPM runtime… ✓ php 8.5 · node 22 · nginx vhost written
+ ✓ linked in 1.3s
+
+  Site        http://mysite.test
+  PHP         8.5 · FPM
+  Node        22
+  Framework   drupal
+```
+
+Drupal is detected from `drupal/core-recommended` or `drupal/core` in `composer.json`, and the document root is set to `web/`, so nothing outside it is ever served.
+
+::: info Already parked?
+If `~/Lerd` was registered with `lerd park ~/Lerd` earlier, every subdirectory under it is auto-linked and you can skip `lerd link`.
+:::
+
+---
+
+## 3. Configure PHP, database, services
+
+```bash
+lerd init
+```
+
+The wizard asks for the PHP version, Node version, HTTPS, a database and any services. Drupal runs on PHP 8.3 to 8.5 and has no front-end build of its own, so leaving the Node field blank is fine. Pick MySQL or PostgreSQL, and add `redis` and `mailpit` if you want a cache backend and a mail catcher.
+
+The answers land in `.lerd.yaml`:
+
+```yaml
+domains:
+  - mysite
+php_version: "8.5"
+framework: drupal
+framework_version: "11"
+secured: true
+services:
+  - mailpit
+  - mysql
+  - redis
+```
+
+Commit that file; on another machine `lerd link` reads it and restores the same setup without re-running the wizard. `lerd init` also links the site, issues the TLS certificate, creates the project database and writes the connection values, so the site is already on `https://mysite.test` when the wizard exits.
+
+---
+
+## 4. Add Drush
+
+Everything lerd knows how to do with a Drupal site goes through Drush: the setup steps, the cron worker, and the quick actions in the dashboard. `drupal/recommended-project` does not ship it, so install it before going further:
+
+```bash
+lerd composer require drush/drush
+```
+
+Until Drush is present, `lerd setup` offers only `composer install` and `lerd mcp:inject`, and the cron worker does not appear at all. That is deliberate, the steps are gated on the package being installed, but it does mean a fresh project looks emptier than it is.
+
+---
+
+## 5. Install the site
+
+```bash
+lerd php vendor/drush/drush/drush.php site:install \
+  --db-url=mysql://root:lerd@lerd-mysql:3306/mysite \
+  --site-name="My site" --account-name=admin --account-pass=secret --yes
+```
+
+```
+ [notice] Performed install task: install_base_system
+ [notice] Performed install task: install_profile_modules
+ [notice] Performed install task: install_finished
+ [success] Installation complete. (Admin)
+```
+
+::: warning Drupal does not read `.env`
+`lerd init` writes `DB_DRIVER`, `DB_HOST`, `DB_NAME`, `DB_USER` and `DB_PASSWORD` into `.env`, which is where lerd records what it provisioned and where the dashboard reads it from. Drupal itself has no dotenv wiring in `drupal/recommended-project`, so it never reads that file. Pass `--db-url` on the first install, as above, and Drush writes the real credentials into `web/sites/default/settings.php`, which is what Drupal actually loads from then on. Running `site:install` with no `--db-url` on a fresh project fails with `Call to a member function getInstallTasks() on null`, because there is nothing for it to connect to yet.
+
+The `.env` values still matter if you wire `settings.php` up to read them yourself, which is the usual pattern for a project that keeps credentials out of the repo.
+:::
+
+Use `--db-url=pgsql://postgres:lerd@lerd-postgres:5432/mysite` for PostgreSQL. The database itself was already created by `lerd init`, so the URL only has to point at it.
+
+---
+
+## 6. Run the remaining setup steps
+
+```bash
+lerd setup
+```
+
+With Drush installed the full step list appears, pre-selecting what a normal run needs:
+
+```
+? Setup steps
+  [ ] composer install
+  [ ] lerd mcp:inject
+  [ ] Install site
+  [•] Run database updates
+  [•] Rebuild cache
+  [ ] Import config
+  [ ] cron:start
+```
+
+`Run database updates` and `Rebuild cache` are the two that matter after a pull. `Install site` is the step you just ran by hand, `Import config` runs `drush config:import` for a project that tracks its configuration in the repo, and `cron:start` launches the cron worker as a systemd user service.
+
+::: info One-shot
+`lerd setup --all` skips the prompt and runs every pre-selected step. Useful in scripts or after a fresh clone.
+:::
+
+---
+
+## 7. Verify
+
+```bash
+lerd status
+```
+
+The site answers on `https://mysite.test` with a trusted certificate, and the cron worker shows as running once started:
+
+```bash
+lerd worker start cron
+```
+
+```
+ → starting Cron… ✓
+   logs: journalctl --user -u lerd-cron-mysite -f
+```
+
+Live logs are in the [Web UI](../features/web-ui.md) at `http://127.0.0.1:7073` under the **App Logs** tab.
+
+---
+
+## What just happened
+
+| Command | What it did |
+|---|---|
+| `lerd link` | Registered `mysite.test` with nginx + dnsmasq, document root `web/` |
+| `lerd init` | Wrote `.lerd.yaml`, issued the TLS certificate, created the `mysite` database, started MySQL, Redis and Mailpit |
+| `lerd env` (via init) | Wrote `DB_*`, `REDIS_*` and `SMTP_*` into `.env` |
+| `drush site:install` | Installed Drupal and wrote the connection into `web/sites/default/settings.php` |
+| `lerd worker start cron` | Launched `lerd-cron-mysite`, which runs `drush cron` under systemd |
+
+---
+
+## Drush quick commands
+
+The Drupal definition ships five one-click actions, available on the site's card in the dashboard, in the TUI, and to an AI assistant over MCP:
+
+| Command | Runs | What it does |
+|---|---|---|
+| `cr` | `drush cr` | Rebuild all Drupal caches |
+| `uli` | `drush uli` | Generate a one-time admin login URL |
+| `updb` | `drush updb -y` | Apply pending `hook_update_N` updates |
+| `cex` | `drush cex -y` | Export configuration to the sync directory |
+| `cim` | `drush cim -y` | Import configuration from the sync directory |
+
+`uli` returns a URL, so the dashboard shows it as a link you can open straight into an authenticated session. `cim` asks for confirmation first, since it overwrites live configuration.
+
+From a shell, run any Drush command through the project's PHP container:
+
+```bash
+lerd php vendor/drush/drush/drush.php cr
+lerd php vendor/drush/drush/drush.php uli
+```
+
+The [Tinker tab](../features/tinker.md) is wired to `drush php:eval`, so you can evaluate code against a booted Drupal from the dashboard.
+
+---
+
+## Next steps
+
+- [Frameworks & Workers](../usage/frameworks.md): how the framework definition drives all of the above
+- [Database](../usage/database.md): `lerd db:import`, `lerd db:shell`, snapshots
+- [Services](../usage/services.md): Meilisearch for search, RustFS for S3, or a database you run on the host
+- [HTTPS](../features/https.md): wildcard certs for git worktrees
+- [AI Integration (MCP)](../features/mcp.md): drive lerd from Claude Code, Cursor, etc.


### PR DESCRIPTION
The docs ship walkthroughs for Laravel, Symfony and WordPress while the store supports nine frameworks, so someone arriving with Drupal had no getting-started path even though lerd already detects, scaffolds and serves it. This is the first of the six missing pages, listed alongside the others in the Framework walkthroughs nav.

I wrote it from a real run rather than from the framework definition, which is how three things worth saying out loud turned up. Everything lerd does with a Drupal site goes through Drush, and `drupal/recommended-project` does not ship it, so a fresh project's `lerd setup` offers only `composer install` and `lerd mcp:inject` until you require `drush/drush`. Drupal has no dotenv wiring of its own, so the `DB_*` values lerd writes into `.env` are a record of what it provisioned rather than something the app reads. And the first install needs an explicit `--db-url`, after which Drush writes the real credentials into `web/sites/default/settings.php`, which is what Drupal loads from then on.

The rest follows the shape of the existing pages: create, link, configure, install, verify, what just happened, then the five Drush quick actions the definition ships and where they surface.

Refs #1286