### PR TITLE
fix(install): keep a service on its registered definition

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,6 +289,8 @@ If a service with that name already exists locally and the definitions differ, a
 Replace service/mongodb with the version from .lerd.yaml? (y/N)
 ```
 
+Once a service is registered, the registered definition is the one lerd runs. The inline block stays a record of what the project asked for at link time, so an old copy committed months ago cannot put an already-installed service back on the image or the host port it shipped with: `lerd install` regenerates every unit from `~/.config/lerd/services/<name>.yaml`. Use the replace prompt above to move a registered service to a newer inline definition.
+
 ### Custom frameworks
 
 When `lerd init` runs in a project that uses a custom framework (one added with `lerd framework add`), the full framework definition is embedded under `framework_def`. On a fresh machine the definition is restored automatically before linking, no manual `lerd framework add` step needed.

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -722,7 +722,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 					path := filepath.Join(config.QuadletDir(), "lerd-"+svc.Name+".container")
 					before, _ := os.ReadFile(path)
 					if svc.Custom != nil {
-						ensureCustomServiceQuadlet(svc.Custom) //nolint:errcheck
+						ensureCustomServiceQuadlet(installedServiceDefinition(svc.Name, svc.Custom)) //nolint:errcheck
 					} else {
 						ensureServiceQuadlet(svc.Name) //nolint:errcheck
 					}

--- a/internal/cli/install_service_definition_test.go
+++ b/internal/cli/install_service_definition_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// A site keeps a copy of the service definition it was linked with. When that
+// copy has gone stale against the store, install must regenerate the quadlet
+// from the installed definition instead, or the service goes back to an old
+// image and an old host port that another service now publishes.
+func TestInstalledServiceDefinition_prefersTheInstalledYAML(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	installed := &config.CustomService{
+		Name:  "adminui",
+		Image: "docker.io/library/adminui:latest",
+		Ports: []string{"8080:80"},
+	}
+	if err := config.SaveCustomService(installed); err != nil {
+		t.Fatalf("saving the installed definition: %v", err)
+	}
+
+	stale := &config.CustomService{
+		Name:  "adminui",
+		Image: "docker.io/adminui/adminui:latest",
+		Ports: []string{"8081:80"},
+	}
+
+	got := installedServiceDefinition("adminui", stale)
+	if got.Image != installed.Image {
+		t.Errorf("image = %q, want the installed %q", got.Image, installed.Image)
+	}
+	if len(got.Ports) != 1 || got.Ports[0] != "8080:80" {
+		t.Errorf("ports = %v, want the installed [8080:80]", got.Ports)
+	}
+}
+
+// A service declared inline in .lerd.yaml and never installed globally has no
+// other definition, so the site copy stays the one install writes.
+func TestInstalledServiceDefinition_fallsBackToTheSiteCopy(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	inline := &config.CustomService{
+		Name:  "inlineonly",
+		Image: "docker.io/library/inlineonly:latest",
+		Ports: []string{"9500:80"},
+	}
+
+	got := installedServiceDefinition("inlineonly", inline)
+	if got != inline {
+		t.Errorf("got %+v, want the inline definition", got)
+	}
+}

--- a/internal/cli/services.go
+++ b/internal/cli/services.go
@@ -902,6 +902,18 @@ func ensureCustomServiceQuadlet(svc *config.CustomService) error {
 	return serviceops.EnsureCustomServiceQuadlet(svc)
 }
 
+// installedServiceDefinition returns the definition a service quadlet should be
+// written from. A site's .lerd.yaml keeps the copy it was linked with, while the
+// installed YAML is the one reconcile keeps in sync with the store, so an
+// install that preferred the site copy would put the service back on an image
+// and a host port the store has since moved away from.
+func installedServiceDefinition(name string, inline *config.CustomService) *config.CustomService {
+	if installed, err := config.LoadCustomService(name); err == nil && installed != nil {
+		return installed
+	}
+	return inline
+}
+
 // newServiceExposeCmd returns the `service expose` command.
 func newServiceExposeCmd() *cobra.Command {
 	var remove bool


### PR DESCRIPTION
A project can declare a service inline in its .lerd.yaml, and lerd registers that definition under the config directory when the site is linked. Every service command reads the registered file from then on, except install, which rewrote the quadlet from the copy still sitting in the site file while restoring unit files for each linked site.

That copy is frozen at link time, so a service installed months ago came back with the image and the host port it carried that day. When a preset had since moved to another host port, install put the unit back on the old one, saw the content change, restarted the service, and found the port already published by another admin UI, so the container could not bind and the unit spent its restart budget before a later pass regenerated it correctly. The run still ended healthy, which is why it read as a warning rather than a broken install, but it repeated on every install.

Install now regenerates a registered service from its registered definition and falls back to the inline block only when nothing is registered under that name, so the block stays a record of what the project asked for rather than an instruction that outlives it.

Closes #1481