### PR TITLE
feat(cli): make lerd new a wizard and fix the config files the frameworks it offers actually read

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -43,8 +43,9 @@
 
 | Command | Description |
 |---|---|
-| `lerd new <name-or-path>` | Scaffold a new PHP project using the framework's create command (default: Laravel) |
-| `lerd new <name> --framework=<name>` | Scaffold using a specific framework |
+| `lerd new` | Ask for the project name, framework and version, then scaffold, link and set it up |
+| `lerd new <name-or-path>` | Ask which framework to scaffold, then take the project through link and setup |
+| `lerd new <name> --framework=<name>` | Scaffold a specific framework, skipping the question |
 | `lerd new <name> -- <extra args>` | Pass extra args to the scaffold command |
 
 ## Project setup

--- a/docs/usage/frameworks.md
+++ b/docs/usage/frameworks.md
@@ -131,11 +131,28 @@ The installer walks you through starter kit selection, database setup, and other
 
 
 ```bash
-lerd new myapp                          # create using Laravel (default)
-lerd new myapp --framework=symfony      # create using Symfony's create command
+lerd new                                # ask for the name, the framework and the version
+lerd new myapp                          # ask which framework to use
+lerd new myapp --framework=symfony      # scaffold Symfony, no questions
 lerd new /path/to/myapp                 # create at an absolute path
 lerd new myapp -- --no-interaction      # pass extra flags to the scaffold command
 ```
+
+On a terminal it asks which framework to scaffold rather than assuming one,
+offering the catalogue [`lerd framework list`](#lerd-framework-list) shows, which
+your install seeds from the store. When the framework you pick has more than one
+major published it asks which, defaulting to the current release and pulling that
+major's definition before scaffolding. Called with no name at all it asks for
+that too. Naming a framework with `--framework` skips the question, and a run
+with no terminal skips all of them and scaffolds the default, so scripts and CI
+never start blocking on a prompt.
+
+The command then carries the project the rest of the way: it links the new
+directory, which routes a project with no `.lerd.yaml` through the
+[init wizard](/usage/sites) for PHP version, HTTPS and services, and offers setup
+at the end. What it cannot do is move your own shell, so it closes by telling you
+to `cd` into the project. A run with no terminal stops after scaffolding and
+prints the `lerd link && lerd setup` hint as before.
 
 `--framework` works before or after the name. The definition comes from the
 store, so a new project starts from the currently published create command rather
@@ -162,7 +179,12 @@ framework whose current release tops out below your default PHP is scaffolded on
 a version inside that range instead, and composer resolves against a PHP the
 framework actually supports rather than rejecting every candidate.
 
-After creation:
+After creation, move into the project:
+```bash
+cd myapp
+```
+
+A run with no terminal did not link or set the project up, so finish it by hand:
 ```bash
 cd myapp
 lerd link

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -27,46 +27,65 @@ func NewNewCmd() *cobra.Command {
 	var frameworkName string
 
 	cmd := &cobra.Command{
-		Use:   "new <name-or-path>",
-		Short: "Scaffold a new PHP project",
+		Use:   "new [name-or-path]",
+		Short: "Scaffold a new PHP project and take it through link and setup",
 		Long: `Create a new PHP project using the framework's scaffold command.
 
-  lerd new myapp                          # create ./myapp using Laravel (default)
-  lerd new myapp --framework=symfony      # create ./myapp using Symfony
+On a terminal this asks which framework to use, offering what the store
+publishes and which major to scaffold, then carries the project through link
+and setup so it ends up served. Name a framework and that question is skipped;
+run without a terminal and the questions are too, so scripts keep working.
+
+  lerd new                                # ask for the name, framework and version
+  lerd new myapp                          # ask which framework to use
+  lerd new myapp --framework=symfony      # scaffold Symfony, no questions
   lerd new /path/to/myapp                 # create at an absolute path
   lerd new myapp -- --no-interaction      # pass extra args to the scaffold command
 
 Flags anywhere on the line belong to lerd; everything after '--' is handed to
 the scaffold command untouched.
 
-For Laravel this runs:
-  composer create-project --no-install --no-plugins --no-scripts laravel/laravel <target> [extra args]
-
-Other frameworks must define a 'create' field in their YAML definition:
-  create: composer create-project myvendor/myframework
-
-After creation, register the site with:
-  cd <target>
-  lerd link
-  lerd setup`,
-		Args:                  cobra.MinimumNArgs(1),
+Every framework's scaffold command comes from its YAML definition:
+  create: composer create-project myvendor/myframework`,
+		Args:                  cobra.ArbitraryArgs,
 		DisableFlagsInUseLine: true,
 		SilenceUsage:          true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			target := args[0]
-			extraArgs := args[1:]
+			target, extraArgs := newArgs(args, cmd.ArgsLenAtDash())
 			return runNew(target, frameworkName, extraArgs)
 		},
 	}
 
-	cmd.Flags().StringVar(&frameworkName, "framework", "laravel", "Framework to use")
+	cmd.Flags().StringVar(&frameworkName, "framework", "",
+		"Framework to scaffold; asked on a terminal when omitted, "+defaultScaffoldFramework+" otherwise")
 
 	return cmd
 }
 
+// newArgs splits the command line into the target and the arguments to hand the
+// scaffold command. dash is cobra's ArgsLenAtDash: the count of arguments before
+// a literal `--`, or -1 when there was none. It is what tells `lerd new -- --x`,
+// which names no project, from `lerd new myapp -- --x`, which names one, since
+// both arrive as a plain list.
+func newArgs(args []string, dash int) (string, []string) {
+	if dash == 0 {
+		return "", args
+	}
+	if len(args) == 0 {
+		return "", nil
+	}
+	return args[0], args[1:]
+}
+
 // newNextStep builds the post-scaffold hint, preserving the path the user
