### PR TITLE
fix: address the defects found testing v1.33.0 across distro guests

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -146,7 +146,7 @@ Supported PHP versions: **8.5**, **8.4**, **8.3**, **8.2**, **8.1**, and the fro
 | `lerd use <version>` | Set the global PHP version and build the FPM image if needed |
 | `lerd isolate <version>` | Pin PHP version for cwd: writes `.php-version` and updates `.lerd.yaml` if present, then re-links |
 | `lerd php:list` | List all installed PHP-FPM versions |
-| `lerd php:rebuild [--local]` | Force-rebuild all installed PHP-FPM images (pulls pre-built base by default; `--local` builds from source) |
+| `lerd php:rebuild [version] [--local]` | Force-rebuild PHP-FPM images, or install a version this machine does not have (pulls pre-built base by default; `--local` builds from source) |
 | `lerd fetch [version...] [--local]` | Pull pre-built PHP FPM base images from ghcr.io for the given (or all supported) versions; `--local` builds from source instead |
 | `lerd xdebug on [version] [--mode MODE] [--on-demand]` | Enable Xdebug for a PHP version. `--mode` defaults to `debug`; accepts `coverage`, `develop`, `profile`, `trace`, `gcstats`, or comma combos like `debug,coverage`. `--on-demand` sets `start_with_request=trigger` so nothing auto-connects |
 | `lerd xdebug off [version]` | Disable Xdebug |

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -7,7 +7,7 @@
 | `lerd use <version>` | Set the global PHP version and build the FPM image if needed |
 | `lerd isolate <version>` | Pin PHP version for cwd: writes `.php-version` and updates `.lerd.yaml` if it exists, then re-links |
 | `lerd php:list` | List all installed PHP-FPM versions |
-| `lerd php:rebuild [--local]` | Force-rebuild all installed PHP-FPM images; `--local` builds from source instead of pulling a base |
+| `lerd php:rebuild [version] [--local]` | Force-rebuild PHP-FPM images, or add a version this machine does not have yet; `--local` builds from source instead of pulling a base |
 | `lerd fetch [version...] [--local]` | Pull pre-built PHP FPM base images from ghcr.io; `--local` builds from source instead |
 | `lerd xdebug on [version] [--mode MODE] [--on-demand]` | Enable Xdebug for a PHP version with the given mode (default `debug`) and restart the FPM container. `--on-demand` sets `start_with_request=trigger` so nothing auto-connects |
 | `lerd xdebug off [version]` | Disable Xdebug and restart the FPM container |
@@ -157,6 +157,8 @@ Lerd automatically manages which PHP-FPM containers are running based on which v
 **Auto-start**: FPM is started automatically when you link a site (`lerd link`, `lerd park`, `lerd isolate`) or change the global default (`lerd use`). When unpausing a site, lerd also ensures the required FPM container is running before restoring the nginx vhost.
 
 **Build on first use**: when a link lands on a PHP version this machine has never built (an older framework clamps to a version below the ones you have, say), `lerd link` builds that version's image before starting it, so the site serves rather than answering 502. The build streams its progress as a link step. If the build cannot run (an unattended `lerd park` sweep withholds builds) or fails, the site is still registered and lerd names the one command that finishes the job, `lerd php:rebuild <version>`.
+
+**Adding a version by hand**: `lerd php:rebuild <version>` names a version this machine has never installed and installs it, registering the unit before it builds so the version shows up in `lerd php:list` either way. That is the command every surface points at when one is missing, so a pin written ahead of the install (`lerd isolate 8.4` in a directory that is not a site yet) has a way to be satisfied without waiting for a link.
 
 **Manual control**: unused PHP versions (no active sites) can be started and stopped manually from the dashboard (System > PHP > Start / Stop). From the CLI:
 

