### PR TITLE
fix(env): write a project's own env file rather than the fallback it can be read through

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -42,7 +42,7 @@ env:
   file: .env                        # primary env file
   example_file: .env.example        # copied to file if missing
   format: dotenv                    # dotenv | php-const | php-array
-  fallback_file: wp-config.php      # used when file doesn't exist
+  fallback_file: wp-config.php      # read when file doesn't exist (never written)
   fallback_format: php-const        # format for fallback_file
   url_key: APP_URL                  # env key holding the app URL (or "none")
   worktree_url_keys:                # keys set to a worktree's own base URL
@@ -69,6 +69,14 @@ env:
         - DB_USERNAME=root
         - DB_PASSWORD=lerd
 ```
+
+### Which file lerd writes
+
+`file` is the env file lerd writes, and `lerd env` creates it when it is not there yet, from `example_file` when the definition names one and empty otherwise. `fallback_file` is only ever read, so a project that is already configured is detected through the file it actually has.
+
+That distinction matters for a framework whose own configuration is not the file lerd writes. Drupal keeps its database in a `$databases` array its installer writes into `settings.php`, and its `site:install` command sources a `.env` at the project root to build the `--db-url` it hands drush. So the definition names `.env` as its `file` and `settings.php` as a read-only `fallback_file`: lerd writes the former, Drupal writes the latter, and neither trips over the other.
+
+A definition that names no `file` at all has only its fallback, and then that fallback *is* the configuration and lerd writes it. That is WordPress, whose `wp-config.php` is the whole story.
 
 ### Env file formats
 

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -530,7 +530,13 @@ func runEnv(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("'lerd env' is not supported for %s\nConfigure the env section in the framework YAML to enable it", fw.Label)
 	}
 
-	envRelPath, envFormat := fw.Env.Resolve(cwd)
+	// The file lerd writes is the one the framework declares as its own, created
+	// below when it isn't there yet. A fallback a definition publishes so an
+	// already-configured project can be read is never written: Drupal's
+	// settings.php holds a $databases array its installer writes, and appending
+	// constants to it wires nothing while leaving the .env its install command
+	// sources uncreated.
+	envRelPath, envFormat := fw.Env.ResolveWrite(cwd)
 	envPath := filepath.Join(cwd, envRelPath)
 
 	exampleRelPath := fw.Env.ExampleFile

--- a/internal/cli/worktree_add.go
+++ b/internal/cli/worktree_add.go
@@ -336,7 +336,7 @@ func worktreeEnvFile(worktreePath string) string {
 	if !ok {
 		return fallback
 	}
-	file, _ := fw.Env.Resolve(site.Path)
+	file, _ := fw.Env.ResolveWrite(site.Path)
 	if file == "" || !filepath.IsLocal(file) {
 		return fallback
 	}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -532,9 +532,31 @@ type FrameworkServiceDetect struct {
 	ValuePrefix string `yaml:"value_prefix,omitempty"`
 }
 
-// Resolve returns the env file path and format to use for the given project directory.
-// It returns the primary file if it exists, otherwise the fallback.
-// Defaults to ".env" with "dotenv" format if nothing is configured.
+// ResolveWrite returns the env file lerd writes for a project, and its format.
+// A definition that names a primary file means that file is lerd's to write,
+// whether or not it exists yet, and any fallback is a read source for detecting
+// an already-configured project: Drupal keeps its database in a $databases
+// array its own installer writes into settings.php, and lerd writing there
+// appends constants Drupal never reads while the .env its install command
+// sources is never created. A definition naming no primary at all has only its
+// fallback, and that fallback is the configuration itself, which is WordPress's
+// wp-config.php and is written as normal.
+func (e FrameworkEnvConf) ResolveWrite(projectDir string) (file, format string) {
+	if e.File == "" {
+		return e.Resolve(projectDir)
+	}
+	format = e.Format
+	if format == "" {
+		format = "dotenv"
+	}
+	return e.File, format
+}
+
+// Resolve returns the env file path and format to read for the given project
+// directory. It returns the primary file if it exists, otherwise the fallback.
+// Defaults to ".env" with "dotenv" format if nothing is configured. Writers
+// want ResolveWrite, which never answers with a fallback a framework only
+// publishes so an existing project can be read.
 func (e FrameworkEnvConf) Resolve(projectDir string) (file, format string) {
 	primary := e.File
 	if primary == "" {

--- a/internal/config/framework_env_write_test.go
+++ b/internal/config/framework_env_write_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A definition that names a primary env file means that file is lerd's to
+// write. Drupal's settings.php is declared as a fallback so an installed site
+// can be read, and writing there appends constants Drupal never looks at while
+// the .env its own install command sources is never created.
+func TestResolveWrite_declaredPrimaryWinsOverAnExistingFallback(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "web", "sites", "default"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "web/sites/default/settings.php"), []byte("<?php\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	env := FrameworkEnvConf{
+		File:           ".env",
+		Format:         "dotenv",
+		FallbackFile:   "web/sites/default/settings.php",
+		FallbackFormat: "php-const",
+	}
+
+	if file, format := env.ResolveWrite(dir); file != ".env" || format != "dotenv" {
+		t.Errorf("ResolveWrite = (%q, %q), want (.env, dotenv)", file, format)
+	}
+	// Reading still finds the installed site's own configuration.
+	if file, format := env.Resolve(dir); file != "web/sites/default/settings.php" || format != "php-const" {
+		t.Errorf("Resolve = (%q, %q), want the fallback", file, format)
+	}
+}
+
+// A definition that names no primary has only its fallback, and that fallback
+// is the configuration itself: WordPress keeps everything in wp-config.php and
+// lerd must go on writing it rather than inventing a .env beside it.
+func TestResolveWrite_fallbackIsTheConfigWhenNoPrimaryIsDeclared(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "wp-config.php"), []byte("<?php\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	env := FrameworkEnvConf{FallbackFile: "wp-config.php", FallbackFormat: "php-const"}
+
+	if file, format := env.ResolveWrite(dir); file != "wp-config.php" || format != "php-const" {
+		t.Errorf("ResolveWrite = (%q, %q), want (wp-config.php, php-const)", file, format)
+	}
+}
+
+// The common shape: one declared file, present or not, written either way.
+func TestResolveWrite_declaredPrimaryIsReturnedWhenMissing(t *testing.T) {
+	env := FrameworkEnvConf{File: ".env.local", Format: "dotenv"}
+	if file, _ := env.ResolveWrite(t.TempDir()); file != ".env.local" {
+		t.Errorf("ResolveWrite = %q, want .env.local even though it does not exist yet", file)
+	}
+}
+
+func TestResolveWrite_defaultsToDotenv(t *testing.T) {
+	env := FrameworkEnvConf{}
+	if file, format := env.ResolveWrite(t.TempDir()); file != ".env" || format != "dotenv" {
+		t.Errorf("ResolveWrite = (%q, %q), want (.env, dotenv)", file, format)
+	}
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -294,7 +294,7 @@ func EnsureWorktreeEnv(mainRepoPath, worktreePath, worktreeDomain string, secure
 	var worktreeURLKeys []string
 	if fwName, ok := config.DetectFrameworkForDir(mainRepoPath); ok {
 		if fw, ok := config.GetFrameworkForDir(fwName, mainRepoPath); ok {
-			file, f := fw.Env.Resolve(mainRepoPath)
+			file, f := fw.Env.ResolveWrite(mainRepoPath)
 			if !filepath.IsLocal(file) {
 				return
 			}

--- a/internal/sitedoctor/env_present_write_target_test.go
+++ b/internal/sitedoctor/env_present_write_target_test.go
@@ -68,3 +68,15 @@ func TestCheckEnvPresent_passesOnceThePrimaryExists(t *testing.T) {
 		}
 	}
 }
+
+// The finding has to name the remedy. Leaving it at "it is missing" starts the
+// debugging session lerd exists to save.
+func TestEnvMissingDetail_namesTheCommandThatCreatesIt(t *testing.T) {
+	if d := envMissingDetail(".env", ""); !strings.Contains(d, "lerd env") {
+		t.Errorf("detail = %q, want the command that creates it", d)
+	}
+	d := envMissingDetail(".env", ".env.example")
+	if !strings.Contains(d, "lerd env") || !strings.Contains(d, ".env.example") {
+		t.Errorf("detail = %q, want the command and the example it copies", d)
+	}
+}

--- a/internal/sitedoctor/env_present_write_target_test.go
+++ b/internal/sitedoctor/env_present_write_target_test.go
@@ -1,0 +1,70 @@
+package sitedoctor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// drupalish declares a primary env file lerd writes and a fallback published so
+// an already-installed project can be read, which is Drupal's shape.
+func drupalish() *config.Framework {
+	return &config.Framework{
+		Name:  "drupalish",
+		Label: "Drupalish",
+		Env: config.FrameworkEnvConf{
+			File:           ".env",
+			Format:         "dotenv",
+			FallbackFile:   "web/sites/default/settings.php",
+			FallbackFormat: "php-const",
+			Services: map[string]config.FrameworkServiceDef{
+				"mysql": {Vars: []string{"DB_HOST=lerd-mysql", "DB_NAME={{site}}"}},
+			},
+		},
+	}
+}
+
+// A project read through its fallback still has no env file of its own, and
+// reporting the fallback as present hides the one lerd and the framework's own
+// install command both need.
+func TestCheckEnvPresent_reportsTheMissingPrimaryBehindAReadableFallback(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "web", "sites", "default"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "web/sites/default/settings.php"), []byte("<?php\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := Run(context.Background(), dir, drupalish())
+
+	for _, c := range resp.Checks {
+		if c.Name != "env_present" {
+			continue
+		}
+		if c.Status != StatusFail || !strings.Contains(c.Detail, ".env") {
+			t.Errorf("env_present = %+v, want a failure naming .env", c)
+		}
+		return
+	}
+	t.Fatal("no env_present check in the report")
+}
+
+func TestCheckEnvPresent_passesOnceThePrimaryExists(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("DB_HOST=lerd-mysql\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := Run(context.Background(), dir, drupalish())
+
+	for _, c := range resp.Checks {
+		if c.Name == "env_present" && c.Status != StatusOK {
+			t.Errorf("env_present = %+v, want ok", c)
+		}
+	}
+}

--- a/internal/sitedoctor/sitedoctor.go
+++ b/internal/sitedoctor/sitedoctor.go
@@ -393,11 +393,16 @@ func applyLabels(resp *Response) {
 
 // checkEnvPresent fails when the framework's env file is missing — every other
 // env-driven check would otherwise read an empty file and misreport.
+// envMissingDetail names the remedy rather than the symptom. `lerd env` is what
+// creates the file, copying the framework's example when it declares one and
+// seeding an empty one when it does not, and then writes the connection values
+// for the services the project picks. Leaving the finding at "it is missing"
+// hands the user a question lerd already knows the answer to.
 func envMissingDetail(envFile, exampleFile string) string {
 	if exampleFile == "" {
-		return fmt.Sprintf("%s is missing.", envFile)
+		return fmt.Sprintf("%s is missing, run `lerd env` to create it and wire the services this project picks.", envFile)
 	}
-	return fmt.Sprintf("%s is missing, copy it from the example and configure it.", envFile)
+	return fmt.Sprintf("%s is missing, run `lerd env` to create it from %s and wire the services this project picks.", envFile, exampleFile)
 }
 
 func checkEnvPresent(path, envFile, exampleFile string) (Check, bool) {

--- a/internal/sitedoctor/sitedoctor.go
+++ b/internal/sitedoctor/sitedoctor.go
@@ -156,7 +156,12 @@ func Run(ctx context.Context, path string, fw *config.Framework) Response {
 		resp.add(c)
 	}
 	if hasEnvConfig(fw) {
-		if c, ok := checkEnvPresent(path, envFile, fwExampleFile(fw)); ok {
+		// The file that has to exist is the one lerd writes, not whichever one it
+		// can currently read: a Drupal project with no .env is read through the
+		// settings.php its installer wrote, and reporting that as the env file
+		// present would hide the missing one lerd and drush both need.
+		writeFile, _ := fw.Env.ResolveWrite(path)
+		if c, ok := checkEnvPresent(path, writeFile, fwExampleFile(fw)); ok {
 			resp.add(c)
 		}
 		if c, ok := checkServiceWiring(path, envFile, fw); ok {


### PR DESCRIPTION
`lerd env` on a Drupal project reported success and wrote to a file the application ignores. It appended DB_DRIVER, DB_HOST and DB_NAME as PHP constants to settings.php, next to the $databases array pointing at SQLite that Drupal's installer had written and that Drupal actually reads, created the MySQL databases, and left the site running on SQLite with nothing to say so.

The definition was never wrong. Its own install command sources ./.env and builds drush's --db-url from it, so the .env at the project root is lerd's file and settings.php is Drupal's; the fallback exists so an already-installed site can be detected through the file it has. Resolve answers with that fallback whenever the primary is missing, and the write path used the same answer, so a fresh checkout with no .env wrote to settings.php and never reached the branch that creates a missing env file.

Writing now resolves separately: a definition naming a primary file means that file is lerd's to write, created when missing from the example the definition names or empty when it names none, and any fallback is a read source. A definition naming no primary at all has only its fallback, and that fallback is the configuration itself, which is WordPress's wp-config.php and is written exactly as before. Of the definitions published today only Drupal declares both, so that is the only behaviour that moves. Reading is untouched, so an installed site is still detected through settings.php.

The doctor asks the same question of the same file: a project read through a fallback still has no env file of its own, and reporting the fallback as present hid the missing one lerd and drush both need. Its finding also names the command that creates it, rather than telling the user to copy an example by hand, which is what `lerd env` does for them.

This is the shape that works against the definitions published today. Once #1388's php-vars format is used by a redrafted Drupal definition, which declares settings.php as its only file, the split goes inert rather than wrong: nothing then declares both a primary and a fallback.

Refs #1386
