### PR TITLE
docs: put the Omarchy bar widget in the sidebar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -224,6 +224,7 @@ export default defineConfig({
             { text: 'Web UI', link: '/features/web-ui' },
             { text: 'Terminal Dashboard', link: '/features/tui' },
             { text: 'System Tray', link: '/features/system-tray' },
+            { text: 'Omarchy Bar Widget', link: '/features/omarchy-glance' },
             { text: 'AI Integration (MCP)', link: '/features/mcp' },
           ],
         },

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,7 +99,6 @@ nav:
       - Dump viewer: features/dumps.md
       - Query viewer: features/queries.md
       - System Tray: features/system-tray.md
-      - Omarchy bar widget: features/omarchy-glance.md
       - HTTPS / TLS: features/https.md
       - DNS: features/dns.md
       - Git Worktrees: features/git-worktrees.md


### PR DESCRIPTION
The Omarchy bar widget page went out with nothing linking to it. The entry I added landed in the mkdocs nav, which the site does not read, so the page was reachable only by typing the URL.

The site is built by VitePress, so the sidebar in its config is the nav that renders. The page now sits under Interfaces next to the system tray, where a reader looking for the desktop surfaces will find it. The mkdocs entry is removed rather than left in place, since nothing in the repo reads that file and keeping it would imply the nav lives in two places.

Refs #1520