### PR TITLE
fix: restore the guards a release of refactoring dropped

### DIFF
--- a/docs/features/env-setup.md
+++ b/docs/features/env-setup.md
@@ -100,7 +100,7 @@ Use `host.containers.internal` for the host rather than `127.0.0.1`. The overrid
 
 On macOS that is all it takes: the connection is delivered to the host's loopback, so a server bound to `127.0.0.1` with `'user'@'localhost'` grants accepts it unchanged. On Linux it arrives from a real, non-loopback address instead, so a distro package left at its defaults refuses it and the server needs to listen past loopback and grant from somewhere other than `localhost`. [Using a service you run on the host](../usage/services.md#using-a-service-you-run-on-the-host) has the per-platform detail.
 
-The value is comma or space separated, so `LERD_EXTERNAL_SERVICES=postgres, redis` opts both out. The reserved key is consumed by lerd and is never written into `.env`.
+The value is comma or space separated, so `LERD_EXTERNAL_SERVICES=postgres, redis` opts both out. The reserved key is consumed by lerd and is never written into `.env`. The [site doctor](/features/web-ui) reads it too: a service you run yourself is never reported as missing, and never offered for install, however loudly your project declares it.
 
 The variables lerd writes for an external service are the ones your framework reads, since they are what the override file then overrides. An external MariaDB on Symfony gets the `DATABASE_URL` Doctrine reads, not the Laravel-shaped `DB_*` keys Symfony has no use for. A framework whose env file is a returned PHP array, as Magento's `app/etc/env.php` is, cannot take an override at all: its keys are dotted paths and `.env.lerd_override` is dotenv, so there is no key lerd could write that you would then point at your own instance. lerd writes nothing for it, tells you so, and leaves the connection in `env.php` to you.
 

--- a/internal/cli/db_move.go
+++ b/internal/cli/db_move.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -319,13 +320,21 @@ func runDbMoveOne(sitePath, siteName, from, to string) error {
 // runLerdEnv re-execs `lerd env` in the project directory so the existing env
 // setup (service start, .env rewrite, database provisioning) runs unchanged.
 func runLerdEnv(dir string) error {
+	return runLerdEnvTo(dir, os.Stdout)
+}
+
+// runLerdEnvTo runs `lerd env` in dir with the child's output sent to out. A
+// caller whose own stdout carries a machine-readable document passes stderr:
+// the child writes plain prose, and on stdout it lands in the middle of the
+// document and nothing can parse it.
+func runLerdEnvTo(dir string, out io.Writer) error {
 	self, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolving lerd executable: %w", err)
 	}
 	cmd := exec.Command(self, "env")
 	cmd.Dir = dir
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = out
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -435,11 +435,36 @@ func envApplyLine(svc string, detectedFromEnv bool) {
 	}
 }
 
+// startableFrameworkService reports whether a service a framework declares is
+// one lerd can actually run. SQLite is a file the project owns: there is no
+// preset and no container, so trying to start it ends in "custom service
+// \"sqlite\" not found", which reads as a broken project when nothing is wrong.
+func startableFrameworkService(svc string) bool {
+	return svc != "sqlite"
+}
+
 // userPickedDBFromYAML returns true when the user has named any database
 // service in .lerd.yaml: sqlite, the built-in mysql/postgres, or a custom DB
 // family alternate (mysql-5-6, mariadb-11, postgres-14, mongo-6, …). This
 // signal is what lets us replace whatever the existing .env says about
 // DB_CONNECTION with the user's actual pick.
