### PR TITLE
fix(doctor): resolve the SQLite database through the framework's own keys

### DIFF
--- a/internal/sitedoctor/migrate_fix_test.go
+++ b/internal/sitedoctor/migrate_fix_test.go
@@ -55,7 +55,7 @@ func TestCheckSQLiteDatabase_offersTheFrameworksOwnMigrateCommand(t *testing.T) 
 	dir := t.TempDir()
 	writeEnv(t, dir, ".env", "DB_CONNECTION=sqlite\n")
 
-	c, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), symfony)
+	c, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), "dotenv", symfony)
 	if !ok || c.Status != StatusFail {
 		t.Fatalf("check = %+v (ok=%v), want a failure", c, ok)
 	}

--- a/internal/sitedoctor/sitedoctor.go
+++ b/internal/sitedoctor/sitedoctor.go
@@ -171,16 +171,21 @@ func Run(ctx context.Context, path string, fw *config.Framework) Response {
 	// The env drift and app-key checks parse the file as dotenv, so skip them for
 	// frameworks that store config another way (WordPress's wp-config.php, etc.).
 	dbBroken := false
+	// The SQLite check reads whichever keys the framework declares, in whatever
+	// format it declares them, so a project configured through a PHP settings
+	// file is checked like any other.
+	if c, ok := checkSQLiteDatabase(path, envPath, envFormat, fw); ok {
+		resp.add(c)
+		dbBroken = c.Status == StatusFail
+	}
+	// The app-key and drift checks parse the file as dotenv (one diffs it against
+	// a committed example), so they stay for the frameworks that keep one.
 	if envFormat == "dotenv" {
 		if c, ok := checkAppKey(envPath, fw); ok {
 			resp.add(c)
 		}
 		if c, ok := checkEnvDrift(path, envPath, filepath.Join(path, exampleFile)); ok {
 			resp.add(c)
-		}
-		if c, ok := checkSQLiteDatabase(path, envPath, fw); ok {
-			resp.add(c)
-			dbBroken = c.Status == StatusFail
 		}
 		if c, ok := checkServerDatabase(path, envPath, fw); ok {
 			resp.add(c)
@@ -438,21 +443,12 @@ func checkAppKey(envPath string, fw *config.Framework) (Check, bool) {
 // ("no such table"), which migrate:status can't surface: it reports the missing
 // migrations table, so the remedy would point at migrate rather than the absent
 // file. Skipped unless DB_CONNECTION is sqlite; an in-memory database has none.
-func checkSQLiteDatabase(path, envPath string, fw *config.Framework) (Check, bool) {
-	if !strings.EqualFold(strings.TrimSpace(envfile.ReadKey(envPath, "DB_CONNECTION")), "sqlite") {
+func checkSQLiteDatabase(path, envPath, envFormat string, fw *config.Framework) (Check, bool) {
+	dbFile, ok := declaredSQLiteFile(envPath, envFormat, fw)
+	if !ok || dbFile == ":memory:" {
 		return Check{}, false
 	}
-	dbFile := strings.TrimSpace(envfile.ReadKey(envPath, "DB_DATABASE"))
-	if dbFile == ":memory:" {
-		return Check{}, false
-	}
-	if dbFile == "" {
-		dbFile = filepath.Join("database", "database.sqlite") // Laravel default
-	}
-	abs := dbFile
-	if !filepath.IsAbs(abs) {
-		abs = filepath.Join(path, dbFile)
-	}
+	abs := sqliteFilePath(path, dbFile)
 	fix := migrateFix(fw)
 	info, err := os.Stat(abs)
 	switch {

--- a/internal/sitedoctor/sitedoctor_test.go
+++ b/internal/sitedoctor/sitedoctor_test.go
@@ -647,7 +647,7 @@ func TestCheckSQLiteDatabase(t *testing.T) {
 	t.Run("missing file fails with migrate fix", func(t *testing.T) {
 		dir := t.TempDir()
 		writeEnv(t, dir, ".env", "DB_CONNECTION=sqlite\n")
-		c, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), migrateFW)
+		c, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), "dotenv", migrateFW)
 		if !ok || c.Status != StatusFail || c.Fix != "migrate" {
 			t.Fatalf("missing default sqlite db should fail with a migrate fix, got ok=%v %+v", ok, c)
 		}
@@ -658,7 +658,7 @@ func TestCheckSQLiteDatabase(t *testing.T) {
 		writeEnv(t, dir, ".env", "DB_CONNECTION=sqlite\n")
 		mustMkdir(t, filepath.Join(dir, "database"))
 		writeEnv(t, filepath.Join(dir, "database"), "database.sqlite", "")
-		c, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), migrateFW)
+		c, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), "dotenv", migrateFW)
 		if !ok || c.Status != StatusFail || c.Fix != "migrate" {
 			t.Fatalf("empty sqlite db should fail with a migrate fix, got ok=%v %+v", ok, c)
 		}
@@ -667,7 +667,7 @@ func TestCheckSQLiteDatabase(t *testing.T) {
 	t.Run("no migrate command means no fix offered", func(t *testing.T) {
 		dir := t.TempDir()
 		writeEnv(t, dir, ".env", "DB_CONNECTION=sqlite\n")
-		c, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), &config.Framework{})
+		c, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), "dotenv", &config.Framework{})
 		if !ok || c.Status != StatusFail || c.Fix != "" {
 			t.Fatalf("a framework without a migrate command must not offer a fix, got ok=%v %+v", ok, c)
 		}
@@ -678,7 +678,7 @@ func TestCheckSQLiteDatabase(t *testing.T) {
 		writeEnv(t, dir, ".env", "DB_CONNECTION=sqlite\n")
 		mustMkdir(t, filepath.Join(dir, "database"))
 		writeEnv(t, filepath.Join(dir, "database"), "database.sqlite", "SQLite format 3\x00")
-		c, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), migrateFW)
+		c, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), "dotenv", migrateFW)
 		if !ok || c.Status != StatusOK {
 			t.Fatalf("populated sqlite db should pass, got ok=%v %+v", ok, c)
 		}
