### PR TITLE
fix: resolve the shims on every surface that runs a framework command

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -160,8 +160,7 @@ func runNamedCommand(cwd string, cmds []config.FrameworkCommand, name string, as
 		runDir = filepath.Join(runDir, target.CWD)
 	}
 
-	c := exec.Command("sh", "-c", target.Command)
-	c.Dir = runDir
+	c := newCommandExec(runDir, target.Command)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -172,4 +171,15 @@ func runNamedCommand(cwd string, cmds []config.FrameworkCommand, name string, as
 		return err
 	}
 	return nil
+}
+
+// newCommandExec builds the shell invocation for a framework command. The
+// dashboard runs the same strings with lerd's shim dir on PATH; the CLI has to
+// do it too, or every command that starts with `php` dies with "command not
+// found" for anyone running `lerd path:disable`.
+func newCommandExec(dir, command string) *exec.Cmd {
+	c := exec.Command("sh", "-c", command)
+	c.Dir = dir
+	c.Env = append(os.Environ(), "PATH="+config.PathWithBinDir())
+	return c
 }

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -118,3 +118,25 @@ commands:
 		}
 	}
 }
+
+// Framework commands all start with `php`, which resolves only through lerd's
+// shim dir. `lerd path:disable` keeps that dir off the user's shell PATH, so
+// without this the CLI runner dies with "php: command not found" on every
+// command while the dashboard, which prepends the dir itself, works fine.
+func TestNewCommandExec_PutsShimDirOnPath(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+	c := newCommandExec(t.TempDir(), "php artisan optimize:clear")
+
+	var got string
+	for _, kv := range c.Env {
+		if strings.HasPrefix(kv, "PATH=") {
+			got = strings.TrimPrefix(kv, "PATH=")
+		}
+	}
+	if !strings.HasPrefix(got, config.BinDir()+string(os.PathListSeparator)) {
+		t.Errorf("PATH = %q, want it to start with the shim dir %q", got, config.BinDir())
+	}
+	if !strings.HasSuffix(got, "/usr/bin:/bin") {
+		t.Errorf("PATH = %q, want the inherited entries kept", got)
+	}
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -44,6 +44,20 @@ func BinDir() string {
 	return filepath.Join(DataDir(), "bin")
 }
 
+// PathWithBinDir returns the inherited PATH with lerd's shim dir in front, for
+// child processes that run a shell command string. Framework commands all start
+// with `php`, which only resolves through that dir, and it is absent from the
+// user's own PATH both under `lerd path:disable` and under launchd on macOS.
+// An empty inherited PATH yields the dir alone: a trailing separator would make
+// the shell search the working directory.
+func PathWithBinDir() string {
+	path := BinDir()
+	if existing := os.Getenv("PATH"); existing != "" {
+		path += string(os.PathListSeparator) + existing
+	}
+	return path
+}
+
 // NodeGlobalDir is the npm prefix lerd points its node shim at, so
 // `npm install -g foo` lands in a stable per-user path instead of a
 // version-specific fnm directory that nothing has on PATH.

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -158,5 +159,28 @@ func TestDataSubDir(t *testing.T) {
 	got := DataSubDir("mysql")
 	if !strings.Contains(got, "mysql") {
 		t.Errorf("DataSubDir(mysql) = %q, expected to contain mysql", got)
+	}
+}
+
+// A command string from a framework definition starts with `php` (php spark,
+// php please, php bin/magento, php vendor/drush/drush/drush.php). Those resolve
+// through lerd's shim dir, which `lerd path:disable` deliberately keeps off the
+// user's shell PATH, so every caller that hands such a string to a shell has to
+// put the dir back for the child process.
+func TestPathWithBinDir_PrependsShimDir(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+	got := PathWithBinDir()
+	want := BinDir() + string(os.PathListSeparator) + "/usr/bin:/bin"
+	if got != want {
+		t.Errorf("PathWithBinDir() = %q, want %q", got, want)
+	}
+}
+
+// A bare "PATH=<bin>:" searches the working directory on POSIX, so an empty
+// inherited PATH must not gain a trailing separator.
+func TestPathWithBinDir_EmptyPathHasNoTrailingSeparator(t *testing.T) {
+	t.Setenv("PATH", "")
+	if got := PathWithBinDir(); got != BinDir() {
+		t.Errorf("PathWithBinDir() = %q, want %q", got, BinDir())
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3088,6 +3088,7 @@ func execCommandsRun(args map[string]any) (any, *rpcError) {
 	}
 	cmd := exec.Command("sh", "-c", target.Command)
 	cmd.Dir = cwd
+	cmd.Env = hostCommandEnv()
 	out, runErr := cmd.CombinedOutput()
 	body := string(out)
 	if runErr != nil {
@@ -4626,4 +4627,11 @@ func execUnpark(args map[string]any) (any, *rpcError) {
 		return toolErr("path is required"), nil
 	}
 	return runLerdCmd("unpark", path)
+}
+
+// hostCommandEnv is the environment for a framework command run on the host.
+// Those strings all start with `php`, which resolves through lerd's shim dir,
+// and `lerd path:disable` keeps that dir off the user's own PATH.
+func hostCommandEnv() []string {
+	return append(os.Environ(), "PATH="+config.PathWithBinDir())
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
@@ -541,5 +542,26 @@ func TestExecServiceConfig_ReadHonoursInlineTuningSpec(t *testing.T) {
 	}
 	if !bytes.Contains(raw, []byte("user-defined memcached overrides")) {
 		t.Errorf("response missing inline template: %s", raw)
+	}
+}
+
+// An AI assistant running a framework command goes through the same host shell
+// as `lerd run` and the dashboard, so it needs lerd's shim dir on PATH too:
+// every framework command starts with `php`, which `lerd path:disable` takes
+// off the user's own PATH.
+func TestHostCommandEnv_PutsShimDirOnPath(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	var got string
+	for _, kv := range hostCommandEnv() {
+		if strings.HasPrefix(kv, "PATH=") {
+			got = strings.TrimPrefix(kv, "PATH=")
+		}
+	}
+	if !strings.HasPrefix(got, config.BinDir()+string(os.PathListSeparator)) {
+		t.Errorf("PATH = %q, want it to start with the shim dir %q", got, config.BinDir())
+	}
+	if !strings.HasSuffix(got, "/usr/bin:/bin") {
+		t.Errorf("PATH = %q, want the inherited entries kept", got)
 	}
 }

--- a/internal/sitedoctor/sitedoctor.go
+++ b/internal/sitedoctor/sitedoctor.go
@@ -1051,11 +1051,7 @@ func plural(n int, one, many string) string {
 func runCapture(ctx context.Context, cwd, command string) (string, int, error) {
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Dir = cwd
-	path := config.BinDir()
-	if existing := os.Getenv("PATH"); existing != "" {
-		path += string(os.PathListSeparator) + existing
-	}
-	cmd.Env = append(os.Environ(), "PATH="+path)
+	cmd.Env = append(os.Environ(), "PATH="+config.PathWithBinDir())
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -258,17 +258,10 @@ func streamShellRun(w http.ResponseWriter, ctx context.Context, cwd, shell strin
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", shell)
 	cmd.Dir = cwd
-	// Prepend BinDir so php/composer/npm shims resolve under launchd's
-	// restricted PATH on macOS. Skip the trailing separator when PATH is
-	// empty — a bare "PATH=<bin>:" would search CWD on POSIX.
-	path := config.BinDir()
-	if existing := os.Getenv("PATH"); existing != "" {
-		path += string(os.PathListSeparator) + existing
-	}
 	// Force colour on: the command runs against a pipe, so composer, artisan
 	// and friends would otherwise strip their ANSI escapes and the run modal
 	// would show a wall of grey.
-	cmd.Env = logcolor.Environ(append(os.Environ(), "PATH="+path))
+	cmd.Env = logcolor.Environ(append(os.Environ(), "PATH="+config.PathWithBinDir()))
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
Framework commands are shell strings that all begin with `php`: `php spark`, `php please`, `php bin/magento`, `php artisan`, `php vendor/drush/drush/drush.php`. That `php` only resolves through lerd's shim dir, which `lerd path:disable` deliberately keeps off the user's PATH. Two of the four surfaces that run those strings on the host were not putting it back.

```
$ env PATH=/usr/bin:/bin lerd run cache:clear
sh: line 1: php: command not found
```

`lerd run` inherited whatever PATH the shell had, and MCP `commands_run` inherited whatever the assistant's client exported, so both failed for every framework command while the dashboard ran them fine. The site doctor was already prepending the dir with its own copy of the logic; all four share one helper now, so they cannot drift apart again.

The PHP page already promises that every `lerd …` command works unchanged with the shim disabled, because child processes resolve the shims internally, so this makes that true rather than changing what it says.

I checked the remaining surfaces rather than assuming. The TUI shells out to the lerd binary itself, so it inherits whatever the CLI does. `lerd setup` steps exec inside the container and never touch the host PATH. Both worker paths build their own PATH starting at the shim dir, the Linux unit through `Environment=PATH=` and the macOS guard script through an explicit argument. `lerd console`, `lerd php` and `lerd composer` resolve the container directly and were never affected.

Verified with the shim dir stripped from PATH on a real linked site: `lerd run`, `lerd console` and `lerd php` from the CLI, `commands_run` driven over MCP stdio, and the dashboard's own SSE endpoint as a regression check.

Found while fixing the Drupal definition in lerd-env/frameworks#35, whose new `site:install` command runs from `lerd run` and lands straight on this.