### PR TITLE
fix(services): serve the admin dashboards same-origin so their sessions survive the overlay

### DIFF
--- a/docs/usage/custom-services.md
+++ b/docs/usage/custom-services.md
@@ -228,7 +228,7 @@ site_init:
 ```
 
 ::: tip Bundled admin dashboards embed in place
-The bundled RabbitMQ and RedisInsight presets carry `dashboard_external`, but lerd does not send you to a new tab for them. lerd-ui proxies their UI same-origin under `/_svc/<service>/`, so their session and consent cookies stay first-party and the dashboard embeds in the in-app overlay with a sidebar shortcut like every other service. The new-tab behavior above applies only to your own custom services.
+The bundled admin dashboards (phpMyAdmin, pgAdmin, Mongo Express, RabbitMQ, RedisInsight) carry `dashboard_external`, but lerd does not send you to a new tab for them. lerd-ui proxies their UI same-origin under `/_svc/<service>/`, so their session and consent cookies stay first-party and the dashboard embeds in the in-app overlay with a sidebar shortcut like every other service. Without it a browser treats the embedded UI as third-party and withholds the cookie, which leaves the dashboard rendering but failing every form it posts. The new-tab behavior above applies only to your own custom services.
 :::
 
 ## Site handle placeholders

--- a/docs/usage/custom-services.md
+++ b/docs/usage/custom-services.md
@@ -228,7 +228,9 @@ site_init:
 ```
 
 ::: tip Bundled admin dashboards embed in place
-The bundled admin dashboards (phpMyAdmin, pgAdmin, Mongo Express, RabbitMQ, RedisInsight) carry `dashboard_external`, but lerd does not send you to a new tab for them. lerd-ui proxies their UI same-origin under `/_svc/<service>/`, so their session and consent cookies stay first-party and the dashboard embeds in the in-app overlay with a sidebar shortcut like every other service. Without it a browser treats the embedded UI as third-party and withholds the cookie, which leaves the dashboard rendering but failing every form it posts. The new-tab behavior above applies only to your own custom services.
+The bundled admin dashboards (phpMyAdmin, pgAdmin, Mongo Express, RabbitMQ, RedisInsight) ask to be proxied, and lerd does not send you to a new tab for them. lerd-ui serves their UI same-origin under `/_svc/<service>/`, so their session and consent cookies stay first-party and the dashboard embeds in the in-app overlay with a sidebar shortcut like every other service. Without it a browser treats the embedded UI as third-party and withholds the cookie, which leaves the dashboard rendering but failing every form it posts. The new-tab behavior above applies only to your own custom services.
+
+Two fields ask for this, and a preset picks one by where its mount path comes from. A preset that carries its own (RabbitMQ's `management.path_prefix`, phpMyAdmin's Apache alias) uses `dashboard_external`, which every lerd understands. A preset whose mount path lerd supplies at generation time (pgAdmin's `X-Script-Name` header, Mongo Express's base-URL env) uses `dashboard_proxy` instead, because a lerd released before that wiring existed would otherwise proxy the dashboard without ever telling the upstream it moved, and serve you the upstream's own 404. A lerd that predates `dashboard_proxy` ignores the field and leaves the dashboard exactly as it was.
 :::
 
 ## Site handle placeholders

--- a/internal/config/preset_files.go
+++ b/internal/config/preset_files.go
@@ -34,6 +34,9 @@ func DashboardProxyPath(name string) string {
 // (Preset set and still resolvable) that asked for it qualifies; a user-defined
 // custom service with dashboard_external keeps the new-tab behavior.
 //
+// Either flag asks for the proxy. They differ in what an older binary does with
+// them, which is why a preset picks one deliberately: see Preset.DashboardProxy.
+//
 // The flag is read from the preset rather than the copy saved when the service
 // was installed, so a store definition that moves a dashboard behind the proxy
 // reaches services installed before it, the way file mounts do.
@@ -47,7 +50,7 @@ func DashboardProxied(svc *CustomService) bool {
 		return false
 	}
 	p, err := LoadPreset(svc.Preset)
-	return err == nil && p.DashboardExternal
+	return err == nil && (p.DashboardProxy || p.DashboardExternal)
 }
 
 // PresetProxyEnv returns the container env that makes a bundled upstream serve

--- a/internal/config/preset_files.go
+++ b/internal/config/preset_files.go
@@ -19,9 +19,9 @@ var presetFileGenerators = map[string]func(*CustomService) (string, error){
 }
 
 // DashboardProxyPrefix is the lerd-ui mount under which bundled admin
-// dashboards (rabbitmq, redisinsight) are served same-origin so their cookies
-// stay first-party in the iframe overlay. Shared by the lerd-ui proxy and the
-// quadlet generator, which configures each upstream to serve its UI there.
+// dashboards are served same-origin so their cookies stay first-party in the
+// iframe overlay. Shared by the lerd-ui proxy and the quadlet generator, which
+// configures each upstream to serve its UI there.
 const DashboardProxyPrefix = "/_svc/"
 
 // DashboardProxyPath is the same-origin mount path for a proxied dashboard.
@@ -29,20 +29,67 @@ func DashboardProxyPath(name string) string {
 	return DashboardProxyPrefix + name + "/"
 }
 
+// DashboardProxied reports whether svc's dashboard is served through lerd-ui's
+// same-origin proxy rather than opened at its own origin. Only a bundled preset
+// (Preset set and still resolvable) that asked for it qualifies; a user-defined
+// custom service with dashboard_external keeps the new-tab behavior.
+//
+// The flag is read from the preset rather than the copy saved when the service
+// was installed, so a store definition that moves a dashboard behind the proxy
+// reaches services installed before it, the way file mounts do.
+//
+// Everything that puts a service behind the proxy has to agree with this, or
+// the two halves land apart: telling an upstream to serve under the mount while
+// the dashboard still opens at its own root leaves the app answering nowhere the
+// UI looks.
+func DashboardProxied(svc *CustomService) bool {
+	if svc == nil || svc.Dashboard == "" || svc.Preset == "" {
+		return false
+	}
+	p, err := LoadPreset(svc.Preset)
+	return err == nil && p.DashboardExternal
+}
+
 // PresetProxyEnv returns the container env that makes a bundled upstream serve
 // its UI under the same /_svc/<name> path the lerd-ui proxy mounts it at, so
 // the dashboard embeds same-origin. It is injected at quadlet generation (not
 // stored in the service YAML) so existing installs pick it up on the next