@@ -687,7 +687,7 @@ func TestCheckSQLiteDatabase(t *testing.T) {
 	t.Run("non-sqlite connection is skipped", func(t *testing.T) {
 		dir := t.TempDir()
 		writeEnv(t, dir, ".env", "DB_CONNECTION=mysql\n")
-		if _, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), migrateFW); ok {
+		if _, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), "dotenv", migrateFW); ok {
 			t.Error("a non-sqlite connection must not produce a database check")
 		}
 	})
@@ -695,7 +695,7 @@ func TestCheckSQLiteDatabase(t *testing.T) {
 	t.Run("in-memory database is skipped", func(t *testing.T) {
 		dir := t.TempDir()
 		writeEnv(t, dir, ".env", "DB_CONNECTION=sqlite\nDB_DATABASE=:memory:\n")
-		if _, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), migrateFW); ok {
+		if _, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), "dotenv", migrateFW); ok {
 			t.Error("an in-memory sqlite database has no file to check")
 		}
 	})
@@ -704,7 +704,7 @@ func TestCheckSQLiteDatabase(t *testing.T) {
 		dir := t.TempDir()
 		dbPath := filepath.Join(dir, "custom.sqlite")
 		writeEnv(t, dir, ".env", "DB_CONNECTION=sqlite\nDB_DATABASE="+dbPath+"\n")
-		c, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), migrateFW)
+		c, ok := checkSQLiteDatabase(dir, filepath.Join(dir, ".env"), "dotenv", migrateFW)
 		if !ok || c.Status != StatusFail {
 			t.Fatalf("missing absolute sqlite db should fail, got ok=%v %+v", ok, c)
 		}

