### PR TITLE
fix(init): show every option in the wizard's multi-select steps

### DIFF
--- a/internal/cli/db_move.go
+++ b/internal/cli/db_move.go
@@ -391,11 +391,11 @@ func dbMoveWizard(reg *config.SiteRegistry, from, to string) (string, string, []
 	}
 	selected := append([]string(nil), siteOpts...)
 	if err := huh.NewForm(huh.NewGroup(
-		huh.NewMultiSelect[string]().
-			Title(fmt.Sprintf("Which sites to move from %s to %s?", from, to)).
-			Description("All selected by default; deselect any you want to leave behind.").
-			Options(huh.NewOptions(siteOpts...)...).
-			Value(&selected),
+		newMultiSelect(
+			fmt.Sprintf("Which sites to move from %s to %s?", from, to),
+			"All selected by default; deselect any you want to leave behind.",
+			siteOpts, &selected,
+		),
 	)).WithTheme(huh.ThemeFunc(huh.ThemeCatppuccin)).Run(); err != nil {
 		return "", "", nil, err
 	}

--- a/internal/cli/huh_fields.go
+++ b/internal/cli/huh_fields.go
@@ -1,0 +1,19 @@
+package cli
+
+import "charm.land/huh/v2"
+
+// newMultiSelect builds the wizard's multi-select fields. Pass an empty
+// description to leave it off.
+//
+// The explicit height is not cosmetic: an unsized huh multi-select sizes its
+// viewport to the option count and then subtracts the title and description
+// lines, so short lists lose rows and can render nothing at all.
+func newMultiSelect(title, description string, options []string, value *[]string) *huh.MultiSelect[string] {
+	field := huh.NewMultiSelect[string]().Title(title)
+	height := len(options) + 1
+	if description != "" {
+		field = field.Description(description)
+		height++
+	}
+	return field.Options(huh.NewOptions(options...)...).Value(value).Height(height)
+}

--- a/internal/cli/huh_fields_test.go
+++ b/internal/cli/huh_fields_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewMultiSelectShowsEveryOption(t *testing.T) {
+	cases := []struct {
+		name        string
+		description string
+		options     []string
+	}{
+		{name: "one option", options: []string{"schedule"}},
+		{name: "two options", options: []string{"queue", "schedule"}},
+		{name: "with description", description: "Auto-start when linking", options: []string{"queue", "schedule"}},
+		{name: "six options", description: "Deselect to remove", options: []string{"mailpit", "meilisearch", "redis", "rustfs", "gotenberg", "opensearch"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var selected []string
+			view := newMultiSelect("Workers", tc.description, tc.options, &selected).View()
+			for _, opt := range tc.options {
+				if !strings.Contains(view, opt) {
+					t.Errorf("option %q missing from rendered field:\n%s", opt, view)
+				}
+			}
+		})
+	}
+}
+
+func TestNewMultiSelectKeepsTitleAndDescription(t *testing.T) {
+	var selected []string
+	view := newMultiSelect("Workers", "Auto-start when linking", []string{"queue"}, &selected).View()
+
+	if !strings.Contains(view, "Workers") {
+		t.Errorf("title missing from rendered field:\n%s", view)
+	}
+	if !strings.Contains(view, "Auto-start when linking") {
+		t.Errorf("description missing from rendered field:\n%s", view)
+	}
+}
+
+func TestNewMultiSelectBindsValue(t *testing.T) {
+	selected := []string{"schedule"}
+	field := newMultiSelect("Workers", "", []string{"queue", "schedule"}, &selected)
+
+	got, ok := field.GetValue().([]string)
+	if !ok {
+		t.Fatalf("GetValue returned %T, want []string", field.GetValue())
+	}
+	if len(got) != 1 || got[0] != "schedule" {
+		t.Errorf("bound value = %v, want [schedule]", got)
+	}
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -302,10 +302,7 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 			Title("Database").
 			Options(dbOptions...).
 			Value(&dbChoice),
-		huh.NewMultiSelect[string]().
-			Title("Services").
-			Options(huh.NewOptions(nonDBServiceOptions...)...).
-			Value(&nonDBSelected),
+		newMultiSelect("Services", "", nonDBServiceOptions, &nonDBSelected),
 	)
 
 	formGroups := []*huh.Group{huh.NewGroup(firstGroupFields...)}
