### PR TITLE
feat(ui): draw the store's marks in the preset picker and the palette

### DIFF
--- a/docs/features/web-ui.md
+++ b/docs/features/web-ui.md
@@ -68,8 +68,8 @@ Every widget is driven by the same Svelte stores that power the rest of the dash
 Press **`Cmd+K`** (macOS) / **`Ctrl+K`** (Linux/Windows), or **`/`** anywhere outside an input, to open a global command palette overlay. It searches across:
 
 - **Pages**: Dashboard, Sites, Services, System
-- **Sites**: every linked domain, with framework hint
-- **Services**: every core service, with version hint
+- **Sites**: every linked domain, with framework hint, led by the framework's own mark
+- **Services**: every core service, with version hint, led by the mark its preset ships in the same way
 - **Install service**: every installable bundled preset, so searching "install redis" installs it inline without opening the picker modal
 - **Actions**: Link a site, Add a service, Heal failing workers (when any), Check for updates, Open documentation, Open current site in browser, Toggle theme
 
@@ -132,7 +132,7 @@ Selecting a site opens the detail panel with:
 
 The middle panel lists core infrastructure services (MySQL, Redis, PostgreSQL, Meilisearch, RustFS, Mailpit), any installed preset alternates (e.g. MySQL 5.7, MariaDB 11, MongoDB) and admin UIs (phpMyAdmin, pgAdmin, Mongo Express), grouped by service type under labelled sections (Databases, Cache, Messaging, Search, Mail & PDF, Admin UIs, Storage, Testing) in the same order the discovery grid uses, plus grouped per-site workers (Queues, Horizon, Schedules, Workers, Stripe, Reverb) below them.
 
-The header has a **+** button that opens the **preset picker modal**: a one-click installer for the bundled service presets. A search box at the top filters the list by name, description, or image as you type. Multi-version presets like `mysql` and `mariadb` show a version dropdown next to the **Add** button. Already-installed entries are filtered out.
+The header has a **+** button that opens the **preset picker modal**: a one-click installer for the bundled service presets. Every row leads with the mark its preset ships, in the brand colour the preset declares, falling back to the category-tinted glyph the preset names when the store carries no mark for it. A search box at the top filters the list by name, description, or image as you type. Multi-version presets like `mysql` and `mariadb` show a version dropdown next to the **Add** button. Already-installed entries are filtered out.
 
 ![Service preset picker modal](/assets/screenshots/preset-picker-modal.png)
 

--- a/internal/ui/web/src/components/CommandPalette.svelte
+++ b/internal/ui/web/src/components/CommandPalette.svelte
@@ -31,6 +31,7 @@
     type Command
   } from '$stores/commands';
   import FrameworkMark from '$components/FrameworkMark.svelte';
+  import ServiceIcon from '$components/ServiceIcon.svelte';
   import { m } from '../paraglide/messages.js';
 
   type Group = 'pages' | 'sites' | 'services' | 'presets' | 'toggles' | 'commands' | 'actions';
@@ -38,8 +39,10 @@
     id: string;
     label: string;
     hint?: string;
-    // Framework name for a site entry, so its hint can carry the mark.
+    // Framework name for a site entry, service name for a service one, so the
+    // hint can carry the mark either one is known by.
     framework?: string;
+    service?: string;
     group: Group;
     action: () => void | Promise<void>;
   }
@@ -73,6 +76,7 @@
         id: 'svc:' + svc.name,
         label: serviceLabel(svc.name),
         hint: svc.version || (svc.status === 'active' ? 'active' : 'inactive'),
+        service: svc.name,
         group: 'services',
         action: () => goToTab('services', svc.name)
       });