+// projectUsesSQLite reports whether the project's data lives in a file rather
+// than in a service. SQLite is deliberately not written into .lerd.yaml (it has
+// no preset, no container, nothing to install), so the pick has to be read from
+// the project's own configuration: the framework declares a sqlite wiring, its
+// detect rules match the env file, and no database service was chosen instead.
+// The .lerd.yaml entry is still honoured for projects linked before that.
+func projectUsesSQLite(lerdYAMLServices map[string]bool, envMap map[string]string, fw *config.Framework, externalDB bool) bool {
+	if lerdYAMLServices["sqlite"] {
+		return true
+	}
+	if fw == nil || externalDB || userPickedDBFromYAML(lerdYAMLServices) {
+		return false
+	}
+	def, ok := fw.Env.Services["sqlite"]
+	return ok && frameworkServiceDetected(def, envMap)
+}
+
 func userPickedDBFromYAML(lerdYAMLServices map[string]bool) bool {
 	if lerdYAMLServices["sqlite"] || lerdYAMLServices["mysql"] || lerdYAMLServices["postgres"] {
 		return true
@@ -736,6 +761,12 @@ func runEnv(_ *cobra.Command, _ []string) error {
 				continue
 			}
 
+			// The sqlite step below owns the file database entirely, vars and
+			// all, so reporting and applying it here too would say it twice and
+			// then try to start a container that does not exist.
+			if !startableFrameworkService(svc) {
+				continue
+			}
 			envApplyLine(svc, detectedFromEnv)
 			isDB := svc == "mysql" || svc == "postgres"
 			for _, kv := range def.Vars {
@@ -877,11 +908,11 @@ func runEnv(_ *cobra.Command, _ []string) error {
 	}
 
 	// 3a-bis. SQLite is not a containerized service but is a valid choice from
-	// the init wizard / runtime DB prompt. When listed in .lerd.yaml, apply the
-	// standard Laravel sqlite env vars and ensure the database file exists so
-	// migrations can run immediately. No service to start, no SQL DB to create.
-	if lerdYAMLServices["sqlite"] {
-		envApplyLine("sqlite", false)
+	// the init wizard / runtime DB prompt. Apply the framework's sqlite env vars
+	// and ensure the database file exists so migrations can run immediately. No
+	// service to start, no SQL DB to create.
+	if projectUsesSQLite(lerdYAMLServices, envMap, fw, externalDBPicked(extServices)) {
+		envApplyLine("sqlite", !lerdYAMLServices["sqlite"])
 		for _, kv := range serviceEnvVars("sqlite") {
 			k, v, _ := strings.Cut(kv, "=")
 			updates[k] = v
@@ -1101,17 +1132,11 @@ func runEnv(_ *cobra.Command, _ []string) error {
 				}
 			} else if kg.FallbackPrefix != "" {
 				envInfo("  Generating %s (vendor not installed yet)...\n", kg.EnvKey)
-				key := generateRandomKey(kg.FallbackPrefix)
-				if err := envfile.ApplyUpdates(envPath, map[string]string{kg.EnvKey: key}); err != nil {
-					feedback.Warn("writing %s: %v", kg.EnvKey, err)
-				}
+				writeGeneratedKey(envPath, envFormat, kg)
 			}
 		} else if kg.FallbackPrefix != "" {
 			envInfo("  Generating %s...\n", kg.EnvKey)
-			key := generateRandomKey(kg.FallbackPrefix)
-			if err := envfile.ApplyUpdates(envPath, map[string]string{kg.EnvKey: key}); err != nil {
-				feedback.Warn("writing %s: %v", kg.EnvKey, err)
-			}
+			writeGeneratedKey(envPath, envFormat, kg)
 		}
 	}
 
@@ -1660,5 +1685,17 @@ func patchDuskTestCase(dir string) {
 			return
 		}
 		fmt.Println("  Patched tests/DuskTestCase.php for lerd Selenium")
+	}
+}
+
+// writeGeneratedKey writes a locally generated application key through the
+// framework's own env format. The key is written to the file the definition
+// names, which for a PHP-configured framework is a settings file: the dotenv
+// writer would append a bare key=value line after the closing tag and take the
+// site down with a parse error.
+func writeGeneratedKey(envPath, envFormat string, kg *config.EnvKeyGeneration) {
+	key := generateRandomKey(kg.FallbackPrefix)
+	if err := envfile.ApplyUpdatesIn(envPath, envFormat, map[string]string{kg.EnvKey: key}); err != nil {
+		feedback.Warn("writing %s: %v", kg.EnvKey, err)
 	}
 }

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -832,3 +832,59 @@ func TestWiredVarsFor_ExternalUnmappedKeepsThePresetKeys(t *testing.T) {
 		t.Errorf("got %v, want the preset's own keys", got)
 	}
 }
