### PR TITLE
fix(init): prefill the wizard Node version field and say what clearing it does

### DIFF
--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -23,7 +23,7 @@ lerd init
 ```
 → Configuring site...
 ? PHP version: 8.5
-? Node version (leave blank to skip): 22
+? Node version (clear to follow the lerd default instead of pinning): 22
 ? Enable HTTPS? No
 ? Database: mysql
 ? Services: [mysql, redis]
@@ -33,6 +33,8 @@ Linked: my-app -> my-app.test (PHP 8.5, Node 22, Framework: laravel)
 ```
 
 The answers are saved to `.lerd.yaml` in the project root and applied immediately: the site is linked, HTTPS is enabled if requested, the database is created, and the chosen services are started.
+
+The Node version field asks which version, not whether. It is prefilled like the PHP field above it, from `.lerd.yaml` if a version is already saved and otherwise from `.nvmrc`, `.node-version`, `package.json` engines or the global default. Accepting it writes `node_version` to `.lerd.yaml`, which outranks all four from then on. Clear the field and no version is saved, so the project keeps resolving its own.
 
 The services list includes both built-in services and any custom services already registered with `lerd service add`. The workers step pre-selects workers based on the framework and detected packages; Horizon is shown automatically when `laravel/horizon` is in `composer.json`, replacing the generic queue option.
 

--- a/docs/getting-started/laravel.md
+++ b/docs/getting-started/laravel.md
@@ -65,7 +65,7 @@ lerd init
 
 ```
 ? PHP version: 8.5
-? Node version (leave blank to skip): 22
+? Node version (clear to follow the lerd default instead of pinning): 22
 ? Enable HTTPS? Yes
 ? Database: MySQL (lerd-mysql)
 ? Services: [redis, mailpit]

--- a/docs/getting-started/symfony.md
+++ b/docs/getting-started/symfony.md
@@ -138,7 +138,7 @@ lerd init
 
 ```
 ? PHP version: 8.5
-? Node version (leave blank to skip): 22
+? Node version (clear to follow the lerd default instead of pinning): 22
 ? Enable HTTPS? Yes
 ? Database: mysql
 ? Services: [mailpit]

--- a/docs/getting-started/wordpress.md
+++ b/docs/getting-started/wordpress.md
@@ -83,7 +83,7 @@ lerd init
 
 ```
 ? PHP version: 8.3
-? Node version (leave blank to skip):
+? Node version (clear to follow the lerd default instead of pinning): 22
 ? Enable HTTPS? Yes
 ? Services: [mysql]
 Saved .lerd.yaml

--- a/docs/usage/sites.md
+++ b/docs/usage/sites.md
@@ -37,7 +37,7 @@ lerd init
 
 ```
 ? PHP version: 8.5
-? Node version (leave blank to skip):
+? Node version (clear to follow the lerd default instead of pinning): 22
 ? Enable HTTPS? No
 ? Database:
   > SQLite (no service)
@@ -55,6 +55,7 @@ Linked: my-app -> my-app.test (PHP 8.5, Node 22, Framework: laravel)
 Wizard defaults are populated intelligently on first run:
 
 - **PHP version**: from the site registry if already linked, otherwise from `.php-version`, `composer.json`, or the global default
+- **Node version**: from `.lerd.yaml` if already saved, otherwise from `.nvmrc`, `.node-version`, `package.json` engines, or the global default; clear the field to save no version and keep following those
 - **Enable HTTPS**: pre-checked if the site is already secured
 - **Database**: pre-selected from any database already in `.lerd.yaml`, otherwise from `DB_CONNECTION` in `.env` (or `.env.example` for a fresh clone), falling back to SQLite (Laravel's default for new projects)
 - **Services**: pre-checked based on what's detected in the project's `.env` file (only non-database services here, since the database is its own step)

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/envfile"
 	"github.com/geodro/lerd/internal/feedback"
+	nodeDet "github.com/geodro/lerd/internal/node"
 	phpPkg "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/podman"
 	"github.com/spf13/cobra"
@@ -94,6 +95,27 @@ func runInit(fresh bool) error {
 // for an absent-or-empty config, and `lerd init --fresh` for an explicit redo).
 func initShouldRunWizard(hasExisting, fresh bool) bool {
 	return !hasExisting || fresh
+}
+
+// nodeVersionDefault prefills the Node field the way the PHP one above it is
+// prefilled: a version already saved in .lerd.yaml wins, otherwise the version
+// the project resolves to on its own.
+func nodeVersionDefault(saved, resolved string) string {
+	if saved != "" {
+		return saved
+	}
+	return resolved
+}
+
+// nodeVersionDescription says what clearing the Node field does. An answer there
+// writes a node_version pin that outranks .nvmrc, .node-version, engines.node
+// and the machine default, and keeps outranking them, so an empty field is not
+// Node being turned off, it is the project going on resolving its own version.
+func nodeVersionDescription(source string) string {
+	if source == "" {
+		return "Clear to leave the version unpinned"
+	}
+	return fmt.Sprintf("Clear to follow %s instead of pinning", source)
 }
 
 func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfig, error) {
@@ -290,10 +312,12 @@ func runWizard(cwd string, defaults *config.ProjectConfig) (*config.ProjectConfi
 			}),
 	}
 	if lerdManagesNode() {
+		resolved, source := nodeDet.UnpinnedVersion(cwd)
+		nodeVersion = nodeVersionDefault(nodeVersion, resolved)
 		firstGroupFields = append(firstGroupFields,
 			huh.NewInput().
 				Title("Node version").
-				Description("Leave blank to skip").
+				Description(nodeVersionDescription(source)).
 				Value(&nodeVersion),
 		)
 	}

