### PR TITLE
fix(test): guard the macOS unit dir the way the Linux ones are guarded

### DIFF
--- a/docs/contributing/building.md
+++ b/docs/contributing/building.md
@@ -23,6 +23,8 @@ make clean       # remove ./build/ and internal/ui/web/dist/
 
 Tests must isolate lerd's state before they touch it, with `t.Setenv("XDG_CONFIG_HOME", t.TempDir())` and `t.Setenv("XDG_DATA_HOME", t.TempDir())`. Anything writing or deleting a real config file, systemd unit or quadlet panics with the path it tried to touch, because a test that skipped this once removed a developer's lerd-dns quadlet and left the container running under a unit systemd no longer knew about.
 
+On macOS the launchd units in `~/Library/LaunchAgents` follow `HOME` instead, so a test that writes or removes one needs `t.Setenv("HOME", t.TempDir())` on top of the XDG pair, guarded by `runtime.GOOS == "darwin"`. Moving `HOME` on Linux would relocate podman's container storage into the temp dir, which the test then cannot clean up. The guard names whichever var applies when it fires.
+
 ## Cross-compile for arm64
 
 Without tray (no CGO required):

--- a/internal/cli/install_dns_darwin.go
+++ b/internal/cli/install_dns_darwin.go
@@ -70,6 +70,7 @@ func installDNSService(w io.Writer) error {
 	if err := os.MkdirAll(filepath.Dir(plistFile), 0755); err != nil {
 		return err
 	}
+	config.GuardRealWrite(plistFile)
 	return os.WriteFile(plistFile, []byte(plist), 0644)
 }
 

--- a/internal/cli/startstop_darwin.go
+++ b/internal/cli/startstop_darwin.go
@@ -38,7 +38,8 @@ func migrateExecWorkerPlists() {
 			name := strings.TrimSuffix(filepath.Base(p), ".plist")
 			domain := fmt.Sprintf("gui/%d", os.Getuid())
 			exec.Command("launchctl", "bootout", domain+"/com.lerd."+name).Run() //nolint:errcheck
-			os.Remove(p)                                                         //nolint:errcheck
+			config.GuardRealWrite(p)
+			os.Remove(p) //nolint:errcheck
 		}
 	}
 }

