### PR TITLE
feat(ui): let a framework decline the repeated-query warning

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -330,6 +330,17 @@ The `commands:` list is the framework's own verbs: the things you would otherwis
 
 `lerd check` validates a definition's commands, and it is the fastest way to catch a typo: an unknown `output` is an error, and an unknown `icon` is a warning.
 
+## Declining a warning
+
+A definition can turn off a warning that says nothing useful about sites built on it:
+
+```yaml
+notifications:
+  nplusone: false                 # this framework's own layers issue the repeats
+```
+
+The repeated-query warning is the case that needs it. On a content management system the entity, config and cache layers issue the repeats during an ordinary request, so the warning names a loop inside the framework that nobody using it can change, and browsing an admin fires one after another. Where the queries come from the code a developer writes, which is most application frameworks, it stays on and is worth having, so a definition saying nothing keeps it.
+
 ## Doctor checks
 
 The `doctor:` section adds framework-specific health checks to the ones every site gets for free (env file present, every picked service wired into it, dependencies installed and locked, audit clean, PHP version in range, nginx vhost current). They run on `lerd site:doctor` and in the dashboard's doctor panel. Keeping them declarative is what stops the doctor from growing a Go branch per framework.

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -70,6 +70,8 @@ type Framework struct {
 	// request with an error about an entity type it can no longer find. A
 	// framework declaring none is left alone.
 	CacheCommand string `yaml:"cache_command,omitempty"`
+	// Notifications turns off warnings that cannot apply to this framework.
+	Notifications *FrameworkNotifications `yaml:"notifications,omitempty"`
 	// Console is the console command to run (without 'php' prefix).
 	// Example: "artisan", "bin/console"
 	Console string `yaml:"console,omitempty"`
@@ -475,6 +477,28 @@ func (f *Framework) HasEnvConfig() bool {
 	}
 	e := f.Env
 	return e.File != "" || e.FallbackFile != "" || e.ExampleFile != "" || e.KeyGeneration != nil || len(e.Services) > 0
+}
+
+// FrameworkNotifications lets a definition decline a warning that says nothing
+// useful about sites built on it.
+type FrameworkNotifications struct {
+	// NPlusOne, set false, stops the repeated-query warning for this
+	// framework's sites. It is for the frameworks whose own request pipeline
+	// does the querying: on a content management system the entity, config and
+	// cache layers issue the repeats, so the warning names a loop inside the
+	// framework that nobody using it can change. Where the queries come from
+	// the code a developer writes, which is most application frameworks, it
+	// stays on.
+	NPlusOne *bool `yaml:"nplusone,omitempty"`
+}
+
+// WarnsNPlusOne reports whether repeated-query warnings apply to a framework's
+// sites, which they do unless the definition says otherwise.
+func (f *Framework) WarnsNPlusOne() bool {
+	if f == nil || f.Notifications == nil || f.Notifications.NPlusOne == nil {
+		return true
+	}
+	return *f.Notifications.NPlusOne
 }
 
 // EnvKeyGeneration describes how to generate an application encryption key.

--- a/internal/ui/notify_nplusone.go
+++ b/internal/ui/notify_nplusone.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/dumps"
 	"github.com/geodro/lerd/internal/push"
 	"github.com/geodro/lerd/internal/reqstats"
@@ -46,13 +47,39 @@ type nPlusOneTracker struct {
 	perReq map[string]map[string]int // rid -> fingerprint -> count
 	order  []string                  // rid insertion order, for eviction
 	warned map[string]bool           // route key -> already warned
+	warns  map[string]bool           // site -> its framework wants the warning
 }
 
 func newNPlusOneTracker() *nPlusOneTracker {
 	return &nPlusOneTracker{
 		perReq: map[string]map[string]int{},
 		warned: map[string]bool{},
+		warns:  map[string]bool{},
 	}
+}
+
+// siteWarns reports whether the site's framework wants repeated-query warnings.
+// A content management system issues the repeats from its own entity, config
+// and cache layers, so the warning names a loop inside the framework rather
+// than anything the developer wrote, and its definition says so.
+//
+// Resolved once per site: this is asked of every query event, and the answer
+// changes about as often as a site changes framework.
+func (t *nPlusOneTracker) siteWarns(site string) bool {
+	if site == "" {
+		return true
+	}
+	if v, ok := t.warns[site]; ok {
+		return v
+	}
+	warns := true
+	if s, err := config.FindSite(site); err == nil && s != nil {
+		if fw, ok := config.GetFrameworkForDir(s.Framework, s.Path); ok {
+			warns = fw.WarnsNPlusOne()
+		}
+	}
+	t.warns[site] = warns
+	return warns
 }
 
 // routeKeyForQuery collapses a query event to the "route or script" the warning
