### PR TITLE
fix(update): repair a Homebrew upgrade that lands with nobody at the terminal

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -153,6 +153,27 @@ brews:
     install: |
       bin.install "lerd"
       bin.install "lerd-tray" if File.exist?("lerd-tray")
+    # brew retires the previous keg on upgrade, so a set-up install is left with
+    # user services and shims naming a binary that is on its way out. Distros
+    # that upgrade brew packages unattended would break with nobody at the
+    # terminal to see it, so the hook repoints them here (#1432). It is a no-op
+    # on a machine where `lerd install` has never run, and never fails the
+    # upgrade.
+    post_install: |
+      # brew runs this inside a read-only mount namespace with HOME pointed at
+      # a throwaway directory, and everything the repair touches lives in the
+      # real home. On Linux the user's own systemd manager runs it outside that
+      # namespace; elsewhere the direct call is all there is to try.
+      if OS.linux?
+        quiet_system "/bin/sh", "-c",
+          "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/$(id -u)} systemd-run --user --quiet --collect --wait " \
+          "--unit=lerd-post-upgrade #{bin}/lerd post-upgrade"
+      else
+        require "etc"
+        with_env(HOME: Etc.getpwuid(Process.uid).dir, XDG_CONFIG_HOME: nil, XDG_DATA_HOME: nil) do
+          quiet_system bin/"lerd", "post-upgrade"
+        end
+      end
     caveats: |
       To finish setting up Lerd, run:
         lerd install