@@ -388,7 +392,11 @@
                 <span class="flex-1 truncate">{e.label}</span>
                 {#if e.hint}
                   <span class="flex items-center gap-1 text-[11px] font-mono text-gray-400 dark:text-gray-500 truncate">
-                    <FrameworkMark name={e.framework} />
+                    {#if e.service}
+                      <ServiceIcon name={e.service} bare inline />
+                    {:else}
+                      <FrameworkMark name={e.framework} />
+                    {/if}
                     {e.hint}
                   </span>
                 {/if}

--- a/internal/ui/web/src/components/CommandPalette.test.ts
+++ b/internal/ui/web/src/components/CommandPalette.test.ts
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import CommandPalette from './CommandPalette.svelte';
+import { paletteOpen } from '$stores/commandPalette';
+import { presets } from '$stores/presets';
+import { services } from '$stores/services';
+import { serviceIcons } from '$stores/serviceIcons';
+import { sites } from '$stores/sites';
+
+const MARK = '<svg viewBox="0 0 24 24"><path d="M3 3h18v18H3z"/></svg>';
+
+describe('CommandPalette service marks', () => {
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('offline');
+    }) as unknown as typeof fetch;
+    sites.set([]);
+    presets.set([]);
+    serviceIcons.set({});
+    paletteOpen.set(true);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    paletteOpen.set(false);
+    services.set([]);
+    serviceIcons.set({});
+  });
+
+  // A service row names the service and its version, the way a site row names
+  // its domain and framework, so the mark rides beside the version too.
+  it('draws the mark beside a service row', () => {
+    serviceIcons.set({ redis: MARK });
+    services.set([
+      { name: 'redis', status: 'active', site_count: 0, version: '7.4', category: 'cache', color: '#ff4438' }
+    ]);
+    const { container } = render(CommandPalette);
+    expect(screen.getByText('7.4')).toBeInTheDocument();
+    expect(container.querySelector('.mark-glyph path')?.getAttribute('d')).toBe('M3 3h18v18H3z');
+  });
+
+  // The row it sits in is a line of text, so the mark matches the framework
+  // mark a site row carries rather than the icon a card draws.
+  it('sizes the mark to the text beside it', () => {
+    serviceIcons.set({ redis: MARK });
+    services.set([{ name: 'redis', status: 'active', site_count: 0, version: '7.4' }]);
+    const { container } = render(CommandPalette);
+    expect(container.querySelector('.mark-glyph')?.getAttribute('class')).toContain('w-3.5');
+  });
+});

--- a/internal/ui/web/src/components/ServiceIcon.svelte
+++ b/internal/ui/web/src/components/ServiceIcon.svelte
@@ -18,6 +18,9 @@
     // A mark in a strip of icons (the rail) answers to their hover and active
     // colours instead, so it carries no tone of its own.
     tint?: boolean;
+    // A bare mark set beside a line of text takes the text's size, the way a
+    // framework's own mark does in the same position.
+    inline?: boolean;
   }
   let {
     name,
@@ -27,7 +30,8 @@
     preset,
     compact = false,
     bare = false,
-    tint = true
+    tint = true,
+    inline = false
   }: Props = $props();
 
   // A caller holding the preset or service passes its declared values; one
@@ -70,7 +74,15 @@
     bare ? '' : compact ? 'w-8 h-8' : 'w-9 h-9 transition-transform group-hover:scale-105'
   );
   const glyph = $derived(
-    bare ? (compact ? 'w-5 h-5' : 'w-7 h-7') : compact ? 'w-4 h-4' : 'w-5 h-5'
+    bare
+      ? inline
+        ? 'w-3.5 h-3.5'
+        : compact
+          ? 'w-5 h-5'
+          : 'w-7 h-7'
+      : compact
+        ? 'w-4 h-4'
+        : 'w-5 h-5'
   );
 </script>
 

--- a/internal/ui/web/src/components/ServiceIcon.test.ts
+++ b/internal/ui/web/src/components/ServiceIcon.test.ts
@@ -78,6 +78,16 @@ describe('ServiceIcon', () => {
     expect(svg.getAttribute('fill')).toBe('none');
   });
 
