### PR TITLE
feat(frameworks): host a monochrome mark and a brand colour in the framework store

### DIFF
--- a/.claude/skills/lerd-add-framework/SKILL.md
+++ b/.claude/skills/lerd-add-framework/SKILL.md
@@ -42,11 +42,22 @@ and test against, but the pull request goes to **lerd-env/frameworks**.
      destructive
    - `tinker`, `logs`, `console`, `composer`, `npm`
 
-3. **Update `frameworks/index.json`** if the store requires it (check how the
+3. **Give it its mark and its colour.** `color:` is the framework's brand tint, a
+   plain hex literal (`#ff2d20`) and nothing else, repeated in every version file
+   since that is the only YAML a framework has. The mark itself is per family, so
+   it goes beside the versioned directory as `frameworks/<name>.svg`, one file
+   every version shares. That file is **monochrome**: a single silhouette of
+   filled paths with no `fill`, `stroke`, `style` or `class` of its own, in a bare
+   `<svg viewBox="...">`, since lerd strips everything but the geometry on the way
+   in and paints it in the declared colour. Not a full colour logo and not a
+   wordmark. This is not the `icon:` a command declares, which names a built-in
+   glyph for a dashboard button.
+
+4. **Update `frameworks/index.json`** if the store requires it (check how the
    existing entries are registered), and the README table in the
    lerd-env/frameworks `README.md`.
 
-4. **Validate end-to-end** against a real project:
+5. **Validate end-to-end** against a real project:
    ```bash
    lerd link           # in a project of that framework — detection must fire
    lerd site:doctor    # the declared checks must run

--- a/docs/usage/framework-definitions.md
+++ b/docs/usage/framework-definitions.md
@@ -123,6 +123,7 @@ Do not pin a database version your framework passes to its ORM. Doctrine picks i
 # Required
 name: symfony                     # slug [a-z0-9-], must match filename stem
 label: Symfony                    # display name
+color: "#000000"                  # brand colour the dashboard tints the mark with
 public_dir: public                # document root relative to project
 
 # Version (required for store definitions)
@@ -301,6 +302,39 @@ worktree:
 ```
 
 An app that keeps deployment state in its database cannot share the parent's. Magento hashes its file config and stores the hash in the database, so seeding a worktree's own base URL into `env.php` makes the store refuse to serve until `app:config:import` re-syncs it, and running that import against a shared database would rewrite the hash out from under the parent site. `db_isolation: required` therefore skips the prompt and isolates, `db_source: main` clones the parent's data (an empty schema is useless to a store that cannot bootstrap itself), and `commands` run afterwards, in the worktree, through the framework's own `console` binary.
+
+## The framework's own mark
+
+A framework had a label and nothing else to identify it, so it showed up as a
+text badge on the site header, in the sites widget, in a site tile's subtitle, as
+the heading a sites dashboard groups under, and as the hint in the command
+palette. A definition in the store can now bring its own logo: a
+`frameworks/<name>.svg` beside the versioned files, fetched and cached with the
+definition, so a framework published tomorrow arrives with its mark and no lerd
+release.
+
+The mark is per family, not per version. Laravel 11 and Laravel 12 are the same
+logo, so one file sits next to `<name>/<version>.yaml` rather than inside each of
+them, and every version resolves to it. The colour is the opposite: it is
+declared in the YAML, which only exists per version, so each version file repeats
+the same `color:`.
+
+It is **monochrome**: a silhouette of filled paths with no colours of its own,
+rendered through `currentColor` and tinted by `color:`. Because that markup is
+remote and ends up inlined in the page, lerd cuts it down on the way in to the
+same drawing subset a service mark gets, dropping script, `foreignObject`, event
+handlers, external references and any `fill`, `stroke` or `style` of its own. See
+[service presets](service-presets.md) for the exact subset; the rule is shared.
+
+`color:` must be a plain hex literal. Anything else, a colour function or a CSS
+variable, is dropped rather than passed through, and a colour too dark or too
+light for the card it lands on is nudged toward it until it separates, so
+Symfony's black still reads on the dark card. A framework that declares a colour
+but ships no mark still gets the tint; one with neither renders as its label
+alone, which is what every framework did before.
+
+This is not the `icon:` a framework command declares. That names a glyph from the
+built-in set for a button in the dashboard and is a different thing entirely.
 
 ## Site placeholders
 

--- a/internal/cli/store_frameworks_test.go
+++ b/internal/cli/store_frameworks_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/geodro/lerd/internal/config"
@@ -99,8 +100,9 @@ func TestRefreshStoreFrameworks_KeepsRefreshingAnUnpublishedDefinition(t *testin
 
 	refreshStoreFrameworks(nil)
 
+	definitions := yamlAsks(*asked)
 	found := false
-	for _, path := range *asked {
+	for _, path := range definitions {
 		if path == "/statamic/6.yaml" {
 			found = true
 		}
@@ -108,8 +110,8 @@ func TestRefreshStoreFrameworks_KeepsRefreshingAnUnpublishedDefinition(t *testin
 	if !found {
 		t.Errorf("unpublished definition was not refreshed, asked for %v", *asked)
 	}
-	if len(*asked) != 5 {
-		t.Errorf("asked for %d definitions, want the catalogue's 4 plus statamic: %v", len(*asked), *asked)
+	if len(definitions) != 5 {
+		t.Errorf("asked for %d definitions, want the catalogue's 4 plus statamic: %v", len(definitions), definitions)
 	}
 }
 
@@ -128,7 +130,20 @@ func TestRefreshStoreFrameworks_UsesTheCallersIndex(t *testing.T) {
 		{Name: "tempest", Label: "Tempest", Versions: []string{"3"}, Latest: "3"},
 	}})
 
-	if len(*asked) != 1 || (*asked)[0] != "/tempest/3.yaml" {
-		t.Errorf("asked for %v, want just /tempest/3.yaml", *asked)
+	if definitions := yamlAsks(*asked); len(definitions) != 1 || definitions[0] != "/tempest/3.yaml" {
+		t.Errorf("asked for %v, want just /tempest/3.yaml", definitions)
 	}
+}
+
+// yamlAsks keeps only the definition requests. A refresh also asks for each
+// framework's mark, which these tests are not about: what they pin is how many
+// definitions get pulled and off which index.
+func yamlAsks(asked []string) []string {
+	var out []string
+	for _, path := range asked {
+		if strings.HasSuffix(path, ".yaml") {
+			out = append(out, path)
+		}
+	}
+	return out
 }

--- a/internal/config/framework.go
+++ b/internal/config/framework.go
@@ -45,6 +45,11 @@ type Framework struct {
 	// Laravel 10 definition); callers must not clamp PHP to its range.
 	VersionGuessed bool `yaml:"-"`
 	// PHP defines the supported PHP version range for this framework version.
+	// Color is the brand tint the dashboard paints the framework mark and label
+	// with, a plain hex literal; anything else is dropped rather than reaching
+	// the page as CSS. Declared per version file since that is the only YAML a
+	// framework has, but it describes the family, so every version repeats it.
+	Color     string          `yaml:"color,omitempty"`
 	PHP       FrameworkPHP    `yaml:"php,omitempty"`
 	Detect    []FrameworkRule `yaml:"detect,omitempty"`
 	PublicDir string          `yaml:"public_dir"`

--- a/internal/config/framework_icon.go
+++ b/internal/config/framework_icon.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// The framework store's half of the mark handling; the sanitiser and the cache
+// read and write it sits on are in store_icon.go, shared with the service store.
+//
+// A framework's mark is per family, not per version: Laravel 11 and Laravel 12
+// are the same logo, so one <name>.svg sits beside the <name>@<version>.yaml
+// files rather than inside them. Nothing is embedded here the way the default
+// service stack is, because no framework definition ships in the binary at all.
+
+// FrameworkMark is a framework's identity as the dashboard needs it: the
+// silhouette and the colour to paint it in. Either half may be empty, and a
+// framework with neither keeps rendering as its label alone.
+type FrameworkMark struct {
+	SVG   string `json:"svg,omitempty"`
+	Color string `json:"color,omitempty"`
+}
+
+// SaveStoreFrameworkIcon caches an icon fetched from the framework store beside
+// the definition's YAML.
+func SaveStoreFrameworkIcon(name string, data []byte) error {
+	return saveStoreIcon(StoreFrameworksDir(), name, data)
+}
+
+// FrameworkIcon returns a framework's mark, if the store shipped one.
+func FrameworkIcon(name string) (string, bool) {
+	return readStoreIcon(StoreFrameworksDir(), name)
+}
+
+// FrameworkMarks returns the mark and brand colour of every framework this
+// install has a cached definition for, keyed by framework name, so lerd-ui can
+// hand the dashboard the whole set in one response and the browser never
+// reaches the store origin itself. A framework whose definition declares a
+// colour but ships no mark still appears, since the colour alone tints its
+// label.
+func FrameworkMarks() map[string]FrameworkMark {
+	out := make(map[string]FrameworkMark)
+	for _, name := range frameworkNamesInCache() {
+		mark := FrameworkMark{Color: NormalizeBrandColor(cachedFrameworkColor(name))}
+		if svg, ok := FrameworkIcon(name); ok {
+			mark.SVG = svg
+		}
+		if mark.SVG != "" || mark.Color != "" {
+			out[name] = mark
+		}
+	}
+	return out
+}
+
+// frameworkNamesInCache lists the framework names the store cache holds, from
+// both the versioned <name>@<version>.yaml files and any unversioned <name>.yaml,
+// plus any name that has a mark but whose definition has since been pruned.
+func frameworkNamesInCache() []string {
+	entries, err := os.ReadDir(StoreFrameworksDir())
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	add := func(name string) {
+		if name == "" || seen[name] || !validPresetName(name) {
+			return
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		switch {
+		case strings.HasSuffix(e.Name(), ".yaml"):
+			name := strings.TrimSuffix(e.Name(), ".yaml")
+			add(strings.SplitN(name, "@", 2)[0])
+		case strings.HasSuffix(e.Name(), ".svg"):
+			add(strings.TrimSuffix(e.Name(), ".svg"))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// cachedFrameworkColor reads the brand colour off any cached definition for a
+// framework. The colour is a property of the family rather than of one release,
+// so every version file carries the same value and the first one found answers.
+func cachedFrameworkColor(name string) string {
+	paths, _ := filepath.Glob(filepath.Join(StoreFrameworksDir(), name+"@*.yaml"))
+	paths = append(paths, filepath.Join(StoreFrameworksDir(), name+".yaml"))
+	sort.Strings(paths)
+	for _, p := range paths {
+		if fw := loadFrameworkYAML(p); fw != nil && fw.Color != "" {
+			return fw.Color
+		}
+	}
+	return ""
+}

--- a/internal/config/framework_icon_test.go
+++ b/internal/config/framework_icon_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeCachedFramework(t *testing.T, filename, body string) {
+	t.Helper()
+	dir := StoreFrameworksDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSaveStoreFrameworkIcon_SanitizesOnTheWayInAndTheSeamServesIt(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	raw := `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#ff2d20"><path d="M2 2h8v8H2z"/><script>bad()</script></svg>`
+	if err := SaveStoreFrameworkIcon("laravel", []byte(raw)); err != nil {
+		t.Fatalf("SaveStoreFrameworkIcon: %v", err)
+	}
+	svg, ok := FrameworkIcon("laravel")
+	if !ok {
+		t.Fatal("the seam did not serve the saved mark")
+	}
+	if strings.Contains(svg, "bad()") || strings.Contains(svg, "#ff2d20") {
+		t.Errorf("the cached mark was not sanitized: %s", svg)
+	}
+	if !strings.Contains(svg, `d="M2 2h8v8H2z"`) {
+		t.Errorf("the cached mark lost its drawing: %s", svg)
+	}
+}
+
+// One mark serves the whole family, so it sits beside the versioned files
+// rather than inside them and every version resolves to the same file.
+func TestFrameworkMarks_OneMarkServesEveryVersion(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	writeCachedFramework(t, "laravel@11.yaml", "name: laravel\nlabel: Laravel\nversion: \"11\"\ncolor: \"#FF2D20\"\n")
+	writeCachedFramework(t, "laravel@12.yaml", "name: laravel\nlabel: Laravel\nversion: \"12\"\ncolor: \"#FF2D20\"\n")
+	if err := SaveStoreFrameworkIcon("laravel", []byte(`<svg viewBox="0 0 24 24"><path d="M2 2h8v8H2z"/></svg>`)); err != nil {
+		t.Fatalf("SaveStoreFrameworkIcon: %v", err)
+	}
+
+	marks := FrameworkMarks()
+	got, ok := marks["laravel"]
+	if !ok {
+		t.Fatalf("laravel missing from the marks: %v", marks)
+	}
+	if !strings.Contains(got.SVG, "<path") {
+		t.Errorf("laravel mark = %q", got.SVG)
+	}
+	if got.Color != "#ff2d20" {
+		t.Errorf("laravel colour = %q, want the normalized hex", got.Color)
+	}
+	if len(marks) != 1 {
+		t.Errorf("two version files must not become two entries, got %v", marks)
+	}
+}
+
+// A colour with no mark still tints the label, so it must not be dropped for
+// want of artwork.
+func TestFrameworkMarks_ColourAloneStillCounts(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	writeCachedFramework(t, "symfony@7.yaml", "name: symfony\nlabel: Symfony\nversion: \"7\"\ncolor: \"#000000\"\n")
+	writeCachedFramework(t, "tempest@1.yaml", "name: tempest\nlabel: Tempest\nversion: \"1\"\n")
+
+	marks := FrameworkMarks()
+	if marks["symfony"].Color != "#000000" {
+		t.Errorf("symfony should carry its colour, got %+v", marks["symfony"])
+	}
+	if _, ok := marks["tempest"]; ok {
+		t.Errorf("a framework with neither mark nor colour should be absent, got %+v", marks["tempest"])
+	}
+}
+
+// A colour that is not a plain hex must never reach the page as CSS.
+func TestFrameworkMarks_DropsAColourThatIsNotPlainHex(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	writeCachedFramework(t, "evil@1.yaml", "name: evil\nlabel: Evil\nversion: \"1\"\ncolor: \"url(https://evil.test/x)\"\n")
+	if _, ok := FrameworkMarks()["evil"]; ok {
+		t.Error("a non-hex colour must be dropped, leaving nothing to serve")
+	}
+}
+
+// The cache holds <name>@<version>.yaml, so the family name has to come off the
+// left of the @ rather than the whole stem.
+func TestFrameworkMarks_KeysByFamilyNotByVersionedFilename(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	writeCachedFramework(t, "wordpress.yaml", "name: wordpress\nlabel: WordPress\ncolor: \"#21759B\"\n")
+	marks := FrameworkMarks()
+	if _, ok := marks["wordpress"]; !ok {
+		t.Errorf("an unversioned definition should still key by name, got %v", marks)
+	}
+}

--- a/internal/config/preset_icon.go
+++ b/internal/config/preset_icon.go
@@ -1,232 +1,17 @@
 package config
 
 import (
-	"encoding/xml"
-	"errors"
-	"fmt"
-	"io"
-	"io/fs"
 	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
 )
 
-// A preset carries its own mark next to its YAML: services/<name>.svg in the
-// store, cached beside <name>.yaml here. The markup is remote and ends up in an
-// {@html} block, so it is cut down to a plain drawing on the way in, the same
-// spirit as SanitizeProjectFrameworkDef for untrusted project YAML. What comes
-// out is a monochrome silhouette with no colours of its own; the dashboard
-// paints it through currentColor with the preset's declared brand colour.
+// The service store's half of the mark handling; the sanitiser and the cache
+// read and write it sits on are in store_icon.go, shared with the framework
+// store.
 
-const (
-	maxIconBytes    = 32 * 1024
-	maxIconElements = 400
-	svgNS           = "http://www.w3.org/2000/svg"
-)
-
-// iconElements is the drawing subset an icon may use. Anything else, script and
-// foreignObject included, is dropped with its whole subtree.
-var iconElements = map[string]bool{
-	"g": true, "path": true, "circle": true, "ellipse": true,
-	"rect": true, "line": true, "polyline": true, "polygon": true,
-}
-
-// iconAttrs is the geometry an element may keep. Every presentation attribute
-// is dropped, so the icon cannot carry a colour, reach outside itself, or smuggle
-// CSS: no fill, stroke, style, class, id, href or event handler survives.
-var iconAttrs = map[string]bool{
-	"d": true, "points": true, "transform": true,
-	"x": true, "y": true, "x1": true, "y1": true, "x2": true, "y2": true,
-	"cx": true, "cy": true, "r": true, "rx": true, "ry": true,
-	"width": true, "height": true,
-	"fill-rule": true, "clip-rule": true,
-}
-
-// SanitizeServiceIcon reduces remote SVG markup to a bare drawing: a single
-// <svg> carrying only its viewBox, wrapping the allowed shape elements with
-// their geometry attributes. It fails rather than returning something empty, so
-// a caller never caches markup that would draw nothing.
-func SanitizeServiceIcon(data []byte) ([]byte, error) {
-	if len(data) == 0 {
-		return nil, errors.New("empty icon")
-	}
-	if len(data) > maxIconBytes {
-		return nil, fmt.Errorf("icon is %d bytes, over the %d byte limit", len(data), maxIconBytes)
-	}
-
-	dec := xml.NewDecoder(strings.NewReader(string(data)))
-	var (
-		out      strings.Builder
-		viewBox  string
-		started  bool
-		shapes   int
-		elements int
-		skipDep  int
-		open     []string
-	)
-	for {
-		tok, err := dec.Token()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("parsing icon: %w", err)
-		}
-		switch t := tok.(type) {
-		case xml.StartElement:
-			// Inside a dropped element everything goes with it, however deep.
-			if skipDep > 0 {
-				skipDep++
-				continue
-			}
-			local := t.Name.Local
-			if !started {
-				if local != "svg" {
-					return nil, fmt.Errorf("icon root is <%s>, not <svg>", local)
-				}
-				started = true
-				viewBox = rootViewBox(t)
-				continue
-			}
-			elements++
-			if elements > maxIconElements {
-				return nil, fmt.Errorf("icon has over %d elements", maxIconElements)
-			}
-			if !iconElements[local] || (t.Name.Space != "" && t.Name.Space != svgNS) {
-				skipDep = 1
-				continue
-			}
-			if local != "g" {
-				shapes++
-			}
-			out.WriteString("<" + local)
-			writeIconAttrs(&out, t.Attr)
-			out.WriteString(">")
-			open = append(open, local)
-		case xml.EndElement:
-			if skipDep > 0 {
-				skipDep--
-				continue
-			}
-			if len(open) == 0 {
-				continue
-			}
-			out.WriteString("</" + open[len(open)-1] + ">")
-			open = open[:len(open)-1]
-		}
-	}
-
-	if !started {
-		return nil, errors.New("icon has no <svg> root")
-	}
-	if viewBox == "" {
-		return nil, errors.New("icon declares no viewBox")
-	}
-	if shapes == 0 {
-		return nil, errors.New("icon draws nothing")
-	}
-	return []byte(`<svg xmlns="` + svgNS + `" viewBox="` + viewBox + `">` + out.String() + `</svg>`), nil
-}
-
-// rootViewBox reads the root element's viewBox, falling back to one derived from
-// a plain numeric width and height so an icon exported without a viewBox still
-// scales instead of being rejected.
-func rootViewBox(root xml.StartElement) string {
-	var w, h string
-	for _, a := range root.Attr {
-		switch a.Name.Local {
-		case "viewBox":
-			if v := numericList(a.Value); v != "" {
-				return v
-			}
-		case "width":
-			w = a.Value
-		case "height":
-			h = a.Value
-		}
-	}
-	if isNumber(w) && isNumber(h) {
-		return "0 0 " + w + " " + h
-	}
-	return ""
-}
-
-// writeIconAttrs emits the geometry attributes an element is allowed to keep.
-// Namespaced attributes (xlink:href and friends) are dropped wholesale.
-func writeIconAttrs(out *strings.Builder, attrs []xml.Attr) {
-	for _, a := range attrs {
-		if a.Name.Space != "" || !iconAttrs[a.Name.Local] {
-			continue
-		}
-		out.WriteString(" " + a.Name.Local + `="`)
-		xml.EscapeText(out, []byte(a.Value))
-		out.WriteString(`"`)
-	}
-}
-
-// numericList keeps a whitespace or comma separated list of numbers, so a
-// viewBox can never carry anything but coordinates.
-func numericList(v string) string {
-	fields := strings.FieldsFunc(v, func(r rune) bool { return r == ' ' || r == ',' || r == '\t' || r == '\n' })
-	if len(fields) != 4 {
-		return ""
-	}
-	for _, f := range fields {
-		if !isNumber(f) {
-			return ""
-		}
-	}
-	return strings.Join(fields, " ")
-}
-
-func isNumber(v string) bool {
-	if v == "" {
-		return false
-	}
-	_, err := strconv.ParseFloat(v, 64)
-	return err == nil
-}
-
-// NormalizeBrandColor returns the preset's declared colour as a lowercase hex
-// literal, or empty when it is anything else. The value reaches the dashboard as
-// a custom property on the element, so only a plain hex may pass: arbitrary CSS
-// would be a value out of the store deciding how a page renders.
-func NormalizeBrandColor(v string) string {
-	v = strings.ToLower(strings.TrimSpace(v))
-	if len(v) != 4 && len(v) != 7 {
-		return ""
-	}
-	if !strings.HasPrefix(v, "#") {
-		return ""
-	}
-	for _, c := range v[1:] {
-		if !strings.ContainsRune("0123456789abcdef", c) {
-			return ""
-		}
-	}
-	return v
-}
-
-// SaveStorePresetIcon sanitizes an icon fetched from the service store and
-// writes it beside the preset's cached YAML. Unlike SaveStorePreset it does not
-// keep the original bytes: what a future binary would have to trust is exactly
-// what an older one already stripped, so the cache holds the safe form.
+// SaveStorePresetIcon caches an icon fetched from the service store beside the
+// preset's YAML.
 func SaveStorePresetIcon(name string, data []byte) error {
-	if !validPresetName(name) {
-		return fmt.Errorf("invalid preset name %q", name)
-	}
-	clean, err := SanitizeServiceIcon(data)
-	if err != nil {
-		return fmt.Errorf("icon for preset %q: %w", name, err)
-	}
-	dir := StorePresetsDir()
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
-	}
-	path := filepath.Join(dir, name+".svg")
-	guardRealWrite(path)
-	return publishStoreFile(path, clean, 0o644)
+	return saveStoreIcon(StorePresetsDir(), name, data)
 }
 
 // PresetIcon returns a preset's own mark, if it has one. It layers the same way
@@ -236,11 +21,11 @@ func SaveStorePresetIcon(name string, data []byte) error {
 // way to carry a mark at all. A preset with none falls back to the built-in
 // glyph its YAML names.
 func PresetIcon(name string) (string, bool) {
+	if svg, ok := readStoreIcon(StorePresetsDir(), name); ok {
+		return svg, true
+	}
 	if !validPresetName(name) {
 		return "", false
-	}
-	if data, err := os.ReadFile(filepath.Join(StorePresetsDir(), name+".svg")); err == nil {
-		return string(data), true
 	}
 	data, err := presetFS.ReadFile("presets/" + name + ".svg")
 	if err != nil {
@@ -267,33 +52,8 @@ func PresetIcons() map[string]string {
 	return out
 }
 
-// iconNames lists the preset names an icon layer can serve.
-func iconNames(fsys fs.FS, dir string) []string {
-	entries, err := fs.ReadDir(fsys, dir)
-	if err != nil {
-		return nil
-	}
-	var out []string
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".svg") {
-			continue
-		}
-		if name := strings.TrimSuffix(e.Name(), ".svg"); validPresetName(name) {
-			out = append(out, name)
-		}
-	}
-	return out
-}
-
 // removeStorePresetIcon drops a preset's cached icon, called wherever the cached
 // YAML goes so the two never outlive each other.
 func removeStorePresetIcon(name string) error {
-	if !validPresetName(name) {
-		return nil
-	}
-	err := os.Remove(filepath.Join(StorePresetsDir(), name+".svg"))
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	return nil
+	return removeStoreIcon(StorePresetsDir(), name)
 }

--- a/internal/config/preset_icon_test.go
+++ b/internal/config/preset_icon_test.go
@@ -7,16 +7,16 @@ import (
 	"testing"
 )
 
-func TestSanitizeServiceIcon_KeepsTheDrawingAndDropsItsColours(t *testing.T) {
+func TestSanitizeStoreIcon_KeepsTheDrawingAndDropsItsColours(t *testing.T) {
 	raw := `<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 24 24" fill="#00758f" class="brand" id="mysql">
 	  <g transform="translate(1 1)" style="fill:red">
 	    <path d="M4 4h16v16H4z" fill="#ff0000" stroke="blue" fill-rule="evenodd"/>
 	    <circle cx="12" cy="12" r="5"/>
 	  </g>
 	</svg>`
-	got, err := SanitizeServiceIcon([]byte(raw))
+	got, err := SanitizeStoreIcon([]byte(raw))
 	if err != nil {
-		t.Fatalf("SanitizeServiceIcon: %v", err)
+		t.Fatalf("SanitizeStoreIcon: %v", err)
 	}
 	out := string(got)
 	for _, want := range []string{`viewBox="0 0 24 24"`, `d="M4 4h16v16H4z"`, `fill-rule="evenodd"`, `transform="translate(1 1)"`, `<circle`, `r="5"`} {
@@ -31,7 +31,7 @@ func TestSanitizeServiceIcon_KeepsTheDrawingAndDropsItsColours(t *testing.T) {
 	}
 }
 
-func TestSanitizeServiceIcon_DropsScriptExternalRefsAndHandlers(t *testing.T) {
+func TestSanitizeStoreIcon_DropsScriptExternalRefsAndHandlers(t *testing.T) {
 	raw := `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24" onload="alert(1)">
 	  <script>alert(2)</script>
 	  <foreignObject><div>hi</div></foreignObject>
@@ -39,9 +39,9 @@ func TestSanitizeServiceIcon_DropsScriptExternalRefsAndHandlers(t *testing.T) {
 	  <use href="#x"/>
 	  <path d="M1 1h2v2H1z" onclick="alert(3)"/>
 	</svg>`
-	got, err := SanitizeServiceIcon([]byte(raw))
+	got, err := SanitizeStoreIcon([]byte(raw))
 	if err != nil {
-		t.Fatalf("SanitizeServiceIcon: %v", err)
+		t.Fatalf("SanitizeStoreIcon: %v", err)
 	}
 	out := string(got)
 	if !strings.Contains(out, `d="M1 1h2v2H1z"`) {
@@ -54,18 +54,18 @@ func TestSanitizeServiceIcon_DropsScriptExternalRefsAndHandlers(t *testing.T) {
 	}
 }
 
-func TestSanitizeServiceIcon_DerivesAViewBoxFromWidthAndHeight(t *testing.T) {
+func TestSanitizeStoreIcon_DerivesAViewBoxFromWidthAndHeight(t *testing.T) {
 	raw := `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48"><path d="M0 0h1v1H0z"/></svg>`
-	got, err := SanitizeServiceIcon([]byte(raw))
+	got, err := SanitizeStoreIcon([]byte(raw))
 	if err != nil {
-		t.Fatalf("SanitizeServiceIcon: %v", err)
+		t.Fatalf("SanitizeStoreIcon: %v", err)
 	}
 	if !strings.Contains(string(got), `viewBox="0 0 48 48"`) {
 		t.Errorf("width/height should become a viewBox, got %s", got)
 	}
 }
 
-func TestSanitizeServiceIcon_RejectsWhatIsNotADrawing(t *testing.T) {
+func TestSanitizeStoreIcon_RejectsWhatIsNotADrawing(t *testing.T) {
 	cases := map[string]string{
 		"not svg":       `<html><body>hi</body></html>`,
 		"no drawing":    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><script>x</script></svg>`,
@@ -75,16 +75,16 @@ func TestSanitizeServiceIcon_RejectsWhatIsNotADrawing(t *testing.T) {
 		"unknown enity": `<svg viewBox="0 0 24 24"><path d="&xxe;"/></svg>`,
 	}
 	for name, raw := range cases {
-		if _, err := SanitizeServiceIcon([]byte(raw)); err == nil {
+		if _, err := SanitizeStoreIcon([]byte(raw)); err == nil {
 			t.Errorf("%s: expected a rejection, got none", name)
 		}
 	}
 }
 
-func TestSanitizeServiceIcon_RejectsAnOversizedIcon(t *testing.T) {
+func TestSanitizeStoreIcon_RejectsAnOversizedIcon(t *testing.T) {
 	raw := `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="` +
 		strings.Repeat("M0 0h1v1H0z", maxIconBytes/10) + `"/></svg>`
-	if _, err := SanitizeServiceIcon([]byte(raw)); err == nil {
+	if _, err := SanitizeStoreIcon([]byte(raw)); err == nil {
 		t.Error("an icon past the size cap should be rejected")
 	}
 }
@@ -178,7 +178,7 @@ func TestPresetIcon_ShippedMarksAreAlreadySanitized(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 
 	for name, svg := range PresetIcons() {
-		clean, err := SanitizeServiceIcon([]byte(svg))
+		clean, err := SanitizeStoreIcon([]byte(svg))
 		if err != nil {
 			t.Errorf("%s ships a mark the sanitizer rejects: %v", name, err)
 			continue

--- a/internal/config/store_icon.go
+++ b/internal/config/store_icon.go
@@ -1,0 +1,276 @@
+package config
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Both stores let a definition carry its own mark next to its YAML, cached in
+// the same directory. The markup is remote and ends up in an {@html} block, so
+// it is cut down to a plain drawing on the way in, the same spirit as
+// SanitizeProjectFrameworkDef for untrusted project YAML. What comes out is a
+// monochrome silhouette with no colours of its own; the dashboard paints it
+// through currentColor with the definition's declared brand colour.
+//
+// This file is the half both stores share: the sanitiser, the colour rule, and
+// the read and write of a cached mark. The per-store halves are in
+// preset_icon.go and framework_icon.go.
+
+const (
+	maxIconBytes    = 32 * 1024
+	maxIconElements = 400
+	svgNS           = "http://www.w3.org/2000/svg"
+)
+
+// iconElements is the drawing subset an icon may use. Anything else, script and
+// foreignObject included, is dropped with its whole subtree.
+var iconElements = map[string]bool{
+	"g": true, "path": true, "circle": true, "ellipse": true,
+	"rect": true, "line": true, "polyline": true, "polygon": true,
+}
+
+// iconAttrs is the geometry an element may keep. Every presentation attribute
+// is dropped, so the icon cannot carry a colour, reach outside itself, or smuggle
+// CSS: no fill, stroke, style, class, id, href or event handler survives.
+var iconAttrs = map[string]bool{
+	"d": true, "points": true, "transform": true,
+	"x": true, "y": true, "x1": true, "y1": true, "x2": true, "y2": true,
+	"cx": true, "cy": true, "r": true, "rx": true, "ry": true,
+	"width": true, "height": true,
+	"fill-rule": true, "clip-rule": true,
+}
+
+// SanitizeStoreIcon reduces remote SVG markup to a bare drawing: a single
+// <svg> carrying only its viewBox, wrapping the allowed shape elements with
+// their geometry attributes. It fails rather than returning something empty, so
+// a caller never caches markup that would draw nothing.
+func SanitizeStoreIcon(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, errors.New("empty icon")
+	}
+	if len(data) > maxIconBytes {
+		return nil, fmt.Errorf("icon is %d bytes, over the %d byte limit", len(data), maxIconBytes)
+	}
+
+	dec := xml.NewDecoder(strings.NewReader(string(data)))
+	var (
+		out      strings.Builder
+		viewBox  string
+		started  bool
+		shapes   int
+		elements int
+		skipDep  int
+		open     []string
+	)
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("parsing icon: %w", err)
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			// Inside a dropped element everything goes with it, however deep.
+			if skipDep > 0 {
+				skipDep++
+				continue
+			}
+			local := t.Name.Local
+			if !started {
+				if local != "svg" {
+					return nil, fmt.Errorf("icon root is <%s>, not <svg>", local)
+				}
+				started = true
+				viewBox = rootViewBox(t)
+				continue
+			}
+			elements++
+			if elements > maxIconElements {
+				return nil, fmt.Errorf("icon has over %d elements", maxIconElements)
+			}
+			if !iconElements[local] || (t.Name.Space != "" && t.Name.Space != svgNS) {
+				skipDep = 1
+				continue
+			}
+			if local != "g" {
+				shapes++
+			}
+			out.WriteString("<" + local)
+			writeIconAttrs(&out, t.Attr)
+			out.WriteString(">")
+			open = append(open, local)
+		case xml.EndElement:
+			if skipDep > 0 {
+				skipDep--
+				continue
+			}
+			if len(open) == 0 {
+				continue
+			}
+			out.WriteString("</" + open[len(open)-1] + ">")
+			open = open[:len(open)-1]
+		}
+	}
+
+	if !started {
+		return nil, errors.New("icon has no <svg> root")
+	}
+	if viewBox == "" {
+		return nil, errors.New("icon declares no viewBox")
+	}
+	if shapes == 0 {
+		return nil, errors.New("icon draws nothing")
+	}
+	return []byte(`<svg xmlns="` + svgNS + `" viewBox="` + viewBox + `">` + out.String() + `</svg>`), nil
+}
+
+// rootViewBox reads the root element's viewBox, falling back to one derived from
+// a plain numeric width and height so an icon exported without a viewBox still
+// scales instead of being rejected.
+func rootViewBox(root xml.StartElement) string {
+	var w, h string
+	for _, a := range root.Attr {
+		switch a.Name.Local {
+		case "viewBox":
+			if v := numericList(a.Value); v != "" {
+				return v
+			}
+		case "width":
+			w = a.Value
+		case "height":
+			h = a.Value
+		}
+	}
+	if isNumber(w) && isNumber(h) {
+		return "0 0 " + w + " " + h
+	}
+	return ""
+}
+
+// writeIconAttrs emits the geometry attributes an element is allowed to keep.
+// Namespaced attributes (xlink:href and friends) are dropped wholesale.
+func writeIconAttrs(out *strings.Builder, attrs []xml.Attr) {
+	for _, a := range attrs {
+		if a.Name.Space != "" || !iconAttrs[a.Name.Local] {
+			continue
+		}
+		out.WriteString(" " + a.Name.Local + `="`)
+		xml.EscapeText(out, []byte(a.Value))
+		out.WriteString(`"`)
+	}
+}
+
+// numericList keeps a whitespace or comma separated list of numbers, so a
+// viewBox can never carry anything but coordinates.
+func numericList(v string) string {
+	fields := strings.FieldsFunc(v, func(r rune) bool { return r == ' ' || r == ',' || r == '\t' || r == '\n' })
+	if len(fields) != 4 {
+		return ""
+	}
+	for _, f := range fields {
+		if !isNumber(f) {
+			return ""
+		}
+	}
+	return strings.Join(fields, " ")
+}
+
+func isNumber(v string) bool {
+	if v == "" {
+		return false
+	}
+	_, err := strconv.ParseFloat(v, 64)
+	return err == nil
+}
+
+// NormalizeBrandColor returns the preset's declared colour as a lowercase hex
+// literal, or empty when it is anything else. The value reaches the dashboard as
+// a custom property on the element, so only a plain hex may pass: arbitrary CSS
+// would be a value out of the store deciding how a page renders.
+func NormalizeBrandColor(v string) string {
+	v = strings.ToLower(strings.TrimSpace(v))
+	if len(v) != 4 && len(v) != 7 {
+		return ""
+	}
+	if !strings.HasPrefix(v, "#") {
+		return ""
+	}
+	for _, c := range v[1:] {
+		if !strings.ContainsRune("0123456789abcdef", c) {
+			return ""
+		}
+	}
+	return v
+}
+
+// saveStoreIcon sanitizes a mark fetched from a store and writes it into that
+// store's cache dir. Unlike the YAML beside it the original bytes are not kept:
+// what a future binary would otherwise have to trust is exactly what an older
+// one already stripped, so the cache holds the safe form.
+func saveStoreIcon(dir, name string, data []byte) error {
+	if !validPresetName(name) {
+		return fmt.Errorf("invalid definition name %q", name)
+	}
+	clean, err := SanitizeStoreIcon(data)
+	if err != nil {
+		return fmt.Errorf("icon for %q: %w", name, err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, name+".svg")
+	guardRealWrite(path)
+	return publishStoreFile(path, clean, 0o644)
+}
+
+// readStoreIcon returns the cached mark for a name, if one was ever fetched.
+func readStoreIcon(dir, name string) (string, bool) {
+	if !validPresetName(name) {
+		return "", false
+	}
+	data, err := os.ReadFile(filepath.Join(dir, name+".svg"))
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
+}
+
+// removeStoreIcon drops a cached mark, called wherever the cached definition
+// goes so the two never outlive each other.
+func removeStoreIcon(dir, name string) error {
+	if !validPresetName(name) {
+		return nil
+	}
+	err := os.Remove(filepath.Join(dir, name+".svg"))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// iconNames lists the names an icon layer can serve.
+func iconNames(fsys fs.FS, dir string) []string {
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".svg") {
+			continue
+		}
+		if name := strings.TrimSuffix(e.Name(), ".svg"); validPresetName(name) {
+			out = append(out, name)
+		}
+	}
+	return out
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -66,6 +66,22 @@ func autoFetchFramework(name, version string) (*config.Framework, error) {
 	return fw, nil
 }
 
+// fetchFrameworkIcon caches a framework's mark, <name>.svg beside the versioned
+// definitions it belongs to. The mark is per family rather than per version, so
+// it is fetched by name and shared by every version. Best effort throughout: a
+// framework that ships no mark, an unreachable store, or markup the sanitizer
+// refuses all leave the framework rendering as its label alone.
+func (c *Client) fetchFrameworkIcon(name string) {
+	if _, ok := config.FrameworkIcon(name); ok {
+		return
+	}
+	data, err := c.fetch(name + ".svg")
+	if err != nil {
+		return
+	}
+	_ = config.SaveStoreFrameworkIcon(name, data)
+}
+
 // NewClient returns a store client with default settings.
 func NewClient() *Client {
 	urls := origin.StoreBaseURLs()
@@ -192,6 +208,9 @@ func (c *Client) FetchFramework(name, version string) (*config.Framework, error)
 	if fw.Name == "" {
 		return nil, fmt.Errorf("invalid framework definition for %s@%s: missing name", name, version)
 	}
+	// Every path that caches a remote definition comes through here, so the mark
+	// is pulled alongside it in one place rather than at each of the callers.
+	c.fetchFrameworkIcon(name)
 
 	return &fw, nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -72,6 +72,9 @@ console: bin/console
 	mux.HandleFunc("/symfony/7.yaml", func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(symfonyYAML)) //nolint:errcheck
 	})
+	mux.HandleFunc("/laravel.svg", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#ff2d20"><path d="M3 3h18v18H3z"/></svg>`)) //nolint:errcheck
+	})
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	})
@@ -375,5 +378,42 @@ func TestFetchWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&calls); got != maxFetchAttempts {
 		t.Fatalf("expected %d attempts, got %d", maxFetchAttempts, got)
+	}
+}
+
+// The mark travels with the definition, one file for the whole family, so
+// fetching any version of a framework caches it.
+func TestFetchFramework_CachesTheFamilyMark(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	srv := testServer(t)
+	defer srv.Close()
+
+	if _, err := testClient(t, srv).FetchFramework("laravel", "11"); err != nil {
+		t.Fatalf("FetchFramework: %v", err)
+	}
+	svg, ok := config.FrameworkIcon("laravel")
+	if !ok {
+		t.Fatal("the framework's mark was not cached")
+	}
+	if !strings.Contains(svg, `d="M3 3h18v18H3z"`) {
+		t.Errorf("cached mark lost its drawing: %s", svg)
+	}
+	if strings.Contains(svg, "#ff2d20") {
+		t.Errorf("cached mark kept a colour of its own: %s", svg)
+	}
+}
+
+// A framework with no mark in the store is the common case, so a missing file
+// must leave the fetch itself successful.
+func TestFetchFramework_SucceedsWithoutAMark(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	srv := testServer(t)
+	defer srv.Close()
+
+	if _, err := testClient(t, srv).FetchFramework("symfony", "7"); err != nil {
+		t.Fatalf("FetchFramework without a mark: %v", err)
+	}
+	if _, ok := config.FrameworkIcon("symfony"); ok {
+		t.Error("no mark in the store should mean no mark in the cache")
 	}
 }

--- a/internal/ui/framework_marks_test.go
+++ b/internal/ui/framework_marks_test.go
@@ -1,0 +1,67 @@
+package ui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// The dashboard inlines these marks, so the endpoint must hand it the sanitized
+// cached copy and nothing the browser has to fetch from the store itself.
+func TestHandleFrameworkMarks_ServesTheCachedMarkAndColour(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	dir := config.StoreFrameworksDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "name: laravel\nlabel: Laravel\nversion: \"12\"\ncolor: \"#FF2D20\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "laravel@12.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	raw := `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#f00"><path d="M4 4h6v6H4z"/><script>bad()</script></svg>`
+	if err := config.SaveStoreFrameworkIcon("laravel", []byte(raw)); err != nil {
+		t.Fatalf("SaveStoreFrameworkIcon: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	handleFrameworkMarks(rec, httptest.NewRequest(http.MethodGet, "/api/frameworks/marks", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got map[string]config.FrameworkMark
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	mark, ok := got["laravel"]
+	if !ok {
+		t.Fatalf("marks response missing laravel: %v", got)
+	}
+	if !strings.Contains(mark.SVG, `d="M4 4h6v6H4z"`) {
+		t.Errorf("served mark lost its drawing: %s", mark.SVG)
+	}
+	if strings.Contains(mark.SVG, "bad()") || strings.Contains(mark.SVG, "#f00") {
+		t.Errorf("served mark is not the sanitized copy: %s", mark.SVG)
+	}
+	if mark.Color != "#ff2d20" {
+		t.Errorf("served colour = %q", mark.Color)
+	}
+}
+
+// With nothing cached the dashboard must get an object it can iterate, not a
+// null it has to guard against.
+func TestHandleFrameworkMarks_EmptyCacheServesAnObject(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	rec := httptest.NewRecorder()
+	handleFrameworkMarks(rec, httptest.NewRequest(http.MethodGet, "/api/frameworks/marks", nil))
+	if body := strings.TrimSpace(rec.Body.String()); body != "{}" {
+		t.Errorf("empty cache should serve an empty object, got %q", body)
+	}
+}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -233,6 +233,7 @@ func Start(currentVersion string) error {
 
 	mux.HandleFunc("/api/services/presets", withCORS(handleServicePresets))
 	mux.HandleFunc("/api/services/icons", withCORS(handleServiceIcons))
+	mux.HandleFunc("/api/frameworks/marks", withCORS(handleFrameworkMarks))
 	mux.HandleFunc("/api/services/presets/", withCORS(publishAfter(handleServicePresetInstall, eventbus.KindServices, eventbus.KindStatus)))
 	mux.HandleFunc("/api/services/", withCORS(publishAfter(handleServiceAction, eventbus.KindServices, eventbus.KindStatus, eventbus.KindSites)))
 	mux.HandleFunc("/api/databases", withCORS(handleDatabases))
@@ -1831,6 +1832,23 @@ func handleServiceIcons(w http.ResponseWriter, r *http.Request) {
 		icons = map[string]string{}
 	}
 	writeJSON(w, icons)
+}
+
+// handleFrameworkMarks returns the mark and brand colour of every framework
+// this install has a definition for, keyed by framework name. The dashboard
+// reads them from here rather than from the store origin, so a site's framework
+// keeps drawing offline and over remote access, and the markup it inlines is the
+// sanitized copy this binary wrote.
+func handleFrameworkMarks(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	marks := config.FrameworkMarks()
+	if marks == nil {
+		marks = map[string]config.FrameworkMark{}
+	}
+	writeJSON(w, marks)
 }
 
 // handleServicePresetInstall installs a bundled preset and streams per-phase

--- a/internal/ui/web/demo/stubs.ts
+++ b/internal/ui/web/demo/stubs.ts
@@ -573,6 +573,7 @@ window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Res
   if (path === '/api/services/presets') return jsonResponse(presets);
   // The demo ships no store cache, so every service draws its built-in glyph.
   if (path === '/api/services/icons') return jsonResponse({});
+  if (path === '/api/frameworks/marks') return jsonResponse({});
 
   if (path === '/api/lan/status' && method === 'POST') {
     const body = JSON.parse(String(init?.body || '{}')) as { action?: string };

--- a/internal/ui/web/src/App.svelte
+++ b/internal/ui/web/src/App.svelte
@@ -16,6 +16,7 @@
   import { loadSites } from '$stores/sites';
   import { loadServices } from '$stores/services';
   import { loadServiceIcons } from '$stores/serviceIcons';
+  import { loadFrameworkMarks } from '$stores/frameworkMarks';
   import { loadWorkerHealth } from '$stores/workerHealth';
   import { connectWs, disconnectWs } from '$lib/ws';
   import { initDashboardRoute } from '$stores/dashboard';
@@ -54,6 +55,7 @@
     loadSites();
     loadServices();
     loadServiceIcons();
+    loadFrameworkMarks();
     loadWorkerHealth();
     connectWs();
     initDashboardRoute();

--- a/internal/ui/web/src/app.css
+++ b/internal/ui/web/src/app.css
@@ -262,25 +262,43 @@ button {
   border-color: var(--color-lerd-border);
 }
 
-/* A store preset brings its own mark and brand colour, so neither can be a
-   Tailwind class: the colour arrives as a custom property and the badge derives
-   its background from it at low alpha, the glyph taking the solid tone. Each
-   theme gets its own tone (see brandTint) so a dark brand still reads on the
-   dark card. The mark itself is injected markup, hence the global rule. */
-.svc-tint {
-  background-color: color-mix(in srgb, var(--svc-tint) 12%, transparent);
-  color: var(--svc-tint);
+/* A definition in either store brings its own mark and brand colour, so neither
+   can be a Tailwind class: the colour arrives as a custom property and the badge
+   derives its background from it at low alpha, the glyph taking the solid tone.
+   Each theme gets its own tone (see brandTint) so a dark brand still reads on
+   the dark card. The mark itself is injected markup, hence the global rules. */
+.mark-tint {
+  background-color: color-mix(in srgb, var(--mark-tint) 12%, transparent);
+  color: var(--mark-tint);
 }
-.dark .svc-tint {
-  background-color: color-mix(in srgb, var(--svc-tint-dark) 16%, transparent);
-  color: var(--svc-tint-dark);
+.dark .mark-tint {
+  background-color: color-mix(in srgb, var(--mark-tint-dark) 16%, transparent);
+  color: var(--mark-tint-dark);
 }
-.svc-mark {
+.mark-glyph {
   display: block;
 }
-.svc-mark > svg {
+.mark-glyph > svg,
+.mark-ink > svg,
+.mark-inherit > svg {
   width: 100%;
   height: 100%;
   fill: currentColor;
   stroke: none;
+}
+
+/* A framework mark sits inline beside its label. Inside a badge it takes the
+   badge's own colour, so the pill stays one object; standing on its own it takes
+   the brand tone, with no background either way. */
+.mark-inherit {
+  display: inline-flex;
+  flex: none;
+}
+.mark-ink {
+  display: inline-flex;
+  flex: none;
+  color: var(--mark-tint);
+}
+.dark .mark-ink {
+  color: var(--mark-tint-dark);
 }

--- a/internal/ui/web/src/components/CommandPalette.svelte
+++ b/internal/ui/web/src/components/CommandPalette.svelte
@@ -30,6 +30,7 @@
     launchCommand,
     type Command
   } from '$stores/commands';
+  import FrameworkMark from '$components/FrameworkMark.svelte';
   import { m } from '../paraglide/messages.js';
 
   type Group = 'pages' | 'sites' | 'services' | 'presets' | 'toggles' | 'commands' | 'actions';
@@ -37,6 +38,8 @@
     id: string;
     label: string;
     hint?: string;
+    // Framework name for a site entry, so its hint can carry the mark.
+    framework?: string;
     group: Group;
     action: () => void | Promise<void>;
   }
@@ -59,6 +62,7 @@
         id: 'site:' + s.domain,
         label: s.domain,
         hint: s.framework_label || s.framework,
+        framework: s.framework,
         group: 'sites',
         action: () => goToTab('sites', s.domain)
       });
@@ -383,7 +387,10 @@
               >
                 <span class="flex-1 truncate">{e.label}</span>
                 {#if e.hint}
-                  <span class="text-[11px] font-mono text-gray-400 dark:text-gray-500 truncate">{e.hint}</span>
+                  <span class="flex items-center gap-1 text-[11px] font-mono text-gray-400 dark:text-gray-500 truncate">
+                    <FrameworkMark name={e.framework} />
+                    {e.hint}
+                  </span>
                 {/if}
               </button>
             </li>

--- a/internal/ui/web/src/components/DashboardSection.svelte
+++ b/internal/ui/web/src/components/DashboardSection.svelte
@@ -4,16 +4,24 @@
   interface Props {
     label?: string; // omitted for a bucket that needs no heading
     sub?: boolean;
+    // Drawn before the label when the heading has a mark of its own; the
+    // section itself stays unaware of what the mark is.
+    icon?: Snippet;
     children: Snippet;
   }
-  let { label, sub = false, children }: Props = $props();
+  let { label, sub = false, icon, children }: Props = $props();
+
+  const headingClass = $derived(
+    (sub ? 'text-[11px]' : 'text-xs') +
+      ' flex items-center gap-1.5 font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500'
+  );
 </script>
 
 <section class={sub ? 'space-y-2' : 'space-y-2.5'}>
   {#if label && sub}
-    <h3 class="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">{label}</h3>
+    <h3 class={headingClass}>{#if icon}{@render icon()}{/if}{label}</h3>
   {:else if label}
-    <h2 class="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">{label}</h2>
+    <h2 class={headingClass}>{#if icon}{@render icon()}{/if}{label}</h2>
   {/if}
   <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-2">
     {@render children()}

--- a/internal/ui/web/src/components/FrameworkMark.svelte
+++ b/internal/ui/web/src/components/FrameworkMark.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { frameworkMarks } from '$stores/frameworkMarks';
+  import { brandTintStyle } from '$lib/brandTint';
+
+  interface Props {
+    // The framework's store name (laravel, symfony), not its display label.
+    name: string | undefined;
+    size?: 'sm' | 'md';
+    // A mark inside a coloured pill takes the pill's colour rather than the
+    // brand tone, so the badge reads as one object instead of two.
+    tint?: boolean;
+  }
+  let { name, size = 'sm', tint = true }: Props = $props();
+
+  // A framework with no mark renders nothing at all rather than a placeholder
+  // glyph: the label beside it already says which framework it is, so a stand-in
+  // would only add noise to a header that is mostly text.
+  const mark = $derived(name ? $frameworkMarks[name] : undefined);
+  const style = $derived(tint ? brandTintStyle(mark?.color) : '');
+  const box = $derived(size === 'md' ? 'w-4 h-4' : 'w-3.5 h-3.5');
+  const wrapper = $derived(tint ? 'mark-ink' : 'mark-inherit');
+</script>
+
+{#if mark?.svg}
+  <span class="{wrapper} {box}" style={style} aria-hidden="true">{@html mark.svg}</span>
+{/if}

--- a/internal/ui/web/src/components/FrameworkMark.test.ts
+++ b/internal/ui/web/src/components/FrameworkMark.test.ts
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect, beforeEach } from 'vitest';
+import FrameworkMark from './FrameworkMark.svelte';
+import { frameworkMarks } from '$stores/frameworkMarks';
+
+const MARK = '<svg viewBox="0 0 24 24"><path d="M3 3h18v18H3z"/></svg>';
+
+beforeEach(() => {
+  frameworkMarks.set({});
+});
+
+describe('FrameworkMark', () => {
+  it('draws the mark the store shipped, tinted by the declared colour', () => {
+    frameworkMarks.set({ laravel: { svg: MARK, color: '#e02419' } });
+    const { container } = render(FrameworkMark, { props: { name: 'laravel' } });
+    expect(container.querySelector('path')?.getAttribute('d')).toBe('M3 3h18v18H3z');
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.className).toContain('mark-ink');
+    expect(el.getAttribute('style')).toContain('--mark-tint: #e02419');
+  });
+
+  // The label beside it already names the framework, so a stand-in glyph would
+  // only add noise.
+  it('draws nothing when the framework has no mark', () => {
+    frameworkMarks.set({ laravel: { color: '#e02419' } });
+    const { container } = render(FrameworkMark, { props: { name: 'laravel' } });
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('draws nothing for a framework the store knows nothing about', () => {
+    const { container } = render(FrameworkMark, { props: { name: 'nope' } });
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('draws nothing when the site has no framework at all', () => {
+    frameworkMarks.set({ laravel: { svg: MARK, color: '#e02419' } });
+    const { container } = render(FrameworkMark, { props: { name: undefined } });
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  // Inside a coloured pill the mark takes the pill's colour, so the badge reads
+  // as one object rather than a mark sitting next to a badge.
+  it('takes the surrounding colour when the caller turns the tint off', () => {
+    frameworkMarks.set({ laravel: { svg: MARK, color: '#e02419' } });
+    const { container } = render(FrameworkMark, { props: { name: 'laravel', tint: false } });
+    const el = container.firstElementChild as HTMLElement;
+    expect(el.className).toContain('mark-inherit');
+    expect(el.className).not.toContain('mark-ink');
+    expect(el.getAttribute('style') || '').not.toContain('--mark-tint');
+    expect(container.querySelector('path')).not.toBeNull();
+  });
+
+  // A colour out of the store must never reach the page as arbitrary CSS.
+  it('ignores a colour that is not a plain hex', () => {
+    frameworkMarks.set({ laravel: { svg: MARK, color: 'url(#x)' } });
+    const { container } = render(FrameworkMark, { props: { name: 'laravel' } });
+    const style = (container.firstElementChild as HTMLElement).getAttribute('style') || '';
+    expect(style).not.toContain('url(');
+  });
+});

--- a/internal/ui/web/src/components/ServiceIcon.svelte
+++ b/internal/ui/web/src/components/ServiceIcon.svelte
@@ -29,14 +29,14 @@
   const storeIcon = $derived($serviceIcons[resolvedPreset]);
   const brand = $derived(brandTintStyle(color ?? meta?.color));
 
-  const tint = $derived(brand ? 'svc-tint' : tintFor(resolvedCategory));
+  const tint = $derived(brand ? 'mark-tint' : tintFor(resolvedCategory));
   const box = $derived(compact ? 'w-8 h-8' : 'w-9 h-9 transition-transform group-hover:scale-105');
   const glyph = $derived(compact ? 'w-4 h-4' : 'w-5 h-5');
 </script>
 
 <span class="shrink-0 inline-flex items-center justify-center rounded-lg {tint} {box}" style={brand}>
   {#if storeIcon}
-    <span class="svc-mark {glyph}">{@html storeIcon}</span>
+    <span class="mark-glyph {glyph}">{@html storeIcon}</span>
   {:else}
     <svg class={glyph} fill="none" stroke="currentColor" viewBox="0 0 24 24"
       >{@html dashboardIconSvg(name, resolvedIcon)}</svg

--- a/internal/ui/web/src/components/ServiceIcon.test.ts
+++ b/internal/ui/web/src/components/ServiceIcon.test.ts
@@ -59,11 +59,11 @@ describe('ServiceIcon', () => {
     serviceIcons.set({ mysql: MARK });
     presets.set([{ name: 'mysql', category: 'databases', icon: 'database', color: '#e02419' }]);
     const { container } = render(ServiceIcon, { props: { name: 'mysql' } });
-    expect(container.querySelector('.svc-mark path')?.getAttribute('d')).toBe('M3 3h18v18H3z');
-    expect(box(container).className).toContain('svc-tint');
+    expect(container.querySelector('.mark-glyph path')?.getAttribute('d')).toBe('M3 3h18v18H3z');
+    expect(box(container).className).toContain('mark-tint');
     expect(box(container).className).not.toContain('indigo');
-    expect(box(container).getAttribute('style')).toContain('--svc-tint: #e02419');
-    expect(box(container).getAttribute('style')).toContain('--svc-tint-dark: #e02419');
+    expect(box(container).getAttribute('style')).toContain('--mark-tint: #e02419');
+    expect(box(container).getAttribute('style')).toContain('--mark-tint-dark: #e02419');
   });
 
   // A versioned member carries no mark of its own; it draws its family's.
@@ -73,14 +73,14 @@ describe('ServiceIcon', () => {
       { name: 'mariadb-11-8', status: 'active', site_count: 0, preset: 'mariadb', category: 'databases' }
     ]);
     const { container } = render(ServiceIcon, { props: { name: 'mariadb-11-8' } });
-    expect(container.querySelector('.svc-mark path')).not.toBeNull();
+    expect(container.querySelector('.mark-glyph path')).not.toBeNull();
   });
 
   // A bundled preset, or a cache written before icons existed, keeps rendering.
   it('falls back to the declared glyph and category tint with no store mark', () => {
     presets.set([{ name: 'mysql', category: 'databases', icon: 'database' }]);
     const { container } = render(ServiceIcon, { props: { name: 'mysql' } });
-    expect(container.querySelector('.svc-mark')).toBeNull();
+    expect(container.querySelector('.mark-glyph')).toBeNull();
     expect(box(container).className).toContain('indigo');
   });
 

--- a/internal/ui/web/src/lib/brandTint.test.ts
+++ b/internal/ui/web/src/lib/brandTint.test.ts
@@ -43,7 +43,7 @@ describe('brandTint', () => {
 
 describe('brandTintStyle', () => {
   it('declares both tones as custom properties', () => {
-    expect(brandTintStyle('#e02419')).toBe('--svc-tint:#e02419;--svc-tint-dark:#e02419');
+    expect(brandTintStyle('#e02419')).toBe('--mark-tint:#e02419;--mark-tint-dark:#e02419');
   });
 
   it('is empty when there is no usable colour, so the category tint stands', () => {

--- a/internal/ui/web/src/lib/brandTint.ts
+++ b/internal/ui/web/src/lib/brandTint.ts
@@ -40,7 +40,7 @@ export function brandTint(color: string | undefined | null): BrandTint | null {
 // is no usable colour so the caller falls back to its category tint.
 export function brandTintStyle(color: string | undefined | null): string {
   const t = brandTint(color);
-  return t ? `--svc-tint:${t.light};--svc-tint-dark:${t.dark}` : '';
+  return t ? `--mark-tint:${t.light};--mark-tint-dark:${t.dark}` : '';
 }
 
 function parseHex(color: string | undefined | null): [number, number, number] | null {

--- a/internal/ui/web/src/stores/frameworkMarks.ts
+++ b/internal/ui/web/src/stores/frameworkMarks.ts
@@ -1,0 +1,22 @@
+import { writable } from 'svelte/store';
+import { apiJson } from '$lib/api';
+
+export interface FrameworkMark {
+  svg?: string;
+  color?: string;
+}
+
+// The mark and brand colour a framework definition carries, keyed by framework
+// name. lerd-ui serves them from its own cache of the store, already sanitized,
+// so the browser never reaches the store origin and a site's framework keeps
+// drawing offline and over remote access. A framework that declares neither is
+// simply absent here and renders as its label alone.
+export const frameworkMarks = writable<Record<string, FrameworkMark>>({});
+
+export async function loadFrameworkMarks() {
+  try {
+    frameworkMarks.set((await apiJson<Record<string, FrameworkMark>>('/api/frameworks/marks')) || {});
+  } catch {
+    /* keep whatever we already drew */
+  }
+}

--- a/internal/ui/web/src/tabs/sites/SiteHeader.svelte
+++ b/internal/ui/web/src/tabs/sites/SiteHeader.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import Badge from '$components/Badge.svelte';
+  import FrameworkMark from '$components/FrameworkMark.svelte';
   import {
     type Site,
     pauseSite,
@@ -464,7 +465,12 @@
 
       <span class="flex items-center gap-1.5 shrink-0">
         {#if activeFrameworkLabel}
-          <span class="hidden @md:inline-flex"><Badge tone="framework">{activeFrameworkLabel}</Badge></span>
+          <span class="hidden @md:inline-flex">
+            <Badge tone="framework">
+              <FrameworkMark name={activeWorktree?.framework || site.framework} tint={false} />
+              {activeFrameworkLabel}
+            </Badge>
+          </span>
         {/if}
         {#if lanOn && lanURL}
           <span class="hidden @md:inline-flex items-center gap-1 text-[10px] text-teal-600 dark:text-teal-400">

--- a/internal/ui/web/src/tabs/sites/SitesDashboard.svelte
+++ b/internal/ui/web/src/tabs/sites/SitesDashboard.svelte
@@ -5,6 +5,7 @@
   import LoadingRow from '$components/LoadingRow.svelte';
   import DashboardHeader from '$components/DashboardHeader.svelte';
   import DashboardSection from '$components/DashboardSection.svelte';
+  import FrameworkMark from '$components/FrameworkMark.svelte';
   import SiteTile from './SiteTile.svelte';
   import { sites, sitesLoaded, siteWorkerFailing, type Site } from '$stores/sites';
   import { accessMode } from '$stores/accessMode';
@@ -24,20 +25,24 @@
   // Groups keep their first-seen order; unknown frameworks fold into a trailing
   // "Other" bucket. This is the overview's original grouping, kept for as long
   // as the user has no workspace to organise by.
-  function byFramework(): Array<{ label: string; sites: Site[] }> {
+  function byFramework(): Array<{ label: string; framework?: string; sites: Site[] }> {
     const order: string[] = [];
     const byLabel = new Map<string, Site[]>();
+    // The heading carries the framework's mark, so the group remembers which
+    // name produced its label rather than only the label itself.
+    const nameOf = new Map<string, string | undefined>();
     for (const s of active) {
       const label = s.framework_label || m.sites_dash_otherFramework();
       if (!byLabel.has(label)) {
         byLabel.set(label, []);
+        nameOf.set(label, s.framework);
         order.push(label);
       }
       byLabel.get(label)!.push(s);
     }
     const other = m.sites_dash_otherFramework();
     order.sort((a, b) => (a === other ? 1 : b === other ? -1 : 0));
-    return order.map((label) => ({ label, sites: byLabel.get(label)! }));
+    return order.map((label) => ({ label, framework: nameOf.get(label), sites: byLabel.get(label)! }));
   }
 
   // Active sites grouped by workspace, in the order the config lists them. An
@@ -71,6 +76,9 @@
     {:else}
       {#each groups as group (group.label)}
         <DashboardSection label={group.label}>
+          {#snippet icon()}
+            <FrameworkMark name={group.framework} />
+          {/snippet}
           {#each group.sites as site (site.domain)}
             <SiteTile {site} />
           {/each}


### PR DESCRIPTION
A framework had a label and nothing else to identify it, so it appeared as a text badge on the site header, as the heading a sites dashboard groups under, and as the hint in the command palette. Nothing in lerd drew a Laravel or a Symfony and nothing could, because a definition had no place to put one.

The store now carries a frameworks/<name>.svg beside the versioned files and a colour in the YAML, both pulled in by the fetch that every path caching a definition already goes through, so a framework published tomorrow arrives with its mark and no Go change. The mark is per family rather than per version, since Laravel 11 and Laravel 12 are the same logo, so one file sits next to the version directory and every version resolves to it. The colour is the other way round, declared in the only YAML a framework has, so each version file repeats it.

This is the second store to want all of this, so rather than growing a parallel set the sanitiser, the colour rule and the read and write of a cached mark move into a shared seam, with a per store half on either side of it. The tint custom properties and classes lose their service specific prefix for the same reason. Nothing about the service side changes behaviour.

The mark lands on the header badge, where it sits inside the pill and takes its colour so the two read as one object, on the dashboard group heading and on the command palette hint. It is deliberately absent from the site tile even though the issue lists it: the tile already carries a site icon, and the framework sits mid way through a dot separated subline where a mark either reads as belonging to the domain beside it or crowds a two line card. A framework with no mark renders as its label alone, which is what every framework did before, so an older cache and a framework that never publishes one both keep working.

Store definitions reach installs that have not upgraded, and the new key follows the same rule the service colour did: unknown keys are ignored, so an older binary parses these definitions unchanged and simply draws no mark.

Closes #1366