--- a/cmd/lerd/main.go
+++ b/cmd/lerd/main.go
@@ -108,6 +108,7 @@ func main() {
 	// Register all subcommands
 	root.AddCommand(cli.NewInstallCmd())
 	root.AddCommand(cli.NewBootstrapCmd())
+	root.AddCommand(cli.NewPostUpgradeCmd())
 	root.AddCommand(cli.NewStartCmd())
 	root.AddCommand(cli.NewStopCmd())
 	root.AddCommand(cli.NewQuitCmd())

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -138,7 +138,7 @@ lerd install
 
 Unlike on macOS, Podman is not pulled in as a Homebrew dependency: lerd integrates with the distribution's own Podman, so install that with your package manager first. Homebrew itself needs its usual Linux prerequisites, notably a C compiler such as gcc, even though the formula only unpacks a prebuilt binary. If Homebrew refuses the tap as untrusted, run `brew trust lerd-env/lerd` once.
 
-Update with `brew upgrade lerd`. Homebrew installs every version into its own directory, so an upgrade moves the binary; the next `lerd start` repoints the user services and the shims at the new location and says which ones it moved.
+Update with `brew upgrade lerd`. Homebrew installs every version into its own directory, so an upgrade moves the binary; the formula repoints the user services and the shims at the new location as part of the upgrade and restarts the daemons, so an unattended upgrade leaves nothing broken behind it. The rest of the environment is reapplied by the first lerd command you run at a terminal afterwards.
 
 ---
 

--- a/docs/usage/lifecycle.md
+++ b/docs/usage/lifecycle.md
@@ -43,7 +43,7 @@ If you ran `lerd uninstall` and then reinstalled, worker units and service quadl
 :::
 
 ::: info After the binary moves
-The `lerd-ui`, `lerd-watcher` and `lerd-tray` services and the shims on your `PATH` (`php`, `composer`, `laravel`, the client tools) all record where the lerd binary is. A package manager that installs each version into its own directory, Homebrew above all, retires that path on the next upgrade. `lerd start` rewrites the services to point at the binary that is running and repoints any shim whose path has gone, and the shims themselves fall back to whatever `lerd` is on your `PATH`.
+The `lerd-ui`, `lerd-watcher` and `lerd-tray` services and the shims on your `PATH` (`php`, `composer`, `laravel`, the client tools) all record where the lerd binary is. A package manager that installs each version into its own directory, Homebrew above all, retires that path on the next upgrade. On Linux, `brew upgrade lerd` repoints them as part of the upgrade and restarts the daemons, which matters on a machine that upgrades its packages unattended. Otherwise `lerd start` rewrites the services to point at the binary that is running and repoints any shim whose path has gone, and the shims themselves fall back to whatever `lerd` is on your `PATH`.
 :::
 
 ::: info Deleted project directories are auto-cleaned

--- a/internal/cli/binpath_heal.go
+++ b/internal/cli/binpath_heal.go
@@ -24,7 +24,31 @@ var daemonUnits = []string{"lerd-ui", "lerd-watcher", "lerd-tray", "lerd-autosta
 // surfaces as daemons failing with a bare exit status 203 and `php` reporting
 // no such file (#1432).
 func healLerdBinaryMove() (units, shims []string) {
-	return healDaemonUnits(), healShimBinaryPaths(config.LerdBinary())
+	return healLerdBinaryPaths(binaryGone)
+}
+
+// healLerdBinaryUpgrade is the same repair from the package-manager hook, which
+// runs from the install that has just landed. It also repoints an older keg of
+// the same formula while brew still has it on disk: the cleanup that deletes it
+// comes later, and by then there is nobody at the terminal to notice.
+func healLerdBinaryUpgrade() (units, shims []string) {
+	return healLerdBinaryPaths(binarySuperseded)
+}
+
+func healLerdBinaryPaths(superseded func(string) bool) (units, shims []string) {
+	return healDaemonUnits(superseded), healShimBinaryPaths(config.LerdBinary(), superseded)
+}
+
+// binaryGone is the rule the start repairs by: only a path that is not there is
+// rewritten, so starting a build from a checkout cannot take the login daemons
+// of a working install with it.
+func binaryGone(path string) bool {
+	_, err := os.Stat(path)
+	return err != nil
+}
+
+func binarySuperseded(path string) bool {
+	return config.SupersededBinary(path, config.LerdBinary())
 }
 
 // repairSummary is the line the start prints once a move has been repaired, so
@@ -40,18 +64,14 @@ func repairSummary(units, shims []string) string {
 	return "Repointed " + strings.Join(parts, " and ") + " at " + config.LerdBinary()
 }
 
-// healDaemonUnits rewrites daemon units whose ExecStart names a binary that is
-// no longer on disk, so they run the lerd that is installed now. A unit that
-// still resolves is left alone, which keeps a start from a checkout build from
-// quietly taking the login daemons with it.
-func healDaemonUnits() []string {
+// healDaemonUnits rewrites daemon units whose ExecStart names a binary the
+// caller's rule counts as superseded, so they run the lerd that is installed
+// now. A unit the rule leaves alone is left exactly as installed.
+func healDaemonUnits(superseded func(string) bool) []string {
 	var healed []string
 	for _, name := range daemonUnits {
 		installed := services.InstalledUnitBinary(name)
-		if installed == "" {
-			continue
-		}
-		if _, err := os.Stat(installed); err == nil {
+		if installed == "" || !superseded(installed) {
 			continue
 		}
 		content, err := lerdSystemd.GetUnit(name)
@@ -73,10 +93,10 @@ func healDaemonUnits() []string {
 }
 
 // healShimBinaryPaths repoints shims in lerd's bin dir that run a lerd binary
-// which is no longer on disk. Only a dead path is rewritten: a shim that still
-// resolves is left exactly as installed, so starting a build from a checkout
-// never takes the user's shims with it.
-func healShimBinaryPaths(lerdBin string) []string {
+// the caller's rule counts as superseded. Everything else is left exactly as
+// installed, so starting a build from a checkout never takes the user's shims
+// with it.
+func healShimBinaryPaths(lerdBin string, superseded func(string) bool) []string {
 	if info, err := os.Stat(lerdBin); err != nil || info.IsDir() {
 		return nil
 	}
@@ -95,7 +115,7 @@ func healShimBinaryPaths(lerdBin string) []string {
 		if err != nil || !strings.HasPrefix(string(data), "#!") {
 			continue
 		}
-		repaired, changed := healedShim(string(data), lerdBin)
+		repaired, changed := healedShim(string(data), lerdBin, superseded)
 		if !changed {
 			continue
 		}
@@ -108,16 +128,16 @@ func healShimBinaryPaths(lerdBin string) []string {
 	return healed
 }
 
-// healedShim swaps every absolute path to a lerd binary that is not there any
-// more for lerdBin. Anything else the shim runs (composer.phar, a version
-// manager, the tool itself) is left alone.
-func healedShim(content, lerdBin string) (string, bool) {
+// healedShim swaps every absolute path to a superseded lerd binary for lerdBin.
+// Anything else the shim runs (composer.phar, a version manager, the tool
+// itself) is left alone.
+func healedShim(content, lerdBin string, superseded func(string) bool) (string, bool) {
 	changed := false
 	for _, token := range shimTokens(content) {
 		if token == lerdBin || !filepath.IsAbs(token) || filepath.Base(token) != "lerd" {
 			continue
 		}
-		if _, err := os.Stat(token); err == nil {
+		if !superseded(token) {
 			continue
 		}
 		content = strings.ReplaceAll(content, token, lerdBin)

--- a/internal/cli/binpath_heal_linux_test.go
+++ b/internal/cli/binpath_heal_linux_test.go
@@ -17,7 +17,7 @@ func TestHealDaemonUnitsRewritesUnitsWithAGoneBinary(t *testing.T) {
 	fake := &fakeServiceMgr{writeChanged: true}
 	swapMgr(t, fake)
 
-	healed := healDaemonUnits()
+	healed := healDaemonUnits(binaryGone)
 
 	if !equalStrings(fake.calls, []string{"write:lerd-ui", "reload"}) {
 		t.Errorf("expected the lerd-ui unit to be rewritten and reloaded, got %v", fake.calls)
@@ -38,7 +38,7 @@ func TestHealDaemonUnitsLeavesResolvableUnitsAlone(t *testing.T) {
 	fake := &fakeServiceMgr{writeChanged: true}
 	swapMgr(t, fake)
 
-	if healed := healDaemonUnits(); len(healed) != 0 {
+	if healed := healDaemonUnits(binaryGone); len(healed) != 0 {
 		t.Errorf("healDaemonUnits() = %v; want nothing repaired", healed)
 	}
 
@@ -55,7 +55,7 @@ func TestHealDaemonUnitsSkipsAUnitTheRewriteCannotFix(t *testing.T) {
 	fake := &fakeServiceMgr{writeChanged: true}
 	swapMgr(t, fake)
 
-	if healed := healDaemonUnits(); len(healed) != 0 {
+	if healed := healDaemonUnits(binaryGone); len(healed) != 0 {
 		t.Errorf("healDaemonUnits() = %v; want nothing reported", healed)
 	}
 	if len(fake.calls) != 0 {

--- a/internal/cli/binpath_heal_test.go
+++ b/internal/cli/binpath_heal_test.go
@@ -18,7 +18,7 @@ func TestHealShimBinaryPathsRepointsShimsAtTheLiveBinary(t *testing.T) {
 	writeShim(t, binDir, "php", "#!/bin/sh\nLERD=\""+gone+"\"\n[ -x \"$LERD\" ] || LERD=lerd\nexec \"$LERD\" php \"$@\"\n")
 	writeShim(t, binDir, "mysql", "#!/bin/sh\n# lerd client shim\nexec "+gone+" client-exec mysql \"$@\"\n")
 
-	healShimBinaryPaths(current)
+	healShimBinaryPaths(current, binaryGone)
 
 	for _, tool := range []string{"php", "mysql"} {
 		shim := readShim(t, binDir, tool)
@@ -43,7 +43,7 @@ func TestHealShimBinaryPathsLeavesWorkingShimsAlone(t *testing.T) {
 	body := "#!/bin/sh\nexec " + other + " php \"$@\"\n"
 	writeShim(t, binDir, "php", body)
 
-	healShimBinaryPaths(current)
+	healShimBinaryPaths(current, binaryGone)
 
 	if got := readShim(t, binDir, "php"); got != body {
 		t.Errorf("php shim was rewritten:\n%s", got)
@@ -58,7 +58,7 @@ func TestHealShimBinaryPathsKeepsNonBinaryPaths(t *testing.T) {
 	phar := filepath.Join(binDir, "composer.phar")
 	writeShim(t, binDir, "composer", "#!/bin/sh\nLERD=\""+gone+"\"\nexec \"$LERD\" php "+phar+" \"$@\"\n")
 
-	healShimBinaryPaths(current)
+	healShimBinaryPaths(current, binaryGone)
 
 	shim := readShim(t, binDir, "composer")
 	if !strings.Contains(shim, phar) {
@@ -76,7 +76,7 @@ func TestHealShimBinaryPathsSkipsWhenTheBinaryIsMissing(t *testing.T) {
 	body := "#!/bin/sh\nexec /gone/lerd php \"$@\"\n"
 	writeShim(t, binDir, "php", body)
 
-	healShimBinaryPaths(filepath.Join(filepath.Dir(current), "absent"))
+	healShimBinaryPaths(filepath.Join(filepath.Dir(current), "absent"), binaryGone)
 
 	if got := readShim(t, binDir, "php"); got != body {
 		t.Errorf("php shim was rewritten:\n%s", got)
@@ -102,7 +102,7 @@ func TestHealShimBinaryPathsIgnoresADirectory(t *testing.T) {
 	body := "#!/bin/sh\nexec /gone/lerd php \"$@\"\n"
 	writeShim(t, binDir, "php", body)
 
-	if healed := healShimBinaryPaths(filepath.Dir(current)); len(healed) != 0 {
+	if healed := healShimBinaryPaths(filepath.Dir(current), binaryGone); len(healed) != 0 {
 		t.Errorf("healShimBinaryPaths() = %v; want nothing repaired", healed)
 	}
 	if got := readShim(t, binDir, "php"); got != body {

--- a/internal/cli/post_upgrade.go
+++ b/internal/cli/post_upgrade.go
@@ -19,6 +19,7 @@ import (
 var upgradeSkipCommands = map[string]bool{
 	"install":       true,
 	"bootstrap":     true,
+	"post-upgrade":  true,
 	"update":        true,
 	"uninstall":     true,
 	"serve-ui":      true,

--- a/internal/cli/upgrade_hook.go
+++ b/internal/cli/upgrade_hook.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/geodro/lerd/internal/services"
+)
+
+// Seams for the hook's effects, swapped in tests so the decision can be checked
+// without a service manager or a real install underneath.
+var (
+	healUpgradedBinary = healLerdBinaryUpgrade
+	daemonEnabled      = func(name string) bool { return services.Mgr.IsEnabled(name) }
+	restartDaemon      = func(name string) error { return services.Mgr.Restart(name) }
+)
+
+// NewPostUpgradeCmd returns the hook a package manager runs once it has put a
+// new lerd binary in place. Homebrew's post-install step calls it, because an
+// upgrade that lands unattended otherwise leaves the daemons dead and `php`
+// broken until someone opens a terminal and runs a lerd command (#1432).
+func NewPostUpgradeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "post-upgrade",
+		Short:  "Repoint lerd's user services and shims at the binary installed now",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			runPostUpgradeHook()
+			return nil
+		},
+	}
+}
+
+// runPostUpgradeHook repairs what replacing the binary broke, and nothing else.
+// The rest of the environment (quadlets, nginx, the stores) is reapplied by the
+// first lerd command run at a terminal, which has someone watching and can
+// afford the minutes. It never fails: a package manager whose post-install step
+// exits non-zero reports the upgrade itself as broken.
+func runPostUpgradeHook() {
+	// A machine with no install has nothing pointing anywhere yet, and the
+	// `lerd install` it still owes asks questions a package script cannot
+	// answer on the user's behalf.
+	if !isSetUp() {
+		return
+	}
+	units, shims := healUpgradedBinary()
+	if len(units)+len(shims) == 0 {
+		return
+	}
+	fmt.Println(repairSummary(units, shims))
+	for _, name := range units {
+		if !daemonEnabled(name) {
+			continue
+		}
+		if err := restartDaemon(name); err != nil {
+			fmt.Printf("  WARN: restarting %s: %v\n", name, err)
+		}
+	}
+}

--- a/internal/cli/upgrade_hook_test.go
+++ b/internal/cli/upgrade_hook_test.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/geodro/lerd/internal/config"
+)
+
+// The daemons are dead the moment the binary they name is replaced, so the hook
+// that repointed their units has to start them again. Nothing else is watching:
+// this is the upgrade that landed while the user was away.
+func TestPostUpgradeHookRestartsTheDaemonsItRepointed(t *testing.T) {
+	markSetUp(t)
+	hookFixture(t, []string{"lerd-ui", "lerd-watcher"}, []string{"php"})
+	enabled := map[string]bool{"lerd-ui": true, "lerd-watcher": true}
+	daemonEnabled = func(name string) bool { return enabled[name] }
+	var restarted []string
+	restartDaemon = func(name string) error {
+		restarted = append(restarted, name)
+		return nil
+	}
+
+	runPostUpgradeHook()
+
+	if !equalStrings(restarted, []string{"lerd-ui", "lerd-watcher"}) {
+		t.Errorf("restarted %v; want both repointed daemons started again", restarted)
+	}
+}
+
+// A daemon the user never wanted at login stays down. The tray is the case:
+// on a headless machine it is installed and disabled, and starting it would
+// fail for a reason that has nothing to do with the upgrade.
+func TestPostUpgradeHookLeavesDisabledDaemonsDown(t *testing.T) {
+	markSetUp(t)
+	hookFixture(t, []string{"lerd-ui", "lerd-tray"}, nil)
+	daemonEnabled = func(name string) bool { return name == "lerd-ui" }
+	var restarted []string
+	restartDaemon = func(name string) error {
+		restarted = append(restarted, name)
+		return nil
+	}
+
+	runPostUpgradeHook()
+
+	if !equalStrings(restarted, []string{"lerd-ui"}) {
+		t.Errorf("restarted %v; want only the daemon set to start at login", restarted)
+	}
+}
+
+// A fresh package install has a binary and no environment. The install it still
+// owes is the user's own next step, and it asks questions.
+func TestPostUpgradeHookSkipsAMachineThatWasNeverSetUp(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	hookFixture(t, []string{"lerd-ui"}, nil)
+	healed := false
+	healUpgradedBinary = func() ([]string, []string) {
+		healed = true
+		return nil, nil
+	}
+	restartDaemon = func(string) error {
+		t.Error("a machine with no lerd install had a daemon restarted")
+		return nil
+	}
+
+	runPostUpgradeHook()
+
+	if healed {
+		t.Error("a machine with no lerd install was repaired behind the user's back")
+	}
+}
+
+// An upgrade that broke nothing, which is every upgrade of an install that
+// carries the version-independent path already, must not restart anything.
+func TestPostUpgradeHookIsQuietWhenNothingMoved(t *testing.T) {
+	markSetUp(t)
+	hookFixture(t, nil, nil)
+	restartDaemon = func(name string) error {
+		t.Errorf("%s was restarted with nothing to repair", name)
+		return nil
+	}
+
+	runPostUpgradeHook()
+}
+
+// A shim repaired on its own is worth reporting, but there is no daemon to
+// start for it.
+func TestPostUpgradeHookRestartsNothingForShimsAlone(t *testing.T) {
+	markSetUp(t)
+	hookFixture(t, nil, []string{"php", "composer"})
+	restartDaemon = func(name string) error {
+		t.Errorf("%s was restarted for a shim repair", name)
+		return nil
+	}
+
+	runPostUpgradeHook()
+}
+
+// markSetUp writes the global config, which is what tells the hook an install
+// exists to repair.
+func markSetUp(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(config.GlobalConfigFile()), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.GlobalConfigFile(), []byte("dns:\n  tld: test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// hookFixture makes the repair report the given units and shims, and restores
+// every seam once the test is done.
+func hookFixture(t *testing.T, units, shims []string) {
+	t.Helper()
+	t.Cleanup(restoreHookSeams(t))
+	healUpgradedBinary = func() ([]string, []string) { return units, shims }
+	daemonEnabled = func(string) bool { return true }
+	restartDaemon = func(string) error { return nil }
+}
+
+func restoreHookSeams(t *testing.T) func() {
+	t.Helper()
+	heal, enabled, restart := healUpgradedBinary, daemonEnabled, restartDaemon
+	return func() { healUpgradedBinary, daemonEnabled, restartDaemon = heal, enabled, restart }
+}

--- a/internal/config/lerd_binary.go
+++ b/internal/config/lerd_binary.go
@@ -31,6 +31,21 @@ func LerdBinary() string {
 	return exe
 }
 
+// SupersededBinary reports whether recorded names a lerd binary that current
+// has taken over from: one that is no longer on disk, or an older Homebrew keg
+// of the formula current is the opt link for. A path belonging to some other
+// install (a script install under ~/.local/bin, a distro package) is never
+// superseded, so a brew install standing next to one cannot claim its units.
+func SupersededBinary(recorded, current string) bool {
+	if recorded == "" || current == "" || recorded == current {
+		return false
+	}
+	if _, err := os.Stat(recorded); err != nil {
+		return true
+	}
+	return brewOptPath(recorded) == current
+}
+
 // brewOptPath maps a Homebrew keg path (<prefix>/Cellar/lerd/1.32.0/bin/lerd) to
 // its opt equivalent (<prefix>/opt/lerd/bin/lerd), the link brew repoints at the
 // current version on every upgrade. Returns "" for a path outside a Cellar, or

--- a/internal/config/lerd_binary_test.go
+++ b/internal/config/lerd_binary_test.go
@@ -82,6 +82,47 @@ func TestLerdBinaryPrefersBrewOptPath(t *testing.T) {
 	}
 }
 
+// The keg brew is replacing is still on disk when its post-install hook runs;
+// the cleanup that deletes it comes later, with nobody watching. So an older
+// keg of the same formula counts as superseded while it is still there.
+func TestSupersededBinaryCoversAnOlderKegOfTheSameFormula(t *testing.T) {
+	prefix := resolvedTempDir(t)
+	previous := filepath.Join(prefix, "Cellar", "lerd", "1.32.0", "bin", "lerd")
+	opt := filepath.Join(prefix, "opt", "lerd", "bin", "lerd")
+	writeExecutable(t, previous)
+	writeExecutable(t, opt)
+
+	if !SupersededBinary(previous, opt) {
+		t.Errorf("SupersededBinary(%q, %q) = false; want the older keg superseded", previous, opt)
+	}
+}
+
+func TestSupersededBinaryCoversABinaryThatIsGone(t *testing.T) {
+	if !SupersededBinary("/home/linuxbrew/.linuxbrew/Cellar/lerd/1.31.0/bin/lerd", "/usr/bin/lerd") {
+		t.Error("a recorded binary that is not on disk should count as superseded")
+	}
+}
+
+// A working install of a different provenance keeps its units and shims: a brew
+// install has no claim on the lerd someone installed with the script.
+func TestSupersededBinaryLeavesAnotherInstallAlone(t *testing.T) {
+	prefix := resolvedTempDir(t)
+	script := filepath.Join(prefix, "home", ".local", "bin", "lerd")
+	opt := filepath.Join(prefix, "opt", "lerd", "bin", "lerd")
+	writeExecutable(t, script)
+	writeExecutable(t, opt)
+
+	if SupersededBinary(script, opt) {
+		t.Errorf("SupersededBinary(%q, %q) = true; want another install left alone", script, opt)
+	}
+	if SupersededBinary(opt, opt) {
+		t.Error("a binary that is the one running is not superseded by itself")
+	}
+	if SupersededBinary("", opt) || SupersededBinary(script, "") {
+		t.Error("an unknown path on either side is not something to repoint")
+	}
+}
+
 // resolvedTempDir is t.TempDir() with symlinks resolved, so a comparison
 // against a path LerdBinary resolved does not fail on macOS, where the temp dir
 // lives under the /var → /private/var symlink.


### PR DESCRIPTION
A Homebrew install of lerd carries the version-independent opt path since 1.33.0, but an install set up before that still names the keg in its user services and its shims, and lerd only repairs that when a person shows up: `lerd start` rewrites what points at a binary that is gone, and the first command run at a terminal reapplies the rest of the environment. On a distribution that upgrades brew packages unattended neither happens, so the dashboard and the watcher are down and `php` resolves to a file that no longer exists, with nothing on screen to say why.

The formula now finishes the job itself. A `post-upgrade` hook repoints the daemon units and the shims at the lerd that is installed now and restarts the daemons that are set to start at login, and stops there. Reapplying quadlets, nginx and the stores is still the first terminal command's work, where someone is watching and the minutes it takes are affordable. On a machine that has never run `lerd install` the hook does nothing, because that install asks questions a package script has no business answering, and it cannot fail the upgrade.

What counts as a stale path now depends on who is asking. A start still repairs only a binary that is no longer on disk, so starting a build from a checkout cannot take a working install's daemons with it. The hook runs from the release that has just landed, so it also repoints an older keg of the same formula while brew still has it on disk, since the cleanup that deletes it comes later. A binary from an unrelated install is left alone either way.

The hook had to be handed to systemd to work at all. brew runs post_install inside a read-only mount namespace with HOME pointed at a throwaway directory, so every write into the real home fails there, quietly. On Linux the user's own systemd manager runs the repair outside that namespace, which is what the formula asks it to do; on macOS the direct call with the real home is all that can be tried.

Refs #1432