--- a/internal/cli/init_node_field_test.go
+++ b/internal/cli/init_node_field_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// The Node field is prefilled like the PHP field above it: a saved pin is the
+// answer to beat, and with none the box shows what the project already resolves
+// to rather than sitting empty.
+func TestNodeVersionDefault(t *testing.T) {
+	cases := []struct{ saved, resolved, want string }{
+		{"18", "22", "18"},
+		{"", "22", "22"},
+		{"", "", ""},
+	}
+	for _, c := range cases {
+		if got := nodeVersionDefault(c.saved, c.resolved); got != c.want {
+			t.Errorf("nodeVersionDefault(%q, %q) = %q, want %q", c.saved, c.resolved, got, c.want)
+		}
+	}
+}
+
+// Clearing the field writes no pin, which leaves the project following its own
+// files. The description has to say that rather than claim the field skips Node.
+func TestNodeVersionDescription_NamesWhatClearingDoes(t *testing.T) {
+	got := nodeVersionDescription(".nvmrc")
+	if !strings.Contains(got, ".nvmrc") {
+		t.Errorf("description %q should name what an empty field follows", got)
+	}
+	if strings.Contains(strings.ToLower(got), "skip") {
+		t.Errorf("description %q must not claim an empty field skips Node", got)
+	}
+}
+
+// Nothing resolved is a case the wizard still has to describe, without naming a
+// source it does not have.
+func TestNodeVersionDescription_NoSource(t *testing.T) {
+	got := nodeVersionDescription("")
+	if got == "" || strings.Contains(strings.ToLower(got), "skip") {
+		t.Errorf("description %q should describe an empty field without claiming a skip", got)
+	}
+}

--- a/internal/node/detector.go
+++ b/internal/node/detector.go
@@ -38,28 +38,43 @@ func SafeVersion(v string) string {
 //  5. global config default
 func DetectVersion(dir string) (string, error) {
 	// 1. .lerd.yaml — explicit lerd override takes top priority
-	lerdYaml := filepath.Join(dir, ".lerd.yaml")
-	if data, err := os.ReadFile(lerdYaml); err == nil {
-		var lerdCfg struct {
-			NodeVersion string `yaml:"node_version"`
-		}
-		// Unlike .nvmrc and .node-version below, this value is not reduced to a
-		// numeric major, so a full pin survives. It still has to be version
-		// shaped: it is repository content and ends up on a command line.
-		if yaml.Unmarshal(data, &lerdCfg) == nil {
-			if v := SafeVersion(lerdCfg.NodeVersion); v != "" {
-				return v, nil
-			}
-		}
+	if v := pinnedVersion(dir); v != "" {
+		return v, nil
 	}
+	v, _ := UnpinnedVersion(dir)
+	return v, nil
+}
 
+// pinnedVersion returns the .lerd.yaml node_version override for dir, empty
+// when there is none. Unlike .nvmrc and .node-version it is not reduced to a
+// numeric major, so a full pin survives. It still has to be version shaped: it
+// is repository content and ends up on a command line.
+func pinnedVersion(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, ".lerd.yaml"))
+	if err != nil {
+		return ""
+	}
+	var lerdCfg struct {
+		NodeVersion string `yaml:"node_version"`
+	}
+	if yaml.Unmarshal(data, &lerdCfg) != nil {
+		return ""
+	}
+	return SafeVersion(lerdCfg.NodeVersion)
+}
+
+// UnpinnedVersion resolves the version dir gets while .lerd.yaml carries no
+// node_version, and names where that answer came from. The setup wizard writes
+// that pin, so the version an unanswered field accepts has to be resolved with
+// the pin left out of the order.
+func UnpinnedVersion(dir string) (version, source string) {
 	// 2. .nvmrc
 	nvmrc := filepath.Join(dir, ".nvmrc")
 	if data, err := os.ReadFile(nvmrc); err == nil {
 		v := strings.TrimSpace(string(data))
 		v = strings.TrimPrefix(v, "v")
 		if major := extractMajor(v); isNumericVersion(major) {
-			return major, nil
+			return major, ".nvmrc"
 		}
 	}
 
@@ -69,7 +84,7 @@ func DetectVersion(dir string) (string, error) {
 		v := strings.TrimSpace(string(data))
 		v = strings.TrimPrefix(v, "v")
 		if major := extractMajor(v); isNumericVersion(major) {
-			return major, nil
+			return major, ".node-version"
 		}
 	}
 
@@ -77,7 +92,7 @@ func DetectVersion(dir string) (string, error) {
 	// before package.json constraints would otherwise let any installed
 	// version satisfying engines.node win.
 	if site, ok := config.ParentSiteForWorktreeDir(dir); ok && site.NodeVersion != "" {
-		return site.NodeVersion, nil
+		return site.NodeVersion, "the parent checkout"
 	}
 
 	// 3. package.json engines.node
@@ -90,7 +105,7 @@ func DetectVersion(dir string) (string, error) {
 		}
 		if json.Unmarshal(data, &pkg) == nil && pkg.Engines.Node != "" {
 			if v := parseNodeConstraint(pkg.Engines.Node); v != "" {
-				return v, nil
+				return v, "package.json"
 			}
 		}
 	}
@@ -98,9 +113,9 @@ func DetectVersion(dir string) (string, error) {
 	// 4. global config default
 	cfg, err := config.LoadGlobal()
 	if err != nil {
-		return "22", nil
+		return "22", "the lerd default"
 	}
-	return cfg.Node.DefaultVersion, nil
+	return cfg.Node.DefaultVersion, "the lerd default"
 }
 
 // extractMajor returns the major version number from a semver-like string.

--- a/internal/node/detector_test.go
+++ b/internal/node/detector_test.go
@@ -159,6 +159,52 @@ func TestDetectVersion_noFiles_returnsDefault(t *testing.T) {
 	}
 }
 
