### PR TITLE
fix(store): publish cached definitions atomically

### DIFF
--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/geodro/lerd/internal/atomicfile"
 	"gopkg.in/yaml.v3"
 )
 
@@ -1742,6 +1743,13 @@ func GetConsoleCommand(projectDir string) (string, error) {
 // SaveStoreFramework writes a store-installed framework definition to StoreFrameworksDir().
 // If the framework has a Version field, the file is named <name>@<version>.yaml.
 // Otherwise it is named <name>.yaml (backwards compatible).
+//
+// The write is atomic because the store has several writers and more readers:
+// the fetch hook fires from any GetFrameworkForDir, which the watcher, the
+// dashboard poll and the vhost renderer all reach, and the CLI hits it from
+// link and framework add. A definition cut above the workers key still parses,
+// so a torn read hands back a valid looking framework with nothing to run
+// rather than the error that would fall through to the fallback.
 func SaveStoreFramework(fw *Framework) error {
 	dir := StoreFrameworksDir()
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -1755,7 +1763,8 @@ func SaveStoreFramework(fw *Framework) error {
 	if fw.Version != "" {
 		filename = fw.Name + "@" + fw.Version + ".yaml"
 	}
-	return os.WriteFile(filepath.Join(dir, filename), data, 0644)
+	_, err = atomicfile.WriteIfChanged(filepath.Join(dir, filename), data, 0644)
+	return err
 }
 
 // RemoveUserFramework silently removes a user-defined framework YAML if it exists.

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/geodro/lerd/internal/atomicfile"
 	"gopkg.in/yaml.v3"
 )
 
@@ -1763,8 +1762,7 @@ func SaveStoreFramework(fw *Framework) error {
 	if fw.Version != "" {
 		filename = fw.Name + "@" + fw.Version + ".yaml"
 	}
-	_, err = atomicfile.WriteIfChanged(filepath.Join(dir, filename), data, 0644)
-	return err
+	return publishStoreFile(filepath.Join(dir, filename), data, 0644)
 }
 
 // RemoveUserFramework silently removes a user-defined framework YAML if it exists.

--- a/internal/config/framework_store_write_test.go
+++ b/internal/config/framework_store_write_test.go
@@ -154,34 +154,6 @@ func TestSaveStoreFramework_leavesNoTempFileBehind(t *testing.T) {
 	}
 }
 
