### PR TITLE
fix(doctor): see, reach and fix a site's database whatever framework it belongs to

### DIFF
--- a/internal/cli/site_doctor.go
+++ b/internal/cli/site_doctor.go
@@ -60,23 +60,33 @@ func runSiteDoctor(domain string, asJSON, fix bool) error {
 }
 
 // applySiteDoctorFixes resolves the findings lerd can act on by itself and
-// returns a fresh report. Only host-side fixes qualify: the composer and npm
-// ones run in the site's container behind a run lock and stream their output,
+// returns a fresh report: a drifted vhost is rewritten, and a service picked but
+// not wired has its connection written. The composer and npm ones are left out;
+// they run in the site's container behind a run lock and stream their output,
 // which belongs to the surfaces that can show it.
 func applySiteDoctorFixes(path, fwName string, resp sitedoctor.Response, quiet bool) sitedoctor.Response {
 	fixed := false
 	for _, c := range resp.Checks {
-		if c.Fix != sitedoctor.FixVhostRegenerate {
-			continue
+		switch c.Fix {
+		case sitedoctor.FixVhostRegenerate:
+			if err := sitedoctor.FixVhost(path); err != nil {
+				feedback.Warn("regenerating the vhost: %v", err)
+				continue
+			}
+			if !quiet {
+				fmt.Printf("  %s\n\n", feedback.Dim("regenerated the site's nginx vhost"))
+			}
+			fixed = true
+		case sitedoctor.FixEnvSync:
+			if err := runLerdEnv(path); err != nil {
+				feedback.Warn("writing the env: %v", err)
+				continue
+			}
+			if !quiet {
+				fmt.Printf("  %s\n\n", feedback.Dim("wrote the connection values for the services this project picks"))
+			}
+			fixed = true
 		}
-		if err := sitedoctor.FixVhost(path); err != nil {
-			feedback.Warn("regenerating the vhost: %v", err)
-			continue
-		}
-		if !quiet {
-			fmt.Printf("  %s\n\n", feedback.Dim("regenerated the site's nginx vhost"))
-		}
-		fixed = true
 	}
 	if !fixed {
 		return resp

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -108,7 +108,7 @@ func ApplyUpdates(path string, updates map[string]string) error {
 	if out == string(original) {
 		return nil
 	}
-	return os.WriteFile(path, []byte(out), info.Mode().Perm())
+	return writeFile(path, []byte(out), info.Mode().Perm())
 }
 
 // validateEnvKey rejects keys that would corrupt .env structure if written

--- a/internal/envfile/phparray.go
+++ b/internal/envfile/phparray.go
@@ -104,7 +104,7 @@ func ApplyPhpArrayUpdates(path string, updates map[string]string) error {
 			return err
 		}
 	}
-	return os.WriteFile(path, []byte(b.String()), 0o644)
+	return writeFile(path, []byte(b.String()), 0o644)
 }
 
 func flatten(prefix string, v *phpValue, out map[string]string) {

--- a/internal/envfile/phpconst.go
+++ b/internal/envfile/phpconst.go
@@ -78,5 +78,5 @@ func ApplyPhpConstUpdates(path string, updates map[string]string) error {
 	if content == string(data) {
 		return nil
 	}
-	return os.WriteFile(path, []byte(content), 0644)
+	return writeFile(path, []byte(content), 0644)
 }

--- a/internal/envfile/phpvars.go
+++ b/internal/envfile/phpvars.go
@@ -134,7 +134,7 @@ func ApplyPhpVarsUpdates(path string, updates map[string]string) error {
 			return err
 		}
 	}
-	return os.WriteFile(path, []byte(out), 0o644)
+	return writeFile(path, []byte(out), 0o644)
 }
 
 func sameValues(a, b map[string]string) bool {

--- a/internal/envfile/write.go
+++ b/internal/envfile/write.go
@@ -1,0 +1,27 @@
+package envfile
+
+import "os"
+
+// writeFile writes an env file, restoring write permission for the duration
+// when the file has none and putting the mode back exactly as it was.
+//
+// A framework may harden its own configuration: Drupal's installer leaves
+// settings.php read-only, and its directory too, which is correct for a
+// deployed site and is not a reason for lerd to refuse to configure a local
+// one. Failing with "permission denied" left the user to chmod by hand, work
+// out that lerd had already created the databases, and undo the rest.
+//
+// The mode is restored even when the write fails, so a file lerd could not
+// update is left exactly as hardened as it was found.
+func writeFile(path string, data []byte, perm os.FileMode) error {
+	if info, err := os.Stat(path); err == nil {
+		perm = info.Mode().Perm()
+		if perm&0o200 == 0 {
+			if err := os.Chmod(path, perm|0o200); err != nil {
+				return err
+			}
+			defer func() { _ = os.Chmod(path, perm) }()
+		}
+	}
+	return os.WriteFile(path, data, perm)
+}

--- a/internal/envfile/write_test.go
+++ b/internal/envfile/write_test.go
@@ -1,0 +1,95 @@
+package envfile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Drupal's installer leaves settings.php read-only, which is correct for a
+// deployed site and is not a reason for lerd to refuse to configure a local
+// one. It failed with "permission denied" after already creating the databases,
+// leaving the user to chmod by hand and undo the rest.
+func TestApplyPhpVarsUpdates_writesAReadOnlyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.php")
+	body := "<?php\n$databases['default']['default'] = ['driver' => 'sqlite'];\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o444); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ApplyPhpVarsUpdates(path, map[string]string{"databases.default.default.driver": "mysql"}); err != nil {
+		t.Fatalf("ApplyPhpVarsUpdates on a read-only file: %v", err)
+	}
+
+	out, _ := os.ReadFile(path)
+	if !strings.Contains(string(out), "'mysql'") {
+		t.Errorf("the file was not updated:\n%s", out)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o444 {
+		t.Errorf("mode = %v, want the 444 the framework hardened it to", info.Mode().Perm())
+	}
+}
+
+// Every format goes through the same writer, so a hardened dotenv or wp-config
+// behaves the same way.
+func TestWriters_allHandleAHardenedFile(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name, seed string
+		apply      func(string) error
+		want       string
+	}{
+		{".env", "DB_HOST=old\n", func(p string) error {
+			return ApplyUpdates(p, map[string]string{"DB_HOST": "lerd-mysql"})
+		}, "lerd-mysql"},
+		{"wp-config.php", "<?php\ndefine( 'DB_HOST', 'old' );\n", func(p string) error {
+			return ApplyPhpConstUpdates(p, map[string]string{"DB_HOST": "lerd-mysql"})
+		}, "lerd-mysql"},
+		{"env.php", "<?php\nreturn ['db' => ['host' => 'old']];\n", func(p string) error {
+			return ApplyPhpArrayUpdates(p, map[string]string{"db.host": "lerd-mysql"})
+		}, "lerd-mysql"},
+	}
+	for _, c := range cases {
+		path := filepath.Join(dir, c.name)
+		if err := os.WriteFile(path, []byte(c.seed), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, 0o444); err != nil {
+			t.Fatal(err)
+		}
+		if err := c.apply(path); err != nil {
+			t.Errorf("%s: %v", c.name, err)
+			continue
+		}
+		out, _ := os.ReadFile(path)
+		if !strings.Contains(string(out), c.want) {
+			t.Errorf("%s not updated:\n%s", c.name, out)
+		}
+		if info, _ := os.Stat(path); info.Mode().Perm() != 0o444 {
+			t.Errorf("%s mode = %v, want 444 restored", c.name, info.Mode().Perm())
+		}
+	}
+}
+
+// A writable file keeps the mode it had, untouched.
+func TestWriteFile_leavesAWritableFileAlone(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("A=1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ApplyUpdates(path, map[string]string{"A": "2"}); err != nil {
+		t.Fatal(err)
+	}
+	if info, _ := os.Stat(path); info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %v, want 600 preserved", info.Mode().Perm())
+	}
+}

