### PR TITLE
Remove a service's rendered config with the service

### DIFF
--- a/docs/getting-started/services.md
+++ b/docs/getting-started/services.md
@@ -198,7 +198,7 @@ lerd service stop mongodb        # stop without removing
 lerd service remove mongodb      # stop + remove quadlet + delete YAML
 ```
 
-The data directory at `~/.local/share/lerd/data/<name>/` is **not** deleted by `service remove`. Wipe it manually if you want a clean slate.
+The data directory at `~/.local/share/lerd/data/<name>/` is **not** deleted by `service remove`. Wipe it manually if you want a clean slate. The config a preset renders for its container (`~/.local/share/lerd/service-files/<name>/`) does go, since it is generated from the definition being removed and a later install renders it again.
 
 ---
 

--- a/docs/usage/cleanup.md
+++ b/docs/usage/cleanup.md
@@ -42,6 +42,8 @@ lerd cleanup --safe       # only reclaim images provably built by lerd, keep unu
 lerd cleanup --yes        # skip the confirmation prompt (for scripts)
 ```
 
+Alongside images, cleanup reclaims the config a preset rendered for a service that is no longer installed (`~/.local/share/lerd/service-files/<name>/`). Removing a service clears its own, so what turns up here was left by an older lerd. A directory is only listed when nothing answers for the name any more: no service definition, no default preset, and no installed quadlet. Your databases live elsewhere, under `~/.local/share/lerd/data/<name>/`, and cleanup never touches them.
+
 Reported sizes are an estimate of the disk each removal frees. An image a live image is still built on is never listed (removing it is impossible and would free nothing), so cleanup never promises space it can't reclaim, though images that share layers with each other can add up to less than their sizes suggest. `lerd doctor` shows the reclaimable total as a read-only line so you discover the bloat early.
 
 The dashboard surfaces this too. The resources widget shows the reclaimable total alongside live CPU and memory, and a **Clean up** button opens a confirmation modal that lists the images that would be removed and the space they would return, mirroring the preview above, before it runs the deep reclaim. Confirming re-inspects the host and applies that fresh plan, so a modal left open across a rebuild never asks podman to remove an image that has since become live. Cleanup only ever reclaims images and never touches a named data volume, and the watcher already runs it unattended every day, so it does not sit in the same class as migrate, remove, or reinstall, which stay CLI-only. The TUI stays informative only.

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -10,9 +10,11 @@ package cleanup
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/podman"
 )
 
@@ -26,10 +28,17 @@ const lerdLabelPrefix = "dev.lerd."
 // base images use) is the ownership signal.
 var baseImageRe = regexp.MustCompile(`/lerd-php\d+-fpm-base:`)
 
+// Target kinds. An image target is removed through podman, a files target is a
+// directory on disk lerd rendered and no longer has an owner for.
+const (
+	KindImage = "image"
+	KindFiles = "files"
+)
+
 // Target is one reclaimable resource.
 type Target struct {
-	Kind  string // "image"
-	ID    string // short image ID
+	Kind  string // KindImage or KindFiles
+	ID    string // short image ID, or the directory path for KindFiles
 	Desc  string // human description for the plan output
 	Bytes int64
 }