@@ -94,7 +121,7 @@ func (t *nPlusOneTracker) observe(ev dumps.Event) *push.Notification {
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if t.warned[route] {
+	if t.warned[route] || !t.siteWarns(ev.Ctx.Site) {
 		return nil
 	}
 	m := t.perReq[ev.Ctx.RID]

--- a/internal/ui/notify_nplusone_optout_test.go
+++ b/internal/ui/notify_nplusone_optout_test.go
@@ -1,0 +1,92 @@
+package ui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/dumps"
+)
+
+func queryEventFor(site, request string) dumps.Event {
+	data, _ := json.Marshal(dumps.QueryData{SQL: "SELECT * FROM cachetags WHERE tag = 'x'"})
+	return dumps.Event{
+		V:    1,
+		Kind: dumps.KindQuery,
+		Data: data,
+		Ctx:  dumps.Context{RID: "r1", Site: site, Request: request},
+	}
+}
+
+// registerFrameworkSite installs a definition and a site on it, in a sandboxed
+// config so the developer's own install is never read.
+func registerFrameworkSite(t *testing.T, name, defYAML string) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	store := config.StoreFrameworksDir()
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store, name+".yaml"), []byte(defYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := config.AddSite(config.Site{Name: "s", Domains: []string{"s.test"}, Path: dir, Framework: name}); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// A content management system issues the repeats from its own entity, config
+// and cache layers, so the warning names a loop inside the framework that
+// nobody using it can change. Browsing such a site flooded the desktop.
+func TestNPlusOne_frameworkCanDeclineTheWarning(t *testing.T) {
+	registerFrameworkSite(t, "cmsish", "name: cmsish\nlabel: CMSish\npublic_dir: web\nnotifications:\n  nplusone: false\n")
+
+	tracker := newNPlusOneTracker()
+	for range 10 {
+		if n := tracker.observe(queryEventFor("s", "GET /admin/content")); n != nil {
+			t.Fatalf("a framework that declined the warning produced one: %s", n.Body)
+		}
+	}
+}
+
+// A framework that says nothing keeps the warning, which is most of them: the
+// queries come from the code the developer wrote.
+func TestNPlusOne_frameworkWithoutADeclarationStillWarns(t *testing.T) {
+	registerFrameworkSite(t, "appish", "name: appish\nlabel: Appish\npublic_dir: public\n")
+
+	tracker := newNPlusOneTracker()
+	var got bool
+	for range 5 {
+		if n := tracker.observe(queryEventFor("s", "GET /orders")); n != nil {
+			got = true
+		}
+	}
+	if !got {
+		t.Error("a framework with no declaration stopped warning")
+	}
+}
+
+func TestFrameworkWarnsNPlusOne_defaults(t *testing.T) {
+	off := false
+	on := true
+	if (&config.Framework{}).WarnsNPlusOne() != true {
+		t.Error("a framework declaring nothing should warn")
+	}
+	if (&config.Framework{Notifications: &config.FrameworkNotifications{NPlusOne: &off}}).WarnsNPlusOne() {
+		t.Error("a framework declining should not warn")
+	}
+	if !(&config.Framework{Notifications: &config.FrameworkNotifications{NPlusOne: &on}}).WarnsNPlusOne() {
+		t.Error("a framework declaring true should warn")
+	}
+	var nilFW *config.Framework
+	if !nilFW.WarnsNPlusOne() {
+		t.Error("no framework at all should warn")
+	}
+}


### PR DESCRIPTION
Browsing a content management system's admin fires the repeated-query warning again and again, and none of it is actionable: the entity, config and cache layers issue the repeats during an ordinary request, so the warning names a loop inside the framework that nobody using it can change.

lerd cannot tell those apart from a developer's own loop. Every query event reports the framework's database layer as its source, 39 of 39 in a browsing session pointing at Drupal's own PdoTrait, so there is nothing to distinguish core's repeats from a module's. That is #1412 and worth fixing on its own; until it is, the fact that a framework's own pipeline does the querying is something the definition knows and can say.

So a definition can decline the warning:

    notifications:
      nplusone: false

A framework that says nothing keeps it, which is most of them: where the queries come from the code a developer writes the warning is worth having, and the existing global toggle would take it away from those sites too. The answer is resolved once per site, since it is asked of every query event and changes about as often as a site changes framework.

Which frameworks decline it is theirs to declare, and a store change: Drupal, WordPress and Magento are the published ones whose request pipelines do their own querying.

Driven against the site that produced the flood, with the declaration installed: four page loads through the front page and the admin, no notifications.

Closes #1413
