### PR TITLE
fix(ui): settle a failed tool toggle on what the server actually holds

### DIFF
--- a/internal/ui/web/src/stores/services.test.ts
+++ b/internal/ui/web/src/stores/services.test.ts
@@ -100,7 +100,10 @@ describe('services store', () => {
     expect(calls.some((c) => c[0] === '/api/services')).toBe(true);
   });
 
-  it('setServiceShim surfaces a server error without reloading', async () => {
+  // A shim toggle typically fails because the shim dir no longer matches what
+  // the dashboard is showing, so the failure refreshes too: the control then
+  // sits where the server says it does, next to the reason it did not move.
+  it('setServiceShim surfaces a server error and refreshes', async () => {
     const calls: string[] = [];
     globalThis.fetch = vi.fn(async (url: unknown) => {
       calls.push(String(url));
@@ -112,7 +115,7 @@ describe('services store', () => {
     const res = await setServiceShim('mysql', { tool: 'mysqldump', enabled: true });
     expect(res.ok).toBe(false);
     expect(res.error).toBe('boom');
-    expect(calls.includes('/api/services')).toBe(false);
+    expect(calls.includes('/api/services')).toBe(true);
   });
 
   it('setServicePorts POSTs the published port and extra ports as JSON', async () => {

--- a/internal/ui/web/src/stores/services.ts
+++ b/internal/ui/web/src/stores/services.ts
@@ -262,6 +262,10 @@ export async function setServiceShim(
       await loadServices();
       return { ok: true };
     }
+    // A toggle usually fails because the shim dir no longer holds what the
+    // dashboard is showing, so refresh on the way out as well: the control ends
+    // up where the server says it belongs, beside the reason it did not move.
+    await loadServices();
     return { ok: false, error: data.error || m.common_failed() };
   } catch (e) {
     return { ok: false, error: String(e) };

--- a/internal/ui/web/src/tabs/services/ServiceToolsTab.svelte
+++ b/internal/ui/web/src/tabs/services/ServiceToolsTab.svelte
@@ -56,7 +56,13 @@
             />
           </div>
           {#if errors[shim.tool]}
-            <p class="text-[10px] text-red-500 break-words max-w-[220px]">{errors[shim.tool]}</p>
+            <p
+              class="text-[10px] font-medium text-red-500 dark:text-red-400 break-words max-w-[220px]"
+              role="status"
+              aria-live="polite"
+            >
+              {errors[shim.tool]}
+            </p>
           {/if}
         </div>
       {/each}


### PR DESCRIPTION
A shim toggle that fails left the control rendering whatever the last services load happened to say, since only a success refreshed. That is the state the dashboard is least entitled to trust: a toggle usually fails because the shim dir no longer holds what is on screen. The failure refreshes on its way out now, so the control ends up where the server says it belongs, beside the reason it did not move.

The message takes the dark theme colour the ports and config tabs use for a failed action, and carries a live region so it is announced rather than only appearing.

Refs #1352