@@ -329,11 +326,7 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 
 	if len(customWorkerNames) > 0 {
 		formGroups = append(formGroups, huh.NewGroup(
-			huh.NewMultiSelect[string]().
-				Title("Custom workers").
-				Description("Deselect to remove from .lerd.yaml").
-				Options(huh.NewOptions(customWorkerNames...)...).
-				Value(&keepCustomWorkers),
+			newMultiSelect("Custom workers", "Deselect to remove from .lerd.yaml", customWorkerNames, &keepCustomWorkers),
 		))
 	}
 
@@ -410,11 +403,7 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 	if len(workerOptions) > 0 {
 		workerGroups := []*huh.Group{
 			huh.NewGroup(
-				huh.NewMultiSelect[string]().
-					Title("Workers").
-					Description("Auto-start when linking").
-					Options(huh.NewOptions(workerOptions...)...).
-					Value(&selectedWorkers),
+				newMultiSelect("Workers", "Auto-start when linking", workerOptions, &selectedWorkers),
 			),
 		}
 		if err := huh.NewForm(workerGroups...).WithTheme(huh.ThemeFunc(huh.ThemeCatppuccin)).Run(); err != nil {
@@ -595,10 +584,7 @@ func runCustomContainerWizard(cwd string, defaults *config.ProjectConfig, gcfg *
 
 	if len(serviceOptions) > 0 {
 		if err := huh.NewForm(huh.NewGroup(
-			huh.NewMultiSelect[string]().
-				Title("Services").
-				Options(huh.NewOptions(serviceOptions...)...).
-				Value(&selectedServices),
+			newMultiSelect("Services", "", serviceOptions, &selectedServices),
 		)).WithTheme(huh.ThemeFunc(huh.ThemeCatppuccin)).Run(); err != nil {
 			return nil, err
 		}
@@ -616,11 +602,7 @@ func runCustomContainerWizard(cwd string, defaults *config.ProjectConfig, gcfg *
 		copy(keepCustomWorkers, customWorkerNames)
 
 		if err := huh.NewForm(huh.NewGroup(
-			huh.NewMultiSelect[string]().
-				Title("Custom workers").
-				Description("Deselect to remove from .lerd.yaml").
-				Options(huh.NewOptions(customWorkerNames...)...).
-				Value(&keepCustomWorkers),
+			newMultiSelect("Custom workers", "Deselect to remove from .lerd.yaml", customWorkerNames, &keepCustomWorkers),
 		)).WithTheme(huh.ThemeFunc(huh.ThemeCatppuccin)).Run(); err != nil {
 			return nil, err
 		}
@@ -807,10 +789,7 @@ func runHostProxyWizard(cwd string, defaults *config.ProjectConfig, gcfg *config
 	selectedServices := defaults.ServiceNames()
 	if len(serviceOptions) > 0 {
 		if err := huh.NewForm(huh.NewGroup(
-			huh.NewMultiSelect[string]().
-				Title("Services").
-				Options(huh.NewOptions(serviceOptions...)...).
-				Value(&selectedServices),
+			newMultiSelect("Services", "", serviceOptions, &selectedServices),
 		)).WithTheme(huh.ThemeFunc(huh.ThemeCatppuccin)).Run(); err != nil {
 			return nil, err
 		}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -469,10 +469,7 @@ func runSetup(allSteps, skipOpen bool) error {
 		feedback.Begin()
 		if err := huh.NewForm(
 			huh.NewGroup(
-				huh.NewMultiSelect[string]().
-					Title("Setup steps").
-					Options(huh.NewOptions(options...)...).
-					Value(&selected),
+				newMultiSelect("Setup steps", "", options, &selected),
 			),
 		).WithTheme(huh.ThemeFunc(huh.ThemeCatppuccin)).Run(); err != nil {
 			return err


### PR DESCRIPTION
On a fresh install, lerd new laravel followed by lerd init put up a Workers step with a title, a description, and nothing under it. The list was being built correctly, queue and schedule were both in it, they simply never made it onto the screen.

The cause is in huh v2. An unsized multi-select sizes its viewport to the number of options it holds, then subtracts the height of the title and description from that same number. A two option list with a title and a description therefore lands on a zero height viewport, and a zero height viewport renders nothing. huh v1 returned early in the unsized case and v2's single select still does, which is why the Database step sitting right next to it was fine while the multi-selects were not. It came in with the Charm v2 dependency bump, the wizard code around it has not changed.

Workers was the visible casualty but every multi-select in the wizard is affected. The ones with a title and no description lose a single row off the bottom, so the Services step has been offering five entries out of six and quietly hiding opensearch from anyone running the wizard.

All eight fields now go through one helper that gives the field the height it actually needs. Lists longer than the terminal still scroll the way they did before, they just no longer start out clipped.

Refs #1344