### PR TITLE
fix(dns): note NixOS resolver ownership on install and start

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -799,6 +799,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		ok()
 
 		feedback.Line("configuring DNS resolver")
+		dns.NoteNixOSOwnsResolver()
 		if err := dns.ConfigureResolver(); err != nil {
 			fmt.Printf("    WARN: %v\n", err)
 		}
@@ -869,6 +870,7 @@ func runInstall(cmd *cobra.Command, _ []string) error {
 		ok()
 
 		feedback.Line("configuring DNS resolver")
+		dns.NoteNixOSOwnsResolver()
 		if err := dns.ConfigureResolver(); err != nil {
 			fmt.Printf("    WARN: %v\n", err)
 		}

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -21,6 +21,24 @@ func TestIsShell_fish(t *testing.T) {
 	}
 }
 
+// Interactive install must explain NixOS resolver ownership around
+// ConfigureResolver. The note itself lives in dns.NoteNixOSOwnsResolver so
+// install+start in one process print once; ConfigureResolver stays silent
+// because the watcher calls it on every .test failure.
+func TestInstallNotesNixOSOwnsResolver(t *testing.T) {
+	src, err := os.ReadFile("install.go")
+	if err != nil {
+		t.Fatalf("reading install.go: %v", err)
+	}
+	body := string(src)
+	if !strings.Contains(body, "dns.NoteNixOSOwnsResolver()") {
+		t.Error("install must call NoteNixOSOwnsResolver around ConfigureResolver")
+	}
+	if strings.Count(body, "dns.NoteNixOSOwnsResolver()") < strings.Count(body, "dns.ConfigureResolver()") {
+		t.Error("every ConfigureResolver call on the install path must be paired with NoteNixOSOwnsResolver")
+	}
+}
+
 func TestIsShell_zsh(t *testing.T) {
 	if !isShell("/bin/zsh", "zsh") {
 		t.Error("expected /bin/zsh to match zsh")

--- a/internal/cli/startstop.go
+++ b/internal/cli/startstop.go
@@ -644,6 +644,9 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// Re-apply DNS routing so .test resolves via lerd-dns on every start.
 	// resolvectl settings are ephemeral and reset on reboot; the NM dispatcher
 	// script fires on interface "up" but that event precedes lerd-dns starting.
+	// The NixOS note lives here (and on install), not inside ConfigureResolver:
+	// the watcher calls that whenever .test fails.
+	dns.NoteNixOSOwnsResolver()
 	if err := dns.ConfigureResolver(); err != nil {
 		fmt.Printf("  WARN: DNS resolver config: %v\n", err)
 	}

--- a/internal/cli/startstop_test.go
+++ b/internal/cli/startstop_test.go
@@ -238,3 +238,20 @@ func TestRunStart_skipsSudoersRefreshWhenDNSDisabled(t *testing.T) {
 		t.Error("the sudoers refresh must be gated on dnsEnabled(), or a disabled-DNS host still installs DNS grants on start")
 	}
 }
+
+// Interactive start must explain NixOS resolver ownership around
+// ConfigureResolver. The helper is once-per-process so install+start in one
+// process do not spam; ConfigureResolver itself stays silent.
+func TestRunStart_notesNixOSOwnsResolver(t *testing.T) {
+	src, err := os.ReadFile("startstop.go")
+	if err != nil {
+		t.Fatalf("reading startstop.go: %v", err)
+	}
+	body := string(src)
+	if !strings.Contains(body, "dns.NoteNixOSOwnsResolver()") {
+		t.Error("start must call NoteNixOSOwnsResolver around ConfigureResolver")
+	}
+	if strings.Count(body, "dns.NoteNixOSOwnsResolver()") < strings.Count(body, "dns.ConfigureResolver()") {
+		t.Error("every ConfigureResolver call on the start path must be paired with NoteNixOSOwnsResolver")
+	}
+}

--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/geodro/lerd/internal/config"
 	"github.com/geodro/lerd/internal/feedback"
@@ -434,6 +435,21 @@ func Setup() error {
 var HostOwnsResolver = func() bool {
 	_, err := os.Stat("/etc/NIXOS")
 	return err == nil
+}
+
+var noteNixOSOwnsResolverOnce sync.Once
+
+// NoteNixOSOwnsResolver prints once per process that NixOS owns the resolver
+// and that configuration.nix must route ~test to lerd-dns. Call from interactive
+// install and start only — never from ConfigureResolver, which the watcher
+// invokes whenever .test fails.
+func NoteNixOSOwnsResolver() {
+	if !HostOwnsResolver() {
+		return
+	}
+	noteNixOSOwnsResolverOnce.Do(func() {
+		feedback.Note("NixOS owns the resolver; lerd is not writing host DNS. configuration.nix must route ~test to 127.0.0.1:5300 (lerd-nixos README / getting-started/nixos block #5).")
+	})
 }
 
 // ConfigureResolver configures the system DNS resolver to forward .test to the

--- a/internal/dns/setup_darwin.go
+++ b/internal/dns/setup_darwin.go
@@ -185,3 +185,7 @@ func ReadUpstreamDNS() []string {
 func ResolverHint() string {
 	return "run 'lerd install' to reconfigure DNS"
 }
+
+// NoteNixOSOwnsResolver is a no-op on macOS: NixOS host-resolver ownership is
+// Linux-only. The shared install and start paths call this around ConfigureResolver.
+func NoteNixOSOwnsResolver() {}

--- a/internal/dns/setup_test.go
+++ b/internal/dns/setup_test.go
@@ -3,10 +3,14 @@
 package dns
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/geodro/lerd/internal/feedback"
 )
 
 // --- parseNmcliOutput ---
@@ -854,8 +858,96 @@ func TestConfigureResolver_doesNothingWhenHostOwnsResolver(t *testing.T) {
 	orig := HostOwnsResolver
 	t.Cleanup(func() { HostOwnsResolver = orig })
 	HostOwnsResolver = func() bool { return true }
+
+	var buf bytes.Buffer
+	defer feedback.SetTestWriter(&buf)()
+
 	if err := ConfigureResolver(); err != nil {
 		t.Fatalf("ConfigureResolver: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("ConfigureResolver NixOS path must stay silent, got %q", buf.String())
+	}
+}
+
+// The watcher calls ConfigureResolver whenever .test fails. A Note there would
+// spam (or mislead) on every repair; the once-per-run explanation lives on the
+// interactive install and start paths instead.
+func TestConfigureResolver_hostOwnsResolverPathDoesNotPrint(t *testing.T) {
+	src, err := os.ReadFile("setup.go")
+	if err != nil {
+		t.Fatalf("reading setup.go: %v", err)
+	}
+	fn := section(t, string(src), "func ConfigureResolver() error {", "func setupDummyLink")
+	if strings.Contains(fn, "NoteNixOSOwnsResolver") {
+		t.Error("ConfigureResolver must not call NoteNixOSOwnsResolver; the watcher invokes it on every .test failure")
+	}
+	i := strings.Index(fn, "if HostOwnsResolver() {")
+	if i < 0 {
+		t.Fatal("HostOwnsResolver guard missing")
+	}
+	block := fn[i:]
+	if j := strings.Index(block, "return nil"); j >= 0 {
+		block = block[:j]
+	}
+	for _, needle := range []string{"feedback.Note", "feedback.Line", "fmt.Print", "fmt.Printf"} {
+		if strings.Contains(block, needle) {
+			t.Errorf("ConfigureResolver NixOS return path must stay silent, found %s", needle)
+		}
+	}
+}
+
+func TestNoteNixOSOwnsResolver_mentionsHostOwnsResolver(t *testing.T) {
+	src, err := os.ReadFile("setup.go")
+	if err != nil {
+		t.Fatalf("reading setup.go: %v", err)
+	}
+	fn := section(t, string(src), "func NoteNixOSOwnsResolver() {", "func ConfigureResolver()")
+	assertContains(t, fn, "HostOwnsResolver()")
+}
+
+func TestNoteNixOSOwnsResolver_printsOnceWhenHostOwnsResolver(t *testing.T) {
+	orig := HostOwnsResolver
+	t.Cleanup(func() {
+		HostOwnsResolver = orig
+		noteNixOSOwnsResolverOnce = sync.Once{}
+	})
+	noteNixOSOwnsResolverOnce = sync.Once{}
+	HostOwnsResolver = func() bool { return true }
+
+	var buf bytes.Buffer
+	defer feedback.SetTestWriter(&buf)()
+
+	NoteNixOSOwnsResolver()
+	NoteNixOSOwnsResolver()
+
+	got := buf.String()
+	if strings.Count(got, "NixOS owns the resolver") != 1 {
+		t.Fatalf("got %q, want the NixOS resolver note once", got)
+	}
+	if !strings.Contains(got, "127.0.0.1:5300") {
+		t.Errorf("note should mention 127.0.0.1:5300, got %q", got)
+	}
+	if !strings.Contains(got, "block #5") {
+		t.Errorf("note should point at configuration.nix block #5, got %q", got)
+	}
+}
+
+func TestNoteNixOSOwnsResolver_silentWhenHostDoesNotOwnResolver(t *testing.T) {
+	orig := HostOwnsResolver
+	t.Cleanup(func() {
+		HostOwnsResolver = orig
+		noteNixOSOwnsResolverOnce = sync.Once{}
+	})
+	noteNixOSOwnsResolverOnce = sync.Once{}
+	HostOwnsResolver = func() bool { return false }
+
+	var buf bytes.Buffer
+	defer feedback.SetTestWriter(&buf)()
+
+	NoteNixOSOwnsResolver()
+	if buf.Len() != 0 {
+		t.Fatalf("non-NixOS path must stay silent, got %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Follow-up to #1509. `ConfigureResolver` still returns nil silently on NixOS (the watcher calls it whenever `.test` fails, so a note there would spam). Interactive `lerd install` and `lerd start` now print a once-per-process `feedback.Note` that NixOS owns the resolver and that `configuration.nix` must route `~test` to `127.0.0.1:5300` (lerd-nixos README / getting-started/nixos block #5).
- The note lives in `dns.NoteNixOSOwnsResolver()` (`sync.Once`, gated on `HostOwnsResolver()`), called immediately around `ConfigureResolver` in `install.go` and `startstop.go`. Non-NixOS paths and Teardown are unchanged.

## Test plan
- [x] `go test ./internal/dns/ -run 'TestConfigureResolver_|TestNoteNixOSOwnsResolver'` — ConfigureResolver NixOS path stays silent; helper prints once when stubbed on and nothing when stubbed off
- [x] `go test ./internal/cli/ -tags nogui -run 'TestInstallNotesNixOSOwnsResolver|TestRunStart_notesNixOSOwnsResolver'`
- [ ] On NixOS without block #5, `lerd install` / `lerd start` print the note once and still do not write host DNS
- [ ] On a non-NixOS Linux guest, install/start output is unchanged