@@ -172,7 +181,7 @@ func Inspect(scope Scope) (Plan, error) {
 
 	var p Plan
 	add := func(id, desc string, bytes int64) {
-		p.Targets = append(p.Targets, Target{Kind: "image", ID: id, Desc: desc, Bytes: bytes})
+		p.Targets = append(p.Targets, Target{Kind: KindImage, ID: id, Desc: desc, Bytes: bytes})
 	}
 	var baseCandidates []image
 	for _, img := range imgs {
@@ -224,10 +233,56 @@ func Inspect(scope Scope) (Plan, error) {
 			p.Targets = append(p.Targets, deepTargets(imgs, repos, prot, canonPulled(), reapAllDangling)...)
 		}
 	}
+	p.Targets = append(p.Targets, staleServiceFiles()...)
 	// podman lists a multi-tag image once per tag, so dedupe by ref/ID to avoid
 	// counting or trying to remove the same target twice.
 	p.Targets = dedupTargets(p.Targets)
 	return p, nil
+}
+
+// staleServiceFiles lists the rendered preset config of services that are gone.
+// Removal clears these now, so what remains was left by a lerd that did not, and
+// nothing else reaps it. A directory is only claimed when no definition, no
+// default preset and no installed quadlet still answers for the name.
+func staleServiceFiles() []Target {
+	entries, err := os.ReadDir(config.ServiceFilesRoot())
+	if err != nil {
+		return nil
+	}
+	var out []Target
+	for _, e := range entries {
+		name := e.Name()
+		if !e.IsDir() || config.IsDefaultPreset(name) || config.CustomServiceExists(name) {
+			continue
+		}
+		if podman.QuadletInstalled("lerd-" + name) {
+			continue
+		}
+		dir := config.ServiceFilesDir(name)
+		out = append(out, Target{
+			Kind:  KindFiles,
+			ID:    dir,
+			Desc:  "rendered config left by removed service " + name,
+			Bytes: dirBytes(dir),
+		})
+	}
+	return out
+}
+
+// dirBytes sums the files directly inside dir; rendered config is a flat set of
+// small files, so an unreadable entry just contributes nothing.
+func dirBytes(dir string) int64 {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	var total int64
+	for _, e := range entries {
+		if info, err := e.Info(); err == nil {
+			total += info.Size()
+		}
+	}
+	return total
 }
 
 // dedupTargets drops repeated targets, keeping the first of each ID/ref.
@@ -307,6 +362,14 @@ func podmanRemoveImage(id string) error {
 	return podman.RunSilent("image", "rm", id)
 }
 
+// removeTarget deletes one target, whichever kind it is.
+func removeTarget(t Target) error {
+	if t.Kind == KindFiles {
+		return os.RemoveAll(t.ID)
+	}
+	return removeImage(t.ID)
+}
+
 // Apply removes every target in the plan and returns how many images were
 // actually removed and the disk reclaimed (a skipped target counts toward
 // neither). It sweeps in repeated passes, retrying targets that failed until a full pass
