### PR TITLE
feat(store): seed the framework store on install and scaffold from the published definition

### DIFF
--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -15,6 +15,8 @@ Lerd resolves framework definitions from multiple sources. Higher priority wins:
 
 Workers from the user overlay and project `.lerd.yaml` are merged on top of store or built-in definitions. See [Framework workers](framework-workers.md) for the worker lifecycle and how custom workers are added and managed.
 
+`lerd install` seeds the store: it pulls the index early, so detection sees the whole published catalogue rather than only the frameworks compiled into the binary, then fetches every definition the index lists. A fresh machine therefore ends up with the same definitions an established one has, and resolves any of them offline, instead of collecting them one at a time as the projects that need each one turn up. The refresh keeps any definition you already have that the store has since stopped publishing, and the watcher refreshes the index every six hours. An install that cannot reach the store keeps working on the built-ins and seeds itself on the next run.
+
 ::: warning Untrusted projects
 A `.lerd.yaml` ships inside a project, so its embedded `framework_def` is treated as untrusted, and lerd strips its host-execution surfaces when restoring it into the store: `command`-type doctor checks, `host: true` workers, the whole `commands:` list, the `nginx:` block, `requires:`, and `php.cli_ini` are dropped, because each would otherwise run on your host, rewrite your nginx config, or start containers straight from a cloned repo. Those run only for frameworks that come from the store, a built-in, or your user overlay (`~/.config/lerd/frameworks/`); a definition already installed there is never overwritten by a project's embedded copy. In-container workers, env, symlink, and combo checks are inert and still work from a project definition.
 