--- a/internal/sitedoctor/server_database.go
+++ b/internal/sitedoctor/server_database.go
@@ -5,15 +5,8 @@ import (
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
-	"github.com/geodro/lerd/internal/envfile"
 	"github.com/geodro/lerd/internal/serviceops"
 )
-
-// serverDatabaseFamilies are the env driver names that mean the site's data
-// lives in an engine lerd runs, rather than in a file next to the code.
-var serverDatabaseFamilies = map[string]bool{
-	"mysql": true, "mariadb": true, "pgsql": true, "postgres": true, "postgresql": true,
-}
 
 // listDatabases is the engine-agnostic lookup, hooked so tests can drive the
 // check without a running container. The command itself comes from the service
@@ -37,36 +30,47 @@ func stubDatabaseLister(fn func(string) ([]string, error)) func() {
 	return func() { listDatabases = prev }
 }
 
-// checkServerDatabase fails when the env file points at a MySQL or Postgres
-// schema that does not exist on the service. Without it such a site 500s on
-// every request while the doctor reports nothing wrong: the framework's own
-// migration check cannot reach the app either, so it degrades to "couldn't run"
-// and is not counted as a failure.
-func checkServerDatabase(_ string, envPath string, fw *config.Framework) (Check, bool) {
-	driver := strings.ToLower(strings.TrimSpace(envfile.ReadKey(envPath, "DB_CONNECTION")))
-	if !serverDatabaseFamilies[driver] {
+// checkServerDatabase fails when the site's database does not exist on the
+// engine it points at. Without it such a site 500s on every request while the
+// doctor reports nothing wrong: the framework's own migration check cannot reach
+// the app either, so it degrades to "couldn't run" and is not counted.
+//
+// Which database on which service is read from the framework declaration, so a
+// project keeping its configuration in a PHP settings file or behind a DSN is
+// checked like any other. It used to read DB_CONNECTION, DB_HOST and DB_DATABASE
+// by name, which are Laravel's, so the frameworks least likely to be wired that
+// way were the ones it could not check.
+func checkServerDatabase(path string, fw *config.Framework) (Check, bool) {
+	targets := config.DBTargetsFor(path)
+	if len(targets) == 0 {
+		// No lerd-run database: a file database, an external server, or nothing
+		// configured. None of those is this check's to judge.
 		return Check{}, false
 	}
-	dbName := strings.TrimSpace(envfile.ReadKey(envPath, "DB_DATABASE"))
-	host := strings.TrimSpace(envfile.ReadKey(envPath, "DB_HOST"))
-	service := strings.TrimPrefix(host, "lerd-")
-	if dbName == "" || service == "" || !strings.HasPrefix(host, "lerd-") {
-		// An external database, or one lerd does not run, is not ours to judge.
-		return Check{}, false
-	}
-
-	names, err := listDatabases(service)
-	if err != nil {
-		// The engine is down or unreachable. Reporting that as a missing schema
-		// would send the user to create a database that may already exist.
-		return Check{}, false
-	}
-	for _, n := range names {
-		if strings.EqualFold(n, dbName) {
-			return Check{Name: "server_database", Status: StatusOK}, true
+	checked := false
+	for _, t := range targets {
+		names, err := listDatabases(t.Service)
+		if err != nil {
+			// The engine is down or unreachable. Reporting that as a missing
+			// schema would send the user to create a database that may exist.
+			continue
+		}
+		checked = true
+		found := false
+		for _, n := range names {
+			if strings.EqualFold(n, t.Database) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return Check{Name: "server_database", Status: StatusFail, Fix: migrateFix(fw),
+				Detail: fmt.Sprintf("Database %q does not exist on %s — create it with lerd db:create %s, then run migrations.", t.Database, t.Service, t.Database)}, true
 		}
 	}
-
-	return Check{Name: "server_database", Status: StatusFail, Fix: migrateFix(fw),
-		Detail: fmt.Sprintf("Database %q does not exist on %s — create it with lerd db:create %s, then run migrations.", dbName, service, dbName)}, true
+	if !checked {
+		// Nothing could be asked, so there is nothing to report either way.
+		return Check{}, false
+	}
+	return Check{Name: "server_database", Status: StatusOK}, true
 }

--- a/internal/sitedoctor/server_database_declared_test.go
+++ b/internal/sitedoctor/server_database_declared_test.go
@@ -1,0 +1,64 @@
+package sitedoctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// Whether the site's database exists is asked through the framework
+// declaration, so a project keeping its configuration in a PHP settings file is
+// checked like any other. Reading DB_HOST and DB_DATABASE by name meant the
+// frameworks least likely to be wired that way were the ones lerd could not
+// check at all.
+func TestCheckServerDatabase_readsAPHPSettingsFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	store := config.StoreFrameworksDir()
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	def := "name: drupalish\nlabel: Drupalish\npublic_dir: web\nenv:\n" +
+		"  app_file: web/sites/default/settings.php\n  app_format: php-vars\n  services:\n    mysql:\n" +
+		"      detect:\n        - key: databases.default.default.driver\n          value_prefix: mysql\n" +
+		"      vars:\n        - databases.default.default.driver=mysql\n" +
+		"        - databases.default.default.host=lerd-mysql\n" +
+		"        - databases.default.default.database={{site}}\n"
+	if err := os.WriteFile(filepath.Join(store, "drupalish.yaml"), []byte(def), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "web", "sites", "default"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("framework: drupalish\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	body := "<?php\n$databases['default']['default'] = ['driver' => 'mysql', 'host' => 'lerd-mysql', 'database' => 'shop'];\n"
+	if err := os.WriteFile(filepath.Join(dir, "web/sites/default/settings.php"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fw, ok := config.GetFrameworkForDir("drupalish", dir)
+	if !ok {
+		t.Fatal("the test definition did not resolve")
+	}
+
+	restore := stubDatabaseLister(func(string) ([]string, error) { return []string{"other"}, nil })
+	defer restore()
+	c, produced := checkServerDatabase(dir, fw)
+	if !produced || c.Status != StatusFail {
+		t.Fatalf("check = %+v (produced=%v), want a failure for the missing schema", c, produced)
+	}
+
+	restore()
+	restore2 := stubDatabaseLister(func(string) ([]string, error) { return []string{"shop"}, nil })
+	defer restore2()
+	if c, _ := checkServerDatabase(dir, fw); c.Status != StatusOK {
+		t.Errorf("check = %+v, want ok once the database exists", c)
+	}
+}

--- a/internal/sitedoctor/service_wiring.go
+++ b/internal/sitedoctor/service_wiring.go
@@ -58,8 +58,9 @@ func checkServiceWiring(path, envFile string, fw *config.Framework) (Check, bool
 	return Check{
 		Name:   "service_wiring",
 		Status: StatusWarn,
+		Fix:    FixEnvSync,
 		Detail: strings.Join(unwired, ", ") + " picked in .lerd.yaml, but nothing in " + envFile +
-			" points at it — the app is using something else, or was never wired up",
+			" points at it — run `lerd env` to write the connection, which repoints the app at that service",
 	}, true
 }
 

--- a/internal/sitedoctor/sitedoctor.go
+++ b/internal/sitedoctor/sitedoctor.go
@@ -50,6 +50,10 @@ const (
 	// project knows which of two values it meant, so the dashboard opens the env
 	// editor's resolver on it instead of running anything.
 	FixEnvDuplicates = "env_duplicates_resolve"
+	// FixEnvSync writes the connection values for the services a project picks
+	// into the env file its framework declares, which is what `lerd env` does
+	// and what resolves a service picked but not wired.
+	FixEnvSync = "env_sync"
 )
 
 // DoctorFixCommands maps each universal fix key to the shell command run in the
@@ -60,6 +64,9 @@ var DoctorFixCommands = map[string]string{
 	FixComposerUpdate:  "composer update",
 	FixNpmInstall:      "npm install",
 	FixNpmAuditFix:     "npm audit fix",
+	// Not a package manager, but the same shape: a command run in the project
+	// directory with lerd's own bin dir on PATH, streaming what it did.
+	FixEnvSync: "lerd env",
 }
 
 // commandTimeout bounds each container exec a check makes (declared command
@@ -187,16 +194,18 @@ func Run(ctx context.Context, path string, fw *config.Framework) Response {
 	if c, ok := checkEnvDuplicates(path, envFile, envFormat); ok {
 		resp.add(c)
 	}
+	// Whether the site's database exists is answered through the framework
+	// declaration, so it is asked of every format, not only dotenv.
+	if c, ok := checkServerDatabase(path, fw); ok {
+		resp.add(c)
+		dbBroken = dbBroken || c.Status == StatusFail
+	}
 	if envFormat == "dotenv" {
 		if c, ok := checkAppKey(envPath, fw); ok {
 			resp.add(c)
 		}
 		if c, ok := checkEnvDrift(path, envPath, filepath.Join(path, exampleFile)); ok {
 			resp.add(c)
-		}
-		if c, ok := checkServerDatabase(path, envPath, fw); ok {
-			resp.add(c)
-			dbBroken = dbBroken || c.Status == StatusFail
 		}
 	}
 

--- a/internal/sitedoctor/sitedoctor_test.go
+++ b/internal/sitedoctor/sitedoctor_test.go
@@ -817,6 +817,12 @@ func TestApplies(t *testing.T) {
 // migration check degrades to "couldn't run" and is not counted, so a 500ing
 // site reported 0 failing.
 func TestCheckServerDatabase(t *testing.T) {
+	// The resolution reads the framework store and the service presets, so the
+	// config directories are sandboxed away from the developer's own install.
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
 	migrateFW := &config.Framework{Commands: []config.FrameworkCommand{{Name: "migrate"}}}
 	env := "DB_CONNECTION=mysql\nDB_HOST=lerd-mysql\nDB_DATABASE=shop\n"
 
@@ -825,7 +831,7 @@ func TestCheckServerDatabase(t *testing.T) {
 		writeEnv(t, dir, ".env", env)
 		restore := stubDatabaseLister(func(string) ([]string, error) { return []string{"other", "lerd"}, nil })
 		defer restore()
-		c, ok := checkServerDatabase(dir, filepath.Join(dir, ".env"), migrateFW)
+		c, ok := checkServerDatabase(dir, migrateFW)
 		if !ok || c.Status != StatusFail {
 			t.Fatalf("a missing schema should fail, got ok=%v %+v", ok, c)
 		}
@@ -836,7 +842,7 @@ func TestCheckServerDatabase(t *testing.T) {
 		writeEnv(t, dir, ".env", env)
 		restore := stubDatabaseLister(func(string) ([]string, error) { return []string{"shop"}, nil })
 		defer restore()
-		c, ok := checkServerDatabase(dir, filepath.Join(dir, ".env"), migrateFW)
+		c, ok := checkServerDatabase(dir, migrateFW)
 		if !ok || c.Status != StatusOK {
 			t.Fatalf("an existing schema should pass, got ok=%v %+v", ok, c)
 		}
@@ -847,7 +853,7 @@ func TestCheckServerDatabase(t *testing.T) {
 		writeEnv(t, dir, ".env", env)
 		restore := stubDatabaseLister(func(string) ([]string, error) { return nil, errors.New("engine down") })
 		defer restore()
-		if _, ok := checkServerDatabase(dir, filepath.Join(dir, ".env"), migrateFW); ok {
+		if _, ok := checkServerDatabase(dir, migrateFW); ok {
 			t.Fatal("an engine that could not be queried should produce no check")
 		}
 	})
@@ -855,7 +861,7 @@ func TestCheckServerDatabase(t *testing.T) {
 	t.Run("sqlite is left to the sqlite check", func(t *testing.T) {
 		dir := t.TempDir()
 		writeEnv(t, dir, ".env", "DB_CONNECTION=sqlite\n")
-		if _, ok := checkServerDatabase(dir, filepath.Join(dir, ".env"), migrateFW); ok {
+		if _, ok := checkServerDatabase(dir, migrateFW); ok {
 			t.Fatal("sqlite should be skipped")
 		}
 	})

--- a/internal/ui/web/src/tabs/sites/SiteDoctorModal.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteDoctorModal.svelte
@@ -130,6 +130,7 @@
     composer_update: 'Run composer update',
     npm_install: 'Run npm install',
     npm_audit_fix: 'Run npm audit fix',
+    env_sync: 'Run lerd env (writes the connection and repoints the app)',
     vhost_regenerate: 'Regenerate nginx vhost'
   };
 


### PR DESCRIPTION
Three things stood between the doctor and a Drupal site's database, and together they let a site be misconfigured, say so, and offer nothing.

The wiring finding named the problem and stopped there. It had no fix because, when it was written, `lerd env` would have appended constants Drupal never reads and the button would have resolved nothing. lerd writes the array Drupal actually runs on now, so the finding offers to write it, from the dashboard and from `lerd site:doctor --fix` alike. The detail says it repoints the app, because it does.

`lerd env` then failed on the file it needed to write:

    ✗ writing web/sites/default/settings.php: open ...: permission denied

Drupal's installer leaves settings.php read-only, and its directory too, which is right for a deployed site and no reason to refuse to configure a local one. By then the databases had been created, so the user was left to chmod by hand and work out what else was half done. Writing restores permission for the duration and puts the mode back exactly, even when the write fails, so a file lerd could not update is left as hardened as it was found. Every format goes through the one writer, so a hardened wp-config or env.php behaves the same.

And the check that catches a database which does not exist could not see a Drupal one at all: it read DB_CONNECTION, DB_HOST and DB_DATABASE by name, which are Laravel's, from behind a dotenv gate. It resolves through the framework declaration now, like its SQLite sibling, so a project configured in a PHP settings file or behind a DSN is checked like any other. An engine that cannot be reached still produces no finding rather than a false one.

Driven end to end against a Drupal project serving 200 throughout:

    mode before:  -r--r--r--     HTTP before: 200
    ⚠ Service Wiring ... fix: env_sync
    → lerd site:doctor --fix     wrote the connection values
    ✓ Service Wiring             ✓ Database
    mode after:   -r--r--r--     HTTP after:  200

and with the database dropped out from under it:

    ✗ Database
        Database "dru" does not exist on mysql — create it with lerd db:create dru, then run migrations.
        fix: updb

which is the framework's own command, not Laravel's word for it.

Closes #1405
