### PR TITLE
fix(dns): skip host resolver mutation on NixOS

### DIFF
--- a/docs/getting-started/nixos.md
+++ b/docs/getting-started/nixos.md
@@ -124,7 +124,11 @@ Add the following to `configuration.nix`. Each block is explained in the comment
 
 This is the part that bites people. Lerd is built for Debian/Ubuntu/Arch and, by default, **imperatively rewrites your system resolver** (a systemd-resolved drop-in and/or a NetworkManager dispatcher script) to point *all* DNS at its container. On those distros it works; on NixOS it fights the declarative config and, if the lerd-dns container isn't up, can take down **all** name resolution (you'll see `Could not resolve host: cache.nixos.org` even during `nixos-rebuild`).
 
-The config above sidesteps that: **NixOS** owns the resolver and routes only `~test` to lerd-dns. Because that routing lives in the main `resolved.conf` (which lerd never edits), it's the stable anchor. The consequence is that you should **decline** lerd's offer to configure DNS, see the next section.
+The config above sidesteps that: **NixOS** owns the resolver and routes only `~test` to lerd-dns. Because that routing lives in the main `resolved.conf` (which lerd never edits), it's the stable anchor.
+
+Since 1.30, lerd also writes an always-up dummy link (`lerd0`) and empties systemd-resolved's `FallbackDNS`. Since 1.31, `lerd install` runs `sudo lerd bootstrap --system` first, which installs a passwordless DNS sudoers rule, so `lerd start` and the watcher can apply those files without a prompt. Ctrl+C on the old dispatcher line no longer stops it. On NixOS that combination takes down **all** name resolution, not just `.test`.
+
+Lerd skips those host-resolver writes when `/etc/NIXOS` exists. The `lerd-dns` container still runs; block #5 is what routes `*.test` to it. Non-NixOS behaviour is unchanged.
 
 ## First-time lerd setup
 
@@ -144,9 +148,7 @@ Do this once, in order. You need working internet DNS first, and if it's already
 
    This generates the mkcert root CA at `~/.local/share/mkcert/rootCA.pem`, writes the container Quadlets, and starts dns/nginx/php-fpm.
 
