### PR TITLE
feat(env): read and write a framework's own PHP settings file

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -77,6 +77,9 @@ env:
 | `dotenv` | `KEY=value` lines | `DB_HOST` |
 | `php-const` | `define('KEY', 'value')` calls, as in WordPress's `wp-config.php` | `DB_HOST` |
 | `php-array` | a PHP file that `return`s a nested array, as in Magento's `app/etc/env.php` | dotted path, `db.connection.default.host` |
+| `php-vars` | a PHP file of top-level assignments, as in Drupal's `web/sites/default/settings.php` | dotted path rooted at the variable, `databases.default.default.host` |
+
+`php-vars` is for a framework that configures itself through assignments rather than a returned array. `databases.default.default.host` addresses `$databases['default']['default']['host']`, and writing rewrites only the statements whose values change, leaving the rest of the file, which for Drupal is hundreds of lines of guidance the user may have edited, byte for byte. A key no statement covers is appended as one of its own. That is how lerd writes the file Drupal actually reads: its installer puts the `$databases` array in `settings.php` and reads it back on every request, so connection values left anywhere else wire nothing.
 
 The `php-array` reader flattens the returned array to dotted keys, and the writer sets a dotted path, creating the intermediate arrays when they are missing. Scalar types are preserved, so an int stays an int and a bool stays a bool. The file is reparsed and reprinted rather than patched line by line, which is what Magento's own `DeploymentConfig\Writer` does, so comments in it are not preserved by lerd or by Magento. A rewrite that would not change anything is skipped, so a file already holding every value lerd wants keeps its mtime.
 

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -317,7 +317,7 @@ func emptyEnvFile(envFormat string) []byte {
 	switch envFormat {
 	case "php-array":
 		return []byte("<?php\nreturn [];\n")
-	case "php-const":
+	case "php-const", "php-vars":
 		return []byte("<?php\n")
 	default:
 		return []byte("")
@@ -586,6 +586,8 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		envMap, err = envfile.ReadPhpConst(envPath)
 	case "php-array":
 		envMap, err = envfile.ReadPhpArray(envPath)
+	case "php-vars":
+		envMap, err = envfile.ReadPhpVars(envPath)
 	default:
 		envMap, err = parseEnvMap(envPath)
 	}
@@ -907,10 +909,11 @@ func runEnv(_ *cobra.Command, _ []string) error {
 
 		family := config.FamilyOf(svc)
 		isDB := family == "mysql" || family == "mariadb" || family == "postgres"
-		// Only php-array addresses its keys by dotted path, so it alone cannot take a
-		// preset's env_vars. A php-const file's keys are flat and dotenv-shaped, so
-		// they land there as they always have.
-		dottedEnv := envFormat == "php-array"
+		// The dotted-path formats cannot take a preset's env_vars, which are flat
+		// and Laravel-shaped: there is nowhere in a nested config for a bare
+		// DB_HOST to go. A php-const file's keys are flat, so they land there as
+		// they always have.
+		dottedEnv := envFormat == "php-array" || envFormat == "php-vars"
 
 		// A service with nothing to wire (an admin dashboard) is only ever started.
 		if len(svc.EnvVars) == 0 {
@@ -1042,6 +1045,8 @@ func runEnv(_ *cobra.Command, _ []string) error {
 			writeErr = envfile.ApplyPhpConstUpdates(envPath, updates)
 		case "php-array":
 			writeErr = envfile.ApplyPhpArrayUpdates(envPath, updates)
+		case "php-vars":
+			writeErr = envfile.ApplyPhpVarsUpdates(envPath, updates)
 		default:
 			writeErr = envfile.ApplyUpdates(envPath, updates)
 		}

--- a/internal/cli/worktree_db.go
+++ b/internal/cli/worktree_db.go
@@ -50,6 +50,8 @@ func applyDBEnvUpdate(path, format string, updates map[string]string) error {
 		return envfile.ApplyPhpConstUpdates(path, updates)
 	case "php-array":
 		return envfile.ApplyPhpArrayUpdates(path, updates)
+	case "php-vars":
+		return envfile.ApplyPhpVarsUpdates(path, updates)
 	default:
 		return envfile.ApplyUpdates(path, updates)
 	}

--- a/internal/envfile/phparray.go
+++ b/internal/envfile/phparray.go
@@ -263,6 +263,23 @@ func parsePhpReturn(src string) (*phpValue, error) {
 	return nil, nil
 }
 
+// hasLiteral reports whether the cursor sits on one of PHP's keyword literals,
+// which are case-insensitive: Drupal's settings.php writes FALSE, and reading
+// that as an unsupported value would drop the whole statement.
+func (p *phpParser) hasLiteral(w string) bool {
+	if len(p.src)-p.pos < len(w) {
+		return false
+	}
+	if !strings.EqualFold(p.src[p.pos:p.pos+len(w)], w) {
+		return false
+	}
+	if p.pos > 0 && isIdentByte(p.src[p.pos-1]) {
+		return false
+	}
+	after := p.pos + len(w)
+	return after >= len(p.src) || !isIdentByte(p.src[after])
+}
+
 // hasWord reports whether the cursor sits on w as a standalone identifier.
 func (p *phpParser) hasWord(w string) bool {
 	if !strings.HasPrefix(p.src[p.pos:], w) {
@@ -324,14 +341,14 @@ func (p *phpParser) parseValue() (*phpValue, error) {
 	case c == '\'' || c == '"':
 		s, err := p.parseString()
 		return &phpValue{kind: phpString, str: s}, err
-	case p.hasWord("true"), p.hasWord("false"):
+	case p.hasLiteral("true"), p.hasLiteral("false"):
 		w := "true"
-		if p.hasWord("false") {
+		if p.hasLiteral("false") {
 			w = "false"
 		}
 		p.pos += len(w)
 		return &phpValue{kind: phpBool, str: w}, nil
-	case p.hasWord("null"):
+	case p.hasLiteral("null"):
 		p.pos += len("null")
 		return &phpValue{kind: phpNull}, nil
 	case c == '-' || c == '.' || c >= '0' && c <= '9':
@@ -430,9 +447,9 @@ func (p *phpParser) parseString() (string, error) {
 }
 
 // Values reads every key/value pair from an env file in the given format
-// ("dotenv", "php-const", "php-array"). An unreadable file yields an empty
-// (non-nil) map, so callers need no error path for a project whose env file
-// isn't there yet. Prefer this over Reader when several keys are wanted, or
+// ("dotenv", "php-const", "php-array", "php-vars"). An unreadable file yields
+// an empty (non-nil) map, so callers need no error path for a project whose env
+// file isn't there yet. Prefer this over Reader when several keys are wanted, or
 // when the absence of a key has to be told apart from an empty value.
 func Values(path, format string) map[string]string {
 	var (
@@ -444,6 +461,8 @@ func Values(path, format string) map[string]string {
 		values, err = ReadPhpConst(path)
 	case "php-array":
 		values, err = ReadPhpArray(path)
+	case "php-vars":
+		values, err = ReadPhpVars(path)
 	default:
 		return ReadValues(path)
 	}
@@ -454,8 +473,9 @@ func Values(path, format string) map[string]string {
 }
 
 // Reader returns a key lookup for an env file in the given format ("dotenv",
-// "php-const", "php-array"). An unreadable file yields a reader that returns
-// empty strings, so callers need no error path for a missing env file.
+// "php-const", "php-array", "php-vars"). An unreadable file yields a reader
+// that returns empty strings, so callers need no error path for a missing env
+// file.
 func Reader(path, format string) func(key string) string {
 	if format == "dotenv" || format == "" {
 		return func(key string) string { return ReadKey(path, key) }

--- a/internal/envfile/phpvars.go
+++ b/internal/envfile/phpvars.go
@@ -1,0 +1,319 @@
+package envfile
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// This file handles the "php-vars" env format: a PHP file whose configuration
+// is a series of top-level assignments to variables, as Drupal's settings.php
+// is. Keys are addressed by a dotted path rooted at the variable name, so
+// databases.default.default.host is $databases['default']['default']['host'].
+//
+// It is the shape a framework writes for itself. Drupal's installer appends the
+// $databases array to settings.php and reads it back on every request, so lerd
+// has to speak that file rather than leave connection values somewhere the
+// application never looks. Writing rewrites only the statements it changes and
+// leaves the rest of the file, which is mostly guidance the user may have
+// edited, byte for byte.
+
+// phpAssignment is one top-level `$var['a']['b'] = <value>;` statement, with
+// the offsets of the value expression so it can be rewritten in place.
+type phpAssignment struct {
+	path     []string
+	value    *phpValue
+	rhsStart int
+	rhsEnd   int
+}
+
+// ReadPhpVars parses a PHP file's top-level assignments and flattens them to
+// dotted keys. A file with no assignments yields an empty map, not an error.
+func ReadPhpVars(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]string{}
+	root := &phpValue{kind: phpArray}
+	for _, a := range scanPhpAssignments(string(data)) {
+		setPathValue(root, a.path, a.value)
+	}
+	flatten("", root, out)
+	return out, nil
+}
+
+// ApplyPhpVarsUpdates sets each dotted key, rewriting the statement that owns it
+// and appending a statement of its own for a key no assignment covers. A missing
+// file (and its parent dirs) is created. An existing scalar keeps its type when
+// the new value fits it.
+func ApplyPhpVarsUpdates(path string, updates map[string]string) error {
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	original := string(data)
+	src := original
+	if src == "" {
+		src = "<?php\n"
+	}
+
+	assignments := scanPhpAssignments(src)
+
+	// Sorted so a file gains new statements in a stable order however the
+	// updates were collected.
+	keys := make([]string, 0, len(updates))
+	for k := range updates {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Reprinting an assignment renders it in lerd's own style, so a statement
+	// whose values already match is left exactly as the framework wrote it
+	// rather than reformatted for nothing.
+	before := make([]map[string]string, len(assignments))
+	for i, a := range assignments {
+		before[i] = map[string]string{}
+		flatten("", a.value, before[i])
+	}
+
+	touched := map[int]bool{}
+	var appended []string
+	for _, key := range keys {
+		segs := strings.Split(key, ".")
+		if i, rest := ownerOf(assignments, segs); i >= 0 {
+			setPath(assignments[i].value, rest, updates[key])
+			touched[i] = true
+			continue
+		}
+		appended = append(appended, printAssignment(segs, updates[key]))
+	}
+
+	dirty := map[int]bool{}
+	for i := range assignments {
+		if !touched[i] {
+			continue
+		}
+		after := map[string]string{}
+		flatten("", assignments[i].value, after)
+		dirty[i] = !sameValues(before[i], after)
+	}
+
+	// Rewritten back to front so each splice leaves the earlier offsets valid.
+	out := src
+	for i := len(assignments) - 1; i >= 0; i-- {
+		if !dirty[i] {
+			continue
+		}
+		var b strings.Builder
+		printValue(&b, assignments[i].value, 0)
+		out = out[:assignments[i].rhsStart] + b.String() + out[assignments[i].rhsEnd:]
+	}
+	if len(appended) > 0 {
+		if !strings.HasSuffix(out, "\n") {
+			out += "\n"
+		}
+		out += strings.Join(appended, "")
+	}
+
+	// A file already holding every target value keeps its mtime, so an env sync
+	// that changes nothing doesn't churn a file the user has open.
+	if out == original {
+		return nil
+	}
+	if dir := filepath.Dir(path); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(path, []byte(out), 0o644)
+}
+
+func sameValues(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// ownerOf returns the assignment that owns a key, which is the one whose own
+// path is the longest prefix of it, along with the segments left to set inside
+// that assignment's value. A file holding both `$databases = []` and
+// `$databases['default']['default'] = [...]` resolves to the second.
+func ownerOf(assignments []phpAssignment, segs []string) (int, []string) {
+	best, bestLen := -1, -1
+	for i, a := range assignments {
+		if len(a.path) >= len(segs) || len(a.path) <= bestLen {
+			continue
+		}
+		if a.value.kind != phpArray {
+			continue
+		}
+		match := true
+		for j, seg := range a.path {
+			if segs[j] != seg {
+				match = false
+				break
+			}
+		}
+		if match {
+			best, bestLen = i, len(a.path)
+		}
+	}
+	if best < 0 {
+		return -1, nil
+	}
+	return best, segs[bestLen:]
+}
+
+// printAssignment renders a statement for a key no assignment covers, assigning
+// the leaf directly: PHP creates the arrays above it on the way.
+func printAssignment(segs []string, value string) string {
+	var b strings.Builder
+	b.WriteString("$")
+	b.WriteString(segs[0])
+	for _, seg := range segs[1:] {
+		b.WriteString("['")
+		b.WriteString(escapeSingle(seg))
+		b.WriteString("']")
+	}
+	b.WriteString(" = ")
+	printValue(&b, scalarValue(value, phpString), 0)
+	b.WriteString(";\n")
+	return b.String()
+}
+
+// setPathValue grafts a parsed value onto the tree at segs, replacing whatever
+// sat there. Assignments are applied in file order, so a later statement wins
+// over an earlier one exactly as PHP would run them.
+func setPathValue(root *phpValue, segs []string, v *phpValue) {
+	cur := root
+	for i, seg := range segs {
+		idx := -1
+		for j := range cur.entries {
+			if cur.entries[j].key == seg {
+				idx = j
+				break
+			}
+		}
+		if i == len(segs)-1 {
+			if idx >= 0 {
+				cur.entries[idx].val = v
+			} else {
+				cur.entries = append(cur.entries, phpEntry{key: seg, isInt: isIntKey(seg), val: v})
+			}
+			return
+		}
+		if idx < 0 {
+			child := &phpValue{kind: phpArray}
+			cur.entries = append(cur.entries, phpEntry{key: seg, isInt: isIntKey(seg), val: child})
+			cur = child
+			continue
+		}
+		if cur.entries[idx].val.kind != phpArray {
+			cur.entries[idx].val = &phpValue{kind: phpArray}
+		}
+		cur = cur.entries[idx].val
+	}
+}
+
+// scanPhpAssignments walks the source for `$var['a']['b'] = <value>;`
+// statements. skipTrivia eats comments, so an assignment shown as an example
+// inside one is never read as configuration, and a string literal is stepped
+// over whole so a `$` inside it starts nothing.
+func scanPhpAssignments(src string) []phpAssignment {
+	var out []phpAssignment
+	p := &phpParser{src: src}
+	for {
+		p.skipTrivia()
+		if p.pos >= len(p.src) {
+			return out
+		}
+		if c := p.src[p.pos]; c == '\'' || c == '"' {
+			if _, err := p.parseString(); err != nil {
+				return out
+			}
+			continue
+		}
+		if p.src[p.pos] != '$' {
+			p.pos++
+			continue
+		}
+		start := p.pos
+		a, ok := p.parseAssignment()
+		if !ok {
+			p.pos = start + 1
+			continue
+		}
+		out = append(out, a)
+	}
+}
+
+// parseAssignment reads one assignment statement from the cursor. It returns
+// false, leaving the cursor for the caller to reset, for anything that is not a
+// plain `$var[...] = <value>;`: a read of a variable, a compound assignment, a
+// comparison, or a value shape the parser doesn't model.
+func (p *phpParser) parseAssignment() (phpAssignment, bool) {
+	p.pos++ // the '$'
+	nameStart := p.pos
+	for p.pos < len(p.src) && isIdentByte(p.src[p.pos]) {
+		p.pos++
+	}
+	if p.pos == nameStart {
+		return phpAssignment{}, false
+	}
+	path := []string{p.src[nameStart:p.pos]}
+
+	for {
+		p.skipTrivia()
+		if p.pos >= len(p.src) || p.src[p.pos] != '[' {
+			break
+		}
+		p.pos++
+		p.skipTrivia()
+		if p.pos >= len(p.src) || (p.src[p.pos] != '\'' && p.src[p.pos] != '"') {
+			return phpAssignment{}, false
+		}
+		key, err := p.parseString()
+		if err != nil {
+			return phpAssignment{}, false
+		}
+		p.skipTrivia()
+		if p.pos >= len(p.src) || p.src[p.pos] != ']' {
+			return phpAssignment{}, false
+		}
+		p.pos++
+		path = append(path, key)
+	}
+
+	p.skipTrivia()
+	if p.pos >= len(p.src) || p.src[p.pos] != '=' {
+		return phpAssignment{}, false
+	}
+	// '==', '=>' and the compound assignments are not this statement.
+	if p.pos+1 < len(p.src) && (p.src[p.pos+1] == '=' || p.src[p.pos+1] == '>') {
+		return phpAssignment{}, false
+	}
+	p.pos++
+	p.skipTrivia()
+
+	rhsStart := p.pos
+	value, err := p.parseValue()
+	if err != nil {
+		return phpAssignment{}, false
+	}
+	rhsEnd := p.pos
+	p.skipTrivia()
+	if p.pos >= len(p.src) || p.src[p.pos] != ';' {
+		return phpAssignment{}, false
+	}
+	p.pos++
+
+	return phpAssignment{path: path, value: value, rhsStart: rhsStart, rhsEnd: rhsEnd}, true
+}

--- a/internal/envfile/phpvars_test.go
+++ b/internal/envfile/phpvars_test.go
@@ -1,0 +1,202 @@
+package envfile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// drupalSettings is the shape Drupal's own installer leaves behind: hundreds of
+// lines of commented guidance, then the assignments that actually run.
+const drupalSettings = `<?php
+
+/**
+ * @file
+ * Drupal site-specific configuration file.
+ *
+ * $databases['default']['default'] = [ ... ];  // an example inside a comment
+ */
+
+$settings['update_free_access'] = FALSE;
+
+$databases = [];
+
+$databases['default']['default'] = array (
+  'prefix' => '',
+  'database' => 'sites/default/files/.ht.sqlite',
+  'driver' => 'sqlite',
+  'namespace' => 'Drupal\\sqlite\\Driver\\Database\\sqlite',
+  'autoload' => 'core/modules/sqlite/src/Driver/Database/sqlite/',
+);
+$settings['config_sync_directory'] = 'sites/default/files/sync';
+`
+
+func writeSettings(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "settings.php")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// Drupal addresses its database through top-level assignments, not a returned
+// array, so the keys have to come out of the statements themselves.
+func TestReadPhpVars(t *testing.T) {
+	vals, err := ReadPhpVars(writeSettings(t, drupalSettings))
+	if err != nil {
+		t.Fatalf("ReadPhpVars: %v", err)
+	}
+	cases := map[string]string{
+		"databases.default.default.database": "sites/default/files/.ht.sqlite",
+		"databases.default.default.driver":   "sqlite",
+		"settings.update_free_access":        "false",
+		"settings.config_sync_directory":     "sites/default/files/sync",
+	}
+	for k, want := range cases {
+		if vals[k] != want {
+			t.Errorf("%s = %q, want %q", k, vals[k], want)
+		}
+	}
+}
+
+// An assignment written inside a comment is documentation, not configuration.
+func TestReadPhpVars_ignoresCommentedExamples(t *testing.T) {
+	vals, err := ReadPhpVars(writeSettings(t, "<?php\n// $databases['default']['default'] = ['driver' => 'mysql'];\n$settings['x'] = 'y';\n"))
+	if err != nil {
+		t.Fatalf("ReadPhpVars: %v", err)
+	}
+	if _, found := vals["databases.default.default.driver"]; found {
+		t.Errorf("a commented assignment was read as configuration: %v", vals)
+	}
+}
+
+// Writing has to change the values and leave everything else exactly as it was:
+// settings.php is Drupal's file, and it is mostly guidance a user may have
+// edited.
+func TestApplyPhpVarsUpdates_rewritesInPlace(t *testing.T) {
+	path := writeSettings(t, drupalSettings)
+
+	err := ApplyPhpVarsUpdates(path, map[string]string{
+		"databases.default.default.driver":    "mysql",
+		"databases.default.default.database":  "drupal",
+		"databases.default.default.host":      "lerd-mysql",
+		"databases.default.default.port":      "3306",
+		"databases.default.default.username":  "root",
+		"databases.default.default.password":  "lerd",
+		"databases.default.default.namespace": `Drupal\mysql\Driver\Database\mysql`,
+	})
+	if err != nil {
+		t.Fatalf("ApplyPhpVarsUpdates: %v", err)
+	}
+
+	vals, err := ReadPhpVars(path)
+	if err != nil {
+		t.Fatalf("ReadPhpVars: %v", err)
+	}
+	for k, want := range map[string]string{
+		"databases.default.default.driver":   "mysql",
+		"databases.default.default.database": "drupal",
+		"databases.default.default.host":     "lerd-mysql",
+		"databases.default.default.port":     "3306",
+		"databases.default.default.username": "root",
+	} {
+		if vals[k] != want {
+			t.Errorf("%s = %q, want %q", k, vals[k], want)
+		}
+	}
+	// The rest of Drupal's file survives untouched.
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, keep := range []string{
+		"@file",
+		"Drupal site-specific configuration file.",
+		"$settings['update_free_access'] = FALSE;",
+		"$settings['config_sync_directory'] = 'sites/default/files/sync';",
+	} {
+		if !strings.Contains(string(body), keep) {
+			t.Errorf("rewrite dropped %q:\n%s", keep, body)
+		}
+	}
+	// The prefix Drupal set and lerd said nothing about is still there.
+	if vals["databases.default.default.prefix"] != "" {
+		t.Errorf("prefix = %q, want the empty string Drupal wrote", vals["databases.default.default.prefix"])
+	}
+}
+
+// A key no assignment covers is appended as its own statement, so a project
+// missing a setting entirely still ends up with it.
+func TestApplyPhpVarsUpdates_appendsAKeyNoAssignmentCovers(t *testing.T) {
+	path := writeSettings(t, "<?php\n$settings['x'] = 'y';\n")
+
+	if err := ApplyPhpVarsUpdates(path, map[string]string{"databases.default.default.host": "lerd-mysql"}); err != nil {
+		t.Fatalf("ApplyPhpVarsUpdates: %v", err)
+	}
+
+	vals, _ := ReadPhpVars(path)
+	if vals["databases.default.default.host"] != "lerd-mysql" {
+		t.Errorf("host = %q, want lerd-mysql", vals["databases.default.default.host"])
+	}
+	body, _ := os.ReadFile(path)
+	if !strings.Contains(string(body), "$databases['default']['default']['host'] = 'lerd-mysql';") {
+		t.Errorf("appended statement not as expected:\n%s", body)
+	}
+}
+
+// An update that changes nothing must not rewrite the file, or every env sync
+// churns a file the user is watching in an editor.
+func TestApplyPhpVarsUpdates_skipsAnUnchangedWrite(t *testing.T) {
+	path := writeSettings(t, drupalSettings)
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ApplyPhpVarsUpdates(path, map[string]string{"databases.default.default.driver": "sqlite"}); err != nil {
+		t.Fatalf("ApplyPhpVarsUpdates: %v", err)
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Error("an update that changes nothing rewrote the file")
+	}
+}
+
+// An int in the file stays an int, the same rule the returned-array format
+// follows, so a port does not turn into a quoted string.
+func TestApplyPhpVarsUpdates_keepsScalarTypes(t *testing.T) {
+	path := writeSettings(t, "<?php\n$databases['default']['default'] = ['port' => 3306, 'host' => 'localhost'];\n")
+
+	if err := ApplyPhpVarsUpdates(path, map[string]string{
+		"databases.default.default.port": "3307",
+		"databases.default.default.host": "lerd-mysql",
+	}); err != nil {
+		t.Fatalf("ApplyPhpVarsUpdates: %v", err)
+	}
+
+	body, _ := os.ReadFile(path)
+	if !strings.Contains(string(body), "'port' => 3307") {
+		t.Errorf("port lost its type:\n%s", body)
+	}
+	if !strings.Contains(string(body), "'host' => 'lerd-mysql'") {
+		t.Errorf("host not written as a string:\n%s", body)
+	}
+}
+
+// The format joins the others, so everything that reads an env file by name
+// reads this one too.
+func TestReader_readsPhpVars(t *testing.T) {
+	path := writeSettings(t, drupalSettings)
+	if got := Reader(path, "php-vars")("databases.default.default.database"); got != "sites/default/files/.ht.sqlite" {
+		t.Errorf("Reader = %q, want the sqlite path", got)
+	}
+	if got := Reader(path, "php-vars")("databases.default.default.driver"); got != "sqlite" {
+		t.Errorf("Reader = %q, want sqlite", got)
+	}
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -375,6 +375,8 @@ func EnsureWorktreeEnv(mainRepoPath, worktreePath, worktreeDomain string, secure
 		_ = envfile.ApplyPhpConstUpdates(worktreeEnv, updates)
 	case "php-array":
 		_ = envfile.ApplyPhpArrayUpdates(worktreeEnv, updates)
+	case "php-vars":
+		_ = envfile.ApplyPhpVarsUpdates(worktreeEnv, updates)
 	default:
 		_ = envfile.ApplyUpdates(worktreeEnv, updates)
 	}


### PR DESCRIPTION
Drupal keeps its database in a $databases array its installer writes into settings.php and reads back on every request. lerd had no way to speak that file: php-const writes constants Drupal never looks at, and php-array expects a file that returns an array, while Drupal's is a series of top-level assignments. So a Drupal project picking mysql went on running whatever settings.php already said, with lerd reporting the site wired and its databases created.

The php-vars format addresses those assignments by a dotted path rooted at the variable, so databases.default.default.host is $databases['default']['default']['host']. Reading flattens every top-level assignment in file order, the way PHP would run them, and an assignment shown as an example inside a comment is documentation rather than configuration. Writing rewrites only the statements whose values actually change and leaves the rest of the file byte for byte, which matters because settings.php is mostly guidance a user may have edited; a key no statement covers is appended as a statement of its own, since PHP creates the arrays above a leaf on the way. Scalars keep the type the file already used.

PHP's keyword literals are case-insensitive and Drupal writes FALSE, which the value parser rejected outright, dropping the whole statement it appeared in. It reads them in any case now, which the returned-array format gains too.

On a scratch project with the redrafted definition this writes the connection into the file Drupal actually reads, driver, host, port, database, username, password, namespace and autoload, leaving the docblock and both $settings lines exactly as they were. The definition change itself belongs in lerd-env/frameworks and is not part of this: without it Drupal keeps its current declaration and nothing here changes for anyone.

Refs #1386