--- a/internal/sitedoctor/sqlite_target.go
+++ b/internal/sitedoctor/sqlite_target.go
@@ -1,0 +1,137 @@
+package sitedoctor
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/envfile"
+)
+
+// declaredSQLiteFile returns the SQLite file a project is configured to open,
+// read only through keys its own framework declares.
+//
+// The check used to read DB_CONNECTION and DB_DATABASE wherever it found them,
+// which are Laravel's key names. A Symfony project keeps its SQLite path inside
+// the DATABASE_URL DSN and has neither key, so the check either said nothing or,
+// where those keys survived as leftovers, reported a file the application never
+// opens and offered to migrate it. Asking only about declared keys is what keeps
+// one framework's vocabulary from being read into another's project.
+//
+// ok is false when the project is not configured for SQLite at all, which is
+// most of them.
+func declaredSQLiteFile(envPath, envFormat string, fw *config.Framework) (string, bool) {
+	declared := declaredEnvKeys(fw)
+	if len(declared) == 0 {
+		// A framework that declares no env vocabulary, or no framework at all,
+		// leaves nothing to respect: a bare project's .env is read by the
+		// convention such a project follows.
+		declared = map[string]bool{"DB_CONNECTION": true, "DB_DATABASE": true}
+	}
+	vals := envfile.Values(envPath, envFormat)
+
+	// The flat shape: a declared key names the connection, another names the
+	// file. Laravel spells them DB_CONNECTION and DB_DATABASE; a framework
+	// storing its config as a nested array spells the same pair as paths.
+	for key, val := range vals {
+		if !declared[key] || !strings.EqualFold(strings.TrimSpace(val), "sqlite") {
+			continue
+		}
+		if file := declaredCompanionValue(vals, declared, key); file != "" {
+			return file, true
+		}
+	}
+
+	// The DSN shape: one declared key carries scheme and path together.
+	for key, val := range vals {
+		if !declared[key] {
+			continue
+		}
+		if file := sqliteDSNPath(val); file != "" {
+			return file, true
+		}
+	}
+	return "", false
+}
+
+// declaredCompanionValue finds the declared key naming the database file that
+// sits beside the one naming the connection: DB_CONNECTION is answered by
+// DB_DATABASE, and a dotted driver key by the database key in the same block.
+func declaredCompanionValue(vals map[string]string, declared map[string]bool, connKey string) string {
+	candidates := []string{"DB_DATABASE"}
+	// Laravel's own default, which its .env leaves unset more often than not.
+	defaultFile := filepath.Join("database", "database.sqlite")
+	if i := strings.LastIndex(connKey, "."); i >= 0 {
+		candidates = append([]string{connKey[:i+1] + "database"}, candidates...)
+	}
+	for _, k := range candidates {
+		if declared[k] {
+			if v := strings.TrimSpace(vals[k]); v != "" {
+				return v
+			}
+			return defaultFile
+		}
+	}
+	return ""
+}
+
+// sqliteDSNPath returns the file a SQLite connection string points at, or empty
+// for anything else. Symfony writes sqlite:///%kernel.project_dir%/var/app.db,
+// and that placeholder is the project root the caller already knows.
+func sqliteDSNPath(value string) string {
+	v := strings.Trim(strings.TrimSpace(value), `"'`)
+	rest, ok := strings.CutPrefix(v, "sqlite://")
+	if !ok {
+		if rest, ok = strings.CutPrefix(v, "sqlite:"); !ok {
+			return ""
+		}
+	}
+	rest = strings.TrimPrefix(rest, "/")
+	rest = strings.ReplaceAll(rest, "%kernel.project_dir%/", "")
+	rest = strings.ReplaceAll(rest, "%kernel.project_dir%", "")
+	if rest == "" || rest == ":memory:" {
+		return ""
+	}
+	return rest
+}
+
+// declaredEnvKeys is every env key a framework names, across its service
+// detection rules, its service vars and its unconditional vars. It is the
+// project's whole vocabulary, so a key outside it means nothing here however
+// familiar it looks.
+func declaredEnvKeys(fw *config.Framework) map[string]bool {
+	if fw == nil {
+		return nil
+	}
+	keys := map[string]bool{}
+	add := func(kv string) {
+		if k, _, found := strings.Cut(kv, "="); found {
+			keys[strings.TrimSpace(k)] = true
+		}
+	}
+	for _, kv := range fw.Env.Vars {
+		add(kv)
+	}
+	for _, def := range fw.Env.Services {
+		for _, rule := range def.Detect {
+			if rule.Key != "" {
+				keys[rule.Key] = true
+			}
+		}
+		for _, kv := range def.Vars {
+			add(kv)
+		}
+	}
+	if fw.Env.KeyGeneration != nil && fw.Env.KeyGeneration.EnvKey != "" {
+		keys[fw.Env.KeyGeneration.EnvKey] = true
+	}
+	return keys
+}
+
+// sqliteFilePath resolves a declared SQLite file against the project root.
+func sqliteFilePath(projectPath, dbFile string) string {
+	if filepath.IsAbs(dbFile) {
+		return dbFile
+	}
+	return filepath.Join(projectPath, dbFile)
+}