--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -137,10 +137,15 @@ lerd new /path/to/myapp                 # create at an absolute path
 lerd new myapp -- --no-interaction      # pass extra flags to the scaffold command
 ```
 
-`--framework` works before or after the name. A framework the store publishes
-but you have not installed yet is fetched on demand, so you can scaffold a
-project type you have never built before without an install step; only a name the
-store does not know is refused. Flags belong to lerd wherever they
+`--framework` works before or after the name. The definition comes from the
+store, so a new project starts from the currently published create command rather
+than whichever snapshot of it your lerd binary was built with, and a framework
+the store publishes but you have not installed yet is fetched on demand, so you
+can scaffold a project type you have never built before without an install step.
+A definition already on disk from the last day is taken as current and used
+without a round trip, and when the store cannot be reached lerd falls back to
+what you have installed, then to its built-in definition; only a name nothing
+knows is refused. Flags belong to lerd wherever they
 appear on the line, so anything meant for the scaffold command itself goes after
 `--`. An absolute target outside your home directory is fine: lerd creates the
 parent directory and mounts it into the PHP container before scaffolding.

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -23,6 +23,7 @@ import (
 	"github.com/geodro/lerd/internal/services"
 	"github.com/geodro/lerd/internal/shims"
 	"github.com/geodro/lerd/internal/siteops"
+	"github.com/geodro/lerd/internal/store"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/geodro/lerd/internal/tray"
 	"github.com/spf13/cobra"
@@ -352,6 +353,21 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	ok()
+
+	// 3b. Framework store index, before the vhost pass below, which resolves a
+	// definition per site. A fresh machine has no index, and the only thing that
+	// refreshes it is the long-running watcher on a six-hour cadence, so until
+	// that first tick the only frameworks lerd can detect are the two compiled
+	// into the binary. The definitions it lists are fetched later in the run, once
+	// the containers that serve them are up. Best effort: an install with no
+	// network keeps working on the built-ins and picks the index up next time.
+	step("Fetching framework store index")
+	storeIndex, indexErr := store.NewClient().RefreshIndex()
+	if indexErr != nil {
+		feedback.Warn("could not reach the framework store, framework detection uses the built-in definitions until the next refresh")
+	} else {
+		ok()
+	}
 
 	// Ask before RunParallel steals stdin. Only offer the Laravel installer
 	// when at least one PHP version is already installed — composer needs a
@@ -1068,7 +1084,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		regenerateHostWorkers()
 	}
 
-	refreshStoreFrameworks()
+	refreshStoreFrameworks(storeIndex)
 	refreshStorePresets()
 	refreshGlobalMCPSkills()
 	refreshProjectMCPSkills()

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -178,10 +178,10 @@ func runNew(target, frameworkName string, extraArgs []string) error {
 		target = filepath.Join(cwd, target)
 	}
 
-	// Look up the framework, fetching from the store if it's published but not
-	// installed here yet — starting a project you've never built is exactly when
-	// the definition won't be local.
-	fw, ok := config.GetFrameworkOrFetch(frameworkName)
+	// Look up the framework in the store, so a new project starts from the
+	// published definition rather than whichever snapshot of it this binary was
+	// built with. Falls back to the local definition when the store is unreachable.
+	fw, ok := config.GetFrameworkForScaffold(frameworkName)
 	if !ok {
 		return fmt.Errorf("unknown framework %q — run 'lerd framework list' to see available frameworks", frameworkName)
 	}

--- a/internal/cli/store_frameworks_test.go
+++ b/internal/cli/store_frameworks_test.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/store"
+)
+
+// storeFrameworkServer serves a two-framework catalogue with two majors each,
+// and records which definition paths were asked for.
+func storeFrameworkServer(t *testing.T) (*httptest.Server, *[]string) {
+	t.Helper()
+
+	const index = `{"frameworks":[
+	  {"name":"drupal","label":"Drupal","versions":["11","10"],"latest":"11","detect":[{"composer":"drupal/core"}]},
+	  {"name":"laravel","label":"Laravel","versions":["13","12"],"latest":"13","detect":[{"file":"artisan"}]}
+	]}`
+
+	var asked []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/index.json", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(index))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		name, version := filepath.Base(filepath.Dir(r.URL.Path)), filepath.Base(r.URL.Path)
+		asked = append(asked, r.URL.Path)
+		_, _ = fmt.Fprintf(w, "name: %s\nversion: %q\nlabel: %s\npublic_dir: public\n",
+			name, version[:len(version)-len(".yaml")], name)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &asked
+}
+
+func installedDefinitionNames(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(config.StoreFrameworksDir())
+	if err != nil {
+		t.Fatalf("reading store dir: %v", err)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.Name() != "index.json" {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// A just-installed machine has nothing cached, so a refresh that only revisits
+// what is already on disk fetches nothing at all and leaves the machine with the
+// built-ins alone. Every definition the catalogue publishes has to land.
+func TestRefreshStoreFrameworks_FetchesTheWholeCatalogueOnAFreshMachine(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	srv, _ := storeFrameworkServer(t)
+	t.Setenv("LERD_STORE_BASE_URL", srv.URL)
+
+	refreshStoreFrameworks(nil)
+
+	got := installedDefinitionNames(t)
+	want := []string{"drupal@10.yaml", "drupal@11.yaml", "laravel@12.yaml", "laravel@13.yaml"}
+	if len(got) != len(want) {
+		t.Fatalf("installed definitions = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("installed definitions = %v, want %v", got, want)
+		}
+	}
+}
+
+// A definition on disk that the catalogue no longer lists must still be
+// refreshed. Dropping it from the target list would strand a project whose
+// framework was unpublished on a copy that never updates again.
+func TestRefreshStoreFrameworks_KeepsRefreshingAnUnpublishedDefinition(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	if err := config.SaveStoreFramework(&config.Framework{
+		Name: "statamic", Label: "Statamic", Version: "6", PublicDir: "public",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, asked := storeFrameworkServer(t)
+	t.Setenv("LERD_STORE_BASE_URL", srv.URL)
+
+	refreshStoreFrameworks(nil)
+
+	found := false
+	for _, path := range *asked {
+		if path == "/statamic/6.yaml" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("unpublished definition was not refreshed, asked for %v", *asked)
+	}
+	if len(*asked) != 5 {
+		t.Errorf("asked for %d definitions, want the catalogue's 4 plus statamic: %v", len(*asked), *asked)
+	}
+}
+
+// The index the caller already fetched is used as given, so install does not pay
+// for a second round trip to the file it just wrote. Nothing is cached on disk
+// here, so a target list built from the cache alone would come out empty.
+func TestRefreshStoreFrameworks_UsesTheCallersIndex(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	srv, asked := storeFrameworkServer(t)
+	t.Setenv("LERD_STORE_BASE_URL", srv.URL)
+
+	refreshStoreFrameworks(&store.Index{Frameworks: []store.IndexEntry{
+		{Name: "tempest", Label: "Tempest", Versions: []string{"3"}, Latest: "3"},
+	}})
+
+	if len(*asked) != 1 || (*asked)[0] != "/tempest/3.yaml" {
+		t.Errorf("asked for %v, want just /tempest/3.yaml", *asked)
+	}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/geodro/lerd/internal/config"
@@ -190,23 +191,23 @@ func runUpdate(currentVersion string, beta bool) error {
 	return nil
 }
 
-// refreshStoreFrameworks re-fetches every cached framework yaml so users pick
-// up schema additions (per_worktree, etc.) without waiting for the 24h
-// staleness check in GetFrameworkForDir to expire.
-func refreshStoreFrameworks() {
-	dir := config.StoreFrameworksDir()
-	entries, err := os.ReadDir(dir)
+// storeFrameworkTarget is one definition to fetch: a framework name and the
+// major version of its yaml, empty for a legacy unversioned file.
+type storeFrameworkTarget struct{ name, version string }
+
+// installedStoreFrameworkTargets lists the definitions already cached on disk.
+func installedStoreFrameworkTargets() []storeFrameworkTarget {
+	entries, err := os.ReadDir(config.StoreFrameworksDir())
 	if err != nil {
-		return
+		return nil
 	}
-	type target struct{ name, version string }
-	var targets []target
+	var targets []storeFrameworkTarget
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
 			continue
 		}
 		base := strings.TrimSuffix(e.Name(), ".yaml")
-		var t target
+		var t storeFrameworkTarget
 		if at := strings.Index(base, "@"); at != -1 {
 			t.name = base[:at]
 			t.version = base[at+1:]
@@ -215,9 +216,59 @@ func refreshStoreFrameworks() {
 		}
 		targets = append(targets, t)
 	}
+	return targets
+}
+
+// publishedStoreFrameworkTargets lists every definition the store's cached index
+// publishes. A fresh machine has nothing on disk to refresh, so without this the
+// whole catalogue only arrives one definition at a time, as projects that need
+// each one turn up.
+func publishedStoreFrameworkTargets(idx *store.Index) []storeFrameworkTarget {
+	if idx == nil {
+		var err error
+		if idx, err = store.CachedIndex(); err != nil {
+			// No cache to read: this is the fresh machine the seeding is for, or a
+			// run whose earlier index fetch failed. Ask the store, so a network that
+			// has come back since still fills the catalogue on this run.
+			if idx, err = store.NewClient().RefreshIndex(); err != nil {
+				return nil
+			}
+		}
+	}
+	var targets []storeFrameworkTarget
+	for _, e := range idx.Frameworks {
+		for _, v := range e.Versions {
+			targets = append(targets, storeFrameworkTarget{name: e.Name, version: v})
+		}
+	}
+	return targets
+}
+
+// refreshStoreFrameworks fetches every definition the store publishes, plus any
+// already cached here that it no longer does, so users pick up schema additions
+// (per_worktree, etc.) without waiting for the 24h staleness check in
+// GetFrameworkForDir to expire, and a just-installed machine holds the same
+// catalogue an established one does rather than only the built-ins. idx is the
+// index the caller has already fetched; nil reads the cached copy.
+func refreshStoreFrameworks(idx *store.Index) {
+	seen := map[storeFrameworkTarget]bool{}
+	var targets []storeFrameworkTarget
+	for _, t := range append(publishedStoreFrameworkTargets(idx), installedStoreFrameworkTargets()...) {
+		if seen[t] {
+			continue
+		}
+		seen[t] = true
+		targets = append(targets, t)
+	}
 	if len(targets) == 0 {
 		return
 	}
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].name != targets[j].name {
+			return targets[i].name < targets[j].name
+		}
+		return frameworkVersionOrder(targets[i].version) < frameworkVersionOrder(targets[j].version)
+	})
 	feedback.Header(fmt.Sprintf("Refreshing %d framework%s", len(targets), pluralS(len(targets))))
 	client := store.NewClient()
 	for _, t := range targets {
@@ -237,6 +288,20 @@ func refreshStoreFrameworks() {
 		}
 		step.OK("")
 	}
+}
+
+// frameworkVersionOrder sorts a definition's major version numerically, so the
+// listing reads laravel@10 before laravel@13 rather than in string order. An
+// unversioned file has no number and sorts first, ahead of every major.
+func frameworkVersionOrder(version string) int {
+	if version == "" {
+		return -1
+	}
+	n, err := strconv.Atoi(version)
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 // refreshStorePresets re-fetches the store preset backing every installed

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -959,22 +959,40 @@ func GetFramework(name string) (*Framework, bool) {
 	return mergeBuiltinTinker(mergeBuiltinFrankenPHP(mergeUserOverlay(base))), true
 }
 
-// GetFrameworkOrFetch is like GetFramework but, when the framework is not
-// installed locally, fetches its latest definition from the store and saves it,
-// the way linking pulls a definition for a project whose framework isn't
-// installed yet. It returns false only when the store doesn't publish the name
-// either. Scaffolding a project you've never built before lands here.
-func GetFrameworkOrFetch(name string) (*Framework, bool) {
-	if fw, ok := GetFramework(name); ok {
-		return fw, true
-	}
-	if frameworkFetchHook == nil {
+// GetFrameworkForScaffold returns the definition to scaffold a new project with.
+// Unlike GetFramework it asks the store first, even for a name that is built in:
+// the create command compiled into the binary is a snapshot of a published one,
+// so a just-installed machine would otherwise scaffold from a definition every
+// established install has already replaced. A copy installed here inside the
+// store's refresh window counts as current, so a repeat scaffold and an offline
+// one don't wait on the network. Falls back to what is installed, then to the
+// built-in, and reports false only when nothing knows the name.
+func GetFrameworkForScaffold(name string) (*Framework, bool) {
+	if name == "" {
 		return nil, false
 	}
-	if _, err := frameworkFetchHook(name, ""); err != nil {
-		return nil, false
+
+	installed := storeFrameworkPath(name)
+	var base *Framework
+	if installed != "" && !olderThan(installed, storeRefreshWindow) {
+		base = loadFrameworkYAML(installed)
 	}
-	return GetFramework(name)
+	if base == nil && frameworkFetchHook != nil {
+		if fetched, err := frameworkFetchHook(name, ""); err == nil {
+			base = fetched
+		}
+	}
+	if base == nil && installed != "" {
+		base = loadFrameworkYAML(installed)
+	}
+	// A definition that cannot scaffold is no reason to lose one that can. The
+	// store owns the create command and is free to publish a framework without
+	// one, and that reaches every binary within the day, with nothing gating it
+	// per version. So a name whose built-in can still scaffold keeps it.
+	if base == nil || (base.Create == "" && builtinFramework(name) != nil) {
+		return GetFramework(name)
+	}
+	return mergeBuiltinTinker(mergeBuiltinFrankenPHP(mergeUserOverlay(base))), true
 }
 
 // loadBaseFramework returns the base definition for a framework:
@@ -990,6 +1008,20 @@ func loadBaseFramework(name string) *Framework {
 		return fw
 	}
 	return loadBestVersionedFramework(name, "")
+}
+
+// storeFrameworkPath returns the path of the store-installed definition for a
+// framework: the unversioned file if it exists (backwards compatible), otherwise
+// the highest version installed. Empty when the store has installed none.
+func storeFrameworkPath(name string) string {
+	unversioned := filepath.Join(StoreFrameworksDir(), name+".yaml")
+	if _, err := os.Stat(unversioned); err == nil {
+		return unversioned
+	}
+	if paths := versionedFrameworkPaths(name); len(paths) > 0 {
+		return paths[0]
+	}
+	return ""
 }
 
 // copyBuiltin returns a deep-enough copy of a built-in framework so callers
@@ -1141,9 +1173,7 @@ func GetFrameworkForDir(name, projectDir string) (*Framework, bool) {
 	if version != "" && frameworkFetchHook != nil && frameworkVersionPublished(name, version) {
 		shouldFetch := base == nil
 		if !shouldFetch && versionedPath != "" {
-			if info, err := os.Stat(versionedPath); err == nil {
-				shouldFetch = time.Since(info.ModTime()) > 24*time.Hour
-			}
+			shouldFetch = olderThan(versionedPath, storeRefreshWindow)
 		}
 		if shouldFetch {
 			if fetched, err := frameworkFetchHook(name, version); err == nil && fetched != nil {
@@ -1418,15 +1448,26 @@ func frameworkVersionPublished(name, version string) bool {
 	return staleStoreIndex()
 }
 
+// storeRefreshWindow is how long a copy of store data stays current. Younger
+// than this, what is on disk is taken as what the store publishes; older, it is
+// re-fetched and what it does not say proves nothing.
+const storeRefreshWindow = 24 * time.Hour
+
 // staleStoreIndex reports whether the cached store index is older than the
 // window definitions themselves are refreshed on, i.e. old enough that what it
 // does not list proves nothing.
 func staleStoreIndex() bool {
-	info, err := os.Stat(StoreIndexFile())
+	return olderThan(StoreIndexFile(), storeRefreshWindow)
+}
+
+// olderThan reports whether a file was last written further back than d. A file
+// that cannot be stat'ed counts as older, so the caller re-fetches it.
+func olderThan(path string, d time.Duration) bool {
+	info, err := os.Stat(path)
 	if err != nil {
 		return true
 	}
-	return time.Since(info.ModTime()) > 24*time.Hour
+	return time.Since(info.ModTime()) > d
 }
 
 // latestPublishedFrameworkVersion returns the newest version the cached index
@@ -1470,23 +1511,31 @@ func clampFrameworkVersion(name, detected string) string {
 	return ""
 }
 
-// loadBestVersionedFramework scans StoreFrameworksDir for <name>@<version>.yaml files.
-// If preferVersion is set, it tries that first. Otherwise picks the first match
-// alphabetically (which for numeric versions gives the latest).
+// versionedFrameworkPaths returns the store's <name>@<version>.yaml paths for a
+// framework, highest version first. The order is numeric on purpose: sorting the
+// file names as strings ranks @9 above @12, which hands a caller asking for the
+// newest definition the older one on any machine holding both.
+func versionedFrameworkPaths(name string) []string {
+	matches, _ := filepath.Glob(filepath.Join(StoreFrameworksDir(), name+"@*.yaml"))
+	prefix := name + "@"
+	version := func(path string) int {
+		n, _ := strconv.Atoi(strings.TrimPrefix(strings.TrimSuffix(filepath.Base(path), ".yaml"), prefix))
+		return n
+	}
+	sort.SliceStable(matches, func(i, j int) bool { return version(matches[i]) > version(matches[j]) })
+	return matches
+}
+
+// loadBestVersionedFramework scans StoreFrameworksDir for <name>@<version>.yaml
+// files. If preferVersion is set, it tries that first. Otherwise it takes the
+// highest version that parses.
 func loadBestVersionedFramework(name, preferVersion string) *Framework {
 	if preferVersion != "" {
 		if fw := loadFrameworkYAML(filepath.Join(StoreFrameworksDir(), name+"@"+preferVersion+".yaml")); fw != nil {
 			return fw
 		}
 	}
-	pattern := filepath.Join(StoreFrameworksDir(), name+"@*.yaml")
-	matches, _ := filepath.Glob(pattern)
-	if len(matches) == 0 {
-		return nil
-	}
-	// Reverse sort so highest version comes first (e.g. @7 before @6).
-	sort.Sort(sort.Reverse(sort.StringSlice(matches)))
-	for _, path := range matches {
+	for _, path := range versionedFrameworkPaths(name) {
 		if fw := loadFrameworkYAML(path); fw != nil {
 			return fw
 		}

--- a/internal/config/framework_test.go
+++ b/internal/config/framework_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -176,12 +177,27 @@ func TestGetFrameworkCustom_WithoutLogs(t *testing.T) {
 	}
 }
 
-// ── GetFrameworkOrFetch ──────────────────────────────────────────────────────
+// ── GetFrameworkForScaffold ──────────────────────────────────────────────────
+
+// installStoreFrameworkAged installs a store definition and back-dates it, so a
+// test can place one either inside or outside the store's refresh window.
+func installStoreFrameworkAged(t *testing.T, fw *Framework, age time.Duration) {
+	t.Helper()
+	installStoreFramework(t, fw)
+	path := filepath.Join(StoreFrameworksDir(), fw.Name+".yaml")
+	if fw.Version != "" {
+		path = filepath.Join(StoreFrameworksDir(), fw.Name+"@"+fw.Version+".yaml")
+	}
+	when := time.Now().Add(-age)
+	if err := os.Chtimes(path, when, when); err != nil {
+		t.Fatalf("Chtimes(%s): %v", path, err)
+	}
+}
 
 // A framework the store publishes but the machine hasn't installed must be
 // fetched on demand, so `lerd new --framework=X` can scaffold a project type
 // you've never built before.
-func TestGetFrameworkOrFetch_FetchesUninstalled(t *testing.T) {
+func TestGetFrameworkForScaffold_FetchesUninstalled(t *testing.T) {
 	setConfigDir(t)
 
 	prev := frameworkFetchHook
@@ -197,9 +213,9 @@ func TestGetFrameworkOrFetch_FetchesUninstalled(t *testing.T) {
 		return fw, nil
 	}
 
-	got, ok := GetFrameworkOrFetch("codeigniter")
+	got, ok := GetFrameworkForScaffold("codeigniter")
 	if !ok {
-		t.Fatal("GetFrameworkOrFetch(codeigniter): not found after fetch")
+		t.Fatal("GetFrameworkForScaffold(codeigniter): not found after fetch")
 	}
 	if got.Label != "CodeIgniter" {
 		t.Errorf("Label = %q, want CodeIgniter", got.Label)
@@ -209,24 +225,61 @@ func TestGetFrameworkOrFetch_FetchesUninstalled(t *testing.T) {
 	}
 }
 
-// An installed framework resolves locally and must never reach for the store.
-func TestGetFrameworkOrFetch_SkipsFetchWhenInstalled(t *testing.T) {
+// A built-in name must still go to the store: the create command in the binary
+// is a snapshot, and scaffolding on a fresh install has to use the published one.
+func TestGetFrameworkForScaffold_PrefersStoreOverBuiltin(t *testing.T) {
+	setConfigDir(t)
+
+	prev := frameworkFetchHook
+	t.Cleanup(func() { frameworkFetchHook = prev })
+
+	const published = "composer create-project laravel/laravel --published"
+	frameworkFetchHook = func(name, version string) (*Framework, error) {
+		fw := &Framework{Name: name, Label: "Laravel", Version: "12", PublicDir: "public", Create: published}
+		if err := SaveStoreFramework(fw); err != nil {
+			return nil, err
+		}
+		return fw, nil
+	}
+
+	got, ok := GetFrameworkForScaffold("laravel")
+	if !ok {
+		t.Fatal("GetFrameworkForScaffold(laravel): not found")
+	}
+	if got.Create != published {
+		t.Errorf("Create = %q, want the store's %q", got.Create, published)
+	}
+}
+
+// A published definition with no create command must not cost a built-in name
+// the one it has. Store data reaches every binary within the day and nothing
+// gates it per version, so `lerd new laravel` has to keep working through a
+// definition that drops the field or renames it.
+func TestGetFrameworkForScaffold_BuiltinSurvivesADefinitionThatCannotScaffold(t *testing.T) {
 	setConfigDir(t)
 
 	prev := frameworkFetchHook
 	t.Cleanup(func() { frameworkFetchHook = prev })
 	frameworkFetchHook = func(name, version string) (*Framework, error) {
-		t.Fatalf("fetch hook called for an installed framework (%q)", name)
-		return nil, nil
+		fw := &Framework{Name: name, Label: "Laravel", Version: "13", PublicDir: "public"}
+		if err := SaveStoreFramework(fw); err != nil {
+			return nil, err
+		}
+		return fw, nil
 	}
 
-	if _, ok := GetFrameworkOrFetch("laravel"); !ok {
-		t.Fatal("GetFrameworkOrFetch(laravel): built-in not found")
+	got, ok := GetFrameworkForScaffold("laravel")
+	if !ok {
+		t.Fatal("GetFrameworkForScaffold(laravel): not found")
+	}
+	if got.Create != laravelFramework.Create {
+		t.Errorf("Create = %q, want the built-in %q", got.Create, laravelFramework.Create)
 	}
 }
 
-// A name the store doesn't publish keeps the original not-found result.
-func TestGetFrameworkOrFetch_UnknownStaysNotFound(t *testing.T) {
+// An unreachable store leaves the built-in as the scaffold definition, so
+// `lerd new` still works offline.
+func TestGetFrameworkForScaffold_FallsBackToBuiltin(t *testing.T) {
 	setConfigDir(t)
 
 	prev := frameworkFetchHook
@@ -235,8 +288,113 @@ func TestGetFrameworkOrFetch_UnknownStaysNotFound(t *testing.T) {
 		return nil, os.ErrNotExist
 	}
 
-	if _, ok := GetFrameworkOrFetch("nonexistent"); ok {
-		t.Error("GetFrameworkOrFetch(nonexistent) = true, want false")
+	got, ok := GetFrameworkForScaffold("laravel")
+	if !ok {
+		t.Fatal("GetFrameworkForScaffold(laravel): built-in not found")
+	}
+	if got.Create != laravelFramework.Create {
+		t.Errorf("Create = %q, want the built-in %q", got.Create, laravelFramework.Create)
+	}
+}
+
+// A definition installed inside the refresh window is already current, so a
+// repeat scaffold must not spend a store round trip on it.
+func TestGetFrameworkForScaffold_SkipsFetchWhenFresh(t *testing.T) {
+	setConfigDir(t)
+
+	installStoreFrameworkAged(t, &Framework{
+		Name: "laravel", Label: "Laravel", Version: "12", PublicDir: "public",
+		Create: "composer create-project laravel/laravel --fresh",
+	}, time.Minute)
+
+	prev := frameworkFetchHook
+	t.Cleanup(func() { frameworkFetchHook = prev })
+	frameworkFetchHook = func(name, version string) (*Framework, error) {
+		t.Fatalf("fetch hook called for a fresh definition (%q)", name)
+		return nil, nil
+	}
+
+	got, ok := GetFrameworkForScaffold("laravel")
+	if !ok {
+		t.Fatal("GetFrameworkForScaffold(laravel): not found")
+	}
+	if got.Create != "composer create-project laravel/laravel --fresh" {
+		t.Errorf("Create = %q, want the installed definition's", got.Create)
+	}
+}
+
+// A stale definition is re-fetched, and when the store cannot be reached the
+// stale copy still beats the built-in: it is the newer of the two.
+func TestGetFrameworkForScaffold_KeepsStaleWhenStoreUnreachable(t *testing.T) {
+	setConfigDir(t)
+
+	installStoreFrameworkAged(t, &Framework{
+		Name: "laravel", Label: "Laravel", Version: "12", PublicDir: "public",
+		Create: "composer create-project laravel/laravel --stale",
+	}, 48*time.Hour)
+
+	prev := frameworkFetchHook
+	t.Cleanup(func() { frameworkFetchHook = prev })
+	fetched := false
+	frameworkFetchHook = func(name, version string) (*Framework, error) {
+		fetched = true
+		return nil, os.ErrNotExist
+	}
+
+	got, ok := GetFrameworkForScaffold("laravel")
+	if !ok {
+		t.Fatal("GetFrameworkForScaffold(laravel): not found")
+	}
+	if !fetched {
+		t.Error("stale definition was not re-fetched")
+	}
+	if got.Create != "composer create-project laravel/laravel --stale" {
+		t.Errorf("Create = %q, want the installed definition's", got.Create)
+	}
+}
+
+// With several versions installed, the newest one scaffolds. Version numbers are
+// compared as numbers: as strings, @9 sorts above @12.
+func TestGetFrameworkForScaffold_PrefersHighestInstalledVersion(t *testing.T) {
+	setConfigDir(t)
+
+	installStoreFrameworkAged(t, &Framework{
+		Name: "laravel", Label: "Laravel", Version: "9", PublicDir: "public",
+		Create: "composer create-project laravel/laravel --nine",
+	}, time.Minute)
+	installStoreFrameworkAged(t, &Framework{
+		Name: "laravel", Label: "Laravel", Version: "12", PublicDir: "public",
+		Create: "composer create-project laravel/laravel --twelve",
+	}, time.Minute)
+
+	prev := frameworkFetchHook
+	t.Cleanup(func() { frameworkFetchHook = prev })
+	frameworkFetchHook = func(name, version string) (*Framework, error) {
+		t.Fatalf("fetch hook called for a fresh definition (%q)", name)
+		return nil, nil
+	}
+
+	got, ok := GetFrameworkForScaffold("laravel")
+	if !ok {
+		t.Fatal("GetFrameworkForScaffold(laravel): not found")
+	}
+	if got.Create != "composer create-project laravel/laravel --twelve" {
+		t.Errorf("Create = %q, want Laravel 12's", got.Create)
+	}
+}
+
+// A name the store doesn't publish keeps the original not-found result.
+func TestGetFrameworkForScaffold_UnknownStaysNotFound(t *testing.T) {
+	setConfigDir(t)
+
+	prev := frameworkFetchHook
+	t.Cleanup(func() { frameworkFetchHook = prev })
+	frameworkFetchHook = func(name, version string) (*Framework, error) {
+		return nil, os.ErrNotExist
+	}
+
+	if _, ok := GetFrameworkForScaffold("nonexistent"); ok {
+		t.Error("GetFrameworkForScaffold(nonexistent) = true, want false")
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3747,7 +3747,7 @@ func execProjectNew(args map[string]any) (any, *rpcError) {
 	}
 	extraArgs := strSliceArg(args, "args")
 
-	fw, ok := config.GetFrameworkOrFetch(frameworkName)
+	fw, ok := config.GetFrameworkForScaffold(frameworkName)
 	if !ok {
 		return toolErr(fmt.Sprintf("unknown framework %q — use framework_list to see available frameworks", frameworkName)), nil
 	}

--- a/internal/store/main_test.go
+++ b/internal/store/main_test.go
@@ -1,0 +1,25 @@
+package store
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain points the XDG roots at a throwaway directory for the whole package,
+// so no test can write the developer's real framework store. Fetching is the
+// business of this package and several of its entry points cache what they pull,
+// including ones that only read: resolving a latest version refreshes the index.
+// A test that forgets to isolate would otherwise overwrite a real catalogue with
+// a two-framework fixture, which the tests themselves cannot notice. Tests that
+// want their own directory still set these with t.Setenv.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "lerd-store-tests")
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("XDG_DATA_HOME", tmp)   //nolint:errcheck
+	os.Setenv("XDG_CONFIG_HOME", tmp) //nolint:errcheck
+	code := m.Run()
+	os.RemoveAll(tmp) //nolint:errcheck
+	os.Exit(code)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -120,6 +120,12 @@ func WatchIndex(interval time.Duration) {
 	}
 }
 
+// CachedIndex reads the locally cached store index without touching the network,
+// for callers that need the published catalogue and have not just fetched it.
+func CachedIndex() (*Index, error) {
+	return loadCachedIndex()
+}
+
 // loadCachedIndex reads and parses the locally cached store index.
 func loadCachedIndex() (*Index, error) {
 	data, err := os.ReadFile(config.StoreIndexFile())
@@ -139,16 +145,30 @@ func loadCachedIndex() (*Index, error) {
 // fixed one lets two concurrent fetches truncate and fill the same temp, and the
 // rename then publishes their blend. Best effort: a cache we cannot write just
 // means the next read falls back to the network.
+// An unchanged index is still touched, because its mtime is what tells the
+// readers whether the cache still speaks for the store: skipping the touch ages
+// a catalogue that is refreshing perfectly well past the point where a version
+// missing from it counts as evidence, and every resolver starts asking for
+// versions the store does not publish again.
 func writeCachedIndex(data []byte) {
-	_, _ = atomicfile.WriteIfChanged(config.StoreIndexFile(), data, 0o644)
+	path := config.StoreIndexFile()
+	wrote, err := atomicfile.WriteIfChanged(path, data, 0o644)
+	if err != nil || wrote {
+		return
+	}
+	now := time.Now()
+	_ = os.Chtimes(path, now, now)
 }
 
 // FetchFramework downloads a framework definition from the store.
 // Always fetches from remote to ensure definitions are up to date.
 func (c *Client) FetchFramework(name, version string) (*config.Framework, error) {
 	if version == "" {
-		// Resolve latest from index
-		idx, err := c.FetchIndex()
+		// Resolve latest from the index, and keep the copy this pulls: the fetch
+		// that resolves a latest version is the one a machine with no cached index
+		// makes, and dropping it leaves offline detection blind until the watcher's
+		// first refresh hours later.
+		idx, err := c.RefreshIndex()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/store/store_index_cache_test.go
+++ b/internal/store/store_index_cache_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
 )
@@ -29,5 +30,57 @@ func TestRefreshIndex_CachesToDisk(t *testing.T) {
 	}
 	if len(idx.Frameworks) != 2 || idx.Frameworks[1].Name != "symfony" {
 		t.Fatalf("unexpected cached index: %+v", idx)
+	}
+}
+
+// A refresh that finds the catalogue unchanged still has to move the cache's
+// mtime forward. That mtime is how the resolvers decide whether what the index
+// does not list counts as evidence, and a store that publishes nothing new for a
+// day would otherwise look like a store nobody has reached in one.
+func TestRefreshIndex_TouchesAnUnchangedCache(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	if _, err := c.RefreshIndex(); err != nil {
+		t.Fatalf("RefreshIndex: %v", err)
+	}
+	backdated := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(config.StoreIndexFile(), backdated, backdated); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	if _, err := c.RefreshIndex(); err != nil {
+		t.Fatalf("RefreshIndex (second): %v", err)
+	}
+	info, err := os.Stat(config.StoreIndexFile())
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if time.Since(info.ModTime()) > time.Minute {
+		t.Errorf("cached index still dated %v, want it touched by the refresh", info.ModTime())
+	}
+}
+
+// Fetching a framework without naming a version reads the index to resolve the
+// latest, and that copy has to be kept. It is the fetch a machine that has never
+// reached the store makes, and throwing the index away there leaves detection
+// seeing only the built-ins until the watcher's first refresh.
+func TestFetchFramework_LatestCachesTheIndex(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	srv := testServer(t)
+	defer srv.Close()
+	c := testClient(t, srv)
+
+	if _, err := c.FetchFramework("laravel", ""); err != nil {
+		t.Fatalf("FetchFramework(laravel, latest): %v", err)
+	}
+	idx, err := loadCachedIndex()
+	if err != nil {
+		t.Fatalf("loadCachedIndex: %v", err)
+	}
+	if len(idx.Frameworks) != 2 {
+		t.Fatalf("cached index has %d frameworks, want 2", len(idx.Frameworks))
 	}
 }


### PR DESCRIPTION
A fresh install had no framework store on disk. Nothing seeded it, and the cached index only appeared once the long running watcher reached its first refresh, so until then the only definitions lerd could resolve were the two compiled into the binary and detection was narrower than it would be a few minutes later. Install now pulls the index early, before the vhost pass that resolves a definition per site, and then fetches every definition the index publishes, so a new machine holds the catalogue an established one does rather than collecting it one project at a time.

The refresh that already ran at the end of install built its target list by reading the store directory, which meant it could only revisit definitions that were already there and did nothing at all on a machine that had none. It now targets everything the index publishes as well, and keeps refreshing a definition the store has since stopped publishing rather than leaving a project on a copy that never updates again.

lerd new resolved its definition through a lookup that returned the built-in immediately for laravel and symfony, so scaffolding a new project used the create command baked into the binary rather than the one the store publishes today. It now asks the store first even for those names, takes a definition installed inside the refresh window as current so a repeat or an offline scaffold does not wait on the network, and falls back to what is installed and then to the built-in. Store data reaches every binary within the day with nothing gating it per version, so a published definition carrying no create command no longer costs a built-in name the one it has.

Two things this leans on were wrong. Definition files were ranked by sorting their names as strings, which puts laravel@9 above laravel@12 and hands the newest definition to nobody, and the index cache was left untouched when a refresh found the catalogue unchanged, so a store that published nothing new for a day looked like a store nobody had reached in one.

Closes #1345
