### PR TITLE
fix(sites): report the framework version a project runs, not the definition it borrowed

### DIFF
--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -1068,7 +1068,6 @@ func GetFrameworkForDir(name, projectDir string) (*Framework, bool) {
 	//     lowest one (not the latest) and mark it guessed, so callers relax PHP
 	//     clamping (a Laravel 6 project must still allow PHP 7.4).
 	guessed := false
-	guessedVersion := ""
 	if base == nil && version != "" {
 		if clamped := clampFrameworkVersion(name, version); clamped != "" {
 			clampedPath := filepath.Join(StoreFrameworksDir(), name+"@"+clamped+".yaml")
@@ -1080,7 +1079,6 @@ func GetFrameworkForDir(name, projectDir string) (*Framework, bool) {
 			}
 			if base != nil {
 				guessed = true
-				guessedVersion = version
 			}
 		}
 	}
@@ -1107,9 +1105,17 @@ func GetFrameworkForDir(name, projectDir string) (*Framework, bool) {
 	}
 
 	if base != nil {
+		// A project served by a definition of another version reports its own,
+		// whichever direction it was borrowed from: a WordPress 7 site read
+		// "WordPress 6" because only the legacy clamp recorded it. VersionGuessed
+		// stays the narrower claim, that the borrowed definition's PHP range must
+		// not constrain the project, which is true when it predates every
+		// definition and not when it postdates them all.
 		if guessed {
 			base.VersionGuessed = true
-			base.DetectedVersion = guessedVersion
+		}
+		if version != "" && version != base.Version {
+			base.DetectedVersion = version
 		}
 		base = mergeUserOverlay(base)
 		base = mergeBuiltinFrankenPHP(base)

--- a/internal/config/framework_detected_version_test.go
+++ b/internal/config/framework_detected_version_test.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func installVersionedDef(t *testing.T, name, version string) {
+	t.Helper()
+	dir := StoreFrameworksDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "name: " + name + "\nlabel: " + name + "\nversion: \"" + version + "\"\npublic_dir: public\n" +
+		"php:\n  min: \"8.1\"\n  max: \"8.3\"\n"
+	if err := os.WriteFile(filepath.Join(dir, name+"@"+version+".yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A project past the newest published definition is served that definition, and
+// used to report itself as its version: a WordPress 7 site read "WordPress 6".
+// The version it runs is the project's, whichever definition lerd had to borrow.
+func TestGetFrameworkForDir_reportsTheVersionAProjectRuns(t *testing.T) {
+	setConfigDir(t)
+	installVersionedDef(t, "acme", "6")
+
+	dir := t.TempDir()
+	writeProjectFile(t, dir, ".lerd.yaml", "framework: acme\nframework_version: \"7\"\n")
+
+	fw, ok := GetFrameworkForDir("acme", dir)
+	if !ok {
+		t.Fatal("GetFrameworkForDir resolved nothing")
+	}
+	if fw.Version != "6" {
+		t.Errorf("Version = %q, want the borrowed definition's 6", fw.Version)
+	}
+	if fw.DetectedVersion != "7" {
+		t.Errorf("DetectedVersion = %q, want the project's own 7", fw.DetectedVersion)
+	}
+	// The borrowed definition is the newest there is, so its PHP range is the
+	// best answer available and still applies.
+	if fw.VersionGuessed {
+		t.Error("VersionGuessed = true, want false: the PHP range still holds for a future version")
+	}
+}
+
+// The legacy case keeps both: the project's version to report, and the flag
+// that says the borrowed definition's PHP range must not constrain it.
+func TestGetFrameworkForDir_legacyProjectKeepsItsVersionAndItsRelaxedRange(t *testing.T) {
+	setConfigDir(t)
+	installVersionedDef(t, "acme", "10")
+	installVersionedDef(t, "acme", "13")
+
+	dir := t.TempDir()
+	writeProjectFile(t, dir, ".lerd.yaml", "framework: acme\nframework_version: \"6\"\n")
+
+	fw, ok := GetFrameworkForDir("acme", dir)
+	if !ok {
+		t.Fatal("GetFrameworkForDir resolved nothing")
+	}
+	if fw.Version != "10" || fw.DetectedVersion != "6" {
+		t.Errorf("Version/DetectedVersion = %q/%q, want 10/6", fw.Version, fw.DetectedVersion)
+	}
+	if !fw.VersionGuessed {
+		t.Error("VersionGuessed = false, want true for a legacy clamp")
+	}
+}
+
+// An exact match runs what it says, so there is no second version to report.
+func TestGetFrameworkForDir_exactVersionReportsNoOther(t *testing.T) {
+	setConfigDir(t)
+	installVersionedDef(t, "acme", "6")
+
+	dir := t.TempDir()
+	writeProjectFile(t, dir, ".lerd.yaml", "framework: acme\nframework_version: \"6\"\n")
+
+	fw, ok := GetFrameworkForDir("acme", dir)
+	if !ok {
+		t.Fatal("GetFrameworkForDir resolved nothing")
+	}
+	if fw.DetectedVersion != "" {
+		t.Errorf("DetectedVersion = %q, want empty when the definition is the project's own version", fw.DetectedVersion)
+	}
+	if fw.VersionGuessed {
+		t.Error("VersionGuessed = true, want false for an exact match")
+	}
+}

--- a/internal/siteinfo/framework_version_test.go
+++ b/internal/siteinfo/framework_version_test.go
@@ -1,0 +1,40 @@
+package siteinfo
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// The label and the version a surface shows are the project's, not the
+// definition's: a WordPress 7 site served by the 6 definition read "WordPress 6"
+// and looked a major version behind.
+func TestFrameworkVersionOf_prefersWhatTheProjectRuns(t *testing.T) {
+	borrowed := &config.Framework{Label: "WordPress", Version: "6", DetectedVersion: "7"}
+	if got := frameworkVersionOf(borrowed); got != "7" {
+		t.Errorf("frameworkVersionOf = %q, want the project's 7", got)
+	}
+	if got := frameworkLabel("wordpress", "/srv/blog", borrowed, true); got != "WordPress 7" {
+		t.Errorf("label = %q, want WordPress 7", got)
+	}
+}
+
+// A legacy project reports its own version too, which it already did, and this
+// must not regress while the flag stops being what carries it.
+func TestFrameworkVersionOf_legacyProjectUnchanged(t *testing.T) {
+	clamped := &config.Framework{Label: "Laravel", Version: "10", DetectedVersion: "6", VersionGuessed: true}
+	if got := frameworkLabel("laravel", "/srv/app", clamped, true); got != "Laravel 6" {
+		t.Errorf("label = %q, want Laravel 6", got)
+	}
+}
+
+// An exact match has only one version to report.
+func TestFrameworkVersionOf_exactMatch(t *testing.T) {
+	exact := &config.Framework{Label: "Laravel", Version: "12"}
+	if got := frameworkLabel("laravel", "/srv/app", exact, true); got != "Laravel 12" {
+		t.Errorf("label = %q, want Laravel 12", got)
+	}
+	if got := frameworkVersionOf(nil); got != "" {
+		t.Errorf("frameworkVersionOf(nil) = %q, want empty", got)
+	}
+}

--- a/internal/siteinfo/siteinfo.go
+++ b/internal/siteinfo/siteinfo.go
@@ -323,14 +323,12 @@ func Enrich(s config.Site, flags EnrichFlag) EnrichedSite {
 		}
 		fw, hasFw = config.GetFrameworkForDir(e.FrameworkName, s.Path)
 		if hasFw {
-			e.FrameworkVersion = fw.Version
-			if fw.VersionGuessed {
-				// Report the project's real version, not the borrowed
-				// definition's, and don't enforce that definition's PHP range.
-				if fw.DetectedVersion != "" {
-					e.FrameworkVersion = fw.DetectedVersion
-				}
-			} else {
+			// The version reported is the one the project runs, whichever
+			// definition lerd had to borrow to serve it. The PHP range is a
+			// separate question: it holds unless the definition predates the
+			// project so far that its ceiling would be wrong.
+			e.FrameworkVersion = frameworkVersionOf(fw)
+			if !fw.VersionGuessed {
 				e.FrameworkPHPMin = fw.PHP.Min
 				e.FrameworkPHPMax = fw.PHP.Max
 			}
@@ -705,10 +703,7 @@ func (e *EnrichedSite) enrichGit() {
 				info.LANPort = entry.Port
 			}
 			if fw, ok := config.GetFrameworkForDir(e.FrameworkName, wt.Path); ok {
-				info.FrameworkVersion = fw.Version
-				if fw.VersionGuessed && fw.DetectedVersion != "" {
-					info.FrameworkVersion = fw.DetectedVersion
-				}
+				info.FrameworkVersion = frameworkVersionOf(fw)
 				info.FrameworkLabel = frameworkLabel(e.FrameworkName, wt.Path, fw, true)
 				info.FrameworkWorkers = enrichWorktreeWorkers(e.Name, wt.Path, fw)
 			} else {
@@ -804,19 +799,28 @@ func (e *EnrichedSite) enrichLogs(fw *config.Framework, hasFw bool) {
 	e.HasAppLogs = hasLogFiles(hasFw, fw, e.Path)
 }
 
+// frameworkVersionOf is the version a site runs, which is the project's own
+// whenever it differs from the definition serving it. A WordPress 7 site read
+// "WordPress 6" because the borrowed definition's version was reported instead,
+// and a definition is borrowed in both directions: below the oldest published
+// one and past the newest.
+func frameworkVersionOf(fw *config.Framework) string {
+	if fw == nil {
+		return ""
+	}
+	if fw.DetectedVersion != "" {
+		return fw.DetectedVersion
+	}
+	return fw.Version
+}
+
 func frameworkLabel(name, path string, fw *config.Framework, hasFw bool) string {
 	if name == "" {
 		return ""
 	}
 	if hasFw {
-		// A guessed version is labelled by the version detected from the project,
-		// not the borrowed definition's, so a Laravel 6 project reads "Laravel 6"
-		// rather than "Laravel 10".
-		if fw.VersionGuessed && fw.DetectedVersion != "" {
-			return fw.Label + " " + fw.DetectedVersion
-		}
-		if fw.Version != "" {
-			return fw.Label + " " + fw.Version
+		if v := frameworkVersionOf(fw); v != "" {
+			return fw.Label + " " + v
 		}
 		return fw.Label
 	}


### PR DESCRIPTION
blog.astrolov.test runs WordPress 7.0.2 and read "WordPress 6". The store publishes 5 and 6, so the site is served the 6 definition, and every surface reported that definition's version rather than the project's.

The project's own version was recorded only for the legacy clamp, where a project predates every published definition, because one flag carried two claims at once: which version to report, and whether the borrowed definition's PHP range may constrain the project. A definition is borrowed in both directions, so the first claim is true whenever the versions differ while the second is true only below the range. A project past the newest definition needs its version reported without giving up a PHP ceiling that is still the best answer available.

They are separate now. The detected version is recorded whenever it differs from the definition serving the project, and it is what the site list, the dashboard, the worktree rows and the labels report. VersionGuessed keeps the narrower meaning it always had for PHP clamping, and stays reserved for the clamp downward, so nothing about which PHP versions a site may run has moved.

Refs #1377