--- a/internal/cli/worker_unit_fields_test.go
+++ b/internal/cli/worker_unit_fields_test.go
@@ -57,6 +57,7 @@ func TestWriteWorkerUnitFileAcceptsNormalFields(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("XDG_DATA_HOME", tmp)
+	isolateLaunchAgents(t)
 
 	changed, err := writeWorkerUnitFile(
 		"lerd-queue-mysite", "Queue Worker", "mysite", t.TempDir(), "8.4",

--- a/internal/cli/workers_mode_test.go
+++ b/internal/cli/workers_mode_test.go
@@ -50,6 +50,7 @@ func TestWorkersModeFromArgs_UnknownValueErrors(t *testing.T) {
 func TestApplyWorkersMode_UpdatesConfig(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	isolateLaunchAgents(t)
 
 	if err := applyWorkersMode(config.WorkerExecModeContainer, nil); err != nil {
 		t.Fatalf("applyWorkersMode: %v", err)
@@ -75,6 +76,7 @@ func TestApplyWorkersMode_UpdatesConfig(t *testing.T) {
 func TestApplyWorkersMode_SameValueIsNoOp(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	isolateLaunchAgents(t)
 	// Default is exec; applying exec should succeed without error.
 	if err := applyWorkersMode(config.WorkerExecModeExec, nil); err != nil {
 		t.Fatalf("applyWorkersMode no-op: %v", err)

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -160,6 +160,20 @@ func SystemdUserDir() string {
 	return filepath.Join(xdgConfigHome(), "systemd", "user")
 }
 
+// LaunchAgentsDir returns the directory macOS keeps lerd's launchd units in,
+// empty on Linux, whose unit dirs follow the XDG vars instead. This one follows
+// HOME, which is why isolating only the XDG vars leaves it exposed.
+func LaunchAgentsDir() string {
+	if runtime.GOOS != "darwin" {
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, "Library", "LaunchAgents")
+}
+
 // PHPImageHashFile returns the path to the stored PHP-FPM Containerfile hash.
 // InstalledVersionFile records the lerd version whose `lerd install` last ran,
 // so a binary replaced by a package manager can be told from one this install

--- a/internal/config/testguard.go
+++ b/internal/config/testguard.go
@@ -10,8 +10,11 @@ import (
 // realStateDirs are the lerd dirs of whoever is running the process, resolved once
 // at start. XDG_DATA_HOME and XDG_CONFIG_HOME decide them and a test moves those,
 // so resolving later can't tell a test's temp dir from the developer's own. The
-// unit dirs are here too: the bug that started this wrote a real systemd unit.
-var realStateDirs = []string{DataDir(), ConfigDir(), SystemdUserDir(), QuadletDir()}
+// unit dirs are here too: the bug that started this wrote a real systemd unit,
+// and the macOS one follows HOME, which the XDG isolation every test does misses.
+var realLaunchAgentsDir = LaunchAgentsDir()
+
+var realStateDirs = []string{DataDir(), ConfigDir(), SystemdUserDir(), QuadletDir(), realLaunchAgentsDir}
 
 // underTest reports whether this process is a test binary, read from the command
 // line rather than testing.Testing() so the std testing package stays out of the
@@ -51,10 +54,19 @@ func guardRealWrite(path string) {
 		}
 		real = resolveLinks(real)
 		if abs == real || strings.HasPrefix(abs, real+string(os.PathSeparator)) {
-			panic(fmt.Sprintf("test wrote to or removed the real lerd state at %s: isolate it with "+
-				`t.Setenv("XDG_DATA_HOME", t.TempDir())`+" and "+`t.Setenv("XDG_CONFIG_HOME", t.TempDir())`, abs))
+			panic(fmt.Sprintf("test wrote to or removed the real lerd state at %s: isolate it with %s", abs, isolationHint(real)))
 		}
 	}
+}
+
+// isolationHint names the vars that actually move the dir the test tripped on.
+// The launchd one follows HOME, so telling its author to set the XDG vars would
+// send them after an isolation that cannot work.
+func isolationHint(dir string) string {
+	if realLaunchAgentsDir != "" && dir == resolveLinks(realLaunchAgentsDir) {
+		return `t.Setenv("HOME", t.TempDir())`
+	}
+	return `t.Setenv("XDG_DATA_HOME", t.TempDir())` + " and " + `t.Setenv("XDG_CONFIG_HOME", t.TempDir())`
 }
 
 // resolveLinks canonicalises what exists of path, so a symlinked state dir can't

--- a/internal/config/testguard_test.go
+++ b/internal/config/testguard_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -35,6 +36,48 @@ func TestGuardRealWrite(t *testing.T) {
 		}()
 		guardRealWrite(filepath.Join(t.TempDir(), "lerd", "sites.yaml"))
 	})
+}
+
+// The macOS unit dir follows HOME, not any XDG var, so a test that isolated only
+// the XDG vars still wrote real launchd units and left a developer without an
+// nginx. The guard has to know that dir the way it knows the Linux ones.
+func TestGuardRealWrite_coversTheLaunchAgentsDir(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		if LaunchAgentsDir() != "" {
+			t.Errorf("launchd units are a macOS path, got %q", LaunchAgentsDir())
+		}
+		t.Skip("no launchd on this platform")
+	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("writing a real launchd unit from a test must panic, not silently land")
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "real lerd state") {
+			t.Errorf("panic should name the problem, got %v", r)
+		}
+		// The XDG advice is useless here, so the hint has to name the var that
+		// actually moves this dir.
+		if !strings.Contains(msg, `t.Setenv("HOME"`) {
+			t.Errorf("panic should point at HOME for a launchd unit, got %v", r)
+		}
+	}()
+	guardRealWrite(filepath.Join(LaunchAgentsDir(), "lerd-nginx.plist"))
+}
+
+// An isolated HOME is what a well-behaved test sets, and it must stay allowed.
+func TestGuardRealWrite_allowsAnIsolatedLaunchAgentsDir(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("no launchd on this platform")
+	}
+	t.Setenv("HOME", t.TempDir())
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("a relocated HOME must not trip the guard, got %v", r)
+		}
+	}()
+	guardRealWrite(filepath.Join(LaunchAgentsDir(), "lerd-nginx.plist"))
 }
 
 // The dirs are captured at process start, because a test relocates XDG_DATA_HOME