--- a/internal/cli/fpm_ensure.go
+++ b/internal/cli/fpm_ensure.go
@@ -242,10 +242,12 @@ func persistWorktreePHPVersion(worktree, version string) {
 
 // notInstalledErr builds the error returned when a version isn't installed and
 // we can't prompt (no TTY) or have nothing to switch to.
+// It names php:rebuild rather than `lerd install`, which takes no version and
+// so could never add the one being asked for.
 func notInstalledErr(version string) error {
 	if installed := otherInstalledVersions(version); len(installed) > 0 {
-		return fmt.Errorf("PHP %s is not installed (installed: %s) — pin one with a .php-version file, or run 'lerd install' to add %s",
-			version, strings.Join(installed, ", "), version)
+		return fmt.Errorf("PHP %s is not installed (installed: %s) — pin one with a .php-version file, or run 'lerd php:rebuild %s' to add %s",
+			version, strings.Join(installed, ", "), version, version)
 	}
-	return fmt.Errorf("PHP %s is not installed — run 'lerd install' to add it", version)
+	return fmt.Errorf("PHP %s is not installed — run 'lerd php:rebuild %s' to add it", version, version)
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1041,6 +1041,16 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		startPerSiteContainers()
 	}
 
+	// Pull the current preset for every installed service and re-render what it
+	// changed. A store preset that adds a file mount or moves a dashboard behind
+	// the lerd-ui proxy reaches a running container only through this pass, and
+	// the surfaces that read the preset itself switch over the moment it lands,
+	// so a service left on its old unit answers nowhere the dashboard looks.
+	// After the start above, not before: the family-discovery pass that follows a
+	// start rewrites a consumer's unit too, and a reconcile that ran first would
+	// have its restart undone by a unit written after it.
+	refreshPresetsThenReconcile()
+
 	if wantLaravelInstaller {
 		step("installing Laravel installer")
 		if err := installLaravelInstaller(); err != nil {
@@ -1087,7 +1097,6 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 	}
 
 	refreshStoreFrameworks(storeIndex)
-	refreshStorePresets()
 	refreshGlobalMCPSkills()
 	refreshProjectMCPSkills()
 

--- a/internal/cli/install_preset_refresh_test.go
+++ b/internal/cli/install_preset_refresh_test.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The install used to fetch the current store presets at the very end of its
+// run, after the services had already started from the quadlets they had. A
+// preset that gained a file mount (phpmyadmin's Apache alias, which the
+// dashboard proxy needs) therefore landed on disk with nothing left in the run
+// to re-render the unit, so lerd-ui — which reads the preset, not the
+// install-time copy — served the dashboard at a path the container knew nothing
+// about until the user's next `lerd start`. The refresh has to come first and
+// the reconcile has to follow it in the same run.
+func TestRefreshPresetsThenReconcile_refreshesBeforeReconciling(t *testing.T) {
+	var order []string
+
+	origRefresh, origReconcile := refreshPresetsFn, reconcileServicesFn
+	refreshPresetsFn = func() { order = append(order, "refresh") }
+	reconcileServicesFn = func() { order = append(order, "reconcile") }
+	t.Cleanup(func() { refreshPresetsFn, reconcileServicesFn = origRefresh, origReconcile })
+
+	refreshPresetsThenReconcile()
+
+	if want := []string{"refresh", "reconcile"}; !reflect.DeepEqual(order, want) {
+		t.Errorf("ran %v, want %v", order, want)
+	}
+}

--- a/internal/cli/isolate.go
+++ b/internal/cli/isolate.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
+	phpDet "github.com/geodro/lerd/internal/php"
 	"github.com/geodro/lerd/internal/siteops"
 	"github.com/spf13/cobra"
 )
@@ -57,6 +58,9 @@ func runIsolate(_ *cobra.Command, args []string) error {
 		_ = config.SetProjectPHPVersion(cwd, version)
 		feedback.Begin()
 		feedback.Done("PHP pinned to " + feedback.Val(version))
+		if note := phpVersionNotInstalledNote(version); note != "" {
+			feedback.Note(note)
+		}
 		return nil
 	}
 
@@ -80,6 +84,18 @@ func runIsolate(_ *cobra.Command, args []string) error {
 		warnMissingExtensions(cwd, site.Name, res.Version, cfg)
 	}
 	return nil
+}
+
+// phpVersionNotInstalledNote describes a pin that names a PHP version this
+// machine does not have, and returns "" when it does. A pin is legitimate on its
+// own — link provisions the version when the directory becomes a site — but
+// saying only "pinned" left every command run there next failing on a version
+// the user was never told was missing.
+func phpVersionNotInstalledNote(version string) string {
+	if phpDet.IsInstalled(version) {
+		return ""
+	}
+	return "PHP " + version + " has no image yet; 'lerd link' provisions it here, or run 'lerd php:rebuild " + version + "' to add it now"
 }
 
 // reportImageGap surfaces what the new version's image is missing. Changing