--- a/internal/sitedoctor/sqlite_target_test.go
+++ b/internal/sitedoctor/sqlite_target_test.go
@@ -1,0 +1,112 @@
+package sitedoctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+func laravelish() *config.Framework {
+	return &config.Framework{
+		Name: "laravelish",
+		Env: config.FrameworkEnvConf{File: ".env", Services: map[string]config.FrameworkServiceDef{
+			"mysql": {
+				Detect: []config.FrameworkServiceDetect{{Key: "DB_CONNECTION", ValuePrefix: "mysql"}},
+				Vars:   []string{"DB_CONNECTION=mysql", "DB_HOST=lerd-mysql", "DB_DATABASE={{site}}"},
+			},
+		}},
+	}
+}
+
+func symfonyish() *config.Framework {
+	return &config.Framework{
+		Name: "symfonyish",
+		Env: config.FrameworkEnvConf{File: ".env.local", Services: map[string]config.FrameworkServiceDef{
+			"mysql": {
+				Detect: []config.FrameworkServiceDetect{{Key: "DATABASE_URL", ValuePrefix: "mysql://"}},
+				Vars:   []string{"DATABASE_URL=mysql://root:lerd@lerd-mysql:3306/{{site}}"},
+			},
+		}},
+	}
+}
+
+func envAt(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// A Symfony project carrying Laravel's keys as leftovers was reported against a
+// file it never opens, and offered migrations for a database that isn't its
+// own. Its framework declares neither key, so neither is read.
+func TestDeclaredSQLiteFile_ignoresKeysTheFrameworkNeverDeclares(t *testing.T) {
+	env := envAt(t, "DATABASE_URL=postgresql://postgres:lerd@lerd-postgres:5432/app\nDB_CONNECTION=sqlite\nDB_DATABASE=database/database.sqlite\n")
+
+	if file, ok := declaredSQLiteFile(env, "dotenv", symfonyish()); ok {
+		t.Errorf("declaredSQLiteFile = %q, want none: neither key belongs to this framework", file)
+	}
+}
+
+// The same project genuinely on SQLite is found through the key it does
+// declare, with Symfony's project-root placeholder resolved away.
+func TestDeclaredSQLiteFile_readsADeclaredDSN(t *testing.T) {
+	env := envAt(t, `DATABASE_URL="sqlite:///%kernel.project_dir%/var/app.db"`+"\n")
+
+	file, ok := declaredSQLiteFile(env, "dotenv", symfonyish())
+	if !ok || file != "var/app.db" {
+		t.Errorf("declaredSQLiteFile = %q (ok=%v), want var/app.db", file, ok)
+	}
+}
+
+// A framework that does declare the flat pair is read through it as before.
+func TestDeclaredSQLiteFile_readsTheDeclaredFlatPair(t *testing.T) {
+	env := envAt(t, "DB_CONNECTION=sqlite\nDB_DATABASE=storage/app.sqlite\n")
+
+	file, ok := declaredSQLiteFile(env, "dotenv", laravelish())
+	if !ok || file != "storage/app.sqlite" {
+		t.Errorf("declaredSQLiteFile = %q (ok=%v), want storage/app.sqlite", file, ok)
+	}
+}
+
+// A project on a server database has no SQLite file, so there is nothing to
+// check and no finding to raise.
+func TestDeclaredSQLiteFile_noneForAServerDatabase(t *testing.T) {
+	env := envAt(t, "DB_CONNECTION=mysql\nDB_DATABASE=app\n")
+
+	if file, ok := declaredSQLiteFile(env, "dotenv", laravelish()); ok {
+		t.Errorf("declaredSQLiteFile = %q, want none for a mysql project", file)
+	}
+}
+
+// A framework configured through a nested file spells the same pair as paths,
+// and the companion is found in the same block rather than by Laravel's name.
+func TestDeclaredSQLiteFile_readsDottedKeys(t *testing.T) {
+	drupalish := &config.Framework{
+		Name: "drupalish",
+		Env: config.FrameworkEnvConf{File: "settings.php", Format: "php-vars", Services: map[string]config.FrameworkServiceDef{
+			"mysql": {
+				Detect: []config.FrameworkServiceDetect{{Key: "databases.default.default.driver", ValuePrefix: "mysql"}},
+				Vars: []string{
+					"databases.default.default.driver=mysql",
+					"databases.default.default.database={{site}}",
+				},
+			},
+		}},
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.php")
+	body := "<?php\n$databases['default']['default'] = ['driver' => 'sqlite', 'database' => 'sites/default/files/.ht.sqlite'];\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	file, ok := declaredSQLiteFile(path, "php-vars", drupalish)
+	if !ok || file != "sites/default/files/.ht.sqlite" {
+		t.Errorf("declaredSQLiteFile = %q (ok=%v), want the path in the same block", file, ok)
+	}
+}


### PR DESCRIPTION
A Symfony project was reported as having an empty database needing migrations, and clicking the fix ran migrations against a project with no migration classes at all, so Doctrine answered that there were none registered. The database it complained about was a 0-byte file the application never opens; the one the site actually uses was healthy the whole time.

The check read DB_CONNECTION and DB_DATABASE wherever it found them, which are Laravel's key names:

    if !strings.EqualFold(envfile.ReadKey(envPath, "DB_CONNECTION"), "sqlite") { return }
    dbFile := envfile.ReadKey(envPath, "DB_DATABASE")

A Symfony project keeps its SQLite path inside the DATABASE_URL DSN and declares neither key, so where those keys survived as leftovers from something else they were read as though they meant something.

It reads only keys the project's own framework declares now, taking the whole vocabulary from the definition's service detection rules and vars. A framework declaring the flat pair is read through it exactly as before. A DSN is read as a DSN, so a project genuinely on SQLite through a connection string is found rather than passed over, with Symfony's project-root placeholder resolved away. A framework declaring nothing, or a project with no framework at all, falls back to the convention a bare project follows, since there is no vocabulary to respect.

Reading by declared key also means the format no longer matters, so the check moved out of the dotenv-only gate: a framework configured through a PHP settings file is checked through its own dotted keys, and its database file is found in the same block that names its driver. The app-key and drift checks stay behind that gate, one of them diffing against a committed dotenv example.

checkServerDatabase has the same shape and still reads DB_HOST and DB_DATABASE by name. It is left for its own change.

Refs #1392
