### PR TITLE
fix(doctor): stop reporting a broken resolver on NixOS

### DIFF
--- a/docs/getting-started/nixos.md
+++ b/docs/getting-started/nixos.md
@@ -130,6 +130,8 @@ Since 1.30, lerd also writes an always-up dummy link (`lerd0`) and empties syste
 
 Lerd skips those host-resolver writes when `/etc/NIXOS` exists. The `lerd-dns` container still runs; block #5 is what routes `*.test` to it. Non-NixOS behaviour is unchanged.
 
+`lerd install` and `lerd start` say so when they skip, and `lerd doctor` reports the resolver hookup as skipped rather than failed, leaves out the interface and `lerd0` checks it no longer installs, and points at `configuration.nix` instead of `lerd install` when `.test` does not resolve.
+
 ## First-time lerd setup
 
 Do this once, in order. You need working internet DNS first, and if it's already broken from an earlier attempt, see [DNS is completely broken](#dns-is-completely-broken).

--- a/internal/dns/diagnose.go
+++ b/internal/dns/diagnose.go
@@ -68,6 +68,14 @@ type probeFns struct {
 	// for the nmDnsmasqKind hookup, where NetworkManager needs it to act on
 	// the config lerd writes.
 	hostDnsmasqPresent func() bool
+	// hostOwnsResolver reports a host whose own config owns the resolver, so
+	// the hookup, interface and lerd0 rungs probe files lerd never wrote.
+	hostOwnsResolver func() bool
+}
+
+// ownsResolver keeps the rungs working for callers that predate the field.
+func (p probeFns) ownsResolver() bool {
+	return p.hostOwnsResolver != nil && p.hostOwnsResolver()
 }
 
 // exposedIP is the LAN IP dnsmasq publishes under lan:expose, or "" when the
@@ -236,6 +244,7 @@ func diagnose(tld string, p probeFns) Diagnostic {
 
 	// Rung 5 — resolver hookup file.
 	kind, exists, path := p.resolverHookup()
+	hostOwned := p.ownsResolver()
 	if exists && kind == nmDnsmasqKind && p.hostDnsmasqPresent != nil && !p.hostDnsmasqPresent() {
 		// Config file is real, but with no dnsmasq binary to run it
 		// NetworkManager silently keeps using upstream DNS instead.
@@ -247,9 +256,20 @@ func diagnose(tld string, p probeFns) Diagnostic {
 		})
 		return finalize(d)
 	}