--- a/internal/cli/isolate_uninstalled_test.go
+++ b/internal/cli/isolate_uninstalled_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// isolate on a directory that is not yet a site writes the pin and nothing else,
+// so pinning a version this machine has never installed reported success and the
+// next command in that directory failed with "PHP 8.4 is not installed". The pin
+// is still correct; what was missing is saying the version has nowhere to run
+// yet, and how to get it.
+func TestPHPVersionNotInstalledNote_namesTheMissingVersion(t *testing.T) {
+	isolateUnitDir(t)
+
+	note := phpVersionNotInstalledNote("8.4")
+	if note == "" {
+		t.Fatal("pinning an uninstalled version reported nothing")
+	}
+	if !strings.Contains(note, "8.4") {
+		t.Errorf("note %q does not name the version it is about", note)
+	}
+	if !strings.Contains(note, "php:rebuild 8.4") {
+		t.Errorf("note %q does not name a command that installs the version", note)
+	}
+}
+
+// A version that is installed needs no note; the pin is all there is to say.
+func TestPHPVersionNotInstalledNote_silentForAnInstalledVersion(t *testing.T) {
+	isolateUnitDir(t)
+	stageFPMQuadlet(t, "8.4")
+
+	if note := phpVersionNotInstalledNote("8.4"); note != "" {
+		t.Errorf("note for an installed version: %q", note)
+	}
+}

