### PR TITLE
fix(shims): report a client shim toggle that could not be carried out

### DIFF
--- a/docs/usage/database.md
+++ b/docs/usage/database.md
@@ -341,6 +341,8 @@ lerd shims add mysqldump      # put it back
 
 The same per-tool toggles are on each database service's Tools tab in the web UI. When two services of the same family are installed (say mysql and mariadb, which both provide `mysqldump`), one owns the shim and runs it; the others show that tool disabled on their Tools tab so it is managed in one place.
 
+Whether a tool reads as installed is answered by the shim dir itself rather than by the choice you made, so a tool counts as on only while its shim is really there. If the name is already taken in `~/.local/share/lerd/bin` by a file lerd did not write, it is left alone and adding the shim fails with that path instead of being recorded as on, both from the command and from the toggle in the web UI. Remove the file and add the shim again.
+
 ## Recovering after a service reinstall
 
 `lerd service reinstall <name> --reset-data` wipes the database server's data dir (rename-aside, recoverable) and then walks every active site that depends on the service to recreate the database it expects via `CREATE DATABASE IF NOT EXISTS`. Database name resolution is the same as `lerd env`: `.lerd.yaml` `db.database` first, then `.env` `DB_DATABASE`, then a name derived from the site name.

--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -11,6 +11,7 @@
 package shims
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -181,13 +182,13 @@ func ServiceShims(name string) []Info {
 		if cs.Name == "" {
 			continue
 		}
-		enabled, decided := decision(cs.Name)
+		_, decided := decision(cs.Name)
 		out = append(out, Info{
 			Tool:    cs.Name,
 			Service: name,
 			Owner:   targets[cs.Name].Service,
 			HostHas: hostHasTool(cs.Name),
-			Enabled: enabled,
+			Enabled: installed(cs.Name),
 			Decided: decided,
 		})
 	}
