### PR TITLE
fix(php): show the new patch after a base image update

### DIFF
--- a/internal/podman/php_version.go
+++ b/internal/podman/php_version.go
@@ -6,17 +6,19 @@ import (
 )
 
 // The full PHP version (e.g. "8.5.1") is not something status can read cheaply:
-// it lives inside the image. We probe it once per image build with a throwaway
-// container and cache it, keyed on the image's containerfile hash so a rebuild
-// re-probes. buildStatus reads the cache only — the probe runs in the
+// it lives inside the image. We probe it once per image with a throwaway
+// container and cache it, keyed on the image ID so every rebuild re-probes —
+// including a base-image update, which ships a new PHP patch without touching
+// the containerfile. buildStatus reads the cache only — the probe runs in the
 // background — so the status hot path never blocks on podman.
 var (
-	phpVerMu       sync.Mutex
-	phpVerCache    = map[string]phpVerEntry{}
-	phpVerInflight = map[string]bool{}
+	phpVerMu     sync.Mutex
+	phpVerCache  = map[string]phpVerEntry{}
+	phpVerProbes = map[string]*sync.Mutex{}
+	imageIDFn    = FPMImageID
 )
 
-type phpVerEntry struct{ hash, patch string }
+type phpVerEntry struct{ imageID, patch string }
 
 // FPMPHPVersion returns the cached full PHP version for a version's FPM image,
 // or "" when it has not been probed yet or the image is not built. It never
@@ -30,31 +32,50 @@ func FPMPHPVersion(version string) string {
 	return patch
 }
 
