### PR TITLE
fix: keep lerd's services and shims pointing at the binary after a package upgrade

### DIFF
--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -86,6 +86,10 @@ func main() {
 		// this runs for every command.
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.SilenceUsage = true
+			// A package manager that upgraded lerd swapped the binary and ran
+			// nothing else, so the environment step `lerd update` performs for a
+			// self-updating install happens here instead. No-op otherwise.
+			cli.ApplyPendingUpgrade(cmd)
 			return nil
 		},
 		// After any command that rebuilt a PHP image, reclaim the now-orphaned

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -152,6 +152,8 @@ Fetches the latest release from GitHub, downloads the binary for your architectu
 
 This applies to script and source installs in `~/.local/bin`. On a packaged install the binary is owned by apt or dnf, so `lerd update` prints that package manager's upgrade command instead of self-replacing; a Homebrew install updates with `brew upgrade lerd`.
 
+Replacing the binary is only half of an update: quadlets, DNS, nginx config, the user services and the shims all have to be reapplied, which `lerd update` does for you by re-running `lerd install`. A package manager does none of that, so the first lerd command you run at a terminal after the new binary lands reapplies it for you and says so. It runs once per version, and never on a machine where `lerd install` has not run yet, in a script, or from a daemon.
+
 You can also re-run the installer:
 
 ::: code-group