@@ -320,7 +383,7 @@ func Apply(p Plan) (removed int, reclaimed int64) {
 		var stuck []Target
 		progress := false
 		for _, t := range remaining {
-			if err := removeImage(t.ID); err != nil {
+			if err := removeTarget(t); err != nil {
 				stuck = append(stuck, t)
 				continue
 			}

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -2,8 +2,11 @@ package cleanup
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/imgledger"
 )
 
@@ -11,6 +14,12 @@ import (
 // restores them after. layers maps an image ID to its RootFS layers.
 func withImages(t *testing.T, imgs []image, layers map[string][]string) {
 	t.Helper()
+	// Point the config paths at a temp dir: the plan now includes rendered
+	// service config from disk, and no test may read, let alone reclaim, what is
+	// under the real ~/.local/share/lerd.
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
 	scanImages = func() ([]image, error) { return imgs, nil }
 	imageLayers = func(ids []string) (map[string][]string, error) {
 		m := map[string][]string{}
@@ -349,5 +358,70 @@ func TestApply_SkipsFailedRemovalsButContinues(t *testing.T) {
 	}
 	if gotN != 1 {
 		t.Errorf("removed count = %d, want 1 (only the successful removal)", gotN)
+	}
+}
+
+// seedServiceFiles renders a service's file directory and returns its path.
+func seedServiceFiles(t *testing.T, name string) string {
+	t.Helper()
+	dir := config.ServiceFilesDir(name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "conf"), []byte("rendered\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return dir
+}
+
+// Rendered config for a service that no longer exists is reclaimable; anything
+// still backed by a definition, a default preset or an installed quadlet is not.
+func TestInspect_ListsRenderedFilesOfRemovedServicesOnly(t *testing.T) {
+	withImages(t, nil, nil)
+
+	gone := seedServiceFiles(t, "phpmyadmin")
+	seedServiceFiles(t, "mysql")     // default preset, still ours
+	seedServiceFiles(t, "gotenberg") // custom definition below
+	seedServiceFiles(t, "typesense") // no definition, but a quadlet is installed
+
+	if err := config.SaveCustomService(&config.CustomService{Name: "gotenberg", Image: "docker.io/gotenberg/gotenberg:8"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := os.MkdirAll(config.QuadletDir(), 0o755); err != nil {
+		t.Fatalf("mkdir quadlet dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(config.QuadletDir(), "lerd-typesense.container"), []byte("[Container]\n"), 0o644); err != nil {
+		t.Fatalf("write quadlet: %v", err)
+	}
+
+	plan, err := Inspect(ScopeDeep)
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+
+	var got []string
+	for _, tgt := range plan.Targets {
+		if tgt.Kind == KindFiles {
+			got = append(got, tgt.ID)
+		}
+	}
+	if len(got) != 1 || got[0] != gone {
+		t.Fatalf("file targets = %v, want [%s]", got, gone)
+	}
+}
+
+// The sweep deletes the directory and counts what it freed.
+func TestApply_RemovesRenderedFileTargets(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	dir := seedServiceFiles(t, "phpmyadmin")
+
+	gotN, freed := Apply(Plan{Targets: []Target{{Kind: KindFiles, ID: dir, Desc: "rendered config", Bytes: 9}}})
+
+	if gotN != 1 || freed != 9 {
+		t.Errorf("removed=%d freed=%d, want 1 and 9", gotN, freed)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("directory should be gone, stat err = %v", err)
 	}
 }

--- a/internal/cli/cleanup.go
+++ b/internal/cli/cleanup.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/geodro/lerd/internal/cleanup"
 	"github.com/geodro/lerd/internal/config"
@@ -118,17 +119,17 @@ func runCleanup(dryRun, yes, safe bool) error {
 	// stay behind for the live images that still reference them.
 	rows := make([][]string, 0, len(plan.Targets))
 	for _, t := range plan.Targets {
-		rows = append(rows, []string{t.ID, t.Desc, humanSize(t.Bytes)})
+		rows = append(rows, []string{targetLabel(t), t.Desc, humanSize(t.Bytes)})
 	}
-	feedback.Header("Reclaimable lerd images")
-	feedback.Table([]string{"IMAGE", "KIND", "RECLAIMABLE"}, rows)
-	feedback.Note(fmt.Sprintf("About %s across %d image(s).", humanSize(plan.ReclaimBytes()), len(plan.Targets)))
+	feedback.Header("Reclaimable lerd disk")
+	feedback.Table([]string{"TARGET", "KIND", "RECLAIMABLE"}, rows)
+	feedback.Note(fmt.Sprintf("About %s across %d item(s).", humanSize(plan.ReclaimBytes()), len(plan.Targets)))
 
 	if dryRun {
 		showHeldHint(plan)
 		return nil
 	}
-	if !yes && !feedback.Confirm("Remove these images?", false) {
+	if !yes && !feedback.Confirm("Remove these?", false) {
 		return nil
 	}
 
@@ -136,6 +137,16 @@ func runCleanup(dryRun, yes, safe bool) error {
 	feedback.Done(fmt.Sprintf("Freed about %s.", humanSize(freed)))
 	showHeldHint(plan)
 	return nil
+}
+
+// targetLabel is what the first column shows: an image ref as it is, and a
+// rendered-config directory as the tail of its path, since the leading
+// ~/.local/share/lerd is the same for every one of them.
+func targetLabel(t cleanup.Target) string {
+	if t.Kind == cleanup.KindFiles {
+		return filepath.Join("service-files", filepath.Base(t.ID))
+	}
+	return t.ID
 }
 
 // showHeldHint tells the user when reclaimable disk is locked behind running

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -383,7 +383,13 @@ func CustomServicesDir() string {
 // for the named custom service. Each file is bind-mounted into the container
 // at its declared target path.
 func ServiceFilesDir(name string) string {
-	return filepath.Join(DataDir(), "service-files", name)
+	return filepath.Join(ServiceFilesRoot(), name)
+}
+
+// ServiceFilesRoot returns the parent of every service's rendered FileMount
+// directory, so a sweep can tell which of them no service claims any more.
+func ServiceFilesRoot() string {
+	return filepath.Join(DataDir(), "service-files")
 }
 
 // ServiceTuningFile returns the host path for a service's user-editable runtime

--- a/internal/serviceops/remove.go
+++ b/internal/serviceops/remove.go
@@ -170,6 +170,14 @@ func RemoveService(name string, opts RemoveOptions, emit func(PhaseEvent)) error
 		return fmt.Errorf("remove service config: %w", err)
 	}
 
+	// The rendered preset files are derived from the definition just deleted, not
+	// user state like the data dir or the tuning override, so they leave with it.
+	// Kept, they hand the next install a stale rendering, and a chown:true mount
+	// among them is one podman has re-owned beyond this user's reach.
+	if err := os.RemoveAll(config.ServiceFilesDir(name)); err != nil {
+		return fmt.Errorf("remove rendered files for %s: %w", name, err)
+	}
+
 	// Prune the cached store preset once no installed service still references it,
 	// so a removed add-on reverts from "local" back to "store" and a reinstall
 	// fetches a fresh definition. Never touches embedded presets. Best-effort: a

--- a/internal/serviceops/remove_test.go
+++ b/internal/serviceops/remove_test.go
@@ -76,6 +76,25 @@ func mkTestDataDir(t *testing.T, name string, contents string) string {
 	return dir
 }
 
+// mkTestServiceFiles seeds a service's rendered preset files the way
+// MaterializeServiceFilesChanged would, hash sidecar included.
+func mkTestServiceFiles(t *testing.T, name string) string {
+	t.Helper()
+	dir := config.ServiceFilesDir(name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	for file, body := range map[string]string{
+		"pgpass":        "lerd-postgres:5432:*:postgres:lerd\n",
+		"pgpass.sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, file), []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", file, err)
+		}
+	}
+	return dir
+}
+
 func TestRemoveService_NoData_PreservesDataDir(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)
@@ -193,6 +212,40 @@ func TestRemoveService_WithoutData_KeepsTuningOverride(t *testing.T) {
 	// that state.
 	if _, err := os.Stat(tuningPath); err != nil {
 		t.Errorf("tuning override must survive RemoveData=false, stat err = %v", err)
+	}
+}
+
+// The rendered preset files are derived from the definition being deleted, so
+// they go with it whether or not the data does. Left behind, the next install
+// of the same preset inherits them, including one podman re-owned through :U
+// that this user can no longer read.
+func TestRemoveService_ClearsRenderedPresetFiles(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	stubPodmanRemove(t)
+
+	filesDir := mkTestServiceFiles(t, "pgadmin")
+
+	if err := RemoveService("pgadmin", RemoveOptions{RemoveData: false}, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("RemoveService: %v", err)
+	}
+
+	if _, err := os.Stat(filesDir); !os.IsNotExist(err) {
+		t.Errorf("rendered preset files should be gone, stat err = %v", err)
+	}
+}
+
+// A service that never rendered any preset file has no directory to clear, and
+// that is not a failure.
+func TestRemoveService_NoRenderedFilesSucceeds(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	stubPodmanRemove(t)
+
+	if err := RemoveService("redis", RemoveOptions{}, func(PhaseEvent) {}); err != nil {
+		t.Fatalf("RemoveService: %v", err)
 	}
 }
 

--- a/internal/ui/web/messages/de.json
+++ b/internal/ui/web/messages/de.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "Wird freigegeben…",
   "dashboard_disk_cleanup": "Aufräumen",
   "dashboard_disk_held": "{size} weitere von laufenden Containern belegt, werden beim Neustart frei",
-  "dashboard_disk_modalBody": "Diese Images können entfernt werden, um etwa {size} freizugeben:",
+  "dashboard_disk_modalBody": "Diese Elemente können entfernt werden, um etwa {size} freizugeben:",
   "dashboard_disk_modalConfirm": "Freigeben",
   "dashboard_disk_modalDeepNote": "Diese gründliche Bereinigung entfernt auch ungetaggte, verwaiste Images anderer Podman-Workloads auf diesem Rechner. Benannte Datenvolumes werden nie angetastet.",
   "dashboard_disk_modalTitle": "Speicher freigeben",

--- a/internal/ui/web/messages/en.json
+++ b/internal/ui/web/messages/en.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "Reclaiming…",
   "dashboard_disk_cleanup": "Clean up",
   "dashboard_disk_held": "{size} more held by running containers, freed on restart",
-  "dashboard_disk_modalBody": "These images can be removed to free about {size}:",
+  "dashboard_disk_modalBody": "These items can be removed to free about {size}:",
   "dashboard_disk_modalConfirm": "Reclaim",
   "dashboard_disk_modalDeepNote": "This deep clean also removes dangling untagged images left by other podman workloads on this machine. It never touches named data volumes.",
   "dashboard_disk_modalTitle": "Reclaim disk",

--- a/internal/ui/web/messages/es.json
+++ b/internal/ui/web/messages/es.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "Recuperando…",
   "dashboard_disk_cleanup": "Limpiar",
   "dashboard_disk_held": "{size} más retenidos por contenedores en ejecución, se liberan al reiniciar",
-  "dashboard_disk_modalBody": "Estas imágenes se pueden eliminar para liberar unos {size}:",
+  "dashboard_disk_modalBody": "Estos elementos se pueden eliminar para liberar unos {size}:",
   "dashboard_disk_modalConfirm": "Recuperar",
   "dashboard_disk_modalDeepNote": "Esta limpieza profunda también elimina imágenes colgantes sin etiqueta dejadas por otras cargas de trabajo de podman en esta máquina. Nunca toca los volúmenes de datos con nombre.",
   "dashboard_disk_modalTitle": "Recuperar disco",

--- a/internal/ui/web/messages/fr.json
+++ b/internal/ui/web/messages/fr.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "Récupération…",
   "dashboard_disk_cleanup": "Nettoyer",
   "dashboard_disk_held": "{size} de plus retenus par des conteneurs en cours d'exécution, libérés au redémarrage",
-  "dashboard_disk_modalBody": "Ces images peuvent être supprimées pour libérer environ {size} :",
+  "dashboard_disk_modalBody": "Ces éléments peuvent être supprimés pour libérer environ {size} :",
   "dashboard_disk_modalConfirm": "Récupérer",
   "dashboard_disk_modalDeepNote": "Ce nettoyage profond supprime aussi les images sans étiquette laissées par d'autres charges de travail podman sur cette machine. Il ne touche jamais aux volumes de données nommés.",
   "dashboard_disk_modalTitle": "Récupérer de l'espace disque",

--- a/internal/ui/web/messages/id.json
+++ b/internal/ui/web/messages/id.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "Mereklamasi…",
   "dashboard_disk_cleanup": "Bersihkan",
   "dashboard_disk_held": "{size} lagi ditahan oleh kontainer yang berjalan, dibebaskan saat mulai ulang",
-  "dashboard_disk_modalBody": "Image ini dapat dihapus untuk membebaskan sekitar {size}:",
+  "dashboard_disk_modalBody": "Item ini dapat dihapus untuk membebaskan sekitar {size}:",
   "dashboard_disk_modalConfirm": "Reklamasi",
   "dashboard_disk_modalDeepNote": "Pembersihan mendalam ini juga menghapus image menggantung tanpa tag milik beban kerja podman lain di mesin ini. Volume data bernama tidak pernah disentuh.",
   "dashboard_disk_modalTitle": "Reklamasi disk",

--- a/internal/ui/web/messages/it.json
+++ b/internal/ui/web/messages/it.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "Recupero in corso…",
   "dashboard_disk_cleanup": "Pulisci",
   "dashboard_disk_held": "{size} in più trattenuti dai container in esecuzione, liberati al riavvio",
-  "dashboard_disk_modalBody": "Queste immagini possono essere rimosse per liberare circa {size}:",
+  "dashboard_disk_modalBody": "Questi elementi possono essere rimossi per liberare circa {size}:",
   "dashboard_disk_modalConfirm": "Recupera",
   "dashboard_disk_modalDeepNote": "Questa pulizia profonda rimuove anche le immagini penzolanti senza tag lasciate da altri carichi di lavoro podman su questa macchina. Non tocca mai i volumi di dati denominati.",
   "dashboard_disk_modalTitle": "Recupera spazio su disco",

--- a/internal/ui/web/messages/ja.json
+++ b/internal/ui/web/messages/ja.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "回収中…",
   "dashboard_disk_cleanup": "クリーンアップ",
   "dashboard_disk_held": "実行中のコンテナがさらに {size} を保持しています。再起動で解放されます",
-  "dashboard_disk_modalBody": "これらのイメージを削除すると約 {size} を解放できます:",
+  "dashboard_disk_modalBody": "これらの項目を削除すると約 {size} を解放できます:",
   "dashboard_disk_modalConfirm": "回収",
   "dashboard_disk_modalDeepNote": "このディープクリーンは、このマシン上の他の podman ワークロードが残した未タグのダングリングイメージも削除します。名前付きデータボリュームには一切触れません。",
   "dashboard_disk_modalTitle": "ディスクを回収",

--- a/internal/ui/web/messages/nl.json
+++ b/internal/ui/web/messages/nl.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "Bezig met vrijmaken…",
   "dashboard_disk_cleanup": "Opruimen",
   "dashboard_disk_held": "{size} meer vastgehouden door draaiende containers, vrijgemaakt bij herstart",
-  "dashboard_disk_modalBody": "Deze images kunnen worden verwijderd om ongeveer {size} vrij te maken:",
+  "dashboard_disk_modalBody": "Deze items kunnen worden verwijderd om ongeveer {size} vrij te maken:",
   "dashboard_disk_modalConfirm": "Vrijmaken",
   "dashboard_disk_modalDeepNote": "Deze grondige opschoning verwijdert ook ongetagde losse images van andere podman-workloads op deze machine. Benoemde datavolumes worden nooit aangeraakt.",
   "dashboard_disk_modalTitle": "Schijfruimte vrijmaken",

--- a/internal/ui/web/messages/pl.json
+++ b/internal/ui/web/messages/pl.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "Odzyskiwanie…",
   "dashboard_disk_cleanup": "Wyczyść",
   "dashboard_disk_held": "{size} więcej zajęte przez działające kontenery, zwalniane po restarcie",
-  "dashboard_disk_modalBody": "Te obrazy można usunąć, aby zwolnić około {size}:",
+  "dashboard_disk_modalBody": "Te elementy można usunąć, aby zwolnić około {size}:",
   "dashboard_disk_modalConfirm": "Odzyskaj",
   "dashboard_disk_modalDeepNote": "To głębokie czyszczenie usuwa również nieoznaczone wiszące obrazy pozostawione przez inne zadania podman na tej maszynie. Nigdy nie narusza nazwanych woluminów danych.",
   "dashboard_disk_modalTitle": "Odzyskaj miejsce na dysku",

--- a/internal/ui/web/messages/pt.json
+++ b/internal/ui/web/messages/pt.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "Recuperando…",
   "dashboard_disk_cleanup": "Limpar",
   "dashboard_disk_held": "{size} a mais retidos por contêineres em execução, liberados ao reiniciar",
-  "dashboard_disk_modalBody": "Estas imagens podem ser removidas para liberar cerca de {size}:",
+  "dashboard_disk_modalBody": "Estes itens podem ser removidos para liberar cerca de {size}:",
   "dashboard_disk_modalConfirm": "Recuperar",
   "dashboard_disk_modalDeepNote": "Esta limpeza profunda também remove imagens pendentes sem tag deixadas por outras cargas de trabalho do podman nesta máquina. Nunca toca em volumes de dados nomeados.",
   "dashboard_disk_modalTitle": "Recuperar disco",

--- a/internal/ui/web/messages/ro.json
+++ b/internal/ui/web/messages/ro.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "Se recuperează…",
   "dashboard_disk_cleanup": "Curăță",
   "dashboard_disk_held": "încă {size} ocupați de containere active, eliberați la repornire",
-  "dashboard_disk_modalBody": "Aceste imagini pot fi șterse pentru a elibera aproximativ {size}:",
+  "dashboard_disk_modalBody": "Aceste elemente pot fi șterse pentru a elibera aproximativ {size}:",
   "dashboard_disk_modalConfirm": "Recuperează",
   "dashboard_disk_modalDeepNote": "Această curățare profundă șterge și imaginile fără etichetă rămase de la alte sarcini podman de pe această mașină. Nu atinge niciodată volumele de date denumite.",
   "dashboard_disk_modalTitle": "Recuperează spațiu pe disc",

--- a/internal/ui/web/messages/tr.json
+++ b/internal/ui/web/messages/tr.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "Geri kazanılıyor…",
   "dashboard_disk_cleanup": "Temizle",
   "dashboard_disk_held": "Çalışan kapsayıcılar {size} daha tutuyor, yeniden başlatınca boşalır",
-  "dashboard_disk_modalBody": "Bu görüntüler yaklaşık {size} boşaltmak için kaldırılabilir:",
+  "dashboard_disk_modalBody": "Bu öğeler yaklaşık {size} boşaltmak için kaldırılabilir:",
   "dashboard_disk_modalConfirm": "Geri kazan",
   "dashboard_disk_modalDeepNote": "Bu derin temizlik, bu makinedeki diğer podman iş yüklerinden kalan etiketsiz sarkan görüntüleri de kaldırır. Adlandırılmış veri birimlerine asla dokunmaz.",
   "dashboard_disk_modalTitle": "Disk alanı geri kazan",

--- a/internal/ui/web/messages/vi.json
+++ b/internal/ui/web/messages/vi.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "Đang thu hồi…",
   "dashboard_disk_cleanup": "Dọn dẹp",
   "dashboard_disk_held": "{size} nữa đang bị các container đang chạy giữ, được giải phóng khi khởi động lại",
-  "dashboard_disk_modalBody": "Có thể xóa các image này để giải phóng khoảng {size}:",
+  "dashboard_disk_modalBody": "Có thể xóa các mục này để giải phóng khoảng {size}:",
   "dashboard_disk_modalConfirm": "Thu hồi",
   "dashboard_disk_modalDeepNote": "Việc dọn dẹp sâu này cũng xóa các image lơ lửng không gắn thẻ do các tải công việc podman khác trên máy này để lại. Nó không bao giờ đụng đến các volume dữ liệu có tên.",
   "dashboard_disk_modalTitle": "Thu hồi dung lượng đĩa",

--- a/internal/ui/web/messages/zh.json
+++ b/internal/ui/web/messages/zh.json
@@ -84,7 +84,7 @@
   "dashboard_disk_cleaning": "正在回收…",
   "dashboard_disk_cleanup": "清理",
   "dashboard_disk_held": "运行中的容器还占用 {size}，重启后释放",
-  "dashboard_disk_modalBody": "删除这些镜像可释放约 {size}：",
+  "dashboard_disk_modalBody": "删除这些项目可释放约 {size}：",
   "dashboard_disk_modalConfirm": "回收",
   "dashboard_disk_modalDeepNote": "此深度清理还会删除本机上其他 podman 工作负载遗留的未标记悬空镜像。它绝不会触及命名数据卷。",
   "dashboard_disk_modalTitle": "回收磁盘空间",


### PR DESCRIPTION
Removing a service left the config its preset had rendered under ~/.local/share/lerd/service-files/<name>, so the next install of the same preset inherited whatever the last one wrote instead of starting from a clean rendering. One of those files, for a chown:true mount, is one podman has re-owned to a userns uid and the user can no longer read. They are generated from the definition being deleted rather than user state like the data dir or the tuning override, so they now leave with it.

That only covers removals from here on, so cleanup reclaims the directories an older lerd left behind. One is claimed only when nothing answers for the name any more, no service definition, no default preset and no installed quadlet, and it shows up in the plan beside the images with its own size. The plan is no longer images only, so the command's header, column and count are kind neutral now, and the dashboard modal says items rather than images in every language.

Closes #1507