-// refreshPHPVersion probes the image's PHP version and caches it, unless the
-// cache is already fresh for the current image hash. Safe to call concurrently:
-// one probe per version runs at a time.
+// RefreshFPMPHPVersion probes synchronously, waiting for a probe already in
+// flight rather than skipping it. A caller that has just rebuilt the image uses
+// it to get the new patch into the cache before it reports the build done, so
+// the status that follows carries the number rather than nothing.
+func RefreshFPMPHPVersion(version string) {
+	mu := phpVerProbeMu(version)
+	mu.Lock()
+	defer mu.Unlock()
+	probePHPVersion(version)
+}
+
+// refreshPHPVersion is the background path: it gives up when another probe for
+// the version is running, since that one fills the same cache entry.
 func refreshPHPVersion(version string) {
-	phpVerMu.Lock()
-	if phpVerInflight[version] {
-		phpVerMu.Unlock()
+	mu := phpVerProbeMu(version)
+	if !mu.TryLock() {
 		return
 	}
-	phpVerInflight[version] = true
-	phpVerMu.Unlock()
-	defer func() {
-		phpVerMu.Lock()
-		phpVerInflight[version] = false
-		phpVerMu.Unlock()
-	}()
+	defer mu.Unlock()
+	probePHPVersion(version)
+}
 
-	hash := imageLabelFn(FPMImageName(version), fpmContainerfileHashLabel)
-	if hash == "" {
-		return // image not built (or predates the label)
+func phpVerProbeMu(version string) *sync.Mutex {
+	phpVerMu.Lock()
+	defer phpVerMu.Unlock()
+	mu, ok := phpVerProbes[version]
+	if !ok {
+		mu = &sync.Mutex{}
+		phpVerProbes[version] = mu
+	}
+	return mu
+}
+
+// probePHPVersion reads the PHP version out of the image and caches it, unless
+// the cache already holds it for the image that is there now.
+func probePHPVersion(version string) {
+	id := imageIDFn(version)
+	if id == "" {
+		return // image not built
 	}
 	phpVerMu.Lock()
 	cur, ok := phpVerCache[version]
 	phpVerMu.Unlock()
-	if ok && cur.hash == hash {
+	if ok && cur.imageID == id {
 		return // already fresh for this image
 	}
 
@@ -67,6 +88,6 @@ func refreshPHPVersion(version string) {
 		return
 	}
 	phpVerMu.Lock()
-	phpVerCache[version] = phpVerEntry{hash: hash, patch: patch}
+	phpVerCache[version] = phpVerEntry{imageID: id, patch: patch}
 	phpVerMu.Unlock()
 }

--- a/internal/podman/php_version_test.go
+++ b/internal/podman/php_version_test.go
@@ -2,24 +2,25 @@ package podman
 
 import (
 	"os/exec"
+	"sync"
 	"testing"
 )
 
 func resetPHPVerCache() {
 	phpVerMu.Lock()
 	phpVerCache = map[string]phpVerEntry{}
-	phpVerInflight = map[string]bool{}
+	phpVerProbes = map[string]*sync.Mutex{}
 	phpVerMu.Unlock()
 }
 
 // A version's full patch is probed from the image once and cached, keyed on the
-// image's containerfile hash.
+// image ID.
 func TestRefreshPHPVersion_probesAndCaches(t *testing.T) {
-	origLabel, origExec := imageLabelFn, execCommand
-	t.Cleanup(func() { imageLabelFn = origLabel; execCommand = origExec; resetPHPVerCache() })
+	origID, origExec := imageIDFn, execCommand
+	t.Cleanup(func() { imageIDFn = origID; execCommand = origExec; resetPHPVerCache() })
 	resetPHPVerCache()
 
-	imageLabelFn = func(_, _ string) string { return "hash1" }
+	imageIDFn = func(string) string { return "sha256:aaa" }
 	probes := 0
 	execCommand = func(name string, arg ...string) *exec.Cmd {
 		probes++
@@ -34,14 +35,14 @@ func TestRefreshPHPVersion_probesAndCaches(t *testing.T) {
 		t.Fatalf("cached patch = %q, want 8.5.1", got)
 	}
 
-	// A second call with the same image hash must not re-probe.
+	// A second call with the same image must not re-probe.
 	refreshPHPVersion("8.5")
 	if probes != 1 {
 		t.Errorf("probed %d times, want 1 (cache should serve the unchanged image)", probes)
 	}
 
-	// A new image hash (a rebuild) must re-probe.
-	imageLabelFn = func(_, _ string) string { return "hash2" }
+	// A new image ID (a rebuild) must re-probe.
+	imageIDFn = func(string) string { return "sha256:bbb" }
 	execCommand = func(name string, arg ...string) *exec.Cmd { return exec.Command("printf", "8.5.2") }
 	refreshPHPVersion("8.5")
 	phpVerMu.Lock()
@@ -52,13 +53,60 @@ func TestRefreshPHPVersion_probesAndCaches(t *testing.T) {
 	}
 }
 
-// An unbuilt image (no hash label) yields no patch and no probe.
-func TestRefreshPHPVersion_unbuiltImageIsNoop(t *testing.T) {
-	origLabel, origExec := imageLabelFn, execCommand
-	t.Cleanup(func() { imageLabelFn = origLabel; execCommand = origExec; resetPHPVerCache() })
+// A base-image update rebuilds the image without touching the containerfile, so
+// its hash label is byte identical either side of the build. The patch must
+// still be re-probed: only the image ID moves.
+func TestRefreshPHPVersion_reprobesWhenOnlyTheBaseChanged(t *testing.T) {
+	origID, origLabel, origExec := imageIDFn, imageLabelFn, execCommand
+	t.Cleanup(func() {
+		imageIDFn, imageLabelFn, execCommand = origID, origLabel, origExec
+		resetPHPVerCache()
+	})
 	resetPHPVerCache()
 
-	imageLabelFn = func(_, _ string) string { return "" }
+	imageLabelFn = func(_, _ string) string { return "same-containerfile-hash" }
+	imageIDFn = func(string) string { return "sha256:before" }
+	execCommand = func(name string, arg ...string) *exec.Cmd { return exec.Command("printf", "8.5.1") }
+	refreshPHPVersion("8.5")
+
+	imageIDFn = func(string) string { return "sha256:after" }
+	execCommand = func(name string, arg ...string) *exec.Cmd { return exec.Command("printf", "8.5.2") }
+	refreshPHPVersion("8.5")
+
+	phpVerMu.Lock()
+	got := phpVerCache["8.5"].patch
+	phpVerMu.Unlock()
+	if got != "8.5.2" {
+		t.Errorf("cached patch = %q, want 8.5.2 (an unchanged containerfile must not keep the old patch)", got)
+	}
+}
+
+// RefreshFPMPHPVersion is the synchronous path a just-finished rebuild uses: the
+// new patch is in the cache by the time it returns.
+func TestRefreshFPMPHPVersion_fillsCacheBeforeReturning(t *testing.T) {
+	origID, origExec := imageIDFn, execCommand
+	t.Cleanup(func() { imageIDFn = origID; execCommand = origExec; resetPHPVerCache() })
+	resetPHPVerCache()
+
+	imageIDFn = func(string) string { return "sha256:aaa" }
+	execCommand = func(name string, arg ...string) *exec.Cmd { return exec.Command("printf", "8.5.3") }
+
+	RefreshFPMPHPVersion("8.5")
+	phpVerMu.Lock()
+	got := phpVerCache["8.5"].patch
+	phpVerMu.Unlock()
+	if got != "8.5.3" {
+		t.Errorf("cached patch = %q, want 8.5.3", got)
+	}
+}
+
+// An unbuilt image (no ID) yields no patch and no probe.
+func TestRefreshPHPVersion_unbuiltImageIsNoop(t *testing.T) {
+	origID, origExec := imageIDFn, execCommand
+	t.Cleanup(func() { imageIDFn = origID; execCommand = origExec; resetPHPVerCache() })
+	resetPHPVerCache()
+
+	imageIDFn = func(string) string { return "" }
 	probed := false
 	execCommand = func(name string, arg ...string) *exec.Cmd { probed = true; return exec.Command("true") }
 

--- a/internal/ui/php_rebuild_test.go
+++ b/internal/ui/php_rebuild_test.go
@@ -1,0 +1,43 @@
+package ui
+
+import (
+	"testing"
+	"time"
+)
+
+// A finished rebuild must re-probe the patch and drop the status snapshot
+// before the client is told it is done, or the card keeps the old number until
+// the snapshot's TTL expires.
+func TestRefreshAfterPHPRebuild(t *testing.T) {
+	origPoll, origPatch := pollContainersFn, refreshPHPPatchFn
+	t.Cleanup(func() {
+		pollContainersFn, refreshPHPPatchFn = origPoll, origPatch
+		snapshots.status.mu.Lock()
+		snapshots.status.data, snapshots.status.at = nil, time.Time{}
+		snapshots.status.mu.Unlock()
+	})
+
+	polled := false
+	probed := ""
+	pollContainersFn = func() { polled = true }
+	refreshPHPPatchFn = func(version string) { probed = version }
+
+	snapshots.status.mu.Lock()
+	snapshots.status.data, snapshots.status.at = []byte(`{"php":[]}`), time.Now()
+	snapshots.status.mu.Unlock()
+
+	refreshAfterPHPRebuild("8.5")
+
+	if !polled {
+		t.Error("container cache was not polled")
+	}
+	if probed != "8.5" {
+		t.Errorf("probed patch for %q, want 8.5", probed)
+	}
+	snapshots.status.mu.Lock()
+	at := snapshots.status.at
+	snapshots.status.mu.Unlock()
+	if !at.IsZero() {
+		t.Error("status snapshot still fresh, the card would report the old image")
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -4865,6 +4865,22 @@ func handlePHPInstall(w http.ResponseWriter, r *http.Request) {
 	done(map[string]any{"ok": true, "version": version})
 }
 
+var (
+	pollContainersFn  = podman.Cache.PollNow
+	refreshPHPPatchFn = podman.RefreshFPMPHPVersion
+)
+
+// refreshAfterPHPRebuild brings back what a finished rebuild made stale: the
+// container states, the PHP patch probed out of the old image, and the cached
+// status snapshot built from both. It runs before the done event because the
+// client loads status the moment the modal closes, ahead of publishAfter's own
+// invalidation.
+func refreshAfterPHPRebuild(version string) {
+	pollContainersFn()
+	refreshPHPPatchFn(version)
+	snapshots.Invalidate(eventbus.KindStatus)
+}
+
 // handlePHPRebuild answers POST /api/php-versions/{version}/rebuild by
 // force-rebuilding that version's image against the current prebuilt base and
 // restarting everything running on it, streaming the build log as SSE. This is
@@ -4898,7 +4914,7 @@ func handlePHPRebuild(w http.ResponseWriter, r *http.Request, version string) {
 		done(map[string]any{"ok": false, "error": err.Error(), "version": version})
 		return
 	}
-	podman.Cache.PollNow()
+	refreshAfterPHPRebuild(version)
 	done(map[string]any{"ok": true, "version": version})
 }
 


### PR DESCRIPTION
Closes #1437

Updating a PHP version's base image from the UI ran the rebuild and reported success, but the version card kept the patch it showed before and stayed that way until lerd-ui restarted. The cached probe was keyed on the image's containerfile hash, and a base update leaves the containerfile untouched, so the key matched either side of the build and php -r echo PHP_VERSION never ran against the new image. It is keyed on the image ID now, which moves on every rebuild whatever caused it, so this is correct beyond the one case that exposed it.

The probe is deliberately asynchronous so the status hot path never blocks on podman, which meant the first load after a rebuild reported an empty patch even once the entry was dropped. The rebuild handler now probes synchronously and drops the status snapshot before it emits done, the way it already refreshes the container cache, so the status the modal loads carries the new number rather than nothing.