-// typed (filepath.Base would drop the parent dirs of a nested target).
-func newNextStep(typedTarget string) string {
+// typed (filepath.Base would drop the parent dirs of a nested target). A run
+// that already carried the project through link and setup has nothing left to
+// suggest but the one thing the command cannot do, which is move the user's own
+// shell into the new directory.
+func newNextStep(typedTarget string, chained bool) string {
+	if chained {
+		return "cd " + typedTarget
+	}
 	return "cd " + typedTarget + " && lerd link && lerd setup"
 }
 
@@ -166,6 +185,33 @@ func runScaffold(plan scaffold, workDir, version string) error {
 }
 
 func runNew(target, frameworkName string, extraArgs []string) error {
+	interactive := isInteractive()
+	frameworkVersion := ""
+
+	// Ask for what the command was not told. A terminal gets the catalogue and
+	// the majors published for whatever it picks; anything else keeps the
+	// long-standing default so a script never starts blocking on a prompt.
+	if target == "" {
+		if !interactive {
+			return fmt.Errorf("give the project a name: lerd new <name-or-path>")
+		}
+		answer, err := askProjectName()
+		if err != nil {
+			return err
+		}
+		target = answer
+	}
+	if newShouldAskFramework(interactive, frameworkName != "") {
+		name, version, err := askScaffoldFramework(scaffoldCatalogue())
+		if err != nil {
+			return err
+		}
+		frameworkName, frameworkVersion = name, version
+	}
+	if frameworkName == "" {
+		frameworkName = defaultScaffoldFramework
+	}
+
 	// Preserve the path as typed for the "Next" hint before resolving it.
 	typedTarget := target
 
@@ -181,7 +227,7 @@ func runNew(target, frameworkName string, extraArgs []string) error {
 	// Look up the framework in the store, so a new project starts from the
 	// published definition rather than whichever snapshot of it this binary was
 	// built with. Falls back to the local definition when the store is unreachable.
-	fw, ok := config.GetFrameworkForScaffold(frameworkName)
+	fw, ok := config.GetFrameworkForScaffold(frameworkName, frameworkVersion)
 	if !ok {
 		return fmt.Errorf("unknown framework %q — run 'lerd framework list' to see available frameworks", frameworkName)
 	}
@@ -214,9 +260,39 @@ func runNew(target, frameworkName string, extraArgs []string) error {
 	}
 
 	feedback.Success("created "+filepath.Base(target), time.Since(start))
+
+	// Take the project the rest of the way. The link routes a project with no
+	// .lerd.yaml through the init wizard (PHP version, HTTPS, services) and
+	// offers setup at the end, so scaffolding lands on a served site rather than
+	// three commands the user has to know about.
+	chained := false
+	if interactive {
+		chained = true
+		if err := inDir(target, func() error { return runLinkOrInit(nil) }); err != nil {
+			feedback.Warn("link: %v", err)
+		}
+	}
+
 	feedback.NewSummary().
 		Row("Path", target).
-		Row("Next", newNextStep(typedTarget)).
+		Row("Next", newNextStep(typedTarget, chained)).
 		Print()
 	return nil
+}
+
+// inDir runs fn with the process working directory moved to dir, restoring it
+// afterwards. The chained steps each resolve the project from os.Getwd, and this
+// is the one caller that has to point them somewhere other than where the user
+// ran the command, so it moves once here rather than threading a directory
+// through link, init and setup.
+func inDir(dir string, fn func() error) error {
+	prev, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if err := os.Chdir(dir); err != nil {
+		return err
+	}
+	defer func() { _ = os.Chdir(prev) }()
+	return fn()
 }

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -15,16 +15,48 @@ import (
 // base name breaks for nested targets (lerd new apps/myapp → cd myapp).
 func TestNewNextStep(t *testing.T) {
 	cases := []struct {
-		target string
-		want   string
+		target  string
+		chained bool
+		want    string
 	}{
-		{"myapp", "cd myapp && lerd link && lerd setup"},
-		{"apps/myapp", "cd apps/myapp && lerd link && lerd setup"},
-		{"/abs/path/myapp", "cd /abs/path/myapp && lerd link && lerd setup"},
+		{"myapp", false, "cd myapp && lerd link && lerd setup"},
+		{"apps/myapp", false, "cd apps/myapp && lerd link && lerd setup"},
+		{"/abs/path/myapp", false, "cd /abs/path/myapp && lerd link && lerd setup"},
+		// A run that linked and set the project up itself has nothing left to
+		// suggest but the move it cannot make on the user's behalf.
+		{"myapp", true, "cd myapp"},
+		{"apps/myapp", true, "cd apps/myapp"},
 	}
 	for _, tc := range cases {
-		if got := newNextStep(tc.target); got != tc.want {
-			t.Errorf("newNextStep(%q) = %q, want %q", tc.target, got, tc.want)
+		if got := newNextStep(tc.target, tc.chained); got != tc.want {
+			t.Errorf("newNextStep(%q, %v) = %q, want %q", tc.target, tc.chained, got, tc.want)
+		}
+	}
+}
+
+// `lerd new` with no name at all has to reach the wizard rather than index a
+// positional that isn't there, and `lerd new -- --flag` names no project either:
+// both arrive as a bare list, so only the dash position tells them apart.
+func TestNewArgs(t *testing.T) {
+	cases := []struct {
+		name       string
+		args       []string
+		dash       int
+		wantTarget string
+		wantExtra  []string
+	}{
+		{"no arguments", nil, -1, "", nil},
+		{"target only", []string{"myapp"}, -1, "myapp", []string{}},
+		{"target and extras", []string{"myapp", "--dev"}, 1, "myapp", []string{"--dev"}},
+		{"extras with no target", []string{"--dev"}, 0, "", []string{"--dev"}},
+	}
+	for _, tc := range cases {
+		target, extra := newArgs(tc.args, tc.dash)
+		if target != tc.wantTarget {
+			t.Errorf("%s: target = %q, want %q", tc.name, target, tc.wantTarget)
+		}
+		if len(extra) != len(tc.wantExtra) {
+			t.Errorf("%s: extra = %v, want %v", tc.name, extra, tc.wantExtra)
 		}
 	}
 }
@@ -35,8 +67,7 @@ func runNewCmd(t *testing.T, args ...string) (target, framework string, extra []
 	t.Helper()
 	cmd := NewNewCmd()
 	cmd.RunE = func(c *cobra.Command, positional []string) error {
-		target = positional[0]
-		extra = positional[1:]
+		target, extra = newArgs(positional, c.ArgsLenAtDash())
 		framework, _ = c.Flags().GetString("framework")
 		return nil
 	}
@@ -84,8 +115,10 @@ func TestNewCmdForwardsArgsAfterDash(t *testing.T) {
 	if target != "myapp" {
 		t.Errorf("target = %q, want myapp", target)
 	}
-	if framework != "laravel" {
-		t.Errorf("framework = %q, want laravel", framework)
+	// The flag carries no default any more: an empty value is what tells the
+	// command to ask, and runNew is where a non-interactive run falls back.
+	if framework != "" {
+		t.Errorf("framework = %q, want it unset", framework)
 	}
 	if want := []string{"--no-interaction", "--dev"}; !reflect.DeepEqual(extra, want) {
 		t.Errorf("extra args = %v, want %v", extra, want)

--- a/internal/cli/new_wizard.go
+++ b/internal/cli/new_wizard.go
@@ -1,0 +1,254 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"charm.land/huh/v2"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/store"
+)
+
+// defaultScaffoldFramework is the framework `lerd new` scaffolds when nothing
+// asks for another: the answer the wizard starts on, and the one a run with no
+// terminal keeps using so scripts and CI behave as they always have.
+const defaultScaffoldFramework = "laravel"
+
+// scaffoldChoice is one framework the wizard can offer: the store name a
+// definition resolves by, the label to show, and the majors available with the
+// newest first.
+type scaffoldChoice struct {
+	Name     string
+	Label    string
+	Versions []string
+	Latest   string
+
+	// sawDefinition records that a definition for this framework was read here,
+	// so creatable means something. creatable records that one of them carries a
+	// create command. A framework published but not installed leaves both false:
+	// nothing about it is known yet, and it is offered rather than hidden.
+	sawDefinition bool
+	creatable     bool
+}
+
+// canScaffold reports whether the wizard should offer this framework. Not every
+// definition can start a project: the store publishes frameworks whose install
+// is not a composer create-project at all, and offering one only to refuse it
+// after the questions is worse than never listing it.
+func (c scaffoldChoice) canScaffold() bool {
+	return c.creatable || !c.sawDefinition
+}
+
+// scaffoldCatalogue lists the frameworks `lerd new` can scaffold. It reads the
+// definitions `lerd framework list` shows, which install seeds from the store,
+// and folds in anything the cached index publishes that this machine has not
+// installed yet, so a framework whose definition arrives on selection is still
+// offered. Order follows the index, whose sequence is the store's to choose,
+// with installed-only names after it.
+func scaffoldCatalogue() []scaffoldChoice {
+	byName := map[string]*scaffoldChoice{}
+
+	add := func(name, label string) *scaffoldChoice {
+		if c, ok := byName[name]; ok {
+			if c.Label == "" {
+				c.Label = label
+			}
+			return c
+		}
+		c := &scaffoldChoice{Name: name, Label: label}
+		byName[name] = c
+		return c
+	}
+
+	var published []string
+	if idx, err := store.CachedIndex(); err == nil {
+		for _, e := range idx.Frameworks {
+			c := add(e.Name, e.Label)
+			c.Latest = e.Latest
+			for _, v := range e.Versions {
+				c.Versions = appendVersion(c.Versions, v)
+			}
+			published = append(published, e.Name)
+		}
+	}
+
+	var localOnly []string
+	for _, info := range config.ListFrameworksDetailed() {
+		if _, known := byName[info.Name]; !known {
+			localOnly = append(localOnly, info.Name)
+		}
+		c := add(info.Name, info.Label)
+		c.Versions = appendVersion(c.Versions, info.Version)
+		c.sawDefinition = true
+		if info.Create != "" {
+			c.creatable = true
+		}
+	}
+	sort.Strings(localOnly)
+
+	var out []scaffoldChoice
+	for _, name := range append(published, localOnly...) {
+		c := byName[name]
+		if !c.canScaffold() {
+			continue
+		}
+		sortFrameworkVersionsDesc(c.Versions)
+		if c.Latest == "" && len(c.Versions) > 0 {
+			c.Latest = c.Versions[0]
+		}
+		if c.Label == "" {
+			c.Label = c.Name
+		}
+		out = append(out, *c)
+	}
+	return out
+}
+
+// appendVersion adds a major to a version list, skipping blanks (a legacy
+// unversioned definition) and repeats.
+func appendVersion(versions []string, v string) []string {
+	if v == "" {
+		return versions
+	}
+	for _, have := range versions {
+		if have == v {
+			return versions
+		}
+	}
+	return append(versions, v)
+}
+
+// sortFrameworkVersionsDesc orders majors newest first, numerically, so 9 sits
+// below 12 rather than above it the way a string comparison would put it.
+func sortFrameworkVersionsDesc(versions []string) {
+	sort.SliceStable(versions, func(i, j int) bool {
+		a, aErr := strconv.Atoi(versions[i])
+		b, bErr := strconv.Atoi(versions[j])
+		if aErr != nil || bErr != nil {
+			return versions[i] > versions[j]
+		}
+		return a > b
+	})
+}
+
+// scaffoldChoiceByName returns the catalogue entry for a name, or nil.
+func scaffoldChoiceByName(catalogue []scaffoldChoice, name string) *scaffoldChoice {
+	for i := range catalogue {
+		if catalogue[i].Name == name {
+			return &catalogue[i]
+		}
+	}
+	return nil
+}
+
+// newShouldAskFramework reports whether `lerd new` should ask which framework to
+// scaffold. A run that named one has already answered, and a run with no
+// terminal must never block on the question.
+func newShouldAskFramework(interactive, frameworkGiven bool) bool {
+	return interactive && !frameworkGiven
+}
+
+// frameworkSelectOptions renders the catalogue as picker options, labelled the
+// way lerd framework list names each framework.
+func frameworkSelectOptions(catalogue []scaffoldChoice) []huh.Option[string] {
+	opts := make([]huh.Option[string], 0, len(catalogue))
+	for _, c := range catalogue {
+		opts = append(opts, huh.NewOption(c.Label, c.Name))
+	}
+	return opts
+}
+
+// versionSelectOptions renders a framework's majors as picker options, marking
+// the one the store publishes as current.
+func versionSelectOptions(c scaffoldChoice) []huh.Option[string] {
+	opts := make([]huh.Option[string], 0, len(c.Versions))
+	for _, v := range c.Versions {
+		label := v
+		if v == c.Latest {
+			label = v + " (latest)"
+		}
+		opts = append(opts, huh.NewOption(label, v))
+	}
+	return opts
+}
+
+// initialScaffoldFramework picks which entry the framework question starts on:
+// the command's long-standing default when the catalogue offers it, otherwise
+// the first thing it does offer.
+func initialScaffoldFramework(catalogue []scaffoldChoice) string {
+	if scaffoldChoiceByName(catalogue, defaultScaffoldFramework) != nil {
+		return defaultScaffoldFramework
+	}
+	if len(catalogue) > 0 {
+		return catalogue[0].Name
+	}
+	return defaultScaffoldFramework
+}
+
+// validateProjectName rejects an answer that cannot become a directory, so the
+// wizard says so at the prompt rather than failing several steps later.
+func validateProjectName(s string) error {
+	if strings.TrimSpace(s) == "" {
+		return fmt.Errorf("enter a name for the project")
+	}
+	if strings.ContainsRune(s, 0) {
+		return fmt.Errorf("the name cannot contain a NUL byte")
+	}
+	return nil
+}
+
+// askProjectName prompts for the target when the command was called without one.
+func askProjectName() (string, error) {
+	name := ""
+	err := huh.NewForm(huh.NewGroup(
+		huh.NewInput().
+			Title("Project name").
+			Description("A path works too, relative to here or absolute").
+			Value(&name).
+			Validate(validateProjectName),
+	)).WithTheme(huh.ThemeFunc(huh.ThemeCatppuccin)).Run()
+	return strings.TrimSpace(name), err
+}
+
+// askScaffoldFramework prompts for the framework and, when it has more than one
+// major published, for which one. Returns the store name and version to resolve
+// the definition by; an empty version means the latest.
+func askScaffoldFramework(catalogue []scaffoldChoice) (string, string, error) {
+	if len(catalogue) == 0 {
+		return defaultScaffoldFramework, "", nil
+	}
+
+	name := initialScaffoldFramework(catalogue)
+	if err := huh.NewForm(huh.NewGroup(
+		huh.NewSelect[string]().
+			Title("Framework").
+			Options(frameworkSelectOptions(catalogue)...).
+			Value(&name),
+	)).WithTheme(huh.ThemeFunc(huh.ThemeCatppuccin)).Run(); err != nil {
+		return "", "", err
+	}
+
+	choice := scaffoldChoiceByName(catalogue, name)
+	if choice == nil || len(choice.Versions) < 2 {
+		return name, "", nil
+	}
+
+	version := choice.Latest
+	if err := huh.NewForm(huh.NewGroup(
+		huh.NewSelect[string]().
+			Title(choice.Label + " version").
+			Options(versionSelectOptions(*choice)...).
+			Value(&version),
+	)).WithTheme(huh.ThemeFunc(huh.ThemeCatppuccin)).Run(); err != nil {
+		return "", "", err
+	}
+	// The latest needs no pin: resolving without one follows the store as it
+	// publishes new majors instead of freezing on the one listed today.
+	if version == choice.Latest {
+		version = ""
+	}
+	return name, version, nil
+}

--- a/internal/cli/new_wizard_test.go
+++ b/internal/cli/new_wizard_test.go
@@ -1,0 +1,307 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// writeStoreIndex publishes a catalogue to the cached index the wizard reads.
+func writeStoreIndex(t *testing.T, body string) {
+	t.Helper()
+	if err := os.MkdirAll(config.StoreFrameworksDir(), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if !json.Valid([]byte(body)) {
+		t.Fatalf("test index is not valid json: %s", body)
+	}
+	if err := os.WriteFile(config.StoreIndexFile(), []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The wizard offers what the store publishes, in the order the store lists it,
+// with each framework's majors newest first so the default lands on the current
+// release.
+func TestScaffoldCatalogue_FollowsThePublishedOrder(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	writeStoreIndex(t, `{"frameworks":[
+	  {"name":"laravel","label":"Laravel","versions":["13","12","11","10"],"latest":"13"},
+	  {"name":"drupal","label":"Drupal","versions":["10","11"],"latest":"11"}
+	]}`)
+
+	got := scaffoldCatalogue()
+	if got[0].Name != "laravel" || got[1].Name != "drupal" {
+		t.Errorf("order starts %s, %s, want laravel, drupal", got[0].Name, got[1].Name)
+	}
+	if got[0].Label != "Laravel" {
+		t.Errorf("label = %q, want Laravel", got[0].Label)
+	}
+	drupal := scaffoldChoiceByName(got, "drupal")
+	if drupal.Versions[0] != "11" {
+		t.Errorf("drupal versions = %v, want 11 first", drupal.Versions)
+	}
+	if got[0].Latest != "13" {
+		t.Errorf("laravel latest = %q, want 13", got[0].Latest)
+	}
+}
+
+// catalogueNames lists the entries in offered order.
+func catalogueNames(catalogue []scaffoldChoice) []string {
+	names := make([]string, 0, len(catalogue))
+	for _, c := range catalogue {
+		names = append(names, c.Name)
+	}
+	return names
+}
+
+// Not every published framework can start a project: an install that is not a
+// composer create-project publishes no create command. Offering one and then
+// refusing it after every question is worse than never listing it.
+func TestScaffoldCatalogue_OmitsFrameworksThatCannotScaffold(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	writeStoreIndex(t, `{"frameworks":[
+	  {"name":"laravel","label":"Laravel","versions":["13"],"latest":"13"},
+	  {"name":"wordpress","label":"WordPress","versions":["6","5"],"latest":"6"}
+	]}`)
+	for _, v := range []string{"5", "6"} {
+		if err := config.SaveStoreFramework(&config.Framework{
+			Name: "wordpress", Label: "WordPress", Version: v, PublicDir: ".",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := config.SaveStoreFramework(&config.Framework{
+		Name: "laravel", Label: "Laravel", Version: "13", PublicDir: "public",
+		Create: "composer create-project laravel/laravel",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := scaffoldCatalogue()
+	if scaffoldChoiceByName(got, "wordpress") != nil {
+		t.Errorf("catalogue = %v, want wordpress left out: no definition can scaffold it",
+			catalogueNames(got))
+	}
+	if scaffoldChoiceByName(got, "laravel") == nil {
+		t.Errorf("catalogue = %v, want laravel offered", catalogueNames(got))
+	}
+}
+
+// A framework the index publishes but this machine has not installed says
+// nothing about whether it can scaffold, so it stays on offer and its definition
+// is fetched when picked.
+func TestScaffoldCatalogue_KeepsPublishedFrameworksItCannotInspect(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	writeStoreIndex(t, `{"frameworks":[
+	  {"name":"tempest","label":"Tempest","versions":["3"],"latest":"3"}
+	]}`)
+
+	got := scaffoldCatalogue()
+	if scaffoldChoiceByName(got, "tempest") == nil {
+		t.Errorf("catalogue = %v, want the uninstalled tempest still offered",
+			catalogueNames(got))
+	}
+}
+
+// Majors are compared as numbers. Sorted as strings, 9 outranks 12 and the
+// wizard would default a Laravel project onto the older release.
+func TestSortFrameworkVersionsDesc_IsNumeric(t *testing.T) {
+	versions := []string{"9", "12", "10"}
+	sortFrameworkVersionsDesc(versions)
+	want := []string{"12", "10", "9"}
+	for i := range want {
+		if versions[i] != want[i] {
+			t.Fatalf("sorted = %v, want %v", versions, want)
+		}
+	}
+}
+
+// A framework installed here that the catalogue no longer lists is still
+// offered, below the published ones, so a definition someone keeps locally does
+// not vanish from the picker.
+func TestScaffoldCatalogue_KeepsInstalledOnlyFrameworksLast(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	writeStoreIndex(t, `{"frameworks":[
+	  {"name":"laravel","label":"Laravel","versions":["13"],"latest":"13"}
+	]}`)
+	if err := config.SaveStoreFramework(&config.Framework{
+		Name: "mystack", Label: "My Stack", Version: "2", PublicDir: "public",
+		Create: "composer create-project mystack/app",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := scaffoldCatalogue()
+	names := catalogueNames(got)
+	if got[0].Name != "laravel" {
+		t.Errorf("catalogue = %v, want the published laravel first", names)
+	}
+
+	local := scaffoldChoiceByName(got, "mystack")
+	if local == nil {
+		t.Fatalf("catalogue = %v, want the locally installed mystack offered", names)
+	}
+	if local.Label != "My Stack" {
+		t.Errorf("label = %q, want My Stack", local.Label)
+	}
+	// Everything the index publishes sits above everything that only exists here,
+	// so the picker opens on the store's own order.
+	for i, name := range names {
+		if name == "mystack" && i == 0 {
+			t.Errorf("catalogue = %v, want mystack below the published entries", names)
+		}
+	}
+	if local.Versions[0] != "2" {
+		t.Errorf("mystack versions = %v, want its installed 2", local.Versions)
+	}
+}
+
+// An install that has never reached the store still offers what it has, so the
+// wizard works offline instead of falling silently back to one framework.
+func TestScaffoldCatalogue_WorksWithNoIndex(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+
+	for _, v := range []string{"12", "13"} {
+		if err := config.SaveStoreFramework(&config.Framework{
+			Name: "laravel", Label: "Laravel", Version: v, PublicDir: "public",
+			Create: "composer create-project laravel/laravel",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := scaffoldCatalogue()
+	choice := scaffoldChoiceByName(got, "laravel")
+	if choice == nil {
+		t.Fatalf("catalogue = %+v, want the installed laravel", got)
+	}
+	if len(choice.Versions) != 2 || choice.Versions[0] != "13" {
+		t.Errorf("versions = %v, want 13 first of two", choice.Versions)
+	}
+	if choice.Latest != "13" {
+		t.Errorf("latest = %q, want 13 inferred from what is installed", choice.Latest)
+	}
+}
+
+// The question is only asked when the command was not told the answer, and never
+// where there is no terminal to answer it.
+func TestNewShouldAskFramework(t *testing.T) {
+	cases := []struct {
+		interactive, given, want bool
+	}{
+		{true, false, true},
+		{true, true, false},
+		{false, false, false},
+		{false, true, false},
+	}
+	for _, tc := range cases {
+		if got := newShouldAskFramework(tc.interactive, tc.given); got != tc.want {
+			t.Errorf("newShouldAskFramework(%v, %v) = %v, want %v",
+				tc.interactive, tc.given, got, tc.want)
+		}
+	}
+}
+
+// The version picker marks which major the store considers current, so picking
+// an older one is a deliberate act rather than a guess.
+func TestVersionSelectOptions_MarksLatest(t *testing.T) {
+	opts := versionSelectOptions(scaffoldChoice{
+		Name: "laravel", Label: "Laravel", Versions: []string{"13", "12"}, Latest: "13",
+	})
+	if len(opts) != 2 {
+		t.Fatalf("options = %+v, want 2", opts)
+	}
+	if opts[0].Key != "13 (latest)" || opts[0].Value != "13" {
+		t.Errorf("first option = %q/%q, want 13 (latest)/13", opts[0].Key, opts[0].Value)
+	}
+	if opts[1].Key != "12" {
+		t.Errorf("second option = %q, want a bare 12", opts[1].Key)
+	}
+}
+
+// The picker starts on the framework this command has always scaffolded, and on
+// whatever is first when that one is not on offer at all.
+func TestInitialScaffoldFramework(t *testing.T) {
+	catalogue := []scaffoldChoice{
+		{Name: "drupal", Label: "Drupal"},
+		{Name: defaultScaffoldFramework, Label: "Default"},
+	}
+	if got := initialScaffoldFramework(catalogue); got != defaultScaffoldFramework {
+		t.Errorf("initial = %q, want %q", got, defaultScaffoldFramework)
+	}
+	if got := initialScaffoldFramework(catalogue[:1]); got != "drupal" {
+		t.Errorf("initial without the default = %q, want drupal", got)
+	}
+}
+
+// A blank answer cannot become a directory, so the prompt has to reject it there
+// rather than let the scaffold fail several steps later.
+func TestValidateProjectName(t *testing.T) {
+	for _, bad := range []string{"", "   ", "\t"} {
+		if err := validateProjectName(bad); err == nil {
+			t.Errorf("validateProjectName(%q) = nil, want an error", bad)
+		}
+	}
+	for _, good := range []string{"myapp", "apps/myapp", "/abs/myapp"} {
+		if err := validateProjectName(good); err != nil {
+			t.Errorf("validateProjectName(%q) = %v, want nil", good, err)
+		}
+	}
+}
+
+// The chained steps read the working directory for themselves, so lerd new has
+// to move into the project and put the shell back where it found it.
+func TestInDirMovesAndRestores(t *testing.T) {
+	before, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seen := ""
+	if err := inDir(target, func() error {
+		seen, _ = os.Getwd()
+		return nil
+	}); err != nil {
+		t.Fatalf("inDir: %v", err)
+	}
+	if seen != target {
+		t.Errorf("ran in %q, want %q", seen, target)
+	}
+	after, _ := os.Getwd()
+	if after != before {
+		t.Errorf("left the process in %q, want %q", after, before)
+	}
+}
+
+// A failing step must not strand the process in the new project either.
+func TestInDirRestoresAfterAnError(t *testing.T) {
+	before, _ := os.Getwd()
+	if err := inDir(t.TempDir(), func() error { return os.ErrInvalid }); err == nil {
+		t.Fatal("inDir swallowed the error")
+	}
+	if after, _ := os.Getwd(); after != before {
+		t.Errorf("left the process in %q, want %q", after, before)
+	}
+}

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -967,23 +967,34 @@ func GetFramework(name string) (*Framework, bool) {
 // store's refresh window counts as current, so a repeat scaffold and an offline
 // one don't wait on the network. Falls back to what is installed, then to the
 // built-in, and reports false only when nothing knows the name.
-func GetFrameworkForScaffold(name string) (*Framework, bool) {
+// version pins the major to scaffold, for a caller offering the choice; empty
+// takes whatever the store publishes as its latest.
+func GetFrameworkForScaffold(name, version string) (*Framework, bool) {
 	if name == "" {
 		return nil, false
 	}
 
 	installed := storeFrameworkPath(name)
+	if version != "" {
+		installed = filepath.Join(StoreFrameworksDir(), name+"@"+version+".yaml")
+	}
+
 	var base *Framework
-	if installed != "" && !olderThan(installed, storeRefreshWindow) {
+	if !olderThan(installed, storeRefreshWindow) {
 		base = loadFrameworkYAML(installed)
 	}
 	if base == nil && frameworkFetchHook != nil {
-		if fetched, err := frameworkFetchHook(name, ""); err == nil {
+		if fetched, err := frameworkFetchHook(name, version); err == nil {
 			base = fetched
 		}
 	}
-	if base == nil && installed != "" {
+	if base == nil {
 		base = loadFrameworkYAML(installed)
+	}
+	// A pinned major nothing here or upstream serves resolves as if none had been
+	// asked for, rather than reporting a framework lerd does not know.
+	if base == nil && version != "" {
+		return GetFrameworkForScaffold(name, "")
 	}
 	// A definition that cannot scaffold is no reason to lose one that can. The
 	// store owns the create command and is free to publish a framework without

--- a/internal/config/framework_test.go
+++ b/internal/config/framework_test.go
@@ -213,7 +213,7 @@ func TestGetFrameworkForScaffold_FetchesUninstalled(t *testing.T) {
 		return fw, nil
 	}
 
-	got, ok := GetFrameworkForScaffold("codeigniter")
+	got, ok := GetFrameworkForScaffold("codeigniter", "")
 	if !ok {
 		t.Fatal("GetFrameworkForScaffold(codeigniter): not found after fetch")
 	}
@@ -242,7 +242,7 @@ func TestGetFrameworkForScaffold_PrefersStoreOverBuiltin(t *testing.T) {
 		return fw, nil
 	}
 
-	got, ok := GetFrameworkForScaffold("laravel")
+	got, ok := GetFrameworkForScaffold("laravel", "")
 	if !ok {
 		t.Fatal("GetFrameworkForScaffold(laravel): not found")
 	}
@@ -268,7 +268,7 @@ func TestGetFrameworkForScaffold_BuiltinSurvivesADefinitionThatCannotScaffold(t 
 		return fw, nil
 	}
 
-	got, ok := GetFrameworkForScaffold("laravel")
+	got, ok := GetFrameworkForScaffold("laravel", "")
 	if !ok {
 		t.Fatal("GetFrameworkForScaffold(laravel): not found")
 	}
@@ -288,7 +288,7 @@ func TestGetFrameworkForScaffold_FallsBackToBuiltin(t *testing.T) {
 		return nil, os.ErrNotExist
 	}
 
-	got, ok := GetFrameworkForScaffold("laravel")
+	got, ok := GetFrameworkForScaffold("laravel", "")
 	if !ok {
 		t.Fatal("GetFrameworkForScaffold(laravel): built-in not found")
 	}
@@ -314,7 +314,7 @@ func TestGetFrameworkForScaffold_SkipsFetchWhenFresh(t *testing.T) {
 		return nil, nil
 	}
 
-	got, ok := GetFrameworkForScaffold("laravel")
+	got, ok := GetFrameworkForScaffold("laravel", "")
 	if !ok {
 		t.Fatal("GetFrameworkForScaffold(laravel): not found")
 	}
@@ -341,7 +341,7 @@ func TestGetFrameworkForScaffold_KeepsStaleWhenStoreUnreachable(t *testing.T) {
 		return nil, os.ErrNotExist
 	}
 
-	got, ok := GetFrameworkForScaffold("laravel")
+	got, ok := GetFrameworkForScaffold("laravel", "")
 	if !ok {
 		t.Fatal("GetFrameworkForScaffold(laravel): not found")
 	}
@@ -374,12 +374,100 @@ func TestGetFrameworkForScaffold_PrefersHighestInstalledVersion(t *testing.T) {
 		return nil, nil
 	}
 
-	got, ok := GetFrameworkForScaffold("laravel")
+	got, ok := GetFrameworkForScaffold("laravel", "")
 	if !ok {
 		t.Fatal("GetFrameworkForScaffold(laravel): not found")
 	}
 	if got.Create != "composer create-project laravel/laravel --twelve" {
 		t.Errorf("Create = %q, want Laravel 12's", got.Create)
+	}
+}
+
+// A pinned major scaffolds that major's definition, not the newest one on disk.
+// Someone starting a project on an older release picked it deliberately.
+func TestGetFrameworkForScaffold_PinnedVersionWins(t *testing.T) {
+	setConfigDir(t)
+
+	installStoreFrameworkAged(t, &Framework{
+		Name: "laravel", Label: "Laravel", Version: "11", PublicDir: "public",
+		Create: "composer create-project laravel/laravel --eleven",
+	}, time.Minute)
+	installStoreFrameworkAged(t, &Framework{
+		Name: "laravel", Label: "Laravel", Version: "13", PublicDir: "public",
+		Create: "composer create-project laravel/laravel --thirteen",
+	}, time.Minute)
+
+	prev := frameworkFetchHook
+	t.Cleanup(func() { frameworkFetchHook = prev })
+	frameworkFetchHook = func(name, version string) (*Framework, error) {
+		t.Fatalf("fetch hook called for a fresh pinned definition (%q@%q)", name, version)
+		return nil, nil
+	}
+
+	got, ok := GetFrameworkForScaffold("laravel", "11")
+	if !ok {
+		t.Fatal("GetFrameworkForScaffold(laravel, 11): not found")
+	}
+	if got.Create != "composer create-project laravel/laravel --eleven" {
+		t.Errorf("Create = %q, want Laravel 11's", got.Create)
+	}
+}
+
+// A pinned major that is not installed is fetched by that version, so choosing
+// an older release in a wizard does not silently scaffold the latest.
+func TestGetFrameworkForScaffold_FetchesThePinnedVersion(t *testing.T) {
+	setConfigDir(t)
+
+	prev := frameworkFetchHook
+	t.Cleanup(func() { frameworkFetchHook = prev })
+	asked := ""
+	frameworkFetchHook = func(name, version string) (*Framework, error) {
+		asked = version
+		fw := &Framework{Name: name, Label: "Laravel", Version: version, PublicDir: "public",
+			Create: "composer create-project laravel/laravel --v" + version}
+		if err := SaveStoreFramework(fw); err != nil {
+			return nil, err
+		}
+		return fw, nil
+	}
+
+	got, ok := GetFrameworkForScaffold("laravel", "10")
+	if !ok {
+		t.Fatal("GetFrameworkForScaffold(laravel, 10): not found")
+	}
+	if asked != "10" {
+		t.Errorf("fetch hook asked for version %q, want 10", asked)
+	}
+	if got.Create != "composer create-project laravel/laravel --v10" {
+		t.Errorf("Create = %q, want the fetched Laravel 10 definition's", got.Create)
+	}
+}
+
+// A major nothing publishes resolves as if none had been pinned, rather than
+// reporting a framework lerd knows perfectly well as unknown.
+func TestGetFrameworkForScaffold_UnservedPinFallsBackToLatest(t *testing.T) {
+	setConfigDir(t)
+
+	prev := frameworkFetchHook
+	t.Cleanup(func() { frameworkFetchHook = prev })
+	frameworkFetchHook = func(name, version string) (*Framework, error) {
+		if version != "" {
+			return nil, os.ErrNotExist
+		}
+		fw := &Framework{Name: name, Label: "Laravel", Version: "13", PublicDir: "public",
+			Create: "composer create-project laravel/laravel --latest"}
+		if err := SaveStoreFramework(fw); err != nil {
+			return nil, err
+		}
+		return fw, nil
+	}
+
+	got, ok := GetFrameworkForScaffold("laravel", "99")
+	if !ok {
+		t.Fatal("GetFrameworkForScaffold(laravel, 99): not found")
+	}
+	if got.Create != "composer create-project laravel/laravel --latest" {
+		t.Errorf("Create = %q, want the latest definition's", got.Create)
 	}
 }
 
@@ -393,7 +481,7 @@ func TestGetFrameworkForScaffold_UnknownStaysNotFound(t *testing.T) {
 		return nil, os.ErrNotExist
 	}
 
-	if _, ok := GetFrameworkForScaffold("nonexistent"); ok {
+	if _, ok := GetFrameworkForScaffold("nonexistent", ""); ok {
 		t.Error("GetFrameworkForScaffold(nonexistent) = true, want false")
 	}
 }

--- a/internal/envfile/phparray.go
+++ b/internal/envfile/phparray.go
@@ -24,6 +24,15 @@ const (
 	phpNull
 	phpFloat
 	phpArray
+
+	// phpExpr is a value this reader cannot evaluate, held as the source text
+	// that produced it: a function call, a constant, a concatenation. Only PHP
+	// knows what it comes to, so lerd reports no value for the key and prints the
+	// expression back untouched. Refusing the file instead would cost every other
+	// key in it, and a framework whose defaults are written as calls (CakePHP's
+	// app_local.php opens with filter_var(env('DEBUG', true), ...)) keeps its
+	// whole configuration there.
+	phpExpr
 )
 
 // phpValue is a parsed PHP value. Arrays keep their entry order so a rewrite
@@ -32,6 +41,12 @@ type phpValue struct {
 	kind    phpKind
 	str     string
 	entries []phpEntry
+
+	// start and end bracket the value's source, so a write can replace just that
+	// span and leave the rest of the file alone. A value built in memory rather
+	// than parsed has both zero.
+	start int
+	end   int
 }
 
 type phpEntry struct {
@@ -74,9 +89,6 @@ func ApplyPhpArrayUpdates(path string, updates map[string]string) error {
 		return err
 	}
 	original := string(data)
-	if root == nil || root.kind != phpArray {
-		root = &phpValue{kind: phpArray}
-	}
 
 	// Sort so the emitted file is deterministic when several new paths are added.
 	keys := make([]string, 0, len(updates))
@@ -84,19 +96,176 @@ func ApplyPhpArrayUpdates(path string, updates map[string]string) error {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	for _, k := range keys {
-		setPath(root, strings.Split(k, "."), updates[k])
+
+	if root != nil && root.kind == phpArray {
+		return writePhpArrayInPlace(path, original, root, keys, updates)
 	}
 
+	// No array to edit: the file is new, or holds something this reader does not
+	// recognise as configuration. Print one.
+	fresh := &phpValue{kind: phpArray}
+	for _, k := range keys {
+		setPath(fresh, strings.Split(k, "."), updates[k])
+	}
 	var b strings.Builder
 	b.WriteString("<?php\nreturn ")
-	printValue(&b, root, 0)
+	printValue(&b, fresh, 0)
 	b.WriteString(";\n")
+	return writePhpArrayFile(path, original, b.String())
+}
 
-	// A rewrite reprints the whole file, so without this an env already holding
-	// every target value still gets its mtime bumped and its formatting churned
-	// on every call — and EnsureWorktreeEnv is called on every worktree sync.
-	if b.String() == original {
+// writePhpArrayInPlace edits only the spans that change, leaving the rest of the
+// file byte for byte. These files are read by people as much as by code:
+// CakePHP's app_local.php is mostly guidance on what each key does, and opens
+// with the `use function` import its own values depend on. Reprinting the parsed
+// tree would return a valid array and a file that had lost all of it.
+func writePhpArrayInPlace(path, original string, root *phpValue, keys []string, updates map[string]string) error {
+	type edit struct {
+		start, end int
+		text       string
+	}
+	var edits []edit
+
+	// Keys whose path does not exist yet are grafted onto the deepest array that
+	// does, one insertion per array however many keys land in it, so two new keys
+	// under the same new parent produce one entry rather than two of the same name.
+	grafts := map[*phpValue]*phpValue{}
+	var graftOrder []*phpValue
+
+	for _, key := range keys {
+		segs := strings.Split(key, ".")
+		node, rest := descendPhpArray(root, segs)
+		if len(rest) == 0 {
+			edits = append(edits, edit{node.start, node.end,
+				renderPhpValue(scalarValue(updates[key], node.kind), indentAt(original, node.start))})
+			continue
+		}
+		if node.kind != phpArray {
+			// Something that is not an array sits where one has to be. Replacing it
+			// is the only way through, and it is what the whole-file writer did.
+			replacement := &phpValue{kind: phpArray}
+			setPath(replacement, rest, updates[key])
+			edits = append(edits, edit{node.start, node.end, renderPhpValue(replacement, indentAt(original, node.start))})
+			continue
+		}
+		graft := grafts[node]
+		if graft == nil {
+			graft = &phpValue{kind: phpArray}
+			grafts[node] = graft
+			graftOrder = append(graftOrder, node)
+		}
+		setPath(graft, rest, updates[key])
+	}
+
+	for _, node := range graftOrder {
+		at, indent, ok := phpArrayInsertion(original, node)
+		if !ok {
+			// An array written on one line has nowhere to insert a line, so it is
+			// reprinted whole. It has no comments inside it to lose.
+			merged := clonePhpValue(node)
+			for _, e := range grafts[node].entries {
+				setPathValue(merged, []string{e.key}, e.val)
+			}
+			edits = append(edits, edit{node.start, node.end, renderPhpValue(merged, indentAt(original, node.start))})
+			continue
+		}
+		var b strings.Builder
+		for _, e := range grafts[node].entries {
+			b.WriteString(indent + "'" + escapeSingle(e.key) + "' => ")
+			printValue(&b, e.val, len(indent)/4)
+			b.WriteString(",\n")
+		}
+		edits = append(edits, edit{at, at, b.String()})
+	}
+
+	// Applied back to front so each splice leaves the earlier offsets valid.
+	sort.SliceStable(edits, func(i, j int) bool { return edits[i].start > edits[j].start })
+	out := original
+	for _, e := range edits {
+		out = out[:e.start] + e.text + out[e.end:]
+	}
+	return writePhpArrayFile(path, original, out)
+}
+
+// descendPhpArray walks as far into the tree as the file already goes, returning
+// the deepest node reached and the segments still to be created below it.
+func descendPhpArray(root *phpValue, segs []string) (*phpValue, []string) {
+	node := root
+	for i, seg := range segs {
+		if node.kind != phpArray {
+			return node, segs[i:]
+		}
+		next := (*phpValue)(nil)
+		for j := range node.entries {
+			if node.entries[j].key == seg {
+				next = node.entries[j].val
+				break
+			}
+		}
+		if next == nil {
+			return node, segs[i:]
+		}
+		node = next
+	}
+	return node, nil
+}
+
+// phpArrayInsertion returns where a new entry goes in an array written across
+// several lines, and the indentation to give it: the start of the line holding
+// the closing bracket, so the entry becomes the last one and the bracket keeps
+// its own line. Reports false for an array written on a single line.
+func phpArrayInsertion(src string, arr *phpValue) (int, string, bool) {
+	closer := arr.end - 1
+	if closer <= arr.start {
+		return 0, "", false
+	}
+	lineStart := strings.LastIndexByte(src[:closer], '\n') + 1
+	if lineStart <= arr.start {
+		return 0, "", false
+	}
+	closerIndent := src[lineStart:closer]
+	if strings.TrimSpace(closerIndent) != "" {
+		return 0, "", false
+	}
+	return lineStart, closerIndent + "    ", true
+}
+
+// indentAt returns the leading whitespace of the line offset sits on, so a
+// replacement renders at the nesting the file already uses there.
+func indentAt(src string, offset int) string {
+	if offset > len(src) {
+		return ""
+	}
+	lineStart := strings.LastIndexByte(src[:offset], '\n') + 1
+	indent := src[lineStart:offset]
+	if trimmed := strings.TrimLeft(indent, " \t"); trimmed != "" {
+		return indent[:len(indent)-len(trimmed)]
+	}
+	return indent
+}
+
+// renderPhpValue prints a value as it should read at a given indentation.
+func renderPhpValue(v *phpValue, indent string) string {
+	var b strings.Builder
+	printValue(&b, v, len(indent)/4)
+	return b.String()
+}
+
+// clonePhpValue copies a parsed value deeply enough to graft onto without
+// disturbing the offsets the edits are computed from.
+func clonePhpValue(v *phpValue) *phpValue {
+	out := &phpValue{kind: v.kind, str: v.str}
+	for _, e := range v.entries {
+		out.entries = append(out.entries, phpEntry{key: e.key, isInt: e.isInt, val: clonePhpValue(e.val)})
+	}
+	return out
+}
+
+// writePhpArrayFile persists a rewrite, skipping a write that changes nothing so
+// an env sync doesn't churn a file the user has open. EnsureWorktreeEnv reaches
+// here on every worktree sync.
+func writePhpArrayFile(path, original, out string) error {
+	if out == original {
 		return nil
 	}
 	if dir := filepath.Dir(path); dir != "." {
@@ -104,10 +273,15 @@ func ApplyPhpArrayUpdates(path string, updates map[string]string) error {
 			return err
 		}
 	}
-	return writeFile(path, []byte(b.String()), 0o644)
+	return writeFile(path, []byte(out), 0o644)
 }
 
 func flatten(prefix string, v *phpValue, out map[string]string) {
+	// An expression has no value until PHP runs it, so the key is left out
+	// rather than reported as whatever its source text happens to read like.
+	if v.kind == phpExpr {
+		return
+	}
 	if v.kind != phpArray {
 		out[prefix] = scalarString(v)
 		return
@@ -217,7 +391,7 @@ func printValue(b *strings.Builder, v *phpValue, depth int) {
 			b.WriteString(",\n")
 		}
 		b.WriteString(strings.Repeat("    ", depth) + "]")
-	case phpInt, phpFloat, phpBool:
+	case phpInt, phpFloat, phpBool, phpExpr:
 		b.WriteString(v.str)
 	case phpNull:
 		b.WriteString("null")
@@ -321,8 +495,20 @@ func (p *phpParser) skipTrivia() {
 	}
 }
 
+// parseValue records where the value it read begins and ends, so a writer can
+// splice a replacement over exactly that span.
 func (p *phpParser) parseValue() (*phpValue, error) {
 	p.skipTrivia()
+	start := p.pos
+	v, err := p.parseValueAt()
+	if err != nil {
+		return nil, err
+	}
+	v.start, v.end = start, p.pos
+	return v, nil
+}
+
+func (p *phpParser) parseValueAt() (*phpValue, error) {
 	if p.pos >= len(p.src) {
 		return nil, fmt.Errorf("unexpected end of file")
 	}
@@ -368,7 +554,51 @@ func (p *phpParser) parseValue() (*phpValue, error) {
 		}
 		return &phpValue{kind: kind, str: p.src[start:p.pos]}, nil
 	}
-	return nil, fmt.Errorf("unsupported value at offset %d", p.pos)
+	return p.parseExpression()
+}
+
+// parseExpression captures a value that is not a literal as the source text
+// that produced it, so the rest of the file stays readable and writable around
+// it. It ends where the value does: a comma or a closing bracket that belongs
+// to the array holding it, neither of which it consumes. Brackets, strings and
+// comments inside the expression are stepped over whole, so a comma within any
+// of them does not end it early.
+func (p *phpParser) parseExpression() (*phpValue, error) {
+	start := p.pos
+	depth := 0
+	for p.pos < len(p.src) {
+		c := p.src[p.pos]
+		switch {
+		case c == '\'' || c == '"':
+			if _, err := p.parseString(); err != nil {
+				return nil, err
+			}
+			continue
+		case strings.HasPrefix(p.src[p.pos:], "//"), c == '#',
+			strings.HasPrefix(p.src[p.pos:], "/*"):
+			p.skipTrivia()
+			continue
+		case c == '(' || c == '[' || c == '{':
+			depth++
+		case c == ')' || c == ']' || c == '}':
+			if depth == 0 {
+				return expressionValue(p.src[start:p.pos]), nil
+			}
+			depth--
+		case c == ',' && depth == 0:
+			return expressionValue(p.src[start:p.pos]), nil
+		case c == ';' && depth == 0:
+			return expressionValue(p.src[start:p.pos]), nil
+		}
+		p.pos++
+	}
+	return nil, fmt.Errorf("unterminated value at offset %d", start)
+}
+
+// expressionValue trims the trailing layout off captured source, so reprinting
+// an array does not carry the old spacing before its comma into the new one.
+func expressionValue(src string) *phpValue {
+	return &phpValue{kind: phpExpr, str: strings.TrimRight(src, " \t\r\n")}
 }
 
 func (p *phpParser) parseArrayBody(closer byte) (*phpValue, error) {

--- a/internal/envfile/phparray_test.go
+++ b/internal/envfile/phparray_test.go
@@ -345,3 +345,143 @@ func TestApplyPhpArrayUpdates_NoOpWhenUnchanged(t *testing.T) {
 		t.Errorf("db.host = %q, want lerd-mariadb-11-8", got["db.host"])
 	}
 }
+
+// A returning-array config is read by people as much as by code: CakePHP's
+// app_local.php is mostly guidance on what each key is for, and its values call
+// a function it imports at the top. Rewriting a value must leave all of that
+// where it was, so the writer edits spans rather than reprinting the tree.
+const cakeAppLocalPHP = `<?php
+
+use function Cake\Core\env;
+
+/*
+ * Local configuration file.
+ */
+return [
+    'debug' => filter_var(env('DEBUG', true), FILTER_VALIDATE_BOOLEAN),
+
+    'Datasources' => [
+        'default' => [
+            'host' => 'localhost',
+            /*
+             * MAMP users will want to set the port.
+             */
+            //'port' => 'non_standard_port_number',
+
+            'username' => 'my_app',
+            'database' => 'my_app',
+
+            'url' => env('DATABASE_URL', null),
+        ],
+    ],
+];
+`
+
+func TestApplyPhpArrayUpdates_KeepsCommentsAndExpressions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app_local.php")
+	if err := os.WriteFile(path, []byte(cakeAppLocalPHP), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ApplyPhpArrayUpdates(path, map[string]string{
+		"Datasources.default.host":     "lerd-mysql",
+		"Datasources.default.database": "fourth",
+	}); err != nil {
+		t.Fatalf("ApplyPhpArrayUpdates: %v", err)
+	}
+	body, _ := os.ReadFile(path)
+	got := string(body)
+
+	for _, keep := range []string{
+		"use function Cake\\Core\\env;",
+		"* Local configuration file.",
+		"* MAMP users will want to set the port.",
+		"//'port' => 'non_standard_port_number',",
+		"filter_var(env('DEBUG', true), FILTER_VALIDATE_BOOLEAN)",
+		"env('DATABASE_URL', null)",
+	} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("rewrite dropped %q:\n%s", keep, got)
+		}
+	}
+	if !strings.Contains(got, "'host' => 'lerd-mysql',") {
+		t.Errorf("host was not rewritten:\n%s", got)
+	}
+	if strings.Contains(got, "'my_app'") && !strings.Contains(got, "'username' => 'my_app'") {
+		t.Errorf("rewrite disturbed a value it was not given:\n%s", got)
+	}
+}
+
+// A key the file does not have yet is inserted into the array it belongs to,
+// indented with its siblings, rather than reprinting the array around it.
+func TestApplyPhpArrayUpdates_InsertsMissingKeyInPlace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app_local.php")
+	if err := os.WriteFile(path, []byte(cakeAppLocalPHP), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ApplyPhpArrayUpdates(path, map[string]string{"Datasources.default.port": "3306"}); err != nil {
+		t.Fatalf("ApplyPhpArrayUpdates: %v", err)
+	}
+	body, _ := os.ReadFile(path)
+	if !strings.Contains(string(body), "\n            'port' => '3306',\n") {
+		t.Errorf("port was not inserted alongside its siblings:\n%s", body)
+	}
+	if !strings.Contains(string(body), "use function Cake\\Core\\env;") {
+		t.Errorf("insertion cost the file its import:\n%s", body)
+	}
+	vals, err := ReadPhpArray(path)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if vals["Datasources.default.port"] != "3306" {
+		t.Errorf("port = %q, want 3306", vals["Datasources.default.port"])
+	}
+}
+
+// Several new keys under one absent parent produce a single entry for it, not
+// one per key, which would leave the array holding the same name twice.
+func TestApplyPhpArrayUpdates_GroupsKeysUnderOneNewParent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app_local.php")
+	if err := os.WriteFile(path, []byte(cakeAppLocalPHP), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ApplyPhpArrayUpdates(path, map[string]string{
+		"Datasources.replica.host":     "lerd-mysql",
+		"Datasources.replica.database": "fourth",
+	}); err != nil {
+		t.Fatalf("ApplyPhpArrayUpdates: %v", err)
+	}
+	body, _ := os.ReadFile(path)
+	if n := strings.Count(string(body), "'replica' =>"); n != 1 {
+		t.Errorf("replica written %d times, want once:\n%s", n, body)
+	}
+	vals, _ := ReadPhpArray(path)
+	if vals["Datasources.replica.host"] != "lerd-mysql" || vals["Datasources.replica.database"] != "fourth" {
+		t.Errorf("replica values did not survive: %v", vals)
+	}
+}
+
+// A value the reader cannot evaluate is nobody's to report: the key is absent
+// from a read rather than carrying the source text as if it were the value.
+func TestReadPhpArray_OmitsExpressionValues(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app_local.php")
+	if err := os.WriteFile(path, []byte(cakeAppLocalPHP), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	vals, err := ReadPhpArray(path)
+	if err != nil {
+		t.Fatalf("ReadPhpArray: %v", err)
+	}
+	if _, ok := vals["debug"]; ok {
+		t.Errorf("debug = %q, want no value for an expression", vals["debug"])
+	}
+	if _, ok := vals["Datasources.default.url"]; ok {
+		t.Errorf("url = %q, want no value for an expression", vals["Datasources.default.url"])
+	}
+	if vals["Datasources.default.host"] != "localhost" {
+		t.Errorf("host = %q, want the literal alongside the expressions", vals["Datasources.default.host"])
+	}
+}

--- a/internal/envfile/phpvars.go
+++ b/internal/envfile/phpvars.go
@@ -79,7 +79,7 @@ func ApplyPhpVarsUpdates(path string, updates map[string]string) error {
 	}
 
 	touched := map[int]bool{}
-	var appended []string
+	var unowned []string
 	for _, key := range keys {
 		segs := strings.Split(key, ".")
 		if i, rest := ownerOf(assignments, segs); i >= 0 {
@@ -94,8 +94,9 @@ func ApplyPhpVarsUpdates(path string, updates map[string]string) error {
 			touched[i] = true
 			continue
 		}
-		appended = append(appended, printAssignment(segs, updates[key]))
+		unowned = append(unowned, key)
 	}
+	appended := newAssignments(unowned, updates)
 
 	dirty := map[int]bool{}
 	for i := range assignments {
@@ -181,9 +182,53 @@ func ownerOf(assignments []phpAssignment, segs []string) (int, []string) {
 	return best, segs[bestLen:]
 }
 
-// printAssignment renders a statement for a key no assignment covers, assigning
-// the leaf directly: PHP creates the arrays above it on the way.
-func printAssignment(segs []string, value string) string {
+// newAssignments renders the statements for keys no assignment covers, one per
+// parent path with that parent's new leaves gathered into a single array.
+//
+// Assigning each leaf on its own line runs identically in PHP, but it is not the
+// shape a framework writes for itself, and one of them reads the file back that
+// way: Drupal's installer rewrites settings.php by walking it index by index
+// against the settings it is about to write, whose value for the connection node
+// is an object. An index below that node makes the walk subscript the object,
+// and the install dies at the database step. Assigning the node itself gives the
+// walk somewhere to stop.
+func newAssignments(keys []string, updates map[string]string) []string {
+	var order []string
+	byParent := map[string][]string{}
+	for _, key := range keys {
+		segs := strings.Split(key, ".")
+		parent := strings.Join(segs[:len(segs)-1], ".")
+		if _, seen := byParent[parent]; !seen {
+			order = append(order, parent)
+		}
+		byParent[parent] = append(byParent[parent], key)
+	}
+
+	var out []string
+	for _, parent := range order {
+		parentSegs := strings.Split(parent, ".")
+		// Only an indexed node is gathered. A key sitting directly under its
+		// variable would otherwise have the whole variable assigned to it, which
+		// discards everything else the application puts there.
+		if parent == "" || len(parentSegs) < 2 {
+			for _, key := range byParent[parent] {
+				out = append(out, printAssignment(strings.Split(key, "."), scalarValue(updates[key], phpString)))
+			}
+			continue
+		}
+		node := &phpValue{kind: phpArray}
+		for _, key := range byParent[parent] {
+			segs := strings.Split(key, ".")
+			setPath(node, segs[len(segs)-1:], updates[key])
+		}
+		out = append(out, printAssignment(parentSegs, node))
+	}
+	return out
+}
+
+// printAssignment renders one `$var['a']['b'] = <value>;` statement. PHP creates
+// the arrays above the assigned path on the way.
+func printAssignment(segs []string, value *phpValue) string {
 	var b strings.Builder
 	b.WriteString("$")
 	b.WriteString(segs[0])
@@ -193,7 +238,7 @@ func printAssignment(segs []string, value string) string {
 		b.WriteString("']")
 	}
 	b.WriteString(" = ")
-	printValue(&b, scalarValue(value, phpString), 0)
+	printValue(&b, value, 0)
 	b.WriteString(";\n")
 	return b.String()
 }

--- a/internal/envfile/phpvars_test.go
+++ b/internal/envfile/phpvars_test.go
@@ -127,8 +127,9 @@ func TestApplyPhpVarsUpdates_rewritesInPlace(t *testing.T) {
 	}
 }
 
-// A key no assignment covers is appended as its own statement, so a project
-// missing a setting entirely still ends up with it.
+// A key no assignment covers is appended, so a project missing a setting
+// entirely still ends up with it, and the statement assigns the node it belongs
+// to rather than reaching an index below it.
 func TestApplyPhpVarsUpdates_appendsAKeyNoAssignmentCovers(t *testing.T) {
 	path := writeSettings(t, "<?php\n$settings['x'] = 'y';\n")
 
@@ -141,8 +142,12 @@ func TestApplyPhpVarsUpdates_appendsAKeyNoAssignmentCovers(t *testing.T) {
 		t.Errorf("host = %q, want lerd-mysql", vals["databases.default.default.host"])
 	}
 	body, _ := os.ReadFile(path)
-	if !strings.Contains(string(body), "$databases['default']['default']['host'] = 'lerd-mysql';") {
+	if !strings.Contains(string(body), "$databases['default']['default'] = [") {
 		t.Errorf("appended statement not as expected:\n%s", body)
+	}
+	// What was already in the file is left where it was.
+	if !strings.Contains(string(body), "$settings['x'] = 'y';") {
+		t.Errorf("rewrite disturbed the existing statement:\n%s", body)
 	}
 }
 
@@ -198,5 +203,62 @@ func TestReader_readsPhpVars(t *testing.T) {
 	}
 	if got := Reader(path, "php-vars")("databases.default.default.driver"); got != "sqlite" {
 		t.Errorf("Reader = %q, want sqlite", got)
+	}
+}
+
+// A settings file lerd creates from nothing has to hold its connection as one
+// array assigned to the node it belongs to, not a statement per leaf. Both run
+// the same in PHP, but Drupal's own installer rewrites settings.php by walking
+// it index by index against the settings it is about to write, and its new
+// value for that node is an object. Meeting another index below it, the walk
+// subscripts that object and the installer dies on "Cannot use object of type
+// stdClass as array" at the database step of a fresh install.
+func TestApplyPhpVarsUpdates_GroupsNewKeysUnderTheirParent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.php")
+
+	updates := map[string]string{
+		"databases.default.default.database": "third",
+		"databases.default.default.driver":   "mysql",
+		"databases.default.default.host":     "lerd-mysql",
+	}
+	if err := ApplyPhpVarsUpdates(path, updates); err != nil {
+		t.Fatalf("ApplyPhpVarsUpdates: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+
+	if !strings.Contains(got, "$databases['default']['default'] = [") {
+		t.Errorf("file does not assign the node as one array:\n%s", got)
+	}
+	if strings.Contains(got, "$databases['default']['default']['host']") {
+		t.Errorf("file still writes a statement per leaf:\n%s", got)
+	}
+
+	// Whatever the shape, the values have to read back under the same keys.
+	back, err := ReadPhpVars(path)
+	if err != nil {
+		t.Fatalf("ReadPhpVars: %v", err)
+	}
+	for key, want := range updates {
+		if back[key] != want {
+			t.Errorf("read back %s = %q, want %q", key, back[key], want)
+		}
+	}
+}
+
+// A key directly under its variable has no parent to group beneath, so it keeps
+// the plain assignment it always had.
+func TestApplyPhpVarsUpdates_LeavesShallowKeysAlone(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.php")
+
+	if err := ApplyPhpVarsUpdates(path, map[string]string{"settings.hash_salt": "abc"}); err != nil {
+		t.Fatalf("ApplyPhpVarsUpdates: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), "$settings['hash_salt'] = 'abc';") {
+		t.Errorf("shallow key was not written plainly:\n%s", data)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3747,7 +3747,7 @@ func execProjectNew(args map[string]any) (any, *rpcError) {
 	}
 	extraArgs := strSliceArg(args, "args")
 
-	fw, ok := config.GetFrameworkForScaffold(frameworkName)
+	fw, ok := config.GetFrameworkForScaffold(frameworkName, "")
 	if !ok {
 		return toolErr(fmt.Sprintf("unknown framework %q — use framework_list to see available frameworks", frameworkName)), nil
 	}


### PR DESCRIPTION
lerd new scaffolded Laravel without asking and ended by printing three commands for the user to type. On a terminal it now asks which framework to use, offering what the store publishes and which major to scaffold, defaulting to the current release and resolving that major's definition before scaffolding. Called with no name it asks for that too. It then changes into the new project and runs the link flow, which routes a project with no .lerd.yaml through the init wizard for PHP version, HTTPS and services and offers setup at the end, so scaffolding lands on a served site. Naming a framework skips the question and a run with no terminal skips all of them, leaving scripts and CI exactly as they were.

The catalogue only offers what can actually start a project. The store index carries no create command, so a framework whose definition has none was offered and then refused after every question had been answered.

Scaffolding straight into a served site made two things reachable that a link and a setup always could have. A fresh Drupal has no settings.php, and creating one with a statement per key left a file Drupal's own installer cannot rewrite: it walks the file index by index against the settings it is about to write, whose value for the connection is an object, and an index below that node makes the walk subscript it. New keys are now gathered under the node they belong to and assigned once, which is the shape a framework writes for itself. Only an indexed node is gathered, never a bare variable, since assigning a whole variable would discard everything else the application puts there.

CakePHP's connection went to config/.env, which the skeleton never reads, while the file it does read holds a host of localhost that PDO resolves as a socket. Naming the right file needs the php-array reader and writer to cope with it first. A value the reader cannot evaluate is now carried as the source text that produced it, reported as no value and printed back untouched, rather than refusing the file over the filter_var call app_local.php opens with. And the writer edits only the spans that change instead of reprinting the parsed tree, which on a hand-edited config discarded every comment and the use function import its own values depend on. Magento's generated env.php was the only user of this format, which is why neither surfaced before.

The CakePHP definition itself is a store change and goes to lerd-env/frameworks separately; this side is what makes it possible.

Closes #1355
Closes #1433
Refs #1434