-// The definition is rewritten every time it passes the staleness check, and the
-// bytes are almost always the same ones. Republishing them costs a write and a
-// rename for nothing, and each rename is a window another process can read in.
-func TestSaveStoreFramework_skipsTheWriteWhenNothingChanged(t *testing.T) {
-	store := storeSandbox(t)
-	path := filepath.Join(store, "acme@1.yaml")
-
-	if err := SaveStoreFramework(storeFrameworkWithWorkers("Acme", 10)); err != nil {
-		t.Fatal(err)
-	}
-	before, err := os.Stat(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := SaveStoreFramework(storeFrameworkWithWorkers("Acme", 10)); err != nil {
-		t.Fatal(err)
-	}
-	after, err := os.Stat(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !after.ModTime().Equal(before.ModTime()) {
-		t.Error("an unchanged definition was republished")
-	}
-}
-
 // The unversioned filename is what older installs read, so it has to keep
 // working alongside the versioned one.
 func TestSaveStoreFramework_writesTheUnversionedNameWhenVersionIsEmpty(t *testing.T) {

--- a/internal/config/framework_store_write_test.go
+++ b/internal/config/framework_store_write_test.go
@@ -1,0 +1,199 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// storeFrameworkWithWorkers builds a definition big enough that a truncated
+// write lands mid-file rather than never starting.
+func storeFrameworkWithWorkers(label string, workers int) *Framework {
+	fw := &Framework{
+		Name:      "acme",
+		Version:   "1",
+		Label:     label,
+		PublicDir: "public",
+		Workers:   map[string]FrameworkWorker{},
+	}
+	for i := 0; i < workers; i++ {
+		name := "worker" + strings.Repeat("x", i%40) + string(rune('a'+i%26))
+		fw.Workers[name] = FrameworkWorker{
+			Label:   strings.Repeat("padding ", 32),
+			Command: "php artisan " + strings.Repeat("y", 200),
+			Restart: "always",
+		}
+	}
+	return fw
+}
+
+// A definition cut above the workers key still parses, so a reader of a
+// half-written file gets a valid looking framework with nothing to run rather
+// than an error and the fallback that would follow it.
+func TestSaveStoreFramework_readerNeverSeesAPartialDefinition(t *testing.T) {
+	store := storeSandbox(t)
+	path := filepath.Join(store, "acme@1.yaml")
+
+	if err := SaveStoreFramework(storeFrameworkWithWorkers("Seed", 60)); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 40; i++ {
+			if err := SaveStoreFramework(storeFrameworkWithWorkers(strings.Repeat("L", i+1), 60)); err != nil {
+				t.Errorf("save: %v", err)
+				break
+			}
+		}
+		close(stop)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			var fw Framework
+			if err := yaml.Unmarshal(data, &fw); err != nil {
+				t.Errorf("reader saw an unparseable definition: %v", err)
+				return
+			}
+			if len(fw.Workers) != 60 {
+				t.Errorf("reader saw %d workers, want 60: the definition was published half written", len(fw.Workers))
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+// Concurrent writers must publish one writer's definition whole, never a blend
+// of two. The store has several: the fetch hook fires from the watcher, the
+// dashboard poll and the vhost renderer, and the CLI reaches it from link and
+// framework add.
+func TestSaveStoreFramework_concurrentWritersNeverPublishAMerge(t *testing.T) {
+	store := storeSandbox(t)
+	path := filepath.Join(store, "acme@1.yaml")
+
+	labels := []string{"Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot"}
+	var wg sync.WaitGroup
+	for _, label := range labels {
+		wg.Add(1)
+		go func(label string) {
+			defer wg.Done()
+			for i := 0; i < 5; i++ {
+				if err := SaveStoreFramework(storeFrameworkWithWorkers(label, 60)); err != nil {
+					t.Errorf("save %s: %v", label, err)
+					return
+				}
+			}
+		}(label)
+	}
+	wg.Wait()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fw Framework
+	if err := yaml.Unmarshal(data, &fw); err != nil {
+		t.Fatalf("published definition does not parse: %v", err)
+	}
+	found := false
+	for _, label := range labels {
+		if fw.Label == label {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("published label %q belongs to no single writer", fw.Label)
+	}
+	if len(fw.Workers) != 60 {
+		t.Errorf("published definition has %d workers, want 60", len(fw.Workers))
+	}
+}
+
+// The temp a write goes through must not survive it, or the store dir fills
+// with debris that the framework listing then has to ignore.
+func TestSaveStoreFramework_leavesNoTempFileBehind(t *testing.T) {
+	store := storeSandbox(t)
+
+	for i := 0; i < 3; i++ {
+		if err := SaveStoreFramework(storeFrameworkWithWorkers("Acme", 10)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	entries, err := os.ReadDir(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "acme@1.yaml" {
+			t.Errorf("unexpected leftover in the store dir: %s", e.Name())
+		}
+	}
+}
+
+// The definition is rewritten every time it passes the staleness check, and the
+// bytes are almost always the same ones. Republishing them costs a write and a
+// rename for nothing, and each rename is a window another process can read in.
+func TestSaveStoreFramework_skipsTheWriteWhenNothingChanged(t *testing.T) {
+	store := storeSandbox(t)
+	path := filepath.Join(store, "acme@1.yaml")
+
+	if err := SaveStoreFramework(storeFrameworkWithWorkers("Acme", 10)); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SaveStoreFramework(storeFrameworkWithWorkers("Acme", 10)); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Error("an unchanged definition was republished")
+	}
+}
+
+// The unversioned filename is what older installs read, so it has to keep
+// working alongside the versioned one.
+func TestSaveStoreFramework_writesTheUnversionedNameWhenVersionIsEmpty(t *testing.T) {
+	store := storeSandbox(t)
+
+	fw := storeFrameworkWithWorkers("Acme", 4)
+	fw.Version = ""
+	if err := SaveStoreFramework(fw); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(store, "acme.yaml")); err != nil {
+		t.Errorf("unversioned definition not written: %v", err)
+	}
+}

--- a/internal/config/preset_source.go
+++ b/internal/config/preset_source.go
@@ -8,8 +8,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-
-	"github.com/geodro/lerd/internal/atomicfile"
 )
 
 // presetStaleAfter is how long a cached store preset is served before EnsurePreset
@@ -140,7 +138,7 @@ func SaveStorePreset(name string, data []byte) error {
 		return err
 	}
 	guardRealWrite(filepath.Join(dir, name+".yaml"))
-	if _, err := atomicfile.WriteIfChanged(filepath.Join(dir, name+".yaml"), data, 0o644); err != nil {
+	if err := publishStoreFile(filepath.Join(dir, name+".yaml"), data, 0o644); err != nil {
 		return err
 	}
 	presetCache.Delete(name)

--- a/internal/config/preset_source.go
+++ b/internal/config/preset_source.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/geodro/lerd/internal/atomicfile"
 )
 
 // presetStaleAfter is how long a cached store preset is served before EnsurePreset
@@ -138,7 +140,7 @@ func SaveStorePreset(name string, data []byte) error {
 		return err
 	}
 	guardRealWrite(filepath.Join(dir, name+".yaml"))
-	if err := os.WriteFile(filepath.Join(dir, name+".yaml"), data, 0o644); err != nil {
+	if _, err := atomicfile.WriteIfChanged(filepath.Join(dir, name+".yaml"), data, 0o644); err != nil {
 		return err
 	}
 	presetCache.Delete(name)

--- a/internal/config/preset_store_write_test.go
+++ b/internal/config/preset_store_write_test.go
@@ -77,33 +77,6 @@ func TestSaveStorePreset_readerNeverSeesAPartialPreset(t *testing.T) {
 	wg.Wait()
 }
 
-// EnsurePreset refreshes on a staleness tick, and the bytes it fetches are
-// nearly always the ones already on disk.
-func TestSaveStorePreset_skipsTheWriteWhenNothingChanged(t *testing.T) {
-	t.Setenv("XDG_DATA_HOME", t.TempDir())
-	path := filepath.Join(StorePresetsDir(), "redis.yaml")
-
-	if err := SaveStorePreset("redis", storePresetYAML("1")); err != nil {
-		t.Fatal(err)
-	}
-	before, err := os.Stat(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := SaveStorePreset("redis", storePresetYAML("1")); err != nil {
-		t.Fatal(err)
-	}
-	after, err := os.Stat(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !after.ModTime().Equal(before.ModTime()) {
-		t.Error("an unchanged preset was republished")
-	}
-}
-
 func TestSaveStorePreset_leavesNoTempFileBehind(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	dir := StorePresetsDir()

--- a/internal/config/preset_store_write_test.go
+++ b/internal/config/preset_store_write_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// storePresetYAML builds a preset long enough that a truncated write lands
+// mid-file. The versions list is last, so a cut above it still parses.
+func storePresetYAML(tag string) []byte {
+	var sb strings.Builder
+	sb.WriteString("name: redis\n")
+	sb.WriteString("description: " + strings.Repeat("padding ", 200) + "\n")
+	sb.WriteString("versions:\n")
+	for i := 0; i < 40; i++ {
+		v := tag + "." + strconv.Itoa(i)
+		sb.WriteString("    - tag: \"" + v + "\"\n")
+		sb.WriteString("      image: example/redis:" + v + "\n")
+	}
+	return []byte(sb.String())
+}
+
+// The service store cache has the same shape of writer as the framework store:
+// the fetch hook refreshes a preset past its staleness window while other
+// processes are reading it. A preset cut above its versions key still parses.
+func TestSaveStorePreset_readerNeverSeesAPartialPreset(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	path := filepath.Join(StorePresetsDir(), "redis.yaml")
+
+	if err := SaveStorePreset("redis", storePresetYAML("1")); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 40; i++ {
+			if err := SaveStorePreset("redis", storePresetYAML(strconv.Itoa(i))); err != nil {
+				t.Errorf("save: %v", err)
+				break
+			}
+		}
+		close(stop)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			if err := ValidatePresetYAML(data, "redis"); err != nil {
+				t.Errorf("reader saw a half written preset: %v", err)
+				return
+			}
+			if n := strings.Count(string(data), "    - tag:"); n != 40 {
+				t.Errorf("reader saw %d versions, want 40: the preset was published half written", n)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+// EnsurePreset refreshes on a staleness tick, and the bytes it fetches are
+// nearly always the ones already on disk.
+func TestSaveStorePreset_skipsTheWriteWhenNothingChanged(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	path := filepath.Join(StorePresetsDir(), "redis.yaml")
+
+	if err := SaveStorePreset("redis", storePresetYAML("1")); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SaveStorePreset("redis", storePresetYAML("1")); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Error("an unchanged preset was republished")
+	}
+}
+
+func TestSaveStorePreset_leavesNoTempFileBehind(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	dir := StorePresetsDir()
+
+	for i := 0; i < 3; i++ {
+		if err := SaveStorePreset("redis", storePresetYAML(strconv.Itoa(i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "redis.yaml" {
+			t.Errorf("unexpected leftover in the preset cache dir: %s", e.Name())
+		}
+	}
+}

--- a/internal/config/store_write.go
+++ b/internal/config/store_write.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"os"
+	"time"
+
+	"github.com/geodro/lerd/internal/atomicfile"
+)
+
+// publishStoreFile writes a store-cache file atomically and, when the bytes on
+// disk already matched, leaves the file alone but moves its mtime forward.
+//
+// Both staleness windows in the store are measured from the cached file's
+// mtime, and the fetch that refreshes it almost always brings back the bytes
+// already there. Skipping that write without restamping would leave the file
+// looking permanently stale, turning a once-a-day refetch into one on every
+// call.
+func publishStoreFile(path string, data []byte, perm os.FileMode) error {
+	wrote, err := atomicfile.WriteIfChanged(path, data, perm)
+	if err != nil || wrote {
+		return err
+	}
+	now := time.Now()
+	return os.Chtimes(path, now, now)
+}

--- a/internal/config/store_write.go
+++ b/internal/config/store_write.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/geodro/lerd/internal/atomicfile"
@@ -15,11 +16,24 @@ import (
 // already there. Skipping that write without restamping would leave the file
 // looking permanently stale, turning a once-a-day refetch into one on every
 // call.
+//
+// Publishing through a rename is what makes the write atomic, but it also
+// replaces the file rather than rewriting it, which a plain os.WriteFile never
+// did. Resolving symlinks first keeps a store entry someone pointed at their
+// own checkout pointing there, and carrying the existing mode over keeps a
+// tightened file tightened.
 func publishStoreFile(path string, data []byte, perm os.FileMode) error {
-	wrote, err := atomicfile.WriteIfChanged(path, data, perm)
+	target := path
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		target = resolved
+	}
+	if info, err := os.Stat(target); err == nil {
+		perm = info.Mode().Perm()
+	}
+	wrote, err := atomicfile.WriteIfChanged(target, data, perm)
 	if err != nil || wrote {
 		return err
 	}
 	now := time.Now()
-	return os.Chtimes(path, now, now)
+	return os.Chtimes(target, now, now)
 }

--- a/internal/config/store_write_test.go
+++ b/internal/config/store_write_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// statOf identifies the file behind a path, so os.SameFile can tell an
+// untouched file from one republished through a temp and a rename.
+func statOf(t *testing.T, path string) os.FileInfo {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info
+}
+
+func ageFile(t *testing.T, path string, age time.Duration) {
+	t.Helper()
+	stamp := time.Now().Add(-age)
+	if err := os.Chtimes(path, stamp, stamp); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// GetFrameworkForDir refetches a definition once its file is over 24h old, and
+// that window is measured from the file's mtime. Skipping the write for
+// unchanged bytes must still move the stamp, or every call past the window
+// refetches over the network forever instead of once a day.
+func TestSaveStoreFramework_refreshesTheStalenessStampWhenContentIsUnchanged(t *testing.T) {
+	store := storeSandbox(t)
+	path := filepath.Join(store, "acme@1.yaml")
+
+	if err := SaveStoreFramework(storeFrameworkWithWorkers("Acme", 10)); err != nil {
+		t.Fatal(err)
+	}
+	ageFile(t, path, 48*time.Hour)
+	before := statOf(t, path)
+
+	if err := SaveStoreFramework(storeFrameworkWithWorkers("Acme", 10)); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if time.Since(info.ModTime()) > time.Minute {
+		t.Errorf("staleness stamp still reads %v old, so the definition refetches on every call", time.Since(info.ModTime()))
+	}
+	if !os.SameFile(before, statOf(t, path)) {
+		t.Error("unchanged definition was republished rather than restamped")
+	}
+}
+
+// EnsurePreset uses the same 24h window on the preset's own mtime.
+func TestSaveStorePreset_refreshesTheStalenessStampWhenContentIsUnchanged(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	path := filepath.Join(StorePresetsDir(), "redis.yaml")
+
+	if err := SaveStorePreset("redis", storePresetYAML("1")); err != nil {
+		t.Fatal(err)
+	}
+	ageFile(t, path, 48*time.Hour)
+	before := statOf(t, path)
+
+	if err := SaveStorePreset("redis", storePresetYAML("1")); err != nil {
+		t.Fatal(err)
+	}
+
+	if storePresetStale("redis") {
+		t.Error("preset still reads stale after a refresh, so it refetches on every call")
+	}
+	if !os.SameFile(before, statOf(t, path)) {
+		t.Error("unchanged preset was republished rather than restamped")
+	}
+}

--- a/internal/config/store_write_test.go
+++ b/internal/config/store_write_test.go
@@ -26,6 +26,78 @@ func ageFile(t *testing.T, path string, age time.Duration) {
 	}
 }
 
+// os.WriteFile wrote through a symlink; a rename would replace it with a plain
+// file. A developer pointing a store entry at their lerd-frameworks checkout
+// keeps that link either way.
+func TestPublishStoreFile_writesThroughASymlink(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real.yaml")
+	link := filepath.Join(dir, "link.yaml")
+	if err := os.WriteFile(real, []byte("old\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := publishStoreFile(link, []byte("new\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Error("the symlink was replaced by a regular file")
+	}
+	got, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new\n" {
+		t.Errorf("symlink target holds %q, want %q", got, "new\n")
+	}
+}
+
+// os.WriteFile leaves an existing file's mode alone, so a store entry someone
+// tightened to 0600 must not be widened back to 0644 by a refresh.
+func TestPublishStoreFile_preservesAnExistingFileMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "def.yaml")
+	if err := os.WriteFile(path, []byte("old\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := publishStoreFile(path, []byte("new\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Errorf("mode is %v, want 0600: a refresh widened an existing file", got)
+	}
+}
+
+// A file that does not exist yet still lands on the requested mode.
+func TestPublishStoreFile_appliesTheRequestedModeToANewFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "def.yaml")
+
+	if err := publishStoreFile(path, []byte("new\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0644 {
+		t.Errorf("mode is %v, want 0644", got)
+	}
+}
+
 // GetFrameworkForDir refetches a definition once its file is over 24h old, and
 // that window is measured from the file's mtime. Skipping the write for
 // unchanged bytes must still move the stamp, or every call past the window

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,10 +7,10 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/geodro/lerd/internal/atomicfile"
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/origin"
 	"gopkg.in/yaml.v3"
@@ -133,22 +133,14 @@ func loadCachedIndex() (*Index, error) {
 	return &idx, nil
 }
 
-// writeCachedIndex persists the raw index bytes to the local cache atomically
-// (temp then rename) so an offline reader in another process, or a crash
-// mid-write, never sees a truncated file. Best effort: a cache we cannot write
-// just means the next read falls back to the network.
+// writeCachedIndex persists the raw index bytes to the local cache through a
+// uniquely named temp and a rename, so an offline reader in another process, or
+// a crash mid-write, never sees a truncated file. The unique name matters: a
+// fixed one lets two concurrent fetches truncate and fill the same temp, and the
+// rename then publishes their blend. Best effort: a cache we cannot write just
+// means the next read falls back to the network.
 func writeCachedIndex(data []byte) {
-	path := config.StoreIndexFile()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return
-	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-	}
+	_, _ = atomicfile.WriteIfChanged(config.StoreIndexFile(), data, 0o644)
 }
 
 // FetchFramework downloads a framework definition from the store.

--- a/internal/store/store_index_write_test.go
+++ b/internal/store/store_index_write_test.go
@@ -1,0 +1,134 @@
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// indexBytes builds an index big enough that a truncated write lands mid-file.
+func indexBytes(label string, entries int) []byte {
+	var idx Index
+	for i := 0; i < entries; i++ {
+		idx.Frameworks = append(idx.Frameworks, IndexEntry{
+			Name:     label + "-" + strconv.Itoa(i),
+			Label:    label + " " + strings.Repeat("padding ", 16),
+			Versions: []string{"1", "2", "3"},
+			Latest:   "3",
+		})
+	}
+	data, err := json.Marshal(idx)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+// Two fetches racing on the cache used to share one fixed temp name, so both
+// truncated and filled the same file and the rename published their blend.
+func TestWriteCachedIndex_concurrentWritersNeverPublishAMerge(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	labels := []string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot"}
+	var wg sync.WaitGroup
+	for _, label := range labels {
+		wg.Add(1)
+		go func(label string) {
+			defer wg.Done()
+			data := indexBytes(label, 2000)
+			for i := 0; i < 5; i++ {
+				writeCachedIndex(data)
+			}
+		}(label)
+	}
+	wg.Wait()
+
+	idx, err := loadCachedIndex()
+	if err != nil {
+		t.Fatalf("published index does not parse: %v", err)
+	}
+	if len(idx.Frameworks) != 2000 {
+		t.Fatalf("published index has %d entries, want 2000", len(idx.Frameworks))
+	}
+	prefix := strings.SplitN(idx.Frameworks[0].Name, "-", 2)[0]
+	for _, e := range idx.Frameworks {
+		if !strings.HasPrefix(e.Name, prefix+"-") {
+			t.Fatalf("published index blends writers: found %q alongside %q", e.Name, prefix)
+		}
+	}
+}
+
+// A reader hitting the cache mid-refresh must get the previous index or the
+// complete new one, never a truncated file that fails to unmarshal.
+func TestWriteCachedIndex_readerNeverSeesAPartialIndex(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	writeCachedIndex(indexBytes("seed", 2000))
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	var writers sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		writers.Add(1)
+		go func(w int) {
+			defer writers.Done()
+			for i := 0; i < 40; i++ {
+				writeCachedIndex(indexBytes("w"+strconv.Itoa(w)+"r"+strconv.Itoa(i), 2000))
+			}
+		}(w)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		writers.Wait()
+		close(stop)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			idx, err := loadCachedIndex()
+			if err != nil {
+				t.Errorf("reader saw an unparseable index: %v", err)
+				return
+			}
+			if len(idx.Frameworks) != 2000 {
+				t.Errorf("reader saw %d entries, want 2000: the index was published half written", len(idx.Frameworks))
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestWriteCachedIndex_leavesNoTempFileBehind(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	for i := 0; i < 3; i++ {
+		writeCachedIndex(indexBytes("round"+strconv.Itoa(i), 10))
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(config.StoreIndexFile()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Errorf("temp file survived the write: %s", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
config.SaveStoreFramework wrote a definition with a plain os.WriteFile, so a reader that arrived mid-write saw whatever bytes had landed so far. That is quiet rather than loud, because a definition cut above the workers key still parses, and the reader ends up with a valid looking framework that has nothing to run instead of the parse error that would have fallen through to the fallback.

There are more writers than it looks. The fetch hook fires from any call to GetFrameworkForDir, which the watcher, the dashboard poll and the vhost renderer all reach, the CLI hits the same path from link and framework add, and install seeds the cache in the same window. Nothing dedupes them, and the definition is rewritten again every time it passes the staleness check.

The service preset cache had the identical problem, and so did the store index, which is worth spelling out because the index looked like the safe example to copy. It did go through a temp file and a rename, but the temp name was fixed, so two concurrent fetches truncated and filled the same file, and once the first one renamed it into place the second kept writing through its open handle into the live index. A reader in that window gets a truncated file that does not unmarshal at all.

All three now go through internal/atomicfile, which writes a uniquely named temp in the target directory and renames it into place, so a reader sees either the previous definition or the complete new one. Content that has not changed is left untouched, which also takes the staleness tick's pointless rewrite off the disk and closes most of the windows a reader could have landed in.

Refs #1346