+  // Beside a line of text the mark answers to the text, not to the icons in a
+  // card, so it draws at the size a framework's own inline mark does.
+  it('draws a bare mark at text size when inline', () => {
+    serviceIcons.set({ mysql: MARK });
+    const { container } = render(ServiceIcon, {
+      props: { name: 'mysql', bare: true, inline: true }
+    });
+    expect(container.querySelector('.mark-glyph')?.getAttribute('class')).toContain('w-3.5');
+  });
+
   it('draws a bare mark at icon size when compact', () => {
     serviceIcons.set({ mysql: MARK });
     const { container } = render(ServiceIcon, { props: { name: 'mysql', bare: true, compact: true } });

--- a/internal/ui/web/src/modals/PresetModal.svelte
+++ b/internal/ui/web/src/modals/PresetModal.svelte
@@ -3,6 +3,7 @@
   import Modal from '$components/Modal.svelte';
   import Dropdown from '$components/Dropdown.svelte';
   import DetailButton from '$components/DetailButton.svelte';
+  import ServiceIcon from '$components/ServiceIcon.svelte';
   import { closeModal } from '$stores/modals';
   import {
     presets,
@@ -60,6 +61,15 @@
       {#each filtered as p (p.name)}
         <div class="border border-gray-100 dark:border-lerd-border rounded-lg p-3 mb-2 last:mb-0">
           <div class="flex items-center gap-3">
+            <span class="self-start">
+              <ServiceIcon
+                name={p.name}
+                category={p.category}
+                icon={p.icon}
+                color={p.color}
+                compact
+              />
+            </span>
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2">
                 <span class="text-sm font-semibold text-gray-900 dark:text-white">{p.name}</span>

--- a/internal/ui/web/src/modals/PresetModal.test.ts
+++ b/internal/ui/web/src/modals/PresetModal.test.ts
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/svelte';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import PresetModal from './PresetModal.svelte';
 import { presets, presetsLoaded } from '$stores/presets';
+import { serviceIcons } from '$stores/serviceIcons';
 
 // onMount runs loadPresets() which hits /api/services/presets; make it fail so
 // the seeded store is preserved and the tests drive a known preset list.
@@ -23,6 +24,7 @@ describe('PresetModal search', () => {
     globalThis.fetch = realFetch;
     presets.set([]);
     presetsLoaded.set(false);
+    serviceIcons.set({});
   });
 
   it('lists every installable preset with no query', () => {
@@ -44,5 +46,40 @@ describe('PresetModal search', () => {
     const input = screen.getByPlaceholderText('Search presets…');
     await fireEvent.input(input, { target: { value: 'nothing-here' } });
     expect(screen.getByText('No presets match your search.')).toBeInTheDocument();
+  });
+});
+
+describe('PresetModal icons', () => {
+  const MARK = '<svg viewBox="0 0 24 24"><path d="M3 3h18v18H3z"/></svg>';
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('offline');
+    }) as unknown as typeof fetch;
+    presetsLoaded.set(true);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    presets.set([]);
+    presetsLoaded.set(false);
+    serviceIcons.set({});
+  });
+
+  it('leads each row with the mark the preset ships, in its declared colour', () => {
+    serviceIcons.set({ redis: MARK });
+    presets.set([{ name: 'redis', category: 'cache', icon: 'cache', color: '#ff4438' }]);
+    const { container } = render(PresetModal);
+    expect(container.querySelector('.mark-glyph path')?.getAttribute('d')).toBe('M3 3h18v18H3z');
+    expect(container.querySelector('.mark-tint')?.getAttribute('style')).toContain(
+      '--mark-tint: #ff4438'
+    );
+  });
+
+  it('falls back to the declared glyph and category tint with no mark', () => {
+    presets.set([{ name: 'beanstalkd', category: 'messaging', icon: 'queue' }]);
+    const { container } = render(PresetModal);
+    expect(container.querySelector('.mark-glyph')).toBeNull();
+    expect(container.querySelector('.text-violet-600')).not.toBeNull();
   });
 });


### PR DESCRIPTION
Closes #1467

The marks landed everywhere a service is drawn as an object, on the cards, in the rail, on a detail header, in the Apps grid, and skipped the two places where a service is only a line in a list. The Add a service preset modal listed each preset as a name, a description and an image tag with nothing to recognise it by, and the command palette drew a site row's framework mark while leaving the service row under it bare, so one list read two ways.

Both now go through ServiceIcon, which means an admin tool still borrows the mark of what it administers and a preset the store ships no silhouette for keeps its category-tinted glyph. In the picker the mark sits at the top of its row rather than centred in it, because a preset that lists a dashboard and its dependencies runs to four lines.

The palette needed one addition: a bare mark set beside a line of text now takes the text's size, the same size a framework's mark already takes in that exact position, instead of the larger one the rail uses.