--- a/internal/cli/new_php_version_test.go
+++ b/internal/cli/new_php_version_test.go
@@ -31,11 +31,13 @@ func fwWithRange(min, max string) *config.Framework {
 func TestScaffoldPHPVersion_clampsDefaultAboveTheRange(t *testing.T) {
 	setDefaultPHP(t, "8.5")
 
-	// No in-range version is installed in the temp home, so the clamp falls back
-	// to the framework minimum, which is still inside the supported range.
+	// No in-range version is installed in the temp home, so the clamp lands on a
+	// boundary. It has to be the ceiling: a default above the range means the
+	// machine is newer than the framework, and answering the floor sends the
+	// scaffold to a PHP several releases older than the newest one it supports.
 	got := scaffoldPHPVersion(fwWithRange("8.1", "8.3"))
-	if got != "8.1" {
-		t.Errorf("scaffoldPHPVersion = %q, want 8.1 (clamped into 8.1-8.3, not the 8.5 default)", got)
+	if got != "8.3" {
+		t.Errorf("scaffoldPHPVersion = %q, want 8.3 (the top of 8.1-8.3, not the 8.5 default)", got)
 	}
 }
 

--- a/internal/cli/php_rebuild.go
+++ b/internal/cli/php_rebuild.go
@@ -143,6 +143,25 @@ func restartInContainerWorkers() {
 	}
 }
 
+// registerPHPVersionForRebuild writes the FPM quadlet for a version this machine
+// has never installed, so an explicit rebuild of it registers the version rather
+// than building an image nothing points at. Every surface that reports a missing
+// version sends the user here, and without the unit the build was invisible:
+// php:list omitted the version, the shims still called it uninstalled, and the
+// restart at the end of the rebuild failed on a unit that did not exist. Writing
+// it first mirrors the ensure path, which registers before it builds so a failed
+// build still leaves the version known.
+func registerPHPVersionForRebuild(version string) error {
+	if phpPkg.IsInstalled(version) {
+		return nil
+	}
+	if err := writeFPMQuadlet(version); err != nil {
+		return fmt.Errorf("registering PHP %s: %w", version, err)
+	}
+	feedback.Note("registered PHP " + version + ", which was not installed")
+	return nil
+}
+
 // NewPhpRebuildCmd returns the php:rebuild command.
 func NewPhpRebuildCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -163,6 +182,9 @@ func runPhpRebuild(cmd *cobra.Command, args []string) error {
 	if len(args) == 1 {
 		v, err := config.NormalizePHPVersion(args[0])
 		if err != nil {
+			return err
+		}
+		if err := registerPHPVersionForRebuild(v); err != nil {
 			return err
 		}
 		versions = []string{v}

--- a/internal/cli/php_rebuild_register_test.go
+++ b/internal/cli/php_rebuild_register_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// stageFPMQuadlet writes the unit file that makes a PHP version count as
+// installed, so a test can tell a version this machine has from one it doesn't.
+func stageFPMQuadlet(t *testing.T, version string) {
+	t.Helper()
+	dir := config.QuadletDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	short := ""
+	for _, c := range version {
+		if c != '.' {
+			short += string(c)
+		}
+	}
+	path := filepath.Join(dir, "lerd-php"+short+"-fpm.container")
+	if err := os.WriteFile(path, []byte("[Container]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// php:rebuild is the command every surface names when a version is missing: the
+// doctor's fix, isolate's image-gap note, the shim's not-installed error. It
+// only ever built the image, so on a version this machine had never installed
+// the build landed on nothing — php:list kept omitting it, `lerd php` kept
+// calling it uninstalled, and the restart at the end failed with "unit not
+// found". The rebuild registers the version first now.
+func TestRegisterPHPVersionForRebuild_writesAMissingQuadlet(t *testing.T) {
+	isolateUnitDir(t)
+
+	var wrote []string
+	orig := writeFPMQuadlet
+	writeFPMQuadlet = func(version string) error {
+		wrote = append(wrote, version)
+		return nil
+	}
+	t.Cleanup(func() { writeFPMQuadlet = orig })
+
+	if err := registerPHPVersionForRebuild("8.4"); err != nil {
+		t.Fatalf("registerPHPVersionForRebuild: %v", err)
+	}
+	if len(wrote) != 1 || wrote[0] != "8.4" {
+		t.Errorf("wrote quadlets for %v, want exactly [8.4]", wrote)
+	}
+}
+
+// A version that is already installed keeps the unit it has: rewriting it would
+// churn systemd on every rebuild for no change.
+func TestRegisterPHPVersionForRebuild_leavesAnInstalledVersionAlone(t *testing.T) {
+	isolateUnitDir(t)
+	stageFPMQuadlet(t, "8.4")
+
+	var wrote []string
+	orig := writeFPMQuadlet
+	writeFPMQuadlet = func(version string) error {
+		wrote = append(wrote, version)
+		return nil
+	}
+	t.Cleanup(func() { writeFPMQuadlet = orig })
+
+	if err := registerPHPVersionForRebuild("8.4"); err != nil {
+		t.Fatalf("registerPHPVersionForRebuild: %v", err)
+	}
+	if len(wrote) != 0 {
+		t.Errorf("rewrote the quadlet for an installed version: %v", wrote)
+	}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -304,6 +304,24 @@ func frameworkVersionOrder(version string) int {
 	return n
 }
 
+// Seams for the refresh/reconcile pair, swapped in tests so the order between
+// them can be asserted without a network fetch or a systemd reload.
+var (
+	refreshPresetsFn    = refreshStorePresets
+	reconcileServicesFn = reconcileCustomServices
+)
+
+// refreshPresetsThenReconcile pulls the current store preset for every installed
+// service and then re-renders the services those presets describe. The order is
+// the point: the reconcile is what carries a store change into a running
+// container, and running it against presets that have not been refreshed yet
+// leaves the container a release behind while every surface that reads the
+// preset directly has already moved on.
+func refreshPresetsThenReconcile() {
+	refreshPresetsFn()
+	reconcileServicesFn()
+}
+
 // refreshStorePresets re-fetches the store preset backing every installed
 // service so its definition and file mounts keep resolving offline after an
 // upgrade, mirroring refreshStoreFrameworks. Best-effort: a failed fetch leaves

--- a/internal/php/detector.go
+++ b/internal/php/detector.go
@@ -168,21 +168,24 @@ func ClampToRange(version, min, max string) string {
 		return version
 	}
 
-	inRange := true
+	// Which bound the version misses decides where it lands when nothing
+	// installed satisfies the range, so track them apart rather than as one
+	// in-range flag.
+	belowMin, aboveMax := false, false
 	if min != "" {
 		mMajor, mMinor := parseMajorMinor(min)
 		if mMajor >= 0 && (major < mMajor || (major == mMajor && minor < mMinor)) {
-			inRange = false
+			belowMin = true
 		}
 	}
 	if max != "" {
 		mMajor, mMinor := parseMajorMinor(max)
 		if mMajor >= 0 && (major > mMajor || (major == mMajor && minor > mMinor)) {
-			inRange = false
+			aboveMax = true
 		}
 	}
 
-	if inRange {
+	if !belowMin && !aboveMax {
 		return version
 	}
 
@@ -199,7 +202,14 @@ func ClampToRange(version, min, max string) string {
 		return best
 	}
 
-	// No installed version in range; fall back to min if set.
+	// Nothing installed satisfies the range, so fall back to the bound the
+	// version missed. Answering min for a version that sat above max handed the
+	// caller the oldest release the framework tolerates rather than the newest
+	// it supports, which is what `lerd new` then tried to scaffold under: a
+	// default of 8.5 against a framework capped at 8.4 asked for 8.1.
+	if aboveMax {
+		return max
+	}
 	if min != "" {
 		return min
 	}

--- a/internal/php/detector_test.go
+++ b/internal/php/detector_test.go
@@ -290,6 +290,10 @@ func TestDetectExtensions_NoExtRequires(t *testing.T) {
 // ── ClampToRange ─────────────────────────────────────────────────────────────
 
 func TestClampToRange(t *testing.T) {
+	// Stage an empty installed set so every case lands on the boundary fallback
+	// rather than on whatever the developer happens to have installed, which is
+	// the branch that decides which version a caller is offered.
+	installedPHP(t)
 	tests := []struct {
 		version, min, max, want string
 	}{
@@ -304,14 +308,18 @@ func TestClampToRange(t *testing.T) {
 		// Below min — clamps (falls back to min if no installed version).
 		{"8.1", "8.2", "8.4", "8.2"},
 		{"7.4", "8.2", "8.5", "8.2"},
-		// Above max — clamps.
+		// Above max — clamps to the ceiling, the newest the framework supports.
 		{"8.5", "8.2", "8.4", "8.4"},
+		{"8.5", "8.1", "8.4", "8.4"},
+		{"8.5", "8.2", "8.2", "8.2"},
+		// Above a range with no ceiling — nothing to clamp against, keep the floor.
+		{"8.5", "8.2", "", "8.5"},
 	}
 	for _, tt := range tests {
 		got := ClampToRange(tt.version, tt.min, tt.max)
-		// ClampToRange may pick a different installed version within range,
-		// but when no installed version matches it falls back to min/max boundary.
-		// We check that the result is within the stated range.
+		if got != tt.want {
+			t.Errorf("ClampToRange(%q, %q, %q) = %q, want %q", tt.version, tt.min, tt.max, got, tt.want)
+		}
 		if tt.min != "" {
 			gMaj, gMin := parseMajorMinor(got)
 			mMaj, mMin := parseMajorMinor(tt.min)

--- a/internal/serviceops/reconcile.go
+++ b/internal/serviceops/reconcile.go
@@ -3,7 +3,9 @@ package serviceops
 import (
 	"errors"
 	"fmt"
-	"slices"
+	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
@@ -19,7 +21,33 @@ var (
 	newestFileMtimeFn        = config.ServiceFilesNewestMtime
 	containerStartedAtFn     = podman.ContainerStartedAt
 	restartUnitFn            = podman.RestartUnit
+	quadletMtimeFn           = quadletMtime
 )
+
+// quadletMtime reports when a service's unit file was last written, and whether
+// it exists at all.
+func quadletMtime(name string) (time.Time, bool) {
+	info, err := os.Stat(filepath.Join(config.QuadletDir(), "lerd-"+name+".container"))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return info.ModTime(), true
+}
+
+// containerOlderThanUnit reports whether a running container was started before
+// the unit file it runs from was last written. A unit rewritten by an earlier
+// pass — the install refreshes every service quadlet long before it reaches the
+// reconcile — leaves nothing for this pass to change, so asking only "did I just
+// rewrite it" let a container keep serving a definition that had already moved
+// on. Comparing against the container's own start time catches both.
+func containerOlderThanUnit(name string) bool {
+	started, running := containerStartedAtFn("lerd-" + name)
+	if !running {
+		return false
+	}
+	mtime, ok := quadletMtimeFn(name)
+	return ok && mtime.After(started)
+}
 
 // ReconcileResult reports what ReconcileServices changed.
 type ReconcileResult struct {
@@ -63,25 +91,26 @@ func ReconcileServices(emit func(PhaseEvent)) (ReconcileResult, error) {
 			}
 		}
 		unitInstalled := UnitInstalledFn("lerd-" + svc.Name)
-		// Regenerate the quadlet when the unit is missing, or when the definition
-		// changed. WriteQuadletDiff is a no-op when the content is identical, so a
-		// client_shims-only change (which never appears in the quadlet) is free.
+		// Render the quadlet every pass and let the content decide. What a unit
+		// renders to is not all in the YAML: file mounts and the proxy env come
+		// from the preset when the quadlet is written and are never stored on the
+		// service, so gating this on the definition having changed left a preset
+		// that added either of them unable to reach the unit at all. WriteQuadletDiff
+		// is a no-op when the content is identical, so a steady state costs a
+		// comparison and a change nobody can see in the YAML still lands.
 		//
-		// Before the drift restart below, not after: a definition that adds a file
+		// Before the drift restart below, not after: a change that adds a file
 		// mount changes the unit too, and restarting the old one brings the
 		// container back without the mount, leaving it a pass behind until
 		// something restarts it again.
-		unitChanged := false
-		if !unitInstalled || slices.Contains(res.DefinitionsRefreshed, svc.Name) {
-			changed, err := ensureQuadletFn(svc)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("regenerating quadlet for %s: %w", svc.Name, err))
-				continue
-			}
-			unitChanged = changed
-			if !unitInstalled {
-				res.QuadletsRegenerated = append(res.QuadletsRegenerated, svc.Name)
-			}
+		changed, err := ensureQuadletFn(svc)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("regenerating quadlet for %s: %w", svc.Name, err))
+			continue
+		}
+		unitChanged := changed
+		if !unitInstalled {
+			res.QuadletsRegenerated = append(res.QuadletsRegenerated, svc.Name)
 		}
 		if unitInstalled {
 			applied, err := RestartIfConfigDrifted(svc.Name, svc.Preset)
@@ -89,7 +118,7 @@ func ReconcileServices(emit func(PhaseEvent)) (ReconcileResult, error) {
 				errs = append(errs, err)
 			} else if applied {
 				res.ConfigsApplied = append(res.ConfigsApplied, svc.Name)
-			} else if unitChanged {
+			} else if unitChanged || containerOlderThanUnit(svc.Name) {
 				// The drift check reads the materialised config files and is blind to
 				// the unit itself, so a definition that moved a port, changed the image
 				// or added an environment variable would sit rewritten on disk while the

--- a/internal/serviceops/reconcile_test.go
+++ b/internal/serviceops/reconcile_test.go
@@ -387,7 +387,21 @@ func TestReconcileServices_noRestartWhenConfigCurrent(t *testing.T) {
 	}
 	writeQuadlet(t, "mysql", true)
 
+	// The staged unit is a stand-in, not what the generator would write, so
+	// report it unchanged: this test is about the drift decision, and a unit
+	// that rewrote itself here would restart the container for its own reason.
+	prevEnsure := ensureQuadletFn
+	t.Cleanup(func() { ensureQuadletFn = prevEnsure })
+	ensureQuadletFn = func(*config.CustomService) (bool, error) { return false, nil }
+
 	boot := time.Unix(1_000_000, 0)
+	// The staged file carries a real mtime while the container's boot is
+	// synthetic, so date the unit behind it: this service booted from the unit it
+	// has, which is the case being asserted.
+	prevMtime := quadletMtimeFn
+	t.Cleanup(func() { quadletMtimeFn = prevMtime })
+	quadletMtimeFn = func(string) (time.Time, bool) { return boot.Add(-time.Hour), true }
+
 	restarted := false
 	restore := swapDriftSeams(t,
 		func(*config.CustomService) error { return nil },
@@ -550,5 +564,136 @@ func TestReconcileServices_leavesAStoppedServiceStopped(t *testing.T) {
 	}
 	if restarted {
 		t.Error("a stopped service was started by a unit rewrite")
+	}
+}
+
+// A store preset can change the unit without changing the YAML saved when the
+// service was installed: file mounts and the proxy env are read from the preset
+// at render time and never stored on the service. Gating the re-render on the
+// definition having changed meant a preset that moved a dashboard behind the
+// lerd-ui proxy landed on disk with the container still on a unit that had no
+// mount for it, so the dashboard answered 404 at the path the UI had already
+// switched to. What the unit would render to decides, not what the YAML says.
+func TestReconcileServices_regeneratesWhenOnlyThePresetChanged(t *testing.T) {
+	reconcileEnv(t)
+	if err := config.SaveStorePreset("probe-svc", []byte("name: probe-svc\nimage: example/probe:1\ndashboard: http://localhost:9999\n")); err != nil {
+		t.Fatalf("store preset: %v", err)
+	}
+	// Saved exactly as the preset resolves, so nothing about the definition is
+	// stale and the refresh reports no change.
+	if err := config.SaveCustomService(&config.CustomService{
+		Name:      "probe-svc",
+		Image:     "example/probe:1",
+		Dashboard: "http://localhost:9999",
+		Preset:    "probe-svc",
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	writeQuadlet(t, "probe-svc", true)
+
+	var order []string
+	prevEnsure := ensureQuadletFn
+	t.Cleanup(func() { ensureQuadletFn = prevEnsure })
+	ensureQuadletFn = func(*config.CustomService) (bool, error) {
+		order = append(order, "regenerate")
+		return true, nil
+	}
+
+	boot := time.Unix(1_000_000, 0)
+	restore := swapDriftSeams(t,
+		func(*config.CustomService) error { return nil },
+		func(*config.CustomService) (time.Time, bool) { return time.Time{}, false },
+		func(string) (time.Time, bool) { return boot, true },
+		func(string) error { order = append(order, "restart"); return nil },
+		func(string) bool { return true },
+	)
+	defer restore()
+
+	res, err := ReconcileServices(nil)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(res.DefinitionsRefreshed) != 0 {
+		t.Fatalf("the definition was not supposed to change, got %v", res.DefinitionsRefreshed)
+	}
+	if len(order) != 2 || order[0] != "regenerate" || order[1] != "restart" {
+		t.Fatalf("a preset-only change never reached the unit, got %v", order)
+	}
+}
+
+// A container is stale against a unit that changed at any point, not only
+// against one this pass rewrote. The install rewrites service quadlets early and
+// leaves an already-running container alone, so by the time the reconcile came
+// round the unit on disk was current, nothing looked changed, and the container
+// kept serving from the definition it booted with. What the container started
+// before decides.
+func TestReconcileServices_restartsAContainerOlderThanItsUnit(t *testing.T) {
+	reconcileEnv(t)
+	if err := config.SaveCustomService(&config.CustomService{Name: "probe-svc", Image: "example/probe:1"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	writeQuadlet(t, "probe-svc", true)
+
+	prevEnsure := ensureQuadletFn
+	t.Cleanup(func() { ensureQuadletFn = prevEnsure })
+	// Nothing to rewrite: the unit on disk is already what it should be.
+	ensureQuadletFn = func(*config.CustomService) (bool, error) { return false, nil }
+
+	prevMtime := quadletMtimeFn
+	t.Cleanup(func() { quadletMtimeFn = prevMtime })
+	boot := time.Unix(1_000_000, 0)
+	quadletMtimeFn = func(string) (time.Time, bool) { return boot.Add(time.Hour), true }
+
+	restarted := false
+	restore := swapDriftSeams(t,
+		func(*config.CustomService) error { return nil },
+		func(*config.CustomService) (time.Time, bool) { return time.Time{}, false },
+		func(string) (time.Time, bool) { return boot, true },
+		func(string) error { restarted = true; return nil },
+		func(string) bool { return true },
+	)
+	defer restore()
+
+	if _, err := ReconcileServices(nil); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !restarted {
+		t.Fatal("a container older than its unit was left running on the old definition")
+	}
+}
+
+// The same check must not restart a container that already booted from the
+// current unit, or every pass would bounce every service.
+func TestReconcileServices_leavesAContainerNewerThanItsUnit(t *testing.T) {
+	reconcileEnv(t)
+	if err := config.SaveCustomService(&config.CustomService{Name: "probe-svc", Image: "example/probe:1"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	writeQuadlet(t, "probe-svc", true)
+
+	prevEnsure := ensureQuadletFn
+	t.Cleanup(func() { ensureQuadletFn = prevEnsure })
+	ensureQuadletFn = func(*config.CustomService) (bool, error) { return false, nil }
+
+	prevMtime := quadletMtimeFn
+	t.Cleanup(func() { quadletMtimeFn = prevMtime })
+	boot := time.Unix(1_000_000, 0)
+	quadletMtimeFn = func(string) (time.Time, bool) { return boot.Add(-time.Hour), true }
+
+	restarted := false
+	restore := swapDriftSeams(t,
+		func(*config.CustomService) error { return nil },
+		func(*config.CustomService) (time.Time, bool) { return time.Time{}, false },
+		func(string) (time.Time, bool) { return boot, true },
+		func(string) error { restarted = true; return nil },
+		func(string) bool { return true },
+	)
+	defer restore()
+
+	if _, err := ReconcileServices(nil); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if restarted {
+		t.Fatal("a container already running the current unit was restarted for nothing")
 	}
 }

--- a/internal/systemd/dbus_linux.go
+++ b/internal/systemd/dbus_linux.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/coreos/go-systemd/v22/dbus"
+	godbus "github.com/godbus/dbus/v5"
 )
 
 // errUnitOpTimedOut is the sentinel a single unit-op attempt returns when the
@@ -162,10 +163,27 @@ func DBusStartUnit(name string) error {
 // DBusStopUnit stops a user unit via DBus.
 func DBusStopUnit(name string) error {
 	if err := dbusUnitOp("stop", "stop", name); err != nil {
+		if unitNotLoaded(err) {
+			return nil
+		}
 		return err
 	}
 	_ = DBusResetFailed(name)
 	return nil
+}
+
+// unitNotLoaded reports whether an op failed because systemd has no such unit.
+// For a stop that is the goal already met, not a failure: the stop set is built
+// partly from what a site declares rather than from what is on disk, so a
+// machine that never installed a declared worker named units systemd has never
+// heard of and a clean shutdown printed a failure for each one. launchd's side
+// has always treated its equivalent (exit 36) as success.
+func unitNotLoaded(err error) bool {
+	var dberr godbus.Error
+	if errors.As(err, &dberr) {
+		return dberr.Name == "org.freedesktop.systemd1.NoSuchUnit"
+	}
+	return false
 }
 
 // DBusRestartUnit restarts a user unit via DBus.

--- a/internal/systemd/dbus_linux_test.go
+++ b/internal/systemd/dbus_linux_test.go
@@ -2,7 +2,13 @@
 
 package systemd
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	godbus "github.com/godbus/dbus/v5"
+)
 
 // withServiceSuffix is the gate every DBus unit op passes through. A bug here
 // breaks Start/Stop/Restart/Enable/Disable/IsEnabled for every caller, so the
@@ -157,4 +163,32 @@ func TestRunUnitOpWithRetry(t *testing.T) {
 			t.Fatalf("calls = %d, want 1 (clamped)", calls)
 		}
 	})
+}
+
+// A stop aimed at a unit systemd has never loaded is already satisfied: there
+// is nothing running to stop. `lerd stop` enumerates workers a site declares,
+// which on a machine that never installed one names a unit systemd does not
+// know, so a clean shutdown reported a screen of failures for workers that were
+// never up.
+func TestUnitNotLoaded(t *testing.T) {
+	missing := godbus.Error{
+		Name: "org.freedesktop.systemd1.NoSuchUnit",
+		Body: []any{"Unit lerd-queue-acme.service not loaded."},
+	}
+	if !unitNotLoaded(fmt.Errorf("stop lerd-queue-acme failed: %w", missing)) {
+		t.Error("a NoSuchUnit error must read as already stopped")
+	}
+
+	// A unit that exists and genuinely failed to stop must still be an error, or
+	// a stop that left a container running would report success.
+	realFailure := godbus.Error{
+		Name: "org.freedesktop.systemd1.JobFailed",
+		Body: []any{"Job for lerd-mysql.service failed."},
+	}
+	if unitNotLoaded(fmt.Errorf("stop lerd-mysql failed: %w", realFailure)) {
+		t.Error("a genuine stop failure was swallowed")
+	}
+	if unitNotLoaded(errors.New("stop lerd-mysql timed out after 30s")) {
+		t.Error("a timeout was swallowed")
+	}
 }


### PR DESCRIPTION
A store preset that changes what a unit renders to could not reach a container that was already running. File mounts and the dashboard proxy env are read from the preset when the quadlet is written and are never stored on the service, while the reconcile re-rendered a unit only when the unit was missing or the saved YAML had changed, so the preset that moves phpMyAdmin behind the lerd-ui proxy landed on disk with the container still on a unit that had no mount for it and the dashboard answered 404 at the path the UI had already switched to. The quadlet is rendered every pass now and its content decides, which in a steady state costs a comparison. A container that started before its unit file was last written counts as stale too, since the install rewrites service quadlets long before it reaches the reconcile and leaves an already running container alone, leaving that pass nothing to notice. The install refreshes the store presets and reconciles after it starts services, so the pass that carries a store change into a container has the last word over the family discovery that rewrites consumer units behind it.

A default PHP version above a framework's ceiling resolved to the framework's floor. When nothing installed satisfies the range the fallback always answered the minimum, so scaffolding CakePHP on a machine whose only PHP is 8.5 asked for 8.1 rather than 8.4 and stopped there, which left CakePHP and CodeIgniter unscaffoldable on a stock install. It falls back to the bound the version actually missed.

php:rebuild is what the doctor, isolate and the shims all name when a PHP version is missing, and it only ever built the image. On a version this machine had never installed the build landed on nothing: php:list omitted it, the shims still called it uninstalled, and the run ended by failing to restart a unit that did not exist. It writes the unit first now, the way the ensure path does, so a failed build still leaves the version registered. isolate says when a pin names a version with no image instead of reporting a bare success, and the not installed error stops naming lerd install, which takes no version and could never have added the one being asked for.

Stopping a unit systemd has never loaded is the goal already met, not a failure. The stop set is built partly from the workers a site declares rather than from the units on disk, so a machine that never installed a declared worker named units systemd does not know and a clean shutdown printed a red line for each one. The launchd side has always treated its equivalent as success.

Closes #1487