-	if exists {
+	switch {
+	case exists:
 		d.Steps = append(d.Steps, Step{Name: "resolver hookup", Status: StepOK, Detail: kind + ": " + path})
-	} else {
+	case hostOwned:
+		// Not a failure and not repairable by lerd: on NixOS the resolver is
+		// generated from configuration.nix, so lerd writes no hookup at all and
+		// the ~tld route there is what carries .test. Rung 7 is the real test.
+		d.Steps = append(d.Steps, Step{
+			Name:   "resolver hookup",
+			Status: StepSkip,
+			Detail: "NixOS owns the resolver; lerd installs no hookup here",
+			Hint:   "the ~" + tld + " route in configuration.nix is what carries ." + tld,
+		})
+	default:
 		d.Steps = append(d.Steps, Step{
 			Name:   "resolver hookup",
 			Status: StepFail,
@@ -263,7 +283,7 @@ func diagnose(tld string, p probeFns) Diagnostic {
 	// own dnsmasq answers .test without systemd-resolved, which is typically
 	// masked on those hosts, so resolvectl has nothing to report and probing it
 	// would warn about a healthy install.
-	if runtime.GOOS == "linux" && kind != nmDnsmasqKind {
+	if runtime.GOOS == "linux" && kind != nmDnsmasqKind && !hostOwned {
 		iface, has5300, hasTLD, err := p.interfaceRouting(tld)
 		switch {
 		case err != nil:
@@ -300,7 +320,7 @@ func diagnose(tld string, p probeFns) Diagnostic {
 	// way, and the damage only shows once the user goes offline, which is exactly
 	// why it's worth saying out loud here rather than leaving them to find it on a
 	// train.
-	if runtime.GOOS == "linux" && usesDummyLink(kind) && p.dummyLinkRouting != nil {
+	if runtime.GOOS == "linux" && usesDummyLink(kind) && p.dummyLinkRouting != nil && !hostOwned {
 		switch present, routed := p.dummyLinkRouting(tld); {
 		case !present:
 			d.Steps = append(d.Steps, Step{
@@ -331,10 +351,10 @@ func diagnose(tld string, p probeFns) Diagnostic {
 	accepted := acceptedAnswer(addrs, lanIP)
 	switch {
 	case err != nil:
-		d.Steps = append(d.Steps, systemLookupFailStep(err.Error(), vpn))
+		d.Steps = append(d.Steps, systemLookupFailStep(err.Error(), vpn, hostOwned))
 	case accepted == "":
 		d.Steps = append(d.Steps, systemLookupFailStep(
-			fmt.Sprintf("got %v, want one entry to be %s", addrs, want), vpn))
+			fmt.Sprintf("got %v, want one entry to be %s", addrs, want), vpn, hostOwned))
 	default:
 		d.Steps = append(d.Steps, Step{Name: "system DNS lookup", Status: StepOK, Detail: accepted})
 	}
@@ -347,7 +367,15 @@ func diagnose(tld string, p probeFns) Diagnostic {
 // taken over DNS, .test still resolves via lerd-dns directly, and the
 // watcher re-syncs container DNS automatically. That is a warning, not a
 // failure, so the chain doesn't flag a broken state lerd already handles.
-func systemLookupFailStep(detail string, vpn bool) Step {
+func systemLookupFailStep(detail string, vpn, hostOwned bool) Step {
+	if hostOwned && !vpn {
+		return Step{
+			Name:   "system DNS lookup",
+			Status: StepFail,
+			Detail: detail,
+			Hint:   "lerd leaves the resolver alone on NixOS; route the TLD yourself in configuration.nix (services.resolved.domains, see docs/getting-started/nixos.md)",
+		}
+	}
 	if vpn {
 		return Step{
 			Name:   "system DNS lookup",
@@ -401,6 +429,7 @@ func defaultProbes() probeFns {
 		vpnActive:          VPNActive,
 		lanExposedIP:       defaultLanExposedIP,
 		hostDnsmasqPresent: hostDnsmasqPresent,
+		hostOwnsResolver:   HostOwnsResolver,
 	}
 }
 

--- a/internal/dns/diagnose_test.go
+++ b/internal/dns/diagnose_test.go
@@ -28,6 +28,70 @@ func fakeProbes() probeFns {
 		vpnActive:          func() bool { return false },
 		lanExposedIP:       func() string { return "" },
 		hostDnsmasqPresent: func() bool { return true },
+		hostOwnsResolver:   func() bool { return false },
+	}
+}
+
+// nixosProbes is a NixOS host: no lerd hookup file, because lerd deliberately
+// writes none there, with .test still resolving through the ~test route the
+// user's configuration.nix installs.
+func nixosProbes() probeFns {
+	p := fakeProbes()
+	p.hostOwnsResolver = func() bool { return true }
+	p.resolverHookup = func() (string, bool, string) { return "", false, "" }
+	return p
+}
+
+func TestDiagnose_nixosHookupIsNotAFailure(t *testing.T) {
+	d := diagnose("test", nixosProbes())
+	if d.FirstFailure != -1 {
+		t.Errorf("FirstFailure = %d, want -1: a missing hookup is expected on NixOS", d.FirstFailure)
+	}
+	hookup := findStep(d, "resolver hookup")
+	if hookup == nil || hookup.Status != StepSkip {
+		t.Fatalf("resolver hookup = %+v, want a skip", hookup)
+	}
+	if !strings.Contains(hookup.Detail, "NixOS") {
+		t.Errorf("detail = %q, want it to name NixOS", hookup.Detail)
+	}
+	if findStep(d, "system DNS lookup") == nil {
+		t.Error("the chain must go on to the system lookup, which is the real proof on NixOS")
+	}
+}
+
+// The interface and lerd0 rungs probe files lerd no longer writes on NixOS, so
+// running them there reports a broken machine that resolves .test perfectly.
+func TestDiagnose_nixosSkipsLerdOwnedRungs(t *testing.T) {
+	p := nixosProbes()
+	p.interfaceRouting = func(string) (string, bool, bool, error) { return "eth0", false, false, nil }
+	p.dummyLinkRouting = func(string) (bool, bool) { return false, false }
+
+	d := diagnose("test", p)
+	if d.FirstFailure != -1 {
+		t.Errorf("FirstFailure = %d, want -1", d.FirstFailure)
+	}
+	if s := findStep(d, "interface routes"); s != nil {
+		t.Errorf("interface rung ran on NixOS: %+v", s)
+	}
+	if s := findStep(d, "offline ."); s != nil {
+		t.Errorf("offline route rung ran on NixOS: %+v", s)
+	}
+}
+
+// A NixOS user who never added the ~test route gets the failure at the system
+// lookup, where the hint has to point at configuration.nix rather than at the
+// `lerd install` that will now deliberately do nothing.
+func TestDiagnose_nixosLookupFailureHintsAtConfigurationNix(t *testing.T) {
+	p := nixosProbes()
+	p.systemLookup = func(string) ([]string, error) { return nil, errors.New("no such host") }
+
+	d := diagnose("test", p)
+	s := findStep(d, "system DNS lookup")
+	if s == nil || s.Status != StepFail {
+		t.Fatalf("system DNS lookup = %+v, want a failure", s)
+	}
+	if !strings.Contains(s.Hint, "configuration.nix") {
+		t.Errorf("hint = %q, want it to point at configuration.nix", s.Hint)
 	}
 }
 

--- a/internal/dns/setup.go
+++ b/internal/dns/setup.go
@@ -428,15 +428,6 @@ func Setup() error {
 	return ConfigureResolver()
 }
 
-// HostOwnsResolver reports whether the OS, not lerd, owns systemd-resolved.
-// NixOS generates resolved.conf from configuration.nix; writing drop-ins,
-// the lerd0 dummy link, or FallbackDNS= there takes down all name resolution.
-// A func var so tests can force the non-NixOS path without touching /etc/NIXOS.
-var HostOwnsResolver = func() bool {
-	_, err := os.Stat("/etc/NIXOS")
-	return err == nil
-}
-
 var noteNixOSOwnsResolverOnce sync.Once
 
 // NoteNixOSOwnsResolver prints once per process that NixOS owns the resolver

--- a/internal/dns/setup_common.go
+++ b/internal/dns/setup_common.go
@@ -18,6 +18,15 @@ import (
 	"github.com/geodro/lerd/internal/config"
 )
 
+// HostOwnsResolver reports whether the OS, not lerd, owns systemd-resolved.
+// NixOS generates resolved.conf from configuration.nix; writing drop-ins,
+// the lerd0 dummy link, or FallbackDNS= there takes down all name resolution.
+// A func var so tests can force the non-NixOS path without touching /etc/NIXOS.
+var HostOwnsResolver = func() bool {
+	_, err := os.Stat("/etc/NIXOS")
+	return err == nil
+}
+
 // sudoersMarkerPath is a user-owned record of the sudoers drop-in lerd last
 // installed. /etc/sudoers.d is root-only (0750), so the invoking user cannot
 // read the drop-in back to compare content; without this marker InstallSudoers


### PR DESCRIPTION
Follow-up to #1509 and #1513. Those two stopped lerd writing the host resolver on NixOS and made the skip audible on install and start, which leaves the diagnostic as the last place still describing the old behaviour.

`lerd doctor` went on probing for a hookup lerd deliberately no longer writes. The resolver hookup rung failed with a hint to rerun `lerd install`, now the one command guaranteed not to help, and the interface routing and `lerd0` rungs kept checking files that were never going to be there, so a host resolving `.test` perfectly through its own `configuration.nix` came back broken in three places at once.

The hookup reads as skipped now, naming the `~test` route as what carries the TLD, and the rungs that only make sense for a lerd-owned resolver are left out. A failed end to end lookup is still a failure, since on that host it means the route really is missing, but the hint sends the user to `configuration.nix`.

The NixOS guide gains a line describing what install, start and doctor now say, and `HostOwnsResolver` moves to the untagged file so the diagnostic can consult it on macOS too.

Closes #1512