### PR TITLE
docs: add a page for updating an install from before the lerd-env move

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -128,6 +128,7 @@ export default defineConfig({
           items: [
             { text: 'Requirements', link: '/getting-started/requirements' },
             { text: 'Installation', link: '/getting-started/installation' },
+            { text: 'Updating from before 1.26', link: '/getting-started/updating-from-pre-1.26' },
             { text: 'Windows (WSL2, beta)', link: '/getting-started/wsl2' },
             { text: 'NixOS', link: '/getting-started/nixos' },
             { text: 'Quick Start', link: '/getting-started/quick-start' },

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -166,6 +166,10 @@ wget -qO- https://lerd.sh/install.sh | bash -s -- --update
 
 :::
 
+::: warning Running something older than 1.26?
+`lerd update` fails on builds from before the project moved to the lerd-env organisation, with an error about an unexpected release URL. [Updating from a version before 1.26](./updating-from-pre-1.26) gets you across in one step.
+:::
+
 ---
 
 ### Uninstall

--- a/docs/getting-started/updating-from-pre-1.26.md
+++ b/docs/getting-started/updating-from-pre-1.26.md
@@ -1,0 +1,92 @@
+# Updating from a version before 1.26
+
+If `lerd update` stops with this, you're on a build from before the project moved to the [lerd-env](https://github.com/lerd-env) organisation:
+
+```
+could not fetch latest version: unexpected release URL format: https://github.com/lerd-env/lerd/releases/latest
+```
+
+That build can no longer find releases on its own. Re-run the installer once and every later update goes back to working normally.
+
+## Are you affected
+
+```bash
+lerd --version
+```
+
+Anything below **1.26.0** is affected. Version 1.26.0 is where lerd learned to follow the move by itself, so 1.26.0 and newer update without any of this.
+
+You may also see nothing at all rather than an error. The "update available" notice in `lerd status` and `lerd doctor` fails quietly by design, so an old install simply stops telling you that new versions exist.
+
+## What's actually broken
+
+Only the version lookup. Everything else an old binary fetches still resolves, because GitHub forwards the old links: downloading a release archive, fetching the framework and service stores, reading the changelog, and pulling the prebuilt PHP base images from GHCR all keep working. Your sites, certificates, services and data are untouched by this, and the install keeps serving normally. It just can't discover a newer release.
+
+The lookup asks GitHub for `/releases/latest` and reads the `Location` header of the redirect it gets back, expecting a URL that ends in `/tag/v1.32.0`. After the move that header points at the new organisation's `/releases/latest` instead of at a tag, and the old parser has nothing to read a version out of. Version 1.26.0 replaced those hardcoded links with a layer that tries each known location in order and remembers whichever answered, which is why the move is invisible from that release on.
+
+## Fix it
+
+### Script installs in `~/.local/bin`
+
+Re-run the one-line installer. It replaces the binary with the current release and then runs `lerd install` to reapply the Quadlet units, DNS and certificate setup, which matters when you're crossing several releases at once. Your config, sites, certificates and service data are left alone.
+
+::: code-group
+
+```bash [curl]
+curl -fsSL https://lerd.sh/install.sh | bash
+```
+
+```bash [wget]
+wget -qO- https://lerd.sh/install.sh | bash
+```
+
+:::
+
+If you keep the standalone installer around, `lerd-installer --update` swaps the binary too, but it stops there. Follow it with `lerd install` yourself.
+
+### Homebrew on macOS
+
+The tap moved along with everything else, and Homebrew follows the redirect, so the ordinary upgrade still works:
+
+```bash
+brew update
+brew upgrade lerd
+```
+
+To stop leaning on that redirect, point Homebrew at the tap's real home afterwards:
+
+```bash
+brew untap geodro/lerd
+brew tap lerd-env/lerd
+```
+
+### apt and dnf
+
+Packaged installs aren't affected. The Ubuntu PPA lives on Launchpad and the Fedora package on COPR, neither of which moved:
+
+```bash
+sudo apt upgrade      # Ubuntu, Debian
+sudo dnf upgrade      # Fedora
+```
+
+An old `lerd update` still errors out on a packaged install, because it looks up the release before it gets as far as telling you to use your package manager. The package manager is the right route regardless.
+
+### By hand
+
+If you'd rather not pipe a script anywhere, take the archive for your platform from the [releases page](https://github.com/lerd-env/lerd/releases/latest), then:
+
+```bash
+tar -xzf lerd_<version>_linux_amd64.tar.gz
+install -m 755 lerd ~/.local/bin/lerd
+install -m 755 lerd-tray ~/.local/bin/lerd-tray   # only if the archive has one
+lerd install
+```
+
+## Confirm it worked
+
+```bash
+lerd --version
+lerd update
+```
+
+The version should be 1.26.0 or newer, and `lerd update` should now report that you're already on the latest release instead of failing. From here on `lerd update` handles itself, including any future move.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -382,6 +382,8 @@ curl -fsSL https://lerd.sh/install.sh | bash
 ```
 
 Everything from 1.26 onwards resolves the organisation move on its own, so this is a one-time step.
+
+On Homebrew, apt, dnf, or if you'd rather not pipe a script anywhere, [Updating from a version before 1.26](getting-started/updating-from-pre-1.26.md) has the route for each.
 :::
 
 ::: details Error: NetworkUpdate is not supported for backend CNI: invalid argument


### PR DESCRIPTION
Anyone still on a build older than 1.26 cannot update, and nothing we release can reach them, so the docs are the only way across. The troubleshooting entry we already have answers that for a script install, but it sits in a collapsed block and says nothing to someone on Homebrew or a packaged build.

This adds a page under Getting Started covering the whole thing. How to tell whether you are affected, that only the release lookup is broken while the store, the changelog, the release archives and the GHCR base images all still resolve through GitHub redirects, and then the route for each way lerd can be installed. Homebrew still upgrades through the tap redirect, apt and dnf were never affected because the PPA lives on Launchpad and the package on COPR, and there is a manual archive swap for anyone who would rather not pipe a script anywhere.

It also calls out that the update notice in lerd status and lerd doctor fails quietly here, so a good number of affected users are not seeing an error at all, they simply stopped hearing that new releases exist.

The existing troubleshooting block stays and links to the page for the install methods it does not cover.

Closes #1342