### PR TITLE
fix(env): write the assignment a PHP settings file actually runs

### DIFF
--- a/internal/envfile/phpvars.go
+++ b/internal/envfile/phpvars.go
@@ -83,7 +83,14 @@ func ApplyPhpVarsUpdates(path string, updates map[string]string) error {
 	for _, key := range keys {
 		segs := strings.Split(key, ".")
 		if i, rest := ownerOf(assignments, segs); i >= 0 {
-			setPath(assignments[i].value, rest, updates[key])
+			if len(rest) == 0 {
+				// The statement assigns this very path, so its value is the one
+				// to replace: `$databases['default']['default']['host'] = 'x';`
+				// has nothing below it to descend into.
+				assignments[i].value = scalarValue(updates[key], assignments[i].value.kind)
+			} else {
+				setPath(assignments[i].value, rest, updates[key])
+			}
 			touched[i] = true
 			continue
 		}
@@ -142,17 +149,19 @@ func sameValues(a, b map[string]string) bool {
 	return true
 }
 
-// ownerOf returns the assignment that owns a key, which is the one whose own
-// path is the longest prefix of it, along with the segments left to set inside
-// that assignment's value. A file holding both `$databases = []` and
-// `$databases['default']['default'] = [...]` resolves to the second.
+// ownerOf returns the assignment that owns a key, along with the segments left
+// to set inside that assignment's value.
+//
+// PHP runs a file top to bottom, so where several assignments reach the same
+// path the last one is what the application ends up with, whether it is a whole
+// array replacing an earlier one or a leaf overriding it. Writing to any
+// earlier one leaves the value shadowed: the file would say what lerd wrote and
+// the application would go on using what came after it. So the match is the
+// last, not the most specific.
 func ownerOf(assignments []phpAssignment, segs []string) (int, []string) {
 	best, bestLen := -1, -1
 	for i, a := range assignments {
-		if len(a.path) >= len(segs) || len(a.path) <= bestLen {
-			continue
-		}
-		if a.value.kind != phpArray {
+		if len(a.path) > len(segs) || a.value.kind != phpArray && len(a.path) != len(segs) {
 			continue
 		}
 		match := true

--- a/internal/envfile/phpvars_dup_test.go
+++ b/internal/envfile/phpvars_dup_test.go
@@ -1,0 +1,56 @@
+package envfile
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// PHP runs a file top to bottom, so the last assignment to a path is the one
+// the application ends up with. Writing to the first left lerd's value shadowed
+// by whatever came after it, and the site went on using the old database while
+// every surface reported the new one.
+func TestApplyPhpVarsUpdates_writesTheAssignmentThatWins(t *testing.T) {
+	path := writeSettings(t, "<?php\n$databases['default']['default'] = ['host' => 'first'];\n$databases['default']['default'] = ['host' => 'second'];\n")
+
+	if err := ApplyPhpVarsUpdates(path, map[string]string{"databases.default.default.host": "lerd-mysql"}); err != nil {
+		t.Fatalf("ApplyPhpVarsUpdates: %v", err)
+	}
+
+	// Reading applies the assignments in order, so this is the value PHP would
+	// see, and it has to be the one lerd wrote.
+	if got := mustRead(t, path)["databases.default.default.host"]; got != "lerd-mysql" {
+		t.Errorf("effective host = %q, want lerd-mysql", got)
+	}
+	body, _ := os.ReadFile(path)
+	if strings.Contains(string(body), "'second'") {
+		t.Errorf("the winning assignment was left stale:\n%s", body)
+	}
+}
+
+// A later leaf assignment overrides an earlier whole-array one, so that leaf is
+// what has to change.
+func TestApplyPhpVarsUpdates_writesALaterLeafOverAnEarlierArray(t *testing.T) {
+	path := writeSettings(t, "<?php\n$databases['default']['default'] = ['host' => 'first', 'port' => 3306];\n$databases['default']['default']['host'] = 'override';\n")
+
+	if err := ApplyPhpVarsUpdates(path, map[string]string{"databases.default.default.host": "lerd-mysql"}); err != nil {
+		t.Fatalf("ApplyPhpVarsUpdates: %v", err)
+	}
+
+	vals := mustRead(t, path)
+	if vals["databases.default.default.host"] != "lerd-mysql" {
+		t.Errorf("effective host = %q, want lerd-mysql", vals["databases.default.default.host"])
+	}
+	if vals["databases.default.default.port"] != "3306" {
+		t.Errorf("port = %q, want the 3306 the earlier assignment set", vals["databases.default.default.port"])
+	}
+}
+
+func mustRead(t *testing.T, path string) map[string]string {
+	t.Helper()
+	vals, err := ReadPhpVars(path)
+	if err != nil {
+		t.Fatalf("ReadPhpVars: %v", err)
+	}
+	return vals
+}


### PR DESCRIPTION
Writing a PHP settings file updated the first statement that reached a key. PHP runs a file top to bottom, so where a later statement reaches the same key the value lerd wrote was shadowed by whatever came after it:

    $databases['default']['default'] = ['host' => 'lerd-mysql'];   <- lerd wrote here
    $databases['default']['default'] = ['host' => 'other'];        <- the site uses this

The file says one thing and the application uses another, which is worse than either, because every surface then reports a database the site is not on. The ordinary shape of a settings file makes it easy to hit, since a local override at the end is exactly a later statement reaching the same key.

The owning statement is the last one to reach the key now, whether that is a whole array replacing an earlier one or a leaf overriding it, and a statement assigning the key itself has its value replaced rather than being descended into. Reading already applied assignments in file order the way PHP would run them, so the two agree again.

Everything else the file says is left alone. A port set in an array and a host overridden by a later leaf both land in the statement that owns them:

    $databases['default']['default'] = [
        'host' => 'old',
        'port' => 3307,
    ];
    $databases['default']['default']['host'] = 'lerd-mysql';

which reads back as host lerd-mysql and port 3307, the values PHP would see.

The other formats were checked and are unaffected: a dotenv writer rewrites every occurrence of a key, so no contradiction survives it, and a php-const writer updates the first define, which is the one PHP keeps.

Closes #1399