@@ -267,12 +268,12 @@ func List() []Info {
 	sort.Strings(tools)
 	out := make([]Info, 0, len(tools))
 	for _, t := range tools {
-		enabled, decided := decision(t)
+		_, decided := decision(t)
 		out = append(out, Info{
 			Tool:    t,
 			Service: targets[t].Service,
 			HostHas: hostHasTool(t),
-			Enabled: enabled,
+			Enabled: installed(t),
 			Decided: decided,
 		})
 	}
@@ -281,23 +282,34 @@ func List() []Info {
 
 // Set is the single entry point for an explicit shim decision, shared by the
 // CLI (`lerd shims add/remove`) and the web UI toggle. It validates that an
-// installed service actually exposes the tool, records the decision, and
-// reconciles so the change takes effect at once. It never prompts.
+// installed service actually exposes the tool, applies the change to the shim
+// dir, and only records the decision once that succeeded, so a toggle that
+// could not be carried out never reads back as done. It never prompts.
 func Set(tool string, enabled bool) error {
 	if _, ok := Targets()[tool]; !ok {
 		return fmt.Errorf("no installed service exposes the %q client tool", tool)
 	}
-	if err := setDecision(tool, enabled); err != nil {
+	lerdBin, err := os.Executable()
+	if err != nil {
 		return err
 	}
-	return Reconcile(nil)
+	binDir := config.BinDir()
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return err
+	}
+	if err := apply(lerdBin, binDir, tool, enabled); err != nil {
+		return err
+	}
+	return recordDecision(tool, enabled)
 }
 
 // Reconcile brings the host shim dir in line with the tools the installed
 // services expose and the recorded decisions. prompt resolves a host-conflict
 // on first sight; pass nil on non-interactive paths (a removal, an update
 // reconcile) to leave conflicts undecided. Shims for tools no longer exposed by
-// any installed service are pruned.
+// any installed service are pruned. A tool it could not carry out is reported
+// rather than skipped quietly, and its decision stays unrecorded so the next
+// run tries again.
 func Reconcile(prompt Prompter) error {
 	lerdBin, err := os.Executable()
 	if err != nil {
@@ -309,41 +321,54 @@ func Reconcile(prompt Prompter) error {
 	}
 
 	targets := Targets()
+	var errs []error
 	for tool := range targets {
-		enabled, _ := decide(tool, prompt)
-		shimPath := filepath.Join(binDir, tool)
-		if enabled {
-			if canWriteShim(shimPath) {
-				_ = os.WriteFile(shimPath, []byte(script(lerdBin, tool)), 0755)
+		enabled, decided := decide(tool, prompt)
+		if err := apply(lerdBin, binDir, tool, enabled); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if decided {
+			if err := recordDecision(tool, enabled); err != nil {
+				errs = append(errs, err)
 			}
-		} else {
-			removeIfShim(shimPath)
 		}
 	}
 	pruneOrphans(targets)
-	return nil
+	return errors.Join(errs...)
+}
+
+// apply brings one tool's shim in line with a resolved decision: write it when
+// enabled, take ours away when not. An enable whose target path is held by a
+// file lerd will not overwrite is an error rather than a silent skip, so the
+// caller can say why the tool did not appear on PATH.
+func apply(lerdBin, binDir, tool string, enabled bool) error {
+	path := filepath.Join(binDir, tool)
+	if !enabled {
+		return removeIfShim(path)
+	}
+	if !canWriteShim(path) {
+		return fmt.Errorf("%s already exists and is not a lerd shim, so the %s shim was not installed; remove that file first", path, tool)
+	}
+	return os.WriteFile(path, []byte(script(lerdBin, tool)), 0755)
 }
 
 // decide resolves whether a tool's shim should be installed. A recorded decision
 // wins. Otherwise, when the host lacks the tool there is no conflict so the shim
-// is enabled automatically; when the host already has it, prompt decides (and
-// the answer is recorded). A nil prompt leaves the conflict undecided.
+// is enabled automatically; when the host already has it, prompt decides. A nil
+// prompt leaves the conflict undecided. Recording the answer is the caller's
+// job, once the shim it implies is actually on disk.
 func decide(tool string, prompt Prompter) (enabled, decided bool) {
 	if e, d := decision(tool); d {
 		return e, true
 	}
 	if !hostHasTool(tool) {
-		_ = setDecision(tool, true)
 		return true, true
 	}
 	if prompt == nil {
 		return false, false
 	}
-	e, d := prompt(tool)
-	if d {
-		_ = setDecision(tool, e)
-	}
-	return e, d
+	return prompt(tool)
 }
 
 // hostHasTool reports whether the user already has the named tool on their PATH,
@@ -376,10 +401,18 @@ func canWriteShim(path string) bool {
 
 // removeIfShim deletes path only when it is one of lerd's client shims, so the
 // reconcile never removes a user's own binary of the same name.
-func removeIfShim(path string) {
-	if isShimFile(path) {
-		_ = os.Remove(path)
+func removeIfShim(path string) error {
+	if !isShimFile(path) {
+		return nil
 	}
+	return os.Remove(path)
+}
+
+// installed reports whether a tool's shim is actually on disk, which is what
+// "enabled" means to a caller. Reading the recorded decision instead would
+// surface a tool as on whose shim never got written.
+func installed(tool string) bool {
+	return isShimFile(filepath.Join(config.BinDir(), tool))
 }
 
 // pruneOrphans removes generated shims whose tool is no longer exposed by any
@@ -401,8 +434,9 @@ func pruneOrphans(targets map[string]Target) {
 		}
 		path := filepath.Join(binDir, tool)
 		if isShimFile(path) {
-			_ = os.Remove(path)
-			_ = forgetDecision(tool)
+			if err := os.Remove(path); err == nil {
+				_ = forgetDecision(tool)
+			}
 		}
 	}
 }
@@ -437,6 +471,15 @@ func decision(tool string) (enabled, decided bool) {
 	}
 	v, ok := m[tool]
 	return v, ok
+}
+
+// recordDecision stores a resolved decision, skipping the write when the file
+// already says the same thing so a routine reconcile leaves it untouched.
+func recordDecision(tool string, enabled bool) error {
+	if e, d := decision(tool); d && e == enabled {
+		return nil
+	}
+	return setDecision(tool, enabled)
 }
 
 func setDecision(tool string, enabled bool) error {

--- a/internal/shims/shims_test.go
+++ b/internal/shims/shims_test.go
@@ -219,6 +219,132 @@ func TestDecideLeavesConflictUndecidedWithoutPrompter(t *testing.T) {
 	}
 }
 
+// installMysql sets up an isolated data/config home with a single installed
+// service exposing the mysql client tools, so the Set/Reconcile tests below run
+// against real Targets() without a podman backend.
+func installMysql(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir()) // host has neither tool
+
+	svc := &config.CustomService{Name: "mysql-8", Image: "docker.io/library/mysql:8.4.4",
+		Ports: []string{"3306:3306"}, ClientShims: []config.ClientShim{{Name: "mysql"}, {Name: "mysqldump"}}}
+	if err := config.SaveCustomService(svc); err != nil {
+		t.Fatalf("SaveCustomService: %v", err)
+	}
+	prev := services.Mgr
+	services.Mgr = &fakeMgr{installed: map[string]bool{"lerd-mysql-8": true}}
+	t.Cleanup(func() { services.Mgr = prev })
+}
+
+// A toggle must report what actually happened: when the target path is held by
+// a file lerd will not overwrite, Set fails, says so, and records nothing, so
+// the tool cannot come back as enabled from a decision whose shim never landed.
+func TestSetFailsAndRecordsNothingWhenThePathIsOccupied(t *testing.T) {
+	installMysql(t)
+	binDir := config.BinDir()
+	_ = os.MkdirAll(binDir, 0755)
+	occupied := filepath.Join(binDir, "mysql")
+	_ = os.WriteFile(occupied, []byte("#!/bin/sh\necho mine\n"), 0755)
+
+	err := Set("mysql", true)
+	if err == nil {
+		t.Fatal("Set must fail when the shim path holds a file lerd does not own")
+	}
+	if !strings.Contains(err.Error(), "mysql") {
+		t.Errorf("error should name the tool, got %q", err)
+	}
+	if _, decided := decision("mysql"); decided {
+		t.Error("a failed write must leave the decision unrecorded")
+	}
+	data, _ := os.ReadFile(occupied)
+	if string(data) != "#!/bin/sh\necho mine\n" {
+		t.Error("the occupying file must be left intact")
+	}
+	for _, info := range ServiceShims("mysql-8") {
+		if info.Tool == "mysql" && info.Enabled {
+			t.Error("a tool with no shim on disk must not report as enabled")
+		}
+	}
+}
+
+func TestSetWritesTheShimThenRecordsTheDecision(t *testing.T) {
+	installMysql(t)
+	if err := Set("mysqldump", true); err != nil {
+		t.Fatalf("Set(true): %v", err)
+	}
+	shim := filepath.Join(config.BinDir(), "mysqldump")
+	if !isShimFile(shim) {
+		t.Fatal("enabling should have written the shim")
+	}
+	if e, d := decision("mysqldump"); !d || !e {
+		t.Fatalf("want decided+enabled, got decided=%v enabled=%v", d, e)
+	}
+
+	if err := Set("mysqldump", false); err != nil {
+		t.Fatalf("Set(false): %v", err)
+	}
+	if _, err := os.Stat(shim); !os.IsNotExist(err) {
+		t.Error("disabling should have removed the shim")
+	}
+	if e, d := decision("mysqldump"); !d || e {
+		t.Fatalf("want decided+disabled, got decided=%v enabled=%v", d, e)
+	}
+}
+
+// Enabled follows the shim on disk, not the recorded intent: a decision left
+// over from a write that never landed reads as not installed.
+func TestEnabledFollowsTheShimOnDisk(t *testing.T) {
+	installMysql(t)
+	_ = setDecision("mysql", true)
+
+	for _, info := range List() {
+		if info.Tool == "mysql" && info.Enabled {
+			t.Error("List: a recorded decision with no shim must not read as enabled")
+		}
+	}
+
+	_ = os.MkdirAll(config.BinDir(), 0755)
+	_ = os.WriteFile(filepath.Join(config.BinDir(), "mysql"), []byte(script("lerd", "mysql")), 0755)
+	found := false
+	for _, info := range ServiceShims("mysql-8") {
+		if info.Tool == "mysql" {
+			found = true
+			if !info.Enabled {
+				t.Error("ServiceShims: a shim present on disk must read as enabled")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("mysql should be listed among the service's shims")
+	}
+}
+
+// The reconcile is not allowed to be quiet about a shim it could not write: it
+// reports the skip and leaves the decision unrecorded so the next run retries.
+func TestReconcileReportsAnOccupiedPath(t *testing.T) {
+	installMysql(t)
+	binDir := config.BinDir()
+	_ = os.MkdirAll(binDir, 0755)
+	_ = os.WriteFile(filepath.Join(binDir, "mysql"), []byte("#!/bin/sh\necho mine\n"), 0755)
+
+	err := Reconcile(nil)
+	if err == nil || !strings.Contains(err.Error(), "mysql") {
+		t.Fatalf("Reconcile should report the skipped tool, got %v", err)
+	}
+	if _, decided := decision("mysql"); decided {
+		t.Error("a skipped write must leave the decision unrecorded")
+	}
+	// The other tool of the same service is unaffected by the skip.
+	if !isShimFile(filepath.Join(binDir, "mysqldump")) {
+		t.Error("a skip on one tool must not stop the rest of the reconcile")
+	}
+	if e, d := decision("mysqldump"); !d || !e {
+		t.Errorf("the written tool should be recorded, got decided=%v enabled=%v", d, e)
+	}
+}
+
 // Targets() keeps only the first installed service as a tool's shared
 // "owner"; ToolCandidates must return every installed service exposing the
 // tool, so a caller can disambiguate among several same-family instances

--- a/internal/ui/web/src/tabs/services/ServiceToolsTab.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceToolsTab.svelte
@@ -11,14 +11,16 @@
   const shims = $derived(svc.client_shims ?? []);
 
   let pending = $state<Record<string, boolean>>({});
-  let failed = $state<Record<string, boolean>>({});
+  let errors = $state<Record<string, string>>({});
 
   async function toggle(tool: string, enabled: boolean) {
     pending = { ...pending, [tool]: true };
-    failed = { ...failed, [tool]: false };
+    errors = { ...errors, [tool]: '' };
     const res = await setServiceShim(svc.name, { tool, enabled });
     pending = { ...pending, [tool]: false };
-    if (!res.ok) failed = { ...failed, [tool]: true };
+    // A toggle that could not be carried out says why, rather than springing
+    // back with nothing to explain it.
+    if (!res.ok) errors = { ...errors, [tool]: res.error || m.common_failed() };
   }
 </script>
 
@@ -47,12 +49,15 @@
               on={shim.enabled}
               tone={shim.host_has ? 'amber' : 'emerald'}
               loading={pending[shim.tool]}
-              failing={failed[shim.tool]}
+              failing={Boolean(errors[shim.tool])}
               disabled={managedElsewhere}
               title={managedElsewhere ? m.services_tools_providedBy({ service: shim.owner ?? '' }) : shim.tool}
               onclick={() => toggle(shim.tool, !shim.enabled)}
             />
           </div>
+          {#if errors[shim.tool]}
+            <p class="text-[10px] text-red-500 break-words max-w-[220px]">{errors[shim.tool]}</p>
+          {/if}
         </div>
       {/each}
     </div>

--- a/internal/ui/web/src/tabs/services/ServiceToolsTab.test.ts
+++ b/internal/ui/web/src/tabs/services/ServiceToolsTab.test.ts
@@ -29,13 +29,14 @@ describe('ServiceToolsTab', () => {
     expect(setServiceShim).toHaveBeenCalledWith('postgres', { tool: 'psql', enabled: true });
   });
 
-  it('marks a tool failed when its toggle rejects', async () => {
-    setServiceShim.mockResolvedValue({ ok: false, error: 'boom' });
-    const { getByRole } = render(ServiceToolsTab, { props: { svc: svc() } });
+  it('marks a tool failed and says why when its toggle rejects', async () => {
+    setServiceShim.mockResolvedValue({ ok: false, error: 'psql already exists and is not a lerd shim' });
+    const { getByRole, findByText } = render(ServiceToolsTab, { props: { svc: svc() } });
     const toggle = getByRole('button');
     await fireEvent.click(toggle);
     // A failed toggle marks that tool failing, which the control shows in red.
     expect(toggle.className).toContain('bg-red-500');
+    expect(await findByText('psql already exists and is not a lerd shim')).toBeTruthy();
   });
 
   it('disables a tool managed by another service', () => {


### PR DESCRIPTION
Toggling a client tool could record the decision and then fail to write the shim, because the write path stored the decision first and reconciled afterwards. The recorded state then said enabled with nothing on disk, and the next unrelated toggle read that decision back and brought the tool up as on. The reconcile was quiet about the shim it wrote as well, discarding the write result and skipping a path already held by a file lerd does not own without saying anything, so a tool that never got a shim still came back enabled.

The shim is written first now and the decision recorded only once that succeeded, so a toggle that could not be carried out leaves nothing behind to resurface. An enable onto a path lerd will not overwrite fails with that path named instead of being dropped, from the command and from the toggle in the web UI alike, and the state a tool reports follows the shim in the bin dir rather than the recorded intent. A reconcile keeps going past a tool it could not handle, then reports the ones it skipped rather than returning success, and their decisions stay unrecorded so the next run tries again.

The toggle in the web UI marked the control failed with no text next to it, which is why the original report saw no visible result at all, so the reason now sits under the tool.

Refs #1351