+// ── UnpinnedVersion ──────────────────────────────────────────────────────────
+
+// The wizard offers the version a blank Node answer accepts, and the field it
+// offers it in writes the .lerd.yaml pin, so an existing pin must not be the
+// answer to that question.
+func TestUnpinnedVersion_ignoresLerdYAMLPin(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	os.WriteFile(filepath.Join(dir, ".lerd.yaml"), []byte("node_version: \"18\"\n"), 0644)
+	os.WriteFile(filepath.Join(dir, ".nvmrc"), []byte("20\n"), 0644)
+
+	if pinned, err := DetectVersion(dir); err != nil || pinned != "18" {
+		t.Fatalf("guard sanity: DetectVersion = %q, %v, want %q", pinned, err, "18")
+	}
+	got, source := UnpinnedVersion(dir)
+	if got != "20" || source != ".nvmrc" {
+		t.Errorf("UnpinnedVersion = %q from %q, want %q from %q", got, source, "20", ".nvmrc")
+	}
+}
+
+func TestUnpinnedVersion_namesTheSource(t *testing.T) {
+	cases := []struct {
+		name         string
+		files        map[string]string
+		want, source string
+	}{
+		{"nvmrc", map[string]string{".nvmrc": "20\n"}, "20", ".nvmrc"},
+		{"node-version file", map[string]string{".node-version": "v18.5.0\n"}, "18", ".node-version"},
+		{"package.json engines", map[string]string{"package.json": `{"engines":{"node":">=24"}}`}, "24", "package.json"},
+		{"nothing declared", nil, "22", "the lerd default"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			for name, body := range tc.files {
+				os.WriteFile(filepath.Join(dir, name), []byte(body), 0644)
+			}
+			got, source := UnpinnedVersion(dir)
+			if got != tc.want || source != tc.source {
+				t.Errorf("UnpinnedVersion = %q from %q, want %q from %q", got, source, tc.want, tc.source)
+			}
+		})
+	}
+}
+
 func TestDetectVersion_nvmrcOverridesPackageJSON(t *testing.T) {
 	dir := t.TempDir()
 	os.WriteFile(filepath.Join(dir, ".nvmrc"), []byte("20\n"), 0644)


### PR DESCRIPTION
The Node version field in the setup wizard described itself as "Leave blank to skip", which is not something that field can do. Whatever you type goes into .lerd.yaml as node_version, and that sits above .nvmrc, .node-version, package.json engines and the machine default in the detection order, so a blank answer never skipped Node, it only declined to pin a version. The question the field actually asks, which version, was answered nowhere on screen.

It now prefills the way the PHP field right above it does, from the saved value when there is one and otherwise from the version the project already resolves to, and the description says what an empty box falls back to instead, "Clear to follow .nvmrc instead of pinning". Working that fallback out means resolving the version with the pin left out of the order, since the pin is the thing being decided, so the Node detector grew UnpinnedVersion alongside DetectVersion and it reports which file the answer came from. Detection order and results are unchanged for every existing caller.

The docs pages that carry wizard transcripts were updated to match, and the project setup page now spells out that the field pins a version rather than switching Node on or off.

Closes #1430