### PR TITLE
docs: add Omarchy, Laradock and Sail landing pages

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -124,17 +124,30 @@ export default defineConfig({
     sidebar: {
       '/getting-started/': [
         {
-          text: 'Getting Started',
+          text: 'Start here',
           items: [
             { text: 'Requirements', link: '/getting-started/requirements' },
             { text: 'Installation', link: '/getting-started/installation' },
-            { text: 'Updating from before 1.26', link: '/getting-started/updating-from-pre-1.26' },
-            { text: 'Windows (WSL2, beta)', link: '/getting-started/wsl2' },
-            { text: 'NixOS', link: '/getting-started/nixos' },
             { text: 'Quick Start', link: '/getting-started/quick-start' },
+            { text: 'Updating from before 1.26', link: '/getting-started/updating-from-pre-1.26' },
+          ],
+        },
+        {
+          text: 'Platform guides',
+          items: [
+            { text: 'Omarchy', link: '/getting-started/omarchy' },
+            { text: 'NixOS', link: '/getting-started/nixos' },
+            { text: 'Windows (WSL2, beta)', link: '/getting-started/wsl2' },
+          ],
+        },
+        {
+          text: 'Coming from another tool',
+          items: [
             { text: 'Comparison', link: '/getting-started/comparison' },
             { text: 'Laravel Herd for Linux', link: '/getting-started/herd-linux' },
             { text: 'Laragon for Linux', link: '/getting-started/laragon-linux' },
+            { text: 'Laradock alternative', link: '/getting-started/laradock' },
+            { text: 'Laravel Sail alternative', link: '/getting-started/sail' },
           ],
         },
         {

--- a/docs/features/omarchy-glance.md
+++ b/docs/features/omarchy-glance.md
@@ -5,7 +5,8 @@
 desktop bar, so the answer to "is anything broken" is already on screen.
 
 It is a separate, optional install. lerd does not need it and it does not need anything
-from lerd beyond the dashboard already running.
+from lerd beyond the dashboard already running. If you are setting lerd up on Omarchy for
+the first time, start with [PHP development on Omarchy](../getting-started/omarchy.md).
 
 ```bash
 omarchy plugin add https://github.com/lerd-env/lerd-omarchy-glance.git --enable

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -94,7 +94,7 @@ cd ~/Projects/myapp
 lerd sail import
 ```
 
-See [Importing from Laravel Sail](/usage/import-sail) for details.
+See [Laravel Sail alternative](/getting-started/sail) for the full migration guide, and [Importing from Laravel Sail](/usage/import-sail) for the flag reference.
 
 ---
 
@@ -153,3 +153,33 @@ See [Importing from Laravel Sail](/usage/import-sail) for details.
 **Choose Lando when:** your team is cross-platform, you want per-project service isolation defined in the repo, you work with hosting platforms like Pantheon, Platform.sh, or Lagoon and want their `lando pull` / `lando push` workflow, or your workflow already depends on Docker.
 
 **Choose Lerd when:** you want a zero-config shared stack you can drop any project into without committing a config file, prefer rootless Podman with a lighter footprint, or want a built-in web UI and terminal dashboard on Linux or macOS.
+
+---
+
+## Lerd vs Laradock
+
+[Laradock](https://laradock.io) is a collection of prebuilt Docker images behind one `docker-compose.yml`, checked into the repo as a `laradock/` folder, with a `workspace` container you shell into to run PHP tooling. Lerd replaces the whole arrangement with one shared, rootless stack and no files in the repo.
+
+|  | Lerd | Laradock |
+|---|---|---|
+| Platforms | Linux (systemd), macOS | Linux, macOS, Windows |
+| License | Open source (MIT) | Open source (MIT) |
+| Container runtime | Rootless Podman, no daemon | Docker, root daemon or Docker Desktop |
+| Architecture | Shared nginx + PHP-FPM across all projects | Per-project Compose stack, one container per service |
+| PHP versions | 7.4, 8.0–8.5, per project, no rebuild | Set in `laradock/.env`, rebuild the image to change |
+| Services (MySQL, Redis…) | One shared instance | Per-project, uncommented in the Compose file |
+| Domains | `.test`, automatic | Manual `/etc/hosts` plus a site conf per project |
+| HTTPS | `lerd secure` for a trusted mkcert cert instantly | Bring your own certificate |
+| Running tooling | `lerd artisan` / `lerd composer` from your own shell | `docker compose exec workspace` first |
+| Per-project config | `.lerd.yaml`, optional | `laradock/` submodule + `docker-compose.yml` + its `.env` |
+| RAM with 5 projects running | ~200 MB | Several GB (5× full stacks) |
+| First run | Pulls prebuilt images | Builds images from source |
+| Works on legacy / client repos | Yes, just `lerd link` | Only if you can add Laradock to it |
+| Dashboard | Web UI at `127.0.0.1:7073`, system tray, installable PWA | CLI + Docker Desktop |
+| Cost | Free | Free |
+
+**Choose Laradock when:** two projects need different major versions of the same database at the same time, or your team wants the environment fully described inside the repo.
+
+**Choose Lerd when:** you juggle several projects at once, you are tired of rebuilding images to change a PHP version, or you want `.test` URLs and HTTPS without wiring them by hand.
+
+See [Laradock alternative](/getting-started/laradock) for the full migration path.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -6,15 +6,23 @@ description: Install lerd and get a PHP site running on a local .test domain wit
 
 Lerd is a local PHP development environment for Linux and macOS, with Windows supported through WSL2. It runs Nginx, PHP-FPM and your services as rootless Podman containers, so there is no Docker daemon, no sudo for day to day work, and nothing installed system wide.
 
-If you just want a site running, read [Requirements](/getting-started/requirements) and then [Installation](/getting-started/installation). Together they take a few minutes.
+## Start here
 
-## Install
+Three pages, in order, and you have a site running.
 
 - [Requirements](/getting-started/requirements) covers the supported distributions and the handful of packages lerd expects to find.
 - [Installation](/getting-started/installation) is the main path, a single install script that sets up directories, the container network, DNS and certificates.
-- [Windows (WSL2, beta)](/getting-started/wsl2) explains the systemd and mirrored networking setup Windows needs, most of which `lerd wsl:setup` does for you.
-- [NixOS](/getting-started/nixos) documents the flake based route for immutable and declarative systems.
 - [Quick Start](/getting-started/quick-start) is the short version once lerd is installed: link a directory, get a `.test` domain with HTTPS.
+
+Already running an older lerd? [Updating from before 1.26](/getting-started/updating-from-pre-1.26) covers the one release that needs a manual step.
+
+## Platform guides
+
+The install script covers mainstream Linux and macOS on its own. These pages are for the systems that need something extra, or that have their own integration worth knowing about.
+
+- [Omarchy](/getting-started/omarchy) is the Arch and Hyprland desktop, with the `crun` and `nss` prerequisites, the systemd-resolved detail and the lerd bar widget.
+- [NixOS](/getting-started/nixos) documents the flake based route for immutable and declarative systems.
+- [Windows (WSL2, beta)](/getting-started/wsl2) explains the systemd and mirrored networking setup Windows needs, most of which `lerd wsl:setup` does for you.
 
 ## Framework walkthroughs
 
@@ -25,11 +33,20 @@ Lerd detects your framework from the project itself and configures workers, envi
 - [WordPress](/getting-started/wordpress)
 - [Containers (Node, Python, Go, …)](/getting-started/containers) for stacks that are not PHP at all.
 
-## Add-ons and context
+The sidebar also carries walkthroughs for Drupal, CakePHP, CodeIgniter, Statamic, Tempest and Magento.
 
-- [Services](/getting-started/services) adds MongoDB, phpMyAdmin, Redis and the rest of the service presets.
-- [Comparison](/getting-started/comparison) sets lerd against Herd, Laragon, DDEV, Lando and Sail.
+## Coming from another tool
+
+Each of these is a migration guide, not just a feature table: what the equivalent command is, and how to move your projects and databases across.
+
+- [Comparison](/getting-started/comparison) sets lerd against Herd, Laragon, Laradock, DDEV, Lando and Sail in one place.
 - [Laravel Herd for Linux](/getting-started/herd-linux) is aimed at people who used Herd on a Mac and moved to Linux.
 - [Laragon for Linux](/getting-started/laragon-linux) is aimed at people moving over from Windows.
+- [Laradock alternative](/getting-started/laradock) is for people leaving a per-project Docker Compose stack behind.
+- [Laravel Sail alternative](/getting-started/sail) is the one with an automated importer, `lerd import sail`, database and S3 files included.
+
+## Add-ons
+
+- [Services](/getting-started/services) adds MongoDB, phpMyAdmin, Redis and the rest of the service presets.
 
 Once you are set up, [Usage](/usage/sites) covers day to day site management and [Features](/features/web-ui) covers the web UI, TUI, MCP server and the rest.

--- a/docs/getting-started/laradock.md
+++ b/docs/getting-started/laradock.md
@@ -1,0 +1,196 @@
+---
+title: Laradock alternative
+description: 'Laradock gives every project its own Docker Compose stack and a workspace container. Lerd replaces it with one shared rootless Podman environment: automatic .test domains, HTTPS, per-project PHP 7.4 to 8.5, and no docker-compose.yml in the repo.'
+head:
+  - - meta
+    - name: keywords
+      content: laradock alternative, laradock replacement, laradock linux, laradock too slow, laradock vs, migrate from laradock, laradock without docker, local php development linux, laradock laravel alternative
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What is the best Laradock alternative?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Lerd, if the part of Laradock you want to keep is having every service available and the part you want to lose is a Compose stack and a workspace container per project. Lerd runs one shared nginx, PHP-FPM and service layer as rootless Podman containers, gives each project a .test domain and HTTPS automatically, and needs no files committed to the repo. DDEV and Lando are the alternatives if you would rather stay on per-project Docker."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Why is Laradock slow?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Laradock builds large images from source on first run, and each project you spin up brings its own copy of PHP, nginx and every service it needs. Running several projects at once means several full stacks in memory. Lerd shares one nginx, one PHP-FPM per version and one instance of each service across every site, so five running projects cost around 200 MB rather than a full stack each."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How do I migrate a Laradock project to Lerd?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Dump the database out of the Laradock MySQL or PostgreSQL container with docker compose exec, move the project directory out from under the Laradock parent folder, then run lerd link inside it, lerd env to rewrite the .env connection values, and lerd db:import to restore the dump. The laradock/ submodule and its docker-compose.yml can then be deleted."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does Lerd need Docker?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. Lerd runs nginx, PHP-FPM and services as rootless Podman containers under your own user account, managed by systemd user units. There is no daemon, no Docker Desktop licence and no root. Docker can stay installed alongside it."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can I still pick service versions without Laradock?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes, per service rather than per project. Lerd runs versioned service presets, so you choose which MySQL, PostgreSQL, Redis, MongoDB or Meilisearch version runs, and every site shares it. If two projects genuinely need different major versions of the same database at the same time, a per-project Docker stack still fits that case better."
+            }
+          }
+        ]
+      }
+---
+
+# Laradock alternative
+
+[Laradock](https://laradock.io) solved a real problem: every service a PHP project might want, prebuilt, behind one `docker-compose.yml`. The cost is the shape it leaves behind. A `laradock/` submodule inside the repo, a Compose file and an `.env` to keep in sync, a `workspace` container you have to shell into before you can run `artisan` or `composer`, images that build from source the first time, and one full stack per project when you have four projects open.
+
+**Lerd keeps the useful half and drops the rest.** One shared nginx, one PHP-FPM per version and one instance of each service, all as rootless Podman containers under your own user. Every project gets a `.test` domain and a trusted certificate automatically. Nothing is committed to the repo, nothing is built from source, and `composer` and `artisan` run from your own shell.
+
+```bash
+curl -fsSL https://lerd.sh/install.sh | bash
+cd ~/code/myapp
+lerd link
+```
+
+Your project is live at `https://myapp.test`. No Compose file, no workspace container, no port to remember.
+
+## Every Laradock habit, and the Lerd equivalent
+
+| What you did in Laradock | The same thing in Lerd |
+|---|---|
+| `docker compose up -d nginx mysql redis` before you can work | `lerd start` once, then everything is up for every project |
+| `docker compose exec workspace bash` to reach PHP tooling | `lerd php`, `lerd composer`, `lerd artisan`, run from your own shell in the project directory |
+| Edit `laradock/.env`, set `PHP_VERSION`, rebuild the image | `lerd isolate 8.4`, or let it read `composer.json`, no rebuild |
+| A `laradock/nginx/sites/*.conf` per project, plus `/etc/hosts` entries | An nginx vhost generated on `lerd link`, and the `.test` hostname registered for you |
+| Self-signed cert wired in by hand, or plain HTTP | `lerd secure`, a real mkcert certificate trusted by your system and browsers |
+| Uncomment a service in `docker-compose.yml` and rebuild | `lerd service start mongodb`, shared across every site |
+| `APP_CODE_PATH_HOST` pointing at a sibling project directory | Projects live wherever you keep them, there is no parent folder to respect |
+| `docker compose logs -f php-fpm` | A [log viewer](/features/logs) in the dashboard, or `lerd logs` |
+| Queue and scheduler as extra Compose services | `lerd worker start queue` / `schedule`, as systemd user services with [self-healing](/usage/worker-heal) |
+| `laradock/` submodule committed to the repo | [`.lerd.yaml`](/configuration#per-project-config-lerd-yaml), optional, a handful of lines |
+| Docker Desktop, or Docker Engine plus a daemon running as root | Rootless Podman, no daemon, no root |
+
+## Lerd vs Laradock
+
+|  | Lerd | Laradock |
+|---|---|---|
+| Platforms | Linux (systemd), macOS, Windows via WSL2 (beta) | Linux, macOS, Windows |
+| License | Open source (MIT) | Open source (MIT) |
+| Container runtime | Rootless Podman, no daemon | Docker, with a root daemon or Docker Desktop |
+| Architecture | One shared nginx, PHP-FPM and service layer across every site | A per-project Compose stack, one container per service |
+| RAM with 5 projects running | ~200 MB | Several GB, five full stacks |
+| First run | Pulls prebuilt images, minutes | Builds images from source, often much longer |
+| PHP versions | 7.4, 8.0 to 8.5, per project, no rebuild | Set in `laradock/.env`, rebuild the image to change |
+| `.test` domains | Automatic, through a dnsmasq container | Manual `/etc/hosts` entries plus a site conf per project |
+| HTTPS | `lerd secure`, trusted mkcert certificate | Bring your own certificate and wire it into the nginx conf |
+| Running tooling | `lerd artisan`, `lerd composer`, `lerd node` from your own shell | `docker compose exec workspace` first |
+| Files in the repo | None required, `.lerd.yaml` optional | `laradock/` submodule, `docker-compose.yml`, its own `.env` |
+| Works on a client repo you cannot modify | Yes, just `lerd link` | Only if you can add Laradock to it |
+| Per-project service versions | No, services are shared and versioned globally | Yes, each project pins its own |
+| Dashboard | [Web UI](/features/web-ui) at `127.0.0.1:7073`, [system tray](/features/system-tray), [terminal dashboard](/features/tui) | CLI, plus whatever Docker Desktop shows |
+| AI / MCP | Built-in [MCP server](/features/mcp) for Claude Code, Cursor, Junie and Windsurf | Not built in |
+
+**Choose Laradock when:** two projects genuinely need different major versions of the same database at the same time, your team already standardised on it, or you want the environment fully described inside the repo.
+
+**Choose Lerd when:** you work across several projects at once and do not want a stack per repo, you are tired of rebuilding images to change a PHP version, you want `.test` URLs and HTTPS without wiring them, or you want to work on repos you cannot add files to.
+
+## Moving a Laradock project to Lerd
+
+There is no automated importer for Laradock the way there is for [Laravel Sail](/usage/import-sail), because Laradock stacks vary too much to migrate blind. The manual path is five commands.
+
+**1. Dump the database while Laradock is still up.** From the `laradock/` directory:
+
+```bash
+docker compose up -d mysql
+docker compose exec mysql mysqldump -u root -proot myapp > ~/myapp.sql
+```
+
+For PostgreSQL:
+
+```bash
+docker compose exec postgres pg_dump -U default myapp > ~/myapp.sql
+```
+
+Use whatever credentials your `laradock/.env` actually sets, they are commonly `root` / `root` for MySQL and `default` / `secret` for PostgreSQL.
+
+**2. Move the project out of the Laradock layout.** Laradock expects the project to sit beside the `laradock/` checkout, pointed at by `APP_CODE_PATH_HOST`. Lerd has no such requirement, so the project directory can go anywhere, for example `~/code/myapp`.
+
+**3. Install Lerd and start it.**
+
+```bash
+curl -fsSL https://lerd.sh/install.sh | bash
+lerd start
+```
+
+**4. Link the project.**
+
+```bash
+cd ~/code/myapp
+lerd link
+```
+
+Lerd detects the framework, picks the PHP version from `composer.json`, writes the nginx vhost, registers `myapp.test` and provisions the certificate. Use `lerd init` instead if you want to choose the PHP version, HTTPS and services through a wizard and save the answers to [`.lerd.yaml`](/configuration#per-project-config-lerd-yaml).
+
+**5. Start the services and restore the dump.**
+
+```bash
+lerd service start mysql
+lerd env
+lerd db:import ~/myapp.sql
+```
+
+`lerd env` rewrites the `DB_*`, `REDIS_*` and `MAIL_*` entries in `.env` to match the services Lerd is running, so the connection values line up without you editing them. The original file is saved as `.env.before_lerd` the first time, and `lerd env:restore` puts it back if you want to return to Laradock.
+
+**6. Delete the Laradock leftovers.** The `laradock/` submodule, the Compose file and its `.env` no longer do anything. Laradock's persistent data lives outside the repo in `~/.laradock/data`, so remove that too once you have confirmed the import.
+
+Full detail lives in the [quick start](/getting-started/quick-start) and the [site management](/usage/sites) guide.
+
+## What is genuinely different
+
+These are the places where the mental model changes, worth knowing before you commit to the move:
+
+- **Services are shared, not per project.** One MySQL, one Redis, one Mailpit across every site. That is where the memory saving comes from, and it is also the one thing Laradock does that Lerd does not: pinning a different MySQL major version per project.
+- **No workspace container.** PHP tooling runs through `lerd php`, `lerd composer` and `lerd artisan`, which execute in the project's PHP container but from your own shell, in your own directory, with your own files. There is nothing to `exec` into first.
+- **The environment is not in the repo.** Instead of a committed Compose file, you commit an optional [`.lerd.yaml`](/configuration#per-project-config-lerd-yaml) describing the PHP version, Node version, services and workers. A teammate with Lerd installed gets the same environment from it; a teammate without Lerd is unaffected, since nothing else in the project changed.
+- **Nginx, not Apache.** If a project leaned on Laradock's Apache container and `.htaccess` rules, translate them into an [nginx override](/usage/nginx-overrides).
+- **One `sudo` at install time.** Only to point the system resolver at the `.test` domains. Everything after that runs as your own user.
+
+## Frequently asked questions
+
+**Why is Laradock so slow to start?**
+It builds its images from source on first run, and each project brings a full stack. Lerd pulls prebuilt images once and shares one nginx, one PHP-FPM per version and one copy of each service across every site.
+
+**Can I keep Docker installed?**
+Yes. Lerd uses rootless Podman with no daemon, so the two do not conflict. Keep Laradock running on the projects you have not moved yet.
+
+**Do I need to change my project's code?**
+No. Lerd reads projects where they are. The only file it touches is `.env`, and only when you run `lerd env`, which backs up the original first.
+
+**What about Xdebug and profiling?**
+Both are built in. See the [profiler](/features/profiler), the [dump viewer](/features/dumps) and the [query viewer](/features/queries).
+
+**Is Lerd free for commercial work?**
+Yes. MIT licensed, with no paid tier and no licence popup.
+
+## Next steps
+
+- [Requirements](/getting-started/requirements) and [installation](/getting-started/installation)
+- [Quick start](/getting-started/quick-start), a project served in two commands
+- [Full comparison](/getting-started/comparison) against Laravel Herd, Sail, DDEV and Lando
+- [Importing from Laravel Sail](/usage/import-sail), if you also have Sail projects

--- a/docs/getting-started/omarchy.md
+++ b/docs/getting-started/omarchy.md
@@ -1,0 +1,194 @@
+---
+title: PHP development on Omarchy
+description: 'Omarchy ships an opinionated Arch and Hyprland desktop, but no PHP stack. Lerd adds one: automatic .test domains, HTTPS, per-project PHP 7.4 to 8.5, shared MySQL, PostgreSQL and Redis, rootless Podman, plus a native Omarchy bar widget.'
+head:
+  - - meta
+    - name: keywords
+      content: omarchy php, php development omarchy, omarchy laravel, laravel omarchy, omarchy web development, local php environment arch linux, omarchy dev environment, hyprland php development
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Does Omarchy come with a PHP development environment?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. Omarchy gives you the desktop, the terminal and the editor, but there is no bundled web server, no PHP-FPM and no local domain routing. You install a PHP environment on top of it. Lerd is built for exactly that: one install gives every project a .test domain, HTTPS, its own PHP version and the databases it needs."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How do I install Lerd on Omarchy?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Run curl -fsSL https://lerd.sh/install.sh | bash. Omarchy is Arch-based, so the installer takes the Arch path: it checks for Podman 4.5 or newer, offers to install the missing prerequisites, wires the system resolver for .test domains and installs the binary to ~/.local/bin/lerd. Then run lerd link inside a project."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does the Lerd tray icon work on Omarchy's Hyprland?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Lerd's tray unit is wired to graphical-session.target, which Omarchy reaches because it launches Hyprland through uwsm. Bare Hyprland started without uwsm never reaches that target and needs a one-line change to the unit."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Is there an Omarchy bar widget for Lerd?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. lerd Glance is an optional plugin for the Omarchy Quattro shell that puts sites, services, workers, DNS and container memory in the desktop bar, with a coloured dot only when something needs attention. Install it with omarchy plugin add https://github.com/lerd-env/lerd-omarchy-glance.git --enable."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does Lerd need Docker on Omarchy?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. Lerd runs nginx, PHP-FPM and services as rootless Podman containers under your own user account, managed by systemd user units. Nothing runs as root and there is no daemon. If you already use Docker on Omarchy for other work, the two coexist."
+            }
+          }
+        ]
+      }
+---
+
+# PHP development on Omarchy
+
+[Omarchy](https://omarchy.org) hands you a finished Arch and Hyprland desktop: the terminal, the editor, the keybindings and the theming are all decided for you. What it deliberately does not decide is your web stack. There is no nginx, no PHP-FPM, no `.test` routing and no local TLS, so the first day of any PHP work on a fresh Omarchy box is the one part of the setup that is still yours to solve.
+
+**Lerd is that missing half.** One install, and every project gets a `.test` URL, a trusted certificate, the PHP version it asks for and the databases it needs, all as rootless Podman containers under your own user. It fits the Omarchy shape: no sudo after install, nothing written into system directories, everything under `~/.config` and `~/.local/share`, and a bar widget so the state of the stack is on screen instead of behind a command.
+
+```bash
+curl -fsSL https://lerd.sh/install.sh | bash
+cd ~/code/myapp
+lerd link
+```
+
+Your project is live at `https://myapp.test`. That is the whole setup.
+
+## Why it suits Omarchy
+
+| What Omarchy already gives you | What Lerd adds on top |
+|---|---|
+| Arch with a curated package set, Hyprland launched through `uwsm` | nginx, PHP-FPM and services as rootless Podman containers, managed by systemd user units |
+| A terminal, an editor, and language toolchains you install yourself | PHP 7.4 and 8.0 to 8.5, picked per project by `lerd isolate 8.4` or read from `composer.json` |
+| No local web server, no vhost management | An nginx vhost generated on `lerd link`, with [overrides](/usage/nginx-overrides) when a project needs them |
+| No local domain routing | Automatic `.test` domains through a dnsmasq container wired into systemd-resolved, no `/etc/hosts` edits |
+| No local TLS | `lerd secure`, a real mkcert certificate trusted by your system and browsers |
+| Docker available if you install it | Rootless Podman, no daemon, no root, no `docker-compose.yml` per project |
+| A themed bar with a plugin system | A [native bar widget](/features/omarchy-glance) showing sites, services, workers, DNS and container memory |
+| A tray that follows `graphical-session.target` | A [system tray](/features/system-tray) that autostarts there, because Omarchy runs Hyprland under `uwsm` |
+
+## Installing on Omarchy
+
+Omarchy is Arch-based, so the installer takes the Arch path and Podman is already new enough. Arch ships podman 4.5 or newer out of the box, which is Lerd's [minimum](/getting-started/requirements#podman-4-5-minimum).
+
+```bash
+curl -fsSL https://lerd.sh/install.sh | bash
+```
+
+The installer checks the prerequisites, offers to install anything missing, points the system resolver at the `.test` domains (the one place it needs `sudo`) and installs the binary to `~/.local/bin/lerd`. Nothing goes into `/usr/local`.
+
+Two Arch defaults are worth knowing about, because they differ from the Debian and Fedora side:
+
+**`crun` is not the default runtime.** Arch defaults to `runc`. Both work, but `crun` is lighter and purpose-built for rootless containers, and `lerd doctor` will tell you it is missing:
+
+```bash
+sudo pacman -S crun
+```
+
+**`nss` provides `certutil`.** mkcert needs it to install the CA into Chrome and Firefox, so `lerd secure` produces a certificate the browser accepts with no warning page:
+
+```bash
+sudo pacman -S nss
+```
+
+Then start it and check the environment:
+
+```bash
+lerd start
+lerd doctor
+```
+
+`lerd doctor` is the fastest way to confirm the resolver, the trust store, linger and the container runtime all landed correctly. If `systemctl --user` units do not survive logout, run `loginctl enable-linger $USER` once.
+
+## The bar widget
+
+[lerd Glance](/features/omarchy-glance) is an optional plugin for the Omarchy Quattro shell. It carries Lerd's mark in the bar and stays quiet while everything is healthy, showing a coloured dot only when a service, a worker or DNS needs attention.
+
+```bash
+omarchy plugin add https://github.com/lerd-env/lerd-omarchy-glance.git --enable
+```
+
+Clicking opens a panel with the site and service counts, one row per worker type, nginx and `.test` resolution status, the running PHP versions, the containers with their versions and ports, and total CPU and memory across the whole environment. Two buttons: open the dashboard, and clean up reclaimable disk space when there is any.
+
+It reads the local dashboard API on `127.0.0.1:7073` and sends nothing anywhere else.
+
+## The tray, and the `uwsm` detail
+
+Lerd's tray unit is wired to `graphical-session.target`. Omarchy launches Hyprland through `uwsm`, which reaches that target on login, so [the tray](/features/system-tray) autostarts with no extra work.
+
+This is worth knowing if you ever move off Omarchy's session setup: bare Hyprland, Sway or i3 started without `uwsm` never reaches `graphical-session.target`, and the tray will not autostart. Either run the compositor under `uwsm`, or change `WantedBy=graphical-session.target` to `WantedBy=default.target` in `~/.config/systemd/user/lerd-tray.service`. Every other Lerd unit uses `default.target` and is unaffected either way.
+
+## `.test` domains on a systemd-resolved-only host
+
+Omarchy uses systemd-resolved without NetworkManager, which used to be the awkward case: `.test` resolution could stop working when there was no network link for systemd-resolved to hang the route on.
+
+Lerd now keeps an always-up dummy interface, `lerd0`, that carries the `~test` route. Because that link never goes down, systemd-resolved keeps forwarding `.test` to the Lerd resolver even with no network connection at all. It is created by a small system service, `lerd-dns-link.service`, which starts on every boot, so it survives reboots and applies on your next `lerd start` with nothing to run by hand.
+
+If you would rather not touch the system resolver at all, pick the `.localhost` mode at install time. `.localhost` resolves to loopback by convention, so no resolver configuration is involved and the `dnsmasq` and `certutil` prerequisites are skipped entirely.
+
+## A first project
+
+```bash
+lerd new myapp          # scaffolds through the framework's own installer, then links it
+cd myapp
+lerd service start mysql
+lerd env                # rewrites .env to match the running services
+```
+
+Or take a repo you already have:
+
+```bash
+cd ~/code/existing-app
+lerd link
+```
+
+Lerd detects the framework, picks the PHP version from `composer.json`, writes the vhost, registers the `.test` hostname and provisions the certificate. Use `lerd init` instead if you would rather choose the PHP version, HTTPS and services through a wizard and commit the answers to [`.lerd.yaml`](/configuration#per-project-config-lerd-yaml).
+
+Services are shared rather than per project, which is why several running sites cost around 200 MB of RAM rather than a full stack each. MySQL, PostgreSQL, Redis, Meilisearch, MongoDB, S3-compatible storage and Mailpit are all a `lerd service start` away.
+
+## Beyond PHP
+
+Omarchy attracts people working across several stacks at once. Lerd serves non-PHP projects through a [`Containerfile.lerd`](/getting-started/containers) in the project root: Node, Python, Go and Rails apps get the same `.test` domain, the same certificate and the same dashboard row as a PHP site. A Rails app on `blog.test` and a Laravel app on `shop.test` sit side by side with one nginx in front of both.
+
+## Frequently asked questions
+
+**Does Omarchy include a PHP environment?**
+No. It gives you the desktop, the terminal and the editor. The web stack is yours to install, which is what Lerd is for.
+
+**Is Lerd in the AUR?**
+Not yet. Install with the [one-line installer](/getting-started/installation#one-line-installer-recommended), which handles the Arch prerequisites, or with [Homebrew on Linux](/getting-started/installation#install-via-homebrew) if you already use it. `lerd update` self-replaces the binary on a script install.
+
+**Will it fight with Docker?**
+No. Lerd uses rootless Podman with no daemon, so Docker can stay installed and running for other work.
+
+**Does it need sudo?**
+Once, at install, to point the system resolver at the `.test` domains. Everything after that runs as your own user. The `.localhost` mode skips even that.
+
+**Does it survive a reboot?**
+Yes, provided `loginctl enable-linger $USER` is set, which the installer handles. The DNS route is re-created by `lerd-dns-link.service` on every boot.
+
+**Does it theme with Omarchy?**
+The bar widget follows the Quattro shell's own styling. The [web dashboard](/features/web-ui) has its own light and dark themes and follows your browser.
+
+## Next steps
+
+- [Requirements](/getting-started/requirements) and [installation](/getting-started/installation)
+- [Quick start](/getting-started/quick-start), a project served in two commands
+- [Omarchy bar widget](/features/omarchy-glance), the full panel reference
+- [Comparison](/getting-started/comparison) against Laravel Herd, Sail, DDEV and Lando

--- a/docs/getting-started/sail.md
+++ b/docs/getting-started/sail.md
@@ -1,0 +1,169 @@
+---
+title: Laravel Sail alternative
+description: 'Laravel Sail gives every project its own Docker Compose stack. Lerd replaces it with one shared rootless Podman environment, and lerd import sail migrates a Sail project database and S3 files across in a single command.'
+head:
+  - - meta
+    - name: keywords
+      content: laravel sail alternative, sail without docker, migrate from laravel sail, laravel sail slow, laravel sail linux, sail vs herd, laravel local development linux, replace laravel sail
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What is the best Laravel Sail alternative?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Lerd, if you work across several Laravel projects at once and do not want a Docker Compose stack per repo. It runs one shared nginx, PHP-FPM and service layer as rootless Podman containers, gives each project a .test domain and HTTPS automatically, and needs no files committed to the project. DDEV and Lando are the alternatives if you would rather stay on per-project Docker."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How do I migrate a Laravel Sail project to Lerd?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Run lerd sail import in the Sail project root. It starts only Sail's data services with remapped ports so nothing clashes with lerd, dumps the database, mirrors S3 and MinIO files into lerd's storage, then stops Sail. Running lerd link on a project with laravel/sail in composer.json offers the import automatically."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Do I have to delete docker-compose.yml to use Lerd?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. Lerd does not touch it, so Sail keeps working. The only file lerd modifies is .env, when you run lerd env, and it saves the original as .env.before_lerd first. Run lerd env:restore to switch a project back to Sail."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Why is Laravel Sail heavy to run?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Each Sail project is a full Compose stack: its own PHP container, its own database, its own Redis. Five projects open means five of everything. Lerd shares one nginx, one PHP-FPM per version and one instance of each service across every site, so five running projects cost around 200 MB rather than one to two gigabytes."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does Lerd need Docker?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. Lerd runs on rootless Podman with no daemon and no root. Docker can stay installed alongside it, which is what makes the Sail import possible in the first place: lerd drives your existing Docker or Podman Compose to pull the data out."
+            }
+          }
+        ]
+      }
+---
+
+# Laravel Sail alternative
+
+[Laravel Sail](https://laravel.com/docs/sail) is the official per-project Docker Compose setup: a `docker-compose.yml` in the repo, a container per service, and `./vendor/bin/sail` in front of every command. It works, and it is the right answer when a team wants the environment described inside the project.
+
+The friction shows up when you have several projects open. Each one is a full stack, so five repos means five copies of PHP, five databases and five Redis instances, plus a port to remember for each. **Lerd takes the shared-infrastructure route instead**: one nginx, one PHP-FPM per version, one instance of each service, across every site, as rootless Podman containers under your own user. Every project gets a `.test` domain and a trusted certificate with nothing committed to the repo.
+
+```bash
+curl -fsSL https://lerd.sh/install.sh | bash
+cd ~/code/myapp
+lerd link
+```
+
+`https://myapp.test`, no port, no `sail up`.
+
+## The one-command migration
+
+Sail is the only tool with an automated importer in Lerd, because a Sail stack has a predictable shape. From the project root:
+
+```bash
+lerd sail import
+```
+
+It reads the Compose file, remaps any ports that would clash with Lerd's running services, starts **only** the data services (so a slow or broken app image build never blocks you), waits for the database, dumps it, imports it into Lerd's MySQL or PostgreSQL, mirrors S3 and MinIO files into Lerd's storage, then stops Sail again.
+
+You rarely have to remember the command: running `lerd link` on a project with `laravel/sail` in its `composer.json` offers the import before setup.
+
+The flags, the credential handling and the `.env.before_lerd` behaviour are all covered in [Importing from Laravel Sail](/usage/import-sail).
+
+## Every Sail habit, and the Lerd equivalent
+
+| What you did with Sail | The same thing in Lerd |
+|---|---|
+| `sail up -d` per project before you can work | `lerd start` once, then every project is served |
+| `sail artisan`, `sail composer`, `sail npm` | `lerd artisan`, `lerd composer`, `lerd node`, from your own shell |
+| `localhost:${APP_PORT}`, a different port per project | `https://myapp.test`, automatic, no ports |
+| `/etc/hosts` edits when you wanted a real hostname | Automatic `.test` domains through a dnsmasq container |
+| No TLS, or mkcert wired in by hand | `lerd secure`, a real mkcert certificate trusted by your system and browsers |
+| Change the PHP version by switching the Sail image and rebuilding | `lerd isolate 8.4`, or let it read `composer.json`, no rebuild |
+| Add a service by editing `docker-compose.yml` | `lerd service start meilisearch`, shared across every site |
+| Queue and scheduler as extra Compose services | `lerd worker start queue` / `schedule`, as user services with [self-healing](/usage/worker-heal) |
+| `sail logs -f` | A [log viewer](/features/logs) in the dashboard, or `lerd logs` |
+| `docker-compose.yml` committed to the repo | [`.lerd.yaml`](/configuration#per-project-config-lerd-yaml), optional, a handful of lines |
+| Docker Desktop, Orbstack or Colima | Rootless Podman, no daemon, no licence |
+
+## Lerd vs Laravel Sail
+
+|  | Lerd | Laravel Sail |
+|---|---|---|
+| Platforms | Linux (systemd), macOS, Windows via WSL2 (beta) | Linux, macOS, Windows |
+| License | Open source (MIT) | Open source (MIT) |
+| Container runtime | Rootless Podman, no daemon | Docker Desktop / Orbstack / Colima |
+| Architecture | One shared nginx, PHP-FPM and service layer | A per-project Compose stack |
+| PHP versions | 7.4, 8.0 to 8.5, per project, no rebuild | Per-project Sail image |
+| Services (MySQL, Redis…) | One shared instance | Per project |
+| `.test` domains | Automatic, zero config | Manual hosts entries, or `localhost:${APP_PORT}` |
+| HTTPS | `lerd secure`, trusted mkcert certificate | Manual, or roll your own mkcert |
+| RAM with 5 projects running | ~200 MB | ~1–2 GB, five full stacks |
+| Requires changes to project files | No | Yes, `docker-compose.yml` committed |
+| Works on legacy / client repos | Yes, just `lerd link` | Only if you can add Sail |
+| Non-PHP projects | First-class via [`Containerfile.lerd`](/getting-started/containers) | Add your own container to the stack |
+| Per-project service versions | No, services are shared and versioned globally | Yes, each project pins its own |
+| Dashboard | [Web UI](/features/web-ui), [system tray](/features/system-tray), [terminal dashboard](/features/tui) | CLI + Docker Desktop |
+| AI / MCP | Built-in [MCP server](/features/mcp) | Not built in |
+| Cost | Free | Free |
+
+**Choose Sail when:** your team already standardised on it, two projects need different major versions of the same database at the same time, or you want the infrastructure defined in the repo.
+
+**Choose Lerd when:** you work across many projects at once, you cannot modify a client's project files, you want `.test` routing and HTTPS without wiring them, or you want the same environment on Linux and macOS.
+
+## Running both
+
+They coexist. Lerd uses rootless Podman with no daemon, so Docker stays installed and Sail keeps working on the projects you have not moved.
+
+The only file Lerd touches in a project is `.env`, and only when you run `lerd env`. The original is saved as `.env.before_lerd` the first time, so a project can go back:
+
+```bash
+lerd env:restore
+```
+
+That makes the migration reversible per project, which is the sane way to move a team over: convert one repo, live on it for a week, then do the rest.
+
+## What is genuinely different
+
+- **Services are shared, not per project.** One MySQL, one Redis, one Mailpit across every site. That is where the memory saving comes from, and it is the one thing Sail does that Lerd does not: pinning a different database major version per project.
+- **No `sail` prefix.** `lerd artisan` and `lerd composer` run in the project's PHP container but from your own shell and your own directory.
+- **The environment is not in the repo.** Instead of a Compose file, you commit an optional [`.lerd.yaml`](/configuration#per-project-config-lerd-yaml) describing PHP, Node, services and workers. Teammates without Lerd are unaffected, since nothing else changed.
+- **One `sudo` at install time.** Only to point the system resolver at the `.test` domains.
+
+## Frequently asked questions
+
+**Does the import handle S3 and MinIO?**
+Yes, files are mirrored into Lerd's S3-compatible storage. Skip it with `--skip-s3` if the project does not use it.
+
+**What if my Sail app image will not build?**
+It does not matter. The import starts only the data services with `--no-deps`, so the app container is never built.
+
+**Can I keep Sail's database credentials?**
+The import auto-detects the database name and tries Sail's defaults. Override with `--sail-db-name`, `--sail-db-user` and `--sail-db-password` when your project uses custom ones.
+
+**Does it work if I run Sail on Podman Compose?**
+Yes. The command tries `docker compose` first and falls back to `podman compose`.
+
+**Is Lerd free for commercial work?**
+Yes. MIT licensed, no paid tier.
+
+## Next steps
+
+- [Importing from Laravel Sail](/usage/import-sail), the full flag and credential reference
+- [Requirements](/getting-started/requirements) and [installation](/getting-started/installation)
+- [Quick start](/getting-started/quick-start), a project served in two commands
+- [Full comparison](/getting-started/comparison) against Herd, Laragon, Laradock, DDEV and Lando

--- a/docs/usage/import-sail.md
+++ b/docs/usage/import-sail.md
@@ -1,6 +1,6 @@
 # Importing from Laravel Sail
 
-`lerd import sail` migrates a Laravel Sail project into lerd in one command, database and S3/MinIO storage included.
+`lerd import sail` migrates a Laravel Sail project into lerd in one command, database and S3/MinIO storage included. For the wider picture, why you would move and what changes day to day, see the [Laravel Sail alternative](../getting-started/sail.md) guide.
 
 ```bash
 cd ~/Projects/myapp   # the Sail project root


### PR DESCRIPTION
Three pages we did not have, aimed at people searching for the problem rather than for lerd.

Omarchy is the distribution developers are actually talking about right now, and it ships a finished Arch and Hyprland desktop with no web stack at all, so the PHP side is the one thing left to solve on a fresh install. The page covers the Arch prerequisites that are not defaults there, crun and nss, the systemd-resolved without NetworkManager case that lerd0 handles, why the tray autostarts because Omarchy runs Hyprland through uwsm and would not on bare Hyprland, and the Glance bar widget.

Laradock had nothing, despite being the stack a lot of people are actively trying to get out of. There is no automated importer for it and there should not be, Laradock setups vary too much to migrate blind, so the page documents the manual route: dump from the Laradock database container, move the project out from under APP_CODE_PATH_HOST, then link, env and db:import. It keeps the honest case for staying, per project database major versions, which is the one thing lerd does not do.

Sail had the importer documented under usage but nothing explaining why you would move, and the Getting Started entry pointing at it dropped the reader into a different sidebar. It now has a sibling page to the other migration guides and links onward for the flags.

The Getting Started sidebar had become a flat list of eleven unrelated items. It is now three groups, Start here, Platform guides and Coming from another tool, and the section index follows the same shape. Existing labels and every URL are unchanged, so nothing already indexed moves.