--- a/internal/services/launchd_darwin.go
+++ b/internal/services/launchd_darwin.go
@@ -133,6 +133,22 @@ func plistPath(name string) string {
 	return filepath.Join(launchAgentsDir(), name+".plist")
 }
 
+// writePlist and removePlist are the only ways a unit file is created or
+// deleted, so the guard that keeps a forgetful test off the developer's own
+// LaunchAgents dir sits on the single path all of them go through.
+func writePlist(name, plist string) error {
+	config.GuardRealWrite(plistPath(name))
+	return os.WriteFile(plistPath(name), []byte(plist), 0644)
+}
+
+func removePlist(name string) error {
+	config.GuardRealWrite(plistPath(name))
+	if err := os.Remove(plistPath(name)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 func plistLabel(name string) string {
 	return "com.lerd." + name
 }
@@ -628,7 +644,7 @@ func (m *darwinServiceManager) WriteServiceUnit(name, content string) error {
 	}
 	logPath := filepath.Join(lerdLogsDir(), name+".log")
 	plist := buildPlist(plistLabel(name), args, true, keepAlive, logPath, logPath)
-	return os.WriteFile(plistPath(name), []byte(plist), 0644)
+	return writePlist(name, plist)
 }
 
 func (m *darwinServiceManager) WriteServiceUnitIfChanged(name, content string) (bool, error) {
@@ -646,7 +662,7 @@ func (m *darwinServiceManager) WriteServiceUnitIfChanged(name, content string) (
 	if err := ensurePlistDirs(name); err != nil {
 		return false, err
 	}
-	return true, os.WriteFile(plistPath(name), []byte(newPlist), 0644)
+	return true, writePlist(name, newPlist)
 }
 
 // WriteTimerUnitIfChanged is a no-op on macOS until launchd
@@ -665,10 +681,7 @@ func (m *darwinServiceManager) RemoveTimerUnit(_ string) error { return nil }
 func (m *darwinServiceManager) ListTimerUnits(_ string) []string { return nil }
 
 func (m *darwinServiceManager) RemoveServiceUnit(name string) error {
-	if err := os.Remove(plistPath(name)); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	return nil
+	return removePlist(name)
 }
 
 func (m *darwinServiceManager) ListServiceUnits(nameGlob string) []string {
@@ -714,7 +727,7 @@ func (m *darwinServiceManager) WriteContainerUnit(name, content string) error {
 	// Stdout is suppressed (/dev/null) because `podman run -d` only prints the container
 	// ID there; real container output is accessible via `podman logs <name>`.
 	plist := buildPlist(plistLabel(name), args, false, keepAliveNever, "/dev/null", logPath)
-	return os.WriteFile(plistPath(name), []byte(plist), 0644)
+	return writePlist(name, plist)
 }
 
 func (m *darwinServiceManager) ContainerUnitInstalled(name string) bool {
@@ -723,10 +736,7 @@ func (m *darwinServiceManager) ContainerUnitInstalled(name string) bool {
 }
 
 func (m *darwinServiceManager) RemoveContainerUnit(name string) error {
-	if err := os.Remove(plistPath(name)); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	return nil
+	return removePlist(name)
 }
 
 func (m *darwinServiceManager) ListContainerUnits(nameGlob string) []string {

--- a/internal/siteops/custom_container_test.go
+++ b/internal/siteops/custom_container_test.go
@@ -18,6 +18,7 @@ func setupCustomContainerEnv(t *testing.T) (projectDir, confD string) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	isolateLaunchAgents(t)
 
 	// Stub out functions that call podman/systemd.
 	origWriteUnit := podman.WriteContainerUnitFn

--- a/internal/siteops/demote_test.go
+++ b/internal/siteops/demote_test.go
@@ -43,6 +43,7 @@ func TestDemoteFrankenPHPToFPM_stopsContainerAndRecreatesWorkers(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)
 	t.Setenv("XDG_CONFIG_HOME", tmp)
+	isolateLaunchAgents(t)
 	fakePodmanOnPath(t)
 
 	rec := &recordingLifecycle{}

--- a/internal/siteops/launchagents_test.go
+++ b/internal/siteops/launchagents_test.go
@@ -1,0 +1,16 @@
+package siteops
+
+import (
+	"runtime"
+	"testing"
+)
+
+// isolateLaunchAgents redirects HOME so a test that writes or removes a unit
+// cannot touch the real ~/Library/LaunchAgents. Only macOS derives that
+// directory from HOME; the Linux unit dir already follows XDG_CONFIG_HOME.
+func isolateLaunchAgents(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "darwin" {
+		t.Setenv("HOME", t.TempDir())
+	}
+}

--- a/internal/ui/launchagents_test.go
+++ b/internal/ui/launchagents_test.go
@@ -1,0 +1,16 @@
+package ui
+
+import (
+	"runtime"
+	"testing"
+)
+
+// isolateLaunchAgents redirects HOME so a test that writes or removes a unit
+// cannot touch the real ~/Library/LaunchAgents. Only macOS derives that
+// directory from HOME; the Linux unit dir already follows XDG_CONFIG_HOME.
+func isolateLaunchAgents(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "darwin" {
+		t.Setenv("HOME", t.TempDir())
+	}
+}

--- a/internal/ui/nginx_global_test.go
+++ b/internal/ui/nginx_global_test.go
@@ -22,6 +22,7 @@ func setupGlobalNginx(t *testing.T) string {
 	data := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", data)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	isolateLaunchAgents(t)
 	stubNginxReload(t)
 	stubNginxTest(t, "nginx: configuration file /etc/nginx/nginx.conf test is successful", nil)
 	if _, err := nginx.RewriteNginxQuadlet(); err != nil {

--- a/internal/ui/worker_mode_test.go
+++ b/internal/ui/worker_mode_test.go
@@ -17,6 +17,7 @@ import (
 func TestHandleSettingsWorkerMode_UpdatesConfig(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	isolateLaunchAgents(t)
 
 	body, _ := json.Marshal(map[string]string{"mode": config.WorkerExecModeContainer})
 	req := httptest.NewRequest(http.MethodPost, "/api/settings/worker-mode", bytes.NewReader(body))
@@ -39,6 +40,7 @@ func TestHandleSettingsWorkerMode_UpdatesConfig(t *testing.T) {
 func TestHandleSettingsWorkerMode_RejectsUnknownMode(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	isolateLaunchAgents(t)
 
 	body, _ := json.Marshal(map[string]string{"mode": "unknown"})
 	req := httptest.NewRequest(http.MethodPost, "/api/settings/worker-mode", bytes.NewReader(body))


### PR DESCRIPTION
The guard that keeps a test off the developer's own lerd state knew the XDG dirs and the Linux unit dirs, and never knew about ~/Library/LaunchAgents, which follows HOME instead. The plist writers went straight to os.WriteFile and os.Remove without asking it, so both halves had to change before listing the directory could bite.

The macOS unit dir joins realStateDirs, and every plist write and remove goes through one pair of helpers that call the guard first, as do the DNS unit writer and the worker plist migration in the start path.

Turning it on found six places across cli, siteops and ui that were reaching the real directory. One writes lerd-nginx.plist and two write a real site's schedule worker, which is the shape of the phantom worker units that have needed hand cleanup before. They isolate HOME on darwin now. The isolation stays scoped to macOS because moving HOME on Linux relocates podman's container storage into the temp dir, which the test then cannot clean up.

The panic names whichever var moves the dir it fired on. Pointing the author of a launchd unit at XDG_DATA_HOME sent them after an isolation that could never work, and the contributing guide said the same thing.

Closes #1471