-   ::: warning Decline the DNS prompt
-   When it prints **"Configuring NetworkManager dispatcher for .test DNS resolution"** and asks for sudo, press **Ctrl+C to decline.** Your NixOS config (block #5) already resolves `.test`, so lerd doesn't need to touch DNS. Declining keeps it out of your resolver permanently.
-   :::
+   On NixOS (`/etc/NIXOS`), lerd does not write resolver drop-ins, `lerd0`, or the DNS sudoers rule. Block #5 is what routes `*.test` to the `lerd-dns` container. If you are on an older binary that still offers the dispatcher sudo prompt, decline it — but 1.31+ can apply the new files without a prompt you can usefully Ctrl+C.
 
 3. **Trust the CA.** Copy it into your config repo and enable line #6:
 
@@ -211,7 +213,8 @@ sudo rm -f /etc/systemd/resolved.conf.d/lerd-fallback.conf \
            /etc/NetworkManager/conf.d/lerd-dns-link.conf \
            /etc/NetworkManager/conf.d/lerd.conf \
            /etc/NetworkManager/dnsmasq.d/lerd.conf \
-           /etc/NetworkManager/dispatcher.d/99-lerd-dns
+           /etc/NetworkManager/dispatcher.d/99-lerd-dns \
+           /etc/sudoers.d/lerd
 sudo systemctl daemon-reload
 
 # Reset and restart whichever resolver you run
@@ -228,7 +231,7 @@ sudo rm -f /etc/resolv.conf
 printf 'nameserver 192.168.0.1\nnameserver 8.8.8.8\n' | sudo tee /etc/resolv.conf
 ```
 
-The permanent fix is the NixOS DNS config (block #5) plus declining lerd's DNS prompt. Once that's in place this shouldn't recur. The only things that re-touch DNS are `lerd install` / `lerd start` (decline the prompt) and the lerd watcher (which only acts when `.test` is already broken).
+The permanent fix is the NixOS DNS config (block #5) plus a lerd that skips host resolver writes when `/etc/NIXOS` exists. An older 1.31+ binary will put the files back on `lerd install` / `lerd start` / watcher repair.
 
 ### "could not find … lerd-nginx" on `lerd link`
 

--- a/internal/cli/bootstrap_linux.go
+++ b/internal/cli/bootstrap_linux.go
@@ -41,6 +41,10 @@ func runBootstrapSystem(target string, skipSudoers bool) error {
 	} else {
 		feedback.Done("systemd linger enabled for " + target)
 	}
+	if dns.HostOwnsResolver() {
+		feedback.Note("NixOS owns the resolver; skipping DNS sudoers")
+		return nil
+	}
 	if skipSudoers {
 		return nil
 	}

--- a/internal/cli/bootstrap_linux_test.go
+++ b/internal/cli/bootstrap_linux_test.go
@@ -5,17 +5,21 @@ package cli
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/geodro/lerd/internal/dns"
 )
 
 // stubBootstrapSystem redirects the three root actions runBootstrapSystem
 // performs so the test never touches /etc or the real login manager.
 func stubBootstrapSystem(t *testing.T) (*[][]string, *[]string) {
 	t.Helper()
-	origPath, origRunner, origSudoers := unprivPortDropIn, bootstrapRunner, writeDNSSudoers
+	origPath, origRunner, origSudoers, origOwns := unprivPortDropIn, bootstrapRunner, writeDNSSudoers, dns.HostOwnsResolver
 	t.Cleanup(func() {
 		unprivPortDropIn, bootstrapRunner, writeDNSSudoers = origPath, origRunner, origSudoers
+		dns.HostOwnsResolver = origOwns
 	})
 	unprivPortDropIn = filepath.Join(t.TempDir(), "99-lerd-ports.conf")
+	dns.HostOwnsResolver = func() bool { return false }
 
 	var runs [][]string
 	bootstrapRunner = func(name string, args ...string) error {
@@ -54,6 +58,24 @@ func TestRunBootstrapSystemSkipsSudoers(t *testing.T) {
 	}
 	if len(*users) != 0 {
 		t.Errorf("sudoers grant written despite --skip-sudoers: %v", *users)
+	}
+	if len(*runs) != 2 {
+		t.Errorf("commands = %v, want ports and linger still applied", *runs)
+	}
+}
+
+// NixOS owns systemd-resolved from configuration.nix. Writing the DNS sudoers
+// grant there lets a later start or watcher apply lerd0 and empty FallbackDNS
+// without a prompt, which takes down all name resolution.
+func TestRunBootstrapSystemSkipsSudoersOnNixOS(t *testing.T) {
+	runs, users := stubBootstrapSystem(t)
+	dns.HostOwnsResolver = func() bool { return true }
+
+	if err := runBootstrapSystem("george", false); err != nil {
+		t.Fatalf("runBootstrapSystem: %v", err)
+	}
+	if len(*users) != 0 {
+		t.Errorf("sudoers grant written on NixOS: %v", *users)
 	}
 	if len(*runs) != 2 {
 		t.Errorf("commands = %v, want ports and linger still applied", *runs)

--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -427,6 +427,15 @@ func Setup() error {
 	return ConfigureResolver()
 }
 
+// HostOwnsResolver reports whether the OS, not lerd, owns systemd-resolved.
+// NixOS generates resolved.conf from configuration.nix; writing drop-ins,
+// the lerd0 dummy link, or FallbackDNS= there takes down all name resolution.
+// A func var so tests can force the non-NixOS path without touching /etc/NIXOS.
+var HostOwnsResolver = func() bool {
+	_, err := os.Stat("/etc/NIXOS")
+	return err == nil
+}
+
 // ConfigureResolver configures the system DNS resolver to forward .test to the
 // lerd-dns dnsmasq container on port 5300. Call this after lerd-dns is running so
 // that any immediate resolvectl changes don't break DNS before dnsmasq is up.
@@ -435,6 +444,13 @@ func ConfigureResolver() error {
 	// localhost, so carrying on here would prompt for a password and point a
 	// ~localhost route at a lerd-dns that is deliberately not running.
 	if cfg, err := config.LoadGlobal(); err == nil && cfg != nil && !cfg.DNS.Enabled {
+		return nil
+	}
+	// NixOS routes only ~test to lerd-dns from configuration.nix. The
+	// installer, lerd start, and the watcher would otherwise write
+	// lerd-fallback.conf (empty FallbackDNS) and lerd0, which on NixOS
+	// takes down every name, not just .test.
+	if HostOwnsResolver() {
 		return nil
 	}
 	if isSystemdResolvedActive() {
@@ -978,6 +994,9 @@ func removeSudoersGrant() bool {
 // grant the passwordless DNS rules up front, letting a later unattended install
 // configure the resolver without a prompt. Idempotent.
 func WriteSudoersForUser(user string) error {
+	if HostOwnsResolver() {
+		return nil
+	}
 	if err := validSudoersUser(user); err != nil {
 		return err
 	}
@@ -1076,6 +1095,9 @@ func SudoersCurrent() bool {
 }
 
 func InstallSudoers() error {
+	if HostOwnsResolver() {
+		return nil
+	}
 	user := os.Getenv("USER")
 	if user == "" {
 		user = os.Getenv("LOGNAME")

--- a/internal/dns/setup_test.go
+++ b/internal/dns/setup_test.go
@@ -844,6 +844,37 @@ func TestConfigureResolver_doesNothingWhenDNSIsDisabled(t *testing.T) {
 	if strings.Index(fn, "!cfg.DNS.Enabled") > strings.Index(fn, "isSystemdResolvedActive()") {
 		t.Error("the disabled check must come before any resolver path runs")
 	}
+	assertContains(t, fn, "HostOwnsResolver()")
+	if strings.Index(fn, "HostOwnsResolver()") > strings.Index(fn, "isSystemdResolvedActive()") {
+		t.Error("the NixOS host-owns-resolver check must come before any resolver path runs")
+	}
+}
+
+func TestConfigureResolver_doesNothingWhenHostOwnsResolver(t *testing.T) {
+	orig := HostOwnsResolver
+	t.Cleanup(func() { HostOwnsResolver = orig })
+	HostOwnsResolver = func() bool { return true }
+	if err := ConfigureResolver(); err != nil {
+		t.Fatalf("ConfigureResolver: %v", err)
+	}
+}
+
+func TestWriteSudoersForUser_skipsWhenHostOwnsResolver(t *testing.T) {
+	orig := HostOwnsResolver
+	t.Cleanup(func() { HostOwnsResolver = orig })
+	HostOwnsResolver = func() bool { return true }
+	if err := WriteSudoersForUser("not a valid user"); err != nil {
+		t.Fatalf("WriteSudoersForUser: %v", err)
+	}
+}
+
+func TestInstallSudoers_skipsWhenHostOwnsResolver(t *testing.T) {
+	orig := HostOwnsResolver
+	t.Cleanup(func() { HostOwnsResolver = orig })
+	HostOwnsResolver = func() bool { return true }
+	if err := InstallSudoers(); err != nil {
+		t.Fatalf("InstallSudoers: %v", err)
+	}
 }
 
 // section returns the source between two markers, failing the test if either is
@@ -921,4 +952,9 @@ func TestLinuxSudoers_grantsEveryPrivilegedCommandTheCodeRuns(t *testing.T) {
 			t.Errorf("missing NOPASSWD grant, headless watcher would prompt: %s", want)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	HostOwnsResolver = func() bool { return false }
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
## Summary
- On NixOS, `*.test` is already routed to lerd-dns from `configuration.nix`. Since 1.30, `ConfigureResolver` also writes an always-up `lerd0` dummy link and empties systemd-resolved's `FallbackDNS`; since 1.31, `lerd bootstrap --system` installs a passwordless DNS sudoers rule so `lerd start` and the watcher re-apply those files without a prompt. That takes down **all** name resolution on NixOS, not just `.test`.
- Skip host-resolver writes (`ConfigureResolver`, `InstallSudoers`, `WriteSudoersForUser`, bootstrap DNS sudoers) only when `/etc/NIXOS` exists. The `lerd-dns` container still runs. Debian/Ubuntu/Arch/macOS follow the same path as today.
- Update the NixOS guide: Ctrl+C on the old dispatcher prompt is no longer enough on 1.31+, and recovery now includes `lerd-fallback.conf`, `lerd-dns-link.service`, and `/etc/sudoers.d/lerd`.

## Test plan
- [x] `go test ./internal/dns/` (HostOwnsResolver stubbed off so CI/Ubuntu is the existing path)
- [x] `go test ./internal/cli/ -tags nogui -run TestRunBootstrapSystem` (includes the new NixOS skip)
- [ ] Confirm a non-NixOS Linux guest still writes the dispatcher / `lerd0` / FallbackDNS drop-in on `lerd install`
- [ ] On NixOS, `lerd install` / `lerd start` do not create `/etc/systemd/resolved.conf.d/lerd-fallback.conf`, `lerd-dns-link.service`, or `/etc/sudoers.d/lerd`, and `*.test` still resolves via the NixOS `~test` route