-// start without a reinstall, mirroring how PresetFiles are re-sourced. Returns
-// ok=false for presets that configure the prefix another way: rabbitmq uses a
-// management.path_prefix conf mount (see presetFiles).
+// start without a reinstall, mirroring how PresetFiles are re-sourced. Keeping
+// it out of the YAML also matters for compatibility: both values move the app
+// off "/", and a binary that predates the proxy still opens the dashboard
+// there. Returns ok=false for presets that configure the prefix another way:
+// rabbitmq uses a management.path_prefix conf mount and phpmyadmin an apache
+// Alias (see presetFiles), pgadmin reads a per-request header (see
+// PresetProxyHeader).
 func PresetProxyEnv(svc *CustomService) (key, value string, ok bool) {
-	if svc == nil {
+	if !DashboardProxied(svc) {
 		return "", "", false
 	}
 	switch svc.Preset {
 	case "redisinsight":
 		return "RI_PROXY_PATH", strings.TrimSuffix(DashboardProxyPath(svc.Name), "/"), true
+	case "mongo-express":
+		// Its router is mounted at site.baseUrl, which the config expects with
+		// both slashes.
+		return "ME_CONFIG_SITE_BASEURL", DashboardProxyPath(svc.Name), true
+	}
+	return "", "", false
+}
+
+// PresetProxyHeader returns a request header the lerd-ui proxy must add so a
+// bundled upstream serves its UI under the /_svc/<name> mount. It is the same
+// job as PresetProxyEnv for apps that take the prefix per request rather than
+// at boot, which is the better half of the deal: the prefix applies without
+// restarting the container, and the app keeps answering at "/" alongside it.
+// pgAdmin's ReverseProxied middleware reads X-Script-Name, strips it from the
+// path and prefixes every URL it generates.
+func PresetProxyHeader(svc *CustomService) (key, value string, ok bool) {
+	if !DashboardProxied(svc) {
+		return "", "", false
+	}
+	switch svc.Preset {
+	case "pgadmin":
+		return "X-Script-Name", strings.TrimSuffix(DashboardProxyPath(svc.Name), "/"), true
 	}
 	return "", "", false
 }

--- a/internal/config/preset_files_test.go
+++ b/internal/config/preset_files_test.go
@@ -138,6 +138,7 @@ func TestRabbitMQPresetMountsPathPrefix(t *testing.T) {
 }
 
 func TestRedisInsightProxyEnvInjectedByPreset(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	// RI_PROXY_PATH is injected at quadlet generation from the preset, not
 	// stored in the service YAML, so existing installs serve under the proxy
 	// mount after a restart without a reinstall.
@@ -149,6 +150,78 @@ func TestRedisInsightProxyEnvInjectedByPreset(t *testing.T) {
 	// A user custom service (no bundled preset) gets no proxy env.
 	if _, _, ok := PresetProxyEnv(&CustomService{Name: "x"}); ok {
 		t.Error("non-bundled service must not receive proxy env")
+	}
+}
+
+func TestMongoExpressProxyEnvInjectedByPreset(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	// mongo-express mounts its whole router at site.baseUrl, so the value keeps
+	// the trailing slash its config expects. It stays out of the service YAML
+	// because it moves the app off "/", and a binary that predates the proxy
+	// still opens the dashboard there.
+	svc := &CustomService{Name: "mongo-express", Preset: "mongo-express", Dashboard: "http://localhost:8082", DashboardExternal: true}
+	k, v, ok := PresetProxyEnv(svc)
+	if !ok || k != "ME_CONFIG_SITE_BASEURL" || v != "/_svc/mongo-express/" {
+		t.Errorf("PresetProxyEnv = (%q,%q,%v), want (ME_CONFIG_SITE_BASEURL, /_svc/mongo-express/, true)", k, v, ok)
+	}
+}
+
+// A binary that knows the proxy must not inject the prefix when the store
+// preset backing an installed service does not ask to be proxied: the env moves
+// the app off "/", while the dashboard link still points there, and the overlay
+// gets the upstream's own 404.
+func TestPresetProxyPrefix_NotInjectedWhenPresetIsNotProxied(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	writeStorePreset(t, "mongo-express", "name: mongo-express\nimage: docker.io/library/mongo-express:latest\ndashboard: http://localhost:8082\n")
+	svc := &CustomService{Name: "mongo-express", Preset: "mongo-express", Dashboard: "http://localhost:8082"}
+	if k, v, ok := PresetProxyEnv(svc); ok {
+		t.Errorf("PresetProxyEnv = (%q,%q,true), want no env while the preset keeps the dashboard off the proxy", k, v)
+	}
+	writeStorePreset(t, "pgadmin", "name: pgadmin\nimage: docker.io/dpage/pgadmin4:latest\ndashboard: http://localhost:8081\n")
+	pga := &CustomService{Name: "pgadmin", Preset: "pgadmin", Dashboard: "http://localhost:8081"}
+	if k, v, ok := PresetProxyHeader(pga); ok {
+		t.Errorf("PresetProxyHeader = (%q,%q,true), want no header while the preset keeps the dashboard off the proxy", k, v)
+	}
+}
+
+func TestPgAdminProxyHeaderInjectedByPreset(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	// pgAdmin reads the mount path per request from X-Script-Name, so the proxy
+	// sends it as a header instead of an env var: an install picks the prefix up
+	// without a restart, and the app keeps answering at "/" for anything else.
+	svc := &CustomService{Name: "pgadmin", Preset: "pgadmin", Dashboard: "http://localhost:8081", DashboardExternal: true}
+	k, v, ok := PresetProxyHeader(svc)
+	if !ok || k != "X-Script-Name" || v != "/_svc/pgadmin" {
+		t.Errorf("PresetProxyHeader = (%q,%q,%v), want (X-Script-Name, /_svc/pgadmin, true)", k, v, ok)
+	}
+	if _, _, ok := PresetProxyHeader(&CustomService{Name: "x"}); ok {
+		t.Error("non-bundled service must not receive a proxy header")
+	}
+}
+
+func TestPhpMyAdminPresetMountsPathPrefix(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	files := PresetFiles("phpmyadmin")
+	var alias, userConfig string
+	for _, f := range files {
+		switch f.Target {
+		case "/etc/apache2/conf-enabled/lerd-path-prefix.conf":
+			alias = f.Content
+		case "/etc/phpmyadmin/config.user.inc.php":
+			userConfig = f.Content
+		}
+	}
+	// An Alias rather than a DocumentRoot move: the app answers under the proxy
+	// mount and at "/", so a binary that predates the proxy still reaches it.
+	if !strings.Contains(alias, "Alias /_svc/phpmyadmin /var/www/html") {
+		t.Errorf("phpmyadmin must alias /_svc/phpmyadmin to its docroot\n%s", alias)
+	}
+	// Served same-origin, the session cookie needs neither SameSite=None nor the
+	// forced HTTPS that phpmyadmin demands before it will set Secure.
+	for _, banned := range []string{"CookieSameSite", "$_SERVER['HTTPS']"} {
+		if strings.Contains(userConfig, banned) {
+			t.Errorf("phpmyadmin config must not still carry %s\n%s", banned, userConfig)
+		}
 	}
 }
 

--- a/internal/config/preset_files_test.go
+++ b/internal/config/preset_files_test.go
@@ -166,14 +166,17 @@ func TestMongoExpressProxyEnvInjectedByPreset(t *testing.T) {
 	}
 }
 
-// A preset whose mount path the binary supplies has to ask for the proxy with
-// the flag an older binary ignores. dashboard_external is understood by every
-// released binary that proxies, so it would start routing the overlay to
-// /_svc/<name>/ without ever telling the upstream it moved, and the dashboard
-// would 404 on installs that did nothing but pick up a store refresh.
-func TestGoMountedPresetsAskForTheProxyWithTheInertFlag(t *testing.T) {
+// These three ask for the proxy with the flag an older binary ignores.
+// dashboard_external is understood by every released binary that proxies, so it
+// would route the overlay to /_svc/<name>/ on nothing more than a store
+// refresh, before that binary does the rest of what the mount needs, and the
+// dashboard would answer 404 in between. pgadmin and mongo-express because the
+// path is supplied by the binary, phpmyadmin because its alias only reaches the
+// container on a restart that regenerates the unit, which an older reconcile
+// does after it has already restarted. Verified on a 1.31.0 guest.
+func TestProxiedPresetsAskWithTheInertFlag(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
-	for _, name := range []string{"pgadmin", "mongo-express"} {
+	for _, name := range []string{"phpmyadmin", "pgadmin", "mongo-express"} {
 		p, err := LoadPreset(name)
 		if err != nil {
 			t.Fatalf("LoadPreset(%s): %v", name, err)
@@ -184,15 +187,6 @@ func TestGoMountedPresetsAskForTheProxyWithTheInertFlag(t *testing.T) {
 		if !p.DashboardProxy {
 			t.Errorf("%s must set dashboard_proxy to be served same-origin", name)
 		}
-	}
-	// phpmyadmin carries its own mount path in the YAML, so every binary that
-	// proxies it reaches it and the older flag stays correct.
-	p, err := LoadPreset("phpmyadmin")
-	if err != nil {
-		t.Fatalf("LoadPreset(phpmyadmin): %v", err)
-	}
-	if !p.DashboardExternal {
-		t.Error("phpmyadmin ships its own alias, so it should keep dashboard_external and reach older binaries too")
 	}
 }
 
@@ -246,11 +240,13 @@ func TestPhpMyAdminPresetMountsPathPrefix(t *testing.T) {
 	if !strings.Contains(alias, "Alias /_svc/phpmyadmin /var/www/html") {
 		t.Errorf("phpmyadmin must alias /_svc/phpmyadmin to its docroot\n%s", alias)
 	}
-	// Served same-origin, the session cookie needs neither SameSite=None nor the
-	// forced HTTPS that phpmyadmin demands before it will set Secure.
-	for _, banned := range []string{"CookieSameSite", "$_SERVER['HTTPS']"} {
-		if strings.Contains(userConfig, banned) {
-			t.Errorf("phpmyadmin config must not still carry %s\n%s", banned, userConfig)
+	// The cross-origin workaround stays. A lerd that does not know dashboard_proxy
+	// still frames this from its own origin, and without SameSite=None the cookie
+	// is not sent at all there. It is inert once the dashboard is same-origin, so
+	// dropping it only takes something away from older binaries.
+	for _, kept := range []string{"CookieSameSite", "$_SERVER['HTTPS']"} {
+		if !strings.Contains(userConfig, kept) {
+			t.Errorf("phpmyadmin config must keep %s for a lerd that still frames it cross-origin\n%s", kept, userConfig)
 		}
 	}
 }

--- a/internal/config/preset_files_test.go
+++ b/internal/config/preset_files_test.go
@@ -166,6 +166,36 @@ func TestMongoExpressProxyEnvInjectedByPreset(t *testing.T) {
 	}
 }
 
+// A preset whose mount path the binary supplies has to ask for the proxy with
+// the flag an older binary ignores. dashboard_external is understood by every
+// released binary that proxies, so it would start routing the overlay to
+// /_svc/<name>/ without ever telling the upstream it moved, and the dashboard
+// would 404 on installs that did nothing but pick up a store refresh.
+func TestGoMountedPresetsAskForTheProxyWithTheInertFlag(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	for _, name := range []string{"pgadmin", "mongo-express"} {
+		p, err := LoadPreset(name)
+		if err != nil {
+			t.Fatalf("LoadPreset(%s): %v", name, err)
+		}
+		if p.DashboardExternal {
+			t.Errorf("%s takes its mount path from the binary, so it must not use dashboard_external", name)
+		}
+		if !p.DashboardProxy {
+			t.Errorf("%s must set dashboard_proxy to be served same-origin", name)
+		}
+	}
+	// phpmyadmin carries its own mount path in the YAML, so every binary that
+	// proxies it reaches it and the older flag stays correct.
+	p, err := LoadPreset("phpmyadmin")
+	if err != nil {
+		t.Fatalf("LoadPreset(phpmyadmin): %v", err)
+	}
+	if !p.DashboardExternal {
+		t.Error("phpmyadmin ships its own alias, so it should keep dashboard_external and reach older binaries too")
+	}
+}
+
 // A binary that knows the proxy must not inject the prefix when the store
 // preset backing an installed service does not ask to be proxied: the env moves
 // the app off "/", while the dashboard link still points there, and the overlay

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -60,7 +60,20 @@ type PresetPlatformImage struct {
 // the user picks a tag, Resolve() materialises a concrete CustomService whose
 // Name and Image are version-specific while every other field stays shared.
 type Preset struct {
-	CustomService     `yaml:",inline"`
+	CustomService `yaml:",inline"`
+	// DashboardProxy asks lerd-ui to serve this dashboard same-origin under
+	// /_svc/<name>/, for a preset whose mount path the binary supplies rather
+	// than the YAML (pgadmin's X-Script-Name header, mongo-express's base-URL
+	// env; see PresetProxyHeader / PresetProxyEnv).
+	//
+	// It exists alongside dashboard_external because that flag is not safe here:
+	// a released binary understands it and starts proxying, without the half
+	// that tells the upstream it moved, so the overlay gets the upstream's own
+	// 404. A binary that predates this field ignores it and keeps behaving
+	// exactly as it does today. A preset carrying its own mount path in the YAML
+	// (rabbitmq's path prefix, phpmyadmin's apache alias) needs no such care and
+	// keeps using dashboard_external, which works on every binary.
+	DashboardProxy    bool                  `yaml:"dashboard_proxy,omitempty" json:"dashboard_proxy,omitempty"`
 	Versions          []PresetVersion       `yaml:"versions,omitempty"`
 	DefaultVersion    string                `yaml:"default_version,omitempty"`
 	Default           bool                  `yaml:"default,omitempty"`

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -105,8 +105,8 @@ func TestLoadPreset_PgAdmin(t *testing.T) {
 	if !foundFramingCfg {
 		t.Errorf("pgadmin preset must ship config_local.py clearing X_FRAME_OPTIONS for iframe embedding")
 	}
-	if !p.DashboardExternal {
-		t.Errorf("pgadmin must set dashboard_external so lerd-ui proxies it same-origin and its session cookie survives the iframe")
+	if !p.DashboardProxy {
+		t.Errorf("pgadmin must set dashboard_proxy so lerd-ui proxies it same-origin and its session cookie survives the iframe")
 	}
 }
 
@@ -119,8 +119,8 @@ func TestLoadPreset_MongoExpress(t *testing.T) {
 	if len(p.DependsOn) != 1 || p.DependsOn[0] != "mongo" {
 		t.Errorf("mongo-express should depend on mongo, got %v", p.DependsOn)
 	}
-	if !p.DashboardExternal {
-		t.Errorf("mongo-express must set dashboard_external so lerd-ui proxies it same-origin and its session cookie survives the iframe")
+	if !p.DashboardProxy {
+		t.Errorf("mongo-express must set dashboard_proxy so lerd-ui proxies it same-origin and its session cookie survives the iframe")
 	}
 	if _, ok := p.Environment["ME_CONFIG_SITE_BASEURL"]; ok {
 		t.Errorf("the proxy base URL must be injected at generation, not stored in the preset, or a binary that predates the proxy moves the app off / and 404s its own dashboard link")

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -81,8 +81,8 @@ func TestLoadPreset_PhpMyAdmin(t *testing.T) {
 	if !foundFramingCfg {
 		t.Errorf("phpmyadmin preset must ship config.user.inc.php enabling AllowThirdPartyFraming for iframe embedding")
 	}
-	if !p.DashboardExternal {
-		t.Errorf("phpmyadmin must set dashboard_external so lerd-ui proxies it same-origin and its session cookie survives the iframe")
+	if !p.DashboardProxy {
+		t.Errorf("phpmyadmin must set dashboard_proxy so lerd-ui proxies it same-origin and its session cookie survives the iframe")
 	}
 }
 

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -60,6 +60,7 @@ func TestListPresets_SortedByName(t *testing.T) {
 }
 
 func TestLoadPreset_PhpMyAdmin(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	p, err := LoadPreset("phpmyadmin")
 	if err != nil {
 		t.Fatalf("LoadPreset(phpmyadmin) error = %v", err)
@@ -80,9 +81,13 @@ func TestLoadPreset_PhpMyAdmin(t *testing.T) {
 	if !foundFramingCfg {
 		t.Errorf("phpmyadmin preset must ship config.user.inc.php enabling AllowThirdPartyFraming for iframe embedding")
 	}
+	if !p.DashboardExternal {
+		t.Errorf("phpmyadmin must set dashboard_external so lerd-ui proxies it same-origin and its session cookie survives the iframe")
+	}
 }
 
 func TestLoadPreset_PgAdmin(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	p, err := LoadPreset("pgadmin")
 	if err != nil {
 		t.Fatalf("LoadPreset(pgadmin) error = %v", err)
@@ -99,6 +104,26 @@ func TestLoadPreset_PgAdmin(t *testing.T) {
 	}
 	if !foundFramingCfg {
 		t.Errorf("pgadmin preset must ship config_local.py clearing X_FRAME_OPTIONS for iframe embedding")
+	}
+	if !p.DashboardExternal {
+		t.Errorf("pgadmin must set dashboard_external so lerd-ui proxies it same-origin and its session cookie survives the iframe")
+	}
+}
+
+func TestLoadPreset_MongoExpress(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	p, err := LoadPreset("mongo-express")
+	if err != nil {
+		t.Fatalf("LoadPreset(mongo-express) error = %v", err)
+	}
+	if len(p.DependsOn) != 1 || p.DependsOn[0] != "mongo" {
+		t.Errorf("mongo-express should depend on mongo, got %v", p.DependsOn)
+	}
+	if !p.DashboardExternal {
+		t.Errorf("mongo-express must set dashboard_external so lerd-ui proxies it same-origin and its session cookie survives the iframe")
+	}
+	if _, ok := p.Environment["ME_CONFIG_SITE_BASEURL"]; ok {
+		t.Errorf("the proxy base URL must be injected at generation, not stored in the preset, or a binary that predates the proxy moves the app off / and 404s its own dashboard link")
 	}
 }
 

--- a/internal/podman/quadlet_embed_test.go
+++ b/internal/podman/quadlet_embed_test.go
@@ -376,6 +376,12 @@ func TestGenerateCustomQuadlet_ShareHosts(t *testing.T) {
 }
 
 func TestGenerateCustomQuadlet_InjectsRedisInsightProxyPath(t *testing.T) {
+	// The prefix is injected only for a preset that asks to be proxied, so the
+	// store definition has to be resolvable here.
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := config.SaveStorePreset("redisinsight", []byte("name: redisinsight\nimage: docker.io/redis/redisinsight:latest\ndashboard: http://localhost:8085\ndashboard_external: true\n")); err != nil {
+		t.Fatalf("seeding the redisinsight preset: %v", err)
+	}
 	svc := &config.CustomService{
 		Name:              "redisinsight",
 		Image:             "docker.io/redis/redisinsight:latest",

--- a/internal/presetfixtures/testdata/mongo-express.yaml
+++ b/internal/presetfixtures/testdata/mongo-express.yaml
@@ -10,6 +10,9 @@ environment:
 depends_on:
   - mongo
 dashboard: http://localhost:8082
+# The express-session cookie is dropped when the dashboard is framed from
+# another origin, so lerd-ui serves it same-origin under /_svc/mongo-express/.
+dashboard_external: true
 category: admin
 icon: leaf
 admin_for:

--- a/internal/presetfixtures/testdata/mongo-express.yaml
+++ b/internal/presetfixtures/testdata/mongo-express.yaml
@@ -12,7 +12,9 @@ depends_on:
 dashboard: http://localhost:8082
 # The express-session cookie is dropped when the dashboard is framed from
 # another origin, so lerd-ui serves it same-origin under /_svc/mongo-express/.
-dashboard_external: true
+# Not dashboard_external: the base URL that moves its router there comes from
+# lerd, so a binary that predates it would proxy to a path it does not serve.
+dashboard_proxy: true
 category: admin
 icon: leaf
 admin_for:

--- a/internal/presetfixtures/testdata/pgadmin.yaml
+++ b/internal/presetfixtures/testdata/pgadmin.yaml
@@ -14,6 +14,9 @@ dynamic_env:
 depends_on:
   - postgres
 dashboard: http://localhost:8081
+# The Flask session cookie is dropped when the dashboard is framed from another
+# origin, so lerd-ui serves it same-origin under /_svc/pgadmin/ instead.
+dashboard_external: true
 files:
   - target: /pgadmin4/servers.json
     generator: pgadmin_servers
@@ -26,12 +29,6 @@ files:
       X_FRAME_OPTIONS = ''
       ENHANCED_COOKIE_PROTECTION = False
       WTF_CSRF_CHECK_DEFAULT = False
-
-      # Allow pgadmin's Flask session + CSRF cookies to flow inside a cross-origin
-      # iframe (the lerd-ui dashboard). SameSite=None requires Secure=True, which
-      # browsers accept over HTTP on localhost.
-      SESSION_COOKIE_SAMESITE = 'None'
-      SESSION_COOKIE_SECURE = True
 category: admin
 icon: elephant
 admin_for:

--- a/internal/presetfixtures/testdata/pgadmin.yaml
+++ b/internal/presetfixtures/testdata/pgadmin.yaml
@@ -31,6 +31,14 @@ files:
       X_FRAME_OPTIONS = ''
       ENHANCED_COOKIE_PROTECTION = False
       WTF_CSRF_CHECK_DEFAULT = False
+
+      # A lerd that does not know dashboard_proxy still frames this from its own
+      # origin, where the Flask session and CSRF cookies need SameSite=None to
+      # be sent at all. That needs Secure=True, which browsers accept over HTTP
+      # on localhost. Inert once the dashboard is served same-origin, so it stays
+      # until no supported lerd frames this cross-origin.
+      SESSION_COOKIE_SAMESITE = 'None'
+      SESSION_COOKIE_SECURE = True
 category: admin
 icon: elephant
 admin_for:

--- a/internal/presetfixtures/testdata/pgadmin.yaml
+++ b/internal/presetfixtures/testdata/pgadmin.yaml
@@ -15,8 +15,10 @@ depends_on:
   - postgres
 dashboard: http://localhost:8081
 # The Flask session cookie is dropped when the dashboard is framed from another
-# origin, so lerd-ui serves it same-origin under /_svc/pgadmin/ instead.
-dashboard_external: true
+# origin, so lerd-ui serves it same-origin under /_svc/pgadmin/ instead. Not
+# dashboard_external: pgadmin learns that path from a header lerd sends, so a
+# binary that predates it would proxy to a mount pgadmin does not answer on.
+dashboard_proxy: true
 files:
   - target: /pgadmin4/servers.json
     generator: pgadmin_servers

--- a/internal/presetfixtures/testdata/phpmyadmin.yaml
+++ b/internal/presetfixtures/testdata/phpmyadmin.yaml
@@ -12,20 +12,16 @@ dynamic_env:
 depends_on:
   - mysql
 dashboard: http://localhost:8080
+# The session cookie is dropped when the dashboard is framed from another
+# origin, so lerd-ui serves it same-origin under /_svc/phpmyadmin/ instead.
+dashboard_external: true
 files:
+  - target: /etc/apache2/conf-enabled/lerd-path-prefix.conf
+    content: |
+      Alias /_svc/phpmyadmin /var/www/html
   - target: /etc/phpmyadmin/config.user.inc.php
     content: |
       <?php
-      // Allow phpmyadmin's session cookie to be sent when it's embedded in
-      // an iframe served from a different origin (the lerd-ui dashboard).
-      // The default SameSite=Strict drops the cookie on form POSTs, which
-      // breaks the server-switch dropdown via CSRF token mismatch.
-      // SameSite=None requires Secure=1, which phpmyadmin only sets when
-      // isHttps() is true, so we force the HTTPS env var — browsers treat
-      // localhost as secure so Secure cookies are accepted over HTTP.
-      $cfg['CookieSameSite'] = 'None';
-      $_SERVER['HTTPS'] = 'on';
-
       // The official phpmyadmin image only handles PMA_USER/PMA_PASSWORD for
       // single-host setups; in multi-host (PMA_HOSTS) it writes host/verbose
       // per server but leaves user/password blank, forcing a login screen.

--- a/internal/presetfixtures/testdata/phpmyadmin.yaml
+++ b/internal/presetfixtures/testdata/phpmyadmin.yaml
@@ -13,7 +13,9 @@ depends_on:
   - mysql
 dashboard: http://localhost:8080
 # The session cookie is dropped when the dashboard is framed from another
-# origin, so lerd-ui serves it same-origin under /_svc/phpmyadmin/ instead.
+# origin, so lerd-ui serves it same-origin under /_svc/phpmyadmin/ instead. The
+# alias below carries that mount path, so any binary that proxies this reaches
+# it and dashboard_external is safe here.
 dashboard_external: true
 files:
   - target: /etc/apache2/conf-enabled/lerd-path-prefix.conf

--- a/internal/presetfixtures/testdata/phpmyadmin.yaml
+++ b/internal/presetfixtures/testdata/phpmyadmin.yaml
@@ -13,10 +13,11 @@ depends_on:
   - mysql
 dashboard: http://localhost:8080
 # The session cookie is dropped when the dashboard is framed from another
-# origin, so lerd-ui serves it same-origin under /_svc/phpmyadmin/ instead. The
-# alias below carries that mount path, so any binary that proxies this reaches
-# it and dashboard_external is safe here.
-dashboard_external: true
+# origin, so lerd-ui serves it same-origin under /_svc/phpmyadmin/ instead. Not
+# dashboard_external: the alias below only reaches the container on a restart
+# that regenerates its unit, which an older lerd does not do in the pass that
+# flips it to the proxy, so it would serve a 404 in between.
+dashboard_proxy: true
 files:
   - target: /etc/apache2/conf-enabled/lerd-path-prefix.conf
     content: |
@@ -24,6 +25,15 @@ files:
   - target: /etc/phpmyadmin/config.user.inc.php
     content: |
       <?php
+      // A lerd that does not know dashboard_proxy still frames this from its own
+      // origin, where SameSite=Strict drops the session cookie on every POST.
+      // SameSite=None needs Secure, which phpmyadmin only sets when isHttps()
+      // is true, hence the forced env var; browsers accept Secure on localhost.
+      // Inert once the dashboard is served same-origin, so it stays until no
+      // supported lerd frames this cross-origin.
+      $cfg['CookieSameSite'] = 'None';
+      $_SERVER['HTTPS'] = 'on';
+
       // The official phpmyadmin image only handles PMA_USER/PMA_PASSWORD for
       // single-host setups; in multi-host (PMA_HOSTS) it writes host/verbose
       // per server but leaves user/password blank, forcing a login screen.

--- a/internal/serviceops/reconcile.go
+++ b/internal/serviceops/reconcile.go
@@ -63,25 +63,29 @@ func ReconcileServices(emit func(PhaseEvent)) (ReconcileResult, error) {
 			}
 		}
 		unitInstalled := UnitInstalledFn("lerd-" + svc.Name)
+		// Regenerate the quadlet when the unit is missing, or when the definition
+		// changed. WriteQuadletDiff is a no-op when the content is identical, so a
+		// client_shims-only change (which never appears in the quadlet) is free.
+		//
+		// Before the drift restart below, not after: a definition that adds a file
+		// mount changes the unit too, and restarting the old one brings the
+		// container back without the mount, leaving it a pass behind until
+		// something restarts it again.
+		if !unitInstalled || slices.Contains(res.DefinitionsRefreshed, svc.Name) {
+			if err := ensureQuadletFn(svc); err != nil {
+				errs = append(errs, fmt.Errorf("regenerating quadlet for %s: %w", svc.Name, err))
+				continue
+			}
+			if !unitInstalled {
+				res.QuadletsRegenerated = append(res.QuadletsRegenerated, svc.Name)
+			}
+		}
 		if unitInstalled {
 			if applied, err := RestartIfConfigDrifted(svc.Name, svc.Preset); err != nil {
 				errs = append(errs, err)
 			} else if applied {
 				res.ConfigsApplied = append(res.ConfigsApplied, svc.Name)
 			}
-			if !slices.Contains(res.DefinitionsRefreshed, svc.Name) {
-				continue
-			}
-		}
-		// Regenerate the quadlet when the unit is missing, or when the definition
-		// changed. WriteQuadletDiff is a no-op when the content is identical, so a
-		// client_shims-only change (which never appears in the quadlet) is free.
-		if err := ensureQuadletFn(svc); err != nil {
-			errs = append(errs, fmt.Errorf("regenerating quadlet for %s: %w", svc.Name, err))
-			continue
-		}
-		if !unitInstalled {
-			res.QuadletsRegenerated = append(res.QuadletsRegenerated, svc.Name)
 		}
 	}
 

--- a/internal/serviceops/reconcile_test.go
+++ b/internal/serviceops/reconcile_test.go
@@ -437,3 +437,44 @@ func TestReconcileServices_steadyStateNoop(t *testing.T) {
 		t.Fatalf("steady state must be a no-op, got %+v", res)
 	}
 }
+
+// A store change that adds a file mount has to land in one pass. The drift
+// restart must run against the regenerated unit, or the container comes back
+// without the new mount and whatever it carried (phpmyadmin's apache alias, so
+// its dashboard answers under the proxy) is missing until something restarts it
+// again.
+func TestReconcileServices_regeneratesBeforeRestartingOnDrift(t *testing.T) {
+	reconcileEnv(t)
+	if err := config.SaveStorePreset("probe-svc", []byte("name: probe-svc\nimage: example/probe:1\ndashboard: http://localhost:9999\n")); err != nil {
+		t.Fatalf("store preset: %v", err)
+	}
+	if err := config.SaveCustomService(&config.CustomService{Name: "probe-svc", Image: "example/probe:1", Preset: "probe-svc"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	writeQuadlet(t, "probe-svc", true)
+
+	var order []string
+	prevEnsure := ensureQuadletFn
+	t.Cleanup(func() { ensureQuadletFn = prevEnsure })
+	ensureQuadletFn = func(*config.CustomService) error {
+		order = append(order, "regenerate")
+		return nil
+	}
+
+	boot := time.Unix(1_000_000, 0)
+	restore := swapDriftSeams(t,
+		func(*config.CustomService) error { return nil },
+		func(*config.CustomService) (time.Time, bool) { return boot.Add(time.Hour), true },
+		func(string) (time.Time, bool) { return boot, true },
+		func(string) error { order = append(order, "restart"); return nil },
+		func(string) bool { return true },
+	)
+	defer restore()
+
+	if _, err := ReconcileServices(nil); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(order) != 2 || order[0] != "regenerate" || order[1] != "restart" {
+		t.Fatalf("want the unit regenerated before the drift restart, got %v", order)
+	}
+}

--- a/internal/ui/dashproxy.go
+++ b/internal/ui/dashproxy.go
@@ -15,14 +15,14 @@ import (
 	"github.com/geodro/lerd/internal/serviceops"
 )
 
-// Bundled admin dashboards (rabbitmq, redisinsight) set session/consent cookies
-// the browser refuses to carry into a cross-origin iframe, and their upstreams
-// expose no SameSite knob the way pgadmin/phpmyadmin do. We serve them
-// same-origin under /_svc/<name>/ so their cookies are first-party again, the
-// same trick the SPX profiler uses under /_spx/ (see profiler.go). The upstream
-// apps are configured to mount their UI at the same /_svc/<name> prefix
-// (rabbitmq management.path_prefix, redisinsight RI_PROXY_PATH), so the proxy
-// forwards the path unchanged rather than stripping it.
+// Bundled admin dashboards set session cookies the browser refuses to carry
+// into a cross-origin iframe. We serve them same-origin under /_svc/<name>/ so
+// their cookies are first-party again, the same trick the SPX profiler uses
+// under /_spx/ (see profiler.go). Each upstream is told to mount its UI at that
+// same prefix, so the proxy forwards the path unchanged rather than stripping
+// it: rabbitmq via management.path_prefix and phpmyadmin via an apache Alias
+// (conf mounts), redisinsight and mongo-express via env (PresetProxyEnv), and
+// pgadmin per request (PresetProxyHeader).
 
 const dashProxyPrefix = config.DashboardProxyPrefix
 
@@ -41,16 +41,30 @@ func dashProxyName(p string) string {
 }
 
 // dashProxyEligible reports whether a custom service should be served through
-// the same-origin proxy rather than opened in a new tab. Only bundled presets
-// (Preset set and still resolvable) that asked for an external dashboard
-// qualify; a user-defined custom service with dashboard_external keeps the
-// new-tab behavior.
+// the same-origin proxy rather than opened in a new tab. It shares the decision
+// with the quadlet generator, which uses it to tell the upstream where it is
+// mounted, so the two can't disagree about where the dashboard lives.
 func dashProxyEligible(svc *config.CustomService) bool {
-	if svc == nil || !svc.DashboardExternal || svc.Dashboard == "" || svc.Preset == "" {
-		return false
+	return config.DashboardProxied(svc)
+}
+
+// dashProxyTweaks are the per-preset adjustments one proxied dashboard needs:
+// a request header telling the upstream which path it is mounted at, and an
+// inline <script> injected into its HTML so it opens authenticated. Both are
+// derived from the preset, so they are stable for a given service name.
+type dashProxyTweaks struct {
+	headerKey   string
+	headerValue string
+	bootstrap   string
+}
+
+// dashProxyTweaksFor collects what the proxy must add for a service's preset.
+func dashProxyTweaksFor(svc *config.CustomService) dashProxyTweaks {
+	tw := dashProxyTweaks{bootstrap: config.PresetDashboardBootstrap(svc)}
+	if k, v, ok := config.PresetProxyHeader(svc); ok {
+		tw.headerKey, tw.headerValue = k, v
 	}
-	_, err := config.LoadPreset(svc.Preset)
-	return err == nil
+	return tw
 }
 
 var (
@@ -59,16 +73,15 @@ var (
 )
 
 // dashProxyFor returns a cached reverse proxy for the named service, keyed by
-// name and target so a changed dashboard URL rebuilds. bootstrap is an inline
-// <script> injected into the dashboard's HTML so it opens authenticated.
-func dashProxyFor(name string, target *url.URL, bootstrap string) *httputil.ReverseProxy {
+// name and target so a changed dashboard URL rebuilds.
+func dashProxyFor(name string, target *url.URL, tw dashProxyTweaks) *httputil.ReverseProxy {
 	key := name + "|" + target.String()
 	dashProxyMu.Lock()
 	defer dashProxyMu.Unlock()
 	if p, ok := dashProxyCache[key]; ok {
 		return p
 	}
-	p := newDashProxy(name, target, bootstrap)
+	p := newDashProxy(name, target, tw)
 	dashProxyCache[key] = p
 	return p
 }
@@ -78,13 +91,18 @@ func dashProxyFor(name string, target *url.URL, bootstrap string) *httputil.Reve
 // because the upstream is mounted at the same prefix; the response is rewritten
 // so it can be embedded in the lerd-ui iframe (strip framing headers, scope
 // cookies and redirects to the mount path).
-func newDashProxy(name string, target *url.URL, bootstrap string) *httputil.ReverseProxy {
+func newDashProxy(name string, target *url.URL, tw dashProxyTweaks) *httputil.ReverseProxy {
 	prefix := strings.TrimSuffix(dashProxyPath(name), "/")
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	orig := proxy.Director
 	proxy.Director = func(req *http.Request) {
 		orig(req)
 		req.Host = target.Host
+		// Set, not add: the mount path is ours to state, and a client-supplied
+		// value would otherwise steer where the upstream thinks it lives.
+		if tw.headerKey != "" {
+			req.Header.Set(tw.headerKey, tw.headerValue)
+		}
 		// Preserve the scheme the browser actually used (nginx forwards it, and
 		// lerd.localhost is served over https) so an upstream that builds absolute
 		// URLs from X-Forwarded-Proto doesn't downgrade them to http. Default to
@@ -102,7 +120,7 @@ func newDashProxy(name string, target *url.URL, bootstrap string) *httputil.Reve
 		}
 		// We rewrite the HTML to inject the auth bootstrap, so ask the upstream
 		// for an uncompressed body we can edit.
-		if bootstrap != "" {
+		if tw.bootstrap != "" {
 			req.Header.Del("Accept-Encoding")
 		}
 	}
@@ -120,8 +138,8 @@ func newDashProxy(name string, target *url.URL, bootstrap string) *httputil.Reve
 		if loc := resp.Header.Get("Location"); loc != "" {
 			resp.Header.Set("Location", rewriteLocation(loc, target.Host, prefix))
 		}
-		if bootstrap != "" {
-			return injectDashboardBootstrap(resp, bootstrap)
+		if tw.bootstrap != "" {
+			return injectDashboardBootstrap(resp, tw.bootstrap)
 		}
 		return nil
 	}
@@ -301,5 +319,5 @@ func handleDashProxy(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("dashboard for %s must be loopback", name), http.StatusBadGateway)
 		return
 	}
-	dashProxyFor(name, target, config.PresetDashboardBootstrap(svc)).ServeHTTP(w, r)
+	dashProxyFor(name, target, dashProxyTweaksFor(svc)).ServeHTTP(w, r)
 }

--- a/internal/ui/dashproxy_test.go
+++ b/internal/ui/dashproxy_test.go
@@ -37,9 +37,16 @@ func TestDashProxyEligible(t *testing.T) {
 	if dashProxyEligible(userCustom) {
 		t.Error("user custom service (no preset) must keep the new-tab behavior")
 	}
-	notExternal := &config.CustomService{Name: "rabbitmq", Dashboard: "http://localhost:15672", DashboardExternal: false, Preset: "rabbitmq"}
+	// The preset decides, not the copy saved at install time: a service installed
+	// before its dashboard moved behind the proxy must still be proxied, or the
+	// store change only reaches people who reinstall.
+	preflag := &config.CustomService{Name: "rabbitmq", Dashboard: "http://localhost:15672", DashboardExternal: false, Preset: "rabbitmq"}
+	if !dashProxyEligible(preflag) {
+		t.Error("dashboard_external must be read from the preset so existing installs pick the proxy up")
+	}
+	notExternal := &config.CustomService{Name: "elasticvue", Dashboard: "http://localhost:8083", DashboardExternal: true, Preset: "elasticvue"}
 	if dashProxyEligible(notExternal) {
-		t.Error("service without dashboard_external should not be proxied")
+		t.Error("a preset whose dashboard is not external must not be proxied")
 	}
 	unknownPreset := &config.CustomService{Name: "x", Dashboard: "http://localhost:1", DashboardExternal: true, Preset: "does-not-exist"}
 	if dashProxyEligible(unknownPreset) {
@@ -99,7 +106,7 @@ func TestRewriteLocation(t *testing.T) {
 
 func TestDashProxyModifyResponse(t *testing.T) {
 	target, _ := url.Parse("http://localhost:15672")
-	p := newDashProxy("rabbitmq", target, "")
+	p := newDashProxy("rabbitmq", target, dashProxyTweaks{})
 	resp := &http.Response{Header: http.Header{}}
 	resp.Header.Set("X-Frame-Options", "DENY")
 	resp.Header.Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'")
@@ -152,7 +159,7 @@ func TestInjectDashboardBootstrap(t *testing.T) {
 
 func TestDashProxyDirector_ForwardsPathAndSetsHost(t *testing.T) {
 	target, _ := url.Parse("http://localhost:15672")
-	p := newDashProxy("rabbitmq", target, "")
+	p := newDashProxy("rabbitmq", target, dashProxyTweaks{})
 	req := httptest.NewRequest("GET", "http://lerd.localhost/_svc/rabbitmq/api/whoami", nil)
 	p.Director(req)
 	if req.URL.Path != "/_svc/rabbitmq/api/whoami" {
@@ -160,6 +167,21 @@ func TestDashProxyDirector_ForwardsPathAndSetsHost(t *testing.T) {
 	}
 	if req.Host != "localhost:15672" {
 		t.Errorf("Host = %q, want localhost:15672", req.Host)
+	}
+}
+
+func TestDashProxyDirector_SendsProxyHeader(t *testing.T) {
+	// pgAdmin learns its mount path from X-Script-Name on every request; without
+	// it the upstream 404s the prefixed path and generates root-absolute URLs.
+	target, _ := url.Parse("http://localhost:8081")
+	p := newDashProxy("pgadmin", target, dashProxyTweaks{headerKey: "X-Script-Name", headerValue: "/_svc/pgadmin"})
+	req := httptest.NewRequest("GET", "http://lerd.localhost/_svc/pgadmin/browser/", nil)
+	// A client-supplied value must not survive: it would move the mount and let a
+	// crafted request drive the upstream to generate URLs pointing off the mount.
+	req.Header.Set("X-Script-Name", "/attacker")
+	p.Director(req)
+	if got := req.Header.Get("X-Script-Name"); got != "/_svc/pgadmin" {
+		t.Errorf("X-Script-Name = %q, want /_svc/pgadmin", got)
 	}
 }
 
@@ -210,7 +232,7 @@ func TestIsLoopbackTarget(t *testing.T) {
 
 func TestDashProxyDirector_RecomputesInjectedForwardedProto(t *testing.T) {
 	target, _ := url.Parse("http://localhost:15672")
-	p := newDashProxy("rabbitmq", target, "")
+	p := newDashProxy("rabbitmq", target, dashProxyTweaks{})
 	req := httptest.NewRequest("GET", "http://lerd.localhost/_svc/rabbitmq/", nil)
 	req.Header.Set("X-Forwarded-Proto", "https\nX-Injected: 1")
 	p.Director(req)

--- a/internal/ui/web/src/components/DashboardOverlay.svelte
+++ b/internal/ui/web/src/components/DashboardOverlay.svelte
@@ -241,13 +241,20 @@
     {#if isDocs}
       <DocsViewer />
     {:else}
-      <iframe
-        bind:this={iframeEl}
-        onload={onIframeLoad}
-        src={iframeSrc}
-        class="flex-1 w-full bg-white border-0"
-        title={d.label || d.name}
-      ></iframe>
+      <!-- Keyed on the source so switching dashboards tears the frame down and
+           builds a new one. Re-pointing the old frame is a navigation, which
+           runs the embedded app's beforeunload handler; an admin UI that
+           registers one (pgAdmin) then blocks the swap behind a native confirm
+           the overlay has no way to answer. -->
+      {#key iframeSrc}
+        <iframe
+          bind:this={iframeEl}
+          onload={onIframeLoad}
+          src={iframeSrc}
+          class="flex-1 w-full bg-white border-0"
+          title={d.label || d.name}
+        ></iframe>
+      {/key}
     {/if}
   </div>
 {/if}

--- a/internal/ui/web/src/components/DashboardOverlay.test.ts
+++ b/internal/ui/web/src/components/DashboardOverlay.test.ts
@@ -99,6 +99,23 @@ describe('DashboardOverlay', () => {
     expect(container.querySelector('.mark-brand')?.getAttribute('style')).toContain('--mark-tint: #0f6cbd');
   });
 
+  // Switching dashboards must replace the frame, not point the old one somewhere
+  // new. Navigating it runs the embedded app's beforeunload handler, and an admin
+  // UI that registers one (pgAdmin) puts up a native confirm the overlay can't
+  // dismiss: the header moves on while the frame stays stuck behind the dialog.
+  it('builds a fresh frame for each dashboard instead of navigating the old one', async () => {
+    dashboardOpen.set({ name: 'pgadmin', label: 'pgAdmin', dashboard: '/_svc/pgadmin/' });
+    const { container } = render(DashboardOverlay);
+    const first = container.querySelector('iframe');
+    expect(first?.getAttribute('src')).toBe('/_svc/pgadmin/');
+
+    dashboardOpen.set({ name: 'phpmyadmin', label: 'phpMyAdmin', dashboard: '/_svc/phpmyadmin/' });
+    await waitFor(() => {
+      expect(container.querySelector('iframe')?.getAttribute('src')).toBe('/_svc/phpmyadmin/');
+    });
+    expect(container.querySelector('iframe')).not.toBe(first);
+  });
+
   // docs and profiler are not services and ship no mark; their built-in glyph
   // has to survive the switch to the shared icon.
   it('keeps the built-in glyph for a dashboard no service backs', () => {


### PR DESCRIPTION
phpMyAdmin renders in the dashboard overlay but every POST it makes comes back as the error page reading "Cannot connect: invalid settings", so switching servers from its dropdown fails. The cause is the session cookie rather than the database. The overlay embeds the admin UI at its own origin inside lerd-ui, so the cookie is third party, and the Chromium that Electron ships blocks it by default. A GET still renders because phpMyAdmin will start a fresh session, a POST cannot and falls back to a server config it does not have. pgAdmin sets the same Secure, SameSite=None cookie and breaks the same way, and Mongo Express carries an express-session cookie with no SameSite override at all.

All three now go through the same-origin proxy that already serves RabbitMQ and RedisInsight under /_svc/<name>/, which puts the cookie back in first party territory and lets the forced HTTPS and the SameSite=None hacks go with it. Each upstream needed its own way to learn where it is mounted. phpMyAdmin takes an Apache alias, the same shape as RabbitMQ's path prefix conf. Mongo Express takes a base URL in its environment. pgAdmin reads the mount path per request from a header, which is the better half of the deal, because the prefix applies without restarting the container and the app keeps answering at its own root alongside it.

Which flag a preset uses to ask for this now depends on where its mount path comes from, because dashboard_external is not safe for the two that take theirs from the binary. Every released lerd that proxies already understands that flag, and reconcile copies preset fields onto the installed service, so publishing it for pgAdmin or Mongo Express would route those overlays to /_svc/<name>/ while the half that tells the upstream it moved does not exist yet, and the dashboard would answer 404 after nothing more than a store refresh. Those two ask with dashboard_proxy, which an older binary reads as an unknown key and ignores, leaving the dashboard exactly where it was. phpMyAdmin keeps dashboard_external, since its alias travels in the same YAML and any binary that proxies it reaches it.

The prefix an upstream is told to serve under and the decision to proxy it come from one predicate, so the two halves cannot land apart. Injecting one without the other moves the app off / while the dashboard link still points there, and the overlay gets the upstream's own 404.

Eligibility reads that flag from the preset rather than the copy saved when the service was installed, so a store definition that moves a dashboard behind the proxy reaches a service installed before it, the way file mounts already do.

Switching between two open dashboards also stranded the overlay behind pgAdmin's unload prompt, because the single iframe was re-pointed rather than replaced. The frame is now keyed on its source, so a switch builds a new one instead of navigating the old one.

Closes #1462
Closes #1469