@@ -253,7 +255,7 @@ Recent Homebrew versions refuse to load formulae from third-party taps until the
 lerd update
 ```
 
-If you installed via Homebrew instead, update with `brew upgrade lerd && lerd install`.
+If you installed via Homebrew instead, update with `brew upgrade lerd`. The `lerd install` that finishes an update is applied for you by the first lerd command you run at a terminal afterwards, and running it yourself does no harm.
 
 If you're running a local development build (a `git describe` version like `1.25.0-6-g7d03`), the one-line installer and `--update` detect it and ask before replacing it with a release binary, so an ahead-of-release build isn't overwritten silently. Decline to keep your build, or reinstall one explicitly with `install.sh --local <path>`.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -138,7 +138,7 @@ lerd install
 
 Unlike on macOS, Podman is not pulled in as a Homebrew dependency: lerd integrates with the distribution's own Podman, so install that with your package manager first. Homebrew itself needs its usual Linux prerequisites, notably a C compiler such as gcc, even though the formula only unpacks a prebuilt binary. If Homebrew refuses the tap as untrusted, run `brew trust lerd-env/lerd` once.
 
-Update with `brew upgrade lerd`. Homebrew installs every version into its own directory, so an upgrade moves the binary; the next `lerd start` repoints the user services and the shims at the new location.
+Update with `brew upgrade lerd`. Homebrew installs every version into its own directory, so an upgrade moves the binary; the next `lerd start` repoints the user services and the shims at the new location and says which ones it moved.
 
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -138,7 +138,7 @@ lerd install
 
 Unlike on macOS, Podman is not pulled in as a Homebrew dependency: lerd integrates with the distribution's own Podman, so install that with your package manager first. Homebrew itself needs its usual Linux prerequisites, notably a C compiler such as gcc, even though the formula only unpacks a prebuilt binary. If Homebrew refuses the tap as untrusted, run `brew trust lerd-env/lerd` once.
 
-Update with `brew upgrade lerd`.
+Update with `brew upgrade lerd`. Homebrew installs every version into its own directory, so an upgrade moves the binary; the next `lerd start` repoints the user services and the shims at the new location.
 
 ---
 

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -42,6 +42,10 @@ A live spinner shows the per-unit progress. If a single SSL vhost references a m
 If you ran `lerd uninstall` and then reinstalled, worker units and service quadlets are recreated by `lerd start` from each site's `.lerd.yaml`. Sites with a committed `.lerd.yaml` come back fully wired up. Sites without one need their workers restarted manually.
 :::
 
+::: info After the binary moves
+The `lerd-ui`, `lerd-watcher` and `lerd-tray` services and the shims on your `PATH` (`php`, `composer`, `laravel`, the client tools) all record where the lerd binary is. A package manager that installs each version into its own directory, Homebrew above all, retires that path on the next upgrade. `lerd start` rewrites the services to point at the binary that is running and repoints any shim whose path has gone, and the shims themselves fall back to whatever `lerd` is on your `PATH`.
+:::
+
 ::: info Deleted project directories are auto-cleaned
 `lerd-watcher` removes sites from `sites.yaml` whenever their project directory disappears on disk. Two paths do this:
 

--- a/internal/cli/binpath_heal.go
+++ b/internal/cli/binpath_heal.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/services"
+	lerdSystemd "github.com/geodro/lerd/internal/systemd"
+)
+
+// daemonUnits are the lerd services whose ExecStart names the lerd binary, so
+// they are the ones a moved binary takes down. lerd-autostart is macOS-only and
+// reads as absent elsewhere.
+var daemonUnits = []string{"lerd-ui", "lerd-watcher", "lerd-tray", "lerd-autostart"}
+
+// healLerdBinaryMove repairs what a lerd binary that moved leaves behind. A
+// package manager can replace lerd underneath a working install: `brew upgrade
+// lerd` retires the previous version's keg, and every unit and shim written
+// against it then runs a path that is gone, which surfaces as daemons failing
+// with a bare exit status 203 and `php` reporting no such file (#1432).
+func healLerdBinaryMove() {
+	healDaemonUnits()
+	healShimBinaryPaths(config.LerdBinary())
+}
+
+// healDaemonUnits rewrites daemon units whose ExecStart names a binary that is
+// no longer on disk, so they run the lerd that is installed now. A unit that
+// still resolves is left alone, which keeps a start from a checkout build from
+// quietly taking the login daemons with it.
+func healDaemonUnits() {
+	for _, name := range daemonUnits {
+		installed := services.InstalledUnitBinary(name)
+		if installed == "" {
+			continue
+		}
+		if _, err := os.Stat(installed); err == nil {
+			continue
+		}
+		content, err := lerdSystemd.GetUnit(name)
+		if err != nil {
+			continue
+		}
+		if err := writeUserServiceWithReload(name, content); err != nil {
+			fmt.Printf("  WARN: repointing the %s unit at %s: %v\n", name, config.LerdBinary(), err)
+		}
+	}
+}
+
+// healShimBinaryPaths repoints shims in lerd's bin dir that run a lerd binary
+// which is no longer on disk. Only a dead path is rewritten: a shim that still
+// resolves is left exactly as installed, so starting a build from a checkout
+// never takes the user's shims with it.
+func healShimBinaryPaths(lerdBin string) {
+	if info, err := os.Stat(lerdBin); err != nil || info.IsDir() {
+		return
+	}
+	binDir := config.BinDir()
+	entries, err := os.ReadDir(binDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(binDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil || !strings.HasPrefix(string(data), "#!") {
+			continue
+		}
+		healed, changed := healedShim(string(data), lerdBin)
+		if !changed {
+			continue
+		}
+		if err := os.WriteFile(path, []byte(healed), 0755); err != nil {
+			fmt.Printf("  WARN: repointing the %s shim at %s: %v\n", entry.Name(), lerdBin, err)
+		}
+	}
+}
+
+// healedShim swaps every absolute path to a lerd binary that is not there any
+// more for lerdBin. Anything else the shim runs (composer.phar, a version
+// manager, the tool itself) is left alone.
+func healedShim(content, lerdBin string) (string, bool) {
+	changed := false
+	for _, token := range shimTokens(content) {
+		if token == lerdBin || !filepath.IsAbs(token) || filepath.Base(token) != "lerd" {
+			continue
+		}
+		if _, err := os.Stat(token); err == nil {
+			continue
+		}
+		content = strings.ReplaceAll(content, token, lerdBin)
+		changed = true
+	}
+	return content, changed
+}
+
+// shimTokens splits shim source into the words a shell would see, so a path is
+// recognised whether it was written bare or quoted.
+func shimTokens(content string) []string {
+	return strings.FieldsFunc(content, func(r rune) bool {
+		return unicode.IsSpace(r) || r == '"' || r == '\''
+	})
+}

--- a/internal/cli/binpath_heal.go
+++ b/internal/cli/binpath_heal.go
@@ -17,21 +17,35 @@ import (
 // reads as absent elsewhere.
 var daemonUnits = []string{"lerd-ui", "lerd-watcher", "lerd-tray", "lerd-autostart"}
 
-// healLerdBinaryMove repairs what a lerd binary that moved leaves behind. A
-// package manager can replace lerd underneath a working install: `brew upgrade
-// lerd` retires the previous version's keg, and every unit and shim written
-// against it then runs a path that is gone, which surfaces as daemons failing
-// with a bare exit status 203 and `php` reporting no such file (#1432).
-func healLerdBinaryMove() {
-	healDaemonUnits()
-	healShimBinaryPaths(config.LerdBinary())
+// healLerdBinaryMove repairs what a lerd binary that moved leaves behind, and
+// reports what it rewrote. A package manager can replace lerd underneath a
+// working install: `brew upgrade lerd` retires the previous version's keg, and
+// every unit and shim written against it then runs a path that is gone, which
+// surfaces as daemons failing with a bare exit status 203 and `php` reporting
+// no such file (#1432).
+func healLerdBinaryMove() (units, shims []string) {
+	return healDaemonUnits(), healShimBinaryPaths(config.LerdBinary())
+}
+
+// repairSummary is the line the start prints once a move has been repaired, so
+// a rewrite of the user's own files is never silent.
+func repairSummary(units, shims []string) string {
+	var parts []string
+	if len(units) > 0 {
+		parts = append(parts, "services "+strings.Join(units, ", "))
+	}
+	if len(shims) > 0 {
+		parts = append(parts, "shims "+strings.Join(shims, ", "))
+	}
+	return "Repointed " + strings.Join(parts, " and ") + " at " + config.LerdBinary()
 }
 
 // healDaemonUnits rewrites daemon units whose ExecStart names a binary that is
 // no longer on disk, so they run the lerd that is installed now. A unit that
 // still resolves is left alone, which keeps a start from a checkout build from
 // quietly taking the login daemons with it.
-func healDaemonUnits() {
+func healDaemonUnits() []string {
+	var healed []string
 	for _, name := range daemonUnits {
 		installed := services.InstalledUnitBinary(name)
 		if installed == "" {
@@ -44,25 +58,34 @@ func healDaemonUnits() {
 		if err != nil {
 			continue
 		}
+		// Nothing to gain when the rewrite would name the same missing file,
+		// which is what a host without the tray helper installed looks like.
+		if services.UnitExecBinary(content) == installed {
+			continue
+		}
 		if err := writeUserServiceWithReload(name, content); err != nil {
 			fmt.Printf("  WARN: repointing the %s unit at %s: %v\n", name, config.LerdBinary(), err)
+			continue
 		}
+		healed = append(healed, name)
 	}
+	return healed
 }
 
 // healShimBinaryPaths repoints shims in lerd's bin dir that run a lerd binary
 // which is no longer on disk. Only a dead path is rewritten: a shim that still
 // resolves is left exactly as installed, so starting a build from a checkout
 // never takes the user's shims with it.
-func healShimBinaryPaths(lerdBin string) {
+func healShimBinaryPaths(lerdBin string) []string {
 	if info, err := os.Stat(lerdBin); err != nil || info.IsDir() {
-		return
+		return nil
 	}
 	binDir := config.BinDir()
 	entries, err := os.ReadDir(binDir)
 	if err != nil {
-		return
+		return nil
 	}
+	var healed []string
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -72,14 +95,17 @@ func healShimBinaryPaths(lerdBin string) {
 		if err != nil || !strings.HasPrefix(string(data), "#!") {
 			continue
 		}
-		healed, changed := healedShim(string(data), lerdBin)
+		repaired, changed := healedShim(string(data), lerdBin)
 		if !changed {
 			continue
 		}
-		if err := os.WriteFile(path, []byte(healed), 0755); err != nil {
+		if err := os.WriteFile(path, []byte(repaired), 0755); err != nil {
 			fmt.Printf("  WARN: repointing the %s shim at %s: %v\n", entry.Name(), lerdBin, err)
+			continue
 		}
+		healed = append(healed, entry.Name())
 	}
+	return healed
 }
 
 // healedShim swaps every absolute path to a lerd binary that is not there any

--- a/internal/cli/binpath_heal_linux_test.go
+++ b/internal/cli/binpath_heal_linux_test.go
@@ -1,0 +1,58 @@
+//go:build linux
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// The daemons are the loudest symptom: their ExecStart names the retired keg,
+// so systemd can only report exit status 203 until the unit is rewritten.
+func TestHealDaemonUnitsRewritesUnitsWithAGoneBinary(t *testing.T) {
+	writeInstalledUnit(t, "lerd-ui", "/home/linuxbrew/.linuxbrew/Cellar/lerd/1.31.0/bin/lerd serve-ui")
+	fake := &fakeServiceMgr{writeChanged: true}
+	swapMgr(t, fake)
+
+	healDaemonUnits()
+
+	if !equalStrings(fake.calls, []string{"write:lerd-ui", "reload"}) {
+		t.Errorf("expected the lerd-ui unit to be rewritten and reloaded, got %v", fake.calls)
+	}
+}
+
+// A daemon whose binary is where the unit says it is must be left alone: a
+// start from a checkout build has no business repointing the login daemons.
+func TestHealDaemonUnitsLeavesResolvableUnitsAlone(t *testing.T) {
+	live := filepath.Join(t.TempDir(), "lerd")
+	if err := os.WriteFile(live, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeInstalledUnit(t, "lerd-ui", live+" serve-ui")
+	fake := &fakeServiceMgr{writeChanged: true}
+	swapMgr(t, fake)
+
+	healDaemonUnits()
+
+	if len(fake.calls) != 0 {
+		t.Errorf("a working unit was rewritten: %v", fake.calls)
+	}
+}
+
+// writeInstalledUnit puts a unit file with the given ExecStart in a temp
+// systemd user dir, standing in for what a previous install left behind.
+func writeInstalledUnit(t *testing.T, name, execStart string) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir := config.SystemdUserDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	unit := "[Service]\nType=notify\nExecStart=" + execStart + "\n"
+	if err := os.WriteFile(filepath.Join(dir, name+".service"), []byte(unit), 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/binpath_heal_linux_test.go
+++ b/internal/cli/binpath_heal_linux_test.go
@@ -17,10 +17,13 @@ func TestHealDaemonUnitsRewritesUnitsWithAGoneBinary(t *testing.T) {
 	fake := &fakeServiceMgr{writeChanged: true}
 	swapMgr(t, fake)
 
-	healDaemonUnits()
+	healed := healDaemonUnits()
 
 	if !equalStrings(fake.calls, []string{"write:lerd-ui", "reload"}) {
 		t.Errorf("expected the lerd-ui unit to be rewritten and reloaded, got %v", fake.calls)
+	}
+	if !equalStrings(healed, []string{"lerd-ui"}) {
+		t.Errorf("healDaemonUnits() = %v; want the repair reported so the start can say so", healed)
 	}
 }
 
@@ -35,10 +38,28 @@ func TestHealDaemonUnitsLeavesResolvableUnitsAlone(t *testing.T) {
 	fake := &fakeServiceMgr{writeChanged: true}
 	swapMgr(t, fake)
 
-	healDaemonUnits()
+	if healed := healDaemonUnits(); len(healed) != 0 {
+		t.Errorf("healDaemonUnits() = %v; want nothing repaired", healed)
+	}
 
 	if len(fake.calls) != 0 {
 		t.Errorf("a working unit was rewritten: %v", fake.calls)
+	}
+}
+
+// A host with no tray helper installed carries a lerd-tray unit whose
+// ExecStart is missing and stays missing however often it is rewritten.
+// Repairing that on every start would report work it never did.
+func TestHealDaemonUnitsSkipsAUnitTheRewriteCannotFix(t *testing.T) {
+	writeInstalledUnit(t, "lerd-tray", filepath.Join(filepath.Dir(config.LerdBinary()), "lerd-tray"))
+	fake := &fakeServiceMgr{writeChanged: true}
+	swapMgr(t, fake)
+
+	if healed := healDaemonUnits(); len(healed) != 0 {
+		t.Errorf("healDaemonUnits() = %v; want nothing reported", healed)
+	}
+	if len(fake.calls) != 0 {
+		t.Errorf("the unit was rewritten to the same content: %v", fake.calls)
 	}
 }
 

--- a/internal/cli/binpath_heal_test.go
+++ b/internal/cli/binpath_heal_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// A Homebrew upgrade retires the keg the shims were written with, so every shim
+// execs a path that is no longer there. Starting lerd points them back at the
+// binary that is actually installed.
+func TestHealShimBinaryPathsRepointsShimsAtTheLiveBinary(t *testing.T) {
+	binDir, current := shimHealFixture(t)
+	gone := "/home/linuxbrew/.linuxbrew/Cellar/lerd/1.31.0/bin/lerd"
+	writeShim(t, binDir, "php", "#!/bin/sh\nLERD=\""+gone+"\"\n[ -x \"$LERD\" ] || LERD=lerd\nexec \"$LERD\" php \"$@\"\n")
+	writeShim(t, binDir, "mysql", "#!/bin/sh\n# lerd client shim\nexec "+gone+" client-exec mysql \"$@\"\n")
+
+	healShimBinaryPaths(current)
+
+	for _, tool := range []string{"php", "mysql"} {
+		shim := readShim(t, binDir, tool)
+		if strings.Contains(shim, gone) {
+			t.Errorf("%s shim still runs the retired %s:\n%s", tool, gone, shim)
+		}
+		if !strings.Contains(shim, current) {
+			t.Errorf("%s shim does not run %s:\n%s", tool, current, shim)
+		}
+	}
+}
+
+// A shim whose binary is where it says it is must be left exactly as written:
+// the heal is a repair, not a chance to repoint a working install at whatever
+// binary happens to be running.
+func TestHealShimBinaryPathsLeavesWorkingShimsAlone(t *testing.T) {
+	binDir, current := shimHealFixture(t)
+	other := filepath.Join(filepath.Dir(current), "lerd-other")
+	if err := os.WriteFile(other, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	body := "#!/bin/sh\nexec " + other + " php \"$@\"\n"
+	writeShim(t, binDir, "php", body)
+
+	healShimBinaryPaths(current)
+
+	if got := readShim(t, binDir, "php"); got != body {
+		t.Errorf("php shim was rewritten:\n%s", got)
+	}
+}
+
+// Paths that are not a lerd binary stay untouched, notably the composer.phar
+// the composer shim falls back to.
+func TestHealShimBinaryPathsKeepsNonBinaryPaths(t *testing.T) {
+	binDir, current := shimHealFixture(t)
+	gone := "/opt/homebrew/Cellar/lerd/1.31.0/bin/lerd"
+	phar := filepath.Join(binDir, "composer.phar")
+	writeShim(t, binDir, "composer", "#!/bin/sh\nLERD=\""+gone+"\"\nexec \"$LERD\" php "+phar+" \"$@\"\n")
+
+	healShimBinaryPaths(current)
+
+	shim := readShim(t, binDir, "composer")
+	if !strings.Contains(shim, phar) {
+		t.Errorf("composer shim lost the phar path %s:\n%s", phar, shim)
+	}
+	if !strings.Contains(shim, current) {
+		t.Errorf("composer shim does not run %s:\n%s", current, shim)
+	}
+}
+
+// Nothing is rewritten when the replacement is not on disk either, so a probe
+// that cannot resolve the binary never makes matters worse.
+func TestHealShimBinaryPathsSkipsWhenTheBinaryIsMissing(t *testing.T) {
+	binDir, current := shimHealFixture(t)
+	body := "#!/bin/sh\nexec /gone/lerd php \"$@\"\n"
+	writeShim(t, binDir, "php", body)
+
+	healShimBinaryPaths(filepath.Join(filepath.Dir(current), "absent"))
+
+	if got := readShim(t, binDir, "php"); got != body {
+		t.Errorf("php shim was rewritten:\n%s", got)
+	}
+}
+
+// shimHealFixture points lerd's data dir at a temp dir and returns the shim dir
+// alongside an installed lerd binary to heal towards.
+func shimHealFixture(t *testing.T) (binDir, lerdBin string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dir)
+	binDir = config.BinDir()
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	lerdBin = filepath.Join(dir, "opt", "lerd", "bin", "lerd")
+	if err := os.MkdirAll(filepath.Dir(lerdBin), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lerdBin, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return binDir, lerdBin
+}
+
+func writeShim(t *testing.T, binDir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(binDir, name), []byte(body), 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readShim(t *testing.T, binDir, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(binDir, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/internal/cli/binpath_heal_test.go
+++ b/internal/cli/binpath_heal_test.go
@@ -83,6 +83,33 @@ func TestHealShimBinaryPathsSkipsWhenTheBinaryIsMissing(t *testing.T) {
 	}
 }
 
+// A repair rewrites files the user did not ask lerd to touch, so the start has
+// to name what it moved.
+func TestRepairSummaryNamesWhatMoved(t *testing.T) {
+	summary := repairSummary([]string{"lerd-ui"}, []string{"php", "composer"})
+
+	for _, want := range []string{"lerd-ui", "php", "composer", config.LerdBinary()} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("summary %q does not mention %q", summary, want)
+		}
+	}
+}
+
+// A lerd that resolves to a directory is not something to heal towards, so the
+// walk stops rather than writing nonsense into every shim.
+func TestHealShimBinaryPathsIgnoresADirectory(t *testing.T) {
+	binDir, current := shimHealFixture(t)
+	body := "#!/bin/sh\nexec /gone/lerd php \"$@\"\n"
+	writeShim(t, binDir, "php", body)
+
+	if healed := healShimBinaryPaths(filepath.Dir(current)); len(healed) != 0 {
+		t.Errorf("healShimBinaryPaths() = %v; want nothing repaired", healed)
+	}
+	if got := readShim(t, binDir, "php"); got != body {
+		t.Errorf("php shim was rewritten:\n%s", got)
+	}
+}
+
 // shimHealFixture points lerd's data dir at a temp dir and returns the shim dir
 // alongside an installed lerd binary to heal towards.
 func shimHealFixture(t *testing.T) (binDir, lerdBin string) {

--- a/internal/cli/composer_exec.go
+++ b/internal/cli/composer_exec.go
@@ -39,11 +39,7 @@ func runComposer(args []string) error {
 
 	// Sync regardless of composer exit status, so a `composer global remove`
 	// that fails partway still cleans up wrappers whose source bin is gone.
-	lerdBin, _ := os.Executable()
-	if lerdBin == "" {
-		home, _ := os.UserHomeDir()
-		lerdBin = filepath.Join(home, ".local", "bin", "lerd")
-	}
+	lerdBin := config.LerdBinary()
 	if syncErr := syncComposerGlobalBins(composerGlobalBinDir(), config.BinDir(), lerdBin); syncErr != nil {
 		fmt.Fprintf(os.Stderr, "lerd: warning: failed to sync composer global wrappers: %v\n", syncErr)
 	}

--- a/internal/cli/dns.go
+++ b/internal/cli/dns.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -367,11 +366,7 @@ func forwarderHolderFallbackHint(goos string, port int) string {
 // rendered as a systemd .service on Linux and a launchd plist on macOS
 // (see services/launchd_darwin.go::parseServiceUnit). Idempotent.
 func installDNSForwarderUnit(lanIP string) error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-	binPath := filepath.Join(home, ".local", "bin", "lerd")
+	binPath := config.LerdBinary()
 	content := fmt.Sprintf(`[Unit]
 Description=Lerd DNS LAN Forwarder (rootless pasta workaround)
 After=lerd-dns.service

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1710,18 +1710,24 @@ func readLine(r io.Reader) string {
 	return b.String()
 }
 
+// shimPreamble opens a shim with the lerd binary it should run: the path
+// recorded when the shim was written, or plain `lerd` from PATH when that path
+// has gone. A package manager that moves the binary under lerd's feet (a
+// Homebrew upgrade retires the previous version's keg) would otherwise leave
+// every shim pointing at a file that is no longer there.
+func shimPreamble(lerdBin string) string {
+	return fmt.Sprintf("#!/bin/sh\nLERD=%q\n[ -x \"$LERD\" ] || LERD=lerd\n", lerdBin)
+}
+
 func addShellShims(manageNode bool) error {
 	home, _ := os.UserHomeDir()
 	binDir := config.BinDir()
 	// Use the running binary so shims work regardless of install method
-	// (Homebrew at /opt/homebrew/bin/lerd, manual at ~/.local/bin/lerd, etc.).
-	lerdBin, _ := os.Executable()
-	if lerdBin == "" {
-		lerdBin = filepath.Join(home, ".local", "bin", "lerd")
-	}
+	// (Homebrew at /opt/homebrew/opt/lerd/bin/lerd, manual at ~/.local/bin/lerd).
+	lerdBin := config.LerdBinary()
 
 	// Write php shim
-	phpShim := fmt.Sprintf("#!/bin/sh\nexec %s php \"$@\"\n", lerdBin)
+	phpShim := shimPreamble(lerdBin) + "exec \"$LERD\" php \"$@\"\n"
 	if err := os.WriteFile(filepath.Join(binDir, "php"), []byte(phpShim), 0755); err != nil {
 		return fmt.Errorf("writing php shim: %w", err)
 	}
@@ -1730,7 +1736,7 @@ func addShellShims(manageNode bool) error {
 	// land in lerd's bin dir as wrappers (mirroring the npm flow), falling
 	// back to a direct `lerd php composer.phar` invocation when the lerd
 	// binary is not reachable (containers where the glibc binary can't run).
-	composerShim := fmt.Sprintf("#!/bin/sh\nLERD=%q\nif [ -x \"$LERD\" ]; then\n  exec \"$LERD\" composer \"$@\"\nfi\nexec %s php %s/.local/share/lerd/bin/composer.phar \"$@\"\n", lerdBin, lerdBin, home)
+	composerShim := shimPreamble(lerdBin) + fmt.Sprintf("if [ -x \"$LERD\" ]; then\n  exec \"$LERD\" composer \"$@\"\nfi\nexec \"$LERD\" php %s/.local/share/lerd/bin/composer.phar \"$@\"\n", home)
 	if err := os.WriteFile(filepath.Join(binDir, "composer"), []byte(composerShim), 0755); err != nil {
 		return fmt.Errorf("writing composer shim: %w", err)
 	}
@@ -1744,7 +1750,7 @@ func addShellShims(manageNode bool) error {
 		}
 		composerHome = filepath.Join(xdgConfig, "composer")
 	}
-	laravelShim := fmt.Sprintf("#!/bin/sh\nexec %s php %s/vendor/bin/laravel \"$@\"\n", lerdBin, composerHome)
+	laravelShim := shimPreamble(lerdBin) + fmt.Sprintf("exec \"$LERD\" php %s/vendor/bin/laravel \"$@\"\n", composerHome)
 	if err := os.WriteFile(filepath.Join(binDir, "laravel"), []byte(laravelShim), 0755); err != nil {
 		return fmt.Errorf("writing laravel shim: %w", err)
 	}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -26,6 +26,7 @@ import (
 	"github.com/geodro/lerd/internal/store"
 	lerdSystemd "github.com/geodro/lerd/internal/systemd"
 	"github.com/geodro/lerd/internal/tray"
+	"github.com/geodro/lerd/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -1088,6 +1089,10 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	refreshStorePresets()
 	refreshGlobalMCPSkills()
 	refreshProjectMCPSkills()
+
+	// Record which version this environment is set up for, so a binary a
+	// package manager swaps underneath it is recognised on the next command.
+	writeInstalledVersion(version.Version)
 
 	feedback.Begin()
 	feedback.Done("lerd installation complete")

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -509,6 +510,32 @@ func TestAddShellShims_ComposerShimDelegatesToLerd(t *testing.T) {
 	}
 	if !strings.Contains(shim, "composer.phar") {
 		t.Errorf("composer shim should keep a composer.phar fallback path, got:\n%s", shim)
+	}
+}
+
+// A shim outlives the binary it was written against: `brew upgrade lerd` moves
+// lerd into a new keg and the recorded path stops resolving. The shim has to
+// reach for lerd on PATH rather than fail with no such file.
+func TestShimPreambleFallsBackToLerdOnPath(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "lerd")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\necho \"ran $*\"\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(dir, "php")
+	body := shimPreamble("/retired/keg/bin/lerd") + "exec \"$LERD\" php \"$@\"\n"
+	if err := os.WriteFile(script, []byte(body), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(script, "-v")
+	cmd.Env = append(os.Environ(), "PATH="+dir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("shim failed: %v\n%s\n%s", err, out, body)
+	}
+	if strings.TrimSpace(string(out)) != "ran php -v" {
+		t.Errorf("shim did not fall back to lerd on PATH, got: %q", out)
 	}
 }
 

--- a/internal/cli/post_upgrade.go
+++ b/internal/cli/post_upgrade.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/geodro/lerd/internal/config"
+	"github.com/geodro/lerd/internal/feedback"
+	"github.com/geodro/lerd/internal/version"
+)
+
+// upgradeSkipCommands never trigger the reapply: `install` is what the reapply
+// runs, the others either do their own or are daemons that would be restarted
+// out from under themselves.
+var upgradeSkipCommands = map[string]bool{
+	"install":       true,
+	"bootstrap":     true,
+	"update":        true,
+	"uninstall":     true,
+	"serve-ui":      true,
+	"watch":         true,
+	"tray":          true,
+	"mcp":           true,
+	"dns-forwarder": true,
+}
+
+// devVersion matches the `git describe` versions a build from a checkout
+// carries, which change with every commit.
+var devVersion = regexp.MustCompile(`-\d+-g[0-9a-f]+`)
+
+// ApplyPendingUpgrade reapplies the environment when the binary was replaced
+// since the last install. `lerd update` already does this for a self-updating
+// install by re-execing `lerd install --from-update`; a package manager swaps
+// the binary and runs nothing, so brew, apt and dnf installs were left with the
+// second half of the install never happening (#1432).
+func ApplyPendingUpgrade(cmd *cobra.Command) {
+	running := version.Version
+	if !shouldApplyUpgrade(topLevelCommand(cmd), running, readInstalledVersion(), isSetUp(), interactiveTerminal()) {
+		return
+	}
+
+	// Record it first so a second shell doesn't start the same reapply, and
+	// clear it again on failure so the next command tries once more.
+	writeInstalledVersion(running)
+	feedback.Begin()
+	feedback.Line("lerd was upgraded to v" + running + ", applying infrastructure changes")
+	if err := reexecInstallReconcile(); err != nil {
+		clearInstalledVersion()
+		feedback.Warn("could not finish applying the upgrade, run `lerd install`: %v", err)
+	}
+}
+
+// shouldApplyUpgrade reports whether this invocation is the one to reapply the
+// environment: a set-up install, running a release it has not set up yet, on a
+// command at a terminal that can afford the wait.
+func shouldApplyUpgrade(command, running, installed string, setUp, interactive bool) bool {
+	if !isReleaseVersion(running) || !setUp || !interactive {
+		return false
+	}
+	if upgradeSkipCommands[command] {
+		return false
+	}
+	return installed != running
+}
+
+// isReleaseVersion reports whether the running binary is one a user could have
+// installed from a release, as opposed to a build from a checkout.
+func isReleaseVersion(v string) bool {
+	if v == "" || v == "dev" || strings.Contains(v, "dirty") {
+		return false
+	}
+	return !devVersion.MatchString(v)
+}
+
+// topLevelCommand names the command as the user typed it after `lerd`, so a
+// subcommand is judged by the group it belongs to.
+func topLevelCommand(cmd *cobra.Command) string {
+	if cmd == nil {
+		return ""
+	}
+	for cmd.Parent() != nil && cmd.Parent().Parent() != nil {
+		cmd = cmd.Parent()
+	}
+	return cmd.Name()
+}
+
+// isSetUp reports whether `lerd install` has ever run on this machine. A fresh
+// package install has a binary and nothing else, and the install it still owes
+// asks questions that must not be answered behind the user's back.
+func isSetUp() bool {
+	_, err := os.Stat(config.GlobalConfigFile())
+	return err == nil
+}
+
+// interactiveTerminal reports whether there is someone to watch an install
+// that restarts services and can take minutes. A script, a daemon or a shim in
+// a pipe is left alone.
+func interactiveTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+func readInstalledVersion() string {
+	data, err := os.ReadFile(config.InstalledVersionFile())
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func writeInstalledVersion(v string) {
+	path := config.InstalledVersionFile()
+	if err := os.MkdirAll(config.DataDir(), 0755); err != nil {
+		return
+	}
+	_ = os.WriteFile(path, []byte(v+"\n"), 0644)
+}
+
+func clearInstalledVersion() {
+	_ = os.Remove(config.InstalledVersionFile())
+}

--- a/internal/cli/post_upgrade_test.go
+++ b/internal/cli/post_upgrade_test.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// A package manager swaps the binary and runs nothing else, so the first
+// command after the swap is what has to reapply the environment.
+func TestShouldApplyUpgradeOnAVersionItHasNotSetUpYet(t *testing.T) {
+	if !shouldApplyUpgrade("php", "1.32.0", "1.31.0", true, true) {
+		t.Error("a set-up install running a newer binary should reapply the environment")
+	}
+}
+
+func TestShouldApplyUpgradeSkipsWhenTheVersionIsUnchanged(t *testing.T) {
+	if shouldApplyUpgrade("php", "1.32.0", "1.32.0", true, true) {
+		t.Error("nothing changed, so nothing should run")
+	}
+}
+
+// A fresh package install has a binary and no environment. The install is the
+// user's own next step, and running it behind their back on the first command
+// would take the choices that step asks them.
+func TestShouldApplyUpgradeSkipsAMachineThatWasNeverSetUp(t *testing.T) {
+	if shouldApplyUpgrade("php", "1.32.0", "", false, true) {
+		t.Error("a machine with no lerd install should be left to `lerd install`")
+	}
+}
+
+// Every install predating the stamp has no recorded version, so the upgrade
+// that introduces it is the one that reapplies the environment once.
+func TestShouldApplyUpgradeOnAnInstallFromBeforeTheStamp(t *testing.T) {
+	if !shouldApplyUpgrade("php", "1.32.0", "", true, true) {
+		t.Error("a set-up install with no recorded version should reapply once")
+	}
+}
+
+// Reapplying restarts services and can take minutes, which is not something to
+// spring on a script, a daemon or a pipe.
+func TestShouldApplyUpgradeSkipsWithoutATerminal(t *testing.T) {
+	if shouldApplyUpgrade("php", "1.32.0", "1.31.0", true, false) {
+		t.Error("a non-interactive invocation should not start an install")
+	}
+}
+
+// The install is what the reapply runs, so triggering from it would recurse,
+// and the commands that already reapply have no need of a second pass.
+func TestShouldApplyUpgradeSkipsTheCommandsThatRunItThemselves(t *testing.T) {
+	for _, name := range []string{"install", "update", "bootstrap", "uninstall", "serve-ui", "watch", "mcp"} {
+		if shouldApplyUpgrade(name, "1.32.0", "1.31.0", true, true) {
+			t.Errorf("%s should not trigger the reapply", name)
+		}
+	}
+}
+
+// A build from a checkout carries a git describe version that changes with
+// every commit, so honouring it would reinstall the environment all day.
+func TestShouldApplyUpgradeSkipsDevelopmentBuilds(t *testing.T) {
+	for _, v := range []string{"1.32.0-12-g5ca3460", "1.32.0-12-g5ca3460-dirty", "", "dev"} {
+		if shouldApplyUpgrade("php", v, "1.31.0", true, true) {
+			t.Errorf("version %q should not trigger the reapply", v)
+		}
+	}
+}
+
+// A release the user can actually be running, betas included, does trigger.
+func TestIsReleaseVersionAcceptsReleases(t *testing.T) {
+	for _, v := range []string{"1.32.0", "1.33.0-beta.1"} {
+		if !isReleaseVersion(v) {
+			t.Errorf("isReleaseVersion(%q) = false; want true", v)
+		}
+	}
+}
+
+// The skip list is written in the words the user types, so a subcommand has to
+// be judged by the command it belongs to rather than its own leaf name.
+func TestTopLevelCommandNamesTheGroup(t *testing.T) {
+	root := &cobra.Command{Use: "lerd"}
+	group := &cobra.Command{Use: "service"}
+	leaf := &cobra.Command{Use: "start"}
+	group.AddCommand(leaf)
+	root.AddCommand(group)
+
+	if got := topLevelCommand(leaf); got != "service" {
+		t.Errorf("topLevelCommand() = %q; want %q", got, "service")
+	}
+	if got := topLevelCommand(group); got != "service" {
+		t.Errorf("topLevelCommand() = %q; want %q", got, "service")
+	}
+}
+
+func TestInstalledVersionRoundTrips(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	if got := readInstalledVersion(); got != "" {
+		t.Errorf("readInstalledVersion() = %q on a fresh machine; want empty", got)
+	}
+	writeInstalledVersion("1.32.0")
+	if got := readInstalledVersion(); got != "1.32.0" {
+		t.Errorf("readInstalledVersion() = %q; want %q", got, "1.32.0")
+	}
+}
+
+// The stamp records that the environment step ran, so a half-applied upgrade
+// has to leave it alone and try again on the next command.
+func TestClearInstalledVersionLetsAFailedReapplyRetry(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	writeInstalledVersion("1.32.0")
+
+	clearInstalledVersion()
+
+	if got := readInstalledVersion(); got != "" {
+		t.Errorf("readInstalledVersion() = %q after clearing; want empty", got)
+	}
+}
+
+func TestIsSetUpFollowsTheGlobalConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if isSetUp() {
+		t.Error("isSetUp() = true with no global config")
+	}
+	if err := os.MkdirAll(filepath.Dir(config.GlobalConfigFile()), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.GlobalConfigFile(), []byte("dns:\n  tld: test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !isSetUp() {
+		t.Error("isSetUp() = false with a global config on disk")
+	}
+}

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -538,7 +538,9 @@ func runStart(_ *cobra.Command, _ []string) error {
 
 	// Repair units and shims left pointing at a lerd binary that moved, which
 	// is what a package-manager upgrade of lerd itself does to an install.
-	healLerdBinaryMove()
+	if units, shims := healLerdBinaryMove(); len(units)+len(shims) > 0 {
+		fmt.Println("  " + repairSummary(units, shims))
+	}
 
 	// Restore quadlets and worker units that may be missing after an
 	// uninstall/reinstall cycle. Reads .lerd.yaml from each active site.

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -536,6 +536,10 @@ func runStart(_ *cobra.Command, _ []string) error {
 		}
 	}
 
+	// Repair units and shims left pointing at a lerd binary that moved, which
+	// is what a package-manager upgrade of lerd itself does to an install.
+	healLerdBinaryMove()
+
 	// Restore quadlets and worker units that may be missing after an
 	// uninstall/reinstall cycle. Reads .lerd.yaml from each active site.
 	restoreSiteInfrastructure()

--- a/internal/config/lerd_binary.go
+++ b/internal/config/lerd_binary.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// selfExecutable is a seam for tests.
+var selfExecutable = os.Executable
+
+// LerdBinary returns the absolute path of the running lerd binary, spelled the
+// way anything that outlives this process (a systemd unit, a launchd plist, a
+// shim on PATH) has to record it. Symlinks are resolved so a link that moves
+// later cannot break the file, with Homebrew as the exception: its kegs are
+// version-pinned, so the resolved path names a directory the next
+// `brew upgrade lerd` deletes. Falls back to ~/.local/bin/lerd, lerd's own
+// install location, when the running executable cannot be resolved.
+func LerdBinary() string {
+	exe, err := selfExecutable()
+	if err != nil || exe == "" {
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, ".local", "bin", "lerd")
+	}
+	if resolved, rErr := filepath.EvalSymlinks(exe); rErr == nil {
+		exe = resolved
+	}
+	if opt := brewOptPath(exe); opt != "" {
+		return opt
+	}
+	return exe
+}
+
+// brewOptPath maps a Homebrew keg path (<prefix>/Cellar/lerd/1.32.0/bin/lerd) to
+// its opt equivalent (<prefix>/opt/lerd/bin/lerd), the link brew repoints at the
+// current version on every upgrade. Returns "" for a path outside a Cellar, or
+// when the opt link is absent, so the caller keeps the path it already has.
+func brewOptPath(path string) string {
+	prefix, keg, ok := strings.Cut(path, "/Cellar/")
+	if !ok {
+		return ""
+	}
+	parts := strings.SplitN(keg, "/", 3) // formula / version / path within the keg
+	if len(parts) != 3 || parts[0] == "" || parts[2] == "" {
+		return ""
+	}
+	opt := filepath.Join(prefix, "opt", parts[0], parts[2])
+	if _, err := os.Stat(opt); err != nil {
+		return ""
+	}
+	return opt
+}

--- a/internal/config/lerd_binary_test.go
+++ b/internal/config/lerd_binary_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Homebrew installs into a version-pinned keg and repoints opt/<formula> at it
+// on every upgrade. A file that records the keg path stops working the moment
+// the next `brew upgrade lerd` removes that version, so the opt spelling is the
+// one units and shims have to carry.
+func TestBrewOptPathRewritesKegPath(t *testing.T) {
+	prefix := resolvedTempDir(t)
+	keg := filepath.Join(prefix, "Cellar", "lerd", "1.32.0", "bin", "lerd")
+	opt := filepath.Join(prefix, "opt", "lerd", "bin", "lerd")
+	writeExecutable(t, keg)
+	writeExecutable(t, opt)
+
+	if got := brewOptPath(keg); got != opt {
+		t.Errorf("brewOptPath(%q) = %q; want the version-independent %q", keg, got, opt)
+	}
+}
+
+// Without the opt link there is nothing stable to point at, so the keg path is
+// still better than a path that does not exist at all.
+func TestBrewOptPathKeepsKegWhenOptMissing(t *testing.T) {
+	prefix := resolvedTempDir(t)
+	keg := filepath.Join(prefix, "Cellar", "lerd", "1.32.0", "bin", "lerd")
+	writeExecutable(t, keg)
+
+	if got := brewOptPath(keg); got != "" {
+		t.Errorf("brewOptPath(%q) = %q; want %q so the caller keeps the real path", keg, got, "")
+	}
+}
+
+func TestBrewOptPathIgnoresOrdinaryInstalls(t *testing.T) {
+	for _, path := range []string{
+		"/home/u/.local/bin/lerd",
+		"/usr/bin/lerd",
+		"/nix/store/abc123-lerd-1.32.0/bin/lerd",
+	} {
+		if got := brewOptPath(path); got != "" {
+			t.Errorf("brewOptPath(%q) = %q; want %q", path, got, "")
+		}
+	}
+}
+
+// The ordinary install resolves symlinks, so a unit written today survives the
+// ~/.local/bin symlink being repointed or removed later.
+func TestLerdBinaryResolvesSymlink(t *testing.T) {
+	dir := resolvedTempDir(t)
+	real := filepath.Join(dir, "versions", "lerd")
+	link := filepath.Join(dir, "lerd")
+	writeExecutable(t, real)
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := selfExecutable
+	selfExecutable = func() (string, error) { return link, nil }
+	defer func() { selfExecutable = prev }()
+
+	if got := LerdBinary(); got != real {
+		t.Errorf("LerdBinary() = %q; want the resolved %q", got, real)
+	}
+}
+
+func TestLerdBinaryPrefersBrewOptPath(t *testing.T) {
+	prefix := resolvedTempDir(t)
+	keg := filepath.Join(prefix, "Cellar", "lerd", "1.32.0", "bin", "lerd")
+	opt := filepath.Join(prefix, "opt", "lerd", "bin", "lerd")
+	writeExecutable(t, keg)
+	writeExecutable(t, opt)
+
+	prev := selfExecutable
+	selfExecutable = func() (string, error) { return keg, nil }
+	defer func() { selfExecutable = prev }()
+
+	if got := LerdBinary(); got != opt {
+		t.Errorf("LerdBinary() = %q; want %q, which brew repoints on upgrade", got, opt)
+	}
+}
+
+// resolvedTempDir is t.TempDir() with symlinks resolved, so a comparison
+// against a path LerdBinary resolved does not fail on macOS, where the temp dir
+// lives under the /var → /private/var symlink.
+func resolvedTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func writeExecutable(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -160,6 +160,13 @@ func SystemdUserDir() string {
 }
 
 // PHPImageHashFile returns the path to the stored PHP-FPM Containerfile hash.
+// InstalledVersionFile records the lerd version whose `lerd install` last ran,
+// so a binary replaced by a package manager can be told from one this install
+// has already been set up for.
+func InstalledVersionFile() string {
+	return filepath.Join(DataDir(), "installed-version")
+}
+
 func PHPImageHashFile() string {
 	return filepath.Join(DataDir(), "php-image-hash")
 }

--- a/internal/services/unit_binary.go
+++ b/internal/services/unit_binary.go
@@ -1,0 +1,21 @@
+package services
+
+import "strings"
+
+// UnitExecBinary returns the program a unit's first ExecStart line runs, or ""
+// when the content has none. Shared by the platform readers and by callers that
+// need to know what a unit they are about to write would end up running.
+func UnitExecBinary(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "ExecStart=") {
+			continue
+		}
+		args := SplitExecStart(strings.TrimPrefix(line, "ExecStart="))
+		if len(args) == 0 {
+			return ""
+		}
+		return args[0]
+	}
+	return ""
+}

--- a/internal/services/unit_binary_darwin.go
+++ b/internal/services/unit_binary_darwin.go
@@ -1,0 +1,14 @@
+//go:build darwin
+
+package services
+
+// InstalledUnitBinary returns the program the installed agent runs, or "" when
+// no plist of that name is on disk. Callers use it to tell an agent that still
+// names a binary which is there from one left behind by a binary that moved.
+func InstalledUnitBinary(name string) string {
+	args, err := plistArgs(plistPath(name))
+	if err != nil || len(args) == 0 {
+		return ""
+	}
+	return args[0]
+}

--- a/internal/services/unit_binary_linux.go
+++ b/internal/services/unit_binary_linux.go
@@ -5,7 +5,6 @@ package services
 import (
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/geodro/lerd/internal/config"
 )
@@ -18,16 +17,5 @@ func InstalledUnitBinary(name string) string {
 	if err != nil {
 		return ""
 	}
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "ExecStart=") {
-			continue
-		}
-		args := SplitExecStart(strings.TrimPrefix(line, "ExecStart="))
-		if len(args) == 0 {
-			return ""
-		}
-		return args[0]
-	}
-	return ""
+	return UnitExecBinary(string(data))
 }

--- a/internal/services/unit_binary_linux.go
+++ b/internal/services/unit_binary_linux.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// InstalledUnitBinary returns the program the installed unit runs, or "" when
+// no unit of that name is on disk. Callers use it to tell a unit that still
+// names a binary which is there from one left behind by a binary that moved.
+func InstalledUnitBinary(name string) string {
+	data, err := os.ReadFile(filepath.Join(config.SystemdUserDir(), name+".service"))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "ExecStart=") {
+			continue
+		}
+		args := SplitExecStart(strings.TrimPrefix(line, "ExecStart="))
+		if len(args) == 0 {
+			return ""
+		}
+		return args[0]
+	}
+	return ""
+}

--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -289,10 +289,7 @@ func Set(tool string, enabled bool) error {
 	if _, ok := Targets()[tool]; !ok {
 		return fmt.Errorf("no installed service exposes the %q client tool", tool)
 	}
-	lerdBin, err := os.Executable()
-	if err != nil {
-		return err
-	}
+	lerdBin := config.LerdBinary()
 	binDir := config.BinDir()
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		return err
@@ -311,10 +308,7 @@ func Set(tool string, enabled bool) error {
 // rather than skipped quietly, and its decision stays unrecorded so the next
 // run tries again.
 func Reconcile(prompt Prompter) error {
-	lerdBin, err := os.Executable()
-	if err != nil {
-		return err
-	}
+	lerdBin := config.LerdBinary()
 	binDir := config.BinDir()
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		return err

--- a/internal/systemd/embed.go
+++ b/internal/systemd/embed.go
@@ -3,9 +3,10 @@ package systemd
 import (
 	"embed"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/geodro/lerd/internal/config"
 )
 
 //go:embed units
@@ -13,32 +14,8 @@ var unitsFS embed.FS
 
 // lerdBinaryPath resolves the absolute path to the running lerd binary so unit
 // ExecStart lines point at wherever lerd is actually installed: ~/.local/bin
-// for curl/brew, /usr/bin for the deb. A var so tests can override it; returns
-// "" when the path can't be resolved, in which case GetUnit leaves the template
-// default in place.
-var lerdBinaryPath = func() string {
-	exe, err := os.Executable()
-	if err != nil {
-		return ""
-	}
-	if resolved, rErr := filepath.EvalSymlinks(exe); rErr == nil {
-		return stableBinaryPath(exe, resolved)
-	}
-	return exe
-}
-
-// stableBinaryPath picks which spelling of the binary a unit should carry.
-// Normally the resolved one, so a symlink that moves cannot break the unit. A
-// Homebrew Cellar is the exception: it is version-pinned, so resolving there
-// writes a path that `brew upgrade lerd` deletes, leaving the daemons pointing
-// at a binary that no longer exists. Homebrew's own symlink is the stable name,
-// so that one is kept.
-func stableBinaryPath(exe, resolved string) string {
-	if strings.Contains(resolved, "/Cellar/") {
-		return exe
-	}
-	return resolved
-}
+// for curl/brew, /usr/bin for the deb. A var so tests can override it.
+var lerdBinaryPath = config.LerdBinary
 
 // GetUnit returns the content of an embedded systemd unit file with the lerd
 // binary path resolved. The templates ship with ExecStart=%h/.local/bin/lerd,
@@ -60,10 +37,11 @@ func GetUnit(name string) (string, error) {
 
 // resolveUnitBinaryPath swaps the hardcoded ~/.local/bin templates for the
 // running binary's real location. lerd-tray is replaced first because its name
-// has lerd as a prefix.
+// has lerd as a prefix. A path that isn't absolute would give systemd an
+// ExecStart it can't run, so the template default is left in place instead.
 func resolveUnitBinaryPath(content string) string {
 	bin := lerdBinaryPath()
-	if bin == "" {
+	if !filepath.IsAbs(bin) {
 		return content
 	}
 	tray := filepath.Join(filepath.Dir(bin), "lerd-tray")

--- a/internal/systemd/embed_brew_test.go
+++ b/internal/systemd/embed_brew_test.go
@@ -5,44 +5,24 @@ import (
 	"testing"
 )
 
-// Homebrew installs the binary into a version-pinned Cellar directory and puts
-// a stable symlink on PATH. Resolving the symlink pins the unit to the version
-// that was current when it was written, so the next `brew upgrade lerd` deletes
-// the path the plist points at and the daemons stop starting at login.
+// Homebrew installs the binary into a version-pinned Cellar directory and links
+// the current version into opt/. A unit that recorded the Cellar path stops
+// working on the next `brew upgrade lerd`, which is why config.LerdBinary hands
+// back the opt spelling for units to carry.
 func TestGetUnitKeepsStableBrewPath(t *testing.T) {
-	for _, brewLink := range []string{
-		"/opt/homebrew/bin/lerd",
-		"/usr/local/bin/lerd",
+	for _, brewPath := range []string{
+		"/opt/homebrew/opt/lerd/bin/lerd",
+		"/home/linuxbrew/.linuxbrew/opt/lerd/bin/lerd",
 	} {
 		prev := lerdBinaryPath
-		lerdBinaryPath = func() string { return brewLink }
+		lerdBinaryPath = func() string { return brewPath }
 		unit, err := GetUnit("lerd-ui")
 		lerdBinaryPath = prev
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !strings.Contains(unit, "ExecStart="+brewLink+" serve-ui") {
-			t.Errorf("unit does not run %s:\n%s", brewLink, unit)
+		if !strings.Contains(unit, "ExecStart="+brewPath+" serve-ui") {
+			t.Errorf("unit does not run %s:\n%s", brewPath, unit)
 		}
-	}
-}
-
-func TestResolveBinaryPathKeepsCellarSymlink(t *testing.T) {
-	link := "/opt/homebrew/bin/lerd"
-	target := "/opt/homebrew/Cellar/lerd/1.31.0/bin/lerd"
-
-	if got := stableBinaryPath(link, target); got != link {
-		t.Errorf("stableBinaryPath() = %q; want the symlink %q, which survives a brew upgrade", got, link)
-	}
-}
-
-// Every other install resolves symlinks as before, so an ostree /usr/local or a
-// ~/.local/bin symlink still points at the real binary.
-func TestResolveBinaryPathResolvesOrdinarySymlink(t *testing.T) {
-	link := "/home/u/.local/bin/lerd"
-	target := "/home/u/apps/lerd-1.31.0/lerd"
-
-	if got := stableBinaryPath(link, target); got != target {
-		t.Errorf("stableBinaryPath() = %q; want the resolved %q", got, target)
 	}
 }


### PR DESCRIPTION
Homebrew installs every version of lerd into its own keg and repoints an opt link at the current one. Everything lerd writes that names its own binary, the lerd-ui, lerd-watcher and lerd-tray user services and the php, composer, laravel and client shims on PATH, recorded the resolved path, which means the keg. The next brew upgrade retires that keg and the whole install stops working at once, the daemons failing with a bare exit status 203 and php reporting no such file, on a machine where the developer changed nothing. There was a guard for exactly this, but it compared the executable path with its symlink resolved form, and on Linux the executable path is resolved to begin with, so the two were always equal and it never fired.

Everything that writes the binary path to disk now goes through one helper that hands back the version independent opt spelling for a keg, and resolves symlinks as before for every other install. The DNS LAN forwarder unit stops hardcoding a path under the home directory that only ever existed for a script install. The shims reach for lerd on PATH as well when the path they carry has gone, so they survive a move on their own.

That still leaves the installs that are broken today, and the second step of an install is where the repair belongs. `lerd update` already re-execs `lerd install --from-update` after swapping the binary; brew, apt and dnf swap it and run nothing, so lerd now records the version its environment was set up for and the first command run at a terminal after a different release lands applies that same step and says so. It runs once per version, and stays out of a machine that has never run `lerd install`, a build from a checkout, the commands that reapply the environment themselves, and anything without a terminal. `lerd start` separately repoints a service or a shim whose binary is missing, leaving alone anything that still resolves, so starting a build from a checkout cannot take the login daemons with it.

Refs #1432