+
+// SQLite is deliberately absent from .lerd.yaml: it is a file the project owns,
+// not a service lerd runs. That left `lerd env` with no signal at all, so a
+// project that picked SQLite in the wizard got neither its database env vars nor
+// the file itself, and the first request 500'd on a database that was never
+// created. The project's own configuration is the signal instead.
+func TestProjectUsesSQLite(t *testing.T) {
+	laravelish := &config.Framework{Env: config.FrameworkEnvConf{Services: map[string]config.FrameworkServiceDef{
+		"sqlite": {
+			Detect: []config.FrameworkServiceDetect{{Key: "DB_CONNECTION", ValuePrefix: "sqlite"}},
+			Vars:   []string{"DB_CONNECTION=sqlite", "DB_DATABASE=database/database.sqlite"},
+		},
+		"mysql": {
+			Detect: []config.FrameworkServiceDetect{{Key: "DB_CONNECTION", ValuePrefix: "mysql"}},
+			Vars:   []string{"DB_CONNECTION=mysql", "DB_HOST=lerd-mysql"},
+		},
+	}}}
+	sqliteEnv := map[string]string{"DB_CONNECTION": "sqlite"}
+
+	for _, tc := range []struct {
+		name  string
+		yaml  map[string]bool
+		env   map[string]string
+		fw    *config.Framework
+		extDB bool
+		want  bool
+	}{
+		{"env says sqlite and nothing else was picked", map[string]bool{}, sqliteEnv, laravelish, false, true},
+		{"an older project still listing sqlite", map[string]bool{"sqlite": true}, map[string]string{}, laravelish, false, true},
+		{"a database service was picked instead", map[string]bool{"mysql": true}, sqliteEnv, laravelish, false, false},
+		{"the user runs their own database", map[string]bool{}, sqliteEnv, laravelish, true, false},
+		{"env names a server driver", map[string]bool{}, map[string]string{"DB_CONNECTION": "mysql"}, laravelish, false, false},
+		{"a framework with no sqlite wiring", map[string]bool{}, sqliteEnv, &config.Framework{}, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := projectUsesSQLite(tc.yaml, tc.env, tc.fw, tc.extDB); got != tc.want {
+				t.Errorf("projectUsesSQLite = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// SQLite has no container, so the service loop must not try to start one: the
+// run ends with "could not start sqlite: custom service not found", which reads
+// as a broken project when nothing is wrong. The sqlite step owns the file and
+// the env vars; the loop leaves it alone.
+func TestShouldStartFrameworkService_neverForSQLite(t *testing.T) {
+	if startableFrameworkService("sqlite") {
+		t.Error("sqlite is a file the project owns, not a service to start")
+	}
+	for _, svc := range []string{"mysql", "postgres", "redis", "meilisearch"} {
+		if !startableFrameworkService(svc) {
+			t.Errorf("%s is a service lerd runs and must still be started", svc)
+		}
+	}
+}

--- a/internal/cli/site_doctor.go
+++ b/internal/cli/site_doctor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/geodro/lerd/internal/config"
@@ -119,7 +120,7 @@ func applySiteDoctorFixes(path, fwName string, resp sitedoctor.Response, quiet b
 				fixed = true
 			}
 		case sitedoctor.FixEnvSync:
-			if err := runLerdEnv(path); err != nil {
+			if err := runLerdEnvTo(path, fixOutput(quiet)); err != nil {
 				feedback.Warn("writing the env: %v", err)
 				continue
 			}
@@ -193,4 +194,14 @@ func doctorGlyph(status string) string {
 	default:
 		return feedback.Dim("?")
 	}
+}
+
+// fixOutput is where a fix's subprocess writes. `--json` puts a document on
+// stdout, so the child's prose goes to stderr instead: a caller parsing stdout
+// gets JSON and nothing else, and a human still sees what happened.
+func fixOutput(quiet bool) io.Writer {
+	if quiet {
+		return os.Stderr
+	}
+	return os.Stdout
 }

--- a/internal/cli/site_doctor_test.go
+++ b/internal/cli/site_doctor_test.go
@@ -91,3 +91,14 @@ func hasVhostWarning(resp sitedoctor.Response) bool {
 	}
 	return false
 }
+
+// `--json` writes a document to stdout, so a fix that shells out must not let
+// the child print there: the report stops being parseable.
+func TestFixOutput_keepsTheJSONDocumentAlone(t *testing.T) {
+	if got := fixOutput(true); got != os.Stderr {
+		t.Errorf("json mode writes subprocess output to %v, want stderr", got)
+	}
+	if got := fixOutput(false); got != os.Stdout {
+		t.Errorf("normal mode writes subprocess output to %v, want stdout", got)
+	}
+}

--- a/internal/config/db_target.go
+++ b/internal/config/db_target.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net"
 	"net/url"
 	"path/filepath"
 	"sort"
@@ -200,14 +201,31 @@ func DBTargetsFor(projectDir string) []DBTarget {
 	for _, t := range declaredDBTargets(projectDir, bindings, vals) {
 		add(t)
 	}
-	add(DBTarget{
-		Service:  dbServiceFor(projectDir, vals["DB_HOST"], ""),
-		Database: vals["DB_DATABASE"],
-	})
+	// The default pair is Laravel's vocabulary and only ever names a database an
+	// engine serves. Writing env vars sets keys and never removes them, so a
+	// project moved to SQLite keeps its DB_HOST, and reading the pair regardless
+	// would hand back a file path as a schema some lerd engine is missing.
+	if serverDBDriver(vals["DB_CONNECTION"]) {
+		add(DBTarget{
+			Service:  dbServiceFor(projectDir, vals["DB_HOST"], ""),
+			Database: vals["DB_DATABASE"],
+		})
+	}
 	for _, t := range dsnTargets(vals) {
 		add(t)
 	}
 	return out
+}
+
+// serverDBDriver reports whether a driver value names a database served by an
+// engine, the only kind a lerd service can hold. An unset value counts: a
+// project that names no driver is read by its host and database keys as before.
+func serverDBDriver(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "mysql", "mariadb", "pgsql", "postgres", "postgresql":
+		return true
+	}
+	return false
 }
 
 // declaredDBTargets resolves the databases the framework declaration accounts
@@ -294,6 +312,12 @@ func dbServiceFor(projectDir, host, declared string) string {
 	if svc, ok := strings.CutPrefix(host, "lerd-"); ok && svc != "" {
 		return strings.TrimSuffix(strings.Split(svc, ":")[0], "/")
 	}
+	// A host lerd does not serve is somebody else's database, whatever the
+	// project's .lerd.yaml happens to list. Only the host-proxy rewrite, which
+	// lands on loopback, is recovered from that list.
+	if host != "" && !isLoopbackHost(host) {
+		return ""
+	}
 	if proj, err := LoadProjectConfig(projectDir); err == nil {
 		for _, svc := range proj.Services {
 			if IsDBServiceName(svc.Name) && svc.Name != "sqlite" {
@@ -305,6 +329,22 @@ func dbServiceFor(projectDir, host, declared string) string {
 		return declared
 	}
 	return ""
+}
+
+// isLoopbackHost reports whether a host value from an env file points back at
+// this machine, in any of the spellings a project writes: with or without a
+// port, and IPv6 in brackets.
+func isLoopbackHost(host string) bool {
+	h := strings.TrimSpace(host)
+	if hostOnly, _, err := net.SplitHostPort(h); err == nil {
+		h = hostOnly
+	}
+	h = strings.Trim(h, "[]")
+	if strings.EqualFold(h, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(h)
+	return ip != nil && (ip.IsLoopback() || ip.IsUnspecified())
 }
 
 // dsnTargets returns the databases the values point at through a connection

--- a/internal/config/db_target_test.go
+++ b/internal/config/db_target_test.go
@@ -425,3 +425,46 @@ func TestEnvFileFor(t *testing.T) {
 		t.Errorf("EnvFileFor(bare) = (%q, %q), want (.env, dotenv)", file, format)
 	}
 }
+
+// A database on someone else's server is not attributed to a lerd engine just
+// because the project's .lerd.yaml happens to list one. The .lerd.yaml fallback
+// exists for the host-proxy rewrite, where the host is loopback.
+func TestDBServiceFor_ExternalHostIsNobodys(t *testing.T) {
+	setConfigDir(t)
+	dir := t.TempDir()
+	writeProjectFile(t, dir, ".lerd.yaml", "services:\n  - mysql\n")
+
+	for _, host := range []string{"db.internal.example.com", "10.0.0.7", "db.example.com:3306"} {
+		if got := DBServiceFor(dir, host); got != "" {
+			t.Errorf("DBServiceFor(%q) = %q, want empty: that database is not ours", host, got)
+		}
+	}
+	// Loopback in its several spellings is the host-proxy rewrite, which does
+	// resolve through .lerd.yaml.
+	for _, host := range []string{"127.0.0.1", "127.0.0.1:3306", "localhost", "::1", "[::1]:3306"} {
+		if got := DBServiceFor(dir, host); got != "mysql" {
+			t.Errorf("DBServiceFor(%q) = %q, want mysql", host, got)
+		}
+	}
+}
+
+// A project moved to SQLite keeps DB_HOST as a leftover, because writing env
+// vars sets keys and never removes them. Reading the default pair anyway turns
+// a file path into a schema the doctor then reports missing from an engine.
+func TestDBTargetsFor_SQLiteProjectHasNoServerTarget(t *testing.T) {
+	setConfigDir(t)
+	dir := t.TempDir()
+	writeProjectFile(t, dir, ".lerd.yaml", "services:\n  - mysql\n")
+	writeProjectFile(t, dir, ".env", "DB_CONNECTION=sqlite\nDB_HOST=lerd-mysql\nDB_DATABASE=database/database.sqlite\n")
+
+	if got := DBTargetsFor(dir); len(got) != 0 {
+		t.Errorf("DBTargetsFor = %+v, want none for a project on SQLite", got)
+	}
+
+	// The same project on a server driver still resolves.
+	writeProjectFile(t, dir, ".env", "DB_CONNECTION=mysql\nDB_HOST=lerd-mysql\nDB_DATABASE=shop\n")
+	got := DBTargetsFor(dir)
+	if len(got) != 1 || got[0].Service != "mysql" || got[0].Database != "shop" {
+		t.Errorf("DBTargetsFor = %+v, want {mysql shop}", got)
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -1408,7 +1408,25 @@ func frameworkVersionPublished(name, version string) bool {
 			return true
 		}
 	}
-	return false
+	// The index is a cache the store refreshes on its own schedule, and this
+	// answers from it without refreshing anything. While it is current, a version
+	// missing from it really is unpublished and asking would only 404. Once it is
+	// older than the store's own refresh window it is no longer evidence: the day
+	// a new major lands, every machine still holding yesterday's copy would
+	// otherwise skip the fetch and quietly serve the project the previous major's
+	// definition, with that major's PHP clamp, workers and doctor checks.
+	return staleStoreIndex()
+}
+
+// staleStoreIndex reports whether the cached store index is older than the
+// window definitions themselves are refreshed on, i.e. old enough that what it
+// does not list proves nothing.
+func staleStoreIndex() bool {
+	info, err := os.Stat(StoreIndexFile())
+	if err != nil {
+		return true
+	}
+	return time.Since(info.ModTime()) > 24*time.Hour
 }
 
 // latestPublishedFrameworkVersion returns the newest version the cached index

--- a/internal/config/framework_published_version_test.go
+++ b/internal/config/framework_published_version_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // writeStoreIndex caches a store index publishing one framework at the given
@@ -181,5 +182,67 @@ func TestClampFrameworkVersion_UnionsDiskAndPublished(t *testing.T) {
 
 	if got := clampFrameworkVersion("acme", "2"); got != "4" {
 		t.Errorf("clampFrameworkVersion(2) = %q, want 4 (installed, below the published range)", got)
+	}
+}
+
+// The gate that stops lerd asking for a version the store has never published
+// answers from the cached index, and that cache is written by the store's own
+// refresh, not by this call. The day a new major lands, every machine whose
+// cache predates it would skip the fetch and silently serve the project the
+// previous major's definition: its PHP clamp, its workers, its doctor checks.
+// A version above everything the cache knows about is exactly the case where
+// the cache is the stale party, so it is asked for.
+func TestGetFrameworkForDir_FetchesAMajorNewerThanTheCachedIndex(t *testing.T) {
+	setConfigDir(t)
+	// The cache predates the release: it lists 12 as the newest, and it was
+	// written before the store's refresh window, so what it omits proves nothing.
+	writeStoreIndex(t, "acme", "12", "12", "11", "10")
+	ageStoreIndex(t, 48*time.Hour)
+	// The store itself already publishes 13.
+	asked := recordFetches(t, "13", "12", "11", "10")
+
+	dir := t.TempDir()
+	writeLerdYAML(t, dir, "framework: acme\nframework_version: \"13\"\n")
+
+	fw, ok := GetFrameworkForDir("acme", dir)
+	if !ok {
+		t.Fatal("GetFrameworkForDir resolved nothing")
+	}
+	if fw.Version != "13" {
+		t.Errorf("version = %q, want 13: the project runs the major the store publishes", fw.Version)
+	}
+	if len(*asked) == 0 || (*asked)[0] != "13" {
+		t.Errorf("fetches = %v, want 13 asked for first", *asked)
+	}
+}
+
+// A version below the published floor is still never asked for: that request
+// can only 404, which is what the gate is there to prevent.
+func TestGetFrameworkForDir_StillSkipsAVersionBelowTheFloor(t *testing.T) {
+	setConfigDir(t)
+	// A current cache: what it does not list, the store does not publish.
+	writeStoreIndex(t, "acme", "12", "12", "11", "10")
+	asked := recordFetches(t, "12", "11", "10")
+
+	dir := t.TempDir()
+	writeLerdYAML(t, dir, "framework: acme\nframework_version: \"7\"\n")
+
+	if _, ok := GetFrameworkForDir("acme", dir); !ok {
+		t.Fatal("GetFrameworkForDir resolved nothing for a legacy project")
+	}
+	for _, v := range *asked {
+		if v == "7" {
+			t.Errorf("fetches = %v, want no request for the unpublished 7", *asked)
+		}
+	}
+}
+
+// ageStoreIndex backdates the cached index so it reads as one the store has not
+// refreshed lately.
+func ageStoreIndex(t *testing.T, age time.Duration) {
+	t.Helper()
+	when := time.Now().Add(-age)
+	if err := os.Chtimes(StoreIndexFile(), when, when); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/envfile/envfile.go
+++ b/internal/envfile/envfile.go
@@ -4,6 +4,7 @@ package envfile
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,6 +41,13 @@ func ApplyUpdates(path string, updates map[string]string) error {
 	original, err := os.ReadFile(path)
 	if err != nil {
 		return err
+	}
+	// This writer appends `key=value` lines, which is nonsense in a PHP settings
+	// file: the file stops parsing and every request to the site fails. A caller
+	// that knows the format goes through ApplyUpdatesIn; one that resolved a path
+	// without carrying the format is stopped here rather than breaking the site.
+	if isPHPSource(original) {
+		return fmt.Errorf("%s holds PHP, not dotenv lines; write it through ApplyUpdatesIn with the framework's format", filepath.Base(path))
 	}
 
 	var lines []string
@@ -343,4 +351,14 @@ func SyncPrimaryDomain(projectPath, envFile, urlKey, domain string, secured bool
 		return nil
 	}
 	return ApplyUpdates(envPath, updates)
+}
+
+// isPHPSource reports whether a file's contents open with a PHP tag, the one
+// shape the dotenv writer must never append to. A byte-order mark counts as
+// leading whitespace: editors leave them behind and they do not make a settings
+// file any less PHP.
+func isPHPSource(content []byte) bool {
+	body := bytes.TrimPrefix(content, []byte{0xEF, 0xBB, 0xBF})
+	body = bytes.TrimLeft(body, " \t\r\n")
+	return bytes.HasPrefix(body, []byte("<?php")) || bytes.HasPrefix(body, []byte("<?="))
 }

--- a/internal/envfile/format_test.go
+++ b/internal/envfile/format_test.go
@@ -77,3 +77,38 @@ func TestKnownFormat(t *testing.T) {
 		t.Error("an unknown format reported as known")
 	}
 }
+
+// The dotenv writer is reachable directly, and a caller that resolved a path
+// without carrying its format alongside can hand it a PHP settings file. Writing
+// `KEY=value` after the closing tag leaves a file that no longer parses, so the
+// site is down: refuse instead, the same way an unknown format is refused.
+func TestApplyUpdates_refusesAFileThatIsNotDotenv(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"wp-config.php", "settings.php"} {
+		path := filepath.Join(dir, name)
+		original := "<?php\ndefine( 'DB_NAME', 'blog' );\n"
+		if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		err := ApplyUpdates(path, map[string]string{"APP_KEY": "base64:abc"})
+		if err == nil {
+			t.Fatalf("%s was written as dotenv rather than refused", name)
+		}
+		if body, _ := os.ReadFile(path); string(body) != original {
+			t.Errorf("%s was modified by a refused write:\n%s", name, body)
+		}
+	}
+
+	// A real dotenv file is still written, leading blank lines and all.
+	env := filepath.Join(dir, ".env")
+	if err := os.WriteFile(env, []byte("\nAPP_ENV=local\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ApplyUpdates(env, map[string]string{"APP_KEY": "base64:abc"}); err != nil {
+		t.Fatalf("a dotenv file must still be writable: %v", err)
+	}
+	if body, _ := os.ReadFile(env); !strings.Contains(string(body), "APP_KEY=base64:abc") {
+		t.Errorf("key not written:\n%s", body)
+	}
+}

--- a/internal/sitedoctor/declared_services_test.go
+++ b/internal/sitedoctor/declared_services_test.go
@@ -32,6 +32,26 @@ func TestMissingDeclaredServices_coversWhatTheProjectPicksNotJustWhatTheFramewor
 	}
 }
 
+// A service listed in LERD_EXTERNAL_SERVICES is one the developer runs
+// themselves. lerd writes its connection vars and otherwise stays out of the
+// way, so reporting it missing is wrong twice over: the fix button would install
+// a second copy that fights the real one for its port.
+func TestDeclaredServices_leavesOutTheOnesTheUserRunsThemselves(t *testing.T) {
+	withStubs(t, map[string]bool{}, map[string]string{})
+	dir := writeProject(t, "services:\n  - postgres\n  - redis\n")
+	if err := os.WriteFile(filepath.Join(dir, ".env.lerd_override"),
+		[]byte("LERD_EXTERNAL_SERVICES=postgres\n"), 0o644); err != nil {
+		t.Fatalf("write override: %v", err)
+	}
+
+	if got := declaredServices(dir, &config.Framework{Requires: []string{"postgres"}}); strings.Join(got, ",") != "redis" {
+		t.Errorf("declared = %v, want [redis]: postgres is the user's own", got)
+	}
+	if got := MissingDeclaredServices(dir, &config.Framework{Requires: []string{"postgres"}}); strings.Join(got, ",") != "redis" {
+		t.Errorf("missing = %v, want [redis]: an external service must not be offered for install", got)
+	}
+}
+
 func TestMissingDeclaredServices_ignoresSQLiteAndInstalledServices(t *testing.T) {
 	withStubs(t, map[string]bool{"lerd-mysql": true}, map[string]string{"lerd-mysql": "active"})
 	dir := writeProject(t, "services:\n  - mysql\n  - sqlite\n")

--- a/internal/sitedoctor/sitedoctor.go
+++ b/internal/sitedoctor/sitedoctor.go
@@ -295,9 +295,17 @@ var (
 // installed it produced no finding at all.
 //
 // SQLite is excluded because it is a file the project owns rather than
-// something lerd runs.
+// something lerd runs, and so is anything the project names in
+// LERD_EXTERNAL_SERVICES: that is the developer saying they run it themselves,
+// which the wiring check and `lerd env` already respect. Reporting one of those
+// missing would offer to install a second copy alongside the real one.
 func declaredServices(path string, fw *config.Framework) []string {
 	seen := map[string]bool{"sqlite": true}
+	if _, external := envfile.ReadOverride(path); external != nil {
+		for name := range external {
+			seen[strings.ToLower(strings.TrimSpace(name))] = true
+		}
+	}
 	var out []string
 	add := func(name string) {
 		name = strings.ToLower(strings.TrimSpace(name))
@@ -550,8 +558,13 @@ func checkSQLiteDatabase(path, envPath, envFormat string, fw *config.Framework) 
 	for _, abs := range sqliteFilePaths(path, publicDirOf(fw), dbFile) {
 		info, err := os.Stat(abs)
 		switch {
-		case err != nil:
+		case os.IsNotExist(err):
 			continue // not here; the next candidate root may have it
+		case err != nil:
+			// A permission error, a flaky mount, a symlink loop: the file may be
+			// there and healthy. Saying it is missing would offer to migrate over
+			// a database this cannot even see.
+			return Check{}, false
 		case info.Size() == 0:
 			empty = true
 		default:

--- a/internal/sitedoctor/sqlite_path_test.go
+++ b/internal/sitedoctor/sqlite_path_test.go
@@ -75,3 +75,36 @@ func TestCheckSQLiteDatabase_missingFromEveryRoot(t *testing.T) {
 		t.Errorf("check = %+v (ok=%v), want a failure", c, ok)
 	}
 }
+
+// A stat that fails for a reason other than absence says nothing about whether
+// the database is there. Reading it as missing offers to run migrations over a
+// database this process merely could not look at.
+func TestCheckSQLiteDatabase_saysNothingWhenItCannotLook(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can traverse a directory with no execute bit")
+	}
+	project := t.TempDir()
+	dbDir := filepath.Join(project, "database")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dbDir, "database.sqlite"), []byte("healthy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	env := filepath.Join(project, ".env")
+	if err := os.WriteFile(env, []byte("DB_CONNECTION=sqlite\nDB_DATABASE=database/database.sqlite\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Take away the execute bit so the file cannot be stat'ed through it.
+	if err := os.Chmod(dbDir, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dbDir, 0o755) })
+
+	fw := &config.Framework{Env: config.FrameworkEnvConf{File: ".env", Services: map[string]config.FrameworkServiceDef{
+		"sqlite": {Vars: []string{"DB_CONNECTION=sqlite", "DB_DATABASE=database/database.sqlite"}},
+	}}}
+	if c, ok := checkSQLiteDatabase(project, env, "dotenv", fw); ok {
+		t.Errorf("check = %+v, want no finding: the file could not be stat'ed, which is not the same as absent", c)
+	}
+}

--- a/internal/sitedoctor/sqlite_target.go
+++ b/internal/sitedoctor/sqlite_target.go
@@ -65,10 +65,17 @@ func declaredCompanionValue(vals map[string]string, declared map[string]bool, co
 		candidates = append([]string{connKey[:i+1] + "database"}, candidates...)
 	}
 	for _, k := range candidates {
-		if declared[k] {
-			if v := strings.TrimSpace(vals[k]); v != "" {
-				return v
-			}
+		if !declared[k] {
+			continue
+		}
+		if v := strings.TrimSpace(vals[k]); v != "" {
+			return v
+		}
+		// An empty value only has a default where the convention exists. That is
+		// Laravel's, spelled DB_DATABASE; a framework that addresses its database
+		// by a dotted path has no such default, and inventing one sends the user
+		// to create a file the application will never open.
+		if k == "DB_DATABASE" {
 			return defaultFile
 		}
 	}

--- a/internal/sitedoctor/sqlite_target_test.go
+++ b/internal/sitedoctor/sqlite_target_test.go
@@ -110,3 +110,40 @@ func TestDeclaredSQLiteFile_readsDottedKeys(t *testing.T) {
 		t.Errorf("declaredSQLiteFile = %q (ok=%v), want the path in the same block", file, ok)
 	}
 }
+
+// A framework that addresses its database by a dotted path has no Laravel
+// default to fall back on. Answering with one sends the user to create a file
+// the application will never open, and offers migrations against it.
+func TestDeclaredCompanionValue_noLaravelDefaultForADottedKey(t *testing.T) {
+	drupalish := &config.Framework{
+		Name: "drupalish",
+		Env: config.FrameworkEnvConf{File: "settings.php", Services: map[string]config.FrameworkServiceDef{
+			"mysql": {
+				Detect: []config.FrameworkServiceDetect{{Key: "databases.default.default.driver", ValuePrefix: "mysql"}},
+				Vars: []string{
+					"databases.default.default.driver=mysql",
+					"databases.default.default.database={{site}}",
+				},
+			},
+		}},
+	}
+	declared := declaredEnvKeys(drupalish)
+	vals := map[string]string{
+		"databases.default.default.driver":   "sqlite",
+		"databases.default.default.database": "",
+	}
+
+	if got := declaredCompanionValue(vals, declared, "databases.default.default.driver"); got != "" {
+		t.Errorf("companion = %q, want empty: this framework has no database/database.sqlite convention", got)
+	}
+
+	// The same empty value under Laravel's own key keeps its default, which is
+	// where the convention actually comes from.
+	lara := declaredEnvKeys(&config.Framework{Env: config.FrameworkEnvConf{Services: map[string]config.FrameworkServiceDef{
+		"sqlite": {Vars: []string{"DB_CONNECTION=sqlite", "DB_DATABASE="}},
+	}}})
+	got := declaredCompanionValue(map[string]string{"DB_CONNECTION": "sqlite", "DB_DATABASE": ""}, lara, "DB_CONNECTION")
+	if got != filepath.Join("database", "database.sqlite") {
+		t.Errorf("companion = %q, want Laravel's default", got)
+	}
+}

--- a/internal/ui/web/src/lib/envDuplicates.test.ts
+++ b/internal/ui/web/src/lib/envDuplicates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { findDuplicates, keepOnly } from "./envDuplicates";
+import { findDuplicates, keepOnly, keepOnlyEach } from "./envDuplicates";
 
 describe("env duplicates", () => {
   const file = [
@@ -44,5 +44,42 @@ describe("env duplicates", () => {
     const out = keepOnly(file, "DATABASE_URL", dupes[0].occurrences[0].line);
     expect(out).toContain("postgresql://");
     expect(out).not.toContain("sqlite:///var/app.db");
+  });
+
+  // Resolving one key drops lines anywhere in the file, above the kept line as
+  // well as below it, so every line number taken from the same reading of the
+  // buffer has to be resolved against that reading. Applying them one after
+  // another renumbers the file under the choices still to come, and the file
+  // silently loses keys the user never chose to drop.
+  it("resolves several keys against the file the user was looking at", () => {
+    const many = [
+      "DB_HOST=old",
+      "DB_DATABASE=old",
+      "APP_ENV=local",
+      "DB_HOST=lerd-mysql",
+      "DB_DATABASE=acme",
+    ].join("\n");
+    const dupes = findDuplicates(many);
+    const keepLast = dupes.map((d) => ({
+      key: d.key,
+      line: d.occurrences[d.occurrences.length - 1].line,
+    }));
+
+    const out = keepOnlyEach(many, keepLast);
+    expect(out.split("\n")).toEqual(["APP_ENV=local", "DB_HOST=lerd-mysql", "DB_DATABASE=acme"]);
+    expect(findDuplicates(out)).toEqual([]);
+  });
+
+  it("resolves a mix of first and last choices in one pass", () => {
+    const many = ["A=1", "B=1", "A=2", "B=2", "A=3"].join("\n");
+    const out = keepOnlyEach(many, [
+      { key: "A", line: 0 },
+      { key: "B", line: 3 },
+    ]);
+    expect(out.split("\n")).toEqual(["A=1", "B=2"]);
+  });
+
+  it("leaves a file alone when nothing was chosen", () => {
+    expect(keepOnlyEach(file, [])).toBe(file);
   });
 });

--- a/internal/ui/web/src/lib/envDuplicates.ts
+++ b/internal/ui/web/src/lib/envDuplicates.ts
@@ -40,14 +40,25 @@ export function findDuplicates(text: string): EnvDuplicate[] {
  * and saves like any other.
  */
 export function keepOnly(text: string, key: string, keepLine: number): string {
-  const lines = text.split("\n");
-  const out = lines.filter((raw, i) => {
-    if (i === keepLine) return true;
+  return keepOnlyEach(text, [{ key, line: keepLine }]);
+}
+
+/**
+ * Resolves several keys at once against the buffer the line numbers were read
+ * from. One pass, because dropping an occurrence renumbers every line under it:
+ * resolving the keys one after another would leave the later choices pointing at
+ * lines that have moved, and the file would lose keys nobody chose to drop.
+ */
+export function keepOnlyEach(text: string, choices: { key: string; line: number }[]): string {
+  if (choices.length === 0) return text;
+  const keep = new Map(choices.map((c) => [c.key, c.line]));
+  const out = text.split("\n").filter((raw, i) => {
     const line = raw.trim();
     if (!line || line.startsWith("#")) return true;
     const eq = line.indexOf("=");
     if (eq <= 0) return true;
-    return line.slice(0, eq).trim() !== key;
+    const keepLine = keep.get(line.slice(0, eq).trim());
+    return keepLine === undefined || keepLine === i;
   });
   return out.join("\n");
 }

--- a/internal/ui/web/src/tabs/sites/SiteEnvTab.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteEnvTab.svelte
@@ -21,7 +21,7 @@
   import { status } from '$stores/status';
   import { addedLineNumbers } from '$lib/diff';
   import { homeShorten } from '$lib/path';
-  import { findDuplicates, keepOnly } from '$lib/envDuplicates';
+  import { findDuplicates, keepOnlyEach } from '$lib/envDuplicates';
   import { m } from '../../paraglide/messages.js';
 
   interface Props {
@@ -69,14 +69,12 @@
 
   // Resolving in the modal drops the other occurrences from the buffer. That
   // leaves an ordinary unsaved change the user reviews and saves with the normal
-  // button, the same way a staged missing key does. Choices are applied from the
-  // bottom up so each removal leaves the earlier line numbers valid.
+  // button, the same way a staged missing key does. Every choice carries a line
+  // number read from the same buffer, so they are resolved in one pass: removing
+  // one key's extra lines renumbers the ones below, and applying the choices one
+  // after another would drop lines the user asked to keep.
   function applyDuplicateChoices(choices: { key: string; line: number }[]) {
-    let next = text;
-    for (const c of [...choices].sort((a, b) => b.line - a.line)) {
-      next = keepOnly(next, c.key, c.line);
-    }
-    text = next;
+    text = keepOnlyEach(text, choices);
   }
 
   function reviewDuplicates() {


### PR DESCRIPTION
A review of everything merged since v1.32.0 turned up ten defects, and seven of them are the same mistake made in different places: a guard deleted alongside a refactor that made it look redundant. What they have in common on the outside is a healthy project being told it is broken, three of them with a destructive remedy attached, which is why they are worth fixing together rather than one at a time.

Resolving duplicate keys in the env editor applied the user's choices one after another, and dropping one key's extra occurrences renumbers the file under every choice still to come. A file setting two keys twice lost one of them outright, the buffer looked like the resolution that was asked for, and the site fell back to a framework default. The choices all carry line numbers read from a single buffer, so they are now resolved against that buffer in one pass.

SQLite stopped being written into .lerd.yaml, which was the point of that change, but it was also the only signal that reached lerd env. A project picking SQLite got neither its connection values nor its database file, and the first request failed on a database nothing had created. The project's own configuration answers that question now: the framework declares a sqlite wiring, its detect rules match the env file, and no database service was picked or declared external, with the old .lerd.yaml entry still honoured for projects linked before the change. Smoke testing that fix surfaced two more things in the same run, neither of them in the review: the service loop was trying to start a container for SQLite and warning that no such service exists, and the step announced the pick as coming from a .lerd.yaml the project does not have.

A database on someone else's server was attributed to whichever engine the project's .lerd.yaml happened to list, and the doctor then offered to create it on that engine and migrate it. A project moved to SQLite kept its DB_HOST, because writing env vars sets keys and never removes them, and with the driver check gone its file path was read as a schema missing from MySQL. A host lerd does not serve now resolves to nobody, the .lerd.yaml fallback is reached only for the loopback rewrite it was written for, and the default key pair is read only for a driver an engine actually serves.

Three in the doctor. It ignored LERD_EXTERNAL_SERVICES, so a service you run yourself was reported missing with a button that installs a second copy to contend with the real one for its port. It read any failed stat of a SQLite file as absence, so a database behind a directory that lost its execute bit was reported gone with migrations offered over it. And it answered an empty dotted database key with Laravel's own database/database.sqlite, a path frameworks that address their database that way never use.

The gate that stops lerd asking the store for a version it has never published answers from a cached index, which nothing in that path refreshes. The day a new major lands, every machine still holding yesterday's copy would skip the fetch and quietly serve the project the previous major's definition, with that major's PHP clamp, workers and doctor checks. The cache is evidence while it is current and stops being evidence once it is older than the window definitions themselves refresh on.

Generating an application key wrote through the dotenv writer against a path that resolves, for a PHP-configured framework, to its settings file. A bare key=value line after the closing tag is how a site goes down with a parse error, which is the failure the format guard added in this same range exists to prevent, so the key now goes through the format the definition names and the dotenv writer refuses a file that opens with a PHP tag whoever calls it. Last, site:doctor --json --fix let the fix subprocess print onto stdout ahead of the report, so nothing could parse it.

Verified against real linked sites rather than fixtures: the SQLite database file is created and its vars written, wp-config.php survives lerd env as valid PHP, an externally declared service produces no finding while the same service without the opt-out still fails with its install fix, an external host produces no finding while a genuinely missing database on a lerd engine still does, and site:doctor --json --fix emits a document that parses.
